### PR TITLE
Fix #1242

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -4442,8 +4442,11 @@ job_free_all(void)
 }
 #endif
 
+/*
+ * Return TRUE if the process of "job" has to be checked whether is ended.
+ */
     static int
-job_still_alive(job_T *job)
+job_need_end_check(job_T *job)
 {
     return job->jv_status == JOB_STARTED
 		   && (job->jv_stoponexit != NULL || job->jv_exit_cb != NULL);
@@ -4463,7 +4466,7 @@ job_channel_still_useful(job_T *job)
     static int
 job_still_useful(job_T *job)
 {
-    return job_still_alive(job) || job_channel_still_useful(job);
+    return job_need_end_check(job) || job_channel_still_useful(job);
 }
 
 /*
@@ -4539,7 +4542,7 @@ job_unref(job_T *job)
 	{
 	    /* Do not free the job when it has not ended yet and there is a
 	     * "stoponexit" flag or an exit callback. */
-	    if (!job_still_alive(job))
+	    if (!job_need_end_check(job))
 	    {
 		job_free(job);
 	    }

--- a/src/channel.c
+++ b/src/channel.c
@@ -4674,6 +4674,9 @@ job_check_ended(void)
 {
     int		i;
 
+    if (first_job == NULL)
+	return;
+
     for (i = 0; i < MAX_CHECK_ENDED; ++i)
     {
 	job_T	*job = mch_detect_ended_job(first_job);

--- a/src/channel.c
+++ b/src/channel.c
@@ -4478,7 +4478,9 @@ job_cleanup(job_T *job)
 	typval_T	rettv;
 	int		dummy;
 
-	/* invoke the exit callback; make sure the refcount is > 0 */
+	/* invoke the exit callback; make sure the refcount is > 0.  Do not
+	 * free it in case that the close callback of the associated channel
+	 * isn't invoked yet and will get information by job_info(). */
 	++job->jv_refcount;
 	argv[0].v_type = VAR_JOB;
 	argv[0].vval.v_job = job;
@@ -4493,8 +4495,9 @@ job_cleanup(job_T *job)
     }
     if (job->jv_refcount == 0 && !job_channel_still_useful(job))
     {
-	/* The job was already unreferenced, now that it ended it can be
-	 * freed. Careful: caller must not use "job" after this! */
+	/* The job was already unreferenced and the associated channel was
+	 * detached, now that it ended it can be freed. Careful: caller must
+	 * not use "job" after this! */
 	job_free(job);
     }
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -7283,7 +7283,7 @@ get_tv_string_buf_chk(typval_T *varp, char_u *buf)
 		if (job == NULL)
 		    return (char_u *)"no process";
 		status = job->jv_status == JOB_FAILED ? "fail"
-				: job->jv_status == JOB_ENDED ? "dead"
+				: job->jv_status >= JOB_ENDED ? "dead"
 				: "run";
 # ifdef UNIX
 		vim_snprintf((char *)buf, NUMBUFLEN,

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -5354,7 +5354,7 @@ mch_job_status(job_T *job)
     return "run";
 
 return_dead:
-    if (job->jv_status != JOB_ENDED)
+    if (job->jv_status < JOB_ENDED)
     {
 	ch_log(job->jv_channel, "Job ended");
 	job->jv_status = JOB_ENDED;
@@ -5398,7 +5398,7 @@ mch_detect_ended_job(job_T *job_list)
 		job->jv_exitval = WEXITSTATUS(status);
 	    else if (WIFSIGNALED(status))
 		job->jv_exitval = -1;
-	    if (job->jv_status != JOB_ENDED)
+	    if (job->jv_status < JOB_ENDED)
 	    {
 		ch_log(job->jv_channel, "Job ended");
 		job->jv_status = JOB_ENDED;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4978,7 +4978,7 @@ mch_job_status(job_T *job)
 	    || dwExitCode != STILL_ACTIVE)
     {
 	job->jv_exitval = (int)dwExitCode;
-	if (job->jv_status != JOB_ENDED)
+	if (job->jv_status < JOB_ENDED)
 	{
 	    ch_log(job->jv_channel, "Job ended");
 	    job->jv_status = JOB_ENDED;

--- a/src/structs.h
+++ b/src/structs.h
@@ -1425,7 +1425,8 @@ typedef enum
 {
     JOB_FAILED,
     JOB_STARTED,
-    JOB_ENDED
+    JOB_ENDED,
+    JOB_FINISHED
 } jobstatus_T;
 
 /*


### PR DESCRIPTION
## cause of #1242 

Job process may be completed before its channel closed.
In this case, `job-close_cb` is invoked after `job-exit_cb`, thus `ch_getjob(ch)` returns invalid job
(`ch->ch_job == NULL`) in close_cb.

## solution proposal

When job completed after its channel closed, release job resource at once as until now.
Otherwise, keep job reference until its channel closed, and release job resource at GC.