### PR TITLE
cscope improvements

### DIFF
--- a/runtime/doc/if_cscop.txt
+++ b/runtime/doc/if_cscop.txt
@@ -129,6 +129,9 @@ The available subcommands are:
 		6 or e: Find this egrep pattern
 		7 or f: Find this file
 		8 or i: Find files #including this file
+		9 or a: Find assignments to this symbol
+		(uppercase letters): Same as lowercase with switched case
+                                     sensitivity
 
 	For all types, except 4 and 6, leading white space for {name} is
 	removed.  For 4 and 6 there is exactly one space between {querytype}
@@ -255,13 +258,13 @@ started will have no effect!
 {not available when compiled without the |+quickfix| feature}
 'cscopequickfix' specifies whether to use quickfix window to show cscope
 results.  This is a list of comma-separated values. Each item consists of
-|cscope-find| command (s, g, d, c, t, e, f or i) and flag (+, - or 0).
+|cscope-find| command (s, g, d, c, t, e, f, i or a) and flag (+, - or 0).
 '+' indicates that results must be appended to quickfix window,
 '-' implies previous results clearance, '0' or command absence - don't use
 quickfix.  Search is performed from start until first command occurrence.
 The default value is "" (don't use quickfix anyway).  The following value
 seems to be useful: >
-	:set cscopequickfix=s-,c-,d-,i-,t-,e-
+	:set cscopequickfix=s-,c-,d-,i-,t-,e-,a-
 <
 							*cscopetag* *cst*
 If 'cscopetag' is set, the commands ":tag" and CTRL-] as well as "vim -t"
