### PR TITLE
Fix crash when t_Co <= 1 and termguicolors is enabled

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -8127,7 +8127,7 @@ screen_start_highlight(int attr)
 			term_bg_color(aep->ae_u.cterm.bg_color - 1);
 		}
 
-		if (t_colors <= 1)
+		if (!IS_CTERM)
 		{
 		    if (aep->ae_u.term.start != NULL)
 			out_str(aep->ae_u.term.start);


### PR DESCRIPTION
# Problem
Causes segmentation fault when t_Co option is changed to 0 or 1 in termguicolors

# Repro steps

Execute `vim -u NONE -N`

Execute Ex command `:set termguicolors`

Execute one of the following
```
:set t_Co=0
:set t_Co=1
"atoi returns 0 at fail
:set t_Co=
```

# Solution
In screen_start_highlight function, cterm is always used in termguicolors is enabled. but the condition of cterm is missing in the part of the problem.

Modify the conditions to use IS_CTERM macro.

