### PR TITLE
find_tags: Use a hashtab_T instead of garray_T to collect tag results

### DIFF
--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -70,7 +70,6 @@ hash_init(hashtab_T *ht)
     ht->ht_mask = HT_INIT_SIZE - 1;
 }
 
-#if defined(FEAT_EVAL) || defined(FEAT_SYN_HL) || defined(PROTO)
 /*
  * Free the array of a hash table.  Does not free the items it contains!
  * If "ht" is not freed then you should call hash_init() next!
@@ -104,7 +103,6 @@ hash_clear_all(hashtab_T *ht, int off)
     }
     hash_clear(ht);
 }
-#endif
 
 /*
  * Find "key" in hashtable "ht".  "key" must not be NULL.

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -10,8 +10,11 @@
 /*
  * hashtab.c: Handling of a hashtable with Vim-specific properties.
  *
- * Each item in a hashtable has a NUL terminated string key.  A key can appear
- * only once in the table.
+ * Each item in a hashtable has a unique key.  The key can either be a NUL
+ * terminated string or a fixed-length byte sequence (buf).  The hash_buf_*
+ * functions are used for storing/retrieving hash items represented by a
+ * fixed-length byte sequence, while the similarly named hash_* functions are
+ * used for NUL terminated strings.
  *
  * A hash number is computed from the key for quick lookup.  When the hashes
  * of two different keys point to the same entry an algorithm is used to
@@ -118,11 +121,23 @@ hash_find(hashtab_T *ht, char_u *key)
     return hash_lookup(ht, key, hash_hash(key));
 }
 
+    hashitem_T *
+hash_buf_find(hashtab_T *ht, char_u *key, size_t keylen)
+{
+    return hash_buf_lookup(ht, key, keylen, hash_buf_hash(key, keylen));
+}
+
 /*
  * Like hash_find(), but caller computes "hash".
  */
     hashitem_T *
 hash_lookup(hashtab_T *ht, char_u *key, hash_T hash)
+{
+    return hash_buf_lookup(ht, key, STRLEN(key), hash);
+}
+
+    hashitem_T *
+hash_buf_lookup(hashtab_T *ht, char_u *key, size_t keylen, hash_T hash)
 {
     hash_T	perturb;
     hashitem_T	*freeitem;
@@ -146,7 +161,8 @@ hash_lookup(hashtab_T *ht, char_u *key, hash_T hash)
 	return hi;
     if (hi->hi_key == HI_KEY_REMOVED)
 	freeitem = hi;
-    else if (hi->hi_hash == hash && STRCMP(hi->hi_key, key) == 0)
+    else if (hi->hi_hash == hash && hi->hi_keylen == keylen
+		&& memcmp(hi->hi_key, key, keylen) == 0)
 	return hi;
     else
 	freeitem = NULL;
@@ -171,7 +187,8 @@ hash_lookup(hashtab_T *ht, char_u *key, hash_T hash)
 	    return freeitem == NULL ? hi : freeitem;
 	if (hi->hi_hash == hash
 		&& hi->hi_key != HI_KEY_REMOVED
-		&& STRCMP(hi->hi_key, key) == 0)
+		&& hi->hi_keylen == keylen
+		&& memcmp(hi->hi_key, key, keylen) == 0)
 	    return hi;
 	if (hi->hi_key == HI_KEY_REMOVED && freeitem == NULL)
 	    freeitem = hi;
@@ -202,16 +219,22 @@ hash_debug_results(void)
     int
 hash_add(hashtab_T *ht, char_u *key)
 {
-    hash_T	hash = hash_hash(key);
+    return hash_buf_add(ht, key, STRLEN(key));
+}
+
+    int
+hash_buf_add(hashtab_T *ht, char_u *key, size_t keylen)
+{
+    hash_T	hash = hash_buf_hash(key, keylen);
     hashitem_T	*hi;
 
-    hi = hash_lookup(ht, key, hash);
+    hi = hash_buf_lookup(ht, key, keylen, hash);
     if (!HASHITEM_EMPTY(hi))
     {
-	internal_error("hash_add()");
+	internal_error("hash_buf_add()");
 	return FAIL;
     }
-    return hash_add_item(ht, hi, key, hash);
+    return hash_buf_add_item(ht, hi, key, keylen, hash);
 }
 
 /*
@@ -227,6 +250,17 @@ hash_add_item(
     char_u	*key,
     hash_T	hash)
 {
+    return hash_buf_add_item(ht, hi, key, STRLEN(key), hash);
+}
+
+    int
+hash_buf_add_item(
+    hashtab_T	*ht,
+    hashitem_T	*hi,
+    char_u	*key,
+    size_t	keylen,
+    hash_T	hash)
+{
     /* If resizing failed before and it fails again we can't add an item. */
     if (ht->ht_error && hash_may_resize(ht, 0) == FAIL)
 	return FAIL;
