### PR TITLE
Fix: v:shell_error does not indicate the exit-status when do `:!cmd` with 'guioptions-!'

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4796,6 +4796,7 @@ mch_call_shell_terminal(
     long_u	cmdlen;
     int		retval = -1;
     buf_T	*buf;
+    job_T	*job;
     aco_save_T	aco;
     oparg_T	oa;		/* operator arguments */
 
@@ -4826,6 +4827,9 @@ mch_call_shell_terminal(
     if (buf == NULL)
 	return 255;
 
+    job = term_getjob(buf->b_term);
+    ++job->jv_refcount;
+
     /* Find a window to make "buf" curbuf. */
     aucmd_prepbuf(&aco, buf);
 
@@ -4842,8 +4846,10 @@ mch_call_shell_terminal(
 	else
 	    normal_cmd(&oa, TRUE);
     }
-    retval = 0;
+    retval = job->jv_exitval;
     ch_log(NULL, "system command finished");
+
+    job_unref(job);
 
     /* restore curwin/curbuf and a few other things */
     aucmd_restbuf(&aco);

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -55,5 +55,6 @@ void f_term_setkill(typval_T *argvars, typval_T *rettv);
 void f_term_start(typval_T *argvars, typval_T *rettv);
 void f_term_wait(typval_T *argvars, typval_T *rettv);
 void term_send_eof(channel_T *ch);
+job_T *term_getjob(term_T *term);
 int terminal_enabled(void);
 /* vim: set ft=c : */

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -5329,6 +5329,12 @@ term_send_eof(channel_T *ch)
 	}
 }
 
+    job_T *
+term_getjob(term_T *term)
+{
+    return term != NULL ? term->tl_job : NULL;
+}
+
 # if defined(WIN3264) || defined(PROTO)
 
 /**************************************

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1539,3 +1539,35 @@ func Test_terminwinscroll()
 
   exe buf . 'bwipe!'
 endfunc
+
+func Test_terminal_guioptions_bang()
+  if !has('gui_running')
+    return
+  endif
+  set guioptions+=!
+
+  let filename = 'Xtestscript'
+  if has('win32')
+    let filename .= '.bat'
+    let prefix = ''
+    let contents = ['@echo off', 'exit %1']
+  else
+    let filename .= '.sh'
+    let prefix = './'
+    let contents = ['#!/bin/sh', 'exit $1']
+  endif
+  call writefile(contents, filename)
+  call setfperm(filename, 'rwxrwx---')
+
+  " Check if v:shell_error is equal to the exit status.
+  let exitval = 0
+  execute printf(':!%s%s %d', prefix, filename, exitval)
+  call assert_equal(exitval, v:shell_error)
+
+  let exitval = 9
+  execute printf(':!%s%s %d', prefix, filename, exitval)
+  call assert_equal(exitval, v:shell_error)
+
+  set guioptions&
+  call delete(filename)
+endfunc


### PR DESCRIPTION
## Problem (reported by @Bakudankun)

When set `guioptions-!` and do `:!cmd`, `v:shell_error` is always 0 regardless of the exit-status of `cmd`.

## Repro steps

In unix-like environment,

`gvim --clean`

```vim
:set guioptions+=!
:!false
:echo v:shell_error
```

This shows

Expected: 1
Actual: 0

same as in Windows.

## Solution

* In `mch_call_shell_terminal()`, set `retval` to `exitval` of terminal-job