### PR TITLE
Use sig_atomic_t instead of int in variables read/written by signal handlers

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -518,7 +518,7 @@ EXTERN char	*foreground_argument INIT(= NULL);
  *
  * volatile because it is used in signal handler sig_sysmouse().
  */
-EXTERN volatile int hold_gui_events INIT(= 0);
+EXTERN volatile sig_atomic_t hold_gui_events INIT(= 0);
 
 /*
  * When resizing the shell is postponed, remember the new size, and call
@@ -655,7 +655,7 @@ EXTERN int	entered_free_all_mem INIT(= FALSE);
 				/* TRUE when in or after free_all_mem() */
 #endif
 /* volatile because it is used in signal handler deathtrap(). */
-EXTERN volatile int full_screen INIT(= FALSE);
+EXTERN volatile sig_atomic_t full_screen INIT(= FALSE);
 				/* TRUE when doing full-screen output
 				 * otherwise only writing some messages */
 
@@ -800,11 +800,11 @@ EXTERN JMP_BUF x_jump_env;
 EXTERN JMP_BUF lc_jump_env;	/* argument to SETJMP() */
 # ifdef SIGHASARG
 /* volatile because it is used in signal handlers. */
-EXTERN volatile int lc_signal;	/* caught signal number, 0 when no was signal
+EXTERN volatile sig_atomic_t lc_signal;	/* caught signal number, 0 when no was signal
 				   caught; used for mch_libcall() */
 # endif
 /* volatile because it is used in signal handler deathtrap(). */
-EXTERN volatile int lc_active INIT(= FALSE); /* TRUE when lc_jump_env is valid. */
+EXTERN volatile sig_atomic_t lc_active INIT(= FALSE); /* TRUE when lc_jump_env is valid. */
 #endif
 
 #if defined(FEAT_MBYTE) || defined(FEAT_POSTSCRIPT)
@@ -1037,7 +1037,7 @@ EXTERN FILE	*scriptout  INIT(= NULL);   /* stream to write script to */
 EXTERN int	read_cmd_fd INIT(= 0);	    /* fd to read commands from */
 
 /* volatile because it is used in signal handler catch_sigint(). */
-EXTERN volatile int got_int INIT(= FALSE);    /* set to TRUE when interrupt
+EXTERN volatile sig_atomic_t got_int INIT(= FALSE); /* set to TRUE when interrupt
 						signal occurred */
 #ifdef USE_TERM_CONSOLE
 EXTERN int	term_console INIT(= FALSE); /* set to TRUE when console used */

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -161,7 +161,7 @@ static int get_x11_title(int);
 static int get_x11_icon(int);
 
 static char_u	*oldtitle = NULL;
-static volatile int oldtitle_outdated = FALSE;
+static volatile sig_atomic_t oldtitle_outdated = FALSE;
 static int	did_set_title = FALSE;
 static char_u	*oldicon = NULL;
 static int	did_set_icon = FALSE;
@@ -205,7 +205,7 @@ static RETSIGTYPE catch_sigpwr SIGPROTOARG;
 # define SET_SIG_ALARM
 static RETSIGTYPE sig_alarm SIGPROTOARG;
 /* volatile because it is used in signal handler sig_alarm(). */
-static volatile int sig_alarm_called;
+static volatile sig_atomic_t sig_alarm_called;
 #endif
 static RETSIGTYPE deathtrap SIGPROTOARG;
 
@@ -231,13 +231,13 @@ static int save_patterns(int num_pat, char_u **pat, int *num_file, char_u ***fil
 #endif
 
 /* volatile because it is used in signal handler sig_winch(). */
-static volatile int do_resize = FALSE;
+static volatile sig_atomic_t do_resize = FALSE;
 static char_u	*extra_shell_arg = NULL;
 static int	show_shell_mess = TRUE;
 /* volatile because it is used in signal handler deathtrap(). */
-static volatile int deadly_signal = 0;	    /* The signal we caught */
+static volatile sig_atomic_t deadly_signal = 0;	   /* The signal we caught */
 /* volatile because it is used in signal handler deathtrap(). */
-static volatile int in_mch_delay = FALSE;    /* sleeping in mch_delay() */
+static volatile sig_atomic_t in_mch_delay = FALSE; /* sleeping in mch_delay() */
 
 #if defined(FEAT_JOB_CHANNEL) && !defined(USE_SYSTEM)
 static int dont_check_job_ended = 0;
@@ -1247,7 +1247,7 @@ after_sigcont(void)
 
 #if defined(SIGCONT)
 static RETSIGTYPE sigcont_handler SIGPROTOARG;
-static volatile int in_mch_suspend = FALSE;
+static volatile sig_atomic_t in_mch_suspend = FALSE;
 
 /*
  * With multi-threading, suspending might not work immediately.  Catch the
@@ -1260,7 +1260,7 @@ static volatile int in_mch_suspend = FALSE;
  *
  * volatile because it is used in signal handler sigcont_handler().
  */
-static volatile int sigcont_received;
+static volatile sig_atomic_t sigcont_received;
 static RETSIGTYPE sigcont_handler SIGPROTOARG;
 
 /*

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -89,6 +89,7 @@
 
 #define FNAME_ILLEGAL "\"*?><|" /* illegal characters in a file name */
 
+#include <signal.h>
 #include <stdlib.h>
 #include <time.h>
 #include <sys/types.h>


### PR DESCRIPTION
This PR replaces int with sig_atomic_t type for variables read/written
by signal handlers.

sig_atomic_t was introduced in C89, so hopefully this change should be
acceptable without any configure script change.

See: https://wiki.sei.cmu.edu/confluence/display/c/SIG31-C.+Do+not+access+shared+objects+in+signal+handlers

This is to guarantee that there is no way that a signal handler would be invoked
in the middle of writing or reading those variables.  In practice, 'int' was probably
atomic on most architectures anyway, but sig_atomic_t offers more guarantees 
according to C89, so it can avoid subtle issues on exotic platforms.

Note that if those variables read/written by signal handlers are used in different
threads, then sig_atomic_t is in theory not good enough (neither was int). 
C11 atomic variables would offer stronger guarantee in such scenario
but Vim does not use C11. As was seen in https://github.com/vim/vim/issues/3346
signal handlers may be triggered in other threads than the main thread.  So
in theory, using int or sig_atomic_int may not be good enough. There is
no way to make it 100% safe without using C11 atomic variable.  In practice
I do not see any issue.