### PR TITLE
fixed g{j,k} when starting from inside a fold.

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -7941,11 +7941,7 @@ nv_g_cmd(cmdarg_T *cap)
     case K_DOWN:
 	/* with 'nowrap' it works just like the normal "j" command; also when
 	 * in a closed fold */
-	if (!curwin->w_p_wrap
-#ifdef FEAT_FOLDING
-		|| hasFolding(curwin->w_cursor.lnum, NULL, NULL)
-#endif
-		)
+	if (!curwin->w_p_wrap)
 	{
 	    oap->motion_type = MLINE;
 	    i = cursor_down(cap->count1, oap->op_type == OP_NOP);
@@ -7960,11 +7956,7 @@ nv_g_cmd(cmdarg_T *cap)
     case K_UP:
 	/* with 'nowrap' it works just like the normal "k" command; also when
 	 * in a closed fold */
-	if (!curwin->w_p_wrap
-#ifdef FEAT_FOLDING
-		|| hasFolding(curwin->w_cursor.lnum, NULL, NULL)
-#endif
-	   )
+	if (!curwin->w_p_wrap)
 	{
 	    oap->motion_type = MLINE;
 	    i = cursor_up(cap->count1, oap->op_type == OP_NOP);


### PR DESCRIPTION
When using `[n]g{j, k}` starting inside a fold, the behavior differs from what it is described to be: 


### What it does:
- It behaves like [n]j if started from inside a fold. 
- When outside a closed fold, it does what it is supposed to do.


### What it is supposed to do:
move down `n` lines, where `lines` refers to the visual line on screen (taking into account wrapped lines as multiple lines).

### Example:
![description](https://user-images.githubusercontent.com/9212314/54114293-5f318580-43ea-11e9-9cc9-787bebbe85c2.jpg)
Example: when typing `6j` from line `14` (fold, currently active in screenshot), it moves to the relative line `6` (two beneath the wrapped line), although it should move into the 3rd line of the wrapped lines.


#### Sample text that can be used for reproducing the issue
Even though it is straight forward to reproduce it, below you can find text for reproducing the issue. Be sure to close the fold located at line `4` and to reduce the window's size and to have wrapped enabled.
Then issue `6gj`

Setup environment
```vim
" paste below text and ensure that the line is wrapped
:4
:setlocal foldmethod=indent
zc
:set relativenumber

```

```

{
	-
	-
	-
	-
}



This is a line that spans across multiple single lines because line-wrapping is enabled. (2) This is a line that spans across multiple single lines because line-wrapping is enabled. (3) This is a line that spans across multiple single lines because line-wrapping is enabled. (4)  This is a line that spans across multiple single lines because line-wrapping is enabled. 

```


I am not sure why it is checked whether the current line is inside a closed fold anyway (and assume that that is a leftover from when `gj` was implemented differently. 
