### PR TITLE
Fix #3799

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -222,7 +222,7 @@ ui_wait_for_chars_or_timer(
     long    remaining = wtime;
     int	    tb_change_cnt = typebuf.tb_change_cnt;
 # ifdef FEAT_JOB_CHANNEL
-    int	    brief_wait = TRUE;
+    int	    brief_wait = FALSE;
 # endif
 
     // When waiting very briefly don't trigger timers.


### PR DESCRIPTION
"brief_wait" in "ui_wait_for_chars_or_timer()" must be set to FALSE first.