### PR TITLE
Fix drawing background with &termguicolors

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -8960,9 +8960,12 @@ can_clear(char_u *p)
 		|| gui.in_use
 #endif
 #ifdef FEAT_TERMGUICOLORS
-		|| (p_tgc && cterm_normal_bg_gui_color != (long_u)INVALCOLOR)
+		|| (p_tgc && cterm_normal_bg_gui_color == (long_u)INVALCOLOR)
+		|| (!p_tgc && cterm_normal_bg_color == 0)
+#else
+		|| cterm_normal_bg_color == 0
 #endif
-		|| cterm_normal_bg_color == 0 || *T_UT != NUL));
+		|| *T_UT != NUL));
 }
 
 /*


### PR DESCRIPTION
This is a fix for https://github.com/vim/vim/issues/804.

In terminal Vim, `can_clear()` should return true when the current background is the default terminal background color (or `&t_ut` is not empty). With `&termguicolors` set, this is the case only when `cterm_normal_bg_gui_color` is invalid. With `&termguicolors` not set (or if not built with `+termguicolors`), this is if `cterm_normal_bg_color` is zero.
