### PR TITLE
Fix bug when :earlier cannot undo before Vim startup time.

### DIFF
--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -238,7 +238,8 @@ endfunc
 
 func Test_undofile_earlier()
   " Issue #1254
-  let t0 = localtime() - 10
+  " create undofile with timestamps older than Vim startup time.
+  let t0 = localtime() - 43200
   call test_settime(t0)
   new Xfile
   call feedkeys("ione\<Esc>", 'xt')
@@ -252,19 +253,13 @@ func Test_undofile_earlier()
   w
   wundo Xundofile
   bwipe!
+  " restore normal timestamps.
   call test_settime(0)
-  new Xearlier.vim
-  put ='edit Xfile'
-  put ='rundo Xundofile'
-  put ='earlier 1m'
-  put ='x'
-  w
-  bwipe!
-  silent execute '!' fnameescape(v:progpath) '-e -s -i NONE -S Xearlier.vim'
   new Xfile
+  rundo Xundofile
+  earlier 1d
   call assert_equal('', getline(1))
   bwipe!
   call delete('Xfile')
   call delete('Xundofile')
-  call delete('Xearlier.vim')
 endfunc

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -235,3 +235,36 @@ func Test_insert_expr()
 
   close!
 endfunc
+
+func Test_undofile_earlier()
+  " Issue #1254
+  let t0 = localtime() - 10
+  call test_settime(t0)
+  new Xfile
+  call feedkeys("ione\<Esc>", 'xt')
+  set ul=100
+  call test_settime(t0 + 1)
+  call feedkeys("otwo\<Esc>", 'xt')
+  set ul=100
+  call test_settime(t0 + 2)
+  call feedkeys("othree\<Esc>", 'xt')
+  set ul=100
+  w
+  wundo Xundofile
+  bwipe!
+  call test_settime(0)
+  new Xearlier.vim
+  put ='edit Xfile'
+  put ='rundo Xundofile'
+  put ='earlier 1m'
+  put ='x'
+  w
+  bwipe!
+  silent execute '!' fnameescape(v:progpath) '-e -s -i NONE -S Xearlier.vim'
+  new Xfile
+  call assert_equal('', getline(1))
+  bwipe!
+  call delete('Xfile')
+  call delete('Xundofile')
+  call delete('Xearlier.vim')
+endfunc

--- a/src/undo.c
+++ b/src/undo.c
@@ -2298,10 +2298,8 @@ undo_time(
     }
     else
     {
-	/* When doing computations with time_t subtract starttime, because
-	 * time_t converted to a long may result in a wrong number. */
 	if (dosec)
-	    target = (long)(curbuf->b_u_time_cur - starttime) + step;
+	    target = (long)(curbuf->b_u_time_cur) + step;
 	else if (dofile)
 	{
 	    if (step < 0)
@@ -2350,7 +2348,7 @@ undo_time(
 	else
 	{
 	    if (dosec)
-		closest = (long)(vim_time() - starttime + 1);
+		closest = (long)(vim_time() + 1);
 	    else if (dofile)
 		closest = curbuf->b_u_save_nr_last + 2;
 	    else
@@ -2388,7 +2386,7 @@ undo_time(
 	{
 	    uhp->uh_walk = mark;
 	    if (dosec)
-		val = (long)(uhp->uh_time - starttime);
+		val = (long)(uhp->uh_time);
 	    else if (dofile)
 		val = uhp->uh_save_nr;
 	    else


### PR DESCRIPTION
This resolves #1254.