### PR TITLE
Fix TextChanged event false triggering

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -290,6 +290,10 @@ open_buffer(
     else if (retval == OK && !read_stdin && !read_fifo)
 	unchanged(curbuf, FALSE);
     save_file_ff(curbuf);		/* keep this fileformat */
+    curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
+#ifdef FEAT_INS_EXPAND
+    curbuf->b_last_changedtick_pum = CHANGEDTICK(curbuf);
+#endif
 
     /* require "!" to overwrite the file, because it wasn't read completely */
 #ifdef FEAT_EVAL

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -1,5 +1,7 @@
 " Tests for autocommands
 
+source shared.vim
+
 func! s:cleanup_buffers() abort
   for bnr in range(1, bufnr('$'))
     if bufloaded(bnr) && bufnr('%') != bnr
@@ -1303,4 +1305,23 @@ func Test_ChangedP()
   set complete&vim completeopt&vim
 
   bw!
+endfunc
+
+func Test_Changed_FirstTime()
+  if !has('terminal') || has('gui_running')
+    return
+  endif
+  " Prepare file for TextChanged event.
+  call writefile([''], 'Xchanged.txt')
+  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': 3})
+  call assert_equal('running', term_getstatus(buf))
+  " It's only adding autocmd, so that no event occurs.
+  call term_sendkeys(buf, ":au! TextChanged <buffer> call writefile(['No'], 'Xchanged.txt')\<cr>")
+  call term_sendkeys(buf, "\<C-\\>\<C-N>:qa!\<cr>")
+  call WaitFor({-> term_getstatus(buf) == 'finished'})
+  call assert_equal([''], readfile('Xchanged.txt'))
+  " clean up
+  call delete('Xchanged.txt')
+
+  bwipe!
 endfunc


### PR DESCRIPTION
When adding autocmd TextChanged, Unexpected TextChanged event is triggered.

### How to reproduce:
1. Start vanilla Vim.
```
$ vim -Nu NONE
```
2. Add autocmd
```
:autocmd TextChanged * echom 'foo'
```

### Expected behavior:
No event triggered.

### Actual behavior:
TextChanged event triggered.

### Investigation result:
- It will happen after Vim 8.0.1494
- [The trigger condition of TextChanged is here](https://github.com/vim/vim/blob/master/src/main.c#L1190).
But, `curbuf->b_last_changedtick` and `CHANGEDTICK(curbuf)` have different values at the time of creating the buffer.
  - `curbuf->b_last_changedtick` : 0
  - `CHANGEDTICK(curbuf)` : 2

  So, just adding autocmd will cause an TextChanged event.

### How to fix:
- We should assign `CHANGEDTICK(curbuf)` to `curbuf->b_last_changedtick` in open_buffer().
Also `curbuf->b_last_changedtick_pum`.

--
Best regards,
Hirohito Higashi (h_east)