### PR TITLE
Add options to specify interfaces shared library

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -1,4 +1,4 @@
-*if_lua.txt*    For Vim version 7.4.  Last change: 2013 Sep 04
+*if_lua.txt*    For Vim version 7.4.  Last change: 2015 Oct 16
 
 
 		  VIM REFERENCE MANUAL    by Luis Carvalho
@@ -14,6 +14,7 @@ The Lua Interface to Vim				*lua* *Lua*
 6. Buffer userdata		|lua-buffer|
 7. Window userdata		|lua-window|
 8. The luaeval function		|lua-luaeval|
+9. Dynamic loading		|lua-dynamic|
 
 {Vi does not have any of these commands}
 
@@ -397,6 +398,25 @@ Examples: >
 	:  return luaeval('(_A.y-_A.x)*math.random()+_A.x', {'x':a:x,'y':a:y})
 	:  endfunction
 	:echo Rand(1,10)
+
+
+==============================================================================
+9. Dynamic loading				    *lua-dynamic*
+
+On MS-Windows and Unix the Lua library can be loaded dynamically.  The
+|:version| output then includes |+lua/dyn|.
+
+This means that Vim will search for the Lua DLL or shared library file only
+when needed.  When you don't use the Lua interface you don't need it, thus
+you can use Vim without this file.
+
+On MS-Windows to use the Lua interface the Lua DLL must be in your search path.
+In a console window type "path" to see what directories are used.  The version
+of the DLL must match the Lua version Vim was compiled with.
+
+On Unix the 'luadll' option can be used to specify the Lua shared library file
+instead of DYNAMIC_LUA_DLL file what was specified at compile time.  The
+version of the shared library must match the Lua version Vim was compiled with.
 
 
 ==============================================================================

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -1,4 +1,4 @@
-*if_perl.txt*   For Vim version 7.4.  Last change: 2013 Oct 05
+*if_perl.txt*   For Vim version 7.4.  Last change: 2015 Oct 16
 
 
 		  VIM REFERENCE MANUAL    by Sven Verdoolaege
@@ -289,6 +289,14 @@ In a console window type "path" to see what directories are used.
 The name of the DLL must match the Perl version Vim was compiled with.
 Currently the name is "perl512.dll".  That is for Perl 5.12.  To know for
 sure edit "gvim.exe" and search for "perl\d*.dll\c".
+
+
+Unix ~
+
+The 'perldll' option can be used to specify the Perl shared library file
+instead of DYNAMIC_PERL_DLL file what was specified at compile time.  The
+version of the shared library must match the Perl version Vim was compiled
+with.
 
 ==============================================================================
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -1,4 +1,4 @@
-*if_pyth.txt*   For Vim version 7.4.  Last change: 2014 Jul 23
+*if_pyth.txt*   For Vim version 7.4.  Last change: 2015 Oct 16
 
 
 		  VIM REFERENCE MANUAL    by Paul Moore
@@ -679,19 +679,25 @@ functions to evaluate Python expressions and pass their values to VimL.
 ==============================================================================
 9. Dynamic loading					*python-dynamic*
 
-On MS-Windows the Python library can be loaded dynamically.  The |:version|
-output then includes |+python/dyn|.
+On MS-Windows and Unix the Python library can be loaded dynamically.  The
+|:version| output then includes |+python/dyn| or |+python3/dyn|.
 
-This means that Vim will search for the Python DLL file only when needed.
-When you don't use the Python interface you don't need it, thus you can use
-Vim without this DLL file.
+This means that Vim will search for the Python DLL or shared library file only
+when needed.  When you don't use the Python interface you don't need it, thus
+you can use Vim without this file.
 
-To use the Python interface the Python DLL must be in your search path.  In a
-console window type "path" to see what directories are used.
+On MS-Windows to use the Python interface the Python DLL must be in your search
+path.  In a console window type "path" to see what directories are used.
 
 The name of the DLL must match the Python version Vim was compiled with.
 Currently the name is "python24.dll".  That is for Python 2.4.  To know for
 sure edit "gvim.exe" and search for "python\d*.dll\c".
+
+On Unix the 'pythondll' or 'python3dll' option can be used to specify the
+Python shared library file instead of DYNAMIC_PYTHON_DLL or
+DYNAMIC_PYTHON3_DLL file what were specified at compile time.  The version of
+the shared library must match the Python 2.x or Python 3 version Vim was
+compiled with.
 
 ==============================================================================
 10. Python 3						*python3*

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -1,4 +1,4 @@
-*if_ruby.txt*   For Vim version 7.4.  Last change: 2015 Feb 22
+*if_ruby.txt*   For Vim version 7.4.  Last change: 2015 Oct 16
 
 
 		  VIM REFERENCE MANUAL    by Shugo Maeda
