### PR TITLE
Added test for :suspend

### DIFF
--- a/src/Make_all.mak
+++ b/src/Make_all.mak
@@ -168,6 +168,7 @@ NEW_TESTS = \
 	test_stat \
 	test_statusline \
 	test_substitute \
+	test_suspend \
 	test_swap \
 	test_syn_attr \
 	test_syntax \

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -52,6 +52,7 @@ source test_set.vim
 source test_sort.vim
 source test_sha256.vim
 source test_statusline.vim
+source test_suspend.vim
 source test_syn_attr.vim
 source test_tabline.vim
 source test_tabpage.vim

--- a/src/testdir/test_suspend.vim
+++ b/src/testdir/test_suspend.vim
@@ -1,0 +1,51 @@
+" Test :suspend
+
+source shared.vim
+
+func Test_suspend()
+  if !has('terminal') || !executable('/bin/sh')
+    return
+  endif
+
+  let buf = term_start('/bin/sh')
+  " Wait for shell prompt '$ '.
+  call WaitForAssert({-> assert_equal('$ ', term_getline(buf, '.'))})
+
+  call term_sendkeys(buf, v:progpath
+        \               . " --clean -X"
+        \               . " -c 'set nu'"
+        \               . " -c 'call setline(1, \"foo\")'"
+        \               . " Xfoo\<CR>")
+  " Cursor in terminal buffer should be on first line in spawned vim.
+  call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
+
+  for suspend_cmd in [":suspend\<CR>",
+        \             ":stop\<CR>",
+        \             ":suspend!\<CR>",
+        \             ":stop!\<CR>",
+        \             "\<C-Z>"]
+    " Suspend and wait for shell prompt '$ '.
+    call term_sendkeys(buf, suspend_cmd)
+    call WaitForAssert({-> assert_equal('$ ', term_getline(buf, '.'))})
+
+    " Without 'autowrite', buffer should not be written.
+    call assert_equal(0, filereadable('Xfoo'))
+
+    call term_sendkeys(buf, "fg\<CR>")
+    call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
+  endfor
+
+  " Test that :suspend! with 'autowrite' writes content of buffers if modified.
+  call term_sendkeys(buf, ":set autowrite\<CR>")
+  call assert_equal(0, filereadable('Xfoo'))
+  call term_sendkeys(buf, ":suspend\<CR>")
+  " Wait for shell prompt '$ '.
+  call WaitForAssert({-> assert_equal('$ ', term_getline(buf, '.'))})
+  call assert_equal(['foo'], readfile('Xfoo'))
+  call term_sendkeys(buf, "fg\<CR>")
+  call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
+
+  exe buf . 'bwipe!'
+  call delete('Xfoo')
+  set autowrite&
+endfunc

--- a/src/testdir/test_suspend.vim
+++ b/src/testdir/test_suspend.vim
@@ -9,7 +9,7 @@ func Test_suspend()
 
   let buf = term_start('/bin/sh')
   " Wait for shell prompt.
-  call WaitForAssert({-> assert_match('.*$ $', term_getline(buf, '.'))})
+  call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
 
   call term_sendkeys(buf, v:progpath
         \               . " --clean -X"
@@ -26,7 +26,7 @@ func Test_suspend()
         \             "\<C-Z>"]
     " Suspend and wait for shell prompt.
     call term_sendkeys(buf, suspend_cmd)
-    call WaitForAssert({-> assert_match('.*$ $', term_getline(buf, '.'))})
+    call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
 
     " Without 'autowrite', buffer should not be written.
     call assert_equal(0, filereadable('Xfoo'))
@@ -40,7 +40,7 @@ func Test_suspend()
   call assert_equal(0, filereadable('Xfoo'))
   call term_sendkeys(buf, ":suspend\<CR>")
   " Wait for shell prompt.
-  call WaitForAssert({-> assert_match('.*$ $', term_getline(buf, '.'))})
+  call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
   call assert_equal(['foo'], readfile('Xfoo'))
   call term_sendkeys(buf, "fg\<CR>")
   call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})

--- a/src/testdir/test_suspend.vim
+++ b/src/testdir/test_suspend.vim
@@ -8,8 +8,8 @@ func Test_suspend()
   endif
 
   let buf = term_start('/bin/sh')
-  " Wait for shell prompt '$ '.
-  call WaitForAssert({-> assert_equal('$ ', term_getline(buf, '.'))})
+  " Wait for shell prompt.
+  call WaitForAssert({-> assert_match('.*$ $', term_getline(buf, '.'))})
 
   call term_sendkeys(buf, v:progpath
         \               . " --clean -X"
@@ -24,9 +24,9 @@ func Test_suspend()
         \             ":suspend!\<CR>",
         \             ":stop!\<CR>",
         \             "\<C-Z>"]
-    " Suspend and wait for shell prompt '$ '.
+    " Suspend and wait for shell prompt.
     call term_sendkeys(buf, suspend_cmd)
-    call WaitForAssert({-> assert_equal('$ ', term_getline(buf, '.'))})
+    call WaitForAssert({-> assert_match('.*$ $', term_getline(buf, '.'))})
 
     " Without 'autowrite', buffer should not be written.
     call assert_equal(0, filereadable('Xfoo'))
@@ -39,8 +39,8 @@ func Test_suspend()
   call term_sendkeys(buf, ":set autowrite\<CR>")
   call assert_equal(0, filereadable('Xfoo'))
   call term_sendkeys(buf, ":suspend\<CR>")
-  " Wait for shell prompt '$ '.
-  call WaitForAssert({-> assert_equal('$ ', term_getline(buf, '.'))})
+  " Wait for shell prompt.
+  call WaitForAssert({-> assert_match('.*$ $', term_getline(buf, '.'))})
   call assert_equal(['foo'], readfile('Xfoo'))
   call term_sendkeys(buf, "fg\<CR>")
   call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})


### PR DESCRIPTION
This PR adds a test for the `:suspend` command.
It was not yet tested according to codcov:

https://codecov.io/gh/vim/vim/src/7ff8a3cfb6b029f9af1fdf3890e1320cafce5111/src/os_unix.c#L1350