### PR TITLE
test_sha256 and test_utf8_comparisons not executed

### DIFF
--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -44,6 +44,7 @@ source test_reltime.vim
 source test_searchpos.vim
 source test_set.vim
 source test_sort.vim
+source test_sha256.vim
 source test_statusline.vim
 source test_syn_attr.vim
 source test_tabline.vim
@@ -54,4 +55,5 @@ source test_taglist.vim
 source test_timers.vim
 source test_true_false.vim
 source test_unlet.vim
+source test_utf8_comparisons.vim
 source test_window_cmd.vim


### PR DESCRIPTION
Recent patch 8.0.0684 added test_sha256.vim and test_utf8_comparisons.vim,
but they are not executed.  We can see in codecov that function f_sha256()
for example is currently not covered with tests:

https://codecov.io/gh/vim/vim/src/master/src/evalfunc.c#L10448

This PR fixes it.