### PR TITLE
Set the quickfix title correctly

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -10473,7 +10473,7 @@ set_qf_ll_list(
 	}
 
 	if (l != NULL && action && valid_dict && set_errorlist(wp, l, action,
-	    (char_u *)(wp == NULL ? "setqflist()" : "setloclist()"), d) == OK)
+	  (char_u *)(wp == NULL ? ":setqflist()" : ":setloclist()"), d) == OK)
 	    rettv->vval.v_number = 0;
     }
 #endif

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1515,7 +1515,7 @@ qf_cmdtitle(char_u *cmd)
 {
     static char_u qftitle_str[IOSIZE];
 
-    snprintf((char *)qftitle_str, IOSIZE, ":%s", (char *)cmd);
+    vim_snprintf((char *)qftitle_str, IOSIZE, ":%s", (char *)cmd);
     return qftitle_str;
 }
 

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1500,7 +1500,7 @@ qf_store_title(qf_info_T *qi, int qf_idx, char_u *title)
 
 	qi->qf_lists[qf_idx].qf_title = p;
 	if (p != NULL)
-	    sprintf((char *)p, "%s", (char *)title);
+	    STRCPY(p, title);
     }
 }
 

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1025,6 +1025,8 @@ qf_parse_get_fields(
     fields->type = 0;
     *tail = NULL;
 
+    /* Always ignore case when looking for a matching error. */
+    regmatch.rm_ic = TRUE;
     regmatch.regprog = fmt_ptr->prog;
     r = vim_regexec(&regmatch, linebuf, (colnr_T)0);
     fmt_ptr->prog = regmatch.regprog;
@@ -1498,8 +1500,23 @@ qf_store_title(qf_info_T *qi, int qf_idx, char_u *title)
 
 	qi->qf_lists[qf_idx].qf_title = p;
 	if (p != NULL)
-	    sprintf((char *)p, ":%s", (char *)title);
+	    sprintf((char *)p, "%s", (char *)title);
     }
+}
+
+/*
+ * The title of a quickfix/location list is set, by default, to the command
+ * that created the quickfix list with the ":" prefix.
+ * Create a quickfix list title string by prepending ":" to a user command.
+ * Returns a pointer to a static buffer with the title.
+ */
+    static char_u *
+qf_cmdtitle(char_u *cmd)
+{
+    static char_u qftitle_str[IOSIZE];
+
+    snprintf((char *)qftitle_str, IOSIZE, ":%s", (char *)cmd);
+    return qftitle_str;
 }
 
 /*
@@ -4020,7 +4037,7 @@ ex_make(exarg_T *eap)
 			    && eap->cmdidx != CMD_lmake) ? p_gefm : p_efm,
 					   (eap->cmdidx != CMD_grepadd
 					    && eap->cmdidx != CMD_lgrepadd),
-					   *eap->cmdlinep, enc);
+					   qf_cmdtitle(*eap->cmdlinep), enc);
     if (wp != NULL)
 	qi = GET_LOC_LIST(wp);
     if (res >= 0 && qi != NULL)
@@ -4413,7 +4430,8 @@ ex_cfile(exarg_T *eap)
      * quickfix list then a new list is created.
      */
     res = qf_init(wp, p_ef, p_efm, (eap->cmdidx != CMD_caddfile
-			&& eap->cmdidx != CMD_laddfile), *eap->cmdlinep, enc);
+			&& eap->cmdidx != CMD_laddfile),
+			qf_cmdtitle(*eap->cmdlinep), enc);
     if (wp != NULL)
 	qi = GET_LOC_LIST(wp);
     if (res >= 0 && qi != NULL)
@@ -4749,7 +4767,7 @@ ex_vimgrep(exarg_T *eap)
 
     /* Get the search pattern: either white-separated or enclosed in // */
     regmatch.regprog = NULL;
-    title = vim_strsave(*eap->cmdlinep);
+    title = vim_strsave(qf_cmdtitle(*eap->cmdlinep));
     p = skip_vimgrep_pat(eap->arg, &s, &flags);
     if (p == NULL)
     {
@@ -4773,7 +4791,7 @@ ex_vimgrep(exarg_T *eap)
 		&& eap->cmdidx != CMD_lvimgrepadd)
 					|| qi->qf_curlist == qi->qf_listcount)
 	/* make place for a new list */
-	qf_new_list(qi, title != NULL ? title : *eap->cmdlinep);
+	qf_new_list(qi, title != NULL ? title : qf_cmdtitle(*eap->cmdlinep));
 
     /* parse the list of arguments */
     if (get_arglist_exp(p, &fcount, &fnames, TRUE) == FAIL)
@@ -4828,7 +4846,7 @@ ex_vimgrep(exarg_T *eap)
 
 	/* Check whether the quickfix list is still valid. When loading a
 	 * buffer above, autocommands might have changed the quickfix list. */
