### PR TITLE
Proposal: ":terminal" option about winpty/conpty

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -9474,8 +9474,6 @@ term_start({cmd}, {options})				*term_start()*
 		   "ansi_colors"     A list of 16 color names or hex codes
 				     defining the ANSI palette used in GUI
 				     color modes.  See |g:terminal_ansi_colors|.
-		   "tty_type"	     (MS-Windows only): Specify which pty to
-				     use.  See 'termwintype' for the values.
 
 		{only available when compiled with the |+terminal| feature}
 

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -228,9 +228,6 @@ Syntax ~
 					for Python "++eof=exit()".  Special
 					codes can be used like with `:map`,
 					e.g. "<C-Z>" for CTRL-Z.
-			++type={pty}	(MS-Windows only): Use {pty} as the
-					virtual console.  See 'termwintype'
-					for the values.
 
 			If you want to use more options use the |term_start()|
 			function.

--- a/src/channel.c
+++ b/src/channel.c
@@ -4947,28 +4947,6 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		opt->jo_set2 |= JO2_TERM_KILL;
 		opt->jo_term_kill = tv_get_string_chk(item);
 	    }
-	    else if (STRCMP(hi->hi_key, "tty_type") == 0)
-	    {
-		char_u *p;
-
-		if (!(supported2 & JO2_TTY_TYPE))
-		    break;
-		opt->jo_set2 |= JO2_TTY_TYPE;
-		p = tv_get_string_chk(item);
-		if (p == NULL)
-		{
-		    semsg(_(e_invargval), "tty_type");
-		    return FAIL;
-		}
-		// Allow empty string, "winpty", "conpty".
-		if (!(*p == NUL || STRCMP(p, "winpty") == 0
-					          || STRCMP(p, "conpty") == 0))
-		{
-		    semsg(_(e_invargval), "tty_type");
-		    return FAIL;
-		}
-		opt->jo_tty_type = p[0];
-	    }
 # if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
 	    else if (STRCMP(hi->hi_key, "ansi_colors") == 0)
 	    {

--- a/src/structs.h
+++ b/src/structs.h
@@ -1792,7 +1792,6 @@ struct channel_S {
 #define JO2_NORESTORE	    0x2000	/* "norestore" */
 #define JO2_TERM_KILL	    0x4000	/* "term_kill" */
 #define JO2_ANSI_COLORS	    0x8000	/* "ansi_colors" */
-#define JO2_TTY_TYPE	    0x10000	/* "tty_type" */
 
 #define JO_MODE_ALL	(JO_MODE + JO_IN_MODE + JO_OUT_MODE + JO_ERR_MODE)
 #define JO_CB_ALL \
@@ -1865,7 +1864,6 @@ typedef struct
 # if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
     long_u	jo_ansi_colors[16];
 # endif
-    int		jo_tty_type;	    // first character of "tty_type"
 #endif
 } jobopt_T;
 


### PR DESCRIPTION
I propose to change current "++winpty" and "++conpty" option of ":terminal" command to "++mode={pty}" style.

```
:term ++mode=conpty
```

Reasons:

* "++winpty" and "++conpty" are mutually exclusive and coordinate values, so better to treat them as values of one option.

* "term_start()" has "term_mode" option to specify pty. I think nice to be consistency with this style for usability.

* If an another new pty is added in future, add "++newpty" option...?