### PR TITLE
fix endless resizing

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -901,7 +901,16 @@ term_update_window(win_T *wp)
     {
 	int rows = term->tl_rows_fixed ? term->tl_rows : wp->w_height;
 	int cols = term->tl_cols_fixed ? term->tl_cols : wp->w_width;
+	win_T	*twp;
 
+	FOR_ALL_WINDOWS(twp)
+	{
+	    if (twp->w_buffer == term->tl_buffer)
+	    {
+		if (twp->w_width < cols) cols = twp->w_width;
+		if (twp->w_height < rows) rows = twp->w_height;
+	    }
+	}
 	vterm_set_size(vterm, rows, cols);
 	ch_logn(term->tl_job->jv_channel, "Resizing terminal to %d lines",
 									 rows);


### PR DESCRIPTION
When splice terminal window vertically to two, both windows goes resizing forever.

![termianl](https://user-images.githubusercontent.com/10111/28681374-43a21d9e-7334-11e7-9426-f1d30c400279.gif)

Window size should be minimum width and minimum height since it's same console.