### PR TITLE
screen.c: account for translated string length

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -6730,7 +6730,7 @@ win_redr_status(win_T *wp)
 	if (wp->w_buffer->b_p_ro)
 	{
 	    STRCPY(p + len, _("[RO]"));
-	    len += 4;
+	    len += (int)STRLEN(p + len);
 	}
 
 	this_ru_col = ru_col - (Columns - W_WIDTH(wp));


### PR DESCRIPTION
`[RO]` is appended to the status line and `len` is increased with the length of
this string (4). However, the string is marked for translation and may thus well
be larger (or smaller) than 4. Therefore, we check the length at runtime. The
resulting len is never actually used, and thus could be removed.  However, by
keeping this line, the body of this if-statement is kept consistent with
surrounding code, and future changes can not forget to add this line when
additional strings are added to p.

This issue was found in Neovim: https://github.com/neovim/neovim/pull/6148

cc @chrisbra 