### PR TITLE
Fix Test_marks_cmd_multibyte()

### DIFF
--- a/src/testdir/test_marks.vim
+++ b/src/testdir/test_marks.vim
@@ -126,15 +126,14 @@ func Test_marks_cmd_multibyte()
     return
   endif
   new Xone
-  call setline(1, ['ááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááá'])
+  let line = 'ááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááá'
+  call setline(1, [line])
   norm! ma
 
   let a = split(execute('marks a'), "\n")
   call assert_equal(2, len(a))
   let expected = ' a      1    0 '
-  while strwidth(expected) < &columns - 1
-    let expected .= 'á'
-  endwhile
+  let expected .= repeat('á', min([&columns - 1 - strwidth(expected), strwidth(line)]) / strwidth('á'))
   call assert_equal(expected, a[1])
 
   bwipe!


### PR DESCRIPTION
This will fix #3180 

On wide-width window (>= 98 cols), Test_marks_cmd_multibyte() fails.

```
strwidth(' a      1    0 ') : 15
strwidth('ááá...') : 81
15 + 81 + 1 == 97
```

so when columns >= 98, `:marks a` can show whole marked line, thus expected-value (by `&columns - 1`) is too long.