### PR TITLE
Fix configure script with DEVELOPER_DIR environment variable

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -4198,7 +4198,7 @@ if test "${with_developer_dir+set}" = set; then :
   withval=$with_developer_dir; DEVELOPER_DIR="$withval"; { $as_echo "$as_me:${as_lineno-$LINENO}: result: $DEVELOPER_DIR" >&5
 $as_echo "$DEVELOPER_DIR" >&6; }
 else
-  DEVELOPER_DIR=""; { $as_echo "$as_me:${as_lineno-$LINENO}: result: not present" >&5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: not present" >&5
 $as_echo "not present" >&6; }
 fi
 

--- a/src/configure.in
+++ b/src/configure.in
@@ -153,7 +153,7 @@ if test "`(uname) 2>/dev/null`" = Darwin; then
   AC_MSG_CHECKING(--with-developer-dir argument)
   AC_ARG_WITH(developer-dir, [  --with-developer-dir=PATH    use PATH as location for Xcode developer tools],
 	DEVELOPER_DIR="$withval"; AC_MSG_RESULT($DEVELOPER_DIR),
-        DEVELOPER_DIR=""; AC_MSG_RESULT(not present))
+        AC_MSG_RESULT(not present))
   
   if test "x$DEVELOPER_DIR" = "x"; then
     AC_PATH_PROG(XCODE_SELECT, xcode-select)


### PR DESCRIPTION
configure script always fails if DEVELOPER_DIR environment variable is set even
though it is the right value (`xcode-select -print-path`).

```
$ DEVELOPER_DIR=`xcode-select -print-path` ./configure
...
no terminal library found
checking for tgetent()... configure: error: NOT FOUND!
      You need to install a terminal library; for example ncurses.
      Or specify the name of the library with --with-tlib.
```

The problem is configure script overrides DEVELOPER_DIR environment variable
with empty string not make variable if `--with-developer-dir` option is not
present and DEVELOPER_DIR environment variable already exists.
