### PR TITLE
Allow default expressions for named arguments

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10608,7 +10608,7 @@ call, not definition.  Thus it is possible to use invalid expressions which
 are not immediately checked.  The expressions are are also only evaluated
 when arguments are not specified during a call.
 
-								*E982*
+								*E983*
 Optional arguments with default expressions must occur after any mandatory
 arguments.  You can use "..." after all optional named arguments.
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10591,9 +10591,40 @@ change their contents.  Thus you can pass a |List| to a function and have the
 function add an item to it.  If you want to make sure the function cannot
 change a |List| or |Dictionary| use |:lockvar|.
 
+You can provide default values for positional named arguments.  This makes
+them optional for function calls.  When a positional argument is not
+specified at a call, the default expression is used to initialize it.
+This only works for functions declared with |function|, not for lambda
+expressions |expr-lambda|.
+
+Example: >
+  :function Something(mandatory, optional = 10)
+  :endfunction
+  :call Something(10)	" OK
+<
+
+The argument default expressions are evaluated at the time of the function
+call, not definition.  Thus it is possible to use invalid expressions which
+are not immediately checked.  The expressions are are also only evaluated
+when arguments are not specified during a call.
+
+								*E982*
+Optional arguments with default expressions must occur after any mandatory
+arguments.  You can mix optional arguments and "...".
+
+It is possible for later argument defaults to refer to prior arguments,
+but not the other way around.
+
+Example: >
+  :function Okay(mandatory, optional = a:mandatory)
+  :endfunction
+  :function NoGood(mandatory = a:optional, optional = a:mandatory)
+  :endfunction
+<
+
 When not using "...", the number of arguments in a function call must be equal
-to the number of named arguments.  When using "...", the number of arguments
-may be larger.
+to the number of mandatory named arguments.  When using "...", the number of
+arguments may be larger.
 
 It is also possible to define a function without any arguments.  You must
 still supply the () then.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10608,6 +10608,15 @@ call, not definition.  Thus it is possible to use invalid expressions which
 are not immediately checked.  The expressions are are also only evaluated
 when arguments are not specified during a call.
 
+You can omit an argument and use its default expression using |v:none|.
+Note that this means you cannot pass v:none as an ordinary value when an
+argument has a default expression.
+
+Example: >
+  :function Something(a = 10, b = 20, c = 30)
+  :endfunction
+  :call Something(1, v:none, 3)	    " b = 20
+<
 								*E983*
 Optional arguments with default expressions must occur after any mandatory
 arguments.  You can use "..." after all optional named arguments.
@@ -10621,7 +10630,6 @@ Example: >
   :function NoGood(mandatory = a:optional, optional = a:mandatory)
   :endfunction
 <
-
 When not using "...", the number of arguments in a function call must be equal
 to the number of mandatory named arguments.  When using "...", the number of
 arguments may be larger.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10610,10 +10610,10 @@ when arguments are not specified during a call.
 
 								*E982*
 Optional arguments with default expressions must occur after any mandatory
-arguments.  You can mix optional arguments and "...".
+arguments.  You can use "..." after all optional named arguments.
 
 It is possible for later argument defaults to refer to prior arguments,
-but not the other way around.
+but not the other way around.  They must be prefixed with "a:".
 
 Example: >
   :function Okay(mandatory, optional = a:mandatory)

--- a/src/structs.h
+++ b/src/structs.h
@@ -1404,6 +1404,7 @@ typedef struct
     int		uf_calls;	/* nr of active calls */
     int		uf_cleared;	/* func_clear() was already called */
     garray_T	uf_args;	/* arguments */
+    garray_T	uf_def_args;	/* default argument expressions */
     garray_T	uf_lines;	/* function lines */
 # ifdef FEAT_PROFILE
     int		uf_profiling;	/* TRUE when func is being profiled */

--- a/src/testdir/test_user_func.vim
+++ b/src/testdir/test_user_func.vim
@@ -119,7 +119,7 @@ func Test_default_arg()
   call assert_equal(b['0'], 0)
   call assert_equal(c['0'], 1)
   call assert_equal(a.optional, v:null)
-  call assert_fails("call MakeBadFunc()", 'E982')
+  call assert_fails("call MakeBadFunc()", 'E983')
   call assert_fails("fu F(a=1 ,) | endf", 'E475')
   delfunc Log
   delfunc Args

--- a/src/testdir/test_user_func.vim
+++ b/src/testdir/test_user_func.vim
@@ -103,6 +103,10 @@ func Args(mandatory, optional = v:null, ...)
   return deepcopy(a:)
 endfunc
 
