### PR TITLE
test_charsearch: Fix syntax of last setcharsearch() call

### DIFF
--- a/src/testdir/test_charsearch.in
+++ b/src/testdir/test_charsearch.in
@@ -14,7 +14,8 @@ fip:call setcharsearch(csave)
 /^Z
 ylfep:call setcharsearch({'char': 'k'})
 ;p:call setcharsearch({'forward': 0})
-$;p:call setcharseearch({'until'}: 1})
+$;p:call setcharsearch({'until': 1})
+:set cpo-=;
 ;;p:
 :/^X/,$w! test.out
 :qa!

--- a/src/testdir/test_charsearch.ok
+++ b/src/testdir/test_charsearch.ok
@@ -1,3 +1,3 @@
 XabcdeXfghijkeXmnopqreXtuvwxyz
 YabcdeYfghiYjkeYmnopqreYtuvwxyz
-ZabcdeZfghijkZemnokZqretkZvwxyz
+ZabcdeZfghijkZZemnokqretkZvwxyz


### PR DESCRIPTION
The final call to setcharsearch() is both spelled incorrectly and uses
invalid syntax for the dictionary argument.  The expected test output
was incorrectly written according to the observed behavior rather than
expected behavior, which is why this went unnoticed.

Fix the syntax of the call and adjust the expected test output
accordingly.
