### PR TITLE
win32: Make the main item of the installer readonly

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -179,7 +179,7 @@ FunctionEnd
 
 ##########################################################
 Section "Vim executables and runtime files"
-	SectionIn 1 2 3
+	SectionIn 1 2 3 RO
 
 	# we need also this here if the user changes the instdir
 	StrCpy $0 "$INSTDIR\vim${VER_MAJOR}${VER_MINOR}"


### PR DESCRIPTION
This is related to k-takata/vim-win32-installer#3.
Current win32 installer can uncheck "Vim executables and runtime files"
item, but it is nonsense.  Make the item readonly.