### PR TITLE
resolve duplicated helptags

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -895,14 +895,14 @@ the <CR> key.  |<>|)
 
 See section |42.4| in the user manual.
 
-							*:tmenu* *:tm*
-:tm[enu] {menupath} {rhs}	Define a tip for a menu or tool.  {only in
+							*:tmenu* *:tme*
+:tme[nu] {menupath} {rhs}	Define a tip for a menu or tool.  {only in
 				X11 and Win32 GUI}
 
-:tm[enu] [menupath]		List menu tips. {only in X11 and Win32 GUI}
+:tme[nu] [menupath]		List menu tips. {only in X11 and Win32 GUI}
 
-							*:tunmenu* *:tu*
-:tu[nmenu] {menupath}		Remove a tip for a menu or tool.
+							*:tunmenu* *:tunme*
+:tunme[nu] {menupath}		Remove a tip for a menu or tool.
 				{only in X11 and Win32 GUI}
 
 When a tip is defined for a menu item, it appears in the command-line area

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -47,11 +47,6 @@ compiler (see |errorformat| below).
 							*quickfix-ID*
 Each quickfix list has a unique identifier called the quickfix ID and this
 number will not change within a Vim session. The getqflist() function can be
-used to get the identifier assigned to a list.
-
-							*quickfix-ID*
-Each quickfix list has a unique identifier called the quickfix ID and this
-number will not change within a Vim session. The getqflist() function can be
 used to get the identifier assigned to a list. There is also a quickfix list
 number which may change whenever more than ten lists are added to a quickfix
 stack.


### PR DESCRIPTION
Problem:    `:helptags $VIMRUNTIME/doc` failed with E154 errors

Solution:    Correct helptags and doc for :tmenu and :tunmenu, delete
    duplicated "quickfix-ID" paragraph.