### PR TITLE
update kivy syntax file

### DIFF
--- a/runtime/syntax/kivy.vim
+++ b/runtime/syntax/kivy.vim
@@ -1,35 +1,56 @@
 " Vim syntax file
-" Language:    Kivy
-" Maintainer:  Corey Prophitt <prophitt.corey@gmail.com>
-" Last Change: May 29th, 2014
-" Version:     1
+" ~/.vim/syntax/kivy.vim
+"
+" Vim syntax file
+" Language:	Kivy
+" Maintainer:	Gabriel Pettier <gabriel.pettier@gmail.com>
+" Last Change:	2017 august 26
+" Version:     2
 " URL:         http://kivy.org/
 
 if exists("b:current_syntax")
     finish
 endif
 
-" Load Python syntax first (Python can be used within Kivy)
 syn include @pyth $VIMRUNTIME/syntax/python.vim
 
-" Kivy language rules can be found here
-"   http://kivy.org/docs/guide/lang.html
+syn match kivyComment       /#.*\n/ display contains=pythonTodo,Spell
+syn match kivyPreProc       /^#:.*/
+syn match kivyDefine        /^#:set .*/
+syn match kivyInclude       /^#:include .*/
+syn match kivyImport        /^#:import .*/
+syn match kivyAttribute     /\I\i*/ nextgroup=kivyValue
+syn match kivyBind          /on_\I\i*:/ nextgroup=kivyValue
+syn match kivyRule          /<-*\I\i*\([,@]s*\I\i*\)*>:/
+syn match kivyRootRule      /^\I\i*:$/
+syn match kivyInstruction   /^\s\+\u\i*:/ nextgroup=kivyValue
+syn match kivyWidget        /^\s\+\u\i*:/
 
-" Define Kivy syntax
-syn match kivyPreProc   /#:.*/
-syn match kivyComment   /#.*/
-syn match kivyRule      /<\I\i*\(,\s*\I\i*\)*>:/
-syn match kivyAttribute /\<\I\i*\>/ nextgroup=kivyValue
+syn region kivyAttribute start=/^\z(\s\+\)\l\+:\n\1\s\{4}/ skip=/^\z1\s\{4}.*$/ end=/^$/ contains=@pyth
 
-syn region kivyValue start=":" end=/$/  contains=@pyth skipwhite
+syn region kivyBind start=/^\z(\s\+\)on_\i\+:\n\1\s\{4}/ skip=/^\z1\s\{4}.*$/ end=/^$/ contains=@pyth
+syn region kivyBind start=/^\z(\s\+\)on_\i\+:\n\1\s\{4}/ skip="^$\|^\z1\s{4}" end="^\z1\I"me=e-9999 contains=@pyth
+syn region kivyBind start=/on_\i\+:\s/ end=/$/ contains=@pyth
 
-syn region kivyAttribute matchgroup=kivyIdent start=/[\a_][\a\d_]*:/ end=/$/ contains=@pyth skipwhite
+syn match kivyValue /\(id\s*\)\@<!:\s*.*$/ contains=@pyth skipwhite
+syn match kivyId   /\(id:\s*\)\@<=\w\+/
 
-hi def link kivyPreproc   PreProc
-hi def link kivyComment   Comment
-hi def link kivyRule      Function
-hi def link kivyIdent     Statement
-hi def link kivyAttribute Label
+syn match kivyCanvas         /^\s*canvas.*:$/ nextgroup=kivyInstruction
+syn region kivyCanvas        start=/^\z(\s*\)canvas.*:$/ skip="^$\|^\z1\s{4}" end="^\z1\I"me=e-9999 contains=kivyInstruction,kivyValue
+
+hi def link kivyPreproc      PreProc
+hi def link kivyComment      Comment
+hi def link kivyRule         Typedef
+hi def link kivyRootRule     Identifier
+hi def link kivyAttribute    Label
+hi def link kivyBind         Keyword
+hi def link kivyWidget       Type
+hi def link kivyCanvas       Function
+hi def link kivyInstruction  Statement
+hi def link KivyId           Define
+hi def link kivyDefine       Define
+hi def link kivyImport       Macro
+hi def link kivyInclude      Include
 
 let b:current_syntax = "kivy"
 


### PR DESCRIPTION
- differenciates between root and normal rules
- correctly highlight python after ":", both on same line or next block,
  including blocks with empty lines in them (as long as indentation
  doesn't change)
- differente context/colors for canvas instructions, and their
  properties, with the value also highlighted as python
- fixes comments not including XXX/TODO/FIXME/NOTE when on their own line
- special treatment for id property
- magically fixes some parsing errors that would break next line after a
  comment, a number with a dot, and some bad string end detection