### PR TITLE
build: Always check tgetent return code

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3355,10 +3355,9 @@ if test "x$vim_cv_terminfo" = "xyes" ; then
   AC_DEFINE(TERMINFO)
 fi
 
-if test "x$olibs" != "x$LIBS"; then
-  AC_CACHE_CHECK([what tgetent() returns for an unknown terminal], [vim_cv_tgent],
-    [
-      AC_RUN_IFELSE([AC_LANG_SOURCE([[
+AC_CACHE_CHECK([what tgetent() returns for an unknown terminal], [vim_cv_tgent],
+  [
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include "confdefs.h"
 #ifdef HAVE_TERMCAP_H
 # include <termcap.h>
@@ -3369,18 +3368,17 @@ if test "x$olibs" != "x$LIBS"; then
 #endif
 main()
 {char s[10000]; int res = tgetent(s, "thisterminaldoesnotexist"); exit(res != 0); }
-      ]])],[
-	vim_cv_tgent=zero
-      ],[
-	vim_cv_tgent=non-zero
-      ],[
-	AC_MSG_ERROR(failed to compile test program.)
-      ])
+    ]])],[
+  vim_cv_tgent=zero
+    ],[
+  vim_cv_tgent=non-zero
+    ],[
+  AC_MSG_ERROR(failed to compile test program.)
     ])
-  
-  if test "x$vim_cv_tgent" = "xzero" ; then
-    AC_DEFINE(TGETENT_ZERO_ERR, 0)
-  fi
+  ])
+
+if test "x$vim_cv_tgent" = "xzero" ; then
+  AC_DEFINE(TGETENT_ZERO_ERR, 0)
 fi
 
 AC_MSG_CHECKING(whether termcap.h contains ospeed)


### PR DESCRIPTION
Hey folks,
I finally found the root cause of the problem I experienced and reported in issue #1601 thanks to the extra information I got from #1634. I explicitly set the terminal library by passing `--with-tlib=ncurses`. Due to the logic in the configure script this caused the check to determine whether the tgetent returns zero or non-zero when given a non-existent terminal. The check is only run when `$olibs != $LIBS` which is not met when `--with-tlib` is passed, because in that case `$LIBS` is intentionally set to `$olibs` in oder to meet the `$olibs = $LIBS` condition of the subsequent check for the function `tgetent`. Therefore `TGETENT_ZERO_ERR` won't be defined even if the specified terminal library returns zero.
My best judgement is that the check should be run no matter if the terminal library was explicitly given or automatically selected. The proposed patched removes the condition around the check, so that it's always run 