### PR TITLE
[GvimExt] fix the memory leak

### DIFF
--- a/src/GvimExt/gvimext.cpp
+++ b/src/GvimExt/gvimext.cpp
@@ -1025,6 +1025,7 @@ STDMETHODIMP CShellExt::InvokeSingleGvim(HWND hParent,
 {
     wchar_t	m_szFileUserClickedOn[BUFSIZE];
     wchar_t	*cmdStrW;
+    wchar_t	*cmdStrWtmp;
     size_t	cmdlen;
     size_t	len;
     UINT i;
@@ -1046,7 +1047,16 @@ STDMETHODIMP CShellExt::InvokeSingleGvim(HWND hParent,
 	if (len > cmdlen)
 	{
 	    cmdlen = len + BUFSIZE;
-	    cmdStrW = (wchar_t *)realloc(cmdStrW, cmdlen * sizeof(wchar_t));
+	    cmdStrWtmp = (wchar_t *)realloc(cmdStrW, cmdlen * sizeof(wchar_t));
+	    if (cmdStrWtmp != NULL)
+	    {
+	        cmdStrW = cmdStrWtmp;
+	    }
+	    else
+	    {
+	    	free(cmdStrW);
+	    	/* And handle error */
+	    }
 	}
 	wcscat(cmdStrW, L" \"");
 	wcscat(cmdStrW, m_szFileUserClickedOn);

--- a/src/GvimExt/gvimext.cpp
+++ b/src/GvimExt/gvimext.cpp
@@ -1055,7 +1055,7 @@ STDMETHODIMP CShellExt::InvokeSingleGvim(HWND hParent,
 	    else
 	    {
 	    	free(cmdStrW);
-	    	/* And handle error */
+	    	cmdStrW = NULL;
 	    }
 	}
 	wcscat(cmdStrW, L" \"");


### PR DESCRIPTION
Passing one pointer into `realloc()` and assigning the result directly into that same pointer variable can cause a memory leak if the reallocation fails, because the original allocation will still exist. The correct way to do this is to use a temporary pointer variable.
