### PR TITLE
Configure fails on RHEL/Fedora, because -fPIC is missing

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -4554,6 +4554,15 @@ $as_echo "yes" >&6; };;
 $as_echo "no" >&6; };;
 esac
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for RHEL/Fedora" >&5
+$as_echo_n "checking for RHEL/Fedora... " >&6; }
+RH_OS=`cat /etc/os-release | grep -e 'Fedora\|Red Hat'`
+if test ! -z "$RH_OS"; then
+  LDFLAGS="$LDFLAGS -fPIC"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Darwin (Mac OS X)" >&5
 $as_echo_n "checking for Darwin (Mac OS X)... " >&6; }
 if test "`(uname) 2>/dev/null`" = Darwin; then

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -4556,7 +4556,7 @@ esac
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for RHEL/Fedora" >&5
 $as_echo_n "checking for RHEL/Fedora... " >&6; }
-RH_OS=`cat /etc/os-release | grep -e 'Fedora\|Red Hat'`
+RH_OS=`cat /etc/os-release 2>/dev/null | grep -e 'Fedora\|Red Hat'`
 if test ! -z "$RH_OS"; then
   LDFLAGS="$LDFLAGS -fPIC"
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -168,7 +168,7 @@ dnl Check for RHEL/Fedora, because they needs -fPIC in LDFLAGS.
 dnl Configuring can fail without it, because linker wants -fPIC
 dnl when it is linking test samples from AC_TRY_LINK directives
 AC_MSG_CHECKING([for RHEL/Fedora])
-RH_OS=`cat /etc/os-release | grep -e 'Fedora\|Red Hat'`
+RH_OS=`cat /etc/os-release 2>/dev/null | grep -e 'Fedora\|Red Hat'`
 if test ! -z "$RH_OS"; then
   LDFLAGS="$LDFLAGS -fPIC"
   AC_MSG_RESULT(yes)

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -164,6 +164,16 @@ case `uname` in
     *)		QNX=no; AC_MSG_RESULT(no);;
 esac
 
+dnl Check for RHEL/Fedora, because they needs -fPIC in LDFLAGS.
+dnl Configuring can fail without it, because linker wants -fPIC
+dnl when it is linking test samples from AC_TRY_LINK directives
+AC_MSG_CHECKING([for RHEL/Fedora])
+RH_OS=`cat /etc/os-release | grep -e 'Fedora\|Red Hat'`
+if test ! -z "$RH_OS"; then
+  LDFLAGS="$LDFLAGS -fPIC"
+  AC_MSG_RESULT(yes)
+fi
+
 dnl Check for Darwin and MacOS X
 dnl We do a check for MacOS X in the very beginning because there
 dnl are a lot of other things we need to change besides GUI stuff


### PR DESCRIPTION
Fixing #1081 - it checks for strings Red Hat and Fedora in /etc/os-release. If there are some strings, it adds -fPIC into LDFLAGS.