### PR TITLE
Fixed overlapping strcpy with 8bit terminal

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -1483,7 +1483,7 @@ parse_builtin_tcap(char_u *term)
 			    if (term_7to8bit(t))
 			    {
 				*t = term_7to8bit(t);
-				STRCPY(t + 1, t + 2);
+				STRMOVE(t + 1, t + 2);
 			    }
 			term_strings[p->bt_entry] = s;
 			set_term_option_alloced(&term_strings[p->bt_entry]);


### PR DESCRIPTION
This PR fixes a bug detected by valgrind in term.c in Vim-8.1.173 and older:
```
==13302== Memcheck, a memory error detector
==13302== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==13302== Using Valgrind-3.14.0.GIT and LibVEX; rerun with -h for copyright info
==13302== Command: ./vim --clean -c q
==13302== 
==13302== Source and destination overlap in strcpy(0x7d29ad1, 0x7d29ad2)
==13302==    at 0x4C33337: strcpy (vg_replace_strmem.c:512)
==13302==    by 0x30A893: parse_builtin_tcap (term.c:1486)
==13302==    by 0x30B2FB: set_termname (term.c:1842)
==13302==    by 0x30BD96: termcapinit (term.c:2513)
==13302==    by 0x3647DF: main (main.c:383)
```
Bug is reproducible with:
```
$ TERM=xterm-8bit valgrind vim --clean -c q 2> valgrind.log
```
And valgrind.log contains the above error message.

Coverity detected this bug (defect Id=1307798). See:

https://scan5.coverity.com/reports.htm#v41229/p10101/fileInstanceId=143617210&defectInstanceId=40347990&mergedDefectId=1307798
