### PR TITLE
Fix test_options

### DIFF
--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -350,55 +350,57 @@ func Test_backupskip()
 endfunc
 
 func Test_copy_winopt()
-    set hidden
+  set hidden
 
-    " Test copy option from current buffer in window
-    split
-    enew
-    setlocal numberwidth=5
-    wincmd w
-    call assert_equal(4,&numberwidth)
-    bnext
-    call assert_equal(5,&numberwidth)
-    bw!
-    call assert_equal(4,&numberwidth)
+  " Test copy option from current buffer in window
+  split
+  enew
+  setlocal numberwidth=5
+  wincmd w
+  call assert_equal(4,&numberwidth)
+  bnext
+  call assert_equal(5,&numberwidth)
+  bw!
+  call assert_equal(4,&numberwidth)
 
-    " Test copy value from window that used to be display the buffer
-    split
-    enew
-    setlocal numberwidth=6
-    bnext
-    wincmd w
-    call assert_equal(4,&numberwidth)
-    bnext
-    call assert_equal(6,&numberwidth)
-    bw!
+  " Test copy value from window that used to be display the buffer
+  split
+  enew
+  setlocal numberwidth=6
+  bnext
+  wincmd w
+  call assert_equal(4,&numberwidth)
+  bnext
+  call assert_equal(6,&numberwidth)
+  bw!
 
-    " Test that if buffer is current, don't use the stale cached value
-    " from the last time the buffer was displayed.
-    split
-    enew
-    setlocal numberwidth=7
-    bnext
-    bnext
-    setlocal numberwidth=8
-    wincmd w
-    call assert_equal(4,&numberwidth)
-    bnext
-    call assert_equal(8,&numberwidth)
-    bw!
+  " Test that if buffer is current, don't use the stale cached value
+  " from the last time the buffer was displayed.
+  split
+  enew
+  setlocal numberwidth=7
+  bnext
+  bnext
+  setlocal numberwidth=8
+  wincmd w
+  call assert_equal(4,&numberwidth)
+  bnext
+  call assert_equal(8,&numberwidth)
+  bw!
 
-    " Test value is not copied if window already has seen the buffer
-    enew
-    split
-    setlocal numberwidth=9
-    bnext
-    setlocal numberwidth=10
-    wincmd w
-    call assert_equal(4,&numberwidth)
-    bnext
-    call assert_equal(4,&numberwidth)
-    bw!
+  " Test value is not copied if window already has seen the buffer
+  enew
+  split
+  setlocal numberwidth=9
+  bnext
+  setlocal numberwidth=10
+  wincmd w
+  call assert_equal(4,&numberwidth)
+  bnext
+  call assert_equal(4,&numberwidth)
+  bw!
+
+  set hidden&
 endfunc
 
 func Test_shortmess_F()


### PR DESCRIPTION
## Problem

When generating opt_test.vim fails for any reason, `Test_shortmess_F2` fails at executing test_options. 

## Cause

* `Test_copy_winopt` does `set hidden` and not restore it
* `:source opt_test.vim` in `Test_set_values` does `set nohidden`

Thus, when generating opt_test.vim fails (then `Test_set_values` is skipped and `set hidden` is kept), `execute('bn', '')` in `Test_shortmess_F2` returns an empty string, which doesn't match the expected value.

## Solution

* Do `set hidden&` at the end of `Test_copy_winopt`

NOTE: This patch fixes also indent of `Test_copy_winopt`. Actual change is below:

```diff
--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -399,6 +399,8 @@ func Test_copy_winopt()
   bnext
   call assert_equal(4,&numberwidth)
   bw!
+
+  set hidden&
 endfunc

 func Test_shortmess_F()
```