### PR TITLE
Fix: cannot complete filter command with some patterns

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3865,7 +3865,6 @@ set_one_cmd_context(
 	case CMD_cfdo:
 	case CMD_confirm:
 	case CMD_debug:
-	case CMD_filter:
 	case CMD_folddoclosed:
 	case CMD_folddoopen:
 	case CMD_hide:
@@ -3889,6 +3888,16 @@ set_one_cmd_context(
 	case CMD_vertical:
 	case CMD_windo:
 	    return arg;
+
+	case CMD_filter:
+	    if (*arg != NUL)
+		arg = skip_vimgrep_pat(arg, NULL, NULL);
+	    if (arg == NULL || *arg == NUL)
+	    {
+		xp->xp_context = EXPAND_NOTHING;
+		return NULL;
+	    }
+	    return skipwhite(arg);
 
 #ifdef FEAT_CMDL_COMPL
 # ifdef FEAT_SEARCH_EXTRA

--- a/src/testdir/test_filter_cmd.vim
+++ b/src/testdir/test_filter_cmd.vim
@@ -52,3 +52,25 @@ func Test_filter_fails()
   call assert_fails('filter! /pat/', 'E476:')
   call assert_fails('filter! /pat/ asdf', 'E492:')
 endfunc
+
+function s:complete_filter_cmd(filtcmd)
+  let keystroke = "\<TAB>\<C-R>=execute('let cmdline = getcmdline()')\<CR>\<C-C>"
+  let cmdline = ''
+  call feedkeys(':' . a:filtcmd . keystroke, 'ntx')
+  return cmdline
+endfunction
+
+func Test_filter_cmd_completion()
+  " Do not complete pattern
+  call assert_equal("filter \t", s:complete_filter_cmd('filter '))
+  call assert_equal("filter pat\t", s:complete_filter_cmd('filter pat'))
+  call assert_equal("filter /pat\t", s:complete_filter_cmd('filter /pat'))
+  call assert_equal("filter /pat/\t", s:complete_filter_cmd('filter /pat/'))
+
+  " Complete after string pattern
+  call assert_equal('filter pat print', s:complete_filter_cmd('filter pat pri'))
+
+  " Complete after regexp pattern
+  call assert_equal('filter /pat/ print', s:complete_filter_cmd('filter /pat/ pri'))
+  call assert_equal('filter #pat# print', s:complete_filter_cmd('filter #pat# pri'))
+endfunc


### PR DESCRIPTION
This patch fixes completion behavior of `:filter` command.

### repro steps

`vim -Nu NONE`

**OK**

regexp with slash

* `:filter /pat/ pri` and input `<TAB>`, completion is done: `:filter /pat/ print`

**FAIL**

string

* `:filter pat pri` and input `<TAB>`, but no completion: `:filter pat pri`

regexp with other than slash

* `:filter #pat# pri` and input `<TAB>`, but no completion: `:filter #pat# pri`

completion by `<C-D>` is too.