### PR TITLE
Proposal: filter the tests using a make-variable

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -348,6 +348,11 @@ if argc() > 1
   let s:tests = filter(s:tests, 'v:val =~ argv(1)')
 endif
 
+" If there is 'TEST_FILTER' variable filter the function names against it.
+if $TEST_FILTER !=# ''
+  let s:tests = filter(s:tests, 'v:val =~ $TEST_FILTER')
+endif
+
 " Execute the tests in alphabetical order.
 for s:test in sort(s:tests)
   " Silence, please!


### PR DESCRIPTION
I think this is convenient when we'd like to execute specific tests via `make` command.

Example: `make -C src test_terminal TEST_FILTER=wipe_buffer`