### PR TITLE
Regression: :resize in :autocmd on :copen fails with E788 (after 8.0.677)

### DIFF
--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -2199,6 +2199,23 @@ func Test_cclose_from_copen()
     augroup! QF_Test
 endfunc
 
+func Test_resize_from_copen()
+    augroup QF_Test
+	au!
+        au FileType qf resize 5
+    augroup END
+    try
+	" This should succeed without any exception.  No other buffers are
+	" involved in the autocmd.
+	copen
+    finally
+	augroup QF_Test
+	    au!
+	augroup END
+	augroup! QF_Test
+    endtry
+endfunc
+
 " Tests for getting the quickfix stack size
 func XsizeTests(cchar)
   call s:setup_commands(a:cchar)


### PR DESCRIPTION
I have an `:autocmd` that adapts the height of the quickfix window if there are fewer entries in it than the window height (to save screen space).  It boils down to this:

    :autocmd BufRead quickfix resize [N]

Since Vim 8.0.0677 (_setting 'filetype' may switch buffers_; found through bisecting), this fails with `E788: Not allowed to edit another buffer now`.

The patch locks the current buffer.  However, I don't see why resizing the current window should be affected by the lock.

I tried following the call chain of `:resize`, but couldn't locate where this encounters the check of `curbuf_lock`.  All I can offer is the following test (based on `Test_cclose_from_copen()`) that highlights the regression.  It also uses `:autocmd FileType qf` instead of `:autocmd BufRead quickfix`; both show the issue.
