### PR TITLE
Fix compilation warning about unused variables.

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -4757,9 +4757,11 @@ check_termcode(
 			if (i - j >= 21 && STRNCMP(tp + j + 3, "rgb:", 4) == 0
 			    && tp[j + 11] == '/' && tp[j + 16] == '/')
 			{
+#ifdef FEAT_TERMINAL
 			    int rval = hexhex2nr(tp + j + 7);
 			    int gval = hexhex2nr(tp + j + 12);
 			    int bval = hexhex2nr(tp + j + 17);
+#endif
 
 			    if (is_bg)
 			    {


### PR DESCRIPTION
This PR fixes the following warnings when Vim
is configured with:
```
$ ./configure --with-features=tiny --enable-gui=gtk2
```
```
term.c: In function ‘check_termcode’:
term.c:4762:12: warning: unused variable ‘bval’ [-Wunused-variable]
        int bval = hexhex2nr(tp + j + 17);
            ^~~~
term.c:4761:12: warning: unused variable ‘gval’ [-Wunused-variable]
        int gval = hexhex2nr(tp + j + 12);
            ^~~~
term.c:4760:12: warning: unused variable ‘rval’ [-Wunused-variable]
        int rval = hexhex2nr(tp + j + 7);
```