### PR TITLE
Minor fixes for filetype detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -197,7 +197,7 @@ func dist#ft#FTe()
     exe 'setf ' . g:filetype_euphoria
   else
     let n = 1
-    while n < 100 && n < line("$")
+    while n < 100 && n <= line('$')
       if getline(n) =~ "^\\s*\\(<'\\|'>\\)\\s*$"
 	setf specman
 	return
@@ -211,7 +211,7 @@ endfunc
 " Distinguish between HTML, XHTML and Django
 func dist#ft#FThtml()
   let n = 1
-  while n < 10 && n < line("$")
+  while n < 10 && n <= line('$')
     if getline(n) =~ '\<DTD\s\+XHTML\s'
       setf xhtml
       return
@@ -222,13 +222,13 @@ func dist#ft#FThtml()
     endif
     let n = n + 1
   endwhile
-  setf html
+  setf FALLBACK html
 endfunc
 
 " Distinguish between standard IDL and MS-IDL
 func dist#ft#FTidl()
   let n = 1
-  while n < 50 && n < line("$")
+  while n < 50 && n <= line('$')
     if getline(n) =~ '^\s*import\s\+"\(unknwn\|objidl\)\.idl"'
       setf msidl
       return
@@ -699,7 +699,7 @@ endfunc
 
 func dist#ft#FTxml()
   let n = 1
-  while n < 100 && n < line("$")
+  while n < 100 && n <= line('$')
     let line = getline(n)
     " DocBook 4 or DocBook 5.
     let is_docbook4 = line =~ '<!DOCTYPE.*DocBook'
@@ -725,7 +725,7 @@ endfunc
 
 func dist#ft#FTy()
   let n = 1
-  while n < 100 && n < line("$")
+  while n < 100 && n <= line('$')
     let line = getline(n)
     if line =~ '^\s*%'
       setf yacc

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -383,7 +383,7 @@ Setting the filetype
 
 			When the optional FALLBACK argument is present, a
 			later :setfiletype command will override the
-			'filetype'.  This is to used for filetype detections
+			'filetype'.  This is to be used for filetype detections
 			that are just a guess.  |did_filetype()| will return
 			false after this command.
 


### PR DESCRIPTION
- fix upper boundaries with `while n < …` loops.
  E.g. dist#ft#FThtml would not detect htmldjango with a buffer that
  contains a single line only (confusing).
- typo in docs