### PR TITLE
Fixed invalid memory access with :set complete=s\

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -7017,7 +7017,7 @@ did_set_string_option(
 		    /* skip optional filename after 'k' and 's' */
 		    while (*s && *s != ',' && *s != ' ')
 		    {
-			if (*s == '\\')
+			if (*s == '\\' && s[1] != NUL)
 			    ++s;
 			++s;
 		    }

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -136,6 +136,15 @@ func Test_thesaurus()
   call Check_dir_option('thesaurus')
 endfun
 
+func Test_complete()
+  " Trailing single backslash used to cause invalid memory access.
+  set complete=s\
+  new
+  call feedkeys("i\<C-N>")
+  bwipe!
+  set complete&
+endfun
+
 func Test_set_completion()
   call feedkeys(":set di\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set dictionary diff diffexpr diffopt digraph directory display', @:)


### PR DESCRIPTION
This PR fixes an invalid memory access in Vim-8.0.329 and older when
the 'complete' option is set with a single trailing backslash:
 
```
:set complete=s\
```

Valgrind error:
```
==23076== Invalid read of size 1
==23076==    at 0x4F54AB: did_set_string_option.constprop.10 (option.c:7018)
==23076==    by 0x4FAD30: do_set (option.c:5006)
==23076==    by 0x46B734: do_one_cmd (ex_docmd.c:2981)
==23076==    by 0x46B734: do_cmdline (ex_docmd.c:1120)
==23076==    by 0x4D71E4: nv_colon (normal.c:5403)
==23076==    by 0x4E0EF1: normal_cmd (normal.c:1150)
==23076==    by 0x5BED24: main_loop (main.c:1315)
==23076==    by 0x5BFDF2: vim_main2 (main.c:877)
==23076==    by 0x40C3D3: main (main.c:415)
==23076==  Address 0x9854eb3 is 0 bytes after a block of size 3 alloc'd
==23076==    at 0x4C2ABF5: malloc (vg_replace_malloc.c:299)
==23076==    by 0x4C4D0B: lalloc (misc2.c:942)
==23076==    by 0x4FA72A: do_set (option.c:4796)
==23076==    by 0x46B734: do_one_cmd (ex_docmd.c:2981)
==23076==    by 0x46B734: do_cmdline (ex_docmd.c:1120)
==23076==    by 0x4D71E4: nv_colon (normal.c:5403)
==23076==    by 0x4E0EF1: normal_cmd (normal.c:1150)
==23076==    by 0x5BED24: main_loop (main.c:1315)
==23076==    by 0x5BFDF2: vim_main2 (main.c:877)
==23076==    by 0x40C3D3: main (main.c:415)
```
Bug was found using afl-fuzz.