### PR TITLE
Fix typo (mrsvim.vim -> mrswin.vim)

### DIFF
--- a/runtime/mswin.vim
+++ b/runtime/mswin.vim
@@ -1,9 +1,9 @@
 " Set options and add mapping such that Vim behaves a lot like MS-Windows
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last change:	2017 Oct 28
+" Last change:	2018 Dec 6
 
-" bail out if this isn't wanted (mrsvim.vim uses this).
+" bail out if this isn't wanted.
 if exists("g:skip_loading_mswin") && g:skip_loading_mswin
   finish
 endif


### PR DESCRIPTION
I think this is referring to https://github.com/vim-scripts/mrswin.vim.