### PR TITLE
Render 'cc' with lower priority

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -5502,7 +5502,8 @@ win_line(
 	 * Also highlight the 'colorcolumn' if it is different than
 	 * 'cursorcolumn' */
 	vcol_save_attr = -1;
-	if (draw_state == WL_LINE && !lnum_in_visual_area)
+	if (draw_state == WL_LINE && !lnum_in_visual_area
+	    && search_attr == 0 && area_attr == 0)
 	{
 	    if (wp->w_p_cuc && VCOL_HLC == (long)wp->w_virtcol
 						 && lnum != wp->w_cursor.lnum)

--- a/src/testdir/test_listlbr_utf8.vim
+++ b/src/testdir/test_listlbr_utf8.vim
@@ -194,6 +194,21 @@ func Test_multibyte_sign_and_colorcolumn()
   call s:close_windows()
 endfunc
 
+func Test_colorcolumn_priority()
+  call s:test_windows('setl cc=4 cuc hls')
+  call setline(1, ["xxyy", ""])
+  norm! gg
+  exe "normal! /xxyy\<CR>"
+  norm! G
+  redraw!
+  let line_attr = s:screen_attr(1, [1, &cc])
+  " Search wins over CursorColumn
+  call assert_equal(line_attr[1], line_attr[0])
+  " Search wins over Colorcolumn
+  call assert_equal(line_attr[2], line_attr[3])
+  call s:close_windows('setl hls&vim')
+endfunc
+
 func Test_illegal_byte_and_breakat()
   call s:test_windows("setl sbr= brk+=<")
   vert resize 18


### PR DESCRIPTION
This _should_ (the redisplay code is a huge beast) fix a long-standing problem that's been irking me for so long and it's also been sitting in the `todo.txt` list for a while.

> 'colorcolumn' has higher priority than hlsearch.  Should probably be the other
way around. (Nazri Ramliy, 2013 Feb 19)
