### PR TITLE
Fix completeopt noinsert select problem

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -2827,6 +2827,7 @@ set_completion(colnr_T startcol, list_T *list)
     }
     else
 	ins_complete(Ctrl_N, FALSE);
+    compl_enter_selects = compl_no_insert;
 
     /* Lazily show the popup menu, unless we got interrupted. */
     if (!compl_interrupted)


### PR DESCRIPTION
Reproduce ways
1.    vim -Nu test.vim
2.   Press `i<F5><CR>`

``` vim
" test.vim
set completeopt+=noinsert

inoremap <F5>  <C-R>=Test()<CR>

function! Test() abort
  call complete(1, ['source', 'soundfold'])
  return ''
endfunction
```

Expected result:

```
source
```

Current result:

```
```

Note: It does not fix #874 problem.
