### PR TITLE
Added test for overstrike in Ex command line

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -581,4 +581,24 @@ func Test_setcmdpos()
   call assert_equal(1, setcmdpos(3))
 endfunc
 
+func Test_cmdline_overstrike()
+  " Test overstrike in the middle of the command line.
+  call feedkeys(":\"01234\<home>\<right>\<right>ab\<right>\<insert>cd\<enter>", 'xt')
+  call assert_equal('"0ab1cd4', @:)
+
+  " Test overstrike going beyond end of command line.
+  call feedkeys(":\"01234\<home>\<right>\<right>ab\<right>\<insert>cdefgh\<enter>", 'xt')
+  call assert_equal('"0ab1cdefgh', @:)
+
+  " Test toggling insert/overstrike a few times.
+  call feedkeys(":\"01234\<home>\<right>ab\<right>\<insert>cd\<right>\<insert>ef\<enter>", 'xt')
+  call assert_equal('"ab0cd3ef4', @:)
+
+  if has('multi_byte')
+    " Test overstrike with multi-byte characters.
+    call feedkeys(":\"テキストエディタ\<home>\<right>\<right>ab\<right>\<insert>cd\<enter>", 'xt')
+    call assert_equal('"テabキcdエディタ', @:)
+  endif
+endfunc
+
 set cpo&

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -582,23 +582,31 @@ func Test_setcmdpos()
 endfunc
 
 func Test_cmdline_overstrike()
-  " Test overstrike in the middle of the command line.
-  call feedkeys(":\"01234\<home>\<right>\<right>ab\<right>\<insert>cd\<enter>", 'xt')
-  call assert_equal('"0ab1cd4', @:)
+  let encodings = has('multi_byte') ? [ 'latin1', 'utf8' ] : [ 'latin1' ]
 
-  " Test overstrike going beyond end of command line.
-  call feedkeys(":\"01234\<home>\<right>\<right>ab\<right>\<insert>cdefgh\<enter>", 'xt')
-  call assert_equal('"0ab1cdefgh', @:)
+  for e in encodings
+    exe 'set encoding=' . e
 
-  " Test toggling insert/overstrike a few times.
-  call feedkeys(":\"01234\<home>\<right>ab\<right>\<insert>cd\<right>\<insert>ef\<enter>", 'xt')
-  call assert_equal('"ab0cd3ef4', @:)
+    " Test overstrike in the middle of the command line.
+    call feedkeys(":\"01234\<home>\<right>\<right>ab\<right>\<insert>cd\<enter>", 'xt')
+    call assert_equal('"0ab1cd4', @:)
+
+    " Test overstrike going beyond end of command line.
+    call feedkeys(":\"01234\<home>\<right>\<right>ab\<right>\<insert>cdefgh\<enter>", 'xt')
+    call assert_equal('"0ab1cdefgh', @:)
+
+    " Test toggling insert/overstrike a few times.
+    call feedkeys(":\"01234\<home>\<right>ab\<right>\<insert>cd\<right>\<insert>ef\<enter>", 'xt')
+    call assert_equal('"ab0cd3ef4', @:)
+  endfor
 
   if has('multi_byte')
     " Test overstrike with multi-byte characters.
     call feedkeys(":\"テキストエディタ\<home>\<right>\<right>ab\<right>\<insert>cd\<enter>", 'xt')
     call assert_equal('"テabキcdエディタ', @:)
   endif
+
+  set encoding&
 endfunc
 
 set cpo&


### PR DESCRIPTION
This PR adds a test for overstrike in command line mode
(see :help c_Insert) which was not tested according to codecov:

https://codecov.io/gh/vim/vim/src/master/src/ex_getln.c#L3433