### PR TITLE
Remove macro in regexp

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -1933,12 +1933,10 @@ regpiece(int *flagp)
     {
 	/* Can't have a multi follow a multi. */
 	if (peekchr() == Magic('*'))
-	    sprintf((char *)IObuff, _("E61: Nested %s*"),
-					   reg_magic >= MAGIC_ON ? "" : "\\");
+	    semsg(_("E61: Nested %s*"), reg_magic >= MAGIC_ON ? "" : "\\");
 	else
-	    sprintf((char *)IObuff, _("E62: Nested %s%c"),
-		     reg_magic == MAGIC_ALL ? "" : "\\", no_Magic(peekchr()));
-	emsg((char *)IObuff);
+	    semsg(_("E62: Nested %s%c"), reg_magic == MAGIC_ALL ? "" : "\\",
+							 no_Magic(peekchr()));
 	rc_did_emsg = TRUE;
 	return NULL;
     }
@@ -2125,10 +2123,9 @@ regatom(int *flagp)
       case Magic('{'):
       case Magic('*'):
 	c = no_Magic(c);
-	sprintf((char *)IObuff, _("E64: %s%c follows nothing"),
+	semsg(_("E64: %s%c follows nothing"),
 		(c == '*' ? reg_magic >= MAGIC_ON : reg_magic == MAGIC_ALL)
 		? "" : "\\", c);
-	emsg((char *)IObuff);
 	rc_did_emsg = TRUE;
 	return NULL;
 	/* NOTREACHED */
@@ -3519,9 +3516,8 @@ read_limits(long *minval, long *maxval)
 	regparse++;	/* Allow either \{...} or \{...\} */
     if (*regparse != '}')
     {
-	sprintf((char *)IObuff, _("E554: Syntax error in %s{...}"),
+	semsg(_("E554: Syntax error in %s{...}"),
 					  reg_magic == MAGIC_ALL ? "" : "\\");
-	emsg((char *)IObuff);
 	rc_did_emsg = TRUE;
 	return FAIL;
     }


### PR DESCRIPTION
This pull-req proposes avoid to use macro in regexp.c.

And I found some fixes in regexp.c, the following parts: (this pull-req includes them)

* Use semsg() directly instead of sprintf() and emsg()
* Fix error message in re_mult_next()

```diff
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -1897,12 +1897,12 @@ regpiece(int *flagp)
     {
        /* Can't have a multi follow a multi. */
        if (peekchr() == Magic('*'))
-           sprintf((char *)IObuff, _("E61: Nested %s*"),
-                                           reg_magic >= MAGIC_ON ? "" : "\\");
+           semsg(_("E61: Nested %s*"), reg_magic >= MAGIC_ON ? "" : "\\");
        else
-           sprintf((char *)IObuff, _("E62: Nested %s%c"),
-               reg_magic == MAGIC_ALL ? "" : "\\", no_Magic(peekchr()));
-       EMSG_RET_NULL((char *)IObuff);
+           semsg(_("E62: Nested %s%c"), reg_magic == MAGIC_ALL ? "" : "\\",
+                                                        no_Magic(peekchr()));
+       rc_did_emsg = TRUE;
+       return NULL;
     }

     return ret;
@@ -2075,10 +2075,11 @@ regatom(int *flagp)
       case Magic('{'):
       case Magic('*'):
        c = no_Magic(c);
-       sprintf((char *)IObuff, _("E64: %s%c follows nothing"),
+       semsg(_("E64: %s%c follows nothing"),
                (c == '*' ? reg_magic >= MAGIC_ON : reg_magic == MAGIC_ALL)
                ? "" : "\\", c);
-       EMSG_RET_NULL((char *)IObuff);
+       rc_did_emsg = TRUE;
+       return NULL;
        /* NOTREACHED */

       case Magic('~'):         /* previous substitute pattern */
@@ -3403,11 +3404,8 @@ read_limits(long *minval, long *maxval)
     if (*regparse == '\\')
        regparse++;     /* Allow either \{...} or \{...\} */
     if (*regparse != '}')
-    {
-       sprintf((char *)IObuff, _("E554: Syntax error in %s{...}"),
-                                         reg_magic == MAGIC_ALL ? "" : "\\");
-       EMSG_RET_FAIL((char *)IObuff);
-    }
+       EMSG2_RET_FAIL(_("E554: Syntax error in %s{...}"),
+                                                     reg_magic == MAGIC_ALL);

     /*
      * Reverse the range if there was a '-', or make sure it is in the right
@@ -6998,7 +6996,11 @@ regprop(char_u *op)
 re_mult_next(char *what)
 {
     if (re_multi_type(peekchr()) == MULTI_MULT)
-       EMSG2_RET_FAIL(_("E888: (NFA regexp) cannot repeat %s"), what);
+    {
+       semsg(_("E888: (NFA regexp) cannot repeat %s"), what);
+       rc_did_emsg = TRUE;
+       return FAIL;
+    }
     return OK;
 }
```
