### PR TITLE
Handle empty and non-existing quickfix lists in getqflist() properly

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4687,7 +4687,7 @@ getqflist([{what}])					*getqflist()*
 			winid	get the quickfix |window-ID|
 			all	all of the above quickfix properties
 		Non-string items in {what} are ignored. To get the value of a
-		particular item, set it to one.
+		particular item, set it to zero.
 		If "nr" is not present then the current quickfix list is used.
 		If both "nr" and a non-zero "id" are specified, then the list
 		specified by "id" is used.
@@ -4697,17 +4697,21 @@ getqflist([{what}])					*getqflist()*
 		When "lines" is specified, all the other items except "efm"
 		are ignored.  The returned dictionary contains the entry
 		"items" with the list of entries.
-		In case of error processing {what}, an empty dictionary is
-		returned.
 
 		The returned dictionary contains the following entries:
-			context	context information stored with |setqflist()|
-			id	quickfix list ID |quickfix-ID|
-			idx	index of the current entry in the list
-			items	quickfix list entries
-			nr	quickfix list number
-			size	number of entries in the quickfix list
-			title	quickfix list title text
+			context	context information stored with |setqflist()|.
+				If not present, set to "".
+			id	quickfix list ID |quickfix-ID|. If not
+				present, set to 0.
+			idx	index of the current entry in the list. If not
+				present, set to 0.
+			items	quickfix list entries. If not present, set to
+				an empty list.
+			nr	quickfix list number. If not present, set to 0
+			size	number of entries in the quickfix list. If not
+				present, set to 0.
+			title	quickfix list title text. If not present, set
+				to "".
 			winid	quickfix |window-ID|. If not present, set to 0
 
 		Examples: >

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -4865,20 +4865,28 @@ qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
 
     if (dict_find(what, (char_u *)"all", -1) != NULL)
 	flags |= QF_GETLIST_ALL;
+
     if (dict_find(what, (char_u *)"title", -1) != NULL)
 	flags |= QF_GETLIST_TITLE;
-    if (dict_find(what, (char_u *)"items", -1) != NULL)
-	flags |= QF_GETLIST_ITEMS;
+
     if (dict_find(what, (char_u *)"nr", -1) != NULL)
 	flags |= QF_GETLIST_NR;
+
     if (dict_find(what, (char_u *)"winid", -1) != NULL)
 	flags |= QF_GETLIST_WINID;
+
     if (dict_find(what, (char_u *)"context", -1) != NULL)
 	flags |= QF_GETLIST_CONTEXT;
+
     if (dict_find(what, (char_u *)"id", -1) != NULL)
 	flags |= QF_GETLIST_ID;
+
+    if (dict_find(what, (char_u *)"items", -1) != NULL)
+	flags |= QF_GETLIST_ITEMS;
+
     if (dict_find(what, (char_u *)"idx", -1) != NULL)
 	flags |= QF_GETLIST_IDX;
+
     if (dict_find(what, (char_u *)"size", -1) != NULL)
 	flags |= QF_GETLIST_SIZE;
 

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -2883,7 +2883,7 @@ endfunc
 
 " Tests for the getqflist() and getloclist() functions when the list is not
 " present or is empty
-func Xgetlist_tests(cchar)
+func Xgetlist_empty_tests(cchar)
   call s:setup_commands(a:cchar)
 
   call g:Xsetlist([], 'f')
@@ -2907,28 +2907,31 @@ func Xgetlist_tests(cchar)
   call assert_notequal('', g:Xgetlist({'title' : 0}).title)
   call assert_equal(0, g:Xgetlist({'winid' : 0}).winid)
 
-  call assert_equal('', g:Xgetlist({'id' : 999999, 'context' : 0}).context)
-  call assert_equal(0, g:Xgetlist({'id' : 999999}).id)
-  call assert_equal(0, g:Xgetlist({'id' : 999999, 'idx' : 0}).idx)
-  call assert_equal([], g:Xgetlist({'id' : 999999, 'items' : 0}).items)
-  call assert_equal(0, g:Xgetlist({'id' : 999999, 'nr' : 0}).nr)
-  call assert_equal(0, g:Xgetlist({'id' : 999999, 'size' : 0}).size)
-  call assert_equal('', g:Xgetlist({'id' : 999999, 'title' : 0}).title)
-  call assert_equal(0, g:Xgetlist({'id' : 999999, 'winid' : 0}).winid)
-  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0}, g:Xgetlist({'id' : 999999, 'all' : 0}))
+  let qfid = g:Xgetlist({'id' : 0}).id
+  call g:Xsetlist([], 'f')
 
