### PR TITLE
Allow NSE scripts to have syntax highlighting.

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1366,6 +1366,9 @@ endfunc
 " Not Quite C
 au BufNewFile,BufRead *.nqc			setf nqc
 
+" NSE
+au BufNewFile,BufRead *.nse			setf lua
+
 " NSIS
 au BufNewFile,BufRead *.nsi,*.nsh		setf nsis
 


### PR DESCRIPTION
nmap uses Lua for it's [scripting engine](https://nmap.org/book/nse.html) so it would be nice to have those automatically highlighted as Lua scripts.