### PR TITLE
Added test for the Ex := command

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -105,6 +105,7 @@ NEW_TESTS = \
 	test_erasebackword \
 	test_escaped_glob \
 	test_eval_stuff \
+	test_ex_equal \
 	test_ex_undo \
 	test_ex_z \
 	test_exit \

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -10,6 +10,7 @@ source test_changedtick.vim
 source test_compiler.vim
 source test_cursor_func.vim
 source test_delete.vim
+source test_ex_equal.vim
 source test_ex_undo.vim
 source test_ex_z.vim
 source test_execute_func.vim

--- a/src/testdir/test_ex_equal.vim
+++ b/src/testdir/test_ex_equal.vim
@@ -1,0 +1,32 @@
+" Test Ex := command.
+
+func Test_ex_equal()
+  new
+  call setline(1, ["foo\tbar", "bar\tfoo"])
+
+  let a = execute('=')
+  call assert_equal("\n2", a)
+
+  let a = execute('=#')
+  call assert_equal("\n2\n  1 foo     bar", a)
+
+  let a = execute('=l')
+  call assert_equal("\n2\nfoo^Ibar$", a)
+
+  let a = execute('=p')
+  call assert_equal("\n2\nfoo     bar", a)
+
+  let a = execute('=l#')
+  call assert_equal("\n2\n  1 foo^Ibar$", a)
+
+  let a = execute('=p#')
+  call assert_equal("\n2\n  1 foo     bar", a)
+
+  let a = execute('.=')
+  call assert_equal("\n1", a)
+
+  call assert_fails('3=', 'E16:')
+  call assert_fails('=x', 'E488:')
+
+  bwipe!
+endfunc


### PR DESCRIPTION
This PR adds a test for the Ex `:=` command which
was not tested according to codecov:

https://codecov.io/gh/vim/vim/src/9ba6117de6dc2993f8b42ccb9754c23694db2950/src/ex_docmd.c#L9197