### PR TITLE
Add completion / popupmenu mode keys to documentation index

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -166,6 +166,21 @@ commands in CTRL-X submode				*i_CTRL-X_index*
 |i_CTRL-X_s|		CTRL-X s	spelling suggestions
 {not available when compiled without the |+insert_expand| feature}
 
+commands in completion mode (see |popupmenu-keys|)
+
+|complete_CTRL-E| CTRL-E	stop completion and go back to original text
+		<Tab>		stop completion and insert <Tab>
+		CTRL-L		insert one character from the current match
+		<CR>		insert currently selected match
+		<BS>		delete one character and redo search
+		CTRL-H		same as <BS>
+|complete_CTRL-Y| CTRL-Y	accept selected match and stop completion
+		<Space>		stop completion and insert <Space>
+		<Up>		select the previous match
+		<Down>		select the next match
+		<PageUp>	select a match several entries back
+		<PageDown>	select a match several entries forward
+
 ==============================================================================
 2. Normal mode						*normal-index*
 


### PR DESCRIPTION
Similar to #4027, add more commands to the documentation index page. This time, add the commands in Insert mode's completion / popupmenu sub-mode.

I think I have caught most of the missing commands. Not sure if there are random stragglers that I missed though as I didn't do an exhaustive search, and not all commands have tags associated with them making it hard to scrub through all of them.