+func Args2(a = 1, b = 2, c = 3)
+  return deepcopy(a:)
+endfunc
+
 func MakeBadFunc()
   func s:fcn(a,b=1,c)
   endfunc
@@ -121,7 +125,10 @@ func Test_default_arg()
   call assert_equal(a.optional, v:null)
   call assert_fails("call MakeBadFunc()", 'E983')
   call assert_fails("fu F(a=1 ,) | endf", 'E475')
+  let d = Args2(7,v:none,9)
+  call assert_equal([d.a, d.b, d.c], [7, 2, 9])
   delfunc Log
   delfunc Args
+  delfunc Args2
   delfunc MakeBadFunc
 endfunc

--- a/src/testdir/test_user_func.vim
+++ b/src/testdir/test_user_func.vim
@@ -120,4 +120,8 @@ func Test_default_arg()
   call assert_equal(c['0'], 1)
   call assert_equal(a.optional, v:null)
   call assert_fails("call MakeBadFunc()", 'E982')
+  call assert_fails("fu F(a=1 ,) | endf", 'E475')
+  delfunc Log
+  delfunc Args
+  delfunc MakeBadFunc
 endfunc

--- a/src/testdir/test_user_func.vim
+++ b/src/testdir/test_user_func.vim
@@ -94,3 +94,30 @@ func Test_user_func()
   unlet g:retval g:counter
   enew!
 endfunc
+
+func Log(val, base = 10)
+  return log(a:val) / log(a:base)
+endfunc
+
+func Args(mandatory, optional = v:null, ...)
+  return deepcopy(a:)
+endfunc
+
+func MakeBadFunc()
+  func s:fcn(a,b=1,c)
+  endfunc
+endfunc
+
+func Test_default_arg()
+  call Log(1)
+  call Log(1, exp(1))
+  call assert_fails("call Log(1,2,3)", 'E118')
+  let a = Args(1)
+  let b = Args(1,2)
+  let c = Args(1,2,3)
+  call assert_equal(a['0'], 0)
+  call assert_equal(b['0'], 0)
+  call assert_equal(c['0'], 1)
+  call assert_equal(a.optional, v:null)
+  call assert_fails("call MakeBadFunc()", 'E982')
+endfunc

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -186,7 +186,7 @@ get_function_args(
 	    }
 	    else if (any_default)
 	    {
-		emsg(_("E982: Non-default argument follows default argument"));
+		emsg(_("E983: Non-default argument follows default argument"));
 		mustend = TRUE;
 	    }
 	    if (*p == ',')

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -83,6 +83,7 @@ get_function_args(
     char_u	endchar,
     garray_T	*newargs,
     int		*varargs,
+    garray_T	*default_args,
     int		skip)
 {
     int		mustend = FALSE;
@@ -90,9 +91,13 @@ get_function_args(
     char_u	*p = arg;
     int		c;
     int		i;
+    int		any_default = FALSE;
+    char_u	*expr;
 
     if (newargs != NULL)
 	ga_init2(newargs, (int)sizeof(char_u *), 3);
+    if (default_args != NULL)
+	ga_init2(default_args, (int)sizeof(char_u *), 3);
 
     if (varargs != NULL)
 	*varargs = FALSE;
@@ -147,6 +152,40 @@ get_function_args(
 		newargs->ga_len++;
 
 		*p = c;
+	    }
+	    if (*skipwhite(p) == '=')
+	    {
+		typval_T	rettv;
+		any_default = TRUE;
+		p = skipwhite(p) + 1;
+		p = skipwhite(p);
+		expr = p;
+		if (eval1(&p, &rettv, FALSE) != FAIL)
+		{
+		    if (default_args != NULL && ga_grow(default_args, 1) == FAIL)
+			goto err_ret;
+		    if (default_args != NULL)
+		    {
+			c = *p;
+			*p = NUL;
+			expr = vim_strsave(expr);
+			if (expr == NULL)
+			{
+			    *p = c;
+			    goto err_ret;
+			}
+			((char_u **)(default_args->ga_data))[default_args->ga_len] = expr;
+			default_args->ga_len++;
+			*p = c;
+		    }
+		}
+		else
+		    mustend = TRUE;
+	    }
+	    else if (any_default)
+	    {
+		emsg(_("E982: Non-default argument follows default argument"));
+		mustend = TRUE;
 	    }
 	    if (*p == ',')
 		++p;
@@ -217,7 +256,7 @@ get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate)
     ga_init(&newlines);
 
     /* First, check if this is a lambda expression. "->" must exist. */
-    ret = get_function_args(&start, '-', NULL, NULL, TRUE);
+    ret = get_function_args(&start, '-', NULL, NULL, NULL, TRUE);
     if (ret == FAIL || *start != '>')
 	return NOTDONE;
 
@@ -227,7 +266,7 @@ get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate)
     else
 	pnewargs = NULL;
     *arg = skipwhite(*arg + 1);
