### PR TITLE
Update ssh_config and sshd_config syntax

### DIFF
--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -2,8 +2,9 @@
 " Language:	OpenSSH client configuration file (ssh_config)
 " Author:	David Necas (Yeti)
 " Maintainer:   Leonard Ehrenfried <leonard.ehrenfried@web.de>	
-" Last Change:	2012 Feb 24 
-" SSH Version:	5.9p1
+" Modified By:	Dominik Fischer
+" Last Change:	2015 Dec 3 
+" SSH Version:	6.5
 "
 
 " Setup
@@ -100,6 +101,8 @@ syn case ignore
 " Keywords
 syn keyword sshconfigHostSect Host
 
+syn keyword sshconfigMatch exec host originalhost user localuser all
+
 syn keyword sshconfigKeyword AddressFamily
 syn keyword sshconfigKeyword BatchMode
 syn keyword sshconfigKeyword BindAddress
@@ -148,6 +151,7 @@ syn keyword sshconfigKeyword LocalCommand
 syn keyword sshconfigKeyword LocalForward
 syn keyword sshconfigKeyword LogLevel
 syn keyword sshconfigKeyword MACs
+syn keyword sshconfigKeyword Match
 syn keyword sshconfigKeyword NoHostAuthenticationForLocalhost
 syn keyword sshconfigKeyword NumberOfPasswordPrompts
 syn keyword sshconfigKeyword PKCS11Provider
@@ -157,6 +161,7 @@ syn keyword sshconfigKeyword Port
 syn keyword sshconfigKeyword PreferredAuthentications
 syn keyword sshconfigKeyword Protocol
 syn keyword sshconfigKeyword ProxyCommand
+syn keyword sshconfigKeyword ProxyUseFDPass
 syn keyword sshconfigKeyword PubkeyAuthentication
 syn keyword sshconfigKeyword RSAAuthentication
 syn keyword sshconfigKeyword RekeyLimit
@@ -211,6 +216,7 @@ if version >= 508 || !exists("did_sshconfig_syntax_inits")
   HiLink sshconfigSpecial        Special
   HiLink sshconfigKeyword        Keyword
   HiLink sshconfigHostSect       Type
+  HiLink sshconfigMatch          Type
   delcommand HiLink
 endif
 

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	OpenSSH client configuration file (ssh_config)
 " Author:	David Necas (Yeti)
-" Maintainer:   Leonard Ehrenfried <leonard.ehrenfried@web.de>	
-" Modified By:	Dominik Fischer
+" Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
+" Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>	
 " Last Change:	2015 Dec 3 
 " SSH Version:	7.0
 "

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -4,7 +4,7 @@
 " Maintainer:   Leonard Ehrenfried <leonard.ehrenfried@web.de>	
 " Modified By:	Dominik Fischer
 " Last Change:	2015 Dec 3 
-" SSH Version:	6.8
+" SSH Version:	7.0
 "
 
 " Setup
@@ -163,6 +163,7 @@ syn keyword sshconfigKeyword PreferredAuthentications
 syn keyword sshconfigKeyword Protocol
 syn keyword sshconfigKeyword ProxyCommand
 syn keyword sshconfigKeyword ProxyUseFDPass
+syn keyword sshconfigKeyword PubkeyAcceptedKeyTypes
 syn keyword sshconfigKeyword PubkeyAuthentication
 syn keyword sshconfigKeyword RSAAuthentication
 syn keyword sshconfigKeyword RekeyLimit

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -4,7 +4,7 @@
 " Maintainer:   Leonard Ehrenfried <leonard.ehrenfried@web.de>	
 " Modified By:	Dominik Fischer
 " Last Change:	2015 Dec 3 
-" SSH Version:	6.5
+" SSH Version:	6.8
 "
 
 " Setup
@@ -101,7 +101,7 @@ syn case ignore
 " Keywords
 syn keyword sshconfigHostSect Host
 
