### PR TITLE
Failed to build from source - save_ccline

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -212,7 +212,7 @@ getcmdline(
 #endif
     expand_T	xpc;
     long	*b_im_ptr = NULL;
-#if defined(FEAT_WILDMENU) || defined(FEAT_EVAL) || defined(FEAT_SEARCH_EXTRA)
+#if defined(FEAT_WILDMENU) || defined(FEAT_EVAL) || defined(FEAT_SEARCH_EXTRA) || defined(FEAT_CMDWIN)
     /* Everything that may work recursively should save and restore the
      * current command line in save_ccline.  That includes update_screen(), a
      * custom status line may invoke ":normal". */


### PR DESCRIPTION
Hi, 

when I tried to build vim,m it ended with compile error that save_ccline variable is not defined. That error happened in part of code, which is in #ifdef FEAT_CMDWIN, so I solved it by adding this name to line 215.