### PR TITLE
Fixed crash with blobs and ruby + added tests

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -1267,7 +1267,7 @@ static VALUE vim_blob(VALUE self UNUSED, VALUE str)
     int	i;
     for (i = 0; i < RSTRING_LEN(str); i++)
     {
-	sprintf(buf, "%02X", RSTRING_PTR(str)[i]);
+	sprintf(buf, "%02X", (unsigned char)(RSTRING_PTR(str)[i]));
 	rb_str_concat(result, rb_str_new2(buf));
     }
     return result;

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -306,6 +306,9 @@ func Test_Vim_evaluate()
   call assert_equal('foo',      RubyEval('Vim::evaluate("\"foo\"")'))
   call assert_equal('String',   RubyEval('Vim::evaluate("\"foo\"").class'))
 
+  call assert_equal('["\x01\xAB"]', RubyEval('Vim::evaluate("0z01ab").unpack("M")'))
+  call assert_equal('String',       RubyEval('Vim::evaluate("0z01ab").class'))
+
   call assert_equal('[1, 2]',   RubyEval('Vim::evaluate("[1, 2]")'))
   call assert_equal('Array',    RubyEval('Vim::evaluate("[1, 2]").class'))
 
@@ -322,6 +325,12 @@ func Test_Vim_evaluate()
   call assert_equal('TrueClass', RubyEval('Vim::evaluate("v:true").class'))
   call assert_equal('false',     RubyEval('Vim::evaluate("v:false")'))
   call assert_equal('FalseClass',RubyEval('Vim::evaluate("v:false").class'))
+endfunc
+
+func Test_Vim_blob()
+  call assert_equal('0z',         RubyEval('Vim::blob("")'))
+  call assert_equal('0z31326162', RubyEval('Vim::blob("12ab")'))
+  call assert_equal('0z00010203', RubyEval('Vim::blob("\x00\x01\x02\x03")'))
 endfunc
 
 func Test_Vim_evaluate_list()

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -331,6 +331,8 @@ func Test_Vim_blob()
   call assert_equal('0z',         RubyEval('Vim::blob("")'))
   call assert_equal('0z31326162', RubyEval('Vim::blob("12ab")'))
   call assert_equal('0z00010203', RubyEval('Vim::blob("\x00\x01\x02\x03")'))
+  call assert_equal('0z8081FEFF', RubyEval('Vim::blob("\x80\x81\xfe\xff")'))
+
 endfunc
 
 func Test_Vim_evaluate_list()


### PR DESCRIPTION
This PR adds tests for blobs with the ruby interface
and fixes a crash discovered while adding tests:
```
$ vim --clean -c 'ruby print Vim::blob("\xab")'
Vim: Caught deadly signal ABRT
Vim: Finished.
Aborted (core dumped)
```
Blobs with ruby were not tested according to codecov:

https://codecov.io/gh/vim/vim/src/e4963c543ddcfc4845fa0d42893b6a4e1aa27c47/src/if_ruby.c#L1180
https://codecov.io/gh/vim/vim/src/e4963c543ddcfc4845fa0d42893b6a4e1aa27c47/src/if_ruby.c#L1263