### PR TITLE
DirectWrite: Fix vertical alignment when 'linespace' is not 0

### DIFF
--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -1031,7 +1031,7 @@ DWriteContext::DrawText(const WCHAR *text, int len,
 
 	TextRenderer renderer(this);
 	TextRendererContext context = { color, FLOAT(cellWidth), 0.0f };
-	textLayout->Draw(&context, &renderer, FLOAT(x), FLOAT(y) - 0.5f);
+	textLayout->Draw(&context, &renderer, FLOAT(x), FLOAT(y));
     }
 
     SafeRelease(&textLayout);

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -6337,7 +6337,8 @@ gui_mch_draw_string(
 	{
 	    /* Add one to "cells" for italics. */
 	    DWriteContext_DrawText(s_dwc, unicodebuf, wlen,
-		    TEXT_X(col), TEXT_Y(row), FILL_X(cells + 1), FILL_Y(1),
+		    TEXT_X(col), TEXT_Y(row),
+		    FILL_X(cells + 1), FILL_Y(1) - p_linespace,
 		    gui.char_width, gui.currFgColor,
 		    foptions, pcliprect, unicodepdy);
 	}


### PR DESCRIPTION
After 8.1.1009 (#4116), the vertical alignment of DirectWrite became slightly
different from GDI. This is because he DirectWrite code didn't take 'linespace' into
account. This fixes the alignment when 'linespace' is not 0.