### PR TITLE
Fix #2346 - Add the deleted text to register 1 only if no register is provided wi…

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -1833,12 +1833,12 @@ op_delete(oparg_T *oap)
 
 	/*
 	 * Put deleted text into register 1 and shift number registers if the
-	 * delete contains a line break, or when a regname has been specified.
+	 * delete contains a line break and a regname has not been specified.
 	 * Use the register name from before adjust_clip_reg() may have
 	 * changed it.
 	 */
-	if (orig_regname != 0 || oap->motion_type == MLINE
-				   || oap->line_count > 1 || oap->use_reg_one)
+	if (((oap->motion_type == MLINE
+		|| oap->line_count > 1) && orig_regname == 0) || oap->use_reg_one)
 	{
 	    shift_delete_registers();
 	    if (op_yank(oap, TRUE, FALSE) == OK)

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -42,7 +42,6 @@ func Test_display_registers()
     call assert_match('^\n--- Registers ---\n'
           \ .         '""   a\n'
           \ .         '"0   ba\n'
-          \ .         '"1   b\n'
           \ .         '"a   b\n'
           \ .         '.*'
           \ .         '"-   a\n'
@@ -61,5 +60,14 @@ func Test_display_registers()
     call assert_match('^\n--- Registers ---\n'
           \ .         '":   ls', a)
 
+	exe 'norm! dd' 
+	exe 'norm! "add' 
+    let a = execute('registers 1')
+    call assert_match('^\n--- Registers ---\n'
+          \ .         '"1   8r', a)
+
+    let a = execute('registers a')
+    call assert_match('^\n--- Registers ---\n'
+          \ .         '"a   foo', a)
     bwipe!
 endfunc


### PR DESCRIPTION
Fix #2346 - Add the deleted text to register 1 only if no register is provided with delete command.