### PR TITLE
Clarity in lesson 3.4

### DIFF
--- a/runtime/tutor/tutor.pt
+++ b/runtime/tutor/tutor.pt
@@ -455,8 +455,8 @@ de Inserção.
 
   4. Mova o cursor até o primeiro erro.
 
-  5. Digite  c$  para tornar o resto da linha igual à segunda e pressione
-     <ESC>.
+  5. Digite  c$  e digite o resto da segunda para torná-las iguais e 
+     pressione  <ESC>.
 
 ---> O fim desta linha precisa de ajuda para ficar igual à segunda.
 ---> O fim desta linha precisa ser corrigido usando o comando  c$.

--- a/runtime/tutor/tutor.pt.utf-8
+++ b/runtime/tutor/tutor.pt.utf-8
@@ -455,8 +455,8 @@ de Inserção.
 
   4. Mova o cursor até o primeiro erro.
 
-  5. Digite  c$  para tornar o resto da linha igual à segunda e pressione
-     <ESC>.
+  5. Digite  c$  e digite o resto da segunda linha para torná-las iguais e 
+     pressione <ESC>.
 
 ---> O fim desta linha precisa de ajuda para ficar igual à segunda.
 ---> O fim desta linha precisa ser corrigido usando o comando  c$.


### PR DESCRIPTION
Including information to type the second line according to the original english text. 

The original portuguese text did not mention to type the second line in the lesson in question which could make some users (like dumb-old me) that the c$ command would magically copy the second line. 

Just mentioning because the original text mentions to type the rest of the second line, which was omitted in the portuguese version. 