### PR TITLE
Make :stag observe the 'switchbuf' option

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -3204,7 +3204,7 @@ jumpto_tag(
      * open a new tab page. */
     if (postponed_split && (swb_flags & (SWB_USEOPEN | SWB_USETAB)))
     {
-	buf_T *existing_buf = buflist_findname(fname);
+	buf_T *existing_buf = buflist_findname_exp(fname);
 	if (existing_buf != NULL)
 	{
 	    win_T *wp = NULL;

--- a/src/tag.c
+++ b/src/tag.c
@@ -3088,7 +3088,7 @@ jumpto_tag(
     char_u	*fname;
     tagptrs_T	tagp;
     int		retval = FAIL;
-    int		getfile_result;
+    int		getfile_result = 1;
     int		search_options;
 #ifdef FEAT_SEARCH_EXTRA
     int		save_no_hlsearch;
@@ -3202,7 +3202,26 @@ jumpto_tag(
 
     /* If it was a CTRL-W CTRL-] command split window now.  For ":tab tag"
      * open a new tab page. */
-    if (postponed_split || cmdmod.tab != 0)
+    if (postponed_split && (swb_flags & (SWB_USEOPEN | SWB_USETAB)))
+    {
+	buf_T *existing_buf = buflist_findname(fname);
+	if (existing_buf != NULL)
+	{
+	    win_T *wp = NULL;
+	    if (swb_flags & SWB_USEOPEN)
+		wp = buf_jump_open_win(existing_buf);
+
+	    /* If 'switchbuf' contains "usetab": jump to first window in any tab
+	     * page containing "existing_buf" if one exists */
+	    if (wp == NULL && (swb_flags & SWB_USETAB))
+		wp = buf_jump_open_tab(existing_buf);
+	    /* We've switched to the buffer, the usual loading of the file must
+	     * be skipped. */
+	    if (wp != NULL)
+		getfile_result = 0;
+	}
+    }
+    if (getfile_result > 0 && (postponed_split || cmdmod.tab != 0))
     {
 	if (win_split(postponed_split > 0 ? postponed_split : 0,
 						postponed_split_flags) == FAIL)
@@ -3225,7 +3244,8 @@ jumpto_tag(
 #endif
 	    keep_help_flag = curbuf->b_help;
     }
-    getfile_result = getfile(0, fname, NULL, TRUE, (linenr_T)0, forceit);
+    if (getfile_result > 0)
+	getfile_result = getfile(0, fname, NULL, TRUE, (linenr_T)0, forceit);
     keep_help_flag = FALSE;
 
     if (getfile_result <= 0)		/* got to the right file */

--- a/src/testdir/test_tagjump.vim
+++ b/src/testdir/test_tagjump.vim
@@ -65,6 +65,48 @@ func Test_duplicate_tagjump()
   call delete('Xfile1')
 endfunc
 
+func Test_tagjump_switchbuf()
+  set tags=Xtags
+  call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//",
+        \ "second\tXfile1\t2",
+        \ "third\tXfile1\t3",],
+        \ 'Xtags')
+  call writefile(['first', 'second', 'third'], 'Xfile1')
+
+  enew | only
+  set switchbuf=
+  stag second
+  call assert_equal(2, winnr('$'))
+  call assert_equal(2, line('.'))
+  stag third
+  call assert_equal(3, winnr('$'))
+  call assert_equal(3, line('.'))
+
+  enew | only
+  set switchbuf=useopen
+  stag second
+  call assert_equal(2, winnr('$'))
+  call assert_equal(2, line('.'))
+  stag third
+  call assert_equal(2, winnr('$'))
+  call assert_equal(3, line('.'))
+
+  enew | only
+  set switchbuf=usetab
+  tab stag second
+  call assert_equal(2, tabpagenr('$'))
+  call assert_equal(2, line('.'))
+  1tabnext | stag third
+  call assert_equal(2, tabpagenr('$'))
+  call assert_equal(3, line('.'))
+
+  tabclose!
+  enew | only
+  call delete('Xfile1')
+  call delete('Xtags')
+  set switchbuf&vim
+endfunc
+
 " Tests for [ CTRL-I and CTRL-W CTRL-I commands
 function Test_keyword_jump()
   call writefile(["#include Xinclude", "",


### PR DESCRIPTION
The `useopen` and `usetab` values of `'switchbuf'` should (according to `:help 'swb'`) be _used in all buffer related split commands, for example ":sbuffer", ":sbnext", or ":sbrewind"._

The `:stag` / `:stselect` / `:stjump` commands also split windows and open a new buffer. Therefore, users expect them to be influenced by `'switchbuf'` as well, but they currently are not. When navigating tags, `:set switchbuf=useopen` can have great benefits: It avoids that multiple buffers with the same source file are opened; users will end up with the minimum amount of split windows, just one for each source file, and do not have to manually manage duplicate window splits. [This deleted question on Stack Overflow](http://stackoverflow.com/questions/30571503/changing-vim-go-to-behaviour) asks for this explicitly. I want this, too, and think this is a change that most users would welcome, and would add more consistency to the Vim command set. Users that don't like this behavior probably don't have `'switchbuf'` configured, anyway.

The implementation in `jumpto_tag()` parallels the one in `buflist_getfile()`. `getfile_result`, already used later as a flag is now initialized at the beginning of the function, and used to actually skip the `getfile()` call if a window reuse has happened.
