### PR TITLE
Simplify GTK code

### DIFF
--- a/src/gui_beval.c
+++ b/src/gui_beval.c
@@ -264,7 +264,6 @@ addEventHandler(GtkWidget *target, BalloonEval *beval)
     static void
 removeEventHandler(BalloonEval *beval)
 {
-    /* LINTED: avoid warning: dubious operation on enum */
     g_signal_handlers_disconnect_by_func(G_OBJECT(beval->target),
 					 FUNC2GENERIC(target_event_cb),
 					 beval);
@@ -272,7 +271,6 @@ removeEventHandler(BalloonEval *beval)
     if (gtk_socket_id == 0 && gui.mainwin != NULL
 	    && gtk_widget_is_ancestor(beval->target, gui.mainwin))
     {
-	/* LINTED: avoid warning: dubious operation on enum */
 	g_signal_handlers_disconnect_by_func(G_OBJECT(gui.mainwin),
 					     FUNC2GENERIC(mainwin_event_cb),
 					     beval);

--- a/src/gui_beval.c
+++ b/src/gui_beval.c
@@ -244,16 +244,9 @@ addEventHandler(GtkWidget *target, BalloonEval *beval)
      * This allows us to catch events independently of the signal handlers
      * in gui_gtk_x11.c.
      */
-# if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(target), "event",
 		     G_CALLBACK(target_event_cb),
 		     beval);
-# else
-    /* Should use GTK_OBJECT() here, but that causes a lint warning... */
-    gtk_signal_connect((GtkObject*)(target), "event",
-		       GTK_SIGNAL_FUNC(target_event_cb),
-		       beval);
-# endif
     /*
      * Nasty:  Key press events go to the main window thus the drawing area
      * will never see them.  This means we have to connect to the main window
@@ -262,15 +255,9 @@ addEventHandler(GtkWidget *target, BalloonEval *beval)
     if (gtk_socket_id == 0 && gui.mainwin != NULL
 	    && gtk_widget_is_ancestor(target, gui.mainwin))
     {
-# if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(gui.mainwin), "event",
 			 G_CALLBACK(mainwin_event_cb),
 			 beval);
-# else
-	gtk_signal_connect((GtkObject*)(gui.mainwin), "event",
-			   GTK_SIGNAL_FUNC(mainwin_event_cb),
-			   beval);
-# endif
     }
 }
 
@@ -278,29 +265,17 @@ addEventHandler(GtkWidget *target, BalloonEval *beval)
 removeEventHandler(BalloonEval *beval)
 {
     /* LINTED: avoid warning: dubious operation on enum */
-# if GTK_CHECK_VERSION(3,0,0)
     g_signal_handlers_disconnect_by_func(G_OBJECT(beval->target),
 					 FUNC2GENERIC(target_event_cb),
 					 beval);
-# else
-    gtk_signal_disconnect_by_func((GtkObject*)(beval->target),
-				  GTK_SIGNAL_FUNC(target_event_cb),
-				  beval);
-# endif
 
     if (gtk_socket_id == 0 && gui.mainwin != NULL
 	    && gtk_widget_is_ancestor(beval->target, gui.mainwin))
     {
 	/* LINTED: avoid warning: dubious operation on enum */
-# if GTK_CHECK_VERSION(3,0,0)
 	g_signal_handlers_disconnect_by_func(G_OBJECT(gui.mainwin),
 					     FUNC2GENERIC(mainwin_event_cb),
 					     beval);
-# else
-	gtk_signal_disconnect_by_func((GtkObject*)(gui.mainwin),
-				      GTK_SIGNAL_FUNC(mainwin_event_cb),
-				      beval);
-# endif
     }
 }
 
@@ -433,13 +408,8 @@ pointer_event(BalloonEval *beval, int x, int y, unsigned state)
 	    }
 	    else
 	    {
-# if GTK_CHECK_VERSION(3,0,0)
 		beval->timerID = g_timeout_add((guint)p_bdlay,
 					       &timeout_cb, beval);
-# else
-		beval->timerID = gtk_timeout_add((guint32)p_bdlay,
-						 &timeout_cb, beval);
-# endif
 	    }
 	}
     }
@@ -1039,11 +1009,7 @@ cancelBalloon(BalloonEval *beval)
 
     if (beval->timerID != 0)
     {
-# if GTK_CHECK_VERSION(3,0,0)
 	g_source_remove(beval->timerID);
-# else
-	gtk_timeout_remove(beval->timerID);
-# endif
 	beval->timerID = 0;
     }
     beval->showState = ShS_NEUTRAL;
@@ -1055,17 +1021,9 @@ createBalloonEvalWindow(BalloonEval *beval)
     beval->balloonShell = gtk_window_new(GTK_WINDOW_POPUP);
 
     gtk_widget_set_app_paintable(beval->balloonShell, TRUE);
-# if GTK_CHECK_VERSION(3,0,0)
     gtk_window_set_resizable(GTK_WINDOW(beval->balloonShell), FALSE);
-# else
-    gtk_window_set_policy(GTK_WINDOW(beval->balloonShell), FALSE, FALSE, TRUE);
-# endif
     gtk_widget_set_name(beval->balloonShell, "gtk-tooltips");
-# if GTK_CHECK_VERSION(3,0,0)
     gtk_container_set_border_width(GTK_CONTAINER(beval->balloonShell), 4);
-# else
-    gtk_container_border_width(GTK_CONTAINER(beval->balloonShell), 4);
-# endif
 
 # if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(beval->balloonShell), "draw",

--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -756,13 +756,8 @@ gui_mch_add_menu_item(vimmenu_T *menu, int idx)
 #  endif
 
 	    if (gtk_socket_id != 0)
-#  if GTK_CHECK_VERSION(3,0,0)
 		g_signal_connect(G_OBJECT(menu->id), "focus-in-event",
 			G_CALLBACK(toolbar_button_focus_in_event), NULL);
-#  else
-		gtk_signal_connect(GTK_OBJECT(menu->id), "focus_in_event",
-			GTK_SIGNAL_FUNC(toolbar_button_focus_in_event), NULL);
-#  endif
 
 	    CONVERT_TO_UTF8_FREE(text);
 	    CONVERT_TO_UTF8_FREE(tooltip);
@@ -792,12 +787,8 @@ gui_mch_add_menu_item(vimmenu_T *menu, int idx)
 	    gtk_widget_set_sensitive(menu->id, FALSE);
 # endif
 	    gtk_widget_show(menu->id);
-# if GTK_CHECK_VERSION(3,0,0)
 	    gtk_menu_shell_insert(GTK_MENU_SHELL(parent->submenu_id),
 		    menu->id, idx);
-# else
-	    gtk_menu_insert(GTK_MENU(parent->submenu_id), menu->id, idx);
-# endif
 
 	    return;
 	}
@@ -805,21 +796,12 @@ gui_mch_add_menu_item(vimmenu_T *menu, int idx)
 	/* Add textual menu item. */
 	menu_item_new(menu, parent->submenu_id);
 	gtk_widget_show(menu->id);
-# if GTK_CHECK_VERSION(3,0,0)
 	gtk_menu_shell_insert(GTK_MENU_SHELL(parent->submenu_id),
 		menu->id, idx);
-# else
-	gtk_menu_insert(GTK_MENU(parent->submenu_id), menu->id, idx);
-# endif
 
 	if (menu->id != NULL)
-# if GTK_CHECK_VERSION(3,0,0)
 	    g_signal_connect(G_OBJECT(menu->id), "activate",
 			     G_CALLBACK(menu_item_activate), menu);
-# else
-	    gtk_signal_connect(GTK_OBJECT(menu->id), "activate",
-			       GTK_SIGNAL_FUNC(menu_item_activate), menu);
-# endif
     }
 }
 #endif /* FEAT_MENU */
@@ -1000,7 +982,6 @@ gui_mch_set_scrollbar_thumb(scrollbar_T *sb, long val, long size, long max)
 
 	adjustment = gtk_range_get_adjustment(GTK_RANGE(sb->id));
 
-#if GTK_CHECK_VERSION(3,0,0)
 	gtk_adjustment_set_lower(adjustment, 0.0);
 	gtk_adjustment_set_value(adjustment, val);
 	gtk_adjustment_set_upper(adjustment, max + 1);
@@ -1008,34 +989,15 @@ gui_mch_set_scrollbar_thumb(scrollbar_T *sb, long val, long size, long max)
 	gtk_adjustment_set_page_increment(adjustment,
 					  size < 3L ? 1L : size - 2L);
 	gtk_adjustment_set_step_increment(adjustment, 1.0);
-#else
-	adjustment->lower = 0.0;
-	adjustment->value = val;
-	adjustment->upper = max + 1;
-	adjustment->page_size = size;
-	adjustment->page_increment = size < 3L ? 1L : size - 2L;
-	adjustment->step_increment = 1.0;
-#endif
 
-#if GTK_CHECK_VERSION(3,0,0)
-	g_signal_handler_block(G_OBJECT(adjustment),
-						      (gulong)sb->handler_id);
-#else
-	g_signal_handler_block(GTK_OBJECT(adjustment),
-						      (gulong)sb->handler_id);
-#endif
+	g_signal_handler_block(G_OBJECT(adjustment), (gulong)sb->handler_id);
 
 #if !GTK_CHECK_VERSION(3,18,0)
 	gtk_adjustment_changed(adjustment);
 #endif
 
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_handler_unblock(G_OBJECT(adjustment),
 						      (gulong)sb->handler_id);
-#else
-	g_signal_handler_unblock(GTK_OBJECT(adjustment),
-						      (gulong)sb->handler_id);
-#endif
     }
 }
 
@@ -1063,11 +1025,7 @@ adjustment_value_changed(GtkAdjustment *adjustment, gpointer data)
 #endif
 
     sb = gui_find_scrollbar((long)data);
-#if GTK_CHECK_VERSION(3,0,0)
     value = gtk_adjustment_get_value(adjustment);
-#else
-    value = (long)adjustment->value;
-#endif
 #if !GTK_CHECK_VERSION(3,0,0)
     /*
      * The dragging argument must be right for the scrollbar to work with
@@ -1136,26 +1094,15 @@ gui_mch_create_scrollbar(scrollbar_T *sb, int orient)
     {
 	GtkAdjustment *adjustment;
 
-#if GTK_CHECK_VERSION(3,0,0)
 	gtk_widget_set_can_focus(sb->id, FALSE);
-#else
-	GTK_WIDGET_UNSET_FLAGS(sb->id, GTK_CAN_FOCUS);
-#endif
 	gtk_form_put(GTK_FORM(gui.formwin), sb->id, 0, 0);
 
 	adjustment = gtk_range_get_adjustment(GTK_RANGE(sb->id));
 
-#if GTK_CHECK_VERSION(3,0,0)
 	sb->handler_id = g_signal_connect(
 			     G_OBJECT(adjustment), "value-changed",
 			     G_CALLBACK(adjustment_value_changed),
 			     GINT_TO_POINTER(sb->ident));
-#else
-	sb->handler_id = gtk_signal_connect(
-			     GTK_OBJECT(adjustment), "value_changed",
-			     GTK_SIGNAL_FUNC(adjustment_value_changed),
-			     GINT_TO_POINTER(sb->ident));
-#endif
 	gui_mch_update();
     }
 }
@@ -1803,7 +1750,7 @@ gui_mch_dialog(int	type,	    /* type of dialog */
 
     /* Allow activation of mnemonic accelerators without pressing <Alt> when
      * there is no textfield.  Handle pressing Esc. */