-syn keyword sshconfigMatch exec host originalhost user localuser all
+syn keyword sshconfigMatch canonical exec host originalhost user localuser all
 
 syn keyword sshconfigKeyword AddressFamily
 syn keyword sshconfigKeyword BatchMode
@@ -141,6 +141,7 @@ syn keyword sshconfigKeyword HostKeyAlgorithms
 syn keyword sshconfigKeyword HostKeyAlias
 syn keyword sshconfigKeyword HostName
 syn keyword sshconfigKeyword HostbasedAuthentication
+syn keyword sshconfigKeyword HostbasedKeyTypes
 syn keyword sshconfigKeyword IPQoS
 syn keyword sshconfigKeyword IdentitiesOnly
 syn keyword sshconfigKeyword IdentityFile

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -106,6 +106,7 @@ syn keyword sshdconfigKeyword AcceptEnv
 syn keyword sshdconfigKeyword AddressFamily
 syn keyword sshdconfigKeyword AllowAgentForwarding
 syn keyword sshdconfigKeyword AllowGroups
+syn keyword sshdconfigKeyword AllowStreamLocalForwarding
 syn keyword sshdconfigKeyword AllowTcpForwarding
 syn keyword sshdconfigKeyword AllowUsers
 syn keyword sshdconfigKeyword AuthorizedKeysFile

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -3,9 +3,10 @@
 " Maintainer:	David Necas (Yeti)
 " Maintainer:   Leonard Ehrenfried <leonard.ehrenfried@web.de>	
 " Modified By:	Thilo Six
+" Modified By:	Dominik Fischer
 " Originally:	2009-07-09
-" Last Change:	2011 Oct 31 
-" SSH Version:	5.9p1
+" Last Change:	2015 Dec 3 
+" SSH Version:	5.9
 "
 
 " Setup
@@ -38,6 +39,8 @@ syn keyword sshdconfigTodo TODO FIXME NOTE contained
 syn keyword sshdconfigYesNo yes no none
 
 syn keyword sshdconfigAddressFamily any inet inet6
+
+syn keyword sshdconfigPrivilegeSeparation sandbox
 
 syn keyword sshdconfigCipher aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
 syn keyword sshdconfigCipher aes192-cbc aes256-cbc aes128-ctr aes192-ctr aes256-ctr
@@ -192,6 +195,7 @@ if version >= 508 || !exists("did_sshdconfig_syntax_inits")
   HiLink sshdconfigConstant       Constant
   HiLink sshdconfigYesNo          sshdconfigEnum
   HiLink sshdconfigAddressFamily  sshdconfigEnum
+  HiLink sshdconfigPrivilegeSeparation  sshdconfigEnum
   HiLink sshdconfigCipher         sshdconfigEnum
   HiLink sshdconfigMAC            sshdconfigEnum
   HiLink sshdconfigRootLogin      sshdconfigEnum

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -6,7 +6,7 @@
 " Modified By:	Dominik Fischer
 " Originally:	2009-07-09
 " Last Change:	2015 Dec 3 
-" SSH Version:	6.7
+" SSH Version:	6.8
 "
 
 " Setup
@@ -129,6 +129,7 @@ syn keyword sshdconfigKeyword GSSAPIStrictAcceptorCheck
 syn keyword sshdconfigKeyword GatewayPorts
 syn keyword sshdconfigKeyword HostCertificate
 syn keyword sshdconfigKeyword HostKey
+syn keyword sshdconfigKeyword HostbasedAcceptedKeyTypes
 syn keyword sshdconfigKeyword HostbasedAuthentication
 syn keyword sshdconfigKeyword HostbasedUsesNameFromPacketOnly
 syn keyword sshdconfigKeyword IPQoS
@@ -163,6 +164,7 @@ syn keyword sshdconfigKeyword Port
 syn keyword sshdconfigKeyword PrintLastLog
 syn keyword sshdconfigKeyword PrintMotd
 syn keyword sshdconfigKeyword Protocol
