### PR TITLE
fix drawing multi-byte strings in terminal

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -628,9 +628,15 @@ term_update_window(win_T *wp)
 		{
 #if defined(FEAT_MBYTE)
 		    if (enc_utf8 && c >= 0x80)
+		    {
 			ScreenLinesUC[off] = c;
+			ScreenLines[off] = ' ';
+		    }
 		    else
+		    {
 			ScreenLines[off] = c;
+			ScreenLinesUC[off] = NUL;
+		    }
 #else
 		    ScreenLines[off] = c;
 #endif
@@ -642,7 +648,7 @@ term_update_window(win_T *wp)
 		++off;
 		if (cell.width == 2)
 		{
-		    ScreenLines[off] = ' ';
+		    ScreenLines[off] = NUL;
 		    ScreenLinesUC[off] = NUL;
 		    ++pos.col;
 		    ++off;


### PR DESCRIPTION
tailing cell is not displayed. or broken

![before](http://go-gyazo.appspot.com/fc5b1d60e20ff7ca.png)

Below is correct.

![after](http://go-gyazo.appspot.com/8369680e5017dc94.png)