### PR TITLE
Avoid using Ctrl-O when do_cmdline_cmd is called.

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -1038,8 +1038,7 @@ doESCkey:
 	    if (!p_im)
 		goto normalchar;	/* insert CTRL-Z as normal char */
 	    do_cmdline_cmd((char_u *)"stop");
-	    c = Ctrl_O;
-	    /*FALLTHROUGH*/
+	    continue;
 
 	case Ctrl_O:	/* execute one command */
 #ifdef FEAT_COMPL_FUNC

--- a/src/normal.c
+++ b/src/normal.c
@@ -2982,8 +2982,6 @@ do_mouse(
 		|| (mod_mask & MOD_MASK_MULTI_CLICK) == MOD_MASK_2CLICK)
 	    && bt_quickfix(curbuf))
     {
-	if (State & INSERT)
-	    stuffcharReadbuff(Ctrl_O);
 	if (curwin->w_llist_ref == NULL)	/* quickfix window */
 	    do_cmdline_cmd((char_u *)".cc");
 	else					/* location list window */


### PR DESCRIPTION
Patch 8.0.0208 replaced some uses of readahead buffer, but left in the
now unnecessary use of Ctrl-O to temporarily exit INSERT mode.

Additionally, 8.0.0208 introduced a small regression with cursor shape when
using Ctrl-Z with 'insertmode' set.  If cursor shape is enabled, when Vim is
resumed the "INSERT" mode cursor shape will not be restored.  The cursor shape
will be incorrect until the user causes a mode change.

I wasn't sure the best way to fix that.