### PR TITLE
Fix invalid memory access with :recover command

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2177,6 +2177,7 @@ test_arglist \
 	test_pyx2 \
 	test_pyx3 \
 	test_quickfix \
+	test_recover \
 	test_regexp_latin \
 	test_regexp_utf8 \
 	test_reltime \

--- a/src/memline.c
+++ b/src/memline.c
@@ -1863,8 +1863,10 @@ recover_names(
 	    else
 	    {
 #if defined(UNIX) || defined(WIN3264)
-		p = dir_name + STRLEN(dir_name);
-		if (after_pathsep(dir_name, p) && p[-1] == p[-2])
+		int	len = STRLEN(dir_name);
+
+		p = dir_name + len;
+		if (after_pathsep(dir_name, p) && len > 1 && p[-1] == p[-2])
 		{
 		    /* Ends with '//', Use Full path for swap name */
 		    tail = make_percent_swname(dir_name, fname_res);
@@ -3922,8 +3924,10 @@ makeswapname(
 #endif
 
 #if defined(UNIX) || defined(WIN3264)  /* Need _very_ long file names */
-    s = dir_name + STRLEN(dir_name);
-    if (after_pathsep(dir_name, s) && s[-1] == s[-2])
+    int		len = STRLEN(dir_name);
+
+    s = dir_name + len;
+    if (after_pathsep(dir_name, s) && len > 1 && s[-1] == s[-2])
     {			       /* Ends with '//', Use Full path */
 	r = NULL;
 	if ((s = make_percent_swname(dir_name, fname)) != NULL)

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -34,6 +34,7 @@ source test_messages.vim
 source test_partial.vim
 source test_popup.vim
 source test_put.vim
+source test_recover.vim
 source test_reltime.vim
 source test_searchpos.vim
 source test_set.vim

--- a/src/testdir/test_recover.vim
+++ b/src/testdir/test_recover.vim
@@ -4,6 +4,7 @@ func Test_recover_root_dir()
   " This used to access invalid memory.
   set dir=/
   call assert_fails('recover', 'E305:')
+  set dir&
 endfunc
 
-" TODO: move recover tests from tests78.in to here.
+" TODO: move recover tests from test78.in to here.

--- a/src/testdir/test_recover.vim
+++ b/src/testdir/test_recover.vim
@@ -1,0 +1,9 @@
+" Test :recover
+
+func Test_recover_root_dir()
+  " This used to access invalid memory.
+  set dir=/
+  call assert_fails('recover', 'E305:')
+endfunc
+
+" TODO: move recover tests from tests78.in to here.


### PR DESCRIPTION
This PR fixes an invalid memory access in the :recover command in
Vim-8.0.336 and older. It's an old bug since at least vim-7.4.52
in ubuntu-14.04 already has the bug. Bug was found using afl-fuzz.

Step to reproduce:

$ valgrind vim -u NONE -c 'set dir=/' -c rec -cq 2>vg.log

And vg.log contains:

==17014== Memcheck, a memory error detector
==17014== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==17014== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==17014== Command: vim -u NONE -c set\ dir=/ -c rec -cq
==17014== 
==17014== Invalid read of size 1
==17014==    at 0x4AB231: recover_names (memline.c:1867)
==17014==    by 0x4A9AD0: ml_recover (memline.c:1167)
==17014==    by 0x46688B: ex_recover (ex_docmd.c:8234)
==17014==    by 0x45CCFD: do_one_cmd (ex_docmd.c:2981)
==17014==    by 0x458F5D: do_cmdline (ex_docmd.c:1120)
==17014==    by 0x5D1F2C: exe_commands (main.c:2905)
==17014==    by 0x5D1F2C: vim_main2 (main.c:781)
==17014==    by 0x5D0859: main (main.c:415)
==17014==  Address 0x769305f is 1 bytes before a block of size 2 alloc'd
==17014==    at 0x4C2ABF5: malloc (vg_replace_malloc.c:299)
==17014==    by 0x4C5A17: lalloc (misc2.c:942)
==17014==    by 0x4AB150: recover_names (memline.c:1801)
==17014==    by 0x4A9AD0: ml_recover (memline.c:1167)
==17014==    by 0x46688B: ex_recover (ex_docmd.c:8234)
==17014==    by 0x45CCFD: do_one_cmd (ex_docmd.c:2981)
==17014==    by 0x458F5D: do_cmdline (ex_docmd.c:1120)
==17014==    by 0x5D1F2C: exe_commands (main.c:2905)
==17014==    by 0x5D1F2C: vim_main2 (main.c:781)
==17014==    by 0x5D0859: main (main.c:415)