### PR TITLE
[PATCH] cscope: vim hangs when a tag is not found

### DIFF
--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -677,7 +677,7 @@ cs_cnt_matches(int idx)
 {
     char *stok;
     char *buf;
-    int nlines;
+    int nlines=0;
 
     buf = (char *)alloc(CSREAD_BUFSIZE);
     if (buf == NULL)
@@ -703,6 +703,12 @@ cs_cnt_matches(int idx)
 	 */
 	if ((stok = strtok(buf, (const char *)" ")) == NULL)
 	    continue;
+	/*
+	 * When the search() function in cscope encounters an error or does not
+	 * not find the pattern it returns this message
+	 */
+	if (strstr((const char *)stok, "Unable to search database") == NULL)
+	    break;
 	if (strstr((const char *)stok, "cscope:") == NULL)
 	    continue;
 


### PR DESCRIPTION
cs_cnt_matches():
  When cscope does not find a tag, it returns "Unable to search database", and thus:
```
    if (strstr((const char *)stok, "cscope:") == NULL)
      continue;
```
  should become:
```
    if (strstr((const char *)stok, "cscope:") == NULL)
      break;
```
  and return nlines which must be initialized at zero.
  Continuing does not make sens, and results in a buffer underflow on my machine when the loop calls fgets for the second time.

cscope version: 15.8b
vim version: v8.0.1437
uname -r: 4.9.65