### PR TITLE
Make sure helptags are generated before running tests

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2128,10 +2128,14 @@ scripttests:
 	-if test $(VIMTARGET) != vim -a ! -r vim; then \
 		ln -s $(VIMTARGET) vim; \
 	fi
+# Ensure the help tags file are generated, since the tests use them
+	-@srcdir=`pwd`; cd $(HELPSOURCE); $(MAKE) VIMEXE=$$srcdir/$(VIMTARGET) vimtags
 	cd testdir; $(MAKE) -f Makefile $(GUI_TESTTARGET) VIMPROG=../$(VIMTARGET) $(GUI_TESTARG) SCRIPTSOURCE=../$(SCRIPTSOURCE)
 
 # Run the tests with the GUI.  Assumes vim/gvim was already built
 testgui:
+# Ensure the help tags file are generated, since the tests use them
+	-@srcdir=`pwd`; cd $(HELPSOURCE); $(MAKE) VIMEXE=$$srcdir/$(VIMTARGET) vimtags
 	cd testdir; $(MAKE) -f Makefile $(GUI_TESTTARGET) VIMPROG=../$(VIMTARGET) GUI_FLAG=-g $(GUI_TESTARG) SCRIPTSOURCE=../$(SCRIPTSOURCE)
 
 benchmark:


### PR DESCRIPTION
This resolves the problem I raised the other day about test_edit.vim hanging.
The runtime/doc/tags file had been cleaned up as part of the packaging, which
caused all the tests that interacted with `:help`/`:helpgrep` to fail.

Tests that change options, especially ones as disruptive as `'insertmode'`
should probably do so with a try/finally setup to ensure it gets set back to
normal, but I'll leave that for another time/person.