### PR TITLE
GvimExt: Create a submenu for "Edit with existing Vim"

### DIFF
--- a/src/GvimExt/gvimext.cpp
+++ b/src/GvimExt/gvimext.cpp
@@ -708,11 +708,26 @@ STDMETHODIMP CShellExt::QueryContextMenu(HMENU hMenu,
 	m_edit_existing_off = 1;
     }
 
+    HMENU hSubMenu = NULL;
+    if (m_cntOfHWnd > 1)
+    {
+	hSubMenu = CreatePopupMenu();
+	mii.fMask |= MIIM_SUBMENU;
+	mii.wID = idCmd;
+	mii.dwTypeData = _("Edit with existing Vim");
+	mii.cch = lstrlen(mii.dwTypeData);
+	mii.hSubMenu = hSubMenu;
+	InsertMenuItem(hMenu, indexMenu++, TRUE, &mii);
+	mii.fMask = mii.fMask & ~MIIM_SUBMENU;
+	mii.hSubMenu = NULL;
+    }
     // Now display all the vim instances
     for (int i = 0; i < m_cntOfHWnd; i++)
     {
 	char title[BUFSIZE];
 	char temp[BUFSIZE];
+	int index;
+	HMENU hmenu;
 
 	// Obtain window title, continue if can not
 	if (GetWindowText(m_hWnd[i], title, BUFSIZE - 1) == 0)
@@ -726,15 +741,30 @@ STDMETHODIMP CShellExt::QueryContextMenu(HMENU hMenu,
 	    *pos = 0;
 	}
 	// Now concatenate
-	strncpy(temp, _("Edit with existing Vim - "), BUFSIZE - 1);
-	temp[BUFSIZE - 1] = '\0';
+	if (m_cntOfHWnd > 1)
+	    temp[0] = '\0';
+	else
+	{
+	    strncpy(temp, _("Edit with existing Vim - "), BUFSIZE - 1);
+	    temp[BUFSIZE - 1] = '\0';
+	}
 	strncat(temp, title, BUFSIZE - 1 - strlen(temp));
 	temp[BUFSIZE - 1] = '\0';
 
 	mii.wID = idCmd++;
 	mii.dwTypeData = temp;
 	mii.cch = lstrlen(mii.dwTypeData);
-	InsertMenuItem(hMenu, indexMenu++, TRUE, &mii);
+	if (m_cntOfHWnd > 1)
+	{
+	    hmenu = hSubMenu;
+	    index = i;
+	}
+	else
+	{
+	    hmenu = hMenu;
+	    index = indexMenu++;
+	}
+	InsertMenuItem(hmenu, index, TRUE, &mii);
     }
     // InsertMenu(hMenu, indexMenu++, MF_SEPARATOR|MF_BYPOSITION, 0, NULL);
 


### PR DESCRIPTION
If we have a lot of gVim instances, many numbers of "Edit with existing Vim"
items will be shown in the context menu with the current implementation.

E.g.

    Edit with Vim
    Edit with existing Vim - instance 1
    Edit with existing Vim - instance 2
    Edit with existing Vim - instance 3
    Edit with existing Vim - instance 4
    Edit with existing Vim - instance 5
    Edit with existing Vim - instance 6
    Edit with existing Vim - instance 7

<img width=303 src="https://user-images.githubusercontent.com/840186/47477549-c0542480-d860-11e8-806f-6f840bc9a399.png"/>

I feel this is a bit noisy.

This PR makes the menu items structured and move the instances into a
submenu.  So the context menu becomes simpler.

E.g.

    Edit with Vim
    Edit with existing Vim > instance 1
                             instance 2
                             instance 3
                             instance 4
                             instance 5
                             instance 6
                             instance 7

<img width=383 src="https://user-images.githubusercontent.com/840186/47477600-04dfc000-d861-11e8-975c-2ccb8542c3dc.png"/>

If there is only one gVim instance, the item will be shown directly:

    Edit with Vim
    Edit with existing Vim - instance 1

<img width=279 src="https://user-images.githubusercontent.com/840186/47477636-2e98e700-d861-11e8-8874-671f385e44b3.png"/>
