### PR TITLE
Fix memory leaks in if_pythonx

### DIFF
--- a/src/if_python.c
+++ b/src/if_python.c
@@ -1561,24 +1561,10 @@ do_pyeval (char_u *str, typval_T *rettv)
 	    (rangeinitializer) init_range_eval,
 	    (runner) run_eval,
 	    (void *) rettv);
-    switch (rettv->v_type)
+    if (rettv->v_type == VAR_UNKNOWN)
     {
-	case VAR_DICT: ++rettv->vval.v_dict->dv_refcount; break;
-	case VAR_LIST: ++rettv->vval.v_list->lv_refcount; break;
-	case VAR_FUNC: func_ref(rettv->vval.v_string);    break;
-	case VAR_PARTIAL: ++rettv->vval.v_partial->pt_refcount; break;
-	case VAR_UNKNOWN:
-	    rettv->v_type = VAR_NUMBER;
-	    rettv->vval.v_number = 0;
-	    break;
-	case VAR_NUMBER:
-	case VAR_STRING:
-	case VAR_FLOAT:
-	case VAR_SPECIAL:
-	case VAR_JOB:
-	case VAR_CHANNEL:
-	case VAR_BLOB:
-	    break;
+	rettv->v_type = VAR_NUMBER;
+	rettv->vval.v_number = 0;
     }
 }
 

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -1555,7 +1555,7 @@ FunctionGetattr(PyObject *self, char *name)
 }
 
     void
-do_pyeval (char_u *str, typval_T *rettv)
+do_pyeval(char_u *str, typval_T *rettv)
 {
     DoPyCommand((char *) str,
 	    (rangeinitializer) init_range_eval,
@@ -1580,7 +1580,7 @@ Py_GetProgramName(void)
 #endif /* Python 1.4 */
 
     int
-set_ref_in_python (int copyID)
+set_ref_in_python(int copyID)
 {
     return set_ref_in_py(copyID);
 }

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -1662,7 +1662,7 @@ LineToString(const char *str)
 }
 
     void
-do_py3eval (char_u *str, typval_T *rettv)
+do_py3eval(char_u *str, typval_T *rettv)
 {
     DoPyCommand((char *) str,
 	    (rangeinitializer) init_range_eval,
@@ -1676,7 +1676,7 @@ do_py3eval (char_u *str, typval_T *rettv)
 }
 
     int
-set_ref_in_python3 (int copyID)
+set_ref_in_python3(int copyID)
 {
     return set_ref_in_py(copyID);
 }

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -1668,24 +1668,10 @@ do_py3eval (char_u *str, typval_T *rettv)
 	    (rangeinitializer) init_range_eval,
 	    (runner) run_eval,
 	    (void *) rettv);
-    switch(rettv->v_type)
+    if (rettv->v_type == VAR_UNKNOWN)
     {
-	case VAR_DICT: ++rettv->vval.v_dict->dv_refcount; break;
-	case VAR_LIST: ++rettv->vval.v_list->lv_refcount; break;
-	case VAR_FUNC: func_ref(rettv->vval.v_string);    break;
-	case VAR_PARTIAL: ++rettv->vval.v_partial->pt_refcount; break;
-	case VAR_UNKNOWN:
-	    rettv->v_type = VAR_NUMBER;
-	    rettv->vval.v_number = 0;
-	    break;
-	case VAR_NUMBER:
-	case VAR_STRING:
-	case VAR_FLOAT:
-	case VAR_SPECIAL:
-	case VAR_JOB:
-	case VAR_CHANNEL:
-	case VAR_BLOB:
-	    break;
+	rettv->v_type = VAR_NUMBER;
+	rettv->vval.v_number = 0;
     }
 }
 


### PR DESCRIPTION
ASAN reports about test87 (if_python3):
https://gist.github.com/ichizok/db5f3d0f5f390e20234db54b67b41b0b

```
Direct leak of 576 byte(s) in 12 object(s) allocated from:
    #0 0x7fdac2803b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x56520670f27a in lalloc /home/who/Workspace/vim/src/misc2.c:942
    #2 0x56520670f0f8 in alloc_clear /home/who/Workspace/vim/src/misc2.c:851
    #3 0x565206a37cb6 in _ConvertFromPyObject /home/who/Workspace/vim/src/if_py_both.h:6236
    #4 0x565206a37801 in ConvertFromPyObject /home/who/Workspace/vim/src/if_py_both.h:6211
    #5 0x565206a3485a in run_eval /home/who/Workspace/vim/src/if_py_both.h:5815
    #6 0x565206a3b533 in DoPyCommand /home/who/Workspace/vim/src/if_python3.c:985
    #7 0x565206a3e4b4 in do_py3eval /home/who/Workspace/vim/src/if_python3.c:1667
    #8 0x56520656c13b in f_py3eval /home/who/Workspace/vim/src/evalfunc.c:8963
    (..snip..)
```

Also test86 (if_python).

## Cause

"do_py3eval()" increases the reference count of dict/list/funcref/partial, but this is an extra counting.

```vim
let var = py3eval("[]")
" The reference count of List object "var" should be 1, but actually 2.
```

Although dict and list are freed by GC at some point, funcref and partial are not, so they leak.