### PR TITLE
unix: mch_can_exe: return FALSE with empty PATH

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -3188,8 +3188,10 @@ mch_can_exe(char_u *name, char_u **path, int use_path)
     }
 
     p = (char_u *)getenv("PATH");
-    if (p == NULL || *p == NUL)
+    if (p == NULL)
 	return -1;
+    if (*p == NUL)
+	return FALSE;
     buf = alloc((unsigned)(STRLEN(name) + STRLEN(p) + 2));
     if (buf == NULL)
 	return -1;


### PR DESCRIPTION
Without this `executable("foobar")` is 1 after `let $PATH=""`.

https://github.com/vim/vim/pull/3282 would change/fix this already, but
I think an empty $PATH should not be considered to be "not implemented".

This is not a real use case, but I am using this in tests.