### PR TITLE
Fix incorrect highlighting of after-EOL matches under the cursor. 

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -5496,15 +5496,6 @@ win_line(
 	if (c == NUL)
 	{
 #ifdef FEAT_SYN_HL
-	    if (eol_hl_off > 0 && vcol - eol_hl_off == (long)wp->w_virtcol
-		    && lnum == wp->w_cursor.lnum)
-	    {
-		/* highlight last char after line */
-		--col;
-		--off;
-		--vcol;
-	    }
-
 	    /* Highlight 'cursorcolumn' & 'colorcolumn' past end of the line. */
 	    if (wp->w_p_wrap)
 		v = wp->w_skipcol;

--- a/src/testdir/test_hlsearch.vim
+++ b/src/testdir/test_hlsearch.vim
@@ -4,7 +4,6 @@ function! Test_hlsearch()
   new
   call setline(1, repeat(['aaa'], 10))
   set hlsearch nolazyredraw
-  let r=[]
   " redraw is needed to make hlsearch highlight the matches
   exe "normal! /aaa\<CR>" | redraw
   let r1 = screenattr(1, 1)
@@ -49,5 +48,18 @@ func Test_hlsearch_hangs()
   call assert_true(elapsed > 0.1)
   call assert_true(elapsed < 1.0)
   set nohlsearch redrawtime&
+  bwipe!
+endfunc
+
+func Test_hlsearch_eol_highlight()
+  new
+  call append(1, repeat([''], 9))
+  set hlsearch nolazyredraw
+  exe "normal! /$\<CR>" | redraw
+  let attr = screenattr(1, 1)
+  for row in range(2, 10)
+    call assert_equal(attr, screenattr(row, 1))
+  endfor
+  set nohlsearch
   bwipe!
 endfunc


### PR DESCRIPTION
To reproduce this issue:

vim -N -u NONE
Enable hlsearch.
Insert a couple of empty new lines.
Search for either ^ or $.
Move the cursor away from its current row.
Observe that the cell that the cursor moved out of is not highlighted.

In vim commands:

```
:set hlsearch
10i<CR><Esc><Esc>gg/$<CR>j
```