### PR TITLE
WIP: Filter found ctags by the type/kind

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -4449,7 +4449,7 @@ ins_compl_get_exp(pos_T *ini)
 	    if (find_tags(compl_pattern, &num_matches, &matches,
 		    TAG_REGEXP | TAG_NAMES | TAG_NOIC | TAG_INS_COMP
 		    | (ctrl_x_mode != CTRL_X_NORMAL ? TAG_VERBOSE : 0),
-		    TAG_MANY, curbuf->b_ffname) == OK && num_matches > 0)
+		    TAG_MANY, curbuf->b_ffname, '\0') == OK && num_matches > 0)
 	    {
 		ins_compl_add_matches(num_matches, matches, p_ic);
 	    }

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -6689,7 +6689,7 @@ find_help_tags(
     flags = TAG_HELP | TAG_REGEXP | TAG_NAMES | TAG_VERBOSE;
     if (keep_lang)
 	flags |= TAG_KEEP_LANG;
-    if (find_tags(IObuff, num_matches, matches, flags, (int)MAXCOL, NULL) == OK
+    if (find_tags(IObuff, num_matches, matches, flags, (int)MAXCOL, NULL, '\0') == OK
 	    && *num_matches > 0)
     {
 	/* Sort the matches found on the heuristic number that is after the

--- a/src/proto/tag.pro
+++ b/src/proto/tag.pro
@@ -2,7 +2,7 @@
 int do_tag(char_u *tag, int type, int count, int forceit, int verbose);
 void tag_freematch(void);
 void do_tags(exarg_T *eap);
-int find_tags(char_u *pat, int *num_matches, char_u ***matchesp, int flags, int mincount, char_u *buf_ffname);
+int find_tags(char_u *pat, int *num_matches, char_u ***matchesp, int flags, int mincount, char_u *buf_ffname, int filter);
 void free_tag_stuff(void);
 int get_tagfname(tagname_T *tnp, int first, char_u *buf);
 void tagname_free(tagname_T *tnp);

--- a/src/tag.c
+++ b/src/tag.c
@@ -137,6 +137,8 @@ do_tag(
     int		save_pos = FALSE;
     fmark_T	saved_fmark;
     int		taglen;
+    int		filter = 0;
+    int		filter_input = 0;
 #ifdef FEAT_CSCOPE
     int		jumped_to_tag = FALSE;
 #endif
@@ -591,181 +593,194 @@ do_tag(
 		cur_match = count > 0 ? count - 1 : 0;
 	    else if (type == DT_SELECT || (type == DT_JUMP && num_matches > 1))
 	    {
-		/*
-		 * List all the matching tags.
-		 * Assume that the first match indicates how long the tags can
-		 * be, and align the file names to that.
-		 */
-		parse_match(matches[0], &tagp);
-		taglen = (int)(tagp.tagname_end - tagp.tagname + 2);
-		if (taglen < 18)
-		    taglen = 18;
-		if (taglen > Columns - 25)
-		    taglen = MAXCOL;
-		if (msg_col == 0)
-		    msg_didout = FALSE;	/* overwrite previous message */
-		msg_start();
-		MSG_PUTS_ATTR(_("  # pri kind tag"), HL_ATTR(HLF_T));
-		msg_clr_eos();
-		taglen_advance(taglen);
-		MSG_PUTS_ATTR(_("file\n"), HL_ATTR(HLF_T));
-
-		for (i = 0; i < num_matches && !got_int; ++i)
+		do
 		{
-		    parse_match(matches[i], &tagp);
-		    if (!new_tag && (
-#if defined(FEAT_QUICKFIX)
-				(g_do_tagpreview != 0
-				 && i == ptag_entry.cur_match) ||
-#endif
-				(use_tagstack
-				 && i == tagstack[tagstackidx].cur_match)))
-			*IObuff = '>';
-		    else
-			*IObuff = ' ';
-		    vim_snprintf((char *)IObuff + 1, IOSIZE - 1,
-			    "%2d %s ", i + 1,
-					   mt_names[matches[i][0] & MT_MASK]);
-		    msg_puts(IObuff);
-		    if (tagp.tagkind != NULL)
-			msg_outtrans_len(tagp.tagkind,
-				      (int)(tagp.tagkind_end - tagp.tagkind));
-		    msg_advance(13);
-		    msg_outtrans_len_attr(tagp.tagname,
-				       (int)(tagp.tagname_end - tagp.tagname),
-							      HL_ATTR(HLF_T));
-		    msg_putchar(' ');
-		    taglen_advance(taglen);
-
-		    /* Find out the actual file name. If it is long, truncate
-		     * it and put "..." in the middle */
-		    p = tag_full_fname(&tagp);
-		    if (p != NULL)
-		    {
-			msg_puts_long_attr(p, HL_ATTR(HLF_D));
-			vim_free(p);
-		    }
-		    if (msg_col > 0)
-			msg_putchar('\n');
-		    if (got_int)
-			break;
-		    msg_advance(15);
-
-		    /* print any extra fields */
-		    command_end = tagp.command_end;
-		    if (command_end != NULL)
-		    {
-			p = command_end + 3;
-			while (*p && *p != '\r' && *p != '\n')
-			{
-			    while (*p == TAB)
-				++p;
-
-			    /* skip "file:" without a value (static tag) */
-			    if (STRNCMP(p, "file:", 5) == 0
-							 && vim_isspace(p[5]))
-			    {
-				p += 5;
-				continue;
-			    }
-			    /* skip "kind:<kind>" and "<kind>" */
-			    if (p == tagp.tagkind
-				    || (p + 5 == tagp.tagkind
-					    && STRNCMP(p, "kind:", 5) == 0))
-			    {
-				p = tagp.tagkind_end;
-				continue;
-			    }
-			    /* print all other extra fields */
-			    attr = HL_ATTR(HLF_CM);
-			    while (*p && *p != '\r' && *p != '\n')
-			    {
-				if (msg_col + ptr2cells(p) >= Columns)
-				{
-				    msg_putchar('\n');
-				    if (got_int)
-					break;
-				    msg_advance(15);
-				}
-				p = msg_outtrans_one(p, attr);
-				if (*p == TAB)
-				{
-				    msg_puts_attr((char_u *)" ", attr);
-				    break;
-				}
-				if (*p == ':')
-				    attr = 0;
-			    }
-			}
-			if (msg_col > 15)
-			{
-			    msg_putchar('\n');
-			    if (got_int)
-				break;
-			    msg_advance(15);
-			}
-		    }
+		    if (filter == filter_input)
+			filter = 0;
 		    else
 		    {
-			for (p = tagp.command;
-					  *p && *p != '\r' && *p != '\n'; ++p)
-			    ;
-			command_end = p;
+			filter = filter_input;
+			update_screen(0);
 		    }
-
 		    /*
-		     * Put the info (in several lines) at column 15.
-		     * Don't display "/^" and "?^".
+		     * List all the matching tags.
+		     * Assume that the first match indicates how long the tags can
+		     * be, and align the file names to that.
 		     */
-		    p = tagp.command;
-		    if (*p == '/' || *p == '?')
-		    {
-			++p;
-			if (*p == '^')
-			    ++p;
-		    }
-		    /* Remove leading whitespace from pattern */
-		    while (p != command_end && vim_isspace(*p))
-			++p;
+		    parse_match(matches[0], &tagp);
+		    taglen = (int)(tagp.tagname_end - tagp.tagname + 2);
+		    if (taglen < 18)
+			taglen = 18;
+		    if (taglen > Columns - 25)
+			taglen = MAXCOL;
+		    if (msg_col == 0)
+			msg_didout = FALSE;	/* overwrite previous message */
+		    msg_start();
+		    MSG_PUTS_ATTR(_("  # pri kind tag"), HL_ATTR(HLF_T));
+		    msg_clr_eos();
+		    taglen_advance(taglen);
+		    MSG_PUTS_ATTR(_("file\n"), HL_ATTR(HLF_T));
 
-		    while (p != command_end)
+		    for (i = 0; i < num_matches && !got_int; ++i)
 		    {
-			if (msg_col + (*p == TAB ? 1 : ptr2cells(p)) > Columns)
+			parse_match(matches[i], &tagp);
+			if (filter && *tagp.tagkind != filter)
+			    continue;
+
+			if (!new_tag && (
+    #if defined(FEAT_QUICKFIX)
+				    (g_do_tagpreview != 0
+				     && i == ptag_entry.cur_match) ||
+    #endif
+				    (use_tagstack
+				     && i == tagstack[tagstackidx].cur_match)))
+			    *IObuff = '>';
+			else
+			    *IObuff = ' ';
+			vim_snprintf((char *)IObuff + 1, IOSIZE - 1,
+				"%2d %s ", i + 1,
+					       mt_names[matches[i][0] & MT_MASK]);
+			msg_puts(IObuff);
+			if (tagp.tagkind != NULL)
+			    msg_outtrans_len(tagp.tagkind,
+					  (int)(tagp.tagkind_end - tagp.tagkind));
+			msg_advance(13);
+			msg_outtrans_len_attr(tagp.tagname,
+					   (int)(tagp.tagname_end - tagp.tagname),
+								  HL_ATTR(HLF_T));
+			msg_putchar(' ');
+			taglen_advance(taglen);
+
+			/* Find out the actual file name. If it is long, truncate
+			 * it and put "..." in the middle */
+			p = tag_full_fname(&tagp);
+			if (p != NULL)
+			{
+			    msg_puts_long_attr(p, HL_ATTR(HLF_D));
+			    vim_free(p);
+			}
+			if (msg_col > 0)
 			    msg_putchar('\n');
 			if (got_int)
 			    break;
 			msg_advance(15);
 
-			/* skip backslash used for escaping a command char or
-			 * a backslash */
-			if (*p == '\\' && (*(p + 1) == *tagp.command
-					|| *(p + 1) == '\\'))
-			    ++p;
-
-			if (*p == TAB)
+			/* print any extra fields */
+			command_end = tagp.command_end;
+			if (command_end != NULL)
 			{
-			    msg_putchar(' ');
-			    ++p;
+			    p = command_end + 3;
+			    while (*p && *p != '\r' && *p != '\n')
+			    {
+				while (*p == TAB)
+				    ++p;
+
+				/* skip "file:" without a value (static tag) */
+				if (STRNCMP(p, "file:", 5) == 0
+							     && vim_isspace(p[5]))
+				{
+				    p += 5;
+				    continue;
+				}
+				/* skip "kind:<kind>" and "<kind>" */
+				if (p == tagp.tagkind
+					|| (p + 5 == tagp.tagkind
+						&& STRNCMP(p, "kind:", 5) == 0))
+				{
+				    p = tagp.tagkind_end;
+				    continue;
+				}
+				/* print all other extra fields */
+				attr = HL_ATTR(HLF_CM);
+				while (*p && *p != '\r' && *p != '\n')
+				{
+				    if (msg_col + ptr2cells(p) >= Columns)
+				    {
+					msg_putchar('\n');
+					if (got_int)
+					    break;
+					msg_advance(15);
+				    }
+				    p = msg_outtrans_one(p, attr);
+				    if (*p == TAB)
+				    {
+					msg_puts_attr((char_u *)" ", attr);
+					break;
+				    }
+				    if (*p == ':')
+					attr = 0;
+				}
+			    }
+			    if (msg_col > 15)
+			    {
+				msg_putchar('\n');
+				if (got_int)
+				    break;
+				msg_advance(15);
+			    }
 			}
 			else
-			    p = msg_outtrans_one(p, 0);
+			{
+			    for (p = tagp.command;
+					      *p && *p != '\r' && *p != '\n'; ++p)
+				;
+			    command_end = p;
+			}
 
-			/* don't display the "$/;\"" and "$?;\"" */
-			if (p == command_end - 2 && *p == '$'
-						 && *(p + 1) == *tagp.command)
-			    break;
-			/* don't display matching '/' or '?' */
-			if (p == command_end - 1 && *p == *tagp.command
-						 && (*p == '/' || *p == '?'))
-			    break;
+			/*
+			 * Put the info (in several lines) at column 15.
+			 * Don't display "/^" and "?^".
+			 */
+			p = tagp.command;
+			if (*p == '/' || *p == '?')
+			{
+			    ++p;
+			    if (*p == '^')
+				++p;
+			}
+			/* Remove leading whitespace from pattern */
+			while (p != command_end && vim_isspace(*p))
+			    ++p;
+
+			while (p != command_end)
+			{
+			    if (msg_col + (*p == TAB ? 1 : ptr2cells(p)) > Columns)
+				msg_putchar('\n');
+			    if (got_int)
+				break;
+			    msg_advance(15);
+
+			    /* skip backslash used for escaping a command char or
+			     * a backslash */
+			    if (*p == '\\' && (*(p + 1) == *tagp.command
+					    || *(p + 1) == '\\'))
+				++p;
+
+			    if (*p == TAB)
+			    {
+				msg_putchar(' ');
+				++p;
+			    }
+			    else
+				p = msg_outtrans_one(p, 0);
+
+			    /* don't display the "$/;\"" and "$?;\"" */
+			    if (p == command_end - 2 && *p == '$'
+						     && *(p + 1) == *tagp.command)
+				break;
+			    /* don't display matching '/' or '?' */
+			    if (p == command_end - 1 && *p == *tagp.command
+						     && (*p == '/' || *p == '?'))
+				break;
+			}
+			if (msg_col)
+			    msg_putchar('\n');
+			ui_breakcheck();
 		    }
-		    if (msg_col)
-			msg_putchar('\n');
-		    ui_breakcheck();
-		}
-		if (got_int)
-		    got_int = FALSE;	/* only stop the listing */
-		ask_for_selection = TRUE;
+		    if (got_int)
+			got_int = FALSE;	/* only stop the listing */
+		    ask_for_selection = TRUE;
+		} while ((filter_input = plain_vgetc()) && isalnum(filter_input));
 	    }
 #if defined(FEAT_QUICKFIX) && defined(FEAT_EVAL)
 	    else if (type == DT_LTAG)


### PR DESCRIPTION
Especially when working with the linux kernel, `ctags` output often has dozens of entries and so far in `vim` there are no means to easily filter them by type (e.g. `structure name` or other types as specified in http://ctags.sourceforge.net/FORMAT). This (lack of) behavior is annoying, and targeted for improvement in the `runtime/doc/todo.txt`

Introducing a filter that will by default retain the old practice of displaying everything, but will only show a specific type of `ctags` records after a mapped letter is pressed on the keyboard.

To test the patch, do (for example):
1) Set up `ctags` as you would normally do and open a source code file
2) Put the cursor on a structure name somewhere
3) Press `g ]` or otherwise enter the mode where you see a list of tags
4) Press `s` to only see your structure's definition
*) If there are more than one screen worth of entries, you'd need to exit the `more` mode with `q` before the filter starts accepting keypresses. `more` will return upon refreshing the filter if necessary.
*) Press `s` again to clear the filter
6) Hit `Enter` to go to the entry number prompt

This patch only deals with one (my) user case so far, but I'm looking to expand it, hence the `WIP` prefix. Please help me by defining other cases here, if they are deemed necessary.

_Please make your `diff` ignore whitespaces as these commits includes many indentation changes._ 