### PR TITLE
Fix <C-S> during insert mode on mswin.vim

### DIFF
--- a/runtime/mswin.vim
+++ b/runtime/mswin.vim
@@ -60,7 +60,7 @@ noremap <C-Q>		<C-V>
 " Use CTRL-S for saving, also in Insert mode
 noremap <C-S>		:update<CR>
 vnoremap <C-S>		<C-C>:update<CR>
-inoremap <C-S>		<C-O>:update<CR>
+inoremap <C-S>		<Esc>:update<CR>a
 
 " For CTRL-V to work autoselect must be off.
 " On Unix we have two selections, autoselect can be used.

--- a/runtime/mswin.vim
+++ b/runtime/mswin.vim
@@ -60,7 +60,7 @@ noremap <C-Q>		<C-V>
 " Use CTRL-S for saving, also in Insert mode
 noremap <C-S>		:update<CR>
 vnoremap <C-S>		<C-C>:update<CR>
-inoremap <C-S>		<Esc>:update<CR>a
+inoremap <C-S>		<Esc>:update<CR>gi
 
 " For CTRL-V to work autoselect must be off.
 " On Unix we have two selections, autoselect can be used.


### PR DESCRIPTION
Originally, the mapping for `<C-S>` on mswin.vim during insert mode is:

```
inoremap <C-S> <C-O>:update<CR>
```

This mapping will cause problem during omnicompletion. Omnicompletion is triggered by `<C-X><C-O>`, and so if you type `<C-O>` during omnicompletion it will not change to normal mode, but cycle through the suggestions.