### PR TITLE
Fix redrawing popup-menu

### DIFF
--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -64,206 +64,207 @@ pum_display(
     win_T	*pvwin;
 #endif
 
-redo:
-    def_width = PUM_DEF_WIDTH;
-    max_width = 0;
-    kind_width = 0;
-    extra_width = 0;
-    above_row = 0;
-    below_row = cmdline_row;
+    do
+    {
+	def_width = PUM_DEF_WIDTH;
+	max_width = 0;
+	kind_width = 0;
+	extra_width = 0;
+	above_row = 0;
+	below_row = cmdline_row;
 
-    /* Pretend the pum is already there to avoid that must_redraw is set when
-     * 'cuc' is on. */
-    pum_array = (pumitem_T *)1;
-    validate_cursor_col();
-    pum_array = NULL;
+	/* Pretend the pum is already there to avoid that must_redraw is set
+	 * when 'cuc' is on. */
+	pum_array = (pumitem_T *)1;
+	validate_cursor_col();
+	pum_array = NULL;
 
-    row = curwin->w_wrow + W_WINROW(curwin);
+	row = curwin->w_wrow + W_WINROW(curwin);
 
 #if defined(FEAT_QUICKFIX)
-    FOR_ALL_WINDOWS(pvwin)
-	if (pvwin->w_p_pvw)
-	    break;
-    if (pvwin != NULL)
-    {
-	if (W_WINROW(pvwin) < W_WINROW(curwin))
-	    above_row = W_WINROW(pvwin) + pvwin->w_height;
-	else if (W_WINROW(pvwin) > W_WINROW(curwin) + curwin->w_height)
-	    below_row = W_WINROW(pvwin);
-    }
+	FOR_ALL_WINDOWS(pvwin)
+	    if (pvwin->w_p_pvw)
+		break;
+	if (pvwin != NULL)
+	{
+	    if (W_WINROW(pvwin) < W_WINROW(curwin))
+		above_row = W_WINROW(pvwin) + pvwin->w_height;
+	    else if (W_WINROW(pvwin) > W_WINROW(curwin) + curwin->w_height)
+		below_row = W_WINROW(pvwin);
+	}
 #endif
 
-    /*
-     * Figure out the size and position of the pum.
-     */
-    if (size < PUM_DEF_HEIGHT)
-	pum_height = size;
-    else
-	pum_height = PUM_DEF_HEIGHT;
-    if (p_ph > 0 && pum_height > p_ph)
-	pum_height = p_ph;
-
-    /* Put the pum below "row" if possible.  If there are few lines decide on
-     * where there is more room. */
-    if (row + 2 >= below_row - pum_height
-			    && row - above_row > (below_row - above_row) / 2)
-    {
-	/* pum above "row" */
-
-	/* Leave two lines of context if possible */
-	if (curwin->w_wrow - curwin->w_cline_row >= 2)
-	    context_lines = 2;
-	else
-	    context_lines = curwin->w_wrow - curwin->w_cline_row;
-
-	if (row >= size + context_lines)
-	{
-	    pum_row = row - size - context_lines;
+	/*
+	 * Figure out the size and position of the pum.
+	 */
+	if (size < PUM_DEF_HEIGHT)
 	    pum_height = size;
-	}
 	else
-	{
-	    pum_row = 0;
-	    pum_height = row - context_lines;
-	}
-	if (p_ph > 0 && pum_height > p_ph)
-	{
-	    pum_row += pum_height - p_ph;
-	    pum_height = p_ph;
-	}
-    }
-    else
-    {
-	/* pum below "row" */
-
-	/* Leave two lines of context if possible */
-	if (curwin->w_cline_row + curwin->w_cline_height - curwin->w_wrow >= 3)
-	    context_lines = 3;
-	else
-	    context_lines = curwin->w_cline_row
-				+ curwin->w_cline_height - curwin->w_wrow;
-
-	pum_row = row + context_lines;
-	if (size > below_row - pum_row)
-	    pum_height = below_row - pum_row;
-	else
-	    pum_height = size;
+	    pum_height = PUM_DEF_HEIGHT;
 	if (p_ph > 0 && pum_height > p_ph)
 	    pum_height = p_ph;
-    }
 
-    /* don't display when we only have room for one line */
-    if (pum_height < 1 || (pum_height == 1 && size > 1))
-	return;
+	/* Put the pum below "row" if possible.  If there are few lines decide
+	 * on where there is more room. */
+	if (row + 2 >= below_row - pum_height
+			     && row - above_row > (below_row - above_row) / 2)
+	{
+	    /* pum above "row" */
+
+	    /* Leave two lines of context if possible */
+	    if (curwin->w_wrow - curwin->w_cline_row >= 2)
+		context_lines = 2;
+	    else
+		context_lines = curwin->w_wrow - curwin->w_cline_row;
+
+	    if (row >= size + context_lines)
+	    {
+		pum_row = row - size - context_lines;
+		pum_height = size;
+	    }
+	    else
+	    {
+		pum_row = 0;
+		pum_height = row - context_lines;
+	    }
+	    if (p_ph > 0 && pum_height > p_ph)
+	    {
+		pum_row += pum_height - p_ph;
+		pum_height = p_ph;
+	    }
+	}
+	else
+	{
+	    /* pum below "row" */
+
+	    /* Leave two lines of context if possible */
+	    if (curwin->w_cline_row
+			       + curwin->w_cline_height - curwin->w_wrow >= 3)
+		context_lines = 3;
+	    else
+		context_lines = curwin->w_cline_row
+				    + curwin->w_cline_height - curwin->w_wrow;
+
+	    pum_row = row + context_lines;
+	    if (size > below_row - pum_row)
+		pum_height = below_row - pum_row;
+	    else
+		pum_height = size;
+	    if (p_ph > 0 && pum_height > p_ph)
+		pum_height = p_ph;
+	}
+
+	/* don't display when we only have room for one line */
+	if (pum_height < 1 || (pum_height == 1 && size > 1))
+	    return;
 
 #if defined(FEAT_QUICKFIX)
-    /* If there is a preview window at the above avoid drawing over it. */
-    if (pvwin != NULL && pum_row < above_row && pum_height > above_row)
-    {
-	pum_row += above_row;
-	pum_height -= above_row;
-    }
-#endif
-
-    /* Compute the width of the widest match and the widest extra. */
-    for (i = 0; i < size; ++i)
-    {
-	w = vim_strsize(array[i].pum_text);
-	if (max_width < w)
-	    max_width = w;
-	if (array[i].pum_kind != NULL)
+	/* If there is a preview window at the above avoid drawing over it. */
+	if (pvwin != NULL && pum_row < above_row && pum_height > above_row)
 	{
-	    w = vim_strsize(array[i].pum_kind) + 1;
-	    if (kind_width < w)
-		kind_width = w;
+	    pum_row += above_row;
+	    pum_height -= above_row;
 	}
-	if (array[i].pum_extra != NULL)
+#endif
+
+	/* Compute the width of the widest match and the widest extra. */
+	for (i = 0; i < size; ++i)
 	{
-	    w = vim_strsize(array[i].pum_extra) + 1;
-	    if (extra_width < w)
-		extra_width = w;
+	    w = vim_strsize(array[i].pum_text);
+	    if (max_width < w)
+		max_width = w;
+	    if (array[i].pum_kind != NULL)
+	    {
+		w = vim_strsize(array[i].pum_kind) + 1;
+		if (kind_width < w)
+		    kind_width = w;
+	    }
+	    if (array[i].pum_extra != NULL)
+	    {
+		w = vim_strsize(array[i].pum_extra) + 1;
+		if (extra_width < w)
+		    extra_width = w;
+	    }
 	}
-    }
-    pum_base_width = max_width;
-    pum_kind_width = kind_width;
+	pum_base_width = max_width;
+	pum_kind_width = kind_width;
 
-    /* Calculate column */
-#ifdef FEAT_RIGHTLEFT
-    if (curwin->w_p_rl)
-	col = W_WINCOL(curwin) + W_WIDTH(curwin) - curwin->w_wcol - 1;
-    else
-#endif
-	col = W_WINCOL(curwin) + curwin->w_wcol;
-
-    /* if there are more items than room we need a scrollbar */
-    if (pum_height < size)
-    {
-	pum_scrollbar = 1;
-	++max_width;
-    }
-    else
-	pum_scrollbar = 0;
-
-    if (def_width < max_width)
-	def_width = max_width;
-
-    if (((col < Columns - PUM_DEF_WIDTH || col < Columns - max_width)
-#ifdef FEAT_RIGHTLEFT
-		&& !curwin->w_p_rl)
-	    || (curwin->w_p_rl && (col > PUM_DEF_WIDTH || col > max_width)
-#endif
-       ))
-    {
-	/* align pum column with "col" */
-	pum_col = col;
-
+	/* Calculate column */
 #ifdef FEAT_RIGHTLEFT
 	if (curwin->w_p_rl)
-	    pum_width = pum_col - pum_scrollbar + 1;
+	    col = W_WINCOL(curwin) + W_WIDTH(curwin) - curwin->w_wcol - 1;
 	else
 #endif
-	    pum_width = Columns - pum_col - pum_scrollbar;
+	    col = W_WINCOL(curwin) + curwin->w_wcol;
 
-	if (pum_width > max_width + kind_width + extra_width + 1
+	/* if there are more items than room we need a scrollbar */
+	if (pum_height < size)
+	{
+	    pum_scrollbar = 1;
+	    ++max_width;
+	}
+	else
+	    pum_scrollbar = 0;
+
+	if (def_width < max_width)
+	    def_width = max_width;
+
+	if (((col < Columns - PUM_DEF_WIDTH || col < Columns - max_width)
+#ifdef FEAT_RIGHTLEFT
+		    && !curwin->w_p_rl)
+		|| (curwin->w_p_rl && (col > PUM_DEF_WIDTH || col > max_width)
+#endif
+	   ))
+	{
+	    /* align pum column with "col" */
+	    pum_col = col;
+
+#ifdef FEAT_RIGHTLEFT
+	    if (curwin->w_p_rl)
+		pum_width = pum_col - pum_scrollbar + 1;
+	    else
+#endif
+		pum_width = Columns - pum_col - pum_scrollbar;
+
+	    if (pum_width > max_width + kind_width + extra_width + 1
 						 && pum_width > PUM_DEF_WIDTH)
-	{
-	    pum_width = max_width + kind_width + extra_width + 1;
-	    if (pum_width < PUM_DEF_WIDTH)
-		pum_width = PUM_DEF_WIDTH;
+	    {
+		pum_width = max_width + kind_width + extra_width + 1;
+		if (pum_width < PUM_DEF_WIDTH)
+		    pum_width = PUM_DEF_WIDTH;
+	    }
 	}
-    }
-    else if (Columns < def_width)
-    {
-	/* not enough room, will use what we have */
+	else if (Columns < def_width)
+	{
+	    /* not enough room, will use what we have */
 #ifdef FEAT_RIGHTLEFT
-	if (curwin->w_p_rl)
-	    pum_col = Columns - 1;
-	else
+	    if (curwin->w_p_rl)
+		pum_col = Columns - 1;
+	    else
 #endif
-	    pum_col = 0;
-	pum_width = Columns - 1;
-    }
-    else
-    {
-	if (max_width > PUM_DEF_WIDTH)
-	    max_width = PUM_DEF_WIDTH;	/* truncate */
+		pum_col = 0;
+	    pum_width = Columns - 1;
+	}
+	else
+	{
+	    if (max_width > PUM_DEF_WIDTH)
+		max_width = PUM_DEF_WIDTH;	/* truncate */
 #ifdef FEAT_RIGHTLEFT
-	if (curwin->w_p_rl)
-	    pum_col = max_width - 1;
-	else
+	    if (curwin->w_p_rl)
+		pum_col = max_width - 1;
+	    else
 #endif
-	    pum_col = Columns - max_width;
-	pum_width = max_width - pum_scrollbar;
-    }
+		pum_col = Columns - max_width;
+	    pum_width = max_width - pum_scrollbar;
+	}
 
-    pum_array = array;
-    pum_size = size;
+	pum_array = array;
+	pum_size = size;
 
-    /* Set selected item and redraw.  If the window size changed need to redo
-     * the positioning.  Limit this to two times, when there is not much
-     * room the window size will keep changing. */
-    if (pum_set_selected(selected, redo_count) && ++redo_count <= 2)
-	goto redo;
+	/* Set selected item and redraw.  If the window size changed need to
+	 * redo the positioning.  Limit this to two times, when there is not
+	 * much room the window size will keep changing. */
+    } while (pum_set_selected(selected, redo_count) && ++redo_count <= 2);
 }
 
 /*

--- a/src/term.c
+++ b/src/term.c
@@ -3271,11 +3271,10 @@ set_shellsize(int width, int height, int mustset)
 		if (pum_visible())
 		{
 		    redraw_later(NOT_VALID);
-		    ins_compl_show_pum(); /* This includes the redraw. */
+		    ins_compl_show_pum();
 		}
-		else
 #endif
-		    update_screen(NOT_VALID);
+		update_screen(NOT_VALID);
 		if (redrawing())
 		    setcursor();
 	    }

