### PR TITLE
fix crash due to hash table not being initialized

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6314,6 +6314,10 @@ ex_ownsyntax(eap)
     {
 	curwin->w_s = (synblock_T *)alloc(sizeof(synblock_T));
 	memset(curwin->w_s, 0, sizeof(synblock_T));
+#ifdef FEAT_SYN_HL
+	hash_init(&curwin->w_s->b_keywtab);
+	hash_init(&curwin->w_s->b_keywtab_ic);
+#endif
 #ifdef FEAT_SPELL
 	/* TODO: keep the spell checking as it was. */
 	curwin->w_p_spell = FALSE;	/* No spell checking */


### PR DESCRIPTION
triggered by:
vim -u NONE -c ow -c 'sy keyword x c'

https://groups.google.com/forum/#!topic/vim_dev/3Ac_v2nOa7k
