### PR TITLE
Handle SIGUSR1 signal by calling the corresponding vimscript function

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -160,6 +160,7 @@ static struct event_name
     {"SessionLoadPost",	EVENT_SESSIONLOADPOST},
     {"ShellCmdPost",	EVENT_SHELLCMDPOST},
     {"ShellFilterPost",	EVENT_SHELLFILTERPOST},
+    {"SigUSR1",	EVENT_SIGUSR1},
     {"SourceCmd",	EVENT_SOURCECMD},
     {"SourcePre",	EVENT_SOURCEPRE},
     {"SourcePost",	EVENT_SOURCEPOST},

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2098,6 +2098,13 @@ parse_queued_messages(void)
 	if (has_sound_callback_in_queue())
 	    invoke_sound_callback();
 # endif
+#ifdef SIGUSR1
+	if (got_usr1)
+	{
+		apply_autocmds(EVENT_SIGUSR1, NULL, NULL, FALSE, curbuf);
+		got_usr1 = FALSE;
+       }
+#endif
 	break;
     }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -1093,6 +1093,11 @@ EXTERN int	read_cmd_fd INIT(= 0);	    // fd to read commands from
 // volatile because it is used in signal handler catch_sigint().
 EXTERN volatile sig_atomic_t got_int INIT(= FALSE); // set to TRUE when interrupt
 						// signal occurred
+#ifdef SIGUSR1
+// volatile because it is used in signal handler catch_sigusr1().
+EXTERN volatile sig_atomic_t got_usr1 INIT(= FALSE); // set to TRUE when interrupt
+                                                // signal occurred
+#endif
 #ifdef USE_TERM_CONSOLE
 EXTERN int	term_console INIT(= FALSE); // set to TRUE when console used
 #endif

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -168,6 +168,9 @@ static RETSIGTYPE sig_winch SIGPROTOARG;
 #if defined(SIGINT)
 static RETSIGTYPE catch_sigint SIGPROTOARG;
 #endif
+#if defined(SIGUSR1)
+static RETSIGTYPE catch_sigusr1 SIGPROTOARG;
+#endif
 #if defined(SIGPWR)
 static RETSIGTYPE catch_sigpwr SIGPROTOARG;
 #endif
@@ -300,7 +303,7 @@ static struct signalinfo
     {SIGXFSZ,	    "XFSZ",	TRUE},
 #endif
 #ifdef SIGUSR1
-    {SIGUSR1,	    "USR1",	TRUE},
+    {SIGUSR1,	    "USR1",	FALSE},
 #endif
 #if defined(SIGUSR2) && !defined(FEAT_SYSMOUSE)
     /* Used for sysmouse handling */
@@ -838,6 +841,17 @@ catch_sigint SIGDEFARG(sigarg)
 }
 #endif
 
+#if defined(SIGUSR1)
+    static RETSIGTYPE
+catch_sigusr1 SIGDEFARG(sigarg)
+{
+    /* this is not required on all systems, but it doesn't hurt anybody */
+    signal(SIGUSR1, catch_sigusr1);
+    got_usr1 = TRUE;
+    SIGRETURN;
+}
+#endif
+
 #if defined(SIGPWR)
     static RETSIGTYPE
 catch_sigpwr SIGDEFARG(sigarg)
@@ -1327,6 +1341,13 @@ set_signals(void)
 
 #ifdef SIGINT
     catch_int_signal();
+#endif
+
+    /*
+     * Call user's handler on SIGUSR1
+     */
+#ifdef SIGUSR1
+    signal(SIGUSR1, catch_sigusr1);
 #endif
 
     /*

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2292,10 +2292,11 @@ endfunc
 " Tests for SigUSR1 autocmd event, which is only available on posix systems.
 if !has('win32')
   function Test_autocmd_sigusr1()
-    let sigusr1_passed=0
-    au SigUSR1 * sigusr1_passed=1
+    let g:sigusr1_passed=0
+    au SigUSR1 * :let g:sigusr1_passed=1
     call system('/bin/kill -s usr1 ' . getpid())
-    call assert_true(sigusr1_passed)
+    call WaitForAssert({-> assert_true(g:sigusr1_passed)})
     au! SigUSR1
+    unlet g:sigusr1_passed
   endfunc
 end

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2288,3 +2288,14 @@ func Test_autocmd_CmdWinEnter()
   call StopVimInTerminal(buf)
   call delete(filename)
 endfunc
+
+" Tests for SigUSR1 autocmd event, which is only available on posix systems.
+if !has('win32')
+  function Test_autocmd_sigusr1()
+    let sigusr1_passed=0
+    au SigUSR1 * sigusr1_passed=1
+    call system('/bin/kill -s usr1 ' . getpid())
+    call assert_true(sigusr1_passed)
+    au! SigUSR1
+  endfunc
+end

--- a/src/vim.h
+++ b/src/vim.h
@@ -1329,6 +1329,7 @@ enum auto_event
     EVENT_SESSIONLOADPOST,	// after loading a session file
     EVENT_SHELLCMDPOST,		// after ":!cmd"
     EVENT_SHELLFILTERPOST,	// after ":1,2!cmd", ":w !cmd", ":r !cmd".
+    EVENT_SIGUSR1,		// after the SIGUSR1 signal
     EVENT_SOURCECMD,		// sourcing a Vim script using command
     EVENT_SOURCEPRE,		// before sourcing a Vim script
     EVENT_SOURCEPOST,		// after sourcing a Vim script


### PR DESCRIPTION
This is a stab at allowing users to add custom handlers for the SIGUSR1 signal. My use case was automatically reloading the configuration file in all open vim processes. I chose SIGUSR1 as it is commonly used for custom handlers and, unlike SIGUSR2, doesn't appear to have any known conflicts. 

The PR sets the SIGUSR1 signal as 'non-deadly' and attaches a handler function that calls the vimscript function `SIGUSR1_handler`.

Aside from general fitness for this in core vim, I'm unsure about a few implementation details:
- The vimscript handler's name is defined in `os_unix.c` above the C wrapper function. Does that better fit in a header file?
- Would it make sense to provide a default noop handler or is the current "Unknown function" message suitable?

I appreciate any feedback!