### PR TITLE
export VIM_SERVERNAME on Windows :terminal

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -335,6 +335,9 @@ to point to the right file, if needed.  If you have both the 32-bit and 64-bit
 version, rename to winpty32.dll and winpty64.dll to match the way Vim was
 build.
 
+Environment variables are used to pass information to the running job:
+    VIM_SERVERNAME	v:servername
+
 ==============================================================================
 2. Remote testing					*terminal-testing*
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -5034,11 +5034,14 @@ job_io_file_open(
  * environment argument of vim_create_process().
  */
     void
-win32_build_env(dict_T *env, garray_T *gap)
+win32_build_env(dict_T *env, garray_T *gap, int is_terminal)
 {
     hashitem_T	*hi;
-    int		todo = (int)env->dv_hashtab.ht_used;
+    int		todo = env != NULL ? (int)env->dv_hashtab.ht_used : 0;
     LPVOID	base = GetEnvironmentStringsW();
+# ifdef FEAT_CLIENTSERVER
+    char_u	*servername;
+# endif
 
     /* for last \0 */
     if (ga_grow(gap, 1) == FAIL)
@@ -5062,35 +5065,56 @@ win32_build_env(dict_T *env, garray_T *gap)
 	*((WCHAR*)gap->ga_data + gap->ga_len++) = L'\0';
     }
 
-    for (hi = env->dv_hashtab.ht_array; todo > 0; ++hi)
+    if (env != NULL)
     {
-	if (!HASHITEM_EMPTY(hi))
+	for (hi = env->dv_hashtab.ht_array; todo > 0; ++hi)
 	{
-	    typval_T *item = &dict_lookup(hi)->di_tv;
-	    WCHAR   *wkey = enc_to_utf16((char_u *)hi->hi_key, NULL);
-	    WCHAR   *wval = enc_to_utf16(get_tv_string(item), NULL);
-	    --todo;
-	    if (wkey != NULL && wval != NULL)
+	    if (!HASHITEM_EMPTY(hi))
 	    {
-		size_t	n;
-		size_t	lkey = wcslen(wkey);
-		size_t	lval = wcslen(wval);
+		typval_T *item = &dict_lookup(hi)->di_tv;
+		WCHAR   *wkey = enc_to_utf16((char_u *)hi->hi_key, NULL);
+		WCHAR   *wval = enc_to_utf16(get_tv_string(item), NULL);
+		--todo;
+		if (wkey != NULL && wval != NULL)
+		{
+		    size_t	n;
+		    size_t	lkey = wcslen(wkey);
+		    size_t	lval = wcslen(wval);
 
-		if (ga_grow(gap, (int)(lkey + lval + 2)) != OK)
-		    continue;
-		for (n = 0; n < lkey; n++)
-		    *((WCHAR*)gap->ga_data + gap->ga_len++) = wkey[n];
-		*((WCHAR*)gap->ga_data + gap->ga_len++) = L'=';
-		for (n = 0; n < lval; n++)
-		    *((WCHAR*)gap->ga_data + gap->ga_len++) = wval[n];
-		*((WCHAR*)gap->ga_data + gap->ga_len++) = L'\0';
+		    if (ga_grow(gap, (int)(lkey + lval + 2)) != OK)
+			continue;
+		    for (n = 0; n < lkey; n++)
+			*((WCHAR*)gap->ga_data + gap->ga_len++) = wkey[n];
+		    *((WCHAR*)gap->ga_data + gap->ga_len++) = L'=';
+		    for (n = 0; n < lval; n++)
+			*((WCHAR*)gap->ga_data + gap->ga_len++) = wval[n];
+		    *((WCHAR*)gap->ga_data + gap->ga_len++) = L'\0';
+		}
+		if (wkey != NULL) vim_free(wkey);
+		if (wval != NULL) vim_free(wval);
 	    }
-	    if (wkey != NULL) vim_free(wkey);
-	    if (wval != NULL) vim_free(wval);
 	}
     }
 
-    *((WCHAR*)gap->ga_data + gap->ga_len++) = L'\0';
+# ifdef FEAT_CLIENTSERVER
+    if (is_terminal)
+    {
+	size_t	lval;
+	servername = get_vim_var_str(VV_SEND_SERVER);
+	lval = STRLEN(servername);
+	if (ga_grow(gap, (int)(14 + lval + 2)) == OK)
+	{
+	    size_t	n;
+	    for (n = 0; n < 15; n++)
+		*((WCHAR*)gap->ga_data + gap->ga_len++) =
+		    (WCHAR)"VIM_SERVERNAME="[n];
+	    for (n = 0; n < lval; n++)
+		*((WCHAR*)gap->ga_data + gap->ga_len++) =
+		    (WCHAR)servername[n];
+	    *((WCHAR*)gap->ga_data + gap->ga_len++) = L'\0';
+	}
+    }
+# endif
 }
 
     void
