### PR TITLE
Update thesaurus wordlist URL

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8125,8 +8125,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	non-keyword characters (white space is preferred).  Maximum line
 	length is 510 bytes.
 	To obtain a file to be used here, check out this ftp site:
-	[Sorry this link doesn't work anymore, do you know the right one?]
-	ftp://ftp.ox.ac.uk/pub/wordlists/  First get the README file.
+	ftp://ftp.cerias.purdue.edu/pub/dict/wordlists/  First get the README file.
 	To include a comma in a file name precede it with a backslash.  Spaces
 	after a comma are ignored, otherwise spaces are included in the file
 	name.  See |option-backslash| about using backslashes.


### PR DESCRIPTION
According to [this](https://www.openwall.com/passwords/wordlists/), the new URL in this commit "includes the ox.ac.uk archive and more". 

Fixes #629