### PR TITLE
Restore :sleep in Test_existent_file

### DIFF
--- a/src/testdir/test_stat.vim
+++ b/src/testdir/test_stat.vim
@@ -4,9 +4,11 @@ func Test_existent_file()
   let fname = 'Xtest.tmp'
 
   let ts = localtime()
+  sleep 1
   let fl = ['Hello World!']
   call writefile(fl, fname)
   let tf = getftime(fname)
+  sleep 1
   let te = localtime()
 
   call assert_true(ts <= tf && tf <= te)


### PR DESCRIPTION
The sleep calls were removed in 8.0.0292.  Since the granularity of a
file's timestamps are different than that of localtime(), this increases
the chances that the test will fail (and it did[0]).

[0]: https://buildd.debian.org/status/fetch.php?pkg=vim&arch=arm64&ver=2%3A8.0.0946-1&stamp=1502768816&raw=0