### PR TITLE
Feature proposal: Position expressions with offset suffix

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3539,6 +3539,7 @@ col({expr})	The result is a Number, which is the byte index of the column
 			    cursor is the end).  When not in Visual mode
 			    returns the cursor position.  Differs from |'<| in
 			    that it's updated right away.
+		These expressions except "v" accept offset suffix.
 		Additionally {expr} can be [lnum, col]: a |List| with the line
 		and column number. Most useful when the column is "$", to get
 		the last column of a specific line.  When "lnum" or "col" is
@@ -3552,6 +3553,9 @@ col({expr})	The result is a Number, which is the byte index of the column
 			col("$")		length of cursor line plus one
 			col("'t")		column of mark t
 			col("'" . markname)	column of mark markname
+<		Examples of offset suffix: >
+			col(".+2")		column of cursor + 2
+			col("$-1")		length of cursor line
 <		The first column is 1.  0 is returned for an error.
 		For an uppercase mark the column may actually be in another
 		buffer.
@@ -6268,6 +6272,7 @@ line({expr})	The result is a Number, which is the line number of the file
 			    cursor is the end).  When not in Visual mode
 			    returns the cursor position.  Differs from |'<| in
 			    that it's updated right away.
+		These expressions except "v" accept offset suffix.
 		Note that a mark in another file can be used.  The line number
 		then applies to another buffer.
 		To get the column number use |col()|.  To get both use
@@ -6276,7 +6281,10 @@ line({expr})	The result is a Number, which is the line number of the file
 			line(".")		line number of the cursor
 			line("'t")		line number of mark t
 			line("'" . marker)	line number of mark marker
-<
+<		Examples of offset suffix: >
+			line(".-3")		line number of the cursor - 3
+			line("$+1")		the last line + 1
+<							*last-position-jump*
 		To jump to the last known position when opening a file see
 		|last-position-jump|.
 
@@ -10266,6 +10274,7 @@ virtcol({expr})						*virtcol()*
 			    cursor is the end).  When not in Visual mode
 			    returns the cursor position.  Differs from |'<| in
 			    that it's updated right away.
+		These expressions except "v" accept offset suffix.
 		Note that only marks in the current file can be used.
 		Examples: >
   virtcol(".")	   with text "foo^Lbar", with cursor on the "^L", returns 5

--- a/src/proto/eval.pro
+++ b/src/proto/eval.pro
@@ -56,7 +56,7 @@ char_u *echo_string(typval_T *tv, char_u **tofree, char_u *numbuf, int copyID);
 char_u *tv2string(typval_T *tv, char_u **tofree, char_u *numbuf, int copyID);
 char_u *string_quote(char_u *str, int function);
 int string2float(char_u *text, float_T *value);
-pos_T *var2fpos(typval_T *varp, int dollar_lnum, int *fnum);
+pos_T *var2fpos(typval_T *varp, int dollar_lnum, int *fnum, int *offset);
 int list2fpos(typval_T *arg, pos_T *posp, int *fnump, colnr_T *curswantp);
 int get_id_len(char_u **arg);
 int get_name_len(char_u **arg, char_u **alias, int evaluate, int verbose);

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -162,6 +162,7 @@ NEW_TESTS = \
 	test_langmap \
 	test_largefile \
 	test_let \
+	test_linecol \
 	test_lineending \
 	test_lispwords \
 	test_listchars \

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -36,6 +36,7 @@ source test_help_tagjump.vim
 source test_join.vim
 source test_jumps.vim
 source test_lambda.vim
+source test_linecol.vim
 source test_lispwords.vim
 source test_mapping.vim
 source test_match.vim

--- a/src/testdir/test_bufline.vim
+++ b/src/testdir/test_bufline.vim
@@ -19,7 +19,7 @@ func Test_setbufline_getbufline()
   wincmd w
   call assert_equal(1, setbufline(b, 5, ['x']))
   call assert_equal(1, setbufline(bufnr('$') + 1, 1, ['x']))
-  call assert_equal(0, setbufline(b, 4, ['d', 'e']))
+  call assert_equal(0, setbufline(b, '$+1', ['d', 'e']))
   call assert_equal(['c'], getbufline(b, 3))
   call assert_equal(['d'], getbufline(b, 4))
   call assert_equal(['e'], getbufline(b, 5))

