### PR TITLE
support :terminal on Windows

### DIFF
--- a/src/INSTALLpc.txt
+++ b/src/INSTALLpc.txt
@@ -29,10 +29,11 @@ Contents:
 10. Building with Perl support
 11. Building with Ruby support
 12. Building with Tcl support
-13. Windows 3.1
-14. MS-DOS
+13. Building with Terminal support
+14. Windows 3.1
+15. MS-DOS
 
-15. Installing after building from sources
+16. Installing after building from sources
 
 
 The currently preferred method is using the free Visual C++ Toolkit 2008
@@ -702,19 +703,35 @@ Or when using MinGW (as one line):
         TCL=C:\Tcl86 DYNAMIC_TCL=yes TCL_VER=86 TCL_VER_LONG=8.6
 
 
-13. Windows 3.1x
+13. Building with Terminal support
+==================================
+
+Vim with Terminal support can be built with MinGW or Cygwin.
+Terminal support require winpty which provide following two files.
+
+    winpty.dll
+    winpty-agent.dll
+
+You can download following page:
+
+    https://github.com/rprichard/winpty
+
+It don't need header files or libraries. Just put them on your PATH.
+
+
+14. Windows 3.1x
 ================
 
 The Windows 3.1x support was removed in patch 7.4.1364.
 
 
-14. MS-DOS
+15. MS-DOS
 ==========
 
 The MS-DOS support was removed in patch 7.4.1399.
 
 
-15. Installing after building from sources
+16. Installing after building from sources
 ==========================================
 
 [provided by Michael Soyka]

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -750,6 +750,7 @@ endif
 
 ifeq ($(TERMINAL),yes)
 OBJ += $(OUTDIR)/terminal.o
+VTERM_LIB = libvterm/.libs/libvterm.a
 endif
 
 
@@ -849,7 +850,7 @@ uninstal.exe: uninstal.c
 	$(CC) $(CFLAGS) -o uninstal.exe uninstal.c $(LIB)
 
 $(TARGET): $(OUTDIR) $(OBJ)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $(OBJ) $(LIB) -lole32 -luuid $(LUA_LIB) $(MZSCHEME_LIBDIR) $(MZSCHEME_LIB) $(PYTHONLIB) $(PYTHON3LIB) $(RUBYLIB)
+	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $(OBJ) $(LIB) -lole32 -luuid $(LUA_LIB) $(MZSCHEME_LIBDIR) $(MZSCHEME_LIB) $(PYTHONLIB) $(PYTHON3LIB) $(RUBYLIB) $(VTERM_LIB)
 
 upx: exes
 	upx gvim.exe
@@ -864,6 +865,9 @@ xxd/xxd.exe: xxd/xxd.c
 
 GvimExt/gvimext.dll: GvimExt/gvimext.cpp GvimExt/gvimext.rc GvimExt/gvimext.h
 	$(MAKE) -C GvimExt -f Make_ming.mak CROSS=$(CROSS) CROSS_COMPILE=$(CROSS_COMPILE) CXX='$(CXX)' STATIC_STDCPLUS=$(STATIC_STDCPLUS)
+
+libvterm/.libs/libvterm.a :
+	cd libvterm && $(MAKE) libvterm.la
 
 clean:
 	-$(DEL) $(OUTDIR)$(DIRSLASH)*.o

--- a/src/channel.c
+++ b/src/channel.c
@@ -4643,7 +4643,7 @@ job_still_useful(job_T *job)
  * changed to JOB_ENDED (i.e. after job_status() returned "dead" first or
  * mch_detect_ended_job() returned non-NULL).
  */
