### PR TITLE
Fix if_python3 build warning

### DIFF
--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -802,7 +802,7 @@ static struct PyModuleDef vimmodule;
 #define GET_ATTR_STRING(name, nameobj) \
     char	*name = ""; \
     if (PyUnicode_Check(nameobj)) \
-	name = _PyUnicode_AsString(nameobj)
+	name = (char *)_PyUnicode_AsString(nameobj)
 
 #define PY3OBJ_DELETED(obj) (obj->ob_base.ob_refcnt<=0)
 


### PR DESCRIPTION
```
if_python3.c:1114:5: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    GET_ATTR_STRING(name, nameobj);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
if_python3.c:805:7: note: expanded from macro 'GET_ATTR_STRING'
        name = _PyUnicode_AsString(nameobj)
             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

"_PyUnicode_AsString()" (macro of "PyUnicode_AsUTF8()") returns "const char *" since 3.7.0.