### PR TITLE
fix mouse pointer for get_number

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3565,6 +3565,9 @@ get_number(
 	else if (c == CAR || c == NL || c == Ctrl_C || c == ESC)
 	    break;
     }
+#ifdef FEAT_MOUSE
+    setmouse();
+#endif
     --no_mapping;
     --allow_keys;
     return n;


### PR DESCRIPTION
When input number (ex: :tselect), mouse pointer is hidden while input number. This is expected. But the mouse pointer is not redrawn after jumped to the buffer decided.