### PR TITLE
Fix: Test_terminal_out_err could fail

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1503,8 +1503,8 @@ func Test_terminal_out_err()
 
   let outfile = 'Xtermstdout'
   let buf = term_start(['./Xechoerrout.sh'], {'out_io': 'file', 'out_name': outfile})
-  call WaitForAssert({-> assert_inrange(1, 2, len(readfile(outfile)))})
-  call assert_equal("this is standard out", readfile(outfile)[0])
+  call WaitFor({-> !empty(readfile(outfile)) && !empty(term_getline(buf, 1))})
+  call assert_equal(['this is standard out'], readfile(outfile))
   call assert_equal('this is standard error', term_getline(buf, 1))
 
   call WaitForAssert({-> assert_equal('dead', job_status(term_getjob(buf)))})


### PR DESCRIPTION
## Problem

`Test_terminal_out_err` in test_terminal could fail in cases such as below.

In `WaitForAssert`:

```
check the condition (`assert_inrange(1, 2, len(readfile(outfile)))`)
sleep 10m
(A)
check the condition
sleep 10m
(B)
check ...
...
```

When output of both err and out occur between `sleep` and checking the condition (as (A) or (B) or...),
Vim cannot receive the contents of err as of next `term_getline()`.

I think should call `term_wait()` right after `WaitForAssert` in order to ensure reading err at least once.