### PR TITLE
Allow getcwd(-1) to retrieve global dir after :lcd 

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4488,6 +4488,8 @@ getcwd([{winnr} [, {tabnr}]])
 		With {winnr} and {tabnr} return the local current directory of
 		the window in the specified tab page.
 		{winnr} can be the window number or the |window-ID|.
+		If {winnr} is -1 return the name of the global working
+		directory.  See also |haslocaldir()|.
 		Return an empty string if the arguments are invalid.
 
 getfsize({fname})					*getfsize()*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4613,16 +4613,21 @@ f_getcwd(typval_T *argvars, typval_T *rettv)
 {
     win_T	*wp = NULL;
     char_u	*cwd;
+    int		global = FALSE;
 
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = NULL;
 
-    wp = find_tabwin(&argvars[0], &argvars[1]);
-    if (wp != NULL)
+    if (argvars[0].v_type == VAR_NUMBER && argvars[0].vval.v_number == -1)
+	global = TRUE;
+    else
+	wp = find_tabwin(&argvars[0], &argvars[1]);
+
+    if (wp != NULL && wp->w_localdir != NULL)
+	rettv->vval.v_string = vim_strsave(wp->w_localdir);
+    else if (wp != NULL || global)
     {
-	if (wp->w_localdir != NULL)
-	    rettv->vval.v_string = vim_strsave(wp->w_localdir);
-	else if (globaldir != NULL)
+	if (globaldir != NULL)
 	    rettv->vval.v_string = vim_strsave(globaldir);
 	else
 	{

--- a/src/testdir/test_getcwd.vim
+++ b/src/testdir/test_getcwd.vim
@@ -37,6 +37,7 @@ function SetUp()
 	new
 	call mkdir('Xtopdir')
 	cd Xtopdir
+	let g:topdir = getcwd()
 	call mkdir('Xdir1')
 	call mkdir('Xdir2')
 	call mkdir('Xdir3')
@@ -56,36 +57,44 @@ function Test_GetCwd()
 	3wincmd w
 	lcd Xdir1
 	call assert_equal("a Xdir1 1", GetCwdInfo(0, 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	call assert_equal("b Xtopdir 0", GetCwdInfo(0, 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	lcd Xdir3
 	call assert_equal("c Xdir3 1", GetCwdInfo(0, 0))
 	call assert_equal("a Xdir1 1", GetCwdInfo(bufwinnr("a"), 0))
 	call assert_equal("b Xtopdir 0", GetCwdInfo(bufwinnr("b"), 0))
 	call assert_equal("c Xdir3 1", GetCwdInfo(bufwinnr("c"), 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	call assert_equal("a Xdir1 1", GetCwdInfo(bufwinnr("a"), tabpagenr()))
 	call assert_equal("b Xtopdir 0", GetCwdInfo(bufwinnr("b"), tabpagenr()))
 	call assert_equal("c Xdir3 1", GetCwdInfo(bufwinnr("c"), tabpagenr()))
+	call assert_equal(g:topdir, getcwd(-1))
 
 	tabnew x
 	new y
 	new z
 	3wincmd w
 	call assert_equal("x Xtopdir 0", GetCwdInfo(0, 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	lcd Xdir2
 	call assert_equal("y Xdir2 1", GetCwdInfo(0, 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	lcd Xdir3
 	call assert_equal("z Xdir3 1", GetCwdInfo(0, 0))
 	call assert_equal("x Xtopdir 0", GetCwdInfo(bufwinnr("x"), 0))
 	call assert_equal("y Xdir2 1", GetCwdInfo(bufwinnr("y"), 0))
 	call assert_equal("z Xdir3 1", GetCwdInfo(bufwinnr("z"), 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	let tp_nr = tabpagenr()
 	tabrewind
 	call assert_equal("x Xtopdir 0", GetCwdInfo(3, tp_nr))
 	call assert_equal("y Xdir2 1", GetCwdInfo(2, tp_nr))
 	call assert_equal("z Xdir3 1", GetCwdInfo(1, tp_nr))
+	call assert_equal(g:topdir, getcwd(-1))
 endfunc


### PR DESCRIPTION
Problem: There is no easy way to get the global directory.
Solution: Add `getglobaldir()` function to retrieve the global directory regardless of the state of `haslocaldir()`.

Is there some reason this information isn't already exposed?  It seems like a simple and useful addition.

An alternative idea would be to add a special value to `getcwd` which is invalid for windows, for instance `getcwd(-1)` to return the global directory.

