### PR TITLE
luaeval('vim.buffer().name') gave wrong result in unnamed buffer

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -1123,9 +1123,11 @@ luaV_buffer_index(lua_State *L)
     {
 	const char *s = lua_tostring(L, 2);
 	if (strncmp(s, "name", 4) == 0)
-	    lua_pushstring(L, (char *) b->b_sfname);
+	    lua_pushstring(L, (b->b_sfname == NULL)
+					? "" : (char *) b->b_sfname);
 	else if (strncmp(s, "fname", 5) == 0)
-	    lua_pushstring(L, (char *) b->b_ffname);
+	    lua_pushstring(L, (b->b_ffname == NULL)
+					? "" : (char *) b->b_ffname);
 	else if (strncmp(s, "number", 6) == 0)
 	    lua_pushinteger(L, b->b_fnum);
 	/* methods */

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -198,11 +198,8 @@ endfunc
 " Test vim.buffer().name and vim.buffer().fname
 func Test_buffer_name()
   new
-  " FIXME: for an unnamed buffer, I would expect
-  " vim.buffer().name to give an empty string, but
-  " it returns 0. Is it a bug?
-  " so this assert_equal is commented out.
-  " call assert_equal('', luaeval('vim.buffer().name'))
+  call assert_equal('', luaeval('vim.buffer().name'))
+  call assert_equal('', luaeval('vim.buffer().fname'))
   bwipe!
 
   new Xfoo


### PR DESCRIPTION
This PR fixes a bug with :echo luaeval('vim.buffer().name')
which did not work with an unknown buffer.  It gave an
error "luaeval: cannot convert value" and returned 0.
Same for :echo luaeval('vim.buffer().fname')

It now returns an empty string as expected.

