### PR TITLE
Mac build overhaul

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8872,9 +8872,8 @@ listcmds		Compiled with commands for the buffer list |:files|
 			and the argument list |arglist|.
 localmap		Compiled with local mappings and abbr. |:map-local|
 lua			Compiled with Lua interface |Lua|.
-mac			Any Macintosh version of Vim, but not all OS X.
-macunix			Compiled for OS X, with |mac-darwin-feature|
-osx			Compiled for OS X, with or w/o |mac-darwin-feature|
+mac			Any Macintosh version of Vim  cf. osx
+macunix			Synonym for osxdarwin
 menu			Compiled with support for |:menu|.
 mksession		Compiled with support for |:mksession|.
 modify_fname		Compiled with file name modifiers. |filename-modifiers|
@@ -8897,6 +8896,8 @@ netbeans_enabled	Compiled with support for |netbeans| and connected.
 netbeans_intg		Compiled with support for |netbeans|.
 num64			Compiled with 64-bit |Number| support.
 ole			Compiled with OLE automation support for Win32.
+osx			Compiled for macOS  cf. mac
+osxdarwin		Compiled for macOS, with |mac-darwin-feature|
 packages		Compiled with |packages| support.
 path_extra		Compiled with up/downwards search in 'path' and 'tags'
 perl			Compiled with Perl interface.

--- a/runtime/doc/os_mac.txt
+++ b/runtime/doc/os_mac.txt
@@ -164,8 +164,9 @@ If you want to disable it, pass `--disable-darwin` to the configure script: >
 and then run `make` to build Vim.  The order of the options doesn't matter.
 
 To make sure at runtime whether or not the darwin feature is compiled in, you
-can use `has('macunix')` which returns 1 if the feature is compiled in; 0
-otherwise.
+can use `has('osxdarwin')` which returns 1 if the feature is compiled in; 0
+otherwise.  For backwards comptibility, you can still use `macunix` instead of
+`osxdarwin`.
 
 Notable use cases where `--disable-darwin` is turned out to be useful are:
 

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -4176,6 +4176,7 @@ if test "`(uname) 2>/dev/null`" = Darwin; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
   MACOS_X=yes
+  CPPFLAGS="$CPPFLAGS -DMACOS_X"
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking --disable-darwin argument" >&5
 $as_echo_n "checking --disable-darwin argument... " >&6; }

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -5711,7 +5711,7 @@ $as_echo "OK" >&6; }
 		-e 's/-fdebug-prefix-map[^ ]*//g' \
 		-e 's/-pipe //' \
 		-e 's/-W[^ ]*//g' \
-                -e 's/-D_FORTIFY_SOURCE=.//g'`
+		-e 's/-D_FORTIFY_SOURCE=.//g'`
             perllibs=`cd $srcdir; $vi_cv_path_perl -MExtUtils::Embed -e 'ldopts' | \
 		sed -e '/Warning/d' -e '/Note (probably harmless)/d' \
 			-e 's/-bE:perl.exp//' -e 's/-lc //'`
@@ -14095,20 +14095,43 @@ if test "x$MACOS_X" = "xyes" -a -n "$PERL"; then
   fi
 fi
 
-if test "x$MACOS_X_UNIX" = "xyes"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need -framework Cocoa" >&5
-$as_echo_n "checking whether we need -framework Cocoa... " >&6; }
-      if test "x$features" != "xtiny" || test "x$enable_multibyte" = "xyes"; then
-    LIBS=$"$LIBS -framework Cocoa"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
+if test "$MACOS_X" = "yes"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need macOS frameworks" >&5
+$as_echo_n "checking whether we need macOS frameworks... " >&6; }
+  if test "$GUITYPE" = "CARBONGUI"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, we need Carbon" >&5
+$as_echo "yes, we need Carbon" >&6; }
+    LIBS="$LIBS -framework Carbon"
+  elif test "$MACOS_X_UNIX" = "yes"; then
+    if test "$features" = "tiny"; then
+            OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_macosx.m++'`
+      OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_macosx.o++'`
+      if test "$enable_multibyte" = "yes"; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, we need CoreServices" >&5
+$as_echo "yes, we need CoreServices" >&6; }
+        LIBS="$LIBS -framework CoreServices"
+      else
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+        OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_mac_conv.c++'`
+        OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_mac_conv.o++'`
+        CPPFLAGS=`echo "$CPPFLAGS" | sed -e 's+-DMACOS_X_UNIX++'`
+      fi
+    else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, we need AppKit" >&5
+$as_echo "yes, we need AppKit" >&6; }
+      LIBS="$LIBS -framework AppKit"
+      if test "$features" = "small" -a "$enable_multibyte" = "no"; then
+                                { $as_echo "$as_me:${as_lineno-$LINENO}: +multi_byte will be set in favor of +clipboard" >&5
+$as_echo "$as_me: +multi_byte will be set in favor of +clipboard" >&6;}
+        enable_multibyte=yes
+        $as_echo "#define FEAT_MBYTE 1" >>confdefs.h
+
+      fi
+    fi
   else
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-  fi
-        if test "x$features" = "xtiny"; then
-    OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_macosx.m++'`
-    OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_macosx.o++'`
   fi
 fi
 if test "x$MACARCH" = "xboth" && test "x$GUITYPE" = "xCARBONGUI"; then

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -12066,7 +12066,7 @@ for ac_func in fchdir fchown fsync getcwd getpseudotty \
 	getpgid setpgid setsid sigaltstack sigstack sigset sigsetjmp sigaction \
 	sigprocmask sigvec strcasecmp strerror strftime stricmp strncasecmp \
 	strnicmp strpbrk strtol tgetent towlower towupper iswupper \
-	usleep utime utimes
+	usleep utime utimes mblen
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -4347,10 +4347,10 @@ rm -f core conftest.err conftest.$ac_objext \
   fi
 
   if test "$enable_darwin" = "yes"; then
-    MACOS_X_UNIX=yes
+    MACOS_X_DARWIN=yes
     OS_EXTRA_SRC="os_macosx.m os_mac_conv.c";
     OS_EXTRA_OBJ="objects/os_macosx.o objects/os_mac_conv.o"
-            CPPFLAGS="$CPPFLAGS -DMACOS_X_UNIX"
+            CPPFLAGS="$CPPFLAGS -DMACOS_X_DARWIN"
 
                 # On IRIX 5.3, sys/types and inttypes.h are conflicting.
 for ac_header in sys/types.h sys/stat.h stdlib.h string.h memory.h strings.h \
@@ -14103,7 +14103,7 @@ $as_echo_n "checking whether we need macOS frameworks... " >&6; }
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, we need Carbon" >&5
 $as_echo "yes, we need Carbon" >&6; }
     LIBS="$LIBS -framework Carbon"
-  elif test "$MACOS_X_UNIX" = "yes"; then
+  elif test "$MACOS_X_DARWIN" = "yes"; then
     if test "$features" = "tiny"; then
             OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_macosx.m++'`
       OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_macosx.o++'`
@@ -14116,7 +14116,7 @@ $as_echo "yes, we need CoreServices" >&6; }
 $as_echo "no" >&6; }
         OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_mac_conv.c++'`
         OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_mac_conv.o++'`
-        CPPFLAGS=`echo "$CPPFLAGS" | sed -e 's+-DMACOS_X_UNIX++'`
+        CPPFLAGS=`echo "$CPPFLAGS" | sed -e 's+-DMACOS_X_DARWIN++'`
       fi
     else
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, we need AppKit" >&5

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -759,7 +759,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -892,7 +891,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1145,15 +1143,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1291,7 +1280,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1444,7 +1433,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -4187,6 +4175,7 @@ $as_echo_n "checking for Darwin (Mac OS X)... " >&6; }
 if test "`(uname) 2>/dev/null`" = Darwin; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
+  MACOS_X=yes
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking --disable-darwin argument" >&5
 $as_echo_n "checking --disable-darwin argument... " >&6; }
@@ -4357,7 +4346,7 @@ rm -f core conftest.err conftest.$ac_objext \
   fi
 
   if test "$enable_darwin" = "yes"; then
-    MACOSX=yes
+    MACOS_X_UNIX=yes
     OS_EXTRA_SRC="os_macosx.m os_mac_conv.c";
     OS_EXTRA_OBJ="objects/os_macosx.o objects/os_mac_conv.o"
             CPPFLAGS="$CPPFLAGS -DMACOS_X_UNIX"
@@ -5153,7 +5142,7 @@ rm -f core conftest.err conftest.$ac_objext \
       if test -f "${vi_cv_path_lua_pfx}/bin/cyglua-${vi_cv_version_lua}.dll"; then
 	vi_cv_dll_name_lua="cyglua-${vi_cv_version_lua}.dll"
       else
-	if test "x$MACOSX" = "xyes"; then
+	if test "x$MACOS_X" = "xyes"; then
 	  ext="dylib"
 	  indexes=""
 	else
@@ -5199,7 +5188,7 @@ $as_echo "yes" >&6; }
       LUA_CFLAGS="-DDYNAMIC_LUA_DLL=\\\"${vi_cv_dll_name_lua}\\\" $LUA_CFLAGS"
     fi
     if test "X$LUA_CFLAGS$LUA_LIBS" != "X" && \
-       test "x$MACOSX" = "xyes" && test "x$vi_cv_with_luajit" != "xno" && \
+       test "x$MACOS_X" = "xyes" && test "x$vi_cv_with_luajit" != "xno" && \
        test "`(uname -m) 2>/dev/null`" = "x86_64"; then
             LUA_LIBS="-pagezero_size 10000 -image_base 100000000 $LUA_LIBS"
     fi
@@ -5404,7 +5393,7 @@ $as_echo "not found" >&6; }
 
     for path in "${vi_cv_path_mzscheme_pfx}/lib" "${SCHEME_LIB}"; do
       if test "X$path" != "X"; then
-	if test "x$MACOSX" = "xyes"; then
+	if test "x$MACOS_X" = "xyes"; then
 	  MZSCHEME_LIBS="-framework Racket"
 	  MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
 	elif test -f "${path}/libmzscheme3m.a"; then
@@ -5784,7 +5773,7 @@ $as_echo ">>> too old; need Perl version 5.003_01 or later <<<" >&6; }
     fi
   fi
 
-  if test "x$MACOSX" = "xyes"; then
+  if test "x$MACOS_X" = "xyes"; then
         dir=/System/Library/Perl
     darwindir=$dir/darwin
     if test -d $darwindir; then
@@ -6002,7 +5991,7 @@ __:
 eof
 	    	    eval "`cd ${PYTHON_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
 	    rm -f -- "${tmp_mkf}"
-	    if test "x$MACOSX" = "xyes" && test -n "${python_PYTHONFRAMEWORK}" && ${vi_cv_path_python} -c \
+	    if test "x$MACOS_X" = "xyes" && test -n "${python_PYTHONFRAMEWORK}" && ${vi_cv_path_python} -c \
 		"import sys; sys.exit(${vi_cv_var_python_version} < 2.3)"; then
 	      vi_cv_path_python_plibs="-framework Python"
 	      if test "x${vi_cv_path_python}" != "x/usr/bin/python" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
@@ -6965,7 +6954,7 @@ $as_echo "$tclver - OK" >&6; };
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for location of Tcl include" >&5
 $as_echo_n "checking for location of Tcl include... " >&6; }
-      if test "x$MACOSX" != "xyes"; then
+      if test "x$MACOS_X" != "xyes"; then
 	tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
       else
 		tclinc="/System/Library/Frameworks/Tcl.framework/Headers"
@@ -6987,7 +6976,7 @@ $as_echo "<not found>" >&6; }
       if test -z "$SKIP_TCL"; then
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for location of tclConfig.sh script" >&5
 $as_echo_n "checking for location of tclConfig.sh script... " >&6; }
-	if test "x$MACOSX" != "xyes"; then
+	if test "x$MACOS_X" != "xyes"; then
 	  tclcnf=`echo $tclinc | sed s/include/lib/g`
 	  tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
 	else
@@ -7567,7 +7556,7 @@ fi
 $as_echo "$enable_fontset" >&6; }
 
 test -z "$with_x" && with_x=yes
-test "${enable_gui-yes}" != no -a "x$MACOSX" != "xyes" -a "x$QNX" != "xyes" && with_x=yes
+test "${enable_gui-yes}" != no -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" && with_x=yes
 if test "$with_x" = no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: defaulting to: don't HAVE_X11" >&5
 $as_echo "defaulting to: don't HAVE_X11" >&6; }
@@ -8584,7 +8573,7 @@ $as_echo "$ac_cv_small_wchar_t" >&6; }
   fi
 fi
 
