### PR TITLE
Add getqfwinid() command.

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4290,6 +4290,15 @@ getqflist()						*getqflist()*
 			:endfor
 
 
+getqfwinid([{winnr}])					*getqfwinid()*
+		Returns the window ID of the quickfix window if active or -1
+		if it's not shown.
+		If {winnr} is supplied the window ID of the location list
+		associated to the window is returned instead, if the argument
+		is invalid -1 is returned.
+		{winnr} can be the window number or the window ID.
+
+
 getreg([{regname} [, 1 [, {list}]]])			*getreg()*
 		The result is a String, which is the contents of register
 		{regname}.  Example: >

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -816,6 +816,8 @@ Quickfix and location lists:			*quickfix-functions*
 	setqflist()		modify a quickfix list
 	getloclist()		list of location list items
 	setloclist()		modify a location list
+	getqfwinid()		get the window ID of a quickfix or location
+				list window
 
 Insert mode completion:				*completion-functions*
 	complete()		set found matches

--- a/src/eval.c
+++ b/src/eval.c
@@ -611,6 +611,7 @@ static void f_getpid(typval_T *argvars, typval_T *rettv);
 static void f_getcurpos(typval_T *argvars, typval_T *rettv);
 static void f_getpos(typval_T *argvars, typval_T *rettv);
 static void f_getqflist(typval_T *argvars, typval_T *rettv);
+static void f_getqfwinid(typval_T *argvars, typval_T *rettv);
 static void f_getreg(typval_T *argvars, typval_T *rettv);
 static void f_getregtype(typval_T *argvars, typval_T *rettv);
 static void f_gettabvar(typval_T *argvars, typval_T *rettv);
@@ -8626,6 +8627,7 @@ static struct fst
     {"getpid",		0, 0, f_getpid},
     {"getpos",		1, 1, f_getpos},
     {"getqflist",	0, 0, f_getqflist},
+    {"getqfwinid",	0, 1, f_getqfwinid},
     {"getreg",		0, 3, f_getreg},
     {"getregtype",	0, 1, f_getregtype},
     {"gettabvar",	2, 3, f_gettabvar},
@@ -13545,13 +13547,37 @@ f_getqflist(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 	wp = NULL;
 	if (argvars[0].v_type != VAR_UNKNOWN)	/* getloclist() */
 	{
-	    wp = find_win_by_nr(&argvars[0], NULL);
+	    wp = find_win_by_nr(&argvars[0], curtab);
 	    if (wp == NULL)
 		return;
 	}
 
 	(void)get_errorlist(wp, rettv->vval.v_list);
     }
+#endif
+}
+
+    static void
+f_getqfwinid(typval_T *argvars, typval_T *rettv)
+{
+#ifdef FEAT_QUICKFIX
+    win_T	*wp = NULL;
+#endif
+
+    rettv->vval.v_number = -1;
+
+#ifdef FEAT_QUICKFIX
+    /* get the loclist for the given window */
+    if (argvars[0].v_type != VAR_UNKNOWN)
+    {
+        wp = find_win_by_nr(&argvars[0], NULL);
+        if (wp == NULL)
+            return;
+    }
+
+    wp = qf_get_cur_window(wp);
+
+    rettv->vval.v_number = (wp != NULL) ? wp->w_id : -1;
 #endif
 }
 
