### PR TITLE
Fix small error in the documentation of how nocompatible and -N interact

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1012,9 +1012,10 @@ starts its initializations.  But as soon as:
 - a user vimrc file is found, or
 - a vimrc file in the current directory, or
 - the "VIMINIT" environment variable is set, or
-- the "-N" command line argument is given, or
+- the "-N" command line argument is given, even
+  when no vimrc file exists, or the "-u NONE"
+  command line argument is set, or
 - the "--clean" command line argument is given, or
-  even when no vimrc file exists.
 - the |defaults.vim| script is loaded, or
 - gvimrc file was found,
 then it will be set to 'nocompatible'.


### PR DESCRIPTION
It seems that the patch that introduced -N made a small typo, then the patch that introduced --clean added a line of doc inbetween two lines of doc that explained -N and should have been kept together. Finally, it seems that the original doc for -N was unclear. It doesn't immediately make sense to say "-N will work even when there's no vimrc". Maybe what was meant was that "-N will work even when -u NONE is used", so I updated that part.