### PR TITLE
Check scrollbind in nv_mousescroll using scrolled window

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -4671,6 +4671,11 @@ nv_mousescroll(cap)
 # ifdef FEAT_WINDOWS
     curwin->w_redr_status = TRUE;
 
+#  ifdef FEAT_SCROLLBIND
+    if (curwin->w_p_scb)
+	do_check_scrollbind(TRUE);
+#  endif
+
     curwin = old_curwin;
     curbuf = curwin->w_buffer;
 # endif


### PR DESCRIPTION
Given certain conditions:
- Running gvim
- Multiple splits open
- 'scrollbind' set in all splits
- Cursor in a split other than the top-left

scrolling the top-left window with the mouse wheel will not maintain the
scrolled view in all scroll bound windows.

normal_cmd calls do_check_scrollbind after running
nv_cmds[idx].cmd_func, but by the time that happens "curwin" is the
window where the cursor is, which wasn't scrolled, so nothing happens.

nv_mousescroll temporarily sets curwin to the window which is actually
being scrolled, so add a call to do_check_scrollbind there.  This
happens before restoring curwin's original value, thus allowing it to
actually notice the scroll that occurred and propagate that to all
windows which are being synced by 'scrollbind'.
