### PR TITLE
Command :args accessed invalid memory when an arg is longer the number of columns

### DIFF
--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -411,3 +411,10 @@ func Test_arg_all_expand()
   call assert_equal('notexist Xx\ x runtest.vim', expand('##'))
   call delete('Xx x')
 endfunc
+
+func Test_large_arg()
+  " Argument longer or equal to the number of columns used to cause
+  " access to invalid memory.
+  exe 'argadd ' .repeat('x', &columns)
+  args
+endfunc

--- a/src/version.c
+++ b/src/version.c
@@ -1721,7 +1721,7 @@ list_in_columns(char_u **items, int size, int current)
     if (Columns < width)
     {
 	/* Not enough screen columns - show one per line */
-	for (i = 0; items[i] != NULL; ++i)
+	for (i = 0; i < item_count; ++i)
 	{
 	    version_msg_wrap(items[i], i == current);
 	    if (msg_col > 0)


### PR DESCRIPTION
This PR fixes a bug found by using afl-fuzz:  Vim-8.1.401 and older
accesses invalid memory with the `:args` command when an arg is
longer than the number of columns.

Bug can be reproduce with the following command, assuming 
that the terminal is not larger than the number of 'x' in the argument:
```
$ valgrind vim --clean xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -c args  2> vg.log
```
And vg.log contains:
```
$ cat vg.log
==18714== Memcheck, a memory error detector
==18714== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18714== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==18714== Command: ./vim --clean xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -c args
==18714== 
==18714== Invalid read of size 8
==18714==    at 0x35AEFA: list_in_columns (version.c:1724)
==18714==    by 0x1CCD5D: ex_args (ex_cmds2.c:2773)
==18714==    by 0x1D56A6: do_one_cmd (ex_docmd.c:2533)
==18714==    by 0x1D2B11: do_cmdline (ex_docmd.c:1041)
==18714==    by 0x1D210F: do_cmdline_cmd (ex_docmd.c:642)
==18714==    by 0x3B928F: exe_commands (main.c:2958)
==18714==    by 0x3B6379: vim_main2 (main.c:816)
==18714==    by 0x3B5CA0: main (main.c:443)
==18714==  Address 0x9283288 is 0 bytes after a block of size 8 alloc'd
==18714==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18714==    by 0x254499: lalloc (misc2.c:976)
==18714==    by 0x254364: alloc (misc2.c:874)
==18714==    by 0x1CCCB7: ex_args (ex_cmds2.c:2763)
==18714==    by 0x1D56A6: do_one_cmd (ex_docmd.c:2533)
==18714==    by 0x1D2B11: do_cmdline (ex_docmd.c:1041)
==18714==    by 0x1D210F: do_cmdline_cmd (ex_docmd.c:642)
==18714==    by 0x3B928F: exe_commands (main.c:2958)
==18714==    by 0x3B6379: vim_main2 (main.c:816)
==18714==    by 0x3B5CA0: main (main.c:443)
etc.
```

I added a test Test_large_arg() that triggers the invalid memory
access prior to the fix.