-    g_signal_connect(G_OBJECT(dialog), "key_press_event",
+    g_signal_connect(G_OBJECT(dialog), "key-press-event",
 			 G_CALLBACK(&dialog_key_press_event_cb), &dialoginfo);
 
     if (def_but > 0)
@@ -2203,17 +2150,10 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 	if (entry_text != NULL)
 	{
 	    gtk_entry_set_text(GTK_ENTRY(frdp->what), (char *)entry_text);
-#if GTK_CHECK_VERSION(3,0,0)
 	    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(frdp->wword),
 							     (gboolean)wword);
 	    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(frdp->mcase),
 							     (gboolean)mcase);
-#else
-	    gtk_toggle_button_set_state(GTK_TOGGLE_BUTTON(frdp->wword),
-							     (gboolean)wword);
-	    gtk_toggle_button_set_state(GTK_TOGGLE_BUTTON(frdp->mcase),
-							     (gboolean)mcase);
-#endif
 	}
 	gtk_window_present(GTK_WINDOW(frdp->dialog));
 
@@ -2278,11 +2218,7 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 	table = gtk_table_new(1024, 3, FALSE);
 #endif
     gtk_box_pack_start(GTK_BOX(hbox), table, TRUE, TRUE, 0);
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_container_set_border_width(GTK_CONTAINER(table), 4);
-#else
-    gtk_container_border_width(GTK_CONTAINER(table), 4);
-#endif
 
     tmp = gtk_label_new(CONV(_("Find what:")));
 #if GTK_CHECK_VERSION(3,16,0)
@@ -2315,19 +2251,11 @@ find_replace_dialog_create(char_u *arg, int do_replace)
     sensitive = (entry_text != NULL && entry_text[0] != NUL);
     if (entry_text != NULL)
 	gtk_entry_set_text(GTK_ENTRY(frdp->what), (char *)entry_text);
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(frdp->what), "changed",
 		     G_CALLBACK(entry_changed_cb), frdp->dialog);
     g_signal_connect_after(G_OBJECT(frdp->what), "key-press-event",
 			   G_CALLBACK(find_key_press_event),
 			   (gpointer) frdp);
-#else
-    gtk_signal_connect(GTK_OBJECT(frdp->what), "changed",
-		       GTK_SIGNAL_FUNC(entry_changed_cb), frdp->dialog);
-    gtk_signal_connect_after(GTK_OBJECT(frdp->what), "key_press_event",
-				 GTK_SIGNAL_FUNC(find_key_press_event),
-				 (gpointer) frdp);
-#endif
 #if GTK_CHECK_VERSION(3,4,0)
     gtk_grid_attach(GTK_GRID(table), frdp->what, 2, 0, 5, 1);
 #else
@@ -2365,21 +2293,12 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 			 GTK_FILL, GTK_EXPAND, 2, 2);
 #endif
 	frdp->with = gtk_entry_new();
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(frdp->with), "activate",
 			 G_CALLBACK(find_replace_cb),
 			 GINT_TO_POINTER(FRD_R_FINDNEXT));
 	g_signal_connect_after(G_OBJECT(frdp->with), "key-press-event",
 			       G_CALLBACK(find_key_press_event),
 			       (gpointer) frdp);
-#else
-	gtk_signal_connect(GTK_OBJECT(frdp->with), "activate",
-			   GTK_SIGNAL_FUNC(find_replace_cb),
-			   GINT_TO_POINTER(FRD_R_FINDNEXT));
-	gtk_signal_connect_after(GTK_OBJECT(frdp->with), "key_press_event",
-				 GTK_SIGNAL_FUNC(find_key_press_event),
-				 (gpointer) frdp);
-#endif
 #if GTK_CHECK_VERSION(3,4,0)
 	gtk_grid_attach(GTK_GRID(table), frdp->with, 2, 1, 5, 1);
 #else
@@ -2391,39 +2310,23 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 	 * Make the entry activation only change the input focus onto the
 	 * with item.
 	 */
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(frdp->what), "activate",
 			 G_CALLBACK(entry_activate_cb), frdp->with);
-#else
-	gtk_signal_connect(GTK_OBJECT(frdp->what), "activate",
-			   GTK_SIGNAL_FUNC(entry_activate_cb), frdp->with);
-#endif
     }
     else
     {
 	/*
 	 * Make the entry activation do the search.
 	 */
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(frdp->what), "activate",
 			 G_CALLBACK(find_replace_cb),
 			 GINT_TO_POINTER(FRD_FINDNEXT));
-#else
-	gtk_signal_connect(GTK_OBJECT(frdp->what), "activate",
-			   GTK_SIGNAL_FUNC(find_replace_cb),
-			   GINT_TO_POINTER(FRD_FINDNEXT));
-#endif
     }
 
     /* whole word only button */
     frdp->wword = gtk_check_button_new_with_label(CONV(_("Match whole word only")));
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(frdp->wword),
 							(gboolean)wword);
-#else
-    gtk_toggle_button_set_state(GTK_TOGGLE_BUTTON(frdp->wword),
-							(gboolean)wword);
-#endif
     if (do_replace)
 #if GTK_CHECK_VERSION(3,4,0)
 	gtk_grid_attach(GTK_GRID(table), frdp->wword, 0, 2, 5, 1);
@@ -2441,13 +2344,8 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 
     /* match case button */
     frdp->mcase = gtk_check_button_new_with_label(CONV(_("Match case")));
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(frdp->mcase),
 							     (gboolean)mcase);
-#else
-    gtk_toggle_button_set_state(GTK_TOGGLE_BUTTON(frdp->mcase),
-							     (gboolean)mcase);
-#endif
     if (do_replace)
 #if GTK_CHECK_VERSION(3,4,0)
 	gtk_grid_attach(GTK_GRID(table), frdp->mcase, 0, 3, 5, 1);
@@ -2484,30 +2382,16 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 #else
     vbox = gtk_vbox_new(FALSE, 0);
 #endif
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_container_set_border_width(GTK_CONTAINER(vbox), 0);
-#else
-    gtk_container_border_width(GTK_CONTAINER(vbox), 0);
-#endif
     gtk_container_add(GTK_CONTAINER(tmp), vbox);
 
     /* 'Up' and 'Down' buttons */
     frdp->up = gtk_radio_button_new_with_label(NULL, CONV(_("Up")));
     gtk_box_pack_start(GTK_BOX(vbox), frdp->up, TRUE, TRUE, 0);
-#if GTK_CHECK_VERSION(3,0,0)
     frdp->down = gtk_radio_button_new_with_label(
 			gtk_radio_button_get_group(GTK_RADIO_BUTTON(frdp->up)),
 			CONV(_("Down")));
-#else
-    frdp->down = gtk_radio_button_new_with_label(
-			gtk_radio_button_group(GTK_RADIO_BUTTON(frdp->up)),
-			CONV(_("Down")));
-#endif
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(frdp->down), TRUE);
-#else
-    gtk_toggle_button_set_state(GTK_TOGGLE_BUTTON(frdp->down), TRUE);
-#endif
     gtk_container_set_border_width(GTK_CONTAINER(vbox), 2);
     gtk_box_pack_start(GTK_BOX(vbox), frdp->down, TRUE, TRUE, 0);
 
@@ -2517,11 +2401,7 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 #else
     actionarea = gtk_vbutton_box_new();
 #endif
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_container_set_border_width(GTK_CONTAINER(actionarea), 2);
-#else
-    gtk_container_border_width(GTK_CONTAINER(actionarea), 2);
-#endif
     gtk_box_pack_end(GTK_BOX(hbox), actionarea, FALSE, FALSE, 0);
 
     /* 'Find Next' button */
@@ -2532,23 +2412,12 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 #endif
     gtk_widget_set_sensitive(frdp->find, sensitive);
 
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(frdp->find), "clicked",
 		     G_CALLBACK(find_replace_cb),
 		     (do_replace) ? GINT_TO_POINTER(FRD_R_FINDNEXT)
 				  : GINT_TO_POINTER(FRD_FINDNEXT));
-#else
-    gtk_signal_connect(GTK_OBJECT(frdp->find), "clicked",
-		       GTK_SIGNAL_FUNC(find_replace_cb),
-		       (do_replace) ? GINT_TO_POINTER(FRD_R_FINDNEXT)
-				    : GINT_TO_POINTER(FRD_FINDNEXT));
-#endif
 
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_set_can_default(frdp->find, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(frdp->find, GTK_CAN_DEFAULT);
-#endif
     gtk_box_pack_start(GTK_BOX(actionarea), frdp->find, FALSE, FALSE, 0);
     gtk_widget_grab_default(frdp->find);
 
@@ -2561,21 +2430,11 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 	frdp->replace = create_image_button(GTK_STOCK_CONVERT, _("Replace"));
 #endif
 	gtk_widget_set_sensitive(frdp->replace, sensitive);
-#if GTK_CHECK_VERSION(3,0,0)
 	gtk_widget_set_can_default(frdp->find, TRUE);
-#else
-	GTK_WIDGET_SET_FLAGS(frdp->replace, GTK_CAN_DEFAULT);
-#endif
 	gtk_box_pack_start(GTK_BOX(actionarea), frdp->replace, FALSE, FALSE, 0);
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(frdp->replace), "clicked",
 			 G_CALLBACK(find_replace_cb),
 			 GINT_TO_POINTER(FRD_REPLACE));
-#else
-	gtk_signal_connect(GTK_OBJECT(frdp->replace), "clicked",
-			   GTK_SIGNAL_FUNC(find_replace_cb),
-			   GINT_TO_POINTER(FRD_REPLACE));
-#endif
 
 	/* 'Replace All' button */
 #if GTK_CHECK_VERSION(3,10,0)
@@ -2584,21 +2443,11 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 	frdp->all = create_image_button(GTK_STOCK_CONVERT, _("Replace All"));
 #endif
 	gtk_widget_set_sensitive(frdp->all, sensitive);
-#if GTK_CHECK_VERSION(3,0,0)
 	gtk_widget_set_can_default(frdp->all, TRUE);
-#else
-	GTK_WIDGET_SET_FLAGS(frdp->all, GTK_CAN_DEFAULT);
-#endif
 	gtk_box_pack_start(GTK_BOX(actionarea), frdp->all, FALSE, FALSE, 0);
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(frdp->all), "clicked",
 			 G_CALLBACK(find_replace_cb),
 			 GINT_TO_POINTER(FRD_REPLACEALL));
-#else
-	gtk_signal_connect(GTK_OBJECT(frdp->all), "clicked",
-			   GTK_SIGNAL_FUNC(find_replace_cb),
-			   GINT_TO_POINTER(FRD_REPLACEALL));
-#endif
     }
 
     /* 'Cancel' button */
@@ -2607,27 +2456,14 @@ find_replace_dialog_create(char_u *arg, int do_replace)
 #else
     tmp = gtk_button_new_from_stock(GTK_STOCK_CLOSE);
 #endif
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_set_can_default(tmp, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(tmp, GTK_CAN_DEFAULT);
-#endif
     gtk_box_pack_end(GTK_BOX(actionarea), tmp, FALSE, FALSE, 0);
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect_swapped(G_OBJECT(tmp),
 			     "clicked", G_CALLBACK(gtk_widget_hide),
 			     G_OBJECT(frdp->dialog));
     g_signal_connect_swapped(G_OBJECT(frdp->dialog),
 			     "delete-event", G_CALLBACK(gtk_widget_hide_on_delete),
 			     G_OBJECT(frdp->dialog));
-#else
-    gtk_signal_connect_object(GTK_OBJECT(tmp),
-			      "clicked", GTK_SIGNAL_FUNC(gtk_widget_hide),
-			      GTK_OBJECT(frdp->dialog));
-    gtk_signal_connect_object(GTK_OBJECT(frdp->dialog),
-			      "delete_event", GTK_SIGNAL_FUNC(gtk_widget_hide_on_delete),
-			      GTK_OBJECT(frdp->dialog));
-#endif
 
 #if GTK_CHECK_VERSION(3,2,0)
     tmp = gtk_separator_new(GTK_ORIENTATION_VERTICAL);
@@ -2693,23 +2529,11 @@ find_replace_cb(GtkWidget *widget UNUSED, gpointer data)
     }
 
     find_text = (char_u *)gtk_entry_get_text(GTK_ENTRY(sfr->what));
