### PR TITLE
Add test_increment_dbcs.vim for Vim 7.4.1948

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2031,6 +2031,7 @@ test_arglist \
 	test_help_tagjump \
 	test_history \
 	test_increment \
+	test_increment_dbcs \
 	test_join \
 	test_json \
 	test_langmap \

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -173,6 +173,7 @@ NEW_TESTS = test_arglist.res \
 	    test_hardcopy.res \
 	    test_history.res \
 	    test_increment.res \
+	    test_increment_dbcs.res \
 	    test_json.res \
 	    test_langmap.res \
 	    test_man.res \

--- a/src/testdir/test_increment_dbcs.vim
+++ b/src/testdir/test_increment_dbcs.vim
@@ -1,0 +1,30 @@
+" Tests for using Ctrl-A/Ctrl-X using DBCS.
+if !has('multi_byte')
+  finish
+endif
+set encoding=cp932
+scriptencoding cp932
+
+func SetUp()
+  new
+  set nrformats&
+endfunc
+
+func TearDown()
+  bwipe!
+endfunc
+
+func Test_increment_dbcs_1()
+  set nrformats+=alpha
+  call setline(1, ["ŽR1"])
+  exec "norm! 0\<C-A>"
+  call assert_equal(["ŽR2"], getline(1, '$'))
+  call assert_equal([0, 1, 3, 0], getpos('.'))
+
+  call setline(1, ["‚`‚a‚b0xDE‚e"])
+  exec "norm! 0\<C-X>"
+  call assert_equal(["‚`‚a‚b0xDD‚e"], getline(1, '$'))
+  call assert_equal([0, 1, 10, 0], getpos('.'))
+endfunc
+
+" vim: tabstop=2 shiftwidth=2 expandtab


### PR DESCRIPTION
Hi,

I wrote a test for Vim 7.4.1948
https://github.com/vim/vim/commit/ad5ca9bc1e7145474adb082775a805f1731e9e37

Related thread is here:
https://groups.google.com/d/msg/vim_dev/6LtfyZw7NF4/3g9h6LDWJwAJ
## :+1: 

Best regards,
Hirohito Higashi (a.k.a. h_east)
