### PR TITLE
Function getcmdwintype() was not tested

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -511,6 +511,22 @@ func Test_getcmdtype()
   cunmap <F6>
 endfunc
 
+func Test_getcmdwintype()
+  call feedkeys("q/:let a = getcmdwintype()\<CR>:q\<CR>", 'x!')
+  call assert_equal('/', a)
+
+  call feedkeys("q?:let a = getcmdwintype()\<CR>:q\<CR>", 'x!')
+  call assert_equal('?', a)
+
+  call feedkeys("q::let a = getcmdwintype()\<CR>:q\<CR>", 'x!')
+  call assert_equal(':', a)
+
+  call feedkeys(":\<C-F>:let a = getcmdwintype()\<CR>:q\<CR>", 'x!')
+  call assert_equal(':', a)
+
+  call assert_equal('', getcmdwintype())
+endfunc
+
 func Test_verbosefile()
   set verbosefile=Xlog
   echomsg 'foo'


### PR DESCRIPTION
This PR adds a test for function getcmdwintype() which
was not tested according to codecov:
https://codecov.io/gh/vim/vim/src/5efa0102de6ed6049fb19e1e83787e5b3b24b6a2/src/evalfunc.c#L4837