### PR TITLE
flush typebuf after display attensions to clear queued messages.

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -4519,6 +4519,9 @@ findswapname(
 			/* We don't want a 'q' typed at the more-prompt
 			 * interrupt loading a file. */
 			got_int = FALSE;
+
+			/* flush all typeahead */
+			flush_buffers(TRUE);
 		    }
 
 #if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG)


### PR DESCRIPTION
#2192 occured on Windows GUI but possibly occured on another platforms. when attension message are displayed for swap file, remaining typebuf will not be removed in main loop. So need to type CTRL-C to break hang.