### PR TITLE
win32: Update dosinst.c

### DIFF
--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -1192,7 +1192,9 @@ install_vimrc(int idx)
 	/* Use the diff.exe that comes with the self-extracting gvim.exe. */
 	fclose(tfd);
 	fprintf(fd, "\n");
-	fprintf(fd, "set diffexpr=MyDiff()\n");
+	fprintf(fd, "if &diffopt !~# 'internal'\n");
+	fprintf(fd, "  set diffexpr=MyDiff()\n");
+	fprintf(fd, "endif\n");
 	fprintf(fd, "function MyDiff()\n");
 	fprintf(fd, "  let opt = '-a --binary '\n");
 	fprintf(fd, "  if &diffopt =~ 'icase' | let opt = opt . '-i ' | endif\n");

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -18,6 +18,7 @@
  */
 #define DOSINST
 #include "dosinst.h"
+#include <io.h>
 
 #define GVIMEXT64_PATH	    "GvimExt64\\gvimext.dll"
 #define GVIMEXT32_PATH	    "GvimExt32\\gvimext.dll"
@@ -569,7 +570,6 @@ uninstall_check(int skip_question)
 			sleep(1);  /* wait for uninstaller to start up */
 			num_windows = 0;
 			EnumWindows(window_cb, 0);
-			sleep(1);  /* wait for windows to be counted */
 			if (num_windows == 0)
 			{
 			    /* Did not find the uninstaller, ask user to press
@@ -585,9 +585,9 @@ uninstall_check(int skip_question)
 			    {
 				printf(".");
 				fflush(stdout);
+				sleep(1);  /* wait for the uninstaller to finish */
 				num_windows = 0;
 				EnumWindows(window_cb, 0);
-				sleep(1);  /* wait for windows to be counted */
 			    } while (num_windows > 0);
 			}
 			printf("\nDone!\n");
@@ -2589,7 +2589,7 @@ main(int argc, char **argv)
 
 	/* When nothing found exit quietly.  If something found wait for
 	 * a little while, so that the user can read the messages. */
-	if (i)
+	if (i && _isatty(1))
 	    sleep(3);
 	exit(0);
     }

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -63,6 +63,7 @@ int		choice_count = 0;	/* number of choices available */
 enum
 {
     compat_vi = 1,
+    compat_vim,
     compat_some_enhancements,
     compat_all_enhancements
 };
@@ -70,6 +71,7 @@ char	*(compat_choices[]) =
 {
     "\nChoose the default way to run Vim:",
     "Vi compatible",
+    "Vim default",
     "with some Vim enhancements",
     "with syntax highlighting and other features switched on",
 };
@@ -1161,6 +1163,11 @@ install_vimrc(int idx)
 	case compat_vi:
 		    fprintf(fd, "set compatible\n");
 		    break;
+	case compat_vim:
+		    fprintf(fd, "if &compatible\n");
+		    fprintf(fd, "  set nocompatible\n");
+		    fprintf(fd, "endif\n");
+		    break;
 	case compat_some_enhancements:
 		    fprintf(fd, "source $VIMRUNTIME/defaults.vim\n");
 		    break;
@@ -2239,6 +2246,8 @@ print_cmd_line_help(void)
     printf("    Remap keys when creating a default _vimrc file.\n");
     printf("-vimrc-behave [unix|mswin|default]\n");
     printf("    Set mouse behavior when creating a default _vimrc file.\n");
+    printf("-vimrc-compat [vi|vim|defaults|all]\n");
+    printf("    Set Vi compatibility when creating a default _vimrc file.\n");
     printf("-install-popup\n");
     printf("    Install the Edit-with-Vim context menu entry\n");
     printf("-install-openwith\n");
@@ -2315,6 +2324,20 @@ command_line_setup_choices(int argc, char **argv)
 		mouse_choice = mouse_mswin;
 	    else if (strcmp(argv[i], "default") == 0)
 		mouse_choice = mouse_default;
