### PR TITLE
Fix macOS fcntl/fsync usage properly

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5135,7 +5135,7 @@ vim_fsync(int fd)
 
 # ifdef MACOS_X
     r = fcntl(fd, F_FULLFSYNC);
-    if (r != 0 && (errno == ENOTTY || errno == ENOTSUP))
+    if (r != 0)
 # endif
 	r = fsync(fd);
     return r;


### PR DESCRIPTION
When fcntl fails, don't check `errno` when deciding whether to call fsync, as there are different possible `errno` results and they are not documented in the man page. Instead, always fall back to fsync. Worst case is that it's only slightly slower but that should only happen when something is wrong anyway so that's not a big deal.

Also see: https://github.com/vim/vim/pull/4016 for the first attempt to fix this.