### PR TITLE
Extend argv() and argc() functions to return argument list entries for any window

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2024,11 +2024,10 @@ add({list}, {item})		List	append {item} to |List| {list}
 and({expr}, {expr})		Number	bitwise AND
 append({lnum}, {string})	Number	append {string} below line {lnum}
 append({lnum}, {list})		Number	append lines {list} below line {lnum}
-argc( [{winnr} [, {tabnr}]])	Number	number of files in the argument list
+argc( [{expr}])			Number	number of files in the argument list
 argidx()			Number	current index in the argument list
 arglistid([{winnr} [, {tabnr}]]) Number	argument list id
-argv( {nr} [, {winnr} [, {tabnr}]])
-				String	{nr} entry of the argument list
+argv({nr} [, {expr}])		String	{nr} entry of the argument list
 argv( [-1, {winnr} [, {tabnr}]])
 				List	the argument list
 assert_beeps({cmd})		none	assert {cmd} causes a beep
@@ -2596,15 +2595,15 @@ appendbufline({expr}, {lnum}, {text})			*appendbufline()*
 			:let failed = appendbufline(13, 0, "# THE START")
 <
 							*argc()*
-argc([{winnr}, [ {tabnr} ]])
+argc([{expr}])
 		The result is the number of files in the argument list of the
 		current window.  See |arglist|.
 		Returns -1 if the arguments are invalid.
 
-		Without arguments use the current window.
-		With {winnr} only use this window in the current tab page.
-		With {winnr} and {tabnr} use the window in the specified tab
-		page. With {winnr} set to -1, uses the global argument list.
+		Without any arguments, the argument list of the current window
+		is used. The {expr} argument specifies the window ID. If
+		supplied, the specified window is used. If {expr} is -1, the
+		global argument list is used.
 
 							*argidx()*
 argidx()	The result is the current index in the argument list.  0 is
@@ -2624,7 +2623,7 @@ arglistid([{winnr} [, {tabnr}]])
 		{winnr} can be the window number or the |window-ID|.
 
 							*argv()*
