### PR TITLE
Add term name option for term_start

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8008,7 +8008,9 @@ term_start({cmd}, {options})				*term_start()*
 		Returns the buffer number of the terminal window.
 		When opening the window fails zero is returned.
 
-		{options} are not implemented yet.
+		{options} are able to change for {job} in terminal.
+		Below is additional options for terminal:
+		   "term_name"	terminal name used instead of command name.
 
 term_wait({buf})						*term_wait()*
 		Wait for pending updates of {buf} to be handled.

--- a/src/channel.c
+++ b/src/channel.c
@@ -4386,6 +4386,18 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported)
 		    return FAIL;
 		}
 	    }
+	    else if (STRCMP(hi->hi_key, "term_name") == 0)
+	    {
+		if (!(supported & JO2_TERM_NAME))
+		    break;
+		opt->jo_set2 |= JO2_TERM_NAME;
+		opt->jo_term_name = get_tv_string_chk(item);
+		if (opt->jo_term_name == NULL)
+		{
+		    EMSG2(_(e_invarg2), "term_name");
+		    return FAIL;
+		}
+	    }
 	    else if (STRCMP(hi->hi_key, "waittime") == 0)
 	    {
 		if (!(supported & JO_WAITTIME))

--- a/src/structs.h
+++ b/src/structs.h
@@ -1684,7 +1684,8 @@ struct channel_S {
 
 #define JO2_OUT_MSG	    0x0001	/* "out_msg" */
 #define JO2_ERR_MSG	    0x0002	/* "err_msg" (JO_OUT_ << 1) */
-#define JO2_ALL		    0x0003
+#define JO2_TERM_NAME	    0x0004	/* "term_name" */
+#define JO2_ALL		    0x0007
 
 #define JO_MODE_ALL	(JO_MODE + JO_IN_MODE + JO_OUT_MODE + JO_ERR_MODE)
 #define JO_CB_ALL \
@@ -1741,6 +1742,7 @@ typedef struct
     /* when non-zero run the job in a terminal window of this size */
     int		jo_term_rows;
     int		jo_term_cols;
+    char_u	*jo_term_name;
 #endif
 } jobopt_T;
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -261,6 +261,9 @@ term_start(char_u *cmd, jobopt_T *opt)
     if (cmd == NULL || *cmd == NUL)
 	cmd = p_sh;
 
+    if (opt->jo_term_name != NULL)
+	curbuf->b_ffname = vim_strsave(opt->jo_term_name);
+    else
     {
 	int	i;
 	size_t	len = STRLEN(cmd) + 10;
@@ -2123,7 +2126,8 @@ f_term_start(typval_T *argvars, typval_T *rettv)
     if (argvars[1].v_type != VAR_UNKNOWN
 	    && get_job_options(&argvars[1], &opt,
 		JO_TIMEOUT_ALL + JO_STOPONEXIT
-		+ JO_EXIT_CB + JO_CLOSE_CALLBACK) == FAIL)
+		+ JO_EXIT_CB + + JO_CLOSE_CALLBACK
+		+ JO2_TERM_NAME) == FAIL)
 	return;
 
     term_start(cmd, &opt);


### PR DESCRIPTION
usage
```
call term_start(&shell, {"term_name": "Super Ultra Command"})
```
