### PR TITLE
Do not specify colors directly for italic/bold syntax in reStructuredText

### DIFF
--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -189,8 +189,8 @@ hi def link rstHyperlinkTarget              String
 hi def link rstExDirective                  String
 hi def link rstSubstitutionDefinition       rstDirective
 hi def link rstDelimiter                    Delimiter
-hi def rstEmphasis ctermfg=13 term=italic cterm=italic gui=italic
-hi def rstStrongEmphasis ctermfg=1 term=bold cterm=bold gui=bold
+hi def rstEmphasis                          term=italic cterm=italic gui=italic
+hi def rstStrongEmphasis                    term=bold cterm=bold gui=bold
 hi def link rstInterpretedTextOrHyperlinkReference  Identifier
 hi def link rstInlineLiteral                String
 hi def link rstSubstitutionReference        PreProc


### PR DESCRIPTION
In `syntax/rst.vim`, colors for italic/bold syntax are directly specified in CUI version of Vim as high-contrast purple and red. This is not useful for low-contrast colorschemes. Here is one example I'm using:

![screenshot](https://user-images.githubusercontent.com/823277/42939919-82db567a-8b92-11e8-8959-51dcbcfe4961.png)

I removed the colors following the same manner as [syntax/html.vim](https://github.com/vim/vim/blob/f63db65b2418140d1bdbc032511f530234bd2496/runtime/syntax/html.vim#L291).