@@ -235,6 +269,7 @@ hash_add_item(
     if (hi->hi_key == NULL)
 	++ht->ht_filled;
     hi->hi_key = key;
+    hi->hi_keylen = keylen;
     hi->hi_hash = hash;
 
     /* When the space gets low may resize the array. */
@@ -462,16 +497,24 @@ hash_may_resize(
     hash_T
 hash_hash(char_u *key)
 {
+    return hash_buf_hash(key, STRLEN(key));
+}
+
+    hash_T
+hash_buf_hash(char_u *key, size_t keylen)
+{
     hash_T	hash;
     char_u	*p;
 
-    if ((hash = *key) == 0)
-	return (hash_T)0;
+    hash = *key;
+    if (hash == 0 && keylen <= 1)
+	return hash;
     p = key + 1;
+    keylen--;
 
     /* A simplistic algorithm that appears to do very well.
      * Suggested by George Reilly. */
-    while (*p != NUL)
+    while (keylen-- > 0)
 	hash = hash * 101 + *p++;
 
     return hash;

--- a/src/proto/hashtab.pro
+++ b/src/proto/hashtab.pro
@@ -3,12 +3,17 @@ void hash_init(hashtab_T *ht);
 void hash_clear(hashtab_T *ht);
 void hash_clear_all(hashtab_T *ht, int off);
 hashitem_T *hash_find(hashtab_T *ht, char_u *key);
+hashitem_T *hash_buf_find(hashtab_T *ht, char_u *key, size_t keylen);
 hashitem_T *hash_lookup(hashtab_T *ht, char_u *key, hash_T hash);
+hashitem_T *hash_buf_lookup(hashtab_T *ht, char_u *key, size_t keylen, hash_T hash);
 void hash_debug_results(void);
 int hash_add(hashtab_T *ht, char_u *key);
+int hash_buf_add(hashtab_T *ht, char_u *key, size_t keylen);
 int hash_add_item(hashtab_T *ht, hashitem_T *hi, char_u *key, hash_T hash);
+int hash_buf_add_item(hashtab_T *ht, hashitem_T *hi, char_u *key, size_t keylen, hash_T hash);
 void hash_remove(hashtab_T *ht, hashitem_T *hi);
 void hash_lock(hashtab_T *ht);
 void hash_unlock(hashtab_T *ht);
 hash_T hash_hash(char_u *key);
+hash_T hash_buf_hash(char_u *key, size_t keylen);
 /* vim: set ft=c : */

--- a/src/structs.h
+++ b/src/structs.h
@@ -1098,6 +1098,7 @@ struct stl_hlrec
 typedef struct hashitem_S
 {
     long_u	hi_hash;	/* cached hash number of hi_key */
+    size_t	hi_keylen;
     char_u	*hi_key;
 } hashitem_T;
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -1236,29 +1236,6 @@ prepare_pats(pat_T *pats, int has_re)
 	pats->regmatch.regprog = NULL;
 }
 
-static hash_T tag_hash(char_u *key, int len);
-
-/*
- * Get the hash number for a key.
- * Unlike hash_hash, this supports embedded NUL bytes.
- */
-    static hash_T
-tag_hash(char_u *key, int len)
-{
-    hash_T	hash;
-    char_u	*p;
-
-    if ((hash = *key) == 0)
-	return (hash_T)0;
-    p = key + 1;
-    len--;
-
-    while (len-- > 0)
-	hash = hash * 101 + *p++;
-
-    return hash;
-}
-
 /*
  * find_tags() - search for tags in tags files
  *
@@ -2417,11 +2394,11 @@ parse_line:
 			hash++;
 		    else
 #endif
-			hash = tag_hash(mfp, len);
-		    hi = hash_lookup(&ht_match[mtt], mfp, hash);
+			hash = hash_buf_hash(mfp, len);
+		    hi = hash_buf_lookup(&ht_match[mtt], mfp, len, hash);
 		    if (HASHITEM_EMPTY(hi))
 		    {
-			if (hash_add_item(&ht_match[mtt], hi, mfp, hash) == FAIL)
+			if (hash_buf_add_item(&ht_match[mtt], hi, mfp, len, hash) == FAIL)
 			{
 			    /* Out of memory! Just forget about the rest. */
 			    retval = OK;

--- a/src/tag.c
+++ b/src/tag.c
@@ -35,9 +35,9 @@ typedef struct tag_pointers
 } tagptrs_T;
 
 /*
- * The matching tags are first stored in ga_match[].  In which one depends on
+ * The matching tags are first stored in ht_match[].  In which one depends on
  * the priority of the match.
- * At the end, the matches from ga_match[] are concatenated, to make a list
+ * At the end, the matches from ht_match[] are concatenated, to make a list
  * sorted on priority.
  */
 #define MT_ST_CUR	0		/* static match in current file */
@@ -1236,6 +1236,29 @@ prepare_pats(pat_T *pats, int has_re)
 	pats->regmatch.regprog = NULL;
 }
 
