### PR TITLE
Add `QuickFixLine` highlight group to syntax.txt

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4982,10 +4982,11 @@ PmenuSbar	Popup menu: scrollbar.
 PmenuThumb	Popup menu: Thumb of the scrollbar.
 							*hl-Question*
 Question	|hit-enter| prompt and yes/no questions
-							*hl-Search*
+							*hl-QuickFixLine*
+QuickFixLine	Current |quickfix| item in the quickfix window.
+							*hl-Search*						
 Search		Last search pattern highlighting (see 'hlsearch').
-		Also used for highlighting the current line in the quickfix
-		window and similar items that need to stand out.
+		Also used for  similar items that need to stand out.
 							*hl-SpecialKey*
 SpecialKey	Meta and special keys listed with ":map", also for text used
 		to show unprintable characters in the text, 'listchars'.


### PR DESCRIPTION
I see that the `QuickFixLine` highlight group was added in https://github.com/vim/vim/commit/2102035488e80ef6fd5038ed15d21672712ba0f6, but `syntax.txt` was not updated to mention it.

This PR updates `syntax.txt` to document `QuickFixLine`.