### PR TITLE
Added GNUC __attribute__ format and fix incorrect formats it found

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1407,7 +1407,7 @@ do_buffer(
 	    else
 #endif
 	    {
-		semsg(_("E89: No write since last change for buffer %ld (add ! to override)"),
+		semsg(_("E89: No write since last change for buffer %d (add ! to override)"),
 								 buf->b_fnum);
 		return FAIL;
 	    }
@@ -2283,7 +2283,7 @@ buflist_getfile(
 	if ((options & GETF_ALT) && n == 0)
 	    emsg(_(e_noalt));
 	else
-	    semsg(_("E92: Buffer %ld not found"), n);
+	    semsg(_("E92: Buffer %d not found"), n);
 	return FAIL;
     }
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -173,7 +173,7 @@ diff_buf_add(buf_T *buf)
 	    return;
 	}
 
-    semsg(_("E96: Cannot diff more than %ld buffers"), DB_COUNT);
+    semsg(_("E96: Cannot diff more than %d buffers"), DB_COUNT);
 }
 
 /*

--- a/src/eval.c
+++ b/src/eval.c
@@ -268,7 +268,7 @@ compare_func_name(const void *s1, const void *s2)
 
 /*
  * Sort the function table by function name.
- * The sorting of the table above is ASCII dependant.
+ * The sorting of the table above is ASCII dependent.
  * On machines using EBCDIC we have to sort it.
  */
     static void

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8256,7 +8256,7 @@ f_matchadd(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 	return;
     if (id >= 1 && id <= 3)
     {
-	semsg(_("E798: ID is reserved for \":match\": %ld"), id);
+	semsg(_("E798: ID is reserved for \":match\": %d"), id);
 	return;
     }
 
@@ -8314,7 +8314,7 @@ f_matchaddpos(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     /* id == 3 is ok because matchaddpos() is supposed to substitute :3match */
     if (id == 1 || id == 2)
     {
-	semsg(_("E798: ID is reserved for \":match\": %ld"), id);
+	semsg(_("E798: ID is reserved for \":match\": %d"), id);
 	return;
     }
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1296,7 +1296,7 @@ do_cmdline(
 	 */
 	if (did_throw)
 	{
-	    char_u	*p = NULL;
+	    void	*p = NULL;
 	    char_u	*saved_sourcing_name;
 	    int		saved_sourcing_lnum;
 	    struct msglist	*messages = NULL, *next;
@@ -1347,7 +1347,7 @@ do_cmdline(
 	    }
 	    else if (p != NULL)
 	    {
-		semsg("%s", p);
+		emsg(p);
 		vim_free(p);
 	    }
 	    vim_free(sourcing_name);
@@ -6958,7 +6958,7 @@ do_ucmd(exarg_T *eap)
 		}
 	    }
 
-	    /* break if there no <item> is found */
+	    /* break if no <item> is found */
 	    if (start == NULL || end == NULL)
 		break;
 
@@ -8022,7 +8022,7 @@ handle_drop_internal(void)
 /*
  * Handle a file drop. The code is here because a drop is *nearly* like an
  * :args command, but not quite (we have a list of exact filenames, so we
- * don't want to (a) parse a command line, or (b) expand wildcards. So the
+ * don't want to (a) parse a command line, or (b) expand wildcards). So the
  * code is very similar to :args and hence needs access to a lot of the static
  * functions in this file.
  *

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1296,7 +1296,7 @@ do_cmdline(
 	 */
 	if (did_throw)
 	{
-	    void	*p = NULL;
+	    char_u	*p = NULL;
 	    char_u	*saved_sourcing_name;
 	    int		saved_sourcing_lnum;
 	    struct msglist	*messages = NULL, *next;
@@ -1347,7 +1347,7 @@ do_cmdline(
 	    }
 	    else if (p != NULL)
 	    {
-		semsg(p);
+		semsg("%s", p);
 		vim_free(p);
 	    }
 	    vim_free(sourcing_name);
@@ -5788,8 +5788,8 @@ check_more(
 		return FAIL;
 	    }
 #endif
-	    semsg(NGETTEXT("E173: %ld more file to edit",
-			"E173: %ld more files to edit", n), n);
+	    semsg(NGETTEXT("E173: %d more file to edit",
+			"E173: %d more files to edit", n), n);
 	    quitmore = 2;	    /* next try to quit is allowed */
 	}
 	return FAIL;

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -651,7 +651,7 @@ cs_cnt_connections(void)
 cs_reading_emsg(
     int idx)	/* connection index */
 {
-    semsg(_("E262: error reading cscope connection %ld"), idx);
+    semsg(_("E262: error reading cscope connection %d"), idx);
 }
 
 #define	CSREAD_BUFSIZE	2048

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -1541,7 +1541,7 @@ nb_do_cmd(
 		if (!buf->bufp->b_netbeans_file)
 		{
 		    nbdebug(("E658: NetBeans connection lost for buffer %ld\n", buf->bufp->b_fnum));
-		    semsg(_("E658: NetBeans connection lost for buffer %ld"),
+		    semsg(_("E658: NetBeans connection lost for buffer %d"),
 							   buf->bufp->b_fnum);
 		}
 		else

--- a/src/proto.h
+++ b/src/proto.h
@@ -108,19 +108,31 @@ int
 #  ifdef __BORLANDC__
 _RTLENTRYF
 #  endif
-smsg(const char *, ...);
+smsg(const char *, ...)
+#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+    __attribute__((format(printf, 1, 0)))
+#endif
+    ;
 
 int
 #  ifdef __BORLANDC__
 _RTLENTRYF
 #  endif
-smsg_attr(int, const char *, ...);
+smsg_attr(int, const char *, ...)
+#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+    __attribute__((format(printf, 2, 3)))
+#endif
+    ;
 
 int
 #  ifdef __BORLANDC__
 _RTLENTRYF
 #  endif
-smsg_attr_keep(int, const char *, ...);
+smsg_attr_keep(int, const char *, ...)
+#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+    __attribute__((format(printf, 2, 3)))
+#endif
+    ;
 
 int
 #  ifdef __BORLANDC__

--- a/src/proto/message.pro
+++ b/src/proto/message.pro
@@ -11,9 +11,18 @@ int emsg_not_now(void);
 void ignore_error_for_testing(char_u *error);
 void do_perror(char *msg);
 int emsg(char *s);
-int semsg(const char *s, ...);
+
+int semsg(const char *s, ...)
+#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+    __attribute__((format(printf, 1, 2)))
+#endif
+;
 void iemsg(char *s);
-void siemsg(const char *s, ...);
+void siemsg(const char *s, ...)
+#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+    __attribute__((format(printf, 1, 2)))
+#endif
+;
 void internal_error(char *where);
 void emsg_invreg(int name);
 char_u *msg_trunc_attr(char_u *s, int force, int attr);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -6263,7 +6263,7 @@ qf_add_entry_from_dict(
 	if (!did_bufnr_emsg)
 	{
 	    did_bufnr_emsg = TRUE;
-	    semsg(_("E92: Buffer %ld not found"), bufnum);
+	    semsg(_("E92: Buffer %d not found"), bufnum);
 	}
 	valid = FALSE;
 	bufnum = 0;

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1307,7 +1307,7 @@ nfa_regatom(void)
 		    rc_did_emsg = TRUE;
 		    return FAIL;
 		}
-		siemsg("INTERNAL: Unknown character class char: %ld", c);
+		siemsg("INTERNAL: Unknown character class char: %d", c);
 		return FAIL;
 	    }
 #ifdef FEAT_MBYTE

--- a/src/sign.c
+++ b/src/sign.c
@@ -162,7 +162,7 @@ sign_group_get_next_signid(buf_T *buf, char_u *groupname)
 	group = HI2SG(hi);
     }
 
-    // Search for the next usuable sign identifier
+    // Search for the next usable sign identifier
     while (!found)
     {
 	if (group == NULL)
@@ -996,7 +996,7 @@ sign_jump(int sign_id, char_u *sign_group, buf_T *buf)
 
     if ((lnum = buf_findsign(buf, sign_id, sign_group)) <= 0)
     {
-	semsg(_("E157: Invalid sign ID: %ld"), sign_id);
+	semsg(_("E157: Invalid sign ID: %d"), sign_id);
 	return -1;
     }
 

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -6014,7 +6014,7 @@ mkspell(
     else if (vim_strchr(gettail(wfname), '_') != NULL)
 	emsg(_("E751: Output file name must not have region name"));
     else if (incount > MAXREGIONS)
-	semsg(_("E754: Only up to %ld regions supported"), MAXREGIONS);
+	semsg(_("E754: Only up to %d regions supported"), MAXREGIONS);
     else
     {
 	/* Check for overwriting before doing things that may take a lot of
@@ -6274,7 +6274,7 @@ spell_add_word(
 		break;
 	    if (*spf == NUL)
 	    {
-		semsg(_("E765: 'spellfile' does not have %ld entries"), idx);
+		semsg(_("E765: 'spellfile' does not have %d entries"), idx);
 		vim_free(fnamebuf);
 		return;
 	    }

--- a/src/window.c
+++ b/src/window.c
@@ -6782,7 +6782,7 @@ match_add(
 	return -1;
     if (id < -1 || id == 0)
     {
-	semsg(_("E799: Invalid ID: %ld (must be greater than or equal to 1)"), id);
+	semsg(_("E799: Invalid ID: %d (must be greater than or equal to 1)"), id);
 	return -1;
     }
     if (id != -1)
@@ -6792,7 +6792,7 @@ match_add(
 	{
 	    if (cur->id == id)
 	    {
-		semsg(_("E801: ID already taken: %ld"), id);
+		semsg(_("E801: ID already taken: %d"), id);
 		return -1;
 	    }
 	    cur = cur->next;
@@ -6969,7 +6969,7 @@ match_delete(win_T *wp, int id, int perr)
     if (id < 1)
     {
 	if (perr == TRUE)
-	    semsg(_("E802: Invalid ID: %ld (must be greater than or equal to 1)"),
+	    semsg(_("E802: Invalid ID: %d (must be greater than or equal to 1)"),
 									  id);
 	return -1;
     }
@@ -6981,7 +6981,7 @@ match_delete(win_T *wp, int id, int perr)
     if (cur == NULL)
     {
 	if (perr == TRUE)
-	    semsg(_("E803: ID not found: %ld"), id);
+	    semsg(_("E803: ID not found: %d"), id);
 	return -1;
     }
     if (cur == prev)


### PR DESCRIPTION
This PR adds some `__attribute__((format(printf, ...))`
to detect incorrect format at compilation time and 
fix a few incorrect format it found.