### PR TITLE
Fix drawing ambiguous-width character

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -8319,13 +8319,24 @@ screen_char(unsigned off, int row, int col)
 
 	/* Convert UTF-8 character to bytes and write it. */
 
-	buf[utfc_char2bytes(off, buf)] = NUL;
-
-	out_str(buf);
 	if (utf_ambiguous_width(ScreenLinesUC[off]))
+	{
+	    if (*p_ambw == 'd'
+# ifdef FEAT_GUI
+		    && !gui.in_use
+# endif
+		    )
+	    {
+		out_str((char_u *)"  ");
+		term_windgoto(row, col);
+	    }
 	    screen_cur_col = 9999;
+	}
 	else if (utf_char2cells(ScreenLinesUC[off]) > 1)
 	    ++screen_cur_col;
+
+	buf[utfc_char2bytes(off, buf)] = NUL;
+	out_str(buf);
     }
     else
 #endif


### PR DESCRIPTION
## Problem summary

Under the following conditions, Vim does not update the cells of unicode ambiguous-width character properly.

* On a terminal which treats ambiguous-width as 1 cell
* `:set ambiwidth=double`

## Repro steps

**Create 1.txt and 2.txt**

`vim --clean`

```vim
:e 1.txt
:normal! izzzzzz
:w
:e 2.txt
:exe "normal!" "iab\u03bbef"
:wq
```

* `\u03bb` is λ (lambda)

1.txt:
![1 txt](https://user-images.githubusercontent.com/943423/33872523-8583fa7e-df5a-11e7-87d7-b5895360db89.png)

2.txt: (`ambw=double`)
![2 txt](https://user-images.githubusercontent.com/943423/33872529-8b84496a-df5a-11e7-97c7-b0ae8b2ac110.png)


**Open 1.txt and 2.txt**

`vim --clean +'set ambw=double'`

```vim
:e 1.txt
:e 2.txt
```

**Result**

![1to2](https://user-images.githubusercontent.com/943423/33872551-a548a3aa-df5a-11e7-98bc-86412d2de984.png)

`z` of 1.txt remains just behind lambda of 2.txt.

## Details

When drawing a content of 2.txt, Vim outputs into terminal:

```
>>>   CSI 1;1H                CUP / move cursor to (row=1, col=1)
>>>  abλ
>>>   CSI 1;5H                CUP / move cursor to (row=1, col=5)
>>>  ef
```

Vim treats lambda as 2 cells but terminal treats it as 1 cell, so (row=1, col=4) cell is not updated.

## Solution

* Overwrite the cells by 2-spaces before output ambiguous-width (when `ambw=double`)

