### PR TITLE
Simplify os_w32exe.c

### DIFF
--- a/src/os_w32exe.c
+++ b/src/os_w32exe.c
@@ -20,54 +20,26 @@
 # endif
 #endif
 
-/* cproto doesn't create a prototype for main() */
-int _cdecl
-#if defined(FEAT_GUI_MSWIN)
-VimMain
-#else
-    main
-#endif
-	(int argc, char **argv);
-static int (_cdecl *pmain)(int, char **);
-
-#ifndef PROTO
+int _cdecl VimMain(int argc, char **argv);
 #ifdef FEAT_GUI
 void _cdecl SaveInst(HINSTANCE hInst);
-static void (_cdecl *pSaveInst)(HINSTANCE);
 #endif
 
+#ifndef PROTO
     int WINAPI
 WinMain(
-    HINSTANCE	hInstance UNUSED,
+    HINSTANCE	hInstance,
     HINSTANCE	hPrevInst UNUSED,
     LPSTR	lpszCmdLine UNUSED,
     int		nCmdShow UNUSED)
 {
     int		argc = 0;
     char	**argv = NULL;
-#ifdef FEAT_GUI
-    pSaveInst = SaveInst;
-#endif
-    pmain =
-#if defined(FEAT_GUI_MSWIN)
-    //&& defined(__MINGW32__)
-	VimMain
-#else
-	main
-#endif
-	;
-#ifdef FEAT_GUI
-    pSaveInst(
-#ifdef __MINGW32__
-	    GetModuleHandle(NULL)
-#else
-	    hInstance
-#endif
-	    );
-#endif
-    pmain(argc, argv);
 
-    free_cmd_argsW();
+# ifdef FEAT_GUI
+    SaveInst(hInstance);
+# endif
+    VimMain(argc, argv);
 
     return 0;
 }


### PR DESCRIPTION
It can be simplified after the removal of `VIMDLL`.