### PR TITLE
head filename modifier: go beyond the current directory

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -868,7 +868,10 @@ These modifiers can be given, in this order:
 		When the file name is an absolute path (starts with "/" for
 		Unix; "x:\" for MS-DOS, WIN32, OS/2; "drive:" for Amiga), that
 		part is not removed.  When there is no head (path is relative
-		to current directory) the result is empty.
+		to current directory) it will expand the current directory,
+		thus "expand('%:h:h')" always returns the full path of the
+		parent directory even if the current directory is set to what
+		"%:h" expands to.
 	:t	Tail of the file name (last component of the name).  Must
 		precede any :r or :e.
 	:r	Root of the file name (the last extension removed).  When

--- a/src/eval.c
+++ b/src/eval.c
@@ -25824,6 +25824,17 @@ repeat:
     {
 	valid |= VALID_HEAD;
 	*usedlen += 2;
+        if (*fnamep != NULL && **fnamep == '.' && *fnamelen == 1)
+        {
+            /* fnamep was already set to '.', try to move one directory up */
+            *fnamep = FullName_save(*fnamep, FALSE);
+            vim_free(*bufp);
+            if (*fnamep == NULL)
+                return -1;
+            p = *bufp = *fnamep;
+            tail = gettail(*fnamep);
+            *fnamelen = (int)STRLEN(*fnamep);
+        }
 	s = get_past_head(*fnamep);
 	while (tail > s && after_pathsep(s, tail))
 	    mb_ptr_back(*fnamep, tail);

--- a/src/testdir/test_expand.vim
+++ b/src/testdir/test_expand.vim
@@ -46,7 +46,7 @@ func Test_head()
   let dir = getcwd()
   " go beyond current directory
   let parentDir = expand('%:h:h')
-  let parentDir_ = split(dir, '/')
+  let parentDir_ = split(dir, '/', 1)
   call remove(parentDir_, len(parentDir_) - 1)
-  call assert_equal(parentDir, '/' . join(parentDir_, '/'))
+  call assert_equal(parentDir, join(parentDir_, '/'))
 endfunc

--- a/src/testdir/test_expand.vim
+++ b/src/testdir/test_expand.vim
@@ -39,3 +39,14 @@ func Test_with_tilde()
   call delete('Xdir ~ dir', 'd')
   call assert_false(isdirectory('Xdir ~ dir'))
 endfunc
+
+func Test_head()
+  let dir = expand('%:h:p')
+  exe 'cd ' . fnameescape(dir)
+  let dir = getcwd()
+  " go beyond current directory
+  let parentDir = expand('%:h:h')
+  let parentDir_ = split(dir, '/')
+  call remove(parentDir_, len(parentDir_) - 1)
+  call assert_equal(parentDir, '/' . join(parentDir_, '/'))
+endfunc


### PR DESCRIPTION
If the current path is set to "%:h" (like with the 'autochdir' setting),
the "%:h:h" will now expand to the full path of the parent directory,
rather than just return ".".

The pull request contains a test, but I am not sure if it will succeed on a windows machine.
