### PR TITLE
Fix the flag of 'cursorcolumn' and add tests

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -989,7 +989,7 @@ static struct vimoption options[] =
     {"cursorbind",  "crb",  P_BOOL|P_VI_DEF,
 			    (char_u *)VAR_WIN, PV_CRBIND,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
-    {"cursorcolumn", "cuc", P_BOOL|P_VI_DEF|P_RWIN,
+    {"cursorcolumn", "cuc", P_BOOL|P_VI_DEF|P_RWINONLY,
 #ifdef FEAT_SYN_HL
 			    (char_u *)VAR_WIN, PV_CUC,
 #else

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -46,3 +46,24 @@ func Test_curswant_with_autocommand()
   quit!
 endfunc
 
+
+" Tests for behavior of curswant with cursorcolumn/line
+func Test_curswant_with_cursorcolumn()
+  new
+  call setline(1, ['01234567', ''])
+  exe "normal! ggf6j"
+  call assert_equal(6, winsaveview().curswant)
+  set cursorcolumn
+  call assert_equal(6, winsaveview().curswant)
+  quit!
+endfunc
+
+func Test_curswant_with_cursorline()
+  new
+  call setline(1, ['01234567', ''])
+  exe "normal! ggf6j"
+  call assert_equal(6, winsaveview().curswant)
+  set cursorline
+  call assert_equal(6, winsaveview().curswant)
+  quit!
+endfunc


### PR DESCRIPTION
Problem:   curswant is forcibly changed when 'cursorcolumn' is set.
Solution:  Fix flag of 'cursorcolumn' to P_RWINONLY.