### PR TITLE
Minor grammar fix for docs

### DIFF
--- a/runtime/doc/gui_x11.txt
+++ b/runtime/doc/gui_x11.txt
@@ -673,7 +673,7 @@ Of these three, Vim uses PRIMARY when reading and writing the "* register
 register.  Vim does not access the SECONDARY selection.
 
 Examples: (assuming the default option values)
-- Select an URL in Visual mode in Vim.  Go to your browser and click the
+- Select a URL in Visual mode in Vim.  Go to your browser and click the
   middle mouse button in the URL text field.  The selected text will be
   inserted (hopefully!).  Note: in Firefox you can set the
   middlemouse.contentLoadURL preference to true in about:config, then the

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -738,7 +738,7 @@ Nread as shown in |netrw-transparent| (ie. simply use >
   :r url
   :w url
 instead, as appropriate) -- see |netrw-urls|.  In the explanations
-below, a {netfile} is an url to a remote file.
+below, a {netfile} is a url to a remote file.
 
 						*:Nwrite*  *:Nw*
 :[range]Nw[rite]	Write the specified lines to the current
@@ -3796,7 +3796,7 @@ netrw:
 				  tell me how they're useful and should be
 				  retained?
 		Nov 20, 2015	* Added |netrw-ma| and |netrw-mA| support
-		Nov 20, 2015	* gx (|netrw-gx|) on an url downloaded the
+		Nov 20, 2015	* gx (|netrw-gx|) on a url downloaded the
 				  file in addition to simply bringing up the
 				  url in a browser.  Fixed.
 		Nov 23, 2015	* Added |g:netrw_sizestyle| support

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -5620,11 +5620,11 @@ Various improvements:
 -   Support %name% expansion for "gf" on Windows.
 -   Make "gf" work on "file://c:/path/name".  "file:/c:/" and "file:///c:/"
     should also work?
--   Add 'urlpath', used like 'path' for when "gf" used on an URL?
+-   Add 'urlpath', used like 'path' for when "gf" used on a URL?
 8   When using "gf" on an absolute file name, while editing a remote file
     (starts with scp:// or http://) should prepend the method and machine
     name.
--   When finding an URL or file name, and it doesn't exist, try removing a
+-   When finding a URL or file name, and it doesn't exist, try removing a
     trailing '.'.
 -   Add ":path" command modifier.  Should work for every command that takes a
     file name argument, to search for the file name in 'path'.	Use


### PR DESCRIPTION
Change "an URL" to "a URL".