### PR TITLE
It's difficult for channel server to parse messages from ch_evalexpr() and ch_sendexpr()

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -3504,6 +3504,9 @@ ch_expr_common(typval_T *argvars, typval_T *rettv, int eval)
     if (text == NULL)
 	return;
 
+    /* append \n as delimiter */
+    STRCAT(text, "\n");
+
     channel = send_common(argvars, text, id, eval, &opt,
 			    eval ? "ch_evalexpr" : "ch_sendexpr", &part_read);
     vim_free(text);

--- a/src/json.c
+++ b/src/json.c
@@ -39,6 +39,7 @@ json_encode(typval_T *val, int options)
 	vim_free(ga.ga_data);
 	return vim_strsave((char_u *)"");
     }
+    ga_grow(&ga, 1);   /* Reserve a room for "\n". */
     return ga.ga_data;
 }
 

--- a/src/testdir/test_channel.py
+++ b/src/testdir/test_channel.py
@@ -38,10 +38,10 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
             print("received: {0}".format(received))
 
             # We may receive two messages at once. Take the part up to the
-            # matching "]" (recognized by finding "][").
+            # matching "]" (recognized by finding "\n" as a delimiter).
             todo = received
             while todo != '':
-                splitidx = todo.find('][')
+                splitidx = todo.find('\n')
                 if splitidx < 0:
                      used = todo
                      todo = ''
@@ -202,6 +202,10 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                     elif decoded[1] == 'wait a bit':
                         time.sleep(0.2)
                         response = "waited"
+                    elif decoded[1] == 'contains `][`':
+                        response = "ok"
+                    elif decoded[1] == 'contains `\n`':
+                        response = "ok"
                     elif decoded[1] == '!quit!':
                         # we're done
                         self.server.shutdown()

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -175,6 +175,12 @@ func Ch_communicate(port)
   call assert_equal(type(11), type(resp[0]))
   call assert_equal('waited', resp[1])
 
+  " contains `][`
+  call assert_equal('ok', ch_evalexpr(handle, 'contains `][`'))
+
+  " contains \n
+  call assert_equal('ok', ch_evalexpr(handle, "contains `\n`"))
+
   " make the server quit, can't check if this works, should not hang.
   call ch_sendexpr(handle, '!quit!')
 endfunc


### PR DESCRIPTION
Hi, bram.

As [patch 7.4.1252](https://github.com/vim/vim/commit/e7bed627c89ed80bc4b2d96f542819029adf6e76) said, channel servers may receive multiple messages concatenated like this one (`[1,"hello!"][2,"hello!"]`).

It may also occurs in every channel servers including sample demoserver.py ($VIMRUNTIME/tools/demoserver.py)
### How to Reproduce
#### test.vim

``` vim
function! s:test() abort
  let handle = ch_open('localhost:8765')
  for _ in range(10)
    call ch_sendexpr(handle, 'hello!')
  endfor
endfunction

call s:test()
```
1. $ python demoserver.py ($VIMRUNTIME/tools/demoserver.py)
2. $ vim test.vim
3. :source %

We can see following server error like this.

```
=== socket opened ===
received: [1,"hello!"][2,"hello!"][3,"hello!"][4,"hello!"][5,"hello!"][6,"hello!"][7,"hello!"][8,"hello!"]
json decoding failed
received: [9,"hello!"][10,"hello!"]
json decoding failed
=== socket closed ===
```
### Solution

[patch 7.4.1252](https://github.com/vim/vim/commit/e7bed627c89ed80bc4b2d96f542819029adf6e76) fixed the test server by finding `][`, but it doesn't handle messages which contains `][`.
On top of that, every channel servers, regardless of programing language, have to handle this problem.
It's possible, but really troublesome to handle messages correctly.

So, I suggest to use '\n' as delimiter which is handy for channel servers, regardless of  programing language, to handle messages.

How do you think?
I guess we cannot change channel specification after Vim 8.0 release, so we should include this change or include other solution.
### Other

This pull request doens't include doc changes nor demoserver.py improvement.
This pull request just intends to show the problem and disscuss it. Of course, you can discard this patch.
This patch includes @k-takata's work. Thanks @k-takata.
