### PR TITLE
if_perl: Fix perl 5.27.3 or later on Windows

### DIFF
--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -126,6 +126,11 @@
 # define PERL5101_OR_LATER
 #endif
 
+#if (PERL_REVISION == 5) && ((PERL_VERSION > 27) || \
+    (PERL_VERSION == 27) && (PERL_SUBVERSION >= 3))
+# define PERL5273_OR_LATER
+#endif
+
 #ifndef pTHX
 # define pTHX void
 # define pTHX_
@@ -199,6 +204,9 @@ typedef int perl_key;
 # define Perl_gv_stashpv dll_Perl_gv_stashpv
 # define Perl_markstack_grow dll_Perl_markstack_grow
 # define Perl_mg_find dll_Perl_mg_find
+# ifdef PERL5273_OR_LATER
+#  define Perl_mg_get dll_Perl_mg_get
+# endif
 # define Perl_newXS dll_Perl_newXS
 # define Perl_newSV dll_Perl_newSV
 # define Perl_newSViv dll_Perl_newSViv
@@ -342,6 +350,9 @@ static I32* (*Perl_markstack_grow)(pTHX);
 static void (*Perl_markstack_grow)(pTHX);
 # endif
 static MAGIC* (*Perl_mg_find)(pTHX_ SV*, int);
+# ifdef PERL5273_OR_LATER
+static int (*Perl_mg_get)(pTHX_ SV*);
+# endif
 static CV* (*Perl_newXS)(pTHX_ char*, XSUBADDR_t, char*);
 static SV* (*Perl_newSV)(pTHX_ STRLEN);
 static SV* (*Perl_newSViv)(pTHX_ IV);
@@ -494,6 +505,9 @@ static struct {
     {"Perl_gv_stashpv", (PERL_PROC*)&Perl_gv_stashpv},
     {"Perl_markstack_grow", (PERL_PROC*)&Perl_markstack_grow},
     {"Perl_mg_find", (PERL_PROC*)&Perl_mg_find},
+# ifdef PERL5273_OR_LATER
+    {"Perl_mg_get", (PERL_PROC*)&Perl_mg_get},
+# endif
     {"Perl_newXS", (PERL_PROC*)&Perl_newXS},
     {"Perl_newSV", (PERL_PROC*)&Perl_newSV},
     {"Perl_newSViv", (PERL_PROC*)&Perl_newSViv},

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -126,11 +126,6 @@
 # define PERL5101_OR_LATER
 #endif
 
-#if (PERL_REVISION == 5) && ((PERL_VERSION > 27) || \
-    (PERL_VERSION == 27) && (PERL_SUBVERSION >= 3))
-# define PERL5273_OR_LATER
-#endif
-
 #ifndef pTHX
 # define pTHX void
 # define pTHX_
@@ -204,7 +199,7 @@ typedef int perl_key;
 # define Perl_gv_stashpv dll_Perl_gv_stashpv
 # define Perl_markstack_grow dll_Perl_markstack_grow
 # define Perl_mg_find dll_Perl_mg_find
-# ifdef PERL5273_OR_LATER
+# if (PERL_REVISION == 5) && (PERL_VERSION >= 28)
 #  define Perl_mg_get dll_Perl_mg_get
 # endif
 # define Perl_newXS dll_Perl_newXS
@@ -350,7 +345,7 @@ static I32* (*Perl_markstack_grow)(pTHX);
 static void (*Perl_markstack_grow)(pTHX);
 # endif
 static MAGIC* (*Perl_mg_find)(pTHX_ SV*, int);
-# ifdef PERL5273_OR_LATER
+# if (PERL_REVISION == 5) && (PERL_VERSION >= 28)
 static int (*Perl_mg_get)(pTHX_ SV*);
 # endif
 static CV* (*Perl_newXS)(pTHX_ char*, XSUBADDR_t, char*);
