### PR TITLE
Add two entries to .gitignore, ignore leftovers from "make test"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,7 @@ src/testdir/test.log
 src/testdir/dostmp/*
 src/testdir/messages
 src/testdir/viminfo
+src/testdir/Xnetbeans
 src/memfile_test
 src/json_test
+src/message_test


### PR DESCRIPTION
Problem:    After "make test", a couple of files are listed as unknown in "git status".
Solution:   Add two entries to .gitignore.
