### PR TITLE
Enhance the documentation of :autocmd

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -79,11 +79,15 @@ exception is that "<sfile>" is expanded when the autocmd is defined.  Example:
 
 Here Vim expands <sfile> to the name of the file containing this line.
 
-When your .vimrc file is sourced twice, the autocommands will appear twice.
-To avoid this, put this command in your .vimrc file, before defining
-autocommands: >
+":autocmd" adds to the list of autocommands regardless of whether they are
+already present.  If you'd like to be able to source your .vimrc more than
+once avoiding repeated autocommands, just wrap them in a group and clear the
+group first with ":autocmd!":
 
-	:autocmd!	" Remove ALL autocommands for the current group.
+        augroup vimrc
+            autocmd! " Remove all commands in the vimrc group
+            au BufNewFile,BufRead *.html so <sfile>:h/html.vim
+        augroup END
 
 If you don't want to remove all autocommands, you can instead use a variable
 to ensure that Vim includes the autocommands only once: >


### PR DESCRIPTION
Closes #1119.

This patch improves the documentation of `:autocmd` for the use case in which users want to source _~/.vimrc_ more than once.

First time I edit the help, please if the format is wrong just tell me and I'll revise.
