### PR TITLE
Fixing typographical errors

### DIFF
--- a/runtime/autoload/getscript.vim
+++ b/runtime/autoload/getscript.vim
@@ -236,7 +236,7 @@ fun! getscript#GetLatestVimScripts()
 "    call Decho("..depscript<".depscript.">")
 
     " found a "GetLatestVimScripts: # #" line in the script;
-    " check if its already in the datafile by searching backwards from llp1,
+    " check if it's already in the datafile by searching backwards from llp1,
     " the (prior to reading in the plugin script) last line plus one of the GetLatestVimScripts.dat file,
     " for the script-id with no wrapping allowed.
     let curline     = line(".")

--- a/runtime/autoload/phpcomplete.vim
+++ b/runtime/autoload/phpcomplete.vim
@@ -931,7 +931,7 @@ function! phpcomplete#EvaluateModifiers(modifiers, required_modifiers, prohibite
 		endfor
 
 		for modifier in a:modifiers
-			" if the modifier is prohibited its a no match
+			" if the modifier is prohibited it's a no match
 			if index(a:prohibited_modifiers, modifier) != -1
 				return 0
 			endif

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -117,7 +117,7 @@ fun! tar#Browse(tarfile)
   if !filereadable(a:tarfile)
 "   call Decho('a:tarfile<'.a:tarfile.'> not filereadable')
    if a:tarfile !~# '^\a\+://'
-    " if its an url, don't complain, let url-handlers such as vim do its thing
+    " if it's an url, don't complain, let url-handlers such as vim do its thing
     redraw!
     echohl Error | echo "***error*** (tar#Browse) File not readable<".a:tarfile.">" | echohl None
    endif

--- a/runtime/autoload/vimball.vim
+++ b/runtime/autoload/vimball.vim
@@ -347,7 +347,7 @@ fun! vimball#Vimball(really,...)
 "   call Decho("exe tabn ".curtabnr)
     exe "tabn ".curtabnr
 
-    " set up help if its a doc/*.txt file
+    " set up help if it's a doc/*.txt file
 "   call Decho("didhelp<".didhelp."> fname<".fname.">")
     if a:really && didhelp == "" && fname =~ 'doc/[^/]\+\.\(txt\|..x\)$'
     	let didhelp= substitute(fname,'^\(.*\<doc\)[/\\][^.]*\.\(txt\|..x\)$','\1','')

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -72,7 +72,7 @@ fun! zip#Browse(zipfile)
 "   call Dret("zip#Browse : not a zipfile<".a:zipfile.">")
    return
 "  else        " Decho
-"   call Decho("zip#Browse: a:zipfile<".a:zipfile."> passed PK test - its a zip file")
+"   call Decho("zip#Browse: a:zipfile<".a:zipfile."> passed PK test - it's a zip file")
   endif
 
   let repkeep= &report
@@ -95,7 +95,7 @@ fun! zip#Browse(zipfile)
   endif
   if !filereadable(a:zipfile)
    if a:zipfile !~# '^\a\+://'
-    " if its an url, don't complain, let url-handlers such as vim do its thing
+    " if it's an url, don't complain, let url-handlers such as vim do its thing
     redraw!
     echohl Error | echo "***error*** (zip#Browse) File not readable<".a:zipfile.">" | echohl None
 "    call inputsave()|call input("Press <cr> to continue")|call inputrestore()

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -65,7 +65,7 @@ endif
 " zip#Browse: {{{2
 fun! zip#Browse(zipfile)
 "  call Dfunc("zip#Browse(zipfile<".a:zipfile.">)")
