### PR TITLE
Update syntax highlight of haskell.vim

### DIFF
--- a/runtime/syntax/haskell.vim
+++ b/runtime/syntax/haskell.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		Haskell
 " Maintainer:		Haskell Cafe mailinglist <haskell-cafe@haskell.org>
-" Last Change:		2017 Jun 04
+" Last Change:		2017 Dec 16
 " Original Author:	John Williams <jrw@pobox.com>
 "
 " Thanks to Ryan Crumley for suggestions and John Meacham for

--- a/runtime/syntax/haskell.vim
+++ b/runtime/syntax/haskell.vim
@@ -59,8 +59,8 @@ syn match   hsSpecialCharError	contained "\\&\|'''\+"
 syn region  hsString		start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=hsSpecialChar
 syn match   hsCharacter		"[^a-zA-Z0-9_']'\([^\\]\|\\[^']\+\|\\'\)'"lc=1 contains=hsSpecialChar,hsSpecialCharError
 syn match   hsCharacter		"^'\([^\\]\|\\[^']\+\|\\'\)'" contains=hsSpecialChar,hsSpecialCharError
-syn match   hsNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>"
-syn match   hsFloat		"\<[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\=\>"
+syn match   hsNumber		"\<[0-9]\%(_*[0-9]\)*\>\|\<0[xX]_*[0-9a-fA-F]\%(_*[0-9a-fA-F]\)*\>\|\<0[oO]_*\%(_*[0-7]\)*\>\|\<0[bB]_*[01]\%(_*[01]\)*\>"
+syn match   hsFloat		"\<[0-9]\%(_*[0-9]\)*\.[0-9]\%(_*[0-9]\)*\%(_*[eE][-+]\?[0-9]\%(_*[0-9]\)*\)\?\>\|\<[0-9]\%(_*[0-9]\)*_*[eE][-+]\?[0-9]\%(_*[0-9]\)*\>\|\<0[xX]_*[0-9a-fA-F]\%(_*[0-9a-fA-F]\)*\.[0-9a-fA-F]\%(_*[0-9a-fA-F]\)*\%(_*[pP][-+]\?[0-9]\%(_*[0-9]\)*\)\?\>\|\<0[xX]_*[0-9a-fA-F]\%(_*[0-9a-fA-F]\)*_*[pP][-+]\?[0-9]\%(_*[0-9]\)*\>"
 
 " Keyword definitions. These must be patterns instead of keywords
 " because otherwise they would match as keywords at the start of a

--- a/runtime/syntax/haskell.vim
+++ b/runtime/syntax/haskell.vim
@@ -59,8 +59,8 @@ syn match   hsSpecialCharError	contained "\\&\|'''\+"
 syn region  hsString		start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=hsSpecialChar
 syn match   hsCharacter		"[^a-zA-Z0-9_']'\([^\\]\|\\[^']\+\|\\'\)'"lc=1 contains=hsSpecialChar,hsSpecialCharError
 syn match   hsCharacter		"^'\([^\\]\|\\[^']\+\|\\'\)'" contains=hsSpecialChar,hsSpecialCharError
-syn match   hsNumber		"\<[0-9]\%(_*[0-9]\)*\>\|\<0[xX]_*[0-9a-fA-F]\%(_*[0-9a-fA-F]\)*\>\|\<0[oO]_*\%(_*[0-7]\)*\>\|\<0[bB]_*[01]\%(_*[01]\)*\>"
-syn match   hsFloat		"\<[0-9]\%(_*[0-9]\)*\.[0-9]\%(_*[0-9]\)*\%(_*[eE][-+]\?[0-9]\%(_*[0-9]\)*\)\?\>\|\<[0-9]\%(_*[0-9]\)*_*[eE][-+]\?[0-9]\%(_*[0-9]\)*\>\|\<0[xX]_*[0-9a-fA-F]\%(_*[0-9a-fA-F]\)*\.[0-9a-fA-F]\%(_*[0-9a-fA-F]\)*\%(_*[pP][-+]\?[0-9]\%(_*[0-9]\)*\)\?\>\|\<0[xX]_*[0-9a-fA-F]\%(_*[0-9a-fA-F]\)*_*[pP][-+]\?[0-9]\%(_*[0-9]\)*\>"
+syn match   hsNumber		"\v<[0-9]%(_*[0-9])*>|<0[xX]_*[0-9a-fA-F]%(_*[0-9a-fA-F])*>|<0[oO]_*%(_*[0-7])*>|<0[bB]_*[01]%(_*[01])*>"
+syn match   hsFloat		"\v<[0-9]%(_*[0-9])*\.[0-9]%(_*[0-9])*%(_*[eE][-+]?[0-9]%(_*[0-9])*)?>|<[0-9]%(_*[0-9])*_*[eE][-+]?[0-9]%(_*[0-9])*>|<0[xX]_*[0-9a-fA-F]%(_*[0-9a-fA-F])*\.[0-9a-fA-F]%(_*[0-9a-fA-F])*%(_*[pP][-+]?[0-9]%(_*[0-9])*)?>|<0[xX]_*[0-9a-fA-F]%(_*[0-9a-fA-F])*_*[pP][-+]?[0-9]%(_*[0-9])*>"
 
 " Keyword definitions. These must be patterns instead of keywords
 " because otherwise they would match as keywords at the start of a


### PR DESCRIPTION
This patch implemented Haskell/GHC's newly accepted proposal for numeric literals. (I'm author of the proposal.)
  * https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0009-numeric-underscores.rst#new-syntax-this-proposal

I contacted the maintainer of haskell.vim.
  * https://mail.haskell.org/pipermail/haskell-cafe/2017-December/128281.html

I also contacted vim_dev.
  * https://groups.google.com/forum/#!topic/vim_dev/b5ug8xOXyxo

I visually verified this patch with a test file.
  * https://github.com/takenobu-hs/ghc/blob/squashed-numeric-underscores/testsuite/tests/parser/should_run/NumericUnderscores0.hs

