### PR TITLE
Enable syntax highlighting for EditorConfig files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -676,6 +676,9 @@ au BufNewFile,BufRead *.dts,*.dtsi		setf dts
 " EDIF (*.edf,*.edif,*.edn,*.edo)
 au BufNewFile,BufRead *.ed\(f\|if\|n\|o\)	setf edif
 
+" EditorConfig (close enough to dosini)
+au BufNewFile,BufRead .editorconfig		setf dosini
+
 " Embedix Component Description
 au BufNewFile,BufRead *.ecd			setf ecd
 


### PR DESCRIPTION
[EditorConfig ](http://editorconfig.org) files, named `.editorconfig`, are just dosini files.
