### PR TITLE
Enable SGR mouse support on mintty

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8433,7 +8433,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	number, more intelligent detection process runs.
 	The "xterm2" value will be set if the xterm version is reported to be
 	from 95 to 276.  The "sgr" value will be set if the xterm version is
-	277 or higher and when Vim detects Mac Terminal.app or iTerm2.
+	277 or higher or when Vim detects Mac Terminal.app, iTerm2 or mintty.
 	If you do not want 'ttymouse' to be set to "xterm2" or "sgr"
 	automatically, set t_RV to an empty string: >
 		:set t_RV=

--- a/src/term.c
+++ b/src/term.c
@@ -4698,6 +4698,12 @@ check_termcode(
 			int need_flush = FALSE;
 # ifdef FEAT_MOUSE_SGR
 			int is_iterm2 = FALSE;
+			int is_mintty = FALSE;
+
+			// mintty 2.9.5 sends 77;20905;0c.
+			// (77 is ASCII 'M' for mintty.)
+			if (STRNCMP(tp + extra - 3, "77;", 3) == 0)
+			    is_mintty = TRUE;
 # endif
 
 			/* if xterm version >= 141 try to get termcap codes */
@@ -4751,8 +4757,9 @@ check_termcode(
 			{
 # ifdef FEAT_MOUSE_SGR
 			    /* Xterm version 277 supports SGR.  Also support
-			     * Terminal.app and iTerm2. */
-			    if (version >= 277 || is_iterm2 || is_mac_terminal)
+			     * Terminal.app, iTerm2 and mintty. */
+			    if (version >= 277 || is_iterm2 || is_mac_terminal
+				    || is_mintty)
 				set_option_value((char_u *)"ttym", 0L,
 							  (char_u *)"sgr", 0);
 			    else


### PR DESCRIPTION
This was originally discussed at mintty/mintty#827.

Currently 'ttymouse' is set to "xterm" even mintty supports SGR mouse mode.
I think it is useful if Vim detects mintty and set 'ttymouse' to "sgr" automatically.

mintty 2.9.5 returns `ESC[>77;20905;0c` to `v:termresponse`. (`77` is ASCII 'M'.)
This PR detects mintty by checking `77;`.