### PR TITLE
Fix: the script exited accidentally in some cases

### DIFF
--- a/vimtutor.bat
+++ b/vimtutor.bat
@@ -10,7 +10,7 @@
 :: When that also fails, it uses the English version.
 
 :: Use Vim to copy the tutor, it knows the value of $VIMRUNTIME
-FOR %%d in (. %TMP% %TEMP%) DO IF EXIST %%d\nul SET TUTORCOPY=%%d\$tutor$
+FOR %%d in (. "%TMP%" "%TEMP%") DO IF EXIST %%d\nul SET TUTORCOPY=%%d\$tutor$
 
 SET xx=%1
 


### PR DESCRIPTION
When %TMP% or %TEMP% contains special characters as below, some problem may show up.
1. `&` - the script terminated with an error `& was unexpected at this time.`
2. ` ` - The path will be separated into two pieces unexpectedly

using `"%TMP%"` instead of `%TMP%` can fix these problems.