### PR TITLE
gzip plugin: Support transparent (de)compression of *.lz files

### DIFF
--- a/runtime/doc/pi_gzip.txt
+++ b/runtime/doc/pi_gzip.txt
@@ -1,4 +1,4 @@
-*pi_gzip.txt*   For Vim version 8.0.  Last change: 2012 Jul 19
+*pi_gzip.txt*   For Vim version 8.0.  Last change: 2016 Oct 30
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -27,6 +27,7 @@ with these extensions:
 	*.bz2		bzip2
 	*.lzma		lzma
 	*.xz		xz
+	*.lz		lzip
 
 That's actually the only thing you need to know.  There are no options.
 

--- a/runtime/plugin/gzip.vim
+++ b/runtime/plugin/gzip.vim
@@ -1,6 +1,6 @@
 " Vim plugin for editing compressed files.
 " Maintainer: Bram Moolenaar <Bram@vim.org>
-" Last Change: 2010 Mar 10
+" Last Change: 2016 Oct 30
 
 " Exit quickly when:
 " - this plugin was already loaded
@@ -20,25 +20,29 @@ augroup gzip
   "
   " Set binary mode before reading the file.
   " Use "gzip -d", gunzip isn't always available.
-  autocmd BufReadPre,FileReadPre	*.gz,*.bz2,*.Z,*.lzma,*.xz setlocal bin
+  autocmd BufReadPre,FileReadPre	*.gz,*.bz2,*.Z,*.lzma,*.xz,*.lz setlocal bin
   autocmd BufReadPost,FileReadPost	*.gz  call gzip#read("gzip -dn")
   autocmd BufReadPost,FileReadPost	*.bz2 call gzip#read("bzip2 -d")
   autocmd BufReadPost,FileReadPost	*.Z   call gzip#read("uncompress")
   autocmd BufReadPost,FileReadPost	*.lzma call gzip#read("lzma -d")
   autocmd BufReadPost,FileReadPost	*.xz  call gzip#read("xz -d")
+  autocmd BufReadPost,FileReadPost	*.lz  call gzip#read("lzip -d")
   autocmd BufWritePost,FileWritePost	*.gz  call gzip#write("gzip")
   autocmd BufWritePost,FileWritePost	*.bz2 call gzip#write("bzip2")
   autocmd BufWritePost,FileWritePost	*.Z   call gzip#write("compress -f")
   autocmd BufWritePost,FileWritePost	*.lzma call gzip#write("lzma -z")
   autocmd BufWritePost,FileWritePost	*.xz  call gzip#write("xz -z")
+  autocmd BufWritePost,FileWritePost	*.lz  call gzip#write("lzip")
   autocmd FileAppendPre			*.gz  call gzip#appre("gzip -dn")
   autocmd FileAppendPre			*.bz2 call gzip#appre("bzip2 -d")
   autocmd FileAppendPre			*.Z   call gzip#appre("uncompress")
   autocmd FileAppendPre			*.lzma call gzip#appre("lzma -d")
   autocmd FileAppendPre			*.xz   call gzip#appre("xz -d")
+  autocmd FileAppendPre			*.lz   call gzip#appre("lzip -d")
   autocmd FileAppendPost		*.gz  call gzip#write("gzip")
   autocmd FileAppendPost		*.bz2 call gzip#write("bzip2")
   autocmd FileAppendPost		*.Z   call gzip#write("compress -f")
   autocmd FileAppendPost		*.lzma call gzip#write("lzma -z")
   autocmd FileAppendPost		*.xz call gzip#write("xz -z")
+  autocmd FileAppendPost		*.lz call gzip#write("lzip")
 augroup END


### PR DESCRIPTION
Support compressing and decompressing *.lz files created using the lzip
compressor (http://www.nongnu.org/lzip/) transparently.
