### PR TITLE
tag.c: Convert mfp to NUL delimited string for all mtt

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -2280,7 +2280,7 @@ parse_line:
 		     */
 		    *tagp.tagname_end = NUL;
 		    len = (int)(tagp.tagname_end - tagp.tagname);
-		    mfp = (char_u *)alloc((int)sizeof(char_u) + len + 10 + ML_EXTRA + 1);
+		    mfp = (char_u *)alloc(len + 10 + ML_EXTRA + 1);
 		    if (mfp != NULL)
 		    {
 			int heuristic;
@@ -2317,7 +2317,7 @@ parse_line:
 			if (tagp.command + 2 < temp_end)
 			{
 			    len = (int)(temp_end - tagp.command - 2);
-			    mfp = (char_u *)alloc((int)sizeof(char_u) + len + 1);
+			    mfp = (char_u *)alloc(len + 1);
 			    if (mfp != NULL)
 				vim_strncpy(mfp, tagp.command + 2, len);
 			}
@@ -2328,7 +2328,7 @@ parse_line:
 		    else
 		    {
 			len = (int)(tagp.tagname_end - tagp.tagname);
-			mfp = (char_u *)alloc((int)sizeof(char_u) + len + 1);
+			mfp = (char_u *)alloc(len + 1);
 			if (mfp != NULL)
 			    vim_strncpy(mfp, tagp.tagname, len);
 
@@ -2362,7 +2362,7 @@ parse_line:
 		    else
 			++len;
 #endif
-		    mfp = (char_u *)alloc((int)sizeof(char_u) + len + 1);
+		    mfp = (char_u *)alloc(len + 1);
 		    if (mfp != NULL)
 		    {
 			p = mfp;
@@ -2549,7 +2549,7 @@ findtag_end:
 		else
 		{
 		    /* now change the TAG_SEP back to NUL */
-		    for (p = mfp; *p != NUL; ++p)
+		    for (p = mfp + 1; *p != NUL; ++p)
 			if (*p == TAG_SEP)
 			    *p = NUL;
 		    matches[match_count++] = (char_u *)mfp;


### PR DESCRIPTION
In 8.0.0190, matching tags were added to a hash table as 0x1 delimited
strings.  After finding all matches, the 0x1 were supposed to be
converted back to NUL so the rest of the tag code, and importantly
parse_match(), didn't see any change in behavior.

However, the loop that converts the bytes back was not skipping over the
initial byte of the tag, which indicates the table in which the tag was
stored.  Since the table corresponding to the ctags table is represented
by a 0 byte, this was causing the loop to exit without performing any
replacements, thus breaking parse_match()'s expectations.