### PR TITLE
Allow repeated put from expression register ("=p.)

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -844,6 +844,14 @@ start_redo(long count, int old_redo)
 	if (c >= '1' && c < '9')
 	    ++c;
 	add_char_buff(&readbuf2, c);
+
+	/* expression register should be re-evaluated */
+	if (c == '=')
+	{
+	    add_char_buff(&readbuf2, CAR);
+	    cmd_silent = TRUE;
+	}
+
 	c = read_redo(FALSE, old_redo);
     }
 

--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -45,3 +45,18 @@ func Test_put_lines()
   bw!
   call setreg('a', a[0], a[1])
 endfunc
+
+func Test_put_expr()
+  new
+  let a = [ getreg('=', 1), getregtype('=') ]
+  call setline(1, repeat(['A'], 6))
+  exec "1norm! \"=line('.')\<cr>p"
+  norm! j0.
+  norm! j0.
+  exec "4norm! \"=\<cr>P"
+  norm! j0.
+  norm! j0.
+  call assert_equal(['A1','A2','A3','4A','5A','6A'], getline(1,'$'))
+  bw!
+  call setreg('=', a[0], a[1])
+endfunc


### PR DESCRIPTION
Problem: Cannot repeat a put from the expression register.
Solution: Allow evaluation of expression register during repeats.

Using `.` after `"=p` is right now completely useless.  Here is a very simple fix to cause the register to be evaluated again.  This relies on the behavior of `"=<cr>` which reuses the previous expression.  With this patch, for instance, `"=strftime('%S')<cr>p......` will work as one might expect.
