### PR TITLE
Change the translations to show a valid command that exits vim

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -8986,7 +8986,7 @@ nv_esc(cmdarg_T *cap)
 #endif
 		&& !VIsual_active
 		&& no_reason)
-	    MSG(_("Type  :quit<Enter>  to exit Vim"));
+	    MSG(_("Type  :quit  and press <Enter> to exit Vim"));
 
 	/* Don't reset "restart_edit" when 'insertmode' is set, it won't be
 	 * set again below when halfway a mapping. */

--- a/src/po/af.po
+++ b/src/po/af.po
@@ -3403,7 +3403,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: By die einde van die veranderingslys"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Tik   :quit<Enter>  om Vim te verlaat"
+msgstr "Tik   :quit|<Enter>  om Vim te verlaat"
 
 # Het te doen met < en >
 #, c-format

--- a/src/po/af.po
+++ b/src/po/af.po
@@ -3402,7 +3402,7 @@ msgstr "E662: By die begin van die veranderingslys"
 msgid "E663: At end of changelist"
 msgstr "E663: By die einde van die veranderingslys"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Tik   :quit<Enter>  om Vim te verlaat"
 
 # Het te doen met < en >

--- a/src/po/af.po
+++ b/src/po/af.po
@@ -3403,7 +3403,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: By die einde van die veranderingslys"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Tik   :quit|<Enter>  om Vim te verlaat"
+msgstr "Tik   :quit<Enter>  om Vim te verlaat"
 
 # Het te doen met < en >
 #, c-format

--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -3917,7 +3917,7 @@ msgstr "E663: A l'inici de la llista de canvis"
 
 # amplada 53 caràcters
 msgid "Type  :quit  and press <Enter> to exit Vim"
-msgstr "Feu  :quit<Entrar>  per sortir"
+msgstr "Feu  :quit i llavors 'Entrar/Intro'  per sortir"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -3917,7 +3917,7 @@ msgstr "E663: A l'inici de la llista de canvis"
 
 # amplada 53 caràcters
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Feu  :quit<Entrar>  per sortir"
+msgstr "Feu  :quit|<Entrar>  per sortir"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -3916,7 +3916,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: A l'inici de la llista de canvis"
 
 # amplada 53 caràcters
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Feu  :quit<Entrar>  per sortir"
 
 #, c-format

--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -3917,7 +3917,7 @@ msgstr "E663: A l'inici de la llista de canvis"
 
 # amplada 53 caràcters
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Feu  :quit|<Entrar>  per sortir"
+msgstr "Feu  :quit<Entrar>  per sortir"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -3797,7 +3797,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Am Ende der Liste der Änderungen"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Bitte  :quit|<Enter>  eingeben um Vim zu verlassen"
+msgstr "Bitte  :quit<Enter>  eingeben um Vim zu verlassen"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -3797,7 +3797,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Am Ende der Liste der Änderungen"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Bitte  :quit<Enter>  eingeben um Vim zu verlassen"
+msgstr "Bitte  :quit|<Enter>  eingeben um Vim zu verlassen"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -3796,7 +3796,7 @@ msgstr "E662: Am Anfang der Liste der Änderungen"
 msgid "E663: At end of changelist"
 msgstr "E663: Am Ende der Liste der Änderungen"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Bitte  :quit<Enter>  eingeben um Vim zu verlassen"
 
 #, c-format

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -4117,7 +4117,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ĉe fino de ŝanĝlisto"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Tajpu \":quit|<Enenklavo>\" por eliri el Vim"
+msgstr "Tajpu \":quit<Enenklavo>\" por eliri el Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -4117,7 +4117,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ĉe fino de ŝanĝlisto"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Tajpu \":quit<Enenklavo>\" por eliri el Vim"
+msgstr "Tajpu \":quit|<Enenklavo>\" por eliri el Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -4116,7 +4116,7 @@ msgstr "E662: Ĉe komenco de ŝanĝlisto"
 msgid "E663: At end of changelist"
 msgstr "E663: Ĉe fino de ŝanĝlisto"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Tajpu \":quit<Enenklavo>\" por eliri el Vim"
 
 #, c-format

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -5330,7 +5330,7 @@ msgstr "E663: Al final de la lista de cambios"
 
 #: normal.c:8734
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Escriba \":quit<intro>\" para salir de Vim"
+msgstr "Escriba \":quit|<intro>\" para salir de Vim"
 
 #: ops.c:293
 #, c-format

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -5329,7 +5329,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Al final de la lista de cambios"
 
 #: normal.c:8734
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Escriba \":quit<intro>\" para salir de Vim"
 
 #: ops.c:293

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -5330,7 +5330,7 @@ msgstr "E663: Al final de la lista de cambios"
 
 #: normal.c:8734
 msgid "Type  :quit  and press <Enter> to exit Vim"
