### PR TITLE
Fix: matchaddpos match incorrectly highlighted as hlsearch.

### DIFF
--- a/src/testdir/test_match.vim
+++ b/src/testdir/test_match.vim
@@ -186,4 +186,31 @@ func Test_matchaddpos()
   set hlsearch&
 endfunc
 
+func Test_matchaddpos_using_negative_priority()
+  set hlsearch
+
+  call clearmatches()
+
+  call setline(1, 'x')
+  let @/='x'
+  redraw!
+  let search_attr = screenattr(1,1)
+
+  let @/=''
+  call matchaddpos('Error', [1], 10)
+  redraw!
+  let error_attr = screenattr(1,1)
+
+  call setline(2, '-1 match priority')
+  call matchaddpos('Error', [2], -1)
+  redraw!
+  let negative_match_priority_attr = screenattr(2,1)
+
+  call assert_notequal(negative_match_priority_attr, search_attr, "Match with negative priority is incorrectly highlighted with Search highlight.")
+  call assert_equal(negative_match_priority_attr, error_attr)
+
+  nohl
+  set hlsearch&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
The following demonstrates the problem:
    set hlsearch
    let @/=''
    0put='---'
    call matchaddpos('ErrorMsg', [1])
    1put='**\* This should be highlighted as ErrorMsg (as the line above), not as Search. ***'
    call matchaddpos('ErrorMsg', [2], -1)

About the fix:
The next_search_hl function sets fields in a match_T. The function can use a matchitem_T\* which is passed as its last argument. There is no matchitem_T for the hlsearch in which case I think NULL should be (but wasn't) passed as the last argument to next_search_hl.

(An alternate solution would be to have next_search_hl check if the matchitem_T\* passed corresponds with the match_T\* passed. However I think the code is probably easier to understand when NULL is passed when there is no matchitem_T corresponding to the match_T\* passed.)
