### PR TITLE
Fix hang-up when cancaling popup by Ctrl-C

### DIFF
--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -1175,7 +1175,7 @@ pum_show_popupmenu(vimmenu_T *menu)
 	out_flush();
 
 	c = vgetc();
-	if (c == ESC)
+	if (c == ESC || c == Ctrl_C)
 	    break;
 	else if (c == CAR || c == NL)
 	{


### PR DESCRIPTION
## Repro steps

`vim --clean`

```
:so $VIMRUNTIME/menu.vim
:popup PopUp
```

then type Ctrl-C, Vim will hang.

## Solution

In `pum_show_popupmenu`, I think it should also check if input is Ctrl-C.
https://github.com/vim/vim/blob/3324d0a86421a634572758dcfde917547f4d4c67/src/popupmnu.c#L1169-L1230 