### PR TITLE
Use shiftwidth() instead of &sw in indent/vim.vim

### DIFF
--- a/runtime/indent/ada.vim
+++ b/runtime/indent/ada.vim
@@ -87,7 +87,7 @@ function s:MainBlockIndent (prev_indent, prev_lnum, blockstart, stop_at)
       endwhile
    endwhile
    " Fallback - just move back one
-   return a:prev_indent - &sw
+   return a:prev_indent - shiftwidth()
 endfunction MainBlockIndent
 
 " Section: s:EndBlockIndent {{{1
@@ -131,7 +131,7 @@ function s:EndBlockIndent( prev_indent, prev_lnum, blockstart, blockend )
       endwhile
    endwhile
    " Fallback - just move back one
-   return a:prev_indent - &sw
+   return a:prev_indent - shiftwidth()
 endfunction EndBlockIndent
 
 " Section: s:StatementIndent {{{1
@@ -213,15 +213,15 @@ function GetAdaIndent()
       endif
       " Move indent in
       if ! false_match
-	 let ind = ind + &sw
+	 let ind = ind + shiftwidth()
       endif
    elseif line =~ '^\s*\(case\|exception\)\>'
       " Move indent in twice (next 'when' will move back)
-      let ind = ind + 2 * &sw
+      let ind = ind + 2 * shiftwidth()
    elseif line =~ '^\s*end\s*record\>'
       " Move indent back to tallying 'type' preceeding the 'record'.
       " Allow indent to be equal to 'end record's.
-      let ind = s:MainBlockIndent( ind+&sw, lnum, 'type\>', '' )
+      let ind = s:MainBlockIndent( ind+shiftwidth(), lnum, 'type\>', '' )
    elseif line =~ '\(^\s*new\>.*\)\@<!)\s*[;,]\s*$'
       " Revert to indent of line that started this parenthesis pair
       exe lnum
@@ -235,10 +235,10 @@ function GetAdaIndent()
       exe v:lnum
    elseif line =~ '[.=(]\s*$'
       " A statement continuation - move in one
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
    elseif line =~ '^\s*new\>'
       " Multiple line generic instantiation ('package blah is\nnew thingy')
-      let ind = s:StatementIndent( ind - &sw, lnum )
+      let ind = s:StatementIndent( ind - shiftwidth(), lnum )
    elseif line =~ ';\s*$'
       " Statement end (but not 'end' ) - try to find current statement-start indent
       let ind = s:StatementIndent( ind, lnum )
@@ -256,17 +256,17 @@ function GetAdaIndent()
    elseif continuation && line =~ '^\s*('
       " Don't do this if we've already indented due to the previous line
       if ind == initind
-	 let ind = ind + &sw
+	 let ind = ind + shiftwidth()
       endif
    elseif line =~ '^\s*\(begin\|is\)\>'
       let ind = s:MainBlockIndent( ind, lnum, '\(procedure\|function\|declare\|package\|task\)\>', 'begin\>' )
    elseif line =~ '^\s*record\>'
-      let ind = s:MainBlockIndent( ind, lnum, 'type\>\|for\>.*\<use\>', '' ) + &sw
+      let ind = s:MainBlockIndent( ind, lnum, 'type\>\|for\>.*\<use\>', '' ) + shiftwidth()
    elseif line =~ '^\s*\(else\|elsif\)\>'
       let ind = s:MainBlockIndent( ind, lnum, 'if\>', '' )
    elseif line =~ '^\s*when\>'
       " Align 'when' one /in/ from matching block start
-      let ind = s:MainBlockIndent( ind, lnum, '\(case\|exception\)\>', '' ) + &sw
+      let ind = s:MainBlockIndent( ind, lnum, '\(case\|exception\)\>', '' ) + shiftwidth()
    elseif line =~ '^\s*end\>\s*\<if\>'
       " End of if statements
       let ind = s:EndBlockIndent( ind, lnum, 'if\>', 'end\>\s*\<if\>' )

--- a/runtime/indent/awk.vim
+++ b/runtime/indent/awk.vim
@@ -60,7 +60,7 @@ function! GetAwkIndent()
    " 'pattern { action }' (simple check match on /{/ increases the indent then)
 
    if s:Get_brace_balance( prev_data, '{', '}' ) > 0
-      return ind + &sw
+      return ind + shiftwidth()
    endif
 
    let brace_balance = s:Get_brace_balance( prev_data, '(', ')' )
@@ -99,7 +99,7 @@ function! GetAwkIndent()
 	  return s:Safe_indent( ind, s:First_word_len(prev_data), getline(v:lnum))
        else
 	 " if/for/while without '{'
-	 return ind + &sw
+	 return ind + shiftwidth()
        endif
      endif
    endif
@@ -140,7 +140,7 @@ function! GetAwkIndent()
 
    " Decrease indent if this line contains a '}'.
    if getline(v:lnum) =~ '^\s*}'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
    endif
 
    return ind

--- a/runtime/indent/bst.vim
+++ b/runtime/indent/bst.vim
@@ -69,7 +69,7 @@ function! GetBstIndent(lnum) abort
     endif
     let fakeline = substitute(line,'^}','','').matchstr(cline,'^}')
     let ind = indent(lnum)
-    let ind = ind + &sw * s:count(line,'{')
-    let ind = ind - &sw * s:count(fakeline,'}')
+    let ind = ind + shiftwidth() * s:count(line,'{')
+    let ind = ind - shiftwidth() * s:count(fakeline,'}')
     return ind
 endfunction

--- a/runtime/indent/bzl.vim
+++ b/runtime/indent/bzl.vim
@@ -43,9 +43,8 @@ function GetBzlIndent(lnum) abort
     endif
     " Vim 7.3.693 and later defines a shiftwidth() function to get the effective
     " shiftwidth value. Fall back to &shiftwidth if the function doesn't exist.
-    let l:sw_expr = exists('*shiftwidth') ? 'shiftwidth()' : '&shiftwidth'
-    let g:pyindent_nested_paren = l:sw_expr . ' * 2'
-    let g:pyindent_open_paren = l:sw_expr . ' * 2'
+    let g:pyindent_nested_paren = 'shiftwidth() * 2'
+    let g:pyindent_open_paren = 'shiftwidth() * 2'
   endif
 
   let l:indent = -1

--- a/runtime/indent/cdl.vim
+++ b/runtime/indent/cdl.vim
@@ -47,7 +47,7 @@ fun! CdlGetIndent(lnum)
   let thisline = getline(a:lnum)
   if match(thisline, '^\s*\(\k\+\|\[[^]]*]\)\s*\(,\|;\s*$\)') >= 0
     " it's an attributes line
-    return &sw
+    return shiftwidth()
   elseif match(thisline, '^\c\s*\([{}]\|\/[*/]\|dimension\|schedule\|group\|hierarchy\|class\)') >= 0
     " it's a header or '{' or '}' or a comment
     return 0
@@ -71,13 +71,13 @@ fun! CdlGetIndent(lnum)
     let c = line[inicio-1]
     " ')' and '=' don't change indent and are useless to set 'f'
     if c == '{'
-      return &sw
+      return shiftwidth()
     elseif c != ')' && c != '='
       let f = 1 " all but 'elseif' are followed by a formula
       if c ==? 'n' || c ==? 'e' " 'then', 'else'
-	let ind = ind + &sw
+	let ind = ind + shiftwidth()
       elseif strpart(line, inicio-6, 6) ==? 'elseif' " elseif, set f to conditional
-	let ind = ind + &sw
+	let ind = ind + shiftwidth()
 	let f = 0
       end
     end
@@ -98,16 +98,16 @@ fun! CdlGetIndent(lnum)
       let ind = 0
       let f = 1
     elseif c == ')' || c== ';' || strpart(line, inicio-5, 5) ==? 'endif'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     elseif c == '(' || c ==? 'f' " '(' or 'if'
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     else " c == '='
       " if it is an asignment increase indent
       if f == -1 " we don't know yet, find out
 	let f = CdlAsignment(lnum, strpart(line, 0, inicio))
       end
       if f == 1 " formula increase it
-	let ind = ind + &sw
+	let ind = ind + shiftwidth()
       end
     end
   endw
@@ -115,13 +115,13 @@ fun! CdlGetIndent(lnum)
   " CURRENT LINE, if it starts with a closing element, decrease indent
   " or if it starts with '=' (asignment), increase indent
   if match(thisline, '^\c\s*\(else\|then\|endif\|[);]\)') >= 0
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   elseif match(thisline, '^\s*=') >= 0
     if f == -1 " we don't know yet if is an asignment, find out
       let f = CdlAsignment(lnum, "")
     end
     if f == 1 " formula increase it
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     end
   end
 

--- a/runtime/indent/chaiscript.vim
+++ b/runtime/indent/chaiscript.vim
@@ -31,19 +31,19 @@ function! GetChaiScriptIndent()
   let flag = 0
   let prevline = getline(lnum)
   if prevline =~ '^.*{.*'
-    let ind = ind + &shiftwidth
+    let ind = ind + shiftwidth()
     let flag = 1
   endif
 
   " Subtract a 'shiftwidth' after lines containing a { followed by a }
   " to keep it balanced
   if flag == 1 && prevline =~ '.*{.*}.*'
-    let ind = ind - &shiftwidth
+    let ind = ind - shiftwidth()
   endif
 
   " Subtract a 'shiftwidth' on lines ending with }
   if getline(v:lnum) =~ '^\s*\%(}\)'
-    let ind = ind - &shiftwidth
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/clojure.vim
+++ b/runtime/indent/clojure.vim
@@ -247,7 +247,7 @@ if exists("*searchpairpos")
 		call cursor(paren)
 
 		if s:IsMethodSpecialCase(paren)
-			return paren[1] + &shiftwidth - 1
+			return paren[1] + shiftwidth() - 1
 		endif
 
 		" In case we are at the last character, we use the paren position.
@@ -281,19 +281,19 @@ if exists("*searchpairpos")
 		let ww = s:StripNamespaceAndMacroChars(w)
 
 		if &lispwords =~# '\V\<' . ww . '\>'
-			return paren[1] + &shiftwidth - 1
+			return paren[1] + shiftwidth() - 1
 		endif
 
 		if g:clojure_fuzzy_indent
 			\ && !s:MatchesOne(g:clojure_fuzzy_indent_blacklist, ww)
 			\ && s:MatchesOne(g:clojure_fuzzy_indent_patterns, ww)
-			return paren[1] + &shiftwidth - 1
+			return paren[1] + shiftwidth() - 1
 		endif
 
 		call search('\v\_s', 'cW')
 		call search('\v\S', 'W')
 		if paren[0] < line(".")
-			return paren[1] + (g:clojure_align_subforms ? 0 : &shiftwidth - 1)
+			return paren[1] + (g:clojure_align_subforms ? 0 : shiftwidth() - 1)
 		endif
 
 		call search('\v\S', 'bW')

--- a/runtime/indent/cmake.vim
+++ b/runtime/indent/cmake.vim
@@ -68,19 +68,19 @@ fun! CMakeGetIndent(lnum)
     let ind = ind
   else
     if previous_line =~? cmake_indent_begin_regex
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
     if previous_line =~? cmake_indent_open_regex
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
   endif
 
   " Subtract
   if this_line =~? cmake_indent_end_regex
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   if previous_line =~? cmake_indent_close_regex
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/cobol.vim
+++ b/runtime/indent/cobol.vim
@@ -52,11 +52,11 @@ function! s:optionalblock(lnum,ind,blocks,clauses)
         if getline(lastclause) =~? clauses && s:stripped(lastclause) !~? '^'.begin
             let ind = indent(lastclause)
         elseif lastclause > 0
-            let ind = indent(lastclause) + &sw
-            "let ind = ind + &sw
+            let ind = indent(lastclause) + shiftwidth()
+            "let ind = ind + shiftwidth()
         endif
     elseif line =~? clauses && cline !~? end
-        let ind = ind + &sw
+        let ind = ind + shiftwidth()
     endif
     return ind
 endfunction
@@ -98,8 +98,8 @@ function! GetCobolIndent(lnum) abort
                 let num = matchstr(line,'^\s*\zs\d\+\>')
                 if 0+cnum == num
                     return lindent
-                elseif 0+cnum > num && default < lindent + &sw
-                    let default = lindent + &sw
+                elseif 0+cnum > num && default < lindent + shiftwidth()
+                    let default = lindent + shiftwidth()
                 endif
             elseif lindent < bshft && lindent >= ashft
                 break
@@ -135,13 +135,13 @@ function! GetCobolIndent(lnum) abort
     if line =~? '^PERFORM\>'
         let perfline = substitute(line, '\c^PERFORM\s*', "", "")
         if perfline =~? '^\%(\k\+\s\+TIMES\)\=\s*$'
-            let ind = ind + &sw
+            let ind = ind + shiftwidth()
         elseif perfline =~? '^\%(WITH\s\+TEST\|VARYING\|UNTIL\)\>.*[^.]$'
-            let ind = ind + &sw
+            let ind = ind + shiftwidth()
         endif
     endif
     if line =~? '^\%(IF\|THEN\|ELSE\|READ\|EVALUATE\|SEARCH\|SELECT\)\>'
-        let ind = ind + &sw
+        let ind = ind + shiftwidth()
     endif
     let ind = s:optionalblock(a:lnum,ind,'ADD\|COMPUTE\|DIVIDE\|MULTIPLY\|SUBTRACT','ON\s\+SIZE\s\+ERROR')
     let ind = s:optionalblock(a:lnum,ind,'STRING\|UNSTRING\|ACCEPT\|DISPLAY\|CALL','ON\s\+OVERFLOW\|ON\s\+EXCEPTION')
@@ -157,10 +157,10 @@ function! GetCobolIndent(lnum) abort
             "&& s:stripped(lastclause) !~? '^\%(SEARCH\|EVALUATE\|READ\)\>'
             let ind = indent(lastclause)
         elseif lastclause > 0
-            let ind = indent(lastclause) + &sw
+            let ind = indent(lastclause) + shiftwidth()
         endif
     elseif line =~? '^WHEN\>'
-        let ind = ind + &sw
+        let ind = ind + shiftwidth()
     endif
     "I'm not sure why I had this
     "if line =~? '^ELSE\>-\@!' && line !~? '\.$'
@@ -168,7 +168,7 @@ function! GetCobolIndent(lnum) abort
     "endif
     if cline =~? '^\(END\)\>-\@!'
         " On lines with just END, 'guess' a simple shift left
-        let ind = ind - &sw
+        let ind = ind - shiftwidth()
     elseif cline =~? '^\(END-IF\|THEN\|ELSE\)\>-\@!'
         call cursor(a:lnum,indent(a:lnum))
         let match = searchpair('\c-\@<!\<IF\>','\c-\@<!\%(THEN\|ELSE\)\>','\c-\@<!\<END-IF\>\zs','bnW',s:skip)
@@ -209,7 +209,7 @@ function! GetCobolIndent(lnum) abort
         if match > 0
             let ind = indent(match)
         elseif cline =~? '^\(END-\(READ\|EVALUATE\|SEARCH\|PERFORM\)\)\>'
-            let ind = ind - &sw
+            let ind = ind - shiftwidth()
         endif
     endif
     return ind < bshft ? bshft : ind

--- a/runtime/indent/css.vim
+++ b/runtime/indent/css.vim
@@ -75,8 +75,8 @@ function GetCSSIndent()
     return 0
   endif
 
