### PR TITLE
Add src/proto/beval.pro into Filelist

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -141,6 +141,7 @@ SRC_ALL =	\
 		src/testdir/xterm_ramp.vim \
 		src/proto.h \
 		src/proto/arabic.pro \
+		src/proto/beval.pro \
 		src/proto/blowfish.pro \
 		src/proto/buffer.pro \
 		src/proto/channel.pro \


### PR DESCRIPTION
Hi,
file src/proto/beval.pro is missing from SRC_ALL macro in Filetype file, which makes problem when I want to build Vim from source tarball, which is got by 'make unixall'