### PR TITLE
add Github Issue Template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,19 @@ maillist is also fine.
 
 Please use the GitHub issues only for actual issues. If you are not 100% sure
 that your problem is a Vim issue, please first discuss this on the Vim user
-maillist.  Try reproducing the problem without any plugins or settings:
+maillist.
+
+Describe your issue properly.  If you spend 30 seconds throwing out a sloppy
+report, do expect that others will spend exactly the same amount on trying to
+resolve it.  In contrast, if you write a complete and pleasantly informative
+bug report, you will almost certainly be rewarded by excellent help with your
+problem.
+
+Please be polite.  You are asking software developers for help, that spend their
+spare time for free, so you might want to avoid treating them as if they were a
+commodity or at your free disposal.
+
+Try reproducing the problem without any plugins or settings:
 
     vim -N -u NONE
 
@@ -36,8 +48,9 @@ Feel free to report even the smallest problem, also typos in the documentation.
 You can find known issues in the todo file: ":help todo".
 Or open [the todo file] on GitHub to see the latest version.
 
-[the todo file]: https://github.com/vim/vim/blob/master/runtime/doc/todo.txt
+Please be prepared to try out patches.
 
+[the todo file]: https://github.com/vim/vim/blob/master/runtime/doc/todo.txt
 
 # Syntax, indent and other runtime files
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,54 @@
+ Please fill out the following questions:
+
+ - I have read the [Contribution guidelines](https://github.com/vim/vim/blob/master/CONTRIBUTING.md):  Yes/No
+ - I have read the [faq](https://vimhelp.appspot.com/vim_faq.txt.html#faq-2.5) regarding my problem: Yes/No
+ - I am not asking a usage question: Yes/No
+   Those questions are better suited at the [vim-use ml](https://groups.google.com/forum/#!forum/vim_use) or [stackexchange](https://vi.stackexchange.com/).
+ - I was not able to find an [open](https://github.com/vim/vim/issues?q=is%3Aopen)
+   or [closed](https://github.com/vim/vim/issues?q=is%3Aclosed) issue
+   similar to the one I'm about to report and couldn't find an answer to my problem: Yes/No
+ - The issue has not yet been discussed on the [vim-dev mailinglist](https://groups.google.com/forum/#!forum/vim_dev): Yes/No
+ - The problem is not already present in the [todo list](https://github.com/vim/vim/blob/master/runtime/doc/todo.txt): Yes/No
+ - I have verified the problem with the latest patch level of vim: Yes/No
+ - I am reporting a whishlist feature: Yes/No
+ - The problem is related to a subproject (xxd, GvimExt, etc...): Yes/No
+
+### Setup
+
+ - Which version of Vim are you using? Is it 32-bit or 64-bit? On which Operating System?
+
+```
+$ vim --version
+```
+
+ - Any other interesting things about your environment that might be related
+   to the issue you're seeing?
+
+ _TODO_
+
+### Details
+
+ - In case of a terminal Vim:
+   What terminal are you using? What is $TERM variable?
+   What is the 'term' option value in Vim? What is the t_Co option?
+   What shell are you using?
+
+ _TODO_
+
+ - Any option set, that might be relevant?
+
+ _TODO_
+
+ - What commands did you run to trigger this issue? If you can, provide a
+   [Minimal, Complete, and Verifiable example](http://stackoverflow.com/help/mcve)
+   this will help us understand and reproduce the issue, starting from `vim -u NONE -N`
+
+ _TODO_
+
+ - What did you expect to occur after running these commands?
+
+ _TODO_
+
+ - What actually happened instead?
+
+ _TODO_


### PR DESCRIPTION
This PR is about to improve the documentation regarding reporting issues. It contains of 2 parts basically:
1. More and more people are reporting user questions here, so therefore improve the Contributing guidelines, so people know how to write good bug reports.
2. Create an ISSUE_TEMPLATE.md file, that will be used as template, when a new issue is created. This works as a basic questionnaire to ask for relevent information from the reporter and also make sure, people read the contribution guidelines. (since this is a PR from my private repository, you can see how this works [here](https://github.com/chrisbra/vim/issues/new))

Comments on how to improve the situation are welcome.
