### PR TITLE
Typos: correct 'cursur' ---> 'cursor'

### DIFF
--- a/runtime/doc/version8.txt
+++ b/runtime/doc/version8.txt
@@ -1799,7 +1799,7 @@ Solution:   Always use the stubs. (Danek Duvall, Yukihiro Nakadaira)
 Files:	    src/if_ruby.c
 
 Patch 7.4.226 (after 7.4.219)
-Problem:    Cursurline highlighting not redrawn when scrolling. (John
+Problem:    Cursorline highlighting not redrawn when scrolling. (John
 	    Marriott)
 Solution:   Check for required redraw in two places.
 Files:	    src/move.c

--- a/src/edit.c
+++ b/src/edit.c
@@ -431,7 +431,7 @@ edit(
 #ifdef FEAT_CONCEAL
     /* Check if the cursor line needs redrawing before changing State.  If
      * 'concealcursor' is "n" it needs to be redrawn without concealing. */
-    conceal_check_cursur_line();
+    conceal_check_cursor_line();
 #endif
 
 #ifdef FEAT_MOUSE

--- a/src/normal.c
+++ b/src/normal.c
@@ -7797,7 +7797,7 @@ n_start_visual_mode(int c)
 {
 #ifdef FEAT_CONCEAL
     /* Check for redraw before changing the state. */
-    conceal_check_cursur_line();
+    conceal_check_cursor_line();
 #endif
 
     VIsual_mode = c;
@@ -7824,7 +7824,7 @@ n_start_visual_mode(int c)
 #endif
 #ifdef FEAT_CONCEAL
     /* Check for redraw after changing the state. */
-    conceal_check_cursur_line();
+    conceal_check_cursor_line();
 #endif
 
     if (p_smd && msg_silent == 0)

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -2153,7 +2153,7 @@ msgid "E254: Cannot allocate color %s"
 msgstr "E254: Kann die Farbe %s nicht zuweisen."
 
 msgid "No match at cursor, finding next"
-msgstr "Kein Treffer beim Cursur, finde den nächsten"
+msgstr "Kein Treffer beim Cursor, finde den nächsten"
 
 msgid "<cannot open> "
 msgstr "<kann nicht öffnen> "

--- a/src/proto/screen.pro
+++ b/src/proto/screen.pro
@@ -12,7 +12,7 @@ void redrawWinline(linenr_T lnum, int invalid);
 void update_curbuf(int type);
 int update_screen(int type_arg);
 int conceal_cursor_line(win_T *wp);
-void conceal_check_cursur_line(void);
+void conceal_check_cursor_line(void);
 void update_single_line(win_T *wp, linenr_T lnum);
 void update_debug_sign(buf_T *buf, linenr_T lnum);
 void updateWindow(win_T *wp);

--- a/src/screen.c
+++ b/src/screen.c
@@ -906,7 +906,7 @@ conceal_cursor_line(win_T *wp)
  * Check if the cursor line needs to be redrawn because of 'concealcursor'.
  */
     void
-conceal_check_cursur_line(void)
+conceal_check_cursor_line(void)
 {
     if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin))
     {

--- a/src/ui.c
+++ b/src/ui.c
@@ -1971,7 +1971,7 @@ ui_cursor_shape_forced(int forced)
 # endif
 
 # ifdef FEAT_CONCEAL
-    conceal_check_cursur_line();
+    conceal_check_cursor_line();
 # endif
 }
 


### PR DESCRIPTION
Hi Bram,

please pull these trivial typo fixes.  They compile and don't break any exisiting tests.

Regards, Ann

The following changes since commit 39de95257714b76ccd845d081cff57830a79b488:

  patch 8.0.1806: InsertCharPre causes problems for autocomplete (2018-05-08 22:48:00 +0200)

are available in the Git repository at:

  https://github.com/bedhanger/vim.git fix-typos

for you to fetch changes up to 4604f6da2e4fdad6f59bceb9c931c35df768505d:

  Typos: correct 'cursur' ---> 'cursor' (2018-05-09 16:34:04 +0200)

----------------------------------------------------------------
Ann T Ropea (1):
      Typos: correct 'cursur' ---> 'cursor'