### PR TITLE
fix '%' matching for php

### DIFF
--- a/runtime/ftplugin/php.vim
+++ b/runtime/ftplugin/php.vim
@@ -52,7 +52,7 @@ if exists("loaded_matchit")
 		      \ '\<do\>:\<while\>,' .
 		      \ '\<for\>:\<endfor\>,' .
 		      \ '\<foreach\>:\<endforeach\>,' .
-                      \ '(:),[:],{:},' .
+                      \ '(:),\[:\],{:},' .
 		      \ s:match_words
 endif
 " ###


### PR DESCRIPTION
'b:match_words' pattern from ftplugin/html.vim ( '<\@<=([^/][^ \t>]_)[^>]_\%(>|$):<\@<=/\1>' ) was causing the bracket matching in ftplugin/php.vim ( '[:]' ) to fail.  Escaping the brackets seems to fix it.  Perhaps related to NFA/backtracking?
