### PR TITLE
Fix check fd is not INVALID_FD for prevent SEGV

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -4151,7 +4151,8 @@ channel_select_check(int ret_in, void *rfds_in, void *wfds_in)
 					    && FD_ISSET(in_part->ch_fd, wfds))
 	{
 	    channel_write_input(channel);
-	    FD_CLR(in_part->ch_fd, wfds);
+	    if (in_part->ch_fd != INVALID_FD)
+		FD_CLR(in_part->ch_fd, wfds);
 	    --ret;
 	}
     }


### PR DESCRIPTION
## Problem
Send a fixed amount of text to other program(use STDIN) via `job_start` cause SEGV at macOS.

When https://github.com/vim/vim/blob/25a6e8a769aa1c0d308b5f871132961f37986d0a/src/channel.c#L4153 was called, `in_part->ch_fd` would be `-1`.

In macOS, send `-1` to `FD_CLR` cause SEGV.
https://github.com/apple/darwin-xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/sys/_types/_fd_def.h#L62
macOS's `FD_CLR` does not check `-1`.

\# Linux did not SEGV.

## Solution
Check `fd` is not invalid.