### PR TITLE
fix broken ifeq/endif

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -685,7 +685,6 @@ OBJ += $(OUTDIR)/netbeans.o
 LIB += -lwsock32
 endif
 endif
-endif
 
 ifeq ($(CHANNEL),yes)
 OBJ += $(OUTDIR)/channel.o


### PR DESCRIPTION
after [7.4.496](https://github.com/vim/vim/commit/4f7e821f26019c14f4470deb0867c919548d5cd5)
See the git blame. https://github.com/vim/vim/blame/master/src/Make_cyg_ming.mak#L685
i get failure on mingw build.
