### PR TITLE
Add UseRoaming to sshconfig.

### DIFF
--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -182,6 +182,7 @@ syn keyword sshconfigKeyword UseBlacklistedKeys
 syn keyword sshconfigKeyword UsePrivilegedPort
 syn keyword sshconfigKeyword User
 syn keyword sshconfigKeyword UserKnownHostsFile
+syn keyword sshconfigKeyword UseRoaming
 syn keyword sshconfigKeyword VerifyHostKeyDNS
 syn keyword sshconfigKeyword VisualHostKey
 syn keyword sshconfigKeyword XAuthLocation


### PR DESCRIPTION
This is an undocumented/unreleased feature in openssh client. Current recommendation is to use `UseRoaming no` in ~/.ssh/config. See CVE-2016-0777 and CVE-2016-0778.

cc @dffischer
