### PR TITLE
Fix unclosed parenthesis indent settings.

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -413,11 +413,10 @@ The examples below assume a 'shiftwidth' of 4.
 <
 							*cino-(*
 	(N    When in unclosed parentheses, indent N characters from the line
-	      with the unclosed parentheses.  Add a 'shiftwidth' for every
-	      unclosed parentheses.  When N is 0 or the unclosed parentheses
-	      is the first non-white character in its line, line up with the
-	      next non-white character after the unclosed parentheses.
-	      (default 'shiftwidth' * 2).
+	      with the unclosed parentheses.  When N is 0 or the unclosed
+	      parentheses is the first non-white character in its line, line
+	      up with the next non-white character after the unclosed
+	      parentheses.  (default 'shiftwidth' * 2).
 
 		cino=			  cino=(0 >
 		  if (c1 && (c2 ||	    if (c1 && (c2 ||
@@ -428,7 +427,8 @@ The examples below assume a 'shiftwidth' of 4.
 		     {			       {
 <
 							*cino-u*
-	uN    Same as (N, but for one level deeper.  (default 'shiftwidth').
+	uN    Same as (N, but for nested parenthesies beyond the first.
+	      (default 'shiftwidth').
 
 		cino=			  cino=u2 >
 		  if (c123456789	    if (c123456789


### PR DESCRIPTION
Previously the documentation was very confusing because it said that it added 'shiftwidth' to every indent, this was only true by the default setting of the uN option.