### PR TITLE
Added test for the -q [errorfile] command line argument

### DIFF
--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -269,6 +269,52 @@ func Test_V_arg()
    call assert_match("sourcing \"$VIMRUNTIME[\\/]defaults\.vim\"\r\nline 1: \" The default vimrc file\..*  verbose=15\n", out)
 endfunc
 
+" Test the '-q [errorfile]' argument.
+func Test_q_arg()
+  let after = [
+	\ 'call writefile([&errorfile, string(getpos("."))], "Xtestout")',
+	\ 'copen',
+	\ 'w >> Xtestout',
+	\ 'qall'
+	\ ]
+
+  " Test with default argument '-q'.
+  call assert_equal('errors.err', &errorfile)
+  call writefile(["../memfile.c:1482:5: error: expected ';' before '}' token"], 'errors.err')
+  if RunVim([], after, '-q')
+    let lines = readfile('Xtestout')
+    call assert_equal(['errors.err',
+	\              '[0, 1482, 5, 0]',
+	\              "../memfile.c|1482 col 5| error: expected ';' before '}' token"],
+	\             lines)
+  endif
+  call delete('Xtestout')
+  call delete('errors.err')
+
+  " Test with explicit argument '-q Xerrors' (with space).
+  call writefile(["../memfile.c:1482:5: error: expected ';' before '}' token"], 'Xerrors')
+  if RunVim([], after, '-q Xerrors')
+    let lines = readfile('Xtestout')
+    call assert_equal(['Xerrors',
+	\              '[0, 1482, 5, 0]',
+	\              "../memfile.c|1482 col 5| error: expected ';' before '}' token"],
+	\             lines)
+  endif
+  call delete('Xtestout')
+
+  " Test with explicit argument '-qXerrors' (without space).
+  if RunVim([], after, '-qXerrors')
+    let lines = readfile('Xtestout')
+    call assert_equal(['Xerrors',
+	\              '[0, 1482, 5, 0]',
+	\              "../memfile.c|1482 col 5| error: expected ';' before '}' token"],
+	\             lines)
+  endif
+
+  call delete('Xtestout')
+  call delete('Xerrors')
+endfunc
+
 " Test the -V[N]{filename} argument to set the 'verbose' option to N
 " and set 'verbosefile' to filename.
 func Test_V_file_arg()

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -271,7 +271,7 @@ endfunc
 
 " Test the '-q [errorfile]' argument.
 func Test_q_arg()
-  let source_file = has('win32') ? '..\\memfile.c' : '../memfile.c'
+  let source_file = has('win32') ? '..\memfile.c' : '../memfile.c'
   let after = [
 	\ 'call writefile([&errorfile, string(getpos("."))], "Xtestout")',
 	\ 'copen',

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -271,6 +271,7 @@ endfunc
 
 " Test the '-q [errorfile]' argument.
 func Test_q_arg()
+  let source_file = has('win32') ? '..\\memfile.c' : '../memfile.c'
   let after = [
 	\ 'call writefile([&errorfile, string(getpos("."))], "Xtestout")',
 	\ 'copen',
@@ -285,7 +286,7 @@ func Test_q_arg()
     let lines = readfile('Xtestout')
     call assert_equal(['errors.err',
 	\              '[0, 1482, 5, 0]',
-	\              "../memfile.c|1482 col 5| error: expected ';' before '}' token"],
+	\              source_file . "|1482 col 5| error: expected ';' before '}' token"],
 	\             lines)
   endif
   call delete('Xtestout')
@@ -297,7 +298,7 @@ func Test_q_arg()
     let lines = readfile('Xtestout')
     call assert_equal(['Xerrors',
 	\              '[0, 1482, 5, 0]',
-	\              "../memfile.c|1482 col 5| error: expected ';' before '}' token"],
+	\              source_file . "|1482 col 5| error: expected ';' before '}' token"],
 	\             lines)
   endif
   call delete('Xtestout')
@@ -307,7 +308,7 @@ func Test_q_arg()
     let lines = readfile('Xtestout')
     call assert_equal(['Xerrors',
 	\              '[0, 1482, 5, 0]',
-	\              "../memfile.c|1482 col 5| error: expected ';' before '}' token"],
+	\              source_file . "|1482 col 5| error: expected ';' before '}' token"],
 	\             lines)
   endif
 


### PR DESCRIPTION
This PR adds tests for the quickfix comment line argument '-q [errorfile]'
which was not tested according to codecov:

https://codecov.io/gh/vim/vim/src/c8c8849267503b2d2d6d821047ee8619c7821728/src/main.c#L2134