### PR TITLE
Fixed regression introduced by 8.0.1660 when doing :edit ++enc=utf8 +bad=...

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5318,7 +5318,9 @@ get_bad_opt(char_u *p, exarg_T *eap)
 	eap->bad_char = BAD_DROP;
     else if (MB_BYTE2LEN(*p) == 1 && p[1] == NUL)
 	eap->bad_char = *p;
-    return FAIL;
+    else
+	return FAIL;
+    return OK;
 }
 #endif
 

--- a/src/testdir/test_plus_arg_edit.vim
+++ b/src/testdir/test_plus_arg_edit.vim
@@ -15,21 +15,21 @@ func Test_edit_bad()
   endif
 
   " Test loading a utf8 file with bad utf8 sequences.
-  call writefile(["[\xff][\xc0\x20][\xe2\x89\xf0][\xc2\xc2]"], "Xfile")
+  call writefile(["[\xff][\xc0][\xe2\x89\xf0][\xc2\xc2]"], "Xfile")
   new
 
   " Without ++bad=..., the default behavior is like ++bad=?
   e! ++enc=utf8 Xfile
-  call assert_equal('[?][? ][???][??]', getline(1))
+  call assert_equal('[?][?][???][??]', getline(1))
 
   e! ++enc=utf8 ++bad=_ Xfile
-  call assert_equal('[_][_ ][___][__]', getline(1))
+  call assert_equal('[_][_][___][__]', getline(1))
 
   e! ++enc=utf8 ++bad=drop Xfile
-  call assert_equal('[][ ][][]', getline(1))
+  call assert_equal('[][][][]', getline(1))
 
   e! ++enc=utf8 ++bad=keep Xfile
-  call assert_equal("[\xff][\xc0\x20][\xe2\x89\xf0][\xc2\xc2]", getline(1))
+  call assert_equal("[\xff][\xc0][\xe2\x89\xf0][\xc2\xc2]", getline(1))
 
   call assert_fails('e! ++enc=utf8 ++bad=foo Xfile', 'E474:')
 

--- a/src/testdir/test_plus_arg_edit.vim
+++ b/src/testdir/test_plus_arg_edit.vim
@@ -8,3 +8,29 @@ function Test_edit()
   call delete('Xfile1')
   call delete('Xfile2')
 endfunction
+
+func Test_edit_bad()
+  if !has('multi_byte')
+    finish
+  endif
+
+  " Test loading a utf8 file with bad utf8 sequences.
+  call writefile(["[\xff][\xc0\x20][\xe2\x89\xf0][\xc2\xc2]"], "Xfile") 
+  new
+
+  " Without ++bad=..., the default behavior is like ++bad=?
+  e! ++enc=utf8 Xfile
+  call assert_equal('[?][? ][???][??]', getline(1))
+
+  e! ++enc=utf8 ++bad=_ Xfile
+  call assert_equal('[_][_ ][___][__]', getline(1))
+
+  e! ++enc=utf8 ++bad=drop Xfile
+  call assert_equal('[][ ][][]', getline(1))
+
+  e! ++enc=utf8 ++bad=keep Xfile
+  call assert_equal("[\xff][\xc0\x20][\xe2\x89\xf0][\xc2\xc2]", getline(1))
+
+  bw!
+  call delete('Xfile')
+endfunc

--- a/src/testdir/test_plus_arg_edit.vim
+++ b/src/testdir/test_plus_arg_edit.vim
@@ -1,7 +1,7 @@
 " Tests for complicated + argument to :edit command
 function Test_edit()
-  call writefile(["foo|bar"], "Xfile1") 
-  call writefile(["foo/bar"], "Xfile2") 
+  call writefile(["foo|bar"], "Xfile1")
+  call writefile(["foo/bar"], "Xfile2")
   edit +1|s/|/PIPE/|w Xfile1| e Xfile2|1 | s/\//SLASH/|w
   call assert_equal(["fooPIPEbar"], readfile("Xfile1"))
   call assert_equal(["fooSLASHbar"], readfile("Xfile2"))
@@ -15,7 +15,7 @@ func Test_edit_bad()
   endif
 
   " Test loading a utf8 file with bad utf8 sequences.
-  call writefile(["[\xff][\xc0\x20][\xe2\x89\xf0][\xc2\xc2]"], "Xfile") 
+  call writefile(["[\xff][\xc0\x20][\xe2\x89\xf0][\xc2\xc2]"], "Xfile")
   new
 
   " Without ++bad=..., the default behavior is like ++bad=?
@@ -30,6 +30,8 @@ func Test_edit_bad()
 
   e! ++enc=utf8 ++bad=keep Xfile
   call assert_equal("[\xff][\xc0\x20][\xe2\x89\xf0][\xc2\xc2]", getline(1))
+
+  call assert_fails('e! ++enc=utf8 ++bad=foo Xfile', 'E474:')
 
   bw!
   call delete('Xfile')


### PR DESCRIPTION
This PR fixes a regression introduced by patch 8.0.1660.
Since that patch, it is no longer possible to do things like:
```
  :e! ++enc=utf8 ++bad=keep
```
It results "E474: Invalid argument" whereas it should succeed.
The PR also adds a test as ++bad= was until now not covered 
by tests according to codecov:

https://codecov.io/gh/vim/vim/src/master/src/ex_docmd.c#L5313