### PR TITLE
Add wincmds g[hjkl] to move window into a split of the given neighbor

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -508,7 +508,6 @@ CTRL-W H	Move the current window to be at the far left, using the
 		current window and then creating another one with
 		":vert topleft split", except that the current window contents
 		is used for the new window.
-		{not available when compiled without the |+vertsplit| feature}
 
 						*CTRL-W_L*
 CTRL-W L	Move the current window to be at the far right, using the full
@@ -516,7 +515,38 @@ CTRL-W L	Move the current window to be at the far right, using the full
 		current window and then creating another one with
 		":vert botright split", except that the current window
 		contents is used for the new window.
-		{not available when compiled without the |+vertsplit| feature}
+
+						*CTRL-W_gk*
+CTRL-W g k	Move the current window to a new vertical split of the window
+		above the current window.  This is similar to using |CTRL-W_k|
+		to move to a different window, creating a new split using
+		":vsplit" but having the same contents as the previous window,
+		and then closing the previous window.  If there is no window
+		above the current window, this behaves like |CTRL-W_K|.
+
+						*CTRL-W_gj*
+CTRL-W g j	Move the current window to a new vertical split of the window
+		below the current window.  This is similar to using |CTRL-W_j|
+		to move to a different window, creating a new split with
+		":vsplit" but having the same contents as the previous window,
+		and then closing the previous window.  If there is no window
+		below the current window, this behaves like |CTRL-W_J|.
+
+						*CTRL-W_gh*
+CTRL-W g h	Move the current window to a new horizontal split of the window
+		left of the current window.  This is similar to using |CTRL-W_h|
+		to move to a different window, creating a new split with
+		":split" but having the same contents as the previous window,
+		and then closing the previous window.  If there is no window
+		to the left of the current window, this behaves like |CTRL-W_H|.
+
+						*CTRL-W_gl*
+CTRL-W g l	Move the current window to a new horizontal split of the window
+		right of the current window.  This is similar to using |CTRL-W_l|
+		to move to a different window, creating a new split with
+		":split" but having the same contents as the previous window,
+		and then closing the previous window.  If there is no window
+		to the right of the current window, this behaves like |CTRL-W_L|.
 
 						*CTRL-W_T*
 CTRL-W T	Move the current window to a new tab page.  This fails if

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -788,4 +788,32 @@ func Test_winnr()
   only | tabonly
 endfunc
 
+func Test_win_splitmove()
+  edit a
+  leftabove split b
+  leftabove vsplit c
+  leftabove split d
+  wincmd gl
+  call assert_equal(bufname(winbufnr(1)), 'c')
+  call assert_equal(bufname(winbufnr(2)), 'd')
+  call assert_equal(bufname(winbufnr(3)), 'b')
+  call assert_equal(bufname(winbufnr(4)), 'a')
+  wincmd gj
+  wincmd gj
+  call assert_equal(bufname(winbufnr(1)), 'c')
+  call assert_equal(bufname(winbufnr(2)), 'b')
+  call assert_equal(bufname(winbufnr(3)), 'd')
+  call assert_equal(bufname(winbufnr(4)), 'a')
+  wincmd gk
+  call assert_equal(bufname(winbufnr(1)), 'd')
+  call assert_equal(bufname(winbufnr(2)), 'c')
+  call assert_equal(bufname(winbufnr(3)), 'b')
+  call assert_equal(bufname(winbufnr(4)), 'a')
+  wincmd gh
+  call assert_equal(bufname(winbufnr(1)), 'd')
+  call assert_equal(bufname(winbufnr(2)), 'c')
+  call assert_equal(bufname(winbufnr(3)), 'b')
+  call assert_equal(bufname(winbufnr(4)), 'a')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -18,6 +18,7 @@ static void frame_setwidth(frame_T *curfrp, int width);
 static void win_exchange(long);
 static void win_rotate(int, int);
 static void win_totop(int size, int flags);
+static void win_moveinto(int size, int vert, int above);
 static void win_equal_rec(win_T *next_curwin, int current, frame_T *topfr, int dir, int col, int row, int width, int height);
 static win_T *win_free_mem(win_T *win, int *dirp, tabpage_T *tp);
 static frame_T *win_altframe(win_T *win, tabpage_T *tp);
@@ -587,6 +588,16 @@ wingotofile:
 
 		    case 'T':	    // CTRL-W gT: go to previous tab page
 			goto_tabpage(-(int)Prenum1);
+			break;
+
+		    // move window into a new split of another window
+		    case 'k':
+		    case 'j':
+		    case 'h':
+		    case 'l':
+			CHECK_CMDWIN;
+			win_moveinto((int)Prenum, xchar == 'h' || xchar == 'l',
+				xchar == 'h' || xchar == 'k');
 			break;
 
 		    default:
@@ -1697,6 +1708,91 @@ win_totop(int size, int flags)
 #if defined(FEAT_GUI)
     /* When 'guioptions' includes 'L' or 'R' may have to remove or add
      * scrollbars.  Have to update them anyway. */
