### PR TITLE
Channel-handling has broken by 8.1.0342

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -6366,11 +6366,6 @@ parse_queued_messages(void)
 {
     win_T *old_curwin = curwin;
 
-    // Do not handle messages while redrawing, because it may cause buffers to
-    // change or be wiped while they are being redrawn.
-    if (updating_screen)
-	return;
-
     // For Win32 mch_breakcheck() does not check for input, do it here.
 # if defined(WIN32) && defined(FEAT_JOB_CHANNEL)
     channel_handle_events(FALSE);


### PR DESCRIPTION
## Problem

Channel-handling does not work under certain situation, e.g. in `statusline` function.

## Repro steps

sample.vim:
```vim
function! StatusLine()
  let job = job_start(['echo'])
  let ch = job_getchannel(job)
  while ch_status(ch) =~# '^\(open\|buffered\)'
    sleep 1m
  endwhile
  return 'Hello'
endfunction

set statusline=%{StatusLine()}
set laststatus=2
```

`vim --clean -S sample.vim`

then Vim hangs at while loop in `StatusLine()` function (can cancel by Ctrl-C).

## Cause

https://github.com/vim/vim/blob/e3521d9cbb786806eaff106707851d37d2c0ecef/src/misc2.c#L6369-L6372

Since 8.1.0342, `parse_queued_messages()` does nothing when `updating_screen` is TRUE.


## Solution

* Remove checking `updating_screen` in `parse_queued_messages()`

It appears that this check is unnecessary since 8.1.0349 has resolved the crash problem referred at 8.0.342.