### PR TITLE
Fix build warning: Ruby 2.6

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -124,7 +124,7 @@
 #endif
 
 #if defined(DYNAMIC_RUBY_VER) && DYNAMIC_RUBY_VER >= 26
-# define rb_ary_detransient (*dll_rb_ary_detransient)
+# define rb_ary_detransient rb_ary_detransient_stub
 #endif
 
 #include <ruby.h>
@@ -547,6 +547,13 @@ void rb_gc_writebarrier_unprotect_stub(VALUE obj)
     dll_rb_gc_writebarrier_unprotect(obj);
 }
 #  endif
+# endif
+
+# if defined(DYNAMIC_RUBY_VER) && DYNAMIC_RUBY_VER >= 26
+void rb_ary_detransient_stub(VALUE x)
+{
+    dll_rb_ary_detransient(x);
+}
 # endif
 
 static HINSTANCE hinstRuby = NULL; /* Instance of ruby.dll */


### PR DESCRIPTION
```
In file included from if_ruby.c:130:
In file included from /usr/local/Cellar/ruby/2.6.0/include/ruby-2.6.0/ruby.h:33:
/usr/local/Cellar/ruby/2.6.0/include/ruby-2.6.0/ruby/ruby.h:2160:9: warning: variable 'dll_rb_ary_detransient' is uninitialized when used here [-Wuninitialized]
        rb_ary_detransient(a);
        ^~~~~~~~~~~~~~~~~~
if_ruby.c:127:31: note: expanded from macro 'rb_ary_detransient'
# define rb_ary_detransient (*dll_rb_ary_detransient)
                              ^~~~~~~~~~~~~~~~~~~~~~
/usr/local/Cellar/ruby/2.6.0/include/ruby-2.6.0/ruby/ruby.h:2157:37: note: initialize the variable 'dll_rb_ary_detransient' to silence this warning
    void rb_ary_detransient(VALUE a);
                                    ^
                                     = NULL
/usr/local/Cellar/ruby/2.6.0/include/ruby-2.6.0/ruby/ruby.h:2176:13: warning: variable 'dll_rb_ary_detransient' is uninitialized when used here [-Wuninitialized]
            rb_ary_detransient(a);
            ^~~~~~~~~~~~~~~~~~
if_ruby.c:127:31: note: expanded from macro 'rb_ary_detransient'
# define rb_ary_detransient (*dll_rb_ary_detransient)
                              ^~~~~~~~~~~~~~~~~~~~~~
/usr/local/Cellar/ruby/2.6.0/include/ruby-2.6.0/ruby/ruby.h:2175:45: note: initialize the variable 'dll_rb_ary_detransient' to silence this warning
            void rb_ary_detransient(VALUE a);
                                            ^
                                             = NULL
2 warnings generated.
```

This patch wraps `dll_rb_ary_detransient` by `rb_ary_detransient_stub`.