### PR TITLE
return current line for term_getline/term_scrape when 2nd arg is omitted.

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7914,12 +7914,13 @@ term_getjob({buf})					*term_getjob()*
 		Get the Job associated with terminal window {buf}.
 		{buf} is used as with |term_getsize()|.
 
-term_getline({buf}, {row})				*term_getline()*
+term_getline({buf} [, {row}])				*term_getline()*
 		Get a line of text from the terminal window of {buf}.
 		{buf} is used as with |term_getsize()|.
 
 		The first line has {row} zero.  When {row} is invalid an empty
-		string is returned.
+		string is returned. When {row} is omitted, return line cursor
+		located.
 
 term_getsize({buf})					*term_getsize()*
 		Get the size of terminal {buf}. Returns a list with two
@@ -7930,17 +7931,18 @@ term_getsize({buf})					*term_getsize()*
 		buffer does not exist or is not a terminal window, an empty
 		list is returned.
 
-term_list(})						*term_list()*
+term_list()						*term_list()*
 		Return a list with the buffer numbers of all buffers for
 		terminal windows.
 
-term_scrape({buf}, {row})				*term_scrape()*
+term_scrape({buf} [, {row}])				*term_scrape()*
 		Get the contents of {row} of terminal screen of {buf}.
 		For {buf} see |term_getsize()|.
 
 		The first {row} is zero.  When {row} is invalid an empty list
-		is returned.
-		
+		is returned. When {row} is omitted, return line cursor
+		located.
+
 		Return a List containing a Dict for each screen cell: 
 		    "chars"	character(s) at the cell
 		    "fg"	foreground color as #rrggbb

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -833,10 +833,10 @@ static struct fst
 #ifdef FEAT_TERMINAL
     {"term_getattr",	2, 2, f_term_getattr},
     {"term_getjob",	1, 1, f_term_getjob},
-    {"term_getline",	2, 2, f_term_getline},
+    {"term_getline",	1, 2, f_term_getline},
     {"term_getsize",	1, 1, f_term_getsize},
     {"term_list",	0, 0, f_term_list},
-    {"term_scrape",	2, 2, f_term_scrape},
+    {"term_scrape",	1, 2, f_term_scrape},
     {"term_sendkeys",	2, 2, f_term_sendkeys},
     {"term_start",	1, 2, f_term_start},
     {"term_wait",	1, 1, f_term_wait},

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1719,7 +1719,22 @@ f_term_getline(typval_T *argvars, typval_T *rettv)
     if (buf == NULL)
 	return;
     term = buf->b_term;
-    row = (int)get_tv_number(&argvars[1]);
+    if (argvars[1].v_type == VAR_UNKNOWN)
+    {
+	win_T	*wp;
+
+	row = 0;
+	FOR_ALL_WINDOWS(wp)
+	{
+	    if (wp->w_buffer == term->tl_buffer)
+	    {
+		row = wp->w_wrow;
+		break;
+	    }
+	}
+    }
+    else
+	row = (int)get_tv_number(&argvars[1]);
 
     if (term->tl_vterm == NULL)
     {
@@ -1810,7 +1825,22 @@ f_term_scrape(typval_T *argvars, typval_T *rettv)
 	screen = vterm_obtain_screen(term->tl_vterm);
 
     l = rettv->vval.v_list;
-    pos.row = (int)get_tv_number(&argvars[1]);
+    if (argvars[1].v_type == VAR_UNKNOWN)
+    {
+	win_T	*wp;
+
+	pos.row = 0;
+	FOR_ALL_WINDOWS(wp)
+	{
+	    if (wp->w_buffer == term->tl_buffer)
+	    {
+		pos.row = wp->w_wrow;
+		break;
+	    }
+	}
+    }
+    else
+	pos.row = (int)get_tv_number(&argvars[1]);
     for (pos.col = 0; pos.col < term->tl_cols; )
     {
 	dict_T		*dcell;


### PR DESCRIPTION
This makes easy to test?