### PR TITLE
add module field to quickfix dict entry

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4728,6 +4728,7 @@ getqflist([{what}])					*getqflist()*
 		list item is a dictionary with these entries:
 			bufnr	number of buffer that has the file name, use
 				bufname() to get the name
+			module	module name
 			lnum	line number in the buffer (first line is 1)
 			col	column number (first column is 1)
 			vcol	|TRUE|: "col" is visual column
@@ -7210,6 +7211,8 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 				buffer
 		    filename	name of a file; only used when "bufnr" is not
 				present or it is invalid.
+		    module	name of a module; if given it will be used in
+				quickfix error window instead of the filename.
 		    lnum	line number in the file
 		    pattern	search pattern used to locate the error
 		    col		column number

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1130,6 +1130,7 @@ you want to match case, add "\C" to the pattern |/\C|.
 Basic items
 
 	%f		file name (finds a string)
+	%o		module name (finds a string)
 	%l		line number (finds a number)
 	%c		column number (finds a number representing character
 			column of the error, (1 <tab> == 1 character column))
@@ -1173,6 +1174,11 @@ text is prefixed with the "\V" atom to make it "very nomagic".  The "%s"
 conversion can be used to locate lines without a line number in the error
 output.  Like the output of the "grep" shell command.
 When the pattern is present the line number will not be used.
+
+The "%o" conversion will set up module name in quickfix list.  If present it
+will be used in quickfix error window instead of the filename.  The module
+name is used only for displaying purposes and file name is used when jumping
+to the file.
 
 Changing directory
 

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -15,6 +15,7 @@ typedef enum {
 	aid_qf_dirname_start,
 	aid_qf_dirname_now,
 	aid_qf_namebuf,
+	aid_qf_module,
 	aid_qf_errmsg,
 	aid_qf_pattern,
 	aid_last

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -138,6 +138,16 @@ func XlistTests(cchar)
 	      \ ' 4:40 col 20 x  44: Other',
 	      \ ' 5:50 col 25  55: one'], l)
 
+  " Test for module names, one needs to explicitly set `'valid':v:true` so
+  call g:Xsetlist([
+	\ {'lnum':10,'col':5,'type':'W','module':'Data.Text','text':'ModuleWarning','nr':11,'valid':v:true},
+	\ {'lnum':20,'col':10,'type':'W','module':'Data.Text','filename':'Data/Text.hs','text':'ModuleWarning','nr':22,'valid':v:true},
+	\ {'lnum':30,'col':15,'type':'W','filename':'Data/Text.hs','text':'FileWarning','nr':33,'valid':v:true}])
+  let l = split(execute('Xlist', ""), "\n")
+  call assert_equal([' 1 Data.Text:10 col 5 warning  11: ModuleWarning',
+	\ ' 2 Data.Text:20 col 10 warning  22: ModuleWarning',
+	\ ' 3 Data/Text.hs:30 col 15 warning  33: FileWarning'], l)
+
   " Error cases
   call assert_fails('Xlist abc', 'E488:')
 endfunc
@@ -1141,6 +1151,21 @@ func Test_efm2()
   call assert_equal(89, l[4].lnum)
   call assert_equal(1, l[4].valid)
   call assert_equal('unittests/dbfacadeTest.py', bufname(l[4].bufnr))
+
+  " Test for %o
+  set efm=%f(%o):%l\ %m
+  cgetexpr ['Xtestfile(Language.PureScript.Types):20 Error']
+  call writefile(['Line1'], 'Xtestfile')
+  let l = getqflist()
+  call assert_equal(1, len(l), string(l))
+  call assert_equal('Language.PureScript.Types', l[0].module)
+  copen
+  call assert_equal('Language.PureScript.Types|20| Error', getline(1))
+  call feedkeys("\<CR>", 'xn')
+  call assert_equal('Xtestfile', expand('%:t'))
+  cclose
+  bd
+  call delete("Xtestfile")
 
   " The following sequence of commands used to crash Vim
   set efm=%W%m


### PR DESCRIPTION
Can be used to show module name instead of file name in
quickfix/location list.

