### PR TITLE
Update the PHP indentation script from 1.62 to 1.66

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -907,6 +907,25 @@ In PHP braces are not required inside 'case/default' blocks therefore 'case:'
 and 'default:' are indented at the same level than the 'switch()' to avoid
 meaningless indentation. You can use the above option to return to the
 traditional way.
+-------------
+
+							*PHP_noArrowMatching*
+By default the indent script will indent multi-line chained calls by matching
+the position of the '->': >
+
+    $user_name_very_long->name()
+                        ->age()
+                        ->info();
+
+You can revert to the classic way of indenting by setting this option to 1: >
+    :let g:PHP_noArrowMatching = 1
+
+You will obtain the following result: >
+
+    $user_name_very_long->name()
+        ->age()
+        ->info();
+
 
 
 PYTHON							*ft-python-indent*

--- a/runtime/indent/php.vim
+++ b/runtime/indent/php.vim
@@ -3,8 +3,8 @@
 " Author:	John Wellesz <John.wellesz (AT) teaser (DOT) fr>
 " URL:		http://www.2072productions.com/vim/indent/php.vim
 " Home:		https://github.com/2072/PHP-Indenting-for-VIm
-" Last Change:	2018 May 14
-" Version:	1.62
+" Last Change:	2018 May 18th
+" Version:	1.66
 "
 "
 "	Type :help php-indent for available options
@@ -82,6 +82,12 @@ else
     let b:PHP_outdentphpescape = 1
 endif
 
+if exists("PHP_noArrowMatching")
+    let b:PHP_noArrowMatching = PHP_noArrowMatching
+else
+    let b:PHP_noArrowMatching = 0
+endif
+
 
 if exists("PHP_vintage_case_default_indent") && PHP_vintage_case_default_indent
     let b:PHP_vintage_case_default_indent = 1
@@ -130,7 +136,7 @@ endif
 let s:PHP_validVariable = '[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*'
 let s:notPhpHereDoc = '\%(break\|return\|continue\|exit\|die\|else\)'
 let s:blockstart = '\%(\%(\%(}\s*\)\=else\%(\s\+\)\=\)\=if\>\|\%(}\s*\)\?else\>\|do\>\|while\>\|switch\>\|case\>\|default\>\|for\%(each\)\=\>\|declare\>\|class\>\|trait\>\|use\>\|interface\>\|abstract\>\|final\>\|try\>\|\%(}\s*\)\=catch\>\|\%(}\s*\)\=finally\>\)'
-let s:functionDecl = '\<function\>\%(\s\+'.s:PHP_validVariable.'\)\=\s*(.*'
+let s:functionDecl = '\<function\>\%(\s\+&\='.s:PHP_validVariable.'\)\=\s*(.*'
 let s:endline = '\s*\%(//.*\|#.*\|/\*.*\*/\s*\)\=$'
 let s:unstated = '\%(^\s*'.s:blockstart.'.*)\|\%(//.*\)\@<!\<e'.'lse\>\)'.s:endline
 
@@ -138,7 +144,6 @@ let s:unstated = '\%(^\s*'.s:blockstart.'.*)\|\%(//.*\)\@<!\<e'.'lse\>\)'.s:endl
 let s:terminated = '\%(\%(;\%(\s*\%(?>\|}\)\)\=\|<<<\s*[''"]\=\a\w*[''"]\=$\|^\s*}\|^\s*'.s:PHP_validVariable.':\)'.s:endline.'\)'
 let s:PHP_startindenttag = '<?\%(.*?>\)\@!\|<script[^>]*>\%(.*<\/script>\)\@!'
 let s:structureHead = '^\s*\%(' . s:blockstart . '\)\|'. s:functionDecl . s:endline . '\|\<new\s\+class\>'
-
 
 
 let s:escapeDebugStops = 0
@@ -257,7 +262,7 @@ endfun
 
 function! Skippmatch()	" {{{
     let synname = synIDattr(synID(line("."), col("."), 0), "name")
-    if synname == "Delimiter" || synname == "phpRegionDelimiter" || synname =~# "^phpParent" || synname == "phpArrayParens" || synname =~# '^php\%(Block\|Brace\)' || synname == "javaScriptBraces" || synname =~# '^php\%(Doc\)\?Comment' && b:UserIsTypingComment
+    if synname ==? "Delimiter" || synname ==? "phpRegionDelimiter" || synname =~? "^phpParent" || synname ==? "phpArrayParens" || synname =~? '^php\%(Block\|Brace\)' || synname ==? "javaScriptBraces" || synname =~? '^php\%(Doc\)\?Comment' && b:UserIsTypingComment
 	return 0
     else
 	return 1
@@ -296,6 +301,48 @@ function! BalanceDirection (str)
 
     return balance
 endfun
