### PR TITLE
Rectified file detection algorithim of tex flavors

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2252,7 +2252,7 @@ func! s:FTtex()
   if firstline =~ '^%&\s*\a\+'
     let format = tolower(matchstr(firstline, '\a\+'))
     let format = substitute(format, 'pdf', '', '')
-    if format == 'tex'
+    if format == 'plaintex'
       let format = 'plain'
     endif
   else


### PR DESCRIPTION
The algorithim for parsing %&tex and %&plaintext switched the detected filetypes around. i.e. %&tex detected as plaintex, %&plaintex detected as tex. The fix above corrected the matching.