### PR TITLE
Add WASM syntax highlighting

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1763,6 +1763,9 @@ au BufNewFile,BufRead *.wrl			setf vrml
 " Vroom (vim testing and executable documentation)
 au BufNewFile,BufRead *.vroom			setf vroom
 
+" WebAssembly
+autocmd BufNewFile,BufReadPost *.wast,*.wat	setf wast
+
 " Webmacro
 au BufNewFile,BufRead *.wm			setf webmacro
 

--- a/runtime/ftplugin/wasm.vim
+++ b/runtime/ftplugin/wasm.vim
@@ -1,0 +1,13 @@
+if exists("b:did_ftplugin")
+    finish
+endif
+
+setl comments=:;
+setl define=^\\s*(\\%(func\\|module\\)\\s\\+
+setl formatoptions-=t
+setl lisp
+setl commentstring=;%s
+setl comments^=:;;;,:;;
+setl iskeyword+=$,.
+
+let b:undo_ftplugin = "setlocal comments< define< formatoptions< lisp< commentstring< iskeyword<"

--- a/runtime/indent/wasm.vim
+++ b/runtime/indent/wasm.vim
@@ -1,0 +1,11 @@
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+
+setlocal comments=:;
+setlocal commentstring=;%s
+setlocal formatoptions-=t
+setlocal lisp
+
+let b:undo_indent = "setl comments< commentstring< formatoptions< lisp<"

--- a/runtime/syntax/wasm.vim
+++ b/runtime/syntax/wasm.vim
@@ -1,3 +1,7 @@
+" Vim syntax file
+" Author: @rhysd (www.github.com/rhysd)
+" Language: WebAssembly
+
 if exists("b:current_syntax")
   finish
 endif

--- a/runtime/syntax/wasm.vim
+++ b/runtime/syntax/wasm.vim
@@ -1,0 +1,32 @@
+if exists("b:current_syntax")
+  finish
+endif
+
+syn cluster wastCluster       contains=wastModuleKeyword,wastInst,wastString,wastNamedVar,wastUnnamedVar,wastFloat,wastNumber,wastComment,wastList
+syn keyword wastModuleKeyword module export func contained
+syn match   wastInst          "\%((\s*\)\@<=\<[[:alnum:]_.]\+\>" contained display
+syn match   wastNamedVar      "$\@<!$[^$][^[:space:])]*" contained display
+syn match   wastUnnamedVar    "$$\d\+" contained display
+syn region  wastString        start=+"+ skip=+\\\\\|\\"+ end=+"+
+syn match   wastFloat         "\d\+\.\d*\(e[-+]\=\d\+\)\=[fl]\=" display contained
+syn match   wastFloat         "\.\d\+\(e[-+]\=\d\+\)\=[fl]\=\>" display contained
+syn match   wastFloat         "\d\+e[-+]\=\d\+[fl]\=\>" display contained
+syn match   wastNumber        "\<\d\+\>" display contained
+syn match   wastNumber        "\<0x\x\+\>" display contained
+syn match   wastNumber        "\<0o\o\+\>" display contained
+syn region  wastComment       start=";" end="$" display
+syn region  wastList          matchgroup=wastListDelimiter start="(" matchgroup=wastListDelimiter end=")" contains=@wastCluster
+
+syn sync lines=100
+
+hi def link wastModuleKeyword PreProc
+hi def link wastListDelimiter Delimiter
+hi def link wastInst          Statement
+hi def link wastString        String
+hi def link wastNamedVar      Identifier
+hi def link wastUnnamedVar    PreProc
+hi def link wastFloat         Float
+hi def link wastNumber        Number
+hi def link wastComment       Comment
+
+let b:current_syntax = "wast"


### PR DESCRIPTION
Code was copied from https://github.com/rhysd/vim-wasm. I believe that we should add this is it negates the need for an external plugin. You may consider changing the wasm.vim files to wast.vim files as wast was set in the filetype.vim file.