### PR TITLE
clear inversion on winbar

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -2699,7 +2699,7 @@ retnomove:
 	    /* A click in the window toolbar does not enter another window or
 	     * change Visual highlighting. */
 	    winbar_click(wp, col);
-	    return IN_OTHER_WIN;
+	    return IN_UNKNOWN;
 	}
 #endif
 


### PR DESCRIPTION
![menu](https://user-images.githubusercontent.com/10111/30726475-fad3f26c-9f85-11e7-9379-757424917b80.gif)

text inversion should be deleted after click menu.

