### PR TITLE
Added test for error E963 when doing :let v:errors=''

### DIFF
--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -53,3 +53,9 @@ func Test_line_continuation()
 	"\ and some more
   call assert_equal([5, 6], array)
 endfunc
+
+func Test_E963()
+  " These commands used to cause an internal error prior to vim 8.1.0563
+  call assert_fails("let v:errors=''", 'E963:')
+  call assert_fails("let v:oldfiles=''", 'E963:')
+endfunc


### PR DESCRIPTION
This PR adds a test for the internal error which was
changed to a regular error E963 in 8.1.0563 and which
happens when doing :let v:errors=''
