### PR TITLE
Unified spellings "VIM" to "Vim" and "GVIM" or "Gvim" or "gVim" to "gvim" in help documents

### DIFF
--- a/runtime/doc/arabic.txt
+++ b/runtime/doc/arabic.txt
@@ -10,11 +10,11 @@ Arabic Language support (options & mappings) for Vim		*Arabic*
 
 								*E800*
 In order to use right-to-left and Arabic mapping support, it is
-necessary to compile VIM with the |+arabic| feature.
+necessary to compile Vim with the |+arabic| feature.
 
 These functions have been created by Nadim Shaikli <nadim-at-arabeyes.org>
 
-It is best to view this file with these settings within VIM's GUI: >
+It is best to view this file with these settings within Vim's GUI: >
 
 	:set encoding=utf-8
 	:set arabicshape
@@ -42,7 +42,7 @@ the user interface remains the standard Vi interface.
 
 Highlights
 ----------
-o  Editing left-to-right files as in the original VIM hasn't changed.
+o  Editing left-to-right files as in the original Vim hasn't changed.
 
 o  Viewing and editing files in right-to-left windows.	 File
    orientation is per window, so it is possible to view the same
@@ -52,7 +52,7 @@ o  No special terminal with right-to-left capabilities is required.
    The right-to-left changes are completely hardware independent.
    Only Arabic fonts are necessary.
 
-o  Compatible with the original VIM.   Almost all features work in
+o  Compatible with the original Vim.   Almost all features work in
    right-to-left mode (there are liable to be bugs).
 
 o  Changing keyboard mapping and reverse insert modes using a single
@@ -66,14 +66,14 @@ o  While in Arabic mode, numbers are entered from left to right.  Upon
 
 o  Arabic keymapping on the command line in reverse insert mode.
 
-o  Proper Bidirectional functionality is possible given VIM is
+o  Proper Bidirectional functionality is possible given Vim is
    started within a Bidi capable terminal emulator.
 
 
 Arabic Fonts						*arabicfonts*
 ------------
 
-VIM requires monospaced fonts of which there are many out there.
+Vim requires monospaced fonts of which there are many out there.
 Arabic requires ISO-8859-6 as well as Presentation Form-B fonts
 (without Form-B, Arabic will _NOT_ be usable).	It is highly
 recommended that users search for so-called 'ISO-10646-1' fonts.
@@ -96,13 +96,13 @@ o  Installation of fonts for X Window systems (Unix/Linux)
 
 Usage
 -----
-Prior to the actual usage of Arabic within VIM, a number of settings
+Prior to the actual usage of Arabic within Vim, a number of settings
 need to be accounted for and invoked.
 
 o  Setting the Arabic fonts
 
-   +  For VIM GUI set the 'guifont' to your_ARABIC_FONT.  This is done
-      by entering the following command in the VIM window.
+   +  For Vim GUI set the 'guifont' to your_ARABIC_FONT.  This is done
+      by entering the following command in the Vim window.
 >
 		:set guifont=your_ARABIC_FONT
 <
@@ -115,7 +115,7 @@ o  Setting the Arabic fonts
       you can include ':set guifont=your_ARABIC_FONT' to your .vimrc
       file.
 
-   +  Under the X Window environment, you can also start VIM with
+   +  Under the X Window environment, you can also start Vim with
       '-fn your_ARABIC_FONT' option.
 
 o  Setting the appropriate character Encoding
@@ -124,7 +124,7 @@ o  Setting the appropriate character Encoding
 >
 		:set encoding=utf-8
 <
-   to your .vimrc file (entering the command manually into you VIM
+   to your .vimrc file (entering the command manually into you Vim
    window is highly discouraged).  In short, include ':set
    encoding=utf-8' to your .vimrc file.
 
@@ -137,11 +137,11 @@ o  Setting the appropriate character Encoding
 o  Enable Arabic settings [short-cut]
 
    In order to simplify and streamline things, you can either invoke
-   VIM with the command-line option,
+   Vim with the command-line option,
 
      % vim -A my_utf8_arabic_file ...
 
-   or enable 'arabic' via the following command within VIM
+   or enable 'arabic' via the following command within Vim
 >
 		:set arabic
 <
@@ -189,7 +189,7 @@ o  Enable Arabic settings [short-cut]
 >
 		:set keymap=arabic
 <
-      in your VIM window.  You can also append the 'keymap' set command to
+      in your Vim window.  You can also append the 'keymap' set command to
       your .vimrc file.  In other words, you can include ':set keymap=arabic'
       to your .vimrc file.
 
@@ -202,7 +202,7 @@ o  Enable Arabic settings [short-cut]
 
    +  Arabic deletion of a combined pair character
 
-      By default VIM has the 'delcombine' option disabled.  This option
+      By default Vim has the 'delcombine' option disabled.  This option
       allows the deletion of ALEF in a LAM_ALEF (LAA) combined character
       and still retain the LAM (i.e. it reverts to treating the combined
       character as its natural two characters form -- this also pertains
@@ -211,13 +211,13 @@ o  Enable Arabic settings [short-cut]
 >
 		:set delcombine
 <
-      in our VIM window.  You can also append the 'delcombine' set command
+      in our Vim window.  You can also append the 'delcombine' set command
       to your .vimrc file.  In other words, you can include ':set delcombine'
       to your .vimrc file.
 
    +  Arabic right-to-left Mode
 
-      By default VIM starts in Left-to-right mode.  'rightleft' is the
+      By default Vim starts in Left-to-right mode.  'rightleft' is the
       command that allows one to alter a window's orientation - that can
       be accomplished via,
 
@@ -253,7 +253,7 @@ o  Enable Arabic settings [short-cut]
 >
 		:set arabicshape
 <
-      in our VIM window.  You can also append the 'arabicshape' set
+      in our Vim window.  You can also append the 'arabicshape' set
       command to your .vimrc file.  In other words, you can include
       ':set arabicshape' to your .vimrc file.
 
@@ -261,7 +261,7 @@ o  Enable Arabic settings [short-cut]
 Keymap/Keyboard						*arabickeymap*
 ---------------
 
-The character/letter encoding used in VIM is the standard UTF-8.
+The character/letter encoding used in Vim is the standard UTF-8.
 It is widely discouraged that any other encoding be used or even
 attempted.
 
@@ -294,7 +294,7 @@ o  Keyboard
 Restrictions
 ------------
 
-o  VIM in its GUI form does not currently support Bi-directionality
+o  Vim in its GUI form does not currently support Bi-directionality
    (i.e. the ability to see both Arabic and Latin intermixed within
    the same line).
 

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -610,7 +610,7 @@ FileChangedShell		When Vim notices that the modification time of
 				|timestamp|
 				Mostly triggered after executing a shell
 				command, but also with a |:checktime| command
-				or when Gvim regains input focus.
+				or when gvim regains input focus.
 				This autocommand is triggered for each changed
 				file.  It is not used when 'autoread' is set
 				and the buffer was not changed.  If a

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1455,7 +1455,7 @@ Do this before writing the file.  When reading an encrypted file it will be
 set automatically to the method used when that file was written.  You can
 change 'cryptmethod' before writing that file to change the method.
 
-To set the default method, used for new files, use this in your |vimrc|
+To set the default method, used for new files, use this in your |vimrc| 
 file: >
 	set cm=blowfish2
 Using "blowfish2" is highly recommended.  Only use another method if you

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1040,7 +1040,7 @@ if the system allows it (the directory must be writable).
 							*write-fail*
 If the writing of the new file fails, you have to be careful not to lose
 your changes AND the original file.  If there is no backup file and writing
-the new file failed, you have already lost the original file!  DON'T EXIT VIM
+the new file failed, you have already lost the original file!  DON'T EXIT Vim
 UNTIL YOU WRITE OUT THE FILE!  If a backup was made, it is put back in place
 of the original file (if possible).  If you exit Vim, and lose the changes
 you made, the original file will mostly still be there.  If putting back the
@@ -1455,7 +1455,7 @@ Do this before writing the file.  When reading an encrypted file it will be
 set automatically to the method used when that file was written.  You can
 change 'cryptmethod' before writing that file to change the method.
 
-To set the default method, used for new files, use this in your |vimrc| 
+To set the default method, used for new files, use this in your |vimrc|
 file: >
 	set cm=blowfish2
 Using "blowfish2" is highly recommended.  Only use another method if you

--- a/runtime/doc/ft_ada.txt
+++ b/runtime/doc/ft_ada.txt
@@ -116,7 +116,7 @@ NOTE: "gnat xref -v" is very tricky to use as it has almost no diagnostic
     then "gnat xref -v *.ad?"
 4)  Project manager support is completely broken - don't even try "gnat xref
     -Padacl.gpr".
-5)  VIM is faster when the tags file is sorted - use "sort --unique
+5)  Vim is faster when the tags file is sorted - use "sort --unique
     --ignore-case --output=tags tags" .
 6)  Remember to insert "!_TAG_FILE_SORTED 2 %sort ui" as first line to mark
     the file assorted.

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -383,7 +383,7 @@ Note that a menu that starts with ']' will not be displayed.
 7. Command line arguments				*gui-w32-cmdargs*
 
 Analysis of a command line into parameters is not standardised in MS Windows.
