### PR TITLE
Fix parsing of ctags-generated etags files

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -2355,18 +2355,19 @@ parse_line:
 		}
 		else
 		{
-#define TAG_SEP 0x01
+#define TAG_SEP 0x02
 		    size_t tag_fname_len = STRLEN(tag_fname);
 #ifdef FEAT_EMACS_TAGS
 		    size_t ebuf_len = 0;
 #endif
 
 		    /* Save the tag in a buffer.
-		     * Use 0x01 to separate fields (Can't use NUL, because the
-		     * hash key is terminated by NUL).
-		     * Emacs tag: <mtt><tag_fname><0x01><ebuf><0x01><lbuf><NUL>
-		     * other tag: <mtt><tag_fname><0x01><0x01><lbuf><NUL>
-		     * without Emacs tags: <mtt><tag_fname><0x01><lbuf><NUL>
+		     * Use 0x02 to separate fields (Can't use NUL because the
+		     * hash key is terminated by NUL, or Ctrl_A because that is
+		     * part of some Emacs tag files -- see parse_tag_line).
+		     * Emacs tag: <mtt><tag_fname><0x02><ebuf><0x02><lbuf><NUL>
+		     * other tag: <mtt><tag_fname><0x02><0x02><lbuf><NUL>
+		     * without Emacs tags: <mtt><tag_fname><0x02><lbuf><NUL>
 		     * Here <mtt> is the "mtt" value plus 1 to avoid NUL.
 		     */
 		    len = (int)tag_fname_len + (int)STRLEN(lbuf) + 3;

--- a/src/testdir/test_taglist.vim
+++ b/src/testdir/test_taglist.vim
@@ -19,3 +19,34 @@ func Test_taglist()
   bwipe
 endfunc
 
+func Test_taglist_native_etags()
+  call writefile([
+	\ "\x0c",
+	\ "src/os_unix.c,13491",
+	\ "set_signals(\x7f1335,32699",
+	\ "reset_signals(\x7f1407,34136",
+	\ ], 'Xtags')
+
+  set tags=Xtags
+
+  call assert_equal([['set_signals', '1335,32699'], ['reset_signals', '1407,34136']],
+	\ map(taglist('set_signals'), {i, v -> [v.name, v.cmd]}))
+
+  call delete('Xtags')
+endfunc
+
+func Test_taglist_ctags_etags()
+  call writefile([
+	\ "\x0c",
+	\ "src/os_unix.c,13491",
+	\ "set_signals(void)\x7fset_signals\x011335,32699",
+	\ "reset_signals(void)\x7freset_signals\x011407,34136",
+	\ ], 'Xtags')
+
+  set tags=Xtags
+
+  call assert_equal([['set_signals', '1335,32699'], ['reset_signals', '1407,34136']],
+	\ map(taglist('set_signals'), {i, v -> [v.name, v.cmd]}))
+
+  call delete('Xtags')
+endfunc

--- a/src/testdir/test_taglist.vim
+++ b/src/testdir/test_taglist.vim
@@ -20,6 +20,9 @@ func Test_taglist()
 endfunc
 
 func Test_taglist_native_etags()
+  if !has('emacs_tags')
+    return
+  endif
   call writefile([
 	\ "\x0c",
 	\ "src/os_unix.c,13491",
@@ -36,6 +39,9 @@ func Test_taglist_native_etags()
 endfunc
 
 func Test_taglist_ctags_etags()
+  if !has('emacs_tags')
+    return
+  endif
   call writefile([
 	\ "\x0c",
 	\ "src/os_unix.c,13491",


### PR DESCRIPTION
In v8.0.0190, 0x01 was used to demark parts of the tag data to avoid
changing the hashtab implementation.  Before returning from find_tags,
the 0x01 are changed back to NUL.

However, as noted in parse_tag_line, 0x01 is an expected character in
some etags-format files, so this sweeping replacement breaks parsing
those files.

Use 0x02 for TAG_SEP instead to avoid breaking parsing of etags files.