-test "x$with_x" = xno -a "x$MACOSX" != "xyes" -a "x$QNX" != "xyes" && enable_gui=no
+test "x$with_x" = xno -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" && enable_gui=no
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking --enable-gui argument" >&5
 $as_echo_n "checking --enable-gui argument... " >&6; }
@@ -8626,7 +8615,7 @@ $as_echo "Sorry, $enable_gui GUI is not supported" >&6; }
 		SKIP_PHOTON=YES ;;
   esac
 
-elif test "x$MACOSX" = "xyes" -a "x$with_x" = "xno" ; then
+elif test "x$MACOS_X" = "xyes" -a "x$with_x" = "xno" ; then
   SKIP_CARBON=
   case "$enable_gui_canon" in
     no)		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no GUI support" >&5
@@ -8804,7 +8793,7 @@ $as_echo "$enable_carbon_check" >&6; };
 fi
 
 
-if test "x$MACOSX" = "xyes" -a -z "$SKIP_CARBON" -a "x$CARBON" = "xyes"; then
+if test "x$MACOS_X" = "xyes" -a -z "$SKIP_CARBON" -a "x$CARBON" = "xyes"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Carbon GUI" >&5
 $as_echo_n "checking for Carbon GUI... " >&6; }
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
@@ -10624,7 +10613,7 @@ fi
 
 done
 
-if test "x$MACOSX" = "xyes"; then
+if test "x$MACOS_X" = "xyes"; then
     $as_echo "#define NO_STRINGS_WITH_STRING_H 1" >>confdefs.h
 
 else
@@ -12182,7 +12171,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -12228,7 +12217,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -12252,7 +12241,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -12297,7 +12286,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -12321,7 +12310,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -14099,14 +14088,14 @@ fi
 done
 
 
-if test "x$MACOSX" = "xyes" -a -n "$PERL"; then
+if test "x$MACOS_X" = "xyes" -a -n "$PERL"; then
     if echo $LIBS | grep -e '-ldl' >/dev/null; then
     LIBS=`echo $LIBS | sed s/-ldl//`
     PERL_LIBS="$PERL_LIBS -ldl"
   fi
 fi
 
-if test "x$MACOSX" = "xyes"; then
+if test "x$MACOS_X_UNIX" = "xyes"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need -framework Cocoa" >&5
 $as_echo_n "checking whether we need -framework Cocoa... " >&6; }
       if test "x$features" != "xtiny" || test "x$enable_multibyte" = "xyes"; then

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -212,6 +212,7 @@
 #undef HAVE_USLEEP
 #undef HAVE_UTIME
 #undef HAVE_BIND_TEXTDOMAIN_CODESET
+#undef HAVE_MBLEN
 
 /* Define, if needed, for accessing large files. */
 #undef _LARGE_FILES

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -134,6 +134,7 @@ dnl are a lot of other things we need to change besides GUI stuff
 AC_MSG_CHECKING([for Darwin (Mac OS X)])
 if test "`(uname) 2>/dev/null`" = Darwin; then
   AC_MSG_RESULT(yes)
