### PR TITLE
Optionally skip jump when cscopequickfix is used

### DIFF
--- a/runtime/doc/if_cscop.txt
+++ b/runtime/doc/if_cscop.txt
@@ -1,4 +1,4 @@
-*if_cscop.txt*  For Vim version 8.1.  Last change: 2018 Jan 21
+*if_cscop.txt*  For Vim version 8.1.  Last change: 2018 Aug 30
 
 
 		  VIM REFERENCE MANUAL    by Andy Kahn
@@ -258,13 +258,19 @@ started will have no effect!
 'cscopequickfix' specifies whether to use quickfix window to show cscope
 results.  This is a list of comma-separated values. Each item consists of
 |cscope-find| command (s, g, d, c, t, e, f, i or a) and flag (+, - or 0).
-'+' indicates that results must be appended to quickfix window,
-'-' implies previous results clearance, '0' or command absence - don't use
-quickfix.  Search is performed from start until first command occurrence.
-The default value is "" (don't use quickfix anyway).  The following value
-seems to be useful: >
+'+' and '-' flags may be followed by optional '!'
+    '+' flag will make cscope append its results to the quickfix window
+    '-' means that results will overwrite previous data
+    '0' or command absence - don't use quickfix
+With '!', cscope will not jump to the first location like |:make|!
+Search is performed from start until first command occurrence.
+The default value is "" (don't use quickfix). The following value
+seems useful enough: >
 	:set cscopequickfix=s-,c-,d-,i-,t-,e-,a-
 <
+Example below will prevent 's' search from jumping to the first location: >
+	:set cscopequickfix=s-!,c-,t0
++
 							*cscopetag* *cst*
 If 'cscopetag' is set, the commands ":tag" and CTRL-] as well as "vim -t"
 will always use |:cstag| instead of the default :tag behavior.  Effectively,

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1253,7 +1253,8 @@ cs_find_common(
 		     */
 		    qi = (bt_quickfix(wp->w_buffer) && wp->w_llist_ref != NULL)
 			?  wp->w_llist_ref : wp->w_llist;
-		qf_jump(qi, 0, 0, forceit);
+		if (qfpos[1] != '!')
+		    qf_jump(qi, 0, 0, forceit);
 	    }
 	}
 	mch_remove(tmp);

--- a/src/option.c
+++ b/src/option.c
@@ -7439,18 +7439,43 @@ did_set_string_option(
 	    p = p_csqf;
 	    while (*p != NUL)
 	    {
-		if (vim_strchr((char_u *)CSQF_CMDS, *p) == NULL
-			|| p[1] == NUL
-			|| vim_strchr((char_u *)CSQF_FLAGS, p[1]) == NULL
-			|| (p[2] != NUL && p[2] != ','))
+		int ok = FALSE;
+		if (vim_strchr((char_u *)CSQF_CMDS, *p) != NULL
+			&& p[1] != NUL
+			&& vim_strchr((char_u *)CSQF_FLAGS, p[1]) != NULL)
+		{
+		    switch (p[2])
+		    {
+		    case NUL:
+			p += 2;
+			ok = TRUE;
+			break;
+		    case ',':
+			p += 3;
+			ok = TRUE;
+			break;
+		    case '!':
+			if (p[1] == '0')
+			    break;
+			if (p[3] == NUL)
+			{
+			    p += 3;
+			    ok = TRUE;
+			}
+			else if (p[3] == ',')
+			{
+			    p += 4;
+			    ok = TRUE;
+			}
+			break;
+		    }
+
+		}
+		if (!ok)
 		{
 		    errmsg = e_invarg;
 		    break;
 		}
-		else if (p[2] == NUL)
-		    break;
-		else
-		    p += 3;
 	    }
 	}
     }


### PR DESCRIPTION
Problem:    When performing a cscopequickfix is set, performing a cscope
            search will unconditionally jump to the first entry.
Solution:   Add a '!' option to cscopequickfix that will avoid the jump,
            similar to make! or grep!