### PR TITLE
Fix termdebug

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -73,8 +73,9 @@ let s:pc_id = 12
 let s:break_id = 13  " breakpoint number is added to this
 let s:stopped = 1
 
-function s:NR(nr)
-  return '' . float2nr(str2float(a:nr) * 1000)
+func s:NR(nr)
+  let t = split(a:nr, '\.')
+  return len(t) == 2 ? t[0] * 1000 + t[1] : t[0] * 1000
 endfunction
 
 func s:Highlight(init, old, new)

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -75,7 +75,7 @@ let s:stopped = 1
 
 func s:NR(nr)
   let t = split(a:nr, '\.')
-  return len(t) == 2 ? t[0] * 1000 + t[1] : t[0] * 1000
+  return t[0] * 1000 + len(t) == 2 ? t[1] : 0
 endfunction
 
 func s:Highlight(init, old, new)

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -73,6 +73,10 @@ let s:pc_id = 12
 let s:break_id = 13  " breakpoint number is added to this
 let s:stopped = 1
 
+function s:NR(nr)
+  return '' . float2nr(a:nr * 1000)
+endfunction
+
 func s:Highlight(init, old, new)
   let default = a:init ? 'default ' : ''
   if a:new ==# 'light' && a:old !=# 'light'
@@ -138,9 +142,9 @@ endfunc
 func s:StartDebug_term(dict)
   " Open a terminal window without a job, to run the debugged program in.
   let s:ptybuf = term_start('NONE', {
-	\ 'term_name': 'debugged program',
-	\ 'vertical': s:vertical,
-	\ })
+        \ 'term_name': 'debugged program',
+        \ 'vertical': s:vertical,
+        \ })
   if s:ptybuf == 0
     echoerr 'Failed to open the program terminal window'
     return
@@ -155,10 +159,10 @@ func s:StartDebug_term(dict)
 
   " Create a hidden terminal window to communicate with gdb
   let s:commbuf = term_start('NONE', {
-	\ 'term_name': 'gdb communication',
-	\ 'out_cb': function('s:CommOutput'),
-	\ 'hidden': 1,
-	\ })
+        \ 'term_name': 'gdb communication',
+        \ 'out_cb': function('s:CommOutput'),
+        \ 'hidden': 1,
+        \ })
   if s:commbuf == 0
     echoerr 'Failed to open the communication terminal window'
     exe 'bwipe! ' . s:ptybuf
@@ -174,9 +178,9 @@ func s:StartDebug_term(dict)
   let cmd = [g:termdebugger, '-quiet', '-tty', pty] + gdb_args
   call ch_log('executing "' . join(cmd) . '"')
   let s:gdbbuf = term_start(cmd, {
-	\ 'exit_cb': function('s:EndTermDebug'),
-	\ 'term_finish': 'close',
-	\ })
+        \ 'exit_cb': function('s:EndTermDebug'),
+        \ 'term_finish': 'close',
+        \ })
   if s:gdbbuf == 0
     echoerr 'Failed to open the gdb terminal window'
     exe 'bwipe! ' . s:ptybuf
@@ -200,18 +204,18 @@ func s:StartDebug_term(dict)
     let response = ''
     for lnum in range(1,200)
       if term_getline(s:gdbbuf, lnum) =~ 'new-ui mi '
-	" response can be in the same line or the next line
-	let response = term_getline(s:gdbbuf, lnum) . term_getline(s:gdbbuf, lnum + 1)
-	if response =~ 'Undefined command'
-	  echoerr 'Sorry, your gdb is too old, gdb 7.12 is required'
-	  exe 'bwipe! ' . s:ptybuf
-	  exe 'bwipe! ' . s:commbuf
-	  return
-	endif
-	if response =~ 'New UI allocated'
-	  " Success!
-	  break
-	endif
+        " response can be in the same line or the next line
+        let response = term_getline(s:gdbbuf, lnum) . term_getline(s:gdbbuf, lnum + 1)
+        if response =~ 'Undefined command'
+          echoerr 'Sorry, your gdb is too old, gdb 7.12 is required'
+          exe 'bwipe! ' . s:ptybuf
+          exe 'bwipe! ' . s:commbuf
+          return
+        endif
+        if response =~ 'New UI allocated'
+          " Success!
+          break
+        endif
       endif
     endfor
     if response =~ 'New UI allocated'
