### PR TITLE
fix crash when closing terminal with exit_cb

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -955,7 +955,7 @@ terminal_loop(void)
 	update_cursor(curbuf->b_term, FALSE);
 
 	c = term_vgetc();
-	if (curbuf->b_term->tl_vterm == NULL
+	if (curbuf->b_term == NULL || curbuf->b_term->tl_vterm == NULL
 					  || !term_job_running(curbuf->b_term))
 	    /* job finished while waiting for a character */
 	    break;
@@ -968,7 +968,7 @@ terminal_loop(void)
 	    /* We don't know if the job can handle CTRL-C itself or not, this
 	     * may kill the shell instead of killing the command running in the
 	     * shell. */
-	    mch_stop_job(curbuf->b_term->tl_job, (char_u *)"quit")
+	    mch_stop_job(curbuf->b_term->tl_job, (char_u *)"quit");
 #endif
 
 	if (c == (termkey == 0 ? Ctrl_W : termkey))


### PR DESCRIPTION
When closing terminal with exit_cb options of job, vim crash. Below is a script to reproduce.
```vim
function! s:exit_cb(job, st)
  exe s:buf 'bwipe!'
endfunction

function! s:test()
  let s:buf = term_start('ls')
  let job = term_getjob(s:buf)
  call job_setoptions(job, {'exit_cb': function('s:exit_cb')})
endfunction

call s:test()
```