### PR TITLE
Fix some tests

### DIFF
--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1945,10 +1945,11 @@ func Test_job_start_in_timer()
   endif
 
   func OutCb(chan, msg)
+    let g:val += 1
   endfunc
 
   func ExitCb(job, status)
-    let g:val = 1
+    let g:val += 1
     call Resume()
   endfunc
 
@@ -1967,6 +1968,7 @@ func Test_job_start_in_timer()
   call timer_start(1, 'TimerCb')
   let elapsed = Standby(&ut)
   call assert_inrange(1, &ut / 2, elapsed)
+  call WaitForAssert({-> assert_equal(2, g:val)})
   call job_stop(g:job)
 
   delfunc OutCb

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -643,19 +643,15 @@ func Test_terminal_write_stdin()
 endfunc
 
 func Test_terminal_no_cmd()
-  " Does not work on Mac.
-  if has('mac')
-    return
-  endif
   let buf = term_start('NONE', {})
   call assert_notequal(0, buf)
 
   let pty = job_info(term_getjob(buf))['tty_out']
   call assert_notequal('', pty)
-  if has('win32')
-    silent exe '!start cmd /c "echo look here > ' . pty . '"'
-  else
+  if has('gui_running') && !has('win32')
     call system('echo "look here" > ' . pty)
+  else
+    call job_start([&shell, &shellcmdflag, 'echo "look here" > ' . pty])
   endif
   call WaitForAssert({-> assert_match('look here', term_getline(buf, 1))})
 


### PR DESCRIPTION
### Test_job_start_in_timer

There is a case that "OutCb" is invoked unexpectedly (in "sleep" command) after this test has finished 
then an error occurs since "OutCb" is already deleted.
Thus should make sure "OutCb" is invoked in this test running.

 ### Test_terminal_no_cmd

On macOS (and some *BSD), if the process A (which reads from pty) does not read all from pty by the 
time when the process B (which writes in pty) finishes terminating itself and I/O, the process A cannot
read the rest from pty after B finished.

When using "system()", parent (Vim) tries to read from pty after waits for child (system()) terminating,
this is just the above case.
Using job instead of "system()" can solve this problem.

On the other hand, on GUI cannot use job in this case because gVim doesn't read from channel (pty)
during "sleep". 