### PR TITLE
Fix logic error which causes buffers to be unloaded instead of hidden.

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7198,7 +7198,7 @@ ex_quit(exarg_T *eap)
 	need_mouse_correct = TRUE;
 # endif
 	/* close window; may free buffer */
-	win_close(wp, !P_HID(wp->w_buffer) || eap->forceit);
+	win_close(wp, !P_HID(wp->w_buffer) && eap->forceit);
 #endif
     }
 }

--- a/src/testdir/test31.in
+++ b/src/testdir/test31.in
@@ -34,27 +34,27 @@ A 1:sp
 :all
 :1wincmd w
 :w >>test.out
-:" test abandoning changed buffer, should be unloaded even when 'hidden' set
-:" write "testtext 2 2" twice
+:" test abandoning changed buffer, should not be unloaded when 'hidden' set
+:" write "testtext 2 2" then "testtext 1 1 1 1"
 :set hidden
 A 1:q!
 :w >>test.out
 :unhide
 :w >>test.out
-:" test ":hide" hides anyway when 'hidden' not set; write "testtext 3"
+:" test ":hide" hides anyway when 'hidden' not set; write "testtext 2 2"
 :set nohidden
-A 2:hide
+A 1:hide
 :w >>test.out
 :" test ":edit" failing in modified buffer when 'hidden' not set
-:" write "testtext 3 3"
-A 3:e Xtest1
+:" write "testtext 2 2 2"
+A 2:e Xtest1
 :w >>test.out
-:" test ":edit" working in modified buffer when 'hidden' set; write "testtext 1"
+:" test ":edit" working in modified buffer when 'hidden' set; write "testtext 1 1 1 1 1"
 :set hidden
 :e Xtest1
 :w >>test.out
 :" test ":close" not hiding when 'hidden' not set in modified buffer;
-:" write "testtext 3 3 3"
+:" write "testtext 3 3"
 :sp Xtest3
 :set nohidden
 A 3:close

--- a/src/testdir/test31.ok
+++ b/src/testdir/test31.ok
@@ -3,12 +3,12 @@ testtext 2 2
 testtext 1 1
 testtext 1 1 1
 testtext 2 2
+testtext 1 1 1 1
 testtext 2 2
-testtext 3
+testtext 2 2 2
+testtext 1 1 1 1 1
+testtext 1 1 1 1 1
 testtext 3 3
-testtext 1
-testtext 3 3 3
-testtext 1
 testtext 2 2 2
 testtext 3
 testtext 1


### PR DESCRIPTION
Although there are tests verifying the behavior I'm changing, I belive
them and the behavior to be wrong.

The entire purpose of causing a buffer to be hidden is so that the
buffer (regardless of whether it is modified) remains loaded when it is
no longer displayed in a window.  The existing behavior caused `:q!` in
the last window displaying a hidden buffer to unload the buffer,
potentially losing data in the process.

A simple example to demonstrate the problem is:

``` sh
  $ vim -u NONE -N
```

``` vim
  :new baz
  ifoo<Esc>
  :set hidden
  :quit!
  :ls!
  :b2
```

`:ls!` will show that the buffer has been unloaded.  Similarly, when
`:b2` is run to focus buffer 2 in the window, the unsaved content (foo)
will not exist and Vim will indicate that baz is a new file.

This appears to be completely contrary to the purpose of specifying that
buffers should be hidden when they're no longer displayed.  If a user
truly wants to unload a hidden buffer instead of hiding it, she should
use one of `:bdelete!`, `:bwipeout!`, or `:bunload!`.
