### PR TITLE
Fix broken listchars handling for nbsp and space

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4809,33 +4809,28 @@ win_line(
 #endif
 
 		// 'list': change char 160 to lcs_nbsp and space to lcs_space.
-		if (wp->w_p_list)
-		{
-		    if ((c == 160
+		if (wp->w_p_list
+			&& (((c == 160
 			      || (mb_utf8 && (mb_c == 160 || mb_c == 0x202f)))
-			    && lcs_nbsp)
+				&& lcs_nbsp)
+			|| (c == ' ' && mb_l == 1 && lcs_space && ptr - line <= trailcol)))
+		{
+		    c = (c == ' ') ? lcs_space : lcs_nbsp;
+		    if (area_attr == 0 && search_attr == 0)
 		    {
-			c = lcs_nbsp;
-			mb_c = c;
-			if (enc_utf8 && utf_char2len(c) > 1)
-			{
-			    mb_utf8 = TRUE;
-			    u8cc[0] = 0;
-			    c = 0xc0;
-			}
-			else
-			    mb_utf8 = FALSE;
+			n_attr = 1;
+			extra_attr = HL_ATTR(HLF_8);
+			saved_attr2 = char_attr; /* save current attr */
 		    }
-		    else if (c == ' ' && lcs_space && ptr - line <= trailcol)
+		    mb_c = c;
+		    if (enc_utf8 && utf_char2len(c) > 1)
 		    {
-			c = lcs_space;
-			if (mb_utf8 == FALSE && area_attr == 0 && search_attr == 0)
-			{
-			    n_attr = 1;
-			    extra_attr = HL_ATTR(HLF_8);
-			    saved_attr2 = char_attr; // save current attr
-			}
+			mb_utf8 = TRUE;
+			u8cc[0] = 0;
+			c = 0xc0;
 		    }
+		    else
+			mb_utf8 = FALSE;
 		}
 
 		if (trailcol != MAXCOL && ptr > line + trailcol && c == ' ')

--- a/src/screen.c
+++ b/src/screen.c
@@ -4809,11 +4809,13 @@ win_line(
 #endif
 
 		// 'list': change char 160 to lcs_nbsp and space to lcs_space.
+		// Only do so when the characters are not affected by following
+		// composing characters (use mb_l to check that)
 		if (wp->w_p_list
-			&& (((c == 160
-			      || (mb_utf8 && (mb_c == 160 || mb_c == 0x202f)))
-				&& lcs_nbsp)
-			|| (c == ' ' && mb_l == 1 && lcs_space && ptr - line <= trailcol)))
+			&& ((((c == 160 && mb_l == 1)
+			      || (mb_utf8 && ((mb_c == 160 && mb_l == 2) || (mb_c == 0x202f && mb_l == 3))))
+			     && lcs_nbsp)
+			    || (c == ' ' && mb_l == 1 && lcs_space && ptr - line <= trailcol)))
 		{
 		    c = (c == ' ') ? lcs_space : lcs_nbsp;
 		    if (area_attr == 0 && search_attr == 0)

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -114,6 +114,33 @@ func Test_listchars()
   set listchars& ff&
 endfunc
 
+" Test that unicode listchars characters get properly inserted
+func Test_listchars_unicode()
+  enew!
+  let oldencoding=&encoding
+  set encoding=utf-8
+  set ff=unix
+
+  set listchars=eol:⇔,space:␣,nbsp:≠,tab:←↔→
+  set list
+
+  let nbsp = nr2char(0xa0)
+  call append(0, [
+        \ "a\tb c".nbsp."d"
+        \ ])
+  let expected = [
+        \ 'a←↔↔↔↔↔→b␣c≠d⇔'
+        \ ]
+  redraw!
+  call cursor(1, 1)
+  call assert_equal(expected, ScreenLines(1, virtcol('$')))
+  let &encoding=oldencoding
+  enew!
+  set listchars& ff&
+endfunction
+
+" Tests that characters with a leading 0x20 composing character won't get
+" treated as a space.
 func Test_listchars_composing()
   enew!
   let oldencoding=&encoding
@@ -130,9 +157,8 @@ func Test_listchars_composing()
         \ ]
   redraw!
   call cursor(1, 1)
-  let got = ScreenLines(1, virtcol('$'))
-  bw!
-  call assert_equal(expected, got)
+  call assert_equal(expected, ScreenLines(1, virtcol('$')))
   let &encoding=oldencoding
+  enew!
   set listchars& ff&
 endfunction

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -139,8 +139,8 @@ func Test_listchars_unicode()
   set listchars& ff&
 endfunction
 
-" Tests that characters with a leading 0x20 composing character won't get
-" treated as a space.
+" Tests that space characters following composing character won't get replaced
+" by listchars.
 func Test_listchars_composing()
   enew!
   let oldencoding=&encoding
@@ -148,12 +148,15 @@ func Test_listchars_composing()
   set ff=unix
   set list
 
-  set listchars=eol:$,space:_
+  set listchars=eol:$,space:_,nbsp:=
+  
+  let nbsp1 = nr2char(0xa0)
+  let nbsp2 = nr2char(0x202f)
   call append(0, [
-        \ "  \u3099	 \u309A"
+        \ "  \u3099\t \u309A".nbsp1.nbsp1."\u0302".nbsp2.nbsp2."\u0302",
         \ ])
   let expected = [
-        \ "_ \u3099^I \u309A$"
+        \ "_ \u3099^I \u309A=".nbsp1."\u0302=".nbsp2."\u0302$"
         \ ]
   redraw!
   call cursor(1, 1)


### PR DESCRIPTION
Previously, `listchars` didn't properly handle characters like ' ゙' which has a composing character 0x20 which is the same as space. As a result the character would have turned into the listchar for space when `listchars` was set.

PR #4046 attempted to fix this issue but it didn't address the fact that the composing char wasn't correctly handled. As side effect, nbsp (non-breaking whitespace) listchar no longer gets syntax highlighting, and unicode characters no longer worked for space listchars, e.g. '→'.

Fix the issue by reverting back to the original listchars handling code, but check for whether the space character (0x20) that we are handling is a composing char or an actual space.