### PR TITLE
Updated Breton spelling dictionary from latest available in Libreoffice.

### DIFF
--- a/runtime/spell/br/main.aap
+++ b/runtime/spell/br/main.aap
@@ -25,16 +25,16 @@ $SPELLDIR/br.utf-8.spl : $FILES
 #
 # Fetching the files from OpenOffice.org.
 #
-OODIR = http://extensions.libreoffice.org/extension-center/an-drouizig-breton-spellchecker/releases/0.11/
-:attr {fetch = $OODIR/%file%} dict-br-0.11.oxt
+OODIR = http://extensions.libreoffice.org/extension-center/an-drouizig-breton-spellchecker/releases/0.13/
+:attr {fetch = $OODIR/%file%} difazier-an-drouizig-0_13.oxt
 
 # The files don't depend on the .zip file so that we can delete it.
 # Only download the zip file if the targets don't exist.
 br_FR.aff br_FR.dic: {buildcheck=}
         :assertpkg unzip patch
-        :fetch dict-br-0.11.oxt
-        :sys $UNZIP dict-br-0.11.oxt
-        :delete dict-br-0.11.oxt
+        :fetch difazier-an-drouizig-0_13.oxt
+        :sys $UNZIP difazier-an-drouizig-0_13.oxt
+        :delete difazier-an-drouizig-0_13.oxt
         :copy dictionaries/br_FR.aff br_FR.aff
         :copy dictionaries/br_FR.dic br_FR.dic
         # The br_FR.aff file contains a BOM, remove it.
@@ -65,12 +65,12 @@ diff:
 
 check:
         :assertpkg unzip diff
-        :fetch dict-br-0.11.oxt
+        :fetch difazier-an-drouizig-0_13.oxt
         :mkdir tmp
         :cd tmp
         @try:
             @import stat
-            :sys $UNZIP ../dict-br-0.11.oxt
+            :sys $UNZIP ../difazier-an-drouizig-0_13.oxt
             :sys {force} diff ../dictionaries/br_FR.aff br_FR.aff >d
             @if os.stat('d')[stat.ST_SIZE] > 0:
                 :copy br_FR.aff ../br_FR.new.aff
@@ -80,7 +80,7 @@ check:
         @finally:
             :cd ..
             :delete {r}{f}{q} tmp
-            :delete dict-br-0.11.oxt
+            :delete difazier-an-drouizig-0_13.oxt
 
 
 # vim: set sts=4 sw=4 :


### PR DESCRIPTION
This pull requests updates the Breton spelling dictionary of Vim to use the latest dictionary from LibreOffice available at:
http://extensions.libreoffice.org/extension-center/an-drouizig-breton-spellchecker