-  return indent(pnum) + s:count_braces(pnum, 1) * &sw
-        \ - s:count_braces(v:lnum, 0) * &sw
+  return indent(pnum) + s:count_braces(pnum, 1) * shiftwidth()
+        \ - s:count_braces(v:lnum, 0) * shiftwidth()
 endfunction
 
 let &cpo = s:keepcpo

--- a/runtime/indent/cucumber.vim
+++ b/runtime/indent/cucumber.vim
@@ -35,38 +35,38 @@ function! GetCucumberIndent()
     return 0
   elseif csyn ==# 'cucumberExamples' || cline =~# '^\s*\%(Examples\|Scenarios\):'
     " examples heading
-    return 2 * &sw
+    return 2 * shiftwidth()
   elseif csyn =~# '^cucumber\%(Background\|Scenario\|ScenarioOutline\)$' || cline =~# '^\s*\%(Background\|Scenario\|Scenario Outline\):'
     " background, scenario or outline heading
-    return &sw
+    return shiftwidth()
   elseif syn ==# 'cucumberFeature' || line =~# '^\s*Feature:'
     " line after feature heading
-    return &sw
+    return shiftwidth()
   elseif syn ==# 'cucumberExamples' || line =~# '^\s*\%(Examples\|Scenarios\):'
     " line after examples heading
-    return 3 * &sw
+    return 3 * shiftwidth()
   elseif syn =~# '^cucumber\%(Background\|Scenario\|ScenarioOutline\)$' || line =~# '^\s*\%(Background\|Scenario\|Scenario Outline\):'
     " line after background, scenario or outline heading
-    return 2 * &sw
+    return 2 * shiftwidth()
   elseif cline =~# '^\s*[@#]' && (nsyn == 'cucumberFeature' || nline =~# '^\s*Feature:' || indent(prevnonblank(v:lnum-1)) <= 0)
     " tag or comment before a feature heading
     return 0
   elseif cline =~# '^\s*@'
     " other tags
-    return &sw
+    return shiftwidth()
   elseif cline =~# '^\s*[#|]' && line =~# '^\s*|'
     " mid-table
     " preserve indent
     return indent(prevnonblank(v:lnum-1))
   elseif cline =~# '^\s*|' && line =~# '^\s*[^|]'
     " first line of a table, relative indent
-    return indent(prevnonblank(v:lnum-1)) + &sw
+    return indent(prevnonblank(v:lnum-1)) + shiftwidth()
   elseif cline =~# '^\s*[^|]' && line =~# '^\s*|'
     " line after a table, relative unindent
-    return indent(prevnonblank(v:lnum-1)) - &sw
+    return indent(prevnonblank(v:lnum-1)) - shiftwidth()
   elseif cline =~# '^\s*#' && getline(v:lnum-1) =~ '^\s*$' && (nsyn =~# '^cucumber\%(Background\|Scenario\|ScenarioOutline\)$' || nline =~# '^\s*\%(Background\|Scenario\|Scenario Outline\):')
     " comments on scenarios
-    return &sw
+    return shiftwidth()
   endif
   return indent(prevnonblank(v:lnum-1))
 endfunction

--- a/runtime/indent/dtd.vim
+++ b/runtime/indent/dtd.vim
@@ -84,7 +84,7 @@ function GetDTDIndent()
 
   let [declaration, end] = s:lex1(line, col)
   if declaration == ""
-    return indent + &sw
+    return indent + shiftwidth()
   elseif declaration == '--'
     " We’re looking at a comment.  Now, simply determine if the comment is
     " terminated or not.  If it isn’t, let Vim take care of that using
@@ -100,7 +100,7 @@ function GetDTDIndent()
     " Check for element name.  If none exists, indent one level.
     let [name, end] = s:lex(line, end)
     if name == ""
-      return indent + &sw
+      return indent + shiftwidth()
     endif
 
     " Check for token following element name.  This can be a specification of
@@ -113,7 +113,7 @@ function GetDTDIndent()
       let n += 1
     endwhile
     if token == ""
-      return indent + &sw
+      return indent + shiftwidth()
     endif
 
     " Next comes the content model.  If the token we’ve found isn’t a
@@ -148,7 +148,7 @@ function GetDTDIndent()
           return indent
         endif
         " TODO: Should use s:lex here on getline(v:lnum) and check for >.
-        return getline(v:lnum) =~ '^\s*>' || count(values(seen), 0) == 0 ? indent : (indent + &sw)
+        return getline(v:lnum) =~ '^\s*>' || count(values(seen), 0) == 0 ? indent : (indent + shiftwidth())
       endif
 
       " If we’ve seen an addition or exception already and this is of the same
@@ -167,7 +167,7 @@ function GetDTDIndent()
     " Check for element name.  If none exists, indent one level.
     let [name, end] = s:lex(line, end)
     if name == ""
-      return indent + &sw
+      return indent + shiftwidth()
     endif
 
     " Check for any number of attributes.
@@ -180,7 +180,7 @@ function GetDTDIndent()
       let [name, end] = s:lex(line, end)
       if name == ""
         " TODO: Should use s:lex here on getline(v:lnum) and check for >.
-        return getline(v:lnum) =~ '^\s*>' ? indent : (indent + &sw)
+        return getline(v:lnum) =~ '^\s*>' ? indent : (indent + shiftwidth())
       elseif name == ">"
         return indent
       endif
@@ -194,14 +194,14 @@ function GetDTDIndent()
       " (CDATA|NMTOKEN|NMTOKENS|ID|IDREF|IDREFS|ENTITY|ENTITIES)?
       let [value, end] = s:lex(line, end, '^\%((\|[^[:space:]]\+\)')
       if value == ""
-        return indent + &sw * 2
+        return indent + shiftwidth() * 2
       elseif value == 'NOTATION'
         " If this is a enumerated value based on notations, read another token
         " for the actual value.  If it doesn’t exist, indent three levels.
         " TODO: If validating according to above, value must be equal to '('.
         let [value, end] = s:lex(line, end, '^\%((\|[^[:space:]]\+\)')
         if value == ""
-          return indent + &sw * 3
+          return indent + shiftwidth() * 3
         endif
       endif
 
@@ -216,13 +216,13 @@ function GetDTDIndent()
       " two levels.
       let [default, end] = s:lex(line, end, '^\%("\_[^"]*"\|#\(REQUIRED\|IMPLIED\|FIXED\)\)')
       if default == ""
-        return indent + &sw * 2
+        return indent + shiftwidth() * 2
       elseif default == '#FIXED'
         " We need to look for the fixed value.  If non exists, indent three
         " levels.
         let [default, end] = s:lex(line, end, '^"\_[^"]*"')
         if default == ""
-          return indent + &sw * 3
+          return indent + shiftwidth() * 3
         endif
       endif
     endwhile
@@ -233,11 +233,11 @@ function GetDTDIndent()
     " again, if none exists, indent one level.
     let [name, end] = s:lex(line, end)
     if name == ""
-      return indent + &sw
+      return indent + shiftwidth()
     elseif name == '%'
       let [name, end] = s:lex(line, end)
       if name == ""
-        return indent + &sw
+        return indent + shiftwidth()
       endif
     endif
 
@@ -256,27 +256,27 @@ function GetDTDIndent()
     " we’re now done with this entity.
     let [value, end] = s:lex(line, end)
     if value == ""
-      return indent + &sw
+      return indent + shiftwidth()
     elseif value == 'SYSTEM' || value == 'PUBLIC'
       let [quoted_string, end] = s:lex(line, end, '\%("[^"]\+"\|''[^'']\+''\)')
       if quoted_string == ""
-        return indent + &sw * 2
+        return indent + shiftwidth() * 2
       endif
 
       if value == 'PUBLIC'
         let [quoted_string, end] = s:lex(line, end, '\%("[^"]\+"\|''[^'']\+''\)')
         if quoted_string == ""
-          return indent + &sw * 2
+          return indent + shiftwidth() * 2
         endif
       endif
 
       let [ndata, end] = s:lex(line, end)
       if ndata == ""
-        return indent + &sw
+        return indent + shiftwidth()
       endif
 
       let [name, end] = s:lex(line, end)
-      return name == "" ? (indent + &sw * 2) : indent
+      return name == "" ? (indent + shiftwidth() * 2) : indent
     else
       return indent
     endif
@@ -284,24 +284,24 @@ function GetDTDIndent()
     " Check for notation name.  If none exists, indent one level.
     let [name, end] = s:lex(line, end)
     if name == ""
-      return indent + &sw
+      return indent + shiftwidth()
     endif
 
     " Now check for the external ID.  If none exists, indent one level.
     let [id, end] = s:lex(line, end)
     if id == ""
-      return indent + &sw
+      return indent + shiftwidth()
     elseif id == 'SYSTEM' || id == 'PUBLIC'
       let [quoted_string, end] = s:lex(line, end, '\%("[^"]\+"\|''[^'']\+''\)')
       if quoted_string == ""
-        return indent + &sw * 2
+        return indent + shiftwidth() * 2
       endif
 
       if id == 'PUBLIC'
         let [quoted_string, end] = s:lex(line, end, '\%("[^"]\+"\|''[^'']\+''\|>\)')
         if quoted_string == ""
           " TODO: Should use s:lex here on getline(v:lnum) and check for >.
-          return getline(v:lnum) =~ '^\s*>' ? indent : (indent + &sw * 2)
+          return getline(v:lnum) =~ '^\s*>' ? indent : (indent + shiftwidth() * 2)
         elseif quoted_string == '>'
           return indent
         endif

--- a/runtime/indent/dylan.vim
+++ b/runtime/indent/dylan.vim
@@ -45,13 +45,13 @@ function DylanGetIndent()
 
   " If previous line was a 'define', indent
   if prevline =~? '\(^\s*\(begin\|block\|case\|define\|else\|elseif\|for\|finally\|if\|select\|unless\|while\)\|\s*\S*\s*=>$\)'
-    let chg = &sw
+    let chg = shiftwidth()
   " local methods indent the shift-width, plus 6 for the 'local'
   elseif prevline =~? '^\s*local'
-    let chg = &sw + 6
+    let chg = shiftwidth() + 6
   " If previous line was a let with no closing semicolon, indent
   elseif prevline =~? '^\s*let.*[^;]\s*$'
-    let chg = &sw
+    let chg = shiftwidth()
   " If previous line opened a parenthesis, and did not close it, indent
   elseif prevline =~ '^.*(\s*[^)]*\((.*)\)*[^)]*$'
     return = match( prevline, '(.*\((.*)\|[^)]\)*.*$') + 1
@@ -75,13 +75,13 @@ function DylanGetIndent()
     " line doesn't start with an indentable command:
     let curr_str = getline(curr_line)
     if curr_str =~? '^\s*\(begin\|block\|case\|define\|else\|elseif\|for\|finally\|if\|select\|unless\|while\)'
-      let chg = &sw
+      let chg = shiftwidth()
     endif
   endif
 
   " If a line starts with end, un-indent (even if we just indented!)
   if cline =~? '^\s*\(cleanup\|end\|else\|elseif\|exception\|finally\|otherwise\)'
-    let chg = chg - &sw
+    let chg = chg - shiftwidth()
   endif
 
   return ind + chg

--- a/runtime/indent/eiffel.vim
+++ b/runtime/indent/eiffel.vim
@@ -63,23 +63,23 @@ function GetEiffelIndent()
   " Add a 'shiftwidth' after lines that start with an indent word
   let ind = indent(lnum)
   if getline(lnum) =~ s:relative_indent
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   " Indent to single indent
   if getline(v:lnum) =~ s:single_dent && getline(v:lnum) !~ s:relative_indent
 	   \ && getline(v:lnum) !~ '\s*\<\(and\|or\|implies\)\>'
-     let ind = &sw
+     let ind = shiftwidth()
   endif
 
   " Indent to double indent
   if getline(v:lnum) =~ s:inheritance_dent
-     let ind = 2 * &sw
+     let ind = 2 * shiftwidth()
   endif
 
   " Indent line after the first line of the function definition
   if getline(lnum) =~ s:single_dent
-     let ind = ind + &sw
+     let ind = ind + shiftwidth()
   endif
 
   " The following should always be at the start of a line, no indenting
@@ -91,17 +91,17 @@ function GetEiffelIndent()
   " or first thing after the 'do'
   if getline(v:lnum) =~ s:outdent && getline(v:lnum - 1) !~ s:single_dent
 	\ && getline(v:lnum - 1) !~ '^\s*do\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   " Subtract a shiftwidth for end statements
   if getline(v:lnum) =~ '^\s*end\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   " set indent of zero end statements that are at an indent of 3, this should
   " only ever be the class's end.
-  if getline(v:lnum) =~ '^\s*end\>' && ind == &sw
+  if getline(v:lnum) =~ '^\s*end\>' && ind == shiftwidth()
     let ind = 0
   endif
 

--- a/runtime/indent/erlang.vim
+++ b/runtime/indent/erlang.vim
@@ -669,7 +669,7 @@ function! s:BeginningOfClauseFound(stack, token, stored_vcol)
     call s:Pop(a:stack)
     if empty(a:stack)
       call s:Log('    Stack is ["when"], so LTI is in a guard -> return')
-      return [1, a:stored_vcol + &sw + 2]
+      return [1, a:stored_vcol + shiftwidth() + 2]
     else
       return [1, s:UnexpectedToken(a:token, a:stack)]
     endif
@@ -678,7 +678,7 @@ function! s:BeginningOfClauseFound(stack, token, stored_vcol)
     call s:Pop(a:stack)
     if empty(a:stack)
       call s:Log('    Stack is ["->"], so LTI is in function body -> return')
-      return [1, a:stored_vcol + &sw]
+      return [1, a:stored_vcol + shiftwidth()]
     elseif a:stack[0] ==# ';'
       call s:Pop(a:stack)
       if empty(a:stack)
@@ -797,7 +797,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
 
       elseif token ==# 'begin'
         let [ret, res] = s:BeginElementFound(stack, token, curr_vcol,
-                                            \stored_vcol, 'end', &sw)
+                                            \stored_vcol, 'end', shiftwidth())
         if ret | return res | endif
 
       " case EXPR of BRANCHES end
@@ -848,11 +848,11 @@ function! s:ErlangCalcIndent2(lnum, stack)
         elseif stack == ['->']
           call s:Log('    LTI is in a branch after ' .
                     \'"of/receive/after/if/catch" -> return')
-          return stored_vcol + &sw
+          return stored_vcol + shiftwidth()
         elseif stack == ['when']
           call s:Log('    LTI is in a guard after ' .
                     \'"of/receive/after/if/catch" -> return')
-          return stored_vcol + &sw
+          return stored_vcol + shiftwidth()
         else
           return s:UnexpectedToken(token, stack)
         endif
@@ -888,7 +888,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
           if empty(stack)
             call s:Log('    LTI is in a condition; matching ' .
                       \'"case/if/try/receive" found')
-            let stored_vcol = curr_vcol + &sw
+            let stored_vcol = curr_vcol + shiftwidth()
           elseif stack[0] ==# 'align_to_begin_element'
             call s:Pop(stack)
             let stored_vcol = curr_vcol
