### PR TITLE
Remove redundant code and add a test.

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -608,6 +608,12 @@ using these functions are below:
     " get the identifier of the current quickfix list
     :let qfid = getqflist({'id' : 0}).id
 
+    " get the identifier of the fourth quickfix list in the stack
+    :let qfid = getqflist({'nr' : 4, 'id' : 0}).id
+
+    " check whether a quickfix list with a specific identifier exists
+    :if getqflist({'id' : qfid}).id == qfid
+
     " get the index of the current quickfix list in the stack
     :let qfnum = getqflist({'nr' : 0}).nr
 
@@ -653,6 +659,11 @@ The setqflist() and setloclist() functions can be used to set the various
 attributes of a quickfix and location list respectively. Some examples for
 using these functions are below:
 >
+    " create an empty quickfix list with a title and a context
+    :let t = 'Search results'
+    :let c = {'cmd' : 'grep'}
+    :call setqflist([], ' ', {'title' : t, 'context' : c})
+
     " set the title of the current quickfix list
     :call setqflist([], 'a', {'title' : 'Mytitle'})
 
@@ -670,6 +681,9 @@ using these functions are below:
     :let newItems = [{'filename' : 'a.txt', 'lnum' : 10, 'text' : "Apple"},
 		    \ {'filename' : 'b.txt', 'lnum' : 20, 'text' : "Orange"}]
     :call setqflist([], 'a', {'id' : qfid, 'items' : newItems})
+
+    " empty a quickfix list specified by an identifier
+    :call setqflist([], 'r', {'id' : qfid, 'items' : []})
 
     " free all the quickfix lists in the stack
     :call setqflist([], 'f')

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5798,16 +5798,6 @@ qf_setprop_items(qf_info_T *qi, int qf_idx, dictitem_T *di, int action)
     title_save = vim_strsave(qi->qf_lists[qf_idx].qf_title);
     retval = qf_add_entries(qi, qf_idx, di->di_tv.vval.v_list,
 	    title_save, action == ' ' ? 'a' : action);
-    if (action == 'r')
-    {
-	/*
-	 * When replacing the quickfix list entries using
-	 * qf_add_entries(), the title is set with a ':' prefix.
-	 * Restore the title with the saved title.
-	 */
-	vim_free(qi->qf_lists[qf_idx].qf_title);
-	qi->qf_lists[qf_idx].qf_title = vim_strsave(title_save);
-    }
     vim_free(title_save);
 
     return retval;

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1185,6 +1185,13 @@ func Test_efm2()
   call assert_equal(1, len(l), string(l))
   call assert_equal('|| msg2', l[0].text)
 
+  " When matching error lines, case should be ignored. Test for this.
+  set noignorecase
+  let l=getqflist({'lines' : ['Xtest:FOO10:Line 20'], 'efm':'%f:foo%l:%m'})
+  call assert_equal(10, l.items[0].lnum)
+  call assert_equal('Line 20', l.items[0].text)
+  set ignorecase&
+
   new | only
   let &efm = save_efm
 endfunc


### PR DESCRIPTION
After patch 1831, part of the changes introduced by patch 1093 is
not needed. Remove it. Add a new test and update the help.
