### PR TITLE
Fixed compilation warnings: ‘mch_endjmp’ defined but not used

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -998,6 +998,8 @@ static volatile sig_atomic_t lc_signal;
 // Volatile because it is used in signal handler deathtrap().
 static volatile sig_atomic_t lc_active INIT(= FALSE);
 
+#if (defined(FEAT_LIBCALL) || (defined(FEAT_X11) && defined(FEAT_XCLIPBOARD))) \
+	|| defined(PROTO)
 /*
  * A simplistic version of setjmp() that only allows one level of using.
  * Used to protect areas where we could crash.
@@ -1044,6 +1046,7 @@ mch_didjmp(void)
     init_signal_stack();
 # endif
 }
+#endif
 #endif
 
 /*
@@ -2100,7 +2103,7 @@ get_x11_thing(
     return retval;
 }
 
-/* Xutf8 functions are not avaialble on older systems. Note that on some
+/* Xutf8 functions are not available on older systems. Note that on some
  * systems X_HAVE_UTF8_STRING may be defined in a header file but
  * Xutf8SetWMProperties() is not in the X11 library.  Configure checks for
  * that and defines HAVE_XUTF8SETWMPROPERTIES. */
@@ -2953,7 +2956,7 @@ mch_copy_sec(char_u *from_file, char_u *to_file)
 		case ENOTSUP:
 		    /* extended attributes aren't supported or enabled */
 		    /* should a message be echoed? not sure... */
-		    return; /* leave because it isn't usefull to continue */
+		    return; /* leave because it isn't useful to continue */
 
 		case ERANGE:
 		default:

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -980,11 +980,7 @@ sig_alarm SIGDEFARG(sigarg)
 }
 #endif
 
-#if (defined(HAVE_SETJMP_H) \
-	&& ((defined(FEAT_X11) && defined(FEAT_XCLIPBOARD)) \
-	    || defined(FEAT_LIBCALL))) \
-    || defined(PROTO)
-
+#if defined(HAVE_SETJMP_H) || defined(PROTO)
 // argument to SETJMP()
 static JMP_BUF lc_jump_env;
 
@@ -7497,9 +7493,9 @@ setup_term_clip(void)
     if (app_context != NULL && xterm_Shell == (Widget)0)
     {
 	int (*oldhandler)();
-# if defined(HAVE_SETJMP_H)
+#if defined(HAVE_SETJMP_H)
 	int (*oldIOhandler)();
-# endif
+#endif
 # ifdef ELAPSED_FUNC
 	elapsed_T start_tv;
 
@@ -7510,7 +7506,7 @@ setup_term_clip(void)
 	/* Ignore X errors while opening the display */
 	oldhandler = XSetErrorHandler(x_error_check);
 
-# if defined(HAVE_SETJMP_H)
+#if defined(HAVE_SETJMP_H)
 	/* Ignore X IO errors while opening the display */
 	oldIOhandler = XSetIOErrorHandler(x_IOerror_check);
 	mch_startjmp();
@@ -7520,21 +7516,21 @@ setup_term_clip(void)
 	    xterm_dpy = NULL;
 	}
 	else
-# endif
+#endif
 	{
 	    xterm_dpy = XtOpenDisplay(app_context, xterm_display,
 		    "vim_xterm", "Vim_xterm", NULL, 0, &z, &strp);
 	    if (xterm_dpy != NULL)
 		xterm_dpy_retry_count = 0;
-# if defined(HAVE_SETJMP_H)
+#if defined(HAVE_SETJMP_H)
 	    mch_endjmp();
-# endif
+#endif
 	}
 
-# if defined(HAVE_SETJMP_H)
+#if defined(HAVE_SETJMP_H)
 	/* Now handle X IO errors normally. */
 	(void)XSetIOErrorHandler(oldIOhandler);
-# endif
+#endif
 	/* Now handle X errors normally. */
 	(void)XSetErrorHandler(oldhandler);
 


### PR DESCRIPTION
Attached PR fixed compilation warnings
reported by Tony Mechelynck introduced by
vim-8.1.0785.

