### PR TITLE
fix crash recursibly call of foldtextresult(v:foldstart) in 'foldtext'

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3642,11 +3642,17 @@ f_foldtextresult(typval_T *argvars UNUSED, typval_T *rettv)
     char_u	buf[FOLD_TEXT_LEN];
     foldinfo_T  foldinfo;
     int		fold_count;
+    static int	evaluating = FALSE;
 #endif
 
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = NULL;
+
 #ifdef FEAT_FOLDING
+    if (evaluating == TRUE)
+	return;
+    evaluating = TRUE;
+
     lnum = get_tv_lnum(argvars);
     /* treat illegal types and illegal string values for {lnum} the same */
     if (lnum < 0)
@@ -3660,6 +3666,8 @@ f_foldtextresult(typval_T *argvars UNUSED, typval_T *rettv)
 	    text = vim_strsave(text);
 	rettv->vval.v_string = text;
     }
+
+    evaluating = FALSE;
 #endif
 }
 


### PR DESCRIPTION
This file make recursibly call, and crash.

```vim
# vim: fen fdm=marker fdt=foldtextresult(v\:foldstart)
{{{
	Can you see this?
}}}
```
