### PR TITLE
Update documentation for --clean

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -520,7 +520,8 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 		  'nocompatible': use Vim defaults
 		- no |gvimrc| script is loaded
 		- no viminfo file is read or written
-		- the home directory is excluded from 'runtimepath'
+		- the home directory is excluded from 'runtimepath' (does not
+		  happen with -u DEFAULTS)
 							*-x*
 -x		Use encryption to read/write files.  Will prompt for a key,
 		which is then stored in the 'key' option.  All writes will


### PR DESCRIPTION
The code (added in 8.0.1554) that excludes the home directory from
'runtimepath' is specific to --clean. One of the differences from -u
DEFAULTS is already described in this :help, so adding this difference
in, too.

Steps to reproduce:

1. `vim -u DEFAULTS`
2. `set runtimepath?`
3. `:q`
4. `vim --clean`
5. `set runtimepath?`
