### PR TITLE
Fix GUI cursor problem

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -350,7 +350,7 @@ update_cursor(term_T *term, int redraw)
 	    cursor_on();
 	out_flush();
 #ifdef FEAT_GUI
-	if (gui.in_use && term->tl_cursor_visible)
+	if (gui.in_use)
 	    gui_update_cursor(FALSE, FALSE);
 #endif
     }
@@ -691,7 +691,7 @@ handle_movecursor(
     if (is_current)
     {
 	may_toggle_cursor(term);
-	update_cursor(term, TRUE);
+	update_cursor(term, term->tl_cursor_visible);
     }
 
     return 1;
@@ -941,11 +941,11 @@ term_channel_closed(channel_T *ch)
 	/* Need to break out of vgetc(). */
 	ins_char_typebuf(K_IGNORE);
 
-	if (curbuf->b_term != NULL)
+	if ((term = curbuf->b_term) != NULL)
 	{
-	    if (curbuf->b_term->tl_job == ch->ch_job)
+	    if (term->tl_job == ch->ch_job)
 		maketitle();
-	    update_cursor(curbuf->b_term, TRUE);
+	    update_cursor(term, term->tl_cursor_visible);
 	}
     }
 }


### PR DESCRIPTION
When sending hide-cursor sequence (e.g. echo -e "\e[?25l") to terminal-window on gvim,
it causes the delaying of moving cursor.

Repro steps:

* I confirmed Vim 8.0.0802 (with gtk2) on Ubuntu 16.04

`SHELL=/bin/bash gvim --clean +terminal`

and execute the following on terminal-window

`echo -e "\e[?25l"`

then, putting `<CR>` key, cursor-move to the next line is delayed.

Solution:

Increase the frequency of calling `gui_update_cursor()` in `update_cursor()` while preventing cursor flicker:

* calling always: when called from `write_to_term()`
* calling when `tl_cursor_visible` is true: other callers (e.g. `handle_movecursor()`)

Ozaki Kiichi
