### PR TITLE
Amend omnifunc return value documentation

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1054,10 +1054,11 @@ could be part of the completed item.  The text between this column and the
 cursor column will be replaced with the matches.
 
 Special return values:
-   -1 If no completion can be done, the completion will be cancelled with an
-      error message.
    -2 To cancel silently and stay in completion mode.
    -3 To cancel silently and leave completion mode.
+
+If another value is returned, completion is assumed to start at the cursor
+column.
 
 On the second invocation the arguments are:
    a:findstart  0


### PR DESCRIPTION
The documentation says that [the completion is cancelled if the return value of the omnifunc is -1](https://github.com/vim/vim/blob/3f6a16f022c437eccaeb683640b25a972cb1b376/runtime/doc/insert.txt#L1057-L1058). In fact, if we look at [the code](https://github.com/vim/vim/blob/3f6a16f022c437eccaeb683640b25a972cb1b376/src/edit.c#L5585-L5621), nothing special is done for that value and the completion is assumed to start at the cursor column. This PR updates the documentation to reflect this.