-    ret = get_function_args(arg, '-', pnewargs, &varargs, FALSE);
+    ret = get_function_args(arg, '-', pnewargs, &varargs, NULL, FALSE);
     if (ret == FAIL || **arg != '>')
 	goto errret;
 
@@ -283,6 +322,7 @@ get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate)
 	STRCPY(fp->uf_name, name);
 	hash_add(&func_hashtab, UF2HIKEY(fp));
 	fp->uf_args = newargs;
+	ga_init(&fp->uf_def_args);
 	fp->uf_lines = newlines;
 	if (current_funccal != NULL && eval_lavars)
 	{
@@ -706,6 +746,7 @@ call_user_func(
     int		using_sandbox = FALSE;
     funccall_T	*fc;
     int		save_did_emsg;
+    int		default_arg_err = FALSE;
     static int	depth = 0;
     dictitem_T	*v;
     int		fixvar_idx = 0;	/* index in fixvar[] */
@@ -782,12 +823,13 @@ call_user_func(
 
     /*
      * Init a: variables.
-     * Set a:0 to "argcount".
+     * Set a:0 to "argcount" less number of named arguments, if >= 0.
      * Set a:000 to a list with room for the "..." arguments.
      */
     init_var_dict(&fc->l_avars, &fc->l_avars_var, VAR_SCOPE);
     add_nr_var(&fc->l_avars, &fc->fixvar[fixvar_idx++].var, "0",
-				(varnumber_T)(argcount - fp->uf_args.ga_len));
+				(varnumber_T)(argcount >= fp->uf_args.ga_len
+				    ? argcount - fp->uf_args.ga_len : 0));
     fc->l_avars.dv_lock = VAR_FIXED;
     /* Use "name" to avoid a warning from some compiler that checks the
      * destination size. */
@@ -812,9 +854,10 @@ call_user_func(
 						      (varnumber_T)firstline);
     add_nr_var(&fc->l_avars, &fc->fixvar[fixvar_idx++].var, "lastline",
 						       (varnumber_T)lastline);
-    for (i = 0; i < argcount; ++i)
+    for (i = 0; i < argcount || i < fp->uf_args.ga_len; ++i)
     {
 	int	    addlocal = FALSE;
+	typval_T    def_rettv;
 
 	ai = i - fp->uf_args.ga_len;
 	if (ai < 0)
@@ -823,6 +866,22 @@ call_user_func(
 	    name = FUNCARG(fp, i);
 	    if (islambda)
 		addlocal = TRUE;
+
+	    // evaluate named argument default expression
+	    if (ai + fp->uf_def_args.ga_len >= 0 && i >= argcount)
+	    {
+		char_u	    *default_expr = NULL;
+		def_rettv.v_type = VAR_NUMBER;
+		def_rettv.vval.v_number = -1;
+
+		default_expr = ((char_u **)(fp->uf_def_args.ga_data))
+						 [ai + fp->uf_def_args.ga_len];
+		if (eval1(&default_expr, &def_rettv, TRUE) == FAIL)
+		{
+		    default_arg_err = 1;
+		    break;
+		}
+	    }
 	}
 	else
 	{
@@ -845,9 +904,12 @@ call_user_func(
 	}
 	STRCPY(v->di_key, name);
 
-	/* Note: the values are copied directly to avoid alloc/free.
-	 * "argvars" must have VAR_FIXED for v_lock. */
-	v->di_tv = argvars[i];
+	if (i < argcount)
+	    /* Note: the values are copied directly to avoid alloc/free.
+	     * "argvars" must have VAR_FIXED for v_lock. */
+	    v->di_tv = argvars[i];
+	else
+	    v->di_tv = def_rettv;
 	v->di_tv.v_lock = VAR_FIXED;
 
 	if (addlocal)
@@ -964,8 +1026,11 @@ call_user_func(
     save_did_emsg = did_emsg;
     did_emsg = FALSE;
 
-    /* call do_cmdline() to execute the lines */
-    do_cmdline(NULL, get_func_line, (void *)fc,
+    if (default_arg_err && (fp->uf_flags & FC_ABORT))
+	did_emsg = TRUE;
+    else
+	/* call do_cmdline() to execute the lines */
+	do_cmdline(NULL, get_func_line, (void *)fc,
 				     DOCMD_NOWAIT|DOCMD_VERBOSE|DOCMD_REPEAT);
 
     --RedrawingDisabled;
@@ -1121,6 +1186,7 @@ func_remove(ufunc_T *fp)
 func_clear_items(ufunc_T *fp)
 {
     ga_clear_strings(&(fp->uf_args));
+    ga_clear_strings(&(fp->uf_def_args));
     ga_clear_strings(&(fp->uf_lines));
 #ifdef FEAT_PROFILE
     vim_free(fp->uf_tml_count);
@@ -1474,7 +1540,7 @@ call_func(
 
 		if (fp->uf_flags & FC_RANGE)
 		    *doesrange = TRUE;
-		if (argcount < fp->uf_args.ga_len)
+		if (argcount < fp->uf_args.ga_len - fp->uf_def_args.ga_len)
 		    error = ERROR_TOOFEW;
 		else if (!fp->uf_varargs && argcount > fp->uf_args.ga_len)
 		    error = ERROR_TOOMANY;
@@ -1865,6 +1931,7 @@ ex_function(exarg_T *eap)
     char_u	*arg;
     char_u	*line_arg = NULL;
     garray_T	newargs;
+    garray_T	default_args;
     garray_T	newlines;
     int		varargs = FALSE;
     int		flags = 0;
@@ -2079,7 +2146,8 @@ ex_function(exarg_T *eap)
 	    emsg(_("E862: Cannot use g: here"));
     }
 
-    if (get_function_args(&p, ')', &newargs, &varargs, eap->skip) == FAIL)
+    if (get_function_args(&p, ')', &newargs, &varargs,
+					    &default_args, eap->skip) == FAIL)
 	goto errret_2;
 
     /* find extra arguments "range", "dict", "abort" and "closure" */
@@ -2487,6 +2555,7 @@ ex_function(exarg_T *eap)
 	fp->uf_refcount = 1;
     }
     fp->uf_args = newargs;
+    fp->uf_def_args = default_args;
     fp->uf_lines = newlines;
     if ((flags & FC_CLOSURE) != 0)
     {
@@ -2511,6 +2580,7 @@ ex_function(exarg_T *eap)
 
 erret:
     ga_clear_strings(&newargs);
+    ga_clear_strings(&default_args);
 errret_2:
     ga_clear_strings(&newlines);
 ret_free:

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -862,6 +862,7 @@ call_user_func(
     {
 	int	    addlocal = FALSE;
 	typval_T    def_rettv;
+	int	    isdefault = FALSE;
 
 	ai = i - fp->uf_args.ga_len;
 	if (ai < 0)
@@ -872,7 +873,10 @@ call_user_func(
 		addlocal = TRUE;
 
 	    // evaluate named argument default expression
-	    if (ai + fp->uf_def_args.ga_len >= 0 && i >= argcount)
+	    isdefault = ai + fp->uf_def_args.ga_len >= 0
+		       && (i >= argcount || argvars[i].v_type == VAR_SPECIAL
+				   && argvars[i].vval.v_number == VVAL_NONE);
+	    if (isdefault)
 	    {
 		char_u	    *default_expr = NULL;
 		def_rettv.v_type = VAR_NUMBER;
@@ -908,12 +912,12 @@ call_user_func(
 	}
 	STRCPY(v->di_key, name);
 
-	if (i < argcount)
+	if (isdefault)
+	    v->di_tv = def_rettv;
+	else
 	    /* Note: the values are copied directly to avoid alloc/free.
 	     * "argvars" must have VAR_FIXED for v_lock. */
 	    v->di_tv = argvars[i];
-	else
-	    v->di_tv = def_rettv;
 	v->di_tv.v_lock = VAR_FIXED;
 
 	if (addlocal)


### PR DESCRIPTION
This is my stab at optional arguments, adding the ability to use default expressions for named arguments when using `function` (mentioned in todo.txt).

        e.g., func Func(mandatory, optional = 10 + 20, other = a:optional)

The expressions are evaluated each time at call time, like in ruby.  So it is possible to declare a function with invalid expressions which are only detected at call, or use expressions with side-effects.

Few possible remaining issues:
    - Does not work for lambdas.  I'm not sure this should be allowed at all.
    - `func Func(arg = g:global)` works but `func Func(arg1 = global)` doesn't (might be a good thing).
    - Errors that occur in the default expressions do not appear to be reported as happening "inside the function."  This was intentional because arguments are evaluated, then allocated in the order they appear, so one can't refer circularly.  Thus,

    function! Func(arg1 = error, arg2 = 10)
        echo arg2
    endfunction

gives

    E121: Undefined variable: error
    Error detected while processing function Func:
    line    1:
    E121: Undefined variable: arg2

This reporting could probably be altered with some more work if it makes sense semantically.  Note that "abort" does already work as expected.

