### PR TITLE
Fix detection of perl .t

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -618,7 +618,11 @@ func dist#ft#FTperl()
     setf perl
     return 1
   endif
-  if search('^use\s\s*\k', 'nc', 30)
+  let save_cursor = getpos('.')
+  call cursor(1,1)
+  let has_use = search('^use\s\s*\k', 'c', 30)
+  call setpos('.', save_cursor)
+  if has_use
     setf perl
     return 1
   endif


### PR DESCRIPTION
When doing :e with cursor in the middle of a file, or alternatively with 
BufRead autocmd that does g'" to restore last cursor position, perl tests
could fail to be detected.

The fix is inspired by dist#ft#FTtex().