### PR TITLE
Fix cmake indent

### DIFF
--- a/runtime/indent/cmake.vim
+++ b/runtime/indent/cmake.vim
@@ -14,7 +14,6 @@ if exists("b:did_indent")
 endif
 let b:did_indent = 1
 
-setlocal et
 setlocal indentexpr=CMakeGetIndent(v:lnum)
 setlocal indentkeys+==ENDIF(,ENDFOREACH(,ENDMACRO(,ELSE(,ELSEIF(,ENDWHILE(
 

--- a/runtime/indent/cmake.vim
+++ b/runtime/indent/cmake.vim
@@ -67,19 +67,19 @@ fun! CMakeGetIndent(lnum)
     let ind = ind
   else
     if previous_line =~? cmake_indent_begin_regex
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
     if previous_line =~? cmake_indent_open_regex
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
   endif
 
   " Subtract
   if this_line =~? cmake_indent_end_regex
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   if previous_line =~? cmake_indent_close_regex
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind


### PR DESCRIPTION
Requested here:

* https://github.com/vim/vim/commit/37c64c78fd87e086b5a945ad7032787c274e2dcb#commitcomment-24418497

Also contains a fix backported from cmake project;
* https://gitlab.kitware.com/cmake/cmake/merge_requests/1273