-msgstr "Escriba \":quit<intro>\" para salir de Vim"
+msgstr "Escriba \":quit\" y luego presione 'Intro/Enter' para salir de Vim"
 
 #: ops.c:293
 #, c-format

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -5330,7 +5330,7 @@ msgstr "E663: Al final de la lista de cambios"
 
 #: normal.c:8734
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Escriba \":quit|<intro>\" para salir de Vim"
+msgstr "Escriba \":quit<intro>\" para salir de Vim"
 
 #: ops.c:293
 #, c-format

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -4043,7 +4043,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Muutoslistan lopussa"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Komento :quit|<Enter> lopettaa Vimin"
+msgstr "Komento :quit<Enter> lopettaa Vimin"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -4043,7 +4043,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Muutoslistan lopussa"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Komento :quit<Enter> lopettaa Vimin"
+msgstr "Komento :quit|<Enter> lopettaa Vimin"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -4042,7 +4042,7 @@ msgstr "E662: Muutoslistan alussa"
 msgid "E663: At end of changelist"
 msgstr "E663: Muutoslistan lopussa"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Komento :quit<Enter> lopettaa Vimin"
 
 #, c-format

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -4338,7 +4338,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: À la fin de la liste des modifications"
 
 msgid "Type  :quit  and press <Enter> to exit Vim"
-msgstr "tapez  :q<Entrée>  pour quitter Vim"
+msgstr "tapez  :q et alors la touche 'Entrée'  pour quitter Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -4338,7 +4338,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: À la fin de la liste des modifications"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "tapez  :q|<Entrée>  pour quitter Vim"
+msgstr "tapez  :q<Entrée>  pour quitter Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -4338,7 +4338,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: À la fin de la liste des modifications"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "tapez  :q<Entrée>  pour quitter Vim"
+msgstr "tapez  :q|<Entrée>  pour quitter Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -4338,7 +4338,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: À la fin de la liste des modifications"
 
 msgid "Type  :quit  and press <Enter> to exit Vim"
-msgstr "tapez  :q et alors la touche 'Entrée'  pour quitter Vim"
+msgstr "tapez  :q puis la touche <Entrée>  pour quitter Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -4337,7 +4337,7 @@ msgstr "E662: Au début de la liste des modifications"
 msgid "E663: At end of changelist"
 msgstr "E663: À la fin de la liste des modifications"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "tapez  :q<Entrée>  pour quitter Vim"
 
 #, c-format

--- a/src/po/ga.po
+++ b/src/po/ga.po
@@ -4122,7 +4122,7 @@ msgstr "E662: Ag tosach liosta na n-athruithe"
 msgid "E663: At end of changelist"
 msgstr "E663: Ag deireadh liosta na n-athruithe"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Clóscríobh  :quit<Enter>  chun Vim a scor"
 
 # ouch - English -ed ?

--- a/src/po/ga.po
+++ b/src/po/ga.po
@@ -4123,7 +4123,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ag deireadh liosta na n-athruithe"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Clóscríobh  :quit|<Enter>  chun Vim a scor"
+msgstr "Clóscríobh  :quit<Enter>  chun Vim a scor"
 
 # ouch - English -ed ?
 #, c-format

