### PR TITLE
test_tabpage: Check &buftype in Test_tabpage_with_tab_modifier

### DIFF
--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -195,7 +195,7 @@ function Test_tabpage_with_tab_modifier()
     exec 'tabnext ' . a:pre_nr
     exec a:cmd
     call assert_equal(a:post_nr, tabpagenr())
-    call assert_equal('help', &filetype)
+    call assert_equal('help', &buftype)
     helpclose
   endfunc
 


### PR DESCRIPTION
If the tests are run in a (fake)root environment,
Test_tabpage_with_tab_modifier fails when run through test_alot.vim.
This is due to &filetype being set by the modeline of the help files,
and modelines are disabled when running as (fake)root.

Using &buftype instead avoids the fickleness of the way &filetype is
being set.

This was found while attempting to update the Debian packaging of Vim,
but can be boiled down to:

  $ fakeroot make -C src/testdir test_alot.res
