### PR TITLE
Signs in multiple buffers are not displayed by the :sign place command

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7971,6 +7971,9 @@ sign_getplaced([{expr} [, {dict}]])			*sign_getplaced()*
 			name	name of the defined sign
 			priority	sign priority
 
+		The returned signs in a buffer are ordered by their line
+		number.
+
 		Returns an empty list on failure or if there are no placed
 		signs.
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -11462,7 +11462,7 @@ f_sign_place(typval_T *argvars, typval_T *rettv)
     buf = tv_get_buf(&argvars[3], FALSE);
     if (buf == NULL)
     {
-	EMSG2(_("E158: Invalid buffer name: %s"), tv_get_string(&argvars[2]));
+	EMSG2(_("E158: Invalid buffer name: %s"), tv_get_string(&argvars[3]));
 	goto cleanup;
     }
 

--- a/src/sign.c
+++ b/src/sign.c
@@ -631,11 +631,11 @@ sign_list_placed(buf_T *rbuf, char_u *sign_group)
 	    if (!sign_in_group(sign, sign_group))
 		continue;
 	    if (sign->group != NULL)
-		vim_snprintf(group, BUFSIZ, "  group=%s",
+		vim_snprintf(group, BUFSIZ, _("  group=%s"),
 							sign->group->sg_name);
 	    else
 		group[0] = '\0';
-	    vim_snprintf(lbuf, BUFSIZ, _("    line=%ld  id=%d%s  name=%s "
+	    vim_snprintf(lbuf, BUFSIZ, _("    line=%ld  id=%d%s  name=%s  "
 							"priority=%d"),
 			   (long)sign->lnum, sign->id, group,
 			   sign_typenr2name(sign->typenr), sign->priority);

--- a/src/sign.c
+++ b/src/sign.c
@@ -1237,6 +1237,7 @@ parse_sign_cmd_args(
     char_u	*arg1;
     char_u	*name;
     char_u	*filename = NULL;
+    int		lnum_arg = FALSE;
 
     // first arg could be placed sign id
     arg1 = arg;
@@ -1259,6 +1260,7 @@ parse_sign_cmd_args(
 	    arg += 5;
 	    *lnum = atoi((char *)arg);
 	    arg = skiptowhite(arg);
+	    lnum_arg = TRUE;
 	}
 	else if (STRNCMP(arg, "*", 1) == 0 && cmd == SIGNCMD_UNPLACE)
 	{
@@ -1327,7 +1329,8 @@ parse_sign_cmd_args(
 
     // If the filename is not supplied for the sign place or the sign jump
     // command, then use the current buffer.
-    if (filename == NULL && (cmd == SIGNCMD_PLACE || cmd == SIGNCMD_JUMP))
+    if (filename == NULL && ((cmd == SIGNCMD_PLACE && lnum_arg) ||
+		cmd == SIGNCMD_JUMP))
 	*buf = curwin->w_buffer;
 
     return OK;

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -663,6 +663,18 @@ func Test_sign_group()
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
 	      \ "    line=10  id=5  name=sign1 priority=10\n", a)
 
+  " Place signs in more than one buffer and list the signs
+  split foo
+  set buftype=nofile
+  sign place 25 line=76 name=sign1 priority=99 file=foo
+  let a = execute('sign place')
+  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
+	      \ "    line=10  id=5  name=sign1 priority=10\n" .
+	      \ "Signs for foo:\n" .
+	      \ "    line=76  id=25  name=sign1 priority=99\n", a)
+  close
+  bwipe foo
+
   " :sign place group={group}
   let a = execute('sign place group=g1')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -67,7 +67,7 @@ func Test_sign()
   " Check placed signs
   let a=execute('sign place')
   call assert_equal("\n--- Signs ---\nSigns for [NULL]:\n" .
-		\ "    line=3  id=41  name=Sign1 priority=10\n", a)
+		\ "    line=3  id=41  name=Sign1  priority=10\n", a)
 
   " Unplace the sign and try jumping to it again should fail.
   sign unplace 41
@@ -95,7 +95,7 @@ func Test_sign()
   sign place 77 line=9 name=Sign2
   let a=execute('sign place')
   call assert_equal("\n--- Signs ---\nSigns for [NULL]:\n" .
-		\ "    line=9  id=77  name=Sign2 priority=10\n", a)
+		\ "    line=9  id=77  name=Sign2  priority=10\n", a)
   sign unplace *
 
   " Check :jump with file=...
@@ -161,7 +161,7 @@ func Test_sign()
   exe 'sign place 20 line=3 name=004 buffer=' . bufnr('')
   let a = execute('sign place')
   call assert_equal("\n--- Signs ---\nSigns for foo:\n" .
-		\ "    line=3  id=20  name=4 priority=10\n", a)
+		\ "    line=3  id=20  name=4  priority=10\n", a)
   exe 'sign unplace 20 buffer=' . bufnr('')
   sign undefine 004
   call assert_fails('sign list 4', 'E155:')
@@ -189,7 +189,7 @@ func Test_sign_undefine_still_placed()
   " Listing placed sign should show that sign is deleted.
   let a=execute('sign place')
   call assert_equal("\n--- Signs ---\nSigns for foobar:\n" .
-		\ "    line=1  id=41  name=[Deleted] priority=10\n", a)
+		\ "    line=1  id=41  name=[Deleted]  priority=10\n", a)
 
   sign unplace 41
   let a=execute('sign place')
