### PR TITLE
Fix "normal" highlighting with termguicolors

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -8765,6 +8765,10 @@ hl_combine_attr(int char_attr, int prim_attr)
 	else
 	{
 	    vim_memset(&new_en, 0, sizeof(new_en));
+#ifdef FEAT_TERMGUICOLORS
+	    new_en.ae_u.cterm.bg_rgb = INVALCOLOR;
+	    new_en.ae_u.cterm.fg_rgb = INVALCOLOR;
+#endif
 	    if (char_attr <= HL_ALL)
 		new_en.ae_attr = char_attr;
 	}


### PR DESCRIPTION
The 'uninitialised' value for RGB values is `INVALCOLOR`, but new entries in the
`cterm_attr_table` were initialised to 0, meaning black.

Fixes #1343

## Testing

I have tested this fixes the reported issue, and I have run `make test` successfully. However I haven't done extensive regression testing and I have equally not written any new tests. The former I will do in parallel, the latter because I wasn't able to find an obvious way to test this as it pertains to what is put on the screen. If there are any suggestions, I'm happy to write tests.

A final test (less canonical) was to install the `vim-solarized8` plugin and `:set termguicolors`, `:set cursorline`, `:colorscheme solarized8_dark`, then `:so $VIMRUNTIME/syntax/hitest.vim`. Before, a number of entries would randomly render in black, now they render correctly. It was using this colorscheme that I noticed the original issue.

Otherwise, the repro steps on the attached issue can be used to verify.