### PR TITLE
Various code cleanups

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2163,11 +2163,9 @@ free_buf_options(
     clear_string_option(&buf->b_p_isk);
 #ifdef FEAT_VARTABS
     clear_string_option(&buf->b_p_vsts);
-    if (buf->b_p_vsts_nopaste)
-	vim_free(buf->b_p_vsts_nopaste);
+    vim_free(buf->b_p_vsts_nopaste);
     buf->b_p_vsts_nopaste = NULL;
-    if (buf->b_p_vsts_array)
-	vim_free(buf->b_p_vsts_array);
+    vim_free(buf->b_p_vsts_array);
     buf->b_p_vsts_array = NULL;
     clear_string_option(&buf->b_p_vts);
     VIM_CLEAR(buf->b_p_vts_array);

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -42,7 +42,7 @@ typedef struct {
     /* Optional function pointer for a self-test. */
     int (* self_test_fn)();
 
-    /* Function pointer for initializing encryption/decription. */
+    /* Function pointer for initializing encryption/description. */
     void (* init_fn)(cryptstate_T *state, char_u *key,
 		      char_u *salt, int salt_len, char_u *seed, int seed_len);
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2451,7 +2451,7 @@ f_char2nr(typval_T *argvars, typval_T *rettv)
 	    utf8 = (int)tv_get_number_chk(&argvars[1], NULL);
 
 	if (utf8)
-	    rettv->vval.v_number = (*utf_ptr2char)(tv_get_string(&argvars[0]));
+	    rettv->vval.v_number = utf_ptr2char(tv_get_string(&argvars[0]));
 	else
 	    rettv->vval.v_number = (*mb_ptr2char)(tv_get_string(&argvars[0]));
     }
@@ -8701,7 +8701,7 @@ f_nr2char(typval_T *argvars, typval_T *rettv)
 	if (argvars[1].v_type != VAR_UNKNOWN)
 	    utf8 = (int)tv_get_number_chk(&argvars[1], NULL);
 	if (utf8)
-	    buf[(*utf_char2bytes)((int)tv_get_number(&argvars[0]), buf)] = NUL;
+	    buf[utf_char2bytes((int)tv_get_number(&argvars[0]), buf)] = NUL;
 	else
 	    buf[(*mb_char2bytes)((int)tv_get_number(&argvars[0]), buf)] = NUL;
     }
@@ -11647,7 +11647,7 @@ f_sign_jump(typval_T *argvars, typval_T *rettv)
 
     rettv->vval.v_number = -1;
 
-    // Sign identifer
+    // Sign identifier
     sign_id = (int)tv_get_number_chk(&argvars[0], &notanum);
     if (notanum)
 	return;
@@ -11699,7 +11699,7 @@ f_sign_place(typval_T *argvars, typval_T *rettv)
 
     rettv->vval.v_number = -1;
 
-    // Sign identifer
+    // Sign identifier
     sign_id = (int)tv_get_number_chk(&argvars[0], &notanum);
     if (notanum)
 	return;

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -2380,7 +2380,7 @@ check_changed_any(
 
 		goto_tabpage_win(tp, wp);
 
-		/* Paranoia: did autocms wipe out the buffer with changes? */
+		/* Paranoia: did autocmd wipe out the buffer with changes? */
 		if (!bufref_valid(&bufref))
 		    goto theend;
 		goto buf_found;

--- a/src/globals.h
+++ b/src/globals.h
@@ -426,7 +426,7 @@ EXTERN int	mouse_dragging INIT(= 0);	/* extending Visual area with
 # if defined(FEAT_MOUSE_DEC)
 /*
  * When the DEC mouse has been pressed but not yet released we enable
- * automatic querys for the mouse position.
+ * automatic queries for the mouse position.
  */
 EXTERN int	WantQueryMouse INIT(= FALSE);
 # endif

--- a/src/gui_gtk_f.c
+++ b/src/gui_gtk_f.c
@@ -561,7 +561,7 @@ gtk_form_draw(GtkWidget *widget, cairo_t *cr)
 	     * gtk_widget_size_allocate() in advance with a well-posed
 	     * allocation for a given child widget in order to set a
 	     * certain private GtkWidget variable, called
-	     * widget->priv->alloc_need, to the proper value; othewise,
+	     * widget->priv->alloc_need, to the proper value; otherwise,
 	     * gtk_widget_draw() fails and the relevant scrollbar won't
 	     * appear on the screen.
 	     *

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -7015,7 +7015,7 @@ gui_mch_drawsign(int row, int col, int typenr)
 		 (double)(MIN(height, SIGN_HEIGHT))) < 1.15)
 	    {
 		/* Change the aspect ratio by at most 15% to fill the
-		 * available space completly. */
+		 * available space completely. */
 		height = (double)SIGN_HEIGHT * SIGN_ASPECT / aspect;
 		height = MIN(height, SIGN_HEIGHT);
 	    }

