### PR TITLE
matlab: support cell mode separators

### DIFF
--- a/runtime/ftplugin/matlab.vim
+++ b/runtime/ftplugin/matlab.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
 " Language:	matlab
 " Maintainer:	Jake Wasserman <jwasserman at gmail dot com>
-" Last Changed: 2014 Dec 30
+" Last Changed: 2017 Jan 23
 
 " Contributors:
 " Charles Campbell
+" Alex Burka
 
 if exists("b:did_ftplugin")
 	finish
@@ -25,8 +26,31 @@ endif
 setlocal suffixesadd=.m
 setlocal suffixes+=.asv
 
+" redefine section movement commands for cell mode
+function! s:NextSection(type, backwards, visual)
+	if a:visual
+		normal! gv
+	endif
+	if a:backwards
+		let dir = '?'
+	else
+		let dir = '/'
+	endif
+	execute 'silent normal! ' . dir . '^%%' . "\r"
+endfunction
+noremap <script> <buffer> <silent> ]] :call <SID>NextSection(1, 0, 0)<cr>
+noremap <script> <buffer> <silent> [[ :call <SID>NextSection(1, 1, 0)<cr>
+noremap <script> <buffer> <silent> ][ :call <SID>NextSection(2, 0, 0)<cr>
+noremap <script> <buffer> <silent> [] :call <SID>NextSection(2, 1, 0)<cr>
+vnoremap <script> <buffer> <silent> ]] :<c-u>call <SID>NextSection(1, 0, 1)<cr>
+vnoremap <script> <buffer> <silent> [[ :<c-u>call <SID>NextSection(1, 1, 1)<cr>
+vnoremap <script> <buffer> <silent> ][ :<c-u>call <SID>NextSection(2, 0, 1)<cr>
+vnoremap <script> <buffer> <silent> [] :<c-u>call <SID>NextSection(2, 1, 1)<cr>
+
 let b:undo_ftplugin = "setlocal suffixesadd< suffixes< "
 	\ . "| unlet! b:match_words"
+	\ . "| nunmap ]] | nunmap [[ | nunmap ][ | nunmap []"
+	\ . "| vunmap ]] | vunmap [[ | vunmap ][ | vunmap []"
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/syntax/matlab.vim
+++ b/runtime/syntax/matlab.vim
@@ -2,10 +2,12 @@
 " Language:	Matlab
 " Maintainer:	Maurizio Tranchero - maurizio(.)tranchero(@)gmail(.)com
 " Credits:	Preben 'Peppe' Guldberg <peppe-vim@wielders.org>
+"               Alex Burka
 "		Original author: Mario Eusebio
-" Last Change:	Wed Jan 13 11:12:34 CET 2010
-" 		sinh added to matlab implicit commands
+" Last Change:	Mon Jan 23 2017
+" 		added support for cell mode
 " Change History:
+" 		- now highlights cell-mode separator comments
 " 		- 'global' and 'persistent' keyword are now recognized
 
 " quit when a syntax file was already loaded
@@ -60,6 +62,7 @@ syn match matlabComment			"%.*$"	contains=matlabTodo,matlabTab
 " MT_ADDON - correctly highlights words after '...' as comments
 syn match matlabComment			"\.\.\..*$"	contains=matlabTodo,matlabTab
 syn region matlabMultilineComment	start=+%{+ end=+%}+ contains=matlabTodo,matlabTab
+syn match matlabCellComment     "^%%.*$"
 
 syn keyword matlabOperator		break zeros default margin round ones rand
 syn keyword matlabOperator		ceil floor size clear zeros eye mean std cov
@@ -96,6 +99,7 @@ hi def link matlabOO			Statement
 hi def link matlabSemicolon		SpecialChar
 hi def link matlabComment			Comment
 hi def link matlabMultilineComment		Comment
+hi def link matlabCellComment          Todo
 hi def link matlabScope			Type
 
 hi def link matlabArithmeticOperator	matlabOperator

--- a/runtime/syntax/matlab.vim
+++ b/runtime/syntax/matlab.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	Matlab
-" Maintainer:	Maurizio Tranchero - maurizio(.)tranchero(@)gmail(.)com
+" Maintainer:	Alex Burka <vim@alexburka.com>
 " Credits:	Preben 'Peppe' Guldberg <peppe-vim@wielders.org>
-"               Alex Burka
+"		Maurizio Tranchero - maurizio(.)tranchero(@)gmail(.)com
 "		Original author: Mario Eusebio
 " Last Change:	Mon Jan 23 2017
 " 		added support for cell mode


### PR DESCRIPTION
This patch adds some support for Matlab comments which are actually cell mode separators.

In Matlab you can write a script in "cell mode" where each cell (delimited by a single line comment which starts with `%%`) can be executed separately when using the Matlab editor.

In the syntax file, I highlighted such comments as Todo (to get the background highlighted). In the ftplugin, I redefined the nroff section movement commands `[[ ]] ][ []` to move between cells. The code is pretty much copied from [Learn Vimscript the Hard Way](http://learnvimscriptthehardway.stevelosh.com/chapters/51.html).