### PR TITLE
filetype.vim: Remove wildcard from PKGBUILD match

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1462,7 +1462,7 @@ au BufNewFile,BufRead sgml.catalog*		call s:StarSetf('catalog')
 
 " Shell scripts (sh, ksh, bash, bash2, csh); Allow .profile_foo etc.
 " Gentoo ebuilds and Arch Linux PKGBUILDs are actually bash scripts
-au BufNewFile,BufRead .bashrc*,bashrc,bash.bashrc,.bash[_-]profile*,.bash[_-]logout*,.bash[_-]aliases*,bash-fc[-.]*,*.bash,*/{,.}bash[_-]completion{,.d,.sh}{,/*},*.ebuild,*.eclass,PKGBUILD* call dist#ft#SetFileTypeSH("bash")
+au BufNewFile,BufRead .bashrc*,bashrc,bash.bashrc,.bash[_-]profile*,.bash[_-]logout*,.bash[_-]aliases*,bash-fc[-.]*,*.bash,*/{,.}bash[_-]completion{,.d,.sh}{,/*},*.ebuild,*.eclass,PKGBUILD call dist#ft#SetFileTypeSH("bash")
 au BufNewFile,BufRead .kshrc*,*.ksh call dist#ft#SetFileTypeSH("ksh")
 au BufNewFile,BufRead */etc/profile,.profile*,*.sh,*.env call dist#ft#SetFileTypeSH(getline(1))
 


### PR DESCRIPTION
The wildcard match causes a hassle when working with `PKGBUILD.vim` 
runtime files. Actual `PKGBUILD` scripts with a suffix are rare. This 
would correlate with our `ftdetect/`:
https://git.archlinux.org/pacman-contrib.git/tree/src/vim/ftdetect/PKGBUILD.vim?id=0ece925dc026bc7a02015d1f93e09af29fde98f3

Working around this in `ftdetect/` or modelines is still inconvenient:
https://github.com/w0rp/ale/issues/2213#issuecomment-454709141