### PR TITLE
commands: allow using `-addr=other` with user commands

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5940,6 +5940,7 @@ static struct
     {ADDR_BUFFERS, "buffers"},
     {ADDR_WINDOWS, "windows"},
     {ADDR_QUICKFIX, "quickfix"},
+    {ADDR_OTHER, "other"},
     {-1, NULL}
 };
 #endif


### PR DESCRIPTION
(This is useful e.g. for user commands that wrap location/quickfix list
navigation, where `-addr=quickfix` cannot be used (because it only uses
the location list with internal commands, starting with "l").)

Ref: https://github.com/vim/vim/issues/3654