### PR TITLE
Fix Test_popup_and_window_resize

### DIFF
--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -127,17 +127,20 @@ newtestssilent: $(NEW_TESTS)
 
 
 .vim.res:
-	@echo "$(RUN_VIMTEST)" > vimcmd
+	@echo "$(VIMPROG)" > vimcmd
+	@echo "$(RUN_VIMTEST)" >> vimcmd
 	$(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim
 	@rm vimcmd
 
 test_gui.res: test_gui.vim
-	@echo "$(RUN_GVIMTEST)" > vimcmd
+	@echo "$(VIMPROG)" > vimcmd
+	@echo "$(RUN_GVIMTEST)" >> vimcmd
 	$(RUN_VIMTEST) -u NONE $(NO_INITS) -S runtest.vim $<
 	@rm vimcmd
 
 test_gui_init.res: test_gui_init.vim
-	@echo "$(RUN_GVIMTEST_WITH_GVIMRC)" > vimcmd
+	@echo "$(VIMPROG)" > vimcmd
+	@echo "$(RUN_GVIMTEST_WITH_GVIMRC)" >> vimcmd
 	$(RUN_VIMTEST) -u gui_preinit.vim -U gui_init.vim $(NO_PLUGINS) -S runtest.vim $<
 	@rm vimcmd
 

--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -170,6 +170,14 @@ func s:feedkeys(timer)
   call feedkeys('x', 'nt')
 endfunc
 
+" Get $VIMPROG to run Vim executable.
+func GetVimProg()
+  if !filereadable('vimcmd')
+    return ''
+  endif
+  return readfile('vimcmd')[0]
+endfunc
+
 " Get the command to run Vim, with -u NONE and --not-a-term arguments.
 " If there is an argument use it instead of "NONE".
 " Returns an empty string on error.
@@ -182,7 +190,8 @@ func GetVimCommand(...)
   else
     let name = a:1
   endif
-  let cmd = readfile('vimcmd')[0]
+  let lines = readfile('vimcmd')
+  let cmd = get(lines, 1, lines[0])
   let cmd = substitute(cmd, '-u \f\+', '-u ' . name, '')
   if cmd !~ '-u '. name
     let cmd = cmd . ' -u ' . name

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -644,9 +644,9 @@ func Test_popup_and_window_resize()
     return
   endif
   let g:buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': h / 3})
-  call term_sendkeys(g:buf, (h / 3 - 1)."o\<esc>G")
-  call term_sendkeys(g:buf, "i\<c-x>")
+  call term_sendkeys(g:buf, (h / 3 - 1)."o\<esc>")
   call term_wait(g:buf, 200)
+  call term_sendkeys(g:buf, "Gi\<c-x>")
   call term_sendkeys(g:buf, "\<c-v>")
   call term_wait(g:buf, 100)
   " popup first entry "!" must be at the top

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -643,7 +643,7 @@ func Test_popup_and_window_resize()
   if h < 15
     return
   endif
-  let g:buf = term_start([$VIMPROG, '--clean', '-c', 'set noswapfile'], {'term_rows': h / 3})
+  let g:buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': h / 3})
   call term_sendkeys(g:buf, (h / 3 - 1)."o\<esc>G")
   call term_sendkeys(g:buf, "i\<c-x>")
   call term_wait(g:buf, 200)


### PR DESCRIPTION
Fix for https://groups.google.com/forum/#!topic/vim_dev/RskqZ2J-040

* Change the contents of `vimcmd`; set first line to `$VIMPROG`
* Define `GetVimProg()` to get first line of `vimcmd` i.e. `$VIMPROG`

<del>For example, on Mac `v:progpath` is just `vim`, so is useless to get vim path. </del>

Fix for https://ci.appveyor.com/project/chrisbra/vim-win32-installer/build/503

As for as I investigated, on Windows it needs a wait after sending `<esc>`, otherwise vim cannot enter normal mode and receives characters `Gi` (following `<esc>`) on insert mode.