### PR TITLE
Add support for "match" textobjects

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -659,6 +659,14 @@ i`							*v_i`* *i`*
 			Special case: With a count of 2 the quotes are
 			included, but no extra white space as with a"/a'/a`.
 
+am{char}						*v_am* *am*
+			"a matched {char}".  Selects the text from the
+			previous {char} until the next {char}.  A count is
+			currently not used.
+
+im{char}						*v_im* *im*
+			Like am{char} but exclude the {char}.
+
 When used after an operator:
 For non-block objects:
 	For the "a" commands: The operator applies to the object and the white

--- a/src/normal.c
+++ b/src/normal.c
@@ -892,6 +892,7 @@ getcount:
 	}
 	lang = (repl || (nv_cmds[idx].cmd_flags & NV_LANG));
 
+getchar:
 	/*
 	 * Get a second or third character.
 	 */
@@ -1039,6 +1040,18 @@ getcount:
 	    }
 	    ++no_mapping;
 	}
+#ifdef FEAT_TEXTOBJ
+	/*
+	 * The im/am text object needs one more character to use as left/right
+	 * bounds.
+	 */
+	if ((ca.cmdchar == 'a' || ca.cmdchar == 'i') && ca.nchar == 'm'
+		&& ca.extra_char == NUL)
+	{
+	    cp = &ca.extra_char;
+	    goto getchar;
+	}
+#endif
 	--no_mapping;
 	--allow_keys;
     }
@@ -1412,6 +1425,16 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 	    prep_redo(oap->regname, cap->count0,
 		    get_op_char(oap->op_type), get_extra_op_char(oap->op_type),
 		    oap->motion_force, cap->cmdchar, cap->nchar);
