### PR TITLE
define HAVE_STDINT_H for DEBUG build

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -626,6 +626,11 @@ CFLAGS = $(CFLAGS) /MP
 !endif
 !endif
 
+# VC10 or later has stdint.h.
+!if $(MSVC_MAJOR) >= 10
+CFLAGS = $(CFLAGS) -DHAVE_STDINT_H
+!endif
+
 
 !ifdef NODEBUG
 VIM = vim
@@ -647,11 +652,6 @@ OPTFLAG = $(OPTFLAG) /GL
 # (/Wp64 is deprecated in VC9 and generates an obnoxious warning.)
 !if ($(MSVC_MAJOR) == 7) || ($(MSVC_MAJOR) == 8)
 CFLAGS=$(CFLAGS) $(WP64CHECK)
-!endif
-
-# VC10 or later has stdint.h.
-!if $(MSVC_MAJOR) >= 10
-CFLAGS = $(CFLAGS) -DHAVE_STDINT_H
 !endif
 
 # Static code analysis generally available starting with VS2012 (VC11) or


### PR DESCRIPTION
Problem: HAVE_STDINT_H is defined for no debug build on for MSWIN.
It cause problem when compiling debug versoin with if_python3 feature.

Solution: move the definition block of HAVE_STDINT_H to out of NODEBUG
block.

---

It happend with Python 3.7.2 from https://www.python.org