### PR TITLE
Refactor the qf_parse_match() and qf_list() functions in quickfix.c

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -861,8 +861,8 @@ typedef struct {
 } qffields_T;
 
 /*
- * Parse the match for filename ('%f') specifier in regmatch and
- * return the matched value in 'fields->namebuf'.
+ * Parse the match for filename ('%f') pattern in regmatch.
+ * Return the matched value in 'fields->namebuf'.
  */
     static int
 qf_parse_fmt_f(int idx, regmatch_T *regmatch, int i, qffields_T *fields)
@@ -878,6 +878,10 @@ qf_parse_fmt_f(int idx, regmatch_T *regmatch, int i, qffields_T *fields)
     expand_env(regmatch->startp[i], fields->namebuf, CMDBUFFSIZE);
     *regmatch->endp[i] = c;
 
+    /*
+     * For separate filename patterns (%O, %P and %Q), the specified file
+     * should exist.
+     */
     if (vim_strchr((char_u *)"OPQ", idx) != NULL
 	    && mch_getperm(fields->namebuf) == -1)
 	return QF_FAIL;
@@ -886,8 +890,8 @@ qf_parse_fmt_f(int idx, regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the match for error number ('%n') specifier in regmatch and
- * return the matched value in 'fields->enr'.
+ * Parse the match for error number ('%n') pattern in regmatch.
+ * Return the matched value in 'fields->enr'.
  */
     static int
 qf_parse_fmt_n(regmatch_T *regmatch, int i, qffields_T *fields)
@@ -899,8 +903,8 @@ qf_parse_fmt_n(regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the match for line number (%l') specifier in regmatch and
- * return the matched value in 'fields->lnum'.
+ * Parse the match for line number (%l') pattern in regmatch.
+ * Return the matched value in 'fields->lnum'.
  */
     static int
 qf_parse_fmt_l(regmatch_T *regmatch, int i, qffields_T *fields)
@@ -912,8 +916,8 @@ qf_parse_fmt_l(regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the match for column number ('%c') specifier in regmatch and
- * return the matched value in 'fields->col'.
+ * Parse the match for column number ('%c') pattern in regmatch.
+ * Return the matched value in 'fields->col'.
  */
     static int
 qf_parse_fmt_c(regmatch_T *regmatch, int i, qffields_T *fields)
@@ -925,8 +929,8 @@ qf_parse_fmt_c(regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the match for error type ('%t') specifier in regmatch and
- * return the matched value in 'fields->type'.
+ * Parse the match for error type ('%t') pattern in regmatch.
+ * Return the matched value in 'fields->type'.
  */
     static int
 qf_parse_fmt_t(regmatch_T *regmatch, int i, qffields_T *fields)
@@ -938,8 +942,8 @@ qf_parse_fmt_t(regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the match for '%+' code from linebuf and return the matched line in
- * 'fields->errmsg'.
+ * Parse the match for '%+' format pattern. The whole matching line is included
+ * in the error string.  Return the matched line in 'fields->errmsg'.
  */
     static int
 qf_parse_fmt_plus(char_u *linebuf, int linelen, qffields_T *fields)
@@ -959,8 +963,8 @@ qf_parse_fmt_plus(char_u *linebuf, int linelen, qffields_T *fields)
 }
 
 /*
- * Parse the match for error message ('%m') specifier in regmatch and
- * return the matched value in 'fields->errmsg'.
+ * Parse the match for error message ('%m') pattern in regmatch.
+ * Return the matched value in 'fields->errmsg'.
  */
     static int
 qf_parse_fmt_m(regmatch_T *regmatch, int i, qffields_T *fields)
@@ -984,8 +988,8 @@ qf_parse_fmt_m(regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the match for rest of line ('%r') specifier and return the matched
- * value in 'tail'.
+ * Parse the match for rest of a single-line file message ('%r') pattern.
+ * Return the matched value in 'tail'.
  */
     static int
 qf_parse_fmt_r(regmatch_T *regmatch, int i, char_u **tail)
@@ -997,8 +1001,8 @@ qf_parse_fmt_r(regmatch_T *regmatch, int i, char_u **tail)
 }
 
 /*
- * Parse the match for the pointer line ('%p') specifier in regmatch and
- * return the matched value in 'fields->col'.
+ * Parse the match for the pointer line ('%p') pattern in regmatch.
+ * Return the matched value in 'fields->col'.
  */
     static int
 qf_parse_fmt_p(regmatch_T *regmatch, int i, qffields_T *fields)
@@ -1024,8 +1028,8 @@ qf_parse_fmt_p(regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the match for the virtual column number ('%v') specifier in
- * regmatch and return the matched value in 'fields->col'.
+ * Parse the match for the virtual column number ('%v') pattern in regmatch.
+ * Return the matched value in 'fields->col'.
  */
     static int
 qf_parse_fmt_v(regmatch_T *regmatch, int i, qffields_T *fields)
@@ -1038,8 +1042,8 @@ qf_parse_fmt_v(regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the match for the search text ('%s') specifier in regmatch and
- * return the matched value in 'fields->pattern'.
+ * Parse the match for the search text ('%s') pattern in regmatch.
+ * Return the matched value in 'fields->pattern'.
  */
     static int
 qf_parse_fmt_s(regmatch_T *regmatch, int i, qffields_T *fields)
@@ -1060,8 +1064,8 @@ qf_parse_fmt_s(regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the match for the module ('%o') specifier in regmatch and
- * return the matched value in 'fields->module'.
+ * Parse the match for the module ('%o') pattern in regmatch.
+ * Return the matched value in 'fields->module'.
  */
     static int
 qf_parse_fmt_o(regmatch_T *regmatch, int i, qffields_T *fields)
@@ -1078,10 +1082,10 @@ qf_parse_fmt_o(regmatch_T *regmatch, int i, qffields_T *fields)
 }
 
 /*
- * Parse the error format matches in 'regmatch' and set the values in 'fields'.
- * fmt_ptr contains the 'efm' format specifiers/prefixes that have a match.
- * Returns QF_OK if all the matches are successfully parsed. On failure,
- * returns QF_FAIL or QF_NOMEM.
+ * Parse the error format pattern matches in 'regmatch' and set the values in
+ * 'fields'.  fmt_ptr contains the 'efm' format specifiers/prefixes that have a
+ * match.  Returns QF_OK if all the matches are successfully parsed. On
+ * failure, returns QF_FAIL or QF_NOMEM.
  */
     static int
 qf_parse_match(

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -865,24 +865,24 @@ typedef struct {
  * Return the matched value in 'fields->namebuf'.
  */
     static int
-qf_parse_fmt_f(regmatch_T *regmatch, int i, qffields_T *fields, int idx)
+qf_parse_fmt_f(regmatch_T *rmp, int midx, qffields_T *fields, int prefix)
 {
     int c;
 
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL)
+    if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
 	return QF_FAIL;
 
     /* Expand ~/file and $HOME/file to full path. */
-    c = *regmatch->endp[i];
-    *regmatch->endp[i] = NUL;
-    expand_env(regmatch->startp[i], fields->namebuf, CMDBUFFSIZE);
-    *regmatch->endp[i] = c;
+    c = *rmp->endp[midx];
+    *rmp->endp[midx] = NUL;
+    expand_env(rmp->startp[midx], fields->namebuf, CMDBUFFSIZE);
+    *rmp->endp[midx] = c;
 
     /*
      * For separate filename patterns (%O, %P and %Q), the specified file
      * should exist.
      */
-    if (vim_strchr((char_u *)"OPQ", idx) != NULL
+    if (vim_strchr((char_u *)"OPQ", prefix) != NULL
 	    && mch_getperm(fields->namebuf) == -1)
 	return QF_FAIL;
 
@@ -894,11 +894,11 @@ qf_parse_fmt_f(regmatch_T *regmatch, int i, qffields_T *fields, int idx)
  * Return the matched value in 'fields->enr'.
  */
     static int
-qf_parse_fmt_n(regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_n(regmatch_T *rmp, int midx, qffields_T *fields)
 {
-    if (regmatch->startp[i] == NULL)
+    if (rmp->startp[midx] == NULL)
 	return QF_FAIL;
-    fields->enr = (int)atol((char *)regmatch->startp[i]);
+    fields->enr = (int)atol((char *)rmp->startp[midx]);
     return QF_OK;
 }
 
@@ -907,11 +907,11 @@ qf_parse_fmt_n(regmatch_T *regmatch, int i, qffields_T *fields)
  * Return the matched value in 'fields->lnum'.
  */
     static int
-qf_parse_fmt_l(regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_l(regmatch_T *rmp, int midx, qffields_T *fields)
 {
-    if (regmatch->startp[i] == NULL)
+    if (rmp->startp[midx] == NULL)
 	return QF_FAIL;
-    fields->lnum = atol((char *)regmatch->startp[i]);
+    fields->lnum = atol((char *)rmp->startp[midx]);
     return QF_OK;
 }
 
@@ -920,11 +920,11 @@ qf_parse_fmt_l(regmatch_T *regmatch, int i, qffields_T *fields)
  * Return the matched value in 'fields->col'.
  */
     static int
-qf_parse_fmt_c(regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_c(regmatch_T *rmp, int midx, qffields_T *fields)
 {
-    if (regmatch->startp[i] == NULL)
+    if (rmp->startp[midx] == NULL)
 	return QF_FAIL;
-    fields->col = (int)atol((char *)regmatch->startp[i]);
+    fields->col = (int)atol((char *)rmp->startp[midx]);
     return QF_OK;
 }
 
@@ -933,11 +933,11 @@ qf_parse_fmt_c(regmatch_T *regmatch, int i, qffields_T *fields)
  * Return the matched value in 'fields->type'.
  */
     static int
-qf_parse_fmt_t(regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_t(regmatch_T *rmp, int midx, qffields_T *fields)
 {
-    if (regmatch->startp[i] == NULL)
+    if (rmp->startp[midx] == NULL)
 	return QF_FAIL;
-    fields->type = *regmatch->startp[i];
+    fields->type = *rmp->startp[midx];
     return QF_OK;
 }
 
@@ -967,14 +967,14 @@ qf_parse_fmt_plus(char_u *linebuf, int linelen, qffields_T *fields)
  * Return the matched value in 'fields->errmsg'.
  */
     static int
-qf_parse_fmt_m(regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_m(regmatch_T *rmp, int midx, qffields_T *fields)
 {
     char_u	*p;
     int		len;
 
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL)
+    if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
 	return QF_FAIL;
-    len = (int)(regmatch->endp[i] - regmatch->startp[i]);
+    len = (int)(rmp->endp[midx] - rmp->startp[midx]);
     if (len >= fields->errmsglen)
     {
 	/* len + null terminator */
@@ -983,7 +983,7 @@ qf_parse_fmt_m(regmatch_T *regmatch, int i, qffields_T *fields)
 	fields->errmsg = p;
 	fields->errmsglen = len + 1;
     }
-    vim_strncpy(fields->errmsg, regmatch->startp[i], len);
+    vim_strncpy(fields->errmsg, rmp->startp[midx], len);
     return QF_OK;
 }
 
@@ -992,11 +992,11 @@ qf_parse_fmt_m(regmatch_T *regmatch, int i, qffields_T *fields)
  * Return the matched value in 'tail'.
  */
     static int
-qf_parse_fmt_r(regmatch_T *regmatch, int i, char_u **tail)
+qf_parse_fmt_r(regmatch_T *rmp, int midx, char_u **tail)
 {
-    if (regmatch->startp[i] == NULL)
+    if (rmp->startp[midx] == NULL)
 	return QF_FAIL;
-    *tail = regmatch->startp[i];
+    *tail = rmp->startp[midx];
     return QF_OK;
 }
 
@@ -1005,15 +1005,15 @@ qf_parse_fmt_r(regmatch_T *regmatch, int i, char_u **tail)
  * Return the matched value in 'fields->col'.
  */
     static int
-qf_parse_fmt_p(regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_p(regmatch_T *rmp, int midx, qffields_T *fields)
 {
     char_u	*match_ptr;
 
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL)
+    if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
 	return QF_FAIL;
     fields->col = 0;
-    for (match_ptr = regmatch->startp[i];
-	    match_ptr != regmatch->endp[i]; ++match_ptr)
+    for (match_ptr = rmp->startp[midx]; match_ptr != rmp->endp[midx];
+								++match_ptr)
     {
 	++fields->col;
 	if (*match_ptr == TAB)
@@ -1032,11 +1032,11 @@ qf_parse_fmt_p(regmatch_T *regmatch, int i, qffields_T *fields)
  * Return the matched value in 'fields->col'.
  */
     static int
-qf_parse_fmt_v(regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_v(regmatch_T *rmp, int midx, qffields_T *fields)
 {
-    if (regmatch->startp[i] == NULL)
+    if (rmp->startp[midx] == NULL)
 	return QF_FAIL;
-    fields->col = (int)atol((char *)regmatch->startp[i]);
+    fields->col = (int)atol((char *)rmp->startp[midx]);
     fields->use_viscol = TRUE;
     return QF_OK;
 }
@@ -1046,17 +1046,17 @@ qf_parse_fmt_v(regmatch_T *regmatch, int i, qffields_T *fields)
  * Return the matched value in 'fields->pattern'.
  */
     static int
-qf_parse_fmt_s(regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_s(regmatch_T *rmp, int midx, qffields_T *fields)
 {
     int		len;
 
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL)
+    if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
 	return QF_FAIL;
-    len = (int)(regmatch->endp[i] - regmatch->startp[i]);
+    len = (int)(rmp->endp[midx] - rmp->startp[midx]);
     if (len > CMDBUFFSIZE - 5)
 	len = CMDBUFFSIZE - 5;
     STRCPY(fields->pattern, "^\\V");
-    STRNCAT(fields->pattern, regmatch->startp[i], len);
+    STRNCAT(fields->pattern, rmp->startp[midx], len);
     fields->pattern[len + 3] = '\\';
     fields->pattern[len + 4] = '$';
     fields->pattern[len + 5] = NUL;
@@ -1068,18 +1068,38 @@ qf_parse_fmt_s(regmatch_T *regmatch, int i, qffields_T *fields)
  * Return the matched value in 'fields->module'.
  */
     static int
-qf_parse_fmt_o(regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_o(regmatch_T *rmp, int midx, qffields_T *fields)
 {
     int		len;
 
-    if (regmatch->startp[i] == NULL || regmatch->endp[i] == NULL)
+    if (rmp->startp[midx] == NULL || rmp->endp[midx] == NULL)
 	return QF_FAIL;
-    len = (int)(regmatch->endp[i] - regmatch->startp[i]);
+    len = (int)(rmp->endp[midx] - rmp->startp[midx]);
     if (len > CMDBUFFSIZE)
 	len = CMDBUFFSIZE;
-    STRNCAT(fields->module, regmatch->startp[i], len);
+    STRNCAT(fields->module, rmp->startp[midx], len);
     return QF_OK;
 }
+
+/*
+ * 'errorformat' format pattern parser functions.
+ * The '%f' and '%r' formats are parsed differently from other formats.
+ * See qf_parse_match() for details.
+ */
+static int (*qf_parse_fmt[FMT_PATTERNS])(regmatch_T *, int, qffields_T *) =
+{
+    NULL,
+    qf_parse_fmt_n,
+    qf_parse_fmt_l,
+    qf_parse_fmt_c,
+    qf_parse_fmt_t,
+    qf_parse_fmt_m,
+    NULL,
+    qf_parse_fmt_p,
+    qf_parse_fmt_v,
+    qf_parse_fmt_s,
+    qf_parse_fmt_o
+};
 
 /*
  * Parse the error format pattern matches in 'regmatch' and set the values in
@@ -1100,6 +1120,7 @@ qf_parse_match(
 {
     int		idx = fmt_ptr->prefix;
     int		i;
+    int		midx;
     int		status;
 
     if ((idx == 'C' || idx == 'Z') && !qf_multiline)
@@ -1113,48 +1134,27 @@ qf_parse_match(
      * We check for an actual submatch, because "\[" and "\]" in
      * the 'errorformat' may cause the wrong submatch to be used.
      */
-    if ((i = (int)fmt_ptr->addr[0]) > 0)		/* %f */
-	if (qf_parse_fmt_f(regmatch, i, fields, idx) == QF_FAIL)
-	    return QF_FAIL;
-    if ((i = (int)fmt_ptr->addr[1]) > 0)		/* %n */
-	if (qf_parse_fmt_n(regmatch, i, fields) == QF_FAIL)
-	    return QF_FAIL;
-    if ((i = (int)fmt_ptr->addr[2]) > 0)		/* %l */
-	if (qf_parse_fmt_l(regmatch, i, fields) == QF_FAIL)
-	    return QF_FAIL;
-    if ((i = (int)fmt_ptr->addr[3]) > 0)		/* %c */
-	if (qf_parse_fmt_c(regmatch, i, fields) == QF_FAIL)
-	    return QF_FAIL;
-    if ((i = (int)fmt_ptr->addr[4]) > 0)		/* %t */
-	if (qf_parse_fmt_t(regmatch, i, fields) == QF_FAIL)
-	    return QF_FAIL;
-    if (fmt_ptr->flags == '+' && !qf_multiscan)	/* %+ */
+    for (i = 0; i < FMT_PATTERNS; i++)
     {
-	status = qf_parse_fmt_plus(linebuf, linelen, fields);
+	status = QF_OK;
+	midx = (int)fmt_ptr->addr[i];
+	if (i == 0 && midx > 0)				/* %f */
+	    status = qf_parse_fmt_f(regmatch, midx, fields, idx);
+	else if (i == 5)
+	{
+	    if (fmt_ptr->flags == '+' && !qf_multiscan)	/* %+ */
+		status = qf_parse_fmt_plus(linebuf, linelen, fields);
+	    else if (midx > 0)				/* %m */
+		status = qf_parse_fmt_m(regmatch, midx, fields);
+	}
+	else if (i == 6 && midx > 0)			/* %r */
+	    status = qf_parse_fmt_r(regmatch, midx, tail);
+	else if (midx > 0)				/* others */
+	    status = (qf_parse_fmt[i])(regmatch, midx, fields);
+
 	if (status != QF_OK)
 	    return status;
     }
-    else if ((i = (int)fmt_ptr->addr[5]) > 0)	/* %m */
-    {
-	status = qf_parse_fmt_m(regmatch, i, fields);
-	if (status != QF_OK)
-	    return status;
-    }
-    if ((i = (int)fmt_ptr->addr[6]) > 0)		/* %r */
-	if (qf_parse_fmt_r(regmatch, i, tail) == QF_FAIL)
-	    return QF_FAIL;
-    if ((i = (int)fmt_ptr->addr[7]) > 0)		/* %p */
-	if (qf_parse_fmt_p(regmatch, i, fields) == QF_FAIL)
-	    return QF_FAIL;
-    if ((i = (int)fmt_ptr->addr[8]) > 0)		/* %v */
-	if (qf_parse_fmt_v(regmatch, i, fields) == QF_FAIL)
-	    return QF_FAIL;
-    if ((i = (int)fmt_ptr->addr[9]) > 0)		/* %s */
-	if (qf_parse_fmt_s(regmatch, i, fields) == QF_FAIL)
-	    return QF_FAIL;
-    if ((i = (int)fmt_ptr->addr[10]) > 0)		/* %o */
-	if (qf_parse_fmt_o(regmatch, i, fields) == QF_FAIL)
-	    return QF_FAIL;
 
     return QF_OK;
 }

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -865,7 +865,7 @@ typedef struct {
  * Return the matched value in 'fields->namebuf'.
  */
     static int
-qf_parse_fmt_f(int idx, regmatch_T *regmatch, int i, qffields_T *fields)
+qf_parse_fmt_f(regmatch_T *regmatch, int i, qffields_T *fields, int idx)
 {
     int c;
 
@@ -1114,7 +1114,7 @@ qf_parse_match(
      * the 'errorformat' may cause the wrong submatch to be used.
      */
     if ((i = (int)fmt_ptr->addr[0]) > 0)		/* %f */
-	if (qf_parse_fmt_f(idx, regmatch, i, fields) == QF_FAIL)
+	if (qf_parse_fmt_f(regmatch, i, fields, idx) == QF_FAIL)
 	    return QF_FAIL;
     if ((i = (int)fmt_ptr->addr[1]) > 0)		/* %n */
 	if (qf_parse_fmt_n(regmatch, i, fields) == QF_FAIL)


### PR DESCRIPTION
The qf_parse_match() and qf_list() functions are too long.
Refactor and simplify the functions. No new functionality
is introduced in this patch.
