### PR TITLE
win32: Use Wide API in vim_getenv() in misc1.c

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -4302,40 +4302,44 @@ expand_env_esc(
     char_u *
 vim_getenv(char_u *name, int *mustfree)
 {
-    char_u	*p;
+    char_u	*p = NULL;
     char_u	*pend;
     int		vimruntime;
+#ifdef MSWIN
+    WCHAR	*wn, *wp;
 
-#if defined(MSWIN)
-    /* use "C:/" when $HOME is not set */
+    // use "C:/" when $HOME is not set
     if (STRCMP(name, "HOME") == 0)
 	return homedir;
-#endif
 
+    // Use Wide function
+    wn = enc_to_utf16(name, NULL);
+    if (wn == NULL)
+	return NULL;
+
+    wp = _wgetenv(wn);
+    vim_free(wn);
+
+    if (wp != NULL && *wp == NUL)   // empty is the same as not set
+	wp = NULL;
+
+    if (wp != NULL)
+    {
+	p = utf16_to_enc(wp, NULL);
+	if (p == NULL)
+	    return NULL;
+
+	*mustfree = TRUE;
+	return p;
+    }
+#else
     p = mch_getenv(name);
-    if (p != NULL && *p == NUL)	    /* empty is the same as not set */
+    if (p != NULL && *p == NUL)	    // empty is the same as not set
 	p = NULL;
 
     if (p != NULL)
-    {
-#if defined(MSWIN)
-	if (enc_utf8)
-	{
-	    int	    len;
-	    char_u  *pp = NULL;
-
-	    /* Convert from active codepage to UTF-8.  Other conversions are
-	     * not done, because they would fail for non-ASCII characters. */
-	    acp_to_enc(p, (int)STRLEN(p), &pp, &len);
-	    if (pp != NULL)
-	    {
-		p = pp;
-		*mustfree = TRUE;
-	    }
-	}
-#endif
 	return p;
-    }
+#endif
 
     vimruntime = (STRCMP(name, "VIMRUNTIME") == 0);
     if (!vimruntime && STRCMP(name, "VIM") != 0)
@@ -4351,8 +4355,25 @@ vim_getenv(char_u *name, int *mustfree)
 #endif
        )
     {
+#ifdef MSWIN
+	// Use Wide function
+	wp = _wgetenv(L"VIM");
+	if (wp != NULL && *wp == NUL)	    // empty is the same as not set
+	    wp = NULL;
+	if (wp != NULL)
+	{
+	    char_u *q = utf16_to_enc(wp, NULL);
+	    if (q != NULL)
+	    {
+		p = vim_version_dir(q);
+		*mustfree = TRUE;
+		if (p == NULL)
+		    p = q;
+	    }
+	}
+#else
 	p = mch_getenv((char_u *)"VIM");
-	if (p != NULL && *p == NUL)	    /* empty is the same as not set */
+	if (p != NULL && *p == NUL)	    // empty is the same as not set
 	    p = NULL;
 	if (p != NULL)
 	{
@@ -4361,27 +4382,8 @@ vim_getenv(char_u *name, int *mustfree)
 		*mustfree = TRUE;
 	    else
 		p = mch_getenv((char_u *)"VIM");
-
-#if defined(MSWIN)
-	    if (enc_utf8)
-	    {
-		int	len;
-		char_u  *pp = NULL;
-
-		/* Convert from active codepage to UTF-8.  Other conversions
-		 * are not done, because they would fail for non-ASCII
-		 * characters. */
-		acp_to_enc(p, (int)STRLEN(p), &pp, &len);
-		if (pp != NULL)
-		{
-		    if (*mustfree)
-			vim_free(p);
-		    p = pp;
-		    *mustfree = TRUE;
-		}
-	    }
-#endif
 	}
+#endif
     }
 
     /*

--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -146,3 +146,8 @@ func Test_let_varg_fail()
   call assert_fails('call s:set_varg8(1)', 'E742:')
   call s:set_varg9([0])
 endfunction
+
+func Test_let_utf8_environment()
+  let $a = 'ĀĒĪŌŪあいうえお'
+  call assert_equal('ĀĒĪŌŪあいうえお', $a)
+endfunc


### PR DESCRIPTION
Currently, `vim_getenv()` cannot handle Unicode characters on Windows. E.g.:

```
:let $a='Ā'
:echo $a
?
```

This patch makes it possible by using Wide API:

```
:let $a='Ā'
:echo $a
Ā
```