### PR TITLE
fix crash when xxx not exists on :terminal xxx

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -629,7 +629,7 @@ term_job_running(term_T *term)
 {
     /* Also consider the job finished when the channel is closed, to avoid a
      * race condition when updating the title. */
-    return term->tl_job != NULL
+    return term != NULL && term->tl_job != NULL
 	&& term->tl_job->jv_status == JOB_STARTED
 	&& channel_is_open(term->tl_job->jv_channel);
 }


### PR DESCRIPTION
When  run `:terminal command-not-found`, vim crash.
