### PR TITLE
remove an invaild prerequisite for ".vim.res"

### DIFF
--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -148,7 +148,7 @@ newtests: newtestssilent
 newtestssilent: $(NEW_TESTS_RES)
 
 
-.vim.res: writevimcmd
+.vim.res:
 	@echo "$(VIMPROG)" > vimcmd
 	@echo "$(RUN_VIMTEST)" >> vimcmd
 	$(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim $(REDIR_TEST_TO_NULL)


### PR DESCRIPTION
I found an invalid prerequisite for `.vim.res` in src/testdir/Makefile. This PR removes it.

https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html#Suffix-Rules
> Suffix rules cannot have any prerequisites of their own. If they have any, they are treated as normal files with funny names, not as suffix rules.

Acually, however, it looks like a prerequisite is just ignored when suffixes are defined. I think this is why the current test works well.
```
.SUFFIXES: .in .out .res .vim
```

I confirmed that all test results `make test &> test_result` are identical in the following cases.
1. No change.
1. Changed `writevimcmd` to another random text.
1. Just removed `writevimcmd`.

This prerequisite has been added by https://github.com/vim/vim/commit/631820536e4084e01bf990f9314ec385b60b21d7, but [the original change](https://github.com/vim/vim/pull/2186/files) doesn't have this prerequisites.