### PR TITLE
Migrate shebang of python scripts to python3

### DIFF
--- a/runtime/tools/demoserver.py
+++ b/runtime/tools/demoserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Server that will accept connections from a Vim channel.
 # Run this server and then in Vim you can open the channel:
@@ -14,21 +14,13 @@
 # To exit cleanly type "quit<Enter>".
 #
 # See ":help channel-demo" in Vim.
-#
-# This requires Python 2.6 or later.
 
 from __future__ import print_function
 import json
 import socket
 import sys
 import threading
-
-try:
-    # Python 3
-    import socketserver
-except ImportError:
-    # Python 2
-    import SocketServer as socketserver
+import socketserver
 
 thesocket = None
 

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -6396,7 +6396,7 @@ eof
 	    if test "x$MACOS_X" = "xyes" && test -n "${python_PYTHONFRAMEWORK}" && ${vi_cv_path_python} -c \
 		"import sys; sys.exit(${vi_cv_var_python_version} < 2.3)"; then
 	      vi_cv_path_python_plibs="-framework Python"
-	      if test "x${vi_cv_path_python}" != "x/usr/bin/python" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
+	      if test "x${vi_cv_path_python}" != "x/usr/bin/python2" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
 		  vi_cv_path_python_plibs="-F${python_PYTHONFRAMEWORKPREFIX} -framework Python"
 	      fi
 	    else

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1248,7 +1248,7 @@ eof
 	    if test "x$MACOS_X" = "xyes" && test -n "${python_PYTHONFRAMEWORK}" && ${vi_cv_path_python} -c \
 		"import sys; sys.exit(${vi_cv_var_python_version} < 2.3)"; then
 	      vi_cv_path_python_plibs="-framework Python"
-	      if test "x${vi_cv_path_python}" != "x/usr/bin/python" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
+	      if test "x${vi_cv_path_python}" != "x/usr/bin/python2" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
 		  vi_cv_path_python_plibs="-F${python_PYTHONFRAMEWORKPREFIX} -framework Python"
 	      fi
 	    else

--- a/src/testdir/test_channel.py
+++ b/src/testdir/test_channel.py
@@ -1,9 +1,7 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Server that will accept connections from a Vim channel.
 # Used by test_channel.vim.
-#
-# This requires Python 2.6 or later.
 
 from __future__ import print_function
 import json
@@ -11,13 +9,7 @@ import socket
 import sys
 import time
 import threading
-
-try:
-    # Python 3
-    import socketserver
-except ImportError:
-    # Python 2
-    import SocketServer as socketserver
+import socketserver
 
 class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 

--- a/src/testdir/test_channel_pipe.py
+++ b/src/testdir/test_channel_pipe.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Server that will communicate over stdin/stderr
-#
-# This requires Python 2.6 or later.
 
 from __future__ import print_function
 import sys

--- a/src/testdir/test_channel_write.py
+++ b/src/testdir/test_channel_write.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Program that writes a number to stdout repeatedly
-#
-# This requires Python 2.6 or later.
 
 from __future__ import print_function
 import sys

--- a/src/testdir/test_makeencoding.py
+++ b/src/testdir/test_makeencoding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # Test program for :make, :grep and :cgetfile.
@@ -23,24 +23,7 @@ def set_output_encoding(enc=None):
         kw.setdefault('errors', 'backslashreplace') # use \uXXXX style
         kw.setdefault('closefd', False)
 
-        if sys.version_info[0] < 3:
-            # Work around for Python 2.x
-            # New line conversion isn't needed here. Done in somewhere else.
-            writer = io.open(fo.fileno(), mode='w', newline='', **kw)
-            write = writer.write    # save the original write() function
-            enc = locale.getpreferredencoding()
-            def convwrite(s):
-                if isinstance(s, bytes):
-                    write(s.decode(enc))    # convert to unistr
-                else:
-                    write(s)
-                try:
-                    writer.flush()  # needed on Windows
-                except IOError:
-                    pass
-            writer.write = convwrite
-        else:
-            writer = io.open(fo.fileno(), mode='w', **kw)
+        writer = io.open(fo.fileno(), mode='w', **kw)
         return writer
 
     sys.stdout = get_text_writer(sys.stdout, encoding=enc)

--- a/src/testdir/test_netbeans.py
+++ b/src/testdir/test_netbeans.py
@@ -1,22 +1,14 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Server that will communicate with Vim through the netbeans interface.
 # Used by test_netbeans.vim.
-#
-# This requires Python 2.6 or later.
 
 from __future__ import print_function
 import socket
 import sys
 import time
 import threading
-
-try:
-    # Python 3
-    import socketserver
-except ImportError:
-    # Python 2
-    import SocketServer as socketserver
+import socketserver
 
 class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 

--- a/src/testdir/test_short_sleep.py
+++ b/src/testdir/test_short_sleep.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Program that sleeps for 100 msec
-#
-# This requires Python 2.6 or later.
 
 import time
 


### PR DESCRIPTION
According PEP 394 python scripts should have /usr/bin/python2 or /usr/bin/python3 in shebang. Usage of /usr/bin/python is tricky, because some distributions have different default python, e.g. Arch Linux has python3 as default python and the same thing is going to happen in Fedora, because python2 will become unsupported since 2020-01-01.
I rewrote shebangs to python3 (because python2 will become unsupported) and made several changes to code, which I recognized redundant after migrating to python3.
Would you mind adding it to Vim project?