### PR TITLE
Fix if_lua problems

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -443,7 +443,7 @@ lua_enabled(int verbose)
 
 #if LUA_VERSION_NUM > 501
     static int
-luaL_typeerror (lua_State *L, int narg, const char *tname)
+luaL_typeerror(lua_State *L, int narg, const char *tname)
 {
     const char *msg = lua_pushfstring(L, "%s expected, got %s",
 	    tname, luaL_typename(L, narg));
@@ -693,7 +693,7 @@ luaV_msgfunc(lua_State *L, msgfunc_T mf)
 
 #define luaV_newtype(typ,tname,luatyp,luatname) \
 	static luatyp * \
-    luaV_new##tname (lua_State *L, typ *obj) \
+    luaV_new##tname(lua_State *L, typ *obj) \
     { \
 	luatyp *o = (luatyp *) lua_newuserdata(L, sizeof(luatyp)); \
 	*o = obj; \
@@ -725,7 +725,7 @@ luaV_msgfunc(lua_State *L, msgfunc_T mf)
 
 #define luaV_type_tostring(tname,luatname) \
 	static int \
-    luaV_##tname##_tostring (lua_State *L) \
+    luaV_##tname##_tostring(lua_State *L) \
     { \
 	lua_pushfstring(L, "%s: %p", luatname, lua_touserdata(L, 1)); \
 	return 1; \
@@ -734,7 +734,7 @@ luaV_msgfunc(lua_State *L, msgfunc_T mf)
 /* =======   List type   ======= */
 
     static luaV_List *
-luaV_newlist (lua_State *L, list_T *lis)
+luaV_newlist(lua_State *L, list_T *lis)
 {
     luaV_List *l = (luaV_List *) lua_newuserdata(L, sizeof(luaV_List));
     *l = lis;
@@ -749,7 +749,7 @@ luaV_pushtype(list_T, list, luaV_List)
 luaV_type_tostring(list, LUAVIM_LIST)
 
     static int
-luaV_list_len (lua_State *L)
+luaV_list_len(lua_State *L)
 {
     list_T *l = luaV_unbox(L, luaV_List, 1);
     lua_pushinteger(L, (l == NULL) ? 0 : (int) l->lv_len);
@@ -757,7 +757,7 @@ luaV_list_len (lua_State *L)
 }
 
     static int
-luaV_list_iter (lua_State *L)
+luaV_list_iter(lua_State *L)
 {
     listitem_T *li = (listitem_T *) lua_touserdata(L, lua_upvalueindex(2));
     if (li == NULL) return 0;
@@ -768,7 +768,7 @@ luaV_list_iter (lua_State *L)
 }
 
     static int
-luaV_list_call (lua_State *L)
+luaV_list_call(lua_State *L)
 {
     list_T *l = luaV_unbox(L, luaV_List, 1);
     lua_pushvalue(L, lua_upvalueindex(1)); /* pass cache table along */
@@ -778,7 +778,7 @@ luaV_list_call (lua_State *L)
 }
 
     static int
-luaV_list_index (lua_State *L)
+luaV_list_index(lua_State *L)
 {
     list_T *l = luaV_unbox(L, luaV_List, 1);
     if (lua_isnumber(L, 2)) /* list item? */
@@ -807,7 +807,7 @@ luaV_list_index (lua_State *L)
 }
 
     static int
-luaV_list_newindex (lua_State *L)
+luaV_list_newindex(lua_State *L)
 {
     list_T *l = luaV_unbox(L, luaV_List, 1);
     long n = (long) luaL_checkinteger(L, 2);
@@ -834,7 +834,7 @@ luaV_list_newindex (lua_State *L)
 }
 
     static int
-luaV_list_add (lua_State *L)
+luaV_list_add(lua_State *L)
 {
     luaV_List *lis = luaV_checkudata(L, 1, LUAVIM_LIST);
     list_T *l = (list_T *) luaV_checkcache(L, (void *) *lis);
@@ -851,7 +851,7 @@ luaV_list_add (lua_State *L)
 }
 
     static int
-luaV_list_insert (lua_State *L)
+luaV_list_insert(lua_State *L)
 {
     luaV_List *lis = luaV_checkudata(L, 1, LUAVIM_LIST);
     list_T *l = (list_T *) luaV_checkcache(L, (void *) *lis);
@@ -890,7 +890,7 @@ static const luaL_Reg luaV_List_mt[] = {
 /* =======   Dict type   ======= */
 
     static luaV_Dict *
-luaV_newdict (lua_State *L, dict_T *dic)
+luaV_newdict(lua_State *L, dict_T *dic)
 {
     luaV_Dict *d = (luaV_Dict *) lua_newuserdata(L, sizeof(luaV_Dict));
     *d = dic;
@@ -905,7 +905,7 @@ luaV_pushtype(dict_T, dict, luaV_Dict)
 luaV_type_tostring(dict, LUAVIM_DICT)
 
     static int
-luaV_dict_len (lua_State *L)
+luaV_dict_len(lua_State *L)
 {
     dict_T *d = luaV_unbox(L, luaV_Dict, 1);
     lua_pushinteger(L, (d == NULL) ? 0 : (int) d->dv_hashtab.ht_used);
@@ -913,7 +913,7 @@ luaV_dict_len (lua_State *L)
 }
 
     static int
-luaV_dict_iter (lua_State *L UNUSED)
+luaV_dict_iter(lua_State *L UNUSED)
 {
 #ifdef FEAT_EVAL
     hashitem_T *hi = (hashitem_T *) lua_touserdata(L, lua_upvalueindex(2));
@@ -935,7 +935,7 @@ luaV_dict_iter (lua_State *L UNUSED)
 }
 
     static int
-luaV_dict_call (lua_State *L)
+luaV_dict_call(lua_State *L)
 {
     dict_T *d = luaV_unbox(L, luaV_Dict, 1);
     hashtab_T *ht = &d->dv_hashtab;
@@ -1368,7 +1368,7 @@ luaV_window_index(lua_State *L)
 }
 
     static int
-luaV_window_newindex (lua_State *L)
+luaV_window_newindex(lua_State *L)
 {
     win_T *w = (win_T *) luaV_checkvalid(L, luaV_Window, 1);
     const char *s = luaL_checkstring(L, 2);
@@ -1768,7 +1768,7 @@ luaV_free(lua_State *L)
 }
 
     static int
-luaV_luaeval (lua_State *L)
+luaV_luaeval(lua_State *L)
 {
     luaL_Buffer b;
     size_t l;
@@ -1797,7 +1797,7 @@ luaV_luaeval (lua_State *L)
 }
 
     static int
-luaV_setref (lua_State *L)
+luaV_setref(lua_State *L)
 {
     int		copyID = lua_tointeger(L, 1);
     int		abort = FALSE;
@@ -2053,7 +2053,7 @@ luaV_freetype(buf_T, buffer)
 luaV_freetype(win_T, window)
 
     void
-do_luaeval (char_u *str, typval_T *arg, typval_T *rettv)
+do_luaeval(char_u *str, typval_T *arg, typval_T *rettv)
 {
     lua_init();
     luaV_getfield(L, LUAVIM_LUAEVAL);
@@ -2064,7 +2064,7 @@ do_luaeval (char_u *str, typval_T *arg, typval_T *rettv)
 }
 
     int
-set_ref_in_lua (int copyID)
+set_ref_in_lua(int copyID)
 {
     int aborted = 0;
 

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -449,6 +449,7 @@ func Test_funcref()
   lua d.len = vim.funcref"Mylen" -- assign d as 'self'
   lua res = (d.len() == vim.funcref"len"(vim.eval"l")) and "OK" or "FAIL"
   call assert_equal("OK", luaeval('res'))
+  call assert_equal(function('Mylen', {'data': l, 'len': function('Mylen')}), mydict.len)
 
   lua i1, i2, msg, d, res = nil
 endfunc


### PR DESCRIPTION
## Double-free

Since 8.1.1004, when using lua 5.3 or luajit, double-free error occurs in test_lua.

https://gist.github.com/ichizok/861ce48b91d9b937ae3904e29b116f80
```
=================================================================
==14557==ERROR: AddressSanitizer: heap-use-after-free on address 0x613000006cc4 at pc 0x55fa31c4f804 bp 0x7ffde1901690 sp 0x7ffde1901680
READ of size 4 at 0x613000006cc4 thread T0
    #0 0x55fa31c4f803 in dict_unref /home/who/Workspace/tmp/vim/8.1.1008_lua/src/dict.c:162
    #1 0x55fa3219eea2 in luaV_funcref_gc /home/who/Workspace/tmp/vim/8.1.1008_lua/src/if_lua.c:1075
    (..snip..)

0x613000006cc4 is located 4 bytes inside of 336-byte region [0x613000006cc0,0x613000006e10)
freed by thread T0 here:
    #0 0x7f9f3020c7b8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7b8)
    #1 0x55fa31e95c5a in vim_free /home/who/Workspace/tmp/vim/8.1.1008_lua/src/misc2.c:1810
    #2 0x55fa31c4f747 in dict_free_dict /home/who/Workspace/tmp/vim/8.1.1008_lua/src/dict.c:142
    #3 0x55fa31c4f98e in dict_free_items /home/who/Workspace/tmp/vim/8.1.1008_lua/src/dict.c:197
    #4 0x55fa31cb0c7f in free_unref_items /home/who/Workspace/tmp/vim/8.1.1008_lua/src/eval.c:5542
    #5 0x55fa31cb0b8c in garbage_collect /home/who/Workspace/tmp/vim/8.1.1008_lua/src/eval.c:5489
    #6 0x55fa31d086d7 in f_test_garbagecollect_now /home/who/Workspace/tmp/vim/8.1.1008_lua/src/evalfunc.c:13860
    (..snip..)
```

### Cause

Regarding luaV_Funcref object which has "self" dict:

```vim
func Func() dict
endfunc
let dict = {}
lua d = vim.eval"dict"
lua d.f = vim.funcref"Func" -- create luaV_Funcref object and set it to "self" dict
...
lua d = nil -- discard luaV_Funcref object, but not yet GCed.
(unlet dict) " but refcount of "dict" > 0 (if_lua keeps it) so "dict" is not freed.
...
test_garbagecollect_now() " by vim GC, "dict" is freed because vim cannot reach it
...
(lua's GC) // at some point lua GC runs. luaV_funcref_gc() tries to "dict_unref(f->self)", but it was already freed!
``` 

Therefore "luaV_funcref_gc()" should not do "dict_unref(f->self)".

## Funcref is deleted unexpectedly

test.vim
```vim
func T()
  func F() dict
  endfunc
  let d = {}
  lua d = vim.eval"d"
  lua d.f = vim.funcref"F"
  lua d.f()
  echo d
endfunc
call T()
```

`vim --clean -S test.vim`

Expected:
`{'f': function('F')}`

Actual:
`{'f': function('')}`

and if referring "d.f" (e.g. `echo d.f`), SEGV occurs.
When dropping `lua d.f()` we can get the correct result.

### Cause

In "luaV_pushfuncref()" do "copy_tv()" and "clear_tv()" so the refcount of funcref is not change, thus lua object does not keep funcref and vim discards funcref.

## "luaV_setref()" does not handle "luaV_Funcref" object

Should handle funcref objects.
