### PR TITLE
Make winpty as default on unstable ConPTY environment

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8112,12 +8112,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	window.
 
 	Possible values are:
-	    ""		use ConPTY if possible, winpty otherwise
+	    ""		use ConPTY if it is stable, winpty otherwise
 	    "winpty"	use winpty, fail if not supported
 	    "conpty"	use |ConPTY|, fail if not supported
 
-	|ConPTY| support depends on the platform (Windows 10 October 2018
-	edition).  winpty support needs to be installed.  If neither is
+	|ConPTY| support depends on the platform.  Windows 10 October 2018
+	Update is the first version that supports ConPTY, however it is still
+	considered unstable.  ConPTY might become stable in the next release
+	of Windows 10.  winpty support needs to be installed.  If neither is
 	supported then you cannot open a terminal window.
 
 						*'terse'* *'noterse'*

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -187,6 +187,8 @@ static int win32_setattrs(char_u *name, int attrs);
 static int win32_set_archive(char_u *name);
 
 static int vtp_working = 0;
+static int conpty_working = 0;
+static int conpty_stable = 0;
 static void vtp_flag_init();
 
 #ifndef FEAT_GUI_W32
@@ -7638,9 +7640,10 @@ mch_setenv(char *var, char *value, int x)
 
 /*
  * Support for pseudo-console (ConPTY) was added in windows 10
- * version 1809 (October 2018 update).
+ * version 1809 (October 2018 update).  However, that version is unstable.
  */
-#define CONPTY_FIRST_SUPPORT_BUILD MAKE_VER(10, 0, 17763)
+#define CONPTY_FIRST_SUPPORT_BUILD  MAKE_VER(10, 0, 17763)
+#define CONPTY_STABLE_BUILD	    MAKE_VER(10, 0, 32767)  // T.B.D.
 
     static void
 vtp_flag_init(void)
@@ -7659,10 +7662,10 @@ vtp_flag_init(void)
 	vtp_working = 0;
 #endif
 
-#ifdef FEAT_GUI_W32
     if (ver >= CONPTY_FIRST_SUPPORT_BUILD)
-	vtp_working = 1;
-#endif
+	conpty_working = 1;
+    if (ver >= CONPTY_STABLE_BUILD)
+	conpty_stable = 1;
 
 }
 
@@ -7877,4 +7880,16 @@ is_term_win32(void)
 has_vtp_working(void)
 {
     return vtp_working;
+}
+
+    int
+has_conpty_working(void)
+{
+    return conpty_working;
+}
+
+    int
+is_conpty_stable(void)
+{
+    return conpty_stable;
 }

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -70,7 +70,9 @@ void set_alist_count(void);
 void fix_arg_enc(void);
 int mch_setenv(char *var, char *value, int x);
 void control_console_color_rgb(void);
-int has_vtp_working(void);
 int use_vtp(void);
 int is_term_win32(void);
+int has_vtp_working(void);
+int has_conpty_working(void);
+int is_conpty_stable(void);
 /* vim: set ft=c : */

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -6139,7 +6139,7 @@ term_and_job_init(
 
     if (tty_type == NUL)
     {
-	if (has_conpty && is_conpty_stable())
+	if (has_conpty && (is_conpty_stable() || !has_winpty))
 	    use_conpty = TRUE;
 	else if (has_winpty)
 	    use_winpty = TRUE;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -5521,7 +5521,7 @@ dyn_conpty_init(int verbose)
     if (handled)
 	return result;
 
-    if (!has_vtp_working())
+    if (!has_conpty_working())
     {
 	handled = TRUE;
 	result = FAIL;
@@ -6139,7 +6139,7 @@ term_and_job_init(
 
     if (tty_type == NUL)
     {
-	if (has_conpty)
+	if (has_conpty && is_conpty_stable())
 	    use_conpty = TRUE;
 	else if (has_winpty)
 	    use_winpty = TRUE;


### PR DESCRIPTION
This is an alternative solution for #3946.
I think that the current version of ConPTY is still unstable especially for CJK users. So, I think that the default pty type should be winpty for now.
My proposal is:

* Keep the default value of 'termwintype' as "".
* If 'termwintype' is "" and if ConPTY is considered stable (Win10 1903? or later), use ConPTY.
* If 'termwintype' is "" and if ConPTY is considered unstable (1809), use winpty.
* If 'termwintype' is "" and if ConPTY is not available (before 1809), use winpty.
* If 'termwintype' is "conpty", use ConPTY even if it is unstable (1809).
* If 'termwintype' is "winpty", use winpty.

I also found a bug in the version detection of ConPTY in vim.exe.
It wrongly detects that Win10 1703 supports ConPTY, because `dyn_conpty_init()` uses `has_vtp_working()` to detect the Windows version. I created a new function `has_conpty_working()` to properly detect the availability of ConPTY.

Note: The definition of `CONPTY_STABLE_BUILD` should be updated when the next version of Windows 10 is released.