### PR TITLE
Bug fix: substitute l flag remains sticky

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2098,7 +2098,7 @@ write_viminfo(char_u *file, int forceit)
 			fp_out = NULL;
 # ifdef EEXIST
 			/* Avoid trying lots of names while the problem is lack
-			 * of premission, only retry if the file already
+			 * of permission, only retry if the file already
 			 * exists. */
 			if (errno != EEXIST)
 			    break;
@@ -5040,6 +5040,7 @@ do_sub(exarg_T *eap)
 	}
 	subflags.do_error = TRUE;
 	subflags.do_print = FALSE;
+	subflags.do_list = FALSE;
 	subflags.do_count = FALSE;
 	subflags.do_number = FALSE;
 	subflags.do_ic = 0;

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -108,7 +108,7 @@ func Test_substitute_variants()
 endfunc
 
 " Test the l, p, # flags.
-func Test_sustitutue_flags_lp()
+func Test_substitute_flags_lp()
   new
   call setline(1, "abc\tdef\<C-h>ghi")
 

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -107,6 +107,32 @@ func Test_substitute_variants()
   endfor
 endfunc
 
+" Test the l, p, # flags.
+func Test_sustitutue_flags_lp()
+  new
+  call setline(1, "abc\tdef\<C-h>ghi")
+
+  let a = execute('s/a/a/p')
+  call assert_equal("\nabc     def^Hghi", a)
+
+  let a = execute('s/a/a/l')
+  call assert_equal("\nabc^Idef^Hghi$", a)
+
+  let a = execute('s/a/a/#')
+  call assert_equal("\n  1 abc     def^Hghi", a)
+
+  let a = execute('s/a/a/p#')
+  call assert_equal("\n  1 abc     def^Hghi", a)
+
+  let a = execute('s/a/a/l#')
+  call assert_equal("\n  1 abc^Idef^Hghi$", a)
+
+  let a = execute('s/a/a/')
+  call assert_equal("", a)
+
+  bwipe!
+endfunc
+
 func Test_substitute_repeat()
   " This caused an invalid memory access.
   split Xfile


### PR DESCRIPTION
This PR fixes a bug in the :s/x//l command, where the 'l' flag remained sticky.

To reproduce the bug, run vim as follows:
```
$ vim --clean -c 'call setline(1, "foo\tbar")'
```
Then this first Ex command prints "foo     bar" as expected:
```
:s/f/f/p
```
This second Ex command prints "foo^Ibar$" as exected:
```
:s/f/f/l
```
But re-doing the first Ex command again then prints "foo^Ibar$"
whereas it should print "foo     bar":

```
:s/f/f/p
```
The newly added test will fails without the fix in ex_cmds.c
and succeeds with the fix .