### PR TITLE
Add UseBlacklist and UseBlocklist to runtime/syntax/sshdconfig.vim

### DIFF
--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -221,6 +221,7 @@ syn keyword sshdconfigKeyword Subsystem
 syn keyword sshdconfigKeyword SyslogFacility
 syn keyword sshdconfigKeyword TCPKeepAlive
 syn keyword sshdconfigKeyword TrustedUserCAKeys
+syn keyword sshdconfigKeyword UseBlacklist
 syn keyword sshdconfigKeyword UseDNS
 syn keyword sshdconfigKeyword UseLogin
 syn keyword sshdconfigKeyword UsePAM

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -222,6 +222,7 @@ syn keyword sshdconfigKeyword SyslogFacility
 syn keyword sshdconfigKeyword TCPKeepAlive
 syn keyword sshdconfigKeyword TrustedUserCAKeys
 syn keyword sshdconfigKeyword UseBlacklist
+syn keyword sshdconfigKeyword UseBlocklist
 syn keyword sshdconfigKeyword UseDNS
 syn keyword sshdconfigKeyword UseLogin
 syn keyword sshdconfigKeyword UsePAM


### PR DESCRIPTION
Add UseBlacklist to the sshdconfigKeyword syntax
group since support for blacklistd has been added
to OpenSSH since FreeBSD 11.1 and NetBSD 7.

https://www.freebsd.org/releases/11.1R/relnotes.html
http://www.netbsd.org/releases/formal-7/NetBSD-7.0.html

Problem:    UseBlacklist is not highlighted when editing sshd_config.
Solution:   Add UseBlacklist to sshdconfig.vim. (Samy Mahmoudi)

**Update (2020-10-07): add a second commit to this PR**
Add UseBlocklist to the sshdconfigKeyword syntax group
since blacklistd was renamed blocklistd upstream (NetBSD).
These changes have not been imported into all the relevant
operating systems (e.g. FreeBSD) yet, so maintain UseBlacklist
in this syntax group until the transition is done.

http://mail-index.netbsd.org/current-users/2020/06/15/msg038868.html
https://reviews.freebsd.org/rS363657

Problem:    UseBlocklist is not highlighted when editing sshd_config.
Solution:   Add UseBlocklist to sshdconfig.vim. (Samy Mahmoudi)