--- a/src/gui_mac.c
+++ b/src/gui_mac.c
@@ -1342,10 +1342,6 @@ InstallAEHandlers(void)
     }
     error = AEInstallEventHandler('KAHL', 'MOD ',
 		    NewAEEventHandlerUPP(Handle_KAHL_MOD_AE), 0, false);
-    if (error)
-    {
-	return error;
-    }
 #endif
 
     return error;

--- a/src/macros.h
+++ b/src/macros.h
@@ -329,8 +329,6 @@
  */
 #define VIM_CLEAR(p) \
     do { \
-	if ((p) != NULL) { \
-	    vim_free(p); \
-	    (p) = NULL; \
-	} \
+	vim_free(p); \
+	(p) = NULL; \
     } while (0)

--- a/src/ops.c
+++ b/src/ops.c
@@ -5402,7 +5402,7 @@ op_addsub(
     linenr_T		amount = Prenum1;
 
    // do_addsub() might trigger re-evaluation of 'foldexpr' halfway, when the
-   // buffer is not completly updated yet. Postpone updating folds until before
+   // buffer is not completely updated yet. Postpone updating folds until before
    // the call to changed_lines().
 #ifdef FEAT_FOLDING
    disable_fold_update++;

--- a/src/option.h
+++ b/src/option.h
@@ -193,8 +193,8 @@
 #define SHM_WRI		'w'		/* "[w]" instead of "written" */
 #define SHM_A		"rmfixlnw"	/* represented by 'a' flag */
 #define SHM_WRITE	'W'		/* don't use "written" at all */
-#define SHM_TRUNC	't'		/* trunctate file messages */
-#define SHM_TRUNCALL	'T'		/* trunctate all messages */
+#define SHM_TRUNC	't'		/* truncate file messages */
+#define SHM_TRUNCALL	'T'		/* truncate all messages */
 #define SHM_OVER	'o'		/* overwrite file messages */
 #define SHM_OVERALL	'O'		/* overwrite more messages */
 #define SHM_SEARCH	's'		/* no search hit bottom messages */

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -6418,7 +6418,7 @@ mch_expand_wildcards(
     int		shell_style = STYLE_ECHO;
     int		check_spaces;
     static int	did_find_nul = FALSE;
-    int		ampersent = FALSE;
+    int		ampersand = FALSE;
 		/* vimglob() function to define for Posix shell */
     static char *sh_vimglob_func = "vimglob() { while [ $# -ge 1 ]; do echo \"$1\"; shift; done }; vimglob >";
 
@@ -6535,7 +6535,7 @@ mch_expand_wildcards(
 	    --p;
 	if (*p == '&')				/* remove trailing '&' */
 	{
-	    ampersent = TRUE;
+	    ampersand = TRUE;
 	    *p = ' ';
 	}
 	STRCAT(command, ">");
@@ -6604,7 +6604,7 @@ mch_expand_wildcards(
 	}
     if (flags & EW_SILENT)
 	show_shell_mess = FALSE;
-    if (ampersent)
+    if (ampersand)
 	STRCAT(command, "&");		/* put the '&' after the redirection */
 
     /*
@@ -6630,7 +6630,7 @@ mch_expand_wildcards(
 
     /* When running in the background, give it some time to create the temp
      * file, but don't wait for it to finish. */
-    if (ampersent)
+    if (ampersand)
 	mch_delay(10L, TRUE);
 
     extra_shell_arg = NULL;		/* cleanup */

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2646,7 +2646,7 @@ mch_init(void)
     if (cterm_normal_bg_color == 0)
 	cterm_normal_bg_color = ((g_attrCurrent >> 4) & 0xf) + 1;
 
-    // Fg and Bg color index nunmber at startup
+    // Fg and Bg color index number at startup
     g_color_index_fg = g_attrDefault & 0xf;
     g_color_index_bg = (g_attrDefault >> 4) & 0xf;
 
@@ -4210,8 +4210,7 @@ vim_create_process(
 	    (LPSTARTUPINFOW)si,	/* Startup information */
 	    pi);			/* Process information */
 	vim_free(wcmd);
-	if (wcwd != NULL)
-	    vim_free(wcwd);
+	vim_free(wcwd);
 	return ret;
     }
 fallback:
@@ -5312,8 +5311,8 @@ win32_build_env(dict_T *env, garray_T *gap, int is_terminal)
 			*((WCHAR*)gap->ga_data + gap->ga_len++) = wval[n];
 		    *((WCHAR*)gap->ga_data + gap->ga_len++) = L'\0';
 		}
-		if (wkey != NULL) vim_free(wkey);
-		if (wval != NULL) vim_free(wval);
+		vim_free(wkey);
+		vim_free(wval);
 	    }
 	}
     }

