### PR TITLE
modify_fname: Just duplicate the string when it's zero-length

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -26439,10 +26439,16 @@ repeat:
     if (src[*usedlen] == ':' && src[*usedlen + 1] == 'S')
     {
 	/* vim_strsave_shellescape() needs a NUL terminated string. */
-	c = (*fnamep)[*fnamelen];
-	(*fnamep)[*fnamelen] = NUL;
-	p = vim_strsave_shellescape(*fnamep, FALSE, FALSE);
-	(*fnamep)[*fnamelen] = c;
+	if (*fnamelen)
+	{
+	    c = (*fnamep)[*fnamelen];
+	    (*fnamep)[*fnamelen] = NUL;
+	    p = vim_strsave_shellescape(*fnamep, FALSE, FALSE);
+	    (*fnamep)[*fnamelen] = c;
+	}
+	else
+	    p = vim_strsave_shellescape(*fnamep, FALSE, FALSE);
+
 	if (p == NULL)
 	    return -1;
 	vim_free(*bufp);


### PR DESCRIPTION
In an unnamed buffer, expand('%:S') causes Vim to crash when
saving/restoring the character at *fnamelen.
