### PR TITLE
getftype() was not tested with fifo, symlinks , block and character device files

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5111,7 +5111,7 @@ f_getftype(typval_T *argvars, typval_T *rettv)
 # endif
 # ifdef S_ISSOCK
 	else if (S_ISSOCK(st.st_mode))
-	    t = "fifo";
+	    t = "socket";
 # endif
 	else
 	    t = "other";

--- a/src/testdir/test_stat.vim
+++ b/src/testdir/test_stat.vim
@@ -140,18 +140,21 @@ func Test_getftype()
     call delete('Xfifo')
   endif
 
-  " Test getftype with block and character devices in /dev/
-  for dev in glob('/dev/*', 0, 1)
-    let ftype = system('ls -l ' . dev)[0]
-    if ftype ==# 'b'
-      call assert_equal('bdev', getftype(dev))
-    elseif ftype ==# 'c'
-      call assert_equal('cdev', getftype(dev))
-    endif
+  for cdevfile in systemlist('find /dev -type c -maxdepth 2 2>/dev/null')
+    call assert_equal('cdev', getftype(cdevfile))
   endfor
 
-  " TODO: file types 'socket' and 'other' are not tested.
-  " How can we test those file types?
+  for bdevfile in systemlist('find /dev -type b -maxdepth 2 2>/dev/null')
+    call assert_equal('bdev', getftype(bdevfile))
+  endfor
+
+  " The /run/ directory typically contains socket files.
+  " If it does not, test won't fail but will not test socket files.
+  for socketfile in systemlist('find /run -type s -maxdepth 2 2>/dev/null')
+    call assert_equal('socket', getftype(socketfile))
+  endfor
+
+  " TODO: file type 'other' is not tested. How can we test it?
 endfunc
 
 func Test_win32_symlink_dir()

--- a/src/testdir/test_stat.vim
+++ b/src/testdir/test_stat.vim
@@ -122,6 +122,38 @@ func Test_nonexistent_file()
   call assert_equal('', getfperm(fname))
 endfunc
 
+func Test_getftype()
+  call assert_equal('file', getftype(v:progpath))
+  call assert_equal('dir',  getftype('.'))
+
+  if !has('unix')
+    return
+  endif
+
+  silent !ln -s Xfile Xlink
+  call assert_equal('link', getftype('Xlink'))
+  call delete('Xlink')
+
+  if executable('mkfifo')
+    silent !mkfifo Xfifo
+    call assert_equal('fifo', getftype('Xfifo'))
+    call delete('Xfifo')
+  endif
+
+  " Test getftype with block and character devices in /dev/
+  for dev in glob('/dev/*', 0, 1)
+    let ftype = system('ls -l ' . dev)[0]
+    if ftype ==# 'b'
+      call assert_equal('bdev', getftype(dev))
+    elseif ftype ==# 'c'
+      call assert_equal('cdev', getftype(dev))
+    endif
+  endfor
+
+  " TODO: file types 'socket' and 'other' are not tested.
+  " How can we test those file types?
+endfunc
+
 func Test_win32_symlink_dir()
   " On Windows, non-admin users cannot create symlinks.
   " So we use an existing symlink for this test.


### PR DESCRIPTION
This PR improves test coverage of getftype(): getftype() was not
tested for fifo, symlinks, block and character device files. See:

https://codecov.io/gh/vim/vim/src/f8f88f89e12df516c1fac5851b504238ebc1d2d4/src/evalfunc.c#L5097

The PR still does not test with socket files as I don't think that there is
a an easy way to create socket files types.