### PR TITLE
Add skip expressions to search() function

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5970,7 +5970,8 @@ screenrow()							*screenrow()*
 
 		Note: Same restrictions as with |screencol()|.
 
-search({pattern} [, {flags} [, {stopline} [, {timeout}]]])	*search()*
+								*search()*
+search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 		Search for regexp pattern {pattern}.  The search starts at the
 		cursor position (you can use |cursor()| to set it).
 
@@ -6017,6 +6018,14 @@ search({pattern} [, {flags} [, {stopline} [, {timeout}]]])	*search()*
 		The value must not be negative.  A zero value is like not
 		giving the argument.
 		{only available when compiled with the |+reltime| feature}
+
+		{skip} expression is evaluated with the cursor positioned on
+		the start of the match.  It should return non-zero if this
+		match is to be skipped.  E.g., because it is inside a comment
+		or a string.
+		When {skip} is omitted or empty, every match is accepted.
+		When evaluating {skip} causes an error the search is aborted
+		and -1 returned.
 
 							*search()-sub-match*
 		With the 'p' flag the returned value is one more than the
@@ -6172,7 +6181,8 @@ searchpairpos({start}, {middle}, {end} [, {flags} [, {skip}
 <
 		See |match-parens| for a bigger and more useful example.
 
-searchpos({pattern} [, {flags} [, {stopline} [, {timeout}]]])	*searchpos()*
+								*searchpos()*
+searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 		Same as |search()|, but returns a |List| with the line and
 		column position of the match. The first element of the |List|
 		is the line number and the second element is the byte index of

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -80,3 +80,22 @@ func Test_syntax_after_reload()
   call assert_true(exists('g:gotit'))
   call delete('Xsomefile')
 endfunc
+
+func Test_search_syntax()
+	new
+	call setline(1, [
+	\ '',
+	\ '/* This is VIM */',
+	\ 'Another Text for VIM',
+	\ ' let a="VIM"',
+	\ ''])
+	syntax on
+	syntax match Comment "^/\*.*\*/"
+	syntax match String '".*"'
+	:1
+	call search('VIM', 'w', '', 0, 'synIDattr(synID(line("."),col("."),1),"name")=~?"comment"')
+  call assert_equal('Another Text for VIM', getline('.'))
+	call search('VIM', 'w', '', 0, 'synIDattr(synID(line("."),col("."),1),"name")!~?"string"')
+  call assert_equal(' let a="VIM"', getline('.'))
+	:quit!
+endfu


### PR DESCRIPTION
This allows to search for patterns, and skip on certains expressions
(e.g. skip all matches in comments), similar to how searchpair() works
