### PR TITLE
Prevent an extra character is inserted

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1272,7 +1272,10 @@ check_due_timer(void)
     }
 
     if (did_one)
+    {
 	redraw_after_callback(need_update_screen);
+	typebuf_was_filled = TRUE;
+    }
 
     return current_id != last_timer_id ? 1 : next_due;
 }

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1274,7 +1274,8 @@ check_due_timer(void)
     if (did_one)
     {
 	redraw_after_callback(need_update_screen);
-	typebuf_was_filled = TRUE;
+	if (typebuf.tb_len > 0)
+	    typebuf_was_filled = TRUE;
     }
 
     return current_id != last_timer_id ? 1 : next_due;


### PR DESCRIPTION
On GVim, An extra character is inserted to command-line mode when focus state is changed in timer callback.

* But I'm worried this patch has another side effects :(

[repro step]

* confirmed Vim 8.0.0862 on Ubuntu 16.04, Windows 10

test.vim:

```vim
if has('win32')
  let s:cmd = 'path'
elseif executable('xterm')
  let s:cmd = 'xterm -e "sleep 1"'
endif

fu! T(...)
  call system(s:cmd)
  if winnr('$') > 1
    wincmd p
  else
    split
  endif
endfu
call timer_start(0, 'T')   
```

`gvim --clean -S test.vim`

* Another window shows, executes command, and closes. (*)
* And then input `/` (or `:`, to enter command-line), so `/b` at command line. Thus, an extra character `b` is appended to `/`.

In addition: `FocusLost` and `FocusGained` don't happen at (*) on GVim.

[cause]

* Finishing another window, GUI focus-gained event (from system) calls `gui_focus_change` and stacks bytes (`CSI KS_EXTRA KE_FOCUSGAINED`) into `inbuf`.
* (`wincmd p` or `split`) `vgetorpeek` is called in `wincmd`. After 8.0.0670, `vgetorpeek` called in timer-callback is run beyond [if-clause](https://github.com/vim/vim/blob/master/src/getchar.c#L1987) (`if (vgetc_busy > 0 && ex_normal_busy == 0)`).
* Therefore `typebuf` retrieves `inbuf` data:

```
#0  0x00000000005e5fde in read_from_input_buf (buf=0x8ff65a <typebuf_init+58> "\233\375b~tr\t\200kb\200kb/tr\tvim_\ti\t\r/\200kb:so\200ku\r/", maxlen=3) at ui.c:1758
#1  0x00000000005e3c65 in ui_inchar (buf=0x8ff65a <typebuf_init+58> "\233\375b~tr\t\200kb\200kb/tr\tvim_\ti\t\r/\200kb:so\200ku\r/", maxlen=68, wtime=0, tb_change_cnt=68
) at ui.c:187
#2  0x00000000004babc5 in inchar (buf=0x8ff65a <typebuf_init+58> "\233\375b~tr\t\200kb\200kb/tr\tvim_\ti\t\r/\200kb:so\200ku\r/", maxlen=206, wait_time=0, tb_change_cnt=
68) at getchar.c:3065
#3  0x00000000004ba78f in vgetorpeek (advance=0) at getchar.c:2841
#4  0x00000000004b8d5c in vpeekc () at getchar.c:1842
#5  0x00000000004b8e08 in char_avail () at getchar.c:1898
#6  0x00000000004f7efb in update_mouseshape (shape_idx=-1) at misc2.c:3774
#7  0x00000000005da435 in setmouse () at term.c:3532
#8  0x00000000005ff95c in win_enter_ext (wp=0xe386e0, undo_sync=1, curwin_invalid=0, trigger_new_autocmds=0, trigger_enter_autocmds=1, trigger_leave_autocmds=1)
    at window.c:4476
#9  0x00000000005ff565 in win_enter (wp=0xe386e0, undo_sync=1) at window.c:4348
#10 0x00000000005ff169 in win_goto (wp=0xe386e0) at window.c:4167
#11 0x00000000005f8b69 in do_window (nchar=119, Prenum=0, xchar=0) at window.c:266
#12 0x0000000000486cae in ex_wincmd (eap=0x7ffd88bcb380) at ex_docmd.c:9310
(snip)
```

* then:

```
typebuf.tb_len = 3
typebuf.tb_buf[typebuf.tb_off + 0] = '\233'
typebuf.tb_buf[typebuf.tb_off + 1] = '\375'
typebuf.tb_buf[typebuf.tb_off + 2] = 'b'
```

* `typebuf` is not consumed after timer-callback `T`. Then input `/`:

```
typebuf.tb_len = 3
typebuf.tb_buf[typebuf.tb_off + 0] = '/'
typebuf.tb_buf[typebuf.tb_off + 1] = '\000'
typebuf.tb_buf[typebuf.tb_off + 2] = 'b'
```

Thus `/b` is displayed.

[solution]

* Set `typebuf_was_filled` to `TRUE` in `vgetorpeek` if `timer_busy > 0` in order to comsume `typebuf`.

Ozaki Kiichi