### PR TITLE
strictly checks for 'thesaurus'

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -2660,7 +2660,7 @@ static struct vimoption options[] =
     {"textwidth",   "tw",   P_NUM|P_VI_DEF|P_VIM|P_RBUF,
 			    (char_u *)&p_tw, PV_TW,
 			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-    {"thesaurus",   "tsr",  P_STRING|P_EXPAND|P_VI_DEF|P_ONECOMMA|P_NODUP,
+    {"thesaurus",   "tsr",  P_STRING|P_EXPAND|P_VI_DEF|P_ONECOMMA|P_NODUP|P_NDNAME,
 #ifdef FEAT_INS_EXPAND
 			    (char_u *)&p_tsr, PV_TSR,
 #else

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -121,3 +121,18 @@ func Test_dictionary()
   call assert_fails("set dictionary=/not>there", "E474:")
   call assert_fails("set dictionary=/not.*there", "E474:")
 endfunc
+
+func Test_thesaurus()
+  " Check that it's possible to set the option.
+  set thesaurus=/usr/share/mythes/th
+  call assert_equal('/usr/share/mythes/th', &thesaurus)
+  set thesaurus=/usr/share/mythes/th,/and/there
+  call assert_equal('/usr/share/mythes/th,/and/there', &thesaurus)
+  set thesaurus=/usr/share/mythes\ th
+  call assert_equal('/usr/share/mythes th', &thesaurus)
+
+  " Check rejecting weird characters.
+  call assert_fails("set thesaurus=/not&there", "E474:")
+  call assert_fails("set thesaurus=/not>there", "E474:")
+  call assert_fails("set thesaurus=/not.*there", "E474:")
+endfunc


### PR DESCRIPTION
Applied `P_NDNAME`(added at [v8.0.0102](https://github.com/vim/vim/commit/7554da4033498c4da0af3cde542c3e87e9097b73)) to 'thesaurus' to check the file name.