### PR TITLE
Avoid `rb_load_protect` as a workaround not to crash

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -831,7 +831,7 @@ void ex_rubyfile(exarg_T *eap)
 
     if (ensure_ruby_initialized())
     {
-	rb_load_protect(rb_str_new2((char *) eap->arg), 0, &state);
+	rb_protect((VALUE (*)(VALUE))rb_load, rb_str_new2((char *) eap->arg), &state);
 	if (state) error_print(state);
     }
 }

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -49,3 +49,11 @@ func Test_rubydo()
   bwipe!
   bwipe!
 endfunc
+
+func Test_rubyfile()
+  " Check :rubyfile does not SEGV with Ruby level exception but just fails
+  let tempfile = tempname() . '.rb'
+  call writefile(['raise "vim!"'], tempfile)
+  call assert_fails('rubyfile ' . tempfile)
+  call delete(tempfile)
+endfunc


### PR DESCRIPTION
Short summary: fix a segv for if_ruby.

## Problem

Vim with `+ruby` causes segmentation fault when Ruby throws an exception inside `:rubyfile` command.

```sh
echo 'raise' > /tmp/raise.rb
vim -u NONE -N -c 'rubyfile /tmp/raise.rb'
```

I tested with Vim 7.3.939, 8.0.0000, latest 8.0.1139, with Ruby 2.3.1, 2.4.2, and latest 2.5.0dev. I don't know when exactly happened, but it must have been happening since pretty old version.

This is likely a Ruby bug, since `rb_load_protect` is supposed to be used to avoid segmentation fault, according to [a third-party doc](https://silverhammermba.github.io/emberb/c/#require).[a Ruby committer](https://twitter.com/nalsh/status/911591257117306880) also suggested it may be a Ruby bug.

## Solution

I took a workaround. According to existing `:h rubyfile`, the updated behaviour should be straightforward.

For long-term solution, Ruby should fix the function itself. Vim supports older versions of Ruby, so the above solution should be better.

## Acknowledgement

Thanks @pocke to report this issue at https://github.com/vim-jp/issues/issues/1098, and @mattn to help me a lot contributing to vim core for the first time! Also thanks indirectly to @nurse confirming it's likely a Ruby bug.