-Gvim has to provide logic to analyse a command line.  This logic is likely to
+gvim has to provide logic to analyse a command line.  This logic is likely to
 be different from the default logic provided by a compilation system used to
 build vim.  The differences relate to unusual double quote (") usage.
 The arguments "C:\My Music\freude.txt" and "+/Sch\"iller" are handled in the
@@ -472,7 +472,7 @@ with the Intellimouse driver 2.2 and when "Universal Scrolling" is turned on.
 
 XPM support						*w32-xpm-support*
 
-Gvim can be build on MS-Windows with support for XPM files.  |+xpm_w32|
+gvim can be build on MS-Windows with support for XPM files.  |+xpm_w32|
 See the Make_mvc.mak file for instructions, search for XPM.
 
 To try out if XPM support works do this: >

--- a/runtime/doc/hangulin.txt
+++ b/runtime/doc/hangulin.txt
@@ -6,7 +6,7 @@
 
 Introduction					*hangul*
 ------------
-It is to input hangul, the Korean language, with VIM GUI version.
+It is to input hangul, the Korean language, with Vim GUI version.
 If you have a XIM program, you can use another |+xim| feature.
 Basically, it is for anybody who has no XIM program.
 
@@ -31,7 +31,7 @@ You should set LANG variable to Korean locale such as ko, ko_KR.eucKR
 or ko_KR.UTF-8.
 If you set LC_ALL variable, it should be set to Korean locale also.
 
-VIM resource
+Vim resource
 ------------
 You may want to set 'encoding' and 'fileencodings'.
 Next are examples: >
@@ -53,12 +53,12 @@ If both are set, VIM_KEYBOARD has higher priority.
 
 Hangul Fonts
 ------------
-If you use GTK version of GVIM, you should set 'guifont' and 'guifontwide'.
+If you use GTK version of gvim, you should set 'guifont' and 'guifontwide'.
 For example: >
     set guifont=Courier\ 12
     set guifontwide=NanumGothicCoding\ 12
 
-If you use Motif or Athena version of GVIM, you should set 'guifontset' in
+If you use Motif or Athena version of gvim, you should set 'guifontset' in
 your vimrc.  You can set fontset in the .Xdefaults file.
 
 $HOME/.gvimrc: >
@@ -77,11 +77,11 @@ $HOME/.Xdefaults: >
 
 attention! the , (comma) or ; (semicolon)
 
-And there should be no ':set guifont'.  If it exists, then Gvim ignores
-':set guifontset'.  It means VIM runs without fontset supporting.
+And there should be no ':set guifont'.  If it exists, then gvim ignores
+':set guifontset'.  It means Vim runs without fontset supporting.
 So, you can see only English.  Hangul does not be correctly displayed.
 
-After "fontset" feature is enabled, VIM does not allow using english
+After "fontset" feature is enabled, Vim does not allow using english
 font only in "font" setting for syntax.
 For example, if you use >
    :set guifontset=eng_font,your_font
@@ -99,7 +99,7 @@ We don't support Johab font.
 We don't support Hanja input.
 And We don't have any plan to support them.
 
-If you really need such features, you can use console version of VIM with a
+If you really need such features, you can use console version of Vim with a
 capable terminal emulator.
 
 Bug or Comment

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -31,7 +31,7 @@ Get specific help:  It is possible to go directly to whatever you want help
 		    help entries for "word".
 		    Or use ":helpgrep word". |:helpgrep|
 
-VIM stands for Vi IMproved.  Most of VIM was made by Bram Moolenaar, but only
+Vim stands for Vi IMproved.  Most of Vim was made by Bram Moolenaar, but only
 through the help of many others.  See |credits|.
 ------------------------------------------------------------------------------
 						*doc-file-list* *Q_ct*

--- a/runtime/doc/if_ole.txt
+++ b/runtime/doc/if_ole.txt
@@ -41,9 +41,9 @@ instance), code similar to the following should be used:
 	$vim = new Win32::OLE 'Vim.Application';
 
 [C#] >
-        // Add a reference to VIM in your project. 
+        // Add a reference to Vim in your project.
         // Choose the COM tab.
-        // Select "VIM Ole Interface 1.1 Type Library"
+        // Select "Vim Ole Interface 1.1 Type Library"
 	Vim.Vim vimobj = new Vim.Vim();
 
 Vim does not support acting as a "hidden" OLE server, like some other OLE

--- a/runtime/doc/if_ole.txt
+++ b/runtime/doc/if_ole.txt
@@ -41,7 +41,7 @@ instance), code similar to the following should be used:
 	$vim = new Win32::OLE 'Vim.Application';
 
 [C#] >
-        // Add a reference to Vim in your project.
+        // Add a reference to Vim in your project. 
         // Choose the COM tab.
         // Select "Vim Ole Interface 1.1 Type Library"
 	Vim.Vim vimobj = new Vim.Vim();

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -7,7 +7,7 @@
 Perl and Vim				*perl* *Perl*
 
 1. Editing Perl files			|perl-editing|
-2. Compiling VIM with Perl interface	|perl-compiling|
+2. Compiling Vim with Perl interface	|perl-compiling|
 3. Using the Perl interface		|perl-using|
 4. Dynamic loading			|perl-dynamic|
 
@@ -33,7 +33,7 @@ Vim in the $VIMRUNTIME/tools directory.  This script has currently more
 features than Exuberant ctags' Perl support.
 
 ==============================================================================
-2. Compiling VIM with Perl interface			*perl-compiling*
+2. Compiling Vim with Perl interface			*perl-compiling*
 
 To compile Vim with Perl interface, you need Perl 5.004 (or later).  Perl must
 be installed before you compile Vim.  Vim's Perl interface does NOT work with
@@ -178,7 +178,7 @@ VIM::Windows([{wn}...])	With no arguments, returns a list of all the windows
 VIM::DoCommand({cmd})	Executes Ex command {cmd}.
 
 							*perl-Eval*
-VIM::Eval({expr})	Evaluates {expr} and returns (success, value) in list 
+VIM::Eval({expr})	Evaluates {expr} and returns (success, value) in list
 			context or just value in scalar context.
 			success=1 indicates that val contains the value of
 			{expr}; success=0 indicates a failure to evaluate

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -178,7 +178,7 @@ VIM::Windows([{wn}...])	With no arguments, returns a list of all the windows
 VIM::DoCommand({cmd})	Executes Ex command {cmd}.
 
 							*perl-Eval*
-VIM::Eval({expr})	Evaluates {expr} and returns (success, value) in list
+VIM::Eval({expr})	Evaluates {expr} and returns (success, value) in list 
 			context or just value in scalar context.
 			success=1 indicates that val contains the value of
 			{expr}; success=0 indicates a failure to evaluate

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -84,8 +84,8 @@ The Vim pages contain the most recent information about Vim.  They also
 contain links to the most recent version of Vim.  The FAQ is a list of
 Frequently Asked Questions.  Read this if you have problems.
 
-	VIM home page:	  http://www.vim.org/
-	VIM FAQ:	  http://vimdoc.sf.net/
+	Vim home page:	  http://www.vim.org/
+	Vim FAQ:	  http://vimdoc.sf.net/
 	Downloading:	  ftp://ftp.vim.org/pub/vim/MIRRORS
 
 
@@ -878,10 +878,10 @@ buffer lines	logical lines	window lines	screen lines ~
 						8.  ccc ccc c
 1. aaa		1. aaa		1. aaa		9.  cc
 2. bbb		2. bbb		2. bbb		10. ddd
-3. ccc ccc ccc	3. ccc ccc ccc	3. ccc ccc c	11. ~ 
+3. ccc ccc ccc	3. ccc ccc ccc	3. ccc ccc c	11. ~
 4. ddd		4. ddd		4. cc		12. === status line ===
 				5. ddd		13. (command line)
-				6. ~ 
+				6. ~
 
 ==============================================================================
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -878,10 +878,10 @@ buffer lines	logical lines	window lines	screen lines ~
 						8.  ccc ccc c
 1. aaa		1. aaa		1. aaa		9.  cc
 2. bbb		2. bbb		2. bbb		10. ddd
-3. ccc ccc ccc	3. ccc ccc ccc	3. ccc ccc c	11. ~
+3. ccc ccc ccc	3. ccc ccc ccc	3. ccc ccc c	11. ~ 
 4. ddd		4. ddd		4. cc		12. === status line ===
 				5. ddd		13. (command line)
-				6. ~
+				6. ~ 
 
 ==============================================================================
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -530,9 +530,9 @@ scenario: >
 	:imap <M-C> foo
 	:set encoding=utf-8
 The mapping for <M-C> is defined with the latin1 encoding, resulting in a 0xc3
-byte.  If you type the character á (0xe1 <M-a>) in UTF-8 encoding this is the
+byte.  If you type the character ï¿½ (0xe1 <M-a>) in UTF-8 encoding this is the
 two bytes 0xc3 0xa1.  You don't want the 0xc3 byte to be mapped then or
-otherwise it would be impossible to type the á character.
+otherwise it would be impossible to type the ï¿½ character.
 
 					*<Leader>* *mapleader*
 To define a mapping which uses the "mapleader" variable, the special string
@@ -798,7 +798,7 @@ Bear in mind that convert-meta has been reported to have troubles when used in
 UTF-8 locales.  On terminals like xterm, the "metaSendsEscape" resource can be
 toggled on the fly through the "Main Options" menu, by pressing Ctrl-LeftClick
 on the terminal; that's a good last resource in case you want to send ESC when
-using other applications but not when inside VIM.
+using other applications but not when inside Vim.
 
 
 1.11 MAPPING AN OPERATOR				*:map-operator*
@@ -1231,7 +1231,7 @@ reported if any are supplied).  However, it is possible to specify that the
 command can take arguments, using the -nargs attribute.  Valid cases are:
 
 	-nargs=0    No arguments are allowed (the default)
-	-nargs=1    Exactly one argument is required, it includes spaces 
+	-nargs=1    Exactly one argument is required, it includes spaces
 	-nargs=*    Any number of arguments are allowed (0, 1, or many),
 		    separated by white space
 	-nargs=?    0 or 1 arguments are allowed

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1231,7 +1231,7 @@ reported if any are supplied).  However, it is possible to specify that the
 command can take arguments, using the -nargs attribute.  Valid cases are:
 
 	-nargs=0    No arguments are allowed (the default)
-	-nargs=1    Exactly one argument is required, it includes spaces
+	-nargs=1    Exactly one argument is required, it includes spaces 
 	-nargs=*    Any number of arguments are allowed (0, 1, or many),
 		    separated by white space
 	-nargs=?    0 or 1 arguments are allowed

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -1328,7 +1328,7 @@ Useful commands:
   to automatically detect the encoding of a file.
 
 
-STARTING VIM
+STARTING Vim
 
 If your current locale is in an utf-8 encoding, Vim will automatically start
 in utf-8 mode.

--- a/runtime/doc/netbeans.txt
+++ b/runtime/doc/netbeans.txt
@@ -120,7 +120,7 @@ In case you do not want the NetBeans interface you can disable it by
 uncommenting a line with "--disable-netbeans" in the Makefile.
 
 Currently the NetBeans interface is supported by Vim running in a terminal and
