### PR TITLE
Fix incorrect error for variable

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -437,7 +437,7 @@ endif
 syn match  shDerefSimple	"\$\%(\k\+\|\d\)"
 syn region shDeref	matchgroup=PreProc start="\${" end="}"	contains=@shDerefList,shDerefVarArray
 if !exists("g:sh_no_error")
- syn match  shDerefWordError	"[^}$[]"	contained
+ syn match  shDerefWordError	"[^}$[]_"	contained
 endif
 syn match  shDerefSimple	"\$[-#*@!?]"
 syn match  shDerefSimple	"\$\$"


### PR DESCRIPTION
Without the underscore, vim marks "${some_var}" as having an error from the underscore to the closing brace }
