### PR TITLE
Add missing `var` in output of 2html plugin

### DIFF
--- a/runtime/syntax/2html.vim
+++ b/runtime/syntax/2html.vim
@@ -849,7 +849,7 @@ if s:settings.line_ids
 	\ "  if (lineNum.indexOf('L') == -1) {",
 	\ "    lineNum = 'L'+lineNum;",
 	\ "  }",
-	\ "  lineElem = document.getElementById(lineNum);"
+	\ "  var lineElem = document.getElementById(lineNum);"
 	\ ])
   if s:settings.dynamic_folds
     call extend(s:lines, [


### PR DESCRIPTION
While it works even without the `var`, it should not be relied upon and it isn't future friendly.
