### PR TITLE
Fix directx issues

### DIFF
--- a/src/INSTALLpc.txt
+++ b/src/INSTALLpc.txt
@@ -34,10 +34,11 @@ Contents:
 11. Building with Ruby support
 12. Building with Tcl support
 13. Building with Terminal support
-14. Windows 3.1
-15. MS-DOS
+14. Building with DirectX (DirectWrite) support
+15. Windows 3.1
+16. MS-DOS
 
-16. Installing after building from sources
+17. Installing after building from sources
 
 
 The currently recommended way (that means it has been verified to work) is
@@ -787,25 +788,59 @@ E.g. When using MSVC:
 
     nmake -f Make_mvc.mak TERMINAL=yes
 
-Or when using MinGW (as one line):
+Or when using MinGW:
 
     mingw32-make -f Make_ming.mak TERMINAL=yes
 
 
-14. Windows 3.1x
+14. Building with DirectX (DirectWrite) support
+===============================================
+
+Vim with DirectX (DirectWrite) support can be built with either MSVC or MinGW.
+This requires dwrite_2.h and some other header files which come with Windows
+SDK 8.1 or later (or MinGW-w64), if you want to enable color emoji support.
+This also requires MBYTE=yes which is enabled by default.
+
+A) Using MSVC
+
+If you use MSVC 2013 or later, Windows SDK 8.1 or later is used by default.
+You just need to specify DIRECTX=yes:
+
+    nmake -f Make_mvc.mak DIRECTX=yes
+
+If you use MSVC 2012 or earlier, the required header files are not available
+by default.  However, you can use the header files from newer SDKs with older
+compilers.  E.g.:
+
+    set "INCLUDE=%INCLUDE%;C:\Program Files (x86)\Windows Kits\8.1\Include\um"
+    nmake -f Make_mvc.mak DIRECTX=yes
+
+If you don't need color emoji support, only dwrite.h is required.  You can use
+older compilers (e.g. VC2010) without Windows SDK 8.1.  E.g.:
+
+    nmake -f Make_mvc.mak DIRECTX=yes COLOR_EMOJI=no
+
+B) Using MinGW-w64
+
+Just set DIRECTX to yes:
+
+    mingw32-make -f Make_ming.mak DIRECTX=yes
+
+
+15. Windows 3.1x
 ================
 
 The Windows 3.1x support was removed in patch 7.4.1364.
 
 
-15. MS-DOS
+16. MS-DOS
 ==========
 
 The MS-DOS support was removed in patch 7.4.1399.  Only very old Vim versions
 work on MS-DOS because of the limited amount of memory available.
 
 
-16. Installing after building from sources
+17. Installing after building from sources
 ==========================================
 
 [provided by Michael Soyka, updated by Ken Takata]

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -588,7 +588,7 @@ endif
 ifeq ($(DIRECTX),yes)
 # Only allow DirectWrite for a GUI build.
 ifeq (yes, $(GUI))
-DEFINES += -DFEAT_DIRECTX -DDYNAMIC_DIRECTX
+DEFINES += -DFEAT_DIRECTX -DDYNAMIC_DIRECTX -DFEAT_DIRECTX_COLOR_EMOJI
 endif
 endif
 

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -25,12 +25,15 @@
 #
 #	GUI interface: GUI=yes (default is no)
 #
-#	GUI with DirectWrite(DirectX): DIRECTX=yes
-#	  (default is no, requires GUI=yes)
+#	GUI with DirectWrite (DirectX): DIRECTX=yes
+#	  (default is no, requires GUI=yes and MBYTE=yes)
+#
+#	Color emoji support: COLOR_EMOJI=yes
+#	  (default is yes if DIRECTX=yes, requires WinSDK 8.1 or later.)
 #
 #	OLE interface: OLE=yes (usually with GUI=yes)
 #
-#	Multibyte support: MBYTE=yes (default is no)
+#	Multibyte support: MBYTE=yes (default is yes for NORMAL, BIG, HUGE)
 #
 #	IME support: IME=yes	(requires GUI=yes)
 #	  DYNAMIC_IME=[yes or no]  (to load the imm32.dll dynamically, default
@@ -419,9 +422,12 @@ NBDEBUG_SRC	= nbdebug.c
 NETBEANS_LIB	= WSock32.lib
 !endif
 
-# DirectWrite(DirectX)
+# DirectWrite (DirectX)
 !if "$(DIRECTX)" == "yes"
 DIRECTX_DEFS	= -DFEAT_DIRECTX -DDYNAMIC_DIRECTX
+!if "$(COLOR_EMOJI)" != "no"
+DIRECTX_DEFS	= $(DIRECTX_DEFS) -DFEAT_DIRECTX_COLOR_EMOJI
+!endif
 DIRECTX_INCL	= gui_dwrite.h
 DIRECTX_OBJ	= $(OUTDIR)\gui_dwrite.obj
 !endif

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -38,7 +38,11 @@
 # define _Outptr_
 #endif
 
