### PR TITLE
Introduce TextYankPost

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -959,10 +959,22 @@ TextChangedI			After a change was made to the text in the
 				Otherwise the same as TextChanged.
 							|TextYankPost|
 TextYankPost			After some text has been yanked or deleted in
-				the current buffer.  The value of |v:operator|
-				and |v:register| can be used to determine the
-				operation that invoked this autocmd and which
-				register is affected.
+				the current buffer.  The following values of
+				|v:event| can be used to determine the operation
+				that triggered this autocmd:
+					operator    The operation performed.
+					regcontents Text stored in the
+						    register, as a list of
+						    lines, like |readfile()|.
+					regname	    Name of the |register| or
+						    empty string for the
+						    unnamed one.
+					regtype	    Type of the register, see
+						    |getregtype()|.
+				Not triggered when |quote_| is used nor when
+				called recursively.
+				It is not allowed to change the text |textlock|.
+
 							*User*
 User				Never executed automatically.  To be used for
 				autocommands that are only executed with

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -330,7 +330,7 @@ Name			triggered by ~
 
 |TextChanged|		after a change was made to the text in Normal mode
 |TextChangedI|		after a change was made to the text in Insert mode
-TextYankPost		after some text is yanked or deleted
+|TextYankPost|		after some text is yanked or deleted
 
 |ColorScheme|		after loading a color scheme
 

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -330,6 +330,7 @@ Name			triggered by ~
 
 |TextChanged|		after a change was made to the text in Normal mode
 |TextChangedI|		after a change was made to the text in Insert mode
+TextYankPost		after some text is yanked or deleted
 
 |ColorScheme|		after loading a color scheme
 
@@ -956,6 +957,12 @@ TextChangedI			After a change was made to the text in the
 				current buffer in Insert mode.
 				Not triggered when the popup menu is visible.
 				Otherwise the same as TextChanged.
+							|TextYankPost|
+TextYankPost			After some text has been yanked or deleted in
+				the current buffer.  The value of |v:operator|
+				and |v:register| can be used to determine the
+				operation that invoked this autocmd and which
+				register is affected.
 							*User*
 User				Never executed automatically.  To be used for
 				autocommands that are only executed with

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1554,6 +1554,12 @@ v:errors	Errors found by assert functions, such as |assert_true()|.
 <		If v:errors is set to anything but a list it is made an empty
 		list by the assert function.
 
+					*v:event* *event-variable*
+v:event		Dictionary containing some informations about the current
+		|autocommand|.  The dictionary is emptied when the |autocommand|
+		finishes, please refer to |dict-identity| for how to get an
+		independent copy of it.
+
 					*v:exception* *exception-variable*
 v:exception	The value of the exception most recently caught and not
 		finished.  See also |v:throwpoint| and |throw-variables|.

--- a/src/dict.c
+++ b/src/dict.c
@@ -47,6 +47,15 @@ dict_alloc(void)
     return d;
 }
 
+    dict_T *
+dict_alloc_lock(char lock)
+{
+    dict_T *d = dict_alloc();
+    if (d != NULL)
+	d->dv_lock = lock;
+    return d;
+}
+
 /*
  * Allocate an empty dict for a return value.
  * Returns OK or FAIL.
@@ -80,7 +89,7 @@ rettv_dict_set(typval_T *rettv, dict_T *d)
  * Free a Dictionary, including all non-container items it contains.
  * Ignores the reference count.
  */
-    static void
+    void
 dict_free_contents(dict_T *d)
 {
     int		todo;
@@ -102,6 +111,8 @@ dict_free_contents(dict_T *d)
 	    --todo;
 	}
     }
+
+    hash_unlock(&d->dv_hashtab);
     hash_clear(&d->dv_hashtab);
 }
 
@@ -843,6 +854,22 @@ dict_list(typval_T *argvars, typval_T *rettv, int what)
 		copy_tv(&di->di_tv, &li2->li_tv);
 	    }
 	}
+    }
+}
+
+    void
+dict_set_ro_keys(dict_T *di)
+{
+    int		todo = (int)di->dv_hashtab.ht_used;
+    hashitem_T	*hi;
+
+    /* Set readonly */
+    for (hi = di->dv_hashtab.ht_array; todo > 0 ; ++hi)
+    {
+	if (HASHITEM_EMPTY(hi))
+	    continue;
+	--todo;
+	HI2DI(hi)->di_flags |= DI_FLAGS_RO | DI_FLAGS_FIX;
     }
 }
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -112,7 +112,7 @@ dict_free_contents(dict_T *d)
 	}
     }
 
-    hash_unlock(&d->dv_hashtab);
+    /* The hashtab is still locked, it has to be re-initialized anyway */
     hash_clear(&d->dv_hashtab);
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -192,6 +192,7 @@ static struct vimvar
     {VV_NAME("termu7resp",	 VAR_STRING), VV_RO},
     {VV_NAME("termstyleresp",	VAR_STRING), VV_RO},
     {VV_NAME("termblinkresp",	VAR_STRING), VV_RO},
