### PR TITLE
test87: Account for building from shadowdir in chdir tests

### DIFF
--- a/src/testdir/test87.in
+++ b/src/testdir/test87.in
@@ -910,8 +910,19 @@ fnamemodify = vim.Function('fnamemodify')
 cb.append(str(fnamemodify('.', ':p:h:t')))
 cb.append(vim.eval('@%'))
 os.chdir('..')
-cb.append(str(fnamemodify('.', ':p:h:t')))
-cb.append(vim.eval('@%').replace(os.path.sep, '/'))
+path = fnamemodify('.', ':p:h:t')
+if path != b'src':
+  # Running tests from a shadow directory, so move up another level
+  # This will result in @% looking like shadow/testdir/test87.in, hence the
+  # slicing to remove the leading path and path separator
+  os.chdir('..')
+  cb.append(str(fnamemodify('.', ':p:h:t')))
+  cb.append(vim.eval('@%')[len(path)+1:].replace(os.path.sep, '/'))
+  os.chdir(path)
+else:
+  cb.append(str(fnamemodify('.', ':p:h:t')))
+  cb.append(vim.eval('@%').replace(os.path.sep, '/'))
+del path
 os.chdir('testdir')
 cb.append(str(fnamemodify('.', ':p:h:t')))
 cb.append(vim.eval('@%'))


### PR DESCRIPTION
In 8e46f7264cc303ae3fd723b2f27badccb1d68fbf test86 and test89 were
adjusted to work correctly when using a shadowdir.  This commit applies
a similar fix to test87.
