### PR TITLE
Patch to make the 'buffer' argument optional for the :sign place command

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7891,7 +7891,9 @@ sign_define({name} [, {dict}])				*sign_define()*
 		   text		text that is displayed when there is no icon
 				or the GUI is not being used.
 		   texthl	highlight group used for the text item
-		For an existing sign, the attributes are updated.
+
+		If the sign named {name} already exists, then the attributes
+		of the sign are updated.
 
 		Returns 0 on success and -1 on failure.
 
@@ -7944,6 +7946,7 @@ sign_getplaced([{expr} [, {dict}]])			*sign_getplaced()*
 		empty string, then only signs in the global group are
 		returned.  If no arguments are supplied, then signs in the
 		global group placed in all the buffers are returned.
+		See |sign-group|.
 
 		Each list item in the returned value is a dictionary with the
 		following entries:
@@ -7959,7 +7962,8 @@ sign_getplaced([{expr} [, {dict}]])			*sign_getplaced()*
 			name	name of the defined sign
 			priority	sign priority
 
-		Returns an empty list on failure.
+		Returns an empty list on failure or if there are no placed
+		signs.
 
 		Examples: >
 			" Get a List of signs placed in eval.c in the
@@ -7992,7 +7996,8 @@ sign_place({id}, {group}, {name}, {expr} [, {dict}])
 		allocated.  Otherwise the specified number is used. {group} is
 		the sign group name. To use the global sign group, use an
 		empty string.  {group} functions as a namespace for {id}, thus
-		two groups can use the same IDs.
+		two groups can use the same IDs. Refer to |sign-identifier|
+		for more information.
 
 		{name} refers to a defined sign.
 		{expr} refers to a buffer name or number. For the accepted

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -178,8 +178,9 @@ See |sign_place()| for the equivalent Vim script function.
 			:sign place 9 group=g2 priority=50 line=5
 							\ name=sign1 file=a.py
 <
-:sign place {id} line={lnum} name={name} buffer={nr}
-		Same, but use buffer {nr}.
+:sign place {id} line={lnum} name={name} [ buffer={nr}]
+		Same, but use buffer {nr}.  If the buffer argument is not
+		given, place the sign in the current buffer.
 
 							*E885*
 :sign place {id} name={name} file={fname}
@@ -191,8 +192,9 @@ See |sign_place()| for the equivalent Vim script function.
 		The optional "group={group}" attribute can be used before
 		"file=" to select a sign in a particular group.
 
-:sign place {id} name={name} buffer={nr}
-		Same, but use buffer {nr}.
+:sign place {id} name={name} [ buffer={nr}]
+		Same, but use buffer {nr}.  If the buffer argument is not
+		given, use the current buffer.
 
 
 REMOVING SIGNS						*:sign-unplace* *E159*
@@ -315,11 +317,12 @@ JUMPING TO A SIGN					*:sign-jump* *E157*
 :sign jump {id} group={group} file={fname}
 		Same but jump to the sign in group {group}
 
-:sign jump {id} buffer={nr}					*E934*
+:sign jump {id} [ buffer={nr}]					*E934*
 		Same, but use buffer {nr}.  This fails if buffer {nr} does not
-		have a name.
+		have a name. If the buffer argument is not given, use the
+		current buffer.
 
-:sign jump {id} group={group} buffer={nr}
+:sign jump {id} group={group} [ buffer={nr}]
 		Same but jump to the sign in group {group}
 
 

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -52,13 +52,23 @@ Example to set the color: >
 
 	:highlight SignColumn guibg=darkgrey
 <
+							*sign-identifier*
+Each placed sign is identified by a number called the sign identifier. This
+identifier is used to jump to the sign or to remove the sign. The identifier
+is assigned when placing the sign using the |sign-place| command or the
+|sign_place()| function. Each sign identifier should be a unique number. If
+multiple placed signs use the same identifier, then jumping to or removing a
+sign becomes unpredictable. To avoid overlapping identifiers, sign groups can
+be used. The |sign_place()| function can be called with a zero sign identifier
+to allocate the next available identifier.
+
 							*sign-group*
