### PR TITLE
fix win32 crash during text clicking with balloon

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -4836,7 +4836,8 @@ make_tooltip(beval, text, pt)
 delete_tooltip(beval)
     BalloonEval	*beval;
 {
-    DestroyWindow(beval->balloon);
+    PostMessage(beval->balloon, WM_DESTROY, 0, 0);
+    PostMessage(beval->balloon, WM_NCDESTROY, 0, 0);
 }
 
 /*ARGSUSED*/


### PR DESCRIPTION
analysis and fix by me here:
https://groups.google.com/forum/#!topic/vim_dev/5cRsklhkz2U
