### PR TITLE
Change vim_clear() to macro and rename to VIM_CLEAR()

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -944,7 +944,7 @@ free_buffer_stuff(
     map_clear_int(buf, MAP_ALL_MODES, TRUE, TRUE);   /* clear local abbrevs */
 #endif
 #ifdef FEAT_MBYTE
-    VIM_CLEAR(buf->b_start_fenc);
+    vim_clear((void **)&buf->b_start_fenc);
 #endif
 }
 
@@ -2036,8 +2036,8 @@ buflist_new(
     if ((ffname != NULL && (buf->b_ffname == NULL || buf->b_sfname == NULL))
 	    || buf->b_wininfo == NULL)
     {
-	VIM_CLEAR(buf->b_ffname);
-	VIM_CLEAR(buf->b_sfname);
+	vim_clear((void **)&buf->b_ffname);
+	vim_clear((void **)&buf->b_sfname);
 	if (buf != curbuf)
 	    free_buffer(buf);
 	return NULL;
@@ -3133,8 +3133,8 @@ setfname(
     if (ffname == NULL || *ffname == NUL)
     {
 	/* Removing the name. */
-	VIM_CLEAR(buf->b_ffname);
-	VIM_CLEAR(buf->b_sfname);
+	vim_clear((void **)&buf->b_ffname);
+	vim_clear((void **)&buf->b_sfname);
 #ifdef UNIX
 	st.st_dev = (dev_T)-1;
 #endif
@@ -4256,7 +4256,7 @@ build_stl_str_hl(
 		if (*skipdigits(str) == NUL)
 		{
 		    num = atoi((char *)str);
-		    VIM_CLEAR(str);
+		    vim_clear((void **)&str);
 		    itemisflag = FALSE;
 		}
 	    }

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -944,8 +944,7 @@ free_buffer_stuff(
     map_clear_int(buf, MAP_ALL_MODES, TRUE, TRUE);   /* clear local abbrevs */
 #endif
 #ifdef FEAT_MBYTE
-    vim_free(buf->b_start_fenc);
-    buf->b_start_fenc = NULL;
+    VIM_CLEAR(buf->b_start_fenc);
 #endif
 }
 
@@ -2037,10 +2036,8 @@ buflist_new(
     if ((ffname != NULL && (buf->b_ffname == NULL || buf->b_sfname == NULL))
 	    || buf->b_wininfo == NULL)
     {
-	vim_free(buf->b_ffname);
-	buf->b_ffname = NULL;
-	vim_free(buf->b_sfname);
-	buf->b_sfname = NULL;
+	VIM_CLEAR(buf->b_ffname);
+	VIM_CLEAR(buf->b_sfname);
 	if (buf != curbuf)
 	    free_buffer(buf);
 	return NULL;
@@ -3136,10 +3133,8 @@ setfname(
     if (ffname == NULL || *ffname == NUL)
     {
 	/* Removing the name. */
-	vim_free(buf->b_ffname);
-	vim_free(buf->b_sfname);
-	buf->b_ffname = NULL;
-	buf->b_sfname = NULL;
+	VIM_CLEAR(buf->b_ffname);
+	VIM_CLEAR(buf->b_sfname);
 #ifdef UNIX
 	st.st_dev = (dev_T)-1;
 #endif
@@ -4261,8 +4256,7 @@ build_stl_str_hl(
 		if (*skipdigits(str) == NUL)
 		{
 		    num = atoi((char *)str);
-		    vim_free(str);
-		    str = NULL;
+		    VIM_CLEAR(str);
 		    itemisflag = FALSE;
 		}
 	    }

--- a/src/channel.c
+++ b/src/channel.c
@@ -2978,8 +2978,7 @@ channel_clear_one(channel_T *channel, ch_part_T part)
 channel_clear(channel_T *channel)
 {
     ch_log(channel, "Clearing channel");
-    vim_free(channel->ch_hostname);
-    channel->ch_hostname = NULL;
+    VIM_CLEAR(channel->ch_hostname);
     channel_clear_one(channel, PART_SOCK);
     channel_clear_one(channel, PART_OUT);
     channel_clear_one(channel, PART_ERR);

--- a/src/channel.c
+++ b/src/channel.c
@@ -2978,7 +2978,7 @@ channel_clear_one(channel_T *channel, ch_part_T part)
 channel_clear(channel_T *channel)
 {
     ch_log(channel, "Clearing channel");
-    VIM_CLEAR(channel->ch_hostname);
+    vim_clear((void **)&channel->ch_hostname);
     channel_clear_one(channel, PART_SOCK);
     channel_clear_one(channel, PART_OUT);
     channel_clear_one(channel, PART_ERR);

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -349,7 +349,7 @@ crypt_create_for_writing(
 
     state = crypt_create(method_nr, key, salt, salt_len, seed, seed_len);
     if (state == NULL)
-	VIM_CLEAR(*header);
+	vim_clear((void **)header);
     return state;
 }
 

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -349,10 +349,7 @@ crypt_create_for_writing(
 
     state = crypt_create(method_nr, key, salt, salt_len, seed, seed_len);
     if (state == NULL)
-    {
-	vim_free(*header);
-	*header = NULL;
-    }
+	VIM_CLEAR(*header);
     return state;
 }
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -2928,7 +2928,7 @@ ins_compl_del_pum(void)
     if (compl_match_array != NULL)
     {
 	pum_undisplay();
-	vim_clear((void **)&compl_match_array);
+	VIM_CLEAR(compl_match_array);
     }
 }
 
@@ -3430,8 +3430,8 @@ ins_compl_free(void)
     compl_T *match;
     int	    i;
 
-    vim_clear((void **)&compl_pattern);
-    vim_clear((void **)&compl_leader);
+    VIM_CLEAR(compl_pattern);
+    VIM_CLEAR(compl_leader);
 
     if (compl_first_match == NULL)
 	return;
@@ -3463,10 +3463,10 @@ ins_compl_clear(void)
     compl_cont_status = 0;
     compl_started = FALSE;
     compl_matches = 0;
-    vim_clear((void **)&compl_pattern);
-    vim_clear((void **)&compl_leader);
+    VIM_CLEAR(compl_pattern);
+    VIM_CLEAR(compl_leader);
     edit_submode_extra = NULL;
-    vim_clear((void **)&compl_orig_text);
+    VIM_CLEAR(compl_orig_text);
     compl_enter_selects = FALSE;
     /* clear v:completed_item */
     set_vim_var_dict(VV_COMPLETED_ITEM, dict_alloc_lock(VAR_FIXED));
@@ -5569,8 +5569,8 @@ ins_complete(int c, int enable_pum)
 	if (compl_orig_text == NULL || ins_compl_add(compl_orig_text,
 			-1, p_ic, NULL, NULL, 0, ORIGINAL_TEXT, FALSE) != OK)
 	{
-	    vim_clear((void **)&compl_pattern);
-	    vim_clear((void **)&compl_orig_text);
+	    VIM_CLEAR(compl_pattern);
+	    VIM_CLEAR(compl_orig_text);
 	    return FAIL;
 	}
 
@@ -7199,9 +7199,9 @@ set_last_insert(int c)
     void
 free_last_insert(void)
 {
-    vim_clear((void **)&last_insert);
+    VIM_CLEAR(last_insert);
 # ifdef FEAT_INS_EXPAND
-    vim_clear((void **)&compl_orig_text);
+    VIM_CLEAR(compl_orig_text);
 # endif
 }
 #endif
@@ -7829,7 +7829,7 @@ mb_replace_pop_ins(int cc)
     static void
 replace_flush(void)
 {
-    vim_clear((void **)&replace_stack);
+    VIM_CLEAR(replace_stack);
     replace_stack_len = 0;
     replace_stack_nr = 0;
 }

--- a/src/edit.c
+++ b/src/edit.c
@@ -2939,7 +2939,7 @@ ins_compl_del_pum(void)
     if (compl_match_array != NULL)
     {
 	pum_undisplay();
-	VIM_CLEAR(compl_match_array);
+	vim_clear((void **)&compl_match_array);
     }
 }
 
@@ -3441,8 +3441,8 @@ ins_compl_free(void)
     compl_T *match;
     int	    i;
 
-    VIM_CLEAR(compl_pattern);
-    VIM_CLEAR(compl_leader);
+    vim_clear((void **)&compl_pattern);
+    vim_clear((void **)&compl_leader);
 
     if (compl_first_match == NULL)
 	return;
@@ -3474,10 +3474,10 @@ ins_compl_clear(void)
     compl_cont_status = 0;
     compl_started = FALSE;
     compl_matches = 0;
-    VIM_CLEAR(compl_pattern);
-    VIM_CLEAR(compl_leader);
+    vim_clear((void **)&compl_pattern);
+    vim_clear((void **)&compl_leader);
     edit_submode_extra = NULL;
-    VIM_CLEAR(compl_orig_text);
+    vim_clear((void **)&compl_orig_text);
     compl_enter_selects = FALSE;
     /* clear v:completed_item */
     set_vim_var_dict(VV_COMPLETED_ITEM, dict_alloc_lock(VAR_FIXED));
@@ -5584,8 +5584,8 @@ ins_complete(int c, int enable_pum)
 	if (compl_orig_text == NULL || ins_compl_add(compl_orig_text,
 			-1, p_ic, NULL, NULL, 0, ORIGINAL_TEXT, FALSE) != OK)
 	{
-	    VIM_CLEAR(compl_pattern);
-	    VIM_CLEAR(compl_orig_text);
+	    vim_clear((void **)&compl_pattern);
+	    vim_clear((void **)&compl_orig_text);
 	    return FAIL;
 	}
 
@@ -7214,9 +7214,9 @@ set_last_insert(int c)
     void
 free_last_insert(void)
 {
-    VIM_CLEAR(last_insert);
+    vim_clear((void **)&last_insert);
 # ifdef FEAT_INS_EXPAND
-    VIM_CLEAR(compl_orig_text);
+    vim_clear((void **)&compl_orig_text);
 # endif
 }
 #endif
@@ -7844,7 +7844,7 @@ mb_replace_pop_ins(int cc)
     static void
 replace_flush(void)
 {
-    VIM_CLEAR(replace_stack);
+    vim_clear((void **)&replace_stack);
     replace_stack_len = 0;
     replace_stack_nr = 0;
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -361,7 +361,7 @@ eval_clear(void)
     {
 	p = &vimvars[i];
 	if (p->vv_di.di_tv.v_type == VAR_STRING)
-	    VIM_CLEAR(p->vv_str);
+	    vim_clear((void **)&p->vv_str);
 	else if (p->vv_di.di_tv.v_type == VAR_LIST)
 	{
 	    list_unref(p->vv_list);
@@ -566,11 +566,11 @@ var_redir_stop(void)
 	}
 
 	/* free the collected output */
-	VIM_CLEAR(redir_ga.ga_data);
+	vim_clear((void **)&redir_ga.ga_data);
 
-	VIM_CLEAR(redir_lval);
+	vim_clear((void **)&redir_lval);
     }
-    VIM_CLEAR(redir_varname);
+    vim_clear((void **)&redir_varname);
 }
 
 # if defined(FEAT_MBYTE) || defined(PROTO)
@@ -1003,7 +1003,7 @@ eval_expr(char_u *arg, char_u **nextcmd)
 
     tv = (typval_T *)alloc(sizeof(typval_T));
     if (tv != NULL && eval0(arg, tv, nextcmd, TRUE) == FAIL)
-	VIM_CLEAR(tv);
+	vim_clear((void **)&tv);
 
     return tv;
 }
@@ -3204,7 +3204,7 @@ get_user_var_name(expand_T *xp, int idx)
     if (vidx < VV_LEN)
 	return cat_prefix_varname('v', (char_u *)vimvars[vidx++].vv_name);
 
-    VIM_CLEAR(varnamebuf);
+    vim_clear((void **)&varnamebuf);
     varnamebuflen = 0;
     return NULL;
 }
@@ -6086,7 +6086,7 @@ get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
 	    /* next try expanding things like $VIM and ${HOME} */
 	    string = expand_env_save(name - 1);
 	    if (string != NULL && *string == '$')
-		VIM_CLEAR(string);
+		vim_clear((void **)&string);
 	}
 	name[len] = cc;
 
@@ -7103,7 +7103,7 @@ clear_tv(typval_T *varp)
 		func_unref(varp->vval.v_string);
 		/* FALLTHROUGH */
 	    case VAR_STRING:
-		VIM_CLEAR(varp->vval.v_string);
+		vim_clear((void **)&varp->vval.v_string);
 		break;
 	    case VAR_PARTIAL:
 		partial_unref(varp->vval.v_partial);

--- a/src/eval.c
+++ b/src/eval.c
@@ -361,10 +361,7 @@ eval_clear(void)
     {
 	p = &vimvars[i];
 	if (p->vv_di.di_tv.v_type == VAR_STRING)
-	{
-	    vim_free(p->vv_str);
-	    p->vv_str = NULL;
-	}
+	    VIM_CLEAR(p->vv_str);
 	else if (p->vv_di.di_tv.v_type == VAR_LIST)
 	{
 	    list_unref(p->vv_list);
@@ -569,14 +566,11 @@ var_redir_stop(void)
 	}
 
 	/* free the collected output */
-	vim_free(redir_ga.ga_data);
-	redir_ga.ga_data = NULL;
+	VIM_CLEAR(redir_ga.ga_data);
 
-	vim_free(redir_lval);
-	redir_lval = NULL;
+	VIM_CLEAR(redir_lval);
     }
-    vim_free(redir_varname);
-    redir_varname = NULL;
+    VIM_CLEAR(redir_varname);
 }
 
 # if defined(FEAT_MBYTE) || defined(PROTO)
@@ -1009,10 +1003,7 @@ eval_expr(char_u *arg, char_u **nextcmd)
 
     tv = (typval_T *)alloc(sizeof(typval_T));
     if (tv != NULL && eval0(arg, tv, nextcmd, TRUE) == FAIL)
-    {
-	vim_free(tv);
-	tv = NULL;
-    }
+	VIM_CLEAR(tv);
 
     return tv;
 }
@@ -3213,8 +3204,7 @@ get_user_var_name(expand_T *xp, int idx)
     if (vidx < VV_LEN)
 	return cat_prefix_varname('v', (char_u *)vimvars[vidx++].vv_name);
 
-    vim_free(varnamebuf);
-    varnamebuf = NULL;
+    VIM_CLEAR(varnamebuf);
     varnamebuflen = 0;
     return NULL;
 }
@@ -6096,10 +6086,7 @@ get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
 	    /* next try expanding things like $VIM and ${HOME} */
 	    string = expand_env_save(name - 1);
 	    if (string != NULL && *string == '$')
-	    {
-		vim_free(string);
-		string = NULL;
-	    }
+		VIM_CLEAR(string);
 	}
 	name[len] = cc;
 
@@ -7116,8 +7103,7 @@ clear_tv(typval_T *varp)
 		func_unref(varp->vval.v_string);
 		/* FALLTHROUGH */
 	    case VAR_STRING:
-		vim_free(varp->vval.v_string);
-		varp->vval.v_string = NULL;
+		VIM_CLEAR(varp->vval.v_string);
 		break;
 	    case VAR_PARTIAL:
 		partial_unref(varp->vval.v_partial);

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -9220,10 +9220,7 @@ f_resolve(typval_T *argvars, typval_T *rettv)
 	    if (*q != NUL)
 		STRMOVE(remain, q - 1);
 	    else
-	    {
-		vim_free(remain);
-		remain = NULL;
-	    }
+		VIM_CLEAR(remain);
 	}
 
 	/* If the result is a relative path name, make it explicitly relative to

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -9222,7 +9222,7 @@ f_resolve(typval_T *argvars, typval_T *rettv)
 	    if (*q != NUL)
 		STRMOVE(remain, q - 1);
 	    else
-		VIM_CLEAR(remain);
+		vim_clear((void **)&remain);
 	}
 
 	/* If the result is a relative path name, make it explicitly relative to

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1957,7 +1957,7 @@ write_viminfo(char_u *file, int forceit)
 		    if (!shortname && st_new.st_dev == st_old.st_dev
 						&& st_new.st_ino == st_old.st_ino)
 		    {
-			VIM_CLEAR(tempname);
+			vim_clear((void **)&tempname);
 			shortname = TRUE;
 			break;
 		    }
@@ -5224,7 +5224,7 @@ do_sub(exarg_T *eap)
 		    lnum += regmatch.startpos[0].lnum;
 		    sub_firstlnum += regmatch.startpos[0].lnum;
 		    nmatch -= regmatch.startpos[0].lnum;
-		    VIM_CLEAR(sub_firstline);
+		    vim_clear((void **)&sub_firstline);
 		}
 
 		if (sub_firstline == NULL)
@@ -5386,7 +5386,7 @@ do_sub(exarg_T *eap)
 						     sub_firstline + copycol);
 
 				    if (new_line == NULL)
-					VIM_CLEAR(orig_line);
+					vim_clear((void **)&orig_line);
 				    else
 				    {
 					/* Position the cursor relative to the
@@ -5815,7 +5815,7 @@ skip:
 	    if (did_sub)
 		++sub_nlines;
 	    vim_free(new_start);	/* for when substitute was cancelled */
