### PR TITLE
Fixed duplicate entry in tagfiles() and added test

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -2680,6 +2680,7 @@ get_tagfname(
 	    ++tnp->tn_hf_idx;
 	    STRCPY(buf, p_hf);
 	    STRCPY(gettail(buf), "tags");
+	    simplify_filename(buf);
 
 	    for (i = 0; i < tag_fnames.ga_len; ++i)
 		if (STRCMP(buf, ((char_u **)(tag_fnames.ga_data))[i]) == 0)

--- a/src/tag.c
+++ b/src/tag.c
@@ -2605,8 +2605,16 @@ static void found_tagfile_cb(char_u *fname, void *cookie);
 found_tagfile_cb(char_u *fname, void *cookie UNUSED)
 {
     if (ga_grow(&tag_fnames, 1) == OK)
+    {
+	char_u	*tag_fname = vim_strsave(fname);
+
+#ifdef BACKSLASH_IN_FILENAME
+	slash_adjust(tag_fname);
+#endif
+	simplify_filename(tag_fname);
 	((char_u **)(tag_fnames.ga_data))[tag_fnames.ga_len++] =
-							   vim_strsave(fname);
+							vim_strsave(tag_fname);
+    }
 }
 
 #if defined(EXITFREE) || defined(PROTO)
@@ -2680,6 +2688,9 @@ get_tagfname(
 	    ++tnp->tn_hf_idx;
 	    STRCPY(buf, p_hf);
 	    STRCPY(gettail(buf), "tags");
+#ifdef BACKSLASH_IN_FILENAME
+	    slash_adjust(buf);
+#endif
 	    simplify_filename(buf);
 
 	    for (i = 0; i < tag_fnames.ga_len; ++i)

--- a/src/tag.c
+++ b/src/tag.c
@@ -2638,6 +2638,7 @@ get_tagfname(
 {
     char_u		*fname = NULL;
     char_u		*r_ptr;
+    int			i;
 
     if (first)
 	vim_memset(tnp, 0, sizeof(tagname_T));
@@ -2679,6 +2680,10 @@ get_tagfname(
 	    ++tnp->tn_hf_idx;
 	    STRCPY(buf, p_hf);
 	    STRCPY(gettail(buf), "tags");
+
+	    for (i = 0; i < tag_fnames.ga_len; ++i)
+		if (STRCMP(buf, ((char_u **)(tag_fnames.ga_data))[i]) == 0)
+		    return FAIL; /* Avoid duplicated tags file names */
 	}
 	else
 	    vim_strncpy(buf, ((char_u **)(tag_fnames.ga_data))[

--- a/src/testdir/test_taglist.vim
+++ b/src/testdir/test_taglist.vim
@@ -1,4 +1,4 @@
-" test 'taglist' function and :tags command
+" test taglist(), tagfiles() functions and :tags command
 
 func Test_taglist()
   call writefile([
@@ -60,4 +60,24 @@ endfunc
 func Test_tags_too_long()
   call assert_fails('tag ' . repeat('x', 1020), 'E426')
   tags
+endfunc
+
+func Test_tagfiles()
+  call assert_equal([], tagfiles())
+
+  call writefile(["FFoo\tXfoo\t1"], 'Xtags1')
+  call writefile(["FBar\tXbar\t1"], 'Xtags2')
+  set tags=Xtags1,Xtags2
+  call assert_equal(['Xtags1', 'Xtags2'], tagfiles())
+
+  help
+  call assert_equal(['../../runtime/doc/tags'], tagfiles())
+  helpclose
+  call assert_equal(['Xtags1', 'Xtags2'], tagfiles())
+  set tags&
+  call assert_equal([], tagfiles())
+
+  call delete('Xtags1')
+  call delete('Xtags2')
+  bd
 endfunc

--- a/src/testdir/test_taglist.vim
+++ b/src/testdir/test_taglist.vim
@@ -71,7 +71,10 @@ func Test_tagfiles()
   call assert_equal(['Xtags1', 'Xtags2'], tagfiles())
 
   help
-  call assert_equal(['../../runtime/doc/tags'], tagfiles())
+  let tf = tagfiles()
+  call assert_equal(1, len(tf))
+  call assert_equal(fnamemodify(expand('$VIMRUNTIME/doc/tags'), ':p:gs?\\?/?'),
+	\           fnamemodify(tf[0], ':p:gs?\\?/?'))
   helpclose
   call assert_equal(['Xtags1', 'Xtags2'], tagfiles())
   set tags&


### PR DESCRIPTION
This PR fixes a duplicate value in output of tagfiles().

How to reproduce:
```
$ vim --clean -c help -c 'echo tagfiles()'
```
It shows:
```
['/usr/local/share/vim/vim81/doc/tags', '/usr/local/share/vim/vim81/doc/tags']
```
Expected is:
```
['/usr/local/share/vim/vim81/doc/tags']
```
The tagfiles() function was also not covered with tests according
to codecov:

https://codecov.io/gh/vim/vim/src/c8523e2e6cd072d86a9412f465aa9eef53f5675e/src/evalfunc.c#L12741
