### PR TITLE
Add support for the sign_jump() function

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2412,6 +2412,8 @@ sign_define({name} [, {dict}])	Number	define or update a sign
 sign_getdefined([{name}])	List	get a list of defined signs
 sign_getplaced([{expr} [, {dict}]])
 				List	get a list of placed signs
+sign_jump({id}, {group}, {expr})
+				Number	jump to a sign
 sign_place({id}, {group}, {name}, {expr} [, {dict}])
 				Number	place a sign
 sign_undefine([{name}])		Number	undefine a sign
@@ -7998,6 +8000,20 @@ sign_getplaced([{expr} [, {dict}]])			*sign_getplaced()*
 			" Get a List of all the placed signs
 			echo sign_getplaced()
 <
+							*sign_jump()*
+sign_jump({id}, {group}, {expr})
+		Open the buffer {expr} or jump to the window that contains
+		{expr} and position the cursor at sign {id} in group {group}.
+
+		For the use of {expr}, see |bufname()|.
+
+		Returns the line number of the sign. Returns -1 if the
+		arguments are invalid.
+
+		Example: >
+			" Jump to sign 10 in the current buffer
+			call sign_jump(10, '', '')
+<
 							*sign_place()*
 sign_place({id}, {group}, {name}, {expr} [, {dict}])
 		Place the sign defined as {name} at line {lnum} in file {expr}
@@ -8009,7 +8025,7 @@ sign_place({id}, {group}, {name}, {expr} [, {dict}])
 		the sign group name. To use the global sign group, use an
 		empty string.  {group} functions as a namespace for {id}, thus
 		two groups can use the same IDs. Refer to |sign-identifier|
-		for more information.
+		and |sign-group| for more information.
 
 		{name} refers to a defined sign.
 		{expr} refers to a buffer name or number. For the accepted

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8004,6 +8004,7 @@ sign_getplaced([{expr} [, {dict}]])			*sign_getplaced()*
 sign_jump({id}, {group}, {expr})
 		Open the buffer {expr} or jump to the window that contains
 		{expr} and position the cursor at sign {id} in group {group}.
+		This is similar to the |:sign-jump| command.
 
 		For the use of {expr}, see |bufname()|.
 

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -317,6 +317,8 @@ See |sign_getplaced()| for the equivalent Vim script function.
 
 JUMPING TO A SIGN					*:sign-jump* *E157*
 
+See |sign_jump()| for the equivalent Vim script function.
+
 :sign jump {id} file={fname}
 		Open the file {fname} or jump to the window that contains
 		{fname} and position the cursor at sign {id}.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -987,6 +987,7 @@ Signs:						*sign-functions*
 	sign_define()		define or update a sign
 	sign_getdefined()	get a list of defined signs
 	sign_getplaced()	get a list of placed signs
+	sign_jump()		jump to a sign
 	sign_place()		place a sign
 	sign_undefine()		undefine a sign
 	sign_unplace()		unplace a sign

--- a/src/proto/sign.pro
+++ b/src/proto/sign.pro
@@ -11,6 +11,7 @@ void sign_mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_a
 int sign_define_by_name(char_u *name, char_u *icon, char_u *linehl, char_u *text, char_u *texthl);
 int sign_undefine_by_name(char_u *name);
 int sign_place(int *sign_id, char_u *sign_group, char_u *sign_name, buf_T *buf, linenr_T lnum, int prio);
+linenr_T sign_jump(int sign_id, char_u *sign_group, buf_T *buf);
 int sign_unplace(int sign_id, char_u *sign_group, buf_T *buf, linenr_T atlnum);
 void ex_sign(exarg_T *eap);
 void sign_getlist(char_u *name, list_T *retlist);

--- a/src/sign.c
+++ b/src/sign.c
@@ -22,16 +22,16 @@ typedef struct sign sign_T;
 
 struct sign
 {
-    sign_T	*sn_next;	/* next sign in list */
-    int		sn_typenr;	/* type number of sign */
-    char_u	*sn_name;	/* name of sign */
-    char_u	*sn_icon;	/* name of pixmap */
+    sign_T	*sn_next;	// next sign in list
+    int		sn_typenr;	// type number of sign
+    char_u	*sn_name;	// name of sign
+    char_u	*sn_icon;	// name of pixmap
 # ifdef FEAT_SIGN_ICONS
-    void	*sn_image;	/* icon image */
+    void	*sn_image;	// icon image
 # endif
-    char_u	*sn_text;	/* text used instead of pixmap */
-    int		sn_line_hl;	/* highlight ID for line */
-    int		sn_text_hl;	/* highlight ID for text */
+    char_u	*sn_text;	// text used instead of pixmap
+    int		sn_line_hl;	// highlight ID for line
+    int		sn_text_hl;	// highlight ID for text
 };
 
 static sign_T	*first_sign = NULL;
