### PR TITLE
win32: Fix D&D by disabling HighEntropyVA

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1179,6 +1179,13 @@ LINKARGS1 = $(LINKARGS1) /LTCG:STATUS
 !endif
 !endif
 
+!if $(MSVC_MAJOR) >= 11 && "$(CPU)" == "AMD64" && "$(GUI)" == "yes"
+# This option is required for VC2012 or later so that 64-bit gvim can
+# accept D&D from 32-bit applications.  NOTE: This disables 64-bit ASLR,
+# therefore the security level becomes as same as VC2010.
+LINKARGS1 = $(LINKARGS1) /HIGHENTROPYVA:NO
+!endif
+
 all:	$(VIM).exe \
 	vimrun.exe \
 	install.exe \


### PR DESCRIPTION
Few weeks ago, I had a report that Drag & Drop stopped working with `E341` starting from the 8.0.0960 binary in the vim/vim-win32-installer repository. At first, I didn't understand why it happened, because the main difference before 8.0.0960 and after it in that repository was only the version of VC++ (2010 vs. 2015).

After some investigation, I found an interesting behavior. (May be a bug of Windows?)
It happens when the following conditions are met:

* 64-bit Windows with version 8.0 or later.
* 64-bit gvim is compiled by VC2012 or later with the [`/HIGHENTROPYVA`](https://msdn.microsoft.com/en-us/library/jj835761.aspx) linker option. (This is the default starting from VC2012.)
* Start D&D from a 32-bit application.

The hDrop handle passed by `WM_DROPFILES` becomes broken with these conditions.
When D&D'ed from a 32-bit application, the handle seems to be truncated to 32 bits then sign extended to 64 bits.

```
Example 1:
hDrop: 0x00000000_471100A8 (From 32-bit application)
hDrop: 0x00000298_471100B8 (From 64-bit application)

Example 2:
hDrop: 0xFFFFFFFF_CCF300A8 (From 32-bit application)
hDrop: 0x0000023A_CCF300B8 (From 64-bit application)
```

If this broken handle is passed to `DragQueryFile()` (in `_OnDropFiles()` in `gui_w32.c`), it fails with a return value 0. (If `GetLastError()` is called here, it will return `ERROR_INVALID_HANDLE`.) Then `alloc()` fails with `E341`.

If the `/HIGHENTROPYVA:NO` linker option is specified, this problem doesn't occur. 32-bit applications can D&D to 64-bit vim.