### PR TITLE
Fixed several incorrect printf format in nbdebug(...) calls

### DIFF
--- a/src/nbdebug.h
+++ b/src/nbdebug.h
@@ -42,7 +42,11 @@ typedef enum {
 } WtWait;
 
 
-void		 nbdbg(char *, ...);
+void		 nbdbg(char *, ...)
+#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+   __attribute__((format(printf, 1, 2)))
+#endif
+;
 
 void nbdebug_wait(u_int wait_flags, char *wait_var, u_int wait_secs);
 void nbdebug_log_init(char *log_var, char *level_var);

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -934,7 +934,7 @@ nb_partialremove(linenr_T lnum, colnr_T first, colnr_T last)
     {
 	mch_memmove(newtext, oldtext, first);
 	STRMOVE(newtext + first, oldtext + lastbyte + 1);
-	nbdebug(("    NEW LINE %d: %s\n", lnum, newtext));
+	nbdebug(("    NEW LINE %ld: %s\n", lnum, newtext));
 	ml_replace(lnum, newtext, FALSE);
     }
 }
@@ -1166,7 +1166,7 @@ nb_do_cmd(
 		    return FAIL;
 		}
 		first = *pos;
-		nbdebug(("    FIRST POS: line %d, col %d\n",
+		nbdebug(("    FIRST POS: line %ld, col %d\n",
 						      first.lnum, first.col));
 		pos = off2pos(buf->bufp, off+count-1);
 		if (!pos)
@@ -1178,7 +1178,7 @@ nb_do_cmd(
 		    return FAIL;
 		}
 		last = *pos;
-		nbdebug(("    LAST POS: line %d, col %d\n",
+		nbdebug(("    LAST POS: line %ld, col %d\n",
 							last.lnum, last.col));
 		del_from_lnum = first.lnum;
 		del_to_lnum = last.lnum;
@@ -1264,7 +1264,7 @@ nb_do_cmd(
 			}
 		    }
 
-		    nbdebug(("    Deleting lines %d through %d\n",
+		    nbdebug(("    Deleting lines %ld through %ld\n",
 						 del_from_lnum, del_to_lnum));
 		    curwin->w_cursor.lnum = del_from_lnum;
 		    curwin->w_cursor.col = 0;
@@ -1540,7 +1540,7 @@ nb_do_cmd(
 	    {
 		if (!buf->bufp->b_netbeans_file)
 		{
-		    nbdebug(("E658: NetBeans connection lost for buffer %ld\n", buf->bufp->b_fnum));
+		    nbdebug(("E658: NetBeans connection lost for buffer %d\n", buf->bufp->b_fnum));
 		    semsg(_("E658: NetBeans connection lost for buffer %d"),
 							   buf->bufp->b_fnum);
 		}


### PR DESCRIPTION
Adding ` __attribute__((format(printf, 1, 2)))` to `nbdbg(char *, ...)`
and compiling with `-DNBDEBUG` revealed several incorrect printf
formats, fixed in this PR.