@@ -381,9 +381,9 @@ buf_change_sign_type(
 buf_getsigntype(
     buf_T	*buf,
     linenr_T	lnum,
-    int		type)	/* SIGN_ICON, SIGN_TEXT, SIGN_ANY, SIGN_LINEHL */
+    int		type)	// SIGN_ICON, SIGN_TEXT, SIGN_ANY, SIGN_LINEHL
 {
-    signlist_T	*sign;		/* a sign in a b_signlist */
+    signlist_T	*sign;		// a sign in a b_signlist
 
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
 	if (sign->lnum == lnum
@@ -526,11 +526,11 @@ buf_findsign_id(
  */
     int
 buf_findsigntype_id(
-    buf_T	*buf,		/* buffer whose sign we are searching for */
-    linenr_T	lnum,		/* line number of sign */
-    int		typenr)		/* sign type number */
+    buf_T	*buf,		// buffer whose sign we are searching for
+    linenr_T	lnum,		// line number of sign
+    int		typenr)		// sign type number
 {
-    signlist_T	*sign;		/* a sign in the signlist */
+    signlist_T	*sign;		// a sign in the signlist
 
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
 	if (sign->lnum == lnum && sign->typenr == typenr)
@@ -656,7 +656,7 @@ sign_mark_adjust(
     long	amount,
     long	amount_after)
 {
-    signlist_T	*sign;		/* a sign in a b_signlist */
+    signlist_T	*sign;		// a sign in a b_signlist
 
     FOR_ALL_SIGNS_IN_BUF(curbuf, sign)
     {
@@ -678,8 +678,8 @@ sign_mark_adjust(
  */
     static int
 sign_cmd_idx(
-    char_u	*begin_cmd,	/* begin of sign subcmd */
-    char_u	*end_cmd)	/* just after sign subcmd */
+    char_u	*begin_cmd,	// begin of sign subcmd
+    char_u	*end_cmd)	// just after sign subcmd
 {
     int		idx;
     char	save = *end_cmd;
@@ -984,6 +984,50 @@ sign_unplace_at_cursor(char_u *groupname)
 }
 
 /*
+ * Jump to a sign
+ */
+    linenr_T
+sign_jump(int sign_id, char_u *sign_group, buf_T *buf)
+{
+    linenr_T	lnum;
+
+    if ((lnum = buf_findsign(buf, sign_id, sign_group)) <= 0)
+    {
+	EMSGN(_("E157: Invalid sign ID: %ld"), sign_id);
+	return -1;
+    }
+
+    // goto a sign ...
+    if (buf_jump_open_win(buf) != NULL)
+    {			// ... in a current window
+	curwin->w_cursor.lnum = lnum;
+	check_cursor_lnum();
+	beginline(BL_WHITE);
+    }
+    else
+    {			// ... not currently in a window
+	char_u	*cmd;
+
+	if (buf->b_fname == NULL)
+	{
+	    EMSG(_("E934: Cannot jump to a buffer that does not have a name"));
+	    return -1;
+	}
+	cmd = alloc((unsigned)STRLEN(buf->b_fname) + 25);
+	if (cmd == NULL)
+	    return -1;
+	sprintf((char *)cmd, "e +%ld %s", (long)lnum, buf->b_fname);
+	do_cmdline_cmd(cmd);
+	vim_free(cmd);
+    }
+# ifdef FEAT_FOLDING
+    foldOpenCursor();
+# endif
+
+    return lnum;
+}
+
+/*
  * sign define command
  *   ":sign define {name} ..."
  */
@@ -1180,39 +1224,7 @@ sign_jump_cmd(
 	EMSG(_(e_invarg));
 	return;
     }
-
-    if ((lnum = buf_findsign(buf, id, group)) <= 0)
-    {
-	EMSGN(_("E157: Invalid sign ID: %ld"), id);
-	return;
-    }
-
-    // goto a sign ...
-    if (buf_jump_open_win(buf) != NULL)
-    {			// ... in a current window
-	curwin->w_cursor.lnum = lnum;
-	check_cursor_lnum();
-	beginline(BL_WHITE);
-    }
-    else
-    {			// ... not currently in a window
-	char_u	*cmd;
-
-	if (buf->b_fname == NULL)
-	{
-	    EMSG(_("E934: Cannot jump to a buffer that does not have a name"));
-	    return;
-	}
-	cmd = alloc((unsigned)STRLEN(buf->b_fname) + 25);
-	if (cmd == NULL)
-	    return;
-	sprintf((char *)cmd, "e +%ld %s", (long)lnum, buf->b_fname);
-	do_cmdline_cmd(cmd);
-	vim_free(cmd);
-    }
-# ifdef FEAT_FOLDING
-    foldOpenCursor();
-# endif
+    (void)sign_jump(id, group, buf);
 }
 
 /*
@@ -1685,7 +1697,7 @@ sign_get_text(int typenr)
 # if defined(FEAT_SIGN_ICONS) || defined(PROTO)
     void *
 sign_get_image(
-    int		typenr)		/* the attribute which may have a sign */
+    int		typenr)		// the attribute which may have a sign
 {
     sign_T	*sp;
 
@@ -1709,11 +1721,11 @@ free_signs(void)
 # if defined(FEAT_CMDL_COMPL) || defined(PROTO)
 static enum
 {
-    EXP_SUBCMD,		/* expand :sign sub-commands */
-    EXP_DEFINE,		/* expand :sign define {name} args */
-    EXP_PLACE,		/* expand :sign place {id} args */
-    EXP_UNPLACE,	/* expand :sign unplace" */
-    EXP_SIGN_NAMES	/* expand with name of placed signs */
+    EXP_SUBCMD,		// expand :sign sub-commands
+    EXP_DEFINE,		// expand :sign define {name} args
+    EXP_PLACE,		// expand :sign place {id} args
+    EXP_UNPLACE,	// expand :sign unplace"
+    EXP_SIGN_NAMES	// expand with name of placed signs
 } expand_what;
 
 /*
@@ -1753,7 +1765,7 @@ get_sign_name(expand_T *xp UNUSED, int idx)
 	    return (char_u *)unplace_arg[idx];
 	}
     case EXP_SIGN_NAMES:
-	/* Complete with name of signs already defined */
+	// Complete with name of signs already defined
 	current_idx = 0;
 	for (sp = first_sign; sp != NULL; sp = sp->sn_next)
 	    if (current_idx++ == idx)
@@ -1776,38 +1788,38 @@ set_context_in_sign_cmd(expand_T *xp, char_u *arg)
     int		cmd_idx;
     char_u	*begin_subcmd_args;
 
-    /* Default: expand subcommands. */
+    // Default: expand subcommands.
     xp->xp_context = EXPAND_SIGN;
     expand_what = EXP_SUBCMD;
     xp->xp_pattern = arg;
 
     end_subcmd = skiptowhite(arg);
     if (*end_subcmd == NUL)
-	/* expand subcmd name
-	 * :sign {subcmd}<CTRL-D>*/
+	// expand subcmd name
+	// :sign {subcmd}<CTRL-D>
 	return;
 
     cmd_idx = sign_cmd_idx(arg, end_subcmd);
 
-    /* :sign {subcmd} {subcmd_args}
-     *		      |
-     *		      begin_subcmd_args */
+    // :sign {subcmd} {subcmd_args}
+    //		      |
+    //		      begin_subcmd_args
     begin_subcmd_args = skipwhite(end_subcmd);
     p = skiptowhite(begin_subcmd_args);
     if (*p == NUL)
     {
-	/*
-	 * Expand first argument of subcmd when possible.
-	 * For ":jump {id}" and ":unplace {id}", we could
-	 * possibly expand the ids of all signs already placed.
-	 */
+	//
+	// Expand first argument of subcmd when possible.
+	// For ":jump {id}" and ":unplace {id}", we could
+	// possibly expand the ids of all signs already placed.
+	//
 	xp->xp_pattern = begin_subcmd_args;
 	switch (cmd_idx)
 	{
 	    case SIGNCMD_LIST:
 	    case SIGNCMD_UNDEFINE:
-		/* :sign list <CTRL-D>
-		 * :sign undefine <CTRL-D> */
+		// :sign list <CTRL-D>
+		// :sign undefine <CTRL-D>
 		expand_what = EXP_SIGN_NAMES;
 		break;
 	    default:
@@ -1816,13 +1828,13 @@ set_context_in_sign_cmd(expand_T *xp, char_u *arg)
 	return;
     }
 
-    /* expand last argument of subcmd */
+    // expand last argument of subcmd
 
-    /* :sign define {name} {args}...
-     *		    |
-     *		    p */
+    // :sign define {name} {args}...
+    //		    |
+    //		    p
 
-    /* Loop until reaching last argument. */
+    // Loop until reaching last argument.
     do
     {
 	p = skipwhite(p);
@@ -1832,12 +1844,12 @@ set_context_in_sign_cmd(expand_T *xp, char_u *arg)
 
     p = vim_strchr(last, '=');
 
-    /* :sign define {name} {args}... {last}=
-     *				     |	   |
-     *				  last	   p */
+    // :sign define {name} {args}... {last}=
+    //				     |	   |
+    //				  last	   p
     if (p == NULL)
     {
-	/* Expand last argument name (before equal sign). */
+	// Expand last argument name (before equal sign).
 	xp->xp_pattern = last;
 	switch (cmd_idx)
 	{
@@ -1857,7 +1869,7 @@ set_context_in_sign_cmd(expand_T *xp, char_u *arg)
     }
     else
     {
-	/* Expand last argument value (after equal sign). */
+	// Expand last argument value (after equal sign).
 	xp->xp_pattern = p + 1;
 	switch (cmd_idx)
 	{

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -1255,3 +1255,48 @@ func Test_sign_change_type()
   sign undefine sign2
   enew!
 endfunc
+
+" Test for the sign_jump() function
+func Test_sign_jump_func()
+  enew! | only!
+
+  sign define sign1 text=#> linehl=Comment
+
+  edit foo
+  set buftype=nofile
+  call setline(1, ['A', 'B', 'C', 'D', 'E'])
+  call sign_place(5, '', 'sign1', '', {'lnum' : 2})
+  call sign_place(5, 'g1', 'sign1', '', {'lnum' : 3})
+  call sign_place(6, '', 'sign1', '', {'lnum' : 4})
+  call sign_place(6, 'g1', 'sign1', '', {'lnum' : 5})
+  split bar
+  set buftype=nofile
+  call setline(1, ['P', 'Q', 'R', 'S', 'T'])
+  call sign_place(5, '', 'sign1', '', {'lnum' : 2})
+  call sign_place(5, 'g1', 'sign1', '', {'lnum' : 3})
+  call sign_place(6, '', 'sign1', '', {'lnum' : 4})
+  call sign_place(6, 'g1', 'sign1', '', {'lnum' : 5})
+
+  let r = sign_jump(5, '', 'foo')
+  call assert_equal(2, r)
+  call assert_equal(2, line('.'))
+  let r = sign_jump(6, 'g1', 'foo')
+  call assert_equal(5, r)
+  call assert_equal(5, line('.'))
+  let r = sign_jump(5, '', 'bar')
+  call assert_equal(2, r)
+  call assert_equal(2, line('.'))
+
+  " Error cases
+  call assert_fails("call sign_jump(99, '', 'bar')", 'E157:')
+  call assert_fails("call sign_jump(0, '', 'foo')", 'E474:')
+  call assert_fails("call sign_jump(5, 'g5', 'foo')", 'E157:')
+  call assert_fails('call sign_jump([], "", "foo")', 'E745:')
+  call assert_fails('call sign_jump(2, [], "foo")', 'E730:')
+  call assert_fails('call sign_jump(2, "", {})', 'E158:')
+  call assert_fails('call sign_jump(2, "", "baz")', 'E158:')
+
+  sign unplace * group=*
+  sign undefine sign1
+  enew! | only!
+endfunc


### PR DESCRIPTION
The sign_jump() function provides functionality equivalent to the
":sign jump" Ex command. Also update the comments in sign.c.
