### PR TITLE
Modify function-call cleanup

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -63,8 +63,8 @@ SCRIPTS_GUI =
 # Individual tests, including the ones part of test_alot.
 # Please keep sorted up to test_alot.
 NEW_TESTS = \
-	test_arglist \
 	test_arabic \
+	test_arglist \
 	test_assert \
 	test_assign \
 	test_autochdir \
@@ -108,11 +108,11 @@ NEW_TESTS = \
 	test_ex_equal \
 	test_ex_undo \
 	test_ex_z \
-	test_exit \
 	test_exec_while_if \
 	test_execute_func \
 	test_exists \
 	test_exists_autocmd \
+	test_exit \
 	test_expand \
 	test_expand_dllpath \
 	test_expand_func \
@@ -179,6 +179,7 @@ NEW_TESTS = \
 	test_match \
 	test_matchadd_conceal \
 	test_matchadd_conceal_utf8 \
+	test_memory_usage \
 	test_menu \
 	test_messages \
 	test_mksession \
@@ -354,6 +355,7 @@ NEW_TESTS_RES = \
 	test_maparg.res \
 	test_marks.res \
 	test_matchadd_conceal.res \
+	test_memory_usage.res \
 	test_mksession.res \
 	test_nested_function.res \
 	test_netbeans.res \

