### PR TITLE
Only spell-check comments and strings in Inno Setup files

### DIFF
--- a/runtime/syntax/iss.vim
+++ b/runtime/syntax/iss.vim
@@ -45,13 +45,13 @@ syn match  issParam	"Components:\|Description:\|GroupDescription:\|Types:\|Extra
 syn match  issParam	"StatusMsg:\|RunOnceId:\|Tasks:"
 syn match  issParam	"MessagesFile:\|LicenseFile:\|InfoBeforeFile:\|InfoAfterFile:"
 
-syn match  issComment	"^\s*;.*$"
+syn match  issComment	"^\s*;.*$" contains=@Spell
 
 " folder constant
-syn match  issFolder	"{[^{]*}"
+syn match  issFolder	"{[^{]*}" contains=@NoSpell
 
 " string
-syn region issString	start=+"+ end=+"+ contains=issFolder
+syn region issString	start=+"+ end=+"+ contains=issFolder,@Spell
 
 " [Dirs]
 syn keyword issDirsFlags deleteafterinstall uninsalwaysuninstall uninsneveruninstall


### PR DESCRIPTION
Use @Spell to avoid spell-checking Inno Setup directives and file names,
to avoid showing many spelling errors for any .iss file.

---

Note: I tried contacting Jason Mills whose email is mentioned in the comment in the beginning of this file, as recommended by the contributors guidelines, but this email doesn't work any longer, so I'm submitting it here.