### PR TITLE
enable iminsert=2 though if not have XIM/IME

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4256,8 +4256,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'imactivatefunc' 'imaf'	string (default "")
 			global
 			{not in Vi}
-			{only available when compiled with |+xim| and
-			|+GUI_GTK|}
+			{only available when compiled with |+mbyte|}
 	This option specifies a function that will be called to
 	activate/inactivate Input Method.
 
@@ -4308,8 +4307,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'imcmdline' 'imc'	boolean (default off)
 			global
 			{not in Vi}
-			{only available when compiled with the |+xim|,
-			|+multi_byte_ime| or |global-ime| features}
+			{only available when compiled with |+mbyte|}
 	When set the Input Method is always on when starting to edit a command
 	line, unless entering a search pattern (see 'imsearch' for that).
 	Setting this option is useful when your input method allows entering
@@ -4320,8 +4318,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'imdisable' 'imd'	boolean (default off, on for some systems (SGI))
 			global
 			{not in Vi}
-			{only available when compiled with the |+xim|,
-			|+multi_byte_ime| or |global-ime| features}
+			{only available when compiled with |+mbyte|}
 	When set the Input Method is never used.  This is useful to disable
 	the IM when it doesn't work properly.
 	Currently this option is on by default for SGI/IRIX machines.  This
@@ -4336,8 +4333,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 		0	:lmap is off and IM is off
 		1	:lmap is ON and IM is off
 		2	:lmap is off and IM is ON
-	2 is available only when compiled with the |+multi_byte_ime|, |+xim|
-	or |global-ime|.
 	To always reset the option to zero when leaving Insert mode with <Esc>
 	this can be used: >
 		:inoremap <ESC> <ESC>:set iminsert=0<CR>
@@ -4349,6 +4344,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	It is also used for the argument of commands like "r" and "f".
 	The value 0 may not work correctly with Athena and Motif with some XIM
 	methods.  Use 'imdisable' to disable XIM then.
+
+	You can set 'imactivatefunc' and 'imstatusfunc' to handle IME/XIM
+	via external command if vim is not compiled with the |+xim|,
+	|+multi_byte_ime| or |global-ime|.
 
 						*'imsearch'* *'ims'*
 'imsearch' 'ims'	number (default -1)
@@ -4372,8 +4371,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'imstatusfunc' 'imsf'	string (default "")
 			global
 			{not in Vi}
