### PR TITLE
add movement between cmake elements

### DIFF
--- a/runtime/ftplugin/cmake.vim
+++ b/runtime/ftplugin/cmake.vim
@@ -1,7 +1,11 @@
 " Vim filetype plugin
 " Language:    CMake
 " Maintainer:  Keith Smiley <keithbsmiley@gmail.com>
-" Last Change: 2017 Dec 24
+" Last Change: 2018 Aug 30
+
+" save 'cpo' for restoration at the end of this file
+let s:cpo_save = &cpo
+set cpo&vim
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -24,3 +28,7 @@ if exists('loaded_matchit')
 endif
 
 setlocal commentstring=#\ %s
+
+" restore 'cpo' and clean up buffer variable
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/ftplugin/cmake.vim
+++ b/runtime/ftplugin/cmake.vim
@@ -13,12 +13,14 @@ let b:did_ftplugin = 1
 
 let b:undo_ftplugin = "setl commentstring<"
 
-if exists("loaded_matchit")
-  let b:match_words =  '^[^#]*\<if\>\s*(:^[^#]*\<else\>\s*(:^[^#]*\<elseif\>\s*(:^[^#]*\<endif\>\s*(\c'
-  let b:match_words .= ',^[^#]*\<function\>\s*(:^[^#]*\<endfunction\>\s*(\c'
-  let b:match_words .= ',^[^#]*\<foreach\>\s*(:^[^#]*\<endforeach\>\s*(\c'
-  let b:match_words .= ',^[^#]*\<macro\>\s*(:^[^#]*\<endmacro\>\s*(\c'
-  let b:match_words .= ',^[^#]*\<while\>\s*(:^[^#]*\<endwhile\>\s*(\c'
+if exists('loaded_matchit')
+  let b:match_words = '\<if\>:\<elseif\>\|\<else\>:\<endif\>'
+        \ . ',\<foreach\>\|\<while\>:\<break\>:\<endforeach\>\|\<endwhile\>'
+        \ . ',\<macro\>:\<endmacro\>'
+        \ . ',\<function\>:\<endfunction\>'
+  let b:match_ignorecase = 1
+
+  let b:undo_ftplugin .= "| unlet b:match_words"
 endif
 
 setlocal commentstring=#\ %s

--- a/runtime/ftplugin/cmake.vim
+++ b/runtime/ftplugin/cmake.vim
@@ -13,4 +13,12 @@ let b:did_ftplugin = 1
 
 let b:undo_ftplugin = "setl commentstring<"
 
+if exists("loaded_matchit")
+  let b:match_words =  '^[^#]*\<if\>\s*(:^[^#]*\<else\>\s*(:^[^#]*\<elseif\>\s*(:^[^#]*\<endif\>\s*(\c'
+  let b:match_words .= ',^[^#]*\<function\>\s*(:^[^#]*\<endfunction\>\s*(\c'
+  let b:match_words .= ',^[^#]*\<foreach\>\s*(:^[^#]*\<endforeach\>\s*(\c'
+  let b:match_words .= ',^[^#]*\<macro\>\s*(:^[^#]*\<endmacro\>\s*(\c'
+  let b:match_words .= ',^[^#]*\<while\>\s*(:^[^#]*\<endwhile\>\s*(\c'
+endif
+
 setlocal commentstring=#\ %s


### PR DESCRIPTION
set b:match_words to what is used by indentation:
 - if, else, elseif, endif
 - function, endfunction
 - macro, endmacro
 - while, endwhile
 - foreach, endforeach

with improvements suggested on https://vi.stackexchange.com/a/17212/6044

(highlighting the maintainer @keith)