### PR TITLE
xxd: fix bug where '-a' opt (autoskip 0s) ignored when '-E' (ebcdic) …

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -827,6 +827,8 @@ main(int argc, char *argv[])
 	  for (i = 7; i >= 0; i--)
 	    l[++c] = (e & (1 << i)) ? '1' : '0';
 	}
+      if (e)
+	nonzero++;
       if (ebcdic)
 	e = (e < 64) ? '.' : etoa64[e-64];
       /* When changing this update definition of LLEN above. */
@@ -837,8 +839,6 @@ main(int argc, char *argv[])
 	  (e > 31 && e < 127)
 #endif
 	  ? e : '.';
-      if (e)
-	nonzero++;
       n++;
       if (++p == cols)
 	{


### PR DESCRIPTION
…present

## Testing

Created 2 test files:
* /tmp/zeros: 256 bytes of all 0s
* /tmp/play: same as /tmp/zeros, except first 2 and last 2 bytes are 0x40

Like this:
```
  $ dd if=/dev/zero of=/tmp/zeros bs=256 count=1
  1+0 records in
  1+0 records out
  256 bytes transferred in 0.000021 secs (12201612 bytes/sec)
  $ cp /tmp/zeros /tmp/play
  $ hexedit /tmp/play
```

With UNpatched version of xxd:
```
  $ xxd -g1 -a /tmp/zeros
  00000000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  *
  000000f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................

  $ xxd -g1 -a -E /tmp/zeros
  00000000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000040: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000050: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000060: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000070: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000090: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................

  $ xxd -g1 -a /tmp/play
  00000000: 40 40 00 00 00 00 00 00 00 00 00 00 00 00 00 00  @@..............
  00000010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  *
  000000f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 40 40  ..............@@

  $ xxd -g1 -a -E /tmp/play
  00000000: 40 40 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ..............
  00000010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000040: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000050: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000060: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000070: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  00000090: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  000000f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 40 40  ..............
```
Note above that the "-a" option still display consecutive lines of 0s when "-E" is specified.

With new (patched) version of xxd:
```
  $ xxd -g1 -a /tmp/zeros
  00000000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  *
  000000f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................

  $ xxd -g1 -a -E /tmp/zeros
  00000000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  *
  000000f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................

  $ xxd -g1 -a /tmp/play
  00000000: 40 40 00 00 00 00 00 00 00 00 00 00 00 00 00 00  @@..............
  00000010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  *
  000000f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 40 40  ..............@@

  $ xxd -g1 -a -E /tmp/play
  00000000: 40 40 00 00 00 00 00 00 00 00 00 00 00 00 00 00    ..............
  00000010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
  *
  000000f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 40 40  ..............
```

Note that "-a" now always works correctly, even when "-E" is also specified.