### PR TITLE
Function inputlist() was not covered with tests

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -810,6 +810,17 @@ func Test_col()
   bw!
 endfunc
 
+func Test_inputlist()
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>1\<cr>", 'tx')
+  call assert_equal(1, c)
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>2\<cr>", 'tx')
+  call assert_equal(2, c)
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>3\<cr>", 'tx')
+  call assert_equal(3, c)
+
+  call assert_fails('call inputlist("")', 'E686:')
+endfunc
+
 func Test_balloon_show()
   if has('balloon_eval')
     " This won't do anything but must not crash either.


### PR DESCRIPTION
This PR adds tests for function inputlist() which was not tested according to codecov:

https://codecov.io/gh/vim/vim/src/master/src/evalfunc.c#L6976

I also opened a regression bug as inputlist() no longer honor mouse selection (see https://github.com/vim/vim/issues/3239), but I don't think we can test mouse selection in automated tests.