### PR TITLE
runtime: add sshconfig to filetypes

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2122,7 +2122,7 @@ au BufNewFile,BufRead *.sqlj			setf sqlj
 au BufNewFile,BufRead *.sqr,*.sqi		setf sqr
 
 " OpenSSH configuration
-au BufNewFile,BufRead ssh_config,*/.ssh/config	setf sshconfig
+au BufNewFile,BufRead ssh_config,*/.ssh/config,*.sshconfig	setf sshconfig
 
 " OpenSSH server configuration
 au BufNewFile,BufRead sshd_config		setf sshdconfig


### PR DESCRIPTION
Hello,

[OpenSSH 7.3 introduced the `Include` directive for SSH configuration file](https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/739495), meaning that ssh config files can now be something else than `~/.ssh/config` or `ssh_config` (from which they can be included).

To be able to have the filetype detected on those included files, this commit adds `*.sshconfig` to the matchings for `sshconfig` filetype.

- Current behavior: `~/.ssh/my_sub_config.sshconfig` included by an `Include my_sub_config.sshconfig` in `~/.ssh/config` doesn't get its filetype detected
- Behavior after this commit: `~/.ssh/my_sub_config.sshconfig` included by an `Include my_sub_config.sshconfig` in `~/.ssh/config` gets its filetype detected as `sshconfig`

PS: I didn't find anything in the repo about testing filetypes detection, please point me to it if I missed it so I can add a test for this!