### PR TITLE
Misc change to testdir

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -224,6 +224,7 @@ NEW_TESTS = \
 	test_searchpos \
 	test_set \
 	test_sha256 \
+	test_shortpathname \
 	test_signals \
 	test_signs \
 	test_smartindent \
@@ -258,6 +259,7 @@ NEW_TESTS = \
 	test_true_false \
 	test_undo \
 	test_unlet \
+	test_user_func \
 	test_usercommands \
 	test_utf8 \
 	test_utf8_comparisons \

--- a/src/testdir/README.txt
+++ b/src/testdir/README.txt
@@ -36,8 +36,8 @@ What you can use (see test_assert.vim for an example):
 
 - Use test_alloc_fail() to have memory allocation fail.  This makes it possible
   to check memory allocation failures are handled gracefully.  You need to
-  change the source code to add an ID to the allocation.  Update LAST_ID_USED
-  above alloc_id() to the highest ID used.
+  change the source code to add an ID to the allocation.  Add a new one to
+  alloc_id_T.
 
 - Use test_override() to make Vim behave differently, e.g.  if char_avail()
   must return FALSE for a while.  E.g. to trigger the CursorMovedI autocommand

--- a/src/testdir/README.txt
+++ b/src/testdir/README.txt
@@ -39,11 +39,9 @@ What you can use (see test_assert.vim for an example):
   change the source code to add an ID to the allocation.  Add a new one to
   alloc_id_T.
 
-- Use test_override() to make Vim behave differently, e.g.  if char_avail()
-  must return FALSE for a while.  E.g. to trigger the CursorMovedI autocommand
-  event.
-
-- See test_cursor_func.vim for an example.
+- Use test_override() to make Vim behave differently, e.g. if char_avail() must
+  return FALSE for a while.  E.g. to trigger the CursorMovedI autocommand
+  event.  See test_cursor_func.vim for an example.
 
 - If the bug that is being tested isn't fixed yet, you can throw an exception
   with "Skipped" so that it's clear this still needs work.  E.g.: throw

--- a/src/testdir/README.txt
+++ b/src/testdir/README.txt
@@ -34,10 +34,10 @@ What you can use (see test_assert.vim for an example):
 
 - Use try/catch to avoid an exception aborts the test.
 
-- Use alloc_fail() to have memory allocation fail. This makes it possible to
-  check memory allocation failures are handled gracefully.  You need to change
-  the source code to add an ID to the allocation.  Update LAST_ID_USED above
-  alloc_id() to the highest ID used.
+- Use test_alloc_fail() to have memory allocation fail.  This makes it possible
+  to check memory allocation failures are handled gracefully.  You need to
+  change the source code to add an ID to the allocation.  Update LAST_ID_USED
+  above alloc_id() to the highest ID used.
 
 - Use test_override() to make Vim behave differently, e.g.  if char_avail()
   must return FALSE for a while.  E.g. to trigger the CursorMovedI autocommand

--- a/src/testdir/README.txt
+++ b/src/testdir/README.txt
@@ -61,7 +61,7 @@ TO ADD AN OLD STYLE TEST:
 1) Create test_<subject>.in and test_<subject>.ok files.
 2) Add test_<subject>.out to SCRIPTS_ALL in Make_all.mak in alphabetical order.
 3) Use make test_<subject>.out to run a single test in src/testdir/.
-   Use make test_<subject>  to run a single test in src/.
+   Use make test_<subject> to run a single test in src/.
 4) Also add an entry in src/Makefile.
 
 Keep in mind that the files are used as if everything was typed:

--- a/src/testdir/README.txt
+++ b/src/testdir/README.txt
@@ -36,8 +36,7 @@ What you can use (see test_assert.vim for an example):
 
 - Use alloc_fail() to have memory allocation fail. This makes it possible to
   check memory allocation failures are handled gracefully.  You need to change
-
-- the source code to add an ID to the allocation.  Update LAST_ID_USED above
+  the source code to add an ID to the allocation.  Update LAST_ID_USED above
   alloc_id() to the highest ID used.
 
 - Use test_override() to make Vim behave differently, e.g.  if char_avail()

--- a/src/testdir/test85.ok
+++ b/src/testdir/test85.ok
@@ -1,7 +1,0 @@
-1 changed line 1
-scalar test OK
-2 line 2
-dictionary with list OK
-circular test OK
-[123.0, 'abc', [1, 2, 3], {'a': 1, 'b': 2, 'c': 3}]
-{'4': 123.0, '5': 'abc', '6': [1, 2, 3], '7': {'a': 1, 'b': 2, 'c': 3}}


### PR DESCRIPTION
This doesn't change any actual behavior of test.

Summary:

* Add missing indivisudal tests to NEW_TESTS
* Update or fix README.txt
* Remove test85.ok
    * test85.in has been removed by 4ff4814 due to updating to new-style-test

(This is a rebased PR of #4159.)