### PR TITLE
fix groovy multi-line comment highlight bug

### DIFF
--- a/runtime/syntax/groovy.vim
+++ b/runtime/syntax/groovy.vim
@@ -256,7 +256,7 @@ syn region  groovyString          start=+'+ end=+'+ end=+$+ contains=groovySpeci
 syn region  groovyString          start=+"""+ end=+"""+ contains=groovySpecialChar,groovySpecialError,@Spell,groovyELExpr
 syn region  groovyString          start=+'''+ end=+'''+ contains=groovySpecialChar,groovySpecialError,@Spell
 " regex string
-syn region groovyString           start='/[^/]'  end='/' contains=groovySpecialChar,groovyRegexChar,groovyELExpr
+syn region groovyString           start='/[^*/]'  end='/' contains=groovySpecialChar,groovyRegexChar,groovyELExpr
 " syn region groovyELExpr start=+${+ end=+}+ keepend contained
 syn match groovyELExpr /\${.\{-}}/ contained
 syn match groovyELExpr /\$[a-zA-Z_][a-zA-Z0-9_.]*/ contained


### PR DESCRIPTION
exclude '/*' in addition to '//' in groovy slashy string start regex

According to this [SO](http://stackoverflow.com/questions/26518938/vim-wrong-syntax-highlighting-in-groovy) syntax maintainer was contacted, but doesn't look like it was ever fixed... fix is pretty simple so just submitting as a PR
