### PR TITLE
Static analysis

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1443,7 +1443,7 @@ channel_write_in(channel_T *channel)
     }
     else
 	ch_log(channel, "Still %d more lines to write",
-					  buf->b_ml.ml_line_count - lnum + 1);
+				    (int)buf->b_ml.ml_line_count - lnum + 1);
 }
 
 /*
@@ -1537,7 +1537,7 @@ channel_write_new_lines(buf_T *buf)
 		ch_log(channel, "written %d lines to channel", written);
 	    if (lnum < buf->b_ml.ml_line_count)
 		ch_log(channel, "Still %d more lines to write",
-					      buf->b_ml.ml_line_count - lnum);
+					(int)buf->b_ml.ml_line_count - lnum);
 
 	    in_part->ch_buf_bot = lnum;
 	}
@@ -2081,7 +2081,7 @@ channel_get_json(
 	{
 	    *rettv = item->jq_value;
 	    if (tv->v_type == VAR_NUMBER)
-		ch_log(channel, "Getting JSON message %d", tv->vval.v_number);
+		ch_log(channel, "Getting JSON message %d", (int)tv->vval.v_number);
 	    remove_json_node(head, item);
 	    return OK;
 	}

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -10172,7 +10172,7 @@ set_buffer_lines(buf_T *buf, linenr_T lnum, typval_T *lines, typval_T *rettv)
 	}
 
 	rettv->vval.v_number = 1;	/* FAIL */
-	if (line == NULL || lnum < 1 || lnum > curbuf->b_ml.ml_line_count + 1)
+	if (line == NULL || lnum > curbuf->b_ml.ml_line_count + 1)
 	    break;
 
 	/* When coming here from Insert mode, sync undo, so that this can be

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1420,7 +1420,7 @@ check_due_timer(void)
 	    if (balloonEval != NULL)
 		general_beval_cb(balloonEval, 0);
 	}
-	else if (this_due > 0 && (next_due == -1 || next_due > this_due))
+	else if (next_due == -1 || next_due > this_due)
 	    next_due = this_due;
     }
 #endif

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1389,7 +1389,7 @@ retry:
 
 			/* If the crypt layer is buffering, not producing
 			 * anything yet, need to read more. */
-			if (size > 0 && decrypted_size == 0)
+			if (decrypted_size == 0)
 			    continue;
 
 			if (linerest == 0)

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -4119,7 +4119,7 @@ map_to_exists_mode(char_u *rhs, int mode, int abbr)
     mapblock_T	*mp;
     int		hash;
 # ifdef FEAT_LOCALMAP
-    int		expand_buffer = FALSE;
+    int		exp_buffer = FALSE;
 
     validate_maphash();
 
@@ -4134,14 +4134,14 @@ map_to_exists_mode(char_u *rhs, int mode, int abbr)
 		if (hash > 0)		/* there is only one abbr list */
 		    break;
 #ifdef FEAT_LOCALMAP
-		if (expand_buffer)
+		if (exp_buffer)
 		    mp = curbuf->b_first_abbr;
 		else
 #endif
 		    mp = first_abbr;
 	    }
 # ifdef FEAT_LOCALMAP
-	    else if (expand_buffer)
+	    else if (exp_buffer)
 		mp = curbuf->b_maphash[hash];
 # endif
 	    else
@@ -4154,9 +4154,9 @@ map_to_exists_mode(char_u *rhs, int mode, int abbr)
 	    }
 	}
 # ifdef FEAT_LOCALMAP
-	if (expand_buffer)
+	if (exp_buffer)
 	    break;
-	expand_buffer = TRUE;
+	exp_buffer = TRUE;
     }
 # endif
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -2610,7 +2610,7 @@ do_mouse(
 			end_visual_mode();
 		}
 	    }
-	    else if (c1 < 0)
+	    else
 	    {
 		tabpage_T	*tp;
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -441,7 +441,7 @@ mch_inchar(
 		    /* no character available within "wtime" */
 		    return 0;
 
-		if (wtime < 0)
+		else
 		{
 		    /* no character available within 'updatetime' */
 		    did_start_blocking = TRUE;

--- a/src/search.c
+++ b/src/search.c
@@ -4071,7 +4071,7 @@ again:
 	goto again;
     }
 
-    if (do_include || r < 1)
+    if (do_include)
     {
 	/* Include up to the '>'. */
 	while (*ml_get_cursor() != '>')

--- a/src/term.c
+++ b/src/term.c
@@ -2823,7 +2823,7 @@ term_get_winpos(int *x, int *y, varnumber_T timeout)
 
     winpos_x = prev_winpos_x;
     winpos_y = prev_winpos_y;
-    if (timeout < 10 && prev_winpos_y >= 0 && prev_winpos_y >= 0)
+    if (timeout < 10 && prev_winpos_y >= 0 && prev_winpos_x >= 0)
     {
 	/* Polling: return previous values if we have them. */
 	*x = winpos_x;


### PR DESCRIPTION
This fixes mainly some small cosmetic issues that were found by the static analyzer [lgtm.com](https://lgtm.com)

The most serious one is probably the fix in term.c which currently contains this code:
```C
    winpos_x = prev_winpos_x;
    winpos_y = prev_winpos_y;
    if (timeout < 10 && prev_winpos_y >= 0 && prev_winpos_y >= 0)
    {
	/* Polling: return previous values if we have them. */
	*x = winpos_x;
	*y = winpos_y;
	return OK;
    }
```
I guess the intention of the commit 89894aa671ed1db03d95d38cab3 was to check that the variables prev_winpos_y and prev_winpos_x are larger 0. 

To make it easily understandable, I made one commit per file changed, most of them were however only simplifying some `if()` conditions a bit. 

There are a couple of other issues shown. The complete list is available here: 
https://lgtm.com/projects/g/vim/vim/alerts/?mode=list
I am not sure I understand every warning, so I only changed those that looked like valid issues to me.