### PR TITLE
ex: switch to line buffering in silent mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -359,6 +359,10 @@ main
      */
     check_tty(&params);
 
+    /* Ensure printing works usefully without a tty. */
+    if (silent_mode)
+	setvbuf(stdout, NULL, _IOLBF, 0);
+
     /* This message comes before term inits, but after setting "silent_mode"
      * when the input is not a tty. */
     if (GARGCOUNT > 1 && !silent_mode)


### PR DESCRIPTION
When ex is run without a TTY, it enters silent mode.  When in that mode,
the terminal is not initialized, and we use printf to display output
from :print and other commands.  Since without a TTY, stdio is by
default fully buffered, the :print command does not actually display
anything until the buffer is full or the program exits.  This prevents
usefully using ex interactively on a dumb terminal or otherwise without
a TTY.  Switch the default buffering to line-buffered mode when silent
mode is enabled to address this issue.

No negative impact should occur when using ex in silent mode with a TTY,
as stdio will already have been line buffered there.

Fixes #2399.