### PR TITLE
Support worktrees gitdir in ftplugin/git.vim

### DIFF
--- a/runtime/ftplugin/git.vim
+++ b/runtime/ftplugin/git.vim
@@ -12,6 +12,8 @@ let b:did_ftplugin = 1
 if !exists('b:git_dir')
   if expand('%:p') =~# '[\/]\.git[\/]modules[\/]'
     " Stay out of the way
+  elseif expand('%:p') =~# '[\/]\.git[\/]worktrees'
+    let b:git_dir = matchstr(expand('%:p'),'.*\.git[\/]worktrees[\/][^\/]\+\>')
   elseif expand('%:p') =~# '\.git\>'
     let b:git_dir = matchstr(expand('%:p'),'.*\.git\>')
   elseif $GIT_DIR != ''


### PR DESCRIPTION
This sets proper git_dir for worktrees, which was main git_dir instead of one in .git/worktrees/[name].
