### PR TITLE
Large files were needlessly truncated to 2147483647 lines.

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -9,6 +9,7 @@
 #ifndef VIM__H
 # define VIM__H
 
+#include <limits.h>
 #include "protodef.h"
 
 // _WIN32 is defined as 1 when the compilation target is 32-bit or 64-bit.
@@ -1669,8 +1670,8 @@ typedef unsigned short disptick_T;	/* display tick type */
 # define MAXCOL (0x3fffffffL)		/* maximum column number, 30 bits */
 # define MAXLNUM (0x3fffffffL)		/* maximum (invalid) line number */
 #else
-# define MAXCOL (0x7fffffffL)		/* maximum column number, 31 bits */
-# define MAXLNUM (0x7fffffffL)		/* maximum (invalid) line number */
+# define MAXCOL  INT_MAX		/* maximum column number */
+# define MAXLNUM LONG_MAX		/* maximum (invalid) line number */
 #endif
 
 #define SHOWCMD_COLS 10			/* columns needed by shown command */


### PR DESCRIPTION
This PR fixes a bug discussed in this comment:
https://github.com/vim/vim/pull/4003#issuecomment-465147527

Opening in Vim a large file with many lines truncates it to
2147483647 lines. It happens because `MAXLNUM` in `vim.h` is
defined as `0x3fffffffL`. Yet `linenr_T` type is a `long`,
which is 64-bits on x86_64 at least, so it is possible to
define `MAXLNUM` as `LONG_MAX` to be able to open
large files without truncation.

The issue can be reproduce with:
```
$ yes | head -$(echo "2^31 + 10" | bc -l) > foo.txt
$ vim --clean -c 'set nu' -c 'norm G' foo.txt
```
And observe that the last line number is 2147483647.
It should be 2147483658.

Note that this takes >12GB or RAM and takes 1m44s on my
machine, so it's too slow and too memory hungry to create
a test.