### PR TITLE
Ensure that `exiting` is set correctly on :wq

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7820,6 +7820,7 @@ ex_exit(exarg_T *eap)
     }
     else
     {
+	not_exiting();
 	if (only_one_window())	    /* quit last window, exit Vim */
 	    getout(0);
 # ifdef FEAT_GUI


### PR DESCRIPTION
With this vimrc file:

	augroup test
		autocmd BufWritePre * lexpr [] | lopen
		" Same:
		"autocmd BufWritePre * split
	augroup end

Loaded as:

	$ vim --noplugin -u testvimrc.vim x +wq

Vim is left in an unusable state; it won't quit Vim and the new window is
displayed, but the display is never updated

The behaviour is the same in all version I tested: 8.0.1176, 7.4.1689, 7.0

This is a problem in some plugins which check syntax on `:w`, such as vim-go and
syntastic. See:
https://github.com/fatih/vim-go/pull/1497

---

The problem is that `ex_exit()` it first checks if there is just one window, and
it sets `exiting = TRUE` accordingly. But then in `do_write()` a new window is
opened, and `exiting` is never reset.

By adding `not_exiting()` we make sure that the state gets set correctly.