### PR TITLE
Increase support for Docker keywords and filenames

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -534,7 +534,7 @@ au BufNewFile,BufRead configure.in,configure.ac setf config
 au BufNewFile,BufRead *.cu			setf cuda
 
 " Dockerfile
-au BufNewFile,BufRead Dockerfile		setf dockerfile
+au BufNewFile,BufRead Dockerfile,*.Dockerfile         setf dockerfile
 
 " WildPackets EtherPeek Decoder
 au BufNewFile,BufRead *.dcd			setf dcd

--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -13,7 +13,7 @@ let b:current_syntax = "dockerfile"
 
 syntax case ignore
 
-syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY)\s/
+syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\s/
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/
 


### PR DESCRIPTION
A number of keywords weren't included in the default configuration and have been added. Additionally, those present were ordered inconsistently (now alphabetically).

While `Dockerfile` is the main filename, often `*.Dockerfile` is used in complex builds. Vim now recognises dockerfiles with those names.