--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -405,7 +405,7 @@ pum_redraw(void)
     char_u	*p = NULL;
     int		totwidth, width, w;
     int		thumb_pos = 0;
-    int		thumb_heigth = 1;
+    int		thumb_height = 1;
     int		round;
     int		n;
 
@@ -423,10 +423,10 @@ pum_redraw(void)
 
     if (pum_scrollbar)
     {
-	thumb_heigth = pum_height * pum_height / pum_size;
-	if (thumb_heigth == 0)
-	    thumb_heigth = 1;
-	thumb_pos = (pum_first * (pum_height - thumb_heigth)
+	thumb_height = pum_height * pum_height / pum_size;
+	if (thumb_height == 0)
+	    thumb_height = 1;
+	thumb_pos = (pum_first * (pum_height - thumb_height)
 			    + (pum_size - pum_height) / 2)
 						    / (pum_size - pum_height);
     }
@@ -600,12 +600,12 @@ pum_redraw(void)
 #ifdef FEAT_RIGHTLEFT
 	    if (curwin->w_p_rl)
 		screen_putchar(' ', row, pum_col - pum_width,
-			i >= thumb_pos && i < thumb_pos + thumb_heigth
+			i >= thumb_pos && i < thumb_pos + thumb_height
 						  ? attr_thumb : attr_scroll);
 	    else
 #endif
 		screen_putchar(' ', row, pum_col + pum_width,
-			i >= thumb_pos && i < thumb_pos + thumb_heigth
+			i >= thumb_pos && i < thumb_pos + thumb_height
 						  ? attr_thumb : attr_scroll);
 	}
 

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -6457,7 +6457,7 @@ regdump(char_u *pattern, bt_regprog_T *r)
 	}
 	else if (op == RE_LNUM || op == RE_COL || op == RE_VCOL)
 	{
-	    /* one int plus comperator */
+	    /* one int plus comparator */
 	    fprintf(f, " count %ld", OPERAND_MIN(s));
 	    s += 5;
 	}

--- a/src/ui.c
+++ b/src/ui.c
@@ -1738,7 +1738,7 @@ clip_gen_set_selection(VimClipboard *cbd)
     if (!clip_did_set_selection)
     {
 	/* Updating postponed, so that accessing the system clipboard won't
-	 * hang Vim when accessing it many times (e.g. on a :g comand). */
+	 * hang Vim when accessing it many times (e.g. on a :g command). */
 	if ((cbd == &clip_plus && (clip_unnamed_saved & CLIP_UNNAMED_PLUS))
 		|| (cbd == &clip_star && (clip_unnamed_saved & CLIP_UNNAMED)))
 	{

--- a/src/version.c
+++ b/src/version.c
@@ -41,7 +41,7 @@ init_longVersion(void)
 {
     /*
      * Construct the long version string.  Necessary because
-     * VAX C can't catenate strings in the preprocessor.
+     * VAX C can't concatenate strings in the preprocessor.
      */
     strcpy(longVersion, VIM_VERSION_LONG_DATE);
     strcat(longVersion, __DATE__);


### PR DESCRIPTION
This PR makes various minor code clean-ups:
* remove useless checks for `NULL` when calling `vim_free()`
* `utf_ptr2char` and `utf_char2bytes` are functions, not function pointers, so calling `(*utf_ptr2char)(...)` was strange, use  `utf_ptr2char(...)` instead
* fixed typos