### PR TITLE
Fix HTML indent for custom elements

### DIFF
--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -860,7 +860,7 @@ func! HtmlIndent_FindStartTag()
   " The cursor must be on or before a closing tag.
   " If found, positions the cursor at the match and returns the line number.
   " Otherwise returns 0.
-  let tagname = matchstr(getline('.')[col('.') - 1:], '</\zs\w\+\ze')
+  let tagname = matchstr(getline('.')[col('.') - 1:], '</\zs\w\+\(-\w\+\)*\ze')
   let start_lnum = searchpair('<' . tagname . '\>', '', '</' . tagname . '\>', 'bW')
   if start_lnum > 0
     return start_lnum
@@ -876,7 +876,7 @@ func! HtmlIndent_FindTagEnd()
   " a self-closing tag, to the matching ">".
   " Limited to look up to b:html_indent_line_limit lines away.
   let text = getline('.')
-  let tagname = matchstr(text, '\w\+\|!--', col('.'))
+  let tagname = matchstr(text, '\w\+\(-\w\+\)*\|!--', col('.'))
   if tagname == '!--'
     call search('--\zs>')
   elseif s:get_tag('/' . tagname) != 0


### PR DESCRIPTION
Hi Bram

I found current HTML indent file don't work well on [custom elements][1].
A sample code snippet for test:

```html
<dom-module id="my-component">
  <template>

    <paper-toolbar>
    </paper-toolbar>
  </template>
  <script src="my-component.js"></script>
</dom-module>
```

And the reason is the tagname pattern in `HtmlIndent_FindStartTag`  can't match [custom element name][2] (this PR uses a more general pattern, not strict align the spec).

[1]:https://www.w3.org/TR/custom-elements/
[2]:https://www.w3.org/TR/custom-elements/#valid-custom-element-name