+    {VV_NAME("event",		VAR_DICT), VV_RO},
 };
 
 /* shorthand */
@@ -321,6 +322,7 @@ eval_init(void)
     set_vim_var_nr(VV_HLSEARCH, 1L);
     set_vim_var_dict(VV_COMPLETED_ITEM, dict_alloc());
     set_vim_var_list(VV_ERRORS, list_alloc());
+    set_vim_var_dict(VV_EVENT, dict_alloc());
 
     set_vim_var_nr(VV_FALSE, VVAL_FALSE);
     set_vim_var_nr(VV_TRUE, VVAL_TRUE);
@@ -6625,6 +6627,16 @@ get_vim_var_str(int idx)
 get_vim_var_list(int idx)
 {
     return vimvars[idx].vv_list;
+}
+
+/*
+ * Get Dict v: variable value.  Caller must take care of reference count when
+ * needed.
+ */
+    dict_T *
+get_vim_var_dict(int idx)
+{
+    return vimvars[idx].vv_dict;
 }
 
 /*

--- a/src/eval.c
+++ b/src/eval.c
@@ -286,6 +286,7 @@ eval_init(void)
 {
     int		    i;
     struct vimvar   *p;
+    dict_T	    *d;
 
     init_var_dict(&globvardict, &globvars_var, VAR_DEF_SCOPE);
     init_var_dict(&vimvardict, &vimvars_var, VAR_SCOPE);
@@ -322,7 +323,7 @@ eval_init(void)
     set_vim_var_nr(VV_HLSEARCH, 1L);
     set_vim_var_dict(VV_COMPLETED_ITEM, dict_alloc());
     set_vim_var_list(VV_ERRORS, list_alloc());
-    set_vim_var_dict(VV_EVENT, dict_alloc());
+    set_vim_var_dict(VV_EVENT, dict_alloc_lock(VAR_FIXED));
 
     set_vim_var_nr(VV_FALSE, VVAL_FALSE);
     set_vim_var_nr(VV_TRUE, VVAL_TRUE);
@@ -6713,25 +6714,13 @@ set_vim_var_list(int idx, list_T *val)
     void
 set_vim_var_dict(int idx, dict_T *val)
 {
-    int		todo;
-    hashitem_T	*hi;
-
     clear_tv(&vimvars[idx].vv_di.di_tv);
     vimvars[idx].vv_type = VAR_DICT;
     vimvars[idx].vv_dict = val;
     if (val != NULL)
     {
 	++val->dv_refcount;
-
-	/* Set readonly */
-	todo = (int)val->dv_hashtab.ht_used;
-	for (hi = val->dv_hashtab.ht_array; todo > 0 ; ++hi)
-	{
-	    if (HASHITEM_EMPTY(hi))
-		continue;
-	    --todo;
-	    HI2DI(hi)->di_flags |= DI_FLAGS_RO | DI_FLAGS_FIX;
-	}
+	dict_set_ro_keys(val);
     }
 }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -7805,6 +7805,7 @@ static struct event_name
     {"WinEnter",	EVENT_WINENTER},
     {"WinLeave",	EVENT_WINLEAVE},
     {"VimResized",	EVENT_VIMRESIZED},
+    {"TextYankPost",	EVENT_TEXTYANKPOST},
     {NULL,		(event_T)0}
 };
 
@@ -9346,6 +9347,15 @@ has_cmdundefined(void)
 has_funcundefined(void)
 {
     return (first_autopat[(int)EVENT_FUNCUNDEFINED] != NULL);
+}
+
+/*
+ * Return TRUE when there is a TextYankPost autocommand defined.
+ */
+    int
+has_textyankpost(void)
+{
+    return (first_autopat[(int)EVENT_TEXTYANKPOST] != NULL);
 }
 
 /*

--- a/src/ops.c
+++ b/src/ops.c
@@ -1645,6 +1645,21 @@ shift_delete_registers()
     y_regs[1].y_array = NULL;		/* set register one to empty */
 }
 