-#if GTK_CHECK_VERSION(3,0,0)
     direction_down = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(sfr->down));
-#else
-    direction_down = GTK_TOGGLE_BUTTON(sfr->down)->active;
-#endif
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(sfr->wword)))
-#else
-    if (GTK_TOGGLE_BUTTON(sfr->wword)->active)
-#endif
 	flags |= FRD_WHOLE_WORD;
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(sfr->mcase)))
-#else
-    if (GTK_TOGGLE_BUTTON(sfr->mcase)->active)
-#endif
 	flags |= FRD_MATCH_CASE;
 
     repl_text = CONVERT_FROM_UTF8(repl_text);

--- a/src/gui_gtk_f.c
+++ b/src/gui_gtk_f.c
@@ -97,9 +97,6 @@ static void gtk_form_send_configure(GtkForm *form);
 static void gtk_form_child_map(GtkWidget *widget, gpointer user_data);
 static void gtk_form_child_unmap(GtkWidget *widget, gpointer user_data);
 
-#if !GTK_CHECK_VERSION(3,0,0)
-static GtkWidgetClass *parent_class = NULL;
-#endif
 
 /* Public interface
  */
@@ -109,11 +106,7 @@ gtk_form_new(void)
 {
     GtkForm *form;
 
-#if GTK_CHECK_VERSION(3,0,0)
     form = g_object_new(GTK_TYPE_FORM, NULL);
-#else
-    form = gtk_type_new(gtk_form_get_type());
-#endif
 
     return GTK_WIDGET(form);
 }
@@ -212,30 +205,7 @@ gtk_form_thaw(GtkForm *form)
 
 /* Basic Object handling procedures
  */
-#if GTK_CHECK_VERSION(3,0,0)
 G_DEFINE_TYPE(GtkForm, gtk_form, GTK_TYPE_CONTAINER)
-#else
-    GtkType
-gtk_form_get_type(void)
-{
-    static GtkType form_type = 0;
-
-    if (!form_type)
-    {
-	GtkTypeInfo form_info;
-
-	vim_memset(&form_info, 0, sizeof(form_info));
-	form_info.type_name = "GtkForm";
-	form_info.object_size = sizeof(GtkForm);
-	form_info.class_size = sizeof(GtkFormClass);
-	form_info.class_init_func = (GtkClassInitFunc)gtk_form_class_init;
-	form_info.object_init_func = (GtkObjectInitFunc)gtk_form_init;
-
-	form_type = gtk_type_unique(GTK_TYPE_CONTAINER, &form_info);
-    }
-    return form_type;
-}
-#endif /* !GTK_CHECK_VERSION(3,0,0) */
 
     static void
 gtk_form_class_init(GtkFormClass *klass)
@@ -245,10 +215,6 @@ gtk_form_class_init(GtkFormClass *klass)
 
     widget_class = (GtkWidgetClass *) klass;
     container_class = (GtkContainerClass *) klass;
-
-#if !GTK_CHECK_VERSION(3,0,0)
-    parent_class = gtk_type_class(gtk_container_get_type());
-#endif
 
     widget_class->realize = gtk_form_realize;
     widget_class->unrealize = gtk_form_unrealize;
@@ -433,13 +399,8 @@ gtk_form_unrealize(GtkWidget *widget)
 	tmp_list = tmp_list->next;
     }
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (GTK_WIDGET_CLASS (gtk_form_parent_class)->unrealize)
 	 (* GTK_WIDGET_CLASS (gtk_form_parent_class)->unrealize) (widget);
-#else
-    if (GTK_WIDGET_CLASS (parent_class)->unrealize)
-	 (* GTK_WIDGET_CLASS (parent_class)->unrealize) (widget);
-#endif
 }
 
     static void

--- a/src/gui_gtk_f.c
+++ b/src/gui_gtk_f.c
@@ -150,21 +150,13 @@ gtk_form_put(GtkForm	*form,
      * that gtk_widget_set_parent() realizes the widget if it's visible
      * and its parent is mapped.
      */
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_widget_get_realized(GTK_WIDGET(form)))
-#else
-    if (GTK_WIDGET_REALIZED(form))
-#endif
 	gtk_form_attach_child_window(form, child);
 
     gtk_widget_set_parent(child_widget, GTK_WIDGET(form));
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_widget_get_realized(GTK_WIDGET(form))
 	    && !gtk_widget_get_realized(child_widget))
-#else
-    if (GTK_WIDGET_REALIZED(form) && !GTK_WIDGET_REALIZED(child_widget))
-#endif
 	gtk_form_realize_child(form, child);
 
     gtk_form_position_child(form, child, TRUE);
@@ -300,32 +292,19 @@ gtk_form_realize(GtkWidget *widget)
     GtkForm *form;
     GdkWindowAttr attributes;
     gint attributes_mask;
+    GtkAllocation allocation;
 
     g_return_if_fail(GTK_IS_FORM(widget));
 
     form = GTK_FORM(widget);
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_set_realized(widget, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(form, GTK_REALIZED);
-#endif
 
+    gtk_widget_get_allocation(widget, &allocation);
     attributes.window_type = GDK_WINDOW_CHILD;
-#if GTK_CHECK_VERSION(3,0,0)
-    {
-	GtkAllocation allocation;
-	gtk_widget_get_allocation(widget, &allocation);
-	attributes.x = allocation.x;
-	attributes.y = allocation.y;
-	attributes.width = allocation.width;
-	attributes.height = allocation.height;
-    }
-#else
-    attributes.x = widget->allocation.x;
-    attributes.y = widget->allocation.y;
-    attributes.width = widget->allocation.width;
-    attributes.height = widget->allocation.height;
-#endif
+    attributes.x = allocation.x;
+    attributes.y = allocation.y;
+    attributes.width = allocation.width;
+    attributes.height = allocation.height;
     attributes.wclass = GDK_INPUT_OUTPUT;
     attributes.visual = gtk_widget_get_visual(widget);
 #if GTK_CHECK_VERSION(3,0,0)
@@ -341,14 +320,9 @@ gtk_form_realize(GtkWidget *widget)
     attributes_mask = GDK_WA_X | GDK_WA_Y | GDK_WA_VISUAL | GDK_WA_COLORMAP;
 #endif
 
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_set_window(widget,
 			  gdk_window_new(gtk_widget_get_parent_window(widget),
 					 &attributes, attributes_mask));
-#else
-    widget->window = gdk_window_new(gtk_widget_get_parent_window(widget),
-				    &attributes, attributes_mask);
-#endif
     gdk_window_set_user_data(gtk_widget_get_window(widget), widget);
 
     attributes.x = 0;
@@ -382,11 +356,7 @@ gtk_form_realize(GtkWidget *widget)
 
 	gtk_form_attach_child_window(form, child);
 
-#if GTK_CHECK_VERSION(3,0,0)
 	if (gtk_widget_get_visible(child->widget))
-#else
-	if (GTK_WIDGET_VISIBLE(child->widget))
-#endif
 	    gtk_form_realize_child(form, child);
     }
 }
@@ -410,11 +380,7 @@ gtk_form_map(GtkWidget *widget)
 
     form = GTK_FORM(widget);
 
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_set_mapped(widget, TRUE);
-#else
-    GTK_WIDGET_SET_FLAGS(widget, GTK_MAPPED);
-#endif
 
     gdk_window_show(gtk_widget_get_window(widget));
     gdk_window_show(form->bin_window);
@@ -423,13 +389,8 @@ gtk_form_map(GtkWidget *widget)
     {
 	GtkFormChild *child = tmp_list->data;
 
-#if GTK_CHECK_VERSION(3,0,0)
 	if (gtk_widget_get_visible(child->widget)
 		&& !gtk_widget_get_mapped(child->widget))
-#else
-	if (GTK_WIDGET_VISIBLE(child->widget)
-		&& !GTK_WIDGET_MAPPED(child->widget))
-#endif
 	    gtk_widget_map(child->widget);
     }
 }
@@ -456,21 +417,12 @@ gtk_form_unrealize(GtkWidget *widget)
 
 	if (child->window != NULL)
 	{
-#if GTK_CHECK_VERSION(3,0,0)
 	    g_signal_handlers_disconnect_by_func(G_OBJECT(child->widget),
 		    FUNC2GENERIC(gtk_form_child_map),
 		    child);
 	    g_signal_handlers_disconnect_by_func(G_OBJECT(child->widget),
 		    FUNC2GENERIC(gtk_form_child_unmap),
 		    child);
-#else
-	    gtk_signal_disconnect_by_func(GTK_OBJECT(child->widget),
-		    GTK_SIGNAL_FUNC(gtk_form_child_map),
-		    child);
-	    gtk_signal_disconnect_by_func(GTK_OBJECT(child->widget),
-		    GTK_SIGNAL_FUNC(gtk_form_child_unmap),
-		    child);
-#endif
 
 	    gdk_window_set_user_data(child->window, NULL);
 	    gdk_window_destroy(child->window);
@@ -534,34 +486,20 @@ gtk_form_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
     GList *tmp_list;
     GtkForm *form;
     gboolean need_reposition;
-#if GTK_CHECK_VERSION(3,0,0)
     GtkAllocation cur_alloc;
-#endif
 
     g_return_if_fail(GTK_IS_FORM(widget));
 
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_get_allocation(widget, &cur_alloc);
 
     if (cur_alloc.x == allocation->x
 	    && cur_alloc.y == allocation->y
 	    && cur_alloc.width == allocation->width
 	    && cur_alloc.height == allocation->height)
-#else
-    if (widget->allocation.x == allocation->x
-	    && widget->allocation.y == allocation->y
-	    && widget->allocation.width == allocation->width
-	    && widget->allocation.height == allocation->height)
-#endif
 	return;
 
-#if GTK_CHECK_VERSION(3,0,0)
     need_reposition = cur_alloc.width != allocation->width
 		   || cur_alloc.height != allocation->height;
-#else
-    need_reposition = widget->allocation.width != allocation->width
-		   || widget->allocation.height != allocation->height;
-#endif
     form = GTK_FORM(widget);
 
     if (need_reposition)
@@ -577,11 +515,7 @@ gtk_form_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 	}
     }
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_widget_get_realized(widget))
-#else
-    if (GTK_WIDGET_REALIZED(widget))
-#endif
     {
 	gdk_window_move_resize(gtk_widget_get_window(widget),
 			       allocation->x, allocation->y,
@@ -590,11 +524,7 @@ gtk_form_size_allocate(GtkWidget *widget, GtkAllocation *allocation)
 			       0, 0,
 			       allocation->width, allocation->height);
     }
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_set_allocation(widget, allocation);
-#else
-    widget->allocation = *allocation;
-#endif
     if (need_reposition)
 	gtk_form_send_configure(form);
 }
