### PR TITLE
Mouse buttons 6-9 support for X11 and GTK GUIs

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -1689,6 +1689,12 @@ button_press_event(GtkWidget *widget,
     case 3:
 	button = MOUSE_RIGHT;
 	break;
+    case 8:
+	button = MOUSE_X1;
+	break;
+    case 9:
+	button = MOUSE_X2;
+	break;
     default:
 	return FALSE;		/* Unknown button */
     }

--- a/src/gui_x11.c
+++ b/src/gui_x11.c
@@ -1132,6 +1132,10 @@ gui_x11_mouse_cb(w, dud, event, dum)
 		case Button3:	button = MOUSE_RIGHT;	break;
 		case Button4:	button = MOUSE_4;	break;
 		case Button5:	button = MOUSE_5;	break;
+		case 6:		button = MOUSE_7;	break;
+		case 7:		button = MOUSE_6;	break;
+		case 8:		button = MOUSE_X1;	break;
+		case 9:		button = MOUSE_X2;	break;
 		default:
 		    return;	/* Unknown button */
 	    }


### PR DESCRIPTION
- gui/gtk: add support for mouse buttons 8 and 9 (<X2Mouse> and <X1Mouse> on Windows)
- gui/x11: add support for mouse buttons 6-9 (<ScrollWheelLeft>, <ScrollWheelRight>, <X2Mouse> and <X1Mouse>)
