### PR TITLE
Adding RelLineAbove and RelLineBelow highlight groups

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4860,6 +4860,12 @@ LineNr		Line number for ":number" and ":#" commands, and when 'number'
 							*hl-CursorLineNr*
 CursorLineNr	Like LineNr when 'cursorline' or 'relativenumber' is set for
 		the cursor line.
+							*hl-RelLineAbove*
+RelLineAbove	Like LineNr when 'relativenumber' is set, but applies only to
+		line numbers above the cursor line.
+							*hl-RelLineBelow*
+RelLineBelow	Like LineNr when 'relativenumber' is set, but applies only to
+		line numbers below the cursor line.
 							*hl-MatchParen*
 MatchParen	The character under the cursor or just before it, if it
 		is a paired bracket, and its match. |pi_paren.txt|

--- a/src/option.c
+++ b/src/option.c
@@ -475,9 +475,9 @@ struct vimoption
 #if defined(FEAT_DIFF) || defined(FEAT_FOLDING) || defined(FEAT_SPELL) \
 	|| defined(FEAT_VERTSPLIT) || defined(FEAT_CLIPBOARD) \
 	|| defined(FEAT_INS_EXPAND) || defined(FEAT_SYN_HL) || defined(FEAT_CONCEAL)
-# define HIGHLIGHT_INIT "8:SpecialKey,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn"
+# define HIGHLIGHT_INIT "8:SpecialKey,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,a:RelLineAbove,b:RelLineBelow,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn"
 #else
-# define HIGHLIGHT_INIT "8:SpecialKey,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,t:Title,v:Visual,w:WarningMsg,W:WildMenu,>:SignColumn,*:TabLine,#:TabLineSel,_:TabLineFill"
+# define HIGHLIGHT_INIT "8:SpecialKey,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,a:RelLineAbove,b:RelLineBelow,r:Question,s:StatusLine,S:StatusLineNC,t:Title,v:Visual,w:WarningMsg,W:WildMenu,>:SignColumn,*:TabLine,#:TabLineSel,_:TabLineFill"
 #endif
 
 /*

--- a/src/screen.c
+++ b/src/screen.c
@@ -3724,6 +3724,16 @@ win_line(
 		    if ((wp->w_p_cul || wp->w_p_rnu)
 						 && lnum == wp->w_cursor.lnum)
 			char_attr = hl_attr(HLF_CLN);
+
+                    if (wp->w_p_rnu && (lnum < wp->w_cursor.lnum))
+                        /* high light relative above (<) cursor */
+                        char_attr = hl_combine_attr(
+                                char_attr, hl_attr(HLF_RNA));
+
+                    if (wp->w_p_rnu && (lnum > wp->w_cursor.lnum))
+                        /* high light relative below (>) cursor */
+                        char_attr = hl_combine_attr(
+                                char_attr, hl_attr(HLF_RNB));
 #endif
 		}
 	    }

--- a/src/vim.h
+++ b/src/vim.h
@@ -1339,6 +1339,8 @@ typedef enum
     , HLF_CM	    /* Mode (e.g., "-- INSERT --") */
     , HLF_N	    /* line number for ":number" and ":#" commands */
     , HLF_CLN	    /* current line number */
+    , HLF_RNA	    /* relative line number above current line */
+    , HLF_RNB	    /* relative line number below current line */
     , HLF_R	    /* return to continue message and yes/no questions */
     , HLF_S	    /* status lines */
     , HLF_SNC	    /* status lines of not-current windows */
@@ -1376,8 +1378,8 @@ typedef enum
 /* The HL_FLAGS must be in the same order as the HLF_ enums!
  * When changing this also adjust the default for 'highlight'. */
 #define HL_FLAGS {'8', '@', 'd', 'e', 'h', 'i', 'l', 'm', 'M', \
-		  'n', 'N', 'r', 's', 'S', 'c', 't', 'v', 'V', 'w', 'W', \
-		  'f', 'F', 'A', 'C', 'D', 'T', '-', '>', \
+		  'n', 'N', 'a', 'b', 'r', 's', 'S', 'c', 't', 'v', 'V', 'w', \
+		  'W', 'f', 'F', 'A', 'C', 'D', 'T', '-', '>', \
 		  'B', 'P', 'R', 'L', \
 		  '+', '=', 'x', 'X', '*', '#', '_', '!', '.', 'o'}
 


### PR DESCRIPTION
I wanted my relative line numbers to be colored differently above and below the
cursor line.  I believe a highlight group applied conditionally is the correct
way to achieve this.

This is my first foray in to the vim sources, so please let me know if I missed
the mark or could do things differently/better.
