### PR TITLE
Fix input() while job callback

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -8325,12 +8325,15 @@ get_user_input(
 	if (defstr != NULL)
 	{
 	    int save_ex_normal_busy = ex_normal_busy;
+	    int save_vgetc_busy = vgetc_busy;
 
 	    ex_normal_busy = 0;
+	    vgetc_busy = 0;
 	    rettv->vval.v_string =
 		getcmdline_prompt(secret ? NUL : '@', p, echo_attr,
 							      xp_type, xp_arg);
 	    ex_normal_busy = save_ex_normal_busy;
+	    vgetc_busy = save_vgetc_busy;
 	}
 	if (inputdialog && rettv->vval.v_string == NULL
 		&& argvars[1].v_type != VAR_UNKNOWN

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1985,15 +1985,16 @@ func Test_input_with_job_callback()
 
   func TimerCb(timer)
     let g:val = getcmdline()
-    call feedkeys("<CR>", 'nt')
+    call feedkeys("\<CR>", 'nt')
   endfunc
 
   func Callback(...)
+    call timer_start(100, 'TimerCb')
     call input('x: ', 'y')
   endfunc
 
-  call timer_start(100, 'TimerCb')
   let g:job = job_start([&shell, &shellcmdflag, 'echo 1'], {'callback': 'Callback'})
+  call WaitFor({-> job_status(job) ==# 'dead'})
 
   call assert_equal('y', g:val)
   call job_stop(g:job)
@@ -2003,4 +2004,3 @@ func Test_input_with_job_callback()
   unlet! g:val
   unlet! g:job
 endfunc
-

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1975,3 +1975,32 @@ func Test_job_start_in_timer()
   unlet! g:val
   unlet! g:job
 endfunc
+
+func Test_input_with_job_callback()
+  if !has('job') || !has('timers')
+    return
+  endif
+
+  let g:val = ''
+
+  func TimerCb(timer)
+    let g:val = getcmdline()
+    call feedkeys("<CR>", 'nt')
+  endfunc
+
+  func Callback(...)
+    call input('x: ', 'y')
+  endfunc
+
+  call timer_start(100, 'TimerCb')
+  let g:job = job_start([&shell, &shellcmdflag, 'echo 1'], {'callback': 'Callback'})
+
+  call assert_equal('y', g:val)
+  call job_stop(g:job)
+
+  delfunc TimerCb
+  delfunc Callback
+  unlet! g:val
+  unlet! g:job
+endfunc
+

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1994,7 +1994,7 @@ func Test_input_with_job_callback()
   endfunc
 
   let g:job = job_start([&shell, &shellcmdflag, 'echo 1'], {'callback': 'Callback'})
-  call WaitFor({-> job_status(job) ==# 'dead'})
+  call WaitFor({-> job_status(g:job) ==# 'dead'})
 
   call assert_equal('y', g:val)
   call job_stop(g:job)


### PR DESCRIPTION
When using input() while callback of job, default value is not set.

```
call job_start([&shell, &shellcmdflag, 'echo 1'], {'callback': {x->input('x: ', 'y')}})
```

This expect:

```
x: y
```

but got

```
x: 
```