### PR TITLE
scripts.vim: Improve detection of strace output files

### DIFF
--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -306,7 +306,9 @@ else
     set ft=virata
 
     " Strace
-  elseif s:line1 =~# '^\(\[pid \d\+\] \)\=[0-9:.]* *execve(' || s:line1 =~# '^__libc_start_main'
+  elseif s:line1 =~# '^\(\[pid \d\+\] \)\=[0-9:.]* *execve('
+    \ || s:line1 =~# '^__libc_start_main'
+    \ || s:line1 =~# 'execve(.*)\s\+= \d\+'
     set ft=strace
 
     " VSE JCL


### PR DESCRIPTION
Only recently did I learn that vim already has a syntax coloring for
strace output[1] although I've been using vim to study them since I learned
how to use strace. Seems like detection of strace files isn't very good
(at least for the common case on modern linux distributions).

This patchset improves the detection of strace output files by relying
solely on the assumption of the most basic strace output when invoked
without any additional options (ie: line1 has a call to execve followed
by the string ' = \<return code\>'.

I haven't removed any of the earlier regexs because I am not sure about
compatibility with output from strace from other platforms.

[1] thanks to https://codeyarns.com/2015/03/27/how-to-enable-syntax-highlighting-for-strace-output-in-vim/