### PR TITLE
Correctly detect apachestyle comments

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1925,6 +1925,9 @@ au StdinReadPost * if !did_filetype() | runtime! scripts.vim | endif
 " Most of these should call s:StarSetf() to avoid names ending in .gz and the
 " like are used.
 
+" More Apache style config files
+au BufNewFile,BufRead */etc/proftpd/*.conf*,*/etc/proftpd/conf.*/*	call s:StarSetf('apachestyle')
+
 " More Apache config files
 au BufNewFile,BufRead access.conf*,apache.conf*,apache2.conf*,httpd.conf*,srm.conf*	call s:StarSetf('apache')
 au BufNewFile,BufRead */etc/apache2/*.conf*,*/etc/apache2/conf.*/*,*/etc/apache2/mods-*/*,*/etc/apache2/sites-*/*,*/etc/httpd/conf.d/*.conf*		call s:StarSetf('apache')

--- a/runtime/syntax/apachestyle.vim
+++ b/runtime/syntax/apachestyle.vim
@@ -1,8 +1,10 @@
 " Vim syntax file
 " Language:	Apache-Style configuration files (proftpd.conf/apache.conf/..)
-" Maintainer:	Christian Hammers <ch@westend.com>
+" Maintainer:	Christian Hammers <ch@westend.com>, Ben RUBSON <ben.rubson@gmail.com>
 " URL:		none
 " ChangeLog:
+"	2017-12-17,ch
+"		correctly detect comments
 "	2001-05-04,ch
 "		adopted Vim 6.0 syntax style
 "	1999-10-28,ch

--- a/runtime/syntax/apachestyle.vim
+++ b/runtime/syntax/apachestyle.vim
@@ -27,8 +27,8 @@ endif
 
 syn case ignore
 
-syn match  apComment	/^\s*#.*$/
 syn match  apOption	/^\s*[^ \t#<=]*/
+syn match  apComment	/^\s*#.*$/
 "syn match  apLastValue	/[^ \t<=#]*$/ contains=apComment	ugly
 
 " tags


### PR DESCRIPTION
Hi,

This PR makes the comments correctly detected in apachestyle syntax.
Without this modification, comments are not correctly detected / not shown into the correct color.

It's really tiny as it just swaps the order of 2 lines.

Thank you very much 👍 

Ben