### PR TITLE
Added test for user name and language completion

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -393,7 +393,7 @@ endfunc
 
 func Test_cmdline_complete_user_names()
   if has('unix') && executable('whoami')
-    " Can make this test work on Windows?
+    " TODO: can wk make this test work on Windows?
     let whoami = systemlist('whoami')[0]
     let first_letter = whoami[0]
     if len(first_letter) > 0
@@ -412,7 +412,7 @@ funct Test_cmdline_complete_languages()
   call assert_match('^"language .*\<ctype\>.*\<messages\>.*\<time\>', @:)
 
   if has('unix')
-    " These tests don't work on Windows. lang appears to be 'C'
+    " TODO: these tests don't work on Windows. lang appears to be 'C'
     " but C does not appear in the completion. Why?
     call assert_match('^"language .*\<' . lang . '\>', @:)
 

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -392,9 +392,8 @@ func Test_cmdline_complete_user_cmd()
 endfunc
 
 func Test_cmdline_complete_user_names()
-  " The whoami command is probably not available on Windows.
-  " How can we get the user name on Windows?
-  if executable('whoami')
+  if has('unix') && executable('whoami')
+    " Can make this test work on Windows?
     let whoami = systemlist('whoami')[0]
     let first_letter = whoami[0]
     if len(first_letter) > 0
@@ -410,17 +409,22 @@ funct Test_cmdline_complete_languages()
   let lang = substitute(execute('language messages'), '.*"\(.*\)"$', '\1', '')
 
   call feedkeys(":language \<c-a>\<c-b>\"\<cr>", 'tx')
-  call assert_match('^"language .*\<' . lang . '\>', @:)
   call assert_match('^"language .*\<ctype\>.*\<messages\>.*\<time\>', @:)
 
-  call feedkeys(":language messages \<c-a>\<c-b>\"\<cr>", 'tx')
-  call assert_match('^"language .*\<' . lang . '\>', @:)
+  if has('unix')
+    " These tests don't work on Windows. lang appears to be 'C'
+    " but C does not appear in the completion. Why?
+    call assert_match('^"language .*\<' . lang . '\>', @:)
 
-  call feedkeys(":language ctype \<c-a>\<c-b>\"\<cr>", 'tx')
-  call assert_match('^"language .*\<' . lang . '\>', @:)
+    call feedkeys(":language messages \<c-a>\<c-b>\"\<cr>", 'tx')
+    call assert_match('^"language .*\<' . lang . '\>', @:)
 
-  call feedkeys(":language time \<c-a>\<c-b>\"\<cr>", 'tx')
-  call assert_match('^"language .*\<' . lang . '\>', @:)
+    call feedkeys(":language ctype \<c-a>\<c-b>\"\<cr>", 'tx')
+    call assert_match('^"language .*\<' . lang . '\>', @:)
+
+    call feedkeys(":language time \<c-a>\<c-b>\"\<cr>", 'tx')
+    call assert_match('^"language .*\<' . lang . '\>', @:)
+  endif
 endfunc
 
 func Test_cmdline_write_alternatefile()

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1,6 +1,5 @@
 " Tests for editing the command line.
 
-
 func Test_complete_tab()
   call writefile(['testfile'], 'Xtestfile')
   call feedkeys(":e Xtest\t\r", "tx")
@@ -390,6 +389,38 @@ func Test_cmdline_complete_user_cmd()
   call feedkeys(":Foo b\<Tab>\<Home>\"\<cr>", 'tx')
   call assert_equal('"Foo blue', @:)
   delcommand Foo
+endfunc
+
+func Test_cmdline_complete_user_names()
+  " The whoami command is probably not available on Windows.
+  " How can we get the user name on Windows?
+  if executable('whoami')
+    let whoami = systemlist('whoami')[0]
+    let first_letter = whoami[0]
+    if len(first_letter) > 0
+      " Trying completion of  :e ~x  where x is the first letter of
+      " the user name should complete to at least the user name.
+      call feedkeys(':e ~' . first_letter . "\<c-a>\<c-B>\"\<cr>", 'tx')
+      call assert_match('^"e \~.*\<' . whoami . '\>', @:)
+    endif
+  endif
+endfunc
+
+funct Test_cmdline_complete_languages()
+  let lang = substitute(execute('language messages'), '.*"\(.*\)"$', '\1', '')
+
+  call feedkeys(":language \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
+  call assert_match('^"language .*\<ctype\>.*\<messages\>.*\<time\>', @:)
+
+  call feedkeys(":language messages \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
+
+  call feedkeys(":language ctype \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
+
+  call feedkeys(":language time \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 endfunc
 
 func Test_cmdline_write_alternatefile()

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -393,7 +393,9 @@ endfunc
 
 func Test_cmdline_complete_user_names()
   if has('unix') && executable('whoami')
-    " TODO: can wk make this test work on Windows?
+    " TODO: user name completion is not yet implemented on Windows.
+    " See todo.txt: "Patch to support user name completion on
+    " MS-Windows. (Yasuhiro Matsumoto, 2012 Aug 16)".
     let whoami = systemlist('whoami')[0]
     let first_letter = whoami[0]
     if len(first_letter) > 0


### PR DESCRIPTION
This PR adds tests for completion of user names and languages
which were not tested according to codecov:

https://codecov.io/gh/vim/vim/src/33c5e9fa7af935c61a8aac461b9664c501003440/src/misc1.c#L4627
https://codecov.io/gh/vim/vim/src/33c5e9fa7af935c61a8aac461b9664c501003440/src/ex_cmds2.c#L5634


