### PR TITLE
Fix creating vim.Function object in if_python3

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -2922,8 +2922,7 @@ FunctionNew(PyTypeObject *subtype, char_u *name, int argc, typval_T *argv,
 {
     FunctionObject	*self;
 
-    self = (FunctionObject *) subtype->tp_alloc(subtype, 0);
-
+    self = (FunctionObject *)subtype->tp_alloc(subtype, 0);
     if (self == NULL)
 	return NULL;
 
@@ -2938,14 +2937,35 @@ FunctionNew(PyTypeObject *subtype, char_u *name, int argc, typval_T *argv,
 	self->name = vim_strsave(name);
     }
     else
-	if ((self->name = get_expanded_name(name,
-				    vim_strchr(name, AUTOLOAD_CHAR) == NULL))
-		== NULL)
+    {
+	char_u *p;
+
+	if ((p = get_expanded_name(name,
+			    vim_strchr(name, AUTOLOAD_CHAR) == NULL)) == NULL)
 	{
 	    PyErr_FORMAT(PyExc_ValueError,
 		    N_("function %s does not exist"), name);
 	    return NULL;
 	}
+
+	if (p[0] == K_SPECIAL && p[1] == KS_EXTRA && p[2] == (int)KE_SNR)
+	{
+	    char_u *np;
+	    size_t len = STRLEN(p) + 1;
+
+	    if ((np = alloc(len + 2)) == NULL)
+	    {
+		vim_free(p);
+		return NULL;
+	    }
+	    mch_memmove(np, "<SNR>", 5);
+	    mch_memmove(np + 5, p + 3, len - 3);
+	    vim_free(p);
+	    self->name = np;
+	}
+	else
+	    self->name = p;
+    }
 
     func_ref(self->name);
     self->argc = argc;

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -36,3 +36,30 @@ func Test_set_cursor()
   normal j
   call assert_equal([2, 6], [line('.'), col('.')])
 endfunc
+
+func Test_vim_function()
+  " Check creating vim.Function object
+  py import vim
+
+  func s:foo()
+    return matchstr(expand('<sfile>'), '<SNR>\zs\d\+_foo$')
+  endfunc
+  let name = '<SNR>' . s:foo()
+
+  try
+    py f = vim.bindeval('function("s:foo")')
+    call assert_equal(name, pyeval('f.name'))
+  catch
+    call assert_false(v:exception)
+  endtry
+
+  try
+    py f = vim.Function('\x80\xfdR' + vim.eval('s:foo()'))
+    call assert_equal(name, pyeval('f.name'))
+  catch
+    call assert_false(v:exception)
+  endtry
+
+  py del f
+  delfunc s:foo
+endfunc

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -36,3 +36,30 @@ func Test_set_cursor()
   normal j
   call assert_equal([2, 6], [line('.'), col('.')])
 endfunc
+
+func Test_vim_function()
+  " Check creating vim.Function object
+  py3 import vim
+
+  func s:foo()
+    return matchstr(expand('<sfile>'), '<SNR>\zs\d\+_foo$')
+  endfunc
+  let name = '<SNR>' . s:foo()
+
+  try
+    py3 f = vim.bindeval('function("s:foo")')
+    call assert_equal(name, py3eval('f.name'))
+  catch
+    call assert_false(v:exception)
+  endtry
+
+  try
+    py3 f = vim.Function(b'\x80\xfdR' + vim.eval('s:foo()').encode())
+    call assert_equal(name, py3eval('f.name'))
+  catch
+    call assert_false(v:exception)
+  endtry
+
+  py3 del f
+  delfunc s:foo
+endfunc


### PR DESCRIPTION
## Problem

When creating `vim.Function` object from script-local function, `name` attribute starts with SID prefix bytes `\x80\xfd`; this is an invalid sequence of UTF-8 so causes UnicodeDecodeError on python3.

test.vim:

```vim
function! s:f()
endfunction
let g:F = function('s:f')
py3 vim.bindeval('g:F').name
```

`vim -Nu test.vim`

```
Error detected while processing /tmp/test.vim:
line    4:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 0: invalid start byte
```

This error occurs at `PyString_FromString()`; this is `PyUnicode_Decode()` in if_python3.
https://github.com/vim/vim/blob/master/src/if_py_both.h#L3082 (in `FunctionAttr()`)

Another example: creating `vim.Function` by function name bytes

```vim
function! s:f()
endfunction
py3 f = vim.Function(b'\x80\xfdR1_f')
py3 f.name
```

## Solution proposal

* Set string `<SNR>` instead of bytes `\x80\xfdR` into name attribute
