### PR TITLE
javascript: remove C-indenting to resolve ASI issues 

### DIFF
--- a/runtime/indent/javascript.vim
+++ b/runtime/indent/javascript.vim
@@ -9,10 +9,4 @@ if exists("b:did_indent")
 endif
 let b:did_indent = 1
 
-" C indenting is not too bad.
-setlocal cindent
-setlocal cinoptions+=j1,J1
-setlocal cinkeys-=0#
-setlocal cinkeys+=0]
-
 let b:undo_indent = "setl cin<"


### PR DESCRIPTION
Not necessarily opposed to using `cindent`,  however it is currently quite debilitating for [those of us that use ASI](https://github.com/feross/standard).

Example:

``` javascript
/* ex: set cindent: */

function () {
  var a = b
    // new line begins here
  // instead of here
}
```

If a semi-colon is inserted,  then the indentation works as expected.

This PR might not be the best solution,  but it at least resolves the situation.
Happy to close if another solution exists.
