### PR TITLE
Test :wnext, :wNext and :wprevious

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -269,6 +269,7 @@ NEW_TESTS = \
 	test_window_cmd \
 	test_window_id \
 	test_windows_home \
+	test_wnext \
 	test_wordcount \
 	test_writefile \
 	test_xxd \

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -66,3 +66,4 @@ source test_true_false.vim
 source test_unlet.vim
 source test_virtualedit.vim
 source test_window_cmd.vim
+source test_wnext.vim

--- a/src/testdir/test_wnext.vim
+++ b/src/testdir/test_wnext.vim
@@ -1,0 +1,91 @@
+" Test :wnext :wNext and :wprevious
+
+func Test_wnext()
+  args X1 X2
+
+  call setline(1, '1')
+  wnext
+  call assert_equal(['1'], readfile('X1'))
+  call assert_equal('X2', bufname('%'))
+
+  call setline(1, '2')
+  call assert_fails('wnext', 'E165:')
+  call assert_equal(['2'], readfile('X2'))
+  call assert_equal('X2', bufname('%'))
+
+  " Test :wnext with a single file.
+  args X1
+  call assert_equal('X1', bufname('%'))
+  call assert_fails('wnext', 'E163:')
+
+  " Test :wnext with a count.
+  args X1 X2 X3
+  call assert_equal('X1', bufname('%'))
+  2wnext
+  call assert_equal('X3', bufname('%'))
+
+  " Test :wnext {file}.
+  args X1 X2 X3
+  wnext X4
+  call assert_equal(['1'], readfile('X4'))
+  call assert_equal('X2', bufname('%'))
+  call assert_fails('wnext X4', 'E13:')
+  call assert_equal(['1'], readfile('X4'))
+  wnext! X4
+  call assert_equal(['2'], readfile('X4'))
+  call assert_equal('X3', bufname('%'))
+
+  %bwipe!
+  call delete('X1')
+  call delete('X2')
+  call delete('X3')
+  call delete('X4')
+endfunc
+
+func Test_wprevious()
+  args X1 X2
+
+  next
+  call assert_equal('X2', bufname('%'))
+  call setline(1, '2')
+  wprevious
+  call assert_equal(['2'], readfile('X2'))
+  call assert_equal('X1', bufname('%'))
+
+  call setline(1, '1')
+  call assert_fails('wprevious', 'E164:')
+  call assert_fails('wNext', 'E164:')
+
+  " Test :wprevious with a single file.
+  args X1
+  call assert_fails('wprevious', 'E163:')
+  call assert_fails('wNext', 'E163:')
+
+  " Test :wprevious with a count.
+  args X1 X2 X3
+  2next
+  call setline(1, '3')
+  call assert_equal('X3', bufname('%'))
+  2wprevious
+  call assert_equal('X1', bufname('%'))
+  call assert_equal(['3'], readfile('X3'))
+
+  " Test :wprevious {file}
+  args X1 X2 X3
+  2next
+  call assert_equal('X3', bufname('%'))
+  wprevious X4
+  call assert_equal(['3'], readfile('X4'))
+  call assert_equal('X2', bufname('%'))
+  call assert_fails('wprevious X4', 'E13:')
+  call assert_equal(['3'], readfile('X4'))
+  wprevious! X4
+  call assert_equal(['2'], readfile('X4'))
+  call assert_equal('X1', bufname('%'))
+
+  %bwipe!
+  call delete('X1')
+  call delete('X2')
+  call delete('X3')
+  call delete('X4')
+endfunc

--- a/src/testdir/test_wnext.vim
+++ b/src/testdir/test_wnext.vim
@@ -35,9 +35,10 @@ func Test_wnext()
   call assert_equal(['2'], readfile('X4'))
   call assert_equal('X3', bufname('%'))
 
-  args X1 X2
-  call assert_fails('wnext .', 'E17:')
-  call assert_fails('wnext! .', 'E502:')
+  " Commented out as, E13 occurs on Windows instead of E17
+  "args X1 X2
+  "call assert_fails('wnext .', 'E17:')
+  "call assert_fails('wnext! .', 'E502:')
 
   %bwipe!
   call delete('X1')
@@ -87,9 +88,10 @@ func Test_wprevious()
   call assert_equal(['2'], readfile('X4'))
   call assert_equal('X1', bufname('%'))
 
-  args X1 X2
-  call assert_fails('wprevious .', 'E17:')
-  call assert_fails('wprevious! .', 'E502:')
+  " Commented out as, E13 occurs on Windows instead of E17
+  "args X1 X2
+  "call assert_fails('wprevious .', 'E17:')
+  "call assert_fails('wprevious! .', 'E502:')
 
   %bwipe!
   call delete('X1')

--- a/src/testdir/test_wnext.vim
+++ b/src/testdir/test_wnext.vim
@@ -35,10 +35,10 @@ func Test_wnext()
   call assert_equal(['2'], readfile('X4'))
   call assert_equal('X3', bufname('%'))
 
+  args X1 X2
   " Commented out as, E13 occurs on Windows instead of E17
-  "args X1 X2
   "call assert_fails('wnext .', 'E17:')
-  "call assert_fails('wnext! .', 'E502:')
+  call assert_fails('wnext! .', 'E502:')
 
   %bwipe!
   call delete('X1')
@@ -88,10 +88,10 @@ func Test_wprevious()
   call assert_equal(['2'], readfile('X4'))
   call assert_equal('X1', bufname('%'))
 
+  args X1 X2
   " Commented out as, E13 occurs on Windows instead of E17
-  "args X1 X2
   "call assert_fails('wprevious .', 'E17:')
-  "call assert_fails('wprevious! .', 'E502:')
+  call assert_fails('wprevious! .', 'E502:')
 
   %bwipe!
   call delete('X1')

--- a/src/testdir/test_wnext.vim
+++ b/src/testdir/test_wnext.vim
@@ -35,6 +35,10 @@ func Test_wnext()
   call assert_equal(['2'], readfile('X4'))
   call assert_equal('X3', bufname('%'))
 
+  args X1 X2
+  call assert_fails('wnext .', 'E17:')
+  call assert_fails('wnext! .', 'E502:')
+
   %bwipe!
   call delete('X1')
   call delete('X2')
@@ -82,6 +86,10 @@ func Test_wprevious()
   wprevious! X4
   call assert_equal(['2'], readfile('X4'))
   call assert_equal('X1', bufname('%'))
+
+  args X1 X2
+  call assert_fails('wprevious .', 'E17:')
+  call assert_fails('wprevious! .', 'E502:')
 
   %bwipe!
   call delete('X1')


### PR DESCRIPTION
This PR adds tests for `:wnext`, `:wNext` and `:wprevious` which were not yet covered according to codecov:

https://codecov.io/gh/vim/vim/src/9b5c1fcdeae75f82a2083fafbbf75ab220f6ac1e/src/ex_cmds.c#L3483