### PR TITLE
Fixed crash with Blobs and Perl interface + added tests

### DIFF
--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -1570,7 +1570,7 @@ Blob(SV* sv)
     newsv = newSVpv("0z", 2);
     for (i = 0; i < len; i++)
     {
-	sprintf(buf, "%02X", s[i]);
+	sprintf(buf, "%02X", (unsigned char)(s[i]));
 	sv_catpvn(newsv, buf, 2);
     }
     RETVAL = newsv;

--- a/src/testdir/test_perl.vim
+++ b/src/testdir/test_perl.vim
@@ -29,6 +29,13 @@ EOF
   call assert_equal('abc/def/', getline('$'))
 endfunc
 
+funct Test_VIM_Blob()
+  call assert_equal('0z',         perleval('VIM::Blob("")'))
+  call assert_equal('0z31326162', perleval('VIM::Blob("12ab")'))
+  call assert_equal('0z00010203', perleval('VIM::Blob("\x00\x01\x02\x03")'))
+  call assert_equal('0z8081FEFF', perleval('VIM::Blob("\x80\x81\xfe\xff")'))
+endfunc
+
 func Test_buffer_Delete()
   new
   call setline(1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'])


### PR DESCRIPTION
This PR fixes a crash with Blob and the Perl interface:
```
$ vim --clean -c 'perl print VIM::Blob("\xab")'
Vim: Caught deadly signal ABRT
Vim: Finished.
Aborted (core dumped)
```
PR also adds tests as Blobs were not tested with Perl.

This is the same kind of issue as was discovered in Ruby. See: https://github.com/vim/vim/pull/4036
