### PR TITLE
More info on nested calling functions

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -23954,7 +23954,7 @@ call_user_func(fp, argcount, argvars, rettv, firstline, lastline, selfdict)
     {
 	if (save_sourcing_name != NULL
 			  && STRNCMP(save_sourcing_name, "function ", 9) == 0)
-	    sprintf((char *)sourcing_name, "%s..", save_sourcing_name);
+	    sprintf((char *)sourcing_name, "%s[%d]..", save_sourcing_name, save_sourcing_lnum);
 	else
 	    STRCPY(sourcing_name, "function ");
 	cat_func_name(sourcing_name + STRLEN(sourcing_name), fp);


### PR DESCRIPTION
Problem: Follow trace to execution point
Solution: Add lnum to <sfile> output

This patch allows `<sfile>` to share lnum to on nested called functions.

Resolves #1. Instead of

```
function <SNR>139_SourcePart..Bar..Foo..Baz
```

you get

```
function <SNR>139_SourcePart[4]..Bar[3]..Foo[2]..Baz
```

Will be used to solve an issue about breakpts (visual debugging vim
plugin)

https://github.com/albfan/vim-breakpts/issues/2

Using visual debugging with breakpts plugin lacks from backtrace
information.

To keep compatibility maybe a `<sfilelnum>` can be added as special key.
