### PR TITLE
Add "lcd" as a default viewoption

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8387,7 +8387,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 						*'viewoptions'* *'vop'*
-'viewoptions' 'vop'	string	(default: "folds,options,cursor")
+'viewoptions' 'vop'	string	(default: "folds,options,cursor,lcd")
 			global
 			{not in Vi}
 			{not available when compiled without the |+mksession|

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1418,7 +1418,7 @@ The output of ":mkview" contains these items:
 5. The scroll position and the cursor position in the file.  Doesn't work very
    well when there are closed folds.
 6. The local current directory, if it is different from the global current
-   directory.
+   directory and 'viewoptions' contains "lcd".
 
 Note that Views and Sessions are not perfect:
 - They don't restore everything.  For example, defined functions, autocommands

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -11697,7 +11697,13 @@ put_view(
     /*
      * Local directory.
      */
-    if (wp->w_localdir != NULL)
+    /* 
+     * Do not save if the current flag is view options and the local directory
+     * option is not set
+     */
+    if (wp->w_localdir != NULL
+	&& (flagp != &vop_flags
+	    || (*flagp & SSOP_LOCALCD)))
     {
 	if (fputs("lcd ", fd) < 0
 		|| ses_put_fname(fd, wp->w_localdir, flagp) == FAIL

--- a/src/option.c
+++ b/src/option.c
@@ -2926,7 +2926,7 @@ static struct vimoption options[] =
     {"viewoptions", "vop",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_SESSION
 			    (char_u *)&p_vop, PV_NONE,
-			    {(char_u *)"folds,options,cursor", (char_u *)0L}
+			    {(char_u *)"folds,options,cursor,lcd", (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}

--- a/src/option.h
+++ b/src/option.h
@@ -741,7 +741,7 @@ EXTERN unsigned	ssop_flags;
 /* Also used for 'viewoptions'! */
 static char *(p_ssop_values[]) = {"buffers", "winpos", "resize", "winsize",
     "localoptions", "options", "help", "blank", "globals", "slash", "unix",
-    "sesdir", "curdir", "folds", "cursor", "tabpages", NULL};
+    "sesdir", "curdir", "folds", "cursor", "tabpages", "lcd", NULL};
 # endif
 # define SSOP_BUFFERS		0x001
 # define SSOP_WINPOS		0x002
@@ -759,6 +759,7 @@ static char *(p_ssop_values[]) = {"buffers", "winpos", "resize", "winsize",
 # define SSOP_FOLDS		0x2000
 # define SSOP_CURSOR		0x4000
 # define SSOP_TABPAGES		0x8000
+# define SSOP_LOCALCD           0x10000
 #endif
 EXTERN char_u	*p_sh;		/* 'shell' */
 EXTERN char_u	*p_shcf;	/* 'shellcmdflag' */


### PR DESCRIPTION
The option enables the current local directory set by ":lcd" to be saved to views which is the current default behaviour. The option can be removed to disable this behaviour.

Problem:
The ":lcd" setting is saved to views and you cannot unset or remove this from your view without manual intervention. This creates some unintended side effects since if you reuse the window after ":lcd" has been set by opening another buffer, then creating a view, the new view associated with the buffer is now permanently associated with the previous ":lcd". If you do not keep track of which window has ":lcd" set, that value will permanently stay in all buffers/views created from that window until it is manually deleted from the view.

This issue has shown up before in at least one other plugin:
https://github.com/kopischke/vim-stay/issues/10
This issue causes unintended side effects from other plugins when also using views:
https://github.com/junegunn/fzf/issues/1085

Solution:
Add "lcd" as a viewoption and make it default to avoid breaking existing behaviour. Users can now remove "lcd" as a viewoption to disable saving the "lcd" to the view.