+syn keyword sshdconfigKeyword PubkeyAcceptedKeyTypes
 syn keyword sshdconfigKeyword PubkeyAuthentication
 syn keyword sshdconfigKeyword RSAAuthentication
 syn keyword sshdconfigKeyword RekeyLimit

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -6,7 +6,7 @@
 " Modified By:	Dominik Fischer
 " Originally:	2009-07-09
 " Last Change:	2015 Dec 3 
-" SSH Version:	6.2
+" SSH Version:	6.3
 "
 
 " Setup
@@ -163,6 +163,7 @@ syn keyword sshdconfigKeyword PrintMotd
 syn keyword sshdconfigKeyword Protocol
 syn keyword sshdconfigKeyword PubkeyAuthentication
 syn keyword sshdconfigKeyword RSAAuthentication
+syn keyword sshdconfigKeyword RekeyLimit
 syn keyword sshdconfigKeyword RevokedKeys
 syn keyword sshdconfigKeyword RhostsRSAAuthentication
 syn keyword sshdconfigKeyword ServerKeyBits

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -6,7 +6,7 @@
 " Modified By:	Dominik Fischer
 " Originally:	2009-07-09
 " Last Change:	2015 Dec 3 
-" SSH Version:	5.9
+" SSH Version:	6.1
 "
 
 " Setup
@@ -172,6 +172,7 @@ syn keyword sshdconfigKeyword UseDNS
 syn keyword sshdconfigKeyword UseLogin
 syn keyword sshdconfigKeyword UsePAM
 syn keyword sshdconfigKeyword UsePrivilegeSeparation
+syn keyword sshdconfigKeyword VersionAddendum
 syn keyword sshdconfigKeyword X11DisplayOffset
 syn keyword sshdconfigKeyword X11Forwarding
 syn keyword sshdconfigKeyword X11UseLocalhost

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -6,7 +6,7 @@
 " Modified By:	Dominik Fischer
 " Originally:	2009-07-09
 " Last Change:	2015 Dec 3 
-" SSH Version:	6.5
+" SSH Version:	6.7
 "
 
 " Setup
@@ -157,6 +157,7 @@ syn keyword sshdconfigKeyword PermitRootLogin
 syn keyword sshdconfigKeyword PermitTTY
 syn keyword sshdconfigKeyword PermitTunnel
 syn keyword sshdconfigKeyword PermitUserEnvironment
+syn keyword sshdconfigKeyword PermitUserRC
 syn keyword sshdconfigKeyword PidFile
 syn keyword sshdconfigKeyword Port
 syn keyword sshdconfigKeyword PrintLastLog

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -6,7 +6,7 @@
 " Modified By:	Dominik Fischer
 " Originally:	2009-07-09
 " Last Change:	2015 Dec 3 
-" SSH Version:	6.1
+" SSH Version:	6.2
 "
 
 " Setup
@@ -41,6 +41,8 @@ syn keyword sshdconfigYesNo yes no none
 syn keyword sshdconfigAddressFamily any inet inet6
 
 syn keyword sshdconfigPrivilegeSeparation sandbox
+
+syn keyword sshdconfigTcpForwarding local remote
 
 syn keyword sshdconfigCipher aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
 syn keyword sshdconfigCipher aes192-cbc aes256-cbc aes128-ctr aes192-ctr aes256-ctr
@@ -105,6 +107,8 @@ syn keyword sshdconfigKeyword AllowGroups
 syn keyword sshdconfigKeyword AllowTcpForwarding
 syn keyword sshdconfigKeyword AllowUsers
 syn keyword sshdconfigKeyword AuthorizedKeysFile
+syn keyword sshdconfigKeyword AuthorizedKeysCommand
+syn keyword sshdconfigKeyword AuthorizedKeysCommandUser
 syn keyword sshdconfigKeyword AuthorizedPrincipalsFile
 syn keyword sshdconfigKeyword Banner
 syn keyword sshdconfigKeyword ChallengeResponseAuthentication