-by GVim when it is run with one of the following GUIs: GTK, GNOME, Windows,
+by gvim when it is run with one of the following GUIs: GTK, GNOME, Windows,
 Athena and Motif.
 
 If Motif support is required the user must supply XPM libraries.  See
@@ -996,7 +996,7 @@ to "Vim".  In the Expert tab make sure the "Vim Command" is correct.
 You should be careful if you change the "Vim Command".  There are command
 line options there which must be there for the connection to be properly
 set up.  You can change the command name but that's about it.  If your gvim
-can be found by your $PATH then the VIM Command can start with "gvim".  If
+can be found by your $PATH then the Vim Command can start with "gvim".  If
 you don't want gvim searched from your $PATH then hard code in the full
 Unix path name.  At this point you should get a gvim for any source file
 you open in NetBeans.

--- a/runtime/doc/os_beos.txt
+++ b/runtime/doc/os_beos.txt
@@ -144,7 +144,7 @@ The default value for $VIM is set at compile time and can be determined with >
   :version
 
 The normal value is /boot/home/config/share/vim.  If you don't like it you can
-set the VIM environment variable to override this, or set 'helpfile' in your
+set the Vim environment variable to override this, or set 'helpfile' in your
 .vimrc: >
 
   :if version >= 500

--- a/runtime/doc/os_vms.txt
+++ b/runtime/doc/os_vms.txt
@@ -539,7 +539,7 @@ More info under :help hardcopy
 
 8.10 Setting up the symbols
 
-When I use GVIM this way and press CTRL-Y in the parent terminal, gvim exits.
+When I use gvim this way and press CTRL-Y in the parent terminal, gvim exits.
 I now use a different symbol that seems to work OK and fixes the problem.
 I suggest this instead: >
 
@@ -547,7 +547,7 @@ I suggest this instead: >
 
 The /INPUT=NLA0: separates the standard input of the gvim process from the
 parent terminal, to block signals from the parent window.
-Without the -GEOMETRY, the GVIM window size will be minimal and the menu
+Without the -GEOMETRY, the gvim window size will be minimal and the menu
 will be confused after a window-resize.
 
 (Carlo Mekenkamp, Coen Engelbarts, Vim 6.0ac)
@@ -702,13 +702,13 @@ In a cluster that contains nodes with different architectures like below:
 $show cluster
 View of Cluster from system ID 11655  node: TOR                                                                     18-AUG-2008 11:58:31
 +---------------------------------+
-¦        SYSTEMS        ¦ MEMBERS ¦
-+-----------------------+---------¦
-¦  NODE  ¦   SOFTWARE   ¦  STATUS ¦
-+--------+--------------+---------¦
-¦ TOR    ¦ VMS V7.3-2   ¦ MEMBER  ¦
-¦ TITAN2 ¦ VMS V8.3     ¦ MEMBER  ¦
-¦ ODIN   ¦ VMS V7.3-2   ¦ MEMBER  ¦
+ï¿½        SYSTEMS        ï¿½ MEMBERS ï¿½
++-----------------------+---------ï¿½
+ï¿½  NODE  ï¿½   SOFTWARE   ï¿½  STATUS ï¿½
++--------+--------------+---------ï¿½
+ï¿½ TOR    ï¿½ VMS V7.3-2   ï¿½ MEMBER  ï¿½
+ï¿½ TITAN2 ï¿½ VMS V8.3     ï¿½ MEMBER  ï¿½
+ï¿½ ODIN   ï¿½ VMS V7.3-2   ï¿½ MEMBER  ï¿½
 +---------------------------------+
 
 It is convenient to have a common VIM directory but execute different
@@ -764,14 +764,14 @@ GNU_TOOLS.ZIP package downloadable from http://www.polarhome.com/vim/
 
 9. VMS related changes					*vms-changes*
 
-Version 7.4 
-- Undo: VMS can not handle more than one dot in the filenames use "dir/name" -> "dir/_un_name" 
+Version 7.4
+- Undo: VMS can not handle more than one dot in the filenames use "dir/name" -> "dir/_un_name"
   add _un_ at the beginning to keep the extension
 - correct swap file name wildcard handling
 - handle iconv usage correctly
 - do not optimize on vax - otherwise it hangs compiling crypto files
 - fileio.c fix the comment
-- correct RealWaitForChar 
+- correct RealWaitForChar
 - after 7.4-119 use different functions lib$cvtf_to_internal_time because Alpha and VAX have
   G_FLOAT but IA64 uses IEEE float otherwise Vim crashes
 - guard against crashes that are caused by mixed filenames

--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -135,7 +135,7 @@ you will need to get a version older than that.
 6. Running under Windows 3.1				*win32-win3.1*
 
 					*win32s* *windows-3.1* *gui-w32s*
-There was a special version of Gvim that runs under Windows 3.1 and 3.11.
+There was a special version of gvim that runs under Windows 3.1 and 3.11.
 Support was removed in patch 7.4.1363.
 
 ==============================================================================
@@ -195,7 +195,7 @@ A. VisionFS can't handle certain dot (.) three letter extension file names.
    SCO declares this behavior required for backwards compatibility with 16bit
    DOS/Windows environments.  The two commands below demonstrate the behavior:
 >
-	echo Hello > file.bat~ 
+	echo Hello > file.bat~
 	dir > file.bat
 <
    The result is that the "dir" command updates the "file.bat~" file, instead

--- a/runtime/doc/pi_getscript.txt
+++ b/runtime/doc/pi_getscript.txt
@@ -9,7 +9,7 @@ Copyright: (c) 2004-2012 by Charles E. Campbell	*glvs-copyright*
 	The VIM LICENSE (see |copyright|) applies to the files in this
 	package, including getscriptPlugin.vim, getscript.vim,
 	GetLatestVimScripts.dist, and pi_getscript.txt, except use "getscript"
-	instead of "VIM".  Like anything else that's free, getscript and its
+	instead of "Vim".  Like anything else that's free, getscript and its
 	associated files are provided *as is* and comes with no warranty of
 	any kind, either expressed or implied.  No guarantees of
 	merchantability.  No guarantees of suitability for any purpose.  By
@@ -41,13 +41,13 @@ get the latest versions of scripts listed therein from http://vim.sf.net/.
 2. GetLatestVimScripts -- Getting Started		*getscript-start*
 						*getlatestvimscripts-install*
 
-	VERSION FROM VIM DISTRIBUTION			*glvs-dist-install*
+	VERSION FROM Vim DISTRIBUTION			*glvs-dist-install*
 
 Vim 7.0 does not include the GetLatestVimScripts.dist file which
 serves as an example and a template.  So, you'll need to create
 your own!  See |GetLatestVimScripts_dat|.
 
-	VERSION FROM VIM SF NET				*glvs-install*
+	VERSION FROM Vim SF NET				*glvs-install*
 
 NOTE: The last step, that of renaming/moving the GetLatestVimScripts.dist
 file, is for those who have just downloaded GetLatestVimScripts.tar.bz2 for
@@ -68,7 +68,7 @@ Your computer needs to have wget or curl for GetLatestVimScripts to do its work.
 		mv GetLatestVimScripts.dist GetLatestVimScripts.dat
 		(edit GetLatestVimScripts.dat to install your own personal
 		list of desired plugins -- see |GetLatestVimScripts_dat|)
-	
+
 	3. Windows:
 		vim getscript.vba
 		:so %

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1334,7 +1334,7 @@ Associated setting variables:
    |g:netrw_winsize| control initial sizing
 
 
