### PR TITLE
Fix: An error(E315) occurs when using appendbufline() with `set stl=%f`

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1742,6 +1742,9 @@ enter_buffer(buf_T *buf)
     /* mark cursor position as being invalid */
     curwin->w_valid = 0;
 
+    buflist_setfpos(curbuf, curwin, curbuf->b_last_cursor.lnum,
+		    curbuf->b_last_cursor.col, TRUE);
+
     /* Make sure the buffer is loaded. */
     if (curbuf->b_ml.ml_mfp == NULL)	/* need to load the file */
     {

--- a/src/testdir/test_bufline.vim
+++ b/src/testdir/test_bufline.vim
@@ -91,6 +91,33 @@ func Test_appendbufline()
   exe "bwipe! " . b
 endfunc
 
+func Test_appendbufline_no_E315()
+  let after = [
+    \ 'set stl=%f ls=2',
+    \ 'new',
+    \ 'let buf = bufnr("%")',
+    \ 'quit',
+    \ 'vsp',
+    \ 'exec "buffer" buf',
+    \ 'wincmd w',
+    \ 'call appendbufline(buf, 0, "abc")',
+    \ 'redraw',
+    \ 'while getbufline(buf, 1)[0] =~ "^\\s*$"',
+    \ '  sleep 10m',
+    \ 'endwhile',
+    \ 'au VimLeavePre * call writefile([v:errmsg], "Xerror")',
+    \ 'au VimLeavePre * call writefile(["done"], "Xdone")',
+    \ 'qall!',
+    \ ]
+  if !RunVim([], after, '--clean')
+    return
+  endif
+  call assert_notmatch("^E315:", readfile("Xerror")[0])
+  call assert_equal("done", readfile("Xdone")[0])
+  call delete("Xerror")
+  call delete("Xdone")
+endfunc
+
 func Test_deletebufline()
   new
   let b = bufnr('%')


### PR DESCRIPTION
Hi Bram and Vim developers,

### How to reproduce:
- Start Vim with some commands.
  $ vim --clean +"new b" +q +vsp +2b +"wincmd w" a
- Append a line to buffer "b" from buffer "a"'s window.
  :call appendbufline(2,0,"A")
- set 'statusline' to "%f".
  :set stl=%f

### Expected behavior:
- No error occurs.

### Actual behavior:
- An Error(E315) occurs.
  E315: ml_get: invalid lnum: 3


### Investigation result:
  Vim can not set `curwin` to buffer "b"'s window in the following place when `:call appendbufline(2,0,"A")` is executed.
  Because the buffer "b"'s `b_wininfo->wi_win` is free() and cleared when `:q` was executed.

  ```
#0  find_win_for_curbuf () at evalfunc.c:1244
#1  0x00005562f9570939 in set_buffer_lines (buf=0x5562fa478940, lnum_arg=0,
    append=1, lines=0x7ffff3779960, rettv=0x7ffff3779b20) at evalfunc.c:1289
#2  0x00005562f9570cc9 in f_appendbufline (argvars=0x7ffff3779940,
    rettv=0x7ffff3779b20) at evalfunc.c:1407
[...]
  ```
  ```
  (gdb) p lastbuf->b_fname
  $36 = (char_u *) 0x55e21fcc00e0 "b"
  (gdb) p lastbuf->b_wininfo->wi_win
  $4 = (win_T *) 0x0
  ```

  This causes `set_buffer_lines()` to be executed with wrong `curwin`, so a discrepancy arises between the buffer information and the window information.

  ```
  (gdb) p lastbuf
  $35 = (buf_T *) 0x55e21fcc3940
  (gdb) p lastbuf->b_fname
  $36 = (char_u *) 0x55e21fcc00e0 "b"
  (gdb) p lastbuf->b_ml.ml_line_count
  $37 = 2                             // this is correct.

  (gdb) p firstwin
  $38 = (win_T *) 0x55e21fcbe2b0
  (gdb) p firstwin->w_buffer
  $39 = (buf_T *) 0x55e21fcc3940      // buffer "b"
  (gdb) p firstwin->w_wincol
  $40 = 0
  (gdb) p firstwin->w_cursor.lnum
  $41 = 3                             // Wrong lnum!!!
  ```

  By setting `set stl=%f` after this, the internal abnormality becomes manifest as an error.


### Solution:
- When `:buffer` command etc. are called, set `b_wininfo-> wi_win`, if possible.
  (I added to call `buflist_setfpos()` within `enter_buffer()`)


### NOTE:
- This issue was reported by Masashi Iizuka.
  https://github.com/vim-jp/issues/issues/1180 (Japanese)

--

Best regards,
Hirohito Higashi (h_east)