### PR TITLE
Update the C# syntax file

### DIFF
--- a/runtime/syntax/cs.vim
+++ b/runtime/syntax/cs.vim
@@ -2,7 +2,7 @@
 " Language:	C#
 " Maintainer:	Anduin Withers <awithers@anduin.com>
 " Former Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	Fri Aug 14 13:56:37 PDT 2009
+" Last Change:	2018 Apr 30
 " Filenames:	*.cs
 " $Id: cs.vim,v 1.4 2006/05/03 21:20:02 vimboss Exp $
 "
@@ -18,9 +18,9 @@ set cpo&vim
 
 
 " type
-syn keyword csType			bool byte char decimal double float int long object sbyte short string uint ulong ushort void
+syn keyword csType			bool byte char decimal double float int long object sbyte short string T uint ulong ushort var void dynamic
 " storage
-syn keyword csStorage			class delegate enum interface namespace struct
+syn keyword csStorage			delegate enum interface namespace struct
 " repeat / condition / label
 syn keyword csRepeat			break continue do for foreach goto return while
 syn keyword csConditional		else if switch
@@ -34,15 +34,18 @@ syn keyword csModifier			abstract const extern internal override private protect
 " constant
 syn keyword csConstant			false null true
 " exception
-syn keyword csException			try catch finally throw
+syn keyword csException			try catch finally throw when
 
 " TODO:
-syn keyword csUnspecifiedStatement	as base checked event fixed in is lock new operator out params ref sizeof stackalloc this typeof unchecked unsafe using
+syn keyword csUnspecifiedStatement	as base checked event fixed get in is lock nameof operator out params ref set sizeof stackalloc this typeof unchecked unsafe using
+
+syn keyword csLinqKeyword               ascending by descending equals from group in into join let on orderby select where
 " TODO:
 syn keyword csUnsupportedStatement	add remove value
 " TODO:
 syn keyword csUnspecifiedKeyword	explicit implicit
 
+syn keyword csAsyncKeyword		async await
 
 " Contextual Keywords
 syn match csContextualStatement	/\<yield[[:space:]\n]\+\(return\|break\)/me=s+5
@@ -56,7 +59,7 @@ syn match csContextualStatement	/\<where\>[^:]\+:/me=s+5
 "
 " TODO: include strings ?
 "
-syn keyword csTodo		contained TODO FIXME XXX NOTE
+syn keyword csTodo		contained TODO FIXME XXX NOTE HACK
 syn region  csComment		start="/\*"  end="\*/" contains=@csCommentHook,csTodo,@Spell
 syn match   csComment		"//.*$" contains=@csCommentHook,csTodo,@Spell
 
@@ -89,8 +92,15 @@ syn region	csPreCondit
     \ skip="\\$" end="$" contains=csComment keepend
 syn region	csRegion matchgroup=csPreCondit start="^\s*#\s*region.*$"
     \ end="^\s*#\s*endregion" transparent fold contains=TOP
+syn region	csSummary start="^\s*/// <summary" end="^\(\s*///\)\@!" transparent fold keepend
 
 
+syn region	csClassType start="\(@\)\@<!class\>"hs=s+6 end="[:\n{]"he=e-1 contains=csClass
+syn region	csNewType start="\(@\)\@<!new\>"hs=s+4 end="[\(\<{\[]"he=e-1 contains=csNew contains=csNewType
+syn region	csIsType start="\v (is|as) "hs=s+4 end="\v[A-Za-z0-9]+" oneline contains=csIsAs
+syn keyword	csNew new contained
+syn keyword	csClass class contained
+syn keyword	csIsAs is as
 
 " Strings and constants
 syn match   csSpecialError	contained "\\."
@@ -113,7 +123,11 @@ syn match   csNumber		"\<\d\+\([eE][-+]\=\d\+\)\=[fFdD]\>"
 
 " The default highlighting.
 hi def link csType			Type
+hi def link csNewType			Type
+hi def link csClassType			Type
+hi def link csIsType			Type
 hi def link csStorage			StorageClass
+hi def link csClass			StorageClass
 hi def link csRepeat			Repeat
 hi def link csConditional		Conditional
 hi def link csLabel			Label
@@ -121,10 +135,15 @@ hi def link csModifier			StorageClass
 hi def link csConstant			Constant
 hi def link csException			Exception
 hi def link csUnspecifiedStatement	Statement
