### PR TITLE
fix cterm colors

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -731,6 +731,12 @@ color2index(VTermColor *color)
     int blue = color->blue;
     int green = color->green;
 
+#if defined(WIN3264) && !defined(FEAT_GUI)
+    int	tmp = red;
+    red = blue;
+    blue = tmp;
+#endif
+
     if (red == 0)
     {
 	if (green == 0)


### PR DESCRIPTION
Some color index are wrong values.

![before](http://go-gyazo.appspot.com/8732c14e0340693b.png)

![after](http://go-gyazo.appspot.com/5f41bd19a042a16d.png)
