### PR TITLE
Check for __FreeBSD_kernel__ in OPEN_CHR_FILES checks

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -2494,7 +2494,7 @@ typedef enum
 #define FNE_INCL_BR	1	/* include [] in name */
 #define FNE_CHECK_START	2	/* check name starts with valid character */
 
-#if (defined(sun) || defined(__FreeBSD__)) && defined(S_ISCHR)
+#if (defined(sun) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)) && defined(S_ISCHR)
 # define OPEN_CHR_FILES
 #endif
 


### PR DESCRIPTION
The Debian GNU/kFreebsd project provides a Debian userland on top of the
FreeBSD kernel.  Vim wasn't properly detecting that it should define
OPEN_CHR_FILES there because **freebsd** isn't defined there.

Adding the check for **FreeBSD_kernel**, which is defined when running a
FreeBSD kernel regardless of userland, ensures OPEN_CHR_FILES is set for
Debian GNU/kFreebsd.
