### PR TITLE
Improve color emoji

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6153,19 +6153,23 @@ A jump table for the options with a short description can be found at |Q_op|.
 		See this URL for detail:
 		  https://msdn.microsoft.com/en-us/library/dd368170.aspx
 
-		For scrlines: set the threshold for lines to be scrolled.
-		Vim normally uses the ScrollWindowEx API to scroll lines.
-		However, redrawing is faster than scrolling in some conditions.
-		It might depend on the lines to be scrolled, your GPU and/or
-		CPU.  (Using the ScrollWindowEx API might become slower when
-		the lines to be scrolled are increased.)  You can optimize the
-		behavior by changing this value:
-
-		    0 - Always use the ScrollWindowEx API. (default)
-		    1 - Always use the RedrawWindow API.
+		For scrlines: threshold for lines to be scrolled.
+		    0 - Always use scrolling. (default)
+		    1 - Use full page redrawing.
 		  > 1 - If the lines to be scrolled is grater or equal to the
-			specified value, use the RedrawWindow API.  Otherwise
-			use the ScrollWindowEx API.
+			specified value, use redrawing.  Otherwise use
+			scrolling.
+
+		If you feel scrolling a page (CTRL-F) is too slow with DirectX
+		mode, try this "scrlines" option.
+		When set it "1", Vim uses full page redrawing instead of
+		scrolling, because of redrawing a page is faster than
+		scrolling a page in some environments.
+		After that, when you feel scrolling lines (CTRL-Y) become slow,
+		please try "2" or greater value for this option.
+		It works threshold line number to switch scrolling to
+		redrawing.  Scrolling few lines might be faster than redrawing
+		a page in some environments.
 
 		Example: >
 		  set encoding=utf-8

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6161,12 +6161,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 			scrolling.
 
 		If you feel scrolling a page (CTRL-F) is too slow with DirectX
-		mode, try this "scrlines" option.
+		renderer, try this "scrlines" option.
 		When set it "1", Vim uses full page redrawing instead of
-		scrolling, because of redrawing a page is faster than
-		scrolling a page in some environments.
-		After that, when you feel scrolling lines (CTRL-Y) become slow,
-		please try "2" or greater value for this option.
+		scrolling.  Redrawing a page is faster than scrolling a
+		page in some environments.
+		After that, when you feel scrolling lines (CTRL-Y) becomes
+		slow, please try "2" or greater value for this option.
 		It works threshold line number to switch scrolling to
 		redrawing.  Scrolling a few lines might be faster than
 		redrawing a page in some environments.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6159,8 +6159,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 		If select a raster font (Courier, Terminal or FixedSys which
 		have ".fon" extension in file name) to 'guifont', it will be
-		drawn by GDI as a fallback.  This fallback will cause
-		significant slow down on drawing.
+		drawn by GDI as a fallback.  This fallback will cause slow
+		down on drawing.
 
 		NOTE: It is known that some fonts and options combination
 		causes trouble on drawing glyphs.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6159,8 +6159,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 		If select a raster font (Courier, Terminal or FixedSys which
 		have ".fon" extension in file name) to 'guifont', it will be
-		drawn by GDI as a fallback.  This fallback will cause slow
-		down on drawing.
+		drawn by GDI as a fallback.
 
 		NOTE: It is known that some fonts and options combination
 		causes trouble on drawing glyphs.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6168,8 +6168,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		After that, when you feel scrolling lines (CTRL-Y) become slow,
 		please try "2" or greater value for this option.
 		It works threshold line number to switch scrolling to
-		redrawing.  Scrolling few lines might be faster than redrawing
-		a page in some environments.
+		redrawing.  Scrolling a few lines might be faster than
+		redrawing a page in some environments.
 
 		Example: >
 		  set encoding=utf-8

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6119,9 +6119,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		  geom	    pixelGeometry	int	0 - 2 (see below)
 		  renmode   renderingMode	int	0 - 6 (see below)
 		  taamode   textAntialiasMode	int	0 - 3 (see below)
+		  scrlines  Scroll Lines	int	>= 0  (see below)
 
-		See this URL for detail:
-		  http://msdn.microsoft.com/en-us/library/dd368190.aspx
+		See this URL for detail (except for scrlines):
+		  https://msdn.microsoft.com/en-us/library/dd368190.aspx
 
 		For geom: structure of a device pixel.
 		  0 - DWRITE_PIXEL_GEOMETRY_FLAT
@@ -6129,7 +6130,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		  2 - DWRITE_PIXEL_GEOMETRY_BGR
 
 		See this URL for detail:
