### PR TITLE
Make luaeval support v:null as well as v:true/v:false

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -562,6 +562,10 @@ luaV_totypval(lua_State *L, int pos, typval_T *tv)
 	    tv->v_type = VAR_SPECIAL;
 	    tv->vval.v_number = (varnumber_T) lua_toboolean(L, pos);
 	    break;
+	case LUA_TNIL:
+	    tv->v_type = VAR_SPECIAL;
+	    tv->vval.v_number = VVAL_NULL;
+	    break;
 	case LUA_TSTRING:
 	    tv->v_type = VAR_STRING;
 	    tv->vval.v_string = vim_strsave((char_u *) lua_tostring(L, pos));

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -298,17 +298,18 @@ func Test_list()
   lua l:add('abc')
   lua l:add(true)
   lua l:add(false)
+  lua l:add(nil)
   lua l:add(vim.eval("[1, 2, 3]"))
   lua l:add(vim.eval("{'a':1, 'b':2, 'c':3}"))
-  call assert_equal([123.0, 'abc', v:true, v:false, [1, 2, 3], {'a': 1, 'b': 2, 'c': 3}], l)
-  call assert_equal(6.0, luaeval('#l'))
+  call assert_equal([123.0, 'abc', v:true, v:false, v:null, [1, 2, 3], {'a': 1, 'b': 2, 'c': 3}], l)
+  call assert_equal(7.0, luaeval('#l'))
   call assert_match('^list: \%(0x\)\?\x\+$', luaeval('tostring(l)'))
 
   lua l[0] = 124
-  lua l[4] = nil
+  lua l[5] = nil
   lua l:insert('first')
   lua l:insert('xx', 3)
-  call assert_equal(['first', 124.0, 'abc', 'xx', v:true, v:false, {'a': 1, 'b': 2, 'c': 3}], l)
+  call assert_equal(['first', 124.0, 'abc', 'xx', v:true, v:false, v:null, {'a': 1, 'b': 2, 'c': 3}], l)
 
   lockvar 1 l
   call assert_fails('lua l:add("x")', '[string "vim chunk"]:1: list is locked')


### PR DESCRIPTION
`echo luaeval('true')` returns v:true, and `echo luaeval('false')` returns v:false.
On the other hand, `echo luaeval('nil')` gives E426 "luaeval: cannot convert value".

This patch makes `echo luaeval('nil')` returns v:null instead.

I didn't find help docs mentioning about luaeval type conversion, so this
commit doesn't include that, but if you'd like I can add one.

(Happy new year! Current time in Japan is 2019-01-01 12:10am)