### PR TITLE
Fix executable() on windows

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3535,10 +3535,8 @@ mch_can_exe(char_u *name, char_u **path, int use_path)
     if (len >= _MAX_PATH)	/* safety check */
 	return FALSE;
 
-    /* If there already is an extension try using the name directly.  Also do
-     * this with a Unix-shell like 'shell'. */
-    if (vim_strchr(gettail(name), '.') != NULL
-			       || strstr((char *)gettail(p_sh), "sh") != NULL)
+    /* Ty using the name directly when a Unix-shell like 'shell'. */
+    if (strstr((char *)gettail(p_sh), "sh") != NULL)
 	if (executable_exists((char *)name, path, use_path))
 	    return TRUE;
 

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -12,6 +12,7 @@ source test_cursor_func.vim
 source test_delete.vim
 source test_ex_undo.vim
 source test_ex_z.vim
+source test_executable.vim
 source test_execute_func.vim
 source test_expand.vim
 source test_expand_dllpath.vim

--- a/src/testdir/test_executable.vim
+++ b/src/testdir/test_executable.vim
@@ -1,0 +1,15 @@
+" Tests for executable()
+
+function! Test_Executable()
+  if has('win32')
+    call assert_equal(1, executable('notepad'))
+    call assert_equal(1, executable('notepad.exe'))
+    call assert_equal(0, executable('notepad.exe.exe'))
+    call assert_equal(0, executable('shell32.dll'))
+    call assert_equal(0, executable('win.ini'))
+  elseif has('unix')
+    call assert_equal(1, executable('cat'))
+    call assert_equal(0, executable('dog'))
+  endif
+endfunction
+


### PR DESCRIPTION
Current implementation of executable() return 1 even though it is not an executable. On Windows, executable command must have suffix that contains in PATHEXT. But current implementation check...

* If it have file extension and the name exists in curdir or PATH.
* If the filename with appending suffixes exists in curdir or PATH.

So `executable('shell32.dll')` or `executable('win.ini')` return 1.
