### PR TITLE
Fix invalid memory access with  :set whichwrap=h,h

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -4954,7 +4954,7 @@ do_set(
 			    if (flags & P_FLAGLIST)
 			    {
 				/* Remove flags that appear twice. */
-				for (s = newval; *s; ++s)
+				for (s = newval; *s;)
 				{
 				    /* if options have P_FLAGLIST and
 				     * P_ONECOMMA such as 'whichwrap' */
@@ -4966,7 +4966,7 @@ do_set(
 					    /* Remove the duplicated value and
 					     * the next comma. */
 					    STRMOVE(s, s + 2);
-					    s -= 2;
+					    continue;
 					}
 				    }
 				    else
@@ -4975,9 +4975,10 @@ do_set(
 					      && vim_strchr(s + 1, *s) != NULL)
 					{
 					    STRMOVE(s, s + 1);
-					    --s;
+					    continue;
 					}
 				    }
+				    ++s;
 				}
 			    }
 

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -13,6 +13,12 @@ function! Test_whichwrap()
   set whichwrap+=h,l
   call assert_equal('b,s,h,l', &whichwrap)
 
+  set whichwrap=h,h
+  call assert_equal('h', &whichwrap)
+
+  set whichwrap=h,h,h
+  call assert_equal('h', &whichwrap)
+
   set whichwrap&
 endfunction
 


### PR DESCRIPTION
This PR fixes an invalid memory access in Vim-8.0.304 discovered with afl-fuzz.

Step to reproduce:
```
$ valgrind vim -u NONE -c 'set whichwrap=h,h' -cq 2> vg.log
```
vg.log then contains:

```
==19391== Memcheck, a memory error detector
==19391== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==19391== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==19391== Command: vim -u NONE -c set\ whichwrap=h,h -cq
==19391== 
==19391== Invalid read of size 1
==19391==    at 0x4F3703: do_set (option.c:4957)
==19391==    by 0x45D3F8: do_one_cmd (ex_docmd.c:2981)
==19391==    by 0x45965D: do_cmdline (ex_docmd.c:1120)
==19391==    by 0x5D371C: exe_commands (main.c:2905)
==19391==    by 0x5D371C: vim_main2 (main.c:781)
==19391==    by 0x5D2049: main (main.c:415)
==19391==  Address 0x768de9f is 1 bytes before a block of size 4 alloc'd
==19391==    at 0x4C2ABF5: malloc (vg_replace_malloc.c:299)
==19391==    by 0x4C6267: lalloc (misc2.c:942)
==19391==    by 0x4F3081: do_set (option.c:4796)
==19391==    by 0x45D3F8: do_one_cmd (ex_docmd.c:2981)
==19391==    by 0x45965D: do_cmdline (ex_docmd.c:1120)
==19391==    by 0x5D371C: exe_commands (main.c:2905)
==19391==    by 0x5D371C: vim_main2 (main.c:781)
==19391==    by 0x5D2049: main (main.c:415)
```