### PR TITLE
Resolve warning about undefined behavior

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -2872,14 +2872,20 @@ term_color(char_u *s, int n)
 #else
 	char *format = "%s%s%%dm";
 #endif
+#if defined(FEAT_VTP) && defined(FEAT_TERMGUICOLORS)
 	sprintf(buf, format,
 		i == 2 ?
-#if defined(FEAT_VTP) && defined(FEAT_TERMGUICOLORS)
 		s[1] == '|' ? IF_EB("\033|", ESC_STR "|") :
-#endif
 		IF_EB("\033[", ESC_STR "[") : "\233",
 		s[i] == '3' ? (n >= 16 ? "38;5;" : "9")
 			    : (n >= 16 ? "48;5;" : "10"));
+#else
+	sprintf(buf, format,
+		i == 2 ?
+		IF_EB("\033[", ESC_STR "[") : "\233",
+		s[i] == '3' ? (n >= 16 ? "38;5;" : "9")
+			    : (n >= 16 ? "48;5;" : "10"));
+#endif
 	OUT_STR(tgoto(buf, 0, n >= 16 ? n : n - 8));
     }
     else


### PR DESCRIPTION
This bug is very similar to another issue I reported, that was fixed
in patch 7.4.1819.

The error message is:

```
term.c:2877:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
\#if defined(FEAT_VTP) && defined(FEAT_TERMGUICOLORS)
 ^
1 warning generated.
```

The issue is caused because sprintf() is implemented as a macro on some
systems.

Therefore, this sprintf() call has its parameters conditionally modified
by the preprocessor, and embedding a preprocessor directive within macro
arguments causes undefined behavior.

My proposed fix would be to move the preprocessor check outside the call
to sprintf().