### PR TITLE
'tabline' is disable with builtin error which is caught correctly

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -10266,16 +10266,16 @@ draw_tabline(void)
     /* Use the 'tabline' option if it's set. */
     if (*p_tal != NUL)
     {
-	int	save_called_emsg = called_emsg;
+	int	saved_did_emsg = did_emsg;
 
 	/* Check for an error.  If there is one we would loop in redrawing the
 	 * screen.  Avoid that by making 'tabline' empty. */
-	called_emsg = FALSE;
+	did_emsg = FALSE;
 	win_redr_custom(NULL, FALSE);
-	if (called_emsg)
+	if (did_emsg)
 	    set_string_option_direct((char_u *)"tabline", -1,
 					   (char_u *)"", OPT_FREE, SID_ERROR);
-	called_emsg |= save_called_emsg;
+	did_emsg |= saved_did_emsg;
     }
     else
 #endif

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -24,6 +24,7 @@ source test_set.vim
 source test_sort.vim
 source test_statusline.vim
 source test_syn_attr.vim
+source test_tabline.vim
 source test_timers.vim
 source test_undolevels.vim
 source test_unlet.vim

--- a/src/testdir/test_tabline.vim
+++ b/src/testdir/test_tabline.vim
@@ -1,5 +1,5 @@
 function! TablineWithCaughtError()
-  let s:func_in_statusline_called = 1
+  let s:func_in_tabline_called = 1
   try
     call eval('unknown expression')
   catch
@@ -8,35 +8,35 @@ function! TablineWithCaughtError()
 endfunction
 
 function! TablineWithError()
-  let s:func_in_statusline_called = 1
+  let s:func_in_tabline_called = 1
   call eval('unknown expression')
   return ''
 endfunction
 
-function! Test_caught_error_in_statusline()
+function! Test_caught_error_in_tabline()
   let showtabline_save = &showtabline
   set showtabline=2
-  let s:func_in_statusline_called = 0
+  let s:func_in_tabline_called = 0
   let tabline = '%{TablineWithCaughtError()}'
   let &tabline = tabline
   redraw!
-  call assert_true(s:func_in_statusline_called)
+  call assert_true(s:func_in_tabline_called)
   call assert_equal(tabline, &tabline)
   set tabline=
   let &showtabline = showtabline_save
 endfunction
 
-function! Test_statusline_will_be_disabled_with_error()
+function! Test_tabline_will_be_disabled_with_error()
   let showtabline_save = &showtabline
   set showtabline=2
-  let s:func_in_statusline_called = 0
+  let s:func_in_tabline_called = 0
   let tabline = '%{TablineWithError()}'
   try
     let &tabline = tabline
     redraw!
   catch
   endtry
-  call assert_true(s:func_in_statusline_called)
+  call assert_true(s:func_in_tabline_called)
   call assert_equal('', &tabline)
   set tabline=
   let &showtabline = showtabline_save

--- a/src/testdir/test_tabline.vim
+++ b/src/testdir/test_tabline.vim
@@ -1,0 +1,43 @@
+function! TablineWithCaughtError()
+  let s:func_in_statusline_called = 1
+  try
+    call eval('unknown expression')
+  catch
+  endtry
+  return ''
+endfunction
+
+function! TablineWithError()
+  let s:func_in_statusline_called = 1
+  call eval('unknown expression')
+  return ''
+endfunction
+
+function! Test_caught_error_in_statusline()
+  let showtabline_save = &showtabline
+  set showtabline=2
+  let s:func_in_statusline_called = 0
+  let tabline = '%{TablineWithCaughtError()}'
+  let &tabline = tabline
+  redraw!
+  call assert_true(s:func_in_statusline_called)
+  call assert_equal(tabline, &tabline)
+  set tabline=
+  let &showtabline = showtabline_save
+endfunction
+
+function! Test_statusline_will_be_disabled_with_error()
+  let showtabline_save = &showtabline
+  set showtabline=2
+  let s:func_in_statusline_called = 0
+  let tabline = '%{TablineWithError()}'
+  try
+    let &tabline = tabline
+    redraw!
+  catch
+  endtry
+  call assert_true(s:func_in_statusline_called)
+  call assert_equal('', &tabline)
+  set tabline=
+  let &showtabline = showtabline_save
+endfunction


### PR DESCRIPTION
This problem is similar as #729
### Problem

'tabline' is disable with builtin error which is cathced correctly
### How To Reproduce
#### tabline_test.vimrc

``` vim
function! TablineKiller() abort
  try
    call eval('error!')
  catch
    return 'OK: error catched!'
  endtry
  return 'OK'
endfunction

set showtabline=2
set tabline=%{TablineKiller()}
redraw!
```
1. vim -Nu tabline_test.vimrc
   - tabline shows `[No Name]`
#### Expect

tabline shows `Ok: error catched!`
