### PR TITLE
Update regexp for HTML filetype detection

### DIFF
--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -245,7 +245,7 @@ else
     set ft=xhtml
 
     " HTML (e.g.: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN")
-  elseif s:line1 =~? '\<DOCTYPE\s\+html\>'
+  elseif s:line1 =~? '<!DOCTYPE\s\+html\>'
     set ft=html
 
     " PDF


### PR DESCRIPTION
In #822 I address the issue where Vim incorrectly detects [Slim](http://slim-lang.com/) files, starting with a doctype declaration, as HTML. This pull request addresses the issue by improving on the existing regexp for HTML filetype detection.

I've used https://www.w3.org/TR/html-markup/syntax.html#doctype as a reference for updating the regexp. The document outlines different types of doctype declarations and the parts they consist of. A common theme amongst all of them is the following:

> 1. Any case-insensitive match for the string "<!DOCTYPE".
> 2. One or more space characters.
> 3. Any case-insensitive match for the string "HTML".

I've made changes accordingly.