+
+function! StripEndlineComments (line)
+    return substitute(a:line,"\\(//\\|#\\)\\(\\(\\([^\"']*\\([\"']\\)[^\"']*\\5\\)\\+[^\"']*$\\)\\|\\([^\"']*$\\)\\)",'','')
+endfun
+
+function! FindArrowIndent (lnum)  " {{{
+
+    let parrentArrowPos = 0
+    let lnum = a:lnum
+    while lnum > 1
+	let last_line = getline(lnum)
+	if last_line =~ '^\s*->'
+	    let parrentArrowPos = indent(a:lnum)
+	    break
+	else
+	    call cursor(lnum, 1)
+	    let cleanedLnum = StripEndlineComments(last_line)
+	    if cleanedLnum =~ '->'
+		if ! b:PHP_noArrowMatching
+		    let parrentArrowPos = searchpos('->', 'W', lnum)[1] - 1
+		else
+		    let parrentArrowPos = indent(lnum) + shiftwidth()
+		endif
+		break
+	    elseif cleanedLnum =~ ')'.s:endline && BalanceDirection(last_line) < 0
+		call searchpos(')'.s:endline, 'cW', lnum)
+		let openedparent = searchpair('(', '', ')', 'bW', 'Skippmatch()')
+		if openedparent != lnum
+		    let lnum = openedparent
+		else
+		    let openedparent = -1
+		endif
+
+	    else
+		let parrentArrowPos = indent(lnum) + shiftwidth()
+		break
+	    endif
+	endif
+    endwhile
+
+    return parrentArrowPos
+endfun "}}}
 
 function! FindTheIfOfAnElse (lnum, StopAfterFirstPrevElse) " {{{
 
@@ -368,7 +415,7 @@ function! FindTheSwitchIndent (lnum) " {{{
 
 endfunction "}}}
 
-let s:SynPHPMatchGroups = {'phpParent':1, 'Delimiter':1, 'Define':1, 'Storageclass':1, 'StorageClass':1, 'Structure':1, 'Exception':1}
+let s:SynPHPMatchGroups = {'phpparent':1, 'delimiter':1, 'define':1, 'storageclass':1, 'structure':1, 'exception':1}
 function! IslinePHP (lnum, tofind) " {{{
     let cline = getline(a:lnum)
 
@@ -384,7 +431,7 @@ function! IslinePHP (lnum, tofind) " {{{
 
     let synname = synIDattr(synID(a:lnum, coltotest, 0), "name")
 
-    if synname == 'phpStringSingle' || synname == 'phpStringDouble' || synname == 'phpBacktick'
+    if synname ==? 'phpStringSingle' || synname ==? 'phpStringDouble' || synname ==? 'phpBacktick'
 	if cline !~ '^\s*[''"`]'
 	    return "SpecStringEntrails"
 	else
@@ -392,7 +439,7 @@ function! IslinePHP (lnum, tofind) " {{{
 	end
     end
 
-    if get(s:SynPHPMatchGroups, synname) || synname =~ '^php' ||  synname =~? '^javaScript'
+    if get(s:SynPHPMatchGroups, tolower(synname)) || synname =~ '^php' ||  synname =~? '^javaScript'
 	return synname
     else
 	return ""
@@ -422,6 +469,10 @@ function! ResetPhpOptions()
 endfunc
 
 call ResetPhpOptions()
+
+function! GetPhpIndentVersion()
+    return "1.66-bundle"
+endfun
 
 function! GetPhpIndent()
 
@@ -480,14 +531,14 @@ function! GetPhpIndent()
 	endif
 
 	if synname!=""
-	    if synname == "SpecStringEntrails"
+	    if synname ==? "SpecStringEntrails"
 		let b:InPHPcode = -1 " thumb down
 		let b:InPHPcode_tofind = ""
-	    elseif synname != "phpHereDoc" && synname != "phpHereDocDelimiter"
+	    elseif synname !=? "phpHereDoc" && synname !=? "phpHereDocDelimiter"
 		let b:InPHPcode = 1
 		let b:InPHPcode_tofind = ""
 
-		if synname =~# '^php\%(Doc\)\?Comment'
+		if synname =~? '^php\%(Doc\)\?Comment'
 		    let b:UserIsTypingComment = 1
 		    let b:InPHPcode_checked = 0
 		endif
@@ -556,7 +607,7 @@ function! GetPhpIndent()
 
     if 1 == b:InPHPcode
 
-	if !b:InPHPcode_and_script && last_line =~ '\%(<?.*\)\@<!?>\%(.*<?\)\@!' && IslinePHP(lnum, '?>')=~"Delimiter"
+	if !b:InPHPcode_and_script && last_line =~ '\%(<?.*\)\@<!?>\%(.*<?\)\@!' && IslinePHP(lnum, '?>')=~?"Delimiter"
 	    if cline !~? s:PHP_startindenttag
 		let b:InPHPcode = 0
 		let b:InPHPcode_tofind = s:PHP_startindenttag