-	if (!vgr_qflist_valid(wp, qi, save_qfid, *eap->cmdlinep))
+	if (!vgr_qflist_valid(wp, qi, save_qfid, qf_cmdtitle(*eap->cmdlinep)))
 	{
 	    FreeWild(fcount, fnames);
 	    goto theend;
@@ -6125,7 +6143,7 @@ ex_cbuffer(exarg_T *eap)
 	    EMSG(_(e_invrange));
 	else
 	{
-	    char_u *qf_title = *eap->cmdlinep;
+	    char_u *qf_title = qf_cmdtitle(*eap->cmdlinep);
 
 	    if (buf->b_sfname)
 	    {
@@ -6203,8 +6221,8 @@ ex_cexpr(exarg_T *eap)
 	    res = qf_init_ext(qi, qi->qf_curlist, NULL, NULL, tv, p_efm,
 			    (eap->cmdidx != CMD_caddexpr
 			     && eap->cmdidx != CMD_laddexpr),
-				 (linenr_T)0, (linenr_T)0, *eap->cmdlinep,
-				 NULL);
+				 (linenr_T)0, (linenr_T)0,
+				 qf_cmdtitle(*eap->cmdlinep), NULL);
 	    if (res >= 0)
 		qf_list_changed(qi, qi->qf_curlist);
 	    if (au_name != NULL)
@@ -6476,7 +6494,7 @@ ex_helpgrep(exarg_T *eap)
     if (regmatch.regprog != NULL)
     {
 	/* create a new quickfix list */
-	qf_new_list(qi, *eap->cmdlinep);
+	qf_new_list(qi, qf_cmdtitle(*eap->cmdlinep));
 
 	hgr_search_in_rtp(qi, &regmatch, eap->arg);
 

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -3250,3 +3250,96 @@ func Test_shorten_fname()
   silent! clist
   call assert_equal('test_quickfix.vim', bufname('test_quickfix.vim'))
 endfunc
+
+" Quickfix title tests
+" In the below tests, 'exe "cmd"' is used to invoke the quickfix commands.
+" Otherwise due to indentation, the title is set with spaces at the beginning
+" of the command.
+func Test_qftitle()
+  call writefile(["F1:1:Line1"], 'Xerr')
+
+  " :cexpr
+  exe "cexpr readfile('Xerr')"
+  call assert_equal(":cexpr readfile('Xerr')", getqflist({'title' : 1}).title)
+
+  " :cgetexpr
+  exe "cgetexpr readfile('Xerr')"
+  call assert_equal(":cgetexpr readfile('Xerr')",
+					\ getqflist({'title' : 1}).title)
+
+  " :caddexpr
+  call setqflist([], 'f')
+  exe "caddexpr readfile('Xerr')"
+  call assert_equal(":caddexpr readfile('Xerr')",
+					\ getqflist({'title' : 1}).title)
+
+  " :cbuffer
+  new Xerr
+  exe "cbuffer"
+  call assert_equal(':cbuffer (Xerr)', getqflist({'title' : 1}).title)
+
+  " :cgetbuffer
+  edit Xerr
+  exe "cgetbuffer"
+  call assert_equal(':cgetbuffer (Xerr)', getqflist({'title' : 1}).title)
+
+  " :caddbuffer
+  call setqflist([], 'f')
+  edit Xerr
+  exe "caddbuffer"
+  call assert_equal(':caddbuffer (Xerr)', getqflist({'title' : 1}).title)
+
+  " :cfile
+  exe "cfile Xerr"
+  call assert_equal(':cfile Xerr', getqflist({'title' : 1}).title)
+
+  " :cgetfile
+  exe "cgetfile Xerr"
+  call assert_equal(':cgetfile Xerr', getqflist({'title' : 1}).title)
+
+  " :caddfile
+  call setqflist([], 'f')
+  exe "caddfile Xerr"
+  call assert_equal(':caddfile Xerr', getqflist({'title' : 1}).title)
+
+  " :grep
+  set grepprg=internal
+  exe "grep F1 Xerr"
+  call assert_equal(':grep F1 Xerr', getqflist({'title' : 1}).title)
+
+  " :grepadd
+  call setqflist([], 'f')
+  exe "grepadd F1 Xerr"
+  call assert_equal(':grepadd F1 Xerr', getqflist({'title' : 1}).title)
+  set grepprg&vim
+
+  " :vimgrep
+  exe "vimgrep F1 Xerr"
+  call assert_equal(':vimgrep F1 Xerr', getqflist({'title' : 1}).title)
+
+  " :vimgrepadd
+  call setqflist([], 'f')
+  exe "vimgrepadd F1 Xerr"
+  call assert_equal(':vimgrepadd F1 Xerr', getqflist({'title' : 1}).title)
+
+  call setqflist(['F1:10:L10'], ' ')
+  call assert_equal(':setqflist()', getqflist({'title' : 1}).title)
+
+  call setqflist([], 'f')
+  call setqflist(['F1:10:L10'], 'a')
+  call assert_equal(':setqflist()', getqflist({'title' : 1}).title)
+
+  call setqflist([], 'f')
+  call setqflist(['F1:10:L10'], 'r')
+  call assert_equal(':setqflist()', getqflist({'title' : 1}).title)
+
+  close
+  call delete('Xerr')
+
+  call setqflist([], ' ', {'title' : 'Errors'})
+  copen
+  call assert_equal('Errors', w:quickfix_title)
+  call setqflist([], 'r', {'items' : [{'filename' : 'a.c', 'lnum' : 10}]})
+  call assert_equal('Errors', w:quickfix_title)
+  cclose
+endfunc


### PR DESCRIPTION
Fix the breakage introduced by 8.0.1805 (Ignore case when matching against error lines)
Sometimes the quickfix window title is incorrectly prefixed by ":". Fix the issue.
Add a test for checking the quickfix list title.