### PR TITLE
Add missing test files to Make_all.mak

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -122,7 +122,6 @@ NEW_TESTS = test_arabic.res \
 	    test_job_fails.res \
 	    test_json.res \
 	    test_langmap.res \
-	    test_largefile.res \
 	    test_let.res \
 	    test_lineending.res \
 	    test_listchars.res \

--- a/src/testdir/test_escaped_glob.vim
+++ b/src/testdir/test_escaped_glob.vim
@@ -15,6 +15,8 @@ function Test_glob()
   w! Xxx\$
   call assert_equal("Xxx{", glob('Xxx\{'))
   call assert_equal("Xxx$", glob('Xxx\$'))
+  call delete('Xxx{')
+  call delete('Xxx$')
 endfunction
 
 function Test_globpath()

--- a/src/testdir/test_escaped_glob.vim
+++ b/src/testdir/test_escaped_glob.vim
@@ -9,6 +9,11 @@ function SetUp()
 endfunction
 
 function Test_glob()
+  if !has('unix')
+    " This test fails on Windows because of the special characters in the
+    " filenames. Disable the test on non-Unix systems for now.
+    return
+  endif
   call assert_equal("", glob('Xxx\{'))
   call assert_equal("", glob('Xxx\$'))
   w! Xxx{

--- a/src/testdir/test_plus_arg_edit.vim
+++ b/src/testdir/test_plus_arg_edit.vim
@@ -5,4 +5,6 @@ function Test_edit()
   edit +1|s/|/PIPE/|w Xfile1| e Xfile2|1 | s/\//SLASH/|w
   call assert_equal(["fooPIPEbar"], readfile("Xfile1"))
   call assert_equal(["fooSLASHbar"], readfile("Xfile2"))
+  call delete('Xfile1')
+  call delete('Xfile2')
 endfunction


### PR DESCRIPTION
Several test files are missing from src/testdir/Make_all.mak. But they
are present in the src/Makefile file. Add them to Make_all.mak.