### PR TITLE
NUL-terminate *fnamep before passing it to vim_strsave_shellescape.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -26439,6 +26439,13 @@ repeat:
 
     if (src[*usedlen] == ':' && src[*usedlen + 1] == 'S')
     {
+	/* *fnamep may still contain the entire original string, but *fnamelen
+	 * indicates to the caller how much of the string to use.
+	 * Since vim_strsave_shellescape duplicates the given string, we need
+	 * to mark the end of the string in *fnamep.
+	 */
+	(*fnamep)[*fnamelen] = NUL;
+
 	p = vim_strsave_shellescape(*fnamep, FALSE, FALSE);
 	if (p == NULL)
 	    return -1;

--- a/src/testdir/test105.in
+++ b/src/testdir/test105.in
@@ -35,6 +35,7 @@ STARTTEST
 :Put fnamemodify('abc'' ''def',    ':S'      )
 :Put fnamemodify('abc''%''def',    ':S'      )
 :Put fnamemodify("abc\ndef",       ':S'      )
+:Put expand('%:r:S') == shellescape(expand('%:r'))
 :set shell=tcsh
 :Put fnamemodify("abc\ndef",       ':S'      )
 :$put ='vim: ts=8'

--- a/src/testdir/test105.ok
+++ b/src/testdir/test105.ok
@@ -25,5 +25,6 @@ fnamemodify('abc"%"def',      ':S'      )	'''abc"%"def'''
 fnamemodify('abc'' ''def',    ':S'      )	'''abc''\'''' ''\''''def'''
 fnamemodify('abc''%''def',    ':S'      )	'''abc''\''''%''\''''def'''
 fnamemodify("abc\ndef",       ':S'      )	'''abc^@def'''
+expand('%:r:S') == shellescape(expand('%:r'))	1
 fnamemodify("abc\ndef",       ':S'      )	'''abc\^@def'''
 vim: ts=8


### PR DESCRIPTION
Some of the transformations that occur earlier in modify_fname simply
adjust *fnamelen to indicate to the caller what portion of *fnamep to
use as the modified filename.  Since vim_strsave_shellescape expects a
NUL-terminated string (so it can duplicate it), ensure *fnamep has been
terminated appropriately before the call.

This fixes issue #706.
