### PR TITLE
Reduced sizeof(regitem_T) from 48 to 40 bytes on x86_64

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -3546,13 +3546,13 @@ typedef enum regstate_E
 typedef struct regitem_S
 {
     regstate_T	rs_state;	/* what we are doing, one of RS_ above */
+    short	rs_no;		/* submatch nr or BEHIND/NOBEHIND */
     char_u	*rs_scan;	/* current node in program */
     union
     {
 	save_se_T  sesave;
 	regsave_T  regsave;
     } rs_un;			/* room for saving rex.input */
-    short	rs_no;		/* submatch nr or BEHIND/NOBEHIND */
 } regitem_T;
 
 static regitem_T *regstack_push(regstate_T state, char_u *scan);


### PR DESCRIPTION
This PR reduces sizeof(regitem_T) from 48 bytes to 40 bytes
on x86_64 by reordering fields to waste less memory in
alignment padding.

It admittedly does not not help to save much memory, as regitem_T
are only temporarily allocated/deallocated by regstack_push() &
regstack_pop() in regexp.c.