### PR TITLE
Fixed invalid memory access with 'cinkeys'

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -8178,7 +8178,8 @@ in_cinkeys(
 	{
 	    if (try_match && *look == keytyped)
 		return TRUE;
-	    ++look;
+	    if (*look != NUL)
+		++look;
 	}
 
 	/*

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -132,6 +132,7 @@ func Test_cinkeys()
   " This used to cause invalid memory access
   set cindent cinkeys=0
   norm a
+  set cindent& cinkeys&
 endfunc
 
 func Test_dictionary()

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -128,6 +128,12 @@ func Check_dir_option(name)
   call assert_fails("set " . a:name . "=/not.*there", "E474:")
 endfunc
 
+func Test_cinkeys()
+  " This used to cause invalid memory access
+  set cindent cinkeys=0
+  norm a
+endfunc
+
 func Test_dictionary()
   call Check_dir_option('dictionary')
 endfunc


### PR DESCRIPTION
This PR fixes an invalid memory access in vim-8.0.341 and older.
It's an old bug since it was in vim-7.4.52 already.
I did not check earlier version.
Bug was found using afl-fuzz.

Step to reproduce:
```
$ vim -u NONE -c'set cin cinkeys=0' -c 'norm a' -cq 2>log
```
And log file contains:
```
==4184== Memcheck, a memory error detector
==4184== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==4184== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==4184== Command: ./vim -u NONE -cset\ cin\ cinkeys=0 -c norm\ a -cq
==4184== 
==4184== Invalid read of size 1
==4184==    at 0x4B5C84: skip_to_option_part (misc1.c:2707)
==4184==    by 0x41D5DC: in_cinkeys (edit.c:8187)
==4184==    by 0x41AB1A: edit (edit.c:949)
==4184==    by 0x4DCB1D: nv_edit (normal.c:0)
==4184==    by 0x4D5E63: normal_cmd (normal.c:1150)
==4184==    by 0x461DF1: exec_normal (ex_docmd.c:10418)
==4184==    by 0x461CE8: exec_normal_cmd (ex_docmd.c:10401)
==4184==    by 0x461CE8: ex_normal (ex_docmd.c:10310)
==4184==    by 0x45CD1D: do_one_cmd (ex_docmd.c:2981)
==4184==    by 0x458F7D: do_cmdline (ex_docmd.c:1120)
==4184==    by 0x5D1E4C: exe_commands (main.c:2905)
==4184==    by 0x5D1E4C: vim_main2 (main.c:781)
==4184==    by 0x5D0779: main (main.c:415)
==4184==  Address 0x7690d32 is 0 bytes after a block of size 2 alloc'd
==4184==    at 0x4C2ABF5: malloc (vg_replace_malloc.c:299)
==4184==    by 0x4C5A37: lalloc (misc2.c:942)
==4184==    by 0x4F2306: do_set (option.c:4799)
==4184==    by 0x45CD1D: do_one_cmd (ex_docmd.c:2981)
==4184==    by 0x458F7D: do_cmdline (ex_docmd.c:1120)
==4184==    by 0x5D1E4C: exe_commands (main.c:2905)
==4184==    by 0x5D1E4C: vim_main2 (main.c:781)
==4184==    by 0x5D0779: main (main.c:415)
(snip more errors)
```