### PR TITLE
Fix OS X build on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_install:
     # building cffi only works with gcc, not with clang
   - if [ "$COVERAGE" = "yes" ]; then CC=gcc pip install --user pyopenssl ndg-httpsclient pyasn1; fi
     # Lua is not installed on Travis OSX
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install lua; export LUA_PREFIX=/usr/local; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export HOMEBREW_NO_AUTO_UPDATE=1; brew update; brew install lua; export LUA_PREFIX=/usr/local; fi
     # Use llvm-cov instead of gcov when compiler is clang.
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CC" = "clang" ]; then ln -sf $(which llvm-cov) /home/travis/bin/gcov; fi
 


### PR DESCRIPTION
The latest brew requires ruby 2.3 or later, and `brew-update` installs its own ruby binary.
`brew-install` does `brew-update` under its process, but `brew-install` is continued on the previous ruby envs (<del>system default:</del> 2.0.0), so brew reports ruby-version error.

To fix it:

* do separately `brew-update` and `brew-install`
* do `brew-install` with `HOMEBREW_NO_AUTO_UPDATE=1` (means don't do `brew-update` in `brew-install`)