### PR TITLE
resolve() was not tested with a symlink cycle

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -225,6 +225,11 @@ func Test_resolve()
   call assert_equal('Xdir/Xfile', resolve('Xlink'))
   call delete('Xlink')
 
+  silent !ln -s -f Xlink2/ Xlink1
+  call assert_equal('Xlink2', resolve('Xlink1'))
+  call assert_equal('Xlink2/', resolve('Xlink1/'))
+  call delete('Xlink1')
+
   silent !ln -s -f ./Xlink2 Xlink1
   call assert_equal('Xlink2', resolve('Xlink1'))
   call assert_equal('./Xlink2', resolve('./Xlink1'))

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -190,6 +190,38 @@ func Test_strftime()
   call assert_fails('call strftime("%Y", [])', 'E745:')
 endfunc
 
+func Test_resolve()
+  if !has('unix')
+    return
+  endif
+
+  " Xlink1 -> Xlink2
+  " Xlink2 -> Xlink3
+  silent !ln -s -f Xlink2 Xlink1
+  silent !ln -s -f Xlink3 Xlink2
+  call assert_equal('Xlink3', resolve('Xlink1'))
+  call assert_equal('./Xlink3', resolve('./Xlink1'))
+  " FIXME: these tests result in things like "Xlink2/" instead of "Xlink3/"?!
+  "call assert_equal('Xlink3/', resolve('Xlink1/'))
+  "call assert_equal('./Xlink3/', resolve('./Xlink1/'))
+  "call assert_equal(getcwd() . '/Xlink3/', resolve(getcwd() . '/Xlink1/'))
+  call assert_equal(getcwd() . '/Xlink3', resolve(getcwd() . '/Xlink1'))
+
+  " Test resolve() with a symlink cycle.
+  " Xlink1 -> Xlink2
+  " Xlink2 -> Xlink3
+  " Xlink3 -> Xlink1
+  silent !ln -s -f Xlink1 Xlink3
+  call assert_fails('call resolve("Xlink1")',   'E655:')
+  call assert_fails('call resolve("./Xlink1")', 'E655:')
+  call assert_fails('call resolve("Xlink2")',   'E655:')
+  call assert_fails('call resolve("Xlink3")',   'E655:')
+
+  call delete('Xlink1')
+  call delete('Xlink2')
+  call delete('Xlink3')
+endfunc
+
 func Test_simplify()
   call assert_equal('',            simplify(''))
   call assert_equal('/',           simplify('/'))

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -201,6 +201,7 @@ func Test_resolve()
   silent !ln -s -f Xlink3 Xlink2
   call assert_equal('Xlink3', resolve('Xlink1'))
   call assert_equal('./Xlink3', resolve('./Xlink1'))
+  call assert_equal('Xlink3/', resolve('Xlink2/'))
   " FIXME: these tests result in things like "Xlink2/" instead of "Xlink3/"?!
   "call assert_equal('Xlink3/', resolve('Xlink1/'))
   "call assert_equal('./Xlink3/', resolve('./Xlink1/'))
@@ -216,10 +217,18 @@ func Test_resolve()
   call assert_fails('call resolve("./Xlink1")', 'E655:')
   call assert_fails('call resolve("Xlink2")',   'E655:')
   call assert_fails('call resolve("Xlink3")',   'E655:')
-
   call delete('Xlink1')
   call delete('Xlink2')
   call delete('Xlink3')
+
+  silent !ln -s -f Xdir//Xfile Xlink
+  call assert_equal('Xdir/Xfile', resolve('Xlink'))
+  call delete('Xlink')
+
+  silent !ln -s -f ./Xlink2 Xlink1
+  call assert_equal('Xlink2', resolve('Xlink1'))
+  call assert_equal('./Xlink2', resolve('./Xlink1'))
+  call delete('Xlink1')
 endfunc
 
 func Test_simplify()


### PR DESCRIPTION
This PR adds a test for the resolve() function.
In particular, testing with symlink cycle was not covered
with tests according to codcov:

https://codecov.io/gh/vim/vim/src/2bc152ab53c4b01072edf6ec2ff61e504cb03cbe/src/evalfunc.c#L9657

I put some FIXME comments in the test where resolve() does not behave
as I expected.

I'll remove WIP in the title when CI shows enough code coverage.