### PR TITLE
Handle changes to the "Xft/DPI" setting

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -792,9 +792,9 @@ property_event(GtkWidget *widget,
  * Handle changes to the "Xft/DPI" setting
  */
     static void
-gtk_settings_xft_dpi_changed_cb(GtkSettings *gtk_settings,
-                                GParamSpec *pspec,
-                                gpointer data)
+gtk_settings_xft_dpi_changed_cb(GtkSettings *gtk_settings UNUSED,
+                                GParamSpec *pspec UNUSED,
+                                gpointer data UNUSED)
 {
     /*
      * Create a new PangoContext for this screen, and initialize it
@@ -4403,7 +4403,6 @@ gui_mch_init(void)
     /* Pretend we don't have input focus, we will get an event if we do. */
     gui.in_focus = FALSE;
 
-#if GTK_CHECK_VERSION(3,0,0)
     /* Handle changes to the "Xft/DPI" setting. */
     {
 	GtkSettings *gtk_settings;
@@ -4411,7 +4410,6 @@ gui_mch_init(void)
 	g_signal_connect(gtk_settings, "notify::gtk-xft-dpi",
 			   G_CALLBACK(gtk_settings_xft_dpi_changed_cb), NULL);
     }
-#endif
 
     return OK;
 }


### PR DESCRIPTION
GTK uses the XSETTINGS Xft/DPI value to determine the text size. A change
of this value causes e.g. the window title text to be adjusted. However,
the window's contents are currently not adjusted.

By connecting a callback handler to the "notify::gtk-xft-dpi" signal,
the gui.text_context and font are re-initialized on a change of this
setting, similar to how the "screen-changed" signal is processed.

A slight difference with that "screen-changed" handler is how the
desired font is chosen; in case of an empty p_guifont value, the default
font is forced. Otherwise in case no specific font is configured, the
initially selected (default) font is forgotten about.

This change was tested on Fedora 26 running Xfce, with command:
`xfconf-query -c xsettings -p /Xft/DPI -s <dpi>`
with `<dpi>` e.g. 96 or 144.

I hope my change fits the standards and doesn't get things completely
wrong. Please merge if applicable.