### PR TITLE
Fix TabClosed: trigger it in win_close_othertab

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -917,7 +917,8 @@ Syntax				When the 'syntax' option has been set.  The
 				the new value of 'syntax'.
 				See |:syn-on|.
 							*TabClosed*
-TabClosed			After closing a tab page.
+TabClosed			After closing a tab page. <afile> can be used
+				for the tab page number.
 							*TabEnter*
 TabEnter			Just after entering a tab page. |tab-page|
 				After triggering the WinEnter and before

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7652,10 +7652,6 @@ tabpage_close_other(tabpage_T *tp, int forceit)
 	    break;
     }
 
-#ifdef FEAT_AUTOCMD
-    apply_autocmds(EVENT_TABCLOSED, NULL, NULL, FALSE, curbuf);
-#endif
-
     redraw_tabline = TRUE;
     if (h != tabline_height())
 	shell_new_rows();

--- a/src/window.c
+++ b/src/window.c
@@ -2155,11 +2155,6 @@ close_windows(
 
     --RedrawingDisabled;
 
-#ifdef FEAT_AUTOCMD
-    if (count != tabpage_index(NULL))
-	apply_autocmds(EVENT_TABCLOSED, NULL, NULL, FALSE, curbuf);
-#endif
-
     redraw_tabline = TRUE;
     if (h != tabline_height())
 	shell_new_rows();
@@ -2242,7 +2237,6 @@ close_last_window_tabpage(
 	/* Since goto_tabpage_tp above did not trigger *Enter autocommands, do
 	 * that now. */
 #ifdef FEAT_AUTOCMD
-	apply_autocmds(EVENT_TABCLOSED, NULL, NULL, FALSE, curbuf);
 	apply_autocmds(EVENT_WINENTER, NULL, NULL, FALSE, curbuf);
 	apply_autocmds(EVENT_TABENTER, NULL, NULL, FALSE, curbuf);
 	if (old_curbuf != curbuf)
@@ -2528,6 +2522,10 @@ win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
     /* When closing the last window in a tab page remove the tab page. */
     if (tp->tp_firstwin == tp->tp_lastwin)
     {
+#ifdef FEAT_AUTOCMD
+	char_u prev_idx[NUMBUFLEN];
+       vim_snprintf((char *)prev_idx, NUMBUFLEN, "%i", tabpage_index(tp));
+#endif
 	if (tp == first_tabpage)
 	    first_tabpage = tp->tp_next;
 	else
@@ -2543,6 +2541,9 @@ win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
 	    ptp->tp_next = tp->tp_next;
 	}
 	free_tp = TRUE;
+#ifdef FEAT_AUTOCMD
+	apply_autocmds(EVENT_TABCLOSED, prev_idx, prev_idx, FALSE, curbuf);
+#endif
     }
 
     /* Free the memory used for the window. */


### PR DESCRIPTION
This sets `<afile>` to the tab page number, as originally done in
https://groups.google.com/d/msg/vim_dev/bduueOtT-4c/-ow4iDKJHTAJ.

Via https://github.com/neovim/neovim/issues/7781.
Via https://github.com/neovim/neovim/pull/7782.

Tests were added for Neovim in https://github.com/neovim/neovim/pull/7782, but since I am not sure about if the `<afile>` change gets accepted, I've not looked into porting them.