### PR TITLE
Fix: Use sysconf() instead of getpagesize()

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -603,7 +603,7 @@ mch_total_mem(int special UNUSED)
 #  ifdef MAC_OS_X_VERSION_10_9
 					    + vm_stat.compressor_page_count
 #  endif
-					    ) * getpagesize();
+					    ) * sysconf(_SC_PAGESIZE);
 	mach_port_deallocate(mach_task_self(), host);
     }
 # endif


### PR DESCRIPTION
https://github.com/vim/vim/pull/2735#issuecomment-375207630

This is fix for 'maxmem' on macOS.
`getpagesize()` has been dropped from POSIX.