-BROWSING USING A GVIM SERVER			*netrw-ctrl-r* {{{2
+BROWSING USING A gvim SERVER			*netrw-ctrl-r* {{{2
 
 One may keep a browsing gvim separate from the gvim being used to edit.
 Use the <c-r> map on a file (not a directory) in the netrw browser, and it
@@ -2206,7 +2206,7 @@ future I may make it possible to use |regexp|s instead of glob()-style
 expressions (yet-another-option).
 
 
-MARKED FILES, ARBITRARY VIM COMMAND				*netrw-mv*  {{{2
+MARKED FILES, ARBITRARY Vim COMMAND				*netrw-mv*  {{{2
 	    (See |netrw-mf| and |netrw-mr| for how to mark files)
 		      (uses the local marked-file list)
 

--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -99,25 +99,25 @@ If the option is empty, then vim will use the system default printer for
 					HPUX: hp-roman8,
 					EBCDIC: ebcdic-uk)
 			global
-Sets the character encoding used when printing.  This option tells VIM which
+Sets the character encoding used when printing.  This option tells Vim which
 print character encoding file from the "print" directory in 'runtimepath' to
 use.
 
 This option will accept any value from |encoding-names|.  Any recognized names
-are converted to VIM standard names - see 'encoding' for more details.  Names
-not recognized by VIM will just be converted to lower case and underscores
+are converted to Vim standard names - see 'encoding' for more details.  Names
+not recognized by Vim will just be converted to lower case and underscores
 replaced with '-' signs.
 
-If 'printencoding' is empty or VIM cannot find the file then it will use
-'encoding' (if VIM is compiled with |+multi_byte| and it is set an 8-bit
-encoding) to find the print character encoding file.  If VIM is unable to find
+If 'printencoding' is empty or Vim cannot find the file then it will use
+'encoding' (if Vim is compiled with |+multi_byte| and it is set an 8-bit
+encoding) to find the print character encoding file.  If Vim is unable to find
 a character encoding file then it will use the "latin1" print character
 encoding file.
 
-When 'encoding' is set to a multi-byte encoding, VIM will try to convert
+When 'encoding' is set to a multi-byte encoding, Vim will try to convert
 characters to the printing encoding for printing (if 'printencoding' is empty
 then the conversion will be to latin1).  Conversion to a printing encoding
-other than latin1 will require VIM to be compiled with the |+iconv| feature.
+other than latin1 will require Vim to be compiled with the |+iconv| feature.
 If no conversion is possible then printing will fail.  Any characters that
 cannot be converted will be replaced with upside down question marks.
 
@@ -203,7 +203,7 @@ header is used when this option is empty.
 'printmbcharset' 'pmbcs'  string (default "")
 			  global
 Sets the CJK character set to be used when generating CJK output from
-|:hardcopy|.  The following predefined values are currently recognised by VIM:
+|:hardcopy|.  The following predefined values are currently recognised by Vim:
 
 		Value		Description ~
   Chinese	GB_2312-80
@@ -270,7 +270,7 @@ Japanese text you would do the following; >
 
 If 'printmbcharset' is not one of the above values then it is assumed to
 specify a custom multi-byte character set and no check will be made that it is
-compatible with the value for 'printencoding'.  VIM will look for a file
+compatible with the value for 'printencoding'.  Vim will look for a file
 defining the character set in the "print" directory in 'runtimepath'.
 
 							*pmbfn-option*
@@ -420,10 +420,10 @@ There are currently a number of limitations with PostScript printing:
   possible to get all the characters in an encoding to print by installing a
   new version of the Courier font family.
 
-- Multi-byte support - Currently VIM will try to convert multi-byte characters
+- Multi-byte support - Currently Vim will try to convert multi-byte characters
   to the 8-bit encoding specified by 'printencoding' (or latin1 if it is
   empty).  Any characters that are not successfully converted are shown as
-  unknown characters.  Printing will fail if VIM cannot convert the multi-byte
+  unknown characters.  Printing will fail if Vim cannot convert the multi-byte
   to the 8-bit encoding.
 
 ==============================================================================
@@ -434,11 +434,11 @@ you need to define your own PostScript font encoding vector.  Details on how
 to define a font encoding vector is beyond the scope of this help file, but
 you can find details in the PostScript Language Reference Manual, 3rd Edition,
 published by Addison-Wesley and available in PDF form at
-http://www.adobe.com/.  The following describes what you need to do for VIM to
+http://www.adobe.com/.  The following describes what you need to do for Vim to
 locate and use your print character encoding.
 
 i.   Decide on a unique name for your encoding vector, one that does not clash
-     with any of the recognized or standard encoding names that VIM uses (see
+     with any of the recognized or standard encoding names that Vim uses (see
      |encoding-names| for a list), and that no one else is likely to use.
 ii.  Copy $VIMRUNTIME/print/latin1.ps to the print subdirectory in your
      'runtimepath' and rename it with your unique name.
@@ -446,23 +446,23 @@ iii. Edit your renamed copy of latin1.ps, replacing all occurrences of latin1
      with your unique name (don't forget the line starting %%Title:), and
      modify the array of glyph names to define your new encoding vector.  The
      array must have exactly 256 entries or you will not be able to print!
-iv.  Within VIM, set 'printencoding' to your unique encoding name and then
-     print your file.  VIM will now use your custom print character encoding.
+iv.  Within Vim, set 'printencoding' to your unique encoding name and then
+     print your file.  Vim will now use your custom print character encoding.
 
-VIM will report an error with the resource file if you change the order or
+Vim will report an error with the resource file if you change the order or
 content of the first 3 lines, other than the name of the encoding on the line
 starting %%Title: or the version number on the line starting %%Version:.
 
-[Technical explanation for those that know PostScript - VIM looks for a file
+[Technical explanation for those that know PostScript - Vim looks for a file
 with the same name as the encoding it will use when printing.  The file
 defines a new PostScript Encoding resource called /VIM-name, where name is the
-print character encoding VIM will use.]
+print character encoding Vim will use.]
 
 ==============================================================================
 5. PostScript CJK Printing			*postscript-cjk-printing*
 							*E673* *E674* *E675*
 
-VIM supports printing of Chinese, Japanese, and Korean files.  Setting up VIM
+Vim supports printing of Chinese, Japanese, and Korean files.  Setting up Vim
 to correctly print CJK files requires setting up a few more options.
 
 Each of these countries has many standard character sets and encodings which
@@ -483,7 +483,7 @@ option allows you to specify different fonts to use when printing characters
 which are syntax highlighted with the font styles normal, italic, bold and
 bold-italic.
 
-No CJK fonts are supplied with VIM.  There are some free Korean, Japanese, and
+No CJK fonts are supplied with Vim.  There are some free Korean, Japanese, and
 Traditional Chinese fonts available at:
 
   http://examples.oreilly.com/cjkvinfo/adobe/samples/
@@ -498,7 +498,7 @@ CJK fonts can be large containing several thousand glyphs, and it is not
 uncommon to find that they only contain a subset of a national standard.  It
 is not unusual to find the fonts to not include characters for codes in the
 ASCII code range.  If you find half-width Roman characters are not appearing
-in your printout then you should configure VIM to use the Courier font the
+in your printout then you should configure Vim to use the Courier font the
 half-width ASCII characters with 'printmbfont'.  If your font does not include
 other characters then you will need to find another font that does.
 
@@ -506,7 +506,7 @@ Another issue with ASCII characters, is that the various national character
 sets specify a couple of different glyphs in the ASCII code range.  If you
 print ASCII text using the national character set you may see some unexpected
 characters.  If you want true ASCII code printing then you need to configure
-VIM to output ASCII characters for the ASCII code range with 'printmbfont'.
+Vim to output ASCII characters for the ASCII code range with 'printmbfont'.
 
 It is possible to define your own multi-byte character set although this
 should not be attempted lightly.  A discussion on the process if beyond the
@@ -525,13 +525,13 @@ print job completing.
 There are a number of possible causes as to why the printing may have failed:
 
 - Wrong version of the prolog resource file.  The prolog resource file
-  contains some PostScript that VIM needs to be able to print.  Each version
-  of VIM needs one particular version.  Make sure you have correctly installed
+  contains some PostScript that Vim needs to be able to print.  Each version
+  of Vim needs one particular version.  Make sure you have correctly installed
   the runtime files, and don't have any old versions of a file called prolog
   in the print directory in your 'runtimepath' directory.
 
 - Paper size.  Some PostScript printers will abort printing a file if they do
-  not support the requested paper size.  By default VIM uses A4 paper.  Find
+  not support the requested paper size.  By default Vim uses A4 paper.  Find
   out what size paper your printer normally uses and set the appropriate paper
   size with 'printoptions'.  If you cannot find the name of the paper used,
   measure a sheet and compare it with the table of supported paper sizes listed
@@ -668,7 +668,7 @@ complex print document creation.
 
 N-UP PRINTING
 
-The psnup utility takes an existing PostScript file generated from VIM and
+The psnup utility takes an existing PostScript file generated from Vim and
 convert it to an n-up version.  The simplest way to create a 2-up printout is
 to first create a PostScript file with: >
 
@@ -724,16 +724,16 @@ There are a couple of points to bear in mind:
 ==============================================================================
 8. Formfeed Characters					*printing-formfeed*
 
-By default VIM does not do any special processing of |formfeed| control
-characters.  Setting the 'printoptions' formfeed item will make VIM recognize
+By default Vim does not do any special processing of |formfeed| control
+characters.  Setting the 'printoptions' formfeed item will make Vim recognize
 formfeed characters and continue printing the current line at the beginning
 of the first line on a new page.  The use of formfeed characters provides
 rudimentary print control but there are certain things to be aware of.
 
-VIM will always start printing a line (including a line number if enabled)
+Vim will always start printing a line (including a line number if enabled)
 containing a formfeed character, even if it is the first character on the
 line.  This means if a line starting with a formfeed character is the first
-line of a page then VIM will print a blank page.
+line of a page then Vim will print a blank page.
 
 Since the line number is printed at the start of printing the line containing
 the formfeed character, the remainder of the line printed on the new page
@@ -742,7 +742,7 @@ lines of a long line when wrap in 'printoptions' is enabled).
 
 If the formfeed character is the last character on a line, then printing will
 continue on the second line of the new page, not the first.  This is due to
-VIM processing the end of the line after the formfeed character and moving
+Vim processing the end of the line after the formfeed character and moving
 down a line to continue printing.
 
 Due to the points made above it is recommended that when formfeed character

--- a/runtime/doc/quotes.txt
+++ b/runtime/doc/quotes.txt
@@ -18,7 +18,7 @@ Coming with a very GUI mindset from Windows, I always thought of people using
 Vi as some kind of outer space alien in human clothes.  Once I tried I really
 got addicted by its power and now I found myself typing Vim keypresses in the
 oddest places! That's why I would like to see Vim embedded in every
-application which deals with text editing.  (José Fonseca)
+application which deals with text editing.  (Josï¿½ Fonseca)
 
 I was a 12-year emacs user who switched to Vim about a year ago after finally
 giving up on the multiple incompatible versions, flaky contributed packages,
@@ -63,53 +63,53 @@ versions of 'emacs' in the late 1970's and was relieved by finding 'vi' in the
 first UNIX I came across in 1983).  In my opinion, it's about time 'VIM'
 replace 'emacs' as the standard for top editors.  (Bo Thide', Sweden)
 
-I love and use VIM heavily too.  (Larry Wall)
+I love and use Vim heavily too.  (Larry Wall)
 
 Vi is like a Ferrari, if you're a beginner, it handles like a bitch, but once
 you get the hang of it, it's small, powerful and FAST! (Unknown)
-VIM is like a new model Ferrari, and sounds like one too - "VIIIIIIMMM!"
+Vim is like a new model Ferrari, and sounds like one too - "VIIIIIIMMM!"
 (Stephen Riehm, Germany)
 
-Schon bei Nutzung eines Bruchteils der VIM-Funktionen wird der Benutzer recht
+Schon bei Nutzung eines Bruchteils der Vim-Funktionen wird der Benutzer recht
 schnell die Vorzuege dieses Editors kennen- und schaetzenlernen.
-Translated: Even when only using a fraction of VIM-functions, the user will
+Translated: Even when only using a fraction of Vim-functions, the user will
 quickly get used to and appreciate the advantages of this editor.  (Garry
-Glendown, conclusion of an article on VIM in iX magazine 9/1998)
+Glendown, conclusion of an article on Vim in iX magazine 9/1998)
 
-I've recently acquired the O'Reilly book on VI (it also discusses VIM
+I've recently acquired the O'Reilly book on VI (it also discusses Vim
 in-depth), and I'm amazed at just how powerful this application is.  (Jeffrey
 Rankin)
 
-This guide was written using the Windows 9.x distribution of GVIM, which is
+This guide was written using the Windows 9.x distribution of gvim, which is
 quite possibly the greatest thing to come along since God created the naked
 girl.  (Michael DiBernardo)
 
-Boy, I thought I knew almost everything about VIM, but every time I browse the
-online documentation, I hit upon a minor but cool aspect of a VIM feature that
+Boy, I thought I knew almost everything about Vim, but every time I browse the
+online documentation, I hit upon a minor but cool aspect of a Vim feature that
 I didn't know before!  I must say the documentation is one the finest I've
 ever seen in a product -- even better than most commercial products.
 (Gautam Mudunuri)
 
-VIM 4.5 is really a fantastic editor.  It has sooooo many features and more
+Vim 4.5 is really a fantastic editor.  It has sooooo many features and more
 importantly, the defaults are so well thought out that you really don't have
 to change anything!!  Words cannot express my amazement and gratitude to the
-creators of VIM.  Keep it up.  (Vikas, USA)
+creators of Vim.  Keep it up.  (Vikas, USA)
 
 I wonder how long it will be before people will refer to other Vi editors as
-VIM clones?  (Darren Hiebert)
+Vim clones?  (Darren Hiebert)
 
 I read about [auto-positioning-in-file-based-on-the-errors-from-make] in one
 of those "Perfect Programmer's Editor" threads and was delighted to discover
-that VIM already supports it.  (Brendan Macmillan, Australia)
+that Vim already supports it.  (Brendan Macmillan, Australia)
 
-I just discovered VIM (5.0) and I'm telling everyone I know about it!
-I tell them VIM stands for VI for the new (M)illenium.  Thanks so much!
+I just discovered Vim (5.0) and I'm telling everyone I know about it!
+I tell them Vim stands for VI for the new (M)illenium.  Thanks so much!
 (Matt F. Valentine)
 
 I think from now on "vi" should be called "Vim Imitation", not the other way
 around.  (Rungun Ramanathan)
 
-The Law of VIM:
+The Law of Vim:
 For each member b of the possible behaviour space B of program P, there exists
 a finite time t before which at least one user u in the total user space U of
 program P will request b becomes a member of the allowed behaviour space B'
@@ -118,42 +118,42 @@ In other words: Sooner or later everyone wants everything as an option.
 (Negri)
 
 Whenever I move to a new computing platform, the first thing I do is to port
-VIM.  Lately, I am simply stunned by its ease of compilation using the
+Vim.  Lately, I am simply stunned by its ease of compilation using the
 configure facility.  (A.M. Sabuncu, Turkey)
 
 The options are really excellent and very powerful.  (Anish Maharaj)
 
 The Spring user-interface designs are in, and word from the boutiques is that
-80x24 text-only mode is back with a *vengeance! Vi editor clone VIM burst onto
+80x24 text-only mode is back with a *vengeance! Vi editor clone Vim burst onto
 March desk-tops with a dazzling show of pastel syntax highlights for its 5.0
-look.  Strident and customizable, VIM raises eyebrows with its interpretation
+look.  Strident and customizable, Vim raises eyebrows with its interpretation
 of the classic Vi single-key macro collection.
 http://www.ntk.net/index.cgi?back=archive98/now0327.txt&line=179#l
 
-I just wanted to take this opportunity to let you know that VIM 5 ROCKS!
+I just wanted to take this opportunity to let you know that Vim 5 ROCKS!
 Syntax highlighting: how did I survive without it?!  Thank you for creating
 mankind's best editor!  (Mun Johl, USA)
 
-Thanks again for VIM.  I use it every day on Linux.  (Eric Foster-Johnson,
+Thanks again for Vim.  I use it every day on Linux.  (Eric Foster-Johnson,
 author of the book "UNIX Programming Tools")
 
 The BEST EDITOR EVER (Stuart Woolford)
 
-I have used most of VIM's fancy features at least once, many frequently, and I
+I have used most of Vim's fancy features at least once, many frequently, and I
 can honestly say that I couldn't live with anything less anymore.  My
 productivity has easily doubled compared to what it was when I used vi.
 (Sitaram Chamarty)
 
-I luv VIM.  It is incredible.  I'm naming my first-born Vimberly.  (Jose
+I luv Vim.  It is incredible.  I'm naming my first-born Vimberly.  (Jose
 Unpingco, USA)
 
-Hint:  "VIM" is "vi improved" - much better! (Sven Guckes, Germany)
+Hint:  "Vim" is "vi improved" - much better! (Sven Guckes, Germany)
 
-I use VIM every day.  I spend more time in VIM than in any other program...
+I use Vim every day.  I spend more time in Vim than in any other program...
 It's the best vi clone there is.  I think it's great.  (Craig Sanders,
 Australia)
 
-I strongly advise using VIM--its infinite undo/redo saved me much grief.
+I strongly advise using Vim--its infinite undo/redo saved me much grief.
 (Terry Brown)
 
 Thanks very much for writing what in my opinion is the finest text editor on
@@ -163,98 +163,98 @@ the planet.  If I were to get another cat, I would name it "Vim".
 I typed :set all and the screen FILLED up with options.  A whole screen of
 things to be set and unset.  I saw some of my old friends like wrapmargin,
 modelines and showmode, but the screen was FILLED with new friends!   I love
-them all!   I love VIM!   I'm so happy that I've found this editor!  I feel
+them all!   I love Vim!   I'm so happy that I've found this editor!  I feel
 like how I once felt when I started using vi after a couple of years of using
 ed.  I never thought I'd forsake my beloved ed, but vi ... oh god, vi was
-great.  And now, VIM.  (Peter Jay Salzman, USA)
+great.  And now, Vim.  (Peter Jay Salzman, USA)
 
 I am really happy with such a wonderful software package.  Much better than
 almost any expensive, off the shelf program.  (Jeff Walker)
 
-Whenever I reread the VIM documentation I'm overcome with excitement at the
+Whenever I reread the Vim documentation I'm overcome with excitement at the
 power of the editor.  (William Edward Webber, Australia)
 
-Hurrah for VIM!! It is "at your fingertips" like vi, and has the extensions
+Hurrah for Vim!! It is "at your fingertips" like vi, and has the extensions
 that vi sorely needs: highlighting for executing commands on blocks, an easily
 navigable and digestible help screen, and more.  (Paul Pax)
 
 The reason WHY I don't have this amazingly useful macro anymore, is that I
-now use VIM - and this is built in!! (Stephen Riehm, Germany)
+now use Vim - and this is built in!! (Stephen Riehm, Germany)
 
-I am a user of VIM and I love it.  I use it to do all my programming, C,
+I am a user of Vim and I love it.  I use it to do all my programming, C,
 C++, HTML what ever.  (Tim Allwine)
 
-I discovered VIM after years of struggling with the original vi, and I just
+I discovered Vim after years of struggling with the original vi, and I just
 can't live without it anymore.  (Emmanuel Mogenet, USA)
 
-Emacs has not a bit of chance to survive so long as VIM is around.  Besides,
+Emacs has not a bit of chance to survive so long as Vim is around.  Besides,
 it also has the most detailed software documentation I have ever seen---much
 better than most commercial software!  (Leiming Qian)
 
-This version of VIM will just blow people apart when they discover just how
+This version of Vim will just blow people apart when they discover just how
 fantastic it is! (Tony Nugent, Australia)
 
-I took your advice & finally got VIM & I'm really impressed.  Instant convert.
+I took your advice & finally got Vim & I'm really impressed.  Instant convert.
 (Patrick Killelea, USA)
 
-VIM is by far my favorite piece of shareware and I have been particularly
+Vim is by far my favorite piece of shareware and I have been particularly
 pleased with version 3.0.  This is really a solid piece of work.  (Robert
 Colon, USA)
 
-VIM is a joy to use, it is so well thought and practical that I wonder why
-anybody would use visual development tools.  VIM is powerful and elegant, it
+Vim is a joy to use, it is so well thought and practical that I wonder why
+anybody would use visual development tools.  Vim is powerful and elegant, it
 looks deceptively simple but is almost as complex as a 747 (especially when I
-look at my growing .vimrc), keep up that wonderful job, VIM is a centerpiece
+look at my growing .vimrc), keep up that wonderful job, Vim is a centerpiece
 of the free software world.  (Louis-David Mitterand, USA)
 
-I cannot believe how great it is to use VIM.  I think the guys at work are
+I cannot believe how great it is to use Vim.  I think the guys at work are
 getting tired of hearing me bragging about it.  Others eyes are lighting up.
 (Rick Croote)
 
 Emacs takes way too much time to start up and run, it is too big and bulky for
-effective use and the interface is more confusing than it is of any help.  VIM
+effective use and the interface is more confusing than it is of any help.  Vim
 however is short, it is fast, it is powerful, it has a good interface and it
 is all purpose.  (Paal Ditlefsen Ekran)
 
-From the first time I got VIM3.0, I was very enthusiastic.  It has almost no
+From the first time I got Vim3.0, I was very enthusiastic.  It has almost no
 problems.  The swapfile handling and the backup possibilities are robust, also
 the protection against editing one file twice.  It is very compatible to the
 real VI (and that is a MUST, because my brain is trained over years in using
 it).  (Gert van Antwerpen, Holland)
 
-Visual mode in VIM is a very powerful thing! (Tony Nugent, Australia)
+Visual mode in Vim is a very powerful thing! (Tony Nugent, Australia)
 
-I have to say that VIM is =THE= single greatest piece of source code to ever
+I have to say that Vim is =THE= single greatest piece of source code to ever
 come across the net (Jim Battle, USA).
 
-In fact, if you do want to get a new vi I'd suggest VIM-3.0.  This is, by
+In fact, if you do want to get a new vi I'd suggest Vim-3.0.  This is, by
 far, the best version of vi I've ever seen (Albert W. Schueller).
 
-I should mention that VIM is a very good editor and can compete with anything
+I should mention that Vim is a very good editor and can compete with anything
 (Ilya Beloozerov).
 
 To tell the truth sometimes I used elvis, vile, xvi, calvin, etc.  And this is
-the reason that I can state that VIM is the best! (Ferenc Deak, Hungary)
+the reason that I can state that Vim is the best! (Ferenc Deak, Hungary)
 
-VIM is by far the best editor that I have used in a long time, and I have
+Vim is by far the best editor that I have used in a long time, and I have
 looked at just about every thing that is available for every platform that I
-use.  VIM is the best on all of them.  (Guy L. Oliver)
+use.  Vim is the best on all of them.  (Guy L. Oliver)
 
-VIM is the greatest editor since the stone chisel.  (Jose Unpingco, USA)
+Vim is the greatest editor since the stone chisel.  (Jose Unpingco, USA)
 
-I would like to say that with VIM I am finally making the 'emacs to vi'
+I would like to say that with Vim I am finally making the 'emacs to vi'
 transition - as an Editor it is so much better in many ways: keyboard layout,
 memory usage, text alteration to name 3.  (Mark Adam)
 
 In fact, now if I want to know what a particular setting does in vi, I fire up
-VIM and check out its help!  (Nikhil Patel, USA)
+Vim and check out its help!  (Nikhil Patel, USA)
 
-As a vi user, VIM has made working with text a far more pleasant task than
+As a vi user, Vim has made working with text a far more pleasant task than
 before I encountered this program.  (Steinar Knutsen, Norway)
 
-I use VIM since version 3.0.  Since that time, it is the ONLY editor I use,
-with Solaris, Linux and OS/2 Warp.  I suggest all my friends to use VIM, they
-try, and they continue using it.  VIM is really the best software I have ever
+I use Vim since version 3.0.  Since that time, it is the ONLY editor I use,
+with Solaris, Linux and OS/2 Warp.  I suggest all my friends to use Vim, they
+try, and they continue using it.  Vim is really the best software I have ever
 downloaded from the Internet, and the best editor I know of.  (Marco
 Eccettuato, Italy)
 

--- a/runtime/doc/quotes.txt
+++ b/runtime/doc/quotes.txt
@@ -18,7 +18,7 @@ Coming with a very GUI mindset from Windows, I always thought of people using
 Vi as some kind of outer space alien in human clothes.  Once I tried I really
 got addicted by its power and now I found myself typing Vim keypresses in the
 oddest places! That's why I would like to see Vim embedded in every
-application which deals with text editing.  (Jos� Fonseca)
+application which deals with text editing.  (José Fonseca)
 
 I was a 12-year emacs user who switched to Vim about a year ago after finally
 giving up on the multiple incompatible versions, flaky contributed packages,

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -426,7 +426,7 @@ program, and add @NoSpell for items that shouldn't be checked.
 Also see |:syn-spell| for text that is not in a syntax item.
 
 
-VIM SCRIPTS
+Vim SCRIPTS
 
 If you want to write a Vim script that does something with spelling, you may
 find these functions useful:
@@ -478,7 +478,7 @@ Vim uses a binary file format for spelling.  This greatly speeds up loading
 the word list and keeps it small.
 						    *.aff* *.dic* *Myspell*
 You can create a Vim spell file from the .aff and .dic files that Myspell
-uses.  Myspell is used by OpenOffice.org and Mozilla. The OpenOffice .oxt 
+uses.  Myspell is used by OpenOffice.org and Mozilla. The OpenOffice .oxt
 files are zip files which contain the .aff and .dic files. You should be able
 to find them here:
 	http://extensions.services.openoffice.org/dictionary
@@ -907,9 +907,9 @@ when using "cp1250" on Unix.
 						*spell-LOW* *spell-UPP*
 Three lines in the affix file are needed.  Simplistic example:
 
-	FOL  áëñ ~
-	LOW  áëñ ~
-	UPP  ÁËÑ ~
+	FOL  ï¿½ï¿½ï¿½ ~
+	LOW  ï¿½ï¿½ï¿½ ~
+	UPP  ï¿½ï¿½ï¿½ ~
 
 All three lines must have exactly the same number of characters.
 
@@ -924,9 +924,9 @@ The "UPP" line specifies the characters with upper-case.  That is, a character
 is upper-case where it's different from the character at the same position in
 "FOL".
 
-An exception is made for the German sharp s ß.  The upper-case version is
+An exception is made for the German sharp s ï¿½.  The upper-case version is
 "SS".  In the FOL/LOW/UPP lines it should be included, so that it's recognized
-as a word character, but use the ß character in all three.
+as a word character, but use the ï¿½ character in all three.
 
 ASCII characters should be omitted, Vim always handles these in the same way.
 When the encoding is UTF-8 no word characters need to be specified.
@@ -1397,7 +1397,7 @@ suggestions would spend most time trying all kind of weird compound words.
 							*spell-SYLLABLE*
 The SYLLABLE item defines characters or character sequences that are used to
 count the number of syllables in a word.  Example:
-	SYLLABLE aáeéiíoóöõuúüûy/aa/au/ea/ee/ei/ie/oa/oe/oo/ou/uu/ui ~
+	SYLLABLE aï¿½eï¿½iï¿½oï¿½ï¿½ï¿½uï¿½ï¿½ï¿½y/aa/au/ea/ee/ei/ie/oa/oe/oo/ou/uu/ui ~
 
 Before the first slash is the set of characters that are counted for one
 syllable, also when repeated and mixed, until the next character that is not
@@ -1478,8 +1478,8 @@ alike.  This is mostly used for a letter with different accents.  This is used
 to prefer suggestions with these letters substituted.  Example:
 
 	MAP 2 ~
-	MAP eéëêè ~
-	MAP uüùúû ~
+	MAP eï¿½ï¿½ï¿½ï¿½ ~
+	MAP uï¿½ï¿½ï¿½ï¿½ ~
 
 The first line specifies the number of MAP lines following.  Vim ignores the
 number, but the line must be there.
@@ -1614,7 +1614,7 @@ COMPOUNDSYLLABLE  (Hunspell)			*spell-COMPOUNDSYLLABLE*
 KEY		(Hunspell)				*spell-KEY*
 		Define characters that are close together on the keyboard.
 		Used to give better suggestions.  Not supported.
-		
+
 LANG		(Hunspell)				*spell-LANG*
 		This specifies language-specific behavior.  This actually
 		moves part of the language knowledge into the program,

--- a/runtime/doc/sponsor.txt
+++ b/runtime/doc/sponsor.txt
@@ -5,7 +5,7 @@
 
 
 
-SPONSOR VIM DEVELOPMENT						*sponsor*
+SPONSOR Vim DEVELOPMENT						*sponsor*
 
 Fixing bugs and adding new features takes a lot of time and effort.  To show
 your appreciation for the work and motivate Bram and others to continue
@@ -22,7 +22,7 @@ For the most recent information about sponsoring look on the Vim web site:
 More explanations can be found in the |sponsor-faq|.
 
 
-REGISTERED VIM USER						*register*
+REGISTERED Vim USER						*register*
 
 You can become a registered Vim user by sending at least 10 euro.  This works
 similar to sponsoring Vim, see |sponsor| above.  Registration was made

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -52,7 +52,7 @@ are creating a new file.  The message information is temporary and other
 information overwrites it.
 
 
-THE VIM COMMAND
+THE Vim COMMAND
 
 The gvim command causes the editor to create a new window for editing.  If you
 use this command: >

--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -396,13 +396,13 @@ this -, the fold will close.
 "zo" to open a fold and "zc" to close it.
 
 
-DIFFING IN VIM
+DIFFING IN Vim
 
 Another way to start in diff mode can be done from inside Vim.  Edit the
 "main.c" file, then make a split and show the differences: >
 
 	:edit main.c
-	:vertical diffsplit main.c~ 
+	:vertical diffsplit main.c~
 
 The ":vertical" command is used to make the window split vertically.  If you
 omit this, you will get a horizontal split.

--- a/runtime/doc/usr_09.txt
+++ b/runtime/doc/usr_09.txt
@@ -5,7 +5,7 @@
 				Using the GUI
 
 
-Vim works in an ordinary terminal.  GVim can do the same things and a few
+Vim works in an ordinary terminal.  gvim can do the same things and a few
 more.  The GUI offers menus, a toolbar, scrollbars and other items.  This
 chapter is about these extra things that the GUI offers.
 
@@ -191,7 +191,7 @@ mouse button.  The selected text will be inserted.
 The "current selection" will only remain valid until some other text is
 selected.  After doing the paste in the other gVim, now select some characters
 in that window.  You will notice that the words that were previously selected
-in the other gVim window are displayed differently.  This means that it no
+in the other gvim window are displayed differently.  This means that it no
 longer is the current selection.
 
 You don't need to select text with the mouse, using the keyboard commands for
@@ -215,7 +215,7 @@ USING BOTH
 
 This use of both the "current selection" and the "real clipboard" might sound
 a bit confusing.  But it is very useful.  Let's show this with an example.
-Use one gVim with a text file and perform these actions:
+Use one gvim with a text file and perform these actions:
 
 -  Select two words in Visual mode.
 -  Use the Edit/Copy menu to get these words onto the clipboard.

--- a/runtime/doc/usr_21.txt
+++ b/runtime/doc/usr_21.txt
@@ -153,7 +153,7 @@ information.  This may cause information that previously exiting Vims stored
 to be lost.  Each item can be remembered only once.
 
 
-GETTING BACK TO WHERE YOU STOPPED VIM
+GETTING BACK TO WHERE YOU STOPPED Vim
 
 You are halfway editing a file and it's time to leave for holidays.  You exit
 Vim and go enjoy yourselves, forgetting all about your work.  After a couple
@@ -210,7 +210,7 @@ Type "2" and press <Enter> to edit the second file.
 More info at |:oldfiles|, |v:oldfiles| and |c_#<|.
 
 
-MOVE INFO FROM ONE VIM TO ANOTHER
+MOVE INFO FROM ONE Vim TO ANOTHER
 
 You can use the ":wviminfo" and ":rviminfo" commands to save and restore the
 information while still running Vim.  This is useful for exchanging register

--- a/runtime/doc/usr_31.txt
+++ b/runtime/doc/usr_31.txt
@@ -236,7 +236,7 @@ using the terminal for something else.  The "-f" argument is used here to run
 the GUI in the foreground.  You can also use ":gui -f".
 
 
-THE GVIM STARTUP FILE
+THE gvim STARTUP FILE
 
 When gvim starts, it reads the gvimrc file.  That's similar to the vimrc file
 used when starting Vim.  The gvimrc file can be used for settings and commands

--- a/runtime/doc/version5.txt
+++ b/runtime/doc/version5.txt
@@ -297,7 +297,7 @@ using a bold Font, which would imply a certain color.  See |:highlight| and
 Use of $VIM						*$VIM-use*
 -----------
 
-Vim now uses the VIM environment variable to find all Vim system files.  This
+Vim now uses the Vim environment variable to find all Vim system files.  This
 includes the global vimrc, gvimrc, and menu.vim files and all on-line help
 and syntax files.  See |$VIM|.  Starting with version 5.4, |$VIMRUNTIME| can
 also be used.

--- a/runtime/doc/version6.txt
+++ b/runtime/doc/version6.txt
@@ -6103,7 +6103,7 @@ New tutor translations:
 	Slovak (Lubos Celko)
 	Greek (Christos Kontas)
 	German (Joachim Hofmann)
-	Norwegian (Øyvind Holm)
+	Norwegian (ï¿½yvind Holm)
 
 New filetype plugins:
 	Occam (Mario Schweigler)
@@ -6121,13 +6121,13 @@ New compiler plugins:
 	Modelsim vcom (Paul Baleme)
 
 New menu translations:
-	Brazilian (José de Paula)
+	Brazilian (Josï¿½ de Paula)
 	British (Mike Williams)
 	Korean in UTF-8. (Nam SungHyun)
-	Norwegian (Øyvind Holm)
+	Norwegian (ï¿½yvind Holm)
 	Serbian (Aleksandar Jelenak)
 
-New message translation for Norwegian. (Øyvind Holm)
+New message translation for Norwegian. (ï¿½yvind Holm)
 
 New color scheme:
 	desert (Hans Fugal)
@@ -9250,7 +9250,7 @@ Files:	    runtime/doc/various.txt, src/ex_cmds.h, src/ex_docmd.c,
 	    src/proto/quickfix.pro, src/quickfix.c
 
 Patch 6.1.424 (extra)
-Problem:    Win32: Gvim compiled with VC++ 7.0 run on Windows 95 does not show
+Problem:    Win32: gvim compiled with VC++ 7.0 run on Windows 95 does not show
 	    menu items.
 Solution:   Define $WINVER to avoid an extra item is added to MENUITEMINFO.
 	    (Muraoka Taro)
@@ -10066,7 +10066,7 @@ Files:	    src/os_unix.c
 
 Patch 6.2.019 (lang)
 Problem:    Loading the Portuguese menu causes an error message.
-Solution:   Join two lines.  (Jose Pedro Oliveira, José de Paula)
+Solution:   Join two lines.  (Jose Pedro Oliveira, Josï¿½ de Paula)
 Files:	    runtime/lang/menu_pt_br.vim
 
 Patch 6.2.020
@@ -12319,7 +12319,7 @@ Solution:   Don't ignore the WM_SYSKEYUP event when the menu is disabled.
 Files:	    src/gui_w32.c
 
 Patch 6.2.362 (extra, after 6.2.347)
-Problem:    Win32: The manifest causes Gvim not to work. (Dave Roberts)
+Problem:    Win32: The manifest causes gvim not to work. (Dave Roberts)
 Solution:   Change "x86" to "X86". (Serge Pirotte)
 Files:	    src/gvim.exe.mnf
 
@@ -12418,7 +12418,7 @@ Files:	    src/message.c
 
 Patch 6.2.376
 Problem:    Win32: Ruby interface cannot be dynamically linked with Ruby 1.6.
-Solution:   Add #ifdefs around use of rb_w32_snprintf().  (Benoît Cerrina)
+Solution:   Add #ifdefs around use of rb_w32_snprintf().  (Benoï¿½t Cerrina)
 Files:	    src/if_ruby.c
 
 Patch 6.2.377 (after 6.2.372)
@@ -14320,7 +14320,7 @@ Files:	    src/edit.c
 Patch 6.3.061
 Problem:    When editing a utf-8 file in an utf-8 xterm and there is a
 	    multi-byte character in the last column, displaying is messed up.
-	    (Joël Rio)
+	    (Joï¿½l Rio)
 Solution:   Check for a multi-byte character, not a multi-column character.
 Files:	    src/screen.c
 

--- a/runtime/doc/version7.txt
+++ b/runtime/doc/version7.txt
@@ -4151,7 +4151,7 @@ Patch 7.0.173
 Problem:    ":call f().TT()" doesn't work.  (Richard Emberson)
 Solution:   When a function returns a Dictionary or another composite continue
 	    evaluating what follows.
-Files:	    src/eval.c    
+Files:	    src/eval.c
 
 Patch 7.0.174
 Problem:    ":mksession" doesn't restore window layout correctly in tab pages
@@ -4265,7 +4265,7 @@ Problem:    When 'swapfile' is switched off in an empty file it is possible
 	    that not all blocks are loaded into memory, causing ml_get errors
 	    later.
 Solution:   Rename "dont_release" to "mf_dont_release" and also use it to
-	    avoid using the cached line and locked block. 
+	    avoid using the cached line and locked block.
 Files:	    src/globals.h, src/memfile.c, src/memline.c
 
 Patch 7.0.193
@@ -6031,7 +6031,7 @@ Solution:   Add type casts. (Ben Schmidt)
 Files:	    src/version.c
 
 Patch 7.1.207
-Problem:    Netbeans: "remove" cannot delete one line. 
+Problem:    Netbeans: "remove" cannot delete one line.
 Solution:   Remove partial lines and whole lines properly.  Avoid a memory
 	    leak.  (Xavier de Gaye)
 Files:	    src/netbeans.c
@@ -7991,7 +7991,7 @@ Files:	    src/ex_cmds.c
 
 Patch 7.2.097
 Problem:    "!xterm&" doesn't work when 'shell' is "bash".
-Solution:   Ignore SIGHUP after calling setsid(). (Simon Schubert) 
+Solution:   Ignore SIGHUP after calling setsid(). (Simon Schubert)
 Files:	    src/os_unix.c
 
 Patch 7.2.098
@@ -8510,7 +8510,7 @@ Files:	    src/if_mzsch.c, src/gui.c, src/gui_gtk.c, src/gui_gtk_x11.c,
 	    src/gui_gtk_f.c, src/gui_beval.c, src/netbeans.c
 
 Patch 7.2.182 (after 7.2.181)
-Problem:    Compilation problems after previous patch for Motif.  Gvim with
+Problem:    Compilation problems after previous patch for Motif.  gvim with
 	    GTK crashes on startup.
 Solution:   Add comma.  Init form structure to zeroes.
 Files:	    src/netbeans.c, src/gui_gtk_f.c
@@ -8740,7 +8740,7 @@ Files:	    src/gui_gtk_x11.c, src/message.c, src/ops.c, src/proto/ui.pro,
 	    src/ui.c
 
 Patch 7.2.222
-Problem:   ":mksession" doesn't work properly with 'acd' set. 
+Problem:   ":mksession" doesn't work properly with 'acd' set.
 Solution:   Make it work. (Yakov Lerner)
 Files:	    src/ex_docmd.c
 
@@ -9150,7 +9150,7 @@ Solution:   Add the missing "else". (Lech Lorens)
 Files:	    src/ops.c
 
 Patch 7.2.293
-Problem:    When setting 'comments' option it may be used in a wrong way. 
+Problem:    When setting 'comments' option it may be used in a wrong way.
 Solution:   Don't increment after skipping over digits. (Yukihiro Nakadaira)
 Files:	    src/misc1.c
 
@@ -10191,32 +10191,32 @@ More information here: |two-engines|
 Better Python interface				*better-python-interface*
 -----------------------
 
-Added |python-bindeval| function. Unlike |python-eval| this one returns 
-|python-Dictionary|, |python-List| and |python-Function| objects for 
-dictionaries lists and functions respectively in place of their Python 
+Added |python-bindeval| function. Unlike |python-eval| this one returns
+|python-Dictionary|, |python-List| and |python-Function| objects for
+dictionaries lists and functions respectively in place of their Python
 built-in equivalents (or None if we are talking about function references).
-   For simple types this function returns Python built-in types and not only 
-Python `str()` like |python-eval| does. On Python 3 it will return `bytes()` 
+   For simple types this function returns Python built-in types and not only
+Python `str()` like |python-eval| does. On Python 3 it will return `bytes()`
 objects in place of `str()` ones avoiding possibility of UnicodeDecodeError.
    Interface of new objects mimics standard Python `dict()` and `list()`
 interfaces to some extent. Extent will be improved in the future.
 
-Added special |python-vars| objects also available for |python-buffer| and 
+Added special |python-vars| objects also available for |python-buffer| and
 |python-window|. They ease access to Vim script variables from Python.
 
-Now you no longer need to alter `sys.path` to import your module: special 
-hooks are responsible for importing from {rtp}/python2, {rtp}/python3 and 
-{rtp}/pythonx directories (for Python 2, Python 3 and both respectively). 
+Now you no longer need to alter `sys.path` to import your module: special
+hooks are responsible for importing from {rtp}/python2, {rtp}/python3 and
+{rtp}/pythonx directories (for Python 2, Python 3 and both respectively).
 See |python-special-path|.
 
 Added possibility to work with |tabpage|s through |python-tabpage| object.
 
-Added automatic conversion of Vim errors and exceptions to Python 
+Added automatic conversion of Vim errors and exceptions to Python
 exceptions.
 
-Changed the behavior of the |python-buffers| object: it now uses buffer numbers 
-as keys in place of the index of the buffer in the internal buffer list. 
-This should not break anything as the only way to get this index was 
+Changed the behavior of the |python-buffers| object: it now uses buffer numbers
+as keys in place of the index of the buffer in the internal buffer list.
+This should not break anything as the only way to get this index was
 iterating over |python-buffers|.
 
 Added |:pydo| and |:py3do| commands.
@@ -10226,7 +10226,7 @@ Added the |pyeval()| and |py3eval()| functions.
 Now in all places which previously accepted `str()` objects, `str()` and
 `unicode()` (Python 2) or `bytes()` and `str()` (Python 3) are accepted.
 
-|python-window| has gained `.col` and `.row` attributes that are currently 
+|python-window| has gained `.col` and `.row` attributes that are currently
 the only way to get internal window positions.
 
 Added or fixed support for `dir()` in Vim Python objects.
@@ -10235,12 +10235,12 @@ Added or fixed support for `dir()` in Vim Python objects.
 Changed							*changed-7.4*
 -------
 
-Old Python versions (≤2.2) are no longer supported. Building with them did 
+Old Python versions (≤2.2) are no longer supported. Building with them did
 not work anyway.
 
 Options:
-	Added ability to automatically save the selection into the system 
-	clipboard when using non-GUI version of Vim (autoselectplus in 
+	Added ability to automatically save the selection into the system
+	clipboard when using non-GUI version of Vim (autoselectplus in
 	'clipboard'). Also added ability to use the system clipboard as
 	default register (previously only primary selection could be used).
 	(Ivan Krasilnikov, Christian Brabandt, Bram Moolenaar)
@@ -10255,12 +10255,12 @@ Options:
 	'relativenumber'.  (Christian Brabandt)
 
 Commands:
-	|:diffoff| now saves the local values of some settings and restores 
-	them in place of blindly resetting them to the defaults. (Christian 
+	|:diffoff| now saves the local values of some settings and restores
+	them in place of blindly resetting them to the defaults. (Christian
 	Brabandt)
 
 Other:
-	Lua interface now also uses userdata binded to Vim structures. (Taro 
+	Lua interface now also uses userdata binded to Vim structures. (Taro
 	Muraoka, Luis Carvalho)
 
 	glob() and autocommand patterns used to work with the undocumented
@@ -10285,74 +10285,74 @@ Functions:
 
 	Added |wildmenumode()| function. (Christian Brabandt)
 
-	Debugging functions: |screenattr()|, |screenchar()|, |screencol()|, 
+	Debugging functions: |screenattr()|, |screenchar()|, |screencol()|,
 	|screenrow()|. (Simon Ruderich, Bram Moolenaar)
 
-	Added ability to use |Dictionary-function|s for |sort()|ing, via 
+	Added ability to use |Dictionary-function|s for |sort()|ing, via
 	optional third argument. (Nikolay Pavlov)
 
-	Added special |expand()| argument that expands to the current line 
+	Added special |expand()| argument that expands to the current line
 	number.
 
-	Made it possible to force |char2nr()| to always give unicode codepoints 
+	Made it possible to force |char2nr()| to always give unicode codepoints
 	regardless of current encoding. (Yasuhiro Matsumoto)
 
-	Made it possible for functions generating file list generate |List| 
-	and not NL-separated string. (e.g. |glob()|, |expand()|) (Christian 
+	Made it possible for functions generating file list generate |List|
+	and not NL-separated string. (e.g. |glob()|, |expand()|) (Christian
 	Brabandt)
 
-	Functions that obtain variables from the specific window, tabpage or 
-	buffer scope dictionary can now return specified default value in 
-	place of empty string in case variable is not found. (|gettabvar()|, 
+	Functions that obtain variables from the specific window, tabpage or
+	buffer scope dictionary can now return specified default value in
+	place of empty string in case variable is not found. (|gettabvar()|,
 	|getwinvar()|, |getbufvar()|) (Shougo Matsushita, Hirohito Higashi)
 
 Autocommands:
-	Added |InsertCharPre| event launched before inserting character. 
+	Added |InsertCharPre| event launched before inserting character.
 	(Jakson A. Aquino)
 
-	Added |CompleteDone| event launched after finishing completion in 
+	Added |CompleteDone| event launched after finishing completion in
 	insert mode. (idea by Florian Klein)
 
-	Added |QuitPre| event launched when commands that can either close Vim 
+	Added |QuitPre| event launched when commands that can either close Vim
 	or only some window(s) are launched.
 
-	Added |TextChanged| and |TextChangedI| events launched when text is 
+	Added |TextChanged| and |TextChangedI| events launched when text is
 	changed.
 
 Commands:
 	|:syntime| command useful for debugging.
 
-	Made it possible to remove all signs from the current buffer using 
+	Made it possible to remove all signs from the current buffer using
 	|:sign-unplace|. (Christian Brabandt)
 
 	Added |:language| autocompletion. (Dominique Pelle)
 
-	Added more |:command-complete| completion types: |:behave| suboptions, 
-	color schemes, compilers, |:cscope| suboptions, files from 'path', 
-	|:history| suboptions, locale names, |:syntime| suboptions, user 
+	Added more |:command-complete| completion types: |:behave| suboptions,
+	color schemes, compilers, |:cscope| suboptions, files from 'path',
+	|:history| suboptions, locale names, |:syntime| suboptions, user
 	names. (Dominique Pelle)
 
-	Added |:map-nowait| creating mapping which when having lhs that is the 
-	prefix of another mapping’s lhs will not allow Vim to wait for user to 
-	type more characters to resolve ambiguity, forcing Vim to take the 
+	Added |:map-nowait| creating mapping which when having lhs that is the
+	prefix of another mapping’s lhs will not allow Vim to wait for user to
+	type more characters to resolve ambiguity, forcing Vim to take the
 	shorter alternative: one with <nowait>.
 
 Options:
 	Made it possible to ignore case when completing: 'wildignorecase'.
 
-	Added ability to delete comment leader when using |J| by `j` flag in 
+	Added ability to delete comment leader when using |J| by `j` flag in
 	'formatoptions' (|fo-table|). (Lech Lorens)
 
-	Added ability to control indentation inside namespaces: |cino-N|. 
+	Added ability to control indentation inside namespaces: |cino-N|.
 	(Konstantin Lepa)
 
-	Added ability to control alignment inside `if` condition separately 
+	Added ability to control alignment inside `if` condition separately
 	from alignment inside function arguments: |cino-k|. (Lech Lorens)
 
 Other:
 	Improved support for cmd.exe. (Ben Fritz, Bram Moolenaar)
 
-	Added |v:windowid| variable containing current window number in GUI 
+	Added |v:windowid| variable containing current window number in GUI
 	Vim. (Christian J. Robinson, Lech Lorens)
 
 	Added rxvt-unicode and SGR mouse support. (Yiding Jia, Hayaki Saito)
@@ -11923,7 +11923,7 @@ Solution:   Pass the separator character to in_history(). (Taro Muraoka)
 Files:	    src/ex_getln.c
 
 Patch 7.3.266
-Problem:    In Gvim with iBus typing space in Insert mode doesn't work.
+Problem:    In gvim with iBus typing space in Insert mode doesn't work.
 Solution:   Clear xim_expected_char after checking it.
 Files:	    src/mbyte.c
 
@@ -11938,7 +11938,7 @@ Solution:   Use O_NOCTTY both in the master and slave. (Bjorn Winckler)
 Files:	    src/os_unix.c
 
 Patch 7.3.269
-Problem:    'shellcmdflag' only works with one flag. 
+Problem:    'shellcmdflag' only works with one flag.
 Solution:   Split into multiple arguments. (Gary Johnson)
 Files:	    src/os_unix.c
 
@@ -13118,7 +13118,7 @@ Files:	    src/ops.c
 Patch 7.3.477
 Problem:    Using ":echo" to output enough lines to scroll, then using "j" and
 	    "k" at the more prompt, displays the command on top of the output.
-	    (Marcin Szamotulski) 
+	    (Marcin Szamotulski)
 Solution:   Put the output below the command. (Christian Brabandt)
 Files:	    src/eval.c
 
@@ -13371,7 +13371,7 @@ Solution:   Recognize completefunction returning -3.  (Matsushita Shougo)
 Files:	    src/edit.c
 
 Patch 7.3.520
-Problem:    Gvim starts up slow on Ubuntu 12.04.
+Problem:    gvim starts up slow on Ubuntu 12.04.
 Solution:   Move the call to gui_mch_init_check() to after fork(). (Yasuhiro
 	    Matsumoto)  Do check $DISPLAY being set.
 Files:	    src/gui.c, src/gui_gtk_x11.c, src/proto/gui_gtk_x11.pro
@@ -13424,7 +13424,7 @@ Solution:   Make the count select that many characters or lines. (Christian
 Files:	    src/normal.c
 
 Patch 7.3.530 (after 7.3.520)
-Problem:    Gvim does not work when 'guioptions' includes "f". (Davido)
+Problem:    gvim does not work when 'guioptions' includes "f". (Davido)
 Solution:   Call gui_mch_init_check() when running GUI in the foreground.
 	    (Yasuhiro Matsumoto)
 Files:	    src/gui.c
@@ -14287,7 +14287,7 @@ Files:	    Filelist
 Patch 7.3.682 (after 7.3.677)
 Problem:    Compiler complains about incompatible types.
 Solution:   Remove type casts. (hint by Danek Duvall)
-Files:	    src/edit.c 
+Files:	    src/edit.c
 
 Patch 7.3.683
 Problem:    ":python" may crash when vimbindeval() returns None.
@@ -16340,7 +16340,7 @@ Solution:   Avoid negative argument to vim_strncpy(). (Narendran
 Files:	    src/if_cscope.c
 
 Patch 7.3.1039
-Problem:    New regexp engine does not support \%23c, \%<23c and the like. 
+Problem:    New regexp engine does not support \%23c, \%<23c and the like.
 Solution:   Implement them. (partly by Yasuhiro Matsumoto)
 Files:	    src/regexp.h, src/regexp_nfa.c, src/testdir/test64.in,
 	    src/testdir/test64.ok
@@ -17552,9 +17552,9 @@ Solution:   Specify a separate viminfo file.
 Files:	    src/testdir/test61.in
 
 Patch 7.3.1252
-Problem:    Gvim does not find the toolbar bitmap files in ~/vimfiles/bitmaps
+Problem:    gvim does not find the toolbar bitmap files in ~/vimfiles/bitmaps
 	    if the corresponding menu command contains additional characters
-	    like the shortcut marker '&' or if you use a non-english locale.  
+	    like the shortcut marker '&' or if you use a non-english locale.
 Solution:   Use menu->en_dname or menu->dname. (Martin Gieseking)
 Files:	    src/gui_w32.c
 
@@ -18175,7 +18175,7 @@ Files:	    src/window.c
 
 Patch 7.4a.045
 Problem:    Configure does not always find the right library for Lua.  Missing
-	    support for LuaJit. 
+	    support for LuaJit.
 Solution:   Improve the configure detection of Lua. (Hiroshi Shirosaki)
 Files:	    src/Makefile, src/configure.in, src/auto/configure
 


### PR DESCRIPTION
Unified spellings "VIM" to "Vim" and "GVIM" or "Gvim" or "gVim" to "gvim" in help documents.