### PR TITLE
Added test for libcall() and libcallnr()

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -961,21 +961,20 @@ func Test_libcall_libcallnr()
     " will be skipped. Can we test libcall()/libcallnr() on macOs?
     let libs = split(glob('/lib/libc.so.[1-9]'), "\n")
           \  + split(glob('/lib64/libc.so.[1-9]'), "\n")
-    if len(libs) > 0
-      let libc = libs[-1]
+    if len(libs) == 0
+      return
     endif
+    let libc = libs[-1]
   endif
 
-  if !exists('libc') || len(libc) == 0
-    return
+  if has('win32')
+    call assert_equal($USERPROFILE, libcall(libc, 'getenv', 'USERPROFILE'))
+  else
+    call assert_equal($HOME, libcall(libc, 'getenv', 'HOME'))
   endif
-
-  let $X_TEST_ENV_VAR = 'foo'
-  call assert_equal('foo', libcall(libc, 'getenv', 'X_TEST_ENV_VAR'))
-  unlet $X_TEST_ENV_VAR
 
   " If function returns NULL, libcall() should return an empty string.
-  call assert_equal('', libcall(libc, 'getenv', 'X_TEST_ENV_DOES_NOT_EXIT'))
+  call assert_equal('', libcall(libc, 'getenv', 'X_ENV_DOES_NOT_EXIT'))
 
   " Test libcallnr() with string and integer argument.
   call assert_equal(4, libcallnr(libc, 'strlen', 'abcd'))

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -950,17 +950,19 @@ func Test_reg_executing_and_recording()
 endfunc
 
 func Test_libcall_libcallnr()
+  " TODO:
+  " - it should be possible to test libcall()/libcallnr() on Windows.
+  " - on macOs, the test will not find /lib64/libc.so.[1-9] so the test
+  "   will be skipped. Can we test libcall()/libcallnr() on macOs?
   if !has('unix') || !has('libcall')
-    " TODO: it should be possible to test libcall()/libcallnr() on Windows.
     return
   endif
 
-  let libc = split(glob('/lib64/libc.so.[1-9]'), "\n")[-1]
-  if len(libc) == 0
-     let libc = split(glob('/lib/libc.so.[1-9]'), "\n")[-1]
-  endif
+  let libs = split(glob('/lib/libc.so.[1-9]'), "\n")
+        \  + split(glob('/lib64/libc.so.[1-9]'), "\n")
+  if len(libs) > 0
+    let libc = libs[-1]
 
-  if len(libc) > 0
     let home = libcall(libc, 'getenv', 'HOME')
     call assert_equal($HOME, home)
 

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -956,15 +956,13 @@ func Test_libcall_libcallnr()
 
   if has('win32')
     let libc = 'msvcrt.dll'
+  elseif has('mac')
+    let libc = 'libSystem.B.dylib'
   else
-    " TODO: on macOs, the test will not find /lib64/libc.so.[1-9] so the test
-    " will be skipped. Can we test libcall()/libcallnr() on macOs?
-    let libs = split(glob('/lib/libc.so.[1-9]'), "\n")
-          \  + split(glob('/lib64/libc.so.[1-9]'), "\n")
-    if len(libs) == 0
-      return
-    endif
-    let libc = libs[-1]
+    " On Unix, libc.so can be in various places.
+    " Interestingly, using an empty string for the 1st argument of libcall
+    " allows to call functions from libc which is not documented.
+    let libc = ''
   endif
 
   if has('win32')

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -966,13 +966,13 @@ func Test_libcall_libcallnr()
     endif
   endif
 
-  if len(libc) == 0
+  if !exists('libc') || len(libc) == 0
     return
   endif
 
-  let $X_TEST_ENV_VAR_ = 'foo'
-  call assert_equal('foo', libcall(libc, 'getenv', 'X_TEST_ENV_VAR_'))
-  unlet $X_TEST_ENV_VAR_
+  let $X_TEST_ENV_VAR = 'foo'
+  call assert_equal('foo', libcall(libc, 'getenv', 'X_TEST_ENV_VAR'))
+  unlet $X_TEST_ENV_VAR
 
   " If function returns NULL, libcall() should return an empty string.
   call assert_equal('', libcall(libc, 'getenv', 'X_TEST_ENV_DOES_NOT_EXIT'))

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -948,3 +948,29 @@ func Test_reg_executing_and_recording()
   delfunc s:save_reg_stat
   unlet s:reg_stat
 endfunc
+
+func Test_libcall_libcallnr()
+  if !has('unix') || !has('libcall')
+    " TODO: it should be possible to test libcall()/libcallnr() on Windows.
+    return
+  endif
+
+  let libc = split(glob('/lib64/libc.so.[1-9]'), "\n")[-1]
+  if len(libc) == 0
+     let libc = split(glob('/lib/libc.so.[1-9]'), "\n")[-1]
+  endif
+
+  if len(libc) > 0
+    let home = libcall(libc, 'getenv', 'HOME')
+    call assert_equal($HOME, home)
+
+    let pid = libcallnr(libc, 'getpid', '')
+    call assert_equal(getpid(), pid)
+
+    call assert_fails("call libcall(libc, 'Xdoesnotexist_', '')", 'E364:')
+    call assert_fails("call libcallnr(libc, 'Xdoesnotexist_', '')", 'E364:')
+  endif
+
+  call assert_fails("call libcall('Xdoesnotexist_', 'getenv', 'HOME')", 'E364:')
+  call assert_fails("call libcall('Xdoesnotexist_', 'getpid', '')", 'E364:')
+endfunc


### PR DESCRIPTION
This PR adds tests for the libcall() and libcallnr() functions
which were not covered with tests according to codecov:

https://codecov.io/gh/vim/vim/src/6b810d92a9cd9378ab46ea0db07079cb789f9faa/src/os_unix.c#L7264
https://codecov.io/gh/vim/vim/src/6b810d92a9cd9378ab46ea0db07079cb789f9faa/src/evalfunc.c#L7229

I only enabled the tests on Linux as I don't know how these
functions can be tested on Windows. I'd appreciate if someone
who has windows can make the libcall/libcallnr test work on Windows.