### PR TITLE
Update fstab.vim to allow PARTLABEL

### DIFF
--- a/runtime/syntax/fstab.vim
+++ b/runtime/syntax/fstab.vim
@@ -38,6 +38,8 @@ syn match fsDeviceError /\%([^a-zA-Z0-9_\/#@:\.-]\|^\w\{-}\ze\W\)/ contained
 syn keyword fsDeviceKeyword contained none proc linproc tmpfs devpts devtmpfs sysfs usbfs
 syn keyword fsDeviceKeyword contained LABEL nextgroup=fsDeviceLabel
 syn keyword fsDeviceKeyword contained UUID nextgroup=fsDeviceUUID
+syn keyword fsDeviceKeyword contained PARTLABEL nextgroup=fsDeviceLabel
+syn keyword fsDeviceKeyword contained PARTUUID nextgroup=fsDeviceUUID
 syn keyword fsDeviceKeyword contained sshfs nextgroup=fsDeviceSshfs
 syn match fsDeviceKeyword contained /^[a-zA-Z0-9.\-]\+\ze:/
 syn match fsDeviceLabel contained /=[^ \t]\+/hs=s+1 contains=fsOperator


### PR DESCRIPTION
PARTLABEL and PARTUUID are options supported by GPT partition.
They are allowed in fstab, just as LABEL and UUID are.