### PR TITLE
Test pasting @" register in terminal with CTRL-W ""

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -93,6 +93,13 @@ func Test_terminal_paste_register()
   call WaitForAssert({-> assert_match("echo text to paste$", getline(1))})
   call WaitForAssert({-> assert_equal('text to paste',       getline(2))})
 
+
+  " Wait for the shell to display a prompt
+  call WaitForAssert({-> assert_notequal('', term_getline(buf, 3))})
+
+  call feedkeys("\<C-W>\"=37 + 5\<CR>", 'xt')
+  call WaitForAssert({-> assert_match('42$', getline(3))})
+
   exe buf . 'bwipe!'
   unlet g:job
 endfunc

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -82,6 +82,21 @@ func Test_terminal_make_change()
   unlet g:job
 endfunc
 
+func Test_terminal_paste_register()
+  let @" = "text to paste"
+
+  let buf = Run_shell_in_terminal({})
+  " Wait for the shell to display a prompt
+  call WaitForAssert({-> assert_notequal('', term_getline(buf, 1))})
+
+  call feedkeys("echo '\<C-W>\"\"'\<CR>", 'xt')
+  call WaitForAssert({-> assert_match("echo 'text to paste'$", getline(1))})
+  call WaitForAssert({-> assert_equal('text to paste',         getline(2))})
+
+  exe buf . 'bwipe!'
+  unlet g:job
+endfunc
+
 func Test_terminal_wipe_buffer()
   let buf = Run_shell_in_terminal({})
   call assert_fails(buf . 'bwipe', 'E517')

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -89,9 +89,9 @@ func Test_terminal_paste_register()
   " Wait for the shell to display a prompt
   call WaitForAssert({-> assert_notequal('', term_getline(buf, 1))})
 
-  call feedkeys("echo '\<C-W>\"\"'\<CR>", 'xt')
-  call WaitForAssert({-> assert_match("echo 'text to paste'$", getline(1))})
-  call WaitForAssert({-> assert_equal('text to paste',         getline(2))})
+  call feedkeys("echo \<C-W>\"\"\<CR>", 'xt')
+  call WaitForAssert({-> assert_match("echo text to paste$", getline(1))})
+  call WaitForAssert({-> assert_equal('text to paste',       getline(2))})
 
   exe buf . 'bwipe!'
   unlet g:job

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -89,16 +89,9 @@ func Test_terminal_paste_register()
   " Wait for the shell to display a prompt
   call WaitForAssert({-> assert_notequal('', term_getline(buf, 1))})
 
-  call feedkeys("echo \<C-W>\"\"\<CR>", 'xt')
-  call WaitForAssert({-> assert_match("echo text to paste$", getline(1))})
-  call WaitForAssert({-> assert_equal('text to paste',       getline(2))})
-
-
-  " Wait for the shell to display a prompt
-  call WaitForAssert({-> assert_notequal('', term_getline(buf, 3))})
-
-  call feedkeys("\<C-W>\"=37 + 5\<CR>", 'xt')
-  call WaitForAssert({-> assert_match('42$', getline(3))})
+  call feedkeys("echo \<C-W>\"\" \<C-W>\"=37 + 5\<CR>\<CR>", 'xt')
+  call WaitForAssert({-> assert_match("echo text to paste 42$", getline(1))})
+  call WaitForAssert({-> assert_equal('text to paste 42',       getline(2))})
 
   exe buf . 'bwipe!'
   unlet g:job


### PR DESCRIPTION
This PR adds a test for pasting a register in the terminal using `CTRL-W ""`.

Pasting register in terminal was not tested according to codecov:
https://codecov.io/gh/vim/vim/src/2472ae81dff8c30f5d63db8ad2c937deae8be646/src/terminal.c#L1984