--- a/src/testdir/test_memory_usage.vim
+++ b/src/testdir/test_memory_usage.vim
@@ -1,0 +1,140 @@
+" Tests for memory usage.
+
+if !has('terminal') || has('gui_running')
+  finish
+endif
+
+source shared.vim
+
+func s:pick_nr(str) abort
+  return substitute(a:str, '[^0-9]', '', 'g') * 1
+endfunc
+
+if has('win32')
+  if !executable('wmic')
+    finish
+  endif
+  func s:memory_usage(pid) abort
+    let cmd = printf('wmic process where processid=%d get WorkingSetSize', a:pid)
+    return s:pick_nr(system(cmd)) / 1024
+  endfunc
+elseif has('unix')
+  if !executable('ps')
+    finish
+  endif
+  func s:memory_usage(pid) abort
+    return s:pick_nr(system('ps -o rss= -p ' . a:pid))
+  endfunc
+endif
+
+" Wait for memory usage to level off.
+func s:monitor_memory_usage(pid) abort
+  let proc = {}
+  let proc.pid = a:pid
+  let proc.hist = []
+  let proc.min = 0
+  let proc.max = 0
+
+  func proc.op() abort
+    " Check the last 200ms.
+    let val = s:memory_usage(self.pid)
+    if self.min > val
+      let self.min = val
+    elseif self.max < val
+      let self.max = val
+    endif
+    call add(self.hist, val)
+    if len(self.hist) < 20
+      return 0
+    endif
+    let sample = remove(self.hist, 0)
+    return len(uniq([sample] + self.hist)) == 1
+  endfunc
+
+  call WaitFor({-> proc.op()}, 10000)
+  return {'last': get(proc.hist, -1), 'min': proc.min, 'max': proc.max}
+endfunc
+
+let s:term_vim = {}
+
+func s:term_vim.start(...) abort
+  let self.buf = term_start([GetVimProg()] + a:000)
+  let self.job = term_getjob(self.buf)
+  call WaitFor({-> job_status(self.job) ==# 'run'})
+  let self.pid = job_info(self.job).process
+endfunc
+
+func s:term_vim.stop() abort
+  call term_sendkeys(self.buf, ":qall!\<CR>")
+  call WaitFor({-> job_status(self.job) ==# 'dead'})
+  exe self.buf . 'bwipe!'
+endfunc
+
+func s:vim_new() abort
+  return copy(s:term_vim)
+endfunc
+
+func Test_memory_func_capture_vargs()
+  " Case: if a local variable captures a:000, funccall object will be free
+  " just after it finishes.
+  let testfile = 'Xtest.vim'
+  call writefile([
+        \ 'func s:f(...)',
+        \ '  let x = a:000',
+        \ 'endfunc',
+        \ 'for _ in range(10000)',
+        \ '  call s:f(0)',
+        \ 'endfor',
+        \ ], testfile)
+
+  let vim = s:vim_new()
+  call vim.start('--clean', '-c', 'set noswapfile', testfile)
+  let before = s:monitor_memory_usage(vim.pid).last
+
+  call term_sendkeys(vim.buf, ":so %\<CR>")
+  call WaitFor({-> term_getcursor(vim.buf)[0] == 1})
+  let after = s:monitor_memory_usage(vim.pid)
+
+  " Estimate the limit of max usage as 2x initial usage.
+  call assert_inrange(before, 2 * before, after.max)
+  " In this case, garbase collecting is not needed.
+  call assert_equal(after.last, after.max)
+
+  call vim.stop()
+  call delete(testfile)
+endfunc
+
+func Test_memory_func_capture_lvars()
+  " Case: if a local variable captures l: dict, funccall object will not be
+  " free until garbage collector runs, but after that memory usage doesn't
+  " increase so much even when rerun Xtest.vim since system memory caches.
+  let testfile = 'Xtest.vim'
+  call writefile([
+        \ 'func s:f()',
+        \ '  let x = l:',
+        \ 'endfunc',
+        \ 'for _ in range(10000)',
+        \ '  call s:f()',
+        \ 'endfor',
+        \ ], testfile)
+
+  let vim = s:vim_new()
+  call vim.start('--clean', '-c', 'set noswapfile', testfile)
+  let before = s:monitor_memory_usage(vim.pid).last
+
+  call term_sendkeys(vim.buf, ":so %\<CR>")
+  call WaitFor({-> term_getcursor(vim.buf)[0] == 1})
+  let after = s:monitor_memory_usage(vim.pid)
+
+  " Rerun Xtest.vim.
+  for _ in range(3)
+    call term_sendkeys(vim.buf, ":so %\<CR>")
+    call WaitFor({-> term_getcursor(vim.buf)[0] == 1})
+    let last = s:monitor_memory_usage(vim.pid).last
+  endfor
+
+  call assert_inrange(before, after.max + (after.last - before), last)
+
+  call vim.stop()
+  call delete(testfile)
+endfunc

--- a/src/testdir/test_memory_usage.vim
+++ b/src/testdir/test_memory_usage.vim
@@ -1,6 +1,8 @@
 " Tests for memory usage.
 
-if !has('terminal') || has('gui_running')
+if !has('terminal') || has('gui_running') || $ASAN_OPTIONS !=# ''
+  " Skip tests on Travis CI ASAN build because it's difficult to estimate
+  " memory usage.
   finish
 endif
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -699,7 +699,10 @@ cleanup_function_call(funccall_T *fc)
 	fc->caller = previous_funccal;
 	previous_funccal = fc;
 
-	if (++made_copy == 10000)
+	if (want_garbage_collect)
+	    // If garbage collector is ready, clear count.
+	    made_copy = 0;
+	else if (++made_copy >= (4096 * 1024) / sizeof(*fc))
 	{
 	    // We have made a lot of copies.  This can happen when
 	    // repetitively calling a function that creates a reference to

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -757,7 +757,7 @@ call_user_func(
 
     line_breakcheck();		/* check for CTRL-C hit */
 
-    fc = (funccall_T *)alloc(sizeof(funccall_T));
+    fc = (funccall_T *)alloc_clear(sizeof(funccall_T));
     if (fc == NULL)
 	return;
     fc->caller = current_funccal;
@@ -858,16 +858,15 @@ call_user_func(
 	{
 	    v = &fc->fixvar[fixvar_idx++].var;
 	    v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
+	    STRCPY(v->di_key, name);
 	}
 	else
 	{
-	    v = (dictitem_T *)alloc((unsigned)(sizeof(dictitem_T)
-							     + STRLEN(name)));
+	    v = dictitem_alloc(name);
 	    if (v == NULL)
 		break;
-	    v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX | DI_FLAGS_ALLOC;
+	    v->di_flags |= DI_FLAGS_RO | DI_FLAGS_FIX;
 	}
-	STRCPY(v->di_key, name);
 
 	/* Note: the values are copied directly to avoid alloc/free.
 	 * "argvars" must have VAR_FIXED for v_lock. */


### PR DESCRIPTION
Ref: #3835

## Proposal

At the end of function call, if "funccall" object and its "l:" vars are not referred by anyone,
Vim may be able to free "a:", "a:000" vars, so and "funccall".

Therefore, this patch changes:

* In cleanup_function_call(), check the references of "l:", "a:", "a:000" separately and free each of them if can (or retain)

By doing this, in the case of #3835 "funccall" object can be freed just after its function ends,
so the memory usage doesn't gain almost and then needs no GC here.

## Confirmation

On Ubuntu 18.04.

test.vim
```vim
func s:f(...)
  let l:x = a:000
endfunc
for _ in range(100000)
  call s:f(0)
endfor
```

```
$ vim --clean test.vim
:so %
```

monitoring memory usage:

```
$ while :; do grep '^VmRSS' /proc/$(pgrep vim)/status; sleep 1; done
```

8.1.0918:
```
VmRSS:      8712 kB
VmRSS:      8712 kB
VmRSS:      8712 kB
VmRSS:    225716 kB    # do ":so %"
VmRSS:    225716 kB
VmRSS:    225716 kB
VmRSS:    225716 kB    # though GC was done, RSS doesn't decrease immediately because of cached
...
```

patched:
```
VmRSS:      8740 kB
VmRSS:      8740 kB
VmRSS:      8740 kB
VmRSS:     13224 kB    # do ":so %"
VmRSS:     13224 kB
VmRSS:     13224 kB
VmRSS:     13224 kB    # no change also after this
...
```