### PR TITLE
also check CPPFLAGS for -D_FORTIFY_SOURCE=2

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4359,6 +4359,7 @@ if test "$GCC" = yes; then
   AC_MSG_CHECKING(whether we need -D_FORTIFY_SOURCE=1)
   if test "$gccmajor" -gt "3"; then
     CFLAGS=`echo "$CFLAGS" | sed -e 's/ *-Wp,-D_FORTIFY_SOURCE=.//g' -e 's/ *-D_FORTIFY_SOURCE=.//g' -e 's/ *-U_FORTIFY_SOURCE//g' -e 's/$/ -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1/'`
+    CPPFLAGS=`echo "$CPPFLAGS" | sed -e 's/ *-Wp,-D_FORTIFY_SOURCE=.//g' -e 's/ *-D_FORTIFY_SOURCE=.//g' -e 's/ *-U_FORTIFY_SOURCE//g'`
     AC_MSG_RESULT(yes)
   else
     AC_MSG_RESULT(no)


### PR DESCRIPTION
`-D_FORTIFY_SOURCE=2` can be present in CPPFLAGS as well as CFLAGS so
filter CPPFLAGS like CFLAGS are filtered to avoid breaking vim.