### PR TITLE
Disabled Test_V_arg on Windows as it hangs in Appveyor

### DIFF
--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -227,6 +227,11 @@ endfunc
 
 " Test the -p[N] argument to open N tabpages.
 func Test_p_arg()
+  if has('win32')
+    " FIXME: Disabled on for Windows until Appveyor hang is fixed.
+    return
+  endif
+
   let after = [
 	\ 'call writefile(split(execute("tabs"), "\n"), "Xtestout")',
 	\ 'qall',
@@ -254,17 +259,19 @@ endfunc
 
 " Test the -V[N] argument to set the 'verbose' option to [N]
 func Test_V_arg()
-  " FIXME: disabled for Windows as this test hangs in Appveyor.
-  if !has('win32')
-    let out = system(GetVimCommand() . ' --clean -es -X -V0 -c "set verbose?" -cq')
-    call assert_equal("  verbose=0\n", out)
-
-    let out = system(GetVimCommand() . ' --clean -es -X -V2 -c "set verbose?" -cq')
-    call assert_match("^sourcing \"$VIMRUNTIME/defaults\.vim\"\r\nSearching for \"filetype\.vim\".*\n  verbose=2\n$", out)
-
-    let out = system(GetVimCommand() . ' --clean -es -X -V15 -c "set verbose?" -cq')
-    call assert_match("\+*\nsourcing \"$VIMRUNTIME/defaults\.vim\"\r\nline 1: \" The default vimrc file\..*\n  verbose=15\n\+*", out)
+  if has('win32')
+    " FIXME: Disabled on for Windows until Appveyor hang is fixed.
+    return
   endif
+
+  let out = system(GetVimCommand() . ' --clean -es -X -V0 -c "set verbose?" -cq')
+  call assert_equal("  verbose=0\n", out)
+
+  let out = system(GetVimCommand() . ' --clean -es -X -V2 -c "set verbose?" -cq')
+  call assert_match("^sourcing \"$VIMRUNTIME/defaults\.vim\"\r\nSearching for \"filetype\.vim\".*\n  verbose=2\n$", out)
+
+  let out = system(GetVimCommand() . ' --clean -es -X -V15 -c "set verbose?" -cq')
+  call assert_match("\+*\nsourcing \"$VIMRUNTIME/defaults\.vim\"\r\nline 1: \" The default vimrc file\..*\n  verbose=15\n\+*", out)
 endfunc
 
 " Test the -A, -F and -H arguments (Arabic, Farsi and Hebrew modes).

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -228,7 +228,7 @@ endfunc
 " Test the -p[N] argument to open N tabpages.
 func Test_p_arg()
   if has('win32')
-    " FIXME: Disabled on for Windows until Appveyor hang is fixed.
+    " FIXME: Disabled on Windows until Appveyor hang is fixed.
     return
   endif
 
@@ -260,7 +260,7 @@ endfunc
 " Test the -V[N] argument to set the 'verbose' option to [N]
 func Test_V_arg()
   if has('win32')
-    " FIXME: Disabled on for Windows until Appveyor hang is fixed.
+    " FIXME: Disabled on Windows until Appveyor hang is fixed.
     return
   endif
 
@@ -276,6 +276,11 @@ endfunc
 
 " Test the -A, -F and -H arguments (Arabic, Farsi and Hebrew modes).
 func Test_A_F_H_arg()
+  if has('win32')
+    " FIXME: Disabled on Windows until Appveyor hang is fixed.
+    return
+  endif
+
   let after = [
 	\ 'call writefile([&rightleft, &arabic, &fkmap, &hkmap], "Xtestout")',
 	\ 'qall',

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -227,11 +227,6 @@ endfunc
 
 " Test the -p[N] argument to open N tabpages.
 func Test_p_arg()
-  if has('win32')
-    " FIXME: Disabled on Windows until Appveyor hang is fixed.
-    return
-  endif
-
   let after = [
 	\ 'call writefile(split(execute("tabs"), "\n"), "Xtestout")',
 	\ 'qall',

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -252,16 +252,19 @@ func Test_p_arg()
   call delete('Xtestout')
 endfunc
 
-" Test the -V[N] argument to set the 'version' option to [N]
+" Test the -V[N] argument to set the 'verbose' option to [N]
 func Test_V_arg()
-  let out = system(GetVimCommand() . ' --clean -es -X -V0 -c "set verbose?" -cq')
-  call assert_equal("  verbose=0\n", out)
+  " FIXME: disabled for Windows as this test hangs in Appveyor.
+  if !has('win32')
+    let out = system(GetVimCommand() . ' --clean -es -X -V0 -c "set verbose?" -cq')
+    call assert_equal("  verbose=0\n", out)
 
-  let out = system(GetVimCommand() . ' --clean -es -X -V2 -c "set verbose?" -cq')
-  call assert_match("^sourcing \"$VIMRUNTIME/defaults\.vim\"\r\nSearching for \"filetype\.vim\".*\n  verbose=2\n$", out)
+    let out = system(GetVimCommand() . ' --clean -es -X -V2 -c "set verbose?" -cq')
+    call assert_match("^sourcing \"$VIMRUNTIME/defaults\.vim\"\r\nSearching for \"filetype\.vim\".*\n  verbose=2\n$", out)
 
-  let out = system(GetVimCommand() . ' --clean -es -X -V15 -c "set verbose?" -cq')
-  call assert_match("\+*\nsourcing \"$VIMRUNTIME/defaults\.vim\"\r\nline 1: \" The default vimrc file\..*\n  verbose=15\n\+*", out)
+    let out = system(GetVimCommand() . ' --clean -es -X -V15 -c "set verbose?" -cq')
+    call assert_match("\+*\nsourcing \"$VIMRUNTIME/defaults\.vim\"\r\nline 1: \" The default vimrc file\..*\n  verbose=15\n\+*", out)
+  endif
 endfunc
 
 " Test the -A, -F and -H arguments (Arabic, Farsi and Hebrew modes).


### PR DESCRIPTION
This PR disables test Test_V_arg which was recently
added in patch 8.1.0406.  This should hopefully avoid
Appveyor CI to hang in test_startup, with timeout
after 60 min.  I'm not sure why the test hangs but
I suppose that it's related to using system().

It would also be nice the reduce the Appveyor timeout
to 30 minutes or so, as tests on Windows typically
take 20 minutes. How can we do that?