### PR TITLE
Proposal: Store the script line number

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -832,11 +832,12 @@ it, no matter how many backslashes.
 	   \\#			\#
 Also see |`=|.
 
-			       *:<cword>* *:<cWORD>* *:<cfile>* *<cfile>*
-			       *:<sfile>* *<sfile>* *:<afile>* *<afile>*
-			       *:<abuf>* *<abuf>* *:<amatch>* *<amatch>*
-			       *:<cexpr>* *<cexpr>*
-			       *<slnum>* *E495* *E496* *E497* *E499* *E500*
+			       *:<cword>* *<cword>* *:<cWORD>* *<cWORD>*
+			       *:<cexpr>* *<cexpr>* *:<cfile>* *<cfile>*
+			       *:<afile>* *<afile>* *:<abuf>* *<abuf>*
+			       *:<amatch>* *<amatch>*
+			       *:<sfile>* *<sfile>* *:<slnum>* *<slnum>*
+			       *:<flnum>* *<flnum>* *E499* *E500*
 Note: these are typed literally, they are not special keys!
 	<cword>    is replaced with the word under the cursor (like |star|)
 	<cWORD>    is replaced with the WORD under the cursor (see |WORD|)
@@ -849,15 +850,16 @@ Note: these are typed literally, they are not special keys!
 		   |gf| uses)
 	<afile>    When executing autocommands, is replaced with the file name
 		   of the buffer being manipulated, or the file for a read or
-		   write.
+		   write.  *E495*
 	<abuf>     When executing autocommands, is replaced with the currently
 		   effective buffer number (for ":r file" and ":so file" it is
 		   the current buffer, the file being read/sourced is not in a
-		   buffer).
+		   buffer).  *E496*
 	<amatch>   When executing autocommands, is replaced with the match for
-		   which this autocommand was executed.  It differs from
-		   <afile> only when the file name isn't used to match with
-		   (for FileType, Syntax and SpellFileMissing events).
+		   which this autocommand was executed.  *E497*
+		   It differs from <afile> only when the file name isn't used
+		   to match with (for FileType, Syntax and SpellFileMissing
+		   events).
 	<sfile>    When executing a ":source" command, is replaced with the
 		   file name of the sourced file.  *E498*
 		   When executing a function, is replaced with:
@@ -867,9 +869,13 @@ Note: these are typed literally, they are not special keys!
 		   Note that filename-modifiers are useless when <sfile> is
 		   used inside a function.
 	<slnum>	   When executing a ":source" command, is replaced with the
-	           line number.  *E842*
+		   line number.  *E842*
 		   When executing a function it's the line number relative to
 		   the start of the function.
+	<flnum>	   When executing a script, is replaced with the line number.
+		   *E958*
+		   It differs from <slnum> in that <flnum> is replaced with
+		   the current line number in any situation.
 
 							 *filename-modifiers*
 *:_%:* *::8* *::p* *::.* *::~* *::h* *::t* *::r* *::e* *::s* *::gs* *::S*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3792,6 +3792,7 @@ expand({expr} [, {nosuf} [, {list}]])				*expand()*
 			<amatch>	autocmd matched name
 			<sfile>		sourced script file or function name
 			<slnum>		sourced script file line number
+			<flnum>		current script file line number
 			<cword>		word under the cursor
 			<cWORD>		WORD under the cursor
 			<client>	the {clientid} of the last received

--- a/src/Make_all.mak
+++ b/src/Make_all.mak
@@ -52,6 +52,7 @@ NEW_TESTS = \
 	test_exists_autocmd \
 	test_expand \
 	test_expand_dllpath \
+	test_expand_func \
 	test_expr \
 	test_expr_utf8 \
 	test_farsi \

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5400,7 +5400,7 @@ chk_modeline(
     char_u	*save_sourcing_name;
     linenr_T	save_sourcing_lnum;
 #ifdef FEAT_EVAL
-    scid_T	save_SID;
+    sctx_T	save_sctx;
 #endif
 
     prev = -1;
@@ -5485,12 +5485,13 @@ chk_modeline(
 	    if (*s != NUL)		/* skip over an empty "::" */
 	    {
 #ifdef FEAT_EVAL
-		save_SID = current_SID;
+		save_sctx = current_sctx;
 		current_SID = SID_MODELINE;
+		current_SLN = 0;
 #endif
 		retval = do_set(s, OPT_MODELINE | OPT_LOCAL | flags);
 #ifdef FEAT_EVAL
-		current_SID = save_SID;
+		current_sctx = save_sctx;
 #endif
 		if (retval == FAIL)		/* stop if error found */
 		    break;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5400,7 +5400,7 @@ chk_modeline(
     char_u	*save_sourcing_name;
     linenr_T	save_sourcing_lnum;
 #ifdef FEAT_EVAL
-    sctx_T	save_sctx;
+    sctx_T	save_current_sctx;
 #endif
 
     prev = -1;
@@ -5485,13 +5485,13 @@ chk_modeline(
 	    if (*s != NUL)		/* skip over an empty "::" */
 	    {
 #ifdef FEAT_EVAL
-		save_sctx = current_sctx;
+		save_current_sctx = current_sctx;
 		current_SID = SID_MODELINE;
 		current_SLN = 0;
 #endif
 		retval = do_set(s, OPT_MODELINE | OPT_LOCAL | flags);
 #ifdef FEAT_EVAL
-		current_sctx = save_sctx;
+		current_sctx = save_current_sctx;
 #endif
 		if (retval == FAIL)		/* stop if error found */
 		    break;

--- a/src/eval.c
+++ b/src/eval.c
@@ -8729,13 +8729,13 @@ store_session_globals(FILE *fd)
  * Should only be invoked when 'verbose' is non-zero.
  */
     void
-last_set_msg(sctx_T sctx)
+last_set_msg(sctx_T script_ctx)
 {
     char_u *p;
 
-    if (sctx.sc_scid != 0)
+    if (script_ctx.sc_scid != 0)
     {
-	p = home_replace_save(NULL, get_scriptname(sctx.sc_scid));
+	p = home_replace_save(NULL, get_scriptname(script_ctx.sc_scid));
 	if (p != NULL)
 	{
 	    verbose_enter();

--- a/src/eval.c
+++ b/src/eval.c
@@ -8729,13 +8729,13 @@ store_session_globals(FILE *fd)
  * Should only be invoked when 'verbose' is non-zero.
  */
     void
-last_set_msg(scid_T scriptID)
+last_set_msg(sctx_T sctx)
 {
     char_u *p;
 
-    if (scriptID != 0)
+    if (sctx.sc_scid != 0)
     {
-	p = home_replace_save(NULL, get_scriptname(scriptID));
+	p = home_replace_save(NULL, get_scriptname(sctx.sc_scid));
 	if (p != NULL)
 	{
 	    verbose_enter();

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7618,7 +7618,7 @@ get_maparg(typval_T *argvars, typval_T *rettv, int exact)
 	dict_add_number(dict, "noremap", mp->m_noremap ? 1L : 0L);
 	dict_add_number(dict, "expr", mp->m_expr ? 1L : 0L);
 	dict_add_number(dict, "silent", mp->m_silent ? 1L : 0L);
-	dict_add_number(dict, "sid", (long)mp->m_script_ID);
+	dict_add_number(dict, "sid", (long)mp->m_sctx.sc_scid);
 	dict_add_number(dict, "buffer", (long)buffer_local);
 	dict_add_number(dict, "nowait", mp->m_nowait ? 1L : 0L);
 	dict_add_string(dict, "mode", mapmode);

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7618,7 +7618,7 @@ get_maparg(typval_T *argvars, typval_T *rettv, int exact)
 	dict_add_number(dict, "noremap", mp->m_noremap ? 1L : 0L);
 	dict_add_number(dict, "expr", mp->m_expr ? 1L : 0L);
 	dict_add_number(dict, "silent", mp->m_silent ? 1L : 0L);
-	dict_add_number(dict, "sid", (long)mp->m_sctx.sc_scid);
+	dict_add_number(dict, "sid", (long)mp->m_script_ctx.sc_scid);
 	dict_add_number(dict, "buffer", (long)buffer_local);
 	dict_add_number(dict, "nowait", mp->m_nowait ? 1L : 0L);
 	dict_add_string(dict, "mode", mapmode);

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -4301,7 +4301,7 @@ do_source(
     char_u		    *firstline = NULL;
     int			    retval = FAIL;
 #ifdef FEAT_EVAL
-    scid_T		    save_current_SID;
+    sctx_T		    save_current_sctx;
     static scid_T	    last_current_SID = 0;
     void		    *save_funccalp;
     int			    save_debug_break_level = debug_break_level;
@@ -4471,7 +4471,8 @@ do_source(
      * Check if this script was sourced before to finds its SID.
      * If it's new, generate a new SID.
      */
-    save_current_SID = current_SID;
+    save_current_sctx = current_sctx;
+    current_SLN = 0;
 # ifdef UNIX
     stat_ok = (mch_stat((char *)fname_exp, &st) >= 0);
 # endif
@@ -4621,7 +4622,7 @@ do_source(
 
 #ifdef FEAT_EVAL
 almosttheend:
-    current_SID = save_current_SID;
+    current_sctx = save_current_sctx;
     restore_funccal(save_funccalp);
 # ifdef FEAT_PROFILE
     if (do_profiling == PROF_YES)

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -10729,14 +10729,16 @@ find_cmdline_var(char_u *src, int *usedlen)
 		    "<slnum>",		/* ":so" file line number */
 #define SPEC_SLNUM  (SPEC_SFILE + 1)
 		    "<afile>",		/* autocommand file name */
-#define SPEC_AFILE (SPEC_SLNUM + 1)
+#define SPEC_AFILE  (SPEC_SLNUM + 1)
 		    "<abuf>",		/* autocommand buffer number */
-#define SPEC_ABUF  (SPEC_AFILE + 1)
+#define SPEC_ABUF   (SPEC_AFILE + 1)
 		    "<amatch>",		/* autocommand match name */
 #define SPEC_AMATCH (SPEC_ABUF + 1)
+		    "<flnum>",		/* current file line number */
+#define SPEC_FLNUM  (SPEC_AMATCH + 1)
 #ifdef FEAT_CLIENTSERVER
 		    "<client>"
-# define SPEC_CLIENT (SPEC_AMATCH + 1)
+# define SPEC_CLIENT (SPEC_FLNUM + 1)
 #endif
     };
 
@@ -10992,6 +10994,7 @@ eval_vars(
 		    return NULL;
 		}
 		break;
+
 	case SPEC_SLNUM:	/* line in file for ":so" command */
 		if (sourcing_name == NULL || sourcing_lnum == 0)
 		{
@@ -11001,13 +11004,28 @@ eval_vars(
 		sprintf((char *)strbuf, "%ld", (long)sourcing_lnum);
 		result = strbuf;
 		break;
-#if defined(FEAT_CLIENTSERVER)
+
+#ifdef FEAT_EVAL
+	case SPEC_FLNUM:	/* line in file current executed */
+		if (current_SLN + sourcing_lnum == 0)
+		{
+		    *errormsg = (char_u *)_("E958: no line number to use for \"<flnum>\"");
+		    return NULL;
+		}
+		sprintf((char *)strbuf, "%ld",
+					 (long)(current_SLN + sourcing_lnum));
+		result = strbuf;
+		break;
+#endif
+
+#ifdef FEAT_CLIENTSERVER
 	case SPEC_CLIENT:	/* Source of last submitted input */
 		sprintf((char *)strbuf, PRINTF_HEX_LONG_U,
 							(long_u)clientWindow);
 		result = strbuf;
 		break;
 #endif
+
 	default:
 		result = (char_u *)""; /* avoid gcc warning */
 		break;

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -29,7 +29,7 @@ typedef struct ucmd
     int		uc_compl;	/* completion type */
     int		uc_addr_type;	/* The command's address type */
 # ifdef FEAT_EVAL
-    sctx_T	uc_sctx;	/* SCTX where the command was defined */
+    sctx_T	uc_script_ctx;	/* SCTX where the command was defined */
 #  ifdef FEAT_CMDL_COMPL
     char_u	*uc_compl_arg;	/* completion argument if any */
 #  endif
@@ -3332,8 +3332,8 @@ find_ucmd(
 		    if (xp != NULL)
 		    {
 			xp->xp_arg = uc->uc_compl_arg;
-			xp->xp_sctx = uc->uc_sctx;
-			xp->xp_sctx.sc_lnum += sourcing_lnum;
+			xp->xp_script_ctx = uc->uc_script_ctx;
+			xp->xp_script_ctx.sc_lnum += sourcing_lnum;
 		    }
 #  endif
 # endif
@@ -5912,8 +5912,8 @@ uc_add_command(
     cmd->uc_def = def;
     cmd->uc_compl = compl;
 #ifdef FEAT_EVAL
-    cmd->uc_sctx = current_sctx;
-    cmd->uc_sctx.sc_lnum += sourcing_lnum;
+    cmd->uc_script_ctx = current_sctx;
+    cmd->uc_script_ctx.sc_lnum += sourcing_lnum;
 # ifdef FEAT_CMDL_COMPL
     cmd->uc_compl_arg = compl_arg;
 # endif
@@ -6134,7 +6134,7 @@ uc_list(char_u *name, size_t name_len)
 	    msg_outtrans_special(cmd->uc_rep, FALSE);
 #ifdef FEAT_EVAL
 	    if (p_verbose > 0)
-		last_set_msg(cmd->uc_sctx);
+		last_set_msg(cmd->uc_script_ctx);
 #endif
 	    out_flush();
 	    ui_breakcheck();
@@ -7000,7 +7000,7 @@ do_ucmd(exarg_T *eap)
     }
 
 #ifdef FEAT_EVAL
-    current_SID = cmd->uc_sctx.sc_scid;
+    current_SID = cmd->uc_script_ctx.sc_scid;
 #endif
     (void)do_cmdline(buf, eap->getline, eap->cookie,
 				   DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_KEYTYPED);

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -5593,7 +5593,7 @@ call_user_expand_func(
     save_ccline = ccline;
     ccline.cmdbuff = NULL;
     ccline.cmdprompt = NULL;
-    current_sctx = xp->xp_sctx;
+    current_sctx = xp->xp_script_ctx;
 
     ret = user_expand_func(xp->xp_arg, 3, args);
 

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -5563,7 +5563,7 @@ call_user_expand_func(
 {
     int		keep = 0;
     typval_T	args[4];
-    int		save_current_SID = current_SID;
+    sctx_T	save_current_sctx = current_sctx;
     char_u	*pat = NULL;
     void	*ret;
     struct cmdline_info	    save_ccline;
@@ -5593,12 +5593,12 @@ call_user_expand_func(
     save_ccline = ccline;
     ccline.cmdbuff = NULL;
     ccline.cmdprompt = NULL;
-    current_SID = xp->xp_scriptID;
+    current_sctx = xp->xp_sctx;
 
     ret = user_expand_func(xp->xp_arg, 3, args);
 
     ccline = save_ccline;
-    current_SID = save_current_SID;
+    current_sctx = save_current_sctx;
     if (ccline.cmdbuff != NULL)
 	ccline.cmdbuff[ccline.cmdlen] = keep;
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -7700,7 +7700,7 @@ typedef struct AutoCmd
     char	    nested;		/* If autocommands nest here */
     char	    last;		/* last command in list */
 #ifdef FEAT_EVAL
-    sctx_T	    sctx;		/* script context where defined */
+    sctx_T	    script_ctx;		/* script context where defined */
 #endif
     struct AutoCmd  *next;		/* Next AutoCmd in list */
 } AutoCmd;
@@ -7962,7 +7962,7 @@ show_autocmd(AutoPat *ap, event_T event)
 	    msg_outtrans(ac->cmd);
 #ifdef FEAT_EVAL
 	    if (p_verbose > 0)
-		last_set_msg(ac->sctx);
+		last_set_msg(ac->script_ctx);
 #endif
 	    if (got_int)
 		return;
@@ -8845,8 +8845,8 @@ do_autocmd_event(
 		return FAIL;
 	    ac->cmd = vim_strsave(cmd);
 #ifdef FEAT_EVAL
-	    ac->sctx = current_sctx;
-	    ac->sctx.sc_lnum += sourcing_lnum;
+	    ac->script_ctx = current_sctx;
+	    ac->script_ctx.sc_lnum += sourcing_lnum;
 #endif
 	    if (ac->cmd == NULL)
 	    {
@@ -9950,7 +9950,7 @@ getnextac(int c UNUSED, void *cookie, int indent UNUSED)
     retval = vim_strsave(ac->cmd);
     autocmd_nested = ac->nested;
 #ifdef FEAT_EVAL
-    current_sctx = ac->sctx;
+    current_sctx = ac->script_ctx;
 #endif
     if (ac->last)
 	acp->nextcmd = NULL;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -7700,7 +7700,7 @@ typedef struct AutoCmd
     char	    nested;		/* If autocommands nest here */
     char	    last;		/* last command in list */
 #ifdef FEAT_EVAL
-    scid_T	    scriptID;		/* script ID where defined */
+    sctx_T	    sctx;		/* script context where defined */
 #endif
     struct AutoCmd  *next;		/* Next AutoCmd in list */
 } AutoCmd;
@@ -7962,7 +7962,7 @@ show_autocmd(AutoPat *ap, event_T event)
 	    msg_outtrans(ac->cmd);
 #ifdef FEAT_EVAL
 	    if (p_verbose > 0)
-		last_set_msg(ac->scriptID);
+		last_set_msg(ac->sctx);
 #endif
 	    if (got_int)
 		return;
@@ -8845,7 +8845,8 @@ do_autocmd_event(
 		return FAIL;
 	    ac->cmd = vim_strsave(cmd);
 #ifdef FEAT_EVAL
-	    ac->scriptID = current_SID;
+	    ac->sctx = current_sctx;
+	    ac->sctx.sc_lnum += sourcing_lnum;
 #endif
 	    if (ac->cmd == NULL)
 	    {
@@ -9412,7 +9413,7 @@ apply_autocmds_group(
     AutoPatCmd	patcmd;
     AutoPat	*ap;
 #ifdef FEAT_EVAL
-    scid_T	save_current_SID;
+    sctx_T	save_current_sctx;
     void	*save_funccalp;
     char_u	*save_cmdarg;
     long	save_cmdbang;
@@ -9621,7 +9622,7 @@ apply_autocmds_group(
     sourcing_lnum = 0;		/* no line number here */
 
 #ifdef FEAT_EVAL
-    save_current_SID = current_SID;
+    save_current_sctx = current_sctx;
 
 # ifdef FEAT_PROFILE
     if (do_profiling == PROF_YES)
@@ -9725,7 +9726,7 @@ apply_autocmds_group(
     autocmd_bufnr = save_autocmd_bufnr;
     autocmd_match = save_autocmd_match;
 #ifdef FEAT_EVAL
-    current_SID = save_current_SID;
+    current_sctx = save_current_sctx;
     restore_funccal(save_funccalp);
 # ifdef FEAT_PROFILE
     if (do_profiling == PROF_YES)
@@ -9949,7 +9950,7 @@ getnextac(int c UNUSED, void *cookie, int indent UNUSED)
     retval = vim_strsave(ac->cmd);
     autocmd_nested = ac->nested;
 #ifdef FEAT_EVAL
-    current_SID = ac->scriptID;
+    current_sctx = ac->sctx;
 #endif
     if (ac->last)
 	acp->nextcmd = NULL;

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -3677,8 +3677,8 @@ do_map(
 				mp->m_mode = mode;
 #ifdef FEAT_EVAL
 				mp->m_expr = expr;
-				mp->m_sctx = current_sctx;
-				mp->m_sctx.sc_lnum += sourcing_lnum;
+				mp->m_script_ctx = current_sctx;
+				mp->m_script_ctx.sc_lnum += sourcing_lnum;
 #endif
 				did_it = TRUE;
 			    }
@@ -3784,8 +3784,8 @@ do_map(
     mp->m_mode = mode;
 #ifdef FEAT_EVAL
     mp->m_expr = expr;
-    mp->m_sctx = current_sctx;
-    mp->m_sctx.sc_lnum += sourcing_lnum;
+    mp->m_script_ctx = current_sctx;
+    mp->m_script_ctx.sc_lnum += sourcing_lnum;
 #endif
 
     /* add the new entry in front of the abbrlist or maphash[] list */
@@ -4099,7 +4099,7 @@ showmap(
     }
 #ifdef FEAT_EVAL
     if (p_verbose > 0)
-	last_set_msg(mp->m_sctx);
+	last_set_msg(mp->m_script_ctx);
 #endif
     out_flush();			/* show one line at a time */
 }

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -3677,7 +3677,8 @@ do_map(
 				mp->m_mode = mode;
 #ifdef FEAT_EVAL
 				mp->m_expr = expr;
-				mp->m_script_ID = current_SID;
+				mp->m_sctx = current_sctx;
+				mp->m_sctx.sc_lnum += sourcing_lnum;
 #endif
 				did_it = TRUE;
 			    }
@@ -3783,7 +3784,8 @@ do_map(
     mp->m_mode = mode;
 #ifdef FEAT_EVAL
     mp->m_expr = expr;
-    mp->m_script_ID = current_SID;
+    mp->m_sctx = current_sctx;
+    mp->m_sctx.sc_lnum += sourcing_lnum;
 #endif
 
     /* add the new entry in front of the abbrlist or maphash[] list */
@@ -4097,7 +4099,7 @@ showmap(
     }
 #ifdef FEAT_EVAL
     if (p_verbose > 0)
-	last_set_msg(mp->m_script_ID);
+	last_set_msg(mp->m_sctx);
 #endif
     out_flush();			/* show one line at a time */
 }

--- a/src/globals.h
+++ b/src/globals.h
@@ -325,8 +325,10 @@ EXTERN int	may_garbage_collect INIT(= FALSE);
 EXTERN int	want_garbage_collect INIT(= FALSE);
 EXTERN int	garbage_collect_at_exit INIT(= FALSE);
 
-/* ID of script being sourced or was sourced to define the current function. */
-EXTERN scid_T	current_SID INIT(= 0);
+/* Script CTX being sourced or was sourced to define the current function. */
+EXTERN sctx_T	current_sctx INIT(= {0 COMMA 0});
+# define current_SID	current_sctx.sc_scid
+# define current_SLN	current_sctx.sc_lnum
 #endif
 
 EXTERN int	did_source_packages INIT(= FALSE);

--- a/src/main.c
+++ b/src/main.c
@@ -3159,7 +3159,7 @@ process_env(
     char_u	*save_sourcing_name;
     linenr_T	save_sourcing_lnum;
 #ifdef FEAT_EVAL
-    scid_T	save_sid;
+    sctx_T	save_sctx;
 #endif
 
     if ((initstr = mch_getenv(env)) != NULL && *initstr != NUL)
@@ -3171,14 +3171,15 @@ process_env(
 	sourcing_name = env;
 	sourcing_lnum = 0;
 #ifdef FEAT_EVAL
-	save_sid = current_SID;
+	save_sctx = current_sctx;
 	current_SID = SID_ENV;
+	current_SLN = 0;
 #endif
 	do_cmdline_cmd(initstr);
 	sourcing_name = save_sourcing_name;
 	sourcing_lnum = save_sourcing_lnum;
 #ifdef FEAT_EVAL
-	current_SID = save_sid;
+	current_sctx = save_sctx;
 #endif
 	return OK;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -3159,7 +3159,7 @@ process_env(
     char_u	*save_sourcing_name;
     linenr_T	save_sourcing_lnum;
 #ifdef FEAT_EVAL
-    sctx_T	save_sctx;
+    sctx_T	save_current_sctx;
 #endif
 
     if ((initstr = mch_getenv(env)) != NULL && *initstr != NUL)
@@ -3171,7 +3171,7 @@ process_env(
 	sourcing_name = env;
 	sourcing_lnum = 0;
 #ifdef FEAT_EVAL
-	save_sctx = current_sctx;
+	save_current_sctx = current_sctx;
 	current_SID = SID_ENV;
 	current_SLN = 0;
 #endif
@@ -3179,7 +3179,7 @@ process_env(
 	sourcing_name = save_sourcing_name;
 	sourcing_lnum = save_sourcing_lnum;
 #ifdef FEAT_EVAL
-	current_sctx = save_sctx;
+	current_sctx = save_current_sctx;
 #endif
 	return OK;
     }

--- a/src/option.c
+++ b/src/option.c
@@ -414,10 +414,10 @@ struct vimoption
 				 * local option: indirect option index */
     char_u	*def_val[2];	/* default values for variable (vi and vim) */
 #ifdef FEAT_EVAL
-    scid_T	scriptID;	/* script in which the option was last set */
-# define SCRIPTID_INIT , 0
+    sctx_T	sctx;	/* script in which the option was last set */
+# define SCTX_INIT , {0, 0}
 #else
-# define SCRIPTID_INIT
+# define SCTX_INIT
 #endif
 };
 
@@ -515,7 +515,7 @@ static struct vimoption options[] =
 #else
 			    (char_u *)224L,
 #endif
-					    (char_u *)0L} SCRIPTID_INIT},
+					    (char_u *)0L} SCTX_INIT},
     {"antialias",   "anti", P_BOOL|P_VI_DEF|P_VIM|P_RCLR,
 #if defined(FEAT_GUI_MAC)
 			    (char_u *)&p_antialias, PV_NONE,
@@ -524,35 +524,35 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)FALSE}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"arabic",	    "arab", P_BOOL|P_VI_DEF|P_VIM|P_CURSWANT,
 #ifdef FEAT_ARABIC
 			    (char_u *)VAR_WIN, PV_ARAB,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"arabicshape", "arshape", P_BOOL|P_VI_DEF|P_VIM|P_RCLR,
 #ifdef FEAT_ARABIC
 			    (char_u *)&p_arshape, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"allowrevins", "ari",  P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_RIGHTLEFT
 			    (char_u *)&p_ari, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"altkeymap",   "akm",  P_BOOL|P_VI_DEF,
 #ifdef FEAT_FKMAP
 			    (char_u *)&p_altkeymap, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"ambiwidth",  "ambw",  P_STRING|P_VI_DEF|P_RCLR,
 #if defined(FEAT_MBYTE)
 			    (char_u *)&p_ambw, PV_NONE,
@@ -561,7 +561,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"autochdir",  "acd",   P_BOOL|P_VI_DEF,
 #ifdef FEAT_AUTOCHDIR
 			    (char_u *)&p_acd, PV_NONE,
@@ -570,22 +570,22 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"autoindent",  "ai",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_ai, PV_AI,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"autoprint",   "ap",   P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"autoread",    "ar",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_ar, PV_AR,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"autowrite",   "aw",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_aw, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"autowriteall","awa",  P_BOOL|P_VI_DEF,
 			    (char_u *)&p_awa, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"background",  "bg",   P_STRING|P_VI_DEF|P_RCLR,
 			    (char_u *)&p_bg, PV_NONE,
 			    {
@@ -594,13 +594,13 @@ static struct vimoption options[] =
 #else
 			    (char_u *)"light",
 #endif
-					    (char_u *)0L} SCRIPTID_INIT},
+					    (char_u *)0L} SCTX_INIT},
     {"backspace",   "bs",   P_STRING|P_VI_DEF|P_VIM|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_bs, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"backup",	    "bk",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_bk, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"backupcopy",  "bkc",  P_STRING|P_VIM|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_bkc, PV_BKC,
 #ifdef UNIX
@@ -608,11 +608,11 @@ static struct vimoption options[] =
 #else
 			    {(char_u *)"auto", (char_u *)"auto"}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"backupdir",   "bdir", P_STRING|P_EXPAND|P_VI_DEF|P_ONECOMMA
 							    |P_NODUP|P_SECURE,
 			    (char_u *)&p_bdir, PV_NONE,
-			    {(char_u *)DFLT_BDIR, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)DFLT_BDIR, (char_u *)0L} SCTX_INIT},
     {"backupext",   "bex",  P_STRING|P_VI_DEF|P_NFNAME,
 			    (char_u *)&p_bex, PV_NONE,
 			    {
@@ -621,7 +621,7 @@ static struct vimoption options[] =
 #else
 			    (char_u *)"~",
 #endif
-					    (char_u *)0L} SCRIPTID_INIT},
+					    (char_u *)0L} SCTX_INIT},
     {"backupskip",  "bsk",  P_STRING|P_VI_DEF|P_ONECOMMA,
 #ifdef FEAT_WILDIGN
 			    (char_u *)&p_bsk, PV_NONE,
@@ -630,7 +630,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"balloondelay","bdlay",P_NUM|P_VI_DEF,
 #ifdef FEAT_BEVAL
 			    (char_u *)&p_bdlay, PV_NONE,
@@ -639,7 +639,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"ballooneval", "beval",P_BOOL|P_VI_DEF|P_NO_MKRC,
 #ifdef FEAT_BEVAL_GUI
 			    (char_u *)&p_beval, PV_NONE,
@@ -648,7 +648,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"balloonevalterm", "bevalterm",P_BOOL|P_VI_DEF|P_NO_MKRC,
 #ifdef FEAT_BEVAL_TERM
 			    (char_u *)&p_bevalterm, PV_NONE,
@@ -657,7 +657,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"balloonexpr", "bexpr", P_STRING|P_ALLOCED|P_VI_DEF|P_VIM,
 #if defined(FEAT_BEVAL) && defined(FEAT_EVAL)
 			    (char_u *)&p_bexpr, PV_BEXPR,
@@ -666,26 +666,26 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"beautify",    "bf",   P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"belloff",      "bo",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
 			    (char_u *)&p_bo, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"binary",	    "bin",  P_BOOL|P_VI_DEF|P_RSTAT,
 			    (char_u *)&p_bin, PV_BIN,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"bioskey",	    "biosk",P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"bomb",	    NULL,   P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_bomb, PV_BOMB,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"breakat",	    "brk",  P_STRING|P_VI_DEF|P_RALL|P_FLAGLIST,
 #ifdef FEAT_LINEBREAK
 			    (char_u *)&p_breakat, PV_NONE,
@@ -694,7 +694,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"breakindent",   "bri",  P_BOOL|P_VI_DEF|P_VIM|P_RWIN,
 #ifdef FEAT_LINEBREAK
 			    (char_u *)VAR_WIN, PV_BRI,
@@ -703,7 +703,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"breakindentopt", "briopt", P_STRING|P_ALLOCED|P_VI_DEF|P_RBUF
 						  |P_ONECOMMA|P_NODUP,
 #ifdef FEAT_LINEBREAK
@@ -713,7 +713,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"browsedir",   "bsdir",P_STRING|P_VI_DEF,
 #ifdef FEAT_BROWSE
 			    (char_u *)&p_bsdir, PV_NONE,
@@ -722,19 +722,19 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"bufhidden",   "bh",   P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB,
 			    (char_u *)&p_bh, PV_BH,
 			    {(char_u *)"", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"buflisted",   "bl",   P_BOOL|P_VI_DEF|P_NOGLOB,
 			    (char_u *)&p_bl, PV_BL,
 			    {(char_u *)1L, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"buftype",	    "bt",   P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB,
 			    (char_u *)&p_bt, PV_BT,
 			    {(char_u *)"", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"casemap",	    "cmp",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_cmp, PV_NONE,
@@ -743,7 +743,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"cdpath",	    "cd",   P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
 #ifdef FEAT_SEARCHPATH
 			    (char_u *)&p_cdpath, PV_NONE,
@@ -752,7 +752,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"cedit",	    NULL,   P_STRING,
 #ifdef FEAT_CMDWIN
 			    (char_u *)&p_cedit, PV_NONE,
@@ -761,7 +761,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"charconvert",  "ccv", P_STRING|P_VI_DEF|P_SECURE,
 #if defined(FEAT_MBYTE) && defined(FEAT_EVAL)
 			    (char_u *)&p_ccv, PV_NONE,
@@ -770,14 +770,14 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"cindent",	    "cin",  P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_CINDENT
 			    (char_u *)&p_cin, PV_CIN,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"cinkeys",	    "cink", P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_CINDENT
 			    (char_u *)&p_cink, PV_CINK,
@@ -786,14 +786,14 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"cinoptions",  "cino", P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_CINDENT
 			    (char_u *)&p_cino, PV_CINO,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"cinwords",    "cinw", P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #if defined(FEAT_SMARTINDENT) || defined(FEAT_CINDENT)
 			    (char_u *)&p_cinw, PV_CINW,
@@ -803,7 +803,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"clipboard",   "cb",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_CLIPBOARD
 			    (char_u *)&p_cb, PV_NONE,
@@ -817,27 +817,27 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"cmdheight",   "ch",   P_NUM|P_VI_DEF|P_RALL,
 			    (char_u *)&p_ch, PV_NONE,
-			    {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1L, (char_u *)0L} SCTX_INIT},
     {"cmdwinheight", "cwh", P_NUM|P_VI_DEF,
 #ifdef FEAT_CMDWIN
 			    (char_u *)&p_cwh, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)7L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)7L, (char_u *)0L} SCTX_INIT},
     {"colorcolumn", "cc",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP|P_RWIN,
 #ifdef FEAT_SYN_HL
 			    (char_u *)VAR_WIN, PV_CC,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"columns",	    "co",   P_NUM|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|P_RCLR,
 			    (char_u *)&Columns, PV_NONE,
-			    {(char_u *)80L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)80L, (char_u *)0L} SCTX_INIT},
     {"comments",    "com",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA
 							  |P_NODUP|P_CURSWANT,
 #ifdef FEAT_COMMENTS
@@ -848,7 +848,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"commentstring", "cms", P_STRING|P_ALLOCED|P_VI_DEF|P_CURSWANT,
 #ifdef FEAT_FOLDING
 			    (char_u *)&p_cms, PV_CMS,
@@ -857,12 +857,12 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
 			    /* P_PRI_MKRC isn't needed here, optval_default()
 			     * always returns TRUE for 'compatible' */
     {"compatible",  "cp",   P_BOOL|P_RALL,
 			    (char_u *)&p_cp, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)FALSE} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)FALSE} SCTX_INIT},
     {"complete",    "cpt",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_INS_EXPAND
 			    (char_u *)&p_cpt, PV_CPT,
@@ -871,7 +871,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"concealcursor","cocu", P_STRING|P_ALLOCED|P_RWIN|P_VI_DEF,
 #ifdef FEAT_CONCEAL
 			    (char_u *)VAR_WIN, PV_COCU,
@@ -880,7 +880,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"conceallevel","cole", P_NUM|P_RWIN|P_VI_DEF,
 #ifdef FEAT_CONCEAL
 			    (char_u *)VAR_WIN, PV_COLE,
@@ -888,7 +888,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 #endif
 			    {(char_u *)0L, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"completefunc", "cfu", P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
 #ifdef FEAT_COMPL_FUNC
 			    (char_u *)&p_cfu, PV_CFU,
@@ -897,7 +897,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"completeopt",   "cot",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_INS_EXPAND
 			    (char_u *)&p_cot, PV_NONE,
@@ -906,24 +906,24 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"confirm",     "cf",   P_BOOL|P_VI_DEF,
 #if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG)
 			    (char_u *)&p_confirm, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"conskey",	    "consk",P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"copyindent",  "ci",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_ci, PV_CI,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"cpoptions",   "cpo",  P_STRING|P_VIM|P_RALL|P_FLAGLIST,
 			    (char_u *)&p_cpo, PV_NONE,
 			    {(char_u *)CPO_VI, (char_u *)CPO_VIM}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"cryptmethod", "cm",   P_STRING|P_ALLOCED|P_VI_DEF,
 #ifdef FEAT_CRYPT
 			    (char_u *)&p_cm, PV_CM,
@@ -932,14 +932,14 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"cscopepathcomp", "cspc", P_NUM|P_VI_DEF|P_VIM,
 #ifdef FEAT_CSCOPE
 			    (char_u *)&p_cspc, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"cscopeprg",   "csprg", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #ifdef FEAT_CSCOPE
 			    (char_u *)&p_csprg, PV_NONE,
@@ -948,7 +948,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"cscopequickfix", "csqf", P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #if defined(FEAT_CSCOPE) && defined(FEAT_QUICKFIX)
 			    (char_u *)&p_csqf, PV_NONE,
@@ -957,55 +957,55 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"cscoperelative", "csre", P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_CSCOPE
 			    (char_u *)&p_csre, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"cscopetag",   "cst",  P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_CSCOPE
 			    (char_u *)&p_cst, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"cscopetagorder", "csto", P_NUM|P_VI_DEF|P_VIM,
 #ifdef FEAT_CSCOPE
 			    (char_u *)&p_csto, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"cscopeverbose", "csverb", P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_CSCOPE
 			    (char_u *)&p_csverbose, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"cursorbind",  "crb",  P_BOOL|P_VI_DEF,
 			    (char_u *)VAR_WIN, PV_CRBIND,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"cursorcolumn", "cuc", P_BOOL|P_VI_DEF|P_RWIN,
 #ifdef FEAT_SYN_HL
 			    (char_u *)VAR_WIN, PV_CUC,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"cursorline",   "cul", P_BOOL|P_VI_DEF|P_RWINONLY,
 #ifdef FEAT_SYN_HL
 			    (char_u *)VAR_WIN, PV_CUL,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"debug",	    NULL,   P_STRING|P_VI_DEF,
 			    (char_u *)&p_debug, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"define",	    "def",  P_STRING|P_ALLOCED|P_VI_DEF|P_CURSWANT,
 #ifdef FEAT_FIND_ID
 			    (char_u *)&p_def, PV_DEF,
@@ -1014,28 +1014,28 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"delcombine", "deco",  P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_deco, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"dictionary",  "dict", P_STRING|P_EXPAND|P_VI_DEF|P_ONECOMMA|P_NODUP|P_NDNAME,
 #ifdef FEAT_INS_EXPAND
 			    (char_u *)&p_dict, PV_DICT,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"diff",	    NULL,   P_BOOL|P_VI_DEF|P_RWIN|P_NOGLOB,
 #ifdef FEAT_DIFF
 			    (char_u *)VAR_WIN, PV_DIFF,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"diffexpr",    "dex",  P_STRING|P_VI_DEF|P_SECURE|P_CURSWANT,
 #if defined(FEAT_DIFF) && defined(FEAT_EVAL)
 			    (char_u *)&p_dex, PV_NONE,
@@ -1044,7 +1044,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"diffopt",	    "dip",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN|P_ONECOMMA
 								     |P_NODUP,
 #ifdef FEAT_DIFF
@@ -1054,28 +1054,28 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"digraph",	    "dg",   P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_DIGRAPHS
 			    (char_u *)&p_dg, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"directory",   "dir",  P_STRING|P_EXPAND|P_VI_DEF|P_ONECOMMA
 							    |P_NODUP|P_SECURE,
 			    (char_u *)&p_dir, PV_NONE,
-			    {(char_u *)DFLT_DIR, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)DFLT_DIR, (char_u *)0L} SCTX_INIT},
     {"display",	    "dy",   P_STRING|P_VI_DEF|P_ONECOMMA|P_RALL|P_NODUP,
 			    (char_u *)&p_dy, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"eadirection", "ead",  P_STRING|P_VI_DEF,
 			    (char_u *)&p_ead, PV_NONE,
 			    {(char_u *)"both", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"edcompatible","ed",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_ed, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"emoji",  "emo",	    P_BOOL|P_VI_DEF|P_RCLR,
 #if defined(FEAT_MBYTE)
 			    (char_u *)&p_emoji, PV_NONE,
@@ -1084,7 +1084,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"encoding",    "enc",  P_STRING|P_VI_DEF|P_RCLR|P_NO_ML,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_enc, PV_NONE,
@@ -1093,19 +1093,19 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"endofline",   "eol",  P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
 			    (char_u *)&p_eol, PV_EOL,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"equalalways", "ea",   P_BOOL|P_VI_DEF|P_RALL,
 			    (char_u *)&p_ea, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"equalprg",    "ep",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_ep, PV_EP,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"errorbells",  "eb",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_eb, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"errorfile",   "ef",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #ifdef FEAT_QUICKFIX
 			    (char_u *)&p_ef, PV_NONE,
@@ -1114,7 +1114,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"errorformat", "efm",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_QUICKFIX
 			    (char_u *)&p_efm, PV_EFM,
@@ -1123,19 +1123,19 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"esckeys",	    "ek",   P_BOOL|P_VIM,
 			    (char_u *)&p_ek, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)TRUE} SCTX_INIT},
     {"eventignore", "ei",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_ei, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"expandtab",   "et",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_et, PV_ET,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"exrc",	    "ex",   P_BOOL|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_exrc, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"fileencoding","fenc", P_STRING|P_ALLOCED|P_VI_DEF|P_RSTAT|P_RBUF
 								   |P_NO_MKRC,
 #ifdef FEAT_MBYTE
@@ -1145,7 +1145,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"fileencodings","fencs", P_STRING|P_VI_DEF|P_ONECOMMA,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_fencs, PV_NONE,
@@ -1154,15 +1154,15 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"fileformat",  "ff",   P_STRING|P_ALLOCED|P_VI_DEF|P_RSTAT|P_NO_MKRC
 								  |P_CURSWANT,
 			    (char_u *)&p_ff, PV_FF,
-			    {(char_u *)DFLT_FF, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)DFLT_FF, (char_u *)0L} SCTX_INIT},
     {"fileformats", "ffs",  P_STRING|P_VIM|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_ffs, PV_NONE,
 			    {(char_u *)DFLT_FFS_VI, (char_u *)DFLT_FFS_VIM}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"fileignorecase", "fic", P_BOOL|P_VI_DEF,
 			    (char_u *)&p_fic, PV_NONE,
 			    {
@@ -1171,28 +1171,28 @@ static struct vimoption options[] =
 #else
 				    (char_u *)FALSE,
 #endif
-					(char_u *)0L} SCRIPTID_INIT},
+					(char_u *)0L} SCTX_INIT},
     {"filetype",    "ft",   P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB|P_NFNAME,
 			    (char_u *)&p_ft, PV_FT,
 			    {(char_u *)"", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"fillchars",   "fcs",  P_STRING|P_VI_DEF|P_RALL|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_fcs, PV_NONE,
 			    {(char_u *)"vert:|,fold:-", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"fixendofline",  "fixeol", P_BOOL|P_VI_DEF|P_RSTAT,
 			    (char_u *)&p_fixeol, PV_FIXEOL,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"fkmap",	    "fk",   P_BOOL|P_VI_DEF,
 #ifdef FEAT_FKMAP
 			    (char_u *)&p_fkmap, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"flash",	    "fl",   P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"foldclose",   "fcl",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP|P_RWIN,
 #ifdef FEAT_FOLDING
 			    (char_u *)&p_fcl, PV_NONE,
@@ -1201,7 +1201,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldcolumn",  "fdc",  P_NUM|P_VI_DEF|P_RWIN,
 #ifdef FEAT_FOLDING
 			    (char_u *)VAR_WIN, PV_FDC,
@@ -1210,7 +1210,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldenable",  "fen",  P_BOOL|P_VI_DEF|P_RWIN,
 #ifdef FEAT_FOLDING
 			    (char_u *)VAR_WIN, PV_FEN,
@@ -1219,7 +1219,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldexpr",    "fde",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
 #if defined(FEAT_FOLDING) && defined(FEAT_EVAL)
 			    (char_u *)VAR_WIN, PV_FDE,
@@ -1228,7 +1228,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldignore",  "fdi",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
 #ifdef FEAT_FOLDING
 			    (char_u *)VAR_WIN, PV_FDI,
@@ -1237,7 +1237,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldlevel",   "fdl",  P_NUM|P_VI_DEF|P_RWIN,
 #ifdef FEAT_FOLDING
 			    (char_u *)VAR_WIN, PV_FDL,
@@ -1246,7 +1246,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldlevelstart","fdls", P_NUM|P_VI_DEF|P_CURSWANT,
 #ifdef FEAT_FOLDING
 			    (char_u *)&p_fdls, PV_NONE,
@@ -1255,7 +1255,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldmarker",  "fmr",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|
 						    P_RWIN|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_FOLDING
@@ -1265,7 +1265,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldmethod",  "fdm",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
 #ifdef FEAT_FOLDING
 			    (char_u *)VAR_WIN, PV_FDM,
@@ -1274,7 +1274,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldminlines","fml",  P_NUM|P_VI_DEF|P_RWIN,
 #ifdef FEAT_FOLDING
 			    (char_u *)VAR_WIN, PV_FML,
@@ -1283,7 +1283,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldnestmax", "fdn",  P_NUM|P_VI_DEF|P_RWIN,
 #ifdef FEAT_FOLDING
 			    (char_u *)VAR_WIN, PV_FDN,
@@ -1292,7 +1292,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldopen",    "fdo",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP|P_CURSWANT,
 #ifdef FEAT_FOLDING
 			    (char_u *)&p_fdo, PV_NONE,
@@ -1302,7 +1302,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"foldtext",    "fdt",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
 #if defined(FEAT_FOLDING) && defined(FEAT_EVAL)
 			    (char_u *)VAR_WIN, PV_FDT,
@@ -1311,7 +1311,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"formatexpr", "fex",   P_STRING|P_ALLOCED|P_VI_DEF|P_VIM,
 #ifdef FEAT_EVAL
 			    (char_u *)&p_fex, PV_FEX,
@@ -1320,18 +1320,18 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"formatoptions","fo",  P_STRING|P_ALLOCED|P_VIM|P_FLAGLIST,
 			    (char_u *)&p_fo, PV_FO,
 			    {(char_u *)DFLT_FO_VI, (char_u *)DFLT_FO_VIM}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"formatlistpat","flp", P_STRING|P_ALLOCED|P_VI_DEF,
 			    (char_u *)&p_flp, PV_FLP,
 			    {(char_u *)"^\\s*\\d\\+[\\]:.)}\\t ]\\s*",
-						 (char_u *)0L} SCRIPTID_INIT},
+						 (char_u *)0L} SCTX_INIT},
     {"formatprg",   "fp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_fp, PV_FP,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"fsync",       "fs",   P_BOOL|P_SECURE|P_VI_DEF,
 #ifdef HAVE_FSYNC
 			    (char_u *)&p_fs, PV_NONE,
@@ -1340,13 +1340,13 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"gdefault",    "gd",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_gd, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"graphic",	    "gr",   P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"grepformat",  "gfm",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_QUICKFIX
 			    (char_u *)&p_gefm, PV_NONE,
@@ -1355,7 +1355,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"grepprg",	    "gp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #ifdef FEAT_QUICKFIX
 			    (char_u *)&p_gp, PV_GP,
@@ -1381,7 +1381,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"guicursor",    "gcr", P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef CURSOR_SHAPE
 			    (char_u *)&p_guicursor, PV_NONE,
@@ -1396,7 +1396,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"guifont",	    "gfn",  P_STRING|P_VI_DEF|P_RCLR|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_GUI
 			    (char_u *)&p_guifont, PV_NONE,
@@ -1405,7 +1405,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"guifontset",  "gfs",  P_STRING|P_VI_DEF|P_RCLR|P_ONECOMMA,
 #if defined(FEAT_GUI) && defined(FEAT_XFONTSET)
 			    (char_u *)&p_guifontset, PV_NONE,
@@ -1414,7 +1414,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"guifontwide", "gfw",  P_STRING|P_VI_DEF|P_RCLR|P_ONECOMMA|P_NODUP,
 #if defined(FEAT_GUI) && defined(FEAT_MBYTE)
 			    (char_u *)&p_guifontwide, PV_NONE,
@@ -1423,14 +1423,14 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"guiheadroom", "ghr",  P_NUM|P_VI_DEF,
 #if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_X11)
 			    (char_u *)&p_ghr, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)50L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)50L, (char_u *)0L} SCTX_INIT},
     {"guioptions",  "go",   P_STRING|P_VI_DEF|P_RALL|P_FLAGLIST,
 #if defined(FEAT_GUI)
 			    (char_u *)&p_go, PV_NONE,
@@ -1443,14 +1443,14 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"guipty",	    NULL,   P_BOOL|P_VI_DEF,
 #if defined(FEAT_GUI)
 			    (char_u *)&p_guipty, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"guitablabel",  "gtl", P_STRING|P_VI_DEF|P_RWIN,
 #if defined(FEAT_GUI_TABLINE)
 			    (char_u *)&p_gtl, PV_NONE,
@@ -1459,7 +1459,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"guitabtooltip",  "gtt", P_STRING|P_VI_DEF|P_RWIN,
 #if defined(FEAT_GUI_TABLINE)
 			    (char_u *)&p_gtt, PV_NONE,
@@ -1468,17 +1468,17 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"hardtabs",    "ht",   P_NUM|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"helpfile",    "hf",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_hf, PV_NONE,
 			    {(char_u *)DFLT_HELPFILE, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"helpheight",  "hh",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_hh, PV_NONE,
-			    {(char_u *)20L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)20L, (char_u *)0L} SCTX_INIT},
     {"helplang",    "hlg",  P_STRING|P_VI_DEF|P_ONECOMMA,
 #ifdef FEAT_MULTI_LANG
 			    (char_u *)&p_hlg, PV_NONE,
@@ -1487,51 +1487,51 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"hidden",	    "hid",  P_BOOL|P_VI_DEF,
 			    (char_u *)&p_hid, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"highlight",   "hl",   P_STRING|P_VI_DEF|P_RCLR|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_hl, PV_NONE,
 			    {(char_u *)HIGHLIGHT_INIT, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"history",	    "hi",   P_NUM|P_VIM,
 			    (char_u *)&p_hi, PV_NONE,
-			    {(char_u *)0L, (char_u *)50L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)50L} SCTX_INIT},
     {"hkmap",	    "hk",   P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_RIGHTLEFT
 			    (char_u *)&p_hkmap, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"hkmapp",	    "hkp",  P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_RIGHTLEFT
 			    (char_u *)&p_hkmapp, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"hlsearch",    "hls",  P_BOOL|P_VI_DEF|P_VIM|P_RALL,
 			    (char_u *)&p_hls, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"icon",	    NULL,   P_BOOL|P_VI_DEF,
 #ifdef FEAT_TITLE
 			    (char_u *)&p_icon, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"iconstring",  NULL,   P_STRING|P_VI_DEF,
 #ifdef FEAT_TITLE
 			    (char_u *)&p_iconstring, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"ignorecase",  "ic",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_ic, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"imactivatefunc","imaf",P_STRING|P_VI_DEF|P_SECURE,
 #if defined(FEAT_EVAL) && defined(FEAT_MBYTE)
 			    (char_u *)&p_imaf, PV_NONE,
@@ -1540,21 +1540,21 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 # endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"imactivatekey","imak",P_STRING|P_VI_DEF,
 #if defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
 			    (char_u *)&p_imak, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"imcmdline",   "imc",  P_BOOL|P_VI_DEF,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_imcmdline, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"imdisable",   "imd",  P_BOOL|P_VI_DEF,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_imdisable, PV_NONE,
@@ -1566,15 +1566,15 @@ static struct vimoption options[] =
 #else
 			    {(char_u *)FALSE, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"iminsert",    "imi",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_iminsert, PV_IMI,
 			    {(char_u *)B_IMODE_NONE, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"imsearch",    "ims",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_imsearch, PV_IMS,
 			    {(char_u *)B_IMODE_USE_INSERT, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"imstatusfunc","imsf",P_STRING|P_VI_DEF|P_SECURE,
 #if defined(FEAT_EVAL) && defined(FEAT_MBYTE)
 			    (char_u *)&p_imsf, PV_NONE,
@@ -1583,7 +1583,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"imstyle",	    "imst", P_NUM|P_VI_DEF|P_SECURE,
 #if defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
 			    (char_u *)&p_imst, PV_NONE,
@@ -1592,7 +1592,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"include",	    "inc",  P_STRING|P_ALLOCED|P_VI_DEF,
 #ifdef FEAT_FIND_ID
 			    (char_u *)&p_inc, PV_INC,
@@ -1601,7 +1601,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"includeexpr", "inex", P_STRING|P_ALLOCED|P_VI_DEF,
 #if defined(FEAT_FIND_ID) && defined(FEAT_EVAL)
 			    (char_u *)&p_inex, PV_INEX,
@@ -1610,10 +1610,10 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"incsearch",   "is",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_is, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"indentexpr", "inde",  P_STRING|P_ALLOCED|P_VI_DEF|P_VIM,
 #if defined(FEAT_CINDENT) && defined(FEAT_EVAL)
 			    (char_u *)&p_inde, PV_INDE,
@@ -1622,7 +1622,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"indentkeys", "indk",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #if defined(FEAT_CINDENT) && defined(FEAT_EVAL)
 			    (char_u *)&p_indk, PV_INDK,
@@ -1631,13 +1631,13 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"infercase",   "inf",  P_BOOL|P_VI_DEF,
 			    (char_u *)&p_inf, PV_INF,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"insertmode",  "im",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_im, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"isfname",	    "isf",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
 			    (char_u *)&p_isf, PV_NONE,
 			    {
@@ -1660,7 +1660,7 @@ static struct vimoption options[] =
 #  endif
 # endif
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"isident",	    "isi",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
 			    (char_u *)&p_isi, PV_NONE,
 			    {
@@ -1677,7 +1677,7 @@ static struct vimoption options[] =
 			    (char_u *)"@,48-57,_,192-255",
 # endif
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"iskeyword",   "isk",  P_STRING|P_ALLOCED|P_VIM|P_COMMA|P_NODUP,
 			    (char_u *)&p_isk, PV_ISK,
 			    {
@@ -1696,7 +1696,7 @@ static struct vimoption options[] =
 				ISK_LATIN1
 # endif
 #endif
-			    } SCRIPTID_INIT},
+			    } SCTX_INIT},
     {"isprint",	    "isp",  P_STRING|P_VI_DEF|P_RALL|P_COMMA|P_NODUP,
 			    (char_u *)&p_isp, PV_NONE,
 			    {
@@ -1710,10 +1710,10 @@ static struct vimoption options[] =
 			    ISP_LATIN1,
 # endif
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"joinspaces",  "js",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_js, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"key",	    NULL,   P_STRING|P_ALLOCED|P_VI_DEF|P_NO_MKRC,
 #ifdef FEAT_CRYPT
 			    (char_u *)&p_key, PV_KEY,
@@ -1722,7 +1722,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"keymap",	    "kmp",  P_STRING|P_ALLOCED|P_VI_DEF|P_RBUF|P_RSTAT|P_NFNAME|P_PRI_MKRC,
 #ifdef FEAT_KEYMAP
 			    (char_u *)&p_keymap, PV_KMAP,
@@ -1731,10 +1731,10 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"keymodel",    "km",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_km, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"keywordprg",  "kp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_kp, PV_KP,
 			    {
@@ -1751,7 +1751,7 @@ static struct vimoption options[] =
 #  endif
 # endif
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"langmap",     "lmap", P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP|P_SECURE,
 #ifdef FEAT_LANGMAP
 			    (char_u *)&p_langmap, PV_NONE,
@@ -1760,41 +1760,41 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL,
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"langmenu",    "lm",   P_STRING|P_VI_DEF|P_NFNAME,
 #if defined(FEAT_MENU) && defined(FEAT_MULTI_LANG)
 			    (char_u *)&p_lm, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"langnoremap",  "lnr",   P_BOOL|P_VI_DEF,
 #ifdef FEAT_LANGMAP
 			    (char_u *)&p_lnr, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"langremap",  "lrm",   P_BOOL|P_VI_DEF,
 #ifdef FEAT_LANGMAP
 			    (char_u *)&p_lrm, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"laststatus",  "ls",   P_NUM|P_VI_DEF|P_RALL,
 			    (char_u *)&p_ls, PV_NONE,
-			    {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1L, (char_u *)0L} SCTX_INIT},
     {"lazyredraw",  "lz",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_lz, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"linebreak",   "lbr",  P_BOOL|P_VI_DEF|P_RWIN,
 #ifdef FEAT_LINEBREAK
 			    (char_u *)VAR_WIN, PV_LBR,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"lines",	    NULL,   P_NUM|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|P_RCLR,
 			    (char_u *)&Rows, PV_NONE,
 			    {
@@ -1803,7 +1803,7 @@ static struct vimoption options[] =
 #else
 			    (char_u *)24L,
 #endif
-					    (char_u *)0L} SCRIPTID_INIT},
+					    (char_u *)0L} SCTX_INIT},
     {"linespace",   "lsp",  P_NUM|P_VI_DEF|P_RCLR,
 #ifdef FEAT_GUI
 			    (char_u *)&p_linespace, PV_NONE,
@@ -1815,14 +1815,14 @@ static struct vimoption options[] =
 #else
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"lisp",	    NULL,   P_BOOL|P_VI_DEF,
 #ifdef FEAT_LISP
 			    (char_u *)&p_lisp, PV_LISP,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"lispwords",   "lw",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_LISP
 			    (char_u *)&p_lispwords, PV_LW,
@@ -1831,16 +1831,16 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"list",	    NULL,   P_BOOL|P_VI_DEF|P_RWIN,
 			    (char_u *)VAR_WIN, PV_LIST,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"listchars",   "lcs",  P_STRING|P_VI_DEF|P_RALL|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_lcs, PV_NONE,
-			    {(char_u *)"eol:$", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"eol:$", (char_u *)0L} SCTX_INIT},
     {"loadplugins", "lpl",  P_BOOL|P_VI_DEF,
 			    (char_u *)&p_lpl, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"luadll",      NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(DYNAMIC_LUA)
 			    (char_u *)&p_luadll, PV_NONE,
@@ -1849,7 +1849,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"macatsui",    NULL,   P_BOOL|P_VI_DEF|P_RCLR,
 #ifdef FEAT_GUI_MAC
 			    (char_u *)&p_macatsui, PV_NONE,
@@ -1858,10 +1858,10 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"magic",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_magic, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"makeef",	    "mef",  P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #ifdef FEAT_QUICKFIX
 			    (char_u *)&p_mef, PV_NONE,
@@ -1870,7 +1870,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"makeencoding","menc", P_STRING|P_VI_DEF,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_menc, PV_MENC,
@@ -1879,7 +1879,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"makeprg",	    "mp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #ifdef FEAT_QUICKFIX
 			    (char_u *)&p_mp, PV_MP,
@@ -1892,52 +1892,52 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"matchpairs",  "mps",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_mps, PV_MPS,
 			    {(char_u *)"(:),{:},[:]", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"matchtime",   "mat",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_mat, PV_NONE,
-			    {(char_u *)5L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)5L, (char_u *)0L} SCTX_INIT},
     {"maxcombine",  "mco",  P_NUM|P_VI_DEF|P_CURSWANT,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_mco, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)2, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)2, (char_u *)0L} SCTX_INIT},
     {"maxfuncdepth", "mfd", P_NUM|P_VI_DEF,
 #ifdef FEAT_EVAL
 			    (char_u *)&p_mfd, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)100L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)100L, (char_u *)0L} SCTX_INIT},
     {"maxmapdepth", "mmd",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_mmd, PV_NONE,
-			    {(char_u *)1000L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1000L, (char_u *)0L} SCTX_INIT},
     {"maxmem",	    "mm",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_mm, PV_NONE,
 			    {(char_u *)DFLT_MAXMEM, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"maxmempattern","mmp", P_NUM|P_VI_DEF,
 			    (char_u *)&p_mmp, PV_NONE,
-			    {(char_u *)1000L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1000L, (char_u *)0L} SCTX_INIT},
     {"maxmemtot",   "mmt",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_mmt, PV_NONE,
 			    {(char_u *)DFLT_MAXMEMTOT, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"menuitems",   "mis",  P_NUM|P_VI_DEF,
 #ifdef FEAT_MENU
 			    (char_u *)&p_mis, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)25L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)25L, (char_u *)0L} SCTX_INIT},
     {"mesg",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"mkspellmem",  "msm",  P_STRING|P_VI_DEF|P_EXPAND|P_SECURE,
 #ifdef FEAT_SPELL
 			    (char_u *)&p_msm, PV_NONE,
@@ -1946,22 +1946,22 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"modeline",    "ml",   P_BOOL|P_VIM,
 			    (char_u *)&p_ml, PV_ML,
-			    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)TRUE} SCTX_INIT},
     {"modelines",   "mls",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_mls, PV_NONE,
-			    {(char_u *)5L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)5L, (char_u *)0L} SCTX_INIT},
     {"modifiable",  "ma",   P_BOOL|P_VI_DEF|P_NOGLOB,
 			    (char_u *)&p_ma, PV_MA,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"modified",    "mod",  P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
 			    (char_u *)&p_mod, PV_MOD,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"more",	    NULL,   P_BOOL|P_VIM,
 			    (char_u *)&p_more, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)TRUE} SCTX_INIT},
     {"mouse",	    NULL,   P_STRING|P_VI_DEF|P_FLAGLIST,
 			    (char_u *)&p_mouse, PV_NONE,
 			    {
@@ -1970,21 +1970,21 @@ static struct vimoption options[] =
 #else
 				(char_u *)"",
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"mousefocus",   "mousef", P_BOOL|P_VI_DEF,
 #ifdef FEAT_GUI
 			    (char_u *)&p_mousef, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"mousehide",   "mh",   P_BOOL|P_VI_DEF,
 #ifdef FEAT_GUI
 			    (char_u *)&p_mh, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"mousemodel",  "mousem", P_STRING|P_VI_DEF,
 			    (char_u *)&p_mousem, PV_NONE,
 			    {
@@ -1997,7 +1997,7 @@ static struct vimoption options[] =
 				(char_u *)"extend",
 # endif
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"mouseshape",  "mouses",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_MOUSESHAPE
 			    (char_u *)&p_mouseshape, PV_NONE,
@@ -2006,10 +2006,10 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"mousetime",   "mouset",	P_NUM|P_VI_DEF,
 			    (char_u *)&p_mouset, PV_NONE,
-			    {(char_u *)500L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)500L, (char_u *)0L} SCTX_INIT},
     {"mzschemedll", NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(DYNAMIC_MZSCHEME)
 			    (char_u *)&p_mzschemedll, PV_NONE,
@@ -2018,7 +2018,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"mzschemegcdll", NULL, P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(DYNAMIC_MZSCHEME)
 			    (char_u *)&p_mzschemegcdll, PV_NONE,
@@ -2027,31 +2027,31 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"mzquantum",  "mzq",   P_NUM,
 #ifdef FEAT_MZSCHEME
 			    (char_u *)&p_mzq, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)100L, (char_u *)100L} SCRIPTID_INIT},
+			    {(char_u *)100L, (char_u *)100L} SCTX_INIT},
     {"novice",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"nrformats",   "nf",   P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_nf, PV_NF,
 			    {(char_u *)"bin,octal,hex", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"number",	    "nu",   P_BOOL|P_VI_DEF|P_RWIN,
 			    (char_u *)VAR_WIN, PV_NU,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"numberwidth", "nuw",  P_NUM|P_RWIN|P_VIM,
 #ifdef FEAT_LINEBREAK
 			    (char_u *)VAR_WIN, PV_NUW,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)8L, (char_u *)4L} SCRIPTID_INIT},
+			    {(char_u *)8L, (char_u *)4L} SCTX_INIT},
     {"omnifunc",    "ofu",  P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
 #ifdef FEAT_COMPL_FUNC
 			    (char_u *)&p_ofu, PV_OFU,
@@ -2060,10 +2060,10 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"open",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"opendevice",  "odev", P_BOOL|P_VI_DEF,
 #if defined(MSWIN)
 			    (char_u *)&p_odev, PV_NONE,
@@ -2071,31 +2071,31 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 #endif
 			    {(char_u *)FALSE, (char_u *)FALSE}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"operatorfunc", "opfunc", P_STRING|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_opfunc, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"optimize",    "opt",  P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"osfiletype",  "oft",  P_STRING|P_ALLOCED|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"packpath",    "pp",   P_STRING|P_VI_DEF|P_EXPAND|P_ONECOMMA|P_NODUP
 								    |P_SECURE,
 			    (char_u *)&p_pp, PV_NONE,
 			    {(char_u *)DFLT_RUNTIMEPATH, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"paragraphs",  "para", P_STRING|P_VI_DEF,
 			    (char_u *)&p_para, PV_NONE,
 			    {(char_u *)"IPLPPPQPP TPHPLIPpLpItpplpipbp",
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"paste",	    NULL,   P_BOOL|P_VI_DEF|P_PRI_MKRC,
 			    (char_u *)&p_paste, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"pastetoggle", "pt",   P_STRING|P_VI_DEF,
 			    (char_u *)&p_pt, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"patchexpr",   "pex",  P_STRING|P_VI_DEF|P_SECURE,
 #if defined(FEAT_DIFF) && defined(FEAT_EVAL)
 			    (char_u *)&p_pex, PV_NONE,
@@ -2104,10 +2104,10 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"patchmode",   "pm",   P_STRING|P_VI_DEF|P_NFNAME,
 			    (char_u *)&p_pm, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"path",	    "pa",   P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
 			    (char_u *)&p_path, PV_PATH,
 			    {
@@ -2116,7 +2116,7 @@ static struct vimoption options[] =
 #else
 			    (char_u *)".,/usr/include,,",
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"perldll",     NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(DYNAMIC_PERL)
 			    (char_u *)&p_perldll, PV_NONE,
@@ -2125,24 +2125,24 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"preserveindent", "pi", P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_pi, PV_PI,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"previewheight", "pvh", P_NUM|P_VI_DEF,
 #if defined(FEAT_QUICKFIX)
 			    (char_u *)&p_pvh, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)12L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)12L, (char_u *)0L} SCTX_INIT},
     {"previewwindow", "pvw", P_BOOL|P_VI_DEF|P_RSTAT|P_NOGLOB,
 #if defined(FEAT_QUICKFIX)
 			    (char_u *)VAR_WIN, PV_PVW,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"printdevice", "pdev", P_STRING|P_VI_DEF|P_SECURE,
 #ifdef FEAT_PRINTER
 			    (char_u *)&p_pdev, PV_NONE,
@@ -2151,7 +2151,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"printencoding", "penc", P_STRING|P_VI_DEF,
 #ifdef FEAT_POSTSCRIPT
 			    (char_u *)&p_penc, PV_NONE,
@@ -2160,7 +2160,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"printexpr", "pexpr",  P_STRING|P_VI_DEF|P_SECURE,
 #ifdef FEAT_POSTSCRIPT
 			    (char_u *)&p_pexpr, PV_NONE,
@@ -2169,7 +2169,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"printfont", "pfn",    P_STRING|P_VI_DEF,
 #ifdef FEAT_PRINTER
 			    (char_u *)&p_pfn, PV_NONE,
@@ -2184,7 +2184,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"printheader", "pheader",  P_STRING|P_VI_DEF|P_GETTEXT,
 #ifdef FEAT_PRINTER
 			    (char_u *)&p_header, PV_NONE,
@@ -2195,7 +2195,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
    {"printmbcharset", "pmbcs",  P_STRING|P_VI_DEF,
 #if defined(FEAT_POSTSCRIPT) && defined(FEAT_MBYTE)
 			    (char_u *)&p_pmcs, PV_NONE,
@@ -2204,7 +2204,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"printmbfont", "pmbfn",  P_STRING|P_VI_DEF,
 #if defined(FEAT_POSTSCRIPT) && defined(FEAT_MBYTE)
 			    (char_u *)&p_pmfn, PV_NONE,
@@ -2213,7 +2213,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"printoptions", "popt", P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_PRINTER
 			    (char_u *)&p_popt, PV_NONE,
@@ -2222,24 +2222,24 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"prompt",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_prompt, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"pumheight",   "ph",   P_NUM|P_VI_DEF,
 #ifdef FEAT_INS_EXPAND
 			    (char_u *)&p_ph, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"pumwidth",    "pw",   P_NUM|P_VI_DEF,
 #ifdef FEAT_INS_EXPAND
 			    (char_u *)&p_pw, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)15L, (char_u *)15L} SCRIPTID_INIT},
+			    {(char_u *)15L, (char_u *)15L} SCTX_INIT},
     {"pythonthreedll",  NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(DYNAMIC_PYTHON3)
 			    (char_u *)&p_py3dll, PV_NONE,
@@ -2248,7 +2248,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"pythonthreehome", NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(FEAT_PYTHON3)
 			    (char_u *)&p_py3home, PV_NONE,
@@ -2257,7 +2257,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"pythondll",   NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(DYNAMIC_PYTHON)
 			    (char_u *)&p_pydll, PV_NONE,
@@ -2266,7 +2266,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"pythonhome",  NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(FEAT_PYTHON)
 			    (char_u *)&p_pyhome, PV_NONE,
@@ -2275,7 +2275,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"pyxversion", "pyx",   P_NUM|P_VI_DEF|P_SECURE,
 #if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 			    (char_u *)&p_pyx, PV_NONE,
@@ -2283,7 +2283,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 #endif
 			    {(char_u *)DEFAULT_PYTHON_VER, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"quoteescape", "qe",   P_STRING|P_ALLOCED|P_VI_DEF,
 #ifdef FEAT_TEXTOBJ
 			    (char_u *)&p_qe, PV_QE,
@@ -2292,29 +2292,29 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"readonly",    "ro",   P_BOOL|P_VI_DEF|P_RSTAT|P_NOGLOB,
 			    (char_u *)&p_ro, PV_RO,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"redraw",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"redrawtime",  "rdt",  P_NUM|P_VI_DEF,
 #ifdef FEAT_RELTIME
 			    (char_u *)&p_rdt, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)2000L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)2000L, (char_u *)0L} SCTX_INIT},
     {"regexpengine", "re",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_re, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"relativenumber", "rnu", P_BOOL|P_VI_DEF|P_RWIN,
 			    (char_u *)VAR_WIN, PV_RNU,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"remap",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_remap, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"renderoptions", "rop", P_STRING|P_ONECOMMA|P_RCLR|P_VI_DEF,
 #ifdef FEAT_RENDER_OPTIONS
 			    (char_u *)&p_rop, PV_NONE,
@@ -2323,31 +2323,31 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"report",	    NULL,   P_NUM|P_VI_DEF,
 			    (char_u *)&p_report, PV_NONE,
-			    {(char_u *)2L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)2L, (char_u *)0L} SCTX_INIT},
     {"restorescreen", "rs", P_BOOL|P_VI_DEF,
 #ifdef WIN3264
 			    (char_u *)&p_rs, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"revins",	    "ri",   P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_RIGHTLEFT
 			    (char_u *)&p_ri, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"rightleft",   "rl",   P_BOOL|P_VI_DEF|P_RWIN,
 #ifdef FEAT_RIGHTLEFT
 			    (char_u *)VAR_WIN, PV_RL,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"rightleftcmd", "rlc", P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
 #ifdef FEAT_RIGHTLEFT
 			    (char_u *)VAR_WIN, PV_RLC,
@@ -2356,7 +2356,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"rubydll",     NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(DYNAMIC_RUBY)
 			    (char_u *)&p_rubydll, PV_NONE,
@@ -2365,56 +2365,56 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"ruler",	    "ru",   P_BOOL|P_VI_DEF|P_VIM|P_RSTAT,
 #ifdef FEAT_CMDL_INFO
 			    (char_u *)&p_ru, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"rulerformat", "ruf",  P_STRING|P_VI_DEF|P_ALLOCED|P_RSTAT,
 #ifdef FEAT_STL_OPT
 			    (char_u *)&p_ruf, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"runtimepath", "rtp",  P_STRING|P_VI_DEF|P_EXPAND|P_ONECOMMA|P_NODUP
 								    |P_SECURE,
 			    (char_u *)&p_rtp, PV_NONE,
 			    {(char_u *)DFLT_RUNTIMEPATH, (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"scroll",	    "scr",  P_NUM|P_NO_MKRC|P_VI_DEF,
 			    (char_u *)VAR_WIN, PV_SCROLL,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"scrollbind",  "scb",  P_BOOL|P_VI_DEF,
 			    (char_u *)VAR_WIN, PV_SCBIND,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"scrolljump",  "sj",   P_NUM|P_VI_DEF|P_VIM,
 			    (char_u *)&p_sj, PV_NONE,
-			    {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1L, (char_u *)0L} SCTX_INIT},
     {"scrolloff",   "so",   P_NUM|P_VI_DEF|P_VIM|P_RALL,
 			    (char_u *)&p_so, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"scrollopt",   "sbo",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_sbo, PV_NONE,
 			    {(char_u *)"ver,jump", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"sections",    "sect", P_STRING|P_VI_DEF,
 			    (char_u *)&p_sections, PV_NONE,
 			    {(char_u *)"SHNHH HUnhsh", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"secure",	    NULL,   P_BOOL|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_secure, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"selection",   "sel",  P_STRING|P_VI_DEF,
 			    (char_u *)&p_sel, PV_NONE,
 			    {(char_u *)"inclusive", (char_u *)0L}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"selectmode",  "slm",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_slm, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"sessionoptions", "ssop", P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_SESSION
 			    (char_u *)&p_ssop, PV_NONE,
@@ -2424,7 +2424,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"shell",	    "sh",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_sh, PV_NONE,
 			    {
@@ -2437,7 +2437,7 @@ static struct vimoption options[] =
 			    (char_u *)"sh",
 # endif
 #endif /* VMS */
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"shellcmdflag","shcf", P_STRING|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_shcf, PV_NONE,
 			    {
@@ -2446,7 +2446,7 @@ static struct vimoption options[] =
 #else
 			    (char_u *)"-c",
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"shellpipe",   "sp",   P_STRING|P_VI_DEF|P_SECURE,
 #ifdef FEAT_QUICKFIX
 			    (char_u *)&p_sp, PV_NONE,
@@ -2461,30 +2461,30 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"shellquote",  "shq",  P_STRING|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_shq, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"shellredir",  "srr",  P_STRING|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_srr, PV_NONE,
-			    {(char_u *)">", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)">", (char_u *)0L} SCTX_INIT},
     {"shellslash",  "ssl",   P_BOOL|P_VI_DEF,
 #ifdef BACKSLASH_IN_FILENAME
 			    (char_u *)&p_ssl, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"shelltemp",   "stmp", P_BOOL,
 			    (char_u *)&p_stmp, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)TRUE} SCTX_INIT},
     {"shelltype",   "st",   P_NUM|P_VI_DEF,
 #ifdef AMIGA
 			    (char_u *)&p_st, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"shellxquote", "sxq",  P_STRING|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_sxq, PV_NONE,
 			    {
@@ -2493,7 +2493,7 @@ static struct vimoption options[] =
 #else
 			    (char_u *)"",
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"shellxescape", "sxe", P_STRING|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_sxe, PV_NONE,
 			    {
@@ -2502,27 +2502,27 @@ static struct vimoption options[] =
 #else
 			    (char_u *)"",
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"shiftround",  "sr",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_sr, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"shiftwidth",  "sw",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_sw, PV_SW,
-			    {(char_u *)8L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)8L, (char_u *)0L} SCTX_INIT},
     {"shortmess",   "shm",  P_STRING|P_VIM|P_FLAGLIST,
 			    (char_u *)&p_shm, PV_NONE,
 			    {(char_u *)"", (char_u *)"filnxtToO"}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"shortname",   "sn",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_sn, PV_SN,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"showbreak",   "sbr",  P_STRING|P_VI_DEF|P_RALL,
 #ifdef FEAT_LINEBREAK
 			    (char_u *)&p_sbr, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"showcmd",	    "sc",   P_BOOL|P_VIM,
 #ifdef FEAT_CMDL_INFO
 			    (char_u *)&p_sc, PV_NONE,
@@ -2535,25 +2535,25 @@ static struct vimoption options[] =
 #else
 				(char_u *)TRUE
 #endif
-				} SCRIPTID_INIT},
+				} SCTX_INIT},
     {"showfulltag", "sft",  P_BOOL|P_VI_DEF,
 			    (char_u *)&p_sft, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"showmatch",   "sm",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_sm, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"showmode",    "smd",  P_BOOL|P_VIM,
 			    (char_u *)&p_smd, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)TRUE} SCTX_INIT},
     {"showtabline", "stal", P_NUM|P_VI_DEF|P_RALL,
 			    (char_u *)&p_stal, PV_NONE,
-			    {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1L, (char_u *)0L} SCTX_INIT},
     {"sidescroll",  "ss",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_ss, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"sidescrolloff", "siso", P_NUM|P_VI_DEF|P_VIM|P_RBUF,
 			    (char_u *)&p_siso, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"signcolumn",   "scl",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
 #ifdef FEAT_SIGNS
 			    (char_u *)VAR_WIN, PV_SCL,
@@ -2562,36 +2562,36 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"slowopen",    "slow", P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"smartcase",   "scs",  P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_scs, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"smartindent", "si",   P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_SMARTINDENT
 			    (char_u *)&p_si, PV_SI,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"smarttab",    "sta",  P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_sta, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"softtabstop", "sts",  P_NUM|P_VI_DEF|P_VIM,
 			    (char_u *)&p_sts, PV_STS,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"sourceany",   NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"spell",	    NULL,   P_BOOL|P_VI_DEF|P_RWIN,
 #ifdef FEAT_SPELL
 			    (char_u *)VAR_WIN, PV_SPELL,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"spellcapcheck", "spc", P_STRING|P_ALLOCED|P_VI_DEF|P_RBUF,
 #ifdef FEAT_SPELL
 			    (char_u *)&p_spc, PV_SPC,
@@ -2600,7 +2600,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"spellfile",   "spf",  P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_SECURE
 								  |P_ONECOMMA,
 #ifdef FEAT_SPELL
@@ -2610,7 +2610,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"spelllang",   "spl",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA
 							     |P_RBUF|P_EXPAND,
 #ifdef FEAT_SPELL
@@ -2620,7 +2620,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"spellsuggest", "sps", P_STRING|P_VI_DEF|P_EXPAND|P_SECURE|P_ONECOMMA,
 #ifdef FEAT_SPELL
 			    (char_u *)&p_sps, PV_NONE,
@@ -2629,27 +2629,27 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"splitbelow",  "sb",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_sb, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"splitright",  "spr",  P_BOOL|P_VI_DEF,
 			    (char_u *)&p_spr, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"startofline", "sol",  P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_sol, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"statusline"  ,"stl",  P_STRING|P_VI_DEF|P_ALLOCED|P_RSTAT,
 #ifdef FEAT_STL_OPT
 			    (char_u *)&p_stl, PV_STL,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"suffixes",    "su",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_su, PV_NONE,
 			    {(char_u *)".bak,~,.o,.h,.info,.swp,.obj",
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"suffixesadd", "sua",  P_STRING|P_VI_DEF|P_ALLOCED|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_SEARCHPATH
 			    (char_u *)&p_sua, PV_SUA,
@@ -2658,16 +2658,16 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"swapfile",    "swf",  P_BOOL|P_VI_DEF|P_RSTAT,
 			    (char_u *)&p_swf, PV_SWF,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"swapsync",    "sws",  P_STRING|P_VI_DEF,
 			    (char_u *)&p_sws, PV_NONE,
-			    {(char_u *)"fsync", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"fsync", (char_u *)0L} SCTX_INIT},
     {"switchbuf",   "swb",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_swb, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"synmaxcol",   "smc",  P_NUM|P_VI_DEF|P_RBUF,
 #ifdef FEAT_SYN_HL
 			    (char_u *)&p_smc, PV_SMC,
@@ -2676,7 +2676,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"syntax",	    "syn",  P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB|P_NFNAME,
 #ifdef FEAT_SYN_HL
 			    (char_u *)&p_syn, PV_SYN,
@@ -2685,20 +2685,20 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"tabline",	    "tal",  P_STRING|P_VI_DEF|P_RALL,
 #ifdef FEAT_STL_OPT
 			    (char_u *)&p_tal, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"tabpagemax",  "tpm",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_tpm, PV_NONE,
-			    {(char_u *)10L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)10L, (char_u *)0L} SCTX_INIT},
     {"tabstop",	    "ts",   P_NUM|P_VI_DEF|P_RBUF,
 			    (char_u *)&p_ts, PV_TS,
-			    {(char_u *)8L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)8L, (char_u *)0L} SCTX_INIT},
     {"tagbsearch",  "tbs",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_tbs, PV_NONE,
 #ifdef VMS	/* binary searching doesn't appear to work on VMS */
@@ -2706,16 +2706,16 @@ static struct vimoption options[] =
 #else
 			    {(char_u *)TRUE, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"tagcase",	    "tc",   P_STRING|P_VIM,
 			    (char_u *)&p_tc, PV_TC,
-			    {(char_u *)"followic", (char_u *)"followic"} SCRIPTID_INIT},
+			    {(char_u *)"followic", (char_u *)"followic"} SCTX_INIT},
     {"taglength",   "tl",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_tl, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"tagrelative", "tr",   P_BOOL|P_VIM,
 			    (char_u *)&p_tr, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)TRUE} SCTX_INIT},
     {"tags",	    "tag",  P_STRING|P_EXPAND|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_tags, PV_TAGS,
 			    {
@@ -2724,10 +2724,10 @@ static struct vimoption options[] =
 #else
 			    (char_u *)"./tags,tags",
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"tagstack",    "tgst", P_BOOL|P_VI_DEF,
 			    (char_u *)&p_tgst, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"tcldll",      NULL,   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(DYNAMIC_TCL)
 			    (char_u *)&p_tcldll, PV_NONE,
@@ -2736,17 +2736,17 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"term",	    NULL,   P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|P_RALL,
 			    (char_u *)&T_NAME, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"termbidi", "tbidi",   P_BOOL|P_VI_DEF,
 #ifdef FEAT_ARABIC
 			    (char_u *)&p_tbidi, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"termencoding", "tenc", P_STRING|P_VI_DEF|P_RCLR,
 #ifdef FEAT_MBYTE
 			    (char_u *)&p_tenc, PV_NONE,
@@ -2755,7 +2755,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"termguicolors", "tgc", P_BOOL|P_VI_DEF|P_VIM|P_RCLR,
 #ifdef FEAT_TERMGUICOLORS
 			    (char_u *)&p_tgc, PV_NONE,
@@ -2764,7 +2764,7 @@ static struct vimoption options[] =
 			    (char_u*)NULL, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)FALSE}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"termwinkey", "twk",   P_STRING|P_ALLOCED|P_RWIN|P_VI_DEF,
 #ifdef FEAT_TERMINAL
 			    (char_u *)VAR_WIN, PV_TWK,
@@ -2773,7 +2773,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"termwinscroll", "twsl", P_NUM|P_VI_DEF|P_VIM|P_RBUF,
 #ifdef FEAT_TERMINAL
 			    (char_u *)&p_twsl, PV_TWSL,
@@ -2782,7 +2782,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"termwinsize", "tws",  P_STRING|P_ALLOCED|P_RWIN|P_VI_DEF,
 #ifdef FEAT_TERMINAL
 			    (char_u *)VAR_WIN, PV_TWS,
@@ -2791,14 +2791,14 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"terse",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_terse, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"textauto",    "ta",   P_BOOL|P_VIM,
 			    (char_u *)&p_ta, PV_NONE,
 			    {(char_u *)DFLT_TEXTAUTO, (char_u *)TRUE}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"textmode",    "tx",   P_BOOL|P_VI_DEF|P_NO_MKRC,
 			    (char_u *)&p_tx, PV_TX,
 			    {
@@ -2807,40 +2807,40 @@ static struct vimoption options[] =
 #else
 			    (char_u *)FALSE,
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"textwidth",   "tw",   P_NUM|P_VI_DEF|P_VIM|P_RBUF,
 			    (char_u *)&p_tw, PV_TW,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"thesaurus",   "tsr",  P_STRING|P_EXPAND|P_VI_DEF|P_ONECOMMA|P_NODUP|P_NDNAME,
 #ifdef FEAT_INS_EXPAND
 			    (char_u *)&p_tsr, PV_TSR,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"tildeop",	    "top",  P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_to, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"timeout",	    "to",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_timeout, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"timeoutlen",  "tm",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_tm, PV_NONE,
-			    {(char_u *)1000L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1000L, (char_u *)0L} SCTX_INIT},
     {"title",	    NULL,   P_BOOL|P_VI_DEF,
 #ifdef FEAT_TITLE
 			    (char_u *)&p_title, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"titlelen",    NULL,   P_NUM|P_VI_DEF,
 #ifdef FEAT_TITLE
 			    (char_u *)&p_titlelen, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)85L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)85L, (char_u *)0L} SCTX_INIT},
     {"titleold",    NULL,   P_STRING|P_VI_DEF|P_GETTEXT|P_SECURE|P_NO_MKRC,
 #ifdef FEAT_TITLE
 			    (char_u *)&p_titleold, PV_NONE,
@@ -2850,14 +2850,14 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"titlestring", NULL,   P_STRING|P_VI_DEF,
 #ifdef FEAT_TITLE
 			    (char_u *)&p_titlestring, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"toolbar",     "tb",   P_STRING|P_ONECOMMA|P_VI_DEF|P_NODUP,
 #if defined(FEAT_TOOLBAR) && !defined(FEAT_GUI_W32)
 			    (char_u *)&p_toolbar, PV_NONE,
@@ -2866,7 +2866,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"toolbariconsize",	"tbis", P_STRING|P_VI_DEF,
 #if defined(FEAT_TOOLBAR) && defined(FEAT_GUI_GTK)
 			    (char_u *)&p_tbis, PV_NONE,
@@ -2875,32 +2875,32 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"ttimeout",    NULL,   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_ttimeout, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"ttimeoutlen", "ttm",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_ttm, PV_NONE,
-			    {(char_u *)-1L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)-1L, (char_u *)0L} SCTX_INIT},
     {"ttybuiltin",  "tbi",  P_BOOL|P_VI_DEF,
 			    (char_u *)&p_tbi, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"ttyfast",	    "tf",   P_BOOL|P_NO_MKRC|P_VI_DEF,
 			    (char_u *)&p_tf, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"ttymouse",    "ttym", P_STRING|P_NODEFAULT|P_NO_MKRC|P_VI_DEF,
 #if defined(FEAT_MOUSE) && (defined(UNIX) || defined(VMS))
 			    (char_u *)&p_ttym, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"ttyscroll",   "tsl",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_ttyscroll, PV_NONE,
-			    {(char_u *)999L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)999L, (char_u *)0L} SCTX_INIT},
     {"ttytype",	    "tty",  P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|P_RALL,
 			    (char_u *)&T_NAME, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"undodir",     "udir", P_STRING|P_EXPAND|P_ONECOMMA|P_NODUP|P_SECURE
 								    |P_VI_DEF,
 #ifdef FEAT_PERSISTENT_UNDO
@@ -2910,14 +2910,14 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"undofile",    "udf",  P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_PERSISTENT_UNDO
 			    (char_u *)&p_udf, PV_UDF,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"undolevels",  "ul",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_ul, PV_UL,
 			    {
@@ -2926,16 +2926,16 @@ static struct vimoption options[] =
 #else
 			    (char_u *)100L,
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"undoreload",  "ur",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_ur, PV_NONE,
-			    { (char_u *)10000L, (char_u *)0L} SCRIPTID_INIT},
+			    { (char_u *)10000L, (char_u *)0L} SCTX_INIT},
     {"updatecount", "uc",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_uc, PV_NONE,
-			    {(char_u *)200L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)200L, (char_u *)0L} SCTX_INIT},
     {"updatetime",  "ut",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_ut, PV_NONE,
-			    {(char_u *)4000L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)4000L, (char_u *)0L} SCTX_INIT},
     {"varsofttabstop", "vsts",  P_STRING|P_VI_DEF|P_VIM|P_COMMA,
 #ifdef FEAT_VARTABS
 			    (char_u *)&p_vsts, PV_VSTS,
@@ -2944,7 +2944,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"vartabstop",  "vts",  P_STRING|P_VI_DEF|P_VIM|P_RBUF|P_COMMA,
 #ifdef FEAT_VARTABS
 			    (char_u *)&p_vts, PV_VTS,
@@ -2953,13 +2953,13 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"verbose",	    "vbs",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_verbose, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"verbosefile", "vfile", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_vfile, PV_NONE,
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"viewdir",     "vdir", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #ifdef FEAT_SESSION
 			    (char_u *)&p_vdir, PV_NONE,
@@ -2968,7 +2968,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"viewoptions", "vop",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_SESSION
 			    (char_u *)&p_vop, PV_NONE,
@@ -2978,7 +2978,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"viminfo",	    "vi",   P_STRING|P_ONECOMMA|P_NODUP|P_SECURE,
 #ifdef FEAT_VIMINFO
 			    (char_u *)&p_viminfo, PV_NONE,
@@ -2996,7 +2996,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"viminfofile", "vif",  P_STRING|P_EXPAND|P_ONECOMMA|P_NODUP
 							    |P_SECURE|P_VI_DEF,
 #ifdef FEAT_VIMINFO
@@ -3006,7 +3006,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"virtualedit", "ve",   P_STRING|P_ONECOMMA|P_NODUP|P_VI_DEF
 							    |P_VIM|P_CURSWANT,
 #ifdef FEAT_VIRTUALEDIT
@@ -3016,55 +3016,55 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"visualbell",  "vb",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_vb, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"w300",	    NULL,   P_NUM|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"w1200",	    NULL,   P_NUM|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"w9600",	    NULL,   P_NUM|P_VI_DEF,
 			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"warn",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_warn, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"weirdinvert", "wiv",  P_BOOL|P_VI_DEF|P_RCLR,
 			    (char_u *)&p_wiv, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"whichwrap",   "ww",   P_STRING|P_VIM|P_ONECOMMA|P_FLAGLIST,
 			    (char_u *)&p_ww, PV_NONE,
-			    {(char_u *)"", (char_u *)"b,s"} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)"b,s"} SCTX_INIT},
     {"wildchar",    "wc",   P_NUM|P_VIM,
 			    (char_u *)&p_wc, PV_NONE,
 			    {(char_u *)(long)Ctrl_E, (char_u *)(long)TAB}
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"wildcharm",   "wcm",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_wcm, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"wildignore",  "wig",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_WILDIGN
 			    (char_u *)&p_wig, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"wildignorecase", "wic", P_BOOL|P_VI_DEF,
 			    (char_u *)&p_wic, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"wildmenu",    "wmnu", P_BOOL|P_VI_DEF,
 #ifdef FEAT_WILDMENU
 			    (char_u *)&p_wmnu, PV_NONE,
 #else
 			    (char_u *)NULL, PV_NONE,
 #endif
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"wildmode",    "wim",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_wim, PV_NONE,
-			    {(char_u *)"full", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"full", (char_u *)0L} SCTX_INIT},
     {"wildoptions", "wop",  P_STRING|P_VI_DEF,
 #ifdef FEAT_CMDL_COMPL
 			    (char_u *)&p_wop, PV_NONE,
@@ -3073,7 +3073,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"winaltkeys",  "wak",  P_STRING|P_VI_DEF,
 #ifdef FEAT_WAK
 			    (char_u *)&p_wak, PV_NONE,
@@ -3082,25 +3082,25 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"window",	    "wi",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_window, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"winheight",   "wh",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_wh, PV_NONE,
-			    {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1L, (char_u *)0L} SCTX_INIT},
     {"winfixheight", "wfh", P_BOOL|P_VI_DEF|P_RSTAT,
 			    (char_u *)VAR_WIN, PV_WFH,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"winfixwidth", "wfw", P_BOOL|P_VI_DEF|P_RSTAT,
 			    (char_u *)VAR_WIN, PV_WFW,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"winminheight", "wmh", P_NUM|P_VI_DEF,
 			    (char_u *)&p_wmh, PV_NONE,
-			    {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1L, (char_u *)0L} SCTX_INIT},
     {"winminwidth", "wmw", P_NUM|P_VI_DEF,
 			    (char_u *)&p_wmw, PV_NONE,
-			    {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)1L, (char_u *)0L} SCTX_INIT},
     {"winptydll", NULL,	    P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(WIN3264) && defined(FEAT_TERMINAL)
 			    (char_u *)&p_winptydll, PV_NONE, {
@@ -3114,25 +3114,25 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
 #endif
-			    SCRIPTID_INIT},
+			    SCTX_INIT},
     {"winwidth",   "wiw",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_wiw, PV_NONE,
-			    {(char_u *)20L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)20L, (char_u *)0L} SCTX_INIT},
     {"wrap",	    NULL,   P_BOOL|P_VI_DEF|P_RWIN,
 			    (char_u *)VAR_WIN, PV_WRAP,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"wrapmargin",  "wm",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_wm, PV_WM,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"wrapscan",    "ws",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_ws, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"write",	    NULL,   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_write, PV_NONE,
-			    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"writeany",    "wa",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_wa, PV_NONE,
-			    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"writebackup", "wb",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_wb, PV_NONE,
 			    {
@@ -3141,15 +3141,15 @@ static struct vimoption options[] =
 #else
 			    (char_u *)FALSE,
 #endif
-				(char_u *)0L} SCRIPTID_INIT},
+				(char_u *)0L} SCTX_INIT},
     {"writedelay",  "wd",   P_NUM|P_VI_DEF,
 			    (char_u *)&p_wd, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
 
 /* terminal output codes */
 #define p_term(sss, vvv)   {sss, NULL, P_STRING|P_VI_DEF|P_RALL|P_SECURE, \
 			    (char_u *)&vvv, PV_NONE, \
-			    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
 
     p_term("t_AB", T_CAB)
     p_term("t_AF", T_CAF)
@@ -3233,7 +3233,7 @@ static struct vimoption options[] =
 /* terminal key codes are not in here */
 
     /* end marker */
-    {NULL, NULL, 0, NULL, PV_NONE, {NULL, NULL} SCRIPTID_INIT}
+    {NULL, NULL, 0, NULL, PV_NONE, {NULL, NULL} SCTX_INIT}
 };
 
 #define PARAM_COUNT (sizeof(options) / sizeof(struct vimoption))
@@ -3314,7 +3314,7 @@ static char_u *did_set_spell_option(int is_spellfile);
 static char_u *compile_cap_prog(synblock_T *synblock);
 #endif
 #ifdef FEAT_EVAL
-static void set_option_scriptID_idx(int opt_idx, int opt_flags, int id);
+static void set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T sctx);
 #endif
 static char_u *set_bool_option(int opt_idx, char_u *varp, int value, int opt_flags);
 static char_u *set_num_option(int opt_idx, char_u *varp, long value, char_u *errbuf, size_t errbuflen, int opt_flags);
@@ -3854,7 +3854,7 @@ set_option_default(
     }
 
 #ifdef FEAT_EVAL
-    set_option_scriptID_idx(opt_idx, opt_flags, current_SID);
+    set_option_sctx_idx(opt_idx, opt_flags, current_sctx);
 #endif
 }
 
@@ -4679,12 +4679,12 @@ do_set(
 		    {
 			/* Mention where the option was last set. */
 			if (varp == options[opt_idx].var)
-			    last_set_msg(options[opt_idx].scriptID);
+			    last_set_msg(options[opt_idx].sctx);
 			else if ((int)options[opt_idx].indir & PV_WIN)
-			    last_set_msg(curwin->w_p_scriptID[
+			    last_set_msg(curwin->w_p_sctx[
 				      (int)options[opt_idx].indir & PV_MASK]);
 			else if ((int)options[opt_idx].indir & PV_BUF)
-			    last_set_msg(curbuf->b_p_scriptID[
+			    last_set_msg(curbuf->b_p_sctx[
 				      (int)options[opt_idx].indir & PV_MASK]);
 		    }
 #endif
@@ -5898,7 +5898,7 @@ set_string_option_direct(
     int		opt_idx,
     char_u	*val,
     int		opt_flags,	/* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
-    int		set_sid UNUSED)
+    int		set_sid)
 {
     char_u	*s;
     char_u	**varp;
@@ -5943,8 +5943,18 @@ set_string_option_direct(
 	}
 # ifdef FEAT_EVAL
 	if (set_sid != SID_NONE)
-	    set_option_scriptID_idx(idx, opt_flags,
-					set_sid == 0 ? current_SID : set_sid);
+	{
+	    sctx_T sctx;
+
+	    if (set_sid == 0)
+		sctx = current_sctx;
+	    else
+	    {
+		sctx.sc_scid = set_sid;
+		sctx.sc_lnum = 0;
+	    }
+	    set_option_sctx_idx(idx, opt_flags, sctx);
+	}
 # endif
     }
 }
@@ -7656,7 +7666,7 @@ did_set_string_option(
     {
 #ifdef FEAT_EVAL
 	/* Remember where the option was set. */
-	set_option_scriptID_idx(opt_idx, opt_flags, current_SID);
+	set_option_sctx_idx(opt_idx, opt_flags, current_sctx);
 #endif
 	/*
 	 * Free string options that are in allocated memory.
@@ -8215,25 +8225,27 @@ compile_cap_prog(synblock_T *synblock)
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 /*
- * Set the scriptID for an option, taking care of setting the buffer- or
+ * Set the SCTX for an option, taking care of setting the buffer- or
  * window-local value.
  */
     static void
-set_option_scriptID_idx(int opt_idx, int opt_flags, int id)
+set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T sctx)
 {
     int		both = (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0;
     int		indir = (int)options[opt_idx].indir;
 
+    sctx.sc_lnum += sourcing_lnum;
+
     /* Remember where the option was set.  For local options need to do that
      * in the buffer or window structure. */
     if (both || (opt_flags & OPT_GLOBAL) || (indir & (PV_BUF|PV_WIN)) == 0)
-	options[opt_idx].scriptID = id;
+	options[opt_idx].sctx = sctx;
     if (both || (opt_flags & OPT_LOCAL))
     {
 	if (indir & PV_BUF)
-	    curbuf->b_p_scriptID[indir & PV_MASK] = id;
+	    curbuf->b_p_sctx[indir & PV_MASK] = sctx;
 	else if (indir & PV_WIN)
-	    curwin->w_p_scriptID[indir & PV_MASK] = id;
+	    curwin->w_p_sctx[indir & PV_MASK] = sctx;
     }
 }
 #endif
@@ -8262,7 +8274,7 @@ set_bool_option(
     *(int *)varp = value;	    /* set the new value */
 #ifdef FEAT_EVAL
     /* Remember where the option was set. */
-    set_option_scriptID_idx(opt_idx, opt_flags, current_SID);
+    set_option_sctx_idx(opt_idx, opt_flags, current_sctx);
 #endif
 
 #ifdef FEAT_GUI
@@ -8898,7 +8910,7 @@ set_num_option(
     *pp = value;
 #ifdef FEAT_EVAL
     /* Remember where the option was set. */
-    set_option_scriptID_idx(opt_idx, opt_flags, current_SID);
+    set_option_sctx_idx(opt_idx, opt_flags, current_sctx);
 #endif
 #ifdef FEAT_GUI
     need_mouse_correct = TRUE;

--- a/src/proto/eval.pro
+++ b/src/proto/eval.pro
@@ -119,7 +119,7 @@ int script_autoload(char_u *name, int reload);
 int read_viminfo_varlist(vir_T *virp, int writing);
 void write_viminfo_varlist(FILE *fp);
 int store_session_globals(FILE *fd);
-void last_set_msg(sctx_T sctx);
+void last_set_msg(sctx_T script_ctx);
 void reset_v_option_vars(void);
 void prepare_assert_error(garray_T *gap);
 void assert_error(garray_T *gap);

--- a/src/proto/eval.pro
+++ b/src/proto/eval.pro
@@ -119,7 +119,7 @@ int script_autoload(char_u *name, int reload);
 int read_viminfo_varlist(vir_T *virp, int writing);
 void write_viminfo_varlist(FILE *fp);
 int store_session_globals(FILE *fd);
-void last_set_msg(scid_T scriptID);
+void last_set_msg(sctx_T sctx);
 void reset_v_option_vars(void);
 void prepare_assert_error(garray_T *gap);
 void assert_error(garray_T *gap);

--- a/src/structs.h
+++ b/src/structs.h
@@ -75,6 +75,14 @@ typedef struct VimMenu vimmenu_T;
 #endif
 
 /*
+ * Information of script context (SCTX).
+ */
+typedef struct {
+    scid_T	sc_scid;
+    linenr_T	sc_lnum;
+} sctx_T;
+
+/*
  * Reference to a buffer that stores the value of buf_free_count.
  * bufref_valid() only needs to check "buf" when the count differs.
  */
@@ -278,8 +286,8 @@ typedef struct
 #endif
 
 #ifdef FEAT_EVAL
-    int		wo_scriptID[WV_COUNT];	/* SIDs for window-local options */
-# define w_p_scriptID w_onebuf_opt.wo_scriptID
+    sctx_T	wo_sctx[WV_COUNT];	/* SCTXs for window-local options */
+# define w_p_sctx w_onebuf_opt.wo_sctx
 #endif
 } winopt_T;
 
@@ -541,7 +549,7 @@ typedef struct expand
     int		xp_pattern_len;		/* bytes in xp_pattern before cursor */
 #if defined(FEAT_USR_CMDS) && defined(FEAT_EVAL) && defined(FEAT_CMDL_COMPL)
     char_u	*xp_arg;		/* completion function */
-    int		xp_scriptID;		/* SID for completion function */
+    sctx_T	xp_sctx;		/* SCTX for completion function */
 #endif
     int		xp_backslash;		/* one of the XP_BS_ values */
 #ifndef BACKSLASH_IN_FILENAME
@@ -1071,7 +1079,7 @@ struct mapblock
     char	m_nowait;	/* <nowait> used */
 #ifdef FEAT_EVAL
     char	m_expr;		/* <expr> used, m_str is an expression */
-    scid_T	m_script_ID;	/* ID of script where map was defined */
+    sctx_T	m_sctx;		/* SCTX where map was defined */
 #endif
 };
 
@@ -1361,7 +1369,7 @@ typedef struct
     int		uf_tml_idx;	/* index of line being timed; -1 if none */
     int		uf_tml_execed;	/* line being timed was executed */
 #endif
-    scid_T	uf_script_ID;	/* ID of script where function was defined,
+    sctx_T	uf_sctx;	/* SCTX where function was defined,
 				   used for s: variables */
     int		uf_refcount;	/* reference count, see func_name_refcount() */
     funccall_T	*uf_scoped;	/* l: local variables for closure */
@@ -2121,7 +2129,7 @@ struct file_buffer
     int		b_p_initialized;	/* set when options initialized */
 
 #ifdef FEAT_EVAL
-    int		b_p_scriptID[BV_COUNT];	/* SIDs for buffer-local options */
+    sctx_T	b_p_sctx[BV_COUNT];	/* SCTXs for buffer-local options */
 #endif
 
     int		b_p_ai;		/* 'autoindent' */

--- a/src/structs.h
+++ b/src/structs.h
@@ -78,8 +78,8 @@ typedef struct VimMenu vimmenu_T;
  * Information of script context (SCTX).
  */
 typedef struct {
-    scid_T	sc_scid;
-    linenr_T	sc_lnum;
+    scid_T	sc_scid;	/* script ID */
+    linenr_T	sc_lnum;	/* line number */
 } sctx_T;
 
 /*
@@ -286,8 +286,8 @@ typedef struct
 #endif
 
 #ifdef FEAT_EVAL
-    sctx_T	wo_sctx[WV_COUNT];	/* SCTXs for window-local options */
-# define w_p_sctx w_onebuf_opt.wo_sctx
+    sctx_T	wo_script_ctx[WV_COUNT];	/* SCTXs for window-local options */
+# define w_p_script_ctx w_onebuf_opt.wo_script_ctx
 #endif
 } winopt_T;
 
@@ -549,7 +549,7 @@ typedef struct expand
     int		xp_pattern_len;		/* bytes in xp_pattern before cursor */
 #if defined(FEAT_USR_CMDS) && defined(FEAT_EVAL) && defined(FEAT_CMDL_COMPL)
     char_u	*xp_arg;		/* completion function */
-    sctx_T	xp_sctx;		/* SCTX for completion function */
+    sctx_T	xp_script_ctx;		/* SCTX for completion function */
 #endif
     int		xp_backslash;		/* one of the XP_BS_ values */
 #ifndef BACKSLASH_IN_FILENAME
@@ -1079,7 +1079,7 @@ struct mapblock
     char	m_nowait;	/* <nowait> used */
 #ifdef FEAT_EVAL
     char	m_expr;		/* <expr> used, m_str is an expression */
-    sctx_T	m_sctx;		/* SCTX where map was defined */
+    sctx_T	m_script_ctx;		/* SCTX where map was defined */
 #endif
 };
 
@@ -1369,7 +1369,7 @@ typedef struct
     int		uf_tml_idx;	/* index of line being timed; -1 if none */
     int		uf_tml_execed;	/* line being timed was executed */
 #endif
-    sctx_T	uf_sctx;	/* SCTX where function was defined,
+    sctx_T	uf_script_ctx;	/* SCTX where function was defined,
 				   used for s: variables */
     int		uf_refcount;	/* reference count, see func_name_refcount() */
     funccall_T	*uf_scoped;	/* l: local variables for closure */
@@ -2129,7 +2129,7 @@ struct file_buffer
     int		b_p_initialized;	/* set when options initialized */
 
 #ifdef FEAT_EVAL
-    sctx_T	b_p_sctx[BV_COUNT];	/* SCTXs for buffer-local options */
+    sctx_T	b_p_script_ctx[BV_COUNT];	/* SCTXs for buffer-local options */
 #endif
 
     int		b_p_ai;		/* 'autoindent' */

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -58,7 +58,7 @@ struct hl_group
     int		sg_link;	/* link to this highlight group ID */
     int		sg_set;		/* combination of SG_* flags */
 #ifdef FEAT_EVAL
-    sctx_T	sg_sctx;	/* script in which the group was last set */
+    sctx_T	sg_script_ctx;	/* script in which the group was last set */
 #endif
 };
 
@@ -7507,7 +7507,7 @@ do_highlight(
 	    }
 	    else if (HL_TABLE()[from_id - 1].sg_link != to_id
 #ifdef FEAT_EVAL
-		    || HL_TABLE()[from_id - 1].sg_sctx.sc_scid != current_SID
+		    || HL_TABLE()[from_id - 1].sg_script_ctx.sc_scid != current_SID
 #endif
 		    || HL_TABLE()[from_id - 1].sg_cleared)
 	    {
@@ -7515,8 +7515,8 @@ do_highlight(
 		    HL_TABLE()[from_id - 1].sg_set |= SG_LINK;
 		HL_TABLE()[from_id - 1].sg_link = to_id;
 #ifdef FEAT_EVAL
-		HL_TABLE()[from_id - 1].sg_sctx = current_sctx;
-		HL_TABLE()[from_id - 1].sg_sctx.sc_lnum += sourcing_lnum;
+		HL_TABLE()[from_id - 1].sg_script_ctx = current_sctx;
+		HL_TABLE()[from_id - 1].sg_script_ctx.sc_lnum += sourcing_lnum;
 #endif
 		HL_TABLE()[from_id - 1].sg_cleared = FALSE;
 		redraw_all_later(SOME_VALID);
@@ -8278,8 +8278,8 @@ do_highlight(
 	else
 	    set_hl_attr(idx);
 #ifdef FEAT_EVAL
-	HL_TABLE()[idx].sg_sctx = current_sctx;
-	HL_TABLE()[idx].sg_sctx.sc_lnum += sourcing_lnum;
+	HL_TABLE()[idx].sg_script_ctx = current_sctx;
+	HL_TABLE()[idx].sg_script_ctx.sc_lnum += sourcing_lnum;
 #endif
     }
 
@@ -8407,8 +8407,8 @@ highlight_clear(int idx)
      * cleared. */
     if (HL_TABLE()[idx].sg_link == 0)
     {
-	HL_TABLE()[idx].sg_sctx.sc_scid = 0;
-	HL_TABLE()[idx].sg_sctx.sc_lnum = 0;
+	HL_TABLE()[idx].sg_script_ctx.sc_scid = 0;
+	HL_TABLE()[idx].sg_script_ctx.sc_lnum = 0;
     }
 #endif
 }
@@ -9277,7 +9277,7 @@ highlight_list_one(int id)
 	highlight_list_arg(id, didh, LIST_STRING, 0, (char_u *)"cleared", "");
 #ifdef FEAT_EVAL
     if (p_verbose > 0)
-	last_set_msg(sgp->sg_sctx);
+	last_set_msg(sgp->sg_script_ctx);
 #endif
 }
 

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -14,6 +14,7 @@ source test_ex_z.vim
 source test_execute_func.vim
 source test_expand.vim
 source test_expand_dllpath.vim
+source test_expand_func.vim
 source test_expr.vim
 source test_feedkeys.vim
 source test_file_perm.vim

--- a/src/testdir/test_expand_func.vim
+++ b/src/testdir/test_expand_func.vim
@@ -1,0 +1,66 @@
+" Tests for expand()
+
+let s:sfile = expand('<sfile>')
+let s:slnum = str2nr(expand('<slnum>'))
+let s:flnum = str2nr(expand('<flnum>'))
+
+func s:expand_sfile()
+  return expand('<sfile>')  
+endfunc
+
+func s:expand_slnum()
+  return str2nr(expand('<slnum>'))  
+endfunc
+
+func s:expand_flnum()
+  return str2nr(expand('<flnum>'))  
+endfunc
+
+func Test_expand_sfile()
+  call assert_match('test_expand_func\.vim$', s:sfile)
+  call assert_match('^function .*\.\.Test_expand_sfile$', expand('<sfile>'))
+
+  " Call in script-local function
+  call assert_match('^function .*\.\.Test_expand_sfile\[5\]\.\.<SNR>\d\+_expand_sfile$', s:expand_sfile())
+
+  " Call in command
+  command Sfile echo expand('<sfile>')
+  call assert_match('^function .*\.\.Test_expand_sfile$', trim(execute('Sfile')))
+  delcommand Sfile
+endfunc
+
+func Test_expand_slnum()
+  call assert_equal(4, s:slnum)
+  call assert_equal(2, str2nr(expand('<slnum>')))
+
+  " Line-continuation
+  call assert_equal(
+        \ 5,
+        \ str2nr(expand('<slnum>')))
+
+  " Call in script-local function
+  call assert_equal(1, s:expand_slnum())
+
+  " Call in command
+  command Slnum echo expand('<slnum>')
+  call assert_equal(14, str2nr(trim(execute('Slnum'))))
+  delcommand Slnum
+endfunc
+
+func Test_expand_flnum()
+  call assert_equal(5, s:flnum)
+  call assert_equal(52, str2nr(expand('<flnum>')))
+
+  " Line-continuation
+  call assert_equal(
+        \ 55,
+        \ str2nr(expand('<flnum>')))
+
+  " Call in script-local function
+  call assert_equal(16, s:expand_flnum())
+
+  " Call in command
+  command Flnum echo expand('<flnum>')
+  call assert_equal(64, str2nr(trim(execute('Flnum'))))
+  delcommand Flnum
+endfunc

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -302,8 +302,8 @@ get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate)
 	fp->uf_varargs = TRUE;
 	fp->uf_flags = flags;
 	fp->uf_calls = 0;
-	fp->uf_sctx = current_sctx;
-	fp->uf_sctx.sc_lnum += sourcing_lnum - newlines.ga_len;
+	fp->uf_script_ctx = current_sctx;
+	fp->uf_script_ctx.sc_lnum += sourcing_lnum - newlines.ga_len;
 
 	pt->pt_func = fp;
 	pt->pt_refcount = 1;
@@ -946,7 +946,7 @@ call_user_func(
 #endif
 
     save_current_sctx = current_sctx;
-    current_sctx = fp->uf_sctx;
+    current_sctx = fp->uf_script_ctx;
     save_did_emsg = did_emsg;
     did_emsg = FALSE;
 
@@ -1575,7 +1575,7 @@ list_func_head(ufunc_T *fp, int indent)
 	MSG_PUTS(" closure");
     msg_clr_eos();
     if (p_verbose > 0)
-	last_set_msg(fp->uf_sctx);
+	last_set_msg(fp->uf_script_ctx);
 }
 
 /*
@@ -2455,8 +2455,8 @@ ex_function(exarg_T *eap)
 	flags |= FC_SANDBOX;
     fp->uf_flags = flags;
     fp->uf_calls = 0;
-    fp->uf_sctx = current_sctx;
-    fp->uf_sctx.sc_lnum += sourcing_lnum - newlines.ga_len - 1;
+    fp->uf_script_ctx = current_sctx;
+    fp->uf_script_ctx.sc_lnum += sourcing_lnum - newlines.ga_len - 1;
     goto ret_free;
 
 erret:

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -302,7 +302,8 @@ get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate)
 	fp->uf_varargs = TRUE;
 	fp->uf_flags = flags;
 	fp->uf_calls = 0;
-	fp->uf_script_ID = current_SID;
+	fp->uf_sctx = current_sctx;
+	fp->uf_sctx.sc_lnum += sourcing_lnum - newlines.ga_len;
 
 	pt->pt_func = fp;
 	pt->pt_refcount = 1;
@@ -690,7 +691,7 @@ call_user_func(
 {
     char_u	*save_sourcing_name;
     linenr_T	save_sourcing_lnum;
-    scid_T	save_current_SID;
+    sctx_T	save_current_sctx;
     int		using_sandbox = FALSE;
     funccall_T	*fc;
     int		save_did_emsg;
@@ -944,8 +945,8 @@ call_user_func(
     }
 #endif
 
-    save_current_SID = current_SID;
-    current_SID = fp->uf_script_ID;
+    save_current_sctx = current_sctx;
+    current_sctx = fp->uf_sctx;
     save_did_emsg = did_emsg;
     did_emsg = FALSE;
 
@@ -1026,7 +1027,7 @@ call_user_func(
     vim_free(sourcing_name);
     sourcing_name = save_sourcing_name;
     sourcing_lnum = save_sourcing_lnum;
-    current_SID = save_current_SID;
+    current_sctx = save_current_sctx;
 #ifdef FEAT_PROFILE
     if (do_profiling == PROF_YES)
 	script_prof_restore(&wait_start);
@@ -1574,7 +1575,7 @@ list_func_head(ufunc_T *fp, int indent)
 	MSG_PUTS(" closure");
     msg_clr_eos();
     if (p_verbose > 0)
-	last_set_msg(fp->uf_script_ID);
+	last_set_msg(fp->uf_sctx);
 }
 
 /*
@@ -2454,7 +2455,8 @@ ex_function(exarg_T *eap)
 	flags |= FC_SANDBOX;
     fp->uf_flags = flags;
     fp->uf_calls = 0;
-    fp->uf_script_ID = current_SID;
+    fp->uf_sctx = current_sctx;
+    fp->uf_sctx.sc_lnum += sourcing_lnum - newlines.ga_len - 1;
     goto ret_free;
 
 erret:


### PR DESCRIPTION
This pull-req proposes storing the script line number with script ID.

## Purpose

1. Get the current script line number in any position.

We can get the script line number (by `expand('<slnum>')`), but this returns lnum based on the top of current function, except while doing `:source`.
This patch adds new key `<flnum>` to `expand()`, `expand('<flnum>')` shows the current line number.

2. Get the line number:

* where option is set
* where function/map/command/autocmd is defined

Vim saves the script ID for each items, but no line number.
This patch can provide more details, the line number information, to user.

## Details

Replacing "scriptID" field of each struct by `sctx_T` (means Script ConTeXt) :

```c
typedef struct {
    scid_T	sc_scid; // script ID
    linenr_T	sc_lnum; // script line number
} sctx_T;
```

And add `current_sctx` to save the current context:

* Redefine `current_SID` as the macro of `current_sctx.sc_scid`
* Define `current_SLN` as the macro of `current_sctx.sc_lnum`

Thus, by loading `sc_lnum` of context item into `current_SLN`, `current_SLN + sourcing_lnum` means the current script line number. `expand('<flnum>')` returns it.

## Application examples

### Better profiling

By @blueyed.
#3286 
https://github.com/vim-jp/issues/issues/1178#issuecomment-412985328

### Detailed information for items

By @ujihisa.

* Make `:verbose ...` show the line number

```diff
--- a/src/eval.c
+++ b/src/eval.c
@@ -8742,6 +8742,13 @@ last_set_msg(sctx_T sctx)
            MSG_PUTS(_("\n\tLast set from "));
            MSG_PUTS(p);
            vim_free(p);
+           if (sctx.sc_lnum > 0)
+           {
+               char_u s[21];
+
+               vim_snprintf((char *)s, sizeof(s), ":%ld", sctx.sc_lnum);
+               MSG_PUTS(s);
+           }
            verbose_leave();
        }
     }
```

`vim --clean`

present:
```
:verbose map
   Q             gq
        Last set from /usr/local/share/vim/vim81/defaults.vim
```

patched:
```
:verbose map
   Q             gq
        Last set from /usr/local/share/vim/vim81/defaults.vim:69
```

~~**NOTE** No test and doc yet.~~