### PR TITLE
Use do_cmdline_cmd instead of stuffReadbuff to inject commands

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -1025,7 +1025,7 @@ doESCkey:
 	case Ctrl_Z:	/* suspend when 'insertmode' set */
 	    if (!p_im)
 		goto normalchar;	/* insert CTRL-Z as normal char */
-	    stuffReadbuff((char_u *)":st\r");
+	    do_cmdline_cmd("stop");
 	    c = Ctrl_O;
 	    /*FALLTHROUGH*/
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -2982,9 +2982,9 @@ do_mouse(
 	if (State & INSERT)
 	    stuffcharReadbuff(Ctrl_O);
 	if (curwin->w_llist_ref == NULL)	/* quickfix window */
-	    stuffReadbuff((char_u *)":.cc\n");
+	    do_cmdline_cmd(".cc");
 	else					/* location list window */
-	    stuffReadbuff((char_u *)":.ll\n");
+	    do_cmdline_cmd(".ll");
 	got_click = FALSE;		/* ignore drag&release now */
     }
 #endif


### PR DESCRIPTION
Change double-click in quickfix/location list and <C-z> in insert mode,
when 'insertmode' is set, to use do_cmdline_cmd to perform their
respective commands.  Using stuffReadbuff adds the (un-typed) commands
to the user's command history, which clutters the user's history with
commands that are the results of implementation details.

These issues were initially reported by Matthew Malcomson.

* https://github.com/neovim/issues/5966
* https://github.com/neovim/issues/5967