-    static void
+    void
 job_cleanup(job_T *job)
 {
     if (job->jv_status != JOB_ENDED)
@@ -4773,7 +4773,7 @@ free_unused_jobs(int copyID, int mask)
 /*
  * Allocate a job.  Sets the refcount to one and sets options default.
  */
-    static job_T *
+    job_T *
 job_alloc(void)
 {
     job_T *job;

--- a/src/proto/channel.pro
+++ b/src/proto/channel.pro
@@ -55,6 +55,8 @@ void clear_job_options(jobopt_T *opt);
 void free_job_options(jobopt_T *opt);
 int get_job_options(typval_T *tv, jobopt_T *opt, int supported);
 channel_T *get_channel_arg(typval_T *tv, int check_open, int reading, ch_part_T part);
+job_T *job_alloc(void);
+void job_cleanup(job_T *job);
 void job_free_all(void);
 int set_ref_in_job(int copyID);
 void job_unref(job_T *job);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -68,11 +68,11 @@
 #ifdef FEAT_TERMINAL
 
 #ifdef WIN3264
-/* MS-Windows: use a native console. */
-#else
-/* Unix-like: use libvterm. */
-# include "libvterm/include/vterm.h"
+# define MIN(x,y) (x < y ? x : y)
+# define MAX(x,y) (x > y ? x : y)
 #endif
+
+#include "libvterm/include/vterm.h"
 
 /* typedef term_T in structs.h */
 struct terminal_S {
@@ -80,9 +80,10 @@ struct terminal_S {
 
 #ifdef WIN3264
     /* console handle? */
-#else
-    VTerm	*tl_vterm;
+    void	*wp_config;
+    void	*wp_pty;
 #endif
+    VTerm	*tl_vterm;
     job_T	*tl_job;
     buf_T	*tl_buffer;
 
@@ -97,7 +98,7 @@ struct terminal_S {
 #define KEY_BUF_LEN 200
 
 /* Functions implemented for MS-Windows and Unix-like systems. */
-static int term_init(term_T *term, int rows, int cols);
+static int term_init(term_T *term, int rows, int cols, char_u *cmd);
 static void term_free(term_T *term);
 static void term_write_job_output(term_T *term, char_u *msg, size_t len);
 static int term_convert_key(int c, char *buf);
@@ -122,9 +123,7 @@ ex_terminal(exarg_T *eap)
     int		cols;
     exarg_T	split_ea;
     win_T	*old_curwin = curwin;
-    typval_T	argvars[2];
     term_T	*term;
-    jobopt_T	opt;
 
     if (check_restricted() || check_secure())
 	return;
@@ -168,27 +167,7 @@ ex_terminal(exarg_T *eap)
 	cols = curwin->w_width;
     }
 
-    if (term_init(term, rows, cols) == OK)
-    {
-	argvars[0].v_type = VAR_STRING;
-	argvars[0].vval.v_string = eap->arg;
-
-	clear_job_options(&opt);
-	opt.jo_mode = MODE_RAW;
-	opt.jo_out_mode = MODE_RAW;
-	opt.jo_err_mode = MODE_RAW;
-	opt.jo_set = JO_MODE | JO_OUT_MODE | JO_ERR_MODE;
-	opt.jo_io[PART_OUT] = JIO_BUFFER;
-	opt.jo_io[PART_ERR] = JIO_BUFFER;
-	opt.jo_set |= JO_OUT_IO + (JO_OUT_IO << (PART_ERR - PART_OUT));
-	opt.jo_io_buf[PART_OUT] = curbuf->b_fnum;
-	opt.jo_io_buf[PART_ERR] = curbuf->b_fnum;
-	opt.jo_set |= JO_OUT_BUF + (JO_OUT_BUF << (PART_ERR - PART_OUT));
-	opt.jo_term_rows = rows;
-	opt.jo_term_cols = cols;
-
-	term->tl_job = job_start(argvars, &opt);
-    }
+    term_init(term, rows, cols, eap->arg);
 
     if (term->tl_job == NULL)
 	/* Wiping out the buffer will also close the window. */
@@ -271,6 +250,7 @@ terminal_loop(void)
 	out_flush();
 	++no_mapping;
 	++allow_keys;
+	got_int = FALSE;
 	c = vgetc();
 	--no_mapping;
 	--allow_keys;
@@ -344,71 +324,6 @@ position_cursor(win_T *wp, VTermPos *pos)
     wp->w_wcol = MIN(pos->col, MAX(0, wp->w_width - 1));
 }
 
-#ifdef WIN3264
-
-/**************************************
- * 2. MS-Windows implementation.
- */
-
-/*
- * Create a new terminal of "rows" by "cols" cells.
- * Store a reference in "term".
- * Return OK or FAIL.
- */
-    static int
-term_init(term_T *term, int rows, int cols)
-{
-    /* TODO: Create a hidden console */
-    return FAIL;
-}
-
-/*
- * Free the terminal emulator part of "term".
- */
-    static void
-term_free(term_T *term)
-{
-    /* TODO */
-}
-
-/*
- * Write job output "msg[len]" to the terminal.
- */
-    static void
-term_write_job_output(term_T *term, char_u *msg, size_t len)
-{
-    /* TODO */
-}
-
-/*
- * Convert typed key "c" into bytes to send to the job.
- * Return the number of bytes in "buf".
- */
-    static int
-term_convert_key(int c, char *buf)
-{
-    /* TODO */
-    return 0;
-}
-
-/*
- * Called to update the window that contains the terminal.
- */
-    static void
-term_update_lines(win_T *wp)
-{
-    /* TODO */
-}
-
-#else
-
-/**************************************
- * 3. Unix-like implementation.
- *
- * For a terminal one VTerm is constructed.  This uses libvterm.  A copy of
- * that library is in the libvterm directory.
- */
-
 static int handle_damage(VTermRect rect, void *user);
 static int handle_moverect(VTermRect dest, VTermRect src, void *user);
 static int handle_movecursor(VTermPos pos, VTermPos oldpos, int visible, void *user);
@@ -424,37 +339,6 @@ static VTermScreenCallbacks screen_callbacks = {
   NULL,			/* sb_pushline */
   NULL			/* sb_popline */
 };
-
-/*
- * Create a new terminal of "rows" by "cols" cells.
- * Store a reference in "term".
- * Return OK or FAIL.
- */
-    static int
-term_init(term_T *term, int rows, int cols)
-{
-    VTerm *vterm = vterm_new(rows, cols);
-    VTermScreen *screen;
-
-    term->tl_vterm = vterm;
-    screen = vterm_obtain_screen(vterm);
-    vterm_screen_set_callbacks(screen, &screen_callbacks, term);
-    /* TODO: depends on 'encoding'. */
-    vterm_set_utf8(vterm, 1);
-    /* Required to initialize most things. */
-    vterm_screen_reset(screen, 1 /* hard */);
-
-    return OK;
-}
-
-/*
- * Free the terminal emulator part of "term".
- */
-    static void
-term_free(term_T *term)
-{
-    vterm_free(term->tl_vterm);
-}
 
 /*
  * Write job output "msg[len]" to the terminal.
@@ -473,7 +357,7 @@ term_write_job_output(term_T *term, char_u *msg, size_t len)
 	{
 	    if (*p == NL)
 		break;
-	    p += mb_ptr2len_len(p, len - (p - msg));
+	    p += utf_ptr2len_len(p, len - (p - msg));
 	}
 	len_now = p - msg - done;
 	vterm_input_write(vterm, (char *)msg + done, len_now);
@@ -508,11 +392,11 @@ handle_moverect(VTermRect dest UNUSED, VTermRect src UNUSED, void *user)
     return 1;
 }
 
-  static int
+    static int
 handle_movecursor(
 	VTermPos pos,
-	VTermPos oldpos UNUSED,
-	int visible UNUSED,
+	VTermPos oldpos,
+	int visible,
 	void *user)
 {
     term_T	*term = (term_T *)user;
@@ -555,6 +439,64 @@ handle_resize(int rows, int cols, void *user)
 
     redraw_buf_later(term->tl_buffer, NOT_VALID);
     return 1;
+}
+
+/*
+ * Called to update the window that contains the terminal.
+ */
+    static void
+term_update_lines(win_T *wp)
+{
+    int		vterm_rows;
+    int		vterm_cols;
+    VTerm	*vterm = wp->w_buffer->b_term->tl_vterm;
+    VTermScreen *screen = vterm_obtain_screen(vterm);
+    VTermPos	pos;
+
+    vterm_get_size(vterm, &vterm_rows, &vterm_cols);
+
+    /* TODO: Only redraw what changed. */
+    for (pos.row = 0; pos.row < wp->w_height; ++pos.row)
+    {
+	int off = screen_get_current_line_off();
+
+	for (pos.col = 0; pos.col < wp->w_width && pos.col < vterm_cols; ++pos.col)
+	{
+	    ScreenLines[off + pos.col] = ' ';
+	    ScreenLinesUC[off + pos.col] = 0x00;
+	}
+
+	if (pos.row < vterm_rows)
+	{
+	    for (pos.col = 0; pos.col < wp->w_width && pos.col < vterm_cols;)
+	    {
+		VTermScreenCell cell;
+		int c;
+
+		vterm_screen_get_cell(screen, pos, &cell);
+		/* TODO: use cell.attrs and colors */
+		c = cell.chars[0];
+		if (c != NUL)
+		{
+#if defined(FEAT_MBYTE)
+		    if (enc_utf8 && c >= 0x80)
+			ScreenLinesUC[off] = c;
+		    else
+			ScreenLines[off] = c;
+#else
+		    ScreenLines[off] = c;
+#endif
+		    ScreenAttrs[off] = 0;
+		}
+
+		pos.col += cell.width;
+		off += cell.width;
+	    }
+	}
+
+	screen_line(wp->w_winrow + pos.row, wp->w_wincol,
+		MIN(wp->w_width, vterm_cols), wp->w_width, FALSE);
+    }
 }
 
 /*
@@ -662,60 +604,295 @@ term_convert_key(int c, char *buf)
     return vterm_output_read(vterm, buf, KEY_BUF_LEN);
 }
 
+#ifdef WIN3264
+
+#define WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN 1ul
+#define WINPTY_SPAWN_FLAG_EXIT_AFTER_SHUTDOWN 2ull
+
+void* (*winpty_config_new)(int, void*);
+void* (*winpty_open)(void*, void*);
+void* (*winpty_spawn_config_new)(int, void*, LPCWSTR, void*, void*, void*);
+BOOL (*winpty_spawn)(void*, void*, HANDLE*, HANDLE*, DWORD*, void*);
+void (*winpty_config_set_initial_size)(void*, int, int);
+LPCWSTR (*winpty_conin_name)(void*);
+LPCWSTR (*winpty_conout_name)(void*);
+LPCWSTR (*winpty_conerr_name)(void*);
+void (*winpty_free)(void*);
+void (*winpty_config_free)(void*);
+void (*winpty_spawn_config_free)(void*);
+void (*winpty_error_free)(void*);
+
+/**************************************
+ * 2. MS-Windows implementation.
+ */
+
+#define WINPTY_DLL "winpty.dll"
+
+static HINSTANCE hWinPtyDLL = NULL;
+
+    int
+dyn_winpty_init(void)
+{
+    int i;
+    static struct
+    {
+	char	    *name;
+	FARPROC	    *ptr;
+    } winpty_entry[] =
+    {
+	{"winpty_conerr_name", (FARPROC*)&winpty_conerr_name},
+	{"winpty_config_free", (FARPROC*)&winpty_config_free},
+	{"winpty_config_new", (FARPROC*)&winpty_config_new},
+	{"winpty_config_set_initial_size", (FARPROC*)&winpty_config_set_initial_size},
+	{"winpty_conin_name", (FARPROC*)&winpty_conin_name},
+	{"winpty_conout_name", (FARPROC*)&winpty_conout_name},
+	{"winpty_error_free", (FARPROC*)&winpty_error_free},
+	{"winpty_free", (FARPROC*)&winpty_free},
+	{"winpty_open", (FARPROC*)&winpty_open},
+	{"winpty_spawn", (FARPROC*)&winpty_spawn},
+	{"winpty_spawn_config_free", (FARPROC*)&winpty_spawn_config_free},
+	{"winpty_spawn_config_new", (FARPROC*)&winpty_spawn_config_new},
+	{NULL, NULL}
+    };
+
+    /* No need to initialize twice. */
+    if (hWinPtyDLL)
+	return 1;
+    /* Load winpty.dll */
+    hWinPtyDLL = vimLoadLib(WINPTY_DLL);
+    if (!hWinPtyDLL)
+    {
+	if (p_verbose > 0)
+	{
+	    verbose_enter();
+	    EMSG2(_(e_loadlib), WINPTY_DLL);
+	    verbose_leave();
+	}
+	return 0;
+    }
+    for (i = 0; winpty_entry[i].name != NULL
+					 && winpty_entry[i].ptr != NULL; ++i)
+    {
+	if ((*winpty_entry[i].ptr = (FARPROC)GetProcAddress(hWinPtyDLL,
+					      winpty_entry[i].name)) == NULL)
+	{
+	    if (p_verbose > 0)
+	    {
+		verbose_enter();
+		EMSG2(_(e_loadfunc), winpty_entry[i].name);
+		verbose_leave();
+	    }
+	    return 0;
+	}
+    }
+
+    return 1;
+}
+
 /*
- * Called to update the window that contains the terminal.
+ * Create a new terminal of "rows" by "cols" cells.
+ * Store a reference in "term".
+ * Return OK or FAIL.
+ */
+    static int
+term_init(term_T *term, int rows, int cols, char_u *cmd)
+{
+    WCHAR	    *p = enc_to_utf16(cmd, NULL);
+    channel_T	    *channel = NULL;
+    job_T	    *job = NULL;
+    jobopt_T	    opt;
+    DWORD	    error;
+    HANDLE	    jo = NULL, child_process_handle, child_thread_handle;
+    void	    *err;
+    void	    *spawn_config;
+
+    VTerm	    *vterm;
+    VTermScreen	    *screen;
+
+    if (!dyn_winpty_init())
+	return FAIL;
+
+    if (p == NULL)
+	return FAIL;
+
+    job = job_alloc();
+    if (job == NULL)
+	goto failed;
+
+    channel = add_channel();
+    if (channel == NULL)
+	goto failed;
+
+    term->wp_config = winpty_config_new(0, &err);
+    if (term->wp_config == NULL)
+	goto failed;
+
+    winpty_config_set_initial_size(term->wp_config, cols, rows);
+    term->wp_pty = winpty_open(term->wp_config, &err);
+    if (term->wp_pty == NULL)
+	goto failed;
+
+    spawn_config = winpty_spawn_config_new(
+	    WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN |
+		WINPTY_SPAWN_FLAG_EXIT_AFTER_SHUTDOWN,
+	    NULL,
+	    p,
+	    NULL,
+	    NULL,
+	    &err);
+    if (spawn_config == NULL)
+	goto failed;
+
+    channel = add_channel();
+    if (channel == NULL)
+	goto failed;
+
+    job = job_alloc();
+    if (job == NULL)
+	goto failed;
+
+    if (!winpty_spawn(term->wp_pty, spawn_config, &child_process_handle,
+	    &child_thread_handle, &error, &err))
+	goto failed;
+
+    channel_set_pipes(channel,
+	(sock_T) CreateFileW(
+	    winpty_conin_name(term->wp_pty),
+	    GENERIC_WRITE, 0, NULL,
+	    OPEN_EXISTING, 0, NULL),
+	(sock_T) CreateFileW(
+	    winpty_conout_name(term->wp_pty),
+	    GENERIC_READ, 0, NULL,
+	    OPEN_EXISTING, 0, NULL),
+	(sock_T) CreateFileW(
+	    winpty_conerr_name(term->wp_pty),
+	    GENERIC_READ, 0, NULL,
+	    OPEN_EXISTING, 0, NULL));
+
+    jo = CreateJobObject(NULL, NULL);
+    if (jo == NULL)
+	goto failed;
+
+    if (!AssignProcessToJobObject(jo, child_process_handle))
+	goto failed;
+
+    winpty_spawn_config_free(spawn_config);
+
+    vterm = vterm_new(rows, cols);
+
+    term->tl_vterm = vterm;
+    screen = vterm_obtain_screen(vterm);
+    vterm_screen_set_callbacks(screen, &screen_callbacks, term);
+    /* TODO: depends on 'encoding'. */
+    vterm_set_utf8(vterm, 1);
+    /* Required to initialize most things. */
+    vterm_screen_reset(screen, 1 /* hard */);
+
+    clear_job_options(&opt);
+    opt.jo_mode = MODE_RAW;
+    opt.jo_out_mode = MODE_RAW;
+    opt.jo_err_mode = MODE_RAW;
+    opt.jo_set = JO_MODE | JO_OUT_MODE | JO_ERR_MODE;
+    opt.jo_io[PART_OUT] = JIO_BUFFER;
+    opt.jo_io[PART_ERR] = JIO_BUFFER;
+    opt.jo_set |= JO_OUT_IO + (JO_OUT_IO << (PART_ERR - PART_OUT));
+    opt.jo_io_buf[PART_OUT] = curbuf->b_fnum;
+    opt.jo_io_buf[PART_ERR] = curbuf->b_fnum;
+    opt.jo_set |= JO_OUT_BUF + (JO_OUT_BUF << (PART_ERR - PART_OUT));
+    channel_set_job(channel, job, &opt);
+
+    job->jv_channel = channel;
+    job->jv_proc_info.hProcess = child_process_handle;
+    job->jv_proc_info.dwProcessId = GetProcessId(child_process_handle);
+    job->jv_job_object = jo;
+    job->jv_status = JOB_STARTED;
+    term->tl_job = job;
+
+    return OK;
+
+failed:
+    if (channel)
+	channel_clear(channel);
+    if (job)
+	job_cleanup(job);
+    if (jo)
+	CloseHandle(jo);
+    if (term->wp_pty)
+	winpty_free(term->wp_pty);
+    if (term->wp_config)
+	winpty_config_free(term->wp_config);
+    if (err)
+	winpty_error_free(err);
+    return FAIL;
+}
+
+/*
+ * Free the terminal emulator part of "term".
  */
     static void
-term_update_lines(win_T *wp)
+term_free(term_T *term)
 {
-    int		vterm_rows;
-    int		vterm_cols;
-    VTerm	*vterm = wp->w_buffer->b_term->tl_vterm;
-    VTermScreen *screen = vterm_obtain_screen(vterm);
-    VTermState	*state = vterm_obtain_state(vterm);
-    VTermPos	pos;
+    winpty_free(term->wp_pty);
+    winpty_config_free(term->wp_config);
+    vterm_free(term->tl_vterm);
+}
 
-    vterm_get_size(vterm, &vterm_rows, &vterm_cols);
+#else
 
-    if (*wp->w_p_tms == NUL
-		  && (vterm_rows != wp->w_height || vterm_cols != wp->w_width))
-    {
-	vterm_set_size(vterm, wp->w_height, wp->w_width);
-	/* Get the size again, in case setting the didn't work. */
-	vterm_get_size(vterm, &vterm_rows, &vterm_cols);
-    }
+/**************************************
+ * 3. Unix-like implementation.
+ *
+ * For a terminal one VTerm is constructed.  This uses libvterm.  A copy of
+ * that library is in the libvterm directory.
+ */
+/*
+ * Create a new terminal of "rows" by "cols" cells.
+ * Store a reference in "term".
+ * Return OK or FAIL.
+ */
+    static int
+term_init(term_T *term, int rows, int cols, char_u *cmd)
+{
+    VTerm *vterm = vterm_new(rows, cols);
+    VTermScreen *screen;
+    typval_T	argvars[2];
+    jobopt_T	opt;
 
-    /* The cursor may have been moved when resizing. */
-    vterm_state_get_cursorpos(state, &pos);
-    position_cursor(wp, &pos);
+    term->tl_vterm = vterm;
+    screen = vterm_obtain_screen(vterm);
+    vterm_screen_set_callbacks(screen, &screen_callbacks, term);
+    /* TODO: depends on 'encoding'. */
+    vterm_set_utf8(vterm, 1);
+    /* Required to initialize most things. */
+    vterm_screen_reset(screen, 1 /* hard */);
 
-    /* TODO: Only redraw what changed. */
-    for (pos.row = 0; pos.row < wp->w_height; ++pos.row)
-    {
-	int off = screen_get_current_line_off();
+    argvars[0].v_type = VAR_STRING;
+    argvars[0].vval.v_string = cmd;
 
-	if (pos.row < vterm_rows)
-	    for (pos.col = 0; pos.col < wp->w_width && pos.col < vterm_cols;
-								     ++pos.col)
-	    {
-		VTermScreenCell cell;
-		int c;
+    clear_job_options(&opt);
+    opt.jo_mode = MODE_RAW;
+    opt.jo_out_mode = MODE_RAW;
+    opt.jo_err_mode = MODE_RAW;
+    opt.jo_set = JO_MODE | JO_OUT_MODE | JO_ERR_MODE;
+    opt.jo_io[PART_OUT] = JIO_BUFFER;
+    opt.jo_io[PART_ERR] = JIO_BUFFER;
+    opt.jo_set |= JO_OUT_IO + (JO_OUT_IO << (PART_ERR - PART_OUT));
+    opt.jo_io_buf[PART_OUT] = curbuf->b_fnum;
+    opt.jo_io_buf[PART_ERR] = curbuf->b_fnum;
+    opt.jo_set |= JO_OUT_BUF + (JO_OUT_BUF << (PART_ERR - PART_OUT));
 
-		vterm_screen_get_cell(screen, pos, &cell);
-		/* TODO: use cell.attrs and colors */
-		/* TODO: use cell.width */
-		/* TODO: multi-byte chars */
-		c = cell.chars[0];
-		ScreenLines[off] = c == NUL ? ' ' : c;
-		ScreenAttrs[off] = 0;
-		++off;
-	    }
-	else
-	    pos.col = 0;
+    term->tl_job = job_start(argvars, &opt);
 
-	screen_line(wp->w_winrow + pos.row, wp->w_wincol, pos.col, wp->w_width,
-									FALSE);
-    }
+    return term->tl_job != NULL ? OK : FAIL;
+}
+
+/*
+ * Free the terminal emulator part of "term".
+ */
+    static void
+term_free(term_T *term)
+{
+    vterm_free(term->tl_vterm);
 }
 
 #endif

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -625,6 +625,7 @@ void (*winpty_free)(void*);
 void (*winpty_config_free)(void*);
 void (*winpty_spawn_config_free)(void*);
 void (*winpty_error_free)(void*);
+LPCWSTR (*winpty_error_msg)(void*);
 
 /**************************************
  * 2. MS-Windows implementation.
@@ -656,6 +657,7 @@ dyn_winpty_init(void)
 	{"winpty_spawn", (FARPROC*)&winpty_spawn},
 	{"winpty_spawn_config_free", (FARPROC*)&winpty_spawn_config_free},
 	{"winpty_spawn_config_new", (FARPROC*)&winpty_spawn_config_new},
+	{"winpty_error_msg", (FARPROC*)&winpty_error_msg},
 	{NULL, NULL}
     };
 
@@ -816,7 +818,11 @@ failed:
     if (term->wp_config)
 	winpty_config_free(term->wp_config);
     if (err)
+    {
+	char_u* msg = utf16_to_enc((short_u*) winpty_error_msg(err), NULL);
+	EMSG(msg);
 	winpty_error_free(err);
+    }
     return FAIL;
 }
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -170,8 +170,12 @@ ex_terminal(exarg_T *eap)
     term_init(term, rows, cols, eap->arg);
 
     if (term->tl_job == NULL)
+    {
+	first_term = term->tl_next;
+	curbuf->b_term = NULL;
 	/* Wiping out the buffer will also close the window. */
 	do_buffer(DOBUF_WIPE, DOBUF_CURRENT, FORWARD, 0, TRUE);
+    }
 
     /* TODO: Setup pty, see mch_call_shell(). */
 }
@@ -662,12 +666,7 @@ dyn_winpty_init(void)
     hWinPtyDLL = vimLoadLib(WINPTY_DLL);
     if (!hWinPtyDLL)
     {
-	if (p_verbose > 0)
-	{
-	    verbose_enter();
-	    EMSG2(_(e_loadlib), WINPTY_DLL);
-	    verbose_leave();
-	}
+	EMSG2(_(e_loadlib), WINPTY_DLL);
 	return 0;
     }
     for (i = 0; winpty_entry[i].name != NULL
@@ -676,12 +675,7 @@ dyn_winpty_init(void)
 	if ((*winpty_entry[i].ptr = (FARPROC)GetProcAddress(hWinPtyDLL,
 					      winpty_entry[i].name)) == NULL)
 	{
-	    if (p_verbose > 0)
-	    {
-		verbose_enter();
-		EMSG2(_(e_loadfunc), winpty_entry[i].name);
-		verbose_leave();
-	    }
+	    EMSG2(_(e_loadfunc), winpty_entry[i].name);
 	    return 0;
 	}
     }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -608,6 +608,22 @@ term_convert_key(int c, char *buf)
     return vterm_output_read(vterm, buf, KEY_BUF_LEN);
 }
 
