### PR TITLE
Add bzl filetype with syntax, ftplugin, and indent

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -112,8 +112,6 @@ specifically?  First try with the parens, then without.
 Value returned by virtcol() changes depending on how lines wrap.  This is
 inconsistent with the documentation.
 
-Add bzl filetype support. (David Barnett, 2015 Aug 11)
-
 When complete() first argument is before where insert started and 'backspace'
 is Vi compatible, the completion fails. (Hirohito Higashi, 2015 Feb 19)
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -308,6 +308,9 @@ au BufNewFile,BufRead *.bl			setf blank
 " Blkid cache file
 au BufNewFile,BufRead */etc/blkid.tab,*/etc/blkid.tab.old   setf xml
 
+" Bazel (http://bazel.io)
+autocmd BufRead,BufNewFile *.bzl,BUILD,WORKSPACE setfiletype bzl
+
 " C or lpc
 au BufNewFile,BufRead *.c			call s:FTlpc()
 

--- a/runtime/ftplugin/bzl.vim
+++ b/runtime/ftplugin/bzl.vim
@@ -1,0 +1,94 @@
+" Vim filetype plugin file
+" Language:	Bazel (http://bazel.io)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-bzl)
+" Last Change:	2015 Aug 11
+
+""
+" @section Introduction, intro
+" Core settings for the bzl filetype, used for BUILD and *.bzl files for the
+" Bazel build system (http://bazel.io/).
+
+if exists('b:did_ftplugin')
+  finish
+endif
+
+
+" Vim 7.4.051 has opinionated settings in ftplugin/python.vim that try to force
+" PEP8 conventions on every python file, but these conflict with Google's
+" indentation guidelines. As a workaround, we explicitly source the system
+" ftplugin, but save indentation settings beforehand and restore them after.
+let s:save_expandtab = &l:expandtab
+let s:save_shiftwidth = &l:shiftwidth
+let s:save_softtabstop = &l:softtabstop
+let s:save_tabstop = &l:tabstop
+
+" NOTE: Vim versions before 7.3.511 had a ftplugin/python.vim that was broken
+" for compatible mode.
+let s:save_cpo = &cpo
+set cpo&vim
+
+" Load base python ftplugin (also defines b:did_ftplugin).
+source $VIMRUNTIME/ftplugin/python.vim
+
+" NOTE: Vim versions before 7.4.104 and later set this in ftplugin/python.vim.
+setlocal comments=b:#,fb:-
+
+" Restore pre-existing indentation settings.
+let &l:expandtab = s:save_expandtab
+let &l:shiftwidth = s:save_shiftwidth
+let &l:softtabstop = s:save_softtabstop
+let &l:tabstop = s:save_tabstop
+
+setlocal formatoptions-=t
+
+" Make gf work with imports in BUILD files.
+setlocal includeexpr=substitute(v:fname,'//','','')
+
+" Enable syntax-based folding, if specified.
+if get(g:, 'ft_bzl_fold', 0)
+  setlocal foldmethod=syntax
+  setlocal foldtext=BzlFoldText()
+endif
+
+if exists('*BzlFoldText')
+  finish
+endif
+
+function BzlFoldText() abort
+  let l:start_num = nextnonblank(v:foldstart)
+  let l:end_num = prevnonblank(v:foldend)
+
+  if l:end_num <= l:start_num + 1
+    " If the fold is empty, don't print anything for the contents.
+    let l:content = ''
+  else
+    " Otherwise look for something matching the content regex.
+    " And if nothing matches, print an ellipsis.
+    let l:content = '...'
+    for l:line in getline(l:start_num + 1, l:end_num - 1)
+      let l:content_match = matchstr(l:line, '\m\C^\s*name = \zs.*\ze,$')
+      if !empty(l:content_match)
+        let l:content = l:content_match
+        break
+      endif
+    endfor
+  endif
+
+  " Enclose content with start and end
+  let l:start_text = getline(l:start_num)
+  let l:end_text = substitute(getline(l:end_num), '^\s*', '', '')
+  let l:text = l:start_text . ' ' . l:content . ' ' . l:end_text
+
+  " Compute the available width for the displayed text.
+  let l:width = winwidth(0) - &foldcolumn - (&number ? &numberwidth : 0)
+  let l:lines_folded = ' ' . string(1 + v:foldend - v:foldstart) . ' lines'
+
+  " Expand tabs, truncate, pad, and concatenate
+  let l:text = substitute(l:text, '\t', repeat(' ', &tabstop), 'g')
+  let l:text = strpart(l:text, 0, l:width - len(l:lines_folded))
+  let l:padding = repeat(' ', l:width - len(l:lines_folded) - len(l:text))
+  return l:text . l:padding . l:lines_folded
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/runtime/indent/bzl.vim
+++ b/runtime/indent/bzl.vim
@@ -1,0 +1,97 @@
+" Vim indent file
+" Language:	Bazel (http://bazel.io)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-bzl)
+" Last Change:	2015 Aug 11
+
+if exists('b:did_indent')
+  finish
+endif
+
+" Load base python indent.
+if !exists('*GetPythonIndent')
+  runtime! indent/python.vim
+endif
+
+let b:did_indent = 1
+
+" Only enable bzl google indent if python google indent is enabled.
+if !get(g:, 'no_google_python_indent')
+  setlocal indentexpr=GetBzlIndent(v:lnum)
+endif
+
+if exists('*GetBzlIndent')
+  finish
+endif
+
+let s:save_cpo = &cpo
+set cpo-=C
+
+" Maximum number of lines to look backwards.
+let s:maxoff = 50
+
+""
+" Determine the correct indent level given an {lnum} in the current buffer.
+function GetBzlIndent(lnum) abort
+  let l:use_recursive_indent = !get(g:, 'no_google_python_recursive_indent')
+  if l:use_recursive_indent
+    " Backup and override indent setting variables.
+    if exists('g:pyindent_nested_paren')
+      let l:pyindent_nested_paren = g:pyindent_nested_paren
+    endif
+    if exists('g:pyindent_open_paren')
+      let l:pyindent_open_paren = g:pyindent_open_paren
+    endif
+    " Vim 7.3.693 and later defines a shiftwidth() function to get the effective
+    " shiftwidth value. Fall back to &shiftwidth if the function doesn't exist.
+    let l:sw_expr = exists('*shiftwidth') ? 'shiftwidth()' : '&shiftwidth'
+    let g:pyindent_nested_paren = l:sw_expr . ' * 2'
+    let g:pyindent_open_paren = l:sw_expr . ' * 2'
+  endif
+
+  let l:indent = -1
+
+  " Indent inside parens.
+  " Align with the open paren unless it is at the end of the line.
+  " E.g.
+  "   open_paren_not_at_EOL(100,
+  "                         (200,
+  "                          300),
+  "                         400)
+  "   open_paren_at_EOL(
+  "       100, 200, 300, 400)
+  call cursor(a:lnum, 1)
+  let [l:par_line, l:par_col] = searchpairpos('(\|{\|\[', '', ')\|}\|\]', 'bW',
+      \ "line('.') < " . (a:lnum - s:maxoff) . " ? dummy :" .
+      \ " synIDattr(synID(line('.'), col('.'), 1), 'name')" .
+      \ " =~ '\\(Comment\\|String\\)$'")
+  if l:par_line > 0
+    call cursor(l:par_line, 1)
+    if l:par_col != col('$') - 1
+      let l:indent = l:par_col
+    endif
+  endif
+
+  " Delegate the rest to the original function.
+  if l:indent == -1
+    let l:indent = GetPythonIndent(a:lnum)
+  endif
+
+  if l:use_recursive_indent
+    " Restore global variables.
+    if exists('l:pyindent_nested_paren')
+      let g:pyindent_nested_paren = l:pyindent_nested_paren
+    else
+      unlet g:pyindent_nested_paren
+    endif
+    if exists('l:pyindent_open_paren')
+      let g:pyindent_open_paren = l:pyindent_open_paren
+    else
+      unlet g:pyindent_open_paren
+    endif
+  endif
+
+  return l:indent
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/runtime/syntax/bzl.vim
+++ b/runtime/syntax/bzl.vim
@@ -1,0 +1,16 @@
+" Vim syntax file
+" Language:	Bazel (http://bazel.io)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-bzl)
+" Last Change:	2015 Aug 11
+
+if exists('b:current_syntax')
+  finish
+endif
+
+
+runtime! syntax/python.vim
+
+let b:current_syntax = 'bzl'
+
+syn region bzlRule start='^\w\+($' end='^)\n*' transparent fold
+syn region bzlList start='\[' end='\]' transparent fold


### PR DESCRIPTION
Syntax highlighting and filetype configuration for the bzl filetype.

It's merged from https://github.com/google/vim-ft-bzl, which is itself under Apache license, but I have approval to license this patch under the Vim license.

Patch originally sent on vim_dev at https://groups.google.com/d/topic/vim_dev/Nf4TRDSg-yM/discussion.
