### PR TITLE
Add completepath

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1866,6 +1866,21 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
+						*'completepath'* *'cop'*
+'completepath' 'cop'	string	(default: "")
+			local to buffer
+			{not in Vi}  {only for MS-Windows}
+	When set 'shellslash', CTRL-X CTRL-F expand path/filename with forward
+	slash separator. But when set 'noshellslash', backslash is used on
+	Windows. When "slash" is set for this option, a forward slash is used
+	for path completion in insert mode. This is useful when editing HTML
+	tag, or Makefile with 'noshellslash' on Windows.
+	When "backslash" is set to this option, backslash is used. This is
+	useful when editing batch file with 'shellslash' on Windows.
+	If empty string is set, same character is used for 'shellslash'.
+	And when global value is set, this behavior is enabled on command line
+	completion.
+
 						*'completeopt'* *'cot'*
 'completeopt' 'cot'	string	(default: "menu,preview")
 			global

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -5070,6 +5070,24 @@ ExpandFromContext(
 	ret = expand_wildcards_eval(&pat, num_file, file, flags);
 	if (free_pat)
 	    vim_free(pat);
+#ifdef BACKSLASH_IN_FILENAME
+	if (p_cop[0] != NUL)
+	{
+	    int	    i;
+	    for (i = 0; i < *num_file; ++i)
+	    {
+		char_u	*ptr = (*file)[i];
+		while (*ptr != NUL)
+		{
+		    if (p_cop[0] == 's' && *ptr == '\\')
+			*ptr = '/';
+		    else if (p_cop[0] == 'b' && *ptr == '/')
+			*ptr = '\\';
+		    ptr += (*mb_ptr2len)(ptr);
+		}
+	    }
+	}
+#endif
 	return ret;
     }
 

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2671,6 +2671,24 @@ ins_compl_get_exp(pos_T *ini)
 
 		// May change home directory back to "~".
 		tilde_replace(compl_pattern, num_matches, matches);
+#ifdef BACKSLASH_IN_FILENAME
+		if (curbuf->b_p_cop[0] != NUL)
+		{
+		    int	    i;
+		    for (i = 0; i < num_matches; ++i)
+		    {
+			char_u	*ptr = matches[i];
+			while (*ptr != NUL)
+			{
+			    if (curbuf->b_p_cop[0] == 's' && *ptr == '\\')
+				*ptr = '/';
+			    else if (curbuf->b_p_cop[0] == 'b' && *ptr == '/')
+				*ptr = '\\';
+			    ptr += (*mb_ptr2len)(ptr);
+			}
+		    }
+		}
+#endif
 		ins_compl_add_matches(num_matches, matches, p_fic || p_wic);
 	    }
 	    break;

--- a/src/option.c
+++ b/src/option.c
@@ -88,6 +88,7 @@
 # define PV_DICT	OPT_BOTH(OPT_BUF(BV_DICT))
 # define PV_TSR		OPT_BOTH(OPT_BUF(BV_TSR))
 #endif
+#define PV_COP		OPT_BUF(BV_COP)
 #ifdef FEAT_COMPL_FUNC
 # define PV_CFU		OPT_BUF(BV_CFU)
 #endif
@@ -885,6 +886,15 @@ static struct vimoption options[] =
 #ifdef FEAT_INS_EXPAND
 			    (char_u *)&p_cot, PV_NONE,
 			    {(char_u *)"menu,preview", (char_u *)0L}
