### PR TITLE
Add automatic server name feature in HUGE

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8820,6 +8820,7 @@ amiga			Amiga version of Vim.
 arabic			Compiled with Arabic support |Arabic|.
 arp			Compiled with ARP support (Amiga).
 autocmd			Compiled with autocommand support. |autocommand|
+autoservername		Automatically enable |clientserver|
 balloon_eval		Compiled with |balloon-eval| support.
 balloon_multiline	GUI supports multiline balloons.
 beos			BeOS version of Vim.

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -309,6 +309,7 @@ g8			Print the hex values of the bytes used in the
    *+ARP*		Amiga only: ARP support included
 B  *+arabic*		|Arabic| language support
 N  *+autocmd*		|:autocmd|, automatic commands
+H  *+autoservername*	Automatically enable |clientserver|
 m  *+balloon_eval*	|balloon-eval| support. Included when compiling with
 			supported GUI (Motif, GTK, GUI) and either
 			Netbeans/Sun Workshop integration or |+eval| feature.

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -817,6 +817,7 @@ enable_workshop
 enable_netbeans
 enable_channel
 enable_terminal
+enable_autoservername
 enable_multibyte
 enable_hangulinput
 enable_xim
@@ -1495,6 +1496,7 @@ Optional Features:
   --disable-netbeans      Disable NetBeans integration support.
   --disable-channel       Disable process communication support.
   --enable-terminal       Enable terminal emulation support.
+  --enable-autoservername         Automatically define servername at vim startup.
   --enable-multibyte      Include multibyte editing support.
   --enable-hangulinput    Include Hangul input support.
   --enable-xim            Include XIM input support.
@@ -7513,6 +7515,22 @@ if test "$enable_terminal" = "yes"; then
   TERM_SRC="libvterm/src/encoding.c libvterm/src/keyboard.c libvterm/src/mouse.c libvterm/src/parser.c libvterm/src/pen.c libvterm/src/screen.c libvterm/src/state.c libvterm/src/unicode.c libvterm/src/vterm.c"
 
   TERM_OBJ="objects/term_encoding.o objects/term_keyboard.o objects/term_mouse.o objects/term_parser.o objects/term_pen.o objects/term_screen.o objects/term_state.o objects/term_unicode.o objects/term_vterm.o"
+
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking --enable-autoservername argument" >&5
+$as_echo_n "checking --enable-autoservername argument... " >&6; }
+# Check whether --enable-autoservername was given.
+if test "${enable_autoservername+set}" = set; then :
+  enableval=$enable_autoservername;
+else
+  enable_autoservername="no"
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_autoservername" >&5
+$as_echo "$enable_autoservername" >&6; }
+if test "$enable_autoservername" = "yes"; then
+  $as_echo "#define FEAT_AUTOSERVERNAME 1" >>confdefs.h
 
 fi
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -384,6 +384,9 @@
 /* Define if you want to include multibyte support. */
 #undef FEAT_MBYTE
 
+/* Define if you want to always define a server name at vim startup. */
+#undef FEAT_AUTOSERVERNAME
+
 /* Define if you want to include fontset support. */
 #undef FEAT_XFONTSET
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2066,6 +2066,15 @@ if test "$enable_terminal" = "yes"; then
   AC_SUBST(TERM_OBJ)
 fi
 
+AC_MSG_CHECKING(--enable-autoservername argument)
+AC_ARG_ENABLE(autoservername,
+	[  --enable-autoservername         Automatically define servername at vim startup.], ,
+	[enable_autoservername="no"])
+AC_MSG_RESULT($enable_autoservername)
+if test "$enable_autoservername" = "yes"; then
+  AC_DEFINE(FEAT_AUTOSERVERNAME)
+fi
+
 AC_MSG_CHECKING(--enable-multibyte argument)
 AC_ARG_ENABLE(multibyte,
 	[  --enable-multibyte      Include multibyte editing support.], ,

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5580,6 +5580,9 @@ f_has(typval_T *argvars, typval_T *rettv)
 #ifdef FEAT_AUTOCMD
 	"autocmd",
 #endif
+#ifdef FEAT_AUTOSERVERNAME
+	"autoservername",
+#endif
 #ifdef FEAT_BEVAL
 	"balloon_eval",
 # ifndef FEAT_GUI_W32 /* other GUIs always have multiline balloons */

--- a/src/feature.h
+++ b/src/feature.h
@@ -1168,6 +1168,14 @@
 #endif
 
 /*
+ * +autoservername	Automatically generate a servername for clientserver
+ *			when --servername is not passed on the command line.
+ */
+#if !defined (FEAT_CLIENTSERVER) && defined(FEAT_AUTOSERVERNAME)
+# undef FEAT_AUTOSERVERNAME
+#endif
+
+/*
  * +termresponse	send t_RV to obtain terminal response.  Used for xterm
  *			to check if mouse dragging can be used and if term
  *			codes can be obtained.

--- a/src/main.c
+++ b/src/main.c
@@ -3673,12 +3673,18 @@ prepare_server(mparm_T *parmp)
     /*
      * Register for remote command execution with :serversend and --remote
      * unless there was a -X or a --servername '' on the command line.
-     * Only register nongui-vim's with an explicit --servername argument.
+     * Only register nongui-vim's with an explicit --servername argument,
+     * or when compiling with autoservername.
      * When running as root --servername is also required.
      */
     if (X_DISPLAY != NULL && parmp->servername != NULL && (
-#  ifdef FEAT_GUI
-		(gui.in_use
+#  if defined(FEAT_AUTOSERVERNAME) || defined(FEAT_GUI)
+		(
+#   if defined(FEAT_AUTOSERVERNAME)
+		    1
+#   else
+		    gui.in_use
+#   endif
 #   ifdef UNIX
 		 && getuid() != ROOT_UID
 #   endif

--- a/src/version.c
+++ b/src/version.c
@@ -83,6 +83,11 @@ static char *(features[]) =
 #else
 	"-autocmd",
 #endif
+#ifdef FEAT_AUTOSERVERNAME
+	"+autoservername",
+#else
+	"-autoservername",
+#endif
 #ifdef FEAT_BEVAL
 	"+balloon_eval",
 #else


### PR DESCRIPTION
Fixes #320 on github: With the option enabled, `v:servername` is now set automatically on UNIX too, unless `--servername ''` is passed or uid is root.

As suggested by Bram Molenaar when the feature was first suggested ([on the google groups](https://groups.google.com/forum/m/#!topic/vim_use/Jsf4vsmoeXM)) I've made this a compile-time option, not to burden startup overheads for builds less than HUGE.

My startuptime log times the overhead at a little under 3ms, for what it's worth, on an i7-5600u @2.6GHz:

> 058.503  003.505: setup clipboard
> 061.425  002.922: register server name