### PR TITLE
Add lgtm.yml file to prevent lgtm.com parsing tutor.es as ECMAScript

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  documentation:
+    - runtime/tutor

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,3 @@
 path_classifiers:
   documentation:
-    - runtime/tutor
+    - runtime/tutor/tutor*


### PR DESCRIPTION
I just noticed that lgtm.com tries to parse tutor.es as ECMAScript: https://lgtm.com/projects/g/vim/vim/alerts. This hint should stop it from doing that.

The behaviour of lgtm.com can be tweaked using this `lgtm.yml` file. More info here: https://lgtm.com/help/lgtm/lgtm.yml-configuration-file

(full disclosure: I'm part of the team that built lgtm.com)