### PR TITLE
Fix Test_getftype

### DIFF
--- a/src/testdir/test_stat.vim
+++ b/src/testdir/test_stat.vim
@@ -141,17 +141,26 @@ func Test_getftype()
   endif
 
   for cdevfile in systemlist('find /dev -type c -maxdepth 2 2>/dev/null')
-    call assert_equal('cdev', getftype(cdevfile))
+    let type = getftype(cdevfile)
+    if type !=# ''
+      call assert_equal('cdev', type)
+    endif
   endfor
 
   for bdevfile in systemlist('find /dev -type b -maxdepth 2 2>/dev/null')
-    call assert_equal('bdev', getftype(bdevfile))
+    let type = getftype(bdevfile)
+    if type !=# ''
+      call assert_equal('bdev', type)
+    endif
   endfor
 
   " The /run/ directory typically contains socket files.
   " If it does not, test won't fail but will not test socket files.
   for socketfile in systemlist('find /run -type s -maxdepth 2 2>/dev/null')
-    call assert_equal('socket', getftype(socketfile))
+    let type = getftype(socketfile)
+    if type !=# ''
+      call assert_equal('socket', type)
+    endif
   endfor
 
   " TODO: file type 'other' is not tested. How can we test it?


### PR DESCRIPTION
## Problem

In GUI, the check for char-device file type in `Test_getftype()` fails.
(GUI: Linux GVim, MacVim)

Example:
https://travis-ci.org/ichizok/vim/jobs/418035329
(Changed .travis.yml to execute "make -C src testgui" on Linux)

```
From test_stat.vim:
Found errors in Test_getftype():
function RunTheTest[40]..Test_getftype line 19: Expected 'cdev' but got ''
```

## Cause

In GUI, `systemlist()` and `system()` create new pty for the executing command (when `guipty` is on or `guioptions` has `!`), so the command (`find`) returns the pty path and the pty is gone after the command finishes.
Thus `getftype()` for the pty returns empty string and test fails.

Generally, the filepath returned by the external command may have been lost before doing `getftype()`.

## Solution

* Check if file exists (the result of `getftype()` is not empty) before `assert_equal()`