### PR TITLE
win32: executable() may fail on very long filename

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3527,14 +3527,17 @@ mch_writable(char_u *name)
     int
 mch_can_exe(char_u *name, char_u **path, int use_path)
 {
-    char_u	buf[_MAX_PATH];
+    // WinNT and later can use _MAX_PATH wide characters for a pathname, which
+    // means that the maximum pathname is _MAX_PATH * 3 bytes when 'enc' is
+    // UTF-8.
+    char_u	buf[_MAX_PATH * 3];
     int		len = (int)STRLEN(name);
     char_u	*p, *saved;
 
-    if (len >= _MAX_PATH)	/* safety check */
+    if (len >= sizeof(buf))	// safety check
 	return FALSE;
 
-    /* Ty using the name directly when a Unix-shell like 'shell'. */
+    // Try using the name directly when a Unix-shell like 'shell'.
     if (strstr((char *)gettail(p_sh), "sh") != NULL)
 	if (executable_exists((char *)name, path, use_path))
 	    return TRUE;
@@ -3567,7 +3570,7 @@ mch_can_exe(char_u *name, char_u **path, int use_path)
     }
     vim_free(saved);
 
-    vim_strncpy(buf, name, _MAX_PATH - 1);
+    vim_strncpy(buf, name, sizeof(buf) - 1);
     p = mch_getenv("PATHEXT");
     if (p == NULL)
 	p = (char_u *)".com;.exe;.bat;.cmd";
@@ -3582,7 +3585,7 @@ mch_can_exe(char_u *name, char_u **path, int use_path)
 		++p;
 	}
 	else
-	    copy_option_part(&p, buf + len, _MAX_PATH - len, ";");
+	    copy_option_part(&p, buf + len, sizeof(buf) - len, ";");
 	if (executable_exists((char *)buf, path, use_path))
 	    return TRUE;
     }

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -944,6 +944,17 @@ func Test_Executable()
   endif
 endfunc
 
+func Test_executable_longname()
+  if !has('win32')
+    return
+  endif
+
+  let fname = 'X' . repeat('あ', 200) . '.bat'
+  call writefile([], fname)
+  call assert_equal(1, executable(fname))
+  call delete(fname)
+endfunc
+
 func Test_hostname()
   let hostname_vim = hostname()
   if has('unix')


### PR DESCRIPTION
This PR is based on the following vim_dev thread:
https://groups.google.com/d/msg/vim_dev/RoAYpQupl0U/i_QMhHuFAgAJ

I newly added a test on this patch.
Let's see if the test passes on AppVeyor.