### PR TITLE
Redraw screen if completion causes horizontal scrolling

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -5098,6 +5098,14 @@ ins_complete(int c, int enable_pum)
     int		save_w_wrow;
     int		insert_match;
     int		save_did_ai = did_ai;
+    static win_T    *lastwin = NULL;
+    static colnr_T  lastcol = 0;
+
+    if (lastwin != curwin)
+    {
+	lastwin = curwin;
+	lastcol = curwin->w_leftcol;
+    }
 
     compl_direction = ins_compl_key2dir(c);
     insert_match = ins_compl_use_match(c);
@@ -5696,6 +5704,11 @@ ins_complete(int c, int enable_pum)
     }
     compl_was_interrupted = compl_interrupted;
     compl_interrupted = FALSE;
+
+    if (lastcol != curwin->w_leftcol) {
+	redraw_later(CLEAR);
+	lastcol = curwin->w_leftcol;
+    }
 
     return OK;
 }


### PR DESCRIPTION
Issue brought up on Neovim: https://github.com/neovim/neovim/issues/6184

When the popup menu is displayed over an adjacent window and a completion causes the window to scroll horizontally to center the cursor, the previous popup area is not redrawn.

Wasn't sure if there's a smarter way to do this, but I think a screen clear is sufficient considering that this *shouldn't* happen often under normal circumstances.

Before:

![before](https://cloud.githubusercontent.com/assets/111942/23390848/8a68c8b6-fd3e-11e6-88f8-447b55b6474a.gif)

After:

![after](https://cloud.githubusercontent.com/assets/111942/23439666/c07db298-fde5-11e6-99b8-9319becf3532.gif)