### PR TITLE
htmlcomplete.vim: Fix crash in CompleteTags() (Fix issue #1302)

### DIFF
--- a/runtime/autoload/htmlcomplete.vim
+++ b/runtime/autoload/htmlcomplete.vim
@@ -245,7 +245,7 @@ function! htmlcomplete#CompleteTags(findstart, base)
 	" If context contains white space it is attribute.
 	" It can be also value of attribute.
 	" We have to get first word to offer proper completions
-	if context == ''
+	if context =~ '\v^\s*$'
 		let tag = ''
 	else
 		let tag = split(context)[0]


### PR DESCRIPTION
A crash would sometimes happen in htmlcomplete.vim:251 when the 'context' variable only contained whitespace (split() would try to split context on whitespace and return an empty array, the first cell of which we tried to access). This commit prevents this crash from happening.