-			{only available when compiled with |+xim| and
-			|+GUI_GTK|}
+			{only available when compiled with |+mbyte|}
 	This option specifies a function that is called to obtain the status
 	of Input Method.  It must return a positive number when IME is active.
 

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -6474,10 +6474,10 @@ im_get_status()
     void
 im_set_active(int active)
 {
+#ifdef USE_IM_CONTROL
     if (p_imdisable)
 	active = FALSE;
 
-#  ifdef FEAT_EVAL
     if (p_imaf[0] != NUL)
     {
 	char_u *argv[1];

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -6442,6 +6442,56 @@ xim_get_status_area_height(void)
 }
 # endif
 
+#else
+
+# ifndef FEAT_GUI_W32
+    int
+im_get_status()
+{
+#  ifdef FEAT_EVAL
+    if (p_imsf[0] != NUL)
+    {
+	int is_active;
+
+	/* FIXME: Don't execute user function in unsafe situation. */
+	if (exiting
+#   ifdef FEAT_AUTOCMD
+		|| is_autocmd_blocked()
+#   endif
+		)
+	    return FALSE;
+	/* FIXME: :py print 'xxx' is shown duplicate result.
+	 * Use silent to avoid it. */
+	++msg_silent;
+	is_active = call_func_retnr(p_imsf, 0, NULL, FALSE);
+	--msg_silent;
+	return (is_active > 0);
+    }
+#  endif
+    return FALSE;
+}
+
+    void
+im_set_active(int active)
+{
+    if (p_imdisable)
+	active = FALSE;
+
+#  ifdef FEAT_EVAL
+    if (p_imaf[0] != NUL)
+    {
+	char_u *argv[1];
+
+	if (!im_get_status())
+	    argv[0] = (char_u *)"1";
+	else
+	    argv[0] = (char_u *)"0";
+	(void)call_func_retnr(p_imaf, 1, argv, FALSE);
+    }
+#  endif
+}
+# endif
+
 #endif /* FEAT_XIM */
 
 #if defined(FEAT_MBYTE) || defined(PROTO)

--- a/src/option.c
+++ b/src/option.c
@@ -1539,7 +1539,7 @@ static struct vimoption options[] =
 			    (char_u *)&p_ic, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
     {"imactivatefunc","imaf",P_STRING|P_VI_DEF|P_SECURE,
-# if defined(FEAT_EVAL) && defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
+#if defined(FEAT_EVAL) && defined(USE_IM_CONTROL)
 			    (char_u *)&p_imaf, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
 # else
@@ -1582,7 +1582,7 @@ static struct vimoption options[] =
 			    {(char_u *)B_IMODE_USE_INSERT, (char_u *)0L}
 			    SCRIPTID_INIT},
     {"imstatusfunc","imsf",P_STRING|P_VI_DEF|P_SECURE,
-#if defined(FEAT_EVAL) && defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
+#if defined(FEAT_EVAL) && defined(USE_IM_CONTROL)
 			    (char_u *)&p_imsf, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
 #else

--- a/src/option.h
+++ b/src/option.h
@@ -579,7 +579,7 @@ EXTERN int	p_icon;		/* 'icon' */
 EXTERN char_u	*p_iconstring;	/* 'iconstring' */
 #endif
 EXTERN int	p_ic;		/* 'ignorecase' */
-#if defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
+#if defined(FEAT_EVAL) && defined(USE_IM_CONTROL)
 EXTERN char_u	*p_imak;	/* 'imactivatekey' */
 EXTERN char_u	*p_imaf;	/* 'imactivatefunc' */
 EXTERN char_u	*p_imsf;	/* 'imstatusfunc' */

--- a/src/option.h
+++ b/src/option.h
@@ -583,10 +583,10 @@ EXTERN int	p_ic;		/* 'ignorecase' */
 EXTERN char_u	*p_imak;	/* 'imactivatekey' */
 EXTERN char_u	*p_imaf;	/* 'imactivatefunc' */
 EXTERN char_u	*p_imsf;	/* 'imstatusfunc' */
-EXTERN long	p_imst;		/* 'imstyle' */
 # define IM_ON_THE_SPOT		0L
 # define IM_OVER_THE_SPOT	1L
 #endif
+EXTERN long	p_imst;		/* 'imstyle' */
 #ifdef USE_IM_CONTROL
 EXTERN int	p_imcmdline;	/* 'imcmdline' */
 EXTERN int	p_imdisable;	/* 'imdisable' */

--- a/src/option.h
+++ b/src/option.h
@@ -579,14 +579,16 @@ EXTERN int	p_icon;		/* 'icon' */
 EXTERN char_u	*p_iconstring;	/* 'iconstring' */
 #endif
 EXTERN int	p_ic;		/* 'ignorecase' */
-#if defined(FEAT_EVAL) && defined(USE_IM_CONTROL)
+#if defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
 EXTERN char_u	*p_imak;	/* 'imactivatekey' */
+#define IM_ON_THE_SPOT		0L
+#define IM_OVER_THE_SPOT	1L
+EXTERN long	p_imst;		/* 'imstyle' */
+#endif
+#if defined(FEAT_EVAL) && defined(USE_IM_CONTROL)
 EXTERN char_u	*p_imaf;	/* 'imactivatefunc' */
 EXTERN char_u	*p_imsf;	/* 'imstatusfunc' */
-# define IM_ON_THE_SPOT		0L
-# define IM_OVER_THE_SPOT	1L
 #endif
-EXTERN long	p_imst;		/* 'imstyle' */
 #ifdef USE_IM_CONTROL
 EXTERN int	p_imcmdline;	/* 'imcmdline' */
 EXTERN int	p_imdisable;	/* 'imdisable' */

--- a/src/structs.h
+++ b/src/structs.h
@@ -2091,12 +2091,8 @@ struct file_buffer
 #define B_IMODE_USE_INSERT -1	/*	Use b_p_iminsert value for search */
 #define B_IMODE_NONE 0		/*	Input via none */
 #define B_IMODE_LMAP 1		/*	Input via langmap */
-#ifndef USE_IM_CONTROL
-# define B_IMODE_LAST 1
-#else
-# define B_IMODE_IM 2		/*	Input via input method */
-# define B_IMODE_LAST 2
-#endif
+#define B_IMODE_IM 2		/*	Input via input method */
+#define B_IMODE_LAST 2
 
 #ifdef FEAT_KEYMAP
     short	b_kmap_state;	/* using "lmap" mappings */

--- a/src/testdir/test_iminsert.vim
+++ b/src/testdir/test_iminsert.vim
@@ -1,0 +1,29 @@
+if !has('multi_byte')
+  finish
+endif
+
+source view_util.vim
+
+let s:imactivatefunc_called = 0
+let s:imstatusfunc_called = 0
+
+function! IM_activatefunc(active)
+  let s:imactivatefunc_called = 1
+endfunction
+
+function! IM_statusfunc()
+  let s:imstatusfunc_called = 1
+  return 0
+endfunction
+
+func Test_iminsert2()
+  set imactivatefunc=IM_activatefunc
+  set imstatusfunc=IM_statusfunc
+  set iminsert=2
+  normal! i
+  set iminsert=0
+  set imactivatefunc=
+  set imstatusfunc=
+  call assert_equal(1, s:imactivatefunc_called)
+  call assert_equal(1, s:imstatusfunc_called)
+endfunc

--- a/src/vim.h
+++ b/src/vim.h
@@ -536,9 +536,7 @@ typedef unsigned long u8char_T;	    /* long should be 32 bits or more */
 /*
  * Check input method control.
  */
-#if defined(FEAT_XIM) \
-    || (defined(FEAT_GUI) && (defined(FEAT_MBYTE_IME) || defined(GLOBAL_IME))) \
-    || (defined(FEAT_GUI_MAC) && defined(FEAT_MBYTE))
+#if defined(FEAT_MBYTE)
 # define USE_IM_CONTROL
 #endif
 


### PR DESCRIPTION
Recent version of vim has imactivatefunc and imstatusfunc. This is useful to activate/deactivate input method from Vim. For example, fcitx provide fcitx-remote command.

```vim
set iminsert=2
set imsearch=2
set imcmdline
set imactivatefunc=ImActivate
function! ImActivate(active)
  if a:active
    call system('fcitx-remote -o')
  else
    call system('fcitx-remote -c')
  endif
endfunction
set imstatusfunc=ImStatus
function! ImStatus()
  return system('fcitx-remote')[0] is# '2'
endfunction
```
Using this script, we can activate/deactivate XIM via Vim which is not compiled with +xim. But if Vim doesn't compiled with `+xim`, it does not allow to set iminsert=2. This change allow to set iminsert=2 though if Vim is not compiled with `+xim` since I'm thinking this is useful to simulate IM on Vim script. For example, it's possible to implement input method with pure Vim script.