### PR TITLE
Fix for line2byte(line("$")) returning wrong value when noendofline and nofixendofline options are set.

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -5267,7 +5267,7 @@ ml_find_line_or_offset(buf_T *buf, linenr_T lnum, long *offp)
 	/* Don't count the last line break if 'noeol' and ('bin' or
 	 * 'nofixeol'). */
 	if ((!buf->b_p_fixeol || buf->b_p_bin) && !buf->b_p_eol
-					   && buf->b_ml.ml_line_count == lnum)
+					   && lnum > buf->b_ml.ml_line_count)
 	    size -= ffdos + 1;
     }
 

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -682,6 +682,7 @@ endfunc
 
 func Test_byte2line_line2byte()
   new
+  set endofline
   call setline(1, ['a', 'bc', 'd'])
 
   set fileformat=unix
@@ -702,7 +703,17 @@ func Test_byte2line_line2byte()
   call assert_equal([-1, -1, 1, 4, 8, 11, -1],
   \                 map(range(-1, 5), 'line2byte(v:val)'))
 
-  set fileformat&
+  bw!
+
+  set noendofline nofixendofline
+  normal a-
+  for ff in ["unix", "mac", "dos"]
+    let &fileformat = ff
+    call assert_equal(1, line2byte(1))
+    call assert_equal(2, line2byte(2))  " line2byte(line("$") + 1) is the buffer size plus one (as per :help line2byte).
+  endfor
+
+  set endofline& fixendofline& fileformat&
   bw!
 endfunc
 


### PR DESCRIPTION
line2byte({lnum}) with {lnum} == last line was treated as a special case when it shouldn't have been. The "special case" is when {lnum} is _one beyond_ the last line and the noendofline and nofixendofline/binary options are set.