### PR TITLE
disable translation in default value for printheader

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -2196,7 +2196,7 @@ static struct vimoption options[] =
     {"printheader", "pheader",  P_STRING|P_VI_DEF|P_GETTEXT,
 #ifdef FEAT_PRINTER
 			    (char_u *)&p_header, PV_NONE,
-			    {(char_u *)N_("%<%f%h%m%=Page %N"), (char_u *)0L}
+			    {(char_u *)"%<%f%h%m%=Page %N", (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}


### PR DESCRIPTION
When set encoding=utf-8 on Windows, printheader become invalid string. Default value of printheader is translated for the locale. But many users set encoding=utf-8 for now. Then the value become invalid string. I suggest to disable translation.