### PR TITLE
Fixed memory leak in ex_jump, reproduced with: make test_alot

### DIFF
--- a/src/mark.c
+++ b/src/mark.c
@@ -900,7 +900,10 @@ ex_jumps(exarg_T *eap UNUSED)
 
 	    // apply :filter /pat/ or file name not available
 	    if (name == NULL || message_filtered(name))
+	    {
+		vim_free(name);
 		continue;
+	    }
 
 	    msg_putchar('\n');
 	    if (got_int)


### PR DESCRIPTION
This PR fixes a memory leak visible with valgrind
when running `make test_alot`:
```
==16613== 9 bytes in 1 blocks are definitely lost in loss record 8 of 143
==16613==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==16613==    by 0x2005E0: lalloc (misc2.c:943)
==16613==    by 0x1F6539: home_replace_save (misc1.c:4953)
==16613==    by 0x1E378E: ex_jumps (mark.c:899)
==16613==    by 0x1A5FA3: do_one_cmd (ex_docmd.c:2520)
==16613==    by 0x1A5FA3: do_cmdline (ex_docmd.c:1033)
==16613==    by 0x17824B: f_execute (evalfunc.c:3370)
==16613==    by 0x180E78: call_internal_func (evalfunc.c:1117)
==16613==    by 0x2DCDF7: call_func (userfunc.c:1520)
==16613==    by 0x2DDE8C: get_func_tv (userfunc.c:455)
==16613==    by 0x16C34F: eval7 (eval.c:4382)
==16613==    by 0x16CBB3: eval6 (eval.c:3985)
==16613==    by 0x16CE83: eval5 (eval.c:3781)
==16613==    by 0x166B63: eval4 (eval.c:3665)
==16613==    by 0x166B63: eval3 (eval.c:3585)
==16613==    by 0x166D03: eval2 (eval.c:3517)
==16613==    by 0x166D03: eval1 (eval.c:3445)
==16613==    by 0x2DDC59: get_func_tv (userfunc.c:425)
==16613==    by 0x16C34F: eval7 (eval.c:4382)
==16613==    by 0x16CBB3: eval6 (eval.c:3985)
==16613==    by 0x16CE83: eval5 (eval.c:3781)
==16613==    by 0x166B63: eval4 (eval.c:3665)
==16613==    by 0x166B63: eval3 (eval.c:3585)
==16613==    by 0x166D03: eval2 (eval.c:3517)
==16613==    by 0x166D03: eval1 (eval.c:3445)
==16613==    by 0x1677CC: eval0 (eval.c:3403)
==16613==    by 0x16B702: ex_let (eval.c:1260)
==16613==    by 0x1A5FA3: do_one_cmd (ex_docmd.c:2520)
==16613==    by 0x1A5FA3: do_cmdline (ex_docmd.c:1033)
==16613==    by 0x2DD5AD: call_user_func (userfunc.c:967)
==16613==    by 0x2DD5AD: call_func (userfunc.c:1501)
==16613==    by 0x2DDE8C: get_func_tv (userfunc.c:455)
```