### PR TITLE
Runtime: Refine syntax matching for dosini files

### DIFF
--- a/runtime/syntax/dosini.vim
+++ b/runtime/syntax/dosini.vim
@@ -3,10 +3,12 @@
 " Version:                2.1
 " Original Author:        Sean M. McKee <mckee@misslink.net>
 " Previous Maintainer:    Nima Talebi <nima@it.net.au>
-" Current Maintainer:     Hong Xu <xuhdev@gmail.com>
+" Current Maintainer:     Hong Xu <hong@topbug.net>
 " Homepage:               http://www.vim.org/scripts/script.php?script_id=3747
-"                         https://bitbucket.org/xuhdev/syntax-dosini.vim
-" Last Change:            2011 Nov 8
+" Repository:
+"     Mercurial:          https://bitbucket.org/xuhdev/syntax-dosini.vim
+"     Git:                https://github.com/xuhdev/syntax-dosini.vim
+" Last Change:            2018 Sep 11
 
 
 " quit when a syntax file was already loaded
@@ -17,10 +19,11 @@ endif
 " shut case off
 syn case ignore
 
-syn match  dosiniNumber   "\<\d\+\>"
-syn match  dosiniNumber   "\<\d*\.\d\+\>"
-syn match  dosiniNumber   "\<\d\+e[+-]\=\d\+\>"
-syn match  dosiniLabel    "^.\{-}="
+syn match  dosiniLabel    "^.\{-}\ze\s*=" nextgroup=dosiniNumber,dosiniValue
+syn match  dosiniValue    "=\zs.*"
+syn match  dosiniNumber   "=\zs\s*\d\+\s*$"
+syn match  dosiniNumber   "=\zs\s*\d*\.\d\+\s*$"
+syn match  dosiniNumber   "=\zs\s*\d\+e[+-]\=\d\+\s*$"
 syn region dosiniHeader   start="^\s*\[" end="\]"
 syn match  dosiniComment  "^[#;].*$"
 
@@ -31,6 +34,7 @@ hi def link dosiniNumber   Number
 hi def link dosiniHeader   Special
 hi def link dosiniComment  Comment
 hi def link dosiniLabel    Type
+hi def link dosiniValue    String
 
 
 let b:current_syntax = "dosini"


### PR DESCRIPTION
dosiniLabel match no longer includes the equal sign, add new dosiniValue
group-name

Update upstream information as well

(I have added a request with the maintainer as well, see with https://github.com/xuhdev/syntax-dosini.vim/pull/3, but I think he/she is otherwise occupied.)