### PR TITLE
win32: Fix some tests on Windows

### DIFF
--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -49,7 +49,7 @@ endfunc
 " Read the port number from the Xportnr file.
 func GetPort()
   let l = []
-  for i in range(200)
+  for i in range(400)
     try
       let l = readfile("Xportnr")
     catch

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1340,7 +1340,7 @@ func Test_close_and_exit_cb()
     let self.ret['exit_cb'] = job_status(a:job)
   endfunc
 
-  let g:job = job_start('echo', {
+  let g:job = job_start(has('win32') ? 'cmd /c echo:' : 'echo', {
         \ 'close_cb': g:retdict.close_cb,
         \ 'exit_cb': g:retdict.exit_cb,
         \ })
@@ -1369,7 +1369,8 @@ func Test_exit_cb_wipes_buf()
   new
   let g:wipe_buf = bufnr('')
 
-  let job = job_start(['true'], {'exit_cb': 'ExitCbWipe'})
+  let job = job_start(has('win32') ? 'cmd /c echo:' : ['true'],
+			  \ {'exit_cb': 'ExitCbWipe'})
   let timer = timer_start(300, {-> feedkeys("\<Esc>", 'nt')}, {'repeat': 5})
   call feedkeys(repeat('g', 1000) . 'o', 'ntx!')
   call WaitForAssert({-> assert_equal("dead", job_status(job))})


### PR DESCRIPTION
* Windows doesn't have the 'echo' and 'true' commands without Cygwin/MSYS2.
  Use 'cmd /c echo:' for a command just do nothing.
* On AppVeyor, sometimes fail to start test_channel.py.
  E.g. https://ci.appveyor.com/project/chrisbra/vim-win32-installer/builds/19446847/job/77vobc2osadmlhho#L3844
  Wait a bit longer.