### PR TITLE
WIP: Fix passed timeout with backwards searchpair

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -973,7 +973,13 @@ searchit(
 					      NULL, NULL
 #endif
 					    )) == 0)
+			    {
+#ifdef FEAT_RELTIME
+				if (timed_out != NULL && *timed_out)
+				    match_ok = false;
+#endif
 				break;
+			    }
 
 			    /* Need to get the line pointer again, a
 			     * multi-line search may have made it invalid. */

--- a/src/search.c
+++ b/src/search.c
@@ -976,7 +976,7 @@ searchit(
 			    {
 #ifdef FEAT_RELTIME
 				if (timed_out != NULL && *timed_out)
-				    match_ok = false;
+				    match_ok = FALSE;
 #endif
 				break;
 			    }


### PR DESCRIPTION
searchpair(pos) might return an invalid value in case a timeout is used.

This can be triggered using `searchpairpos('(', '', ')', 'bnW', '', 1,
500)` (not reliably, but very often from line 1818 of
    https://github.com/vim-jp/vim-vimlparser/blob/9eb216ff880d7b7fee036f096b6ad822651ea4db/py/vimlparser.py#L1818).

This is a WIP PR to check if any existing tests are failing.
For Neovim: https://github.com/neovim/neovim/pull/7852