@@ -613,19 +613,19 @@ func Test_sign_group()
   " :sign place file={fname}
   let a = execute('sign place file=Xsign')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  name=sign1 priority=10\n", a)
+	      \ "    line=10  id=5  name=sign1  priority=10\n", a)
 
   " :sign place group={group} file={fname}
   let a = execute('sign place group=g2 file=Xsign')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  group=g2  name=sign1 priority=10\n", a)
+	      \ "    line=10  id=5  group=g2  name=sign1  priority=10\n", a)
 
   " :sign place group=* file={fname}
   let a = execute('sign place group=* file=Xsign')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  group=g2  name=sign1 priority=10\n" .
-	      \ "    line=10  id=5  group=g1  name=sign1 priority=10\n" .
-	      \ "    line=10  id=5  name=sign1 priority=10\n", a)
+	      \ "    line=10  id=5  group=g2  name=sign1  priority=10\n" .
+	      \ "    line=10  id=5  group=g1  name=sign1  priority=10\n" .
+	      \ "    line=10  id=5  name=sign1  priority=10\n", a)
 
   " Error case: non-existing group
   let a = execute('sign place group=xyz file=Xsign')
@@ -640,19 +640,19 @@ func Test_sign_group()
   " :sign place buffer={fname}
   let a = execute('sign place buffer=' . bnum)
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  name=sign1 priority=10\n", a)
+	      \ "    line=10  id=5  name=sign1  priority=10\n", a)
 
   " :sign place group={group} buffer={fname}
   let a = execute('sign place group=g2 buffer=' . bnum)
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=12  id=5  group=g2  name=sign1 priority=10\n", a)
+	      \ "    line=12  id=5  group=g2  name=sign1  priority=10\n", a)
 
   " :sign place group=* buffer={fname}
   let a = execute('sign place group=* buffer=' . bnum)
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  name=sign1 priority=10\n" .
-	      \ "    line=11  id=5  group=g1  name=sign1 priority=10\n" .
-	      \ "    line=12  id=5  group=g2  name=sign1 priority=10\n", a)
+	      \ "    line=10  id=5  name=sign1  priority=10\n" .
+	      \ "    line=11  id=5  group=g1  name=sign1  priority=10\n" .
+	      \ "    line=12  id=5  group=g2  name=sign1  priority=10\n", a)
 
   " Error case: non-existing group
   let a = execute('sign place group=xyz buffer=' . bnum)
@@ -661,7 +661,7 @@ func Test_sign_group()
   " :sign place
   let a = execute('sign place')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  name=sign1 priority=10\n", a)
+	      \ "    line=10  id=5  name=sign1  priority=10\n", a)
 
   " Place signs in more than one buffer and list the signs
   split foo
@@ -669,23 +669,23 @@ func Test_sign_group()
   sign place 25 line=76 name=sign1 priority=99 file=foo
   let a = execute('sign place')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  name=sign1 priority=10\n" .
+	      \ "    line=10  id=5  name=sign1  priority=10\n" .
 	      \ "Signs for foo:\n" .
-	      \ "    line=76  id=25  name=sign1 priority=99\n", a)
+	      \ "    line=76  id=25  name=sign1  priority=99\n", a)
   close
   bwipe foo
 
   " :sign place group={group}
   let a = execute('sign place group=g1')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=11  id=5  group=g1  name=sign1 priority=10\n", a)
+	      \ "    line=11  id=5  group=g1  name=sign1  priority=10\n", a)
 
   " :sign place group=*
   let a = execute('sign place group=*')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  name=sign1 priority=10\n" .
-	      \ "    line=11  id=5  group=g1  name=sign1 priority=10\n" .
-	      \ "    line=12  id=5  group=g2  name=sign1 priority=10\n", a)
+	      \ "    line=10  id=5  name=sign1  priority=10\n" .
+	      \ "    line=11  id=5  group=g1  name=sign1  priority=10\n" .
+	      \ "    line=12  id=5  group=g2  name=sign1  priority=10\n", a)
 
   " Test for ':sign jump' command with groups
   sign jump 5 group=g1 file=Xsign
@@ -1140,14 +1140,14 @@ func Test_sign_priority()
   sign place 5 group=g2 line=10 name=sign1 priority=25 file=Xsign
   let a = execute('sign place group=*')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  name=sign1 priority=30\n" .
-	      \ "    line=10  id=5  group=g2  name=sign1 priority=25\n" .
-	      \ "    line=10  id=5  group=g1  name=sign1 priority=20\n", a)
+	      \ "    line=10  id=5  name=sign1  priority=30\n" .
+	      \ "    line=10  id=5  group=g2  name=sign1  priority=25\n" .
+	      \ "    line=10  id=5  group=g1  name=sign1  priority=20\n", a)
 
   " Test for :sign place group={group}
   let a = execute('sign place group=g1')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
-	      \ "    line=10  id=5  group=g1  name=sign1 priority=20\n", a)
+	      \ "    line=10  id=5  group=g1  name=sign1  priority=20\n", a)
 
   call sign_unplace('*')
   call sign_undefine()


### PR DESCRIPTION
After the changes made for 8.1.0697, the ":sign place" command displays only the signs
placed in the current buffer instead of displaying signs in all the buffers.
Handle this condition correctly and add a test for this.
