### PR TITLE
Always invoke the QuickFixCmdPost autocmd after executing a quickfix command

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5441,6 +5441,7 @@ ex_cbuffer(exarg_T *eap)
 #ifdef FEAT_AUTOCMD
     char_u	*au_name = NULL;
 #endif
+    int		res;
 
     if (eap->cmdidx == CMD_lbuffer || eap->cmdidx == CMD_lgetbuffer
 	    || eap->cmdidx == CMD_laddbuffer)
@@ -5500,20 +5501,19 @@ ex_cbuffer(exarg_T *eap)
 		qf_title = IObuff;
 	    }
 
-	    if (qf_init_ext(qi, qi->qf_curlist, NULL, buf, NULL, p_efm,
+	    res = qf_init_ext(qi, qi->qf_curlist, NULL, buf, NULL, p_efm,
 			    (eap->cmdidx != CMD_caddbuffer
 			     && eap->cmdidx != CMD_laddbuffer),
 						   eap->line1, eap->line2,
-						   qf_title, NULL) > 0)
-	    {
+						   qf_title, NULL);
 #ifdef FEAT_AUTOCMD
-		if (au_name != NULL)
-		    apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name,
-			    curbuf->b_fname, TRUE, curbuf);
+	    if (au_name != NULL)
+		apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name,
+						curbuf->b_fname, TRUE, curbuf);
 #endif
-		if (eap->cmdidx == CMD_cbuffer || eap->cmdidx == CMD_lbuffer)
-		    qf_jump(qi, 0, 0, eap->forceit);  /* display first error */
-	    }
+	    if (res > 0 && (eap->cmdidx == CMD_cbuffer ||
+						eap->cmdidx == CMD_lbuffer))
+		qf_jump(qi, 0, 0, eap->forceit);  /* display first error */
 	}
     }
 }
@@ -5531,6 +5531,7 @@ ex_cexpr(exarg_T *eap)
 #ifdef FEAT_AUTOCMD
     char_u	*au_name = NULL;
 #endif
+    int		res;
 
     if (eap->cmdidx == CMD_lexpr || eap->cmdidx == CMD_lgetexpr
 	    || eap->cmdidx == CMD_laddexpr)
@@ -5569,20 +5570,19 @@ ex_cexpr(exarg_T *eap)
 	if ((tv->v_type == VAR_STRING && tv->vval.v_string != NULL)
 		|| (tv->v_type == VAR_LIST && tv->vval.v_list != NULL))
 	{
-	    if (qf_init_ext(qi, qi->qf_curlist, NULL, NULL, tv, p_efm,
+	    res = qf_init_ext(qi, qi->qf_curlist, NULL, NULL, tv, p_efm,
 			    (eap->cmdidx != CMD_caddexpr
 			     && eap->cmdidx != CMD_laddexpr),
 				 (linenr_T)0, (linenr_T)0, *eap->cmdlinep,
-				 NULL) > 0)
-	    {
+				 NULL);
 #ifdef FEAT_AUTOCMD
-		if (au_name != NULL)
-		    apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name,
-			    curbuf->b_fname, TRUE, curbuf);
+	    if (au_name != NULL)
+		apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name,
+						curbuf->b_fname, TRUE, curbuf);
 #endif
-		if (eap->cmdidx == CMD_cexpr || eap->cmdidx == CMD_lexpr)
-		    qf_jump(qi, 0, 0, eap->forceit);  /* display first error */
-	    }
+	    if (res > 0 && (eap->cmdidx == CMD_cexpr ||
+						eap->cmdidx == CMD_lexpr))
+		qf_jump(qi, 0, 0, eap->forceit);  /* display first error */
 	}
 	else
 	    EMSG(_("E777: String or List expected"));

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -4055,6 +4055,7 @@ ex_cfile(exarg_T *eap)
 #ifdef FEAT_AUTOCMD
     char_u	*au_name = NULL;
 #endif
