### PR TITLE
Fix OS X (< 10.9) build

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -566,7 +566,6 @@ mch_check_messages(void)
 # ifdef MACOS_X_DARWIN
 #  include <mach/mach_host.h>
 #  include <mach/mach_port.h>
-#  include <mach/vm_page_size.h>
 # endif
 
 /*


### PR DESCRIPTION
fixes #2688 

Sorry, `mach/vm_page_size.h` is unnecessary.

