### PR TITLE
Remove netrw_browse_split help's :Lexplore exception

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -2555,8 +2555,6 @@ your browsing preferences.  (see also: |netrw-settings|)
 				    editing.  It will also use the specified tab
 				    and window numbers to perform editing
 				    (see |clientserver|, |netrw-ctrl-r|)
-				This option does not affect |:Lexplore|
-				windows.
 
 				Related topics:
 				    |g:netrw_alto|	|g:netrw_altv|


### PR DESCRIPTION
As far as I can tell, the note in the documentation about g:netrw_browse_split not applying to :Lexplore windows isn't currently accurate.