### PR TITLE
Remove UTF8 tests that are already invoked from test_alot_utf8.vim

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -126,7 +126,6 @@ NEW_TESTS = test_arabic.res \
 	    test_listchars.res \
 	    test_listdict.res \
 	    test_listlbr.res \
-	    test_listlbr_utf8.res \
 	    test_lua.res \
 	    test_makeencoding.res \
 	    test_man.res \
@@ -134,7 +133,6 @@ NEW_TESTS = test_arabic.res \
 	    test_marks.res \
 	    test_matchadd_conceal.res \
 	    test_mksession.res \
-	    test_mksession_utf8.res \
 	    test_nested_function.res \
 	    test_netbeans.res \
 	    test_normal.res \
@@ -162,7 +160,6 @@ NEW_TESTS = test_arabic.res \
 	    test_smartindent.res \
 	    test_spell.res \
 	    test_startup.res \
-	    test_startup_utf8.res \
 	    test_stat.res \
 	    test_substitute.res \
 	    test_swap.res \

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -79,7 +79,6 @@ NEW_TESTS = test_arabic.res \
 	    test_cdo.res \
 	    test_channel.res \
 	    test_charsearch.res \
-	    test_charsearch_utf8.res \
 	    test_cindent.res \
 	    test_clientserver.res \
 	    test_close_count.res \
@@ -98,7 +97,6 @@ NEW_TESTS = test_arabic.res \
 	    test_exec_while_if.res \
 	    test_exists.res \
 	    test_exists_autocmd.res \
-	    test_expr_utf8.res \
 	    test_farsi.res \
 	    test_file_size.res \
 	    test_find_complete.res \
@@ -135,7 +133,6 @@ NEW_TESTS = test_arabic.res \
 	    test_maparg.res \
 	    test_marks.res \
 	    test_matchadd_conceal.res \
-	    test_matchadd_conceal_utf8.res \
 	    test_mksession.res \
 	    test_mksession_utf8.res \
 	    test_nested_function.res \
@@ -156,8 +153,6 @@ NEW_TESTS = test_arabic.res \
 	    test_quickfix.res \
 	    test_quotestar.res \
 	    test_regex_char_classes.res \
-	    test_regexp_latin.res \
-	    test_regexp_utf8.res \
 	    test_registers.res \
 	    test_retab.res \
 	    test_ruby.res \
@@ -165,7 +160,6 @@ NEW_TESTS = test_arabic.res \
 	    test_search.res \
 	    test_signs.res \
 	    test_smartindent.res \
-	    test_source_utf8.res \
 	    test_spell.res \
 	    test_startup.res \
 	    test_startup_utf8.res \
@@ -183,8 +177,6 @@ NEW_TESTS = test_arabic.res \
 	    test_undo.res \
 	    test_user_func.res \
 	    test_usercommands.res \
-	    test_utf8.res \
-	    test_utf8_comparisons.res \
 	    test_viminfo.res \
 	    test_vimscript.res \
 	    test_visual.res \

--- a/src/testdir/test_alot_utf8.vim
+++ b/src/testdir/test_alot_utf8.vim
@@ -7,8 +7,11 @@
 
 source test_charsearch_utf8.vim
 source test_expr_utf8.vim
+source test_listlbr_utf8.vim
 source test_matchadd_conceal_utf8.vim
+source test_mksession_utf8.vim
 source test_regexp_utf8.vim
 source test_source_utf8.vim
+source test_startup_utf8.vim
 source test_utf8.vim
 source test_utf8_comparisons.vim

--- a/src/testdir/test_mksession_utf8.vim
+++ b/src/testdir/test_mksession_utf8.vim
@@ -99,6 +99,7 @@ func Test_mksession_utf8()
   call delete('test_mks.out')
   call delete(tmpfile)
   let &wrap = wrap_save
+  set sessionoptions& splitbelow& fileencoding&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Several UTF8 related tests are already invoked from test_alot_utf8.vim.
Remove these tests from Make_all.mak.
