### PR TITLE
Fix callback handler for job channel

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -3456,7 +3456,7 @@ send_common(
 	    EMSG2(_("E917: Cannot use a callback with %s()"), fun);
 	    return NULL;
 	}
-	channel_set_req_callback(channel, part_send,
+	channel_set_req_callback(channel, *part_read,
 				       opt->jo_callback, opt->jo_partial, id);
     }
 


### PR DESCRIPTION
Hi! I found the problem of job/channel feature and wrote patch.
### Problem

The callback option of `ch_sendexpr()` doesn't work with job(piped) handler.
The callback won't be called when accepting msg.
### Solution

Use `part_read` instead of `part_write` for `channel_set_req_callback` in `send_common()`.

Please take a look at this. Thanks!
