### PR TITLE
Allow WaitFor to accept a funcref and fix an arbitrary wait

### DIFF
--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -113,7 +113,8 @@ func s:kill_server(cmd)
   endif
 endfunc
 
-" Wait for up to a second for "expr" to become true.
+" Wait for up to a second for "expr" (stringified expression to evaluate, or
+" 0-arg funcref) to become true.
 " Return time slept in milliseconds.  With the +reltime feature this can be
 " more than the actual waiting time.  Without +reltime it can also be less.
 func WaitFor(expr, ...)
@@ -124,8 +125,13 @@ func WaitFor(expr, ...)
   else
     let slept = 0
   endif
+  if type(a:expr) == v:t_func
+    let Test = a:expr
+  else
+    let Test = {-> eval(a:expr) }
+  endif
   for i in range(timeout / 10)
-    if eval(a:expr)
+    if Test()
       if has('reltime')
 	return float2nr(reltimefloat(reltime(start)) * 1000)
       endif

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -482,17 +482,17 @@ func Test_search_cmdline8()
   " Prepare buffer text
   let lines = ['abb vim vim vi', 'vimvivim']
   call writefile(lines, 'Xsearch.txt')
-  let g:buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
+  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
 
-  call WaitFor({-> lines == [term_getline(g:buf, 1), term_getline(g:buf, 2)] })
+  call WaitFor({-> lines == [term_getline(buf, 1), term_getline(buf, 2)] })
 
-  call term_sendkeys(g:buf, ":set incsearch hlsearch\<cr>")
-  call term_sendkeys(g:buf, ":14vsp\<cr>")
-  call term_sendkeys(g:buf, "/vim\<cr>")
-  call term_sendkeys(g:buf, "/b\<esc>")
-  call term_sendkeys(g:buf, "gg0")
-  call term_wait(g:buf, 500)
-  let screen_line = term_scrape(g:buf, 1)
+  call term_sendkeys(buf, ":set incsearch hlsearch\<cr>")
+  call term_sendkeys(buf, ":14vsp\<cr>")
+  call term_sendkeys(buf, "/vim\<cr>")
+  call term_sendkeys(buf, "/b\<esc>")
+  call term_sendkeys(buf, "gg0")
+  call term_wait(buf, 500)
+  let screen_line = term_scrape(buf, 1)
   let [a0,a1,a2,a3] = [screen_line[3].attr, screen_line[4].attr,
         \ screen_line[18].attr, screen_line[19].attr]
   call assert_notequal(a0, a1)
@@ -605,17 +605,16 @@ func Test_search_cmdline_incsearch_highlight_attr()
   endif
 
   " Prepare buffer text
-  let g:lines = ['abb vim vim vi', 'vimvivim']
-  call writefile(g:lines, 'Xsearch.txt')
-  let g:buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
-  call WaitFor({-> g:lines == [term_getline(g:buf, 1), term_getline(g:buf, 2)] })
-  unlet g:lines
+  let lines = ['abb vim vim vi', 'vimvivim']
+  call writefile(lines, 'Xsearch.txt')
+  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
+  call WaitFor({-> lines == [term_getline(buf, 1), term_getline(buf, 2)] })
 
   " Get attr of normal(a0), incsearch(a1), hlsearch(a2) highlight
-  call term_sendkeys(g:buf, ":set incsearch hlsearch\<cr>")
-  call term_sendkeys(g:buf, '/b')
-  call term_wait(g:buf, 200)
-  let screen_line1 = term_scrape(g:buf, 1)
+  call term_sendkeys(buf, ":set incsearch hlsearch\<cr>")
+  call term_sendkeys(buf, '/b')
+  call term_wait(buf, 200)
+  let screen_line1 = term_scrape(buf, 1)
   call assert_true(len(screen_line1) > 2)
   " a0: attr_normal
   let a0 = screen_line1[0].attr
@@ -626,53 +625,53 @@ func Test_search_cmdline_incsearch_highlight_attr()
   call assert_notequal(a0, a1)
   call assert_notequal(a0, a2)
   call assert_notequal(a1, a2)
-  call term_sendkeys(g:buf, "\<cr>gg0")
+  call term_sendkeys(buf, "\<cr>gg0")
 
   " Test incremental highlight search
-  call term_sendkeys(g:buf, "/vim")
-  call term_wait(g:buf, 200)
+  call term_sendkeys(buf, "/vim")
+  call term_wait(buf, 200)
   " Buffer:
   " abb vim vim vi
   " vimvivim
   " Search: /vim
   let attr_line1 = [a0,a0,a0,a0,a1,a1,a1,a0,a2,a2,a2,a0,a0,a0]
   let attr_line2 = [a2,a2,a2,a0,a0,a2,a2,a2]
