### PR TITLE
Properly handle the location list window closure when it is still in use

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -8586,7 +8586,7 @@ find_win_by_nr_or_id(typval_T *vp)
     int	nr = (int)tv_get_number_chk(vp, NULL);
 
     if (nr >= LOWEST_WIN_ID)
-	return win_id2wp(vp);
+	return win_id2wp(tv_get_number(vp));
     return find_win_by_nr(vp, NULL);
 }
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5800,7 +5800,7 @@ f_getwininfo(typval_T *argvars, typval_T *rettv)
 
     if (argvars[0].v_type != VAR_UNKNOWN)
     {
-	wparg = win_id2wp(argvars);
+	wparg = win_id2wp(tv_get_number(&argvars[0]));
 	if (wparg == NULL)
 	    return;
     }

--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -91,7 +91,7 @@ int get_tab_number(tabpage_T *tp);
 int win_getid(typval_T *argvars);
 int win_gotoid(typval_T *argvars);
 void win_id2tabwin(typval_T *argvars, list_T *list);
-win_T *win_id2wp(typval_T *argvars);
+win_T *win_id2wp(int id);
 int win_id2win(typval_T *argvars);
 void win_findbuf(typval_T *argvars, list_T *list);
 void get_framelayout(frame_T *fr, list_T *l, int outer);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3334,7 +3334,7 @@ qf_jump_newwin(qf_info_T	*qi,
     if (retval == NOTDONE)
 	goto theend;
 
-    retval = qf_jump_to_buffer(qi, qf_index, qf_ptr, forceit, oldwin,
+    retval = qf_jump_to_buffer(qi, qf_index, qf_ptr, forceit, curwin,
 	    &opened_window, old_KeyTyped, print_message);
     if (retval == NOTDONE)
     {
@@ -3362,7 +3362,7 @@ theend:
 	qfl->qf_ptr = qf_ptr;
 	qfl->qf_index = qf_index;
     }
-    if (p_swb != old_swb && opened_window)
+    if (p_swb != old_swb)
     {
 	// Restore old 'switchbuf' value, but not when an autocommand or
 	// modeline has changed the value.

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -3974,7 +3974,7 @@ func Test_winonly_autocmd()
   let loclistid = getloclist(0, {'id' : 0}).id
   lopen
   call assert_equal(loclistid, getloclist(0, {'id' : 0}).id)
-  silent! ll
+  ll
   call assert_equal(loclistid, getloclist(0, {'id' : 0}).id)
   autocmd! WinEnter
   new | only

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1,4 +1,4 @@
-" Test for the quickfix commands.
+" Test for the quickfix feature.
 
 if !has('quickfix')
   finish
@@ -1419,7 +1419,7 @@ func XquickfixSetListWithAct(cchar)
           \    {'filename': 'fnameD', 'text': 'D'},
           \    {'filename': 'fnameE', 'text': 'E'}]
 
-  " {action} is unspecified.  Same as specifing ' '.
+  " {action} is unspecified.  Same as specifying ' '.
   new | only
   silent! Xnewer 99
   call g:Xsetlist(list1)
@@ -2348,7 +2348,7 @@ func Test_cwindow_jump()
   " Open a new window and create a location list
   " Open the location list window and close the other window
   " Jump to an entry.
-  " Should create a new window and jump to the entry. The scrtach buffer
+  " Should create a new window and jump to the entry. The scratch buffer
   " should not be used.
   enew | only
   set buftype=nofile
@@ -3831,7 +3831,7 @@ func Test_splitview()
   new | only
 
   " When split opening files from a helpgrep location list window, a new help
-  " window should be opend with a copy of the location list.
+  " window should be opened with a copy of the location list.
   lhelpgrep window
   let locid = getloclist(0, {'id' : 0}).id
   lwindow
@@ -3968,14 +3968,25 @@ endfunc
 " If there is an autocmd to use only one window, then opening the location
 " list window used to crash Vim.
 func Test_winonly_autocmd()
+  call s:create_test_file('Xtest1')
+  " Autocmd to show only one Vim window at a time
   autocmd WinEnter * only
-  new | only
-  lexpr "F1:10:Line10"
+  new
+  " Load the location list
+  lexpr "Xtest1:5:Line5\nXtest1:10:Line10\nXtest1:15:Line15"
   let loclistid = getloclist(0, {'id' : 0}).id
+  " Open the location list window. Only this window will be shown and the file
+  " window is closed.
   lopen
   call assert_equal(loclistid, getloclist(0, {'id' : 0}).id)
-  ll
+  " Jump to an entry in the location list and make sure that the cursor is
+  " positioned correctly.
+  ll 3
   call assert_equal(loclistid, getloclist(0, {'id' : 0}).id)
+  call assert_equal('Xtest1', bufname(''))
+  call assert_equal(15, line('.'))
+  " Cleanup
   autocmd! WinEnter
   new | only
+  call delete('Xtest1')
 endfunc

--- a/src/window.c
+++ b/src/window.c
@@ -7193,11 +7193,10 @@ win_id2tabwin(typval_T *argvars, list_T *list)
 }
 
     win_T *
-win_id2wp(typval_T *argvars)
+win_id2wp(int id)
 {
     win_T	*wp;
     tabpage_T   *tp;
-    int		id = tv_get_number(&argvars[0]);
 
     FOR_ALL_TAB_WINDOWS(tp, wp)
 	if (wp->w_id == id)


### PR DESCRIPTION
Vim crashes when the location list window is closed using an autocmd while
it is still in use. Properly handle this scenario.