### PR TITLE
Unlist the quickfix buffer when quickfix window is closed

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4964,10 +4964,16 @@ getloclist({nr} [, {what}])				*getloclist()*
 		If the optional {what} dictionary argument is supplied, then
 		returns the items listed in {what} as a dictionary. Refer to
 		|getqflist()| for the supported items in {what}.
-		If {what} contains 'filewinid', then returns the id of the
-		window used to display files from the location list. This
-		field is applicable only when called from a location list
-		window. See |location-list-file-window| for more details.
+
+		In addition to the items supported by |getqflist()| in {what},
+		the following item is supported by |getloclist()|:
+
+			filewinid 	id of the window used to display files
+					from the location list. This field is
+					applicable only when called from a
+					location list window. See
+					|location-list-file-window| for more
+					details.
 
 getmatches()						*getmatches()*
 		Returns a |List| with all matches previously defined by
@@ -5069,6 +5075,9 @@ getqflist([{what}])					*getqflist()*
 			nr	get information for this quickfix list; zero
 				means the current quickfix list and "$" means
 				the last quickfix list
+			qfbufnr number of the buffer displayed in the quickfix
+				window. Returns 0 if the quickfix buffer is
+				not present.
 			size	number of entries in the quickfix list
 			title	get the list title |quickfix-title|
 			winid	get the quickfix |window-ID|
@@ -5097,6 +5106,8 @@ getqflist([{what}])					*getqflist()*
 			items	quickfix list entries. If not present, set to
 				an empty list.
 			nr	quickfix list number. If not present, set to 0
+			qfbufnr	number of the buffer displayed in the quickfix
+				window. If not present, set to 0.
 			size	number of entries in the quickfix list. If not
 				present, set to 0.
 			title	quickfix list title text. If not present, set

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5077,7 +5077,7 @@ getqflist([{what}])					*getqflist()*
 				the last quickfix list
 			qfbufnr number of the buffer displayed in the quickfix
 				window. Returns 0 if the quickfix buffer is
-				not present.
+				not present. See |quickfix-buffer|.
 			size	number of entries in the quickfix list
 			title	get the list title |quickfix-title|
 			winid	get the quickfix |window-ID|

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -496,6 +496,7 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 			second quickfix window.  If [height] is given the
 			existing window will be resized to it.
 
+							*quickfix-buffer*
 			The window will contain a special buffer, with
 			'buftype' equal to "quickfix".  Don't change this!
 			The window will have the w:quickfix_title variable set
@@ -504,7 +505,11 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 			status line if the value of 'statusline' is adjusted
 			properly. Whenever this buffer is modified by a
 			quickfix command or function, the |b:changedtick|
-			variable is incremented.
+			variable is incremented.  You can get the number of
+			this buffer using the getqflist() and getloclist()
+			functions by passing the 'qfbufnr' item. For a
+			location list, this buffer is wiped out when the
+			location list is removed.
 
 							*:lop* *:lopen*
 :lop[en] [height]	Open a window to show the location list for the
@@ -670,11 +675,17 @@ using these functions are below:
     " get the quickfix list window id
     :echo getqflist({'winid' : 0}).winid
 
+    " get the quickfix list window buffer number
+    :echo getqflist({'qfbufnr' : 0}).qfbufnr
+
     " get the context of the current location list
     :echo getloclist(0, {'context' : 0}).context
 
     " get the location list window id of the third window
     :echo getloclist(3, {'winid' : 0}).winid
+
+    " get the location list window buffer number of the third window
+    :echo getloclist(3, {'qfbufnr' : 0}).qfbufnr
 
     " get the file window id of a location list window (winnr: 4)
     :echo getloclist(4, {'filewinid' : 0}).filewinid

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5907,7 +5907,8 @@ enum {
     QF_GETLIST_SIZE	= 0x80,
     QF_GETLIST_TICK	= 0x100,
     QF_GETLIST_FILEWINID	= 0x200,
-    QF_GETLIST_ALL	= 0x3FF,
+    QF_GETLIST_QFBUFNR	= 0x400,
+    QF_GETLIST_ALL	= 0x7FF,
 };
 
 /*
@@ -5977,6 +5978,17 @@ qf_winid(qf_info_T *qi)
 }
 
 /*
+ * Returns the number of the buffer displayed in the quickfix/location list
+ * window. If there is no buffer associated with the list, then returns 0.
+ */
+    static int
+qf_getprop_qfbufnr(qf_info_T *qi, dict_T *retdict)
+{
+    return dict_add_number(retdict, "qfbufnr",
+					(qi == NULL) ? 0 : qi->qf_bufnr);
+}
+
+/*
  * Convert the keys in 'what' to quickfix list property flags.
  */
     static int
@@ -6021,6 +6033,9 @@ qf_getprop_keys2flags(dict_T *what, int loclist)
 
     if (loclist && dict_find(what, (char_u *)"filewinid", -1) != NULL)
 	flags |= QF_GETLIST_FILEWINID;
+
+    if (dict_find(what, (char_u *)"qfbufnr", -1) != NULL)
+	flags |= QF_GETLIST_QFBUFNR;
 
     return flags;
 }
@@ -6114,6 +6129,8 @@ qf_getprop_defaults(qf_info_T *qi, int flags, int locstack, dict_T *retdict)
 	status = dict_add_number(retdict, "changedtick", 0);
     if ((status == OK) && locstack && (flags & QF_GETLIST_FILEWINID))
 	status = dict_add_number(retdict, "filewinid", 0);
