### PR TITLE
Fix macOS fsync error when saving SMB shared file

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5135,7 +5135,7 @@ vim_fsync(int fd)
 
 # ifdef MACOS_X
     r = fcntl(fd, F_FULLFSYNC);
-    if (r != 0 && errno == ENOTTY)
+    if (r != 0 && (errno == ENOTTY || errno == ENOTSUP))
 # endif
 	r = fsync(fd);
     return r;


### PR DESCRIPTION
Correctly handle fcntl() failure when calling on unsupported storage systems (e.g. SMB network shared file). The current code only checks for ENOTTY but the OS actually returns ENOTSUP (45) when trying to save to a network shared file. Currently this incorrect handling leads to files not being properly fsync'ed and display a scary error to the user.

## Reproduce
To reproduce this case, on a Mac, just mount a shared SMB drive (from Windows). Then try to open a shared network file and save to it. You see see an error saying "E667: Fsync failed".

## Notes
Annoyingly, both `ENOTTY` and `ENOTSUP` error codes are not documented in the Apple [`fcntl`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html) man page. 

Descriptions for `ENOTSUP` can be found [here](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/intro.2.html):

>      45 ENOTSUP Not supported.  The attempted operation is not supported for
>             the type of object referenced.

This makes sense to me because the docs says `fcntl` is only implemented for some filesystems so returning `ENOTSUP` just means you should use `fsync` as a backup.

An alternative is to simply *not* check error code and always try `fsync` as a backup.

## Related

* This bug originated from: https://github.com/macvim-dev/macvim/issues/861
* Original thread on Neovim: https://github.com/neovim/neovim/issues/9611
* Link I found online that shows similar result: https://cboard.cprogramming.com/linux-programming/109089-mac-file-locking-fcntl-fails-shared-volumes.html