### PR TITLE
python syntax: Fix False and None highlighting

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -72,7 +72,7 @@ set cpo&vim
 "   built-in below (use 'from __future__ import print_function' in 2)
 " - async and await were added in Python 3.5 and are soft keywords.
 "
-syn keyword pythonStatement	False, None, True
+syn keyword pythonStatement	False None True
 syn keyword pythonStatement	as assert break continue del exec global
 syn keyword pythonStatement	lambda nonlocal pass print return with yield
 syn keyword pythonStatement	class def nextgroup=pythonFunction skipwhite


### PR DESCRIPTION
When python_no_builtin_highlight is set, both True, False and None should be highlighted. Remove commas (invalid in syn keyword).
