### PR TITLE
Allow to honor PYTHONHOME environment variable for +python/dyn and +python3/dyn

### DIFF
--- a/src/if_python.c
+++ b/src/if_python.c
@@ -928,7 +928,10 @@ Python_Init(void)
 #endif
 
 #ifdef PYTHON_HOME
-	Py_SetPythonHome(PYTHON_HOME);
+# ifdef DYNAMIC_PYTHON
+	if (mch_getenv((char_u *)"PYTHONHOME") == NULL)
+# endif
+	    Py_SetPythonHome(PYTHON_HOME);
 #endif
 
 	init_structs();

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -858,7 +858,10 @@ Python3_Init(void)
 
 
 #ifdef PYTHON3_HOME
-	Py_SetPythonHome(PYTHON3_HOME);
+# ifdef DYNAMIC_PYTHON3
+	if (mch_getenv((char_u *)"PYTHONHOME") == NULL)
+# endif
+	    Py_SetPythonHome(PYTHON3_HOME);
 #endif
 
 	PyImport_AppendInittab("vim", Py3Init_vim);


### PR DESCRIPTION
According to Python 2.7 and 3.5 source code, Python doesn't honor `PYTHONHOME` environment variable after `Py_SetPythonHome` call.

```
static char *default_home = NULL;

void
Py_SetPythonHome(char *home)
{
    default_home = home;
}

char *
Py_GetPythonHome(void)
{
    char *home = default_home;
    if (home == NULL && !Py_IgnoreEnvironmentFlag)
        home = Py_GETENV("PYTHONHOME");
    return home;
}
```

So, check `PYTHONHOME` environment variable first. It is required for `pythondll` and `pythonthreedll` options.
