### PR TITLE
Separate highlighting for quickfix selected line - different than 'Search'

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -477,9 +477,9 @@ struct vimoption
 #if defined(FEAT_DIFF) || defined(FEAT_FOLDING) || defined(FEAT_SPELL) \
 	|| defined(FEAT_WINDOWS) || defined(FEAT_CLIPBOARD) \
 	|| defined(FEAT_INS_EXPAND) || defined(FEAT_SYN_HL) || defined(FEAT_CONCEAL)
-# define HIGHLIGHT_INIT "8:SpecialKey,~:EndOfBuffer,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn"
+# define HIGHLIGHT_INIT "8:SpecialKey,~:EndOfBuffer,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixCurrentLine"
 #else
-# define HIGHLIGHT_INIT "8:SpecialKey,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,t:Title,v:Visual,w:WarningMsg,W:WildMenu,>:SignColumn,*:TabLine,#:TabLineSel,_:TabLineFill"
+# define HIGHLIGHT_INIT "8:SpecialKey,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,t:Title,v:Visual,w:WarningMsg,W:WildMenu,>:SignColumn,*:TabLine,#:TabLineSel,_:TabLineFill,q:QuickFixCurrentLine"
 #endif
 
 /* Default python version for pyx* commands */

--- a/src/option.c
+++ b/src/option.c
@@ -477,9 +477,9 @@ struct vimoption
 #if defined(FEAT_DIFF) || defined(FEAT_FOLDING) || defined(FEAT_SPELL) \
 	|| defined(FEAT_WINDOWS) || defined(FEAT_CLIPBOARD) \
 	|| defined(FEAT_INS_EXPAND) || defined(FEAT_SYN_HL) || defined(FEAT_CONCEAL)
-# define HIGHLIGHT_INIT "8:SpecialKey,~:EndOfBuffer,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixCurrentLine"
+# define HIGHLIGHT_INIT "8:SpecialKey,~:EndOfBuffer,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine"
 #else
-# define HIGHLIGHT_INIT "8:SpecialKey,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,t:Title,v:Visual,w:WarningMsg,W:WildMenu,>:SignColumn,*:TabLine,#:TabLineSel,_:TabLineFill,q:QuickFixCurrentLine"
+# define HIGHLIGHT_INIT "8:SpecialKey,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,t:Title,v:Visual,w:WarningMsg,W:WildMenu,>:SignColumn,*:TabLine,#:TabLineSel,_:TabLineFill,q:QuickFixLine"
 #endif
 
 /* Default python version for pyx* commands */

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2575,7 +2575,7 @@ qf_list(exarg_T *eap)
 		vim_snprintf((char *)IObuff, IOSIZE, "%2d %s",
 							    i, (char *)fname);
 	    msg_outtrans_attr(IObuff, i == qi->qf_lists[qi->qf_curlist].qf_index
-					   ? HL_ATTR(HLF_L) : HL_ATTR(HLF_D));
+					   ? HL_ATTR(HLF_QFC) : HL_ATTR(HLF_D));
 	    if (qfp->qf_lnum == 0)
 		IObuff[0] = NUL;
 	    else if (qfp->qf_col == 0)

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2575,7 +2575,7 @@ qf_list(exarg_T *eap)
 		vim_snprintf((char *)IObuff, IOSIZE, "%2d %s",
 							    i, (char *)fname);
 	    msg_outtrans_attr(IObuff, i == qi->qf_lists[qi->qf_curlist].qf_index
-					   ? HL_ATTR(HLF_QFC) : HL_ATTR(HLF_D));
+					   ? HL_ATTR(HLF_QFL) : HL_ATTR(HLF_D));
 	    if (qfp->qf_lnum == 0)
 		IObuff[0] = NUL;
 	    else if (qfp->qf_col == 0)

