### PR TITLE
filetype: handle lines with `{#\s\+` as htmldjango

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -872,7 +872,7 @@ func! s:FThtml()
       setf xhtml
       return
     endif
-    if getline(n) =~ '{%\s*\(extends\|block\|load\)\>'
+    if getline(n) =~ '{%\s*\(extends\|block\|load\)\>\|{#\s\+'
       setf htmldjango
       return
     endif


### PR DESCRIPTION
If you have a snippet file without extends, block or load tags, but a
comment at the beginning, this will handle it has `htmldjango` now, too.
