### PR TITLE
Fix lnum overflow in :z command

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2239,6 +2239,7 @@ test_arglist \
 	test_window_cmd \
 	test_window_id \
 	test_writefile \
+	test_z \
 	test_alot_latin \
 	test_alot_utf8 \
 	test_alot:

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4602,7 +4602,10 @@ ex_z(exarg_T *eap)
 	else
 	{
 	    bigness = atol((char *)x);
-	    if (bigness > 2*curbuf->b_ml.ml_line_count)
+
+	    /* bigness could be < 0 if atol(x) overflows. */
+	    if (bigness > 2*curbuf->b_ml.ml_line_count ||
+						bigness < 0)
 		bigness = 2*curbuf->b_ml.ml_line_count;
 
 	    p_window = bigness;

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4564,7 +4564,7 @@ ex_change(exarg_T *eap)
 ex_z(exarg_T *eap)
 {
     char_u	*x;
-    int		bigness;
+    long	bigness;
     char_u	*kind;
     int		minus = 0;
     linenr_T	start, end, curs, i;
@@ -4601,7 +4601,7 @@ ex_z(exarg_T *eap)
 	}
 	else
 	{
-	    bigness = atoi((char *)x);
+	    bigness = atol((char *)x);
 	    p_window = bigness;
 	    if (*kind == '=')
 		bigness += 2;

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4602,6 +4602,9 @@ ex_z(exarg_T *eap)
 	else
 	{
 	    bigness = atol((char *)x);
+	    if (bigness > 2*curbuf->b_ml.ml_line_count)
+		bigness = 2*curbuf->b_ml.ml_line_count;
+
 	    p_window = bigness;
 	    if (*kind == '=')
 		bigness += 2;

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -53,3 +53,4 @@ source test_timers.vim
 source test_true_false.vim
 source test_unlet.vim
 source test_window_cmd.vim
+source test_z.vim

--- a/src/testdir/test_z.vim
+++ b/src/testdir/test_z.vim
@@ -26,7 +26,7 @@ func Test_z()
   call assert_equal(20, line('.'))
 
   let a=execute('20z=3')
-  call assert_match("\n18\n19\n-\\+\n20\n-\\+\n21\n22", a)
+  call assert_match("^\n18\n19\n-\\+\n20\n-\\+\n21\n22$", a)
   call assert_equal(20, line('.'))
 
   let a=execute('20z^3')
@@ -37,10 +37,6 @@ func Test_z()
   call assert_equal("\n19\n20\n21", a)
   call assert_equal(21, line('.'))
 
-  let a=execute('20z=1000')
-  call assert_match("\n1\n.*\n-\\+\n20\n-\\\+\n.*\n100", a)
-  call assert_equal(20, line('.'))
-
   let a=execute('20z#3')
   call assert_equal("\n 20 20\n 21 21\n 22 22", a)
   call assert_equal(22, line('.'))
@@ -50,7 +46,20 @@ func Test_z()
   call assert_equal(20, line('.'))
 
   let a=execute('20z#=3')
-  call assert_match("\n 18 18\n 19 19\n-\\+\n 20 20\n-\\+\n 21 21\n 22 22", a)
+  call assert_match("^\n 18 18\n 19 19\n-\\+\n 20 20\n-\\+\n 21 21\n 22 22$", a)
+  call assert_equal(20, line('.'))
+
+  " Test with {count} bigger than the number of lines in buffer.
+  let a=execute('20z1000')
+  call assert_match("^\n20\n21\n.*\n99\n100$", a)
+  call assert_equal(100, line('.'))
+
+  let a=execute('20z-1000')
+  call assert_match("^\n1\n2\n.*\n19\n20$", a)
+  call assert_equal(20, line('.'))
+
+  let a=execute('20z=1000')
+  call assert_match("^\n1\n.*\n-\\+\n20\n-\\\+\n.*\n100$", a)
   call assert_equal(20, line('.'))
 
   call assert_fails('20z=a', 'E144:')

--- a/src/testdir/test_z.vim
+++ b/src/testdir/test_z.vim
@@ -1,0 +1,69 @@
+" Test :z
+
+func Test_z()
+  call setline(1, range(1, 100))
+
+  let a=execute('20z3')
+  call assert_equal("\n20\n21\n22", a)
+  call assert_equal(22, line('.'))
+  " 'window' should be set to the {count} value.
+  call assert_equal(3, &window)
+
+  " If there is only one window, then twice the amount of 'scroll' is used.
+  set scroll=2
+  let a=execute('20z')
+  call assert_equal("\n20\n21\n22\n23", a)
+  call assert_equal(23, line('.'))
+
+  let a=execute('20z+3')
+  " FIXME: I would expect the same result as '20z3' but it
+  " gives "\n21\n22\n23" instead. Bug in Vim or in ":help :z"?
+  "call assert_equal("\n20\n21\n22", a)
+  "call assert_equal(22, line('.'))
+
+  let a=execute('20z-3')
+  call assert_equal("\n18\n19\n20", a)
+  call assert_equal(20, line('.'))
+
+  let a=execute('20z=3')
+  call assert_match("\n18\n19\n-\\+\n20\n-\\+\n21\n22", a)
+  call assert_equal(20, line('.'))
+
+  let a=execute('20z^3')
+  call assert_equal("\n14\n15\n16\n17", a)
+  call assert_equal(17, line('.'))
+
+  let a=execute('20z.3')
+  call assert_equal("\n19\n20\n21", a)
+  call assert_equal(21, line('.'))
+
+  let a=execute('20z=1000')
+  call assert_match("\n1\n.*\n-\\+\n20\n-\\\+\n.*\n100", a)
+  call assert_equal(20, line('.'))
+
+  let a=execute('20z#3')
+  call assert_equal("\n 20 20\n 21 21\n 22 22", a)
+  call assert_equal(22, line('.'))
+
+  let a=execute('20z#-3')
+  call assert_equal("\n 18 18\n 19 19\n 20 20", a)
+  call assert_equal(20, line('.'))
+
+  let a=execute('20z#=3')
+  call assert_match("\n 18 18\n 19 19\n-\\+\n 20 20\n-\\+\n 21 21\n 22 22", a)
+  call assert_equal(20, line('.'))
+
+  call assert_fails('20z=a', 'E144:')
+
+  set window& scroll&
+  bw!
+endfunc
+
+func Test_z_bug()
+  " This used to access invalid memory as a result of an integer overflow
+  " and freeze vim.
+  normal ox
+  normal Heat
+  z777777776666666
+  ')
+endfunc


### PR DESCRIPTION
This PR fixes a bug in the :z command, which causes access to invalid
memory and freezes vim, as a result of an integer overflow (line numbers
should use 'long', not 'int').

Step to reproduce the bug:

```
$ cat > bug-z.vim <<EOF
normal ox
normal Heat
z777777776666666
')
EOF
$ valgrind vim -u NONE -S bug-z.vim 2> vg.log
```

Observe that vim freezes (I have to kill it with "kill -9") and observe
valgrind errors in vg.log:

```
==23558== Memcheck, a memory error detector
==23558== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==23558== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==23558== Command: vim -u NONE -S bug-z.vim
==23558== 
==23558== Invalid read of size 1
==23558==    at 0x4E1BC0: utf_ptr2char (mbyte.c:1761)
==23558==    by 0x5747CA: findsent (search.c:2684)
==23558==    by 0x4B3395: getmark_buf_fnum (mark.c:394)
==23558==    by 0x470B16: get_address (ex_docmd.c:4576)
==23558==    by 0x4694D7: do_one_cmd (ex_docmd.c:2229)
==23558==    by 0x46710D: do_cmdline (ex_docmd.c:1160)
==23558==    by 0x465099: do_source (ex_cmds2.c:4313)
==23558==    by 0x4645F3: cmd_source (ex_cmds2.c:3926)
==23558==    by 0x46AF0F: do_one_cmd (ex_docmd.c:3021)
==23558==    by 0x46710D: do_cmdline (ex_docmd.c:1160)
==23558==    by 0x60906C: exe_commands (main.c:2913)
==23558==    by 0x60906C: vim_main2 (main.c:789)
==23558==    by 0x607974: main (main.c:418)
==23558==  Address 0xd5801e0 is 0 bytes after a block of size 4,096 alloc'd
==23558==    at 0x4C2ABF5: malloc (vg_replace_malloc.c:299)
==23558==    by 0x4D62B7: lalloc (misc2.c:942)
==23558==    by 0x60B365: mf_alloc_bhdr (memfile.c:907)
==23558==    by 0x60B365: mf_new (memfile.c:381)
==23558==    by 0x4B7574: ml_new_data (memline.c:3515)
==23558==    by 0x4B7574: ml_open (memline.c:400)
==23558==    by 0x4129C4: open_buffer (buffer.c:163)
==23558==    by 0x608BD4: create_windows (main.c:2685)
==23558==    by 0x608BD4: vim_main2 (main.c:712)
==23558==    by 0x607974: main (main.c:418)
==23558== 
==23558== Invalid read of size 1
==23558==    at 0x4D5C60: inc (misc2.c:355)
==23558==    by 0x4D5C60: incl (misc2.c:392)
==23558==    by 0x574825: findsent (search.c:2687)
==23558==    by 0x4B3395: getmark_buf_fnum (mark.c:394)
==23558==    by 0x470B16: get_address (ex_docmd.c:4576)
==23558==    by 0x4694D7: do_one_cmd (ex_docmd.c:2229)
==23558==    by 0x46710D: do_cmdline (ex_docmd.c:1160)
==23558==    by 0x465099: do_source (ex_cmds2.c:4313)
==23558==    by 0x4645F3: cmd_source (ex_cmds2.c:3926)
==23558==    by 0x46AF0F: do_one_cmd (ex_docmd.c:3021)
==23558==    by 0x46710D: do_cmdline (ex_docmd.c:1160)
==23558==    by 0x60906C: exe_commands (main.c:2913)
==23558==    by 0x60906C: vim_main2 (main.c:789)
==23558==    by 0x607974: main (main.c:418)
==23558==  Address 0xd5801e0 is 0 bytes after a block of size 4,096 alloc'd
==23558==    at 0x4C2ABF5: malloc (vg_replace_malloc.c:299)
==23558==    by 0x4D62B7: lalloc (misc2.c:942)
==23558==    by 0x60B365: mf_alloc_bhdr (memfile.c:907)
==23558==    by 0x60B365: mf_new (memfile.c:381)
==23558==    by 0x4B7574: ml_new_data (memline.c:3515)
==23558==    by 0x4B7574: ml_open (memline.c:400)
==23558==    by 0x4129C4: open_buffer (buffer.c:163)
==23558==    by 0x608BD4: create_windows (main.c:2685)
==23558==    by 0x608BD4: vim_main2 (main.c:712)
==23558==    by 0x607974: main (main.c:418)
==23558== 
```

Bug was discovered using afl-fuzz.