### PR TITLE
Remove Test_stop_in_terminal

### DIFF
--- a/src/testdir/test_suspend.vim
+++ b/src/testdir/test_suspend.vim
@@ -45,6 +45,11 @@ func Test_suspend()
   call term_sendkeys(buf, "fg\<CR>")
   call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
 
+  " Quit gracefully to dump coverage information.
+  call term_sendkeys(buf, ":quit\<CR>")
+  call term_wait(buf)
+  call Stop_shell_in_terminal(buf)
+
   exe buf . 'bwipe!'
   call delete('Xfoo')
   set autowrite&

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1690,39 +1690,6 @@ func Test_terminal_does_not_truncate_last_newlines()
   call delete('Xfile')
 endfunc
 
-func Test_stop_in_terminal()
-  " We can't expect this to work on all systems, just test on Linux for now.
-  if !has('unix') || system('uname') !~ 'Linux'
-    return
-  endif
-  term /bin/sh
-  let bufnr = bufnr('')
-  call WaitForAssert({-> assert_equal('running', term_getstatus(bufnr))})
-  let lastrow = term_getsize(bufnr)[0]
-
-  call term_sendkeys(bufnr, GetVimCommandClean() . "\r")
-  call term_sendkeys(bufnr, ":echo 'ready'\r")
-  call WaitForAssert({-> assert_match('ready', Get_terminal_text(bufnr, lastrow))})
-
-  call term_sendkeys(bufnr, ":stop\r")
-  " Not sure where "Stopped" shows up, need five lines for Arch.
-  call WaitForAssert({-> assert_match('Stopped',
-	\ Get_terminal_text(bufnr, 1) . 
-	\ Get_terminal_text(bufnr, 2) . 
-	\ Get_terminal_text(bufnr, 3) . 
-	\ Get_terminal_text(bufnr, 4) . 
-	\ Get_terminal_text(bufnr, 5))})
-
-  call term_sendkeys(bufnr, "fg\r")
-  call term_sendkeys(bufnr, ":echo 'back again'\r")
-  call WaitForAssert({-> assert_match('back again', Get_terminal_text(bufnr, lastrow))})
-
-  call term_sendkeys(bufnr, ":quit\r")
-  call term_wait(bufnr)
-  call Stop_shell_in_terminal(bufnr)
-  exe bufnr . 'bwipe'
-endfunc
-
 func Test_terminal_no_job()
   let term = term_start('false', {'term_finish': 'close'})
   call WaitForAssert({-> assert_equal(v:null, term_getjob(term)) })


### PR DESCRIPTION
I think Test_stop_in_terminal is unnecessary, because:

* Duplicated of Test_suspend

Test_suspend is for ":stop" and more detailed.

* Test_stop_in_terminal causes CI fail on GUI

https://travis-ci.org/ichizok/vim/jobs/480976509
On GUI, Test_stop_in_terminal tries to launch gVim in terminal, so will fail.