### PR TITLE
Fixed memory leak when :cd fails

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -4657,7 +4657,10 @@ vim_findfile(void *search_ctx_arg)
 			add_pathsep(file_path);
 		    }
 		    else
+		    {
+			ff_free_stack_element(stackp);
 			goto fail;
+		    }
 		}
 
 		/* append the fix part of the search path */
@@ -4667,7 +4670,10 @@ vim_findfile(void *search_ctx_arg)
 		    add_pathsep(file_path);
 		}
 		else
+		{
+		    ff_free_stack_element(stackp);
 		    goto fail;
+		}
 
 #ifdef FEAT_PATH_EXTRA
 		rest_of_wildcards = stackp->ffs_wc_path;
@@ -4687,7 +4693,10 @@ vim_findfile(void *search_ctx_arg)
 			    if (len + 1 < MAXPATHL)
 				file_path[len++] = '*';
 			    else
+			    {
+				ff_free_stack_element(stackp);
 				goto fail;
+			    }
 			}
 
 			if (*p == 0)
@@ -4718,7 +4727,10 @@ vim_findfile(void *search_ctx_arg)
 			if (len + 1 < MAXPATHL)
 			    file_path[len++] = *rest_of_wildcards++;
 			else
+			{
+			    ff_free_stack_element(stackp);
 			    goto fail;
+			}
 
 		    file_path[len] = NUL;
 		    if (vim_ispathsep(*rest_of_wildcards))
@@ -4787,7 +4799,10 @@ vim_findfile(void *search_ctx_arg)
 			    STRCAT(file_path, search_ctx->ffsc_file_to_search);
 			}
 			else
+			{
+			    ff_free_stack_element(stackp);
 			    goto fail;
+			}
 
 			/*
 			 * Try without extra suffix and then with suffixes


### PR DESCRIPTION
This PR fixes a memory leak which is 100% reproducible
when running the following test with valgrind:
```
$ cd vim/src/testdir
$ make test_cd
```
```
==12661== 358 (56 direct, 302 indirect) bytes in 1 blocks are definitely lost in loss record 117 of 148
==12661==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12661==    by 0x2045F0: lalloc (misc2.c:943)
==12661==    by 0x205862: alloc (misc2.c:828)
==12661==    by 0x205862: ff_create_stack_element (misc2.c:5268)
==12661==    by 0x208ACC: vim_findfile_init (misc2.c:4431)
==12661==    by 0x2098D8: find_file_in_path_option (misc2.c:5688)
==12661==    by 0x209E52: find_directory_in_path (misc2.c:5506)
==12661==    by 0x209E52: vim_chdir (misc2.c:5741)
==12661==    by 0x1A52F3: ex_cd (ex_docmd.c:9161)
==12661==    by 0x1A9FB3: do_one_cmd (ex_docmd.c:2520)
==12661==    by 0x1A9FB3: do_cmdline (ex_docmd.c:1033)
==12661==    by 0x169C0F: assert_fails (eval.c:9449)
==12661==    by 0x17D208: f_assert_fails (evalfunc.c:1624)
==12661==    by 0x184AD8: call_internal_func (evalfunc.c:1117)
==12661==    by 0x2E1C67: call_func (userfunc.c:1520)
==12661==    by 0x2E2CFC: get_func_tv (userfunc.c:455)
==12661==    by 0x2E59FD: ex_call (userfunc.c:3184)
==12661==    by 0x1A9FB3: do_one_cmd (ex_docmd.c:2520)
==12661==    by 0x1A9FB3: do_cmdline (ex_docmd.c:1033)
==12661==    by 0x2E241D: call_user_func (userfunc.c:967)
==12661==    by 0x2E241D: call_func (userfunc.c:1501)
==12661==    by 0x2E2CFC: get_func_tv (userfunc.c:455)
==12661==    by 0x2E59FD: ex_call (userfunc.c:3184)
==12661==    by 0x1A9FB3: do_one_cmd (ex_docmd.c:2520)
==12661==    by 0x1A9FB3: do_cmdline (ex_docmd.c:1033)
==12661==    by 0x16B116: ex_execute (eval.c:8536)
==12661==    by 0x1A9FB3: do_one_cmd (ex_docmd.c:2520)
==12661==    by 0x1A9FB3: do_cmdline (ex_docmd.c:1033)
==12661==    by 0x2E241D: call_user_func (userfunc.c:967)
==12661==    by 0x2E241D: call_func (userfunc.c:1501)
==12661==    by 0x2E2CFC: get_func_tv (userfunc.c:455)
==12661==    by 0x2E59FD: ex_call (userfunc.c:3184)
==12661==    by 0x1A9FB3: do_one_cmd (ex_docmd.c:2520)
==12661==    by 0x1A9FB3: do_cmdline (ex_docmd.c:1033)
==12661==    by 0x19A7A6: do_source (ex_cmds2.c:4615)
==12661==    by 0x19B5B0: cmd_source (ex_cmds2.c:4228)
==12661==    by 0x1A9FB3: do_one_cmd (ex_docmd.c:2520)
==12661==    by 0x1A9FB3: do_cmdline (ex_docmd.c:1033)
==12661==    by 0x321AEF: exe_commands (main.c:2959)
==12661==    by 0x321AEF: vim_main2 (main.c:809)
==12661==    by 0x139CBC: main (main.c:441)
```

The leak happens in this test:
```
func Test_cd_large_path()
  " This used to crash with a heap write overflow.
  call assert_fails('cd ' . repeat('x', 5000), 'E472:')
endfunc
```
Calling it N times causes N blocks to leak.

