### PR TITLE
Fix some filename operations in Cygwin

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2500,7 +2500,8 @@ mch_FullName(fname, buf, len, force)
      * This helps for when "/etc/hosts" is a symlink to "c:/something/hosts".
      */
 # if CYGWIN_VERSION_DLL_MAJOR >= 1007
-    cygwin_conv_path(CCP_WIN_A_TO_POSIX, fname, posix_fname, MAXPATHL);
+    cygwin_conv_path(CCP_WIN_A_TO_POSIX | CCP_RELATIVE,
+	    fname, posix_fname, MAXPATHL);
 # else
     cygwin_conv_to_posix_path(fname, posix_fname);
 # endif


### PR DESCRIPTION
Currently, `fnamemodify('.', ':.')` returns an empty string in Cygwin which causes some problems in plugins using `fnamemodify`. `mch_FullName` in os_unix.c calls `cygwin_conv_path` to convert from Windows-style paths into POSIX. The problem is that using `cygwin_conv_path` returns a path that ends in a forward slash for some inputs, and then `shorten_fname` checks if the name ends in a `/` and thinks its job is done.

Using `CCP_RELATIVE` in the call to `cygwin_conv_path` returns relative paths that are consistent with what's used for other systems. `CCP_RELATIVE` still converts relative and absolute paths both in Windows and POSIX forms:

``` c
#include <sys/cygwin.h>
#include <stdio.h>

static const char *paths[] = {
   "C:\\Windows\\..\\Windows",
   "c:/something/hosts",
   "/etc/hosts",
   ".",
   "./",
   "../.",
   0
};

void main() {
   char buf[320];
   const char **p = paths;

   printf("CCP_ABSOLUTE:\n");
   do {
      cygwin_conv_path(CCP_WIN_A_TO_POSIX, *p, buf, sizeof(buf));
      printf("%s -> %s\n", *p, buf);
   } while (*++p);


   printf("\nCCP_RELATIVE:\n");
   p = paths;
   do {
      cygwin_conv_path(CCP_WIN_A_TO_POSIX | CCP_RELATIVE, *p, buf, sizeof(buf));
      printf("%s -> %s\n", *p, buf);
   } while (*++p);
}

/*
 * Output:
 *    CCP_ABSOLUTE:
 *    C:\Windows\..\Windows -> /cygdrive/c/Windows
 *    c:/something/hosts -> /cygdrive/c/something/hosts
 *    /etc/hosts -> /etc/hosts
 *    . -> /home/Jake/temp/
 *    ./ -> /home/Jake/temp/
 *    ../. -> /home/Jake/
 *
 *    CCP_RELATIVE:
 *    C:\Windows\..\Windows -> /cygdrive/c/Windows
 *    c:/something/hosts -> /cygdrive/c/something/hosts
 *    /etc/hosts -> /etc/hosts
 *    . -> .
 *    ./ -> ./
 *    ../. -> ../.
 */
```
