### PR TITLE
fix dialog fonts on Windows

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -7304,7 +7304,7 @@ gui_mch_dialog(
 #endif
 	{
 	    *p++ = DLG_FONT_POINT_SIZE;		// point size
-	    nchar = nCopyAnsiToWideChar(p, TEXT(DLG_FONT_NAME), FALSE);
+	    nchar = nCopyAnsiToWideChar(p, DLG_FONT_NAME, FALSE);
 	}
 	p += nchar;
     }
@@ -7873,7 +7873,7 @@ gui_mch_tearoff(
 #endif
 	{
 	    *p++ = DLG_FONT_POINT_SIZE;		// point size
-	    nchar = nCopyAnsiToWideChar(p, TEXT(DLG_FONT_NAME), FALSE);
+	    nchar = nCopyAnsiToWideChar(p, DLG_FONT_NAME, FALSE);
 	}
 	p += nchar;
     }

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -4384,7 +4384,7 @@ add_dialog_element(
 	WORD clss,
 	const char *caption);
 static LPWORD lpwAlign(LPWORD);
-static int nCopyAnsiToWideChar(LPWORD, LPSTR);
+static int nCopyAnsiToWideChar(LPWORD, LPSTR, BOOL);
 #if defined(FEAT_MENU) && defined(FEAT_TEAROFF)
 static void gui_mch_tearoff(char_u *title, vimmenu_T *menu, int initX, int initY);
 #endif
@@ -7285,8 +7285,8 @@ gui_mch_dialog(
 
     /* copy the title of the dialog */
     nchar = nCopyAnsiToWideChar(p, (title ?
-				    (LPSTR)title :
-				    (LPSTR)("Vim "VIM_VERSION_MEDIUM)));
+			    (LPSTR)title :
+			    (LPSTR)("Vim "VIM_VERSION_MEDIUM)), TRUE);
     p += nchar;
 
     if (s_usenewlook)
@@ -7298,13 +7298,13 @@ gui_mch_dialog(
 	    /* point size */
 	    *p++ = -MulDiv(lfSysmenu.lfHeight, 72,
 		    GetDeviceCaps(hdc, LOGPIXELSY));
-	    nchar = nCopyAnsiToWideChar(p, TEXT(lfSysmenu.lfFaceName));
+	    nchar = nCopyAnsiToWideChar(p, lfSysmenu.lfFaceName, FALSE);
 	}
 	else
 #endif
 	{
 	    *p++ = DLG_FONT_POINT_SIZE;		// point size
-	    nchar = nCopyAnsiToWideChar(p, TEXT(DLG_FONT_NAME));
+	    nchar = nCopyAnsiToWideChar(p, TEXT(DLG_FONT_NAME), FALSE);
 	}
 	p += nchar;
     }
@@ -7485,7 +7485,7 @@ add_dialog_element(
     *p++ = (WORD)0xffff;
     *p++ = clss;			//2 more here
 
-    nchar = nCopyAnsiToWideChar(p, (LPSTR)caption); //strlen(caption)+1
+    nchar = nCopyAnsiToWideChar(p, (LPSTR)caption, TRUE); //strlen(caption)+1
     p += nchar;
 
     *p++ = 0;  // advance pointer over nExtraStuff WORD   - 2 more
@@ -7521,7 +7521,8 @@ lpwAlign(
     static int
 nCopyAnsiToWideChar(
     LPWORD lpWCStr,
-    LPSTR lpAnsiIn)
+    LPSTR lpAnsiIn,
+    BOOL enc)
 {
     int		nChar = 0;
 #ifdef FEAT_MBYTE
@@ -7529,7 +7530,7 @@ nCopyAnsiToWideChar(
     int		i;
     WCHAR	*wn;
 
-    if (enc_codepage == 0 && (int)GetACP() != enc_codepage)
+    if (enc && enc_codepage >= 0 && (int)GetACP() != enc_codepage)
     {
 	/* Not a codepage, use our own conversion function. */
 	wn = enc_to_utf16((char_u *)lpAnsiIn, NULL);
@@ -7852,8 +7853,8 @@ gui_mch_tearoff(
 
     /* copy the title of the dialog */
     nchar = nCopyAnsiToWideChar(p, ((*title)
-				    ? (LPSTR)title
-				    : (LPSTR)("Vim "VIM_VERSION_MEDIUM)));
+			    ? (LPSTR)title
+			    : (LPSTR)("Vim "VIM_VERSION_MEDIUM)), TRUE);
     p += nchar;
 
     if (s_usenewlook)
@@ -7865,13 +7866,13 @@ gui_mch_tearoff(
 	    /* point size */
 	    *p++ = -MulDiv(lfSysmenu.lfHeight, 72,
 		    GetDeviceCaps(hdc, LOGPIXELSY));
-	    nchar = nCopyAnsiToWideChar(p, TEXT(lfSysmenu.lfFaceName));
+	    nchar = nCopyAnsiToWideChar(p, lfSysmenu.lfFaceName, FALSE);
 	}
 	else
 #endif
 	{
 	    *p++ = DLG_FONT_POINT_SIZE;		// point size
-	    nchar = nCopyAnsiToWideChar (p, TEXT(DLG_FONT_NAME));
+	    nchar = nCopyAnsiToWideChar(p, TEXT(DLG_FONT_NAME), FALSE);
 	}
 	p += nchar;
     }

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -7517,7 +7517,8 @@ lpwAlign(
  * parameter as wide character (16-bits / char) string, and returns integer
  * number of wide characters (words) in string (including the trailing wide
  * char NULL).  Partly taken from the Win32SDK samples.
- */
+ * If enc is TRUE, 'encoding' is used for lpAnsiIn. If FALSE, current ACP is
+ * used for lpAnsiIn. */
     static int
 nCopyAnsiToWideChar(
     LPWORD lpWCStr,


### PR DESCRIPTION
When encoding=utf-8, dialog font size is incorrect on Windows.

Current
![6d179f8097c49f2c](https://user-images.githubusercontent.com/10111/30855659-acf8a128-a2f0-11e7-880f-4a0d843df07f.png)

Fixed
![bea149a6e91115f1](https://user-images.githubusercontent.com/10111/30855653-a5290866-a2f0-11e7-8285-2a91c34d2858.png)

Also tearoff dialog

Current
![c08205cbbd576005](https://user-images.githubusercontent.com/10111/30855687-c02e4a2c-a2f0-11e7-908f-c652c296d51f.png)

Fixed
![895b3a1ae8a0434a](https://user-images.githubusercontent.com/10111/30855676-bb3cae5a-a2f0-11e7-8065-2eb8caeb9271.png)

The font name is treated as UTF-8 eventhough it's ANSI.