### PR TITLE
Enable local context for remote calls on debug mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -4184,7 +4184,13 @@ eval_client_expr_to_string(char_u *expr)
 
     /* Evaluate the expression at the toplevel, don't use variables local to
      * the calling function. */
-    fc = clear_current_funccal();
+    if (State & CMDLINE)
+    {
+    }
+    else
+    {
+	fc = clear_current_funccal();
+    }
 
      /* Disable debugging, otherwise Vim hangs, waiting for "cont" to be
       * typed. */
@@ -4201,7 +4207,13 @@ eval_client_expr_to_string(char_u *expr)
     --emsg_silent;
     if (emsg_silent < 0)
 	emsg_silent = 0;
-    restore_current_funccal(fc);
+    if (State & CMDLINE)
+    {
+    }
+    else
+    {
+	restore_current_funccal(fc);
+    }
 
     /* A client can tell us to redraw, but not to display the cursor, so do
      * that here. */


### PR DESCRIPTION
This solves #2237 

Don't know how to better detect when remote is on debug mode, so when it is not clear current_funccall

I use the else from

    if (State & CMDLINE)

I still don't provide a test for this, I will do in next 24h, later
