### PR TITLE
Improve source code readability

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1969,6 +1969,7 @@ vgetorpeek(int advance)
 #endif
     int		old_wcol, old_wrow;
     int		wait_tb_len;
+    long	wait_time = 0L;
 
     /*
      * This function doesn't work very well when called recursively.  This may
@@ -2828,18 +2829,21 @@ vgetorpeek(int advance)
 		    // that has a <Nop> RHS.
 		    timedout = FALSE;
 
+		if (advance)
+		{
+		    if (typebuf.tb_len == 0 || !(p_timeout
+				|| (p_ttimeout && keylen == KEYLEN_PART_KEY)))
+			wait_time = -1L;
+		    else if (keylen == KEYLEN_PART_KEY && p_ttm >= 0)
+			wait_time = p_ttm;
+		    else
+			wait_time = p_tm;
+		}
+
 		wait_tb_len = typebuf.tb_len;
 		c = inchar(typebuf.tb_buf + typebuf.tb_off + typebuf.tb_len,
 			typebuf.tb_buflen - typebuf.tb_off - typebuf.tb_len - 1,
-			!advance
-			    ? 0
-			    : ((typebuf.tb_len == 0
-				    || !(p_timeout || (p_ttimeout
-					       && keylen == KEYLEN_PART_KEY)))
-				    ? -1L
-				    : ((keylen == KEYLEN_PART_KEY && p_ttm >= 0)
-					    ? p_ttm
-					    : p_tm)));
+			wait_time);
 
 #ifdef FEAT_CMDL_INFO
 		if (i != 0)

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -5603,19 +5603,23 @@ mch_job_start(char **argv, job_T *job, jobopt_T *options, int is_terminal)
 	close(fd_err[1]);
     if (channel != NULL)
     {
-	int in_fd = use_file_for_in || use_null_for_in
-			? INVALID_FD : fd_in[1] < 0 ? pty_master_fd : fd_in[1];
-	int out_fd = use_file_for_out || use_null_for_out
-		      ? INVALID_FD : fd_out[0] < 0 ? pty_master_fd : fd_out[0];
-	/* When using pty_master_fd only set it for stdout, do not duplicate it
-	 * for stderr, it only needs to be read once. */
-	int err_fd = use_out_for_err || use_file_for_err || use_null_for_err
-		      ? INVALID_FD
-		      : fd_err[0] >= 0
-		         ? fd_err[0]
-		         : (out_fd == pty_master_fd
-				 ? INVALID_FD
-				 : pty_master_fd);
+	int in_fd = INVALID_FD;
+	int out_fd = INVALID_FD;
+	int err_fd = INVALID_FD;
+
+	if (!(use_file_for_in || use_null_for_in))
+	    in_fd = fd_in[1] >= 0 ? fd_in[1] : pty_master_fd;
+	if (!(use_file_for_out || use_null_for_out))
+	    out_fd = fd_out[0] >= 0 ? fd_out[0] : pty_master_fd;
+	// When using pty_master_fd only set it for stdout, do not duplicate
+	// it for stderr, it only needs to be read once.
+	if (!(use_out_for_err || use_file_for_err || use_null_for_err))
+	{
+	    if (fd_err[0] >= 0)
+		err_fd = fd_err[0];
+	    else if (out_fd != pty_master_fd)
+		err_fd = pty_master_fd;
+	}
 
 	channel_set_pipes(channel, in_fd, out_fd, err_fd);
 	channel_set_job(channel, job, options);


### PR DESCRIPTION
This pull-req purposes to improve readability of the following complicated codes.

* vgetorpeek() in getchar.c
```c
		c = inchar(typebuf.tb_buf + typebuf.tb_off + typebuf.tb_len,
			typebuf.tb_buflen - typebuf.tb_off - typebuf.tb_len - 1,
			!advance
			    ? 0
			    : ((typebuf.tb_len == 0
				    || !(p_timeout || (p_ttimeout
					       && keylen == KEYLEN_PART_KEY)))
				    ? -1L
				    : ((keylen == KEYLEN_PART_KEY && p_ttm >= 0)
					    ? p_ttm
					    : p_tm)));
```

* mch_job_start() in os_unix.c
```c
	int in_fd = use_file_for_in || use_null_for_in
			? INVALID_FD : fd_in[1] < 0 ? pty_master_fd : fd_in[1];
	int out_fd = use_file_for_out || use_null_for_out
		      ? INVALID_FD : fd_out[0] < 0 ? pty_master_fd : fd_out[0];
	/* When using pty_master_fd only set it for stdout, do not duplicate it
	 * for stderr, it only needs to be read once. */
	int err_fd = use_out_for_err || use_file_for_err || use_null_for_err
		      ? INVALID_FD
		      : fd_err[0] >= 0
		         ? fd_err[0]
		         : (out_fd == pty_master_fd
				 ? INVALID_FD
				 : pty_master_fd);
```