### PR TITLE
Modify '\%V' example

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -871,7 +871,7 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 	This is a |/zero-width| match.  To make sure the whole pattern is
 	inside the Visual area put it at the start and end of the pattern,
 	e.g.: >
-		/\%Vfoo.*bar\%V
+		/\%Vfoo.*ba\%Vr
 <	Only works for the current buffer.
 
 						*/\%#* *cursor-position*


### PR DESCRIPTION
The example of `\%V` in help-doc does not work.

`vim -Nu NONE`

```vim
set wrapscan
" input 'foo123bar'
normal ifoo123bar
" set visual area 'foo123bar'
normal 0ve
/\%Vfoo.*bar\%V
```

`E486: Pattern not found: \%Vfoo.*bar\%V`

but pattern `/\%Vfoo.*ba\%Vr` matches.

**NOTE:** Actually, `\%V` matches the following cases:

* the next char of `\%V` is in Visual area; `\%Va`means `a` is in Visual area
* otherwise (`\%V` is a trailing of the pattern), works as if the next char is `.` (i.e. `\%V.`)

Other zero-width atoms also behave the same way. 