--- a/src/po/ga.po
+++ b/src/po/ga.po
@@ -4123,7 +4123,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ag deireadh liosta na n-athruithe"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Clóscríobh  :quit<Enter>  chun Vim a scor"
+msgstr "Clóscríobh  :quit|<Enter>  chun Vim a scor"
 
 # ouch - English -ed ?
 #, c-format

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -4180,7 +4180,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Alla fine della lista modifiche"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Batti :quit|<Invio>  per uscire da Vim"
+msgstr "Batti :quit<Invio>  per uscire da Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -4180,7 +4180,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Alla fine della lista modifiche"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Batti :quit<Invio>  per uscire da Vim"
+msgstr "Batti :quit|<Invio>  per uscire da Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -4179,7 +4179,7 @@ msgstr "E662: All'inizio della lista modifiche"
 msgid "E663: At end of changelist"
 msgstr "E663: Alla fine della lista modifiche"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Batti :quit<Invio>  per uscire da Vim"
 
 #, c-format

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -4063,7 +4063,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Vimを終了するには :quit|<Enter> と入力してください"
+msgstr "Vimを終了するには :quit<Enter> と入力してください"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -4062,7 +4062,7 @@ msgstr "E662: 変更リストの先頭"
 msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Vimを終了するには :quit<Enter> と入力してください"
 
 #, c-format

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -4063,7 +4063,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Vimを終了するには :quit<Enter> と入力してください"
+msgstr "Vimを終了するには :quit|<Enter> と入力してください"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -4063,7 +4063,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Vimを終了するには :quit|<Enter> と入力してください"
+msgstr "Vimを終了するには :quit<Enter> と入力してください"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -4063,7 +4063,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Vimを終了するには :quit<Enter> と入力してください"
+msgstr "Vimを終了するには :quit|<Enter> と入力してください"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -4062,7 +4062,7 @@ msgstr "E662: 変更リストの先頭"
 msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Vimを終了するには :quit<Enter> と入力してください"
 
 #, c-format

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -4063,7 +4063,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Vimを終了するには :quit<Enter> と入力してください"
+msgstr "Vimを終了するには :quit|<Enter> と入力してください"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -4063,7 +4063,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Vimを終了するには :quit|<Enter> と入力してください"
+msgstr "Vimを終了するには :quit<Enter> と入力してください"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -4062,7 +4062,7 @@ msgstr "E662: 変更リストの先頭"
 msgid "E663: At end of changelist"
 msgstr "E663: 変更リストの末尾"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Vimを終了するには :quit<Enter> と入力してください"
 
 #, c-format

--- a/src/po/ko.UTF-8.po
+++ b/src/po/ko.UTF-8.po
@@ -4044,7 +4044,7 @@ msgstr "E664: changelist가 비었습니다"
 #~ msgstr ""
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "VIM을 마치려면  :quit<Enter>  입력"
+msgstr "VIM을 마치려면  :quit|<Enter>  입력"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ko.UTF-8.po
+++ b/src/po/ko.UTF-8.po
@@ -4043,7 +4043,7 @@ msgstr "E664: changelist가 비었습니다"
 #~ msgid "E663: At end of changelist"
 #~ msgstr ""
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "VIM을 마치려면  :quit<Enter>  입력"
 
 #, c-format

