### PR TITLE
Add settings for CI services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ before_install:
   - pip install --user cpp-coveralls
 
 script:
-  - cd vim && ./configure --with-features=$FEATURES $CONFOPT --enable-fail-if-missing && make
+  - ./configure --with-features=$FEATURES $CONFOPT --enable-fail-if-missing && make
   - ./src/vim --version
   - if [ "$TEST" = "yes" ]; then make test; fi
 
 after_success:
-  - if [ x"$COVERAGE" == "xyes" ] ; then cd vim && ~/.local/bin/coveralls -b src -x .xs -e src/xxd -e src/if_perl.c --encodings utf-8 latin-1 EUC-KR; fi
+  - if [ x"$COVERAGE" = "xyes" ]; then ~/.local/bin/coveralls -b src -x .xs -e src/xxd -e src/if_perl.c --encodings utf-8 latin-1 EUC-KR; fi
 
 # vim:set sts=2 sw=2 tw=0 et:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: c
+
+compiler:
+  - clang
+  - gcc
+
+env:
+  - COVERAGE=yes TEST=yes CFLAGS=--coverage LDFLAGS=--coverage FEATURES=huge
+    "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-python3interp --enable-rubyinterp --enable-luainterp'"
+  - COVERAGE=no TEST=yes FEATURES=small CONFOPT=
+  - COVERAGE=no TEST=yes FEATURES=tiny  CONFOPT=
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - lcov
+      - libperl-dev
+      - python-dev
+      - python3-dev
+      - liblua5.1-0-dev
+      - lua5.1
+
+before_install:
+  - pip install --user cpp-coveralls
+
+script:
+  - cd vim && ./configure --with-features=$FEATURES $CONFOPT --enable-fail-if-missing && make
+  - ./src/vim --version
+  - if [ "$TEST" = "yes" ]; then make test; fi
+
+after_success:
+  - if [ x"$COVERAGE" == "xyes" ] ; then cd vim && ~/.local/bin/coveralls -b src -x .xs -e src/xxd -e src/if_perl.c --encodings utf-8 latin-1 EUC-KR; fi
+
+# vim:set sts=2 sw=2 tw=0 et:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ compiler:
   - gcc
 
 env:
-  - COVERAGE=yes TEST=yes CFLAGS=--coverage LDFLAGS=--coverage FEATURES=huge
+  - COVERAGE=yes CFLAGS=--coverage LDFLAGS=--coverage FEATURES=huge
     "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-python3interp --enable-rubyinterp --enable-luainterp'"
-  - COVERAGE=no TEST=yes FEATURES=small CONFOPT=
-  - COVERAGE=no TEST=yes FEATURES=tiny  CONFOPT=
+  - COVERAGE=no FEATURES=small CONFOPT=
+  - COVERAGE=no FEATURES=tiny  CONFOPT=
 
 sudo: false
 
@@ -28,7 +28,7 @@ before_install:
 script:
   - ./configure --with-features=$FEATURES $CONFOPT --enable-fail-if-missing && make
   - ./src/vim --version
-  - if [ "$TEST" = "yes" ]; then make test; fi
+  - make test
 
 after_success:
   - if [ x"$COVERAGE" = "xyes" ]; then ~/.local/bin/coveralls -b src -x .xs -e src/xxd -e src/if_perl.c --encodings utf-8 latin-1 EUC-KR; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ before_install:
   - pip install --user cpp-coveralls
 
 script:
-  - ./configure --with-features=$FEATURES $CONFOPT --enable-fail-if-missing && make
+  - NPROC=$(getconf _NPROCESSORS_ONLN)
+  - ./configure --with-features=$FEATURES $CONFOPT --enable-fail-if-missing && make -j$NPROC
   - ./src/vim --version
   - make test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,9 @@ clone_folder: c:\projects\vim-ci
 
 before_build:
   - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release'
-  - git submodule update --init --depth 5
 
 build_script:
-  - cd vim/src
+  - cd src
   - sed -e "s/\$(LINKARGS2)/\$(LINKARGS2) | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak
   - nmake -f Make_mvc2.mak CPU=AMD64 GUI=yes IME=yes MBYTE=yes ICONV=yes DEBUG=no PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27-x64 PYTHON3_VER=34 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python34-x64
   - .\gvim -u NONE -c "redir @a | ver | 0put a | wq!" ver.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 version: "{build}"
 
-clone_folder: c:\projects\vim-ci
-
 before_build:
   - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: "{build}"
+
+clone_folder: c:\projects\vim-ci
+
+before_build:
+  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release'
+  - git submodule update --init --depth 5
+
+build_script:
+  - cd vim/src
+  - sed -e "s/\$(LINKARGS2)/\$(LINKARGS2) | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak
+  - nmake -f Make_mvc2.mak CPU=AMD64 GUI=yes IME=yes MBYTE=yes ICONV=yes DEBUG=no PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27-x64 PYTHON3_VER=34 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python34-x64
+  - .\gvim -u NONE -c "redir @a | ver | 0put a | wq!" ver.txt
+  - type ver.txt
+
+test_script:
+  - cd testdir
+  - nmake -f Make_dos.mak VIMPROG=..\gvim


### PR DESCRIPTION
Now the official Vim repository is on GitHub, we can easily use many CI services.
This PR adds setting files for the following CI services:
- Travis CI
- Coveralls
- AppVeyor

These setting files were written for [vim-ci](https://github.com/vim-jp/vim-ci) by [vim-jp](https://github.com/vim-jp) members.

Here are the sample results:
- https://travis-ci.org/k-takata/vim/builds/77359110
- https://coveralls.io/builds/3406634
- https://ci.appveyor.com/project/k-takata/vim/build/1

Note: In order to use these settings, someone needs to set up accounts for the services.
