### PR TITLE
Changed window border calculations when in child mode

### DIFF
--- a/src/gui_w48.c
+++ b/src/gui_w48.c
@@ -3335,17 +3335,29 @@ gui_mch_newfont()
     RECT	rect;
 
     GetWindowRect(s_hwnd, &rect);
-    gui_resize_shell(rect.right - rect.left
-			- (GetSystemMetrics(SM_CXFRAME) +
-			   GetSystemMetrics(SM_CXPADDEDBORDER)) * 2,
-		     rect.bottom - rect.top
-			- (GetSystemMetrics(SM_CYFRAME) +
-			   GetSystemMetrics(SM_CXPADDEDBORDER)) * 2
-			- GetSystemMetrics(SM_CYCAPTION)
+    if (win_socket_id == 0)
+    {
+	gui_resize_shell(rect.right - rect.left
+	    - (GetSystemMetrics(SM_CXFRAME) +
+	       GetSystemMetrics(SM_CXPADDEDBORDER)) * 2,
+	    rect.bottom - rect.top
+	    - (GetSystemMetrics(SM_CYFRAME) +
+	       GetSystemMetrics(SM_CXPADDEDBORDER)) * 2
+	    - GetSystemMetrics(SM_CYCAPTION)
 #ifdef FEAT_MENU
-			- gui_mswin_get_menu_height(FALSE)
+	    - gui_mswin_get_menu_height(FALSE)
 #endif
-	    );
+	);
+    }
+    else
+    {
+	gui_resize_shell(rect.right - rect.left,
+	    rect.bottom - rect.top
+#ifdef FEAT_MENU
+	    - gui_mswin_get_menu_height(FALSE)
+#endif
+	);
+    }
 }
 
 /*


### PR DESCRIPTION
See screenshot here for details:
http://superuser.com/questions/971915/weird-conemu-gvim-resize-border-on-gvim-spawn
