### PR TITLE
Allow whitespace in one of the 2 characters for sign text

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -2073,13 +2073,21 @@ rem_backslash(char_u *str)
  * Halve the number of backslashes in a file name argument.
  * For MS-DOS we only do this if the character after the backslash
  * is not a normal file character.
+ * Returns the number of characters removed.
  */
-    void
+    int
 backslash_halve(char_u *p)
 {
+    int num_removed=0;
     for ( ; *p; ++p)
+    {
 	if (rem_backslash(p))
+	{
 	    STRMOVE(p, p + 1);
+	    ++num_removed;
+	}
+    }
+    return num_removed;
 }
 
 /*

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -7640,6 +7640,7 @@ ex_sign(exarg_T *eap)
 			int	len;
 
 			arg += 5;
+			p -= backslash_halve(arg); // allow spaces
 # ifdef FEAT_MBYTE
 			/* Count cells and check for non-printable chars */
 			if (has_mbyte)

--- a/src/proto/charset.pro
+++ b/src/proto/charset.pro
@@ -58,7 +58,7 @@ void vim_str2nr(char_u *start, int *prep, int *len, int what, varnumber_T *nptr,
 int hex2nr(int c);
 int hexhex2nr(char_u *p);
 int rem_backslash(char_u *str);
-void backslash_halve(char_u *p);
+int backslash_halve(char_u *p);
 char_u *backslash_halve_save(char_u *p);
 void ebcdic2ascii(char_u *buffer, int len);
 /* vim: set ft=c : */

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -92,7 +92,7 @@ func Test_sign()
   call setline(1, ['A', 'B', 'C', 'D'])
 
   try
-    sign define Sign3 text=y texthl=DoesNotExist linehl=DoesNotExist icon=doesnotexist.xpm
+    sign define Sign3 text=xy texthl=DoesNotExist linehl=DoesNotExist icon=doesnotexist.xpm
   catch /E255:/
     " ignore error: E255: it can happens for guis.
   endtry
@@ -103,6 +103,33 @@ func Test_sign()
   call assert_notequal(fn, expand('%:p'))
   exe 'sign jump 43 file=' . fn
   call assert_equal('B', getline('.'))
+
+  " You can't define a sign with a non-printable character as text
+  call assert_fails( "sign define Sign4 text=\e linehl=Comment", 'E239:' )
+  call assert_fails( "sign define Sign4 text=a\e linehl=Comment", 'E239:' )
+  call assert_fails( "sign define Sign4 text=\ea linehl=Comment", 'E239:' )
+
+  " Only 1 or 2 character text is allowed
+  call assert_fails( "sign define Sign4 text=abc linehl=Comment", 'E239:' )
+  call assert_fails( "sign define Sign4 text= linehl=Comment", 'E239:' )
+  call assert_fails( "sign define Sign4 text=\ ab  linehl=Comment", 'E239:' )
+
+  " You _can_ define signs with whitespace
+  sign define Sign4 text=\ X linehl=Comment
+  sign undefine Sign4
+  sign define Sign4 linehl=Comment text=\ X
+  sign undefine Sign4
+
+  " And backslashes
+  sign define Sign4 text=\\\\ linehl=Comment
+  sign undefine Sign4
+  sign define Sign4 text=\\ linehl=Comment
+  sign undefine Sign4
+
+  sign define Sign5 text=X\  linehl=Comment
+  sign undefine Sign5
+  sign define Sign5 linehl=Comment text=X\ 
+  sign undefine Sign5
 
   " After undefining the sign, we should no longer be able to place it.
   sign undefine Sign1


### PR DESCRIPTION
Minor issue: Allow to populate only the right-hand column of the sign (gutter?) by specifying a single space as the first character of sign's text. This requires accepting an escaped space `\ ` and removing it when parsing the text.

I noticed that while the docs say you can use any 2 printable characters, space is not allowed currently when defining the text for a sign.

This PR also adds a few tests for that part of the code (it validates string length and that text is printable). Happy to split and just submit the new tests if you prefer.

No hard feelings if this is either too niche or if it is intentional.
