### PR TITLE
Remove -O2 or other optimization flags from cproto

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2029,7 +2029,7 @@ proto: $(PRO_AUTO) $(PRO_MANUAL)
 # The -E"gcc -E" argument must be separate to avoid problems with shell
 # quoting.
 CPROTO = cproto $(PROTO_FLAGS) -DPROTO \
-	 `echo '$(LINT_CFLAGS)' | sed -e 's/ -[a-z-]\+//g'`
+	 `echo '$(LINT_CFLAGS)' | sed -e 's/ -[a-z-]\+//g' -e 's/ -O[^ ]\+//g'`
 
 ### Would be nice if this would work for "normal" make.
 ### Currently it only works for (Free)BSD make.


### PR DESCRIPTION
When running cproto on Cygwin, the flags might include -O2, but it
causes the stderr to be written to a file "2".  Strip them.