### PR TITLE
Syntax folding optimization

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -1011,6 +1011,9 @@ doESCkey:
 
 	    if (ins_esc(&count, cmdchar, nomove))
 	    {
+#ifdef FEAT_FOLDING
+		foldUpdateInsert();
+#endif
 #ifdef FEAT_AUTOCMD
 		if (cmdchar != 'r' && cmdchar != 'v')
 		    apply_autocmds(EVENT_INSERTLEAVE, NULL, NULL,
@@ -1428,10 +1431,8 @@ doESCkey:
 
 docomplete:
 	    compl_busy = TRUE;
-	    disable_fold_update++;  /* don't redraw folds here */
 	    if (ins_complete(c, TRUE) == FAIL)
 		compl_cont_status = 0;
-	    disable_fold_update--;
 	    compl_busy = FALSE;
 	    break;
 #endif /* FEAT_INS_EXPAND */

--- a/src/fold.c
+++ b/src/fold.c
@@ -811,7 +811,7 @@ foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 {
     fold_T	*fp;
 
-    if (disable_fold_update > 0)
+    if (State & INSERT)
 	return;
 
     /* Mark all folds from top to bot as maybe-small. */
@@ -838,6 +838,22 @@ foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 	foldUpdateIEMS(wp, top, bot);
 	got_int |= save_got_int;
     }
+}
+
+/* foldUpdateInsert() {{{2 */
+/*
+ * Update folds for the insert changes in the buffer of a window.
+ */
+    void
+foldUpdateInsert()
+{
+    if (foldmethodIsManual(curwin)
+	    || foldmethodIsSyntax(curwin)
+	    || foldmethodIsExpr(curwin))
+	return;
+
+    foldUpdateAll(curwin);
+    foldOpenCursor();
 }
 
 /* foldUpdateAll() {{{2 */

--- a/src/globals.h
+++ b/src/globals.h
@@ -1195,10 +1195,6 @@ EXTERN int	fill_fold INIT(= '-');
 EXTERN int	fill_diff INIT(= '-');
 #endif
 
-#ifdef FEAT_FOLDING
-EXTERN int	disable_fold_update INIT(= 0);
-#endif
-
 /* Whether 'keymodel' contains "stopsel" and "startsel". */
 EXTERN int	km_stopsel INIT(= FALSE);
 EXTERN int	km_startsel INIT(= FALSE);

--- a/src/normal.c
+++ b/src/normal.c
@@ -7099,6 +7099,10 @@ nv_replace(cmdarg_T *cap)
 	curwin->w_set_curswant = TRUE;
 	set_last_insert(cap->nchar);
     }
+
+#ifdef FEAT_FOLDING
+    foldUpdateInsert();
+#endif
 }
 
 /*

--- a/src/proto/fold.pro
+++ b/src/proto/fold.pro
@@ -25,6 +25,7 @@ void foldCreate(linenr_T start, linenr_T end);
 void deleteFold(linenr_T start, linenr_T end, int recursive, int had_visual);
 void clearFolding(win_T *win);
 void foldUpdate(win_T *wp, linenr_T top, linenr_T bot);
+void foldUpdateInsert();
 void foldUpdateAll(win_T *win);
 int foldMoveTo(int updown, int dir, long count);
 void foldInitWin(win_T *new_win);


### PR DESCRIPTION
- Add disable_fold_update set in complete()
- Ignore folding update if foldmethod is "expr" or "sytax" and in insert mode like FastFold plugin

I have analyzed and fixed the problem.

https://github.com/neovim/neovim/issues/5270#issuecomment-243981260

> To be fair, although this is a well known bug, no one has ever analyzed or profiled Vim and suggested a fix. So it is not fair, to claim, we would not fix it. In fact, I believe a PR would have been as well included in Vim pretty fast.

@chrisbra Please check it.
