### PR TITLE
Fixed memory overflow in buffer in the stack.

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -8032,7 +8032,7 @@ xsmp_init(void)
 	    &smcallbacks,
 	    NULL,
 	    &xsmp.clientid,
-	    sizeof(errorstring),
+	    sizeof(errorstring) - 1,
 	    errorstring);
     if (xsmp.smcconn == NULL)
     {

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -272,7 +272,7 @@ endfunc
 " Test the -V[N]{filename} argument to set the 'verbose' option to N
 " and set 'verbosefile' to filename.
 func Test_V_file_arg()
-  if RunVim([], [], ' --clean -X -V2Xverbosefile -c "set verbose? verbosefile?" -cq')
+  if RunVim([], [], ' --clean -V2Xverbosefile -c "set verbose? verbosefile?" -cq')
     let out = join(readfile('Xverbosefile'), "\n")
     call assert_match("sourcing \"$VIMRUNTIME[\\/]defaults\.vim\"\n", out)
     call assert_match("\n  verbose=2\n", out)


### PR DESCRIPTION
This PR fixes a memory overflow in the stack in Vim-8.1.425 and
older. Bug is discovered by asan (address sanitizer). Valgrind can't
detect the bug as it only detects overflows in the heap:
```
=================================================================
==5396==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fff346f6d80 at pc 0x7f4bc610057d bp 0x7fff346f65a0 sp 0x7fff346f5d48
READ of size 87 at 0x7fff346f6d80 thread T0
    #0 0x7f4bc610057c  (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x9957c)
    #1 0x55a7f028703b in vim_vsnprintf_typval /home/pel/sb/vim/src/message.c:4582
    #2 0x55a7f0285ef2 in vim_vsnprintf /home/pel/sb/vim/src/message.c:4325
    #3 0x55a7f0285e5f in vim_snprintf /home/pel/sb/vim/src/message.c:4313
    #4 0x55a7eff44c34 in xsmp_init /home/pel/sb/vim/src/os_unix.c:8043
    #5 0x55a7f0262c82 in main /home/pel/sb/vim/src/main.c:358
    #6 0x7f4bc3be4b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #7 0x55a7efbd7ad9 in _start (/home/pel/sb/vim/src/vim+0x13aad9)

Address 0x7fff346f6d80 is located in stack of thread T0 at offset 208 in frame
    #0 0x55a7eff4487b in xsmp_init /home/pel/sb/vim/src/os_unix.c:7991

  This frame has 3 object(s):
    [32, 96) 'smcallbacks'
    [128, 208) 'errorstring'
    [256, 388) 'errorreport' <== Memory access at offset 208 partially underflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x9957c) 
Shadow bytes around the buggy address:
  0x1000668d6d60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1
  0x1000668d6d70: f1 f1 00 00 00 f2 00 00 00 00 00 00 00 00 00 00
  0x1000668d6d80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000668d6d90: 00 00 00 00 00 00 f1 f1 f1 f1 00 00 00 00 00 00
  0x1000668d6da0: 00 00 f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 00
=>0x1000668d6db0:[f2]f2 f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 00
  0x1000668d6dc0: 00 00 00 00 00 00 04 f2 f2 f2 00 00 00 00 00 00
  0x1000668d6dd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000668d6de0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000668d6df0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000668d6e00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==5396==ABORTING
```

To reproduce it, remove `-X` in `src/testdir/test_startup.vim` as follows
```
$ diff --git a/src/testdir/test_startup.vim b/src/testdir/test_startup.vim
index 4a296ec01..6f06ab877 100644
--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -272,7 +272,7 @@ endfunc
 " Test the -V[N]{filename} argument to set the 'verbose' option to N
 " and set 'verbosefile' to filename.
 func Test_V_file_arg()
-  if RunVim([], [], ' --clean -X -V2Xverbosefile -c "set verbose? verbosefile?" -cq')
+  if RunVim([], [], ' --clean -V2Xverbosefile -c "set verbose? verbosefile?" -cq')
     let out = join(readfile('Xverbosefile'), "\n")
     call assert_match("sourcing \"$VIMRUNTIME[\\/]defaults\.vim\"\n", out)
     call assert_match("\n  verbose=2\n", out)
```

Then build vim with the address sanitizer and run:
```
$ cd src
$ make test_startup
```
Vim then crashes with the above stack.

The call to `SmcOpenConnection()` at line `os_unix.c:8025` does not end
the string `errorstring` when when the error string is longer than
`sizeof(errorstring)` bytes. So code later accesses beyond
`errorstring[]` at `os_unix.c:8043`:
```
8024     /* Create an SM connection */
8025     xsmp.smcconn = SmcOpenConnection(
8026             NULL,
8027             NULL,
8028             SmProtoMajor,
8029             SmProtoMinor,
8030             SmcSaveYourselfProcMask | SmcDieProcMask
8031                      | SmcSaveCompleteProcMask | SmcShutdownCancelledProcMask,
8032             &smcallbacks,
8033             NULL,
8034             &xsmp.clientid,
8035             sizeof(errorstring),
8036             errorstring);
8037     if (xsmp.smcconn == NULL)
8038     {
8039         char errorreport[132];
8040 
8041         if (p_verbose > 0)
8042         {
8043             vim_snprintf(errorreport, sizeof(errorreport),
8044                          _("XSMP SmcOpenConnection failed: %s"), errorstring);
```