### PR TITLE
fixed: bracketed paste remaining set after vim exits

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -3491,8 +3491,13 @@ settmode(int tmode)
 	    if (tmode != TMODE_RAW)
 		mch_setmouse(FALSE);	/* switch mouse off */
 #endif
-	    if (tmode != TMODE_RAW)
-		out_str(T_BD);		/* disable bracketed paste mode */
+	    if (termcap_active)
+	    {
+		if (tmode != TMODE_RAW)
+		    out_str(T_BD);		/* disable bracketed paste mode */
+		else
+		    out_str(T_BE);		/* enable bracketed paste mode */
+	    }
 	    out_flush();
 	    mch_settmode(tmode);	/* machine specific function */
 	    cur_tmode = tmode;
@@ -3500,9 +3505,6 @@ settmode(int tmode)
 	    if (tmode == TMODE_RAW)
 		setmouse();		/* may switch mouse on */
 #endif
-	    if (tmode == TMODE_RAW)
-		out_str(T_BE);		/* enable bracketed paste mode */
-	    out_flush();
 	}
 #ifdef FEAT_TERMRESPONSE
 	may_req_termresponse();


### PR DESCRIPTION
Fixes #1671 (closed with no fix) caused by 62cf09b.

Due to 62cf09b, bracketed paste was getting set _before_ going into termcap mode.
The terminal emulator appears to save this setting, so when vim comes out of termcap,
the bracketed paste option is restored (even if vim unset bracketed paste while in termcap).

This change causes `settmode()` to only toggle bracketed paste when vim is already in termcap.