### PR TITLE
align bottom when drawing text

### DIFF
--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -822,7 +822,7 @@ DWriteContext::CreateTextFormatFromLOGFONT(const LOGFONTW &logFont,
 
     if (SUCCEEDED(hr))
 	hr = pTextFormat->SetParagraphAlignment(
-		DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+		DWRITE_PARAGRAPH_ALIGNMENT_FAR);
 
     if (SUCCEEDED(hr))
 	hr = pTextFormat->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP);


### PR DESCRIPTION
This PR would fix https://github.com/vim/vim/issues/1520

Problem:
Current DirectWrite renders texts with vertical center alignment.
It causes some gaps when render texts with lower hight chars without highest characters.
(See #1520)

Solution:
Use bottom alignment.

cf. https://docs.microsoft.com/en-us/windows/desktop/api/dwrite/ne-dwrite-dwrite_paragraph_alignment