### PR TITLE
Fix set-scroll error

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2240,6 +2240,7 @@ test_arglist \
 	test_reltime \
 	test_retab \
 	test_ruby \
+	test_scroll_opt \
 	test_scrollbind \
 	test_search \
 	test_searchpos \

--- a/src/option.c
+++ b/src/option.c
@@ -3889,7 +3889,7 @@ set_init_2(void)
      * 'scroll' defaults to half the window height. Note that this default is
      * wrong when the window height changes.
      */
-    set_number_default("scroll", (long)((long_u)Rows >> 1));
+    set_number_default("scroll", 0L);
     idx = findoption((char_u *)"scroll");
     if (idx >= 0 && !(options[idx].flags & P_WAS_SET))
 	set_option_default(idx, OPT_LOCAL, p_cp);

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -44,6 +44,7 @@ source test_popup.vim
 source test_put.vim
 source test_recover.vim
 source test_reltime.vim
+source test_scroll_opt.vim
 source test_searchpos.vim
 source test_set.vim
 source test_sort.vim

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1,0 +1,36 @@
+" Test for reset 'scroll'
+"
+
+func Test_reset_scroll()
+  let scr = &l:scroll
+
+  setlocal scroll=1
+  setlocal scroll&
+  call assert_equal(scr, &l:scroll)
+
+  setlocal scroll=1
+  setlocal scroll=0
+  call assert_equal(scr, &l:scroll)
+
+  try
+    execute 'setlocal scroll=' . (winheight(0) + 1)
+    " not reached
+    call assert_false(1)
+  catch
+    call assert_exception('E49:')
+  endtry
+
+  split
+
+  let scr = &l:scroll
+
+  setlocal scroll=1
+  setlocal scroll&
+  call assert_equal(scr, &l:scroll)
+
+  setlocal scroll=1
+  setlocal scroll=0
+  call assert_equal(scr, &l:scroll)
+
+  quit!
+endfunc


### PR DESCRIPTION
There is `set scroll&` error when `winheight(0)  < rows/2`.
(rows: the number of rows at vim launching)

### repro steps

`vim --clean`
```
:split
:set scroll&
E49: Invalid scroll size: scroll&
```

### cause

https://github.com/vim/vim/blob/4033c55/src/option.c#3892

The default value of `'scroll'` (`options[*].def_val[VI_DEFAULT]`) is set to `Rows >> 2` and this is fixed during vim running.

https://github.com/vim/vim/blob/4033c55/src/option.c#9100

so `set scroll&` makes `curwin->w_p_scr > curwin->w_height` be true when the height of window is lower than an half of initial value.

### solution proposal

* Set the default value of `'scroll'` (`options[*].def_val[VI_DEFAULT]`) to 0.

Then `set scroll&` means `set scroll=0`, reset the value of `'scroll'`.

Ozaki Kiichi