### PR TITLE
Fix: job which starts under specific conditions finishes instantly (and unexpectedly)

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -5638,13 +5638,14 @@ mch_job_start(char **argv, job_T *job, jobopt_T *options)
 	close(fd_err[1]);
     if (channel != NULL)
     {
-	channel_set_pipes(channel,
-		use_file_for_in || use_null_for_in
-			? INVALID_FD : fd_in[1] < 0 ? pty_master_fd : fd_in[1],
-		use_file_for_out || use_null_for_out
-		      ? INVALID_FD : fd_out[0] < 0 ? pty_master_fd : fd_out[0],
-		use_out_for_err || use_file_for_err || use_null_for_err
-		     ? INVALID_FD : fd_err[0] < 0 ? pty_master_fd : fd_err[0]);
+	int in_fd = use_file_for_in || use_null_for_in
+			? INVALID_FD : fd_in[1] < 0 ? pty_master_fd : fd_in[1];
+	int out_fd = use_file_for_out || use_null_for_out
+		      ? INVALID_FD : fd_out[0] < 0 ? pty_master_fd : fd_out[0];
+	int err_fd = use_out_for_err || use_file_for_err || use_null_for_err
+		      ? INVALID_FD : fd_err[0] < 0 ? pty_master_fd : fd_err[0];
+
+	channel_set_pipes(channel, in_fd, out_fd, err_fd);
 	channel_set_job(channel, job, options);
     }
     else

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1848,3 +1848,14 @@ func Test_zz_ch_log()
   call assert_match("%s%s", text[2])
   call delete('Xlog')
 endfunc
+
+func Test_keep_pty_open()
+  if !has('unix')
+    return
+  endif
+
+  let job = job_start(s:python . ' -c "import time;time.sleep(0.2)"', {'out_io': 'null', 'err_io': 'null', 'pty': 1})
+  let elapsed = WaitFor({-> job_status(job) ==# 'dead'})
+  call assert_inrange(200, 1000, elapsed)
+  call job_stop(job)
+endfunc


### PR DESCRIPTION
## Problem

On unix-like system.
Under the following conditions, job finishes instantly, unexpectedly.

* with pty
* redirect both stdout and stderr to file (or null)

## Repro steps

`vim --clean`

```
:call term_start('sleep 10', {'out_io': 'null', 'err_io': 'null'})
```

`sleep 10` will finish instantly without wait of 10 seconds. This behavior is unexpected.

## Cause

When redirect both stdout and stderr of job to file or null, this means the job-channel parts of them are closed from the beginning of job, so stdin of job-channel is closed instantly.
And using pty in this case, since pty is assigned to only stdin, closing stdin means closing pty so then kernel sends SIGHUP to job process.

## Solution Proposal

When stdin of job-channel is tty, set the bit of `PART_IN` of `ch_to_be_closed` and close stdin of job-channel manually at job ended.

In addition, changing the conditions in `has_pending_job`.
This is because, when Vim doesn't handle both stdout and stderr of the job, there is no chance of checking job status and changing status-line string (e.g. "running", "finished") of terminal window until next user-input occurs.
Therefore add the condition "job is finished and its job-channel remains closeable" to `has_pending_job`.