### PR TITLE
Fix typo of `./configure --help`: --enable-terminal

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -1494,7 +1494,7 @@ Optional Features:
   --enable-workshop       Include Sun Visual Workshop support.
   --disable-netbeans      Disable NetBeans integration support.
   --disable-channel      Disable process communication support.
-  --enable-terminal     Disable terminal emulation support.
+  --enable-terminal       Enable terminal emulation support.
   --enable-multibyte      Include multibyte editing support.
   --enable-hangulinput    Include Hangul input support.
   --enable-xim            Include XIM input support.

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2030,7 +2030,7 @@ fi
 
 AC_MSG_CHECKING(--enable-terminal argument)
 AC_ARG_ENABLE(terminal,
-	[  --enable-terminal     Disable terminal emulation support.],
+	[  --enable-terminal     Enable terminal emulation support.],
 	[enable_terminal="yes"], )
 if test "$enable_terminal" = "yes"; then
   if test "x$features" = "xtiny" -o "x$features" = "xsmall"; then


### PR DESCRIPTION
`--enable-terminal     Disable terminal emulation support.` must be `  --enable-terminal     Enable terminal emulation support.`