### PR TITLE
Fix Test_getchar_zero

### DIFF
--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -257,9 +257,10 @@ func Test_getchar_zero()
     return
   endif
 
+  let start = reltime()
   let id = timer_start(20, {id -> feedkeys('x', 'L')})
   let c = 0
-  while c == 0
+  while c == 0 && reltimefloat(reltime(start)) < 0.2
     let c = getchar(0)
     sleep 10m
   endwhile


### PR DESCRIPTION
It must feed Ctrl-C, otherwise the test hangs when using earlier Vim.