### PR TITLE
Also free qf_last_bufname in ll_new_list

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1532,6 +1532,10 @@ ll_new_list(void)
 	qi->qf_refcount++;
     }
 
+    /* Do not used the cached buffer, it may have been wiped out. */
+    vim_free(qf_last_bufname);
+    qf_last_bufname = NULL;
+
     return qi;
 }
 


### PR DESCRIPTION
Followup to https://github.com/vim/vim/pull/1728.

Without this, the Neomake test suite would still fail.