### PR TITLE
Convert tempfile name from active codepage to UTF-8 since mch_call_shell

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -7578,6 +7578,22 @@ vim_tempname(
 	for (p = retval; *p; ++p)
 	    if (*p == '\\')
 		*p = '/';
+
+
+#if defined(FEAT_MBYTE) && defined(WIN3264)
+    if (enc_utf8)
+    {
+	int	len;
+	char_u  *pp = NULL;
+
+	/* Convert from active codepage to UTF-8 since mch_call_shell
+	 * convert command-line to wide string from encoding. */
+	acp_to_enc(retval, (int)STRLEN(retval), &pp, &len);
+	if (pp != NULL)
+	    return pp;
+    }
+#endif
+
     return retval;
 
 # else /* WIN3264 */

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -11392,6 +11392,23 @@ get_cmd_output(
 	return NULL;
     }
 
+#if defined(FEAT_MBYTE) && defined(WIN3264)
+    if (enc_utf8)
+    {
+	int	len;
+	char_u  *pp = NULL;
+
+	/* Convert from active codepage to UTF-8 since mch_call_shell
+	 * convert command-line to wide string from encoding. */
+	acp_to_enc(tempname, (int)STRLEN(tempname), &pp, &len);
+	if (pp != NULL)
+	{
+	    vim_free(tempname);
+	    tempname = pp;
+	}
+    }
+#endif
+
     /* Add the redirection stuff */
     command = make_filter_cmd(cmd, infile, tempname);
     if (command == NULL)

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -11392,23 +11392,6 @@ get_cmd_output(
 	return NULL;
     }
 
-#if defined(FEAT_MBYTE) && defined(WIN3264)
-    if (enc_utf8)
-    {
-	int	len;
-	char_u  *pp = NULL;
-
-	/* Convert from active codepage to UTF-8 since mch_call_shell
-	 * convert command-line to wide string from encoding. */
-	acp_to_enc(tempname, (int)STRLEN(tempname), &pp, &len);
-	if (pp != NULL)
-	{
-	    vim_free(tempname);
-	    tempname = pp;
-	}
-    }
-#endif
-
     /* Add the redirection stuff */
     command = make_filter_cmd(cmd, infile, tempname);
     if (command == NULL)


### PR DESCRIPTION
fix #1698

When encoding=utf-8, system() make filter-command like below.
```
cmd /c (my-command) > c:\path\to\temp\VIFOO.tmp
```

But the tempfile name is encoded to system encoding. (not utf-8)
So convert tempfile name from active codepage to utf-8.

@k-takata Could you please review this?