### PR TITLE
avoid quadratic time behavior in regex state allocation

### DIFF
--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -509,7 +509,7 @@ nfa_get_match_text(nfa_state_T *start)
 realloc_post_list(void)
 {
     int   nstate_max = (int)(post_end - post_start);
-    int   new_max = nstate_max + 1000;
+    int   new_max = nstate_max * 3 / 2 + 50;
     int   *new_start;
     int	  *old_start;
 


### PR DESCRIPTION
This change makes following case much faster

$ xxd modeline.slow
00000000: 7669 3a73 7063 3d5c 5c76 2828 2828 284e  vi:spc=\\v(((((N
00000010: 0000 0000 0000 0026 2600 0000 0029 7b31  .......&&....){1
00000020: 3739 7d29 2b29 2b29 2b29 7b31 3739 7d    79})+)+)+){179}

$ vim -u NONE -i NONE -n --cmd 'set modeline' -c 'qa!
70s -> 0.7s
