### PR TITLE
Fix SIGFPE crash with /= and %= operators when 2nd operand is 0

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1785,8 +1785,8 @@ ex_let_one(
 			    case '+': n = numval + n; break;
 			    case '-': n = numval - n; break;
 			    case '*': n = numval * n; break;
-			    case '/': n = num_divide(numval, n); break;
-			    case '%': n = num_modulus(numval, n); break;
+			    case '/': n = (long)num_divide(numval, n); break;
+			    case '%': n = (long)num_modulus(numval, n); break;
 			}
 		    }
 		    else if (opt_type == 0 && stringval != NULL) // string

--- a/src/eval.c
+++ b/src/eval.c
@@ -253,6 +253,33 @@ static char_u *find_option_end(char_u **arg, int *opt_flags);
 /* for VIM_VERSION_ defines */
 #include "version.h"
 
+	static varnumber_T
+num_divide(varnumber_T n1, varnumber_T n2)
+{
+    varnumber_T	result;
+
+    if (n2 == 0)	// give an error message?
+    {
+	if (n1 == 0)
+	    result = VARNUM_MIN; // similar to NaN
+	else if (n1 < 0)
+	    result = -VARNUM_MAX;
+	else
+	    result = VARNUM_MAX;
+    }
+    else
+	result = n1 / n2;
+
+    return result;
+}
+
+	static varnumber_T
+num_modulus(varnumber_T n1, varnumber_T n2)
+{
+    // Give an error when n2 is 0?
+    return (n2 == 0) ? 0 : (n1 % n2);
+}
+
 
 #if defined(EBCDIC) || defined(PROTO)
 /*
@@ -1758,8 +1785,8 @@ ex_let_one(
 			    case '+': n = numval + n; break;
 			    case '-': n = numval - n; break;
 			    case '*': n = numval * n; break;
-			    case '/': n = numval / n; break;
-			    case '%': n = numval % n; break;
+			    case '/': n = num_divide(numval, n); break;
+			    case '%': n = num_modulus(numval, n); break;
 			}
 		    }
 		    else if (opt_type == 0 && stringval != NULL) // string
@@ -2538,8 +2565,8 @@ tv_op(typval_T *tv1, typval_T *tv2, char_u *op)
 			    case '+': n += tv_get_number(tv2); break;
 			    case '-': n -= tv_get_number(tv2); break;
 			    case '*': n *= tv_get_number(tv2); break;
-			    case '/': n /= tv_get_number(tv2); break;
-			    case '%': n %= tv_get_number(tv2); break;
+			    case '/': n = num_divide(n, tv_get_number(tv2)); break;
+			    case '%': n = num_modulus(n, tv_get_number(tv2)); break;
 			}
 			clear_tv(tv1);
 			tv1->v_type = VAR_NUMBER;
@@ -4113,26 +4140,10 @@ eval6(
 		if (op == '*')
 		    n1 = n1 * n2;
 		else if (op == '/')
-		{
-		    if (n2 == 0)	/* give an error message? */
-		    {
-			if (n1 == 0)
-			    n1 = VARNUM_MIN; /* similar to NaN */
-			else if (n1 < 0)
-			    n1 = -VARNUM_MAX;
-			else
-			    n1 = VARNUM_MAX;
-		    }
-		    else
-			n1 = n1 / n2;
-		}
+		    n1 = num_divide(n1, n2);
 		else
-		{
-		    if (n2 == 0)	/* give an error message? */
-			n1 = 0;
-		    else
-			n1 = n1 % n2;
-		}
+		    n1 = num_modulus(n1, n2);
+
 		rettv->v_type = VAR_NUMBER;
 		rettv->vval.v_number = n1;
 	    }

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -21,7 +21,7 @@ com! -nargs=1	     Xout     call Xout(<args>)
 "
 " Create a script that consists of the body of the function a:funcname.
 " Replace any ":return" by a ":finish", any argument variable by a global
-" variable, and and every ":call" by a ":source" for the next following argument
+" variable, and every ":call" by a ":source" for the next following argument
 " in the variable argument list.  This function is useful if similar tests are
 " to be made for a ":return" from a function call or a ":finish" in a script
 " file.
@@ -1456,6 +1456,43 @@ func Test_compound_assignment_operators()
     call assert_equal(2, x)
     let x .= 'n'
     call assert_equal('2n', x)
+
+    " Test special cases: division or modulus with 0.
+    let x = 1
+    let x /= 0
+    if has('num64')
+        call assert_equal(0x7FFFFFFFFFFFFFFF, x)
+    else
+        call assert_equal(0x7fffffff, x)
+    endif
+
+    let x = -1
+    let x /= 0
+    if has('num64')
+        call assert_equal(-0x7FFFFFFFFFFFFFFF, x)
+    else
+        call assert_equal(-0x7fffffff, x)
+    endif
+
+    let x = 0
+    let x /= 0
+    if has('num64')
+        call assert_equal(-0x7FFFFFFFFFFFFFFF - 1, x)
+    else
+        call assert_equal(-0x7FFFFFFF - 1, x)
+    endif
+
+    let x = 1
+    let x %= 0
+    call assert_equal(0, x)
+
+    let x = -1
+    let x %= 0
+    call assert_equal(0, x)
+
+    let x = 0
+    let x %= 0
+    call assert_equal(0, x)
 
     " Test for string
     let x = 'str'


### PR DESCRIPTION
This PR fixes a crash in Vim-8.1.0895 when dividing
by 0 with the recently introduced operators `/=` and `%=`
in Vim-8.1.0902:
```
$ vim --clean -c 'let x = 1' -c 'let x /= 0'
Vim: Caught deadly signal FPE
Vim: Finished.
Floating point exception (core dumped)
```

Similarly, this also crashes:
```
$ vim --clean -c 'let x = 1' -c 'let x %= 0'
Vim: Caught deadly signal FPE
Vim: Finished.
Floating point exception (core dumped)
```