### PR TITLE
Fix doc for ch_log: s/must open/must be open/

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3070,7 +3070,7 @@ ch_log({msg} [, {handle}])					*ch_log()*
 		When {handle} is passed the channel number is used for the
 		message.
 		{handle} can be Channel or a Job that has a Channel.  The
-		Channel must open.
+		Channel must be open.
 
 ch_logfile({fname} [, {mode}])					*ch_logfile()*
 		Start logging channel activity to {fname}.


### PR DESCRIPTION
Not sure if it's factual correct, but grammatically it's not.. ;)
