### PR TITLE
Fix reg_executing() in the case using a command which waits user input

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4811,7 +4811,6 @@ f_getchar(typval_T *argvars, typval_T *rettv)
 {
     varnumber_T		n;
     int			error = FALSE;
-    int			save_reg_executing = reg_executing;
 
 #ifdef MESSAGE_QUEUE
     // vpeekc() used to check for messages, but that caused problems, invoking
@@ -4846,7 +4845,6 @@ f_getchar(typval_T *argvars, typval_T *rettv)
     }
     --no_mapping;
     --allow_keys;
-    reg_executing = save_reg_executing;
 
     set_vim_var_nr(VV_MOUSE_WIN, 0);
     set_vim_var_nr(VV_MOUSE_WINID, 0);

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1699,6 +1699,7 @@ do_one_cmd(
     exarg_T		ea;			/* Ex command arguments */
     int			save_msg_scroll = msg_scroll;
     cmdmod_T		save_cmdmod;
+    int			save_reg_executing = reg_executing;
     int			ni;			/* set when Not Implemented */
     char_u		*cmd;
 
@@ -2579,6 +2580,7 @@ doend:
 
     free_cmdmod();
     cmdmod = save_cmdmod;
+    reg_executing = save_reg_executing;
 
     if (ea.save_msg_silent != -1)
     {

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1150,20 +1150,38 @@ func Test_reg_executing_and_recording()
   " getchar() command saves and restores reg_executing
   map W :call TestFunc()<CR>
   let @q = "W"
+  let g:typed = ''
+  let g:regs = []
   func TestFunc() abort
-    let g:reg1 = reg_executing()
+    let g:regs += [reg_executing()]
     let g:typed = getchar(0)
-    let g:reg2 = reg_executing()
+    let g:regs += [reg_executing()]
   endfunc
   call feedkeys("@qy", 'xt')
   call assert_equal(char2nr("y"), g:typed)
-  call assert_equal('q', g:reg1)
-  call assert_equal('q', g:reg2)
+  call assert_equal(['q', 'q'], g:regs)
   delfunc TestFunc
   unmap W
   unlet g:typed
-  unlet g:reg1
-  unlet g:reg2
+  unlet g:regs
+
+  " input() command saves and restores reg_executing
+  map W :call TestFunc()<CR>
+  let @q = "W"
+  let g:typed = ''
+  let g:regs = []
+  func TestFunc() abort
+    let g:regs += [reg_executing()]
+    let g:typed = input('?')
+    let g:regs += [reg_executing()]
+  endfunc
+  call feedkeys("@qy\<CR>", 'xt')
+  call assert_equal("y", g:typed)
+  call assert_equal(['q', 'q'], g:regs)
+  delfunc TestFunc
+  unmap W
+  unlet g:typed
+  unlet g:regs
 
   bwipe!
   delfunc s:save_reg_stat


### PR DESCRIPTION
Ref #4066 

There is still a problematic case.

test.vim
```vim
function! TestFunc() abort
  echomsg "before: " . reg_executing()
  call input('?')
  echomsg "after: " . reg_executing()
endfunction
nnoremap W :<C-u>call TestFunc()<CR>
messages clear
let @q = "W"
normal! @q
```

```
$ vim --clean -S test.vim
```

and feed any key.

Expected:
```
before: q
after: q
```

Actual:
```
before: q
after:
```

I think better to save/restore "reg_executing" variable on "do_one_cmd()" than on each function (e.g. "f_getchar()").