### PR TITLE
...a lot about...

### DIFF
--- a/src/msvc2017.bat
+++ b/src/msvc2017.bat
@@ -1,0 +1,13 @@
+@echo off
+rem To be used on MS-Windows for Visual C++ 2017 Express Edition
+rem   aka Microsoft Visual Studio 15
+rem See INSTALLpc.txt for information.
+
+rem Fast way: open Folder of VIM/SRC in VC2017
+rem use "Developer command prompt" from from Solution Explorer window (RKM - Main folder of project)
+rem and in command prompt type: nmake -f Make_mvc.mak
+rem after build vim.exe open it in VC2017 (File-Open) for debug if need
+
+rem Member! Close VIM.EXE in VS2017 before rebuild/rewrite .exe in command prompt
+@echo on
+call "%ProgramFiles%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -21,6 +21,8 @@
  */
 
 #include "vim.h"
+#include <VersionHelpers.h>
+
 
 #ifdef FEAT_MZSCHEME
 # include "if_mzsch.h"
@@ -227,64 +229,56 @@ read_console_input(
 	IRSIZE = 10
     };
     static INPUT_RECORD s_irCache[IRSIZE];
-    static DWORD s_dwIndex = 0;
-    static DWORD s_dwMax = 0;
+    static DWORD s_dwIndex;
+    static DWORD s_dwUnreadEvents;
     DWORD dwEvents;
     int head;
     int tail;
     int i;
 
     if (nLength == -2)
-	return (s_dwMax > 0) ? TRUE : FALSE;
+		return (s_dwUnreadEvents > 0) ? TRUE : FALSE;
 
-    if (!win8_or_later)
-    {
-	if (nLength == -1)
-	    return PeekConsoleInputW(hInput, lpBuffer, 1, lpEvents);
-	return ReadConsoleInputW(hInput, lpBuffer, 1, &dwEvents);
-    }
-
-    if (s_dwMax == 0)
-    {
-	if (nLength == -1)
-	    return PeekConsoleInputW(hInput, lpBuffer, 1, lpEvents);
-	if (!ReadConsoleInputW(hInput, s_irCache, IRSIZE, &dwEvents))
-	    return FALSE;
-	s_dwIndex = 0;
-	s_dwMax = dwEvents;
-	if (dwEvents == 0)
+	if (nLength == -1) // Peek request
 	{
-	    *lpEvents = 0;
-	    return TRUE;
+		if (!win8_or_later || !s_dwUnreadEvents)
+			return PeekConsoleInputW(hInput, lpBuffer, 1, lpEvents); //1,3 - if Buf is empty or old Win then (Peek)
 	}
-
-	if (s_dwMax > 1)
-	{
-	    head = 0;
-	    tail = s_dwMax - 1;
-	    while (head != tail)
-	    {
-		if (s_irCache[head].EventType == WINDOW_BUFFER_SIZE_EVENT
-			&& s_irCache[head + 1].EventType
-						  == WINDOW_BUFFER_SIZE_EVENT)
+	else // Read request
 		{
-		    /* Remove duplicate event to avoid flicker. */
-		    for (i = head; i < tail; ++i)
-			s_irCache[i] = s_irCache[i + 1];
-		    --tail;
-		    continue;
+		if (!win8_or_later)
+			return ReadConsoleInputW(hInput, lpBuffer, 1, &dwEvents); //2 if old Win then (Read)
+		if (!s_dwUnreadEvents--)  //4 if Buf is empty - Try (Read) 
+		{
+			s_dwIndex = 0;
+			if (!ReadConsoleInputW(hInput, s_irCache, IRSIZE, &s_dwUnreadEvents))
+				return s_dwUnreadEvents = 0; // FALSE;
+			if (!s_dwUnreadEvents)
+			{
+				*lpEvents = 0;
+				return TRUE;
+			}
+			tail = s_dwUnreadEvents - 1;
+				for (head = 0;head < tail; head++)
+				{
+					if (s_irCache[head].EventType == WINDOW_BUFFER_SIZE_EVENT
+					&& s_irCache[head + 1].EventType
+					== WINDOW_BUFFER_SIZE_EVENT)
+					{
+						/* Remove duplicate event to avoid flicker. */
+						for (i = head; i < tail; i++)
+							s_irCache[i] = s_irCache[i + 1];
+						--tail;
+					}
+				}
+			s_dwUnreadEvents = tail; // Always UnreadEvents-1 because return 1 Event now
 		}
-		head++;
-	    }
-	    s_dwMax = tail + 1;
+		else 
+			s_dwIndex++; // 5 Buf is no empty, return next element of buf (virtual Peek)
 	}
-    }
-
-    *lpBuffer = s_irCache[s_dwIndex];
-    if (!(nLength == -1 || nLength == -2) && ++s_dwIndex >= s_dwMax)
-	s_dwMax = 0;
-    *lpEvents = 1;
-    return TRUE;
+	*lpBuffer = s_irCache[s_dwIndex];
+	*lpEvents = 1;
+	return TRUE;
 }
 
 /*
@@ -349,7 +343,7 @@ get_exe_name(void)
     if (exe_path == NULL && exe_name != NULL)
     {
 	exe_path = vim_strnsave(exe_name,
-				     (int)(gettail_sep(exe_name) - exe_name));
+				     (int)(gettail_sep(exe_name) - (int)exe_name));
 	if (exe_path != NULL)
 	{
 	    /* Append our starting directory to $PATH, so that when doing
@@ -678,7 +672,7 @@ null_libintl_wputenv(const wchar_t *envstring UNUSED)
 # define VER_PLATFORM_WIN32_WINDOWS 1
 #endif
 
-DWORD g_PlatformId;
+DWORD g_PlatformId = VER_PLATFORM_WIN32s;
 
 #ifdef HAVE_ACL
 # ifndef PROTO
@@ -733,19 +727,23 @@ win32_enable_privilege(LPTSTR lpszPrivilege, BOOL bEnable)
 PlatformId(void)
 {
     static int done = FALSE;
+	
 
     if (!done)
     {
-	OSVERSIONINFO ovi;
-
-	ovi.dwOSVersionInfoSize = sizeof(ovi);
+	/* LPOSVERSIONINFOW ovi;
+	
+	ovi->dwOSVersionInfoSize = sizeof(LPOSVERSIONINFOW);
 	GetVersionEx(&ovi);
 
-	g_PlatformId = ovi.dwPlatformId;
+	g_PlatformId = ovi->dwPlatformId; */
 
