### PR TITLE
fix ctrl-break on Windows

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1672,7 +1672,7 @@ EXTERN int *eval_lavars_used INIT(= NULL);
 #endif
 
 #ifdef WIN3264
-EXTERN int ctrl_break_was_pressed = FALSE;
+EXTERN int ctrl_break_was_pressed INIT(= FALSE);
 #endif
 
 /*

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3741,6 +3741,9 @@ mch_free_acl(vim_acl_T acl)
 handler_routine(
     DWORD dwCtrlType)
 {
+    INPUT_RECORD ir;
+    DWORD out;
+
     switch (dwCtrlType)
     {
     case CTRL_C_EVENT:
@@ -3750,6 +3753,16 @@ handler_routine(
 
     case CTRL_BREAK_EVENT:
 	g_fCBrkPressed	= TRUE;
+	ctrl_break_was_pressed = TRUE;
+	/* ReadConsoleInput is blocking. So send key event. */
+	ir.EventType = KEY_EVENT;
+	ir.Event.KeyEvent.bKeyDown = TRUE;
+	ir.Event.KeyEvent.wRepeatCount = 1;
+	ir.Event.KeyEvent.wVirtualKeyCode = VK_CANCEL;
+	ir.Event.KeyEvent.wVirtualScanCode = 0;
+	ir.Event.KeyEvent.dwControlKeyState = 0;
+	ir.Event.KeyEvent.uChar.UnicodeChar = 0;
+	WriteConsoleInput(g_hConIn, &ir, 1, &out);
 	return TRUE;
 
     /* fatal events: shut down gracefully */

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1208,8 +1208,6 @@ terminal_loop(void)
 	 * or not.  Therefore CTRL-C only sends a CTRL_C_EVENT to avoid killing
 	 * the shell instead of a command running in the shell.
 	 * Use CTRL-BREAK to kill the job. */
-	if (c == Ctrl_C)
-	    mch_signal_job(curbuf->b_term->tl_job, (char_u *)"int");
 	if (ctrl_break_was_pressed)
 	    mch_signal_job(curbuf->b_term->tl_job, (char_u *)"kill");
 #endif


### PR DESCRIPTION
On Windows, CTRL-C (key code 3) should be sent as key code not CTRL-C event since winpty alrady handle this.

https://github.com/rprichard/winpty/blob/4978cf94b6ea48e38eea3146bd0d23210f87aa89/src/agent/ConsoleInput.cc#L398

So vim must not send CTRL-C event. And also ReadConsoleInput doesn't stop reading with CTRL-BREAK.