### PR TITLE
Fixed write to free memory in jumpto_tag() with autocmd

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -249,6 +249,15 @@ func Test_augroup_warning()
   au! VimEnter
 endfunc
 
+func Test_BufReadCmd()
+  " This used to cause access to free memory
+  au BufReadCmd * e +h
+  help
+
+  helpclose
+  au! BufReadCmd
+endfunc
+
 func Test_augroup_deleted()
   " This caused a crash before E936 was introduced
   augroup x


### PR DESCRIPTION
This PR fixes write to free memory.
Bug was found using afl-fuzz.

Steps to reproduce the bug:
```
$ cat bug.vim
au BufReadCmd * e +h
help

$ valgrind --num-callers=30 vim -u NONE -S bug.vim -c qa 2> vg.log

$ cat vg.log
==21531== Memcheck, a memory error detector
==21531== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==21531== Using Valgrind-3.14.0.GIT and LibVEX; rerun with -h for copyright info
==21531== Command: vim -u NONE -S bug.vim -c qa
==21531== 
==21531== Invalid write of size 1
==21531==    at 0x595D6E: jumpto_tag (tag.c:3445)
==21531==    by 0x595D6E: do_tag (tag.c:1029)
==21531==    by 0x452B16: ex_help (ex_cmds.c:6372)
==21531==    by 0x46188A: do_one_cmd (ex_docmd.c:2908)
==21531==    by 0x45DB8D: do_cmdline (ex_docmd.c:1071)
==21531==    by 0x45BBE3: do_source (ex_cmds2.c:4355)
==21531==    by 0x45B41A: cmd_source (ex_cmds2.c:3968)
==21531==    by 0x45B41A: ex_source (ex_cmds2.c:3943)
==21531==    by 0x46188A: do_one_cmd (ex_docmd.c:2908)
==21531==    by 0x45DB8D: do_cmdline (ex_docmd.c:1071)
==21531==    by 0x5EDC6C: exe_commands (main.c:2955)
==21531==    by 0x5EDC6C: vim_main2 (main.c:800)
==21531==    by 0x5EC891: main (main.c:429)
==21531==  Address 0x9accbb7 is 55 bytes inside a block of size 71 free'd
==21531==    at 0x4C2ECF0: free (vg_replace_malloc.c:530)
==21531==    by 0x4C7887: FreeWild (misc1.c:11277)
==21531==    by 0x5948D3: do_tag (tag.c:561)
==21531==    by 0x452B16: ex_help (ex_cmds.c:6372)
==21531==    by 0x46188A: do_one_cmd (ex_docmd.c:2908)
==21531==    by 0x45DB8D: do_cmdline (ex_docmd.c:1071)
==21531==    by 0x44FD73: do_ecmd (ex_cmds.c:4318)
==21531==    by 0x466083: do_exedit (ex_docmd.c:8661)
==21531==    by 0x46188A: do_one_cmd (ex_docmd.c:2908)
==21531==    by 0x45DB8D: do_cmdline (ex_docmd.c:1071)
==21531==    by 0x48AD73: apply_autocmds_group (fileio.c:9629)
==21531==    by 0x47EAA5: apply_autocmds_exarg (fileio.c:9190)
==21531==    by 0x47EAA5: readfile (fileio.c:397)
==21531==    by 0x40A0EC: open_buffer (buffer.c:236)
==21531==    by 0x44FAD7: do_ecmd (ex_cmds.c:4185)
==21531==    by 0x44EEFD: getfile (ex_cmds.c:3596)
==21531==    by 0x5959FD: jumpto_tag (tag.c:3250)
==21531==    by 0x5959FD: do_tag (tag.c:1029)
==21531==    by 0x452B16: ex_help (ex_cmds.c:6372)
==21531==    by 0x46188A: do_one_cmd (ex_docmd.c:2908)
==21531==    by 0x45DB8D: do_cmdline (ex_docmd.c:1071)
==21531==    by 0x45BBE3: do_source (ex_cmds2.c:4355)
==21531==    by 0x45B41A: cmd_source (ex_cmds2.c:3968)
==21531==    by 0x45B41A: ex_source (ex_cmds2.c:3943)
==21531==    by 0x46188A: do_one_cmd (ex_docmd.c:2908)
==21531==    by 0x45DB8D: do_cmdline (ex_docmd.c:1071)
==21531==    by 0x5EDC6C: exe_commands (main.c:2955)
==21531==    by 0x5EDC6C: vim_main2 (main.c:800)
==21531==    by 0x5EC891: main (main.c:429)
==21531==  Block was alloc'd at
==21531==    at 0x4C2DBF6: malloc (vg_replace_malloc.c:299)
==21531==    by 0x4C8DD5: lalloc (misc2.c:954)
==21531==    by 0x597E38: find_tags (tag.c:2382)
==21531==    by 0x594685: do_tag (tag.c:530)
==21531==    by 0x452B16: ex_help (ex_cmds.c:6372)
==21531==    by 0x46188A: do_one_cmd (ex_docmd.c:2908)
==21531==    by 0x45DB8D: do_cmdline (ex_docmd.c:1071)
==21531==    by 0x45BBE3: do_source (ex_cmds2.c:4355)
==21531==    by 0x45B41A: cmd_source (ex_cmds2.c:3968)
==21531==    by 0x45B41A: ex_source (ex_cmds2.c:3943)
==21531==    by 0x46188A: do_one_cmd (ex_docmd.c:2908)
==21531==    by 0x45DB8D: do_cmdline (ex_docmd.c:1071)
==21531==    by 0x5EDC6C: exe_commands (main.c:2955)
==21531==    by 0x5EDC6C: vim_main2 (main.c:800)
==21531==    by 0x5EC891: main (main.c:429)
...snip...
 ```