### PR TITLE
Fixed invalid memory access when setting empty 'wildchar'

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -4454,7 +4454,7 @@ do_set(
 	    }
 
 	    /*
-	     * allow '=' and ':' for hystorical reasons (MSDOS command.com
+	     * allow '=' and ':' for historical reasons (MSDOS command.com
 	     * allows only one '=' character per "set" command line. grrr. (jw)
 	     */
 	    if (nextchar == '?'
@@ -4598,7 +4598,7 @@ do_set(
 				    || (long *)varp == &p_wcm)
 				&& (*arg == '<'
 				    || *arg == '^'
-				    || ((!arg[1] || vim_iswhite(arg[1]))
+				    || (*arg != NUL && (!arg[1] || vim_iswhite(arg[1]))
 					&& !VIM_ISDIGIT(*arg))))
 			{
 			    value = string_to_key(arg);
@@ -5829,7 +5829,7 @@ set_string_option(
 							   opt_flags)) == NULL)
 	    did_set_option(opt_idx, opt_flags, TRUE);
 
-	/* call autocomamnd after handling side effects */
+	/* call autocommand after handling side effects */
 #if defined(FEAT_AUTOCMD) && defined(FEAT_EVAL)
 	if (saved_oldval != NULL)
 	{

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -29,6 +29,19 @@ function! Test_isfname()
   set isfname&
 endfunction
 
+function Test_wildchar()
+  " Empty 'wildchar' used to access invalid memory.
+  call assert_fails('set wildchar=', 'E521:')
+  call assert_fails('set wildchar=abc', 'E521:')
+  set wildchar=<Esc>
+  let a=execute('set wildchar?')
+  call assert_equal("\n  wildchar=<Esc>", a)
+  set wildchar=27
+  let a=execute('set wildchar?')
+  call assert_equal("\n  wildchar=<Esc>", a)
+  set wildchar&
+endfunction
+
 function Test_options()
   let caught = 'ok'
   try


### PR DESCRIPTION
This PR fixes invalid memory access in vim-8.0.363 and older when
trying to set an empty value for the 'wildchar' option. Bug was found
using afl-fuzz.  

Step to reproduce:
```
$ valgrind vim -u NONE -c 'set wildchar=' 2> log
```
And log file contains:

```
==18780== Memcheck, a memory error detector
==18780== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==18780== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==18780== Command: vim -u NONE -c set\ wildchar=
==18780== 
==18780== Invalid read of size 1
==18780==    at 0x4F7F76: do_set (option.c:4601)
==18780==    by 0x46A044: do_one_cmd (ex_docmd.c:2981)
==18780==    by 0x46A044: do_cmdline (ex_docmd.c:1120)
==18780==    by 0x5AF69B: exe_commands (main.c:2905)
==18780==    by 0x5AF69B: vim_main2 (main.c:781)
==18780==    by 0x40B5B5: main (main.c:415)
==18780==  Address 0x852a41e is 0 bytes after a block of size 14 alloc'd
==18780==    at 0x4C2ABF5: malloc (vg_replace_malloc.c:299)
==18780==    by 0x4C254B: lalloc (misc2.c:942)
==18780==    by 0x4C2F4D: alloc (misc2.c:840)
==18780==    by 0x4C2F4D: vim_strsave (misc2.c:1285)
==18780==    by 0x46ADB7: do_cmdline (ex_docmd.c:1050)
==18780==    by 0x5AF69B: exe_commands (main.c:2905)
==18780==    by 0x5AF69B: vim_main2 (main.c:781)
==18780==    by 0x40B5B5: main (main.c:415)
```