### PR TITLE
an action help language CTRL-] in tag.c fixed

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -1479,12 +1479,12 @@ find_tags(
 #ifdef FEAT_MULTI_LANG
     /* Set a flag if the file extension is .txt */
     int is_txt = 0;
-      if ((flags & TAG_KEEP_LANG)
-              && help_lang_find == NULL
-	      && curbuf->b_fname != NULL
-	      && (i = (int)STRLEN(curbuf->b_fname)) > 4
-	      && STRICMP(curbuf->b_fname + i - 4, ".txt") == 0)
-	  is_txt = 1;
+    if ((flags & TAG_KEEP_LANG)
+	  && help_lang_find == NULL
+	  && curbuf->b_fname != NULL
+	  && (i = (int)STRLEN(curbuf->b_fname)) > 4
+	  && STRICMP(curbuf->b_fname + i - 4, ".txt") == 0)
+	is_txt = 1;
 #endif
 #ifdef FEAT_TAG_BINS
     orgpat.regmatch.rm_ic = ((p_ic || !noic)
@@ -1524,7 +1524,7 @@ find_tags(
 		    STRCPY(help_lang, "en");
 		else
 		{
-	    	    /* Prefer help tags according to 'helplang'.  Put the
+		    /* Prefer help tags according to 'helplang'.  Put the
 		     * two-letter language name in help_lang[]. */
 		    i = (int)STRLEN(tag_fname);
 		    if (i > 3 && tag_fname[i - 3] == '-')

--- a/src/tag.c
+++ b/src/tag.c
@@ -1478,13 +1478,13 @@ find_tags(
      */
 #ifdef FEAT_MULTI_LANG
     /* Set a flag if the file extension is .txt */
-    int is_txt = 0;
+    int is_txt = FALSE;
     if ((flags & TAG_KEEP_LANG)
-	  && help_lang_find == NULL
-	  && curbuf->b_fname != NULL
-	  && (i = (int)STRLEN(curbuf->b_fname)) > 4
-	  && STRICMP(curbuf->b_fname + i - 4, ".txt") == 0)
-	is_txt = 1;
+	    && help_lang_find == NULL
+	    && curbuf->b_fname != NULL
+	    && (i = (int)STRLEN(curbuf->b_fname)) > 4
+	    && STRICMP(curbuf->b_fname + i - 4, ".txt") == 0)
+	is_txt = TRUE;
 #endif
 #ifdef FEAT_TAG_BINS
     orgpat.regmatch.rm_ic = ((p_ic || !noic)

--- a/src/tag.c
+++ b/src/tag.c
@@ -1356,6 +1356,7 @@ find_tags(
     char_u	*help_lang_find = NULL;		/* lang to be found */
     char_u	help_lang[3];			/* lang of current tags file */
     char_u	*saved_pat = NULL;		/* copy of pat[] */
+    int 	is_txt = FALSE;			/* flag of file extension */
 #endif
 
     pat_T	orgpat;			/* holds unconverted pattern info */
@@ -1478,7 +1479,6 @@ find_tags(
      */
 #ifdef FEAT_MULTI_LANG
     /* Set a flag if the file extension is .txt */
-    int is_txt = FALSE;
     if ((flags & TAG_KEEP_LANG)
 	    && help_lang_find == NULL
 	    && curbuf->b_fname != NULL

--- a/src/tag.c
+++ b/src/tag.c
@@ -1476,6 +1476,16 @@ find_tags(
      * When the tag file is case-fold sorted, it is either one or the other.
      * Only ignore case when TAG_NOIC not used or 'ignorecase' set.
      */
+#ifdef FEAT_MULTI_LANG
+    /* Set a flag if the file extension is .txt */
+    int is_txt = 0;
+      if ((flags & TAG_KEEP_LANG)
+              && help_lang_find == NULL
+	      && curbuf->b_fname != NULL
+	      && (i = (int)STRLEN(curbuf->b_fname)) > 4
+	      && STRICMP(curbuf->b_fname + i - 4, ".txt") == 0)
+	  is_txt = 1;
+#endif
 #ifdef FEAT_TAG_BINS
     orgpat.regmatch.rm_ic = ((p_ic || !noic)
 				&& (findall || orgpat.headlen == 0 || !p_tbs));
@@ -1509,14 +1519,19 @@ find_tags(
 #ifdef FEAT_MULTI_LANG
 	    if (curbuf->b_help)
 	    {
-		/* Prefer help tags according to 'helplang'.  Put the
-		 * two-letter language name in help_lang[]. */
-		i = (int)STRLEN(tag_fname);
-		if (i > 3 && tag_fname[i - 3] == '-')
-		    STRCPY(help_lang, tag_fname + i - 2);
-		else
+		/* Keep en if the file extension is .txt*/
+		if (is_txt)
 		    STRCPY(help_lang, "en");
-
+		else
+		{
+	    	    /* Prefer help tags according to 'helplang'.  Put the
+		     * two-letter language name in help_lang[]. */
+		    i = (int)STRLEN(tag_fname);
+		    if (i > 3 && tag_fname[i - 3] == '-')
+			STRCPY(help_lang, tag_fname + i - 2);
+		    else
+			STRCPY(help_lang, "en");
+		}
 		/* When searching for a specific language skip tags files
 		 * for other languages. */
 		if (help_lang_find != NULL

--- a/src/testdir/test_help_tagjump.vim
+++ b/src/testdir/test_help_tagjump.vim
@@ -150,4 +150,36 @@ func Test_help_complete()
   endtry
 endfunc
 
+func Test_help_respect_current_file_lang()
+  try
+    let list = []
+    call s:doc_config_setup()
+
+    if has('multi_lang')
+      function s:check_help_file_ext(help_keyword, ext)
+        exec 'help ' . a:help_keyword
+        call assert_equal(a:ext, expand('%:e'))
+        call feedkeys("\<C-]>", 'tx')
+        call assert_equal(a:ext, expand('%:e'))
+        pop
+        helpclose
+      endfunc
+
+      set rtp+=Xdir1/doc-ab
+      set rtp+=Xdir1/doc-ja
+
+      set helplang=ab
+      call s:check_help_file_ext('test-char', 'abx')
+      call s:check_help_file_ext('test-char@ja', 'jax')
+      set helplang=ab,ja
+      call s:check_help_file_ext('test-char@ja', 'jax')
+      call s:check_help_file_ext('test-char@en', 'txt')
+    endif
+  catch
+    call assert_exception('X')
+  finally
+    call s:doc_config_teardown()
+  endtry
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When I set translated help(for example: `set helplang=ja,en` in .vimrc), open translated help and press `CTRL-]`, Vim opens help in translated help, but open English help and press `CTRL-]`, Vim opens translated help.
I'd like vim to open same language help as current opened help. 
So, I fixed tag.c.