-		  http://msdn.microsoft.com/en-us/library/dd368114.aspx
+		  https://msdn.microsoft.com/en-us/library/dd368114.aspx
 
 		For renmode: method of rendering glyphs.
 		  0 - DWRITE_RENDERING_MODE_DEFAULT
@@ -6141,7 +6142,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		  6 - DWRITE_RENDERING_MODE_OUTLINE
 
 		See this URL for detail:
-		  http://msdn.microsoft.com/en-us/library/dd368118.aspx
+		  https://msdn.microsoft.com/en-us/library/dd368118.aspx
 
 		For taamode: antialiasing mode used for drawing text.
 		  0 - D2D1_TEXT_ANTIALIAS_MODE_DEFAULT
@@ -6150,7 +6151,21 @@ A jump table for the options with a short description can be found at |Q_op|.
 		  3 - D2D1_TEXT_ANTIALIAS_MODE_ALIASED
 
 		See this URL for detail:
-		  http://msdn.microsoft.com/en-us/library/dd368170.aspx
+		  https://msdn.microsoft.com/en-us/library/dd368170.aspx
+
+		For scrlines: set the threshold for lines to be scrolled.
+		Vim normally uses the ScrollWindowEx API to scroll lines.
+		However, redrawing is faster than scrolling in some conditions.
+		It might depend on the lines to be scrolled, your GPU and/or
+		CPU.  (Using the ScrollWindowEx API might become slower when
+		the lines to be scrolled are increased.)  You can optimize the
+		behavior by changing this value:
+
+		    0 - Always use the ScrollWindowEx API. (default)
+		    1 - Always use the RedrawWindow API.
+		  > 1 - If the lines to be scrolled is grater or equal to the
+			specified value, use the RedrawWindow API.  Otherwise
+			use the ScrollWindowEx API.
 
 		Example: >
 		  set encoding=utf-8
@@ -6164,7 +6179,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		NOTE: It is known that some fonts and options combination
 		causes trouble on drawing glyphs.
 
