### PR TITLE
Detect gitconfig files in .gitconfig.d

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -619,7 +619,7 @@ au BufNewFile,BufRead *.ged,lltxxxxx.txt	setf gedcom
 " Git
 au BufNewFile,BufRead COMMIT_EDITMSG,MERGE_MSG,TAG_EDITMSG 	setf gitcommit
 au BufNewFile,BufRead *.git/config,.gitconfig,/etc/gitconfig 	setf gitconfig
-au BufNewFile,BufRead */.gitconfig.d/*,/etc/gitconfig.d/* 	setf gitconfig
+au BufNewFile,BufRead */.gitconfig.d/*,/etc/gitconfig.d/* 	call s:StarSetf('gitconfig')
 au BufNewFile,BufRead */.config/git/config			setf gitconfig
 au BufNewFile,BufRead .gitmodules,*.git/modules/*/config	setf gitconfig
 if !empty($XDG_CONFIG_HOME)

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -619,6 +619,7 @@ au BufNewFile,BufRead *.ged,lltxxxxx.txt	setf gedcom
 " Git
 au BufNewFile,BufRead COMMIT_EDITMSG,MERGE_MSG,TAG_EDITMSG 	setf gitcommit
 au BufNewFile,BufRead *.git/config,.gitconfig,/etc/gitconfig 	setf gitconfig
+au BufNewFile,BufRead */.gitconfig.d/*,/etc/gitconfig.d/* 	setf gitconfig
 au BufNewFile,BufRead */.config/git/config			setf gitconfig
 au BufNewFile,BufRead .gitmodules,*.git/modules/*/config	setf gitconfig
 if !empty($XDG_CONFIG_HOME)


### PR DESCRIPTION
git-config allows for includes:
https://git-scm.com/docs/git-config#_includes

I propose detecting files in `*/.gitconfig.d/*` and `/etc/gitconfig.d/*` as gitconfig files in order to support modular git configurations inside of a `.gitconfig.d` directory.