### PR TITLE
Ring a bell if search hit top/bottom and is continuing

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1170,6 +1170,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	spell	    Error happened on spell suggest.
 	wildmode    More matches in |cmdline-completion| available
 		    (depends on the 'wildmode' setting).
+	topbot	    Do not ring a bell when search hit top or bottom (and
+		    is continuing).
 
 	This is most useful, to fine tune when in insert mode the bell should
 	be rung. For normal mode and ex commands, the bell is often rung to

--- a/src/option.h
+++ b/src/option.h
@@ -347,7 +347,7 @@ static char *(p_bo_values[]) = {"all", "backspace", "cursor", "complete",
 				 "copy", "ctrlg", "error", "esc", "ex",
 				 "hangul", "insertmode", "lang", "mess",
 				 "showmatch", "operator", "register", "shell", 
-				 "spell", "wildmode", NULL};
+				 "spell", "wildmode", "topbot", NULL};
 # endif
 
 /* values for the 'beepon' option */
@@ -370,6 +370,7 @@ static char *(p_bo_values[]) = {"all", "backspace", "cursor", "complete",
 #define BO_SH		0x10000
 #define BO_SPELL	0x20000
 #define BO_WILD		0x40000
+#define BO_TOPBOT	0x80000
 
 #ifdef FEAT_WILDIGN
 EXTERN char_u	*p_bsk;		/* 'backupskip' */

--- a/src/search.c
+++ b/src/search.c
@@ -1027,9 +1027,11 @@ searchit(
 		lnum = buf->b_ml.ml_line_count;
 	    else
 		lnum = 1;
-	    if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG))
+	    if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG)) {
 		give_warning((char_u *)_(dir == BACKWARD
 					  ? top_bot_msg : bot_top_msg), TRUE);
+		vim_beep(BO_TOPBOT);
+	    }
 	}
 	if (got_int || called_emsg
 #ifdef FEAT_SEARCH_EXTRA


### PR DESCRIPTION
Also add 'bo' option value: `topbot`, which removes the bell.
