### PR TITLE
Deleting a location list buffer, breaks location list window functionality

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -4032,22 +4032,27 @@ qf_open_new_cwindow(qf_info_T *qi, int height)
 	// Create a new quickfix buffer
 	(void)do_ecmd(0, NULL, NULL, NULL, ECMD_ONE, ECMD_HIDE, oldwin);
 
-	// switch off 'swapfile'
-	set_option_value((char_u *)"swf", 0L, NULL, OPT_LOCAL);
-	set_option_value((char_u *)"bt", 0L, (char_u *)"quickfix",
-		OPT_LOCAL);
-	set_option_value((char_u *)"bh", 0L, (char_u *)"hide", OPT_LOCAL);
-	RESET_BINDING(curwin);
-#ifdef FEAT_DIFF
-	curwin->w_p_diff = FALSE;
-#endif
-#ifdef FEAT_FOLDING
-	set_option_value((char_u *)"fdm", 0L, (char_u *)"manual",
-		OPT_LOCAL);
-#endif
 	// save the number of the new buffer
 	qi->qf_bufnr = curbuf->b_fnum;
     }
+
+    // Mark the quickfix buffer as a temporary scratch buffer
+    // Do this even if the quickfix buffer was already present, as an autocmd
+    // might have deleted (:bdelete) this buffer.
+
+    // switch off 'swapfile'
+    set_option_value((char_u *)"swf", 0L, NULL, OPT_LOCAL);
+    set_option_value((char_u *)"bt", 0L, (char_u *)"quickfix",
+	    OPT_LOCAL);
+    set_option_value((char_u *)"bh", 0L, (char_u *)"hide", OPT_LOCAL);
+    RESET_BINDING(curwin);
+#ifdef FEAT_DIFF
+    curwin->w_p_diff = FALSE;
+#endif
+#ifdef FEAT_FOLDING
+    set_option_value((char_u *)"fdm", 0L, (char_u *)"manual",
+	    OPT_LOCAL);
+#endif
 
     // Only set the height when still in the same tab page and there is no
     // window to the side.

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3981,8 +3981,7 @@ qf_goto_cwindow(qf_info_T *qi, int resize, int sz, int vertsplit)
 }
 
 /*
- * Set options for a quickfix/location list buffer and window. Called to set
- * options for the buffer in a quickfix or location list window.
+ * Set options for the buffer in the quickfix or location list window.
  */
     static void
 qf_set_cwindow_opts(void)
@@ -4058,10 +4057,11 @@ qf_open_new_cwindow(qf_info_T *qi, int height)
 	qi->qf_bufnr = curbuf->b_fnum;
     }
 
-    // Set the options for the quickfix buffer/window.
+    // Set the options for the quickfix buffer/window (if not already done)
     // Do this even if the quickfix buffer was already present, as an autocmd
     // might have previously deleted (:bdelete) the quickfix buffer.
-    qf_set_cwindow_opts();
+    if (curbuf->b_p_bt[0] != 'q')
+	qf_set_cwindow_opts();
 
     // Only set the height when still in the same tab page and there is no
     // window to the side.

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3981,6 +3981,28 @@ qf_goto_cwindow(qf_info_T *qi, int resize, int sz, int vertsplit)
 }
 
 /*
+ * Set options for a quickfix/location list buffer and window. Called to set
+ * options for the buffer in a quickfix or location list window.
+ */
+    static void
+qf_set_cwindow_opts(void)
+{
+    // switch off 'swapfile'
+    set_option_value((char_u *)"swf", 0L, NULL, OPT_LOCAL);
+    set_option_value((char_u *)"bt", 0L, (char_u *)"quickfix",
+	    OPT_LOCAL);
+    set_option_value((char_u *)"bh", 0L, (char_u *)"hide", OPT_LOCAL);
+    RESET_BINDING(curwin);
+#ifdef FEAT_DIFF
+    curwin->w_p_diff = FALSE;
+#endif
+#ifdef FEAT_FOLDING
+    set_option_value((char_u *)"fdm", 0L, (char_u *)"manual",
+	    OPT_LOCAL);
+#endif
+}
+
+/*
  * Open a new quickfix or location list window, load the quickfix buffer and
  * set the appropriate options for the window.
  * Returns FAIL if the window could not be opened.
@@ -4036,23 +4058,10 @@ qf_open_new_cwindow(qf_info_T *qi, int height)
 	qi->qf_bufnr = curbuf->b_fnum;
     }
 
-    // Mark the quickfix buffer as a temporary scratch buffer
+    // Set the options for the quickfix buffer/window.
     // Do this even if the quickfix buffer was already present, as an autocmd
-    // might have deleted (:bdelete) this buffer.
-
-    // switch off 'swapfile'
-    set_option_value((char_u *)"swf", 0L, NULL, OPT_LOCAL);
-    set_option_value((char_u *)"bt", 0L, (char_u *)"quickfix",
-	    OPT_LOCAL);
-    set_option_value((char_u *)"bh", 0L, (char_u *)"hide", OPT_LOCAL);
-    RESET_BINDING(curwin);
-#ifdef FEAT_DIFF
-    curwin->w_p_diff = FALSE;
-#endif
-#ifdef FEAT_FOLDING
-    set_option_value((char_u *)"fdm", 0L, (char_u *)"manual",
-	    OPT_LOCAL);
-#endif
+    // might have previously deleted (:bdelete) the quickfix buffer.
+    qf_set_cwindow_opts();
 
     // Only set the height when still in the same tab page and there is no
     // window to the side.

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -3933,6 +3933,16 @@ func Xqfbuf_test(cchar)
     call assert_match(qfbnum . '  h-  "\[Location List]"', execute('ls'))
     call assert_true(bufloaded(qfbnum))
 
+    " After deleting a location list buffer using ":bdelete", opening the
+    " location list window should mark the buffer as a location list buffer.
+    exe "bdelete " . qfbnum
+    lopen
+    call assert_equal("quickfix", &buftype)
+    call assert_equal(1, getwininfo(win_getid(winnr()))[0].loclist)
+    call assert_equal(wid, getloclist(0, {'filewinid' : 0}).filewinid)
+    call assert_false(&swapfile)
+    lclose
+
     " When the location list is cleared for the window, the buffer should be
     " removed
     call setloclist(0, [], 'f')


### PR DESCRIPTION
After closing the location list window, if the location list buffer is deleted using ":bdelete", reopening the location list window doesn't mark the buffer as a location list buffer. This breaks the location list window functionality.
