### PR TITLE
Fix delay of sending bracketed-paste-end sequence

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -858,8 +858,10 @@ term_convert_key(term_T *term, int c, char *buf)
 #ifdef FEAT_AUTOCMD
 	case K_CURSORHOLD:	return 0;
 #endif
-	case K_PS:		vterm_keyboard_start_paste(vterm); return 0;
-	case K_PE:		vterm_keyboard_end_paste(vterm); return 0;
+	case K_PS:		vterm_keyboard_start_paste(vterm);
+				mouse = TRUE; break;
+	case K_PE:		vterm_keyboard_end_paste(vterm);
+				mouse = TRUE; break;
     }
 
     /*


### PR DESCRIPTION
## Problem (reported by @itchyny)

On `:terminal` on terminal-application with support for bracketed-paste, paste (e.g. Cmd-V on macOS) may not work properly.

## Repro steps

The case of zsh:

`vim --clean +'term zsh'`

and paste text "echo hello", then an extra character `~` is appended.

![32777341-242a6836-c979-11e7-93c4-219241f8f57e](https://user-images.githubusercontent.com/943423/32882899-1b13bb68-caf9-11e7-804b-fc23194a94e4.gif)

## Detail

When user pastes "echo hello", Vim receives `\e[200~echo hello\e[201~` and trys to send it to `:terminal`, but the end sequence `\e[201~` is separated from the body of paste-text and then zsh will interpret it as mere `~` character.

expected:

```
in << \e[200~echo hello\e[201~
out>> echo hello
```

actual:

```
in << \e[200~echo hello
out>> echo hello
in << \e[201~
out>> ~
```

`in <<` means "Vim sends to `:term zsh`", and `out>>` means the echoback from tty.

## Cause

terminal.c:861 `term_convert_key()`

```c
        case K_PS:              vterm_keyboard_start_paste(vterm); return 0;
        case K_PE:              vterm_keyboard_end_paste(vterm); return 0;
```

When there is an input of bracketed-paste sequence `\e[200~` or `\e[201~`, it is stored to vtrem buffer and is not sent at this time; then it will be sent to tty together with next input.
Therefore the end sequence `\e[201~` is not sent at the time of doing paste.