### PR TITLE
Improved test coverage of the :cd command

### DIFF
--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -14,13 +14,15 @@ func Test_cd_up_and_down()
 endfunc
 
 func Test_cd_no_arg()
-  " Test that cd without argument goes to $HOME directory.
-  let path = getcwd()
-  cd
-  call assert_equal($HOME, getcwd())
-  call assert_notequal(path, getcwd())
-  exe 'cd ' . path
-  call assert_equal(path, getcwd())
+  " Test that cd without argument goes to $HOME directory on Unix systems.
+  if has('unix')
+    let path = getcwd()
+    cd
+    call assert_equal($HOME, getcwd())
+    call assert_notequal(path, getcwd())
+    exe 'cd ' . path
+    call assert_equal(path, getcwd())
+  endif
 endfunc
 
 func Test_cd_minus()

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -8,6 +8,55 @@ endfunc
 func Test_cd_up_and_down()
   let path = getcwd()
   cd ..
+  call assert_notequal(path, getcwd())
   exe 'cd ' . path
   call assert_equal(path, getcwd())
+endfunc
+
+func Test_cd_no_arg()
+  " Test that cd without argument goes to $HOME directory.
+  let path = getcwd()
+  cd
+  call assert_equal($HOME, getcwd())
+  call assert_notequal(path, getcwd())
+  exe 'cd ' . path
+  call assert_equal(path, getcwd())
+endfunc
+
+func Test_cd_minus()
+  " Test the  :cd -  goes back to the previous directory.
+  let path = getcwd()
+  cd ..
+  let path_dotdot = getcwd()
+  call assert_notequal(path, path_dotdot)
+  cd -
+  call assert_equal(path, getcwd())
+  cd -
+  call assert_equal(path_dotdot, getcwd())
+  cd -
+  call assert_equal(path, getcwd())
+endfunc
+
+func Test_cd_with_cpo_chdir()
+  e Xfoo
+  call setline(1, 'foo')
+  let path = getcwd()
+  set cpo+=.
+
+  " :cd should fail when buffer is modified and 'cpo' contains dot.
+  call assert_fails('cd ..', 'E747:')
+  call assert_equal(path, getcwd())
+
+  " :cd with exclamation mark should succeed.
+  cd! ..
+  call assert_notequal(path, getcwd())
+
+  " :cd should succeed when buffer has been written.
+  w!
+  exe 'cd ' . path
+  call assert_equal(path, getcwd())
+
+  call delete('Xfoo')
+  set cpo&
+  bw!
 endfunc


### PR DESCRIPTION
This PR improves test coverage of the ":cd" command and checks that:
* cd without argument should go to the $HOME directory
* cd with minus sign should go to the previous directory
* cd with dot in 'cpo' should fail with E747 when buffer is modified.
* cd with exclamation mark should override the E747 restriction.