### PR TITLE
Fix termdebug

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -75,9 +75,8 @@ let s:stopped = 1
 
 " Take a breakpoint number as used by GDB and turn it into an integer.
 " The breakpoint may contain a dot: 123.4
-func s:Breakpoint2SignNumber(nr)
-  let t = split(a:nr, '\.')
-  return t[0] * 1000 + (len(t) == 2 ? t[1] : 0)
+func s:Breakpoint2SignNumber(id, subid)
+  return s:break_id + a:id * 1000 + a:subid
 endfunction
 
 func s:Highlight(init, old, new)
@@ -683,8 +682,10 @@ func s:DeleteCommands()
   endif
 
   exe 'sign unplace ' . s:pc_id
-  for key in keys(s:breakpoints)
-    exe 'sign unplace ' . (s:break_id + s:Breakpoint2SignNumber(key))
+  for [id, entries] in items(s:breakpoints)
+    for subid in keys(entries)
+      exe 'sign unplace ' . s:Breakpoint2SignNumber(id, subid)
+    endfor
   endfor
   unlet s:breakpoints
 
@@ -721,14 +722,18 @@ endfunc
 func s:ClearBreakpoint()
   let fname = fnameescape(expand('%:p'))
   let lnum = line('.')
-  for [key, val] in items(s:breakpoints)
-    if val['fname'] == fname && val['lnum'] == lnum
-      call s:SendCommand('-break-delete ' . key)
-      " Assume this always wors, the reply is simply "^done".
-      exe 'sign unplace ' . (s:break_id + s:Breakpoint2SignNumber(key))
-      unlet s:breakpoints[key]
-      break
-    endif
+  for [id, entries] in items(s:breakpoints)
+    for entry in values(entries)
+      if entry['fname'] == fname && entry['lnum'] == lnum
+        call s:SendCommand('-break-delete ' . id)
+        for subid in keys(entries)
+          " Assume this always wors, the reply is simply "^done".
+          exe 'sign unplace ' . s:Breakpoint2SignNumber(id, subid)
+        endfor
+        unlet s:breakpoints[id]
+        return
+      endif
+    endfor
   endfor
 endfunc
 
@@ -873,15 +878,16 @@ endfunc
 
 let s:BreakpointSigns = []
 
-func s:CreateBreakpoint(nr)
-  if index(s:BreakpointSigns, a:nr) == -1
-    call add(s:BreakpointSigns, a:nr)
-    exe "sign define debugBreakpoint" . a:nr . " text=" . substitute(a:nr, '\..*', '', '') . " texthl=debugBreakpoint"
+func s:CreateBreakpoint(id, subid)
+  let nr = printf('%d.%d', a:id, a:subid)
+  if index(s:BreakpointSigns, nr) == -1
+    call add(s:BreakpointSigns, nr)
+    exe "sign define debugBreakpoint" . nr . " text=" . substitute(nr, '\..*', '', '') . " texthl=debugBreakpoint"
   endif
 endfunc
 
-func s:SplitMsg(s)
-  return split(a:s, '{\%([a-z-]\+=[^,]\+,*\)\+}\zs')
+func! s:SplitMsg(s)
+  return split(a:s, '{.\{-}}\zs')
 endfunction
 
 " Handle setting a breakpoint
@@ -900,13 +906,21 @@ func s:HandleNewBreakpoint(msg)
     if empty(nr)
       return
     endif
-    call s:CreateBreakpoint(nr)
 
-    if has_key(s:breakpoints, nr)
-      let entry = s:breakpoints[nr]
+    let [id, subid; _] = map(split(nr . '.0', '\.'), 'v:val + 0')
+    call s:CreateBreakpoint(id, subid)
+
+    if has_key(s:breakpoints, id)
+      let entries = s:breakpoints[id]
+    else
+      let entries = {}
+      let s:breakpoints[id] = entries
+    endif
+    if has_key(entries, subid)
+      let entry = entries[subid]
     else
       let entry = {}
-      let s:breakpoints[nr] = entry
+      let entries[subid] = entry
     endif
 
     let lnum = substitute(msg, '.*line="\([^"]*\)".*', '\1', '')
@@ -914,34 +928,33 @@ func s:HandleNewBreakpoint(msg)
     let entry['lnum'] = lnum
 
     if bufloaded(fname)
-      call s:PlaceSign(nr, entry)
+      call s:PlaceSign(id, subid, entry)
     endif
   endfor
 endfunc
 
