### PR TITLE
Add `jv_ctty` (controlling terminal) field to job_T

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5192,6 +5192,8 @@ job_info({job})						*job_info()*
 		Returns a Dictionary with information about {job}:
 		   "status"	what |job_status()| returns
 		   "channel"	what |job_getchannel()| returns
+		   "process"	process ID
+		   "tty"	controlling terminal (if exists)
 		   "exitval"	only valid when "status" is "dead"
 		   "exit_cb"	function to be called on exit
 		   "stoponexit"	|job-stoponexit|

--- a/src/channel.c
+++ b/src/channel.c
@@ -1016,11 +1016,9 @@ ch_close_part(channel_T *channel, ch_part_T part)
 	{
 	    /* When using a pty the same FD is set on multiple parts, only
 	     * close it when the last reference is closed. */
-	    if ((part == PART_IN || channel->ch_part[PART_IN].ch_fd != *fd)
-		    && (part == PART_OUT
-				    || channel->ch_part[PART_OUT].ch_fd != *fd)
-		    && (part == PART_ERR
-				   || channel->ch_part[PART_ERR].ch_fd != *fd))
+	    if ((part == PART_IN || channel->CH_IN_FD != *fd)
+		    && (part == PART_OUT || channel->CH_OUT_FD != *fd)
+		    && (part == PART_ERR || channel->CH_ERR_FD != *fd))
 		fd_close(*fd);
 	}
 	*fd = INVALID_FD;

--- a/src/channel.c
+++ b/src/channel.c
@@ -4592,6 +4592,7 @@ job_free_contents(job_T *job)
     }
     mch_clear_job(job);
 
+    vim_free(job->jv_ctty);
     vim_free(job->jv_stoponexit);
     free_callback(job->jv_exit_cb, job->jv_exit_partial);
 }
@@ -5164,6 +5165,8 @@ job_info(job_T *job, dict_T *dict)
     nr = job->jv_proc_info.dwProcessId;
 #endif
     dict_add_nr_str(dict, "process", nr, NULL);
+    dict_add_nr_str(dict, "tty", 0L,
+			job->jv_ctty != NULL ? job->jv_ctty : (char_u *)"");
 
     dict_add_nr_str(dict, "exitval", job->jv_exitval, NULL);
     dict_add_nr_str(dict, "exit_cb", 0L, job->jv_exit_cb);

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -5192,9 +5192,9 @@ error:
 mch_job_start(char **argv, job_T *job, jobopt_T *options)
 {
     pid_t	pid;
-    int		fd_in[2];	/* for stdin */
-    int		fd_out[2];	/* for stdout */
-    int		fd_err[2];	/* for stderr */
+    int		fd_in[2] = {-1, -1};	/* for stdin */
+    int		fd_out[2] = {-1, -1};	/* for stdout */
+    int		fd_err[2] = {-1, -1};	/* for stderr */
     int		pty_master_fd = -1;
     int		pty_slave_fd = -1;
     channel_T	*channel = NULL;
@@ -5212,12 +5212,6 @@ mch_job_start(char **argv, job_T *job, jobopt_T *options)
 
     /* default is to fail */
     job->jv_status = JOB_FAILED;
-    fd_in[0] = -1;
-    fd_in[1] = -1;
-    fd_out[0] = -1;
-    fd_out[1] = -1;
-    fd_err[0] = -1;
-    fd_err[1] = -1;
 
     if (options->jo_pty)
 	open_pty(&pty_master_fd, &pty_slave_fd, &job->jv_ctty);

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4170,7 +4170,7 @@ set_default_child_environment(void)
  * When successful both file descriptors are stored.
  */
     static void
-open_pty(int *pty_master_fd, int *pty_slave_fd)
+open_pty(int *pty_master_fd, int *pty_slave_fd, char_u **ttyn)
 {
     char	*tty_name;
 
@@ -4190,6 +4190,9 @@ open_pty(int *pty_master_fd, int *pty_slave_fd)
 	    close(*pty_master_fd);
 	    *pty_master_fd = -1;
 	}
+
+	if (ttyn != NULL)
+	    *ttyn = vim_strsave((char_u *)tty_name);
     }
 }
 #endif
@@ -4384,7 +4387,7 @@ mch_call_shell(
 	 * If the slave can't be opened, close the master pty.
 	 */
 	if (p_guipty && !(options & (SHELL_READ|SHELL_WRITE)))
-	    open_pty(&pty_master_fd, &pty_slave_fd);
+	    open_pty(&pty_master_fd, &pty_slave_fd, NULL);
 	/*
 	 * If not opening a pty or it didn't work, try using pipes.
 	 */
@@ -5217,7 +5220,7 @@ mch_job_start(char **argv, job_T *job, jobopt_T *options)
     fd_err[1] = -1;
 
     if (options->jo_pty)
-	open_pty(&pty_master_fd, &pty_slave_fd);
+	open_pty(&pty_master_fd, &pty_slave_fd, &job->jv_ctty);
 
     /* TODO: without the channel feature connect the child to /dev/null? */
     /* Open pipes for stdin, stdout, stderr. */

--- a/src/structs.h
+++ b/src/structs.h
@@ -1478,6 +1478,7 @@ struct jobvar_S
     PROCESS_INFORMATION	jv_proc_info;
     HANDLE		jv_job_object;
 #endif
+    char_u	*jv_ctty;	/* controlling tty, allocated */
     jobstatus_T	jv_status;
     char_u	*jv_stoponexit; /* allocated */
     int		jv_exitval;
@@ -1537,18 +1538,20 @@ typedef enum {
     JIO_OUT
 } job_io_T;
 
+#define CH_PART_FD(part)	ch_part[part].ch_fd
+
 /* Ordering matters, it is used in for loops: IN is last, only SOCK/OUT/ERR
  * are polled. */
 typedef enum {
     PART_SOCK = 0,
-#define CH_SOCK_FD	ch_part[PART_SOCK].ch_fd
+#define CH_SOCK_FD	CH_PART_FD(PART_SOCK)
 #ifdef FEAT_JOB_CHANNEL
     PART_OUT,
-# define CH_OUT_FD	ch_part[PART_OUT].ch_fd
+# define CH_OUT_FD	CH_PART_FD(PART_OUT)
     PART_ERR,
-# define CH_ERR_FD	ch_part[PART_ERR].ch_fd
+# define CH_ERR_FD	CH_PART_FD(PART_ERR)
     PART_IN,
-# define CH_IN_FD	ch_part[PART_IN].ch_fd
+# define CH_IN_FD	CH_PART_FD(PART_IN)
 #endif
     PART_COUNT
 } ch_part_T;

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -30,6 +30,11 @@ endfunc
 
 func Test_terminal_basic()
   let buf = Run_shell_in_terminal()
+  if has("unix")
+    call assert_match("^/dev/", job_info(g:job).tty)
+  else
+    call assert_equal("", job_info(g:job).tty)
+  endif
   call Stop_shell_in_terminal(buf)
   call term_wait(buf)
 


### PR DESCRIPTION
I think, when using terminal window, it is convenient if be able to get information about controlling tty.

Ozaki Kiichi