### PR TITLE
Redirect if_ruby's stderr to vim message

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -232,6 +232,7 @@ static void ruby_vim_init(void);
 # define rb_define_singleton_method	dll_rb_define_singleton_method
 # define rb_define_virtual_variable	dll_rb_define_virtual_variable
 # define rb_stdout			(*dll_rb_stdout)
+# define rb_stderr			(*dll_rb_stderr)
 # define rb_eArgError			(*dll_rb_eArgError)
 # define rb_eIndexError			(*dll_rb_eIndexError)
 # define rb_eRuntimeError		(*dll_rb_eRuntimeError)
@@ -360,6 +361,7 @@ static void (*dll_rb_define_module_function) (VALUE,const char*,VALUE(*)(),int);
 static void (*dll_rb_define_singleton_method) (VALUE,const char*,VALUE(*)(),int);
 static void (*dll_rb_define_virtual_variable) (const char*,VALUE(*)(),void(*)());
 static VALUE *dll_rb_stdout;
+static VALUE *dll_rb_stderr;
 static VALUE *dll_rb_eArgError;
 static VALUE *dll_rb_eIndexError;
 static VALUE *dll_rb_eRuntimeError;
@@ -553,6 +555,7 @@ static struct
     {"rb_define_singleton_method", (RUBY_PROC*)&dll_rb_define_singleton_method},
     {"rb_define_virtual_variable", (RUBY_PROC*)&dll_rb_define_virtual_variable},
     {"rb_stdout", (RUBY_PROC*)&dll_rb_stdout},
+    {"rb_stderr", (RUBY_PROC*)&dll_rb_stderr},
     {"rb_eArgError", (RUBY_PROC*)&dll_rb_eArgError},
     {"rb_eIndexError", (RUBY_PROC*)&dll_rb_eIndexError},
     {"rb_eRuntimeError", (RUBY_PROC*)&dll_rb_eRuntimeError},
@@ -1542,11 +1545,15 @@ static void ruby_io_init(void)
 {
 #ifndef DYNAMIC_RUBY
     RUBYEXTERN VALUE rb_stdout;
+    RUBYEXTERN VALUE rb_stderr;
 #endif
 
     rb_stdout = rb_obj_alloc(rb_cObject);
+    rb_stderr = rb_obj_alloc(rb_cObject);
     rb_define_singleton_method(rb_stdout, "write", vim_message, 1);
     rb_define_singleton_method(rb_stdout, "flush", f_nop, 0);
+    rb_define_singleton_method(rb_stderr, "write", vim_message, 1);
+    rb_define_singleton_method(rb_stderr, "flush", f_nop, 0);
     rb_define_global_function("p", f_p, -1);
 }
 


### PR DESCRIPTION
Problem
===

Sometimes Ruby program outputs warnings to stderr. And it breaks vim drawing when using if_ruby.
For example:

```vim
" in vimrc
ruby $stderr.write 'something'
```

It breaks Vim drawing. And reading the warning is hard. Because the warning will fade out by re-rendering of Vim.

Solution
====

Redirect stderr to vim message same as stdout.
This change will display warnings as vim's message, so it does not break drawing of Vim. And we can look again warnings by `:messages` command.