### PR TITLE
fix typo in sign docs (leading zeros are ignored)

### DIFF
--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -88,7 +88,7 @@ See |sign_define()| for the equivalent Vim script function.
 :sign define {name} {argument}...
 		Define a new sign or set attributes for an existing sign.
 		The {name} can either be a number (all digits) or a name
-		starting with a non-digit.  Leading digits are ignored, thus
+		starting with a non-digit.  Leading zeros are ignored, thus
 		"0012", "012" and "12" are considered the same name.
 		About 120 different signs can be defined.
 


### PR DESCRIPTION
Original docs says leading digits are ignored, but (rightfully) only
leading zeros are ignored. `01`, `001`, and `1` are the same, `01word`
and `1word` are the same, but `1word` and `2word` are different.