### PR TITLE
Fix: :terminal truncate last newlines.

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1592,6 +1592,14 @@ update_snapshot(term_T *term)
 	}
     }
 
+    // Add last empty lines.
+    for (pos.row = term->tl_scrollback.ga_len; pos.row
+	    < term->tl_scrollback_scrolled + term->tl_cursor_pos.row; ++pos.row)
+    {
+	if (add_empty_scrollback(term, &fill_attr, 0) == OK)
+	    add_scrollback_line_to_buffer(term, (char_u *)"", 0);
+    }
+
     term->tl_dirty_snapshot = FALSE;
 #ifdef FEAT_TIMERS
     term->tl_timer_set = FALSE;

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1658,3 +1658,25 @@ func Test_terminal_hidden_and_close()
   call WaitForAssert({-> assert_false(bufexists(bnr))})
   call assert_equal(1, winnr('$'))
 endfunc
+
+func Test_terminal_does_not_truncate_last_newlines()
+  let cmd = has('win32') ? 'type' : 'cat'
+  let contents = [
+  \   [ 'One', '', 'X' ],
+  \   [ 'Two', '', '' ],
+  \   [ 'Three' ] + repeat([''], 30)
+  \ ]
+
+  for c in contents
+    call writefile(c, 'Xfile')
+    exec 'term' cmd 'Xfile'
+    let bnr = bufnr('$')
+    call assert_equal('terminal', getbufvar(bnr, '&buftype'))
+    call WaitForAssert({-> assert_equal('finished', term_getstatus(bnr))})
+    sleep 50m
+    call assert_equal(c, getline(1, line('$')))
+    quit
+  endfor
+
+  call delete('Xfile')
+endfunc


### PR DESCRIPTION
Hi Bram and developers,

How to reproduce:
- Exec vanilla Vim
  $ vim --clean
- Exec :terminal command with arguments.
  :term echo -e Hello\\n\\n

Expected behavior:
- Displayed three lines in terminal window.  ('Hello', '', '')
```
Hello


```

Actual behavior:
- Displayed only 'Hello'.

I wrote a patch with test.
Please check it out.

--

Best regards,
Hirohito Higashi (h_east)