### PR TITLE
Use defined(BSD) check when defining OPEN_CHR_FILES

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -2485,7 +2485,7 @@ typedef enum {
 #define FNE_INCL_BR	1	/* include [] in name */
 #define FNE_CHECK_START	2	/* check name starts with valid character */
 
-#if (defined(SUN_SYSTEM) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)) \
+#if (defined(SUN_SYSTEM) || defined(BSD) || defined(__FreeBSD_kernel__)) \
 	&& defined(S_ISCHR)
 # define OPEN_CHR_FILES
 #endif


### PR DESCRIPTION
Rather than enumerate predefines for all BSD systems, just rely on the
fact that they all "#define BSD" in sys/param.h.  vim.h includes
sys/param.h via os_unix.h, so it will be included by the time this check
is performed.

Debian's GNU/kFreeBSD still requires its own check, since it isn't using
the BSD userspace.

This fixes vim/vim#2376.

References:
OpenBSD - https://github.com/openbsd/src/blob/210ebf9df0460bbdad02da9bbd5d859b61f57462/sys/sys/param.h#L40
FreeBSD - https://github.com/freebsd/freebsd/blob/f5d95e1f8d32db4ccccfd5ad9cecb21ed07a695d/sys/sys/param.h#L43
NetBSD - https://github.com/NetBSD/src/blob/ea620980793cf2011e5424f4a537b0488e3ffb4d/sys/sys/param.h#L49
DragonFlyBSD - https://github.com/DragonFlyBSD/DragonFlyBSD/blob/94ecf1295bb42b59772448d58ff40dd75c4a3ef8/sys/sys/param.h#L41