### PR TITLE
Fix timer invoked causes key mapping timeout

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -36,6 +36,30 @@ if has('timers')
     set updatetime&
   endfunc
 
+  func Test_cursorhold_insert_with_timer_interrupt()
+    if !has('job')
+      return
+    endif
+    " Need to move the cursor.
+    call feedkeys("ggG", "xt")
+
+    " Confirm the timer invoked in exit_cb of the job doesn't disturb
+    " CursorHoldI event.
+    let g:triggered = 0
+    au CursorHoldI * let g:triggered += 1
+    set updatetime=200
+    if has('win32')
+      let cmd = ['cmd', '/c', 'echo.']
+    else
+      let cmd = ['echo']
+    endif
+    call job_start(cmd, {'exit_cb': {j, s -> timer_start(500, 'ExitInsertMode')}})
+    call feedkeys('a', 'x!')
+    call assert_equal(1, g:triggered)
+    au! CursorHoldI
+    set updatetime&
+  endfunc
+
   func Test_cursorhold_insert_ctrl_x()
     let g:triggered = 0
     au CursorHoldI * let g:triggered += 1


### PR DESCRIPTION
Fixes #3417 

## Cause

Ref: #3417 map_timeout.vim

After "job_start()" and typing "\12":

1. To wait key mapping timeout:
```
...
  -> inchar(..., 10000)
    -> ui_inchar(..., 10000, ...)
      -> gui_inchar(..., 10000, ...)
        -> gui_wait_for_chars(10000, ...)
          -> gui_wait_for_chars_or_timer(10000)
            -> ui_wait_for_chars_or_timer(10000, gui_wait_for_chars_3, NULL, 0)
```
2. In `ui_wait_for_chars_or_timer()`, because there is no timer yet `check_due_timer()` returns -1, so `gui_mch_wait_for_chars(10000)` is called (`due_time == 10000`)
2. In `gui_mch_wait_for_chars(10000)`, exit_cb of the job is invoked and a new timer is added
3. `did_add_timer` is set to TRUE so `gui_mch_wait_for_chars(10000)` returns FAIL after 3000msec has elapsed
4. `remaining -= due_time`, so `remaining == 0`, `gui_mch_wait_for_chars(10000)` returns FAIL ... thus `inchar()` finishes
5. The above processing is treated as "10000msec has elapsed without any user input (i.e. key mapping is timeout)" -- though only 3000msec has elapsed

## Solution proposal

* When `gui_wait_for_chars_or_timer()` returns FAIL in less than wait_time, call it once again with the remaining time