### PR TITLE
Fix test_prompt_buffer (after 8.1.91)

### DIFF
--- a/src/testdir/test_prompt_buffer.vim
+++ b/src/testdir/test_prompt_buffer.vim
@@ -24,6 +24,8 @@ func WriteScript(name)
   call writefile([
 	\ 'func TextEntered(text)',
 	\ '  if a:text == "exit"',
+	\ '    " Reset &modified to allow the buffer to be closed.',
+	\ '    set nomodified',
 	\ '    stopinsert',
 	\ '    close',
 	\ '  else',


### PR DESCRIPTION
Patch 8.1.0091 (https://github.com/vim/vim/commit/4551c0a9fcdbdef52836d4852686d54b5e47fdaf) causes tests in test_prompt_buffer.vim fail.
https://travis-ci.org/vim/vim/builds/394738008

In bufIsChangedNotTerm():
> // In a "prompt" buffer we do respect 'modified', so that we can control
> // closing the window by setting or resetting that option.

It should modify test script.