### PR TITLE
Cache terminal default colors

### DIFF
--- a/src/libvterm/src/pen.c
+++ b/src/libvterm/src/pen.c
@@ -213,9 +213,7 @@ void vterm_state_get_palette_color(const VTermState *state, int index, VTermColo
 void vterm_state_set_default_colors(VTermState *state, const VTermColor *default_fg, const VTermColor *default_bg)
 {
   state->default_fg = *default_fg;
-  state->default_fg.ansi_index = VTERM_ANSI_INDEX_DEFAULT;
   state->default_bg = *default_bg;
-  state->default_bg.ansi_index = VTERM_ANSI_INDEX_DEFAULT;
 }
 
 void vterm_state_set_palette_color(VTermState *state, int index, const VTermColor *col)

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -20,6 +20,7 @@ void term_change_in_curbuf(void);
 int term_get_attr(buf_T *buf, linenr_T lnum, int col);
 char_u *term_get_status_text(term_T *term);
 int set_ref_in_term(int copyID);
+void set_terminal_default_colors(int cterm_fg, int cterm_bg);
 void f_term_getaltscreen(typval_T *argvars, typval_T *rettv);
 void f_term_getattr(typval_T *argvars, typval_T *rettv);
 void f_term_getcursor(typval_T *argvars, typval_T *rettv);

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -7391,6 +7391,9 @@ do_highlight(
     int		error = FALSE;
     int		color;
     int		is_normal_group = FALSE;	/* "Normal" group */
+#ifdef FEAT_TERMINAL
+    int		is_terminal_group = FALSE;	/* "Terminal" group */
+#endif
 #ifdef FEAT_GUI_X11
     int		is_menu_group = FALSE;		/* "Menu" group */
     int		is_scrollbar_group = FALSE;	/* "Scrollbar" group */
@@ -7616,6 +7619,10 @@ do_highlight(
 
     if (STRCMP(HL_TABLE()[idx].sg_name_u, "NORMAL") == 0)
 	is_normal_group = TRUE;
+#ifdef FEAT_TERMINAL
+    else if (STRCMP(HL_TABLE()[idx].sg_name_u, "TERMINAL") == 0)
+	is_terminal_group = TRUE;
+#endif
 #ifdef FEAT_GUI_X11
     else if (STRCMP(HL_TABLE()[idx].sg_name_u, "MENU") == 0)
 	is_menu_group = TRUE;
@@ -8239,6 +8246,11 @@ do_highlight(
 	    }
 #endif
 	}
+#ifdef FEAT_TERMINAL
+	else if (is_terminal_group)
+	    set_terminal_default_colors(
+		    HL_TABLE()[idx].sg_cterm_fg, HL_TABLE()[idx].sg_cterm_bg);
+#endif
 #ifdef FEAT_GUI_X11
 # ifdef FEAT_MENU
 	else if (is_menu_group)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -188,6 +188,9 @@ static void term_free_vterm(term_T *term);
  * backspace key. */
 static int term_backspace_char = BS;
 
+/* "Terminal" highlight group colors. */
+static int term_default_cterm_fg = -1;
+static int term_default_cterm_bg = -1;
 
 /**************************************
  * 1. Generic code for all systems.
@@ -1834,20 +1837,12 @@ cell2attr(VTermScreenCellAttrs cellattrs, VTermColor cellfg, VTermColor cellbg)
 	int bg = color2index(&cellbg, FALSE, &bold);
 
 	/* Use the "Terminal" highlighting for the default colors. */
-	if (fg == 0 || bg == 0)
+	if ((fg == 0 || bg == 0) && t_colors >= 16)
 	{
-	    int id = syn_name2id((char_u *)"Terminal");
-
-	    if (id != 0 && t_colors >= 16)
-	    {
-		int cterm_fg, cterm_bg;
-
-		syn_id2cterm_bg(id, &cterm_fg, &cterm_bg);
-		if (cterm_fg >= 0)
-		    fg = cterm_fg + 1;
-		if (cterm_bg >= 0)
-		    bg = cterm_bg + 1;
-	    }
+	    if (fg == 0 && term_default_cterm_fg >= 0)
+		fg = term_default_cterm_fg + 1;
+	    if (bg == 0 && term_default_cterm_bg >= 0)
+		bg = term_default_cterm_bg + 1;
 	}
 
 	/* with 8 colors set the bold attribute to get a bright foreground */
@@ -2470,6 +2465,7 @@ cterm_color2rgb(int nr, VTermColor *rgb)
 	rgb->blue  = cube_value[idx      % 6];
 	rgb->green = cube_value[idx / 6  % 6];
 	rgb->red   = cube_value[idx / 36 % 6];
+	rgb->ansi_index = VTERM_ANSI_INDEX_NONE;
     }
     else if (nr < 256)
     {
@@ -2478,6 +2474,7 @@ cterm_color2rgb(int nr, VTermColor *rgb)
 	rgb->blue  = grey_ramp[idx];
 	rgb->green = grey_ramp[idx];
 	rgb->red   = grey_ramp[idx];
+	rgb->ansi_index = VTERM_ANSI_INDEX_NONE;
     }
 }
 