--- a/src/screen.c
+++ b/src/screen.c
@@ -3371,7 +3371,7 @@ win_line(
 # if defined(FEAT_QUICKFIX) && defined(FEAT_WINDOWS)
     /* Highlight the current line in the quickfix window. */
     if (bt_quickfix(wp->w_buffer) && qf_current_entry(wp) == lnum)
-	line_attr = HL_ATTR(HLF_L);
+	line_attr = HL_ATTR(HLF_QFC);
 # endif
     if (line_attr != 0)
 	area_highlighting = TRUE;

--- a/src/screen.c
+++ b/src/screen.c
@@ -3371,7 +3371,7 @@ win_line(
 # if defined(FEAT_QUICKFIX) && defined(FEAT_WINDOWS)
     /* Highlight the current line in the quickfix window. */
     if (bt_quickfix(wp->w_buffer) && qf_current_entry(wp) == lnum)
-	line_attr = HL_ATTR(HLF_QFC);
+	line_attr = HL_ATTR(HLF_QFL);
 # endif
     if (line_attr != 0)
 	area_highlighting = TRUE;

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6970,6 +6970,8 @@ static char *(highlight_init_light[]) =
 #ifdef FEAT_GUI
 	"Normal gui=NONE",
 #endif
+	CENT("QuickFixCurrentLine term=reverse ctermbg=Cyan",
+	     "QuickFixCurrentLine term=reverse ctermbg=Cyan guibg=Cyan"),
 	NULL
     };
 
@@ -7055,6 +7057,8 @@ static char *(highlight_init_dark[]) =
 	CENT("Conceal ctermbg=DarkGrey ctermfg=LightGrey",
 	     "Conceal ctermbg=DarkGrey ctermfg=LightGrey guibg=DarkGrey guifg=LightGrey"),
 #endif
+	CENT("QuickFixCurrentLine term=reverse ctermbg=Cyan",
+	     "QuickFixCurrentLine term=reverse ctermbg=Cyan guibg=Cyan"),
 #ifdef FEAT_GUI
 	"Normal gui=NONE",
 #endif

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6970,8 +6970,8 @@ static char *(highlight_init_light[]) =
 #ifdef FEAT_GUI
 	"Normal gui=NONE",
 #endif
-	CENT("QuickFixCurrentLine term=reverse ctermbg=Cyan",
-	     "QuickFixCurrentLine term=reverse ctermbg=Cyan guibg=Cyan"),
+	CENT("QuickFixLine term=reverse ctermbg=Cyan",
+	     "QuickFixLine term=reverse ctermbg=Cyan guibg=Cyan"),
 	NULL
     };
 
@@ -7057,8 +7057,8 @@ static char *(highlight_init_dark[]) =
 	CENT("Conceal ctermbg=DarkGrey ctermfg=LightGrey",
 	     "Conceal ctermbg=DarkGrey ctermfg=LightGrey guibg=DarkGrey guifg=LightGrey"),
 #endif
-	CENT("QuickFixCurrentLine term=reverse ctermbg=Cyan",
-	     "QuickFixCurrentLine term=reverse ctermbg=Cyan guibg=Cyan"),
+	CENT("QuickFixLine term=reverse ctermbg=Cyan",
+	     "QuickFixLine term=reverse ctermbg=Cyan guibg=Cyan"),
 #ifdef FEAT_GUI
 	"Normal gui=NONE",
 #endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -1433,7 +1433,7 @@ typedef enum
     , HLF_CUC	    /* 'cursurcolumn' */
     , HLF_CUL	    /* 'cursurline' */
     , HLF_MC	    /* 'colorcolumn' */
-    , HLF_QFC	    /* 'quickfix window current line' */
+    , HLF_QFC	    /* quickfix window current line */
     , HLF_COUNT	    /* MUST be the last one */
 } hlf_T;
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -1433,7 +1433,7 @@ typedef enum
     , HLF_CUC	    /* 'cursurcolumn' */
     , HLF_CUL	    /* 'cursurline' */
     , HLF_MC	    /* 'colorcolumn' */
-    , HLF_QFC	    /* quickfix window current line */
+    , HLF_QFL	    /* quickfix window line currently selected */
     , HLF_COUNT	    /* MUST be the last one */
 } hlf_T;
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -1433,6 +1433,7 @@ typedef enum
     , HLF_CUC	    /* 'cursurcolumn' */
     , HLF_CUL	    /* 'cursurline' */
     , HLF_MC	    /* 'colorcolumn' */
+    , HLF_QFC	    /* 'quickfix window current line' */
     , HLF_COUNT	    /* MUST be the last one */
 } hlf_T;
 
@@ -1442,7 +1443,7 @@ typedef enum
 		  'n', 'N', 'r', 's', 'S', 'c', 't', 'v', 'V', 'w', 'W', \
 		  'f', 'F', 'A', 'C', 'D', 'T', '-', '>', \
 		  'B', 'P', 'R', 'L', \
-		  '+', '=', 'x', 'X', '*', '#', '_', '!', '.', 'o'}
+		  '+', '=', 'x', 'X', '*', '#', '_', '!', '.', 'o', 'q'}
 
 /*
  * Boolean constants


### PR DESCRIPTION
Currently, the quickfix window selected entry is shown with the same highlighting as `Search` group.
Because of this, it's difficult to search for something within the quick fix window.
Plus I would rather like the ability to disable the highlighting for that line.

Issue filed: https://github.com/vim/vim/issues/1080