### PR TITLE
win32: Fix vim.exe wrongly uses guicolor on 256 colors mode

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7844,7 +7844,7 @@ set_console_color_rgb(void)
 	return;
 
     id = syn_name2id((char_u *)"Normal");
-    if (id > 0)
+    if (id > 0 && p_tgc)
 	syn_id2colors(id, &fg, &bg);
     if (fg == INVALCOLOR)
     {


### PR DESCRIPTION
The vim.exe wrongly uses guicolor on 256 colors mode.
How to reproduce:

1. `vim --clean`
2. `:set t_Co=256` (Enable using VTP with 256 colors mode.)
3. `:colorscheme desert` (The background becomes grey which should be black.)

The desert colorscheme sets `guibg=grey20`, so the background should be grey
when 'tgc' is on, however, it becomes grey even if 'tgc' is off.
This PR fixes the problem.