### PR TITLE
WIP: configure: use libruby's SONAME path

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1902,9 +1902,9 @@ if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
 	RUBY_PRO="if_ruby.pro"
 	AC_DEFINE(FEAT_RUBY)
 	if test "$enable_rubyinterp" = "dynamic"; then
-	  libruby=`$vi_cv_path_ruby -r rbconfig -e "puts $ruby_rbconfig::CONFIG[['LIBRUBY_SO']]"`
+	  libruby_soname=`$vi_cv_path_ruby -r rbconfig -e "puts $ruby_rbconfig::CONFIG[['LIBRUBY_ALIASES']].split[[0]]"`
 	  AC_DEFINE(DYNAMIC_RUBY)
-	  RUBY_CFLAGS="-DDYNAMIC_RUBY_DLL=\\\"$libruby\\\" -DDYNAMIC_RUBY_VER=$rubyversion $RUBY_CFLAGS"
+	  RUBY_CFLAGS="-DDYNAMIC_RUBY_DLL=\\\"$libruby_soname\\\" -DDYNAMIC_RUBY_VER=$rubyversion $RUBY_CFLAGS"
 	  RUBY_LIBS=
 	fi
       else


### PR DESCRIPTION
When using the LIBRUBY_SO name directly, Vim is sensitive to every patch
version bump in Ruby. Instead, open in via the SONAME which is stable
across ABI for all Ruby versions.

---
I don't think this works as-is on non-ELF platforms. Some alternative logic may be required.

Note that a similar issue exists with Perl dynamic support. It seems that `libperl.so` is used which requires `perl-devel` (or equivalent) for Perl to actually work. I don't see how to get such information from a `perl` executable though.