@@ -422,6 +425,7 @@ Cscope Home Page (http://cscope.sourceforge.net/): >
 	nmap <C-_>f :cs find f <C-R>=expand("<cfile>")<CR><CR>
 	nmap <C-_>i :cs find i ^<C-R>=expand("<cfile>")<CR>$<CR>
 	nmap <C-_>d :cs find d <C-R>=expand("<cword>")<CR><CR>
+	nmap <C-_>a :cs find a <C-R>=expand("<cword>")<CR><CR>
 
 	" Using 'CTRL-spacebar' then a search type makes the vim window
 	" split horizontally, with search result displayed in
@@ -435,6 +439,7 @@ Cscope Home Page (http://cscope.sourceforge.net/): >
 	nmap <C-Space>f :scs find f <C-R>=expand("<cfile>")<CR><CR>
 	nmap <C-Space>i :scs find i ^<C-R>=expand("<cfile>")<CR>$<CR>
 	nmap <C-Space>d :scs find d <C-R>=expand("<cword>")<CR><CR>
+	nmap <C-Space>a :scs find a <C-R>=expand("<cword>")<CR><CR>
 
 	" Hitting CTRL-space *twice* before the search type does a vertical
 	" split instead of a horizontal one
@@ -453,6 +458,8 @@ Cscope Home Page (http://cscope.sourceforge.net/): >
 		\:vert scs find i ^<C-R>=expand("<cfile>")<CR>$<CR>
 	nmap <C-Space><C-Space>d
 		\:vert scs find d <C-R>=expand("<cword>")<CR><CR>
+	nmap <C-Space><C-Space>a
+		\:vert scs find a <C-R>=expand("<cword>")<CR><CR>
 
 ==============================================================================
 7. Cscope availability and information			*cscope-info*

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -70,7 +70,7 @@ static cscmd_T	    cs_cmds[] =
     { "add",	cs_add,
 		N_("Add a new database"),     "add file|dir [pre-path] [flags]", 0 },
     { "find",	cs_find,
-		N_("Query for a pattern"),    "find c|d|e|f|g|i|s|t name", 1 },
+		N_("Query for a pattern"),    "find a|c|d|e|f|g|i|s|t name (also uppercase letters)", 1 },
     { "help",	cs_help,
 		N_("Show this message"),      "help", 0 },
     { "kill",	cs_kill,
@@ -126,7 +126,8 @@ get_cscope_name(expand_T *xp UNUSED, int idx)
 	{
 	    const char *query_type[] =
 	    {
-		"c", "d", "e", "f", "g", "i", "s", "t", NULL
+		"A", "C", "D", "E", "F", "G", "I", "S", "T",
+		"a", "c", "d", "e", "f", "g", "i", "s", "t", NULL
 	    };
 
 	    /* Complete with query type of ":cscope find {query_type}".
@@ -767,30 +768,33 @@ cs_create_cmd(char *csoption, char *pattern)
 
     switch (csoption[0])
     {
-    case '0' : case 's' :
+    case '0' : case 's' : case 'S' :
 	search = 0;
 	break;
-    case '1' : case 'g' :
+    case '1' : case 'g' : case 'G' :
 	search = 1;
 	break;
-    case '2' : case 'd' :
+    case '2' : case 'd' : case 'D' :
 	search = 2;
 	break;
-    case '3' : case 'c' :
+    case '3' : case 'c' : case 'C' :
 	search = 3;
 	break;
-    case '4' : case 't' :
+    case '4' : case 't' : case 'T' :
 	search = 4;
 	break;
-    case '6' : case 'e' :
+    case '6' : case 'e' : case 'E' :
 	search = 6;
 	break;
-    case '7' : case 'f' :
+    case '7' : case 'f' : case 'F' :
 	search = 7;
 	break;
-    case '8' : case 'i' :
+    case '8' : case 'i' : case 'I' :
 	search = 8;
 	break;
+    case '9' : case 'a' : case 'A' :
+        search = 9;
+        break;
     default :
 	(void)EMSG(_("E561: unknown cscope search type"));
 	cs_usage_msg(Find);
@@ -1127,29 +1131,32 @@ cs_find_common(
     /* get cmd letter */
     switch (opt[0])
     {
-    case '0' :
+    case '0' : case 'S':
 	cmdletter = 's';
 	break;
-    case '1' :
+    case '1' : case 'G':
 	cmdletter = 'g';
 	break;
-    case '2' :
+    case '2' : case 'D':
 	cmdletter = 'd';
 	break;
-    case '3' :
+    case '3' : case 'C':
 	cmdletter = 'c';
 	break;
-    case '4' :
+    case '4' : case 'T':
 	cmdletter = 't';
 	break;
-    case '6' :
+    case '6' : case 'E':
 	cmdletter = 'e';
 	break;
-    case '7' :
+    case '7' : case 'F':
 	cmdletter = 'f';
 	break;
-    case '8' :
+    case '8' : case 'I':
 	cmdletter = 'i';
+	break;
+    case '9' : case 'A':
+	cmdletter = 'a';
 	break;
     default :
 	cmdletter = opt[0];
@@ -1210,6 +1217,19 @@ cs_find_common(
     {
 	if (csinfo[i].fname == NULL || csinfo[i].to_fp == NULL)
 	    continue;
+   
+        if ((opt[0] >= 'A' && opt[0] <= 'Z') && csinfo[i].switched_case == 0 ||
+            (opt[0] < 'A' || opt[0] > 'Z') && csinfo[i].switched_case == 1) 
+        {
+            /* swap case sensitivity for this search */
+            (void)fprintf(csinfo[i].to_fp, "c\n");
+            (void)fflush(csinfo[i].to_fp);
+            (void)cs_read_prompt(i);
+            if (csinfo[i].switched_case == 0)
+                csinfo[i].switched_case = 1;
+            else
+                csinfo[i].switched_case = 0;
+        }
 
 	/* send cmd to cscope */
 	(void)fprintf(csinfo[i].to_fp, "%s\n", cmd);
@@ -1345,6 +1365,7 @@ cs_help(exarg_T *eap UNUSED)
 				      cmdp->usage);
 	if (strcmp(cmdp->name, "find") == 0)
 	    MSG_PUTS(_("\n"
+		       "       a: Find assignments to this symbol\n"
 		       "       c: Find functions calling this function\n"
 		       "       d: Find functions called by this function\n"
 		       "       e: Find this egrep pattern\n"
@@ -1352,7 +1373,9 @@ cs_help(exarg_T *eap UNUSED)
 		       "       g: Find this definition\n"
 		       "       i: Find files #including this file\n"
 		       "       s: Find this C symbol\n"
-		       "       t: Find this text string\n"));
+		       "       t: Find this text string\n"
+		       "(uppercase letters): Same as lowercase with switched"
+                       " case sensitivity\n"));
 
 	cmdp++;
     }
@@ -1379,6 +1402,7 @@ clear_csinfo(int i)
     csinfo[i].pid    = 0;
     csinfo[i].fr_fp  = NULL;
     csinfo[i].to_fp  = NULL;
+    csinfo[i].switched_case = 0;
 #if defined(WIN32)
     csinfo[i].hProc = NULL;
 #endif

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1234,6 +1234,13 @@ cs_find_common(
 	/* send cmd to cscope */
 	(void)fprintf(csinfo[i].to_fp, "%s\n", cmd);
 	(void)fflush(csinfo[i].to_fp);
+    }
+    vim_free(cmd);
+
+    for (i = 0; i < csinfo_size; i++)
+    {
+	if (csinfo[i].fname == NULL || csinfo[i].to_fp == NULL)
+	    continue;
 
 	nummatches[i] = cs_cnt_matches(i);
 
@@ -1243,7 +1250,6 @@ cs_find_common(
 	if (nummatches[i] == 0)
 	    (void)cs_read_prompt(i);
     }
-    vim_free(cmd);
 
     if (totmatches == 0)
     {

--- a/src/if_cscope.h
+++ b/src/if_cscope.h
@@ -30,11 +30,11 @@
  * d 2name	Find functions called by this function
  * c 3name	Find functions calling this function
  * t 4string	find text string (cscope 12.9)
- * t 4name	Find assignments to (cscope 13.3)
  *   5pattern	change pattern -- NOT USED
  * e 6pattern	Find this egrep pattern
  * f 7name	Find this file
  * i 8name	Find files #including this file
+ * a 9name	Find assignments to (cscope 15.8)
  */
 
 typedef struct {
@@ -65,6 +65,7 @@ typedef struct csi {
 
     FILE *	    fr_fp;	/* from cscope: FILE. */
     FILE *	    to_fp;	/* to cscope: FILE. */
+    int             switched_case;  /* switched case sensitivity */
 } csinfo_T;
 
 typedef enum { Add, Find, Help, Kill, Reset, Show } csid_e;

--- a/src/option.h
+++ b/src/option.h
@@ -429,7 +429,7 @@ EXTERN char_u	*p_csprg;	/* 'cscopeprg' */
 EXTERN int	p_csre;		/* 'cscoperelative' */
 # ifdef FEAT_QUICKFIX
 EXTERN char_u	*p_csqf;	/* 'cscopequickfix' */
-#  define	CSQF_CMDS   "sgdctefi"
+#  define	CSQF_CMDS   "sgdctefia"
 #  define	CSQF_FLAGS  "+-0"
 # endif
 EXTERN int	p_cst;		/* 'cscopetag' */


### PR DESCRIPTION
- Added new search type - find assignment to this symbol (available since cscope 15.8)
- Added option to switch case sensitivity by using upper case letters in searches (e.g. :cs f G Main, :cs f S totalcount, ...)
- Changed execution of a cscope query to be parallel, when using multiple cscope files. This is particularly useful when working with multi-core machines and huge projects (just split source files into N similarly sized lists and create N cscope files and load them in Vim - any cscope query will be send to all N cscope processes at the same time).
