### PR TITLE
Fixing some issues found by coverity scan

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1378,6 +1378,8 @@ getcmdline_int(
 			    redrawcmd();
 			    goto cmdline_changed;
 			}
+			else
+			    vim_free(p);
 		    }
 		}
 		beep_flush();

--- a/src/move.c
+++ b/src/move.c
@@ -1961,7 +1961,7 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
 	    scrolled += loff.height;
 	    if (loff.lnum == curwin->w_botline
 #ifdef FEAT_DIFF
-			    && boff.fill == 0
+			    && loff.fill == 0
 #endif
 		    )
 		scrolled -= curwin->w_empty_rows;


### PR DESCRIPTION
Hi,

I did coverity scan on Vim when Vim 8.0 was in Fedora 28 and the scan found several issues - mostly false positives I reckon, but I selected two of them, which seemed worth to fix - here are results with reasoning why I think it is/is not false positives https://zdohnal.fedorapeople.org/.vim/scan-results-imp.err .
Does it look worth to fix?