-argv([{nr} [, {winnr} [, {tabnr} ]]])
+argv([{nr} [, {expr}])
 		The result is the {nr}th file in the argument list of the
 		current window.  See |arglist|.  "argv(0)" is the first one.
 		Example: >
@@ -2637,12 +2636,11 @@ argv([{nr} [, {winnr} [, {tabnr} ]]])
 <		Without the {nr} argument a |List| with the whole |arglist| is
 		returned.
 
-		Without arguments use the current window.
-		With {winnr} only use this window in the current tab page.
-		With {winnr} and {tabnr} use the window in the specified tab
-		page. With {nr} set to -1, returns the entire argument list
-		of {winnr} in {tabnr}. With {winnr} set to -1, uses the global
-		argument list.
+		Without arguments the current window is used. The {expr}
+		argument specifies the window ID. If supplied, the argument
+		list of the specified window is used.  With {nr} set to -1,
+		returns the entire argument list of the specified window. If
+		{expr} is -1, the global argument list is used.
 
 assert_beeps({cmd})					*assert_beeps()*
 		Run {cmd} and add an error message to |v:errors| if it does

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2024,12 +2024,14 @@ add({list}, {item})		List	append {item} to |List| {list}
 and({expr}, {expr})		Number	bitwise AND
 append({lnum}, {string})	Number	append {string} below line {lnum}
 append({lnum}, {list})		Number	append lines {list} below line {lnum}
-argc()				Number	number of files in the argument list
+argc( [{winnr} [, {tabnr}]])	Number	number of files in the argument list
 argidx()			Number	current index in the argument list
 arglistid([{winnr} [, {tabnr}]]) Number	argument list id
-argv({nr})			String	{nr} entry of the argument list
-argv()				List	the argument list
-assert_beeps({cmd})		Number	assert {cmd} causes a beep
+argv( {nr} [, {winnr} [, {tabnr}]])
+				String	{nr} entry of the argument list
+argv( [-1, {winnr} [, {tabnr}]])
+				List	the argument list
+assert_beeps({cmd})		none	assert {cmd} causes a beep
 assert_equal({exp}, {act} [, {msg}])
 				Number	assert {exp} is equal to {act}
 assert_equalfile({fname-one}, {fname-two})
@@ -2594,8 +2596,15 @@ appendbufline({expr}, {lnum}, {text})			*appendbufline()*
 			:let failed = appendbufline(13, 0, "# THE START")
 <
 							*argc()*
-argc()		The result is the number of files in the argument list of the
+argc([{winnr}, [ {tabnr} ]])
+		The result is the number of files in the argument list of the
 		current window.  See |arglist|.
+		Returns -1 if the arguments are invalid.
+
+		Without arguments use the current window.
+		With {winnr} only use this window in the current tab page.
+		With {winnr} and {tabnr} use the window in the specified tab
+		page. With {winnr} set to -1, uses the global argument list.
 
 							*argidx()*
 argidx()	The result is the current index in the argument list.  0 is
@@ -2606,7 +2615,7 @@ arglistid([{winnr} [, {tabnr}]])
 		Return the argument list ID.  This is a number which
 		identifies the argument list being used.  Zero is used for the
 		global argument list.  See |arglist|.
-		Return -1 if the arguments are invalid.
+		Returns -1 if the arguments are invalid.
 
 		Without arguments use the current window.
 		With {winnr} only use this window in the current tab page.
@@ -2615,7 +2624,8 @@ arglistid([{winnr} [, {tabnr}]])
 		{winnr} can be the window number or the |window-ID|.
 
 							*argv()*
-argv([{nr}])	The result is the {nr}th file in the argument list of the
+argv([{nr} [, {winnr} [, {tabnr} ]]])
+		The result is the {nr}th file in the argument list of the
 		current window.  See |arglist|.  "argv(0)" is the first one.
 		Example: >
 	:let i = 0
@@ -2626,6 +2636,13 @@ argv([{nr}])	The result is the {nr}th file in the argument list of the
 	:endwhile
 <		Without the {nr} argument a |List| with the whole |arglist| is
 		returned.
+
+		Without arguments use the current window.
+		With {winnr} only use this window in the current tab page.
+		With {winnr} and {tabnr} use the window in the specified tab
+		page. With {nr} set to -1, returns the entire argument list
+		of {winnr} in {tabnr}. With {winnr} set to -1, uses the global
+		argument list.
 
 assert_beeps({cmd})					*assert_beeps()*
 		Run {cmd} and add an error message to |v:errors| if it does

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2024,12 +2024,11 @@ add({list}, {item})		List	append {item} to |List| {list}
 and({expr}, {expr})		Number	bitwise AND
 append({lnum}, {string})	Number	append {string} below line {lnum}
 append({lnum}, {list})		Number	append lines {list} below line {lnum}
-argc( [{expr}])			Number	number of files in the argument list
+argc( [{winid}])		Number	number of files in the argument list
 argidx()			Number	current index in the argument list
 arglistid([{winnr} [, {tabnr}]]) Number	argument list id
-argv({nr} [, {expr}])		String	{nr} entry of the argument list
-argv( [-1, {winnr} [, {tabnr}]])
-				List	the argument list
+argv({nr} [, {winid}])		String	{nr} entry of the argument list
+argv( [-1, [{winid}]])		List	the argument list
 assert_beeps({cmd})		none	assert {cmd} causes a beep
 assert_equal({exp}, {act} [, {msg}])
 				Number	assert {exp} is equal to {act}
@@ -2595,15 +2594,15 @@ appendbufline({expr}, {lnum}, {text})			*appendbufline()*
 			:let failed = appendbufline(13, 0, "# THE START")
 <
 							*argc()*
-argc([{expr}])
+argc([{winid}])
 		The result is the number of files in the argument list of the
 		current window.  See |arglist|.
 		Returns -1 if the arguments are invalid.
 
-		Without any arguments, the argument list of the current window
-		is used. The {expr} argument specifies the window ID. If
-		supplied, the specified window is used. If {expr} is -1, the
-		global argument list is used.
+		The {winid} argument specifies the window ID. If supplied, the
+		argument list of the specified window is used. If {winid} is
+		-1, the global argument list is used. If {winid} is not
+		supplied, the argument list of the current window is used.
 
 							*argidx()*
 argidx()	The result is the current index in the argument list.  0 is
@@ -2623,7 +2622,7 @@ arglistid([{winnr} [, {tabnr}]])
 		{winnr} can be the window number or the |window-ID|.
 
 							*argv()*
-argv([{nr} [, {expr}])
+argv([{nr} [, {winid}])
 		The result is the {nr}th file in the argument list of the
 		current window.  See |arglist|.  "argv(0)" is the first one.
 		Example: >
@@ -2636,11 +2635,12 @@ argv([{nr} [, {expr}])
 <		Without the {nr} argument a |List| with the whole |arglist| is
 		returned.
 
-		Without arguments the current window is used. The {expr}
-		argument specifies the window ID. If supplied, the argument
-		list of the specified window is used.  With {nr} set to -1,
-		returns the entire argument list of the specified window. If
-		{expr} is -1, the global argument list is used.
+		The {winid} argument specifies the window ID. If supplied, the
+		|arglist| of the specified window is used.  With {nr} set to
+		-1, returns a |List| with the whole |arglist| of the specified
+		window. With {winid} set to -1, the global |arglist| is used.
+		If {winid} is not supplied, the argument list of the current
+		window is used.
 
 assert_beeps({cmd})					*assert_beeps()*
 		Run {cmd} and add an error message to |v:errors| if it does

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2029,7 +2029,7 @@ argidx()			Number	current index in the argument list
 arglistid([{winnr} [, {tabnr}]]) Number	argument list id
 argv({nr} [, {winid}])		String	{nr} entry of the argument list
 argv( [-1, [{winid}]])		List	the argument list
-assert_beeps({cmd})		none	assert {cmd} causes a beep
+assert_beeps({cmd})		Number	assert {cmd} causes a beep
 assert_equal({exp}, {act} [, {msg}])
 				Number	assert {exp} is equal to {act}
 assert_equalfile({fname-one}, {fname-two})

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1431,7 +1431,6 @@ f_argc(typval_T *argvars, typval_T *rettv)
     }
 }
 
-
 /*
  * "argidx()" function
  */
@@ -5419,7 +5418,6 @@ getpos_both(
 	rettv->vval.v_number = FALSE;
 }
 
-
 /*
  * "getcurpos()" function
  */
@@ -7042,7 +7040,6 @@ f_inputlist(typval_T *argvars, typval_T *rettv)
 
     rettv->vval.v_number = selected;
 }
-
 
 static garray_T	    ga_userinput = {0, 0, sizeof(tasave_T), 4, NULL};
 
@@ -12474,7 +12471,6 @@ f_synIDattr(typval_T *argvars UNUSED, typval_T *rettv)
 	    modec = 't';
     }
 
