### PR TITLE
fixes #2779, fail silently if b:did_indent not set

### DIFF
--- a/runtime/indent/rnoweb.vim
+++ b/runtime/indent/rnoweb.vim
@@ -21,7 +21,7 @@ else
   let s:TeXIndent = function(substitute(&indentexpr, "()", "", ""))
 endif
 
-unlet b:did_indent
+unlet! b:did_indent
 runtime indent/r.vim
 let s:RIndent = function(substitute(&indentexpr, "()", "", ""))
 let b:did_indent = 1


### PR DESCRIPTION
Instead of throwing an error, removing `b:did_indent` is removed silently if it doesn't exist. This is consistent with the usage in other file types, such as eruby.vim