### PR TITLE
Fix win_remove() so that it does not break f_gettabvar()

### DIFF
--- a/src/testdir/test_getvar.vim
+++ b/src/testdir/test_getvar.vim
@@ -86,3 +86,19 @@ func Test_var()
   call assert_equal(1, gettabwinvar(2, 3, '&nux', 1))
   tabonly
 endfunc
+
+" It was discovered that "gettabvar()" would fail if called from within the
+" tabline when the user closed a window.  This test confirms the fix.
+func Test_gettabvar_in_tabline()
+  let t:var_str = 'value'
+
+  set tabline=%{assert_equal('value',gettabvar(1,'var_str'))}
+  set showtabline=2
+
+  " Simulate the user opening a split (which becomes window #1) and then
+  " closing the split, which triggers the redrawing of the tabline.
+  leftabove split
+  redrawstatus!
+  close
+  redrawstatus!
+endfunc

--- a/src/window.c
+++ b/src/window.c
@@ -4775,13 +4775,14 @@ win_remove(
     if (wp->w_prev != NULL)
 	wp->w_prev->w_next = wp->w_next;
     else if (tp == NULL)
-	firstwin = wp->w_next;
+	firstwin = curtab->tp_firstwin = wp->w_next;
     else
 	tp->tp_firstwin = wp->w_next;
+
     if (wp->w_next != NULL)
 	wp->w_next->w_prev = wp->w_prev;
     else if (tp == NULL)
-	lastwin = wp->w_prev;
+	lastwin = curtab->tp_lastwin = wp->w_prev;
     else
 	tp->tp_lastwin = wp->w_prev;
 }


### PR DESCRIPTION
# Summary 

Fix bug in `win_remove()` in `window.c` so that it simultaneously sets `firstwin` and `curtab->tp_firstwin` (and same for `lastwin`).

# Reproduce the Bug

To reproduce the bug interactively, follow these steps:
1. Open Vim with `vim -N -u NONE`.
2. Run `:set nocp` and `:set showtabline=2`.
3. Run `:let t:var = 'test'`.
4. Run `:set tabline=%{gettabvar(1,'var')}`. You may need to hit `<C-L>` to see the word "test" in the tabline.
5. Type `:vsp<CR><C-W>c`, and you will see "test" disappear.

This perfectly reproduces the bug.  Since "test" disappeared, we can conclude that `gettabvar()` is failing to find a tab-local variable that should be there.  What happened?

# Solution

Closing the window obviously triggered the problem with the `gettabvar()` function.  Upon inspecting `f_gettabvar()` (the function in `evalfunc.c` that drives the builtin), we can see the following if-clause:

```c
/* Set tp to be our tabpage, temporarily.  Also set the window to the
 * first window in the tabpage, otherwise the window is not valid. */
if (switch_win(&oldcurwin, &oldtabpage,
	    tp->tp_firstwin == NULL ? firstwin : tp->tp_firstwin, tp, TRUE)
								== OK)
{
    /* look up the variable */
    /* Let gettabvar({nr}, "") return the "t:" dictionary. */
    v = find_var_in_ht(&tp->tp_vars->dv_hashtab, 't', varname, FALSE);
    if (v != NULL)
    {
	copy_tv(&v->di_tv, rettv);
	done = TRUE;
    }
}
```

So, `switch_win()` must succeed for `f_gettabvar()` to work!  You can see from the commit that `win_remove()` function call does not update `curtab->tp_firstwin` pointer which is used to set the `win` argument to `switch_win`. Thus, the call to `switch_win` is guaranteed to `FAIL`.

By changing `win_remove` to update both pointers (on both ends of the window list just to be safe), we can avoid this problem of having the pointers out of sync.

# Steps Needed

I may need to add a commit or two to update the test so that it will work non-interactively.  The test function performs as expected before and after the fix (i.e., it fails then succeeds on re-compilation with the fix).  However, running it non-interactively with `make test_getvar` seems to not work for me. 

Since I'm a novice around these parts, I'll hope for some guidance!
