### PR TITLE
fix SHIFT-Insert on Windows command prompt

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -1816,9 +1816,18 @@ mch_inchar(
 		    typeahead[typeaheadlen] = c;
 		if (ch2 != NUL)
 		{
-		    typeahead[typeaheadlen + n] = 3;
-		    typeahead[typeaheadlen + n + 1] = (char_u)ch2;
-		    n += 2;
+		    if (c == K_NUL && (ch2 & 0xff00) != 0)
+		    {
+			/* fAnsiKey with modifier keys */
+			typeahead[typeaheadlen + n] = (char_u)ch2;
+			n++;
+		    }
+		    else
+		    {
+			typeahead[typeaheadlen + n] = 3;
+			typeahead[typeaheadlen + n + 1] = (char_u)ch2;
+			n += 2;
+		    }
 		}
 
 		/* Use the ALT key to set the 8th bit of the character


### PR DESCRIPTION
This is fixing for a bug which vim.exe doesn't accept SHIFT-INSERT.

https://groups.google.com/forum/#!topic/vim_use/G1hB7FJbyAo/discussion

When patch 7.4.852 was included, combination of K_NUL & ANSI keys was not handled. And it was converted to unicode.

https://groups.google.com/forum/#!topic/vim_dev/Gu7pDIjS1UE/discussion

```c
		if (ch2 != NUL)
		{
		    typeahead[typeaheadlen + n] = 3;
		    typeahead[typeaheadlen + n + 1] = (char_u)ch2;
		    n += 2;
		}
```

For example, following part use K_NUL & ANSI key to handle SHIFT-INSERT.

https://github.com/vim/vim/blob/bdb8139098d170ede2bc79dd4f62e4ed5e778d3e/src/os_win32.c#L989-L1013

This change handle K_NUL in leading-character.