### PR TITLE
Modify channel-logging

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -138,7 +138,7 @@ ch_log_active(void)
 }
 
     static void
-ch_log_lead(char *what, channel_T *ch)
+ch_log_lead(const char *what, channel_T *ch)
 {
     if (log_fd != NULL)
     {
@@ -1813,12 +1813,11 @@ channel_save(channel_T *channel, ch_part_T part, char_u *buf, int len,
 	head->rq_prev = node;
     }
 
-    if (log_fd != NULL && lead != NULL)
+    if (ch_log_active() && lead != NULL)
     {
 	ch_log_lead(lead, channel);
 	fprintf(log_fd, "'");
-	if (fwrite(buf, len, 1, log_fd) != 1)
-	    return FAIL;
+	ignored = (int)fwrite(buf, len, 1, log_fd);
 	fprintf(log_fd, "'\n");
     }
     return OK;
@@ -3385,7 +3384,7 @@ channel_read_block(channel_T *channel, ch_part_T part, int timeout)
 	    channel_consume(channel, part, (int)(nl - buf) + 1);
 	}
     }
-    if (log_fd != NULL)
+    if (ch_log_active())
 	ch_log(channel, "Returning %d bytes", (int)STRLEN(msg));
     return msg;
 }
@@ -3670,7 +3669,7 @@ channel_send(
 	return FAIL;
     }
 
-    if (log_fd != NULL)
+    if (ch_log_active())
     {
 	ch_log_lead("SEND ", channel);
 	fprintf(log_fd, "'");


### PR DESCRIPTION
In `channel_save` when `fwrite` fails it returns `FAIL`, but I think the logging had better not to effect
the result of the function itself.

* let `ignored`store the result of `fwrite` (as with https://github.com/vim/vim/blob/b984b80/src/channel.c#L3677 in `channel_send`)