### PR TITLE
two FEAT_FLOAT fixes

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -8405,7 +8405,9 @@ static struct fst
     {"range",		1, 3, f_range},
     {"readfile",	1, 3, f_readfile},
     {"reltime",		0, 2, f_reltime},
+#ifdef FEAT_FLOAT
     {"reltimefloat",	1, 1, f_reltimefloat},
+#endif
     {"reltimestr",	1, 1, f_reltimestr},
     {"remote_expr",	2, 3, f_remote_expr},
     {"remote_foreground", 1, 1, f_remote_foreground},

--- a/src/json.c
+++ b/src/json.c
@@ -676,9 +676,9 @@ json_decode_item(js_read_T *reader, typval_T *res, int options)
 	default:
 	    if (VIM_ISDIGIT(*p) || *p == '-')
 	    {
+#ifdef FEAT_FLOAT
 		char_u  *sp = p;
 
-#ifdef FEAT_FLOAT
 		if (*sp == '-')
 		{
 		    ++sp;


### PR DESCRIPTION
my vim port has no FEAT_FLOAT currently, so these helped fix my build.

the moved define in json.c fixes gcc -Werror -Wunused-variable.
