### PR TITLE
Fix test_utf8 fails at AppVeyor.  (dirty workaround)

### DIFF
--- a/src/testdir/test_utf8.in
+++ b/src/testdir/test_utf8.in
@@ -21,24 +21,35 @@ STARTTEST
 :endfor
 :"
 :" Test for customlist completion
+:let ofs=0
 :function! CustomComplete1(lead, line, pos)
 :	return ['あ', 'い']
 :endfunction
-:command -nargs=1 -complete=customlist,CustomComplete1 Test1 echo
-:call feedkeys(":Test1 \<C-L>'\<C-B>$put='\<CR>", 't')
+:command -nargs=1 -complete=customlist,CustomComplete1 Test1
+:call feedkeys(":Test1 \<C-L>'\<C-B>let str='\<CR>", 't')
 :
+:" Against AppVeyor test failed.
+:if str[0] == ':'
+:	let ofs=1
+:endif
+:$put=str[ofs :]
+:"
 :function! CustomComplete2(lead, line, pos)
 :	return ['あたし', 'あたま', 'あたりめ']
 :endfunction
-:command -nargs=1 -complete=customlist,CustomComplete2 Test2 echo
-:call feedkeys(":Test2 \<C-L>'\<C-B>$put='\<CR>", 't')
+:command -nargs=1 -complete=customlist,CustomComplete2 Test2
+:call feedkeys(":Test2 \<C-L>'\<C-B>let str='\<CR>", 't')
 :
+:$put=str[ofs :]
+:"
 :function! CustomComplete3(lead, line, pos)
 :	return ['Nこ', 'Nん', 'Nぶ']
 :endfunction
-:command -nargs=1 -complete=customlist,CustomComplete3 Test3 echo
-:call feedkeys(":Test3 \<C-L>'\<C-B>$put='\<CR>", 't')
+:command -nargs=1 -complete=customlist,CustomComplete3 Test3
+:call feedkeys(":Test3 \<C-L>'\<C-B>let str='\<CR>", 't')
 :
+:$put=str[ofs :]
+:"
 :call garbagecollect(1)
 :/^start:/,$wq! test.out
 ENDTEST


### PR DESCRIPTION
This problem is occured by 'feedkeys() with GUI.

Investigated by Yukihiro Nakadaira in 2013 Jul.
https://github.com/vim-jp/issues/issues/429#issuecomment-20932913 (Sorry in Japanese)
I tried to translate to rough.

> Proccess flow is getcmdline () -> setmouse () -> update_mouseshape () -> char_avail ().
> On GUI, Called char_avail() by cursor update in the last of getcmdline().
> So ':' of the next line is read into the type-ahead-buffer before execution of feedkeys().

My solution:
- The next line of the 'call feedkeys()' is empty.  (Only ':')
- Without '$put=' in the feedkeys(), once I put in a string variable.
- When the first character equivalent to ':', skip this character.

It's dirty...  :-)
## How about this?

Best regards,
Hirohito Higashi (a.k.a h_east)
