### PR TITLE
Fixed build when configuring with --disable-channel

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2059,7 +2059,7 @@ else
     AC_MSG_RESULT(no)
   fi
 fi
-if test "$enable_terminal" = "yes"; then
+if test "$enable_terminal" = "yes" -a "$enable_channel" = "yes"; then
   AC_DEFINE(FEAT_TERMINAL)
   TERM_SRC="libvterm/src/encoding.c libvterm/src/keyboard.c libvterm/src/mouse.c libvterm/src/parser.c libvterm/src/pen.c libvterm/src/screen.c libvterm/src/state.c libvterm/src/unicode.c libvterm/src/vterm.c"
   AC_SUBST(TERM_SRC)


### PR DESCRIPTION
Vim fails to build when configuring with:
```
$ ./configure --with-features=huge --disable-channel
$ make
...
objects/term_unicode.o: In function `vterm_unicode_width':
/home/pel/sb/vim/src/libvterm/src/unicode.c:345: undefined reference to `utf_uint2cells'
objects/term_unicode.o: In function `vterm_unicode_is_combining':
/home/pel/sb/vim/src/libvterm/src/unicode.c:350: undefined reference to `utf_iscomposing_uint'
collect2: error: ld returned 1 exit status
```

This PR fixes the issue.
