### PR TITLE
Temporary file XtestProp was not removed

### DIFF
--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -308,4 +308,5 @@ funct Test_textprop_screenshots()
   " clean up
   call StopVimInTerminal(buf)
   call delete('Xtest_folds_with_rnu')
+  call delete('XtestProp')
 endfunc


### PR DESCRIPTION
This PR removes temporary file XtestProp which remained after running tests.