--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -162,7 +162,7 @@ func Resume()
 endfunc
 
 func s:feedkeys(timer)
-  call feedkeys('x', 'nt')
+  call feedkeys("\<c-c>", 'nt')
 endfunc
 
 " Get the command to run Vim, with -u NONE and --not-a-term arguments.


### PR DESCRIPTION
### problem

When popup-menu is displayed above the position of cursor,

1. the height of terminal maximizing makes popup-menu duplicated.

2. the height of terminal reducing makes popup-menu overlapped with cursor.

### repro steps

sample.vim

```vim
execute 'normal!' winheight('%') . 'o'
call feedkeys("Gi\<C-x>\<C-v>")
```

Precondition: terminal is not maximized (nor full-screen mode).

`vim --clean -S sample.vim`

After popup-menu is displayed, make terminal maximize.
* Point: change the height of terminal discontinuously (do not use mouse-dragging)

![](https://user-images.githubusercontent.com/18260849/29813807-2dbfbed4-8ce6-11e7-839b-16472ed9d49b.png)

the upper popup is invalid display. (problem 1)

Reset the terminal size and reduce the height of terminal. (can use mouse-dragging)

![](https://user-images.githubusercontent.com/18260849/30061933-560e5f6e-9284-11e7-989b-8b221d4bbcaa.png)

cursor is overlapped with popup. (problem 2)

### solution proposal

* Do `update_screen` after popup drawing (`ins_compl_show_pum`) also, in `set_shellsize`

NOTE:

* Changes of src/popupmnu.c is not concerned with this problem.
  I think do-while is better than goto-loop in this case.

* If it is undesirable that do `update_screen` always after `ins_compl_show_pum` in `set_shellsize`,
   check the change of `pum_row` and `pum_height` in `pum_display` and use this result to decide whether do `update_screen`.

Ozaki Kiichi
