### PR TITLE
Added tests for :mkview and :loadview

### DIFF
--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -311,27 +311,6 @@ endfunc
 
 endif " has('terminal')
 
-" Test :mkview and :loadview without argument.
-func Test_mkview_loadview()
-  " Create a view with line number and a fold.
-  help :mkview
-  set number
-  norm! V}zf
-  let pos = getpos('.')
-  let linefoldclosed1 = foldclosed('.')
-  mkview
-  set nonumber
-  norm! zrj
-
-  loadview
-  call assert_equal(1, &number)
-  call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(pos, getpos('.'))
-  call assert_equal(linefoldclosed1, foldclosed('.'))
-
-  helpclose
-endfunc
-
 " Test :mkview with a file argument.
 func Test_mkview_file()
   " Create a view with line number and a fold.
@@ -364,44 +343,6 @@ func Test_mkview_file()
 
   call delete('Xview')
   bwipe
-endfunc
-
-" Test :mkview {nr} and :loadview {nr}.
-func Test_mkview_loadview_nr()
-  if has('win32')
-    " FIXME: This test fails on Windows with error:
-    " Cannot create directory: C:\projects\vim/vimfiles/view
-    return
-  endif
-
-  " Create a first view with line number and a fold.
-  help :mkview
-  set number
-  norm! V}zf
-  let pos1 = getpos('.')
-  let linefoldclosed1 = foldclosed('.')
-  mkview 1
-
-  " Create a second view without line number and without fold.
-  help :loadview
-  set nonumber
-  norm! zr
-  let pos2 = getpos('.')
-  mkview 2
-
-  loadview 1
-  call assert_equal(1, &number)
-  call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(pos1, getpos('.'))
-  call assert_equal(linefoldclosed1, foldclosed('.'))
-
-  loadview 2
-  call assert_equal(0, &number)
-  call assert_match('\*:loadview\*$', getline('.'))
-  call assert_equal(pos2, getpos('.'))
-  call assert_equal(-1, foldclosed('.'))
-
-  helpclose
 endfunc
 
 " Test :mkview and :loadview with a custom 'viewdir'.
@@ -448,6 +389,7 @@ func Test_mkview_no_file_name()
   source Xview
   call assert_equal('', bufname('%'))
 
+  call delete('Xview')
   %bwipe
 endfunc
 

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -317,7 +317,7 @@ func Test_mkview_loadview()
   help :mkview
   set number
   norm! V}zf
-  let curpos = getcurpos()
+  let pos = getpos('.')
   let linefoldclosed1 = foldclosed('.')
   mkview
   set nonumber
@@ -326,7 +326,7 @@ func Test_mkview_loadview()
   loadview
   call assert_equal(1, &number)
   call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(curpos, getcurpos())
+  call assert_equal(pos, getpos('.'))
   call assert_equal(linefoldclosed1, foldclosed('.'))
 
   helpclose
@@ -338,7 +338,7 @@ func Test_mkview_file()
   help :mkview
   set number
   norm! V}zf
-  let curpos = getcurpos()
+  let pos = getpos('.')
   let linefoldclosed1 = foldclosed('.')
   mkview! Xview
   set nonumber
@@ -350,7 +350,7 @@ func Test_mkview_file()
   source Xview
   call assert_equal(1, &number)
   call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(curpos, getcurpos())
+  call assert_equal(pos, getpos('.'))
   call assert_equal(linefoldclosed1, foldclosed('.'))
 
   " Creating a view again with the same file name should fail (file
@@ -368,11 +368,17 @@ endfunc
 
 " Test :mkview {nr} and :loadview {nr}.
 func Test_mkview_loadview_nr()
+  if has('win32')
+    " FIXME: This test fails on Windows with error:
+    " Cannot create directory: C:\projects\vim/vimfiles/view
+    return
+  endif
+
   " Create a first view with line number and a fold.
   help :mkview
   set number
   norm! V}zf
-  let curpos1 = getcurpos()
+  let pos1 = getpos('.')
   let linefoldclosed1 = foldclosed('.')
   mkview 1
 
@@ -380,19 +386,19 @@ func Test_mkview_loadview_nr()
   help :loadview
   set nonumber
   norm! zr
-  let curpos2 = getcurpos()
+  let pos2 = getpos('.')
   mkview 2
 
   loadview 1
   call assert_equal(1, &number)
   call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(curpos1, getcurpos())
+  call assert_equal(pos1, getpos('.'))
   call assert_equal(linefoldclosed1, foldclosed('.'))
 
   loadview 2
   call assert_equal(0, &number)
   call assert_match('\*:loadview\*$', getline('.'))
-  call assert_equal(curpos2, getcurpos())
+  call assert_equal(pos2, getpos('.'))
   call assert_equal(-1, foldclosed('.'))
 
   helpclose
@@ -405,7 +411,7 @@ func Test_mkview_loadview_with_viewdir()
   help :mkview
   set number
   norm! V}zf
-  let curpos = getcurpos()
+  let pos = getpos('.')
   let linefoldclosed1 = foldclosed('.')
   mkview 1
   set nonumber
@@ -415,11 +421,14 @@ func Test_mkview_loadview_with_viewdir()
 
   " The directory Xviewdir/ should have been created and the view
   " should be stored in that directory.
-  call assert_equal('Xviewdir/' . substitute(expand('%:p'), '/', '=+', 'g') . '=1.vim',
+  call assert_equal('Xviewdir/' .
+        \           substitute(
+        \             substitute(
+        \               expand('%:p'), '/', '=+', 'g'), ':', '=-', 'g') . '=1.vim',
         \           glob('Xviewdir/*'))
   call assert_equal(1, &number)
   call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(curpos, getcurpos())
+  call assert_equal(pos, getpos('.'))
   call assert_equal(linefoldclosed1, foldclosed('.'))
 
   call delete('Xviewdir', 'rf')


### PR DESCRIPTION
This PR adds tests for :mkview and :loadview.

:loadview was not tested according to codecov:

https://codecov.io/gh/vim/vim/src/a06afc7f5e7ba085abf1475a65ae3ea79c961a0e/src/ex_docmd.c#L12053