### PR TITLE
Added test for conceal and fixed bug with 2nd value returned by synconcealed()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7656,12 +7656,12 @@ synconcealed({lnum}, {col})				*synconcealed()*
 		concealable region, 1 if it is. The second item in the list is
 		a string. If the first item is 1, the second item contains the
 		text which will be displayed in place of the concealed text,
-		depending on the current setting of 'conceallevel'. The third
-		and final item in the list is a unique number representing the
-		specific syntax region matched. This allows detection of the
-		beginning of a new concealable region if there are two
-		consecutive regions with the same replacement character.
-		For an example use see $VIMRUNTIME/syntax/2html.vim .
+		depending on the current setting of 'conceallevel' and
+                'listchars'. The third and final item in the list is a unique
+                number representing the specific syntax region matched. This
+                allows detection of the beginning of a new concealable region
+                if there are two consecutive regions with the same replacement
+		character.  For an example use see $VIMRUNTIME/syntax/2html.vim .
 
 
 synstack({lnum}, {col})					*synstack()*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -11841,8 +11841,8 @@ f_synconcealed(typval_T *argvars UNUSED, typval_T *rettv)
 	    if ((syntax_flags & HL_CONCEAL) && curwin->w_p_cole < 3)
 	    {
 		cchar = syn_get_sub_char();
-		if (cchar == NUL && curwin->w_p_cole == 1 && lcs_conceal != NUL)
-		    cchar = lcs_conceal;
+		if (cchar == NUL && curwin->w_p_cole == 1)
+		    cchar = (lcs_conceal == NUL) ? ' ' : lcs_conceal;
 		if (cchar != NUL)
 		{
 # ifdef FEAT_MBYTE

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -484,7 +484,7 @@ func Test_conceal()
   " should be a space. But synconcealed() gives an empty string in
   " the 2nd value of the returned list. Bug?
   " So for now, the following line is commented out:
-  "call assert_equal([[0, ''], [1, 'X'], [1, 'X'], [1, ' '], [1, ' '], [0, '']], map(range(1, 6), 'synconcealed(2, v:val)[0:1]'))
+  call assert_equal([[0, ''], [1, 'X'], [1, 'X'], [1, ' '], [1, ' '], [0, '']], map(range(1, 6), 'synconcealed(2, v:val)[0:1]'))
 
   set conceallevel=1
   set listchars=conceal:Y

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -4,6 +4,8 @@ if !has("syntax")
   finish
 endif
 
+source view_util.vim
+
 func GetSyntaxItem(pat)
   let c = ''
   let a = ['a', getreg('a'), getregtype('a')]
@@ -457,4 +459,46 @@ func Test_syntax_hangs()
 
   set redrawtime&
   bwipe!
+endfunc
+
+
+func Test_conceal()
+  if !has('conceal')
+    return
+  endif
+
+  new
+  call setline(1, ['', '123456'])
+  syn match test23 "23" conceal cchar=X
+  syn match test45 "45" conceal
+
+  set conceallevel=0
+  call assert_equal('123456 ', ScreenLines(2, 7)[0])
+  call assert_equal([[0, ''], [0, ''], [0, ''], [0, ''], [0, ''], [0, '']], map(range(1, 6), 'synconcealed(2, v:val)[0:1]'))
+
+  set conceallevel=1
+  call assert_equal('1X 6   ', ScreenLines(2, 7)[0])
+  " FIXME: with conceallevel=1, I would expect that the portion "45" of
+  " the line to be replaced with a space since ":help 'conceallevel'
+  " states that if listchars is not set, then the default replacement
+  " should be a space. But synconcealed() gives an empty string in
+  " the 2nd value of the returned list. Bug?
+  " So for now, the following line is commented out:
+  "call assert_equal([[0, ''], [1, 'X'], [1, 'X'], [1, ' '], [1, ' '], [0, '']], map(range(1, 6), 'synconcealed(2, v:val)[0:1]'))
+
+  set conceallevel=1
+  set listchars=conceal:Y
+  call assert_equal([[0, ''], [1, 'X'], [1, 'X'], [1, 'Y'], [1, 'Y'], [0, '']], map(range(1, 6), 'synconcealed(2, v:val)[0:1]'))
+  call assert_equal('1XY6   ', ScreenLines(2, 7)[0])
+
+  set conceallevel=2
+  call assert_match('1X6    ', ScreenLines(2, 7)[0])
+  call assert_equal([[0, ''], [1, 'X'], [1, 'X'], [1, ''], [1, ''], [0, '']], map(range(1, 6), 'synconcealed(2, v:val)[0:1]'))
+
+  set conceallevel=3
+  call assert_match('16     ', ScreenLines(2, 7)[0])
+  call assert_equal([[0, ''], [1, ''], [1, ''], [1, ''], [1, ''], [0, '']], map(range(1, 6), 'synconcealed(2, v:val)[0:1]'))
+
+  set conceallevel&
+  bw!
 endfunc

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -499,6 +499,7 @@ func Test_conceal()
   call assert_match('16     ', ScreenLines(2, 7)[0])
   call assert_equal([[0, ''], [1, ''], [1, ''], [1, ''], [1, ''], [0, '']], map(range(1, 6), 'synconcealed(2, v:val)[0:1]'))
 
+  syn clear
   set conceallevel&
   bw!
 endfunc


### PR DESCRIPTION
This PR adds a test for the conceal feature, and in particular
for the synconcealed() function which was not covered with tests.

While creating the test, I noticed 2 bugs:

1) The 2nd element in the list returned by synconcealed()
is wrong when conceallevel=1 and when the syntax element
has no cchar and when using the default value of 'listchars'.
It should be a space but it's an empty string.
See the commented out line in Test_conceal() test which
I would expect to pass but I had to comment it out.

2) The 3rd element in the list returned by synconcealed() is different
for every calls.  It looks like a bug, or I did not understand how to
use it.  Example:
```
$ vim -u NONE -c 'set conceallevel=1|syntax on|help'
:echo synconcealed(1, 1) 
[1, '', 33]
:echo synconcealed(1, 1) 
[1, '', 43]
:echo synconcealed(1, 1) 
[1, '', 53]
```
Notice that the 3rd value changes at each call. Bug?
So I did no test the 3rd element in the list returned by
synconcealed().  
