### PR TITLE
fix indent of java class with class annotations

### DIFF
--- a/runtime/indent/java.vim
+++ b/runtime/indent/java.vim
@@ -68,6 +68,12 @@ function GetJavaIndent()
   " find start of previous line, in case it was a continuation line
   let lnum = SkipJavaBlanksAndComments(v:lnum - 1)
 
+  " If the previous line starts with 'package' or 'import', we should have the same indent as
+  " the previous one
+  if getline(lnum) =~ '^\s*\(package\|import\)\s\+.*'
+    return indent(lnum)
+  endif
+
   " If the previous line starts with '@', we should have the same indent as
   " the previous one
   if getline(lnum) =~ '^\s*@\S\+\s*$'

--- a/src/Makefile
+++ b/src/Makefile
@@ -2123,6 +2123,7 @@ test_arglist \
 	test_hlsearch \
 	test_increment \
 	test_increment_dbcs \
+	test_indent_java_class_annotation \
 	test_job_fails \
 	test_join \
 	test_json \

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -162,6 +162,7 @@ NEW_TESTS = test_arglist.res \
 	    test_hlsearch.res \
 	    test_increment.res \
 	    test_increment_dbcs.res \
+	    test_indent_java_class_annotation.res \
 	    test_job_fails.res \
 	    test_json.res \
 	    test_langmap.res \

--- a/src/testdir/test_indent_java_class_annotation.vim
+++ b/src/testdir/test_indent_java_class_annotation.vim
@@ -1,0 +1,34 @@
+" Tests for indentation of a java class with multiple class annotations
+function! Test_indent_class_annotation_after_package()
+  new
+  call append(0, ["package com.foo;",
+      	\ "",
+      	\ "@SomeClassAnnotation",
+      	\ "@SomeOtherAnnotation(true)",
+      	\ "public class Bar {",
+        \ "}"])
+  set autoindent
+  filetype plugin indent on
+  set filetype=java
+  exe "normal! gg=G\<CR>"
+  call assert_equal("@SomeClassAnnotation", getline(3))
+  enew! | close
+endfunction
+
+function! Test_indent_class_annotation_after_import()
+  new
+  call append(0, ["package com.foo;",
+      	\ "",
+      	\ "import java.util.String;",
+      	\ "",
+      	\ "@SomeClassAnnotation",
+      	\ "@SomeOtherAnnotation(true)",
+      	\ "public class Bar {",
+        \ "}"])
+  set autoindent
+  filetype plugin indent on
+  set filetype=java
+  exe "normal! gg=G\<CR>"
+  call assert_equal("@SomeClassAnnotation", getline(5))
+  enew! | close
+endfunction


### PR DESCRIPTION
I noticed that the indentation for java class files is off if the class contains multiple annotations and the first annotation contains no args. The entire file, starting with the first annotation after the package and import statements is indented.

I made a small addition to the indent/java.vim, where I return the same indent of the previous line if the previous line was either a package or import statement.