### PR TITLE
Avoid calling ui_breakcheck recursively

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -403,7 +403,12 @@ ui_breakcheck(void)
     void
 ui_breakcheck_force(int force)
 {
+    static int	recursive = 0;
     int save_updating_screen = updating_screen;
+
+    if (recursive)
+	return;
+    recursive++;
 
     /* We do not want gui_resize_shell() to redraw the screen here. */
     ++updating_screen;
@@ -419,6 +424,8 @@ ui_breakcheck_force(int force)
 	updating_screen = TRUE;
     else
 	reset_updating_screen(FALSE);
+
+    recursive--;
 }
 
 /*****************************************************************************


### PR DESCRIPTION
It's possible to get stuck in an infinitely recursive call loop when
stderr is redirected.  A call to ui_breakcheck() will eventually make
its way to fill_input_buf(), which calls settmode() when stdin isn't a
tty.

settmode() calls down to vgetorpeek(), which then calls ui_breakcheck()
to see if it should break out of an infinite for loop.