### PR TITLE
Fix build errors for small build +eval and normal build -eval

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -866,7 +866,11 @@ theend:
     int
 diff_internal(void)
 {
+#ifdef FEAT_EVAL
     return (diff_flags & DIFF_INTERNAL) != 0 && *p_dex == NUL;
+#else
+    return (diff_flags & DIFF_INTERNAL) != 0;
+#endif
 }
 
 /*

--- a/src/search.c
+++ b/src/search.c
@@ -567,7 +567,9 @@ set_last_search_pat(
 	    saved_spats[idx].pat = NULL;
 	else
 	    saved_spats[idx].pat = vim_strsave(spats[idx].pat);
+# ifdef FEAT_SEARCH_EXTRA
 	saved_spats_last_idx = last_idx;
+# endif
     }
 # ifdef FEAT_SEARCH_EXTRA
     /* If 'hlsearch' set and search pat changed: need redraw. */


### PR DESCRIPTION
Added some #ifdefs to fix build errors when:
- FEAT_EVAL defined and FEAT_SEARCH_EXTRA undefined
- FEAT_DIFF defined and FEAT_EVAL undefined