### PR TITLE
Implement EVENT_DIRCHANGED and EVENT_DIRCHANGEDLOCAL and ...

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -295,6 +295,8 @@ Name			triggered by ~
 |FileChangedShellPost|	After handling a file changed since editing started
 |FileChangedRO|		before making the first change to a read-only file
 
+|DirChanged|		after the working directory has changed
+
 |ShellCmdPost|		after executing a shell command
 |ShellFilterPost|	after filtering with a shell command
 
@@ -626,6 +628,10 @@ FileChangedRO			Before making the first change to a read-only
 							*E881*
 				If the number of lines changes saving for undo
 				may fail and the change will be aborted.
+							*DirChanged*
+DirChanged			The working directory has changed in response
+				to the |:cd| or |:lcd| commands, or as a result of
+				the 'autochdir' option.
 							*FileChangedShell*
 FileChangedShell		When Vim notices that the modification time of
 				a file has changed since editing started.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1862,8 +1862,19 @@ do_autochdir(void)
 {
     if ((starting == 0 || test_autochdir)
 	    && curbuf->b_ffname != NULL
-	    && vim_chdirfile(curbuf->b_ffname) == OK)
+	    && vim_chdirfile(curbuf->b_ffname) == OK) {
+#ifdef FEAT_AUTOCMD
+	char_u dir[MAXPATHL];
+#endif
+
 	shorten_fnames(TRUE);
+
+#ifdef FEAT_AUTOCMD
+	vim_strncpy(dir, curbuf->b_ffname, MAXPATHL - 1);
+	*gettail_sep(dir) = NUL;
+	apply_autocmds(EVENT_DIRCHANGED, (char_u *)"window", dir, FALSE, curbuf);
+#endif
+    }
 }
 #endif
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -9048,11 +9048,17 @@ ex_cd(exarg_T *eap)
 	    EMSG(_(e_failed));
 	else
 	{
-	    post_chdir(eap->cmdidx == CMD_lcd || eap->cmdidx == CMD_lchdir);
+	    char_u *chdir_scope;
+	    int is_local_chdir = eap->cmdidx == CMD_lcd || eap->cmdidx == CMD_lchdir;
+	    post_chdir(is_local_chdir);
 
 	    /* Echo the new current directory if the command was typed. */
 	    if (KeyTyped || p_verbose >= 5)
 		ex_pwd(eap);
+#ifdef FEAT_AUTOCMD
+	    chdir_scope = is_local_chdir ? (char_u *)"window" : (char_u *)"global";
+	    apply_autocmds(EVENT_DIRCHANGED, chdir_scope, new_dir, FALSE, curbuf);
+#endif
 	}
 	vim_free(tofree);
     }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -7797,6 +7797,7 @@ static struct event_name
     {"CursorHoldI",	EVENT_CURSORHOLDI},
     {"CursorMoved",	EVENT_CURSORMOVED},
     {"CursorMovedI",	EVENT_CURSORMOVEDI},
+    {"DirChanged",	EVENT_DIRCHANGED},
     {"EncodingChanged",	EVENT_ENCODINGCHANGED},
     {"FileEncoding",	EVENT_ENCODINGCHANGED},
     {"FileAppendPost",	EVENT_FILEAPPENDPOST},
@@ -9587,7 +9588,7 @@ apply_autocmds_group(
     {
 	sfname = vim_strsave(fname);
 	/* Don't try expanding FileType, Syntax, FuncUndefined, WindowID,
-	 * ColorScheme or QuickFixCmd* */
+	 * ColorScheme, QuickFixCmd*, or DirChanged */
 	if (event == EVENT_FILETYPE
 		|| event == EVENT_SYNTAX
 		|| event == EVENT_FUNCUNDEFINED
@@ -9596,7 +9597,8 @@ apply_autocmds_group(
 		|| event == EVENT_QUICKFIXCMDPRE
 		|| event == EVENT_COLORSCHEME
 		|| event == EVENT_OPTIONSET
-		|| event == EVENT_QUICKFIXCMDPOST)
+		|| event == EVENT_QUICKFIXCMDPOST
+		|| event == EVENT_DIRCHANGED)
 	    fname = vim_strsave(fname);
 	else
 	    fname = FullName_save(fname, FALSE);

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -1178,3 +1178,38 @@ func Test_nocatch_wipe_dummy_buffer()
   call assert_fails('lv½ /x', 'E480')
   au!
 endfunc
+
+function s:Before_test_dirchanged()
+  augroup test_dirchanged
+    autocmd!
+  augroup END
+  let s:li=[]
+  let s:dir_this=getcwd()
+  let s:dir_other=s:dir_this . '/foo'
+endfunc
+
+function s:After_test_dirchanged()
+  exe 'cd' s:dir_this
+endfunc
+
+function Test_dirchanged_global()
+  call s:Before_test_dirchanged()
+  autocmd test_dirchanged DirChanged global call add(s:li, "cd:")
+  autocmd test_dirchanged DirChanged global call add(s:li, expand("<afile>"))
+  exe 'cd' s:dir_other
+  call assert_equal(["cd:", s:dir_other], s:li)
+  exe 'lcd' s:dir_other
+  call assert_equal(["cd:", s:dir_other], s:li)
+  call s:After_test_dirchanged()
+endfunc
+
+function Test_dirchanged_local()
+  call s:Before_test_dirchanged()
+  autocmd test_dirchanged DirChanged window call add(s:li, "lcd:")
+  autocmd test_dirchanged DirChanged window call add(s:li, expand("<afile>"))
+  exe 'cd' s:dir_other
+  call assert_equal([], s:li)
+  exe 'lcd' s:dir_other
+  call assert_equal(["lcd:", s:dir_other], s:li)
+  call s:After_test_dirchanged()
+endfunc

--- a/src/vim.h
+++ b/src/vim.h
@@ -1275,6 +1275,7 @@ enum auto_event
     EVENT_CMDWINLEAVE,		/* before leaving the cmdline window */
     EVENT_COLORSCHEME,		/* after loading a colorscheme */
     EVENT_COMPLETEDONE,		/* after finishing insert complete */
+    EVENT_DIRCHANGED,		/* after changing directory as a result of user cmd */
     EVENT_FILEAPPENDPOST,	/* after appending to a file */
     EVENT_FILEAPPENDPRE,	/* before appending to a file */
     EVENT_FILEAPPENDCMD,	/* append to a file using command */


### PR DESCRIPTION
... fire autocmds on :cd and :lcd family of commands, as well as on autochdir.

This is intended to fix #868.

Note that it only responds to user-initiated changes.
