### PR TITLE
Fix MSCVER for VS2017 updates.

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -289,7 +289,7 @@ MSVC_MAJOR = ($(MSVCVER) / 100 - 6)
 MSVCRT_VER = ($(MSVCVER) / 10 - 60)
 # Visual C++ 2017 needs special handling
 # it has an _MSC_VER of 1910->14.1, but is actually v15 with runtime v140
-!elseif $(MSVCVER) == 1910
+!elseif $(MSVCVER) >= 1910
 MSVC_MAJOR = 15
 MSVCRT_VER = 140
 !else


### PR DESCRIPTION
VS2017 updates continue screwing with our MSCVER detection.

Since there's no way to predict what numbering madness MS will embark on next, just make it so the makefile sets it correctly for the latest VS2017 build, and possibly (should, hopefully, etc) future updates to that product.