### PR TITLE
Allow independent coloring of underline in supported terminals

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1855,6 +1855,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	'tagcase'	& "followic"	'ignorecase' when searching tags file
 	'tagrelative'	& off		tag file names are not relative
 	'termguicolors'	+ off		don't use highlight-(guifg|guibg)
+	'termguiul'	+ off		don't use highlight-guisp
 	'textauto'	& off		no automatic textmode detection
 	'textwidth'	+ 0		no automatic line wrap
 	'tildeop'	+ off		tilde is not an operator
@@ -7865,6 +7866,20 @@ A jump table for the options with a short description can be found at |Q_op|.
 	compatible terminal.
 	If setting this option does not work (produces a colorless UI)
 	reading |xterm-true-color| might help.
+	Note that the "cterm" attributes are still used, not the "gui" ones.
+	NOTE: This option is reset when 'compatible' is set.
+
+						*'termguiul'* *'tgu'*
+'termguiul' 'tgu'	boolean (default off)
+			global
+			{not in Vi}
+			{not available when compiled without the
+			|+termguicolors| feature}
+	When on, uses the |highlight-guisp| attribute in the terminal to set
+	underline color independently from foreground color (either
+	|highlight-guifg| or |highlight-ctermfg|).
+	For this to work, the correct terminal escape sequence has to be set
+	with |t_8u|. Further reading at |xterm-underline-color|.
 	Note that the "cterm" attributes are still used, not the "gui" ones.
 	NOTE: This option is reset when 'compatible' is set.
 

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -924,6 +924,7 @@ Short explanation of each option:		*option-list*
 'termbidi'	  'tbidi'   terminal takes care of bi-directionality
 'termencoding'	  'tenc'    character encoding used by the terminal
 'termguicolors'	  'tgc'     use GUI colors for the terminal
+'termguiul'	  'tgu'     use independent colors for underlines in terminal
 'termkey'	  'tk'	    key that precedes a Vim command in a terminal
 'termsize'	  'tms'	    size of a terminal window
 'terse'			    shorten some messages

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -333,6 +333,8 @@ Added by Vim (there are no standard codes for these):
 		|xterm-true-color|
 	t_8b	set background color (R, G, B)			*t_8b* *'t_8b'*
 		|xterm-true-color|
+	t_8u	set underline color (R, G, B)			*t_8u* *'t_8u'*
+		|xterm-underline-color|
 	t_BE	enable bracketed paste mode			*t_BE* *'t_BE'*
 		|xterm-bracketed-paste|
 	t_BD	disable bracketed paste mode			*t_BD* *'t_BD'*
@@ -499,6 +501,15 @@ These options contain printf strings, with |printf()| (actually, its C
 equivalent hence `l` modifier) invoked with the t_ option value and three
 unsigned long integers that may have any value between 0 and 255 (inclusive)
 representing red, green and blue colors respectively.
+
+							*xterm-underline-color*
+Vim supports setting the underline color in the terminal (taken from
+|highlight-guisp|) if the terminal supports this behavior. To enable this, the
+'termguiul' option needs to be set as well as a valid terminal code set to
+|t_8u|. This option accepts the same format used for |t_8f| and |t_8b| (see
+|xterm-true-color|).
+For example, some terminals support the following sequence:
+	`let &t_8u = "\<Esc>[58;2;%lu;%lu;%lum"`
 
 							*xterm-resize*
 Window resizing with xterm only works if the allowWindowOps resource is

--- a/src/globals.h
+++ b/src/globals.h
@@ -379,6 +379,7 @@ EXTERN int	cterm_normal_bg_color INIT(= 0);
 #ifdef FEAT_TERMGUICOLORS
 EXTERN guicolor_T cterm_normal_fg_gui_color INIT(= INVALCOLOR);
 EXTERN guicolor_T cterm_normal_bg_gui_color INIT(= INVALCOLOR);
+EXTERN guicolor_T cterm_normal_ul_gui_color INIT(= INVALCOLOR);
 #endif
 #ifdef FEAT_TERMRESPONSE
 EXTERN int	is_mac_terminal INIT(= FALSE);  /* recognized Terminal.app */

