### PR TITLE
Add error E982 when ConPTY is not available.

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -413,7 +413,7 @@ Just put the files somewhere in your PATH.  You can set the 'winptydll' option
 to point to the right file, if needed.  If you have both the 32-bit and 64-bit
 version, rename to winpty32.dll and winpty64.dll to match the way Vim was
 build.
-							*ConPTY*
+							*ConPTY* *E982*
 On more recent versions of MS-Windows 10 (beginning with the "October 2018
 Update"), winpty is no longer required. On those versions, |:terminal| will use
 Windows' built-in support for hosting terminal applications, "ConPTY".  When

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -5620,9 +5620,7 @@ void (WINAPI *pDeleteProcThreadAttributeList)(LPPROC_THREAD_ATTRIBUTE_LIST);
     static int
 dyn_conpty_init(int verbose)
 {
-    static BOOL	handled = FALSE;
-    static int	result;
-    HMODULE	hKerneldll;
+    static HMODULE	hKerneldll = NULL;
     int		i;
     static struct
     {
@@ -5642,15 +5640,16 @@ dyn_conpty_init(int verbose)
 	{NULL, NULL}
     };
 
-    if (handled)
-	return result;
-
     if (!has_conpty_working())
     {
-	handled = TRUE;
-	result = FAIL;
+	if (verbose)
+	    emsg(_("E982: ConPTY is not available"));
 	return FAIL;
     }
+
+    // No need to initialize twice.
+    if (hKerneldll)
+	return OK;
 
     hKerneldll = vimLoadLib("kernel32.dll");
     for (i = 0; conpty_entry[i].name != NULL
@@ -5661,12 +5660,11 @@ dyn_conpty_init(int verbose)
 	{
 	    if (verbose)
 		semsg(_(e_loadfunc), conpty_entry[i].name);
+	    hKerneldll = NULL;
 	    return FAIL;
 	}
     }
 
-    handled = TRUE;
-    result = OK;
     return OK;
 }
 
@@ -6015,6 +6013,7 @@ dyn_winpty_init(int verbose)
 	{
 	    if (verbose)
 		semsg(_(e_loadfunc), winpty_entry[i].name);
+	    hWinPtyDLL = NULL;
 	    return FAIL;
 	}
     }


### PR DESCRIPTION
Hi,

How to reproduce (on Windows where ConPTY is not available and WinPTY is available):
```
> vim --clean
:term ++type=conpty
```

Expected behavior:
- Terminal window is not opened and an error message is displayed. (I think)

Actual behavior:
- Terminal window is not opened. But No error message is displayed.


I added E982 error.

--
Best regards,
Hirohito Higashi (h_east)