### PR TITLE
Test ga normal command and :ascii Ex command

### DIFF
--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -19,6 +19,7 @@ source test_float_func.vim
 source test_fnamemodify.vim
 source test_functions.vim
 source test_glob2regpat.vim
+source test_ga.vim
 source test_goto.vim
 source test_help_tagjump.vim
 source test_join.vim

--- a/src/testdir/test_ga.vim
+++ b/src/testdir/test_ga.vim
@@ -1,0 +1,37 @@
+" Test ga normal command, and :ascii Ex command.
+func Do_ga(c)
+  call setline(1, a:c)
+  let l:a = execute("norm 1goga")
+  let l:b = execute("ascii")
+  call assert_equal(l:a, l:b)
+  return l:a
+endfunc
+
+func Test_ga_command()
+  new
+  set display=uhex
+  call assert_equal("\nNUL",                            Do_ga(''))
+  call assert_equal("\n<<01>>  1,  Hex 01,  Octal 001", Do_ga("\x01"))
+  call assert_equal("\n<<09>>  9,  Hex 09,  Octal 011", Do_ga("\t"))
+
+  set display=
+  call assert_equal("\nNUL",                             Do_ga(''))
+  call assert_equal("\n<^A>  1,  Hex 01,  Octal 001",    Do_ga("\x01"))
+  call assert_equal("\n<^I>  9,  Hex 09,  Octal 011",    Do_ga("\t"))
+
+  call assert_equal("\n<e>  101,  Hex 65,  Octal 145",   Do_ga('e'))
+
+  if !has('multi_byte')
+    return
+  endif
+
+  " Test a few multi-bytes characters.
+  call assert_equal("\n<é> 233, Hex 00e9, Octal 351",    Do_ga('é'))
+  call assert_equal("\n<ẻ> 7867, Hex 1ebb, Octal 17273", Do_ga('ẻ'))
+
+  " Test with combining characters.
+  call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401", Do_ga("e\u0301"))
+  call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401 < ̱> 817, Hex 0331, Octal 1461", Do_ga("e\u0301\u0331"))
+  call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401 < ̱> 817, Hex 0331, Octal 1461 < ̸> 824, Hex 0338, Octal 1470", Do_ga("e\u0301\u0331\u0338"))
+  bwipe!
+endfunc


### PR DESCRIPTION
This PR adds tests for the ga normal command and :ascii command
which were not tested according coveralls:

https://coveralls.io/builds/9897172/source?filename=src%2Fex_cmds.c#L45

