### PR TITLE
Add expression eval function for displaying arbitrary text in a balloon.

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1993,6 +1993,7 @@ assert_true({actual} [, {msg}])          none  assert {actual} is true
 asin({expr})			Float	arc sine of {expr}
 atan({expr})			Float	arc tangent of {expr}
 atan2({expr1}, {expr2})		Float	arc tangent of {expr1} / {expr2}
+balloon_show({msg})            none    show {msg} inside the balloon
 browse({save}, {title}, {initdir}, {default})
 				String	put up a file requester
 browsedir({title}, {initdir})	String	put up a directory requester
@@ -2617,6 +2618,18 @@ atan2({expr1}, {expr2})					*atan2()*
 <			2.356194
 		{only available when compiled with the |+float| feature}
 
+balloon_show({msg})                                     *balloon_show()*
+                Show {msg} inside the balloon.
+                Examples: >
+                        :call balloon_show('Hello!')
+<
+                Displaying user-defined messages is normally handled
+                with 'balloonexpr'. Limitation, however, with this approach
+                is that message to be displayed has to be known at the moment
+                when 'balloonexpr' is being evaluated. This puts restriction
+                on asynchronous execution where message to be displayed is yet
+                to be provided (e.g. by some plugin).
+                {only available when compiled with the +beval feature}
 
 							*browse()*
 browse({save}, {title}, {initdir}, {default})

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -58,6 +58,9 @@ static void f_asin(typval_T *argvars, typval_T *rettv);
 static void f_atan(typval_T *argvars, typval_T *rettv);
 static void f_atan2(typval_T *argvars, typval_T *rettv);
 #endif
+#ifdef FEAT_BEVAL
+static void f_balloon_show(typval_T *argvars, typval_T *rettv);
+#endif
 static void f_browse(typval_T *argvars, typval_T *rettv);
 static void f_browsedir(typval_T *argvars, typval_T *rettv);
 static void f_bufexists(typval_T *argvars, typval_T *rettv);
@@ -482,6 +485,9 @@ static struct fst
 #ifdef FEAT_FLOAT
     {"atan",		1, 1, f_atan},
     {"atan2",		2, 2, f_atan2},
+#endif
+#ifdef FEAT_BEVAL
+    {"balloon_show",	1, 1, f_balloon_show},
 #endif
     {"browse",		4, 4, f_browse},
     {"browsedir",	2, 2, f_browsedir},
@@ -1357,6 +1363,18 @@ f_atan2(typval_T *argvars, typval_T *rettv)
 	rettv->vval.v_float = atan2(fx, fy);
     else
 	rettv->vval.v_float = 0.0;
+}
+#endif
+
+/*
+ * "balloon_show()" function
+ */
+#ifdef FEAT_BEVAL
+    static void
+f_balloon_show(typval_T *argvars, typval_T *rettv)
+{
+    char_u	*msg = get_tv_string_chk(&argvars[0]);
+    gui_mch_post_balloon(balloonEval, msg);
 }
 #endif
 


### PR DESCRIPTION
As discussed in [vim_dev topic](https://groups.google.com/forum/#!topic/vim_dev/BLyIXVb3TKM) this patch brings us possibility to trigger balloon messages directly via built-in functions interface.

Main motivation was to enable asynchronous handling of balloon messages. I.e.

```
function! MyBalloonExprHandler()
    SendAsyncRequest(v:beval_bufnr, v:beval_lnum, v:beval_col, ...)
    return ''
endfunction

function! AsyncRequestCallback(msg)
    call balloon_show(a:msg)
endfunction

set ballooneval balloonexpr=MyBalloonExprHandler()
```