### PR TITLE
Don't leak buffer in tests

### DIFF
--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -89,32 +89,37 @@ func _SetUpHiddenBuffer()
   call assert_equal( line( '.' ), 11 )
 endfunc
 
+func _CleanUpHiddenBuffer()
+  bwipe! hidden
+  bwipe!
+endfunc
+
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Clear()
   call _SetUpHiddenBuffer()
   py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = None
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_List()
   call _SetUpHiddenBuffer()
   py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = [ 'test' ]
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Str()
   call _SetUpHiddenBuffer()
   py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = 'test'
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_ClearLine()
   call _SetUpHiddenBuffer()
   py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = None
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func _SetUpVisibleBuffer()

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -89,32 +89,37 @@ func _SetUpHiddenBuffer()
   call assert_equal( line( '.' ), 11 )
 endfunc
 
+func _CleanUpHiddenBuffer()
+  bwipe! hidden
+  bwipe!
+endfunc
+
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Clear()
   call _SetUpHiddenBuffer()
   py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = None
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_List()
   call _SetUpHiddenBuffer()
   py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = [ 'test' ]
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Str()
   call _SetUpHiddenBuffer()
   py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = 'test'
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_ClearLine()
   call _SetUpHiddenBuffer()
   py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = None
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func _SetUpVisibleBuffer()


### PR DESCRIPTION
Addressing a comment on https://github.com/vim/vim/pull/4154 from the mailing list: Don't leak the "hidden" buffer.

Alternatively could use `%bwipe!` but this seemed tidier.

