### PR TITLE
fix terminal crash

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -201,6 +201,9 @@ ex_terminal(exarg_T *eap)
     }
     else
     {
+	first_term = term->tl_next;
+	curbuf->b_term = NULL;
+
 	/* Wiping out the buffer will also close the window and call
 	 * free_terminal(). */
 	do_buffer(DOBUF_WIPE, DOBUF_CURRENT, FORWARD, 0, TRUE);


### PR DESCRIPTION
If `:terminal` without arguments, error should be occured. But chain of terminals is not unlinked.