### PR TITLE
Add test for shellslash with :lcd (8.1.0343)

### DIFF
--- a/src/testdir/test_getcwd.vim
+++ b/src/testdir/test_getcwd.vim
@@ -98,3 +98,15 @@ function Test_GetCwd()
 	call assert_equal("z Xdir3 1", GetCwdInfo(1, tp_nr))
 	call assert_equal(g:topdir, getcwd(-1))
 endfunc
+
+function Test_GetCwd_lcd_shellslash()
+	new
+	let root = fnamemodify('/', ':p')
+	exe 'lcd '.root
+	let cwd = getcwd()
+	if !exists('+shellslash') || &shellslash
+		call assert_equal(cwd[-1:], '/')
+	else
+		call assert_equal(cwd[-1:], '\')
+	endif
+endfunc


### PR DESCRIPTION
Tested to fail without the patch in https://ci.appveyor.com/project/blueyed/vim/build/2.