### PR TITLE
Fix Test_raw_large_data()

### DIFF
--- a/src/testdir/test_filechanged.vim
+++ b/src/testdir/test_filechanged.vim
@@ -90,7 +90,7 @@ func Test_FileChangedShell_reload()
 endfunc
 
 func Test_file_changed_dialog()
-  if !has('unix')
+  if !has('unix') || has('gui_running')
     return
   endif
   au! FileChangedShell


### PR DESCRIPTION
I encounter that Test_raw_large_data() in test_channel fails on CI ASAN build environment.

https://travis-ci.org/ichizok/vim/builds/484273079
(Though adding 2 commits to master, the same contents as v8.1.0818) 

I guess: job-callback may be invoked after also "job_status(job)" goes "dead", so need wait for to receive data of a enough length.

In addition, modify some indent and style.