### PR TITLE
bindzone file syntax

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -292,14 +292,14 @@ au BufNewFile,BufRead *.bst			setf bst
 
 " BIND configuration
 " sudoedit uses namedXXXX.conf
-au BufNewFile,BufRead named*.conf,rndc*.conf	setf named
+au BufNewFile,BufRead named*.conf,rndc*.conf,rndc*.key	setf named
 
 " BIND zone
 au BufNewFile,BufRead named.root		setf bindzone
 au BufNewFile,BufRead *.db			call s:BindzoneCheck('')
 
 func! s:BindzoneCheck(default)
-  if getline(1).getline(2).getline(3).getline(4) =~ '^; <<>> DiG [0-9.]\+ <<>>\|BIND.*named\|$ORIGIN\|$TTL\|IN\s\+SOA'
+  if getline(1).getline(2).getline(3).getline(4) =~ '^; <<>> DiG [0-9.]\+ <<>>\|$ORIGIN\|$TTL\|IN\s\+SOA'
     setf bindzone
   elseif a:default != ''
     exe 'setf ' . a:default

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -299,7 +299,7 @@ au BufNewFile,BufRead named.root		setf bindzone
 au BufNewFile,BufRead *.db			call s:BindzoneCheck('')
 
 func! s:BindzoneCheck(default)
-  if getline(1).getline(2).getline(3).getline(4) =~ '^; <<>> DiG [0-9.]\+ <<>>\|$ORIGIN\|$TTL\|IN\s\+SOA'
+  if getline(1).getline(2).getline(3).getline(4) =~ '^; <<>> DiG [0-9.]\+.* <<>>\|$ORIGIN\|$TTL\|IN\s\+SOA'
     setf bindzone
   elseif a:default != ''
     exe 'setf ' . a:default

--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -324,7 +324,7 @@ else
     set ft=sindacmp
 
     " DNS zone files
-  elseif s:line1.s:line2.s:line3.s:line4 =~# '^; <<>> DiG [0-9.]\+ <<>>\|BIND.*named\|$ORIGIN\|$TTL\|IN\s\+SOA'
+  elseif s:line1.s:line2.s:line3.s:line4 =~# '^; <<>> DiG [0-9.]\+ <<>>\|$ORIGIN\|$TTL\|IN\s\+SOA'
     set ft=bindzone
 
     " BAAN

--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -324,7 +324,7 @@ else
     set ft=sindacmp
 
     " DNS zone files
-  elseif s:line1.s:line2.s:line3.s:line4 =~# '^; <<>> DiG [0-9.]\+ <<>>\|$ORIGIN\|$TTL\|IN\s\+SOA'
+  elseif s:line1.s:line2.s:line3.s:line4 =~# '^; <<>> DiG [0-9.]\+.* <<>>\|$ORIGIN\|$TTL\|IN\s\+SOA'
     set ft=bindzone
 
     " BAAN


### PR DESCRIPTION
Several files (like nn.conf, /etc/sysconfig/named etc.) got set to bindzone filetype, which is not correct filetype for them, because of regexp 'BIND.*named'. I consulted this issue with our Fedora bind maintainer and checked it in Debian too and this patch should cover most of cases (except of named.ca, but it is Fedora specific file, but rndc.key isn't. That's why it is added in patch).
Would you mind adding this patch to the project?