-  call assert_equal('', g:Xgetlist({'nr' : 15, 'context' : 0}).context)
-  call assert_equal(0, g:Xgetlist({'nr' : 15}).nr)
-  call assert_equal(0, g:Xgetlist({'nr' : 15, 'idx' : 0}).idx)
-  call assert_equal([], g:Xgetlist({'nr' : 15, 'items' : 0}).items)
-  call assert_equal(0, g:Xgetlist({'nr' : 15, 'id' : 0}).id)
-  call assert_equal(0, g:Xgetlist({'nr' : 15, 'size' : 0}).size)
-  call assert_equal('', g:Xgetlist({'nr' : 15, 'title' : 0}).title)
-  call assert_equal(0, g:Xgetlist({'nr' : 15, 'winid' : 0}).winid)
-  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0}, g:Xgetlist({'nr' : 15, 'all' : 0}))
+  call assert_equal('', g:Xgetlist({'id' : qfid, 'context' : 0}).context)
+  call assert_equal(0, g:Xgetlist({'id' : qfid}).id)
+  call assert_equal(0, g:Xgetlist({'id' : qfid, 'idx' : 0}).idx)
+  call assert_equal([], g:Xgetlist({'id' : qfid, 'items' : 0}).items)
+  call assert_equal(0, g:Xgetlist({'id' : qfid, 'nr' : 0}).nr)
+  call assert_equal(0, g:Xgetlist({'id' : qfid, 'size' : 0}).size)
+  call assert_equal('', g:Xgetlist({'id' : qfid, 'title' : 0}).title)
+  call assert_equal(0, g:Xgetlist({'id' : qfid, 'winid' : 0}).winid)
+  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0}, g:Xgetlist({'id' : qfid, 'all' : 0}))
+
+  call assert_equal('', g:Xgetlist({'nr' : 5, 'context' : 0}).context)
+  call assert_equal(0, g:Xgetlist({'nr' : 5}).nr)
+  call assert_equal(0, g:Xgetlist({'nr' : 5, 'idx' : 0}).idx)
+  call assert_equal([], g:Xgetlist({'nr' : 5, 'items' : 0}).items)
+  call assert_equal(0, g:Xgetlist({'nr' : 5, 'id' : 0}).id)
+  call assert_equal(0, g:Xgetlist({'nr' : 5, 'size' : 0}).size)
+  call assert_equal('', g:Xgetlist({'nr' : 5, 'title' : 0}).title)
+  call assert_equal(0, g:Xgetlist({'nr' : 5, 'winid' : 0}).winid)
+  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0}, g:Xgetlist({'nr' : 5, 'all' : 0}))
 endfunc
 
 func Test_getqflist()
-  call Xgetlist_tests('c')
-  call Xgetlist_tests('l')
+  call Xgetlist_empty_tests('c')
+  call Xgetlist_empty_tests('l')
 endfunc

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1833,8 +1833,8 @@ func Xproperty_tests(cchar)
     call assert_equal(-1, s)
 
     call assert_equal({}, g:Xgetlist({'abc':1}))
-    call assert_equal({}, g:Xgetlist({'nr':99, 'title':1}))
-    call assert_equal({}, g:Xgetlist({'nr':[], 'title':1}))
+    call assert_equal('', g:Xgetlist({'nr':99, 'title':1}).title)
+    call assert_equal('', g:Xgetlist({'nr':[], 'title':1}).title)
 
     if a:cchar == 'l'
 	call assert_equal({}, getloclist(99, {'title': 1}))
@@ -1870,7 +1870,7 @@ func Xproperty_tests(cchar)
 	call assert_equal([1, 2], getloclist(w2_id, {'context':1}).context)
 	only
 	call setloclist(0, [], 'f')
-	call assert_equal({}, getloclist(0, {'context':1}))
+	call assert_equal('', getloclist(0, {'context':1}).context)
     endif
 
     " Test for changing the context of previous quickfix lists