-  " sanity check: insure that the zipfile has "PK" as its first two letters
+  " sanity check: ensure that the zipfile has "PK" as its first two letters
   "               (zipped files have a leading PK as a "magic cookie")
   if !filereadable(a:zipfile) || readfile(a:zipfile, "", 1)[0] !~ '^PK'
    exe "noautocmd e ".fnameescape(a:zipfile)

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -532,7 +532,7 @@ variable (ex. scp uses the variable g:netrw_scp_cmd, which is defaulted to
 	let g:netrw_sftp_cmd= '"c:\Program Files\PuTTY\psftp.exe"'
 <
 (note: it has been reported that windows 7 with putty v0.6's "-batch" option
-       doesn't work, so its best to leave it off for that system)
+       doesn't work, so it's best to leave it off for that system)
 
 See |netrw-p8| for more about putty, pscp, psftp, etc.
 
@@ -1206,7 +1206,7 @@ The :NetrwMB command is available outside of netrw buffers (once netrw has been
 invoked in the session).
 
 The file ".netrwbook" holds bookmarks when netrw (and vim) is not active.  By
-default, its stored on the first directory on the user's |'runtimepath'|.
+default, it's stored on the first directory on the user's |'runtimepath'|.
 
 Related Topics:
 	|netrw-gb| how to return (go) to a bookmark
@@ -1431,7 +1431,7 @@ be used in that count.
 						*.netrwhist*
 See |g:netrw_dirhistmax| for how to control the quantity of history stack
 slots.  The file ".netrwhist" holds history when netrw (and vim) is not
-active.  By default, its stored on the first directory on the user's
+active.  By default, it's stored on the first directory on the user's
 |'runtimepath'|.
 
 Related Topics:
@@ -3271,7 +3271,7 @@ The user function is passed one argument; it resembles >
 
 	fun! ExampleUserMapFunc(islocal)
 <
-where a:islocal is 1 if its a local-directory system call or 0 when
+where a:islocal is 1 if it's a local-directory system call or 0 when
 remote-directory system call.
 
 Use netrw#Expose("varname")          to access netrw-internal (script-local)
@@ -3595,7 +3595,7 @@ Example: Clear netrw's marked file list via a mapping on gu >
 
 								*netrw-p16*
 	P16. When editing remote files (ex. :e ftp://hostname/path/file),
-	     under Windows I get an |E303| message complaining that its unable
+	     under Windows I get an |E303| message complaining that it's unable
 	     to open a swap file.
 
 	     (romainl) It looks like you are starting Vim from a protected
@@ -3649,7 +3649,7 @@ Example: Clear netrw's marked file list via a mapping on gu >
 	P21. I've made a directory (or file) with an accented character, but
 		netrw isn't letting me enter that directory/read that file:
 
-		Its likely that the shell or o/s is using a different encoding
+		It's likely that the shell or o/s is using a different encoding
 		than you have vim (netrw) using.  A patch to vim supporting
 		"systemencoding" may address this issue in the future; for
 		now, just have netrw use the proper encoding.  For example: >

--- a/runtime/indent/cdl.vim
+++ b/runtime/indent/cdl.vim
@@ -16,7 +16,7 @@ if exists("*CdlGetIndent")
     "finish
 endif
 
-" find out if an "...=..." expresion its an asignment (or a conditional)
+" find out if an "...=..." expresion is an assignment (or a conditional)
 " it scans 'line' first, and then the previos lines
 fun! CdlAsignment(lnum, line)
   let f = -1

--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -749,7 +749,7 @@ func! s:CssPrevNonComment(lnum, stopline)
   while 1
     let ccol = match(getline(lnum), '\*/')
     if ccol < 0
-      " No comment end thus its something else.
+      " No comment end thus it's something else.
       return lnum
     endif
     call cursor(lnum, ccol + 1)

--- a/runtime/syntax/ave.vim
+++ b/runtime/syntax/ave.vim
@@ -34,7 +34,7 @@ syn match  aveNumber		"[+-]\=\<[0-9]\+\>"
 " Operator
 
 syn keyword aveOperator		or and max min xor mod by
-" 'not' is a kind of a problem: Its an Operator as well as a method
+" 'not' is a kind of a problem: It's an Operator as well as a method
 " 'not' is only marked as an Operator if not applied as method
 syn match aveOperator		"[^\.]not[^a-zA-Z]"
 

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -381,7 +381,7 @@ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc15 start="<<-\s*\\\z([^ \
 
 " Here Strings: {{{1
 " =============
-" available for: bash; ksh (really should be ksh93 only) but not if its a posix
+" available for: bash; ksh (really should be ksh93 only) but not if it's a posix
 if exists("b:is_bash") || (exists("b:is_kornshell") && !exists("g:is_posix"))
  syn match shHereString "<<<"	skipwhite	nextgroup=shCmdParenRegion
 endif

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6874,7 +6874,7 @@ libcall_common(typval_T *argvars, typval_T *rettv, int type)
 	return;
 
 #ifdef FEAT_LIBCALL
-    /* The first two args must be strings, otherwise its meaningless */
+    /* The first two args must be strings, otherwise it's meaningless */
     if (argvars[0].v_type == VAR_STRING && argvars[1].v_type == VAR_STRING)
     {
 	string_in = NULL;

--- a/src/main.aap
+++ b/src/main.aap
@@ -69,7 +69,7 @@
                     --with-mac-arch=$arch
                     --cache-file=auto/config.cache
 
-    # Configure arguments: create an empty "config.arg" file when its missing
+    # Configure arguments: create an empty "config.arg" file when it's missing
     config.arg:
         :touch {exist} config.arg
 

--- a/src/nbdebug.c
+++ b/src/nbdebug.c
@@ -41,7 +41,7 @@ static int	 errorHandler(Display *, XErrorEvent *);
 
 /*
  * nbdebug_wait	-   This function can be used to delay or stop execution of vim.
- *		    Its normally used to delay startup while attaching a
+ *		    It's normally used to delay startup while attaching a
  *		    debugger to a running process. Since workshop starts gvim
  *		    from a background process this is the only way to debug
  *		    startup problems.

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -2156,7 +2156,7 @@ nb_do_cmd(
 	else if (streq((char *)cmd, "save"))
 	{
 	    /*
-	     * NOTE - This command is obsolete wrt NetBeans. Its left in
+	     * NOTE - This command is obsolete wrt NetBeans. It's left in
 	     * only for historical reasons.
 	     */
 	    if (buf == NULL || buf->bufp == NULL)
@@ -2242,7 +2242,7 @@ nb_do_cmd(
 
     /*
      * Is this needed? I moved the netbeans_Xt_connect() later during startup
-     * and it may no longer be necessary. If its not needed then needupdate
+     * and it may no longer be necessary. If it's not needed then needupdate
      * and do_update can also be removed.
      */
     if (buf != NULL && buf->initDone && do_update)
@@ -2856,7 +2856,7 @@ netbeans_unmodified(buf_T *bufp UNUSED)
 }
 
 /*
- * Send a button release event back to netbeans. Its up to netbeans
+ * Send a button release event back to netbeans. It's up to netbeans
  * to decide what to do (if anything) with this event.
  */
     void
@@ -3453,7 +3453,7 @@ pos2off(buf_T *buf, pos_T *pos)
 
 
 /*
- * This message is printed after NetBeans opens a new file. Its
+ * This message is printed after NetBeans opens a new file. It's
  * similar to the message readfile() uses, but since NetBeans
  * doesn't normally call readfile, we do our own.
  */

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3569,7 +3569,7 @@ get_mef_name(void)
 	STRCAT(name, p + 2);
 	if (mch_getperm(name) < 0
 #ifdef HAVE_LSTAT
-		    /* Don't accept a symbolic link, its a security risk. */
+		    /* Don't accept a symbolic link, it's a security risk. */
 		    && mch_lstat((char *)name, &sb) < 0
 #endif
 		)

--- a/src/workshop.c
+++ b/src/workshop.c
@@ -71,7 +71,7 @@ static Boolean	 workshopHotKeysEnabled = False;
 
 /*
  * The following enum is from <gp_dbx/gp_dbx_common.h>. We can't include it
- * here because its C++.
+ * here because it's C++.
  */
 enum
 {
@@ -1752,7 +1752,7 @@ setDollarVim(
  *			directory. This is a Sun Visual WorkShop requirement!
  *
  * Note:		We override a user's $VIM because it won't have the
- *			WorkShop specific files. S/he may not like this but its
+ *			WorkShop specific files. S/he may not like this but it's
  *			better than getting the wrong files (especially as the
  *			user is likely to have $VIM set to 5.4 or later).
  */

--- a/src/wsdebug.c
+++ b/src/wsdebug.c
@@ -47,7 +47,7 @@ static int	 errorHandler(Display *, XErrorEvent *);
 
 /*
  * wsdebug_wait	-   This function can be used to delay or stop execution of vim.
- *		    Its normally used to delay startup while attaching a
+ *		    It's normally used to delay startup while attaching a
  *		    debugger to a running process. Since workshop starts gvim
  *		    from a background process this is the only way to debug
  *		    startup problems.


### PR DESCRIPTION
Mostly its --> it's in comments. 

Apologies for being pedantic ;) 

I've left changelogs alone as these are somewhat "historical"
