### PR TITLE
Fixes of some test failures on Solaris

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1,4 +1,5 @@
 " Tests for various functions.
+source shared.vim
 
 " Must be done first, since the alternate buffer must be unset.
 func Test_00_bufexists()
@@ -1006,6 +1007,17 @@ func Test_libcall_libcallnr()
     let libc = 'msvcrt.dll'
   elseif has('mac')
     let libc = 'libSystem.B.dylib'
+  elseif system('uname -s') =~ 'SunOS'
+    " Set the path to libc.so according to the architecture.
+    let test_bits = system('file '.GetVimProg())
+    let test_arch = system('uname -p')
+    if test_bits =~ '64-bit' && test_arch =~ 'sparc'
+      let libc = '/usr/lib/sparcv9/libc.so'
+    elseif test_bits =~ '64-bit' && test_arch =~ 'i386'
+      let libc = '/usr/lib/amd64/libc.so'
+    else
+      let libc = '/usr/lib/libc.so'
+    endif
   else
     " On Unix, libc.so can be in various places.
     " Interestingly, using an empty string for the 1st argument of libcall

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -1630,12 +1630,13 @@ fun! Test_normal30_changecase()
   norm! V~
   call assert_equal('THIS IS A simple test: äüöss', getline('.'))
 
-  " Turkish ASCII turns to multi-byte.  On Mac the Turkish locale is available
-  " but toupper()/tolower() don't do the right thing.
-  if !has('mac') && !has('osx')
-    try
-      lang tr_TR.UTF-8
-      set casemap=
+  " Turkish ASCII turns to multi-byte.  On some systems Turkish locale
+  " is available but toupper()/tolower() don't do the right thing.
+  try
+    lang tr_TR.UTF-8
+    set casemap=
+    let iupper = toupper('i')
+    if iupper == "\u0130"
       call setline(1, 'iI')
       1normal gUU
       call assert_equal("\u0130I", getline(1))
@@ -1645,8 +1646,7 @@ fun! Test_normal30_changecase()
       1normal guu
       call assert_equal("i\u0131", getline(1))
       call assert_equal("i\u0131", tolower("iI"))
-
-      set casemap&
+    elseif iupper == "I"
       call setline(1, 'iI')
       1normal gUU
       call assert_equal("II", getline(1))
@@ -1656,13 +1656,25 @@ fun! Test_normal30_changecase()
       1normal guu
       call assert_equal("ii", getline(1))
       call assert_equal("ii", tolower("iI"))
+    else
+      call assert_true(false, "expected toupper('i') to be either 'I' or '\u0130'")
+    endif
+    set casemap&
+    call setline(1, 'iI')
+    1normal gUU
+    call assert_equal("II", getline(1))
+    call assert_equal("II", toupper("iI"))
 
-      lang en_US.UTF-8
-    catch /E197:/
-      " can't use Turkish locale
-      throw 'Skipped: Turkish locale not available'
-    endtry
-  endif
+    call setline(1, 'iI')
+    1normal guu
+    call assert_equal("ii", getline(1))
+    call assert_equal("ii", tolower("iI"))
+
+    lang en_US.UTF-8
+  catch /E197:/
+    " can't use Turkish locale
+    throw 'Skipped: Turkish locale not available'
+  endtry
 
   " clean up
   bw!

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -33,7 +33,7 @@ func Test_writefile_fails_gently()
 endfunc
 
 func Test_writefile_fails_conversion()
-  if !has('multi_byte') || !has('iconv')
+  if !has('multi_byte') || !has('iconv') || system('uname -s') =~ 'SunOS'
     return
   endif
   set nobackup nowritebackup


### PR DESCRIPTION
A recent version of vim fails to pass some tests on Solaris.

This pull request provides fixes to three of them: 
1. Test_writefile_fails_conversion - skipped on Solaris as suggested in #1872
2. Test_libcall_libcallnr - fix invalid path to libc.so
3. Test_normal30_changecase - test more reliable, patch from Björn Linse (neovim)