### PR TITLE
Recognise Sieve scripts with ‘.sieve’ file extension

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1414,8 +1414,8 @@ au BufNewFile,BufRead *.sdl,*.pr		setf sdl
 " sed
 au BufNewFile,BufRead *.sed			setf sed
 
-" Sieve (RFC 3028)
-au BufNewFile,BufRead *.siv			setf sieve
+" Sieve (RFC 5228)
+au BufNewFile,BufRead *.siv,*.sieve		setf sieve
 
 " Sendmail
 au BufNewFile,BufRead sendmail.cf		setf sm


### PR DESCRIPTION
Vim recognises files ending in `.siv` as Sieve scripts. However, the
Sieve RFC has been updated (replaced actually), and now both `.siv` and
`.sieve` are acceptable file extensions. See RFC 5228,
https://tools.ietf.org/html/rfc5228.html#section-7.

This change modifies `filetype.vim` to detect Sieve scripts ending in
`.sieve`.
