### PR TITLE
Fix setbufline()

### DIFF
--- a/src/testdir/test_bufline.vim
+++ b/src/testdir/test_bufline.vim
@@ -13,6 +13,15 @@ func Test_setbufline_getbufline()
   exe "bd!" b
   call assert_equal([], getbufline(b, 1, 2))
 
+  setlocal foldmethod=expr foldexpr=0
+  let b = bufnr('%')
+  new
+  call assert_equal(0, setbufline(b, 1, ['foo', 'bar']))
+  call assert_equal(['foo'], getbufline(b, 1))
+  call assert_equal(['bar'], getbufline(b, 2))
+  call assert_equal(['foo', 'bar'], getbufline(b, 1, 2))
+  exe "bwipe!" b
+
   split Xtest
   call setline(1, ['a', 'b', 'c'])
   let b = bufnr('%')


### PR DESCRIPTION
### Problem

When applying `setbufline()` with lines list to the buffer which sets `foldmethod=expr`, Vim sets lines into unintented buffer.

### Repro steps (by @thinca)

reproduce.vim:

```vim
setlocal foldmethod=expr foldexpr=0
new
call setbufline(1, 1, [1, 2, 3])
```

`$ vim --clean -S reproduce.vim`

expected: lines `[1, 2, 3]` is into bufnr=1 buffer
actual: only 1 line `[1]` is into bufnr=1 buffer, lines `[2, 3]` is into bufnr=2 buffer (current buffer)

### Solution

* Change/restore `curwin`

**Remaining problem:** when `setbufline()` to hidden buffer, `curwin` keeps actual current window, this may cause unexpected buffer-state.