### PR TITLE
Handle unicode composing characters on terminal

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -1402,6 +1402,8 @@ static struct interval ambiguous[] =
     int
 utf_uint2cells(UINT32_T c)
 {
+    if (c >= 0x100 && utf_iscomposing((int)c))
+	return 0;
     return utf_char2cells((int)c);
 }
 #endif

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3151,7 +3151,7 @@ f_term_sendkeys(typval_T *argvars, typval_T *rettv)
     while (*msg != NUL)
     {
 	send_keys_to_term(term, PTR2CHAR(msg), FALSE);
-	msg += MB_PTR2LEN(msg);
+	msg += MB_CPTR2LEN(msg);
     }
 }
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2296,7 +2296,6 @@ term_update_window(win_T *wp)
 		if (vterm_screen_get_cell(screen, pos, &cell) == 0)
 		    vim_memset(&cell, 0, sizeof(cell));
 
-		/* TODO: composing chars */
 		c = cell.chars[0];
 		if (c == NUL)
 		{
@@ -2308,6 +2307,8 @@ term_update_window(win_T *wp)
 		{
 		    if (enc_utf8)
 		    {
+			int i;
+
 			if (c >= 0x80)
 			{
 			    ScreenLines[off] = ' ';
@@ -2318,6 +2319,10 @@ term_update_window(win_T *wp)
 			    ScreenLines[off] = c;
 			    ScreenLinesUC[off] = NUL;
 			}
+			/* composing chars */
+			for (i = 0; i < Screen_mco
+				      && i + 1 < VTERM_MAX_CHARS_PER_CELL; ++i)
+			    ScreenLinesC[i][off] = cell.chars[i + 1];
 		    }
 #ifdef WIN3264
 		    else if (has_mbyte && c >= 0x80)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2309,7 +2309,16 @@ term_update_window(win_T *wp)
 		    {
 			int i;
 
-			if (c >= 0x80)
+			/* composing chars */
+			for (i = 0; i < Screen_mco
+				      && i + 1 < VTERM_MAX_CHARS_PER_CELL; ++i)
+			{
+			    ScreenLinesC[i][off] = cell.chars[i + 1];
+			    if (cell.chars[i + 1] == 0)
+				break;
+			}
+			if (c >= 0x80 || (Screen_mco > 0
+						 && ScreenLinesC[0][off] != 0))
 			{
 			    ScreenLines[off] = ' ';
 			    ScreenLinesUC[off] = c;
@@ -2319,10 +2328,6 @@ term_update_window(win_T *wp)
 			    ScreenLines[off] = c;
 			    ScreenLinesUC[off] = NUL;
 			}
-			/* composing chars */
-			for (i = 0; i < Screen_mco
-				      && i + 1 < VTERM_MAX_CHARS_PER_CELL; ++i)
-			    ScreenLinesC[i][off] = cell.chars[i + 1];
 		    }
 #ifdef WIN3264
 		    else if (has_mbyte && c >= 0x80)

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -678,9 +678,9 @@ func Test_terminal_tmap()
 endfunc
 
 func Test_terminal_composing_unicode()
-  if &encoding !~? 'utf-8'
-    return
-  endif
+  let save_enc = &encoding
+  set encoding=utf-8
+
   if has('win32')
     let cmd = "cmd /K chcp 65001"
     let lnum = [3, 6, 9]
@@ -688,6 +688,7 @@ func Test_terminal_composing_unicode()
     let cmd = &shell
     let lnum = [1, 3, 5]
   endif
+
   enew
   let buf = term_start(cmd, {'curwin': bufnr('')})
   let job = term_getjob(buf)
@@ -730,4 +731,5 @@ func Test_terminal_composing_unicode()
   call WaitFor('job_status(job) == "dead"')
   call assert_equal('dead', job_status(job))
   bwipe!
+  let &encoding = save_enc
 endfunc

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -678,6 +678,9 @@ func Test_terminal_tmap()
 endfunc
 
 func Test_terminal_composing_unicode()
+  if &encoding !~? 'utf-8'
+    return
+  endif
   if has('win32')
     let cmd = "cmd /K chcp 65001"
     let lnum = [3, 6, 9]
@@ -685,7 +688,8 @@ func Test_terminal_composing_unicode()
     let cmd = &shell
     let lnum = [1, 3, 5]
   endif
-  let buf = term_start(cmd)
+  enew
+  let buf = term_start(cmd, {'curwin': bufnr('')})
   let job = term_getjob(buf)
   call term_wait(buf, 50)
 
@@ -725,4 +729,5 @@ func Test_terminal_composing_unicode()
   call term_sendkeys(buf, "exit\r")
   call WaitFor('job_status(job) == "dead"')
   call assert_equal('dead', job_status(job))
+  bwipe!
 endfunc

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -680,20 +680,22 @@ endfunc
 func Test_terminal_composing_unicode()
   if has('win32')
     let cmd = "cmd /K chcp 65001"
+    let lnum = [3, 6, 9]
   else
     let cmd = &shell
+    let lnum = [1, 3, 5]
   endif
   let buf = term_start(cmd)
   let job = term_getjob(buf)
-  call term_wait(buf)
+  call term_wait(buf, 50)
 
   " ascii + composing
   let txt = "a\u0308bc"
   call term_sendkeys(buf, "echo " . txt . "\r")
-  call term_wait(buf)
-  call assert_match("echo " . txt, term_getline(buf, 1))
-  call assert_equal(txt, term_getline(buf, 2))
-  let l = term_scrape(buf, 2)
+  call term_wait(buf, 50)
+  call assert_match("echo " . txt, term_getline(buf, lnum[0]))
+  call assert_equal(txt, term_getline(buf, lnum[0] + 1))
+  let l = term_scrape(buf, lnum[0] + 1)
   call assert_equal("a\u0308", l[0].chars)
   call assert_equal("b", l[1].chars)
   call assert_equal("c", l[2].chars)
@@ -701,10 +703,10 @@ func Test_terminal_composing_unicode()
   " multibyte + composing
   let txt = "\u304b\u3099\u304e\u304f\u3099\u3052\u3053\u3099"
   call term_sendkeys(buf, "echo " . txt . "\r")
-  call term_wait(buf)
-  call assert_match("echo " . txt, term_getline(buf, 3))
-  call assert_equal(txt, term_getline(buf, 4))
-  let l = term_scrape(buf, 4)
+  call term_wait(buf, 50)
+  call assert_match("echo " . txt, term_getline(buf, lnum[1]))
+  call assert_equal(txt, term_getline(buf, lnum[1] + 1))
+  let l = term_scrape(buf, lnum[1] + 1)
   call assert_equal("\u304b\u3099", l[0].chars)
   call assert_equal("\u304e", l[1].chars)
   call assert_equal("\u304f\u3099", l[2].chars)
@@ -714,10 +716,10 @@ func Test_terminal_composing_unicode()
   " \u00a0 + composing
   let txt = "abc\u00a0\u0308"
   call term_sendkeys(buf, "echo " . txt . "\r")
-  call term_wait(buf)
-  call assert_match("echo " . txt, term_getline(buf, 5))
-  call assert_equal(txt, term_getline(buf, 6))
-  let l = term_scrape(buf, 6)
+  call term_wait(buf, 50)
+  call assert_match("echo " . txt, term_getline(buf, lnum[2]))
+  call assert_equal(txt, term_getline(buf, lnum[2] + 1))
+  let l = term_scrape(buf, lnum[2] + 1)
   call assert_equal("\u00a0\u0308", l[3].chars)
 
   call term_sendkeys(buf, "exit\r")


### PR DESCRIPTION
* `utf_uint2cells` should return 0 when `c` is composing char
* Replace `MB_PTR2LEN` by `MB_CPTR2LEN` in`f_term_sendkeys` to enable to send the composing char

When treat the width of the composing char as greater than 0, the extra character is shown.

expected: **ガカ**
actual: **カカ**
![2017-10-08 1 39 37](https://user-images.githubusercontent.com/943423/31309962-2e5a3c18-abca-11e7-9aee-2d6ceeede74e.png)

terminal-normal mode view:
![2017-10-08 1 40 00](https://user-images.githubusercontent.com/943423/31309964-3127cf5a-abca-11e7-899d-3cfe366e1977.png)

