### PR TITLE
Update to trusty (2nd try)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ addons:
 
 before_install:
   - rvm reset
-  - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls==0.3.12; fi
+  - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang
   - if [ "$COVERAGE" = "yes" ]; then CC=gcc pip install --user pyopenssl ndg-httpsclient pyasn1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,8 @@ before_install:
   - echo $PATH
   - which gcov
   - gcov --version
+  - which llvm-cov
+  - llvm-cov --version
 
 # Start virtual framebuffer to be able to test the GUI. Does not work on OS X.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"
     # ASAN build
   - BUILD=yes TEST=test SANITIZER_CFLAGS="-g -O1 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize=address -fno-omit-frame-pointer"
-    FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan"
+    FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=./src/testdir/lsan-suppress.txt"
     "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"
 
 sudo: false
@@ -42,12 +42,12 @@ matrix:
             "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-python3interp --enable-rubyinterp --enable-luainterp'"
     - os: osx
       env: BUILD=yes TEST=test SANITIZER_CFLAGS="-g -O1 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize=address -fno-omit-frame-pointer"
-            FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan"
+            FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=./src/testdir/lsan-suppress.txt"
             "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"
     - os: linux
       compiler: gcc
       env: BUILD=yes TEST=test SANITIZER_CFLAGS="-g -O1 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize=address -fno-omit-frame-pointer"
-            FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan"
+            FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=./src/testdir/lsan-suppress.txt"
             "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"
     - os: linux
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ addons:
   apt:
     packages:
       - autoconf
+      - ggcov
       - lcov
       - libperl-dev
       - python-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"
     # ASAN build
   - BUILD=yes TEST=test SANITIZER_CFLAGS="-g -O1 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize=address -fno-omit-frame-pointer"
-    FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=./src/testdir/lsan-suppress.txt"
+    FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/src/testdir/lsan-suppress.txt"
     "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"
 
 sudo: false
@@ -42,12 +42,12 @@ matrix:
             "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-python3interp --enable-rubyinterp --enable-luainterp'"
     - os: osx
       env: BUILD=yes TEST=test SANITIZER_CFLAGS="-g -O1 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize=address -fno-omit-frame-pointer"
-            FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=./src/testdir/lsan-suppress.txt"
+            FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/src/testdir/lsan-suppress.txt"
             "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"
     - os: linux
       compiler: gcc
       env: BUILD=yes TEST=test SANITIZER_CFLAGS="-g -O1 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize=address -fno-omit-frame-pointer"
-            FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=./src/testdir/lsan-suppress.txt"
+            FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/src/testdir/lsan-suppress.txt"
             "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"
     - os: linux
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,8 @@ addons:
 
 before_install:
   - rvm reset
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv shell system; pyenv versions; pyenv local; pyenv shell; type -a python; type -a python3; fi
   - echo $PATH
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv shell system; pyenv versions; pyenv local; pyenv shell; type -a python3; fi
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
             FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/src/testdir/lsan-suppress.txt"
             "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"
     - os: linux
-      compiler: gcc
+      compiler: clang
       env: BUILD=yes TEST=test SANITIZER_CFLAGS="-g -O1 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize=address -fno-omit-frame-pointer"
             FEATURES=huge SRCDIR=./src CHECK_AUTOCONF=no ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/src/testdir/lsan-suppress.txt"
             "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ addons:
 
 before_install:
   - rvm reset
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv versions; python --version; python3 --version; pyenv rehash; python --version; python3 --version; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv versions; pyenv local; pyenv shell; python --version; python3 --version; pyenv rehash; python --version; python3 --version; fi
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ addons:
 
 before_install:
   - rvm reset
