### PR TITLE
Remove strchr() searches to decide whether to tilde expand

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -9803,7 +9803,7 @@ repeat:
 
 #ifdef WIN3264
 # if _WIN32_WINNT >= 0x0500
-	if (vim_strchr(*fnamep, '~') != NULL)
+	if (**fnamep == '~')
 	{
 	    /* Expand 8.3 filename to full path.  Needed to make sure the same
 	     * file does not have two different names.

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -4924,7 +4924,7 @@ home_replace(
 	homedir_env = NULL;
 
 #if defined(FEAT_MODIFY_FNAME) || defined(FEAT_EVAL)
-    if (homedir_env != NULL && vim_strchr(homedir_env, '~') != NULL)
+    if (homedir_env != NULL && *homedir_env == '~')
     {
 	int	usedlen = 0;
 	int	flen;


### PR DESCRIPTION
Tilde expansion only occurs when the filename starts with `~` (e.g., `~`
or `~user`).  Searching the entire string is a waste of time (both in
the search and the work done if a mid-string `~` is found).