### PR TITLE
Disable undo when running complete() without changes.

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2132,6 +2132,7 @@ f_col(typval_T *argvars, typval_T *rettv)
 f_complete(typval_T *argvars, typval_T *rettv UNUSED)
 {
     int	    startcol;
+    int	    save_undo_off;
 
     if ((State & INSERT) == 0)
     {
@@ -2154,7 +2155,7 @@ f_complete(typval_T *argvars, typval_T *rettv UNUSED)
     if (startcol <= 0)
 	return;
 
-    int save_undo_off = undo_off;
+    save_undo_off = undo_off;
     if (curbuf->b_compl_changedtick != 0
         && curbuf->b_compl_changedtick == curbuf->b_changedtick)
       undo_off = TRUE;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2154,7 +2154,15 @@ f_complete(typval_T *argvars, typval_T *rettv UNUSED)
     if (startcol <= 0)
 	return;
 
+    int save_undo_off = undo_off;
+    if (curbuf->b_compl_changedtick != 0
+        && curbuf->b_compl_changedtick == curbuf->b_changedtick)
+      undo_off = TRUE;
+
     set_completion(startcol - 1, argvars[1].vval.v_list);
+
+    undo_off = save_undo_off;
+    curbuf->b_compl_changedtick = curbuf->b_changedtick;
 }
 
 /*

--- a/src/main.c
+++ b/src/main.c
@@ -1163,8 +1163,11 @@ main_loop(
 		    && last_changedtick != curbuf->b_changedtick)
 	    {
 		if (last_changedtick_buf == curbuf)
-		    apply_autocmds(EVENT_TEXTCHANGED, NULL, NULL,
-							       FALSE, curbuf);
+        {
+		  curbuf->b_compl_changedtick = curbuf->b_changedtick;
+		  apply_autocmds(EVENT_TEXTCHANGED, NULL, NULL,
+						 FALSE, curbuf);
+        }
 		last_changedtick_buf = curbuf;
 		last_changedtick = curbuf->b_changedtick;
 	    }

--- a/src/structs.h
+++ b/src/structs.h
@@ -1888,6 +1888,8 @@ struct file_buffer
     int		b_changed;	/* 'modified': Set to TRUE if something in the
 				   file has been changed and not written out. */
     int		b_changedtick;	/* incremented for each change, also for undo */
+    int		b_compl_changedtick;	/* Used to track the changetick between
+                                           complete() calls */
 
     int		b_saving;	/* Set to TRUE if we are in the middle of
 				   saving the buffer. */


### PR DESCRIPTION
This fixes an issue where `set_completion()` creates empty undo entries when there's no changes to the buffer.  I'm not sure if this is the best approach, but hopefully someone more knowledgeable of the completion code will have more insight.

It looks like the main cause of this issue is `stop_arrow()` in [edit.c#L2802](https://github.com/vim/vim/blob/156919f99afd1ac11d19d4270afbc1afb7245640/src/edit.c#L2802) not accounting for `compl_no_insert`.  Changing that line to `!compl_no_insert && stop_arrow() == FAIL` fixes the issue when calling `complete()` the first time, but subsequent calls continue to create more empty undo entries.  It seems that [edit.c#L3879](https://github.com/vim/vim/blob/156919f99afd1ac11d19d4270afbc1afb7245640/src/edit.c#L3879) defeats it.  I didn't want to try checking `compl_no_insert` and `ctrl_x_mode` there since `insertchar()` is even more unfamiliar code and I wasn't sure of the side effects.

In investigating this, I noticed that `b:changedtick` doesn't increment when the blank undo entries were created, which is why I'm using it for tracking and temporarily disabling undo.  It seems that the correlation between `b:changedtick` and undo creation is broken with `set_completion()`.

I used the following script with `-u` to test/confirm this problem:

``` vim
set nocompatible
set completeopt+=noinsert,noselect
set completeopt+=noinsert
set noshowmode
set shortmess+=c

function! s:changes(name) abort
  echomsg '['.a:name.'] changedtick:' b:changedtick 'changenr:' changenr() '-' string(reltime())
endfunction

function! s:complete() abort
  call complete(1, Omni(0, ''))
  call s:changes('complete')
  return ''
endfunction

function! Omni(findstart, base) abort
  if a:findstart == 1
    return 1
  endif
  return ['January', 'February', 'March',
        \ 'April', 'May', 'June', 'July', 'August', 'September',
        \ 'October', 'November', 'December']
endfunction

set omnifunc=Omni
autocmd InsertEnter * call s:changes('autocmd')

inoremap <right> <c-r>=<sid>complete(0)<cr>
```

With the script sourced, the following happens:
- `a<esc>a<esc>` etc, results in no undo entry.
- `<right>` will display the menu and immediately results in a blank undo entry each time it's pressed.
- `^X^O` displays the menu in insert mode and creates a blank undo entry when pressing `<esc>`.
