### PR TITLE
Proposal: Make "screenchar()" handle unicode composing characters

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2522,7 +2522,8 @@ resolve({filename})		String	get filename a shortcut points to
 reverse({list})			List	reverse {list} in-place
 round({expr})			Float	round off {expr}
 screenattr({row}, {col})	Number	attribute at screen position
-screenchar({row}, {col})	Number	character at screen position
+screenchar({row}, {col} [, {list}])
+				Number or List  character at screen position
 screencol()			Number	current cursor column
 screenrow()			Number	current cursor row
 search({pattern} [, {flags} [, {stopline} [, {timeout}]]])
@@ -7423,15 +7424,19 @@ screenattr({row}, {col})					*screenattr()*
 		arbitrary number that can only be used to compare to the
 		attribute at other positions.
 
-screenchar({row}, {col})					*screenchar()*
+screenchar({row}, {col} [, {list}])				*screenchar()*
 		The result is a Number, which is the character at position
-		[row, col] on the screen.  This works for every possible
+		[{row}, {col}] on the screen.  This works for every possible
 		screen position, also status lines, window separators and the
 		command line.  The top left position is row one, column one
 		The character excludes composing characters.  For double-byte
 		encodings it may only be the first byte.
+		When {list} is present and |TRUE|, return the result as a List.
+		In addition, and with 'encoding' is "utf-8", the result can
+		include number values of combining characters.
 		This is mainly to be used for testing.
-		Returns -1 when row or col is out of range.
+		If {row} or {col} is out of range, return -1 or an empty list
+		when {list} is set to 1 .
 
 screencol()							*screencol()*
 		The result is a Number, which is the current screen column of

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2429,6 +2429,8 @@ libcallnr({lib}, {func}, {arg})	Number	idem, but return a Number
 line({expr})			Number	line nr of cursor, last line or mark
 line2byte({lnum})		Number	byte count of line {lnum}
 lispindent({lnum})		Number	Lisp indent for line {lnum}
+list2str({list} [, {utf8}])	String	convert number values in {list} to one
+					String
 localtime()			Number	current time
 log({expr})			Float	natural logarithm (base e) of {expr}
 log10({expr})			Float	logarithm of Float {expr} to base 10
@@ -2591,6 +2593,8 @@ split({expr} [, {pat} [, {keepempty}]])
 				List	make |List| from {pat} separated {expr}
 sqrt({expr})			Float	square root of {expr}
 str2float({expr})		Float	convert String to Float
+str2list({expr} [, {utf8}])	List	convert each character of {expr} to
+					ASCII/UTF8 value
 str2nr({expr} [, {base}])	Number	convert String to Number
 strchars({expr} [, {skipcc}])	Number	character length of the String {expr}
 strcharpart({str}, {start} [, {len}])
@@ -6095,6 +6099,15 @@ lispindent({lnum})					*lispindent()*
 		When {lnum} is invalid or Vim was not compiled the
 		|+lispindent| feature, -1 is returned.
 
+list2str({list} [, {utf8}])				*list2str()*
+		Return a string which has the number values {expr}.  Examples: >
+			list2str([32])		returns " "
+			list2str([65, 66, 67])	returns "ABC"
+<		When {utf8} is omitted or zero, the current 'encoding' is used.
+		With {utf8} set to 1, always return utf-8 characters.
+		Composing characters are combined to one character: >
+			list2str([97, 769])	returns "á"
+<
 localtime()						*localtime()*
 		Return the current time, measured as seconds since 1st Jan
 		1970.  See also |strftime()| and |getftime()|.
@@ -8566,6 +8579,16 @@ str2float({expr})					*str2float()*
 			let f = str2float(substitute(text, ',', '', 'g'))
 <		{only available when compiled with the |+float| feature}
 
+str2list({expr} [, {utf8}])				*str2list()*
+		Return a list containing the number values which represent
+		each character of String {expr}.  Examples: >
+			str2list(" ")		returns [32]
+			str2list("ABC")		returns [65, 66, 67]
+<		When {utf8} is omitted or zero, the current 'encoding' is used.
+		With {utf8} set to 1, always treat as utf-8 characters.
+		Composing characters are also included in the result: >
+			str2list("á")		returns [97, 769]
+<		|list2str()| does the opposite.
 
 str2nr({expr} [, {base}])				*str2nr()*
 		Convert string {expr} to a number.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -259,6 +259,7 @@ static void f_libcallnr(typval_T *argvars, typval_T *rettv);
 static void f_line(typval_T *argvars, typval_T *rettv);
 static void f_line2byte(typval_T *argvars, typval_T *rettv);
 static void f_lispindent(typval_T *argvars, typval_T *rettv);
+static void f_list2str(typval_T *argvars, typval_T *rettv);
 static void f_localtime(typval_T *argvars, typval_T *rettv);
 #ifdef FEAT_FLOAT
 static void f_log(typval_T *argvars, typval_T *rettv);