@@ -712,7 +763,8 @@ function! GetPhpIndent()
 	    let last_line_num = GetLastRealCodeLNum(last_line_num - 1)
 	    let previous_line = getline(last_line_num)
 	endwhile
-
+    elseif cline =~ '^\s*->'
+	return FindArrowIndent(lnum)
     elseif last_line =~# unstated && cline !~ '^\s*);\='.endline
 	let ind = ind + shiftwidth() " we indent one level further when the preceding line is not stated
 	return ind + addSpecial
@@ -724,7 +776,7 @@ function! GetPhpIndent()
 
 	let isSingleLineBlock = 0
 	while 1
-	    if ! isSingleLineBlock && previous_line =~ '^\s*}\|;\s*}'.endline " XXX
+	    if ! isSingleLineBlock && previous_line =~ '^\s*}\|;\s*}'.endline
 
 		call cursor(last_line_num, 1)
 		if previous_line !~ '^}'
@@ -793,8 +845,7 @@ function! GetPhpIndent()
 
     let AntepenultimateLine = getline(plinnum)
 
-    let last_line = substitute(last_line,"\\(//\\|#\\)\\(\\(\\([^\"']*\\([\"']\\)[^\"']*\\5\\)\\+[^\"']*$\\)\\|\\([^\"']*$\\)\\)",'','')
-
+    let last_line = StripEndlineComments(last_line)
 
     if ind == b:PHP_default_indenting
 	if last_line =~ terminated && last_line !~# s:defaultORcase
@@ -804,11 +855,13 @@ function! GetPhpIndent()
 
     if !LastLineClosed
 
+	let openedparent = -1
+
 
 	if last_line =~# '[{(\[]'.endline || last_line =~? '\h\w*\s*(.*,$' && AntepenultimateLine !~ '[,(\[]'.endline && BalanceDirection(last_line) > 0
 
 	    let dontIndent = 0
-	    if last_line =~ '\S\+\s*{'.endline && last_line !~ '^\s*[)\]]\+\s*{'.endline && last_line !~ s:structureHead
+	    if last_line =~ '\S\+\s*{'.endline && last_line !~ '^\s*[)\]]\+\(\s*:\s*'.s:PHP_validVariable.'\)\=\s*{'.endline && last_line !~ s:structureHead
 		let dontIndent = 1
 	    endif
 
@@ -819,18 +872,17 @@ function! GetPhpIndent()
 	    if b:PHP_BracesAtCodeLevel || b:PHP_vintage_case_default_indent == 1
 		let b:PHP_CurrentIndentLevel = ind
 
-		return ind + addSpecial
 	    endif
 
-	elseif last_line =~ '\S\+\s*),'.endline && BalanceDirection(last_line) < 0
+	elseif last_line =~ '),'.endline && BalanceDirection(last_line) < 0
 	    call cursor(lnum, 1)
-	    call search('),'.endline, 'W') " line never begins with ) so no need for 'c' flag
+	    call searchpos('),'.endline, 'cW')
 	    let openedparent = searchpair('(', '', ')', 'bW', 'Skippmatch()')
 	    if openedparent != lnum
 		let ind = indent(openedparent)
 	    endif
 
-	elseif last_line =~ '^\s*'.s:blockstart
+	elseif last_line =~ s:structureHead
 	    let ind = ind + shiftwidth()
 
 
@@ -838,9 +890,17 @@ function! GetPhpIndent()
 	    let ind = ind + shiftwidth()
 	endif
 
+
+	if openedparent >= 0
+	    let last_line = StripEndlineComments(getline(openedparent))
+	endif
     endif
 
-    if cline =~  '^\s*[)\]];\='
+    if cline =~ '^\s*[)\]];\='
+	let ind = ind - shiftwidth()
+    endif
+
+    if last_line =~ '^\s*->' && last_line !~? s:structureHead && BalanceDirection(last_line) <= 0
 	let ind = ind - shiftwidth()
     endif
 


### PR DESCRIPTION
Changes since 1.62:

- Fix chained multi-line '->' indentation (issue 2072/PHP-Indenting-for-VIm#54 and 2072/PHP-Indenting-for-VIm#59)
- Add a new PHP_noArrowMatching option to disable '->' indentation matching on multi-line chained calls (issue 2072/PHP-Indenting-for-VIm#59).
- Add support for return type declaration on multi-line function declarations (issue 2072/PHP-Indenting-for-VIm#64)
- Fix array indentation when PHP_vintage_case_default_indent is set (issue 2072/PHP-Indenting-for-VIm#58)
- Always ignore case when using syntax highlighting names (issue 2072/PHP-Indenting-for-VIm#52)
- Functions declared as returning references were not indented properly (issue 2072/PHP-Indenting-for-VIm#62).
- Fix to multi-line function declaration argument indentation (issue 2072/PHP-Indenting-for-VIm#63)