### PR TITLE
Added test for the confirm() function

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1156,8 +1156,8 @@ endfunc
 
 " Test confirm({msg} [, {choices} [, {default} [, {type}]]])
 func Test_confirm()
-  if !has('unix') || has('gui_running')
-    " Test uses feedkeys(..., 'L') which only workds for unix or the GUI.
+  if !has('unix') && !has('gui_running')
+    " Test uses feedkeys(..., 'L') which only works for unix or the GUI.
     return
   endif
 
@@ -1193,7 +1193,7 @@ func Test_confirm()
   let a = confirm('Are you sure?', "&Yes\n&No", 0)
   call assert_equal(0, a)
 
-  " Test with type 4th argument
+  " Test with the {type} 4th argument
   for type in ['Error', 'Question', 'Info', 'Warning', 'Generic']
     call feedkeys('y', 'L')
     let a = confirm('Are you sure?', "&Yes\n&No\n", 1, type)

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1198,4 +1198,9 @@ func Test_confirm()
     let a = confirm('Are you sure?', "&Yes\n&No\n", 1, type)
     call assert_equal(1, a)
   endfor
+
+  call assert_fails('call confirm([])', 'E730:')
+  call assert_fails('call confirm("Are you sure?", [])', 'E730:')
+  call assert_fails('call confirm("Are you sure?", "&Yes\n&No\n", [])', 'E745:')
+  call assert_fails('call confirm("Are you sure?", "&Yes\n&No\n", 0, [])', 'E730:')
 endfunc

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1156,8 +1156,7 @@ endfunc
 
 " Test confirm({msg} [, {choices} [, {default} [, {type}]]])
 func Test_confirm()
-  if !has('unix') && !has('gui_running')
-    " Test uses feedkeys(..., 'L') which only works for unix or the GUI.
+  if !has('unix') || has('gui_running')
     return
   endif
 

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1153,3 +1153,50 @@ func Test_func_exists_on_reload()
   call delete('Xfuncexists')
   delfunc ExistingFunction
 endfunc
+
+" Test confirm({msg} [, {choices} [, {default} [, {type}]]])
+func Test_confirm()
+  if !has('unix') || has('gui_running')
+    " Test uses feedkeys(..., 'L') which only workds for unix or the GUI.
+    return
+  endif
+
+  call feedkeys('o', 'L')
+  let a = confirm('Press O to proceed')
+  call assert_equal(1, a)
+
+  call feedkeys('y', 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No")
+  call assert_equal(1, a)
+
+  call feedkeys('n', 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No")
+  call assert_equal(2, a)
+
+  " Confirm should return 0 when pressing CTRL-C.
+  " FIXME: <Esc> should also cause it to return 0 but it has
+  " to be pressed twice (bug?).
+  call feedkeys("\<C-c>", 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No")
+  call assert_equal(0, a)
+
+  " Default choice is returned when pressing <CR>.
+  call feedkeys("\<CR>", 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No")
+  call assert_equal(1, a)
+
+  call feedkeys("\<CR>", 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No", 2)
+  call assert_equal(2, a)
+
+  call feedkeys("\<CR>", 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No", 0)
+  call assert_equal(0, a)
+
+  " Test with type 4th argument
+  for type in ['Error', 'Question', 'Info', 'Warning', 'Generic']
+    call feedkeys('y', 'L')
+    let a = confirm('Are you sure?', "&Yes\n&No\n", 1, type)
+    call assert_equal(1, a)
+  endfor
+endfunc

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1173,7 +1173,7 @@ func Test_confirm()
   let a = confirm('Are you sure?', "&Yes\n&No")
   call assert_equal(2, a)
 
-  " Confirm should return 0 when pressing CTRL-C.
+  " confirm() should return 0 when pressing CTRL-C.
   " FIXME: <Esc> should also cause it to return 0 but it has
   " to be pressed twice (bug?).
   call feedkeys("\<C-c>", 'L')


### PR DESCRIPTION
This PR adds a test for the confirm() function, which was not 
tested according to codecov:
https://codecov.io/gh/vim/vim/src/d39e275b57493f9e25e1b62f84810571eee30cf4/src/evalfunc.c#L2601

According to `:help confirm()`, pressing `<Esc>` or `CTRL-C`
should make `confirm()` return 0.  That works with `CTRL-C`
but the `<Esc>` key has to be pressed twice somehow, which
looks like a bug.