### PR TITLE
Fix: exit_cb of the job which starts in timer-callback may be delayed

### DIFF
--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1893,3 +1893,39 @@ func Test_keep_pty_open()
   call assert_inrange(200, 1000, elapsed)
   call job_stop(job)
 endfunc
+
+func Test_job_start_in_timer()
+  if !has('job') || !has('timers')
+    return
+  endif
+
+  func OutCb(chan, msg)
+  endfunc
+
+  func ExitCb(job, status)
+    let g:val = 1
+    call Resume()
+  endfunc
+
+  func TimerCb(timer)
+    if has('win32')
+      let cmd = ['cmd', '/c', 'echo.']
+    else
+      let cmd = ['echo']
+    endif
+    let g:job = job_start(cmd, {'out_cb': 'OutCb', 'exit_cb': 'ExitCb'})
+    call substitute(repeat('a', 100000), '.', '', 'g')
+  endfunc
+
+  let g:val = 0
+  call timer_start(1, 'TimerCb')
+  let elapsed = Standby(&ut)
+  call assert_inrange(1, 1000, elapsed)
+  call job_stop(g:job)
+
+  delfunc OutCb
+  delfunc ExitCb
+  delfunc TimerCb
+  unlet! g:val
+  unlet! g:job
+endfunc


### PR DESCRIPTION
### Problem

Environments: TUI on Linux and macOS. GUI has probably no problem.

test.vim:
```vim
function! Task()
  call substitute(repeat('a', 100000), '.', '', 'g')
endfunction

function! OutCb(chan, msg)
endfunction

function! ExitCb(job, status)
  let elapsed = reltimestr(reltime(s:starttime))
  echom printf('EXIT: %s', elapsed)
endfunction

function! JobStart(...)
  let s:starttime = reltime()
  let s:job = job_start('echo', {'out_cb': 'OutCb', 'exit_cb': 'ExitCb'})
  call Task()
endfunction

call timer_start(100, 'JobStart')
```

`vim --clean -S test.vim`

and give no input, wait a bit:

Expected: `EXIT:  ...` is displayed instantly
Actual: `EXIT:  ...` is displayed after about `updatetime` has elapsed (default: 4sec)

### Cause

After `call timer_start(...)`;

1. In `mch_inchar()`, vim waits any I/O by `WaitForChar()` (`wait_time = updatetime`).
2. After 100msec, `JobStart` is invoked in `check_due_timer()` in `ui_wait_for_chars_or_timer()`
3. In `call substitute(...)` of `Task()`, job-channels are read all and closed. (in `line_breakcheck()` &rarr; `RealWaitForChar()`)
4. Therefore, no I/O except for user-input, vim cannot return from `WaitForChar()` until `updatetime - 100msec` has elapsed.

### Solution proposal

* Return promptly from `WaitForChar()` when there are any pending jobs or channels (check `has_pending_job() || channel_any_readahead()`)