### PR TITLE
Added tests for the :behave command

### DIFF
--- a/src/Make_all.mak
+++ b/src/Make_all.mak
@@ -14,6 +14,7 @@ NEW_TESTS = \
 	test_autoload \
 	test_backspace_opt \
 	test_backup \
+	test_behave \
 	test_blockedit \
 	test_breakindent \
 	test_bufline \

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -3,6 +3,7 @@
 
 source test_assign.vim
 source test_backup.vim
+source test_behave.vim
 source test_bufline.vim
 source test_cd.vim
 source test_changedtick.vim

--- a/src/testdir/test_behave.vim
+++ b/src/testdir/test_behave.vim
@@ -1,0 +1,29 @@
+" Test the :behave command
+
+func Test_behave()
+  behave mswin
+  call assert_equal('mouse,key', &selectmode)
+  call assert_equal('popup', &mousemodel)
+  call assert_equal('startsel,stopsel', &keymodel)
+  call assert_equal('exclusive', &selection)
+
+  behave xterm
+  call assert_equal('', &selectmode)
+  call assert_equal('extend', &mousemodel)
+  call assert_equal('', &keymodel)
+  call assert_equal('inclusive', &selection)
+
+  set selection&
+  set mousemodel&
+  set keymodel&
+  set selection&
+endfunc
+
+func Test_behave_completion()
+  call feedkeys(":behave \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"behave mswin xterm', @:)
+endfunc
+
+func Test_behave_error()
+  call assert_fails('behave x', 'E475:')
+endfunc


### PR DESCRIPTION
This PR adds tests for the behave command which was not tested
according to codecov:

https://codecov.io/gh/vim/vim/src/c91c500348f3f026a06d1c3565b380d86b8c55ee/src/ex_docmd.c#L12253
https://codecov.io/gh/vim/vim/src/c91c500348f3f026a06d1c3565b380d86b8c55ee/src/ex_docmd.c#L4353