### PR TITLE
win32: Use call in vimtutor.bat

### DIFF
--- a/vimtutor.bat
+++ b/vimtutor.bat
@@ -47,11 +47,11 @@ GOTO end
 
 :use_vim
 :: The script tutor.vim tells Vim which file to copy
-vim -u NONE -c "so $VIMRUNTIME/tutor/tutor.vim"
+call vim -u NONE -c "so $VIMRUNTIME/tutor/tutor.vim"
 IF ERRORLEVEL 1 GOTO no_executable
 
 :: Start vim without any .vimrc, set 'nocompatible'
-vim -u NONE -c "set nocp" %TUTORCOPY%
+call vim -u NONE -c "set nocp" %TUTORCOPY%
 
 GOTO end
 


### PR DESCRIPTION
This is originally reported at k-takata/vim-win32-installer#3.

> Please add to *.bat file
for example vim80\vimtutor.bat
change
vim -u NONE -c "so $VIMRUNTIME/tutor/tutor.vim"
to
call vim -u NONE -c "so $VIMRUNTIME/tutor/tutor.vim"
because now second string (vim -u NONE -c "set nocp" %TUTORCOPY%) newer run

If Vim is installed with "Create .bat files for command line use", the
"vim" command executes "vim.bat" and it causes the reported problem.
Using "call" fixes it.