### PR TITLE
Disallow switching the curbuf when set-ing options

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -5119,10 +5119,16 @@ do_set(
 			    saved_origval = vim_strsave(origval);
 #endif
 
+#ifdef FEAT_AUTOCMD
+			curbuf_lock++;
+#endif
 			/* Handle side effects, and set the global value for
 			 * ":set" on local options. */
 			errmsg = did_set_string_option(opt_idx, (char_u **)varp,
 				new_value_alloced, oldval, errbuf, opt_flags);
+#ifdef FEAT_AUTOCMD
+			curbuf_lock--;
+#endif
 
 			/* If error detected, print the error message. */
 			if (errmsg != NULL)
@@ -5946,9 +5952,15 @@ set_string_option(
 		)
 	    saved_oldval = vim_strsave(oldval);
 #endif
+#ifdef FEAT_AUTOCMD
+	curbuf_lock++;
+#endif
 	if ((r = did_set_string_option(opt_idx, varp, TRUE, oldval, NULL,
 							   opt_flags)) == NULL)
 	    did_set_option(opt_idx, opt_flags, TRUE);
+#ifdef FEAT_AUTOCMD
+	curbuf_lock--;
+#endif
 
 	/* call autocommand after handling side effects */
 #if defined(FEAT_AUTOCMD) && defined(FEAT_EVAL)


### PR DESCRIPTION
When the side-effects are evaluated we may execute user code that may
change the curbuf making varp possibly invalid.

Fixes #1730 

I also haven't been able to reproduce the segfault in a test 🤔