### PR TITLE
add SearchHitBoundary autocommand group

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -322,6 +322,8 @@ Name			triggered by ~
 |QuickFixCmdPre|	before a quickfix command is run
 |QuickFixCmdPost|	after a quickfix command is run
 
+|SearchHitBoundary|	if search hit top or bottom
+
 |SessionLoadPost|	after loading a session file
 
 |MenuPopup|		just before showing the popup menu
@@ -815,6 +817,10 @@ RemoteReply			When a reply from a Vim that functions as
 				Note that even if an autocommand is defined,
 				the reply should be read with |remote_read()|
 				to consume it.
+							*SearchHitBoundary*
+SearchHitBoundary		When search hit top or bottom.  Then
+				|v:searchhit| is set to "top" or "bottom".
+
 							*SessionLoadPost*
 SessionLoadPost			After loading the session file created using
 				the |:mksession| command.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1812,6 +1812,11 @@ v:searchforward			*v:searchforward* *searchforward-variable*
 		function. |function-search-undo|.
 		Read-write.
 
+					*v:searchhit* *searchhit-variable*
+v:searchhit
+		Set to "top" if search hit top, or "bottom" if search hit
+		bottom.  It is only set during |SearchHitBoundary| event.
+
 					*v:shell_error* *shell_error-variable*
 v:shell_error	Result of the last shell command.  When non-zero, the last
 		shell command had an error.  When zero, there was no problem.

--- a/src/eval.c
+++ b/src/eval.c
@@ -187,6 +187,7 @@ static struct vimvar
     {VV_NAME("t_none",		 VAR_NUMBER), VV_RO},
     {VV_NAME("t_job",		 VAR_NUMBER), VV_RO},
     {VV_NAME("t_channel",	 VAR_NUMBER), VV_RO},
+    {VV_NAME("searchhit",	 VAR_STRING), VV_RO},
 };
 
 /* shorthand */

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -7695,6 +7695,7 @@ static struct event_name
     {"QuickFixCmdPre",	EVENT_QUICKFIXCMDPRE},
     {"QuitPre",		EVENT_QUITPRE},
     {"RemoteReply",	EVENT_REMOTEREPLY},
+    {"SearchHitBoundary", EVENT_SEARCHHITBOUNDARY},
     {"SessionLoadPost",	EVENT_SESSIONLOADPOST},
     {"ShellCmdPost",	EVENT_SHELLCMDPOST},
     {"ShellFilterPost",	EVENT_SHELLFILTERPOST},

--- a/src/search.c
+++ b/src/search.c
@@ -1039,7 +1039,9 @@ searchit(
 	    if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG)) {
 		give_warning((char_u *)_(dir == BACKWARD
 					  ? top_bot_msg : bot_top_msg), TRUE);
+		set_vim_var_string(VV_SEARCHHIT, dir == BACKWARD ? "top" : "bottom", -1);
 		apply_autocmds(EVENT_SEARCHHITBOUNDARY, NULL, NULL, FALSE, curbuf);
+		set_vim_var_string(VV_SEARCHHIT, NULL, -1);
 	    }
 	}
 	if (got_int || called_emsg

--- a/src/search.c
+++ b/src/search.c
@@ -1036,9 +1036,11 @@ searchit(
 		lnum = buf->b_ml.ml_line_count;
 	    else
 		lnum = 1;
-	    if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG))
+	    if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG)) {
 		give_warning((char_u *)_(dir == BACKWARD
 					  ? top_bot_msg : bot_top_msg), TRUE);
+		apply_autocmds(EVENT_SEARCHHITBOUNDARY, NULL, NULL, FALSE, curbuf);
+	    }
 	}
 	if (got_int || called_emsg
 #ifdef FEAT_SEARCH_EXTRA

--- a/src/vim.h
+++ b/src/vim.h
@@ -1313,6 +1313,7 @@ enum auto_event
     EVENT_QUICKFIXCMDPOST,	/* after :make, :grep etc. */
     EVENT_QUICKFIXCMDPRE,	/* before :make, :grep etc. */
     EVENT_QUITPRE,		/* before :quit */
+    EVENT_SEARCHHITBOUNDARY,	/* search hit top or bottom */
     EVENT_SESSIONLOADPOST,	/* after loading a session file */
     EVENT_STDINREADPOST,	/* after reading from stdin */
     EVENT_STDINREADPRE,		/* before reading from stdin */

--- a/src/vim.h
+++ b/src/vim.h
@@ -1997,7 +1997,8 @@ typedef int sock_T;
 #define VV_TYPE_NONE	78
 #define VV_TYPE_JOB	79
 #define VV_TYPE_CHANNEL	80
-#define VV_LEN		81	/* number of v: vars */
+#define VV_SEARCHHIT	81
+#define VV_LEN		82	/* number of v: vars */
 
 /* used for v_number in VAR_SPECIAL */
 #define VVAL_FALSE	0L


### PR DESCRIPTION
This group is triggered when search hit top or bottom.  It is very easy to miss the "Search hit top/bottom" message, especially on big screens.  Possible use cases:
- ring a bell

``` vim
au SearchHitBoundary * :!echo $'\a'
```
- or a visual bell:

``` vim
fun! R(...)
    " reset background back to black
    hi Normal guibg=black
endfun
fun! T()
    hi Normal guibg=#202020
    call timer_start(200, function('R'))
endfun
au SearchHitBoundary * :call T()
```
