### PR TITLE
Fixed buffer overflow in do_tags() with long tag

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -1130,7 +1130,7 @@ do_tags(exarg_T *eap UNUSED)
 		continue;
 
 	    msg_putchar('\n');
-	    sprintf((char *)IObuff, "%c%2d %2d %-15s %5ld  ",
+	    vim_snprintf((char *)IObuff, IOSIZE, "%c%2d %2d %-15s %5ld  ",
 		i == tagstackidx ? '>' : ' ',
 		i + 1,
 		tagstack[i].cur_match + 1,


### PR DESCRIPTION
This PR fixes issue #2471 (buffer overflow with :tags command with very long tag).
Bug was reproducible with:

```
$ valgrind ./vim -u NONE -e -s -c 'exe "tag " . repeat("x", 1020)' -c 'tags|q'
==9259== Memcheck, a memory error detector
==9259== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==9259== Using Valgrind-3.14.0.GIT and LibVEX; rerun with -h for copyright info
==9259== Command: ./vim -u NONE -e -s -c exe\ "tag\ "\ .\ repeat("x",\ 1012) -c tags|q
==9259== 
==9259== Invalid read of size 1
==9259==    at 0x7C56760: strchrnul (strchr.S:24)
==9259==    by 0x7C0D207: __find_specmb (printf-parse.h:108)
==9259==    by 0x7C0D207: vfprintf (vfprintf.c:1312)
==9259==    by 0x7CD6713: __vsprintf_chk (vsprintf_chk.c:82)
==9259==    by 0x7CD666C: __sprintf_chk (sprintf_chk.c:31)
==9259==    by 0x5AD8B5: do_tags (tag.c:1133)
==9259==    by 0x468ABC: do_one_cmd (ex_docmd.c:2908)
==9259==    by 0x464D3D: do_cmdline (ex_docmd.c:1071)
==9259==    by 0x625A4C: exe_commands (main.c:2953)
==9259==    by 0x625A4C: vim_main2 (main.c:800)
==9259==    by 0x6245E4: main (main.c:429)
==9259==  Address 0x401 is not stack'd, malloc'd or (recently) free'd
==9259== 
==9259== 
==9259== Process terminating with default action of signal 11 (SIGSEGV)
==9259==    at 0x7BF5767: kill (syscall-template.S:84)
==9259==    by 0x512B68: may_core_dump (os_unix.c:3383)
==9259==    by 0x512B68: mch_exit (os_unix.c:3349)
==9259==    by 0x625EAE: getout (main.c:1542)
==9259==    by 0x7BF54AF: ??? (in /lib/x86_64-linux-gnu/libc-2.23.so)
==9259==    by 0x7C5675F: ??? (in /lib/x86_64-linux-gnu/libc-2.23.so)
==9259==    by 0x7CD6713: __vsprintf_chk (vsprintf_chk.c:82)
==9259==    by 0x7CD666C: __sprintf_chk (sprintf_chk.c:31)
==9259==    by 0x5AD8B5: do_tags (tag.c:1133)
==9259==    by 0x468ABC: do_one_cmd (ex_docmd.c:2908)
==9259==    by 0x464D3D: do_cmdline (ex_docmd.c:1071)
==9259==    by 0x625A4C: exe_commands (main.c:2953)
==9259==    by 0x625A4C: vim_main2 (main.c:800)
==9259==    by 0x6245E4: main (main.c:429)
```