### PR TITLE
Fixed file descriptor leak with :call system("cat", 12345)

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -11832,6 +11832,7 @@ get_cmd_output_as_rettv(
 	    if (buf == NULL)
 	    {
 		EMSGN(_(e_nobufnr), argvars[1].vval.v_number);
+		fclose(fd);
 		goto errret;
 	    }
 


### PR DESCRIPTION
This fixes a file descriptor leak which was detected by Coverity (CID 1398960).
I did not add a test as existing Test_system(...) already triggers the file descriptor
leak when it does:

call assert_fails('call system("wc -l", 99999)', 'E86:')