### PR TITLE
Fixed several issues with Test_profile

### DIFF
--- a/src/testdir/test_profile.vim
+++ b/src/testdir/test_profile.vim
@@ -4,6 +4,9 @@ if !has('profile')
 endif
 
 func Test_profile_func()
+  if !has('unix')
+    return
+  endif
   let lines = [
     \ "func! Foo1()",
     \ "endfunc",
@@ -32,7 +35,7 @@ func Test_profile_func()
     \ ]
 
   call writefile(lines, 'Xprofile_func.vim')
-  let a = system(v:progpath
+  call system(v:progpath
     \ . " -es -u NONE -U NONE -i NONE --noplugin"
     \ . " -c 'profile start Xprofile_func.log'"
     \ . " -c 'profile func Foo*'"
@@ -85,6 +88,9 @@ func Test_profile_func()
 endfunc
 
 func Test_profile_file()
+  if !has('unix')
+    return
+  endif
   let lines = [
     \ 'func! Foo()',
     \ 'endfunc',
@@ -96,7 +102,7 @@ func Test_profile_file()
     \ ]
 
   call writefile(lines, 'Xprofile_file.vim')
-  let a = system(v:progpath
+  call system(v:progpath
     \ . " -es -u NONE -U NONE -i NONE --noplugin"
     \ . " -c 'profile start Xprofile_file.log'"
     \ . " -c 'profile file Xprofile_file.vim'"

--- a/src/testdir/test_profile.vim
+++ b/src/testdir/test_profile.vim
@@ -4,16 +4,13 @@ if !has('profile')
 endif
 
 func Test_profile_func()
-  if !has('unix')
-    return
-  endif
   let lines = [
     \ "func! Foo1()",
     \ "endfunc",
     \ "func! Foo2()",
-    \ "  let count = 100",
-    \ "  while count > 0",
-    \ "    let count = count - 1",
+    \ "  let l:count = 100",
+    \ "  while l:count > 0",
+    \ "    let l:count = l:count - 1",
     \ "  endwhile",
     \ "endfunc",
     \ "func! Foo3()",
@@ -36,46 +33,58 @@ func Test_profile_func()
 
   call writefile(lines, 'Xprofile_func.vim')
   let a = system(v:progpath
-    \ . " -u NONE -i NONE --noplugin"
+    \ . " -es -u NONE -U NONE -i NONE --noplugin"
     \ . " -c 'profile start Xprofile_func.log'"
     \ . " -c 'profile func Foo*'"
     \ . " -c 'so Xprofile_func.vim'"
     \ . " -c 'qall!'")
+  call assert_equal(0, v:shell_error)
+
   let lines = readfile('Xprofile_func.log')
-
-  call assert_equal(28, len(lines))
-
-  call assert_equal('FUNCTION  Foo1()', lines[0])
-  call assert_equal('Called 2 times',   lines[1])
-  call assert_equal('FUNCTION  Foo2()', lines[7])
-  call assert_equal('Called 1 time',    lines[8])
 
   " - Foo1() is called 3 times but should be reported as called twice
   "   since one call is in between "profile pause" .. "profile continue".
-  " - Foo2() should come before Foo1() since Foo1() does much more work.\
+  " - Foo2() should come before Foo1() since Foo1() does much more work.
   " - Foo3() is not reported because function is deleted.
   " - Unlike Foo3(), Foo2() should not be deleted since there is a check
   "   for v:profiling.
   " - Bar() is not reported since it does not match "profile func Foo*".
-  call assert_equal('FUNCTIONS SORTED ON TOTAL TIME',        lines[18])
-  call assert_equal('count  total (s)   self (s)  function', lines[19])
-  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',        lines[20])
-  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',        lines[21])
-  call assert_equal('',                                      lines[22])
-  call assert_equal('FUNCTIONS SORTED ON SELF TIME',         lines[23])
-  call assert_equal('count  total (s)   self (s)  function', lines[24])
-  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',        lines[25])
-  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',        lines[26])
-  call assert_equal('',                                      lines[27])
+  call assert_equal(28, len(lines))
+
+  call assert_equal('FUNCTION  Foo1()',                            lines[0])
+  call assert_equal('Called 2 times',                              lines[1])
+  call assert_match('^Total time:\s\+\d\+\.\d\+$',                 lines[2])
+  call assert_match('^ Self time:\s\+\d\+\.\d\+$',                 lines[3])
+  call assert_equal('',                                            lines[4])
+  call assert_equal('count  total (s)   self (s)',                 lines[5])
+  call assert_equal('',                                            lines[6])
+  call assert_equal('FUNCTION  Foo2()',                            lines[7])
+  call assert_equal('Called 1 time',                               lines[8])
+  call assert_match('^Total time:\s\+\d\+\.\d\+$',                 lines[9])
+  call assert_match('^ Self time:\s\+\d\+\.\d\+$',                 lines[10])
+  call assert_equal('',                                            lines[11])
+  call assert_equal('count  total (s)   self (s)',                 lines[12])
+  call assert_match('^\s*1\s\+.*\slet l:count = 100$',             lines[13])
+  call assert_match('^\s*101\s\+.*\swhile l:count > 0$',           lines[14])
+  call assert_match('^\s*100\s\+.*\s  let l:count = l:count - 1$', lines[15])
+  call assert_match('^\s*100\s\+.*\sendwhile$',                    lines[16])
+  call assert_equal('',                                            lines[17])
+  call assert_equal('FUNCTIONS SORTED ON TOTAL TIME',              lines[18])
+  call assert_equal('count  total (s)   self (s)  function',       lines[19])
+  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',              lines[20])
+  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',              lines[21])
+  call assert_equal('',                                            lines[22])
+  call assert_equal('FUNCTIONS SORTED ON SELF TIME',               lines[23])
+  call assert_equal('count  total (s)   self (s)  function',       lines[24])
+  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',              lines[25])
+  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',              lines[26])
+  call assert_equal('',                                            lines[27])
 
   call delete('Xprofile_func.vim')
   call delete('Xprofile_func.log')
 endfunc
 
 func Test_profile_file()
-  if !has('unix')
-    return
-  endif
   let lines = [
     \ 'func! Foo()',
     \ 'endfunc',
@@ -88,12 +97,13 @@ func Test_profile_file()
 
   call writefile(lines, 'Xprofile_file.vim')
   let a = system(v:progpath
-    \ . " -u NONE -i NONE --noplugin"
+    \ . " -es -u NONE -U NONE -i NONE --noplugin"
     \ . " -c 'profile start Xprofile_file.log'"
     \ . " -c 'profile file Xprofile_file.vim'"
     \ . " -c 'so Xprofile_file.vim'"
     \ . " -c 'so Xprofile_file.vim'"
     \ . " -c 'qall!'")
+  call assert_equal(0, v:shell_error)
 
   let lines = readfile('Xprofile_file.log')
 


### PR DESCRIPTION
- Test_profile was unexpected slow, -es Vim option makes it much faster
- using count instead of l:count caused error in script profiled by Test_profile_func
- check for v:shell_error after running system
- tentatively re-enable tests for Windows as above fixes presumably explain
  while test failed on Windows.