### PR TITLE
Added .pythonstartup detection as Python file.

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1624,6 +1624,9 @@ au BufNewFile,BufRead *.pyx,*.pxd		setf pyrex
 " Python
 au BufNewFile,BufRead *.py,*.pyw		setf python
 
+" Python Shell Startup
+au BufNewFile,BufRead .pythonstartup            setf python
+
 " Quixote (Python-based web framework)
 au BufNewFile,BufRead *.ptl			setf python
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1625,7 +1625,7 @@ au BufNewFile,BufRead *.pyx,*.pxd		setf pyrex
 au BufNewFile,BufRead *.py,*.pyw		setf python
 
 " Python Shell Startup
-au BufNewFile,BufRead .pythonstartup            setf python
+au BufNewFile,BufRead .pythonstartu		setf python
 
 " Quixote (Python-based web framework)
 au BufNewFile,BufRead *.ptl			setf python

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1624,8 +1624,8 @@ au BufNewFile,BufRead *.pyx,*.pxd		setf pyrex
 " Python
 au BufNewFile,BufRead *.py,*.pyw		setf python
 
-" Python Shell Startup
-au BufNewFile,BufRead .pythonstartu		setf python
+" Python Shell Startup Files
+au BufNewFile,BufRead .pythonstartup,.pythonrc	setf python
 
 " Quixote (Python-based web framework)
 au BufNewFile,BufRead *.ptl			setf python


### PR DESCRIPTION
As I began working with Python in MacVim, I was surprised that `.pythonstartup` wasn't automatically set as a Python file. I hope it's not presumptuous of me to edit the `filetype.vim` file and offer a pull request. :)
