### PR TITLE
Recognize XML filetype for WSDL by extension

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1865,6 +1865,9 @@ au BufNewFile,BufRead */etc/xdg/menus/*.menu	setf xml
 " ATI graphics driver configuration
 au BufNewFile,BufRead fglrxrc			setf xml
 
+" Web Services Description Language (WSDL)
+au BufNewFile,BufRead *.wsdl			setf xml
+
 " XLIFF (XML Localisation Interchange File Format) is also XML
 au BufNewFile,BufRead *.xlf			setf xml
 au BufNewFile,BufRead *.xliff			setf xml


### PR DESCRIPTION
[Web Services Description Language](https://www.w3.org/TR/wsdl) is a W3C-standardized XML-based interface definition language.  The .wsdl extension is both conventional and defined in the [`application/wsdl+xml` media type registration](https://www.iana.org/assignments/media-types/application/wsdl+xml).

This PR sets the xml filetype for files with the .wsdl extension to handle cases where the XML prolog is not present, where the filetype would not otherwise be recognized.

Thanks for considering,
Kevin