### PR TITLE
Fix a typo in runtime/doc/windows.txt

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -721,7 +721,7 @@ can also get to them with the buffer list commands, like ":bnext".
 							*:bufdo*
 :[range]bufdo[!] {cmd}	Execute {cmd} in each buffer in the buffer list or if
 			[range] is given only for buffers for which their
-			buffer numer is in the [range].  It works like doing
+			buffer number is in the [range].  It works like doing
 			this: >
 				:bfirst
 				:{cmd}


### PR DESCRIPTION
Noticed a spelling mistake -
`numer` > `number`
