### PR TITLE
appveyor: Update Python3 to 3.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ build_script:
 test_script:
   - cd src/testdir
     # Testing with MSVC gvim
+  - path C:\Python35-x64;%PATH%
   - nmake -f Make_dos.mak VIMPROG=..\gvim
   - nmake -f Make_dos.mak clean
     # Testing with MingW console version

--- a/src/appveyor.bat
+++ b/src/appveyor.bat
@@ -16,7 +16,7 @@ mingw32-make.exe -f Make_ming.mak clean
 :: with specified features without python.
 echo "Building MinGW 32bit GUI version"
 if "%FEATURE%" == "HUGE" (
-    mingw32-make.exe -f Make_ming.mak OPTIMIZE=speed CHANNEL=yes GUI=yes IME=yes MBYTE=yes ICONV=yes DEBUG=no PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27 PYTHON3_VER=34 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python34 FEATURES=%FEATURE% || exit 1
+    mingw32-make.exe -f Make_ming.mak OPTIMIZE=speed CHANNEL=yes GUI=yes IME=yes MBYTE=yes ICONV=yes DEBUG=no PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27 PYTHON3_VER=35 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python35 FEATURES=%FEATURE% || exit 1
 ) ELSE (
     mingw32-make.exe -f Make_ming.mak OPTIMIZE=speed GUI=yes IME=yes MBYTE=yes ICONV=yes DEBUG=no FEATURES=%FEATURE% || exit 1
 )
@@ -31,7 +31,7 @@ nmake -f Make_mvc2.mak clean
 :: GUI needs to be last, so that testing works
 echo "Building MSVC 64bit GUI Version"
 if "%FEATURE%" == "HUGE" (
-    nmake -f Make_mvc2.mak DIRECTX=yes CPU=AMD64 CHANNEL=yes OLE=no GUI=yes IME=yes MBYTE=yes ICONV=yes DEBUG=no PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27-x64 PYTHON3_VER=34 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python34-x64 FEATURES=%FEATURE% || exit 1
+    nmake -f Make_mvc2.mak DIRECTX=yes CPU=AMD64 CHANNEL=yes OLE=no GUI=yes IME=yes MBYTE=yes ICONV=yes DEBUG=no PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27-x64 PYTHON3_VER=35 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python35-x64 FEATURES=%FEATURE% || exit 1
 ) ELSE (
     nmake -f Make_mvc2.mak CPU=AMD64 OLE=no GUI=yes IME=yes MBYTE=yes ICONV=yes DEBUG=no FEATURES=%FEATURE% || exit 1
 )


### PR DESCRIPTION
The bigvim(64).bat is updated to use Python 3.5 by 7.4.2302. This PR updates to Python 3.5 also on AppVeyor.
Note that python35.dll is not installed in `C:\Windows\System`, which differs from Python 3.4. We need to add `C:\python35(-x64)` to the %PATH%.
