### PR TITLE
Improve travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,8 +154,8 @@ script:
     if [[ -n "${ASAN_OPTIONS}" ]]; then
       while read log; do
         asan_symbolize < "${log}"
+        false # exit 1 if there are ASAN logs
       done < <(find . -type f -name 'asan.*' -size +0)
-      [[ -z "${log}" ]] # exit 1 if there are ASAN logs
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,7 @@ before_script:
 
 script:
   - NPROC=$(getconf _NPROCESSORS_ONLN)
+  - set -o errexit
   - echo "Configuring Vim" && echo -en "travis_fold:start:configure\r"
   - |
     if [[ "${CHECK_AUTOCONF}" = "yes" ]] && [[ "${CC}" = "gcc" ]]; then
@@ -143,6 +144,7 @@ script:
       make ${SHADOWOPT} -j${NPROC}
     fi
   - echo -en "travis_fold:end:build\r"
+  - set +o errexit
   - echo "Testing Vim" && echo -en "travis_fold:start:test\r"
   # Show Vim version and also if_xx versions.
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,8 @@ script:
     if [[ -n "${SHADOWOPT}" ]]; then
       make -C src shadow
     fi
-  - (cd "${SRCDIR}" && ./configure --with-features=${FEATURES} ${CONFOPT} --enable-fail-if-missing)
+  # "./configure" changes its working directory into "$SRCDIR".
+  - ./configure --with-features=${FEATURES} ${CONFOPT} --enable-fail-if-missing
   - echo -en "travis_fold:end:configure\r"
   - echo "Building Vim" && echo -en "travis_fold:start:build\r"
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ before_script:
 script:
   - NPROC=$(getconf _NPROCESSORS_ONLN)
   - set -o errexit
-  - echo "Configuring Vim" && echo -en "travis_fold:start:configure\r"
+  - echo -e "\\033[33;1mConfiguring Vim\\033[0m" && echo -en "travis_fold:start:configure\\r\\033[0K"
   - |
     if [[ "${CHECK_AUTOCONF}" = "yes" ]] && [[ "${CC}" = "gcc" ]]; then
       make -C src autoconf
@@ -138,15 +138,15 @@ script:
     fi
   # "./configure" changes its working directory into "$SRCDIR".
   - ./configure --with-features=${FEATURES} ${CONFOPT} --enable-fail-if-missing
-  - echo -en "travis_fold:end:configure\r"
-  - echo "Building Vim" && echo -en "travis_fold:start:build\r"
+  - echo -en "travis_fold:end:configure\\r\\033[0K"
+  - echo -e "\\033[33;1mBuilding Vim\\033[0m" && echo -en "travis_fold:start:build\\r\\033[0K"
   - |
     if [[ "${BUILD}" = "yes" ]]; then
       make ${SHADOWOPT} -j${NPROC}
     fi
-  - echo -en "travis_fold:end:build\r"
+  - echo -en "travis_fold:end:build\\r\\033[0K"
   - set +o errexit
-  - echo "Testing Vim" && echo -en "travis_fold:start:test\r"
+  - echo -e "\\033[33;1mTesting Vim\\033[0m" && echo -en "travis_fold:start:test\\r\\033[0K"
   # Show Vim version and also if_xx versions.
   - |
     if [[ "${BUILD}" = "yes" ]]; then
@@ -156,7 +156,7 @@ script:
       cat if_ver.txt
     fi
   - make ${SHADOWOPT} ${TEST}
-  - echo -en "travis_fold:end:test\r"
+  - echo -en "travis_fold:end:test\\r\\033[0K"
   - |
     if [[ -n "${ASAN_OPTIONS}" ]]; then
       while read log; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,7 @@ before_script:
 
 script:
   - NPROC=$(getconf _NPROCESSORS_ONLN)
+  - echo "Configuring Vim" && echo -en "travis_fold:start:configure\r"
   - |
     if [[ "${CHECK_AUTOCONF}" = "yes" ]] && [[ "${CC}" = "gcc" ]]; then
       make -C src autoconf
@@ -134,13 +135,15 @@ script:
     if [[ -n "${SHADOWOPT}" ]]; then
       make -C src shadow
     fi
+  - (cd "${SRCDIR}" && ./configure --with-features=${FEATURES} ${CONFOPT} --enable-fail-if-missing)
+  - echo -en "travis_fold:end:configure\r"
+  - echo "Building Vim" && echo -en "travis_fold:start:build\r"
   - |
-    (
-    cd "${SRCDIR}" \
-      && ./configure --with-features=${FEATURES} ${CONFOPT} --enable-fail-if-missing
-    ) && if [[ "${BUILD}" = "yes" ]]; then
+    if [[ "${BUILD}" = "yes" ]]; then
       make ${SHADOWOPT} -j${NPROC}
     fi
+  - echo -en "travis_fold:end:build\r"
+  - echo "Testing Vim" && echo -en "travis_fold:start:test\r"
   # Show Vim version and also if_xx versions.
   - |
     if [[ "${BUILD}" = "yes" ]]; then
@@ -150,6 +153,7 @@ script:
       cat if_ver.txt
     fi
   - make ${SHADOWOPT} ${TEST}
+  - echo -en "travis_fold:end:test\r"
   - |
     if [[ -n "${ASAN_OPTIONS}" ]]; then
       while read log; do

--- a/configure
+++ b/configure
@@ -3,4 +3,4 @@
 # This is just a stub for the Unix configure script, to provide support for
 # doing "./configure" in the top Vim directory.
 
-cd src && exec ./configure "$@"
+cd "${SRCDIR:-src}" && exec ./configure "$@"


### PR DESCRIPTION
## Fold log messages

Example:
![log](https://user-images.githubusercontent.com/943423/54136133-87f36280-445e-11e9-8460-004c69862202.png)

"Configuring Vim", "Building Vim", "Testing Vim".

## Fix ASAN dump

Bash executes "while read" loop on subshell so variables which are set during while-loop are discarded after the loop finishes.
Therefore, in order to exit from while-loop with exit-status 1, must finish do-done block with exit-status 1. (e.g. `do ...; false; done`)

## Do "./configure" on "SRCDIR"

On travis "osx" env, when with `set -o errexit` (also `set -e`), `(cd "$SRCDIR && ./configure ...)` fails (hangs?) unexpectedly.
I propose to change working directory to "$SRCDIR" in "./configure".