-Each sign can be assigned to either the global group or a named group. When
-placing a sign, if a group name is not supplied, or an empty string is used,
-then the sign is placed in the global group. Otherwise the sign is placed in
-the named group. The sign identifier is unique within a group. The sign group
-allows Vim plugins to use unique signs without interfering with other plugins
-using signs.
+Each placed sign can be assigned to either the global group or a named group.
+When placing a sign, if a group name is not supplied, or an empty string is
+used, then the sign is placed in the global group. Otherwise the sign is
+placed in the named group. The sign identifier is unique within a group. The
+sign group allows Vim plugins to use unique signs without interfering with
+other plugins using signs.
 
 							*sign-priority*
 Each placed sign is assigned a priority value. When multiple signs are placed

--- a/src/sign.c
+++ b/src/sign.c
@@ -1168,7 +1168,7 @@ sign_jump_cmd(
 	int		id,
 	char_u		*group)
 {
-    if (buf == NULL && sign_name == NULL && group == NULL && id == -1)
+    if (sign_name == NULL && group == NULL && id == -1)
     {
 	EMSG(_(e_argreq));
 	return;
@@ -1324,6 +1324,11 @@ parse_sign_cmd_args(
 	EMSG2(_("E158: Invalid buffer name: %s"), filename);
 	return FAIL;
     }
+
+    // If the filename is not supplied for the sign place or the sign jump
+    // command, then use the current buffer.
+    if (filename == NULL && (cmd == SIGNCMD_PLACE || cmd == SIGNCMD_JUMP))
+	*buf = curwin->w_buffer;
 
     return OK;
 }

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -63,7 +63,8 @@ func Test_sign()
 
   " Check placed signs
   let a=execute('sign place')
-  call assert_equal("\n--- Signs ---\nSigns for [NULL]:\n    line=3  id=41  name=Sign1 priority=10\n", a)
+  call assert_equal("\n--- Signs ---\nSigns for [NULL]:\n" .
+		\ "    line=3  id=41  name=Sign1 priority=10\n", a)
 
   " Unplace the sign and try jumping to it again should fail.
   sign unplace 41
@@ -86,6 +87,13 @@ func Test_sign()
   sign unplace *
   let a=execute('sign place')
   call assert_equal("\n--- Signs ---\n", a)
+
+  " Place a sign without specifying the filename or buffer
+  sign place 77 line=9 name=Sign2
+  let a=execute('sign place')
+  call assert_equal("\n--- Signs ---\nSigns for [NULL]:\n" .
+		\ "    line=9  id=77  name=Sign2 priority=10\n", a)
+  sign unplace *
 
   " Check :jump with file=...
   edit foo
@@ -148,37 +156,11 @@ func Test_sign()
   call assert_equal("\nsign 4 text=#> linehl=Comment", a)
   exe 'sign place 20 line=3 name=004 buffer=' . bufnr('')
   let a = execute('sign place')
-  call assert_equal("\n--- Signs ---\nSigns for foo:\n    line=3  id=20  name=4 priority=10\n", a)
+  call assert_equal("\n--- Signs ---\nSigns for foo:\n" .
+		\ "    line=3  id=20  name=4 priority=10\n", a)
   exe 'sign unplace 20 buffer=' . bufnr('')
   sign undefine 004
   call assert_fails('sign list 4', 'E155:')
-
-  " Error cases
-  call assert_fails("sign place abc line=3 name=Sign1 buffer=" .
-			  \ bufnr('%'), 'E474:')
-  call assert_fails("sign unplace abc name=Sign1 buffer=" .
-			  \ bufnr('%'), 'E474:')
-  call assert_fails("sign place 1abc line=3 name=Sign1 buffer=" .
-			  \ bufnr('%'), 'E474:')
-  call assert_fails("sign unplace 2abc name=Sign1 buffer=" .
-			  \ bufnr('%'), 'E474:')
-  call assert_fails("sign unplace 2 *", 'E474:')
-  call assert_fails("sign place 1 line=3 name=Sign1 buffer=" .
-			  \ bufnr('%') . " a", 'E488:')
-  call assert_fails("sign place name=Sign1 buffer=" . bufnr('%'), 'E474:')
-  call assert_fails("sign place line=10 buffer=" . bufnr('%'), 'E474:')
-  call assert_fails("sign unplace 2 line=10 buffer=" . bufnr('%'), 'E474:')
-  call assert_fails("sign unplace 2 name=Sign1 buffer=" . bufnr('%'), 'E474:')
-  call assert_fails("sign place 2 line=3 buffer=" . bufnr('%'), 'E474:')
-  call assert_fails("sign place 2", 'E474:')
-  call assert_fails("sign place abc", 'E474:')
-  call assert_fails("sign place 5 line=3", 'E474:')
-  call assert_fails("sign place 5 name=Sign1", 'E474:')
-  call assert_fails("sign place 5 group=g1", 'E474:')
-  call assert_fails("sign place 5 group=*", 'E474:')
-  call assert_fails("sign place 5 priority=10", 'E474:')
-  call assert_fails("sign place 5 line=3 name=Sign1", 'E474:')
-  call assert_fails("sign place 5 group=g1 line=3 name=Sign1", 'E474:')
 
   " After undefining the sign, we should no longer be able to place it.
   sign undefine Sign1
@@ -202,7 +184,8 @@ func Test_sign_undefine_still_placed()
 
   " Listing placed sign should show that sign is deleted.
   let a=execute('sign place')
-  call assert_equal("\n--- Signs ---\nSigns for foobar:\n    line=1  id=41  name=[Deleted] priority=10\n", a)
+  call assert_equal("\n--- Signs ---\nSigns for foobar:\n" .
+		\ "    line=1  id=41  name=[Deleted] priority=10\n", a)
 
   sign unplace 41
   let a=execute('sign place')
@@ -306,16 +289,11 @@ func Test_sign_invalid_commands()
   call assert_fails("sign place abc", 'E474:')
   " Placing a sign with only line number
   call assert_fails("sign place 5 line=3", 'E474:')
-  " Placing a sign with only sign name
-  call assert_fails("sign place 5 name=Sign1", 'E474:')
   " Placing a sign with only sign group
   call assert_fails("sign place 5 group=g1", 'E474:')
   call assert_fails("sign place 5 group=*", 'E474:')
   " Placing a sign with only sign priority
   call assert_fails("sign place 5 priority=10", 'E474:')
-  " Placing a sign without buffer number or file name
-  call assert_fails("sign place 5 line=3 name=Sign1", 'E474:')
-  call assert_fails("sign place 5 group=g1 line=3 name=Sign1", 'E474:')
 
   sign undefine Sign1
 endfunc
@@ -689,6 +667,12 @@ func Test_sign_group()
   call assert_equal('Xsign', bufname(''))
   sign jump 5 group=g2 file=Xsign
   call assert_equal(12, line('.'))
+
+  " Test for :sign jump command without the filename or buffer
+  sign jump 5
+  call assert_equal(10, line('.'))
+  sign jump 5 group=g1
+  call assert_equal(11, line('.'))
 
   " Error cases
   call assert_fails("sign place 3 group= name=sign1 buffer=" . bnum, 'E474:')

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -14,7 +14,8 @@ func Test_sign()
   " the icon name when listing signs.
   sign define Sign1 text=x
   try
-    sign define Sign2 text=xy texthl=Title linehl=Error icon=../../pixmaps/stock_vim_find_help.png
+    sign define Sign2 text=xy texthl=Title linehl=Error
+		\ icon=../../pixmaps/stock_vim_find_help.png
   catch /E255:/
     " Ignore error: E255: Couldn't read in sign data!
     " This error can happen when running in the GUI.
@@ -23,7 +24,9 @@ func Test_sign()
 
   " Test listing signs.
   let a=execute('sign list')
-  call assert_match("^\nsign Sign1 text=x \nsign Sign2 icon=../../pixmaps/stock_vim_find_help.png .*text=xy linehl=Error texthl=Title$", a)
+  call assert_match('^\nsign Sign1 text=x \nsign Sign2 ' .
+	      \ 'icon=../../pixmaps/stock_vim_find_help.png .*text=xy ' .
+	      \ 'linehl=Error texthl=Title$', a)
 
   let a=execute('sign list Sign1')
   call assert_equal("\nsign Sign1 text=x ", a)
@@ -100,7 +103,8 @@ func Test_sign()
   call setline(1, ['A', 'B', 'C', 'D'])
 
   try
-    sign define Sign3 text=y texthl=DoesNotExist linehl=DoesNotExist icon=doesnotexist.xpm
+    sign define Sign3 text=y texthl=DoesNotExist linehl=DoesNotExist
+		\ icon=doesnotexist.xpm
   catch /E255:/
     " ignore error: E255: it can happens for guis.
   endtry
@@ -203,7 +207,8 @@ func Test_sign_completion()
   call assert_equal('"sign define Sign icon= linehl= text= texthl=', @:)
 
   call feedkeys(":sign define Sign linehl=Spell\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"sign define Sign linehl=SpellBad SpellCap SpellLocal SpellRare', @:)
+  call assert_equal('"sign define Sign linehl=SpellBad SpellCap ' .
+	      \ 'SpellLocal SpellRare', @:)
 
   call writefile(['foo'], 'XsignOne')
   call writefile(['bar'], 'XsignTwo')
@@ -256,17 +261,22 @@ func Test_sign_invalid_commands()
   call assert_fails('sign jump 1 line=100', '474:')
   call assert_fails('sign define Sign2 text=', 'E239:')
   " Non-numeric identifier for :sign place
-  call assert_fails("sign place abc line=3 name=Sign1 buffer=" . bufnr('%'), 'E474:')
+  call assert_fails("sign place abc line=3 name=Sign1 buffer=" . bufnr(''),
+								\ 'E474:')
   " Non-numeric identifier for :sign unplace
-  call assert_fails("sign unplace abc name=Sign1 buffer=" . bufnr('%'), 'E474:')
+  call assert_fails("sign unplace abc name=Sign1 buffer=" . bufnr(''),
+								\ 'E474:')
   " Number followed by an alphabet as sign identifier for :sign place
-  call assert_fails("sign place 1abc line=3 name=Sign1 buffer=" . bufnr('%'), 'E474:')
+  call assert_fails("sign place 1abc line=3 name=Sign1 buffer=" . bufnr(''),
+								\ 'E474:')
   " Number followed by an alphabet as sign identifier for :sign unplace
-  call assert_fails("sign unplace 2abc name=Sign1 buffer=" . bufnr('%'), 'E474:')
+  call assert_fails("sign unplace 2abc name=Sign1 buffer=" . bufnr(''),
+								\ 'E474:')
   " Sign identifier and '*' for :sign unplace
   call assert_fails("sign unplace 2 *", 'E474:')
   " Trailing characters after buffer number for :sign place
-  call assert_fails("sign place 1 line=3 name=Sign1 buffer=" . bufnr('%') . 'xxx', 'E488:')
+  call assert_fails("sign place 1 line=3 name=Sign1 buffer=" .
+						\ bufnr('%') . 'xxx', 'E488:')
   " Trailing characters after buffer number for :sign unplace
   call assert_fails("sign unplace 1 buffer=" . bufnr('%') . 'xxx', 'E488:')
   call assert_fails("sign unplace * buffer=" . bufnr('%') . 'xxx', 'E488:')
@@ -602,11 +612,13 @@ func Test_sign_group()
 
   " :sign place file={fname}
   let a = execute('sign place file=Xsign')
-  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n    line=10  id=5  name=sign1 priority=10\n", a)
+  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
+	      \ "    line=10  id=5  name=sign1 priority=10\n", a)
 
   " :sign place group={group} file={fname}
   let a = execute('sign place group=g2 file=Xsign')
-  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n    line=10  id=5  group=g2  name=sign1 priority=10\n", a)
+  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
+	      \ "    line=10  id=5  group=g2  name=sign1 priority=10\n", a)
 
   " :sign place group=* file={fname}
   let a = execute('sign place group=* file=Xsign')
@@ -627,11 +639,13 @@ func Test_sign_group()
 
   " :sign place buffer={fname}
   let a = execute('sign place buffer=' . bnum)
-  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n    line=10  id=5  name=sign1 priority=10\n", a)
+  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
+	      \ "    line=10  id=5  name=sign1 priority=10\n", a)
 
   " :sign place group={group} buffer={fname}
   let a = execute('sign place group=g2 buffer=' . bnum)
-  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n    line=12  id=5  group=g2  name=sign1 priority=10\n", a)
+  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
+	      \ "    line=12  id=5  group=g2  name=sign1 priority=10\n", a)
 
   " :sign place group=* buffer={fname}
   let a = execute('sign place group=* buffer=' . bnum)


### PR DESCRIPTION
Port the patch from Christian Brabandt to make the "buffer" argument for the ":sign place" and
the :sign jump" commands optional. Remove duplicate tests.