-func s:PlaceSign(nr, entry)
-  exe 'sign place ' . (s:break_id +  s:Breakpoint2SignNumber(a:nr)) . ' line=' . a:entry['lnum'] . ' name=debugBreakpoint' . a:nr . ' file=' . a:entry['fname']
+func s:PlaceSign(id, subid, entry)
+  let nr = printf('%d.%d', a:id, a:subid)
+  exe 'sign place ' . s:Breakpoint2SignNumber(a:id, a:subid) . ' line=' . a:entry['lnum'] . ' name=debugBreakpoint' . nr . ' file=' . a:entry['fname']
   let a:entry['placed'] = 1
 endfunc
 
 " Handle deleting a breakpoint
 " Will remove the sign that shows the breakpoint
 func s:HandleBreakpointDelete(msg)
-  let key = substitute(a:msg, '.*id="\([0-9.]*\)\".*', '\1', '')
-  if empty(key)
+  let id = substitute(a:msg, '.*id="\([0-9]*\)\".*', '\1', '') + 0
+  if empty(id)
     return
   endif
-  for [nr, entry] in items(s:breakpoints)
-    if stridx(nr, key) != 0
-      continue
-    endif
-    let entry = s:breakpoints[nr]
-    if has_key(entry, 'placed')
-      exe 'sign unplace ' . (s:break_id + s:Breakpoint2SignNumber(nr))
-      unlet entry['placed']
-    endif
-    unlet s:breakpoints[nr]
-  endfor
+  if has_key(s:breakpoints, id)
+    for [subid, entry] in items(s:breakpoints[id])
+      if has_key(entry, 'placed')
+        exe 'sign unplace ' . s:Breakpoint2SignNumber(id, subid)
+        unlet entry['placed']
+      endif
+    endfor
+    unlet s:breakpoints[id]
+  endif
 endfunc
 
 " Handle the debugged program starting to run.
@@ -958,20 +971,24 @@ endfunc
 " Handle a BufRead autocommand event: place any signs.
 func s:BufRead()
   let fname = expand('<afile>:p')
-  for [nr, entry] in items(s:breakpoints)
-    if entry['fname'] == fname
-      call s:PlaceSign(nr, entry)
-    endif
+  for [id, entries] in items(s:breakpoints)
+    for [subid, entry] in items(entries)
+      if entry['fname'] == fname
+        call s:PlaceSign(id, subid, entry)
+      endif
+    endfor
   endfor
 endfunc
 
 " Handle a BufUnloaded autocommand event: unplace any signs.
 func s:BufUnloaded()
   let fname = expand('<afile>:p')
-  for [nr, entry] in items(s:breakpoints)
-    if entry['fname'] == fname
-      let entry['placed'] = 0
-    endif
+  for [id, entries] in items(s:breakpoints)
+    for [subid, entry] in items(entries)
+      if entry['fname'] == fname
+        let entry['placed'] = 0
+      endif
+    endfor
   endfor
 endfunc
 


### PR DESCRIPTION
## Problem

Sample C++ source:

```cpp
class A {};
void func() {}              // 1
void func(A) {}             // 2
void func(A, A) {}          // 3
void func(A, A, A) {}       // 4
void func(A, A, A, A) {}    // 5
void func(A, A, A, A, A) {} // 6
int main(void)
{
    func(A(), A());
    return 0;
}
```

### `SplitMsg()` doesn't work properly when C++ function signature has comma

When do gdb command `break func`:

Expected: set breakpoint sign at all `func(...)`
Actual: set sign only at `func` of 1,2,6.

Because vim receives the message like the following from gdb, `func=` field has comma, then `SplitMsg()` (`split(a:s, '{\%([a-z-]\+=[^,]\+,*\)\+}\zs')`) cannot separate message parts properly.

```
=breakpoint-created,bkpt=...,{number="2.3",enabled="y",addr="0x000000000000067c",func="func(A, A)",file="hello.cc",fullname="/home/who/trunk/tmp/hello.cc",line="4",thread-groups=["i1"]},..
```

### `Clear` command behavior

When do gdb command `break func` and do `:Clear` on the line of any `func(...)`, its sign highlighting is removed but breakpoint does not deleted (disabled).

After do `:Clear` on the line of `void func() {}` (breakpoint 1.1):
```
(gdb) info breakpoints
Num     Type           Disp Enb Address            What
1       breakpoint     keep y   <MULTIPLE>
1.1                         y     0x000000000000066e in func() at hello.cc:2
1.2                         y     0x0000000000000675 in func(A) at hello.cc:3
1.3                         y     0x000000000000067c in func(A, A) at hello.cc:4
1.4                         y     0x0000000000000683 in func(A, A, A) at hello.cc:5
1.5                         y     0x000000000000068a in func(A, A, A, A) at hello.cc:6
1.6                         y     0x0000000000000691 in func(A, A, A, A, A) at hello.cc:7
```

breakpoint 1.1 is still active.

gdb command `clear 2` delete the all breakpoints of `1.*`, so this patch makes `:Clear` behavior the same.