### PR TITLE
make manpager.vim self-contained

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -602,7 +602,7 @@ MANPAGER				      *manpager.vim*
 The :Man command allows you to turn Vim into a manpager (that syntax highlights
 manpages and follows linked manpages on hitting CTRL-]).
 
-Works on:
+Tested on:
 
   - Linux
   - Mac OS
@@ -617,25 +617,36 @@ Untested:
   - BeOS
   - OS/2
 
-For bash,zsh,ksh or dash by adding to the config file (.bashrc,.zshrc, ...)
+If man sets the $MAN_PN environment variable, like man-db, the most common
+implementation on Linux, then the "env MAN_PN=1 " part below should NOT be
+set, that is, the "env MAN_PN=1" should be omitted! Otherwise, the Vim 
+manpager does not correctly recognize manpages whose title contains a capital 
+letter. See the discussion on
+
+  https://groups.google.com/forum/#!topic/vim_dev/pWZmt_7GkxI
+
+For bash,zsh,ksh or dash, add to the config file (.bashrc,.zshrc, ...)
 
 	export MANPAGER="env MAN_PN=1 vim -M +MANPAGER -"
+
+For (t)csh, add to the config file
+
+	setenv MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
+
+For fish, add to the config file
+
+	set -x MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
 
 On OpenBSD:
 
         export MANPAGER="env MAN_PN=1 vim -M +MANPAGER"
 
-For (t)csh by adding to the config file
+If you experience still issues on manpages whose titles do not contain capital
+letters, then try adding MANPATH=${MANPATH} after MAN_PN=1. If your manpages do
+not show up localized, then try adding, LANGUAGE=${LANG} after MAN_PN=1. See
 
-	setenv MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
+  https://github.com/vim/vim/issues/1002
 
-For fish by adding to the config file
-
-	set -x MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
-
-If man sets the $MAN_PN environment variable, like man-db, the most common
-implementation on Linux and Mac OS, then the "env MAN_PN=1 " part above is
-superfluous.
 
 PDF							*ft-pdf-plugin*
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,4 +1,5 @@
-*filetype.txt*  For Vim version 8.0.  Last change: 2017 Oct 10
+
+*filetype.txt*  For Vim version 8.0.  Last change: 2017 Dec 05
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -602,51 +603,17 @@ MANPAGER				      *manpager.vim*
 The :Man command allows you to turn Vim into a manpager (that syntax highlights
 manpages and follows linked manpages on hitting CTRL-]).
 
-Tested on:
-
-  - Linux
-  - Mac OS
-  - FreeBSD
-  - OpenBSD
-  - Cygwin
-  - Win 10 under Bash
-
-Untested:
-
-  - Amiga OS
-  - BeOS
-  - OS/2
-
-If man sets the $MAN_PN environment variable, like man-db, the most common
-implementation on Linux, then the "env MAN_PN=1 " part below should NOT be
-set, that is, the "env MAN_PN=1" should be omitted! Otherwise, the Vim 
-manpager does not correctly recognize manpages whose title contains a capital 
-letter. See the discussion on
-
-  https://groups.google.com/forum/#!topic/vim_dev/pWZmt_7GkxI
-
 For bash,zsh,ksh or dash, add to the config file (.bashrc,.zshrc, ...)
 
-	export MANPAGER="env MAN_PN=1 vim -M +MANPAGER -"
+	export MANPAGER="vim -M +MANPAGER -"
 
 For (t)csh, add to the config file
 
-	setenv MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
+	setenv MANPAGER "vim -M +MANPAGER -"
 
 For fish, add to the config file
 
-	set -x MANPAGER "env MAN_PN=1 vim -M +MANPAGER -"
-
-On OpenBSD:
-
-        export MANPAGER="env MAN_PN=1 vim -M +MANPAGER"
-
-If you experience still issues on manpages whose titles do not contain capital
-letters, then try adding MANPATH=${MANPATH} after MAN_PN=1. If your manpages do
-not show up localized, then try adding, LANGUAGE=${LANG} after MAN_PN=1. See
-
-  https://github.com/vim/vim/issues/1002
-
+	set -x MANPAGER "vim -M +MANPAGER -"
 
 PDF							*ft-pdf-plugin*
 
@@ -704,6 +671,25 @@ You can change the default by defining the variable g:tex_flavor to the format
 	let g:tex_flavor = "context"
 	let g:tex_flavor = "latex"
 Currently no other formats are recognized.
