### PR TITLE
Fix: interrupting confirm() called in timer causes vim hang

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -467,6 +467,11 @@ flush_buffers(int flush_typeahead)
 	    ;
 	typebuf.tb_off = MAXMAPLEN;
 	typebuf.tb_len = 0;
+#if defined(FEAT_CLIENTSERVER) || defined(FEAT_EVAL)
+	/* Reset the flag that text received from a client or from feedkeys()
+	 * was inserted in the typeahead buffer. */
+	typebuf_was_filled = FALSE;
+#endif
     }
     else		    /* remove mapped characters at the start only */
     {


### PR DESCRIPTION
### repro steps

test-environments:

* macOS 10.12.5, Terminal.app
* Ubuntu 16.04, gnome-terminal

test.vim

```vim
fu! Test_timer(timer) abort
  call feedkeys('o')
  call confirm('?')
endfu
call timer_start(100, 'Test_timer')
```

`vim -Nu NONE -S test.vim`

and input Ctrl-C to interrupt `confirm()`, then vim will hang.

Note: `input()` also instead of `confirm()`.

### cause

preconditions:

* `confirm()` and `feedkeys()` are called from timer fired in waiting for input (not in `do_sleep()`)
* `confirm()` isn't enclosed by `try` (i.e. exception isn't caught inside timer callback)

`feedkeys()` in timer sets `typebuf_was_filled` to TRUE, so `typebuf_changed()` returns TRUE,
but Ctrl-C flushes all input buffer and `typebuf_was_filled` is kept to TRUE, thus cannot exit from this loop: https://github.com/vim/vim/tree/06f1ed2f78c5c03af95054fc3a8665df39dec362/src/getchar.c#L2029

### proposal of fix

* Set `typebuf_was_filled` to FALSE in `flush_buffers()`
(but but I'm not sure there is no side influence by this change...)

Ozaki Kiichi