### PR TITLE
"nocombine" attribute for term/cterm/gui

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4689,6 +4689,7 @@ the same syntax file on all terminals, and use the optimal highlighting.
 
 					*bold* *underline* *undercurl*
 					*inverse* *italic* *standout*
+					*nocombine*
 term={attr-list}			*attr-list* *highlight-term* *E418*
 	attr-list is a comma separated list (without spaces) of the
 	following items (in any order):
@@ -4699,6 +4700,7 @@ term={attr-list}			*attr-list* *highlight-term* *E418*
 		inverse		same as reverse
 		italic
 		standout
+		nocombine	override attributes instead of mixing
 		NONE		no attributes used (used to reset it)
 
 	Note that "bold" can be used here and by using a bold font.  They

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -560,7 +560,7 @@ syn match	vimHiBang	contained	"!"	skipwhite nextgroup=@vimHighlightCluster
 
 syn match	vimHiGroup	contained	"\i\+"
 syn case ignore
-syn keyword	vimHiAttrib	contained	none bold inverse italic reverse standout underline undercurl
+syn keyword	vimHiAttrib	contained	none bold inverse italic reverse standout underline undercurl nocombine
 syn keyword	vimFgBgAttrib	contained	none bg background fg foreground
 syn case match
 syn match	vimHiAttribList	contained	"\i\+"	contains=vimHiAttrib

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -86,9 +86,10 @@ static int include_link = 0;	/* when 2 include "link" and "clear" */
  */
 static char *(hl_name_table[]) =
     {"bold", "standout", "underline", "undercurl",
-				      "italic", "reverse", "inverse", "NONE"};
+				      "italic", "reverse", "inverse", "nocombine", "NONE"};
 static int hl_attr_table[] =
-    {HL_BOLD, HL_STANDOUT, HL_UNDERLINE, HL_UNDERCURL, HL_ITALIC, HL_INVERSE, HL_INVERSE, 0};
+    {HL_BOLD, HL_STANDOUT, HL_UNDERLINE, HL_UNDERCURL, HL_ITALIC, HL_INVERSE, HL_INVERSE, HL_NOCOMBINE, 0};
+#define ATTR_COMBINE(attr_a,attr_b) (((attr_b) & HL_NOCOMBINE ? 0 : (attr_a)) | (attr_b))
 
 static int get_attr_entry(garray_T *table, attrentry_T *aep);
 static void syn_unadd_group(void);
@@ -8912,7 +8913,7 @@ hl_combine_attr(int char_attr, int prim_attr)
     if (char_attr == 0)
 	return prim_attr;
     if (char_attr <= HL_ALL && prim_attr <= HL_ALL)
-	return char_attr | prim_attr;
+	return ATTR_COMBINE(char_attr, prim_attr);
 #ifdef FEAT_GUI
     if (gui.in_use)
     {
@@ -8931,13 +8932,13 @@ hl_combine_attr(int char_attr, int prim_attr)
 	}
 
 	if (prim_attr <= HL_ALL)
-	    new_en.ae_attr |= prim_attr;
+	    new_en.ae_attr = ATTR_COMBINE(new_en.ae_attr, prim_attr);
 	else
 	{
 	    spell_aep = syn_gui_attr2entry(prim_attr);
 	    if (spell_aep != NULL)
 	    {
-		new_en.ae_attr |= spell_aep->ae_attr;
+		new_en.ae_attr = ATTR_COMBINE(new_en.ae_attr, spell_aep->ae_attr);
 		if (spell_aep->ae_u.gui.fg_color != INVALCOLOR)
 		    new_en.ae_u.gui.fg_color = spell_aep->ae_u.gui.fg_color;
 		if (spell_aep->ae_u.gui.bg_color != INVALCOLOR)
@@ -8974,13 +8975,13 @@ hl_combine_attr(int char_attr, int prim_attr)
 	}
 
 	if (prim_attr <= HL_ALL)
-	    new_en.ae_attr |= prim_attr;
+		new_en.ae_attr = ATTR_COMBINE(new_en.ae_attr, prim_attr);
 	else
 	{
 	    spell_aep = syn_cterm_attr2entry(prim_attr);
 	    if (spell_aep != NULL)
 	    {
-		new_en.ae_attr |= spell_aep->ae_attr;
+		new_en.ae_attr = ATTR_COMBINE(new_en.ae_attr, spell_aep->ae_attr);
 		if (spell_aep->ae_u.cterm.fg_color > 0)
 		    new_en.ae_u.cterm.fg_color = spell_aep->ae_u.cterm.fg_color;
 		if (spell_aep->ae_u.cterm.bg_color > 0)
@@ -9008,13 +9009,13 @@ hl_combine_attr(int char_attr, int prim_attr)
     }
 
     if (prim_attr <= HL_ALL)
-	new_en.ae_attr |= prim_attr;
+	new_en.ae_attr = ATTR_COMBINE(new_en.ae_attr, prim_attr);
     else
     {
 	spell_aep = syn_term_attr2entry(prim_attr);
 	if (spell_aep != NULL)
 	{
-	    new_en.ae_attr |= spell_aep->ae_attr;
+	    new_en.ae_attr = ATTR_COMBINE(new_en.ae_attr, spell_aep->ae_attr);
 	    if (spell_aep->ae_u.term.start != NULL)
 	    {
 		new_en.ae_u.term.start = spell_aep->ae_u.term.start;

--- a/src/vim.h
+++ b/src/vim.h
@@ -680,7 +680,8 @@ extern int (*dyn_libintl_putenv)(const char *envstring);
 #define HL_UNDERLINE		0x08
 #define HL_UNDERCURL		0x10
 #define HL_STANDOUT		0x20
-#define HL_ALL			0x3f
+#define HL_NOCOMBINE		0x40
+#define HL_ALL			0x7f
 
 /* special attribute addition: Put message in history */
 #define MSG_HIST		0x1000


### PR DESCRIPTION
Right now, a match highlight with cterm=NONE will take on the cterm attributes of the underlying syntax highlighting. This is sometimes unwanted, for example with trying to run two matches differentiated by boldness over a file with syntax that already has some text bolded.
This does not affect any existing functionality, as only highlight groups with the attribute "nocombine" will override the cterm attribute; without nocombine, match highlighting (and other highlighting such as CursorLine) still works as before.