### PR TITLE
Add direct MODIFIED_BY for MSVC build and support for chevrons in Windows cmd when building

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -106,6 +106,8 @@
 #	Default is "xpm", using the files included in the distribution.
 #	Use "no" to disable this feature.
 #
+#   Name of who modified a release version: MODIFIED_BY=[name of modifier]
+#
 #	Optimization: OPTIMIZE=[SPACE, SPEED, MAXSPEED] (default is MAXSPEED)
 #
 #	Processor Version: CPUNR=[i386, i486, i586, i686, pentium4] (default is
@@ -996,6 +998,13 @@ CFLAGS = $(CFLAGS) -DMSWINPS
 !endif # POSTSCRIPT
 
 #
+# MODIFIED_BY - Name of who modified a release version
+#
+!if "$(MODIFIED_BY)" != ""
+CFLAGS = $(CFLAGS) -DMODIFIED_BY=\"$(MODIFIED_BY)\"
+!endif
+
+#
 # FEATURES: TINY, SMALL, NORMAL, BIG or HUGE
 #
 CFLAGS = $(CFLAGS) -DFEAT_$(FEATURES)
@@ -1350,13 +1359,17 @@ $(OUTDIR)/dimm_i.obj: $(OUTDIR) dimm_i.c $(INCL)
 
 $(OUTDIR)/glbl_ime.obj:	$(OUTDIR) glbl_ime.cpp  dimm.h $(INCL)
 
-# $CFLAGS may contain backslashes and double quotes, escape them both.
+# $CFLAGS may contain backslashes, double quotes and chevrons, escape them all.
 E0_CFLAGS = $(CFLAGS:\=\\)
-E_CFLAGS = $(E0_CFLAGS:"=\")
+E00_CFLAGS = $(E0_CFLAGS:"=\")
+E000_CFLAGS = $(E00_CFLAGS:<=^^<)
+E_CFLAGS = $(E000_CFLAGS:>=^^>)
 # ") stop the string
-# $LINKARGS2 may contain backslashes and double quotes, escape them both.
+# $LINKARGS2 may contain backslashes, double quotes and chevrons, escape them all.
 E0_LINKARGS2 = $(LINKARGS2:\=\\)
-E_LINKARGS2 = $(E0_LINKARGS2:"=\")
+E00_LINKARGS2 = $(E0_LINKARGS2:"=\")
+E000_LINKARGS2 = $(E00_LINKARGS2:<=^^<)
+E_LINKARGS2 = $(E000_LINKARGS2:>=^^>)
 # ") stop the string
 
 $(PATHDEF_SRC): auto


### PR DESCRIPTION
When building under Microsoft Windows using Visual Studio with `nmake -f Make_mvc.mak`, It's not easy to pass `MODIFIED_BY` to the compiler using `DEFINES="-DMODIFIED_BY=...."` args. so I created this pull request with the following changes:
1. Add direct `MODIFIED_BY` argument in `Make_mvc.mak` to parse and generate `MODIFIED_BY` Macro when building.
2. Another problem is when we try to pass an argument containing `<` or ` >` in `CFLAGS` or other arguments,  it's not possible to pass chevrons  when generating the `pathdef.c` in `Make_mvc.mak`

```
$(PATHDEF_SRC): auto
	@echo creating $(PATHDEF_SRC)
	@echo /* pathdef.c */ > $(PATHDEF_SRC)
	@echo #include "vim.h" >> $(PATHDEF_SRC)
	@echo char_u *default_vim_dir = (char_u *)"$(VIMRCLOC:\=\\)"; >> $(PATHDEF_SRC)
	@echo char_u *default_vimruntime_dir = (char_u *)"$(VIMRUNTIMEDIR:\=\\)"; >> $(PATHDEF_SRC)
	@echo char_u *all_cflags = (char_u *)"$(CC:\=\\) $(E_CFLAGS)"; >> $(PATHDEF_SRC)
	@echo char_u *all_lflags = (char_u *)"$(link:\=\\) $(LINKARGS1:\=\\) $(E_LINKARGS2)"; >> $(PATHDEF_SRC)
	@echo char_u *compiled_user = (char_u *)"$(USERNAME)"; >> $(PATHDEF_SRC)
	@echo char_u *compiled_sys = (char_u *)"$(USERDOMAIN)"; >> $(PATHDEF_SRC)
``` 
Now we can just use `nmake -f Make_mvc.mak MODIFIED_BY=Spock^<spock@uss-ncc-1701^>` to compile.
Hope these changes will be useful for windows VIM users and modifier.

Thanks.