### PR TITLE
Add reminder to update side effects documentation for 'compatible'

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -483,6 +483,8 @@ struct vimoption
  * Exception: "t_" options are at the end.
  * The options with a NULL variable are 'hidden': a set command for them is
  * ignored and they are not printed.
+ * Please keep the table for 'compatible' in runtime/doc/options.txt updated
+ * when making changes here.
  */
 static struct vimoption options[] =
 {


### PR DESCRIPTION
The side effects table of 'compatible' in runtime/doc/options.txt got
quite out of sync and was just updated. Hopefully this comment will
reduce the likelihood of reoccurrance.