@@ -2383,8 +2383,8 @@ func XsizeTests(cchar)
 
   call g:Xsetlist([], 'f')
   call assert_equal(0, g:Xgetlist({'nr':'$'}).nr)
-  call assert_equal(1, len(g:Xgetlist({'nr':'$', 'all':1})))
-  call assert_equal(0, len(g:Xgetlist({'nr':0})))
+  call assert_equal('', g:Xgetlist({'nr':'$', 'all':1}).title)
+  call assert_equal(0, g:Xgetlist({'nr':0}).nr)
 
   Xexpr "File1:10:Line1"
   Xexpr "File2:20:Line2"
@@ -2754,7 +2754,7 @@ func Xqfid_tests(cchar)
   call s:setup_commands(a:cchar)
 
   call g:Xsetlist([], 'f')
-  call assert_equal({}, g:Xgetlist({'id':0}))
+  call assert_equal(0, g:Xgetlist({'id':0}).id)
   Xexpr ''
   let start_id = g:Xgetlist({'id' : 0}).id
   Xexpr '' | Xexpr ''
@@ -2762,10 +2762,10 @@ func Xqfid_tests(cchar)
   call assert_equal(start_id, g:Xgetlist({'id':0, 'nr':1}).id)
   call assert_equal(start_id + 1, g:Xgetlist({'id':0, 'nr':0}).id)
   call assert_equal(start_id + 2, g:Xgetlist({'id':0, 'nr':'$'}).id)
-  call assert_equal({}, g:Xgetlist({'id':0, 'nr':99}))
+  call assert_equal(0, g:Xgetlist({'id':0, 'nr':99}).id)
   call assert_equal(2, g:Xgetlist({'id':start_id + 1, 'nr':0}).nr)
-  call assert_equal({}, g:Xgetlist({'id':99, 'nr':0}))
-  call assert_equal({}, g:Xgetlist({'id':"abc", 'nr':0}))
+  call assert_equal(0, g:Xgetlist({'id':99, 'nr':0}).id)
+  call assert_equal(0, g:Xgetlist({'id':"abc", 'nr':0}).id)
 
   call g:Xsetlist([], 'a', {'id':start_id, 'context':[1,2]})
   call assert_equal([1,2], g:Xgetlist({'nr':1, 'context':1}).context)
@@ -2776,7 +2776,7 @@ func Xqfid_tests(cchar)
 
   let qfid = g:Xgetlist({'id':0, 'nr':0})
   call g:Xsetlist([], 'f')
-  call assert_equal({}, g:Xgetlist({'id':qfid, 'nr':0}))
+  call assert_equal(0, g:Xgetlist({'id':qfid, 'nr':0}).id)
 endfunc
 
 func Test_qf_id()
@@ -2879,4 +2879,56 @@ endfunc
 func Test_qfjump()
   call Xqfjump_tests('c')
   call Xqfjump_tests('l')
