### PR TITLE
vim.desktop: Set NoDisplay=true

### DIFF
--- a/runtime/vim.desktop
+++ b/runtime/vim.desktop
@@ -73,6 +73,7 @@ Comment[zh_TW]=編輯文字檔
 TryExec=vim
 Exec=vim %F
 Terminal=true
+NoDisplay=true
 Type=Application
 Keywords=Text;editor;
 Icon=gvim


### PR DESCRIPTION
`vim.desktop` [came](https://github.com/vim/vim/pull/455) from Debian where it was [requested](https://bugs.debian.org/760512) so that text files could easily be opened with vim.

However, this also made Vim show up in the applications menu which seems very odd for a terminal "app". It might not have been noticed by GNOME users on Debian since the Debian GNOME team has [blacklisted](https://anonscm.debian.org/viewvc/pkg-gnome/desktop/unstable/gnome-menus/debian/menus.blacklist?view=markup) vim.desktop from showing in GNOME's Activities Overview.

The [Desktop Entry Spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys) says

> NoDisplay means "this application exists, but don't display it in the menus". This can be useful to e.g. associate this application with MIME types, so that it gets launched from a file manager (or other apps), without having a menu entry for it (there are tons of good reasons for this, including e.g. the netscape -remote, or kfmclient openURL kind of stuff). 

Therefore, I think it would be very appropriate for `vim.desktop` to set `NoDisplay=true`. I confirmed that this hides Vim from the Activities Overview but it still shows up in the `Open With` dialog on Ubuntu 17.10.

This is different from `gvim.desktop` which is closer to a traditional desktop app. At least in Debian, `gvim` is a separate package for those who want that instead of the traditional terminal version.