### PR TITLE
fix double expanding arguments on Windows

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -8165,9 +8165,6 @@ alist_add(
 {
     if (fname == NULL)		/* don't add NULL file names */
 	return;
-#ifdef BACKSLASH_IN_FILENAME
-    slash_adjust(fname);
-#endif
     AARGLIST(al)[al->al_ga.ga_len].ae_fname = fname;
     if (set_fnum > 0)
 	AARGLIST(al)[al->al_ga.ga_len].ae_fnum =

--- a/src/main.c
+++ b/src/main.c
@@ -227,7 +227,7 @@ main
 
     if (GARGCOUNT > 0)
     {
-#ifdef EXPAND_FILENAMES
+#if defined(EXPAND_FILENAMES) && !(defined(FEAT_MBYTE) && defined(WIN32))
 	/*
 	 * Expand wildcards in file names.
 	 */


### PR DESCRIPTION
If defined FEAT_MBYTE and WIN32 both, command-line arguments are parsed twice.

```
C:\temp>vim `notepad`
```
notepad appear twice. I'm not sure well, but this patch seems working good.

