### PR TITLE
autocmd: introduce "++once" flag

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -52,7 +52,7 @@ effects.  Be careful not to destroy your text.
 2. Defining autocommands				*autocmd-define*
 
 							*:au* *:autocmd*
-:au[tocmd] [group] {event} {pat} [-once] [-nested] {cmd}
+:au[tocmd] [group] {event} {pat} [++once] [++nested] {cmd}
 			Add {cmd} to the list of commands that Vim will
 			execute automatically on {event} for a file matching
 			{pat} |autocmd-patterns|.
@@ -60,9 +60,9 @@ effects.  Be careful not to destroy your text.
 			:autocmd and won't start a comment.
 			Vim always adds the {cmd} after existing autocommands,
 			so that the autocommands execute in the order in which
-			they were given.  See |autocmd-nested| for [-nested].
+			they were given.  See |autocmd-nested| for [++nested].
 							*autocmd-once*
-			If [-once] is supplied the command is executed once,
+			If [++once] is supplied the command is executed once,
 			then removed ("one shot").
 
 The special pattern <buffer> or <buffer=N> defines a buffer-local autocommand.
@@ -131,11 +131,11 @@ prompt.  When one command outputs two messages this can happen anyway.
 ==============================================================================
 3. Removing autocommands				*autocmd-remove*
 
-:au[tocmd]! [group] {event} {pat} [-once] [-nested] {cmd}
+:au[tocmd]! [group] {event} {pat} [++once] [++nested] {cmd}
 			Remove all autocommands associated with {event} and
 			{pat}, and add the command {cmd}.
-			See |autocmd-once| for [-once].
-			See |autocmd-nested| for [-nested].
+			See |autocmd-once| for [++once].
+			See |autocmd-nested| for [++nested].
 
 :au[tocmd]! [group] {event} {pat}
 			Remove all autocommands associated with {event} and
@@ -1473,7 +1473,7 @@ By default, autocommands do not nest.  If you use ":e" or ":w" in an
 autocommand, Vim does not execute the BufRead and BufWrite autocommands for
 those commands.  If you do want this, use the "nested" flag for those commands
 in which you want nesting.  For example: >
-  :autocmd FileChangedShell *.c -nested e!
+  :autocmd FileChangedShell *.c ++nested e!
 The nesting is limited to 10 levels to get out of recursive loops.
 
 It's possible to use the ":au" command in an autocommand.  This can be a

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -52,7 +52,7 @@ effects.  Be careful not to destroy your text.
 2. Defining autocommands				*autocmd-define*
 
 							*:au* *:autocmd*
-:au[tocmd] [group] {event} {pat} [once] [nested] {cmd}
+:au[tocmd] [group] {event} {pat} [-once] [-nested] {cmd}
 			Add {cmd} to the list of commands that Vim will
 			execute automatically on {event} for a file matching
 			{pat} |autocmd-patterns|.
@@ -60,9 +60,9 @@ effects.  Be careful not to destroy your text.
 			:autocmd and won't start a comment.
 			Vim always adds the {cmd} after existing autocommands,
 			so that the autocommands execute in the order in which
-			they were given.  See |autocmd-nested| for [nested].
+			they were given.  See |autocmd-nested| for [-nested].
 							*autocmd-once*
-			If [once] is supplied the command is executed once,
+			If [-once] is supplied the command is executed once,
 			then removed ("one shot").
 
 The special pattern <buffer> or <buffer=N> defines a buffer-local autocommand.
@@ -131,11 +131,11 @@ prompt.  When one command outputs two messages this can happen anyway.
 ==============================================================================
 3. Removing autocommands				*autocmd-remove*
 
-:au[tocmd]! [group] {event} {pat} [once] [nested] {cmd}
+:au[tocmd]! [group] {event} {pat} [-once] [-nested] {cmd}
 			Remove all autocommands associated with {event} and
 			{pat}, and add the command {cmd}.
-			See |autocmd-once| for [once].
-			See |autocmd-nested| for [nested].
+			See |autocmd-once| for [-once].
+			See |autocmd-nested| for [-nested].
 
 :au[tocmd]! [group] {event} {pat}
 			Remove all autocommands associated with {event} and
@@ -1473,7 +1473,7 @@ By default, autocommands do not nest.  If you use ":e" or ":w" in an
 autocommand, Vim does not execute the BufRead and BufWrite autocommands for
 those commands.  If you do want this, use the "nested" flag for those commands
 in which you want nesting.  For example: >
-  :autocmd FileChangedShell *.c nested e!
+  :autocmd FileChangedShell *.c -nested e!
 The nesting is limited to 10 levels to get out of recursive loops.
 
 It's possible to use the ":au" command in an autocommand.  This can be a

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -52,7 +52,7 @@ effects.  Be careful not to destroy your text.
 2. Defining autocommands				*autocmd-define*
 
 							*:au* *:autocmd*
-:au[tocmd] [group] {event} {pat} [nested] {cmd}
+:au[tocmd] [group] {event} {pat} [once] [nested] {cmd}
 			Add {cmd} to the list of commands that Vim will
 			execute automatically on {event} for a file matching
 			{pat} |autocmd-patterns|.
@@ -61,6 +61,9 @@ effects.  Be careful not to destroy your text.
 			Vim always adds the {cmd} after existing autocommands,
 			so that the autocommands execute in the order in which
 			they were given.  See |autocmd-nested| for [nested].