@@ -897,23 +897,23 @@ function! s:ErlangCalcIndent2(lnum, stack)
                       \'"case/if/try/receive" found')
             call s:Pop(stack)
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + &sw
+            let stored_vcol = curr_vcol + shiftwidth()
           elseif stack[0] ==# '->'
             call s:Log('    LTI is in a branch; matching ' .
                       \'"case/if/try/receive" found')
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + 2 * &sw
+            let stored_vcol = curr_vcol + 2 * shiftwidth()
           elseif stack[0] ==# 'when'
             call s:Log('    LTI is in a guard; matching ' .
                       \'"case/if/try/receive" found')
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + 2 * &sw + 2
+            let stored_vcol = curr_vcol + 2 * shiftwidth() + 2
           endif
 
         endif
 
         let [ret, res] = s:BeginElementFound(stack, token, curr_vcol,
-                                            \stored_vcol, 'end', &sw)
+                                            \stored_vcol, 'end', shiftwidth())
         if ret | return res | endif
 
       elseif token ==# 'fun'
@@ -930,7 +930,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
           " stack = ['when']  =>  LTI is in a guard
           if empty(stack)
             call s:Log('    LTI is in a condition; matching "fun" found')
-            let stored_vcol = curr_vcol + &sw
+            let stored_vcol = curr_vcol + shiftwidth()
           elseif len(stack) > 1 && stack[0] ==# '->' && stack[1] ==# ';'
             call s:Log('    LTI is in a condition; matching "fun" found')
             call s:Pop(stack)
@@ -938,15 +938,15 @@ function! s:ErlangCalcIndent2(lnum, stack)
           elseif stack[0] ==# '->'
             call s:Log('    LTI is in a branch; matching "fun" found')
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + 2 * &sw
+            let stored_vcol = curr_vcol + 2 * shiftwidth()
           elseif stack[0] ==# 'when'
             call s:Log('    LTI is in a guard; matching "fun" found')
             call s:Pop(stack)
-            let stored_vcol = curr_vcol + 2 * &sw + 2
+            let stored_vcol = curr_vcol + 2 * shiftwidth() + 2
           endif
 
           let [ret, res] = s:BeginElementFound(stack, token, curr_vcol,
-                                              \stored_vcol, 'end', &sw)
+                                              \stored_vcol, 'end', shiftwidth())
           if ret | return res | endif
         else
           " Pass: we have a function reference (e.g. "fun f/0")
@@ -1220,7 +1220,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
             "   when A,
             "        LTI
             let [ret, res] = s:BeginElementFoundIfEmpty(stack, token, curr_vcol,
-                                                       \stored_vcol, &sw)
+                                                       \stored_vcol, shiftwidth())
             if ret | return res | endif
           else
             " Example:
@@ -1252,7 +1252,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
           " If LTI is between an 'after' and the corresponding
           " 'end', then let's return
           let [ret, res] = s:BeginElementFoundIfEmpty(stack, token, curr_vcol,
-                                                     \stored_vcol, &sw)
+                                                     \stored_vcol, shiftwidth())
           if ret | return res | endif
         endif
 

--- a/runtime/indent/eruby.vim
+++ b/runtime/indent/eruby.vim
@@ -57,24 +57,24 @@ function! GetErubyIndent(...)
   let line = getline(lnum)
   let cline = getline(v:lnum)
   if cline =~# '^\s*<%[-=]\=\s*\%(}\|end\|else\|\%(ensure\|rescue\|elsif\|when\).\{-\}\)\s*\%([-=]\=%>\|$\)'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   if line =~# '\S\s*<%[-=]\=\s*\%(}\|end\).\{-\}\s*\%([-=]\=%>\|$\)'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   if line =~# '\%({\|\<do\)\%(\s*|[^|]*|\)\=\s*[-=]\=%>'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   elseif line =~# '<%[-=]\=\s*\%(module\|class\|def\|if\|for\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure\|rescue\)\>.*%>'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
   if line =~# '^\s*<%[=#-]\=\s*$' && cline !~# '^\s*end\>'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
   if line !~# '^\s*<%' && line =~# '%>\s*$'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   if cline =~# '^\s*[-=]\=%>\s*$'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   return ind
 endfunction

--- a/runtime/indent/eterm.vim
+++ b/runtime/indent/eterm.vim
@@ -25,11 +25,11 @@ function GetEtermIndent()
   let ind = indent(lnum)
 
   if getline(lnum) =~ '^\s*begin\>'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   if getline(v:lnum) =~ '^\s*end\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/falcon.vim
+++ b/runtime/indent/falcon.vim
@@ -339,7 +339,7 @@ function FalconGetIndent(...)
 
     " If the previous line ended with a block opening, add a level of indent.
     if s:Match(lnum, s:block_regex)
-	return indent(s:GetMSL(lnum)) + &sw
+	return indent(s:GetMSL(lnum)) + shiftwidth()
     endif
 
     " If it contained hanging closing brackets, find the rightmost one, find its
@@ -350,20 +350,20 @@ function FalconGetIndent(...)
 	if opening.pos != -1
 	    if opening.type == '(' && searchpair('(', '', ')', 'bW', s:skip_expr) > 0
 		if col('.') + 1 == col('$')
-		    return ind + &sw
+		    return ind + shiftwidth()
 		else
 		    return virtcol('.')
 		endif
 	    else
 		let nonspace = matchend(line, '\S', opening.pos + 1) - 1
-		return nonspace > 0 ? nonspace : ind + &sw
+		return nonspace > 0 ? nonspace : ind + shiftwidth()
 	    endif
 	elseif closing.pos != -1
 	    call cursor(lnum, closing.pos + 1)
 	    normal! %
 
 	    if s:Match(line('.'), s:falcon_indent_keywords)
-		return indent('.') + &sw
+		return indent('.') + shiftwidth()
 	    else
 		return indent('.')
 	    endif
@@ -392,7 +392,7 @@ function FalconGetIndent(...)
     let col = s:Match(lnum, s:falcon_indent_keywords)
     if col > 0
 	call cursor(lnum, col)
-	let ind = virtcol('.') - 1 + &sw
+	let ind = virtcol('.') - 1 + shiftwidth()
 	" TODO: make this better (we need to count them) (or, if a searchpair
 	" fails, we know that something is lacking an end and thus we indent a
 	" level
@@ -422,9 +422,9 @@ function FalconGetIndent(...)
     " TODO: this does not take into account contrived things such as
     " module Foo; class Bar; end
     if s:Match(lnum, s:falcon_indent_keywords)
-	let ind = msl_ind + &sw
+	let ind = msl_ind + shiftwidth()
 	if s:Match(lnum, s:end_end_regex)
-	    let ind = ind - &sw
+	    let ind = ind - shiftwidth()
 	endif
 	return ind
     endif
@@ -433,7 +433,7 @@ function FalconGetIndent(...)
     " closing bracket, indent one extra level.
     if s:Match(lnum, s:non_bracket_continuation_regex) && !s:Match(lnum, '^\s*\([\])}]\|end\)')
 	if lnum == p_lnum
-	    let ind = msl_ind + &sw
+	    let ind = msl_ind + shiftwidth()
 	else
 	    let ind = msl_ind
 	endif

--- a/runtime/indent/fortran.vim
+++ b/runtime/indent/fortran.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:	Fortran 2008 (and older: Fortran 2003, 95, 90, and 77)
 " Version:	0.42
-" Last Change:	2015 Nov. 30
+" Last Change:	25-Jan-2016. 30
 " Maintainer:	Ajit J. Thakkar <ajit@unb.ca>; <http://www2.unb.ca/~ajit/>
 " Usage:	For instructions, do :help fortran-indent from Vim
 " Credits:
@@ -92,10 +92,10 @@ function FortranGetIndent(lnum)
   "Indent do loops only if they are all guaranteed to be of do/end do type
   if exists("b:fortran_do_enddo") || exists("g:fortran_do_enddo")
     if prevstat =~? '^\s*\(\d\+\s\)\=\s*\(\a\w*\s*:\)\=\s*do\>'
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
     if getline(v:lnum) =~? '^\s*\(\d\+\s\)\=\s*end\s*do\>'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
   endif
 
@@ -105,14 +105,14 @@ function FortranGetIndent(lnum)
 	\ ||prevstat=~? '^\s*\(type\|interface\|associate\|enum\)\>'
 	\ ||prevstat=~?'^\s*\(\d\+\s\)\=\s*\(\a\w*\s*:\)\=\s*\(forall\|where\|block\)\>'
 	\ ||prevstat=~? '^\s*\(\d\+\s\)\=\s*\(\a\w*\s*:\)\=\s*if\>'
-     let ind = ind + &sw
+     let ind = ind + shiftwidth()
     " Remove unwanted indent after logical and arithmetic ifs
     if prevstat =~? '\<if\>' && prevstat !~? '\<then\>'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
     " Remove unwanted indent after type( statements
     if prevstat =~? '^\s*type\s*('
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
   endif
 
@@ -125,12 +125,12 @@ function FortranGetIndent(lnum)
             \ ||prevstat =~? '^\s*'.prefix.'subroutine\>'
             \ ||prevstat =~? '^\s*'.prefix.type.'function\>'
             \ ||prevstat =~? '^\s*'.type.prefix.'function\>'
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
     if getline(v:lnum) =~? '^\s*contains\>'
           \ ||getline(v:lnum)=~? '^\s*end\s*'
           \ .'\(function\|subroutine\|module\|program\)\>'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
   endif
 
@@ -141,23 +141,23 @@ function FortranGetIndent(lnum)
         \. '\(else\|else\s*if\|else\s*where\|case\|'
         \. 'end\s*\(if\|where\|select\|interface\|'
         \. 'type\|forall\|associate\|enum\|block\)\)\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
     " Fix indent for case statement immediately after select
     if prevstat =~? '\<select\s\+\(case\|type\)\>'
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
   endif
 
   "First continuation line
   if prevstat =~ '&\s*$' && prev2stat !~ '&\s*$'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
   if prevstat =~ '&\s*$' && prevstat =~ '\<else\s*if\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   "Line after last continuation line
   if prevstat !~ '&\s*$' && prev2stat =~ '&\s*$' && prevstat !~? '\<then\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/framescript.vim
+++ b/runtime/indent/framescript.vim
@@ -30,11 +30,11 @@ function GetFrameScriptIndent()
   let ind = indent(lnum)
 
   if getline(lnum) =~? '^\s*\%(If\|Loop\|Sub\)'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   if getline(v:lnum) =~? '^\s*\%(Else\|End\%(If\|Loop\|Sub\)\)'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/gitconfig.vim
+++ b/runtime/indent/gitconfig.vim
@@ -24,13 +24,13 @@ function! GetGitconfigIndent()
   let cline = getline(v:lnum)
   if line =~  '\\\@<!\%(\\\\\)*\\$'
     " odd number of slashes, in a line continuation
-    return 2 * &sw
+    return 2 * shiftwidth()
   elseif cline =~ '^\s*\['
     return 0
   elseif cline =~ '^\s*\a'
-    return &sw
+    return shiftwidth()
   elseif cline == ''       && line =~ '^\['
-    return &sw
+    return shiftwidth()
   else
     return -1
   endif

--- a/runtime/indent/gitolite.vim
+++ b/runtime/indent/gitolite.vim
@@ -27,11 +27,11 @@ function! GetGitoliteIndent()
   let cline = getline(v:lnum)
 
   if cline =~ '^\s*\(C\|R\|RW\|RW+\|RWC\|RW+C\|RWD\|RW+D\|RWCD\|RW+CD\|-\)[ \t=]'
-    return &sw
+    return shiftwidth()
   elseif cline =~ '^\s*config\s'
-    return &sw
+    return shiftwidth()
   elseif pline =~ '^\s*repo\s' && cline =~ '^\s*\(#.*\)\?$'
-    return &sw
+    return shiftwidth()
   elseif cline =~ '^\s*#'
     return indent(prevln)
   elseif cline =~ '^\s*$'

--- a/runtime/indent/go.vim
+++ b/runtime/indent/go.vim
@@ -23,18 +23,6 @@ if exists('*GoIndent')
   finish
 endif
 
-" The shiftwidth() function is relatively new.
-" Don't require it to exist.
-if exists('*shiftwidth')
-  function s:sw() abort
-    return shiftwidth()
-  endfunction
-else
-  function s:sw() abort
-    return &shiftwidth
-  endfunction
-endif
-
 function! GoIndent(lnum)
   let l:prevlnum = prevnonblank(a:lnum-1)
   if l:prevlnum == 0
@@ -51,17 +39,17 @@ function! GoIndent(lnum)
 
   if l:prevl =~ '[({]\s*$'
     " previous line opened a block
-    let l:ind += s:sw()
+    let l:ind += shiftwidth()
   endif
   if l:prevl =~# '^\s*\(case .*\|default\):$'
     " previous line is part of a switch statement
-    let l:ind += s:sw()
+    let l:ind += shiftwidth()
   endif
   " TODO: handle if the previous line is a label.
 
   if l:thisl =~ '^\s*[)}]'
     " this line closed a block
-    let l:ind -= s:sw()
+    let l:ind -= shiftwidth()
   endif
 
   " Colons are tricky.
@@ -69,7 +57,7 @@ function! GoIndent(lnum)
   " We ignore trying to deal with jump labels because (a) they're rare, and
   " (b) they're hard to disambiguate from a composite literal key.
   if l:thisl =~# '^\s*\(case .*\|default\):$'
-    let l:ind -= s:sw()
+    let l:ind -= shiftwidth()
   endif
 
   return l:ind

--- a/runtime/indent/haml.vim
+++ b/runtime/indent/haml.vim
@@ -38,9 +38,9 @@ function! GetHamlIndent()
   let indent = indent(lnum)
   let cindent = indent(v:lnum)
   if cline =~# '\v^-\s*%(elsif|else|when)>'
-    let indent = cindent < indent ? cindent : indent - &sw
+    let indent = cindent < indent ? cindent : indent - shiftwidth()
   endif
-  let increase = indent + &sw
+  let increase = indent + shiftwidth()
   if indent == indent(lnum)
     let indent = cindent <= indent ? -1 : increase
   endif

--- a/runtime/indent/hamster.vim
+++ b/runtime/indent/hamster.vim
@@ -27,13 +27,13 @@ function HamGetIndent(lnum)
   " Add a shiftwidth to statements following if,  else, elseif,
   " case, select, default, do, until, while, for, start
   if prevline =~? '^\s*\<\(if\|else\%(if\)\?\|for\|repeat\|do\|while\|sub\)\>' 
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   " Subtract a shiftwidth from else, elseif, end(if|while|for), until
   let line = getline(v:lnum)
   if line =~? '^\s*\(else\|elseif\|loop\|until\|end\%(if\|while\|for\|sub\)\)\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/hog.vim
+++ b/runtime/indent/hog.vim
@@ -47,7 +47,7 @@ function GetHogIndent()
     " Continuation of a line that wasn't indented
     let prevline = getline(prevlnum)
     if prevline =~ '^\k\+.*\\\s*$'
-        return &sw 
+        return shiftwidth() 
     endif
 
     " Continuation of a line that was indented
@@ -58,13 +58,13 @@ function GetHogIndent()
     " Indent the next line if previous line contained a start of a block
     " definition ('{' or '(').
     if prevline =~ '^\k\+[^#]*{}\@!\s*$' " TODO || prevline =~ '^\k\+[^#]*()\@!\s*$'
-        return &sw
+        return shiftwidth()
     endif
 
     " Match inside of a block
     if s:IsInBlock(v:lnum)
         if prevline =~ "^\k\+.*$"
