### PR TITLE
Introduce pythonhome and pythonthreehome options

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5775,6 +5775,20 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
+						*'pythonhome'*
+'pythonhome'		string	(default "")
+			global
+			{not in Vi}
+			{only available when compiled with the |+python/dyn|
+			feature}
+	Specifies the name of the Python 2.x home directory. When 'pythonhome'
+	and the PYTHONHOME environment variable are not set, PYTHON_HOME,
+	which was specified at compile time, will be used for the Python 2.x
+	home directory.
+	Environment variables are expanded |:set_env|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+
 						*'pythonthreedll'*
 'pythonthreedll'	string	(default depends on the build)
 			global
@@ -5783,6 +5797,20 @@ A jump table for the options with a short description can be found at |Q_op|.
 			feature}
 	Specifies the name of the Python 3 shared library. The default is
 	DYNAMIC_PYTHON3_DLL, which was specified at compile time.
+	Environment variables are expanded |:set_env|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+
+						*'pythonthreehome'*
+'pythonthreehome'	string	(default "")
+			global
+			{not in Vi}
+			{only available when compiled with the |+python3/dyn|
+			feature}
+	Specifies the name of the Python 3 home directory. When
+	'pythonthreehome' and the PYTHONHOME environment variable are not set,
+	PYTHON3_HOME, which was specified at compile time, will be used for
+	the Python 3 home directory.
 	Environment variables are expanded |:set_env|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -834,7 +834,9 @@ Short explanation of each option:		*option-list*
 'prompt'	  'prompt'  enable prompt in Ex mode
 'pumheight'	  'ph'	    maximum height of the popup menu
 'pythondll'		    name of the Python 2 dynamic library
+'pythonhome'		    name of the Python 2 home directory
 'pythonthreedll'	    name of the Python 3 dynamic library
+'pythonthreehome'	    name of the Python 3 home directory
 'quoteescape'	  'qe'	    escape characters used in a string
 'readonly'	  'ro'	    disallow writing the buffer
 'redrawtime'	  'rdt'     timeout for 'hlsearch' and |:match| highlighting

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1328,9 +1328,17 @@ if exists("&pythondll")
   call append("$", "pythondll\tname of the Python 2 dynamic library")
   call <SID>OptionG("pythondll", &pythondll)
 endif
+if exists("&pythonhome")
+  call append("$", "pythonhome\tname of the Python 2 home directory")
+  call <SID>OptionG("pythonhome", &pythonhome)
+endif
 if exists("&pythonthreedll")
   call append("$", "pythonthreedll\tname of the Python 3 dynamic library")
   call <SID>OptionG("pythonthreedll", &pythonthreedll)
+endif
+if exists("&pythonthreehome")
+  call append("$", "pythonthreehome\tname of the Python 3 home directory")
+  call <SID>OptionG("pythonthreehome", &pythonthreehome)
 endif
 if exists("&rubydll")
   call append("$", "rubydll\tname of the Ruby dynamic library")

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -929,13 +929,17 @@ Python_Init(void)
 	    EMSG(_("E263: Sorry, this command is disabled, the Python library could not be loaded."));
 	    goto fail;
 	}
-#endif
 
-#ifdef PYTHON_HOME
-# ifdef DYNAMIC_PYTHON
-	if (mch_getenv((char_u *)"PYTHONHOME") == NULL)
-# endif
+	if (p_pyhome && *p_pyhome != '\0')
+	    Py_SetPythonHome((char *)p_pyhome);
+# ifdef PYTHON_HOME
+	else if (mch_getenv((char_u *)"PYTHONHOME") == NULL)
 	    Py_SetPythonHome(PYTHON_HOME);
+# endif
+#else
+# ifdef PYTHON_HOME
+	Py_SetPythonHome(PYTHON_HOME);
+# endif
 #endif
 
 	init_structs();

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -860,12 +860,26 @@ Python3_Init(void)
 
 	init_structs();
 
-
-#ifdef PYTHON3_HOME
-# ifdef DYNAMIC_PYTHON3
-	if (mch_getenv((char_u *)"PYTHONHOME") == NULL)
-# endif
+#ifdef DYNAMIC_PYTHON3
+	if (*p_py3home != '\0')
+	{
+	    int len;
+	    wchar_t *buf;
+	    len = mbstowcs(NULL, (char *)p_py3home, 0) + 1;
+	    buf = (wchar_t *)alloc(len * sizeof(wchar_t));
+	    if (buf && mbstowcs(buf, (char *)p_py3home, len) != (size_t)-1) {
+		Py_SetPythonHome(buf);
+		/* We must keep buf for Py_SetPythonHome */
+	    }
+	}
+# ifdef PYTHON3_HOME
+	else if (mch_getenv((char_u *)"PYTHONHOME") == NULL)
 	    Py_SetPythonHome(PYTHON3_HOME);
+# endif
+#else
+# ifdef PYTHON3_HOME
+	Py_SetPythonHome(PYTHON3_HOME);
+# endif
 #endif
 
 	PyImport_AppendInittab("vim", Py3Init_vim);

--- a/src/option.c
+++ b/src/option.c
@@ -2135,11 +2135,19 @@ static struct vimoption options[] =
 			    (char_u *)&p_py3dll, PV_NONE,
 			    {(char_u *)DYNAMIC_PYTHON3_DLL, (char_u *)0L}
 			    SCRIPTID_INIT},
+    {"pythonthreehome", NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+			    (char_u *)&p_py3home, PV_NONE,
+			    {(char_u *)"", (char_u *)0L}
+			    SCRIPTID_INIT},
 #endif
 #if defined(DYNAMIC_PYTHON)
     {"pythondll",   NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_pydll, PV_NONE,
 			    {(char_u *)DYNAMIC_PYTHON_DLL, (char_u *)0L}
+			    SCRIPTID_INIT},
+    {"pythonhome",  NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+			    (char_u *)&p_pyhome, PV_NONE,
+			    {(char_u *)"", (char_u *)0L}
 			    SCRIPTID_INIT},
 #endif
     {"quoteescape", "qe",   P_STRING|P_ALLOCED|P_VI_DEF,

--- a/src/option.h
+++ b/src/option.h
@@ -690,9 +690,11 @@ EXTERN char_u	*p_perldll;	/* 'perldll' */
 #endif
 #if defined(DYNAMIC_PYTHON3)
 EXTERN char_u	*p_py3dll;	/* 'pythonthreedll' */
+EXTERN char_u	*p_py3home;	/* 'pythonthreehome' */
 #endif
 #if defined(DYNAMIC_PYTHON)
 EXTERN char_u	*p_pydll;	/* 'pythondll' */
+EXTERN char_u	*p_pyhome;	/* 'pythonhome' */
 #endif
 #ifdef FEAT_RELTIME
 EXTERN long	p_rdt;		/* 'redrawtime' */


### PR DESCRIPTION
It is really difficult to set Python home directory properly for Python
2.7 and 3.5 in .vimrc at the same time since both versions use `$PYTHONHOME`
environment variable. Introduce `pythonhome` and `pythonthreehome`
options in order to set Python home directory via `Py_SetPythonHome` API
for both versions.