-		  - 'rendmode:5' and 'renmode:6' will not work with some
+		  - 'renmode:5' and 'renmode:6' will not work with some
 		    special made fonts (True-Type fonts which includes only
 		    bitmap glyphs).
 		  - 'taamode:3' will not work with some vector fonts.

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -934,7 +934,7 @@ DWriteContext::FillRect(const RECT *rc, COLORREF color)
     if (mInteropHDC != NULL)
     {
 	// GDI functions are used before this call.  Keep using GDI.
-	// (Switching to Direct2D causes terrible slow down.)
+	// (Switching to Direct2D causes terrible slowdown.)
 	HBRUSH hbr = ::CreateSolidBrush(color);
 	::FillRect(mInteropHDC, rc, hbr);
 	::DeleteObject(HGDIOBJ(hbr));
@@ -956,13 +956,13 @@ DWriteContext::DrawLine(int x1, int y1, int x2, int y2, COLORREF color)
     if (mInteropHDC != NULL)
     {
 	// GDI functions are used before this call.  Keep using GDI.
-	// (Switching to Direct2D causes terrible slow down.)
+	// (Switching to Direct2D causes terrible slowdown.)
 	HPEN hpen = ::CreatePen(PS_SOLID, 1, color);
 	HGDIOBJ old_pen = ::SelectObject(mInteropHDC, HGDIOBJ(hpen));
 	::MoveToEx(mInteropHDC, x1, y1, NULL);
 	::LineTo(mInteropHDC, x2, y2);
 	::SelectObject(mInteropHDC, old_pen);
-	::DeleteObject(hpen);
+	::DeleteObject(HGDIOBJ(hpen));
     }
     else
     {

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -863,7 +863,8 @@ DWriteContext::SetDrawingMode(DrawingMode mode)
 {
     HRESULT hr = S_OK;
 
-    switch (mode) {
+    switch (mode)
+    {
 	default:
 	case DM_GDI:
 	    if (mInteropHDC != NULL)

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -899,8 +899,6 @@ DWriteContext::SetDrawingMode(DrawingMode mode)
 {
     HRESULT hr = S_OK;
 
-    CreateDeviceResources();
-
     switch (mode)
     {
 	default:
@@ -917,6 +915,7 @@ DWriteContext::SetDrawingMode(DrawingMode mode)
 		{
 		    hr = S_OK;
 		    DiscardDeviceResources();
+		    CreateDeviceResources();
 		}
 		mDrawing = false;
 	    }
@@ -930,6 +929,7 @@ DWriteContext::SetDrawingMode(DrawingMode mode)
 	    }
 	    else if (mDrawing == false)
 	    {
+		CreateDeviceResources();
 		mRT->BeginDraw();
 		mDrawing = true;
 	    }
@@ -938,6 +938,7 @@ DWriteContext::SetDrawingMode(DrawingMode mode)
 	case DM_INTEROP:
 	    if (mDrawing == false)
 	    {
+		CreateDeviceResources();
 		mRT->BeginDraw();
 		mDrawing = true;
 	    }

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -265,12 +265,14 @@ private:
 
 struct DWriteContext {
     HDC mHDC;
+    HDC mInteropHDC;
     bool mDrawing;
     bool mFallbackDC;
 
     ID2D1Factory *mD2D1Factory;
 
     ID2D1DCRenderTarget *mRT;
+    ID2D1GdiInteropRenderTarget *mGDIRT;
     ID2D1SolidColorBrush *mBrush;
 
     IDWriteFactory *mDWriteFactory;
@@ -299,19 +301,27 @@ struct DWriteContext {
 
     void SetFont(HFONT hFont);
 
-    void BindDC(HDC hdc, RECT *rect);
+    void BindDC(HDC hdc, const RECT *rect);
 
     void AssureDrawing();
 
+    HRESULT AssureInterop();
+
     ID2D1Brush* SolidBrush(COLORREF color);
 
-    void DrawText(const WCHAR* text, int len,
+    void DrawText(const WCHAR *text, int len,
 	int x, int y, int w, int h, int cellWidth, COLORREF color,
-	UINT fuOptions, CONST RECT *lprc, CONST INT * lpDx);
+	UINT fuOptions, const RECT *lprc, const INT *lpDx);
 
-    void FillRect(RECT *rc, COLORREF color);
+    void FillRect(const RECT *rc, COLORREF color);
+
+    void DrawLine(int x1, int y1, int x2, int y2, COLORREF color);
+
+    void SetPixel(int x, int y, COLORREF color);
 
     void Flush();
+
+    void FlushInterop();
 
     void SetRenderingParams(
 	    const DWriteRenderingParams *params);
@@ -561,10 +571,12 @@ private:
 
 DWriteContext::DWriteContext() :
     mHDC(NULL),
+    mInteropHDC(NULL),
     mDrawing(false),
     mFallbackDC(false),
     mD2D1Factory(NULL),
     mRT(NULL),
+    mGDIRT(NULL),
     mBrush(NULL),
     mDWriteFactory(NULL),
     mDWriteFactory2(NULL),
@@ -589,11 +601,19 @@ DWriteContext::DWriteContext() :
 	    D2D1_RENDER_TARGET_TYPE_DEFAULT,
 	    { DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_IGNORE },
 	    0, 0,
-	    D2D1_RENDER_TARGET_USAGE_NONE,
+	    D2D1_RENDER_TARGET_USAGE_GDI_COMPATIBLE,
 	    D2D1_FEATURE_LEVEL_DEFAULT
 	};
 	hr = mD2D1Factory->CreateDCRenderTarget(&props, &mRT);
 	_RPT2(_CRT_WARN, "CreateDCRenderTarget: hr=%p p=%p\n", hr, mRT);
+    }
+
+    if (SUCCEEDED(hr))
+    {
+	// This always succeeds.
+	mRT->QueryInterface(
+		__uuidof(ID2D1GdiInteropRenderTarget),
+		reinterpret_cast<void**>(&mGDIRT));
     }
 
     if (SUCCEEDED(hr))
@@ -645,6 +665,7 @@ DWriteContext::~DWriteContext()
     SafeRelease(&mDWriteFactory);
     SafeRelease(&mDWriteFactory2);
     SafeRelease(&mBrush);
+    SafeRelease(&mGDIRT);
     SafeRelease(&mRT);
     SafeRelease(&mD2D1Factory);
 }
@@ -825,7 +846,7 @@ DWriteContext::SetFont(HFONT hFont)
 }
 
     void
-DWriteContext::BindDC(HDC hdc, RECT *rect)
+DWriteContext::BindDC(HDC hdc, const RECT *rect)
 {
     Flush();
     mRT->BindDC(hdc, rect);
@@ -843,6 +864,15 @@ DWriteContext::AssureDrawing()
     }
 }
 
+    HRESULT
+DWriteContext::AssureInterop()
+{
+    HRESULT hr = S_OK;
+    if (mInteropHDC == NULL)
+	hr = mGDIRT->GetDC(D2D1_DC_INITIALIZE_MODE_COPY, &mInteropHDC);
+    return hr;
+}
+
     ID2D1Brush*
 DWriteContext::SolidBrush(COLORREF color)
 {
@@ -852,18 +882,27 @@ DWriteContext::SolidBrush(COLORREF color)
 }
 
     void
-DWriteContext::DrawText(const WCHAR* text, int len,
+DWriteContext::DrawText(const WCHAR *text, int len,
 	int x, int y, int w, int h, int cellWidth, COLORREF color,
-	UINT fuOptions, CONST RECT *lprc, CONST INT * lpDx)
+	UINT fuOptions, const RECT *lprc, const INT *lpDx)
 {
+    AssureDrawing();
+
     if (mFallbackDC)
     {
-	Flush();
-	ExtTextOutW(mHDC, x, y, fuOptions, lprc, text, len, lpDx);
+	// Fall back to GDI rendering.
+	HRESULT hr = AssureInterop();
+	if (SUCCEEDED(hr))
+	{
+	    HGDIOBJ hFont = GetCurrentObject(mHDC, OBJ_FONT);
+	    HGDIOBJ hOldFont = SelectObject(mInteropHDC, hFont);
+	    SetTextColor(mInteropHDC, color);
+	    SetBkMode(mInteropHDC, GetBkMode(mHDC));
+	    ExtTextOutW(mInteropHDC, x, y, fuOptions, lprc, text, len, lpDx);
+	    SelectObject(mInteropHDC, hOldFont);
+	}
 	return;
     }
-
-    AssureDrawing();
 
     HRESULT hr;
     IDWriteTextLayout *textLayout = NULL;
@@ -886,7 +925,7 @@ DWriteContext::DrawText(const WCHAR* text, int len,
 }
 
     void
-DWriteContext::FillRect(RECT *rc, COLORREF color)
+DWriteContext::FillRect(const RECT *rc, COLORREF color)
 {
     AssureDrawing();
     mRT->FillRectangle(
@@ -896,12 +935,52 @@ DWriteContext::FillRect(RECT *rc, COLORREF color)
 }
 
     void
+DWriteContext::DrawLine(int x1, int y1, int x2, int y2, COLORREF color)
+{
+    AssureDrawing();
+
+    // Use GDI to get the same display result.
+    HRESULT hr = AssureInterop();
+    if (SUCCEEDED(hr))
+    {
+	HPEN hpen = CreatePen(PS_SOLID, 1, color);
+	HGDIOBJ old_pen = SelectObject(mInteropHDC, HGDIOBJ(hpen));
+	MoveToEx(mInteropHDC, x1, y1, NULL);
+	LineTo(mInteropHDC, x2, y2);
+	SelectObject(mInteropHDC, old_pen);
+	DeleteObject(hpen);
+    }
+}
+
+    void
+DWriteContext::SetPixel(int x, int y, COLORREF color)
+{
+    AssureDrawing();
+
+    // Use GDI to get the same display result.
+    HRESULT hr = AssureInterop();
+    if (SUCCEEDED(hr))
+	::SetPixel(mInteropHDC, x, y, color);
+}
+
+    void
 DWriteContext::Flush()
 {
     if (mDrawing)
     {
+	FlushInterop();
 	mRT->EndDraw();
 	mDrawing = false;
+    }
+}
+
+    void
+DWriteContext::FlushInterop()
+{
+    if (mInteropHDC != NULL)
+    {
+	mGDIRT->ReleaseDC(NULL);
+	mInteropHDC = NULL;
     }
 }
 
@@ -1003,7 +1082,7 @@ DWriteContext_Open(void)
 }
 
     void
-DWriteContext_BindDC(DWriteContext *ctx, HDC hdc, RECT *rect)
+DWriteContext_BindDC(DWriteContext *ctx, HDC hdc, const RECT *rect)
 {
     if (ctx != NULL)
 	ctx->BindDC(hdc, rect);
@@ -1019,7 +1098,7 @@ DWriteContext_SetFont(DWriteContext *ctx, HFONT hFont)
     void
 DWriteContext_DrawText(
 	DWriteContext *ctx,
-	const WCHAR* text,
+	const WCHAR *text,
 	int len,
 	int x,
 	int y,
@@ -1028,8 +1107,8 @@ DWriteContext_DrawText(
 	int cellWidth,
 	COLORREF color,
 	UINT fuOptions,
-	CONST RECT *lprc,
-	CONST INT * lpDx)
+	const RECT *lprc,
+	const INT *lpDx)
 {
     if (ctx != NULL)
 	ctx->DrawText(text, len, x, y, w, h, cellWidth, color,
@@ -1037,10 +1116,25 @@ DWriteContext_DrawText(
 }
 
     void
-DWriteContext_FillRect(DWriteContext *ctx, RECT *rc, COLORREF color)
+DWriteContext_FillRect(DWriteContext *ctx, const RECT *rc, COLORREF color)
 {
     if (ctx != NULL)
 	ctx->FillRect(rc, color);
+}
+
+    void
+DWriteContext_DrawLine(DWriteContext *ctx, int x1, int y1, int x2, int y2,
+	COLORREF color)
+{
+    if (ctx != NULL)
+	ctx->DrawLine(x1, y1, x2, y2, color);
+}
+
+    void
+DWriteContext_SetPixel(DWriteContext *ctx, int x, int y, COLORREF color)
+{
+    if (ctx != NULL)
+	ctx->SetPixel(x, y, color);
 }
 
     void
@@ -1048,6 +1142,13 @@ DWriteContext_Flush(DWriteContext *ctx)
 {
     if (ctx != NULL)
 	ctx->Flush();
+}
+
+    void
+DWriteContext_FlushInterop(DWriteContext *ctx)
+{
+    if (ctx != NULL)
+	ctx->FlushInterop();
 }
 
     void

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -894,12 +894,12 @@ DWriteContext::DrawText(const WCHAR *text, int len,
 	HRESULT hr = AssureInterop();
 	if (SUCCEEDED(hr))
 	{
-	    HGDIOBJ hFont = GetCurrentObject(mHDC, OBJ_FONT);
-	    HGDIOBJ hOldFont = SelectObject(mInteropHDC, hFont);
-	    SetTextColor(mInteropHDC, color);
-	    SetBkMode(mInteropHDC, GetBkMode(mHDC));
-	    ExtTextOutW(mInteropHDC, x, y, fuOptions, lprc, text, len, lpDx);
-	    SelectObject(mInteropHDC, hOldFont);
+	    HGDIOBJ hFont = ::GetCurrentObject(mHDC, OBJ_FONT);
+	    HGDIOBJ hOldFont = ::SelectObject(mInteropHDC, hFont);
+	    ::SetTextColor(mInteropHDC, color);
+	    ::SetBkMode(mInteropHDC, ::GetBkMode(mHDC));
+	    ::ExtTextOutW(mInteropHDC, x, y, fuOptions, lprc, text, len, lpDx);
+	    ::SelectObject(mInteropHDC, hOldFont);
 	}
 	return;
     }
@@ -943,12 +943,12 @@ DWriteContext::DrawLine(int x1, int y1, int x2, int y2, COLORREF color)
     HRESULT hr = AssureInterop();
     if (SUCCEEDED(hr))
     {
-	HPEN hpen = CreatePen(PS_SOLID, 1, color);
-	HGDIOBJ old_pen = SelectObject(mInteropHDC, HGDIOBJ(hpen));
-	MoveToEx(mInteropHDC, x1, y1, NULL);
-	LineTo(mInteropHDC, x2, y2);
-	SelectObject(mInteropHDC, old_pen);
-	DeleteObject(hpen);
+	HPEN hpen = ::CreatePen(PS_SOLID, 1, color);
+	HGDIOBJ old_pen = ::SelectObject(mInteropHDC, HGDIOBJ(hpen));
+	::MoveToEx(mInteropHDC, x1, y1, NULL);
+	::LineTo(mInteropHDC, x2, y2);
+	::SelectObject(mInteropHDC, old_pen);
+	::DeleteObject(hpen);
     }
 }
 

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -817,7 +817,10 @@ DWriteContext::SetFont(HFONT hFont)
 	item.pTextFormat = mTextFormat;
 	item.fontWeight = mFontWeight;
 	item.fontStyle = mFontStyle;
+	mFallbackDC = false;
     }
+    else
+	mFallbackDC = true;
     mFontCache.put(item);
 }
 

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -271,6 +271,7 @@ enum DrawingMode {
 
 struct DWriteContext {
     HDC mHDC;
+    RECT mBindRect;
     DrawingMode mDMode;
     HDC mInteropHDC;
     bool mDrawing;
@@ -578,6 +579,7 @@ private:
 
 DWriteContext::DWriteContext() :
     mHDC(NULL),
+    mBindRect(),
     mDMode(DM_GDI),
     mInteropHDC(NULL),
     mDrawing(false),
@@ -676,6 +678,7 @@ DWriteContext::CreateDeviceResources()
 	mRT->QueryInterface(
 		__uuidof(ID2D1GdiInteropRenderTarget),
 		reinterpret_cast<void**>(&mGDIRT));
+	_RPT1(_CRT_WARN, "GdiInteropRenderTarget: p=%p\n", mGDIRT);
     }
 
     if (SUCCEEDED(hr))
@@ -684,6 +687,15 @@ DWriteContext::CreateDeviceResources()
 		D2D1::ColorF(D2D1::ColorF::Black),
 		&mBrush);
 	_RPT2(_CRT_WARN, "CreateSolidColorBrush: hr=%p p=%p\n", hr, mBrush);
+    }
+
+    if (SUCCEEDED(hr))
+    {
+	if (mHDC != NULL)
+	{
+	    mRT->BindDC(mHDC, &mBindRect);
+	    mRT->SetTransform(D2D1::IdentityMatrix());
+	}
     }
 
     return hr;
@@ -879,6 +891,7 @@ DWriteContext::BindDC(HDC hdc, const RECT *rect)
     mRT->BindDC(hdc, rect);
     mRT->SetTransform(D2D1::IdentityMatrix());
     mHDC = hdc;
+    mBindRect = *rect;
 }
 
     HRESULT

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -959,7 +959,7 @@ DWriteContext::DrawText(const WCHAR *text, int len,
     void
 DWriteContext::FillRect(const RECT *rc, COLORREF color)
 {
-    if (mInteropHDC != NULL)
+    if (mDMode == DM_INTEROP)
     {
 	// GDI functions are used before this call.  Keep using GDI.
 	// (Switching to Direct2D causes terrible slowdown.)
@@ -980,7 +980,7 @@ DWriteContext::FillRect(const RECT *rc, COLORREF color)
     void
 DWriteContext::DrawLine(int x1, int y1, int x2, int y2, COLORREF color)
 {
-    if (mInteropHDC != NULL)
+    if (mDMode == DM_INTEROP)
     {
 	// GDI functions are used before this call.  Keep using GDI.
 	// (Switching to Direct2D causes terrible slowdown.)
@@ -1004,7 +1004,7 @@ DWriteContext::DrawLine(int x1, int y1, int x2, int y2, COLORREF color)
     void
 DWriteContext::SetPixel(int x, int y, COLORREF color)
 {
-    if (mInteropHDC != NULL)
+    if (mDMode == DM_INTEROP)
     {
 	// GDI functions are used before this call.  Keep using GDI.
 	// (Switching to Direct2D causes terrible slowdown.)

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -995,6 +995,8 @@ DWriteContext::Flush()
     }
 }
 
+/* Flush GDI drawing.
+ * This should be called before drawing by Direct2D APIs. */
     void
 DWriteContext::FlushInterop()
 {

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -978,10 +978,20 @@ DWriteContext::SetPixel(int x, int y, COLORREF color)
 {
     AssureDrawing();
 
-    // Use GDI to get the same display result.
-    HRESULT hr = AssureInterop();
-    if (SUCCEEDED(hr))
+    if (mInteropHDC != NULL)
+    {
+	// GDI functions are used before this call.  Keep using GDI.
+	// (Switching to Direct2D causes terrible slowdown.)
 	::SetPixel(mInteropHDC, x, y, color);
+    }
+    else
+    {
+	// Direct2D doesn't have SetPixel API.  Use DrawLine instead.
+	mRT->DrawLine(
+		D2D1::Point2F(FLOAT(x), FLOAT(y) + 0.5f),
+		D2D1::Point2F(FLOAT(x+1), FLOAT(y) + 0.5f),
+		SolidBrush(color));
+    }
 }
 
     void

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -934,10 +934,10 @@ DWriteContext::DrawText(const WCHAR *text, int len,
 	return;
     }
 
-    SetDrawingMode(DM_DIRECTX);
     HRESULT hr;
     IDWriteTextLayout *textLayout = NULL;
 
+    SetDrawingMode(DM_DIRECTX);
 
     hr = mDWriteFactory->CreateTextLayout(text, len, mTextFormat,
 	    FLOAT(w), FLOAT(h), &textLayout);

--- a/src/gui_dwrite.h
+++ b/src/gui_dwrite.h
@@ -75,7 +75,6 @@ void DWriteContext_DrawLine(DWriteContext *ctx, int x1, int y1, int x2, int y2,
 	COLORREF color);
 void DWriteContext_SetPixel(DWriteContext *ctx, int x, int y, COLORREF color);
 void DWriteContext_Flush(DWriteContext *ctx);
-void DWriteContext_FlushInterop(DWriteContext *ctx);
 void DWriteContext_Close(DWriteContext *ctx);
 
 void DWriteContext_SetRenderingParams(

--- a/src/gui_dwrite.h
+++ b/src/gui_dwrite.h
@@ -55,11 +55,11 @@ void DWrite_Init(void);
 void DWrite_Final(void);
 
 DWriteContext *DWriteContext_Open(void);
-void DWriteContext_BindDC(DWriteContext *ctx, HDC hdc, RECT *rect);
+void DWriteContext_BindDC(DWriteContext *ctx, HDC hdc, const RECT *rect);
 void DWriteContext_SetFont(DWriteContext *ctx, HFONT hFont);
 void DWriteContext_DrawText(
 	DWriteContext *ctx,
-	const WCHAR* text,
+	const WCHAR *text,
 	int len,
 	int x,
 	int y,
@@ -68,10 +68,14 @@ void DWriteContext_DrawText(
 	int cellWidth,
 	COLORREF color,
 	UINT fuOptions,
-	CONST RECT *lprc,
-	CONST INT * lpDx);
-void DWriteContext_FillRect(DWriteContext *ctx, RECT *rc, COLORREF color);
+	const RECT *lprc,
+	const INT *lpDx);
+void DWriteContext_FillRect(DWriteContext *ctx, const RECT *rc, COLORREF color);
+void DWriteContext_DrawLine(DWriteContext *ctx, int x1, int y1, int x2, int y2,
+	COLORREF color);
+void DWriteContext_SetPixel(DWriteContext *ctx, int x, int y, COLORREF color);
 void DWriteContext_Flush(DWriteContext *ctx);
+void DWriteContext_FlushInterop(DWriteContext *ctx);
 void DWriteContext_Close(DWriteContext *ctx);
 
 void DWriteContext_SetRenderingParams(

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -6298,8 +6298,9 @@ gui_mch_draw_string(
 #if defined(FEAT_DIRECTX)
 	if (IS_ENABLE_DIRECTX())
 	    DWriteContext_FillRect(s_dwc, &rc, gui.currBgColor);
+	else
 #endif
-	FillRect(s_hdc, &rc, hbr);
+	    FillRect(s_hdc, &rc, hbr);
 
 	SetBkMode(s_hdc, TRANSPARENT);
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -1752,11 +1752,6 @@ gui_mch_draw_part_cursor(
     rc.bottom = rc.top + h;
 
     fill_rect(&rc, NULL, color);
-
-#if defined(FEAT_DIRECTX)
-    if (IS_ENABLE_DIRECTX())
-	DWriteContext_Flush(s_dwc);
-#endif
 }
 
 
@@ -6574,14 +6569,6 @@ gui_mch_draw_string(
 	    set_pixel(x, y - offset, gui.currSpColor);
 	}
     }
-
-#if defined(FEAT_DIRECTX)
-    if (IS_ENABLE_DIRECTX())
-    {
-	if (flags & DRAW_CURSOR)
-	    DWriteContext_Flush(s_dwc);
-    }
-#endif
 }
 
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -6297,7 +6297,10 @@ gui_mch_draw_string(
 
 #if defined(FEAT_DIRECTX)
 	if (IS_ENABLE_DIRECTX())
+	{
+	    DWriteContext_FlushInterop(s_dwc);
 	    DWriteContext_FillRect(s_dwc, &rc, gui.currBgColor);
+	}
 	else
 #endif
 	    FillRect(s_hdc, &rc, hbr);
@@ -6533,8 +6536,6 @@ gui_mch_draw_string(
 #if defined(FEAT_DIRECTX)
     if (IS_ENABLE_DIRECTX())
     {
-	DWriteContext_FlushInterop(s_dwc);
-
 	if (flags & DRAW_CURSOR)
 	    DWriteContext_Flush(s_dwc);
     }
@@ -6575,6 +6576,7 @@ clear_rect(RECT *rcp)
 #if defined(FEAT_DIRECTX)
     if (IS_ENABLE_DIRECTX())
     {
+	DWriteContext_FlushInterop(s_dwc);
 	DWriteContext_FillRect(s_dwc, rcp, gui.back_pixel);
 	return;
     }

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -6297,10 +6297,7 @@ gui_mch_draw_string(
 
 #if defined(FEAT_DIRECTX)
 	if (IS_ENABLE_DIRECTX())
-	{
-	    DWriteContext_FlushInterop(s_dwc);
 	    DWriteContext_FillRect(s_dwc, &rc, gui.currBgColor);
-	}
 	else
 #endif
 	    FillRect(s_hdc, &rc, hbr);

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -6459,9 +6459,48 @@ gui_mch_draw_string(
     }
 
 #if defined(FEAT_DIRECTX)
-    if (IS_ENABLE_DIRECTX() &&
-	    (flags & (DRAW_UNDERL | DRAW_STRIKE | DRAW_UNDERC | DRAW_CURSOR)))
-	DWriteContext_Flush(s_dwc);
+    if (IS_ENABLE_DIRECTX())
+    {
+	/* Underline */
+	if (flags & DRAW_UNDERL)
+	{
+	    y = FILL_Y(row + 1) - 1;
+	    if (p_linespace > 1)
+		y -= p_linespace - 1;
+	    DWriteContext_DrawLine(s_dwc,
+		    FILL_X(col), y, FILL_X(col + len), y, gui.currFgColor);
+	}
+
+	/* Strikethrough */
+	if (flags & DRAW_STRIKE)
+	{
+	    y = FILL_Y(row + 1) - gui.char_height/2;
+	    DWriteContext_DrawLine(s_dwc,
+		    FILL_X(col), y, FILL_X(col + len), y, gui.currSpColor);
+	}
+
+	/* Undercurl */
+	if (flags & DRAW_UNDERC)
+	{
+	    int			x;
+	    int			offset;
+	    static const int	val[8] = {1, 0, 0, 0, 1, 2, 2, 2 };
+
+	    y = FILL_Y(row + 1) - 1;
+	    for (x = FILL_X(col); x < FILL_X(col + len); ++x)
+	    {
+		offset = val[x % 8];
+		DWriteContext_SetPixel(s_dwc, x, y - offset, gui.currSpColor);
+	    }
+	}
+
+	DWriteContext_FlushInterop(s_dwc);
+
+	if (flags & DRAW_CURSOR)
+	    DWriteContext_Flush(s_dwc);
+
+	return;
+    }
 #endif
 
     /* Underline */

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -611,10 +611,7 @@ _OnBlinkTimer(
 	blink_timer = (UINT) SetTimer(NULL, 0, (UINT)blink_ontime,
 						    (TIMERPROC)_OnBlinkTimer);
     }
-#if defined(FEAT_DIRECTX)
-    if (IS_ENABLE_DIRECTX())
-	DWriteContext_Flush(s_dwc);
-#endif
+    gui_mch_flush();
 }
 
     static void
@@ -640,7 +637,10 @@ gui_mch_stop_blink(void)
 {
     gui_mswin_rm_blink_timer();
     if (blink_state == BLINK_OFF)
+    {
 	gui_update_cursor(TRUE, FALSE);
+	gui_mch_flush();
+    }
     blink_state = BLINK_NONE;
 }
 
@@ -660,6 +660,7 @@ gui_mch_start_blink(void)
 						    (TIMERPROC)_OnBlinkTimer);
 	blink_state = BLINK_ON;
 	gui_update_cursor(TRUE, FALSE);
+	gui_mch_flush();
     }
 }
 
@@ -5872,6 +5873,7 @@ _OnImeNotify(HWND hWnd, DWORD dwCommand, DWORD dwData UNUSED)
 		}
 	    }
 	    gui_update_cursor(TRUE, FALSE);
+	    gui_mch_flush();
 	    lResult = 0;
 	    break;
     }


### PR DESCRIPTION
Hi,

This pull-request is a supplemental patch for #2375 (v8.0.1343).
This introduces some performance improvements and fixes a bug:

* Improve performance when underlines, strikethroughs or undercurls are used.
  v8.0.1343 uses GDI to draw these lines, however, switching between DirectX and GDI causes terrible slowdown.
  This PR uses Direct2D APIs to draw the lines.

* Improve performance when GDI fallback occurs by using a raster font.
  This PR draws texts on top of a Direct2D surface even if a raster font is selected.

* Add 'scrlines' suboption to the 'rop' option for performance tuning.
  On some environments, redrawing is faster than scrolling. (On my environment, redrawing is about 2x faster.)
  Users can optimize scrolling behavior by using this suboption.

* Fix a bug that the 'mFallbackDC' variable was not properly updated.
  See the following URL for the change: https://github.com/vim-jp/vim/pull/1/commits/080e932a1100956eb55e5a8f4b0202e93bb0b334

This PR was written by koron and me, and also reviewed by mattn.