@@ -5133,7 +5157,7 @@ mch_job_start(char *cmd, job_T *job, jobopt_T *options)
     }
 
     if (options->jo_env != NULL)
-	win32_build_env(options->jo_env, &ga);
+	win32_build_env(options->jo_env, &ga, FALSE);
 
     ZeroMemory(&pi, sizeof(pi));
     ZeroMemory(&si, sizeof(si));

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -67,5 +67,5 @@ void used_file_arg(char *name, int literal, int full_path, int diff_mode);
 void set_alist_count(void);
 void fix_arg_enc(void);
 int mch_setenv(char *var, char *value, int x);
-void win32_build_env(dict_T *l, garray_T *gap);
+void win32_build_env(dict_T *l, garray_T *gap, int is_terminal);
 /* vim: set ft=c : */

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3420,12 +3420,10 @@ term_and_job_init(
 	return FAIL;
     if (opt->jo_cwd != NULL)
 	cwd_wchar = enc_to_utf16(opt->jo_cwd, NULL);
-    if (opt->jo_env != NULL)
-    {
-	ga_init2(&ga_env, (int)sizeof(char*), 20);
-	win32_build_env(opt->jo_env, &ga_env);
-	env_wchar = ga_env.ga_data;
-    }
+
+    ga_init2(&ga_env, (int)sizeof(char*), 20);
+    win32_build_env(opt->jo_env, &ga_env, TRUE);
+    env_wchar = ga_env.ga_data;
 
     job = job_alloc();
     if (job == NULL)
@@ -3527,8 +3525,7 @@ term_and_job_init(
 failed:
     if (argvar->v_type == VAR_LIST)
 	vim_free(ga_cmd.ga_data);
-    if (opt->jo_env != NULL)
-	vim_free(ga_env.ga_data);
+    vim_free(ga_env.ga_data);
     vim_free(cmd_wchar);
     vim_free(cwd_wchar);
     if (spawn_config != NULL)

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -430,6 +430,27 @@ func Test_terminal_cwd()
   call delete('Xdir', 'rf')
 endfunc
 
+func Test_terminal_servername()
+  if !has('clientserver')
+    return
+  endif
+  let g:buf = Run_shell_in_terminal({})
+  " Wait for the shell to display a prompt
+  call WaitFor('term_getline(g:buf, 1) != ""')
+  if has('win32')
+    call term_sendkeys(g:buf, "echo %VIM_SERVERNAME%\r")
+  else
+    call term_sendkeys(g:buf, "echo $VIM_SERVERNAME\r")
+  endif
+  call term_wait(g:buf)
+  call Stop_shell_in_terminal(g:buf)
+  call WaitFor('getline(2) == v:servername')
+  call assert_equal(v:servername, getline(2))
+
+  exe g:buf . 'bwipe'
+  unlet g:buf
+endfunc
+
 func Test_terminal_env()
   let g:buf = Run_shell_in_terminal({'env': {'TESTENV': 'correct'}})
   " Wait for the shell to display a prompt


### PR DESCRIPTION
Current implementation, vim.exe and gvim.exe does not export %VIM_SERVERNAME% on Windows :terminal. This is useful to send back something message into Vim.