### PR TITLE
travis: Update to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ addons:
       - cscope
 
 before_install:
+  - rvm reset
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+dist: trusty
 
 os:
   - osx
@@ -70,8 +71,9 @@ addons:
       - libperl-dev
       - python-dev
       - python3-dev
-      - liblua5.1-0-dev
-      - lua5.1
+      - liblua5.2-dev
+      - lua5.2
+      - ruby-dev
       - cscope
 
 before_install:


### PR DESCRIPTION
* Set dist explicitly.
* Install ruby-dev.
* Update lua to newer version.
* Run `rvm reset` to use the default version of ruby. (Link fails without this.)