### PR TITLE
git diff index line not highlighted

### DIFF
--- a/runtime/syntax/diff.vim
+++ b/runtime/syntax/diff.vim
@@ -347,7 +347,7 @@ syn match diffLine	"^\d\+\(,\d\+\)\=[cda]\d\+\>.*"
 
 syn match diffFile	"^diff\>.*"
 syn match diffFile	"^+++ .*"
-syn match diffFile	"^Index: .*"
+syn match diffFile	"\c^index.*"
 syn match diffFile	"^==== .*"
 syn match diffOldFile	"^\*\*\* .*"
 syn match diffNewFile	"^--- .*"


### PR DESCRIPTION
Seems like it have different syntax nowadays:
`index fe634be..610198d 100644`