### PR TITLE
ins_compl_bs: do not special-case complete()

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -3625,9 +3625,12 @@ ins_compl_bs(void)
 
     /* Deleted more than what was used to find matches or didn't finish
      * finding all matches: need to look for matches all over again. */
-    if (curwin->w_cursor.col <= compl_col + compl_length
-						  || ins_compl_need_restart())
+    if (ctrl_x_mode != CTRL_X_EVAL
+	    && (curwin->w_cursor.col <= compl_col + compl_length
+		|| ins_compl_need_restart())) {
+
 	ins_compl_restart();
+    };
 
     vim_free(compl_leader);
     compl_leader = vim_strnsave(line + compl_col, (int)(p - line) - compl_col);

--- a/src/edit.c
+++ b/src/edit.c
@@ -3618,7 +3618,7 @@ ins_compl_bs(void)
      * Respect the 'backspace' option. */
     if ((int)(p - line) - (int)compl_col < 0
 	    || ((int)(p - line) - (int)compl_col == 0
-		&& ctrl_x_mode != CTRL_X_OMNI) || ctrl_x_mode == CTRL_X_EVAL
+		&& ctrl_x_mode != CTRL_X_OMNI)
 	    || (!can_bs(BS_START) && (int)(p - line) - (int)compl_col
 							- compl_length < 0))
 	return K_BS;


### PR DESCRIPTION
Currently backspace in CTRL_X_EVAL completions (`complete()`) will abort
when <BS> is used.

Side note: the previous aborting would not trigger the CompleteDone
event however, only until later, e.g. when using `complete()` again -
where it then got triggered twice.

I will investigate more, but this patch appears to make sense already.

It comes via e421450a5 [1].
I have checked that `Ctrl-L` still works with my patch, so this might
not be necessary for what patch 7.4.653 was mainly about?!

1: https://github.com/vim/vim/commit/e421450a5

/cc @chrisbra @shougo
(+ Yasuhiro Matsumoto, Hirohito Higashi (they do not complete.. :/))