### PR TITLE
Fix Test_syntax_c

### DIFF
--- a/src/testdir/screendump.vim
+++ b/src/testdir/screendump.vim
@@ -22,6 +22,7 @@ func RunVimInTerminal(arguments, options)
   " Always doo this with 256 colors and a light background.
   set t_Co=256
   hi Normal ctermfg=0 ctermbg=15
+  let $COLORFGBG = '0;15'
 
   let cmd = GetVimCommandClean()
   let cmd .= ' ' . a:arguments

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -527,7 +527,7 @@ endfunc
 " Check highlighting for a small piece of C code with a screen dump.
 func Test_syntax_c()
   " Need to be able to run terminal Vim with 256 colors.
-  if !has('terminal') || has('win32')
+  if !has('terminal') || has('win32') || has('gui_running')
     return
   endif
   call writefile([


### PR DESCRIPTION
## Problem

`Test_syntax_c` fails under the specific condition.

### Case 1: `COLORFGBG`

On the terminal application which supports `COLORFGBG` environment variable (e.g. iTerm2),
when `COLORFGBG` is set to dark-background (e.g. `15;0`), vim starting on `:terminal` takes over `COLORFGBG` and sets `background=dark`.
In this case `Test_syntax_c` will fail since the reference of dump is based on `background=light`.
Therefore `COLORFGBG` should be set to light-background (`0;15`).

### Case 2: On GUI

When testing GUI, `RunVimInTerminal()`  will start `vim -g` or `gvim`, so `:terminal` window will be blank and `Test_syntax_c` will fail.
I think it is better to skip `Test_syntax_c` when on GUI.

Ozaki Kiichi