### PR TITLE
Fix: Vim crashes when passing non dict value to job-option 'env' 

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -4796,9 +4796,14 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 	    {
 		if (!(supported2 & JO2_ENV))
 		    break;
+		if (item->v_type != VAR_DICT)
+		{
+		    EMSG2(_(e_invargval), "env");
+		    return FAIL;
+		}
 		opt->jo_set2 |= JO2_ENV;
 		opt->jo_env = item->vval.v_dict;
-		++item->vval.v_dict->dv_refcount;
+		++opt->jo_env->dv_refcount;
 	    }
 	    else if (STRCMP(hi->hi_key, "cwd") == 0)
 	    {

--- a/src/channel.c
+++ b/src/channel.c
@@ -4803,7 +4803,8 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		}
 		opt->jo_set2 |= JO2_ENV;
 		opt->jo_env = item->vval.v_dict;
-		++opt->jo_env->dv_refcount;
+		if (opt->jo_env != NULL)
+		    ++opt->jo_env->dv_refcount;
 	    }
 	    else if (STRCMP(hi->hi_key, "cwd") == 0)
 	    {

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1720,10 +1720,12 @@ func Test_env()
 
   let g:envstr = ''
   if has('win32')
-    call job_start(['cmd', '/c', 'echo %FOO%'], {'callback': {ch,msg->execute(":let g:envstr .= msg")}, 'env':{'FOO': 'bar'}})
+    let cmd = ['cmd', '/c', 'echo %FOO%']
   else
-    call job_start([&shell, &shellcmdflag, 'echo $FOO'], {'callback': {ch,msg->execute(":let g:envstr .= msg")}, 'env':{'FOO': 'bar'}})
+    let cmd = [&shell, &shellcmdflag, 'echo $FOO']
   endif
+  call assert_fails('call job_start(cmd, {"env": 1})', 'E475:')
+  call job_start(cmd, {'callback': {ch,msg -> execute(":let g:envstr .= msg")}, 'env': {'FOO': 'bar'}})
   call WaitFor('"" != g:envstr')
   call assert_equal("bar", g:envstr)
   unlet g:envstr
@@ -1737,11 +1739,12 @@ func Test_cwd()
   let g:envstr = ''
   if has('win32')
     let expect = $TEMP
-    let job = job_start(['cmd', '/c', 'echo %CD%'], {'callback': {ch,msg->execute(":let g:envstr .= msg")}, 'cwd': expect})
+    let cmd = ['cmd', '/c', 'echo %CD%']
   else
     let expect = $HOME
-    let job = job_start(['pwd'], {'callback': {ch,msg->execute(":let g:envstr .= msg")}, 'cwd': expect})
+    let cmd = ['pwd']
   endif
+  let job = job_start(cmd, {'callback': {ch,msg -> execute(":let g:envstr .= msg")}, 'cwd': expect})
   try
     call WaitFor('"" != g:envstr')
     let expect = substitute(expect, '[/\\]$', '', '')


### PR DESCRIPTION
## Repro steps

`vim --clean`

```vim
:call job_start('echo', {'env': 1})
```

## Cause and Solution

https://github.com/vim/vim/blob/25a6e8a769aa1c0d308b5f871132961f37986d0a/src/channel.c#L4795-L4802

We have to check if the type of `item` is dict.