@@ -697,17 +627,10 @@ gtk_form_remove(GtkContainer *container, GtkWidget *widget)
 #endif
 	if (child->window)
 	{
-#if GTK_CHECK_VERSION(3,0,0)
 	    g_signal_handlers_disconnect_by_func(G_OBJECT(child->widget),
 		    FUNC2GENERIC(&gtk_form_child_map), child);
 	    g_signal_handlers_disconnect_by_func(G_OBJECT(child->widget),
 		    FUNC2GENERIC(&gtk_form_child_unmap), child);
-#else
-	    gtk_signal_disconnect_by_func(GTK_OBJECT(child->widget),
-		    GTK_SIGNAL_FUNC(&gtk_form_child_map), child);
-	    gtk_signal_disconnect_by_func(GTK_OBJECT(child->widget),
-		    GTK_SIGNAL_FUNC(&gtk_form_child_unmap), child);
-#endif
 
 	    /* FIXME: This will cause problems for reparenting NO_WINDOW
 	     * widgets out of a GtkForm
@@ -760,34 +683,25 @@ gtk_form_attach_child_window(GtkForm *form, GtkFormChild *child)
     if (child->window != NULL)
 	return; /* been there, done that */
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (!gtk_widget_get_has_window(child->widget))
-#else
-    if (GTK_WIDGET_NO_WINDOW(child->widget))
-#endif
     {
 	GtkWidget	*widget;
 	GdkWindowAttr	attributes;
 	gint		attributes_mask;
+	GtkRequisition	requisition;
 
 	widget = GTK_WIDGET(form);
 
+#if GTK_CHECK_VERSION(3,0,0)
+	gtk_widget_get_preferred_size(child->widget, &requisition, NULL);
+#else
+	requisition = child->widget->requisition;
+#endif
 	attributes.window_type = GDK_WINDOW_CHILD;
 	attributes.x = child->x;
 	attributes.y = child->y;
-#if GTK_CHECK_VERSION(3,0,0)
-	{
-	    GtkRequisition requisition;
-
-	    gtk_widget_get_preferred_size(child->widget, &requisition, NULL);
-
-	    attributes.width = requisition.width;
-	    attributes.height = requisition.height;
-	}
-#else
-	attributes.width = child->widget->requisition.width;
-	attributes.height = child->widget->requisition.height;
-#endif
+	attributes.width = requisition.width;
+	attributes.height = requisition.height;
 	attributes.wclass = GDK_INPUT_OUTPUT;
 	attributes.visual = gtk_widget_get_visual(widget);
 #if !GTK_CHECK_VERSION(3,0,0)
@@ -824,23 +738,12 @@ gtk_form_attach_child_window(GtkForm *form, GtkFormChild *child)
 	 * Install signal handlers to map/unmap child->window
 	 * alongside with the actual widget.
 	 */
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(child->widget), "map",
 			 G_CALLBACK(&gtk_form_child_map), child);
 	g_signal_connect(G_OBJECT(child->widget), "unmap",
 			 G_CALLBACK(&gtk_form_child_unmap), child);
-#else
-	gtk_signal_connect(GTK_OBJECT(child->widget), "map",
-			   GTK_SIGNAL_FUNC(&gtk_form_child_map), child);
-	gtk_signal_connect(GTK_OBJECT(child->widget), "unmap",
-			   GTK_SIGNAL_FUNC(&gtk_form_child_unmap), child);
-#endif
     }
-#if GTK_CHECK_VERSION(3,0,0)
     else if (!gtk_widget_get_realized(child->widget))
-#else
-    else if (!GTK_WIDGET_REALIZED(child->widget))
-#endif
     {
 	gtk_widget_set_parent_window(child->widget, form->bin_window);
     }
