### PR TITLE
Add c_C-R_C-L and c_C-R_C-O to the list of all commands in index

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1042,10 +1042,11 @@ tag		command		action in Command-line editing mode	~
 				command-line from history.
 |c_CTRL-Q|	CTRL-Q		same as CTRL-V, unless it's used for terminal
 				control flow
-|c_CTRL-R|	CTRL-R {0-9a-z"%#*:= CTRL-F CTRL-P CTRL-W CTRL-A}
+|c_CTRL-R|	CTRL-R {0-9a-z"%#*:= CTRL-F CTRL-P CTRL-W CTRL-A CTRL-L}
 				insert the contents of a register or object
 				under the cursor as if typed
-|c_CTRL-R_CTRL-R| CTRL-R CTRL-R {0-9a-z"%#*:= CTRL-F CTRL-P CTRL-W CTRL-A}
+|c_CTRL-R_CTRL-R| CTRL-R CTRL-R {0-9a-z"%#*:= CTRL-F CTRL-P CTRL-W CTRL-A
+		CTRL-L}
 				insert the contents of a register or object
 				under the cursor literally
 		CTRL-S		(used for terminal control flow)

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1047,6 +1047,8 @@ tag		command		action in Command-line editing mode	~
 				under the cursor as if typed
 |c_CTRL-R_CTRL-R| CTRL-R CTRL-R {0-9a-z"%#*:= CTRL-F CTRL-P CTRL-W CTRL-A
 		CTRL-L}
+|c_CTRL-R_CTRL-O| CTRL-R CTRL-O {0-9a-z"%#*:= CTRL-F CTRL-P CTRL-W CTRL-A
+		CTRL-L}
 				insert the contents of a register or object
 				under the cursor literally
 		CTRL-S		(used for terminal control flow)


### PR DESCRIPTION
`c_CTRL-R_CTRL-L` (#2857) and `c_CTRL-R_CTRL-O` are not documented in the list of all commands. This pull request adds these commands to the list.