### PR TITLE
if_ruby: `Kernel.#p` returns arguments

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -299,6 +299,11 @@ static void ruby_vim_init(void);
 #  define rb_string_value_ptr		dll_rb_string_value_ptr
 #  define rb_float_new			dll_rb_float_new
 #  define rb_ary_new			dll_rb_ary_new
+#  ifdef rb_ary_new4
+#    define RB_ARY_NEW4_MACRO 1
+#    undef rb_ary_new4
+#  endif
+#  define rb_ary_new4			dll_rb_ary_new4
 #  define rb_ary_push			dll_rb_ary_push
 #  if defined(RUBY19_OR_LATER) || defined(RUBY_INIT_STACK)
 #   ifdef __ia64
@@ -441,6 +446,7 @@ static int (*dll_rb_w32_snprintf)(char*, size_t, const char*, ...);
 static char * (*dll_rb_string_value_ptr) (volatile VALUE*);
 static VALUE (*dll_rb_float_new) (double);
 static VALUE (*dll_rb_ary_new) (void);
+static VALUE (*dll_rb_ary_new4) (long n, const VALUE *elts);
 static VALUE (*dll_rb_ary_push) (VALUE, VALUE);
 #  if defined(RUBY19_OR_LATER) || defined(RUBY_INIT_STACK)
 #   ifdef __ia64
@@ -647,6 +653,11 @@ static struct
     {"rb_float_new_in_heap", (RUBY_PROC*)&dll_rb_float_new},
 #  endif
     {"rb_ary_new", (RUBY_PROC*)&dll_rb_ary_new},
+#  ifdef RB_ARY_NEW4_MACRO
+    {"rb_ary_new_from_values", (RUBY_PROC*)&dll_rb_ary_new4},
+#  else
+    {"rb_ary_new4", (RUBY_PROC*)&dll_rb_ary_new4},
+#  endif
     {"rb_ary_push", (RUBY_PROC*)&dll_rb_ary_push},
 # endif
 # ifdef RUBY19_OR_LATER
@@ -1577,6 +1588,7 @@ static VALUE f_p(int argc, VALUE *argv, VALUE self UNUSED)
 {
     int i;
     VALUE str = rb_str_new("", 0);
+    VALUE ret = Qnil;
 
     for (i = 0; i < argc; i++)
     {
@@ -1584,7 +1596,14 @@ static VALUE f_p(int argc, VALUE *argv, VALUE self UNUSED)
 	rb_str_concat(str, rb_inspect(argv[i]));
     }
     MSG(RSTRING_PTR(str));
-    return Qnil;
+
+    if (argc == 1) {
+	ret = argv[0];
+    }
+    else if (argc > 1) {
+	ret = rb_ary_new4(argc, argv);
+    }
+    return ret;
 }
 
 static void ruby_io_init(void)

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -369,6 +369,8 @@ func Test_p()
   call assert_equal('123', RubyEval('p(123)'))
   call assert_equal('[1, 2, 3]', RubyEval('p(1, 2, 3)'))
 
+  " Avoid the "message maintainer" line.
+  let $LANG = ''
   messages clear
   call assert_equal('true', RubyEval('p() == nil'))
 

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -363,4 +363,15 @@ func Test_p()
   ruby p 'Just a test'
   let messages = split(execute('message'), "\n")
   call assert_equal('"Just a test"', messages[-1])
+
+  " Check return values of p method
+
+  call assert_equal('123', RubyEval('p(123)'))
+  call assert_equal('[1, 2, 3]', RubyEval('p(1, 2, 3)'))
+
+  messages clear
+  call assert_equal('true', RubyEval('p() == nil'))
+
+  let messages = split(execute('message'), "\n")
+  call assert_equal(0, len(messages))
 endfunc


### PR DESCRIPTION
# Problem

Ruby's `Kernel.#p` method returns arguments. But the method always returns `nil` with if_ruby because if_ruby redefines `p` method.


For example:



```bash
# In pure Ruby
$ ruby -e 'p(p(10))'
10
10
```


```vim
" with if_ruby
:ruby p(p(10))
10
nil
```


# Solution


Copy `p` method implementation from Ruby code.
https://github.com/ruby/ruby/blob/92c03be88847118bb64fb3ce035520b049247af5/io.c#L7734-L7756

# Note

`rb_ary_new_from_values` has been introduced since Ruby 2.1.0 as alias of `rb_ary_new4`.
https://github.com/ruby/ruby/blob/92c03be88847118bb64fb3ce035520b049247af5/doc/ChangeLog-2.1.0#L12523-L12529
And `rb_ary_new4` changed from a function to a macro. So this patch has a switch by a macro to use rb_ary_new4 with dynamic linking in Ruby 2.1.0 or newer.



I tested this patch with Ruby 1.9.3 ~ 2.5.1 and static / dynamic link.

By the way, I would like to drop the support Ruby 1.9 or older. So I'll create another issue for this suggestion.