### PR TITLE
launch &shell on terminal in default

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -163,6 +163,7 @@ ex_terminal(exarg_T *eap)
     exarg_T	split_ea;
     win_T	*old_curwin = curwin;
     term_T	*term;
+    char_u	*cmd = eap->arg;
 
     if (check_restricted() || check_secure())
 	return;
@@ -195,8 +196,11 @@ ex_terminal(exarg_T *eap)
 
     set_term_and_win_size(term);
 
+    if (cmd == NULL || *cmd == NUL)
+	cmd = p_sh;
+
     /* System dependent: setup the vterm and start the job in it. */
-    if (term_and_job_init(term, term->tl_rows, term->tl_cols, eap->arg) == OK)
+    if (term_and_job_init(term, term->tl_rows, term->tl_cols, cmd) == OK)
     {
 	/* store the size we ended up with */
 	vterm_get_size(term->tl_vterm, &term->tl_rows, &term->tl_cols);


### PR DESCRIPTION
`:terminal` should launch `&shell` in default.

However, I think https://github.com/vim/vim/pull/1858 should be merged since user mistake to set `shell`.