+
+
+VIM							*ft-vim-plugin*
+
+The Vim filetype plugin defines mappings to move to the start and end of
+functions with [[ and ]].  Move around comments with ]" and [".
+
+The mappings can be disabled with: >
+	let g:no_vim_maps = 1
+
+
+ZIMBU							*ft-zimbu-plugin*
+
+The Zimbu filetype plugin defines mappings to move to the start and end of
+functions with [[ and ]].
+
+The mappings can be disabled with: >
+	let g:no_zimbu_maps = 1
+<
 
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -1,29 +1,30 @@
 " Vim plugin for using Vim as manpager.
 " Maintainer: Enno Nagel <ennonagel+vim@gmail.com>
-" Last Change: 2017 November 07
+" Last Change: 2018 January 05
 
-" $MAN_PN is supposed to be set by MANPAGER, see ":help manpager.vim".
-if empty($MAN_PN)
-  finish
-endif
+command! -nargs=0 MANPAGER call s:ManPager() | delcommand MANPAGER
 
-command! -nargs=0 MANPAGER call s:MANPAGER() | delcommand MANPAGER
-
-function! s:MANPAGER()
-  let page_pattern = '\v\w[-_.:0-9A-Za-z]*'
-  let sec_pattern = '\v\w+%(\+\w+)*'
-  let pagesec_pattern = '\v(' . page_pattern . ')\((' . sec_pattern . ')\)'
-
-  if $MAN_PN is '1'
-    let manpage = tolower(matchstr( getline(nextnonblank(1)), '^' . pagesec_pattern ))
-  else
-    let manpage = expand($MAN_PN)
+function! s:ManPager()
+  set nocompatible
+  if exists('+viminfofile')
+    set viminfofile=NONE
   endif
+  set noswapfile 
 
-  let page_sec = matchlist(manpage, '^' . pagesec_pattern  . '$')
+  setlocal ft=man
+  runtime ftplugin/man.vim
+  setlocal buftype=nofile bufhidden=hide iskeyword+=: modifiable
 
-  bwipe!
+  " Emulate 'col -b'
+  silent keepj keepp %s/\v(.)\b\ze\1?//ge
 
-  setlocal filetype=man
-  exe 'Man' page_sec[2] page_sec[1]
+  " Remove empty lines above the header
+  call cursor(1, 1)
+  let n = search(".*(.*)", "c")
+  if n > 1
+    exe "1," . n-1 . "d"
+  endif
+  setlocal nomodified readonly
+
+  syntax on
 endfunction

--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -15,7 +15,7 @@ function! s:MANPAGER()
   let pagesec_pattern = '\v(' . page_pattern . ')\((' . sec_pattern . ')\)'
 
   if $MAN_PN is '1'
-    let manpage = matchstr( getline(1), '^' . pagesec_pattern )
+    let manpage = matchstr( getline(nextnonblank(1)), '^' . pagesec_pattern )
   else
     let manpage = expand('$MAN_PN')
   endif

--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -17,7 +17,7 @@ function! s:MANPAGER()
   if $MAN_PN is '1'
     let manpage = tolower(matchstr( getline(nextnonblank(1)), '^' . pagesec_pattern ))
   else
-    let manpage = $MAN_PN
+    let manpage = expand($MAN_PN)
   endif
 
   let page_sec = matchlist(manpage, '^' . pagesec_pattern  . '$')

--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -1,6 +1,6 @@
 " Vim plugin for using Vim as manpager.
 " Maintainer: Enno Nagel <ennonagel+vim@gmail.com>
-" Last Change: 2016 May 20
+" Last Change: 2017 November 07
 
 " $MAN_PN is supposed to be set by MANPAGER, see ":help manpager.vim".
 if empty($MAN_PN)
@@ -10,17 +10,17 @@ endif
 command! -nargs=0 MANPAGER call s:MANPAGER() | delcommand MANPAGER
 
 function! s:MANPAGER()
-  let page_pattern = '\v\w+%([-_.]\w+)*'
+  let page_pattern = '\v\w[-_.:0-9A-Za-z]*'
   let sec_pattern = '\v\w+%(\+\w+)*'
   let pagesec_pattern = '\v(' . page_pattern . ')\((' . sec_pattern . ')\)'
 
   if $MAN_PN is '1'
-    let manpage = matchstr( getline(nextnonblank(1)), '^' . pagesec_pattern )
+    let manpage = tolower(matchstr( getline(nextnonblank(1)), '^' . pagesec_pattern ))
   else
-    let manpage = expand('$MAN_PN')
+    let manpage = $MAN_PN
   endif
 
-  let page_sec = matchlist(tolower(manpage), '^' . pagesec_pattern  . '$')
+  let page_sec = matchlist(manpage, '^' . pagesec_pattern  . '$')
 
   bwipe!
 


### PR DESCRIPTION
As discussed in https://github.com/vim/vim/issues/2323#issuecomment-346626606

this new implementation does no longer depend on `ftplugin/man.vim` and thus is stabler than the ancient hack.