### PR TITLE
Fixed Gdk-Critical on first balloon show.

### DIFF
--- a/src/gui_beval.c
+++ b/src/gui_beval.c
@@ -958,7 +958,7 @@ drawBalloon(BalloonEval *beval)
 	screen = gtk_widget_get_screen(beval->target);
 	gtk_window_set_screen(GTK_WINDOW(beval->balloonShell), screen);
 # endif
-	gui_gtk_get_screen_geom_of_win(beval->balloonShell,
+	gui_gtk_get_screen_geom_of_win(beval->target,
 				    &screen_x, &screen_y, &screen_w, &screen_h);
 # if !GTK_CHECK_VERSION(3,0,0)
 	gtk_widget_ensure_style(beval->balloonShell);


### PR DESCRIPTION
Encountered this problem on CentOS 6.6, Gtk 2.
At the first time when balloon is shown, call to the `gtk_widget_get_window()` from the `gui_gtk_get_screen_geom_of_win()` function returns 0, since balloon window is not realized yet. Following call to the `gdk_screen_get_monitor_at_window(screen, win)` meets a Gdk assertion.

Fix is to get screen geometry using the draw area widget.