@@ -197,6 +201,7 @@ if version >= 508 || !exists("did_sshdconfig_syntax_inits")
   HiLink sshdconfigYesNo                sshdconfigEnum
   HiLink sshdconfigAddressFamily        sshdconfigEnum
   HiLink sshdconfigPrivilegeSeparation  sshdconfigEnum
+  HiLink sshdconfigTcpForwarding        sshdconfigEnum
   HiLink sshdconfigCipher               sshdconfigEnum
   HiLink sshdconfigMAC                  sshdconfigEnum
   HiLink sshdconfigRootLogin            sshdconfigEnum

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -187,30 +187,30 @@ if version >= 508 || !exists("did_sshdconfig_syntax_inits")
     command -nargs=+ HiLink hi def link <args>
   endif
 
-  HiLink sshdconfigComment        Comment
-  HiLink sshdconfigTodo           Todo
-  HiLink sshdconfigHostPort       sshdconfigConstant
-  HiLink sshdconfigTime           sshdconfigConstant
-  HiLink sshdconfigNumber         sshdconfigConstant
-  HiLink sshdconfigConstant       Constant
-  HiLink sshdconfigYesNo          sshdconfigEnum
-  HiLink sshdconfigAddressFamily  sshdconfigEnum
+  HiLink sshdconfigComment              Comment
+  HiLink sshdconfigTodo                 Todo
+  HiLink sshdconfigHostPort             sshdconfigConstant
+  HiLink sshdconfigTime                 sshdconfigConstant
+  HiLink sshdconfigNumber               sshdconfigConstant
+  HiLink sshdconfigConstant             Constant
+  HiLink sshdconfigYesNo                sshdconfigEnum
+  HiLink sshdconfigAddressFamily        sshdconfigEnum
   HiLink sshdconfigPrivilegeSeparation  sshdconfigEnum
-  HiLink sshdconfigCipher         sshdconfigEnum
-  HiLink sshdconfigMAC            sshdconfigEnum
-  HiLink sshdconfigRootLogin      sshdconfigEnum
-  HiLink sshdconfigLogLevel       sshdconfigEnum
-  HiLink sshdconfigSysLogFacility sshdconfigEnum
-  HiLink sshdconfigVar		  sshdconfigEnum
-  HiLink sshdconfigCompression    sshdconfigEnum
-  HiLink sshdconfigIPQoS	  sshdconfigEnum
-  HiLink sshdconfigKexAlgo	  sshdconfigEnum
-  HiLink sshdconfigTunnel	  sshdconfigEnum
-  HiLink sshdconfigSubsystem	  sshdconfigEnum
-  HiLink sshdconfigEnum           Function
-  HiLink sshdconfigSpecial        Special
-  HiLink sshdconfigKeyword        Keyword
-  HiLink sshdconfigMatch          Type
+  HiLink sshdconfigCipher               sshdconfigEnum
+  HiLink sshdconfigMAC                  sshdconfigEnum
+  HiLink sshdconfigRootLogin            sshdconfigEnum
+  HiLink sshdconfigLogLevel             sshdconfigEnum
+  HiLink sshdconfigSysLogFacility       sshdconfigEnum
+  HiLink sshdconfigVar                  sshdconfigEnum
+  HiLink sshdconfigCompression          sshdconfigEnum
+  HiLink sshdconfigIPQoS                sshdconfigEnum
+  HiLink sshdconfigKexAlgo              sshdconfigEnum
+  HiLink sshdconfigTunnel               sshdconfigEnum
+  HiLink sshdconfigSubsystem            sshdconfigEnum
+  HiLink sshdconfigEnum                 Function
+  HiLink sshdconfigSpecial              Special
+  HiLink sshdconfigKeyword              Keyword
+  HiLink sshdconfigMatch                Type
   delcommand HiLink
 endif
 

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -6,7 +6,7 @@
 " Modified By:	Dominik Fischer
 " Originally:	2009-07-09
 " Last Change:	2015 Dec 3 