@@ -268,9 +272,9 @@ func s:StartDebug_prompt(dict)
   call ch_log('executing "' . join(cmd) . '"')
 
   let s:gdbjob = job_start(cmd, {
-	\ 'exit_cb': function('s:EndPromptDebug'),
-	\ 'out_cb': function('s:GdbOutCallback'),
-	\ })
+        \ 'exit_cb': function('s:EndPromptDebug'),
+        \ 'out_cb': function('s:GdbOutCallback'),
+        \ })
   if job_status(s:gdbjob) != "run"
     echoerr 'Failed to start gdb'
     exe 'bwipe! ' . s:promptbuf
@@ -295,8 +299,8 @@ func s:StartDebug_prompt(dict)
     " Unix: Run the debugged program in a terminal window.  Open it below the
     " gdb window.
     belowright let s:ptybuf = term_start('NONE', {
-	  \ 'term_name': 'debugged program',
-	  \ })
+          \ 'term_name': 'debugged program',
+          \ })
     if s:ptybuf == 0
       echoerr 'Failed to open the program terminal window'
       call job_stop(s:gdbjob)
@@ -466,9 +470,9 @@ func s:DecodeMessage(quotedText)
     if a:quotedText[i] == '\'
       let i += 1
       if a:quotedText[i] == 'n'
-	" drop \n
-	let i += 1
-	continue
+        " drop \n
+        let i += 1
+        continue
       endif
     endif
     let result .= a:quotedText[i]
@@ -479,6 +483,9 @@ endfunc
 
 " Extract the "name" value from a gdb message with fullname="name".
 func s:GetFullname(msg)
+  if a:msg !~ 'fullname'
+    return ''
+  endif
   let name = s:DecodeMessage(substitute(a:msg, '.*fullname=', '', ''))
   if has('win32') && name =~ ':\\\\'
     " sometimes the name arrives double-escaped
@@ -549,17 +556,17 @@ func s:CommOutput(chan, msg)
     endif
     if msg != ''
       if msg =~ '^\(\*stopped\|\*running\|=thread-selected\)'
-	call s:HandleCursor(msg)
+        call s:HandleCursor(msg)
       elseif msg =~ '^\^done,bkpt=' || msg =~ '^=breakpoint-created,'
-	call s:HandleNewBreakpoint(msg)
+        call s:HandleNewBreakpoint(msg)
       elseif msg =~ '^=breakpoint-deleted,'
-	call s:HandleBreakpointDelete(msg)
+        call s:HandleBreakpointDelete(msg)
       elseif msg =~ '^=thread-group-started'
-	call s:HandleProgramRun(msg)
+        call s:HandleProgramRun(msg)
       elseif msg =~ '^\^done,value='
-	call s:HandleEvaluate(msg)
+        call s:HandleEvaluate(msg)
       elseif msg =~ '^\^error,msg='
-	call s:HandleError(msg)
+        call s:HandleError(msg)
       endif
     endif
   endfor
@@ -650,12 +657,12 @@ func s:DeleteCommands()
     let curwinid = win_getid(winnr())
     for winid in s:winbar_winids
       if win_gotoid(winid)
-	aunmenu WinBar.Step
-	aunmenu WinBar.Next
-	aunmenu WinBar.Finish
-	aunmenu WinBar.Cont
-	aunmenu WinBar.Stop
-	aunmenu WinBar.Eval
+        aunmenu WinBar.Step
+        aunmenu WinBar.Next
+        aunmenu WinBar.Finish
+        aunmenu WinBar.Cont
+        aunmenu WinBar.Stop
+        aunmenu WinBar.Eval
       endif
     endfor
     call win_gotoid(curwinid)
@@ -700,7 +707,7 @@ func s:SetBreakpoint()
   endif
   " Use the fname:lnum format, older gdb can't handle --source.
   call s:SendCommand('-break-insert '
-	\ . fnameescape(expand('%:p')) . ':' . line('.'))
+        \ . fnameescape(expand('%:p')) . ':' . line('.'))
   if do_continue
     call s:SendCommand('-exec-continue')
   endif
@@ -839,14 +846,14 @@ func s:HandleCursor(msg)
     if lnum =~ '^[0-9]*$'
     call s:GotoSourcewinOrCreateIt()
       if expand('%:p') != fnamemodify(fname, ':p')
-	if &modified
-	  " TODO: find existing window
-	  exe 'split ' . fnameescape(fname)
-	  let s:sourcewin = win_getid(winnr())
-	  call s:InstallWinbar()
-	else
-	  exe 'edit ' . fnameescape(fname)
-	endif
+        if &modified
+          " TODO: find existing window
+          exe 'split ' . fnameescape(fname)
+          let s:sourcewin = win_getid(winnr())
+          call s:InstallWinbar()
+        else
+          exe 'edit ' . fnameescape(fname)
+        endif
       endif
       exe lnum
       exe 'sign unplace ' . s:pc_id
