### PR TITLE
terminal foreground/background

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1542,7 +1542,7 @@ terminal_loop(void)
     {
 	/* TODO: skip screen update when handling a sequence of keys. */
 	/* Repeat redrawing in case a message is received while redrawing. */
-	while (curwin->w_redr_type != 0)
+	while (curwin->w_redr_type != 0 && !need_highlight_changed)
 	    update_screen(0);
 	update_cursor(curbuf->b_term, FALSE);
 
@@ -2393,6 +2393,7 @@ create_vterm(term_T *term, int rows, int cols)
     VTermValue	    value;
     VTermColor	    *fg, *bg;
     int		    fgval, bgval;
+    VTermState	    *state;
 
     vterm = vterm_new(rows, cols);
     term->tl_vterm = vterm;
@@ -2405,21 +2406,57 @@ create_vterm(term_T *term, int rows, int cols)
      * 'background' is "light". */
     vim_memset(&term->tl_default_color.attrs, 0, sizeof(VTermScreenCellAttrs));
     term->tl_default_color.width = 1;
-    fg = &term->tl_default_color.fg;
-    bg = &term->tl_default_color.bg;
+
+    /* Vterm uses a default black background. */
+    state = vterm_obtain_state(vterm);
+#ifdef FEAT_GUI
+    if (gui.in_use)
+    {
+	long_u	    rgb;
+
+	rgb = GUI_MCH_GET_RGB(gui.norm_pixel);
+	fg->red = (unsigned)(rgb >> 16);
+	fg->green = (unsigned)(rgb >> 8) & 255;
+	fg->blue = (unsigned)rgb & 255;
+	rgb = GUI_MCH_GET_RGB(gui.back_pixel);
+	bg->red = (unsigned)(rgb >> 16);
+	bg->green = (unsigned)(rgb >> 8) & 255;
+	bg->blue = (unsigned)rgb & 255;
+	vterm_state_set_default_colors(state, fg, bg);
+    }
+    else
+#endif
+#ifdef FEAT_TERMGUICOLORS
+    if (p_tgc)
+    {
+	long_u	    rgb;
+
+	rgb = GUI_MCH_GET_RGB(cterm_normal_fg_gui_color);
+	fg->red = (unsigned)(rgb >> 16);
+	fg->green = (unsigned)(rgb >> 8) & 255;
+	fg->blue = (unsigned)rgb & 255;
+	rgb = GUI_MCH_GET_RGB(cterm_normal_bg_gui_color);
+	bg->red = (unsigned)(rgb >> 16);
+	bg->green = (unsigned)(rgb >> 8) & 255;
+	bg->blue = (unsigned)rgb & 255;
+	vterm_state_set_default_colors(state, fg, bg);
+    }
+    else
+#endif
     if (*p_bg == 'l')
     {
-	fgval = 0;
-	bgval = 255;
+	/* Vterm uses a default black background.  Set it to white when
+	 * 'background' is "light". */
+	fg->red = fg->green = fg->blue = 0;
+	bg->red = bg->green = bg->blue = 255;
+	vterm_state_set_default_colors(state, fg, bg);
     }
     else
     {
-	fgval = 255;
-	bgval = 0;
+	fg->red = fg->green = fg->blue = 255;
+	bg->red = bg->green = bg->blue = 0;
+	vterm_state_set_default_colors(state, fg, bg);
     }
-    fg->red = fg->green = fg->blue = fgval;
-    bg->red = bg->green = bg->blue = bgval;
-    vterm_state_set_default_colors(vterm_obtain_state(vterm), fg, bg);
 
     /* Required to initialize most things. */
     vterm_screen_reset(screen, 1 /* hard */);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1542,7 +1542,7 @@ terminal_loop(void)
     {
 	/* TODO: skip screen update when handling a sequence of keys. */
 	/* Repeat redrawing in case a message is received while redrawing. */
-	while (curwin->w_redr_type != 0 && !need_highlight_changed)
+	while (curwin->w_redr_type != 0)
 	    update_screen(0);
 	update_cursor(curbuf->b_term, FALSE);
 
@@ -2392,7 +2392,6 @@ create_vterm(term_T *term, int rows, int cols)
     VTermScreen	    *screen;
     VTermValue	    value;
     VTermColor	    *fg, *bg;
-    int		    fgval, bgval;
     VTermState	    *state;
 
     vterm = vterm_new(rows, cols);
@@ -2406,6 +2405,8 @@ create_vterm(term_T *term, int rows, int cols)
      * 'background' is "light". */
     vim_memset(&term->tl_default_color.attrs, 0, sizeof(VTermScreenCellAttrs));
     term->tl_default_color.width = 1;
+    fg = &term->tl_default_color.fg;
+    bg = &term->tl_default_color.bg;
 
     /* Vterm uses a default black background. */
     state = vterm_obtain_state(vterm);


### PR DESCRIPTION
![bb93e76d0ed71db0](https://user-images.githubusercontent.com/10111/30119872-24b3b69c-9362-11e7-9ed7-8a79d990fd24.png)

This foreground/background colors are decided at time when start `:terminal` since color value is just default value. So this foreground/background colors will not change after `:colorscheme` command. This change support GUI and termguicolor.