### PR TITLE
Fix terminal api tests

### DIFF
--- a/src/testdir/screendump.vim
+++ b/src/testdir/screendump.vim
@@ -47,17 +47,15 @@ func RunVimInTerminal(arguments, options)
   set t_Co=256 background=light
   hi Normal ctermfg=NONE ctermbg=NONE
 
-  " Make the window 20 lines high, unless told otherwise.
-  let rows = 20
-  if has_key(a:options, 'rows')
-    let rows = a:options['rows']
-  endif
+  " Make the window 20 lines high and 75 columns, unless told otherwise.
+  let rows = get(a:options, 'rows', 20)
+  let cols = get(a:options, 'cols', 75)
 
   let cmd = GetVimCommandClean()
   " Add -v to have gvim run in the terminal (if possible)
   let cmd .= ' -v ' . a:arguments
-  let buf = term_start(cmd, {'curwin': 1, 'term_rows': rows, 'term_cols': 75})
-  call assert_equal([rows, 75], term_getsize(buf))
+  let buf = term_start(cmd, {'curwin': 1, 'term_rows': rows, 'term_cols': cols})
+  call assert_equal([rows, cols], term_getsize(buf))
 
   return buf
 endfunc

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1029,10 +1029,10 @@ func Test_terminal_api_drop_newwin()
     return
   endif
   call assert_equal(1, winnr('$'))
-  set title
 
   " Use the title termcap entries to output the escape sequence.
   call writefile([
+	\ 'set title',
 	\ 'exe "set t_ts=\<Esc>]51; t_fs=\x07"',
 	\ 'let &titlestring = ''["drop","Xtextfile"]''',
 	\ 'redraw',
@@ -1046,7 +1046,6 @@ func Test_terminal_api_drop_newwin()
   call StopVimInTerminal(buf)
   call delete('Xscript')
   bwipe Xtextfile
-  set title&
 endfunc
 
 func Test_terminal_api_drop_oldwin()
@@ -1058,10 +1057,10 @@ func Test_terminal_api_drop_oldwin()
   let textfile_winid = win_getid()
   call assert_equal(2, winnr('$'))
   call win_gotoid(firstwinid)
-  set title
 
   " Use the title termcap entries to output the escape sequence.
   call writefile([
+	\ 'set title',
 	\ 'exe "set t_ts=\<Esc>]51; t_fs=\x07"',
 	\ 'let &titlestring = ''["drop","Xtextfile"]''',
 	\ 'redraw',
@@ -1074,7 +1073,6 @@ func Test_terminal_api_drop_oldwin()
   call StopVimInTerminal(buf)
   call delete('Xscript')
   bwipe Xtextfile
-  set title&
 endfunc
 
 func TryThis(bufnum, arg)
@@ -1086,10 +1084,10 @@ func Test_terminal_api_call()
   if !CanRunVimInTerminal()
     return
   endif
-  set title
 
   " Use the title termcap entries to output the escape sequence.
   call writefile([
+	\ 'set title',
 	\ 'exe "set t_ts=\<Esc>]51; t_fs=\x07"',
 	\ 'let &titlestring = ''["call","TryThis",["hello",123]]''',
 	\ 'redraw',
@@ -1104,5 +1102,4 @@ func Test_terminal_api_call()
   call delete('Xscript')
   unlet g:called_bufnum
   unlet g:called_arg
-  set title&
 endfunc


### PR DESCRIPTION
I believe 'set title' should be added to Xscript.

And this patch adds 'cols' option to RunVimInTerminal(), same as 'rows'. 