### PR TITLE
tiny build has no feat diff

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -1769,7 +1769,11 @@ scroll_cursor_top(min_scroll, always)
 	    i = 1;
 	else
 #endif
+#if defined(FEAT_DIFF) || defined(PROTO)
 	    i = plines_nofill(top);
+#else
+	    i = plines(top);
+#endif
 	used += i;
 	if (extra + i <= off && bot < curbuf->b_ml.ml_line_count)
 	{


### PR DESCRIPTION
only use 'plines_nofill' when FEAT_DIFF || PROTO is defined

issue was introduced in 7.4.856

Signed-off-by: BlackEagle ike.devolder@gmail.com
