### PR TITLE
Add jumpnr to the list returned by getjumplist()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4925,6 +4925,10 @@ getjumplist([{winnr} [, {tabnr}]])			*getjumplist()*
 			col		column number
 			coladd		column offset for 'virtualedit'
 			filename	filename if available
+			jumpnr		count passed to the |CTRL-O| and
+					|CTRL-I| commands to jump to a
+					particular entry in the jump list. Set
+					to 0 for the current entry.
 			lnum		line number
 
 							*getline()*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5291,6 +5291,9 @@ f_getjumplist(typval_T *argvars, typval_T *rettv)
 	    return;
 	if (list_append_dict(l, d) == FAIL)
 	    return;
+	dict_add_number(d, "jumpnr",
+		(long)(i > wp->w_jumplistidx ? i - wp->w_jumplistidx
+						: wp->w_jumplistidx - i));
 	dict_add_number(d, "lnum", (long)wp->w_jumplist[i].fmark.mark.lnum);
 	dict_add_number(d, "col", (long)wp->w_jumplist[i].fmark.mark.col);
 	dict_add_number(d, "coladd", (long)wp->w_jumplist[i].fmark.mark.coladd);

--- a/src/testdir/test_jumplist.vim
+++ b/src/testdir/test_jumplist.vim
@@ -29,9 +29,10 @@ func Test_getjumplist()
   normal gg
 
   let expected = [[
-	      \ {'lnum': 1, 'bufnr': bnr, 'col': 0, 'coladd': 0},
-	      \ {'lnum': 50, 'bufnr': bnr, 'col': 0, 'coladd': 0},
-	      \ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0}], 3]
+	\ {'lnum': 1, 'bufnr': bnr, 'col': 0, 'coladd': 0, 'jumpnr' : 3},
+	\ {'lnum': 50, 'bufnr': bnr, 'col': 0, 'coladd': 0, 'jumpnr' : 2},
+	\ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0, 'jumpnr' : 1}],
+	\ 3]
   call assert_equal(expected, getjumplist())
   " jumplist doesn't change in between calls
   call assert_equal(expected, getjumplist())
@@ -40,17 +41,21 @@ func Test_getjumplist()
   5
   exe "normal \<C-O>"
   call assert_equal(2, getjumplist(1)[1])
+  call assert_equal(0, getjumplist(1)[0][2].jumpnr)
   exe "normal 2\<C-O>"
   call assert_equal(0, getjumplist(1, 1)[1])
+  call assert_equal(0, getjumplist(1)[0][0].jumpnr)
   exe "normal 3\<C-I>"
   call assert_equal(3, getjumplist()[1])
+  call assert_equal(0, getjumplist(1)[0][3].jumpnr)
   exe "normal \<C-O>"
   normal 20%
   let expected = [[
-	      \ {'lnum': 1, 'bufnr': bnr, 'col': 0, 'coladd': 0},
-	      \ {'lnum': 50, 'bufnr': bnr, 'col': 0, 'coladd': 0},
-	      \ {'lnum': 5, 'bufnr': bnr, 'col': 0, 'coladd': 0},
-	      \ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0}], 4]
+	\ {'lnum': 1, 'bufnr': bnr, 'col': 0, 'coladd': 0, 'jumpnr' : 4},
+	\ {'lnum': 50, 'bufnr': bnr, 'col': 0, 'coladd': 0, 'jumpnr' : 3},
+	\ {'lnum': 5, 'bufnr': bnr, 'col': 0, 'coladd': 0, 'jumpnr' : 2},
+	\ {'lnum': 100, 'bufnr': bnr, 'col': 0, 'coladd': 0, 'jumpnr' : 1}],
+	\ 4]
   call assert_equal(expected, getjumplist())
   " jumplist doesn't change in between calls
   call assert_equal(expected, getjumplist())


### PR DESCRIPTION
Addresses the issue raised in #4145.