@@ -392,6 +393,7 @@ static void f_split(typval_T *argvars, typval_T *rettv);
 static void f_sqrt(typval_T *argvars, typval_T *rettv);
 static void f_str2float(typval_T *argvars, typval_T *rettv);
 #endif
+static void f_str2list(typval_T *argvars, typval_T *rettv);
 static void f_str2nr(typval_T *argvars, typval_T *rettv);
 static void f_strchars(typval_T *argvars, typval_T *rettv);
 #ifdef HAVE_STRFTIME
@@ -738,6 +740,7 @@ static struct fst
     {"line",		1, 1, f_line},
     {"line2byte",	1, 1, f_line2byte},
     {"lispindent",	1, 1, f_lispindent},
+    {"list2str",	1, 2, f_list2str},
     {"localtime",	0, 0, f_localtime},
 #ifdef FEAT_FLOAT
     {"log",		1, 1, f_log},
@@ -882,6 +885,7 @@ static struct fst
     {"sqrt",		1, 1, f_sqrt},
     {"str2float",	1, 1, f_str2float},
 #endif
+    {"str2list",	1, 2, f_str2list},
     {"str2nr",		1, 2, f_str2nr},
     {"strcharpart",	2, 3, f_strcharpart},
     {"strchars",	1, 2, f_strchars},
@@ -7768,6 +7772,58 @@ f_lispindent(typval_T *argvars UNUSED, typval_T *rettv)
 }
 
 /*
+ * "list2str()" function
+ */
+    static void
+f_list2str(typval_T *argvars, typval_T *rettv)
+{
+    list_T	*l;
+    listitem_T	*li;
+    garray_T	ga;
+
+    if (argvars[0].v_type != VAR_LIST || argvars[0].vval.v_list == NULL)
+    {
+	emsg(_(e_invarg));
+	return;
+    }
+
+    l = argvars[0].vval.v_list;
+    ga_init2(&ga, 1, 80);
+
+    if (has_mbyte)
+    {
+	char_u buf[8];
+	int utf8 = 0;
+	int (*char2bytes)(int, char_u *);
+
+	if (argvars[1].v_type != VAR_UNKNOWN)
+	    utf8 = (int)tv_get_number_chk(&argvars[1], NULL);
+	if (utf8)
+	    char2bytes = utf_char2bytes;
+	else
+	    char2bytes = mb_char2bytes;
+
+	for (li = l->lv_first; li != NULL; li = li->li_next)
+	{
+	    buf[(*char2bytes)(tv_get_number(&li->li_tv), buf)] = NUL;
+	    ga_concat(&ga, buf);
+	}
+	ga_append(&ga, NUL);
+    }
+    else
+    {
+	ga_grow(&ga, list_len(l) + 1);
+
+	for (li = l->lv_first; li != NULL; li = li->li_next)
+	    ga_append(&ga, tv_get_number(&li->li_tv));
+	ga_append(&ga, NUL);
+    }
+
+    rettv->v_type = VAR_STRING;
+    rettv->vval.v_string = ga.ga_data;
+}
+
+/*
  * "localtime()" function
  */
     static void
@@ -12563,6 +12619,49 @@ f_str2float(typval_T *argvars, typval_T *rettv)
     rettv->v_type = VAR_FLOAT;
 }
 #endif