--- a/src/option.c
+++ b/src/option.c
@@ -2755,6 +2755,15 @@ static struct vimoption options[] =
 			    {(char_u *)FALSE, (char_u *)FALSE}
 #endif
 			    SCRIPTID_INIT},
+    {"termguiul", "tgu",    P_BOOL|P_VI_DEF|P_VIM|P_RCLR,
+#ifdef FEAT_TERMGUICOLORS
+			    (char_u *)&p_tgu, PV_NONE,
+			    {(char_u *)FALSE, (char_u *)FALSE}
+#else
+			    (char_u*)NULL, PV_NONE,
+			    {(char_u *)FALSE, (char_u *)FALSE}
+#endif
+			    SCRIPTID_INIT},
     {"termkey", "tk",	    P_STRING|P_ALLOCED|P_RWIN|P_VI_DEF,
 #ifdef FEAT_TERMINAL
 			    (char_u *)VAR_WIN, PV_TK,
@@ -3187,6 +3196,7 @@ static struct vimoption options[] =
     p_term("t_ZR", T_CZR)
     p_term("t_8f", T_8F)
     p_term("t_8b", T_8B)
+    p_term("t_8u", T_8U)
 
 /* terminal key codes are not in here */
 
@@ -8652,7 +8662,7 @@ set_bool_option(
 
 #ifdef FEAT_TERMGUICOLORS
     /* 'termguicolors' */
-    else if ((int *)varp == &p_tgc)
+    else if ((int *)varp == &p_tgc || (int *)varp == &p_tgu)
     {
 # ifdef FEAT_GUI
 	if (!gui.in_use && !gui.starting)

--- a/src/option.h
+++ b/src/option.h
@@ -849,6 +849,7 @@ EXTERN char_u	*p_tenc;	/* 'termencoding' */
 #endif
 #ifdef FEAT_TERMGUICOLORS
 EXTERN int	p_tgc;		/* 'termguicolors' */
+EXTERN int	p_tgu;		/* 'termguiunderline' */
 #endif
 EXTERN int	p_terse;	/* 'terse' */
 EXTERN int	p_ta;		/* 'textauto' */

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -29,6 +29,7 @@ void term_fg_color(int n);
 void term_bg_color(int n);
 void term_fg_rgb_color(guicolor_T rgb);
 void term_bg_rgb_color(guicolor_T rgb);
+void term_ul_rgb_color(guicolor_T rgb);
 void term_settitle(char_u *title);
 void ttest(int pairs);
 void add_long_to_buf(long_u val, char_u *dst);

--- a/src/screen.c
+++ b/src/screen.c
@@ -8078,6 +8078,8 @@ screen_start_highlight(int attr)
 	    if (aep != NULL)
 	    {
 #ifdef FEAT_TERMGUICOLORS
+		if (p_tgu && aep->ae_u.cterm.ul_rgb != INVALCOLOR)
+			term_ul_rgb_color(aep->ae_u.cterm.ul_rgb);
 		if (p_tgc)
 		{
 		    if (aep->ae_u.cterm.fg_rgb != INVALCOLOR)
@@ -8147,6 +8149,7 @@ screen_stop_highlight(void)
 #endif
 				(aep->ae_u.cterm.fg_color || aep->ae_u.cterm.bg_color)
 #ifdef FEAT_TERMGUICOLORS
+			    || (p_tgu && aep->ae_u.cterm.ul_rgb != INVALCOLOR)
 			    )
 #endif
 			)
@@ -8213,6 +8216,8 @@ screen_stop_highlight(void)
 		out_str(T_ME);
 
 #ifdef FEAT_TERMGUICOLORS
+	    if (p_tgu && cterm_normal_ul_gui_color != INVALCOLOR)
+		    term_ul_rgb_color(cterm_normal_ul_gui_color);
 	    if (p_tgc)
 	    {
 		if (cterm_normal_fg_gui_color != INVALCOLOR)

--- a/src/structs.h
+++ b/src/structs.h
@@ -946,6 +946,7 @@ typedef struct attr_entry
 # ifdef FEAT_TERMGUICOLORS
 	    guicolor_T	    fg_rgb;	/* foreground color RGB */
 	    guicolor_T	    bg_rgb;	/* background color RGB */
+	    guicolor_T	    ul_rgb;	/* underline  color RGB */
 # endif
 	} cterm;
 # ifdef FEAT_GUI

--- a/src/term.c
+++ b/src/term.c
@@ -900,6 +900,7 @@ static struct builtin_term builtin_termcaps[] =
     /* These are printf strings, not terminal codes. */
     {(int)KS_8F,	IF_EB("\033[38;2;%lu;%lu;%lum", ESC_STR "[38;2;%lu;%lu;%lum")},
     {(int)KS_8B,	IF_EB("\033[48;2;%lu;%lu;%lum", ESC_STR "[48;2;%lu;%lu;%lum")},
+    {(int)KS_8U,	""},
 #  endif
     {(int)KS_CBE,	IF_EB("\033[?2004h", ESC_STR "[?2004h")},
     {(int)KS_CBD,	IF_EB("\033[?2004l", ESC_STR "[?2004l")},
@@ -1622,7 +1623,7 @@ set_termname(char_u *term)
 				{KS_CWP, "WP"}, {KS_CWS, "WS"},
 				{KS_CSI, "SI"}, {KS_CEI, "EI"},
 				{KS_U7, "u7"}, {KS_RFG, "RF"}, {KS_RBG, "RB"},
-				{KS_8F, "8f"}, {KS_8B, "8b"},
+				{KS_8F, "8f"}, {KS_8B, "8b"}, {KS_8U, "8u"},
 				{KS_CBE, "BE"}, {KS_CBD, "BD"},
 				{KS_CPS, "PS"}, {KS_CPE, "PE"},
 				{(enum SpecialKey)0, NULL}
@@ -2874,6 +2875,12 @@ term_fg_rgb_color(guicolor_T rgb)
 term_bg_rgb_color(guicolor_T rgb)
 {
     term_rgb_color(T_8B, rgb);
+}
+
+    void
+term_ul_rgb_color(guicolor_T rgb)
+{
+    term_rgb_color(T_8U, rgb);
 }
 #endif
 

--- a/src/term.h
+++ b/src/term.h
@@ -98,6 +98,7 @@ enum SpecialKey
     KS_U7,	/* request cursor position */
     KS_8F,	/* set foreground color (RGB) */
     KS_8B,	/* set background color (RGB) */
+    KS_8U,	/* set underline  color (RGB) */
     KS_CBE,	/* enable bracketed paste mode */
     KS_CBD,	/* disable bracketed paste mode */
     KS_CPS,	/* start of bracketed paste */
@@ -192,6 +193,7 @@ extern char_u *(term_strings[]);    /* current terminal strings */
 #define T_U7	(TERM_STR(KS_U7))	/* request cursor position */
 #define T_8F	(TERM_STR(KS_8F))	/* set foreground color (RGB) */
 #define T_8B	(TERM_STR(KS_8B))	/* set background color (RGB) */
+#define T_8U	(TERM_STR(KS_8U))	/* set underline  color (RGB) */
 #define T_BE	(TERM_STR(KS_CBE))	/* enable bracketed paste mode */
 #define T_BD	(TERM_STR(KS_CBD))	/* disable bracketed paste mode */
 #define T_PS	(TERM_STR(KS_CPS))	/* start of bracketed paste */


### PR DESCRIPTION
This uses the new option `termguiul` and the new (proposed) termcap option `t_8u` which should behave analogously to `t_8f` and `t_8b`. This is supported (and inspired) from [kitty](https://github.com/kovidgoyal/kitty) (by @kovidgoyal), as mentioned in #1306 .
Since most terminals will not support this at the moment, I left the default value of `t_8u` as an empty string.

To test this feature in kitty, you can use the following minimal .vimrc
```vim
let &t_8u = "\<Esc>[58;2;%lu;%lu;%lum"
set spell
hi SpellBad cterm=underline ctermbg=NONE guisp=#AB3434
set termguiul
```