+							*autocmd-once*
+			If [once] is supplied the command is executed once,
+			then removed ("one shot").
 
 The special pattern <buffer> or <buffer=N> defines a buffer-local autocommand.
 See |autocmd-buflocal|.
@@ -128,10 +131,11 @@ prompt.  When one command outputs two messages this can happen anyway.
 ==============================================================================
 3. Removing autocommands				*autocmd-remove*
 
-:au[tocmd]! [group] {event} {pat} [nested] {cmd}
+:au[tocmd]! [group] {event} {pat} [once] [nested] {cmd}
 			Remove all autocommands associated with {event} and
-			{pat}, and add the command {cmd}.  See
-			|autocmd-nested| for [nested].
+			{pat}, and add the command {cmd}.
+			See |autocmd-once| for [once].
+			See |autocmd-nested| for [nested].
 
 :au[tocmd]! [group] {event} {pat}
 			Remove all autocommands associated with {event} and

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -890,17 +890,18 @@ do_autocmd(char_u *arg_in, int forceit)
 	cmd = skipwhite(cmd);
 	for (i = 0; i < 2; i++) {
 	  if (*cmd != NUL) {
-	    // Check for "once" flag.
-	    if (!once && STRNCMP(cmd, "once", 4) == 0 && VIM_ISWHITE(cmd[4])) {
+	    // Check for "-once" flag.
+	    if (!once && STRNCMP(cmd, "-once", 5) == 0 && VIM_ISWHITE(cmd[5])) {
 	      once = TRUE;
 	      cmd = skipwhite(cmd + 5);
 	    }
-	    // Check for "nested" flag.
+	    // Check for "-nested" flag.
 	    if (!nested
-		&& ((STRNCMP(cmd, "nested", 6) == 0 && VIM_ISWHITE(cmd[6]))
-		    )) {
+		&& ((STRNCMP(cmd, "-nested", 7) == 0 && VIM_ISWHITE(cmd[7]))
+		    // Deprecated form (without "-").
+		    || (STRNCMP(cmd, "nested", 6) == 0 && VIM_ISWHITE(cmd[6])))) {
 	      nested = TRUE;
-	      cmd = skipwhite(cmd + 6);
+	      cmd = skipwhite(cmd + ('-' == cmd[0] ? 7 : 6));
 	    }
 	  }
 	}

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -394,6 +394,8 @@ au_cleanup(void)
 	{
 	    // loop over all commands for this pattern
 	    prev_ac = &(ap->cmds);
+	    int has_cmd = FALSE;
+
 	    for (ac = *prev_ac; ac != NULL; ac = *prev_ac)
 	    {
 		// remove the command if the pattern is to be deleted or when
@@ -404,8 +406,16 @@ au_cleanup(void)
 		    vim_free(ac->cmd);
 		    vim_free(ac);
 		}
-		else
+		else {
+		    has_cmd = TRUE;
 		    prev_ac = &(ac->next);
+		}
+	    }
+
+	    if (ap->pat != NULL && !has_cmd) {
+		// Pattern was not marked for deletion, but all of its
+		// commands were.  So mark the pattern for deletion.
+		au_remove_pat(ap);
 	    }
 
 	    // remove the pattern if it has been marked for deletion

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -890,18 +890,21 @@ do_autocmd(char_u *arg_in, int forceit)
 	cmd = skipwhite(cmd);
 	for (i = 0; i < 2; i++) {
 	  if (*cmd != NUL) {
-	    // Check for "-once" flag.
-	    if (!once && STRNCMP(cmd, "-once", 5) == 0 && VIM_ISWHITE(cmd[5])) {
+	    // Check for "++once" flag.
+	    if (!once && STRNCMP(cmd, "++once", 6) == 0 && VIM_ISWHITE(cmd[6]))
+	    {
 	      once = TRUE;
-	      cmd = skipwhite(cmd + 5);
+	      cmd = skipwhite(cmd + 6);
 	    }
-	    // Check for "-nested" flag.
+	    // Check for "++nested" flag.
 	    if (!nested
-		&& ((STRNCMP(cmd, "-nested", 7) == 0 && VIM_ISWHITE(cmd[7]))
-		    // Deprecated form (without "-").
-		    || (STRNCMP(cmd, "nested", 6) == 0 && VIM_ISWHITE(cmd[6])))) {
+		&& ((STRNCMP(cmd, "++nested", 8) == 0 && VIM_ISWHITE(cmd[8]))
+		    // Deprecated form (without "++").
+		    || (STRNCMP(cmd, "nested", 6) == 0
+			&& VIM_ISWHITE(cmd[6]))))
+	    {
 	      nested = TRUE;
-	      cmd = skipwhite(cmd + ('-' == cmd[0] ? 7 : 6));
+	      cmd = skipwhite(cmd + ('+' == cmd[0] ? 8 : 6));
 	    }
 	  }
 	}


### PR DESCRIPTION
Adds a new feature to :autocmd which sets the handler to be executed once, then removed.

Before:

    augroup FooGroup
      autocmd!
      autocmd FileType foo call Foo() | autocmd! FooGroup FileType foo
    augroup END

After:

    autocmd FileType foo ++once call Foo()

- commit 2 renames the `once` flag to `-once` and also adds support for `-nested`. This is to avoid yet another "flags" pattern not seen anywhere else in Vim, and instead be consistent with e.g. `:command` flags pattern.
- commit 3 renames again, to `++once` and `++nested`