### PR TITLE
fix doc referencing '-n below' when -n is above

### DIFF
--- a/runtime/doc/vim.1
+++ b/runtime/doc/vim.1
@@ -325,7 +325,7 @@ You can still edit the buffer, but will be prevented from accidentally
 overwriting a file.
 If you do want to overwrite a file, add an exclamation mark to the Ex command,
 as in ":w!".
-The \-R option also implies the \-n option (see below).
+The \-R option also implies the \-n option (see above).
 The 'readonly' option can be reset with ":set noro".
 See ":help 'readonly'".
 .TP

--- a/runtime/doc/vim.man
+++ b/runtime/doc/vim.man
@@ -225,7 +225,7 @@ OPTIONS
                    dentally overwriting a file.  If you do want to overwrite a
                    file, add an exclamation mark to  the  Ex  command,  as  in
                    ":w!".   The  -R  option  also  implies  the -n option (see
-                   below).  The 'readonly' option  can  be  reset  with  ":set
+                   above).  The 'readonly' option  can  be  reset  with  ":set
                    noro".  See ":help 'readonly'".
 
        -r          List  swap  files,  with  information  about using them for


### PR DESCRIPTION
Quick fix to documentation; I noticed in the man page under '-R' option, it references '-n below', when the '-n' documentation actually occurs above i.e. before '-R'.