+    static void
+setup_job_options(jobopt_T *opt)
+{
+    clear_job_options(opt);
+    opt->jo_mode = MODE_RAW;
+    opt->jo_out_mode = MODE_RAW;
+    opt->jo_err_mode = MODE_RAW;
+    opt->jo_set = JO_MODE | JO_OUT_MODE | JO_ERR_MODE;
+    opt->jo_io[PART_OUT] = JIO_BUFFER;
+    opt->jo_io[PART_ERR] = JIO_BUFFER;
+    opt->jo_set |= JO_OUT_IO + (JO_OUT_IO << (PART_ERR - PART_OUT));
+    opt->jo_io_buf[PART_OUT] = curbuf->b_fnum;
+    opt->jo_io_buf[PART_ERR] = curbuf->b_fnum;
+    opt->jo_set |= JO_OUT_BUF + (JO_OUT_BUF << (PART_ERR - PART_OUT));
+}
+
 #ifdef WIN3264
 
 #define WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN 1ul
@@ -784,17 +800,7 @@ term_init(term_T *term, int rows, int cols, char_u *cmd)
     /* Required to initialize most things. */
     vterm_screen_reset(screen, 1 /* hard */);
 
-    clear_job_options(&opt);
-    opt.jo_mode = MODE_RAW;
-    opt.jo_out_mode = MODE_RAW;
-    opt.jo_err_mode = MODE_RAW;
-    opt.jo_set = JO_MODE | JO_OUT_MODE | JO_ERR_MODE;
-    opt.jo_io[PART_OUT] = JIO_BUFFER;
-    opt.jo_io[PART_ERR] = JIO_BUFFER;
-    opt.jo_set |= JO_OUT_IO + (JO_OUT_IO << (PART_ERR - PART_OUT));
-    opt.jo_io_buf[PART_OUT] = curbuf->b_fnum;
-    opt.jo_io_buf[PART_ERR] = curbuf->b_fnum;
-    opt.jo_set |= JO_OUT_BUF + (JO_OUT_BUF << (PART_ERR - PART_OUT));
+    setup_job_options(&opt);
     channel_set_job(channel, job, &opt);
 
     job->jv_channel = channel;
