### PR TITLE
DirectWrite: Force redraw when render target is recreated

### DIFF
--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -930,6 +930,8 @@ DWriteContext::BindDC(HDC hdc, const RECT *rect)
     }
 }
 
+extern "C" void redraw_later_clear(void);
+
     HRESULT
 DWriteContext::SetDrawingMode(DrawingMode mode)
 {
@@ -952,6 +954,7 @@ DWriteContext::SetDrawingMode(DrawingMode mode)
 		    hr = S_OK;
 		    DiscardDeviceResources();
 		    CreateDeviceResources();
+		    redraw_later_clear();
 		}
 		mDrawing = false;
 	    }


### PR DESCRIPTION
DirectWrite sometimes fails with the `D2DERR_RECREATE_TARGET` error.  In
that case, we need to recreate the Direct2D render target.  We already
do it, however, just recreating it is not enough, and the Vim screen
becomes blank.  Typing CTRL-L can work around the problem, but it is not
convenient.  This patch automatically redraws the screen when the render
target is recreated.