### PR TITLE
nsis: Fix typos in comments

### DIFF
--- a/nsis/lang/danish.nsi
+++ b/nsis/lang/danish.nsi
@@ -10,7 +10,7 @@
 
 
 # Overwrite the default translation.
-# These string should be always English.  Otherwise dosinst.c fails.
+# These strings should be always English.  Otherwise dosinst.c fails.
 LangString ^SetupCaption     ${LANG_DANISH}         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_DANISH}         "$(^Name) Uninstall"
 

--- a/nsis/lang/dutch.nsi
+++ b/nsis/lang/dutch.nsi
@@ -11,7 +11,7 @@
 
 
 # Overwrite the default translation.
-# These string should be always English.  Otherwise dosinst.c fails.
+# These strings should be always English.  Otherwise dosinst.c fails.
 LangString ^SetupCaption     ${LANG_DUTCH} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_DUTCH} \

--- a/nsis/lang/english.nsi
+++ b/nsis/lang/english.nsi
@@ -10,7 +10,7 @@
 
 
 # Overwrite the default translation.
-# These string should be always English.  Otherwise dosinst.c fails.
+# These strings should be always English.  Otherwise dosinst.c fails.
 LangString ^SetupCaption     ${LANG_ENGLISH} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_ENGLISH} \

--- a/nsis/lang/german.nsi
+++ b/nsis/lang/german.nsi
@@ -10,7 +10,7 @@
 
 
 # Overwrite the default translation.
-# These string should be always English.  Otherwise dosinst.c fails.
+# These strings should be always English.  Otherwise dosinst.c fails.
 LangString ^SetupCaption     ${LANG_GERMAN} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_GERMAN} \

--- a/nsis/lang/italian.nsi
+++ b/nsis/lang/italian.nsi
@@ -4,14 +4,14 @@
 #
 # Locale ID    : 1040
 # Locale Name  : it
-# fileencoding : latin1
+# fileencoding : UTF-8
 # Author       : Antonio Colombo
 
 !insertmacro MUI_LANGUAGE "Italian"
 
 
 # Overwrite the default translation.
-# These string should be always English.  Otherwise dosinst.c fails.
+# These strings should be always English.  Otherwise dosinst.c fails.
 LangString ^SetupCaption     ${LANG_ITALIAN} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_ITALIAN} \

--- a/nsis/lang/japanese.nsi
+++ b/nsis/lang/japanese.nsi
@@ -10,7 +10,7 @@
 
 
 # Overwrite the default translation.
-# These string should be always English.  Otherwise dosinst.c fails.
+# These strings should be always English.  Otherwise dosinst.c fails.
 LangString ^SetupCaption     ${LANG_JAPANESE} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_JAPANESE} \

--- a/nsis/lang/simpchinese.nsi
+++ b/nsis/lang/simpchinese.nsi
@@ -11,7 +11,7 @@
 
 
 # Overwrite the default translation.
-# These string should be always English.  Otherwise dosinst.c fails.
+# These strings should be always English.  Otherwise dosinst.c fails.
 LangString ^SetupCaption     ${LANG_SIMPCHINESE} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_SIMPCHINESE} \

--- a/nsis/lang/tradchinese.nsi
+++ b/nsis/lang/tradchinese.nsi
@@ -11,7 +11,7 @@
 
 
 # Overwrite the default translation.
-# These string should be always English.  Otherwise dosinst.c fails.
+# These strings should be always English.  Otherwise dosinst.c fails.
 LangString ^SetupCaption     ${LANG_TRADCHINESE} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_TRADCHINESE} \


### PR DESCRIPTION
* Fix plural.
* Fix wrong encoding name in italian.nsi.

Related: #3501