### PR TITLE
Colourful :digraphs output

### DIFF
--- a/src/digraph.c
+++ b/src/digraph.c
@@ -2314,6 +2314,9 @@ printdigraph(digr_T *dp)
 	*p++ = dp->char1;
 	*p++ = dp->char2;
 	*p++ = ' ';
+	*p = NUL;
+	msg_outtrans(buf);
+	p = buf;
 #ifdef FEAT_MBYTE
 	if (has_mbyte)
 	{
@@ -2325,6 +2328,36 @@ printdigraph(digr_T *dp)
 	else
 #endif
 	    *p++ = (char_u)dp->result;
+	*p = NUL;
+	if (dp->result < 161)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG1));
+	else if (dp->result < 915)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG2));
+	else if (dp->result < 1032)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG1));
+	else if (dp->result < 1130)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG2));
+	else if (dp->result < 1775)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG1));
+	else if (dp->result < 7842)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG2));
+	else if (dp->result < 8203)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG1));
+	else if (dp->result < 8356)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG2));
+	else if (dp->result < 8544)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG1));
+	else if (dp->result < 8592)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG2));
+	else if (dp->result < 8942)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG1));
+	else if (dp->result < 9644)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG2));
+	else if (dp->result < 12353)
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG1));
+	else
+	    msg_outtrans_attr(buf,  HL_ATTR(HLF_DG2));
+	p = buf;
 	if (char2cells(dp->result) == 1)
 	    *p++ = ' ';
 	vim_snprintf((char *)p, sizeof(buf) - (p - buf), " %3d", dp->result);

--- a/src/option.c
+++ b/src/option.c
@@ -480,7 +480,7 @@ struct vimoption
 # define ISP_LATIN1 (char_u *)"@,161-255"
 #endif
 
-# define HIGHLIGHT_INIT "8:SpecialKey,~:EndOfBuffer,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine,z:StatusLineTerm,Z:StatusLineTermNC"
+# define HIGHLIGHT_INIT "8:SpecialKey,~:EndOfBuffer,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine,z:StatusLineTerm,Z:StatusLineTermNC,1:Digraph1,2:Digraph2"
 
 /* Default python version for pyx* commands */
 #if defined(FEAT_PYTHON) && defined(FEAT_PYTHON3)

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6859,6 +6859,10 @@ static char *(highlight_init_both[]) = {
     "default link EndOfBuffer NonText",
     CENT("VertSplit term=reverse cterm=reverse",
 	 "VertSplit term=reverse cterm=reverse gui=reverse"),
+    CENT("Digraph1 term=standout cterm=Red",
+	 "Digraph1 term=standout ctermfg=Red guifg=Red"),
+    CENT("Digraph2 term=standout ctermfg=Yellow",
+	 "Digraph2 term=standout ctermfg=Yellow guifg=Yellow" ),
 #ifdef FEAT_CLIPBOARD
     CENT("VisualNOS term=underline,bold cterm=underline,bold",
 	 "VisualNOS term=underline,bold cterm=underline,bold gui=underline,bold"),

--- a/src/vim.h
+++ b/src/vim.h
@@ -1409,6 +1409,8 @@ typedef enum
     , HLF_QFL	    /* quickfix window line currently selected */
     , HLF_ST	    /* status lines of terminal windows */
     , HLF_STNC	    /* status lines of not-current terminal windows */
+    , HLF_DG1
+    , HLF_DG2
     , HLF_COUNT	    /* MUST be the last one */
 } hlf_T;
 
@@ -1419,7 +1421,7 @@ typedef enum
 		  'f', 'F', 'A', 'C', 'D', 'T', '-', '>', \
 		  'B', 'P', 'R', 'L', \
 		  '+', '=', 'x', 'X', '*', '#', '_', '!', '.', 'o', 'q', \
-		  'z', 'Z'}
+		  'z', 'Z', '1', '2'}
 
 /*
  * Boolean constants


### PR DESCRIPTION
This is a tiny patch, that makes the output of `:digraph` command more readable by colouring the `:digraphs` output using the `WarningMsg` highlight group.