### PR TITLE
Missing bracket in tex.vim

### DIFF
--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -511,7 +511,7 @@ if !exists("g:tex_no_math")
   if &ambw == "double" || exists("g:tex_usedblwidth")
     let s:texMathDelimList= s:texMathDelimList + [
      \ ['\\langle'     , '〈'] ,
-     \ ['\\rangle'     , '〉'] ,
+     \ ['\\rangle'     , '〉']]
   else
     let s:texMathDelimList= s:texMathDelimList + [
      \ ['\\langle'     , '<'] ,


### PR DESCRIPTION
Fix for missing bracket in tex.vim (patch is from vim-dev mailing list, created by Hirohito Higashi ). I did not see any pull request or issue here for this problem, so I created this pull request for this reason.