### PR TITLE
Added tests for :spellinfo

### DIFF
--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -141,8 +141,9 @@ func Test_spellinfo()
   endif
 
   set enc=latin1 spell spelllang=en_us,en_nz
-  call assert_match("^\nfile: ../../runtime/spell/en.latin1.spl" .
-                 \  "\nfile: ../../runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
+  call assert_match("^\n" .
+                 \  "file: .*/runtime/spell/en.latin1.spl\n" .
+                 \  "file: .*/runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
 
   set spell spelllang=
   call assert_fails('spellinfo', 'E756:')

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -130,19 +130,19 @@ func Test_spellinfo()
   new
 
   set enc=latin1 spell spelllang=en
-  call assert_equal("\nfile: ../../runtime/spell/en.latin1.spl\n", execute('spellinfo'))
+  call assert_match("^\nfile: .*/runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
 
   set enc=cp1250 spell spelllang=en
-  call assert_equal("\nfile: ../../runtime/spell/en.ascii.spl\n", execute('spellinfo'))
+  call assert_match("^\nfile: .*/runtime/spell/en.ascii.spl\n$", execute('spellinfo'))
 
   if has('multi_byte')
     set enc=utf-8 spell spelllang=en
-    call assert_equal("\nfile: ../../runtime/spell/en.utf-8.spl\n", execute('spellinfo'))
+    call assert_match("^\nfile: .*/runtime/spell/en.utf-8.spl\n$", execute('spellinfo'))
   endif
 
   set enc=latin1 spell spelllang=en_us,en_nz
-  call assert_equal("\nfile: ../../runtime/spell/en.latin1.spl" .
-                 \  "\nfile: ../../runtime/spell/en.latin1.spl\n", execute('spellinfo'))
+  call assert_match("^\nfile: ../../runtime/spell/en.latin1.spl" .
+                 \  "\nfile: ../../runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
 
   set spell spelllang=
   call assert_fails('spellinfo', 'E756:')

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -126,6 +126,34 @@ func Test_spellreall()
   bwipe!
 endfunc
 
+func Test_spellinfo()
+  new
+
+  set enc=latin1 spell spelllang=en
+  call assert_equal("\nfile: ../../runtime/spell/en.latin1.spl\n", execute('spellinfo'))
+
+  set enc=cp1250 spell spelllang=en
+  call assert_equal("\nfile: ../../runtime/spell/en.ascii.spl\n", execute('spellinfo'))
+
+  if has('multi_byte')
+    set enc=utf-8 spell spelllang=en
+    call assert_equal("\nfile: ../../runtime/spell/en.utf-8.spl\n", execute('spellinfo'))
+  endif
+
+  set enc=latin1 spell spelllang=en_us,en_nz
+  call assert_equal("\nfile: ../../runtime/spell/en.latin1.spl" .
+                 \  "\nfile: ../../runtime/spell/en.latin1.spl\n", execute('spellinfo'))
+
+  set spell spelllang=
+  call assert_fails('spellinfo', 'E756:')
+
+  set nospell spelllang=en
+  call assert_fails('spellinfo', 'E756:')
+
+  set enc& spell& spelllang&
+  bwipe
+endfunc
+
 func Test_zz_basic()
   call LoadAffAndDic(g:test_data_aff1, g:test_data_dic1)
   call RunGoodBad("wrong OK puts. Test the end",


### PR DESCRIPTION
This PR adds tests for the :spellinfo command which was not tested
according to codecov:

https://codecov.io/gh/vim/vim/src/f6ceaf1e058c64775fd46cbdb8962f5c19ef83e0/src/spell.c#L8457