+    gui_may_update_scrollbars();
+#endif
+}
+
+/*
+ * Move the current window into a split of the window in a given direction
+ */
+    static void
+win_moveinto(int size, int vert, int above)
+{
+    int		dir;
+    int 	flags;
+    win_T	*targetwin;
+    win_T	*wp;
+    int		height = curwin->w_height;
+
+    if (ONE_WINDOW)
+    {
+	beep_flush();
+	return;
+    }
+
+    // target window is the neighbor in the wincmd h,j,k,l direction
+    if (vert)
+	targetwin = win_horz_neighbor(curtab, curwin, above, 1);
+    else
+	targetwin = win_vert_neighbor(curtab, curwin, above, 1);
+
+    // if no target window, behave like wincmd H,J,K,L
+    if (targetwin == curwin)
+    {
+	win_totop(size, (vert ? WSP_VERT : 0)
+				| (above ? WSP_TOP : WSP_BOT));
+	return;
+    }
+
+    // Make the split left/above depending on relative positions;
+    // - If the current window is at least as big as the target then
+    //   compare the cursor position and the midpoint of the target window
+    // - If the current window is smaller than the target
+    //   then compare the midpoints of the current and target windows
+    if (vert)
+    {
+	if (curwin->w_winrow
+		+ (curwin->w_height >= targetwin->w_height
+			? curwin->w_wrow : curwin->w_height / 2)
+		<= targetwin->w_winrow + targetwin->w_height / 2)
+	    flags = WSP_ABOVE;
+	else
+	    flags = WSP_BELOW;
+    }
+    else
+    {
+	if (curwin->w_wincol
+		+ (curwin->w_width >= targetwin->w_width
+			? curwin->w_wcol : curwin->w_width / 2)
+		<= targetwin->w_wincol + targetwin->w_width / 2)
+	    flags = WSP_VERT | WSP_ABOVE;
+	else
+	    flags = WSP_VERT | WSP_BELOW;
+    }
+
+    // jump to the new window but remember the current one
+    wp = curwin;
+    win_goto(targetwin);
+
+    // remove the old window and frame from the tree of frames
+    (void)winframe_remove(wp, &dir, NULL);
+    win_remove(wp, NULL);
+    last_status(FALSE);	    // may need to remove last status line
+    (void)win_comp_pos();   // recompute window positions
+
+    // split a window on the desired side and put the old window there
+    (void)win_split_ins(size, flags, wp, dir);
+
+    if (!(flags & WSP_VERT))
+    {
+	win_setheight(height);
+	if (p_ea)
+	    win_equal(curwin, TRUE, 'v');
+    }
+
+#if defined(FEAT_GUI)
+    // When 'guioptions' includes 'L' or 'R' may have to remove or add
+    // scrollbars.  Have to update them anyway.
     gui_may_update_scrollbars();
 #endif
 }


### PR DESCRIPTION
Getting to a particular window layout can be a bit frustrating sometimes.

One reason for this is that vim does not offer many ways to move windows
around. :wincmd H, :wincmd J, etc., are useful but only work when you want
to move a window to the far left, bottom, etc. It is also very difficult
to "convert" a horizontal split into a vertical one when there are more
than two windows.

Take the following example:

    +-------------+-----+-----+           +-----------------+-------+
    |             |     |     |           |                 |       |
    |             |     |     |           |                 |       |
    | current win |     |     |           |                 |       |
    |             |     |     | ctrl-w gj |                 |       |
    |             |     |     |           |                 |       |
    +-------------+-----+-----+           +-------------+---+-------+
    |                         | +-------> |             |           |
    |                         |           | current win |           |
    |                         |           |             |           |
    +-------------------------+           +-------------+-----------+

Going from the first layout to the second would normally would require you
to move to the window below, vsplit it, open the correct buffer, and then
finally close the original window.  It is not possible to simplify this
movement with a plugin without potential side-effects from opening/closing
windows and switching buffers.

This patch introduces four new window commands to make this possible:

    CTRL-W g h: move current window into split of left window
    CTRL-W g j: move current window into vsplit of below window
    CTRL-W g k: move current window into vsplit of above window
    CTRL-W g l: move current window into split of right window

Each can be summarized as follows: move the cursor to the window in given
direction (according to wincmd hjkl), make a split (vertical if moving
up/down and horizontal if left/right), and move the old window into that
spot.  There's some logic to determine whether to make splits left/above
or right/below which tries to make moves as frictionless as possible.

This actually feels quite natural and turned out to be simple to implement
using existing functions as a generalization of the Ctrl-w HJKL movements.

Documentation:

    CTRL-W g k  Move the current window to a new vertical split of the window
        above the current window.  This is similar to using |CTRL-W_k|
        to move to a different window, creating a new split using
        ":vsplit" but having the same contents as the previous window,
        and then closing the previous window.  If there is no window
        above the current window, this behaves like |CTRL-W_K|.

    CTRL-W g j  Move the current window to a new vertical split of the window
        below the current window.  This is similar to using |CTRL-W_j|
        to move to a different window, creating a new split with
        ":vsplit" but having the same contents as the previous window,
        and then closing the previous window.  If there is no window
        below the current window, this behaves like |CTRL-W_J|.

    CTRL-W g h  Move the current window to a new horizontal split of the window
        left of the current window.  This is similar to using |CTRL-W_h|
        to move to a different window, creating a new split with
        ":split" but having the same contents as the previous window,
        and then closing the previous window.  If there is no window
        to the left of the current window, this behaves like |CTRL-W_H|.

    CTRL-W g l  Move the current window to a new horizontal split of the window
        right of the current window.  This is similar to using |CTRL-W_l|
        to move to a different window, creating a new split with
        ":split" but having the same contents as the previous window,
        and then closing the previous window.  If there is no window
        to the right of the current window, this behaves like |CTRL-W_L|.