+#ifdef FEAT_TEXTOBJ
+	    /*
+	     * If using the am/im text object, there is one additional
+	     * character used as left/right bounds which needs to be added to
+	     * the redo buffer.
+	     */
+	    if ((cap->cmdchar == 'a' || cap->cmdchar == 'i')
+		&& cap->nchar == 'm' && cap->extra_char != NUL)
+		AppendCharToRedobuff(cap->extra_char);
+#endif
 	    if (cap->cmdchar == '/' || cap->cmdchar == '?') /* was a search */
 	    {
 		/*
@@ -9156,6 +9179,10 @@ nv_object(
 	case '`': /* "a`" = a backtick quoted string */
 		flag = current_quote(cap->oap, cap->count1, include,
 								  cap->nchar);
+		break;
+	case 'm': /* "am{char}" = a matched pair of characters */
+		flag = current_match(cap->oap, cap->count1, include,
+								  cap->extra_char);
 		break;
 #if 0	/* TODO */
 	case 'S': /* "aS" = a section */

--- a/src/proto/search.pro
+++ b/src/proto/search.pro
@@ -43,6 +43,7 @@ int current_block(oparg_T *oap, long count, int include, int what, int other);
 int current_tagblock(oparg_T *oap, long count_arg, int include);
 int current_par(oparg_T *oap, long count, int include, int type);
 int current_quote(oparg_T *oap, long count, int include, int quotechar);
+int current_match(oparg_T *oap, long count, int include, int matchchar);
 int current_search(long count, int forward);
 int linewhite(linenr_T lnum);
 void find_pattern_in_path(char_u *ptr, int dir, int len, int whole, int skip_comments, int type, long count, int action, linenr_T start_lnum, linenr_T end_lnum);

--- a/src/testdir/test_textobjects.vim
+++ b/src/testdir/test_textobjects.vim
@@ -417,6 +417,88 @@ function! Test_match_count()
   endfor
 endfunction!
 
+function! Test_match_visual()
+  for c in [',', '‽']
+    " Single char between matches should immediately expand for im
+    let one = 'X'.c.'foo'.c.'bar'.c.'i'.c.'baz'.c.'quux'.c.'X'
+    " Two chars between characters should first select both chars for im
+    let two = 'X'.c.'foo'.c.'bar'.c.'ii'.c.'baz'.c.'quux'.c.'X'
+
+    " Basic visual selection works
+    call setline(line('.'), one)
+    call setreg('"', '')
+    call feedkeys('0fivim'.c.'y', 'nx')
+    call assert_equal('bar'.c.'i'.c.'baz', getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fivam'.c.'y', 'nx')
+    call assert_equal(c.'i'.c, getreg('"'))
+
+    call setline(line('.'), two)
+    call setreg('"', '')
+    call feedkeys('0fivim'.c.'y', 'nx')
+    call assert_equal('ii', getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fivam'.c.'y', 'nx')
+    call assert_equal(c.'ii'.c, getreg('"'))
+
+    " Visual selection with count
+    call setline(line('.'), one)
+    call setreg('"', '')
+    call feedkeys('0fiv2im'.c.'y', 'nx')
+    call assert_equal('foo'.c.'bar'.c.'i'.c.'baz'.c.'quux', getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fiv2am'.c.'y', 'nx')
+    call assert_equal(c.'bar'.c.'i'.c.'baz'.c, getreg('"'))
+
+    call setline(line('.'), two)
+    call setreg('"', '')
+    call feedkeys('0fiv2im'.c.'y', 'nx')
+    call assert_equal('bar'.c.'ii'.c.'baz', getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fiv2am'.c.'y', 'nx')
+    call assert_equal(c.'bar'.c.'ii'.c.'baz'.c, getreg('"'))
+
+    " Expand an existing visual selection
+    call setline(line('.'), one)
+    call setreg('"', '')
+    call feedkeys('0fivim'.c.'im'.c.'y', 'nx')
+    call assert_equal('foo'.c.'bar'.c.'i'.c.'baz'.c.'quux', getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fivam'.c.'am'.c.'y', 'nx')
+    call assert_equal(c.'bar'.c.'i'.c.'baz'.c, getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fivim'.c.'am'.c.'y', 'nx')
+    call assert_equal(c.'bar'.c.'i'.c.'baz'.c, getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fivam'.c.'im'.c.'y', 'nx')
+    call assert_equal('bar'.c.'i'.c.'baz', getreg('"'))
+
+    call setline(line('.'), two)
+    call setreg('"', '')
+    call feedkeys('0fivim'.c.'im'.c.'y', 'nx')
+    call assert_equal('bar'.c.'ii'.c.'baz', getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fivam'.c.'am'.c.'y', 'nx')
+    call assert_equal(c.'bar'.c.'ii'.c.'baz'.c, getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fivim'.c.'am'.c.'y', 'nx')
+    call assert_equal(c.'ii'.c, getreg('"'))
+
+    call setreg('"', '')
+    call feedkeys('0fivam'.c.'im'.c.'y', 'nx')
+    call assert_equal('bar'.c.'ii'.c.'baz', getreg('"'))
+  endfor
+endfunction
+
 function! Test_match_fail()
   " Unbalanced on the right
   call setline(line('.'), 'foo,i')


### PR DESCRIPTION
Two new textobjects, "im{char}" and "am{char}" are available which will
act on the text between two {char} (inclusive with am).  The textobject
will span multiple lines, if needed, to find the contained text.

This patch was originally written by Daniel "paradigm" Thau, as
discussed in the "Patch to utilize undefined text-objects" [thread](https://www.mail-archive.com/vim_dev%40googlegroups.com/msg26189.html).
The most recent version of the [patch](https://www.mail-archive.com/vim_dev%40googlegroups.com/msg27207.html) was updated against current Vim
code, tests converted to the new style, and additional tests added.

TODO:
- [x] Determine whether this should be considered a "block object", since that impacts visual selection behavior and use with an operator
  - [ ] Verify the text-object behaves as a [block object](https://github.com/vim/vim/blob/d6ef5f9b3d3df2d5dcc666c8741e99fcc77043f6/runtime/doc/motion.txt#L667-L690)
- [x] Tests for expanding visual selections (written before realizing different behaviors for "block" vs. non-block text objects)
  - [ ] Fix visual selection behavior
- [ ] Tests for 'selection' set to "exclusive"