-	    VIM_CLEAR(sub_firstline);	/* free the copy of the original line */
+	    vim_clear((void **)&sub_firstline);	/* free the copy of the original line */
 	}
 
 	line_breakcheck();
@@ -6969,7 +6969,7 @@ fix_help_buffer(void)
 				    && fnamecmp(e1, fname + 4) != 0)
 				{
 				    /* Not .txt and not .abx, remove it. */
-				    VIM_CLEAR(fnames[i1]);
+				    vim_clear((void **)&fnames[i1]);
 				    continue;
 				}
 				if (e1 - f1 != e2 - f2
@@ -6978,7 +6978,7 @@ fix_help_buffer(void)
 				if (fnamecmp(e1, ".txt") == 0
 				    && fnamecmp(e2, fname + 4) == 0)
 				    /* use .abx instead of .txt */
-				    VIM_CLEAR(fnames[i1]);
+				    vim_clear((void **)&fnames[i1]);
 			    }
 			}
 #endif

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1957,8 +1957,7 @@ write_viminfo(char_u *file, int forceit)
 		    if (!shortname && st_new.st_dev == st_old.st_dev
 						&& st_new.st_ino == st_old.st_ino)
 		    {
-			vim_free(tempname);
-			tempname = NULL;
+			VIM_CLEAR(tempname);
 			shortname = TRUE;
 			break;
 		    }
@@ -5225,8 +5224,7 @@ do_sub(exarg_T *eap)
 		    lnum += regmatch.startpos[0].lnum;
 		    sub_firstlnum += regmatch.startpos[0].lnum;
 		    nmatch -= regmatch.startpos[0].lnum;
-		    vim_free(sub_firstline);
-		    sub_firstline = NULL;
+		    VIM_CLEAR(sub_firstline);
 		}
 
 		if (sub_firstline == NULL)
@@ -5388,10 +5386,7 @@ do_sub(exarg_T *eap)
 						     sub_firstline + copycol);
 
 				    if (new_line == NULL)
-				    {
-					vim_free(orig_line);
-					orig_line = NULL;
-				    }
+					VIM_CLEAR(orig_line);
 				    else
 				    {
 					/* Position the cursor relative to the
@@ -5820,8 +5815,7 @@ skip:
 	    if (did_sub)
 		++sub_nlines;
 	    vim_free(new_start);	/* for when substitute was cancelled */
-	    vim_free(sub_firstline);	/* free the copy of the original line */
-	    sub_firstline = NULL;
+	    VIM_CLEAR(sub_firstline);	/* free the copy of the original line */
 	}
 
 	line_breakcheck();
@@ -6975,8 +6969,7 @@ fix_help_buffer(void)
 				    && fnamecmp(e1, fname + 4) != 0)
 				{
 				    /* Not .txt and not .abx, remove it. */
-				    vim_free(fnames[i1]);
-				    fnames[i1] = NULL;
+				    VIM_CLEAR(fnames[i1]);
 				    continue;
 				}
 				if (e1 - f1 != e2 - f2
@@ -6984,11 +6977,8 @@ fix_help_buffer(void)
 				    continue;
 				if (fnamecmp(e1, ".txt") == 0
 				    && fnamecmp(e2, fname + 4) == 0)
-				{
 				    /* use .abx instead of .txt */
-				    vim_free(fnames[i1]);
-				    fnames[i1] = NULL;
-				}
+				    VIM_CLEAR(fnames[i1]);
 			    }
 			}
 #endif

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -5489,8 +5489,7 @@ free_locales(void)
     {
 	for (i = 0; locales[i] != NULL; i++)
 	    vim_free(locales[i]);
-	vim_free(locales);
-	locales = NULL;
+	VIM_CLEAR(locales);
     }
 }
 #  endif

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -5489,7 +5489,7 @@ free_locales(void)
     {
 	for (i = 0; locales[i] != NULL; i++)
 	    vim_free(locales[i]);
-	VIM_CLEAR(locales);
+	vim_clear((void **)&locales);
     }
 }
 #  endif

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -868,8 +868,7 @@ do_cmdline(
 	{
 	    /* Each '|' separated command is stored separately in lines_ga, to
 	     * be able to jump to it.  Don't use next_cmdline now. */
-	    vim_free(cmdline_copy);
-	    cmdline_copy = NULL;
+	    VIM_CLEAR(cmdline_copy);
 
 	    /* Check if a function has returned or, unless it has an unclosed
 	     * try conditional, aborted. */
@@ -1084,8 +1083,7 @@ do_cmdline(
 
 	if (next_cmdline == NULL)
 	{
-	    vim_free(cmdline_copy);
-	    cmdline_copy = NULL;
+	    VIM_CLEAR(cmdline_copy);
 #ifdef FEAT_CMDHIST
 	    /*
 	     * If the command was typed, remember it for the ':' register.
@@ -5802,11 +5800,9 @@ uc_add_command(
 		goto fail;
 	    }
 
-	    vim_free(cmd->uc_rep);
-	    cmd->uc_rep = NULL;
+	    VIM_CLEAR(cmd->uc_rep);
 #if defined(FEAT_EVAL) && defined(FEAT_CMDL_COMPL)
-	    vim_free(cmd->uc_compl_arg);
-	    cmd->uc_compl_arg = NULL;
+	    VIM_CLEAR(cmd->uc_compl_arg);
 #endif
 	    break;
 	}
@@ -8952,11 +8948,8 @@ static char_u	*prev_dir = NULL;
     void
 free_cd_dir(void)
 {
-    vim_free(prev_dir);
-    prev_dir = NULL;
-
-    vim_free(globaldir);
-    globaldir = NULL;
+    VIM_CLEAR(prev_dir);
+    VIM_CLEAR(globaldir);
 }
 #endif
 
@@ -8967,8 +8960,7 @@ free_cd_dir(void)
     void
 post_chdir(int local)
 {
-    vim_free(curwin->w_localdir);
-    curwin->w_localdir = NULL;
+    VIM_CLEAR(curwin->w_localdir);
     if (local)
     {
 	/* If still in global directory, need to remember current
@@ -8983,8 +8975,7 @@ post_chdir(int local)
     {
 	/* We are now in the global directory, no need to remember its
 	 * name. */
-	vim_free(globaldir);
-	globaldir = NULL;
+	VIM_CLEAR(globaldir);
     }
 
     shorten_fnames(TRUE);

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -868,7 +868,7 @@ do_cmdline(
 	{
 	    /* Each '|' separated command is stored separately in lines_ga, to
 	     * be able to jump to it.  Don't use next_cmdline now. */
-	    VIM_CLEAR(cmdline_copy);
+	    vim_clear((void **)&cmdline_copy);
 
 	    /* Check if a function has returned or, unless it has an unclosed
 	     * try conditional, aborted. */
@@ -1083,7 +1083,7 @@ do_cmdline(
 
 	if (next_cmdline == NULL)
 	{
-	    VIM_CLEAR(cmdline_copy);
+	    vim_clear((void **)&cmdline_copy);
 #ifdef FEAT_CMDHIST
 	    /*
 	     * If the command was typed, remember it for the ':' register.
@@ -5800,9 +5800,9 @@ uc_add_command(
 		goto fail;
 	    }
 
-	    VIM_CLEAR(cmd->uc_rep);
+	    vim_clear((void **)&cmd->uc_rep);
 #if defined(FEAT_EVAL) && defined(FEAT_CMDL_COMPL)
-	    VIM_CLEAR(cmd->uc_compl_arg);
+	    vim_clear((void **)&cmd->uc_compl_arg);
 #endif
 	    break;
 	}
@@ -8948,8 +8948,8 @@ static char_u	*prev_dir = NULL;
     void
 free_cd_dir(void)
 {
-    VIM_CLEAR(prev_dir);
-    VIM_CLEAR(globaldir);
+    vim_clear((void **)&prev_dir);
+    vim_clear((void **)&globaldir);
 }
 #endif
 
@@ -8960,7 +8960,7 @@ free_cd_dir(void)
     void
 post_chdir(int local)
 {
-    VIM_CLEAR(curwin->w_localdir);
+    vim_clear((void **)&curwin->w_localdir);
     if (local)
     {
 	/* If still in global directory, need to remember current
@@ -8975,7 +8975,7 @@ post_chdir(int local)
     {
 	/* We are now in the global directory, no need to remember its
 	 * name. */
-	VIM_CLEAR(globaldir);
+	vim_clear((void **)&globaldir);
     }
 
     shorten_fnames(TRUE);

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -164,7 +164,7 @@ trigger_cmd_autocmd(int typechar, int evt)
     static void
 abandon_cmdline(void)
 {
-    VIM_CLEAR(ccline.cmdbuff);
+    vim_clear((void **)&ccline.cmdbuff);
     if (msg_scrolled == 0)
 	compute_cmdrow();
     MSG("");
@@ -499,7 +499,7 @@ getcmdline(
 		&& c != K_KPAGEDOWN && c != K_KPAGEUP
 		&& c != K_LEFT && c != K_RIGHT
 		&& (xpc.xp_numfiles > 0 || (c != Ctrl_P && c != Ctrl_N)))
-	    VIM_CLEAR(lookfor);
+	    vim_clear((void **)&lookfor);
 #endif
 
 	/*
@@ -1092,7 +1092,7 @@ getcmdline(
 			    )
 			goto cmdline_not_changed;
 
-		    VIM_CLEAR(ccline.cmdbuff);	/* no commandline to return */
+		    vim_clear((void **)&ccline.cmdbuff);	/* no commandline to return */
 		    if (!cmd_silent)
 		    {
 #ifdef FEAT_RIGHTLEFT
@@ -3678,7 +3678,7 @@ nextwild(
 			     || ccline.cmdbuff[i + j] == '?')
 			 break;
 		if ((int)STRLEN(p2) < j)
-		    VIM_CLEAR(p2);
+		    vim_clear((void **)&p2);
 	    }
 	}
     }
@@ -3824,7 +3824,7 @@ ExpandOne(
     {
 	FreeWild(xp->xp_numfiles, xp->xp_files);
 	xp->xp_numfiles = -1;
-	VIM_CLEAR(orig_save);
+	vim_clear((void **)&orig_save);
     }
     findex = 0;
 
@@ -6728,7 +6728,7 @@ finish_viminfo_history(vir_T *virp)
 	else
 	    concat_history(type);
 
-	VIM_CLEAR(viminfo_history[type]);
+	vim_clear((void **)&viminfo_history[type]);
 	viminfo_hisidx[type] = 0;
     }
 }
@@ -6852,7 +6852,7 @@ write_viminfo_history(FILE *fp, int merge)
 	for (i = 0; i < viminfo_hisidx[type]; ++i)
 	    if (viminfo_history[type] != NULL)
 		vim_free(viminfo_history[type][i].hisstr);
-	VIM_CLEAR(viminfo_history[type]);
+	vim_clear((void **)&viminfo_history[type]);
 	viminfo_hisidx[type] = 0;
     }
 }

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -164,8 +164,7 @@ trigger_cmd_autocmd(int typechar, int evt)
     static void
 abandon_cmdline(void)
 {
-    vim_free(ccline.cmdbuff);
-    ccline.cmdbuff = NULL;
+    VIM_CLEAR(ccline.cmdbuff);
     if (msg_scrolled == 0)
 	compute_cmdrow();
     MSG("");
@@ -500,10 +499,7 @@ getcmdline(
 		&& c != K_KPAGEDOWN && c != K_KPAGEUP
 		&& c != K_LEFT && c != K_RIGHT
 		&& (xpc.xp_numfiles > 0 || (c != Ctrl_P && c != Ctrl_N)))
-	{
-	    vim_free(lookfor);
-	    lookfor = NULL;
-	}
+	    VIM_CLEAR(lookfor);
 #endif
 
 	/*
@@ -1096,8 +1092,7 @@ getcmdline(
 			    )
 			goto cmdline_not_changed;
 
-		    vim_free(ccline.cmdbuff);	/* no commandline to return */
-		    ccline.cmdbuff = NULL;
+		    VIM_CLEAR(ccline.cmdbuff);	/* no commandline to return */
 		    if (!cmd_silent)
 		    {
 #ifdef FEAT_RIGHTLEFT
@@ -3683,10 +3678,7 @@ nextwild(
 			     || ccline.cmdbuff[i + j] == '?')
 			 break;
 		if ((int)STRLEN(p2) < j)
-		{
-		    vim_free(p2);
-		    p2 = NULL;
-		}
+		    VIM_CLEAR(p2);
 	    }
 	}
     }
@@ -3832,8 +3824,7 @@ ExpandOne(
     {
 	FreeWild(xp->xp_numfiles, xp->xp_files);
 	xp->xp_numfiles = -1;
-	vim_free(orig_save);
-	orig_save = NULL;
+	VIM_CLEAR(orig_save);
     }
     findex = 0;
 
@@ -6737,8 +6728,7 @@ finish_viminfo_history(vir_T *virp)
 	else
 	    concat_history(type);
 
-	vim_free(viminfo_history[type]);
-	viminfo_history[type] = NULL;
+	VIM_CLEAR(viminfo_history[type]);
 	viminfo_hisidx[type] = 0;
     }
 }
@@ -6862,8 +6852,7 @@ write_viminfo_history(FILE *fp, int merge)
 	for (i = 0; i < viminfo_hisidx[type]; ++i)
 	    if (viminfo_history[type] != NULL)
 		vim_free(viminfo_history[type][i].hisstr);
-	vim_free(viminfo_history[type]);
-	viminfo_history[type] = NULL;
+	VIM_CLEAR(viminfo_history[type]);
 	viminfo_hisidx[type] = 0;
     }
 }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1073,7 +1073,7 @@ retry:
 	if (tmpname != NULL)
 	{
 	    mch_remove(tmpname);		/* delete converted file */
-	    VIM_CLEAR(tmpname);
+	    vim_clear((void **)&tmpname);
 	}
     }
 
@@ -2601,7 +2601,7 @@ failed:
 #endif
 		msg_add_lines(c, (long)linecnt, filesize);
 
-	    VIM_CLEAR(keep_msg);
+	    vim_clear((void **)&keep_msg);
 	    msg_scrolled_ign = TRUE;
 #ifdef ALWAYS_USE_GUI
 	    /* Don't show the message when reading stdin, it would end up in a
@@ -2953,7 +2953,7 @@ readfile_charconvert(
 	if (tmpname != NULL)
 	{
 	    mch_remove(tmpname);	/* delete converted file */
-	    VIM_CLEAR(tmpname);
+	    vim_clear((void **)&tmpname);
 	}
     }
 
