### PR TITLE
Fixed E806 with Athena or Motif GUIs when using float feature

### DIFF
--- a/src/gui_x11.c
+++ b/src/gui_x11.c
@@ -1282,6 +1282,17 @@ gui_mch_init_check(void)
 		cmdline_options, XtNumber(cmdline_options),
 		CARDINAL &gui_argc, gui_argv);
 
+# if defined(FEAT_FLOAT) && defined(LC_NUMERIC)
+    {
+	/* The call to XtOpenDisplay() may have set the locale from
+	 * the environment. Set LC_NUMERIC to "C" to make sure
+	 * that strtod() uses a decimal point, not a comma. */
+	char *p = setlocale(LC_NUMERIC, NULL);
+
+	if (p == NULL || strcmp(p, "C") != 0)
+	   setlocale(LC_NUMERIC, "C");
+    }
+# endif
     if (app_context == NULL || gui.dpy == NULL)
     {
 	gui.dying = TRUE;


### PR DESCRIPTION
This PR fixes an error E806 which happens with the athena and motif GUIs 
when doing  ":echo 3.14"  despite float feature being available. The bug only
happens with athena and motif GUIs and with a locale that does not use dot
as decimal separator.

Steps to reproduce:
```
$ ./configure --with-features=huge --enable-gui=motif
$ make

# Set a locale where dot is not a decimal separator.
$ export LC_NUMERIC=nl_NL.UTF-8 
$ ./vim --clean -f -g -c 'echo 3.14'

Error detected while processing command line:
E806: using Float as a String
E15: Invalid expression: 3.14
```
Vim set LC_NUMERIC to "C" in init_locale() but  the call to
XtOpenDisplay() later in gui_mch_init_check() in gui_x11.c
somehow sets back LC_NUMERIC from the environment i.e.
to nl_NL.UTF-8 in my example, and strtod() used by float
feature is then broken. The fix sets LC_NUMERIC locale
to "C" just after calling XtOpenDisplay().