### PR TITLE
Remove USE_CR

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3134,9 +3134,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	is read.
 
 					*'fileformat'* *'ff'*
-'fileformat' 'ff'	string (MS-DOS, MS-Windows, OS/2 default: "dos",
-				Unix default: "unix",
-				Macintosh default: "mac")
+'fileformat' 'ff'	string (MS-Windows default: "dos",
+				Unix, macOS default: "unix")
 			local to buffer
 			{not in Vi}
 	This gives the <EOL> of the current buffer, which is used for
@@ -3159,9 +3158,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 					*'fileformats'* *'ffs'*
 'fileformats' 'ffs'	string (default:
-				Vim+Vi	MS-DOS, MS-Windows OS/2: "dos,unix",
-				Vim	Unix: "unix,dos",
-				Vim	Mac: "mac,unix,dos",
+				Vim+Vi	MS-Windows: "dos,unix",
+				Vim	Unix, macOS: "unix,dos",
 				Vi	Cygwin: "unix,dos",
 				Vi	others: "")
 			global

--- a/src/diff.c
+++ b/src/diff.c
@@ -90,9 +90,7 @@ static int parse_diff_ed(char_u *line, linenr_T *lnum_orig, long *count_orig, li
 static int parse_diff_unified(char_u *line, linenr_T *lnum_orig, long *count_orig, linenr_T *lnum_new, long *count_new);
 static int xdiff_out(void *priv, mmbuffer_t *mb, int nbuf);
 
-#ifndef USE_CR
-# define tag_fgets vim_fgets
-#endif
+#define tag_fgets vim_fgets
 
 /*
  * Called when deleting or unloading a buffer: No longer make a diff with it.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -13431,20 +13431,7 @@ get_cmd_output_as_rettv(
     else
     {
 	res = get_cmd_output(tv_get_string(&argvars[0]), infile, flags, NULL);
-#ifdef USE_CR
-	/* translate <CR> into <NL> */
-	if (res != NULL)
-	{
-	    char_u	*s;
-
-	    for (s = res; *s; ++s)
-	    {
-		if (*s == CAR)
-		    *s = NL;
-	    }
-	}
-#else
-# ifdef USE_CRNL
+#ifdef USE_CRNL
 	/* translate <CR><NL> into <NL> */
 	if (res != NULL)
 	{
@@ -13459,7 +13446,6 @@ get_cmd_output_as_rettv(
 	    }
 	    *d = NUL;
 	}
-# endif
 #endif
 	rettv->vval.v_string = res;
 	res = NULL;

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -4243,7 +4243,7 @@ struct source_cookie
     FILE	*fp;		/* opened file for sourcing */
     char_u      *nextline;      /* if not NULL: line that was read ahead */
     int		finished;	/* ":finish" used */
-#if defined(USE_CRNL) || defined(USE_CR)
+#ifdef USE_CRNL
     int		fileformat;	/* EOL_UNKNOWN, EOL_UNIX or EOL_DOS */
     int		error;		/* TRUE if LF found after CR-LF */
 #endif
@@ -4460,15 +4460,6 @@ do_source(
     /* If no automatic file format: Set default to CR-NL. */
     if (*p_ffs == NUL)
 	cookie.fileformat = EOL_DOS;
-    else
-	cookie.fileformat = EOL_UNKNOWN;
-    cookie.error = FALSE;
-#endif
-
-#ifdef USE_CR
-    /* If no automatic file format: Set default to CR. */
-    if (*p_ffs == NUL)
-	cookie.fileformat = EOL_MAC;
     else
 	cookie.fileformat = EOL_UNKNOWN;
     cookie.error = FALSE;
@@ -4768,59 +4759,6 @@ free_scriptnames(void)
 
 #endif
 
-#if defined(USE_CR) || defined(PROTO)
-
-# if defined(__MSL__) && (__MSL__ >= 22)
-/*
- * Newer version of the Metrowerks library handle DOS and UNIX files
- * without help.
- * Test with earlier versions, MSL 2.2 is the library supplied with
- * Codewarrior Pro 2.
- */
-    char *
-fgets_cr(char *s, int n, FILE *stream)
-{
-    return fgets(s, n, stream);
-}
-# else
-/*
- * Version of fgets() which also works for lines ending in a <CR> only
- * (Macintosh format).
- * For older versions of the Metrowerks library.
- * At least CodeWarrior 9 needed this code.
- */
-    char *
-fgets_cr(char *s, int n, FILE *stream)
-{
-    int	c = 0;
-    int char_read = 0;
-
-    while (!feof(stream) && c != '\r' && c != '\n' && char_read < n - 1)
-    {
-	c = fgetc(stream);
-	s[char_read++] = c;
-	/* If the file is in DOS format, we need to skip a NL after a CR.  I
-	 * thought it was the other way around, but this appears to work... */
-	if (c == '\n')
-	{
-	    c = fgetc(stream);
-	    if (c != '\r')
-		ungetc(c, stream);
-	}
-    }
-
-    s[char_read] = 0;
-    if (char_read == 0)
-	return NULL;
-
-    if (feof(stream) && char_read == 1)
-	return NULL;
-
-    return s;
-}
-# endif
-#endif
-
 /*
  * Get one full line from a sourced file.
  * Called by do_cmdline() when it's called from do_source().
@@ -4954,9 +4892,6 @@ get_one_sourceline(struct source_cookie *sp)
 #ifdef USE_CRNL
     int			has_cr;		/* CR-LF found */
 #endif
-#ifdef USE_CR
-    char_u		*scan;
-#endif
     int			have_read = FALSE;
 
     /* use a growarray to store the sourced line */
@@ -4973,18 +4908,9 @@ get_one_sourceline(struct source_cookie *sp)
 	    break;
 	buf = (char_u *)ga.ga_data;
 
-#ifdef USE_CR
-	if (sp->fileformat == EOL_MAC)
-	{
-	    if (fgets_cr((char *)buf + ga.ga_len, ga.ga_maxlen - ga.ga_len,
+	if (fgets((char *)buf + ga.ga_len, ga.ga_maxlen - ga.ga_len,
 							      sp->fp) == NULL)
-		break;
-	}
-	else
-#endif
-	    if (fgets((char *)buf + ga.ga_len, ga.ga_maxlen - ga.ga_len,
-							      sp->fp) == NULL)
-		break;
+	    break;
 	len = ga.ga_len + (int)STRLEN(buf + ga.ga_len);
 #ifdef USE_CRNL
 	/* Ignore a trailing CTRL-Z, when in Dos mode.	Only recognize the
@@ -4995,34 +4921,6 @@ get_one_sourceline(struct source_cookie *sp)
 	{
 	    buf[len - 1] = NUL;
 	    break;
-	}
-#endif
-
-#ifdef USE_CR
-	/* If the read doesn't stop on a new line, and there's
-	 * some CR then we assume a Mac format */
-	if (sp->fileformat == EOL_UNKNOWN)
-	{
-	    if (buf[len - 1] != '\n' && vim_strchr(buf, '\r') != NULL)
-		sp->fileformat = EOL_MAC;
-	    else
-		sp->fileformat = EOL_UNIX;
-	}
-
-	if (sp->fileformat == EOL_MAC)
-	{
-	    scan = vim_strchr(buf, '\r');
-
-	    if (scan != NULL)
-	    {
-		*scan = '\n';
-		if (*(scan + 1) != 0)
-		{
-		    *(scan + 1) = 0;
-		    fseek(sp->fp, (long)(scan - buf - len + 1), SEEK_CUR);
-		}
-	    }
-	    len = STRLEN(buf);
 	}
 #endif
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5197,14 +5197,12 @@ msg_add_fileformat(int eol_type)
 	return TRUE;
     }
 #endif
-#ifndef USE_CR
     if (eol_type == EOL_MAC)
     {
 	STRCAT(IObuff, shortmess(SHM_TEXT) ? _("[mac]") : _("[mac format]"));
 	return TRUE;
     }
-#endif
-#if defined(USE_CRNL) || defined(USE_CR)
+#ifdef USE_CRNL
     if (eol_type == EOL_UNIX)
     {
 	STRCAT(IObuff, shortmess(SHM_TEXT) ? _("[unix]") : _("[unix format]"));
@@ -6340,11 +6338,7 @@ vim_fgets(char_u *buf, int size, FILE *fp)
     char	tbuf[FGETS_SIZE];
 
     buf[size - 2] = NUL;
-#ifdef USE_CR
-    eof = fgets_cr((char *)buf, size, fp);
-#else
     eof = fgets((char *)buf, size, fp);
-#endif
     if (buf[size - 2] != NUL && buf[size - 2] != '\n')
     {
 	buf[size - 1] = NUL;	    /* Truncate the line */
@@ -6353,56 +6347,11 @@ vim_fgets(char_u *buf, int size, FILE *fp)
 	do
 	{
 	    tbuf[FGETS_SIZE - 2] = NUL;
-#ifdef USE_CR
-	    vim_ignoredp = fgets_cr((char *)tbuf, FGETS_SIZE, fp);
-#else
 	    vim_ignoredp = fgets((char *)tbuf, FGETS_SIZE, fp);
-#endif
 	} while (tbuf[FGETS_SIZE - 2] != NUL && tbuf[FGETS_SIZE - 2] != '\n');
     }
     return (eof == NULL);
 }
-
-#if defined(USE_CR) || defined(PROTO)
-/*
- * Like vim_fgets(), but accept any line terminator: CR, CR-LF or LF.
- * Returns TRUE for end-of-file.
- * Only used for the Mac, because it's much slower than vim_fgets().
- */
-    int
-tag_fgets(char_u *buf, int size, FILE *fp)
-{
-    int		i = 0;
-    int		c;
-    int		eof = FALSE;
-
-    for (;;)
-    {
-	c = fgetc(fp);
-	if (c == EOF)
-	{
-	    eof = TRUE;
-	    break;
-	}
-	if (c == '\r')
-	{
-	    /* Always store a NL for end-of-line. */
-	    if (i < size - 1)
-		buf[i++] = '\n';
-	    c = fgetc(fp);
-	    if (c != '\n')	/* Macintosh format: single CR. */
-		ungetc(c, fp);
-	    break;
-	}
-	if (i < size - 1)
-	    buf[i++] = c;
-	if (c == '\n')
-	    break;
-    }
-    buf[i] = NUL;
-    return eof;
-}
-#endif
 
 /*
  * rename() only works if both files are on the same file system, this

--- a/src/message.c
+++ b/src/message.c
@@ -2605,10 +2605,7 @@ msg_puts_printf(char_u *str, int maxlen)
 	    p = &buf[0];
 	    if (*s == '\n' && !info_message)
 		*p++ = '\r';
-#if defined(USE_CR)
-	    else
-#endif
-		*p++ = *s;
+	    *p++ = *s;
 	    *p = '\0';
 	    if (info_message)	/* informative message, not an error */
 		mch_msg((char *)buf);

--- a/src/ops.c
+++ b/src/ops.c
@@ -6577,11 +6577,7 @@ clip_convert_selection(char_u **str, long_u *len, VimClipboard *cbd)
 #ifdef USE_CRNL
 	    p[i++] = '\r';
 #endif
-#ifdef USE_CR
-	    p[i] = '\r';
-#else
 	    p[i] = '\n';
-#endif
 	    lnum++;
 	    j = -1;
 	}

--- a/src/option.h
+++ b/src/option.h
@@ -50,21 +50,14 @@
 # define DFLT_FFS_VI	"dos,unix"	/* also autodetect in compatible mode */
 # define DFLT_TEXTAUTO	TRUE
 #else
-# ifdef USE_CR
-#  define DFLT_FF	"mac"
-#  define DFLT_FFS_VIM	"mac,unix,dos"
-#  define DFLT_FFS_VI	"mac,unix,dos"
-#  define DFLT_TEXTAUTO	TRUE
+# define DFLT_FF	"unix"
+# define DFLT_FFS_VIM	"unix,dos"
+# ifdef __CYGWIN__
+#  define DFLT_FFS_VI	"unix,dos"	/* Cygwin always needs file detection */
+#  define DFLT_TEXTAUTO TRUE
 # else
-#  define DFLT_FF	"unix"
-#  define DFLT_FFS_VIM	"unix,dos"
-#  ifdef __CYGWIN__
-#   define DFLT_FFS_VI	"unix,dos"	/* Cygwin always needs file detection */
-#   define DFLT_TEXTAUTO TRUE
-#  else
-#   define DFLT_FFS_VI	""
-#   define DFLT_TEXTAUTO FALSE
-#  endif
+#  define DFLT_FFS_VI	""
+#  define DFLT_TEXTAUTO FALSE
 # endif
 #endif
 

--- a/src/proto/ex_cmds2.pro
+++ b/src/proto/ex_cmds2.pro
@@ -93,7 +93,6 @@ void ex_scriptnames(exarg_T *eap);
 void scriptnames_slash_adjust(void);
 char_u *get_scriptname(scid_T id);
 void free_scriptnames(void);
-char *fgets_cr(char *s, int n, FILE *stream);
 char_u *getsourceline(int c, void *cookie, int indent);
 void script_line_start(void);
 void script_line_exec(void);

--- a/src/proto/fileio.pro
+++ b/src/proto/fileio.pro
@@ -17,7 +17,6 @@ void shorten_filenames(char_u **fnames, int count);
 char_u *modname(char_u *fname, char_u *ext, int prepend_dot);
 char_u *buf_modname(int shortname, char_u *fname, char_u *ext, int prepend_dot);
 int vim_fgets(char_u *buf, int size, FILE *fp);
-int tag_fgets(char_u *buf, int size, FILE *fp);
 int vim_rename(char_u *from, char_u *to);
 int check_timestamps(int focus);
 int buf_check_timestamp(buf_T *buf, int focus);

--- a/src/tag.c
+++ b/src/tag.c
@@ -1146,13 +1146,8 @@ do_tags(exarg_T *eap UNUSED)
 	msg_puts("\n>");
 }
 
-/* When not using a CR for line separator, use vim_fgets() to read tag lines.
- * For the Mac use tag_fgets().  It can handle any line separator, but is much
- * slower than vim_fgets().
- */
-#ifndef USE_CR
-# define tag_fgets vim_fgets
-#endif
+// Use vim_fgets() to read tag lines.
+#define tag_fgets vim_fgets
 
 #ifdef FEAT_TAG_BINS
 /*


### PR DESCRIPTION
USE_CR was used for the old Macintosh, but it is not defined now.
Remove all of them.