### PR TITLE
Fix mksession to set localdir correctly when there are multiple tabs

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -11201,6 +11201,8 @@ makeopens(
     tab_topframe = topframe;
     if ((ssop_flags & SSOP_TABPAGES))
     {
+	int	num_tabs;
+
 	/*
 	 * similar to ses_win_rec() below, populate the tab pages first so
 	 * later local options won't be copied to the new tabs.
@@ -11215,7 +11217,7 @@ makeopens(
 		return FAIL;
 	}
 
-	int	num_tabs = tabnr - 1;
+	num_tabs = tabnr - 1;
 	if (num_tabs > 1 && (fprintf(fd, "tabnext -%d", num_tabs - 1) < 0
 	    || put_eol(fd) == FAIL))
 	{

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -11085,6 +11085,12 @@ makeopens(
     if (put_line(fd, "silent only") == FAIL)
 	return FAIL;
 
+    if ((ssop_flags & SSOP_TABPAGES))
+    {
+	if (put_line(fd, "silent tabonly") == FAIL)
+	    return FAIL;
+    }
+
     /*
      * Now a :cd command to the session directory or the current directory
      */
@@ -11193,9 +11199,32 @@ makeopens(
      */
     tab_firstwin = firstwin;	/* first window in tab page "tabnr" */
     tab_topframe = topframe;
+    if ((ssop_flags & SSOP_TABPAGES))
+    {
+	/*
+	 * similar to ses_win_rec() below, populate the tab pages first so
+	 * later local options won't be copied to the new tabs.
+	 */
+	for (tabnr = 1; ; ++tabnr)
+	{
+	    tabpage_T *tp = find_tabpage(tabnr);
+	    if (tp == NULL)	/* done all tab pages */
+		break;
+
+	    if (tabnr > 1 && put_line(fd, "tabnew") == FAIL)
+		return FAIL;
+	}
+
+	int	num_tabs = tabnr - 1;
+	if (num_tabs > 1 && (fprintf(fd, "tabnext -%d", num_tabs - 1) < 0
+	    || put_eol(fd) == FAIL))
+	{
+	    return FAIL;
+	}
+    }
     for (tabnr = 1; ; ++tabnr)
     {
-	int	need_tabnew = FALSE;
+	int	need_tabnext = FALSE;
 	int	cnr = 1;
 
 	if ((ssop_flags & SSOP_TABPAGES))
@@ -11215,7 +11244,7 @@ makeopens(
 		tab_topframe = tp->tp_topframe;
 	    }
 	    if (tabnr > 1)
-		need_tabnew = TRUE;
+		need_tabnext = TRUE;
 	}
 
 	/*
@@ -11233,11 +11262,14 @@ makeopens(
 #endif
 		    )
 	    {
-		if (fputs(need_tabnew ? "tabedit " : "edit ", fd) < 0
+		if (need_tabnext && put_line(fd, "tabnext") == FAIL)
+		    return FAIL;
+		need_tabnext = FALSE;
+
+		if (fputs("edit ", fd) < 0
 			      || ses_fname(fd, wp->w_buffer, &ssop_flags, TRUE)
 								       == FAIL)
 		    return FAIL;
-		need_tabnew = FALSE;
 		if (!wp->w_arg_idx_invalid)
 		    edited_win = wp;
 		break;
@@ -11245,7 +11277,7 @@ makeopens(
 	}
 
 	/* If no file got edited create an empty tab page. */
-	if (need_tabnew && put_line(fd, "tabnew") == FAIL)
+	if (need_tabnext && put_line(fd, "tabnext") == FAIL)
 	    return FAIL;
 
 	/*
@@ -11348,7 +11380,7 @@ makeopens(
     /*
      * Wipe out an empty unnamed buffer we started in.
      */
-    if (put_line(fd, "if exists('s:wipebuf') && s:wipebuf != bufnr('%')")
+    if (put_line(fd, "if exists('s:wipebuf') && len(win_findbuf(s:wipebuf)) == 0")
 								       == FAIL)
 	return FAIL;
     if (put_line(fd, "  silent exe 'bwipe ' . s:wipebuf") == FAIL)

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -162,6 +162,53 @@ func Test_mksession_one_buffer_two_windows()
   call delete('Xtest_mks.out')
 endfunc
 
+func Test_mksession_lcd_multiple_tabs()
+  tabnew
+  tabnew
+  lcd
+  tabfirst
+  lcd
+  mksession! Xtest_mks.out
+  tabonly
+  source Xtest_mks.out
+  call assert_true(haslocaldir(), 'Tab 1 localdir')
+  tabnext 2
+  call assert_true(!haslocaldir(), 'Tab 2 localdir')
+  tabnext 3
+  call assert_true(haslocaldir(), 'Tab 3 localdir')
+  call delete('Xtest_mks.out')
+endfunc
+
+func Test_mksession_blank_tabs()
+  tabnew
+  tabnew
+  tabnew
+  tabnext 3
+  mksession! Xtest_mks.out
+  tabnew
+  tabnew
+  tabnext 2
+  source Xtest_mks.out
+  call assert_equal(4, tabpagenr('$'), 'session restore should restore number of tabs')
+  call assert_equal(3, tabpagenr(), 'session restore should restore the active tab')
+  call delete('Xtest_mks.out')
+endfunc
+
+func Test_mksession_blank_windows()
+  split
+  split
+  split
+  3 wincmd w
+  mksession! Xtest_mks.out
+  split
+  split
+  2 wincmd w
+  source Xtest_mks.out
+  call assert_equal(4, winnr('$'), 'session restore should restore number of windows')
+  call assert_equal(3, winnr(), 'session restore should restore the active window')
+  call delete('Xtest_mks.out')
+endfunc
+
 if has('terminal')
 
 func Test_mksession_terminal_shell()


### PR DESCRIPTION
This patch fixes an issue in `mksession` where local directories don't get properly saved out if there are multiple tabs. A simple repro is as follows:

    edit some_file.txt
    tabedit some_file2.txt
    tabfirst
    lcd ~/.vim
    mksession ~/session.vim
    qa

Then in another Vim instance:

    source ~/session.vim
    tablast
    assert_true(!haslocaldir(), 'should not have localdir')

The assert will fire. The issue is that mksession makes new tabs using `tabedit` after populating the current tab's windows first. The issue is `tabedit` will propagate local options to the new tab, including the localdir. Instead, the fix is to pre-populate all the tabs first (similar to how the script pre-populates the window splits in `ses_win_rec()`).

In testing this I also found a couple bugs that I fixed:

1. The session Vim script doesn't clear all the other tabs on load. This is inconsistent to how it uses `silent only` to clear all the other windows first. To fix this, add `silent tabonly` to make sure everything is cleared on load. This also makes sure the last command in the script to re-select the active tab via `tabnext` will work properly.

* (I do realize this has a small chance of breaking people who got used to the old inconsistent behavior. I don't know how big that population is)

2. If the first window of first tab is a blank window, then `mksession` will generate a script that deletes that window, since `s:wipebuf` is actually the buffer for the blank window when restoring. Fix this by making sure `s:wipebuf` is actually not used anywhere before calling `bwipe` on it. See #1282 for an existing issue calling this out.