### PR TITLE
Added tests for the :compiler command

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2150,6 +2150,7 @@ test_arglist \
 	test_cmdline \
 	test_command_count \
 	test_comparators \
+	test_compiler \
 	test_crypt \
 	test_cscope \
 	test_cursor_func \

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -5,6 +5,7 @@ source test_assign.vim
 source test_bufline.vim
 source test_cd.vim
 source test_changedtick.vim
+source test_compiler.vim
 source test_cursor_func.vim
 source test_delete.vim
 source test_ex_undo.vim

--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -1,0 +1,50 @@
+" Test the :compiler command
+
+func Test_compiler()
+  if !executable('perl')
+    return
+  endif
+
+  e Xfoo.pl
+  compiler perl
+  call assert_equal('perl', b:current_compiler)
+  call assert_fails('let g:current_compiler', 'E121:')
+
+  call setline(1, ['#!/usr/bin/perl -w', 'use strict;', 'my $foo=1'])
+  w!
+  call feedkeys(":make\<CR>\<CR>", 'tx')
+  call assert_fails('clist', 'E42:')
+
+  call setline(1, ['#!/usr/bin/perl -w', 'use strict;', '$foo=1'])
+  w!
+  call feedkeys(":make\<CR>\<CR>", 'tx')
+  let a=execute('clist')
+  call assert_equal("\n 1 Xfoo.pl:3: Global symbol \"\$foo\" "
+  \ .               "requires explicit package name "
+  \ .               "(did you forget to declare \"my $foo\"?)", a)
+
+  call delete('Xfoo.pl')
+  bw!
+endfunc
+
+func Test_compiler_without_arg()
+  let a=split(execute('compiler'))
+  call assert_equal($VIMRUNTIME . '/compiler/ant.vim',   a[0])
+  call assert_equal($VIMRUNTIME . '/compiler/bcc.vim',   a[1])
+  call assert_equal($VIMRUNTIME . '/compiler/xmlwf.vim', a[-1])
+endfunc
+
+func Test_compiler_completion()
+  call feedkeys(":compiler \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_match('^"compiler ant bcc .* xmlwf$', @:)
+
+  call feedkeys(":compiler p\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"compiler pbx perl php pylint pyunit', @:)
+
+  call feedkeys(":compiler! p\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"compiler! pbx perl php pylint pyunit', @:)
+endfunc
+
+func Test_compiler_error()
+  call assert_fails('compiler doesnotexist', 'E666:')
+endfunc


### PR DESCRIPTION
This PR adds tests for the compiler command which
was not tested according to codecov:

https://codecov.io/gh/vim/vim/src/master/src/ex_cmds2.c#L3331
