### PR TITLE
Fixed access to uninitialized memory in expand()

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -4028,15 +4028,12 @@ expand_env_esc(
 		 */
 #  if defined(HAVE_GETPWNAM) && defined(HAVE_PWD_H)
 		{
-		    struct passwd *pw;
-
 		    /* Note: memory allocated by getpwnam() is never freed.
 		     * Calling endpwent() apparently doesn't help. */
-		    pw = getpwnam((char *)dst + 1);
-		    if (pw != NULL)
-			var = (char_u *)pw->pw_dir;
-		    else
-			var = NULL;
+		    struct passwd *pw = (*dst == NUL)
+					? NULL : getpwnam((char *)dst + 1);
+
+		    var = (pw == NULL) ? NULL : (char_u *)pw->pw_dir;
 		}
 		if (var == NULL)
 #  endif

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -22,6 +22,13 @@ function! Test_whichwrap()
   set whichwrap&
 endfunction
 
+function! Test_isfname()
+  " This used to cause Vim to access uninitialized memory.
+  set isfname=
+  call assert_equal("~X", expand("~X"))
+  set isfname&
+endfunction
+
 function Test_options()
   let caught = 'ok'
   try


### PR DESCRIPTION
This PR fixes access to uninitialized memory, along with
a test that accesses uninitialized memory prior to the fix.

Step to reproduce:
```
$ valgrind vim -c 'set isfname= | echo expand("~X") | q' 2> vg.log
```
And vg.log shows this error:
```
==10148== Memcheck, a memory error detector
==10148== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==10148== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==10148== Command: vim -c set\ isfname=\ |\ echo\ expand("~X")\ |\ q
==10148== 
==10148== Conditional jump or move depends on uninitialised value(s)
==10148==    at 0xBFC528A: _nss_compat_getpwnam_r (compat-pwd.c:859)
==10148==    by 0x71F5F3C: getpwnam_r@@GLIBC_2.2.5 (getXXbyYY_r.c:266)
==10148==    by 0x71F58DE: getpwnam (getXXbyYY.c:116)
==10148==    by 0x4DFFAD: expand_env_esc (misc1.c:4035)
==10148==    by 0x4EB8C2: expand_env_save_opt (misc1.c:3869)
==10148==    by 0x4EB8C2: gen_expand_wildcards (misc1.c:10843)
==10148==    by 0x4EB268: expand_wildcards (misc1.c:9630)
==10148==    by 0x4EB21F: expand_wildcards_eval (misc1.c:9601)
==10148==    by 0x49BFC9: ExpandFromContext (ex_getln.c:4755)
==10148==    by 0x498EC6: ExpandOne (ex_getln.c:3732)
==10148==    by 0x460C47: f_expand (evalfunc.c:3009)
==10148==    by 0x45DFD6: call_internal_func (evalfunc.c:979)
==10148==    by 0x5D5578: call_func (userfunc.c:1426)
==10148== 
==10148== Conditional jump or move depends on uninitialised value(s)
==10148==    at 0xBFC5292: _nss_compat_getpwnam_r (compat-pwd.c:859)
==10148==    by 0x71F5F3C: getpwnam_r@@GLIBC_2.2.5 (getXXbyYY_r.c:266)
==10148==    by 0x71F58DE: getpwnam (getXXbyYY.c:116)
==10148==    by 0x4DFFAD: expand_env_esc (misc1.c:4035)
==10148==    by 0x4EB8C2: expand_env_save_opt (misc1.c:3869)
==10148==    by 0x4EB8C2: gen_expand_wildcards (misc1.c:10843)
==10148==    by 0x4EB268: expand_wildcards (misc1.c:9630)
==10148==    by 0x4EB21F: expand_wildcards_eval (misc1.c:9601)
==10148==    by 0x49BFC9: ExpandFromContext (ex_getln.c:4755)
==10148==    by 0x498EC6: ExpandOne (ex_getln.c:3732)
==10148==    by 0x460C47: f_expand (evalfunc.c:3009)
==10148==    by 0x45DFD6: call_internal_func (evalfunc.c:979)
==10148==    by 0x5D5578: call_func (userfunc.c:1426)
==10148== 
==10148== Conditional jump or move depends on uninitialised value(s)
==10148==    at 0x4C2EA2C: strcmp (vg_replace_strmem.c:842)
==10148==    by 0xBFC5480: internal_getpwnam_r (compat-pwd.c:771)
==10148==    by 0xBFC5480: _nss_compat_getpwnam_r (compat-pwd.c:872)
==10148==    by 0x71F5F3C: getpwnam_r@@GLIBC_2.2.5 (getXXbyYY_r.c:266)
==10148==    by 0x71F58DE: getpwnam (getXXbyYY.c:116)
==10148==    by 0x4DFFAD: expand_env_esc (misc1.c:4035)
==10148==    by 0x4EB8C2: expand_env_save_opt (misc1.c:3869)
==10148==    by 0x4EB8C2: gen_expand_wildcards (misc1.c:10843)
==10148==    by 0x4EB268: expand_wildcards (misc1.c:9630)
==10148==    by 0x4EB21F: expand_wildcards_eval (misc1.c:9601)
==10148==    by 0x49BFC9: ExpandFromContext (ex_getln.c:4755)
==10148==    by 0x498EC6: ExpandOne (ex_getln.c:3732)
==10148==    by 0x460C47: f_expand (evalfunc.c:3009)
==10148==    by 0x45DFD6: call_internal_func (evalfunc.c:979)
==10148== 
==10148== Conditional jump or move depends on uninitialised value(s)
==10148==    at 0xBFC5483: internal_getpwnam_r (compat-pwd.c:771)
==10148==    by 0xBFC5483: _nss_compat_getpwnam_r (compat-pwd.c:872)
==10148==    by 0x71F5F3C: getpwnam_r@@GLIBC_2.2.5 (getXXbyYY_r.c:266)
==10148==    by 0x71F58DE: getpwnam (getXXbyYY.c:116)
==10148==    by 0x4DFFAD: expand_env_esc (misc1.c:4035)
==10148==    by 0x4EB8C2: expand_env_save_opt (misc1.c:3869)
==10148==    by 0x4EB8C2: gen_expand_wildcards (misc1.c:10843)
==10148==    by 0x4EB268: expand_wildcards (misc1.c:9630)
==10148==    by 0x4EB21F: expand_wildcards_eval (misc1.c:9601)
==10148==    by 0x49BFC9: ExpandFromContext (ex_getln.c:4755)
==10148==    by 0x498EC6: ExpandOne (ex_getln.c:3732)
==10148==    by 0x460C47: f_expand (evalfunc.c:3009)
==10148==    by 0x45DFD6: call_internal_func (evalfunc.c:979)
==10148==    by 0x5D5578: call_func (userfunc.c:1426)
{noformat}
```
Bug was discovered using afl-fuzz.