### PR TITLE
support ICCs consisting of more than 1 character

### DIFF
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -86,7 +86,7 @@ if (s:ft ==# "c" && !exists("c_no_c11")) || (s:ft ==# "cpp" && !exists("cpp_no_c
   else
     syn region	cString		start=+\%(U\|u8\=\)"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
   endif
-  syn match	cCharacter	"[Uu]'[^\\]'"
+  syn match	cCharacter	"[Uu]'[^\\]\{1,4}'"
   syn match	cCharacter	"[Uu]'[^']*'" contains=cSpecial
   if exists("c_gnu")
     syn match	cSpecialError	"[Uu]'\\[^'\"?\\abefnrtv]'"


### PR DESCRIPTION
Integer character constants with more than one character are syntactically valid C, though their value is implementation defined. Thus, it makes sense to color them properly. Because `sizeof (int) == 4` is typical, I figured `\{1,4}` in the regex was appropriate, though perhaps simply a `*` would be better?
