### PR TITLE
Use utf-8 encoding for child Vim in Test_terminal_dumpwrite_composing

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1025,7 +1025,7 @@ func Test_terminal_dumpwrite_composing()
 
   let text = " a\u0300 e\u0302 o\u0308"
   call writefile([text], 'Xcomposing')
-  let buf = RunVimInTerminal('Xcomposing', {})
+  let buf = RunVimInTerminal('--cmd "set encoding=utf-8" Xcomposing', {})
   call WaitFor({-> term_getline(buf, 1) =~ text})
   call term_dumpwrite(buf, 'Xdump')
   let dumpline = readfile('Xdump')[0]


### PR DESCRIPTION
The test is relying on the child Vim process to display the composed
characters a certain way in order to test term_dumpwrite().  However, if
the tests aren't running in a locale that defaults the child Vim's
'encoding' to utf-8, then the text will look different than expected
(e.g.  `a~@ e~B o~H`).

Forcing the child Vim to use encoding=utf-8, just like the main Vim is
doing, fixes the issue.