### PR TITLE
Document packages in list-features

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7709,6 +7709,7 @@ netbeans_enabled	Compiled with support for |netbeans| and connected.
 netbeans_intg		Compiled with support for |netbeans|.
 ole			Compiled with OLE automation support for Win32.
 os2			OS/2 version of Vim.
+packages		Compiled with support for |packages|
 path_extra		Compiled with up/downwards search in 'path' and 'tags'
 perl			Compiled with Perl interface.
 persistent_undo		Compiled with support for persistent undo history.

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -391,6 +391,7 @@ m  *+mzscheme*		Mzscheme interface |mzscheme|
 m  *+mzscheme/dyn*	Mzscheme interface |mzscheme-dynamic| |/dyn|
 m  *+netbeans_intg*	|netbeans|
 m  *+ole*		Win32 GUI only: |ole-interface|
+N  *+packages*		Loading plugin |packages|
 N  *+path_extra*	Up/downwards search in 'path' and 'tags'
 m  *+perl*		Perl interface |perl|
 m  *+perl/dyn*		Perl interface |perl-dynamic| |/dyn|


### PR DESCRIPTION
`has('packages')` works and my `:version` shows `+packages`, but the feature is not mentioned in `:help feature-list`.

The `N` annotation for the normal build in `+feature-list` is possibly incorrect, I'm not sure how to determine that—I'm looking at [these notes](https://github.com/vim/vim/blob/cefe4f994853c2d4866e2aa4ea3e3f36ab2fea13/src/feature.h#L20-L28) and I'm not sure what table is being referred to in the line about `ex_version()`. I am not seeing any `FEAT_` defined in patch 7.4.1384 (f6fee0e2d4341) or subsequently, so perhaps the build version qualification isn't defined (yet?).

If I'm wrong and someone educates me, I'll update the patch.