@@ -3942,7 +3942,7 @@ buf_write(
 			if (st_new.st_dev == st_old.st_dev
 					    && st_new.st_ino == st_old.st_ino)
 			{
-			    VIM_CLEAR(backup);	/* no backup file to delete */
+			    vim_clear((void **)&backup);	/* no backup file to delete */
 			    /*
 			     * may try again with 'shortname' set
 			     */
@@ -3976,7 +3976,7 @@ buf_write(
 				--*wp;
 			    /* They all exist??? Must be something wrong. */
 			    if (*wp == 'a')
-				VIM_CLEAR(backup);
+				vim_clear((void **)&backup);
 			}
 		    }
 		    break;
@@ -4003,7 +4003,7 @@ buf_write(
 		    (void)umask(umask_save);
 #endif
 		    if (bfd < 0)
-			VIM_CLEAR(backup);
+			vim_clear((void **)&backup);
 		    else
 		    {
 			/* Set file protection same as original file, but
@@ -4146,7 +4146,7 @@ buf_write(
 			    --*p;
 			/* They all exist??? Must be something wrong! */
 			if (*p == 'a')
-			    VIM_CLEAR(backup);
+			    vim_clear((void **)&backup);
 		    }
 		}
 		if (backup != NULL)
@@ -4164,7 +4164,7 @@ buf_write(
 		    if (vim_rename(fname, backup) == 0)
 			break;
 
-		    VIM_CLEAR(backup);   /* don't do the rename below */
+		    vim_clear((void **)&backup);   /* don't do the rename below */
 		}
 	    }
 	    if (backup == NULL && !forceit)
@@ -5065,7 +5065,7 @@ restore_backup:
 	    else if (mch_stat(org, &st) < 0)
 	    {
 		vim_rename(backup, (char_u *)org);
-		VIM_CLEAR(backup);	    /* don't delete the file */
+		vim_clear((void **)&backup);	    /* don't delete the file */
 #ifdef UNIX
 		set_file_time((char_u *)org, st_old.st_atime, st_old.st_mtime);
 #endif
@@ -6212,7 +6212,7 @@ shorten_fnames(int force)
 		    || buf->b_sfname == NULL
 		    || mch_isFullName(buf->b_sfname)))
 	{
-	    VIM_CLEAR(buf->b_sfname);
+	    vim_clear((void **)&buf->b_sfname);
 	    p = shorten_fname(buf->b_ffname, dirname);
 	    if (p != NULL)
 	    {
@@ -7411,7 +7411,7 @@ vim_deltempdir(void)
 	/* remove the trailing path separator */
 	gettail(vim_tempdir)[-1] = NUL;
 	delete_recursive(vim_tempdir);
-	VIM_CLEAR(vim_tempdir);
+	vim_clear((void **)&vim_tempdir);
     }
 }
 
@@ -8001,7 +8001,7 @@ show_autocmd(AutoPat *ap, event_T event)
     static void
 au_remove_pat(AutoPat *ap)
 {
-    VIM_CLEAR(ap->pat);
+    vim_clear((void **)&ap->pat);
     ap->buflocal_nr = -1;
     au_need_clean = TRUE;
 }
@@ -8015,7 +8015,7 @@ au_remove_cmds(AutoPat *ap)
     AutoCmd *ac;
 
     for (ac = ap->cmds; ac != NULL; ac = ac->next)
-	VIM_CLEAR(ac->cmd);
+	vim_clear((void **)&ac->cmd);
     au_need_clean = TRUE;
 }
 
@@ -9073,7 +9073,7 @@ aucmd_prepbuf(
 
 	/* Make sure w_localdir and globaldir are NULL to avoid a chdir() in
 	 * win_enter_ext(). */
-	VIM_CLEAR(aucmd_win->w_localdir);
+	vim_clear((void **)&aucmd_win->w_localdir);
 	aco->globaldir = globaldir;
 	globaldir = NULL;
 
@@ -9855,7 +9855,7 @@ auto_next_pat(
     char_u	*name;
     char	*s;
 
-    VIM_CLEAR(sourcing_name);
+    vim_clear((void **)&sourcing_name);
 
     for (ap = apc->curpat; ap != NULL && !got_int; ap = ap->next)
     {
@@ -10538,7 +10538,7 @@ file_pat_to_reg_pat(
 	    EMSG(_("E219: Missing {."));
 	else
 	    EMSG(_("E220: Missing }."));
-	VIM_CLEAR(reg_pat);
+	vim_clear((void **)&reg_pat);
     }
     return reg_pat;
 }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1073,8 +1073,7 @@ retry:
 	if (tmpname != NULL)
 	{
 	    mch_remove(tmpname);		/* delete converted file */
-	    vim_free(tmpname);
-	    tmpname = NULL;
+	    VIM_CLEAR(tmpname);
 	}
     }
 
@@ -2602,8 +2601,7 @@ failed:
 #endif
 		msg_add_lines(c, (long)linecnt, filesize);
 
-	    vim_free(keep_msg);
-	    keep_msg = NULL;
+	    VIM_CLEAR(keep_msg);
 	    msg_scrolled_ign = TRUE;
 #ifdef ALWAYS_USE_GUI
 	    /* Don't show the message when reading stdin, it would end up in a
@@ -2955,8 +2953,7 @@ readfile_charconvert(
 	if (tmpname != NULL)
 	{
 	    mch_remove(tmpname);	/* delete converted file */
-	    vim_free(tmpname);
-	    tmpname = NULL;
+	    VIM_CLEAR(tmpname);
 	}
     }
 
@@ -3945,8 +3942,7 @@ buf_write(
 			if (st_new.st_dev == st_old.st_dev
 					    && st_new.st_ino == st_old.st_ino)
 			{
-			    vim_free(backup);
-			    backup = NULL;	/* no backup file to delete */
+			    VIM_CLEAR(backup);
 			    /*
 			     * may try again with 'shortname' set
 			     */
@@ -3980,10 +3976,7 @@ buf_write(
 				--*wp;
 			    /* They all exist??? Must be something wrong. */
 			    if (*wp == 'a')
-			    {
-				vim_free(backup);
-				backup = NULL;
-			    }
+				VIM_CLEAR(backup);
 			}
 		    }
 		    break;
@@ -4010,10 +4003,7 @@ buf_write(
 		    (void)umask(umask_save);
 #endif
 		    if (bfd < 0)
-		    {
-			vim_free(backup);
-			backup = NULL;
-		    }
+			VIM_CLEAR(backup);
 		    else
 		    {
 			/* Set file protection same as original file, but
@@ -4156,10 +4146,7 @@ buf_write(
 			    --*p;
 			/* They all exist??? Must be something wrong! */
 			if (*p == 'a')
-			{
-			    vim_free(backup);
-			    backup = NULL;
-			}
+			    VIM_CLEAR(backup);
 		    }
 		}
 		if (backup != NULL)
@@ -4177,8 +4164,7 @@ buf_write(
 		    if (vim_rename(fname, backup) == 0)
 			break;
 
-		    vim_free(backup);   /* don't do the rename below */
-		    backup = NULL;
+		    VIM_CLEAR(backup);   /* don't do the rename below */
 		}
 	    }
 	    if (backup == NULL && !forceit)
@@ -5080,8 +5066,7 @@ restore_backup:
 	    else if (mch_stat(org, &st) < 0)
 	    {
 		vim_rename(backup, (char_u *)org);
-		vim_free(backup);	    /* don't delete the file */
-		backup = NULL;
+		VIM_CLEAR(backup);	    /* don't delete the file */
 #ifdef UNIX
 		set_file_time((char_u *)org, st_old.st_atime, st_old.st_mtime);
 #endif
@@ -6228,8 +6213,7 @@ shorten_fnames(int force)
 		    || buf->b_sfname == NULL
 		    || mch_isFullName(buf->b_sfname)))
 	{
-	    vim_free(buf->b_sfname);
-	    buf->b_sfname = NULL;
+	    VIM_CLEAR(buf->b_sfname);
 	    p = shorten_fname(buf->b_ffname, dirname);
 	    if (p != NULL)
 	    {
@@ -7428,8 +7412,7 @@ vim_deltempdir(void)
 	/* remove the trailing path separator */
 	gettail(vim_tempdir)[-1] = NUL;
 	delete_recursive(vim_tempdir);
-	vim_free(vim_tempdir);
-	vim_tempdir = NULL;
+	VIM_CLEAR(vim_tempdir);
     }
 }
 
@@ -8018,8 +8001,7 @@ show_autocmd(AutoPat *ap, event_T event)
     static void
 au_remove_pat(AutoPat *ap)
 {
-    vim_free(ap->pat);
-    ap->pat = NULL;
+    VIM_CLEAR(ap->pat);
     ap->buflocal_nr = -1;
     au_need_clean = TRUE;
 }
@@ -8033,10 +8015,7 @@ au_remove_cmds(AutoPat *ap)
     AutoCmd *ac;
 
     for (ac = ap->cmds; ac != NULL; ac = ac->next)
-    {
-	vim_free(ac->cmd);
-	ac->cmd = NULL;
-    }
+	VIM_CLEAR(ac->cmd);
     au_need_clean = TRUE;
 }
 
@@ -9094,8 +9073,7 @@ aucmd_prepbuf(
 
 	/* Make sure w_localdir and globaldir are NULL to avoid a chdir() in
 	 * win_enter_ext(). */
-	vim_free(aucmd_win->w_localdir);
-	aucmd_win->w_localdir = NULL;
+	VIM_CLEAR(aucmd_win->w_localdir);
 	aco->globaldir = globaldir;
 	globaldir = NULL;
 
@@ -9868,8 +9846,7 @@ auto_next_pat(
     char_u	*name;
     char	*s;
 
-    vim_free(sourcing_name);
-    sourcing_name = NULL;
+    VIM_CLEAR(sourcing_name);
 
     for (ap = apc->curpat; ap != NULL && !got_int; ap = ap->next)
     {
@@ -10552,8 +10529,7 @@ file_pat_to_reg_pat(
 	    EMSG(_("E219: Missing {."));
 	else
 	    EMSG(_("E220: Missing }."));
-	vim_free(reg_pat);
-	reg_pat = NULL;
+	VIM_CLEAR(reg_pat);
     }
     return reg_pat;
 }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3942,7 +3942,7 @@ buf_write(
 			if (st_new.st_dev == st_old.st_dev
 					    && st_new.st_ino == st_old.st_ino)
 			{
-			    VIM_CLEAR(backup);
+			    VIM_CLEAR(backup);	/* no backup file to delete */
 			    /*
 			     * may try again with 'shortname' set
 			     */

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3838,8 +3838,7 @@ gui_mch_init(void)
 # endif
     }
 #endif
-    vim_free(gui_argv);
-    gui_argv = NULL;
+    VIM_CLEAR(gui_argv);
 
 #if GLIB_CHECK_VERSION(2,1,3)
     /* Set the human-readable application name */
@@ -4668,8 +4667,7 @@ gui_mch_open(void)
 		y += hh - pixel_height;
 	    gtk_window_move(GTK_WINDOW(gui.mainwin), x, y);
 	}
-	vim_free(gui.geom);
-	gui.geom = NULL;
+	VIM_CLEAR(gui.geom);
 
 	/* From now until everyone's stopped trying to set the window hints
 	 * to their correct minimum values, stop them being set as we need

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3838,7 +3838,7 @@ gui_mch_init(void)
 # endif
     }
 #endif
-    VIM_CLEAR(gui_argv);
+    vim_clear((void **)&gui_argv);
 
 #if GLIB_CHECK_VERSION(2,1,3)
     /* Set the human-readable application name */
@@ -4667,7 +4667,7 @@ gui_mch_open(void)
 		y += hh - pixel_height;
 	    gtk_window_move(GTK_WINDOW(gui.mainwin), x, y);
 	}
-	VIM_CLEAR(gui.geom);
+	vim_clear((void **)&gui.geom);
 
 	/* From now until everyone's stopped trying to set the window hints
 	 * to their correct minimum values, stop them being set as we need

--- a/src/gui_photon.c
+++ b/src/gui_photon.c
@@ -1040,7 +1040,7 @@ gui_ph_pg_remove_buffer(char *name)
 	PtSetResource(gui.vimPanelGroup, Pt_ARG_PG_PANEL_TITLES, &empty_title,
 		1);
 
-	VIM_CLEAR(panel_titles);
+	vim_clear((void **)&panel_titles);
     }
 }
 

--- a/src/gui_photon.c
+++ b/src/gui_photon.c
@@ -1040,8 +1040,7 @@ gui_ph_pg_remove_buffer(char *name)
 	PtSetResource(gui.vimPanelGroup, Pt_ARG_PG_PANEL_TITLES, &empty_title,
 		1);
 
-	vim_free(panel_titles);
-	panel_titles = NULL;
+	VIM_CLEAR(panel_titles);
     }
 }
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -4941,8 +4941,7 @@ _WndProc(
 		    char_u		*str = NULL;
 		    static void		*tt_text = NULL;
 
-		    vim_free(tt_text);
-		    tt_text = NULL;
+		    VIM_CLEAR(tt_text);
 
 # ifdef FEAT_GUI_TABLINE
 		    if (gui_mch_showing_tabline()

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -4941,7 +4941,7 @@ _WndProc(
 		    char_u		*str = NULL;
 		    static void		*tt_text = NULL;
 
-		    VIM_CLEAR(tt_text);
+		    vim_clear((void **)&tt_text);
 
 # ifdef FEAT_GUI_TABLINE
 		    if (gui_mch_showing_tabline()

--- a/src/gui_x11.c
+++ b/src/gui_x11.c
@@ -1567,8 +1567,7 @@ gui_mch_uninit(void)
     XtCloseDisplay(gui.dpy);
     gui.dpy = NULL;
     vimShell = (Widget)0;
-    vim_free(gui_argv);
-    gui_argv = NULL;
+    VIM_CLEAR(gui_argv);
 }
 
 /*
@@ -1741,8 +1740,7 @@ gui_mch_exit(int rc UNUSED)
      * says that this isn't needed when exiting, so just skip it. */
     XtCloseDisplay(gui.dpy);
 #endif
-    vim_free(gui_argv);
-    gui_argv = NULL;
+    VIM_CLEAR(gui_argv);
 }
 
 /*

--- a/src/gui_x11.c
+++ b/src/gui_x11.c
@@ -1567,7 +1567,7 @@ gui_mch_uninit(void)
     XtCloseDisplay(gui.dpy);
     gui.dpy = NULL;
     vimShell = (Widget)0;
-    VIM_CLEAR(gui_argv);
+    vim_clear((void **)&gui_argv);
 }
 
 /*
@@ -1740,7 +1740,7 @@ gui_mch_exit(int rc UNUSED)
      * says that this isn't needed when exiting, so just skip it. */
     XtCloseDisplay(gui.dpy);
 #endif
-    VIM_CLEAR(gui_argv);
+    vim_clear((void **)&gui_argv);
 }
 
 /*

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -2210,8 +2210,7 @@ mch_print_cleanup(void)
 	for (i = PRT_PS_FONT_ROMAN; i <= PRT_PS_FONT_BOLDOBLIQUE; i++)
 	{
 	    if (prt_ps_mb_font.ps_fontname[i] != NULL)
-		vim_free(prt_ps_mb_font.ps_fontname[i]);
-	    prt_ps_mb_font.ps_fontname[i] = NULL;
+		VIM_CLEAR(prt_ps_mb_font.ps_fontname[i]);
 	}
     }
 
@@ -2228,10 +2227,7 @@ mch_print_cleanup(void)
 	prt_file_error = FALSE;
     }
     if (prt_ps_file_name != NULL)
-    {
-	vim_free(prt_ps_file_name);
-	prt_ps_file_name = NULL;
-    }
+	VIM_CLEAR(prt_ps_file_name);
 }
 
     static float

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -2210,7 +2210,7 @@ mch_print_cleanup(void)
 	for (i = PRT_PS_FONT_ROMAN; i <= PRT_PS_FONT_BOLDOBLIQUE; i++)
 	{
 	    if (prt_ps_mb_font.ps_fontname[i] != NULL)
-		VIM_CLEAR(prt_ps_mb_font.ps_fontname[i]);
+		vim_clear((void **)&prt_ps_mb_font.ps_fontname[i]);
 	}
     }
 
@@ -2227,7 +2227,7 @@ mch_print_cleanup(void)
 	prt_file_error = FALSE;
     }
     if (prt_ps_file_name != NULL)
-	VIM_CLEAR(prt_ps_file_name);
+	vim_clear((void **)&prt_ps_file_name);
 }
 
     static float

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1479,8 +1479,7 @@ cs_insert_filelist(
     {
 	if ((csinfo[i].ppath = (char *)alloc((unsigned)strlen(ppath) + 1)) == NULL)
 	{
-	    vim_free(csinfo[i].fname);
-	    csinfo[i].fname = NULL;
+	    VIM_CLEAR(csinfo[i].fname);
 	    return -1;
 	}
 	(void)strcpy(csinfo[i].ppath, (const char *)ppath);
@@ -1491,10 +1490,8 @@ cs_insert_filelist(
     {
 	if ((csinfo[i].flags = (char *)alloc((unsigned)strlen(flags) + 1)) == NULL)
 	{
-	    vim_free(csinfo[i].fname);
-	    vim_free(csinfo[i].ppath);
-	    csinfo[i].fname = NULL;
-	    csinfo[i].ppath = NULL;
+	    VIM_CLEAR(csinfo[i].fname);
+	    VIM_CLEAR(csinfo[i].ppath);
 	    return -1;
 	}
 	(void)strcpy(csinfo[i].flags, (const char *)flags);
@@ -1939,10 +1936,8 @@ parse_out:
     if (totsofar == 0)
     {
 	/* No matches, free the arrays and return NULL in "*matches_p". */
