### PR TITLE
Problem: CMake errors are not shown correctly in quickfix.

### DIFF
--- a/runtime/compiler/gcc.vim
+++ b/runtime/compiler/gcc.vim
@@ -2,7 +2,8 @@
 " Compiler:         GNU C Compiler
 " Maintainer:       Nikolai Weibull <now@bitwi.se>
 " Latest Revision:  2010-10-14
-" 			added line suggested by Anton Lindqvist 2016 Mar 31
+"           added line suggested by Anton Lindqvist 2016 Mar 31
+"           CMake support by Fernando Castillo      2016 May 19
 
 if exists("current_compiler")
   finish
@@ -32,6 +33,15 @@ CompilerSet errorformat=
       \%D%*\\a:\ Entering\ directory\ [`']%f',
       \%X%*\\a:\ Leaving\ directory\ [`']%f',
       \%DMaking\ %*\\a\ in\ %f
+
+" CMake
+CompilerSet errorformat+=%E%.%#CMake\ Error\ at\ %f:%l%.%#
+CompilerSet errorformat+=%E%.%#CMake\ Error\ in\ %f:%.%#
+CompilerSet errorformat+=%Z%.%#CMake\ Error:%.%#
+CompilerSet errorformat+=%Z--\ Configuring\ incomplete%.%#
+CompilerSet errorformat+=%C%.%#:%l%.%#
+CompilerSet errorformat+=%C%m
+CompilerSet errorformat+=%C%.%#
 
 if exists('g:compiler_gcc_ignore_unmatched_lines')
   CompilerSet errorformat+=%-G%.%#


### PR DESCRIPTION
Solution: Added gcc efm for CMake

**Samples of CMake errors**

```
-- Boost version: 1.60.0
-- Found the following Boost libraries:
--   system
--   thread
--   filesystem
--   unit_test_framework
--   regex
--   chrono
--   date_time
--   atomic
-- Configuring done
CMake Error at CMakeLists.txt:54 (add_executable):
  Cannot find source file:

    /home/lobo/Dev/git/zombie/test/model/TerriainCreatorTest.cpp

  Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
  .hxx .in .txx


CMake Error: CMake can not determine linker language for target: zombie-test
CMake Error: Cannot determine link language for target "zombie-test".
-- Generating done
-- Build files have been written to: /home/lobo/Dev/git/zombie/build
```

```
-- Boost version: 1.60.0
-- Found the following Boost libraries:
--   system
--   thread
--   filesystem
--   unit_test_framework
--   regex
--   chrono
--   date_time
--   atomic
CMake Error at CMakeLists.txt:21 (iif):
  Unknown CMake command "iif".


-- Configuring incomplete, errors occurred!
See also "/home/lobo/Dev/git/zombie/build/CMakeFiles/CMakeOutput.log".
See also "/home/lobo/Dev/git/zombie/build/CMakeFiles/CMakeError.log".
```

```
-- Boost version: 1.60.0
-- Found the following Boost libraries:
--   system
--   thread
--   filesystem
--   unit_test_framework
--   regex
--   chrono
--   date_time
--   atomic
CMake Error in CMakeLists.txt:
  A logical block opening on the line

    /home/lobo/Dev/git/zombie/CMakeLists.txt:21 (if)

  is not closed.


-- Configuring incomplete, errors occurred!
See also "/home/lobo/Dev/git/zombie/build/CMakeFiles/CMakeOutput.log".
See also "/home/lobo/Dev/git/zombie/build/CMakeFiles/CMakeError.log".

```
