### PR TITLE
Add description of unnamedplus feature to ":help feature-list"

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8463,6 +8463,7 @@ toolbar			Compiled with support for |gui-toolbar|.
 ttyin			input is a terminal (tty)
 ttyout			output is a terminal (tty)
 unix			Unix version of Vim.
+unnamedplus		Compiled with support for "unnamedplus" in 'clipboard'
 user_commands		User-defined commands.
 vertsplit		Compiled with vertically split windows |:vsplit|.
 vim_starting		True while initial source'ing takes place. |startup|


### PR DESCRIPTION
The "unnamedplus" value for 'clipboard' was added in v7.3.074 and
explicitly mentions using `has('unnamedplus')` to check for it being
supported, however ":help feature-list" doesn't mention it.