### PR TITLE
remove whitespace in German translation

### DIFF
--- a/runtime/tutor/tutor.de
+++ b/runtime/tutor/tutor.de
@@ -41,7 +41,7 @@ Anmerkung: Immer, wenn Du Dir unsicher bist über das, was Du getippt hast,
 	   drücke <ESC> , um Dich in den Normalmodus zu begeben.
 	   Dann gib das gewünschte Kommando noch einmal ein.
 
-Anmerkung: Die Cursor-Tasten sollten ebenfalls funktionieren.  Aber wenn Du
+Anmerkung: Die Cursor-Tasten sollten ebenfalls funktionieren. Aber wenn Du
 	   hjkl benutzt, wirst Du in der Lage sein, Dich sehr viel schneller
 	   umherzubewegen, wenn Du Dich einmal daran gewöhnt hast. Wirklich!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/runtime/tutor/tutor.de.utf-8
+++ b/runtime/tutor/tutor.de.utf-8
@@ -41,7 +41,7 @@ Anmerkung: Immer, wenn Du Dir unsicher bist über das, was Du getippt hast,
 	   drücke <ESC> , um Dich in den Normalmodus zu begeben.
 	   Dann gib das gewünschte Kommando noch einmal ein.
 
-Anmerkung: Die Cursor-Tasten sollten ebenfalls funktionieren.  Aber wenn Du
+Anmerkung: Die Cursor-Tasten sollten ebenfalls funktionieren. Aber wenn Du
 	   hjkl benutzt, wirst Du in der Lage sein, Dich sehr viel schneller
 	   umherzubewegen, wenn Du Dich einmal daran gewöhnt hast. Wirklich!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Remove double whitespaces at the beginning of the sentence.