@@ -199,6 +199,8 @@ This means that Vim will search for the Ruby DLL file or shared library only
 when needed.  When you don't use the Ruby interface you don't need it, thus
 you can use Vim even though this library file is not on your system.
 
+MS-Windows ~
+
 You need to install the right version of Ruby for this to work.  You can find
 the package to download from:
 http://www.garbagecollect.jp/ruby/mswin32/en/download/release.html
@@ -215,6 +217,13 @@ If you want to build Vim with Ruby 1.9.1, you need to edit the config.h file
 and comment-out the check for _MSC_VER.
 You may also need to rename the include directory name to match the version,
 strangely for Ruby 1.9.3 the directory is called 1.9.1.
+
+Unix ~
+
+The 'rubydll' option can be used to specify the Ruby shared library file
+instead of DYNAMIC_RUBY_DLL file what was specified at compile time.  The
+version of the shared library must match the Ruby version Vim was compiled
+with.
 
 ==============================================================================
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4847,6 +4847,17 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Note that using the "-u NONE" and "--noplugin" command line arguments
 	reset this option. |-u| |--noplugin|
 
+						*'luadll'*
+'luadll' 		string	(default empty)
+			global
+			{not in Vi} {only for Unix}
+			{only available when compiled with the |+lua/dyn|
+			feature}
+	Specifies the path of the Lua shared library instead of DYNAMIC_LUA_DLL
+	what was specified at compile time.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+
 						*'macatsui'* *'nomacatsui'*
 'macatsui'		boolean	(default on)
 			global
@@ -5550,6 +5561,17 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	Replace the ';' with a ':' or whatever separator is used.  Note that
 	this doesn't work when $INCL contains a comma or white space.
 
+						*'perldll'*
+'perldll' 		string	(default empty)
+			global
+			{not in Vi} {only for Unix}
+			{only available when compiled with the |+perl/dyn|
+			feature}
+	Specifies the path of the Perl shared library instead of
+	DYNAMIC_PERL_DLL what was specified at compile time.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+
 			*'preserveindent'* *'pi'* *'nopreserveindent'* *'nopi'*
 'preserveindent' 'pi'	boolean	(default off)
 			local to buffer
@@ -5676,6 +5698,27 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Insert mode completion.  When zero as much space as available is used.
 	|ins-completion-menu|.
 
