### PR TITLE
Fix wrong background color when scrolling down

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -10066,7 +10066,13 @@ screen_del_lines(
     {
 	windgoto(cursor_end - 1, 0);
 	for (i = line_count; --i >= 0; )
+	{
 	    out_char('\n');		/* cursor will remain on same line */
+	    if (*T_CE)
+		out_str(T_CE);		/* clear line to fix background */
+	}
+	if (*T_CE)
+	    screen_start();
     }
     else
     {


### PR DESCRIPTION
In some terminals, when scrolling down one line, the empty new line is
displayed with background color 0 instead of the specified background
color.

When using 'newline on the last line' to scroll down, follow it with a
'clear to end of line'.

In gnome-terminal:
![vim-bug-gnome-terminal](https://cloud.githubusercontent.com/assets/2654252/25688635/7ae9fd48-3046-11e7-9c71-e1e5ffe54b32.png)
In JuiceSSH:
![vim-bug-juice-ssh](https://cloud.githubusercontent.com/assets/2654252/25688636/7af2610e-3046-11e7-9c1a-ffcc8db63af9.png)