### PR TITLE
Suppress Ruby warning when `RUBYOPT=-w` exists

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -882,7 +882,7 @@ static int ensure_ruby_initialized(void)
 #ifdef RUBY19_OR_LATER
 	    {
 		int dummy_argc = 2;
-		char *dummy_argv[] = {"vim-ruby", "-e0"};
+		char *dummy_argv[] = {"vim-ruby", "-e_=0"};
 		ruby_options(dummy_argc, dummy_argv);
 	    }
 	    ruby_script("vim-ruby");


### PR DESCRIPTION
Problem
======

If `RUBYOPT=-w` exists, Ruby warns when we execute `:ruby` at first time.

Reproduce
------

Start Vim with `RUBYOPT` environment

```bash
$ RUBYOPT='-w' vim -N -u NONE
```

Execute `:ruby`

```vim
:ruby puts "hello"
```

stderr

```
-e:1: warning: possibly useless use of a literal in void context
```

The output disturbs the display.

Cause
====

Vim executes Ruby like `ruby -e0`. Then the `0` is in void context. So, Ruby warns about it.

Solution
======

Assign 0 to `_`. It suppresses the warning. And it does nothing.