### PR TITLE
Fix: adding package path to `runtimepath`

### DIFF
--- a/src/testdir/test_packadd.vim
+++ b/src/testdir/test_packadd.vim
@@ -37,8 +37,8 @@ func Test_packadd()
   call assert_equal(77, g:plugin_also_works)
   call assert_equal(17, g:ftdetect_works)
   call assert_true(len(&rtp) > len(rtp))
-  call assert_true(&rtp =~ '/testdir/Xdir/pack/mine/opt/mytest\($\|,\)')
-  call assert_true(&rtp =~ '/testdir/Xdir/pack/mine/opt/mytest/after$')
+  call assert_match('/testdir/Xdir/pack/mine/opt/mytest\($\|,\)', &rtp)
+  call assert_match('/testdir/Xdir/pack/mine/opt/mytest/after$', &rtp)
 
   " Check exception
   call assert_fails("packadd directorynotfound", 'E919:')
@@ -60,7 +60,7 @@ func Test_packadd_start()
 
   call assert_equal(24, g:plugin_works)
   call assert_true(len(&rtp) > len(rtp))
-  call assert_true(&rtp =~ '/testdir/Xdir/pack/mine/start/other\($\|,\)')
+  call assert_match('/testdir/Xdir/pack/mine/start/other\($\|,\)', &rtp)
 endfunc
 
 func Test_packadd_noload()
@@ -77,7 +77,7 @@ func Test_packadd_noload()
   packadd! mytest
 
   call assert_true(len(&rtp) > len(rtp))
-  call assert_true(&rtp =~ 'testdir/Xdir/pack/mine/opt/mytest\($\|,\)')
+  call assert_match('testdir/Xdir/pack/mine/opt/mytest\($\|,\)', &rtp)
   call assert_equal(0, g:plugin_works)
 
   " check the path is not added twice
@@ -108,7 +108,7 @@ func Test_packadd_symlink_dir()
   packadd mytest
 
   " Must have been inserted in the middle, not at the end
-  call assert_true(&rtp =~ '/pack/mine/opt/mytest,')
+  call assert_match('/pack/mine/opt/mytest,', &rtp)
   call assert_equal(44, g:plugin_works)
 
   " No change when doing it again.
@@ -196,9 +196,9 @@ func Test_helptags()
   helptags ALL
 
   let tags1 = readfile(docdir1 . '/tags') 
-  call assert_true(tags1[0] =~ 'look-here')
+  call assert_match('look-here', tags1[0])
   let tags2 = readfile(docdir2 . '/tags') 
-  call assert_true(tags2[0] =~ 'look-away')
+  call assert_match('look-away', tags2[0])
 endfunc
 
 func Test_colorscheme()


### PR DESCRIPTION
## Problem summary (reported by @Warashi)

When the package path is in symlink, it is added to unexpected position of `runtimepath`.

## Repro steps

Making the package directory:

```
$ mkdir -p /tmp/pack/test/start/foobar
$ ln -s /tmp/pack ~/.vim/pack
```

vimrc:

```vim
set rtp=~/.vim,~/.vim/after
set pp=~/.vim
```

`vim -Nu vimrc` and `:set rtp`:

expected: `runtimepath=~/.vim,~/.vim/pack/test/start/foobar,~/.vim/after`
(added to the next of `~/.vim`)

actual: `runtimepath=~/.vim,~/.vim/after,/tmp/pack/test/start/foobar`
(added to the end)

## Cause

In `add_pack_plugin()`, when checking if the package path is in `runtimepath`:

1. Resolve the real path of `~/.vim/pack/test/start/foobar`: `/tmp/pack/test/start/foobar`
2. Get the parent dir of "pack/": `/tmp`
3. Check if `/tmp` is in `~/.vim` or `~/.vim/after`: No
4. So `/tmp/pack/test/start/foobar` would be added to the end of `runtimepath`

## Solution proposal

* Don't resolve path of the package when adding to `runtimepath`

Ozaki Kiichi