### PR TITLE
Recognize haskell, javascript, and scala by shebang

### DIFF
--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -124,6 +124,10 @@ if s:line1 =~ "^#!"
   elseif s:name =~ 'ruby'
     set ft=ruby
 
+    " JavaScript
+  elseif s:name =~ 'node\>' || s:name =~ 'nodejs\>' || s:name =~ 'rhino\>'
+    set ft=javascript
+
     " BC calculator
   elseif s:name =~ '^bc\>'
     set ft=bc

--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -164,6 +164,10 @@ if s:line1 =~ "^#!"
   elseif s:name =~ 'haskell'
     set ft=haskell
 
+    " Scala
+  elseif s:name =~ 'scala\>'
+    set ft=scala
+
   endif
   unlet s:name
 

--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -160,6 +160,10 @@ if s:line1 =~ "^#!"
   elseif s:name =~ 'escript'
     set ft=erlang
 
+    " Haskell
+  elseif s:name =~ 'haskell'
+    set ft=haskell
+
   endif
   unlet s:name
 


### PR DESCRIPTION
This pull request adds support for recognizing shebang lines for the haskell, javascript, and scala filetypes to runtime/scripts.vim.  The individual commit messages provide more context about the supported interpreters and matching rationale.  Let me know if you would prefer a different matching order (I assumed it was in rough popularity order) or if you require any more justification for popularity or anything else.

Thanks for considering,
Kevin