### PR TITLE
test_suspend: Allow matching root's shell prompt

### DIFF
--- a/src/testdir/test_suspend.vim
+++ b/src/testdir/test_suspend.vim
@@ -9,7 +9,7 @@ func Test_suspend()
 
   let buf = term_start('/bin/sh')
   " Wait for shell prompt.
-  call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
+  call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
 
   call term_sendkeys(buf, v:progpath
         \               . " --clean -X"
@@ -26,7 +26,7 @@ func Test_suspend()
         \             "\<C-Z>"]
     " Suspend and wait for shell prompt.
     call term_sendkeys(buf, suspend_cmd)
-    call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
+    call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
 
     " Without 'autowrite', buffer should not be written.
     call assert_equal(0, filereadable('Xfoo'))
@@ -40,7 +40,7 @@ func Test_suspend()
   call assert_equal(0, filereadable('Xfoo'))
   call term_sendkeys(buf, ":suspend\<CR>")
   " Wait for shell prompt.
-  call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
+  call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
   call assert_equal(['foo'], readfile('Xfoo'))
   call term_sendkeys(buf, "fg\<CR>")
   call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})


### PR DESCRIPTION
If the test is run as root (which happens in some CI environments), the
shell prompt is #, not $.