### PR TITLE
Fix: 'visualbell' doesn't work

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3674,6 +3674,24 @@ beep_flush(void)
     }
 }
 
+static void
+do_visualbell(void)
+{
+#ifdef ELAPSED_FUNC
+    static int		did_init = FALSE;
+    static ELAPSED_TYPE	start_tv;
+
+    /* Only put 'T_VB' once per 200 msec, otherwise a sequence of beeps would
+     * freeze Vim. */
+    if (did_init && ELAPSED_FUNC(start_tv) < 200)
+	return;
+
+    did_init = TRUE;
+    ELAPSED_INIT(start_tv);
+#endif
+    out_str_cf(T_VB);
+}
+
 /*
  * Give a warning for an error.
  */
@@ -3692,7 +3710,7 @@ vim_beep(
 		    && !(gui.in_use && gui.starting)
 #endif
 		    )
-		out_str_cf(T_VB);
+		do_visualbell();
 	    else
 		out_char(BELL);
 	}

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3692,7 +3692,7 @@ vim_beep(
 		    && !(gui.in_use && gui.starting)
 #endif
 		    )
-		out_str(T_VB);
+		out_str_cf(T_VB);
 	    else
 		out_char(BELL);
 	}

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -16,6 +16,7 @@ void out_flush_check(void);
 void out_trash(void);
 void out_char(unsigned c);
 void out_str_nf(char_u *s);
+void out_str_cf(char_u *s);
 void out_str(char_u *s);
 void term_windgoto(int row, int col);
 void term_cursor_right(int i);


### PR DESCRIPTION
### repro steps

test-environments:

* macOS 10.12.5, Terminal.app
* Ubuntu 16.04, gnome-terminal

```
vim -Nu NONE -c 'set vb'
```

and input `h`, but expected visual-bell (flashing screen) doesn't happen.

### details

Vim sends terminal-control-sequences at visualbell event when `t_vb` is `^[[?5h$<100/>^[[?5l`:

expected: `CSI ?5h` (reverse video) &rarr; 100ms delay &rarr; `CSI ?5l` (normal video)
actual:   100ms delay &rarr; `CSI ?5h` (reverse video) &rarr; `CSI ?5l` (normal video)

### cause

At visualbell event, `tputs()` in `out_str(T_VB)` is called,
and `out_char_nf()` writes characters of `T_VB` except `$<100/>` (terminfo string) to `out_buf`.

`$<100/>` is interpreted and executed before `out_buf` is flushed.

```
100ms delay by "$<100/>" in tputs()
out_flush() flushes out_buf (=="\e[?5h\e[?5l")
```

### proposal of fix

`T_VB` has to be flushed, at least, before `$<...>`.

desirable sequence:

```
tputs("\e[?5h")
out_flush()
tputs("$<100/>\e[?5l")
```

This patch adds `out_str_cf()` to check `$<` in `T_VB` and to insert flushing.

Ozaki Kiichi