### PR TITLE
Fix highlighting of jargon marks

### DIFF
--- a/runtime/syntax/jargon.vim
+++ b/runtime/syntax/jargon.vim
@@ -11,7 +11,7 @@ endif
 syn match jargonChaptTitle	/:[^:]*:/
 syn match jargonEmailAddr	/[^<@ ^I]*@[^ ^I>]*/
 syn match jargonUrl	 +\(http\|ftp\)://[^\t )"]*+
-syn match jargonMark	/{[^}]*}/
+syn region jargonMark	 start="{"  end="}"
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet


### PR DESCRIPTION
Fixes the highlighting of jargon marks that have a line break in the
middle. E.g.:

    :boa: n.

       Any  one  of  the fat cables that lurk under the floor in a {dinosaur
       pen}.  Possibly  so  called  because they display a ferocious life of
       their  own when you try to lay them straight and flat after they have
       been  coiled  for  some  time.  It is rumored within IBM that channel
       cables for the 370 are limited to 200 feet because beyond that length
       the  boas  get  dangerous  --  and it is worth noting that one of the
       major cable makers uses the trademark `Anaconda'.

-- jargon-4.4.7

**BEFORE:**

![screenshot-2019-0814-0138](https://user-images.githubusercontent.com/615684/62999527-5aa74800-be34-11e9-8858-7bce83f94e6a.png)

**AFTER:**
![screenshot-2019-0814-0140](https://user-images.githubusercontent.com/615684/62999605-92ae8b00-be34-11e9-8e7b-0bed278df683.png)