-  call assert_equal(attr_line1, map(term_scrape(g:buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
-  call assert_equal(attr_line2, map(term_scrape(g:buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
+  call assert_equal(attr_line1, map(term_scrape(buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
+  call assert_equal(attr_line2, map(term_scrape(buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
 
   " Test <C-g>
-  call term_sendkeys(g:buf, "\<C-g>\<C-g>")
-  call term_wait(g:buf, 200)
+  call term_sendkeys(buf, "\<C-g>\<C-g>")
+  call term_wait(buf, 200)
   let attr_line1 = [a0,a0,a0,a0,a2,a2,a2,a0,a2,a2,a2,a0,a0,a0]
   let attr_line2 = [a1,a1,a1,a0,a0,a2,a2,a2]
-  call assert_equal(attr_line1, map(term_scrape(g:buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
-  call assert_equal(attr_line2, map(term_scrape(g:buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
+  call assert_equal(attr_line1, map(term_scrape(buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
+  call assert_equal(attr_line2, map(term_scrape(buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
 
   " Test <C-t>
-  call term_sendkeys(g:buf, "\<C-t>")
-  call term_wait(g:buf, 200)
+  call term_sendkeys(buf, "\<C-t>")
+  call term_wait(buf, 200)
   let attr_line1 = [a0,a0,a0,a0,a2,a2,a2,a0,a1,a1,a1,a0,a0,a0]
   let attr_line2 = [a2,a2,a2,a0,a0,a2,a2,a2]
-  call assert_equal(attr_line1, map(term_scrape(g:buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
-  call assert_equal(attr_line2, map(term_scrape(g:buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
+  call assert_equal(attr_line1, map(term_scrape(buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
+  call assert_equal(attr_line2, map(term_scrape(buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
 
   " Type Enter and a1(incsearch highlight) should become a2(hlsearch highlight)
-  call term_sendkeys(g:buf, "\<cr>")
-  call term_wait(g:buf, 200)
+  call term_sendkeys(buf, "\<cr>")
+  call term_wait(buf, 200)
   let attr_line1 = [a0,a0,a0,a0,a2,a2,a2,a0,a2,a2,a2,a0,a0,a0]
   let attr_line2 = [a2,a2,a2,a0,a0,a2,a2,a2]
-  call assert_equal(attr_line1, map(term_scrape(g:buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
-  call assert_equal(attr_line2, map(term_scrape(g:buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
+  call assert_equal(attr_line1, map(term_scrape(buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
+  call assert_equal(attr_line2, map(term_scrape(buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
 
   " Test nohlsearch. a2(hlsearch highlight) should become a0(normal highlight)
-  call term_sendkeys(g:buf, ":1\<cr>")
-  call term_sendkeys(g:buf, ":set nohlsearch\<cr>")
-  call term_sendkeys(g:buf, "/vim")
-  call term_wait(g:buf, 200)
+  call term_sendkeys(buf, ":1\<cr>")
+  call term_sendkeys(buf, ":set nohlsearch\<cr>")
+  call term_sendkeys(buf, "/vim")
+  call term_wait(buf, 200)
   let attr_line1 = [a0,a0,a0,a0,a1,a1,a1,a0,a0,a0,a0,a0,a0,a0]
   let attr_line2 = [a0,a0,a0,a0,a0,a0,a0,a0]
-  call assert_equal(attr_line1, map(term_scrape(g:buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
-  call assert_equal(attr_line2, map(term_scrape(g:buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
+  call assert_equal(attr_line1, map(term_scrape(buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
+  call assert_equal(attr_line2, map(term_scrape(buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
   call delete('Xsearch.txt')
 
   call delete('Xsearch.txt')

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -484,9 +484,7 @@ func Test_search_cmdline8()
   call writefile(lines, 'Xsearch.txt')
   let g:buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
 
-  call term_wait(g:buf, 200)
-  call assert_equal(lines[0], term_getline(g:buf, 1))
-  call assert_equal(lines[1], term_getline(g:buf, 2))
+  call WaitFor({-> lines == [term_getline(g:buf, 1), term_getline(g:buf, 2)] })
 
   call term_sendkeys(g:buf, ":set incsearch hlsearch\<cr>")
   call term_sendkeys(g:buf, ":14vsp\<cr>")
@@ -610,9 +608,7 @@ func Test_search_cmdline_incsearch_highlight_attr()
   let g:lines = ['abb vim vim vi', 'vimvivim']
   call writefile(g:lines, 'Xsearch.txt')
   let g:buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
-  call WaitFor('g:lines[0] == term_getline(g:buf, 1)')
-  call assert_equal(g:lines[0], term_getline(g:buf, 1))
-  call assert_equal(g:lines[1], term_getline(g:buf, 2))
+  call WaitFor({-> g:lines == [term_getline(g:buf, 1), term_getline(g:buf, 2)] })
   unlet g:lines
 
   " Get attr of normal(a0), incsearch(a1), hlsearch(a2) highlight


### PR DESCRIPTION
Changing WaitFor() to accept a funcref can make the test code cleaner.  It's
easier to write local closures or lambdas than crafting strings to be eval()d
and avoids creating global variables.

Use this new functionality to fix a test failure in test_search that was
encountered on the latest upload to Debian:

    From test_search.vim:
    Found errors in Test_search_cmdline8():
    function RunTheTest[34]..Test_search_cmdline8 line 19: Expected 'abb vim vim vi' but got ''
    function RunTheTest[34]..Test_search_cmdline8 line 20: Expected 'vimvivim' but got ''