### PR TITLE
Fix: skipped python and python3 commands could modify pyxversion.

### DIFF
--- a/src/if_python.c
+++ b/src/if_python.c
@@ -1109,12 +1109,12 @@ ex_python(exarg_T *eap)
 {
     char_u *script;
 
-    if (p_pyx == 0)
-	p_pyx = 2;
-
     script = script_get(eap, eap->arg);
     if (!eap->skip)
     {
+	if (p_pyx == 0)
+	    p_pyx = 2;
+
 	DoPyCommand(script == NULL ? (char *) eap->arg : (char *) script,
 		(rangeinitializer) init_range_cmd,
 		(runner) run_cmd,

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -1010,12 +1010,12 @@ ex_py3(exarg_T *eap)
 {
     char_u *script;
 
-    if (p_pyx == 0)
-	p_pyx = 3;
-
     script = script_get(eap, eap->arg);
     if (!eap->skip)
     {
+	if (p_pyx == 0)
+	    p_pyx = 3;
+
 	DoPyCommand(script == NULL ? (char *) eap->arg : (char *) script,
 		(rangeinitializer) init_range_cmd,
 		(runner) run_cmd,

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -63,3 +63,11 @@ func Test_vim_function()
   py del f
   delfunc s:foo
 endfunc
+
+func Test_skipped_python_command_does_not_affect_pyxversion()
+  set pyxversion=0
+  if 0
+    python import vim
+  endif
+  call assert_equal(0, &pyxversion)  " This assertion would have failed with Vim 8.0.0251. (pyxversion was introduced in 8.0.0251.)
+endfunc

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -63,3 +63,11 @@ func Test_vim_function()
   py3 del f
   delfunc s:foo
 endfunc
+
+func Test_skipped_python3_command_does_not_affect_pyxversion()
+  set pyxversion=0
+  if 0
+    python3 import vim
+  endif
+  call assert_equal(0, &pyxversion)  " This assertion would have failed with Vim 8.0.0251. (pyxversion was introduced in 8.0.0251.)
+endfunc


### PR DESCRIPTION
Previously:
vim -u NONE
:if 0
:  python import vim
:else
:  python3 import vim
:endif
:echo &pyxversion
" pyxversion == 2 (not 3). pyxversion was incorrectly set by the "skipped" python command following "if 0".

With the python 3 library loaded and pyxversion set to 2, trying to use pythonx, pyxeval, etc. on Ubuntu results in:
E836: This Vim cannot execute :python after using :py3
E263: Sorry, this command is disabled, the Python library could not be loaded.