### PR TITLE
Fix test_set_background (in test_gui.vim) to not assume light background

### DIFF
--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -161,7 +161,7 @@ endfunc
 func Test_set_background()
   let background_saved = &background
 
-  set background&
+  set background=light
   call assert_equal('light', &background)
 
   set background=dark


### PR DESCRIPTION
Technically, gVim doesn't assume a default white background as it's platform-specific and depends on user settings. The current implementation of `test_set_background` assumes the default is "light" and that could break under certain implementations or user settings. Fix it to set background to "light" explicitly instead.

The relevant parts of the docs (`:h 'background'`):

> 'background' 'bg'	string	(default "dark" or "light", see below)

> When starting the GUI, the default value for 'background' will be "light".  When the value is not set in the .gvimrc, and Vim detects that the background is actually quite dark, 'background' is set to "dark".  But this happens only AFTER the .gvimrc file has been read (because the window needs to be opened to find the actual background color).  To get around this, force the GUI window to be opened by putting a ":gui" command in the .gvimrc file, before where the value of 'background' is used (e.g., before ":syntax on").
