### PR TITLE
Fix build warning

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1282,12 +1282,11 @@ main_loop(
 	    /* display message after redraw */
 	    if (keep_msg != NULL)
 	    {
-		char_u *p;
-
 		/* msg_attr_keep() will set keep_msg to NULL, must free the
 		 * string here. Don't reset keep_msg, msg_attr_keep() uses it
 		 * to check for duplicates. */
-		p = keep_msg;
+		char *p = (char *)keep_msg;
+
 		msg_attr(p, keep_msg_attr);
 		vim_free(p);
 	    }

--- a/src/message.c
+++ b/src/message.c
@@ -1389,9 +1389,9 @@ msg_putchar(int c)
 msg_putchar_attr(int c, int attr)
 {
 #ifdef FEAT_MBYTE
-    char	buf[MB_MAXBYTES + 1];
+    char_u	buf[MB_MAXBYTES + 1];
 #else
-    char	buf[4];
+    char_u	buf[4];
 #endif
 
     if (IS_SPECIAL(c))
@@ -1404,13 +1404,13 @@ msg_putchar_attr(int c, int attr)
     else
     {
 #ifdef FEAT_MBYTE
-	buf[(*mb_char2bytes)(c, (char_u *)buf)] = NUL;
+	buf[(*mb_char2bytes)(c, buf)] = NUL;
 #else
 	buf[0] = c;
 	buf[1] = NUL;
 #endif
     }
-    msg_puts_attr(buf, attr);
+    msg_puts_attr((char *)buf, attr);
 }
 
     void


### PR DESCRIPTION
According to clang,

main.c:
```
main.c:1291:12: warning: passing 'char_u *' (aka 'unsigned char *') to parameter
      of type 'char *' converts between pointers to integer types with different
      sign [-Wpointer-sign]
                msg_attr(p, keep_msg_attr);
                         ^
proto/message.pro:4:20: note: passing argument to parameter 's' here
int msg_attr(char *s, int attr);
                   ^
```

message.c:
```
message.c:1400:11: warning: implicit conversion from 'int' to 'char' changes
      value from 254 to -2 [-Wconstant-conversion]
        buf[1] = K_SECOND(c);
               ~ ^~~~~~~~~~~
./keymap.h:132:41: note: expanded from macro 'K_SECOND'
#define K_SECOND(c)     ((c) == K_SPECIAL ? KS_SPECIAL : (c) == NUL ? KS...
                                            ^~~~~~~~~~
./keymap.h:55:21: note: expanded from macro 'KS_SPECIAL'
#define KS_SPECIAL              254
                                ^~~
message.c:1400:11: warning: implicit conversion from 'int' to 'char' changes
      value from 255 to -1 [-Wconstant-conversion]
        buf[1] = K_SECOND(c);
               ~ ^~~~~~~~~~~
./keymap.h:132:67: note: expanded from macro 'K_SECOND'
  ...((c) == K_SPECIAL ? KS_SPECIAL : (c) == NUL ? KS_ZERO : KEY2TERMCAP0(c))
                                                   ^~~~~~~
./keymap.h:49:19: note: expanded from macro 'KS_ZERO'
#define KS_ZERO                 255
                                ^~~
```

v8.1.0779 changed the type of "buf to "char[]", but I think it's better to keep "char_u[]" (and do type-cast to "char *") because of the signedness issue.