### PR TITLE
Fix: `expand_shellcmd` returns duplicate entries

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -5125,7 +5125,7 @@ expand_shellcmd(
 {
     char_u	*pat;
     int		i;
-    char_u	*path;
+    char_u	*path = NULL;
     int		mustfree = FALSE;
     garray_T    ga;
     char_u	*buf = alloc(MAXPATHL);
@@ -5134,6 +5134,9 @@ expand_shellcmd(
     int		flags = flagsarg;
     int		ret;
     int		did_curdir = FALSE;
+    hashtab_T	ht;
+    hashitem_T	*hi;
+    hash_T	hash;
 
     if (buf == NULL)
 	return FAIL;
@@ -5147,15 +5150,14 @@ expand_shellcmd(
 
     flags |= EW_FILE | EW_EXEC | EW_SHELLCMD;
 
-    /* For an absolute name we don't use $PATH. */
-    if (mch_isFullName(pat))
-	path = (char_u *)" ";
-    else if ((pat[0] == '.' && (vim_ispathsep(pat[1])
-			    || (pat[1] == '.' && vim_ispathsep(pat[2])))))
+    if (pat[0] == '.' && (vim_ispathsep(pat[1])
+			       || (pat[1] == '.' && vim_ispathsep(pat[2]))))
 	path = (char_u *)".";
     else
     {
-	path = vim_getenv((char_u *)"PATH", &mustfree);
+	/* For an absolute name we don't use $PATH. */
+	if (!mch_isFullName(pat))
+	    path = vim_getenv((char_u *)"PATH", &mustfree);
 	if (path == NULL)
 	    path = (char_u *)"";
     }
@@ -5166,6 +5168,7 @@ expand_shellcmd(
      * current directory, to find "subdir/cmd".
      */
     ga_init2(&ga, (int)sizeof(char *), 10);
+    hash_init(&ht);
     for (s = path; ; s = e)
     {
 	if (*s == NUL)
@@ -5177,9 +5180,6 @@ expand_shellcmd(
 	}
 	else if (*s == '.')
 	    did_curdir = TRUE;
-
-	if (*s == ' ')
-	    ++s;	/* Skip space used for absolute path name. */
 
 #if defined(MSWIN)
 	e = vim_strchr(s, ';');
@@ -5207,15 +5207,23 @@ expand_shellcmd(
 	    {
 		for (i = 0; i < *num_file; ++i)
 		{
-		    s = (*file)[i];
-		    if (STRLEN(s) > l)
+		    char_u *name = (*file)[i];
+
+		    if (STRLEN(name) > l)
 		    {
-			/* Remove the path again. */
-			STRMOVE(s, s + l);
-			((char_u **)ga.ga_data)[ga.ga_len++] = s;
+			/* Check duplicate item. */
+			hash = hash_hash(name + l);
+			hi = hash_lookup(&ht, name + l, hash);
+			if (HASHITEM_EMPTY(hi))
+			{
+			    /* Remove the path again. */
+			    STRMOVE(name, name + l);
+			    ((char_u **)ga.ga_data)[ga.ga_len++] = name;
+			    hash_add_item(&ht, hi, name, hash);
+			    name = NULL;
+			}
 		    }
-		    else
-			vim_free(s);
+		    vim_free(name);
 		}
 		vim_free(*file);
 	    }
@@ -5230,6 +5238,7 @@ expand_shellcmd(
     vim_free(pat);
     if (mustfree)
 	vim_free(path);
+    hash_clear(&ht);
     return OK;
 }
 

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -226,6 +226,20 @@ func Test_getcompletion()
   let l = getcompletion('not', 'mapclear')
   call assert_equal([], l)
 
+  if has('win32')
+    let root = 'C:\\'
+  else
+    let root = '/'
+  endif
+  let l = getcompletion('.', 'shellcmd')
+  let expected = map(filter(glob('.*', 0, 1),
+        \ 'isdirectory(v:val) || executable(v:val)'), 'isdirectory(v:val) ? v:val . ''/'' : v:val')
+  call assert_equal(expected, l)
+  let l = getcompletion(root, 'shellcmd')
+  let expected = map(filter(glob(root . '*', 0, 1),
+        \ 'isdirectory(v:val) || executable(v:val)'), 'isdirectory(v:val) ? v:val . ''/'' : v:val')
+  call assert_equal(expected, l)
+
   if has('cscope')
     let l = getcompletion('', 'cscope')
     let cmds = ['add', 'find', 'help', 'kill', 'reset', 'show']

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -226,15 +226,10 @@ func Test_getcompletion()
   let l = getcompletion('not', 'mapclear')
   call assert_equal([], l)
 
-  if has('win32')
-    let root = 'C:\\'
-  else
-    let root = '/'
-  endif
   let l = getcompletion('.', 'shellcmd')
-  let expected = map(filter(glob('.*', 0, 1),
-        \ 'isdirectory(v:val) || executable(v:val)'), 'isdirectory(v:val) ? v:val . ''/'' : v:val')
-  call assert_equal(expected, l)
+  call assert_equal(['./', '../'], l[0:1])
+  call assert_equal(-1, match(l[2:], '^\.\.\?/$'))
+  let root = has('win32') ? 'C:\\' : '/'
   let l = getcompletion(root, 'shellcmd')
   let expected = map(filter(glob(root . '*', 0, 1),
         \ 'isdirectory(v:val) || executable(v:val)'), 'isdirectory(v:val) ? v:val . ''/'' : v:val')
@@ -267,8 +262,7 @@ func Test_getcompletion()
   endif
 
   " For others test if the name is recognized.
-  let names = ['buffer', 'environment', 'file_in_path',
-	\ 'mapping', 'shellcmd', 'tag', 'tag_listfiles', 'user']
+  let names = ['buffer', 'environment', 'file_in_path', 'mapping', 'tag', 'tag_listfiles', 'user']
   if has('cmdline_hist')
     call add(names, 'history')
   endif


### PR DESCRIPTION
## Problem (reported by @machakann)

When give the globbing of absolute path or command, `expand_shellcmd` returns duplicate entries.

## Repro steps

Using bang command, `:term` command or user-defined command with `-complete=shellcmd`.

Start `vim --clean` and:

### Case 1. Absolute path

```
:!/bin<C-A>
```

expected:

```
:!/bin/
```

actual:

```
:!/bin/ /bin/
```

`/bin/` is shown twice.

### Case 2. Dot

```
:!.<C-A>
```

When there is no dot-started object on current directory (only `.` and `..`),

expected:

```
:!./ ../
```

actual:

```
:!./ ../ ./ ../ ./ ../ ./ ../ ./ ../
```

`./` and `../` are shown multiple times.
This is the number of paths registered to `PATH` env variable plus 1 (means current directory).

### Case 3. Command

When command `foobar` is both  in /usr/bin and /usr/local/bin and they are in `PATH`,
(e.g. `PATH=/usr/local/bin:/usr/bin`)

```
:!foobar<C-A>
```

expected:

```
:!foobar
```

actual:

```
:!foobar foobar
```

## Cause

Case 1:
https://github.com/vim/vim/blob/29dfa5af3c14406573d08609d2e95add4d6b45fb/src/ex_getln.c#L5169-L5225
This for-loop is executed extra 1 times.

https://github.com/vim/vim/blob/29dfa5af3c14406573d08609d2e95add4d6b45fb/src/ex_getln.c#L5181-L5182
This was for the loop-end condition of `s != NUL`, so is not needed no longer.

Case 2:
Since ./ and ../ are found in each paths registered to `PATH`, they are listed all.

Case 3:
All candidate commands in `PATH` are listed regardless of duplicated.

## Solution Proposal

* Use hashtab to deduplicate.

Or to resolve only case 1 and 2 (I think they look bad especially...), it is enough to apply https://github.com/vim/vim/compare/master...ichizok:fix/expand_shellcmd-1.diff
(if concern about performance issue of using hashtab) 
