### PR TITLE
Add hl-Terminal helpdoc

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5031,6 +5031,8 @@ TabLine		tab pages line, not active tab page label
 TabLineFill	tab pages line, where there are no labels
 							*hl-TabLineSel*
 TabLineSel	tab pages line, active tab page label
+							*hl-Terminal*
+Terminal	|terminal| window (see |terminal-size-color|)
 							*hl-Title*
 Title		titles for output from ":set all", ":autocmd" etc.
 							*hl-Visual*

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6914,6 +6914,10 @@ static char *(highlight_init_both[]) = {
 	 "TabLineSel term=bold cterm=bold gui=bold"),
     CENT("TabLineFill term=reverse cterm=reverse",
 	 "TabLineFill term=reverse cterm=reverse gui=reverse"),
+#ifdef FEAT_TERMINAL
+    CENT("Terminal ctermfg=NONE ctermbg=NONE",
+	 "Terminal ctermfg=NONE ctermbg=NONE guifg=NONE guibg=NONE"),
+#endif
 #ifdef FEAT_GUI
     "Cursor guibg=fg guifg=bg",
     "lCursor guibg=fg guifg=bg", /* should be different, but what? */


### PR DESCRIPTION
* Add `hl-Terminal` description to helpdoc
* Set default `Terminal` hightlight group in order to show `Terminal` at `:hi <C-D>` (completion)