### PR TITLE
Add complete_info() function

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2267,6 +2267,7 @@ col({expr})			Number	column nr of cursor or mark
 complete({startcol}, {matches}) none	set Insert mode completion
 complete_add({expr})		Number	add completion match
 complete_check()		Number	check for key typed during completion
+complete_info([{what}])		Dict	get current completion information
 confirm({msg} [, {choices} [, {default} [, {type}]]])
 				Number	number of choice picked by user
 copy({expr})			any	make a shallow copy of {expr}
@@ -3535,6 +3536,46 @@ complete_check()				*complete_check()*
 		zero otherwise.
 		Only to be used by the function specified with the
 		'completefunc' option.
+
+							*complete_info()*
+complete_info([{what}])
+		Returns a Dictionary with information about insert mode
+		completion.  see |ins-completion|.
+		The items are:
+		   mode		current completion mode name string.
+				See |completion_info_mode| for the values.
+		   pum_visible	|TRUE| if popup menu is visible.
+				See |pumvisible()|.
+		   items	List of completion matches.  Each item is a
+				dictionary containing the entries "word",
+				"abbr", "menu", "kind", "info" and "user_data".
+				See |complete-items|.
+		   selected	Selected item index.  First index is zero.
+				Set -1 if not selected.
+		   inserted	Inserted string. [NOT IMPLEMENT YET]
+
+							*complete_info_mode*
+		mode values are:
+		   ""		Not in completion mode
+		   "keyword"	Keyword completion |i_CTRL-X_CTRL-N|
+		   "ctrl_x"	Just press |i_CTRL-X|
+		   "whole_line"	Whole lines |i_CTRL-X_CTRL-L|
+		   "files"	File names |i_CTRL-X_CTRL-F|
+		   "tags"	Tags |i_CTRL-X_CTRL-]|
+		   "path_defines"    Definition completion |i_CTRL-X_CTRL-D|
+		   "path_patterns"   Include completion |i_CTRL-X_CTRL-I|
+		   "dictionary"	Dictionary |i_CTRL-X_CTRL-K|
+		   "thesaurus"	Thesaurus |i_CTRL-X_CTRL-T|
+		   "cmdline"	Vim Command line completion |i_CTRL-X_CTRL-V|
+		   "function"	User defined completion |i_CTRL-X_CTRL-U|
+		   "omni"	Omni completion |i_CTRL-X_CTRL-O|
+		   "spell"	Spelling suggestions |i_CTRL-X_s|
+		   "eval"	|complete()| completion
+		   "unknown"	Other internal modes
+
+		If the optional {what} dictionary argument is supplied, then
+		only the items listed in {what} are returned.
+		Unsupported keys in {what} are ignored.
 
 						*confirm()*
 confirm({msg} [, {choices} [, {default} [, {type}]]])

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3574,17 +3574,17 @@ complete_info([{what}])
 		   "eval"	|complete()| completion
 		   "unknown"	Other internal modes
 
-		If the optional {what} dictionary argument is supplied, then
+		If the optional {what} list argument is supplied, then
 		only the items listed in {what} are returned.
-		Unsupported keys in {what} are ignored.
+		Unsupported items in {what} are ignored.
 
 		Examples: >
 			" Get all items
 			call complete_info()
 			" Get only 'mode'
-			call complete_info({'mode': ''})
+			call complete_info(['mode'])
 			" Get only 'mode' and 'pum_visible'
-			call complete_info({'mode': '', 'pum_visible': ''})
+			call complete_info(['mode', 'pum_visible'])
 <
 						*confirm()*
 confirm({msg} [, {choices} [, {default} [, {type}]]])

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3551,7 +3551,8 @@ complete_info([{what}])
 				"abbr", "menu", "kind", "info" and "user_data".
 				See |complete-items|.
 		   selected	Selected item index.  First index is zero.
-				Set -1 if not selected.
+				Index is -1 if no item is selected (showing
+				typed text only)
 		   inserted	Inserted string. [NOT IMPLEMENT YET]
 
 							*complete_info_mode*
@@ -3577,6 +3578,14 @@ complete_info([{what}])
 		only the items listed in {what} are returned.
 		Unsupported keys in {what} are ignored.
 
+		Examples: >
+			" Get all items
+			call complete_info()
+			" Get only 'mode'
+			call complete_info({'mode': ''})
+			" Get only 'mode' and 'pum_visible'
+			call complete_info({'mode': '', 'pum_visible': ''})
+<
 						*confirm()*
 confirm({msg} [, {choices} [, {default} [, {type}]]])
 		Confirm() offers the user a dialog, from which a choice can be

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -642,6 +642,7 @@ and one of the CTRL-X commands.  You exit CTRL-X mode by typing a key that is
 not a valid CTRL-X mode command.  Valid keys are the CTRL-X command itself,
 CTRL-N (next), and CTRL-P (previous).
 