+static hash_T tag_hash(char_u *key, int len);
+
+/*
+ * Get the hash number for a key.
+ * Unlike hash_hash, this supports embedded NUL bytes.
+ */
+    static hash_T
+tag_hash(char_u *key, int len)
+{
+    hash_T	hash;
+    char_u	*p;
+
+    if ((hash = *key) == 0)
+	return (hash_T)0;
+    p = key + 1;
+    len--;
+
+    while (len-- > 0)
+	hash = hash * 101 + *p++;
+
+    return hash;
+}
+
 /*
  * find_tags() - search for tags in tags files
  *
@@ -1286,7 +1309,7 @@ find_tags(
     int		eof = FALSE;		/* found end-of-file */
     char_u	*p;
     char_u	*s;
-    int		i;
+    long	i;
 #ifdef FEAT_TAG_BINS
     int		tag_file_sorted = NUL;	/* !_TAG_FILE_SORTED value */
     struct tag_search_info	/* Binary search file offsets */
@@ -1341,12 +1364,9 @@ find_tags(
     int		is_etag;		/* current file is emaces style */
 #endif
 
-    struct match_found
-    {
-	int	len;		/* nr of chars of match[] to be compared */
-	char_u	match[1];	/* actually longer */
-    } *mfp, *mfp2;
-    garray_T	ga_match[MT_COUNT];
+    char_u	*mfp;
+    hashtab_T	ht_match[MT_COUNT];
+    hash_T	hash = 0;
     int		match_count = 0;		/* number of matches found */
     char_u	**matches;
     int		mtt;
@@ -1411,7 +1431,7 @@ find_tags(
     ebuf = alloc(LSIZE);
 #endif
     for (mtt = 0; mtt < MT_COUNT; ++mtt)
-	ga_init2(&ga_match[mtt], (int)sizeof(struct match_found *), 100);
+	hash_init(&ht_match[mtt]);
 
     /* check for out of memory situation */
     if (lbuf == NULL || tag_fname == NULL
@@ -2206,10 +2226,11 @@ parse_line:
 	    }
 
 	    /*
-	     * If a match is found, add it to ga_match[].
+	     * If a match is found, add it to ht_match[].
 	     */
 	    if (match)
 	    {
+		int len;
 #ifdef FEAT_CSCOPE
 		if (use_cscope)
 		{
@@ -2262,179 +2283,157 @@ parse_line:
 		}
 
 		/*
-		 * Add the found match in ga_match[mtt], avoiding duplicates.
+		 * Add the found match in ht_match[mtt].
 		 * Store the info we need later, which depends on the kind of
 		 * tags we are dealing with.
 		 */
-		if (ga_grow(&ga_match[mtt], 1) == OK)
+		if (help_only)
 		{
-		    int len;
-		    int heuristic;
-
-		    if (help_only)
-		    {
 #ifdef FEAT_MULTI_LANG
 # define ML_EXTRA 3
 #else
 # define ML_EXTRA 0
 #endif
-			/*
-			 * Append the help-heuristic number after the
-			 * tagname, for sorting it later.
-			 */
-			*tagp.tagname_end = NUL;
-			len = (int)(tagp.tagname_end - tagp.tagname);
-			mfp = (struct match_found *)
-				 alloc((int)sizeof(struct match_found) + len
-							     + 10 + ML_EXTRA);
-			if (mfp != NULL)
-			{
-			    /* "len" includes the language and the NUL, but
-			     * not the priority. */
-			    mfp->len = len + ML_EXTRA + 1;
-#define ML_HELP_LEN 6
-			    p = mfp->match;
-			    STRCPY(p, tagp.tagname);
-#ifdef FEAT_MULTI_LANG
-			    p[len] = '@';
-			    STRCPY(p + len + 1, help_lang);
-#endif
-
-			    heuristic = help_heuristic(tagp.tagname,
-					match_re ? matchoff : 0, !match_no_ic);
-#ifdef FEAT_MULTI_LANG
-			    heuristic += help_pri;
-#endif
-			    sprintf((char *)p + len + 1 + ML_EXTRA, "%06d",
-								   heuristic);
-			}
-			*tagp.tagname_end = TAB;
-		    }
-		    else if (name_only)
+		    /*
+		     * Append the help-heuristic number after the
+		     * tagname, for sorting it later.
+		     */
+		    *tagp.tagname_end = NUL;
+		    len = (int)(tagp.tagname_end - tagp.tagname);
+		    mfp = (char_u *)alloc((int)sizeof(char_u) + len + 10 + ML_EXTRA + 1);
+		    if (mfp != NULL)
 		    {
-			if (get_it_again)
-			{
-			    char_u *temp_end = tagp.command;
+			int heuristic;
+#define ML_HELP_LEN 6
+			p = mfp;
+			STRCPY(p, tagp.tagname);
+#ifdef FEAT_MULTI_LANG
+			p[len] = '@';
+			STRCPY(p + len + 1, help_lang);
+#endif
 
-			    if (*temp_end == '/')
-				while (*temp_end && *temp_end != '\r'
-					&& *temp_end != '\n'
-					&& *temp_end != '$')
-				    temp_end++;
+			heuristic = help_heuristic(tagp.tagname,
+				    match_re ? matchoff : 0, !match_no_ic);
+#ifdef FEAT_MULTI_LANG
+			heuristic += help_pri;
+#endif
+			sprintf((char *)p + len + 1 + ML_EXTRA, "%06d",
+							       heuristic);
+		    }
+		    *tagp.tagname_end = TAB;
+		}
+		else if (name_only)
+		{
+		    if (get_it_again)
+		    {
+			char_u *temp_end = tagp.command;
 
-			    if (tagp.command + 2 < temp_end)
-			    {
-				len = (int)(temp_end - tagp.command - 2);
-				mfp = (struct match_found *)alloc(
-					(int)sizeof(struct match_found) + len);
-				if (mfp != NULL)
-				{
-				    mfp->len = len + 1; /* include the NUL */
-				    p = mfp->match;
-				    vim_strncpy(p, tagp.command + 2, len);
-				}
-			    }
-			    else
-				mfp = NULL;
-			    get_it_again = FALSE;
-			}
-			else
+			if (*temp_end == '/')
+			    while (*temp_end && *temp_end != '\r'
+				    && *temp_end != '\n'
+				    && *temp_end != '$')
+				temp_end++;
+
+			if (tagp.command + 2 < temp_end)
 			{
-			    len = (int)(tagp.tagname_end - tagp.tagname);
-			    mfp = (struct match_found *)alloc(
-				       (int)sizeof(struct match_found) + len);
+			    len = (int)(temp_end - tagp.command - 2);
+			    mfp = (char_u *)alloc((int)sizeof(char_u) + len + 1);
 			    if (mfp != NULL)
 			    {
-				mfp->len = len + 1; /* include the NUL */
-				p = mfp->match;
-				vim_strncpy(p, tagp.tagname, len);
+				p = mfp;
+				vim_strncpy(p, tagp.command + 2, len);
 			    }
-
-			    /* if wanted, re-read line to get long form too */
-			    if (State & INSERT)
-				get_it_again = p_sft;
 			}
+			else
+			    mfp = NULL;
+			get_it_again = FALSE;
 		    }
 		    else
 		    {
-			/* Save the tag in a buffer.
-			 * Emacs tag: <mtt><tag_fname><NUL><ebuf><NUL><lbuf>
-			 * other tag: <mtt><tag_fname><NUL><NUL><lbuf>
-			 * without Emacs tags: <mtt><tag_fname><NUL><lbuf>
-			 */
-			len = (int)STRLEN(tag_fname)
-						 + (int)STRLEN(lbuf) + 3;
-#ifdef FEAT_EMACS_TAGS
-			if (is_etag)
-			    len += (int)STRLEN(ebuf) + 1;
-			else
-			    ++len;
-#endif
-			mfp = (struct match_found *)alloc(
-				       (int)sizeof(struct match_found) + len);
+			len = (int)(tagp.tagname_end - tagp.tagname);
+			mfp = (char_u *)alloc((int)sizeof(char_u) + len + 1);
 			if (mfp != NULL)
 			{
-			    mfp->len = len;
-			    p = mfp->match;
-			    p[0] = mtt;
-			    STRCPY(p + 1, tag_fname);
-#ifdef BACKSLASH_IN_FILENAME
-			    /* Ignore differences in slashes, avoid adding
-			     * both path/file and path\file. */
-			    slash_adjust(p + 1);
-#endif
-			    s = p + 1 + STRLEN(tag_fname) + 1;
-#ifdef FEAT_EMACS_TAGS
-			    if (is_etag)
-			    {
-				STRCPY(s, ebuf);
-				s += STRLEN(ebuf) + 1;
-			    }
-			    else
-				*s++ = NUL;
-#endif
-			    STRCPY(s, lbuf);
+			    p = mfp;
+			    vim_strncpy(p, tagp.tagname, len);
 			}
-		    }
 
-		    if (mfp != NULL)
-		    {
-			/*
-			 * Don't add identical matches.
-			 * This can take a lot of time when finding many
-			 * matches, check for CTRL-C now and then.
-			 * Add all cscope tags, because they are all listed.
-			 */
-#ifdef FEAT_CSCOPE
-			if (use_cscope)
-			    i = -1;
-			else
-#endif
-			  for (i = ga_match[mtt].ga_len; --i >= 0 && !got_int; )
-			  {
-			      mfp2 = ((struct match_found **)
-						  (ga_match[mtt].ga_data))[i];
-			      if (mfp2->len == mfp->len
-				      && memcmp(mfp2->match, mfp->match,
-						       (size_t)mfp->len) == 0)
-				  break;
-			      fast_breakcheck();
-			  }
-			if (i < 0)
-			{
-			    ((struct match_found **)(ga_match[mtt].ga_data))
-					       [ga_match[mtt].ga_len++] = mfp;
-			    ++match_count;
-			}
-			else
-			    vim_free(mfp);
+			/* if wanted, re-read line to get long form too */
+			if (State & INSERT)
+			    get_it_again = p_sft;
 		    }
 		}
-		else    /* Out of memory! Just forget about the rest. */
+		else
 		{
-		    retval = OK;
-		    stop_searching = TRUE;
-		    break;
+		    /* Save the tag in a buffer.
+		     * Emacs tag: <mtt><tag_fname><NUL><ebuf><NUL><lbuf>
+		     * other tag: <mtt><tag_fname><NUL><NUL><lbuf>
+		     * without Emacs tags: <mtt><tag_fname><NUL><lbuf>
+		     */
+		    len = (int)STRLEN(tag_fname)
+					     + (int)STRLEN(lbuf) + 3;
+#ifdef FEAT_EMACS_TAGS
+		    if (is_etag)
+			len += (int)STRLEN(ebuf) + 1;
+		    else
+			++len;
+#endif
+		    mfp = (char_u *)alloc((int)sizeof(char_u) + len + 1);
+		    if (mfp != NULL)
+		    {
+			p = mfp;
+			p[0] = mtt;
+			STRCPY(p + 1, tag_fname);
+#ifdef BACKSLASH_IN_FILENAME
+			/* Ignore differences in slashes, avoid adding
+			 * both path/file and path\file. */
+			slash_adjust(p + 1);
+#endif
+			s = p + 1 + STRLEN(tag_fname) + 1;
+#ifdef FEAT_EMACS_TAGS
+			if (is_etag)
+			{
+			    STRCPY(s, ebuf);
+			    s += STRLEN(ebuf) + 1;
+			}
+			else
+			    *s++ = NUL;
+#endif
+			STRCPY(s, lbuf);
+		    }
+		}
+
+		if (mfp != NULL)
+		{
+		    /*
+		     * Don't add identical matches.
+		     * This can take a lot of time when finding many
+		     * matches, check for CTRL-C now and then.
+		     * Add all cscope tags, because they are all listed.
+		     */
+		    hashitem_T	*hi;
+#ifdef FEAT_CSCOPE
+		    if (use_cscope)
+			hash++;
+		    else
+#endif
+			hash = tag_hash(mfp, len);
+		    hi = hash_lookup(&ht_match[mtt], mfp, hash);
+		    if (HASHITEM_EMPTY(hi))
+		    {
+			if (hash_add_item(&ht_match[mtt], hi, mfp, hash) == FAIL)
+			{
+			    /* Out of memory! Just forget about the rest. */
+			    retval = OK;
+			    stop_searching = TRUE;
+			    break;
+			}
+			else
+			    ++match_count;
+		    }
+		    else
+			/* Duplicate key */
+			vim_free(mfp);
 		}
 	    }
 #ifdef FEAT_CSCOPE
@@ -2532,7 +2531,7 @@ findtag_end:
 #endif
 
     /*
-     * Move the matches from the ga_match[] arrays into one list of
+     * Move the matches from the ht_match[] arrays into one list of
      * matches.  When retval == FAIL, free the matches.
      */
     if (retval == FAIL)
@@ -2546,22 +2545,23 @@ findtag_end:
     match_count = 0;
     for (mtt = 0; mtt < MT_COUNT; ++mtt)
     {
-	for (i = 0; i < ga_match[mtt].ga_len; ++i)
+	hashitem_T	*hi;
+	i = (long)ht_match[mtt].ht_used;
+	for (hi = ht_match[mtt].ht_array; i > 0; ++hi)
 	{
-	    mfp = ((struct match_found **)(ga_match[mtt].ga_data))[i];
-	    if (matches == NULL)
-		vim_free(mfp);
-	    else
+	    if (!HASHITEM_EMPTY(hi))
 	    {
-		/* To avoid allocating memory again we turn the struct
-		 * match_found into a string.  For help the priority was not
-		 * included in the length. */
-		mch_memmove(mfp, mfp->match,
-			 (size_t)(mfp->len + (help_only ? ML_HELP_LEN : 0)));
-		matches[match_count++] = (char_u *)mfp;
+		mfp = hi->hi_key;
+		if (matches == NULL)
+		    vim_free(mfp);
+		else
+		{
+		    matches[match_count++] = (char_u *)mfp;
+		}
+		i--;
 	    }
 	}
-	ga_clear(&ga_match[mtt]);
+	hash_clear(&ht_match[mtt]);
     }
 
     *matchesp = matches;


### PR DESCRIPTION
As discussed in #1044, much of the time currently spent in finding tags
is looking for duplicate tags.  Since the tags are stored in a garray_T,
this has to perform a linear search of all existing tags every time a
new tag is added.

Using a hashtab_T (with a modified hash function to allow embedded NUL
bytes), the deduplication costs are drastically cheaper.

Comparing the times to find all tags containing the letter a in a tags
file for all of /usr/include:

``` sh
  $ time ./src/vim.hash -u NONE --cmd 'echo len(taglist("a"))' --cmd q
  115305
  ./src/vim -u NONE --cmd 'echo len(taglist("a"))' --cmd q  0.69s user 0.04s system 98% cpu 0.741 total
  $ time ./src/vim -u NONE --cmd 'echo len(taglist("a"))' --cmd q
  115305
  ./src/vim -u NONE --cmd 'echo len(taglist("a"))' --cmd q  80.69s user 0.08s system 99% cpu 1:20.90 total
```
