### PR TITLE
win32: Use Wide API in modify_fname() in eval.c

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -10274,19 +10274,24 @@ repeat:
 # if _WIN32_WINNT >= 0x0500
 	if (vim_strchr(*fnamep, '~') != NULL)
 	{
-	    /* Expand 8.3 filename to full path.  Needed to make sure the same
-	     * file does not have two different names.
-	     * Note: problem does not occur if _WIN32_WINNT < 0x0500. */
-	    p = alloc(_MAX_PATH + 1);
-	    if (p != NULL)
+	    // Expand 8.3 filename to full path.  Needed to make sure the same
+	    // file does not have two different names.
+	    // Note: problem does not occur if _WIN32_WINNT < 0x0500.
+	    WCHAR *wp = enc_to_utf16(*fnamep, NULL);
+	    WCHAR buf[_MAX_PATH];
+
+	    if (wp != NULL)
 	    {
-		if (GetLongPathName((LPSTR)*fnamep, (LPSTR)p, _MAX_PATH))
+		if (GetLongPathNameW(wp, buf, _MAX_PATH))
 		{
-		    vim_free(*bufp);
-		    *bufp = *fnamep = p;
+		    char_u *p = utf16_to_enc(buf, NULL);
+		    if (p != NULL)
+		    {
+			vim_free(*bufp);    // free any allocated file name
+			*bufp = *fnamep = p;
+		    }
 		}
-		else
-		    vim_free(p);
+		vim_free(wp);
 	    }
 	}
 # endif


### PR DESCRIPTION
`modify_fname()` doesn't handle 'encoding' correctly.
This was a long standing problem since 7.3.559, as we discussed in
https://groups.google.com/d/msg/vim_dev/WJb26FXMG7g/Or0DB0yveeQJ .

This PR fixes the problem by using a Wide API.