-
     switch (TOLOWER_ASC(what[0]))
     {
 	case 'b':
@@ -12885,7 +12881,6 @@ f_tabpagebuflist(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     }
 }
 
-
 /*
  * "tabpagenr()" function
  */
@@ -12911,7 +12906,6 @@ f_tabpagenr(typval_T *argvars UNUSED, typval_T *rettv)
 	nr = tabpage_index(curtab);
     rettv->vval.v_number = nr;
 }
-
 
 static int get_winnr(tabpage_T *tp, typval_T *argvar);
 
@@ -12978,7 +12972,6 @@ f_tabpagewinnr(typval_T *argvars UNUSED, typval_T *rettv)
 	nr = get_winnr(tp, &argvars[1]);
     rettv->vval.v_number = nr;
 }
-
 
 /*
  * "tagfiles()" function
@@ -14166,6 +14159,5 @@ f_xor(typval_T *argvars, typval_T *rettv)
     rettv->vval.v_number = get_tv_number_chk(&argvars[0], NULL)
 					^ get_tv_number_chk(&argvars[1], NULL);
 }
-
 
 #endif /* FEAT_EVAL */

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1506,13 +1506,16 @@ f_argv(typval_T *argvars, typval_T *rettv)
 	if (arglist != NULL && idx >= 0 && idx < argcount)
 	    rettv->vval.v_string = vim_strsave(alist_name(&arglist[idx]));
 	else if (idx == -1 && argvars[1].v_type != VAR_UNKNOWN)
-	    return get_arglist_as_rettv(arglist, argcount, rettv);
+	{
+	    get_arglist_as_rettv(arglist, argcount, rettv);
+	    return;
+	}
 	else
 	    rettv->vval.v_string = NULL;
 	rettv->v_type = VAR_STRING;
     }
     else
