### PR TITLE
Add 'hiddenoff' to 'diffopt'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2634,6 +2634,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		vertical	Start diff mode with vertical splits (unless
 				explicitly specified otherwise).
 
+		hiddenoff	Automatically diffoff when a buffer has been
+				hidden.
+
 		foldcolumn:{n}	Set the 'foldcolumn' option to {n} when
 				starting diff mode.  Without this 2 is used.
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -593,6 +593,11 @@ aucmd_abort:
     if (buf->b_nwindows > 0)
 	--buf->b_nwindows;
 
+#ifdef FEAT_DIFF
+    if (diffopt_hiddenoff() && !unload_buf && buf->b_nwindows == 0)
+    	diff_buf_delete(buf);	/* Clear 'diff' for hidden buffer. */
+#endif
+
     /* Return when a window is displaying the buffer or when it's not
      * unloaded. */
     if (buf->b_nwindows > 0 || !unload_buf)

--- a/src/diff.c
+++ b/src/diff.c
@@ -23,6 +23,7 @@ static int	diff_busy = FALSE;	/* ex_diffgetput() is busy */
 #define DIFF_IWHITE	4	/* ignore change in white space */
 #define DIFF_HORIZONTAL	8	/* horizontal splits */
 #define DIFF_VERTICAL	16	/* vertical splits */
+#define DIFF_HIDDEN_OFF	32	/* diffoff when hidden */
 static int	diff_flags = DIFF_FILLER;
 
 #define LBUFLEN 50		/* length of line in diff file */
@@ -1924,6 +1925,11 @@ diffopt_changed(void)
 	    p += 11;
 	    diff_foldcolumn_new = getdigits(&p);
 	}
+	else if (STRNCMP(p, "hiddenoff", 9) == 0)
+	{
+	    p += 9;
+	    diff_flags_new |= DIFF_HIDDEN_OFF;
+	}
 	if (*p != ',' && *p != NUL)
 	    return FAIL;
 	if (*p == ',')
@@ -1959,6 +1965,15 @@ diffopt_changed(void)
 diffopt_horizontal(void)
 {
     return (diff_flags & DIFF_HORIZONTAL) != 0;
+}
+
+/*
+ * Return TRUE if 'diffopt' contains "hiddenoff".
+ */
+    int
+diffopt_hiddenoff(void)
+{
+    return (diff_flags & DIFF_HIDDEN_OFF) != 0;
 }
 
 /*

--- a/src/proto/diff.pro
+++ b/src/proto/diff.pro
@@ -16,6 +16,7 @@ int diff_check_fill(win_T *wp, linenr_T lnum);
 void diff_set_topline(win_T *fromwin, win_T *towin);
 int diffopt_changed(void);
 int diffopt_horizontal(void);
+int diffopt_hiddenoff(void);
 int diff_find_change(win_T *wp, linenr_T lnum, int *startp, int *endp);
 int diff_infold(win_T *wp, linenr_T lnum);
 void nv_diffgetput(int put, long count);

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -375,6 +375,29 @@ func Test_diffopt_vertical()
   %bwipe
 endfunc
 
+func Test_diffopt_hiddenoff()
+  set diffopt=filler,foldcolumn:0,hiddenoff
+  e! one
+  call setline(1, ['Two', 'Three'])
+  redraw
+  let normattr = screenattr(1, 1)
+  diffthis
+  botright vert new two
+  call setline(1, ['One', 'Four'])
+  diffthis
+  redraw
+  call assert_notequal(normattr, screenattr(1, 1))
+  set hidden
+  close
+  redraw
+  " should not diffing with hidden buffer two while 'hiddenoff' is enabled
+  call assert_equal(normattr, screenattr(1, 1))
+
+  bwipe!
+  bwipe!
+  set hidden& diffopt&
+endfunc
+
 func Test_diffoff_hidden()
   set diffopt=filler,foldcolumn:0
   e! one


### PR DESCRIPTION
# Summary
The `diffoff` is not called when a buffer become hidden.
It is a bit annoying when I use `set hidden` because I need to re-open a buffer to call `diffoff` if I just close (hide) the buffer.

However, this behavior seems intentional (`src/testdir/test_difmode.vim:Test_diffoff_hidden`) so I add `'hiddenoff'` to `diffopt` to call `diffoff` automatically when a buffer becomes hidden.

# Procedure
https://asciinema.org/a/2mdgrmk21zim4ixty4iehlc9b

Create the following files.

```
echo "Hello\nWorld" > a.txt
echo "Hello\nworld" > b.txt
echo "foobar" > c.txt
```

Execute vim with `vim -u NONE` and

```
:set hidden  " <- This change the behavior
:e a.txt
:vnew
:e b.txt
:diffthis
:wincmd w
:diffthis
:q
:e c.txt
:diffthis  " <- This compare c.txt to (hidden) a.txt and b.txt which is not what I want usually
```

# Note
This was first discussed in vim-jp https://github.com/vim-jp/issues/issues/1054

And the initial patch was written by @h_east.