### PR TITLE
Adjust size of inverted popupmenu when preview window is above.

### DIFF
--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -199,8 +199,8 @@ pum_display(
 	/* If there is a preview window at the above avoid drawing over it. */
 	if (pvwin != NULL && pum_row < above_row && pum_height > above_row)
 	{
-	    pum_row += above_row;
-	    pum_height -= above_row;
+	    pum_row = above_row;
+	    pum_height = pum_win_row - above_row;
 	}
 #endif
 


### PR DESCRIPTION
When the popup menu is inverted and there is a preview window above such that the top of the popup would intersect the preview window, the top of the popup is pushed down by the full height of the pvwin, not just the amount necessary to avoid drawing over it. e.g. a popup that would be placed on the last row of a 10 row pvwin is squished by 10 rows instead of the 1 necessary row to avoid overlap. This can result in unwieldy short popups and feels like a waste of space. This changes it to take up the available space if it needs.

I'd also like to change it so the popup will not draw over the status line of the pvwin, but I'm not sure if that's intended though it feels odd to me, so I've left it for now.