-#include <dwrite_2.h>
+#ifdef FEAT_DIRECTX_COLOR_EMOJI
+# include <dwrite_2.h>
+#else
+# include <dwrite.h>
+#endif
 
 #include "gui_dwrite.h"
 
@@ -284,7 +288,9 @@ struct DWriteContext {
     ID2D1SolidColorBrush *mBrush;
 
     IDWriteFactory *mDWriteFactory;
+#ifdef FEAT_DIRECTX_COLOR_EMOJI
     IDWriteFactory2 *mDWriteFactory2;
+#endif
 
     IDWriteGdiInterop *mGdiInterop;
     IDWriteRenderingParams *mRenderingParams;
@@ -481,6 +487,7 @@ public:
 	AdjustedGlyphRun adjustedGlyphRun(glyphRun, context->cellWidth,
 		context->offsetX);
 
+#ifdef FEAT_DIRECTX_COLOR_EMOJI
 	if (pDWC_->mDWriteFactory2 != NULL)
 	{
 	    IDWriteColorGlyphRunEnumerator *enumerator = NULL;
@@ -517,6 +524,7 @@ public:
 		return S_OK;
 	    }
 	}
+#endif
 
 	// Draw by IDWriteFactory (without color emoji)
 	pDWC_->mRT->DrawGlyphRun(
@@ -589,7 +597,9 @@ DWriteContext::DWriteContext() :
     mGDIRT(NULL),
     mBrush(NULL),
     mDWriteFactory(NULL),
+#ifdef FEAT_DIRECTX_COLOR_EMOJI
     mDWriteFactory2(NULL),
+#endif
     mGdiInterop(NULL),
     mRenderingParams(NULL),
     mFontCache(8),
@@ -618,6 +628,7 @@ DWriteContext::DWriteContext() :
 		mDWriteFactory);
     }
 
+#ifdef FEAT_DIRECTX_COLOR_EMOJI
     if (SUCCEEDED(hr))
     {
 	DWriteCreateFactory(
@@ -626,6 +637,7 @@ DWriteContext::DWriteContext() :
 		reinterpret_cast<IUnknown**>(&mDWriteFactory2));
 	_RPT1(_CRT_WARN, "IDWriteFactory2: %s\n", SUCCEEDED(hr) ? "available" : "not available");
     }