-            return &sw
+            return shiftwidth()
         else
             return indent(prevlnum)
         endif

--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -56,15 +56,6 @@ if exists("*HtmlIndent") && !exists('g:force_reload_html')
   finish
 endif
 
-" shiftwidth() exists since patch 7.3.694
-if exists('*shiftwidth')
-  let s:ShiftWidth = function('shiftwidth')
-else
-  func! s:ShiftWidth()
-    return &shiftwidth
-  endfunc
-endif
-
 " Allow for line continuation below.
 let s:cpo_save = &cpo
 set cpo-=C
@@ -128,7 +119,7 @@ func! HtmlIndent_CheckUserSettings()
 
   let indone = {"zero": 0
               \,"auto": "indent(prevnonblank(v:lnum-1))"
-              \,"inc": "b:hi_indent.blocktagind + s:ShiftWidth()"}
+              \,"inc": "b:hi_indent.blocktagind + shiftwidth()"}
 
   let script1 = ''
   if exists("b:html_indent_script1")
@@ -363,7 +354,7 @@ func! s:CheckBlockTag(blocktag, ind)
     endif
     let b:hi_newstate.blocklnr = v:lnum
     " save allover indent for the endtag
-    let b:hi_newstate.blocktagind = b:hi_indent.baseindent + (s:nextrel + s:curind) * s:ShiftWidth()
+    let b:hi_newstate.blocktagind = b:hi_indent.baseindent + (s:nextrel + s:curind) * shiftwidth()
     if a:ind == 3
       return "SCRIPT"    " all except this must be lowercase
       " line is to be checked again for the type attribute
@@ -485,7 +476,7 @@ func! s:FreshState(lnum)
       let state.blocklnr = stopline
       " check preceding tags in the line:
       call s:CountITags(tagline[: stopcol-2])
-      let state.blocktagind = indent(stopline) + (s:curind + s:nextrel) * s:ShiftWidth()
+      let state.blocktagind = indent(stopline) + (s:curind + s:nextrel) * shiftwidth()
       return state
     elseif stopline == state.lnum
       " handle special case: previous line (= state.lnum) contains a
@@ -495,7 +486,7 @@ func! s:FreshState(lnum)
       if !swendtag
         let [bline, bcol] = searchpos('<'.blocktag[1:].'\>', "bnW")
         call s:CountITags(tolower(getline(bline)[: bcol-2]))
-        let state.baseindent = indent(bline) + (s:curind + s:nextrel) * s:ShiftWidth()
+        let state.baseindent = indent(bline) + (s:curind + s:nextrel) * shiftwidth()
         return state
       endif
     endif
@@ -516,7 +507,7 @@ func! s:FreshState(lnum)
     if found == 2
       let state.baseindent = b:hi_indent.baseindent
     endif
-    let state.blocktagind = indent(comlnum) + (s:curind + s:nextrel) * s:ShiftWidth()
+    let state.blocktagind = indent(comlnum) + (s:curind + s:nextrel) * shiftwidth()
     return state
   endif
 
@@ -535,7 +526,7 @@ func! s:FreshState(lnum)
       let text = tolower(getline(comlnum)[: comcol-2])
     endif
     call s:CountITags(text)
-    let state.baseindent = indent(comlnum) + (s:curind + s:nextrel) * s:ShiftWidth()
+    let state.baseindent = indent(comlnum) + (s:curind + s:nextrel) * shiftwidth()
     " TODO check tags that follow "-->"
     return state
   endif
@@ -555,9 +546,9 @@ func! s:FreshState(lnum)
         let text = getline(start_lnum)
         let swendtag = match(text, '^\s*</') >= 0
         call s:CountITags(text[: col('.') - 2])
-        let state.baseindent += s:nextrel * s:ShiftWidth()
+        let state.baseindent += s:nextrel * shiftwidth()
         if !swendtag
-          let state.baseindent += s:curind * s:ShiftWidth()
+          let state.baseindent += s:curind * shiftwidth()
         endif
       endif
       return state
@@ -570,9 +561,9 @@ func! s:FreshState(lnum)
   let text = getline(state.lnum)
   let swendtag = match(text, '^\s*</') >= 0
   call s:CountITags(tolower(text))
-  let state.baseindent = indent(state.lnum) + s:nextrel * s:ShiftWidth()
+  let state.baseindent = indent(state.lnum) + s:nextrel * shiftwidth()
   if !swendtag
-    let state.baseindent += s:curind * s:ShiftWidth()
+    let state.baseindent += s:curind * shiftwidth()
   endif
   return state
 endfunc "}}}
@@ -651,7 +642,7 @@ func! s:CSSIndent()
 
   " add indent after {
   let brace_counts = HtmlIndent_CountBraces(prev_lnum)
-  let extra = brace_counts.c_open * s:ShiftWidth()
+  let extra = brace_counts.c_open * shiftwidth()
 
   let prev_text = getline(prev_lnum)
   let below_end_brace = prev_text =~ '}\s*$'
@@ -668,7 +659,7 @@ func! s:CSSIndent()
       " if the current line is not a comment or starts with @ (used by template
       " systems) reduce indent if previous line is a continuation line
       if !prev_hasfield && !prev_special
-        let extra = -s:ShiftWidth()
+        let extra = -shiftwidth()
       endif
     else
       let cur_hasfield = curtext =~ '^\s*[a-zA-Z0-9-]\+:'
@@ -676,14 +667,14 @@ func! s:CSSIndent()
       if !cur_hasfield && (prev_hasfield || prev_unfinished)
         " Continuation line has extra indent if the previous line was not a
         " continuation line.
-        let extra = s:ShiftWidth()
+        let extra = shiftwidth()
         " Align with @if
         if prev_text =~ '^\s*@if '
           let extra = 4
         endif
       elseif cur_hasfield && !prev_hasfield && !prev_special
         " less indent below a continuation line
-        let extra = -s:ShiftWidth()
+        let extra = -shiftwidth()
       endif
     endif
   endif
@@ -704,10 +695,10 @@ func! s:CSSIndent()
     if special
       " do not reduce indent below @{ ... }
       if extra < 0
-        let extra += s:ShiftWidth()
+        let extra += shiftwidth()
       endif
     else
-      let extra -= (brace_counts.c_close - (prev_text =~ '^\s*}')) * s:ShiftWidth()
+      let extra -= (brace_counts.c_close - (prev_text =~ '^\s*}')) * shiftwidth()
     endif
   endif
 
@@ -715,10 +706,10 @@ func! s:CSSIndent()
   if extra == 0
     if brace_counts.p_open > brace_counts.p_close
       " previous line has more ( than ): add a shiftwidth
-      let extra = s:ShiftWidth()
+      let extra = shiftwidth()
     elseif brace_counts.p_open < brace_counts.p_close
       " previous line has more ) than (: subtract a shiftwidth
-      let extra = -s:ShiftWidth()
+      let extra = -shiftwidth()
     endif
   endif
 
@@ -821,7 +812,7 @@ func! s:Alien5()
   let idx = match(prevtext, '^\s*\zs<!--')
   if idx >= 0
     " just below comment start, add a shiftwidth
-    return idx + s:ShiftWidth()
+    return idx + shiftwidth()
   endif
 
   " Some files add 4 spaces just below a TODO line.  It's difficult to detect
@@ -842,7 +833,7 @@ func! s:Alien6()
       return indent(lnum)
     endif
   endif
-  return b:hi_indent.baseindent + s:ShiftWidth()
+  return b:hi_indent.baseindent + shiftwidth()
 endfunc "}}}
 
 " When the "lnum" line ends in ">" find the line containing the matching "<".
@@ -952,7 +943,7 @@ func! HtmlIndent()
   endif
 
   let curtext = tolower(getline(v:lnum))
-  let indentunit = s:ShiftWidth()
+  let indentunit = shiftwidth()
 
   let b:hi_newstate = {}
   let b:hi_newstate.lnum = v:lnum
@@ -1035,9 +1026,9 @@ func! HtmlIndent()
         if col('.') > 2
           let swendtag = match(text, '^\s*</') >= 0
           call s:CountITags(text[: col('.') - 2])
-          let indent += s:nextrel * s:ShiftWidth()
+          let indent += s:nextrel * shiftwidth()
           if !swendtag
-            let indent += s:curind * s:ShiftWidth()
+            let indent += s:curind * shiftwidth()
           endif
         endif
       else

--- a/runtime/indent/idlang.vim
+++ b/runtime/indent/idlang.vim
@@ -34,25 +34,25 @@ function GetIdlangIndent(lnum)
    " Indenting of continued lines.
    if getline(pnum) =~ '\$\s*\(;.*\)\=$'
       if getline(pnum2) !~ '\$\s*\(;.*\)\=$'
-	 let curind = curind+&sw
+	 let curind = curind+shiftwidth()
       endif
    else
       if getline(pnum2) =~ '\$\s*\(;.*\)\=$'
-	 let curind = curind-&sw
+	 let curind = curind-shiftwidth()
       endif
    endif
 
    " Indenting blocks of statements.
    if getline(v:lnum) =~? '^\s*\(endif\|endelse\|endwhile\|endfor\|endrep\)\>'
       if getline(pnum) =~? 'begin\>'
-      elseif indent(v:lnum) > curind-&sw
-	 let curind = curind-&sw
+      elseif indent(v:lnum) > curind-shiftwidth()
+	 let curind = curind-shiftwidth()
       else
 	 return -1
       endif
    elseif getline(pnum) =~? 'begin\>'
-      if indent(v:lnum) < curind+&sw
-	 let curind = curind+&sw
+      if indent(v:lnum) < curind+shiftwidth()
+	 let curind = curind+shiftwidth()
       else
 	 return -1
       endif

--- a/runtime/indent/ishd.vim
+++ b/runtime/indent/ishd.vim
@@ -50,17 +50,17 @@ fun! GetIshdIndent(lnum)
 
     " Add
     if previous_line =~ '^\s*\<\(function\|begin\|switch\|case\|default\|if.\{-}then\|else\|elseif\|while\|repeat\)\>'
-	let ind = ind + &sw
+	let ind = ind + shiftwidth()
     endif
 
     " Subtract
     if this_line =~ '^\s*\<endswitch\>'
-	let ind = ind - 2 * &sw
+	let ind = ind - 2 * shiftwidth()
     elseif this_line =~ '^\s*\<\(begin\|end\|endif\|endwhile\|else\|elseif\|until\)\>'
-	let ind = ind - &sw
+	let ind = ind - shiftwidth()
     elseif this_line =~ '^\s*\<\(case\|default\)\>'
 	if previous_line !~ '^\s*\<switch\>'
-	    let ind = ind - &sw
+	    let ind = ind - shiftwidth()
 	endif
     endif
 

--- a/runtime/indent/java.vim
+++ b/runtime/indent/java.vim
@@ -87,7 +87,7 @@ function GetJavaIndent()
   " classes.
   if getline(v:lnum) =~ '^\s*\(extends\|implements\)\>'
         \ && getline(lnum) !~ '^\s*\(extends\|implements\)\>'
-    let theIndent = theIndent + &sw
+    let theIndent = theIndent + shiftwidth()
   endif
 
   " correct for continuation lines of "throws", "implements" and "extends"
@@ -96,20 +96,20 @@ function GetJavaIndent()
   if strlen(cont_kw) > 0
     let amount = strlen(cont_kw) + 1
     if getline(lnum) !~ ',\s*$'
-      let theIndent = theIndent - (amount + &sw)
+      let theIndent = theIndent - (amount + shiftwidth())
       if theIndent < 0
         let theIndent = 0
       endif
     elseif prev == lnum
       let theIndent = theIndent + amount
       if cont_kw ==# 'throws'
-        let theIndent = theIndent + &sw
+        let theIndent = theIndent + shiftwidth()
       endif
     endif
   elseif getline(prev) =~ '^\s*\(throws\|implements\|extends\)\>'
         \ && (getline(prev) =~ '{\s*$'
         \  || getline(v:lnum) =~ '^\s*{\s*$')
-    let theIndent = theIndent - &sw
+    let theIndent = theIndent - shiftwidth()
   endif
 
   " When the line starts with a }, try aligning it with the matching {,

--- a/runtime/indent/json.vim
+++ b/runtime/indent/json.vim
@@ -141,7 +141,7 @@ function GetJSONIndent()
 
   " If the previous line ended with a block opening, add a level of indent.
   " if s:Match(lnum, s:block_regex)
-    " return indent(lnum) + &sw
+    " return indent(lnum) + shiftwidth()
   " endif
 
   " If the previous line contained an opening bracket, and we are still in it,
@@ -149,7 +149,7 @@ function GetJSONIndent()
   if line =~ '[[({]'
     let counts = s:LineHasOpeningBrackets(lnum)
     if counts[0] == '1' || counts[1] == '1' || counts[2] == '1'
-      return ind + &sw
+      return ind + shiftwidth()
     else
       call cursor(v:lnum, vcol)
     end

--- a/runtime/indent/ld.vim
+++ b/runtime/indent/ld.vim
@@ -65,7 +65,7 @@ function GetLDIndent()
   if line =~ '^\s*\*'
     return cindent(v:lnum)
   elseif line =~ '^\s*}'
-    return indent(v:lnum) - &sw
+    return indent(v:lnum) - shiftwidth()
   endif
 
   let pnum = s:prevnonblanknoncomment(v:lnum - 1)
@@ -73,11 +73,11 @@ function GetLDIndent()
     return 0
   endif
 
-  let ind = indent(pnum) + s:count_braces(pnum, 1) * &sw
+  let ind = indent(pnum) + s:count_braces(pnum, 1) * shiftwidth()
 
   let pline = getline(pnum)
   if pline =~ '}\s*$'
-    let ind -= (s:count_braces(pnum, 0) - (pline =~ '^\s*}' ? 1 : 0)) * &sw
+    let ind -= (s:count_braces(pnum, 0) - (pline =~ '^\s*}' ? 1 : 0)) * shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/liquid.vim
+++ b/runtime/indent/liquid.vim
@@ -54,9 +54,9 @@ function! GetLiquidIndent(...)
   let line  = substitute(line,'\C^\%(\s*{%\s*end\w*\s*%}\)\+','','')
   let line .= matchstr(cline,'\C^\%(\s*{%\s*end\w*\s*%}\)\+')
   let cline = substitute(cline,'\C^\%(\s*{%\s*end\w*\s*%}\)\+','','')
-  let ind += &sw * s:count(line,'{%\s*\%(if\|elsif\|else\|unless\|ifchanged\|case\|when\|for\|empty\|tablerow\|capture\)\>')
-  let ind -= &sw * s:count(line,'{%\s*end\%(if\|unless\|ifchanged\|case\|for\|tablerow\|capture\)\>')
-  let ind -= &sw * s:count(cline,'{%\s*\%(elsif\|else\|when\|empty\)\>')
-  let ind -= &sw * s:count(cline,'{%\s*end\w*$')
+  let ind += shiftwidth() * s:count(line,'{%\s*\%(if\|elsif\|else\|unless\|ifchanged\|case\|when\|for\|empty\|tablerow\|capture\)\>')
+  let ind -= shiftwidth() * s:count(line,'{%\s*end\%(if\|unless\|ifchanged\|case\|for\|tablerow\|capture\)\>')
+  let ind -= shiftwidth() * s:count(cline,'{%\s*\%(elsif\|else\|when\|empty\)\>')
+  let ind -= shiftwidth() * s:count(cline,'{%\s*end\w*$')
   return ind
 endfunction

