### PR TITLE
[RFC] Only expand ~ at beginning of paths

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -5543,7 +5543,7 @@ find_file_in_path_option(ptr, len, options, first, path_option,
 	/* copy file name into NameBuff, expanding environment variables */
 	save_char = ptr[len];
 	ptr[len] = NUL;
-	expand_env(ptr, NameBuff, MAXPATHL);
+	expand_env_esc(ptr, NameBuff, MAXPATHL, FALSE, TRUE, NULL);
 	ptr[len] = save_char;
 
 	vim_free(ff_file_to_find);


### PR DESCRIPTION
Without this patch, you can't switch to a path containing a `~` in the middle:

```
$ mkdir '/tmp/a ~ b'
$ vim
:cd /tmp/a\ ~\ b
E344: Can't find directory "/tmp/a /Users/mhi b/" in cdpath
E472: Command failed
```

It expands the `~`.

This patch tells `expand_env_esc()` to assume only a single file name. The function itself is already handling `~` only at the start of paths (either `~` or `~user`).

It basically does:

``` diff
-   expand_env_esc(ptr, NameBuff, MAXPATHL, FALSE, FALSE, NULL);
+   expand_env_esc(ptr, NameBuff, MAXPATHL, FALSE, TRUE, NULL);
```

The tests run fine.
