### PR TITLE
Do not wait for return if input is not a TTY

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -1036,6 +1036,9 @@ wait_return(int redraw)
     if (msg_silent != 0)
 	return;
 
+    if (!mch_input_isatty())
+	return;
+
     /*
      * When inside vgetc(), we can't wait for a typed character at all.
      * With the global command (and some others) we only need one return at


### PR DESCRIPTION
When using `vim … < /dev/null` to close stdin, it should not display a
"Press ENTER or type command to continue" message, if there is output
via `:echom` in the vimrc.

If stderr/stdout is also redirected (with tests), you might end up with a seemingly hanging/frozen Vim.