### PR TITLE
Improved coverage of colorscheme test: test without arg and E185

### DIFF
--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -47,7 +47,9 @@ func Test_colorscheme()
   call assert_equal(1, g:before_colors)
   call assert_equal(2, g:after_colors)
   call assert_equal("\ntorte", execute('colorscheme'))
-  call assert_equal("\nSearch         xxx term=reverse ctermfg=0 ctermbg=12 gui=bold guifg=Black guibg=Red", execute('hi Search'))
+
+  let a = substitute(execute('hi Search'), "\n\\s\\+", ' ', 'g')
+  call assert_match("\nSearch         xxx term=reverse ctermfg=0 ctermbg=12 gui=bold guifg=Black guibg=Red", a)
 
   call assert_fails('colorscheme does_not_exist', 'E185:')
 

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -46,6 +46,10 @@ func Test_colorscheme()
   call assert_equal('dark', &background)
   call assert_equal(1, g:before_colors)
   call assert_equal(2, g:after_colors)
+  call assert_equal("\ntorte", execute('colorscheme'))
+  call assert_equal("\nSearch         xxx term=reverse ctermfg=0 ctermbg=12 gui=bold guifg=Black guibg=Red", execute('hi Search'))
+
+  call assert_fails('colorscheme does_not_exist', 'E185:')
 
   exec 'colorscheme' colorscheme_saved
   augroup TestColors


### PR DESCRIPTION
This PR improves test coverage of the `:colorscheme` command:
* colorscheme without arg should display the name of the colorscheme
* non-existing colorscheme should give E185

These were not tested according to codecov:
https://codecov.io/gh/vim/vim/src/b589f95b38ddd779d7e696abb0ea011dc92ea903/src/ex_docmd.c#L7232