### PR TITLE
Remove isident/iskeyword local definition in avra.vim syntax file

### DIFF
--- a/runtime/syntax/avra.vim
+++ b/runtime/syntax/avra.vim
@@ -7,9 +7,6 @@
 let s:cpo_save = &cpo
 set cpo&vim
 
-setlocal iskeyword=a-z,A-Z,48-57,.,_
-" 'isident' is a global option, better not set it
-" setlocal isident=a-z,A-Z,48-57,.,_
 syn case ignore
 
 syn keyword avraRegister r0 r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14


### PR DESCRIPTION
Requested change in the original addition PR for avra.vim #439 

Tested with local avr assembly files and seemed to work just fine without those local definitions.
