### PR TITLE
Executing 'aunmenu *' and 'popup Edit', throw E341: Internal error: lalloc(0, )

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -914,7 +914,11 @@ may be used to complete the name of the menu item for the appropriate mode.
 To remove all menus use:			*:unmenu-all*  >
 	:unmenu *	" remove all menus in Normal and visual mode
 	:unmenu! *	" remove all menus in Insert and Command-line mode
-	:aunmenu *	" remove all menus in all modes
+	:aunmenu *	" remove all menus in all modes, except for Terminal
+			" mode.
+
+Note |:aunmenu| is to remove all menus in all modes, except for Terminal mode.
+To remove menus for Terminal mode, use |:tlunmenu| instead.
 
 If you want to get rid of the menu bar: >
 	:set guioptions-=m

--- a/src/globals.h
+++ b/src/globals.h
@@ -1595,6 +1595,10 @@ EXTERN char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 EXTERN char need_key_msg[] INIT(= N_("Need encryption key for \"%s\""));
 #endif
 
+#ifdef FEAT_MENU
+EXTERN char_u e_menuothermode[] INIT(= N_("E328: Menu only exists in another mode"));
+#endif
+
 /*
  * Comms. with the session manager (XSMP)
  */

--- a/src/menu.c
+++ b/src/menu.c
@@ -61,7 +61,6 @@ static char_u *menu_translate_tab_and_shift(char_u *arg_start);
 static char *menu_mode_chars[] = {"n", "v", "s", "o", "i", "c", "tl", "t"};
 
 static char_u e_notsubmenu[] = N_("E327: Part of menu-item path is not sub-menu");
-static char_u e_othermode[] = N_("E328: Menu only exists in another mode");
 static char_u e_nomenu[] = N_("E329: No menu \"%s\"");
 
 #ifdef FEAT_TOOLBAR
@@ -956,7 +955,7 @@ remove_menu(
 	    else if (*name != NUL)
 	    {
 		if (!silent)
-		    EMSG(_(e_othermode));
+		    EMSG(_(e_menuothermode));
 		return FAIL;
 	    }
 
@@ -1130,7 +1129,7 @@ show_menus(char_u *path_name, int modes)
 		}
 		else if ((menu->modes & modes) == 0x0)
 		{
-		    EMSG(_(e_othermode));
+		    EMSG(_(e_menuothermode));
 		    vim_free(path_name);
 		    return FAIL;
 		}

--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -1195,6 +1195,15 @@ pum_show_popupmenu(vimmenu_T *menu)
 		|| (mp->modes & mp->enabled & mode))
 	    ++pum_size;
 
+    /* executing 'tlnoremap ...', 'aunmenu *' and 'popup Edit', pum_size is 0.
+     * because 'aunmenu *' is excluding Terminal mode.
+     */
+    if (pum_size <= 0)
+    {
+	EMSG(e_menuothermode);
+	return;
+    }
+
     array = (pumitem_T *)alloc_clear((unsigned)sizeof(pumitem_T) * pum_size);
     if (array == NULL)
 	return;

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -890,7 +890,7 @@ func Test_menu_only_exists_in_terminal()
       popup Edit
       call assert_false(1, 'command should have failed')
     catch
-      call assert_exception('E973:')
+      call assert_exception('E328:')
     endtry
   endif
 endfunc

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -882,17 +882,19 @@ func Test_complete_o_tab()
   delfunc s:act_on_text_changed
 endfunc
 
-func Test_menu_only_exists_in_terminal()
-  if exists(':tlmenu')
-    tlnoremenu	 &Edit.&Paste<Tab>"+gP		<C-W>"+
-    aunmenu *
-    try
-      popup Edit
-      call assert_false(1, 'command should have failed')
-    catch
-      call assert_exception('E328:')
-    endtry
-  endif
-endfunc
+if !has('gui_running')
+  func Test_menu_only_exists_in_terminal()
+    if exists(':tlmenu')
+      tlnoremenu	 &Edit.&Paste<Tab>"+gP		<C-W>"+
+      aunmenu *
+      try
+        popup Edit
+        call assert_false(1, 'command should have failed')
+      catch
+        call assert_exception('E328:')
+      endtry
+    endif
+  endfunc
+endif
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -882,5 +882,17 @@ func Test_complete_o_tab()
   delfunc s:act_on_text_changed
 endfunc
 
+func Test_menu_only_exists_in_terminal()
+  if exists(':tlmenu')
+    tlnoremenu	 &Edit.&Paste<Tab>"+gP		<C-W>"+
+    aunmenu *
+    try
+      popup Edit
+      call assert_false(1, 'command should have failed')
+    catch
+      call assert_exception('E973:')
+    endtry
+  endif
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
__Problem__
Executing `:aunmenu *` and `:popup Edit`, throw `E341: Internal error: lalloc(0, )`.
Terminal has only this problem(GUI Vim does not) .

__Solution__
Not existing menu's candidates on `:popup` command, throw `E328: Menu only exists in another mode`.