-  - pyenv global system
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv versions; python --version; python3 --version; pyenv rehash; python --version; python3 --version; fi
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ addons:
 
 before_install:
   - rvm reset
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PATH=$(echo $PATH | sed -e "s#$(echo $(which python3) | sed -e 's#/python3\$##'):##"); fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PATH=$(echo $PATH | sed -e "s#$(echo $(which python3) | sed -e 's#/python3$##'):##"); fi
   - echo $PATH
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ addons:
 
 before_install:
   - rvm reset
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv shell system; pyenv versions; pyenv local; pyenv shell; type -a python; type -a python3; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PATH=$(echo $PATH | sed -e "s#$(echo $(which python3) | sed -e 's#/python3\$##'):##"); fi
   - echo $PATH
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,6 @@ addons:
   apt:
     packages:
       - autoconf
-      - ggcov
       - lcov
       - libperl-dev
       - python-dev
@@ -86,6 +85,7 @@ before_install:
   - if [ "$COVERAGE" = "yes" ]; then CC=gcc pip install --user pyopenssl ndg-httpsclient pyasn1; fi
     # Lua is not installed on Travis OSX
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lua; export LUA_PREFIX=/usr/local; fi
+  - if [ "$CC" = "clang" ]; then ln -sf `which llvm-cov` /home/travis/bin/gcov; fi
   - echo $PATH
   - which gcov
   - gcov --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ addons:
       - lua5.2
       - ruby-dev
       - cscope
+      - libgtk2.0-dev
 
 before_install:
   - rvm reset

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ before_install:
   - if [ "$COVERAGE" = "yes" ]; then CC=gcc pip install --user pyopenssl ndg-httpsclient pyasn1; fi
     # Lua is not installed on Travis OSX
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lua; export LUA_PREFIX=/usr/local; fi
+    # Use llvm-cov instead of gcov when compiler is clang.
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CC" = "clang" ]; then ln -sf $(which llvm-cov) /home/travis/bin/gcov; fi
 
 # Start virtual framebuffer to be able to test the GUI. Does not work on OS X.
@@ -99,6 +100,7 @@ script:
   - if [ "$CHECK_AUTOCONF" = "yes" -a "$CC" = "gcc" ]; then make -C src autoconf; fi
   - if [ "x$SHADOWOPT" != x ]; then make -C src shadow; fi
   - (cd ${SRCDIR} && ./configure --with-features=$FEATURES $CONFOPT --enable-fail-if-missing && if [ "$BUILD" = "yes" ]; then make -j$NPROC; fi)
+    # Show Vim version and also if_xx versions.
   - if [ "$BUILD" = "yes" ]; then ${SRCDIR}/vim --version; ${SRCDIR}/vim --not-a-term -u NONE -S ${SRCDIR}/testdir/if_ver-1.vim -c quit > /dev/null; ${SRCDIR}/vim --not-a-term -u NONE -S ${SRCDIR}/testdir/if_ver-2.vim -c quit > /dev/null; cat if_ver.txt; fi
   - if [ -n "$ASAN_OPTIONS" ]; then export PATH=/usr/lib/llvm-$(clang -v 2>&1 | sed -n 's/.*version \([1-9]\.[0-9][0-9]*\).*/\1/p')/bin:$PATH; fi
   - make $SHADOWOPT $TEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ addons:
 
 before_install:
   - rvm reset
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv versions; pyenv local; pyenv shell; python --version; python3 --version; pyenv rehash; python --version; python3 --version; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv shell system; pyenv versions; pyenv local; pyenv shell; python --version; python3 --version; pyenv rehash; python --version; python3 --version; fi
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,11 +86,6 @@ before_install:
     # Lua is not installed on Travis OSX
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lua; export LUA_PREFIX=/usr/local; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CC" = "clang" ]; then ln -sf $(which llvm-cov) /home/travis/bin/gcov; fi
-  - echo $PATH
-  - which gcov
-  - gcov --version
-  - which llvm-cov
-  - llvm-cov --version
 
 # Start virtual framebuffer to be able to test the GUI. Does not work on OS X.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,9 @@ addons:
 
 before_install:
   - rvm reset
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PATH=$(echo $PATH | sed -e "s#$(echo $(which python3) | sed -e 's#/python3$##'):##"); fi
-  - echo $PATH
+    # Remove /opt/python/3.x.x/bin from $PATH for using system python3.
+    # ("pyenv global system" doesn't seem to work.)
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && which python3 | grep '/opt/python/' > /dev/null; then export PATH=$(echo $PATH | sed -e "s#$(echo $(which python3) | sed -e 's#/python3$##'):##"); fi
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,9 @@ before_install:
   - if [ "$COVERAGE" = "yes" ]; then CC=gcc pip install --user pyopenssl ndg-httpsclient pyasn1; fi
     # Lua is not installed on Travis OSX
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lua; export LUA_PREFIX=/usr/local; fi
+  - echo $PATH
+  - which gcov
+  - gcov --version
 
 # Start virtual framebuffer to be able to test the GUI. Does not work on OS X.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,8 @@ addons:
 
 before_install:
   - rvm reset
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv shell system; pyenv versions; pyenv local; pyenv shell; python --version; python3 --version; pyenv rehash; python --version; python3 --version; fi
+  - echo $PATH
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then pyenv global system; pyenv shell system; pyenv versions; pyenv local; pyenv shell; type -a python3; fi
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ addons:
 
 before_install:
   - rvm reset
