### PR TITLE
Fix test failure when total time == self time.

### DIFF
--- a/src/testdir/test_profile.vim
+++ b/src/testdir/test_profile.vim
@@ -121,7 +121,7 @@ func Test_profile_file()
   " First line of loop executes one more time than body to detect end of loop.
   call assert_match('^\s*22\s\+\d\+\.\d\+\s\+for i in range(10)$',    lines[8])
   call assert_equal('                              " a comment',      lines[9])
-  call assert_match('^\s*20\s\+\d\+\.\d\+\s\+\d\+\.\d\+\s\+call Foo()$', lines[10])
+  call assert_match('^\s*20\s\+\(\d\+\.\d\+\s\+\)\=\d\+\.\d\+\s\+call Foo()$', lines[10])
   call assert_match('^\s*20\s\+\d\+\.\d\+\s\+endfor$',                lines[11])
   " if self and total are equal we only get one number
   call assert_match('^\s*2\s\+\(\d\+\.\d\+\s\+\)\=\d\+\.\d\+\s\+call Foo()$', lines[12])


### PR DESCRIPTION
```
From test_profile.vim:
Found errors in Test_profile_file():
function RunTheTest[24]..Test_profile_file line 37: Pattern '^\\s*20\\s\\+\\d\\+\\.\\d\\+\\s\\+\\d\\+\\.\\d\\+\\s\\+call Foo()$' does not match '   20              0.000043   call Foo()'
```