### PR TITLE
vim-da.1: Escape lines starting with '

### DIFF
--- a/runtime/doc/vim-da.1
+++ b/runtime/doc/vim-da.1
@@ -321,13 +321,13 @@ Når N udelades, så åbnes én fanebladsside pr. fil.
 .TP
 \-R
 Skrivebeskyttet tilstand.
-'readonly'-valgmuligheden sættes.
+\&'readonly'-valgmuligheden sættes.
 Du kan stadig redigere bufferen, men vil være forhindret i
 fejlagtigt at overskrive en fil.
 Hvis du vil overskrive en fil, så tilføj et
 udråbstegn til Ex-kommandoen, som i ":w!".
 \-R-tilvalget indebærer også \-n-tilvalget (se ovenfor).
-'readonly'-valgmuligheden kan slås fra med ":set noro".
+\&'readonly'-valgmuligheden kan slås fra med ":set noro".
 Se ":help 'readonly'".
 .TP
 \-r

--- a/runtime/doc/vim-da.UTF-8.1
+++ b/runtime/doc/vim-da.UTF-8.1
@@ -321,13 +321,13 @@ Når N udelades, så åbnes én fanebladsside pr. fil.
 .TP
 \-R
 Skrivebeskyttet tilstand.
-'readonly'-valgmuligheden sættes.
+\&'readonly'-valgmuligheden sættes.
 Du kan stadig redigere bufferen, men vil være forhindret i
 fejlagtigt at overskrive en fil.
 Hvis du vil overskrive en fil, så tilføj et
 udråbstegn til Ex-kommandoen, som i ":w!".
 \-R-tilvalget indebærer også \-n-tilvalget (se ovenfor).
-'readonly'-valgmuligheden kan slås fra med ":set noro".
+\&'readonly'-valgmuligheden kan slås fra med ":set noro".
 Se ":help 'readonly'".
 .TP
 \-r


### PR DESCRIPTION
A ' at the start of a line is an escape sequence in groff.  Use the
zero-width \& at the start of the line to avoid this.

Cc @scootergrisen