### PR TITLE
Fixed bug found thanks to gcc-8 compilation warning

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2040,7 +2040,9 @@ cmdline_changed:
 	    /* Disable 'hlsearch' highlighting if the pattern matches
 	     * everything. Avoids a flash when typing "foo\|". */
 	    if (empty_pattern(ccline.cmdbuff))
+	    {
 		SET_NO_HLSEARCH(TRUE);
+	    }
 
 	    validate_cursor();
 	    /* May redraw the status line to show the cursor position. */


### PR DESCRIPTION
This PR fixes a bug found thanks to a new warning in gcc-8 which says:
```
In file included from ex_getln.c:14:
ex_getln.c: In function 'getcmdline':
vim.h:2462:32: warning: macro expands to multiple statements [-Wmultistatement-macros]
 # define SET_NO_HLSEARCH(flag) no_hlsearch = (flag); set_vim_var_nr(VV_HLSEARCH, !no_hlsearch && p_hls)
                                ^~~~~~~~~~~
ex_getln.c:2043:3: note: in expansion of macro 'SET_NO_HLSEARCH'
   SET_NO_HLSEARCH(TRUE);
   ^~~~~~~~~~~~~~~
ex_getln.c:2042:6: note: some parts of macro expansion are not guarded by this 'if' clause
      if (empty_pattern(ccline.cmdbuff))
      ^~
```

This code in ex_getline.c...
```
2040  /* Disable 'hlsearch' highlighting if the pattern matches
2041   * everything. Avoids a flash when typing "foo\|". */
2042  if (empty_pattern(ccline.cmdbuff))
2043      SET_NO_HLSEARCH(TRUE);
```
... is equivalent to this after macro expansion:
```
      /* Disable 'hlsearch' highlighting if the pattern matches
       * everything. Avoids a flash when typing "foo\|". */
      if (empty_pattern(ccline.cmdbuff))
        no_hlsearch = (TRUE);
      set_vim_var_nr(VV_HLSEARCH, !no_hlsearch && p_hls);
```
... which is most certainly wrong. Intended was:
```
      /* Disable 'hlsearch' highlighting if the pattern matches
       * everything. Avoids a flash when typing "foo\|". */
      if (empty_pattern(ccline.cmdbuff))
      {
        no_hlsearch = (TRUE);
        set_vim_var_nr(VV_HLSEARCH, !no_hlsearch && p_hls);
      }
```