### PR TITLE
Clean-up make_cmdidxs.pl

### DIFF
--- a/src/create_cmdidxs.pl
+++ b/src/create_cmdidxs.pl
@@ -9,15 +9,17 @@
 # Script should be run every time new Ex commands are added in Vim,
 # from the src/vim directory, since it reads commands from "ex_cmds.h".
 
+use strict;
+
 # Find the list of Vim commands from cmdnames[] table in ex_cmds.h
 my @cmds;
-my @skipped;
+my $skipped_cmds;
 open(IN, "< ex_cmds.h") or die "can't open ex_cmds.h: $!\n";
 while (<IN>) {
   if (/^EX\(CMD_\S*,\s*"([a-z][^"]*)"/) {
-    push (@cmds, $1);
+    push @cmds, $1;
   } elsif (/^EX\(CMD_/) {
-    push (@skipped, $1);
+    ++$skipped_cmds;
   }
 }
 
@@ -68,7 +70,6 @@ for my $c1 ('a' .. 'z') {
 }
 print "};\n",
       "\n",
-      "static int command_count = ", $#cmds + $#skipped + 2 , ";\n",
+      "static const int command_count = ", scalar(@cmds) + $skipped_cmds, ";\n",
       "\n",
       "/* End of automatically generated code by create_cmdidxs.pl */\n";
-

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -566,7 +566,7 @@ static const unsigned char cmdidxs2[26][26] =
   /* z */ {  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, }
 };
 
-static int command_count = 539;
+static const int command_count = 539;
 
 /* End of automatically generated code by create_cmdidxs.pl */
 


### PR DESCRIPTION
This PR does a minor cleanup in script create_cmdidxs.pl:
* script was pushing irrelevant value $1 in an array @skipped,
  whereas we only need to count skipped commands.
*  script had an odd magic value 2 to compute command_count
   which is not needed if we compute value differently.
* it also adds a 'const' which is OK now that we use ANSI C.