### PR TITLE
fix for rb_int2big_stub for Ruby 2.6 (uintptr_t instead of SIGNED_VALUE)

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -506,7 +506,11 @@ SIGNED_VALUE rb_num2long_stub(VALUE x)
 {
     return dll_rb_num2long(x);
 }
+#  if defined(DYNAMIC_RUBY_VER) && DYNAMIC_RUBY_VER >= 26
+VALUE rb_int2big_stub(intptr_t x)
+#  else
 VALUE rb_int2big_stub(SIGNED_VALUE x)
+#  endif
 {
     return dll_rb_int2big(x);
 }


### PR DESCRIPTION
Compilation on Archlinux32 with Ruby 2.6.0 with `configure --enable-ruby-interp-dynamic` yields:

```
if_ruby.c:509:7: error: conflicting types for ‘rb_int2big_stub’
 VALUE rb_int2big_stub(SIGNED_VALUE x)
       ^~~~~~~~~~~~~~~
if_ruby.c:107:21: note: previous declaration of ‘rb_int2big_stub’ was here
 # define rb_int2big rb_int2big_stub
                     ^~~~~~~~~~~~~~~
/usr/include/ruby-2.6.0/ruby/ruby.h:776:7: note: in expansion of macro ‘rb_int2big’
 VALUE rb_int2big(intptr_t);
       ^~~~~~~~~~
```

Seems also to affect 32-bit MingGW:

https://www.mail-archive.com/search?l=vim_dev@googlegroups.com&q=subject:"Build+gvim+x86+with+Ruby+support+v2.6+with+mingw32\-make+fails+on+conflict+rb_int2big_stub"&o=newest&f=1

The Ruby Changelog for 2.6.0 says:

```
r62494 | nobu | 2018-02-20 17:01:44 +0900 (Tue, 20 Feb 2018) | 5 lines

Signature of rb_uint2big and rb_int2big

* include/ruby/ruby.h (rb_uint2big, rb_int2big): declare with
  uintptr_t and intptr_t instead of VALUE and SIGNED_VALUE
  respectively.  [ruby-core:83424] [Bug #14036]
```

The old code compiled correctly on 64-bit as SIGNED_VALUE and intptr_t have
the same size (64-bit) presumably.

I'm not sure about the guard checking for the Ruby version, also I don't
understand enough to see what happens, if Ruby is just compiled with 'yes'
instead of 'dynamic'.
