### PR TITLE
Fix 'bg' detection when assigning to Normal

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -7850,7 +7850,7 @@ do_highlight(
 			    {
 				set_string_option_direct((char_u *)"bg", -1,
 				    i ? (char_u *)"dark" : (char_u *)"light",
-				    OPT_FREE, SID_NONE);
+				    OPT_FREE, 0);
 				reset_option_was_set((char_u *)"bg");
 			    }
 			}

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -7838,14 +7838,21 @@ do_highlight(
 				term_bg_color(color);
 			    if (t_colors < 16)
 				i = (color == 0 || color == 4);
-			    else
+			    /* Limit the heuristic to the standard 16 colors */
+			    else if (color < 16)
 				i = (color < 7 || color == 8);
+			    else
+				i = -1;
 			    /* Set the 'background' option if the value is
-			     * wrong. */
-			    if (i != (*p_bg == 'd'))
-				set_option_value((char_u *)"bg", 0L,
-					i ?  (char_u *)"dark"
-					  : (char_u *)"light", 0);
+			     * wrong, but only if it wasn't explicitly set */
+			    if (i >= 0 && i != (*p_bg == 'd')
+				&& !option_was_set((char_u *)"bg"))
+			    {
+				set_string_option_direct((char_u *)"bg", -1,
+				    i ? (char_u *)"dark" : (char_u *)"light",
+				    OPT_FREE, SID_NONE);
+				reset_option_was_set((char_u *)"bg");
+			    }
 			}
 		    }
 		}

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -401,3 +401,21 @@ func Test_highlight_invalid_arg()
   call assert_fails('hi XXX xxx=White', 'E423:')
 endfunc
 
+func Test_bg_detection()
+  if has('gui_running')
+    return
+  endif
+  " auto-detection of &bg, make sure sure it isn't set anywhere before
+  " this test
+  hi Normal ctermbg=4
+  call assert_equal('dark', &bg)
+  hi Normal ctermbg=12
+  call assert_equal('light', &bg)
+  " manually-set &bg takes precendence over auto-detection
+  set bg=light
+  hi Normal ctermbg=4
+  call assert_equal('light', &bg)
+  set bg=dark
+  hi Normal ctermbg=12
+  call assert_equal('dark', &bg)
+endfunc


### PR DESCRIPTION
Do not override the value of 'bg' when the user has set it explicitly.
Limit the heuristic to the first 16 colors, the simplistic algorithm
used here gives a meaningless value for every other color.