### PR TITLE
win32: Make installer faster

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -480,14 +480,12 @@ Function SetCustom
 	# Display the InstallOptions dialog
 
 	# Check if a _vimrc should be created
-	SectionGetFlags ${sec_vimrc_id} $0
-	IntOp $0 $0 & 1
-	StrCmp $0 "1" +2 0
+	SectionGetFlags ${sec_vimrc_id} $3
+	IntOp $3 $3 & 1
+	StrCmp $3 "1" +2 0
 	  Abort
 
-	Push $3
-	  InstallOptions::dialog "$PLUGINSDIR\vimrc.ini"
-	  Pop $3
+	InstallOptions::dialog "$PLUGINSDIR\vimrc.ini"
 	Pop $3
 FunctionEnd
 

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -89,6 +89,11 @@ Page instfiles
 UninstPage uninstConfirm
 UninstPage instfiles
 
+# Reserve files
+# Needed for showing the _vimrc setting page faster.
+ReserveFile /plugin InstallOptions.dll
+ReserveFile vimrc.ini
+
 ##########################################################
 # Functions
 


### PR DESCRIPTION
After 8.0.1232, the _vimrc setting page of the installer takes a few seconds to be opened.  This makes it faster.

See: http://nsis.sourceforge.net/Reference/ReserveFile