### PR TITLE
Make test_listlbr_utf8 succeed when textwidth != 0

### DIFF
--- a/src/testdir/test_listlbr_utf8.in
+++ b/src/testdir/test_listlbr_utf8.in
@@ -96,7 +96,7 @@ GGlGGlGGlGGlGGlGGlGGlGGlGGlGGl
 :else
 :   call append('$', "Not all attributes are different")
 :endif
-:set cpo&vim linebreak selection=exclusive
+:set cpo&vim linebreak selection=exclusive textwidth=0
 :"
 :let g:test ="Test 8: set linebreak with visual block mode and v_b_A and selection=exclusive and multibyte char"
 :$put =g:test


### PR DESCRIPTION
Around one month ago, the test suite started to fail. It was around the 
same day as I installed a new kernel, so I thought that something was 
wrong locally. But when I noticed today that it also fails on a server 
without any changes, something weird was going on.

The failing test is `test_listlbr_utf8`:

```
~
[No Name]
Executing Test_tostring()
"colored" [New File]
Executing Test_valid()
Executing Test_version()
Executing Test_vim_did_enter()
Executing Test_window_cmd_cmdwin_with_vsp()
Executing Test_window_cmd_ls0_with_split()
"messages" 418L, 11939C written

Test results:
test_listlbr_utf8 FAILED
TEST FAILURE
Makefile:41: recipe for target 'report' failed
make[2]: *** [report] Error 1
make[2]: Leaving directory '/home/sunny/src/other/vim/src/testdir'
Makefile:1942: recipe for target 'test' failed
make[1]: *** [test] Error 2
make[1]: Leaving directory '/home/sunny/src/other/vim/src'
Makefile:36: recipe for target 'test' failed
make: *** [test] Error 2
```

The commit that result in the fail is 74db34c (Vim 7.4.753, 2015-06-25), 
but what triggers it, is a change I did some weeks ago in 
~/.vim/syntax/c.vim, setting textwidth=72. I later changed it to 79 
because it turns out you were right, but because it isn't 0, the test 
fails. This patch adds textwidth=0 to test_listlbr_utf8.in which makes 
the test pass.
