### PR TITLE
Return early if mkdir(..., 'p') is called with an existing directory

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8051,22 +8051,31 @@ f_mkdir(typval_T *argvars, typval_T *rettv)
 
     dir = get_tv_string_buf(&argvars[0], buf);
     if (*dir == NUL)
-	rettv->vval.v_number = FAIL;
-    else
-    {
-	if (*gettail(dir) == NUL)
-	    /* remove trailing slashes */
-	    *gettail_sep(dir) = NUL;
+	return;
 
-	if (argvars[1].v_type != VAR_UNKNOWN)
+    if (*gettail(dir) == NUL)
+	/* remove trailing slashes */
+	*gettail_sep(dir) = NUL;
+
+    if (argvars[1].v_type != VAR_UNKNOWN)
+    {
+	if (argvars[2].v_type != VAR_UNKNOWN)
 	{
-	    if (argvars[2].v_type != VAR_UNKNOWN)
-		prot = (int)get_tv_number_chk(&argvars[2], NULL);
-	    if (prot != -1 && STRCMP(get_tv_string(&argvars[1]), "p") == 0)
-		mkdir_recurse(dir, prot);
+	    prot = (int)get_tv_number_chk(&argvars[2], NULL);
+	    if (prot == -1)
+		return;
 	}
-	rettv->vval.v_number = prot == -1 ? FAIL : vim_mkdir_emsg(dir, prot);
+	if (STRCMP(get_tv_string(&argvars[1]), "p") == 0)
+	{
+	    if (mch_isdir(dir))
+	    {
+		rettv->vval.v_number = OK;
+		return;
+	    }
+	    mkdir_recurse(dir, prot);
+	}
     }
+    rettv->vval.v_number = vim_mkdir_emsg(dir, prot);
 }
 #endif
 

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -26,12 +26,19 @@ func Test_nocatch_restore_silent_emsg()
   call assert_equal('wrong', c1 . c2 . c3 . c4 . c5)
 endfunc
 
-func Test_mkdir_p_does_not_error()
-  call mkdir('Xdir')
+func Test_mkdir_p()
+  call mkdir('Xdir/nested', 'p')
+  call assert_true(isdirectory('Xdir/nested'))
   try
+    " Trying to make existing directories doesn't error
     call mkdir('Xdir', 'p')
+    call mkdir('Xdir/nested', 'p')
   catch /E739:/
     call assert_report('mkdir(..., "p") failed for an existing directory')
   endtry
-  call delete('Xdir', 'd')
+  " 'p' doesn't suppress real errors
+  call writefile([], 'Xfile')
+  call assert_fails('call mkdir("Xfile", "p")', 'E739')
+  call delete('Xfile')
+  call delete('Xdir', 'rf')
 endfunc

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -25,3 +25,13 @@ func Test_nocatch_restore_silent_emsg()
   let c5 = nr2char(screenchar(&lines, 5))
   call assert_equal('wrong', c1 . c2 . c3 . c4 . c5)
 endfunc
+
+func Test_mkdir_p_does_not_error()
+  call mkdir('Xdir')
+  try
+    call mkdir('Xdir', 'p')
+  catch /E739:/
+    call assert_report('mkdir(..., "p") failed for an existing directory')
+  endtry
+  call delete('Xdir', 'd')
+endfunc


### PR DESCRIPTION
mkdir(.., 'p') is supposed to be silent about failures for existing
directories.  However, the current code calls mkdir_recurse() and then
falls through to calling vim_mkdir_emsg(), thus emitting an error (and
doing extra work).