### PR TITLE
win32: Make it possible to create a mapfile with MinGW

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -931,6 +931,10 @@ ifeq (yes, $(STATIC_WINPTHREAD))
 LIB += -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic
 endif
 
+ifeq (yes, $(MAP))
+LFLAGS += -Wl,-Map=$(TARGET).map
+endif
+
 all: $(TARGET) vimrun.exe xxd/xxd.exe install.exe uninstal.exe GvimExt/gvimext.dll
 
 vimrun.exe: vimrun.c


### PR DESCRIPTION
Currently Make_mvc.mak can create a mapfile by using `MAP=yes` option.
However Make_mingw.mak cannot do it.  This makes it possible.