### PR TITLE
test_filter_cmd: Ensure 'helplang' is set before trying to filter for it

### DIFF
--- a/src/testdir/test_filter_cmd.vim
+++ b/src/testdir/test_filter_cmd.vim
@@ -105,8 +105,11 @@ func Test_filter_commands()
   unlet test_filter_c
 
   " Test filtering :set command
+  let helplang=&helplang
+  set helplang=en
   let res = join(split(execute("filter /^help/ set"), "\n")[1:], " ")
   call assert_match('^\s*helplang=\w*$', res)
+  let &helplang=helplang
 
   " Test filtering :llist command
   call setloclist(0, [{"filename": "/path/vim.c"}, {"filename": "/path/vim.h"}, {"module": "Main.Test"}])


### PR DESCRIPTION
Since ":set" only shows options with non-default values, ensure
'helplang' has a value before trying to filter for it.