### PR TITLE
Introduce 'uselast' option for 'switchbuf'.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7412,6 +7412,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   vsplit	Just like "split" but split vertically.
 	   newtab	Like "split", but open a new tab page.  Overrules
 			"split" when both are present.
+	   uselast	If included, jump to the previously used window when
+			jumping to errors with |quickfix| commands.
 
 						*'synmaxcol'* *'smc'*
 'synmaxcol' 'smc'	number	(default 3000)

--- a/src/option.h
+++ b/src/option.h
@@ -818,13 +818,14 @@ EXTERN char_u	*p_sws;		/* 'swapsync' */
 EXTERN char_u	*p_swb;		/* 'switchbuf' */
 EXTERN unsigned	swb_flags;
 #ifdef IN_OPTION_C
-static char *(p_swb_values[]) = {"useopen", "usetab", "split", "newtab", "vsplit", NULL};
+static char *(p_swb_values[]) = {"useopen", "usetab", "split", "newtab", "vsplit", "uselast", NULL};
 #endif
 #define SWB_USEOPEN		0x001
 #define SWB_USETAB		0x002
 #define SWB_SPLIT		0x004
 #define SWB_NEWTAB		0x008
 #define SWB_VSPLIT		0x010
+#define SWB_USELAST		0x020
 EXTERN int	p_tbs;		/* 'tagbsearch' */
 EXTERN char_u	*p_tc;		/* 'tagcase' */
 EXTERN unsigned tc_flags;       /* flags from 'tagcase' */

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2246,7 +2246,6 @@ win_found:
 
 	    /*
 	     * Try to find a window that shows the right buffer.
-	     * Default to the window just above the quickfix buffer.
 	     */
 	    win = curwin;
 	    altwin = NULL;
@@ -2262,8 +2261,12 @@ win_found:
 		if (IS_QF_WINDOW(win))
 		{
 		    /* Didn't find it, go to the window before the quickfix
-		     * window. */
-		    if (altwin != NULL)
+		     * window, unless 'switchbuf' contains 'uselast':
+		     * in this case we try to jump to the previously used
+		     * window first. */
+		    if (swb_flags & SWB_USELAST && win_valid(prevwin))
+			win = prevwin;
+		    else if (altwin != NULL)
 			win = altwin;
 		    else if (curwin->w_prev != NULL)
 			win = curwin->w_prev;

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1498,6 +1498,14 @@ func Test_switchbuf()
   call assert_equal(3, tabpagenr('$'))
   tabfirst | enew | tabonly | only
 
+  set switchbuf=uselast
+  split
+  let last_winid = win_getid()
+  copen
+  exe "normal 1G\<CR>"
+  call assert_equal(last_winid, win_getid())
+  enew | only
+
   set switchbuf=
   edit Xqftestfile1
   let file1_winid = win_getid()


### PR DESCRIPTION
This behaviour is more intuitive IMO, full backward compatibility is achieved by introducing a new option, a test is provided.

Cheers.