### PR TITLE
Recognize `.webmanifest` files as JSON

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1019,7 +1019,7 @@ au BufNewFile,BufRead *.jgr			setf jgraph
 au BufNewFile,BufRead *.jov,*.j73,*.jovial	setf jovial
 
 " JSON
-au BufNewFile,BufRead *.json,*.jsonp		setf json
+au BufNewFile,BufRead *.json,*.jsonp,*.webmanifest      setf json
 
 " Kixtart
 au BufNewFile,BufRead *.kix			setf kix


### PR DESCRIPTION
[Web App Manifest](https://w3c.github.io/manifest/) files (having [`webmanifest`](https://w3c.github.io/manifest/#media-type-registration) as the recommended file extension) [use the JSON format](https://w3c.github.io/manifest/#abstract).

See also: https://w3c.github.io/manifest/
## 

Cc @marcoscaceres
## 

_**Edit**_: Added in https://github.com/vim/vim/commit/e18dbe865d190e74fb5d43ac8bc6ac22507d0223. 🎉 
