### PR TITLE
Fix clang/OS X warnings about embedded directives within macro arguments to sprintf

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5230,14 +5230,17 @@ msg_add_lines(
     if (insert_space)
 	*p++ = ' ';
     if (shortmess(SHM_LINES))
-	sprintf((char *)p,
+
 #ifdef LONG_LONG_OFF_T
+	sprintf((char *)p,
 		"%ldL, %lldC", lnum, (long long)nchars
+		);
 #else
+	sprintf((char *)p,
 		/* Explicit typecast avoids warning on Mac OS X 10.6 */
 		"%ldL, %ldC", lnum, (long)nchars
-#endif
 		);
+#endif
     else
     {
 	if (lnum == 1)
@@ -5248,14 +5251,16 @@ msg_add_lines(
 	if (nchars == 1)
 	    STRCPY(p, _("1 character"));
 	else
-	    sprintf((char *)p,
 #ifdef LONG_LONG_OFF_T
+	    sprintf((char *)p,
 		    _("%lld characters"), (long long)nchars
+		    );
 #else
+	    sprintf((char *)p,
 		    /* Explicit typecast avoids warning on Mac OS X 10.6 */
 		    _("%ld characters"), (long)nchars
-#endif
 		    );
+#endif
     }
 }
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -2293,13 +2293,20 @@ parse_line:
 			    p[len] = '@';
 			    STRCPY(p + len + 1, help_lang);
 #endif
+
+
+#ifdef FEAT_MULTI_LANG
 			    sprintf((char *)p + len + 1 + ML_EXTRA, "%06d",
 				    help_heuristic(tagp.tagname,
 					match_re ? matchoff : 0, !match_no_ic)
-#ifdef FEAT_MULTI_LANG
 				    + help_pri
-#endif
 				    );
+#else
+			    sprintf((char *)p + len + 1 + ML_EXTRA, "%06d",
+				    help_heuristic(tagp.tagname,
+					match_re ? matchoff : 0, !match_no_ic)
+				    );
+#endif
 			}
 			*tagp.tagname_end = TAB;
 		    }

--- a/src/term.c
+++ b/src/term.c
@@ -2630,15 +2630,19 @@ term_color(char_u *s, int n)
 		  || STRCMP(s + i + 1, "%dm") == 0)
 	      && (s[i] == '3' || s[i] == '4'))
     {
-	sprintf(buf,
 #ifdef TERMINFO
+	sprintf(buf,
 		"%s%s%%p1%%dm",
-#else
-		"%s%s%%dm",
-#endif
 		i == 2 ? IF_EB("\033[", ESC_STR "[") : "\233",
 		s[i] == '3' ? (n >= 16 ? "38;5;" : "9")
 			    : (n >= 16 ? "48;5;" : "10"));
+#else
+	sprintf(buf,
+		"%s%s%%dm",
+		i == 2 ? IF_EB("\033[", ESC_STR "[") : "\233",
+		s[i] == '3' ? (n >= 16 ? "38;5;" : "9")
+			    : (n >= 16 ? "48;5;" : "10"));
+#endif
 	OUT_STR(tgoto(buf, 0, n >= 16 ? n : n - 8));
     }
     else


### PR DESCRIPTION
While compiling with clang on OS X, there are some warnings about undefined behavior because of embedded pre-processor directives in preprocessor macros. 

Apparently sprintf(3) is implemented as a macro, and there are places where a directive is used to control parameters that are passed to sprintf. I did a quick test with some sample code, and it appears to work okay, but naturally it's not good to rely on undefined behavior.

I think the easiest fix would be to just modify the calls to sprintf() so that the directives wrap the complete macro calls, and not just wrap a parameter. 

Also, I've submitted patches to the list before, but this is my first attempt at using a Github pull request instead of just writing a post directly to vim-dev. Hopefully this works!  :-)

```
clang -c -I. -Iproto -DHAVE_CONFIG_H   -DMACOS_X_UNIX  -Os -Wall -Wextra -fstack-protector -fstack-protector-all -pipe -std=c99 -pedantic -arch x86_64 -mtune=native -mmacosx-version-min=10.11 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1       -o objects/fileio.o fileio.c
fileio.c:5234:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#ifdef LONG_LONG_OFF_T
 ^
fileio.c:5239:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#endif
 ^
fileio.c:5252:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#ifdef LONG_LONG_OFF_T
 ^
fileio.c:5257:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#endif
 ^
clang -c -I. -Iproto -DHAVE_CONFIG_H   -DMACOS_X_UNIX  -Os -Wall -Wextra -fstack-protector -fstack-protector-all -pipe -std=c99 -pedantic -arch x86_64 -mtune=native -mmacosx-version-min=10.11 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1       -o objects/tag.o tag.c
tag.c:2299:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#ifdef FEAT_MULTI_LANG
 ^
tag.c:2301:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#endif
 ^
clang -c -I. -Iproto -DHAVE_CONFIG_H   -DMACOS_X_UNIX  -Os -Wall -Wextra -fstack-protector -fstack-protector-all -pipe -std=c99 -pedantic -arch x86_64 -mtune=native -mmacosx-version-min=10.11 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1       -o objects/term.o term.c
term.c:2634:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#ifdef TERMINFO
 ^
term.c:2636:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
#else
 ^
```
