### PR TITLE
ReST syntax: Literal blocks inside directives

### DIFF
--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -2,7 +2,7 @@
 " Language: reStructuredText documentation format
 " Maintainer: Marshall Ward <marshall.ward@gmail.com>
 " Previous Maintainer: Nikolai Weibull <now@bitwi.se>
-" Latest Revision: 2014-09-07
+" Latest Revision: 2015-09-07
 
 if exists("b:current_syntax")
   finish

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -2,7 +2,7 @@
 " Language: reStructuredText documentation format
 " Maintainer: Marshall Ward <marshall.ward@gmail.com>
 " Previous Maintainer: Nikolai Weibull <now@bitwi.se>
-" Latest Revision: 2014-10-03
+" Latest Revision: 2014-09-07
 
 if exists("b:current_syntax")
   finish
@@ -81,7 +81,7 @@ syn region rstHyperlinkTarget matchgroup=rstDirective
 execute 'syn region rstExDirective contained matchgroup=rstDirective' .
       \ ' start=+' . s:ReferenceName . '::\_s+' .
       \ ' skip=+^$+' .
-      \ ' end=+^\s\@!+ contains=@rstCruft'
+      \ ' end=+^\s\@!+ contains=@rstCruft,rstLiteralBlock'
 
 execute 'syn match rstSubstitutionDefinition contained' .
       \ ' /|' . s:ReferenceName . '|\_s\+/ nextgroup=@rstDirectives'


### PR DESCRIPTION
Currently, there is no syntax highlighting of elements inside of
directive blocks, such as (monospace) literal blocks.

This patch adds literal block functionality to directive blocks.

Thanks to Antony Lee for raising this issue.

In the future, it may be necessary to include additional elements into
directive blocks, such as code blocks.
