### PR TITLE
Regression: Pack plugins are loaded twice (after 8.0.0612)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -462,11 +462,9 @@ vim_main2(void)
 # endif
 	TIME_MSG("loading plugins");
 
-	/* Only source "start" packages if not done already with a :packloadall
-	 * command. */
-	if (!did_source_packages)
-	    load_start_packages();
-	TIME_MSG("loading packages");
+	/* As package directories had been added to 'runtimepath', its plugins
+	 * have been loaded by now, too. */
+	did_source_packages = TRUE;
 
 # ifdef VMS	/* Somehow VMS doesn't handle the "**". */
 	source_runtime((char_u *)"plugin/*.vim", DIP_ALL | DIP_AFTER);

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -26,20 +26,24 @@ func Test_after_comes_later()
 	\ 'set rtp=Xhere,Xafter',
 	\ 'set packpath=Xhere,Xafter',
 	\ 'set nomore',
+	\ 'let g:sequence = ""',
 	\ ]
   let after = [
 	\ 'redir! > Xtestout',
 	\ 'scriptnames',
 	\ 'redir END',
+	\ 'redir! > Xsequence',
+	\ 'echo g:sequence',
+	\ 'redir END',
 	\ 'quit',
 	\ ]
   call mkdir('Xhere/plugin', 'p')
-  call writefile(['let done = 1'], 'Xhere/plugin/here.vim')
+  call writefile(['let g:sequence .= "plugin "'], 'Xhere/plugin/here.vim')
   call mkdir('Xhere/pack/foo/start/foobar/plugin', 'p')
-  call writefile(['let done = 1'], 'Xhere/pack/foo/start/foobar/plugin/foo.vim')
+  call writefile(['let g:sequence .= "pack "'], 'Xhere/pack/foo/start/foobar/plugin/foo.vim')
 
   call mkdir('Xafter/plugin', 'p')
-  call writefile(['let done = 1'], 'Xafter/plugin/later.vim')
+  call writefile(['let g:sequence .= "after "'], 'Xafter/plugin/later.vim')
 
   if RunVim(before, after, '')
 
@@ -56,7 +60,10 @@ func Test_after_comes_later()
     call assert_equal(expected, found)
   endif
 
+  call assert_equal('plugin pack after', substitute(join(readfile('Xsequence', 1), ''), '\s\+$', '', ''))
+
   call delete('Xtestout')
+  call delete('Xsequence')
   call delete('Xhere', 'rf')
   call delete('Xafter', 'rf')
 endfunc


### PR DESCRIPTION
A side effect of adding the pack dirs earlier to `'runtimepath'` (by calling `add_pack_start_dirs()`) is that this call that was originally meant to only load the traditional plugins now also loads the pack plugins as well (fortunately, in the right order):

    source_runtime((char_u *)"plugin/**/*.vim", DIP_ALL | DIP_NOAFTER)

The following invocation of `load_start_packages()` is superfluous and must be dropped to avoid duplicate loading of pack plugins.  Instead, only set the `did_source_packages` flag (as would have done by the dropped call) to neutralize the effect of `:packloadall`.

The existing `Test_after_comes_later()` verifies the ordering of plugin loads, but because :scriptnames just records the _first_ load of a script, it cannot ensure that each plugin is loaded only once.
Record each plugin load in `g:sequence`, and assert ordering (again) and uniqueness (new) in a separate check.