+    int		res;
 
     if (eap->cmdidx == CMD_lfile || eap->cmdidx == CMD_lgetfile
 					       || eap->cmdidx == CMD_laddfile)
@@ -4102,27 +4103,17 @@ ex_cfile(exarg_T *eap)
      * :caddfile adds to an existing quickfix list. If there is no
      * quickfix list then a new list is created.
      */
-    if (qf_init(wp, p_ef, p_efm, (eap->cmdidx != CMD_caddfile
-				  && eap->cmdidx != CMD_laddfile),
-						       *eap->cmdlinep, enc) > 0
-				  && (eap->cmdidx == CMD_cfile
-					     || eap->cmdidx == CMD_lfile))
-    {
+    res = qf_init(wp, p_ef, p_efm, (eap->cmdidx != CMD_caddfile
+			&& eap->cmdidx != CMD_laddfile), *eap->cmdlinep, enc);
 #ifdef FEAT_AUTOCMD
-	if (au_name != NULL)
-	    apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name, NULL, FALSE, curbuf);
+    if (au_name != NULL)
+	apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name, NULL, FALSE, curbuf);
 #endif
+    if (res > 0 && (eap->cmdidx == CMD_cfile || eap->cmdidx == CMD_lfile))
+    {
 	if (wp != NULL)
 	    qi = GET_LOC_LIST(wp);
 	qf_jump(qi, 0, 0, eap->forceit);	/* display first error */
-    }
-
-    else
-    {
-#ifdef FEAT_AUTOCMD
-	if (au_name != NULL)
-	    apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name, NULL, FALSE, curbuf);
-#endif
     }
 }
 

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1979,8 +1979,11 @@ func Test_Autocmd()
 	      \ 'precgetexpr',
 	      \ 'postcgetexpr',
 	      \ 'precexpr',
+	      \ 'postcexpr',
 	      \ 'precaddexpr',
+	      \ 'postcaddexpr',
 	      \ 'precgetexpr',
+	      \ 'postcgetexpr',
 	      \ 'precexpr',
 	      \ 'precaddexpr',
 	      \ 'precgetexpr']

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1962,8 +1962,6 @@ func Test_Autocmd()
   autocmd QuickFixCmdPre * call QfAutoCmdHandler('pre', expand('<amatch>'))
   autocmd QuickFixCmdPost * call QfAutoCmdHandler('post', expand('<amatch>'))
 
-  call writefile(['Xtest:1:Line1'], 'Xtest')
-
   let g:acmds = []
   cexpr "F1:10:Line 10"
   caddexpr "F1:20:Line 20"
@@ -1971,6 +1969,24 @@ func Test_Autocmd()
   cexpr ""
   caddexpr ""
   cgetexpr ""
+  silent! cexpr non_existing_func()
+  silent! caddexpr non_existing_func()
+  silent! cgetexpr non_existing_func()
+  let l = ['precexpr',
+	      \ 'postcexpr',
+	      \ 'precaddexpr',
+	      \ 'postcaddexpr',
+	      \ 'precgetexpr',
+	      \ 'postcgetexpr',
+	      \ 'precexpr',
+	      \ 'precaddexpr',
+	      \ 'precgetexpr',
+	      \ 'precexpr',
+	      \ 'precaddexpr',
+	      \ 'precgetexpr']
+  call assert_equal(l, g:acmds)
+
+  let g:acmds = []
   enew! | call append(0, "F2:10:Line 10")
   cbuffer!
   enew! | call append(0, "F2:20:Line 20")
@@ -1984,12 +2000,50 @@ func Test_Autocmd()
   exe 'silent! cgetbuffer ' . bnum
   exe 'silent! caddbuffer ' . bnum
   enew!
+  let l = ['precbuffer',
+	      \ 'postcbuffer',
+	      \ 'precgetbuffer',
+	      \ 'postcgetbuffer',
+	      \ 'precaddbuffer',
+	      \ 'postcaddbuffer',
+	      \ 'precbuffer',
+	      \ 'precgetbuffer',
+	      \ 'precaddbuffer']
+  call assert_equal(l, g:acmds)
+
+  call writefile(['Xtest:1:Line1'], 'Xtest')
+  call writefile([], 'Xempty')
+  let g:acmds = []
   cfile Xtest
   caddfile Xtest
   cgetfile Xtest
