### PR TITLE
Move cursor to the leftmost column of window when scrolling if left margin is used.

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -9794,6 +9794,7 @@ screen_ins_lines(
     int		j;
     unsigned	temp;
     int		cursor_row;
+    int		cursor_col = 0;
     int		type;
     int		result_empty;
     int		can_ce = can_clear(T_CE);
@@ -9890,6 +9891,10 @@ screen_ins_lines(
     gui_dont_update_cursor(row + off <= gui.cursor_row);
 #endif
 
+    if (wp != NULL && wp->w_wincol != 0 && *T_CSV != NUL && *T_CCS == NUL) {
+	cursor_col = wp->w_wincol;
+    }
+
     if (*T_CCS != NUL)	   /* cursor relative to region */
 	cursor_row = row;
     else
@@ -9936,7 +9941,7 @@ screen_ins_lines(
     }
 
     screen_stop_highlight();
-    windgoto(cursor_row, 0);
+    windgoto(cursor_row, cursor_col);
     if (clear_attr != 0)
 	screen_start_highlight(clear_attr);
 
@@ -9955,7 +9960,7 @@ screen_ins_lines(
 	    if (type == USE_T_AL)
 	    {
 		if (i && cursor_row != 0)
-		    windgoto(cursor_row, 0);
+		    windgoto(cursor_row, cursor_col);
 		out_str(T_AL);
 	    }
 	    else  /* type == USE_T_SR */
@@ -9972,7 +9977,7 @@ screen_ins_lines(
     {
 	for (i = 0; i < line_count; ++i)
 	{
-	    windgoto(off + i, 0);
+	    windgoto(off + i, cursor_col);
 	    out_str(T_CE);
 	    screen_start();	    /* don't know where cursor is now */
 	}
@@ -10008,6 +10013,7 @@ screen_del_lines(
     int		i;
     unsigned	temp;
     int		cursor_row;
+    int		cursor_col = 0;
     int		cursor_end;
     int		result_empty;	/* result is empty until end of region */
     int		can_delete;	/* deleting line codes can be used */
@@ -10107,6 +10113,10 @@ screen_del_lines(
 						&& gui.cursor_row < end + off);
 #endif
 
+    if (wp != NULL && wp->w_wincol != 0 && *T_CSV != NUL && *T_CCS == NUL) {
+	cursor_col = wp->w_wincol;
+    }
+
     if (*T_CCS != NUL)	    /* cursor relative to region */
     {
 	cursor_row = row;
@@ -10169,13 +10179,13 @@ screen_del_lines(
 	redraw_block(row, end, wp);
     else if (type == USE_T_CD)	/* delete the lines */
     {
-	windgoto(cursor_row, 0);
+	windgoto(cursor_row, cursor_col);
 	out_str(T_CD);
 	screen_start();			/* don't know where cursor is now */
     }
     else if (type == USE_T_CDL)
     {
-	windgoto(cursor_row, 0);
+	windgoto(cursor_row, cursor_col);
 	term_delete_lines(line_count);
 	screen_start();			/* don't know where cursor is now */
     }
@@ -10186,7 +10196,7 @@ screen_del_lines(
      */
     else if (type == USE_NL)
     {
-	windgoto(cursor_end - 1, 0);
+	windgoto(cursor_end - 1, cursor_col);
 	for (i = line_count; --i >= 0; )
 	    out_char('\n');		/* cursor will remain on same line */
     }
@@ -10196,12 +10206,12 @@ screen_del_lines(
 	{
 	    if (type == USE_T_DL)
 	    {
-		windgoto(cursor_row, 0);
+		windgoto(cursor_row, cursor_col);
 		out_str(T_DL);		/* delete a line */
 	    }
 	    else /* type == USE_T_CE */
 	    {
-		windgoto(cursor_row + i, 0);
+		windgoto(cursor_row + i, cursor_col);
 		out_str(T_CE);		/* erase a line */
 	    }
 	    screen_start();		/* don't know where cursor is now */
@@ -10216,7 +10226,7 @@ screen_del_lines(
     {
 	for (i = line_count; i > 0; --i)
 	{
-	    windgoto(cursor_end - i, 0);
+	    windgoto(cursor_end - i, cursor_col);
 	    out_str(T_CE);		/* erase a line */
 	    screen_start();		/* don't know where cursor is now */
 	}


### PR DESCRIPTION
If cursor is in the outside of margin, VT525 and xterm ignore some control sequences (e.g. IL, DL).

Following setting enables to use right and left margin when scrolling.
```
let &t_ti .= "\e[?69h"
let &t_te .= "\e7\e[?69l\e8"
let &t_CV = "\e[%i%p1%d;%p2%ds"
```

But xterm (and VT525) does not scroll correctly if window is not leftmost in screen.
This patch fixes this problem.