### PR TITLE
Add *.fth extension for Forth

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -586,7 +586,7 @@ au BufNewFile,BufRead auto.master		setf conf
 au BufNewFile,BufRead *.mas,*.master		setf master
 
 " Forth
-au BufNewFile,BufRead *.fs,*.ft			setf forth
+au BufNewFile,BufRead *.fs,*.ft,*.fth		setf forth
 
 " Reva Forth
 au BufNewFile,BufRead *.frt			setf reva


### PR DESCRIPTION
This is the extension used in [the standard](http://www.forth.org/svfig/Win32Forth/DPANS94.txt) (see A.11.6.1.1010).