--- a/src/po/ko.UTF-8.po
+++ b/src/po/ko.UTF-8.po
@@ -4044,7 +4044,7 @@ msgstr "E664: changelist가 비었습니다"
 #~ msgstr ""
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "VIM을 마치려면  :quit|<Enter>  입력"
+msgstr "VIM을 마치려면  :quit<Enter>  입력"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -4044,7 +4044,7 @@ msgstr "E664: changelist가 비었습니다"
 #~ msgstr ""
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "VIM을 마치려면  :quit<Enter>  입력"
+msgstr "VIM을 마치려면  :quit|<Enter>  입력"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -4043,7 +4043,7 @@ msgstr "E664: changelist가 비었습니다"
 #~ msgid "E663: At end of changelist"
 #~ msgstr ""
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "VIM을 마치려면  :quit<Enter>  입력"
 
 #, c-format

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -4044,7 +4044,7 @@ msgstr "E664: changelist가 비었습니다"
 #~ msgstr ""
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "VIM을 마치려면  :quit|<Enter>  입력"
+msgstr "VIM을 마치려면  :quit<Enter>  입력"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/nb.po
+++ b/src/po/nb.po
@@ -3955,7 +3955,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ved slutten av forandringsliste"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Skriv  :quit|<Enter>  for å avslutte Vim"
+msgstr "Skriv  :quit<Enter>  for å avslutte Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/nb.po
+++ b/src/po/nb.po
@@ -3954,7 +3954,7 @@ msgstr "E662: Ved starten av forandringsliste"
 msgid "E663: At end of changelist"
 msgstr "E663: Ved slutten av forandringsliste"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Skriv  :quit<Enter>  for å avslutte Vim"
 
 #, c-format

--- a/src/po/nb.po
+++ b/src/po/nb.po
@@ -3955,7 +3955,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ved slutten av forandringsliste"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Skriv  :quit<Enter>  for å avslutte Vim"
+msgstr "Skriv  :quit|<Enter>  for å avslutte Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/nl.po
+++ b/src/po/nl.po
@@ -3551,7 +3551,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: einde van wijzigingslijst"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Typ :quit<Enter> om Vim te verlaten"
+msgstr "Typ :quit|<Enter> om Vim te verlaten"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/nl.po
+++ b/src/po/nl.po
@@ -3550,7 +3550,7 @@ msgstr "E662: begin van wijzigingslijst"
 msgid "E663: At end of changelist"
 msgstr "E663: einde van wijzigingslijst"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Typ :quit<Enter> om Vim te verlaten"
 
 #, c-format

--- a/src/po/nl.po
+++ b/src/po/nl.po
@@ -3551,7 +3551,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: einde van wijzigingslijst"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Typ :quit|<Enter> om Vim te verlaten"
+msgstr "Typ :quit<Enter> om Vim te verlaten"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/no.po
+++ b/src/po/no.po
@@ -3955,7 +3955,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ved slutten av forandringsliste"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Skriv  :quit|<Enter>  for å avslutte Vim"
+msgstr "Skriv  :quit<Enter>  for å avslutte Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/no.po
+++ b/src/po/no.po
@@ -3954,7 +3954,7 @@ msgstr "E662: Ved starten av forandringsliste"
 msgid "E663: At end of changelist"
 msgstr "E663: Ved slutten av forandringsliste"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Skriv  :quit<Enter>  for å avslutte Vim"
 
 #, c-format