+#endif
 
     if (SUCCEEDED(hr))
     {
@@ -647,7 +659,9 @@ DWriteContext::~DWriteContext()
     SafeRelease(&mRenderingParams);
     SafeRelease(&mGdiInterop);
     SafeRelease(&mDWriteFactory);
+#ifdef FEAT_DIRECTX_COLOR_EMOJI
     SafeRelease(&mDWriteFactory2);
+#endif
     SafeRelease(&mBrush);
     SafeRelease(&mGDIRT);
     SafeRelease(&mRT);

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -995,7 +995,7 @@ DWriteContext::DrawText(const WCHAR *text, int len,
 
 	TextRenderer renderer(this);
 	TextRendererContext context = { color, FLOAT(cellWidth), 0.0f };
-	textLayout->Draw(&context, &renderer, FLOAT(x), FLOAT(y));
+	textLayout->Draw(&context, &renderer, FLOAT(x), FLOAT(y) - 0.5f);
     }
 
     SafeRelease(&textLayout);

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -3140,7 +3140,8 @@ gui_mch_delete_lines(
     {
 	if (s_directx_scrlines > 0 && s_directx_scrlines <= num_lines)
 	{
-	    RedrawWindow(s_textArea, &rc, NULL, RDW_INVALIDATE);
+	    gui_redraw(rc.left, rc.top,
+		    rc.right - rc.left + 1, rc.bottom - rc.top + 1);
 	    use_redraw = 1;
 	}
 	else
@@ -3152,9 +3153,9 @@ gui_mch_delete_lines(
 	intel_gpu_workaround();
 	ScrollWindowEx(s_textArea, 0, -num_lines * gui.char_height,
 				    &rc, &rc, NULL, NULL, get_scroll_flags());
+	UpdateWindow(s_textArea);
     }
 
-    UpdateWindow(s_textArea);
     /* This seems to be required to avoid the cursor disappearing when
      * scrolling such that the cursor ends up in the top-left character on
      * the screen...   But why?  (Webb) */
@@ -3190,7 +3191,8 @@ gui_mch_insert_lines(
     {
 	if (s_directx_scrlines > 0 && s_directx_scrlines <= num_lines)
 	{
-	    RedrawWindow(s_textArea, &rc, NULL, RDW_INVALIDATE);
+	    gui_redraw(rc.left, rc.top,
+		    rc.right - rc.left + 1, rc.bottom - rc.top + 1);
 	    use_redraw = 1;
 	}
 	else
@@ -3204,9 +3206,8 @@ gui_mch_insert_lines(
 	 * off-screen.  How do we avoid it when it's not needed? */
 	ScrollWindowEx(s_textArea, 0, num_lines * gui.char_height,
 				    &rc, &rc, NULL, NULL, get_scroll_flags());
+	UpdateWindow(s_textArea);
     }
-
-    UpdateWindow(s_textArea);
 
     gui_clear_block(row, gui.scroll_region_left,
 				row + num_lines - 1, gui.scroll_region_right);

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -31,7 +31,7 @@
 
 #if defined(FEAT_DIRECTX)
 # ifndef FEAT_MBYTE
-#  error "FEAT_MBYTE is required for FEAT_DIRECTX."
+#  error FEAT_MBYTE is required for FEAT_DIRECTX.
 # endif
 static DWriteContext *s_dwc = NULL;
 static int s_directx_enabled = 0;

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -50,7 +50,7 @@ static int gui_mswin_get_menu_height(int fix_window);
     int
 gui_mch_set_rendering_options(char_u *s)
 {
-#ifdef FEAT_DIRECTX
+# ifdef FEAT_DIRECTX
     char_u  *p, *q;
 
     int	    dx_enable = 0;
@@ -162,9 +162,9 @@ gui_mch_set_rendering_options(char_u *s)
     s_directx_scrlines = dx_scrlines;
 
     return OK;
-#else
+# else
     return FAIL;
-#endif
+# endif
 }
 #endif
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -30,11 +30,14 @@
 #endif
 
 #if defined(FEAT_DIRECTX)
+# ifndef FEAT_MBYTE
+#  error "FEAT_MBYTE is required for FEAT_DIRECTX."
+# endif
 static DWriteContext *s_dwc = NULL;
 static int s_directx_enabled = 0;
 static int s_directx_load_attempted = 0;
 static int s_directx_scrlines = 0;
-# define IS_ENABLE_DIRECTX() (s_directx_enabled && s_dwc != NULL)
+# define IS_ENABLE_DIRECTX() (s_directx_enabled && s_dwc != NULL && enc_utf8)
 static int directx_enabled(void);
 static void directx_binddc(void);
 #endif
@@ -6402,13 +6405,13 @@ gui_mch_draw_string(
 	    if (text[n] >= 0x80)
 		break;
 
-#if defined(FEAT_DIRECTX)
+# if defined(FEAT_DIRECTX)
     /* Quick hack to enable DirectWrite.  To use DirectWrite (antialias), it is
      * required that unicode drawing routine, currently.  So this forces it
      * enabled. */
-    if (enc_utf8 && IS_ENABLE_DIRECTX())
+    if (IS_ENABLE_DIRECTX())
 	n = 0; /* Keep n < len, to enter block for unicode. */
-#endif
+# endif
 
     /* Check if the Unicode buffer exists and is big enough.  Create it
      * with the same length as the multi-byte string, the number of wide
@@ -6481,7 +6484,7 @@ gui_mch_draw_string(
 	    i += utf_ptr2len_len(text + i, len - i);
 	    ++clen;
 	}
-#if defined(FEAT_DIRECTX)
+# if defined(FEAT_DIRECTX)
 	if (IS_ENABLE_DIRECTX())
 	{
 	    /* Add one to "cells" for italics. */
@@ -6491,7 +6494,7 @@ gui_mch_draw_string(
 		    foptions, pcliprect, unicodepdy);
 	}
 	else
-#endif
+# endif
 	    ExtTextOutW(s_hdc, TEXT_X(col), TEXT_Y(row),
 		    foptions, pcliprect, unicodebuf, wlen, unicodepdy);
 	len = cells;	/* used for underlining */


### PR DESCRIPTION
This PR fixes the following issues in the latest directx renderer:

1. Make scroll slightly faster when `scrlines:1`.

2. Fix y-position of displayed text.
  I hope that this fixes the issue reported at here: https://groups.google.com/d/msg/vim_dev/2AaZMN1T6K8/mnrR9ZJrBgAJ

3. Fix directx with non-utf8 encoding.
  After 8.0.1343, nothing is displayed when 'enc' is not "utf8" and the directx renderer is selected.
  It should have fallen back to the GDI renderer.

4. Add COLOR_EMOJI option and also update INSTALLpc.txt.

Note that the following issues are not fixed yet:

* 8.0.1369 or later becomes slow on some environment.
  Reported at https://groups.google.com/d/msg/vim_dev/2AaZMN1T6K8/x4QxC_XbBQAJ .
* Sometimes the cursor is displayed in a wrong place.
  Reported at https://groups.google.com/d/msg/vim_dev/2AaZMN1T6K8/LRZqOifeBgAJ .