### PR TITLE
Make example consistent

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -998,7 +998,7 @@ inside of strings can change!  Also see 'softtabstop' option. >
 
 :reg[isters] {arg}	Display the contents of the numbered and named
 			registers that are mentioned in {arg}.  For example: >
-				:dis 1a
+				:reg 1a
 <			to display registers '1' and 'a'.  Spaces are allowed
 			in {arg}.  {not in Vi}
 


### PR DESCRIPTION
It seems that the example here should show the :reg command since that is the item it is listed under.

It is true that :dis would result in the same output, but since the example is in the section for the :register command I think the example should be for that command.
