### PR TITLE
Add 'diffbuf' option to only compare with a single buffer for highlighting

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -1872,14 +1872,14 @@ diff_check(win_T *wp, linenr_T lnum)
 	for (i = bufidx_start; i < bufidx_stop; ++i)
 	    if (i != idx && curtab->tp_diffbuf[i] != NULL)
 	    {
-		if (dp->df_count[i] == 0)
-		    zero = TRUE;
-		else
-		{
-		    if (dp->df_count[i] != dp->df_count[idx])
-			return -1;	    /* nr of lines changed. */
-		    cmp = TRUE;
-		}
+	        if (dp->df_count[i] == 0)
+	            zero = TRUE;
+	        else
+	        {
+	            if (dp->df_count[i] != dp->df_count[idx])
+	                return -1;      /* nr of lines changed. */
+	            cmp = TRUE;
+	        }
 	    }
 	if (cmp)
 	{

--- a/src/diff.c
+++ b/src/diff.c
@@ -1830,6 +1830,9 @@ diff_check(win_T *wp, linenr_T lnum)
     int		i;
     buf_T	*buf = wp->w_buffer;
     int		cmp;
+    int     use_dbuf;
+    int     bufidx_start;
+    int     bufidx_stop;
 
     if (curtab->tp_diff_invalid)
 	ex_diffupdate(NULL);		/* update after a big change */
@@ -1866,9 +1869,9 @@ diff_check(win_T *wp, linenr_T lnum)
 	 * zero, the lines were inserted.  If the other buffers have the same
 	 * count, check if the lines are identical. */
 	cmp = FALSE;
-	int use_dbuf = (p_dbuf > 0 && p_dbuf <= DB_COUNT && curtab->tp_diffbuf[p_dbuf-1] != NULL && p_dbuf-1 != idx);
-	int bufidx_start = use_dbuf ? (p_dbuf-1) : 0;
-	int bufidx_stop = use_dbuf ? p_dbuf : DB_COUNT;
+	use_dbuf = (p_dbuf > 0 && p_dbuf <= DB_COUNT && curtab->tp_diffbuf[p_dbuf-1] != NULL && p_dbuf-1 != idx);
+	bufidx_start = use_dbuf ? (p_dbuf-1) : 0;
+	bufidx_stop = use_dbuf ? p_dbuf : DB_COUNT;
 	for (i = bufidx_start; i < bufidx_stop; ++i)
 	    if (i != idx && curtab->tp_diffbuf[i] != NULL)
 	    {

--- a/src/diff.c
+++ b/src/diff.c
@@ -1866,7 +1866,10 @@ diff_check(win_T *wp, linenr_T lnum)
 	 * zero, the lines were inserted.  If the other buffers have the same
 	 * count, check if the lines are identical. */
 	cmp = FALSE;
-	for (i = 0; i < DB_COUNT; ++i)
+	int use_dbuf = (p_dbuf > 0 && p_dbuf <= DB_COUNT && curtab->tp_diffbuf[p_dbuf-1] != NULL && p_dbuf-1 != idx);
+	int bufidx_start = use_dbuf ? (p_dbuf-1) : 0;
+	int bufidx_stop = use_dbuf ? p_dbuf : DB_COUNT;
+	for (i = bufidx_start; i < bufidx_stop; ++i)
 	    if (i != idx && curtab->tp_diffbuf[i] != NULL)
 	    {
 		if (dp->df_count[i] == 0)
@@ -1882,7 +1885,7 @@ diff_check(win_T *wp, linenr_T lnum)
 	{
 	    /* Compare all lines.  If they are equal the lines were inserted
 	     * in some buffers, deleted in others, but not changed. */
-	    for (i = 0; i < DB_COUNT; ++i)
+	    for (i = bufidx_start; i < bufidx_stop; ++i)
 		if (i != idx && curtab->tp_diffbuf[i] != NULL
 						      && dp->df_count[i] != 0)
 		    if (!diff_equal_entry(dp, idx, i))

--- a/src/option.c
+++ b/src/option.c
@@ -1055,6 +1055,14 @@ static struct vimoption options[] =
 			    {(char_u *)"", (char_u *)NULL}
 #endif
 			    SCTX_INIT},
+    {"diffbuf",     "dbuf", P_NUM|P_RALL|P_VI_DEF,
+#ifdef FEAT_DIFF
+			    (char_u *)&p_dbuf, PV_NONE,
+#else
+			    (char_u *)NULL, PV_NONE,
+#endif
+			    {(char_u *)0L, (char_u *)0L}
+			    SCTX_INIT},
     {"digraph",	    "dg",   P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_DIGRAPHS
 			    (char_u *)&p_dg, PV_NONE,

--- a/src/option.h
+++ b/src/option.h
@@ -448,6 +448,7 @@ EXTERN char_u	*p_inc;
 #endif
 #ifdef FEAT_DIFF
 EXTERN char_u	*p_dip;		/* 'diffopt' */
+EXTERN int	p_dbuf;		/* 'diffbuf' */
 # ifdef FEAT_EVAL
 EXTERN char_u	*p_dex;		/* 'diffexpr' */
 # endif

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -174,7 +174,7 @@ endfun
 
 func Test_set_completion()
   call feedkeys(":set di\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"set dictionary diff diffexpr diffopt digraph directory display', @:)
+  call assert_equal('"set dictionary diff diffexpr diffopt diffbuf digraph directory display', @:)
 
   " Expand boolan options. When doing :set no<Tab>
   " vim displays the options names without "no" but completion uses "no...".
@@ -213,7 +213,7 @@ func Test_set_completion()
   call assert_match(' ./samples/.* ./small.vim', @:)
 
   call feedkeys(":set tags=./\\\\ dif\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"set tags=./\\ diff diffexpr diffopt', @:)
+  call assert_equal('"set tags=./\\ diff diffexpr diffopt diffbuf', @:)
 endfunc
 
 func Test_set_errors()


### PR DESCRIPTION
I needed this feature at work today, and it seemed like it would be simple enough to add, so after I got home I decided to give it a shot.

Basically, what this does is add a new option called `diffbuf` (short name `dbuf`) which defaults to 0 (meaning standard behavior) but can also be set to a buffer number. If it's set to a valid buffer number, then instead of highlighting all the lines that any buffer has different, it will only highlight lines that **that specific buffer** has different. That is, for the purpose of highlighting lines, it will be as if the buffer whose lines are to be highlighted and the buffer specified by `diffbuf` are the only buffers open; others won't affect it, beyond adding filler lines if that option is turned on.

Lines *inside* the buffer specified by `diffbuf` will be highlighted as normal.

This is my first contribution to this project—or any project as popular as Vim, for that matter—so please forgive me if I did anything incorrectly.

**EDIT:** I've taken some screenshots to show what the new feature does. Note that **except in the first screenshot, lines 15 and 16 are not representative of intended behavior**; this is a bug that I will explain shortly. So ignore those two lines if you're just trying to understand what this is supposed to do.

![diffbuf=0](https://user-images.githubusercontent.com/687313/46773948-02f8f700-ccce-11e8-9b2d-6e37bbe09178.png)

^ (`diffbuf=0`) This is the standard behavior, the way lines have always been highlighted in diff mode. That is, unless a line is the same in **every** diff buffer that's open, that line will show up as highlighted in **all** of the buffers. Notice how every line that differs in even one window is highlighted across the board. Zero is the default value of `diffbuf`, so the default behavior will not change.

![diffbuf=1](https://user-images.githubusercontent.com/687313/46773955-0a200500-ccce-11e8-806e-b9ba357aeda4.png)

^ (`diffbuf=1`) With `diffbuf` set to 1, however, it will only highlight differences with buffer 1. (The exception is buffer 1 itself, which is highlighted like before.) Line 5 is still highlighted in all rows because both of the other buffers have something different there. But line 10 is not highlighted in buffer 2, because there is no difference when it only compares against buffer 1. Buffer 3 says something different, and it's highlighted there, but with `diffbuf` set to anything but 0 (compare against all buffers) or 3 (compare against buffer 3) that doesn't matter. In other words, buffer 1 is the "master buffer", and if you're looking at any other buffer, it's only the master buffer that needs to be considered. **Remember, ignore lines 15 and 16 here. They aren't supposed to be like that.**

![diffbuf=2](https://user-images.githubusercontent.com/687313/46775686-3ccdfb80-ccd6-11e8-971e-fa584340f9d0.png)

^ (`diffbuf=2`) Here it is comparing against buffer 2 instead. Now buffer 2 is the one that's highlighted normally, and the other buffers are only highlighted if that line differs from buffer 2.

![diffbuf=3](https://user-images.githubusercontent.com/687313/46775708-58390680-ccd6-11e8-888a-d4d97917871e.png)

^ (`diffbuf=3`) Here's 3, not much more to say really.

## Known Issue

As you can see, this currently doesn't work properly with consecutive lines. Look at the third image, where `diffbuf` is 2, for instance. Lines 15 and 16 each differ from the middle buffer on one side, but not the other, but 16 differs on the left and 15 differs on the right. The proper behavior here would be to have line 15 only highlighted on the middle and right buffers, and line 16 only on the middle and left. But for some reason, it's treating consecutive lines like a block, and isn't highlighting only the ones that actually differ. If I were to `set nodiff` in the buffer on the right, line 15 will no longer be highlighted.

With the code working properly, however, changing something in a buffer other than the master one will not affect the appearance of any other buffers, beyond adding filler lines if necessary to keep everything together.