### PR TITLE
Convert encoding for message

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -2940,17 +2940,19 @@ mch_errmsg(char *str)
 #if defined(WIN3264) && !defined(FEAT_GUI_MSWIN)
     int	    len = STRLEN(str);
     DWORD   nwrite = 0;
+    DWORD   mode = 0;
+    HANDLE  h = GetStdHandle(STD_ERROR_HANDLE);
 
-    if (isatty(2) && enc_codepage >= 0 &&
+    if (GetConsoleMode(h, &mode) && enc_codepage >= 0 &&
 	    (int)GetConsoleCP() != enc_codepage)
     {
 	WCHAR	*w = enc_to_utf16((char_u *)str, &len);
-	WriteConsoleW(GetStdHandle(STD_ERROR_HANDLE), w, len, &nwrite, NULL);
+	WriteConsoleW(h, w, len, &nwrite, NULL);
 	vim_free(w);
     }
     else
     {
-	WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, len, &nwrite, NULL);
+	fprintf(stderr, "%s", str);
     }
 #else
     int		len;
@@ -3025,17 +3027,20 @@ mch_msg(char *str)
 #if defined(WIN3264) && !defined(FEAT_GUI_MSWIN)
     int	    len = STRLEN(str);
     DWORD   nwrite = 0;
+    DWORD   mode;
+    HANDLE  h = GetStdHandle(STD_OUTPUT_HANDLE);
 
-    if (isatty(2) && enc_codepage >= 0 &&
+
+    if (GetConsoleMode(h, &mode) && enc_codepage >= 0 &&
 	    (int)GetConsoleCP() != enc_codepage)
     {
 	WCHAR	*w = enc_to_utf16((char_u *)str, &len);
-	WriteConsoleW(GetStdHandle(STD_OUTPUT_HANDLE), w, len, &nwrite, NULL);
+	WriteConsoleW(h, w, len, &nwrite, NULL);
 	vim_free(w);
     }
     else
     {
-	WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), str, len, &nwrite, NULL);
+	printf("%s", str);
     }
 #else
 # if (defined(UNIX) || defined(FEAT_GUI)) && !defined(ALWAYS_USE_GUI)

--- a/src/message.c
+++ b/src/message.c
@@ -2626,7 +2626,7 @@ msg_puts_printf(char_u *str, int maxlen)
 
     if (*p && !(silent_mode && p_verbose == 0))
     {
-	if (STRLEN(p) > maxlen)
+	if (maxlen > 0 && STRLEN(p) > maxlen)
 	    p[maxlen] = 0;
 	if (info_message)
 	    mch_msg((char *)p);

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -675,6 +675,7 @@ mch_suspend(void)
 # undef display_errors
 #endif
 
+#ifdef FEAT_GUI
 /*
  * Display the saved error message(s).
  */
@@ -690,13 +691,9 @@ display_errors(void)
 	    if (!isspace(*p))
 	    {
 		(void)gui_mch_dialog(
-#ifdef FEAT_GUI
 				     gui.starting ? VIM_INFO :
-#endif
 					     VIM_ERROR,
-#ifdef FEAT_GUI
 				     gui.starting ? (char_u *)_("Message") :
-#endif
 					     (char_u *)_("Error"),
 				     (char_u *)p, (char_u *)_("&Ok"),
 					1, NULL, FALSE);
@@ -705,6 +702,13 @@ display_errors(void)
 	ga_clear(&error_ga);
     }
 }
+#else
+    void
+display_errors(void)
+{
+    FlushFileBuffers(GetStdHandle(STD_ERROR_HANDLE));
+}
+#endif
 #endif
 
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -2093,7 +2093,7 @@ typedef enum {
  * functions of these names. The declarations would break if the defines had
  * been seen at that stage.  But it must be before globals.h, where error_ga
  * is declared. */
-#if !defined(FEAT_GUI_W32) && !defined(FEAT_GUI_X11) \
+#if !defined(MSWIN) && !defined(FEAT_GUI_X11) \
 	&& !defined(FEAT_GUI_GTK) && !defined(FEAT_GUI_MAC) && !defined(PROTO)
 # define mch_errmsg(str)	fprintf(stderr, "%s", (str))
 # define display_errors()	fflush(stderr)


### PR DESCRIPTION
Current implementation, mch_msg on Windows is macro of printf. (See vim.h)

So `vim --help` shows messages with current codepage since vimrc is not loaded.

![image](https://user-images.githubusercontent.com/10111/52454886-f956a180-2b90-11e9-94b7-093d709f433f.png)

But when use encoding=utf-8, `cat | vim -` show `"Vim: Reading from stdin...` with utf-8 since vimrc is loaded. Using this patch:

![image](https://user-images.githubusercontent.com/10111/52454908-0ffcf880-2b91-11e9-8035-a0ee73f4f740.png)

For Windows console, mch_msg must be a function that convert encodings.

![image](https://user-images.githubusercontent.com/10111/52454928-260ab900-2b91-11e9-80c5-487d7bb7ccf1.png)
