### PR TITLE
try to guess if a terminal has an xterm-like mouse

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2258,8 +2258,9 @@ vim_is_xterm(char_u *name)
     int
 use_xterm_like_mouse(char_u *name)
 {
-    return (name != NULL
-	    && (term_is_xterm || STRNICMP(name, "screen", 6) == 0));
+    return (NULL != name) && (
+	    is_xterm_like_mouse_from_termcap(name) ||
+	    term_is_xterm || STRNICMP(name, "screen", 6) == 0);
 }
 #endif
 

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -46,6 +46,7 @@ int swapping_screen(void);
 void setmouse(void);
 int mouse_has(int c);
 int mouse_model_popup(void);
+int is_xterm_like_mouse_from_termcap(char_u *name);
 void scroll_start(void);
 void cursor_on(void);
 void cursor_off(void);

--- a/src/term.c
+++ b/src/term.c
@@ -3435,6 +3435,33 @@ mouse_model_popup(void)
 {
     return (p_mousem[0] == 'p');
 }
+
+/*
+ * Return TRUE if the terminal (with terminal name name) has an xterm-style
+ * mouse according to the terminal's capabilities, or FALSE if unknown, or on
+ * error.
+ *
+ * This routine will not give a definite negative, i.e. is it returns FALSE, it
+ * just means it cannot guess at the terminal's capabilities based on its
+ * termcap entry and its own rather dumb internal logic...
+ */
+    int
+is_xterm_like_mouse_from_termcap(char_u* name)
+{
+#if defined(HAVE_TGETENT)
+    char_u tbuf[TBUFSZ];
+    if (NULL == tgetent_error(tbuf, name)) {
+	char_u *tp = tbuf;
+	/* okay, don't have to guess based on terminal name */
+	const char_u* kmous = TGETSTR("Km", &tp);
+	if (kmous) {
+	    /* check if mouse works as the xterm one does */
+	    if (0 == strcmp((const char*) kmous, "\033[M")) return TRUE;
+	}
+    }
+#endif
+    return FALSE;
+}
 #endif
 
 /*


### PR DESCRIPTION
Try to guess if a terminal has an xterm-like mouse (the st terminal from st.suckless.org has, but adding such a short string to match against is asking for trouble...).

The routine to guess uses the termcap entry, specifically the kmous/Km field, and checks if it's equal to "ESC[M", which is the string found in all xterm-like termcap entries with mouse support I've seen recently. If this yields a positive result, it is taken, else the old heuristics of comparing various known good strings to $TERM remains as a fallback.
