### PR TITLE
options: improve copying of buffer-local value of window option

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2948,8 +2948,20 @@ get_winopts(buf_T *buf)
 #endif
 
     wip = find_wininfo(buf, TRUE);
-    if (wip != NULL && wip->wi_optset)
+    if (wip != NULL && wip->wi_win != curwin && wip->wi_win != NULL && wip->wi_win->w_buffer == buf)
     {
+	/* the buffer is currently displayed in the window */
+	win_T *wp = wip->wi_win;
+	copy_winopt(&wp->w_onebuf_opt, &curwin->w_onebuf_opt);
+#ifdef FEAT_FOLDING
+	curwin->w_fold_manual = wp->w_fold_manual;
+	curwin->w_foldinvalid = TRUE;
+	cloneFoldGrowArray(&wp->w_folds, &curwin->w_folds);
+#endif
+    }
+    else if (wip != NULL && wip->wi_optset)
+    {
+	/* the buffer was displayed in the window earlier */
 	copy_winopt(&wip->wi_opt, &curwin->w_onebuf_opt);
 #ifdef FEAT_FOLDING
 	curwin->w_fold_manual = wip->wi_fold_manual;

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -332,3 +332,55 @@ func Test_set_indentexpr()
   call assert_equal('', &indentexpr)
   bwipe!
 endfunc
+
+func Test_copy_winopt()
+    set hidden
+
+    " Test copy option from current buffer in window
+    split
+    enew
+    setlocal numberwidth=5
+    wincmd w
+    call assert_equal(4,&numberwidth)
+    bnext
+    call assert_equal(5,&numberwidth)
+    bw!
+    call assert_equal(4,&numberwidth)
+
+    " Test copy value from window that used to be display the buffer
+    split
+    enew
+    setlocal numberwidth=6
+    bnext
+    wincmd w
+    call assert_equal(4,&numberwidth)
+    bnext
+    call assert_equal(6,&numberwidth)
+    bw!
+
+    " Test that if buffer is current, don't use the stale cached value
+    " from the last time the buffer was displayed.
+    split
+    enew
+    setlocal numberwidth=7
+    bnext
+    bnext
+    setlocal numberwidth=8
+    wincmd w
+    call assert_equal(4,&numberwidth)
+    bnext
+    call assert_equal(8,&numberwidth)
+    bw!
+
+    " Test value is not copied if window already has seen the buffer
+    enew
+    split
+    setlocal numberwidth=9
+    bnext
+    setlocal numberwidth=10
+    wincmd w
+    call assert_equal(4,&numberwidth)
+    bnext
+    call assert_equal(4,&numberwidth)
+    bw!
+endfunc


### PR DESCRIPTION
Before this change, only a value is copied from another window if the buffer
is not current in that window. With this change, it is also copied
from a window, in which the buffer is currently displayed.

Previous discussion: https://github.com/neovim/neovim/pull/7551

