### PR TITLE
Ensure v:progpath is set to an absolute path

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1784,14 +1784,9 @@ v:progname	Contains the name (with path removed) with which Vim was
 		Read-only.
 
 					*v:progpath* *progpath-variable*
-v:progpath	Contains the command with which Vim was invoked, including the
-		path.  Useful if you want to message a Vim server using a
+v:progpath	Contains the absolute path of the command with which Vim was
+		invoked.  Useful if you want to message a Vim server using a
 		|--remote-expr|.
-		To get the full path use: >
-			echo exepath(v:progpath)
-<		If the path is relative it will be expanded to the full path,
-		so that it still works after `:cd`. Thus starting "./vim"
-		results in "/home/user/path/to/vim/src/vim".
 		On MS-Windows the executable may be called "vim.exe", but the
 		".exe" is not added to v:progpath.
 		Read-only.

--- a/src/main.c
+++ b/src/main.c
@@ -3533,21 +3533,17 @@ time_msg(
 set_progpath(char_u *argv0)
 {
     char_u *val = argv0;
-    char_u buf[MAXPATHL];
+    char_u *buf = NULL;
 
     /* A relative path containing a "/" will become invalid when using ":cd",
      * turn it into a full path.
      * On MS-Windows "vim.exe" is found in the current directory, thus also do
      * it when there is no path and the file exists. */
-    if ( !mch_isFullName(argv0)
-# ifdef WIN32
-	    && mch_can_exe(argv0, NULL, TRUE)
-# else
-	    && gettail(argv0) != argv0
-# endif
-	    && vim_FullName(argv0, buf, MAXPATHL, TRUE) != FAIL)
+    if (!mch_isFullName(argv0) && mch_can_exe(argv0, &buf, TRUE) == TRUE)
 	val = buf;
     set_vim_var_string(VV_PROGPATH, val, -1);
+    if (buf != NULL)
+	vim_free(buf);
 }
 
 #endif /* NO_VIM_MAIN */

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -3103,7 +3103,8 @@ mch_can_exe(char_u *name, char_u **path, int use_path)
 	{
 	    if (path != NULL)
 	    {
-		if (name[0] == '.')
+		if (name[0] == '.'
+		    || (name[0] != '/' && vim_strchr(name, '/') != NULL))
 		    *path = FullName_save(name, TRUE);
 		else
 		    *path = vim_strsave(name);
@@ -3142,7 +3143,8 @@ mch_can_exe(char_u *name, char_u **path, int use_path)
 	{
 	    if (path != NULL)
 	    {
-		if (buf[0] == '.')
+		if (buf[0] == '.'
+		    || (buf[0] != '/' && vim_strchr(buf, '/') != NULL))
 		    *path = FullName_save(buf, TRUE);
 		else
 		    *path = vim_strsave(buf);


### PR DESCRIPTION
This just uses the existing logic in mch_can_exe to populate a buffer with the
absolute path to the binary.  The Windows code was already walking
$PATH, so it seems pointless not to actually use the information.

There's no reason not to behave the same way on non-Windows platforms,
so change the code to always use mch_can_exe.  With a small fix to how
mch_can_exe determines whether FullName_save is needed.