+To get the current completion information, |complete_info()| can be used.
 Also see the 'infercase' option if you want to adjust the case of the match.
 
 							*complete_CTRL-E*

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -834,6 +834,7 @@ Insert mode completion:				*completion-functions*
 	complete()		set found matches
 	complete_add()		add to found matches
 	complete_check()	check if completion should be aborted
+	complete_info()		get current completion information
 	pumvisible()		check if the popup menu is displayed
 
 Folding:					*folding-functions*

--- a/src/edit.c
+++ b/src/edit.c
@@ -3555,9 +3555,9 @@ get_complete_info(dict_T *what, dict_T *retdict)
 	li = list_alloc();
 	if (li == NULL)
 	    return;
-	if (compl_first_match != NULL)
+	ret = dict_add_list(retdict, "items", li);
+	if (ret == OK && compl_first_match != NULL)
 	{
-	    ret = dict_add_list(retdict, "items", li);
 	    match = compl_first_match;
 	    do
 	    {

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -113,6 +113,7 @@ static void f_col(typval_T *argvars, typval_T *rettv);
 static void f_complete(typval_T *argvars, typval_T *rettv);
 static void f_complete_add(typval_T *argvars, typval_T *rettv);
 static void f_complete_check(typval_T *argvars, typval_T *rettv);
+static void f_complete_info(typval_T *argvars, typval_T *rettv);
 #endif
 static void f_confirm(typval_T *argvars, typval_T *rettv);
 static void f_copy(typval_T *argvars, typval_T *rettv);
@@ -589,6 +590,7 @@ static struct fst
     {"complete",	2, 2, f_complete},
     {"complete_add",	1, 1, f_complete_add},
     {"complete_check",	0, 0, f_complete_check},
+    {"complete_info",	0, 1, f_complete_info},
 #endif
     {"confirm",		1, 4, f_confirm},
     {"copy",		1, 1, f_copy},
@@ -2591,6 +2593,23 @@ f_complete_check(typval_T *argvars UNUSED, typval_T *rettv)
     ins_compl_check_keys(0, TRUE);
     rettv->vval.v_number = compl_interrupted;
     RedrawingDisabled = saved;
+}
+
+/*
+ * "complete_info()" function
+ */
+    static void
+f_complete_info(typval_T *argvars, typval_T *rettv)
+{
+    if (rettv_dict_alloc(rettv) != OK)
+	return;
+
+    if (argvars[0].v_type == VAR_UNKNOWN)
+	get_complete_info(NULL, rettv->vval.v_dict);
+    else if (argvars[0].v_type == VAR_DICT)
+	get_complete_info(argvars[0].vval.v_dict, rettv->vval.v_dict);
+    else
+	emsg(_(e_dictreq));
 }
 #endif
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2606,10 +2606,10 @@ f_complete_info(typval_T *argvars, typval_T *rettv)
 
     if (argvars[0].v_type == VAR_UNKNOWN)
 	get_complete_info(NULL, rettv->vval.v_dict);
-    else if (argvars[0].v_type == VAR_DICT)
-	get_complete_info(argvars[0].vval.v_dict, rettv->vval.v_dict);
+    else if (argvars[0].v_type == VAR_LIST)
+	get_complete_info(argvars[0].vval.v_list, rettv->vval.v_dict);
     else
-	emsg(_(e_dictreq));
+	emsg(_(e_listreq));
 }
 #endif
 

--- a/src/proto/edit.pro
+++ b/src/proto/edit.pro
@@ -18,7 +18,7 @@ void ins_compl_show_pum(void);
 char_u *find_word_start(char_u *ptr);
 char_u *find_word_end(char_u *ptr);
 int ins_compl_active(void);
-void get_complete_info(dict_T *what, dict_T *retdict);
+void get_complete_info(list_T *what, dict_T *retdict);
 int ins_compl_add_tv(typval_T *tv, int dir);
 void ins_compl_check_keys(int frequency, int in_compl_func);
 int get_literal(void);

--- a/src/proto/edit.pro
+++ b/src/proto/edit.pro
@@ -18,6 +18,7 @@ void ins_compl_show_pum(void);
 char_u *find_word_start(char_u *ptr);
 char_u *find_word_end(char_u *ptr);
 int ins_compl_active(void);
