### PR TITLE
Fix: packadd doesn't work when a new path partly matches with 'runtimepath'

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -3821,10 +3821,29 @@ static int APP_BOTH;
     static void
 add_pack_plugin(char_u *fname, void *cookie)
 {
-    if (cookie != &APP_LOAD && strstr((char *)p_rtp, (char *)fname) == NULL)
-	/* directory is not yet in 'runtimepath', add it */
-	if (add_pack_dir_to_rtp(fname) == FAIL)
-	    return;
+    if (cookie != &APP_LOAD)
+    {
+	char_u *p = p_rtp;
+	size_t l = STRLEN(fname);
+
+	while (p != NULL)
+	{
+	    p = (char_u *)strstr((char *)p, (char *)fname);
+	    if (p != NULL)
+	    {
+		if ((p == p_rtp || p[-1] == ',')
+					      && (p[l] == NUL || p[l] == ','))
+		    break;
+		p = vim_strchr(p + l, ',');
+	    }
+	}
+	if (p == NULL)
+	{
+	    /* directory is not yet in 'runtimepath', add it */
+	    if (add_pack_dir_to_rtp(fname) == FAIL)
+		return;
+	}
+    }
 
     if (cookie != &APP_ADD_DIR)
 	load_pack_plugin(fname);

--- a/src/testdir/test_packadd.vim
+++ b/src/testdir/test_packadd.vim
@@ -40,6 +40,15 @@ func Test_packadd()
   call assert_match('/testdir/Xdir/pack/mine/opt/mytest\($\|,\)', &rtp)
   call assert_match('/testdir/Xdir/pack/mine/opt/mytest/after$', &rtp)
 
+  " NOTE: '/.../opt/myte' forwardly matches with '/.../opt/mytest'
+  call mkdir(fnamemodify(s:plugdir, ':h') . '/myte', 'p')
+  let rtp = &rtp
+  packadd myte
+
+  " Check the path of 'myte' is added
+  call assert_true(len(&rtp) > len(rtp))
+  call assert_match('/testdir/Xdir/pack/mine/opt/myte\($\|,\)', &rtp)
+
   " Check exception
   call assert_fails("packadd directorynotfound", 'E919:')
   call assert_fails("packadd", 'E471:')


### PR DESCRIPTION
Reported by @fw

## Repro steps

Create /opt packages `fo` and `foo`:

```
mkdir -p ~/.vim/pack/test/opt/fo
mkdir -p ~/.vim/pack/test/opt/foo
```

Start Vim and do `packadd`:

`vim --clean`

```vim
:packadd foo
:packadd fo
```

Expected:
Both `~/.vim/pack/test/opt/foo` and `~/.vim/pack/test/opt/foo` are added to runtimepath

Actual:
`~/.vim/pack/test/opt/foo` is added to runtimepath but `~/.vim/pack/test/opt/fo` is not

## Cause and Solution

https://github.com/vim/vim/blob/master/src/ex_cmds2.c#L3824

It checkes a new path is in runtimepath using `strstr()`, but should check also the edge of the result of `strstr()`.

Ozaki Kiichi