### PR TITLE
problem: <c-h> conflicts with <bs> in vim.exe on Windows

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -807,6 +807,7 @@ static const struct
     { VK_NEXT,	TRUE,	'Q',	'\322',	'v',	    '\323', }, /*PgDn*/
     { VK_INSERT,TRUE,	'R',	'\324',	'\325',	    '\326', },
     { VK_DELETE,TRUE,	'S',	'\327',	'\330',	    '\331', },
+    { VK_BACK, TRUE,	'\x7f',	0,	0,	    0, },
 
     { VK_SNAPSHOT,TRUE,	0,	0,	0,	    'r', }, /*PrtScrn*/
 

--- a/src/term.c
+++ b/src/term.c
@@ -633,6 +633,7 @@ static struct builtin_term builtin_termcaps[] =
     {K_K7,		"\316\366"},
     {K_K8,		"\316\372"},
     {K_K9,		"\316\376"},
+    {K_BS,		"\316\x7f"},
 # endif
 
 # if defined(VMS) || defined(ALL_BUILTIN_TCAPS)


### PR DESCRIPTION
All the other platforms
If I remap `<c-h>` to `<left>`, my `<BS>` is not changed, I can still use `<BS>` to delete previous character.

Windows console (vim.exe):
If I remap `<c-h>` to `<left>`, my `<BS>` become `<left>` too. I can't use my `<bs>` to delete last character now.

It has been discussed [here](https://groups.google.com/forum/#!topic/vim_dev/cKgLXgfQUic)

This patch add two new lines in os_win32.c and term.c to solve this problem.