### PR TITLE
Correct syntax in lstlisting w/out g:tex_verbspell

### DIFF
--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -603,6 +603,8 @@ if s:tex_fast =~# 'v'
    endif
   else
    syn region texZone		start="\\begin{[vV]erbatim}"		end="\\end{[vV]erbatim}\|%stopzone\>"
+   " listings package:
+   syn region texZone		start="\\begin{lstlisting}"		end="\\end{lstlisting}\|%stopzone\>"
    if b:tex_stylish
      syn region texZone		start="\\verb\*\=\z([^\ta-zA-Z@]\)"	end="\z1\|%stopzone\>"
    else


### PR DESCRIPTION
In my setup of Vim, `verbatim` environments get highlighted just fine.
The `lstlisting` environments do not have any special syntax
highlighting. Characters like `$` or `_` screw up the syntax
highlighting of all the following LaTeX code although they are not
supposed to be interpreted as LaTeX.

From the source it seems that support for `lstlisting` is built-in, but
for some reason only when `g:tex_verbspell` is available and enabled.
The only difference between the two blocks seems to be the
`contains=@Spell`, so I have just copied the `lstlisting` line to the
other branch.