### PR TITLE
Fix error number E937 at json.c

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -936,7 +936,7 @@ item_end:
 			&& dict_find(top_item->jd_tv.vval.v_dict,
 						 top_item->jd_key, -1) != NULL)
 		{
-		    EMSG2(_("E937: Duplicate key in JSON: \"%s\""),
+		    EMSG2(_("E938: Duplicate key in JSON: \"%s\""),
 							     top_item->jd_key);
 		    clear_tv(&top_item->jd_key_tv);
 		    clear_tv(cur_item);

--- a/src/testdir/test_json.vim
+++ b/src/testdir/test_json.vim
@@ -152,7 +152,7 @@ func Test_json_decode()
   call assert_fails('call json_decode("blah")', "E474:")
   call assert_fails('call json_decode("true blah")', "E488:")
   call assert_fails('call json_decode("<foobar>")', "E474:")
-  call assert_fails('call json_decode("{\"a\":1,\"a\":2}")', "E937:")
+  call assert_fails('call json_decode("{\"a\":1,\"a\":2}")', "E938:")
 
   call assert_fails('call json_decode("{")', "E474:")
   call assert_fails('call json_decode("{foobar}")', "E474:")


### PR DESCRIPTION
Hi Bram and list,

I found that E937 is duplicated.

json.c
```
E937: Duplicate key in JSON: \"%s\"
```

buffer.c
```
E937: Attempt to delete a buffer that is in use
```

I wrote a patch.

 --
Best regards,
Norio Takagi (a.k.a. norio13)
