### PR TITLE
Fix `:change` in function

### DIFF
--- a/src/testdir/test_viml.vim
+++ b/src/testdir/test_viml.vim
@@ -1239,6 +1239,77 @@ func Test_num64()
 endfunc
 
 "-------------------------------------------------------------------------------
+" Test 95:  lines of :append, :change, :insert			    {{{1
+"-------------------------------------------------------------------------------
+
+function! DefineFunction(name, body)
+    let func = join(['function! ' . a:name . '()'] + a:body + ['endfunction'], "\n")
+    exec func
+endfunction
+
+func Test_script_lines()
+    " :append
+    try
+        call DefineFunction('T_Append', [
+                    \ 'append',
+                    \ 'py <<EOS',
+                    \ '.',
+                    \ ])
+    catch
+        call assert_false(1, "Can't define function")
+    endtry
+    try
+        call DefineFunction('T_Append', [
+                    \ 'append',
+                    \ 'abc',
+                    \ ])
+        call assert_false(1, "Shouldn't be able to define function")
+    catch
+        call assert_exception('Vim(function):E126: Missing :endfunction')
+    endtry
+
+    " :change
+    try
+        call DefineFunction('T_Change', [
+                    \ 'change',
+                    \ 'py <<EOS',
+                    \ '.',
+                    \ ])
+    catch
+        call assert_false(1, "Can't define function")
+    endtry
+    try
+        call DefineFunction('T_Change', [
+                    \ 'change',
+                    \ 'abc',
+                    \ ])
+        call assert_false(1, "Shouldn't be able to define function")
+    catch
+        call assert_exception('Vim(function):E126: Missing :endfunction')
+    endtry
+
+    " :insert
+    try
+        call DefineFunction('T_Insert', [
+                    \ 'insert',
+                    \ 'py <<EOS',
+                    \ '.',
+                    \ ])
+    catch
+        call assert_false(1, "Can't define function")
+    endtry
+    try
+        call DefineFunction('T_Insert', [
+                    \ 'insert',
+                    \ 'abc',
+                    \ ])
+        call assert_false(1, "Shouldn't be able to define function")
+    catch
+        call assert_exception('Vim(function):E126: Missing :endfunction')
+    endtry
+endfunc
+
+"-------------------------------------------------------------------------------
 " Modelines								    {{{1
 " vim: ts=8 sw=4 tw=80 fdm=marker
 " vim: fdt=substitute(substitute(foldtext(),\ '\\%(^+--\\)\\@<=\\(\\s*\\)\\(.\\{-}\\)\:\ \\%(\"\ \\)\\=\\(Test\ \\d*\\)\:\\s*',\ '\\3\ (\\2)\:\ \\1',\ \"\"),\ '\\(Test\\s*\\)\\(\\d\\)\\D\\@=',\ '\\1\ \\2',\ "")

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2085,9 +2085,14 @@ ex_function(exarg_T *eap)
 		}
 	    }
 
-	    /* Check for ":append" or ":insert". */
+	    /* Check for ":append", ":change", ":insert". */
 	    p = skip_range(p, NULL);
 	    if ((p[0] == 'a' && (!ASCII_ISALPHA(p[1]) || p[1] == 'p'))
+		    || (p[0] == 'c'
+			&& (!ASCII_ISALPHA(p[1]) || (p[1] == 'h'
+				&& (!ASCII_ISALPHA(p[2]) || (p[2] == 'a'
+					&& (STRNCMP(&p[3], "nge", 3) != 0
+					    || !ASCII_ISALPHA(p[6])))))))
 		    || (p[0] == 'i'
 			&& (!ASCII_ISALPHA(p[1]) || (p[1] == 'n'
 				&& (!ASCII_ISALPHA(p[2]) || (p[2] == 's'))))))


### PR DESCRIPTION
## Problem 1

When `:change` lines includes a command of which next line is not Ex-command (e.g. `py <<EOS`), `:source` fails.

test1a.vim:

```vim
function! F()
  change
py <<EOS
.
endfunction
```

`vim -Nu NONE -S test1a.vim`

then

```
Error detected while processing /tmp/test1a.vim:
line    6:
E126: Missing :endfunction
```

`:append` and `:insert` are no problem.

test1b.vim:

```vim
function! F()
  append
py <<EOS
.
endfunction
```

`vim -Nu NONE -S test1b.vim`

no error.

## Problem 2

No error occurs in spite of no termination character (`.`).

test2a.vim:

```vim
function! F()
  change
123
endfunction
```

`vim -Nu NONE -S test2a.vim`

no error, and `F()` is callable.

`:append` and `:insert`, an error occurs (as expected).

test2b.vim:

```vim
function! F()
  append
123
endfunction
```

`vim -Nu NONE -S test2b.vim`

then

```
Error detected while processing /tmp/test2b.vim:
line    5:
E126: Missing :endfunction
```

## Cause

https://github.com/ichizok/vim/blob/b8f7bd68f/src/userfunc.c#L2088-L2094
There is a lack of treating `:change`.