### PR TITLE
Fix: "-[N]tabmove" doesn't work properly when there is a prefix whitespace

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7588,7 +7588,7 @@ get_tabpage_arg(exarg_T *eap)
 	else
 	{
 	    tab_number = eap->line2;
-	    if (!unaccept_arg0 && **eap->cmdlinep == '-')
+	    if (!unaccept_arg0 && *skipwhite(*eap->cmdlinep) == '-')
 	    {
 		--tab_number;
 		if (tab_number < unaccept_arg0)

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -105,6 +105,14 @@ function Test_tabpage()
   call assert_equal(4, tabpagenr())
   7tabmove 5
   call assert_equal(5, tabpagenr())
+  -tabmove
+  call assert_equal(4, tabpagenr())
+  +tabmove
+  call assert_equal(5, tabpagenr())
+  -2tabmove
+  call assert_equal(3, tabpagenr())
+  +3tabmove
+  call assert_equal(6, tabpagenr())
 
   " The following are a no-op
   norm! 2gt


### PR DESCRIPTION
### Repro steps

```
vim --clean
:tabnew
:tabnew
: -tabmove
```

The above ": -tabmove" has a whitespace between ":" and "-tabmove".

Expected: tab[3] moves to left
Actual: tab[3] doesn't move
 
### Cause

https://github.com/vim/vim/blob/555de4e3b2881b0d9a72242ecc2ba26b5c698c85/src/ex_docmd.c#L7591

In this case, "*eap->cmdlinep" is " -tabmove" so needs "skipwhite()".