### PR TITLE
test_modeline: Ensure 'modeline' is enabled

### DIFF
--- a/src/testdir/test_modeline.vim
+++ b/src/testdir/test_modeline.vim
@@ -3,7 +3,10 @@
 func Test_modeline_invalid()
   " This was reading before allocated memory.
   call writefile(['vi:0', 'nothing'], 'Xmodeline')
+  let modeline=&modeline
+  set modeline
   call assert_fails('split Xmodeline', 'E518:')
+  let &modeline=modeline
   bwipe!
   call delete('Xmodeline')
 endfunc


### PR DESCRIPTION
If the test is run as root, then 'modeline' defaults to disabled.