### PR TITLE
[RFC] script_dump_profile: display SNR with SCRIPT headers

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1934,7 +1934,7 @@ script_dump_profile(FILE *fd)
 	si = &SCRIPT_ITEM(id);
 	if (si->sn_prof_on)
 	{
-	    fprintf(fd, "SCRIPT  %s\n", si->sn_name);
+	    fprintf(fd, "SCRIPT  %s (<SNR>_%d)\n", si->sn_name, id);
 	    if (si->sn_pr_count == 1)
 		fprintf(fd, "Sourced 1 time\n");
 	    else


### PR DESCRIPTION
Not really necessary with https://github.com/vim/vim/pull/3329, but
might be good in general anyway.

Ref: https://github.com/vim/vim/issues/3286