### PR TITLE
Added missing letter "a" at the end of "entera"

### DIFF
--- a/runtime/tutor/tutor.es.utf-8
+++ b/runtime/tutor/tutor.es.utf-8
@@ -256,7 +256,7 @@ NOTE: Para los aventureros, pulsando sólo el objeto estando en modo Normal
 
   2. Para borrar desde el cursor hasta el final de una línea pulse:	d$
 
-  3. Para borrar una línea enter pulse:    dd
+  3. Para borrar una línea entera pulse:    dd
 
   4. El formato de un mandato en modo Normal es:
 


### PR DESCRIPTION
Looks like a typo. The word "enter" won't exist in spanish, and by context its clear that the correct word is "entera" with the trailing "a"