### PR TITLE
Replace (*mb_char2len)(c) with utf_char2len(c) where possible

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -315,7 +315,7 @@ trunc_string(
 	for (;;)
 	{
 	    do
-		half = half - (*mb_head_off)(s, s + half - 1) - 1;
+		half = half - utf_head_off(s, s + half - 1) - 1;
 	    while (half > 0 && utf_iscomposing(utf_ptr2char(s + half)));
 	    n = ptr2cells(s + half);
 	    if (len + n > room || half == 0)

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1874,7 +1874,7 @@ vim_strchr(char_u *string, int c)
     {
 	while (*p != NUL)
 	{
-	    int l = (*mb_ptr2len)(p);
+	    int l = utfc_ptr2len(p);
 
 	    /* Avoid matching an illegal byte here. */
 	    if (utf_ptr2char(p) == c && l > 1)

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -4732,7 +4732,7 @@ regmatch(
 		    break;
 		}
 		if (enc_utf8)
-		    opndc = mb_ptr2char(opnd);
+		    opndc = utf_ptr2char(opnd);
 		if (enc_utf8 && utf_iscomposing(opndc))
 		{
 		    /* When only a composing char is given match at any
@@ -4741,7 +4741,7 @@ regmatch(
 		    for (i = 0; reginput[i] != NUL;
 						i += utf_ptr2len(reginput + i))
 		    {
-			inpc = mb_ptr2char(reginput + i);
+			inpc = utf_ptr2char(reginput + i);
 			if (!utf_iscomposing(inpc))
 			{
 			    if (i > 0)
@@ -4750,7 +4750,7 @@ regmatch(
 			else if (opndc == inpc)
 			{
 			    /* Include all following composing chars. */
-			    len = i + mb_ptr2len(reginput + i);
+			    len = i + utfc_ptr2len(reginput + i);
 			    status = RA_MATCH;
 			    break;
 			}

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1974,7 +1974,7 @@ collection:
 nfa_do_multibyte:
 		/* plen is length of current char with composing chars */
 		if (enc_utf8 && ((*mb_char2len)(c)
-			    != (plen = (*mb_ptr2len)(old_regparse))
+			    != (plen = utfc_ptr2len(old_regparse))
 						       || utf_iscomposing(c)))
 		{
 		    int i = 0;

--- a/src/screen.c
+++ b/src/screen.c
@@ -4116,7 +4116,7 @@ win_line(
 		c = c_extra;
 #ifdef FEAT_MBYTE
 		mb_c = c;	/* doesn't handle non-utf-8 multi-byte! */
-		if (enc_utf8 && (*mb_char2len)(c) > 1)
+		if (enc_utf8 && utf_char2len(c) > 1)
 		{
 		    mb_utf8 = TRUE;
 		    u8cc[0] = 0;
@@ -4137,7 +4137,7 @@ win_line(
 		    {
 			/* If the UTF-8 character is more than one byte:
 			 * Decode it into "mb_c". */
-			mb_l = (*mb_ptr2len)(p_extra);
+			mb_l = utfc_ptr2len(p_extra);
 			mb_utf8 = FALSE;
 			if (mb_l > n_extra)
 			    mb_l = 1;
@@ -4216,7 +4216,7 @@ win_line(
 		{
 		    /* If the UTF-8 character is more than one byte: Decode it
 		     * into "mb_c". */
-		    mb_l = (*mb_ptr2len)(ptr);
+		    mb_l = utfc_ptr2len(ptr);
 		    mb_utf8 = FALSE;
 		    if (mb_l > 1)
 		    {
@@ -4609,7 +4609,7 @@ win_line(
 		    }
 #ifdef FEAT_MBYTE
 		    mb_c = c;
-		    if (enc_utf8 && (*mb_char2len)(c) > 1)
+		    if (enc_utf8 && utf_char2len(c) > 1)
 		    {
 			mb_utf8 = TRUE;
 			u8cc[0] = 0;
@@ -4631,7 +4631,7 @@ win_line(
 		    }
 #ifdef FEAT_MBYTE
 		    mb_c = c;
-		    if (enc_utf8 && (*mb_char2len)(c) > 1)
+		    if (enc_utf8 && utf_char2len(c) > 1)
 		    {
 			mb_utf8 = TRUE;
 			u8cc[0] = 0;
@@ -4762,7 +4762,7 @@ win_line(
 			saved_attr2 = char_attr; /* save current attr */
 #ifdef FEAT_MBYTE
 			mb_c = c;
-			if (enc_utf8 && (*mb_char2len)(c) > 1)
+			if (enc_utf8 && utf_char2len(c) > 1)
 			{
 			    mb_utf8 = TRUE;
 			    u8cc[0] = 0;
@@ -4836,7 +4836,7 @@ win_line(
 		    }
 #ifdef FEAT_MBYTE
 		    mb_c = c;
-		    if (enc_utf8 && (*mb_char2len)(c) > 1)
+		    if (enc_utf8 && utf_char2len(c) > 1)
 		    {
 			mb_utf8 = TRUE;
 			u8cc[0] = 0;
@@ -5000,7 +5000,7 @@ win_line(
 		}
 # ifdef FEAT_MBYTE
 		mb_c = c;
-		if (enc_utf8 && (*mb_char2len)(c) > 1)
+		if (enc_utf8 && utf_char2len(c) > 1)
 		{
 		    mb_utf8 = TRUE;
 		    u8cc[0] = 0;
@@ -5107,7 +5107,7 @@ win_line(
 		extra_attr = HL_ATTR(HLF_AT);
 	    }
 	    mb_c = c;
-	    if (enc_utf8 && (*mb_char2len)(c) > 1)
+	    if (enc_utf8 && utf_char2len(c) > 1)
 	    {
 		mb_utf8 = TRUE;
 		u8cc[0] = 0;
@@ -5380,7 +5380,7 @@ win_line(
 	    char_attr = HL_ATTR(HLF_AT);
 #ifdef FEAT_MBYTE
 	    mb_c = c;
-	    if (enc_utf8 && (*mb_char2len)(c) > 1)
+	    if (enc_utf8 && utf_char2len(c) > 1)
 	    {
 		mb_utf8 = TRUE;
 		u8cc[0] = 0;

--- a/src/spell.c
+++ b/src/spell.c
@@ -1208,7 +1208,7 @@ can_compound(slang_T *slang, char_u *word, char_u *flags)
 	/* Need to convert the single byte flags to utf8 characters. */
 	p = uflags;
 	for (i = 0; flags[i] != NUL; ++i)
-	    p += mb_char2bytes(flags[i], p);
+	    p += utf_char2bytes(flags[i], p);
 	*p = NUL;
 	p = uflags;
     }
@@ -5117,11 +5117,11 @@ suggest_trie_walk(
 				 * SCORE_SUBCOMP. */
 				if (enc_utf8
 					&& utf_iscomposing(
-					    mb_ptr2char(tword
+					    utf_ptr2char(tword
 						+ sp->ts_twordlen
 							   - sp->ts_tcharlen))
 					&& utf_iscomposing(
-					    mb_ptr2char(fword
+					    utf_ptr2char(fword
 							+ sp->ts_fcharstart)))
 				    sp->ts_score -=
 						  SCORE_SUBST - SCORE_SUBCOMP;


### PR DESCRIPTION
This PR changes calls like (*mb_char2len)(c) into utf_char2len(c) wherever
we know that enc_utf8 is true.  That's already done in Vim source code in 
several places, but not systematically.

It should be a bit faster in theory.  Admittedly, I did not see any measurable
difference in speed, so I hesitated to push this this change.  But since I didn't
see any drawback, I created the PR. Perhaps it makes more difference
in speed when building vim with -fwhole-program as calling (*mb_char2len)(c)
with a function pointer should prevent interprocedural optimizations unlike
calling utf_char2len(c) directly.