### PR TITLE
Add support for filetype detection of Clojure scripts

### DIFF
--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -172,6 +172,10 @@ if s:line1 =~# "^#!"
   elseif s:name =~# 'scala\>'
     set ft=scala
 
+    " Clojure
+  elseif s:name =~# 'clojure'
+    set ft=clojure
+
   endif
   unlet s:name
 


### PR DESCRIPTION
Recently Clojure 1.9 was released. That release added support for
writing Clojure scripts by using a shebang line like the following:

    #!/usr/bin/env clojure

This patch updates `runtime/scripts.vim` to detect the filetype of such
Clojure scripts.

Thank you!
