### PR TITLE
Convert vim_memcmp calls to directly using memcmp

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -154,7 +154,6 @@
 #undef BAD_GETCWD
 
 /* Define if you the function: */
-#undef HAVE_BCMP
 #undef HAVE_FCHDIR
 #undef HAVE_FCHOWN
 #undef HAVE_FSEEKO
@@ -170,7 +169,6 @@
 #undef HAVE_ICONV
 #undef HAVE_NL_LANGINFO_CODESET
 #undef HAVE_LSTAT
-#undef HAVE_MEMCMP
 #undef HAVE_MEMSET
 #undef HAVE_MKDTEMP
 #undef HAVE_NANOSLEEP

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3594,8 +3594,8 @@ fi
 
 dnl Check for functions in one big call, to reduce the size of configure.
 dnl Can only be used for functions that do not require any include.
-AC_CHECK_FUNCS(bcmp fchdir fchown fsync getcwd getpseudotty \
-	getpwent getpwnam getpwuid getrlimit gettimeofday getwd lstat memcmp \
+AC_CHECK_FUNCS(fchdir fchown fsync getcwd getpseudotty \
+	getpwent getpwnam getpwuid getrlimit gettimeofday getwd lstat \
 	memset mkdtemp nanosleep opendir putenv qsort readlink select setenv \
 	setpgid setsid sigaltstack sigstack sigset sigsetjmp sigaction \
 	sigprocmask sigvec strcasecmp strerror strftime stricmp strncasecmp \

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1740,27 +1740,6 @@ vim_memset(void *ptr, int c, size_t size)
 }
 #endif
 
-#ifdef VIM_MEMCMP
-/*
- * Return zero when "b1" and "b2" are the same for "len" bytes.
- * Return non-zero otherwise.
- */
-    int
-vim_memcmp(void *b1, void *b2, size_t len)
-{
-    char_u  *p1 = (char_u *)b1, *p2 = (char_u *)b2;
-
-    for ( ; len > 0; --len)
-    {
-	if (*p1 != *p2)
-	    return 1;
-	++p1;
-	++p2;
-    }
-    return 0;
-}
-#endif
-
 /* skipped when generating prototypes, the prototype is in vim.h */
 #ifdef VIM_MEMMOVE
 /*

--- a/src/os_vms_conf.h
+++ b/src/os_vms_conf.h
@@ -101,7 +101,6 @@
 #define HAVE_STRTOL
 #define HAVE_TGETENT
 #define HAVE_MEMSET
-#define HAVE_MEMCMP
 #define HAVE_STRERROR
 #define HAVE_FCHOWN
 #define HAVE_RENAME

--- a/src/osdef1.h.in
+++ b/src/osdef1.h.in
@@ -50,12 +50,7 @@ extern int	poll(struct pollfd *, long, int);
 #ifdef HAVE_MEMSET
 extern void	*memset(void *, int, size_t);
 #endif
-#ifdef HAVE_BCMP
-extern int	bcmp(void *, void *, size_t);
-#endif
-#ifdef HAVE_MEMCMP
 extern int	memcmp(const void *, const void *, size_t);
-#endif
 #ifdef HAVE_STRPBRK
 extern char	*strpbrk(const char *, const char *);
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -1695,7 +1695,7 @@ searchc(cmdarg_T *cap, int t_cmd)
 		}
 		else
 		{
-		    if (vim_memcmp(p + col, lastc_bytes, lastc_bytelen) == 0 && stop)
+		    if (memcmp(p + col, lastc_bytes, lastc_bytelen) == 0 && stop)
 			break;
 		}
 		stop = TRUE;

--- a/src/tag.c
+++ b/src/tag.c
@@ -2400,7 +2400,7 @@ parse_line:
 			      mfp2 = ((struct match_found **)
 						  (ga_match[mtt].ga_data))[i];
 			      if (mfp2->len == mfp->len
-				      && vim_memcmp(mfp2->match, mfp->match,
+				      && memcmp(mfp2->match, mfp->match,
 						       (size_t)mfp->len) == 0)
 				  break;
 			      fast_breakcheck();

--- a/src/vim.h
+++ b/src/vim.h
@@ -1733,17 +1733,6 @@ void mch_memmove(void *, void *, size_t);
 void *vim_memset(void *, int, size_t);
 #endif
 
-#ifdef HAVE_MEMCMP
-# define vim_memcmp(p1, p2, len)   memcmp((p1), (p2), (len))
-#else
-# ifdef HAVE_BCMP
-#  define vim_memcmp(p1, p2, len)   bcmp((p1), (p2), (len))
-# else
-int vim_memcmp(void *, void *, size_t);
-#  define VIM_MEMCMP
-# endif
-#endif
-
 #if defined(UNIX) || defined(FEAT_GUI) || defined(VMS) \
 	|| defined(FEAT_CLIENTSERVER)
 # define USE_INPUT_BUF


### PR DESCRIPTION
vim_memcmp exists to abstract how the memory comparison is performed on
various systems and to fallback to Vim's own memcmp implementation, if
needed.  However, there have been various direct memcmp calls in Vim
since at least 2010 without issue.

Converting the remaining vim_memcmp calls to memcmp allows us to remove
the reimplementation of memcmp and reduces the need to know another
Vim-specific function that should be used.