### PR TITLE
Fix for #1255: add STATIC_WINPTHREAD to allow static winpthread.

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -81,6 +81,13 @@ ifndef STATIC_STDCPLUS
 STATIC_STDCPLUS=no
 endif
 
+
+# Link against the shared version of libwinpthread by default.  Set
+# STATIC_WINPTHREAD to "yes" to link against static version instead.
+ifndef STATIC_WINPTHREAD
+STATIC_WINPTHREAD=no
+endif
+
 # If the user doesn't want gettext, undefine it.
 ifeq (no, $(GETTEXT))
 GETTEXT=
@@ -815,6 +822,10 @@ LIB += -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic
 else
 LIB += -lstdc++
 endif
+endif
+
+ifeq (yes, $(STATIC_WINPTHREAD))
+LIB += -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic
 endif
 
 all: $(TARGET) vimrun.exe xxd/xxd.exe install.exe uninstal.exe GvimExt/gvimext.dll

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -85,7 +85,7 @@ endif
 # Link against the shared version of libwinpthread by default.  Set
 # STATIC_WINPTHREAD to "yes" to link against static version instead.
 ifndef STATIC_WINPTHREAD
-STATIC_WINPTHREAD=no
+STATIC_WINPTHREAD=$(STATIC_STDCPLUS)
 endif
 
 # If the user doesn't want gettext, undefine it.


### PR DESCRIPTION
This is a potential fix for #1255. It adds a STATIC_WINPTHREAD build variable which when set to 'yes' will allow linking the winpthread library statically.

To maintain existing build by default, I'm initializing the value to 'no' if not set. I'm not certain though whether this is a widespread problem. If it is, perhaps the default should be 'yes'.

I'd welcome any ideas or suggestions on how to test more widely outside of my system.