### PR TITLE
Handle invalid utf8 correctly in terminal emulator

### DIFF
--- a/src/libvterm/src/encoding.c
+++ b/src/libvterm/src/encoding.c
@@ -49,11 +49,16 @@ static void decode_utf8(VTermEncoding *enc UNUSED, void *data_,
       if(data->bytes_remaining)
         cp[(*cpi)++] = UNICODE_INVALID;
 
+      data->bytes_remaining = 0;
+
+      // leave 'c' unprocessed when 'cp' is full
+      if(*cpi >= cplen)
+        break;
+
       cp[(*cpi)++] = c;
 #ifdef DEBUG_PRINT_UTF8
       printf(" UTF-8 char: U+%04x\n", c);
 #endif
-      data->bytes_remaining = 0;
     }
 
     else if(c == 0x7f) /* DEL */

--- a/src/libvterm/src/state.c
+++ b/src/libvterm/src/state.c
@@ -248,8 +248,10 @@ static int on_text(const char bytes[], size_t len, void *user)
 
   VTermPos oldpos = state->pos;
 
-  /* We'll have at most len codepoints */
-  codepoints = vterm_allocator_malloc(state->vt, len * sizeof(uint32_t));
+  /* We'll have at most (len + 1) codepoints, the one more codepoint
+   * may come from previous incomplete sequence
+   */
+  codepoints = vterm_allocator_malloc(state->vt, (len + 1) * sizeof(uint32_t));
 
   encoding =
     state->gsingle_set     ? &state->encoding[state->gsingle_set] :


### PR DESCRIPTION
Fixes #2613 
The original implementation:
* missing a boundary checking when output a character after an invalid sequence
* making an incorrect assumption of decoded sequence length