### PR TITLE
Adjust marks when adding a new line to the end of buffer if in diff mode

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1428,7 +1428,11 @@ open_line(
 	 * with markers.
 	 * Skip mark_adjust when adding a line after the last one, there can't
 	 * be marks there. */
-	if (curwin->w_cursor.lnum + 1 < curbuf->b_ml.ml_line_count)
+	if (curwin->w_cursor.lnum + 1 < curbuf->b_ml.ml_line_count
+#ifdef FEAT_DIFF
+	    || curwin->w_p_diff
+#endif
+	    )
 	    mark_adjust(curwin->w_cursor.lnum + 1, (linenr_T)MAXLNUM, 1L, 0L);
 	did_append = TRUE;
     }
@@ -2866,7 +2870,11 @@ appended_lines_mark(linenr_T lnum, long count)
 {
     /* Skip mark_adjust when adding a line after the last one, there can't
      * be marks there. */
-    if (lnum + count < curbuf->b_ml.ml_line_count)
+    if (lnum + count < curbuf->b_ml.ml_line_count
+#ifdef FEAT_DIFF
+	|| curwin->w_p_diff
+#endif
+	)
 	mark_adjust(lnum + 1, (linenr_T)MAXLNUM, count, 0L);
     changed_lines(lnum + 1, 0, lnum + 1, count);
 }

--- a/src/ops.c
+++ b/src/ops.c
@@ -3901,7 +3901,11 @@ error:
 	    /* Skip mark_adjust when adding lines after the last one, there
 	     * can't be marks there. */
 	    if (curbuf->b_op_start.lnum + (y_type == MCHAR) - 1 + nr_lines
-						 < curbuf->b_ml.ml_line_count)
+						 < curbuf->b_ml.ml_line_count
+#ifdef FEAT_DIFF
+						 || curwin->w_p_diff
+#endif
+						 )
 		mark_adjust(curbuf->b_op_start.lnum + (y_type == MCHAR),
 					     (linenr_T)MAXLNUM, nr_lines, 0L);
 

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -235,3 +235,23 @@ func Test_setting_cursor()
   call delete('Xtest1')
   call delete('Xtest2')
 endfunc
+
+func Test_diff_lastline()
+  enew!
+  only!
+  call setline(1, ['This is a ', 'line with five ', 'rows'])
+  diffthis
+  botright vert new
+  call setline(1, ['This is', 'a line with ', 'four rows'])
+  diffthis
+  1
+  call feedkeys("Je a\<CR>", 'tx')
+  call feedkeys("Je a\<CR>", 'tx')
+  let w1lines = winline()
+  wincmd w
+  $
+  let w2lines = winline()
+  call assert_equal(w2lines, w1lines)
+  bwipe!
+  bwipe!
+endfunc


### PR DESCRIPTION
In 7.4.1896, guards were added around specific mark_adjust() calls to
avoid updating marks if a new line was being added to the end of the
buffer.  However, this breaks updating the state of windows in
'diffmode' when a buffer is changed in that manner, leading to incorrect
diff views.