### PR TITLE
Show keymap name in mode indicator

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -3558,8 +3558,6 @@ Multi-byte characters:
     convert_input() for Mac GUI.
 -   Add mnemonics from RFC1345 longer than two characters.
     Support CTRL-K _{mnemonic}_
-7   In "-- INSERT (lang) --" show the name of the keymap used instead of
-    "lang". (Ilya Dogolazky)
 -   Make 'breakat' accept multi-byte characters.  Problem: can't use a lookup
     table anymore (breakat_flags[]).
     Simplistic solution: when 'formatoptions' contains "m" also break a line

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4114,7 +4114,7 @@ build_stl_str_hl(
 
 	case STL_KEYMAP:
 	    fillable = FALSE;
-	    if (get_keymap_str(wp, tmp, TMPLEN))
+	    if (get_keymap_str(wp, (char_u *)"<%s>", tmp, TMPLEN))
 		str = tmp;
 	    break;
 	case STL_PAGENUM:

--- a/src/proto/screen.pro
+++ b/src/proto/screen.pro
@@ -23,7 +23,7 @@ void win_redraw_last_status(frame_T *frp);
 void win_redr_status_matches(expand_T *xp, int num_matches, char_u **matches, int match, int showtail);
 void win_redr_status(win_T *wp);
 int stl_connected(win_T *wp);
-int get_keymap_str(win_T *wp, char_u *buf, int len);
+int get_keymap_str(win_T *wp, char_u *fmt, char_u *buf, int len);
 void screen_putchar(int c, int row, int col, int attr);
 void screen_getbytes(int row, int col, char_u *bytes, int *attrp);
 void screen_puts(char_u *text, int row, int col, int attr);

--- a/src/screen.c
+++ b/src/screen.c
@@ -6767,7 +6767,7 @@ win_redr_status(win_T *wp)
 	screen_fill(row, row + 1, len + W_WINCOL(wp),
 			this_ru_col + W_WINCOL(wp), fillchar, fillchar, attr);
 
-	if (get_keymap_str(wp, NameBuff, MAXPATHL)
+	if (get_keymap_str(wp, (char_u *)"<%s>", NameBuff, MAXPATHL)
 		&& (int)(this_ru_col - len) > (int)(STRLEN(NameBuff) + 1))
 	    screen_puts(NameBuff, row, (int)(this_ru_col - STRLEN(NameBuff)
 						   - 1 + W_WINCOL(wp)), attr);
@@ -6862,6 +6862,7 @@ stl_connected(win_T *wp)
     int
 get_keymap_str(
     win_T	*wp,
+    char_u	*fmt,	    /* format string containing one %s item */
     char_u	*buf,	    /* buffer for the result */
     int		len)	    /* length of buffer */
 {
@@ -6894,9 +6895,7 @@ get_keymap_str(
 #endif
 		p = (char_u *)"lang";
 	}
-	if ((int)(STRLEN(p) + 3) < len)
-	    sprintf((char *)buf, "<%s>", p);
-	else
+	if (vim_snprintf((char *)buf, len, (char *)fmt, p) > len - 1)
 	    buf[0] = NUL;
 #ifdef FEAT_EVAL
 	vim_free(s);
@@ -10166,7 +10165,8 @@ showmode(void)
 			MSG_PUTS_ATTR(_(" Arabic"), attr);
 		    else
 # endif
-			MSG_PUTS_ATTR(_(" (lang)"), attr);
+			if (get_keymap_str(curwin, (char_u *)" (%s)", NameBuff, MAXPATHL))
+			    MSG_PUTS_ATTR(NameBuff, attr);
 		}
 #endif
 		if ((State & INSERT) && p_paste)


### PR DESCRIPTION
Show active keymap name instead of `lang` in `-- INSERT (lang) --` mode indicator.
