### PR TITLE
Fixed infinite loop with: echo count('foo', '')

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3338,7 +3338,8 @@ count({comp}, {expr} [, {ic} [, {start}]])			*count()*
 		When {ic} is given and it's |TRUE| then case is ignored.
 
 		When {comp} is a string then the number of not overlapping
-		occurrences of {expr} is returned.
+		occurrences of {expr} is returned. 0 is returned when {expr}
+		is en empty string.
 
 
 							*cscope_connection()*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2382,7 +2382,7 @@ f_count(typval_T *argvars, typval_T *rettv)
 	char_u *p = argvars[0].vval.v_string;
 	char_u *next;
 
-	if (!error && expr != NULL && p != NULL)
+	if (!error && expr != NULL && *expr != NUL && p != NULL)
 	{
 	    if (ic)
 	    {

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -692,6 +692,7 @@ func Test_count()
   call assert_equal(0, count("foo", "O"))
   call assert_equal(2, count("foo", "O", 1))
   call assert_equal(2, count("fooooo", "oo"))
+  call assert_equal(0, count("foo", ""))
 endfunc
 
 func Test_changenr()


### PR DESCRIPTION
This PR fixes an infinite loop in Vim-8.0.1406 and older which
can be reproduced with:
```
:echo count('foo', '')
```
It is not possible to break the infinite loop with CTRL-C.
Vim takes 100% of the CPU. The only way is to exit is
to kill -9 the Vim process.
