### PR TITLE
HTML syntax file: Add repository in the header and support all HTML 5.1 global attributes

### DIFF
--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -2,7 +2,8 @@
 " Language:             HTML
 " Maintainer:           Jorge Maldonado Ventura <jorgesumle@freakspot.net>
 " Previous Maintainer:  Claudio Fleiner <claudio@fleiner.com>
-" Last Change:          2016 Dec 29
+" Repository:           https://notabug.org/jorgesumle/vim-html-syntax
+" Last Change:          2017 Jan 3
 "                       included patch from Jorge Maldonado Ventura
 
 " Please check :help html.vim for some comments and a description of the options
@@ -94,6 +95,10 @@ syn keyword htmlArg contained headers hreflang lang language longdesc
 syn keyword htmlArg contained multiple nohref nowrap object profile readonly
 syn keyword htmlArg contained rules scheme scope span standby style
 syn keyword htmlArg contained summary tabindex valuetype version
+
+" html 5 args names
+syn keyword htmlArg contained contenteditable contextmenu draggable dropzone
+syn keyword htmlArg contained hidden spellcheck title translate
 
 " special characters
 syn match htmlSpecialChar "&#\=[0-9A-Za-z]\{1,8};"


### PR DESCRIPTION
* Add repository URL (https://notabug.org/jorgesumle/vim-html-syntax), as suggested by @chrisbra in https://github.com/vim/vim/pull/1263
* Add **global** (only global, see explanation below) HTML 5.1 attributes (https://www.w3.org/TR/html51/dom.html#sec-global-attributes)


Global HTML attributes are attributes that can be used with any HTML element. We still have to add some new HTML 5 specific attributes, such as `<a>`'s <code>download</code> attribute. But I think that introducing HTML 5.1 support little by little is less error prone and easier to review. In the future, I'll try to make another pull request adding the remaining specific HTML attributes.