### PR TITLE
js_decode should handle single quote

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -378,7 +378,7 @@ json_skip_white(js_read_T *reader)
 }
 
     static int
-json_decode_string(js_read_T *reader, typval_T *res)
+json_decode_string(js_read_T *reader, typval_T *res, char_u quote)
 {
     garray_T    ga;
     int		len;
@@ -390,7 +390,7 @@ json_decode_string(js_read_T *reader, typval_T *res)
 	ga_init2(&ga, 1, 200);
 
     p = reader->js_buf + reader->js_used + 1; /* skip over " */
-    while (*p != '"')
+    while (*p != quote)
     {
 	/* The JSON is always expected to be utf-8, thus use utf functions
 	 * here. The string is converted below if needed. */
@@ -504,7 +504,7 @@ json_decode_string(js_read_T *reader, typval_T *res)
     }
 
     reader->js_used = (int)(p - reader->js_buf);
-    if (*p == '"')
+    if (*p == quote)
     {
 	++reader->js_used;
 	if (res != NULL)
@@ -620,7 +620,8 @@ json_decode_item(js_read_T *reader, typval_T *res, int options)
 
 	if (top_item != NULL && top_item->jd_type == JSON_OBJECT_KEY
 		&& (options & JSON_JS)
-		&& reader->js_buf[reader->js_used] != '"')
+		&& reader->js_buf[reader->js_used] != '"'
+		&& reader->js_buf[reader->js_used] != '\'')
 	{
 	    char_u *key;
 
@@ -690,7 +691,17 @@ json_decode_item(js_read_T *reader, typval_T *res, int options)
 		    continue;
 
 		case '"': /* string */
-		    retval = json_decode_string(reader, cur_item);
+		    retval = json_decode_string(reader, cur_item, *p);
+		    break;
+
+		case '\'':
+		    if (options & JSON_JS)
+			retval = json_decode_string(reader, cur_item, *p);
+		    else
+		    {
+			EMSG(_(e_invarg));
+			retval = FAIL;
+		    }
 		    break;
 
 		case ',': /* comma: empty item */

--- a/src/testdir/test_json.vim
+++ b/src/testdir/test_json.vim
@@ -255,8 +255,10 @@ func Test_js_decode()
   call assert_equal(v:none, js_decode(''))
   call assert_equal(type(v:none), type(js_decode('')))
   call assert_equal("", js_decode('""'))
+  call assert_equal("", js_decode("''"))
 
   call assert_equal({'n': 1}, js_decode('{"n":1,}'))
+  call assert_equal({'n': '1'}, js_decode("{'n':'1',}"))
 
   call assert_fails('call js_decode("\"")', "E474:")
   call assert_fails('call js_decode("blah")', "E474:")


### PR DESCRIPTION
```
:echo js_decode("{'foo':'bar'}")
```
Should work.