@@ -868,18 +771,10 @@ gtk_form_position_child(GtkForm *form, GtkFormChild *child,
     {
 	if (!child->mapped)
 	{
-#if GTK_CHECK_VERSION(3,0,0)
 	    if (gtk_widget_get_mapped(GTK_WIDGET(form))
 		    && gtk_widget_get_visible(child->widget))
-#else
-	    if (GTK_WIDGET_MAPPED(form) && GTK_WIDGET_VISIBLE(child->widget))
-#endif
 	    {
-#if GTK_CHECK_VERSION(3,0,0)
 		if (!gtk_widget_get_mapped(child->widget))
-#else
-		if (!GTK_WIDGET_MAPPED(child->widget))
-#endif
 		    gtk_widget_map(child->widget);
 
 		child->mapped = TRUE;
@@ -890,31 +785,22 @@ gtk_form_position_child(GtkForm *form, GtkFormChild *child,
 	if (force_allocate)
 	{
 	    GtkAllocation allocation;
-#if GTK_CHECK_VERSION(3,0,0)
 	    GtkRequisition requisition;
 
+#if GTK_CHECK_VERSION(3,0,0)
 	    gtk_widget_get_preferred_size(child->widget, &requisition, NULL);
+#else
+	    requisition = child->widget->requisition;
 #endif
 
-#if GTK_CHECK_VERSION(3,0,0)
 	    if (!gtk_widget_get_has_window(child->widget))
-#else
-	    if (GTK_WIDGET_NO_WINDOW(child->widget))
-#endif
 	    {
 		if (child->window)
 		{
-#if GTK_CHECK_VERSION(3,0,0)
 		    gdk_window_move_resize(child->window,
 			    x, y,
 			    requisition.width,
 			    requisition.height);
-#else
-		    gdk_window_move_resize(child->window,
-			    x, y,
-			    child->widget->requisition.width,
-			    child->widget->requisition.height);
-#endif
 		}
 
 		allocation.x = 0;
@@ -926,13 +812,8 @@ gtk_form_position_child(GtkForm *form, GtkFormChild *child,
 		allocation.y = y;
 	    }
 
-#if GTK_CHECK_VERSION(3,0,0)
 	    allocation.width = requisition.width;
 	    allocation.height = requisition.height;
-#else
-	    allocation.width = child->widget->requisition.width;
-	    allocation.height = child->widget->requisition.height;
-#endif
 
 	    gtk_widget_size_allocate(child->widget, &allocation);
 	}
@@ -943,11 +824,7 @@ gtk_form_position_child(GtkForm *form, GtkFormChild *child,
 	{
 	    child->mapped = FALSE;
 
-#if GTK_CHECK_VERSION(3,0,0)
 	    if (gtk_widget_get_mapped(child->widget))
-#else
-	    if (GTK_WIDGET_MAPPED(child->widget))
-#endif
 		gtk_widget_unmap(child->widget);
 	}
     }
@@ -981,28 +858,17 @@ gtk_form_send_configure(GtkForm *form)
 {
     GtkWidget *widget;
     GdkEventConfigure event;
+    GtkAllocation allocation;
 
     widget = GTK_WIDGET(form);
 
+    gtk_widget_get_allocation(widget, &allocation);
     event.type = GDK_CONFIGURE;
-#if GTK_CHECK_VERSION(3,0,0)
     event.window = gtk_widget_get_window(widget);
-    {
-	GtkAllocation allocation;
-
-	gtk_widget_get_allocation(widget, &allocation);
-	event.x = allocation.x;
-	event.y = allocation.y;
-	event.width = allocation.width;
-	event.height = allocation.height;
-    }
-#else
-    event.window = widget->window;
-    event.x = widget->allocation.x;
-    event.y = widget->allocation.y;
-    event.width = widget->allocation.width;
-    event.height = widget->allocation.height;
-#endif
+    event.x = allocation.x;
+    event.y = allocation.y;
+    event.width = allocation.width;
+    event.height = allocation.height;
 
     gtk_main_do_event((GdkEvent*)&event);
 }

--- a/src/gui_gtk_f.c
+++ b/src/gui_gtk_f.c
@@ -97,6 +97,9 @@ static void gtk_form_send_configure(GtkForm *form);
 static void gtk_form_child_map(GtkWidget *widget, gpointer user_data);
 static void gtk_form_child_unmap(GtkWidget *widget, gpointer user_data);
 
+#if !GTK_CHECK_VERSION(3,0,0)
+static GtkWidgetClass *parent_class = NULL;
+#endif
 
 /* Public interface
  */
@@ -106,7 +109,11 @@ gtk_form_new(void)
 {
     GtkForm *form;
 
+#if GTK_CHECK_VERSION(3,0,0)
     form = g_object_new(GTK_TYPE_FORM, NULL);
+#else
+    form = gtk_type_new(gtk_form_get_type());
+#endif
 
     return GTK_WIDGET(form);
 }
@@ -205,7 +212,30 @@ gtk_form_thaw(GtkForm *form)
 
 /* Basic Object handling procedures
  */
+#if GTK_CHECK_VERSION(3,0,0)
 G_DEFINE_TYPE(GtkForm, gtk_form, GTK_TYPE_CONTAINER)
+#else
+    GtkType
+gtk_form_get_type(void)
+{
+    static GtkType form_type = 0;
+
+    if (!form_type)
+    {
+	GtkTypeInfo form_info;
+
+	vim_memset(&form_info, 0, sizeof(form_info));
+	form_info.type_name = "GtkForm";
+	form_info.object_size = sizeof(GtkForm);
+	form_info.class_size = sizeof(GtkFormClass);
+	form_info.class_init_func = (GtkClassInitFunc)gtk_form_class_init;
+	form_info.object_init_func = (GtkObjectInitFunc)gtk_form_init;
+
+	form_type = gtk_type_unique(GTK_TYPE_CONTAINER, &form_info);
+    }
+    return form_type;
+}
+#endif /* !GTK_CHECK_VERSION(3,0,0) */
 
     static void
 gtk_form_class_init(GtkFormClass *klass)
@@ -215,6 +245,10 @@ gtk_form_class_init(GtkFormClass *klass)
 
     widget_class = (GtkWidgetClass *) klass;
     container_class = (GtkContainerClass *) klass;
+
+#if !GTK_CHECK_VERSION(3,0,0)
+    parent_class = gtk_type_class(gtk_container_get_type());
+#endif
 
     widget_class->realize = gtk_form_realize;
     widget_class->unrealize = gtk_form_unrealize;
@@ -399,8 +433,13 @@ gtk_form_unrealize(GtkWidget *widget)
 	tmp_list = tmp_list->next;
     }
 
+#if GTK_CHECK_VERSION(3,0,0)
     if (GTK_WIDGET_CLASS (gtk_form_parent_class)->unrealize)
 	 (* GTK_WIDGET_CLASS (gtk_form_parent_class)->unrealize) (widget);
+#else
+    if (GTK_WIDGET_CLASS (parent_class)->unrealize)
+	 (* GTK_WIDGET_CLASS (parent_class)->unrealize) (widget);
+#endif
 }
 
     static void

--- a/src/gui_gtk_f.h
+++ b/src/gui_gtk_f.h
@@ -22,17 +22,10 @@ extern "C" {
 #endif
 
 #define GTK_TYPE_FORM		       (gtk_form_get_type ())
-#ifdef USE_GTK3
 #define GTK_FORM(obj)		       (G_TYPE_CHECK_INSTANCE_CAST((obj), GTK_TYPE_FORM, GtkForm))
 #define GTK_FORM_CLASS(klass)	       (G_TYPE_CHECK_CLASS_CAST((klass), GTK_TYPE_FORM, GtkFormClass))
 #define GTK_IS_FORM(obj)	       (G_TYPE_CHECK_INSTANCE_TYPE((obj), GTK_TYPE_FORM))
 #define GTK_IS_FORM_CLASS(klass)       (G_TYPE_CHECK_CLASS_TYPE((klass), GTK_TYPE_FORM))
-#else
-#define GTK_FORM(obj)		       (GTK_CHECK_CAST ((obj), GTK_TYPE_FORM, GtkForm))
-#define GTK_FORM_CLASS(klass)	       (GTK_CHECK_CLASS_CAST ((klass), GTK_TYPE_FORM, GtkFormClass))
-#define GTK_IS_FORM(obj)	       (GTK_CHECK_TYPE ((obj), GTK_TYPE_FORM))
-#define GTK_IS_FORM_CLASS(klass)       (GTK_CHECK_CLASS_TYPE ((klass), GTK_TYPE_FORM))
-#endif
 
 
 typedef struct _GtkForm GtkForm;
@@ -52,11 +45,7 @@ struct _GtkFormClass
     GtkContainerClass parent_class;
 };
 
-#ifdef USE_GTK3
 GType gtk_form_get_type(void);
-#else
-GtkType gtk_form_get_type(void);
-#endif
 
 GtkWidget *gtk_form_new(void);
 

--- a/src/gui_gtk_f.h
+++ b/src/gui_gtk_f.h
@@ -22,10 +22,17 @@ extern "C" {
 #endif
 
 #define GTK_TYPE_FORM		       (gtk_form_get_type ())
+#ifdef USE_GTK3
 #define GTK_FORM(obj)		       (G_TYPE_CHECK_INSTANCE_CAST((obj), GTK_TYPE_FORM, GtkForm))
 #define GTK_FORM_CLASS(klass)	       (G_TYPE_CHECK_CLASS_CAST((klass), GTK_TYPE_FORM, GtkFormClass))
 #define GTK_IS_FORM(obj)	       (G_TYPE_CHECK_INSTANCE_TYPE((obj), GTK_TYPE_FORM))
 #define GTK_IS_FORM_CLASS(klass)       (G_TYPE_CHECK_CLASS_TYPE((klass), GTK_TYPE_FORM))
+#else
+#define GTK_FORM(obj)		       (GTK_CHECK_CAST ((obj), GTK_TYPE_FORM, GtkForm))
+#define GTK_FORM_CLASS(klass)	       (GTK_CHECK_CLASS_CAST ((klass), GTK_TYPE_FORM, GtkFormClass))
+#define GTK_IS_FORM(obj)	       (GTK_CHECK_TYPE ((obj), GTK_TYPE_FORM))
+#define GTK_IS_FORM_CLASS(klass)       (GTK_CHECK_CLASS_TYPE ((klass), GTK_TYPE_FORM))
+#endif
 
 
 typedef struct _GtkForm GtkForm;
@@ -45,7 +52,11 @@ struct _GtkFormClass
     GtkContainerClass parent_class;
 };
 
+#ifdef USE_GTK3
 GType gtk_form_get_type(void);
+#else
+GtkType gtk_form_get_type(void);
+#endif
 
 GtkWidget *gtk_form_new(void);
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -804,11 +804,7 @@ gtk_settings_xft_dpi_changed_cb(GtkSettings *gtk_settings UNUSED,
     }
 }
 
-#if GTK_CHECK_VERSION(3,0,0)
 typedef gboolean timeout_cb_type;
-#else
-typedef gint timeout_cb_type;
-#endif
 
 /*
  * Start a timer that will invoke the specified callback.
@@ -817,21 +813,13 @@ typedef gint timeout_cb_type;
     static guint
 timeout_add(int time, timeout_cb_type (*callback)(gpointer), int *flagp)
 {
-#if GTK_CHECK_VERSION(3,0,0)
     return g_timeout_add((guint)time, (GSourceFunc)callback, flagp);
-#else
-    return gtk_timeout_add((guint32)time, (GtkFunction)callback, flagp);
-#endif
 }
 
     static void
 timeout_remove(guint timer)
 {
-#if GTK_CHECK_VERSION(3,0,0)
     g_source_remove(timer);
-#else
-    gtk_timeout_remove(timer);
-#endif
 }
 
 
@@ -974,11 +962,7 @@ enter_notify_event(GtkWidget *widget UNUSED,
 	gui_mch_start_blink();
 
     /* make sure keyboard input goes there */
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_socket_id == 0 || !gtk_widget_has_focus(gui.drawarea))
-#else
-    if (gtk_socket_id == 0 || !GTK_WIDGET_HAS_FOCUS(gui.drawarea))
-#endif
 	gtk_widget_grab_focus(gui.drawarea);
 
     return FALSE;
@@ -1418,22 +1402,13 @@ selection_received_cb(GtkWidget		*widget UNUSED,
     int		    len;
     int		    motion_type = MAUTO;
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_selection_data_get_selection(data) == clip_plus.gtk_sel_atom)
-#else
-    if (data->selection == clip_plus.gtk_sel_atom)
-#endif
 	cbd = &clip_plus;
     else
 	cbd = &clip_star;
 
-#if GTK_CHECK_VERSION(3,0,0)
     text = (char_u *)gtk_selection_data_get_data(data);
     len = gtk_selection_data_get_length(data);
-#else
-    text = (char_u *)data->data;
-    len  = data->length;
-#endif
 
     if (text == NULL || len <= 0)
     {
@@ -1443,20 +1418,12 @@ selection_received_cb(GtkWidget		*widget UNUSED,
 	return;
     }
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_selection_data_get_data_type(data) == vim_atom)
-#else
-    if (data->type == vim_atom)
-#endif
     {
 	motion_type = *text++;
 	--len;
     }
-#if GTK_CHECK_VERSION(3,0,0)
     else if (gtk_selection_data_get_data_type(data) == vimenc_atom)
-#else
-    else if (data->type == vimenc_atom)
-#endif
     {
 	char_u		*enc;
 	vimconv_T	conv;
@@ -1547,12 +1514,8 @@ selection_get_cb(GtkWidget	    *widget UNUSED,
     GdkAtom	    type;
     VimClipboard    *cbd;
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_selection_data_get_selection(selection_data)
 	    == clip_plus.gtk_sel_atom)
-#else
-    if (selection_data->selection == clip_plus.gtk_sel_atom)
-#endif
 	cbd = &clip_plus;
     else
 	cbd = &clip_star;
@@ -1785,9 +1748,7 @@ process_motion_notify(int x, int y, GdkModifierType state)
 {
     int	    button;
     int_u   vim_modifiers;
-#if GTK_CHECK_VERSION(3,0,0)
     GtkAllocation allocation;
-#endif
 
     button = (state & (GDK_BUTTON1_MASK | GDK_BUTTON2_MASK |
 		       GDK_BUTTON3_MASK | GDK_BUTTON4_MASK |
@@ -1814,17 +1775,11 @@ process_motion_notify(int x, int y, GdkModifierType state)
     /*
      * Auto repeat timer handling.
      */
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_get_allocation(gui.drawarea, &allocation);
 
     if (x < 0 || y < 0
 	    || x >= allocation.width
 	    || y >= allocation.height)
-#else
-    if (x < 0 || y < 0
-	    || x >= gui.drawarea->allocation.width
-	    || y >= gui.drawarea->allocation.height)
-#endif
     {
 
 	int dx;
@@ -1835,13 +1790,8 @@ process_motion_notify(int x, int y, GdkModifierType state)
 	/* Calculate the maximal distance of the cursor from the drawing area.
 	 * (offshoot can't become negative here!).
 	 */
-#if GTK_CHECK_VERSION(3,0,0)
 	dx = x < 0 ? -x : x - allocation.width;
 	dy = y < 0 ? -y : y - allocation.height;
-#else
-	dx = x < 0 ? -x : x - gui.drawarea->allocation.width;
-	dy = y < 0 ? -y : y - gui.drawarea->allocation.height;
-#endif
 
 	offshoot = dx > dy ? dx : dy;
 
@@ -1907,6 +1857,10 @@ gui_gtk_window_at_position(GtkWidget *widget,
     return gdk_device_get_window_at_position(dev, x, y);
 }
 # endif
+#else /* !GTK_CHECK_VERSION(3,0,0) */
+# define gui_gtk_get_pointer(wid, x, y, s) \
+    gdk_window_get_pointer((wid)->window, x, y, s)
+# define gui_gtk_window_at_position(wid, x, y)	gdk_window_at_pointer(x, y)
 #endif
 
 /*
@@ -1919,11 +1873,7 @@ motion_repeat_timer_cb(gpointer data UNUSED)
     int		    y;
     GdkModifierType state;
 
-#if GTK_CHECK_VERSION(3,0,0)
     gui_gtk_get_pointer(gui.drawarea, &x, &y, &state);
-#else
-    gdk_window_get_pointer(gui.drawarea->window, &x, &y, &state);
-#endif
 
     if (!(state & (GDK_BUTTON1_MASK | GDK_BUTTON2_MASK |
 		   GDK_BUTTON3_MASK | GDK_BUTTON4_MASK |
@@ -1968,11 +1918,7 @@ motion_notify_event(GtkWidget *widget,
 	int		y;
 	GdkModifierType	state;
 
-#if GTK_CHECK_VERSION(3,0,0)
 	gui_gtk_get_pointer(widget, &x, &y, &state);
-#else
-	gdk_window_get_pointer(widget->window, &x, &y, &state);
-#endif
 	process_motion_notify(x, y, state);
     }
     else
@@ -2003,11 +1949,7 @@ button_press_event(GtkWidget *widget,
     gui.event_time = event->time;
 
     /* Make sure we have focus now we've been selected */
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_socket_id != 0 && !gtk_widget_has_focus(widget))
-#else
-    if (gtk_socket_id != 0 && !GTK_WIDGET_HAS_FOCUS(widget))
-#endif
 	gtk_widget_grab_focus(widget);
 
     /*
@@ -2069,11 +2011,7 @@ scroll_event(GtkWidget *widget,
     int	    button;
     int_u   vim_modifiers;
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (gtk_socket_id != 0 && !gtk_widget_has_focus(widget))
-#else
-    if (gtk_socket_id != 0 && !GTK_WIDGET_HAS_FOCUS(widget))
-#endif
 	gtk_widget_grab_focus(widget);
 
     switch (event->direction)
@@ -2239,13 +2177,9 @@ drag_handle_uri_list(GdkDragContext	*context,
     char_u  **fnames;
     int	    nfiles = 0;
 
-# if GTK_CHECK_VERSION(3,0,0)
     fnames = parse_uri_list(&nfiles,
 	    (char_u *)gtk_selection_data_get_data(data),
 	    gtk_selection_data_get_length(data));
-# else
-    fnames = parse_uri_list(&nfiles, data->data, data->length);
-# endif
 
     if (fnames != NULL && nfiles > 0)
     {
@@ -2272,19 +2206,10 @@ drag_handle_text(GdkDragContext	    *context,
     int	    len;
     char_u  *tmpbuf = NULL;
 
-# if GTK_CHECK_VERSION(3,0,0)
     text = (char_u *)gtk_selection_data_get_data(data);
     len = gtk_selection_data_get_length(data);
-# else
-    text = data->data;
-    len  = data->length;
-# endif
 
-# if GTK_CHECK_VERSION(3,0,0)
     if (gtk_selection_data_get_data_type(data) == utf8_string_atom)
-# else
-    if (data->type == utf8_string_atom)
-# endif
     {
 	if (input_conv.vc_type != CONV_NONE)
 	    tmpbuf = string_convert(&input_conv, text, &len);
@@ -2320,7 +2245,6 @@ drag_data_received_cb(GtkWidget		*widget,
     GdkModifierType state;
 
     /* Guard against trash */
-# if GTK_CHECK_VERSION(3,0,0)
     const guchar * const data_data = gtk_selection_data_get_data(data);
     const gint data_length = gtk_selection_data_get_length(data);
     const gint data_format = gtk_selection_data_get_format(data);
@@ -2329,12 +2253,6 @@ drag_data_received_cb(GtkWidget		*widget,
 	    || data_length <= 0
 	    || data_format != 8
 	    || data_data[data_length] != '\0')
-# else
-    if (data->data == NULL
-	    || data->length <= 0
-	    || data->format != 8
-	    || data->data[data->length] != '\0')
-# endif
     {
 	gtk_drag_finish(context, FALSE, FALSE, time_);
 	return;
@@ -2342,11 +2260,7 @@ drag_data_received_cb(GtkWidget		*widget,
 
     /* Get the current modifier state for proper distinguishment between
      * different operations later. */
-#if GTK_CHECK_VERSION(3,0,0)
     gui_gtk_get_pointer(widget, NULL, NULL, &state);
-# else
-    gdk_window_get_pointer(widget->window, NULL, NULL, &state);
-# endif
 
     /* Not sure about the role of "text/plain" here... */
     if (info == (guint)TARGET_TEXT_URI_LIST)
@@ -2810,13 +2724,8 @@ mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 				     GDK_WINDOW_XID(mainwin_win));
     }
     gtk_widget_add_events(gui.mainwin, GDK_PROPERTY_CHANGE_MASK);
-# if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.mainwin), "property-notify-event",
 		     G_CALLBACK(property_event), NULL);
-# else
-    gtk_signal_connect(GTK_OBJECT(gui.mainwin), "property_notify_event",
-		       GTK_SIGNAL_FUNC(property_event), NULL);
-# endif
 #endif
 }
 
@@ -2935,9 +2844,7 @@ mainwin_screen_changed_cb(GtkWidget  *widget,
 drawarea_realize_cb(GtkWidget *widget, gpointer data UNUSED)
 {
     GtkWidget *sbar;
-#if GTK_CHECK_VERSION(3,0,0)
     GtkAllocation allocation;
-#endif
 
 #ifdef FEAT_XIM
     xim_init();
@@ -2962,23 +2869,13 @@ drawarea_realize_cb(GtkWidget *widget, gpointer data UNUSED)
     if (!sbar || (!gui.which_scrollbars[SBAR_LEFT]
 				    && firstwin->w_scrollbars[SBAR_RIGHT].id))
 	sbar = firstwin->w_scrollbars[SBAR_RIGHT].id;
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_get_allocation(sbar, &allocation);
     if (sbar && gtk_widget_get_realized(sbar) && allocation.width)
 	gui.scrollbar_width = allocation.width;
-#else
-    if (sbar && GTK_WIDGET_REALIZED(sbar) && sbar->allocation.width)
-	gui.scrollbar_width = sbar->allocation.width;
-#endif
 
     sbar = gui.bottom_sbar.id;
-#if GTK_CHECK_VERSION(3,0,0)
     if (sbar && gtk_widget_get_realized(sbar) && allocation.height)
 	gui.scrollbar_height = allocation.height;
-#else
-    if (sbar && GTK_WIDGET_REALIZED(sbar) && sbar->allocation.height)
-	gui.scrollbar_height = sbar->allocation.height;
-#endif
 }
 
 /*
@@ -3142,32 +3039,21 @@ get_item_dimensions(GtkWidget *widget, GtkOrientation orientation)
 #  define item_orientation GTK_ORIENTATION_HORIZONTAL
 # endif
 
-# if GTK_CHECK_VERSION(3,0,0)
     if (widget != NULL
 	    && item_orientation == orientation
 	    && gtk_widget_get_realized(widget)
 	    && gtk_widget_get_visible(widget))
-# else
-    if (widget != NULL
-	    && item_orientation == orientation
-	    && GTK_WIDGET_REALIZED(widget)
-	    && GTK_WIDGET_VISIBLE(widget))
-# endif
     {
-# if GTK_CHECK_VERSION(3,0,0)
+# if GTK_CHECK_VERSION(3,0,0) || !defined(FEAT_GUI_GNOME)
 	GtkAllocation allocation;
 
 	gtk_widget_get_allocation(widget, &allocation);
 	return allocation.height;
 # else
-#  ifdef FEAT_GUI_GNOME
 	if (orientation == GTK_ORIENTATION_HORIZONTAL)
 	    return widget->allocation.height;
 	else
 	    return widget->allocation.width;
-#  else
-	return widget->allocation.height;
-#  endif
 # endif
     }
     return 0;
@@ -3438,15 +3324,9 @@ add_tabline_menu_item(GtkWidget *menu, char_u *text, int resp)
     CONVERT_TO_UTF8_FREE(utf_text);
 
     gtk_container_add(GTK_CONTAINER(menu), item);
-# if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(item), "activate",
 	    G_CALLBACK(tabline_menu_handler),
 	    GINT_TO_POINTER(resp));
-# else
-    gtk_signal_connect(GTK_OBJECT(item), "activate",
-	    GTK_SIGNAL_FUNC(tabline_menu_handler),
-	    (gpointer)(long)resp);
-# endif
 }
 
 /*
@@ -3488,20 +3368,11 @@ on_tabline_menu(GtkWidget *widget, GdkEvent *event)
 	   )
 	    return TRUE;
 
-# if GTK_CHECK_VERSION(3,0,0)
 	tabwin = gui_gtk_window_at_position(gui.mainwin, &x, &y);
-# else
-	tabwin = gdk_window_at_pointer(&x, &y);
-# endif
 
 	gdk_window_get_user_data(tabwin, (gpointer)&tabwidget);
-# if GTK_CHECK_VERSION(3,0,0)
 	clicked_page = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(tabwidget),
 							 "tab_num"));
-# else
-	clicked_page = (int)(long)gtk_object_get_user_data(
-						       GTK_OBJECT(tabwidget));
-# endif
 
 	/* If the event was generated for 3rd button popup the menu. */
 	if (bevent->button == 3)
@@ -3536,11 +3407,7 @@ on_tabline_menu(GtkWidget *widget, GdkEvent *event)
     static void
 on_select_tab(
 	GtkNotebook	*notebook UNUSED,
-# if GTK_CHECK_VERSION(3,0,0)
 	gpointer	*page UNUSED,
-# else
-	GtkNotebookPage *page UNUSED,
-# endif
 	gint		idx,
 	gpointer	data UNUSED)
 {
@@ -3554,11 +3421,7 @@ on_select_tab(
     static void
 on_tab_reordered(
 	GtkNotebook	*notebook UNUSED,
-# if GTK_CHECK_VERSION(3,0,0)
 	gpointer	*page UNUSED,
-# else
-	GtkNotebookPage *page UNUSED,
-# endif
 	gint		idx,
 	gpointer	data UNUSED)
 {
@@ -3586,11 +3449,7 @@ gui_mch_show_tabline(int showit)
 	gtk_notebook_set_show_tabs(GTK_NOTEBOOK(gui.tabline), showit);
 	update_window_manager_hints(0, 0);
 	if (showit)
-# if GTK_CHECK_VERSION(3,0,0)
 	    gtk_widget_set_can_focus(GTK_WIDGET(gui.tabline), FALSE);
-# else
-	    GTK_WIDGET_UNSET_FLAGS(GTK_WIDGET(gui.tabline), GTK_CAN_FOCUS);
-# endif
     }
 
     gui_mch_update();
@@ -3663,18 +3522,9 @@ gui_mch_update_tabline(void)
 	}
 
 	event_box = gtk_notebook_get_tab_label(GTK_NOTEBOOK(gui.tabline), page);
-# if GTK_CHECK_VERSION(3,0,0)
 	g_object_set_data(G_OBJECT(event_box), "tab_num",
 						     GINT_TO_POINTER(tab_num));
-# else
-	gtk_object_set_user_data(GTK_OBJECT(event_box),
-						     (gpointer)(long)tab_num);
-# endif
-# if GTK_CHECK_VERSION(3,0,0)
 	label = gtk_bin_get_child(GTK_BIN(event_box));
-# else
-	label = GTK_BIN(event_box)->child;
-# endif
 	get_tabline_label(tp, FALSE);
 	labeltext = CONVERT_TO_UTF8(NameBuff);
 	gtk_label_set_text(GTK_LABEL(label), (const char *)labeltext);
@@ -3695,13 +3545,8 @@ gui_mch_update_tabline(void)
     while (gtk_notebook_get_nth_page(GTK_NOTEBOOK(gui.tabline), nr) != NULL)
 	gtk_notebook_remove_page(GTK_NOTEBOOK(gui.tabline), nr);
 
-# if GTK_CHECK_VERSION(3,0,0)
     if (gtk_notebook_get_current_page(GTK_NOTEBOOK(gui.tabline)) != curtabidx)
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(gui.tabline), curtabidx);
-# else
-    if (gtk_notebook_current_page(GTK_NOTEBOOK(gui.tabline)) != curtabidx)
-	gtk_notebook_set_page(GTK_NOTEBOOK(gui.tabline), curtabidx);
-# endif
 
     /* Make sure everything is in place before drawing text. */
     gui_mch_update();
@@ -3719,13 +3564,8 @@ gui_mch_set_curtab(int nr)
 	return;
 
     ignore_tabline_evt = TRUE;
-# if GTK_CHECK_VERSION(3,0,0)
     if (gtk_notebook_get_current_page(GTK_NOTEBOOK(gui.tabline)) != nr - 1)
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(gui.tabline), nr - 1);
-# else
-    if (gtk_notebook_current_page(GTK_NOTEBOOK(gui.tabline)) != nr - 1)
-	gtk_notebook_set_page(GTK_NOTEBOOK(gui.tabline), nr - 1);
-# endif
     ignore_tabline_evt = FALSE;
 }
 
@@ -3872,11 +3712,7 @@ gui_mch_init(void)
 	/* Use GtkSocket from another app. */
 	plug = gtk_plug_new_for_display(gdk_display_get_default(),
 					gtk_socket_id);
-#if GTK_CHECK_VERSION(3,0,0)
 	if (plug != NULL && gtk_plug_get_socket_window(GTK_PLUG(plug)) != NULL)
-#else
-	if (plug != NULL && GTK_PLUG(plug)->socket_window != NULL)
-#endif
 	{
 	    gui.mainwin = plug;
 	}
@@ -3911,26 +3747,14 @@ gui_mch_init(void)
     gui.text_context = gtk_widget_create_pango_context(gui.mainwin);
     pango_context_set_base_dir(gui.text_context, PANGO_DIRECTION_LTR);
 
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_container_set_border_width(GTK_CONTAINER(gui.mainwin), 0);
-#else
-    gtk_container_border_width(GTK_CONTAINER(gui.mainwin), 0);
-#endif
     gtk_widget_add_events(gui.mainwin, GDK_VISIBILITY_NOTIFY_MASK);
 
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.mainwin), "delete-event",
 		     G_CALLBACK(&delete_event_cb), NULL);
 
     g_signal_connect(G_OBJECT(gui.mainwin), "realize",
 		     G_CALLBACK(&mainwin_realize), NULL);
-#else
-    gtk_signal_connect(GTK_OBJECT(gui.mainwin), "delete_event",
-		       GTK_SIGNAL_FUNC(&delete_event_cb), NULL);
-
-    gtk_signal_connect(GTK_OBJECT(gui.mainwin), "realize",
-		       GTK_SIGNAL_FUNC(&mainwin_realize), NULL);
-#endif
 
     g_signal_connect(G_OBJECT(gui.mainwin), "screen-changed",
 		     G_CALLBACK(&mainwin_screen_changed_cb), NULL);
@@ -4084,11 +3908,7 @@ gui_mch_init(void)
 	gtk_widget_show(label);
 	event_box = gtk_event_box_new();
 	gtk_widget_show(event_box);
-# if GTK_CHECK_VERSION(3,0,0)
 	g_object_set_data(G_OBJECT(event_box), "tab_num", GINT_TO_POINTER(1L));
-# else
-	gtk_object_set_user_data(GTK_OBJECT(event_box), (gpointer)1L);
-# endif
 # if !GTK_CHECK_VERSION(3,14,0)
 	gtk_misc_set_padding(GTK_MISC(label), 2, 2);
 # endif
@@ -4097,35 +3917,19 @@ gui_mch_init(void)
 	gtk_notebook_set_tab_reorderable(GTK_NOTEBOOK(gui.tabline), page, TRUE);
     }
 