@@ -865,9 +872,13 @@ let s:BreakpointSigns = []
 func s:CreateBreakpoint(nr)
   if index(s:BreakpointSigns, a:nr) == -1
     call add(s:BreakpointSigns, a:nr)
-    exe "sign define debugBreakpoint" . a:nr . " text=" . a:nr . " texthl=debugBreakpoint"
+    exe "sign define debugBreakpoint" . a:nr . " text=" . substitute(a:nr, '\..*', '', '') . " texthl=debugBreakpoint"
   endif
 endfunc
+
+func! s:SplitMsg(s)
+  return split(a:s, '{\%([a-z-]\+=[^,]\+,*\)\+}\zs')
+endfunction
 
 " Handle setting a breakpoint
 " Will update the sign that shows the breakpoint
@@ -876,50 +887,57 @@ func s:HandleNewBreakpoint(msg)
     " a watch does not have a file name
     return
   endif
+  for msg in s:SplitMsg(a:msg)
+    let fname = s:GetFullname(msg)
+    if empty(fname)
+      continue
+    endif
+    let nr = substitute(msg, '.*number="\([0-9.]*\)\".*', '\1', '')
+    if empty(nr)
+      return
+    endif
+    call s:CreateBreakpoint(nr)
 
-  let nr = substitute(a:msg, '.*number="\([0-9]*\)".*', '\1', '') + 0
-  if nr == 0
-    return
-  endif
-  call s:CreateBreakpoint(nr)
+    if has_key(s:breakpoints, nr)
+      let entry = s:breakpoints[nr]
+    else
+      let entry = {}
+      let s:breakpoints[nr] = entry
+    endif
 
-  if has_key(s:breakpoints, nr)
-    let entry = s:breakpoints[nr]
-  else
-    let entry = {}
-    let s:breakpoints[nr] = entry
-  endif
+    let lnum = substitute(msg, '.*line="\([^"]*\)".*', '\1', '')
+    let entry['fname'] = fname
+    let entry['lnum'] = lnum
 
-  let fname = s:GetFullname(a:msg)
-  let lnum = substitute(a:msg, '.*line="\([^"]*\)".*', '\1', '')
-  let entry['fname'] = fname
-  let entry['lnum'] = lnum
-
-  if bufloaded(fname)
-    call s:PlaceSign(nr, entry)
-  endif
+    if bufloaded(fname)
+      call s:PlaceSign(nr, entry)
+    endif
+  endfor
 endfunc
 
 func s:PlaceSign(nr, entry)
-  exe 'sign place ' . (s:break_id + a:nr) . ' line=' . a:entry['lnum'] . ' name=debugBreakpoint' . a:nr . ' file=' . a:entry['fname']
+  exe 'sign place ' . (s:break_id +  s:NR(a:nr)) . ' line=' . a:entry['lnum'] . ' name=debugBreakpoint' . a:nr . ' file=' . a:entry['fname']
   let a:entry['placed'] = 1
 endfunc
 
 " Handle deleting a breakpoint
 " Will remove the sign that shows the breakpoint
 func s:HandleBreakpointDelete(msg)
-  let nr = substitute(a:msg, '.*id="\([0-9]*\)\".*', '\1', '') + 0
-  if nr == 0
+  let key = substitute(a:msg, '.*id="\([0-9.]*\)\".*', '\1', '')
+  if empty(key)
     return
   endif
-  if has_key(s:breakpoints, nr)
+  for [nr, entry] in items(s:breakpoints)
+    if stridx(nr, key) != 0
+      continue
+    endif
     let entry = s:breakpoints[nr]
     if has_key(entry, 'placed')
-      exe 'sign unplace ' . (s:break_id + nr)
+      exe 'sign unplace ' . (s:break_id + s:NR(nr))
       unlet entry['placed']
     endif
     unlet s:breakpoints[nr]
-  endif
+  endfor
 endfunc
 
 " Handle the debugged program starting to run.

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -74,7 +74,7 @@ let s:break_id = 13  " breakpoint number is added to this
 let s:stopped = 1
 
 function s:NR(nr)
-  return '' . float2nr(a:nr * 1000)
+  return '' . float2nr(str2float(a:nr) * 1000)
 endfunction
 
 func s:Highlight(init, old, new)


### PR DESCRIPTION
This is an issue reported by @EzoeRyou on VimConf2018.

Current implementation, termdebug treat the break point ID as an integer. But when add break point to functions that have same name but overloaded, termdebug does not add sign into the functions since gdb return break point ID like floating point number. This change handle those IDs and make be possible to add multiple break points. 