### PR TITLE
Explicitly link to i_CTRL-O in intro.txt

### DIFF
--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -595,9 +595,9 @@ Virtual Replace mode	Virtual Replace mode is similar to Replace mode, but
 			If the 'showmode' option is on "-- VREPLACE --" is
 			shown at the bottom of the window.
 
-Insert Normal mode	Entered when CTRL-O given in Insert mode.  This is
-			like Normal mode, but after executing one command Vim
-			returns to Insert mode.
+Insert Normal mode	Entered when CTRL-O given in Insert mode (see
+			|i_CTRL-O|).  This is like Normal mode, but after
+			executing one command Vim returns to Insert mode.
 			If the 'showmode' option is on "-- (insert) --" is
 			shown at the bottom of the window.
 


### PR DESCRIPTION
* It's not trivial to open `i_CTRL-O` help for beginners from the sentence
  "Entered when CTRL-O given in Insert mode", considering it being intro
* With this patch users can navigate themselves by hitting CTRL-]