### PR TITLE
if_lua: Add vim.blob type

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -10,11 +10,12 @@ The Lua Interface to Vim				*lua* *Lua*
 2. The vim module		|lua-vim|
 3. List userdata		|lua-list|
 4. Dict userdata		|lua-dict|
-5. Funcref userdata		|lua-funcref|
-6. Buffer userdata		|lua-buffer|
-7. Window userdata		|lua-window|
-8. The luaeval function		|lua-luaeval|
-9. Dynamic loading		|lua-dynamic|
+5. Blob userdata		|lua-blob|
+6. Funcref userdata		|lua-funcref|
+7. Buffer userdata		|lua-buffer|
+8. Window userdata		|lua-window|
+9. The luaeval function		|lua-luaeval|
+10. Dynamic loading		|lua-dynamic|
 
 {Vi does not have any of these commands}
 
@@ -141,6 +142,14 @@ Vim evaluation and command execution, and others.
 				    :" {'1': 3.141593, '2': v:false,
 				    :" 'say': 'hi'}
 <
+	vim.blob([arg])		Returns an empty blob or, if "arg" is a Lua
+				string, returns a blob b such that b is
+				equivalent to "arg" as a byte string.
+				Examples: >
+				    :lua s = "12ab\x00\x80\xfe\xff"
+				    :echo luaeval('vim.blob(s)')
+				    :" 0z31326162.0080FEFF
+<
 	vim.funcref({name})	Returns a Funcref to function {name} (see
 				|Funcref|). It is equivalent to Vim's
 				function().
@@ -260,7 +269,34 @@ Examples:
 <
 
 ==============================================================================
