### PR TITLE
Adjust log messages in testdir

### DIFF
--- a/src/testdir/Make_dos.mak
+++ b/src/testdir/Make_dos.mak
@@ -112,7 +112,10 @@ bench_re_freeze.out: bench_re_freeze.vim
 # to write and a lot easier to read and debug.
 # Limitation: Only works with the +eval feature.
 
-newtests: $(NEW_TESTS)
+newtests: newtestssilent
+	@if exist messages (findstr "SKIPPED FAILED" messages > nul) && type messages
+
+newtestssilent: $(NEW_TESTS)
 
 .vim.res:
 	@echo $(VIMPROG) > vimcmd

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -121,7 +121,7 @@ nolog:
 RUN_VIMTEST = VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(VALGRIND) $(VIMPROG) -f $(GUI_FLAG) -u unix.vim
 
 newtests: newtestssilent
-	@/bin/sh -c "if test -f messages && grep -q 'SKIPPED\|FAILED' messages; then cat messages && if test -f test.log; then cat test.log; fi ; fi"
+	@/bin/sh -c "if test -f messages && grep -q 'SKIPPED\|FAILED' messages; then cat messages; fi"
 
 newtestssilent: $(NEW_TESTS)
 


### PR DESCRIPTION
I found some issues with the makefiles in testdir:

* `messages` wasn't shown with `Make_dos.mak`.
* `test.log` was shown twice with `Makefile`.