### PR TITLE
Remove clip_init(FALSE) call when 'term' is set

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -1880,14 +1880,6 @@ set_termname(term)
 
 	p = (char_u *)"";
 #  ifdef FEAT_MOUSE_XTERM
-#   ifdef FEAT_CLIPBOARD
-#    ifdef FEAT_GUI
-	if (!gui.in_use)
-#    endif
-#    ifndef FEAT_CYGWIN_WIN32_CLIPBOARD
-	    clip_init(FALSE);
-#    endif
-#   endif
 	if (use_xterm_like_mouse(term))
 	{
 	    if (use_xterm_mouse())


### PR DESCRIPTION
Using a Vim that is built to be able to access X's PRIMARY and CLIPBOARD
selections (i.e., "\* and "+), performing “:let &term=&term” causes Vim
to "forget" that it knows how to access those registers.

This is because set_termname() ends up calling clip_init(), which sets
owned = FALSE on both VimClipboard instances.

Changing &term should not modify the state of the clipboard at all, so this
patch removes that bit of the code, resolving the bug.

Original discussion on list is at http://news.gmane.org/find-root.php?message_id=20141202055144.GD13546%40freya.jamessan.com
