### PR TITLE
Modify %v in errorformat to also process multibyte characters

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3047,9 +3047,6 @@ qf_jump_goto_line(
 	char_u		*qf_pattern)
 {
     linenr_T		i;
-    char_u		*line;
-    colnr_T		screen_col;
-    colnr_T		char_col;
 
     if (qf_pattern == NULL)
     {
@@ -3063,29 +3060,11 @@ qf_jump_goto_line(
 	}
 	if (qf_col > 0)
 	{
-	    curwin->w_cursor.col = qf_col - 1;
 	    curwin->w_cursor.coladd = 0;
 	    if (qf_viscol == TRUE)
-	    {
-		// Check each character from the beginning of the error
-		// line up to the error column.  For each tab character
-		// found, reduce the error column value by the length of
-		// a tab character.
-		line = ml_get_curline();
-		screen_col = 0;
-		for (char_col = 0; char_col < curwin->w_cursor.col; ++char_col)
-		{
-		    if (*line == NUL)
-			break;
-		    if (*line++ == '\t')
-		    {
-			curwin->w_cursor.col -= 7 - (screen_col % 8);
-			screen_col += 8 - (screen_col % 8);
-		    }
-		    else
-			++screen_col;
-		}
-	    }
+		coladvance(qf_col - 1);
+	    else
+		curwin->w_cursor.col = qf_col - 1;
 	    curwin->w_set_curswant = TRUE;
 	    check_cursor();
 	}

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -3843,3 +3843,61 @@ func Test_splitview()
   call delete('Xtestfile1')
   call delete('Xtestfile2')
 endfunc
+
+" Test for parsing entries using visual screen column
+func Test_viscol()
+  enew
+  call writefile(["Col1\tCol2\tCol3"], 'Xfile1')
+  edit Xfile1
+
+  " Use byte offset for column number
+  set efm&
+  cexpr "Xfile1:1:5:XX\nXfile1:1:9:YY\nXfile1:1:20:ZZ"
+  call assert_equal([5, 8], [col('.'), virtcol('.')])
+  cnext
+  call assert_equal([9, 12], [col('.'), virtcol('.')])
+  cnext
+  call assert_equal([14, 20], [col('.'), virtcol('.')])
+
+  " Use screen column offset for column number
+  set efm=%f:%l:%v:%m
+  cexpr "Xfile1:1:8:XX\nXfile1:1:12:YY\nXfile1:1:20:ZZ"
+  call assert_equal([5, 8], [col('.'), virtcol('.')])
+  cnext
+  call assert_equal([9, 12], [col('.'), virtcol('.')])
+  cnext
+  call assert_equal([14, 20], [col('.'), virtcol('.')])
+  cexpr "Xfile1:1:6:XX\nXfile1:1:15:YY\nXfile1:1:24:ZZ"
+  call assert_equal([5, 8], [col('.'), virtcol('.')])
+  cnext
+  call assert_equal([10, 16], [col('.'), virtcol('.')])
+  cnext
+  call assert_equal([14, 20], [col('.'), virtcol('.')])
+
+  if has('multi_byte')
+    enew
+    call writefile(["Col1\täü\töß\tCol4"], 'Xfile1')
+
+    " Use byte offset for column number
+    set efm&
+    cexpr "Xfile1:1:8:XX\nXfile1:1:11:YY\nXfile1:1:16:ZZ"
+    call assert_equal([8, 10], [col('.'), virtcol('.')])
+    cnext
+    call assert_equal([11, 17], [col('.'), virtcol('.')])
+    cnext
+    call assert_equal([16, 25], [col('.'), virtcol('.')])
+
+    " Use screen column offset for column number
+    set efm=%f:%l:%v:%m
+    cexpr "Xfile1:1:10:XX\nXfile1:1:17:YY\nXfile1:1:25:ZZ"
+    call assert_equal([8, 10], [col('.'), virtcol('.')])
+    cnext
+    call assert_equal([11, 17], [col('.'), virtcol('.')])
+    cnext
+    call assert_equal([16, 25], [col('.'), virtcol('.')])
+  endif
+
+  enew | only
+  set efm&
+  call delete('Xfile1')
+endfunc


### PR DESCRIPTION
When %v is used in 'errorformat', in addition to processing tab characters,
also process multi byte characters.