+	}
+	else if (strcmp(argv[i], "-vimrc-compat") == 0)
+	{
+	    if (i + 1 == argc)
+		break;
+	    i++;
+	    if (strcmp(argv[i], "vi") == 0)
+		compat_choice = compat_vi;
+	    else if (strcmp(argv[i], "vim") == 0)
+		compat_choice = compat_vim;
+	    else if (strcmp(argv[i], "defaults") == 0)
+		compat_choice = compat_some_enhancements;
+	    else if (strcmp(argv[i], "all") == 0)
+		compat_choice = compat_all_enhancements;
 	}
 	else if (strcmp(argv[i], "-install-popup") == 0)
 	{

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -1491,7 +1491,10 @@ register_uninstall(
     HKEY hRootKey,
     const char *appname,
     const char *display_name,
-    const char *uninstall_string)
+    const char *uninstall_string,
+    const char *display_icon,
+    const char *display_version,
+    const char *publisher)
 {
     LONG lRet = reg_create_key_and_value(hRootKey, appname,
 			     "DisplayName", display_name, KEY_WOW64_64KEY);
@@ -1499,6 +1502,15 @@ register_uninstall(
     if (ERROR_SUCCESS == lRet)
 	lRet = reg_create_key_and_value(hRootKey, appname,
 		     "UninstallString", uninstall_string, KEY_WOW64_64KEY);
+    if (ERROR_SUCCESS == lRet)
+	lRet = reg_create_key_and_value(hRootKey, appname,
+		     "DisplayIcon", display_icon, KEY_WOW64_64KEY);
+    if (ERROR_SUCCESS == lRet)
+	lRet = reg_create_key_and_value(hRootKey, appname,
+		     "DisplayVersion", display_version, KEY_WOW64_64KEY);
+    if (ERROR_SUCCESS == lRet)
+	lRet = reg_create_key_and_value(hRootKey, appname,
+		     "Publisher", publisher, KEY_WOW64_64KEY);
     return lRet;
 }
 
@@ -1519,6 +1531,7 @@ install_registry(void)
     char	vim_exe_path[BUFSIZE];
     char	display_name[BUFSIZE];
     char	uninstall_string[BUFSIZE];
+    char	icon_string[BUFSIZE];
     int		i;
     int		loop_count = is_64bit_os() ? 2 : 1;
     DWORD	flag;
@@ -1583,11 +1596,16 @@ install_registry(void)
     else
 	sprintf(uninstall_string, "%s\\uninstall-gui.exe", installdir);
 
+    sprintf(icon_string, "%s\\gvim.exe,0", installdir);
+
     lRet = register_uninstall(
 	HKEY_LOCAL_MACHINE,
 	"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Vim " VIM_VERSION_SHORT,
 	display_name,
-	uninstall_string);
+	uninstall_string,
+	icon_string,
+	VIM_VERSION_SHORT,
+	"Bram Moolenaar et al.");
     if (ERROR_SUCCESS != lRet)
 	return FAIL;
 

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -1161,17 +1161,21 @@ install_vimrc(int idx)
     switch (compat_choice)
     {
 	case compat_vi:
+		    fprintf(fd, "\" Vi compatible\n");
 		    fprintf(fd, "set compatible\n");
 		    break;
 	case compat_vim:
+		    fprintf(fd, "\" Vim's default behavior\n");
 		    fprintf(fd, "if &compatible\n");
 		    fprintf(fd, "  set nocompatible\n");
 		    fprintf(fd, "endif\n");
 		    break;
 	case compat_some_enhancements:
+		    fprintf(fd, "\" Vim with some enhancements\n");
 		    fprintf(fd, "source $VIMRUNTIME/defaults.vim\n");
 		    break;
 	case compat_all_enhancements:
+		    fprintf(fd, "\" Vim with all enhancements\n");
 		    fprintf(fd, "source $VIMRUNTIME/vimrc_example.vim\n");
 		    break;
     }
@@ -1180,15 +1184,21 @@ install_vimrc(int idx)
 	case remap_no:
 		    break;
 	case remap_win:
+		    fprintf(fd, "\n");
+		    fprintf(fd, "\" Remap a few keys for Windows behavior\n");
 		    fprintf(fd, "source $VIMRUNTIME/mswin.vim\n");
 		    break;
     }
     switch (mouse_choice)
     {
 	case mouse_xterm:
+		    fprintf(fd, "\n");
+		    fprintf(fd, "\" Mouse behavior (the Unix way)\n");
 		    fprintf(fd, "behave xterm\n");
 		    break;
 	case mouse_mswin:
+		    fprintf(fd, "\n");
+		    fprintf(fd, "\" Mouse behavior (the Windows way)\n");
 		    fprintf(fd, "behave mswin\n");
 		    break;
 	case mouse_default:
@@ -1199,6 +1209,8 @@ install_vimrc(int idx)
 	/* Use the diff.exe that comes with the self-extracting gvim.exe. */
 	fclose(tfd);
 	fprintf(fd, "\n");
+	fprintf(fd, "\" Use the internal diff if available.\n");
+	fprintf(fd, "\" Otherwise use the special 'diffexpr' for Windows.\n");
 	fprintf(fd, "if &diffopt !~# 'internal'\n");
 	fprintf(fd, "  set diffexpr=MyDiff()\n");
 	fprintf(fd, "endif\n");


### PR DESCRIPTION
As I mentioned in #3485 and #3501, there are some issues in dosinst.c.
@brammool I don't think you are going to merge #3501 soon, but how about only merging dosinst.c part soon?
This PR extracts only dosinst.c changes from #3501 (by using `git cherry-pick`).

This PR includes 5 commits. (If you really needed, you can merge only some of them.)

1. Fixes #3485. Register DisplayIcon, DisplayVersion and Publisher for the uninstaller's information.
  https://github.com/vim/vim/commit/77bce1333d0b9ea0520c45fdb6ef316ea1d0feaa.patch
2. Don't set `'diffexpr'` in the default `_vimrc` if the internal diff is supported.
  https://github.com/vim/vim/commit/e69597ae1351b9670905a8e33724aca0aca3ada3.patch
3. Support setting Vi compatibility in the default `_vimrc` from command line.
  https://github.com/vim/vim/commit/2348655cfec4c9f4779ced0f38e3dddc6a9164c7.patch
4. Remove needless sleeps.
  `EnumWindows()` is not an asynchronous function. No need to sleep after the function.
  No need to wait 3 seconds after showing "Done!" when the stdout is not a tty.
  https://github.com/vim/vim/commit/fb743bed597c13d77dd319ae912bdb25a6c5b4d0.patch
5. Add some comments to the default `_vimrc`.
  https://github.com/vim/vim/commit/9ccf759a4157236481c096fa73e9583224f49ed9.patch

(Note: No. 5 depends on No. 2.)