### PR TITLE
Fix widget sizing on current Gtk+ 3.22 branch

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4429,6 +4429,12 @@ form_configure_event(GtkWidget *widget UNUSED,
 {
     int usable_height = event->height;
 
+#if GTK_CHECK_VERSION(3,0,0)
+    if (!gtk_check_version(3, 22, 2) &&
+        event->window != gtk_widget_get_window(gui.formwin))
+	return TRUE;
+#endif
+
     /* When in a GtkPlug, we can't guarantee valid heights (as a round
      * no. of char-heights), so we have to manually sanitise them.
      * Widths seem to sort themselves out, don't ask me why.

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3099,6 +3099,9 @@ drawarea_configure_event_cb(GtkWidget	      *widget,
     if (event->width == cur_width && event->height == cur_height)
 	return TRUE;
 
+    if (!gtk_check_version(3, 22, 2) && event->send_event == FALSE)
+	return TRUE;
+
     cur_width = event->width;
     cur_height = event->height;
 


### PR DESCRIPTION
[Gtk recently started emitting configure events when repositioning child windows](https://git.gnome.org/browse/gtk+/commit/?h=gtk-3-22&id=12579fe71b3b8f79eb9c1b80e429443bcc437dd0). Events for the form's child windows bubble up the widget hierarchy, get caught by our configure event handler, and treated as if they were reporting the size of the form window. [As a result, the shell was sized using far too small dimensions](https://bugs.archlinux.org/task/51509). ([bgo](https://bugzilla.gnome.org/show_bug.cgi?id=773387)) This change will be part of Gtk+ 3.22.2.

Solve this by checking whether the configure event we get is really for the form widget.
