### PR TITLE
save/restore wildignore to avoid to be influenced to arguments lists.

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7397,10 +7397,15 @@ fix_arg_enc(void)
 	/* Now expand wildcards in the arguments. */
 	/* Temporarily add '(' and ')' to 'isfname'.  These are valid
 	 * filename characters but are excluded from 'isfname' to make
-	 * "gf" work on a file name in parenthesis (e.g.: see vim.h). */
+	 * "gf" work on a file name in parenthesis (e.g.: see vim.h).
+	 * Also, unset wildignore to not to be influenced this option.
+	 * The arguments specified in command-line should be kept even if
+	 * encoding options was changed. */
 	do_cmdline_cmd((char_u *)":let SaVe_ISF = &isf|set isf+=(,)");
+	do_cmdline_cmd((char_u *)":let SaVe_WIG = &wig|set wig=");
 	alist_expand(fnum_list, used_alist_count);
 	do_cmdline_cmd((char_u *)":let &isf = SaVe_ISF|unlet SaVe_ISF");
+	do_cmdline_cmd((char_u *)":let &wig = SaVe_WIG|unlet SaVe_WIG");
     }
 
     /* If wildcard expansion failed, we are editing the first file of the


### PR DESCRIPTION
On Windows, command-line arguments are parsed in the program it self as opposed to UNIX's one.
Setting encoding option in vimrc convert the encoding of command-line arguments on Windows. However, the arguments must not be depend on wildignore since the arguments is specified in command-line.

```
set wildignore+=.git/*
set encoding=utf-8
```

When using this vimrc, `set encoding=utf-8` do convertion of encoding of the arguments. And it call alist_expand. alist_expand call expand_wildcards. So it is influenced to wildignore option.

```
C:\>mkdir あ\.git
C:\>echo test>あ\.git\config
C:\>cd あ
C:\あ>type con>vimrc
set wildignore+=.git/*
set encoding=utf-8
^Z
C:\あ>vim -u vimrc -N .git\config
```
This test fail to open the file since the arguments is influenced to wildignore option.