+						*'python3dll'*
+'python3dll' 		string	(default empty)
+			global
+			{not in Vi} {only for Unix}
+			{only available when compiled with the |+python3/dyn|
+			feature}
+	Specifies the path of the Python 3 shared library instead of
+	DYNAMIC_PYTHON3_DLL what was specified at compile time.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+
+						*'pythondll'*
+'pythondll' 		string	(default empty)
+			global
+			{not in Vi} {only for Unix}
+			{only available when compiled with the |+python/dyn|
+			feature}
+	Specifies the path of the Python 2.x shared library instead of
+	DYNAMIC_PYTHON_DLL what was specified at compile time.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 						*'quoteescape'* *'qe'*
 'quoteescape' 'qe'	string	(default "\")
@@ -5895,6 +5938,17 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	This is useful for languages such as Hebrew, Arabic and Farsi.
 	The 'rightleft' option must be set for 'rightleftcmd' to take effect.
+
+						*'rubydll'*
+'rubydll' 		string	(default empty)
+			global
+			{not in Vi} {only for Unix}
+			{only available when compiled with the |+ruby/dyn|
+			feature}
+	Specifies the path of the Ruby shared library instead of
+	DYNAMIC_RUBY_DLL what was specified at compile time.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 					 *'ruler'* *'ru'* *'noruler'* *'noru'*
 'ruler' 'ru'		boolean	(default off)

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -415,6 +415,7 @@ $VIMRUNTIME	starting.txt	/*$VIMRUNTIME*
 'lpl'	options.txt	/*'lpl'*
 'ls'	options.txt	/*'ls'*
 'lsp'	options.txt	/*'lsp'*
+'luadll'	options.txt	/*'luadll'*
 'lw'	options.txt	/*'lw'*
 'lz'	options.txt	/*'lz'*
 'ma'	options.txt	/*'ma'*
@@ -727,6 +728,7 @@ $VIMRUNTIME	starting.txt	/*$VIMRUNTIME*
 'path'	options.txt	/*'path'*
 'pdev'	options.txt	/*'pdev'*
 'penc'	options.txt	/*'penc'*
+'perldll'	options.txt	/*'perldll'*
 'pex'	options.txt	/*'pex'*
 'pexpr'	options.txt	/*'pexpr'*
 'pfn'	options.txt	/*'pfn'*
@@ -753,6 +755,8 @@ $VIMRUNTIME	starting.txt	/*$VIMRUNTIME*
 'pumheight'	options.txt	/*'pumheight'*
 'pvh'	options.txt	/*'pvh'*
 'pvw'	options.txt	/*'pvw'*
+'python3dll'	options.txt	/*'python3dll'*
+'pythondll'	options.txt	/*'pythondll'*
 'qe'	options.txt	/*'qe'*
 'quote	motion.txt	/*'quote*
 'quoteescape'	options.txt	/*'quoteescape'*
@@ -779,6 +783,7 @@ $VIMRUNTIME	starting.txt	/*$VIMRUNTIME*
 'rs'	options.txt	/*'rs'*
 'rtp'	options.txt	/*'rtp'*
 'ru'	options.txt	/*'ru'*
+'rubydll'	options.txt	/*'rubydll'*
 'ruf'	options.txt	/*'ruf'*
 'ruler'	options.txt	/*'ruler'*
 'rulerformat'	options.txt	/*'rulerformat'*
@@ -6826,6 +6831,7 @@ lua	if_lua.txt	/*lua*
 lua-buffer	if_lua.txt	/*lua-buffer*
 lua-commands	if_lua.txt	/*lua-commands*
 lua-dict	if_lua.txt	/*lua-dict*
+lua-dynamic	if_lua.txt	/*lua-dynamic*
 lua-eval	if_lua.txt	/*lua-eval*
 lua-funcref	if_lua.txt	/*lua-funcref*
 lua-list	if_lua.txt	/*lua-list*

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -402,7 +402,12 @@ lua_link_init(char *libname, int verbose)
     int
 lua_enabled(int verbose)
 {
-    return lua_link_init(DYNAMIC_LUA_DLL, verbose) == OK;
+#ifdef WIN3264
+    char *dll = DYNAMIC_LUA_DLL;
+#else
+    char *dll = *p_luadll ? (char *)p_luadll : DYNAMIC_LUA_DLL;
+#endif
+    return lua_link_init(dll, verbose) == OK;
 }
 
 #endif /* DYNAMIC_LUA */

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -611,7 +611,12 @@ perl_runtime_link_init(char *libname, int verbose)
 perl_enabled(verbose)
     int		verbose;
 {
-    return perl_runtime_link_init(DYNAMIC_PERL_DLL, verbose) == OK;
+#if WIN3264
+    char *dll = DYNAMIC_PERL_DLL;
+#else
+    char *dll = *p_perldll ? (char *)p_perldll : DYNAMIC_PERL_DLL;
+#endif
+    return perl_runtime_link_init(dll, verbose) == OK;
 }
 #endif /* DYNAMIC_PERL */
 

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -732,7 +732,12 @@ python_runtime_link_init(char *libname, int verbose)
     int
 python_enabled(int verbose)
 {
-    return python_runtime_link_init(DYNAMIC_PYTHON_DLL, verbose) == OK;
+#ifdef WIN3264
+    char *dll = DYNAMIC_PYTHON_DLL;
+#else
+    char *dll = *p_pydll ? (char *)p_pydll : DYNAMIC_PYTHON_DLL;
+#endif
+    return python_runtime_link_init(dll, verbose) == OK;
 }
 
 /*

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -686,7 +686,12 @@ py3_runtime_link_init(char *libname, int verbose)
     int
 python3_enabled(int verbose)
 {
-    return py3_runtime_link_init(DYNAMIC_PYTHON3_DLL, verbose) == OK;
+#ifdef WIN3264
+    char *dll = DYNAMIC_PYTHON3_DLL;
+#else
+    char *dll = *p_py3dll ? (char *)p_py3dll : DYNAMIC_PYTHON3_DLL;
+#endif
+    return py3_runtime_link_init(dll, verbose) == OK;
 }
 
 /* Load the standard Python exceptions - don't import the symbols from the

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -639,7 +639,12 @@ ruby_runtime_link_init(char *libname, int verbose)
 ruby_enabled(verbose)
     int		verbose;
 {
-    return ruby_runtime_link_init(DYNAMIC_RUBY_DLL, verbose) == OK;
+#ifdef WIN3264
+    char *dll = DYNAMIC_RUBY_DLL;
+#else
+    char *dll = *p_rubydll ? (char *)p_rubydll : DYNAMIC_RUBY_DLL;
+#endif
+    return ruby_runtime_link_init(dll, verbose) == OK;
 }
 #endif /* defined(DYNAMIC_RUBY) || defined(PROTO) */
 

--- a/src/option.c
+++ b/src/option.c
@@ -1779,6 +1779,11 @@ static struct vimoption
     {"loadplugins", "lpl",  P_BOOL|P_VI_DEF,
 			    (char_u *)&p_lpl, PV_NONE,
 			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+#if defined(DYNAMIC_LUA) && !defined(WIN3264)
+    {"luadll",      NULL,   P_STRING|P_VI_DEF|P_SECURE,
+			    (char_u *)&p_luadll, PV_NONE,
+			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+#endif
 #ifdef FEAT_GUI_MAC
     {"macatsui",    NULL,   P_BOOL|P_VI_DEF|P_RCLR,
 			    (char_u *)&p_macatsui, PV_NONE,
@@ -2014,6 +2019,11 @@ static struct vimoption
 # endif
 #endif
 				(char_u *)0L} SCRIPTID_INIT},
+#if defined(DYNAMIC_PERL) && !defined(WIN3264)
+    {"perldll",     NULL,   P_STRING|P_VI_DEF|P_SECURE,
+			    (char_u *)&p_perldll, PV_NONE,
+			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+#endif
     {"preserveindent", "pi", P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_pi, PV_PI,
 			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
@@ -2119,6 +2129,16 @@ static struct vimoption
 			    (char_u *)NULL, PV_NONE,
 #endif
 			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+#if defined(DYNAMIC_PYTHON3) && !defined(WIN3264)
+    {"python3dll",  NULL,   P_STRING|P_VI_DEF|P_SECURE,
+			    (char_u *)&p_py3dll, PV_NONE,
+			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+#endif
+#if defined(DYNAMIC_PYTHON) && !defined(WIN3264)
+    {"pythondll",   NULL,   P_STRING|P_VI_DEF|P_SECURE,
+			    (char_u *)&p_pydll, PV_NONE,
+			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+#endif
     {"quoteescape", "qe",   P_STRING|P_ALLOCED|P_VI_DEF,
 #ifdef FEAT_TEXTOBJ
 			    (char_u *)&p_qe, PV_QE,
@@ -2192,6 +2212,11 @@ static struct vimoption
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCRIPTID_INIT},
+#if defined(DYNAMIC_RUBY) && !defined(WIN3264)
+    {"rubydll",     NULL,   P_STRING|P_VI_DEF|P_SECURE,
+			    (char_u *)&p_rubydll, PV_NONE,
+			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+#endif
     {"ruler",	    "ru",   P_BOOL|P_VI_DEF|P_VIM|P_RSTAT,
 #ifdef FEAT_CMDL_INFO
 			    (char_u *)&p_ru, PV_NONE,

--- a/src/option.h
+++ b/src/option.h
@@ -626,6 +626,9 @@ EXTERN char_u	*p_lcs;		/* 'listchars' */
 
 EXTERN int	p_lz;		/* 'lazyredraw' */
 EXTERN int	p_lpl;		/* 'loadplugins' */
+#if defined(DYNAMIC_LUA) && !defined(WIN3264)
+EXTERN char_u	*p_luadll;	/* 'luadll' */
+#endif
 #ifdef FEAT_GUI_MAC
 EXTERN int	p_macatsui;	/* 'macatsui' */
 #endif
@@ -682,6 +685,15 @@ EXTERN char_u	*p_path;	/* 'path' */
 #ifdef FEAT_SEARCHPATH
 EXTERN char_u	*p_cdpath;	/* 'cdpath' */
 #endif
+#if defined(DYNAMIC_PERL) && !defined(WIN3264)
+EXTERN char_u	*p_perldll;	/* 'perldll' */
+#endif
+#if defined(DYNAMIC_PYTHON3) && !defined(WIN3264)
+EXTERN char_u	*p_py3dll;	/* 'python3dll' */
+#endif
+#if defined(DYNAMIC_PYTHON) && !defined(WIN3264)
+EXTERN char_u	*p_pydll;	/* 'pythondll' */
+#endif
 #ifdef FEAT_RELTIME
 EXTERN long	p_rdt;		/* 'redrawtime' */
 #endif
@@ -700,6 +712,9 @@ EXTERN int	p_rs;		/* 'restorescreen' */
 #ifdef FEAT_RIGHTLEFT
 EXTERN int	p_ari;		/* 'allowrevins' */
 EXTERN int	p_ri;		/* 'revins' */
+#endif
+#if defined(DYNAMIC_RUBY) && !defined(WIN3264)
+EXTERN char_u	*p_rubydll;	/* 'rubydll' */
 #endif
 #ifdef FEAT_CMDL_INFO
 EXTERN int	p_ru;		/* 'ruler' */


### PR DESCRIPTION
On Unix, the 'luadll', 'perldll', 'pythondll', 'python3dll', and 'rubydll'
options can be used to specify the shared library file for the interfaces
instead of DYNAMIC_*_DLL files what was specified at compile time.

Specially for OS X El Capitan, DYLD_LIBRARY_PATH cannot be used to specify the
shared library path for security reasons. Thus this mechanism is required to
load shared libraries with various package systems, Homebrew, MacPorts, etc.
