### PR TITLE
[Proposal] Make utf-8 as the default encoding

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2828,7 +2828,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|setcellwidths()| function to change the behavior.
 
 					*'encoding'* *'enc'* *E543*
-'encoding' 'enc'	string (default: "latin1" or value from $LANG)
+'encoding' 'enc'	string (default for MS-Windows: "utf-8",
+				otherwise: value from $LANG or "latin1")
 			global
 	Sets the character encoding used inside Vim.  It applies to text in
 	the buffers, registers, Strings in expressions, text stored in the

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4603,7 +4603,19 @@ enc_locale_env(char *locale)
 enc_locale(void)
 {
 #ifdef MSWIN
-    return vim_strsave((char_u *)ENC_DFLT);
+    char	buf[50];
+    long	acp = GetACP();
+
+    if (acp == 1200)
+	STRCPY(buf, "ucs-2le");
+    else if (acp == 1252)	    // cp1252 is used as latin1
+	STRCPY(buf, "latin1");
+    else if (acp == 65001)
+	STRCPY(buf, "utf-8");
+    else
+	sprintf(buf, "cp%ld", acp);
+
+    return enc_canonize((char_u *)buf);
 #else
     char	*s;
 

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4456,7 +4456,7 @@ enc_canonize(char_u *enc)
 	// Use the default encoding as it's found by set_init_1().
 	r = get_encoding_default();
 	if (r == NULL)
-	    r = (char_u *)"latin1";
+	    r = (char_u *)ENC_DFLT;
 	return vim_strsave(r);
     }
 
@@ -4603,19 +4603,7 @@ enc_locale_env(char *locale)
 enc_locale(void)
 {
 #ifdef MSWIN
-    char	buf[50];
-    long	acp = GetACP();
-
-    if (acp == 1200)
-	STRCPY(buf, "ucs-2le");
-    else if (acp == 1252)	    // cp1252 is used as latin1
-	STRCPY(buf, "latin1");
-    else if (acp == 65001)
-	STRCPY(buf, "utf-8");
-    else
-	sprintf(buf, "cp%ld", acp);
-
-    return enc_canonize((char_u *)buf);
+    return vim_strsave((char_u *)ENC_DFLT);
 #else
     char	*s;
 

--- a/src/option.c
+++ b/src/option.c
@@ -430,8 +430,12 @@ set_init_1(int clean_arg)
 #  endif
 # endif
 
+# ifdef MSWIN
+    p = vim_strsave((char_u *)ENC_DFLT);
+# else
     // enc_locale() will try to find the encoding of the current locale.
     p = enc_locale();
+# endif
     if (p != NULL)
     {
 	char_u *save_enc;

--- a/src/option.c
+++ b/src/option.c
@@ -437,7 +437,7 @@ set_init_1(int clean_arg)
 	char_u *save_enc;
 
 	// Try setting 'encoding' and check if the value is valid.
-	// If not, go back to the default "latin1".
+	// If not, go back to the default encoding.
 	save_enc = p_enc;
 	p_enc = p;
 	if (STRCMP(p_enc, "gb18030") == 0)

--- a/src/option.h
+++ b/src/option.h
@@ -127,7 +127,11 @@ typedef enum {
 #define ENC_UCSBOM	"ucs-bom"	// check for BOM at start of file
 
 // default value for 'encoding'
-#define ENC_DFLT	"latin1"
+#ifdef MSWIN
+# define ENC_DFLT	"utf-8"
+#else
+# define ENC_DFLT	"latin1"
+#endif
 
 // end-of-line style
 #define EOL_UNKNOWN	-1	// not defined yet

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -501,7 +501,7 @@ func Test_write_file_encoding()
   CheckMSWindows
   let save_encoding = &encoding
   let save_fileencodings = &fileencodings
-  set encoding& fileencodings&
+  set encoding=latin1 fileencodings&
   let text =<< trim END
     1 utf-8 text: Ð”Ð»Ñ Vim version 6.2.  ÐŸÐ¾ÑÐ»ÐµÐ´Ð½ÐµÐµ Ð¸Ð·Ð¼ÐµÐ½ÐµÐ½Ð¸Ðµ: 1970 Jan 01
     2 cp1251 text: Äëÿ Vim version 6.2.  Ïîñëåäíåå èçìåíåíèå: 1970 Jan 01


### PR DESCRIPTION
We have graduated FEAT_MBYTE, so there's no need to stuck with old latin1
encoding.  How about make "utf-8" as the default encoding?

Most Unix users may not affected by this change, because most Unix systems
nowadays use utf-8 as the system locale.

Windows users who don't set the 'encoding' explicitly will be affected by
this change.  But I think using utf-8 has many merits.
(E.g. We can use DirectWrite and color emojis.)

What do you think?