### PR TITLE
compile failed with GETTEXT_DLL defined only.

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4461,12 +4461,18 @@ iconv_enabled(verbose)
 
     /* The iconv DLL file goes under different names, try them all. */
     hIconvDLL = vimLoadLib(DYNAMIC_ICONV_DLL);
+#   ifdef DYNAMIC_ICONV_DLL_ALT1
     if (hIconvDLL == 0)
 	hIconvDLL = vimLoadLib(DYNAMIC_ICONV_DLL_ALT1);
+#   endif
+#   ifdef DYNAMIC_ICONV_DLL_ALT2
     if (hIconvDLL == 0)
 	hIconvDLL = vimLoadLib(DYNAMIC_ICONV_DLL_ALT2);
+#   endif
+#   ifdef DYNAMIC_ICONV_DLL_ALT3
     if (hIconvDLL == 0)
 	hIconvDLL = vimLoadLib(DYNAMIC_ICONV_DLL_ALT3);
+#   endif
 
     if (hIconvDLL != 0)
 	hMsvcrtDLL = vimLoadLib(DYNAMIC_MSVCRT_DLL);

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -501,8 +501,10 @@ dyn_libintl_init()
 	return 1;
     /* Load gettext library (libintl.dll) */
     hLibintlDLL = vimLoadLib(GETTEXT_DLL);
+# ifdef GETTEXT_DLL_ALT
     if (!hLibintlDLL)
 	hLibintlDLL = vimLoadLib(GETTEXT_DLL_ALT);
+# endif
     if (!hLibintlDLL)
     {
 	if (p_verbose > 0)


### PR DESCRIPTION
### Problem

On, Windows, if defined GETTEXT_DLL only, GETTEXT_DLL_ALT is never
defined, and it causes copmpile error.  There are same problem about
DYNAMIC_ICONV_DLL.
### Solution

Check existence of ALT macros when use it.

(fixes #589)