-	vim_free(matches);
-	matches = NULL;
-	vim_free(cntxts);
-	cntxts = NULL;
+	VIM_CLEAR(matches);
+	VIM_CLEAR(cntxts);
     }
     *matched = totsofar;
     *matches_p = matches;

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1479,7 +1479,7 @@ cs_insert_filelist(
     {
 	if ((csinfo[i].ppath = (char *)alloc((unsigned)strlen(ppath) + 1)) == NULL)
 	{
-	    VIM_CLEAR(csinfo[i].fname);
+	    vim_clear((void **)&csinfo[i].fname);
 	    return -1;
 	}
 	(void)strcpy(csinfo[i].ppath, (const char *)ppath);
@@ -1490,8 +1490,8 @@ cs_insert_filelist(
     {
 	if ((csinfo[i].flags = (char *)alloc((unsigned)strlen(flags) + 1)) == NULL)
 	{
-	    VIM_CLEAR(csinfo[i].fname);
-	    VIM_CLEAR(csinfo[i].ppath);
+	    vim_clear((void **)&csinfo[i].fname);
+	    vim_clear((void **)&csinfo[i].ppath);
 	    return -1;
 	}
 	(void)strcpy(csinfo[i].flags, (const char *)flags);
@@ -1936,8 +1936,8 @@ parse_out:
     if (totsofar == 0)
     {
 	/* No matches, free the arrays and return NULL in "*matches_p". */
-	VIM_CLEAR(matches);
-	VIM_CLEAR(cntxts);
+	vim_clear((void **)&matches);
+	vim_clear((void **)&cntxts);
     }
     *matched = totsofar;
     *matches_p = matches;

--- a/src/macros.h
+++ b/src/macros.h
@@ -385,6 +385,8 @@
  */
 #define VIM_CLEAR(p) \
     do { \
-	vim_free(p); \
-	p = NULL; \
+	if ((p) != NULL) { \
+	    vim_free(p); \
+	    (p) = NULL; \
+	} \
     } while (0)

--- a/src/macros.h
+++ b/src/macros.h
@@ -379,3 +379,12 @@
 # define mch_enable_flush()
 # define mch_disable_flush()
 #endif
+
+/*
+ * Like vim_free(), and also set the pointer to NULL.
+ */
+#define VIM_CLEAR(p) \
+    do { \
+	vim_free(p); \
+	p = NULL; \
+    } while (0)

--- a/src/macros.h
+++ b/src/macros.h
@@ -379,14 +379,3 @@
 # define mch_enable_flush()
 # define mch_disable_flush()
 #endif
-
-/*
- * Like vim_free(), and also set the pointer to NULL.
- */
-#define VIM_CLEAR(p) \
-    do { \
-	if ((p) != NULL) { \
-	    vim_free(p); \
-	    (p) = NULL; \
-	} \
-    } while (0)

--- a/src/main.c
+++ b/src/main.c
@@ -3951,7 +3951,7 @@ cmdsrv_main(
 		{
 		    /* Output error from remote */
 		    mch_errmsg((char *)res);
-		    VIM_CLEAR(res);
+		    vim_clear((void **)&res);
 		}
 		mch_errmsg(_(": Send expression failed.\n"));
 	    }

--- a/src/main.c
+++ b/src/main.c
@@ -3954,8 +3954,7 @@ cmdsrv_main(
 		{
 		    /* Output error from remote */
 		    mch_errmsg((char *)res);
-		    vim_free(res);
-		    res = NULL;
+		    VIM_CLEAR(res);
 		}
 		mch_errmsg(_(": Send expression failed.\n"));
 	    }

--- a/src/mark.c
+++ b/src/mark.c
@@ -127,7 +127,7 @@ setmark_pos(int c, pos_T *pos, int fnum)
 	    i = c - 'A';
 	namedfm[i].fmark.mark = *pos;
 	namedfm[i].fmark.fnum = fnum;
-	VIM_CLEAR(namedfm[i].fname);
+	vim_clear((void **)&namedfm[i].fname);
 #ifdef FEAT_VIMINFO
 	namedfm[i].time_set = vim_time();
 #endif
@@ -597,7 +597,7 @@ fmarks_check_one(xfmark_T *fm, char_u *name, buf_T *buf)
 	    && fnamecmp(name, fm->fname) == 0)
     {
 	fm->fmark.fnum = buf->b_fnum;
-	VIM_CLEAR(fm->fname);
+	vim_clear((void **)&fm->fname);
     }
 }
 
@@ -860,7 +860,7 @@ ex_delmarks(exarg_T *eap)
 			else
 			    n = i - 'A';
 			namedfm[n].fmark.mark.lnum = 0;
-			VIM_CLEAR(namedfm[n].fname);
+			vim_clear((void **)&namedfm[n].fname);
 #ifdef FEAT_VIMINFO
 			namedfm[n].time_set = 0;
 #endif
@@ -1477,14 +1477,14 @@ finish_viminfo_marks(void)
     {
 	for (i = 0; i < NMARKS + EXTRA_MARKS; ++i)
 	    vim_free(vi_namedfm[i].fname);
-	VIM_CLEAR(vi_namedfm);
+	vim_clear((void **)&vi_namedfm);
     }
 #ifdef FEAT_JUMPLIST
     if (vi_jumplist != NULL)
     {
 	for (i = 0; i < vi_jumplist_len; ++i)
 	    vim_free(vi_jumplist[i].fname);
-	VIM_CLEAR(vi_jumplist);
+	vim_clear((void **)&vi_jumplist);
     }
 #endif
 }

--- a/src/mark.c
+++ b/src/mark.c
@@ -127,8 +127,7 @@ setmark_pos(int c, pos_T *pos, int fnum)
 	    i = c - 'A';
 	namedfm[i].fmark.mark = *pos;
 	namedfm[i].fmark.fnum = fnum;
-	vim_free(namedfm[i].fname);
-	namedfm[i].fname = NULL;
+	VIM_CLEAR(namedfm[i].fname);
 #ifdef FEAT_VIMINFO
 	namedfm[i].time_set = vim_time();
 #endif
@@ -598,8 +597,7 @@ fmarks_check_one(xfmark_T *fm, char_u *name, buf_T *buf)
 	    && fnamecmp(name, fm->fname) == 0)
     {
 	fm->fmark.fnum = buf->b_fnum;
-	vim_free(fm->fname);
-	fm->fname = NULL;
+	VIM_CLEAR(fm->fname);
     }
 }
 
@@ -862,8 +860,7 @@ ex_delmarks(exarg_T *eap)
 			else
 			    n = i - 'A';
 			namedfm[n].fmark.mark.lnum = 0;
-			vim_free(namedfm[n].fname);
-			namedfm[n].fname = NULL;
+			VIM_CLEAR(namedfm[n].fname);
 #ifdef FEAT_VIMINFO
 			namedfm[n].time_set = 0;
 #endif