--- a/src/po/no.po
+++ b/src/po/no.po
@@ -3955,7 +3955,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ved slutten av forandringsliste"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Skriv  :quit<Enter>  for å avslutte Vim"
+msgstr "Skriv  :quit|<Enter>  for å avslutte Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -4124,7 +4124,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na końcu listy zmian"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "wprowadź  :quit|<Enter>    zakończenie programu"
+msgstr "wprowadź  :quit<Enter>    zakończenie programu"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -4124,7 +4124,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na końcu listy zmian"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "wprowadź  :quit<Enter>    zakończenie programu"
+msgstr "wprowadź  :quit|<Enter>    zakończenie programu"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -4123,7 +4123,7 @@ msgstr "E662: Na początku listy zmian"
 msgid "E663: At end of changelist"
 msgstr "E663: Na końcu listy zmian"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "wprowadź  :quit<Enter>    zakończenie programu"
 
 #, c-format

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -4123,7 +4123,7 @@ msgstr "E662: Na pocz¹tku listy zmian"
 msgid "E663: At end of changelist"
 msgstr "E663: Na koñcu listy zmian"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "wprowadŸ  :quit<Enter>    zakoñczenie programu"
 
 #, c-format

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -4124,7 +4124,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na koñcu listy zmian"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "wprowadŸ  :quit<Enter>    zakoñczenie programu"
+msgstr "wprowadŸ  :quit|<Enter>    zakoñczenie programu"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -4124,7 +4124,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na koñcu listy zmian"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "wprowadŸ  :quit|<Enter>    zakoñczenie programu"
+msgstr "wprowadŸ  :quit<Enter>    zakoñczenie programu"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -4124,7 +4124,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na koñcu listy zmian"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "wprowad¼  :quit<Enter>    zakoñczenie programu"
+msgstr "wprowad¼  :quit|<Enter>    zakoñczenie programu"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -4124,7 +4124,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na koñcu listy zmian"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "wprowad¼  :quit|<Enter>    zakoñczenie programu"
+msgstr "wprowad¼  :quit<Enter>    zakoñczenie programu"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -4123,7 +4123,7 @@ msgstr "E662: Na pocz±tku listy zmian"
 msgid "E663: At end of changelist"
 msgstr "E663: Na koñcu listy zmian"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "wprowad¼  :quit<Enter>    zakoñczenie programu"
 
 #, c-format

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -3973,7 +3973,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: No final da lista de modificações"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Digite  :quit|<Enter>  para sair do Vim"
+msgstr "Digite  :quit<Enter>  para sair do Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -3972,7 +3972,7 @@ msgstr "E662: No início da lista de modificações"
 msgid "E663: At end of changelist"
 msgstr "E663: No final da lista de modificações"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Digite  :quit<Enter>  para sair do Vim"
 
 #, c-format

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -3973,7 +3973,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: No final da lista de modificações"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Digite  :quit<Enter>  para sair do Vim"
+msgstr "Digite  :quit|<Enter>  para sair do Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -4182,7 +4182,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: В конце списка изменений"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Введите :quit|<Enter>  для выхода из Vim"
+msgstr "Введите :quit<Enter>  для выхода из Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -4181,7 +4181,7 @@ msgstr "E662: В начале списка изменений"
 msgid "E663: At end of changelist"
 msgstr "E663: В конце списка изменений"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Введите :quit<Enter>  для выхода из Vim"
 
 #, c-format

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -4182,7 +4182,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: В конце списка изменений"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Введите :quit<Enter>  для выхода из Vim"
+msgstr "Введите :quit|<Enter>  для выхода из Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -4181,7 +4181,7 @@ msgstr "E662: В начале списка изменений"
 msgid "E663: At end of changelist"
 msgstr "E663: В конце списка изменений"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Введите :quit<Enter>  для выхода из Vim"
 
 #, c-format

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -4182,7 +4182,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: В конце списка изменений"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Введите :quit<Enter>  для выхода из Vim"
+msgstr "Введите :quit|<Enter>  для выхода из Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -4182,7 +4182,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: В конце списка изменений"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Введите :quit|<Enter>  для выхода из Vim"
+msgstr "Введите :quit<Enter>  для выхода из Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/sk.cp1250.po
+++ b/src/po/sk.cp1250.po
@@ -3733,7 +3733,7 @@ msgstr "E662: Na zaèiatku zoznamu zmien"
 msgid "E663: At end of changelist"
 msgstr "E663: Na konci zoznamu zmien"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Zadajte  :quit<Enter>  pre ukonèenie programu Vim"
 
 #, c-format

