### PR TITLE
Support defining compilation date in $SOURCE_DATE_EPOCH

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -30,6 +30,9 @@
 /* Define when __DATE__ " " __TIME__ can be used */
 #undef HAVE_DATE_TIME
 
+/* Defined as the date of last modification */
+#undef BUILD_DATE
+
 /* Define when __attribute__((unused)) can be used */
 #undef HAVE_ATTRIBUTE_UNUSED
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -62,6 +62,16 @@ if test x"$ac_cv_prog_cc_c99" != xno; then
   fi
 fi
 
+dnl If $SOURCE_DATE_EPOCH is present in the environment, use that as the
+dnl "compiled" timestamp in :version's output.  Attempt to get the formatted
+dnl date using GNU date syntax, BSD date syntax, and finally falling back to
+dnl just using the current time.
+if test -n "$SOURCE_DATE_EPOCH"; then
+  DATE_FMT="%b %d %Y %H:%M:%S"
+  BUILD_DATE=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || LC_ALL=C date -u -r "$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || LC_ALL=C date -u "+$DATE_FMT")
+  AC_DEFINE_UNQUOTED(BUILD_DATE, ["$BUILD_DATE"])
+fi
+
 dnl Check for the flag that fails if stuff are missing.
 
 AC_MSG_CHECKING(--enable-fail-if-missing argument)

--- a/src/version.c
+++ b/src/version.c
@@ -44,9 +44,13 @@ init_longVersion(void)
      * VAX C can't concatenate strings in the preprocessor.
      */
     strcpy(longVersion, VIM_VERSION_LONG_DATE);
+#ifdef BUILD_DATE
+    strcat(longVersion, BUILD_DATE);
+#else
     strcat(longVersion, __DATE__);
     strcat(longVersion, " ");
     strcat(longVersion, __TIME__);
+#endif
     strcat(longVersion, ")");
 }
 
@@ -56,7 +60,11 @@ init_longVersion(void)
 {
     if (longVersion == NULL)
     {
+#ifdef BUILD_DATE
+	char *date_time = BUILD_DATE;
+#else
 	char *date_time = __DATE__ " " __TIME__;
+#endif
 	char *msg = _("%s (%s, compiled %s)");
 	size_t len = strlen(msg)
 		    + strlen(VIM_VERSION_LONG_ONLY)


### PR DESCRIPTION
There is an ongoing [effort](https://reproducible-builds.org/) to make FOSS software reproducibly buildable.  In order to make Vim build reproducibly, it is necessary to allow defining the date/time that is part of `VIM_VERSION_LONG` as part of the build process.

This commit enables that by adding support for the [`SOURCE_DATE_EPOCH` spec](https://reproducible-builds.org/specs/source-date-epoch/).  When the `$SOURCE_DATE_EPOCH` environment variable is defined, it will be used to populate the `BUILD_DATE` preprocessor define.

If `BUILD_DATE` is not defined, the existing behavior of relying on the preprocessor's `__DATE__`/`__TIME__` symbols will be used.
