### PR TITLE
Fixed buffer overflow in tolower() and toupper() with invalid utf8

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1630,7 +1630,7 @@ strup_save(char_u *orig)
 		newl = utf_char2len(uc);
 		if (newl != l)
 		{
-		    s = alloc((unsigned)STRLEN(res) + 1 + newl - l);
+		    s = alloc((unsigned)STRLEN(res + 1) + 2 + newl - l);
 		    if (s == NULL)
 		    {
 			vim_free(res);
@@ -1693,7 +1693,7 @@ strlow_save(char_u *orig)
 		newl = utf_char2len(lc);
 		if (newl != l)
 		{
-		    s = alloc((unsigned)STRLEN(res) + 1 + newl - l);
+		    s = alloc((unsigned)STRLEN(res + 1) + 2 + newl - l);
 		    if (s == NULL)
 		    {
 			vim_free(res);

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -268,6 +268,10 @@ func Test_tolower()
   " Ⱥ (U+023A) and Ⱦ (U+023E) are the *only* code points to increase
   " in length (2 to 3 bytes) when lowercased. So let's test them.
   call assert_equal("ⱥ ⱦ", tolower("Ⱥ Ⱦ"))
+
+  " This call to tolower with invalid utf8 sequence used to cause access to
+  " invalid memory.
+  call tolower("\xC0\x80\xC0")
 endfunc
 
 func Test_toupper()
@@ -338,6 +342,10 @@ func Test_toupper()
   call assert_equal("ZŹŻŽƵẐẔ", toupper("ZŹŻŽƵẐẔ"))
 
   call assert_equal("Ⱥ Ⱦ", toupper("ⱥ ⱦ"))
+
+  " This call to toupper with invalid utf8 sequence used to cause access to
+  " invalid memory.
+  call toupper("\xC0\x80\xC0")
 endfunc
 
 " Tests for the mode() function


### PR DESCRIPTION
This PR fixes write a buffer overflow when calling tolower() or toupper()
with some invalid utf8 strings.

Step to reproduce:
```
$ valgrind ./vim -u NONE -c 'echo tolower("\xC0\x80\xC0")' -cq 2>valgrind.log
```
And observe this error in valgrind.log:

```
==19809== Memcheck, a memory error detector
==19809== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==19809== Using Valgrind-3.14.0.GIT and LibVEX; rerun with -h for copyright info
==19809== Command: ./vim -u NONE -c echo\ tolower("\\xC0\\x80\\xC0") -cq
==19809== 
==19809== Invalid write of size 1
==19809==    at 0x4C30B1F: strcpy (vg_replace_strmem.c:510)
==19809==    by 0x4C734A: strcpy (string3.h:110)
==19809==    by 0x4C734A: strlow_save (misc2.c:1703)
==19809==    by 0x442B46: f_tolower (evalfunc.c:12912)
==19809==    by 0x436984: call_internal_func (evalfunc.c:1020)
==19809==    by 0x5B1A7A: call_func (userfunc.c:1446)
==19809==    by 0x5B15AB: get_func_tv (userfunc.c:455)
==19809==    by 0x435DC5: eval7 (eval.c:4400)
==19809==    by 0x435702: eval6 (eval.c:4037)
==19809==    by 0x435402: eval5 (eval.c:3853)
==19809==    by 0x434C6E: eval4 (eval.c:3552)
==19809==    by 0x434B34: eval3 (eval.c:3469)
==19809==    by 0x42B035: eval2 (eval.c:3401)
==19809==    by 0x42B035: eval1 (eval.c:3329)
==19809==  Address 0x78d8863 is 1 bytes after a block of size 2 alloc'd
==19809==    at 0x4C2DBF6: malloc (vg_replace_malloc.c:299)
==19809==    by 0x4C6605: lalloc (misc2.c:976)
==19809==    by 0x4C730D: alloc (misc2.c:874)
==19809==    by 0x4C730D: strlow_save (misc2.c:1696)
==19809==    by 0x442B46: f_tolower (evalfunc.c:12912)
==19809==    by 0x436984: call_internal_func (evalfunc.c:1020)
==19809==    by 0x5B1A7A: call_func (userfunc.c:1446)
==19809==    by 0x5B15AB: get_func_tv (userfunc.c:455)
==19809==    by 0x435DC5: eval7 (eval.c:4400)
==19809==    by 0x435702: eval6 (eval.c:4037)
==19809==    by 0x435402: eval5 (eval.c:3853)
==19809==    by 0x434C6E: eval4 (eval.c:3552)
==19809==    by 0x434B34: eval3 (eval.c:3469)
(more errors after that)
```

The problem comes from the fact that c = utf_ptr2char(p);
can return 0 on some invalid utf8 sequences at misc2.c:1687
and then calling STRLEN(res) at misc2.c:1696 computes
the buffer length incorrectly.

The proposed change in this PR fixes the issue.  But it might 
be better to change utf_ptr2char() instead, so that it does not
return 0 on an invalid byte sequence. The comment of utf8_ptr2char()
states that it returns the first byte in case of invalid utf8 sequence
but that's not true in all cases, since utf8_ptr2char() returns 0
with the 0xC0 0x80 sequence.

Bug was found by using afl-fuzz.