### PR TITLE
FORTIFY_SOURCE=2 enablement - rewritten flexible array member mechanism

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -14779,16 +14779,6 @@ $as_echo "yes" >&6; }
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
   fi
-          { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need -D_FORTIFY_SOURCE=1" >&5
-$as_echo_n "checking whether we need -D_FORTIFY_SOURCE=1... " >&6; }
-  if test "$gccmajor" -gt "3"; then
-    CFLAGS=`echo "$CFLAGS" | sed -e 's/ *-Wp,-D_FORTIFY_SOURCE=.//g' -e 's/ *-D_FORTIFY_SOURCE=.//g' -e 's/ *-U_FORTIFY_SOURCE//g' -e 's/$/ -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1/'`
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-  else
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-  fi
 fi
 
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4411,17 +4411,6 @@ if test "$GCC" = yes; then
   else
     AC_MSG_RESULT(no)
   fi
-  dnl -D_FORTIFY_SOURCE=2 crashes Vim on strcpy(buf, "000") when buf is
-  dnl declared as char x[1] but actually longer.  Introduced in gcc 4.0.
-  dnl Also remove duplicate _FORTIFY_SOURCE arguments.
-  dnl And undefine it first to avoid a warning.
-  AC_MSG_CHECKING(whether we need -D_FORTIFY_SOURCE=1)
-  if test "$gccmajor" -gt "3"; then
-    CFLAGS=`echo "$CFLAGS" | sed -e 's/ *-Wp,-D_FORTIFY_SOURCE=.//g' -e 's/ *-D_FORTIFY_SOURCE=.//g' -e 's/ *-U_FORTIFY_SOURCE//g' -e 's/$/ -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1/'`
-    AC_MSG_RESULT(yes)
-  else
-    AC_MSG_RESULT(no)
-  fi
 fi
 AC_SUBST(DEPEND_CFLAGS_FILTER)
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -1391,11 +1391,7 @@ struct funccall_S
     ufunc_T	*func;		/* function being called */
     int		linenr;		/* next line to be executed */
     int		returned;	/* ":return" used */
-    struct			/* fixed variables for arguments */
-    {
-	dictitem_T	var;		/* variable (without room for name) */
-	char_u	room[VAR_SHORT_LEN];	/* room for the name */
-    } fixvar[FIXVAR_CNT];
+    dictitem_T * fixvar[FIXVAR_CNT]; /* fixed variables for arguments */
     dict_T	l_vars;		/* l: local function variables */
     dictitem_T	l_vars_var;	/* variable for l: scope */
     dict_T	l_avars;	/* a: argument variables */

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -598,6 +598,16 @@ free_funccal(
     listitem_T	*li;
     int		i;
 
+    int item_index = 0;
+    dictitem_T * item = fc->fixvar[i];
+
+    while(item != NULL && item_index < FIXVAR_CNT)
+    {
+        dictitem_free(item);
+	item_index++;
+        item = fc->fixvar[item_index];
+    }
+
     for (i = 0; i < fc->fc_funcs.ga_len; ++i)
     {
 	ufunc_T	    *fp = ((ufunc_T **)(fc->fc_funcs.ga_data))[i];
@@ -635,16 +645,6 @@ free_funccal(
 cleanup_function_call(funccall_T *fc)
 {
     current_funccal = fc->caller;
-
-    int i = 0;
-    dictitem_T * item = fc->fixvar[i];
-
-    while(item != NULL && i < FIXVAR_CNT)
-    {
-        dictitem_free(item);
-	i++;
-        item = fc->fixvar[i];
-    }
 
     /* If the a:000 list and the l: and a: dicts are not referenced and there
      * is no closure using it, we can free the funccall_T and what's in it. */

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -599,7 +599,7 @@ free_funccal(
     int		i;
 
     int item_index = 0;
-    dictitem_T * item = fc->fixvar[i];
+    dictitem_T * item = fc->fixvar[item_index];
 
     while(item != NULL && item_index < FIXVAR_CNT)
     {


### PR DESCRIPTION
Hi,
I was trying to compile Vim with -D_FORTIFY_SOURCE=2, but I found out it is removed during configure because of intended buffer overflow in userfunc.c with flexible array member mechanism. 
This buffer overflow happens program uses  structure of funccall_T type, where is fixvar structure, which contains dictitem_T element and char_u array named 'room' - dictitemT structure has char di_key[1], which is used for name of variable. 
When Vim tries to create new vim variable in call_user_func(), then puts a name of variable to di_key, and intentionally takes advantage of buffer overflow to 'room' array, which is never used.
According runtime/doc/develop.txt flexible array member mechanism shouldn't be used because of issues across compilers, so I rewrote it to use dynamic allocation instead of flexible array member mechanism. Would you mind checking the patch and adding it to the project?