### PR TITLE
Fixed crash with :exe "normal \<C-V>876543210>"

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -396,7 +396,10 @@ shift_block(oparg_T *oap, int amount)
 	return;
 
     /* total is number of screen columns to be inserted/removed */
-    total = amount * p_sw;
+    total = (int)((unsigned)amount * (unsigned)p_sw);
+    if ((total / p_sw) != amount)
+	return; /* amount * p_sw multiplication overflows */
+
     oldp = ml_get_curline();
 
     if (!left)

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -18,6 +18,12 @@ func Test_block_shift_multibyte()
   q!
 endfunc
 
+func Test_block_shift_overflow()
+  " This used to cause a multiplication overflow followed by a crash.
+  normal ii
+  exe "normal \<C-V>876543210>"
+endfunc
+
 func Test_dotregister_paste()
   new
   exe "norm! ihello world\<esc>"


### PR DESCRIPTION
This PR fixes a multiplication followed by a crash, found by afl-fuzz:
 
```
$ cat > shift-crash.vim <<EOF
normal ii
exe "normal \<C-V>876543210>"
EOF

$ vim -u NONE -S shift-crash.vim
Vim: Caught deadly signal SEGV
Vim: preserving files...
Vim: Finished.
Segmentation fault (core dumped)
```

ubsan points to a multiplication overflow which results
in a negative shift count:
```
ops.c:399:11: runtime error: signed integer overflow: 876543210 * 8 cannot be represented in type 'int'
```
And asan shows that memset was called with a negative size as result:
```
=================================================================
==17674==ERROR: AddressSanitizer: negative-size-param: (size=-197198612)
    #0 0x7fda2462bc69 in __asan_memset (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x8cc69)
    #1 0x60f98d in shift_block /home/pel/sb/vim/src/ops.c:451
    #2 0x60e95b in op_shift /home/pel/sb/vim/src/ops.c:244
    #3 0x5ee93e in do_pending_operator /home/pel/sb/vim/src/normal.c:1842
    #4 0x5eb1e6 in normal_cmd /home/pel/sb/vim/src/normal.c:1183
    #5 0x4efefd in exec_normal /home/pel/sb/vim/src/ex_docmd.c:10415
    #6 0x4efea6 in exec_normal_cmd /home/pel/sb/vim/src/ex_docmd.c:10398
    #7 0x4efae5 in ex_normal /home/pel/sb/vim/src/ex_docmd.c:10307
    #8 0x4d42d2 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2952
    #9 0x4cea01 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:1089
    #10 0x471cbe in ex_execute /home/pel/sb/vim/src/eval.c:8365
    #11 0x4d42d2 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2952
    #12 0x4cea01 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:1089
    #13 0x4cafbf in do_source /home/pel/sb/vim/src/ex_cmds2.c:4377
    #14 0x4ca106 in cmd_source /home/pel/sb/vim/src/ex_cmds2.c:3990
    #15 0x4c9fa7 in ex_source /home/pel/sb/vim/src/ex_cmds2.c:3965
    #16 0x4d42d2 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2952
    #17 0x4cea01 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:1089
    #18 0x4cdd9f in do_cmdline_cmd /home/pel/sb/vim/src/ex_docmd.c:689
    #19 0x8644f4 in exe_commands /home/pel/sb/vim/src/main.c:2968
    #20 0x85ea2d in vim_main2 /home/pel/sb/vim/src/main.c:805
    #21 0x85e25b in main /home/pel/sb/vim/src/main.c:419
    #22 0x7fda2150682f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #23 0x408058 in _start (/home/pel/sb/vim/src/vim+0x408058)

0x7fd928501800 is located 0 bytes inside of 4097768684-byte region [0x7fd928501800,0x7fda1c8f14ec)
allocated by thread T0 here:
    #0 0x7fda24637602 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98602)
    #1 0x5c2a22 in lalloc /home/pel/sb/vim/src/misc2.c:942
    #2 0x5c297c in alloc_check /home/pel/sb/vim/src/misc2.c:885
    #3 0x60f8d5 in shift_block /home/pel/sb/vim/src/ops.c:448
    #4 0x60e95b in op_shift /home/pel/sb/vim/src/ops.c:244
    #5 0x5ee93e in do_pending_operator /home/pel/sb/vim/src/normal.c:1842
    #6 0x5eb1e6 in normal_cmd /home/pel/sb/vim/src/normal.c:1183
    #7 0x4efefd in exec_normal /home/pel/sb/vim/src/ex_docmd.c:10415
    #8 0x4efea6 in exec_normal_cmd /home/pel/sb/vim/src/ex_docmd.c:10398
    #9 0x4efae5 in ex_normal /home/pel/sb/vim/src/ex_docmd.c:10307
    #10 0x4d42d2 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2952
    #11 0x4cea01 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:1089
    #12 0x471cbe in ex_execute /home/pel/sb/vim/src/eval.c:8365
    #13 0x4d42d2 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2952
    #14 0x4cea01 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:1089
    #15 0x4cafbf in do_source /home/pel/sb/vim/src/ex_cmds2.c:4377
    #16 0x4ca106 in cmd_source /home/pel/sb/vim/src/ex_cmds2.c:3990
    #17 0x4c9fa7 in ex_source /home/pel/sb/vim/src/ex_cmds2.c:3965
    #18 0x4d42d2 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2952
    #19 0x4cea01 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:1089
    #20 0x4cdd9f in do_cmdline_cmd /home/pel/sb/vim/src/ex_docmd.c:689
    #21 0x8644f4 in exe_commands /home/pel/sb/vim/src/main.c:2968
    #22 0x85ea2d in vim_main2 /home/pel/sb/vim/src/main.c:805
    #23 0x85e25b in main /home/pel/sb/vim/src/main.c:419
    #24 0x7fda2150682f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

SUMMARY: AddressSanitizer: negative-size-param ??:0 __asan_memset
==17674==ABORTING
```