### PR TITLE
Force -D_FILE_OFFSET_BITS=64 if any other CFLAGS have it

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -14314,6 +14314,18 @@ $as_echo "no" >&6; }
 fi
 
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need to force -D_FILE_OFFSET_BITS=64" >&5
+$as_echo_n "checking whether we need to force -D_FILE_OFFSET_BITS=64... " >&6; }
+if echo "$CFLAGS $LUA_CFLAGS $MZSCHEME_CFLAGS $PERL_CFLAGS $PYTHON_GETPATH_CFLAGS $PYTHON_CFLAGS $PYTHON3_CFLAGS $TCL_CFLAGS $RUBY_CFLAGS $GTK_CFLAGS" | grep -q D_FILE_OFFSET_BITS 2>/dev/null; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+  $as_echo "#define _FILE_OFFSET_BITS 64" >>confdefs.h
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking linker --as-needed support" >&5
 $as_echo_n "checking linker --as-needed support... " >&6; }
 LINK_AS_NEEDED=

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4366,6 +4366,20 @@ if test "$GCC" = yes; then
 fi
 AC_SUBST(DEPEND_CFLAGS_FILTER)
 
+dnl On some systems AC_SYS_LARGEFILE determines that -D_FILE_OFFSET_BITS=64
+dnl isn't required, but the CFLAGS for some of the libraries we're using
+dnl include the define.  Since the define changes the size of some datatypes
+dnl (e.g. ino_t and off_t), all of Vim's modules must be compiled with a
+dnl consistent value.  It's therefore safest to force the use of the define
+dnl if it's present in any of the *_CFLAGS variables.
+AC_MSG_CHECKING(whether we need to force -D_FILE_OFFSET_BITS=64)
+if echo "$CFLAGS $LUA_CFLAGS $MZSCHEME_CFLAGS $PERL_CFLAGS $PYTHON_GETPATH_CFLAGS $PYTHON_CFLAGS $PYTHON3_CFLAGS $TCL_CFLAGS $RUBY_CFLAGS $GTK_CFLAGS" | grep -q D_FILE_OFFSET_BITS 2>/dev/null; then
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(_FILE_OFFSET_BITS, 64)
+else
+  AC_MSG_RESULT(no)
+fi
+
 dnl link.sh tries to avoid overlinking in a hackish way.
 dnl At least GNU ld supports --as-needed which provides the same functionality
 dnl at linker level. Let's use it.


### PR DESCRIPTION
If AC_SYS_LARGEFILE doesn't detect that -D_FILE_OFFSET_BITS=64 is
required, it's possible that modules which use buf_T will be compiled
with different sizes for the b_ino member.

If that happens, accessing any member after b_ino is going to be using
bogus data.  This has been demonstrated to occur on Debian's alpha port
and kFreeBSD ports when accessing buf->b_p_cino in parse_cino()[0].

[0]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=888566

Although this is due to a glibc bug, I think it's worth working around
it in Vim.