### PR TITLE
User name completion completes the value of $USER if it is a valid remote user name

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -4717,8 +4717,8 @@ get_env_name(
 }
 
 /*
- * Add a ser name to the list of users in ga_users.
- * Do nothing is user is NULL or empty.
+ * Add a user name to the list of users in ga_users.
+ * Do nothing if user name is NULL or empty.
  */
     static void
 add_user(char_u *user, int need_copy)
@@ -4760,7 +4760,6 @@ init_users(void)
     }
 # elif defined(WIN3264)
     {
-	char_u*		user;
 	DWORD		nusers = 0, ntotal = 0, i;
 	PUSER_INFO_0	uinfo;
 
@@ -4769,7 +4768,7 @@ init_users(void)
 	{
 	    for (i = 0; i < nusers; i++)
 	    {
-		user = utf16_to_enc(uinfo[i].usri0_name, NULL);
+		char_u	*user = utf16_to_enc(uinfo[i].usri0_name, NULL);
 		add_user(user, FALSE);
 	    }
 
@@ -4780,9 +4779,9 @@ init_users(void)
 # if defined(HAVE_GETPWNAM)
     {
 	// The $USER environment variable may be a valid remote user name (NIS, LDAP)
-	// not already listed by getpwent() as getpwent() only lists local users names.
+	// not already listed by getpwent() as getpwent() only lists local user names.
 	// If $USER is not already listed, check whether it is a valid remote user name
-	// using getpwname() and if it is, add it to the list of user names.
+	// using getpwnam() and if it is, add it to the list of user names.
 	char_u	*user_env = mch_getenv((char_u *)"USER");
 
 	if (user_env != NULL && *user_env != NUL)
@@ -4790,9 +4789,9 @@ init_users(void)
 	    int	i;
 	    for (i = 0; i < ga_users.ga_len; i++)
 	    {
-		char_u	*localuser = ((char_u **)ga_users.ga_data)[i];
+		char_u	*local_user = ((char_u **)ga_users.ga_data)[i];
 
-		if (STRCMP(localuser, user_env) == 0)
+		if (STRCMP(local_user, user_env) == 0)
 		    break;
 	    }
 

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -4717,6 +4717,24 @@ get_env_name(
 }
 
 /*
+ * Add a ser name to the list of users in ga_users.
+ * Do nothing is user is NULL or empty.
+ */
+    static void
+add_user(char_u *user, int need_copy)
+{
+    char_u	*user_copy = (user != NULL && need_copy) ?  vim_strsave(user) : user;
+
+    if (user_copy == NULL || *user_copy == NUL || ga_grow(&ga_users, 1) == FAIL)
+    {
+	if (need_copy)
+	    vim_free(user);
+	return;
+    }
+    ((char_u **)(ga_users.ga_data))[ga_users.ga_len++] = user_copy;
+}
+
+/*
  * Find all user names for user completion.
  * Done only once and then cached.
  */
@@ -4733,21 +4751,11 @@ init_users(void)
 
 # if defined(HAVE_GETPWENT) && defined(HAVE_PWD_H)
     {
-	char_u*		user;
 	struct passwd*	pw;
 
 	setpwent();
 	while ((pw = getpwent()) != NULL)
-	    /* pw->pw_name shouldn't be NULL but just in case... */
-	    if (pw->pw_name != NULL)
-	    {
-		if (ga_grow(&ga_users, 1) == FAIL)
-		    break;
-		user = vim_strsave((char_u*)pw->pw_name);
-		if (user == NULL)
-		    break;
-		((char_u **)(ga_users.ga_data))[ga_users.ga_len++] = user;
-	    }
+	    add_user((char_u *)pw->pw_name, TRUE);
 	endpwent();
     }
 # elif defined(WIN3264)
@@ -4761,15 +4769,40 @@ init_users(void)
 	{
 	    for (i = 0; i < nusers; i++)
 	    {
-		if (ga_grow(&ga_users, 1) == FAIL)
-		    break;
 		user = utf16_to_enc(uinfo[i].usri0_name, NULL);
-		if (user == NULL)
-		    break;
-		((char_u **)(ga_users.ga_data))[ga_users.ga_len++] = user;
+		add_user(user, FALSE);
 	    }
 
 	    NetApiBufferFree(uinfo);
+	}
+    }
+# endif
+# if defined(HAVE_GETPWNAM)
+    {
+	// The $USER environment variable may be a valid remote user name (NIS, LDAP)
+	// not already listed by getpwent() as getpwent() only lists local users names.
+	// If $USER is not already listed, check whether it is a valid remote user name
+	// using getpwname() and if it is, add it to the list of user names.
+	char_u	*user_env = mch_getenv((char_u *)"USER");
+
+	if (user_env != NULL && *user_env != NUL)
+	{
+	    int	i;
+	    for (i = 0; i < ga_users.ga_len; i++)
+	    {
+		char_u	*localuser = ((char_u **)ga_users.ga_data)[i];
+
+		if (STRCMP(localuser, user_env) == 0)
+		    break;
+	    }
+
+	    if (i == ga_users.ga_len)
+	    {
+		struct passwd	*pw = getpwnam((char *)user_env);
+		char_u		*remote_user = (pw == NULL) ? NULL : (char_u *)pw->pw_name;
+
+		add_user(remote_user, TRUE);
+	    }
 	}
     }
 # endif


### PR DESCRIPTION
This PR tentatively fixes the issue reported in the vim-dev
mailing list by Chr. von Stuckrad on Aug 31, 2018 regarding
user name completion which does not complete the value
of $USER even when it's a valid remote user name (NIS or LDAP).
This caused Test_cmdline_complete_user_names() to 
fail according to the bug reporter.

I have not added tests as I do no know how to tests with
remote user names. Hopefully the bug reporter can
confirm whether the change in this PR fixes his issue
before PR is merged.  I will remove the [WIP] annotation
in the title of the PR when it is confirmed that it fixes the issue.
