### PR TITLE
Proposal: Add 'term_api' option to term_start()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2688,6 +2688,8 @@ term_gettty({buf}, [{input}])	String	get the tty name of a terminal
 term_list()			List	get the list of terminal buffers
 term_scrape({buf}, {row})	List	get row of a terminal screen
 term_sendkeys({buf}, {keys})	none	send keystrokes to a terminal
+term_setapi({buf}, {expr})	none	set |terminal-api| function name of a
+					terminal
 term_setansicolors({buf}, {colors})
 				none	set ANSI palette in GUI color mode
 term_setkill({buf}, {how})	none	set signal to stop job in terminal
@@ -9736,6 +9738,18 @@ term_sendkeys({buf}, {keys})				*term_sendkeys()*
 		means the character CTRL-X.
 		{only available when compiled with the |+terminal| feature}
 
+term_setapi({buf}, {expr})				*term_setapi()*
+		Set the function name or pattern whom permits to be called as
+		|terminal-api| function in terminal {buf}.
+		You can use as {expr} a string, or with trailing wildcard or
+		regexp (starts with "/").  For example: >
+		    :call term_setapi(buf, "Tapi_func")
+		    :call term_setapi(buf, "Tapi_*")
+		    :call term_setapi(buf, "/^Tapi_")
+<
+		When {expr} is empty, |terminal-api| function becomes forbidden
+		in {buf}.
+
 term_setansicolors({buf}, {colors})			*term_setansicolors()*
 		Set the ANSI color palette used by terminal {buf}.
 		{colors} must be a List of 16 valid color names or hexadecimal
@@ -9864,6 +9878,9 @@ term_start({cmd} [, {options}])			*term_start()*
 				     color modes.  See |g:terminal_ansi_colors|.
 		   "tty_type"	     (MS-Windows only): Specify which pty to
 				     use.  See 'termwintype' for the values.
+		   "term_api"	     function name or pattern whom permits to
+				     be called as |terminal-api| function.
+				     See |term_setapi()|.
 
 		{only available when compiled with the |+terminal| feature}
 

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -221,7 +221,7 @@ Syntax ~
 					Vim width (no window left or right of
 					the terminal window) this value is
 					ignored.
-			++eof={text}	when using [range]: text to send after
+			++eof={text}	When using [range]: text to send after
 					the last line was written. Cannot
 					contain white space.  A CR is
 					appended.  For MS-Windows the default
@@ -233,6 +233,16 @@ Syntax ~
 			++type={pty}	(MS-Windows only): Use {pty} as the
 					virtual console.  See 'termwintype'
 					for the values.
+			++api[={expr}]	Permit the function name matched with
+					{expr} to be called as |terminal-api|
+					function.  As {expr}, can use a string
+					with trailing wildcard or regexp
+					(starts with "/").
+					E.g. "++api=Tapi_*", "++api=/^Tapi_"
+					When {expr} is omitted, set to
+					"Tapi_*".
+			++noapi		Forbid any user defined function being
+					called as |terminal-api|.
 
 			If you want to use more options use the |term_start()|
 			function.
@@ -469,7 +479,7 @@ Currently supported commands:
 		Call a user defined function with {argument}.
 		The function is called with two arguments: the buffer number
 		of the terminal and {argument}, the decoded JSON argument. 
-		The function name must start with "Tapi_" to avoid
+		By default, The function name must start with "Tapi_" to avoid
 		accidentally calling a function not meant to be used for the
 		terminal API.
 		The user function should sanity check the argument.

--- a/src/channel.c
+++ b/src/channel.c
@@ -5017,6 +5017,17 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		memcpy(opt->jo_ansi_colors, rgb, sizeof(rgb));
 	    }
 # endif
