### PR TITLE
Run garbagecollectnow() to improve lua test coverage

### DIFF
--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -4,6 +4,11 @@ if !has('lua')
   finish
 endif
 
+func TearDown()
+  " Run garbage collection after each test to exercise luaV_setref().
+  call test_garbagecollect_now()
+endfunc
+
 " Check that switching to another buffer does not trigger ml_get error.
 func Test_command_new_no_ml_get_error()
   new


### PR DESCRIPTION
This PR improves test coverage of lua code.
Function `luaV_setref()` was not covered with tests according to codecov:

https://codecov.io/gh/vim/vim/src/cbef8e1aa1f260ffde16491b1678eae53a36cf68/src/if_lua.c#L1803

Running `garbagecollectnow()` after each test exercises that code.