### PR TITLE
Documentation add more commands to index

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -17,9 +17,11 @@ to look for deleting something, use: "/delete".
    2.3. Square bracket commands		|[|
    2.4. Commands starting with 'g'	|g|
    2.5. Commands starting with 'z'	|z|
+   2.6. Operator-pending mode		|operator-pending-index|
 3. Visual mode				|visual-index|
 4. Command-line editing			|ex-edit-index|
-5. EX commands				|ex-cmd-index|
+5. Terminal-Job mode			|terminal-job-index|
+6. EX commands				|ex-cmd-index|
 
 For an overview of options see help.txt |option-list|.
 For an overview of built-in functions see |functions|.
@@ -855,6 +857,17 @@ tag		char	      note action in Normal mode	~
 |z<Right>|	z<Right>	   same as "zl"
 
 ==============================================================================
+2.6 Operator-pending mode			*operator-pending-index*
+
+These can be used after an operator, but before a {motion} has been entered.
+
+tag		char		action in Insert mode	~
+-----------------------------------------------------------------------
+|o_v|		v		force operator to work characterwise
+|o_V|		V		force operator to work linewise
+|o_CTRL-V|	CTRL-V		force operator to work blockwise
+
+==============================================================================
 3. Visual mode						*visual-index*
 
 Most commands in Visual mode are the same as in Normal mode.  The ones listed
@@ -1066,10 +1079,27 @@ tag		command	      action in Command-line editing mode	~
 |c_<Insert>|	<Insert>	toggle insert/overstrike mode
 |c_<LeftMouse>|	<LeftMouse>	cursor at mouse click
 
+==============================================================================
+5. Terminal-Job mode				*terminal-job-index*
+
+Most Normal mode commands except for window commands (|CTRL-W|) do not work in
+a terminal window. Switch to Terminal-Normal mode to use them.
+
+tag		char		action in Insert mode	~
+-----------------------------------------------------------------------
+|t_CTRL-\_CTRL-N| CTRL-\ CTRL-N	switch to Terminal-Normal mode
+|CTRL-W_N|	CTRL-W N	switch to Terminal-Normal mode
+|CTRL-W_:|	CTRL-W :	enter an Ex command
+|CTRL-W_.|	CTRL-W .	type CTRL-W in the terminal
+		CTRL-W CTRL-\	send a CTRL-\ to the job in the terminal
+|CTRL-W_quote|	CTRL-W " {0-9a-z"%#*:=}
+				paste register in the terminal
+|t_CTRL-W_CTRL-C| CTRL-W CTRL-C	forcefully ends the job
+
 You found it, Arthur!				*holy-grail* *:smile*
 
 ==============================================================================
-5. EX commands					*ex-cmd-index* *:index*
+6. EX commands					*ex-cmd-index* *:index*
 
 This is a brief but complete listing of all the ":" commands, without
 mentioning any arguments.  The optional part of the command name is inside [].

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7994,6 +7994,7 @@ omni-sql-completion	ft_sql.txt	/*omni-sql-completion*
 online-help	helphelp.txt	/*online-help*
 opening-window	windows.txt	/*opening-window*
 operator	motion.txt	/*operator*
+operator-pending-index	index.txt	/*operator-pending-index*
 operator-variable	eval.txt	/*operator-variable*
 option-backslash	options.txt	/*option-backslash*
 option-list	quickref.txt	/*option-list*
@@ -9161,6 +9162,7 @@ terminal-diffscreendump	terminal.txt	/*terminal-diffscreendump*
 terminal-dumptest	terminal.txt	/*terminal-dumptest*
 terminal-functions	usr_41.txt	/*terminal-functions*
 terminal-info	term.txt	/*terminal-info*
+terminal-job-index	index.txt	/*terminal-job-index*
 terminal-key-codes	term.txt	/*terminal-key-codes*
 terminal-ms-windows	terminal.txt	/*terminal-ms-windows*
 terminal-options	term.txt	/*terminal-options*


### PR DESCRIPTION
Add operator-pending mode commands, and separate out terminal commands into a separate section to make it clearer (and also a couple terminal commands were not in the index previously).