@@ -13791,7 +13817,7 @@ f_getwinposy(typval_T *argvars UNUSED, typval_T *rettv)
     static win_T *
 find_win_by_nr(
     typval_T	*vp,
-    tabpage_T	*tp UNUSED)	/* NULL for current tab page */
+    tabpage_T	*tp UNUSED)
 {
 #ifdef FEAT_WINDOWS
     win_T	*wp;
@@ -13805,6 +13831,16 @@ find_win_by_nr(
 	return NULL;
     if (nr == 0)
 	return curwin;
+
+    /* If 'vp' is a window id and 'tp' is NULL then search in all the tp. */
+    if (nr >= LOWEST_WIN_ID && tp == NULL)
+    {
+        FOR_ALL_TAB_WINDOWS(tp, wp)
+            if (wp->w_id == nr)
+                return wp;
+
+        return NULL;
+    }
 
     for (wp = (tp == NULL || tp == curtab) ? firstwin : tp->tp_firstwin;
 						  wp != NULL; wp = wp->w_next)
@@ -18762,7 +18798,7 @@ f_setloclist(typval_T *argvars, typval_T *rettv)
 
     rettv->vval.v_number = -1;
 
-    win = find_win_by_nr(&argvars[0], NULL);
+    win = find_win_by_nr(&argvars[0], curtab);
     if (win != NULL)
 	set_qf_ll_list(win, &argvars[1], &argvars[2], rettv);
 }
@@ -21596,7 +21632,7 @@ f_winbufnr(typval_T *argvars, typval_T *rettv)
 {
     win_T	*wp;
 
-    wp = find_win_by_nr(&argvars[0], NULL);
+    wp = find_win_by_nr(&argvars[0], curtab);
     if (wp == NULL)
 	rettv->vval.v_number = -1;
     else
@@ -21621,7 +21657,7 @@ f_winheight(typval_T *argvars, typval_T *rettv)
 {
     win_T	*wp;
 
-    wp = find_win_by_nr(&argvars[0], NULL);
+    wp = find_win_by_nr(&argvars[0], curtab);
     if (wp == NULL)
 	rettv->vval.v_number = -1;
     else
@@ -21773,7 +21809,7 @@ f_winwidth(typval_T *argvars, typval_T *rettv)
 {
     win_T	*wp;
 
-    wp = find_win_by_nr(&argvars[0], NULL);
+    wp = find_win_by_nr(&argvars[0], curtab);
     if (wp == NULL)
 	rettv->vval.v_number = -1;
     else

--- a/src/proto/quickfix.pro
+++ b/src/proto/quickfix.pro
@@ -11,6 +11,7 @@ void ex_cclose(exarg_T *eap);
 void ex_copen(exarg_T *eap);
 void ex_cbottom(exarg_T *eap);
 linenr_T qf_current_entry(win_T *wp);
+win_T *qf_get_cur_window(win_T *win);
 int bt_quickfix(buf_T *buf);
 int bt_nofile(buf_T *buf);
 int bt_dontwrite(buf_T *buf);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2960,12 +2960,13 @@ is_qf_win(win_T *win, qf_info_T *qi)
 qf_find_win(qf_info_T *qi)
 {
     win_T	*win;
+    tabpage_T	*tab;
 
-    FOR_ALL_WINDOWS(win)
+    FOR_ALL_TAB_WINDOWS(tab, win)
 	if (is_qf_win(win, qi))
-	    break;
+	    return win;
 
-    return win;
+    return NULL;
 }
 
 /*
@@ -2983,6 +2984,21 @@ qf_find_buf(qf_info_T *qi)
 	    return win->w_buffer;
 
     return NULL;
+}
+
+    win_T *
+qf_get_cur_window(win_T *win)
+{
+    qf_info_T	*qi = &ql_info;
+
+    if (win != NULL)
+    {
+	qi = GET_LOC_LIST(win);
+	if (qi == NULL)
+	    return NULL;
+    }
+
+    return qf_find_win(qi);
 }
 
 /*

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1438,3 +1438,27 @@ function Test_cbottom()
   call XbottomTests('c')
   call XbottomTests('l')
 endfunction
+
+function s:test_getqfwinid(cchar)
+    call s:setup_commands(a:cchar)
+
+    Xclose
+
+    let this_win = win_getid()
+    call assert_equal(-1, getqfwinid())
+
+    Xgetexpr ['non-error 1', 'non-error 2', 'non-error 3']
+    Xopen
+
+    if a:cchar == 'c'
+        call assert_equal(win_getid(), getqfwinid())
+    else
+        call assert_equal(win_getid(), getqfwinid(this_win))
+    endif
+    Xclose
+endfunction
+
+function Test_getqfwinid()
+    call s:test_getqfwinid('c')
+    call s:test_getqfwinid('l')
+endfunction


### PR DESCRIPTION
This patch adds two new arguments for `winnr()`: `Q` and `L` (I'm not 100% happy with the names) that retrieve the currently active quickfix or loclist window respectively.
Some tests could be added but I wanted to know if you were interested in something like this first.
