### PR TITLE
Avoid "E36: Not enough room" error when restoring a session.

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -11274,7 +11274,7 @@ makeopens(
 	 * winminheight and winminwidth need to be set to avoid an error if the
 	 * user has set winheight or winwidth.
 	 */
-	if (put_line(fd, "set winminheight=1 winheight=1 winminwidth=1 winwidth=1") == FAIL)
+	if (put_line(fd, "set winminheight=0 winheight=1 winminwidth=0 winwidth=1") == FAIL)
 	    return FAIL;
 	if (nr > 1 && ses_winsizes(fd, restore_size, tab_firstwin) == FAIL)
 	    return FAIL;


### PR DESCRIPTION
If the user had set a winheight greater than the current window size,
the session will error out when restoring, causing some session settings to be lost.

This ensures winminheight and winminwidth are below winheight and
winwidth.

Fixes https://github.com/vim/vim/issues/2970