### PR TITLE
Add bvimgrep command

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -780,6 +780,28 @@ commands can be combined to create a NewGrep command: >
 			the current window is used instead of the quickfix
 			list.
 
+						*:vimgrep-<buffer>*
+:vimgrep[!] <buffer> /{pattern}/[g][j] [{buffer} ...]
+:vimgrep[!] <buffer> {pattern} [{buffer} ...]
+			Same as ":vimgrep", except that it searches the given
+			buffers. If no buffer is given, searches the current
+			buffer. Buffer can be given as buffer name (including
+			file-patterns) or number.
+
+                        The difference to the standard vimgrep command is, it
+                        that when using the <buffer> argument, vimgrep will
+                        search all files that are loaded in the current Vim
+                        session and not whatever is written on the disk. This
+                        matters, if the loaded buffer has been modified and
+                        is different from the on disk version.
+
+						*:vimgrepadd-<buffer>*
+:vimgrepa[dd][!] <buffer> /{pattern}/[g][j] [{buffer} ...]
+:vimgrepa[dd][!] <buffer> {pattern} [{buffer} ...]
+			Just like ":vimgrep", but instead of making a new
+			list of errors thep matches are appended to the
+			current list.
+
 5.2 External grep
 
 Vim can interface with "grep" and grep-like programs (such as the GNU

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -2335,7 +2335,7 @@ do_one_arg(char_u *str)
  * Separate the arguments in "str" and return a list of pointers in the
  * growarray "gap".
  */
-    static int
+    int
 get_arglist(garray_T *gap, char_u *str, int escaped)
 {
     ga_init2(gap, (int)sizeof(char_u *), 20);

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1745,6 +1745,7 @@ do_one_cmd(
     int			ni;			/* set when Not Implemented */
     char_u		*cmd;
     int			address_count = 1;
+    int			is_vimgrep_like = FALSE;
 
     vim_memset(&ea, 0, sizeof(ea));
     ea.line1 = 1;
@@ -2439,6 +2440,15 @@ do_one_cmd(
 	}
     }
 
+#ifdef FEAT_LISTCMDS
+    if (ea.cmdidx == CMD_vimgrep || ea.cmdidx == CMD_vimgrepadd ||
+	    ea.cmdidx == CMD_lvimgrep || ea.cmdidx == CMD_lvimgrepadd)
+	is_vimgrep_like = TRUE;
+    /* :vimgrep command depends on the <buffer> argument. */
+    if (is_vimgrep_like && p != NULL)
+	p = get_vimgrep_type(p, &ea);
+#endif
+
     if (!ni && !(ea.argt & BANG) && ea.forceit)	/* no <!> allowed */
     {
 	errormsg = (char_u *)_(e_nobang);
@@ -2853,7 +2863,7 @@ do_one_cmd(
      * number.  Don't do this for a user command.
      */
     if ((ea.argt & BUFNAME) && *ea.arg != NUL && ea.addr_count == 0
-	    && !IS_USER_CMDIDX(ea.cmdidx))
+	    && !IS_USER_CMDIDX(ea.cmdidx) && !is_vimgrep_like)
     {
 	/*
 	 * :bdelete, :bwipeout and :bunload take several arguments, separated
@@ -4113,6 +4123,10 @@ set_one_cmd_context(
 	case CMD_bdelete:
 	case CMD_bwipeout:
 	case CMD_bunload:
+	case CMD_vimgrep:
+	case CMD_vimgrepadd:
+	case CMD_lvimgrep:
+	case CMD_lvimgrepadd:
 	    while ((xp->xp_pattern = vim_strchr(arg, ' ')) != NULL)
 		arg = xp->xp_pattern + 1;
 	    /*FALLTHROUGH*/

--- a/src/proto/buffer.pro
+++ b/src/proto/buffer.pro
@@ -23,6 +23,7 @@ buf_T *buflist_findname_exp(char_u *fname);
 buf_T *buflist_findname(char_u *ffname);
 int buflist_findpat(char_u *pattern, char_u *pattern_end, int unlisted, int diffmode, int curtab_only);
 int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options);
+int get_buflist_exp(char_u *str, int *count, garray_T *ga);
 buf_T *buflist_findnr(int nr);
 char_u *buflist_nr2name(int n, int fullname, int helptail);
 void get_winopts(buf_T *buf);

--- a/src/proto/ex_cmds2.pro
+++ b/src/proto/ex_cmds2.pro
@@ -52,6 +52,7 @@ int can_abandon(buf_T *buf, int forceit);
 int check_changed_any(int hidden, int unload);
 int check_fname(void);
 int buf_write_all(buf_T *buf, int forceit);
+int get_arglist(garray_T *gap, char_u *str, int escaped);
 int get_arglist_exp(char_u *str, int *fcountp, char_u ***fnamesp, int wig);
 void set_arglist(char_u *str);
 void check_arg_idx(win_T *win);

--- a/src/proto/quickfix.pro
+++ b/src/proto/quickfix.pro
@@ -28,4 +28,5 @@ int set_ref_in_quickfix(int copyID);
 void ex_cbuffer(exarg_T *eap);
 void ex_cexpr(exarg_T *eap);
 void ex_helpgrep(exarg_T *eap);
+char_u *get_vimgrep_type(char_u *q, exarg_T *eap);
 /* vim: set ft=c : */

--- a/src/proto/screen.pro
+++ b/src/proto/screen.pro
@@ -15,6 +15,7 @@ int conceal_cursor_line(win_T *wp);
 void conceal_check_cursur_line(void);
 void update_single_line(win_T *wp, linenr_T lnum);
 void update_debug_sign(buf_T *buf, linenr_T lnum);
+void SkipRedraw(int enable);
 void updateWindow(win_T *wp);
 int screen_get_current_line_off(void);
 void screen_line(int row, int coloff, int endcol, int clear_width, int rlflag);

--- a/src/screen.c
+++ b/src/screen.c
@@ -1024,6 +1024,25 @@ update_debug_sign(buf_T *buf, linenr_T lnum)
 }
 #endif
 
+    void
+SkipRedraw(int doit)
+{
+    if (doit)
+    {
+	/* return if already busy updating */
+	if (updating_screen)
+	    return;
+#if defined(FEAT_GUI) || defined(PROTO)
+	update_prepare();
+#endif
+    }
+#if defined(FEAT_GUI) || defined(PROTO)
+    else
+	update_finish();
+#endif
+}
+
+
 
 #if defined(FEAT_GUI) || defined(PROTO)
 /*

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -198,6 +198,7 @@ NEW_TESTS = test_arabic.res \
 	    test_textobjects.res \
 	    test_undo.res \
 	    test_usercommands.res \
+	    test_vimgrep_buffer.res \
 	    test_viminfo.res \
 	    test_vimscript.res \
 	    test_visual.res \

--- a/src/testdir/test_vimgrep_buffer.vim
+++ b/src/testdir/test_vimgrep_buffer.vim
@@ -1,0 +1,60 @@
+" Tests for :bvimgrep
+
+func Test_bvimgrep()
+  set hidden
+  " Test1: only grep in current unsaved buffer foo
+  new
+  :f foo
+  $put ='buffer: foo'
+  vimgrep <buffer> /foo/j foo
+  call assert_equal([{'lnum': 2, 'bufnr': 2, 'col': 9, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'buffer: foo'}], getqflist())
+
+  " Test2: buffer foo twice + buffer foobar
+  new
+  f foobar
+  $put = 'buffer: foobar'
+  vimgrepadd <buffer> /foo/j foo*
+  call assert_equal([
+  \ {'lnum': 2, 'bufnr': 2, 'col': 9, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'buffer: foo'},
+  \ {'lnum': 2, 'bufnr': 2, 'col': 9, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'buffer: foo'},
+  \ {'lnum': 2, 'bufnr': 3, 'col': 9, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'buffer: foobar'}
+  \ ], getqflist())
+
+  " Test3: Only search current buffer: testfile
+  new
+  f testfile
+  call append('$', ['test_1', 'test_2', 'test_3', 'test_4', 'test_5'])
+  try
+    vimgrep <buffer> /test_/j
+  catch
+  endtry
+  call assert_equal([
+  \ {'lnum': 2, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_1'},
+  \ {'lnum': 3, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_2'},
+  \ {'lnum': 4, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_3'},
+  \ {'lnum': 5, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_4'},
+  \ {'lnum': 6, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_5'}
+  \ ], getqflist())
+
+  " Test4: Search all 4 buffers
+  vimgrep <buffer> /^\(test_\d\+\|buffer: foo\)/j *
+  call assert_equal([
+  \ {'lnum': 2, 'bufnr': 2, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'buffer: foo'},
+  \ {'lnum': 2, 'bufnr': 3, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'buffer: foobar'},
+  \ {'lnum': 2, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_1'},
+  \ {'lnum': 3, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_2'},
+  \ {'lnum': 4, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_3'},
+  \ {'lnum': 5, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_4'},
+  \ {'lnum': 6, 'bufnr': 4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'test_5'},
+  \ ], getqflist())
+
+  " Test5: bvimgrep aborts, clears qflist
+  set nohidden
+  try
+    vimgrep <buffer> /\(test_\|foo\)/j *
+    call assert_false(1, 'bvimgrep should have failed')
+  catch
+    call assert_exception('E37:')
+    call assert_equal([], getqflist())
+  endtry
+endfunc


### PR DESCRIPTION
This patch adds the :bvimgrep and :bvimgrepadd command.
This is allows to vimgrep for all available buffers and has the
advantage, that vim does not need to load files from disk.

This patch does not add the :blvimgrep(add). Would that be needed
as well? Or should that be :lbvimgrep(add)?

Also this allows to execute :vimgrep in buffers, that have no
corresponding file on disk (or which are changed for which :vimgrep
would only run on the disk-version).

Usage:
:bvimgrep[!] /{pattern}/[g][j] [{buffer} ...]
:bvimgrep[!] {pattern} [{buffer} ...]
            Same as ":vimgrep", except that it searches the given
            buffers. If no buffer is given, searches the current
            buffer. Buffer can be given as buffer name (including
            file-patterns) or number.

```
                    *:bvimgrepa* *:bvimgrepadd*
```

:bvimgrepa[dd][!] /{pattern}/[g][j] [{buffer} ...]
:bvimgrepa[dd][!] {pattern} [{buffer} ...]
            Just like ":bvimgrep", but instead of making a new
            list of errors thep matches are appended to the
            current list.
