### PR TITLE
filter marks

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -568,6 +568,7 @@ N  *+X11*		Unix only: can restore window title |X11|
 			commands support filtering, try it out to check if it
 			works. Some of the commands that support filtering:
                           |:#|          - filter whole line
+                          |:clist|      - filter by file name or module name
                           |:command|    - filter by command name
                           |:files|      - filter by file name
                           |:highlight|  - filter by highlight group
@@ -575,8 +576,8 @@ N  *+X11*		Unix only: can restore window title |X11|
                           |:let|        - filter by variable name
                           |:list|       - filter whole line
                           |:llist|      - filter by file name or module name
+			  |:marks|      - filter by file name or line
                           |:oldfiles|   - filter by file name
-                          |:clist|      - filter by file name or module name
                           |:set|        - filter by variable name
 
 			Only normal messages are filtered, error messages are

--- a/src/mark.c
+++ b/src/mark.c
@@ -724,7 +724,7 @@ do_marks(exarg_T *eap)
 	    name = fm_getname(&namedfm[i].fmark, 15);
 	else
 	    name = namedfm[i].fname;
-	if (name != NULL)
+	if (name != NULL && !message_filtered(name))
 	{
 	    show_one_mark(i >= NMARKS ? i - NMARKS + '0' : i + 'A',
 		    arg, &namedfm[i].fmark.mark, name,
@@ -733,14 +733,16 @@ do_marks(exarg_T *eap)
 		vim_free(name);
 	}
     }
-    show_one_mark('"', arg, &curbuf->b_last_cursor, NULL, TRUE);
-    show_one_mark('[', arg, &curbuf->b_op_start, NULL, TRUE);
-    show_one_mark(']', arg, &curbuf->b_op_end, NULL, TRUE);
-    show_one_mark('^', arg, &curbuf->b_last_insert, NULL, TRUE);
-    show_one_mark('.', arg, &curbuf->b_last_change, NULL, TRUE);
-    show_one_mark('<', arg, &curbuf->b_visual.vi_start, NULL, TRUE);
-    show_one_mark('>', arg, &curbuf->b_visual.vi_end, NULL, TRUE);
-    show_one_mark(-1, arg, NULL, NULL, FALSE);
+    if (cmdmod.filter_regmatch.regprog == NULL) {
+	show_one_mark('"', arg, &curbuf->b_last_cursor, NULL, TRUE);
+	show_one_mark('[', arg, &curbuf->b_op_start, NULL, TRUE);
+	show_one_mark(']', arg, &curbuf->b_op_end, NULL, TRUE);
+	show_one_mark('^', arg, &curbuf->b_last_insert, NULL, TRUE);
+	show_one_mark('.', arg, &curbuf->b_last_change, NULL, TRUE);
+	show_one_mark('<', arg, &curbuf->b_visual.vi_start, NULL, TRUE);
+	show_one_mark('>', arg, &curbuf->b_visual.vi_end, NULL, TRUE);
+	show_one_mark(-1, arg, NULL, NULL, FALSE);
+    }
 }
 
     static void
@@ -753,6 +755,9 @@ show_one_mark(
 {
     static int	did_title = FALSE;
     int		mustfree = FALSE;
+
+    if (message_filtered(mark_line(p, 15)))
+	return;
 
     if (c == -1)			    /* finish up */
     {

--- a/src/testdir/test_filter_cmd.vim
+++ b/src/testdir/test_filter_cmd.vim
@@ -126,6 +126,14 @@ func Test_filter_commands()
   let res = split(execute("filter /\.c$/ jumps"), "\n")[1:]
   call assert_equal(["   2     1    0 file.c", ">"], res)
 
+  " Test filtering :marks command
+  b file.c
+  mark A
+  b file.h
+  mark B
+  let res = split(execute("filter /\.c$/ marks"), "\n")[1:]
+  call assert_equal([" A      1    0 file.c"], res)
+
   bwipe file.c
   bwipe file.h
   bwipe file.hs


### PR DESCRIPTION
`:filter /pattern/ marks`
will now filter marks depending on the shown text (file name for uppercase marks, line for lower case marks).