### PR TITLE
Vim add 'noet' to modeline in documentation

### DIFF
--- a/runtime/doc/arabic.txt
+++ b/runtime/doc/arabic.txt
@@ -319,4 +319,4 @@ There is one known minor bug,
 
 No other bugs are known to exist.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1593,4 +1593,4 @@ This will write the file without triggering the autocommands defined by the
 gzip plugin.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1884,4 +1884,4 @@ The sorting can be interrupted, but if you interrupt it too late in the
 process you may end up with duplicated lines.  This also depends on the system
 library function used.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -816,4 +816,4 @@ the cursor to the last line.  "A" will move to the end of the line, "I" to the
 start of the line.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1164,4 +1164,4 @@ The character used for the pattern indicates the type of command-line:
 	@	string for |input()|
 	-	text for |:insert| or |:append|
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/debug.txt
+++ b/runtime/doc/debug.txt
@@ -172,4 +172,4 @@ Visual C++ 2005 Express Edition can be downloaded for free from:
     http://msdn.microsoft.com/vstudio/express/visualC/default.aspx
 
 =========================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/debugger.txt
+++ b/runtime/doc/debugger.txt
@@ -139,4 +139,4 @@ Programming Environment.
 
 For Sun NetBeans support see |netbeans|.
 
- vim:tw=78:sw=4:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -563,4 +563,4 @@ long	    32 or 64 bit signed, can hold a pointer
 Note that some compilers cannot handle long lines or strings.  The C89
 standard specifies a limit of 509 characters.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -441,4 +441,4 @@ evaluating 'patchexpr'.  This hopefully avoids that files in the current
 directory are accidentally patched.  Vim will also delete files starting with
 v:fname_in and ending in ".rej" and ".orig".
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/digraph.txt
+++ b/runtime/doc/digraph.txt
@@ -1488,4 +1488,4 @@ char  digraph	hex	dec	official name ~
 ﬅ	ft	FB05	64261	LATIN SMALL LIGATURE LONG S T
 ﬆ	st	FB06	64262	LATIN SMALL LIGATURE ST
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1747,4 +1747,4 @@ There are three different types of searching:
    currently work with 'path' items that contain a URL or use the double star
    with depth limiter (/usr/**2) or upward search (;) notations.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -11647,4 +11647,4 @@ without the |+eval| feature.
 Find more information in the file src/testdir/README.txt.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/farsi.txt
+++ b/runtime/doc/farsi.txt
@@ -266,4 +266,4 @@ changes made in the current line.
 
 For more information about the bugs refer to rileft.txt.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -695,4 +695,4 @@ The mappings can be disabled with: >
 <
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -601,4 +601,4 @@ used.  Otherwise the values from the window where the buffer was edited last
 are used.
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/ft_sql.txt
+++ b/runtime/doc/ft_sql.txt
@@ -777,4 +777,4 @@ Setting the filetype back to Perl sets all the usual "perl" related items back
 as they were.
 
 
-vim:tw=78:ts=8:ft=help:norl:
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -1075,4 +1075,4 @@ careful!
 For the Win32 GUI the external commands are executed in a separate window.
 See |gui-shell-win32|.
 
- vim:tw=78:sw=4:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -451,4 +451,4 @@ To try out if XPM support works do this: >
 	:exe 'sign place 1 line=1 name=vimxpm file=' . expand('%:p')
 <
 
- vim:tw=78:sw=4:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/gui_x11.txt
+++ b/runtime/doc/gui_x11.txt
@@ -721,4 +721,4 @@ and use CLIPBOARD ("+) for cut/copy/paste operations.  You thus have access to
 both by choosing to use either of the "* or "+ registers.
 
 
- vim:tw=78:sw=4:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/hangulin.txt
+++ b/runtime/doc/hangulin.txt
@@ -109,4 +109,4 @@ Send comments, patches and suggestions to:
 				    SungHyun Nam <goweol@gmail.com>
 				    Chi-Deok Hwang <...>
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/hebrew.txt
+++ b/runtime/doc/hebrew.txt
@@ -139,4 +139,4 @@ The result is that all Hebrew characters are displayed as ~x.  To solve this
 problem, set isprint=@,128-255.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -225,4 +225,4 @@ will try to find help for it.  Especially for options in single quotes, e.g.
 'compatible'.
 
 ------------------------------------------------------------------------------
- vim:tw=78:fo=tcq2:isk=!-~,^*,^\|,^\":ts=8:ft=help:norl:
+ vim:tw=78:fo=tcq2:isk=!-~,^*,^\|,^\":ts=8:noet:ft=help:norl:

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -370,4 +370,4 @@ highlighting.  So do these:
 
 You can find the details in $VIMRUNTIME/syntax/help.vim
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/howto.txt
+++ b/runtime/doc/howto.txt
@@ -93,4 +93,4 @@ How to ...				*howdoi* *how-do-i* *howto* *how-to*
 |2html.vim|		convert a colored file to HTML
 |less|			use Vim like less or more with syntax highlighting
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_cscop.txt
+++ b/runtime/doc/if_cscop.txt
@@ -484,4 +484,4 @@ For a cscope version for Win32 see (seems abandoned):
 Win32 support was added by Sergey Khorev <sergey.khorev@gmail.com>.  Contact
 him if you have Win32-specific issues.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_mzsch.txt
+++ b/runtime/doc/if_mzsch.txt
@@ -312,4 +312,4 @@ MzScheme's raco command:
   raco pkg install cext-lib         # raco ctool command
 <
 ======================================================================
-  vim:tw=78:ts=8:sts=4:ft=help:norl:
+  vim:tw=78:ts=8:noet:sts=4:ft=help:norl:

--- a/runtime/doc/if_ole.txt
+++ b/runtime/doc/if_ole.txt
@@ -202,4 +202,4 @@ In Vim >
 [.Net remarks provided by Dave Fishburn and Brian Sturk]
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -303,4 +303,4 @@ version of the shared library must match the Perl version Vim was compiled
 with.
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -924,4 +924,4 @@ If you have more than one version of Python 3, you need to link python3 to the
 one you prefer, before running configure.
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -234,4 +234,4 @@ version of the shared library must match the Ruby version Vim was compiled
 with.
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_sniff.txt
+++ b/runtime/doc/if_sniff.txt
@@ -8,4 +8,4 @@
 The SNiFF+ support was removed at patch 7.4.1433.  If you want to check it out
 sync to before that.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_tcl.txt
+++ b/runtime/doc/if_tcl.txt
@@ -544,4 +544,4 @@ of DYNAMIC_TCL_DLL file what was specified at compile time.  The version of
 the shared library must match the Tcl version Vim was compiled with.
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -1156,4 +1156,4 @@ indent for a continuation line, a line that starts with a backslash: >
 Three times shiftwidth is the default value.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1657,4 +1657,4 @@ tag	      command	      action ~
 |:~|		:~		repeat last ":substitute"
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -2005,4 +2005,4 @@ self explanatory.  Using the long or the short version depends on the
 	[READ ERRORS]			not all of the file could be read
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -906,4 +906,4 @@ buffer lines	logical lines	window lines	screen lines ~
 				6. ~ 
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1552,4 +1552,4 @@ local to the script and use mappings local to the script.  When the user
 invokes the user command, it will run in the context of the script it was
 defined in.  This matters if |<SID>| is used in a command.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -1467,4 +1467,4 @@ Contributions specifically for the multi-byte features by:
 	Taro Muraoka  <koron@tka.att.ne.jp>
 	Yasuhiro Matsumoto <mattn@mail.goo.ne.jp>
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -866,4 +866,4 @@ The |g<| command can be used to see the last page of previous command output.
 This is especially useful if you accidentally typed <Space> at the hit-enter
 prompt.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -210,4 +210,4 @@ a message adapt to language preferences of the user, >
 	:endif
 <
 
- vim:tw=78:sw=4:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1341,4 +1341,4 @@ L			To line [count] from bottom of window (default: Last
 			position is in a status line, that window is made the
 			active window and the cursor is not moved.  {not in Vi}
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/netbeans.txt
+++ b/runtime/doc/netbeans.txt
@@ -1007,4 +1007,4 @@ Expert tab MIME Type property.  NetBeans is MIME oriented and the External
 Editor will only open MIME types specified in this property.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -9204,4 +9204,4 @@ A jump table for the options with a short description can be found at |Q_op|.
 	screen.  When non-zero, characters are sent to the terminal one by
 	one.  For MS-DOS pcterm this does not work.  For debugging purposes.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_390.txt
+++ b/runtime/doc/os_390.txt
@@ -131,4 +131,4 @@ Also look at:
 
 
 ------------------------------------------------------------------------------
- vim:tw=78:fo=tcq2:ts=8:ft=help:norl:
+ vim:tw=78:fo=tcq2:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_amiga.txt
+++ b/runtime/doc/os_amiga.txt
@@ -144,4 +144,4 @@ Installation ~
 	;End VIM
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_beos.txt
+++ b/runtime/doc/os_beos.txt
@@ -317,4 +317,4 @@ it is about 1191K.
 <rhialto@polder.ubc.kun.nl>
 http://polder.ubc.kun.nl/~rhialto/be
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_dos.txt
+++ b/runtime/doc/os_dos.txt
@@ -295,4 +295,4 @@ When starting up, Vim checks for the presence of "sh" anywhere in the 'shell'
 option.  If it is present, Vim sets the 'shellcmdflag' and 'shellquote' or
 'shellxquote' options will be set as described above.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_mac.txt
+++ b/runtime/doc/os_mac.txt
@@ -179,4 +179,4 @@ the system clipboard, the darwin feature should be disabled to prevent Vim
 from hanging at runtime.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_mint.txt
+++ b/runtime/doc/os_mint.txt
@@ -36,4 +36,4 @@ Send bug reports to
 
 	Jens M. Felderhoff, e-mail: <jmf@infko.uni-koblenz.de>
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_msdos.txt
+++ b/runtime/doc/os_msdos.txt
@@ -12,4 +12,4 @@ work, there is not enough memory.  The DOS32 version (using DJGPP) might still
 work on older systems.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_os2.txt
+++ b/runtime/doc/os_os2.txt
@@ -10,4 +10,4 @@ This file used to contain the particularities for the OS/2 version of Vim.
 The OS/2 support was removed in patch 7.4.1008.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_qnx.txt
+++ b/runtime/doc/os_qnx.txt
@@ -135,4 +135,4 @@ Todo:
 	- Replace usage of fork() with spawn() when launching external
 	  programs.
 
- vim:tw=78:sw=4:ts=8:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ts=8:ft=help:norl:

--- a/runtime/doc/os_risc.txt
+++ b/runtime/doc/os_risc.txt
@@ -9,4 +9,4 @@ The RISC OS support has been removed from Vim with patch 7.3.187.
 If you would like to use Vim on RISC OS get the files from before that patch.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_unix.txt
+++ b/runtime/doc/os_unix.txt
@@ -57,4 +57,4 @@ For real color terminals the ":highlight" command can be used.
 The file "tools/vim132" is a shell script that can be used to put Vim in 132
 column mode on a vt100 and lookalikes.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_vms.txt
+++ b/runtime/doc/os_vms.txt
@@ -952,4 +952,4 @@ of OS_VMS.TXT:
 	Bruce Hunsaker <BNHunsaker@chq.byu.edu>
 	Sandor Kopanyi <sandor.kopanyi@mailbox.hu>
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -303,4 +303,4 @@ A. Yes, place your favorite icon in bitmaps/vim.ico in a directory of
    'runtimepath'.  For example ~/vimfiles/bitmaps/vim.ico.
 
 
- vim:tw=78:fo=tcq2:ts=8:ft=help:norl:
+ vim:tw=78:fo=tcq2:ts=8:noet:ft=help:norl:

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1417,4 +1417,4 @@ Finally, these constructs are unique to Perl:
 		":2match" for another plugin.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/pi_getscript.txt
+++ b/runtime/doc/pi_getscript.txt
@@ -479,4 +479,4 @@ v2  May 14, 2003 :   extracts name of item to be obtained from the
                      and they became numbers.  Fixes comparison.
 
 ==============================================================================
-vim:tw=78:ts=8:ft=help:fdm=marker
+vim:tw=78:ts=8:noet:ft=help:fdm=marker

--- a/runtime/doc/pi_gzip.txt
+++ b/runtime/doc/pi_gzip.txt
@@ -40,4 +40,4 @@ compression.  Thus editing the patchmode file will not give you the automatic
 decompression.  You have to rename the file if you want this.
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/pi_logipat.txt
+++ b/runtime/doc/pi_logipat.txt
@@ -118,4 +118,4 @@ Copyright: (c) 2004-2015 by Charles E. Campbell	*logiPat-copyright*
 
 
 ==============================================================================
-vim:tw=78:ts=8:ft=help
+vim:tw=78:ts=8:noet:ft=help

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -4267,4 +4267,4 @@ netrw:
 
 ==============================================================================
 Modelines: {{{1
- vim:tw=78:ts=8:ft=help:norl:fdm=marker
+ vim:tw=78:ts=8:noet:ft=help:norl:fdm=marker

--- a/runtime/doc/pi_paren.txt
+++ b/runtime/doc/pi_paren.txt
@@ -57,4 +57,4 @@ comments.  This is unrelated to the matchparen highlighting, they use a
 different mechanism.
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/pi_spec.txt
+++ b/runtime/doc/pi_spec.txt
@@ -108,4 +108,4 @@ If you don't like the release updating feature and don't want to answer
 
 Good luck!!
 
-vim:tw=78:ts=8:ft=help:norl:
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/pi_tar.txt
+++ b/runtime/doc/pi_tar.txt
@@ -148,4 +148,4 @@ Copyright 2005-2012:					*tar-copyright*
    v1 (original)   * Michael Toren (see http://michael.toren.net/code/)
 
 ==============================================================================
-vim:tw=78:ts=8:ft=help
+vim:tw=78:ts=8:noet:ft=help

--- a/runtime/doc/pi_vimball.txt
+++ b/runtime/doc/pi_vimball.txt
@@ -273,4 +273,4 @@ WINDOWS							*vimball-windows*
 
 
 ==============================================================================
-vim:tw=78:ts=8:ft=help:fdm=marker
+vim:tw=78:ts=8:noet:ft=help:fdm=marker

--- a/runtime/doc/pi_zip.txt
+++ b/runtime/doc/pi_zip.txt
@@ -149,4 +149,4 @@ Copyright: Copyright (C) 2005-2015 Charles E Campbell	 *zip-copyright*
    v1 Sep 15, 2005 * Initial release, had browsing, reading, and writing
 
 ==============================================================================
-vim:tw=78:ts=8:ft=help:fdm=marker
+vim:tw=78:ts=8:noet:ft=help:fdm=marker

--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -752,4 +752,4 @@ to adjust the number of lines before a formfeed character to prevent
 accidental blank pages.
 
 ==============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1794,4 +1794,4 @@ start of the file about how to use it.  (This script is deprecated, see
 
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1447,4 +1447,4 @@ Context-sensitive completion on the command-line:
 |zN|		zN			fold normal set 'foldenable'
 |zi|		zi			invert 'foldenable'
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/quotes.txt
+++ b/runtime/doc/quotes.txt
@@ -272,4 +272,4 @@ In summary:
 	    |____/ |_|	\___/|_|   |_|	 (_|_)	    (Tony Nugent, Australia) `
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -234,4 +234,4 @@ Note that after recovery the key of the swap file will be used for the text
 file.  Thus if you write the text file, you need to use that new key.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -204,4 +204,4 @@ When using gvim, the --remote-wait only works properly this way: >
 
 	start /w gvim --remote-wait file.txt
 <
- vim:tw=78:sw=4:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -1010,4 +1010,4 @@ mind there are various things that may clobber the results:
 - The "self" time is wrong when a function is used recursively.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/rileft.txt
+++ b/runtime/doc/rileft.txt
@@ -121,4 +121,4 @@ o  When both 'rightleft' and 'revins' are on: 'textwidth' does not work.
 o  There is no full bidirectionality (bidi) support.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/russian.txt
+++ b/runtime/doc/russian.txt
@@ -71,4 +71,4 @@ In order to use the Russian documentation, make sure you have set the
    releases of gettext.
 
 ===============================================================================
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/scroll.txt
+++ b/runtime/doc/scroll.txt
@@ -332,4 +332,4 @@ Add these mappings to your vimrc file: >
 	:map <M-Esc>[65~ <S-ScrollWheelDown>
 	:map! <M-Esc>[65~ <S-ScrollWheelDown>
 <
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -202,4 +202,4 @@ JUMPING TO A SIGN					*:sign-jump* *E157*
 		have a name.
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1646,4 +1646,4 @@ WORDCHARS	(Hunspell)				*spell-WORDCHARS*
 		is no need to separate words before checking them (using a
 		trie instead of a hashtable).
 
- vim:tw=78:sw=4:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/sponsor.txt
+++ b/runtime/doc/sponsor.txt
@@ -213,4 +213,4 @@ is done.  But a receipt is possible.
 
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1687,4 +1687,4 @@ most of the information will be restored).
 			Use ! to abandon a modified buffer. |abandon|
 			{not when compiled with tiny or small features}
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5478,4 +5478,4 @@ literal text specify the size of that text (in bytes):
 "<\@1<=span"	Matches the same, but only tries one byte before "span".
 
 
- vim:tw=78:sw=4:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -472,4 +472,4 @@ If you want to show something specific for a tab page, you might want to use a
 tab page local variable. |t:var|
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -854,4 +854,4 @@ Common arguments for the commands above:
 <	For a ":djump", ":dsplit", ":dlist" and ":dsearch" command the pattern
 	is used as a literal string, not as a search pattern.
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -977,4 +977,4 @@ To swap the meaning of the left and right mouse buttons: >
 	:noremap!	<RightDrag>	<LeftDrag>
 	:noremap!	<RightRelease>	<LeftRelease>
 <
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -909,4 +909,4 @@ for when the terminal can't be resized by Vim).
 
 
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -530,4 +530,4 @@ A slightly more advanced version is used in the |matchparen| plugin.
 	autocmd InsertEnter * match none
 <
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
This makes sure 'noexpandtab' is on when editing documentation pages to keep formatting consistent regardless of local settings.

A lot of large software companies (e.g. [Google](https://google.github.io/styleguide/cppguide.html#Spaces_vs._Tabs)) prefers using spaces to tabs. This means `expandtab` will be set for a large amount of developers. Setting `noexpandtab` using modeline makes sure contributors won't make mistakes when editing documentations, similar to the already existing `tw=78` modeline in docs. Also, the C files in Vim repo already sets `noet` in the modeline.