+	    else if (STRCMP(hi->hi_key, "term_api") == 0)
+	    {
+		if (!(supported2 & JO2_TERM_API))
+		    break;
+		opt->jo_set2 |= JO2_TERM_API;
+		if (item->v_type == VAR_STRING)
+		    opt->jo_term_api = item->vval.v_string;
+		else
+		    opt->jo_term_api = tv_get_number(item) == 0
+							? (char_u *)"" : NULL;
+	    }
 #endif
 	    else if (STRCMP(hi->hi_key, "env") == 0)
 	    {

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -982,6 +982,7 @@ static struct fst
 # if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
     {"term_setansicolors", 2, 2, f_term_setansicolors},
 # endif
+    {"term_setapi",	2, 2, f_term_setapi},
     {"term_setkill",	2, 2, f_term_setkill},
     {"term_setrestore",	2, 2, f_term_setrestore},
     {"term_setsize",	3, 3, f_term_setsize},

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -50,6 +50,7 @@ void f_term_scrape(typval_T *argvars, typval_T *rettv);
 void f_term_sendkeys(typval_T *argvars, typval_T *rettv);
 void f_term_getansicolors(typval_T *argvars, typval_T *rettv);
 void f_term_setansicolors(typval_T *argvars, typval_T *rettv);
+void f_term_setapi(typval_T *argvars, typval_T *rettv);
 void f_term_setrestore(typval_T *argvars, typval_T *rettv);
 void f_term_setkill(typval_T *argvars, typval_T *rettv);
 void f_term_start(typval_T *argvars, typval_T *rettv);

--- a/src/structs.h
+++ b/src/structs.h
@@ -1778,7 +1778,7 @@ struct channel_S {
 #define JO_BLOCK_WRITE	    0x10000000	/* "block_write" */
 #define JO_OUT_MODIFIABLE   0x20000000	/* "out_modifiable" */
 #define JO_ERR_MODIFIABLE   0x40000000	/* "err_modifiable" (JO_OUT_ << 1) */
-#define JO_ALL		    0x7fffffff
+#define JO_ALL		    0x7FFFFFFF
 
 #define JO2_OUT_MSG	    0x0001	/* "out_msg" */
 #define JO2_ERR_MSG	    0x0002	/* "err_msg" (JO_OUT_ << 1) */
@@ -1797,6 +1797,8 @@ struct channel_S {
 #define JO2_TERM_KILL	    0x4000	/* "term_kill" */
 #define JO2_ANSI_COLORS	    0x8000	/* "ansi_colors" */
 #define JO2_TTY_TYPE	    0x10000	/* "tty_type" */
+#define JO2_TERM_API	    0x20000	/* "term_api" */
+#define JO2_ALL		    0x3FFFF
 
 #define JO_MODE_ALL	(JO_MODE + JO_IN_MODE + JO_OUT_MODE + JO_ERR_MODE)
 #define JO_CB_ALL \
@@ -1870,6 +1872,7 @@ typedef struct
     long_u	jo_ansi_colors[16];
 # endif
     int		jo_tty_type;	    // first character of "tty_type"
+    char_u	*jo_term_api;
 #endif
 } jobopt_T;
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -708,8 +708,13 @@ ex_terminal(exarg_T *eap)
 	cmd += 2;
 	p = skiptowhite(cmd);
 	ep = vim_strchr(cmd, '=');
-	if (ep != NULL && ep < p)
-	    p = ep;
+	if (ep != NULL)
+	{
+	    if (ep < p)
+		p = ep;
+	    else
+		ep = NULL;
+	}
 
 # define OPTARG_HAS(name) ((int)(p - cmd) == sizeof(name) - 1 \
 				 && STRNICMP(cmd, name, sizeof(name) - 1) == 0)
@@ -731,11 +736,21 @@ ex_terminal(exarg_T *eap)
 	    opt.jo_term_kill = ep + 1;
 	    p = skiptowhite(cmd);
 	}
