### PR TITLE
Add support for c++17 nested namespace syntax

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -5762,6 +5762,7 @@ cin_is_cpp_namespace(char_u *s)
 {
     char_u	*p;
     int		has_name = FALSE;
+    int		has_name_start = FALSE;
 
     s = cin_skipcomment(s);
     if (STRNCMP(s, "namespace", 9) == 0 && (s[9] == NUL || !vim_iswordc(s[9])))
@@ -5780,9 +5781,18 @@ cin_is_cpp_namespace(char_u *s)
 	    }
 	    else if (vim_iswordc(*p))
 	    {
+		has_name_start = TRUE;
 		if (has_name)
 		    return FALSE; /* word character after skipping past name */
 		++p;
+	    }
+	    else if (p[0] == ':' &&
+		    p[1] == ':' &&
+		    vim_iswordc(p[2]))
+	    {
+		if (!has_name_start || has_name)
+		    return FALSE;
+		p += 3;
 	    }
 	    else
 	    {

--- a/src/testdir/test3.in
+++ b/src/testdir/test3.in
@@ -1932,6 +1932,26 @@ namespace test
 {
   111111111111111111;
 }
+namespace test::cpp17
+{
+  111111111111111111;
+}
+namespace ::incorrectcpp17
+{
+  111111111111111111;
+}
+namespace test::incorrectcpp17::
+{
+  111111111111111111;
+}
+namespace test:incorrectcpp17
+{
+  111111111111111111;
+}
+namespace test:::incorrectcpp17
+{
+  111111111111111111;
+}
 namespace{
   111111111111111111;
 }

--- a/src/testdir/test3.ok
+++ b/src/testdir/test3.ok
@@ -1730,6 +1730,26 @@ namespace test
 {
 111111111111111111;
 }
+namespace test::cpp17
+{
+111111111111111111;
+}
+namespace ::incorrectcpp17
+{
+	111111111111111111;
+}
+namespace test::incorrectcpp17::
+{
+	111111111111111111;
+}
+namespace test:incorrectcpp17
+{
+	111111111111111111;
+}
+namespace test:::incorrectcpp17
+{
+	111111111111111111;
+}
 namespace{
 111111111111111111;
 }


### PR DESCRIPTION
Problem:    c++17 extends namespace declaration syntax to allow nested
            namespaces defination (namespace A::B::C)
Solution:   Add check that passes double colon inside a name
