### PR TITLE
Enable "log_tr" to take variable arguments

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -108,10 +108,10 @@ char		*tgetstr(char *, char **);
     /* Change this to "if 1" to debug what happens with termresponse. */
 #  if 0
 #   define DEBUG_TERMRESPONSE
-    static void log_tr(char *msg);
-#   define LOG_TR(msg) log_tr(msg)
+static void log_tr(const char *fmt, ...);
+#   define LOG_TR(msg) log_tr msg
 #  else
-#   define LOG_TR(msg)
+#   define LOG_TR(msg) do { /**/ } while (0)
 #  endif
 
 #  define STATUS_GET	1	/* send request when switching to RAW mode */
@@ -1507,6 +1507,8 @@ may_adjust_color_count(int val)
 {
     if (val != t_colors)
     {
+	int r;
+
 	/* Nr of colors changed, initialize highlighting and
 	 * redraw everything.  This causes a redraw, which usually
 	 * clears the message.  Try keeping the message if it
@@ -1514,17 +1516,8 @@ may_adjust_color_count(int val)
 	set_keep_msg_from_hist();
 	set_color_count(val);
 	init_highlight(TRUE, FALSE);
-# ifdef DEBUG_TERMRESPONSE
-	{
-	    char buf[100];
-	    int  r = redraw_asap(CLEAR);
-
-	    sprintf(buf, "Received t_Co, redraw_asap(): %d", r);
-	    log_tr(buf);
-	}
-# else
-	redraw_asap(CLEAR);
-# endif
+	r = redraw_asap(CLEAR);
+	LOG_TR(("Received t_Co, redraw_asap(): %d", r));
     }
 }
 #endif
@@ -1948,7 +1941,7 @@ set_termname(char_u *term)
     full_screen = TRUE;		/* we can use termcap codes from now on */
     set_term_defaults();	/* use current values as defaults */
 #ifdef FEAT_TERMRESPONSE
-    LOG_TR("setting crv_status to STATUS_GET");
+    LOG_TR(("setting crv_status to STATUS_GET"));
     crv_status = STATUS_GET;	/* Get terminal version later */
 #endif
 
@@ -3510,7 +3503,7 @@ may_req_termresponse(void)
 	    && starting == 0
 	    && *T_CRV != NUL)
     {
-	LOG_TR("Sending CRV request");
+	LOG_TR(("Sending CRV request"));
 	out_str(T_CRV);
 	crv_status = STATUS_SENT;
 	/* check for the characters now, otherwise they might be eaten by
@@ -3541,7 +3534,7 @@ may_req_ambiguous_char_width(void)
     {
 	 char_u	buf[16];
 
-	 LOG_TR("Sending U7 request");
+	 LOG_TR(("Sending U7 request"));
 	 /* Do this in the second row.  In the first row the returned sequence
 	  * may be CSI 1;2R, which is the same as <S-F3>. */
 	 term_windgoto(1, 0);
@@ -3583,7 +3576,7 @@ may_req_bg_color(void)
 	/* Only request foreground if t_RF is set. */
 	if (rfg_status == STATUS_GET && *T_RFG != NUL)
 	{
-	    LOG_TR("Sending FG request");
+	    LOG_TR(("Sending FG request"));
 	    out_str(T_RFG);
 	    rfg_status = STATUS_SENT;
 	    didit = TRUE;
@@ -3593,7 +3586,7 @@ may_req_bg_color(void)
 	/* Only request background if t_RB is set. */
 	if (rbg_status == STATUS_GET && *T_RBG != NUL)
 	{
-	    LOG_TR("Sending BG request");
+	    LOG_TR(("Sending BG request"));
 	    out_str(T_RBG);
 	    rbg_status = STATUS_SENT;
 	    didit = TRUE;
@@ -3611,11 +3604,12 @@ may_req_bg_color(void)
 
 # ifdef DEBUG_TERMRESPONSE
     static void
-log_tr(char *msg)
+log_tr(const char *fmt, ...)
 {
     static FILE *fd_tr = NULL;
     static proftime_T start;
     proftime_T now;
+    va_list ap;
 
     if (fd_tr == NULL)
     {
@@ -3624,11 +3618,14 @@ log_tr(char *msg)
     }
     now = start;
     profile_end(&now);
-    fprintf(fd_tr, "%s: %s %s\n",
-	    profile_msg(&now),
-	    must_redraw == NOT_VALID ? "NV"
-					 : must_redraw == CLEAR ? "CL" : "  ",
-	    msg);
+    fprintf(fd_tr, "%s: %s ", profile_msg(&now),
+					must_redraw == NOT_VALID ? "NV"
+					: must_redraw == CLEAR ? "CL" : "  ");
+    va_start(ap, fmt);
+    vfprintf(fd_tr, fmt, ap);
+    va_end(ap);
+    fputc('\n', fd_tr);
+    fflush(fd_tr);
 }
 # endif
 #endif
@@ -4179,7 +4176,7 @@ switch_to_8bit(void)
 	need_gather = TRUE;		/* need to fill termleader[] */
     }
     detected_8bit = TRUE;
-    LOG_TR("Switching to 8 bit");
+    LOG_TR(("Switching to 8 bit"));
 }
 #endif
 
@@ -4512,7 +4509,7 @@ check_termcode(
 		    }
 		if (i == len)
 		{
-		    LOG_TR("Not enough characters for CRV");
+		    LOG_TR(("Not enough characters for CRV"));
 		    return -1;
 		}
 		if (extra > 0)
@@ -4529,7 +4526,7 @@ check_termcode(
 		    {
 			char *aw = NULL;
 
-			LOG_TR("Received U7 status");
+			LOG_TR(("Received U7 status"));
 			u7_status = STATUS_GOT;
 			did_cursorhold = TRUE;
 			if (col == 2)
@@ -4538,24 +4535,15 @@ check_termcode(
 			    aw = "double";
 			if (aw != NULL && STRCMP(aw, p_ambw) != 0)
 			{
+			    int r;
+
 			    /* Setting the option causes a screen redraw. Do
 			     * that right away if possible, keeping any
 			     * messages. */
 			    set_option_value((char_u *)"ambw", 0L,
 					     (char_u *)aw, 0);
-# ifdef DEBUG_TERMRESPONSE
-			    {
-				char buf[100];
-				int  r = redraw_asap(CLEAR);
-
-				sprintf(buf,
-					"set 'ambiwidth', redraw_asap(): %d",
-					r);
-				log_tr(buf);
-			    }
-# else
-			    redraw_asap(CLEAR);
-# endif
+			    r = redraw_asap(CLEAR);
+			    LOG_TR(("set 'ambiwidth', redraw_asap(): %d", r));
 			}
 		    }
 		    key_name[0] = (int)KS_EXTRA;
@@ -4572,7 +4560,7 @@ check_termcode(
 		{
 		    int version = col;
 
-		    LOG_TR("Received CRV response");
+		    LOG_TR(("Received CRV response"));
 		    crv_status = STATUS_GOT;
 		    did_cursorhold = TRUE;
 
@@ -4598,7 +4586,7 @@ check_termcode(
 			/* if xterm version >= 141 try to get termcap codes */
 			if (version >= 141)
 			{
-			    LOG_TR("Enable checking for XT codes");
+			    LOG_TR(("Enable checking for XT codes"));
 			    check_for_codes = TRUE;
 			    need_gather = TRUE;
 			    req_codes_from_term();
@@ -4688,7 +4676,7 @@ check_termcode(
 				&& *T_CSH != NUL
 				&& *T_CRS != NUL)
 			{
-			    LOG_TR("Sending cursor style request");
+			    LOG_TR(("Sending cursor style request"));
 			    out_str(T_CRS);
 			    rcs_status = STATUS_SENT;
 			    need_flush = TRUE;
@@ -4701,7 +4689,7 @@ check_termcode(
 				&& !is_not_xterm
 				&& *T_CRC != NUL)
 			{
-			    LOG_TR("Sending cursor blink mode request");
+			    LOG_TR(("Sending cursor blink mode request"));
 			    out_str(T_CRC);
 			    rbm_status = STATUS_SENT;
 			    need_flush = TRUE;
@@ -4737,7 +4725,7 @@ check_termcode(
 		{
 		    initial_cursor_blink = (tp[j + 4] == '1');
 		    rbm_status = STATUS_GOT;
-		    LOG_TR("Received cursor blinking mode response");
+		    LOG_TR(("Received cursor blinking mode response"));
 		    key_name[0] = (int)KS_EXTRA;
 		    key_name[1] = (int)KE_IGNORE;
 		    slen = i + 1;
@@ -4779,7 +4767,7 @@ check_termcode(
 		    }
 		    if (i == len)
 		    {
-			LOG_TR("not enough characters for winpos");
+			LOG_TR(("not enough characters for winpos"));
 			return -1;
 		    }
 		}
@@ -4825,7 +4813,7 @@ check_termcode(
 				char *newval = (3 * '6' < tp[j+7] + tp[j+12]
 						+ tp[j+17]) ? "light" : "dark";
 
-				LOG_TR("Received RBG response");
+				LOG_TR(("Received RBG response"));
 				rbg_status = STATUS_GOT;
 #ifdef FEAT_TERMINAL
 				bg_r = rval;
@@ -4845,7 +4833,7 @@ check_termcode(
 #ifdef FEAT_TERMINAL
 			    else
 			    {
-				LOG_TR("Received RFG response");
+				LOG_TR(("Received RFG response"));
 				rfg_status = STATUS_GOT;
 				fg_r = rval;
 				fg_g = gval;
@@ -4866,7 +4854,7 @@ check_termcode(
 		    }
 		if (i == len)
 		{
-		    LOG_TR("not enough characters for RB");
+		    LOG_TR(("not enough characters for RB"));
 		    return -1;
 		}
 	    }
@@ -4940,7 +4928,7 @@ check_termcode(
 			    initial_cursor_shape_blink =
 						   (number & 1) ? FALSE : TRUE;
 			    rcs_status = STATUS_GOT;
-			    LOG_TR("Received cursor shape response");
+			    LOG_TR(("Received cursor shape response"));
 
 			    key_name[0] = (int)KS_EXTRA;
 			    key_name[1] = (int)KE_IGNORE;
@@ -4957,7 +4945,7 @@ check_termcode(
 		{
 		    /* These codes arrive many together, each code can be
 		     * truncated at any point. */
-		    LOG_TR("not enough characters for XT");
+		    LOG_TR(("not enough characters for XT"));
 		    return -1;
 		}
 	    }
@@ -5907,7 +5895,7 @@ check_termcode(
     }
 
 #ifdef FEAT_TERMRESPONSE
-    LOG_TR("normal character");
+    LOG_TR(("normal character"));
 #endif
 
     return 0;			    /* no match found */
@@ -6390,15 +6378,10 @@ req_more_codes_from_term(void)
      * many, there can be a buffer overflow somewhere. */
     while (xt_index_out < xt_index_in + 10 && key_names[xt_index_out] != NULL)
     {
-# ifdef DEBUG_TERMRESPONSE
-	char dbuf[100];
+	char *key_name = key_names[xt_index_out];
 
-	sprintf(dbuf, "Requesting XT %d: %s",
-				       xt_index_out, key_names[xt_index_out]);
-	log_tr(dbuf);
-# endif
-	sprintf(buf, "\033P+q%02x%02x\033\\",
-		      key_names[xt_index_out][0], key_names[xt_index_out][1]);
+	LOG_TR(("Requesting XT %d: %s", xt_index_out, key_name));
+	sprintf(buf, "\033P+q%02x%02x\033\\", key_name[0], key_name[1]);
 	out_str_nf((char_u *)buf);
 	++xt_index_out;
     }
@@ -6441,14 +6424,9 @@ got_code_from_term(char_u *code, int len)
 		break;
 	    }
 	}
-# ifdef DEBUG_TERMRESPONSE
-	{
-	    char buf[100];
 
-	    sprintf(buf, "Received XT %d: %s", xt_index_in, (char *)name);
-	    log_tr(buf);
-	}
-# endif
+	LOG_TR(("Received XT %d: %s", xt_index_in, (char *)name));
+
 	if (key_names[i] != NULL)
 	{
 	    for (i = 8; (c = hexhex2nr(code + i)) >= 0; i += 2)


### PR DESCRIPTION
I think this is a trivial but a bit useful change. 
We can trim awkward debug code: `sprintf` in `DEBUG_TERMRESPONSE` block.