### PR TITLE
Fix formatting and remove some trailing spaces

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -433,7 +433,7 @@ An example for using CTRL-G U: >
 	inoremap ( ()<C-G>U<Left>
 
 This makes it possible to use the cursor keys in Insert mode, without breaking
-the undo sequence and therefore using |.| (redo) will work as expected. 
+the undo sequence and therefore using |.| (redo) will work as expected.
 Also entering a text like (with the "(" mapping from above): >
 
    Lorem ipsum (dolor
@@ -1473,7 +1473,7 @@ The completions provided by CTRL-X CTRL-O are sensitive to the context:
 
 Notes:
  - Vim will load/evaluate code in order to provide completions.  This may
-   cause some code execution, which may be a concern. This is no longer 
+   cause some code execution, which may be a concern. This is no longer
    enabled by default, to enable this feature add >
      let g:rubycomplete_buffer_loading = 1
 <- In context 1 above, Vim can parse the entire buffer to add a list of
@@ -1529,15 +1529,15 @@ that begin with the filetype, "php", in this case.  For example these syntax
 groups are included by default with the PHP: phpEnvVar, phpIntVar,
 phpFunctions.
 
-If you wish non-filetype syntax items to also be included, you can use a 
-regular expression syntax (added in version 13.0 of autoload\syntaxcomplete.vim)
-to add items.  Looking at the output from ":syntax list" while editing a PHP file 
-I can see some of these entries: >
+If you wish non-filetype syntax items to also be included, you can use a
+regular expression syntax (added in version 13.0 of
+autoload\syntaxcomplete.vim) to add items.  Looking at the output from
+":syntax list" while editing a PHP file I can see some of these entries: >
     htmlArg,htmlTag,htmlTagName,javaScriptStatement,javaScriptGlobalObjects
 
 To pick up any JavaScript and HTML keyword syntax groups while editing a PHP
-file, you can use 3 different regexs, one for each language.  Or you can 
-simply restrict the include groups to a particular value, without using 
+file, you can use 3 different regexs, one for each language.  Or you can
+simply restrict the include groups to a particular value, without using
 a regex string: >
     let g:omni_syntax_group_include_php = 'php\w\+,javaScript\w\+,html\w\+'
     let g:omni_syntax_group_include_php = 'phpFunctions,phpMethods'
@@ -1550,9 +1550,9 @@ highlight.  These items will be available within the omni completion list.
 
 Some people may find this list unwieldy or are only interested in certain
 items.  There are two ways to prune this list (if necessary).  If you find
-certain syntax groups you do not wish displayed you can use two different 
-methods to identify these groups.  The first specifically lists the syntax 
-groups by name.  The second uses a regular expression to identify both 
+certain syntax groups you do not wish displayed you can use two different
+methods to identify these groups.  The first specifically lists the syntax
+groups by name.  The second uses a regular expression to identify both
 syntax groups.  Simply add one the following to your vimrc: >
     let g:omni_syntax_group_exclude_php = 'phpCoreConstant,phpConstant'
     let g:omni_syntax_group_exclude_php = 'php\w*Constant'
@@ -1575,22 +1575,22 @@ vimrc: >
 
 For plugin developers, the plugin exposes a public function OmniSyntaxList.
 This function can be used to request a List of syntax items.  When editing a
-SQL file (:e syntax.sql) you can use the ":syntax list" command to see the 
+SQL file (:e syntax.sql) you can use the ":syntax list" command to see the
 various groups and syntax items.  For example: >
-    syntax list 
+    syntax list
 
 Yields data similar to this: >
-    sqlOperator    xxx some prior all like and any escape exists in is not 
+    sqlOperator    xxx some prior all like and any escape exists in is not
                        or intersect minus between distinct
                        links to Operator
-    sqlType        xxx varbit varchar nvarchar bigint int uniqueidentifier 
-                       date money long tinyint unsigned xml text smalldate 
-                       double datetime nchar smallint numeric time bit char 
+    sqlType        xxx varbit varchar nvarchar bigint int uniqueidentifier
+                       date money long tinyint unsigned xml text smalldate
+                       double datetime nchar smallint numeric time bit char
                        varbinary binary smallmoney
                        image float integer timestamp real decimal
 
 There are two syntax groups listed here: sqlOperator and sqlType.  To retrieve
-a List of syntax items you can call OmniSyntaxList a number of different 
+a List of syntax items you can call OmniSyntaxList a number of different
 ways.  To retrieve all syntax items regardless of syntax group:  >
     echo OmniSyntaxList( [] )
 
@@ -1607,7 +1607,7 @@ From within a plugin, you would typically assign the output to a List: >
     let myKeywords = []
     let myKeywords = OmniSyntaxList( ['sqlKeyword'] )
 
-    
+
 
 SQL							*ft-sql-omni*
 

--- a/runtime/doc/usr_27.txt
+++ b/runtime/doc/usr_27.txt
@@ -224,10 +224,10 @@ specify a line offset, this can cause trouble.  For example: >
 
 	/const/-2
 
-This finds the next word "const" and then moves two lines up.  If you
-use "n" to search again, Vim could start at the current position and find the same
-"const" match.  Then using the offset again, you would be back where you started.
-You would be stuck!
+This finds the next word "const" and then moves two lines up.  If you use "n"
+to search again, Vim could start at the current position and find the same
+"const" match.  Then using the offset again, you would be back where you
+started.  You would be stuck!
    It could be worse: Suppose there is another match with "const" in the next
 line.  Then repeating the forward search would find this match and move two
 lines up.  Thus you would actually move the cursor back!


### PR DESCRIPTION
The doc files `insert.txt` and `usr_27.txt` had non-example texts having 80 character-long lines. The display was messy.

I have also removed some trailing spaces in `insert.txt`.