### PR TITLE
win32: if_perl: Generate if_perl.c into the auto directory

### DIFF
--- a/src/Make_bc5.mak
+++ b/src/Make_bc5.mak
@@ -820,6 +820,8 @@ clean:
 !endif
 !ifdef PERL
 	-@del perl.lib
+	-@del if_perl.c
+	-@del auto\if_perl.c
 !endif
 !ifdef PYTHON
 	-@del python.lib
@@ -948,12 +950,12 @@ $(OBJDIR)\if_ole.obj: if_ole.cpp
 $(OBJDIR)\if_lua.obj: if_lua.c lua.lib
 	$(CC) $(CCARG) $(CC1) $(CC2)$@ -pc if_lua.c
 
-$(OBJDIR)\if_perl.obj: if_perl.c perl.lib
-	$(CC) $(CCARG) $(CC1) $(CC2)$@ -pc if_perl.c
+$(OBJDIR)\if_perl.obj: auto/if_perl.c perl.lib
+	$(CC) $(CCARG) $(CC1) $(CC2)$@ -pc auto/if_perl.c
 
-if_perl.c: if_perl.xs typemap
+auto/if_perl.c: if_perl.xs typemap
 	$(PERL)\bin\perl.exe $(PERL)\lib\ExtUtils\xsubpp -prototypes -typemap \
-	    $(PERL)\lib\ExtUtils\typemap if_perl.xs > $@
+	    $(PERL)\lib\ExtUtils\typemap if_perl.xs -output $@
 
 $(OBJDIR)\if_python.obj: if_python.c if_py_both.h python.lib
 	$(CC) -I$(PYTHON)\include $(CCARG) $(CC1) $(CC2)$@ -pc if_python.c

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -985,6 +985,7 @@ clean:
 	-$(DEL) pathdef.c
 ifdef PERL
 	-$(DEL) if_perl.c
+	-$(DEL) auto$(DIRSLASH)if_perl.c
 endif
 ifdef MZSCHEME
 	-$(DEL) mzscheme_base.c
@@ -1043,9 +1044,13 @@ mzscheme_base.c:
 $(OUTDIR)/if_ole.o:	if_ole.cpp $(INCL) if_ole.h
 	$(CC) $(CFLAGS) $(CXXFLAGS) -c -o $(OUTDIR)/if_ole.o if_ole.cpp
 
-if_perl.c:		if_perl.xs typemap
+auto/if_perl.c:		if_perl.xs typemap
 	$(XSUBPP) -prototypes -typemap \
 	     $(PERLTYPEMAP) if_perl.xs -output $@
+
+$(OUTDIR)/if_perl.o:	auto/if_perl.c $(INCL)
+	$(CC) -c $(CFLAGS) auto/if_perl.c -o $(OUTDIR)/if_perl.o
+
 
 $(OUTDIR)/if_ruby.o:	if_ruby.c $(INCL)
 ifeq (16, $(RUBY))

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1286,6 +1286,7 @@ clean:
 	- if exist install.exe del install.exe
 	- if exist uninstal.exe del uninstal.exe
 	- if exist if_perl.c del if_perl.c
+	- if exist auto\if_perl.c del auto\if_perl.c
 	- if exist dimm.h del dimm.h
 	- if exist dimm_i.c del dimm_i.c
 	- if exist dimm.tlb del dimm.tlb
@@ -1424,12 +1425,12 @@ $(OUTDIR)/if_cscope.obj: $(OUTDIR) if_cscope.c  $(INCL) if_cscope.h
 $(OUTDIR)/if_lua.obj: $(OUTDIR) if_lua.c  $(INCL)
 	$(CC) $(CFLAGS_OUTDIR) $(LUA_INC) if_lua.c
 
-if_perl.c : if_perl.xs typemap
+auto/if_perl.c : if_perl.xs typemap
 	$(XSUBPP) -prototypes -typemap $(XSUBPP_TYPEMAP) \
-		-typemap typemap if_perl.xs -output if_perl.c
+		-typemap typemap if_perl.xs -output $@
 
-$(OUTDIR)/if_perl.obj: $(OUTDIR) if_perl.c  $(INCL)
-	$(CC) $(CFLAGS_OUTDIR) $(PERL_INC) if_perl.c
+$(OUTDIR)/if_perl.obj: $(OUTDIR) auto/if_perl.c  $(INCL)
+	$(CC) $(CFLAGS_OUTDIR) $(PERL_INC) auto/if_perl.c
 
 $(OUTDIR)/if_perlsfio.obj: $(OUTDIR) if_perlsfio.c  $(INCL)
 	$(CC) $(CFLAGS_OUTDIR) $(PERL_INC) if_perlsfio.c


### PR DESCRIPTION
As I mentioned at https://github.com/vim/vim/issues/3526#issuecomment-428974612,
win32 makefiles generate `if_perl.c` into the `src/` directory, however unix
makefile generates into the `src/auto/` directory.

Make win32 makefiles as same as the unix makefile.