### PR TITLE
Make upward search work when start directory does not exist

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -4369,21 +4369,21 @@ vim_findfile_init(path, filename, stopdirs, level, free_visited, find_what,
 		temp = alloc((int)(STRLEN(search_ctx->ffsc_wc_path)
 				 + STRLEN(search_ctx->ffsc_fix_path + len)
 				 + 1));
-	    }
 
-	    if (temp == NULL || wc_path == NULL)
-	    {
-		vim_free(buf);
-		vim_free(temp);
+		if (temp == NULL || wc_path == NULL)
+		{
+		    vim_free(buf);
+		    vim_free(temp);
+		    vim_free(wc_path);
+		    goto error_return;
+		}
+
+		STRCPY(temp, search_ctx->ffsc_fix_path + len);
+		STRCAT(temp, search_ctx->ffsc_wc_path);
+		vim_free(search_ctx->ffsc_wc_path);
 		vim_free(wc_path);
-		goto error_return;
+		search_ctx->ffsc_wc_path = temp;
 	    }
-
-	    STRCPY(temp, search_ctx->ffsc_fix_path + len);
-	    STRCAT(temp, search_ctx->ffsc_wc_path);
-	    vim_free(search_ctx->ffsc_wc_path);
-	    vim_free(wc_path);
-	    search_ctx->ffsc_wc_path = temp;
 	}
 #endif
 	vim_free(buf);


### PR DESCRIPTION
Problem: Upward search fails immediately when the start directory does not exist
Solution: Only perform a wildcard-related memory allocation check in vim_findile_init() if the search path contains wildcards

According to the "file-searching" section in the documentation, if your current directory is
/u/user_x/work/release and you have set the path option with:
:set path=include;/u/user_x

Then vim would search for a file in
/u/user_x/work/release/include, /u/user_x/work/include, /u/user_x/include

But if the directory /u/user_x/work/release/include does not exist, then the file search immediately says that it cannot find the given file instead of also searching /u/user_x/work/include and
/u/user_x/include

This is because vim_findfile_init() checks if the start directory exists. If it doesn't, the function does some fiddling with wildcards in the search path. This code contains wildcard-related error handling that is also triggered even if the search path has no wildcards. This code causes vim_findfile_init() to fail.

Doing the error check only if the search path has wildcards now makes vim do the upwards search even if the start directory does not exist.
