### PR TITLE
Fix get_winbuf_options on big-endian systems

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -12364,7 +12364,7 @@ get_winbuf_options(int bufopt)
 		if (opt->flags & P_STRING)
 		    dict_add_nr_str(d, opt->fullname, 0L, *(char_u **)varp);
 		else
-		    dict_add_nr_str(d, opt->fullname, *varp, NULL);
+		    dict_add_nr_str(d, opt->fullname, *(long *)varp, NULL);
 	    }
 	}
     }


### PR DESCRIPTION
The value for an option in struct vimoption is defined as `char_u
*var;`.  However, long and int values are stored in memory for P_NUM and
P_BOOL values, respectively.

When get_winbuf_options attempts to retrive the value of a P_NUM option,
it simply dereferences the char_u\* and passes that value through the
varnumber_T parameter of dict_add_nr_str.  Now that varnumber_T is a
64-bit value, this plain dereference of the char_u pointer passes along
the high (zero) byte of the option's value.

Casting the char_u\* to a long\* first and then dereferencing that, as is
already done by get_option_value, passes along the value of the entire
long instead of just one byte of it.
