### PR TITLE
Improved test coverage of diff mode and fixed memory error

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -1244,7 +1244,7 @@ ex_diffoff(exarg_T *eap)
 		    wp->w_p_wrap = wp->w_p_wrap_save;
 #ifdef FEAT_FOLDING
 		free_string_option(wp->w_p_fdm);
-		wp->w_p_fdm = wp->w_p_fdm_savevim_strsave(
+		wp->w_p_fdm = vim_strsave(
 		    *wp->w_p_fdm_save ? wp->w_p_fdm_save : (char_u*)"manual");
 
 		if (wp->w_p_fdc == diff_foldcolumn)

--- a/src/diff.c
+++ b/src/diff.c
@@ -1243,8 +1243,11 @@ ex_diffoff(exarg_T *eap)
 		if (!wp->w_p_wrap)
 		    wp->w_p_wrap = wp->w_p_wrap_save;
 #ifdef FEAT_FOLDING
-		free_string_option(wp->w_p_fdm);
-		wp->w_p_fdm = vim_strsave(wp->w_p_fdm_save);
+		if (*wp->w_p_fdm_save)
+		{
+		    free_string_option(wp->w_p_fdm);
+		    wp->w_p_fdm = vim_strsave(wp->w_p_fdm_save);
+		}
 
 		if (wp->w_p_fdc == diff_foldcolumn)
 		    wp->w_p_fdc = wp->w_p_fdc_save;

--- a/src/diff.c
+++ b/src/diff.c
@@ -1243,11 +1243,9 @@ ex_diffoff(exarg_T *eap)
 		if (!wp->w_p_wrap)
 		    wp->w_p_wrap = wp->w_p_wrap_save;
 #ifdef FEAT_FOLDING
-		if (*wp->w_p_fdm_save)
-		{
-		    free_string_option(wp->w_p_fdm);
-		    wp->w_p_fdm = vim_strsave(wp->w_p_fdm_save);
-		}
+		free_string_option(wp->w_p_fdm);
+		wp->w_p_fdm = wp->w_p_fdm_savevim_strsave(
+		    *wp->w_p_fdm_save ? wp->w_p_fdm_save : (char_u*)"manual");
 
 		if (wp->w_p_fdc == diff_foldcolumn)
 		    wp->w_p_fdc = wp->w_p_fdc_save;

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -246,6 +246,7 @@ endfunc
 func Test_diffoff()
   enew!
   call setline(1, ['Two', 'Three'])
+  redraw
   let normattr = screenattr(1, 1)
   diffthis
   botright vert new
@@ -265,6 +266,7 @@ func Test_diffopt_icase()
 
   e one
   call setline(1, ['One', 'Two', 'Three', 'Four'])
+  redraw
   let normattr = screenattr(1, 1)
   diffthis
 
@@ -287,9 +289,10 @@ func Test_diffopt_iwhite()
   set diffopt=iwhite,foldcolumn:0
 
   e one
-  " Difference in trailing space should be ignore,
+  " Difference in trailing spaces should be ignored,
   " but not other space differences.
   call setline(1, ["One \t", 'Two', 'Three', 'Four'])
+  redraw
   let normattr = screenattr(1, 1)
   diffthis
 
@@ -340,6 +343,7 @@ func Test_diffoff_hidden()
   set diffopt=filler,foldcolumn:0
   e! one
   call setline(1, ['Two', 'Three'])
+  redraw
   let normattr = screenattr(1, 1)
   diffthis
   botright vert new two
@@ -409,6 +413,37 @@ func Test_diff_move_to()
   norm 10[c
   call assert_equal(2, line('.'))
   %bwipe!
+endfunc
+
+func Test_diffexpr()
+  if !executable('diff')
+    return
+  endif
+
+  func DiffExpr()
+    silent exe '!diff ' . v:fname_in . ' ' . v:fname_new . '>' . v:fname_out
+  endfunc
+  set diffexpr=DiffExpr()
+  set diffopt=foldcolumn:0
+
+  enew!
+  call setline(1, ['one', 'two', 'three'])
+  redraw
+  let normattr = screenattr(1, 1)
+  diffthis
+
+  botright vert new
+  call setline(1, ['one', 'two', 'three.'])
+  diffthis
+
+  redraw
+  call assert_equal(normattr, screenattr(1, 1))
+  call assert_equal(normattr, screenattr(2, 1))
+  call assert_notequal(normattr, screenattr(3, 1))
+
+  diffoff!
+  %bwipe!
+  set diffexpr& diffopt&
 endfunc
 
 func Test_diffpatch()

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -311,6 +311,24 @@ func Test_diffopt_iwhite()
   set diffopt&
 endfunc
 
+func Test_diffopt_context()
+  enew!
+  call setline(1, ['1', '2', '3', '4', '5', '6', '7'])
+  diffthis
+  new
+  call setline(1, ['1', '2', '3', '4', '5x', '6', '7'])
+  diffthis
+
+  set diffopt=context:2
+  call assert_equal('+--  2 lines: 1', foldtextresult(1))
+  set diffopt=context:1
+  call assert_equal('+--  3 lines: 1', foldtextresult(1))
+
+  diffoff!
+  %bwipe!
+  set diffopt&
+endfunc
+
 func Test_diffopt_horizontal()
   set diffopt=horizontal
   diffsplit

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -202,17 +202,19 @@ func Test_diffget_diffput()
   %bwipe!
 endfunc
 
-func Test_dp_do_bufnr()
-  enew!
+func Test_dp_do_buffer()
+  e! one
   let bn1=bufnr('%')
-  let l = range(50)
+  let l = range(60)
   call setline(1, l)
   diffthis
 
-  new
+  new two
   let l[10] = 'one'
   let l[20] = 'two'
   let l[30] = 'three'
+  let l[40] = 'four'
+  let l[50] = 'five'
   call setline(1, l)
   diffthis
 
@@ -220,24 +222,37 @@ func Test_dp_do_bufnr()
   11
   call assert_fails('norm 99999dp', 'E102:')
   call assert_fails('norm 99999do', 'E102:')
+  call assert_fails('diffput non_existing_buffer', 'E94:')
+  call assert_fails('diffget non_existing_buffer', 'E94:')
 
   " dp and do with valid buffer number.
   call assert_equal('one', getline('.'))
   exe 'norm ' . bn1 . 'do'
   call assert_equal('10', getline('.'))
   21
-  exe 'norm ' . bn1 . 'dp'
-  wincmd w
-  21
   call assert_equal('two', getline('.'))
+  diffget one
+  call assert_equal('20', getline('.'))
 
-  " dp and do with buffer number which is not in diff mode.
-  new
-  let bn3=bufnr('%')
+  31
+  exe 'norm ' . bn1 . 'dp'
+  41
+  diffput one
   wincmd w
   31
+  call assert_equal('three', getline('.'))
+  41
+  call assert_equal('four', getline('.'))
+
+  " dp and do with buffer number which is not in diff mode.
+  new not_in_diff_mode
+  let bn3=bufnr('%')
+  wincmd w
+  51
   call assert_fails('exe "norm" . bn3 . "dp"', 'E103:')
   call assert_fails('exe "norm" . bn3 . "do"', 'E103:')
+  call assert_fails('diffput not_in_diff_mode', 'E94:')
+  call assert_fails('diffget not_in_diff_mode', 'E94:')
 
   windo diffoff
   %bwipe!


### PR DESCRIPTION
This PR improves test coverage of diff mode:
- test vertical, horizontal, iwhite and icase values of 'diffopt' option
- test  normal commands "dp" and "do" with a buffer number