### PR TITLE
Fix ins-completion that was slowed down by 8.0.0050

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -511,7 +511,7 @@ mch_inchar(
 		|| interrupted
 #endif
 		|| wait_time > 0
-		|| !did_start_blocking)
+		|| wtime < 0 && !did_start_blocking)
 	    continue;
 
 	/* no character available or interrupted */


### PR DESCRIPTION
Since 8.0.0050, an extra waiting occurs when reading completion candidates from other files in ins-completion.

* Example(compl-dictionary)

  ![ctrl-x_ctrl-k](https://cloud.githubusercontent.com/assets/1222926/24319595/c77b1fcc-1163-11e7-8667-04d8804a8a39.gif)

Therefore, fixed the conditional statement so that the waiting does not occur.
This patch was advised by @h-east .

Ref: vim-jp/issues#1040