### PR TITLE
Proposal: Add some system names to feature-list of has()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10159,7 +10159,7 @@ beos			BeOS version of Vim.
 browse			Compiled with |:browse| support, and browse() will
 			work.
 browsefilter		Compiled with support for |browsefilter|.
-bsd			*BSD (including macOS) version of Vim.
+bsd			Compiled for the OS in BSD family (including macOS).
 builtin_terms		Compiled with some builtin terminals.
 byte_offset		Compiled with support for 'o' in 'statusline'
 cindent			Compiled with 'cindent' support.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10159,6 +10159,7 @@ beos			BeOS version of Vim.
 browse			Compiled with |:browse| support, and browse() will
 			work.
 browsefilter		Compiled with support for |browsefilter|.
+bsd			*BSD (including macOS) version of Vim.
 builtin_terms		Compiled with some builtin terminals.
 byte_offset		Compiled with support for 'o' in 'statusline'
 cindent			Compiled with 'cindent' support.
@@ -10211,6 +10212,7 @@ gui_running		Vim is running in the GUI, or it will start soon.
 gui_win32		Compiled with MS Windows Win32 GUI.
 gui_win32s		idem, and Win32s system being used (Windows 3.1)
 hangul_input		Compiled with Hangul input support. |hangul|
+hpux			HP-UX version of Vim.
 iconv			Can use iconv() for conversion.
 insert_expand		Compiled with support for CTRL-X expansion commands in
 			Insert mode.
@@ -10221,6 +10223,7 @@ langmap			Compiled with 'langmap' support.
 libcall			Compiled with |libcall()| support.
 linebreak		Compiled with 'linebreak', 'breakat', 'showbreak' and
 			'breakindent' support.
+linux			Linux version of Vim.
 lispindent		Compiled with support for lisp indenting.
 listcmds		Compiled with commands for the buffer list |:files|
 			and the argument list |arglist|.
@@ -10279,6 +10282,7 @@ spell			Compiled with spell checking support |spell|.
 startuptime		Compiled with |--startuptime| support.
 statusline		Compiled with support for 'statusline', 'rulerformat'
 			and special formats of 'titlestring' and 'iconstring'.
+sun			SunOS version of Vim.
 sun_workshop		Support for Sun |workshop| has been removed.
 syntax			Compiled with syntax highlighting support |syntax|.
 syntax_items		There are active syntax highlighting items for the

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10159,7 +10159,7 @@ beos			BeOS version of Vim.
 browse			Compiled with |:browse| support, and browse() will
 			work.
 browsefilter		Compiled with support for |browsefilter|.
-bsd			Compiled for the OS in BSD family (including macOS).
+bsd			Compiled for the OS in BSD family (excluding macOS).
 builtin_terms		Compiled with some builtin terminals.
 byte_offset		Compiled with support for 'o' in 'statusline'
 cindent			Compiled with 'cindent' support.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6139,7 +6139,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 #ifdef __BEOS__
 	"beos",
 #endif
-#ifdef BSD
+#if defined(BSD) && !defined(MACOS_X)
 	"bsd",
 #endif
 #ifdef hpux

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6139,6 +6139,15 @@ f_has(typval_T *argvars, typval_T *rettv)
 #ifdef __BEOS__
 	"beos",
 #endif
+#ifdef BSD
+	"bsd",
+#endif
+#ifdef hpux
+	"hpux",
+#endif
+#ifdef __linux__
+	"linux",
+#endif
 #ifdef MACOS_X
 	"mac",		/* Mac OS X (and, once, Mac OS Classic) */
 	"osx",		/* Mac OS X */
@@ -6149,6 +6158,9 @@ f_has(typval_T *argvars, typval_T *rettv)
 #endif
 #ifdef __QNX__
 	"qnx",
+#endif
+#ifdef SUN_SYSTEM
+	"sun",
 #endif
 #ifdef UNIX
 	"unix",
@@ -6179,7 +6191,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 #endif
 	"autocmd",
 #ifdef FEAT_AUTOCHDIR
-       "autochdir",
+	"autochdir",
 #endif
 #ifdef FEAT_AUTOSERVERNAME
 	"autoservername",

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -29,7 +29,7 @@ endfunc
 func s:get_resources()
   let pid = getpid()
 
-  if has('mac')
+  if executable('lsof')
     return systemlist('lsof -p ' . pid . ' | awk ''$4~/^[0-9]*[rwu]$/&&$5=="REG"{print$NF}''')
   elseif isdirectory('/proc/' . pid . '/fd/')
     return systemlist('readlink /proc/' . pid . '/fd/* | grep -v ''^/dev/''')

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1179,7 +1179,7 @@ func Test_platform_name()
   call assert_equal(has('win32'), has('win32') && !has('unix'))
   call assert_equal(has('win32unix'), has('win32unix') && has('unix'))
 
-  if executable('uname')
+  if has('unix') && executable('uname')
     let uname = system('uname')
     call assert_equal(uname =~? 'BeOS', has('beos'))
     call assert_equal(uname =~? 'BSD\|DragonFly', has('bsd'))

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1165,7 +1165,7 @@ endfunc
 
 func Test_platform_name()
   " The system matches at most only one name.
-  let names = ['amiga', 'beos', 'bsd', 'hpux', 'linux', 'mac', 'qnx', 'sun', 'vms', 'win32']
+  let names = ['amiga', 'beos', 'bsd', 'hpux', 'linux', 'mac', 'qnx', 'sun', 'vms', 'win32', 'win32unix']
   call assert_inrange(0, 1, len(filter(copy(names), 'has(v:val)')))
 
   " Is Unix?
