### PR TITLE
Fix cursor behavior on :terminal

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -675,7 +675,10 @@ update_cursor(term_T *term, int redraw)
 	out_flush();
 #ifdef FEAT_GUI
 	if (gui.in_use)
+	{
 	    gui_update_cursor(FALSE, FALSE);
+	    gui_mch_flush();
+	}
 #endif
     }
 }


### PR DESCRIPTION
Sorry, after #2401 cursor is not properly updated when using :terminal.
I think basically gui_mch_flush() is required after gui_update_cursor().