### PR TITLE
Update vimrc_example to check for +persistent_undo

### DIFF
--- a/runtime/vimrc_example.vim
+++ b/runtime/vimrc_example.vim
@@ -25,7 +25,9 @@ if has("vms")
   set nobackup		" do not keep a backup file, use versions instead
 else
   set backup		" keep a backup file (restore to previous version)
-  set undofile		" keep an undo file (undo changes after closing)
+  if has('persistent_undo')
+    set undofile	" keep an undo file (undo changes after closing)
+  endif
 endif
 set history=50		" keep 50 lines of command line history
 set ruler		" show the cursor position all the time


### PR DESCRIPTION
Otherwise initialization could fail with

```
Error detected while processing ~/.vimrc:
line   28:
E518: Unknown option: undofile
```

if `+persistent_undo` is not enabled.
