### PR TITLE
Fix undotree() sequence number

### DIFF
--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -4,22 +4,83 @@
 " Also tests :earlier and :later.
 
 func Test_undotree()
-  exe "normal Aabc\<Esc>"
-  set ul=100
-  exe "normal Adef\<Esc>"
-  set ul=100
-  undo
-  let d = undotree()
-  call assert_true(d.seq_last > 0)
-  call assert_true(d.seq_cur > 0)
-  call assert_true(d.seq_cur < d.seq_last)
-  call assert_true(len(d.entries) > 0)
+  new
   " TODO: check more members of d
 
+  normal! Aabc
+  set ul=100
+  let d = undotree()
+  call assert_equal(1, d.seq_last)
+  call assert_equal(1, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(1, len(d.entries))
+  call assert_equal(1, d.entries[0].newhead)
+  call assert_equal(1, d.entries[0].seq)
+  call assert_true(d.entries[0].time <= d.time_cur)
+
+  normal! Adef
+  set ul=100
+  let d = undotree()
+  call assert_equal(2, d.seq_last)
+  call assert_equal(2, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(2, len(d.entries))
+  call assert_equal(1, d.entries[0].seq)
+  call assert_equal(1, d.entries[1].newhead)
+  call assert_equal(2, d.entries[1].seq)
+  call assert_true(d.entries[1].time <= d.time_cur)
+
+  undo
+  set ul=100
+  let d = undotree()
+  call assert_equal(2, d.seq_last)
+  call assert_equal(1, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(2, len(d.entries))
+  call assert_equal(1, d.entries[0].seq)
+  call assert_equal(1, d.entries[1].curhead)
+  call assert_equal(1, d.entries[1].newhead)
+  call assert_equal(2, d.entries[1].seq)
+  call assert_true(d.entries[1].time == d.time_cur)
+
+  normal! Aghi
+  set ul=100
+  let d = undotree()
+  call assert_equal(3, d.seq_last)
+  call assert_equal(3, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(2, len(d.entries))
+  call assert_equal(1, d.entries[0].seq)
+  call assert_equal(2, d.entries[1].alt[0].seq)
+  call assert_equal(1, d.entries[1].newhead)
+  call assert_equal(3, d.entries[1].seq)
+  call assert_true(d.entries[1].time <= d.time_cur)
+
+  undo
+  set ul=100
+  let d = undotree()
+  call assert_equal(3, d.seq_last)
+  call assert_equal(1, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(2, len(d.entries))
+  call assert_equal(1, d.entries[0].seq)
+  call assert_equal(2, d.entries[1].alt[0].seq)
+  call assert_equal(1, d.entries[1].curhead)
+  call assert_equal(1, d.entries[1].newhead)
+  call assert_equal(3, d.entries[1].seq)
+  call assert_true(d.entries[1].time == d.time_cur)
+
   w! Xtest
-  call assert_equal(d.save_last + 1, undotree().save_last)
+  let d = undotree()
+  call assert_equal(1, d.save_cur)
+  call assert_equal(1, d.save_last)
   call delete('Xtest')
-  bwipe Xtest
+  bwipe! Xtest
 endfunc
 
 func FillBuffer()

--- a/src/undo.c
+++ b/src/undo.c
@@ -2863,9 +2863,14 @@ u_undoredo(int undo)
     /* Remember where we are for "g-" and ":earlier 10s". */
     curbuf->b_u_seq_cur = curhead->uh_seq;
     if (undo)
+    {
 	/* We are below the previous undo.  However, to make ":earlier 1s"
 	 * work we compute this as being just above the just undone change. */
-	--curbuf->b_u_seq_cur;
+	if (curhead->uh_next.ptr != NULL)
+	    curbuf->b_u_seq_cur = curhead->uh_next.ptr->uh_seq;
+	else
+	    --curbuf->b_u_seq_cur;
+    }
 
     /* Remember where we are for ":earlier 1f" and ":later 1f". */
     if (curhead->uh_save_nr != 0)

--- a/src/undo.c
+++ b/src/undo.c
@@ -2869,7 +2869,7 @@ u_undoredo(int undo)
 	if (curhead->uh_next.ptr != NULL)
 	    curbuf->b_u_seq_cur = curhead->uh_next.ptr->uh_seq;
 	else
-	    --curbuf->b_u_seq_cur;
+	    curbuf->b_u_seq_cur = 0;
     }
 
     /* Remember where we are for ":earlier 1f" and ":later 1f". */


### PR DESCRIPTION
## Problem (reported by @machakann)

`undotree().seq_cur` shows wrong value after the certain operations.

## Repro steps

`vim --clean`

```vim
:normal! Afoo
:normal! Abar
:undo
:normal! Abaz
:undo
```

then last `undotree().seq_cur` is:

expected: 1
actual: 2

```
[3] baz
 |[2] bar
 |/
[1] foo
[0]
```

In detail:
When going back to the common parent node from branches, `seq_cur` should be set to the parent node number, but just decreased.

## Solution

* Fetch `seq_cur` of the parent node instead of decreasing

Ozaki Kiichi