### PR TITLE
Fix build with FEAT_INS_EXPAND disabled

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -8741,11 +8741,15 @@ call_func(funcname, len, rettv, argcount, argvars, firstline, lastline,
 		     * redo buffer.
 		     */
 		    save_search_patterns();
+#ifdef FEAT_INS_EXPAND
 		    if (!ins_compl_active())
 		    {
+#endif
 			saveRedobuff();
 			did_save_redo = TRUE;
+#ifdef FEAT_INS_EXPAND
 		    }
+#endif
 		    ++fp->uf_calls;
 		    call_user_func(fp, argcount, argvars, rettv,
 					       firstline, lastline,

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -9450,11 +9450,15 @@ apply_autocmds_group(event, fname, fname_io, force, group, buf, eap)
     if (!autocmd_busy)
     {
 	save_search_patterns();
+#ifdef FEAT_INS_EXPAND
 	if (!ins_compl_active())
 	{
+#endif
 	    saveRedobuff();
 	    did_save_redobuff = TRUE;
+#ifdef FEAT_INS_EXPAND
 	}
+#endif
 	did_filetype = keep_filetype;
     }
 


### PR DESCRIPTION
- Fall back to the old behaviour since ins_compl_active won't
  exist without FEAT_INS_EXPAND

Change-Id: I52fc08df176816e61839dd88f4acbb21408dcbac
