### PR TITLE
Fix SEGV when do `bwipe` in callback

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1323,7 +1323,7 @@ check_due_timer(void)
     long	current_id = last_timer_id;
 
     /* Don't run any timers while exiting or dealing with an error. */
-    if (exiting || aborting())
+    if (exiting || aborting() || dont_invoke_callback > 0)
 	return next_due;
 
     profile_start(&now);

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1847,9 +1847,18 @@ plain_vgetc(void)
     int
 vpeekc(void)
 {
+    int		c;
+
     if (old_char != -1)
 	return old_char;
-    return vgetorpeek(FALSE);
+#if defined(FEAT_JOB_CHANNEL) || defined(FEAT_TIMERS)
+    ++dont_invoke_callback;
+#endif
+    c = vgetorpeek(FALSE);
+#if defined(FEAT_JOB_CHANNEL) || defined(FEAT_TIMERS)
+    --dont_invoke_callback;
+#endif
+    return c;
 }
 
 #if defined(FEAT_TERMRESPONSE) || defined(FEAT_TERMINAL) || defined(PROTO)

--- a/src/globals.h
+++ b/src/globals.h
@@ -1643,6 +1643,10 @@ EXTERN int  bevalexpr_due_set INIT(= FALSE);
 EXTERN proftime_T bevalexpr_due;
 #endif
 
+#if defined(FEAT_JOB_CHANNEL) || defined(FEAT_TIMERS)
+EXTERN int  dont_invoke_callback INIT(= 0);
+#endif
+
 #ifdef FEAT_EVAL
 EXTERN time_T time_for_testing INIT(= 0);
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -6344,6 +6344,9 @@ parse_queued_messages(void)
 {
     win_T *old_curwin = curwin;
 
+    if (dont_invoke_callback > 0)
+	return;
+
     /* For Win32 mch_breakcheck() does not check for input, do it here. */
 # if defined(WIN32) && defined(FEAT_JOB_CHANNEL)
     channel_handle_events(FALSE);


### PR DESCRIPTION
### repro steps

sample.vim

```vim
function! s:exit_cb(buf, job, st, ...)
    exe a:buf 'bwipe!'
endfunction

set lazyredraw
syntax on
set filetype=vim
call setline(1, ['echo 1'])
new
let buf = bufnr('')

let cmd = 'echo 1'
call term_start(cmd, {'curwin': buf, 'exit_cb': function('s:exit_cb', [buf])})
```

`vim -Nu sample.vim`

or: `vim --clean` and `:so sample.vim` (maybe need many tries)

### detail

stacktrace:

```
Program received signal SIGSEGV, Segmentation fault.
0x00000000004f23a0 in curs_rows (wp=0x13a8a50) at move.c:680
680                             || wp->w_lines[0].wl_lnum > wp->w_topline);
(gdb) bt
#0  0x00000000004f23a0 in curs_rows (wp=0x13a8a50) at move.c:680
#1  0x00000000004f2d46 in curs_columns (may_scroll=1) at move.c:951
#2  0x00000000004f236f in validate_cursor () at move.c:642
#3  0x000000000061d53c in main_loop (cmdwin=0, noexmode=0) at main.c:1253
#4  0x000000000061cf6f in vim_main2 () at main.c:911
#5  0x000000000061c6f8 in main (argc=3, argv=0x7fffad7831a8) at main.c:420
(gdb) p curwin
$1 = (win_T *) 0x1136db0
```

In `curs_rows(curwin)`, the value of `curwin` has changed at the point of following.

```
#0  win_close (win=0x13a8a50, free_buf=0) at window.c:2433
#1  0x000000000040821f in do_buffer (action=4, start=1, dir=1, count=2, forceit=1) at buffer.c:1476
#2  0x0000000000407b8f in do_bufdel (command=4, arg=0x1438ca8 "", addr_count=1, start_bnr=2, end_bnr=2, forceit=1) at buffer.c:1201
#3  0x0000000000477d5d in ex_bunload (eap=0x7fffad781410) at ex_docmd.c:5599
#4  0x0000000000472956 in do_one_cmd (cmdlinep=0x7fffad781630, sourcing=1, cstack=0x7fffad781720, fgetline=0x5eb0df <get_func_line>, cookie=0x13bccf0)
    at ex_docmd.c:2952
#5  0x000000000046f37e in do_cmdline (cmdline=0x1438c40 "2 bwipe!", fgetline=0x5eb0df <get_func_line>, cookie=0x13bccf0, flags=3) at ex_docmd.c:1089
#6  0x000000000043c1fa in ex_execute (eap=0x7fffad781d10) at eval.c:8369
#7  0x0000000000472956 in do_one_cmd (cmdlinep=0x7fffad781f30, sourcing=1, cstack=0x7fffad782020, fgetline=0x5eb0df <get_func_line>, cookie=0x13bccf0)
    at ex_docmd.c:2952
#8  0x000000000046f37e in do_cmdline (cmdline=0x0, fgetline=0x5eb0df <get_func_line>, cookie=0x13bccf0, flags=7) at ex_docmd.c:1089
#9  0x00000000005e5e43 in call_user_func (fp=0x1161150, argcount=3, argvars=0x7fffad782950, rettv=0x7fffad782b40, firstline=0, lastline=0, selfdict=0x0)
    at userfunc.c:942
#10 0x00000000005e6d3b in call_func (funcname=0x13beb80 "<SNR>1_exit_cb", len=14, rettv=0x7fffad782b40, argcount_in=2, argvars_in=0x7fffad782b50, argv_func=0x0,
    firstline=0, lastline=0, doesrange=0x7fffad782b3c, evaluate=1, partial=0x13beba0, selfdict_in=0x0) at userfunc.c:1427
#11 0x00000000006157ea in job_cleanup (job=0x13be000) at channel.c:5093
#12 0x0000000000615d61 in job_check_ended () at channel.c:5311
#13 0x00000000004f1456 in parse_queued_messages () at misc2.c:6347
#14 0x000000000052c3f0 in mch_inchar (buf=0x8b3316 <typebuf_init+54> "", maxlen=70, wtime=0, tb_change_cnt=1) at os_unix.c:419
#15 0x00000000005d8b00 in ui_inchar (buf=0x8b3316 <typebuf_init+54> "", maxlen=70, wtime=0, tb_change_cnt=1) at ui.c:195
#16 0x00000000004b1751 in inchar (buf=0x8b3316 <typebuf_init+54> "", maxlen=210, wait_time=0) at getchar.c:3067
#17 0x00000000004b1370 in vgetorpeek (advance=0) at getchar.c:2843
#18 0x00000000004afae7 in vpeekc () at getchar.c:1846
#19 0x00000000004afb93 in char_avail () at getchar.c:1902
#20 0x000000000057d400 in redrawing () at screen.c:10819
#21 0x00000000004f2383 in curs_rows (wp=0x13a8a50) at move.c:678
#22 0x00000000004f2d46 in curs_columns (may_scroll=1) at move.c:951
#23 0x00000000004f236f in validate_cursor () at move.c:642
#24 0x000000000061d53c in main_loop (cmdwin=0, noexmode=0) at main.c:1253
#25 0x000000000061cf6f in vim_main2 () at main.c:911
#26 0x000000000061c6f8 in main (argc=3, argv=0x7fffad7831a8) at main.c:420
```

that is, the callback (`bwipe`) is invoked in `vpeekc()` and `curwin` has changed unexpectedly.

### solution proposal

* Don't invoke callback during `vpeekc`

or, at least, should not invoke during `char_avail()`.

Ozaki Kiichi