--- a/runtime/indent/logtalk.vim
+++ b/runtime/indent/logtalk.vim
@@ -38,24 +38,24 @@ function! GetLogtalkIndent()
 	endif
 	" Check for entity opening directive on previous line
 	if pline =~ '^\s*:-\s\(object\|protocol\|category\)\ze(.*,$'
-		let ind = ind + &sw
+		let ind = ind + shiftwidth()
 	" Check for clause head on previous line
 	elseif pline =~ ':-\s*\(%.*\)\?$'
-		let ind = ind + &sw
+		let ind = ind + shiftwidth()
 	" Check for entity closing directive on previous line
 	elseif pline =~ '^\s*:-\send_\(object\|protocol\|category\)\.\(%.*\)\?$'
-		let ind = ind - &sw
+		let ind = ind - shiftwidth()
 	" Check for end of clause on previous line
 	elseif pline =~ '\.\s*\(%.*\)\?$'
-		let ind = ind - &sw
+		let ind = ind - shiftwidth()
 	endif
 	" Check for opening conditional on previous line
 	if pline =~ '^\s*\([(;]\|->\)' && pline !~ '\.\s*\(%.*\)\?$' && pline !~ '^.*\([)][,]\s*\(%.*\)\?$\)'
-		let ind = ind + &sw
+		let ind = ind + shiftwidth()
 	endif
 	" Check for closing an unclosed paren, or middle ; or ->
 	if line =~ '^\s*\([);]\|->\)'
-		let ind = ind - &sw
+		let ind = ind - shiftwidth()
 	endif
 	return ind
 endfunction

--- a/runtime/indent/lua.vim
+++ b/runtime/indent/lua.vim
@@ -48,7 +48,7 @@ function! GetLuaIndent()
     " Add 'shiftwidth' if what we found previously is not in a comment and
     " an "end" or "until" is not present on the same line.
     if synIDattr(synID(prevlnum, midx + 1, 1), "name") != "luaComment" && prevline !~ '\<end\>\|\<until\>'
-      let ind = ind + &shiftwidth
+      let ind = ind + shiftwidth()
     endif
   endif
 
@@ -56,7 +56,7 @@ function! GetLuaIndent()
   " This is the part that requires 'indentkeys'.
   let midx = match(getline(v:lnum), '^\s*\%(end\>\|else\>\|elseif\>\|until\>\|}\)')
   if midx != -1 && synIDattr(synID(v:lnum, midx + 1, 1), "name") != "luaComment"
-    let ind = ind - &shiftwidth
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/make.vim
+++ b/runtime/indent/make.vim
@@ -48,14 +48,14 @@ function GetMakeIndent()
     if prev_prev_line =~ s:continuation_rx
       return indent(prev_lnum)
     elseif prev_line =~ s:rule_rx
-      return &sw
+      return shiftwidth()
     elseif prev_line =~ s:assignment_rx
       call cursor(prev_lnum, 1)
       if search(s:assignment_rx, 'W') != 0
         return virtcol('.') - 1
       else
         " TODO: ?
-        return &sw
+        return shiftwidth()
       endif
     else
       " TODO: OK, this might be a continued shell command, so perhaps indent
@@ -66,7 +66,7 @@ function GetMakeIndent()
       "    return indent(prev_lnum) + 2
       "  endif
       "endif
-      return indent(prev_lnum) + &sw
+      return indent(prev_lnum) + shiftwidth()
     endif
   elseif prev_prev_line =~ s:continuation_rx
     let folded_line = s:remove_continuation(prev_prev_line) . ' ' . s:remove_continuation(prev_line)
@@ -102,13 +102,13 @@ function GetMakeIndent()
       return &ts
     endif
   elseif prev_line =~ s:conditional_directive_rx
-    return &sw
+    return shiftwidth()
   else
     let line = getline(v:lnum)
     if line =~ s:just_inserted_rule_rx
       return 0
     elseif line =~ s:end_conditional_directive_rx
-      return v:lnum - 1 == 0 ? 0 : indent(v:lnum - 1) - &sw
+      return v:lnum - 1 == 0 ? 0 : indent(v:lnum - 1) - shiftwidth()
     else
       return v:lnum - 1 == 0 ? 0 : indent(v:lnum - 1)
     endif

--- a/runtime/indent/matlab.vim
+++ b/runtime/indent/matlab.vim
@@ -44,9 +44,9 @@ function GetMatlabIndent(lnum)
     " See if this line does not follow the line right after an openblock
     if getline(plnum) =~ '^\s*\(for\|if\|else\|elseif\|case\|while\|switch\|try\|otherwise\|catch\)\>'
     " See if the user has already dedented
-    elseif indent(v:lnum) > curind - &sw
+    elseif indent(v:lnum) > curind - shiftwidth()
       " If not, recommend one dedent
-	let curind = curind - &sw
+	let curind = curind - shiftwidth()
     else
       " Otherwise, trust the user
       return -1
@@ -56,9 +56,9 @@ function GetMatlabIndent(lnum)
   " If the previous line opened a block
   elseif getline(plnum) =~ '^\s*\(for\|if\|else\|elseif\|case\|while\|switch\|try\|otherwise\|catch\)\>'
     " See if the user has already indented
-    if indent(v:lnum) < curind + &sw
+    if indent(v:lnum) < curind + shiftwidth()
       "If not, recommend indent
-      let curind = curind + &sw
+      let curind = curind + shiftwidth()
     else
       " Otherwise, trust the user
       return -1

--- a/runtime/indent/mma.vim
+++ b/runtime/indent/mma.vim
@@ -49,7 +49,7 @@ function GetMmaIndent()
     " also, indent only if this line if this line isn't starting a new
     " block... TODO - fix this with indentkeys?
     if getline(v:lnum-1) =~ '\\\@<!\%(\[[^\]]*\|([^)]*\|{[^}]*\)$' && getline(v:lnum) !~ '\s\+[\[({]'
-        let ind = ind+&sw
+        let ind = ind+shiftwidth()
     endif
 
     " if this line had unmatched closing block,

--- a/runtime/indent/mp.vim
+++ b/runtime/indent/mp.vim
@@ -162,18 +162,18 @@ function! GetMetaPostIndent()
   " if it is an internal/external :for or :if statements {{{2
   let pnn_s = getline(MetaPrevNonblankNoncomment(cl-1))
   if  pnn_s =~ '\<\(for\|if\)\>.\+:\s*\($\|%\)'
-    let ind = match(pnn_s, '\<\(for\|if\)\>.\+:\s*\($\|%\)') + &sw
+    let ind = match(pnn_s, '\<\(for\|if\)\>.\+:\s*\($\|%\)') + shiftwidth()
   " }}}
   " if it is a :def, :vardef, :beginfig, :begingroup, :else, :elseif {{{2
   elseif pnn_s =~ '^\s*\('                       .
         \ '\(var\)\=def\|'                       .
         \ 'begin\(group\|fig\s*(\s*\d\+\s*)\)\|' .
         \ 'else\(if\)\='                         . '\)\>'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   " }}}
   " if it is a broken line {{{2
   elseif pnn_s !~ end_of_item.'\s*\($\|%\)'
-    let ind = ind + (2 * &sw)
+    let ind = ind + (2 * shiftwidth())
   endif
   " }}}
   " }}}
@@ -196,7 +196,7 @@ function! GetMetaPostIndent()
   " }}}
   " if this is :endgroup statement {{{2
   elseif cs =~ '^\s*endgroup\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   " }}}
   " }}}

--- a/runtime/indent/ocaml.vim
+++ b/runtime/indent/ocaml.vim
@@ -101,7 +101,7 @@ function! GetOCamlIndent()
 
  " Return double 'shiftwidth' after lines matching:
  if lline =~ '^\s*|.*->\s*$'
-   return ind + &sw + &sw
+   return ind + shiftwidth() * 2
  endif
 
  let line = getline(v:lnum)
@@ -172,7 +172,7 @@ function! GetOCamlIndent()
  " Indent if current line begins with 'and':
  elseif line =~ '^\s*and\>'
    if lline !~ '^\s*\(and\|let\|type\)\>\|\<end\s*$'
-     return ind - &sw
+     return ind - shiftwidth()
    endif
 
  " Indent if current line begins with 'with':
@@ -199,14 +199,14 @@ function! GetOCamlIndent()
  " or 'method':
  elseif line =~ '^\s*\(constraint\|inherit\|initializer\|method\)\>'
    if lline !~ s:obj
-     return indent(search('\<\(object\|object\s*(.*)\)\s*$', 'bW')) + &sw
+     return indent(search('\<\(object\|object\s*(.*)\)\s*$', 'bW')) + shiftwidth()
    endif
 
  endif
 
  " Add a 'shiftwidth' after lines ending with:
  if lline =~ '\(:\|=\|->\|<-\|(\|\[\|{\|{<\|\[|\|\[<\|\<\(begin\|do\|else\|fun\|function\|functor\|if\|initializer\|object\|parser\|private\|sig\|struct\|then\|try\)\|\<object\s*(.*)\)\s*$'
-   let ind = ind + &sw
+   let ind = ind + shiftwidth()
 
  " Back to normal indent after lines ending with ';;':
  elseif lline =~ ';;\s*$' && lline !~ '^\s*;;'
@@ -263,7 +263,7 @@ function! GetOCamlIndent()
 
  " Subtract a 'shiftwidth' after lines matching 'match ... with parser':
  if lline =~ '\<match\>.*\<with\>\s*\<parser\s*$'
-   let ind = ind - &sw
+   let ind = ind - shiftwidth()
  endif
 
  return ind

--- a/runtime/indent/occam.vim
+++ b/runtime/indent/occam.vim
@@ -131,7 +131,7 @@ function GetOccamIndent()
   if line =~ s:FirstLevelIndent || (line =~ s:FirstLevelNonColonEndIndent && line !~ s:ColonEnd)
 	\ || (line !~ s:ColonStart && (prevline =~ s:SecondLevelIndent
 	\ || (prevline =~ s:SecondLevelNonColonEndIndent && prevline !~ s:ColonEnd)))
-    let curindent = curindent + &shiftwidth
+    let curindent = curindent + shiftwidth()
 
     " Restore magic
     if !save_magic|setlocal nomagic|endif
@@ -153,7 +153,7 @@ function GetOccamIndent()
 
   while !found
 
-    if indent(prevlinenum) == curindent - &shiftwidth
+    if indent(prevlinenum) == curindent - shiftwidth()
       let found = 1
     endif
 
@@ -171,7 +171,7 @@ function GetOccamIndent()
 
   if prevlinenum > 0
     if getline(prevlinenum) =~ s:SecondLevelIndent
-      let curindent = curindent + &shiftwidth
+      let curindent = curindent + shiftwidth()
     endif
   endif
 

--- a/runtime/indent/pascal.vim
+++ b/runtime/indent/pascal.vim
@@ -102,12 +102,12 @@ function! GetPascalIndent( line_num )
 
 	" If the PREVIOUS LINE ended in these items, always indent
 	if prev_codeline =~ '\<\(type\|const\|var\)$'
-		return indnt + &shiftwidth
+		return indnt + shiftwidth()
 	endif
 
 	if prev_codeline =~ '\<repeat$'
 		if this_codeline !~ '^\s*until\>'
-			return indnt + &shiftwidth
+			return indnt + shiftwidth()
 		else
 			return indnt
 		endif
@@ -115,7 +115,7 @@ function! GetPascalIndent( line_num )
 
 	if prev_codeline =~ '\<\(begin\|record\)$'
 		if this_codeline !~ '^\s*end\>'
-			return indnt + &shiftwidth
+			return indnt + shiftwidth()
 		else
 			return indnt
 		endif
@@ -125,10 +125,10 @@ function! GetPascalIndent( line_num )
 	" followed by "begin"
 	if prev_codeline =~ '\<\(\|else\|then\|do\)$' || prev_codeline =~ ':$'
 		if this_codeline !~ '^\s*begin\>'
-			return indnt + &shiftwidth
+			return indnt + shiftwidth()
 		else
 			" If it does start with "begin" then keep the same indent
-			"return indnt + &shiftwidth
+			"return indnt + shiftwidth()
 			return indnt
 		endif
 	endif
@@ -137,7 +137,7 @@ function! GetPascalIndent( line_num )
 	" only the line before the current one. TODO: Get it working for
 	" parameter lists longer than two lines.
 	if prev_codeline =~ '([^)]\+$'
-		return indnt + &shiftwidth
+		return indnt + shiftwidth()
 	endif
 
 
@@ -146,7 +146,7 @@ function! GetPascalIndent( line_num )
 	" Lines starting with "else", but not following line ending with
 	" "end".
 	if this_codeline =~ '^\s*else\>' && prev_codeline !~ '\<end$'
-		return indnt - &shiftwidth
+		return indnt - shiftwidth()
 	endif
 
 	" Lines after a single-statement branch/loop.
@@ -160,16 +160,16 @@ function! GetPascalIndent( line_num )
 		" additional unindentation.
 		if this_codeline =~ '^\s*\(end;\|except\|finally\|\)$'
 			" Note that we don't return from here.
-			return indnt - &shiftwidth - &shiftwidth
+			return indnt - (shiftwidth() * 2)
 		endif
-		return indnt - &shiftwidth
+		return indnt - shiftwidth()
 	endif
 
 	" Lines starting with "until" or "end". This rule must be overridden
 	" by the one for "end" after a single-statement branch/loop. In
 	" other words that rule should come before this one.
 	if this_codeline =~ '^\s*\(end\|until\)\>'
-		return indnt - &shiftwidth
+		return indnt - shiftwidth()
 	endif
 
 
@@ -201,7 +201,7 @@ function! GetPascalIndent( line_num )
 
 	" If the PREVIOUS LINE ended in these items, always indent.
 	if prev_codeline =~ '^\s*\(unit\|uses\|try\|except\|finally\|private\|protected\|public\|published\)$'
-		return indnt + &shiftwidth
+		return indnt + shiftwidth()
 	endif
 
 	" ???? Indent "procedure" and "functions" if they appear within an
@@ -212,11 +212,11 @@ function! GetPascalIndent( line_num )
 	" UNINDENT ONCE
 
 	if this_codeline =~ '^\s*\(except\|finally\)$'
-		return indnt - &shiftwidth
+		return indnt - shiftwidth()
 	endif
 
 	if this_codeline =~ '^\s*\(private\|protected\|public\|published\)$'
-		return indnt - &shiftwidth
+		return indnt - shiftwidth()
 	endif
 
 

--- a/runtime/indent/perl.vim
+++ b/runtime/indent/perl.vim
@@ -138,9 +138,9 @@ function! GetPerlIndent()
                         \ || synid =~ '^perl\(Sub\|Block\|Package\)Fold'
                 let brace = strpart(line, bracepos, 1)
                 if brace == '(' || brace == '{' || brace == '['
-                    let ind = ind + &sw
+                    let ind = ind + shiftwidth()
                 else
-                    let ind = ind - &sw
+                    let ind = ind - shiftwidth()
                 endif
             endif
             let bracepos = match(line, braceclass, bracepos + 1)
@@ -152,25 +152,25 @@ function! GetPerlIndent()
                         \ || synid == "perlMatchStartEnd"
                         \ || synid == "perlBraces"
                         \ || synid =~ '^perl\(Sub\|Block\|Package\)Fold'