-" SSH Version:	6.3
+" SSH Version:	6.5
 "
 
 " Setup
@@ -154,6 +154,7 @@ syn keyword sshdconfigKeyword PermitBlacklistedKeys
 syn keyword sshdconfigKeyword PermitEmptyPasswords
 syn keyword sshdconfigKeyword PermitOpen
 syn keyword sshdconfigKeyword PermitRootLogin
+syn keyword sshdconfigKeyword PermitTTY
 syn keyword sshdconfigKeyword PermitTunnel
 syn keyword sshdconfigKeyword PermitUserEnvironment
 syn keyword sshdconfigKeyword PidFile

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -6,7 +6,7 @@
 " Modified By:	Dominik Fischer
 " Originally:	2009-07-09
 " Last Change:	2015 Dec 3 
-" SSH Version:	6.8
+" SSH Version:	7.0
 "
 
 " Setup
@@ -56,7 +56,7 @@ syn keyword sshdconfigMAC hmac-sha2-256 hmac-sha256-96 hmac-sha2-512
 syn keyword sshdconfigMAC hmac-sha2-512-96
 syn match   sshdconfigMAC "\<umac-64@openssh\.com\>"
 
-syn keyword sshdconfigRootLogin without-password forced-commands-only
+syn keyword sshdconfigRootLogin prohibit-password without-password forced-commands-only
 
 syn keyword sshdconfigLogLevel QUIET FATAL ERROR INFO VERBOSE
 syn keyword sshdconfigLogLevel DEBUG DEBUG1 DEBUG2 DEBUG3
@@ -131,6 +131,7 @@ syn keyword sshdconfigKeyword GSSAPIStrictAcceptorCheck
 syn keyword sshdconfigKeyword GatewayPorts
 syn keyword sshdconfigKeyword HostCertificate
 syn keyword sshdconfigKeyword HostKey
+syn keyword sshdconfigKeyword HostKeyAlgorithms
 syn keyword sshdconfigKeyword HostbasedAcceptedKeyTypes
 syn keyword sshdconfigKeyword HostbasedAuthentication
 syn keyword sshdconfigKeyword HostbasedUsesNameFromPacketOnly

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -44,6 +44,8 @@ syn keyword sshdconfigPrivilegeSeparation sandbox
 
 syn keyword sshdconfigTcpForwarding local remote
 
+syn keyword sshdconfigRootLogin prohibit-password without-password forced-commands-only
+
 syn keyword sshdconfigCipher aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
 syn keyword sshdconfigCipher aes192-cbc aes256-cbc aes128-ctr aes192-ctr aes256-ctr
 syn keyword sshdconfigCipher arcfour arcfour128 arcfour256 cast128-cbc
@@ -207,6 +209,7 @@ if version >= 508 || !exists("did_sshdconfig_syntax_inits")
   HiLink sshdconfigAddressFamily        sshdconfigEnum
   HiLink sshdconfigPrivilegeSeparation  sshdconfigEnum
   HiLink sshdconfigTcpForwarding        sshdconfigEnum
+  HiLink sshdconfigRootLogin            sshdconfigEnum
   HiLink sshdconfigCipher               sshdconfigEnum
   HiLink sshdconfigMAC                  sshdconfigEnum
   HiLink sshdconfigRootLogin            sshdconfigEnum

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:	OpenSSH server configuration file (sshd_config)
-" Maintainer:	David Necas (Yeti)
-" Maintainer:   Leonard Ehrenfried <leonard.ehrenfried@web.de>	
-" Modified By:	Thilo Six
-" Modified By:	Dominik Fischer
+" Author:	David Necas (Yeti)
+" Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
+" Contributor:	Thilo Six
+" Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>	
 " Originally:	2009-07-09
 " Last Change:	2015 Dec 3 
 " SSH Version:	7.0


### PR DESCRIPTION
OpensSSH had a few releases since 2012, so I herein request the inclusion of a patches updating the syntax definitions for the `ssh` and `sshd` configuration files to match the latest version.
