### PR TITLE
try/catch is ignored while error in return statement 

### DIFF
--- a/src/testdir/test_return_with_err.vim
+++ b/src/testdir/test_return_with_err.vim
@@ -1,0 +1,14 @@
+" Test for :return with error
+
+function! s:foo() abort
+  try
+    return [] == 0
+  catch
+    return 1
+  endtry
+endfunction
+
+function Test_return_with_error()
+  let v = s:foo()
+  call assert_equal(1, v)
+endfunction

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2972,6 +2972,9 @@ ex_return(exarg_T *eap)
     /* It's safer to return also on error. */
     else if (!eap->skip)
     {
+	/* In return statement, cause_abort should be force_abort. */
+	update_force_abort();
+
 	/*
 	 * Return unless the expression evaluation has been cancelled due to an
 	 * aborting error, an interrupt, or an exception.


### PR DESCRIPTION
```vim
function! s:foo()
  try
    return [] == 0
  catch
    return 1
  endtry
endfunction

echo s:foo()
```
This must be 1. But E691 occured.
