### PR TITLE
dosinst: Use $HOMEDRIVE$HOMEPATH and $USERPROFILE as fallbacks of plugin directories

### DIFF
--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -2105,8 +2105,8 @@ change_directories_choice(int idx)
 {
     int	    choice_count = TABLE_SIZE(vimfiles_dir_choices);
 
-    /* Don't offer the $HOME choice if $HOME isn't set. */
-    if (getenv("HOME") == NULL)
+    /* Don't offer the $HOME choice if $HOME and $USERPROFILE aren't set. */
+    if (getenv("HOME") == NULL && getenv("USERPROFILE") == NULL)
 	--choice_count;
     vimfiles_dir_choice = get_choice(vimfiles_dir_choices, choice_count);
     set_directories_text(idx);
@@ -2148,8 +2148,12 @@ install_vimfilesdir(int idx)
 	    p = getenv("HOME");
 	    if (p == NULL)
 	    {
-		printf("Internal error: $HOME is NULL\n");
-		p = "c:\\";
+		p = getenv("USERPROFILE");
+		if (p == NULL)
+		{
+		    printf("Internal error: $HOME or $USERPROFILE is NULL\n");
+		    p = "c:\\";
+		}
 	    }
 	    strcpy(vimdir_path, p);
 	    break;
@@ -2377,8 +2381,9 @@ command_line_setup_choices(int argc, char **argv)
 		    vimfiles_dir_choice = (int)vimfiles_dir_vim;
 		else if (strcmp(argv[i], "home") == 0)
 		{
-		    if (getenv("HOME") == NULL) /* No $HOME in environment */
-			vimfiles_dir_choice = (int)vimfiles_dir_vim;
+		    if (getenv("HOME") == NULL && getenv("USERPROFILE"))
+			/* No $HOME or $USERPROFILE in environment */
+			vimfiles_dir_choice = (int)vimfiles_dir_none;
 		    else
 			vimfiles_dir_choice = (int)vimfiles_dir_home;
 		}

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -122,7 +122,6 @@ static char    *(vimfiles_dir_choices[]) =
     "In the VIM directory",
     "In your HOME directory",
 };
-static int     vimfiles_dir_choice;
 
 /* non-zero when selected to install the popup menu entry. */
 static int	install_popup = 0;
@@ -2090,6 +2089,8 @@ dir_remove_last(const char *path, char to[BUFSIZE])
     static void
 set_directories_text(int idx)
 {
+    int vimfiles_dir_choice = choices[idx].arg;
+
     if (vimfiles_dir_choice == (int)vimfiles_dir_none)
 	alloc_text(idx, "Do NOT create plugin directories%s", "");
     else
@@ -2194,7 +2195,7 @@ change_directories_choice(int idx)
     /* Don't offer the $HOME choice if $HOME isn't set. */
     if (homedir == NULL)
 	--choice_count;
-    vimfiles_dir_choice = get_choice(vimfiles_dir_choices, choice_count);
+    choices[idx].arg = get_choice(vimfiles_dir_choices, choice_count);
     set_directories_text(idx);
 }
 
@@ -2206,6 +2207,7 @@ change_directories_choice(int idx)
 install_vimfilesdir(int idx)
 {
     int i;
+    int vimfiles_dir_choice = choices[idx].arg;
     char *p;
     char vimdir_path[BUFSIZE];
     char vimfiles_path[BUFSIZE];
@@ -2271,6 +2273,7 @@ init_directories_choice(void)
     struct stat	st;
     char	tmp_dirname[BUFSIZE];
     char	*p;
+    int		vimfiles_dir_choice;
 
     choices[choice_count].text = alloc(150);
     choices[choice_count].changefunc = change_directories_choice;
@@ -2299,6 +2302,7 @@ init_directories_choice(void)
 	    vimfiles_dir_choice = (int)vimfiles_dir_none;
     }
 
+    choices[choice_count].arg = vimfiles_dir_choice;
     set_directories_text(choice_count);
     ++choice_count;
 }
@@ -2455,6 +2459,8 @@ command_line_setup_choices(int argc, char **argv)
 	}
 	else if (strcmp(argv[i], "-create-directories") == 0)
 	{
+	    int vimfiles_dir_choice;
+
 	    init_directories_choice();
 	    if (argv[i + 1][0] != '-')
 	    {
@@ -2477,6 +2483,7 @@ command_line_setup_choices(int argc, char **argv)
 	    }
 	    else /* No choice specified, default to vim directory */
 		vimfiles_dir_choice = (int)vimfiles_dir_vim;
+	    choices[choice_count - 1].arg = vimfiles_dir_choice;
 	}
 	else if (strcmp(argv[i], "-register-OLE") == 0)
 	{

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -741,7 +741,8 @@ add_dummy_choice(void)
     choices[choice_count].installfunc = NULL;
     choices[choice_count].active = 0;
     choices[choice_count].changefunc = NULL;
-    choices[choice_count].installfunc = NULL;
+    choices[choice_count].text = NULL;
+    choices[choice_count].arg = 0;
     ++choice_count;
 }
 

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3905,6 +3905,8 @@ vim_beep(
  *  - do mch_dirname() to get the real name of that directory.
  *  This also works with mounts and links.
  *  Don't do this for MS-DOS, it will change the "current dir" for a drive.
+ * For Windows:
+ *  This code is copied to init_homedir() in dosinst.c.  Keep sync with it.
  */
 static char_u	*homedir = NULL;
 


### PR DESCRIPTION
Creating plugin directories in $VIM as a fallback of $HOME is not useful.

If the install.exe is executed from the NSIS installer, $VIM is normally
`C:\Program Files (x86)\Vim`.  Normal users cannot put plugin files into it,
because the directory requires administrator privileges.

Currently, the NSIS installer has the following two options:
* [x] Create plugin directories in HOME or VIM
* [ ] Create plugin directories in VIM

The first one is the default, however, most people might not set $HOME.
Then the plugin directories will be created in $VIM (which is not useful).
If the user really wants to create in $VIM, he should select the second one.

If the user doesn't set $HOME, it should fallback to $USERPROFILE.
What do you think?