### PR TITLE
Skip Test_writefile_sync_dev_stdout if /dev/stdout isn't writable

### DIFF
--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -106,5 +106,9 @@ func Test_writefile_sync_dev_stdout()
     return
   endif
   " Just check that this doesn't cause an error.
-  call writefile(['one'], '/dev/stdout')
+  if filewritable('/dev/stdout')
+    call writefile(['one'], '/dev/stdout')
+  else
+    throw 'Skipped: /dev/stdout is not writable'
+  endif
 endfunc


### PR DESCRIPTION
Although it's not common for /dev/stdout to not be available, it has
been seen in a few build/test environments.