+    if ((status == OK) && (flags & QF_GETLIST_QFBUFNR))
+	status = qf_getprop_qfbufnr(qi, retdict);
 
     return status;
 }
@@ -6259,6 +6276,8 @@ qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
 	status = dict_add_number(retdict, "changedtick", qfl->qf_changedtick);
     if ((status == OK) && (wp != NULL) && (flags & QF_GETLIST_FILEWINID))
 	status = qf_getprop_filewinid(wp, qi, retdict);
+    if ((status == OK) && (flags & QF_GETLIST_QFBUFNR))
+	status = qf_getprop_qfbufnr(qi, retdict);
 
     return status;
 }

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -3110,19 +3110,21 @@ func Xgetlist_empty_tests(cchar)
   call assert_equal(0, g:Xgetlist({'changedtick' : 0}).changedtick)
   if a:cchar == 'c'
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0,
-		  \ 'items' : [], 'nr' : 0, 'size' : 0,
+		  \ 'items' : [], 'nr' : 0, 'size' : 0, 'qfbufnr' : 0,
 		  \ 'title' : '', 'winid' : 0, 'changedtick': 0},
 		  \ g:Xgetlist({'all' : 0}))
   else
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0,
 		\ 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '',
-		\ 'winid' : 0, 'changedtick': 0, 'filewinid' : 0},
+		\ 'winid' : 0, 'changedtick': 0, 'filewinid' : 0,
+		\ 'qfbufnr' : 0},
 		\ g:Xgetlist({'all' : 0}))
   endif
 
   " Quickfix window with empty stack
   silent! Xopen
   let qfwinid = (a:cchar == 'c') ? win_getid() : 0
+  let qfbufnr = (a:cchar == 'c') ? bufnr('') : 0
   call assert_equal(qfwinid, g:Xgetlist({'winid' : 0}).winid)
   Xclose
 
@@ -3154,11 +3156,12 @@ func Xgetlist_empty_tests(cchar)
   if a:cchar == 'c'
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
 		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
+		\ 'qfbufnr' : qfbufnr,
 		\ 'changedtick' : 0}, g:Xgetlist({'id' : qfid, 'all' : 0}))
   else
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
 		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
-		\ 'changedtick' : 0, 'filewinid' : 0},
+		\ 'changedtick' : 0, 'filewinid' : 0, 'qfbufnr' : 0},
 		\ g:Xgetlist({'id' : qfid, 'all' : 0}))
   endif
 
@@ -3175,11 +3178,12 @@ func Xgetlist_empty_tests(cchar)
   if a:cchar == 'c'
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
 		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
-		\ 'changedtick' : 0}, g:Xgetlist({'nr' : 5, 'all' : 0}))
+		\ 'changedtick' : 0, 'qfbufnr' : qfbufnr},
+		\ g:Xgetlist({'nr' : 5, 'all' : 0}))
   else
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
 		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
-		\ 'changedtick' : 0, 'filewinid' : 0},
+		\ 'changedtick' : 0, 'filewinid' : 0, 'qfbufnr' : 0},
 		\ g:Xgetlist({'nr' : 5, 'all' : 0}))
   endif
 endfunc
@@ -3912,6 +3916,7 @@ func Xqfbuf_test(cchar)
   Xclose
   " Even after the quickfix window is closed, the buffer should be loaded
   call assert_true(bufloaded(qfbnum))
+  call assert_true(qfbnum, g:Xgetlist({'qfbufnr' : 0}).qfbufnr)
   Xopen
   " Buffer should be reused when opening the window again
   call assert_equal(qfbnum, bufnr(''))
@@ -3947,6 +3952,7 @@ func Xqfbuf_test(cchar)
     " removed
     call setloclist(0, [], 'f')
     call assert_false(bufexists(qfbnum))
+    call assert_equal(0, getloclist(0, {'qfbufnr' : 0}).qfbufnr)
 
     " When the location list is freed with the location list window open, the
     " location list buffer should not be lost. It should be reused when the

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -3935,7 +3935,7 @@ func Xqfbuf_test(cchar)
     close
     " When the location list window is closed, the buffer name should not
     " change to 'Quickfix List'
-    call assert_match(qfbnum . '  h-  "\[Location List]"', execute('ls'))
+    call assert_match(qfbnum . 'u h-  "\[Location List]"', execute('ls!'))
     call assert_true(bufloaded(qfbnum))
 
     " After deleting a location list buffer using ":bdelete", opening the

--- a/src/window.c
+++ b/src/window.c
@@ -2394,6 +2394,12 @@ win_close(win_T *win, int free_buf)
 	reset_synblock(win);
 #endif
 
+#ifdef FEAT_QUICKFIX
+    // When the quickfix/location list window is closed, unlist the buffer
+    if (win->w_buffer != NULL && bt_quickfix(win->w_buffer))
+	win->w_buffer->b_p_bl = FALSE;
+#endif
+
     /*
      * Close the link to the buffer.
      */


### PR DESCRIPTION
After 8.1.0877, the quickfix/location list buffer is hidden when the quickfix/location list window is closed. These buffers show up in the ":ls" output cluttering the output. This patch unlists the quickfix buffer when the quickfix/location window is closed. Some updates to the help is also included.
This patch also adds support for getting the quickfix/location list buffer number using getqflist().