### PR TITLE
Add parameter to disable check timestamps

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1927,6 +1927,10 @@ command_line_scan(mparm_T *parmp)
 		    /* already processed, skip */
 		}
 #endif
+		else if (STRNICMP(argv[0] + argv_idx, "nochecktime", 11) == 0)
+		{
+		    no_check_timestamps++;
+		}
 		else
 		{
 		    if (argv[0][argv_idx])


### PR DESCRIPTION
Hello, I was wondering if you might be open to the idea of adding an option to disable the timecheck. I have the tendency to open logs or build output in gvim and I just get rather tired of constantly being forced to reload or not. I would rather decide myself when I want to reload in those cases. At the same time in other instances I would like to be notified of code changes. Which is why I thought it might be good to have a command line parameter to disable the timecheck in some instances, but leave it at it default state in others.