@@ -1480,16 +1477,14 @@ finish_viminfo_marks(void)
     {
 	for (i = 0; i < NMARKS + EXTRA_MARKS; ++i)
 	    vim_free(vi_namedfm[i].fname);
-	vim_free(vi_namedfm);
-	vi_namedfm = NULL;
+	VIM_CLEAR(vi_namedfm);
     }
 #ifdef FEAT_JUMPLIST
     if (vi_jumplist != NULL)
     {
 	for (i = 0; i < vi_jumplist_len; ++i)
 	    vim_free(vi_jumplist[i].fname);
-	vim_free(vi_jumplist);
-	vi_jumplist = NULL;
+	VIM_CLEAR(vi_jumplist);
     }
 #endif
 }

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4666,7 +4666,7 @@ iconv_string(
 	else if (ICONV_ERRNO != ICONV_E2BIG)
 	{
 	    /* conversion failed */
-	    VIM_CLEAR(result);
+	    vim_clear((void **)&result);
 	    break;
 	}
 	/* Not enough room or skipping illegal sequence. */

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4666,8 +4666,7 @@ iconv_string(
 	else if (ICONV_ERRNO != ICONV_E2BIG)
 	{
 	    /* conversion failed */
-	    vim_free(result);
-	    result = NULL;
+	    VIM_CLEAR(result);
 	    break;
 	}
 	/* Not enough room or skipping illegal sequence. */

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -297,10 +297,8 @@ mf_close_file(
     if (mfp->mf_fname != NULL)
     {
 	mch_remove(mfp->mf_fname);		/* delete the swap file */
-	vim_free(mfp->mf_fname);
-	vim_free(mfp->mf_ffname);
-	mfp->mf_fname = NULL;
-	mfp->mf_ffname = NULL;
+	VIM_CLEAR(mfp->mf_fname);
+	VIM_CLEAR(mfp->mf_ffname);
     }
 }
 
@@ -1288,10 +1286,8 @@ mf_do_open(
      */
     if (mfp->mf_fd < 0)
     {
-	vim_free(mfp->mf_fname);
-	vim_free(mfp->mf_ffname);
-	mfp->mf_fname = NULL;
-	mfp->mf_ffname = NULL;
+	VIM_CLEAR(mfp->mf_fname);
+	VIM_CLEAR(mfp->mf_ffname);
     }
     else
     {

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -297,8 +297,8 @@ mf_close_file(
     if (mfp->mf_fname != NULL)
     {
 	mch_remove(mfp->mf_fname);		/* delete the swap file */
-	VIM_CLEAR(mfp->mf_fname);
-	VIM_CLEAR(mfp->mf_ffname);
+	vim_clear((void **)&mfp->mf_fname);
+	vim_clear((void **)&mfp->mf_ffname);
     }
 }
 
@@ -1286,8 +1286,8 @@ mf_do_open(
      */
     if (mfp->mf_fd < 0)
     {
-	VIM_CLEAR(mfp->mf_fname);
-	VIM_CLEAR(mfp->mf_ffname);
+	vim_clear((void **)&mfp->mf_fname);
+	vim_clear((void **)&mfp->mf_ffname);
     }
     else
     {

--- a/src/memline.c
+++ b/src/memline.c
@@ -535,8 +535,7 @@ ml_set_crypt_key(
 	idx = 0;		/* start with first index in block 1 */
 	error = 0;
 	buf->b_ml.ml_stack_top = 0;
-	vim_free(buf->b_ml.ml_stack);
-	buf->b_ml.ml_stack = NULL;
+	VIM_CLEAR(buf->b_ml.ml_stack);
 	buf->b_ml.ml_stack_size = 0;	/* no stack yet */
 
 	for ( ; !got_int; line_breakcheck())
@@ -852,8 +851,7 @@ ml_close(buf_T *buf, int del_file)
 	vim_free(buf->b_ml.ml_line_ptr);
     vim_free(buf->b_ml.ml_stack);
 #ifdef FEAT_BYTEOFF
-    vim_free(buf->b_ml.ml_chunksize);
-    buf->b_ml.ml_chunksize = NULL;
+    VIM_CLEAR(buf->b_ml.ml_chunksize);
 #endif
     buf->b_ml.ml_mfp = NULL;
 
@@ -4197,8 +4195,7 @@ findswapname(
 	    break;
 	if ((n = (int)STRLEN(fname)) == 0)	/* safety check */
 	{
-	    vim_free(fname);
-	    fname = NULL;
+	    VIM_CLEAR(fname);
 	    break;
 	}
 #if defined(UNIX)
@@ -4578,8 +4575,7 @@ findswapname(
 	    if (fname[n - 2] == 'a')    /* ".saa": tried enough, give up */
 	    {
 		EMSG(_("E326: Too many swap files found"));
-		vim_free(fname);
-		fname = NULL;
+		VIM_CLEAR(fname);
 		break;
 	    }
 	    --fname[n - 2];		/* ".svz", ".suz", etc. */

--- a/src/memline.c
+++ b/src/memline.c
@@ -535,7 +535,7 @@ ml_set_crypt_key(
 	idx = 0;		/* start with first index in block 1 */
 	error = 0;
 	buf->b_ml.ml_stack_top = 0;
-	VIM_CLEAR(buf->b_ml.ml_stack);
+	vim_clear((void **)&buf->b_ml.ml_stack);
 	buf->b_ml.ml_stack_size = 0;	/* no stack yet */
 
 	for ( ; !got_int; line_breakcheck())
@@ -851,7 +851,7 @@ ml_close(buf_T *buf, int del_file)
 	vim_free(buf->b_ml.ml_line_ptr);
     vim_free(buf->b_ml.ml_stack);
 #ifdef FEAT_BYTEOFF
-    VIM_CLEAR(buf->b_ml.ml_chunksize);
+    vim_clear((void **)&buf->b_ml.ml_chunksize);
 #endif
     buf->b_ml.ml_mfp = NULL;
 
@@ -4195,7 +4195,7 @@ findswapname(
 	    break;
 	if ((n = (int)STRLEN(fname)) == 0)	/* safety check */
 	{
-	    VIM_CLEAR(fname);
+	    vim_clear((void **)&fname);
 	    break;
 	}
 #if defined(UNIX)
@@ -4575,7 +4575,7 @@ findswapname(
 	    if (fname[n - 2] == 'a')    /* ".saa": tried enough, give up */
 	    {
 		EMSG(_("E326: Too many swap files found"));
-		VIM_CLEAR(fname);
+		vim_clear((void **)&fname);
 		break;
 	    }
 	    --fname[n - 2];		/* ".svz", ".suz", etc. */

--- a/src/menu.c
+++ b/src/menu.c
@@ -727,7 +727,7 @@ add_menu_path(
 	menup = &menu->children;
 	parent = menu;
 	name = next_name;
-	VIM_CLEAR(dname);
+	vim_clear((void **)&dname);
 	if (pri_tab[pri_idx + 1] != -1)
 	    ++pri_idx;
     }

--- a/src/menu.c
+++ b/src/menu.c
@@ -727,8 +727,7 @@ add_menu_path(
 	menup = &menu->children;
 	parent = menu;
 	name = next_name;
-	vim_free(dname);
-	dname = NULL;
+	VIM_CLEAR(dname);
 	if (pri_tab[pri_idx + 1] != -1)
 	    ++pri_idx;
     }

--- a/src/message.c
+++ b/src/message.c
@@ -415,7 +415,7 @@ static char_u   *last_sourcing_name = NULL;
     void
 reset_last_sourcing(void)
 {
-    VIM_CLEAR(last_sourcing_name);
+    vim_clear((void **)&last_sourcing_name);
     last_sourcing_lnum = 0;
 }
 
@@ -1248,7 +1248,7 @@ wait_return(int redraw)
     reset_last_sourcing();
     if (keep_msg != NULL && vim_strsize(keep_msg) >=
 				  (Rows - cmdline_row - 1) * Columns + sc_col)
-	VIM_CLEAR(keep_msg);	    /* don't redisplay message, it's too long */
+	vim_clear((void **)&keep_msg);	    /* don't redisplay message, it's too long */
 
     if (tmpState == SETWSIZE)	    /* got resize event while in vgetc() */
     {
@@ -1321,7 +1321,7 @@ msg_start(void)
     int		did_return = FALSE;
 
     if (!msg_silent)
-	VIM_CLEAR(keep_msg);
+	vim_clear((void **)&keep_msg);
 
 #ifdef FEAT_EVAL
     if (need_clr_eos)
@@ -3474,7 +3474,7 @@ give_warning(char_u *message, int hl)
 #ifdef FEAT_EVAL
     set_vim_var_string(VV_WARNINGMSG, message, -1);
 #endif
-    VIM_CLEAR(keep_msg);
+    vim_clear((void **)&keep_msg);
     if (hl)
 	keep_msg_attr = HL_ATTR(HLF_W);
     else

--- a/src/message.c
+++ b/src/message.c
@@ -415,8 +415,7 @@ static char_u   *last_sourcing_name = NULL;
     void
 reset_last_sourcing(void)
 {
-    vim_free(last_sourcing_name);
-    last_sourcing_name = NULL;
+    VIM_CLEAR(last_sourcing_name);
     last_sourcing_lnum = 0;
 }
 
@@ -1249,10 +1248,7 @@ wait_return(int redraw)
     reset_last_sourcing();
     if (keep_msg != NULL && vim_strsize(keep_msg) >=
 				  (Rows - cmdline_row - 1) * Columns + sc_col)
-    {
-	vim_free(keep_msg);
-	keep_msg = NULL;	    /* don't redisplay message, it's too long */
-    }
+	VIM_CLEAR(keep_msg);	    /* don't redisplay message, it's too long */
 
     if (tmpState == SETWSIZE)	    /* got resize event while in vgetc() */
     {
@@ -1325,10 +1321,7 @@ msg_start(void)
     int		did_return = FALSE;
 
     if (!msg_silent)
-    {
-	vim_free(keep_msg);
-	keep_msg = NULL;		/* don't display old message now */
-    }
+	VIM_CLEAR(keep_msg);
 
 #ifdef FEAT_EVAL
     if (need_clr_eos)
@@ -3481,8 +3474,7 @@ give_warning(char_u *message, int hl)
 #ifdef FEAT_EVAL
     set_vim_var_string(VV_WARNINGMSG, message, -1);
 #endif
-    vim_free(keep_msg);
-    keep_msg = NULL;
+    VIM_CLEAR(keep_msg);
     if (hl)
 	keep_msg_attr = HL_ATTR(HLF_W);
     else

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3745,8 +3745,7 @@ init_homedir(void)
     char_u  *var;
 
     /* In case we are called a second time (when 'encoding' changes). */
-    vim_free(homedir);
-    homedir = NULL;
+    VIM_CLEAR(homedir);
 
 #ifdef VMS
     var = mch_getenv((char_u *)"SYS$LOGIN");
@@ -4358,10 +4357,7 @@ vim_getenv(char_u *name, int *mustfree)
 		p = vim_strnsave(p, (int)(pend - p));
 
 	    if (p != NULL && !mch_isdir(p))
-	    {
-		vim_free(p);
-		p = NULL;
-	    }
+		VIM_CLEAR(p);
 	    else
 	    {
 #ifdef USE_EXE_NAME
@@ -9775,8 +9771,7 @@ expand_wildcards(
 	/* If the number of matches is now zero, we fail. */
 	if (*num_files == 0)
 	{
-	    vim_free(*files);
-	    *files = NULL;
+	    VIM_CLEAR(*files);
 	    return FAIL;
 	}
     }
@@ -10031,10 +10026,7 @@ dos_expandpath(
 	    hFind = FindFirstFileW(wn, &wfb);
 	    if (hFind == INVALID_HANDLE_VALUE
 			      && GetLastError() == ERROR_CALL_NOT_IMPLEMENTED)
-	    {
-		vim_free(wn);
-		wn = NULL;
-	    }
+		VIM_CLEAR(wn);
 	}
     }
 
@@ -10122,8 +10114,7 @@ dos_expandpath(
 # endif
 		hFind = FindFirstFile((LPCSTR)buf, &fb);
 	    ok = (hFind != INVALID_HANDLE_VALUE);
-	    vim_free(matchname);
-	    matchname = NULL;
+	    VIM_CLEAR(matchname);
 	}
     }
 
@@ -11256,8 +11247,7 @@ get_cmd_output(
     if (i != len)
     {
 	EMSG2(_(e_notread), tempname);
-	vim_free(buffer);
-	buffer = NULL;
+	VIM_CLEAR(buffer);
     }
     else if (ret_len == NULL)
     {

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3745,7 +3745,7 @@ init_homedir(void)
     char_u  *var;
 
     /* In case we are called a second time (when 'encoding' changes). */
-    VIM_CLEAR(homedir);
+    vim_clear((void **)&homedir);
 
 #ifdef VMS
     var = mch_getenv((char_u *)"SYS$LOGIN");
@@ -4357,7 +4357,7 @@ vim_getenv(char_u *name, int *mustfree)
 		p = vim_strnsave(p, (int)(pend - p));
 
 	    if (p != NULL && !mch_isdir(p))
-		VIM_CLEAR(p);
+		vim_clear((void **)&p);
 	    else
 	    {
 #ifdef USE_EXE_NAME
@@ -9771,7 +9771,7 @@ expand_wildcards(
 	/* If the number of matches is now zero, we fail. */
 	if (*num_files == 0)
 	{
-	    VIM_CLEAR(*files);
+	    vim_clear((void **)files);
 	    return FAIL;
 	}
     }
@@ -10026,7 +10026,7 @@ dos_expandpath(
 	    hFind = FindFirstFileW(wn, &wfb);
 	    if (hFind == INVALID_HANDLE_VALUE
 			      && GetLastError() == ERROR_CALL_NOT_IMPLEMENTED)
-		VIM_CLEAR(wn);
+		vim_clear((void **)&wn);
 	}
     }
 
@@ -10114,7 +10114,7 @@ dos_expandpath(
 # endif
 		hFind = FindFirstFile((LPCSTR)buf, &fb);
 	    ok = (hFind != INVALID_HANDLE_VALUE);
-	    VIM_CLEAR(matchname);
+	    vim_clear((void **)&matchname);
 	}
     }
 
@@ -11247,7 +11247,7 @@ get_cmd_output(
     if (i != len)
     {
 	EMSG2(_(e_notread), tempname);
-	VIM_CLEAR(buffer);
+	vim_clear((void **)&buffer);
     }
     else if (ret_len == NULL)
     {

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1827,8 +1827,6 @@ copy_option_part(
  * Replacement for free() that ignores NULL pointers.
  * Also skip free() when exiting for sure, this helps when we caught a deadly
  * signal that was caused by a crash in free().
- * If you want to set NULL after calling this function, you should use
- * VIM_CLEAR() instead.
  */
     void
 vim_free(void *x)
@@ -1839,6 +1837,19 @@ vim_free(void *x)
 	mem_pre_free(&x);
 #endif
 	free(x);
+    }
+}
+
+/*
+ * Like vim_free(), and also set the pointer to NULL.
+ */
+    void
+vim_clear(void **x)
+{
+    if (*x != NULL)
+    {
+	vim_free(*x);
+	*x = NULL;
     }
 }
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1823,6 +1823,8 @@ copy_option_part(
  * Replacement for free() that ignores NULL pointers.
  * Also skip free() when exiting for sure, this helps when we caught a deadly
  * signal that was caused by a crash in free().
+ * If you want to set NULL after calling this function, you should use
+ * VIM_CLEAR() instead.
  */
     void
 vim_free(void *x)
@@ -1833,19 +1835,6 @@ vim_free(void *x)
 	mem_pre_free(&x);
 #endif
 	free(x);
-    }
-}
-
-/*
- * Like vim_free(), and also set the pointer to NULL.
- */
-    void
-vim_clear(void **x)
-{
-    if (*x != NULL)
-    {
-	vim_free(*x);
-	*x = NULL;
     }
 }
 

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -580,8 +580,7 @@ nb_free(void)
 	    buf.bufp->b_was_netbeans_file = FALSE;
 	}
     }
-    vim_free(buf_list);
-    buf_list = NULL;
+    VIM_CLEAR(buf_list);
     buf_list_size = 0;
     buf_list_used = 0;
 
@@ -1477,8 +1476,7 @@ nb_do_cmd(
 		EMSG("E636: invalid buffer identifier in create");
 		return FAIL;
 	    }
-	    vim_free(buf->displayname);
-	    buf->displayname = NULL;
+	    VIM_CLEAR(buf->displayname);
 
 	    netbeansReadFile = 0; /* don't try to open disk file */
 	    do_ecmd(0, NULL, 0, 0, ECMD_ONE, ECMD_HIDE + ECMD_OLDBUF, curwin);
@@ -3447,8 +3445,7 @@ print_read_msg(nbbuf_T *buf)
     msg_add_lines(c, (long)lnum, nchars);
 
     /* Now display it */
-    vim_free(keep_msg);
-    keep_msg = NULL;
+    VIM_CLEAR(keep_msg);
     msg_scrolled_ign = TRUE;
     msg_trunc_attr(IObuff, FALSE, 0);
     msg_scrolled_ign = FALSE;
@@ -3475,8 +3472,7 @@ print_save_msg(nbbuf_T *buf, off_T nchars)
 	msg_add_lines(c, buf->bufp->b_ml.ml_line_count,
 						buf->bufp->b_orig_size);
 
-	vim_free(keep_msg);
-	keep_msg = NULL;
+	VIM_CLEAR(keep_msg);
 	msg_scrolled_ign = TRUE;
 	p = msg_trunc_attr(IObuff, FALSE, 0);
 	if ((msg_scrolled && !need_wait_return) || !buf->initDone)

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -580,7 +580,7 @@ nb_free(void)
 	    buf.bufp->b_was_netbeans_file = FALSE;
 	}
     }
-    VIM_CLEAR(buf_list);
+    vim_clear((void **)&buf_list);
     buf_list_size = 0;
     buf_list_used = 0;
 
@@ -1476,7 +1476,7 @@ nb_do_cmd(
 		EMSG("E636: invalid buffer identifier in create");
 		return FAIL;
 	    }
-	    VIM_CLEAR(buf->displayname);
+	    vim_clear((void **)&buf->displayname);
 
 	    netbeansReadFile = 0; /* don't try to open disk file */
 	    do_ecmd(0, NULL, 0, 0, ECMD_ONE, ECMD_HIDE + ECMD_OLDBUF, curwin);
@@ -3445,7 +3445,7 @@ print_read_msg(nbbuf_T *buf)
     msg_add_lines(c, (long)lnum, nchars);
 
     /* Now display it */
-    VIM_CLEAR(keep_msg);
+    vim_clear((void **)&keep_msg);
     msg_scrolled_ign = TRUE;
     msg_trunc_attr(IObuff, FALSE, 0);
     msg_scrolled_ign = FALSE;
@@ -3472,7 +3472,7 @@ print_save_msg(nbbuf_T *buf, off_T nchars)
 	msg_add_lines(c, buf->bufp->b_ml.ml_line_count,
 						buf->bufp->b_orig_size);
 
-	VIM_CLEAR(keep_msg);
+	vim_clear((void **)&keep_msg);
 	msg_scrolled_ign = TRUE;
 	p = msg_trunc_attr(IObuff, FALSE, 0);
 	if ((msg_scrolled && !need_wait_return) || !buf->initDone)

--- a/src/normal.c
+++ b/src/normal.c
@@ -1482,7 +1482,7 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 		{
 		    AppendToRedobuffLit(repeat_cmdline, -1);
 		    AppendToRedobuff(NL_STR);
-		    VIM_CLEAR(repeat_cmdline);
+		    vim_clear((void **)&repeat_cmdline);
 		}
 	    }
 	}

--- a/src/normal.c
+++ b/src/normal.c
@@ -1482,8 +1482,7 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 		{
 		    AppendToRedobuffLit(repeat_cmdline, -1);
 		    AppendToRedobuff(NL_STR);
-		    vim_free(repeat_cmdline);
-		    repeat_cmdline = NULL;
+		    VIM_CLEAR(repeat_cmdline);
 		}
 	    }
 	}

--- a/src/ops.c
+++ b/src/ops.c
@@ -1235,7 +1235,7 @@ do_execreg(
 	    EMSG(_(e_nolastcmd));
 	    return FAIL;
 	}
-	VIM_CLEAR(new_last_cmdline); /* don't keep the cmdline containing @: */
+	vim_clear((void **)&new_last_cmdline); /* don't keep the cmdline containing @: */
 	/* Escape all control characters with a CTRL-V */
 	p = vim_strsave_escaped_ext(last_cmdline,
 		(char_u *)"\001\002\003\004\005\006\007\010\011\012\013\014\015\016\017\020\021\022\023\024\025\026\027\030\031\032\033\034\035\036\037", Ctrl_V, FALSE);
@@ -2994,7 +2994,7 @@ free_yank(long n)
 #endif
 	    vim_free(y_current->y_array[i]);
 	}
-	VIM_CLEAR(y_current->y_array);
+	vim_clear((void **)&y_current->y_array);
 #ifdef AMIGA
 	if (n >= 1000)
 	    MSG("");
@@ -6038,7 +6038,7 @@ finish_viminfo_registers(void)
 		    vim_free(y_read_regs[i].y_array[j]);
 		vim_free(y_read_regs[i].y_array);
 	    }
-	VIM_CLEAR(y_read_regs);
+	vim_clear((void **)&y_read_regs);
     }
 }
 
@@ -7143,7 +7143,7 @@ str_to_reg(
     /* Without any lines make the register empty. */
     if (y_ptr->y_size + newlines == 0)
     {
-	VIM_CLEAR(y_ptr->y_array);
+	vim_clear((void **)&y_ptr->y_array);
 	return;
     }
 

--- a/src/ops.c
+++ b/src/ops.c
@@ -1235,8 +1235,7 @@ do_execreg(
 	    EMSG(_(e_nolastcmd));
 	    return FAIL;
 	}
-	vim_free(new_last_cmdline); /* don't keep the cmdline containing @: */
-	new_last_cmdline = NULL;
+	VIM_CLEAR(new_last_cmdline); /* don't keep the cmdline containing @: */
 	/* Escape all control characters with a CTRL-V */
 	p = vim_strsave_escaped_ext(last_cmdline,
 		(char_u *)"\001\002\003\004\005\006\007\010\011\012\013\014\015\016\017\020\021\022\023\024\025\026\027\030\031\032\033\034\035\036\037", Ctrl_V, FALSE);
@@ -2995,8 +2994,7 @@ free_yank(long n)
 #endif
 	    vim_free(y_current->y_array[i]);
 	}
-	vim_free(y_current->y_array);
-	y_current->y_array = NULL;
+	VIM_CLEAR(y_current->y_array);
 #ifdef AMIGA
 	if (n >= 1000)
 	    MSG("");
@@ -6040,8 +6038,7 @@ finish_viminfo_registers(void)
 		    vim_free(y_read_regs[i].y_array[j]);
 		vim_free(y_read_regs[i].y_array);
 	    }
-	vim_free(y_read_regs);
-	y_read_regs = NULL;
+	VIM_CLEAR(y_read_regs);
     }
 }
 
