### PR TITLE
BUG: Pack dirs not yet in 'rtp' when normal plugins run

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -3636,24 +3636,40 @@ theend:
 static int did_source_packages = FALSE;
 
 /*
+ * Add all directories in the "start" directory to 'runtimepath'.
+ */
+    void
+add_all_pack_dirs(void)
+{
+    do_in_path(p_pp, (char_u *)"pack/*/start/*", DIP_ALL + DIP_DIR,
+					       add_pack_plugin, &APP_ADD_DIR);
+}
+
+/*
+ * Load plugins from all directories in the "start" directory.
+ */
+    void
+load_all_pack(void)
+{
+    did_source_packages = TRUE;
+    do_in_path(p_pp, (char_u *)"pack/*/start/*", DIP_ALL + DIP_DIR,
+						  add_pack_plugin, &APP_LOAD);
+}
+
+/*
  * ":packloadall"
  * Find plugins in the package directories and source them.
- * "eap" is NULL when invoked during startup.
  */
     void
 ex_packloadall(exarg_T *eap)
 {
     if (!did_source_packages || (eap != NULL && eap->forceit))
     {
-	did_source_packages = TRUE;
-
 	/* First do a round to add all directories to 'runtimepath', then load
 	 * the plugins. This allows for plugins to use an autoload directory
 	 * of another plugin. */
-	do_in_path(p_pp, (char_u *)"pack/*/start/*", DIP_ALL + DIP_DIR,
-					       add_pack_plugin, &APP_ADD_DIR);
-	do_in_path(p_pp, (char_u *)"pack/*/start/*", DIP_ALL + DIP_DIR,
-						  add_pack_plugin, &APP_LOAD);
+	add_all_pack_dirs();
+	load_all_pack();
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -449,6 +449,7 @@ vim_main2(void)
      */
     if (p_lpl)
     {
+	add_all_pack_dirs();
 # ifdef VMS	/* Somehow VMS doesn't handle the "**". */
 	source_runtime((char_u *)"plugin/*.vim", DIP_ALL | DIP_NOAFTER);
 # else
@@ -456,7 +457,7 @@ vim_main2(void)
 # endif
 	TIME_MSG("loading plugins");
 
-	ex_packloadall(NULL);
+	load_all_pack();
 	TIME_MSG("loading packages");
 
 # ifdef VMS	/* Somehow VMS doesn't handle the "**". */

--- a/src/proto/ex_cmds2.pro
+++ b/src/proto/ex_cmds2.pro
@@ -72,6 +72,8 @@ void ex_runtime(exarg_T *eap);
 int source_runtime(char_u *name, int flags);
 int do_in_path(char_u *path, char_u *name, int flags, void (*callback)(char_u *fname, void *ck), void *cookie);
 int do_in_runtimepath(char_u *name, int flags, void (*callback)(char_u *fname, void *ck), void *cookie);
+void add_all_pack_dirs(void);
+void load_all_pack(void);
 void ex_packloadall(exarg_T *eap);
 void ex_packadd(exarg_T *eap);
 void ex_options(exarg_T *eap);

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -61,6 +61,38 @@ func Test_after_comes_later()
   call delete('Xafter', 'rf')
 endfunc
 
+func Test_pack_in_rtp_when_plugins_run()
+  if !has('packages')
+    return
+  endif
+  let before = [
+	\ 'set nocp viminfo+=nviminfo',
+	\ 'set guioptions+=M',
+	\ 'let $HOME = "/does/not/exist"',
+	\ 'set loadplugins',
+	\ 'set rtp=Xhere',
+	\ 'set packpath=Xhere',
+	\ 'set nomore',
+	\ ]
+  let after = [
+	\ 'quit',
+	\ ]
+  call mkdir('Xhere/plugin', 'p')
+  call writefile(['redir! > Xtestout', 'silent set runtimepath?', 'silent! call foo#Trigger()', 'redir END'], 'Xhere/plugin/here.vim')
+  call mkdir('Xhere/pack/foo/start/foobar/autoload', 'p')
+  call writefile(['function! foo#Trigger()', 'echo "autoloaded foo"', 'endfunction'], 'Xhere/pack/foo/start/foobar/autoload/foo.vim')
+
+  if RunVim(before, after, '')
+
+    let lines = filter(readfile('Xtestout'), '!empty(v:val)')
+    call assert_match('Xhere[/\\]pack[/\\]foo[/\\]start[/\\]foobar', get(lines, 0))
+    call assert_match('autoloaded foo', get(lines, 1))
+  endif
+
+  call delete('Xtestout')
+  call delete('Xhere', 'rf')
+endfunc
+
 func Test_help_arg()
   if !has('unix') && has('gui')
     " this doesn't work with gvim on MS-Windows


### PR DESCRIPTION
Some plugins provide autoload functions to customize them, or for reuse by other plugins.  If that client plugin is in a pack directory itself, all is fine (because of `:h packload-two-steps`). However, if the client is in a "normal" `~/.vim/plugin` location, the pack autoload path is not yet in `'runtimepath'`; that is added only _after_ normal plugins have been run.  The client needs to explicitly `:runtime START autoload/foo.vim` or the autoload call will fail.

This behavior is bad, and contradicts the documentation under `:h packages`, which reads:

> When Vim starts up, after processing your .vimrc, it scans all directories in
> 'packpath' for plugins under the "pack/*/start" directory.  First all those
> directories are added to 'runtimepath'.  Then all the plugins are loaded.

The current behavior actually is:

> When Vim starts up, after processing your .vimrc __and normal plugins__, it scans all directories in 'packpath' for plugins under the "pack/*/start" directory.  First all those directories are added to 'runtimepath'.  Then all the __pack__ plugins are loaded.

The problem is that in `vim_main2()`, the `:packloadall` command (via `ex_packloadall()`, which performs both adding and loading) is reused, after the normal plugins have already been sourced.

To solve the issue, factor `add_all_pack_dirs()` and `load_all_pack()` (the two steps) out of `ex_packloadall()`, and invoke the former before sourcing plugins.  This way, `'runtimepath'` is already augmented with the pack plugin paths (but no pack plugin has yet been run), and references to autoload functions in pack plugins work as expected.