@@ -869,18 +875,7 @@ term_init(term_T *term, int rows, int cols, char_u *cmd)
     argvars[0].v_type = VAR_STRING;
     argvars[0].vval.v_string = cmd;
 
-    clear_job_options(&opt);
-    opt.jo_mode = MODE_RAW;
-    opt.jo_out_mode = MODE_RAW;
-    opt.jo_err_mode = MODE_RAW;
-    opt.jo_set = JO_MODE | JO_OUT_MODE | JO_ERR_MODE;
-    opt.jo_io[PART_OUT] = JIO_BUFFER;
-    opt.jo_io[PART_ERR] = JIO_BUFFER;
-    opt.jo_set |= JO_OUT_IO + (JO_OUT_IO << (PART_ERR - PART_OUT));
-    opt.jo_io_buf[PART_OUT] = curbuf->b_fnum;
-    opt.jo_io_buf[PART_ERR] = curbuf->b_fnum;
-    opt.jo_set |= JO_OUT_BUF + (JO_OUT_BUF << (PART_ERR - PART_OUT));
-
+    setup_job_options(&opt);
     term->tl_job = job_start(argvars, &opt);
 
     return term->tl_job != NULL ? OK : FAIL;


### PR DESCRIPTION
* use libvterm on Windows
* use winpty to be possible to handle escape sequence
* dynamic loading of winpty.dll

![terminal](https://user-images.githubusercontent.com/10111/28444965-c7c3e8ca-6dfb-11e7-9b61-cebad84ab1cc.gif)
