### PR TITLE
Fixed invalid memory access when changing color of cursor in terminal

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -171,8 +171,8 @@ static int term_default_cterm_bg = -1;
 
 /* Store the last set and the desired cursor properties, so that we only update
  * them when needed.  Doing it unnecessary may result in flicker. */
-static char_u	*last_set_cursor_color = (char_u *)"";
-static char_u	*desired_cursor_color = (char_u *)"";
+static char_u	*last_set_cursor_color = NULL;
+static char_u	*desired_cursor_color = NULL;
 static int	last_set_cursor_shape = -1;
 static int	desired_cursor_shape = -1;
 static int	last_set_cursor_blink = -1;
@@ -182,6 +182,28 @@ static int	desired_cursor_blink = -1;
 /**************************************
  * 1. Generic code for all systems.
  */
+
+    static void
+cursor_color_copy(char_u** to_color, char_u* from_color)
+{
+    vim_free(*to_color);
+    *to_color = (from_color == NULL) ? NULL : vim_strsave(from_color);
+}
+
+	static int
+cursor_color_equal(char_u *lhs_color, char_u *rhs_color)
+{
+    if (lhs_color != NULL && rhs_color != NULL)
+	return STRCMP(lhs_color, rhs_color) == 0;
+    return lhs_color == NULL && rhs_color == NULL;
+}
+
+	static char_u *
+cursor_color_get(char_u *color)
+{
+    return (color == NULL) ? (char_u *)"" : color;
+}
+
 
 /*
  * Parse 'termwinsize' and set "rows" and "cols" for the terminal size in the
@@ -823,8 +845,6 @@ free_terminal(buf_T *buf)
     if (term->tl_out_fd != NULL)
 	fclose(term->tl_out_fd);
 #endif
-    if (desired_cursor_color == term->tl_cursor_color)
-	desired_cursor_color = (char_u *)"";
     vim_free(term->tl_cursor_color);
     vim_free(term);
     buf->b_term = NULL;
@@ -1954,14 +1974,14 @@ term_get_cursor_shape(guicolor_T *fg, guicolor_T *bg)
     static void
 may_output_cursor_props(void)
 {
-    if (STRCMP(last_set_cursor_color, desired_cursor_color) != 0
+    if (!cursor_color_equal(last_set_cursor_color, desired_cursor_color)
 	    || last_set_cursor_shape != desired_cursor_shape
 	    || last_set_cursor_blink != desired_cursor_blink)
     {
-	last_set_cursor_color = desired_cursor_color;
+	cursor_color_copy(&last_set_cursor_color, desired_cursor_color);
 	last_set_cursor_shape = desired_cursor_shape;
 	last_set_cursor_blink = desired_cursor_blink;
-	term_cursor_color(desired_cursor_color);
+	term_cursor_color(cursor_color_get(desired_cursor_color));
 	if (desired_cursor_shape == -1 || desired_cursor_blink == -1)
 	    /* this will restore the initial cursor style, if possible */
 	    ui_cursor_shape_forced(TRUE);
@@ -1984,10 +2004,7 @@ may_set_cursor_props(term_T *term)
 #endif
     if (in_terminal_loop == term)
     {
-	if (term->tl_cursor_color != NULL)
-	    desired_cursor_color = term->tl_cursor_color;
-	else
-	    desired_cursor_color = (char_u *)"";
+	cursor_color_copy(&desired_cursor_color, term->tl_cursor_color);
 	desired_cursor_shape = term->tl_cursor_shape;
 	desired_cursor_blink = term->tl_cursor_blink;
 	may_output_cursor_props();
@@ -2004,7 +2021,7 @@ prepare_restore_cursor_props(void)
     if (gui.in_use)
 	return;
 #endif
-    desired_cursor_color = (char_u *)"";
+    cursor_color_copy(&desired_cursor_color, NULL);
     desired_cursor_shape = -1;
     desired_cursor_blink = -1;
     may_output_cursor_props();
@@ -2624,13 +2641,7 @@ handle_settermprop(
 	    break;
 
 	case VTERM_PROP_CURSORCOLOR:
-	    if (desired_cursor_color == term->tl_cursor_color)
-		desired_cursor_color = (char_u *)"";
-	    vim_free(term->tl_cursor_color);
-	    if (*value->string == NUL)
-		term->tl_cursor_color = NULL;
-	    else
-		term->tl_cursor_color = vim_strsave((char_u *)value->string);
+	    cursor_color_copy(&term->tl_cursor_color, (char_u*)value->string);
 	    may_set_cursor_props(term);
 	    break;
 
@@ -4711,8 +4722,7 @@ f_term_getcursor(typval_T *argvars, typval_T *rettv)
 	dict_add_nr_str(d, "blink", blink_state_is_inverted()
 		       ? !term->tl_cursor_blink : term->tl_cursor_blink, NULL);
 	dict_add_nr_str(d, "shape", term->tl_cursor_shape, NULL);
-	dict_add_nr_str(d, "color", 0L, term->tl_cursor_color == NULL
-				       ? (char_u *)"" : term->tl_cursor_color);
+	dict_add_nr_str(d, "color", 0L, cursor_color_get(term->tl_cursor_color));
 	list_append_dict(l, d);
     }
 }


### PR DESCRIPTION
This PR fixes access to free memory when changing
the color of cursor in terminal (fixes #2938).

The fix consists in doing deep copies of strings for
last_set_cursor_color and last_set_cursor_shape
instead of doing pointer copy (pointer copies 
could be pointing to freed memory).