+    static void
+yank_do_autocmd(void)
+{
+    static int	recursive = FALSE;
+
+    if (recursive)
+	return;
+
+    recursive = TRUE;
+    textlock++;
+    apply_autocmds(EVENT_TEXTYANKPOST, NULL, NULL, FALSE, curbuf);
+    textlock--;
+    recursive = FALSE;
+}
+
 /*
  * Handle a delete operation.
  *
@@ -1798,6 +1813,11 @@ op_delete(oparg_T *oap)
 		return FAIL;
 	    }
 	}
+
+#ifdef FEAT_AUTOCMD
+	if (did_yank && has_textyankpost())
+	    yank_do_autocmd();
+#endif
     }
 
     /*
@@ -3268,6 +3288,11 @@ op_yank(oparg_T *oap, int deleting, int mess)
 	}
     }
 # endif
+#endif
+
+#ifdef FEAT_AUTOCMD
+    if (!deleting && has_textyankpost())
+	yank_do_autocmd();
 #endif
 
     return OK;

--- a/src/ops.c
+++ b/src/ops.c
@@ -1649,9 +1649,14 @@ shift_delete_registers()
 yank_do_autocmd(void)
 {
     static int	recursive = FALSE;
+    dict_T	*v_event;
+    list_T	*list;
 
     if (recursive)
 	return;
+
+    v_event = get_vim_var_dict(VV_EVENT);
+    list = list_alloc();
 
     recursive = TRUE;
     textlock++;

--- a/src/proto/dict.pro
+++ b/src/proto/dict.pro
@@ -1,7 +1,9 @@
 /* dict.c */
 dict_T *dict_alloc(void);
+dict_T *dict_alloc_lock(char lock);
 int rettv_dict_alloc(typval_T *rettv);
 void rettv_dict_set(typval_T *rettv, dict_T *d);
+void dict_free_contents(dict_T *d);
 void dict_unref(dict_T *d);
 int dict_free_nonref(int copyID);
 void dict_free_items(int copyID);
@@ -23,4 +25,5 @@ void dict_extend(dict_T *d1, dict_T *d2, char_u *action);
 dictitem_T *dict_lookup(hashitem_T *hi);
 int dict_equal(dict_T *d1, dict_T *d2, int ic, int recursive);
 void dict_list(typval_T *argvars, typval_T *rettv, int what);
+void dict_set_ro_keys(dict_T *di);
 /* vim: set ft=c : */

--- a/src/proto/eval.pro
+++ b/src/proto/eval.pro
@@ -64,6 +64,7 @@ void set_vim_var_nr(int idx, varnumber_T val);
 varnumber_T get_vim_var_nr(int idx);
 char_u *get_vim_var_str(int idx);
 list_T *get_vim_var_list(int idx);
+dict_T * get_vim_var_dict(int idx);
 void set_vim_var_char(int c);
 void set_vcount(long count, long count1, int set_prevcount);
 void set_vim_var_string(int idx, char_u *val, int len);

--- a/src/proto/fileio.pro
+++ b/src/proto/fileio.pro
@@ -51,6 +51,7 @@ int has_textchangedI(void);
 int has_insertcharpre(void);
 int has_cmdundefined(void);
 int has_funcundefined(void);
+int has_textyankpost(void);
 void block_autocmds(void);
 void unblock_autocmds(void);
 int is_autocmd_blocked(void);

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -1124,3 +1124,21 @@ func Test_Filter_noshelltemp()
   let &shelltemp = shelltemp
   bwipe!
 endfunc
+
+func Test_TextYankPost()
+  enew!
+  call setline(1, ['foo'])
+
+  let g:accum = []
+  au TextYankPost * let g:accum += [v:operator, v:register]
+
+  norm "ayiw
+  norm "bdiw
+  norm "cciw
+
+  call assert_equal(['y','a','d','b','c','c'], g:accum)
+  unlet g:accum
+
+  au! TextYankPost
+  bwipe!
+endfunc

--- a/src/vim.h
+++ b/src/vim.h
@@ -1984,7 +1984,8 @@ typedef int sock_T;
 #define VV_TERMU7RESP	83
 #define VV_TERMSTYLERESP 84
 #define VV_TERMBLINKRESP 85
-#define VV_LEN		86	/* number of v: vars */
+#define VV_EVENT	86
+#define VV_LEN		87	/* number of v: vars */
 
 /* used for v_number in VAR_SPECIAL */
 #define VVAL_FALSE	0L

--- a/src/vim.h
+++ b/src/vim.h
@@ -1343,6 +1343,7 @@ enum auto_event
     EVENT_TEXTCHANGEDI,		/* text was modified in Insert mode*/
     EVENT_CMDUNDEFINED,		/* command undefined */
     EVENT_OPTIONSET,		/* option was set */
+    EVENT_TEXTYANKPOST,		/* after some text was yanked */
     NUM_EVENTS			/* MUST be the last one */
 };
 


### PR DESCRIPTION
A small excerpt from the "Chronicles of a todo.txt":

> Patch to add TextDeletePost and TextYankPost events. (Philippe Vaucher, 2011
> May 24)  Update May 26.

The patch mentioned above is [this](https://github.com/Silex/vim/commit/de53ab72c89affa8ba77536ed8920751c037d127) one that I've only slightly edited.

The obvious problem with this approach is the inevitable TOCTOU (Time Of Check Time Of Use) one, the content of the registers may have been changed by an external entity by the time the autocmd is executed (think of the `+` and `*` registers).
Neovim works around this problem by explicitly passing the register contents in another variable (that's part of the `v:event` directory).