### PR TITLE
Fix jumps in matchit.vim

### DIFF
--- a/runtime/pack/dist/opt/matchit/plugin/matchit.vim
+++ b/runtime/pack/dist/opt/matchit/plugin/matchit.vim
@@ -1,8 +1,9 @@
 "  matchit.vim: (global plugin) Extended "%" matching
-"  Last Change: Fri Jan 25 10:00 AM 2008 EST
+"  Last Change: Fri Jul 29 01:20 AM 2016 EST
 "  Maintainer:  Benji Fisher PhD   <benji@member.AMS.org>
 "  Version:     1.13.2, for Vim 6.3+
 "		Fix from Fernando Torres included.
+"		Fix from Tommy Allen included.
 "  URL:		http://www.vim.org/script.php?script_id=39
 
 " Documentation:
@@ -255,12 +256,7 @@ function! s:Match_wrapper(word, forward, mode) range
 
   " Fifth step:  actually start moving the cursor and call searchpair().
   " Later, :execute restore_cursor to get to the original screen.
-  let restore_cursor = virtcol(".") . "|"
-  normal! g0
-  let restore_cursor = line(".") . "G" .  virtcol(".") . "|zs" . restore_cursor
-  normal! H
-  let restore_cursor = "normal!" . line(".") . "Gzt" . restore_cursor
-  execute restore_cursor
+  let view = winsaveview()
   call cursor(0, curcol + 1)
   " normal! 0
   " if curcol
@@ -274,7 +270,7 @@ function! s:Match_wrapper(word, forward, mode) range
   let sp_return = searchpair(ini, mid, fin, flag, skip)
   let final_position = "call cursor(" . line(".") . "," . col(".") . ")"
   " Restore cursor position and original screen.
-  execute restore_cursor
+  call winrestview(view)
   normal! m'
   if sp_return > 0
     execute final_position
@@ -635,7 +631,7 @@ endfun
 " idea to give it its own matching patterns.
 fun! s:MultiMatch(spflag, mode)
   if !exists("b:match_words") || b:match_words == ""
-    return ""
+    return {}
   end
   let restore_options = (&ic ? "" : "no") . "ignorecase"
   if exists("b:match_ignorecase")
@@ -695,15 +691,7 @@ fun! s:MultiMatch(spflag, mode)
     let skip = 's:comment\|string'
   endif
   let skip = s:ParseSkip(skip)
-  " let restore_cursor = line(".") . "G" . virtcol(".") . "|"
-  " normal! H
-  " let restore_cursor = "normal!" . line(".") . "Gzt" . restore_cursor
-  let restore_cursor = virtcol(".") . "|"
-  normal! g0
-  let restore_cursor = line(".") . "G" .  virtcol(".") . "|zs" . restore_cursor
-  normal! H
-  let restore_cursor = "normal!" . line(".") . "Gzt" . restore_cursor
-  execute restore_cursor
+  let view = winsaveview()
 
   " Third step: call searchpair().
   " Replace '\('--but not '\\('--with '\%(' and ',' with '\|'.
@@ -721,14 +709,14 @@ fun! s:MultiMatch(spflag, mode)
   while level
     if searchpair(openpat, '', closepat, a:spflag, skip) < 1
       call s:CleanUp(restore_options, a:mode, startline, startcol)
-      return ""
+      return {}
     endif
     let level = level - 1
   endwhile
 
-  " Restore options and return a string to restore the original position.
+  " Restore options and return view dict to restore the original position.
   call s:CleanUp(restore_options, a:mode, startline, startcol)
-  return restore_cursor
+  return view
 endfun
 
 " Search backwards for "if" or "while" or "<tag>" or ...


### PR DESCRIPTION
matchit.vim uses `normal! zt` to reset the buffer's top line but doesn't prevent it from being added to the jump list.  This uses `winsaveview()` and `winrestview()` to restore the view instead.
