### PR TITLE
Add full 64/32 bit range to -o and output

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -52,6 +52,7 @@
  * 2011 March  Better error handling by Florian Zumbiehl.
  * 2011 April  Formatting by Bram Moolenaar
  * 08.06.2013  Little-endian hexdump (-e) and offset (-o) by Vadim Vygonets.
+ * 11.01.2019  Add full 64/32 bit range to -o and output by Christer Jensen.
  *
  * (c) 1990-1998 by Juergen Weigert (jnweiger@informatik.uni-erlangen.de)
  *
@@ -90,6 +91,7 @@
 #include <stdlib.h>
 #include <string.h>	/* for strncmp() */
 #include <ctype.h>	/* for isalnum() */
+#include <limits.h>
 #if __MWERKS__ && !defined(BEBOX)
 # include <unix.h>	/* for fdopen() on MAC */
 #endif
@@ -204,7 +206,7 @@ static void xxdline __P((FILE *, char *, int));
 
 #define TRY_SEEK	/* attempt to use lseek, or skip forward by reading */
 #define COLS 256	/* change here, if you ever need more columns */
-#define LLEN (12 + (9*COLS-1) + COLS + 2)
+#define LLEN ((2*sizeof(unsigned long)) + 4 + (9*COLS-1) + COLS + 2)
 
 char hexxa[] = "0123456789abcdef0123456789ABCDEF", *hexx = hexxa;
 
@@ -461,12 +463,13 @@ static unsigned char etoa64[] =
 main(int argc, char *argv[])
 {
   FILE *fp, *fpo;
-  int c, e, p = 0, relseek = 1, negseek = 0, revert = 0;
+  int c, e, p = 0, relseek = 1, negseek = 0, reloffset = 1, negoffset = 0, revert = 0;
   int cols = 0, nonzero = 0, autoskip = 0, hextype = HEX_NORMAL, capitalize = 0;
   int ebcdic = 0;
   int octspergrp = -1;	/* number of octets grouped in output */
   int grplen;		/* total chars per octet group */
-  long length = -1, n = 0, seekoff = 0, displayoff = 0;
+  long length = -1, n = 0, seekoff = 0;
+  unsigned long displayoff = 0;
   static char l[LLEN+1];  /* static because it may be too big for stack */
   char *pp;
 
@@ -536,13 +539,25 @@ main(int argc, char *argv[])
 	}
       else if (!STRNCMP(pp, "-o", 2))
 	{
+	  int reloffset = 0;
+	  int negoffset = 0;
 	  if (pp[2] && STRNCMP("ffset", pp + 2, 5))
-	    displayoff = (int)strtol(pp + 2, NULL, 0);
+	    displayoff = strtoul(pp + 2, NULL, 0);
 	  else
 	    {
 	      if (!argv[2])
 		exit_with_usage();
-	      displayoff = (int)strtol(argv[2], NULL, 0);
+
+	      if (argv[2][0] == '+')
+	       reloffset++;
+	     if (argv[2][reloffset] == '-')
+	       negoffset++;
+	     
+	     if (negoffset)
+	       displayoff = ULONG_MAX - strtoul(argv[2] + reloffset+negoffset, NULL, 0) + 1;
+	     else
+	       displayoff = strtoul(argv[2] + reloffset+negoffset, NULL, 0);
+
 	      argv++;
 	      argc--;
 	    }
@@ -805,31 +820,32 @@ main(int argc, char *argv[])
   else	/* hextype == HEX_BITS */
     grplen = 8 * octspergrp + 1;
 
+  int s = 9;
   e = 0;
   while ((length < 0 || n < length) && (e = getc(fp)) != EOF)
     {
       if (p == 0)
 	{
-	  sprintf(l, "%08lx:",
-	    ((unsigned long)(n + seekoff + displayoff)) & 0xffffffff);
-	  for (c = 9; c < LLEN; l[c++] = ' ');
+	  s = sprintf(l, "%08lx:",
+	    ((unsigned long)(n + seekoff + displayoff)));
+	  for (c = s; c < LLEN; l[c++] = ' ');
 	}
       if (hextype == HEX_NORMAL)
 	{
-	  l[c = (10 + (grplen * p) / octspergrp)] = hexx[(e >> 4) & 0xf];
+	  l[c = (s + 1 + (grplen * p) / octspergrp)] = hexx[(e >> 4) & 0xf];
 	  l[++c]				  = hexx[ e       & 0xf];
 	}
       else if (hextype == HEX_LITTLEENDIAN)
 	{
 	  int x = p ^ (octspergrp-1);
-	  l[c = (10 + (grplen * x) / octspergrp)] = hexx[(e >> 4) & 0xf];
+	  l[c = (s + 1 + (grplen * x) / octspergrp)] = hexx[(e >> 4) & 0xf];
 	  l[++c]				  = hexx[ e       & 0xf];
 	}
       else /* hextype == HEX_BITS */
 	{
 	  int i;
 
-	  c = (10 + (grplen * p) / octspergrp) - 1;
+	  c = (s + 1 + (grplen * p) / octspergrp) - 1;
 	  for (i = 7; i >= 0; i--)
 	    l[++c] = (e & (1 << i)) ? '1' : '0';
 	}
@@ -838,7 +854,7 @@ main(int argc, char *argv[])
       if (ebcdic)
 	e = (e < 64) ? '.' : etoa64[e-64];
       /* When changing this update definition of LLEN above. */
-      l[12 + (grplen * cols - 1)/octspergrp + p] =
+      l[s + 3 + (grplen * cols - 1)/octspergrp + p] =
 #ifdef __MVS__
 	  (e >= 64)
 #else
@@ -848,7 +864,7 @@ main(int argc, char *argv[])
       n++;
       if (++p == cols)
 	{
-	  l[c = (12 + (grplen * cols - 1)/octspergrp + p)] = '\n'; l[++c] = '\0';
+	  l[c = (s + 3 + (grplen * cols - 1)/octspergrp + p)] = '\n'; l[++c] = '\0';
 	  xxdline(fpo, l, autoskip ? nonzero : 1);
 	  nonzero = 0;
 	  p = 0;
@@ -858,7 +874,7 @@ main(int argc, char *argv[])
     die(2);
   if (p)
     {
-      l[c = (12 + (grplen * cols - 1)/octspergrp + p)] = '\n'; l[++c] = '\0';
+      l[c = (s + 3 + (grplen * cols - 1)/octspergrp + p)] = '\n'; l[++c] = '\0';
       xxdline(fpo, l, 1);
     }
   else if (autoskip)


### PR DESCRIPTION
xxd is unable to output addresses higher that 0xffffffff even when compiled for a 64 bit architecture. This makes it hard to work with any files bigger than 4.3 GB or virtual files (like process memory) that can be addressed higher. It's odd limit since this limit is not imposed on seek and if custom input is feed to xxd -r with addresses higher than 0xffffffff it works fine. So parsing it is no problem.

This commit is removes this limitation allowing for the argument to -o to span the entire [-0xffffffffffffffff, +0xffffffffffffffff] range in case of 64 bit architecture or [-0xffffffff, +0xffffffff] in case of 32 bit architecture, same with the output generated by the program. To be as non-destructive as possible the output stays unchanged until 0xffffffff is exceeded in which case any additional digits is added as needed pushing everything over by however many digits.

The seek is still limited to the size of a signed long, partly due to the API used. Nothing changed regards to that. Testing showed no issues with both 32 and 64 bit binaries on my Linux 64 bit machine.