I got one problem though with test64 (regexp nfa engine - in log_subexpr).  For me this seems unrelated, but I only get it with this patch so I must be wrong:
```
#0  0x00007ffff4f0b41b in vfprintf () from /lib64/libc.so.6
#1  0x00007ffff4f11aff in fprintf () from /lib64/libc.so.6
#2  0x0000000000570d46 in log_subexpr (sub=0x7fffffffbb40) at regexp_nfa.c:3936
#3  0x0000000000570ba5 in log_subsexpr (subs=0x7fffffffbb40) at regexp_nfa.c:3909
#4  0x00000000005743f6 in nfa_regmatch (prog=0x9a3a90, start=0x9a3bf8, submatch=0x7fffffffb950, m=0x7fffffffbb40) at regexp_nfa.c:5806
#5  0x000000000057336e in recursive_regmatch (state=0x9a3c70, pim=0x0, prog=0x9a3a90, submatch=0x7fffffffb950, m=0x7fffffffbb40, listids=0x7fffffffb620) at regexp_nfa.c:5223
#6  0x0000000000574570 in nfa_regmatch (prog=0x9a3a90, start=0x9a3d60, submatch=0x7fffffffb950, m=0x7fffffffbb40) at regexp_nfa.c:5850
#7  0x00000000005775f4 in nfa_regtry (prog=0x9a3a90, col=1, tm=0x0) at regexp_nfa.c:6994
#8  0x0000000000577dd6 in nfa_regexec_both (line=0x99b3d0 " if then else", startcol=0, tm=0x0) at regexp_nfa.c:7186
#9  0x00000000005781eb in nfa_regexec_nl (rmp=0x7fffffffbf70, line=0x99b3d0 " if then else", col=0, line_lbr=1) at regexp_nfa.c:7345
#10 0x000000000057863a in vim_regexec_both (rmp=0x7fffffffbf70, line=0x99b3d0 " if then else", col=0, nl=1) at regexp.c:8217
#11 0x00000000005788d6 in vim_regexec_nl (rmp=0x7fffffffbf70, line=0x99b3d0 " if then else", col=0) at regexp.c:8291
#12 0x0000000000453705 in find_some_match (argvars=0x7fffffffc450, rettv=0x7fffffffcb00, type=3) at evalfunc.c:7313
#13 0x000000000045418f in f_matchlist (argvars=0x7fffffffc450, rettv=0x7fffffffcb00) at evalfunc.c:7600
#14 0x0000000000448764 in call_internal_func (name=0x9a0db0 "matchlist", argcount=2, argvars=0x7fffffffc450, rettv=0x7fffffffcb00) at evalfunc.c:991
#15 0x00000000005f2fd2 in call_func (funcname=0x9a0790 "matchlist(text, pat)", len=9, rettv=0x7fffffffcb00, argcount_in=2, argvars_in=0x7fffffffc450, argv_func=0x0, firstline=1464, 
    lastline=1464, doesrange=0x7fffffffc604, evaluate=1, partial=0x0, selfdict_in=0x0) at userfunc.c:1446
#16 0x00000000005f0dd3 in get_func_tv (name=0x9a0790 "matchlist(text, pat)", len=9, rettv=0x7fffffffcb00, arg=0x7fffffffcaa0, firstline=1464, lastline=1464, doesrange=0x7fffffffc604, 
    evaluate=1, partial=0x0, selfdict=0x0) at userfunc.c:455
#17 0x000000000043d933 in eval7 (arg=0x7fffffffcaa0, rettv=0x7fffffffcb00, evaluate=1, want_string=0) at eval.c:4332
#18 0x000000000043d129 in eval6 (arg=0x7fffffffcaa0, rettv=0x7fffffffcb00, evaluate=1, want_string=0) at eval.c:3969
#19 0x000000000043cc08 in eval5 (arg=0x7fffffffcaa0, rettv=0x7fffffffcb00, evaluate=1) at eval.c:3785
#20 0x000000000043bec1 in eval4 (arg=0x7fffffffcaa0, rettv=0x7fffffffcb00, evaluate=1) at eval.c:3484
#21 0x000000000043bceb in eval3 (arg=0x7fffffffcaa0, rettv=0x7fffffffcb00, evaluate=1) at eval.c:3401
#22 0x000000000043bb41 in eval2 (arg=0x7fffffffcaa0, rettv=0x7fffffffcb00, evaluate=1) at eval.c:3333
#23 0x000000000043b955 in eval1 (arg=0x7fffffffcaa0, rettv=0x7fffffffcb00, evaluate=1) at eval.c:3261
#24 0x000000000043b88b in eval0 (arg=0x98237f "matchlist(text, pat)", rettv=0x7fffffffcb00, nextcmd=0x7fffffffcbe8, evaluate=1) at eval.c:3221
#25 0x000000000043764e in ex_let (eap=0x7fffffffcbe0) at eval.c:1228
#26 0x000000000047b4d6 in do_one_cmd (cmdlinep=0x7fffffffce00, sourcing=0, cstack=0x7fffffffcef0, fgetline=0x478a8f <get_loop_line>, cookie=0x7fffffffce90) at ex_docmd.c:2947
#27 0x0000000000477f15 in do_cmdline (cmdline=0x0, fgetline=0x4939e2 <getexline>, cookie=0x0, flags=0) at ex_docmd.c:1086
#28 0x00000000005100c8 in nv_colon (cap=0x7fffffffd470) at normal.c:5403
#29 0x0000000000508628 in normal_cmd (oap=0x7fffffffd500, toplevel=1) at normal.c:1150
#30 0x0000000000634b8c in main_loop (cmdwin=0, noexmode=0) at main.c:1343
#31 0x00000000006342e0 in vim_main2 () at main.c:896
#32 0x00000000006339e4 in main (argc=11, argv=0x7fffffffd6f8) at main.c:419
```

This is triggered by this test:
```
:call add(tl, [2, 'if \(\(then\)\@!.\)*$', ' if then else'])
```

Anybody willing to help on this?
