### PR TITLE
Fix 3 bugs in prop_remove()

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -788,7 +788,7 @@ static struct fst
     {"prop_add",	3, 3, f_prop_add},
     {"prop_clear",	1, 3, f_prop_clear},
     {"prop_list",	1, 2, f_prop_list},
-    {"prop_remove",	2, 3, f_prop_remove},
+    {"prop_remove",	1, 3, f_prop_remove},
     {"prop_type_add",	2, 2, f_prop_type_add},
     {"prop_type_change", 2, 2, f_prop_type_change},
     {"prop_type_delete", 1, 2, f_prop_type_delete},

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -167,27 +167,66 @@ func Test_prop_add_remove_buf()
   let bufnr = bufnr('')
   call AddPropTypes()
   call setline(1, 'one two three')
+  call setline(2, 'one two three')
+  call setline(3, 'one two three')
+  call setline(4, 'one two three')
   wincmd w
-  call prop_add(1, 1, {'length': 3, 'id': 11, 'type': 'one', 'bufnr': bufnr})
-  call prop_add(1, 5, {'length': 3, 'id': 12, 'type': 'two', 'bufnr': bufnr})
-  call prop_add(1, 11, {'length': 3, 'id': 13, 'type': 'three', 'bufnr': bufnr})
-  
+  for lnum in range(1, 4)
+    call prop_add(lnum, 1, {'length': 3, 'id': 11, 'type': 'one', 'bufnr': bufnr})
+    call prop_add(lnum, 5, {'length': 3, 'id': 12, 'type': 'two', 'bufnr': bufnr})
+    call prop_add(lnum, 11, {'length': 3, 'id': 13, 'type': 'three', 'bufnr': bufnr})
+  endfor
+
   let props = [
 	\ {'col': 1, 'length': 3, 'id': 11, 'type': 'one', 'start': 1, 'end': 1},
 	\ {'col': 5, 'length': 3, 'id': 12, 'type': 'two', 'start': 1, 'end': 1},
 	\ {'col': 11, 'length': 3, 'id': 13, 'type': 'three', 'start': 1, 'end': 1},
 	\]
   call assert_equal(props, prop_list(1, {'bufnr': bufnr}))
- 
+
   " remove by id
-  call prop_remove({'id': 12, 'bufnr': bufnr}, 1)
+  let before_props = deepcopy(props)
   unlet props[1]
+
+  call prop_remove({'id': 12, 'bufnr': bufnr}, 1)
   call assert_equal(props, prop_list(1, {'bufnr': bufnr}))
+  call assert_equal(before_props, prop_list(2, {'bufnr': bufnr}))
+  call assert_equal(before_props, prop_list(3, {'bufnr': bufnr}))
+  call assert_equal(before_props, prop_list(4, {'bufnr': bufnr}))
+
+  call prop_remove({'id': 12, 'bufnr': bufnr}, 3, 4)
+  call assert_equal(props, prop_list(1, {'bufnr': bufnr}))
+  call assert_equal(before_props, prop_list(2, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(3, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(4, {'bufnr': bufnr}))
+
+  call prop_remove({'id': 12, 'bufnr': bufnr})
+  call assert_equal(props, prop_list(1, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(2, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(3, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(4, {'bufnr': bufnr}))
 
   " remove by type
-  call prop_remove({'type': 'one', 'bufnr': bufnr}, 1)
+  let before_props = deepcopy(props)
   unlet props[0]
+
+  call prop_remove({'type': 'one', 'bufnr': bufnr}, 1)
   call assert_equal(props, prop_list(1, {'bufnr': bufnr}))
+  call assert_equal(before_props, prop_list(2, {'bufnr': bufnr}))
+  call assert_equal(before_props, prop_list(3, {'bufnr': bufnr}))
+  call assert_equal(before_props, prop_list(4, {'bufnr': bufnr}))
+
+  call prop_remove({'type': 'one', 'bufnr': bufnr}, 3, 4)
+  call assert_equal(props, prop_list(1, {'bufnr': bufnr}))
+  call assert_equal(before_props, prop_list(2, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(3, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(4, {'bufnr': bufnr}))
+
+  call prop_remove({'type': 'one', 'bufnr': bufnr})
+  call assert_equal(props, prop_list(1, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(2, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(3, {'bufnr': bufnr}))
+  call assert_equal(props, prop_list(4, {'bufnr': bufnr}))
 
   call DeletePropTypes()
   wincmd w

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -629,7 +629,10 @@ f_prop_remove(typval_T *argvars, typval_T *rettv)
 			mch_memmove(newptr, buf->b_ml.ml_line_ptr,
 							buf->b_ml.ml_line_len);
 			buf->b_ml.ml_line_ptr = newptr;
-			curbuf->b_ml.ml_flags |= ML_LINE_DIRTY;
+			buf->b_ml.ml_flags |= ML_LINE_DIRTY;
+
+			cur_prop = buf->b_ml.ml_line_ptr + len
+							+ idx * sizeof(textprop_T);
 		    }
 
 		    taillen = buf->b_ml.ml_line_len - len


### PR DESCRIPTION
1. The second argument {lnum} could not be omitted.
2. `curbuf` had been used instead of `buf`.
3. `cur_prop` was not updated after allocating new memory.

First, I found the 1st bug.  I fixed it and wrote test.
The new test revealed two bugs.  I also fixed them.
Sorry for many fixes in one PR.