### PR TITLE
A few fixes to the Scala support files

### DIFF
--- a/runtime/indent/scala.vim
+++ b/runtime/indent/scala.vim
@@ -412,24 +412,24 @@ function! GetScalaIndent()
     if prevline =~ '^\s*\.'
       return ind
     else
-      return ind + &shiftwidth
+      return ind + shiftwidth()
     endif
   endif
 
   " Indent html literals
   if prevline !~ '/>\s*$' && prevline =~ '^\s*<[a-zA-Z][^>]*>\s*$'
     call scala#ConditionalConfirm("3")
-    return ind + &shiftwidth
+    return ind + shiftwidth()
   endif
 
   " assumes curly braces around try-block
   if curline =~ '^\s*}\s*\<catch\>'
-    return ind - &shiftwidth
+    return ind - shiftwidth()
   elseif curline =~ '^\s*\<catch\>'
     return ind
   endif
 
-  " Add a 'shiftwidth' after lines that start a block
+  " Add a shiftwidth()' after lines that start a block
   " If 'if', 'for' or 'while' end with ), this is a one-line block
   " If 'val', 'var', 'def' end with =, this is a one-line block
   if (prevline =~ '^\s*\<\%(\%(}\?\s*else\s\+\)\?if\|for\|while\)\>.*[)=]\s*$' && scala#NumberOfBraceGroups(prevline) <= 1)
@@ -438,7 +438,7 @@ function! GetScalaIndent()
         \ || prevline =~ '^\s*\%(}\s*\)\?\<else\>\s*$'
         \ || prevline =~ '=\s*$'
     call scala#ConditionalConfirm("4")
-    let ind = ind + &shiftwidth
+    let ind = ind + shiftwidth()
   elseif prevline =~ '^\s*\<\%(}\?\s*else\s\+\)\?if\>' && curline =~ '^\s*}\?\s*\<else\>'
     return ind
   endif
@@ -447,7 +447,7 @@ function! GetScalaIndent()
   let bracketCount = scala#CountBrackets(prevline, '{', '}')
   if bracketCount > 0 || prevline =~ '.*{\s*$'
     call scala#ConditionalConfirm("5b")
-    let ind = ind + &shiftwidth
+    let ind = ind + shiftwidth()
   elseif bracketCount < 0
     call scala#ConditionalConfirm("6b")
     " if the closing brace actually completes the braces entirely, then we
@@ -475,7 +475,7 @@ function! GetScalaIndent()
     let bracketCount = scala#CountBrackets(prevline, '(', ')')
     if bracketCount > 0 || prevline =~ '.*(\s*$'
       call scala#ConditionalConfirm("5a")
-      let ind = ind + &shiftwidth
+      let ind = ind + shiftwidth()
     elseif bracketCount < 0
       call scala#ConditionalConfirm("6a")
       " if the closing brace actually completes the braces entirely, then we
@@ -497,7 +497,7 @@ function! GetScalaIndent()
       else
         " This is the only part that's different from from the '{', '}' one below
         " Yup... some refactoring is necessary at some point.
-        let ind = ind + (bracketCount * &shiftwidth)
+        let ind = ind + (bracketCount * shiftwidth())
         let lineCompletedBrackets = 1
       endif
     endif
@@ -506,10 +506,10 @@ function! GetScalaIndent()
   if curline =~ '^\s*}\?\s*\<else\>\%(\s\+\<if\>\s*(.*)\)\?\s*{\?\s*$' &&
    \ ! scala#LineIsCompleteIf(prevline) &&
    \ prevline !~ '^.*}\s*$'
-    let ind = ind - &shiftwidth
+    let ind = ind - shiftwidth()
   endif
 
-  " Subtract a 'shiftwidth' on '}' or html
+  " Subtract a shiftwidth()' on '}' or html
   let curCurlyCount = scala#CountCurlies(curline)
   if curCurlyCount < 0
     call scala#ConditionalConfirm("14a")
@@ -517,7 +517,7 @@ function! GetScalaIndent()
     return indent(matchline)
   elseif curline =~ '^\s*</[a-zA-Z][^>]*>'
     call scala#ConditionalConfirm("14c")
-    return ind - &shiftwidth
+    return ind - shiftwidth()
   endif
 
   let prevParenCount = scala#CountParens(prevline)
@@ -529,7 +529,7 @@ function! GetScalaIndent()
   let prevCurlyCount = scala#CountCurlies(prevline)
   if prevCurlyCount == 0 && prevline =~ '^.*\%(=>\|⇒\)\s*$' && prevline !~ '^\s*this\s*:.*\%(=>\|⇒\)\s*$' && curline !~ '^\s*\<case\>'
     call scala#ConditionalConfirm("16")
-    let ind = ind + &shiftwidth
+    let ind = ind + shiftwidth()
   endif
 
   if ind == originalIndentValue && curline =~ '^\s*\<case\>'
@@ -555,7 +555,7 @@ function! GetScalaIndent()
   if scala#LineIsAClosingXML(prevline)
     if scala#LineCompletesXML(prevlnum, prevline)
       call scala#ConditionalConfirm("20a")
-      return ind - &shiftwidth
+      return ind - shiftwidth()
     else
       call scala#ConditionalConfirm("20b")
       return ind
@@ -566,7 +566,7 @@ function! GetScalaIndent()
     "let indentMultiplier = scala#LineCompletesDefValr(prevlnum, prevline)
     "if indentMultiplier != 0
     "  call scala#ConditionalConfirm("19a")
-    "  let ind = ind - (indentMultiplier * &shiftwidth)
+    "  let ind = ind - (indentMultiplier * shiftwidth())
     let defValrLine = scala#Test(prevlnum, prevline, '{', '}')
     if defValrLine != -1
       call scala#ConditionalConfirm("21a")
@@ -575,10 +575,10 @@ function! GetScalaIndent()
       call scala#ConditionalConfirm("21b")
       if scala#GetLine(prevnonblank(prevlnum - 1)) =~ '^.*\<else\>\s*\%(//.*\)\?$'
         call scala#ConditionalConfirm("21c")
-        let ind = ind - &shiftwidth
+        let ind = ind - shiftwidth()
       elseif scala#LineCompletesIfElse(prevlnum, prevline)
         call scala#ConditionalConfirm("21d")
-        let ind = ind - &shiftwidth
+        let ind = ind - shiftwidth()
       elseif scala#CountParens(curline) < 0 && curline =~ '^\s*)' && scala#GetLine(scala#GetLineThatMatchesBracket('(', ')')) =~ '.*(\s*$'
         " Handles situations that look like this:
         "
@@ -592,7 +592,7 @@ function! GetScalaIndent()
         "     10
         "   ).somethingHere()
         call scala#ConditionalConfirm("21e")
-        let ind = ind - &shiftwidth
+        let ind = ind - shiftwidth()
       endif
     endif
   endif

--- a/runtime/syntax/scala.vim
+++ b/runtime/syntax/scala.vim
@@ -71,6 +71,8 @@ hi link scalaUnicodeChar Special
 
 syn match scalaOperator "||"
 syn match scalaOperator "&&"
+syn match scalaOperator "|"
+syn match scalaOperator "&"
 hi link scalaOperator Special
 
 syn match scalaNameDefinition /\<[_A-Za-z0-9$]\+\>/ contained nextgroup=scalaPostNameDefinition,scalaVariableDeclarationList
@@ -142,7 +144,7 @@ hi link scalaString String
 hi link scalaStringEmbeddedQuote String
 
 syn region scalaIString matchgroup=scalaInterpolationBrackets start=/\<[a-zA-Z][a-zA-Z0-9_]*"/ skip=/\\"/ end=/"/ contains=scalaInterpolation,scalaInterpolationB,scalaEscapedChar,scalaUnicodeChar
-syn region scalaTripleIString matchgroup=scalaInterpolationBrackets start=/\<[a-zA-Z][a-zA-Z0-9_]*"""/ end=/"""\%([^"]\|$\)/ contains=scalaInterpolation,scalaInterpolationB,scalaEscapedChar,scalaUnicodeChar
+syn region scalaTripleIString matchgroup=scalaInterpolationBrackets start=/\<[a-zA-Z][a-zA-Z0-9_]*"""/ end=/"""\ze\%([^"]\|$\)/ contains=scalaInterpolation,scalaInterpolationB,scalaEscapedChar,scalaUnicodeChar
 hi link scalaIString String
 hi link scalaTripleIString String
 


### PR DESCRIPTION
- Add syntax support for `&` and `|`
  - @RatanRSur: https://github.com/derekwyatt/vim-scala/pull/137/files
- Use `shiftwidth()` instead of `&shiftwidth`
  - @tyru: https://github.com/derekwyatt/vim-scala/pull/136/files
- Stop highlighting the character following the closing `"""`