### PR TITLE
Proposal: Add 'termsig' to job_info - the signal name which terminated process of the job

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5738,14 +5738,14 @@ job_info([{job}])					*job_info()*
 		   "process"	process ID
 		   "tty_in"	terminal input name, empty when none
 		   "tty_out"	terminal output name, empty when none
-		   "exitval"	only valid when "status" is "dead" and
-				"termsig" is empty
-		   "termsig"	the signal which terminated process
-				(See |job_stop()| for the values)
-				only valid when "status" is "dead" and
-				on unix
+		   "exitval"	only valid when "status" is "dead"
 		   "exit_cb"	function to be called on exit
 		   "stoponexit"	|job-stoponexit|
+
+		   Only in Unix:
+		   "termsig"	the signal which terminated process
+				(See |job_stop()| for the values)
+				only valid when "status" is "dead"
 
 		Without any arguments, returns a List with all Job objects.
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5738,7 +5738,12 @@ job_info([{job}])					*job_info()*
 		   "process"	process ID
 		   "tty_in"	terminal input name, empty when none
 		   "tty_out"	terminal output name, empty when none
-		   "exitval"	only valid when "status" is "dead"
+		   "exitval"	only valid when "status" is "dead" and
+				"termsig" is empty
+		   "termsig"	the signal which terminated process
+				(See |job_stop()| for the values)
+				only valid when "status" is "dead" and
+				on unix
 		   "exit_cb"	function to be called on exit
 		   "stoponexit"	|job-stoponexit|
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -5151,8 +5151,10 @@ job_free_contents(job_T *job)
 
     vim_free(job->jv_tty_in);
     vim_free(job->jv_tty_out);
-    vim_free(job->jv_termsig);
     vim_free(job->jv_stoponexit);
+#ifdef UNIX
+    vim_free(job->jv_termsig);
+#endif
     free_callback(job->jv_exit_cb, job->jv_exit_partial);
     if (job->jv_argv != NULL)
     {
@@ -5863,9 +5865,11 @@ job_info(job_T *job, dict_T *dict)
     dict_add_string(dict, "tty_out", job->jv_tty_out);
 
     dict_add_number(dict, "exitval", job->jv_exitval);
-    dict_add_string(dict, "termsig", job->jv_termsig);
     dict_add_string(dict, "exit_cb", job->jv_exit_cb);
     dict_add_string(dict, "stoponexit", job->jv_stoponexit);
+#ifdef UNIX
+    dict_add_string(dict, "termsig", job->jv_termsig);
+#endif
 
     l = list_alloc();
     if (l != NULL)

--- a/src/channel.c
+++ b/src/channel.c
@@ -5151,6 +5151,7 @@ job_free_contents(job_T *job)
 
     vim_free(job->jv_tty_in);
     vim_free(job->jv_tty_out);
+    vim_free(job->jv_termsig);
     vim_free(job->jv_stoponexit);
     free_callback(job->jv_exit_cb, job->jv_exit_partial);
     if (job->jv_argv != NULL)
@@ -5862,7 +5863,7 @@ job_info(job_T *job, dict_T *dict)
     dict_add_string(dict, "tty_out", job->jv_tty_out);
 
     dict_add_number(dict, "exitval", job->jv_exitval);
-    dict_add_number(dict, "termsig", job->jv_termsig);
+    dict_add_string(dict, "termsig", job->jv_termsig);
     dict_add_string(dict, "exit_cb", job->jv_exit_cb);
     dict_add_string(dict, "stoponexit", job->jv_stoponexit);
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -5862,6 +5862,7 @@ job_info(job_T *job, dict_T *dict)
     dict_add_string(dict, "tty_out", job->jv_tty_out);
 
     dict_add_number(dict, "exitval", job->jv_exitval);
+    dict_add_number(dict, "termsig", job->jv_termsig);
     dict_add_string(dict, "exit_cb", job->jv_exit_cb);
     dict_add_string(dict, "stoponexit", job->jv_stoponexit);
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -5758,11 +5758,13 @@ mch_job_status(job_T *job)
 	    ch_log(job->jv_channel, "Job exited with %d", job->jv_exitval);
 	goto return_dead;
     }
-    if (WIFSIGNALED(status))
+    else if (WIFSIGNALED(status))
     {
 	job->jv_exitval = -1;
+	job->jv_termsig = WTERMSIG(status);
 	if (job->jv_status < JOB_ENDED)
-	    ch_log(job->jv_channel, "Job terminated by a signal");
+	    ch_log(job->jv_channel, "Job terminated by a signal %d",
+							      job->jv_termsig);
 	goto return_dead;
     }
     return "run";
@@ -5808,7 +5810,10 @@ mch_detect_ended_job(job_T *job_list)
 		/* LINTED avoid "bitwise operation on signed value" */
 		job->jv_exitval = WEXITSTATUS(status);
 	    else if (WIFSIGNALED(status))
+	    {
 		job->jv_exitval = -1;
+		job->jv_termsig = WTERMSIG(status);
+	    }
 	    if (job->jv_status < JOB_ENDED)
 	    {
 		ch_log(job->jv_channel, "Job ended");

--- a/src/structs.h
+++ b/src/structs.h
@@ -1561,7 +1561,7 @@ struct jobvar_S
     jobstatus_T	jv_status;
     char_u	*jv_stoponexit; /* allocated */
     int		jv_exitval;
-    int		jv_termsig;
+    char_u	*jv_termsig;
     char_u	*jv_exit_cb;	/* allocated */
     partial_T	*jv_exit_partial;
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -1559,9 +1559,11 @@ struct jobvar_S
     char_u	*jv_tty_in;	/* controlling tty input, allocated */
     char_u	*jv_tty_out;	/* controlling tty output, allocated */
     jobstatus_T	jv_status;
-    char_u	*jv_stoponexit; /* allocated */
+    char_u	*jv_stoponexit;	/* allocated */
+#ifdef UNIX
+    char_u	*jv_termsig;	/* allocated */
+#endif
     int		jv_exitval;
-    char_u	*jv_termsig;
     char_u	*jv_exit_cb;	/* allocated */
     partial_T	*jv_exit_partial;
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -1561,6 +1561,7 @@ struct jobvar_S
     jobstatus_T	jv_status;
     char_u	*jv_stoponexit; /* allocated */
     int		jv_exitval;
+    int		jv_termsig;
     char_u	*jv_exit_cb;	/* allocated */
     partial_T	*jv_exit_partial;
 

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1998,3 +1998,27 @@ func Test_raw_large_data()
     unlet g:out
   endtry
 endfunc
+
+func Test_job_exitval_and_termsig()
+  if !has('unix')
+    return
+  endif
+
+  " Terminate job normally
+  let cmd = ['echo']
+  let job = job_start(cmd)
+  call WaitForAssert({-> assert_equal("dead", job_status(job))})
+  let info = job_info(job)
+  call assert_equal(0, info.exitval)
+  call assert_equal("", info.termsig)
+
+  " Terminate job by signal
+  let cmd = ['sleep', '10']
+  let job = job_start(cmd)
+  sleep 10m
+  call job_stop(job)
+  call WaitForAssert({-> assert_equal("dead", job_status(job))})
+  let info = job_info(job)
+  call assert_equal(-1, info.exitval)
+  call assert_equal("term", info.termsig)
+endfunc


### PR DESCRIPTION
Currently, on unix when a job is terminated by signal, user can only get info `job_info(job).exitval == -1`.
For the convenience, this pull-req adds `termsig` field in order to get the signal name which terminated process.