### PR TITLE
Fixed crash with command :call ch_log("%s%s")

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1993,7 +1993,7 @@ f_ch_log(typval_T *argvars, typval_T *rettv UNUSED)
     if (argvars[1].v_type != VAR_UNKNOWN)
 	channel = get_channel_arg(&argvars[1], FALSE, FALSE, 0);
 
-    ch_log(channel, (char *)msg);
+    ch_log(channel, "%s", (char *)msg);
 }
 
 /*
@@ -12927,7 +12927,7 @@ get_callback(typval_T *arg, partial_T **pp)
 }
 
 /*
- * Unref/free "callback" and "partial" retured by get_callback().
+ * Unref/free "callback" and "partial" returned by get_callback().
  */
     void
 free_callback(char_u *callback, partial_T *partial)


### PR DESCRIPTION
This PR fixes a crash in latest vim-8.0.1663 and older when doing:
```
$ vim -c 'call ch_logfile("ch.log")' -c 'call ch_log("%s%s")'
Vim: Caught deadly signal SEGV
Vim: Finished.
Segmentation fault (core dumped)
```
The argument of vim function ch_log() is meant to be a string, but
it was treated as a format when calling ch_log(channel, (char *)msg)
which is insecure and can cause crashes the argument contains %s.