### PR TITLE
Fix opening of gzipped files when 'write' is off

### DIFF
--- a/runtime/autoload/gzip.vim
+++ b/runtime/autoload/gzip.vim
@@ -63,6 +63,9 @@ fun gzip#read(cmd)
   " set 'modifiable'
   let ma_save = &ma
   setlocal ma
+  " set 'write'
+  let write_save = &write
+  set write
   " Reset 'foldenable', otherwise line numbers get adjusted.
   if has("folding")
     let fen_save = &fen
@@ -127,6 +130,7 @@ fun gzip#read(cmd)
   let &pm = pm_save
   let &cpo = cpo_save
   let &l:ma = ma_save
+  let &write = write_save
   if has("folding")
     let &l:fen = fen_save
   endif


### PR DESCRIPTION
The standard plugin gzip.vim throws an error when you try to open a compressed file and 'write' is off.

Steps to reproduce:
1. create a gzipped file `file.gz`
2. open it like this: `vim -M file.gz`

This is especially a problem if you have your help files gzipped, because then there is an error every time you open a random file using `vim -M` and then open the Vim help.

Solution: temporarily enable 'write' when writing the temp file.
