### PR TITLE
MSVC: /analyze couldn't be enabled on debug build

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -631,6 +631,12 @@ CFLAGS = $(CFLAGS) /MP
 CFLAGS = $(CFLAGS) -DHAVE_STDINT_H
 !endif
 
+# Static code analysis generally available starting with VS2012 (VC11) or
+# Windows SDK 7.1 (VC10)
+!if ("$(ANALYZE)" == "yes") && ($(MSVC_MAJOR) >= 10)
+CFLAGS=$(CFLAGS) /analyze
+!endif
+
 !ifdef NODEBUG
 VIM = vim
 !if "$(OPTIMIZE)" == "SPACE"
@@ -651,12 +657,6 @@ OPTFLAG = $(OPTFLAG) /GL
 # (/Wp64 is deprecated in VC9 and generates an obnoxious warning.)
 !if ($(MSVC_MAJOR) == 7) || ($(MSVC_MAJOR) == 8)
 CFLAGS=$(CFLAGS) $(WP64CHECK)
-!endif
-
-# Static code analysis generally available starting with VS2012 (VC11) or
-# Windows SDK 7.1 (VC10)
-!if ("$(ANALYZE)" == "yes") && ($(MSVC_MAJOR) >= 10)
-CFLAGS=$(CFLAGS) /analyze
 !endif
 
 CFLAGS = $(CFLAGS) $(OPTFLAG) -DNDEBUG $(CPUARG)


### PR DESCRIPTION
This PR enables it.

Similar to #4109.