### PR TITLE
Collapse empty statusline groups that contain higlighting changes

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -3883,6 +3883,8 @@ build_stl_str_hl(
     int		width;
     int		itemcnt;
     int		curitem;
+    int		group_end_userhl;
+    int		group_start_userhl;
     int		groupitem[STL_MAX_ITEM];
     int		groupdepth;
     struct stl_item
@@ -4023,11 +4025,20 @@ build_stl_str_hl(
 	    if (curitem > groupitem[groupdepth] + 1
 		    && item[groupitem[groupdepth]].minwid == 0)
 	    {
-		/* remove group if all items are empty */
+		/* remove group if all items are empty and highlight group
+		 * doesn't change */
+		group_start_userhl = group_end_userhl = 0;
+		for (n = 0; n < groupitem[groupdepth]; n++)
+		    if (item[n].type == Highlight)
+			group_start_userhl = item[n].minwid;
 		for (n = groupitem[groupdepth] + 1; n < curitem; n++)
-		    if (item[n].type == Normal || item[n].type == Highlight)
+		{
+		    if (item[n].type == Normal)
 			break;
-		if (n == curitem)
+		    if (item[n].type == Highlight)
+			group_end_userhl = item[n].minwid;
+		}
+		if (n == curitem && group_start_userhl == group_end_userhl)
 		{
 		    p = t;
 		    l = 0;

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -5,7 +5,6 @@
 "   %N
 "   %T
 "   %X
-"   %*
 
 source view_util.vim
 
@@ -248,6 +247,70 @@ func Test_statusline()
   let sa3=screenattr(&lines - 1, 3)
   call assert_equal(sa1, sa3)
   call assert_notequal(sa1, sa2)
+
+  " An empty group that contains highlight changes
+  let g:a = ''
+  set statusline=ab%(cd%1*%{g:a}%*%)de
+  call assert_match('^abde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 4)
+  call assert_equal(sa1, sa2)
+  let g:a = 'X'
+  call assert_match('^abcdXde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 5)
+  let sa3=screenattr(&lines - 1, 7)
+  call assert_equal(sa1, sa3)
+  call assert_notequal(sa1, sa2)
+
+  let g:a = ''
+  set statusline=ab%1*%(cd%*%{g:a}%1*%)de
+  call assert_match('^abde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 4)
+  call assert_notequal(sa1, sa2)
+  let g:a = 'X'
+  call assert_match('^abcdXde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 3)
+  let sa3=screenattr(&lines - 1, 5)
+  let sa4=screenattr(&lines - 1, 7)
+  call assert_notequal(sa1, sa2)
+  call assert_equal(sa1, sa3)
+  call assert_equal(sa2, sa4)
+
+  " An empty group that contains highlight changes and doesn't reset them
+  let g:a = ''
+  set statusline=ab%(cd%1*%{g:a}%)de
+  call assert_match('^abcdde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 5)
+  call assert_notequal(sa1, sa2)
+  let g:a = 'X'
+  call assert_match('^abcdXde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 5)
+  let sa3=screenattr(&lines - 1, 7)
+  call assert_notequal(sa1, sa2)
+  call assert_equal(sa2, sa3)
+
+  let g:a = ''
+  set statusline=ab%1*%(cd%*%{g:a}%)de
+  call assert_match('^abcdde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 3)
+  let sa3=screenattr(&lines - 1, 5)
+  call assert_notequal(sa1, sa2)
+  call assert_equal(sa1, sa3)
+  let g:a = 'X'
+  call assert_match('^abcdXde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 3)
+  let sa3=screenattr(&lines - 1, 5)
+  let sa4=screenattr(&lines - 1, 7)
+  call assert_notequal(sa1, sa2)
+  call assert_equal(sa1, sa3)
+  call assert_equal(sa1, sa4)
 
   " %%: a percent sign.
   set statusline=10%%


### PR DESCRIPTION
Consider a statusline group (%(...%) that has highlighting items (%n*, %#...#)
to be empty if at the end of the group the highlighting is restored to what
it was at the beginning of the group.

Fixes #2227.