@@ -2520,6 +2517,7 @@ create_vterm(term_T *term, int rows, int cols)
     }
     fg->red = fg->green = fg->blue = fgval;
     bg->red = bg->green = bg->blue = bgval;
+    fg->ansi_index = bg->ansi_index = VTERM_ANSI_INDEX_DEFAULT;
 
     /* The "Terminal" highlight group overrules the defaults. */
     id = syn_name2id((char_u *)"Terminal");
@@ -2582,13 +2580,10 @@ create_vterm(term_T *term, int rows, int cols)
 #endif
     if (id != 0 && t_colors >= 16)
     {
-	int cterm_fg, cterm_bg;
-
-	syn_id2cterm_bg(id, &cterm_fg, &cterm_bg);
-	if (cterm_fg >= 0)
-	    cterm_color2rgb(cterm_fg, fg);
-	if (cterm_bg >= 0)
-	    cterm_color2rgb(cterm_bg, bg);
+	if (term_default_cterm_fg >= 0)
+	    cterm_color2rgb(term_default_cterm_fg, fg);
+	if (term_default_cterm_bg >= 0)
+	    cterm_color2rgb(term_default_cterm_bg, bg);
     }
     else
     {
@@ -2702,6 +2697,16 @@ set_ref_in_term(int copyID)
 	    abort = abort || set_ref_in_item(&tv, copyID, NULL, NULL);
 	}
     return abort;
+}
+
+/*
+ * Cache "Terminal" highlight group colors.
+ */
+    void
+set_terminal_default_colors(int cterm_fg, int cterm_bg)
+{
+    term_default_cterm_fg = cterm_fg - 1;
+    term_default_cterm_bg = cterm_bg - 1;
 }
 
 /*


### PR DESCRIPTION
For some problems on v8.0.1360

## Fix terminal coloring

repro step:

`vim --clean`

```vim
:hi Terminal ctermfg=Black ctermbg=White
:term
```

then all characters are colored black (and background are white) ignoring color control sequences.

To fix it, check fg/bg == 0 before reset fg/bg. (in `cell2attr`)

## Remove `.ansi_index = VTERM_ANSI_INDEX_DEFAULT` from `vterm_state_set_default_colors`

If set default_fg/bg.ansi_index to `VTERM_ANSI_INDEX_DEFAULT`, default_fg/bg set to "Terminal" group in `create_vterm` fallbacks to "Terminal" group again in `cell2attr`.

## Cache "Terminal" highlight colors

* Add `set_terminal_default_colors()`; called when setting `:hi Terminal ...` and caches cterm_fg/bg values

Ozaki Kiichi