### PR TITLE
Adjust compiler/rst.vim for sphinx 1.5.1

### DIFF
--- a/runtime/compiler/rst.vim
+++ b/runtime/compiler/rst.vim
@@ -11,7 +11,11 @@ let current_compiler = "rst"
 let s:cpo_save = &cpo
 set cpo&vim
 
-setlocal errorformat=
+if exists(":CompilerSet") != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet errorformat=
       \%f\\:%l:\ %tEBUG:\ %m,
       \%f\\:%l:\ %tNFO:\ %m,
       \%f\\:%l:\ %tARNING:\ %m,

--- a/runtime/compiler/rst.vim
+++ b/runtime/compiler/rst.vim
@@ -1,5 +1,6 @@
 " Vim compiler file
-" Compiler:             reStructuredText Documentation Format
+" Compiler:             sphinx >= 1.0.8, http://www.sphinx-doc.org
+" Description:          reStructuredText Documentation Format
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2017-03-31
 

--- a/runtime/compiler/rst.vim
+++ b/runtime/compiler/rst.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:             reStructuredText Documentation Format
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2006-04-19
+" Latest Revision:      2017-03-31
 
 if exists("current_compiler")
   finish
@@ -12,11 +12,13 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal errorformat=
-      \%f:%l:\ (%tEBUG/0)\ %m,
-      \%f:%l:\ (%tNFO/1)\ %m,
-      \%f:%l:\ (%tARNING/2)\ %m,
-      \%f:%l:\ (%tRROR/3)\ %m,
-      \%f:%l:\ (%tEVERE/3)\ %m,
+      \%f\\:%l:\ %tEBUG:\ %m,
+      \%f\\:%l:\ %tNFO:\ %m,
+      \%f\\:%l:\ %tARNING:\ %m,
+      \%f\\:%l:\ %tRROR:\ %m,
+      \%f\\:%l:\ %tEVERE:\ %m,
+      \%f\\:%s:\ %tARNING:\ %m,
+      \%f\\:%s:\ %tRROR:\ %m,
       \%D%*\\a[%*\\d]:\ Entering\ directory\ `%f',
       \%X%*\\a[%*\\d]:\ Leaving\ directory\ `%f',
       \%DMaking\ %*\\a\ in\ %f


### PR DESCRIPTION
It seems that compiler/rst.vim has no active maintainer 
https://groups.google.com/d/msg/vim_dev/BcDThxEkwNA/n0Fqx9COAgAJ
so I am posting a proposed change here.  The new errorformat appears to work 
with output from sphinx 1.5.1 that is produced for one of my Python packages - 
see example in [sphinx-errors.txt](https://github.com/vim/vim/files/886026/sphinx-errors.txt).

I am however not sure if compiler/rst.vim is intended for sphinx or if it should also
work with some other rst documentation tool. 