### PR TITLE
Patch to add a function to get the jump list

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2167,7 +2167,8 @@ getfperm({fname})		String	file permissions of file {fname}
 getfsize({fname})		Number	size in bytes of file {fname}
 getftime({fname})		Number	last modification time of file
 getftype({fname})		String	description of type of file {fname}
-getjumplist({tabnr}, {winnr})	List	list of jump list items
+getjumplist([{winnr} [, {tabnr}]])
+				List	list of jump list items
 getline({lnum})			String	line {lnum} of current buffer
 getline({lnum}, {end})		List	lines {lnum} to {end} of current buffer
 getloclist({nr} [, {what}])	List	list of location list items
@@ -4559,16 +4560,18 @@ getftype({fname})					*getftype()*
 		directory returns "dir" instead of "link".
 
 							*getjumplist()*
-getjumplist({tabnr}, {winnr})
-		Returns a list with all the entries in the |jumplist| for
-		window {nr} in tab page {tabnr}.  {nr} can be the window
-		number or the |window-ID|.  When {nr} is zero the current
-		window is used.
+getjumplist([{winnr} [, {tabnr}]])
+		Returns the |jumplist| for window {winnr}.
+
+		Without arguments use the current window.
+		With {winnr} only use this window in the current tab page.
+		With {winnr} and {tabnr} use the window in the specified tab
+		page.
 
 		The returned list contains two entries: a list with the jump
-		locations and the last used jump position in the list.  The
-		jump location list contains a list of dictionaries with the
-		following entries:
+		locations and the last used jump position number in the list.
+		Each entry in the jump location list is a dictionary with
+		the following entries:
 			bufnr		buffer number
 			col		column number
 			coladd		column offset for 'virtualedit'

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2167,6 +2167,7 @@ getfperm({fname})		String	file permissions of file {fname}
 getfsize({fname})		Number	size in bytes of file {fname}
 getftime({fname})		Number	last modification time of file
 getftype({fname})		String	description of type of file {fname}
+getjumplist({tabnr}, {winnr})	List	list of jump list items
 getline({lnum})			String	line {lnum} of current buffer
 getline({lnum}, {end})		List	lines {lnum} to {end} of current buffer
 getloclist({nr} [, {what}])	List	list of location list items
@@ -4556,6 +4557,23 @@ getftype({fname})					*getftype()*
 		systems that support it.  On some systems only "dir" and
 		"file" are returned.  On MS-Windows a symbolic link to a
 		directory returns "dir" instead of "link".
+
+							*getjumplist()*
+getjumplist({tabnr}, {winnr})
+		Returns a list with all the entries in the |jumplist| for
+		window {nr} in tab page {tabnr}.  {nr} can be the window
+		number or the |window-ID|.  When {nr} is zero the current
+		window is used.
+
+		The returned list contains two entries: a list with the jump
+		locations and the last used jump position in the list.  The
+		jump location list contains a list of dictionaries with the
+		following entries:
+			bufnr		buffer number
+			col		column number
+			coladd		column offset for 'virtualedit'
+			filename	filename if available
+			lnum		line number
 
 							*getline()*
 getline({lnum} [, {end}])

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -807,6 +807,7 @@ Buffers, windows and the argument list:
 	getbufinfo()		get a list with buffer information
 	gettabinfo()		get a list with tab page information
 	getwininfo()		get a list with window information
+	getjumplist()		get a list of jump list entries
 
 Command line:					*command-line-functions*
 	getcmdline()		get the current command line

--- a/src/Makefile
+++ b/src/Makefile
@@ -2198,6 +2198,7 @@ test_arglist \
 	test_job_fails \
 	test_join \
 	test_json \
+	test_jumplist \
 	test_jumps \
 	test_lambda \
 	test_langmap \