+void get_complete_info(dict_T *what, dict_T *retdict);
 int ins_compl_add_tv(typval_T *tv, int dir);
 void ins_compl_check_keys(int frequency, int in_compl_func);
 int get_literal(void);

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -896,7 +896,7 @@ func Test_menu_only_exists_in_terminal()
   endtry
 endfunc
 
-func Test_popup_complete_info()
+func Test_popup_complete_info_01()
   new
   inoremap <buffer><F5> <C-R>=complete_info().mode<CR>
   func s:complTestEval() abort
@@ -931,12 +931,39 @@ func Test_popup_complete_info()
         \ ["\<C-X>s", 'spell'],
         \ ["\<F6>", 'eval'],
         \]
-    call feedkeys("i" . keys . "\<f5>\<ESC>", 'tx')
+    call feedkeys("i" . keys . "\<F5>\<Esc>", 'tx')
     call assert_equal(mode_name, getline('.'))
     %d
   endfor
   call delete('Xdummy.txt')
   bwipe!
 endfunc
+
+"func UserDefinedComplete(findstart, base)
+"  if a:findstart
+"    return 0
+"  else
+"    return [
+"          \   { 'word': 'Jan', 'menu': 'January' },
+"          \   { 'word': 'Feb', 'menu': 'February' },
+"          \   { 'word': 'Mar', 'menu': 'March' },
+"          \   { 'word': 'Apr', 'menu': 'April' },
+"          \   { 'word': 'May', 'menu': 'May' },
+"          \ ]
+"  endif
+"endfunc
+"
+"func GetCompleteInfo()
+"  let g:compl_info = complete_info()
+"  return ''
+"endfunc
+"
+"func Test_popup_complete_info_02()
+"  new
+"  inoremap <buffer><F5> <C-R>=GetCompleteInfo()<CR>
+"  setlocal completefunc=UserDefinedComplete
+"
+"  bwipe!
+"endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -939,31 +939,62 @@ func Test_popup_complete_info_01()
   bwipe!
 endfunc
 
-"func UserDefinedComplete(findstart, base)
-"  if a:findstart
-"    return 0
-"  else
-"    return [
-"          \   { 'word': 'Jan', 'menu': 'January' },
-"          \   { 'word': 'Feb', 'menu': 'February' },
-"          \   { 'word': 'Mar', 'menu': 'March' },
-"          \   { 'word': 'Apr', 'menu': 'April' },
-"          \   { 'word': 'May', 'menu': 'May' },
-"          \ ]
-"  endif
-"endfunc
-"
-"func GetCompleteInfo()
-"  let g:compl_info = complete_info()
-"  return ''
-"endfunc
-"
-"func Test_popup_complete_info_02()
-"  new
-"  inoremap <buffer><F5> <C-R>=GetCompleteInfo()<CR>
-"  setlocal completefunc=UserDefinedComplete
-"
-"  bwipe!
-"endfunc
+func UserDefinedComplete(findstart, base)
+  if a:findstart
+    return 0
+  else
+    return [
+          \   { 'word': 'Jan', 'menu': 'January' },
+          \   { 'word': 'Feb', 'menu': 'February' },
+          \   { 'word': 'Mar', 'menu': 'March' },
+          \   { 'word': 'Apr', 'menu': 'April' },
+          \   { 'word': 'May', 'menu': 'May' },
+          \ ]
+  endif
+endfunc
+
+func GetCompleteInfo()
+  if empty(g:compl_what)
+    let g:compl_info = complete_info()
+  else
+    let g:compl_info = complete_info(g:compl_what)
+  endif
+  return ''
+endfunc
+
+func Test_popup_complete_info_02()
+  new
+  inoremap <buffer><F5> <C-R>=GetCompleteInfo()<CR>
+  setlocal completefunc=UserDefinedComplete
+
+  let d = {
+    \   'mode': 'function',
+    \   'pum_visible': 1,
+    \   'items': [
+    \     {'word': 'Jan', 'menu': 'January', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''},
+    \     {'word': 'Feb', 'menu': 'February', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''},
+    \     {'word': 'Mar', 'menu': 'March', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''},
+    \     {'word': 'Apr', 'menu': 'April', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''},
+    \     {'word': 'May', 'menu': 'May', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}
+    \   ],
+    \   'selected': 0,
+    \ }
+
+  let g:compl_what = []
+  call feedkeys("i\<C-X>\<C-U>\<F5>", 'tx')
+  call assert_equal(d, g:compl_info)
+
+  let g:compl_what = ['mode', 'pum_visible', 'selected']
+  call remove(d, 'items')
+  call feedkeys("i\<C-X>\<C-U>\<F5>", 'tx')
+  call assert_equal(d, g:compl_info)
+
+  let g:compl_what = ['mode']
+  call remove(d, 'selected')
+  call remove(d, 'pum_visible')
+  call feedkeys("i\<C-X>\<C-U>\<F5>", 'tx')
+  call assert_equal(d, g:compl_info)
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -896,4 +896,47 @@ func Test_menu_only_exists_in_terminal()
   endtry
 endfunc
 
