### PR TITLE
Fix "jump-motions" docs to make sure to include all the jump commands

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1021,12 +1021,12 @@ These commands are not marks themselves, but jump to a mark:
 
 A "jump" is one of the following commands or their variants: "'", "`", "gg",
 "G", "go", "/", "?", "n", "N", "%", "(", ")", "[[", "]]", "{", "}", "[c",
-"]c", "m", "u", ":redo", ":s", ":g", ":print", ":tag", ":cc", "L", "M", "H",
-and the commands that start editing a new file.  If you make the cursor "jump"
-with one of these commands or the command has been used in operator-pending
-mode, the position of the cursor before the jump is remembered.  You can
-return to that position with the "''" and "``" command, unless the line
-containing that position was changed or deleted.
+"]c", "m'", "K", "u", ":redo", ":s", ":g", ":print", ":tag", ":cc", "L", "M",
+"H", and the commands that start editing a new file.  If you make the cursor
+"jump" with one of these commands or the command has been used in
+operator-pending mode, the position of the cursor before the jump is
+remembered.  You can return to that position with the "''" and "``" command,
+unless the line containing that position was changed or deleted.
 
 							*CTRL-O*
 CTRL-O			Go to [count] Older cursor position in jump list

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1019,12 +1019,14 @@ These commands are not marks themselves, but jump to a mark:
 ==============================================================================
 8. Jumps					*jump-motions*
 
-A "jump" is one of the following commands: "'", "`", "G", "/", "?", "n",
-"N", "%", "(", ")", "[[", "]]", "{", "}", ":s", ":tag", "L", "M", "H" and
-the commands that start editing a new file.  If you make the cursor "jump"
-with one of these commands, the position of the cursor before the jump is
-remembered.  You can return to that position with the "''" and "``" command,
-unless the line containing that position was changed or deleted.
+A "jump" is one of the following commands or their variants: "'", "`", "gg",
+"G", "go", "/", "?", "n", "N", "%", "(", ")", "[[", "]]", "{", "}", "[c",
+"]c", "m", "u", ":redo", ":s", ":g", ":print", ":tag", ":cc", "L", "M", "H",
+and the commands that start editing a new file.  If you make the cursor "jump"
+with one of these commands or the command has been used in operator-pending
+mode, the position of the cursor before the jump is remembered.  You can
+return to that position with the "''" and "``" command, unless the line
+containing that position was changed or deleted.
 
 							*CTRL-O*
 CTRL-O			Go to [count] Older cursor position in jump list

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1021,9 +1021,9 @@ These commands are not marks themselves, but jump to a mark:
 
 A "jump" is one of the following commands or their variants: "'", "`", "gg",
 "G", "go", "/", "?", "n", "N", "%", "(", ")", "[[", "]]", "{", "}", "[c",
-"]c", "m'", "K", "u", ":redo", ":s", ":g", ":print", ":tag", ":cc", "L", "M",
-"H", and the commands that start editing a new file.  If you make the cursor
-"jump" with one of these commands or the command has been used in
+"]c", "m'", "u", ":redo", ":s", ":g", ":print", ":tag", ":cc", "L", "M", "H",
+"[count]zz", and the commands that start editing a new file.  If you make the
+cursor "jump" with one of these commands or the command has been used in
 operator-pending mode, the position of the cursor before the jump is
 remembered.  You can return to that position with the "''" and "``" command,
 unless the line containing that position was changed or deleted.


### PR DESCRIPTION
Previously, the docs for "jump-motions" lists a set of commands that will trigger a jump in Vim, but it's not inclusive, nor does it make it clear that operator-pending motions are still counted (e.g. Doing `=G` to indent the file till the end will trigger a jump since "G" itself does). Fix the docs to include most of the possible operations that will trigger jumps.