### PR TITLE
Support for specifying antialiasing on Windows

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -2985,6 +2985,16 @@ get_logfont(
 		    }
 		    break;
 		}
+	    case 'q':
+		{
+		    int q = 0;
+		    while (*p >= '0' && *p <= '9')
+		    {
+			q = q * 10 + *p++ - '0';
+		    }
+		    lf->lfQuality = q;
+		    break;
+		}
 	    default:
 		if (verbose)
 		{


### PR DESCRIPTION
At least for me personally, being able to disable ClearType in my code editor on Windows is a pretty important feature.
