### PR TITLE
st (simple terminal from suckless.org) supports xterm-style mouse

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2259,7 +2259,10 @@ vim_is_xterm(char_u *name)
 use_xterm_like_mouse(char_u *name)
 {
     return (name != NULL
-	    && (term_is_xterm || STRNICMP(name, "screen", 6) == 0));
+	    && (term_is_xterm || STRNICMP(name, "screen", 6) == 0
+		|| STRNICMP(name, "st", 3) == 0 
+		|| STRNICMP(name, "st-", 3) == 0
+		|| STRNICMP(name, "stterm", 6) == 0));
 }
 #endif
 


### PR DESCRIPTION
Add an explicit match against $TERM: if $TERM is either exactly "st" or
starts with "st-", or with "stterm", xterm-like mouse support is
enabled. The slightly convoluted logic in the string match is there to
avoid false positives from terminal names like "st52", and whatever else
might exist out there.
