### PR TITLE
Reduced sizeof(list_T) from 88 to 80 bytes

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -1265,16 +1265,16 @@ struct listvar_S
 {
     listitem_T	*lv_first;	/* first item, NULL if none */
     listitem_T	*lv_last;	/* last item, NULL if none */
-    int		lv_refcount;	/* reference count */
-    int		lv_len;		/* number of items */
     listwatch_T	*lv_watch;	/* first watcher, NULL if none */
-    int		lv_idx;		/* cached index of an item */
     listitem_T	*lv_idx_item;	/* when not NULL item at index "lv_idx" */
-    int		lv_copyID;	/* ID used by deepcopy() */
     list_T	*lv_copylist;	/* copied list used by deepcopy() */
-    char	lv_lock;	/* zero, VAR_LOCKED, VAR_FIXED */
     list_T	*lv_used_next;	/* next list in used lists list */
     list_T	*lv_used_prev;	/* previous list in used lists list */
+    int		lv_refcount;	/* reference count */
+    int		lv_len;		/* number of items */
+    int		lv_idx;		/* cached index of an item */
+    int		lv_copyID;	/* ID used by deepcopy() */
+    char	lv_lock;	/* zero, VAR_LOCKED, VAR_FIXED */
 };
 
 /*


### PR DESCRIPTION
While profiling memory with the massif memory profiler,
I saw about half a MiB allocated from list.c:75:
```
->79.40% (14,733,443B) 0x4C8F2F: lalloc (misc2.c:976)
...
| ->15.09% (2,799,399B) 0x4C9863: alloc_clear (misc2.c:898)
...
| | ->02.70% (500,720B) 0x4AA96C: list_alloc (list.c:75)
| | | ->02.70% (500,456B) 0x4AB7F0: get_list_tv (list.c:865)
| | | | ->02.70% (500,456B) 0x43820C: eval7 (eval.c:4096)
| | | |   ->02.70% (500,456B) 0x438B52: eval6 (eval.c:3823)
| | | |     ->02.70% (500,456B) 0x438E01: eval5 (eval.c:3639)
| | | |     | ->02.70% (500,456B) 0x433852: eval3 (eval.c:3523)
| | | |     |   ->02.70% (500,456B) 0x4339E2: eval1 (eval.c:3375)
| | | |     |     ->02.62% (486,112B) 0x5990FE: get_func_tv (userfunc.c:425)
| | | |     |     | ->02.62% (485,936B) 0x59BE08: ex_call (userfunc.c:3079)
| | | |     |     | | ->02.62% (485,936B) 0x46C4F6: do_cmdline (ex_docmd.c:2909)
| | | |     |     | |   ->02.62% (485,936B) 0x5988ED: call_func (userfunc.c:942)
| | | |     |     | |     ->02.62% (485,936B) 0x599310: get_func_tv (userfunc.c:455)
```
The allocations happened at:
```
70     list_T *
71 list_alloc(void)
72 {
73     list_T  *l;
74 
75     l = (list_T *)alloc_clear(sizeof(list_T));
```
Adding a printf(), I see that sizeof(list_T) is 88 bytes on x86_64.
This PR reorders fields in that struct by their required alignment
which reduces sizeof(list_T) to 80 bytes (-9%).

