### PR TITLE
Change URL from vim.sf.net to www.vim.org

### DIFF
--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -1878,7 +1878,7 @@ install_start_menu(int idx)
 	add_pathsep(shell_folder_path);
 	strcat(shell_folder_path, "Vim Online.url");
 	if (!WritePrivateProfileString("InternetShortcut", "URL",
-				     "http://vim.sf.net/", shell_folder_path))
+				     "https://www.vim.org/", shell_folder_path))
 	{
 	    printf("Creating the Vim online URL failed\n");
 	    return;


### PR DESCRIPTION
http://vim.sf.net/ redirects to
https://vim.sourceforge.io/ which redirects to
https://vim8.org/ but im guessing 
https://www.vim.org/ is the prefered URL.
I wrote https with s because http://www.vim.org/ redirects to https://www.vim.org/