### PR TITLE
curswant is not set on quickfix jumps

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3010,6 +3010,7 @@ qf_jump_goto_line(
 			++screen_col;
 		}
 	    }
+	    curwin->w_set_curswant = TRUE;
 	    check_cursor();
 	}
 	else

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -3546,3 +3546,12 @@ func Test_view_result_split()
   call Xview_result_split_tests('c')
   call Xview_result_split_tests('l')
 endfunc
+
+" Test that :cc sets curswant
+func Test_curswant()
+  helpgrep quickfix
+  normal! llll
+  1cc
+  call assert_equal(getcurpos()[4], virtcol('.'))
+  cclose | helpclose
+endfunc


### PR DESCRIPTION
I noticed that when jumping using quickfix commands such as `:cc` and `:cnext`,  the cursor often moves unexpectedly horizontally when typing `j` ad `k`.  This seems to be caused by not setting curswant in `qf_jump_goto_line`.

It can be reproduced by `vim --clean -c 'helpgrep screen' -c '2q|copen'` then alternating between `:cnext` and moving cursor up and down with `j`/`k`, specifically `:1cc`, `hhhh`, `:1cc`, `j`
