### PR TITLE
Make system() and systemlist() accept a buffer id.

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7548,7 +7548,10 @@ system({expr} [, {input}])				*system()* *E677*
 		If {input} is given and is a |List| it is written to the file
 		in a way |writefile()| does with {binary} set to "b" (i.e.
 		with a newline between each list item with newlines inside
-		list items converted to NULs).  
+		list items converted to NULs).
+		When {input} is given and is a number that is a valid id for
+		an existing buffer then the content of the buffer is written
+		to the file line by line, separated by a NL.
 
 		Pipes are not used, the 'shelltemp' option is not used.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2140,6 +2140,7 @@ test_arglist \
 	test_substitute \
 	test_syn_attr \
 	test_syntax \
+	test_system \
 	test_tabline \
 	test_tabpage \
 	test_tagcase \

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -11824,7 +11824,28 @@ get_cmd_output_as_rettv(
 	    EMSG2(_(e_notopen), infile);
 	    goto errret;
 	}
-	if (argvars[1].v_type == VAR_LIST)
+	if (argvars[1].v_type == VAR_NUMBER)
+	{
+	    linenr_T line;
+	    buf_T *buf;
+	    size_t len;
+
+	    buf = buflist_findnr(argvars[1].vval.v_number);
+	    if (buf == NULL)
+		EMSGN(_(e_nobufnr), argvars[1].vval.v_number);
+
+	    for (line = 1; line <= buf->b_ml.ml_line_count; line++)
+	    {
+		p = ml_get_buf(buf, line, FALSE);
+		len = STRLEN(p);
+		if (len > 0 && fwrite(p, len, 1, fd) != 1) {
+		    err = TRUE;
+		    break;
+		}
+		fputc(NL, fd);
+	    }
+	}
+	else if (argvars[1].v_type == VAR_LIST)
 	{
 	    if (write_list(fd, argvars[1].vval.v_list, TRUE) == FAIL)
 		err = TRUE;

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -181,6 +181,7 @@ NEW_TESTS = test_arglist.res \
 	    test_stat.res \
 	    test_substitute.res \
 	    test_syntax.res \
+	    test_system.res \
 	    test_textobjects.res \
 	    test_undo.res \
 	    test_usercommands.res \

--- a/src/testdir/test_system.vim
+++ b/src/testdir/test_system.vim
@@ -1,0 +1,11 @@
+function! Test_System()
+  if !executable('echo') || !executable('cat') || !executable('wc')
+    return
+  endif
+  call assert_equal("123\n", system('echo 123'))
+  call assert_equal(['123'], systemlist('echo 123'))
+  call assert_equal('123',   system('cat', '123'))
+  call assert_equal(['123'], systemlist('cat', '123'))
+  call assert_equal("11\n",  system('wc -l', bufnr('.')))
+  call assert_equal(['11'],  systemlist('wc -l', bufnr('.')))
+endfunction


### PR DESCRIPTION
This simple patch makes passing the whole buffer to a process easier as you don't have to stitch the lines together on the vimL side.
Comes with a side dish of unix-friendly tests.