### PR TITLE
Fix multibyte line-wrap with 'linebreak' and 'breakat'

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4189,6 +4189,8 @@ win_line(
 	}
 	else
 	{
+	    int c0;
+
 	    if (p_extra_free != NULL)
 	    {
 		vim_free(p_extra_free);
@@ -4197,7 +4199,7 @@ win_line(
 	    /*
 	     * Get a character from the line itself.
 	     */
-	    c = *ptr;
+	    c0 = c = *ptr;
 #ifdef FEAT_MBYTE
 	    if (has_mbyte)
 	    {
@@ -4214,7 +4216,7 @@ win_line(
 			/* Overlong encoded ASCII or ASCII with composing char
 			 * is displayed normally, except a NUL. */
 			if (mb_c < 0x80)
-			    c = mb_c;
+			    c0 = c = mb_c;
 			mb_utf8 = TRUE;
 
 			/* At start of the line we can have a composing char.
@@ -4538,7 +4540,8 @@ win_line(
 		/*
 		 * Found last space before word: check for line break.
 		 */
-		if (wp->w_p_lbr && vim_isbreak(c) && !vim_isbreak(*ptr))
+		if (wp->w_p_lbr && (c0 == c)
+				      && vim_isbreak(c) && !vim_isbreak(*ptr))
 		{
 # ifdef FEAT_MBYTE
 		    int mb_off = has_mbyte ? (*mb_head_off)(line, ptr - 1) : 0;

--- a/src/testdir/test_listlbr_utf8.vim
+++ b/src/testdir/test_listlbr_utf8.vim
@@ -193,3 +193,30 @@ func Test_multibyte_sign_and_colorcolumn()
   call s:compare_lines(expect, lines)
   call s:close_windows()
 endfunc
+
+func Test_illegal_byte_and_breakat()
+  call s:test_windows("setl sbr= brk+=<")
+  vert resize 18
+  call setline(1, repeat("\x80", 6))
+  redraw!
+  let lines = s:screen_lines([1, 2], winwidth(0))
+  let expect = [
+\ "<80><80><80><80><8",
+\ "0><80>            ",
+\ ]
+  call s:compare_lines(expect, lines)
+  call s:close_windows('setl brk&vim')
+endfunc
+
+func Test_multibyte_wrap_and_breakat()
+  call s:test_windows("setl sbr= brk+=>")
+  call setline(1, repeat('a', 17) . repeat('あ', 2))
+  redraw!
+  let lines = s:screen_lines([1, 2], winwidth(0))
+  let expect = [
+\ "aaaaaaaaaaaaaaaaaあ>",
+\ "あ                  ",
+\ ]
+  call s:compare_lines(expect, lines)
+  call s:close_windows('setl brk&vim')
+endfunc


### PR DESCRIPTION
### Problem 1

When `'breakat'` includes `>` and `'linebreak'` is on, and multibyte (2-cells) characters wraps line,
unreasonable characters `<<` is placed on head of wrapped-line.

`vim -Nu NONE`
`:exe "normal! " . (winwidth(0)-3) . "aa\<Esc>2a\<C-V>u3042"`

![vim-issue1a](https://cloud.githubusercontent.com/assets/943423/22720583/fbc2f7ac-edee-11e6-96a0-b719db33ad04.png)

`:setl linebreak breakat+=>`

![vim-issue1b](https://cloud.githubusercontent.com/assets/943423/22720587/034dff80-edef-11e6-8b47-01e38d52290d.png)

And a cursor deviates from actual position.

### Problem 2

When `'breakat'` includes `<` and `'linebreak'` is on, illegal-byte expression (e.g. `<80>`) becomes `<<<<`.

`vim -Nu NONE`
`:exe "normal! a\<C-V>u80"`

![vim-issue2a](https://cloud.githubusercontent.com/assets/943423/22720665/71328b6a-edef-11e6-8035-1f0269cb6c5a.png)

`:setl linebreak breakat+=<`

![vim-issue2b](https://cloud.githubusercontent.com/assets/943423/22720670/789ff9fa-edef-11e6-8dd8-23913fc04261.png)

### Cause (maybe)

https://github.com/vim/vim/blob/65189a129/src/screen.c#L4200
`c` gets a character from the line.

https://github.com/vim/vim/blob/65189a129/src/screen.c#L4264
https://github.com/vim/vim/blob/65189a129/src/screen.c#L4358
When illegal-byte is found or double-width character doesn't fit display, `c` is replaced.

https://github.com/vim/vim/blob/65189a129/src/screen.c#L4541
There checks linebreak by the replaced `c`, but I think this check must be done to original `c`.

Ozaki Kiichi a.k.a ichizok