### PR TITLE
os_unix: treat GNU screen in xterm as xterm

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2280,6 +2280,7 @@ vim_is_xterm(char_u *name)
 		|| STRNICMP(name, "kterm", 5) == 0
 		|| STRNICMP(name, "mlterm", 6) == 0
 		|| STRNICMP(name, "rxvt", 4) == 0
+		|| STRNICMP(name, "screen.xterm", 12) == 0
 		|| STRCMP(name, "builtin_xterm") == 0);
 }
 


### PR DESCRIPTION
```
Problem:    The xterm background color detection does not work when Vim
            is running in GNU screen.
Solution:   Treat GNU screen on xterm as xterm -- it is supposed to
            support the same escape sequences. (Lubomir Rintel)
```

GNU screen recently gained support for OSC 11 sequence that allows us to
detect the terminal background color and pick the right color scheme.
However, termcap does not support the non-standard xterm OSC sequences and they
work only with native xterm support. GNU screen seeks to support the
xterm OSC sequences and in fact indicates that it's running in xterm in
its $TERM variable. Let's trust it that it's xterm compatible in that
case and use the internal xterm terminal support.

Tested on GNU screen git master on GNOME Terminal (that pretends to be
xterm-256color) and xterm.