### PR TITLE
Add missing static functions for perl>=5.26

### DIFF
--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -632,6 +632,29 @@ S_SvREFCNT_dec(pTHX_ SV *sv)
     }
 }
 # endif
+/* perl-5.26 also needs S_TOPMARK and S_POPMARK. */
+# if (PERL_REVISION == 5) && (PERL_VERSION >= 26)
+PERL_STATIC_INLINE I32
+S_TOPMARK(pTHX)
+{
+    DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,
+				 "MARK top  %p %" IVdf "\n",
+				  PL_markstack_ptr,
+				  (IV)*PL_markstack_ptr)));
+    return *PL_markstack_ptr;
+}
+
+PERL_STATIC_INLINE I32
+S_POPMARK(pTHX)
+{
+    DEBUG_s(DEBUG_v(PerlIO_printf(Perl_debug_log,
+				 "MARK pop  %p %" IVdf "\n",
+				  (PL_markstack_ptr-1),
+				  (IV)*(PL_markstack_ptr-1))));
+    assert((PL_markstack_ptr > PL_markstack) || !"MARK underflow");
+    return *PL_markstack_ptr--;
+}
+# endif
 
 /*
  * Make all runtime-links of perl.


### PR DESCRIPTION
I tried to build vim 8.0.0627 (add8dce38de65a0c64e8f54d6bdcadb45a8de2cf) with `--enable-perlinterp=dynamic`, against perl 5.26.0, with GCC 7.1 `-fuse-ld=gold -fuse-linker-plugin -flto`. The build failed at link time, with an error message complaining that `S_POPMARK` was not defined.

I fixed the problem by copying the definitions of `S_TOPMARK` and `S_POPMARK` from perl's `CORE/inline.h` into `if_perl.xs`. With this change, the build (including `make -j1 test`) completes successfully.