### PR TITLE
When using 'c' flag in the substitute, synchronize cursor position if cursorbind is set

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5263,6 +5263,10 @@ do_sub(exarg_T *eap)
 		    setmouse();		/* disable mouse in xterm */
 #endif
 		    curwin->w_cursor.col = regmatch.startpos[0].col;
+#ifdef FEAT_CURSORBIND
+		    if (curwin->w_p_crb)
+			do_check_cursorbind();
+#endif
 
 		    /* When 'cpoptions' contains "u" don't sync undo when
 		     * asking for confirmation. */


### PR DESCRIPTION
If we set `cursorbind` in two windows and then doing a substitute with a 'c' flag, two cursors don't synchronize until we stop the substitution.

This patch fix this.