### PR TITLE
Function getwinpos() was not tested

### DIFF
--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -110,6 +110,7 @@ func Test_getwinpos()
   call assert_match('Window position: X \d\+, Y \d\+', execute('winpos'))
   call assert_true(getwinposx() >= 0)
   call assert_true(getwinposy() >= 0)
+  call assert_equal([getwinposx(), getwinposy()], getwinpos())
 endfunc
 
 func Test_quoteplus()
@@ -138,7 +139,7 @@ func Test_quoteplus()
 
     " Set the quoteplus register to test_call, and another gvim will launched.
     " Then, it first tries to paste the content of its own quotedplus register
-    " onto it.  Second, it tries to substitute test_responce for the pasted
+    " onto it.  Second, it tries to substitute test_response for the pasted
     " sentence.  If the sentence is identical to test_call, the substitution
     " should succeed.  Third, it tries to yank the result of the substitution
     " to its own quoteplus register, and last it quits.  When system()
@@ -249,7 +250,7 @@ func Test_set_balloonexpr()
   setl ballooneval
   call assert_equal('MyBalloonExpr()', &balloonexpr)
   " TODO Read non-empty text, place the pointer at a character of a word,
-  " and check if the content of the balloon is the smae as what is expected.
+  " and check if the content of the balloon is the same as what is expected.
   " Also, check if textlock works as expected.
   setl balloonexpr&
   call assert_equal('', &balloonexpr)
@@ -267,7 +268,7 @@ func Test_set_balloonexpr()
     setl ballooneval
     call assert_equal('MyBalloonFuncForMultilineUsingNL()', &balloonexpr)
     " TODO Read non-empty text, place the pointer at a character of a word,
-    " and check if the content of the balloon is the smae as what is
+    " and check if the content of the balloon is the same as what is
     " expected.  Also, check if textlock works as expected.
     setl balloonexpr&
     delfunc MyBalloonFuncForMultilineUsingNL
@@ -282,7 +283,7 @@ func Test_set_balloonexpr()
     setl ballooneval
     call assert_equal('MyBalloonFuncForMultilineUsingList()', &balloonexpr)
     " TODO Read non-empty text, place the pointer at a character of a word,
-    " and check if the content of the balloon is the smae as what is
+    " and check if the content of the balloon is the same as what is
     " expected.  Also, check if textlock works as expected.
     setl balloonexpr&
     delfunc MyBalloonFuncForMultilineUsingList


### PR DESCRIPTION
This PR adds a test for function getwinpos() which was not tested according to codecov:

https://codecov.io/gh/vim/vim/src/master/src/evalfunc.c#L5536