### PR TITLE
Make sure QuickFixCmd autocommands are triggered by :ltag

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -927,7 +927,7 @@ QuickFixCmdPre			Before a quickfix command is run (|:make|,
 				|:lgetfile|, |:laddfile|, |:helpgrep|,
 				|:lhelpgrep|, |:cexpr|, |:cgetexpr|,
 				|:caddexpr|, |:cbuffer|, |:cgetbuffer|,
-				|:caddbuffer|).
+				|:caddbuffer|,|:ltag|).
 				The pattern is matched against the command
 				being run.  When |:grep| is used but 'grepprg'
 				is set to "internal" it still matches "grep".

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -927,7 +927,7 @@ QuickFixCmdPre			Before a quickfix command is run (|:make|,
 				|:lgetfile|, |:laddfile|, |:helpgrep|,
 				|:lhelpgrep|, |:cexpr|, |:cgetexpr|,
 				|:caddexpr|, |:cbuffer|, |:cgetbuffer|,
-				|:caddbuffer|,|:ltag|).
+				|:caddbuffer|, |:ltag|).
 				The pattern is matched against the command
 				being run.  When |:grep| is used but 'grepprg'
 				is set to "internal" it still matches "grep".

--- a/src/tag.c
+++ b/src/tag.c
@@ -631,6 +631,16 @@ do_tag(
 	    {
 		if (add_llist_tags(tag, num_matches, matches) == FAIL)
 		    goto end_do_tag;
+		/*
+		 * Trigger QuickFixCmdPre autocommand.
+		 */
+		if (apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)"ltag",
+		                                    curbuf->b_fname, TRUE, curbuf))
+		{
+		    if (aborting())
+		        return FALSE;
+		}
+
 		cur_match = 0;		/* Jump to the first tag */
 	    }
 #endif
@@ -751,6 +761,15 @@ do_tag(
 	     * Jump to the desired match.
 	     */
 	    i = jumpto_tag(matches[cur_match], forceit, type != DT_CSCOPE);
+
+	    /*
+	     * Trigger QuickFixCmdPost autocommand.
+	     */
+#if defined(FEAT_QUICKFIX)
+	    if (type == DT_LTAG)
+		apply_autocmds(EVENT_QUICKFIXCMDPOST, (char_u *)"ltag",
+		                                curbuf->b_fname, TRUE, curbuf);
+#endif
 
 #if defined(FEAT_EVAL)
 	    set_vim_var_string(VV_SWAPCOMMAND, NULL, -1);

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -2176,15 +2176,11 @@ func QfAutoCmdHandler(loc, cmd)
 endfunc
 
 func Test_Autocmd()
-
   set tags=Xtags
   call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//",
         \ "one\tXfile1\t/^one/;\"\tf\tfile:\tsignature:(void)"],
         \ 'Xtags')
-  new Xfile1
-  call setline(1, ['empty', 'one()', 'empty'])
-  write
-  bwipe!
+  call writefile(['empty', 'one()', 'empty'], 'Xfile1')
 
   autocmd QuickFixCmdPre * call QfAutoCmdHandler('pre', expand('<amatch>'))
   autocmd QuickFixCmdPost * call QfAutoCmdHandler('post', expand('<amatch>'))

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -2176,6 +2176,16 @@ func QfAutoCmdHandler(loc, cmd)
 endfunc
 
 func Test_Autocmd()
+
+  set tags=Xtags
+  call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//",
+        \ "one\tXfile1\t/^one/;\"\tf\tfile:\tsignature:(void)"],
+        \ 'Xtags')
+  new Xfile1
+  call setline(1, ['empty', 'one()', 'empty'])
+  write
+  bwipe!
+
   autocmd QuickFixCmdPre * call QfAutoCmdHandler('pre', expand('<amatch>'))
   autocmd QuickFixCmdPost * call QfAutoCmdHandler('post', expand('<amatch>'))
 
@@ -2189,6 +2199,7 @@ func Test_Autocmd()
   silent! cexpr non_existing_func()
   silent! caddexpr non_existing_func()
   silent! cgetexpr non_existing_func()
+  ltag one
   let l = ['precexpr',
 	      \ 'postcexpr',
 	      \ 'precaddexpr',
@@ -2203,8 +2214,14 @@ func Test_Autocmd()
 	      \ 'postcgetexpr',
 	      \ 'precexpr',
 	      \ 'precaddexpr',
-	      \ 'precgetexpr']
+	      \ 'precgetexpr',
+	      \ 'preltag',
+	      \ 'postltag']
   call assert_equal(l, g:acmds)
+
+  set tags&
+  call delete('Xtags')
+  call delete('Xfile1')
 
   let g:acmds = []
   enew! | call append(0, "F2:10:Line 10")


### PR DESCRIPTION
## Problem

Autocommands `QuickFixCmdPre` and `QuickFixCmdPost` are not triggered when performing `:ltag`.

## Solution

Trigger these autocommands when performing `:ltag`.