### PR TITLE
enable :drop command for all conditions

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -711,7 +711,6 @@ can also get to them with the buffer list commands, like ":bnext".
 		When using the |:tab| modifier each argument is opened in a
 		tab page.  The last window is used if it's empty.
 		Also see |++opt| and |+cmd|.
-		{only available when compiled with a GUI}
 
 ==============================================================================
 8. Do a command in all buffers or windows			*list-repeat*

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -8335,7 +8335,6 @@ ex_smile(exarg_T *eap UNUSED)
     msg_clr_eos();
 }
 
-#if defined(FEAT_GUI) || defined(FEAT_CLIENTSERVER) || defined(PROTO)
 /*
  * ":drop"
  * Opens the first argument in a window.  When there are two or more arguments
@@ -8415,7 +8414,6 @@ ex_drop(exarg_T *eap)
 	ex_rewind(eap);
     }
 }
-#endif
 
 /*
  * Skip over the pattern argument of ":vimgrep /pat/[g][j]".

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -2549,7 +2549,6 @@ get_arglist_exp(
 }
 #endif
 
-#if defined(FEAT_GUI) || defined(FEAT_CLIENTSERVER) || defined(PROTO)
 /*
  * Redefine the argument list.
  */
@@ -2558,7 +2557,6 @@ set_arglist(char_u *str)
 {
     do_arglist(str, AL_SET, 0);
 }
-#endif
 
 /*
  * "what" == AL_SET: Redefine the argument list to 'str'.

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -201,9 +201,6 @@ static void	ex_wrongmodifier(exarg_T *eap);
 static void	ex_find(exarg_T *eap);
 static void	ex_open(exarg_T *eap);
 static void	ex_edit(exarg_T *eap);
-#if !defined(FEAT_GUI) && !defined(FEAT_CLIENTSERVER)
-# define ex_drop		ex_ni
-#endif
 #ifndef FEAT_GUI
 # define ex_gui			ex_nogui
 static void	ex_nogui(exarg_T *eap);

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -2176,9 +2176,6 @@ func! Test_normal44_textobjects2()
 endfunc
 
 func! Test_normal45_drop()
-  if !has("dnd")
-    return
-  endif
   " basic test for :drop command
   " unfortunately, without a gui, we can't really test much here,
   " so simply test that ~p fails (which uses the drop register)

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -41,40 +41,38 @@ function Test_tabpage()
   call assert_true(t:val_num == 100 && t:val_str == 'SetTabVar test'  && t:val_list == ['red', 'blue', 'green'])
   tabclose
 
-  if has('gui') || has('clientserver')
-    " Test for ":tab drop exist-file" to keep current window.
-    sp test1
-    tab drop test1
-    call assert_true(tabpagenr('$') == 1 && winnr('$') == 2 && winnr() == 1)
-    close
-    "
-    "
-    " Test for ":tab drop new-file" to keep current window of tabpage 1.
-    split
-    tab drop newfile
-    call assert_true(tabpagenr('$') == 2 && tabpagewinnr(1, '$') == 2 && tabpagewinnr(1) == 1)
-    tabclose
-    q
-    "
-    "
-    " Test for ":tab drop multi-opend-file" to keep current tabpage and window.
-    new test1
-    tabnew
-    new test1
-    tab drop test1
-    call assert_true(tabpagenr() == 2 && tabpagewinnr(2, '$') == 2 && tabpagewinnr(2) == 1)
-    tabclose
-    q
-    "
-    "
-    " Test for ":tab drop vertical-split-window" to jump test1 buffer
-    tabedit test1
-    vnew
-    tabfirst
-    tab drop test1
-    call assert_equal([2, 2, 2, 2], [tabpagenr('$'), tabpagenr(), tabpagewinnr(2, '$'), tabpagewinnr(2)])
-    1tabonly
-  endif
+  " Test for ":tab drop exist-file" to keep current window.
+  sp test1
+  tab drop test1
+  call assert_true(tabpagenr('$') == 1 && winnr('$') == 2 && winnr() == 1)
+  close
+  "
+  "
+  " Test for ":tab drop new-file" to keep current window of tabpage 1.
+  split
+  tab drop newfile
+  call assert_true(tabpagenr('$') == 2 && tabpagewinnr(1, '$') == 2 && tabpagewinnr(1) == 1)
+  tabclose
+  q
+  "
+  "
+  " Test for ":tab drop multi-opend-file" to keep current tabpage and window.
+  new test1
+  tabnew
+  new test1
+  tab drop test1
+  call assert_true(tabpagenr() == 2 && tabpagewinnr(2, '$') == 2 && tabpagewinnr(2) == 1)
+  tabclose
+  q
+  "
+  "
+  " Test for ":tab drop vertical-split-window" to jump test1 buffer
+  tabedit test1
+  vnew
+  tabfirst
+  tab drop test1
+  call assert_equal([2, 2, 2, 2], [tabpagenr('$'), tabpagenr(), tabpagewinnr(2, '$'), tabpagewinnr(2)])
+  1tabonly
   "
   "
   for i in range(9) | tabnew | endfor


### PR DESCRIPTION
`:drop` command is useful to open a file without abandon other files. But this feature is provided on GUI enable conditions. However, `:drop` command is not calling GUI features. So I hope to enable this feature for all conditions.