### PR TITLE
runtime: fix LC_MESSAGES handling in tutor

### DIFF
--- a/runtime/tutor/tutor.vim
+++ b/runtime/tutor/tutor.vim
@@ -22,6 +22,12 @@ else
     let s:lang = v:lang
   elseif $LC_ALL =~ '\a\a'
     let s:lang = $LC_ALL
+  elseif $LC_MESSAGES =~ '\a\a' || $LC_MESSAGES ==# "C"
+    " LC_MESSAGES=C can be used to explicitly ask for English messages while keeping LANG
+    " non-English, so don't consider that invalid.
+    if $LC_MESSAGES =~ '\a\a'
+      let s:lang = $LC_MESSAGES
+    endif
   elseif $LANG =~ '\a\a'
     let s:lang = $LANG
   endif


### PR DESCRIPTION
In case you have the following setup:

LANG=hu_HU.UTF-8
LC_MESSAGES=C

Then the expected behavior is that the user interface is still in
English, though other other aspects of locale is non-English. (According
to `man 7 locale`.)

Respect this setup in tutor.vim, so in case LC_MESSAGES is set to C, we
do not take locale from LANG.