### PR TITLE
Change linenr_T from long to int to save memory and speed up regexp e…

### DIFF
--- a/src/fold.c
+++ b/src/fold.c
@@ -3519,7 +3519,7 @@ put_folds_recurse(FILE *fd, garray_T *gap, linenr_T off)
 	/* Do nested folds first, they will be created closed. */
 	if (put_folds_recurse(fd, &fp->fd_nested, off + fp->fd_top) == FAIL)
 	    return FAIL;
-	if (fprintf(fd, "%ld,%ldfold", fp->fd_top + off,
+	if (fprintf(fd, "%d,%dfold", fp->fd_top + off,
 					fp->fd_top + off + fp->fd_len - 1) < 0
 		|| put_eol(fd) == FAIL)
 	    return FAIL;
@@ -3552,7 +3552,7 @@ put_foldopen_recurse(
 	    if (fp->fd_nested.ga_len > 0)
 	    {
 		/* open nested folds while this fold is open */
-		if (fprintf(fd, "%ld", fp->fd_top + off) < 0
+		if (fprintf(fd, "%d", fp->fd_top + off) < 0
 			|| put_eol(fd) == FAIL
 			|| put_line(fd, "normal! zo") == FAIL)
 		    return FAIL;
@@ -3593,7 +3593,7 @@ put_foldopen_recurse(
     static int
 put_fold_open_close(FILE *fd, fold_T *fp, linenr_T off)
 {
-    if (fprintf(fd, "%ld", fp->fd_top + off) < 0
+    if (fprintf(fd, "%d", fp->fd_top + off) < 0
 	    || put_eol(fd) == FAIL
 	    || fprintf(fd, "normal! z%c",
 			   fp->fd_flags == FD_CLOSED ? 'c' : 'o') < 0

--- a/src/mark.c
+++ b/src/mark.c
@@ -776,7 +776,7 @@ show_one_mark(
 	msg_putchar('\n');
 	if (!got_int)
 	{
-	    sprintf((char *)IObuff, " %c %6ld %4d ", c, p->lnum, p->col);
+	    sprintf((char *)IObuff, " %c %6d %4d ", c, p->lnum, p->col);
 	    msg_outtrans(IObuff);
 	    if (name == NULL && current)
 	    {
@@ -911,7 +911,7 @@ ex_jumps(exarg_T *eap UNUSED)
 		vim_free(name);
 		break;
 	    }
-	    sprintf((char *)IObuff, "%c %2d %5ld %4d ",
+	    sprintf((char *)IObuff, "%c %2d %5d %4d ",
 		i == curwin->w_jumplistidx ? '>' : ' ',
 		i > curwin->w_jumplistidx ? i - curwin->w_jumplistidx
 					  : curwin->w_jumplistidx - i,
@@ -2150,7 +2150,7 @@ copy_viminfo_marks(
 		{
 		    unsigned u;
 
-		    sscanf((char *)line + 2, "%ld %u", &pos.lnum, &u);
+		    sscanf((char *)line + 2, "%d %u", &pos.lnum, &u);
 		    pos.col = u;
 		    switch (line[1])
 		    {

--- a/src/memline.c
+++ b/src/memline.c
@@ -262,7 +262,7 @@ static long char_to_long(char_u *);
 static cryptstate_T *ml_crypt_prepare(memfile_T *mfp, off_T offset, int reading);
 #endif
 #ifdef FEAT_BYTEOFF
-static void ml_updatechunk(buf_T *buf, long line, long len, int updtype);
+static void ml_updatechunk(buf_T *buf, linenr_T line, long len, int updtype);
 #endif
 
 /*
@@ -2484,7 +2484,7 @@ ml_get_buf(
 	    /* Avoid giving this message for a recursive call, may happen when
 	     * the GUI redraws part of the text. */
 	    ++recursive;
-	    siemsg(_("E315: ml_get: invalid lnum: %ld"), lnum);
+	    siemsg(_("E315: ml_get: invalid lnum: %d"), lnum);
 	    --recursive;
 	}
 errorret:
@@ -2523,7 +2523,7 @@ errorret:
 		/* Avoid giving this message for a recursive call, may happen
 		 * when the GUI redraws part of the text. */
 		++recursive;
-		siemsg(_("E316: ml_get: cannot find line %ld"), lnum);
+		siemsg(_("E316: ml_get: cannot find line %d"), lnum);
 		--recursive;
 	    }
 	    goto errorret;
@@ -3764,7 +3764,7 @@ ml_flush_line(buf_T *buf)
 
 	hp = ml_find_line(buf, lnum, ML_FIND);
 	if (hp == NULL)
-	    siemsg(_("E320: Cannot find line %ld"), lnum);
+	    siemsg(_("E320: Cannot find line %d"), lnum);
 	else
 	{
 	    dp = (DATA_BL *)(hp->bh_data);
@@ -4051,7 +4051,7 @@ ml_find_line(buf_T *buf, linenr_T lnum, int action)
 	if (idx >= (int)pp->pb_count)	    /* past the end: something wrong! */
 	{
 	    if (lnum > buf->b_ml.ml_line_count)
-		siemsg(_("E322: line number out of range: %ld past the end"),
+		siemsg(_("E322: line number out of range: %d past the end"),
 					      lnum - buf->b_ml.ml_line_count);
 
 	    else

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -54,7 +54,11 @@ static void special_keys(char_u *args);
 static int getConnInfo(char *file, char **host, char **port, char **password);
 
 static void nb_init_graphics(void);
-static void coloncmd(char *cmd, ...);
+static void coloncmd(char *cmd, ...)
+#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+   __attribute__((format(printf, 1, 2)))
+#endif
+;
 static void nb_set_curbuf(buf_T *buf);
 static void nb_parse_cmd(char_u *);
 static int  nb_do_cmd(int, char_u *, int, int, char_u *);
@@ -2001,7 +2005,7 @@ nb_do_cmd(
 	    }
 	    if (pos)
 	    {
-		coloncmd(":sign place %d line=%ld name=%d buffer=%d",
+		coloncmd(":sign place %d line=%d name=%d buffer=%d",
 			   serNum, pos->lnum, typeNum, buf->bufp->b_fnum);
 		if (typeNum == curPCtype)
 		    coloncmd(":sign jump %d buffer=%d", serNum,

--- a/src/proto/message.pro
+++ b/src/proto/message.pro
@@ -11,9 +11,17 @@ int emsg_not_now(void);
 void ignore_error_for_testing(char_u *error);
 void do_perror(char *msg);
 int emsg(char *s);
-int semsg(const char *s, ...);
+int semsg(const char *s, ...)
+#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+   __attribute__((format(printf, 1, 2)))
+#endif
+;
 void iemsg(char *s);
-void siemsg(const char *s, ...);
+void siemsg(const char *s, ...)
+#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+   __attribute__((format(printf, 1, 2)))
+#endif
+;
 void internal_error(char *where);
 void emsg_invreg(int name);
 char *msg_trunc_attr(char *s, int force, int attr);

--- a/src/proto/message.pro
+++ b/src/proto/message.pro
@@ -11,17 +11,9 @@ int emsg_not_now(void);
 void ignore_error_for_testing(char_u *error);
 void do_perror(char *msg);
 int emsg(char *s);
-int semsg(const char *s, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
-   __attribute__((format(printf, 1, 2)))
-#endif
-;
+int semsg(const char *s, ...);
 void iemsg(char *s);
-void siemsg(const char *s, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
-   __attribute__((format(printf, 1, 2)))
-#endif
-;
+void siemsg(const char *s, ...);
 void internal_error(char *where);
 void emsg_invreg(int name);
 char *msg_trunc_attr(char *s, int force, int attr);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3443,9 +3443,9 @@ qf_list_entry(qfline_T *qfp, int qf_idx, int cursel)
     if (qfp->qf_lnum == 0)
 	IObuff[0] = NUL;
     else if (qfp->qf_col == 0)
-	sprintf((char *)IObuff, "%ld", qfp->qf_lnum);
+	sprintf((char *)IObuff, "%d", qfp->qf_lnum);
     else
-	sprintf((char *)IObuff, "%ld col %d",
+	sprintf((char *)IObuff, "%d col %d",
 		qfp->qf_lnum, qfp->qf_col);
     sprintf((char *)IObuff + STRLEN(IObuff), "%s",
 	    (char *)qf_types(qfp->qf_type, qfp->qf_nr));
@@ -4377,7 +4377,7 @@ qf_buf_add_line(buf_T *buf, linenr_T lnum, qfline_T *qfp, char_u *dirname)
 
     if (qfp->qf_lnum > 0)
     {
-	sprintf((char *)IObuff + len, "%ld", qfp->qf_lnum);
+	sprintf((char *)IObuff + len, "%d", qfp->qf_lnum);
 	len += (int)STRLEN(IObuff + len);
 
 	if (qfp->qf_col > 0)

--- a/src/search.c
+++ b/src/search.c
@@ -5586,7 +5586,7 @@ show_pat_in_path(
 	{
 	    sprintf((char *)IObuff, "%3ld: ", count);	/* show match nr */
 	    msg_puts((char *)IObuff);
-	    sprintf((char *)IObuff, "%4ld", *lnum);	/* show line nr */
+	    sprintf((char *)IObuff, "%4d", *lnum);	/* show line nr */
 						/* Highlight line numbers */
 	    msg_puts_attr((char *)IObuff, HL_ATTR(HLF_N));
 	    msg_puts(" ");

--- a/src/tag.c
+++ b/src/tag.c
@@ -1129,7 +1129,7 @@ do_tags(exarg_T *eap UNUSED)
 		continue;
 
 	    msg_putchar('\n');
-	    vim_snprintf((char *)IObuff, IOSIZE, "%c%2d %2d %-15s %5ld  ",
+	    vim_snprintf((char *)IObuff, IOSIZE, "%c%2d %2d %-15s %5d  ",
 		i == tagstackidx ? '>' : ' ',
 		i + 1,
 		tagstack[i].cur_match + 1,

--- a/src/vim.h
+++ b/src/vim.h
@@ -1652,7 +1652,7 @@ typedef UINT32_TYPEDEF UINT32_T;
 # define PERROR(msg)		    do_perror(msg)
 #endif
 
-typedef long	linenr_T;		/* line number type */
+typedef int	linenr_T;		/* line number type */
 typedef int	colnr_T;		/* column number type */
 typedef unsigned short disptick_T;	/* display tick type */
 


### PR DESCRIPTION
This PR changes type of `linenr_T` from `long` to `int`.
It should be fine since `MAXLNUM` is defined as a 32-bit number.

It significantly reduces memory usage of the NFA regexpengine
and speed speeds up the regexp engine. See comment in issue #3937:
https://github.com/vim/vim/issues/3937#issuecomment-464928052

It probably saves memory elsewhere too.

Several messages need to be updated accordingly to change `%ld` 
format into `%d`.