+func Test_popup_complete_info()
+  new
+  inoremap <buffer><F5> <C-R>=complete_info().mode<CR>
+  func s:complTestEval() abort
+    call complete(1, ['aa', 'ab'])
+    return ''
+  endfunc
+  inoremap <buffer><F6> <C-R>=s:complTestEval()<CR>
+  call writefile([
+        \ 'dummy	dummy.txt	1',
+        \], 'Xdummy.txt')
+  setlocal tags=Xdummy.txt
+  setlocal dictionary=Xdummy.txt
+  setlocal thesaurus=Xdummy.txt
+  setlocal omnifunc=syntaxcomplete#Complete
+  setlocal completefunc=syntaxcomplete#Complete
+  setlocal spell
+  for [keys, mode_name] in [
+        \ ["", ''],
+        \ ["\<C-X>", 'ctrl_x'],
+        \ ["\<C-X>\<C-N>", 'keyword'],
+        \ ["\<C-X>\<C-P>", 'keyword'],
+        \ ["\<C-X>\<C-L>", 'whole_line'],
+        \ ["\<C-X>\<C-F>", 'files'],
+        \ ["\<C-X>\<C-]>", 'tags'],
+        \ ["\<C-X>\<C-D>", 'path_defines'],
+        \ ["\<C-X>\<C-I>", 'path_patterns'],
+        \ ["\<C-X>\<C-K>", 'dictionary'],
+        \ ["\<C-X>\<C-T>", 'thesaurus'],
+        \ ["\<C-X>\<C-V>", 'cmdline'],
+        \ ["\<C-X>\<C-U>", 'function'],
+        \ ["\<C-X>\<C-O>", 'omni'],
+        \ ["\<C-X>s", 'spell'],
+        \ ["\<F6>", 'eval'],
+        \]
+    call feedkeys("i" . keys . "\<f5>\<ESC>", 'tx')
+    call assert_equal(mode_name, getline('.'))
+    %d
+  endfor
+  call delete('Xdummy.txt')
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Once the specification is decided, refactor, update the document and add more tests.

```
complete_info([{what}])
		Returns a Dictionary with information about insert mode
		completion.  see |ins-completion|.
		The items are:
		   mode		current completion mode name string.
				See |completion_info_mode| for the values.
		   pum_visible	|TRUE| if popup menu is visible.
				See |pumvisible()|.
		   items	List of completion matches.  Each item is a
				dictionary containing the entries "word",
				"abbr", "menu", "kind", "info" and "user_data".
				See |complete-items|.
		   selected	Selected item index.  First index is zero.
				Set -1 if not selected.
		   inserted	Inserted string. [NOT IMPLEMENT YET]

							*complete_info_mode*
		mode values are:
		   ""		Not in completion mode
		   "keyword"	Keyword completion |i_CTRL-X_CTRL-N|
		   "ctrl_x"	Just press |i_CTRL-X|
		   "whole_line"	Whole lines |i_CTRL-X_CTRL-L|
		   "files"	File names |i_CTRL-X_CTRL-F|
		   "tags"	Tags |i_CTRL-X_CTRL-]|
		   "path_defines"    Definition completion |i_CTRL-X_CTRL-D|
		   "path_patterns"   Include completion |i_CTRL-X_CTRL-I|
		   "dictionary"	Dictionary |i_CTRL-X_CTRL-K|
		   "thesaurus"	Thesaurus |i_CTRL-X_CTRL-T|
		   "cmdline"	Vim Command line completion |i_CTRL-X_CTRL-V|
		   "function"	User defined completion |i_CTRL-X_CTRL-U|
		   "omni"	Omni completion |i_CTRL-X_CTRL-O|
		   "spell"	Spelling suggestions |i_CTRL-X_s|
		   "eval"	|complete()| completion
		   "unknown"	Other internal modes

		If the optional {what} dictionary argument is supplied, then
		only the items listed in {what} are returned.
		Unsupported keys in {what} are ignored.
```

#### Related Issue/Thread
#3866 
https://groups.google.com/d/msg/vim_dev/6utE1ObSYY8/fOaLtsBUGwAJ

--
Best regards,
Hirohito Higashi (h_east)