-                let ind = ind - &sw
+                let ind = ind - shiftwidth()
             endif
         endif
     else
         if line =~ '[{[(]\s*\(#[^])}]*\)\=$'
-            let ind = ind + &sw
+            let ind = ind + shiftwidth()
         endif
         if cline =~ '^\s*[])}]'
-            let ind = ind - &sw
+            let ind = ind - shiftwidth()
         endif
     endif
 
     " Indent lines that begin with 'or' or 'and'
     if cline =~ '^\s*\(or\|and\)\>'
         if line !~ '^\s*\(or\|and\)\>'
-            let ind = ind + &sw
+            let ind = ind + shiftwidth()
         endif
     elseif line =~ '^\s*\(or\|and\)\>'
-        let ind = ind - &sw
+        let ind = ind - shiftwidth()
     endif
 
     return ind

--- a/runtime/indent/perl6.vim
+++ b/runtime/indent/perl6.vim
@@ -107,19 +107,19 @@ function! GetPerl6Indent()
     endif
 
         if line =~ '[<«\[{(]\s*\(#[^)}\]»>]*\)\=$'
-            let ind = ind + &sw
+            let ind = ind + shiftwidth()
         endif
         if cline =~ '^\s*[)}\]»>]'
-            let ind = ind - &sw
+            let ind = ind - shiftwidth()
         endif
 
     " Indent lines that begin with 'or' or 'and'
     if cline =~ '^\s*\(or\|and\)\>'
         if line !~ '^\s*\(or\|and\)\>'
-            let ind = ind + &sw
+            let ind = ind + shiftwidth()
         endif
     elseif line =~ '^\s*\(or\|and\)\>'
-        let ind = ind - &sw
+        let ind = ind - shiftwidth()
     endif
 
     return ind

--- a/runtime/indent/php.vim
+++ b/runtime/indent/php.vim
@@ -53,13 +53,13 @@ let g:php_sync_method = 0
 
 
 if exists("PHP_default_indenting")
-    let b:PHP_default_indenting = PHP_default_indenting * &sw
+    let b:PHP_default_indenting = PHP_default_indenting * shiftwidth()
 else
     let b:PHP_default_indenting = 0
 endif
 
 if exists("PHP_outdentSLComments")
-    let b:PHP_outdentSLComments = PHP_outdentSLComments * &sw
+    let b:PHP_outdentSLComments = PHP_outdentSLComments * shiftwidth()
 else
     let b:PHP_outdentSLComments = 0
 endif
@@ -314,7 +314,7 @@ function! FindTheSwitchIndent (lnum) " {{{
     let test = GetLastRealCodeLNum(a:lnum - 1)
 
     if test <= 1
-	return indent(1) - &sw * b:PHP_vintage_case_default_indent
+	return indent(1) - shiftwidth() * b:PHP_vintage_case_default_indent
     end
 
     while getline(test) =~ '^\s*}' && test > 1
@@ -328,7 +328,7 @@ function! FindTheSwitchIndent (lnum) " {{{
     if getline(test) =~# '^\s*switch\>'
 	return indent(test)
     elseif getline(test) =~# s:defaultORcase
-	return indent(test) - &sw * b:PHP_vintage_case_default_indent
+	return indent(test) - shiftwidth() * b:PHP_vintage_case_default_indent
     else
 	return FindTheSwitchIndent(test)
     endif
@@ -401,7 +401,7 @@ function! GetPhpIndent()
     endif
 
     if b:PHP_default_indenting
-	let b:PHP_default_indenting = g:PHP_default_indenting * &sw
+	let b:PHP_default_indenting = g:PHP_default_indenting * shiftwidth()
     endif
 
     let cline = getline(v:lnum)
@@ -660,7 +660,7 @@ function! GetPhpIndent()
 	let b:PHP_CurrentIndentLevel = b:PHP_default_indenting
 	return indent(FindTheIfOfAnElse(v:lnum, 1))
     elseif cline =~# s:defaultORcase
-	return FindTheSwitchIndent(v:lnum) + &sw * b:PHP_vintage_case_default_indent
+	return FindTheSwitchIndent(v:lnum) + shiftwidth() * b:PHP_vintage_case_default_indent
     elseif cline =~ '^\s*)\=\s*{'
 	let previous_line = last_line
 	let last_line_num = lnum
@@ -672,7 +672,7 @@ function! GetPhpIndent()
 		let ind = indent(last_line_num)
 
 		if  b:PHP_BracesAtCodeLevel
-		    let ind = ind + &sw
+		    let ind = ind + shiftwidth()
 		endif
 
 		return ind
@@ -683,7 +683,7 @@ function! GetPhpIndent()
 	endwhile
 
     elseif last_line =~# unstated && cline !~ '^\s*);\='.endline
-	let ind = ind + &sw
+	let ind = ind + shiftwidth()
 	return ind + addSpecial
 
     elseif (ind != b:PHP_default_indenting || last_line =~ '^[)\]]' ) && last_line =~ terminated
