### PR TITLE
Add escaping for arguments on Cygwin system(scp and rsync)

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -1250,7 +1250,7 @@ fun! netrw#Lexplore(count,rightside,...)
    setlocal winfixwidth
    let g:netrw_altv     = keep_altv
    let t:netrw_lexbufnr = bufnr("%")
-"   call Decho("let t:netrw_lexbufnr=".t:netrw_lexbufnr) 
+"   call Decho("let t:netrw_lexbufnr=".t:netrw_lexbufnr)
 "   call Decho("t:netrw_lexposn".(exists("t:netrw_lexposn")? string(t:netrw_lexposn) : " n/a"))
    if exists("t:netrw_lexposn")
 "    call Decho("restoring to t:netrw_lexposn",'~'.expand("<slnum>"))
@@ -2889,12 +2889,17 @@ fun! s:NetrwGetFile(readcmd, tfile, method)
    return
 
   elseif s:FileReadable(a:tfile)
+   let tfile= a:tfile
+   if g:netrw_cygwin && !has("win32unix")
+    let tfile= substitute(a:tfile,g:netrw_cygdrive.'/\(.\)','\1:','')
+   endif
+
    " read file after current line
 "   call Decho("read file<".a:tfile."> after current line",'~'.expand("<slnum>"))
    let curline = line(".")
    let lastline= line("$")
 "   call Decho("exe<".a:readcmd." ".fnameescape(v:cmdarg)." ".fnameescape(a:tfile).">  line#".curline,'~'.expand("<slnum>"))
-   exe "NetrwKeepj ".a:readcmd." ".fnameescape(v:cmdarg)." ".fnameescape(a:tfile)
+   exe "NetrwKeepj ".a:readcmd." ".fnameescape(v:cmdarg)." ".fnameescape(tfile)
    let line1= curline + 1
    let line2= line("$") - lastline + 1
 
@@ -8038,7 +8043,7 @@ fun! netrw#Shrink()
    elseif winwidth(bufwinnr(t:netrw_lexbufnr)) >= 0
     exe "vert resize ".t:netrw_winwidth
 "    call Decho("vert resize ".t:netrw_winwidth,'~'.expand("<slnum>"))
-   else 
+   else
     call netrw#Lexplore(0,0)
    endif
 
@@ -11764,7 +11769,7 @@ fun! s:NetrwHumanReadable(sz)
 "  call Dfunc("s:NetrwHumanReadable(sz=".a:sz.") type=".type(a:sz)." style=".g:netrw_sizestyle )
 
   if g:netrw_sizestyle == 'h'
-   if a:sz >= 1000000000 
+   if a:sz >= 1000000000
     let sz = printf("%.1f",a:sz/1000000000.0)."g"
    elseif a:sz >= 10000000
     let sz = printf("%d",a:sz/1000000)."m"
@@ -12192,7 +12197,7 @@ endfun
 fun! s:ShellEscape(s, ...)
   if (has('win32') || has('win64')) && $SHELL == '' && &shellslash
     return printf('"%s"', substitute(a:s, '"', '""', 'g'))
-  endif 
+  endif
   let f = a:0 > 0 ? a:1 : 0
   return shellescape(a:s, f)
 endfun


### PR DESCRIPTION
For various environments with Cygwin:

1. VIM of Windows-building(_while `&shell` is `bash.exe`_)
1. VIM of Windows-building(_while `&shell` is `cmd.exe`_)
1. VIM of Cygwin-building

These enhancements try to fix case 1 and case 2 while `/cygdrive/C/...` cannot be read by Windows-building VIM.

And it adds supporting for different escaping for `bash.exe -c` and `cmd.exe`.

I only modify protocols of `scp` and `rsync` and have tested them.