--- a/src/po/sk.cp1250.po
+++ b/src/po/sk.cp1250.po
@@ -3734,7 +3734,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na konci zoznamu zmien"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Zadajte  :quit<Enter>  pre ukonèenie programu Vim"
+msgstr "Zadajte  :quit|<Enter>  pre ukonèenie programu Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/sk.cp1250.po
+++ b/src/po/sk.cp1250.po
@@ -3734,7 +3734,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na konci zoznamu zmien"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Zadajte  :quit|<Enter>  pre ukonèenie programu Vim"
+msgstr "Zadajte  :quit<Enter>  pre ukonèenie programu Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/sk.po
+++ b/src/po/sk.po
@@ -3733,7 +3733,7 @@ msgstr "E662: Na zaèiatku zoznamu zmien"
 msgid "E663: At end of changelist"
 msgstr "E663: Na konci zoznamu zmien"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Zadajte  :quit<Enter>  pre ukonèenie programu Vim"
 
 #, c-format

--- a/src/po/sk.po
+++ b/src/po/sk.po
@@ -3734,7 +3734,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na konci zoznamu zmien"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Zadajte  :quit<Enter>  pre ukonèenie programu Vim"
+msgstr "Zadajte  :quit|<Enter>  pre ukonèenie programu Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/sk.po
+++ b/src/po/sk.po
@@ -3734,7 +3734,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Na konci zoznamu zmien"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Zadajte  :quit|<Enter>  pre ukonèenie programu Vim"
+msgstr "Zadajte  :quit<Enter>  pre ukonèenie programu Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -3933,7 +3933,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Vid slutet av ändringslista"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "skriv  :q|<Enter>                för att avsluta Vim         "
+msgstr "skriv  :q<Enter>                för att avsluta Vim         "
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -3933,7 +3933,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Vid slutet av ändringslista"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "skriv  :q<Enter>                för att avsluta Vim         "
+msgstr "skriv  :q|<Enter>                för att avsluta Vim         "
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -3932,7 +3932,7 @@ msgstr "E662: Vid början av ändringslista"
 msgid "E663: At end of changelist"
 msgstr "E663: Vid slutet av ändringslista"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "skriv  :q<Enter>                för att avsluta Vim         "
 
 #, c-format

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -4198,7 +4198,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Кінець списку змін"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Уведіть :quit<Enter>  щоб вийти з Vim"
+msgstr "Уведіть :quit|<Enter>  щоб вийти з Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -4197,7 +4197,7 @@ msgstr "E662: Початок списку змін"
 msgid "E663: At end of changelist"
 msgstr "E663: Кінець списку змін"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Уведіть :quit<Enter>  щоб вийти з Vim"
 
 #, c-format

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -4198,7 +4198,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Кінець списку змін"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Уведіть :quit|<Enter>  щоб вийти з Vim"
+msgstr "Уведіть :quit<Enter>  щоб вийти з Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -4198,7 +4198,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Кінець списку змін"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Уведіть :quit<Enter>  щоб вийти з Vim"
+msgstr "Уведіть :quit|<Enter>  щоб вийти з Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -4197,7 +4197,7 @@ msgstr "E662: Початок списку змін"
 msgid "E663: At end of changelist"
 msgstr "E663: Кінець списку змін"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Уведіть :quit<Enter>  щоб вийти з Vim"
 
 #, c-format

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -4198,7 +4198,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Кінець списку змін"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Уведіть :quit|<Enter>  щоб вийти з Vim"
+msgstr "Уведіть :quit<Enter>  щоб вийти з Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/vi.po
+++ b/src/po/vi.po
@@ -3443,7 +3443,7 @@ msgstr "E662: Ở đầu danh sách những thay đổi"
 msgid "E663: At end of changelist"
 msgstr "E663: Ở cuối danh sách những thay đổi"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "Gõ :quit<Enter>  để thoát khỏi Vim"
 
 #, c-format

