### PR TITLE
Fixed memory leak when doing :tcl ::vim::expr 2

### DIFF
--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -1385,7 +1385,10 @@ tclvimexpr(
     if (str == NULL)
 	Tcl_SetResult(interp, _("invalid expression"), TCL_STATIC);
     else
+    {
 	Tcl_SetResult(interp, str, TCL_VOLATILE);
+	vim_free(str);
+    }
     err = vimerror(interp);
 #else
     Tcl_SetResult(interp, _("expressions disabled at compile time"), TCL_STATIC);


### PR DESCRIPTION
This PR fixes a memory leak in vim-8.1.146 and older.
The leak happens as meany times as the :tcl::vim::expr command is invoked.
For example, this will leak 1 block:
```
$ valgrind --leak-check=full 2> vg.log ./vim --clean -c'tcl ::vim::expr 2+3' -cq
```
And vg.log contains:
```
==19619== 2 bytes in 1 blocks are definitely lost in loss record 2 of 169
==19619==    at 0x4C2FDCB: malloc (vg_replace_malloc.c:299)
==19619==    by 0x1FC4C0: lalloc (misc2.c:976)
==19619==    by 0x1FD32D: alloc (misc2.c:874)
==19619==    by 0x1FD32D: vim_strsave (misc2.c:1315)
==19619==    by 0x16273E: eval_to_string (eval.c:844)
==19619==    by 0x2EC8C1: tclvimexpr (if_tcl.c:1384)
==19619==    by 0x663F405: TclNRRunCallbacks (in /usr/lib/x86_64-linux-gnu/libtcl8.6.so)
==19619==    by 0x663FFB9: ??? (in /usr/lib/x86_64-linux-gnu/libtcl8.6.so)
==19619==    by 0x663FA62: Tcl_EvalEx (in /usr/lib/x86_64-linux-gnu/libtcl8.6.so)
==19619==    by 0x6640C64: Tcl_Eval (in /usr/lib/x86_64-linux-gnu/libtcl8.6.so)
==19619==    by 0x2EE97E: ex_tcl (if_tcl.c:1922)
==19619==    by 0x19D191: do_one_cmd (ex_docmd.c:2886)
==19619==    by 0x19D191: do_cmdline (ex_docmd.c:1040)
==19619==    by 0x30416F: exe_commands (main.c:2939)
==19619==    by 0x30416F: vim_main2 (main.c:812)
```
The leak was found after adding more Tcl tests
in https://github.com/vim/vim/pull/3140
