### PR TITLE
update po headers as per scootergrisen request

### DIFF
--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -1,5 +1,4 @@
-# translation of pl.po to Polish
-# Polish Translation for Vim
+# Polish translation for Vim
 #
 # updated 2013 for vim-7.4
 #
@@ -12,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2013-07-06 19:33+0200\n"
 "PO-Revision-Date: 2010-08-10 18:15+0200\n"
 "Last-Translator: Mikolaj Machowski <mikmach@wp.pl>\n"
-"Language-Team: \n"
+"Language-Team: Polish\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -1,5 +1,4 @@
-# translation of pl.po to Polish
-# Polish Translation for Vim
+# Polish translation for Vim
 #
 # updated 2013 for vim-7.4
 #
@@ -12,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2013-07-06 19:33+0200\n"
 "PO-Revision-Date: 2010-08-10 18:15+0200\n"
 "Last-Translator: Mikolaj Machowski <mikmach@wp.pl>\n"
-"Language-Team: \n"
+"Language-Team: Polish\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=cp1250\n"

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -1,5 +1,4 @@
-# translation of pl.po to Polish
-# Polish Translation for Vim
+# Polish translation for Vim
 #
 # updated 2013 for vim-7.4
 #
@@ -12,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2013-07-06 19:33+0200\n"
 "PO-Revision-Date: 2010-08-10 18:15+0200\n"
 "Last-Translator: Mikolaj Machowski <mikmach@wp.pl>\n"
-"Language-Team: \n"
+"Language-Team: Polish\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-2\n"


### PR DESCRIPTION
As an official translator of Vim updated headers of po files for Polish (all three encodings: UTF-8, cp1250, iso-8859-2) as per scootergrisen suggestions.