### PR TITLE
don't terminate with CTRL-C on Windows

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -66,6 +66,9 @@ the job.  For example:
 The special key combination CTRL-\ CTRL-N can be used to switch to Normal
 mode, just like this works in any other mode.
 
+							*t_CTRL-C*
+When |CTRL-C| in the terminal, interrupt signal will be sent to the job.
+If you use Windows, |CTRL-C| with shift key terminate the job.
 
 Size ~
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1137,11 +1137,13 @@ terminal_loop(void)
 	may_send_sigint(c, curbuf->b_term->tl_job->jv_pid, 0);
 #endif
 #ifdef WIN3264
-	if (c == Ctrl_C)
-	    /* We don't know if the job can handle CTRL-C itself or not, this
-	     * may kill the shell instead of killing the command running in the
-	     * shell. */
+	if (c == Ctrl_C && (GetKeyState(VK_SHIFT) & 0x8000) != 0)
+	{
+	    /* We don't know if the job can handle CTRL-C itself or not,
+	     * this may kill the shell instead of killing the command
+	     * running in the shell. */
 	    mch_stop_job(curbuf->b_term->tl_job, (char_u *)"quit");
+	}
 #endif
 
 	if (c == (termkey == 0 ? Ctrl_W : termkey) || c == Ctrl_BSL)


### PR DESCRIPTION
When do `:terminal ssh host`, CTRL-C terminate ssh.exe on Windows. ssh.exe works fine with CTRL-C to send interrupt into the session. So I propose to change the key to terminate job to CTRL-SHIFT-C.