+  MACOS_X=yes
 
   AC_MSG_CHECKING(--disable-darwin argument)
   AC_ARG_ENABLE(darwin,
@@ -208,7 +209,7 @@ if test "`(uname) 2>/dev/null`" = Darwin; then
   fi
 
   if test "$enable_darwin" = "yes"; then
-    MACOSX=yes
+    MACOS_X_UNIX=yes
     OS_EXTRA_SRC="os_macosx.m os_mac_conv.c";
     OS_EXTRA_OBJ="objects/os_macosx.o objects/os_mac_conv.o"
     dnl TODO: use -arch i386 on Intel machines
@@ -626,7 +627,7 @@ if test "$enable_luainterp" = "yes" -o "$enable_luainterp" = "dynamic"; then
       if test -f "${vi_cv_path_lua_pfx}/bin/cyglua-${vi_cv_version_lua}.dll"; then
 	vi_cv_dll_name_lua="cyglua-${vi_cv_version_lua}.dll"
       else
-	if test "x$MACOSX" = "xyes"; then
+	if test "x$MACOS_X" = "xyes"; then
 	  ext="dylib"
 	  indexes=""
 	else
@@ -670,7 +671,7 @@ if test "$enable_luainterp" = "yes" -o "$enable_luainterp" = "dynamic"; then
       LUA_CFLAGS="-DDYNAMIC_LUA_DLL=\\\"${vi_cv_dll_name_lua}\\\" $LUA_CFLAGS"
     fi
     if test "X$LUA_CFLAGS$LUA_LIBS" != "X" && \
-       test "x$MACOSX" = "xyes" && test "x$vi_cv_with_luajit" != "xno" && \
+       test "x$MACOS_X" = "xyes" && test "x$vi_cv_with_luajit" != "xno" && \
        test "`(uname -m) 2>/dev/null`" = "x86_64"; then
       dnl OSX/x64 requires these flags. See http://luajit.org/install.html
       LUA_LIBS="-pagezero_size 10000 -image_base 100000000 $LUA_LIBS"
@@ -802,7 +803,7 @@ if test "$enable_mzschemeinterp" = "yes"; then
 
     for path in "${vi_cv_path_mzscheme_pfx}/lib" "${SCHEME_LIB}"; do
       if test "X$path" != "X"; then
-	if test "x$MACOSX" = "xyes"; then
+	if test "x$MACOS_X" = "xyes"; then
 	  MZSCHEME_LIBS="-framework Racket"
 	  MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
 	elif test -f "${path}/libmzscheme3m.a"; then
@@ -1059,7 +1060,7 @@ if test "$enable_perlinterp" = "yes" -o "$enable_perlinterp" = "dynamic"; then
     fi
   fi
 
-  if test "x$MACOSX" = "xyes"; then
+  if test "x$MACOS_X" = "xyes"; then
     dnl Mac OS X 10.2 or later
     dir=/System/Library/Perl
     darwindir=$dir/darwin
@@ -1201,7 +1202,7 @@ eof
 	    dnl -- delete the lines from make about Entering/Leaving directory
 	    eval "`cd ${PYTHON_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
 	    rm -f -- "${tmp_mkf}"
-	    if test "x$MACOSX" = "xyes" && test -n "${python_PYTHONFRAMEWORK}" && ${vi_cv_path_python} -c \
+	    if test "x$MACOS_X" = "xyes" && test -n "${python_PYTHONFRAMEWORK}" && ${vi_cv_path_python} -c \
 		"import sys; sys.exit(${vi_cv_var_python_version} < 2.3)"; then
 	      vi_cv_path_python_plibs="-framework Python"
 	      if test "x${vi_cv_path_python}" != "x/usr/bin/python" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
@@ -1269,7 +1270,7 @@ eof
 	AC_MSG_CHECKING([if -pthread should be used])
 	threadsafe_flag=
 	thread_lib=
-	dnl if test "x$MACOSX" != "xyes"; then
+	dnl if test "x$MACOS_X" != "xyes"; then
         if test "`(uname) 2>/dev/null`" != Darwin; then
 	  test "$GCC" = yes && threadsafe_flag="-pthread"
 	  if test "`(uname) 2>/dev/null`" = FreeBSD; then
@@ -1474,7 +1475,7 @@ eof
         AC_MSG_CHECKING([if -pthread should be used])
         threadsafe_flag=
         thread_lib=
-        dnl if test "x$MACOSX" != "xyes"; then
+        dnl if test "x$MACOS_X" != "xyes"; then
         if test "`(uname) 2>/dev/null`" != Darwin; then
           test "$GCC" = yes && threadsafe_flag="-pthread"
           if test "`(uname) 2>/dev/null`" = FreeBSD; then
@@ -1729,7 +1730,7 @@ if test "$enable_tclinterp" = "yes" -o "$enable_tclinterp" = "dynamic"; then
       tcldll=`echo 'puts libtcl[[info tclversion]][[info sharedlibextension]]' | $vi_cv_path_tcl -`
 
       AC_MSG_CHECKING(for location of Tcl include)
-      if test "x$MACOSX" != "xyes"; then
+      if test "x$MACOS_X" != "xyes"; then
 	tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
       else
 	dnl For Mac OS X 10.3, use the OS-provided framework location
@@ -1749,7 +1750,7 @@ if test "$enable_tclinterp" = "yes" -o "$enable_tclinterp" = "dynamic"; then
       fi
       if test -z "$SKIP_TCL"; then
 	AC_MSG_CHECKING(for location of tclConfig.sh script)
-	if test "x$MACOSX" != "xyes"; then
+	if test "x$MACOS_X" != "xyes"; then
 	  tclcnf=`echo $tclinc | sed s/include/lib/g`
 	  tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
 	else
@@ -2093,7 +2094,7 @@ AC_MSG_RESULT($enable_fontset)
 dnl defining FEAT_XFONTSET is delayed, so that it can be disabled for no GUI
 
 test -z "$with_x" && with_x=yes
-test "${enable_gui-yes}" != no -a "x$MACOSX" != "xyes" -a "x$QNX" != "xyes" && with_x=yes
+test "${enable_gui-yes}" != no -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" && with_x=yes
 if test "$with_x" = no; then
   AC_MSG_RESULT(defaulting to: don't HAVE_X11)
 else
@@ -2224,7 +2225,7 @@ else
   fi
 fi
 
-test "x$with_x" = xno -a "x$MACOSX" != "xyes" -a "x$QNX" != "xyes" && enable_gui=no
+test "x$with_x" = xno -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" && enable_gui=no
 
 AC_MSG_CHECKING(--enable-gui argument)
 AC_ARG_ENABLE(gui,
@@ -2258,7 +2259,7 @@ if test "x$QNX" = "xyes" -a "x$with_x" = "xno" ; then
 		SKIP_PHOTON=YES ;;
   esac
 
-elif test "x$MACOSX" = "xyes" -a "x$with_x" = "xno" ; then
+elif test "x$MACOS_X" = "xyes" -a "x$with_x" = "xno" ; then
   SKIP_CARBON=
   case "$enable_gui_canon" in
     no)		AC_MSG_RESULT(no GUI support)
@@ -2380,7 +2381,7 @@ if test "x$SKIP_CARBON" != "xYES" -a "$enable_gui_canon" != "carbon"; then
 fi
 
 
-if test "x$MACOSX" = "xyes" -a -z "$SKIP_CARBON" -a "x$CARBON" = "xyes"; then
+if test "x$MACOS_X" = "xyes" -a -z "$SKIP_CARBON" -a "x$CARBON" = "xyes"; then
   AC_MSG_CHECKING(for Carbon GUI)
   dnl already did the check, just give the message
   AC_MSG_RESULT(yes);
@@ -3188,7 +3189,7 @@ AC_TRY_COMPILE([
 	      AC_MSG_RESULT(no))
 
 AC_CHECK_HEADERS(strings.h)
-if test "x$MACOSX" = "xyes"; then
+if test "x$MACOS_X" = "xyes"; then
   dnl The strings.h file on OS/X contains a warning and nothing useful.
   AC_DEFINE(NO_STRINGS_WITH_STRING_H)
 else
@@ -4277,7 +4278,7 @@ elif test x${DLL} = xdl.h; then
 fi
 AC_CHECK_HEADERS(setjmp.h)
 
-if test "x$MACOSX" = "xyes" -a -n "$PERL"; then
+if test "x$MACOS_X" = "xyes" -a -n "$PERL"; then
   dnl -ldl must come after DynaLoader.a
   if echo $LIBS | grep -e '-ldl' >/dev/null; then
     LIBS=`echo $LIBS | sed s/-ldl//`
@@ -4285,7 +4286,7 @@ if test "x$MACOSX" = "xyes" -a -n "$PERL"; then
   fi
 fi
 
-if test "x$MACOSX" = "xyes"; then
+if test "x$MACOS_X_UNIX" = "xyes"; then
   AC_MSG_CHECKING(whether we need -framework Cocoa)
   dnl Cocoa is needed with FEAT_CLIPBOARD or FEAT_MBYTE (the former is
   dnl disabled during tiny build)

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3652,7 +3652,7 @@ AC_CHECK_FUNCS(fchdir fchown fsync getcwd getpseudotty \
 	getpgid setpgid setsid sigaltstack sigstack sigset sigsetjmp sigaction \
 	sigprocmask sigvec strcasecmp strerror strftime stricmp strncasecmp \
 	strnicmp strpbrk strtol tgetent towlower towupper iswupper \
-	usleep utime utimes)
+	usleep utime utimes mblen)
 AC_FUNC_FSEEKO
 
 dnl define _LARGE_FILES, _FILE_OFFSET_BITS and _LARGEFILE_SOURCE when

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4286,22 +4286,40 @@ if test "x$MACOS_X" = "xyes" -a -n "$PERL"; then
   fi
 fi
 
-if test "x$MACOS_X_UNIX" = "xyes"; then
-  AC_MSG_CHECKING(whether we need -framework Cocoa)
-  dnl Cocoa is needed with FEAT_CLIPBOARD or FEAT_MBYTE (the former is
-  dnl disabled during tiny build)
-  if test "x$features" != "xtiny" || test "x$enable_multibyte" = "xyes"; then
-    LIBS=$"$LIBS -framework Cocoa"
-    AC_MSG_RESULT(yes)
+if test "$MACOS_X" = "yes"; then
+  AC_MSG_CHECKING([whether we need macOS frameworks])
+  if test "$GUITYPE" = "CARBONGUI"; then
+    AC_MSG_RESULT([yes, we need Carbon])
+    LIBS="$LIBS -framework Carbon"
+  elif test "$MACOS_X_UNIX" = "yes"; then
+    if test "$features" = "tiny"; then
+      dnl Since no FEAT_CLIPBOARD, no longer need for os_macosx.m.
+      OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_macosx.m++'`
+      OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_macosx.o++'`
+      if test "$enable_multibyte" = "yes"; then
+        AC_MSG_RESULT([yes, we need CoreServices])
+        LIBS="$LIBS -framework CoreServices"
+      else
+        dnl Since no FEAT_MBYTE, no longer need for os_mac_conv.c.
+        AC_MSG_RESULT([no])
+        OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_mac_conv.c++'`
+        OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_mac_conv.o++'`
+        CPPFLAGS=`echo "$CPPFLAGS" | sed -e 's+-DMACOS_X_UNIX++'`
+      fi
+    else
+      AC_MSG_RESULT([yes, we need AppKit])
+      LIBS="$LIBS -framework AppKit"
+      if test "$features" = "small" -a "$enable_multibyte" = "no"; then
+        dnl Since FEAT_CLIPBOARD is to be defined in vim.h for FEAT_SMALL, define
+        dnl FEAT_MBYTE in order not to compromise the interoperability of the
+        dnl clipboard.
+        AC_MSG_NOTICE([+multi_byte will be set in favor of +clipboard])
+        enable_multibyte=yes
+        AC_DEFINE(FEAT_MBYTE)
+      fi
+    fi
   else
-    AC_MSG_RESULT(no)
-  fi
-  dnl As mentioned above, tiny build implies os_macosx.m isn't needed.  
-  dnl Exclude it from OS_EXTRA_SRC so that linker won't complain about
-  dnl missing Objective-C symbols.
-  if test "x$features" = "xtiny"; then
-    OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_macosx.m++'`
-    OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_macosx.o++'`
+    AC_MSG_RESULT([no])
   fi
 fi
 if test "x$MACARCH" = "xboth" && test "x$GUITYPE" = "xCARBONGUI"; then

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -210,12 +210,12 @@ if test "`(uname) 2>/dev/null`" = Darwin; then
   fi
 
   if test "$enable_darwin" = "yes"; then
-    MACOS_X_UNIX=yes
+    MACOS_X_DARWIN=yes
     OS_EXTRA_SRC="os_macosx.m os_mac_conv.c";
     OS_EXTRA_OBJ="objects/os_macosx.o objects/os_mac_conv.o"
     dnl TODO: use -arch i386 on Intel machines
     dnl Removed -no-cpp-precomp, only for very old compilers.
-    CPPFLAGS="$CPPFLAGS -DMACOS_X_UNIX"
+    CPPFLAGS="$CPPFLAGS -DMACOS_X_DARWIN"
 
     dnl If Carbon is found, assume we don't want X11
     dnl unless it was specifically asked for (--with-x)
@@ -4292,7 +4292,7 @@ if test "$MACOS_X" = "yes"; then
   if test "$GUITYPE" = "CARBONGUI"; then
     AC_MSG_RESULT([yes, we need Carbon])
     LIBS="$LIBS -framework Carbon"
-  elif test "$MACOS_X_UNIX" = "yes"; then
+  elif test "$MACOS_X_DARWIN" = "yes"; then
     if test "$features" = "tiny"; then
       dnl Since no FEAT_CLIPBOARD, no longer need for os_macosx.m.
       OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_macosx.m++'`
@@ -4305,7 +4305,7 @@ if test "$MACOS_X" = "yes"; then
         AC_MSG_RESULT([no])
         OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_mac_conv.c++'`
         OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_mac_conv.o++'`
-        CPPFLAGS=`echo "$CPPFLAGS" | sed -e 's+-DMACOS_X_UNIX++'`
+        CPPFLAGS=`echo "$CPPFLAGS" | sed -e 's+-DMACOS_X_DARWIN++'`
       fi
     else
       AC_MSG_RESULT([yes, we need AppKit])

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -135,6 +135,7 @@ AC_MSG_CHECKING([for Darwin (Mac OS X)])
 if test "`(uname) 2>/dev/null`" = Darwin; then
   AC_MSG_RESULT(yes)
   MACOS_X=yes
+  CPPFLAGS="$CPPFLAGS -DMACOS_X"
 
   AC_MSG_CHECKING(--disable-darwin argument)
   AC_ARG_ENABLE(darwin,

--- a/src/digraph.c
+++ b/src/digraph.c
@@ -321,7 +321,7 @@ static digr_T digraphdefault[] =
 	};
 
 #  else
-#   if defined(MACOS) && !defined(FEAT_MBYTE)
+#   if defined(MACOS_X) && !defined(FEAT_MBYTE)
 
 	/*
 	 * Macintosh digraphs
@@ -449,7 +449,7 @@ static digr_T digraphdefault[] =
 	{NUL, NUL, NUL}
 	};
 
-#   else	/* !MACOS */
+#   else	/* !MACOS_X */
 
 #    ifdef OLD_DIGRAPHS
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -5974,7 +5974,7 @@ insert_special(
      * Only use mod_mask for special keys, to avoid things like <S-Space>,
      * unless 'allow_modmask' is TRUE.
      */
-#ifdef MACOS
+#ifdef MACOS_X
     /* Command-key never produces a normal key */
     if (mod_mask & MOD_MASK_CMD)
 	allow_modmask = TRUE;
@@ -8753,7 +8753,7 @@ ins_start_select(int c)
 	    case K_KPAGEUP:
 	    case K_PAGEDOWN:
 	    case K_KPAGEDOWN:
-# ifdef MACOS
+# ifdef MACOS_X
 	    case K_LEFT:
 	    case K_RIGHT:
 	    case K_UP:

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5543,7 +5543,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 	"mac",		/* Mac OS Classic or Mac OS X */
 # ifdef MACOS_X
 	"osx",		/* Mac OS X */
-#  ifdef MACOS_X_UNIX
+#  ifdef MACOS_X_DARWIN
 	"macunix",	/* Mac OS X, with the darwin feature */
 	"osxdarwin",	/* synonym for macunix */
 #  endif

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5540,13 +5540,14 @@ f_has(typval_T *argvars, typval_T *rettv)
 	"beos",
 #endif
 #ifdef MACOS
-	"mac",
-#endif
-#if defined(MACOS_X_UNIX)
-	"macunix",  /* built with 'darwin' enabled */
-#endif
-#if defined(__APPLE__) && __APPLE__ == 1
-	"osx",	    /* built with or without 'darwin' enabled */
+	"mac",		/* Mac OS Classic or Mac OS X */
+# ifdef MACOS_X
+	"osx",		/* Mac OS X */
+#  ifdef MACOS_X_UNIX
+	"macunix",	/* Mac OS X, with the darwin feature */
+	"osxdarwin",	/* synonym for macunix */
+#  endif
+# endif
 #endif
 #ifdef __QNX__
 	"qnx",

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -24,7 +24,7 @@
 # include <float.h>
 #endif
 
-#ifdef MACOS
+#ifdef MACOS_X
 # include <time.h>	/* for time_t */
 #endif
 
@@ -5539,14 +5539,12 @@ f_has(typval_T *argvars, typval_T *rettv)
 #ifdef __BEOS__
 	"beos",
 #endif
-#ifdef MACOS
-	"mac",		/* Mac OS X (and, once, Mac OS Classic) */
-# ifdef MACOS_X
-	"osx",		/* Mac OS X */
-#  ifdef MACOS_X_DARWIN
-	"macunix",	/* Mac OS X, with the darwin feature */
-	"osxdarwin",	/* synonym for macunix */
-#  endif
+#ifdef MACOS_X
+       "mac",		/* Mac OS X (and, once, Mac OS Classic) */
+       "osx",		/* Mac OS X */
+# ifdef MACOS_X_DARWIN
+       "macunix",	/* Mac OS X, with the darwin feature */
+       "osxdarwin",	/* synonym for macunix */
 # endif
 #endif
 #ifdef __QNX__

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5540,7 +5540,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 	"beos",
 #endif
 #ifdef MACOS
-	"mac",		/* Mac OS Classic or Mac OS X */
+	"mac",		/* Mac OS X (and, once, Mac OS Classic) */
 # ifdef MACOS_X
 	"osx",		/* Mac OS X */
 #  ifdef MACOS_X_DARWIN

--- a/src/feature.h
+++ b/src/feature.h
@@ -64,7 +64,7 @@
 # if defined(UNIX) || defined(WIN3264) || defined(MACOS)
 #  define FEAT_HUGE
 # else
-#  if defined(MSWIN) || defined(VMS) || defined(MACOS) || defined(AMIGA)
+#  if defined(MSWIN) || defined(VMS) || defined(AMIGA)
 #   define FEAT_BIG
 #  else
 #   define FEAT_NORMAL

--- a/src/feature.h
+++ b/src/feature.h
@@ -777,7 +777,7 @@
  * there is no terminal version, and on Windows we can't figure out how to
  * fork one off with :gui.
  */
-#if defined(FEAT_GUI_MSWIN) || (defined(FEAT_GUI_MAC) && !defined(MACOS_X_UNIX))
+#if defined(FEAT_GUI_MSWIN) || (defined(FEAT_GUI_MAC) && !defined(MACOS_X_DARWIN))
 # define ALWAYS_USE_GUI
 #endif
 

--- a/src/feature.h
+++ b/src/feature.h
@@ -61,7 +61,7 @@
  */
 #if !defined(FEAT_TINY) && !defined(FEAT_SMALL) && !defined(FEAT_NORMAL) \
 	&& !defined(FEAT_BIG) && !defined(FEAT_HUGE)
-# if defined(UNIX) || defined(WIN3264) || defined(MACOS)
+# if defined(UNIX) || defined(WIN3264) || defined(MACOS_X)
 #  define FEAT_HUGE
 # else
 #  if defined(MSWIN) || defined(VMS) || defined(AMIGA)
@@ -363,7 +363,7 @@
  */
 #ifdef FEAT_NORMAL
 # define FEAT_EVAL
-# if defined(HAVE_FLOAT_FUNCS) || defined(WIN3264) || defined(MACOS)
+# if defined(HAVE_FLOAT_FUNCS) || defined(WIN3264) || defined(MACOS_X)
 #  define FEAT_FLOAT
 # endif
 # if defined(HAVE_STDINT_H) || defined(WIN3264) || (VIM_SIZEOF_LONG >= 8)

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4200,20 +4200,6 @@ buf_write(
 	}
     }
 
-#ifdef MACOS_CLASSIC /* TODO: Is it need for MACOS_X? (Dany) */
-    /*
-     * Before risking to lose the original file verify if there's
-     * a resource fork to preserve, and if cannot be done warn
-     * the users. This happens when overwriting without backups.
-     */
-    if (backup == NULL && overwriting && !append)
-	if (mch_has_resource_fork(fname))
-	{
-	    errmsg = (char_u *)_("E460: The resource fork would be lost (add ! to override)");
-	    goto restore_backup;
-	}
-#endif
-
 #ifdef VMS
     vms_remove_version(fname); /* remove version */
 #endif
@@ -4474,13 +4460,7 @@ restore_backup:
 	    }
 	    write_info.bw_fd = fd;
 
-#if defined(MACOS_CLASSIC) || defined(WIN3264)
-	    /* TODO: Is it need for MACOS_X? (Dany) */
-	    /*
-	     * On macintosh copy the original files attributes (i.e. the backup)
-	     * This is done in order to preserve the resource fork and the
-	     * Finder attribute (label, comments, custom icons, file creator)
-	     */
+#if defined(WIN3264)
 	    if (backup != NULL && overwriting && !append)
 	    {
 		if (backup_copy)
@@ -5199,10 +5179,6 @@ nofail:
 
     got_int |= prev_got_int;
 
-#ifdef MACOS_CLASSIC /* TODO: Is it need for MACOS_X? (Dany) */
-    /* Update machine specific information. */
-    mch_post_buffer_write(buf);
-#endif
     return retval;
 }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -68,7 +68,7 @@ static int au_find_group(char_u *name);
 #  define FIO_PUT_CP(x) (((x) & 0xffff) << 16)	/* put codepage in top word */
 #  define FIO_GET_CP(x)	(((x)>>16) & 0xffff)	/* get codepage from top word */
 # endif
-# ifdef MACOS_X
+# ifdef MACOS_CONVERT
 #  define FIO_MACROMAN	0x20	/* convert MacRoman */
 # endif
 # define FIO_ENDIAN_L	0x80	/* little endian */
@@ -127,7 +127,7 @@ static int make_bom(char_u *buf, char_u *name);
 # ifdef WIN3264
 static int get_win_fio_flags(char_u *ptr);
 # endif
-# ifdef MACOS_X
+# ifdef MACOS_CONVERT
 static int get_mac_fio_flags(char_u *ptr);
 # endif
 #endif
@@ -1088,7 +1088,7 @@ retry:
 	    fio_flags = get_win_fio_flags(fenc);
 # endif
 
-# ifdef MACOS_X
+# ifdef MACOS_CONVERT
 	/* Conversion from Apple MacRoman to latin1 or UTF-8 */
 	if (fio_flags == 0)
 	    fio_flags = get_mac_fio_flags(fenc);
@@ -1274,7 +1274,7 @@ retry:
 		else if (fio_flags & FIO_CODEPAGE)
 		    size = size / ICONV_MULT;	/* also worst case */
 # endif
-# ifdef MACOS_X
+# ifdef MACOS_CONVERT
 		else if (fio_flags & FIO_MACROMAN)
 		    size = size / ICONV_MULT;	/* also worst case */
 # endif
@@ -4271,7 +4271,7 @@ buf_write(
     }
 # endif
 
-# ifdef MACOS_X
+# ifdef MACOS_CONVERT
     if (converted && wb_flags == 0 && (wb_flags = get_mac_fio_flags(fenc)) != 0)
     {
 	write_info.bw_conv_buflen = bufsize * 3;
@@ -5972,7 +5972,7 @@ get_win_fio_flags(char_u *ptr)
 }
 #endif
 
-#ifdef MACOS_X
+#ifdef MACOS_CONVERT
 /*
  * Check "ptr" for a Carbon supported encoding and return the FIO_ flags
  * needed for the internal conversion to/from utf-8 or latin1.

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -5257,7 +5257,7 @@ check_map(
 }
 #endif
 
-#if defined(MSWIN) || defined(MACOS)
+#if defined(MSWIN) || defined(MACOS_X)
 
 #define VIS_SEL	(VISUAL+SELECTMODE)	/* abbreviation */
 
@@ -5308,7 +5308,7 @@ static struct initmap
 # endif
 #endif
 
-#if defined(MACOS)
+#if defined(MACOS_X)
 	/* Use the Standard MacOS binding. */
 	/* paste, copy and cut */
 	{(char_u *)"<D-v> \"*P", NORMAL},
@@ -5329,7 +5329,7 @@ static struct initmap
     void
 init_mappings(void)
 {
-#if defined(MSWIN) ||defined(MACOS)
+#if defined(MSWIN) || defined(MACOS_X)
     int		i;
 
     for (i = 0; i < (int)(sizeof(initmappings) / sizeof(struct initmap)); ++i)
@@ -5337,7 +5337,8 @@ init_mappings(void)
 #endif
 }
 
-#if defined(MSWIN) || defined(FEAT_CMDWIN) || defined(MACOS) || defined(PROTO)
+#if defined(MSWIN) || defined(FEAT_CMDWIN) || defined(MACOS_X) \
+							     || defined(PROTO)
 /*
  * Add a mapping "map" for mode "mode".
  * Need to put string in allocated memory, because do_map() will modify it.

--- a/src/globals.h
+++ b/src/globals.h
@@ -1418,7 +1418,7 @@ EXTERN char_u e_failed[]	INIT(= N_("E472: Command failed"));
 #if defined(FEAT_GUI) && defined(FEAT_XFONTSET)
 EXTERN char_u e_fontset[]	INIT(= N_("E234: Unknown fontset: %s"));
 #endif
-#if defined(FEAT_GUI_X11) || defined(FEAT_GUI_GTK) || defined(MACOS) \
+#if defined(FEAT_GUI_X11) || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MAC) \
 	|| defined(FEAT_GUI_PHOTON) || defined(FEAT_GUI_MSWIN)
 EXTERN char_u e_font[]		INIT(= N_("E235: Unknown font: %s"));
 #endif
@@ -1585,7 +1585,7 @@ EXTERN char_u e_invalidreg[]    INIT(= N_("E850: Invalid register name"));
 #endif
 EXTERN char_u e_dirnotf[]	INIT(= N_("E919: Directory not found in '%s': \"%s\""));
 
-#ifdef MACOS_X_UNIX
+#ifdef FEAT_GUI_MAC
 EXTERN short disallow_gui	INIT(= FALSE);
 #endif
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -1538,7 +1538,7 @@ EXTERN char_u e_readerrf[]	INIT(= N_("E47: Error while reading errorfile"));
 EXTERN char_u e_sandbox[]	INIT(= N_("E48: Not allowed in sandbox"));
 #endif
 EXTERN char_u e_secure[]	INIT(= N_("E523: Not allowed here"));
-#if defined(AMIGA) || defined(MACOS) || defined(MSWIN)  \
+#if defined(AMIGA) || defined(MACOS_X) || defined(MSWIN)  \
 	|| defined(UNIX) || defined(VMS)
 EXTERN char_u e_screenmode[]	INIT(= N_("E359: Screen mode setting not supported"));
 #endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -37,7 +37,7 @@ static void gui_set_fg_color(char_u *name);
 static void gui_set_bg_color(char_u *name);
 static win_T *xy2win(int x, int y);
 
-#if defined(UNIX) && !defined(MACOS_X) && !defined(__APPLE__)
+#if defined(UNIX) && !defined(FEAT_GUI_MAC)
 # define MAY_FORK
 static void gui_do_fork(void);
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -2511,7 +2511,7 @@ gui_outstr_nowrap(
 	    /* Draw a composing char on top of the previous char. */
 	    if (comping)
 	    {
-#  if (defined(__APPLE_CC__) || defined(__MRC__)) && TARGET_API_MAC_CARBON
+#  if defined(__APPLE_CC__) && TARGET_API_MAC_CARBON
 		/* Carbon ATSUI autodraws composing char over previous char */
 		gui_mch_draw_string(gui.row, scol, s + i, cl,
 						    draw_flags | DRAW_TRANSP);

--- a/src/gui_mac.c
+++ b/src/gui_mac.c
@@ -267,9 +267,7 @@ static struct
 /*  {XK_Help,		'%', '1'}, */
 /*  {XK_Undo,		'&', '8'}, */
 /*  {XK_BackSpace,	'k', 'b'}, */
-#ifndef MACOS_X
-    {vk_Delete,		'k', 'b'},
-#endif
+/*  {vk_Delete,		'k', 'b'}, */
     {vk_Insert,		'k', 'I'},
     {vk_FwdDelete,	'k', 'D'},
     {vk_Home,		'k', 'h'},

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -944,9 +944,7 @@ Python_Init(void)
 	Py_NoSiteFlag++;
 #endif
 
-#if defined(MACOS_X)
 	Py_Initialize();
-#endif
 
 #if defined(PY_VERSION_HEX) && PY_VERSION_HEX >= 0x02070000
 	/* 'import site' explicitly. */

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -70,10 +70,6 @@
 # undef PY_SSIZE_T_CLEAN
 #endif
 
-#if defined(MACOS) && !defined(MACOS_X)
-# include "macglue.h"
-# include <CodeFragments.h>
-#endif
 #undef main /* Defined in python.h - aargh */
 #undef HAVE_FCNTL_H /* Clash with os_win32.h */
 
@@ -948,10 +944,8 @@ Python_Init(void)
 	Py_NoSiteFlag++;
 #endif
 
-#if !defined(MACOS) || defined(MACOS_X)
+#if defined(MACOS_X)
 	Py_Initialize();
-#else
-	PyMac_Initialize();
 #endif
 
 #if defined(PY_VERSION_HEX) && PY_VERSION_HEX >= 0x02070000
@@ -1024,9 +1018,6 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
 #ifndef PY_CAN_RECURSE
     static int		recursive = 0;
 #endif
-#if defined(MACOS) && !defined(MACOS_X)
-    GrafPtr		oldPort;
-#endif
 #if defined(HAVE_LOCALE_H) || defined(X_LOCALE)
     char		*saved_locale;
 #endif
@@ -1045,12 +1036,6 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
     if (python_end_called)
 	return;
 
-#if defined(MACOS) && !defined(MACOS_X)
-    GetPort(&oldPort);
-    /* Check if the Python library is available */
-    if ((Ptr)PyMac_Initialize == (Ptr)kUnresolvedCFragSymbolAddress)
-	goto theend;
-#endif
     if (Python_Init())
 	goto theend;
 
@@ -1099,9 +1084,6 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
 
     Python_Lock_Vim();		    /* enter vim */
     PythonIO_Flush();
-#if defined(MACOS) && !defined(MACOS_X)
-    SetPort(oldPort);
-#endif
 
 theend:
 #ifndef PY_CAN_RECURSE

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -70,7 +70,7 @@
 # undef PY_SSIZE_T_CLEAN
 #endif
 
-#if defined(MACOS) && !defined(MACOS_X_UNIX)
+#if defined(MACOS) && !defined(MACOS_X)
 # include "macglue.h"
 # include <CodeFragments.h>
 #endif
@@ -948,7 +948,7 @@ Python_Init(void)
 	Py_NoSiteFlag++;
 #endif
 
-#if !defined(MACOS) || defined(MACOS_X_UNIX)
+#if !defined(MACOS) || defined(MACOS_X)
 	Py_Initialize();
 #else
 	PyMac_Initialize();
@@ -1024,7 +1024,7 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
 #ifndef PY_CAN_RECURSE
     static int		recursive = 0;
 #endif
-#if defined(MACOS) && !defined(MACOS_X_UNIX)
+#if defined(MACOS) && !defined(MACOS_X)
     GrafPtr		oldPort;
 #endif
 #if defined(HAVE_LOCALE_H) || defined(X_LOCALE)
@@ -1045,7 +1045,7 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
     if (python_end_called)
 	return;
 
-#if defined(MACOS) && !defined(MACOS_X_UNIX)
+#if defined(MACOS) && !defined(MACOS_X)
     GetPort(&oldPort);
     /* Check if the Python library is available */
     if ((Ptr)PyMac_Initialize == (Ptr)kUnresolvedCFragSymbolAddress)
@@ -1099,7 +1099,7 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
 
     Python_Lock_Vim();		    /* enter vim */
     PythonIO_Flush();
-#if defined(MACOS) && !defined(MACOS_X_UNIX)
+#if defined(MACOS) && !defined(MACOS_X)
     SetPort(oldPort);
 #endif
 

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -867,9 +867,8 @@ Python3_Init(void)
 
 	PyImport_AppendInittab("vim", Py3Init_vim);
 
-#if defined(MACOS_X)
 	Py_Initialize();
-#endif
+
 	/* Initialise threads, and below save the state using
 	 * PyEval_SaveThread.  Without the call to PyEval_SaveThread, thread
 	 * specific state (such as the system trace hook), will be lost

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -74,7 +74,7 @@
 
 #include <Python.h>
 
-#if defined(MACOS) && !defined(MACOS_X_UNIX)
+#if defined(MACOS) && !defined(MACOS_X)
 # include "macglue.h"
 # include <CodeFragments.h>
 #endif
@@ -871,7 +871,7 @@ Python3_Init(void)
 
 	PyImport_AppendInittab("vim", Py3Init_vim);
 
-#if !defined(MACOS) || defined(MACOS_X_UNIX)
+#if !defined(MACOS) || defined(MACOS_X)
 	Py_Initialize();
 #else
 	PyMac_Initialize();
@@ -929,7 +929,7 @@ fail:
     static void
 DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
 {
-#if defined(MACOS) && !defined(MACOS_X_UNIX)
+#if defined(MACOS) && !defined(MACOS_X)
     GrafPtr		oldPort;
 #endif
 #if defined(HAVE_LOCALE_H) || defined(X_LOCALE)
@@ -942,7 +942,7 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
     if (python_end_called)
 	goto theend;
 
-#if defined(MACOS) && !defined(MACOS_X_UNIX)
+#if defined(MACOS) && !defined(MACOS_X)
     GetPort(&oldPort);
     /* Check if the Python library is available */
     if ((Ptr)PyMac_Initialize == (Ptr)kUnresolvedCFragSymbolAddress)
@@ -992,7 +992,7 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
 
     Python_Lock_Vim();		    /* enter vim */
     PythonIO_Flush();
-#if defined(MACOS) && !defined(MACOS_X_UNIX)
+#if defined(MACOS) && !defined(MACOS_X)
     SetPort(oldPort);
 #endif
 

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -74,10 +74,6 @@
 
 #include <Python.h>
 
-#if defined(MACOS) && !defined(MACOS_X)
-# include "macglue.h"
-# include <CodeFragments.h>
-#endif
 #undef main /* Defined in python.h - aargh */
 #undef HAVE_FCNTL_H /* Clash with os_win32.h */
 
@@ -871,10 +867,8 @@ Python3_Init(void)
 
 	PyImport_AppendInittab("vim", Py3Init_vim);
 
-#if !defined(MACOS) || defined(MACOS_X)
+#if defined(MACOS_X)
 	Py_Initialize();
-#else
-	PyMac_Initialize();
 #endif
 	/* Initialise threads, and below save the state using
 	 * PyEval_SaveThread.  Without the call to PyEval_SaveThread, thread
@@ -929,9 +923,6 @@ fail:
     static void
 DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
 {
-#if defined(MACOS) && !defined(MACOS_X)
-    GrafPtr		oldPort;
-#endif
 #if defined(HAVE_LOCALE_H) || defined(X_LOCALE)
     char		*saved_locale;
 #endif
@@ -942,12 +933,6 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
     if (python_end_called)
 	goto theend;
 
-#if defined(MACOS) && !defined(MACOS_X)
-    GetPort(&oldPort);
-    /* Check if the Python library is available */
-    if ((Ptr)PyMac_Initialize == (Ptr)kUnresolvedCFragSymbolAddress)
-	goto theend;
-#endif
     if (Python3_Init())
 	goto theend;
 
@@ -992,9 +977,6 @@ DoPyCommand(const char *cmd, rangeinitializer init_range, runner run, void *arg)
 
     Python_Lock_Vim();		    /* enter vim */
     PythonIO_Flush();
-#if defined(MACOS) && !defined(MACOS_X)
-    SetPort(oldPort);
-#endif
 
 theend:
     return;	    /* keeps lint happy */

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -127,7 +127,7 @@
 #undef _
 
 /* T_DATA defined both by Ruby and Mac header files, hack around it... */
-#if defined(MACOS_X_UNIX) || defined(macintosh)
+#if defined(MACOS_X) || defined(macintosh)
 # define __OPENTRANSPORT__
 # define __OPENTRANSPORTPROTOCOL__
 # define __OPENTRANSPORTPROVIDERS__

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -127,7 +127,7 @@
 #undef _
 
 /* T_DATA defined both by Ruby and Mac header files, hack around it... */
-#if defined(MACOS_X) || defined(macintosh)
+#if defined(MACOS_X)
 # define __OPENTRANSPORT__
 # define __OPENTRANSPORTPROTOCOL__
 # define __OPENTRANSPORTPROVIDERS__

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -479,7 +479,7 @@ enum key_extra
 #define MOD_MASK_2CLICK	    0x20	/* use MOD_MASK_MULTI_CLICK */
 #define MOD_MASK_3CLICK	    0x40	/* use MOD_MASK_MULTI_CLICK */
 #define MOD_MASK_4CLICK	    0x60	/* use MOD_MASK_MULTI_CLICK */
-#ifdef MACOS
+#ifdef MACOS_X
 # define MOD_MASK_CMD	    0x80
 #endif
 

--- a/src/macros.h
+++ b/src/macros.h
@@ -209,18 +209,13 @@
 # define mch_lstat(n, p)	mch_stat((n), (p))
 #endif
 
-#ifdef MACOS_CLASSIC
-/* MacOS classic doesn't support perm but MacOS X does. */
-# define mch_open(n, m, p)	open((n), (m))
-#else
-# ifdef VMS
+#ifdef VMS
 /*
  * It is possible to force some record format with:
  * #  define mch_open(n, m, p) open(vms_fixfilename(n), (m), (p)), "rat=cr", "rfm=stmlf", "mrs=0")
  * but it is not recommended, because it can destroy indexes etc.
  */
-#  define mch_open(n, m, p)	open(vms_fixfilename(n), (m), (p))
-# endif
+# define mch_open(n, m, p)	open(vms_fixfilename(n), (m), (p))
 #endif
 
 /* mch_open_rw(): invoke mch_open() with third argument for user R/W. */

--- a/src/main.c
+++ b/src/main.c
@@ -1723,7 +1723,7 @@ parse_command_name(mparm_T *parmp)
 
     initstr = gettail((char_u *)parmp->argv[0]);
 
-#ifdef MACOS_X_UNIX
+#ifdef FEAT_GUI_MAC
     /* An issue has been seen when launching Vim in such a way that
      * $PWD/$ARGV[0] or $ARGV[0] is not the absolute path to the
      * executable or a symbolic link of it. Until this issue is resolved

--- a/src/main.c
+++ b/src/main.c
@@ -299,7 +299,7 @@ main
 	params.want_full_screen = FALSE;
 #endif
 
-#if defined(FEAT_GUI_MAC) && defined(MACOS_X_UNIX)
+#if defined(FEAT_GUI_MAC) && defined(MACOS_X_DARWIN)
     /* When the GUI is started from Finder, need to display messages in a
      * message box.  isatty(2) returns TRUE anyway, thus we need to check the
      * name to know we're not started from a terminal. */

--- a/src/main.c
+++ b/src/main.c
@@ -926,13 +926,6 @@ common_init(mparm_T *paramp)
     qnx_init();		/* PhAttach() for clipboard, (and gui) */
 #endif
 
-#ifdef MAC_OS_CLASSIC
-    /* Prepare for possibly starting GUI sometime */
-    /* Macintosh needs this before any memory is allocated. */
-    gui_prepare(&paramp->argc, paramp->argv);
-    TIME_MSG("GUI prepared");
-#endif
-
     /* Init the table of Normal mode commands. */
     init_normal_cmds();
 
@@ -983,7 +976,7 @@ common_init(mparm_T *paramp)
 #ifdef FEAT_SUN_WORKSHOP
     findYourself(paramp->argv[0]);
 #endif
-#if defined(FEAT_GUI) && !defined(MAC_OS_CLASSIC)
+#if defined(FEAT_GUI)
     /* Prepare for possibly starting GUI sometime */
     gui_prepare(&paramp->argc, paramp->argv);
     TIME_MSG("GUI prepared");

--- a/src/main.c
+++ b/src/main.c
@@ -2611,7 +2611,7 @@ read_stdin(void)
 #if defined(HAS_SWAP_EXISTS_ACTION)
     check_swap_exists_action();
 #endif
-#if !(defined(AMIGA) || defined(MACOS))
+#if !(defined(AMIGA) || defined(MACOS_X))
     /*
      * Close stdin and dup it from stderr.  Required for GPM to work
      * properly, and for running external commands.

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -516,7 +516,7 @@ mb_init(void)
     int		n;
     int		enc_dbcs_new = 0;
 #if defined(USE_ICONV) && !defined(WIN3264) && !defined(WIN32UNIX) \
-	&& !defined(MACOS)
+	&& !defined(MACOS_CONVERT)
 # define LEN_FROM_CONV
     vimconv_T	vimconv;
     char_u	*p;
@@ -711,7 +711,7 @@ codepage_invalid:
 	     * API */
 	    n = IsDBCSLeadByteEx(enc_dbcs, (WINBYTE)i) ? 2 : 1;
 #else
-# if defined(MACOS) || defined(__amigaos4__) || defined(__ANDROID__)
+# if defined(__amigaos4__) || defined(__ANDROID__)
 	    /*
 	     * if mblen() is not available, character which MSB is turned on
 	     * are treated as leading byte character. (note : This assumption

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -6534,7 +6534,7 @@ convert_setup_ext(
 	vcp->vc_cpto = to_is_utf8 ? 0 : encname2codepage(to);
     }
 #endif
-#ifdef MACOS_X
+#ifdef MACOS_CONVERT
     else if ((from_prop & ENC_MACROMAN) && (to_prop & ENC_LATIN1))
     {
 	vcp->vc_type = CONV_MAC_LATIN1;

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -415,7 +415,7 @@ enc_alias_table[] =
     {"euccn",		IDX_EUC_CN},
     {"gb2312",		IDX_EUC_CN},
     {"euctw",		IDX_EUC_TW},
-#if defined(WIN3264) || defined(WIN32UNIX) || defined(MACOS)
+#if defined(WIN3264) || defined(WIN32UNIX) || defined(MACOS_X)
     {"japan",		IDX_CP932},
     {"korea",		IDX_CP949},
     {"prc",		IDX_CP936},
@@ -918,7 +918,7 @@ dbcs_class(unsigned lead, unsigned trail)
 		unsigned char tb = trail;
 
 		/* convert process code to JIS */
-# if defined(WIN3264) || defined(WIN32UNIX) || defined(MACOS)
+# if defined(WIN3264) || defined(WIN32UNIX) || defined(MACOS_X)
 		/* process code is SJIS */
 		if (lb <= 0x9f)
 		    lb = (lb - 0x81) * 2 + 0x21;

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -714,7 +714,8 @@ codepage_invalid:
 	     * API */
 	    n = IsDBCSLeadByteEx(enc_dbcs, (WINBYTE)i) ? 2 : 1;
 #else
-# if defined(__amigaos4__) || defined(__ANDROID__) || !defined(HAVE_MBLEN)
+# if defined(__amigaos4__) || defined(__ANDROID__) || \
+				   !(defined(HAVE_MBLEN) || defined(X_LOCALE))
 	    /*
 	     * if mblen() is not available, character which MSB is turned on
 	     * are treated as leading byte character. (note : This assumption

--- a/src/message.c
+++ b/src/message.c
@@ -2659,11 +2659,10 @@ msg_puts_printf(char_u *str, int maxlen)
 	if (!(silent_mode && p_verbose == 0))
 	{
 	    /* NL --> CR NL translation (for Unix, not for "--version") */
-	    /* NL --> CR translation (for Mac) */
 	    p = &buf[0];
 	    if (*s == '\n' && !info_message)
 		*p++ = '\r';
-#if defined(USE_CR) && !defined(MACOS_X)
+#if defined(USE_CR)
 	    else
 #endif
 		*p++ = *s;

--- a/src/message.c
+++ b/src/message.c
@@ -2663,7 +2663,7 @@ msg_puts_printf(char_u *str, int maxlen)
 	    p = &buf[0];
 	    if (*s == '\n' && !info_message)
 		*p++ = '\r';
-#if defined(USE_CR) && !defined(MACOS_X_UNIX)
+#if defined(USE_CR) && !defined(MACOS_X)
 	    else
 #endif
 		*p++ = *s;
@@ -3004,7 +3004,7 @@ mch_errmsg(char *str)
      * On Mac, when started from Finder, stderr is the console. */
     if (
 # ifdef UNIX
-#  ifdef MACOS_X_UNIX
+#  ifdef MACOS_X
 	    (isatty(2) && strcmp("/dev/console", ttyname(2)) != 0)
 #  else
 	    isatty(2)
@@ -3071,7 +3071,7 @@ mch_msg(char *str)
      * On Mac, when started from Finder, stderr is the console. */
     if (
 #  ifdef UNIX
-#   ifdef MACOS_X_UNIX
+#   ifdef MACOS_X
 	    (isatty(2) && strcmp("/dev/console", ttyname(2)) != 0)
 #   else
 	    isatty(2)

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -4494,9 +4494,9 @@ get_env_name(
     expand_T	*xp UNUSED,
     int		idx)
 {
-# if defined(AMIGA) || defined(__MRC__) || defined(__SC__)
+# if defined(AMIGA)
     /*
-     * No environ[] on the Amiga and on the Mac (using MPW).
+     * No environ[] on the Amiga.
      */
     return NULL;
 # else

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -4333,12 +4333,8 @@ vim_getenv(char_u *name, int *mustfree)
 	    }
 
 	    /* remove trailing path separator */
-#ifndef MACOS_CLASSIC
-	    /* With MacOS path (with  colons) the final colon is required */
-	    /* to avoid confusion between absolute and relative path */
 	    if (pend > p && after_pathsep(p, pend))
 		--pend;
-#endif
 
 #ifdef MACOS_X
 	    if (p == exe_name || p == p_hf)
@@ -10995,9 +10991,6 @@ gen_expand_wildcards(
 	{
 	    char_u	*t = backslash_halve_save(p);
 
-#if defined(MACOS_CLASSIC)
-	    slash_to_colon(t);
-#endif
 	    /* When EW_NOTFOUND is used, always add files and dirs.  Makes
 	     * "vim c:/" work. */
 	    if (flags & EW_NOTFOUND)

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -6003,19 +6003,14 @@ newenv(void)
     char    **env, *elem;
     int	    i, esize;
 
-#ifdef MACOS
-    /* for Mac a new, empty environment is created */
-    i = 0;
-#else
     for (i = 0; environ[i]; i++)
 	;
-#endif
+
     esize = i + EXTRASIZE + 1;
     env = (char **)alloc((unsigned)(esize * sizeof (elem)));
     if (env == NULL)
 	return -1;
 
-#ifndef MACOS
     for (i = 0; environ[i]; i++)
     {
 	elem = (char *)alloc((unsigned)(strlen(environ[i]) + 1));
@@ -6024,7 +6019,6 @@ newenv(void)
 	env[i] = elem;
 	strcpy(elem, environ[i]);
     }
-#endif
 
     env[i] = 0;
     environ = env;

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -5931,10 +5931,7 @@ pathcmp(const char *p, const char *q, int maxlen)
 #define EXTRASIZE 5		/* increment to add to env. size */
 
 static int  envsize = -1;	/* current size of environment */
-#ifndef MACOS_CLASSIC
-extern
-#endif
-       char **environ;		/* the global which is your env. */
+extern char **environ;		/* the global which is your env. */
 
 static int  findenv(char *name); /* look for a name in the env. */
 static int  newenv(void);	/* copy env. from stack to heap */
@@ -6091,7 +6088,6 @@ filewritable(char_u *fname)
 #if defined(UNIX) || defined(VMS)
     perm = mch_getperm(fname);
 #endif
-#ifndef MACOS_CLASSIC /* TODO: get either mch_writable or mch_access */
     if (
 # ifdef WIN3264
 	    mch_writable(fname) &&
@@ -6102,7 +6098,6 @@ filewritable(char_u *fname)
 # endif
 	    mch_access((char *)fname, W_OK) == 0
        )
-#endif
     {
 	++retval;
 	if (mch_isdir(fname))

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2200,7 +2200,7 @@ static struct modmasktable
     {MOD_MASK_MULTI_CLICK,	MOD_MASK_2CLICK,	(char_u)'2'},
     {MOD_MASK_MULTI_CLICK,	MOD_MASK_3CLICK,	(char_u)'3'},
     {MOD_MASK_MULTI_CLICK,	MOD_MASK_4CLICK,	(char_u)'4'},
-#ifdef MACOS
+#ifdef MACOS_X
     {MOD_MASK_CMD,		MOD_MASK_CMD,		(char_u)'D'},
 #endif
     /* 'A' must be the last one */
@@ -2925,7 +2925,7 @@ extract_modifiers(int key, int *modp)
 {
     int	modifiers = *modp;
 
-#ifdef MACOS
+#ifdef MACOS_X
     /* Command-key really special, no fancynest */
     if (!(modifiers & MOD_MASK_CMD))
 #endif
@@ -2952,7 +2952,7 @@ extract_modifiers(int key, int *modp)
 	if (key == 0)
 	    key = K_ZERO;
     }
-#ifdef MACOS
+#ifdef MACOS_X
     /* Command-key really special, no fancynest */
     if (!(modifiers & MOD_MASK_CMD))
 #endif

--- a/src/option.c
+++ b/src/option.c
@@ -1697,8 +1697,7 @@ static struct vimoption options[] =
     {"isprint",	    "isp",  P_STRING|P_VI_DEF|P_RALL|P_COMMA|P_NODUP,
 			    (char_u *)&p_isp, PV_NONE,
 			    {
-#if defined(MSWIN) || (defined(MACOS) && !defined(MACOS_X)) \
-		|| defined(VMS)
+#if defined(MSWIN) || defined(VMS)
 			    (char_u *)"@,~-255",
 #else
 # ifdef EBCDIC

--- a/src/option.c
+++ b/src/option.c
@@ -1431,7 +1431,7 @@ static struct vimoption options[] =
     {"guioptions",  "go",   P_STRING|P_VI_DEF|P_RALL|P_FLAGLIST,
 #if defined(FEAT_GUI)
 			    (char_u *)&p_go, PV_NONE,
-# if defined(UNIX) && !defined(MACOS)
+# if defined(UNIX) && !defined(FEAT_GUI_MAC)
 			    {(char_u *)"aegimrLtT", (char_u *)0L}
 # else
 			    {(char_u *)"egmrLtT", (char_u *)0L}

--- a/src/option.c
+++ b/src/option.c
@@ -1988,7 +1988,7 @@ static struct vimoption options[] =
 #if defined(MSWIN)
 				(char_u *)"popup",
 #else
-# if defined(MACOS)
+# if defined(MACOS_X)
 				(char_u *)"popup_setpos",
 # else
 				(char_u *)"extend",
@@ -3630,7 +3630,7 @@ set_init_1(void)
 		options[opt_idx].flags |= P_DEF_ALLOCED;
 	    }
 
-#if defined(MSWIN) || defined(MACOS) || defined(VMS)
+#if defined(MSWIN) || defined(MACOS_X) || defined(VMS)
 	    if (STRCMP(p_enc, "latin1") == 0
 # ifdef FEAT_MBYTE
 		    || enc_utf8

--- a/src/option.c
+++ b/src/option.c
@@ -510,7 +510,7 @@ static struct vimoption options[] =
 #endif
 					    (char_u *)0L} SCRIPTID_INIT},
     {"antialias",   "anti", P_BOOL|P_VI_DEF|P_VIM|P_RCLR,
-#if defined(FEAT_GUI) && defined(MACOS_X)
+#if defined(FEAT_GUI_MAC)
 			    (char_u *)&p_antialias, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)FALSE}
 #else

--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -94,15 +94,10 @@
 				       quite fast. Did I forgot to update the
 				       comment */
 
-
 #define USE_FNAME_CASE		/* make ":e os_Mac.c" open the file in its
 				   original case, as "os_mac.c" */
 #define BINARY_FILE_IO
 #define EOL_DEFAULT EOL_MAC
-#ifndef MACOS_X			/* I hope that switching these two lines */
-# define USE_CR			/* does what I want -- BNF */
-# define NO_CONSOLE		/* don't include console mode */
-#endif
 #define HAVE_AVAIL_MEM
 
 #ifndef HAVE_CONFIG_H
@@ -226,11 +221,6 @@
  */
 #define CMDBUFFSIZE 1024	/* size of the command processing buffer */
 
-#if !defined(MACOS_X)
-# define MAXPATHL	256		/* Limited by the Pascal Strings */
-# define BASENAMELEN	(32-5-1)	/* length of base of filename */
-#endif
-
 #ifndef DFLT_MAXMEM
 # define DFLT_MAXMEM	512	/* use up to  512 Kbyte for buffer */
 #endif
@@ -271,33 +261,31 @@
  * of ./configure for console MacOS X.
  */
 
-#ifdef MACOS_X
-# ifndef SIGPROTOARG
-#  define SIGPROTOARG	(int)
-# endif
-# ifndef SIGDEFARG
-#  define SIGDEFARG(s)	(s) int s UNUSED;
-# endif
-# ifndef SIGDUMMYARG
-#  define SIGDUMMYARG	0
-# endif
-# undef  HAVE_AVAIL_MEM
-# ifndef HAVE_CONFIG_H
-#  define RETSIGTYPE void
-#  define SIGRETURN  return
+#ifndef SIGPROTOARG
+# define SIGPROTOARG	(int)
+#endif
+#ifndef SIGDEFARG
+# define SIGDEFARG(s)	(s) int s UNUSED;
+#endif
+#ifndef SIGDUMMYARG
+# define SIGDUMMYARG	0
+#endif
+#undef  HAVE_AVAIL_MEM
+#ifndef HAVE_CONFIG_H
+# define RETSIGTYPE void
+# define SIGRETURN  return
 /*# define USE_SYSTEM */  /* Output ship do debugger :(, but ot compile */
-#  define HAVE_SYS_WAIT_H 1 /* Attempt */
-#  define HAVE_TERMIOS_H 1
-#  define SYS_SELECT_WITH_SYS_TIME 1
-#  define HAVE_SELECT 1
-#  define HAVE_SYS_SELECT_H 1
-#  define HAVE_PUTENV
-#  define HAVE_SETENV
-#  define HAVE_RENAME
-# endif
+# define HAVE_SYS_WAIT_H 1 /* Attempt */
+# define HAVE_TERMIOS_H 1
+# define SYS_SELECT_WITH_SYS_TIME 1
+# define HAVE_SELECT 1
+# define HAVE_SYS_SELECT_H 1
+# define HAVE_PUTENV
+# define HAVE_SETENV
+# define HAVE_RENAME
 #endif
 
-#if defined(MACOS_X) && !defined(HAVE_CONFIG_H)
+#if !defined(HAVE_CONFIG_H)
 # define HAVE_PUTENV
 #endif
 

--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -99,7 +99,7 @@
 				   original case, as "os_mac.c" */
 #define BINARY_FILE_IO
 #define EOL_DEFAULT EOL_MAC
-#ifndef MACOS_X_UNIX		/* I hope that switching these two lines */
+#ifndef MACOS_X			/* I hope that switching these two lines */
 # define USE_CR			/* does what I want -- BNF */
 # define NO_CONSOLE		/* don't include console mode */
 #endif
@@ -226,7 +226,7 @@
  */
 #define CMDBUFFSIZE 1024	/* size of the command processing buffer */
 
-#if !defined(MACOS_X_UNIX)
+#if !defined(MACOS_X)
 # define MAXPATHL	256		/* Limited by the Pascal Strings */
 # define BASENAMELEN	(32-5-1)	/* length of base of filename */
 #endif
@@ -275,7 +275,7 @@
  * of ./configure for console MacOS X.
  */
 
-#ifdef MACOS_X_UNIX
+#ifdef MACOS_X
 # ifndef SIGPROTOARG
 #  define SIGPROTOARG	(int)
 # endif

--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -245,12 +245,8 @@
 #define mch_rename(src, dst) rename(src, dst)
 #define mch_remove(x) unlink((char *)(x))
 #ifndef mch_getenv
-# if defined(__MRC__) || defined(__SC__)
+# if defined(__APPLE_CC__)
 #  define mch_getenv(name)  ((char_u *)getenv((char *)(name)))
-#  define mch_setenv(name, val, x) setenv((name), (val))
-# elif defined(__APPLE_CC__)
-#  define mch_getenv(name)  ((char_u *)getenv((char *)(name)))
-/*# define mch_setenv(name, val, x) setenv((name), (val)) */ /* Obsoleted by Dany on Oct 30, 2001 */
 #  define mch_setenv(name, val, x) setenv(name, val, x)
 # else
   /* vim_getenv() is in pty.c */

--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -77,7 +77,7 @@
  */
 /* When compiled under MacOS X (including CARBON version)
  * we use the Unix File path style.  Also when UNIX is defined. */
-# define USE_UNIXFILENAME
+#define USE_UNIXFILENAME
 
 
 /*
@@ -123,38 +123,38 @@
  */
 
 #ifndef SYS_VIMRC_FILE
-#  define SYS_VIMRC_FILE "$VIM/vimrc"
+# define SYS_VIMRC_FILE "$VIM/vimrc"
 #endif
 #ifndef SYS_GVIMRC_FILE
-#  define SYS_GVIMRC_FILE "$VIM/gvimrc"
+# define SYS_GVIMRC_FILE "$VIM/gvimrc"
 #endif
 #ifndef SYS_MENU_FILE
-#  define SYS_MENU_FILE	"$VIMRUNTIME/menu.vim"
+# define SYS_MENU_FILE	"$VIMRUNTIME/menu.vim"
 #endif
 #ifndef SYS_OPTWIN_FILE
-#  define SYS_OPTWIN_FILE "$VIMRUNTIME/optwin.vim"
+# define SYS_OPTWIN_FILE "$VIMRUNTIME/optwin.vim"
 #endif
 #ifndef VIM_DEFAULTS_FILE
-#  define VIM_DEFAULTS_FILE "$VIMRUNTIME/defaults.vim"
+# define VIM_DEFAULTS_FILE "$VIMRUNTIME/defaults.vim"
 #endif
 #ifndef EVIM_FILE
-#  define EVIM_FILE	"$VIMRUNTIME/evim.vim"
+# define EVIM_FILE	"$VIMRUNTIME/evim.vim"
 #endif
 
 #ifdef FEAT_GUI
 # ifndef USR_GVIMRC_FILE
-#   define USR_GVIMRC_FILE "~/.gvimrc"
+#  define USR_GVIMRC_FILE "~/.gvimrc"
 # endif
 # ifndef GVIMRC_FILE
 #  define GVIMRC_FILE	"_gvimrc"
 # endif
 #endif
 #ifndef USR_VIMRC_FILE
-#  define USR_VIMRC_FILE	"~/.vimrc"
+# define USR_VIMRC_FILE	"~/.vimrc"
 #endif
 
 #ifndef USR_EXRC_FILE
-#  define USR_EXRC_FILE	"~/.exrc"
+# define USR_EXRC_FILE	"~/.exrc"
 #endif
 
 #ifndef VIMRC_FILE
@@ -166,7 +166,7 @@
 #endif
 
 #ifndef DFLT_HELPFILE
-#  define DFLT_HELPFILE	"$VIMRUNTIME/doc/help.txt"
+# define DFLT_HELPFILE	"$VIMRUNTIME/doc/help.txt"
 #endif
 
 #ifndef FILETYPE_FILE
@@ -189,12 +189,12 @@
 #endif
 
 #ifndef SYNTAX_FNAME
-#  define SYNTAX_FNAME	"$VIMRUNTIME/syntax/%s.vim"
+# define SYNTAX_FNAME	"$VIMRUNTIME/syntax/%s.vim"
 #endif
 
 #ifdef FEAT_VIMINFO
 # ifndef VIMINFO_FILE
-#   define VIMINFO_FILE	"~/.viminfo"
+#  define VIMINFO_FILE	"~/.viminfo"
 # endif
 #endif /* FEAT_VIMINFO */
 
@@ -213,7 +213,7 @@
 #define DFLT_ERRORFILE		"errors.err"
 
 #ifndef DFLT_RUNTIMEPATH
-#  define DFLT_RUNTIMEPATH	"~/.vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,~/.vim/after"
+# define DFLT_RUNTIMEPATH	"~/.vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,~/.vim/after"
 #endif
 
 /*

--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -11,7 +11,7 @@
  * os_macosx.m -- Mac specific things for Mac OS/X.
  */
 
-#ifndef MACOS_X_UNIX
+#ifndef MACOS_X_DARWIN
     Error: MACOS 9 is no longer supported in Vim 7
 #endif
 

--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -21,7 +21,7 @@
 #define BalloonEval int   /* used in header files */
 
 #include "vim.h"
-#import <Cocoa/Cocoa.h>
+#import <AppKit/AppKit.h>
 
 
 /*

--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -8,12 +8,8 @@
  */
 
 /*
- * os_macosx.m -- Mac specific things for Mac OS/X.
+ * os_macosx.m -- Mac specific things for Mac OS X.
  */
-
-#ifndef MACOS_X_DARWIN
-    Error: MACOS 9 is no longer supported in Vim 7
-#endif
 
 /* Avoid a conflict for the definition of Boolean between Mac header files and
  * X11 header files. */

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -856,10 +856,6 @@ mch_stackcheck(char *p)
  * completely full.
  */
 
-#if defined(HAVE_AVAILABILITYMACROS_H)
-# include <AvailabilityMacros.h>
-#endif
-
 #ifndef SIGSTKSZ
 # define SIGSTKSZ 8000    /* just a guess of how much stack is needed... */
 #endif
@@ -879,13 +875,6 @@ init_signal_stack(void)
     if (signal_stack != NULL)
     {
 # ifdef HAVE_SIGALTSTACK
-#  if defined(__APPLE__) && (!defined(MAC_OS_X_VERSION_MAX_ALLOWED) \
-		|| MAC_OS_X_VERSION_MAX_ALLOWED <= 1040)
-	/* missing prototype.  Adding it to osdef?.h.in doesn't work, because
-	 * "struct sigaltstack" needs to be declared. */
-	extern int sigaltstack(const struct sigaltstack *ss, struct sigaltstack *oss);
-#  endif
-
 #  ifdef HAVE_SS_BASE
 	sigstk.ss_base = signal_stack;
 #  else

--- a/src/proto.h
+++ b/src/proto.h
@@ -213,7 +213,7 @@ void qsort(void *base, size_t elm_count, size_t elm_size, int (*cmp)(const void 
 # endif
 
 # if defined(FEAT_GUI) || defined(FEAT_JOB_CHANNEL)
-#  if defined(UNIX) || defined(MACOS)
+#  if defined(UNIX) || defined(MACOS_X)
 #   include "pty.pro"
 #  endif
 # endif

--- a/src/proto.h
+++ b/src/proto.h
@@ -286,7 +286,7 @@ extern char *vim_SelFile(Widget toplevel, char *prompt, char *init_path, int (*s
 #ifdef MACOS_CONVERT
 # include "os_mac_conv.pro"
 #endif
-#if defined(MACOS_X_UNIX) && defined(FEAT_CLIPBOARD) && !defined(FEAT_GUI)
+#if defined(MACOS_X_DARWIN) && defined(FEAT_CLIPBOARD) && !defined(FEAT_GUI)
 /* functions in os_macosx.m */
 void clip_mch_lose_selection(VimClipboard *cbd);
 int clip_mch_own_selection(VimClipboard *cbd);

--- a/src/pty.c
+++ b/src/pty.c
@@ -89,7 +89,7 @@
 # include <sys/ptem.h>
 #endif
 
-#if !defined(SUN_SYSTEM) && !defined(VMS) && !defined(MACOS)
+#if !defined(SUN_SYSTEM) && !defined(VMS)
 # include <sys/ioctl.h>
 #endif
 
@@ -379,15 +379,11 @@ OpenPTY(char **ttyn)
     {
 	for (d = PTYRANGE1; (p[1] = *d) != '\0'; d++)
 	{
-#if !defined(MACOS) || defined(USE_CARBONIZED)
 	    if ((f = open(PtyName, O_RDWR | O_NOCTTY | O_EXTRA, 0)) == -1)
-#else
-	    if ((f = open(PtyName, O_RDWR | O_NOCTTY | O_EXTRA)) == -1)
-#endif
 		continue;
 	    q[0] = *l;
 	    q[1] = *d;
-#ifndef MACOS
+#ifndef MACOS /* XXX  is this MACOS meant for Mac OS X? */
 	    if (geteuid() != ROOT_UID && mch_access(TtyName, R_OK | W_OK))
 	    {
 		close(f);

--- a/src/pty.c
+++ b/src/pty.c
@@ -383,13 +383,11 @@ OpenPTY(char **ttyn)
 		continue;
 	    q[0] = *l;
 	    q[1] = *d;
-#ifndef MACOS /* XXX  is this MACOS meant for Mac OS X? */
 	    if (geteuid() != ROOT_UID && mch_access(TtyName, R_OK | W_OK))
 	    {
 		close(f);
 		continue;
 	    }
-#endif
 #if defined(SUN_SYSTEM) && defined(TIOCGPGRP) && !defined(SUNOS3)
 	    /* Hack to ensure that the slave side of the pty is
 	     * unused. May not work in anything other than SunOS4.1

--- a/src/structs.h
+++ b/src/structs.h
@@ -969,7 +969,9 @@ typedef struct attr_entry
 # else
 #  if defined(MACOS_X)
 #   include <sys/errno.h>
-#   define EILSEQ ENOENT /* MacOS X does not have EILSEQ */
+#   ifndef EILSEQ
+#    define EILSEQ ENOENT /* Early MacOS X does not have EILSEQ */
+#   endif
 typedef struct _iconv_t *iconv_t;
 #  else
 #   if defined(MACOS_CLASSIC)

--- a/src/structs.h
+++ b/src/structs.h
@@ -974,16 +974,7 @@ typedef struct attr_entry
 #   endif
 typedef struct _iconv_t *iconv_t;
 #  else
-#   if defined(MACOS_CLASSIC)
-typedef struct _iconv_t *iconv_t;
-#    define EINVAL	22
-#    define E2BIG	7
-#    define ENOENT	2
-#    define EFAULT	14
-#    define EILSEQ	123
-#   else
-#    include <errno.h>
-#   endif
+#   include <errno.h>
 #  endif
 typedef void *iconv_t;
 # endif

--- a/src/term.c
+++ b/src/term.c
@@ -2521,7 +2521,7 @@ out_trash(void)
     void
 out_char(unsigned c)
 {
-#if defined(UNIX) || defined(VMS) || defined(AMIGA) || defined(MACOS_X_UNIX)
+#if defined(UNIX) || defined(VMS) || defined(AMIGA) || defined(MACOS_X)
     if (c == '\n')	/* turn LF into CR-LF (CRMOD doesn't seem to do this) */
 	out_char('\r');
 #endif
@@ -2541,7 +2541,7 @@ static void out_char_nf(unsigned);
     static void
 out_char_nf(unsigned c)
 {
-#if defined(UNIX) || defined(VMS) || defined(AMIGA) || defined(MACOS_X_UNIX)
+#if defined(UNIX) || defined(VMS) || defined(AMIGA) || defined(MACOS_X)
     if (c == '\n')	/* turn LF into CR-LF (CRMOD doesn't seem to do this) */
 	out_char_nf('\r');
 #endif

--- a/src/termlib.c
+++ b/src/termlib.c
@@ -13,7 +13,7 @@
 #include "vim.h"
 #include "termlib.pro"
 
-#if !defined(AMIGA) && !defined(VMS) && !defined(MACOS)
+#if !defined(AMIGA) && !defined(VMS)
 # include <sgtty.h>
 #endif
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -1748,7 +1748,7 @@ read_from_input_buf(char_u *buf, long maxlen)
     void
 fill_input_buf(int exit_on_error UNUSED)
 {
-#if defined(UNIX) || defined(VMS) || defined(MACOS_X_UNIX)
+#if defined(UNIX) || defined(VMS) || defined(MACOS_X)
     int		len;
     int		try;
     static int	did_read_something = FALSE;
@@ -1772,7 +1772,7 @@ fill_input_buf(int exit_on_error UNUSED)
 	return;
     }
 #endif
-#if defined(UNIX) || defined(VMS) || defined(MACOS_X_UNIX)
+#if defined(UNIX) || defined(VMS) || defined(MACOS_X)
     if (vim_is_input_buf_full())
 	return;
     /*

--- a/src/undo.c
+++ b/src/undo.c
@@ -1750,7 +1750,7 @@ write_error:
     if (!write_ok)
 	EMSG2(_("E829: write error in undo file: %s"), file_name);
 
-#if defined(MACOS_CLASSIC) || defined(WIN3264)
+#if defined(WIN3264)
     /* Copy file attributes; for systems where this can only be done after
      * closing the file. */
     if (buf->b_ffname != NULL)

--- a/src/version.c
+++ b/src/version.c
@@ -3270,8 +3270,6 @@ list_version(void)
     MSG_PUTS(_("\nmacOS version"));
 # elif defined(MACOS_X)
     MSG_PUTS(_("\nmacOS version w/o darwin feat."));
-# else
-    MSG_PUTS(_("\nMac OS Classic version"));
 # endif
 #endif
 
@@ -3404,9 +3402,6 @@ list_version(void)
 #	 if defined(TARGET_API_MAC_OSX) && TARGET_API_MAC_OSX
     MSG_PUTS(_("with Cocoa GUI."));
 #	 else
-#	  if defined(MACOS)
-    MSG_PUTS(_("with (classic) GUI."));
-#	  endif
 #	 endif
 #	endif
 #      endif

--- a/src/version.c
+++ b/src/version.c
@@ -3266,7 +3266,7 @@ list_version(void)
 # endif
 #endif
 #ifdef MACOS
-# if defined(MACOS_X_UNIX)
+# if defined(MACOS_X_DARWIN)
     MSG_PUTS(_("\nmacOS version"));
 # elif defined(MACOS_X)
     MSG_PUTS(_("\nmacOS version w/o darwin feat."));

--- a/src/version.c
+++ b/src/version.c
@@ -3266,14 +3266,12 @@ list_version(void)
 # endif
 #endif
 #ifdef MACOS
-# ifdef MACOS_X
-#  ifdef MACOS_X_UNIX
-    MSG_PUTS(_("\nMacOS X (unix) version"));
-#  else
-    MSG_PUTS(_("\nMacOS X version"));
-#  endif
-#else
-    MSG_PUTS(_("\nMacOS version"));
+# if defined(MACOS_X_UNIX)
+    MSG_PUTS(_("\nmacOS version"));
+# elif defined(MACOS_X)
+    MSG_PUTS(_("\nmacOS version w/o darwin feat."));
+# else
+    MSG_PUTS(_("\nMac OS Classic version"));
 # endif
 #endif
 

--- a/src/version.c
+++ b/src/version.c
@@ -3265,10 +3265,10 @@ list_version(void)
 #  endif
 # endif
 #endif
-#ifdef MACOS
+#if defined(MACOS_X)
 # if defined(MACOS_X_DARWIN)
     MSG_PUTS(_("\nmacOS version"));
-# elif defined(MACOS_X)
+# else
     MSG_PUTS(_("\nmacOS version w/o darwin feat."));
 # endif
 #endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -85,26 +85,15 @@
 #endif
 
 /*
- * MACOS	    compiling for Macintosh hardware
  * MACOS_X	    compiling for Mac OS X
- * MACOS_X_DARWIN   compiling with the darwin feature for Mac OS X
- *
- * - MACOS_X_DARWIN always implies MACOS_X, and not vice versa.
- * - Be careful not to confuse "MacOS" in our documents with "macOS".
+ * MACOS_X_DARWIN   integrating the darwin feature into MACOS_X
  */
 #if defined(MACOS_X_DARWIN) && !defined(MACOS_X)
 # define MACOS_X
 #endif
-#if defined(MACOS_X)
-# ifndef HAVE_CONFIG_H
-#  define UNIX
-# endif
-#endif
-#if defined(MACOS_X)
-# define MACOS
-#endif
 /* Unless made through the Makefile enforce GUI on Mac */
-#if defined(MACOS) && !defined(HAVE_CONFIG_H)
+#if defined(MACOS_X) && !defined(HAVE_CONFIG_H)
+# define UNIX
 # define FEAT_GUI_MAC
 #endif
 
@@ -162,15 +151,9 @@
 #  endif
 # endif
 #endif
-#ifdef MACOS
-# if defined(__POWERPC__) || defined(MACOS_X) || defined(__fourbyteints__) \
-						      || defined(__APPLE_CC__)
-#  define VIM_SIZEOF_INT 4
-# else
-#  define VIM_SIZEOF_INT 2
-# endif
+#if defined(MACOS_X) && !defined(HAVE_CONFIG_H)
+#  define VIM_SIZEOF_INT __SIZEOF_INT__
 #endif
-
 
 /*
  * #defines for optionals and features
@@ -295,7 +278,7 @@
 # include "os_mint.h"
 #endif
 
-#if defined(MACOS)
+#if defined(MACOS_X)
 # include "os_mac.h"
 #endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -86,15 +86,17 @@
 
 /*
  * MACOS_CLASSIC compiling for MacOS prior to MacOS X
- * MACOS_X_UNIX  compiling for MacOS X (using os_unix.c)
- * MACOS_X       compiling for MacOS X (using os_unix.c)
+ * MACOS_X       compiling for MacOS X
+ * MACOS_X_UNIX  compiling for MacOS X with the darwin feature
  * MACOS	 compiling for either one
  */
 #if defined(macintosh) && !defined(MACOS_CLASSIC)
 # define MACOS_CLASSIC
 #endif
-#if defined(MACOS_X_UNIX)
+#if defined(MACOS_X_UNIX) && !defined(MACOS_X)
 # define MACOS_X
+#endif
+#if defined(MACOS_X)
 # ifndef HAVE_CONFIG_H
 #  define UNIX
 # endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -85,9 +85,15 @@
 #endif
 
 /*
- * MACOS_X	    compiling for MacOS X
- * MACOS_X_DARWIN   compiling with the darwin feature for MacOS X
- * MACOS	    compiling for either one
+ * MACOS	    compiling for any of Macintosh operating systems
+ * MACOS_X	    compiling for Mac OS X
+ * MACOS_X_DARWIN   compiling with the darwin feature for Mac OS X
+ *
+ * - MACOS stands for all Mac OSs, not macOS alone.
+ * - MACOS_X_DARWIN always implies MACOS_X, and not vice versa.
+ *
+ *   Similarly, be careful not to confuse "MacOS" in our documents with
+ *   "macOS".
  */
 #if defined(MACOS_X_DARWIN) && !defined(MACOS_X)
 # define MACOS_X

--- a/src/vim.h
+++ b/src/vim.h
@@ -85,14 +85,10 @@
 #endif
 
 /*
- * MACOS_CLASSIC    compiling for MacOS prior to MacOS X
  * MACOS_X	    compiling for MacOS X
  * MACOS_X_DARWIN   compiling with the darwin feature for MacOS X
  * MACOS	    compiling for either one
  */
-#if defined(macintosh) && !defined(MACOS_CLASSIC)
-# define MACOS_CLASSIC
-#endif
 #if defined(MACOS_X_DARWIN) && !defined(MACOS_X)
 # define MACOS_X
 #endif
@@ -101,11 +97,8 @@
 #  define UNIX
 # endif
 #endif
-#if defined(MACOS_X) || defined(MACOS_CLASSIC)
+#if defined(MACOS_X)
 # define MACOS
-#endif
-#if defined(MACOS_X) && defined(MACOS_CLASSIC)
-    Error: To compile for both MACOS X and Classic use a Classic Carbon
 #endif
 /* Unless made through the Makefile enforce GUI on Mac */
 #if defined(MACOS) && !defined(HAVE_CONFIG_H)

--- a/src/vim.h
+++ b/src/vim.h
@@ -2350,9 +2350,10 @@ typedef enum {
 # ifdef instr
 #  undef instr
 # endif
-  /* bool may cause trouble on MACOS but is required on a few other systems
-   * and for Perl */
-# if defined(bool) && defined(MACOS) && !defined(FEAT_PERL)
+  /* bool may cause trouble on some old versions of Mac OS X but is required
+   * on a few other systems and for Perl */
+# if (defined(MACOS_X) && !defined(MAC_OS_X_VERSION_10_6)) \
+				       && defined(bool) && !defined(FEAT_PERL)
 #  undef bool
 # endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -164,7 +164,7 @@
 #endif
 #ifdef MACOS
 # if defined(__POWERPC__) || defined(MACOS_X) || defined(__fourbyteints__) \
-  || defined(__MRC__) || defined(__SC__) || defined(__APPLE_CC__)/* MPW Compilers */
+						      || defined(__APPLE_CC__)
 #  define VIM_SIZEOF_INT 4
 # else
 #  define VIM_SIZEOF_INT 2
@@ -296,9 +296,6 @@
 #endif
 
 #if defined(MACOS)
-# if defined(__MRC__) || defined(__SC__) /* MPW Compilers */
-#  define HAVE_SETENV
-# endif
 # include "os_mac.h"
 #endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -85,15 +85,12 @@
 #endif
 
 /*
- * MACOS	    compiling for any of Macintosh operating systems
+ * MACOS	    compiling for Macintosh hardware
  * MACOS_X	    compiling for Mac OS X
  * MACOS_X_DARWIN   compiling with the darwin feature for Mac OS X
  *
- * - MACOS stands for all Mac OSs, not macOS alone.
  * - MACOS_X_DARWIN always implies MACOS_X, and not vice versa.
- *
- *   Similarly, be careful not to confuse "MacOS" in our documents with
- *   "macOS".
+ * - Be careful not to confuse "MacOS" in our documents with "macOS".
  */
 #if defined(MACOS_X_DARWIN) && !defined(MACOS_X)
 # define MACOS_X

--- a/src/vim.h
+++ b/src/vim.h
@@ -85,15 +85,15 @@
 #endif
 
 /*
- * MACOS_CLASSIC compiling for MacOS prior to MacOS X
- * MACOS_X       compiling for MacOS X
- * MACOS_X_UNIX  compiling for MacOS X with the darwin feature
- * MACOS	 compiling for either one
+ * MACOS_CLASSIC    compiling for MacOS prior to MacOS X
+ * MACOS_X	    compiling for MacOS X
+ * MACOS_X_DARWIN   compiling with the darwin feature for MacOS X
+ * MACOS	    compiling for either one
  */
 #if defined(macintosh) && !defined(MACOS_CLASSIC)
 # define MACOS_CLASSIC
 #endif
-#if defined(MACOS_X_UNIX) && !defined(MACOS_X)
+#if defined(MACOS_X_DARWIN) && !defined(MACOS_X)
 # define MACOS_X
 #endif
 #if defined(MACOS_X)
@@ -182,7 +182,7 @@
  */
 #include "feature.h"
 
-#if defined(MACOS_X_UNIX)
+#if defined(MACOS_X_DARWIN)
 # if defined(FEAT_SMALL) && !defined(FEAT_CLIPBOARD)
 #  define FEAT_CLIPBOARD
 # endif
@@ -229,7 +229,7 @@
 #endif
 
 /* The Mac conversion stuff doesn't work under X11. */
-#if defined(FEAT_MBYTE) && defined(MACOS_X_UNIX)
+#if defined(FEAT_MBYTE) && defined(MACOS_X_DARWIN)
 # define MACOS_CONVERT
 #endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -229,7 +229,7 @@
 #endif
 
 /* The Mac conversion stuff doesn't work under X11. */
-#if defined(FEAT_MBYTE) && defined(MACOS_X)
+#if defined(FEAT_MBYTE) && defined(MACOS_X_UNIX)
 # define MACOS_CONVERT
 #endif
 

--- a/src/window.c
+++ b/src/window.c
@@ -6364,7 +6364,7 @@ vim_FullName(
 	/* something failed; use the file name (truncate when too long) */
 	vim_strncpy(buf, fname, len - 1);
     }
-#if defined(MACOS_CLASSIC) || defined(MSWIN)
+#if defined(MSWIN)
     slash_adjust(buf);
 #endif
     return retval;


### PR DESCRIPTION
Currently, in Vim, there are two different classes of configuration for macOS.  
One is with `--enable-darwin` (default) and the other with `--disable-darwin`.

The former takes advantage of the API specific to macOS, thereby enabling system clipboard integration and character set conversion of which encoding is specific to that OS.  The latter is identical with what is commonly used for other UNIX-like platforms.

When "the darwin feature of Vim" (`h: mac-darwin-feature`) was merged into our code base, it appears that some adjustments were done incompletely for some reason.

As a result, for non-darwin Vim, `has('mac')` returns 0, and `:version` doesn't displays anything which is compared to "MacOS X (unix) version" for darwin Vim.

That makes it hard to write Vim scripts for non-darwin Vim.

That's not the only issue.  Even for the darwin configuration/build, the configure script refers to the feature as `MACOS`, the compiler command-line calls it `MACOS_X_UNIX`, a header file gives it two different nicknames, `MACOS_X` and `MACOS`, and they are used in several `*.c` files in an obscure way.  That's anything but manageable.

Also, despite the fact that the support for Mac OS Classic has been discontinued since Vim 7, there are quite a few remnants of it in our code base.  Obviously, that gives unnecessary overhead to code reading and maintenance.

One could look away the last two issues and write a quite simple patch to fix the primary issue.  Actually, I did that.  But that had made me uneasy because I knew such a way of solution would only get the situation worse and get back at me someday, even if it could be helpful for the moment.

My new solution is to examine every use of the `MACOS.*` macros, determine what each is meant for, and get the build system neat and tidy on the basis of that research.  This is not an attempt to change the build system in favor of someone's view or preferences, but an attempt to give it a better shape so that it will clarify itself, what each part of it does and how each relates to other.  I'd like to call it a refactoring, even if it happens to include substantial changes such as bug fixes as "side effects" of it.

To ease the review, the whole patch is logically divided into several commits (ie., it's not a chronological accumulation), and each commit addresses its own issue only.  Honestly, I'm not sure how much it could help people review the patch, but both the whole of it and each of the commits constituting it are easily available to them on GitHub (AFAIK), I try using it.

The patch consists of about 20 commits.  The first three commits will clarify the goal.  The three commits following them fix some breakage in the build system resulted from them.  Then many minor adjustments follow.  The last two commits clean up what I think is the root cause of the headache.  Please refer to the commit messages for details.

Sorry for the wall of text and thank you for taking your time.  I welcome any comment on the proposed patch and open to any proposal.