### PR TITLE
Fix: handling terminal response sequences on `:terminal`

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -650,14 +650,49 @@ free_terminal(buf_T *buf)
 }
 
 /*
+ * Get the part that is connected to the tty. Normally this is PART_IN, but
+ * when writing buffer lines to the job it can be another.  This makes it
+ * possible to do "1,5term vim -".
+ */
+    static ch_part_T
+get_tty_part(term_T *term)
+{
+#ifdef UNIX
+    ch_part_T	parts[3] = {PART_IN, PART_OUT, PART_ERR};
+    int		i;
+
+    for (i = 0; i < 3; ++i)
+    {
+	int fd = term->tl_job->jv_channel->ch_part[parts[i]].ch_fd;
+
+	if (isatty(fd))
+	    return parts[i];
+    }
+#endif
+    return PART_IN;
+}
+
+/*
  * Write job output "msg[len]" to the vterm.
  */
     static void
 term_write_job_output(term_T *term, char_u *msg, size_t len)
 {
     VTerm	*vterm = term->tl_vterm;
+    size_t	prevlen = vterm_output_get_buffer_current(vterm);
 
     vterm_input_write(vterm, (char *)msg, len);
+
+    /* flush vterm buffer when vterm responded to control sequence */
+    if (prevlen != vterm_output_get_buffer_current(vterm))
+    {
+	char msg[KEY_BUF_LEN];
+	size_t len = vterm_output_read(vterm, msg, KEY_BUF_LEN);
+
+	if (len > 0)
+	    channel_send(term->tl_job->jv_channel, get_tty_part(term),
+						(char_u *)msg, (int)len, NULL);
+    }
 
     /* this invokes the damage callbacks */
     vterm_screen_flush_damage(vterm_obtain_screen(vterm));
@@ -1236,29 +1271,6 @@ term_vgetc()
     got_int = FALSE;
     State = save_State;
     return c;
-}
-
-/*
- * Get the part that is connected to the tty. Normally this is PART_IN, but
- * when writing buffer lines to the job it can be another.  This makes it
- * possible to do "1,5term vim -".
- */
-    static ch_part_T
-get_tty_part(term_T *term)
-{
-#ifdef UNIX
-    ch_part_T	parts[3] = {PART_IN, PART_OUT, PART_ERR};
-    int		i;
-
-    for (i = 0; i < 3; ++i)
-    {
-	int fd = term->tl_job->jv_channel->ch_part[parts[i]].ch_fd;
-
-	if (isatty(fd))
-	    return parts[i];
-    }
-#endif
-    return PART_IN;
 }
 
 /*

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -619,6 +619,8 @@ func Test_search_cmdline_incsearch_highlight_attr()
   let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
 
   call WaitFor({-> lines == [term_getline(buf, 1), term_getline(buf, 2)] })
+  " wait for vim to complete initialization
+  call term_wait(buf)
 
   " Get attr of normal(a0), incsearch(a1), hlsearch(a2) highlight
   call term_sendkeys(buf, ":set incsearch hlsearch\<cr>")


### PR DESCRIPTION
## Problem summary (reported by @tyru)

On `:terminal`, when sending a terminal control sequence, the response is not done until user input occurs.

## Repro steps

On bash on common terminal:

```
$ echo -e "\e[6n"

$ ;1R
```

`;1R`, a part of the response sequence of "report cursor position", is displayed.

On bash on vim `:terminal`: `vim --clean +'term bash'`

```
$ echo -e "\e[6n"

$ 
```

No output of the response is shown.
And when user gives any key input, `;1R` (response sequence) would be displayed.

### Another example

test.c

```c
#include <unistd.h>
int main(void)
{
    char buf[1] = {0};
    write(1, "\e[6n", 4);
    read(0, buf, 1);
    return 0;
}
```

```
$ gcc test.c
$ ./a.out
```

On common terminal, `a.out` would return immediately.
On vim `:terminal`, `read()` would block until user input occurs. 

## Cause

Steps of processing:

1. Program (above `echo`, `a.out`) writes the control sequence into stdout (pty slave).
2. Vim receives it from pty master and sends to libvterm.
3. libvterm makes the response seqence and writes it to own output buffer.
4. Vim reads out from libvterm output buffer at a certain timing, and writes its contents into pty master.
5. Program does `read()` it from stdin.

`A certain timing` of step 4 is "when user input occurs", so `read()` of step 5 blocks.

## Solution proposal

* Check the output buffer of libvterm just after step 3, and when it has changed, Vim writes it into pty

Ozaki Kiichi