### PR TITLE
`VIM::Buffers()` should consistently handle unlisted buffers

### DIFF
--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -1558,7 +1558,7 @@ Buffers(...)
 
 		pat = (char_u *)SvPV(sv, len);
 		++emsg_off;
-		b = buflist_findpat(pat, pat+len, FALSE, FALSE, FALSE);
+		b = buflist_findpat(pat, pat+len, TRUE, FALSE, FALSE);
 		--emsg_off;
 	    }
 


### PR DESCRIPTION
In the Perl interface, the `VIM::Buffers()` function handles unlisted
buffers differently if the buffer is referred to by number (succeeds) or
by name (fails).

It boils down to `buflist_findpat()` being told to ignore unlisted
buffers:

https://github.com/vim/vim/blob/89894aa671ed1db03d95d38cab300702c242239d/src/if_perl.xs#L1561

This patch changes the behaviour such that `VIM::Buffers()` will find a
buffer, even an unlisted one, by either number or name.