+
+/*
+ * "str2list()" function
+ */
+    static void
+f_str2list(typval_T *argvars, typval_T *rettv)
+{
+    char_u	*p;
+
+    if (rettv_list_alloc(rettv) == FAIL)
+	return;
+
+    p = tv_get_string(&argvars[0]);
+
+    if (has_mbyte)
+    {
+	int utf8 = 0;
+	int (*ptr2len)(char_u *);
+	int (*ptr2char)(char_u *);
+
+	if (argvars[1].v_type != VAR_UNKNOWN)
+	    utf8 = (int)tv_get_number_chk(&argvars[1], NULL);
+	if (utf8)
+	{
+	    ptr2len = utf_ptr2len;
+	    ptr2char = utf_ptr2char;
+	}
+	else
+	{
+	    ptr2len = mb_ptr2len;
+	    ptr2char = mb_ptr2char;
+	}
+
+	for (; *p != NUL; p += (*ptr2len)(p))
+	    list_append_number(rettv->vval.v_list,
+						 (varnumber_T)(*ptr2char)(p));
+    }
+    else
+    {
+	for (; *p != NUL; ++p)
+	    list_append_number(rettv->vval.v_list, (varnumber_T)*p);
+    }
+}
 
 /*
  * "str2nr()" function

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -1,5 +1,5 @@
 " Tests for Unicode manipulations
- 
+
 
 " Visual block Insert adjusts for multi-byte char
 func Test_visual_block_insert()
@@ -59,4 +59,40 @@ func Test_getvcol()
   call assert_equal(4, col("']"))
   call assert_equal(2, virtcol("'["))
   call assert_equal(2, virtcol("']"))
+endfunc
+
+func Test_list2str_str2list_utf8()
+  " One Unicode codepoint
+  let s = "\u3042"
+  let l = [0x3042]
+  call assert_equal(l, str2list(s, 1))
+  call assert_equal(s, list2str(l, 1))
+
+  " With composing characters
+  let s = "\u304b\u3099"
+  let l = [0x304b, 0x3099]
+  call assert_equal(l, str2list(s, 1))
+  call assert_equal(s, list2str(l, 1))
+endfunc
+
+func Test_screenchar_utf8()
+  new
+
+  " 1-cell, with composing characters 
+  call setline(1, ["ABC\u0308"])
+  redraw
+  call assert_equal([0x0041], screenchar(1, 1, 1))
+  call assert_equal([0x0042], screenchar(1, 2, 1))
+  call assert_equal([0x0043, 0x0308], screenchar(1, 3, 1))
+
+  " 2-cells, with composing characters 
+  call setline(1, ["\u3042\u3044\u3046\u3099"])
+  redraw
+  call assert_equal([0x3042], screenchar(1, 1, 1))
+  call assert_equal([0], screenchar(1, 2, 1))
+  call assert_equal([0x3044], screenchar(1, 3, 1))
+  call assert_equal([0], screenchar(1, 4, 1))
+  call assert_equal([0x3046, 0x3099], screenchar(1, 5, 1))
+
+  bwipe!
 endfunc

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -63,14 +63,14 @@ endfunc
 
 func Test_list2str_str2list_utf8()
   " One Unicode codepoint
-  let s = "\u3042"
-  let l = [0x3042]
+  let s = "\u3042\u3044"
+  let l = [0x3042, 0x3044]
   call assert_equal(l, str2list(s, 1))
   call assert_equal(s, list2str(l, 1))
 
   " With composing characters
-  let s = "\u304b\u3099"
-  let l = [0x304b, 0x3099]
+  let s = "\u304b\u3099\u3044"
+  let l = [0x304b, 0x3099, 0x3044]
   call assert_equal(l, str2list(s, 1))
   call assert_equal(s, list2str(l, 1))
 endfunc

--- a/src/testdir/view_util.vim
+++ b/src/testdir/view_util.vim
@@ -19,7 +19,7 @@ function! ScreenLines(lnum, width, ...) abort
   let utf8 = get(a:000, 0, 0)
   let lines = []
   for l in range(start, end)
-    let lines += [join(map(range(1, a:width), 'list2str(screenchar(l, v:val, utf8), utf8)'), '')]
+    let lines += [join(map(range(1, a:width), 'list2str(screenchar(l, v:val, 1), utf8)'), '')]
   endfor
   return lines
 endfunction

--- a/src/testdir/view_util.vim
+++ b/src/testdir/view_util.vim
@@ -5,9 +5,9 @@ if exists('*ScreenLines')
   finish
 endif
 
-" ScreenLines(lnum, width) or
-" ScreenLines([start, end], width)
-function! ScreenLines(lnum, width) abort
+" ScreenLines(lnum, width [, utf8]) or
+" ScreenLines([start, end], width [, utf8])
+function! ScreenLines(lnum, width, ...) abort
   redraw!
   if type(a:lnum) == v:t_list
     let start = a:lnum[0]
@@ -16,9 +16,10 @@ function! ScreenLines(lnum, width) abort
     let start = a:lnum
     let end = a:lnum
   endif
+  let utf8 = get(a:000, 0, 0)
   let lines = []
   for l in range(start, end)
-    let lines += [join(map(range(1, a:width), 'nr2char(screenchar(l, v:val))'), '')]
+    let lines += [join(map(range(1, a:width), 'list2str(screenchar(l, v:val, utf8), utf8)'), '')]
   endfor
   return lines
 endfunction


### PR DESCRIPTION
I propose to add the following features for handling unicode composing characters.

<del>char2nr(expr [, utf8 [, list]])</del>
str2list(expr [, utf8])
* e.g. str2list("\uXXXX\uYYYY\uZZZZ", 1) == [0xXXXX, 0xYYYY, 0xZZZZ] (\uYYYY is a composing character)

<del>nr2char(expr [, utf8])</del>
list2str(list [, utf8])
* e.g. list2str([0xXXXX, 0xYYYY, 0xZZZZ], 1) == "\uXXXX\uYYYY\uZZZZ" (\uYYYY is a composing character)

screenchar(row, col [, list])
* Add a new optional argument "list": when set it to 1 the result is a List of number values
* e.g. screenchar(1, 1, 1) == [0xXXXX, 0xYYYY] (\uYYYY is a composing character)