### PR TITLE
Use unsigned short instead of ushort in configure

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1995,7 +1995,7 @@ if test "$enable_channel" = "yes"; then
 	/* Check bitfields */
 	struct nbbuf {
 	unsigned int  initDone:1;
-	ushort signmaplen;
+	unsigned short signmaplen;
 	};
 	    ], [
 		/* Check creating a socket. */


### PR DESCRIPTION
Using unsigned short instead of ushort is consistent with the vim codebase as well as more portable (specifically, it fixes a compile error on Android).