### PR TITLE
make manpager.vim work on mac

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -602,7 +602,7 @@ MANPAGER				      *manpager.vim*
 The :Man command allows you to turn Vim into a manpager (that syntax highlights
 manpages and follows linked manpages on hitting CTRL-]).
 
-Works on:
+Tested on:
 
   - Linux
   - Mac OS
@@ -617,25 +617,36 @@ Untested:
   - BeOS
   - OS/2
 
-For bash,zsh,ksh or dash by adding to the config file (.bashrc,.zshrc, ...)
+If man sets the $MAN_PN environment variable, like man-db, the most common
+implementation on Linux, then the "env MAN_PN=1 " part below should NOT be
+set, that is, the "env MAN_PN=1" should be omitted! Otherwise, the Vim 
+manpager does not correctly recognize manpages whose title contains a capital 
+letter. See the discussion on
+
+  https://groups.google.com/forum/#!topic/vim_dev/pWZmt_7GkxI
+
+For bash,zsh,ksh or dash, add to the config file (.bashrc,.zshrc, ...)
 
 	export MANPAGER="env MAN_PN=1 vim -M +MANPAGER -"
+
+For (t)csh, add to the config file
+
+	setenv MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
+
+For fish, add to the config file
+
+	set -x MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
 
 On OpenBSD:
 
         export MANPAGER="env MAN_PN=1 vim -M +MANPAGER"
 
-For (t)csh by adding to the config file
+If you experience still issues on manpages whose titles do not contain capital
+letters, then try adding MANPATH=${MANPATH} after MAN_PN=1. If your manpages do
+not show up localized, then try adding, LANGUAGE=${LANG} after MAN_PN=1. See
 
-	setenv MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
+  https://github.com/vim/vim/issues/1002
 
-For fish by adding to the config file
-
-	set -x MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
-
-If man sets the $MAN_PN environment variable, like man-db, the most common
-implementation on Linux and Mac OS, then the "env MAN_PN=1 " part above is
-superfluous.
 
 PDF							*ft-pdf-plugin*
 

--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -15,7 +15,7 @@ function! s:MANPAGER()
   let pagesec_pattern = '\v(' . page_pattern . ')\((' . sec_pattern . ')\)'
 
   if $MAN_PN is '1'
-    let manpage = matchstr( getline(1), '^' . pagesec_pattern )
+    let manpage = matchstr( getline(nextnonblank(1)), '^' . pagesec_pattern )
   else
     let manpage = expand('$MAN_PN')
   endif

--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -17,7 +17,7 @@ function! s:MANPAGER()
   if $MAN_PN is '1'
     let manpage = tolower(matchstr( getline(nextnonblank(1)), '^' . pagesec_pattern ))
   else
-    let manpage = $MAN_PN
+    let manpage = expand($MAN_PN)
   endif
 
   let page_sec = matchlist(manpage, '^' . pagesec_pattern  . '$')

--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -1,6 +1,6 @@
 " Vim plugin for using Vim as manpager.
 " Maintainer: Enno Nagel <ennonagel+vim@gmail.com>
-" Last Change: 2016 May 20
+" Last Change: 2017 November 07
 
 " $MAN_PN is supposed to be set by MANPAGER, see ":help manpager.vim".
 if empty($MAN_PN)
@@ -10,17 +10,17 @@ endif
 command! -nargs=0 MANPAGER call s:MANPAGER() | delcommand MANPAGER
 
 function! s:MANPAGER()
-  let page_pattern = '\v\w+%([-_.]\w+)*'
+  let page_pattern = '\v\w[-_.:0-9A-Za-z]*'
   let sec_pattern = '\v\w+%(\+\w+)*'
   let pagesec_pattern = '\v(' . page_pattern . ')\((' . sec_pattern . ')\)'
 
   if $MAN_PN is '1'
-    let manpage = matchstr( getline(nextnonblank(1)), '^' . pagesec_pattern )
+    let manpage = tolower(matchstr( getline(nextnonblank(1)), '^' . pagesec_pattern ))
   else
-    let manpage = expand('$MAN_PN')
+    let manpage = $MAN_PN
   endif
 
-  let page_sec = matchlist(tolower(manpage), '^' . pagesec_pattern  . '$')
+  let page_sec = matchlist(manpage, '^' . pagesec_pattern  . '$')
 
   bwipe!
 


### PR DESCRIPTION
under mac, the manpage name is not in the first line, but in the first NONBLANK line.