### PR TITLE
Send CTRL-D on Windows to close stdin spawned from :%terminal

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1421,7 +1421,7 @@ channel_write_in(channel_T *channel)
 	/* TODO(mattn): Send CTRL-D to close stdin on Windows. Windows console
 	 * application doesn't treat closing stdin like pipe on UNIX. */
 	if (channel->ch_job != NULL)
-	    channel_send(channel, PART_IN, (char_u*) "\004\r\n", 3, NULL);
+	    term_close_stdin(channel);
 #endif
 
 	/* Writing is done, no longer need the buffer. */

--- a/src/channel.c
+++ b/src/channel.c
@@ -1417,6 +1417,13 @@ channel_write_in(channel_T *channel)
     in_part->ch_buf_top = lnum;
     if (lnum > buf->b_ml.ml_line_count || lnum > in_part->ch_buf_bot)
     {
+#ifdef WIN32
+	/* TODO(mattn): Send CTRL-D to close stdin on Windows. Windows console
+	 * application doesn't treat closing stdin like pipe on UNIX. */
+	if (channel->ch_job != NULL)
+	    channel_send(channel, PART_IN, (char_u*) "\004\r\n", 3, NULL);
+#endif
+
 	/* Writing is done, no longer need the buffer. */
 	in_part->ch_bufref.br_buf = NULL;
 	ch_log(channel, "Finished writing all lines to channel");

--- a/src/channel.c
+++ b/src/channel.c
@@ -1421,7 +1421,7 @@ channel_write_in(channel_T *channel)
 	/* TODO(mattn): Send CTRL-D to close stdin on Windows. Windows console
 	 * application doesn't treat closing stdin like pipe on UNIX. */
 	if (channel->ch_job != NULL)
-	    term_close_stdin(channel);
+	    term_send_eof(channel);
 #endif
 
 	/* Writing is done, no longer need the buffer. */

--- a/src/channel.c
+++ b/src/channel.c
@@ -1417,7 +1417,7 @@ channel_write_in(channel_T *channel)
     in_part->ch_buf_top = lnum;
     if (lnum > buf->b_ml.ml_line_count || lnum > in_part->ch_buf_bot)
     {
-#ifdef WIN32
+#if defined(WIN32) && defined(FEAT_TERMINAL)
 	/* TODO(mattn): Send CTRL-D to close stdin on Windows. Windows console
 	 * application doesn't treat closing stdin like pipe on UNIX. */
 	if (channel->ch_job != NULL)

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -16,6 +16,7 @@ int term_update_window(win_T *wp);
 int term_is_finished(buf_T *buf);
 int term_show_buffer(buf_T *buf);
 void term_change_in_curbuf(void);
+void term_close_stdin(channel_T *ch);
 int term_get_attr(buf_T *buf, linenr_T lnum, int col);
 char_u *term_get_status_text(term_T *term);
 int set_ref_in_term(int copyID);

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -16,7 +16,7 @@ int term_update_window(win_T *wp);
 int term_is_finished(buf_T *buf);
 int term_show_buffer(buf_T *buf);
 void term_change_in_curbuf(void);
-void term_close_stdin(channel_T *ch);
+void term_send_eof(channel_T *ch);
 int term_get_attr(buf_T *buf, linenr_T lnum, int col);
 char_u *term_get_status_text(term_T *term);
 int set_ref_in_term(int copyID);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3189,7 +3189,7 @@ terminal_enabled(void)
 }
 
     void
-term_close_stdin(channel_T *ch)
+term_send_eof(channel_T *ch)
 {
     term_T	*term;
     for (term = first_term; term != NULL; term = term->tl_next)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3188,6 +3188,14 @@ terminal_enabled(void)
     return dyn_winpty_init(FALSE) == OK;
 }
 
+    void
+term_close_stdin(channel_T *ch)
+{
+    term_T	*term;
+    for (term = first_term; term != NULL; term = term->tl_next)
+	if (term->tl_job == ch->ch_job)
+	    channel_send(ch, PART_IN, (char_u*) "\004\r\n", 3, NULL);
+}
 
 # else
 

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -490,6 +490,7 @@ endfunc
 
 func Test_terminal_write_stdin()
   if !executable('wc')
+    call ch_log('Test_terminal_write_stdin() is skipped because system doesn''t have wc command')
     return
   endif
   new

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -489,22 +489,21 @@ func Test_terminal_noblock()
 endfunc
 
 func Test_terminal_write_stdin()
-  " Todo: make this work on all systems.
-  if !has('unix')
+  if !executable('wc')
     return
   endif
   new
   call setline(1, ['one', 'two', 'three'])
   %term wc
   call WaitFor('getline(1) != ""')
-  let nrs = split(getline(1))
+  let nrs = split(getline('$'))
   call assert_equal(['3', '3', '14'], nrs)
   bwipe
 
   call setline(1, ['one', 'two', 'three', 'four'])
   2,3term wc
   call WaitFor('getline(1) != ""')
-  let nrs = split(getline(1))
+  let nrs = split(getline('$'))
   call assert_equal(['2', '2', '10'], nrs)
   bwipe
 


### PR DESCRIPTION
Since Windows, stdin is not console input(CONIN$), we can implement closing stdin like UNIX perfectly. Instead, sending CTRL-D to close stdin for most CUI applications. And one more issue, cmd.exe output feedback echo of input characters. So need to fix test.