### PR TITLE
Allow `cscope add` to take a variable name

### DIFF
--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -515,7 +515,13 @@ cs_add_common(
     if ((fname = (char *)alloc(MAXPATHL + 1)) == NULL)
 	goto add_err;
 
-    expand_env((char_u *)arg1, (char_u *)fname, MAXPATHL);
+    if (arg1[0] == '&')
+	/* if arg1 starts with '&', assume it is a variable, not a filename */
+	expand_env(get_var_value((char_u *)arg1 + sizeof(char_u)),
+	           (char_u *)fname, MAXPATHL);
+    else
+	expand_env((char_u *)arg1, (char_u *)fname, MAXPATHL);
+
 #ifdef FEAT_MODIFY_FNAME
     len = (int)STRLEN(fname);
     fbuf = (char_u *)fname;

--- a/src/testdir/test_cscope.vim
+++ b/src/testdir/test_cscope.vim
@@ -257,6 +257,18 @@ func Test_cscopeWithCscopeConnections()
 
 endfunc
 
+func Test_addCscopeDbFromVariable()
+    call CscopeSetupOrClean(1)
+    cscope kill -1
+
+    set cscopeverbose
+    let cscopefile='Xcscope.out'
+    let a=execute('cscope add &cscopefile')
+    call assert_match('\nAdded cscope database.*Xcscope.out', a)
+
+    call CscopeSetupOrClean(0)
+endfunc
+
 func Test_cscopequickfix()
   set cscopequickfix=s-,g-,d+,c-,t+,e-,f0,i-,a-
   call assert_equal('s-,g-,d+,c-,t+,e-,f0,i-,a-', &cscopequickfix)


### PR DESCRIPTION
This allows `cscope add` to take a variable name prefixed with `&` instead of a literal file path. It is useful, for example, in conjunction with `glob()` to locate the cscope file in a project.

The leading `&` may be unusual, but it follows the behavior in dereferencing options as variables, and should minimize impact to existing users.

Apologies if this feature is already present in vim; I could not find a way to accomplish it.