### PR TITLE
Added test for the undofile() function

### DIFF
--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -423,9 +423,14 @@ funct Test_undofile()
   " Test undofile() with 'undodir' set to to an existing directory.
   call mkdir('Xundodir')
   set undodir=Xundodir
-  let cwd_with_percent=substitute(getcwd() . '/Xfoo', '/', '%', 'g')
+  let cwd = getcwd()
+  if has('win32')
+    " Raplace windows drive such as C:... into C%...
+    let cwd=substitute(cwd, '^\([A-Z]\):', '\1%', 'g')
+  endif
+  let cwd=substitute(cwd . '/Xfoo', '/', '%', 'g')
   if has('persistent_undo')
-    call assert_equal('Xundodir/' . cwd_with_percent, undofile('Xfoo'))
+    call assert_equal('Xundodir/' . cwd, undofile('Xfoo'))
   else
     call assert_equal('', undofile('Xfoo'))
   endif

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -85,7 +85,7 @@ endfunc
 func FillBuffer()
   for i in range(1,13)
     put=i
-    " Set 'undolevels' to split undo. 
+    " Set 'undolevels' to split undo.
     exe "setg ul=" . &g:ul
   endfor
 endfunc
@@ -409,4 +409,31 @@ func Test_redo_empty_line()
   exe "norm\x16r\x160"
   exe "norm."
   bwipe!
+endfunc
+
+funct Test_undofile()
+  " Test undofile() without setting 'undodir'.
+  if has('persistent_undo')
+    call assert_equal(fnamemodify('.Xfoo.un~', ':p'), undofile('Xfoo'))
+  else
+    call assert_equal('', undofile('Xfoo'))
+  endif
+  call assert_equal('', undofile(''))
+
+  " Test undofile() with 'undodir' set to to an existing directory.
+  call mkdir('Xundodir')
+  set undodir=Xundodir
+  let cwd_with_percent=substitute(getcwd() . '/Xfoo', '/', '%', 'g')
+  if has('persistent_undo')
+    call assert_equal('Xundodir/' . cwd_with_percent, undofile('Xfoo'))
+  else
+    call assert_equal('', undofile('Xfoo'))
+  endif
+  call assert_equal('', undofile(''))
+  call delete('Xundodir', 'd')
+
+  " Test undofile() with 'undodir' set to a non-existing directory.
+  call assert_equal('', undofile('Xfoo'))
+
+  set undodir&
 endfunc


### PR DESCRIPTION
This PR adds a test for the undofile() function which was
not tested according to codecov:

https://codecov.io/gh/vim/vim/src/master/src/evalfunc.c#L13381

I only tested on Linux. Please wait for CI to complete to
make sure the test passes on Widows as I'm not 100% sure
whether it will pass on Windows without additional changes.
I don't have ways to test for Windows locally.