### PR TITLE
do not close terminal when window exists

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -585,7 +585,7 @@ free_terminal(buf_T *buf)
     term_T	*term = buf->b_term;
     term_T	*tp;
 
-    if (term == NULL)
+    if (term == NULL || buf->b_nwindows > 0)
 	return;
     if (first_term == term)
 	first_term = term->tl_next;


### PR DESCRIPTION
1. :terminal
2. `<C-W>s`
3. `<C-W>:q<CR>`

This split window still have terminal but job seems to be closed.