### PR TITLE
Fix terminal multibyte scraping test on Windows

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -185,14 +185,19 @@ func Test_terminal_scrape_multibyte()
   endif
   call writefile(["léttまrs"], 'Xtext')
   if has('win32')
-    let cmd = 'cmd /c "type Xtext"'
+    " Start cmd with UTF-8 codepage to make the type command successfully prints
+    " multibyte characters.
+    let g:buf = term_start("cmd /K chcp 65001")
+    call term_sendkeys(g:buf, "type Xtext\<CR>")
+    call term_sendkeys(g:buf, "exit\<CR>")
+    let g:line = 4
   else
-    let cmd = "cat Xtext"
+    let g:buf = term_start("cat Xtext")
+    let g:line = 1
   endif
-  let g:buf = term_start(cmd)
 
-  call WaitFor('term_scrape(g:buf, 1)[0].chars == "l"')
-  let l = term_scrape(g:buf, 1)
+  call WaitFor('term_scrape(g:buf, g:line)[0].chars == "l"')
+  let l = term_scrape(g:buf, g:line)
   call assert_true(len(l) >= 7)
   call assert_equal('l', l[0].chars)
   call assert_equal('é', l[1].chars)
@@ -210,6 +215,7 @@ func Test_terminal_scrape_multibyte()
 
   exe g:buf . 'bwipe'
   unlet g:buf
+  unlet g:line
   call delete('Xtext')
 endfunc
 


### PR DESCRIPTION
The `Test_terminal_scrape_multibyte` test fails on Windows with the following errors:
```
Found errors in Test_terminal_scrape_multibyte():
function RunTheTest[24]..Test_terminal_scrape_multibyte line 21: Expected 'é' but got '├'
function RunTheTest[24]..Test_terminal_scrape_multibyte line 23: Expected 't' but got '⌐'
function RunTheTest[24]..Test_terminal_scrape_multibyte line 25: Expected 'ま' but got 't'
function RunTheTest[24]..Test_terminal_scrape_multibyte line 26: Expected 2 but got 1
function RunTheTest[24]..Test_terminal_scrape_multibyte line 27: Expected 'r' but got 'π'
function RunTheTest[24]..Test_terminal_scrape_multibyte line 28: Expected 's' but got 'ü'
```
These errors occur because the `type` command prints `l├®ttÒü¥rs` (when the code page is 850 which is the default in Western Europe) instead of `léttまrs` in the terminal . This is fixed by setting the code page to 65001 (UTF-8).