### PR TITLE
if_ruby: Convert `v:true` and `v:false` to `Qtrue` and `Qfalse`

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -1085,8 +1085,10 @@ static VALUE vim_to_ruby(typval_T *tv)
     }
     else if (tv->v_type == VAR_SPECIAL)
     {
-	if (tv->vval.v_number <= VVAL_TRUE)
-	    result = INT2NUM(tv->vval.v_number);
+	if (tv->vval.v_number == VVAL_TRUE)
+	    result = Qtrue;
+	else if (tv->vval.v_number == VVAL_FALSE)
+	    result = Qfalse;
     } /* else return Qnil; */
 
     return result;

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -33,6 +33,14 @@ func Test_ruby_evaluate_dict()
   call assert_equal(['{"a"=>"foo", "b"=>123}'], split(l:out, "\n"))
 endfunc
 
+func Test_ruby_evaluate_special_var()
+  let l = [v:true, v:false, v:null, v:none]
+  redir => l:out
+  ruby d = Vim.evaluate("l"); print d
+  redir END
+  call assert_equal(['[true, false, nil, nil]'], split(l:out, "\n"))
+endfunc
+
 func Test_rubydo()
   " Check deleting lines does not trigger ml_get error.
   new


### PR DESCRIPTION
Problem
===


`Vim.evaluate('v:true')` returns `1` in if_ruby.

```vim
:ruby p Vim.evaluate('[v:true, v:false]')
" => [1, 0]
```

Ruby evaluates both `1` and `0` as true in condition. So this returned values are meaningless.

Solution
===


Use `Qtrue` and `Qfalse` instead of `Integer`.
They are `true` and `false`.

Note
===

`vim_to_ruby` function converts both `v:null` and `v:none` to `Qnil` with and without this patch.
I think this behaviour has no problem.