### PR TITLE
Add v:argv variable

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1429,6 +1429,10 @@ variables for each buffer.  Use local buffer variables instead |b:var|.
 
 Predefined Vim variables:			*vim-variable* *v:var* *v:*
 
+				*v:argv* *argv-variable*
+v:argv		Command line arguments Vim was invoked with.  This is a list
+		of strings.
+
 					*v:beval_col* *beval_col-variable*
 v:beval_col	The number of the column, over which the mouse pointer is.
 		This is the byte index in the |v:beval_lnum| line.

--- a/src/eval.c
+++ b/src/eval.c
@@ -187,6 +187,7 @@ static struct vimvar
     {VV_NAME("t_none",		 VAR_NUMBER), VV_RO},
     {VV_NAME("t_job",		 VAR_NUMBER), VV_RO},
     {VV_NAME("t_channel",	 VAR_NUMBER), VV_RO},
+    {VV_NAME("argv",		 VAR_LIST), VV_RO},
 };
 
 /* shorthand */
@@ -6644,6 +6645,23 @@ set_vim_var_dict(int idx, dict_T *val)
 	    HI2DI(hi)->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
 	}
     }
+}
+
+/*
+ * Set v:argv list.
+ */
+    void
+set_argv_var(char_u **argv)
+{
+    list_T	*l;
+
+    l = list_alloc();
+    l->lv_lock = VAR_FIXED;
+    while (*++argv) {
+	list_append_string(l, *argv, -1);
+	l->lv_last->li_tv.v_lock = VAR_FIXED;
+    }
+    set_vim_var_list(VV_ARGV, l);
 }
 
 /*

--- a/src/main.c
+++ b/src/main.c
@@ -1001,6 +1001,7 @@ common_init(mparm_T *paramp)
 
 #ifdef FEAT_EVAL
     set_lang_var();		/* set v:lang and v:ctype */
+    set_argv_var((char_u **)paramp->argv);  /* set v:argv */
 #endif
 }
 

--- a/src/proto/eval.pro
+++ b/src/proto/eval.pro
@@ -69,6 +69,7 @@ void set_vcount(long count, long count1, int set_prevcount);
 void set_vim_var_string(int idx, char_u *val, int len);
 void set_vim_var_list(int idx, list_T *val);
 void set_vim_var_dict(int idx, dict_T *val);
+void set_argv_var(char_u **argv);
 void set_reg_var(int c);
 char_u *v_exception(char_u *oldval);
 char_u *v_throwpoint(char_u *oldval);

--- a/src/vim.h
+++ b/src/vim.h
@@ -2002,7 +2002,8 @@ typedef int sock_T;
 #define VV_TYPE_NONE	78
 #define VV_TYPE_JOB	79
 #define VV_TYPE_CHANNEL	80
-#define VV_LEN		81	/* number of v: vars */
+#define VV_ARGV		81
+#define VV_LEN		82	/* number of v: vars */
 
 /* used for v_number in VAR_SPECIAL */
 #define VVAL_FALSE	0L


### PR DESCRIPTION
It may be useful to have access to the command line arguments as a List stored in `v:argv` variable. For example one may use it to check if Vim was invoked without any arguments and open file browser automatically
```vim
" ~/.vim/after/plugin/netrw.vim

if !exists(':Explore') || !empty(v:argv)
  finish
endif

augroup after_netrw
  autocmd!
  autocmd VimEnter * Explore | autocmd! after_netrw
augroup END
```