### PR TITLE
Fix swap file detection for symlink pointing to root fs '/'.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1926,6 +1926,7 @@ test1 \
 	test_options \
 	test_perl \
 	test_qf_title \
+	test_resolve_swap \
 	test_ruby \
 	test_search_mbyte \
 	test_set \

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2508,7 +2508,8 @@ mch_FullName(fname, buf, len, force)
 #endif
 
     /* expand it if forced or not an absolute path */
-    if (force || !mch_isFullName(fname))
+    if ((force || !mch_isFullName(fname))
+	    && ((p = vim_strrchr(fname, '/')) == NULL || p != fname))
     {
 	/*
 	 * If the file name has a path, change to that directory for a moment,

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -59,6 +59,7 @@ SCRIPTS = test1.out test2.out test3.out test4.out test5.out test6.out \
 		test_options.out \
 		test_perl.out \
 		test_qf_title.out \
+		test_resolve_swap.out \
 		test_ruby.out \
 		test_search_mbyte.out \
 		test_set.out \

--- a/src/testdir/test_resolve_swap.in
+++ b/src/testdir/test_resolve_swap.in
@@ -1,0 +1,59 @@
+Tests for swap file detection.
+This test failed, if root '/' directory not writable.
+
+STARTTEST
+:so small.vim
+:set nocompatible viminfo+=nviminfo
+:set dir=.
+:fun! TestSwap()
+:  let dir = '/'
+:  let fname = 'Xfile1'
+:  let file = dir.fname
+:  let fileswap = dir.'.'.fname.'.swp'
+:  let link = 'Xlink1'
+:  let linkswap = '.'.link.'.swp'
+:  if !filewritable(dir) || glob(file)
+:    " failed
+:    return
+:  endif
+:  call writefile([], file)
+:  exe '!ln -sfL' file link
+:  exe 'e!' link
+:  call append(0, 'test text swapfile')
+:  preserve
+:  exe '!ls' link '>>test.out'
+:  exe '!ls' linkswap '>>test.out'
+:  exe '!ls' file '>>test.out'
+:  exe '!ls' fileswap '>>test.out'
+:  set bin
+:  exe 'sp' fileswap
+:  w! /Xswap
+:  set nobin
+:  new
+:  only!
+:  exe 'bwipe!' link
+:  exe 'bwipe!' file
+:  exe 'bwipe!' fileswap
+:  call delete(linkswap)
+:  call delete(fileswap)
+:  exe '!echo start not recovered file >>test.out'
+:  exe '!cat' file '>>test.out'
+:  exe '!echo end not recovered file >>test.out'
+:  call rename('/Xswap', fileswap)
+:  exe 'recover' link
+:  w!
+:  exe '!echo start recovered file >>test.out'
+:  exe '!cat' file '>>test.out'
+:  exe '!echo end recovered file >>test.out'
+:  exe 'bwipe!' link
+:  exe 'bwipe!' file
+:  echo delete(fileswap)
+:  echo delete(linkswap)
+:  echo delete(link)
+:  echo delete(file)
+:endfun
+:call writefile([], 'test.out')
+:call TestSwap()
+:qa!
+ENDTEST
+

--- a/src/testdir/test_resolve_swap.ok
+++ b/src/testdir/test_resolve_swap.ok
@@ -1,0 +1,9 @@
+Xlink1
+/Xfile1
+/.Xfile1.swp
+start not recovered file
+end not recovered file
+start recovered file
+test text swapfile
+
+end recovered file


### PR DESCRIPTION
Fix swap file detection for symlink pointing to root fs '/'.
#### Steps
1. Open the file `/file` with Vim, and the swapfile `/.file.swp` is generated.
2. Create the symlink `/tmp/link` pointing to '/file'.
3. Open the symlink `/tmp/link`, but the swapfile `/.file.swp` is not detected.
4. And the new swapfile `/tmp/.link.swp` is genereted.
#### Invalid results of `mch_FullName(..., force=TRUE)` (os_unix.c)

```
fname = "/"        -> buf = "/etc/" (return FAIL)
fname = "/tmp"     -> buf = "/etc/" (return FAIL)
fname = "/file"    -> buf = "/etc/" (return FAIL)
```
#### Tests

Unfortunately, the tests will fail if root fs '/' is not writable.
