### PR TITLE
Tests for autocmd effects on '[/'] and Filter* behavior with 'shelltemp'

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -1010,3 +1010,35 @@ func Test_change_mark_in_autocmds()
   call delete('Xtest')
   call delete('Xtest2')
 endfunc
+
+func Test_Filter_noshelltemp()
+  if executable('cat')
+    enew!
+    call setline(1, ['a', 'b', 'c', 'd'])
+
+    let shelltemp = &shelltemp
+    set shelltemp
+
+    let g:filter_au = 0
+    au FilterWritePre * let g:filter_au += 1
+    au FilterReadPre * let g:filter_au += 1
+    au FilterReadPost * let g:filter_au += 1
+    %!cat
+    call assert_equal(3, g:filter_au)
+
+    if has('filterpipe')
+      set noshelltemp
+
+      let g:filter_au = 0
+      au FilterWritePre * let g:filter_au += 1
+      au FilterReadPre * let g:filter_au += 1
+      au FilterReadPost * let g:filter_au += 1
+      %!cat
+      call assert_equal(0, g:filter_au)
+    endif
+
+    au! FilterWritePre,FilterReadPre,FilterReadPost
+    let &shelltemp = shelltemp
+    bwipe!
+  endif
+endfunc


### PR DESCRIPTION
In another branch, I'm working on making Vim respect :lockmarks when it updates
the '[ and '] marks.  As part of that, I figured it would be good to have
baseline testing of the current invariants for how the marks are exposed to
autocmds so I don't break any of those.