+hi def link csNew			Statement
+hi def link csLinqWords			Statement
 hi def link csUnsupportedStatement	Statement
 hi def link csUnspecifiedKeyword	Keyword
+hi def link csIsAs 			Keyword
+hi def link csAsyncKeyword              Keyword
 hi def link csContextualStatement	Statement
 hi def link csOperatorError		Error
+hi def link csInterfaceDeclaration      Include
 
 hi def link csTodo			Todo
 hi def link csComment			Comment

--- a/runtime/syntax/cs.vim
+++ b/runtime/syntax/cs.vim
@@ -1,10 +1,11 @@
 " Vim syntax file
-" Language:	C#
-" Maintainer:	Anduin Withers <awithers@anduin.com>
-" Former Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	2018 Apr 30
-" Filenames:	*.cs
-" $Id: cs.vim,v 1.4 2006/05/03 21:20:02 vimboss Exp $
+" Language:		C#
+" Maintainer:		Nick Jensen <nickspoon@gmail.com>
+" Former Maintainer:	Anduin Withers <awithers@anduin.com>
+" Last Change:		2018-05-02
+" Filenames:		*.cs
+" License:		Vim (see :h license)
+" Repository:		https://github.com/nickspoons/vim-cs
 "
 " REFERENCES:
 " [1] ECMA TC39: C# Language Specification (WD13Oct01.doc)
@@ -17,11 +18,8 @@ let s:cs_cpo_save = &cpo
 set cpo&vim
 
 
-" type
 syn keyword csType			bool byte char decimal double float int long object sbyte short string T uint ulong ushort var void dynamic
-" storage
 syn keyword csStorage			delegate enum interface namespace struct
-" repeat / condition / label
 syn keyword csRepeat			break continue do for foreach goto return while
 syn keyword csConditional		else if switch
 syn keyword csLabel			case default
@@ -29,23 +27,15 @@ syn keyword csLabel			case default
 syn match csOperatorError		display +::+
 " user labels (see [1] 8.6 Statements)
 syn match   csLabel			display +^\s*\I\i*\s*:\([^:]\)\@=+
-" modifier
 syn keyword csModifier			abstract const extern internal override private protected public readonly sealed static virtual volatile
-" constant
 syn keyword csConstant			false null true
-" exception
 syn keyword csException			try catch finally throw when
+syn keyword csLinq			ascending by descending equals from group in into join let on orderby select where
+syn keyword csAsync			async await
 
-" TODO:
 syn keyword csUnspecifiedStatement	as base checked event fixed get in is lock nameof operator out params ref set sizeof stackalloc this typeof unchecked unsafe using
-
-syn keyword csLinqKeyword               ascending by descending equals from group in into join let on orderby select where
-" TODO:
 syn keyword csUnsupportedStatement	add remove value
-" TODO:
 syn keyword csUnspecifiedKeyword	explicit implicit
-
-syn keyword csAsyncKeyword		async await
 
 " Contextual Keywords
 syn match csContextualStatement	/\<yield[[:space:]\n]\+\(return\|break\)/me=s+5
@@ -135,15 +125,15 @@ hi def link csModifier			StorageClass
 hi def link csConstant			Constant
 hi def link csException			Exception
 hi def link csUnspecifiedStatement	Statement
-hi def link csNew			Statement
-hi def link csLinqWords			Statement
 hi def link csUnsupportedStatement	Statement
 hi def link csUnspecifiedKeyword	Keyword
+hi def link csNew			Statement
+hi def link csLinq			Statement
 hi def link csIsAs 			Keyword
-hi def link csAsyncKeyword              Keyword
+hi def link csAsync			Keyword
 hi def link csContextualStatement	Statement
 hi def link csOperatorError		Error
-hi def link csInterfaceDeclaration      Include
+hi def link csInterfaceDeclaration	Include
 
 hi def link csTodo			Todo
 hi def link csComment			Comment


### PR DESCRIPTION
The runtime/syntax/cs.vim syntax file for C# has not been updated in over 8 years, in which time there have been many changes to the language.

The current maintainer, Anduin Withers, has not responded to my emails, and is possibly not active any more - I can't find any references to the name in the vim-dev mailing list archive.

If it is preferable, I am willing to become the maintainer for this file, in which case I'll set up a repo for it.