### PR TITLE
Fix the highlighting of end-of-line

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -5325,9 +5325,12 @@ win_line(
 #ifdef FEAT_SEARCH_EXTRA
 			/* highlight 'hlsearch' match at end of line */
 			|| (prevcol_hl_flag == TRUE
-# if defined(FEAT_SYN_HL)
+# ifdef FEAT_SYN_HL
 			    && !(wp->w_p_cul && lnum == wp->w_cursor.lnum
 				    && !(wp == curwin && VIsual_active))
+# endif
+# ifdef FEAT_DIFF
+			    && diff_hlf == (hlf_T)0
 # endif
 # if defined(LINE_ATTR)
 			    && did_line_attr <= 1

--- a/src/screen.c
+++ b/src/screen.c
@@ -5059,10 +5059,6 @@ win_line(
 # endif
 					    < W_WIDTH(wp))))
 		{
-		    long n = (v - (wp->w_p_wrap
-					    ? wp->w_skipcol
-					    : wp->w_leftcol)) % W_WIDTH(wp);
-
 		    /* Highlight until the right side of the window */
 		    c = ' ';
 		    --ptr;	    /* put it back at the NUL */
@@ -5071,11 +5067,9 @@ win_line(
 		    ++did_line_attr;
 
 		    /* don't do search HL for the rest of the line */
-		    if (line_attr != 0 && char_attr == search_attr && (
-# ifdef FEAT_RIGHTLEFT
-			    wp->w_p_rl ? W_WIDTH(wp) - col > n + 1 :
-# endif
-			    col > n))
+		    if (line_attr != 0 && char_attr == search_attr
+					&& (did_line_attr > 1
+					    || (wp->w_p_list && lcs_eol > 0)))
 			char_attr = line_attr;
 # ifdef FEAT_DIFF
 		    if (diff_hlf == HLF_TXD)

--- a/src/screen.c
+++ b/src/screen.c
@@ -5323,6 +5323,10 @@ win_line(
 #ifdef FEAT_SEARCH_EXTRA
 			/* highlight 'hlsearch' match at end of line */
 			|| (prevcol_hl_flag == TRUE
+# if defined(FEAT_SYN_HL)
+			    && !(wp->w_p_cul && lnum == wp->w_cursor.lnum
+				    && !(wp == curwin && VIsual_active))
+# endif
 # if defined(LINE_ATTR)
 			    && did_line_attr <= 1
 # endif

--- a/src/screen.c
+++ b/src/screen.c
@@ -5067,7 +5067,7 @@ win_line(
 		    ++did_line_attr;
 
 		    /* don't do search HL for the rest of the line */
-		    if (line_attr != 0 && char_attr == search_attr && col > 0)
+		    if (line_attr != 0 && char_attr == search_attr && col > v)
 			char_attr = line_attr;
 # ifdef FEAT_DIFF
 		    if (diff_hlf == HLF_TXD)

--- a/src/screen.c
+++ b/src/screen.c
@@ -5059,6 +5059,10 @@ win_line(
 # endif
 					    < W_WIDTH(wp))))
 		{
+		    long n = (v - (wp->w_p_wrap
+					    ? wp->w_skipcol
+					    : wp->w_leftcol)) % W_WIDTH(wp);
+
 		    /* Highlight until the right side of the window */
 		    c = ' ';
 		    --ptr;	    /* put it back at the NUL */
@@ -5069,9 +5073,9 @@ win_line(
 		    /* don't do search HL for the rest of the line */
 		    if (line_attr != 0 && char_attr == search_attr && (
 # ifdef FEAT_RIGHTLEFT
-			    wp->w_p_rl ? W_WIDTH(wp) - col > v + 1 :
+			    wp->w_p_rl ? W_WIDTH(wp) - col > n + 1 :
 # endif
-			    col > v))
+			    col > n))
 			char_attr = line_attr;
 # ifdef FEAT_DIFF
 		    if (diff_hlf == HLF_TXD)

--- a/src/screen.c
+++ b/src/screen.c
@@ -5067,7 +5067,11 @@ win_line(
 		    ++did_line_attr;
 
 		    /* don't do search HL for the rest of the line */
-		    if (line_attr != 0 && char_attr == search_attr && col > v)
+		    if (line_attr != 0 && char_attr == search_attr && (
+# ifdef FEAT_RIGHTLEFT
+			    wp->w_p_rl ? W_WIDTH(wp) - col > v + 1 :
+# endif
+			    col > v))
 			char_attr = line_attr;
 # ifdef FEAT_DIFF
 		    if (diff_hlf == HLF_TXD)

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -1,4 +1,7 @@
-" Tests for ":highlight".
+" Tests for ":highlight" and highlighting.
+
+source view_util.vim
+
 func Test_highlight()
   " basic test if ":highlight" doesn't crash
   highlight
@@ -33,4 +36,163 @@ func Test_highlight()
   call assert_equal("Group3         xxx cleared",
 				\ split(execute("hi Group3"), "\n")[0])
   call assert_fails("hi Crash term='asdf", "E475:")
+endfunc
+
+function! HighlightArgs(name)
+  return 'hi ' . substitute(split(execute('hi ' . a:name), '\n')[0], '\<xxx\>', '', '')
+endfunction
+
+function! HiCursorLine()
+  let hiCursorLine = HighlightArgs('CursorLine')
+  if has('gui_running')
+    let hi_ul = 'hi CursorLine gui=underline guibg=NONE'
+    let hi_bg = hiCursorLine
+  else
+    let hi_ul = hiCursorLine
+    let hi_bg = 'hi CursorLine cterm=NONE ctermbg=Gray'
+  endif
+  return [hiCursorLine, hi_ul, hi_bg]
+endfunction
+
+func Test_highlight_eol_with_cursorline()
+  let [hiCursorLine, hi_ul, hi_bg] = HiCursorLine()
+
+  call NewWindow('topleft 5', 20)
+  call setline(1, 'abcd')
+  call matchadd('Search', '\n')
+
+  let expected = "abcd      "
+  let actual = ScreenLines(1, 10)[0]
+  call assert_equal(expected, actual)
+
+  " expected:
+  " 'abcd      '
+  "  ^^^^ ^^^^^   no highlight
+  "      ^        'Search' highlight
+  let attrs0 = ScreenAttrs(1, 10)[0]
+  call assert_equal(repeat([attrs0[0]], 4), attrs0[0:3])
+  call assert_equal(repeat([attrs0[0]], 5), attrs0[5:9])
+  call assert_notequal(attrs0[0], attrs0[4])
+
+  setlocal cursorline
+
+  " underline
+  exe hi_ul
+  redraw!
+
+  let actual = ScreenLines(1, 10)[0]
+  call assert_equal(expected, actual)
+  let attrs = ScreenAttrs(1, 10)[0]
+
+  " expected:
+  " 'abcd      '
+  "  ^^^^         underline
+  "      ^^^^^^   'Search' highlight with underline
+  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+  call assert_equal(repeat([attrs[4]], 6), attrs[4:9])
+  call assert_notequal(attrs[0], attrs[4])
+  call assert_notequal(attrs0[0], attrs[0])
+  call assert_notequal(attrs0[4], attrs[4])
+
+  " bg-color
+  exe hi_bg
+  redraw!
+
+  let actual = ScreenLines(1, 10)[0]
+  call assert_equal(expected, actual)
+  let attrs = ScreenAttrs(1, 10)[0]
+
+  " expected:
+  " 'abcd      '
+  "  ^^^^         bg-color of 'CursorLine'
+  "      ^        'Search' highlight
+  "       ^^^^^   bg-color of 'CursorLine'
+  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+  call assert_equal(repeat([attrs[5]], 5), attrs[5:9])
+  call assert_equal(attrs0[4], attrs[4])
+  call assert_notequal(attrs[0], attrs[4])
+  call assert_notequal(attrs[4], attrs[5])
+  call assert_notequal(attrs0[0], attrs[0])
+  call assert_notequal(attrs0[5], attrs[5])
+
+  call CloseWindow()
+  exe hiCursorLine
+endfunc
+
+func Test_highlight_eol_with_cursorline_vertsplit()
+  if !has('vertsplit')
+    return
+  endif
+
+  let [hiCursorLine, hi_ul, hi_bg] = HiCursorLine()
+
+  call NewWindow('topleft 5', 5)
+  call setline(1, 'abcd')
+  call matchadd('Search', '\n')
+
+  let expected = "abcd |abcd     "
+  let actual = ScreenLines(1, 15)[0]
+  call assert_equal(expected, actual)
+
+  " expected:
+  " 'abcd |abcd     '
+  "  ^^^^  ^^^^^^^^^   no highlight
+  "      ^             'Search' highlight
+  "       ^            'VertSplit' highlight
+  let attrs0 = ScreenAttrs(1, 15)[0]
+  call assert_equal(repeat([attrs0[0]], 4), attrs0[0:3])
+  call assert_equal(repeat([attrs0[0]], 9), attrs0[6:14])
+  call assert_notequal(attrs0[0], attrs0[4])
+  call assert_notequal(attrs0[0], attrs0[5])
+  call assert_notequal(attrs0[4], attrs0[5])
+
+  setlocal cursorline
+
+  " expected:
+  " 'abcd |abcd     '
+  "  ^^^^              underline
+  "      ^             'Search' highlight with underline
+  "       ^            'VertSplit' highlight
+  "        ^^^^^^^^^   no highlight
+
+  " underline
+  exe hi_ul
+  redraw!
+
+  let actual = ScreenLines(1, 15)[0]
+  call assert_equal(expected, actual)
+
+  let attrs = ScreenAttrs(1, 15)[0]
+  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+  call assert_equal(repeat([attrs[6]], 9), attrs[6:14])
+  call assert_equal(attrs0[5:14], attrs[5:14])
+  call assert_notequal(attrs[0], attrs[4])
+  call assert_notequal(attrs[0], attrs[5])
+  call assert_notequal(attrs[0], attrs[6])
+  call assert_notequal(attrs[4], attrs[5])
+  call assert_notequal(attrs[5], attrs[6])
+  call assert_notequal(attrs0[0], attrs[0])
+  call assert_notequal(attrs0[4], attrs[4])
+
+  " bg-color
+  exe hi_bg
+  redraw!
+
+  let actual = ScreenLines(1, 15)[0]
+  call assert_equal(expected, actual)
+
+  let attrs = ScreenAttrs(1, 15)[0]
+  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+  call assert_equal(repeat([attrs[6]], 9), attrs[6:14])
+  call assert_equal(attrs0[5:14], attrs[5:14])
+  call assert_notequal(attrs[0], attrs[4])
+  call assert_notequal(attrs[0], attrs[5])
+  call assert_notequal(attrs[0], attrs[6])
+  call assert_notequal(attrs[4], attrs[5])
+  call assert_notequal(attrs[5], attrs[6])
+  call assert_notequal(attrs0[0], attrs[0])
+  call assert_equal(attrs0[4], attrs[4])
+
+  call CloseWindow()
+  exe hiCursorLine
 endfunc

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -450,3 +450,30 @@ func Test_highlight_eol_with_cursorline_breakindent()
   set showbreak=
   exe hiCursorLine
 endfunc
+
+func Test_highlight_eol_on_diff()
+  call setline(1, ['abcd', ''])
+  call matchadd('Search', '\n')
+  let attrs0 = ScreenAttrs(1, 10)[0]
+
+  diffthis
+  botright new
+  diffthis
+
+  " expected:
+  " '  abcd    '
+  "  ^^           sign
+  "    ^^^^ ^^^   'DiffAdd' highlight
+  "        ^      'Search' highlight
+  let attrs = ScreenAttrs(1, 10)[0]
+  call assert_equal(repeat([attrs[0]], 2), attrs[0:1])
+  call assert_equal(repeat([attrs[2]], 4), attrs[2:5])
+  call assert_equal(repeat([attrs[2]], 3), attrs[7:9])
+  call assert_equal(attrs0[4], attrs[6])
+  call assert_notequal(attrs[0], attrs[2])
+  call assert_notequal(attrs[0], attrs[6])
+  call assert_notequal(attrs[2], attrs[6])
+
+  bwipe!
+  diffoff
+endfunc

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -42,13 +42,18 @@ function! HighlightArgs(name)
   return 'hi ' . substitute(split(execute('hi ' . a:name), '\n')[0], '\<xxx\>', '', '')
 endfunction
 
+function! IsColorable()
+  return has('gui_running') || str2nr(&t_Co) >= 8
+endfunction
+
 function! HiCursorLine()
   let hiCursorLine = HighlightArgs('CursorLine')
   if has('gui_running')
+    let guibg = matchstr(hiCursorLine, 'guibg=\w\+')
     let hi_ul = 'hi CursorLine gui=underline guibg=NONE'
-    let hi_bg = hiCursorLine
+    let hi_bg = 'hi CursorLine gui=NONE ' . guibg
   else
-    let hi_ul = hiCursorLine
+    let hi_ul = 'hi CursorLine cterm=underline ctermbg=NONE'
     let hi_bg = 'hi CursorLine cterm=NONE ctermbg=Gray'
   endif
   return [hiCursorLine, hi_ul, hi_bg]
@@ -94,26 +99,28 @@ func Test_highlight_eol_with_cursorline()
   call assert_notequal(attrs0[0], attrs[0])
   call assert_notequal(attrs0[4], attrs[4])
 
-  " bg-color
-  exe hi_bg
-  redraw!
+  if IsColorable()
+    " bg-color
+    exe hi_bg
+    redraw!
 
-  let actual = ScreenLines(1, 10)[0]
-  call assert_equal(expected, actual)
-  let attrs = ScreenAttrs(1, 10)[0]
+    let actual = ScreenLines(1, 10)[0]
+    call assert_equal(expected, actual)
+    let attrs = ScreenAttrs(1, 10)[0]
 
-  " expected:
-  " 'abcd      '
-  "  ^^^^         bg-color of 'CursorLine'
-  "      ^        'Search' highlight
-  "       ^^^^^   bg-color of 'CursorLine'
-  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
-  call assert_equal(repeat([attrs[5]], 5), attrs[5:9])
-  call assert_equal(attrs0[4], attrs[4])
-  call assert_notequal(attrs[0], attrs[4])
-  call assert_notequal(attrs[4], attrs[5])
-  call assert_notequal(attrs0[0], attrs[0])
-  call assert_notequal(attrs0[5], attrs[5])
+    " expected:
+    " 'abcd      '
+    "  ^^^^         bg-color of 'CursorLine'
+    "      ^        'Search' highlight
+    "       ^^^^^   bg-color of 'CursorLine'
+    call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+    call assert_equal(repeat([attrs[5]], 5), attrs[5:9])
+    call assert_equal(attrs0[4], attrs[4])
+    call assert_notequal(attrs[0], attrs[4])
+    call assert_notequal(attrs[4], attrs[5])
+    call assert_notequal(attrs0[0], attrs[0])
+    call assert_notequal(attrs0[5], attrs[5])
+  endif
 
   call CloseWindow()
   exe hiCursorLine
@@ -174,24 +181,26 @@ func Test_highlight_eol_with_cursorline_vertsplit()
   call assert_notequal(attrs0[0], attrs[0])
   call assert_notequal(attrs0[4], attrs[4])
 
-  " bg-color
-  exe hi_bg
-  redraw!
+  if IsColorable()
+    " bg-color
+    exe hi_bg
+    redraw!
 
-  let actual = ScreenLines(1, 15)[0]
-  call assert_equal(expected, actual)
+    let actual = ScreenLines(1, 15)[0]
+    call assert_equal(expected, actual)
 
-  let attrs = ScreenAttrs(1, 15)[0]
-  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
-  call assert_equal(repeat([attrs[6]], 9), attrs[6:14])
-  call assert_equal(attrs0[5:14], attrs[5:14])
-  call assert_notequal(attrs[0], attrs[4])
-  call assert_notequal(attrs[0], attrs[5])
-  call assert_notequal(attrs[0], attrs[6])
-  call assert_notequal(attrs[4], attrs[5])
-  call assert_notequal(attrs[5], attrs[6])
-  call assert_notequal(attrs0[0], attrs[0])
-  call assert_equal(attrs0[4], attrs[4])
+    let attrs = ScreenAttrs(1, 15)[0]
+    call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+    call assert_equal(repeat([attrs[6]], 9), attrs[6:14])
+    call assert_equal(attrs0[5:14], attrs[5:14])
+    call assert_notequal(attrs[0], attrs[4])
+    call assert_notequal(attrs[0], attrs[5])
+    call assert_notequal(attrs[0], attrs[6])
+    call assert_notequal(attrs[4], attrs[5])
+    call assert_notequal(attrs[5], attrs[6])
+    call assert_notequal(attrs0[0], attrs[0])
+    call assert_equal(attrs0[4], attrs[4])
+  endif
 
   call CloseWindow()
   exe hiCursorLine
@@ -227,23 +236,25 @@ func Test_highlight_eol_with_cursorline_rightleft()
   call assert_notequal(attrs0[9], attrs[9])
   call assert_notequal(attrs0[5], attrs[5])
 
-  " bg-color
-  exe hi_bg
-  redraw!
+  if IsColorable()
+    " bg-color
+    exe hi_bg
+    redraw!
 
-  " expected:
-  " '      dcba'
-  "        ^^^^   bg-color of 'CursorLine'
-  "       ^       'Search' highlight
-  "  ^^^^^        bg-color of 'CursorLine'
-  let attrs = ScreenAttrs(1, 10)[0]
-  call assert_equal(repeat([attrs[9]], 4), attrs[6:9])
-  call assert_equal(repeat([attrs[4]], 5), attrs[0:4])
-  call assert_equal(attrs0[5], attrs[5])
-  call assert_notequal(attrs[9], attrs[5])
-  call assert_notequal(attrs[5], attrs[4])
-  call assert_notequal(attrs0[9], attrs[9])
-  call assert_notequal(attrs0[4], attrs[4])
+    " expected:
+    " '      dcba'
+    "        ^^^^   bg-color of 'CursorLine'
+    "       ^       'Search' highlight
+    "  ^^^^^        bg-color of 'CursorLine'
+    let attrs = ScreenAttrs(1, 10)[0]
+    call assert_equal(repeat([attrs[9]], 4), attrs[6:9])
+    call assert_equal(repeat([attrs[4]], 5), attrs[0:4])
+    call assert_equal(attrs0[5], attrs[5])
+    call assert_notequal(attrs[9], attrs[5])
+    call assert_notequal(attrs[5], attrs[4])
+    call assert_notequal(attrs0[9], attrs[9])
+    call assert_notequal(attrs0[4], attrs[4])
+  endif
 
   call CloseWindow()
   exe hiCursorLine

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -196,3 +196,55 @@ func Test_highlight_eol_with_cursorline_vertsplit()
   call CloseWindow()
   exe hiCursorLine
 endfunc
+
+func Test_highlight_eol_with_cursorline_rightleft()
+  if !has('rightleft')
+    return
+  endif
+
+  let [hiCursorLine, hi_ul, hi_bg] = HiCursorLine()
+
+  call NewWindow('topleft 5', 10)
+  setlocal rightleft
+  call setline(1, 'abcd')
+  call matchadd('Search', '\n')
+  let attrs0 = ScreenAttrs(1, 10)[0]
+
+  setlocal cursorline
+
+  " underline
+  exe hi_ul
+  redraw!
+
+  " expected:
+  " '      dcba'
+  "        ^^^^   underline
+  "  ^^^^^^       'Search' highlight with underline
+  let attrs = ScreenAttrs(1, 10)[0]
+  call assert_equal(repeat([attrs[9]], 4), attrs[6:9])
+  call assert_equal(repeat([attrs[5]], 6), attrs[0:5])
+  call assert_notequal(attrs[9], attrs[5])
+  call assert_notequal(attrs0[9], attrs[9])
+  call assert_notequal(attrs0[5], attrs[5])
+
+  " bg-color
+  exe hi_bg
+  redraw!
+
+  " expected:
+  " '      dcba'
+  "        ^^^^   bg-color of 'CursorLine'
+  "       ^       'Search' highlight
+  "  ^^^^^        bg-color of 'CursorLine'
+  let attrs = ScreenAttrs(1, 10)[0]
+  call assert_equal(repeat([attrs[9]], 4), attrs[6:9])
+  call assert_equal(repeat([attrs[4]], 5), attrs[0:4])
+  call assert_equal(attrs0[5], attrs[5])
+  call assert_notequal(attrs[9], attrs[5])
+  call assert_notequal(attrs[5], attrs[4])
+  call assert_notequal(attrs0[9], attrs[9])
+  call assert_notequal(attrs0[4], attrs[4])
+
+  call CloseWindow()
+  exe hiCursorLine
+endfunc

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -66,10 +66,6 @@ func Test_highlight_eol_with_cursorline()
   call setline(1, 'abcd')
   call matchadd('Search', '\n')
 
-  let expected = "abcd      "
-  let actual = ScreenLines(1, 10)[0]
-  call assert_equal(expected, actual)
-
   " expected:
   " 'abcd      '
   "  ^^^^ ^^^^^   no highlight
@@ -85,14 +81,11 @@ func Test_highlight_eol_with_cursorline()
   exe hi_ul
   redraw!
 
-  let actual = ScreenLines(1, 10)[0]
-  call assert_equal(expected, actual)
-  let attrs = ScreenAttrs(1, 10)[0]
-
   " expected:
   " 'abcd      '
   "  ^^^^         underline
   "      ^^^^^^   'Search' highlight with underline
+  let attrs = ScreenAttrs(1, 10)[0]
   call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
   call assert_equal(repeat([attrs[4]], 6), attrs[4:9])
   call assert_notequal(attrs[0], attrs[4])
@@ -104,15 +97,12 @@ func Test_highlight_eol_with_cursorline()
     exe hi_bg
     redraw!
 
-    let actual = ScreenLines(1, 10)[0]
-    call assert_equal(expected, actual)
-    let attrs = ScreenAttrs(1, 10)[0]
-
     " expected:
     " 'abcd      '
     "  ^^^^         bg-color of 'CursorLine'
     "      ^        'Search' highlight
     "       ^^^^^   bg-color of 'CursorLine'
+    let attrs = ScreenAttrs(1, 10)[0]
     call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
     call assert_equal(repeat([attrs[5]], 5), attrs[5:9])
     call assert_equal(attrs0[4], attrs[4])
@@ -254,6 +244,99 @@ func Test_highlight_eol_with_cursorline_rightleft()
     call assert_notequal(attrs[5], attrs[4])
     call assert_notequal(attrs0[9], attrs[9])
     call assert_notequal(attrs0[4], attrs[4])
+  endif
+
+  call CloseWindow()
+  exe hiCursorLine
+endfunc
+
+func Test_highlight_eol_with_cursorline_linewrap()
+  let [hiCursorLine, hi_ul, hi_bg] = HiCursorLine()
+
+  call NewWindow('topleft 5', 10)
+  call setline(1, [repeat('a', 51) . 'bcd', ''])
+  call matchadd('Search', '\n')
+
+  setlocal wrap
+  normal! gg$
+  redraw!
+  let attrs0 = ScreenAttrs(5, 10)[0]
+  setlocal cursorline
+
+  " underline
+  exe hi_ul
+  redraw!
+
+  " expected:
+  " 'abcd      '
+  "  ^^^^         underline
+  "      ^^^^^^   'Search' highlight with underline
+  let attrs = ScreenAttrs(5, 10)[0]
+  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+  call assert_equal(repeat([attrs[4]], 6), attrs[4:9])
+  call assert_notequal(attrs[0], attrs[4])
+  call assert_notequal(attrs0[0], attrs[0])
+  call assert_notequal(attrs0[4], attrs[4])
+
+  if IsColorable()
+    " bg-color
+    exe hi_bg
+    redraw!
+
+    " expected:
+    " 'abcd      '
+    "  ^^^^         bg-color of 'CursorLine'
+    "      ^        'Search' highlight
+    "       ^^^^^   bg-color of 'CursorLine'
+    let attrs = ScreenAttrs(5, 10)[0]
+    call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+    call assert_equal(repeat([attrs[5]], 5), attrs[5:9])
+    call assert_equal(attrs0[4], attrs[4])
+    call assert_notequal(attrs[0], attrs[4])
+    call assert_notequal(attrs[4], attrs[5])
+    call assert_notequal(attrs0[0], attrs[0])
+    call assert_notequal(attrs0[5], attrs[5])
+  endif
+
+  setlocal nocursorline nowrap
+  normal! gg$
+  redraw!
+  let attrs0 = ScreenAttrs(1, 10)[0]
+  setlocal cursorline
+
+  " underline
+  exe hi_ul
+  redraw!
+
+  " expected:
+  " 'aaabcd    '
+  "  ^^^^^^       underline
+  "        ^^^^   'Search' highlight with underline
+  let attrs = ScreenAttrs(1, 10)[0]
+  call assert_equal(repeat([attrs[0]], 6), attrs[0:5])
+  call assert_equal(repeat([attrs[6]], 4), attrs[6:9])
+  call assert_notequal(attrs[0], attrs[6])
+  call assert_notequal(attrs0[0], attrs[0])
+  call assert_notequal(attrs0[6], attrs[6])
+
+  if IsColorable()
+    " bg-color
+    exe hi_bg
+    redraw!
+
+    " expected:
+    " 'aaabcd    '
+    "  ^^^^^^       bg-color of 'CursorLine'
+    "        ^      'Search' highlight
+    "         ^^^   bg-color of 'CursorLine'
+    let attrs = ScreenAttrs(1, 10)[0]
+    call assert_equal(repeat([attrs[0]], 6), attrs[0:5])
+    call assert_equal(repeat([attrs[7]], 3), attrs[7:9])
+    call assert_equal(attrs0[6], attrs[6])
+    call assert_notequal(attrs[0], attrs[6])
+    call assert_notequal(attrs[6], attrs[7])
+    call assert_notequal(attrs0[0], attrs[0])
+    call assert_notequal(attrs0[7], attrs[7])
   endif
 
   call CloseWindow()

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -79,7 +79,6 @@ func Test_highlight_eol_with_cursorline()
 
   " underline
   exe hi_ul
-  redraw!
 
   " expected:
   " 'abcd      '
@@ -95,7 +94,6 @@ func Test_highlight_eol_with_cursorline()
   if IsColorable()
     " bg-color
     exe hi_bg
-    redraw!
 
     " expected:
     " 'abcd      '
@@ -154,7 +152,6 @@ func Test_highlight_eol_with_cursorline_vertsplit()
 
   " underline
   exe hi_ul
-  redraw!
 
   let actual = ScreenLines(1, 15)[0]
   call assert_equal(expected, actual)
@@ -174,7 +171,6 @@ func Test_highlight_eol_with_cursorline_vertsplit()
   if IsColorable()
     " bg-color
     exe hi_bg
-    redraw!
 
     let actual = ScreenLines(1, 15)[0]
     call assert_equal(expected, actual)
@@ -213,7 +209,6 @@ func Test_highlight_eol_with_cursorline_rightleft()
 
   " underline
   exe hi_ul
-  redraw!
 
   " expected:
   " '      dcba'
@@ -229,7 +224,6 @@ func Test_highlight_eol_with_cursorline_rightleft()
   if IsColorable()
     " bg-color
     exe hi_bg
-    redraw!
 
     " expected:
     " '      dcba'
@@ -259,13 +253,11 @@ func Test_highlight_eol_with_cursorline_linewrap()
 
   setlocal wrap
   normal! gg$
-  redraw!
   let attrs0 = ScreenAttrs(5, 10)[0]
   setlocal cursorline
 
   " underline
   exe hi_ul
-  redraw!
 
   " expected:
   " 'abcd      '
@@ -281,7 +273,6 @@ func Test_highlight_eol_with_cursorline_linewrap()
   if IsColorable()
     " bg-color
     exe hi_bg
-    redraw!
 
     " expected:
     " 'abcd      '
@@ -300,13 +291,11 @@ func Test_highlight_eol_with_cursorline_linewrap()
 
   setlocal nocursorline nowrap
   normal! gg$
-  redraw!
   let attrs0 = ScreenAttrs(1, 10)[0]
   setlocal cursorline
 
   " underline
   exe hi_ul
-  redraw!
 
   " expected:
   " 'aaabcd    '
@@ -322,7 +311,6 @@ func Test_highlight_eol_with_cursorline_linewrap()
   if IsColorable()
     " bg-color
     exe hi_bg
-    redraw!
 
     " expected:
     " 'aaabcd    '
@@ -361,7 +349,6 @@ func Test_highlight_eol_with_cursorline_sign()
 
   " underline
   exe hi_ul
-  redraw!
 
   " expected:
   " '>>abcd    '
@@ -378,7 +365,6 @@ func Test_highlight_eol_with_cursorline_sign()
   if IsColorable()
     " bg-color
     exe hi_bg
-    redraw!
 
     " expected:
     " '>>abcd    '
@@ -417,7 +403,6 @@ func Test_highlight_eol_with_cursorline_breakindent()
 
   " underline
   exe hi_ul
-  redraw!
 
   " expected:
   " '  >bcd    '
@@ -439,7 +424,6 @@ func Test_highlight_eol_with_cursorline_breakindent()
   if IsColorable()
     " bg-color
     exe hi_bg
-    redraw!
 
     " expected:
     " '  >bcd    '

--- a/src/testdir/test_match.vim
+++ b/src/testdir/test_match.vim
@@ -1,6 +1,8 @@
 " Test for :match, :2match, :3match, clearmatches(), getmatches(), matchadd(),
 " matchaddpos(), matcharg(), matchdelete(), and setmatches().
 
+source view_util.vim
+
 function Test_match()
   highlight MyGroup1 term=bold ctermbg=red guibg=red
   highlight MyGroup2 term=italic ctermbg=green guibg=green
@@ -217,6 +219,92 @@ func Test_matchaddpos_using_negative_priority()
 
   nohl
   set hlsearch&
+endfunc
+
+func Test_matchadd_eol_with_cursorline_1()
+  call NewWindow('topleft 5', 20)
+  call setline(1, 'abcd')
+  call matchadd('Search', '\n')
+
+  let expected = "abcd      "
+  let actual = ScreenLines(1, 10)[0]
+  call assert_equal(expected, actual)
+
+  " expected:
+  " 'abcd      '
+  "  ^^^^ ^^^^^   no highlight
+  "      ^        'Search' highlight
+  let attrs0 = ScreenAttrs(1, 10)[0]
+  call assert_equal(repeat([attrs0[0]], 4), attrs0[0:3])
+  call assert_equal(repeat([attrs0[0]], 5), attrs0[5:9])
+  call assert_notequal(attrs0[0], attrs0[4])
+
+  setlocal cursorline
+  redraw!
+
+  let actual = ScreenLines(1, 10)[0]
+  call assert_equal(expected, actual)
+
+  " expected:
+  " 'abcd      '
+  "  ^^^^         underline
+  "      ^^^^^^   'Search' highlight with underline
+  let attrs = ScreenAttrs(1, 10)[0]
+  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+  call assert_equal(repeat([attrs[4]], 6), attrs[4:9])
+  call assert_notequal(attrs[0], attrs[4])
+  call assert_notequal(attrs0[0], attrs[0])
+  call assert_notequal(attrs0[4], attrs[4])
+
+  call CloseWindow()
+endfunc
+
+func Test_matchadd_eol_with_cursorline_2()
+  call NewWindow('topleft 5', 5)
+  call setline(1, 'abcd')
+  call matchadd('Search', '\n')
+
+  let expected = "abcd |abcd     "
+  let actual = ScreenLines(1, 15)[0]
+  call assert_equal(expected, actual)
+
+  " expected:
+  " 'abcd |abcd     '
+  "  ^^^^  ^^^^^^^^^   no highlight
+  "      ^             'Search' highlight
+  "       ^            'VertSplit' highlight
+  let attrs0 = ScreenAttrs(1, 15)[0]
+  call assert_equal(repeat([attrs0[0]], 4), attrs0[0:3])
+  call assert_equal(repeat([attrs0[0]], 9), attrs0[6:14])
+  call assert_notequal(attrs0[0], attrs0[4])
+  call assert_notequal(attrs0[0], attrs0[5])
+  call assert_notequal(attrs0[4], attrs0[5])
+
+  setlocal cursorline
+  redraw!
+
+  let actual = ScreenLines(1, 15)[0]
+  call assert_equal(expected, actual)
+
+  " expected:
+  " 'abcd |abcd     '
+  "  ^^^^              underline
+  "      ^             'Search' highlight with underline
+  "       ^            'VertSplit' highlight
+  "        ^^^^^^^^^   no highlight
+  let attrs = ScreenAttrs(1, 15)[0]
+  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+  call assert_equal(repeat([attrs[6]], 9), attrs[6:14])
+  call assert_equal(attrs0[5:14], attrs[5:14])
+  call assert_notequal(attrs[0], attrs[4])
+  call assert_notequal(attrs[0], attrs[5])
+  call assert_notequal(attrs[0], attrs[6])
+  call assert_notequal(attrs[4], attrs[5])
+  call assert_notequal(attrs[5], attrs[6])
+  call assert_notequal(attrs0[0], attrs[0])
+  call assert_notequal(attrs0[4], attrs[4])
+
+  call CloseWindow()
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_match.vim
+++ b/src/testdir/test_match.vim
@@ -245,16 +245,31 @@ func Test_matchadd_eol_with_cursorline_1()
   let actual = ScreenLines(1, 10)[0]
   call assert_equal(expected, actual)
 
-  " expected:
-  " 'abcd      '
-  "  ^^^^         underline
-  "      ^^^^^^   'Search' highlight with underline
   let attrs = ScreenAttrs(1, 10)[0]
-  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
-  call assert_equal(repeat([attrs[4]], 6), attrs[4:9])
-  call assert_notequal(attrs[0], attrs[4])
-  call assert_notequal(attrs0[0], attrs[0])
-  call assert_notequal(attrs0[4], attrs[4])
+  if has('gui_running')
+    " expected:
+    " 'abcd      '
+    "  ^^^^         guibg of 'CursorLine'
+    "      ^        'Search' highlight
+    "       ^^^^^   guibg of 'CursorLine'
+    call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+    call assert_equal(repeat([attrs[5]], 5), attrs[5:9])
+    call assert_equal(attrs0[4], attrs[4])
+    call assert_notequal(attrs[0], attrs[4])
+    call assert_notequal(attrs[4], attrs[5])
+    call assert_notequal(attrs0[0], attrs[0])
+    call assert_notequal(attrs0[5], attrs[5])
+  else
+    " expected:
+    " 'abcd      '
+    "  ^^^^         underline
+    "      ^^^^^^   'Search' highlight with underline
+    call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
+    call assert_equal(repeat([attrs[4]], 6), attrs[4:9])
+    call assert_notequal(attrs[0], attrs[4])
+    call assert_notequal(attrs0[0], attrs[0])
+    call assert_notequal(attrs0[4], attrs[4])
+  endif
 
   call CloseWindow()
 endfunc
@@ -302,7 +317,11 @@ func Test_matchadd_eol_with_cursorline_2()
   call assert_notequal(attrs[4], attrs[5])
   call assert_notequal(attrs[5], attrs[6])
   call assert_notequal(attrs0[0], attrs[0])
-  call assert_notequal(attrs0[4], attrs[4])
+  if has('gui_running')
+    call assert_equal(attrs0[4], attrs[4])
+  else
+    call assert_notequal(attrs0[4], attrs[4])
+  endif
 
   call CloseWindow()
 endfunc

--- a/src/testdir/test_match.vim
+++ b/src/testdir/test_match.vim
@@ -1,8 +1,6 @@
 " Test for :match, :2match, :3match, clearmatches(), getmatches(), matchadd(),
 " matchaddpos(), matcharg(), matchdelete(), and setmatches().
 
-source view_util.vim
-
 function Test_match()
   highlight MyGroup1 term=bold ctermbg=red guibg=red
   highlight MyGroup2 term=italic ctermbg=green guibg=green
@@ -219,111 +217,6 @@ func Test_matchaddpos_using_negative_priority()
 
   nohl
   set hlsearch&
-endfunc
-
-func Test_matchadd_eol_with_cursorline_1()
-  call NewWindow('topleft 5', 20)
-  call setline(1, 'abcd')
-  call matchadd('Search', '\n')
-
-  let expected = "abcd      "
-  let actual = ScreenLines(1, 10)[0]
-  call assert_equal(expected, actual)
-
-  " expected:
-  " 'abcd      '
-  "  ^^^^ ^^^^^   no highlight
-  "      ^        'Search' highlight
-  let attrs0 = ScreenAttrs(1, 10)[0]
-  call assert_equal(repeat([attrs0[0]], 4), attrs0[0:3])
-  call assert_equal(repeat([attrs0[0]], 5), attrs0[5:9])
-  call assert_notequal(attrs0[0], attrs0[4])
-
-  setlocal cursorline
-  redraw!
-
-  let actual = ScreenLines(1, 10)[0]
-  call assert_equal(expected, actual)
-
-  let attrs = ScreenAttrs(1, 10)[0]
-  if has('gui_running')
-    " expected:
-    " 'abcd      '
-    "  ^^^^         guibg of 'CursorLine'
-    "      ^        'Search' highlight
-    "       ^^^^^   guibg of 'CursorLine'
-    call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
-    call assert_equal(repeat([attrs[5]], 5), attrs[5:9])
-    call assert_equal(attrs0[4], attrs[4])
-    call assert_notequal(attrs[0], attrs[4])
-    call assert_notequal(attrs[4], attrs[5])
-    call assert_notequal(attrs0[0], attrs[0])
-    call assert_notequal(attrs0[5], attrs[5])
-  else
-    " expected:
-    " 'abcd      '
-    "  ^^^^         underline
-    "      ^^^^^^   'Search' highlight with underline
-    call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
-    call assert_equal(repeat([attrs[4]], 6), attrs[4:9])
-    call assert_notequal(attrs[0], attrs[4])
-    call assert_notequal(attrs0[0], attrs[0])
-    call assert_notequal(attrs0[4], attrs[4])
-  endif
-
-  call CloseWindow()
-endfunc
-
-func Test_matchadd_eol_with_cursorline_2()
-  call NewWindow('topleft 5', 5)
-  call setline(1, 'abcd')
-  call matchadd('Search', '\n')
-
-  let expected = "abcd |abcd     "
-  let actual = ScreenLines(1, 15)[0]
-  call assert_equal(expected, actual)
-
-  " expected:
-  " 'abcd |abcd     '
-  "  ^^^^  ^^^^^^^^^   no highlight
-  "      ^             'Search' highlight
-  "       ^            'VertSplit' highlight
-  let attrs0 = ScreenAttrs(1, 15)[0]
-  call assert_equal(repeat([attrs0[0]], 4), attrs0[0:3])
-  call assert_equal(repeat([attrs0[0]], 9), attrs0[6:14])
-  call assert_notequal(attrs0[0], attrs0[4])
-  call assert_notequal(attrs0[0], attrs0[5])
-  call assert_notequal(attrs0[4], attrs0[5])
-
-  setlocal cursorline
-  redraw!
-
-  let actual = ScreenLines(1, 15)[0]
-  call assert_equal(expected, actual)
-
-  " expected:
-  " 'abcd |abcd     '
-  "  ^^^^              underline
-  "      ^             'Search' highlight with underline
-  "       ^            'VertSplit' highlight
-  "        ^^^^^^^^^   no highlight
-  let attrs = ScreenAttrs(1, 15)[0]
-  call assert_equal(repeat([attrs[0]], 4), attrs[0:3])
-  call assert_equal(repeat([attrs[6]], 9), attrs[6:14])
-  call assert_equal(attrs0[5:14], attrs[5:14])
-  call assert_notequal(attrs[0], attrs[4])
-  call assert_notequal(attrs[0], attrs[5])
-  call assert_notequal(attrs[0], attrs[6])
-  call assert_notequal(attrs[4], attrs[5])
-  call assert_notequal(attrs[5], attrs[6])
-  call assert_notequal(attrs0[0], attrs[0])
-  if has('gui_running')
-    call assert_equal(attrs0[4], attrs[4])
-  else
-    call assert_notequal(attrs0[4], attrs[4])
-  endif
-
-  call CloseWindow()
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/view_util.vim
+++ b/src/testdir/view_util.vim
@@ -18,6 +18,22 @@ function! ScreenLines(lnum, width) abort
   return lines
 endfunction
 
+function! ScreenAttrs(lnum, width) abort
+  redraw!
+  if type(a:lnum) == v:t_list
+    let start = a:lnum[0]
+    let end = a:lnum[1]
+  else
+    let start = a:lnum
+    let end = a:lnum
+  endif
+  let attrs = []
+  for l in range(start, end)
+    let attrs += [map(range(1, a:width), 'screenattr(l, v:val)')]
+  endfor
+  return attrs
+endfunction
+
 function! NewWindow(height, width) abort
   exe a:height . 'new'
   exe a:width . 'vsp'


### PR DESCRIPTION
For #1792.

## Summary

sample.vim

```vim
normal! iabcd
syntax on
call matchadd('ErrorMsg', '\n')
setlocal cursorline
```

### current vim

`cursorline`: underline

![2017-09-17 23 58 36](https://user-images.githubusercontent.com/943423/30522065-17621d5c-9c05-11e7-8baa-3baaf9f15c29.png)

`cursorline`: background-color (`:hi CursorLine cterm=NONE ctermbg=DarkGray`)

![2017-09-18 0 05 00](https://user-images.githubusercontent.com/943423/30522070-2aadadcc-9c05-11e7-950b-06af5279abae.png)

### patched

`cursorline`: underline

![2017-09-18 0 03 31](https://user-images.githubusercontent.com/943423/30522076-358d7b8c-9c05-11e7-9a6b-2e0829ffbe0e.png)

`cursorline`: background-color (e.g. `:hi CursorLine cterm=NONE ctermbg=DarkGray`)

![2017-09-18 0 04 17](https://user-images.githubusercontent.com/943423/30522079-3a8227f0-9c05-11e7-8772-dd60cc4b1a8f.png)

This is the similar highlighting as `set list` (of current vim).

![2017-09-18 0 08 57](https://user-images.githubusercontent.com/943423/30522148-77616a5e-9c06-11e7-9a1b-7c2ef5907e4f.png)

![2017-09-18 0 15 44](https://user-images.githubusercontent.com/943423/30522158-8e3de6c6-9c06-11e7-88c0-11a73516de1f.png)

## Additional examples

### `set rightleft` and background-color `cursorline`

the left-col is highlighted:

![2017-09-18 0 21 27](https://user-images.githubusercontent.com/943423/30522214-66e91482-9c07-11e7-89b6-accec2f211d5.png)

fixed:

![2017-09-18 0 23 56](https://user-images.githubusercontent.com/943423/30522236-d8c8168e-9c07-11e7-8697-216ab81f7759.png)

### diff-mode

without `cursorline`.

sample2.vim

```vim
normal! iabcd
call matchadd('ErrorMsg', '\n')
diffthis
vnew
diffthis
```

![2017-09-18 0 29 37](https://user-images.githubusercontent.com/943423/30522287-8cc1d51c-9c08-11e7-9311-cc93c46625e4.png)

fixed:

![2017-09-18 0 30 34](https://user-images.githubusercontent.com/943423/30522296-b60561aa-9c08-11e7-931b-648f55a1bee2.png)


