### PR TITLE
Extend support of `:filter`

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -565,7 +565,18 @@ N  *+X11*		Unix only: can restore window title |X11|
 			The pattern is matched against the relevant part of
 			the output, not necessarily the whole line. Only some
 			commands support filtering, try it out to check if it
-			works.
+			works. Some of the commands that support filtering:
+                          |:#|          - filter whole line
+                          |:command|    - filter by command name
+                          |:files|      - filter by file name
+                          |:highlight|  - filter by highlight group
+                          |:jumps|      - filter by file name
+                          |:let|        - filter by variable name
+                          |:list|       - filter whole line
+                          |:llist|      - filter by file name or module name
+                          |:oldfiles|   - filter by file name
+                          |:clist|      - filter by file name or module name
+                          |:set|        - filter by variable name
 
 			Only normal messages are filtered, error messages are
 			not.

--- a/src/eval.c
+++ b/src/eval.c
@@ -1425,6 +1425,7 @@ list_hashtable_vars(
     hashitem_T	*hi;
     dictitem_T	*di;
     int		todo;
+    char_u	buf[IOSIZE];
 
     todo = (int)ht->ht_used;
     for (hi = ht->ht_array; todo > 0 && !got_int; ++hi)
@@ -1433,6 +1434,13 @@ list_hashtable_vars(
 	{
 	    --todo;
 	    di = HI2DI(hi);
+
+	    /* apply :filter /pat/ to variable name */
+	    vim_strncpy((char_u *) buf, prefix, IOSIZE - 1);
+	    vim_strcat((char_u *) buf, di->di_key, IOSIZE);
+	    if (message_filtered(buf))
+		continue;
+
 	    if (empty || di->di_tv.v_type != VAR_STRING
 					   || di->di_tv.vval.v_string != NULL)
 		list_one_var(di, prefix, first);

--- a/src/mark.c
+++ b/src/mark.c
@@ -901,7 +901,9 @@ ex_jumps(exarg_T *eap UNUSED)
 	if (curwin->w_jumplist[i].fmark.mark.lnum != 0)
 	{
 	    name = fm_getname(&curwin->w_jumplist[i].fmark, 16);
-	    if (name == NULL)	    /* file name not available */
+
+	    /* apply :filter /pat/ or file name not available */
+	    if (name == NULL || message_filtered(name))
 		continue;
 
 	    msg_putchar('\n');

--- a/src/option.c
+++ b/src/option.c
@@ -10083,6 +10083,10 @@ showoptions(
 	item_count = 0;
 	for (p = &options[0]; p->fullname != NULL; p++)
 	{
+	    /* apply :filter /pat/ */
+	    if (message_filtered((char_u *) p->fullname))
+		continue;
+
 	    varp = NULL;
 	    isterm = istermoption(p);
 	    if (opt_flags != 0)

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -9189,7 +9189,11 @@ highlight_list_one(int id)
     struct hl_group	*sgp;
     int			didh = FALSE;
 
+    /* msg_puts(sgp->sg_name); */
     sgp = &HL_TABLE()[id - 1];	    /* index is ID minus one */
+
+    if (message_filtered(sgp->sg_name))
+	return;
 
     didh = highlight_list_arg(id, didh, LIST_ATTR,
 				    sgp->sg_term, NULL, "term");

--- a/src/testdir/test_filter_cmd.vim
+++ b/src/testdir/test_filter_cmd.vim
@@ -87,3 +87,58 @@ func Test_filter_cmd_with_filter()
   call assert_equal('a|b', out)
   set shelltemp&
 endfunction
+
+func Test_filter_commands()
+  let g:test_filter_a = 1
+  let b:test_filter_b = 2
+  let test_filter_c = 3
+
+  " Test filtering :let command
+  let redi = ""
+  redi => redi
+  filter /^test_filter/ let
+  redi END
+  let res = split(redi, "\n")
+  call assert_equal(["test_filter_a         #1"], res)
+
+  redi => redi
+  filter /^\(b:\|\)test_filter/ let
+  redi END
+  let res = split(redi, "\n")
+  call assert_equal(["test_filter_a         #1", "b:test_filter_b       #2"], res)
+
+  unlet g:test_filter_a
+  unlet b:test_filter_b
+  unlet test_filter_c
+
+  " Test filtering :set command
+  redi => redi
+  filter /^help/ set
+  redi END
+  let res = split(redi, "\n")[1:]
+  call assert_equal(["  helplang=en"], res)
+
+  " Test filtering :llist command
+  call setloclist(0, [{"filename": "/path/vim.c"}, {"filename": "/path/vim.h"}, {"module": "Main.Test"}])
+  redi => redi
+  filter /\.c$/ llist
+  redi END
+  let res = split(redi, "\n")
+  call assert_equal([" 1 /path/vim.c:  "], res)
+
+  redi => redi
+  filter /\.Test$/ llist
+  redi END
+  let res = split(redi, "\n")
+  call assert_equal([" 3 Main.Test:  "], res)
+
+  " Test filtering :jump command
+  e file.c
+  e file.h
+  e file.hs
+  redi => redi
+  filter /\.c$/ jumps
+  redi END
+  let res = split(redi, "\n")[1:]
+  call assert_equal(["   2     1    0 file.c", ">"], res)
+endfunc

--- a/src/testdir/test_filter_cmd.vim
+++ b/src/testdir/test_filter_cmd.vim
@@ -94,10 +94,10 @@ func Test_filter_commands()
   let test_filter_c = 3
 
   " Test filtering :let command
-  let res = split(execute("filter /^test_filter/ let"), "\n))
+  let res = split(execute("filter /^test_filter/ let"), "\n")
   call assert_equal(["test_filter_a         #1"], res)
 
-  let res = split(execute("filter /^\(b:\|\)test_filter/ let"), "\n")
+  let res = split(execute("filter /\\v^(b:)?test_filter/ let"), "\n")
   call assert_equal(["test_filter_a         #1", "b:test_filter_b       #2"], res)
 
   unlet g:test_filter_a
@@ -105,15 +105,15 @@ func Test_filter_commands()
   unlet test_filter_c
 
   " Test filtering :set command
-  let res = split(execute("filter /^help/ set"), "\n")[1:]
-  call assert_equal(["  helplang=en"], res)
+  let res = join(split(execute("filter /^help/ set"), "\n")[1:], " ")
+  call assert_match('^\s*helplang=\w*$', res)
 
   " Test filtering :llist command
   call setloclist(0, [{"filename": "/path/vim.c"}, {"filename": "/path/vim.h"}, {"module": "Main.Test"}])
-  let res = split(execute("filter /\.c$/ llist"), "\n")
+  let res = split(execute("filter /\\.c$/ llist"), "\n")
   call assert_equal([" 1 /path/vim.c:  "], res)
 
-  let res = split(execute("filter /\.Test$/ llist"), "\n")
+  let res = split(execute("filter /\\.Test$/ llist"), "\n")
   call assert_equal([" 3 Main.Test:  "], res)
 
   " Test filtering :jump command

--- a/src/testdir/test_filter_cmd.vim
+++ b/src/testdir/test_filter_cmd.vim
@@ -94,17 +94,10 @@ func Test_filter_commands()
   let test_filter_c = 3
 
   " Test filtering :let command
-  let redi = ""
-  redi => redi
-  filter /^test_filter/ let
-  redi END
-  let res = split(redi, "\n")
+  let res = split(execute("filter /^test_filter/ let"), "\n))
   call assert_equal(["test_filter_a         #1"], res)
 
-  redi => redi
-  filter /^\(b:\|\)test_filter/ let
-  redi END
-  let res = split(redi, "\n")
+  let res = split(execute("filter /^\(b:\|\)test_filter/ let"), "\n")
   call assert_equal(["test_filter_a         #1", "b:test_filter_b       #2"], res)
 
   unlet g:test_filter_a
@@ -112,33 +105,21 @@ func Test_filter_commands()
   unlet test_filter_c
 
   " Test filtering :set command
-  redi => redi
-  filter /^help/ set
-  redi END
-  let res = split(redi, "\n")[1:]
+  let res = split(execute("filter /^help/ set"), "\n")[1:]
   call assert_equal(["  helplang=en"], res)
 
   " Test filtering :llist command
   call setloclist(0, [{"filename": "/path/vim.c"}, {"filename": "/path/vim.h"}, {"module": "Main.Test"}])
-  redi => redi
-  filter /\.c$/ llist
-  redi END
-  let res = split(redi, "\n")
+  let res = split(execute("filter /\.c$/ llist"), "\n")
   call assert_equal([" 1 /path/vim.c:  "], res)
 
-  redi => redi
-  filter /\.Test$/ llist
-  redi END
-  let res = split(redi, "\n")
+  let res = split(execute("filter /\.Test$/ llist"), "\n")
   call assert_equal([" 3 Main.Test:  "], res)
 
   " Test filtering :jump command
   e file.c
   e file.h
   e file.hs
-  redi => redi
-  filter /\.c$/ jumps
-  redi END
-  let res = split(redi, "\n")[1:]
+  let res = split(execute("filter /\.c$/ jumps"), "\n")[1:]
   call assert_equal(["   2     1    0 file.c", ">"], res)
 endfunc

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -1853,6 +1853,8 @@ ex_function(exarg_T *eap)
 		{
 		    --todo;
 		    fp = HI2UF(hi);
+		    if (message_filtered(fp->uf_name))
+			continue;
 		    if (!func_name_refcount(fp->uf_name))
 			list_func_head(fp, FALSE);
 		}


### PR DESCRIPTION
It lets one filter output of a few more commands:
* `:function`
* `:command`
* `:let`
* `:mark`
* `:jumps`
* ~`:clist` and `llist` (only by file name or module name.~

Includes tests.

This extends the closed PR: #2327.