--- a/src/testdir/test_linecol.vim
+++ b/src/testdir/test_linecol.vim
@@ -1,0 +1,82 @@
+" Tests for position expressions: '.', '$', 'w0', 'w$', etc.
+
+func Test_position_expr_with_offset()
+  5new
+  call setline(1, map(range(1, 20), 'printf("#line%02d#", v:val)'))
+
+  " line() and getline()
+  normal! 10gg
+
+  " . : the cursor position
+  call assert_equal(10, line('.'))
+  call assert_equal('#line10#', getline('.'))
+  call assert_equal(5, line('.-5'))
+  call assert_equal('#line05#', getline('.-5'))
+  call assert_equal(13, line('.+3'))
+  call assert_equal('#line13#', getline('.+3'))
+
+  " $ : the last line in the current buffer
+  call assert_equal(20, line('$'))
+  call assert_equal('#line20#', getline('$'))
+  call assert_equal(18, line('$-2'))
+  call assert_equal('#line18#', getline('$-2'))
+  call assert_equal(21, line('$+1'))
+  call assert_equal('', getline('$+1'))
+
+  " 'x : position of mark x (if the mark is not set, 0 is returned)
+  mark a
+  normal! gg
+  call assert_equal(10, line("'a"))
+  call assert_equal('#line10#', getline("'a"))
+  call assert_equal(6, line("'a-4"))
+  call assert_equal('#line06#', getline("'a-4"))
+  call assert_equal(14, line("'a+4"))
+  call assert_equal('#line14#', getline("'a+4"))
+  normal! 'a
+  delmarks a
+
+  " w0 : first line visible in current window
+  call assert_equal(8, line('w0'))
+  call assert_equal('#line08#', getline('w0'))
+  call assert_equal(5, line('w0-3'))
+  call assert_equal('#line05#', getline('w0-3'))
+  call assert_equal(9, line('w0+1'))
+  call assert_equal('#line09#', getline('w0+1'))
+
+  " w$ : last line visible in current window
+  call assert_equal(12, line('w$'))
+  call assert_equal('#line12#', getline('w$'))
+  call assert_equal(9, line('w$-3'))
+  call assert_equal('#line09#', getline('w$-3'))
+  call assert_equal(14, line('w$+2'))
+  call assert_equal('#line14#', getline('w$+2'))
+
+  " v : In Visual mode: the start of the Visual area
+  call assert_equal(10, line('v'))
+  call assert_equal('#line10#', getline('v'))
+  normal! kv4j
+  call assert_equal(9, line('v'))
+  call assert_equal('#line09#', getline('v'))
+  " when using 'v', offset suffix is invalid
+  call assert_equal(0, line('v+1'))
+  call assert_equal('', getline('v+1'))
+
+  " confirm invalid suffix has no effect
+  call assert_equal(13, line('.@@@'))
+  call assert_equal('#line13#', getline('.@@@'))
+
+  " col()
+  normal! gg3l
+
+  " . : the cursor position
+  call assert_equal(4, col('.'))
+  call assert_equal(2, col('.-2'))
+  call assert_equal(7, col('.+3'))
+
+  " $ : the end of the cursor line
+  call assert_equal(9, col('$'))
+  call assert_equal(6, col('$-3'))
+  call assert_equal(10, col('$+1'))
+
+  bwipeout!
+endfunc


### PR DESCRIPTION
## Summary

This patch add "offset suffix" to position expressions for some functions.

Examples:

```vim
line('.+2') " the line of current cursor plus 2
col("'x-3") " the column of mark x minus 3

getline('w0-1')
setline('w$+3', 'foobar')
```

Position expressions of `line()` are:

```
line({expr})    The result is a Number, which is the line number of the file
                position given with {expr}.  The accepted positions are:
                    .       the cursor position
                    $       the last line in the current buffer
                    'x      position of mark x (if the mark is not set, 0 is
                            returned)
                    w0      first line visible in current window (one if the
                            display isn't updated, e.g. in silent Ex mode)
                    w$      last line visible in current window (this is one
                            less than "w0" if no lines are visible)
                    v       In Visual mode: the start of the Visual area (the
                            cursor is the end).  When not in Visual mode
                            returns the cursor position.  Differs from '< in
                            that it's updated right away.
```

### NOTE

* Offsets to `.`, `w0`, `w$` are invalid when the specified buffer has no associated window (hidden buffer)
* Visual mode `v` does not accept suffix

## Use case

When user wants to append lines to the end of another buffer, can use `setbufline()` but it is complicated to specify the line.
To calculate the last line of another buffer: `len(getbufline('#', 1, '$'))`

Using offset suffix, can write simply: `setbufline('#', '$+1', [...])`