### PR TITLE
Fixed gvim --windowid feature bug in Windows

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -689,7 +689,7 @@ gui_init(void)
 #ifndef FEAT_GUI_GTK
     /* Set the shell size, adjusted for the screen size.  For GTK this only
      * works after the shell has been opened, thus it is further down. */
-    gui_set_shellsize(TRUE, TRUE, RESIZE_BOTH);
+    gui_set_shellsize(FALSE, TRUE, RESIZE_BOTH);
 #endif
 #if defined(FEAT_GUI_MOTIF) && defined(FEAT_MENU)
     /* Need to set the size of the menubar after all the menus have been


### PR DESCRIPTION
* When attaching gvim to foreign window in Windows with --windowid flag it did not resize to fit parent region correctly on creation