+  - pyenv global system
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 # trusty still has a few problems, use precise until they are solved.
-dist: precise
+dist: trusty
 
 os:
   - osx
@@ -74,9 +74,11 @@ addons:
       - python3-dev
       - liblua5.2-dev
       - lua5.2
+      - ruby-dev
       - cscope
 
 before_install:
+  - rvm reset
   - if [ "$COVERAGE" = "yes" ]; then pip install --user cpp-coveralls==0.3.12; fi
     # needed for https support for coveralls
     # building cffi only works with gcc, not with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ script:
   - if [ "$CHECK_AUTOCONF" = "yes" -a "$CC" = "gcc" ]; then make -C src autoconf; fi
   - if [ "x$SHADOWOPT" != x ]; then make -C src shadow; fi
   - (cd ${SRCDIR} && ./configure --with-features=$FEATURES $CONFOPT --enable-fail-if-missing && if [ "$BUILD" = "yes" ]; then make -j$NPROC; fi)
-  - if [ "$BUILD" = "yes" ]; then ${SRCDIR}/vim --version; fi
+  - if [ "$BUILD" = "yes" ]; then ${SRCDIR}/vim --version; ${SRCDIR}/vim --not-a-term -u NONE -S ${SRCDIR}/testdir/if_ver-1.vim -c quit > /dev/null; ${SRCDIR}/vim --not-a-term -u NONE -S ${SRCDIR}/testdir/if_ver-2.vim -c quit > /dev/null; cat if_ver.txt; fi
   - if [ -n "$ASAN_OPTIONS" ]; then export PATH=/usr/lib/llvm-$(clang -v 2>&1 | sed -n 's/.*version \([1-9]\.[0-9][0-9]*\).*/\1/p')/bin:$PATH; fi
   - make $SHADOWOPT $TEST
   - if [ -n "$ASAN_OPTIONS" ]; then for log in $(find -type f -name 'asan.*' -size +0); do cat "$log"; err=1; done; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: c
-# trusty still has a few problems, use precise until they are solved.
 dist: trusty
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_install:
   - if [ "$COVERAGE" = "yes" ]; then CC=gcc pip install --user pyopenssl ndg-httpsclient pyasn1; fi
     # Lua is not installed on Travis OSX
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lua; export LUA_PREFIX=/usr/local; fi
-  - if [ "$CC" = "clang" ]; then ln -sf `which llvm-cov` /home/travis/bin/gcov; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CC" = "clang" ]; then ln -sf $(which llvm-cov) /home/travis/bin/gcov; fi
   - echo $PATH
   - which gcov
   - gcov --version

