### PR TITLE
Add MenuPopupChanged (orig. Qiming Zhao)

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -360,7 +360,7 @@ Name			triggered by ~
 |SessionLoadPost|	after loading a session file
 
 |MenuPopup|		just before showing the popup menu
-|MenuPopupChanged|	after popup menu changed, not fired on popup menu hide
+|CompleteChanged|	after popup menu changed, not fired on popup menu hide
 |CompleteDone|		after Insert mode completion is done
 
 |User|			to be used in combination with ":doautocmd"
@@ -573,7 +573,21 @@ ColorScheme			After loading a color scheme. |:colorscheme|
 ColorSchemePre			Before loading a color scheme. |:colorscheme|
 				Useful to setup removing things added by a
 				color scheme, before another one is loaded.
+CompleteChanged 					*CompleteChanged*
+				After each time popup menu changed, not fired
+				on popup menu hide, use |CompleteDone| for popup
+				menu hide.
 
+				Sets these |v:event| keys:
+				    completed_item
+				    height
+				    width
+				    row
+				    col
+				    size
+				    scrollbar
+
+				It is not allowed to change the text |textlock|.
 							*CompleteDone*
 CompleteDone			After Insert mode completion is done.  Either
 				when something was completed or abandoning
@@ -848,21 +862,6 @@ MenuPopup			Just before showing the popup menu (under the
 					i	Insert
 					c	Command line
 					tl	Terminal
-MenuPopupChanged 					*MenuPopupChanged*
-				After each time popup menu changed, not fired
-				on popup menu hide, use |CompleteDone| for popup
-				menu hide.
-
-				Sets these |v:event| keys:
-				    completed_item
-				    height
-				    width
-				    row
-				    col
-				    size
-				    scrollbar
-
-				It is not allowed to change the text |textlock|.
 							*OptionSet*
 OptionSet			After setting an option.  The pattern is
 				matched against the long option name.
@@ -888,7 +887,6 @@ OptionSet			After setting an option.  The pattern is
 
 				When using |:set| in the autocommand the event
 				is not triggered again.
-
 							*QuickFixCmdPre*
 QuickFixCmdPre			Before a quickfix command is run (|:make|,
 				|:lmake|, |:grep|, |:lgrep|, |:grepadd|,

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -360,6 +360,7 @@ Name			triggered by ~
 |SessionLoadPost|	after loading a session file
 
 |MenuPopup|		just before showing the popup menu
+|MenuPopupChanged|	after popup menu changed, not fired on popup menu hide
 |CompleteDone|		after Insert mode completion is done
 
 |User|			to be used in combination with ":doautocmd"
@@ -847,6 +848,21 @@ MenuPopup			Just before showing the popup menu (under the
 					i	Insert
 					c	Command line
 					tl	Terminal
+MenuPopupChanged 					*MenuPopupChanged*
+				After each time popup menu changed, not fired
+				on popup menu hide, use |CompleteDone| for popup
+				menu hide.
+
+				Sets these |v:event| keys:
+				    completed_item
+				    height
+				    width
+				    row
+				    col
+				    size
+				    scrollbar
+
+				It is not allowed to change the text |textlock|.
 							*OptionSet*
 OptionSet			After setting an option.  The pattern is
 				matched against the long option name.

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -111,6 +111,7 @@ static struct event_name
     {"CmdUndefined",	EVENT_CMDUNDEFINED},
     {"ColorScheme",	EVENT_COLORSCHEME},
     {"ColorSchemePre",	EVENT_COLORSCHEMEPRE},
+    {"CompleteChanged",	EVENT_COMPLETECHANGED},
     {"CompleteDone",	EVENT_COMPLETEDONE},
     {"CursorHold",	EVENT_CURSORHOLD},
     {"CursorHoldI",	EVENT_CURSORHOLDI},
@@ -148,7 +149,6 @@ static struct event_name
     {"InsertLeave",	EVENT_INSERTLEAVE},
     {"InsertCharPre",	EVENT_INSERTCHARPRE},
     {"MenuPopup",	EVENT_MENUPOPUP},
-    {"MenuPopupChanged",EVENT_MENUPOPUPCHANGED},
     {"OptionSet",	EVENT_OPTIONSET},
     {"QuickFixCmdPost",	EVENT_QUICKFIXCMDPOST},
     {"QuickFixCmdPre",	EVENT_QUICKFIXCMDPRE},
@@ -1752,12 +1752,12 @@ has_textyankpost(void)
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 /*
- * Return TRUE when there is a MenuPopupChanged autocommand defined.
+ * Return TRUE when there is a CompleteChanged autocommand defined.
  */
     int
-has_menupopupchanged(void)
+has_completechanged(void)
 {
-    return (first_autopat[(int)EVENT_MENUPOPUPCHANGED] != NULL);
+    return (first_autopat[(int)EVENT_COMPLETECHANGED] != NULL);
 }
 #endif
 

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -148,6 +148,7 @@ static struct event_name
     {"InsertLeave",	EVENT_INSERTLEAVE},
     {"InsertCharPre",	EVENT_INSERTCHARPRE},
     {"MenuPopup",	EVENT_MENUPOPUP},
+    {"MenuPopupChanged",EVENT_MENUPOPUPCHANGED},
     {"OptionSet",	EVENT_OPTIONSET},
     {"QuickFixCmdPost",	EVENT_QUICKFIXCMDPOST},
     {"QuickFixCmdPre",	EVENT_QUICKFIXCMDPRE},
@@ -1746,6 +1747,17 @@ has_funcundefined(void)
 has_textyankpost(void)
 {
     return (first_autopat[(int)EVENT_TEXTYANKPOST] != NULL);
+}
+#endif
+
+#if defined(FEAT_EVAL) || defined(PROTO)
+/*
+ * Return TRUE when there is a MenuPopupChanged autocommand defined.
+ */
+    int
+has_menupopupchanged(void)
+{
+    return (first_autopat[(int)EVENT_MENUPOPUPCHANGED] != NULL);
 }
 #endif
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -342,18 +342,18 @@ dict_add(dict_T *d, dictitem_T *item)
 }
 
 /*
- * Add a number entry to dictionary "d".
+ * Add a number or special entry to dictionary "d".
  * Returns FAIL when out of memory and when key already exists.
  */
-    int
-dict_add_number(dict_T *d, char *key, varnumber_T nr)
+    static int
+dict_add_number_special(dict_T *d, char *key, varnumber_T nr, int special)
 {
     dictitem_T	*item;
 
     item = dictitem_alloc((char_u *)key);
     if (item == NULL)
 	return FAIL;
-    item->di_tv.v_type = VAR_NUMBER;
+    item->di_tv.v_type = special ? VAR_SPECIAL : VAR_NUMBER;
     item->di_tv.vval.v_number = nr;
     if (dict_add(d, item) == FAIL)
     {
@@ -361,6 +361,26 @@ dict_add_number(dict_T *d, char *key, varnumber_T nr)
 	return FAIL;
     }
     return OK;
+}
+
+/*
+ * Add a number entry to dictionary "d".
+ * Returns FAIL when out of memory and when key already exists.
+ */
+    int
+dict_add_number(dict_T *d, char *key, varnumber_T nr)
+{
+    return dict_add_number_special(d, key, nr, FALSE);
+}
+
+/*
+ * Add a special entry to dictionary "d".
+ * Returns FAIL when out of memory and when key already exists.
+ */
+    int
+dict_add_special(dict_T *d, char *key, varnumber_T nr)
+{
+    return dict_add_number_special(d, key, nr, TRUE);
 }
 
 /*

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1129,7 +1129,7 @@ ins_compl_show_pum(void)
 	pum_display(compl_match_array, compl_match_arraysize, cur);
 	curwin->w_cursor.col = col;
 
-	if (!has_menupopupchanged() || recursive)
+	if (!has_completechanged() || recursive)
 	    return;
 	v_event = get_vim_var_dict(VV_EVENT);
 	if (cur < 0)
@@ -1144,7 +1144,7 @@ ins_compl_show_pum(void)
 
  	recursive = TRUE;
 	textlock++;
-	apply_autocmds(EVENT_MENUPOPUPCHANGED, NULL, NULL, FALSE, curbuf);
+	apply_autocmds(EVENT_COMPLETECHANGED, NULL, NULL, FALSE, curbuf);
 	textlock--;
 	recursive = FALSE;
 

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -200,6 +200,7 @@ static void ins_compl_fixRedoBufForLeader(char_u *ptr_arg);
 static void ins_compl_add_list(list_T *list);
 static void ins_compl_add_dict(dict_T *dict);
 # endif
+static dict_T *ins_compl_dict_alloc(compl_T *match);
 static int  ins_compl_key2dir(int c);
 static int  ins_compl_pum_key(int c);
 static int  ins_compl_key2count(int c);
@@ -1113,6 +1114,10 @@ ins_compl_show_pum(void)
 
     if (compl_match_array != NULL)
     {
+	static int  recursive = FALSE;
+	dict_T	    *v_event;
+	dict_T	    *item;
+
 	// In Replace mode when a $ is displayed at the end of the line only
 	// part of the screen would be updated.  We do need to redraw here.
 	dollar_vcol = -1;
@@ -1123,6 +1128,28 @@ ins_compl_show_pum(void)
 	curwin->w_cursor.col = compl_col;
 	pum_display(compl_match_array, compl_match_arraysize, cur);
 	curwin->w_cursor.col = col;
+
+	if (!has_menupopupchanged() || recursive)
+	    return;
+	v_event = get_vim_var_dict(VV_EVENT);
+	if (cur < 0)
+	    item = dict_alloc();
+	else
+	    item = ins_compl_dict_alloc(compl_curr_match);
+	if (item == NULL)
+	    return;
+	dict_add_dict(v_event, "completed_item", item);
+	pum_set_boundings(v_event);
+	dict_set_items_ro(v_event);
+
+ 	recursive = TRUE;
+	textlock++;
+	apply_autocmds(EVENT_MENUPOPUPCHANGED, NULL, NULL, FALSE, curbuf);
+	textlock--;
+	recursive = FALSE;
+
+ 	dict_free_contents(v_event);
+	hash_init(&v_event->dv_hashtab);
     }
 }
 
@@ -2882,23 +2909,30 @@ ins_compl_insert(int in_compl_func)
 	compl_used_match = FALSE;
     else
 	compl_used_match = TRUE;
-
-    // Set completed item.
-    // { word, abbr, menu, kind, info }
-    dict = dict_alloc_lock(VAR_FIXED);
-    if (dict != NULL)
-    {
-	dict_add_string(dict, "word", compl_shown_match->cp_str);
-	dict_add_string(dict, "abbr", compl_shown_match->cp_text[CPT_ABBR]);
-	dict_add_string(dict, "menu", compl_shown_match->cp_text[CPT_MENU]);
-	dict_add_string(dict, "kind", compl_shown_match->cp_text[CPT_KIND]);
-	dict_add_string(dict, "info", compl_shown_match->cp_text[CPT_INFO]);
-	dict_add_string(dict, "user_data",
-				 compl_shown_match->cp_text[CPT_USER_DATA]);
-    }
+    dict = ins_compl_dict_alloc(compl_shown_match);
     set_vim_var_dict(VV_COMPLETED_ITEM, dict);
     if (!in_compl_func)
 	compl_curr_match = compl_shown_match;
+}
+
+/*
+ * Allocate Dict for the completed item.
+ * { word, abbr, menu, kind, info }
+ */
+    static dict_T *
+ins_compl_dict_alloc(compl_T *match)
+{
+    dict_T *dict = dict_alloc_lock(VAR_FIXED);
+    if (dict != NULL)
+    {
+	dict_add_string(dict, "word", match->cp_str);
+	dict_add_string(dict, "abbr", match->cp_text[CPT_ABBR]);
+	dict_add_string(dict, "menu", match->cp_text[CPT_MENU]);
+	dict_add_string(dict, "kind", match->cp_text[CPT_KIND]);
+	dict_add_string(dict, "info", match->cp_text[CPT_INFO]);
+	dict_add_string(dict, "user_data", match->cp_text[CPT_USER_DATA]);
+    }
+    return dict;
 }
 
 /*

--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -923,6 +923,22 @@ pum_get_height(void)
     return pum_height;
 }
 
+/*
+ * Add size information about the pum to a dict
+ */
+void pum_set_boundings(dict_T *dict)
+{
+    if (!pum_visible())
+	return;
+    dict_add_number(dict, "height", pum_height);
+    dict_add_number(dict, "width", pum_width);
+    dict_add_number(dict, "row", pum_row);
+    dict_add_number(dict, "col", pum_col);
+    dict_add_number(dict, "size", pum_size);
+    dict_add_special(dict, "scrollbar",
+				    pum_scrollbar ? VVAL_TRUE : VVAL_FALSE);
+}
+
 # if defined(FEAT_BEVAL_TERM) || defined(FEAT_TERM_POPUP_MENU) || defined(PROTO)
     static void
 pum_position_at_mouse(int min_width)

--- a/src/proto/autocmd.pro
+++ b/src/proto/autocmd.pro
@@ -26,6 +26,7 @@ int has_insertcharpre(void);
 int has_cmdundefined(void);
 int has_funcundefined(void);
 int has_textyankpost(void);
+int has_menupopupchanged(void);
 void block_autocmds(void);
 void unblock_autocmds(void);
 int is_autocmd_blocked(void);

--- a/src/proto/dict.pro
+++ b/src/proto/dict.pro
@@ -14,6 +14,7 @@ void dictitem_free(dictitem_T *item);
 dict_T *dict_copy(dict_T *orig, int deep, int copyID);
 int dict_add(dict_T *d, dictitem_T *item);
 int dict_add_number(dict_T *d, char *key, varnumber_T nr);
+int dict_add_special(dict_T *d, char *key, varnumber_T nr);
 int dict_add_string(dict_T *d, char *key, char_u *str);
 int dict_add_string_len(dict_T *d, char *key, char_u *str, int len);
 int dict_add_list(dict_T *d, char *key, list_T *list);

--- a/src/proto/popupmnu.pro
+++ b/src/proto/popupmnu.pro
@@ -8,6 +8,7 @@ void pum_clear(void);
 int pum_visible(void);
 void pum_may_redraw(void);
 int pum_get_height(void);
+void pum_set_boundings(dict_T *dict);
 int split_message(char_u *mesg, pumitem_T **array);
 void ui_remove_balloon(void);
 void ui_post_balloon(char_u *mesg, list_T *list);

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -997,7 +997,7 @@ func Test_popup_complete_info_02()
   bwipe!
 endfunc
 
-func Test_MenuPopupChanged()
+func Test_CompleteChanged()
   new
   call setline(1, ['foo', 'bar', 'foobar', ''])
   set complete=. completeopt=noinsert,noselect,menuone
@@ -1008,7 +1008,7 @@ func Test_MenuPopupChanged()
   endfunction
   augroup AAAAA_Group
     au!
-    autocmd MenuPopupChanged * :call OnPumChange()
+    autocmd CompleteChanged * :call OnPumChange()
   augroup END
   call cursor(4, 1)
 

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -997,4 +997,38 @@ func Test_popup_complete_info_02()
   bwipe!
 endfunc
 
+func Test_MenuPopupChanged()
+  new
+  call setline(1, ['foo', 'bar', 'foobar', ''])
+  set complete=. completeopt=noinsert,noselect,menuone
+  function! OnPumChange()
+    let g:event = copy(v:event)
+    let g:item = get(v:event, 'completed_item', {})
+    let g:word = get(g:item, 'word', v:null)
+  endfunction
+  augroup AAAAA_Group
+    au!
+    autocmd MenuPopupChanged * :call OnPumChange()
+  augroup END
+  call cursor(4, 1)
+
+  call feedkeys("Sf\<C-N>", 'tx')
+  call assert_equal({'completed_item': {}, 'width': 15,
+        \ 'height': 2, 'size': 2,
+        \ 'col': 0, 'row': 4, 'scrollbar': v:false}, g:event)
+  call feedkeys("a\<C-N>\<C-N>\<C-E>", 'tx')
+  call assert_equal('foo', g:word)
+  call feedkeys("a\<C-N>\<C-N>\<C-N>\<C-E>", 'tx')
+  call assert_equal('foobar', g:word)
+  call feedkeys("a\<C-N>\<C-N>\<C-N>\<C-N>\<C-E>", 'tx')
+  call assert_equal(v:null, g:word)
+  call feedkeys("a\<C-N>\<C-N>\<C-N>\<C-N>\<C-P>", 'tx')
+  call assert_equal('foobar', g:word)
+
+  autocmd! AAAAA_Group
+  set complete& completeopt&
+  delfunc! OnPumchange
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim.h
+++ b/src/vim.h
@@ -1307,6 +1307,7 @@ enum auto_event
     EVENT_INSERTENTER,		// when entering Insert mode
     EVENT_INSERTLEAVE,		// when leaving Insert mode
     EVENT_MENUPOPUP,		// just before popup menu is displayed
+    EVENT_MENUPOPUPCHANGED,	// after popup menu changed
     EVENT_OPTIONSET,		// option was set
     EVENT_QUICKFIXCMDPOST,	// after :make, :grep etc.
     EVENT_QUICKFIXCMDPRE,	// before :make, :grep etc.

--- a/src/vim.h
+++ b/src/vim.h
@@ -1271,6 +1271,7 @@ enum auto_event
     EVENT_CMDWINLEAVE,		// before leaving the cmdline window
     EVENT_COLORSCHEME,		// after loading a colorscheme
     EVENT_COLORSCHEMEPRE,	// before loading a colorscheme
+    EVENT_COMPLETECHANGED,	// after completion popup menu changed
     EVENT_COMPLETEDONE,		// after finishing insert complete
     EVENT_CURSORHOLD,		// cursor in same position for a while
     EVENT_CURSORHOLDI,		// idem, in Insert mode
@@ -1307,7 +1308,6 @@ enum auto_event
     EVENT_INSERTENTER,		// when entering Insert mode
     EVENT_INSERTLEAVE,		// when leaving Insert mode
     EVENT_MENUPOPUP,		// just before popup menu is displayed
-    EVENT_MENUPOPUPCHANGED,	// after popup menu changed
     EVENT_OPTIONSET,		// option was set
     EVENT_QUICKFIXCMDPOST,	// after :make, :grep etc.
     EVENT_QUICKFIXCMDPRE,	// before :make, :grep etc.


### PR DESCRIPTION
This is a translation of https://github.com/neovim/neovim/pull/9616, which adds an autocmd for when the popup menu item changes during insert completion (and also when the pum is redrawn due to resizing).  This is useful e.g., for showing information about the selected item in the cmdline or making text edits during selection.  The original author is Qiming Zhao aka. @chemzqm.
