### PR TITLE
Fix systemlist()

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2139,6 +2139,7 @@ test_arglist \
 	test_substitute \
 	test_syn_attr \
 	test_syntax \
+	test_system_func \
 	test_tabline \
 	test_tabpage \
 	test_tagcase \

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -11874,7 +11874,7 @@ get_cmd_output_as_rettv(
 	if (list == NULL)
 	    goto errret;
 
-	for (i = 0; i < len; ++i)
+	for (i = 0; i <= len; ++i)
 	{
 	    start = res + i;
 	    while (i < len && res[i] != NL)

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -183,6 +183,7 @@ NEW_TESTS = test_arglist.res \
 	    test_stat.res \
 	    test_substitute.res \
 	    test_syntax.res \
+	    test_system_func.res \
 	    test_textobjects.res \
 	    test_undo.res \
 	    test_usercommands.res \

--- a/src/testdir/test_system_func.vim
+++ b/src/testdir/test_system_func.vim
@@ -1,0 +1,27 @@
+" Test systemlist()
+
+let s:dump_cmd = has('win32') ? 'type' : 'cat'
+
+func! s:systemlist(content) abort
+  let file = tempname()
+  call writefile(a:content, file, 'b')
+  let cmdline = printf('%s %s', s:dump_cmd, shellescape(file))
+  call assert_equal(a:content, systemlist(cmdline))
+  call delete(file)
+endfunc
+
+func Test_systemlist()
+  let save_shellslash = &shellslash
+  set noshellslash  " Need for shellescape()
+
+  " empty file
+  call s:systemlist([''])
+
+  " noeol file
+  call s:systemlist(['foo'])
+
+  " eol file
+  call s:systemlist(['foo', ''])
+
+  let &shellslash = save_shellslash
+endfunc


### PR DESCRIPTION
:help systemlist() says:

> Output is the same as readfile() will output with {binary} argument
> set to "b".

And :help readfile() says:

> When {binary} contains "b" binary mode is used:
> - When the last line ends in a NL an extra empty list item is
>   added.
> - No CR characters are removed.

systemlist() doesn't satisfy the first matter.

``` vim
:echo systemlist('echo hello')
" => ['hello']
" `echo` command outputs text with NL,
" so this should be ['hello', '']
```

This change fixes the above problem.
