### PR TITLE
Fix crash with :cd command and very long path + add test

### DIFF
--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -3,6 +3,7 @@
 
 set belloff=all
 source test_assign.vim
+source test_cd.vim
 source test_changedtick.vim
 source test_cursor_func.vim
 source test_delete.vim

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -1,6 +1,6 @@
 " Test for :cd
 
 func Test_cd_large_path()
-  " This used crash with heap write overflow.
+  " This used to crash with a heap write overflow.
   call assert_fails('cd ' . repeat('x', 5000), 'E472:')
 endfunc

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -1,0 +1,6 @@
+" Test for :cd
+
+func Test_cd_large_path()
+  " This used crash with heap write overflow.
+  call assert_fails('cd ' . repeat('x', 5000), 'E472:')
+endfunc


### PR DESCRIPTION
This PR fixes a crash in Vim-8.0.485 and older when doing 
":cd" with a very long path name, and adds a test for it.

Step to reproduce:
```
$ vim -u NONE -c 'exe "cd " . repeat("x", 5000)'
Vim: Caught deadly signal SEGV
Vim: Finished.
Segmentation fault (core dumped)
```
Bug was discovered with afl-fuzz.