@@ -7146,8 +7143,7 @@ str_to_reg(
     /* Without any lines make the register empty. */
     if (y_ptr->y_size + newlines == 0)
     {
-	vim_free(y_ptr->y_array);
-	y_ptr->y_array = NULL;
+	VIM_CLEAR(y_ptr->y_array);
 	return;
     }
 

--- a/src/option.c
+++ b/src/option.c
@@ -11728,8 +11728,7 @@ ExpandOldSetting(int *num_file, char_u ***file)
 
     if (buf == NULL)
     {
-	vim_free(*file);
-	*file = NULL;
+	VIM_CLEAR(*file);
 	return FAIL;
     }
 

--- a/src/option.c
+++ b/src/option.c
@@ -11735,7 +11735,7 @@ ExpandOldSetting(int *num_file, char_u ***file)
 
     if (buf == NULL)
     {
-	VIM_CLEAR(*file);
+	vim_clear((void **)file);
 	return FAIL;
     }
 

--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -1619,7 +1619,7 @@ mch_getenv(char_u *var)
     else
 #endif
     {
-	VIM_CLEAR(alloced);
+	vim_clear((void **)&alloced);
 	retval = NULL;
 
 	buf = alloc(IOSIZE);

--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -1619,8 +1619,7 @@ mch_getenv(char_u *var)
     else
 #endif
     {
-	vim_free(alloced);
-	alloced = NULL;
+	VIM_CLEAR(alloced);
 	retval = NULL;
 
 	buf = alloc(IOSIZE);

--- a/src/os_mac_conv.c
+++ b/src/os_mac_conv.c
@@ -480,10 +480,7 @@ mac_precompose_path(
 	    if (TECConvertText(gPathConverter, decompPath,
 			decompLen, &decompLen, result,
 			decompLen, &actualLen) != noErr)
-	    {
-		vim_free(result);
-		result = NULL;
-	    }
+		VIM_CLEAR(result);
 	}
     }
 
@@ -517,10 +514,7 @@ mac_utf16_to_utf8(
 	    utf8_len += inputRead;
 	}
 	else
-	{
-	    vim_free(result);
-	    result = NULL;
-	}
+	    VIM_CLEAR(result);
     }
     else
     {

--- a/src/os_mac_conv.c
+++ b/src/os_mac_conv.c
@@ -480,7 +480,7 @@ mac_precompose_path(
 	    if (TECConvertText(gPathConverter, decompPath,
 			decompLen, &decompLen, result,
 			decompLen, &actualLen) != noErr)
-		VIM_CLEAR(result);
+		vim_clear((void **)&result);
 	}
     }
 
@@ -514,7 +514,7 @@ mac_utf16_to_utf8(
 	    utf8_len += inputRead;
 	}
 	else
-	    VIM_CLEAR(result);
+	    vim_clear((void **)&result);
     }
     else
     {

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -1233,7 +1233,7 @@ PrintDlgProc(
 	    if (prt_name != NULL)
 	    {
 		vimSetDlgItemText(hDlg, IDC_PRINTTEXT2, (char_u *)prt_name);
-		VIM_CLEAR(prt_name);
+		vim_clear((void **)&prt_name);
 	    }
 	    EnableMenuItem(GetSystemMenu(hDlg, FALSE), SC_CLOSE, MF_GRAYED);
 #ifndef FEAT_GUI

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -1233,8 +1233,7 @@ PrintDlgProc(
 	    if (prt_name != NULL)
 	    {
 		vimSetDlgItemText(hDlg, IDC_PRINTTEXT2, (char_u *)prt_name);
-		vim_free(prt_name);
-		prt_name = NULL;
+		VIM_CLEAR(prt_name);
 	    }
 	    EnableMenuItem(GetSystemMenu(hDlg, FALSE), SC_CLOSE, MF_GRAYED);
 #ifndef FEAT_GUI

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1311,7 +1311,7 @@ mch_suspend(void)
     /*
      * Set oldtitle to NULL, so the current title is obtained again.
      */
-    VIM_CLEAR(oldtitle);
+    vim_clear((void **)&oldtitle);
 # endif
     settmode(TMODE_RAW);
     need_check_timestamps = TRUE;
@@ -3260,7 +3260,7 @@ mch_free_mem(void)
 	XCloseDisplay(x11_display);
 # endif
 # if defined(HAVE_SIGALTSTACK) || defined(HAVE_SIGSTACK)
-    VIM_CLEAR(signal_stack);
+    vim_clear((void **)&signal_stack);
 # endif
 # ifdef FEAT_TITLE
     vim_free(oldtitle);
@@ -6763,7 +6763,7 @@ mch_expand_wildcards(
 
     if (*num_file == 0)	    /* rejected all entries */
     {
-	VIM_CLEAR(*file);
+	vim_clear((void **)file);
 	goto notfound;
     }
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1311,8 +1311,7 @@ mch_suspend(void)
     /*
      * Set oldtitle to NULL, so the current title is obtained again.
      */
-    vim_free(oldtitle);
-    oldtitle = NULL;
+    VIM_CLEAR(oldtitle);
 # endif
     settmode(TMODE_RAW);
     need_check_timestamps = TRUE;
@@ -3261,8 +3260,7 @@ mch_free_mem(void)
 	XCloseDisplay(x11_display);
 # endif
 # if defined(HAVE_SIGALTSTACK) || defined(HAVE_SIGSTACK)
-    vim_free(signal_stack);
-    signal_stack = NULL;
+    VIM_CLEAR(signal_stack);
 # endif
 # ifdef FEAT_TITLE
     vim_free(oldtitle);
@@ -6765,8 +6763,7 @@ mch_expand_wildcards(
 
     if (*num_file == 0)	    /* rejected all entries */
     {
-	vim_free(*file);
-	*file = NULL;
+	VIM_CLEAR(*file);
 	goto notfound;
     }
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2252,8 +2252,7 @@ SaveConsoleBuffer(
 	cb->Regions = (PSMALL_RECT)alloc(cb->NumRegions * sizeof(SMALL_RECT));
 	if (cb->Regions == NULL)
 	{
-	    vim_free(cb->Buffer);
-	    cb->Buffer = NULL;
+	    VIM_CLEAR(cb->Buffer);
 	    return FALSE;
 	}
     }
@@ -2278,10 +2277,8 @@ SaveConsoleBuffer(
 		BufferCoord,			/* offset in our buffer */
 		&ReadRegion))			/* region to save */
 	{
-	    vim_free(cb->Buffer);
-	    cb->Buffer = NULL;
-	    vim_free(cb->Regions);
-	    cb->Regions = NULL;
+	    VIM_CLEAR(cb->Buffer);
+	    VIM_CLEAR(cb->Regions);
 	    return FALSE;
 	}
 	cb->Regions[i] = ReadRegion;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2252,7 +2252,7 @@ SaveConsoleBuffer(
 	cb->Regions = (PSMALL_RECT)alloc(cb->NumRegions * sizeof(SMALL_RECT));
 	if (cb->Regions == NULL)
 	{
-	    VIM_CLEAR(cb->Buffer);
+	    vim_clear((void **)&cb->Buffer);
 	    return FALSE;
 	}
     }
@@ -2277,8 +2277,8 @@ SaveConsoleBuffer(
 		BufferCoord,			/* offset in our buffer */
 		&ReadRegion))			/* region to save */
 	{
-	    VIM_CLEAR(cb->Buffer);
-	    VIM_CLEAR(cb->Regions);
+	    vim_clear((void **)&cb->Buffer);
+	    vim_clear((void **)&cb->Regions);
 	    return FALSE;
 	}
 	cb->Regions[i] = ReadRegion;

--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -915,8 +915,7 @@ ui_remove_balloon(void)
 	pum_undisplay();
 	while (balloon_arraysize > 0)
 	    vim_free(balloon_array[--balloon_arraysize].pum_text);
-	vim_free(balloon_array);
-	balloon_array = NULL;
+	VIM_CLEAR(balloon_array);
     }
 }
 

--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -975,7 +975,7 @@ ui_remove_balloon(void)
 	pum_undisplay();
 	while (balloon_arraysize > 0)
 	    vim_free(balloon_array[--balloon_arraysize].pum_text);
-	VIM_CLEAR(balloon_array);
+	vim_clear((void **)&balloon_array);
     }
 }
 

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -46,7 +46,6 @@ void vim_strncpy(char_u *to, char_u *from, size_t len);
 void vim_strcat(char_u *to, char_u *from, size_t tosize);
 int copy_option_part(char_u **option, char_u *buf, int maxlen, char *sep_chars);
 void vim_free(void *x);
-void vim_clear(void **x);
 int vim_stricmp(char *s1, char *s2);
 int vim_strnicmp(char *s1, char *s2, size_t len);
 char_u *vim_strchr(char_u *string, int c);

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -46,6 +46,7 @@ void vim_strncpy(char_u *to, char_u *from, size_t len);
 void vim_strcat(char_u *to, char_u *from, size_t tosize);
 int copy_option_part(char_u **option, char_u *buf, int maxlen, char *sep_chars);
 void vim_free(void *x);
