### PR TITLE
Test diff hl

### DIFF
--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -577,7 +577,7 @@ func Test_diff_filler()
   call setline(1, [1, 2, 3, 'x', 4])
   diffthis
   vnew
-  call setline(1, ['1', 2, 'y', 'y', 3, 4])
+  call setline(1, [1, 2, 'y', 'y', 3, 4])
   diffthis
   redraw
 

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -420,7 +420,7 @@ func Test_setting_cursor()
   new Xtest2
   put =range(1,100)
   wq
-  
+
   tabe Xtest2
   $
   diffsp Xtest1
@@ -501,7 +501,7 @@ func Test_diffpatch()
   3
 + 4
 .
-  saveas Xpatch
+  saveas! Xpatch
   bwipe!
   new
   call assert_fails('diffpatch Xpatch', 'E816:')
@@ -544,6 +544,47 @@ func Test_diff_nomodifiable()
   call assert_fails('norm dp', 'E793:')
   setl nomodifiable
   call assert_fails('norm do', 'E21:')
+  %bwipe!
+endfunc
+
+func Test_diff_hlID()
+  new
+  call setline(1, [1, 2, 3])
+  diffthis
+  vnew
+  call setline(1, ['1x', 2, 'x', 3])
+  diffthis
+  redraw
+
+  call assert_equal(synIDattr(diff_hlID(-1, 1), "name"), "")
+
+  call assert_equal(synIDattr(diff_hlID(1, 1), "name"), "DiffChange")
+  call assert_equal(synIDattr(diff_hlID(1, 2), "name"), "DiffText")
+  call assert_equal(synIDattr(diff_hlID(2, 1), "name"), "")
+  call assert_equal(synIDattr(diff_hlID(3, 1), "name"), "DiffAdd")
+  call assert_equal(synIDattr(diff_hlID(4, 1), "name"), "")
+
+  wincmd w
+  call assert_equal(synIDattr(diff_hlID(1, 1), "name"), "DiffChange")
+  call assert_equal(synIDattr(diff_hlID(2, 1), "name"), "")
+  call assert_equal(synIDattr(diff_hlID(3, 1), "name"), "")
+
+  %bwipe!
+endfunc
+
+func Test_diff_filler()
+  new
+  call setline(1, [1, 2, 3, 'x', 4])
+  diffthis
+  vnew
+  call setline(1, ['1', 2, 'y', 'y', 3, 4])
+  diffthis
+  redraw
+
+  call assert_equal([0, 0, 0, 0, 0, 0, 0, 1, 0], map(range(-1, 7), 'diff_filler(v:val)'))
+  wincmd w
+  call assert_equal([0, 0, 0, 0, 2, 0, 0, 0], map(range(-1, 6), 'diff_filler(v:val)'))
+
   %bwipe!
 endfunc
 


### PR DESCRIPTION
This PR adds tests for diff_hlID() and diff_filler() functions which are currently
not tested according to coveralls:

https://coveralls.io/builds/13408237/source?filename=src%2Fevalfunc.c#L2607
