### PR TITLE
Fix autoindent for '\]' in TeX

### DIFF
--- a/runtime/indent/tex.vim
+++ b/runtime/indent/tex.vim
@@ -251,10 +251,10 @@ function! GetTeXIndent() " {{{
             let stay = 0
         endif
 
-        let cind = indent(v:lnum)
-        let char = cline[cind]
+        let clast = strlen(cline)-1
+        let char = cline[clast]
         if (char == ']' || char == '}') &&
-                    \ s:CheckPairedIsLastCharacter(v:lnum, cind)
+                    \ s:CheckPairedIsLastCharacter(v:lnum, clast)
             let ind -= &sw
             let stay = 0
         endif


### PR DESCRIPTION
Check last character on the current line instead of the first (after indent).
