### PR TITLE
Fix E303 errors if 'directory' isn't writable opening a cmdwin

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -6841,6 +6841,7 @@ ex_window(void)
 # endif
     /* don't use a new tab page */
     cmdmod.tab = 0;
+    cmdmod.noswapfile = 1;
 
     /* Create a window for the command-line buffer. */
     if (win_split((int)p_cwh, WSP_BOT) == FAIL)
@@ -6857,7 +6858,6 @@ ex_window(void)
     (void)do_ecmd(0, NULL, NULL, NULL, ECMD_ONE, ECMD_HIDE, NULL);
     (void)setfname(curbuf, (char_u *)"[Command Line]", NULL, TRUE);
     set_option_value((char_u *)"bt", 0L, (char_u *)"nofile", OPT_LOCAL);
-    set_option_value((char_u *)"swf", 0L, NULL, OPT_LOCAL);
     curbuf->b_p_ma = TRUE;
 #ifdef FEAT_FOLDING
     curwin->w_p_fen = FALSE;

--- a/src/option.c
+++ b/src/option.c
@@ -11058,7 +11058,7 @@ buf_copy_options(buf_T *buf, int flags)
 	    buf->b_p_ml = p_ml;
 	    buf->b_p_ml_nobin = p_ml_nobin;
 	    buf->b_p_inf = p_inf;
-	    buf->b_p_swf = p_swf;
+	    buf->b_p_swf = cmdmod.noswapfile ? FALSE : p_swf;
 #ifdef FEAT_INS_EXPAND
 	    buf->b_p_cpt = vim_strsave(p_cpt);
 #endif


### PR DESCRIPTION
Currently, opening a cmdwin creates the buffer and then sets a few
options on that buffer, including 'noswapfile'.  That leaves a gap where
a swap file gets created, potentially showing a useless error to the user.

Since there's now the :noswapfile command modifier, let's check that to
set the buffer-local value of 'swapfile' when creating a new buffer.
That allows us to then set cmdmod.noswapfile when creating the buffer
for a cmdwin, to prevent the swapfile from ever being created.