### PR TITLE
Set backupskip default for macOS

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1087,7 +1087,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	Use 'backupdir' to put the backup in a different directory.
 
 						*'backupskip'* *'bsk'*
-'backupskip' 'bsk'	string	(default: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*")
+'backupskip' 'bsk'	string	(default: "$TMPDIR/*,$TMP/*,$TEMP/*",
+				 Unix: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*",
+				 Mac OS X:
+				 "/private/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*")
 			global
 			{not in Vi}
 			{not available when compiled without the |+wildignore|

--- a/src/option.c
+++ b/src/option.c
@@ -3367,7 +3367,11 @@ set_init_1(int clean_arg)
 	    mustfree = FALSE;
 # ifdef UNIX
 	    if (*names[n] == NUL)
+#  ifdef MACOS_X
+		p = (char_u *)"/private/tmp";
+#  else
 		p = (char_u *)"/tmp";
+#  endif
 	    else
 # endif
 		p = vim_getenv((char_u *)names[n], &mustfree);


### PR DESCRIPTION
On macOS, /tmp is actually a symlink to /private/tmp. This change is necessary to ensure that 'crontab -e' works as expected.

Note that this is only a problem when building your own vim. For /usr/bin/vim, an autocommand in /usr/share/vim/vimrc sets 'nobackup' for `/private/tmp/crontab.*`, but of course this will not be loaded when installing to a different prefix.