### PR TITLE
fix message encoding in cmd.exe

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -2632,8 +2632,25 @@ msg_puts_printf(char_u *str, int maxlen)
     char_u	*p;
 
 #ifdef WIN3264
+# if defined(FEAT_MBYTE) && !defined(FEAT_GUI_MSWIN)
+    char_u	*ccp = NULL;
+# endif
     if (!(silent_mode && p_verbose == 0))
 	mch_settmode(TMODE_COOK);	/* handle '\r' and '\n' correctly */
+# if defined(FEAT_MBYTE) && !defined(FEAT_GUI_MSWIN)
+    if (enc_codepage >= 0 && (int)GetConsoleCP() != enc_codepage)
+    {
+	int	len;
+	WCHAR	*widestr = (WCHAR *)enc_to_utf16(str, &len);
+	if (widestr != NULL)
+	{
+	    WideCharToMultiByte_alloc(GetConsoleCP(), 0, widestr, len,
+						(LPSTR *)&ccp, &len, 0, 0);
+	    vim_free(widestr);
+	    s = str = ccp;
+	}
+    }
+# endif
 #endif
     while ((maxlen < 0 || (int)(s - str) < maxlen) && *s != NUL)
     {
@@ -2677,6 +2694,9 @@ msg_puts_printf(char_u *str, int maxlen)
     msg_didout = TRUE;	    /* assume that line is not empty */
 
 #ifdef WIN3264
+# if defined(FEAT_MBYTE) && !defined(FEAT_GUI_MSWIN)
+    vim_free(ccp);
+# endif
     if (!(silent_mode && p_verbose == 0))
 	mch_settmode(TMODE_RAW);
 #endif


### PR DESCRIPTION
When run command (not found), error message is shown with broken encoding.

before patch
![279665776a9db38e](https://user-images.githubusercontent.com/10111/28917020-202ee662-787f-11e7-9bab-a5e339a189f1.png)

after patch
![c26683475ea334e9](https://user-images.githubusercontent.com/10111/28917017-1e96f394-787f-11e7-9c11-6bbbe6552e72.png)
