### PR TITLE
Simplify filenames when displalying filenames in the quickfix window

### DIFF
--- a/src/proto/fileio.pro
+++ b/src/proto/fileio.pro
@@ -11,6 +11,7 @@ void msg_add_fname(buf_T *buf, char_u *fname);
 void msg_add_lines(int insert_space, long lnum, off_T nchars);
 char_u *shorten_fname1(char_u *full_path);
 char_u *shorten_fname(char_u *full_path, char_u *dir_name);
+void shorten_buf_fname(buf_T *buf, char_u *dirname, int force);
 void shorten_fnames(int force);
 void shorten_filenames(char_u **fnames, int count);
 char_u *modname(char_u *fname, char_u *ext, int prepend_dot);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2736,6 +2736,9 @@ qf_list(exarg_T *eap)
 	    idx2 = (-idx2 > i) ? 0 : idx2 + i + 1;
     }
 
+    /* Shorten all the file names, so that it is easy to read */
+    shorten_fnames(FALSE);
+
     /*
      * Get the attributes for the different quickfix highlight items.  Note
      * that this depends on syntax items defined in the qf.vim syntax file
@@ -3562,7 +3565,16 @@ qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
 		if (qfp->qf_type == 1)	/* :helpgrep */
 		    STRCPY(IObuff, gettail(errbuf->b_fname));
 		else
+		{
+		    if (errbuf->b_sfname == NULL ||
+			    mch_isFullName(errbuf->b_sfname))
+		    {
+			char_u	dirname[MAXPATHL];
+			mch_dirname(dirname, MAXPATHL);
+			shorten_buf_fname(errbuf, dirname, FALSE);
+		    }
 		    STRCPY(IObuff, errbuf->b_fname);
+		}
 		len = (int)STRLEN(IObuff);
 	    }
 	    else

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -3201,3 +3201,27 @@ func Test_lhelpgrep_autocmd()
   au! QuickFixCmdPost
   new | only
 endfunc
+
+" Test for shortening/simplifying the file name when opening the
+" quickfix window or when displaying the quickfix list
+func Test_shorten_fname()
+  if !has('unix')
+    return
+  endif
+  %bwipe
+  " Create a quickfix list with a absolute path filename
+  let fname = getcwd() . '/test_quickfix.vim'
+  call setqflist([], ' ', {'lines':[fname . ":20:Line20"], 'efm':'%f:%l:%m'})
+  call assert_equal(fname, bufname('test_quickfix.vim'))
+  " Opening the quickfix window should simplify the file path
+  cwindow
+  call assert_equal('test_quickfix.vim', bufname('test_quickfix.vim'))
+  cclose
+  %bwipe
+  " Create a quickfix list with a absolute path filename
+  call setqflist([], ' ', {'lines':[fname . ":20:Line20"], 'efm':'%f:%l:%m'})
+  call assert_equal(fname, bufname('test_quickfix.vim'))
+  " Displaying the quickfix list should simplify the file path
+  silent! clist
+  call assert_equal('test_quickfix.vim', bufname('test_quickfix.vim'))
+endfunc


### PR DESCRIPTION
When a file with absolute path is added to a quickfix window, the file
name is not simplified. This results in a condition where some filenames
in the quickfix window are simplified and some are not. This typically
happens when a plugin asynchronously adds file names to the quickfix
list.

Fixes issue #2846.
