### PR TITLE
Upgrade if_python3 to Python 3.6

### DIFF
--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -736,8 +736,8 @@ or 'pythonthreedll' option can be also used to specify the Python DLL.
 
 The name of the DLL should match the Python version Vim was compiled with.
 Currently the name for Python 2 is "python27.dll", that is for Python 2.7.
-That is the default value for 'pythondll'.  For Python 3 it is python35.dll
-(Python 3.5).  To know for sure edit "gvim.exe" and search for
+That is the default value for 'pythondll'.  For Python 3 it is python36.dll
+(Python 3.6).  To know for sure edit "gvim.exe" and search for
 "python\d*.dll\c".
 
 

--- a/src/INSTALLpc.txt
+++ b/src/INSTALLpc.txt
@@ -452,6 +452,19 @@ E.g. When using MSVC (as one line):
         PYTHON3=C:\Python36 DYNAMIC_PYTHON3=yes PYTHON3_VER=36
 
 
+When using msys2 and link with Python3 bundled with msys2 (as one line):
+
+    mingw32-make -f Make_ming.mak PYTHON3=c:/msys64/mingw64
+        PYTHON3_HOME=c:/msys64/mingw64
+        PYTHON3INC=-Ic:/msys64/mingw64/include/python3.6m
+        DYNAMIC_PYTHON3=yes
+        PYTHON3_VER=36
+        DYNAMIC_PYTHON3_DLL=libpython3.6m.dll
+        STATIC_STDCPLUS=yes
+
+(This is for 64-bit builds.  For 32-bit builds, replace mingw64 with mingw32.)
+
+
 8. Building with Racket or MzScheme support
 ========================================
 

--- a/src/INSTALLpc.txt
+++ b/src/INSTALLpc.txt
@@ -438,18 +438,18 @@ You will end up with a Python-enabled, Win32 version. Enjoy!
 ================================
 
 For building with MSVC 2008 the "Windows Installer" from www.python.org
-works fine.  Python 3.4 is recommended.
+works fine.  Python 3.6 is recommended.
 
 When building, you need to set the following variables at least:
 
-    PYTHON3:         Where Python3 is installed. E.g. C:\Python34
+    PYTHON3:         Where Python3 is installed. E.g. C:\Python36
     DYNAMIC_PYTHON3: Whether dynamic linking is used. Usually, set to yes.
-    PYTHON3_VER:     Python3 version. E.g. 34 for Python 3.4.X.
+    PYTHON3_VER:     Python3 version. E.g. 36 for Python 3.6.X.
 
 E.g. When using MSVC (as one line):
 
     nmake -f Make_mvc.mak
-        PYTHON3=C:\Python34 DYNAMIC_PYTHON3=yes PYTHON3_VER=34
+        PYTHON3=C:\Python36 DYNAMIC_PYTHON3=yes PYTHON3_VER=36
 
 
 8. Building with Racket or MzScheme support

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -316,14 +316,14 @@ endif
 #	Python3 interface:
 #	  PYTHON3=[Path to Python3 directory] (Set inside Make_cyg.mak or Make_ming.mak)
 #	  DYNAMIC_PYTHON3=yes (to load the Python3 DLL dynamically)
-#	  PYTHON3_VER=[Python3 version, eg 31, 32] (default is 35)
+#	  PYTHON3_VER=[Python3 version, eg 31, 32] (default is 36)
 ifdef PYTHON3
 ifndef DYNAMIC_PYTHON3
 DYNAMIC_PYTHON3=yes
 endif
 
 ifndef PYTHON3_VER
-PYTHON3_VER=35
+PYTHON3_VER=36
 endif
 ifndef DYNAMIC_PYTHON3_DLL
 DYNAMIC_PYTHON3_DLL=python$(PYTHON3_VER).dll

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -67,7 +67,7 @@
 #	Python3 interface:
 #	  PYTHON3=[Path to Python3 directory]
 #	  DYNAMIC_PYTHON3=yes (to load the Python3 DLL dynamically)
-#	  PYTHON3_VER=[Python3 version, eg 30, 31]  (default is 35)
+#	  PYTHON3_VER=[Python3 version, eg 30, 31]  (default is 36)
 #
 #	Ruby interface:
 #	  RUBY=[Path to Ruby directory]
@@ -906,7 +906,7 @@ PYTHON_LIB = $(PYTHON)\libs\python$(PYTHON_VER).lib
 # PYTHON3 interface
 !ifdef PYTHON3
 !ifndef PYTHON3_VER
-PYTHON3_VER = 35
+PYTHON3_VER = 36
 !endif
 !message Python3 requested (version $(PYTHON3_VER)) - root dir is "$(PYTHON3)"
 !if "$(DYNAMIC_PYTHON3)" == "yes"


### PR DESCRIPTION
There was a report that Python 3.5 entered "security fixes only" mode at vim/vim-win32-installer#40.
I think it's better to upgrade the default if_python3 version to 3.6.