### PR TITLE
Better packadd in example rc

### DIFF
--- a/runtime/evim.vim
+++ b/runtime/evim.vim
@@ -68,7 +68,7 @@ endif " has("autocmd")
 " The matchit plugin makes the % command work better, but it is not backwards
 " compatible.
 if has('syntax') && has('eval')
-  packadd matchit
+  packadd! matchit
 endif
 
 " vim: set sw=2 :

--- a/runtime/vimrc_example.vim
+++ b/runtime/vimrc_example.vim
@@ -54,5 +54,5 @@ endif " has("autocmd")
 " The matchit plugin makes the % command work better, but it is not backwards
 " compatible.
 if has('syntax') && has('eval')
-  packadd matchit
+  packadd! matchit
 endif


### PR DESCRIPTION
These example files are probably the ones used by the distributions to provide starting .vimrc, and the lack of the ! can be confusing when adding other packages.
Eventually, reading the doc like I should have in the beginning help me resolve [#2121](https://github.com/vim/vim/issues/2121), but it may be good to also have good practice in the runtime starting files.