### PR TITLE
BUG: ftdetect in pack dirs are run too late (fixes #1679)

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2765,9 +2765,10 @@ au BufNewFile,BufRead zsh*,zlog*		call s:StarSetf('zsh')
 au BufNewFile,BufRead *.txt,*.text,README	setf text
 
 
-" Use the filetype detect plugins.  They may overrule any of the previously
-" detected filetypes.
+" Use the filetype detect plugins, from normal location and then pack
+" directories.  They may overrule any of the previously detected filetypes.
 runtime! ftdetect/*.vim
+runtime! START ftdetect/*.vim
 
 " NOTE: The above command could have ended the filetypedetect autocmd group
 " and started another one. Let's make sure it has ended to get to a consistent

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -3501,6 +3501,7 @@ source_all_matches(char_u *pat)
 static int APP_ADD_DIR;
 static int APP_LOAD;
 static int APP_BOTH;
+static int APP_BOTH_FTDETECT;
 
     static void
 add_pack_plugin(char_u *fname, void *cookie)
@@ -3610,6 +3611,7 @@ add_pack_plugin(char_u *fname, void *cookie)
 	source_all_matches(pat);
 
 #ifdef FEAT_AUTOCMD
+	if (cookie == &APP_BOTH_FTDETECT)
 	{
 	    char_u *cmd = vim_strsave((char_u *)"g:did_load_filetypes");
 
@@ -3673,7 +3675,7 @@ ex_packadd(exarg_T *eap)
 	return;
     vim_snprintf(pat, len, plugpat, eap->arg);
     do_in_path(p_pp, (char_u *)pat, DIP_ALL + DIP_DIR + DIP_ERR,
-		    add_pack_plugin, eap->forceit ? &APP_ADD_DIR : &APP_BOTH);
+		    add_pack_plugin, eap->forceit ? &APP_ADD_DIR : &APP_BOTH_FTDETECT);
     vim_free(pat);
 }
 


### PR DESCRIPTION
The sourcing of ftdetect scripts from added pack directories in `add_pack_plugin()` adds those autocmds only after _all_ default ftdetect rules have been defined.  This is in contrast to the `:runtime! ftdetect/*.vim` in `filetype.vim`, which ends with a fallback for generic configuration files.

Instead of just sourcing the pack ftdetect scripts from the C code after `.vimrc` load / `:packloadall`, use `:runtime START` inside `filetype.vim`, after loading ftdetect scripts from the normal runtimepath locations.  This way, the normal locations have preference over pack plugins, just as with `~/.vim/plugin` vs. `~/.vim/pack/*/start/*/plugin`.  The loading of ftdetect in `add_pack_plugin()` must be avoided; else, the corresponding autocmds would be included _twice_.

We still need a way to load ftdetect scripts later with `:packadd`, which is also done through `add_pack_plugin()`.  For that, introduce a new special `APP_BOTH_FTDETECT` cookie, and do the sourcing only when that cookie is passed, which only `ex_packadd()` will.

---

Note: I'm fairly new to the pack area, but it seems to be tricky and there are still some corner cases to be smoothed out (also see #1680). Please review carefully; I've only submitted this because I helped with troubleshooting #1679 and found this easy approach that fixes that problem. If I've missed some other cases, a different solution may be to just reject this bug altogether. After all, it currently only affects the overriding of the generic configuration file filetype.
