### PR TITLE
Fixed undefined behavior with line continuation after empty line

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2129,7 +2129,7 @@ ga_concat(garray_T *gap, char_u *s)
 {
     int    len;
 
-    if (s == NULL)
+    if (s == NULL || *s == NUL)
 	return;
     len = (int)STRLEN(s);
     if (ga_grow(gap, len) == OK)

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -1310,6 +1310,17 @@ func Test_script_lines()
 endfunc
 
 "-------------------------------------------------------------------------------
+" Test 96:  line continuation						    {{{1
+"
+"           Undefined behavior was detected by ubsan with line continuation
+"           after an empty line.
+"-------------------------------------------------------------------------------
+func Test_script_emty_line_continuation()
+
+    \
+endfunc
+
+"-------------------------------------------------------------------------------
 " Modelines								    {{{1
 " vim: ts=8 sw=4 tw=80 fdm=marker
 " vim: fdt=substitute(substitute(foldtext(),\ '\\%(^+--\\)\\@<=\\(\\s*\\)\\(.\\{-}\\)\:\ \\%(\"\ \\)\\=\\(Test\ \\d*\\)\:\\s*',\ '\\3\ (\\2)\:\ \\1',\ \"\"),\ '\\(Test\\s*\\)\\(\\d\\)\\D\\@=',\ '\\1\ \\2',\ "")


### PR DESCRIPTION
This PR fixes an error detected by ubsan (undefined sanitizer)
when using line continuation after an empty line. memmove()
is called with a NULL pointer at misc2.c:2137. It does not crash
because the length is 0. However, it is undefined behavior.

It may look nitpicky as one could expect memmove(NULL, NULL, 0)
to do nothing. However, optimizers are known to exploit the fact
that it is undefined. See section "Null pointer checks may be 
optimized away more aggressively" in this gcc-4.9 page
for example:

https://gcc.gnu.org/gcc-4.9/porting_to.html

To reproduce the error, build vim with ubsan (-fsanitize=undefined)
and run vim as follows with this 2-line vim script:

$ cat ub.vim

\q
$ vim -u NONE -N -S ub.vim 2> ubsan.log

And ubsan.log contains this error:

misc2.c:2137:2: runtime error: null pointer passed as argument 1, which is declared to never be null

The PR fixes the bug and adds a test which reproduces the error
prior to the fix.