### PR TITLE
Add `term_getruncmd` function

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2657,6 +2657,8 @@ term_getattr({attr}, {what})	Number	get the value of attribute {what}
 term_getcursor({buf})		List	get the cursor position of a terminal
 term_getjob({buf})		Job	get the job associated with a terminal
 term_getline({buf}, {row})	String	get a line of text from a terminal
+term_getruncmd({buf})		Dict	get information of the process running
+					on a terminal
 term_getscrolled({buf})		Number	get the scroll count of a terminal
 term_getsize({buf})		List	get the size of a terminal
 term_getstatus({buf})		String	get the status of a terminal
@@ -9396,6 +9398,12 @@ term_getline({buf}, {row})				*term_getline()*
 
 		To get attributes of each character use |term_scrape()|.
 		{only available when compiled with the |+terminal| feature}
+
+term_getruncmd({buf})					*term_getruncmd()*
+		Get information of the process running on the shell of
+		terminal {buf}.  This returns a Dictionary:
+		   "process"	process ID
+		   "command"	command name (i.e. argv[0])
 
 term_getscrolled({buf})					*term_getscrolled()*
 		Return the number of lines that scrolled to above the top of

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -948,6 +948,7 @@ static struct fst
     {"term_getcursor",	1, 1, f_term_getcursor},
     {"term_getjob",	1, 1, f_term_getjob},
     {"term_getline",	2, 2, f_term_getline},
+    {"term_getruncmd",	1, 1, f_term_getruncmd},
     {"term_getscrolled", 1, 1, f_term_getscrolled},
     {"term_getsize",	1, 1, f_term_getsize},
     {"term_getstatus",	1, 1, f_term_getstatus},

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4026,7 +4026,7 @@ mch_report_winsize(int fd, int rows, int cols)
     return retval == 0 ? OK : FAIL;
 }
 
-# if defined(__APPLE__)
+# if defined(MACOS_X_DARWIN)
 #  include <libproc.h>
 # elif defined(SUN_SYSTEM)
 #  define _STRUCTURED_PROC 1
@@ -4043,10 +4043,10 @@ int mch_get_runcmd(job_T *job, dict_T *dict)
     int		retval = FAIL;
 
 # if defined(SUN_SYSTEM)
-    if (job->jv_tty_name == NULL)
+    if (job->jv_tty_out == NULL)
 	return FAIL;
 
-    fd = open(job->jv_tty_name, O_RDONLY);
+    fd = open(job->jv_tty_out, O_RDONLY);
     if (fd == INVALID_FD)
 	return FAIL;
 
@@ -4088,7 +4088,7 @@ int mch_get_runcmd(job_T *job, dict_T *dict)
 	    fclose(fp);
 	}
     }
-# elif defined(__APPLE__)
+# elif defined(MACOS_X_DARWIN)
     {
 	struct proc_bsdinfo bi;
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4036,24 +4036,23 @@ mch_report_winsize(int fd, int rows, int cols)
 /**
  * Try to get process information run on terminal.
  */
-void mch_get_runcmd(job_T *job, dict_T *dict)
+int mch_get_runcmd(job_T *job, dict_T *dict)
 {
     channel_T	*ch = job->jv_channel;
     int		fd;
     pid_t	pid;
+    int		retval = FAIL;
 
     if (ch == NULL)
-	return;
+	return FAIL;
 
     fd = (int)ch->CH_IN_FD;
     if (fd == INVALID_FD)
-	return;
+	return FAIL;
 
     pid = tcgetpgrp(fd);
     if (pid <= 0)
-	return;
-
-    dict_add_nr_str(dict, "process", pid, NULL);
+	return FAIL;
 
 # if defined(__linux__)
     {
@@ -4107,6 +4106,7 @@ void mch_get_runcmd(job_T *job, dict_T *dict)
 	}
     }
 # endif
+    return retval;
 }
 #endif
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4033,7 +4033,7 @@ mch_report_winsize(int fd, int rows, int cols)
 #  include <sys/procfs.h>
 # endif
 
-/**
+/*
  * Try to get process information run on terminal.
  */
 int mch_get_runcmd(job_T *job, dict_T *dict)
@@ -4105,6 +4105,10 @@ int mch_get_runcmd(job_T *job, dict_T *dict)
 	    fclose(fp);
 	}
     }
+# else
+    /*
+     * Not yet implemented for other platforms.
+     */
 # endif
     return retval;
 }

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4026,7 +4026,7 @@ mch_report_winsize(int fd, int rows, int cols)
     return retval == 0 ? OK : FAIL;
 }
 
-# if defined(MACOS_X_DARWIN)
+# if defined(MACOS_X_DARWIN) && defined(MAC_OS_X_VERSION_10_5)
 #  include <libproc.h>
 # elif defined(SUN_SYSTEM)
 #  define _STRUCTURED_PROC 1
