### PR TITLE
Support 4608 colour terminals.

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -7700,7 +7700,7 @@ do_highlight(line, forceit, init)
 			color &= 7;	/* truncate to 8 colors */
 		    }
 		    else if (t_colors == 16 || t_colors == 88
-							   || t_colors == 256)
+							   || t_colors >= 256)
 		    {
 			/*
 			 * Guess: if the termcap entry ends in 'm', it is
@@ -7711,19 +7711,16 @@ do_highlight(line, forceit, init)
 			    p = T_CAF;
 			else
 			    p = T_CSF;
-			if (*p != NUL && *(p + STRLEN(p) - 1) == 'm')
-			    switch (t_colors)
-			    {
-				case 16:
-				    color = color_numbers_8[i];
-				    break;
-				case 88:
-				    color = color_numbers_88[i];
-				    break;
-				case 256:
-				    color = color_numbers_256[i];
-				    break;
-			    }
+			if (*p != NUL && (t_colors > 256 ||
+					*(p + STRLEN(p) - 1) == 'm'))
+			{
+			    if (t_colors == 88)
+				color = color_numbers_88[i];
+			    else if (t_colors >= 256)
+				color = color_numbers_256[i];
+			    else
+				color = color_numbers_8[i];
+			}
 		    }
 		}
 	    }


### PR DESCRIPTION
Vim assumed that all terminals that do not have 8, 16, 88 or 256 colours
have a particular non-ansi, non-terminfo ordering to the first 16 colours.
Terminals that had one of those counts would only get ANSI ordering if
the terminfo control sequence ends with a letter "m".

I have left the weirdness in, but added the assumption that a terminal
with more than 256 colours will do the sane thing and use the XTerm-256
ordering for the first 256 of these colours.

If it does not, terminfo is sufficiently programmable to make it happen.

I have checked the terminfo.src from ncurses and the only mentioned non-ansi 
terminals have 64 or fewer colours, and probably don't work with Vim's colours anyway.

Note: the '4608 colours' I'm referring to are the result of placing the terminfo `setaf` 
below with other related codes into the terminfo descriptions of one of the recent crop 
of "24bit truecolor" supporting terminals. 

This makes the colours that vim is already able to use as below, except those hardcoded colour
names go "weird".
- 0..7 -- ANSI standard
- 8..15 -- Bright ANSI  
- 16..231 -- XTerm Colour cube
- 232..255 -- XTerm greys
- 256..4351 -- 12 bit cube
- 4352..4607 -- Full grey scale

``` terminfo
        setaf=\E[
            %?%p1%{8}%<%t3%p1%d
            %e%p1%{16}%<%t%p1%{82}%+%d
            %e%p1%{256}%<%t38;5;%p1%d
            %e38;2;
                %?%p1%{4352}%<%t
                    %p1%{256}%-%{256}%/%{17}%*%d;
                    %p1%{256}%-%{16}%/%{15}%&%{17}%*%d;
                    %p1%{15}%&%{17}%*%d
                %e%p1%{32768}%<%t
                    %p1%{255}%&%Pa%ga%d;%ga%d;%ga%d
                %e
                    %p1%{65536}%/%{255}%&%d;
                    %p1%{256}%/%{255}%&%d;
                    %p1%{255}%&%d
                %;
            %;m,
```
