### PR TITLE
Change 'termwintype' default to "winpty"

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8103,7 +8103,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	adjusted to that size, if possible.
 
 						*'termwintype'* *'twt'*
-'termwintype' 'twt'	string  (default "")
+'termwintype' 'twt'	string  (default "winpty")
 			global
 			{not in Vi}
 			{only available when compiled with the |terminal|

--- a/src/option.c
+++ b/src/option.c
@@ -2730,7 +2730,7 @@ static struct vimoption options[] =
     {"termwintype", "twt",  P_STRING|P_ALLOCED|P_VI_DEF,
 #if defined(WIN3264) && defined(FEAT_TERMINAL)
 			    (char_u *)&p_twt, PV_NONE,
-			    {(char_u *)"", (char_u *)NULL}
+			    {(char_u *)"winpty", (char_u *)NULL}
 #else
 			    (char_u *)NULL, PV_NONE,
 			    {(char_u *)NULL, (char_u *)0L}


### PR DESCRIPTION
I don't think that Microsoft's ConPTY itself is still stable.
Currently, the default value of Vim's `'termwintype'` option is "". (If ConPTY is available, it will be used)
I think it is not good.
In this PR I changed the default value to "winpty".

--
Best regards,
Hirohito Higashi (h_east)