### PR TITLE
Use "ELAPSED_FUNC" instead of "HAVE_GETTIMEOFDAY"

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -4290,7 +4290,7 @@ channel_parse_messages(void)
     int		r;
     ch_part_T	part = PART_SOCK;
 #ifdef ELAPSED_FUNC
-    ELAPSED_TYPE  start_tv;
+    elapsed_T	start_tv;
 
     ELAPSED_INIT(start_tv);
 #endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -2951,9 +2951,9 @@ gui_wait_for_chars_or_timer(long wtime)
     int
 gui_wait_for_chars(long wtime, int tb_change_cnt)
 {
-    int	    retval;
+    int		retval;
 #if defined(ELAPSED_FUNC)
-    ELAPSED_TYPE start_tv;
+    elapsed_T	start_tv;
 #endif
 
 #ifdef FEAT_MENU
@@ -3002,7 +3002,7 @@ gui_wait_for_chars(long wtime, int tb_change_cnt)
     if (gui_wait_for_chars_or_timer(p_ut) == OK)
 	retval = OK;
     else if (trigger_cursorhold()
-#ifdef ELAPSED_FUNC
+#if defined(ELAPSED_FUNC)
 	    && ELAPSED_FUNC(start_tv) >= p_ut
 #endif
 	    && typebuf.tb_change_cnt == tb_change_cnt)

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3891,7 +3891,7 @@ vim_beep(
 	{
 #ifdef ELAPSED_FUNC
 	    static int		did_init = FALSE;
-	    static ELAPSED_TYPE	start_tv;
+	    static elapsed_T	start_tv;
 
 	    /* Only beep once per half a second, otherwise a sequence of beeps
 	     * would freeze Vim. */

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -480,7 +480,7 @@ mch_inchar(
 	}
 
 	/* no character available */
-#if !(defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H))
+#ifndef ELAPSED_FUNC
 	/* estimate the elapsed time */
 	elapsed_time += wait_time;
 #endif
@@ -1907,11 +1907,11 @@ get_x11_windis(void)
 #ifdef SET_SIG_ALARM
 	RETSIGTYPE (*sig_save)();
 #endif
-#if defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H)
-	struct timeval  start_tv;
+#ifdef ELAPSED_FUNC
+	ELAPSED_TYPE start_tv;
 
 	if (p_verbose > 0)
-	    gettimeofday(&start_tv, NULL);
+	    ELAPSED_INIT(start_tv);
 #endif
 
 #ifdef SET_SIG_ALARM
@@ -4831,8 +4831,8 @@ mch_call_shell_fork(
 		int	    fromshell_fd;
 		garray_T    ga;
 		int	    noread_cnt;
-# if defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H)
-		struct timeval  start_tv;
+# ifdef ELAPSED_FUNC
+		ELAPSED_TYPE start_tv;
 # endif
 
 # ifdef FEAT_GUI

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -374,7 +374,7 @@ mch_inchar(
     long	wait_time;
     long	elapsed_time = 0;
 #ifdef ELAPSED_FUNC
-    ELAPSED_TYPE start_tv;
+    elapsed_T	start_tv;
 
     ELAPSED_INIT(start_tv);
 #endif
@@ -1908,7 +1908,7 @@ get_x11_windis(void)
 	RETSIGTYPE (*sig_save)();
 #endif
 #ifdef ELAPSED_FUNC
-	ELAPSED_TYPE start_tv;
+	elapsed_T start_tv;
 
 	if (p_verbose > 0)
 	    ELAPSED_INIT(start_tv);
@@ -4832,7 +4832,7 @@ mch_call_shell_fork(
 		garray_T    ga;
 		int	    noread_cnt;
 # ifdef ELAPSED_FUNC
-		ELAPSED_TYPE start_tv;
+		elapsed_T   start_tv;
 # endif
 
 # ifdef FEAT_GUI
@@ -6073,8 +6073,8 @@ RealWaitForChar(int fd, long msec, int *check_for_gpm UNUSED, int *interrupted)
 # ifdef ELAPSED_FUNC
     /* Remember at what time we started, so that we know how much longer we
      * should wait after being interrupted. */
-    long	    start_msec = msec;
-    ELAPSED_TYPE  start_tv;
+    long	start_msec = msec;
+    elapsed_T	start_tv;
 
     if (msec > 0)
 	ELAPSED_INIT(start_tv);
@@ -7494,7 +7494,7 @@ setup_term_clip(void)
 	int (*oldIOhandler)();
 #endif
 # ifdef ELAPSED_FUNC
-	ELAPSED_TYPE  start_tv;
+	elapsed_T start_tv;
 
 	if (p_verbose > 0)
 	    ELAPSED_INIT(start_tv);

--- a/src/vim.h
+++ b/src/vim.h
@@ -2625,13 +2625,13 @@ typedef enum {
 # define ELAPSED_TIMEVAL
 # define ELAPSED_INIT(v) gettimeofday(&v, NULL)
 # define ELAPSED_FUNC(v) elapsed(&v)
-# define ELAPSED_TYPE struct timeval
+typedef struct timeval elapsed_T;
 long elapsed(struct timeval *start_tv);
 #elif defined(WIN32)
 # define ELAPSED_TICKCOUNT
 # define ELAPSED_INIT(v) v = GetTickCount()
 # define ELAPSED_FUNC(v) elapsed(v)
-# define ELAPSED_TYPE DWORD
+typedef DWORD elapsed_T;
 # ifndef PROTO
 long elapsed(DWORD start_tick);
 # endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -2626,16 +2626,14 @@ typedef enum {
 # define ELAPSED_INIT(v) gettimeofday(&v, NULL)
 # define ELAPSED_FUNC(v) elapsed(&v)
 # define ELAPSED_TYPE struct timeval
-    long elapsed(struct timeval *start_tv);
-#else
-# if defined(WIN32)
-#  define ELAPSED_TICKCOUNT
-#  define ELAPSED_INIT(v) v = GetTickCount()
-#  define ELAPSED_FUNC(v) elapsed(v)
-#  define ELAPSED_TYPE DWORD
-#   ifndef PROTO
-     long elapsed(DWORD start_tick);
-#   endif
+long elapsed(struct timeval *start_tv);
+#elif defined(WIN32)
+# define ELAPSED_TICKCOUNT
+# define ELAPSED_INIT(v) v = GetTickCount()
+# define ELAPSED_FUNC(v) elapsed(v)
+# define ELAPSED_TYPE DWORD
+# ifndef PROTO
+long elapsed(DWORD start_tick);
 # endif
 #endif
 


### PR DESCRIPTION
In some code, using "ELAPSED_FUNC" and "HAVE_GETTIMEOFDAY" have been mixed up.

And I think using "typedef elapsed_T" is better than "ELAPSED_TYPE" macro.