-# if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.tabline), "switch-page",
 		     G_CALLBACK(on_select_tab), NULL);
     g_signal_connect(G_OBJECT(gui.tabline), "page-reordered",
 		     G_CALLBACK(on_tab_reordered), NULL);
-# else
-    gtk_signal_connect(GTK_OBJECT(gui.tabline), "switch_page",
-		       GTK_SIGNAL_FUNC(on_select_tab), NULL);
-    gtk_signal_connect(GTK_OBJECT(gui.tabline), "page-reordered",
-		       GTK_SIGNAL_FUNC(on_tab_reordered), NULL);
-# endif
 
     /* Create a popup menu for the tab line and connect it. */
     tabline_menu = create_tabline_menu();
-# if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect_swapped(G_OBJECT(gui.tabline), "button-press-event",
 	    G_CALLBACK(on_tabline_menu), G_OBJECT(tabline_menu));
-# else
-    gtk_signal_connect_object(GTK_OBJECT(gui.tabline), "button_press_event",
-	    GTK_SIGNAL_FUNC(on_tabline_menu), GTK_OBJECT(tabline_menu));
-# endif
 #endif /* FEAT_GUI_TABLINE */
 
     gui.formwin = gtk_form_new();
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_container_set_border_width(GTK_CONTAINER(gui.formwin), 0);
-#else
-    gtk_container_border_width(GTK_CONTAINER(gui.formwin), 0);
-#endif
 #if !GTK_CHECK_VERSION(3,0,0)
     gtk_widget_set_events(gui.formwin, GDK_EXPOSURE_MASK);
 #endif
