### PR TITLE
Handling of CamelCase in the spell checker

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7131,6 +7131,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When on spell checking will be done.  See |spell|.
 	The languages are specified with 'spelllang'.
 
+						*'spellcamelcase'* *'scc'*
+						*'nospellcamelcase'* *'noscc'*
+'spellcamelcase'	boolean	(default off)
+			local to window
+			{not in Vi}
+			{not available when compiled without the |+syntax|
+			feature}
+	When on spell checking will treat each word in a camelCase identifier
+	as a distinct word.
+
 						*'spellcapcheck'* *'spc'*
 'spellcapcheck' 'spc'	string	(default "[.?!]\_[\])'" \t]\+")
 			local to buffer

--- a/src/option.c
+++ b/src/option.c
@@ -235,6 +235,7 @@
 #define PV_SCROLL	OPT_WIN(WV_SCROLL)
 #ifdef FEAT_SPELL
 # define PV_SPELL	OPT_WIN(WV_SPELL)
+# define PV_SCC		OPT_WIN(WV_SCC)
 #endif
 #ifdef FEAT_SYN_HL
 # define PV_CUC		OPT_WIN(WV_CUC)
@@ -2578,6 +2579,13 @@ static struct vimoption options[] =
     {"spell",	    NULL,   P_BOOL|P_VI_DEF|P_RWIN,
 #ifdef FEAT_SPELL
 			    (char_u *)VAR_WIN, PV_SPELL,
+#else
+			    (char_u *)NULL, PV_NONE,
+#endif
+			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+    {"spellcamelcase", "scc", P_BOOL|P_VI_DEF|P_RWIN,
+#ifdef FEAT_SPELL
+			    (char_u *)VAR_WIN, PV_SCC,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
@@ -10617,6 +10625,7 @@ get_varp(struct vimoption *p)
 	case PV_LIST:	return (char_u *)&(curwin->w_p_list);
 #ifdef FEAT_SPELL
 	case PV_SPELL:	return (char_u *)&(curwin->w_p_spell);
+	case PV_SCC:	return (char_u *)&(curwin->w_p_scc);
 #endif
 #ifdef FEAT_SYN_HL
 	case PV_CUC:	return (char_u *)&(curwin->w_p_cuc);

--- a/src/option.h
+++ b/src/option.h
@@ -1175,6 +1175,7 @@ enum
     , WV_SCROLL
 #ifdef FEAT_SPELL
     , WV_SPELL
+    , WV_SCC
 #endif
 #ifdef FEAT_SYN_HL
     , WV_CUC

--- a/src/structs.h
+++ b/src/structs.h
@@ -228,6 +228,8 @@ typedef struct
 #ifdef FEAT_SPELL
     int		wo_spell;
 # define w_p_spell w_onebuf_opt.wo_spell /* 'spell' */
+    int		wo_scc;
+# define w_p_scc w_onebuf_opt.wo_scc	/* 'spellcamelcase' */
 #endif
 #ifdef FEAT_SYN_HL
     int		wo_cuc;


### PR DESCRIPTION
The problem is that my source code has a lot of camel case identifiers,
dictated by our coding standard. I want to use the spell checker but
it marks every camel case identifier as a miss-spelled word.

This is a simple patch to the spell checking that interprets a lower
case letter followed by an uppercase as a word boundary.

Change-Id: I6f581d0bd15f2a41787df8db6853bd4d3db92913