### PR TITLE
Add support for <mods> escape sequence to user defined commands

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1411,6 +1411,13 @@ The valid escape sequences are
 	<bang>	(See the '-bang' attribute) Expands to a ! if the
 		command was executed with a ! modifier, otherwise
 		expands to nothing.
+						*<mods>*
+	<mods>  The command modifiers, if specified. Otherwise, expands to
+		nothing. Supported modifiers are 'aboveleft', 'belowright',
+		'botright', 'browse', 'confirm', 'hide', 'keepalt',
+		'keepjumps', 'keepmarks', 'keeppatterns', 'lockmarks',
+		'noswapfile', 'silent', 'tab', 'topleft', 'verbose', and
+		'vertical'.
 						*<reg>* *<register>*
 	<reg>	(See the '-register' attribute) The optional register,
 		if specified.  Otherwise, expands to nothing.  <register>

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1413,11 +1413,24 @@ The valid escape sequences are
 		expands to nothing.
 						*<mods>*
 	<mods>  The command modifiers, if specified. Otherwise, expands to
-		nothing. Supported modifiers are 'aboveleft', 'belowright',
-		'botright', 'browse', 'confirm', 'hide', 'keepalt',
-		'keepjumps', 'keepmarks', 'keeppatterns', 'lockmarks',
-		'noswapfile', 'silent', 'tab', 'topleft', 'verbose', and
-		'vertical'.
+		nothing. Supported modifiers are |aboveleft|, |belowright|,
+		|botright|, |browse|, |confirm|, |hide|, |keepalt|,
+		|keepjumps|, |keepmarks|, |keeppatterns|, |lockmarks|,
+		|noswapfile|, |silent|, |tab|, |topleft|, |verbose|, and
+		|vertical|. Examples: >
+		    command! -nargs=+ -complete=file MyEdit
+				\ for f in expand(<q-args>, 0, 1) |
+				\ exe '<mods> split ' . f |
+				\ endfor
+
+		    function! SpecialEdit(files, mods)
+			for f in expand(a:files, 0, 1)
+			    exe a:mods . ' split ' . f
+			endfor
+		    endfunction
+		    command! -nargs=+ -complete=file Sedit
+				\ call SpecialEdit(<q-args>, <q-mods>)
+<
 						*<reg>* *<register>*
 	<reg>	(See the '-register' attribute) The optional register,
 		if specified.  Otherwise, expands to nothing.  <register>

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -179,6 +179,7 @@ NEW_TESTS = test_arglist.res \
 	    test_perl.res \
 	    test_quickfix.res \
 	    test_syntax.res \
+	    test_usrcmds.res \
 	    test_viminfo.res \
 	    test_viml.res \
 	    test_visual.res \

--- a/src/testdir/test_usrcmds.vim
+++ b/src/testdir/test_usrcmds.vim
@@ -1,0 +1,48 @@
+" Tests for user defined commands
+
+" Test for <mods> in user defined commands
+function Test_cmdmods()
+  let g:mods = ''
+
+  command! -nargs=* MyCmd let g:mods .= '<mods> '
+
+  MyCmd
+  aboveleft MyCmd
+  belowright MyCmd
+  botright MyCmd
+  browse MyCmd
+  confirm MyCmd
+  hide MyCmd
+  keepalt MyCmd
+  keepjumps MyCmd
+  keepmarks MyCmd
+  keeppatterns MyCmd
+  lockmarks MyCmd
+  noswapfile MyCmd
+  silent MyCmd
+  tab MyCmd
+  topleft MyCmd
+  verbose MyCmd
+  vertical MyCmd
+
+  aboveleft belowright botright browse confirm hide keepalt keepjumps
+	      \ keepmarks keeppatterns lockmarks noswapfile silent tab
+	      \ topleft verbose vertical MyCmd
+
+  call assert_equal(' aboveleft belowright botright browse confirm ' .
+      \ 'hide keepalt keepjumps keepmarks keeppatterns lockmarks ' .
+      \ 'noswapfile silent tab topleft verbose vertical aboveleft ' .
+      \ 'belowright botright browse confirm hide keepalt keepjumps ' .
+      \ 'keepmarks keeppatterns lockmarks noswapfile silent tab topleft ' .
+      \ 'verbose vertical ', g:mods)
+
+  let g:mods = ''
+  command! -nargs=* MyQCmd let g:mods .= '<q-mods> '
+
+  vertical MyQCmd
+  call assert_equal('"vertical" ', g:mods)
+
+  delcommand MyCmd
+  delcommand MyQCmd
+  unlet g:mods
+endfunction


### PR DESCRIPTION
Add support to make the command modifiers (e.g. vertical, tab, etc.)
available to user defined commands.

When defining user commands, use the &lt;mods&gt; escape sequence
to get the command modifiers.
