### PR TITLE
Fix: can add the new value to "a:" dict

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -2092,8 +2092,9 @@ get_lval(
 
 	    if (lp->ll_di == NULL)
 	    {
-		/* Can't add "v:" variable. */
-		if (lp->ll_dict == &vimvardict)
+		/* Can't add "v:" or "a:" variable. */
+		if (lp->ll_dict == &vimvardict
+			 || &lp->ll_dict->dv_hashtab == get_funccal_args_ht())
 		{
 		    semsg(_(e_illvar), name);
 		    return NULL;
@@ -7919,8 +7920,8 @@ set_var(
     }
     else		    /* add a new variable */
     {
-	/* Can't add "v:" variable. */
-	if (ht == &vimvarht)
+	/* Can't add "v:" or "a:" variable. */
+	if (ht == &vimvarht || ht == get_funccal_args_ht())
 	{
 	    semsg(_(e_illvar), name);
 	    return;

--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -65,15 +65,84 @@ func s:set_arg9(a) abort
   let a:['b'] = 1
 endfunction
 
+func s:set_arg10(a) abort
+  let b = a:
+  call extend(b, {'a': 1})
+endfunction
+
+func s:set_arg11(a) abort
+  let b = a:
+  call extend(b, {'b': 1})
+endfunction
+
+func s:set_arg12(a) abort
+  let b = a:
+  let b['b'] = 1
+endfunction
+
 func Test_let_arg_fail()
   call assert_fails('call s:set_arg1(1)', 'E46:')
   call assert_fails('call s:set_arg2(1)', 'E461:')
   call assert_fails('call s:set_arg3(1)', 'E46:')
   call assert_fails('call s:set_arg4(1)', 'E46:')
   call assert_fails('call s:set_arg5(1)', 'E46:')
-  let a = [0]
-  call s:set_arg6(a)
+  call s:set_arg6([0])
   call assert_fails('call s:set_arg7(1)', 'E742:')
   call assert_fails('call s:set_arg8(1)', 'E742:')
   call assert_fails('call s:set_arg9(1)', 'E461:')
+  call assert_fails('call s:set_arg10(1)', 'E742:')
+  call assert_fails('call s:set_arg11(1)', 'E742:')
+  call assert_fails('call s:set_arg12(1)', 'E461:')
+endfunction
+
+func s:set_varg1(...) abort
+  let a:000 = []
+endfunction
+
+func s:set_varg2(...) abort
+  let a:000[0] = 1
+endfunction
+
+func s:set_varg3(...) abort
+  let a:000 += [1]
+endfunction
+
+func s:set_varg4(...) abort
+  call add(a:000, 1)
+endfunction
+
+func s:set_varg5(...) abort
+  let a:000[0][0] = 1
+endfunction
+
+func s:set_varg6(...) abort
+  let b = a:000
+  let b[0] = 1
+endfunction
+
+func s:set_varg7(...) abort
+  let b = a:000
+  let b += [1]
+endfunction
+
+func s:set_varg8(...) abort
+  let b = a:000
+  call add(b, 1)
+endfunction
+
+func s:set_varg9(...) abort
+  let b = a:000
+  let b[0][0] = 1
+endfunction
+
+func Test_let_varg_fail()
+  call assert_fails('call s:set_varg1(1)', 'E46:')
+  call assert_fails('call s:set_varg2(1)', 'E742:')
+  call assert_fails('call s:set_varg3(1)', 'E46:')
+  call assert_fails('call s:set_varg4(1)', 'E742:')
+  call s:set_varg5([0])
+  call assert_fails('call s:set_varg6(1)', 'E742:')
+  " call assert_fails('call s:set_varg7(1)', 'E46:')
+  call assert_fails('call s:set_varg8(1)', 'E742:')
+  call s:set_varg9([0])
 endfunction

--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -25,3 +25,55 @@ func Test_let()
   let s = "\na                     #1\nb                     #2"
   call assert_equal(s, out)
 endfunc
+
+func s:set_arg1(a) abort
+  let a:a = 1
+endfunction
+
+func s:set_arg2(a) abort
+  let a:b = 1
+endfunction
+
+func s:set_arg3(a) abort
+  let b = a:
+  let b['a'] = 1
+endfunction
+
+func s:set_arg4(a) abort
+  let b = a:
+  let b['a'] = 1
+endfunction
+
+func s:set_arg5(a) abort
+  let b = a:
+  let b['a'][0] = 1
+endfunction
+
+func s:set_arg6(a) abort
+  let a:a[0] = 1
+endfunction
+
+func s:set_arg7(a) abort
+  call extend(a:, {'a': 1})
+endfunction
+
+func s:set_arg8(a) abort
+  call extend(a:, {'b': 1})
+endfunction
+
+func s:set_arg9(a) abort
+  let a:['b'] = 1
+endfunction
+
+func Test_let_arg_fail()
+  call assert_fails('call s:set_arg1(1)', 'E46:')
+  call assert_fails('call s:set_arg2(1)', 'E461:')
+  call assert_fails('call s:set_arg3(1)', 'E46:')
+  call assert_fails('call s:set_arg4(1)', 'E46:')
+  call assert_fails('call s:set_arg5(1)', 'E46:')
+  let a = [0]
+  call s:set_arg6(a)
+  call assert_fails('call s:set_arg7(1)', 'E742:')
+  call assert_fails('call s:set_arg8(1)', 'E742:')
+  call assert_fails('call s:set_arg9(1)', 'E461:')
+endfunction

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -500,17 +500,21 @@ endfunc
 
 " No remove() of write-protected scope-level variable
 func Tfunc1(this_is_a_long_parameter_name)
-  call assert_fails("call remove(a:, 'this_is_a_long_parameter_name')", 'E795')
+  call assert_fails("call remove(a:, 'this_is_a_long_parameter_name')", 'E742')
 endfunc
 func Test_dict_scope_var_remove()
   call Tfunc1('testval')
 endfunc
 
 " No extend() of write-protected scope-level variable
+func Test_dict_scope_var_extend()
+  call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742')
+endfunc
+
 func Tfunc2(this_is_a_long_parameter_name)
   call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742')
 endfunc
-func Test_dict_scope_var_extend()
+func Test_dict_scope_var_extend_overwrite()
   call Tfunc2('testval')
 endfunc
 

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -651,3 +651,75 @@ func Test_listdict_extend()
   call assert_fails("call extend(d, d, 'error')", 'E737:')
   call assert_equal({'a': {'b': 'B'}}, d)
 endfunc
+
+func s:check_scope_dict(x, fixed)
+    func s:gen_cmd(cmd, x)
+        return substitute(a:cmd, '\<x\ze:', a:x, 'g')
+    endfunc
+
+    let cmd = s:gen_cmd('let x:foo = 1', a:x)
+    if a:fixed
+        call assert_fails(cmd, 'E461')
+    else
+        exe cmd
+        exe s:gen_cmd('call assert_equal(1, x:foo)', a:x)
+    endif
+
+    let cmd = s:gen_cmd('let x:["bar"] = 2', a:x)
+    if a:fixed
+        call assert_fails(cmd, 'E461')
+    else
+        exe cmd
+        exe s:gen_cmd('call assert_equal(2, x:bar)', a:x)
+    endif
+
+    let cmd = s:gen_cmd('call extend(x:, {"baz": 3})', a:x)
+    if a:fixed
+        call assert_fails(cmd, 'E742')
+    else
+        exe cmd
+        exe s:gen_cmd('call assert_equal(3, x:baz)', a:x)
+    endif
+
+    if a:fixed
+      if a:x ==# 'a'
+        call assert_fails('unlet a:x', 'E795')
+        call assert_fails('call remove(a:, "x")', 'E742')
+      elseif a:x ==# 'v'
+        call assert_fails('unlet v:count', 'E795')
+        call assert_fails('call remove(v:, "count")', 'E742')
+      endif
+    else
+        exe s:gen_cmd('unlet x:foo', a:x)
+        exe s:gen_cmd('unlet x:bar', a:x)
+        exe s:gen_cmd('call remove(x:, "baz")', a:x)
+    endif
+
+    delfunc s:gen_cmd
+endfunc
+
+func Test_scope_dict()
+    " Test for g:
+    call s:check_scope_dict('g', v:false)
+
+    " Test for s:
+    call s:check_scope_dict('s', v:false)
+
+    " Test for l:
+    call s:check_scope_dict('l', v:false)
+
+    " Test for a:
+    call s:check_scope_dict('a', v:true)
+
+    " Test for b:
+    call s:check_scope_dict('b', v:false)
+
+    " Test for w:
+    call s:check_scope_dict('w', v:false)
+
+    " Test for t:
+    call s:check_scope_dict('t', v:false)
+
+    " Test for v:
+    call s:check_scope_dict('v', v:true)
+endfunc

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -772,7 +772,7 @@ call_user_func(
 	v = &fc->fixvar[fixvar_idx++].var;
 	name = v->di_key;
 	STRCPY(name, "self");
-	v->di_flags = DI_FLAGS_RO + DI_FLAGS_FIX;
+	v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
 	hash_add(&fc->l_vars.dv_hashtab, DI2HIKEY(v));
 	v->di_tv.v_type = VAR_DICT;
 	v->di_tv.v_lock = 0;
@@ -788,6 +788,7 @@ call_user_func(
     init_var_dict(&fc->l_avars, &fc->l_avars_var, VAR_SCOPE);
     add_nr_var(&fc->l_avars, &fc->fixvar[fixvar_idx++].var, "0",
 				(varnumber_T)(argcount - fp->uf_args.ga_len));
+    fc->l_avars.dv_lock = VAR_FIXED;
     /* Use "name" to avoid a warning from some compiler that checks the
      * destination size. */
     v = &fc->fixvar[fixvar_idx++].var;


### PR DESCRIPTION
Currently we can add the new key-value to "a:" dict.

```vim
func s:f() abort
  " no error?
  let a:x = 1
endfunc
call s:f()
```

NOTE: A part of the tests is based on @mattn's code.