### PR TITLE
Fix: cannot paste from clipboard when input() is called from timer

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3191,7 +3191,7 @@ f_feedkeys(typval_T *argvars, typval_T *rettv UNUSED)
 	    ins_typebuf(keys_esc, (remap ? REMAP_YES : REMAP_NONE),
 				  insert ? 0 : typebuf.tb_len, !typed, FALSE);
 	    vim_free(keys_esc);
-	    if (vgetc_busy)
+	    if (vgetc_busy || timer_busy)
 		typebuf_was_filled = TRUE;
 	    if (execute)
 	    {

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1209,14 +1209,17 @@ check_due_timer(void)
 	this_due = GET_TIMEDIFF(timer, now);
 	if (this_due <= 1)
 	{
+	    int save_timer_busy = timer_busy;
 	    int save_vgetc_busy = vgetc_busy;
 
+	    timer_busy = timer_busy > 0 || vgetc_busy > 0;
 	    vgetc_busy = 0;
 	    timer->tr_firing = TRUE;
 	    timer_callback(timer);
 	    timer->tr_firing = FALSE;
 	    timer_next = timer->tr_next;
 	    did_one = TRUE;
+	    timer_busy = save_timer_busy;
 	    vgetc_busy = save_vgetc_busy;
 
 	    /* Only fire the timer again if it repeats and stop_timer() wasn't

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1209,11 +1209,15 @@ check_due_timer(void)
 	this_due = GET_TIMEDIFF(timer, now);
 	if (this_due <= 1)
 	{
+	    int save_vgetc_busy = vgetc_busy;
+
+	    vgetc_busy = 0;
 	    timer->tr_firing = TRUE;
 	    timer_callback(timer);
 	    timer->tr_firing = FALSE;
 	    timer_next = timer->tr_next;
 	    did_one = TRUE;
+	    vgetc_busy = save_vgetc_busy;
 
 	    /* Only fire the timer again if it repeats and stop_timer() wasn't
 	     * called while inside the callback (tr_id == -1). */

--- a/src/globals.h
+++ b/src/globals.h
@@ -1659,6 +1659,7 @@ EXTERN int  in_free_unref_items INIT(= FALSE);
 
 #ifdef FEAT_TIMERS
 EXTERN int  did_add_timer INIT(= FALSE);
+EXTERN int  timer_busy INIT(= 0);   /* when timer is inside vgetc() then > 0 */
 #endif
 
 #ifdef FEAT_EVAL

--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -172,5 +172,21 @@ func Test_stop_all_in_callback()
   call assert_equal(0, len(info))
 endfunc
 
+func FeedkeysCb(timer)
+  call feedkeys("hello\<CR>", 'nt')
+endfunc
+
+func InputCb(timer)
+  call timer_start(10, 'FeedkeysCb')
+  let g:val = input('?')
+  call Resume()
+endfunc
+
+func Test_input_in_timer()
+  let g:val = ''
+  call timer_start(10, 'InputCb')
+  call Standby(1000)
+  call assert_equal('hello', g:val)
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
### repro steps

test-environments:

* macOS 10.12.5, Terminal.app
* Ubuntu 16.04, gnome-terminal

test.vim

```vim
function! Foo(...)
  let g:test = input('> ')
endfunction
call timer_start(1000, 'Foo')
```

1) `vim -Nu NONE -S test.vim`

2) Copy string `foobar` to OS clipboard

3) Attempt to paste from OS clipboard (e.g. Cmd-V on macOS or `<C-R>*`)

4) Cannot paste properly. Some results:

* nothing pasted
* only initial character (`f`)
* partially (e.g. `fbr`)
* with garbage (e.g. `foobar<b0>`)

### cause

When timer fires in waiting for input (i.e. in `vgetc`), `vgetc_busy` is set to positive,
so `vgetorpeek()` returns at https://github.com/vim/vim/tree/06f1ed2f78c5c03af95054fc3a8665df39dec362/src/getchar.c#L1982-L1983
and cannot fetch from typeahead buffer.

### proposal of fix

* Save and restore `vgetc_busy` when timer fires
* Set `timer_busy` when timer fires in waiting for input (`vgetc`)
  to enable to input by `feedkeys()` in timer. the following code will work:

```vim
fu! TimerCb(timer)
  call feedkeys("hello\<CR>", 'nt')
endfu
fu! Test(timer)
  call timer_start(100, 'TimerCb')
  let g:val = input('> ')
  "echomsg printf('[%s]', g:val)
endfu
call timer_start(100, 'Test')
```

Note: this pull-req will fix https://github.com/vim/vim/issues/1129

Ozaki Kiichi