### PR TITLE
Fix file descriptor leaks

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -5528,11 +5528,11 @@ mch_job_start(char **argv, job_T *job, jobopt_T *options)
     if (pty_master_fd >= 0)
 	close(pty_slave_fd); /* not used in the parent */
     /* close child stdin, stdout and stderr */
-    if (!use_file_for_in && fd_in[0] >= 0)
+    if (fd_in[0] >= 0)
 	close(fd_in[0]);
-    if (!use_file_for_out && fd_out[1] >= 0)
+    if (fd_out[1] >= 0)
 	close(fd_out[1]);
-    if (!use_out_for_err && !use_file_for_err && fd_err[1] >= 0)
+    if (fd_err[1] >= 0)
 	close(fd_err[1]);
     if (channel != NULL)
     {

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4542,6 +4542,11 @@ mch_call_shell(
 	    reset_signals();		/* handle signals normally */
 	    UNBLOCK_SIGNALS(&curset);
 
+# ifdef FEAT_JOB_CHANNEL
+	    if (ch_log_active())
+		ch_logfile((char_u *)"", (char_u *)"");
+# endif
+
 	    if (!show_shell_mess || (options & SHELL_EXPAND))
 	    {
 		int fd;
@@ -5400,6 +5405,11 @@ mch_job_start(char **argv, job_T *job, jobopt_T *options)
 	 * children can be kill()ed.  Don't do this when using pipes,
 	 * because stdin is not a tty, we would lose /dev/tty. */
 	(void)setsid();
+# endif
+
+# ifdef FEAT_JOB_CHANNEL
+	if (ch_log_active())
+	    ch_logfile((char_u *)"", (char_u *)"");
 # endif
 
 # ifdef FEAT_TERMINAL


### PR DESCRIPTION
## Problem summary

On unix-like OS, when the job with stdout redirection to file, file descriptor will leak.

## Repro steps

(On Linux)

test.vim

```vim
let jobs = []
for i in range(10)
  let jobs += [job_start('echo ' . i, {'out_io': 'file', 'out_name': 'Xout' . i})]
endfor
```

`vim --clean -S test.vim`

Check with `ls -l /proc/$(pgrep vim)/fd`: fds of `Xout0` ... `Xout9` will remain.

## Cause and Solution

https://github.com/vim/vim/blob/73cddfd559152ea9b7e978ea7cf9c0d3a41e7316/src/os_unix.c#L5531-L5536

`fd_in[0]`, `fd_out[1]`, `fd_err[1]` are used by child process (job), so parent (Vim) should close them when they are available (`>= 0`).

## In Addition

* Close `ch_logfile` handle at child process (job)

Ozaki Kiichi