### PR TITLE
Use ShellExecute in !start

### DIFF
--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -1,4 +1,4 @@
-*os_win32.txt*  For Vim version 8.0.  Last change: 2016 Oct 12
+*os_win32.txt*  For Vim version 8.0.  Last change: 2017 Mar 19
 
 
 		  VIM REFERENCE MANUAL    by George Reilly
@@ -212,10 +212,18 @@ A. You can't!  This is a limitation of the NT console.  NT 5.0 is reported to
    be able to set the blink rate for all console windows at the same time.
 
 							*:!start*
-Q. How can I run an external command or program asynchronously?
+Q. How can I asynchronously run an external command or program, or open a
+   document or URL with default program?
 A. When using :! to run an external command, you can run it with "start": >
-	:!start winfile.exe<CR>
-<  Using "start" stops Vim switching to another screen, opening a new console,
+	:!start notepad<CR>
+        :!start image.jpg<CR>
+        :!start %:h<CR>
+        :!start http://www.vim.org/<CR>
+<  The first command runs notepad, the second one opens image.jpg with default
+   image viewer, the third one opens current folder with Windows Explorer, the
+   forth one opens Vim home page with default browser.
+
+   Using "start" stops Vim switching to another screen, opening a new console,
    or waiting for the program to complete; it indicates that you are running a
    program that does not affect the files you are editing.  Programs begun
    with :!start do not get passed Vim's open file handles, which means they do


### PR DESCRIPTION
ShellExecute Win32 API enables `:!start <filename>` open a file with default app.
For example, `:!start index.html` make the default browser open index.html.