### PR TITLE
Removing SBT compiler support for Scala filetypes

### DIFF
--- a/runtime/ftplugin/scala.vim
+++ b/runtime/ftplugin/scala.vim
@@ -32,6 +32,4 @@ setlocal includeexpr='substitute(v:fname,"\\.","/","g")'
 setlocal path+=src/main/scala,src/test/scala
 setlocal suffixesadd=.scala
 
-compiler sbt
-
 " vim:set sw=2 sts=2 ts=8 et:


### PR DESCRIPTION
- We could integrate it further, but the usage of SBT from within Vim is
  really not a good idea.
- It's far better to keep SBT running in a separate terminal using the
  '~' modifier and letting it do what it does upon the writing of a file
  from within Vim.
