### PR TITLE
Ordering of tags in result of taglist call.

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2352,7 +2352,8 @@ systemlist({expr} [, {input}])	List	output of shell command/filter {expr}
 tabpagebuflist([{arg}])		List	list of buffer numbers in tab page
 tabpagenr([{arg}])		Number	number of current or last tab page
 tabpagewinnr({tabarg}[, {arg}]) Number	number of current window in tab page
-taglist({expr})			List	list of tags matching {expr}
+taglist({expr}[, {buffername}])	List	list of tags matching {expr},
+optionally ordered based on the given buffername.
 tagfiles()			List	tags files used
 tan({expr})			Float	tangent of {expr}
 tanh({expr})			Float	hyperbolic tangent of {expr}
@@ -7714,8 +7715,11 @@ tagfiles()	Returns a |List| with the file names used to search for tags
 		for the current buffer.  This is the 'tags' option expanded.
 
 
-taglist({expr})							*taglist()*
+taglist({expr}[, {buffername}])						*taglist()*
 		Returns a list of tags matching the regular expression {expr}.
+                Uses {buffername} to prioritize the results in the same way
+                that |:tselect| does. See |tag-priority|. If {buffername} is
+                omitted the tags are not prioritized.
 		Each list item is a dictionary with at least the following
 		entries:
 			name		Name of the tag.

--- a/src/Makefile
+++ b/src/Makefile
@@ -2209,6 +2209,7 @@ test_arglist \
 	test_tabpage \
 	test_tagcase \
 	test_tagjump \
+	test_taglist \
 	test_tcl \
 	test_textobjects \
 	test_timers \

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -820,7 +820,7 @@ static struct fst
     {"tabpagenr",	0, 1, f_tabpagenr},
     {"tabpagewinnr",	1, 2, f_tabpagewinnr},
     {"tagfiles",	0, 0, f_tagfiles},
-    {"taglist",		1, 1, f_taglist},
+    {"taglist",		1, 2, f_taglist},
 #ifdef FEAT_FLOAT
     {"tan",		1, 1, f_tan},
     {"tanh",		1, 1, f_tanh},
@@ -12214,6 +12214,7 @@ f_tagfiles(typval_T *argvars UNUSED, typval_T *rettv)
     static void
 f_taglist(typval_T *argvars, typval_T *rettv)
 {
+    char_u  *fname;
     char_u  *tag_pattern;
 
     tag_pattern = get_tv_string(&argvars[0]);
@@ -12222,8 +12223,14 @@ f_taglist(typval_T *argvars, typval_T *rettv)
     if (*tag_pattern == NUL)
 	return;
 
+    if ( argvars[1].v_type != VAR_UNKNOWN ) {
+	fname = get_tv_string(&argvars[1]);
+    } else {
+	fname = NULL;
+    }
+
     if (rettv_list_alloc(rettv) == OK)
-	(void)get_tags(rettv->vval.v_list, tag_pattern);
+	(void)get_tags(rettv->vval.v_list, tag_pattern, fname);
 }
 
 /*

--- a/src/proto/tag.pro
+++ b/src/proto/tag.pro
@@ -8,5 +8,5 @@ int get_tagfname(tagname_T *tnp, int first, char_u *buf);
 void tagname_free(tagname_T *tnp);
 void simplify_filename(char_u *filename);
 int expand_tags(int tagnames, char_u *pat, int *num_file, char_u ***file);
-int get_tags(list_T *list, char_u *pat);
+int get_tags(list_T *list, char_u *pat, char_u* buf_fname);
 /* vim: set ft=c : */

--- a/src/tag.c
+++ b/src/tag.c
@@ -3880,7 +3880,7 @@ add_tag_field(
  * as a dictionary
  */
     int
-get_tags(list_T *list, char_u *pat)
+get_tags(list_T *list, char_u *pat, char_u *buf_fname)
 {
     int		num_matches, i, ret;
     char_u	**matches, *p;
@@ -3890,7 +3890,8 @@ get_tags(list_T *list, char_u *pat)
     long	is_static;
 
     ret = find_tags(pat, &num_matches, &matches,
-				    TAG_REGEXP | TAG_NOIC, (int)MAXCOL, NULL);
+				    TAG_REGEXP | TAG_NOIC, (int)MAXCOL, 
+				    buf_fname);
     if (ret == OK && num_matches > 0)
     {
 	for (i = 0; i < num_matches; ++i)

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -204,6 +204,7 @@ NEW_TESTS = test_arabic.res \
 	    test_substitute.res \
 	    test_syntax.res \
 	    test_system.res \
+	    test_taglist.res \
 	    test_tcl.res \
 	    test_textobjects.res \
 	    test_undo.res \

--- a/src/testdir/test_taglist.vim
+++ b/src/testdir/test_taglist.vim
@@ -1,0 +1,15 @@
+" test 'taglist' function
+
+func Test_taglist()
+  call writefile(["FFoo\tXfoo\t1", "FBar\tXfoo\t2", "BFoo\tXbar\t1", "BBar\tXbar\t2"], 'Xtags')
+  set tags=Xtags
+  e Xtext
+
+  call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo"), {i, v -> v.name}))
+  call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo", "Xtext"), {i, v -> v.name}))
+  call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo", "Xfoo"), {i, v -> v.name}))
+  call assert_equal(['BFoo', 'FFoo'], map(taglist("Foo", "Xbar"), {i, v -> v.name}))
+
+  call delete('Xtags')
+endfunc
+


### PR DESCRIPTION
using :tselect the tags are ordered in a nice way. Using "taglist" tey are not. This allows the buffer name to be specified to "taglist" which makes it prioritise the tags like :tselect would if you were n the buffer with the name specified.
