### PR TITLE
ftplugin/python.vim: improve matching for ]] [[ ]m [m

### DIFF
--- a/runtime/ftplugin/python.vim
+++ b/runtime/ftplugin/python.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	python
 " Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	2014 Feb 09
+" Last Change:	Wed, 01 June 2016
 " Last Change By Johannes: Wed, 21 Apr 2004 13:13:08 CEST
 
 if exists("b:did_ftplugin") | finish | endif
@@ -21,10 +21,10 @@ setlocal omnifunc=pythoncomplete#Complete
 
 set wildignore+=*.pyc
 
-nnoremap <silent> <buffer> ]] :call <SID>Python_jump('/^\(class\\|def\)')<cr>
-nnoremap <silent> <buffer> [[ :call <SID>Python_jump('?^\(class\\|def\)')<cr>
-nnoremap <silent> <buffer> ]m :call <SID>Python_jump('/^\s*\(class\\|def\)')<cr>
-nnoremap <silent> <buffer> [m :call <SID>Python_jump('?^\s*\(class\\|def\)')<cr>
+nnoremap <silent> <buffer> ]] :call <SID>Python_jump('/^\(class\\|def\)\>')<cr>
+nnoremap <silent> <buffer> [[ :call <SID>Python_jump('?^\(class\\|def\)\>')<cr>
+nnoremap <silent> <buffer> ]m :call <SID>Python_jump('/^\s*\(class\\|def\)\>')<cr>
+nnoremap <silent> <buffer> [m :call <SID>Python_jump('?^\s*\(class\\|def\)\>')<cr>
 
 if !exists('*<SID>Python_jump')
   fun! <SID>Python_jump(motion) range


### PR DESCRIPTION
This should stop `]]`, `[[`, `]m`, and `[m` from jumping to identifiers beginning with either "def" or "class".

For instance, as it is currently, if your cursor is on `apply`, below:

```
def apply(f, x):
    return f(x)

default = "foo"
classy_identifier="bar"

def show_default():
    print(default)
```

Then you'll have to do `]m` 3 times in order to land on `def show_default()`, instead of once.
