### PR TITLE
fix default shell

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -465,6 +465,9 @@ ex_terminal(exarg_T *eap)
 	cmd = skipwhite(p);
     }
 
+    if (cmd == NULL || *cmd == NUL)
+	cmd = p_sh;
+
     if (eap->addr_count == 2)
     {
 	opt.jo_term_rows = eap->line1;


### PR DESCRIPTION
Sorry, https://github.com/vim/vim/commit/dcaa61384ca76e42f7feda5640fb85b58cee03e5 break default shell for termianl.