+void vim_clear(void **x);
 int vim_stricmp(char *s1, char *s2);
 int vim_strnicmp(char *s1, char *s2, size_t len);
 char_u *vim_strchr(char_u *string, int c);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1177,7 +1177,7 @@ qf_init_ext(
     int		    status;
 
     /* Do not used the cached buffer, it may have been wiped out. */
-    VIM_CLEAR(qf_last_bufname);
+    vim_clear((void **)&qf_last_bufname);
 
     vim_memset(&state, 0, sizeof(state));
     vim_memset(&fields, 0, sizeof(fields));
@@ -1228,7 +1228,7 @@ qf_init_ext(
     if (last_efm == NULL || (STRCMP(last_efm, efm) != 0))
     {
 	/* free the previously parsed data */
-	VIM_CLEAR(last_efm);
+	vim_clear((void **)&last_efm);
 	free_efm_list(&fmt_first);
 
 	/* parse the current 'efm' */
@@ -1349,7 +1349,7 @@ qf_init_end:
     static void
 qf_store_title(qf_info_T *qi, int qf_idx, char_u *title)
 {
-    VIM_CLEAR(qi->qf_lists[qf_idx].qf_title);
+    vim_clear((void **)&qi->qf_lists[qf_idx].qf_title);
 
     if (title != NULL)
     {
@@ -3000,7 +3000,7 @@ qf_free(qf_info_T *qi, int idx)
 
     qf_free_items(qi, idx);
 
-    VIM_CLEAR(qfl->qf_title);
+    vim_clear((void **)&qfl->qf_title);
     free_tv(qfl->qf_ctx);
     qfl->qf_ctx = NULL;
     qfl->qf_id = 0;

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1177,8 +1177,7 @@ qf_init_ext(
     int		    status;
 
     /* Do not used the cached buffer, it may have been wiped out. */
-    vim_free(qf_last_bufname);
-    qf_last_bufname = NULL;
+    VIM_CLEAR(qf_last_bufname);
 
     vim_memset(&state, 0, sizeof(state));
     vim_memset(&fields, 0, sizeof(fields));
@@ -1229,8 +1228,7 @@ qf_init_ext(
     if (last_efm == NULL || (STRCMP(last_efm, efm) != 0))
     {
 	/* free the previously parsed data */
-	vim_free(last_efm);
-	last_efm = NULL;
+	VIM_CLEAR(last_efm);
 	free_efm_list(&fmt_first);
 
 	/* parse the current 'efm' */
@@ -1351,8 +1349,7 @@ qf_init_end:
     static void
 qf_store_title(qf_info_T *qi, int qf_idx, char_u *title)
 {
-    vim_free(qi->qf_lists[qf_idx].qf_title);
-    qi->qf_lists[qf_idx].qf_title = NULL;
+    VIM_CLEAR(qi->qf_lists[qf_idx].qf_title);
 
     if (title != NULL)
     {
@@ -3003,8 +3000,7 @@ qf_free(qf_info_T *qi, int idx)
 
     qf_free_items(qi, idx);
 
-    vim_free(qfl->qf_title);
-    qfl->qf_title = NULL;
+    VIM_CLEAR(qfl->qf_title);
     free_tv(qfl->qf_ctx);
     qfl->qf_ctx = NULL;
     qfl->qf_id = 0;

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -3996,7 +3996,7 @@ theend:
     /* Free "reg_tofree" when it's a bit big.
      * Free regstack and backpos if they are bigger than their initial size. */
     if (reg_tofreelen > 400)
-	VIM_CLEAR(reg_tofree);
+	vim_clear((void **)&reg_tofree);
     if (regstack.ga_maxlen > REGSTACK_INITIAL)
 	ga_clear(&regstack);
     if (backpos.ga_maxlen > BACKPOS_INITIAL)
@@ -7518,7 +7518,7 @@ vim_regsub_both(
 	    {
 		STRCPY(dest, eval_result);
 		dst += STRLEN(eval_result);
-		VIM_CLEAR(eval_result);
+		vim_clear((void **)&eval_result);
 	    }
 	}
 	else

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -3996,10 +3996,7 @@ theend:
     /* Free "reg_tofree" when it's a bit big.
      * Free regstack and backpos if they are bigger than their initial size. */
     if (reg_tofreelen > 400)
-    {
-	vim_free(reg_tofree);
-	reg_tofree = NULL;
-    }
+	VIM_CLEAR(reg_tofree);
     if (regstack.ga_maxlen > REGSTACK_INITIAL)
 	ga_clear(&regstack);
     if (backpos.ga_maxlen > BACKPOS_INITIAL)
@@ -7521,8 +7518,7 @@ vim_regsub_both(
 	    {
 		STRCPY(dest, eval_result);
 		dst += STRLEN(eval_result);
-		vim_free(eval_result);
-		eval_result = NULL;
+		VIM_CLEAR(eval_result);
 	    }
 	}
 	else

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -7334,13 +7334,13 @@ nfa_regcomp(char_u *expr, int re_flags)
     nfa_regengine.expr = NULL;
 
 out:
-    VIM_CLEAR(post_start);
+    vim_clear((void **)&post_start);
     post_ptr = post_end = NULL;
     state_ptr = NULL;
     return (regprog_T *)prog;
 
 fail:
-    VIM_CLEAR(prog);
+    vim_clear((void **)&prog);
 #ifdef ENABLE_LOG
     nfa_postfix_dump(expr, FAIL);
 #endif

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -7334,14 +7334,13 @@ nfa_regcomp(char_u *expr, int re_flags)
     nfa_regengine.expr = NULL;
 
 out:
-    vim_free(post_start);
-    post_start = post_ptr = post_end = NULL;
+    VIM_CLEAR(post_start);
+    post_ptr = post_end = NULL;
     state_ptr = NULL;
     return (regprog_T *)prog;
 
 fail:
-    vim_free(prog);
-    prog = NULL;
+    VIM_CLEAR(prog);
 #ifdef ENABLE_LOG
     nfa_postfix_dump(expr, FAIL);
 #endif

--- a/src/screen.c
+++ b/src/screen.c
@@ -4326,10 +4326,7 @@ win_line(
 #endif
 
 	    if (p_extra_free != NULL)
-	    {
-		vim_free(p_extra_free);
-		p_extra_free = NULL;
-	    }
+		VIM_CLEAR(p_extra_free);
 	    /*
 	     * Get a character from the line itself.
 	     */
@@ -8860,27 +8857,17 @@ give_up:
 	     * and over again. */
 	    done_outofmem_msg = TRUE;
 	}
-	vim_free(new_ScreenLines);
-	new_ScreenLines = NULL;
+	VIM_CLEAR(new_ScreenLines);
 #ifdef FEAT_MBYTE
-	vim_free(new_ScreenLinesUC);
-	new_ScreenLinesUC = NULL;
+	VIM_CLEAR(new_ScreenLinesUC);
 	for (i = 0; i < p_mco; ++i)
-	{
-	    vim_free(new_ScreenLinesC[i]);
-	    new_ScreenLinesC[i] = NULL;
-	}
-	vim_free(new_ScreenLines2);
-	new_ScreenLines2 = NULL;
+	    VIM_CLEAR(new_ScreenLinesC[i]);
+	VIM_CLEAR(new_ScreenLines2);
 #endif
-	vim_free(new_ScreenAttrs);
-	new_ScreenAttrs = NULL;
-	vim_free(new_LineOffset);
-	new_LineOffset = NULL;
-	vim_free(new_LineWraps);
-	new_LineWraps = NULL;
-	vim_free(new_TabPageIdxs);
-	new_TabPageIdxs = NULL;
+	VIM_CLEAR(new_ScreenAttrs);
+	VIM_CLEAR(new_LineOffset);
+	VIM_CLEAR(new_LineWraps);
+	VIM_CLEAR(new_TabPageIdxs);
     }
     else
     {

--- a/src/screen.c
+++ b/src/screen.c
@@ -4326,7 +4326,7 @@ win_line(
 #endif
 
 	    if (p_extra_free != NULL)
-		VIM_CLEAR(p_extra_free);
+		vim_clear((void **)&p_extra_free);
 	    /*
 	     * Get a character from the line itself.
 	     */
@@ -8857,17 +8857,17 @@ give_up:
 	     * and over again. */
 	    done_outofmem_msg = TRUE;
 	}
-	VIM_CLEAR(new_ScreenLines);
+	vim_clear((void **)&new_ScreenLines);
 #ifdef FEAT_MBYTE
-	VIM_CLEAR(new_ScreenLinesUC);
+	vim_clear((void **)&new_ScreenLinesUC);
 	for (i = 0; i < p_mco; ++i)
-	    VIM_CLEAR(new_ScreenLinesC[i]);
-	VIM_CLEAR(new_ScreenLines2);
+	    vim_clear((void **)&new_ScreenLinesC[i]);
+	vim_clear((void **)&new_ScreenLines2);
 #endif
-	VIM_CLEAR(new_ScreenAttrs);
-	VIM_CLEAR(new_LineOffset);
-	VIM_CLEAR(new_LineWraps);
-	VIM_CLEAR(new_TabPageIdxs);
+	vim_clear((void **)&new_ScreenAttrs);
+	vim_clear((void **)&new_LineOffset);
+	vim_clear((void **)&new_LineWraps);
+	vim_clear((void **)&new_TabPageIdxs);
     }
     else
     {

--- a/src/search.c
+++ b/src/search.c
@@ -5059,7 +5059,7 @@ find_pattern_in_path(
 				prev_fname = NULL;
 			    }
 			}
-			VIM_CLEAR(new_fname);
+			vim_clear((void **)&new_fname);
 			already_searched = TRUE;
 			break;
 		    }

--- a/src/search.c
+++ b/src/search.c
@@ -5059,8 +5059,7 @@ find_pattern_in_path(
 				prev_fname = NULL;
 			    }
 			}
-			vim_free(new_fname);
-			new_fname = NULL;
+			VIM_CLEAR(new_fname);
 			already_searched = TRUE;
 			break;
 		    }

--- a/src/spell.c
+++ b/src/spell.c
@@ -1994,13 +1994,13 @@ slang_clear(slang_T *lp)
     int		i;
     int		round;
 
-    VIM_CLEAR(lp->sl_fbyts);
-    VIM_CLEAR(lp->sl_kbyts);
-    VIM_CLEAR(lp->sl_pbyts);
+    vim_clear((void **)&lp->sl_fbyts);
+    vim_clear((void **)&lp->sl_kbyts);
+    vim_clear((void **)&lp->sl_pbyts);
 
-    VIM_CLEAR(lp->sl_fidxs);
-    VIM_CLEAR(lp->sl_kidxs);
-    VIM_CLEAR(lp->sl_pidxs);
+    vim_clear((void **)&lp->sl_fidxs);
+    vim_clear((void **)&lp->sl_kidxs);
+    vim_clear((void **)&lp->sl_pidxs);
 
     for (round = 1; round <= 2; ++round)
     {
@@ -2042,19 +2042,19 @@ slang_clear(slang_T *lp)
     for (i = 0; i < lp->sl_prefixcnt; ++i)
 	vim_regfree(lp->sl_prefprog[i]);
     lp->sl_prefixcnt = 0;
-    VIM_CLEAR(lp->sl_prefprog);
+    vim_clear((void **)&lp->sl_prefprog);
 
-    VIM_CLEAR(lp->sl_info);
+    vim_clear((void **)&lp->sl_info);
 
-    VIM_CLEAR(lp->sl_midword);
+    vim_clear((void **)&lp->sl_midword);
 
     vim_regfree(lp->sl_compprog);
     lp->sl_compprog = NULL;
-    VIM_CLEAR(lp->sl_comprules);
-    VIM_CLEAR(lp->sl_compstartflags);
-    VIM_CLEAR(lp->sl_compallflags);
+    vim_clear((void **)&lp->sl_comprules);
+    vim_clear((void **)&lp->sl_compstartflags);
+    vim_clear((void **)&lp->sl_compallflags);
 
-    VIM_CLEAR(lp->sl_syllable);
+    vim_clear((void **)&lp->sl_syllable);
     ga_clear(&lp->sl_syl_items);
 
     ga_clear_strings(&lp->sl_comppat);
@@ -2081,8 +2081,8 @@ slang_clear(slang_T *lp)
     void
 slang_clear_sug(slang_T *lp)
 {
-    VIM_CLEAR(lp->sl_sbyts);
-    VIM_CLEAR(lp->sl_sidxs);
+    vim_clear((void **)&lp->sl_sbyts);
+    vim_clear((void **)&lp->sl_sidxs);
     close_spellbuf(lp->sl_sugbuf);
     lp->sl_sugbuf = NULL;
     lp->sl_sugloaded = FALSE;
@@ -2656,7 +2656,7 @@ clear_midword(win_T *wp)
 {
     vim_memset(wp->w_s->b_spell_ismw, 0, 256);
 #ifdef FEAT_MBYTE
-    VIM_CLEAR(wp->w_s->b_spell_ismw_mb);
+    vim_clear((void **)&wp->w_s->b_spell_ismw_mb);
 #endif
 }
 
@@ -2843,7 +2843,7 @@ spell_delete_wordlist(void)
 	mch_remove(int_wordlist);
 	int_wordlist_spl(fname);
 	mch_remove(fname);
-	VIM_CLEAR(int_wordlist);
+	vim_clear((void **)&int_wordlist);
     }
 }
 
@@ -2870,8 +2870,8 @@ spell_free_all(void)
 
     spell_delete_wordlist();
 
-    VIM_CLEAR(repl_to);
-    VIM_CLEAR(repl_from);
+    vim_clear((void **)&repl_to);
+    vim_clear((void **)&repl_from);
 }
 #endif
 
@@ -3406,8 +3406,8 @@ spell_suggest(int count)
     }
     else
     {
-	VIM_CLEAR(repl_from);
-	VIM_CLEAR(repl_to);
+	vim_clear((void **)&repl_from);
+	vim_clear((void **)&repl_to);
 
 #ifdef FEAT_RIGHTLEFT
 	/* When 'rightleft' is set the list is drawn right-left. */

--- a/src/spell.c
+++ b/src/spell.c
@@ -1994,19 +1994,13 @@ slang_clear(slang_T *lp)
     int		i;
     int		round;
 
-    vim_free(lp->sl_fbyts);
-    lp->sl_fbyts = NULL;
-    vim_free(lp->sl_kbyts);
-    lp->sl_kbyts = NULL;
-    vim_free(lp->sl_pbyts);
-    lp->sl_pbyts = NULL;
+    VIM_CLEAR(lp->sl_fbyts);
+    VIM_CLEAR(lp->sl_kbyts);
+    VIM_CLEAR(lp->sl_pbyts);
 
-    vim_free(lp->sl_fidxs);
-    lp->sl_fidxs = NULL;
-    vim_free(lp->sl_kidxs);
-    lp->sl_kidxs = NULL;
-    vim_free(lp->sl_pidxs);
-    lp->sl_pidxs = NULL;
+    VIM_CLEAR(lp->sl_fidxs);
+    VIM_CLEAR(lp->sl_kidxs);
+    VIM_CLEAR(lp->sl_pidxs);
 
     for (round = 1; round <= 2; ++round)
     {
@@ -2048,26 +2042,19 @@ slang_clear(slang_T *lp)
     for (i = 0; i < lp->sl_prefixcnt; ++i)
 	vim_regfree(lp->sl_prefprog[i]);
     lp->sl_prefixcnt = 0;
-    vim_free(lp->sl_prefprog);
-    lp->sl_prefprog = NULL;
+    VIM_CLEAR(lp->sl_prefprog);
 
-    vim_free(lp->sl_info);
-    lp->sl_info = NULL;
+    VIM_CLEAR(lp->sl_info);
 
-    vim_free(lp->sl_midword);
-    lp->sl_midword = NULL;
+    VIM_CLEAR(lp->sl_midword);
 
     vim_regfree(lp->sl_compprog);
-    vim_free(lp->sl_comprules);
-    vim_free(lp->sl_compstartflags);
-    vim_free(lp->sl_compallflags);
     lp->sl_compprog = NULL;
-    lp->sl_comprules = NULL;
-    lp->sl_compstartflags = NULL;
-    lp->sl_compallflags = NULL;
+    VIM_CLEAR(lp->sl_comprules);
+    VIM_CLEAR(lp->sl_compstartflags);
+    VIM_CLEAR(lp->sl_compallflags);
 
-    vim_free(lp->sl_syllable);
-    lp->sl_syllable = NULL;
+    VIM_CLEAR(lp->sl_syllable);
     ga_clear(&lp->sl_syl_items);
 
     ga_clear_strings(&lp->sl_comppat);
@@ -2094,10 +2081,8 @@ slang_clear(slang_T *lp)
     void
 slang_clear_sug(slang_T *lp)
 {
-    vim_free(lp->sl_sbyts);
-    lp->sl_sbyts = NULL;
-    vim_free(lp->sl_sidxs);
-    lp->sl_sidxs = NULL;
+    VIM_CLEAR(lp->sl_sbyts);
+    VIM_CLEAR(lp->sl_sidxs);
     close_spellbuf(lp->sl_sugbuf);
     lp->sl_sugbuf = NULL;
     lp->sl_sugloaded = FALSE;
@@ -2671,8 +2656,7 @@ clear_midword(win_T *wp)
 {
     vim_memset(wp->w_s->b_spell_ismw, 0, 256);
 #ifdef FEAT_MBYTE
-    vim_free(wp->w_s->b_spell_ismw_mb);
-    wp->w_s->b_spell_ismw_mb = NULL;
+    VIM_CLEAR(wp->w_s->b_spell_ismw_mb);
 #endif
 }
 
@@ -2859,8 +2843,7 @@ spell_delete_wordlist(void)
 	mch_remove(int_wordlist);
 	int_wordlist_spl(fname);
 	mch_remove(fname);
-	vim_free(int_wordlist);
-	int_wordlist = NULL;
+	VIM_CLEAR(int_wordlist);
     }
 }
 
@@ -2887,10 +2870,8 @@ spell_free_all(void)
 
     spell_delete_wordlist();
 
-    vim_free(repl_to);
-    repl_to = NULL;
-    vim_free(repl_from);
-    repl_from = NULL;
+    VIM_CLEAR(repl_to);
+    VIM_CLEAR(repl_from);
 }
 #endif
 
@@ -3425,10 +3406,8 @@ spell_suggest(int count)
     }
     else
     {
-	vim_free(repl_from);
-	repl_from = NULL;
-	vim_free(repl_to);
-	repl_to = NULL;
+	VIM_CLEAR(repl_from);
+	VIM_CLEAR(repl_to);
 
 #ifdef FEAT_RIGHTLEFT
 	/* When 'rightleft' is set the list is drawn right-left. */

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -1352,7 +1352,7 @@ read_compound(FILE *fd, slang_T *slang, int len)
 	{
 	    if (c == '?' || c == '+' || c == '*')
 	    {
-		VIM_CLEAR(slang->sl_comprules);
+		vim_clear((void **)&slang->sl_comprules);
 		crp = NULL;
 	    }
 	    else

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -1352,8 +1352,7 @@ read_compound(FILE *fd, slang_T *slang, int len)
 	{
 	    if (c == '?' || c == '+' || c == '*')
 	    {
-		vim_free(slang->sl_comprules);
-		slang->sl_comprules = NULL;
+		VIM_CLEAR(slang->sl_comprules);
 		crp = NULL;
 	    }
 	    else

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -1189,8 +1189,7 @@ syn_stack_free_block(synblock_T *block)
     {
 	for (p = block->b_sst_first; p != NULL; p = p->sst_next)
 	    clear_syn_state(p);
-	vim_free(block->b_sst_array);
-	block->b_sst_array = NULL;
+	VIM_CLEAR(block->b_sst_array);
 	block->b_sst_len = 0;
     }
 }
@@ -3641,8 +3640,7 @@ syntax_clear(synblock_T *block)
 
     vim_regfree(block->b_syn_linecont_prog);
     block->b_syn_linecont_prog = NULL;
-    vim_free(block->b_syn_linecont_pat);
-    block->b_syn_linecont_pat = NULL;
+    VIM_CLEAR(block->b_syn_linecont_pat);
 #ifdef FEAT_FOLDING
     block->b_syn_folditems = 0;
 #endif
@@ -3690,8 +3688,7 @@ syntax_sync_clear(void)
 
     vim_regfree(curwin->w_s->b_syn_linecont_prog);
     curwin->w_s->b_syn_linecont_prog = NULL;
-    vim_free(curwin->w_s->b_syn_linecont_pat);
-    curwin->w_s->b_syn_linecont_pat = NULL;
+    VIM_CLEAR(curwin->w_s->b_syn_linecont_pat);
     clear_string_option(&curwin->w_s->b_syn_isk);
 
     syn_stack_free_all(curwin->w_s);	/* Need to recompute all syntax. */
@@ -3810,8 +3807,7 @@ syn_cmd_clear(exarg_T *eap, int syncing)
 		     */
 		    short scl_id = id - SYNID_CLUSTER;
 
-		    vim_free(SYN_CLSTR(curwin->w_s)[scl_id].scl_list);
-		    SYN_CLSTR(curwin->w_s)[scl_id].scl_list = NULL;
+		    VIM_CLEAR(SYN_CLSTR(curwin->w_s)[scl_id].scl_list);
 		}
 	    }
 	    else
@@ -5954,8 +5950,7 @@ syn_cmd_sync(exarg_T *eap, int syncing UNUSED)
 
 		if (curwin->w_s->b_syn_linecont_prog == NULL)
 		{
-		    vim_free(curwin->w_s->b_syn_linecont_pat);
-		    curwin->w_s->b_syn_linecont_pat = NULL;
+		    VIM_CLEAR(curwin->w_s->b_syn_linecont_pat);
 		    finished = TRUE;
 		    break;
 		}
@@ -8369,10 +8364,8 @@ highlight_clear(int idx)
     HL_TABLE()[idx].sg_cleared = TRUE;
 
     HL_TABLE()[idx].sg_term = 0;
-    vim_free(HL_TABLE()[idx].sg_start);
-    HL_TABLE()[idx].sg_start = NULL;
-    vim_free(HL_TABLE()[idx].sg_stop);
-    HL_TABLE()[idx].sg_stop = NULL;
+    VIM_CLEAR(HL_TABLE()[idx].sg_start);
+    VIM_CLEAR(HL_TABLE()[idx].sg_stop);
     HL_TABLE()[idx].sg_term_attr = 0;
     HL_TABLE()[idx].sg_cterm = 0;
     HL_TABLE()[idx].sg_cterm_bold = FALSE;
@@ -8381,12 +8374,9 @@ highlight_clear(int idx)
     HL_TABLE()[idx].sg_cterm_attr = 0;
 #if defined(FEAT_GUI) || defined(FEAT_EVAL)
     HL_TABLE()[idx].sg_gui = 0;
-    vim_free(HL_TABLE()[idx].sg_gui_fg_name);
-    HL_TABLE()[idx].sg_gui_fg_name = NULL;
-    vim_free(HL_TABLE()[idx].sg_gui_bg_name);
-    HL_TABLE()[idx].sg_gui_bg_name = NULL;
-    vim_free(HL_TABLE()[idx].sg_gui_sp_name);
-    HL_TABLE()[idx].sg_gui_sp_name = NULL;
+    VIM_CLEAR(HL_TABLE()[idx].sg_gui_fg_name);
+    VIM_CLEAR(HL_TABLE()[idx].sg_gui_bg_name);
+    VIM_CLEAR(HL_TABLE()[idx].sg_gui_sp_name);
 #endif
 #if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
     HL_TABLE()[idx].sg_gui_fg = INVALCOLOR;
@@ -8400,8 +8390,7 @@ highlight_clear(int idx)
     gui_mch_free_fontset(HL_TABLE()[idx].sg_fontset);
     HL_TABLE()[idx].sg_fontset = NOFONTSET;
 # endif
-    vim_free(HL_TABLE()[idx].sg_font_name);
-    HL_TABLE()[idx].sg_font_name = NULL;
+    VIM_CLEAR(HL_TABLE()[idx].sg_font_name);
     HL_TABLE()[idx].sg_gui_attr = 0;
 #endif
 #ifdef FEAT_EVAL

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -1189,7 +1189,7 @@ syn_stack_free_block(synblock_T *block)
     {
 	for (p = block->b_sst_first; p != NULL; p = p->sst_next)
 	    clear_syn_state(p);
-	VIM_CLEAR(block->b_sst_array);
+	vim_clear((void **)&block->b_sst_array);
 	block->b_sst_len = 0;
     }
 }
@@ -3640,7 +3640,7 @@ syntax_clear(synblock_T *block)
 
     vim_regfree(block->b_syn_linecont_prog);
     block->b_syn_linecont_prog = NULL;
-    VIM_CLEAR(block->b_syn_linecont_pat);
+    vim_clear((void **)&block->b_syn_linecont_pat);
 #ifdef FEAT_FOLDING
     block->b_syn_folditems = 0;
 #endif
@@ -3688,7 +3688,7 @@ syntax_sync_clear(void)
 
     vim_regfree(curwin->w_s->b_syn_linecont_prog);
     curwin->w_s->b_syn_linecont_prog = NULL;
-    VIM_CLEAR(curwin->w_s->b_syn_linecont_pat);
+    vim_clear((void **)&curwin->w_s->b_syn_linecont_pat);
     clear_string_option(&curwin->w_s->b_syn_isk);
 
     syn_stack_free_all(curwin->w_s);	/* Need to recompute all syntax. */
@@ -3807,7 +3807,7 @@ syn_cmd_clear(exarg_T *eap, int syncing)
 		     */
 		    short scl_id = id - SYNID_CLUSTER;
 
-		    VIM_CLEAR(SYN_CLSTR(curwin->w_s)[scl_id].scl_list);
+		    vim_clear((void **)&SYN_CLSTR(curwin->w_s)[scl_id].scl_list);
 		}
 	    }
 	    else
