### PR TITLE
Allow extend to take Blob for second argument if the first is List

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4093,6 +4093,8 @@ extend({expr1}, {expr2} [, {expr3}])			*extend()*
 		two lists into a new list use the + operator: >
 			:let newlist = [1, 2, 3] + [4, 5]
 <
+		Especially, {expr2} allow to be Blob if the {expr1} is List.
+
 		If they are |Dictionaries|:
 		Add all entries from {expr2} to {expr1}.
 		If a key exists in both {expr1} and {expr2} then {expr3} is

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -318,3 +318,7 @@ endfunc
 func Test_blob_sort()
   call assert_fails('call sort([1.0, 0z11], "f")', 'E975:')
 endfunc
+
+func Test_blob_extend()
+  call assert_equal([222, 173, 190, 239], extend([], 0zDEADBEEF))
+endfunc


### PR DESCRIPTION
Current implementation dose not allow to get a list from blob easily. It is useful if `extend([], blob)` is allowed.