### PR TITLE
Fix terminal scraping test on Windows

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -165,7 +165,7 @@ func Test_terminal_scrape_123()
 
   call term_wait(buf)
   let g:buf = buf
-  call WaitFor('len(term_scrape(g:buf, 1)) > 0')
+  call WaitFor('term_scrape(g:buf, 1)[0].chars == "1"')
   call Check_123(buf)
 
   " Must still work after the job ended.


### PR DESCRIPTION
The `Test_terminal_scrape_123` test may fail on Windows with the following errors:
```
Found errors in Test_terminal_scrape_123():
function RunTheTest[24]..Test_terminal_scrape_123[14]..Check_123 line 7: Expected '1' but got ''
function RunTheTest[24]..Test_terminal_scrape_123[14]..Check_123 line 8: Expected '2' but got ''
function RunTheTest[24]..Test_terminal_scrape_123[14]..Check_123 line 9: Expected '3' but got ''
function RunTheTest[24]..Test_terminal_scrape_123[14]..Check_123 line 10: Expected '#00e000' but got '#000000'
function RunTheTest[24]..Test_terminal_scrape_123[14]..Check_123 line 24: Expected '123' but got ''
```
This happens because the command `cmd /c "echo 123"` seems to output empty lines in the terminal before displaying `123` and the test doesn't wait for the output to be `123` but any output even if containing only empty lines. This is fixed by waiting for the first character to be `1` on the first line.