### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: ''
-assignees: ''
 
 ---
 
@@ -26,7 +25,7 @@ If applicable, add screenshots to help explain your problem.
 **Environment (please complete the following information):**
  - Version [e.g. 8.1.1234] (Or paste the result of `vim --version`.)
  - OS: [e.g. Ubuntu 18.04, Windows 10 1809, macOS 10.14]
- - Terminal: [e.g. GNOME Terminal, mintty, iTerm2, tmux, GNU screen] (If you use a CUI version.)
+ - Terminal: [e.g. GNOME Terminal, mintty, iTerm2, tmux, GNU screen] (Use NONE if you use the GUI.)
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+(Issues related to the runtime files should be reported to the each maintainer. Not here.)
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Run `vim --clean` (or `gvim --clean`, etc.)
+2. Type '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - Version [e.g. 8.1.1234] (Or paste the result of `vim --version`.)
+ - OS: [e.g. Ubuntu 18.04, Windows 10 1809, macOS 10.14]
+ - Terminal: [e.g. GNOME Terminal, mintty, iTerm2, tmux, GNU screen] (If you use a CUI version.)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+(If it is related to runtime files, please discuss with the maintainer.)
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: enhancement
-assignees: ''
 
 ---
 


### PR DESCRIPTION
This adds two simple issue templates for bug reports and feature request.
Both templates are based on the default templates by GitHub and slightly
modified for Vim.