### PR TITLE
Create menu_da.latin1.vim

### DIFF
--- a/runtime/lang/menu_da.latin1.vim
+++ b/runtime/lang/menu_da.latin1.vim
@@ -1,0 +1,3 @@
+" Menu Translations:	Danish
+
+source <sfile>:p:h/menu_da.utf-8.vim


### PR DESCRIPTION
I don't know if this is correct.
It just seems to use the utf-8 file but does it still not just use UTF-8 encoding?