### PR TITLE
Use ruby_sysinit instead of NtInitialize if ruby new enough

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -862,7 +862,11 @@ static int ensure_ruby_initialized(void)
 	    int argc = 1;
 	    char *argv[] = {"gvim.exe"};
 	    char **argvp = argv;
+# ifdef RUBY19_OR_LATER
+	    ruby_sysinit(&argc, &argvp);
+# else
 	    NtInitialize(&argc, &argvp);
+# endif
 #endif
 	    {
 #if defined(RUBY19_OR_LATER) || defined(RUBY_INIT_STACK)


### PR DESCRIPTION
NtInitialize function was replaced with ruby_sysinit, since it
was missing it didn't compile. Now it does.

This change allows Ruby 2.4 to be used with Vim on windows.