### PR TITLE
Replace use of strrchr with strchr

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -281,7 +281,7 @@ linelen(int *has_tab)
     *last = NUL;
     len = linetabsize(line);		/* get line length */
     if (has_tab != NULL)		/* check for embedded TAB */
-	*has_tab = (vim_strrchr(first, TAB) != NULL);
+	*has_tab = (vim_strchr(first, TAB) != NULL);
     *last = save;
 
     return len;


### PR DESCRIPTION
When checking for existence of character in string, it is more efficient to use `strchr` than `strrchr`.