-5. Funcref userdata					*lua-funcref*
+5. Blob userdata					*lua-blob*
+
+Blob userdata represent vim blobs. A blob "b" has the following properties:
+
+Properties
+----------
+	o "#b" is the length of blob "b", equivalent to "len(b)" in Vim.
+	o "b[k]" returns the k-th item in "b"; "b" is zero-indexed, as in Vim.
+	    To modify the k-th item, simply do "b[k] = number"; in particular,
+	    "b[#b] = number" can append a byte to tail.
+
+Methods
+-------
+	o "b:add(bytes)" appends "bytes" to the end of "b".
+
+Examples:
+>
+	:let b = 0z001122
+	:lua b = vim.eval('b') -- same 'b'
+	:lua print(b, b[0], #b)
+	:lua b[1] = 32
+	:lua b[#b] = 0x33 -- append a byte to tail
+	:lua b:add("\x80\x81\xfe\xff")
+	:echo b
+<
+
+==============================================================================
+6. Funcref userdata					*lua-funcref*
 
 Funcref userdata represent funcref variables in Vim. Funcrefs that were
 defined with a "dict" attribute need to be obtained as a dictionary key
@@ -293,7 +329,7 @@ Examples:
 <
 
 ==============================================================================
-6. Buffer userdata					*lua-buffer*
+7. Buffer userdata					*lua-buffer*
 
 Buffer userdata represent vim buffers. A buffer userdata "b" has the following
 properties and methods:
@@ -345,7 +381,7 @@ Examples:
 <
 
 ==============================================================================
-7. Window userdata					*lua-window*
+8. Window userdata					*lua-window*
 
 Window objects represent vim windows. A window userdata "w" has the following
 properties and methods:
@@ -377,7 +413,7 @@ Examples:
 <
 
 ==============================================================================
-8. The luaeval function					*lua-luaeval* *lua-eval*
+9. The luaeval function					*lua-luaeval* *lua-eval*
 
 The (dual) equivalent of "vim.eval" for passing Lua values to Vim is
 "luaeval". "luaeval" takes an expression string and an optional argument and
@@ -390,10 +426,10 @@ returns the result of the expression. It is semantically equivalent in Lua to:
 	end
 <
 Note that "_A" receives the argument to "luaeval". Lua numbers, strings, and
-list, dict, and funcref userdata are converted to their Vim respective types,
-while Lua booleans are converted to numbers. An error is thrown if conversion
-of any of the remaining Lua types, including userdata other than lists, dicts,
-and funcrefs, is attempted.
+list, dict, blob, and funcref userdata are converted to their Vim respective
+types, while Lua booleans are converted to numbers. An error is thrown if
+conversion of any of the remaining Lua types, including userdata other than
+lists, dicts, blobs, and funcrefs, is attempted.
 
 Examples: >
 
@@ -408,7 +444,7 @@ Examples: >
 
 
 ==============================================================================
-9. Dynamic loading				    *lua-dynamic*
+10. Dynamic loading				    *lua-dynamic*
 
 On MS-Windows and Unix the Lua library can be loaded dynamically.  The
 |:version| output then includes |+lua/dyn|.

--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -14,7 +14,7 @@ The Lua Interface to Vim				*lua* *Lua*
 6. Funcref userdata		|lua-funcref|
 7. Buffer userdata		|lua-buffer|
 8. Window userdata		|lua-window|
-9. The luaeval function		|lua-luaeval|
+9. luaeval() Vim function	|lua-luaeval|
 10. Dynamic loading		|lua-dynamic|
 
 {Vi does not have any of these commands}
@@ -413,7 +413,7 @@ Examples:
 <
 
 ==============================================================================
-9. The luaeval function					*lua-luaeval* *lua-eval*
+9. luaeval() Vim function				*lua-luaeval* *lua-eval*
 
 The (dual) equivalent of "vim.eval" for passing Lua values to Vim is
 "luaeval". "luaeval" takes an expression string and an optional argument and

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -50,6 +50,11 @@ func Test_eval()
   call assert_equal('dict', luaeval('vim.type(v)'))
   call assert_equal({'a':'b'}, luaeval('v'))
 
+  " lua.eval with a blob
+  lua v = vim.eval("0z00112233.deadbeef")
+  call assert_equal('blob', luaeval('vim.type(v)'))
+  call assert_equal(0z00112233.deadbeef, luaeval('v'))
+
   call assert_fails('lua v = vim.eval(nil)',
         \ "[string \"vim chunk\"]:1: bad argument #1 to 'eval' (string expected, got nil)")
   call assert_fails('lua v = vim.eval(true)',
@@ -426,6 +431,30 @@ func Test_dict_iter()
   call assert_equal('a:1,b:2,', luaeval('str'))
 
   lua str, d = nil
+endfunc
+
+func Test_blob()
+  call assert_equal(0z, luaeval('vim.blob("")'))
+  call assert_equal(0z31326162, luaeval('vim.blob("12ab")'))
+  call assert_equal(0z00010203, luaeval('vim.blob("\x00\x01\x02\x03")'))
+  call assert_equal(0z8081FEFF, luaeval('vim.blob("\x80\x81\xfe\xff")'))
+
+  lua b = vim.blob("\x00\x00\x00\x00")
+  call assert_equal(0z00000000, luaeval('b'))
+  call assert_equal(4.0, luaeval('#b'))
+  lua b[0], b[1], b[2], b[3] = 1, 32, 256, 0xff
+  call assert_equal(0z012000ff, luaeval('b'))
+  lua b[4] = string.byte("z", 1)
+  call assert_equal(0z012000ff.7a, luaeval('b'))
+  call assert_equal(5.0, luaeval('#b'))
+  call assert_fails('lua b[#b+1] = 0x80', '[string "vim chunk"]:1: index out of range')
+  lua b:add("12ab")
+  call assert_equal(0z012000ff.7a313261.62, luaeval('b'))
+  call assert_equal(9.0, luaeval('#b'))
+  call assert_fails('lua b:add(nil)', '[string "vim chunk"]:1: string expected, got nil')
+  call assert_fails('lua b:add(true)', '[string "vim chunk"]:1: string expected, got boolean')
+  call assert_fails('lua b:add({})', '[string "vim chunk"]:1: string expected, got table')
+  lua b = nil
 endfunc
 
 func Test_funcref()


### PR DESCRIPTION
Examples:
```vim
" create new blob: 0z001122
lua b = vim.blob("\x00\x11\x22")
" get 1st item: 0x11
lua print(b[1]) -- 17
" change 2nd item 
lua b[2] = 0x80
" when the index is `#b` (length of `b`), append a byte to tail
lua b[#b] = 0xff
" method "add": append bytes
lua b:add("12ab")
```