### PR TITLE
syntax: Add support for JavaScript template strings

### DIFF
--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -34,6 +34,7 @@ syn region  javaScriptComment	       start="/\*"  end="\*/" contains=@Spell,java
 syn match   javaScriptSpecial	       "\\\d\d\d\|\\."
 syn region  javaScriptStringD	       start=+"+  skip=+\\\\\|\\"+  end=+"\|$+	contains=javaScriptSpecial,@htmlPreproc
 syn region  javaScriptStringS	       start=+'+  skip=+\\\\\|\\'+  end=+'\|$+	contains=javaScriptSpecial,@htmlPreproc
+syn region  javaScriptStringT	       start=+`+  skip=+\\\\\|\\`+  end=+`+	contains=javaScriptSpecial,@htmlPreproc
 
 syn match   javaScriptSpecialCharacter "'\\.'"
 syn match   javaScriptNumber	       "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
@@ -86,6 +87,7 @@ hi def link javaScriptCommentTodo		Todo
 hi def link javaScriptSpecial		Special
 hi def link javaScriptStringS		String
 hi def link javaScriptStringD		String
+hi def link javaScriptStringT		String
 hi def link javaScriptCharacter		Character
 hi def link javaScriptSpecialCharacter	javaScriptSpecial
 hi def link javaScriptNumber		javaScriptValue


### PR DESCRIPTION
Template literals are part of JavaScript since [version ES2015](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
They add a new way of defining multi-line strings, for example:

``` js
  `string text`

  `line 1
   line 2`

  `string text ${expression} string text`
```

This patch adds syntax support for this new standard, which is currently
not handled by Vim and results in bad `highlight` coloring.
