### PR TITLE
Define S_IS macros for stat()

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -204,13 +204,8 @@ open_buffer(
 #endif
 #ifdef UNIX
 	perm = mch_getperm(curbuf->b_ffname);
-	if (perm >= 0 && (0
-# ifdef S_ISFIFO
-		      || S_ISFIFO(perm)
-# endif
-# ifdef S_ISSOCK
+	if (perm >= 0 && (S_ISFIFO(perm)
 		      || S_ISSOCK(perm)
-# endif
 # ifdef OPEN_CHR_FILES
 		      || (S_ISCHR(perm) && is_dev_fd_file(curbuf->b_ffname))
 # endif

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5088,63 +5088,22 @@ f_getftype(typval_T *argvars, typval_T *rettv)
     rettv->v_type = VAR_STRING;
     if (mch_lstat((char *)fname, &st) >= 0)
     {
-#ifdef S_ISREG
 	if (S_ISREG(st.st_mode))
 	    t = "file";
 	else if (S_ISDIR(st.st_mode))
 	    t = "dir";
-# ifdef S_ISLNK
 	else if (S_ISLNK(st.st_mode))
 	    t = "link";
-# endif
-# ifdef S_ISBLK
 	else if (S_ISBLK(st.st_mode))
 	    t = "bdev";
-# endif
-# ifdef S_ISCHR
 	else if (S_ISCHR(st.st_mode))
 	    t = "cdev";
-# endif
-# ifdef S_ISFIFO
 	else if (S_ISFIFO(st.st_mode))
 	    t = "fifo";
-# endif
-# ifdef S_ISSOCK
 	else if (S_ISSOCK(st.st_mode))
 	    t = "socket";
-# endif
 	else
 	    t = "other";
-#else
-# ifdef S_IFMT
-	switch (st.st_mode & S_IFMT)
-	{
-	    case S_IFREG: t = "file"; break;
-	    case S_IFDIR: t = "dir"; break;
-#  ifdef S_IFLNK
-	    case S_IFLNK: t = "link"; break;
-#  endif
-#  ifdef S_IFBLK
-	    case S_IFBLK: t = "bdev"; break;
-#  endif
-#  ifdef S_IFCHR
-	    case S_IFCHR: t = "cdev"; break;
-#  endif
-#  ifdef S_IFIFO
-	    case S_IFIFO: t = "fifo"; break;
-#  endif
-#  ifdef S_IFSOCK
-	    case S_IFSOCK: t = "socket"; break;
-#  endif
-	    default: t = "other";
-	}
-# else
-	if (mch_isdir(fname))
-	    t = "dir";
-	else
-	    t = "file";
-# endif
-#endif
 	type = vim_strsave((char_u *)t);
     }
     rettv->vval.v_string = type;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -424,12 +424,8 @@ readfile(
 	 */
 	perm = mch_getperm(fname);
 	if (perm >= 0 && !S_ISREG(perm)		    /* not a regular file ... */
-# ifdef S_ISFIFO
 		      && !S_ISFIFO(perm)	    /* ... or fifo */
-# endif
-# ifdef S_ISSOCK
 		      && !S_ISSOCK(perm)	    /* ... or socket */
-# endif
 # ifdef OPEN_CHR_FILES
 		      && !(S_ISCHR(perm) && is_dev_fd_file(fname))
 			/* ... or a character special file named /dev/fd/<n> */
@@ -2497,28 +2493,11 @@ failed:
 	    c = FALSE;
 
 #ifdef UNIX
-# ifdef S_ISFIFO
-	    if (S_ISFIFO(perm))			    /* fifo or socket */
+	    if (S_ISFIFO(perm) || S_ISSOCK(perm))   /* fifo or socket */
 	    {
 		STRCAT(IObuff, _("[fifo/socket]"));
 		c = TRUE;
 	    }
-# else
-#  ifdef S_IFIFO
-	    if ((perm & S_IFMT) == S_IFIFO)	    /* fifo */
-	    {
-		STRCAT(IObuff, _("[fifo]"));
-		c = TRUE;
-	    }
-#  endif
-#  ifdef S_IFSOCK
-	    if ((perm & S_IFMT) == S_IFSOCK)	    /* or socket */
-	    {
-		STRCAT(IObuff, _("[socket]"));
-		c = TRUE;
-	    }
-#  endif
-# endif
 # ifdef OPEN_CHR_FILES
 	    if (S_ISCHR(perm))			    /* or character special */
 	    {

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -2493,9 +2493,14 @@ failed:
 	    c = FALSE;
 
 #ifdef UNIX
-	    if (S_ISFIFO(perm) || S_ISSOCK(perm))   /* fifo or socket */
+	    if (S_ISFIFO(perm))			    /* fifo */
 	    {
-		STRCAT(IObuff, _("[fifo/socket]"));
+		STRCAT(IObuff, _("[fifo]"));
+		c = TRUE;
+	    }
+	    if (S_ISSOCK(perm))			    /* or socket */
+	    {
+		STRCAT(IObuff, _("[socket]"));
 		c = TRUE;
 	    }
 # ifdef OPEN_CHR_FILES

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -581,11 +581,7 @@ staterr:
 
 	i = cs_insert_filelist(fname2, ppath, flags, &statbuf);
     }
-    else if (S_ISREG(statbuf.st_mode)
-#if defined(UNIX)
-	    || S_ISLNK(statbuf.st_mode)
-#endif
-	    )
+    else if (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode))
     {
 	i = cs_insert_filelist(fname, ppath, flags, &statbuf);
     }

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -550,7 +550,7 @@ staterr:
     }
 
     /* if filename is a directory, append the cscope database name to it */
-    if ((statbuf.st_mode & S_IFMT) == S_IFDIR)
+    if (S_ISDIR(statbuf.st_mode))
     {
 	fname2 = (char *)alloc((unsigned)(strlen(CSCOPE_DBFILE) + strlen(fname) + 2));
 	if (fname2 == NULL)
@@ -581,12 +581,11 @@ staterr:
 
 	i = cs_insert_filelist(fname2, ppath, flags, &statbuf);
     }
+    else if (S_ISREG(statbuf.st_mode)
 #if defined(UNIX)
-    else if (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode))
-#else
-	/* WIN32 - substitute define S_ISREG from os_unix.h */
-    else if (((statbuf.st_mode) & S_IFMT) == S_IFREG)
+	    || S_ISLNK(statbuf.st_mode)
 #endif
+	    )
     {
 	i = cs_insert_filelist(fname, ppath, flags, &statbuf);
     }

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -3138,11 +3138,7 @@ mch_isdir(char_u *name)
 	return FALSE;
     if (stat((char *)name, &statb))
 	return FALSE;
-#ifdef _POSIX_SOURCE
     return (S_ISDIR(statb.st_mode) ? TRUE : FALSE);
-#else
-    return ((statb.st_mode & S_IFMT) == S_IFDIR ? TRUE : FALSE);
-#endif
 }
 
 /*
@@ -3159,11 +3155,7 @@ mch_isrealdir(char_u *name)
 	return FALSE;
     if (mch_lstat((char *)name, &statb))
 	return FALSE;
-#ifdef _POSIX_SOURCE
     return (S_ISDIR(statb.st_mode) ? TRUE : FALSE);
-#else
-    return ((statb.st_mode & S_IFMT) == S_IFDIR ? TRUE : FALSE);
-#endif
 }
 
 static int executable_file(char_u *name);

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -458,25 +458,6 @@ int mch_rename(const char *src, const char *dest);
 # endif
 #endif
 
-#if !defined(S_ISDIR) && defined(S_IFDIR)
-# define	S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
-#endif
-#if !defined(S_ISREG) && defined(S_IFREG)
-# define	S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
-#endif
-#if !defined(S_ISBLK) && defined(S_IFBLK)
-# define	S_ISBLK(m) (((m) & S_IFMT) == S_IFBLK)
-#endif
-#if !defined(S_ISSOCK) && defined(S_IFSOCK)
-# define	S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)
-#endif
-#if !defined(S_ISFIFO) && defined(S_IFIFO)
-# define	S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
-#endif
-#if !defined(S_ISCHR) && defined(S_IFCHR)
-# define	S_ISCHR(m) (((m) & S_IFMT) == S_IFCHR)
-#endif
-
 /* Note: Some systems need both string.h and strings.h (Savage).  However,
  * some systems can't handle both, only use string.h in that case. */
 #ifdef HAVE_STRING_H

--- a/src/vim.h
+++ b/src/vim.h
@@ -2300,6 +2300,58 @@ typedef enum {
 # endif
 #endif
 
+/* stat macros */
+#ifndef S_ISDIR
+# ifdef S_IFDIR
+#  define S_ISDIR(m)	(((m) & S_IFMT) == S_IFDIR)
+# else
+#  define S_ISDIR(m)	0
+# endif
+#endif
+#ifndef S_ISREG
+# ifdef S_IFREG
+#  define S_ISREG(m)	(((m) & S_IFMT) == S_IFREG)
+# else
+#  define S_ISREG(m)	0
+# endif
+#endif
+#ifndef S_ISBLK
+# ifdef S_IFBLK
+#  define S_ISBLK(m)	(((m) & S_IFMT) == S_IFBLK)
+# else
+#  define S_ISBLK(m)	0
+# endif
+#endif
+#ifndef S_ISSOCK
+# ifdef S_IFSOCK
+#  define S_ISSOCK(m)	(((m) & S_IFMT) == S_IFSOCK)
+# else
+#  define S_ISSOCK(m)	0
+# endif
+#endif
+#ifndef S_ISFIFO
+# ifdef S_IFFIFO
+#  define S_ISFIFO(m)	(((m) & S_IFMT) == S_IFFIFO)
+# else
+#  define S_ISFIFO(m)	0
+# endif
+#endif
+#ifndef S_ISCHR
+# ifdef S_IFCHR
+#  define S_ISCHR(m)	(((m) & S_IFMT) == S_IFCHR)
+# else
+#  define S_ISCHR(m)	0
+# endif
+#endif
+#ifndef S_ISLNK
+# ifdef S_IFLNK
+#  define S_ISLNK(m)	(((m) & S_IFMT) == S_IFLNK)
+# else
+#  define S_ISLNK(m)	0
+# endif
+#endif
+
+
 #define SIGN_BYTE 1	    /* byte value used where sign is displayed;
 			       attribute value is sign type */
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -2542,8 +2542,8 @@ typedef enum {
 # endif
 #endif
 #ifndef S_ISFIFO
-# ifdef S_IFFIFO
-#  define S_ISFIFO(m)	(((m) & S_IFMT) == S_IFFIFO)
+# ifdef S_IFIFO
+#  define S_ISFIFO(m)	(((m) & S_IFMT) == S_IFIFO)
 # else
 #  define S_ISFIFO(m)	0
 # endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -2290,16 +2290,6 @@ typedef enum {
 
 #endif
 
-/* ISSYMLINK(mode) tests if a file is a symbolic link. */
-#if (defined(S_IFMT) && defined(S_IFLNK)) || defined(S_ISLNK)
-# define HAVE_ISSYMLINK
-# if defined(S_IFMT) && defined(S_IFLNK)
-#  define ISSYMLINK(mode) (((mode) & S_IFMT) == S_IFLNK)
-# else
-#  define ISSYMLINK(mode) S_ISLNK(mode)
-# endif
-#endif
-
 /* stat macros */
 #ifndef S_ISDIR
 # ifdef S_IFDIR

--- a/src/vim.h
+++ b/src/vim.h
@@ -2290,57 +2290,6 @@ typedef enum {
 
 #endif
 
-/* stat macros */
-#ifndef S_ISDIR
-# ifdef S_IFDIR
-#  define S_ISDIR(m)	(((m) & S_IFMT) == S_IFDIR)
-# else
-#  define S_ISDIR(m)	0
-# endif
-#endif
-#ifndef S_ISREG
-# ifdef S_IFREG
-#  define S_ISREG(m)	(((m) & S_IFMT) == S_IFREG)
-# else
-#  define S_ISREG(m)	0
-# endif
-#endif
-#ifndef S_ISBLK
-# ifdef S_IFBLK
-#  define S_ISBLK(m)	(((m) & S_IFMT) == S_IFBLK)
-# else
-#  define S_ISBLK(m)	0
-# endif
-#endif
-#ifndef S_ISSOCK
-# ifdef S_IFSOCK
-#  define S_ISSOCK(m)	(((m) & S_IFMT) == S_IFSOCK)
-# else
-#  define S_ISSOCK(m)	0
-# endif
-#endif
-#ifndef S_ISFIFO
-# ifdef S_IFFIFO
-#  define S_ISFIFO(m)	(((m) & S_IFMT) == S_IFFIFO)
-# else
-#  define S_ISFIFO(m)	0
-# endif
-#endif
-#ifndef S_ISCHR
-# ifdef S_IFCHR
-#  define S_ISCHR(m)	(((m) & S_IFMT) == S_IFCHR)
-# else
-#  define S_ISCHR(m)	0
-# endif
-#endif
-#ifndef S_ISLNK
-# ifdef S_IFLNK
-#  define S_ISLNK(m)	(((m) & S_IFMT) == S_IFLNK)
-# else
-#  define S_ISLNK(m)	0
-# endif
-#endif
-
 
 #define SIGN_BYTE 1	    /* byte value used where sign is displayed;
 			       attribute value is sign type */
@@ -2559,8 +2508,59 @@ typedef enum {
 
 /* BSD is supposed to cover FreeBSD and similar systems. */
 #if (defined(SUN_SYSTEM) || defined(BSD) || defined(__FreeBSD_kernel__)) \
-	&& defined(S_ISCHR)
+	&& (defined(S_ISCHR) || defined(S_IFCHR))
 # define OPEN_CHR_FILES
+#endif
+
+/* stat macros */
+#ifndef S_ISDIR
+# ifdef S_IFDIR
+#  define S_ISDIR(m)	(((m) & S_IFMT) == S_IFDIR)
+# else
+#  define S_ISDIR(m)	0
+# endif
+#endif
+#ifndef S_ISREG
+# ifdef S_IFREG
+#  define S_ISREG(m)	(((m) & S_IFMT) == S_IFREG)
+# else
+#  define S_ISREG(m)	0
+# endif
+#endif
+#ifndef S_ISBLK
+# ifdef S_IFBLK
+#  define S_ISBLK(m)	(((m) & S_IFMT) == S_IFBLK)
+# else
+#  define S_ISBLK(m)	0
+# endif
+#endif
+#ifndef S_ISSOCK
+# ifdef S_IFSOCK
+#  define S_ISSOCK(m)	(((m) & S_IFMT) == S_IFSOCK)
+# else
+#  define S_ISSOCK(m)	0
+# endif
+#endif
+#ifndef S_ISFIFO
+# ifdef S_IFFIFO
+#  define S_ISFIFO(m)	(((m) & S_IFMT) == S_IFFIFO)
+# else
+#  define S_ISFIFO(m)	0
+# endif
+#endif
+#ifndef S_ISCHR
+# ifdef S_IFCHR
+#  define S_ISCHR(m)	(((m) & S_IFMT) == S_IFCHR)
+# else
+#  define S_ISCHR(m)	0
+# endif
+#endif
+#ifndef S_ISLNK
+# ifdef S_IFLNK
+#  define S_ISLNK(m)	(((m) & S_IFMT) == S_IFLNK)
+# else
+#  define S_ISLNK(m)	0
+# endif
 #endif
 
 #if defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H)


### PR DESCRIPTION
Inspired by #3300.

S_ISxxx macros are not available in Windows and some old un*x.
Current source code has many #ifdefs because of this.
Move the definitions in os_unix.h to vim.h (with some modifications) and simplify the code.
If the corresponding S_IFxxx macro is not available, define with 0.

Also remove the unused macro ISSYMLINK().
Now we can S_ISLNK() instead. (It always returns 0 on Windows, though.)