### PR TITLE
Fixed incorrect error message with functions accepting a blob

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -38,7 +38,7 @@ done, the features in this document are not available.  See |+eval| and
 1. Variables						*variables*
 
 1.1 Variable types ~
-							*E712*
+						*E712* *E896* *E897* *E898*
 There are nine types of variables:
 
 Number		A 32 or 64 bit signed number.  |expr-number| *Number*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -29,6 +29,7 @@
 #endif
 
 static char *e_listarg = N_("E686: Argument of %s must be a List");
+static char *e_listblobarg = N_("E898: Argument of %s must be a List or Blob");
 static char *e_stringreq = N_("E928: String required");
 
 #ifdef FEAT_FLOAT
@@ -1269,7 +1270,7 @@ f_add(typval_T *argvars, typval_T *rettv)
 	}
     }
     else
-	emsg(_(e_listreq));
+	emsg(_(e_listblobreq));
 }
 
 /*
@@ -4490,7 +4491,7 @@ f_get(typval_T *argvars, typval_T *rettv)
 	}
     }
     else
-	semsg(_(e_listdictarg), "get()");
+	semsg(_(e_listdictblobarg), "get()");
 
     if (tv == NULL)
     {
@@ -7057,7 +7058,7 @@ f_index(typval_T *argvars, typval_T *rettv)
     }
     else if (argvars[0].v_type != VAR_LIST)
     {
-	emsg(_(e_listreq));
+	emsg(_(e_listblobreq));
 	return;
     }
 
@@ -7281,7 +7282,7 @@ f_insert(typval_T *argvars, typval_T *rettv)
 	copy_tv(&argvars[0], rettv);
     }
     else if (argvars[0].v_type != VAR_LIST)
-	semsg(_(e_listarg), "insert()");
+	semsg(_(e_listblobarg), "insert()");
     else if ((l = argvars[0].vval.v_list) != NULL && !tv_check_lock(l->lv_lock,
 				      (char_u *)N_("insert() argument"), TRUE))
     {
@@ -9789,7 +9790,7 @@ f_remove(typval_T *argvars, typval_T *rettv)
 	}
     }
     else if (argvars[0].v_type != VAR_LIST)
-	semsg(_(e_listdictarg), "remove()");
+	semsg(_(e_listdictblobarg), "remove()");
     else if ((l = argvars[0].vval.v_list) != NULL
 			       && !tv_check_lock(l->lv_lock, arg_errmsg, TRUE))
     {
@@ -10136,7 +10137,7 @@ f_reverse(typval_T *argvars, typval_T *rettv)
     }
 
     if (argvars[0].v_type != VAR_LIST)
-	semsg(_(e_listarg), "reverse()");
+	semsg(_(e_listblobarg), "reverse()");
     else if ((l = argvars[0].vval.v_list) != NULL
 	    && !tv_check_lock(l->lv_lock,
 				    (char_u *)N_("reverse() argument"), TRUE))

--- a/src/globals.h
+++ b/src/globals.h
@@ -1521,7 +1521,9 @@ EXTERN char e_invalblob[]	INIT(= N_("E978: Invalid operation for Blob"));
 EXTERN char e_toomanyarg[]	INIT(= N_("E118: Too many arguments for function: %s"));
 EXTERN char e_dictkey[]	INIT(= N_("E716: Key not present in Dictionary: %s"));
 EXTERN char e_listreq[]	INIT(= N_("E714: List required"));
+EXTERN char e_listblobreq[]	INIT(= N_("E897: List or Blob required"));
 EXTERN char e_listdictarg[]	INIT(= N_("E712: Argument of %s must be a List or Dictionary"));
+EXTERN char e_listdictblobarg[]	INIT(= N_("E896: Argument of %s must be a List, Dictionary or Blob"));
 #endif
 #ifdef FEAT_QUICKFIX
 EXTERN char e_readerrf[]	INIT(= N_("E47: Error while reading errorfile"));

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -32,6 +32,7 @@ func Test_blob_create()
   call assert_fails('let b = 0z1.1')
   call assert_fails('let b = 0z.')
   call assert_fails('let b = 0z001122.')
+  call assert_fails('call get("", 1)', 'E896:')
 endfunc
 
 " assignment to a blob
@@ -182,6 +183,7 @@ func Test_blob_add()
   call assert_equal(0z00112233, b)
 
   call assert_fails('call add(b, [9])', 'E745:')
+  call assert_fails('call add("", 0x01)', 'E897:')
 endfunc
 
 func Test_blob_empty()
@@ -219,7 +221,7 @@ func Test_blob_func_remove()
   call assert_fails("call remove(b, 5)", 'E979:')
   call assert_fails("call remove(b, 1, 5)", 'E979:')
   call assert_fails("call remove(b, 3, 2)", 'E979:')
-  call assert_fails("call remove(1, 0)", 'E712:')
+  call assert_fails("call remove(1, 0)", 'E896:')
   call assert_fails("call remove(b, b)", 'E974:')
 endfunc
 
@@ -255,7 +257,7 @@ func Test_blob_index()
   call assert_equal(2, index(0z11111111, 0x11, -2))
   call assert_equal(3, index(0z11110111, 0x11, -2))
 
-  call assert_fails('call index("asdf", 0)', 'E714:')
+  call assert_fails('call index("asdf", 0)', 'E897:')
 endfunc
 
 func Test_blob_insert()

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -139,7 +139,7 @@ func Test_list_func_remove()
   call assert_fails("call remove(l, 5)", 'E684:')
   call assert_fails("call remove(l, 1, 5)", 'E684:')
   call assert_fails("call remove(l, 3, 2)", 'E16:')
-  call assert_fails("call remove(1, 0)", 'E712:')
+  call assert_fails("call remove(1, 0)", 'E896:')
   call assert_fails("call remove(l, l)", 'E745:')
 endfunc
 
@@ -596,6 +596,8 @@ func Test_reverse_sort_uniq()
   call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 1))
   call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 'i'))
   call assert_equal(['BAR', 'Bar', 'FOO', 'FOOBAR', 'Foo', 'bar', 'foo', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l)))
+
+  call assert_fails('call reverse("")', 'E898:')
 endfunc
 
 " splitting a string to a List


### PR DESCRIPTION
The following error messages given by Vim-8.1.789
are incorrect as all those functions now also accept
a blob as first parameter:
```
  :echo add('', 1)
  E714: List required

  :echo get('', 1)
  E712: Argument of get() must be a List or Dictionary

  :echo index('', 1)
  E714: List required

  :echo remove('', 1)
  E712: Argument of remove() must be a List or Dictionary

  :echo reverse('')
  E686: Argument of reverse() must be a List
```
After change in this PR, errors become:
```
  :echo add('', 1)
  E897: List or Blob required

  :echo get('', 1)
  E896: Argument of get() must be a List, Dictionary or Blob

  :echo index('', 1)
  E897: List or Blob required

  :echo remove('', 1)
  E896: Argument of remove() must be a List, Dictionary or Blob

  :echo reverse('')
  E898: Argument of reverse() must be a List or Blob
```