### PR TITLE
Added tests for Arabic mode

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2092,6 +2092,7 @@ test1 \
 
 # Run individual NEW style test, assuming that Vim was already compiled.
 test_arglist \
+	test_arabic \
 	test_assert \
 	test_assign \
 	test_autochdir \

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -133,7 +133,8 @@ SCRIPTS_GUI =
 
 # Tests using runtest.vim.vim.
 # Keep test_alot*.res as the last one, sort the others.
-NEW_TESTS = test_arglist.res \
+NEW_TESTS = test_arabic.res \
+	    test_arglist.res \
 	    test_assert.res \
 	    test_autochdir.res \
 	    test_backspace_opt.res \

--- a/src/testdir/test_arabic.vim
+++ b/src/testdir/test_arabic.vim
@@ -1,0 +1,78 @@
+" Simplistic testing of Arabic mode.
+
+if !has('arabic')
+  finish
+endif
+
+set encoding=utf-8
+scriptencoding utf-8
+
+" Return list of utf8 sequences of each character at line lnum.
+" Combining characters are treated as a single item.
+func GetCharsUtf8(lnum)
+  call cursor(a:lnum, 1)
+  let chars=[]
+  let numchars=strchars(getline('.'), 1)
+  for i in range(1, numchars)
+    exe 'norm ' i . '|'
+    call add(chars, execute('norm g8'))
+  endfor
+  return chars
+endfunc
+
+func Test_arabic_toggle()
+  set arabic
+  call assert_equal(1, &rightleft)
+  call assert_equal(1, &arabicshape)
+  call assert_equal('arabic', &keymap)
+  call assert_equal(1, &delcombine)
+  set arabic&
+endfunc
+
+func Test_arabic_input()
+  new
+  set arabic
+  " Typing sghl in Arabic insert mode should show the
+  " Arabic word 'Salaam' i.e. 'peace'.
+  call feedkeys('isghl', 'tx')
+  call assert_equal([
+  \ "\nd8 b3 ",
+  \ "\nd9 84 + d8 a7 ",
+  \ "\nd9 85 "], GetCharsUtf8(1))
+
+  " Without shaping, it should give individual Arabic letters.
+  set noarabicshape
+  call assert_equal([
+  \ "\nd8 b3 ",
+  \ "\nd9 84 ",
+  \ "\nd8 a7 ",
+  \ "\nd9 85 "], GetCharsUtf8(1))
+
+  set arabicshape&
+  set arabic&
+  bwipe!
+endfunc
+
+func Test_arabic_toggle_keymap()
+  new
+  set arabic
+  call feedkeys("i12\<C-^>12\<C-^>12", 'tx')
+  call assert_equal('١٢12١٢', getline('.'))
+  set arabic&
+  bwipe!
+endfunc
+
+func Test_delcombine()
+  new
+  set arabic
+  call feedkeys("isghl\<BS>\<BS>", 'tx')
+  call assert_equal(["\nd8 b3 ", "\nd9 84 "], GetCharsUtf8(1))
+
+  " Now the same with nodelcombine
+  set nodelcombine
+  %d
+  call feedkeys("isghl\<BS>\<BS>", 'tx')
+  call assert_equal(["\nd8 b3 "], GetCharsUtf8(1)) 
+  set arabic&
+  bwipe!
+endfunc

--- a/src/testdir/test_arabic.vim
+++ b/src/testdir/test_arabic.vim
@@ -35,6 +35,7 @@ func Test_arabic_input()
   " Typing sghl in Arabic insert mode should show the
   " Arabic word 'Salaam' i.e. 'peace'.
   call feedkeys('isghl', 'tx')
+  redraw
   call assert_equal([
   \ "\nd8 b3 ",
   \ "\nd9 84 + d8 a7 ",
@@ -42,6 +43,7 @@ func Test_arabic_input()
 
   " Without shaping, it should give individual Arabic letters.
   set noarabicshape
+  redraw
   call assert_equal([
   \ "\nd8 b3 ",
   \ "\nd9 84 ",
@@ -57,6 +59,7 @@ func Test_arabic_toggle_keymap()
   new
   set arabic
   call feedkeys("i12\<C-^>12\<C-^>12", 'tx')
+  redraw
   call assert_equal('١٢12١٢', getline('.'))
   set arabic&
   bwipe!
@@ -66,6 +69,7 @@ func Test_delcombine()
   new
   set arabic
   call feedkeys("isghl\<BS>\<BS>", 'tx')
+  redraw
   call assert_equal(["\nd8 b3 ", "\nd9 84 "], GetCharsUtf8(1))
 
   " Now the same with nodelcombine


### PR DESCRIPTION
This PR adds tests for Arabic mode.
Test coverage was 0% in arabic.c prior to this change according to coveralls.
I don't speak Arabic, so tests are basic.