@@ -5950,7 +5950,7 @@ syn_cmd_sync(exarg_T *eap, int syncing UNUSED)
 
 		if (curwin->w_s->b_syn_linecont_prog == NULL)
 		{
-		    VIM_CLEAR(curwin->w_s->b_syn_linecont_pat);
+		    vim_clear((void **)&curwin->w_s->b_syn_linecont_pat);
 		    finished = TRUE;
 		    break;
 		}
@@ -8364,8 +8364,8 @@ highlight_clear(int idx)
     HL_TABLE()[idx].sg_cleared = TRUE;
 
     HL_TABLE()[idx].sg_term = 0;
-    VIM_CLEAR(HL_TABLE()[idx].sg_start);
-    VIM_CLEAR(HL_TABLE()[idx].sg_stop);
+    vim_clear((void **)&HL_TABLE()[idx].sg_start);
+    vim_clear((void **)&HL_TABLE()[idx].sg_stop);
     HL_TABLE()[idx].sg_term_attr = 0;
     HL_TABLE()[idx].sg_cterm = 0;
     HL_TABLE()[idx].sg_cterm_bold = FALSE;
@@ -8374,9 +8374,9 @@ highlight_clear(int idx)
     HL_TABLE()[idx].sg_cterm_attr = 0;
 #if defined(FEAT_GUI) || defined(FEAT_EVAL)
     HL_TABLE()[idx].sg_gui = 0;
-    VIM_CLEAR(HL_TABLE()[idx].sg_gui_fg_name);
-    VIM_CLEAR(HL_TABLE()[idx].sg_gui_bg_name);
-    VIM_CLEAR(HL_TABLE()[idx].sg_gui_sp_name);
+    vim_clear((void **)&HL_TABLE()[idx].sg_gui_fg_name);
+    vim_clear((void **)&HL_TABLE()[idx].sg_gui_bg_name);
+    vim_clear((void **)&HL_TABLE()[idx].sg_gui_sp_name);
 #endif
 #if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
     HL_TABLE()[idx].sg_gui_fg = INVALCOLOR;
@@ -8390,7 +8390,7 @@ highlight_clear(int idx)
     gui_mch_free_fontset(HL_TABLE()[idx].sg_fontset);
     HL_TABLE()[idx].sg_fontset = NOFONTSET;
 # endif
-    VIM_CLEAR(HL_TABLE()[idx].sg_font_name);
+    vim_clear((void **)&HL_TABLE()[idx].sg_font_name);
     HL_TABLE()[idx].sg_gui_attr = 0;
 #endif
 #ifdef FEAT_EVAL

--- a/src/tag.c
+++ b/src/tag.c
@@ -1091,7 +1091,7 @@ end_do_tag:
     void
 tag_freematch(void)
 {
-    VIM_CLEAR(tagmatchname);
+    vim_clear((void **)&tagmatchname);
 }
 
     static void
@@ -2619,7 +2619,7 @@ free_tag_stuff(void)
 
 # if defined(FEAT_QUICKFIX)
     if (ptag_entry.tagname)
-	VIM_CLEAR(ptag_entry.tagname);
+	vim_clear((void **)&ptag_entry.tagname);
 # endif
 }
 #endif

--- a/src/tag.c
+++ b/src/tag.c
@@ -1091,8 +1091,7 @@ end_do_tag:
     void
 tag_freematch(void)
 {
-    vim_free(tagmatchname);
-    tagmatchname = NULL;
+    VIM_CLEAR(tagmatchname);
 }
 
     static void
@@ -2620,10 +2619,7 @@ free_tag_stuff(void)
 
 # if defined(FEAT_QUICKFIX)
     if (ptag_entry.tagname)
-    {
-	vim_free(ptag_entry.tagname);
-	ptag_entry.tagname = NULL;
-    }
+	VIM_CLEAR(ptag_entry.tagname);
 # endif
 }
 #endif

--- a/src/term.c
+++ b/src/term.c
@@ -3912,8 +3912,7 @@ clear_termcodes(void)
 {
     while (tc_len > 0)
 	vim_free(termcodes[--tc_len].code);
-    vim_free(termcodes);
-    termcodes = NULL;
+    VIM_CLEAR(termcodes);
     tc_max_len = 0;
 
 #ifdef HAVE_TGETENT

--- a/src/term.c
+++ b/src/term.c
@@ -3912,7 +3912,7 @@ clear_termcodes(void)
 {
     while (tc_len > 0)
 	vim_free(termcodes[--tc_len].code);
-    VIM_CLEAR(termcodes);
+    vim_clear((void **)&termcodes);
     tc_max_len = 0;
 
 #ifdef HAVE_TGETENT

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1176,7 +1176,7 @@ move_terminal_to_buffer(term_T *term)
 set_terminal_mode(term_T *term, int normal_mode)
 {
     term->tl_normal_mode = normal_mode;
-    VIM_CLEAR(term->tl_status_text);
+    vim_clear((void **)&term->tl_status_text);
     if (term->tl_buffer == curbuf)
 	maketitle();
 }
@@ -1738,8 +1738,8 @@ term_job_ended(job_T *job)
     for (term = first_term; term != NULL; term = term->tl_next)
 	if (term->tl_job == job)
 	{
-	    VIM_CLEAR(term->tl_title);
-	    VIM_CLEAR(term->tl_status_text);
+	    vim_clear((void **)&term->tl_title);
+	    vim_clear((void **)&term->tl_status_text);
 	    redraw_buf_and_status_later(term->tl_buffer, VALID);
 	    did_one = TRUE;
 	}
@@ -2020,7 +2020,7 @@ handle_settermprop(
 #endif
 	    else
 		term->tl_title = vim_strsave((char_u *)value->string);
-	    VIM_CLEAR(term->tl_status_text);
+	    vim_clear((void **)&term->tl_status_text);
 	    if (term == curbuf->b_term)
 		maketitle();
 	    break;
@@ -2185,8 +2185,8 @@ term_channel_closed(channel_T *ch)
 	    term->tl_channel_closed = TRUE;
 	    did_one = TRUE;
 
-	    VIM_CLEAR(term->tl_title);
-	    VIM_CLEAR(term->tl_status_text);
+	    vim_clear((void **)&term->tl_title);
+	    vim_clear((void **)&term->tl_status_text);
 
 	    /* Unless in Terminal-Normal mode: clear the vterm. */
 	    if (!term->tl_normal_mode)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1176,8 +1176,7 @@ move_terminal_to_buffer(term_T *term)
 set_terminal_mode(term_T *term, int normal_mode)
 {
     term->tl_normal_mode = normal_mode;
-    vim_free(term->tl_status_text);
-    term->tl_status_text = NULL;
+    VIM_CLEAR(term->tl_status_text);
     if (term->tl_buffer == curbuf)
 	maketitle();
 }
@@ -1739,10 +1738,8 @@ term_job_ended(job_T *job)
     for (term = first_term; term != NULL; term = term->tl_next)
 	if (term->tl_job == job)
 	{
-	    vim_free(term->tl_title);
-	    term->tl_title = NULL;
-	    vim_free(term->tl_status_text);
-	    term->tl_status_text = NULL;
+	    VIM_CLEAR(term->tl_title);
+	    VIM_CLEAR(term->tl_status_text);
 	    redraw_buf_and_status_later(term->tl_buffer, VALID);
 	    did_one = TRUE;
 	}
@@ -2023,8 +2020,7 @@ handle_settermprop(
 #endif
 	    else
 		term->tl_title = vim_strsave((char_u *)value->string);
-	    vim_free(term->tl_status_text);
-	    term->tl_status_text = NULL;
+	    VIM_CLEAR(term->tl_status_text);
 	    if (term == curbuf->b_term)
 		maketitle();
 	    break;
@@ -2189,10 +2185,8 @@ term_channel_closed(channel_T *ch)
 	    term->tl_channel_closed = TRUE;
 	    did_one = TRUE;
 
-	    vim_free(term->tl_title);
-	    term->tl_title = NULL;
-	    vim_free(term->tl_status_text);
-	    term->tl_status_text = NULL;
+	    VIM_CLEAR(term->tl_title);
+	    VIM_CLEAR(term->tl_status_text);
 
 	    /* Unless in Terminal-Normal mode: clear the vterm. */
 	    if (!term->tl_normal_mode)

--- a/src/ui.c
+++ b/src/ui.c
@@ -130,7 +130,7 @@ ui_inchar(
 	if (maxlen >= ta_len - ta_off)
 	{
 	    mch_memmove(buf, ta_str + ta_off, (size_t)ta_len);
-	    VIM_CLEAR(ta_str);
+	    vim_clear((void **)&ta_str);
 	    return ta_len;
 	}
 	mch_memmove(buf, ta_str + ta_off, (size_t)maxlen);
@@ -1839,7 +1839,7 @@ fill_input_buf(int exit_on_error UNUSED)
 	    unconverted = restlen;
 	mch_memmove(inbuf + inbufcount, rest, unconverted);
 	if (unconverted == restlen)
-	    VIM_CLEAR(rest);
+	    vim_clear((void **)&rest);
 	else
 	{
 	    restlen -= unconverted;

--- a/src/ui.c
+++ b/src/ui.c
@@ -130,8 +130,7 @@ ui_inchar(
 	if (maxlen >= ta_len - ta_off)
 	{
 	    mch_memmove(buf, ta_str + ta_off, (size_t)ta_len);
-	    vim_free(ta_str);
-	    ta_str = NULL;
+	    VIM_CLEAR(ta_str);
 	    return ta_len;
 	}
 	mch_memmove(buf, ta_str + ta_off, (size_t)maxlen);
@@ -1840,10 +1839,7 @@ fill_input_buf(int exit_on_error UNUSED)
 	    unconverted = restlen;
 	mch_memmove(inbuf + inbufcount, rest, unconverted);
 	if (unconverted == restlen)
-	{
-	    vim_free(rest);
-	    rest = NULL;
-	}
+	    VIM_CLEAR(rest);
 	else
 	{
 	    restlen -= unconverted;

--- a/src/undo.c
+++ b/src/undo.c
@@ -849,8 +849,7 @@ u_get_undo_file_name(char_u *buf_ffname, int reading)
 	if (undo_file_name != NULL && (!reading
 			       || mch_stat((char *)undo_file_name, &st) >= 0))
 	    break;
-	vim_free(undo_file_name);
-	undo_file_name = NULL;
+	VIM_CLEAR(undo_file_name);
     }
 
     vim_free(munged_name);
@@ -3454,8 +3453,7 @@ u_clearline(void)
 {
     if (curbuf->b_u_line_ptr != NULL)
     {
-	vim_free(curbuf->b_u_line_ptr);
-	curbuf->b_u_line_ptr = NULL;
+	VIM_CLEAR(curbuf->b_u_line_ptr);
 	curbuf->b_u_line_lnum = 0;
     }
 }

--- a/src/undo.c
+++ b/src/undo.c
@@ -849,7 +849,7 @@ u_get_undo_file_name(char_u *buf_ffname, int reading)
 	if (undo_file_name != NULL && (!reading
 			       || mch_stat((char *)undo_file_name, &st) >= 0))
 	    break;
-	VIM_CLEAR(undo_file_name);
+	vim_clear((void **)&undo_file_name);
     }
 
     vim_free(munged_name);
@@ -3453,7 +3453,7 @@ u_clearline(void)
 {
     if (curbuf->b_u_line_ptr != NULL)
     {
-	VIM_CLEAR(curbuf->b_u_line_ptr);
+	vim_clear((void **)&curbuf->b_u_line_ptr);
 	curbuf->b_u_line_lnum = 0;
     }
 }

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2122,7 +2122,7 @@ ex_function(exarg_T *eap)
 	    /* between ":append" and "." and between ":python <<EOF" and "EOF"
 	     * don't check for ":endfunc". */
 	    if (STRCMP(theline, skip_until) == 0)
-		VIM_CLEAR(skip_until);
+		vim_clear((void **)&skip_until);
 	}
 	else
 	{
@@ -2292,7 +2292,7 @@ ex_function(exarg_T *eap)
 		/* redefine existing function */
 		ga_clear_strings(&(fp->uf_args));
 		ga_clear_strings(&(fp->uf_lines));
-		VIM_CLEAR(name);
+		vim_clear((void **)&name);
 	    }
 	}
     }

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2122,10 +2122,7 @@ ex_function(exarg_T *eap)
 	    /* between ":append" and "." and between ":python <<EOF" and "EOF"
 	     * don't check for ":endfunc". */
 	    if (STRCMP(theline, skip_until) == 0)
-	    {
-		vim_free(skip_until);
-		skip_until = NULL;
-	    }
+		VIM_CLEAR(skip_until);
 	}
 	else
 	{
@@ -2295,8 +2292,7 @@ ex_function(exarg_T *eap)
 		/* redefine existing function */
 		ga_clear_strings(&(fp->uf_args));
 		ga_clear_strings(&(fp->uf_lines));
-		vim_free(name);
-		name = NULL;
+		VIM_CLEAR(name);
 	    }
 	}
     }

--- a/src/window.c
+++ b/src/window.c
@@ -4415,7 +4415,7 @@ win_enter_ext(
 	/* Window doesn't have a local directory and we are not in the global
 	 * directory: Change to the global directory. */
 	ignored = mch_chdir((char *)globaldir);
-	VIM_CLEAR(globaldir);
+	vim_clear((void **)&globaldir);
 	shorten_fnames(TRUE);
     }
 
@@ -4846,7 +4846,7 @@ win_free_lsize(win_T *wp)
 {
     /* TODO: why would wp be NULL here? */
     if (wp != NULL)
-	VIM_CLEAR(wp->w_lines);
+	vim_clear((void **)&wp->w_lines);
 }
 
 /*

--- a/src/window.c
+++ b/src/window.c
@@ -4415,8 +4415,7 @@ win_enter_ext(
 	/* Window doesn't have a local directory and we are not in the global
 	 * directory: Change to the global directory. */
 	ignored = mch_chdir((char *)globaldir);
-	vim_free(globaldir);
-	globaldir = NULL;
+	VIM_CLEAR(globaldir);
 	shorten_fnames(TRUE);
     }
 
@@ -4847,10 +4846,7 @@ win_free_lsize(win_T *wp)
 {
     /* TODO: why would wp be NULL here? */
     if (wp != NULL)
-    {
-	vim_free(wp->w_lines);
-	wp->w_lines = NULL;
-    }
+	VIM_CLEAR(wp->w_lines);
 }
 
 /*


### PR DESCRIPTION
And I completed the following TODO.
> Use vim_clear() in more places, instead of vim_free() and assigning NULL.

Related comment in vim_dev ML.
https://groups.google.com/d/msg/vim_dev/JyOaLFF_zOo/MDYhz3DmAwAJ