### PR TITLE
Fix E315 when writing to hidden buffer using python buffer object

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -4392,7 +4392,10 @@ SetBufferLine(buf_T *buf, PyInt n, PyObject *line, PyInt *len_change)
 	    RAISE_DELETE_LINE_FAIL;
 	else
 	{
-	    if (buf == curbuf)
+	    if (buf == curbuf && (save_curwin != NULL
+					   || save_curbuf.br_buf == NULL))
+		/* Using an existing window for the buffer, adjust the cursor
+		 * position. */
 		py_fix_cursor((linenr_T)n, (linenr_T)n + 1, (linenr_T)-1);
 	    if (save_curbuf.br_buf == NULL)
 		/* Only adjust marks if we managed to switch to a window that
@@ -4642,7 +4645,10 @@ SetBufferLineList(
 						  (long)MAXLNUM, (long)extra);
 	changed_lines((linenr_T)lo, 0, (linenr_T)hi, (long)extra);
 
-	if (buf == curbuf)
+	if (buf == curbuf && (save_curwin != NULL
+					   || save_curbuf.br_buf == NULL))
+	    /* Using an existing window for the buffer, adjust the cursor
+	     * position. */
 	    py_fix_cursor((linenr_T)lo, (linenr_T)hi, (linenr_T)extra);
 
 	/* END of region without "return". */

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -71,3 +71,87 @@ func Test_skipped_python_command_does_not_affect_pyxversion()
   endif
   call assert_equal(0, &pyxversion)  " This assertion would have failed with Vim 8.0.0251. (pyxversion was introduced in 8.0.0251.)
 endfunc
+
+func _SetUpHiddenBuffer()
+  py import vim
+  new
+  edit hidden
+  setlocal bufhidden=hide
+
+  enew
+  let lnum = 0
+  while lnum < 10
+    call append( 1, string( lnum ) )
+    let lnum = lnum + 1
+  endwhile
+  normal G
+
+  call assert_equal( line( '.' ), 11 )
+endfunc
+
+func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Clear()
+  call _SetUpHiddenBuffer()
+  py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = None
+  call assert_equal( line( '.' ), 11 )
+  bwipe!
+endfunc
+
+func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_List()
+  call _SetUpHiddenBuffer()
+  py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = [ 'test' ]
+  call assert_equal( line( '.' ), 11 )
+  bwipe!
+endfunc
+
+func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Str()
+  call _SetUpHiddenBuffer()
+  py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = 'test'
+  call assert_equal( line( '.' ), 11 )
+  bwipe!
+endfunc
+
+func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_ClearLine()
+  call _SetUpHiddenBuffer()
+  py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = None
+  call assert_equal( line( '.' ), 11 )
+  bwipe!
+endfunc
+
+func _SetUpVisibleBuffer()
+  py import vim
+  new
+  let lnum = 0
+  while lnum < 10
+    call append( 1, string( lnum ) )
+    let lnum = lnum + 1
+  endwhile
+  normal G
+  call assert_equal( line( '.' ), 11 )
+endfunc
+
+func Test_Write_To_Current_Buffer_Fixes_Cursor_Clear()
+  call _SetUpVisibleBuffer()
+
+  py vim.current.buffer[:] = None
+  call assert_equal( line( '.' ), 1 )
+
+  bwipe!
+endfunc
+
+func Test_Write_To_Current_Buffer_Fixes_Cursor_List()
+  call _SetUpVisibleBuffer()
+
+  py vim.current.buffer[:] = [ 'test' ]
+  call assert_equal( line( '.' ), 1 )
+
+  bwipe!
+endfunction
+
+func Test_Write_To_Current_Buffer_Fixes_Cursor_Str()
+  call _SetUpVisibleBuffer()
+
+  py vim.current.buffer[-1] = None
+  call assert_equal( line( '.' ), 10 )
+
+  bwipe!
+endfunction

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -71,3 +71,87 @@ func Test_skipped_python3_command_does_not_affect_pyxversion()
   endif
   call assert_equal(0, &pyxversion)  " This assertion would have failed with Vim 8.0.0251. (pyxversion was introduced in 8.0.0251.)
 endfunc
+
+func _SetUpHiddenBuffer()
+  py3 import vim
+  new
+  edit hidden
+  setlocal bufhidden=hide
+
+  enew
+  let lnum = 0
+  while lnum < 10
+    call append( 1, string( lnum ) )
+    let lnum = lnum + 1
+  endwhile
+  normal G
+
+  call assert_equal( line( '.' ), 11 )
+endfunc
+
+func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Clear()
+  call _SetUpHiddenBuffer()
+  py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = None
+  call assert_equal( line( '.' ), 11 )
+  bwipe!
+endfunc
+
+func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_List()
+  call _SetUpHiddenBuffer()
+  py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = [ 'test' ]
+  call assert_equal( line( '.' ), 11 )
+  bwipe!
+endfunc
+
+func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Str()
+  call _SetUpHiddenBuffer()
+  py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = 'test'
+  call assert_equal( line( '.' ), 11 )
+  bwipe!
+endfunc
+
+func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_ClearLine()
+  call _SetUpHiddenBuffer()
+  py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = None
+  call assert_equal( line( '.' ), 11 )
+  bwipe!
+endfunc
+
+func _SetUpVisibleBuffer()
+  py3 import vim
+  new
+  let lnum = 0
+  while lnum < 10
+    call append( 1, string( lnum ) )
+    let lnum = lnum + 1
+  endwhile
+  normal G
+  call assert_equal( line( '.' ), 11 )
+endfunc
+
+func Test_Write_To_Current_Buffer_Fixes_Cursor_Clear()
+  call _SetUpVisibleBuffer()
+
+  py3 vim.current.buffer[:] = None
+  call assert_equal( line( '.' ), 1 )
+
+  bwipe!
+endfunc
+
+func Test_Write_To_Current_Buffer_Fixes_Cursor_List()
+  call _SetUpVisibleBuffer()
+
+  py3 vim.current.buffer[:] = [ 'test' ]
+  call assert_equal( line( '.' ), 1 )
+
+  bwipe!
+endfunction
+
+func Test_Write_To_Current_Buffer_Fixes_Cursor_Str()
+  call _SetUpVisibleBuffer()
+
+  py3 vim.current.buffer[-1] = None
+  call assert_equal( line( '.' ), 10 )
+
+  bwipe!
+endfunction


### PR DESCRIPTION
Fixes #4153 

Tests fail prior to change and pass afterwards.

I found that the check before calling `py_fix_cursor` is not consistently applied, so this patch applies it more consistently.