### PR TITLE
Fixed memory leak when E461 occurs

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -2138,6 +2138,7 @@ get_lval(
 			 || &lp->ll_dict->dv_hashtab == get_funccal_args_ht())
 		{
 		    semsg(_(e_illvar), name);
+		    clear_tv(&var1);
 		    return NULL;
 		}
 


### PR DESCRIPTION
This PR fixes a memory leak which I see when running `make test_let`  with valgrind:
```
==16028== 4 bytes in 2 blocks are definitely lost in loss record 3 of 144
==16028==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==16028==    by 0x25AF50: lalloc (misc2.c:942)
==16028==    by 0x25AF50: alloc (misc2.c:827)
==16028==    by 0x186BF2: get_lit_string_tv (eval.c:5132)
==16028==    by 0x186BF2: eval7 (eval.c:4326)
==16028==    by 0x187263: eval6 (eval.c:4041)
==16028==    by 0x180445: eval5 (eval.c:3837)
==16028==    by 0x180445: eval4 (eval.c:3721)
==16028==    by 0x180445: eval3 (eval.c:3641)
==16028==    by 0x18060B: eval2 (eval.c:3573)
==16028==    by 0x18060B: eval1 (eval.c:3501)
==16028==    by 0x182A22: get_lval (eval.c:2025)
==16028==    by 0x1837AD: ex_let_one (eval.c:1859)
==16028==    by 0x185E9C: ex_let_vars (eval.c:1341)
==16028==    by 0x185E9C: ex_let (eval.c:1306)
==16028==    by 0x1D26D1: do_one_cmd (ex_docmd.c:2525)
==16028==    by 0x1D26D1: do_cmdline (ex_docmd.c:1033)
==16028==    by 0x380CB2: call_user_func (userfunc.c:999)
==16028==    by 0x380CB2: call_func (userfunc.c:1533)
==16028==    by 0x381705: get_func_tv (userfunc.c:453)
==16028==    by 0x386635: ex_call (userfunc.c:3216)
==16028==    by 0x1D26D1: do_one_cmd (ex_docmd.c:2525)
==16028==    by 0x1D26D1: do_cmdline (ex_docmd.c:1033)
==16028==    by 0x17F6FF: assert_fails (eval.c:9553)
==16028==    by 0x1944A8: f_assert_fails (evalfunc.c:1624)
==16028==    by 0x1A1DF5: call_internal_func (evalfunc.c:1117)
==16028==    by 0x3804F0: call_func (userfunc.c:1552)
==16028==    by 0x381705: get_func_tv (userfunc.c:453)
==16028==    by 0x386635: ex_call (userfunc.c:3216)
==16028==    by 0x1D26D1: do_one_cmd (ex_docmd.c:2525)
==16028==    by 0x1D26D1: do_cmdline (ex_docmd.c:1033)
==16028==    by 0x380CB2: call_user_func (userfunc.c:999)
==16028==    by 0x380CB2: call_func (userfunc.c:1533)
==16028==    by 0x381705: get_func_tv (userfunc.c:453)
==16028==    by 0x386635: ex_call (userfunc.c:3216)
==16028==    by 0x1D26D1: do_one_cmd (ex_docmd.c:2525)
==16028==    by 0x1D26D1: do_cmdline (ex_docmd.c:1033)
==16028==    by 0x188656: ex_execute (eval.c:8607)
==16028==    by 0x1D26D1: do_one_cmd (ex_docmd.c:2525)
==16028==    by 0x1D26D1: do_cmdline (ex_docmd.c:1033)
==16028==    by 0x380CB2: call_user_func (userfunc.c:999)
==16028==    by 0x380CB2: call_func (userfunc.c:1533)
==16028==    by 0x381705: get_func_tv (userfunc.c:453)
==16028==    by 0x386635: ex_call (userfunc.c:3216)
==16028==    by 0x1D26D1: do_one_cmd (ex_docmd.c:2525)
==16028==    by 0x1D26D1: do_cmdline (ex_docmd.c:1033)
==16028==    by 0x1BB746: do_source (ex_cmds2.c:4605)
==16028==    by 0x1BBFCB: cmd_source (ex_cmds2.c:4227)
==16028==    by 0x1BBFCB: ex_source (ex_cmds2.c:4202)
==16028==    by 0x1D26D1: do_one_cmd (ex_docmd.c:2525)
==16028==    by 0x1D26D1: do_cmdline (ex_docmd.c:1033)
==16028==    by 0x3E1311: exe_commands (main.c:2943)
==16028==    by 0x3E1311: vim_main2 (main.c:798)
```
The leak is reproducible with this small script:
```
  func s:set_arg9(a) abort
    let a:['x'] = 1
  endfunction
  call assert_fails('call s:set_arg9(1)', 'E461:')
```
The string key of the map leaks when there is an error E461.
Running `call s:set_arg9(1)` N times will leak N blocks.

I did not add a test since existing `test_let.vim` already
triggers the leak.
