### PR TITLE
Fix E315 when switching buffers

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -509,7 +509,9 @@ syntax_start(win_T *wp, linenr_T lnum)
      * Also do this when a change was made, the current state may be invalid
      * then.
      */
-    if (syn_block != wp->w_s || changedtick != syn_buf->b_changedtick)
+    if (syn_block != wp->w_s
+	    || changedtick != syn_buf->b_changedtick
+	    || syn_buf != wp->w_buffer)
     {
 	invalidate_current_state();
 	syn_buf = wp->w_buffer;


### PR DESCRIPTION
When switching to a new buffer, the CursorMoved autocommand is triggered
for the new buffer. If there is a vim script that applies syntax
highlighting in that autocommand, syntax_start will be called while
syn_buf has not been updated to the new buffer. This will cause "E315
ml_get: invalid lnum" as syn_buf is still pointing to the old buffer but
lnum is taken from the new buffer. The additional check for syn_buf !=
wp_buffer causes an additional invalidate_current_state() and sets
syn_buf to the correct buffer.

This might be related to scrooloose/nerdtree#279, vim-airline/vim-airline#75 and critiqjo/lldb.nvim#20. I could confirm that it at least fixes jeaye/color_coded#112.