@@ -4088,7 +4088,7 @@ int mch_get_runcmd(job_T *job, dict_T *dict)
 	    fclose(fp);
 	}
     }
-# elif defined(MACOS_X_DARWIN)
+# elif defined(MACOS_X_DARWIN) && defined(MAC_OS_X_VERSION_10_5)
     {
 	struct proc_bsdinfo bi;
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4026,7 +4026,7 @@ mch_report_winsize(int fd, int rows, int cols)
     return retval == 0 ? OK : FAIL;
 }
 
-# if defined(__APPLE__) || defined(BSD)
+# if defined(__APPLE__)
 #  include <sys/types.h>
 #  include <sys/sysctl.h>
 # elif defined(SUN_SYSTEM)
@@ -4073,7 +4073,7 @@ int mch_get_runcmd(job_T *job, dict_T *dict)
 	    fclose(fp);
 	}
     }
-# elif defined(__APPLE__) || defined(BSD)
+# elif defined(__APPLE__)
     {
 	int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid };
 	struct kinfo_proc kp;

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4041,11 +4041,14 @@ int mch_get_runcmd(job_T *job, dict_T *dict)
     pid_t	pid = -1;
     int		fd;
     int		retval = FAIL;
+# if !defined(SUN_SYSTEM)
+    channel_T	*ch = job->jv_channel;
+# endif
 
-# if defined(SUN_SYSTEM)
     if (job->jv_tty_out == NULL)
 	return FAIL;
 
+# if defined(SUN_SYSTEM)
     fd = open(job->jv_tty_out, O_RDONLY);
     if (fd == INVALID_FD)
 	return FAIL;
@@ -4055,17 +4058,16 @@ int mch_get_runcmd(job_T *job, dict_T *dict)
 
     close(fd);
 # else
-    channel_T	*ch = job->jv_channel;
-
     if (ch == NULL)
 	return FAIL;
 
-    fd = (int)ch->CH_IN_FD;
+    fd = (int)ch->CH_OUT_FD;
     if (fd == INVALID_FD)
 	return FAIL;
 
     pid = tcgetpgrp(fd);
 # endif
+
     if (pid <= 0)
 	return FAIL;
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4027,8 +4027,7 @@ mch_report_winsize(int fd, int rows, int cols)
 }
 
 # if defined(__APPLE__)
-#  include <sys/types.h>
-#  include <sys/sysctl.h>
+#  include <libproc.h>
 # elif defined(SUN_SYSTEM)
 #  define _STRUCTURED_PROC 1
 #  include <sys/procfs.h>
@@ -4091,9 +4090,7 @@ int mch_get_runcmd(job_T *job, dict_T *dict)
     }
 # elif defined(__APPLE__)
     {
-	int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid };
-	struct kinfo_proc kp;
-	size_t size = sizeof(kp);
+	struct proc_bsdinfo bi;
 
 	if (proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &bi, sizeof(bi)) > 0)
 	{

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7394,7 +7394,7 @@ int mch_get_runcmd(job_T *job, dict_T *dict)
 	if (pe.th32ParentProcessID == job->jv_proc_info.dwProcessId)
 	{
 	    pid = pe.th32ProcessID;
-	    STRCPY(fname, pe.szExeFile);
+	    vim_strncpy(fname, pe.szExeFile, MAX_PATH - 1);
 	}
     } while (Process32Next(h, &pe));
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7374,7 +7374,7 @@ resize_console_buf(void)
 /**
  * Try to get process information run on terminal.
  */
