### PR TITLE
Provide a way to tell if a command is executed from i_CTRL-O or not

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6198,9 +6198,9 @@ mode([expr])	Return a string that indicates the current mode.
 
 			n	Normal, Terminal-Normal
 			no	Operator-pending
-			niI	Normal by |CTRL-O| from |Insert-mode|
-			niR	Normal by |CTRL-O| from |Replace-mode|
-			niV	Normal by |CTRL-O| from |Virtual-Replace-mode|
+			niI	Normal by |i_CTRL-O| from |Insert-mode|
+			niR	Normal by |i_CTRL-O| from |Replace-mode|
+			niV	Normal by |i_CTRL-O| from |Virtual-Replace-mode|
 			v	Visual by character
 			V	Visual by line
 			CTRL-V	Visual blockwise

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6198,6 +6198,7 @@ mode([expr])	Return a string that indicates the current mode.
 
 			n	Normal, Terminal-Normal
 			no	Operator-pending
+			nCTRL-Oi	Normal, triggered by |i_CTRL-O|
 			v	Visual by character
 			V	Visual by line
 			CTRL-V	Visual blockwise

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6198,7 +6198,9 @@ mode([expr])	Return a string that indicates the current mode.
 
 			n	Normal, Terminal-Normal
 			no	Operator-pending
-			nCTRL-Oi	Normal, triggered by |i_CTRL-O|
+			niI	Normal by |CTRL-O| from |Insert-mode|
+			niR	Normal by |CTRL-O| from |Replace-mode|
+			niV	Normal by |CTRL-O| from |Virtual-Replace-mode|
 			v	Visual by character
 			V	Visual by line
 			CTRL-V	Visual blockwise

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8381,10 +8381,10 @@ f_mode(typval_T *argvars, typval_T *rettv)
 	buf[0] = 'n';
 	if (finish_op)
 	    buf[1] = 'o';
-	else if (restart_edit == 'I')
+	else if (restart_edit == 'I' || restart_edit == 'R' || restart_edit == 'V')
 	{
-		buf[1] = 'i';
-		buf[2] = 'I';
+	    buf[1] = 'i';
+	    buf[2] = restart_edit;
 	}
     }
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8315,9 +8315,7 @@ f_mode(typval_T *argvars, typval_T *rettv)
 {
     char_u	buf[4];
 
-    buf[1] = NUL;
-    buf[2] = NUL;
-    buf[3] = NUL;
+    vim_memset(buf, 0, sizeof(buf));
 
     if (time_for_testing == 93784)
     {
@@ -8384,7 +8382,8 @@ f_mode(typval_T *argvars, typval_T *rettv)
 
 	if (finish_op)
 	    buf[1] = 'o';
-	else if (restart_edit == 'I') {
+	else if (restart_edit == 'I')
+	{
 		buf[1] = Ctrl_O;
 		buf[2] = 'i';
 	}
@@ -8392,9 +8391,9 @@ f_mode(typval_T *argvars, typval_T *rettv)
 
     /* Clear out the minor mode when the argument is not a non-zero number or
      * non-empty string.  */
-    if (!non_zero_arg(&argvars[0])) {
+    if (!non_zero_arg(&argvars[0]))
+    {
 	buf[1] = NUL;
-	buf[2] = NUL;
     }
 
     rettv->vval.v_string = vim_strsave(buf);

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8379,7 +8379,6 @@ f_mode(typval_T *argvars, typval_T *rettv)
     else
     {
 	buf[0] = 'n';
-
 	if (finish_op)
 	    buf[1] = 'o';
 	else if (restart_edit == 'I')
@@ -8392,9 +8391,7 @@ f_mode(typval_T *argvars, typval_T *rettv)
     /* Clear out the minor mode when the argument is not a non-zero number or
      * non-empty string.  */
     if (!non_zero_arg(&argvars[0]))
-    {
 	buf[1] = NUL;
-    }
 
     rettv->vval.v_string = vim_strsave(buf);
     rettv->v_type = VAR_STRING;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8383,8 +8383,8 @@ f_mode(typval_T *argvars, typval_T *rettv)
 	    buf[1] = 'o';
 	else if (restart_edit == 'I')
 	{
-		buf[1] = Ctrl_O;
-		buf[2] = 'i';
+		buf[1] = 'i';
+		buf[2] = 'I';
 	}
     }
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8313,10 +8313,11 @@ f_mkdir(typval_T *argvars, typval_T *rettv)
     static void
 f_mode(typval_T *argvars, typval_T *rettv)
 {
-    char_u	buf[3];
+    char_u	buf[4];
 
     buf[1] = NUL;
     buf[2] = NUL;
+    buf[3] = NUL;
 
     if (time_for_testing == 93784)
     {
@@ -8380,14 +8381,21 @@ f_mode(typval_T *argvars, typval_T *rettv)
     else
     {
 	buf[0] = 'n';
+
 	if (finish_op)
 	    buf[1] = 'o';
+	else if (restart_edit == 'I') {
+		buf[1] = Ctrl_O;
+		buf[2] = 'i';
+	}
     }
 
     /* Clear out the minor mode when the argument is not a non-zero number or
      * non-empty string.  */
-    if (!non_zero_arg(&argvars[0]))
+    if (!non_zero_arg(&argvars[0])) {
 	buf[1] = NUL;
+	buf[2] = NUL;
+    }
 
     rettv->vval.v_string = vim_strsave(buf);
     rettv->v_type = VAR_STRING;

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -464,6 +464,10 @@ func Test_mode()
   call assert_equal('n', mode(0))
   call assert_equal('n', mode(1))
 
+  " i_CTRL-O
+  exe "normal i\<C-O>:call Save_mode()\<Cr>\<Esc>"
+  call assert_equal("n-n\<C-o>i", g:current_modes)
+
   " How to test operator-pending mode?
 
   call feedkeys("v", 'xt')

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -468,6 +468,14 @@ func Test_mode()
   exe "normal i\<C-O>:call Save_mode()\<Cr>\<Esc>"
   call assert_equal("n-niI", g:current_modes)
 
+  " R_CTRL-O
+  exe "normal R\<C-O>:call Save_mode()\<Cr>\<Esc>"
+  call assert_equal("n-niR", g:current_modes)
+
+  " gR_CTRL-O
+  exe "normal gR\<C-O>:call Save_mode()\<Cr>\<Esc>"
+  call assert_equal("n-niV", g:current_modes)
+
   " How to test operator-pending mode?
 
   call feedkeys("v", 'xt')

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -466,7 +466,7 @@ func Test_mode()
 
   " i_CTRL-O
   exe "normal i\<C-O>:call Save_mode()\<Cr>\<Esc>"
-  call assert_equal("n-n\<C-o>i", g:current_modes)
+  call assert_equal("n-niI", g:current_modes)
 
   " How to test operator-pending mode?
 


### PR DESCRIPTION
## Problem

A user-defined command cannot tell if it's executed as an Ex command, or as `i_CTRL-O` from insert mode. This makes it hard to implement some Vim plugins, such as one that inserts text into the buffer with adjusting contents depending on its context.

Example use case: https://github.com/koron/iferr `:IfErr` command inserts a Go code snippet at the next line of the cursor. Currently users have to `<Esc>` to go back to normal mode, because it doesn't provide intuitive and natural output when you either use `i_CTRL-O` directly or as a key mapping to run that command.

## Solution

Let `mode(1)` return `"n\<CTRL-O>i"` if it's from `i_CTRL-O`

I believe it's natural because Vim plugin authors should be already used to use either the following approach

* `mode() ==# 'n'`
* `mode(1) =~# '^n'`