### PR TITLE
patch 7.4.948

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1400,7 +1400,7 @@ else
   au BufNewFile,BufRead *.pl			call s:FTpl()
 endif
 au BufNewFile,BufRead *.plx,*.al		setf perl
-au BufNewFile,BufRead *.p6,*.pm6		setf perl6
+au BufNewFile,BufRead *.p6,*.pm6,*.pl6 setf perl6
 
 func! s:FTpl()
   if exists("g:filetype_pl")
@@ -1429,6 +1429,7 @@ au BufNewFile,BufRead *.pm
 
 " Perl POD
 au BufNewFile,BufRead *.pod			setf pod
+au BufNewFile,BufRead *.pod6		setf pod6
 
 " Php, php3, php4, etc.
 " Also Phtml (was used for PHP 2 in the past)


### PR DESCRIPTION
Problem:    Missing perl6 file extentions
Solution:   Add pl6 and pod6 extention to filetype mappings
