### PR TITLE
Map Y to yank to end of line in defaults.vim

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -55,6 +55,10 @@ if has('win32')
   set guioptions-=t
 endif
 
+" Use Y to yank to end of line. Consistent with C and D.
+" Revert with ":unmap Y".
+map Y y$
+
 " Don't use Ex mode, use Q for formatting.
 " Revert with ":unmap Q".
 map Q gq


### PR DESCRIPTION
It seems to me, given the inclusion of `defaults.vim`, this would be the sensible time to address this long-standing oddity.

Lets have `Y` function consistenly with its cousins `C` and `D`.