--- a/Filelist
+++ b/Filelist
@@ -134,6 +134,7 @@ SRC_ALL =	\
 		src/testdir/bench*.in \
 		src/testdir/bench*.vim \
 		src/testdir/samples/*.txt \
+		src/testdir/if_ver*.vim \
 		src/proto.h \
 		src/proto/arabic.pro \
 		src/proto/blowfish.pro \

--- a/src/testdir/if_ver-1.vim
+++ b/src/testdir/if_ver-1.vim
@@ -1,0 +1,22 @@
+" Print all interface versions and write the result into if_ver.txt.
+" For Ubuntu. Part 1.
+
+redir! > if_ver.txt
+echo "*** Interface versions ***"
+echo "\nLua:"
+lua print(_VERSION)
+" echo "\nLuaJIT:"
+" lua print(jit.version)
+if has('mzscheme')
+  echo "\nMzScheme:"
+  mzscheme (display (version))
+endif
+echo "\nPerl:"
+perl print $^V
+echo "\nRuby:"
+ruby print RUBY_VERSION
+echo "\nTcl:"
+tcl puts [info patchlevel]
+echo "\nPython 2:"
+python import sys; print sys.version
+redir END

--- a/src/testdir/if_ver-1.vim
+++ b/src/testdir/if_ver-1.vim
@@ -2,21 +2,25 @@
 " For Ubuntu. Part 1.
 
 redir! > if_ver.txt
-echo "*** Interface versions ***"
-echo "\nLua:"
-lua print(_VERSION)
-" echo "\nLuaJIT:"
-" lua print(jit.version)
-if has('mzscheme')
-  echo "\nMzScheme:"
-  mzscheme (display (version))
+if 1
+  echo "*** Interface versions ***"
+  echo "\nLua:"
+  lua print(_VERSION)
+  " echo "\nLuaJIT:"
+  " lua print(jit.version)
+  if has('mzscheme')
+    echo "\nMzScheme:"
+    mzscheme (display (version))
+  endif
+  echo "\nPerl:"
+  perl print $^V
+  echo "\nRuby:"
+  ruby print RUBY_VERSION
+  if has('tcl')
+    echo "\nTcl:"
+    tcl puts [info patchlevel]
+  endif
+  echo "\nPython 2:"
+  python import sys; print sys.version
 endif
-echo "\nPerl:"
-perl print $^V
-echo "\nRuby:"
-ruby print RUBY_VERSION
-echo "\nTcl:"
-tcl puts [info patchlevel]
-echo "\nPython 2:"
-python import sys; print sys.version
 redir END

--- a/src/testdir/if_ver-2.vim
+++ b/src/testdir/if_ver-2.vim
@@ -2,7 +2,9 @@
 " For Ubuntu. Part 2.
 
 redir! >> if_ver.txt
-echo "\nPython 3:"
-python3 import sys; print(sys.version)
-echo "\n"
+if 1
+  echo "\nPython 3:"
+  python3 import sys; print(sys.version)
+  echo "\n"
+endif
 redir END

--- a/src/testdir/if_ver-2.vim
+++ b/src/testdir/if_ver-2.vim
@@ -1,0 +1,8 @@
+" Print py3 interface version and write the result into if_ver.txt.
+" For Ubuntu. Part 2.
+
+redir! >> if_ver.txt
+echo "\nPython 3:"
+python3 import sys; print(sys.version)
+echo "\n"
+redir END

--- a/src/testdir/lsan-suppress.txt
+++ b/src/testdir/lsan-suppress.txt
@@ -1,0 +1,3 @@
+# Suppress leaks from X libraries on Ubuntu trusty.
+leak:libX11.so.6
+leak:libXt.so.6


### PR DESCRIPTION
It seems that #1884 failed because `libgtk2.0-dev` was missing.

If `libgtk2.0-dev` is installed, almost all jobs passes: https://travis-ci.org/k-takata/vim/builds/259091225
But still one job fails: https://travis-ci.org/k-takata/vim/jobs/259091233

```
==8520==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 520 byte(s) in 1 object(s) allocated from:

    #0 0x4e48eb in __interceptor_malloc /home/ben/development/llvm/3.5/final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:40:3

    #1 0x2b8c938b58a8 in XtMalloc (/usr/lib/x86_64-linux-gnu/libXt.so.6+0x138a8)
...
```

Any ideas?