@@ -505,7 +500,7 @@ static struct {
     {"Perl_gv_stashpv", (PERL_PROC*)&Perl_gv_stashpv},
     {"Perl_markstack_grow", (PERL_PROC*)&Perl_markstack_grow},
     {"Perl_mg_find", (PERL_PROC*)&Perl_mg_find},
-# ifdef PERL5273_OR_LATER
+# if (PERL_REVISION == 5) && (PERL_VERSION >= 28)
     {"Perl_mg_get", (PERL_PROC*)&Perl_mg_get},
 # endif
     {"Perl_newXS", (PERL_PROC*)&Perl_newXS},


### PR DESCRIPTION
## Problem
 In the case of Perl 5.27.3 or later, build fails with `DYANIMC_PERL=yes` on Windows.

## Repro steps
On MinGW64(MSYS2)  environment.
```
> pacman -S mingw-w64-x86_64-perl
> make -f Make_cyg_ming.mak GUI=no ARCH=x86-64 PERL=C:/msys64/mingw64 PERLLIB=C:/msys64/mingw64/lib/perl5/core_perl PERL_VER=528 DYNAMIC_PERL=yes
…
gcc -Iproto -DWIN32 -DWINVER=0x0600 -D_WIN32_WINNT=0x0600 -DHAVE_PATHDEF -DFEAT_HUGE -DHAVE_STDINT_H -DMS_WIN64 -DHAVE_GETTEXT -DHAVE_LOCALE_H -DDYNAMIC_GETTEXT -DFEAT_CSCOPE -DFEAT_JOB_CHANNEL -DFEAT_TERMINAL -DFEAT_MBYTE -DFEAT_MBYTE_IME -DDYNAMIC_IME -DDYNAMIC_ICONV -pipe -march=x86-64 -Wall -Ii:/msys64/mingw64/lib/perl5/core_perl/Core -DFEAT_PERL -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -DDYNAMIC_PERL -DDYNAMIC_PERL_DLL=\"perl528.dll\" -O3 -fomit-frame-pointer -freg-struct-return -s  -o vim.exe objx86-64/arabic.o objx86-64/beval.o objx86-64/blowfish.o objx86-64/buffer.o objx86-64/charset.o objx86-64/crypt.o objx86-64/crypt_zip.o objx86-64/dict.o objx86-64/diff.o objx86-64/digraph.o objx86-64/edit.o objx86-64/eval.o objx86-64/evalfunc.o objx86-64/ex_cmds.o objx86-64/ex_cmds2.o objx86-64/ex_docmd.o objx86-64/ex_eval.o objx86-64/ex_getln.o objx86-64/farsi.o objx86-64/fileio.o objx86-64/fold.o objx86-64/getchar.o objx86-64/hardcopy.o objx86-64/hashtab.o objx86-64/json.o objx86-64/list.o objx86-64/main.o objx86-64/mark.o objx86-64/memfile.o objx86-64/memline.o objx86-64/menu.o objx86-64/message.o objx86-64/misc1.o objx86-64/misc2.o objx86-64/move.o objx86-64/mbyte.o objx86-64/normal.o objx86-64/ops.o objx86-64/option.o objx86-64/os_win32.o objx86-64/os_mswin.o objx86-64/winclip.o objx86-64/pathdef.o objx86-64/popupmnu.o objx86-64/quickfix.o objx86-64/regexp.o objx86-64/screen.o objx86-64/search.o objx86-64/sha256.o objx86-64/spell.o objx86-64/spellfile.o objx86-64/syntax.o objx86-64/tag.o objx86-64/term.o objx86-64/ui.o objx86-64/undo.o objx86-64/userfunc.o objx86-64/version.o objx86-64/vimrc.o objx86-64/window.o objx86-64/if_perl.o objx86-64/if_cscope.o objx86-64/channel.o objx86-64/terminal.o objx86-64/term_encoding.o objx86-64/term_keyboard.o objx86-64/term_mouse.o objx86-64/term_parser.o objx86-64/term_pen.o objx86-64/term_screen.o objx86-64/term_state.o objx86-64/term_unicode.o objx86-64/term_vterm.o objx86-64/iscygpty.o -lkernel32 -luser32 -lgdi32 -ladvapi32 -lcomdlg32 -lcomctl32 -lnetapi32 -lversion -lwsock32 -lole32 -luuid
objx86-64/if_perl.o:if_perl.c:(.text+0x3f1b): undefined reference to `__imp_Perl_mg_get'
objx86-64/if_perl.o:if_perl.c:(.text+0x4472): undefined reference to `__imp_Perl_mg_get'
objx86-64/if_perl.o:if_perl.c:(.text+0x4dc4): undefined reference to `__imp_Perl_mg_get'
collect2.exe: error: ld returned 1 exit status
make: *** [Make_cyg_ming.mak:910: vim.exe] Error 1
```

##  Cause
The definition of `SvTRUE()` has been changed to use `SvGETMAGIC()`(`mg_get()`) from [Perl 5.27.3](https://github.com/Perl/perl5/commit/56c6304063762154ca57e85c0fe6f60069dacd77#diff-b22a8a646b73ce4ce62ca038ec20cf6e).

## Solution
Add definition of `Perl_mg_get()` to `if_perl.xs`.