### PR TITLE
Not able to use a function reference as the job exit callback

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -4066,14 +4066,7 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported)
 		if (!(supported & JO_EXIT_CB))
 		    break;
 		opt->jo_set |= JO_EXIT_CB;
-		if (item->v_type == VAR_PARTIAL && item->vval.v_partial != NULL)
-		{
-		    opt->jo_exit_partial = item->vval.v_partial;
-		    opt->jo_exit_cb = item->vval.v_partial->pt_name;
-		}
-		else
-		    opt->jo_exit_cb = get_tv_string_buf_chk(
-						       item, opt->jo_ecb_buf);
+		opt->jo_exit_cb = get_callback(item, &opt->jo_exit_partial);
 		if (opt->jo_exit_cb == NULL)
 		{
 		    EMSG2(_(e_invarg2), "exit_cb");


### PR DESCRIPTION
Not able to use a function reference to set the exit_cb of a job. Other job
callback functions can be set using function references.

Use get_callback() instead of get_tv_string_buf_chk() to set the job exit_cb.