+  cfile Xempty
+  caddfile Xempty
+  cgetfile Xempty
   silent! cfile do_not_exist
   silent! caddfile do_not_exist
   silent! cgetfile do_not_exist
+  let l = ['precfile',
+	      \ 'postcfile',
+	      \ 'precaddfile',
+	      \ 'postcaddfile',
+	      \ 'precgetfile',
+	      \ 'postcgetfile',
+	      \ 'precfile',
+	      \ 'postcfile',
+	      \ 'precaddfile',
+	      \ 'postcaddfile',
+	      \ 'precgetfile',
+	      \ 'postcgetfile',
+	      \ 'precfile',
+	      \ 'postcfile',
+	      \ 'precaddfile',
+	      \ 'postcaddfile',
+	      \ 'precgetfile',
+	      \ 'postcgetfile']
+  call assert_equal(l, g:acmds)
+
+  let g:acmds = []
   helpgrep quickfix
   silent! helpgrep non_existing_help_topic
   vimgrep test Xtest
@@ -1999,38 +2053,7 @@ func Test_Autocmd()
   set makeprg=
   silent! make
   set makeprg&
-
-  let l = ['precexpr',
-	      \ 'postcexpr',
-	      \ 'precaddexpr',
-	      \ 'postcaddexpr',
-	      \ 'precgetexpr',
-	      \ 'postcgetexpr',
-	      \ 'precexpr',
-	      \ 'precaddexpr',
-	      \ 'precgetexpr',
-	      \ 'precbuffer',
-	      \ 'postcbuffer',
-	      \ 'precgetbuffer',
-	      \ 'postcgetbuffer',
-	      \ 'precaddbuffer',
-	      \ 'postcaddbuffer',
-	      \ 'precbuffer',
-	      \ 'precgetbuffer',
-	      \ 'precaddbuffer',
-	      \ 'precfile',
-	      \ 'postcfile',
-	      \ 'precaddfile',
-	      \ 'postcaddfile',
-	      \ 'precgetfile',
-	      \ 'postcgetfile',
-	      \ 'precfile',
-	      \ 'postcfile',
-	      \ 'precaddfile',
-	      \ 'postcaddfile',
-	      \ 'precgetfile',
-	      \ 'postcgetfile',
-	      \ 'prehelpgrep',
+  let l = ['prehelpgrep',
 	      \ 'posthelpgrep',
 	      \ 'prehelpgrep',
 	      \ 'posthelpgrep',
@@ -2069,6 +2092,7 @@ func Test_Autocmd()
   endif
 
   call delete('Xtest')
+  call delete('Xempty')
 endfunc
 
 func Test_Autocmd_Exception()

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1962,16 +1962,43 @@ func Test_Autocmd()
   autocmd QuickFixCmdPre * call QfAutoCmdHandler('pre', expand('<amatch>'))
   autocmd QuickFixCmdPost * call QfAutoCmdHandler('post', expand('<amatch>'))
 
+  call writefile(['Xtest:1:Line1'], 'Xtest')
+
   let g:acmds = []
   cexpr "F1:10:Line 10"
   caddexpr "F1:20:Line 20"
   cgetexpr "F1:30:Line 30"
+  cexpr ""
+  caddexpr ""
+  cgetexpr ""
   enew! | call append(0, "F2:10:Line 10")
   cbuffer!
   enew! | call append(0, "F2:20:Line 20")
   cgetbuffer
   enew! | call append(0, "F2:30:Line 30")
   caddbuffer
+  new
+  let bnum = bufnr('%')
+  bunload
+  exe 'silent! cbuffer! ' . bnum
+  exe 'silent! cgetbuffer ' . bnum
+  exe 'silent! caddbuffer ' . bnum
+  enew!
+  cfile Xtest
+  caddfile Xtest
+  cgetfile Xtest
+  silent! cfile do_not_exist
+  silent! caddfile do_not_exist
+  silent! cgetfile do_not_exist
+  helpgrep quickfix
+  silent! helpgrep non_existing_help_topic
+  vimgrep test Xtest
+  vimgrepadd test Xtest
+  silent! vimgrep non_existing_test Xtest
+  silent! vimgrepadd non_existing_test Xtest
+  set makeprg=
+  silent! make
+  set makeprg&
 
   let l = ['precexpr',
 	      \ 'postcexpr',
@@ -1979,13 +2006,69 @@ func Test_Autocmd()
 	      \ 'postcaddexpr',
 	      \ 'precgetexpr',
 	      \ 'postcgetexpr',
+	      \ 'precexpr',
+	      \ 'precaddexpr',
+	      \ 'precgetexpr',
 	      \ 'precbuffer',
 	      \ 'postcbuffer',
 	      \ 'precgetbuffer',
 	      \ 'postcgetbuffer',
 	      \ 'precaddbuffer',
-	      \ 'postcaddbuffer']
+	      \ 'postcaddbuffer',
+	      \ 'precbuffer',
+	      \ 'precgetbuffer',
+	      \ 'precaddbuffer',
+	      \ 'precfile',
+	      \ 'postcfile',
+	      \ 'precaddfile',
+	      \ 'postcaddfile',
+	      \ 'precgetfile',
+	      \ 'postcgetfile',
+	      \ 'precfile',
+	      \ 'postcfile',
+	      \ 'precaddfile',
+	      \ 'postcaddfile',
+	      \ 'precgetfile',
+	      \ 'postcgetfile',
+	      \ 'prehelpgrep',
+	      \ 'posthelpgrep',
+	      \ 'prehelpgrep',
+	      \ 'posthelpgrep',
+	      \ 'previmgrep',
+	      \ 'postvimgrep',
+	      \ 'previmgrepadd',
+	      \ 'postvimgrepadd',
+	      \ 'previmgrep',
+	      \ 'postvimgrep',
+	      \ 'previmgrepadd',
+	      \ 'postvimgrepadd',
+	      \ 'premake',
+	      \ 'postmake']
   call assert_equal(l, g:acmds)
+
+  if has('unix')
+    " Run this test only on Unix-like systems. The grepprg may not be set on
+    " non-Unix systems.
+    " The following lines are used for the grep test. Don't remove.
+    " Grep_Autocmd_Text: Match 1
+    " GrepAdd_Autocmd_Text: Match 2
+    let g:acmds = []
+    silent grep Grep_Autocmd_Text test_quickfix.vim
+    silent grepadd GrepAdd_Autocmd_Text test_quickfix.vim
+    silent grep abc123def Xtest
+    silent grepadd abc123def Xtest
+    let l = ['pregrep',
+		\ 'postgrep',
+		\ 'pregrepadd',
+		\ 'postgrepadd',
+		\ 'pregrep',
+		\ 'postgrep',
+		\ 'pregrepadd',
+		\ 'postgrepadd']
+    call assert_equal(l, g:acmds)
+  endif
+
+  call delete('Xtest')
 endfunc
 
 func Test_Autocmd_Exception()


### PR DESCRIPTION
The QuickFixCmdPost autocmd is not invoked for some quickfix commands
that fail to add/modify the quickfix list.

For the cfile, cgetfile, caddfile, make, grep, grepadd, vimgrep, vimgrepadd and
helpgrep commands, the QuickFixCmdPost autocmd is always invoked irrespective
of whether command succeeded or not.

For the cexpr, caddexpr, cgetexpr, cbuffer, caddbuffer and cgetbuffer commands,
the QuickFixCmdPost autocmd is invoked only when the command succeeds. Otherwise
the autocmd is not invoked.

This change will make it consistent that whenever the
QuickFixCmdPre autocmd is invoked, the corresponding QuickFixCmdPost
autocmd will also be invoked.
