### PR TITLE
fix writefile()

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -13453,7 +13453,7 @@ f_writefile(typval_T *argvars, typval_T *rettv)
 	{
 	    int	fno = fileno(fd);
 	    struct stat st;
-	    if (do_fsync && fstat(fno, &st) == 0 && S_ISREG(fno)
+	    if (do_fsync && fstat(fno, &st) == 0 && S_ISREG(st.st_mode)
 			&& fsync(fno) != 0)
 		EMSG(_(e_fsync));
 	}

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -13449,8 +13449,14 @@ f_writefile(typval_T *argvars, typval_T *rettv)
 	if (write_list(fd, list, binary) == FAIL)
 	    ret = -1;
 #ifdef HAVE_FSYNC
-	else if (do_fsync && fsync(fileno(fd)) != 0)
-	    EMSG(_(e_fsync));
+	else
+	{
+	    int	fno = fileno(fd);
+	    struct stat st;
+	    if (do_fsync && fstat(fno, &st) == 0 && S_ISREG(fno)
+			&& fsync(fno) != 0)
+		EMSG(_(e_fsync));
+	}
 #endif
 	fclose(fd);
     }

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -100,3 +100,10 @@ func Test_writefile_sync_arg()
   call writefile(['two'], 'Xtest', 'S')
   call delete('Xtest')
 endfunc
+
+func Test_writefile_sync_dev_stdout()
+  if has('win32')
+    return
+  endif
+  call writefile(['one'], '/dev/stdout')
+endfunc


### PR DESCRIPTION
[8.0.1305](https://github.com/vim/vim/commit/7567d0b115e332f61a9f390aaccdf7825b891227) call fsync forcibly. So `writefile(["foo"], "/dev/stdout")` raise an error. This pull-request change to only call fsync for regular file.
