### PR TITLE
Feature: Add `swapname()` function

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2417,6 +2417,7 @@ submatch({nr} [, {list}])	String or List
 substitute({expr}, {pat}, {sub}, {flags})
 				String	all {pat} in {expr} replaced with {sub}
 swapinfo({fname})		Dict	information about swap file {fname}
+swapname({expr})		String	swap file of buffer {expr}
 synID({lnum}, {col}, {trans})	Number	syntax ID at {lnum} and {col}
 synIDattr({synID}, {what} [, {mode}])
 				String	attribute {what} of syntax ID {synID}
@@ -8041,6 +8042,13 @@ swapinfo({fname})					*swapinfo()*
 			Cannot read file: cannot read first block
 			Not a swap file: does not contain correct block ID
 			Magic number mismatch: Info in first block is invalid
+
+swapname({expr})					*swapname()*
+		The result is the swap file path of the buffer {expr}.
+		For the use of {expr}, see |bufname()| above.
+		If buffer {expr} is the current buffer, the result is equal to
+		|:swapname| (unless no swap file).
+		If buffer {expr} has no swap file, returns an empty string.
 
 synID({lnum}, {col}, {trans})				*synID()*
 		The result is a Number, which is the syntax ID at the position

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -399,6 +399,7 @@ static void f_strwidth(typval_T *argvars, typval_T *rettv);
 static void f_submatch(typval_T *argvars, typval_T *rettv);
 static void f_substitute(typval_T *argvars, typval_T *rettv);
 static void f_swapinfo(typval_T *argvars, typval_T *rettv);
+static void f_swapname(typval_T *argvars, typval_T *rettv);
 static void f_synID(typval_T *argvars, typval_T *rettv);
 static void f_synIDattr(typval_T *argvars, typval_T *rettv);
 static void f_synIDtrans(typval_T *argvars, typval_T *rettv);
@@ -865,6 +866,7 @@ static struct fst
     {"submatch",	1, 2, f_submatch},
     {"substitute",	4, 4, f_substitute},
     {"swapinfo",	1, 1, f_swapinfo},
+    {"swapname",	1, 1, f_swapname},
     {"synID",		3, 3, f_synID},
     {"synIDattr",	2, 3, f_synIDattr},
     {"synIDtrans",	1, 1, f_synIDtrans},
@@ -12339,6 +12341,23 @@ f_swapinfo(typval_T *argvars, typval_T *rettv)
 {
     if (rettv_dict_alloc(rettv) == OK)
 	get_b0_dict(get_tv_string(argvars), rettv->vval.v_dict);
+}
+
+/*
+ * "swapname(expr)" function
+ */
+    static void
+f_swapname(typval_T *argvars, typval_T *rettv)
+{
+    buf_T	*buf;
+
+    rettv->v_type = VAR_STRING;
+    buf = get_buf_tv(&argvars[0], FALSE);
+    if (buf == NULL || buf->b_ml.ml_mfp == NULL
+					|| buf->b_ml.ml_mfp->mf_fname == NULL)
+	rettv->vval.v_string = NULL;
+    else
+	rettv->vval.v_string = vim_strsave(buf->b_ml.ml_mfp->mf_fname);
 }
 
 /*

--- a/src/testdir/test_swap.vim
+++ b/src/testdir/test_swap.vim
@@ -1,5 +1,9 @@
 " Tests for the swap feature
 
+func s:swapname()
+  return trim(execute('swapname'))
+endfunc
+
 " Tests for 'directory' option.
 func Test_swap_directory()
   if !has("unix")
@@ -17,7 +21,7 @@ func Test_swap_directory()
   " Verify that the swap file doesn't exist in the current directory
   call assert_equal([], glob(".Xtest1*.swp", 1, 1, 1))
   edit Xtest1
-  let swfname = split(execute("swapname"))[0]
+  let swfname = s:swapname()
   call assert_equal([swfname], glob(swfname, 1, 1, 1))
 
   " './dir', swap file in a directory relative to the file
@@ -27,7 +31,7 @@ func Test_swap_directory()
   edit Xtest1
   call assert_equal([], glob(swfname, 1, 1, 1))
   let swfname = "Xtest2/Xtest1.swp"
-  call assert_equal(swfname, split(execute("swapname"))[0])
+  call assert_equal(swfname, s:swapname())
   call assert_equal([swfname], glob("Xtest2/*", 1, 1, 1))
 
   " 'dir', swap file in directory relative to the current dir
@@ -38,7 +42,7 @@ func Test_swap_directory()
   edit Xtest2/Xtest3
   call assert_equal(["Xtest2/Xtest3"], glob("Xtest2/*", 1, 1, 1))
   let swfname = "Xtest.je/Xtest3.swp"
-  call assert_equal(swfname, split(execute("swapname"))[0])
+  call assert_equal(swfname, s:swapname())
   call assert_equal([swfname], glob("Xtest.je/*", 1, 1, 1))
 
   set dir&
@@ -70,7 +74,7 @@ func Test_swap_group()
 	throw 'Skipped: cannot set second group on test file'
       else
 	split Xtest
-	let swapname = substitute(execute('swapname'), '[[:space:]]', '', 'g')
+	let swapname = s:swapname()
 	call assert_match('Xtest', swapname)
 	" Group of swapfile must now match original file.
 	call assert_match(' ' . groups[1] . ' \d', system('ls -l ' . swapname))
@@ -102,7 +106,7 @@ func Test_swapinfo()
   new Xswapinfo
   call setline(1, ['one', 'two', 'three'])
   w
-  let fname = trim(execute('swapname'))
+  let fname = s:swapname()
   call assert_match('Xswapinfo', fname)
   let info = swapinfo(fname)
 
@@ -139,12 +143,12 @@ endfunc
 
 func Test_swapname()
   edit Xtest1
-  let expected = trim(execute('swapname'))
+  let expected = s:swapname()
   call assert_equal(expected, swapname('%'))
 
   new Xtest2
   let buf = bufnr('%')
-  let expected = trim(execute('swapname'))
+  let expected = s:swapname()
   wincmd p
   call assert_equal(expected, swapname(buf))
 

--- a/src/testdir/test_swap.vim
+++ b/src/testdir/test_swap.vim
@@ -136,3 +136,24 @@ func Test_swapinfo()
   call assert_equal('Not a swap file', info.error)
   call delete('Xnotaswapfile')
 endfunc
+
+func Test_swapname()
+  edit Xtest1
+  let expected = trim(execute('swapname'))
+  call assert_equal(expected, swapname('%'))
+
+  new Xtest2
+  let buf = bufnr('%')
+  let expected = trim(execute('swapname'))
+  wincmd p
+  call assert_equal(expected, swapname(buf))
+
+  new Xtest3
+  setlocal noswapfile
+  call assert_equal('', swapname('%'))
+
+  bwipe!
+  call delete('Xtest1')
+  call delete('Xtest2')
+  call delete('Xtest3')
+endfunc


### PR DESCRIPTION
I propose `swapname()` function to get the swapfile name of specified buffer.

And this pull-req includes the improvement of test_swap. 