### PR TITLE
Rename practise to practice

### DIFF
--- a/runtime/tutor/tutor
+++ b/runtime/tutor/tutor
@@ -12,7 +12,7 @@
 
      ATTENTION:
      The commands in the lessons will modify the text.  Make a copy of this
-     file to practise on (if you started "vimtutor" this is already a copy).
+     file to practice on (if you started "vimtutor" this is already a copy).
 
      It is important to remember that this tutor is set up to teach by
      use.  That means that you need to execute the commands to learn them

--- a/runtime/tutor/tutor.utf-8
+++ b/runtime/tutor/tutor.utf-8
@@ -12,7 +12,7 @@
 
      ATTENTION:
      The commands in the lessons will modify the text.  Make a copy of this
-     file to practise on (if you started "vimtutor" this is already a copy).
+     file to practice on (if you started "vimtutor" this is already a copy).
 
      It is important to remember that this tutor is set up to teach by
      use.  That means that you need to execute the commands to learn them


### PR DESCRIPTION
Hi!

I'm a little bit annoyed by the spelling in vimtutor of 'practise'. 

According to sources online, in American English, 'practice' is preferred in all cases, while in British English 'practise' is preferred only for verbs. However, later in the same file, 'practice' is [used as a verb](https://github.com/vim/vim/blob/master/runtime/tutor/tutor#L755). 

If you think that 'practise' is correct, I would be happy to change the spellings to be consistent the other way around.

Feel free to trash this if you think it's insignificant.

Thanks!
-Jay
