### PR TITLE
Test spellbadword() with argument

### DIFF
--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -68,6 +68,33 @@ func Test_z_equal_on_invalid_utf8_word()
   bwipe!
 endfunc
 
+" Test spellbadword() with argument
+func Test_spellbadword()
+  set spell
+
+  call assert_equal(['bycycle', 'bad'],  spellbadword('My bycycle.'))
+
+  set spelllang=en_us
+  call assert_equal(['centre', 'local'], spellbadword('centre'))
+  call assert_equal(['', ''],            spellbadword('center'))
+  set spelllang=en_gb
+  call assert_equal(['', ''],            spellbadword('centre'))
+  call assert_equal(['center', 'local'], spellbadword('center'))
+  set spelllang=en
+  call assert_equal(['', ''],            spellbadword('centre'))
+  call assert_equal(['', ''],            spellbadword('center'))
+
+  " TODO: can we come up with examples where spellbadword("...")
+  " returns 'caps' or 'rare'?
+
+  " Typo should not be detected without the 'spell' option.
+  set nospell
+  call assert_equal(['', ''], spellbadword('bycycle'))
+
+  set spelllang&
+  set spell&
+endfunc
+
 func Test_spellreall()
   new
   set spell

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -85,7 +85,7 @@ func Test_spellbadword()
   call assert_equal(['', ''],            spellbadword('centre'))
   call assert_equal(['center', 'local'], spellbadword('center'))
 
-  " Create a small word list to test that spellbadword('...'
+  " Create a small word list to test that spellbadword('...')
   " can return ['...', 'rare'].
   e Xwords
   insert

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -73,24 +73,38 @@ func Test_spellbadword()
   set spell
 
   call assert_equal(['bycycle', 'bad'],  spellbadword('My bycycle.'))
+  call assert_equal(['another', 'caps'], spellbadword('A sentence. another sentence'))
 
+  set spelllang=en
+  call assert_equal(['', ''],            spellbadword('centre'))
+  call assert_equal(['', ''],            spellbadword('center'))
   set spelllang=en_us
   call assert_equal(['centre', 'local'], spellbadword('centre'))
   call assert_equal(['', ''],            spellbadword('center'))
   set spelllang=en_gb
   call assert_equal(['', ''],            spellbadword('centre'))
   call assert_equal(['center', 'local'], spellbadword('center'))
-  set spelllang=en
-  call assert_equal(['', ''],            spellbadword('centre'))
-  call assert_equal(['', ''],            spellbadword('center'))
 
-  " TODO: can we come up with examples where spellbadword("...")
-  " returns 'caps' or 'rare'?
+  " Create a small word list to test that spellbadword('...'
+  " can return ['...', 'rare'].
+  e Xwords
+  insert
+foo
+foobar/?
+.
+   w!
+   mkspell! Xwords.spl Xwords
+   set spelllang=Xwords.spl
+   call assert_equal(['foobar', 'rare'], spellbadword('foo foobar'))
 
   " Typo should not be detected without the 'spell' option.
-  set nospell
-  call assert_equal(['', ''], spellbadword('bycycle'))
+  set spelllang=en_gb nospell
+  call assert_equal(['', ''], spellbadword('centre'))
+  call assert_equal(['', ''], spellbadword('My bycycle.'))
+  call assert_equal(['', ''], spellbadword('A sentence. another sentence'))
 
+  call delete('Xwords.spl')
+  call delete('Xwords')
   set spelllang&
   set spell&
 endfunc


### PR DESCRIPTION
This PR adds a test for spellbadword() which
was not tested with a string argument according
to codecov:

https://codecov.io/gh/vim/vim/src/f63db65b2418140d1bdbc032511f530234bd2496/src/evalfunc.c#L11605

There is a TODO comment as I could not come up
with a case were spellbadword("...") returns "rare"
or "caps".