-	else if (OPTARG_HAS("api") && ep != NULL)
+	else if (OPTARG_HAS("api"))
 	{
 	    opt.jo_set2 |= JO2_TERM_API;
-	    opt.jo_term_api = ep + 1;
-	    p = skiptowhite(cmd);
+	    if (ep != NULL)
+	    {
+		opt.jo_term_api = ep + 1;
+		p = skiptowhite(cmd);
+	    }
+	    else
+		opt.jo_term_api = NULL;
+	}
+	else if (OPTARG_HAS("noapi"))
+	{
+	    opt.jo_set2 |= JO2_TERM_API;
+	    opt.jo_term_api = (char_u *)"";
 	}
 	else if (OPTARG_HAS("rows") && ep != NULL && isdigit(ep[1]))
 	{

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -5552,6 +5552,27 @@ f_term_setansicolors(typval_T *argvars, typval_T *rettv UNUSED)
 #endif
 
 /*
+ * "term_setapi(buf, api)" function
+ */
+    void
+f_term_setapi(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
+{
+    buf_T	*buf = term_get_buf(argvars, "term_setapi()");
+    term_T	*term;
+    char_u	*api;
+
+    if (buf == NULL)
+	return;
+    term = buf->b_term;
+    vim_free(term->tl_api);
+    api = tv_get_string_chk(&argvars[1]);
+    if (api != NULL)
+	term->tl_api = vim_strsave(api);
+    else
+	term->tl_api = NULL;
+}
+
+/*
  * "term_setrestore(buf, command)" function
  */
     void

--- a/src/testdir/screendump.vim
+++ b/src/testdir/screendump.vim
@@ -55,14 +55,18 @@ func RunVimInTerminal(arguments, options)
   let statusoff = get(a:options, 'statusoff', 1)
 
   let cmd = GetVimCommandClean()
-
   " Add -v to have gvim run in the terminal (if possible)
   let cmd .= ' -v ' . a:arguments
-  let buf = term_start(cmd, {
+
+  let opts = {
 	\ 'curwin': 1,
 	\ 'term_rows': rows,
 	\ 'term_cols': cols,
-	\ })
+	\ }
+  " Accept other options whose name starts with 'term_'.
+  call extend(opts, filter(copy(a:options), 'v:key =~# "^term_"'))
+
+  let buf = term_start(cmd, opts)
   if &termwinsize == ''
     " in the GUI we may end up with a different size, try to set it.
     if term_getsize(buf) != [rows, cols]

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -2126,3 +2126,34 @@ func Test_terminal_getwinpos()
   set splitright&
   only!
 endfunc
+
+func Test_terminal_setapi_and_call()
+  if !CanRunVimInTerminal()
+    return
+  endif
+
+  call WriteApiCall('Tapi_TryThis')
+  call ch_logfile('Xlog', 'w')
+
+  unlet! g:called_bufnum
+  unlet! g:called_arg
+
+  let buf = RunVimInTerminal('-S Xscript', {'term_api': 0})
+  call WaitForAssert({-> assert_match('Unpermitted function: Tapi_TryThis', string(readfile('Xlog')))})
+  call assert_false(exists('g:called_bufnum'))
+  call assert_false(exists('g:called_arg'))
+
+  call term_setapi(buf, 'Tapi_TryThis')
+  call term_sendkeys(buf, ":set notitle\<CR>")
+  call term_sendkeys(buf, ":source Xscript\<CR>")
+  call WaitFor({-> exists('g:called_bufnum')})
+  call assert_equal(buf, g:called_bufnum)
+  call assert_equal(['hello', 123], g:called_arg)
+  call StopVimInTerminal(buf)
+
+  call delete('Xscript')
+  call ch_logfile('')
+  call delete('Xlog')
+  unlet! g:called_bufnum
+  unlet! g:called_arg
+endfunc


### PR DESCRIPTION
(The comments of https://github.com/vim/vim/commit/2a77d21f7893ba14e682a3c5891d606f117a3f36)

I think we should provide the way to disable terminal-api for who does not really want to use it and in terms of security.
In addition, personally, I'd like to enable to specify API names in order to gain API modulability.

Therefore I propose the following ways:

### 1. Add `term_api` bool option to `term_start()` and `++api`/`++noapi` to `:terminal`

To simply enable/disable terminal-api.

To disable API:

* `term_start(..., {'term_api': 0})`
* `:term ++noapi`

To enable explicitly:

* `term_start(..., {'term_api': 1})` 
* `:term ++api`

### 2. Add `term_api` bool/string option and `++api=XXX`/`++noapi`

This pull-req. as sample

To disable API:

* `term_start(..., {'term_api': 0})`
* `term_start(..., {'term_api': ''})` (means no API name is permitted)
* `:term ++noapi`

To enable explicitly: (permit functions starting with `Tapi_`, default)

* `term_start(..., {'term_api': 1})`

To specify API name: (permit functions starting with `Tfun_`)

* `term_start(..., {'term_api': 'Tfun_*'})` (trailing wildcard)
* `term_start(..., {'term_api': '/^Tfun_'})` (regexp)
* `:term ++api=Tfun_*`

<del>NOTE: no document yet</del>