### PR TITLE
Input test for #1940

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2407,6 +2407,7 @@ term_wait({buf} [, {time}])	Number  wait for screen to be updated
 test_alloc_fail({id}, {countdown}, {repeat})
 				none	make memory allocation fail
 test_autochdir()		none	enable 'autochdir' during startup
+test_feedinput()		none	add key sequence to input buffer
 test_garbagecollect_now()	none	free memory right now for testing
 test_ignore_error({expr})	none	ignore a specific error
 test_null_channel()		Channel	null value for testing
@@ -8160,6 +8161,11 @@ test_alloc_fail({id}, {countdown}, {repeat})		*test_alloc_fail()*
 test_autochdir()					*test_autochdir()*
 		Set a flag to enable the effect of 'autochdir' before Vim
 		startup has finished.
+
+test_feedinput({string})				*test_feedinput()*
+		Characters in {string} are queued for processing as if they
+		were typed by the user.
+		This function works only when with |+unix| or GUI is running.
 
 test_garbagecollect_now()			 *test_garbagecollect_now()*
 		Like garbagecollect(), but executed right away.  This must

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -392,6 +392,7 @@ static void f_tagfiles(typval_T *argvars, typval_T *rettv);
 static void f_tempname(typval_T *argvars, typval_T *rettv);
 static void f_test_alloc_fail(typval_T *argvars, typval_T *rettv);
 static void f_test_autochdir(typval_T *argvars, typval_T *rettv);
+static void f_test_feedinput(typval_T *argvars, typval_T *rettv);
 static void f_test_override(typval_T *argvars, typval_T *rettv);
 static void f_test_garbagecollect_now(typval_T *argvars, typval_T *rettv);
 static void f_test_ignore_error(typval_T *argvars, typval_T *rettv);
@@ -849,6 +850,7 @@ static struct fst
 #endif
     {"test_alloc_fail",	3, 3, f_test_alloc_fail},
     {"test_autochdir",	0, 0, f_test_autochdir},
+    {"test_feedinput",	1, 1, f_test_feedinput},
     {"test_garbagecollect_now",	0, 0, f_test_garbagecollect_now},
     {"test_ignore_error",	1, 1, f_test_ignore_error},
 #ifdef FEAT_JOB_CHANNEL
@@ -12462,6 +12464,23 @@ f_test_autochdir(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 {
 #if defined(FEAT_AUTOCHDIR)
     test_autochdir = TRUE;
+#endif
+}
+
+/*
+ * "test_feedinput()"
+ */
+    static void
+f_test_feedinput(typval_T *argvars, typval_T *rettv UNUSED)
+{
+#ifdef USE_INPUT_BUF
+    char_u	*val = get_tv_string_chk(&argvars[0]);
+
+    if (val != NULL)
+    {
+	trash_input_buf();
+	add_to_input_buf_csi(val, (int)STRLEN(val));
+    }
 #endif
 }
 

--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -206,5 +206,24 @@ func Test_timer_errors()
   call assert_equal(3, g:call_count)
 endfunc
 
+func FeedAndPeek(timer)
+  call test_feedinput('a')
+  call getchar(1)
+endfunc
+
+func Interrupt(timer)
+  call test_feedinput("\<C-C>")
+endfunc
+
+func Test_peek_and_get_char()
+  if !has('unix') && !has('gui_running')
+    return
+  endif
+  call timer_start(0, 'FeedAndPeek')
+  let intr = timer_start(100, 'Interrupt')
+  let c = getchar()
+  call assert_equal(char2nr('a'), c)
+  call timer_stop(intr)
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/ui.c
+++ b/src/ui.c
@@ -1651,11 +1651,6 @@ set_input_buf(char_u *p)
     }
 }
 
-#if defined(FEAT_GUI) \
-	|| defined(FEAT_MOUSE_GPM) || defined(FEAT_SYSMOUSE) \
-	|| defined(FEAT_XCLIPBOARD) || defined(VMS) \
-	|| defined(FEAT_CLIENTSERVER) \
-	|| defined(PROTO)
 /*
  * Add the given bytes to the input buffer
  * Special keys start with CSI.  A real CSI must have been translated to
@@ -1676,15 +1671,7 @@ add_to_input_buf(char_u *s, int len)
     while (len--)
 	inbuf[inbufcount++] = *s++;
 }
-#endif
 
-#if ((defined(FEAT_XIM) || defined(FEAT_DND)) && defined(FEAT_GUI_GTK)) \
-	|| defined(FEAT_GUI_MSWIN) \
-	|| defined(FEAT_GUI_MAC) \
-	|| (defined(FEAT_MBYTE) && defined(FEAT_MBYTE_IME)) \
-	|| (defined(FEAT_GUI) && (!defined(USE_ON_FLY_SCROLL) \
-		|| defined(FEAT_MENU))) \
-	|| defined(PROTO)
 /*
  * Add "str[len]" to the input buffer while escaping CSI bytes.
  */
@@ -1706,7 +1693,6 @@ add_to_input_buf_csi(char_u *str, int len)
 	}
     }
 }
-#endif
 
 #if defined(FEAT_HANGULIN) || defined(PROTO)
     void


### PR DESCRIPTION
* Add `Test_peek_and_get_char` to test_timers
* Add `test_feedinput` to feed data to `inbuf` 

I confirmed this test fails with before 8.0.1020.

https://ci.appveyor.com/project/ichizok/vim/build/428
https://travis-ci.org/ichizok/vim/builds/270689255