### PR TITLE
Removed wrong useless cast to fix compilation warning

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1935,7 +1935,7 @@ get_x11_windis(void)
 	alarm(0);
 	signal(SIGALRM, (RETSIGTYPE (*)())sig_save);
 	if (p_verbose > 0 && sig_alarm_called)
-	    verb_msg((char_u *)_("Opening the X display timed out"));
+	    verb_msg(_("Opening the X display timed out"));
 #endif
 	if (x11_display != NULL)
 	{


### PR DESCRIPTION
Removed wrong useless cast to fix compilation warning with gcc-7.3:
```
$ cc -c -I. -Iproto -DHAVE_CONFIG_H     -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1  -g -O0 -Wall -Wunused-function -fsanitize=address -fno-omit-frame-pointer -DEXITFREE     -o objects/os_unix.o os_unix.c
os_unix.c: In function ‘get_x11_windis’:
os_unix.c:1938:15: warning: pointer targets in passing argument 1 of ‘verb_msg’ differ in signedness [-Wpointer-sign]
      verb_msg((char_u *)_("Opening the X display timed out"));
               ^
In file included from proto.h:160:0,
                 from vim.h:2116,
                 from os_unix.c:21:
proto/message.pro:3:5: note: expected ‘char *’ but argument is of type ‘char_u * {aka unsigned char *}’
 int verb_msg(char *s);
     ^~~~~~~~
```