### PR TITLE
Add support for backtrace on vim debug sessions

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -483,6 +483,16 @@ Additionally, these commands can be used:
 	finish		Finish the current script or user function and come
 			back to debug mode for the command after the one that
 			sourced or called it.
+							*>bt*
+							*>backtrace*
+	backtrace,bt	Show the call stacktrace for actual debugging session.
+							*>frame*
+	frame N		Goes to N bactrace level. + and - signs make movement
+			relative.
+							*>up*
+	up		Goes one level up from call stacktrace.
+							*>down*
+	down		Goes one level down from call stacktrace.
 
 About the additional commands in debug mode:
 - There is no command-line completion for them, you get the completion for the

--- a/src/globals.h
+++ b/src/globals.h
@@ -231,6 +231,7 @@ EXTERN int	ex_nesting_level INIT(= 0);	/* nesting level */
 EXTERN int	debug_break_level INIT(= -1);	/* break below this level */
 EXTERN int	debug_did_msg INIT(= FALSE);	/* did "debug mode" message */
 EXTERN int	debug_tick INIT(= 0);		/* breakpoint change count */
+EXTERN int	debug_backtrace_level INIT(= 0); /* breakpoint backtrace level */
 # ifdef FEAT_PROFILE
 EXTERN int	do_profiling INIT(= PROF_NONE);	/* PROF_ values */
 # endif

--- a/src/proto/ex_cmds2.pro
+++ b/src/proto/ex_cmds2.pro
@@ -1,5 +1,9 @@
 /* ex_cmds2.c */
 void do_debug __ARGS((char_u *cmd));
+void do_showbacktrace __ARGS((char_u *cmd));
+void do_checkbacktracelevel __ARGS((void));
+int get_maxbacktrace_level __ARGS((void));
+void do_setdebugtracelevel __ARGS((char_u *arg));
 void ex_debug __ARGS((exarg_T *eap));
 void dbg_check_breakpoint __ARGS((exarg_T *eap));
 int dbg_check_skipped __ARGS((exarg_T *eap));

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -89,6 +89,7 @@ SCRIPTS_ALL = \
 	test105.out \
 	test106.out \
 	test107.out \
+	test108.out \
 	test_argument_0count.out \
 	test_argument_count.out \
 	test_autocmd_option.out \

--- a/src/testdir/test108.in
+++ b/src/testdir/test108.in
@@ -1,0 +1,87 @@
+Tests for backtrace debug commands.     vim: set ft=vim :
+
+STARTTEST
+:so small.vim
+:function! Foo()
+:   let var1 = 1
+:   let var2 = Bar(var1) + 9
+:   return var2
+:endfunction
+:
+:function! Bar(var)
+:    let var1 = 2 + a:var
+:    let var2 = Bazz(var1) + 4
+:    return var2
+:endfunction
+:
+:function! Bazz(var)
+:    let var1 = 3 + a:var
+:    let var3 = "another var"
+:    return var1
+:endfunction
+:new
+:debuggreedy
+:redir => out
+:debug echo Foo()
+step
+step
+step
+step
+step
+step
+echo "- show backtrace:\n"
+backtrace
+echo "\nshow variables on different levels:\n"
+echo var1
+up
+back
+echo var1
+u
+bt
+echo var1
+echo "\n- undefined vars:\n"
+step
+frame 2
+echo "undefined var3 on former level:"
+echo var3
+fr 0
+echo "here var3 is defined with \"another var\":"
+echo var3
+step
+step
+step
+up
+echo "\nundefined var2 on former level"
+echo var2
+down
+echo "here var2 is defined with 10:"
+echo var2
+echo "\n- backtrace movements:\n"
+b
+echo "\nnext command cannot go down, we are on bottom\n"
+down
+up
+echo "\nnext command cannot go up, we are on top\n"
+up
+b
+echo "f is not frame or finish is file"
+f
+echo "\n- relative backtrace movement\n"
+fr -1
+frame
+fra +1
+fram
+echo "\n- go beyond limits does not crash\n"
+fr 100
+fra
+frame -40
+fram
+echo "\n- final result 19:"
+cont
+:0debuggreedy
+:redir END
+:$put =out
+:w! test.out
+:qa!
+ENDTEST
+

--- a/src/testdir/test108.ok
+++ b/src/testdir/test108.ok
@@ -1,0 +1,84 @@
+
+
+
+- show backtrace:
+
+ #2 function Foo[2]
+ #1 Bar[2]
+ >0 Bazz
+line 2: let var3 = "another var"
+
+show variables on different levels:
+
+6
+ #2 function Foo[2]
+ >1 Bar[2]
+ #0 Bazz
+line 2: let var3 = "another var"
+3
+ >2 function Foo[2]
+ #1 Bar[2]
+ #0 Bazz
+line 2: let var3 = "another var"
+1
+
+- undefined vars:
+
+undefined var3 on former level:
+Error detected while processing function Foo[2]..Bar[2]..Bazz:
+line    3:
+E121: Undefined variable: var3
+E15: Invalid expression: var3
+here var3 is defined with "another var":
+another var
+
+undefined var2 on former level
+Error detected while processing function Foo[2]..Bar:
+line    3:
+E121: Undefined variable: var2
+E15: Invalid expression: var2
+here var2 is defined with 10:
+10
+
+- backtrace movements:
+
+ #1 function Foo[2]
+ >0 Bar
+line 3: End of function
+
+next command cannot go down, we are on bottom
+
+backtrace set to lowest level: 0
+
+next command cannot go up, we are on top
+
+backtrace set to highest level: 1
+ >1 function Foo[2]
+ #0 Bar
+line 3: End of function
+f is not frame or finish is file
+"[No Name]" --No lines in buffer--
+
+- relative backtrace movement
+
+ #1 function Foo[2]
+ >0 Bar
+line 3: End of function
+ >1 function Foo[2]
+ #0 Bar
+line 3: End of function
+
+- go beyond limits does not crash
+
+backtrace set to highest level: 1
+ >1 function Foo[2]
+ #0 Bar
+line 3: End of function
+backtrace set to lowest level: 0
+ #1 function Foo[2]
+ >0 Bar
+line 3: End of function
+
+- final result 19:
+19
+


### PR DESCRIPTION
Added commands
- backtrace(b): Show backtrace and current level
- up(u): Goes up in backtrace
- down(d): Goes down in backtrace

to move around backtrace.

resolves albfan/vim#2
