### PR TITLE
update cursor forcibly on GUI

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -324,6 +324,10 @@ write_to_term(buf_T *buffer, char_u *msg, channel_T *channel)
     update_screen(0);
     setcursor();
     out_flush();
+#ifdef FEAT_GUI
+    if (gui.in_use)
+	gui_update_cursor(FALSE, TRUE);
+#endif
 }
 
 /*


### PR DESCRIPTION
Update cursor forcibly since GUI doesn't redraw cursor immediately.