### PR TITLE
Add `:ls R`, `:ls F` and `:ls ?`

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1051,7 +1051,7 @@ list of buffers. |unlisted-buffer|
 		     #   alternate buffer
 		     R	 terminal buffers with a running job
 		     F	 terminal buffers with a finished job
-		     ?   yerminal buffers without a job: `:terminal NONE`
+		     ?   terminal buffers without a job: `:terminal NONE`
 		Combining flags means they are "and"ed together, e.g.:
 		     h+   hidden buffers which are modified
 		     a+   active buffers which are modified

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1049,6 +1049,9 @@ list of buffers. |unlisted-buffer|
 		     x   buffers with a read error
 		     %   current buffer
 		     #   alternate buffer
+		     R	 terminal buffers with a running job
+		     F	 terminal buffers with a finished job
+		     ?   yerminal buffers without a job: `:terminal NONE`
 		Combining flags means they are "and"ed together, e.g.:
 		     h+   hidden buffers which are modified
 		     a+   active buffers which are modified

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -3014,18 +3014,28 @@ buflist_list(exarg_T *eap)
     int		i;
     int		ro_char;
     int		changed_char;
+    int		job_running;
 
     for (buf = firstbuf; buf != NULL && !got_int; buf = buf->b_next)
     {
+	job_running = term_job_running(buf->b_term);
 	/* skip unlisted buffers, unless ! was used */
 	if ((!buf->b_p_bl && !eap->forceit && !vim_strchr(eap->arg, 'u'))
 		|| (vim_strchr(eap->arg, 'u') && buf->b_p_bl)
 		|| (vim_strchr(eap->arg, '+')
 			&& ((buf->b_flags & BF_READERR) || !bufIsChanged(buf)))
 		|| (vim_strchr(eap->arg, 'a')
-			 && (buf->b_ml.ml_mfp == NULL || buf->b_nwindows == 0))
+			&& (buf->b_ml.ml_mfp == NULL || buf->b_nwindows == 0))
 		|| (vim_strchr(eap->arg, 'h')
-			 && (buf->b_ml.ml_mfp == NULL || buf->b_nwindows != 0))
+			&& (buf->b_ml.ml_mfp == NULL || buf->b_nwindows != 0))
+#ifdef FEAT_TERMINAL
+		|| (vim_strchr(eap->arg, 'R')
+			&& (!job_running || (job_running && term_none_open(buf->b_term))))
+		|| (vim_strchr(eap->arg, '?')
+			&& (!job_running || (job_running && !term_none_open(buf->b_term))))
+		|| (vim_strchr(eap->arg, 'F')
+			&& (job_running || buf->b_term == NULL))
+#endif
 		|| (vim_strchr(eap->arg, '-') && buf->b_p_ma)
 		|| (vim_strchr(eap->arg, '=') && !buf->b_p_ro)
 		|| (vim_strchr(eap->arg, 'x') && !(buf->b_flags & BF_READERR))

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -3018,7 +3018,9 @@ buflist_list(exarg_T *eap)
 
     for (buf = firstbuf; buf != NULL && !got_int; buf = buf->b_next)
     {
+#ifdef FEAT_TERMINAL
 	job_running = term_job_running(buf->b_term);
+#endif
 	/* skip unlisted buffers, unless ! was used */
 	if ((!buf->b_p_bl && !eap->forceit && !vim_strchr(eap->arg, 'u'))
 		|| (vim_strchr(eap->arg, 'u') && buf->b_p_bl)


### PR DESCRIPTION
The `ls R`, `ls F` and `ls ?` filter running, finished and NONE terminal jobs in the output of the `:ls` command. This extends the feature added in 7.4.791 patch.  