### PR TITLE
shut up on mingw

### DIFF
--- a/src/libvterm/src/vterm_internal.h
+++ b/src/libvterm/src/vterm_internal.h
@@ -5,7 +5,7 @@
 
 #include <stdarg.h>
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__MINGW32__)
 # define INTERNAL __attribute__((visibility("internal")))
 # define UNUSED __attribute__((unused))
 #else


### PR DESCRIPTION
Disable the Visibility warning, that seems to be not supported by Mingw32 as seen on appveyor.
I hope this shuts up the warning "warning: visibility attribute not supported in this configuration; ignored [-Wattributes]" on mingw