### PR TITLE
Show the destination register when yanking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2241,6 +2241,7 @@ test_arglist \
 	test_window_cmd \
 	test_window_id \
 	test_writefile \
+	test_yank \
 	test_alot_latin \
 	test_alot_utf8 \
 	test_alot:

--- a/src/ops.c
+++ b/src/ops.c
@@ -3167,19 +3167,24 @@ op_yank(oparg_T *oap, int deleting, int mess)
 	/* Some versions of Vi use ">=" here, some don't...  */
 	if (yanklines > p_report)
 	{
+	    const char regname = oap->regname ? oap->regname : '0';
 	    /* redisplay now, so message is not deleted */
 	    update_topline_redraw();
+
 	    if (yanklines == 1)
 	    {
 		if (oap->block_mode)
-		    MSG(_("block of 1 line yanked"));
+		    smsg((char_u *)_("block of 1 line yanked into \"%c"),
+			 regname);
 		else
-		    MSG(_("1 line yanked"));
+		    smsg((char_u *)_("1 line yanked into \"%c"), regname);
 	    }
 	    else if (oap->block_mode)
-		smsg((char_u *)_("block of %ld lines yanked"), yanklines);
+		smsg((char_u *)_("block of %ld lines yanked into \"%c"),
+		     yanklines, regname);
 	    else
-		smsg((char_u *)_("%ld lines yanked"), yanklines);
+		smsg((char_u *)_("%ld lines yanked into \"%c"), yanklines,
+		     regname);
 	}
     }
 

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -212,6 +212,7 @@ NEW_TESTS = test_arabic.res \
 	    test_visual.res \
 	    test_window_id.res \
 	    test_writefile.res \
+	    test_yank.res \
 	    test_alot_latin.res \
 	    test_alot_utf8.res \
 	    test_alot.res

--- a/src/testdir/test_yank.vim
+++ b/src/testdir/test_yank.vim
@@ -1,0 +1,15 @@
+func Test_yank_shows_register()
+    enew | only
+    set report=0
+    call setline(1, ['foo', 'bar'])
+    " Line-wise
+    exe 'norm! yy'
+    call assert_equal('1 line yanked into "0', v:statusmsg)
+    exe 'norm! "zyj'
+    call assert_equal('2 lines yanked into "z', v:statusmsg)
+    " Block-wise
+    exe "norm! \<C-V>y"
+    call assert_equal('block of 1 line yanked into "0', v:statusmsg)
+    exe "norm! \<C-V>j\"zy"
+    call assert_equal('block of 2 lines yanked into "z', v:statusmsg)
+endfunc


### PR DESCRIPTION
Implements #1803, I've decided to always show the destination register to avoid complicating the if maze.