### PR TITLE
Fixe to have errorformat correctly displayed for ADA

### DIFF
--- a/runtime/autoload/gnat.vim
+++ b/runtime/autoload/gnat.vim
@@ -119,7 +119,8 @@ function gnat#New ()						     " {{{1
       \ 'Tags_Command'     : '"gnat xref -P " . self.Project_File . " -v  *.AD*"',
       \ 'Error_Format'     : '%f:%l:%c: %trror: %m,'   .
 			   \ '%f:%l:%c: %tarning: %m,' .
-			   \ '%f:%l:%c: (%ttyle) %m'}
+                           \ '%f:%l:%c: (%ttyle) %m,'  .                                                                                              
+                           \ '%f:%l:%c: %m'}
 
    return l:Retval
 endfunction gnat#New						  " }}}1


### PR DESCRIPTION
errorformat now recognizes:
    - file/path:line:column: error: message
    - file/path:line:column: warning: message
    - file/path:line:column: (style) message
    - file/path:line:column: message                   <======= now added if -gnatU is not set in the project file
