### PR TITLE
Set curswant when setting the cursor position

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -1217,6 +1217,7 @@ luaV_window_newindex (lua_State *L)
 	luaV_checksandbox(L);
 #endif
 	w->w_cursor.col = v - 1;
+	w->w_set_curswant = TRUE;
 	update_screen(VALID);
     }
     else if (strncmp(s, "width", 5) == 0)

--- a/src/if_mzsch.c
+++ b/src/if_mzsch.c
@@ -2132,6 +2132,7 @@ set_cursor(void *data, int argc, Scheme_Object **argv)
 
     win->win->w_cursor.lnum = lnum;
     win->win->w_cursor.col = col;
+    win->win->w_set_curswant = TRUE;
     update_screen(VALID);
 
     raise_if_error();

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -1660,6 +1660,7 @@ Cursor(win, ...)
       col = (int) SvIV(ST(2));
       win->w_cursor.lnum = lnum;
       win->w_cursor.col = col;
+      win->w_set_curswant = TRUE;
       check_cursor();		    /* put cursor on an existing line */
       update_screen(NOT_VALID);
     }

--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -3945,6 +3945,7 @@ WindowSetattr(WindowObject *self, char *name, PyObject *valObject)
 
 	self->win->w_cursor.lnum = lnum;
 	self->win->w_cursor.col = col;
+	self->win->w_set_curswant = TRUE;
 #ifdef FEAT_VIRTUALEDIT
 	self->win->w_cursor.coladd = 0;
 #endif

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -1514,6 +1514,7 @@ static VALUE window_set_cursor(VALUE self, VALUE pos)
     col = RARRAY_PTR(pos)[1];
     win->w_cursor.lnum = NUM2LONG(lnum);
     win->w_cursor.col = NUM2UINT(col);
+    win->w_set_curswant = TRUE;
     check_cursor();		    /* put cursor on an existing line */
     update_screen(NOT_VALID);
     return Qnil;

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -1091,6 +1091,7 @@ winselfcmd(
 	    /* TODO: should check column */
 	    win->w_cursor.lnum = val1;
 	    win->w_cursor.col = col2vim(val2);
+	    win->w_set_curswant = TRUE;
 	    flags |= FL_UPDATE_SCREEN;
 	    break;
 

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -20,3 +20,20 @@ func Test_luado()
   bwipe!
   bwipe!
 endfunc
+
+func Test_set_cursor()
+  " Check that setting the cursor position works.
+  new
+  call setline(1, ['first line', 'second line'])
+  normal gg
+  lua << EOF
+w = vim.window()
+w.line = 1
+w.col = 5
+EOF
+  call assert_equal([1, 5], [line('.'), col('.')])
+
+  " Check that movement after setting cursor position keeps current column.
+  normal j
+  call assert_equal([2, 5], [line('.'), col('.')])
+endfunc

--- a/src/testdir/test_perl.vim
+++ b/src/testdir/test_perl.vim
@@ -236,3 +236,16 @@ func Test_SvREFCNT()
   VIM::Eval("assert_false($$w)");
 --perl
 endfunc
+
+func Test_set_cursor()
+  " Check that setting the cursor position works.
+  new
+  call setline(1, ['first line', 'second line'])
+  normal gg
+  perldo $curwin->Cursor(1, 5)
+  call assert_equal([1, 6], [line('.'), col('.')])
+
+  " Check that movement after setting cursor position keeps current column.
+  normal j
+  call assert_equal([2, 6], [line('.'), col('.')])
+endfunc

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -22,3 +22,17 @@ func Test_pydo()
   bwipe!
   bwipe!
 endfunc
+
+func Test_set_cursor()
+  " Check that setting the cursor position works.
+  py import vim
+  new
+  call setline(1, ['first line', 'second line'])
+  normal gg
+  pydo vim.current.window.cursor = (1, 5)
+  call assert_equal([1, 6], [line('.'), col('.')])
+
+  " Check that movement after setting cursor position keeps current column.
+  normal j
+  call assert_equal([2, 6], [line('.'), col('.')])
+endfunc

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -1,4 +1,4 @@
-" Test for python 2 commands.
+" Test for python 3 commands.
 " TODO: move tests from test88.in here.
 
 if !has('python3')
@@ -21,4 +21,18 @@ func Test_py3do()
   call assert_equal(wincount + 1, winnr('$'))
   bwipe!
   bwipe!
+endfunc
+
+func Test_set_cursor()
+  " Check that setting the cursor position works.
+  py3 import vim
+  new
+  call setline(1, ['first line', 'second line'])
+  normal gg
+  py3do vim.current.window.cursor = (1, 5)
+  call assert_equal([1, 6], [line('.'), col('.')])
+
+  " Check that movement after setting cursor position keeps current column.
+  normal j
+  call assert_equal([2, 6], [line('.'), col('.')])
 endfunc

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -57,3 +57,16 @@ func Test_rubyfile()
   call assert_fails('rubyfile ' . tempfile)
   call delete(tempfile)
 endfunc
+
+func Test_set_cursor()
+  " Check that setting the cursor position works.
+  new
+  call setline(1, ['first line', 'second line'])
+  normal gg
+  rubydo $curwin.cursor = [1, 5]
+  call assert_equal([1, 6], [line('.'), col('.')])
+
+  " Check that movement after setting cursor position keeps current column.
+  normal j
+  call assert_equal([2, 6], [line('.'), col('.')])
+endfunc

--- a/src/testdir/test_tcl.vim
+++ b/src/testdir/test_tcl.vim
@@ -21,3 +21,15 @@ function Test_tcldo()
   bwipe!
 endfunc
 
+func Test_set_cursor()
+  " Check that setting the cursor position works.
+  new
+  call setline(1, ['first line', 'second line'])
+  normal gg
+  tcldo $::vim::current(window) cursor 1 5
+  call assert_equal([1, 5], [line('.'), col('.')])
+
+  " Check that movement after setting cursor position keeps current column.
+  normal j
+  call assert_equal([2, 5], [line('.'), col('.')])
+endfunc


### PR DESCRIPTION
APIs that set the cursor position should also set `w_curswant` - else subsequent movements unexpectedly cause the cursor to revert to whatever column it was previously in.

cf neovim/neovim#8591

I'd be willing to extend existing testcases to cover this - but I couldn't find them...?