### PR TITLE
ftplugin/python: fix completion if compiled only with +python3

### DIFF
--- a/runtime/ftplugin/python.vim
+++ b/runtime/ftplugin/python.vim
@@ -20,6 +20,9 @@ setlocal comments=b:#,fb:-
 setlocal commentstring=#\ %s
 
 setlocal omnifunc=pythoncomplete#Complete
+if has('python3')
+	setlocal omnifunc=python3complete#Complete
+endif
 
 set wildignore+=*.pyc
 


### PR DESCRIPTION
In Debian, the default vim version is not compiled with `+python`, but with `+python3`. In this case, `pythoncomplete#Complete()` will throw an error as it depends on `+python`. However, we can use `python3complete#Complete()` if `+python3` is available.

If no Python support was compiled, `pythoncomplete#Complete()` will be used and still throw an error, so the user is warned in this case.