-	if ((ovi.dwMajorVersion == 6 && ovi.dwMinorVersion >= 2)
-		|| ovi.dwMajorVersion > 6)
-	    win8_or_later = TRUE;
+	if (IsWindowsXPOrGreater()) 
+		g_PlatformId = VER_PLATFORM_WIN32_NT; // for compatibility 
+	/*if ((ovi.dwMajorVersion == 6 && ovi.dwMinorVersion >= 2)
+		|| ovi.dwMajorVersion > 6)*/
+	if (!IsWindows8OrGreater())
+		win8_or_later = TRUE;
 
 #ifdef HAVE_ACL
 	/* Enable privilege for getting or setting SACLs. */
@@ -1410,6 +1408,7 @@ WaitForChar(long msec, int ignore_input)
     INPUT_RECORD    ir;
     DWORD	    cRecords;
     WCHAR	    ch, ch2;
+
 #ifdef FEAT_TIMERS
     int		    tb_change_cnt = typebuf.tb_change_cnt;
 #endif
@@ -1456,11 +1455,11 @@ WaitForChar(long msec, int ignore_input)
 	}
 	if (msec != 0)
 	{
-	    DWORD dwWaitTime = dwEndTime - dwNow;
-
+		DWORD dwWaitTime = dwEndTime - dwNow;
 #ifdef FEAT_JOB_CHANNEL
+		
 	    /* Check channel while waiting for input. */
-	    if (dwWaitTime > 100)
+	    if (dwWaitTime > 100) 
 	    {
 		dwWaitTime = 100;
 		/* If there is readahead then parse_queued_messages() timed out
@@ -1535,7 +1534,9 @@ WaitForChar(long msec, int ignore_input)
 
 	if (cRecords > 0)
 	{
-	    if (ir.EventType == KEY_EVENT && ir.Event.KeyEvent.bKeyDown)
+	    
+		
+		if (ir.EventType == KEY_EVENT && ir.Event.KeyEvent.bKeyDown)
 	    {
 #ifdef FEAT_MBYTE_IME
 		/* Windows IME sends two '\n's with only one 'ENTER'.  First:
@@ -1552,12 +1553,12 @@ WaitForChar(long msec, int ignore_input)
 		    return TRUE;
 	    }
 
-	    read_console_input(g_hConIn, &ir, 1, &cRecords);
+		read_console_input(g_hConIn, &ir, 1, &cRecords);
 
-	    if (ir.EventType == FOCUS_EVENT)
-		handle_focus_event(ir);
-	    else if (ir.EventType == WINDOW_BUFFER_SIZE_EVENT)
-		shell_resized();
+		if (ir.EventType == FOCUS_EVENT)
+			handle_focus_event(ir);
+		else if (ir.EventType == WINDOW_BUFFER_SIZE_EVENT)
+			shell_resized_check();  // shell_resized() - run if real change size only
 #ifdef FEAT_MOUSE
 	    else if (ir.EventType == MOUSE_EVENT
 		    && decode_mouse_event(&ir.Event.MouseEvent))
@@ -1566,7 +1567,8 @@ WaitForChar(long msec, int ignore_input)
 	}
 	else if (msec == 0)
 	    break;
-    }
+    } 
+// End loop until the end of the time period
 
 #ifdef FEAT_CLIENTSERVER
     /* Something might have been received while we were waiting. */
@@ -1634,7 +1636,7 @@ tgetch(int *pmodifiers, WCHAR *pch2)
 	    return 0;
 # endif
 #endif
-	if (read_console_input(g_hConIn, &ir, 1, &cRecords) == 0)
+	if (!read_console_input(g_hConIn, &ir, 1, &cRecords))
 	{
 	    if (did_create_conin)
 		read_error_exit();
@@ -1651,7 +1653,7 @@ tgetch(int *pmodifiers, WCHAR *pch2)
 	else if (ir.EventType == FOCUS_EVENT)
 	    handle_focus_event(ir);
 	else if (ir.EventType == WINDOW_BUFFER_SIZE_EVENT)
-	    shell_resized();
+		shell_resized_check();  // shell_resized() - run if real change size only
 #ifdef FEAT_MOUSE
 	else if (ir.EventType == MOUSE_EVENT)
 	{
@@ -5468,6 +5470,9 @@ termcap_mode_start(void)
     SetConsoleMode(g_hConIn, cmodein);
 
     redraw_later_clear();
+
+	//FlushConsoleInputBuffer(g_hConIn);
+
     g_fTermcapMode = TRUE;
 }
 


### PR DESCRIPTION
...a lot about... 
os_win32.c
-----------

344 (int) add and kill warning


839 /* Sorry, out of number space! <negri>*/    

and where tolerantion ? ;-D


3208 time(NULL) is time.h? in ui.c

#define MAYBE	2	    /* sometimes used for a variant on TRUE */  ;-) I like it, more of variants!

230
231
When modifying a variable, the static keyword specifies that the variable has static duration (it is allocated when the program begins and deallocated when the program ends) and initializes it to 0 unless another value is specified.
https://msdn.microsoft.com/en-us/library/s1sb61xd(vs.80).aspx
ReadConsoleInputA doesn't return correct double-byte characters in Windows 8 and Windows 10
i'm not test this error and simply rebuild this func.. (but may be need use peekW/readW of SYSTEM ) 


284 "nLength == -2" is Delete from string because cheсk it in 237 
and "nLength != -1" EQ "!(nLength == -1)"

and/or other metod:
"++s_dwIndex" need only if "nLength != -1" put in other block "IF"
else func "peek_console_input(g_hConIn, &ir, 1, &cRecords);" work as 
"read_console_input(g_hConIn, &ir, 1, &cRecords);"

STOP i delete it and present for test my new Compact version of read_console_input()


673 VER_PLATFORM_WIN32s May be... i don't know


unexpected excess clean screen and INTRO before start work in VIM
if size of buf too much and VIM change item
two solutions: 
5477 "FlushConsoleInputBuffer(g_hConIn);"   - kill garbage best before start
now BUG (test it - set bufsize > vertical screen size in properties of terminal window before run VIM)
if VIM set vertical buf to size window on start windows generate EVENT
VIM think - "user change" and clear screen and INTRO delete, no good

first metod:
1555
1650
shell_resized_check();  // shell_resized() - run it if real change size only

and/or other metod:
725 (PlatformId(void))
https://msdn.microsoft.com/en-us/library/windows/desktop/dn481241(v=vs.85).aspx
With the release of Windows 8.1, the behavior of the GetVersion API has changed in the value 
it will return for the operating system version. The value returned by the GetVersion function 
now depends on how the application is manifested. 


24 #include <VersionHelpers.h>