### PR TITLE
Fix execute() in completion function

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2886,6 +2886,7 @@ f_execute(typval_T *argvars, typval_T *rettv)
     int		save_emsg_silent = emsg_silent;
     int		save_emsg_noredir = emsg_noredir;
     int		save_redir_execute = redir_execute;
+    int		save_redir_off = redir_off;
     garray_T	save_ga;
 
     rettv->vval.v_string = NULL;
@@ -2928,6 +2929,7 @@ f_execute(typval_T *argvars, typval_T *rettv)
 	save_ga = redir_execute_ga;
     ga_init2(&redir_execute_ga, (int)sizeof(char), 500);
     redir_execute = TRUE;
+    redir_off = FALSE;
 
     if (cmd != NULL)
 	do_cmdline_cmd(cmd);
@@ -2958,6 +2960,7 @@ f_execute(typval_T *argvars, typval_T *rettv)
     redir_execute = save_redir_execute;
     if (redir_execute)
 	redir_execute_ga = save_ga;
+    redir_off = save_redir_off;
 
     /* "silent reg" or "silent echo x" leaves msg_col somewhere in the
      * line.  Put it back in the first column. */

--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -206,3 +206,15 @@ func Test_CmdCompletion()
   com! -complete=customlist,CustomComp DoCmd :
   call assert_fails("call feedkeys(':DoCmd \<C-D>', 'tx')", 'E117:')
 endfunc
+
+func CallExecute(A, L, P)
+  " Drop first '\n'
+  return execute('echo "hi"')[1:]
+endfunc
+
+func Test_use_execute_in_completion()
+  command! -nargs=* -complete=custom,CallExecute DoExec :
+  call feedkeys(":DoExec \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoExec hi', @:)
+  delcommand DoExec
+endfunc


### PR DESCRIPTION
## Problem (reported by @thinca)

`execute()` returns empty result when used in completion function of user-defined command.

## Repro steps

test.vim

```vim
function! Complete(arglist, cmdline, cursorpos) abort
  let s = execute('echo "hi"')
  " drop first '\n'
  return s[1:]
endfunction
command! -nargs=* -complete=custom,Complete Test :
```

`vim --clean -S test.vim`

```vim
:Test <C-A>
```

Expected: `:Test hi`
Actual: `:Test `

## Cause

In `f_execute`, `redir_off` is kept `TRUE`.

Ozaki Kiichi


