### PR TITLE
Use gitcommit filetype for git tag annotations

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -781,6 +781,7 @@ au BufNewFile,BufRead *.ged,lltxxxxx.txt	setf gedcom
 " Git
 au BufNewFile,BufRead COMMIT_EDITMSG		setf gitcommit
 au BufNewFile,BufRead MERGE_MSG			setf gitcommit
+au BufNewFile,BufRead TAG_EDITMSG		setf gitcommit
 au BufNewFile,BufRead *.git/config,.gitconfig,.gitmodules setf gitconfig
 au BufNewFile,BufRead *.git/modules/*/config	setf gitconfig
 au BufNewFile,BufRead */.config/git/config	setf gitconfig


### PR DESCRIPTION
Pretty self explanatory. Writing a git tag annotation is the same as writing a git commit message so they should use the same format.
