### PR TITLE
Fix c_Ctrl-G/T doesn't work when char_avail() is true

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1702,11 +1702,8 @@ getcmdline(
 		if (p_is && !cmd_silent && (firstc == '/' || firstc == '?'))
 		{
 		    pos_T  t;
-		    int    search_flags = SEARCH_KEEP + SEARCH_NOOF
-							     + SEARCH_PEEK;
+		    int    search_flags = SEARCH_KEEP + SEARCH_NOOF;
 
-		    if (char_avail())
-			continue;
 		    cursor_off();
 		    out_flush();
 		    if (c == Ctrl_G)

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -356,6 +356,26 @@ func Test_search_cmdline4()
   bw!
 endfunc
 
+func Test_search_cmdline5()
+  if !exists('+incsearch')
+    return
+  endif
+  " Do not call test_override("char_avail", 1) so that <C-g> and <C-t> work
+  " regardless char_avail.
+  new
+  call setline(1, ['  1 the first', '  2 the second', '  3 the third'])
+  set incsearch
+  1
+  call feedkeys("/the\<c-g>\<c-g>\<cr>", 'tx')
+  call assert_equal('  3 the third', getline('.'))
+  $
+  call feedkeys("?the\<c-t>\<c-t>\<c-t>\<cr>", 'tx')
+  call assert_equal('  2 the second', getline('.'))
+  " clean up
+  set noincsearch
+  bw!
+endfunc
+
 " Tests for regexp with various magic settings
 func Test_search_regexp()
   enew!


### PR DESCRIPTION
c_Ctrl-G/T should work regardless char_avail() state because it moves
cursor position.

Users might use c_Ctrl-G/T by mapping, :normal or feedkeys().