### PR TITLE
Fix +packages in feature list

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -493,7 +493,11 @@ static char *(features[]) =
 	"-ole",
 # endif
 #endif
+#ifdef FEAT_EVAL
 	"+packages",
+#else
+	"-packages",
+#endif
 #ifdef FEAT_PATH_EXTRA
 	"+path_extra",
 #else


### PR DESCRIPTION
`+packages` is not available without `+eval`.

Reported by:
https://twitter.com/Linda_pp/status/1017244470977294337 (@rhysd)
https://groups.google.com/forum/#!msg/vim_dev/9j6bOHrvPhk/hAx8M8fwAwAJ