### PR TITLE
Profile log may include invalid byte sequences

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1834,6 +1834,22 @@ script_dump_profile(FILE *fd)
 		{
 		    if (vim_fgets(IObuff, IOSIZE, sfd))
 			break;
+		    /* When a line has been truncated, append '\n'. */
+		    if (IObuff[IOSIZE - 2] != NUL && IObuff[IOSIZE - 2] != '\n')
+		    {
+			int n = IOSIZE - 2;
+# ifdef FEAT_MBYTE
+			if (has_mbyte)
+			{
+			    int l = 1;
+
+			    for (n = 0; l > 0 && n + l <= IOSIZE - 2; n += l)
+				l = (*mb_ptr2len)(IObuff + n);
+			}
+# endif
+			IObuff[n] = '\n';
+			IObuff[n + 1] = NUL;
+		    }
 		    if (i < si->sn_prl_ga.ga_len
 				     && (pp = &PRL_ITEM(si, i))->snp_count > 0)
 		    {

--- a/src/testdir/test_profile.vim
+++ b/src/testdir/test_profile.vim
@@ -181,3 +181,42 @@ func Test_profile_errors()
   call assert_fails("profile pause", 'E750:')
   call assert_fails("profile continue", 'E750:')
 endfunc
+
+func Test_profile_truncate_mbyte()
+  if !has('multi_byte') || &enc !=# 'utf-8'
+    return
+  endif
+
+  let lines = [
+    \ 'scriptencoding utf-8',
+    \ 'func! Foo()',
+    \ '  return [',
+    \ '  \ "' . join(map(range(0x4E00, 0x4E00 + 340), 'nr2char(v:val)'), '') . '",',
+    \ '  \ "' . join(map(range(0x4F00, 0x4F00 + 340), 'nr2char(v:val)'), '') . '",',
+    \ '  \ ]',
+    \ 'endfunc',
+    \ 'call Foo()',
+    \ ]
+
+  call writefile(lines, 'Xprofile_file.vim')
+  call system(v:progpath
+    \ . ' -es --clean --cmd "set enc=utf-8"'
+    \ . ' -c "profile start Xprofile_file.log"'
+    \ . ' -c "profile file Xprofile_file.vim"'
+    \ . ' -c "so Xprofile_file.vim"'
+    \ . ' -c "qall!"')
+  call assert_equal(0, v:shell_error)
+
+  new Xprofile_file.log
+  call assert_equal('utf-8', &fenc)
+  /func! Foo()
+  let lnum = line('.')
+  call assert_match('^\s*return \[$', getline(lnum + 1))
+  call assert_match("\u4F52$", getline(lnum + 2))
+  call assert_match("\u5052$", getline(lnum + 3))
+  call assert_match('^\s*\\ \]$', getline(lnum + 4))
+  bwipe!
+
+  call delete('Xprofile_file.vim')
+  call delete('Xprofile_file.log')
+endfunc


### PR DESCRIPTION
## Repro steps

prof.vim
https://gist.github.com/ichizok/74fc6a2a9d0aa4673d3ea7fabc22908f

`vim --clean --cmd 'set enc=utf-8'`

```vim
:profile start prof.log
:profile file prof.vim
:so prof.vim
:qall!
```

`prof.log` will include UTF-8 invalid byte sequences.

## Impact

For external application using profile log, this problem can cause errors related to encoding.
e.g. [covimerage](https://github.com/Vimjas/covimerage) (python application), `UnicodeDecodeError` occurs when reading profile log

## Cause

https://github.com/vim/vim/blob/17471e8/src/ex_cmds2.c#L1835

Each lines of script source file are truncated to `IOSIZE - 1` (==1024) byte ignoring the boundary of multibyte characters.

