### PR TITLE
Accept lambdas as {skip} expressions

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6784,6 +6784,7 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip}
 		When {skip} is omitted or empty, every match is accepted.
 		When evaluating {skip} causes an error the search is aborted
 		and -1 returned.
+		{skip} can be a string, a lambda, a funcref, or a partial.
 
 		For {stopline} and {timeout} see |search()|.
 

--- a/src/proto/evalfunc.pro
+++ b/src/proto/evalfunc.pro
@@ -8,7 +8,7 @@ buf_T *buflist_find_by_name(char_u *name, int curtab_only);
 void execute_redir_str(char_u *value, int value_len);
 void mzscheme_call_vim(char_u *name, typval_T *args, typval_T *rettv);
 float_T vim_round(float_T f);
-long do_searchpair(char_u *spat, char_u *mpat, char_u *epat, int dir, char_u *skip, int flags, pos_T *match_pos, linenr_T lnum_stop, long time_limit);
+long do_searchpair(char_u *spat, char_u *mpat, char_u *epat, int dir, typval_T *skip, int flags, pos_T *match_pos, linenr_T lnum_stop, long time_limit);
 char_u *get_callback(typval_T *arg, partial_T **pp);
 void free_callback(char_u *callback, partial_T *partial);
 /* vim: set ft=c : */

--- a/src/search.c
+++ b/src/search.c
@@ -3980,7 +3980,7 @@ again:
     {
 	if (do_searchpair((char_u *)"<[^ \t>/!]\\+\\%(\\_s\\_[^>]\\{-}[^/]>\\|$\\|\\_s\\=>\\)",
 		    (char_u *)"",
-		    (char_u *)"</[^>]*>", BACKWARD, (char_u *)"", 0,
+		    (char_u *)"</[^>]*>", BACKWARD, NULL, 0,
 						  NULL, (linenr_T)0, 0L) <= 0)
 	{
 	    curwin->w_cursor = old_pos;
@@ -4014,7 +4014,7 @@ again:
     sprintf((char *)spat, "<%.*s\\>\\%%(\\s\\_[^>]\\{-}[^/]>\\|>\\)\\c", len, p);
     sprintf((char *)epat, "</%.*s>\\c", len, p);
 
-    r = do_searchpair(spat, (char_u *)"", epat, FORWARD, (char_u *)"",
+    r = do_searchpair(spat, (char_u *)"", epat, FORWARD, NULL,
 						    0, NULL, (linenr_T)0, 0L);
 
     vim_free(spat);

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -294,6 +294,21 @@ func Test_searchpair()
   q!
 endfunc
 
+func Test_searchpair_skip()
+    func Zero()
+	return 0
+    endfunc
+    new
+    call setline(1, ['{', 'foo', 'foo', 'foo', '}'])
+    3 | call assert_equal(1, searchpair('{', '', '}', 'bWn', ''))
+    3 | call assert_equal(1, searchpair('{', '', '}', 'bWn', '0'))
+    3 | call assert_equal(1, searchpair('{', '', '}', 'bWn', {-> 0}))
+    3 | call assert_equal(1, searchpair('{', '', '}', 'bWn', function('Zero')))
+    " invalid argument
+    3 | call assert_equal(0, searchpair('{', '', '}', 'bWn', 0))
+    bw!
+endfunc
+
 func Test_searchc()
   " These commands used to cause memory overflow in searchc().
   new


### PR DESCRIPTION
String expressions are clumsy because of the quoting madness, lambdas are much nicer.
Closes #1454