-void mch_get_runcmd(job_T *job, dict_T *dict)
+int mch_get_runcmd(job_T *job, dict_T *dict)
 {
     PROCESSENTRY32	pe;
     HANDLE		h;
@@ -7384,7 +7384,7 @@ void mch_get_runcmd(job_T *job, dict_T *dict)
     h = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     pe.dwSize = sizeof(PROCESSENTRY32);
     if (!Process32First(h, &pe))
-	return;
+	return FAIL;
 
     fname[0] = NUL;
 

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -55,7 +55,7 @@ void check_mouse_termcode(void);
 int mch_screenmode(char_u *arg);
 int mch_get_shellsize(void);
 int mch_report_winsize(int fd, int rows, int cols);
-void mch_get_runcmd(job_T *job, dict_T *dict);
+int mch_get_runcmd(job_T *job, dict_T *dict);
 void mch_set_shellsize(void);
 void mch_new_shellsize(void);
 void may_send_sigint(int c, pid_t pid, pid_t wpid);

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -55,6 +55,7 @@ void check_mouse_termcode(void);
 int mch_screenmode(char_u *arg);
 int mch_get_shellsize(void);
 int mch_report_winsize(int fd, int rows, int cols);
+void mch_get_runcmd(job_T *job, dict_T *dict);
 void mch_set_shellsize(void);
 void mch_new_shellsize(void);
 void may_send_sigint(int c, pid_t pid, pid_t wpid);

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -76,4 +76,5 @@ int has_vtp_working(void);
 int has_conpty_working(void);
 int is_conpty_stable(void);
 void resize_console_buf(void);
+void mch_get_runcmd(job_T *job, dict_T *dict);
 /* vim: set ft=c : */

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -76,5 +76,5 @@ int has_vtp_working(void);
 int has_conpty_working(void);
 int is_conpty_stable(void);
 void resize_console_buf(void);
-void mch_get_runcmd(job_T *job, dict_T *dict);
+int mch_get_runcmd(job_T *job, dict_T *dict);
 /* vim: set ft=c : */

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -39,6 +39,7 @@ void f_term_getattr(typval_T *argvars, typval_T *rettv);
 void f_term_getcursor(typval_T *argvars, typval_T *rettv);
 void f_term_getjob(typval_T *argvars, typval_T *rettv);
 void f_term_getline(typval_T *argvars, typval_T *rettv);
+void f_term_getruncmd(typval_T *argvars, typval_T *rettv);
 void f_term_getscrolled(typval_T *argvars, typval_T *rettv);
 void f_term_getsize(typval_T *argvars, typval_T *rettv);
 void f_term_setsize(typval_T *argvars, typval_T *rettv);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -40,6 +40,14 @@
 
 #include "vim.h"
 
+#if defined(__APPLE__)
+# include <sys/types.h>
+# include <sys/sysctl.h>
+#endif
+#if defined(_WIN32)
+# include <tlhelp32.h>
+#endif
+
 #if defined(FEAT_TERMINAL) || defined(PROTO)
 
 #ifndef MIN
@@ -5067,6 +5075,104 @@ f_term_getline(typval_T *argvars, typval_T *rettv)
 	rect.end_row = row + 1;
 	p[vterm_screen_get_text(screen, (char *)p, len, rect)] = NUL;
     }
