### PR TITLE
Fix code highlighting

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -1855,18 +1855,17 @@ fill_input_buf(int exit_on_error UNUSED)
     for (try = 0; try < 100; ++try)
     {
 #  ifdef VMS
-	len = vms_read(
+#   define vim_read_from_input(fd, buf, len)	vms_read(buf, len)
 #  else
-	len = read(read_cmd_fd,
+#   define vim_read_from_input(fd, buf, len)	read(fd, buf, len)
 #  endif
-	    (char *)inbuf + inbufcount, (size_t)((INBUFLEN - inbufcount)
+	len = vim_read_from_input(read_cmd_fd,
+		(char *)inbuf + inbufcount, (size_t)((INBUFLEN - inbufcount)
 #  ifdef FEAT_MBYTE
-		/ input_conv.vc_factor
+		    / input_conv.vc_factor
 #  endif
-		));
-#  if 0
-		)	/* avoid syntax highlight error */
-#  endif
+		    ));
+#  undef vim_read_from_input
 
 	if (len > 0 || got_int)
 	    break;


### PR DESCRIPTION
## Problem

There is a wrong code highlighting at https://github.com/vim/vim/blob/5a3a49e/src/ui.c#L1877-L1893

![vim-wrong-syn-hl](https://user-images.githubusercontent.com/943423/37680377-0c62fa72-2cc7-11e8-83dd-2e035b1fa392.png)

## Cause

A closing parenthesis surrounded by `#if 0` ~ `#endif`:

https://github.com/vim/vim/blob/5a3a49e/src/ui.c#L1867-L1869

Contrary to comment, above code cannot avoid highlighting error.

## Solution Proposal

I think it is better to simplify function interface by using macro.