+#else
+			    (char_u *)NULL, PV_NONE,
+			    {(char_u *)0L, (char_u *)0L}
+#endif
+			    SCTX_INIT},
+    {"completepath",   "cop",  P_STRING|P_VI_DEF|P_VIM,
+#if defined(FEAT_INS_EXPAND) && defined(BACKSLASH_IN_FILENAME)
+			    (char_u *)&p_cop, PV_COP,
+			    {(char_u *)"", (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L}
@@ -3220,6 +3230,7 @@ static char *(p_fcl_values[]) = {"all", NULL};
 #endif
 #ifdef FEAT_INS_EXPAND
 static char *(p_cot_values[]) = {"menu", "menuone", "longest", "preview", "noinsert", "noselect", NULL};
+static char *(p_cop_values[]) = {"slash", "backslash", NULL};
 #endif
 #ifdef FEAT_SIGNS
 static char *(p_scl_values[]) = {"yes", "no", "auto", NULL};
@@ -10880,7 +10891,6 @@ get_varp(struct vimoption *p)
 #endif
 	case PV_MENC:	return *curbuf->b_p_menc != NUL
 				    ? (char_u *)&(curbuf->b_p_menc) : p->var;
-
 #ifdef FEAT_ARABIC
 	case PV_ARAB:	return (char_u *)&(curwin->w_p_arab);
 #endif
@@ -10966,6 +10976,9 @@ get_varp(struct vimoption *p)
 #endif
 #ifdef FEAT_INS_EXPAND
 	case PV_CPT:	return (char_u *)&(curbuf->b_p_cpt);
+# ifdef BACKSLASH_IN_FILENAME
+	case PV_COP:	return (char_u *)&(curbuf->b_p_cop);
+# endif
 #endif
 #ifdef FEAT_COMPL_FUNC
 	case PV_CFU:	return (char_u *)&(curbuf->b_p_cfu);
@@ -11357,6 +11370,9 @@ buf_copy_options(buf_T *buf, int flags)
 	    buf->b_p_swf = cmdmod.noswapfile ? FALSE : p_swf;
 #ifdef FEAT_INS_EXPAND
 	    buf->b_p_cpt = vim_strsave(p_cpt);
+# ifdef BACKSLASH_IN_FILENAME
+	    buf->b_p_cop = vim_strsave(p_cop);
+# endif
 #endif
 #ifdef FEAT_COMPL_FUNC
 	    buf->b_p_cfu = vim_strsave(p_cfu);

--- a/src/option.h
+++ b/src/option.h
@@ -412,6 +412,9 @@ EXTERN int	p_confirm;	/* 'confirm' */
 EXTERN int	p_cp;		/* 'compatible' */
 #ifdef FEAT_INS_EXPAND
 EXTERN char_u	*p_cot;		/* 'completeopt' */
+# ifdef BACKSLASH_IN_FILENAME
+EXTERN char_u  	*p_cop;		/* 'completepath' */
+# endif
 EXTERN long	p_ph;		/* 'pumheight' */
 EXTERN long	p_pw;		/* 'pumwidth' */
 #endif
@@ -992,6 +995,9 @@ enum
     , BV_CPT
     , BV_DICT
     , BV_TSR
+#endif
+#ifdef BACKSLASH_IN_FILENAME
+    , BV_COP
 #endif
 #ifdef FEAT_COMPL_FUNC
     , BV_CFU

--- a/src/structs.h
+++ b/src/structs.h
@@ -2267,6 +2267,9 @@ struct file_buffer
 #ifdef FEAT_INS_EXPAND
     char_u	*b_p_cpt;	/* 'complete' */
 #endif
+#ifdef BACKSLASH_IN_FILENAME
+    char_u	*b_p_cop;	/* 'completepath' */
+#endif
 #ifdef FEAT_COMPL_FUNC
     char_u	*b_p_cfu;	/* 'completefunc' */
     char_u	*b_p_ofu;	/* 'omnifunc' */

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -320,11 +320,10 @@ func Test_ins_completepath()
     return
   endif
   
-  edit test_ins_complete.vim
-
   call mkdir('Xdir')
 
   let orig_shellslash = &shellslash
+  set cpt&
 
   new
   

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -331,29 +331,29 @@ func Test_ins_completepath()
   set noshellslash
 
   set completepath=
-  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir\', getline('.'))
 
   set completepath=backslash
-  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir\', getline('.'))
 
   set completepath=slash
-  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir/', getline('.'))
 
   set shellslash
 
   set completepath=
-  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir/', getline('.'))
 
   set completepath=backslash
-  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir\', getline('.'))
 
   set completepath=slash
-  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir/', getline('.'))
   %bw!
   call delete('Xdir', 'rf')

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -313,3 +313,51 @@ func Test_compl_feedkeys()
   bwipe!
   set completeopt&
 endfunc
+
+" Test for insert path completion with completepath option
+func Test_ins_completepath()
+  if !has('win32')
+    return
+  endif
+  
+  edit test_ins_complete.vim
+
+  call mkdir('Xdir')
+
+  let orig_shellslash = &shellslash
+
+  new
+  
+  set noshellslash
+
+  set completepath=
+  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  call assert_equal('Xdir\', getline('.'))
+
+  set completepath=backslash
+  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  call assert_equal('Xdir\', getline('.'))
+
+  set completepath=slash
+  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  call assert_equal('Xdir/', getline('.'))
+
+  set shellslash
+
+  set completepath=
+  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  call assert_equal('Xdir/', getline('.'))
+
+  set completepath=backslash
+  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  call assert_equal('Xdir\', getline('.'))
+
+  set completepath=slash
+  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  call assert_equal('Xdir/', getline('.'))
+  %bw!
+  call delete('Xdir', 'rf')
+
+  let &shellslash = orig_shellslash
+endfunc
+

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -331,29 +331,29 @@ func Test_ins_completepath()
   set noshellslash
 
   set completepath=
-  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir\', getline('.'))
 
   set completepath=backslash
-  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir\', getline('.'))
 
   set completepath=slash
-  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir/', getline('.'))
 
   set shellslash
 
   set completepath=
-  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir/', getline('.'))
 
   set completepath=backslash
-  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir\', getline('.'))
 
   set completepath=slash
-  exe "normal o\<C-N>\<Esc>IX\<Esc>A\<C-X>\<C-F>\<C-N>"
+  exe "normal o\<C-N>\<Esc>IXd\<Esc>A\<C-X>\<C-F>\<C-N>"
   call assert_equal('Xdir/', getline('.'))
   %bw!
   call delete('Xdir', 'rf')

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -330,29 +330,29 @@ func Test_ins_completepath()
   set noshellslash
 
   set completepath=
-  exe "normal oXd\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>"
   call assert_equal('Xdir\', getline('.'))
 
   set completepath=backslash
-  exe "normal oXd\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>"
   call assert_equal('Xdir\', getline('.'))
 
   set completepath=slash
-  exe "normal oXd\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>"
   call assert_equal('Xdir/', getline('.'))
 
   set shellslash
 
   set completepath=
-  exe "normal oXd\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>"
   call assert_equal('Xdir/', getline('.'))
 
   set completepath=backslash
-  exe "normal oXd\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>"
   call assert_equal('Xdir\', getline('.'))
 
   set completepath=slash
-  exe "normal oXd\<C-X>\<C-F>\<C-N>"
+  exe "normal oXd\<C-X>\<C-F>"
   call assert_equal('Xdir/', getline('.'))
   %bw!
   call delete('Xdir', 'rf')


### PR DESCRIPTION
On Windows, most of users uses noshellslash, however they (including me) are thinking that file completion is not useful for coding HTML or Makefile, css, etc... since those files should use slash separated paths. I added `completepath`. If enable this, file completion use slash separated paths even though noshellslash.