@@ -1176,6 +1176,7 @@ func Test_platform_name()
   call assert_equal(has('mac'), has('mac') && has('unix'))
   call assert_equal(has('qnx'), has('qnx') && has('unix'))
   call assert_equal(has('sun'), has('sun') && has('unix'))
+  call assert_equal(has('win32'), has('win32') && !has('unix'))
   call assert_equal(has('win32unix'), has('win32unix') && has('unix'))
 
   if executable('uname')
@@ -1187,5 +1188,6 @@ func Test_platform_name()
     call assert_equal(uname =~? 'Darwin', has('mac'))
     call assert_equal(uname =~? 'QNX', has('qnx'))
     call assert_equal(uname =~? 'SunOS', has('sun'))
+    call assert_equal(uname =~? 'CYGWIN\|MSYS', has('win32unix'))
   endif
 endfunc

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1162,3 +1162,30 @@ func Test_func_exists_on_reload()
   call delete('Xfuncexists')
   delfunc ExistingFunction
 endfunc
+
+func Test_platform_name()
+  " The system matches at most only one name.
+  let names = ['amiga', 'beos', 'bsd', 'hpux', 'linux', 'mac', 'qnx', 'sun', 'vms', 'win32']
+  call assert_inrange(0, 1, len(filter(copy(names), 'has(v:val)')))
+
+  " Is Unix?
+  call assert_equal(has('beos'), has('beos') && has('unix'))
+  call assert_equal(has('bsd'), has('bsd') && has('unix'))
+  call assert_equal(has('hpux'), has('hpux') && has('unix'))
+  call assert_equal(has('linux'), has('linux') && has('unix'))
+  call assert_equal(has('mac'), has('mac') && has('unix'))
+  call assert_equal(has('qnx'), has('qnx') && has('unix'))
+  call assert_equal(has('sun'), has('sun') && has('unix'))
+  call assert_equal(has('win32unix'), has('win32unix') && has('unix'))
+
+  if executable('uname')
+    let uname = system('uname')
+    call assert_equal(uname =~? 'BeOS', has('beos'))
+    call assert_equal(uname =~? 'BSD\|DragonFly', has('bsd'))
+    call assert_equal(uname =~? 'HP-UX', has('hpux'))
+    call assert_equal(uname =~? 'Linux', has('linux'))
+    call assert_equal(uname =~? 'Darwin', has('mac'))
+    call assert_equal(uname =~? 'QNX', has('qnx'))
+    call assert_equal(uname =~? 'SunOS', has('sun'))
+  endif
+endfunc

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1054,16 +1054,17 @@ func Test_libcall_libcallnr()
     let libc = 'msvcrt.dll'
   elseif has('mac')
     let libc = 'libSystem.B.dylib'
-  elseif has('linux')
-    " On Unix, libc.so can be in various places.
-    " Interestingly, on Linux using an empty string for the 1st argument of
-    " libcall allows to call functions from libc which is not documented.
-    let libc = ''
   elseif executable('ldd')
     let libc = matchstr(split(system('ldd ' . GetVimProg())), '/libc\.so\>')
   endif
-  if !exists('libc')
-    if has('sun')
+  if get(l:, 'libc', '') ==# ''
+    " On Unix, libc.so can be in various places.
+    if has('linux')
+      " There is not documented but regarding the 1st argument of glibc's
+      " dlopen an empty string and nullptr are equivalent, so using an empty
+      " string for the 1st argument of libcall allows to call functions.
+      let libc = ''
+    elseif has('sun')
       " Set the path to libc.so according to the architecture.
       let test_bits = system('file ' . GetVimProg())
       let test_arch = system('uname -p')
@@ -1075,8 +1076,7 @@ func Test_libcall_libcallnr()
         let libc = '/usr/lib/libc.so'
       endif
     else
-      " On other Unix (e.g. BSD) libcall doesn't accept an empty string, and
-      " therefore skip this test until a goo way is found.
+      " Unfortunately skip this test until a good way is found.
       return
     endif
   endif

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -559,7 +559,7 @@ endfunction
 
 func Test_terminal_noblock()
   let buf = term_start(&shell)
-  if has('bsd') || has('mac')
+  if has('bsd') || has('mac') || has('sun')
     " The shell or something else has a problem dealing with more than 1000
     " characters at the same time.
     let len = 1000

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -559,7 +559,7 @@ endfunction
 
 func Test_terminal_noblock()
   let buf = term_start(&shell)
-  if has('bsd')
+  if has('bsd') || has('mac')
     " The shell or something else has a problem dealing with more than 1000
     " characters at the same time.
     let len = 1000

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -559,7 +559,7 @@ endfunction
 
 func Test_terminal_noblock()
   let buf = term_start(&shell)
-  if has('mac')
+  if has('bsd')
     " The shell or something else has a problem dealing with more than 1000
     " characters at the same time.
     let len = 1000

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -33,7 +33,7 @@ func Test_writefile_fails_gently()
 endfunc
 
 func Test_writefile_fails_conversion()
-  if !has('iconv') || system('uname -s') =~ 'SunOS'
+  if !has('iconv') || has('sun')
     return
   endif
   set nobackup nowritebackup


### PR DESCRIPTION
This patch adds "bsd", "hpux", "linux", "sun" to "has()" key.

I think it is convenient when handling platform-specific behaviors (e.g. in test scripts .. especially for BSD and macOS).