### PR TITLE
Include float.h if FEAT_FLOAT is defined

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -2003,6 +2003,9 @@ typedef int VimClipboard;	/* This is required for the prototypes. */
 # define number_width(x) 7
 #endif
 
+#ifdef FEAT_FLOAT
+#include <float.h>
+#endif
 
 #include "globals.h"	    /* global variables and messages */
 


### PR DESCRIPTION
I'm sure I'm doing something wrong, but by default on Centos 7.2 (gcc 4.8.5), the addition of the DBL_MAX CPP macro in patch 1143 appears not to come with a corresponding import of float.h, leading to the following:

```
gcc -c -I. -Iproto -DHAVE_CONFIG_H     -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1       -o objects/ex_cmds.o ex_cmds.c
ex_cmds.c: In function ‘ex_sort’:
ex_cmds.c:560:48: error: ‘DBL_MAX’ undeclared (first use in this function)
       nrs[lnum - eap->line1].st_u.value_flt = -DBL_MAX;
                                                ^
ex_cmds.c:560:48: note: each undeclared identifier is reported only once for each function it appears in
make: *** [objects/ex_cmds.o] Error 1
```

The addition of the float.h include if FEAT_FLOAT is enabled appears to fix the problem.