--- a/src/po/vi.po
+++ b/src/po/vi.po
@@ -3444,7 +3444,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ở cuối danh sách những thay đổi"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Gõ :quit<Enter>  để thoát khỏi Vim"
+msgstr "Gõ :quit|<Enter>  để thoát khỏi Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/vi.po
+++ b/src/po/vi.po
@@ -3444,7 +3444,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: Ở cuối danh sách những thay đổi"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "Gõ :quit|<Enter>  để thoát khỏi Vim"
+msgstr "Gõ :quit<Enter>  để thoát khỏi Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -3858,7 +3858,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "输入  :quit|<Enter>  退出 Vim"
+msgstr "输入  :quit<Enter>  退出 Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -3857,7 +3857,7 @@ msgstr "E662: 已在改变列表的开始处"
 msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "输入  :quit<Enter>  退出 Vim"
 
 #, c-format

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -3858,7 +3858,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "输入  :quit<Enter>  退出 Vim"
+msgstr "输入  :quit|<Enter>  退出 Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -3856,7 +3856,7 @@ msgstr "E662: 已在改变列表的开始处"
 msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "输入  :quit<Enter>  退出 Vim"
 
 #, c-format

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -3857,7 +3857,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "输入  :quit|<Enter>  退出 Vim"
+msgstr "输入  :quit<Enter>  退出 Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -3857,7 +3857,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "输入  :quit<Enter>  退出 Vim"
+msgstr "输入  :quit|<Enter>  退出 Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -3858,7 +3858,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "输入  :quit|<Enter>  退出 Vim"
+msgstr "输入  :quit<Enter>  退出 Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -3858,7 +3858,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "输入  :quit<Enter>  退出 Vim"
+msgstr "输入  :quit|<Enter>  退出 Vim"
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -3857,7 +3857,7 @@ msgstr "E662: 已在改变列表的开始处"
 msgid "E663: At end of changelist"
 msgstr "E663: 已在改变列表的末尾处"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "输入  :quit<Enter>  退出 Vim"
 
 #, c-format

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -3425,7 +3425,7 @@ msgstr "E662: 已在變更列表的開頭"
 msgid "E663: At end of changelist"
 msgstr "E663: 已在變更列表的結尾"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "要離開 Vim 請輸入 :quit<Enter> "
 
 #, c-format

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -3426,7 +3426,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在變更列表的結尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "要離開 Vim 請輸入 :quit|<Enter> "
+msgstr "要離開 Vim 請輸入 :quit<Enter> "
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -3426,7 +3426,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在變更列表的結尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "要離開 Vim 請輸入 :quit<Enter> "
+msgstr "要離開 Vim 請輸入 :quit|<Enter> "
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -3419,7 +3419,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在變更列表的結尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "要離開 Vim 請輸入 :quit<Enter> "
+msgstr "要離開 Vim 請輸入 :quit|<Enter> "
 
 #, c-format
 msgid "1 line %sed 1 time"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -3418,7 +3418,7 @@ msgstr "E662: 已在變更列表的開頭"
 msgid "E663: At end of changelist"
 msgstr "E663: 已在變更列表的結尾"
 
-msgid "Type  :quit<Enter>  to exit Vim"
+msgid "Type  :quit  and press <Enter> to exit Vim"
 msgstr "要離開 Vim 請輸入 :quit<Enter> "
 
 #, c-format

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -3419,7 +3419,7 @@ msgid "E663: At end of changelist"
 msgstr "E663: 已在變更列表的結尾"
 
 msgid "Type  :quit<Enter>  to exit Vim"
-msgstr "要離開 Vim 請輸入 :quit|<Enter> "
+msgstr "要離開 Vim 請輸入 :quit<Enter> "
 
 #, c-format
 msgid "1 line %sed 1 time"


### PR DESCRIPTION
As stated in issues https://github.com/vim/vim/issues/1719 and https://github.com/vim/vim/issues/1720, plenty of new users of vim do not know how to exit vim.

Apparently, some of them type what they see on the screen `:quit<Enter>`, but this is not a valid vim command, as this produces a `E488: Trailing characters`.

The proposal is to change the message to `:quit|<Enter>`, which is a valid command (and exits vim). 

  * Those who type what they see, will exit vim
  * Those who get the idea of typing `:quit`, then `<Enter>` will also exit vim