-	return get_arglist_as_rettv(ARGLIST, ARGCOUNT, rettv);
+	get_arglist_as_rettv(ARGLIST, ARGCOUNT, rettv);
 }
 
 /*

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -288,42 +288,39 @@ func Test_argv()
   call assert_equal('c', argv(2))
   call assert_equal(4, argc())
 
+  let w1_id = win_getid()
   split
+  let w2_id = win_getid()
   arglocal
   args e f g
-  tabnew | split
+  tabnew
+  let w3_id = win_getid()
+  split
+  let w4_id = win_getid()
   argglobal
   tabfirst
-  call assert_equal(3, argc(1))
-  call assert_equal('f', argv(1, 1))
-  call assert_equal(['e', 'f', 'g'], argv(-1, 1))
-  call assert_equal(4, argc(2))
-  call assert_equal('b', argv(1, 2))
-  call assert_equal(['a', 'b', 'c', 'd'], argv(-1, 2))
-  call assert_equal(4, argc(1, 2))
-  call assert_equal('c', argv(2, 1, 2))
-  call assert_equal(['a', 'b', 'c', 'd'], argv(-1, 1, 2))
-  call assert_equal(3, argc(2, 2))
-  call assert_equal('e', argv(0, 2, 2))
-  call assert_equal(['e', 'f', 'g'], argv(-1, 2, 2))
+  call assert_equal(3, argc(w2_id))
+  call assert_equal('f', argv(1, w2_id))
+  call assert_equal(['e', 'f', 'g'], argv(-1, w2_id))
+  call assert_equal(4, argc(w1_id))
+  call assert_equal('b', argv(1, w1_id))
+  call assert_equal(['a', 'b', 'c', 'd'], argv(-1, w1_id))
+  call assert_equal(4, argc(w4_id))
+  call assert_equal('c', argv(2, w4_id))
+  call assert_equal(['a', 'b', 'c', 'd'], argv(-1, w4_id))
+  call assert_equal(3, argc(w3_id))
+  call assert_equal('e', argv(0, w3_id))
+  call assert_equal(['e', 'f', 'g'], argv(-1, w3_id))
   call assert_equal(4, argc(-1))
-  call assert_equal(4, argc(-1, -1))
   call assert_equal(3, argc())
   call assert_equal('d', argv(3, -1))
-  call assert_equal('d', argv(3, -1, -1))
   call assert_equal(['a', 'b', 'c', 'd'], argv(-1, -1))
-  call assert_equal(['a', 'b', 'c', 'd'], argv(-1, -1, -1))
   tabonly | only | enew!
   " Negative test cases
-  call assert_equal(-1, argc(10))
-  call assert_equal(-1, argc(1, 10))
-  call assert_equal('', argv(1, 10))
-  call assert_equal('', argv(1, 1, 10))
-  call assert_equal('', argv(10, 1, 1))
-  call assert_equal([], argv(-1, 10))
-  call assert_equal([], argv(-1, 1, 10))
+  call assert_equal(-1, argc(100))
+  call assert_equal('', argv(1, 100))
+  call assert_equal([], argv(-1, 100))
   call assert_equal('', argv(10, -1))
-  call assert_equal('', argv(10, -1, -1))
 endfunction
 
 " Test for the :argedit command

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -321,7 +321,7 @@ func Test_argv()
   call assert_equal('', argv(1, 100))
   call assert_equal([], argv(-1, 100))
   call assert_equal('', argv(10, -1))
-endfunction
+endfunc
 
 " Test for the :argedit command
 func Test_argedit()

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -278,14 +278,53 @@ func Test_arglistid()
   call assert_equal(0, arglistid())
 endfunc
 
-" Test for argv()
+" Tests for argv() and argc()
 func Test_argv()
   call Reset_arglist()
   call assert_equal([], argv())
   call assert_equal("", argv(2))
+  call assert_equal(0, argc())
   argadd a b c d
   call assert_equal('c', argv(2))
-endfunc
+  call assert_equal(4, argc())
+
+  split
+  arglocal
+  args e f g
+  tabnew | split
+  argglobal
+  tabfirst
+  call assert_equal(3, argc(1))
+  call assert_equal('f', argv(1, 1))
+  call assert_equal(['e', 'f', 'g'], argv(-1, 1))
+  call assert_equal(4, argc(2))
+  call assert_equal('b', argv(1, 2))
+  call assert_equal(['a', 'b', 'c', 'd'], argv(-1, 2))
+  call assert_equal(4, argc(1, 2))
+  call assert_equal('c', argv(2, 1, 2))
+  call assert_equal(['a', 'b', 'c', 'd'], argv(-1, 1, 2))
+  call assert_equal(3, argc(2, 2))
+  call assert_equal('e', argv(0, 2, 2))
+  call assert_equal(['e', 'f', 'g'], argv(-1, 2, 2))
+  call assert_equal(4, argc(-1))
+  call assert_equal(4, argc(-1, -1))
+  call assert_equal(3, argc())
+  call assert_equal('d', argv(3, -1))
+  call assert_equal('d', argv(3, -1, -1))
+  call assert_equal(['a', 'b', 'c', 'd'], argv(-1, -1))
+  call assert_equal(['a', 'b', 'c', 'd'], argv(-1, -1, -1))
+  tabonly | only | enew!
+  " Negative test cases
+  call assert_equal(-1, argc(10))
+  call assert_equal(-1, argc(1, 10))
+  call assert_equal('', argv(1, 10))
+  call assert_equal('', argv(1, 1, 10))
+  call assert_equal('', argv(10, 1, 1))
+  call assert_equal([], argv(-1, 10))
+  call assert_equal([], argv(-1, 1, 10))
+  call assert_equal('', argv(10, -1))
+  call assert_equal('', argv(10, -1, -1))
+endfunction
 
 " Test for the :argedit command
 func Test_argedit()


### PR DESCRIPTION
A Vim window can use either the global argument list or a local argument
list.  The argv() and argc() functions currently support only the
argument list for the current window.

Extend these functions to get the argument list for any window in any
tab page. Also support getting the entries from the global argument list.
