### PR TITLE
Rename get_buf_tv() to tv_get_buf()

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1424,7 +1424,7 @@ f_appendbufline(typval_T *argvars, typval_T *rettv)
     linenr_T	lnum;
     buf_T	*buf;
 
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     if (buf == NULL)
 	rettv->vval.v_number = 1; /* FAIL */
     else
@@ -1892,7 +1892,7 @@ buflist_find_by_name(char_u *name, int curtab_only)
  * Get buffer by number or pattern.
  */
     buf_T *
-get_buf_tv(typval_T *tv, int curtab_only)
+tv_get_buf(typval_T *tv, int curtab_only)
 {
     char_u	*name = tv->vval.v_string;
     buf_T	*buf;
@@ -1925,7 +1925,7 @@ f_bufname(typval_T *argvars, typval_T *rettv)
 
     (void)tv_get_number(&argvars[0]);	    /* issue errmsg if type error */
     ++emsg_off;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     rettv->v_type = VAR_STRING;
     if (buf != NULL && buf->b_fname != NULL)
 	rettv->vval.v_string = vim_strsave(buf->b_fname);
@@ -1946,7 +1946,7 @@ f_bufnr(typval_T *argvars, typval_T *rettv)
 
     (void)tv_get_number(&argvars[0]);	    /* issue errmsg if type error */
     ++emsg_off;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     --emsg_off;
 
     /* If the buffer isn't found and the second argument is not zero create a
@@ -1974,7 +1974,7 @@ buf_win_common(typval_T *argvars, typval_T *rettv, int get_nr)
 
     (void)tv_get_number(&argvars[0]);	    /* issue errmsg if type error */
     ++emsg_off;
-    buf = get_buf_tv(&argvars[0], TRUE);
+    buf = tv_get_buf(&argvars[0], TRUE);
     FOR_ALL_WINDOWS(wp)
     {
 	++winnr;
@@ -2962,7 +2962,7 @@ f_deletebufline(typval_T *argvars, typval_T *rettv)
     tabpage_T	*tp;
     win_T	*wp;
 
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     if (buf == NULL)
     {
 	rettv->vval.v_number = 1; /* FAIL */
@@ -4525,7 +4525,7 @@ f_getbufinfo(typval_T *argvars, typval_T *rettv)
 	/* Information about one buffer.  Argument specifies the buffer */
 	(void)tv_get_number(&argvars[0]);   /* issue errmsg if type error */
 	++emsg_off;
-	argbuf = get_buf_tv(&argvars[0], FALSE);
+	argbuf = tv_get_buf(&argvars[0], FALSE);
 	--emsg_off;
 	if (argbuf == NULL)
 	    return;
@@ -4609,7 +4609,7 @@ f_getbufline(typval_T *argvars, typval_T *rettv)
 
     (void)tv_get_number(&argvars[0]);	    /* issue errmsg if type error */
     ++emsg_off;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     --emsg_off;
 
     lnum = tv_get_lnum_buf(&argvars[1], buf);
@@ -4636,7 +4636,7 @@ f_getbufvar(typval_T *argvars, typval_T *rettv)
     (void)tv_get_number(&argvars[0]);	    /* issue errmsg if type error */
     varname = tv_get_string_chk(&argvars[1]);
     ++emsg_off;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
 
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = NULL;
@@ -4707,7 +4707,7 @@ f_getchangelist(typval_T *argvars, typval_T *rettv)
 #ifdef FEAT_JUMPLIST
     (void)tv_get_number(&argvars[0]);	    /* issue errmsg if type error */
     ++emsg_off;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     --emsg_off;
     if (buf == NULL)
 	return;
@@ -8721,7 +8721,7 @@ f_prompt_setcallback(typval_T *argvars, typval_T *rettv UNUSED)
 
     if (check_secure())
 	return;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     if (buf == NULL)
 	return;
 
@@ -8750,7 +8750,7 @@ f_prompt_setinterrupt(typval_T *argvars, typval_T *rettv UNUSED)
 
     if (check_secure())
 	return;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     if (buf == NULL)
 	return;
 
@@ -8778,7 +8778,7 @@ f_prompt_setprompt(typval_T *argvars, typval_T *rettv UNUSED)
 
     if (check_secure())
 	return;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     if (buf == NULL)
 	return;
 
@@ -10580,7 +10580,7 @@ f_setbufline(typval_T *argvars, typval_T *rettv)
     linenr_T	lnum;
     buf_T	*buf;
 
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     if (buf == NULL)
 	rettv->vval.v_number = 1; /* FAIL */
     else
@@ -10605,7 +10605,7 @@ f_setbufvar(typval_T *argvars, typval_T *rettv UNUSED)
 	return;
     (void)tv_get_number(&argvars[0]);	    /* issue errmsg if type error */
     varname = tv_get_string_chk(&argvars[1]);
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     varp = &argvars[2];
 
     if (buf != NULL && varname != NULL && varp != NULL)
@@ -11365,7 +11365,7 @@ f_sign_getplaced(typval_T *argvars, typval_T *rettv)
     if (argvars[0].v_type != VAR_UNKNOWN)
     {
 	// get signs placed in this buffer
-	buf = get_buf_tv(&argvars[0], FALSE);
+	buf = tv_get_buf(&argvars[0], FALSE);
 	if (buf == NULL)
 	{
 	    EMSG2(_("E158: Invalid buffer name: %s"),
@@ -11457,7 +11457,7 @@ f_sign_place(typval_T *argvars, typval_T *rettv)
 	goto cleanup;
 
     // Buffer to place the sign
-    buf = get_buf_tv(&argvars[3], FALSE);
+    buf = tv_get_buf(&argvars[3], FALSE);
     if (buf == NULL)
     {
 	EMSG2(_("E158: Invalid buffer name: %s"), tv_get_string(&argvars[2]));
@@ -11566,7 +11566,7 @@ f_sign_unplace(typval_T *argvars, typval_T *rettv)
 
 	if ((di = dict_find(dict, (char_u *)"buffer", -1)) != NULL)
 	{
-	    buf = get_buf_tv(&di->di_tv, FALSE);
+	    buf = tv_get_buf(&di->di_tv, FALSE);
 	    if (buf == NULL)
 	    {
 		EMSG2(_("E158: Invalid buffer name: %s"),
@@ -12812,7 +12812,7 @@ f_swapname(typval_T *argvars, typval_T *rettv)
     buf_T	*buf;
 
     rettv->v_type = VAR_STRING;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     if (buf == NULL || buf->b_ml.ml_mfp == NULL
 					|| buf->b_ml.ml_mfp->mf_fname == NULL)
 	rettv->vval.v_string = NULL;

--- a/src/proto/evalfunc.pro
+++ b/src/proto/evalfunc.pro
@@ -4,7 +4,7 @@ char_u *get_expr_name(expand_T *xp, int idx);
 int find_internal_func(char_u *name);
 int call_internal_func(char_u *name, int argcount, typval_T *argvars, typval_T *rettv);
 buf_T *buflist_find_by_name(char_u *name, int curtab_only);
-buf_T *get_buf_tv(typval_T *tv, int curtab_only);
+buf_T *tv_get_buf(typval_T *tv, int curtab_only);
 void execute_redir_str(char_u *value, int value_len);
 void mzscheme_call_vim(char_u *name, typval_T *args, typval_T *rettv);
 float_T vim_round(float_T f);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3842,7 +3842,7 @@ term_get_buf(typval_T *argvars, char *where)
 
     (void)tv_get_number(&argvars[0]);	    /* issue errmsg if type error */
     ++emsg_off;
-    buf = get_buf_tv(&argvars[0], FALSE);
+    buf = tv_get_buf(&argvars[0], FALSE);
     --emsg_off;
     if (buf == NULL || buf->b_term == NULL)
     {

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -130,7 +130,7 @@ get_bufnr_from_arg(typval_T *arg, buf_T **buf)
     di = dict_find(arg->vval.v_dict, (char_u *)"bufnr", -1);
     if (di != NULL)
     {
-	*buf = get_buf_tv(&di->di_tv, FALSE);
+	*buf = tv_get_buf(&di->di_tv, FALSE);
 	if (*buf == NULL)
 	    return FAIL;
     }
@@ -533,7 +533,7 @@ f_prop_remove(typval_T *argvars, typval_T *rettv)
     di = dict_find(dict, (char_u *)"bufnr", -1);
     if (di != NULL)
     {
-	buf = get_buf_tv(&di->di_tv, FALSE);
+	buf = tv_get_buf(&di->di_tv, FALSE);
 	if (buf == NULL)
 	    return;
     }


### PR DESCRIPTION
Rename the get_buf_tv() function to tv_get_buf() along the lines of the
existing tv_get_number(), tv_get_string(), tv_get_lnum(), etc.
functions.
