### PR TITLE
Fix handling of all 2-/3-character :sub variants

### DIFF
--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -39,3 +39,63 @@ function! Test_multiline_subst()
   call assert_equal('xxxxx', getline(13))
   enew!
 endfunction
+
+function! Test_substitute_variants()
+  " Validate that all the 2-/3-letter variants which embed the flags into the
+  " command name actually work
+  enew!
+  let ln = 'Testing string'
+  let variants = [
+	\ { 'cmd': ':sc/Test/test/', 'exp': 'testing string', 'prompt': 'y' },
+	\ { 'cmd': ':sce/foo/bar/', 'exp': ln },
+	\ { 'cmd': ':scg/t/r/', 'exp': 'Tesring srring', 'prompt': 'a' },
+	\ { 'cmd': ':sci/t/r/', 'exp': 'resting string', 'prompt': 'y' },
+	\ { 'cmd': ':scI/t/r/', 'exp': 'Tesring string', 'prompt': 'y' },
+	\ { 'cmd': ':scn/t/r/', 'exp': ln },
+	\ { 'cmd': ':scp/t/r/', 'exp': 'Tesring string', 'prompt': 'y' },
+	\ { 'cmd': ':scl/t/r/', 'exp': 'Tesring string', 'prompt': 'y' },
+	\ { 'cmd': ':sgc/t/r/', 'exp': 'Tesring srring', 'prompt': 'a' },
+	\ { 'cmd': ':sge/foo/bar/', 'exp': ln },
+	\ { 'cmd': ':sg/t/r/', 'exp': 'Tesring srring' },
+	\ { 'cmd': ':sgi/t/r/', 'exp': 'resring srring' },
+	\ { 'cmd': ':sgI/t/r/', 'exp': 'Tesring srring' },
+	\ { 'cmd': ':sgn/t/r/', 'exp': ln },
+	\ { 'cmd': ':sgp/t/r/', 'exp': 'Tesring srring' },
+	\ { 'cmd': ':sgl/t/r/', 'exp': 'Tesring srring' },
+	\ { 'cmd': ':sgr//r/', 'exp': 'Testr strr' },
+	\ { 'cmd': ':sic/t/r/', 'exp': 'resting string', 'prompt': 'y' },
+	\ { 'cmd': ':sie/foo/bar/', 'exp': ln },
+	\ { 'cmd': ':si/t/r/', 'exp': 'resting string' },
+	\ { 'cmd': ':siI/t/r/', 'exp': 'Tesring string' },
+	\ { 'cmd': ':sin/t/r/', 'exp': ln },
+	\ { 'cmd': ':sip/t/r/', 'exp': 'resting string' },
+	\ { 'cmd': ':sir//r/', 'exp': 'Testr string' },
+	\ { 'cmd': ':sIc/t/r/', 'exp': 'Tesring string', 'prompt': 'y' },
+	\ { 'cmd': ':sIe/foo/bar/', 'exp': ln },
+	\ { 'cmd': ':sIg/t/r/', 'exp': 'Tesring srring' },
+	\ { 'cmd': ':sIi/t/r/', 'exp': 'resting string' },
+	\ { 'cmd': ':sI/t/r/', 'exp': 'Tesring string' },
+	\ { 'cmd': ':sIp/t/r/', 'exp': 'Tesring string' },
+	\ { 'cmd': ':sIl/t/r/', 'exp': 'Tesring string' },
+	\ { 'cmd': ':sIr//r/', 'exp': 'Testr string' },
+	\ { 'cmd': ':src//r/', 'exp': 'Testr string', 'prompt': 'y' },
+	\ { 'cmd': ':srg//r/', 'exp': 'Testr strr' },
+	\ { 'cmd': ':sri//r/', 'exp': 'Testr string' },
+	\ { 'cmd': ':srI//r/', 'exp': 'Testr string' },
+	\ { 'cmd': ':srn//r/', 'exp': 'Testing string' },
+	\ { 'cmd': ':srp//r/', 'exp': 'Testr string' },
+	\ { 'cmd': ':srl//r/', 'exp': 'Testr string' },
+	\ { 'cmd': ':sr//r/', 'exp': 'Testr string' },
+	\]
+
+  for var in variants
+    call setline(1, [ln])
+    let msg = printf('using "%s"', var.cmd)
+    let @/='ing'
+    let v:errmsg = ''
+    call feedkeys(var.cmd . "\<CR>" . get(var, 'prompt', ''), 'ntx')
+    " No error should exist (matters for testing e flag)
+    call assert_equal('', v:errmsg, msg)
+    call assert_equal(var.exp, getline('.'), msg)
+  endfor
+endfunction


### PR DESCRIPTION
As can be seen at ":help :sgr", there's an entire table describing
2-/3-character variations on the :substitute command, which embed flags
in the command name.  However, all of those commands actually fail with
"E488: Trailing characters".

This PR adds explicit handling for the named commands and some minimal
testing that they work.