### PR TITLE
Add "Vim—The editor" logo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 `README.md` for version 8.1 of Vim: Vi IMproved.
 
+![Vim Logo](https://www.vim.org/images/vim_editor.gif)
+
 [![Build Status](https://travis-ci.org/vim/vim.svg?branch=master)](https://travis-ci.org/vim/vim)
 [![Coverage Status](https://codecov.io/gh/vim/vim/coverage.svg?branch=master)](https://codecov.io/gh/vim/vim?branch=master)
 [![Coverage Status](https://coveralls.io/repos/vim/vim/badge.svg?branch=master&service=github)](https://coveralls.io/github/vim/vim?branch=master)
 [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/o2qht2kjm02sgghk?svg=true)](https://ci.appveyor.com/project/chrisbra/vim)
 [![Coverity Scan](https://scan.coverity.com/projects/241/badge.svg)](https://scan.coverity.com/projects/vim)
 [![Debian CI](https://badges.debian.net/badges/debian/testing/vim/version.svg)](https://buildd.debian.org/vim)
-
 
 ## What is Vim? ##
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 `README.md` for version 8.1 of Vim: Vi IMproved.
 
-![Vim Logo](https://www.vim.org/images/vim_editor.gif)
+![Vim Logo](https://github.com/vim/vim/blob/master/runtime/vimlogo.gif)
 
 [![Build Status](https://travis-ci.org/vim/vim.svg?branch=master)](https://travis-ci.org/vim/vim)
 [![Coverage Status](https://codecov.io/gh/vim/vim/coverage.svg?branch=master)](https://codecov.io/gh/vim/vim?branch=master)


### PR DESCRIPTION
The official logo hosted at www.vim.org is used. This is not a signifigant change, but I think it really adds some asthetic to the README.