### PR TITLE
Fix that recent test_lua fails on Windows

### DIFF
--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -305,7 +305,7 @@ func Test_list()
   lua l:add(vim.eval("{'a':1, 'b':2, 'c':3}"))
   call assert_equal([123.0, 'abc', v:true, v:false, [1, 2, 3], {'a': 1, 'b': 2, 'c': 3}], l)
   call assert_equal(6.0, luaeval('#l'))
-  call assert_match('^list: 0x\x\+$', luaeval('tostring(l)'))
+  call assert_match('^list: \%(0x\)\?\x\+$', luaeval('tostring(l)'))
 
   lua l[0] = 124
   lua l[4] = nil
@@ -358,7 +358,7 @@ func Test_recursive_list()
 
   call assert_equal('[1.0, 2.0, [...]]', string(luaeval('l')))
 
-  call assert_match('^list: 0x\x\+$', luaeval('tostring(l)'))
+  call assert_match('^list: \%(0x\)\?\x\+$', luaeval('tostring(l)'))
   call assert_equal(luaeval('tostring(l)'), luaeval('tostring(l[2])'))
 
   call assert_equal(luaeval('l'), luaeval('l[2]'))
@@ -380,7 +380,7 @@ func Test_dict()
   lua d[5] = vim.eval("{'a':1, 'b':2, 'c':3}")
   call assert_equal({'0':123.0, '1':'abc', '2':v:true, '3':v:false, '4': [1, 2, 3], '5': {'a':1, 'b':2, 'c':3}}, d)
   call assert_equal(6.0, luaeval('#d'))
-  call assert_match('^dict: 0x\x\+$', luaeval('tostring(d)'))
+  call assert_match('^dict: \%(0x\)\?\x\+$', luaeval('tostring(d)'))
 
   call assert_equal('abc', luaeval('d[1]'))
 


### PR DESCRIPTION
v8.1.0137 on vim-win32-installer fails as follows:
https://ci.appveyor.com/project/chrisbra/vim-win32-installer/build/job/if4ko9mowkpt3ra4#L1465

```
Found errors in Test_dict():
function RunTheTest[40]..Test_dict line 13: Pattern '^dict: 0x\\x\\+$' does not match 'dict: 0000000002a88928'
Found errors in Test_list():
function RunTheTest[40]..Test_list line 13: Pattern '^list: 0x\\x\\+$' does not match 'list: 0000000002a81758'
Found errors in Test_recursive_list():
function RunTheTest[40]..Test_recursive_list line 15: Pattern '^list: 0x\\x\\+$' does not match 'list: 0000000002a80e18'
```

It seems that `tostring()` in some versions of lua returns an address
without the `0x` prefix.
Change the tests to accept them.