+}
+
+/*
+ * "term_getruncmd(buf)" function
+ */
+    void
+f_term_getruncmd(typval_T *argvars, typval_T *rettv)
+{
+    buf_T	*buf = term_get_buf(argvars);
+    channel_T	*ch;
+#ifdef _WIN32
+    PROCESSENTRY32 pe;
+    HANDLE	h;
+#else
+    pid_t	pid;
+#endif
+
+    rettv->v_type = VAR_STRING;
+    rettv->vval.v_string = NULL;
+    if (buf == NULL)
+	return;
+
+    if (buf->b_term->tl_job == NULL)
+	return;
+
+    ch = buf->b_term->tl_job->jv_channel;
+    if (ch == NULL || ch->CH_IN_FD == -1)
+	return;
+
+#ifdef _WIN32
+    h = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    pe.dwSize = sizeof(PROCESSENTRY32);
+    if (Process32First(h, &pe))
+    {
+	char_u	fname[MAX_PATH];
+	fname[0] = NUL;
+	/* Get last process in process list. */
+	do
+	{
+	    if (pe.th32ParentProcessID !=
+		    buf->b_term->tl_job->jv_proc_info.dwProcessId)
+	      continue;
+	    STRCPY(fname, pe.szExeFile);
+	} while (Process32Next(h, &pe));
+
+	if (STRLEN(fname))
+	{
+	    rettv->vval.v_string = vim_strsave(fname);
+	    return;
+	}
+    }
+#else
+    pid = tcgetpgrp(ch->CH_IN_FD);
+    if (pid <= 0)
+	return;
+
+# if defined(__linux__)
+    {
+	struct stat st;
+	char fname[MAXPATHL];
+	char *cmdline = NULL;
+	FILE *fp;
+	size_t bytes_read;
+	size_t i;
+
+	vim_snprintf(fname, MAXPATHL, "/proc/%ld/cmdline", pid);
+	fp = mch_fopen(fname, "r");
+	if (fp == NULL)
+	    return;
+
+	cmdline = alloc(IOSIZE);
+	if (cmdline != NULL)
+	{
+	    bytes_read = fread(cmdline, 1, IOSIZE, fp);
+
+	    for (i = 0; i < bytes_read; ++i)
+		if (cmdline[i] == NUL)
+		    cmdline[i] = ' ';
+	    cmdline[bytes_read - 1] = NUL;
+
+	    rettv->vval.v_string = cmdline;
+	}
+
+	fclose(fp);
+    }
+# elif defined(__APPLE__)
+    {
+	int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid };
+	struct kinfo_proc kp;
+	size_t size = sizeof(kp);
+
+	if (sysctl(mib, 4, &kp, &size, NULL, 0) == -1)
+	    return;
+
+	rettv->vval.v_string = vim_strsave((char_u *)kp.kp_proc.p_comm);
+    }
+# endif
+#endif
 }
 
 /*

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -5077,6 +5077,7 @@ f_term_getruncmd(typval_T *argvars, typval_T *rettv)
 {
     buf_T	*buf = term_get_buf(argvars, "term_getruncmd()");
     term_T	*term;
+    dict_T	*dict;
 
     if (rettv_dict_alloc(rettv) == FAIL)
 	return;
@@ -5084,8 +5085,7 @@ f_term_getruncmd(typval_T *argvars, typval_T *rettv)
 	return;
 
     term = buf->b_term;
-    if (!term_job_running(term))
-	return;
+    dict = rettv->vval.v_dict;
 
     if (!term_job_running(term) || mch_get_runcmd(term->tl_job, dict) == FAIL)
     {

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1891,7 +1891,7 @@ func Test_terminal_statusline()
 endfunc
 
 func Test_terminal_get_runcmd()
-  let buf = Run_shell_in_terminal()
+  let buf = Run_shell_in_terminal({})
 
   if has('win32')
     let cmd = $windir . '\system32\timeout.exe'
@@ -1900,7 +1900,7 @@ func Test_terminal_get_runcmd()
   endif
 
   call term_sendkeys(buf, cmd . " 1\r")
-  sleep 100m
+  call term_wait(buf)
 
   let info = term_getruncmd(buf)
   call assert_true(has_key(info, 'process'))
@@ -1910,7 +1910,6 @@ func Test_terminal_get_runcmd()
 
   call Stop_shell_in_terminal(buf)
   call term_wait(buf)
-  close
-
   unlet g:job
+  bwipe!
 endfunc

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1900,7 +1900,7 @@ func Test_terminal_get_runcmd()
   endif
 
   call term_sendkeys(buf, cmd . " 1\r")
-  call term_wait(buf)
+  call term_wait(buf, 100)
 
   let info = term_getruncmd(buf)
   call assert_true(has_key(info, 'process'))

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1894,12 +1894,14 @@ func Test_terminal_get_runcmd()
   let buf = Run_shell_in_terminal({})
 
   if has('win32')
-    let cmd = $windir . '\system32\timeout.exe'
+    let cmd = 'timeout.exe'
+    let cmdline = $windir . '\system32\' . cmd
   else
     let cmd = 'sleep'
+    let cmdline = cmd
   endif
 
-  call term_sendkeys(buf, cmd . " 1\r")
+  call term_sendkeys(buf, cmdline . " 1\r")
   call term_wait(buf, 100)
 
   let info = term_getruncmd(buf)

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1889,3 +1889,28 @@ func Test_terminal_statusline()
   au! BufLeave
   set statusline=
 endfunc
+
+func Test_terminal_get_runcmd()
+  let buf = Run_shell_in_terminal()
+
+  if has('win32')
+    let cmd = $windir . '\system32\timeout.exe'
+  else
+    let cmd = 'sleep'
+  endif
+
+  call term_sendkeys(buf, cmd . " 1\r")
+  sleep 100m
+
+  let info = term_getruncmd(buf)
+  call assert_true(has_key(info, 'process'))
+  call assert_true(has_key(info, 'command'))
+  call assert_notequal(-1, info.process)
+  call assert_equal(cmd, info.command)
+
+  call Stop_shell_in_terminal(buf)
+  call term_wait(buf)
+  close
+
+  unlet g:job
+endfunc

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1905,13 +1905,9 @@ func Test_terminal_get_runcmd()
   call term_wait(buf, 100)
 
   let info = term_getruncmd(buf)
-  call assert_true(has_key(info, 'process'))
-  call assert_true(has_key(info, 'command'))
   call assert_notequal(-1, info.process)
   call assert_equal(cmd, info.command)
 
-  call Stop_shell_in_terminal(buf)
-  call term_wait(buf)
+  exe buf . 'bwipe!'
   unlet g:job
-  bwipe!
 endfunc


### PR DESCRIPTION
`term_getruncmd()` is to get information of the process running on the shell of terminal window.
Windows support was done by @mattn.

Example:
Do `:terminal` to run `&shell` and execute `sleep 10` on the shell,
then `term_getruncmd(<buf>)` returns `{'process': <pid of sleep>, 'command': 'sleep'}`.

confirmed on:

* [x] Windows
* [x] macOS
* [x] Linux
* [x] Solaris
* [ ] *BSD

Ozaki Kiichi