### PR TITLE
avoid heavy redrawing while modifying highlight

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1476,7 +1476,7 @@ terminal_loop(void)
     {
 	/* TODO: skip screen update when handling a sequence of keys. */
 	/* Repeat redrawing in case a message is received while redrawing. */
-	while (curwin->w_redr_type != 0)
+	while (curwin->w_redr_type != 0 && !need_highlight_changed)
 	    update_screen(0);
 	update_cursor(curbuf->b_term, FALSE);
 


### PR DESCRIPTION
```vim
let &statusline='%#BgColor#%{MyFunc()}'

function! MyFunc() abort
  let m = mode()

  if m ==# 't'
    highlight BgColor term=reverse cterm=reverse ctermfg=lightgreen gui=reverse guifg=lightgreen
  elseif m ==# 'n'
    highlight BgColor term=reverse cterm=reverse ctermfg=lightblue gui=reverse guifg=lightblue
  else
    highlight BgColor term=reverse cterm=reverse ctermfg=gray gui=reverse guifg=gray
  endif
  " }}}

  return '(' . m . ') ' . strftime('%T')
endfunction
```

```
$ vim -u test.vim
```
Then, after open `:terminal` become heavy redrawing which not possible to input anything.