@@ -782,7 +782,7 @@ function! GetPhpIndent()
 	    endif
 
 	    if !dontIndent && (!b:PHP_BracesAtCodeLevel || last_line !~# '^\s*{')
-		let ind = ind + &sw
+		let ind = ind + shiftwidth()
 	    endif
 
 	    if b:PHP_BracesAtCodeLevel || b:PHP_vintage_case_default_indent == 1
@@ -800,17 +800,17 @@ function! GetPhpIndent()
 	    endif
 
 	elseif last_line =~ '^\s*'.s:blockstart
-	    let ind = ind + &sw
+	    let ind = ind + shiftwidth()
 
 
     elseif AntepenultimateLine =~ '{'.endline || AntepenultimateLine =~ terminated || AntepenultimateLine =~# s:defaultORcase
-	    let ind = ind + &sw
+	    let ind = ind + shiftwidth()
 	endif
 
     endif
 
     if cline =~  '^\s*[)\]];\='
-	let ind = ind - &sw
+	let ind = ind - shiftwidth()
     endif
 
     let b:PHP_CurrentIndentLevel = ind

--- a/runtime/indent/postscr.vim
+++ b/runtime/indent/postscr.vim
@@ -41,16 +41,16 @@ function! PostscrIndentGet(lnum)
 
   " Indent for dicts, arrays, and saves with possible trailing comment
   if pline =~ '\(begin\|<<\|g\=save\|{\|[\)\s*\(%.*\)\=$'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   " Remove indent for popped dicts, and restores.
   if pline =~ '\(end\|g\=restore\)\s*$'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
 
   " Else handle immediate dedents of dicts, restores, and arrays.
   elseif getline(a:lnum) =~ '\(end\|>>\|g\=restore\|}\|]\)'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
 
   " Else handle DSC comments - always start of line.
   elseif getline(a:lnum) =~ '^\s*%%'

--- a/runtime/indent/pov.vim
+++ b/runtime/indent/pov.vim
@@ -75,9 +75,9 @@ function GetPoVRayIndent()
   " opening line.
   let cur = s:MatchCount(v:lnum, '^\s*\%(#\s*\%(end\|else\)\>\|[]})]\)')
   if cur > 0
-    let final = plind + (chg - cur) * &sw
+    let final = plind + (chg - cur) * shiftwidth()
   else
-    let final = plind + chg * &sw
+    let final = plind + chg * shiftwidth()
   endif
 
   return final < 0 ? 0 : final

--- a/runtime/indent/prolog.vim
+++ b/runtime/indent/prolog.vim
@@ -41,18 +41,18 @@ function! GetPrologIndent()
     endif
     " Check for clause head on previous line
     if pline =~ ':-\s*\(%.*\)\?$'
-	let ind = ind + &sw
+	let ind = ind + shiftwidth()
     " Check for end of clause on previous line
     elseif pline =~ '\.\s*\(%.*\)\?$'
-	let ind = ind - &sw
+	let ind = ind - shiftwidth()
     endif
     " Check for opening conditional on previous line
     if pline =~ '^\s*\([(;]\|->\)'
-	let ind = ind + &sw
+	let ind = ind + shiftwidth()
     endif
     " Check for closing an unclosed paren, or middle ; or ->
     if line =~ '^\s*\([);]\|->\)'
-	let ind = ind - &sw
+	let ind = ind - shiftwidth()
     endif
     return ind
 endfunction

--- a/runtime/indent/r.vim
+++ b/runtime/indent/r.vim
@@ -273,7 +273,7 @@ function GetRIndent()
         let nlnum = s:Get_prev_line(nlnum)
         let nline = SanitizeRLine(getline(nlnum)) . nline
       endwhile
-      if nline =~ '^\s*function\s*(' && indent(nlnum) == &sw
+      if nline =~ '^\s*function\s*(' && indent(nlnum) == shiftwidth()
         return 0
       endif
     endif
@@ -284,7 +284,7 @@ function GetRIndent()
 
   " line is an incomplete command:
   if line =~ '\<\(if\|while\|for\|function\)\s*()$' || line =~ '\<else$' || line =~ '<-$'
-    return indent(lnum) + &sw
+    return indent(lnum) + shiftwidth()
   endif
 
   " Deal with () and []
@@ -292,14 +292,14 @@ function GetRIndent()
   let pb = s:Get_paren_balance(line, '(', ')')
 
   if line =~ '^\s*{$' || line =~ '(\s*{' || (pb == 0 && (line =~ '{$' || line =~ '(\s*{$'))
-    return indent(lnum) + &sw
+    return indent(lnum) + shiftwidth()
   endif
 
   let s:curtabstop = repeat(' ', &tabstop)
 
   if g:r_indent_align_args == 1
     if pb > 0 && line =~ '{$'
-      return s:Get_last_paren_idx(line, '(', ')', pb) + &sw
+      return s:Get_last_paren_idx(line, '(', ')', pb) + shiftwidth()
     endif
 
     let bb = s:Get_paren_balance(line, '[', ']')
@@ -363,11 +363,11 @@ function GetRIndent()
       if oline =~ g:r_indent_op_pattern
         return indent(lnum)
       else
-        return indent(lnum) + &sw
+        return indent(lnum) + shiftwidth()
       endif
     else
       if oline =~ g:r_indent_op_pattern
-        return indent(lnum) - &sw
+        return indent(lnum) - shiftwidth()
       endif
     endif
   endif
@@ -382,7 +382,7 @@ function GetRIndent()
       let line = linepiece . line
     endwhile
     if line =~ '{$' && post_block == 0
-      return indent(lnum) + &sw
+      return indent(lnum) + shiftwidth()
     endif
 
     " Now we can do some tests again
@@ -392,19 +392,19 @@ function GetRIndent()
     if post_block == 0
       let newl = SanitizeRLine(line)
       if newl =~ '\<\(if\|while\|for\|function\)\s*()$' || newl =~ '\<else$' || newl =~ '<-$'
-        return indent(lnum) + &sw
+        return indent(lnum) + shiftwidth()
       endif
     endif
   endif
 
   if cline =~ '^\s*else'
     if line =~ '<-\s*if\s*()'
-      return indent(lnum) + &sw
+      return indent(lnum) + shiftwidth()
     else
       if line =~ '\<if\s*()'
         return indent(lnum)
       else
-        return indent(lnum) - &sw
+        return indent(lnum) - shiftwidth()
       endif
     endif
   endif
@@ -474,16 +474,16 @@ function GetRIndent()
   let pind = indent(plnum)
 
   if g:r_indent_align_args == 0 && pb != 0
-    let ind += pb * &sw
+    let ind += pb * shiftwidth()
     return ind
   endif
 
   if g:r_indent_align_args == 0 && bb != 0
-    let ind += bb * &sw
+    let ind += bb * shiftwidth()
     return ind
   endif
 
-  if ind == pind || (ind == (pind  + &sw) && pline =~ '{$' && ppost_else == 0)
+  if ind == pind || (ind == (pind  + shiftwidth()) && pline =~ '{$' && ppost_else == 0)
     return ind
   endif
 
@@ -503,7 +503,7 @@ function GetRIndent()
       let pbb = s:Get_paren_balance(pline, '[', ']')
     endwhile
     let pind = indent(plnum)
-    if ind == (pind  + &sw) && pline =~ '{$'
+    if ind == (pind  + shiftwidth()) && pline =~ '{$'
       return ind
     endif
   endwhile

--- a/runtime/indent/readline.vim
+++ b/runtime/indent/readline.vim
@@ -25,11 +25,11 @@ function GetReadlineIndent()
   let ind = indent(lnum)
 
   if getline(lnum) =~ '^\s*$\(if\|else\)\>'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   if getline(v:lnum) =~ '^\s*$\(else\|endif\)\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/rhelp.vim
+++ b/runtime/indent/rhelp.vim
@@ -81,7 +81,7 @@ function GetRHelpIndent()
   let closeb = strlen(line2) - strlen(line3)
   let bb = openb - closeb
 
-  let ind = indent(lnum) + (bb * &sw)
+  let ind = indent(lnum) + (bb * shiftwidth())
 
   if line =~ '^\s*}\s*$'
     let ind = indent(lnum)

--- a/runtime/indent/rpl.vim
+++ b/runtime/indent/rpl.vim
@@ -32,16 +32,16 @@ function RplGetIndent(lnum)
   if prevstat =~? '\<\(if\|iferr\|do\|while\)\>' && prevstat =~? '\<end\>'
   elseif prevstat =~? '\(^\|\s\+\)<<\($\|\s\+\)' && prevstat =~? '\s\+>>\($\|\s\+\)'
   elseif prevstat =~? '\<\(if\|iferr\|then\|else\|elseif\|select\|case\|do\|until\|while\|repeat\|for\|start\|default\)\>' || prevstat =~? '\(^\|\s\+\)<<\($\|\s\+\)'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   " Subtract a shiftwidth from then, else, elseif, end, until, repeat, next,
   " step
   let line = getline(v:lnum)
   if line =~? '^\s*\(then\|else\|elseif\|until\|repeat\|next\|step\|default\|end\)\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   elseif line =~? '^\s*>>\($\|\s\+\)'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/ruby.vim
+++ b/runtime/indent/ruby.vim
@@ -411,12 +411,12 @@ function GetRubyIndent(...)
 
   " If the previous line ended with a block opening, add a level of indent.
   if s:Match(lnum, s:block_regex)
-    return indent(s:GetMSL(lnum)) + &sw
+    return indent(s:GetMSL(lnum)) + shiftwidth()
   endif
 
   " If the previous line ended with the "*" of a splat, add a level of indent
   if line =~ s:splat_regex
-    return indent(lnum) + &sw
+    return indent(lnum) + shiftwidth()
   endif
 
   " If the previous line contained unclosed opening brackets and we are still
@@ -431,20 +431,20 @@ function GetRubyIndent(...)
     if opening.pos != -1
       if opening.type == '(' && searchpair('(', '', ')', 'bW', s:skip_expr) > 0
         if col('.') + 1 == col('$')
-          return ind + &sw
+          return ind + shiftwidth()
         else
           return virtcol('.')
         endif
       else
         let nonspace = matchend(line, '\S', opening.pos + 1) - 1
-        return nonspace > 0 ? nonspace : ind + &sw
+        return nonspace > 0 ? nonspace : ind + shiftwidth()
       endif
     elseif closing.pos != -1
       call cursor(lnum, closing.pos + 1)
       normal! %
 
       if s:Match(line('.'), s:ruby_indent_keywords)
-        return indent('.') + &sw
+        return indent('.') + shiftwidth()
       else
         return indent('.')
       endif
@@ -473,7 +473,7 @@ function GetRubyIndent(...)
   let col = s:Match(lnum, s:ruby_indent_keywords)
   if col > 0
     call cursor(lnum, col)
-    let ind = virtcol('.') - 1 + &sw
+    let ind = virtcol('.') - 1 + shiftwidth()
     " TODO: make this better (we need to count them) (or, if a searchpair
     " fails, we know that something is lacking an end and thus we indent a
     " level
@@ -506,9 +506,9 @@ function GetRubyIndent(...)
   " TODO: this does not take into account contrived things such as
   " module Foo; class Bar; end
   if s:Match(lnum, s:ruby_indent_keywords)
-    let ind = msl_ind + &sw
+    let ind = msl_ind + shiftwidth()
     if s:Match(lnum, s:end_end_regex)
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
     return ind
   endif
@@ -517,7 +517,7 @@ function GetRubyIndent(...)
   " closing bracket, indent one extra level.
   if s:Match(lnum, s:non_bracket_continuation_regex) && !s:Match(lnum, '^\s*\([\])}]\|end\)')
     if lnum == p_lnum
-      let ind = msl_ind + &sw
+      let ind = msl_ind + shiftwidth()
     else
       let ind = msl_ind
     endif

--- a/runtime/indent/sass.vim
+++ b/runtime/indent/sass.vim
@@ -29,9 +29,9 @@ function! GetSassIndent()
   let indent = indent(lnum)
   let cindent = indent(v:lnum)
   if line !~ s:property && line !~ s:extend && cline =~ s:property
-    return indent + &sw
+    return indent + shiftwidth()
   "elseif line =~ s:property && cline !~ s:property
-    "return indent - &sw
+    "return indent - shiftwidth()
   else
     return -1
   endif

--- a/runtime/indent/sdl.vim
+++ b/runtime/indent/sdl.vim
@@ -46,17 +46,17 @@ function! GetSDLIndent()
   if (getline(lnum) =~? '^\s*\(start\|state\|system\|package\|connection\|channel\|alternative\|macro\|operator\|newtype\|select\|substructure\|decision\|generator\|refinement\|service\|method\|exceptionhandler\|asntype\|syntype\|value\|(.*):\|\(priority\s\+\)\=input\|provided\)'
     \ || getline(lnum) =~? virtuality . '\(process\|procedure\|block\|object\)')
     \ && getline(lnum) !~? 'end[[:alpha:]]\+;$'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   " Subtract a 'shiftwidth' after states
   if getline(lnum) =~? '^\s*\(stop\|return\>\|nextstate\)'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   " Subtract a 'shiftwidth' on on end (uncompleted line)
   if getline(v:lnum) =~? '^\s*end\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   " Put each alternatives where the corresponding decision was

--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -28,7 +28,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 function s:buffer_shiftwidth()
-  return &shiftwidth
+  return shiftwidth()
 endfunction
 
 let s:sh_indent_defaults = {

--- a/runtime/indent/sml.vim
+++ b/runtime/indent/sml.vim
@@ -115,9 +115,9 @@ function! GetSMLIndent()
 
 	" Return double 'shiftwidth' after lines matching:
 	if lline =~ '^\s*|.*=>\s*$'
-		return ind + &sw + &sw
+		return ind + shiftwidth() * 2
 	elseif lline =~ '^\s*val\>.*=\s*$'
-		return ind + &sw
+		return ind + shiftwidth()
 	endif
 
   let line = getline(v:lnum)
@@ -157,7 +157,7 @@ function! GetSMLIndent()
 		if lastModule == -1
 			return 0
 		else
-			return lastModule + &sw
+			return lastModule + shiftwidth()
 		endif
 
 	" Indent lines starting with '|' from matching 'case', 'handle'
@@ -172,7 +172,7 @@ function! GetSMLIndent()
 		if switchLine =~ '\<case\>'
 			return col(".") + 2
 		elseif switchLine =~ '\<handle\>'
-			return switchLineIndent + &sw
+			return switchLineIndent + shiftwidth()
 		elseif switchLine =~ '\<datatype\>'
 			call search('=')
 			return col(".") - 1
@@ -184,7 +184,7 @@ function! GetSMLIndent()
   " Indent if last line ends with 'sig', 'struct', 'let', 'then', 'else',
   " 'in'
   elseif lline =~ '\<\(sig\|struct\|let\|in\|then\|else\)\s*$'
-		let ind = ind + &sw
+		let ind = ind + shiftwidth()
 
   " Indent if last line ends with 'of', align from 'case'
   elseif lline =~ '\<\(of\)\s*$'
@@ -199,14 +199,14 @@ function! GetSMLIndent()
 
 	" Indent if last line starts with 'fun', 'case', 'fn'
 	elseif lline =~ '^\s*\(fun\|fn\|case\)\>'
-		let ind = ind + &sw
+		let ind = ind + shiftwidth()
 
 	endif
 
 	" Don't indent 'let' if last line started with 'fun', 'fn'
 	if line =~ '^\s*let\>'
 		if lline =~ '^\s*\(fun\|fn\)'
-			let ind = ind - &sw
+			let ind = ind - shiftwidth()
 		endif
   endif
 

--- a/runtime/indent/sqlanywhere.vim
+++ b/runtime/indent/sqlanywhere.vim
@@ -147,7 +147,7 @@ function! s:CheckToIgnoreRightParan( prev_lnum, num_levels )
     endwhile
 
     " Fallback - just move back one
-    " return a:prev_indent - &sw
+    " return a:prev_indent - shiftwidth()
     return ignore_paran
 endfunction
 
@@ -166,7 +166,7 @@ function! s:GetStmtStarterIndent( keyword, curr_lnum )
     let lnum  = a:curr_lnum
 
     " Default - reduce indent by 1
-    let ind = indent(a:curr_lnum) - &sw
+    let ind = indent(a:curr_lnum) - shiftwidth()
 
     if a:keyword =~? 'end'
         exec 'normal! ^'
@@ -230,7 +230,7 @@ function! s:ModuloIndent(ind)
     let ind = a:ind
 
     if ind > 0
-        let modulo = ind % &shiftwidth
+        let modulo = ind % shiftwidth()
 
         if modulo > 0
             let ind = ind - modulo
@@ -291,7 +291,7 @@ function! GetSQLIndent()
     " where END IF, END, should decrease the indent.
     if prevline =~? s:SQLBlockStart
         " Move indent in
-        let ind = ind + &sw
+        let ind = ind + shiftwidth()
         " echom 'prevl - SQLBlockStart - indent ' . ind . '  line: ' . prevline
     elseif prevline =~ '[()]'
         if prevline =~ '('
@@ -308,7 +308,7 @@ function! GetSQLIndent()
         if num_unmatched_left > 0
             " There is a open left paranethesis
             " increase indent
-            let ind = ind + ( &sw * num_unmatched_left )
+            let ind = ind + ( shiftwidth() * num_unmatched_left )
         elseif num_unmatched_right > 0
             " if it is an unbalanced paranethesis only unindent if
             " it was part of a command (ie create table(..)  )
@@ -323,7 +323,7 @@ function! GetSQLIndent()
             endif
 
             if (num_unmatched_right - ignore) > 0
-                let ind = ind - ( &sw * (num_unmatched_right - ignore) )
+                let ind = ind - ( shiftwidth() * (num_unmatched_right - ignore) )
             endif
 
         endif
@@ -339,12 +339,12 @@ function! GetSQLIndent()
     if line =~? '^\s*els'
         " Any line when you type else will automatically back up one
         " ident level  (ie else, elseif, elsif)
-        let ind = ind - &sw
+        let ind = ind - shiftwidth()
         " echom 'curr - else - indent ' . ind
     elseif line =~? '^\s*end\>'
         let ind = s:GetStmtStarterIndent('end', v:lnum)
         " General case for end
-        " let ind = ind - &sw
+        " let ind = ind - shiftwidth()
         " echom 'curr - end - indent ' . ind
     elseif line =~? '^\s*when\>'
         let ind = s:GetStmtStarterIndent('when', v:lnum)
@@ -352,7 +352,7 @@ function! GetSQLIndent()
         " clause, do not change the indent level, since these
         " statements do not have a corresponding END statement.
         " if stmt_starter =~? 'case'
-        "    let ind = ind - &sw
+        "    let ind = ind - shiftwidth()
         " endif
         " elseif line =~ '^\s*)\s*;\?\s*$'
         " elseif line =~ '^\s*)'
@@ -371,14 +371,14 @@ function! GetSQLIndent()
         " let num_unmatched_right  = s:CountUnbalancedParan( line, ')' )
         " if num_unmatched_right > 0
         " elseif strpart( line, strlen(line)-1, 1 ) =~ ')'
-        " let ind = ind - &sw
+        " let ind = ind - shiftwidth()
         if line =~ '^\s*)'
             " let ignore = ignore + 1
             " echom 'curr - begins ) unbalanced ignore: ' . ignore
         endif
 
         if (num_unmatched_right - ignore) > 0
-            let ind = ind - ( &sw * (num_unmatched_right - ignore) )
+            let ind = ind - ( shiftwidth() * (num_unmatched_right - ignore) )
         endif
         " endif
     endif

--- a/runtime/indent/systemverilog.vim
+++ b/runtime/indent/systemverilog.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:    SystemVerilog
 " Maintainer:  kocha <kocha.lsifrontend@gmail.com>
-" Last Change: 12-Aug-2013. 
+" Last Change: 25-Jan-2016. 
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -29,7 +29,7 @@ function SystemVerilogIndent()
   if exists('b:systemverilog_indent_width')
     let offset = b:systemverilog_indent_width
   else
-    let offset = &sw
+    let offset = shiftwidth()
   endif
   if exists('b:systemverilog_indent_modules')
     let indent_modules = offset

--- a/runtime/indent/tcl.vim
+++ b/runtime/indent/tcl.vim
@@ -56,7 +56,7 @@ function GetTclIndent()
   if line =~ '^\s*\*'
     return cindent(v:lnum)
   elseif line =~ '^\s*}'
-    return indent(v:lnum) - &sw
+    return indent(v:lnum) - shiftwidth()
   endif
 
   let pnum = s:prevnonblanknoncomment(v:lnum - 1)
@@ -64,11 +64,11 @@ function GetTclIndent()
     return 0
   endif
 
-  let ind = indent(pnum) + s:count_braces(pnum, 1) * &sw
+  let ind = indent(pnum) + s:count_braces(pnum, 1) * shiftwidth()
 
   let pline = getline(pnum)
   if pline =~ '}\s*$'
-    let ind -= (s:count_braces(pnum, 0) - (pline =~ '^\s*}' ? 1 : 0)) * &sw
+    let ind -= (s:count_braces(pnum, 0) - (pline =~ '^\s*}' ? 1 : 0)) * shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/tcsh.vim
+++ b/runtime/indent/tcsh.vim
@@ -32,17 +32,17 @@ function TcshGetIndent()
     let ind = indent(lnum)
     let line = getline(lnum)
     if line =~ '\v^\s*%(while|foreach)>|^\s*%(case\s.*:|default:|else)\s*$|%(<then|\\)$'
-	let ind = ind + &sw
+	let ind = ind + shiftwidth()
     endif
 
     if line =~ '\v^\s*breaksw>'
-	let ind = ind - &sw
+	let ind = ind - shiftwidth()
     endif
 
     " Subtract indent if current line has on end, endif, case commands
     let line = getline(v:lnum)
     if line =~ '\v^\s*%(else|end|endif)\s*$'
-	let ind = ind - &sw
+	let ind = ind - shiftwidth()
     endif
 
     return ind

--- a/runtime/indent/teraterm.vim
+++ b/runtime/indent/teraterm.vim
@@ -22,18 +22,6 @@ if exists("*GetTeraTermIndent")
   finish
 endif
 
-" The shiftwidth() function is relatively new.
-" Don't require it to exist.
-if exists('*shiftwidth')
-  function s:sw() abort
-    return shiftwidth()
-  endfunction
-else
-  function s:sw() abort
-    return &shiftwidth
-  endfunction
-endif
-
 function! GetTeraTermIndent(lnum)
   let l:prevlnum = prevnonblank(a:lnum-1)
   if l:prevlnum == 0
@@ -50,15 +38,15 @@ function! GetTeraTermIndent(lnum)
 
   if l:prevl =~ '^\s*if\>.*\<then\s*$'
     " previous line opened a block
-    let l:ind += s:sw()
+    let l:ind += shiftwidth()
   endif
   if l:prevl =~ '^\s*\%(elseif\|else\|do\|until\|while\|for\)\>'
     " previous line opened a block
-    let l:ind += s:sw()
+    let l:ind += shiftwidth()
   endif
   if l:thisl =~ '^\s*\%(elseif\|else\|endif\|enduntil\|endwhile\|loop\|next\)\>'
     " this line closed a block
-    let l:ind -= s:sw()
+    let l:ind -= shiftwidth()
   endif
 
   return l:ind

--- a/runtime/indent/tex.vim
+++ b/runtime/indent/tex.vim
@@ -215,12 +215,12 @@ function! GetTeXIndent() " {{{
     " LH modification : \begin does not always start a line
     " ZYC modification : \end after \begin won't cause wrong indent anymore
     if line =~ '\\begin{.*}' && line !~ g:tex_noindent_env
-        let ind = ind + &sw
+        let ind = ind + shiftwidth()
 
         if g:tex_indent_items
             " Add another sw for item-environments
             if line =~ g:tex_itemize_env
-                let ind = ind + &sw
+                let ind = ind + shiftwidth()
             endif
         endif
     endif
@@ -231,11 +231,11 @@ function! GetTeXIndent() " {{{
         if g:tex_indent_items
             " Remove another sw for item-environments
             if cline =~ g:tex_itemize_env
-                let ind = ind - &sw
+                let ind = ind - shiftwidth()
             endif
         endif
 
-        let ind = ind - &sw
+        let ind = ind - shiftwidth()
     endif
 
     if g:tex_indent_brace
@@ -263,7 +263,7 @@ function! GetTeXIndent() " {{{
             endif
         endfor
 
-        let ind += (sum1 - sum2) * &sw
+        let ind += (sum1 - sum2) * shiftwidth()
     endif
 
     if g:tex_indent_paretheses
@@ -276,12 +276,12 @@ function! GetTeXIndent() " {{{
 
         " '\item' or '\bibitem' itself:
         if cline =~ g:tex_items
-            let ind = ind - &sw
+            let ind = ind - shiftwidth()
         endif
 
         " lines following to '\item' are intented once again:
         if line =~ g:tex_items
-            let ind = ind + &sw
+            let ind = ind + shiftwidth()
         endif
 
     endif

--- a/runtime/indent/tf.vim
+++ b/runtime/indent/tf.vim
@@ -38,14 +38,14 @@ function GetTFIndent()
 	endif
 
 	if line =~ '\(/def.*\\\|/for.*\(%;\s*\)\@\<!\\\)$'
-		let ind = ind + &sw
+		let ind = ind + shiftwidth()
 	elseif line =~ '\(/if\|/else\|/then\)'
 		if line !~ '/endif'
-			let ind = ind + &sw
+			let ind = ind + shiftwidth()
 		endif
 	elseif line =~ '/while'
 		if line !~ '/done'
-			let ind = ind + &sw
+			let ind = ind + shiftwidth()
 		endif
 	endif
 
@@ -53,11 +53,11 @@ function GetTFIndent()
 
 	if line =~ '\(/else\|/endif\|/then\)'
 		if line !~ '/if'
-			let ind = ind - &sw
+			let ind = ind - shiftwidth()
 		endif
 	elseif line =~ '/done'
 		if line !~ '/while'
-			let ind = ind - &sw
+			let ind = ind - shiftwidth()
 		endif
 	endif
 

--- a/runtime/indent/tilde.vim
+++ b/runtime/indent/tilde.vim
@@ -25,11 +25,11 @@ function GetTildeIndent(lnum)
 	endif
 
 	if getline(v:lnum) =~ '^\s*\~\(endif\|else\|elseif\|end\)\>'
-		return indent(v:lnum) - &sw
+		return indent(v:lnum) - shiftwidth()
 	endif
 
 	if getline(plnum) =~ '^\s*\~\(if\|foreach\|foreach_row\|xml_loop\|file_loop\|file_write\|file_append\|imap_loopsections\|imap_index\|imap_list\|ldap_search\|post_loopall\|post_loop\|file_loop\|sql_loop_num\|sql_dbmsselect\|search\|sql_loop\|post\|for\|function_define\|silent\|while\|setvalbig\|mail_create\|systempipe\|mail_send\|dual\|elseif\|else\)\>'
-		return indent(plnum) + &sw
+		return indent(plnum) + shiftwidth()
 	else
 		return -1
 	endif

--- a/runtime/indent/treetop.vim
+++ b/runtime/indent/treetop.vim
@@ -26,12 +26,12 @@ function GetTreetopIndent()
   let line = getline(pnum)
 
   if line =~ '^\s*\%(grammar\|module\|rule\)\>'
-    let ind += &sw
+    let ind += shiftwidth()
   endif
 
   let line = getline(v:lnum)
   if line =~ '^\s*end\>'
-    let ind -= &sw
+    let ind -= shiftwidth()
   end
 
   retur ind

--- a/runtime/indent/vb.vim
+++ b/runtime/indent/vb.vim
@@ -49,26 +49,26 @@ fun! VbGetIndent(lnum)
 
     " Add
     if previous_line =~? '^\s*\<\(begin\|\%(\%(private\|public\|friend\)\s\+\)\=\%(function\|sub\|property\)\|select\|case\|default\|if\|else\|elseif\|do\|for\|while\|enum\|with\)\>'
-	let ind = ind + &sw
+	let ind = ind + shiftwidth()
     endif
 
     " Subtract
     if this_line =~? '^\s*\<end\>\s\+\<select\>'
 	if previous_line !~? '^\s*\<select\>'
-	    let ind = ind - 2 * &sw
+	    let ind = ind - 2 * shiftwidth()
 	else
 	    " this case is for an empty 'select' -- 'end select'
 	    " (w/o any case statements) like:
 	    "
 	    " select case readwrite
 	    " end select
-	    let ind = ind - &sw
+	    let ind = ind - shiftwidth()
 	endif
     elseif this_line =~? '^\s*\<\(end\|else\|elseif\|until\|loop\|next\|wend\)\>'
-	let ind = ind - &sw
+	let ind = ind - shiftwidth()
     elseif this_line =~? '^\s*\<\(case\|default\)\>'
 	if previous_line !~? '^\s*\<select\>'
-	    let ind = ind - &sw
+	    let ind = ind - shiftwidth()
 	endif
     endif
 

--- a/runtime/indent/verilog.vim
+++ b/runtime/indent/verilog.vim
@@ -38,7 +38,7 @@ function GetVerilogIndent()
   if exists('b:verilog_indent_width')
     let offset = b:verilog_indent_width
   else
-    let offset = &sw
+    let offset = shiftwidth()
   endif
   if exists('b:verilog_indent_modules')
     let indent_modules = offset

--- a/runtime/indent/vhdl.vim
+++ b/runtime/indent/vhdl.vim
@@ -114,9 +114,9 @@ function GetVHDLindent()
       return ind2 + m
     else
       if g:vhdl_indent_genportmap
-        return ind2 + stridx(prevs_noi, '(') + &sw
+        return ind2 + stridx(prevs_noi, '(') + shiftwidth()
       else
-        return ind2 + &sw
+        return ind2 + shiftwidth()
       endif
     endif
   endif
@@ -128,7 +128,7 @@ function GetVHDLindent()
     if g:vhdl_indent_rhsassign
       return ind2 + matchend(prevs_noi, '<=\s*\ze.')
     else
-      return ind2 + &sw
+      return ind2 + shiftwidth()
     endif
   endif
 
@@ -218,12 +218,12 @@ function GetVHDLindent()
       let ps = getline(pn)
 
       if (ps =~? s:NC.'\<begin\>')
-        return indent(pn) - &sw
+        return indent(pn) - shiftwidth()
       endif
     endwhile
 
     if (pn == 0)
-      return ind - &sw
+      return ind - shiftwidth()
     else
       return indent(pn)
     endif
@@ -237,7 +237,7 @@ function GetVHDLindent()
     " keyword: "type"
     let s3 = s:NC.s:NE.'\<type\>'
     if curs !~? s3.'.*'.s:NC.'\<\%(record\|units\)\>.*'.s:ES && prevs =~? s3
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
     return ind
   endif
@@ -282,7 +282,7 @@ function GetVHDLindent()
   " removed:  "begin", "case", "elsif", "if", "loop", "record", "units", "while"
   " where:    anywhere in previous line
   if prevs =~? s:NC.s:NE.'\<\%(block\|process\)\>'
-    return ind + &sw
+    return ind + shiftwidth()
   endif
 
   " indent:   +sw
@@ -290,7 +290,7 @@ function GetVHDLindent()
   " removed:  "component", "for", "when", "with"
   " where:    start of previous line
   if prevs =~? '^\s*\%(architecture\|configuration\|entity\|package\)\>'
-    return ind + &sw
+    return ind + shiftwidth()
   endif
 
   " indent:   +sw
@@ -298,7 +298,7 @@ function GetVHDLindent()
   " removed:  "generate", "is", "=>"
   " where:    end of previous line
   if prevs =~? s:NC.'\<select'.s:ES
-    return ind + &sw
+    return ind + shiftwidth()
   endif
 
   " indent:   +sw
@@ -310,7 +310,7 @@ function GetVHDLindent()
   " where:    end of previous line
   " _note_:   indent allowed to leave this filter
   if prevs =~? s:NC.'\%(\<begin\>\|'.s:NE.'\<\%(loop\|record\|units\)\>\)' || prevs =~? '^\s*\%(component\|else\|for\)\>' || prevs =~? s:NC.'\%('.s:NE.'\<generate\|\<\%(is\|then\)\|=>\)'.s:ES
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   " ****************************************************************************************
@@ -322,7 +322,7 @@ function GetVHDLindent()
     if prevs =~? s:NC.'\<is'.s:ES
       return ind
     elseif prevs !~? s4
-      return ind - &sw
+      return ind - shiftwidth()
     else
       return ind2
     endif
@@ -336,7 +336,7 @@ function GetVHDLindent()
     if prevs =~? '^\s*\%(elsif\|'.s5.'\)'
       return ind
     else
-      return ind - &sw
+      return ind - shiftwidth()
     endif
   endif
 
@@ -367,9 +367,9 @@ function GetVHDLindent()
         "where:    start of previous non-comment line
         if m == 1
           if ps =~? '^\s*end\s\+case\>'
-            return indent(pn) - 2 * &sw
+            return indent(pn) - 2 * shiftwidth()
           elseif ps =~? '^\s*when\>'
-            return indent(pn) - &sw
+            return indent(pn) - shiftwidth()
           elseif ps =~? '^\s*case\>'
             return indent(pn)
           endif
@@ -385,14 +385,14 @@ function GetVHDLindent()
       let pn = prevnonblank(pn - 1)
       let ps = getline(pn)
     endwhile
-    return ind - &sw
+    return ind - shiftwidth()
   endif
 
   " indent:   -sw
   " keyword:  ")"
   " where:    start of current line
   if curs =~ '^\s*)'
-    return ind - &sw
+    return ind - shiftwidth()
   endif
 
   " indent:   0
@@ -407,7 +407,7 @@ function GetVHDLindent()
   " where:    start of current line
   "if curs =~? '^\s*end\s\+\w\+\>'
   if curs =~? '^\s*end\%(\s\|;'.s:ES.'\)'
-    return ind - &sw
+    return ind - shiftwidth()
   endif
 
   " ****************************************************************************************

--- a/runtime/indent/vim.vim
+++ b/runtime/indent/vim.vim
@@ -58,19 +58,19 @@ function GetVimIndentIntern()
     if exists("g:vim_indent_cont")
       let ind = ind + g:vim_indent_cont
     else
-      let ind = ind + &sw * 3
+      let ind = ind + shiftwidth() * 3
     endif
   elseif prev_text =~ '^\s*aug\%[roup]' && prev_text !~ '^\s*aug\%[roup]\s*!\=\s\+END'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   else
     " A line starting with :au does not increment/decrement indent.
     if prev_text !~ '^\s*au\%[tocmd]'
       let i = match(prev_text, '\(^\||\)\s*\(if\|wh\%[ile]\|for\|try\|cat\%[ch]\|fina\%[lly]\|fu\%[nction]\|el\%[seif]\)\>')
       if i >= 0
-	let ind += &sw
+	let ind += shiftwidth()
 	if strpart(prev_text, i, 1) == '|' && has('syntax_items')
 	      \ && synIDattr(synID(lnum, i, 1), "name") =~ '\(Comment\|String\)$'
-	  let ind -= &sw
+	  let ind -= shiftwidth()
 	endif
       endif
     endif
@@ -82,7 +82,7 @@ function GetVimIndentIntern()
   let i = match(prev_text, '[^\\]|\s*\(ene\@!\)')
   if i > 0 && prev_text !~ '^\s*au\%[tocmd]'
     if !has('syntax_items') || synIDattr(synID(lnum, i + 2, 1), "name") !~ '\(Comment\|String\)$'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
   endif
 
@@ -90,7 +90,7 @@ function GetVimIndentIntern()
   " Subtract a 'shiftwidth' on a :endif, :endwhile, :catch, :finally, :endtry,
   " :endfun, :else and :augroup END.
   if cur_text =~ '^\s*\(ene\@!\|cat\|fina\|el\|aug\%[roup]\s*!\=\s\+[eE][nN][dD]\)'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/xf86conf.vim
+++ b/runtime/indent/xf86conf.vim
@@ -26,11 +26,11 @@ function GetXF86ConfIndent()
   let ind = indent(lnum)
 
   if getline(lnum) =~? '^\s*\(Sub\)\=Section\>'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
 
   if getline(v:lnum) =~? '^\s*End\(Sub\)\=Section\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/xinetd.vim
+++ b/runtime/indent/xinetd.vim
@@ -47,8 +47,8 @@ function GetXinetdIndent()
     return 0
   endif
 
-  return indent(pnum) + s:count_braces(pnum, 1) * &sw
-        \ - s:count_braces(v:lnum, 0) * &sw
+  return indent(pnum) + s:count_braces(pnum, 1) * shiftwidth()
+        \ - s:count_braces(v:lnum, 0) * shiftwidth()
 endfunction
 
 let &cpo = s:keepcpo

--- a/runtime/indent/xml.vim
+++ b/runtime/indent/xml.vim
@@ -67,7 +67,7 @@ endfun
 fun! <SID>XmlIndentSum(lnum, style, add)
     let line = getline(a:lnum)
     if a:style == match(line, '^\s*</')
-	return (&sw *
+	return (shiftwidth() *
 	\  (<SID>XmlIndentWithPattern(line, b:xml_indent_open)
 	\ - <SID>XmlIndentWithPattern(line, b:xml_indent_close)
 	\ - <SID>XmlIndentWithPattern(line, '.\{-}/>'))) + a:add

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -24,14 +24,6 @@ if exists('*GetYAMLIndent')
     finish
 endif
 
-if exists('*shiftwidth')
-    let s:shiftwidth = function('shiftwidth')
-else
-    function s:shiftwidth()
-        return &shiftwidth
-    endfunction
-endif
-
 function s:FindPrevLessIndentedLine(lnum, ...)
     let prevlnum = prevnonblank(a:lnum-1)
     let curindent = a:0 ? a:1 : indent(a:lnum)
@@ -97,7 +89,7 @@ function GetYAMLIndent(lnum)
         "
         " - |-
         "     Block scalar without indentation indicator
-        return previndent+s:shiftwidth()
+        return previndent+shiftwidth()
     elseif prevline =~# '\v[:-]\ [|>]%(\d+[+\-]?|[+\-]?\d+)%(\#.*|\s*)$'
         " - |+2
         "   block scalar with indentation indicator
@@ -130,7 +122,7 @@ function GetYAMLIndent(lnum)
     elseif prevline =~# s:mapkeyregex
         " Mapping with: value
         "     that is multiline scalar
-        return previndent+s:shiftwidth()
+        return previndent+shiftwidth()
     endif
     return previndent
 endfunction

--- a/runtime/indent/zimbu.vim
+++ b/runtime/indent/zimbu.vim
@@ -74,9 +74,9 @@ func GetZimbuIndent(lnum)
 	  \ . " synIDattr(synID(line('.'), col('.'), 1), 'name')"
 	  \ . " =~ '\\(Comment\\|String\\|Char\\)$'")
       if pp > 0
-	return indent(prevLnum) + &sw
+	return indent(prevLnum) + shiftwidth()
       endif
-      return indent(prevLnum) + &sw * 2
+      return indent(prevLnum) + shiftwidth() * 2
     endif
     if plnumstart == p
       return indent(prevLnum)
@@ -102,13 +102,13 @@ func GetZimbuIndent(lnum)
   endif
 
   if prevline =~ '^\s*\(IF\|\|ELSEIF\|ELSE\|GENERATE_IF\|\|GENERATE_ELSEIF\|GENERATE_ELSE\|WHILE\|REPEAT\|TRY\|CATCH\|FINALLY\|FOR\|DO\|SWITCH\|CASE\|DEFAULT\|FUNC\|VIRTUAL\|ABSTRACT\|DEFINE\|REPLACE\|FINAL\|PROC\|MAIN\|NEW\|ENUM\|CLASS\|INTERFACE\|BITS\|MODULE\|SHARED\)\>'
-    let plindent += &sw
+    let plindent += shiftwidth()
   endif
   if thisline =~ '^\s*\(}\|ELSEIF\>\|ELSE\>\|CATCH\|FINALLY\|GENERATE_ELSEIF\>\|GENERATE_ELSE\>\|UNTIL\>\)'
-    let plindent -= &sw
+    let plindent -= shiftwidth()
   endif
   if thisline =~ '^\s*\(CASE\>\|DEFAULT\>\)' && prevline !~ '^\s*SWITCH\>'
-    let plindent -= &sw
+    let plindent -= shiftwidth()
   endif
 
   " line up continued comment that started after some code


### PR DESCRIPTION
With `set shiftwidth=0`, `gg=G` in `filetype=vim` buffer will result in removing all indents.
Because `indent/vim.vim` doesn't use `shiftwidth()` instead of accessing `&sw` directly.
