### PR TITLE
Fix error check of 'rop'

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -127,6 +127,9 @@ gui_mch_set_rendering_options(char_u *s)
 	    return FAIL;
     }
 
+    if (!gui.in_use)
+	return OK;
+
     /* Enable DirectX/DirectWrite */
     if (dx_enable)
     {

--- a/src/option.c
+++ b/src/option.c
@@ -7406,7 +7406,7 @@ did_set_string_option(
 
 #if defined(FEAT_RENDER_OPTIONS)
     /* 'renderoptions' */
-    else if (varp == &p_rop && gui.in_use)
+    else if (varp == &p_rop)
     {
 	if (!gui_mch_set_rendering_options(p_rop))
 	    errmsg = e_invarg;


### PR DESCRIPTION
Currently, error check of the 'renderoptions' option is inconsistent.
If a wrong value is set to 'rop' after boot up, E474 error is shown.
However, if a wrong value is set in .vimrc or .gvimrc, the error is not shown.
I think this should be an error for consistency.