### PR TITLE
Ensure enabled/disabled state of popup menu item set by MenuPopup autocmd is shown correctly.

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -1970,7 +1970,10 @@ gui_show_popupmenu(void)
 
     /* Only show a popup when it is defined and has entries */
     if (menu != NULL && menu->children != NULL)
+    {
+	gui_update_menus(0);
 	gui_mch_show_popupmenu(menu);
+    }
 }
 #endif /* FEAT_GUI */
 


### PR DESCRIPTION
Call gui_update_menus(0) just prior to calling gui_mch_show_popupmenu; This ensures any updates to the popup menu by a MenuPopup autocmd will be displayed by gui_mch_show_popupmenu.

Previously, on Windows, with
`
 autocmd MenuPopup n,v,o,i amenu PopUp.SHOULD\ BE\ DISABLED : | amenu disable PopUp.SHOULD\ BE\ DISABLED
`
the 'SHOULD BE DISABLED' item in the right mouse click popup menu would appear enabled the first time it was displayed.

Note: gui_mch_show_popupmenu is blocking on Windows. gui_mch_show_popupmenu defined in gui_gtk.c is non-blocking though and when using GTK on Linux the menu item can be disabled soon after being drawn enabled.
