### PR TITLE
Added test for moving with % on #ifdef #endif, and on C comments /* .… */

### DIFF
--- a/src/testdir/test_goto.vim
+++ b/src/testdir/test_goto.vim
@@ -309,3 +309,65 @@ func Test_gd_local_block()
   \ ]
   call XTest_goto_decl('1gd', lines, 11, 11)
 endfunc
+
+func Test_motion_if_elif_else_endif()
+  new
+  a
+/* Test pressing % on #if, #else #elsif and #endif,
+ * with nested #if
+ */
+#if FOO
+/* ... */
+#  if BAR
+/* ... */
+#  endif
+#elif BAR
+/* ... */
+#else
+/* ... */
+#endif
+.
+  /#if FOO
+  norm %
+  call assert_equal([9, 1], getpos('.')[1:2])
+  norm %
+  call assert_equal([11, 1], getpos('.')[1:2])
+  norm %
+  call assert_equal([13, 1], getpos('.')[1:2])
+  norm %
+  call assert_equal([4, 1], getpos('.')[1:2])
+  /#  if BAR
+  norm $%
+  call assert_equal([8, 1], getpos('.')[1:2])
+  norm $%
+  call assert_equal([6, 1], getpos('.')[1:2])
+
+  bw!
+endfunc
+
+func Test_motion_c_comment()
+  new
+  a
+/*
+ * Test pressing % on beginning/end
+ * of C comments.
+ */
+/* Another comment */
+.
+  norm gg0%
+  call assert_equal([4, 3], getpos('.')[1:2])
+  norm %
+  call assert_equal([1, 1], getpos('.')[1:2])
+  norm gg0l%
+  call assert_equal([4, 3], getpos('.')[1:2])
+  norm h%
+  call assert_equal([1, 1], getpos('.')[1:2])
+
+  norm G^
+  norm %
+  call assert_equal([5, 21], getpos('.')[1:2])
+  norm %
+  call assert_equal([5, 1], getpos('.')[1:2])
+
+  bw!
+endfunc


### PR DESCRIPTION
This PR adds test for moving with % in normal mode on #ifdef #endif, and
on C comments /* .… */ which was not tested according to codecov:
https://codecov.io/gh/vim/vim/src/833093bfb0e4a7f89b5adc66babcfa8ac09cfda9/src/search.c#L2085

I submitted a PR for this a long time ago, but I messed up that old review with an 
incorrect merge and closed it at the time. So I'm now creating a new PR.