+endfunc
+
+" Tests for the getqflist() and getloclist() functions when the list is not
+" present or is empty
+func Xgetlist_tests(cchar)
+  call s:setup_commands(a:cchar)
+
+  call g:Xsetlist([], 'f')
+  call assert_equal('', g:Xgetlist({'context' : 0}).context)
+  call assert_equal(0, g:Xgetlist({'id' : 0}).id)
+  call assert_equal(0, g:Xgetlist({'idx' : 0}).idx)
+  call assert_equal([], g:Xgetlist({'items' : 0}).items)
+  call assert_equal(0, g:Xgetlist({'nr' : 0}).nr)
+  call assert_equal(0, g:Xgetlist({'size' : 0}).size)
+  call assert_equal('', g:Xgetlist({'title' : 0}).title)
+  call assert_equal(0, g:Xgetlist({'winid' : 0}).winid)
+  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0}, g:Xgetlist({'all' : 0}))
+
+  Xexpr ""
+  call assert_equal('', g:Xgetlist({'context' : 0}).context)
+  call assert_notequal(0, g:Xgetlist({'id' : 0}).id)
+  call assert_equal(0, g:Xgetlist({'idx' : 0}).idx)
+  call assert_equal([], g:Xgetlist({'items' : 0}).items)
+  call assert_notequal(0, g:Xgetlist({'nr' : 0}).nr)
+  call assert_equal(0, g:Xgetlist({'size' : 0}).size)
+  call assert_notequal('', g:Xgetlist({'title' : 0}).title)
+  call assert_equal(0, g:Xgetlist({'winid' : 0}).winid)
+
+  call assert_equal('', g:Xgetlist({'id' : 999999, 'context' : 0}).context)
+  call assert_equal(0, g:Xgetlist({'id' : 999999}).id)
+  call assert_equal(0, g:Xgetlist({'id' : 999999, 'idx' : 0}).idx)
+  call assert_equal([], g:Xgetlist({'id' : 999999, 'items' : 0}).items)
+  call assert_equal(0, g:Xgetlist({'id' : 999999, 'nr' : 0}).nr)
+  call assert_equal(0, g:Xgetlist({'id' : 999999, 'size' : 0}).size)
+  call assert_equal('', g:Xgetlist({'id' : 999999, 'title' : 0}).title)
+  call assert_equal(0, g:Xgetlist({'id' : 999999, 'winid' : 0}).winid)
+  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0}, g:Xgetlist({'id' : 999999, 'all' : 0}))
+
+  call assert_equal('', g:Xgetlist({'nr' : 15, 'context' : 0}).context)
+  call assert_equal(0, g:Xgetlist({'nr' : 15}).nr)
+  call assert_equal(0, g:Xgetlist({'nr' : 15, 'idx' : 0}).idx)
+  call assert_equal([], g:Xgetlist({'nr' : 15, 'items' : 0}).items)
+  call assert_equal(0, g:Xgetlist({'nr' : 15, 'id' : 0}).id)
+  call assert_equal(0, g:Xgetlist({'nr' : 15, 'size' : 0}).size)
+  call assert_equal('', g:Xgetlist({'nr' : 15, 'title' : 0}).title)
+  call assert_equal(0, g:Xgetlist({'nr' : 15, 'winid' : 0}).winid)
+  call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0}, g:Xgetlist({'nr' : 15, 'all' : 0}))
+endfunc
+
+func Test_getqflist()
+  call Xgetlist_tests('c')
+  call Xgetlist_tests('l')
 endfunc

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -2886,6 +2886,7 @@ endfunc
 func Xgetlist_empty_tests(cchar)
   call s:setup_commands(a:cchar)
 
+  " Empty quickfix stack
   call g:Xsetlist([], 'f')
   call assert_equal('', g:Xgetlist({'context' : 0}).context)
   call assert_equal(0, g:Xgetlist({'id' : 0}).id)
@@ -2897,6 +2898,7 @@ func Xgetlist_empty_tests(cchar)
   call assert_equal(0, g:Xgetlist({'winid' : 0}).winid)
   call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0}, g:Xgetlist({'all' : 0}))
 
+  " Empty quickfix list
   Xexpr ""
   call assert_equal('', g:Xgetlist({'context' : 0}).context)
   call assert_notequal(0, g:Xgetlist({'id' : 0}).id)
@@ -2910,6 +2912,7 @@ func Xgetlist_empty_tests(cchar)
   let qfid = g:Xgetlist({'id' : 0}).id
   call g:Xsetlist([], 'f')
 
+  " Non-existing quickfix identifier
   call assert_equal('', g:Xgetlist({'id' : qfid, 'context' : 0}).context)
   call assert_equal(0, g:Xgetlist({'id' : qfid}).id)
   call assert_equal(0, g:Xgetlist({'id' : qfid, 'idx' : 0}).idx)
@@ -2920,6 +2923,7 @@ func Xgetlist_empty_tests(cchar)
   call assert_equal(0, g:Xgetlist({'id' : qfid, 'winid' : 0}).winid)
   call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0}, g:Xgetlist({'id' : qfid, 'all' : 0}))
 
+  " Non-existing quickfix list number
   call assert_equal('', g:Xgetlist({'nr' : 5, 'context' : 0}).context)
   call assert_equal(0, g:Xgetlist({'nr' : 5}).nr)
   call assert_equal(0, g:Xgetlist({'nr' : 5, 'idx' : 0}).idx)


### PR DESCRIPTION
The getqflist() function returns an empty dictionary if the quickfix stack
is empty or if the quickfix list is not present. This makes it verbose for a
Vim plugin to query the quickfix list. The plugin needs to check whether
the queried item is present in the dictionary using has_key() before
referring to the item.

The attached patch handles this case more gracefully and returns an
appropriate value for the queried item(s).