@@ -4159,17 +3963,10 @@ gui_mch_init(void)
 
     /* For GtkSockets, key-presses must go to the focus widget (drawarea)
      * and not the window. */
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect((gtk_socket_id == 0) ? G_OBJECT(gui.mainwin)
 					  : G_OBJECT(gui.drawarea),
 		       "key-press-event",
 		       G_CALLBACK(key_press_event), NULL);
-#else
-    gtk_signal_connect((gtk_socket_id == 0) ? GTK_OBJECT(gui.mainwin)
-					    : GTK_OBJECT(gui.drawarea),
-		       "key_press_event",
-		       GTK_SIGNAL_FUNC(key_press_event), NULL);
-#endif
 #if defined(FEAT_XIM) || GTK_CHECK_VERSION(3,0,0)
     /* Also forward key release events for the benefit of GTK+ 2 input
      * modules.  Try CTRL-SHIFT-xdigits to enter a Unicode code point. */
@@ -4178,28 +3975,20 @@ gui_mch_init(void)
 		     "key-release-event",
 		     G_CALLBACK(&key_release_event), NULL);
 #endif
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.drawarea), "realize",
 		     G_CALLBACK(drawarea_realize_cb), NULL);
     g_signal_connect(G_OBJECT(gui.drawarea), "unrealize",
 		     G_CALLBACK(drawarea_unrealize_cb), NULL);
+#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.drawarea), "configure-event",
 	    G_CALLBACK(drawarea_configure_event_cb), NULL);
-# if GTK_CHECK_VERSION(3,22,2)
+#endif
+#if GTK_CHECK_VERSION(3,22,2)
     g_signal_connect_after(G_OBJECT(gui.drawarea), "style-updated",
 			   G_CALLBACK(&drawarea_style_updated_cb), NULL);
-# else
+#else
     g_signal_connect_after(G_OBJECT(gui.drawarea), "style-set",
 			   G_CALLBACK(&drawarea_style_set_cb), NULL);
-# endif
-#else
-    gtk_signal_connect(GTK_OBJECT(gui.drawarea), "realize",
-		       GTK_SIGNAL_FUNC(drawarea_realize_cb), NULL);
-    gtk_signal_connect(GTK_OBJECT(gui.drawarea), "unrealize",
-		       GTK_SIGNAL_FUNC(drawarea_unrealize_cb), NULL);
-
-    gtk_signal_connect_after(GTK_OBJECT(gui.drawarea), "style_set",
-			     GTK_SIGNAL_FUNC(&drawarea_style_set_cb), NULL);
 #endif
 
 #if !GTK_CHECK_VERSION(3,0,0)
@@ -4213,11 +4002,7 @@ gui_mch_init(void)
 
     if (gtk_socket_id != 0)
 	/* make sure keyboard input can go to the drawarea */
-#if GTK_CHECK_VERSION(3,0,0)
 	gtk_widget_set_can_focus(gui.drawarea, TRUE);
-#else
-	GTK_WIDGET_SET_FLAGS(gui.drawarea, GTK_CAN_FOCUS);
-#endif
 
     /*
      * Set clipboard specific atoms
@@ -4248,17 +4033,10 @@ gui_mch_init(void)
      */
     if (vim_strchr(p_go, GO_POINTER) != NULL)
     {
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(gui.drawarea), "leave-notify-event",
 			 G_CALLBACK(leave_notify_event), NULL);
 	g_signal_connect(G_OBJECT(gui.drawarea), "enter-notify-event",
 			 G_CALLBACK(enter_notify_event), NULL);
-#else
-	gtk_signal_connect(GTK_OBJECT(gui.drawarea), "leave_notify_event",
-			   GTK_SIGNAL_FUNC(leave_notify_event), NULL);
-	gtk_signal_connect(GTK_OBJECT(gui.drawarea), "enter_notify_event",
-			   GTK_SIGNAL_FUNC(enter_notify_event), NULL);
-#endif
     }
 
     /* Real windows can get focus ... GtkPlug, being a mere container can't,
@@ -4267,47 +4045,25 @@ gui_mch_init(void)
      */
     if (gtk_socket_id == 0)
     {
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(gui.mainwin), "focus-out-event",
 			 G_CALLBACK(focus_out_event), NULL);
 	g_signal_connect(G_OBJECT(gui.mainwin), "focus-in-event",
 			 G_CALLBACK(focus_in_event), NULL);
-#else
-	gtk_signal_connect(GTK_OBJECT(gui.mainwin), "focus_out_event",
-			       GTK_SIGNAL_FUNC(focus_out_event), NULL);
-	gtk_signal_connect(GTK_OBJECT(gui.mainwin), "focus_in_event",
-			       GTK_SIGNAL_FUNC(focus_in_event), NULL);
-#endif
     }
     else
     {
-#if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(gui.drawarea), "focus-out-event",
 			 G_CALLBACK(focus_out_event), NULL);
 	g_signal_connect(G_OBJECT(gui.drawarea), "focus-in-event",
 			 G_CALLBACK(focus_in_event), NULL);
-#else
-	gtk_signal_connect(GTK_OBJECT(gui.drawarea), "focus_out_event",
-			       GTK_SIGNAL_FUNC(focus_out_event), NULL);
-	gtk_signal_connect(GTK_OBJECT(gui.drawarea), "focus_in_event",
-			       GTK_SIGNAL_FUNC(focus_in_event), NULL);
-#endif
 #ifdef FEAT_GUI_TABLINE
-# if GTK_CHECK_VERSION(3,0,0)
 	g_signal_connect(G_OBJECT(gui.tabline), "focus-out-event",
 			 G_CALLBACK(focus_out_event), NULL);
 	g_signal_connect(G_OBJECT(gui.tabline), "focus-in-event",
 			 G_CALLBACK(focus_in_event), NULL);
-# else
-	gtk_signal_connect(GTK_OBJECT(gui.tabline), "focus_out_event",
-			       GTK_SIGNAL_FUNC(focus_out_event), NULL);
-	gtk_signal_connect(GTK_OBJECT(gui.tabline), "focus_in_event",
-			       GTK_SIGNAL_FUNC(focus_in_event), NULL);
-# endif
 #endif /* FEAT_GUI_TABLINE */
     }
 
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.drawarea), "motion-notify-event",
 		     G_CALLBACK(motion_notify_event), NULL);
     g_signal_connect(G_OBJECT(gui.drawarea), "button-press-event",
@@ -4316,41 +4072,19 @@ gui_mch_init(void)
 		     G_CALLBACK(button_release_event), NULL);
     g_signal_connect(G_OBJECT(gui.drawarea), "scroll-event",
 		     G_CALLBACK(&scroll_event), NULL);
-#else
-    gtk_signal_connect(GTK_OBJECT(gui.drawarea), "motion_notify_event",
-		       GTK_SIGNAL_FUNC(motion_notify_event), NULL);
-    gtk_signal_connect(GTK_OBJECT(gui.drawarea), "button_press_event",
-		       GTK_SIGNAL_FUNC(button_press_event), NULL);
-    gtk_signal_connect(GTK_OBJECT(gui.drawarea), "button_release_event",
-		       GTK_SIGNAL_FUNC(button_release_event), NULL);
-    g_signal_connect(G_OBJECT(gui.drawarea), "scroll_event",
-		     G_CALLBACK(&scroll_event), NULL);
-#endif
 
     /*
      * Add selection handler functions.
      */
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.drawarea), "selection-clear-event",
 		     G_CALLBACK(selection_clear_event), NULL);
     g_signal_connect(G_OBJECT(gui.drawarea), "selection-received",
 		     G_CALLBACK(selection_received_cb), NULL);
-#else
-    gtk_signal_connect(GTK_OBJECT(gui.drawarea), "selection_clear_event",
-		       GTK_SIGNAL_FUNC(selection_clear_event), NULL);
-    gtk_signal_connect(GTK_OBJECT(gui.drawarea), "selection_received",
-		       GTK_SIGNAL_FUNC(selection_received_cb), NULL);
-#endif
 
     gui_gtk_set_selection_targets();
 
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.drawarea), "selection-get",
 		     G_CALLBACK(selection_get_cb), NULL);
-#else
-    gtk_signal_connect(GTK_OBJECT(gui.drawarea), "selection_get",
-		       GTK_SIGNAL_FUNC(selection_get_cb), NULL);
-#endif
 
     /* Pretend we don't have input focus, we will get an event if we do. */
     gui.in_focus = FALSE;
@@ -4415,16 +4149,12 @@ set_cairo_source_rgba_from_color(cairo_t *cr, guicolor_T color)
     void
 gui_mch_new_colors(void)
 {
-#if GTK_CHECK_VERSION(3,0,0)
-# if !GTK_CHECK_VERSION(3,22,2)
-    GdkWindow * const da_win = gtk_widget_get_window(gui.drawarea);
-# endif
-
     if (gui.drawarea != NULL && gtk_widget_get_window(gui.drawarea) != NULL)
-#else
-    if (gui.drawarea != NULL && gui.drawarea->window != NULL)
-#endif
     {
+#if !GTK_CHECK_VERSION(3,22,2)
+	GdkWindow * const da_win = gtk_widget_get_window(gui.drawarea);
+#endif
+
 #if GTK_CHECK_VERSION(3,22,2)
 	GtkStyleContext * const context
 	    = gtk_widget_get_style_context(gui.drawarea);
@@ -4462,11 +4192,7 @@ gui_mch_new_colors(void)
 	GdkColor color = { 0, 0, 0, 0 };
 
 	color.pixel = gui.back_pixel;
-# if GTK_CHECK_VERSION(3,0,0)
 	gdk_window_set_background(da_win, &color);
-# else
-	gdk_window_set_background(gui.drawarea->window, &color);
-# endif
 #endif /* !GTK_CHECK_VERSION(3,22,2) */
     }
 }
