### PR TITLE
Make 'scrolloff' and 'sidescrolloff' window global-local

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6571,7 +6571,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'scrolloff'* *'so'*
 'scrolloff' 'so'	number	(default 0, set to 5 in |defaults.vim|)
-			global
+			global or local to window |global-local|
 			{not in Vi}
 	Minimal number of screen lines to keep above and below the cursor.
 	This will make some context visible around where you are working.  If
@@ -7133,7 +7133,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'sidescrolloff'* *'siso'*
 'sidescrolloff' 'siso'	number (default 0)
-			global
+			global or local to window |global-local|
 			{not in Vi}
 	The minimal number of screen columns to keep to the left and to the
 	right of the cursor if 'nowrap' is set.  Setting this option to a

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -319,8 +319,6 @@ behave strangely, as if there is a gap and a vertical window separator.
 Make {skip} argument of searchpair() consistent with other places where we
 pass an expression to evaluate.  Allow passing zero for "never skip".
 
-The 'scrolloff' option is global, make it global-local. #3195
-
 Add an option similar to 'lazyredraw' to skip redrawing while executing a
 script or function.
 
@@ -5574,9 +5572,6 @@ Options:
     that marks if the option was set.  Useful to keep the effect of setting
     'compatible' after ":syntax on" has been used.
 7   There is 'titleold', why is there no 'iconold'? (Chazelas)
-7   Make 'scrolloff' a global-local option, so that it can be different in the
-    quickfix window, for example. (Gary Holloway)
-    Also do 'sidescrolloff'.
 
 
 External commands:

--- a/src/edit.c
+++ b/src/edit.c
@@ -345,6 +345,7 @@ edit(
 #ifdef FEAT_JOB_CHANNEL
     int		cmdchar_todo = cmdchar;
 #endif
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
 
     /* Remember whether editing was restarted after CTRL-O. */
     did_restart_edit = restart_edit;
@@ -735,7 +736,7 @@ edit(
 		(int)curwin->w_wcol < mincol - curbuf->b_p_ts
 #endif
 		    && curwin->w_wrow == W_WINROW(curwin)
-						 + curwin->w_height - 1 - p_so
+						 + curwin->w_height - 1 - *so
 		    && (curwin->w_cursor.lnum != curwin->w_topline
 #ifdef FEAT_DIFF
 			|| curwin->w_topfill > 0

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3800,6 +3800,7 @@ do_ecmd(
 #endif
     int		readfile_flags = 0;
     int		did_inc_redrawing_disabled = FALSE;
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
 
     if (eap != NULL)
 	command = eap->do_ecmd_cmd;
@@ -4414,12 +4415,12 @@ do_ecmd(
     did_inc_redrawing_disabled = FALSE;
     if (!skip_redraw)
     {
-	n = p_so;
+	n = *so;
 	if (topline == 0 && command == NULL)
-	    p_so = 999;			/* force cursor halfway the window */
+	    *so = 999;			/* force cursor halfway the window */
 	update_topline();
 	curwin->w_scbind_pos = curwin->w_topline;
-	p_so = n;
+	*so = n;
 	redraw_curbuf_later(NOT_VALID);	/* redraw this buffer later */
     }
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -8931,6 +8931,7 @@ ex_syncbind(exarg_T *eap UNUSED)
     long	topline;
     long	y;
     linenr_T	old_linenr = curwin->w_cursor.lnum;
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
 
     setpcmark();
 
@@ -8944,7 +8945,7 @@ ex_syncbind(exarg_T *eap UNUSED)
 	{
 	    if (wp->w_p_scb && wp->w_buffer)
 	    {
-		y = wp->w_buffer->b_ml.ml_line_count - p_so;
+		y = wp->w_buffer->b_ml.ml_line_count - *so;
 		if (topline > y)
 		    topline = y;
 	    }

--- a/src/gui.c
+++ b/src/gui.c
@@ -4463,7 +4463,7 @@ gui_do_scroll(void)
 #endif
 	    )
     {
-	if (p_so != 0)
+	if (curwin->w_p_so != 0 || p_so != 0)
 	{
 	    cursor_correct();		/* fix window for 'so' */
 	    update_topline();		/* avoid up/down jump */

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -682,6 +682,7 @@ leftcol_changed(void)
     long	lastcol;
     colnr_T	s, e;
     int		retval = FALSE;
+    long        *siso = curwin->w_p_siso ? &curwin->w_p_siso : &p_siso;
 
     changed_cline_bef_curs();
     lastcol = curwin->w_leftcol + curwin->w_width - curwin_col_off() - 1;
@@ -691,15 +692,15 @@ leftcol_changed(void)
      * If the cursor is right or left of the screen, move it to last or first
      * character.
      */
-    if (curwin->w_virtcol > (colnr_T)(lastcol - p_siso))
+    if (curwin->w_virtcol > (colnr_T)(lastcol - *siso))
     {
 	retval = TRUE;
-	coladvance((colnr_T)(lastcol - p_siso));
+	coladvance((colnr_T)(lastcol - *siso));
     }
-    else if (curwin->w_virtcol < curwin->w_leftcol + p_siso)
+    else if (curwin->w_virtcol < curwin->w_leftcol + *siso)
     {
 	retval = TRUE;
-	(void)coladvance((colnr_T)(curwin->w_leftcol + p_siso));
+	(void)coladvance((colnr_T)(curwin->w_leftcol + *siso));
     }
 
     /*

--- a/src/move.c
+++ b/src/move.c
@@ -195,8 +195,9 @@ update_topline(void)
 #endif
     int		check_topline = FALSE;
     int		check_botline = FALSE;
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
 #ifdef FEAT_MOUSE
-    int		save_so = p_so;
+    int		save_so = *so;
 #endif
 
     /* If there is no valid screen and when the window height is zero just use
@@ -217,7 +218,7 @@ update_topline(void)
 #ifdef FEAT_MOUSE
     /* When dragging with the mouse, don't scroll that quickly */
     if (mouse_dragging > 0)
-	p_so = mouse_dragging - 1;
+	*so = mouse_dragging - 1;
 #endif
 
     old_topline = curwin->w_topline;
@@ -271,11 +272,11 @@ update_topline(void)
 	    if (hasAnyFolding(curwin))
 	    {
 		/* Count the number of logical lines between the cursor and
-		 * topline + p_so (approximation of how much will be
+		 * topline + *so (approximation of how much will be
 		 * scrolled). */
 		n = 0;
 		for (lnum = curwin->w_cursor.lnum;
-				      lnum < curwin->w_topline + p_so; ++lnum)
+				      lnum < curwin->w_topline + *so; ++lnum)
 		{
 		    ++n;
 		    /* stop at end of file or when we know we are far off */
@@ -286,7 +287,7 @@ update_topline(void)
 	    }
 	    else
 #endif
-		n = curwin->w_topline + p_so - curwin->w_cursor.lnum;
+		n = curwin->w_topline + *so - curwin->w_cursor.lnum;
 
 	    /* If we weren't very close to begin with, we scroll to put the
 	     * cursor in the middle of the window.  Otherwise put the cursor
@@ -328,7 +329,7 @@ update_topline(void)
 	    if (curwin->w_cursor.lnum < curwin->w_botline)
 	    {
 	      if (((long)curwin->w_cursor.lnum
-					     >= (long)curwin->w_botline - p_so
+					     >= (long)curwin->w_botline - *so
 #ifdef FEAT_FOLDING
 			|| hasAnyFolding(curwin)
 #endif
@@ -357,11 +358,11 @@ update_topline(void)
 			)
 		{
 		    n += loff.height;
-		    if (n >= p_so)
+		    if (n >= *so)
 			break;
 		    botline_forw(&loff);
 		}
-		if (n >= p_so)
+		if (n >= *so)
 		    /* sufficient context, no need to scroll */
 		    check_botline = FALSE;
 	      }
@@ -375,11 +376,11 @@ update_topline(void)
 		if (hasAnyFolding(curwin))
 		{
 		    /* Count the number of logical lines between the cursor and
-		     * botline - p_so (approximation of how much will be
+		     * botline - *so (approximation of how much will be
 		     * scrolled). */
 		    line_count = 0;
 		    for (lnum = curwin->w_cursor.lnum;
-				     lnum >= curwin->w_botline - p_so; --lnum)
+				     lnum >= curwin->w_botline - *so; --lnum)
 		    {
 			++line_count;
 			/* stop at end of file or when we know we are far off */
@@ -391,7 +392,7 @@ update_topline(void)
 		else
 #endif
 		    line_count = curwin->w_cursor.lnum - curwin->w_botline
-								   + 1 + p_so;
+								   + 1 + *so;
 		if (line_count <= curwin->w_height + 1)
 		    scroll_cursor_bot(scrolljump_value(), FALSE);
 		else
@@ -424,7 +425,7 @@ update_topline(void)
     }
 
 #ifdef FEAT_MOUSE
-    p_so = save_so;
+    *so = save_so;
 #endif
 }
 
@@ -450,8 +451,9 @@ check_top_offset(void)
 {
     lineoff_T	loff;
     int		n;
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
 
-    if (curwin->w_cursor.lnum < curwin->w_topline + p_so
+    if (curwin->w_cursor.lnum < curwin->w_topline + *so
 #ifdef FEAT_FOLDING
 		    || hasAnyFolding(curwin)
 #endif
@@ -465,7 +467,7 @@ check_top_offset(void)
 	n = 0;
 #endif
 	/* Count the visible screen lines above the cursor line. */
-	while (n < p_so)
+	while (n < *so)
 	{
 	    topline_back(&loff);
 	    /* Stop when included a line above the window. */
@@ -477,7 +479,7 @@ check_top_offset(void)
 		break;
 	    n += loff.height;
 	}
-	if (n < p_so)
+	if (n < *so)
 	    return TRUE;
     }
     return FALSE;
@@ -954,6 +956,8 @@ curs_columns(
     colnr_T	startcol;
     colnr_T	endcol;
     colnr_T	prev_skipcol;
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
+    long        *siso = curwin->w_p_siso ? &curwin->w_p_siso : &p_siso;
 
     /*
      * First make sure that w_topline is valid (after moving the cursor).
@@ -1036,9 +1040,9 @@ curs_columns(
 	 * If we get closer to the edge than 'sidescrolloff', scroll a little
 	 * extra
 	 */
-	off_left = (int)startcol - (int)curwin->w_leftcol - p_siso;
+	off_left = (int)startcol - (int)curwin->w_leftcol - *siso;
 	off_right = (int)endcol - (int)(curwin->w_leftcol + curwin->w_width
-								- p_siso) + 1;
+								- *siso) + 1;
 	if (off_left < 0 || off_right > 0)
 	{
 	    if (off_left < 0)
@@ -1087,9 +1091,10 @@ curs_columns(
     prev_skipcol = curwin->w_skipcol;
 
     p_lines = 0;
+
     if ((curwin->w_wrow >= curwin->w_height
 		|| ((prev_skipcol > 0
-			|| curwin->w_wrow + p_so >= curwin->w_height)
+			|| curwin->w_wrow + *so >= curwin->w_height)
 		    && (p_lines =
 #ifdef FEAT_DIFF
 			plines_win_nofill
@@ -1106,25 +1111,25 @@ curs_columns(
 	/* Cursor past end of screen.  Happens with a single line that does
 	 * not fit on screen.  Find a skipcol to show the text around the
 	 * cursor.  Avoid scrolling all the time. compute value of "extra":
-	 * 1: Less than "p_so" lines above
-	 * 2: Less than "p_so" lines below
+	 * 1: Less than "so" lines above
+	 * 2: Less than "so" lines below
 	 * 3: both of them */
 	extra = 0;
-	if (curwin->w_skipcol + p_so * width > curwin->w_virtcol)
+	if (curwin->w_skipcol + *so * width > curwin->w_virtcol)
 	    extra = 1;
 	/* Compute last display line of the buffer line that we want at the
 	 * bottom of the window. */
 	if (p_lines == 0)
 	    p_lines = plines_win(curwin, curwin->w_cursor.lnum, FALSE);
 	--p_lines;
-	if (p_lines > curwin->w_wrow + p_so)
-	    n = curwin->w_wrow + p_so;
+	if (p_lines > curwin->w_wrow + *so)
+	    n = curwin->w_wrow + *so;
 	else
 	    n = p_lines;
 	if ((colnr_T)n >= curwin->w_height + curwin->w_skipcol / width)
 	    extra += 2;
 
-	if (extra == 3 || p_lines < p_so * 2)
+	if (extra == 3 || p_lines < *so * 2)
 	{
 	    /* not enough room for 'scrolloff', put cursor in the middle */
 	    n = curwin->w_virtcol / width;
@@ -1140,7 +1145,7 @@ curs_columns(
 	else if (extra == 1)
 	{
 	    /* less then 'scrolloff' lines above, decrease skipcol */
-	    extra = (curwin->w_skipcol + p_so * width - curwin->w_virtcol
+	    extra = (curwin->w_skipcol + *so * width - curwin->w_virtcol
 				     + width - 1) / width;
 	    if (extra > 0)
 	    {
@@ -1472,7 +1477,7 @@ scrolldown_clamp(void)
 	end_row += curwin->w_cline_height - 1 -
 	    curwin->w_virtcol / curwin->w_width;
     }
-    if (end_row < curwin->w_height - p_so)
+    if (end_row < curwin->w_height - (curwin->w_p_so ? curwin->w_p_so : p_so))
     {
 #ifdef FEAT_DIFF
 	if (can_fill)
@@ -1530,7 +1535,7 @@ scrollup_clamp(void)
 	validate_virtcol();
 	start_row -= curwin->w_virtcol / curwin->w_width;
     }
-    if (start_row >= p_so)
+    if (start_row >= (curwin->w_p_so ? curwin->w_p_so : p_so))
     {
 #ifdef FEAT_DIFF
 	if (curwin->w_topfill > 0)
@@ -1674,7 +1679,7 @@ scroll_cursor_top(int min_scroll, int always)
     linenr_T	old_topfill = curwin->w_topfill;
 #endif
     linenr_T	new_topline;
-    int		off = p_so;
+    int		off = curwin->w_p_so ? curwin->w_p_so : p_so;
 
 #ifdef FEAT_MOUSE
     if (mouse_dragging > 0)
@@ -1850,6 +1855,7 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
     linenr_T	old_valid = curwin->w_valid;
     int		old_empty_rows = curwin->w_empty_rows;
     linenr_T	cln;		    /* Cursor Line Number */
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
 
     cln = curwin->w_cursor.lnum;
     if (set_topbot)
@@ -1906,7 +1912,7 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
      * Stop counting lines to scroll when
      * - hitting start of the file
      * - scrolled nothing or at least 'sj' lines
-     * - at least 'so' lines below the cursor
+     * - at least '*so' lines below the cursor
      * - lines between botline and cursor have been counted
      */
 #ifdef FEAT_FOLDING
@@ -1932,7 +1938,7 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
 #ifdef FEAT_MOUSE
 			    mouse_dragging > 0 ? mouse_dragging - 1 :
 #endif
-			    p_so))
+			    *so))
 		    || boff.lnum + 1 > curbuf->b_ml.ml_line_count)
 		&& loff.lnum <= curwin->w_botline
 #ifdef FEAT_DIFF
@@ -1978,7 +1984,7 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
 #ifdef FEAT_MOUSE
 			mouse_dragging > 0 ? mouse_dragging - 1 :
 #endif
-			p_so) || scrolled < min_scroll)
+			*so) || scrolled < min_scroll)
 	    {
 		extra += boff.height;
 		if (boff.lnum >= curwin->w_botline
@@ -2132,7 +2138,7 @@ scroll_cursor_halfway(int atend)
 
 /*
  * Correct the cursor position so that it is in a part of the screen at least
- * 'so' lines from the top and bottom, if possible.
+ * '*so' lines from the top and bottom, if possible.
  * If not possible, put it at the same position as scroll_cursor_halfway().
  * When called topline must be valid!
  */
@@ -2146,13 +2152,14 @@ cursor_correct(void)
     int		above_wanted, below_wanted;
     linenr_T	cln;		    /* Cursor Line Number */
     int		max_off;
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
 
     /*
      * How many lines we would like to have above/below the cursor depends on
      * whether the first/last line of the file is on screen.
      */
-    above_wanted = p_so;
-    below_wanted = p_so;
+    above_wanted = *so;
+    below_wanted = *so;
 #ifdef FEAT_MOUSE
     if (mouse_dragging > 0)
     {
@@ -2270,6 +2277,7 @@ onepage(int dir, long count)
     int		retval = OK;
     lineoff_T	loff;
     linenr_T	old_topline = curwin->w_topline;
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
 
     if (curbuf->b_ml.ml_line_count == 1)    /* nothing to do */
     {
@@ -2287,7 +2295,7 @@ onepage(int dir, long count)
 	 * last line.
 	 */
 	if (dir == FORWARD
-		? ((curwin->w_topline >= curbuf->b_ml.ml_line_count - p_so)
+		? ((curwin->w_topline >= curbuf->b_ml.ml_line_count - *so)
 		    && curwin->w_botline > curbuf->b_ml.ml_line_count)
 		: (curwin->w_topline == 1
 #ifdef FEAT_DIFF

--- a/src/normal.c
+++ b/src/normal.c
@@ -2848,7 +2848,7 @@ do_mouse(
 
     /* Set global flag that we are extending the Visual area with mouse
      * dragging; temporarily minimize 'scrolloff'. */
-    if (VIsual_active && is_drag && p_so)
+    if (VIsual_active && is_drag && (curwin->w_p_so ? curwin->w_p_so : p_so))
     {
 	/* In the very first line, allow scrolling one line */
 	if (mouse_row == 0)
@@ -4698,7 +4698,7 @@ scroll_redraw(int up, long count)
 	scrollup(count, TRUE);
     else
 	scrolldown(count, TRUE);
-    if (p_so)
+    if (curwin->w_p_so ? curwin->w_p_so : p_so)
     {
 	/* Adjust the cursor position for 'scrolloff'.  Mark w_topline as
 	 * valid, otherwise the screen jumps back at the end of the file. */
@@ -4755,6 +4755,7 @@ nv_zet(cmdarg_T *cap)
 #ifdef FEAT_SPELL
     int		undo = FALSE;
 #endif
+    long        *siso = curwin->w_p_siso ? &curwin->w_p_siso : &p_siso;
 
     if (VIM_ISDIGIT(nchar))
     {
@@ -4937,8 +4938,8 @@ dozet:
 		    else
 #endif
 		    getvcol(curwin, &curwin->w_cursor, &col, NULL, NULL);
-		    if ((long)col > p_siso)
-			col -= p_siso;
+		    if ((long)col > *siso)
+			col -= *siso;
 		    else
 			col = 0;
 		    if (curwin->w_leftcol != col)
@@ -4959,10 +4960,10 @@ dozet:
 #endif
 		    getvcol(curwin, &curwin->w_cursor, NULL, NULL, &col);
 		    n = curwin->w_width - curwin_col_off();
-		    if ((long)col + p_siso < n)
+		    if ((long)col + *siso < n)
 			col = 0;
 		    else
-			col = col + p_siso - n + 1;
+			col = col + *siso - n + 1;
 		    if (curwin->w_leftcol != col)
 		    {
 			curwin->w_leftcol = col;

--- a/src/option.c
+++ b/src/option.c
@@ -233,6 +233,8 @@
 #endif
 #define PV_SCBIND	OPT_WIN(WV_SCBIND)
 #define PV_SCROLL	OPT_WIN(WV_SCROLL)
+#define PV_SISO		OPT_BOTH(OPT_WIN(WV_SISO))
+#define PV_SO		OPT_BOTH(OPT_WIN(WV_SO))
 #ifdef FEAT_SPELL
 # define PV_SPELL	OPT_WIN(WV_SPELL)
 #endif
@@ -2395,7 +2397,7 @@ static struct vimoption options[] =
 			    (char_u *)&p_sj, PV_NONE,
 			    {(char_u *)1L, (char_u *)0L} SCTX_INIT},
     {"scrolloff",   "so",   P_NUM|P_VI_DEF|P_VIM|P_RALL,
-			    (char_u *)&p_so, PV_NONE,
+			    (char_u *)&p_so, PV_SO,
 			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"scrollopt",   "sbo",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_sbo, PV_NONE,
@@ -2552,7 +2554,7 @@ static struct vimoption options[] =
 			    (char_u *)&p_ss, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"sidescrolloff", "siso", P_NUM|P_VI_DEF|P_VIM|P_RBUF,
-			    (char_u *)&p_siso, PV_NONE,
+			    (char_u *)&p_siso, PV_SISO,
 			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
     {"signcolumn",   "scl",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
 #ifdef FEAT_SIGNS
@@ -9412,10 +9414,20 @@ set_num_option(
 	    p_sj = 1;
 	}
     }
+    if (curwin->w_p_so < 0 && full_screen)
+    {
+	errmsg = e_scroll;
+	curwin->w_p_so = 0;
+    }
     if (p_so < 0 && full_screen)
     {
 	errmsg = e_scroll;
 	p_so = 0;
+    }
+    if (curwin->w_p_siso < 0 && full_screen)
+    {
+	errmsg = e_positive;
+	curwin->w_p_siso = 0;
     }
     if (p_siso < 0 && full_screen)
     {
@@ -10646,6 +10658,12 @@ unset_global_local_option(char_u *name, void *from)
 	    clear_string_option(&buf->b_p_tc);
 	    buf->b_tc_flags = 0;
 	    break;
+        case PV_SISO:
+            curwin->w_p_siso = 0;
+            break;
+        case PV_SO:
+            curwin->w_p_so = 0;
+            break;
 #ifdef FEAT_FIND_ID
 	case PV_DEF:
 	    clear_string_option(&buf->b_p_def);
@@ -10735,6 +10753,8 @@ get_varp_scope(struct vimoption *p, int opt_flags)
 	    case PV_AR:   return (char_u *)&(curbuf->b_p_ar);
 	    case PV_TAGS: return (char_u *)&(curbuf->b_p_tags);
 	    case PV_TC:   return (char_u *)&(curbuf->b_p_tc);
+            case PV_SISO: return (char_u *)&(curwin->w_p_siso);
+            case PV_SO:   return (char_u *)&(curwin->w_p_so);
 #ifdef FEAT_FIND_ID
 	    case PV_DEF:  return (char_u *)&(curbuf->b_p_def);
 	    case PV_INC:  return (char_u *)&(curbuf->b_p_inc);
@@ -10795,6 +10815,10 @@ get_varp(struct vimoption *p)
 				    ? (char_u *)&(curbuf->b_p_tc) : p->var;
 	case PV_BKC:	return *curbuf->b_p_bkc != NUL
 				    ? (char_u *)&(curbuf->b_p_bkc) : p->var;
+	case PV_SISO:	return curwin->w_p_siso != 0
+				    ? (char_u *)&(curwin->w_p_siso) : p->var;
+	case PV_SO:	return curwin->w_p_so != 0
+				    ? (char_u *)&(curwin->w_p_so) : p->var;
 #ifdef FEAT_FIND_ID
 	case PV_DEF:	return *curbuf->b_p_def != NUL
 				    ? (char_u *)&(curbuf->b_p_def) : p->var;

--- a/src/option.h
+++ b/src/option.h
@@ -1179,6 +1179,8 @@ enum
 #endif
     , WV_SCBIND
     , WV_SCROLL
+    , WV_SISO
+    , WV_SO
 #ifdef FEAT_SPELL
     , WV_SPELL
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -2616,6 +2616,8 @@ showmatch(
 #endif
     colnr_T	save_dollar_vcol;
     char_u	*p;
+    long        *so = curwin->w_p_so ? &curwin->w_p_so : &p_so;
+    long        *siso = curwin->w_p_siso ? &curwin->w_p_siso : &p_siso;
 
     /*
      * Only show match for chars in the 'matchpairs' option.
@@ -2650,8 +2652,8 @@ showmatch(
 	{
 	    mpos = *lpos;    /* save the pos, update_screen() may change it */
 	    save_cursor = curwin->w_cursor;
-	    save_so = p_so;
-	    save_siso = p_siso;
+	    save_so = *so;
+	    save_siso = *siso;
 	    /* Handle "$" in 'cpo': If the ')' is typed on top of the "$",
 	     * stop displaying the "$". */
 	    if (dollar_vcol >= 0 && dollar_vcol == curwin->w_virtcol)
@@ -2666,8 +2668,8 @@ showmatch(
 	    ui_cursor_shape();		/* may show different cursor shape */
 #endif
 	    curwin->w_cursor = mpos;	/* move to matching char */
-	    p_so = 0;			/* don't use 'scrolloff' here */
-	    p_siso = 0;			/* don't use 'sidescrolloff' here */
+	    *so = 0;			/* don't use 'scrolloff' here */
+	    *siso = 0;			/* don't use 'sidescrolloff' here */
 	    showruler(FALSE);
 	    setcursor();
 	    cursor_on();		/* make sure that the cursor is shown */
@@ -2687,8 +2689,8 @@ showmatch(
 	    else if (!char_avail())
 		ui_delay(p_mat * 100L, FALSE);
 	    curwin->w_cursor = save_cursor;	/* restore cursor position */
-	    p_so = save_so;
-	    p_siso = save_siso;
+	    *so = save_so;
+	    *siso = save_siso;
 #ifdef CURSOR_SHAPE
 	    State = save_state;
 	    ui_cursor_shape();		/* may show different cursor shape */

--- a/src/structs.h
+++ b/src/structs.h
@@ -2872,6 +2872,8 @@ struct window_S
     int		w_p_brishift;	    /* additional shift for breakindent */
     int		w_p_brisbr;	    /* sbr in 'briopt' */
 #endif
+    long        w_p_siso;           /* 'sidescrolloff' local value */
+    long        w_p_so;             /* 'scrolloff' local value */
 
     /* transform a pointer to a "onebuf" option into a "allbuf" option */
 #define GLOBAL_WO(p)	((char *)p + sizeof(winopt_T))

--- a/src/window.c
+++ b/src/window.c
@@ -5868,7 +5868,7 @@ scroll_to_fraction(win_T *wp, int prev_height)
 
     if (wp == curwin)
     {
-	if (p_so)
+	if (curwin->w_p_so || p_so)
 	    update_topline();
 	curs_columns(FALSE);	/* validate w_wrow */
     }


### PR DESCRIPTION
`todo.txt` has two entries suggesting making `scrolloff` global-local, the older one seems to have been there quite a while.

I added a local variable to the window struct and set up references to it in `option.c`. So far so good. Regarding the actual use of `p_so` I took inspiration from `lispwords` and made use of ternary statements as drop-in replacements. In functions where `p_so` where referenced multiple times I declared a pointer variable, which also makes it easier to write to the used value (see `move.c`).

The same was done for `sidescrolloff`. It was not immediately obvious how to test this, as I could not find a simple way to get the cursor position in the window (instead of position in the buffer) in vimscript. The manual testing I have done indicates everything is working though, and the documentation is updated.

Issue #3195 is related.