### PR TITLE
Revise the description of Insert Visual mode

### DIFF
--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -593,9 +593,9 @@ Insert Normal mode	Entered when CTRL-O given in Insert mode.  This is
 			shown at the bottom of the window.
 
 Insert Visual mode	Entered when starting a Visual selection from Insert
-			mode, e.g., by using CTRL-O and then "v", "V" or
-			CTRL-V.  When the Visual selection ends, Vim returns
-			to Insert mode.
+			Normal mode, e.g., by using CTRL-O in Insert mode and
+			then "v", "V" or CTRL-V.  When the Visual selection
+			ends, Vim returns to Insert mode.
 			If the 'showmode' option is on "-- (insert) VISUAL --"
 			is shown at the bottom of the window.
 


### PR DESCRIPTION
If we accept that CTRL-O and "v" is going from Insert mode to Visual mode, then by the same reasoning doing `<Esc>` and "v" goes from Insert mode to Visual mode too.

Therefore, going from Insert mode to Visual mode is not what defines Insert Visual mode. Rather, it is going from Insert Normal mode to Visual mode.