### PR TITLE
Fixed invalid memory access with range command

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2295,8 +2295,8 @@ do_one_cmd(
 	    if (!ea.skip)
 	    {
 		curwin->w_cursor.lnum = ea.line2;
-		/* don't leave the cursor on an illegal line */
-		check_cursor_lnum();
+		/* don't leave the cursor on an illegal line or column */
+		check_cursor();
 	    }
 	}
 	else if (*ea.cmd != ',')


### PR DESCRIPTION
This PR fixes an invalid memory access bug found by afl-fuzz.

Steps to reproduce:
```
$ cat > inv-mem.vim <<EOF
c
x
  x
.
1;y
EOF
$ valgrind vim -u NONE -S inv-mem.vim 2> valgrind.log
```

Then quit vim with  :q!  and valgrind.log contains errors:
```
==5012== Memcheck, a memory error detector
==5012== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==5012== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==5012== Command: vim -u NONE -S inv-mem.vim
==5012== 
==5012== Invalid read of size 1
==5012==    at 0x538914: utf_head_off (mbyte.c:3746)
==5012==    by 0x66E1E7: getvcol (charset.c:1307)
==5012==    by 0x66E7FA: getvvcol (charset.c:1481)
==5012==    by 0x53398C: curs_columns (move.c:964)
==5012==    by 0x533434: validate_cursor (move.c:644)
==5012==    by 0x675EFB: main_loop (main.c:1210)
==5012==    by 0x674783: vim_main2 (main.c:877)
==5012==    by 0x6722A3: main (main.c:415)
==5012==  Address 0x7e6ad80 is 0 bytes after a block of size 4,096 alloc'd
==5012==    at 0x4C2ABF5: malloc (vg_replace_malloc.c:299)
==5012==    by 0x52A28A: lalloc (misc2.c:942)
==5012==    by 0x52A227: alloc (misc2.c:840)
==5012==    by 0x678F0D: mf_alloc_bhdr (memfile.c:907)
==5012==    by 0x678B7B: mf_new (memfile.c:381)
==5012==    by 0x506AE0: ml_new_data (memline.c:3513)
==5012==    by 0x506564: ml_open (memline.c:400)
==5012==    by 0x42BB5F: open_buffer (buffer.c:163)
==5012==    by 0x675086: create_windows (main.c:2677)
==5012==    by 0x6743B1: vim_main2 (main.c:704)
==5012==    by 0x6722A3: main (main.c:415)
(etc.)
```

Doing a bissection, I found that bug started with vim-8.0.0133:
```
commit fe38b494fff56cd9b2fcaeef26a8fd7b6557d69c
Author: Bram Moolenaar <Bram@vim.org>
Date:   Sun Dec 11 21:34:23 2016 +0100

    patch 8.0.0133
    Problem:    "2;'(" causes ml_get errors in an empty buffer.  (Dominique Pelle)
    Solution:   Check the cursor line earlier.
```

I was not able to completely automate reproduction of the bug somehow.
So I have no test.
