### PR TITLE
Improved test coverage of user-defined commands

### DIFF
--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -102,3 +102,94 @@ func Test_CmdUndefined()
   call assert_fails('Dothat', 'E492:')
   call assert_equal('yes', g:didnot)
 endfunc
+
+func Test_CmdErrors()
+  call assert_fails('com! docmd :', 'E183:')
+  call assert_fails('com! \<Tab> :', 'E182:')
+  call assert_fails('com! _ :', 'E182:')
+  call assert_fails('com! X :', 'E841:')
+  call assert_fails('com! - DoCmd :', 'E175:')
+  call assert_fails('com! -xxx DoCmd :', 'E181:')
+  call assert_fails('com! -addr DoCmd :', 'E179:')
+  call assert_fails('com! -complete DoCmd :', 'E179:')
+  call assert_fails('com! -complete=xxx DoCmd :', 'E180:')
+  call assert_fails('com! -nargs=x DoCmd :', 'E176:')
+  call assert_fails('com! -count=1 -count=2 DoCmd :', 'E177:')
+  call assert_fails('com! -count=x DoCmd :', 'E178:')
+  call assert_fails('com! -range=x DoCmd :', 'E178:')
+
+  com! -nargs=0 DoCmd :
+  call assert_fails('DoCmd x', 'E488:')
+
+  com! -nargs=1 DoCmd :
+  call assert_fails('DoCmd', 'E471:')
+
+  com! -nargs=+ DoCmd :
+  call assert_fails('DoCmd', 'E471:')
+
+  call assert_fails('com DoCmd :', 'E174:')
+  comclear
+  call assert_fails('delcom DoCmd', 'E184:')
+endfunc
+
+func CustomComplete(A, L, P)
+  return "January\nFebruary\nMars\n"
+endfunc
+
+func CustomCompleteList(A, L, P)
+  return [ "Monday", "Tuesday", "Wednesday" ]
+endfunc
+
+func Test_CmdCompletion()
+  call feedkeys(":com -\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"com -addr bang bar buffer complete count nargs range register', @:)
+
+  call feedkeys(":com -addr=\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"com -addr=arguments buffers lines loaded_buffers quickfix tabs windows', @:)
+
+  call feedkeys(":com -complete=co\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"com -complete=color command compiler', @:)
+
+  command! DoCmd1 :
+  command! DoCmd2 :
+  call feedkeys(":com \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"com DoCmd1 DoCmd2', @:)
+
+  call feedkeys(":DoC\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd1 DoCmd2', @:)
+
+  call feedkeys(":delcom DoC\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"delcom DoCmd1 DoCmd2', @:)
+
+  delcom DoCmd1
+  call feedkeys(":delcom DoC\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"delcom DoCmd2', @:)
+
+  call feedkeys(":com DoC\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"com DoCmd2', @:)
+
+  delcom DoCmd2
+  call feedkeys(":delcom DoC\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"delcom DoC', @:)
+
+  call feedkeys(":com DoC\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"com DoC', @:)
+
+  com! -complete=behave DoCmd :
+  call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd mswin xterm', @:)
+
+  com! -complete=custom,CustomComplete DoCmd :
+  call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd January February Mars', @:)
+
+  com! -complete=customlist,CustomCompleteList DoCmd :
+  call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd Monday Tuesday Wednesday', @:)
+
+  com! -complete=custom,CustomCompleteList DoCmd :
+  call assert_fails("call feedkeys(':DoCmd \<C-D>', 'tx')", 'E730:')
+
+  com! -complete=customlist,CustomComp DoCmd :
+  call assert_fails("call feedkeys(':DoCmd \<C-D>', 'tx')", 'E117:')
+endfunc

--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -113,6 +113,9 @@ func Test_CmdErrors()
   call assert_fails('com! -addr DoCmd :', 'E179:')
   call assert_fails('com! -complete DoCmd :', 'E179:')
   call assert_fails('com! -complete=xxx DoCmd :', 'E180:')
+  call assert_fails('com! -complete=custom DoCmd :', 'E467:')
+  call assert_fails('com! -complete=customlist DoCmd :', 'E467:')
+  call assert_fails('com! -complete=behave,CustomComplete DoCmd :', 'E468:')
   call assert_fails('com! -nargs=x DoCmd :', 'E176:')
   call assert_fails('com! -count=1 -count=2 DoCmd :', 'E177:')
   call assert_fails('com! -count=x DoCmd :', 'E178:')
@@ -143,6 +146,12 @@ endfunc
 func Test_CmdCompletion()
   call feedkeys(":com -\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"com -addr bang bar buffer complete count nargs range register', @:)
+
+  call feedkeys(":com -nargs=0 -\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"com -nargs=0 -addr bang bar buffer complete count nargs range register', @:)
+
+  call feedkeys(":com -nargs=\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"com -nargs=* + 0 1 ?', @:)
 
   call feedkeys(":com -addr=\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"com -addr=arguments buffers lines loaded_buffers quickfix tabs windows', @:)
@@ -178,6 +187,10 @@ func Test_CmdCompletion()
   com! -complete=behave DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd mswin xterm', @:)
+
+  " This does not work. Why?
+  "call feedkeys(":DoCmd x\<C-A>\<C-B>\"\<CR>", 'tx')
+  "call assert_equal('"DoCmd xterm', @:)
 
   com! -complete=custom,CustomComplete DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')


### PR DESCRIPTION
Completion of user defined functions is not covered by tests according to Coveralls:
https://coveralls.io/builds/9830009/source?filename=src%2Fex_docmd.c#L3932
This PR adds tests for completion as well as for error paths of user-defined commands.