### PR TITLE
string value for job_start() should not skip backslash

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -6462,12 +6462,14 @@ mch_parse_cmd(char_u *cmd, int use_shcf, char ***argv, int *argc)
 		    inquote = !inquote;
 		else
 		{
+# ifndef _WIN32
 		    if (p[0] == '\\' && p[1] != NUL)
 		    {
 			/* First pass: skip over "\ " and "\"".
 			 * Second pass: Remove the backslash. */
 			++p;
 		    }
+# endif
 		    if (i == 1)
 			*d++ = *p;
 		}

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -6440,7 +6440,7 @@ mch_parse_cmd(char_u *cmd, int use_shcf, char ***argv, int *argc)
     int		inquote;
     int		use_escape = TRUE;
 
-# ifndef _WIN32
+# ifdef _WIN32
     use_escape = strstr((char *)gettail(p_sh), "sh") != NULL;
 # endif
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -6438,6 +6438,11 @@ mch_parse_cmd(char_u *cmd, int use_shcf, char ***argv, int *argc)
     int		i;
     char_u	*p, *d;
     int		inquote;
+    int		use_escape = TRUE;
+
+# ifndef _WIN32
+    use_escape = strstr((char *)gettail(p_sh), "sh") != NULL;
+# endif
 
     /*
      * Do this loop twice:
@@ -6462,14 +6467,12 @@ mch_parse_cmd(char_u *cmd, int use_shcf, char ***argv, int *argc)
 		    inquote = !inquote;
 		else
 		{
-# ifndef _WIN32
-		    if (p[0] == '\\' && p[1] != NUL)
+		    if (use_escape && p[0] == '\\' && p[1] != NUL)
 		    {
 			/* First pass: skip over "\ " and "\"".
 			 * Second pass: Remove the backslash. */
 			++p;
 		    }
-# endif
 		    if (i == 1)
 			*d++ = *p;
 		}

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1728,7 +1728,7 @@ func Test_job_start_windows()
 
   let g:echostr = ''
   let cmd = $COMSPEC . ' /c echo 1'
-  call assert_fails('call job_start(cmd, {"env": 1})', 'E475:')
+  call assert_fails('call job_start(cmd)', 'E475:')
   call job_start(cmd, {'callback': {ch,msg -> execute(":let g:echostr .= msg")}})
   call WaitForAssert({-> assert_equal("1", g:echostr)})
   unlet g:echostr

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1728,7 +1728,6 @@ func Test_job_start_windows()
 
   let g:echostr = ''
   let cmd = $COMSPEC . ' /c echo 1'
-  call assert_fails('call job_start(cmd)', 'E475:')
   call job_start(cmd, {'callback': {ch,msg -> execute(":let g:echostr .= msg")}})
   call WaitForAssert({-> assert_equal("1", g:echostr)})
   unlet g:echostr

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1721,6 +1721,19 @@ func Test_read_from_terminated_job()
   call WaitForAssert({-> assert_equal(1, g:linecount)})
 endfunc
 
+func Test_job_start_windows()
+  if !has('job') || !has('win32')
+    return
+  endif
+
+  let g:echostr = ''
+  let cmd = $COMSPEC . ' /c echo 1'
+  call assert_fails('call job_start(cmd, {"env": 1})', 'E475:')
+  call job_start(cmd, {'callback': {ch,msg -> execute(":let g:echostr .= msg")}})
+  call WaitForAssert({-> assert_equal("1", g:echostr)})
+  unlet g:echostr
+endfunction
+
 func Test_env()
   if !has('job')
     return

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1728,9 +1728,11 @@ func Test_job_start_windows()
 
   let g:echostr = ''
   let cmd = $COMSPEC . ' /c echo 1'
-  call job_start(cmd, {'callback': {ch,msg -> execute(":let g:echostr .= msg")}})
+  let job = job_start(cmd, {'callback': {ch,msg -> execute(":let g:echostr .= msg")}})
   call WaitForAssert({-> assert_equal("1", g:echostr)})
   unlet g:echostr
+  let info = job_info(job)
+  call assert_equal([$COMSPEC, '/c', 'echo', '1'], info.cmd)
 endfunction
 
 func Test_env()


### PR DESCRIPTION
fixes https://github.com/vim/vim/issues/3404

When calling job_start(str), the str is parsed to argc/argv. On UNIX, backslash is treated as escaped character. But on Windows, backslash must NOT be treated as it.