### PR TITLE
Do not highlight the first matched entry in wildmenu

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4147,7 +4147,7 @@ showmatches(expand_T *xp, int wildmenu UNUSED)
 	got_int = FALSE;	/* only int. the completion, not the cmd line */
 #ifdef FEAT_WILDMENU
     else if (wildmenu)
-	win_redr_status_matches(xp, num_files, files_found, 0, showtail);
+	win_redr_status_matches(xp, num_files, files_found, -1, showtail);
 #endif
     else
     {


### PR DESCRIPTION
When we just want to show the matching items (eg: wim=longest:full,full
and the user presses <tab> for the first time) there's no need to
highlight the first item.