@@ -4524,13 +4250,8 @@ form_configure_event(GtkWidget *widget UNUSED,
  * We can't do much more here than to trying to preserve what had been done,
  * since the window is already inevitably going away.
  */
-#if GTK_CHECK_VERSION(3,0,0)
     static void
 mainwin_destroy_cb(GObject *object UNUSED, gpointer data UNUSED)
-#else
-    static void
-mainwin_destroy_cb(GtkObject *object UNUSED, gpointer data UNUSED)
-#endif
 {
     /* Don't write messages to the GUI anymore */
     full_screen = FALSE;
@@ -4709,13 +4430,8 @@ gui_mch_open(void)
      * changed them). */
     highlight_gui_started();	/* re-init colors and fonts */
 
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.mainwin), "destroy",
 		     G_CALLBACK(mainwin_destroy_cb), NULL);
-#else
-    gtk_signal_connect(GTK_OBJECT(gui.mainwin), "destroy",
-		       GTK_SIGNAL_FUNC(mainwin_destroy_cb), NULL);
-#endif
 
 #ifdef FEAT_HANGULIN
     hangul_keyboard_set();
@@ -4731,25 +4447,15 @@ gui_mch_open(void)
      * manager upon us and should not interfere with what VIM is requesting
      * upon startup.
      */
-#if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.formwin), "configure-event",
 		     G_CALLBACK(form_configure_event), NULL);
-#else
-    gtk_signal_connect(GTK_OBJECT(gui.formwin), "configure_event",
-		       GTK_SIGNAL_FUNC(form_configure_event), NULL);
-#endif
 
 #ifdef FEAT_DND
     /* Set up for receiving DND items. */
     gui_gtk_set_dnd_targets();
 
-# if GTK_CHECK_VERSION(3,0,0)
     g_signal_connect(G_OBJECT(gui.drawarea), "drag-data-received",
 		     G_CALLBACK(drag_data_received_cb), NULL);
-# else
-    gtk_signal_connect(GTK_OBJECT(gui.drawarea), "drag_data_received",
-		       GTK_SIGNAL_FUNC(drag_data_received_cb), NULL);
-# endif
 #endif
 
 	/* With GTK+ 2, we need to iconify the window before calling show()
@@ -5036,11 +4742,7 @@ gui_mch_enable_menu(int showit)
 	widget = gui.menubar;
 
     /* Do not disable the menu while starting up, otherwise F10 doesn't work. */
-# if GTK_CHECK_VERSION(3,0,0)
     if (!showit != !gtk_widget_get_visible(widget) && !gui.starting)
-# else
-    if (!showit != !GTK_WIDGET_VISIBLE(widget) && !gui.starting)
-# endif
     {
 	if (showit)
 	    gtk_widget_show(widget);
@@ -5071,11 +4773,7 @@ gui_mch_show_toolbar(int showit)
     if (showit)
 	set_toolbar_style(GTK_TOOLBAR(gui.toolbar));
 
-# if GTK_CHECK_VERSION(3,0,0)
     if (!showit != !gtk_widget_get_visible(widget))
-# else
-    if (!showit != !GTK_WIDGET_VISIBLE(widget))
-# endif
     {
 	if (showit)
 	    gtk_widget_show(widget);
@@ -6336,11 +6034,7 @@ gui_mch_beep(void)
 {
     GdkDisplay *display;
 
-#if GTK_CHECK_VERSION(3,0,0)
     if (gui.mainwin != NULL && gtk_widget_get_realized(gui.mainwin))
-#else
-    if (gui.mainwin != NULL && GTK_WIDGET_REALIZED(gui.mainwin))
-#endif
 	display = gtk_widget_get_display(gui.mainwin);
     else
 	display = gdk_display_get_default();
@@ -6700,11 +6394,7 @@ theend:
     void
 gui_mch_flush(void)
 {
-#if GTK_CHECK_VERSION(3,0,0)
     if (gui.mainwin != NULL && gtk_widget_get_realized(gui.mainwin))
-#else
-    if (gui.mainwin != NULL && GTK_WIDGET_REALIZED(gui.mainwin))
-#endif
 	gdk_display_flush(gtk_widget_get_display(gui.mainwin));
 }
 
@@ -7060,11 +6750,7 @@ gui_mch_menu_grey(vimmenu_T *menu, int grey)
 
     gui_mch_menu_hidden(menu, FALSE);
     /* Be clever about bitfields versus true booleans here! */
-# if GTK_CHECK_VERSION(3,0,0)
     if (!gtk_widget_get_sensitive(menu->id) == !grey)
-# else
-    if (!GTK_WIDGET_SENSITIVE(menu->id) == !grey)
-# endif
     {
 	gtk_widget_set_sensitive(menu->id, !grey);
 	gui_mch_update();
@@ -7082,11 +6768,7 @@ gui_mch_menu_hidden(vimmenu_T *menu, int hidden)
 
     if (hidden)
     {
-# if GTK_CHECK_VERSION(3,0,0)
 	if (gtk_widget_get_visible(menu->id))
-# else
-	if (GTK_WIDGET_VISIBLE(menu->id))
-# endif
 	{
 	    gtk_widget_hide(menu->id);
 	    gui_mch_update();
@@ -7094,11 +6776,7 @@ gui_mch_menu_hidden(vimmenu_T *menu, int hidden)
     }
     else
     {
-# if GTK_CHECK_VERSION(3,0,0)
 	if (!gtk_widget_get_visible(menu->id))
-# else
-	if (!GTK_WIDGET_VISIBLE(menu->id))
-# endif
 	{
 	    gtk_widget_show(menu->id);
 	    gui_mch_update();
@@ -7126,15 +6804,7 @@ gui_mch_enable_scrollbar(scrollbar_T *sb, int flag)
     if (sb->id == NULL)
 	return;
 
-#if GTK_CHECK_VERSION(3,0,0)
     gtk_widget_set_visible(sb->id, flag);
-#else
-    if (flag)
-	gtk_widget_show(sb->id);
-    else
-	gtk_widget_hide(sb->id);
-#endif
-
     update_window_manager_hints(0, 0);
 }
 
@@ -7166,11 +6836,7 @@ gui_mch_get_rgb(guicolor_T pixel)
     void
 gui_mch_getmouse(int *x, int *y)
 {
-#if GTK_CHECK_VERSION(3,0,0)
     gui_gtk_get_pointer(gui.drawarea, x, y, NULL);
-#else
-    gdk_window_get_pointer(gui.drawarea->window, x, y, NULL);
-#endif
 }
 
     void

--- a/src/vim.h
+++ b/src/vim.h
@@ -2329,6 +2329,54 @@ typedef enum {
 #ifdef FEAT_GUI_GTK
 # if !GTK_CHECK_VERSION(2,14,0)
 #  define gtk_widget_get_window(wid)	((wid)->window)
+#  define gtk_plug_get_socket_window(wid)	((wid)->socket_window)
+#  define gtk_selection_data_get_data(sel)	((sel)->data)
+#  define gtk_selection_data_get_length(sel)	((sel)->length)
+#  define gtk_selection_data_get_type(sel)	((sel)->type)
+#  define gtk_adjustment_set_lower(adj, low) \
+    do { (adj)->lower = low; } while (0)
+#  define gtk_adjustment_set_upper(adj, up) \
+    do { (adj)->upper = up; } while (0)
+#  define gtk_adjustment_set_page_size(adj, size) \
+    do { (adj)->page_size = size; } while (0)
+#  define gtk_adjustment_set_page_increment(adj, inc) \
+    do { (adj)->page_increment = inc; } while (0)
+#  define gtk_adjustment_set_step_increment(adj, inc) \
+    do { (adj)->step_increment = inc; } while (0)
+# endif
+# if !GTK_CHECK_VERSION(2,16,0)
+#  define gtk_selection_data_get_selection(sel)	((sel)->selection)
+# endif
+# if !GTK_CHECK_VERSION(2,18,0)
+#  define gtk_widget_get_allocation(wid, alloc) \
+    do { *(alloc) = (wid)->allocation; } while (0)
+#  define gtk_widget_set_allocation(wid, alloc) \
+    do { (wid)->allocation = *(alloc); } while (0)
+#  define gtk_widget_get_has_window(wid)	!GTK_WIDGET_NO_WINDOW(wid)
+#  define gtk_widget_get_sensitive(wid)	GTK_WIDGET_SENSITIVE(wid)
+#  define gtk_widget_get_visible(wid)	GTK_WIDGET_VISIBLE(wid)
+#  define gtk_widget_has_focus(wid)	GTK_WIDGET_HAS_FOCUS(wid)
+#  define gtk_widget_set_window(wid, win) \
+    do { (wid)->window = (win); } while (0)
+#  define gtk_widget_set_can_default(wid, can) \
+    do { if (can) { GTK_WIDGET_SET_FLAGS(wid, GTK_CAN_DEFAULT); } \
+	else { GTK_WIDGET_UNSET_FLAGS(wid, GTK_CAN_DEFAULT); } } while (0)
+#  define gtk_widget_set_can_focus(wid, can) \
+    do { if (can) { GTK_WIDGET_SET_FLAGS(wid, GTK_CAN_FOCUS); } \
+	else { GTK_WIDGET_UNSET_FLAGS(wid, GTK_CAN_FOCUS); } } while (0)
+#  define gtk_widget_set_visible(wid, vis) \
+    do { if (vis) { gtk_widget_show(wid); } \
+	else { gtk_widget_hide(wid); } } while (0)
+# endif
+# if !GTK_CHECK_VERSION(2,20,0)
+#  define gtk_widget_get_mapped(wid)	GTK_WIDGET_MAPPED(wid)
+#  define gtk_widget_get_realized(wid)	GTK_WIDGET_REALIZED(wid)
+#  define gtk_widget_set_mapped(wid, map) \
+    do { if (map) { GTK_WIDGET_SET_FLAGS(wid, GTK_MAPPED); } \
+	else { GTK_WIDGET_UNSET_FLAGS(wid, GTK_MAPPED); } } while (0)
+#  define gtk_widget_set_realized(wid, rea) \
+    do { if (rea) { GTK_WIDGET_SET_FLAGS(wid, GTK_REALIZED); } \
+	else { GTK_WIDGET_UNSET_FLAGS(wid, GTK_REALIZED); } } while (0)
 # endif
 #endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -2331,8 +2331,9 @@ typedef enum {
 #  define gtk_widget_get_window(wid)	((wid)->window)
 #  define gtk_plug_get_socket_window(wid)	((wid)->socket_window)
 #  define gtk_selection_data_get_data(sel)	((sel)->data)
+#  define gtk_selection_data_get_data_type(sel)	((sel)->type)
+#  define gtk_selection_data_get_format(sel)	((sel)->format)
 #  define gtk_selection_data_get_length(sel)	((sel)->length)
-#  define gtk_selection_data_get_type(sel)	((sel)->type)
 #  define gtk_adjustment_set_lower(adj, low) \
     do { (adj)->lower = low; } while (0)
 #  define gtk_adjustment_set_upper(adj, up) \


### PR DESCRIPTION
This is a supplemental patch for #3421.
The GTK code still has too many #ifs.
Define some functions and remove old code for GTK1.
E.g. No need to use `gtk_signal_connect()` any more.

This also drops support for Glib 2.3 or earlier.
`G_DEFINE_TYPE` can be used from Glib 2.4.0 (released on 2004).
I don't think we need to support older Glib than that.