### PR TITLE
'statusline' is disable with builtin error which is caught correctly

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2033,6 +2033,7 @@ test_arglist \
 	test_searchpos \
 	test_set \
 	test_sort \
+	test_statusline \
 	test_syn_attr \
 	test_syntax \
 	test_timers \

--- a/src/screen.c
+++ b/src/screen.c
@@ -6779,6 +6779,7 @@ win_redr_status(win_T *wp)
 redraw_custom_statusline(win_T *wp)
 {
     static int	    entered = FALSE;
+    int		    saved_did_emsg = did_emsg;
 
     /* When called recursively return.  This can happen when the statusline
      * contains an expression that triggers a redraw. */
@@ -6786,6 +6787,7 @@ redraw_custom_statusline(win_T *wp)
 	return;
     entered = TRUE;
 
+    did_emsg = FALSE;
     win_redr_custom(wp, FALSE);
     if (did_emsg)
     {
@@ -6796,6 +6798,7 @@ redraw_custom_statusline(win_T *wp)
 		(char_u *)"", OPT_FREE | (*wp->w_p_stl != NUL
 					? OPT_LOCAL : OPT_GLOBAL), SID_ERROR);
     }
+    did_emsg |= saved_did_emsg;
     entered = FALSE;
 }
 #endif

--- a/src/screen.c
+++ b/src/screen.c
@@ -6779,7 +6779,6 @@ win_redr_status(win_T *wp)
 redraw_custom_statusline(win_T *wp)
 {
     static int	    entered = FALSE;
-    int		    save_called_emsg = called_emsg;
 
     /* When called recursively return.  This can happen when the statusline
      * contains an expression that triggers a redraw. */
@@ -6787,9 +6786,8 @@ redraw_custom_statusline(win_T *wp)
 	return;
     entered = TRUE;
 
-    called_emsg = FALSE;
     win_redr_custom(wp, FALSE);
-    if (called_emsg)
+    if (did_emsg)
     {
 	/* When there is an error disable the statusline, otherwise the
 	 * display is messed up with errors and a redraw triggers the problem
@@ -6798,7 +6796,6 @@ redraw_custom_statusline(win_T *wp)
 		(char_u *)"", OPT_FREE | (*wp->w_p_stl != NUL
 					? OPT_LOCAL : OPT_GLOBAL), SID_ERROR);
     }
-    called_emsg |= save_called_emsg;
     entered = FALSE;
 }
 #endif

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -1,7 +1,7 @@
 function! StatuslineWithCatchedError()
   let s:func_in_statusline_called = 1
   try
-    call eval('')
+    call eval('unknown expression')
   catch
   endtry
   return ''
@@ -9,7 +9,7 @@ endfunction
 
 function! StatuslineWithError()
   let s:func_in_statusline_called = 1
-  call eval('')
+  call eval('unknown expression')
   return ''
 endfunction
 

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -1,4 +1,4 @@
-function! StatuslineWithCatchedError()
+function! StatuslineWithCaughtError()
   let s:func_in_statusline_called = 1
   try
     call eval('unknown expression')
@@ -13,10 +13,10 @@ function! StatuslineWithError()
   return ''
 endfunction
 
-function! Test_cached_error_in_statusline()
+function! Test_caught_error_in_statusline()
   let s:func_in_statusline_called = 0
   set laststatus=2
-  let statusline = '%{StatuslineWithCatchedError()}'
+  let statusline = '%{StatuslineWithCaughtError()}'
   let &statusline = statusline
   redrawstatus
   call assert_true(s:func_in_statusline_called)

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -1,0 +1,37 @@
+function! StatuslineWithCatchedError()
+  let s:func_in_statusline_called = 1
+  try
+    call eval('')
+  catch
+  endtry
+  return ''
+endfunction
+
+function! StatuslineWithError()
+  let s:func_in_statusline_called = 1
+  call eval('')
+  return ''
+endfunction
+
+function! Test_cached_error_in_statusline()
+  let s:func_in_statusline_called = 0
+  set laststatus=2
+  let statusline = '%{StatuslineWithCatchedError()}'
+  let &statusline = statusline
+  redrawstatus
+  call assert_true(s:func_in_statusline_called)
+  call assert_equal(statusline, &statusline)
+endfunction
+
+function! Test_statusline_will_be_disabled_with_error()
+  let s:func_in_statusline_called = 0
+  set laststatus=2
+  let statusline = '%{StatuslineWithError()}'
+  try
+    let &statusline = statusline
+    redrawstatus
+  catch
+  endtry
+  call assert_true(s:func_in_statusline_called)
+  call assert_equal('', &statusline)
+endfunction


### PR DESCRIPTION
Hi
### Problem

'statusline' is disable with builtin error which is cathced correctly
#### How To Reproduce
##### statusline_test.vimrc

``` vim
set nocompatible

function! StatuslineKiller() abort
  try
    call eval('error!')
  catch
    return 'OK: error catched!'
  endtry
  return 'OK'
endfunction

set laststatus=2
set statusline=%{StatuslineKiller()}
```
1. `vim -u statusline_test.vimrc -i NONE -N`
   - statusline shows 'OK: error catched!'
2. `:redrawstatus`
   - `" Press ENTER or type command to continue`
   - Press `<Enter>`
   - statusline is disable (`&statusline == ''`)
### Expected
1.  `vim -u statusline_test.vimrc -i NONE -N`
   - statusline shows 'OK: error catched!'
2. `:redrawstatus`
   - statusline shows 'OK: error catched!'

I fixed this problem and also added tests. Please include it.

Thanks.