--- a/src/eval.c
+++ b/src/eval.c
@@ -8443,7 +8443,7 @@ find_win_by_nr(
     if (nr < 0)
 	return NULL;
     if (nr == 0)
-	return (tp == NULL) ? curwin : NULL;
+	return curwin;
 
     FOR_ALL_WINDOWS_IN_TAB(tp, wp)
     {

--- a/src/eval.c
+++ b/src/eval.c
@@ -8443,7 +8443,7 @@ find_win_by_nr(
     if (nr < 0)
 	return NULL;
     if (nr == 0)
-	return curwin;
+	return (tp == NULL) ? curwin : NULL;
 
     FOR_ALL_WINDOWS_IN_TAB(tp, wp)
     {

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -622,7 +622,7 @@ static struct fst
     {"getfsize",	1, 1, f_getfsize},
     {"getftime",	1, 1, f_getftime},
     {"getftype",	1, 1, f_getftype},
-    {"getjumplist",	2, 2, f_getjumplist},
+    {"getjumplist",	0, 2, f_getjumplist},
     {"getline",		1, 2, f_getline},
     {"getloclist",	1, 2, f_getloclist},
     {"getmatches",	0, 0, f_getmatches},
@@ -4836,15 +4836,12 @@ f_getftype(typval_T *argvars, typval_T *rettv)
 }
 
 /*
- * "getjumplist({tabpagenr}, {winnr})" function
+ * "getjumplist()" function
  */
     static void
-f_getjumplist(argvars, rettv)
-    typval_T	*argvars;
-    typval_T	*rettv;
+f_getjumplist(typval_T *argvars, typval_T *rettv)
 {
 #ifdef FEAT_JUMPLIST
-    tabpage_T	*tp;
     win_T	*wp;
     int         i;
     list_T	*l;
@@ -4855,11 +4852,7 @@ f_getjumplist(argvars, rettv)
 	return;
 
 #ifdef FEAT_JUMPLIST
-    tp = find_tabpage((int)get_tv_number_chk(&argvars[0], NULL));
-    if (tp == NULL)
-	return;
-
-    wp = find_win_by_nr(&argvars[1], tp);
+    wp = find_tabwin(&argvars[0], &argvars[1]);
     if (wp == NULL)
 	return;
 

--- a/src/list.c
+++ b/src/list.c
@@ -475,6 +475,27 @@ list_append_dict(list_T *list, dict_T *dict)
 }
 
 /*
+ * Append list2 to list1.
+ * Return FAIL when out of memory.
+ */
+    int
+list_append_list(list1, list2)
+    list_T	*list1;
+    list_T	*list2;
+{
+    listitem_T	*li = listitem_alloc();
+
+    if (li == NULL)
+	return FAIL;
+    li->li_tv.v_type = VAR_LIST;
+    li->li_tv.v_lock = 0;
+    li->li_tv.vval.v_list = list2;
+    list_append(list1, li);
+    ++list2->lv_refcount;
+    return OK;
+}
+
+/*
  * Make a copy of "str" and append it as an item to list "l".
  * When "len" >= 0 use "str[len]".
  * Returns FAIL when out of memory.

--- a/src/proto/list.pro
+++ b/src/proto/list.pro
@@ -21,6 +21,7 @@ long list_idx_of_item(list_T *l, listitem_T *item);
 void list_append(list_T *l, listitem_T *item);
 int list_append_tv(list_T *l, typval_T *tv);
 int list_append_dict(list_T *list, dict_T *dict);
+int list_append_list(list_T *list1, list_T *list2);
 int list_append_string(list_T *l, char_u *str, int len);
 int list_append_number(list_T *l, varnumber_T n);
 int list_insert_tv(list_T *l, typval_T *tv, listitem_T *item);

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -120,6 +120,7 @@ NEW_TESTS = test_arabic.res \
 	    test_ins_complete.res \
 	    test_job_fails.res \
 	    test_json.res \
+	    test_jumplist.res \
 	    test_langmap.res \
 	    test_let.res \
 	    test_lineending.res \

--- a/src/testdir/test_jumplist.vim
+++ b/src/testdir/test_jumplist.vim
@@ -8,7 +8,12 @@ func Test_getjumplist()
 
   %bwipe
   clearjumps
+  call assert_equal([[], 0], getjumplist())
+  call assert_equal([[], 0], getjumplist(1))
   call assert_equal([[], 0], getjumplist(1, 1))
+
+  call assert_equal([], getjumplist(100))
+  call assert_equal([], getjumplist(1, 100))
 
   let lines = []
   for i in range(1, 100)
@@ -28,16 +33,16 @@ func Test_getjumplist()
 	      \ {'lnum': 1, 'bufnr': bnr, 'col': 0, 'coladd': 0},
 	      \ {'lnum': 50, 'bufnr': bnr, 'col': 0, 'coladd': 0},
 	      \ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0}], 4],
-	      \ getjumplist(1, 1))
+	      \ getjumplist())
 
   " Traverse the jump list and verify the results
   5
   exe "normal \<C-O>"
-  call assert_equal(2, getjumplist(1, 1)[1])
+  call assert_equal(2, getjumplist(1)[1])
   exe "normal 2\<C-O>"
   call assert_equal(0, getjumplist(1, 1)[1])
   exe "normal 3\<C-I>"
-  call assert_equal(3, getjumplist(1, 1)[1])
+  call assert_equal(3, getjumplist()[1])
   exe "normal \<C-O>"
   normal 20%
   call assert_equal([[
@@ -46,9 +51,9 @@ func Test_getjumplist()
 	      \ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0},
 	      \ {'lnum': 5, 'bufnr': bnr, 'col': 0, 'coladd': 0},
 	      \ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0}], 5],
-	      \ getjumplist(1, 1))
+	      \ getjumplist())
 
-  let l = getjumplist(1, 1)
+  let l = getjumplist()
   call test_garbagecollect_now()
   call assert_equal(5, l[1])
   clearjumps

--- a/src/testdir/test_jumplist.vim
+++ b/src/testdir/test_jumplist.vim
@@ -1,0 +1,59 @@
+" Tests for the jumplist functionality
+
+" Tests for the getjumplist() function
+func Test_getjumplist()
+  if !has("jumplist")
+    return
+  endif
+
+  %bwipe
+  clearjumps
+  call assert_equal([[], 0], getjumplist(1, 1))
+
+  let lines = []
+  for i in range(1, 100)
+    call add(lines, "Line " . i)
+  endfor
+  call writefile(lines, "Xtest")
+
+  " Jump around and create a jump list
+  edit Xtest
+  let bnr = bufnr('%')
+  normal 50%
+  normal G
+  normal gg
+
+  call assert_equal([[
+	      \ {'lnum': 1, 'bufnr': bnr, 'col': 0, 'coladd': 0},
+	      \ {'lnum': 1, 'bufnr': bnr, 'col': 0, 'coladd': 0},
+	      \ {'lnum': 50, 'bufnr': bnr, 'col': 0, 'coladd': 0},
+	      \ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0}], 4],
+	      \ getjumplist(1, 1))
+
+  " Traverse the jump list and verify the results
+  5
+  exe "normal \<C-O>"
+  call assert_equal(2, getjumplist(1, 1)[1])
+  exe "normal 2\<C-O>"
+  call assert_equal(0, getjumplist(1, 1)[1])
+  exe "normal 3\<C-I>"
+  call assert_equal(3, getjumplist(1, 1)[1])
+  exe "normal \<C-O>"
+  normal 20%
+  call assert_equal([[
+	      \ {'lnum': 1, 'bufnr': bnr, 'col': 0, 'coladd': 0},
+	      \ {'lnum': 50, 'bufnr': bnr, 'col': 0, 'coladd': 0},
+	      \ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0},
+	      \ {'lnum': 5, 'bufnr': bnr, 'col': 0, 'coladd': 0},
+	      \ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0}], 5],
+	      \ getjumplist(1, 1))
+
+  let l = getjumplist(1, 1)
+  call test_garbagecollect_now()
+  call assert_equal(5, l[1])
+  clearjumps
+  call test_garbagecollect_now()
+  call assert_equal(5, l[1])
+
+  call delete("Xtest")
+endfunc


### PR DESCRIPTION
Currently to get the jump list entries, a Vim plugin needs to parse
the output of the ":jumps" command. This patch adds a new
getjumplist() function that returns a list of dictionaries containing
the jump list entries. This will make it easy for a plugin to access
the jump list.