### PR TITLE
Fix: Vim hangs when using feedkeys(_, "L") in timer

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3705,15 +3705,18 @@ f_feedkeys(typval_T *argvars, typval_T *rettv UNUSED)
 #endif
 	    }
 	    else
+	    {
 		ins_typebuf(keys_esc, (remap ? REMAP_YES : REMAP_NONE),
 				  insert ? 0 : typebuf.tb_len, !typed, FALSE);
-	    vim_free(keys_esc);
-	    if (vgetc_busy
+		if (vgetc_busy
 #ifdef FEAT_TIMERS
-		    || timer_busy
+			|| timer_busy
 #endif
-		    )
-		typebuf_was_filled = TRUE;
+			)
+		    typebuf_was_filled = TRUE;
+	    }
+	    vim_free(keys_esc);
+
 	    if (execute)
 	    {
 		int save_msg_scroll = msg_scroll;

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -50,7 +50,7 @@ if has('timers')
     au CursorHoldI * let g:triggered += 1
     set updatetime=500
     call job_start(has('win32') ? 'cmd /c echo:' : 'echo',
-          \ {'exit_cb': {j, s -> timer_start(1000, 'ExitInsertMode')}})
+          \ {'exit_cb': {-> timer_start(1000, 'ExitInsertMode')}})
     call feedkeys('a', 'x!')
     call assert_equal(1, g:triggered)
     unlet g:triggered

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -215,7 +215,7 @@ func Test_map_timeout_with_timer_interrupt()
   set timeout timeoutlen=1000
 
   func ExitCb(job, status)
-    let g:timer = timer_start(1, {_ -> feedkeys("3\<Esc>", 't')})
+    let g:timer = timer_start(1, {-> feedkeys("3\<Esc>", 't')})
   endfunc
 
   call job_start([&shell, &shellcmdflag, 'echo'], {'exit_cb': 'ExitCb'})

--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -251,9 +251,8 @@ func Test_peek_and_get_char()
 endfunc
 
 func Test_getchar_zero()
-  if has('win32')
+  if has('win32') && !has('gui_running')
     " Console: no low-level input
-    " GUI: somehow doesn't work
     return
   endif
 

--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -258,7 +258,7 @@ func Test_getchar_zero()
 
   " Measure the elapsed time to avoid a hang when it fails.
   let start = reltime()
-  let id = timer_start(20, {id -> feedkeys('x', 'L')})
+  let id = timer_start(20, {-> feedkeys('x', 'L')})
   let c = 0
   while c == 0 && reltimefloat(reltime(start)) < 0.2
     let c = getchar(0)


### PR DESCRIPTION
## Repro steps

Environments: On both GUI and terminal

```
vim --clean
:call timer_start(1, {-> feedkeys('x', 'L')})
```

then Vim hangs until feed Ctrl-C.

Also gVim does.

## Cause

feedkeys("x", "L") puts "x" to "inbuf" but sets "typebuf_was_filled" to TRUE, this means that input_available() is true but "typebuf" is empty.
Vim tries to get a character from "typebuf" by inchar() but cannot, thus it causes the infinite loop in vgetorpeek().

## Note

This fix can make Test_getchar_zero enabled on Win32 GUI.