### PR TITLE
Fixed crash when calling setqflist()

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5225,7 +5225,7 @@ qf_set_properties(qf_info_T *qi, dict_T *what, int action, char_u *title)
 	    else if (action != ' ')
 		newlist = FALSE;	/* use the specified list */
 	}
-	else if (di->di_tv.v_type == VAR_STRING
+	else if (di->di_tv.v_type == VAR_STRING && di->di_tv.vval.v_string != NULL
 		&& STRCMP(di->di_tv.vval.v_string, "$") == 0)
 	{
 	    if (qi->qf_listcount > 0)

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -4930,7 +4930,7 @@ qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
 			qf_idx = -1;
 		}
 	    }
-	    else if ((di->di_tv.v_type == VAR_STRING)
+	    else if (di->di_tv.v_type == VAR_STRING && di->di_tv.vval.v_string != NULL
 		    && (STRCMP(di->di_tv.vval.v_string, "$") == 0))
 		/* Get the last quickfix list number */
 		qf_idx = qi->qf_listcount - 1;

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -2951,6 +2951,15 @@ func Test_getqflist()
   call Xgetlist_empty_tests('l')
 endfunc
 
+func Test_getqflist_invalid_nr()
+  " The following commands used to crash Vim
+  cexpr ""
+  call getqflist({'nr' : $XXX_DOES_NOT_EXIST_XXX})
+
+  " Cleanup
+  call setqflist([], 'r')
+endfunc
+
 " Tests for the quickfix/location list changedtick
 func Xqftick_tests(cchar)
   call s:setup_commands(a:cchar)

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1428,6 +1428,11 @@ func XquickfixSetListWithAct(cchar)
   call assert_fails("call g:Xsetlist(list1, 0)", 'E928:')
 endfunc
 
+func Test_setqflist_invalid_nr()
+  " The following command used to crash Vim
+  call setqflist([], ' ', {'nr' : $XXX_DOES_NOT_EXIST})
+endfunc
+
 func Test_quickfix_set_list_with_act()
   call XquickfixSetListWithAct('c')
   call XquickfixSetListWithAct('l')


### PR DESCRIPTION
This PR fixes a crash (read at address 0) in vim-8.0.1406
and older reproducible with:

```
$ vim -u NONE -c 'call setqflist([], " ", {"nr" : $XXX_DOES_NOT_EXIST_XXX})' -cq
Vim: Caught deadly signal SEGV
Vim: Finished.
Segmentation fault (core dumped)
```
Bug was found using afl-fuzz.

I'm not sure whether the fix is a workaround or a proper fix.

Bug happens when accessing an environment variable which
does not exist.  I wonder whether there could be other similar
bugs lurking.
