### PR TITLE
Fix incorrect 'mouseshape' documentation about the defaults

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5497,8 +5497,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The 'mousemodel' option is set by the |:behave| command.
 
 					*'mouseshape'* *'mouses'* *E547*
-'mouseshape' 'mouses'	string	(default "i:beam,r:beam,s:updown,sd:cross,
-					m:no,ml:up-arrow,v:rightup-arrow")
+'mouseshape' 'mouses'	string	(default "i-r:beam,s:updown,sd:udsizing,
+					vs:leftright,vd:lrsizing,m:no,
+					ml:up-arrow,v:rightup-arrow")
 			global
 			{not in Vi}
 			{only available when compiled with the |+mouseshape|


### PR DESCRIPTION
The docs for `'mouseshape` seems to be quite outdated regarding the defaults.

Correct defaults can be found here: https://github.com/vim/vim/blob/master/src/option.c#L1936