### PR TITLE
modify_fname: Duplicate *fnamep instead of truncating it

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -26439,8 +26439,12 @@ repeat:
 
     if (src[*usedlen] == ':' && src[*usedlen + 1] == 'S')
     {
-	/* vim_strsave_shellescape() needs a NUL terminated string. */
-	(*fnamep)[*fnamelen] = NUL;
+	p = vim_strnsave(*fnamep, *fnamelen);
+	if (p == NULL)
+	    return -1;
+	vim_free(*bufp);
+	*bufp = *fnamep = p;
+
 	p = vim_strsave_shellescape(*fnamep, FALSE, FALSE);
 	if (p == NULL)
 	    return -1;

--- a/src/testdir/test105.in
+++ b/src/testdir/test105.in
@@ -36,6 +36,7 @@ STARTTEST
 :Put fnamemodify('abc''%''def',    ':S'      )
 :Put fnamemodify("abc\ndef",       ':S'      )
 :Put expand('%:r:S') == shellescape(expand('%:r'))
+:Put join([expand('%:r'), expand('%:r:S'), expand('%')], ',')
 :set shell=tcsh
 :Put fnamemodify("abc\ndef",       ':S'      )
 :$put ='vim: ts=8'

--- a/src/testdir/test105.ok
+++ b/src/testdir/test105.ok
@@ -26,5 +26,6 @@ fnamemodify('abc'' ''def',    ':S'      )	'''abc''\'''' ''\''''def'''
 fnamemodify('abc''%''def',    ':S'      )	'''abc''\''''%''\''''def'''
 fnamemodify("abc\ndef",       ':S'      )	'''abc^@def'''
 expand('%:r:S') == shellescape(expand('%:r'))	1
+join([expand('%:r'), expand('%:r:S'), expand('%')], ',')	'test105,''test105'',test105.in'
 fnamemodify("abc\ndef",       ':S'      )	'''abc\^@def'''
 vim: ts=8


### PR DESCRIPTION
Truncating *fnamep has side effects, such as causing a later expand()
call in the same expression to return the truncated value.  Duplicate
the substring instead and use that to get the shellescaped version of
the filename.
