### PR TITLE
Stop using ANSI APIs

### DIFF
--- a/src/glbl_ime.cpp
+++ b/src/glbl_ime.cpp
@@ -133,14 +133,7 @@ global_ime_DefWindowProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 
     if (pIApp == NULL || pIApp->OnDefWindowProc(hWnd, Msg,
 					    wParam, lParam, &lResult) != S_OK)
-    {
-#if defined(MSWIN)
-	if (wide_WindowProc)
-	    lResult = DefWindowProcW(hWnd, Msg, wParam, lParam);
-	else
-#endif
-	    lResult = DefWindowProc(hWnd, Msg, wParam, lParam);
-    }
+	lResult = DefWindowProcW(hWnd, Msg, wParam, lParam);
     return lResult;
 }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -822,10 +822,6 @@ EXTERN int	enc_latin9 INIT(= FALSE);	/* 'encoding' is latin9 */
 #endif
 EXTERN int	has_mbyte INIT(= 0);		/* any multi-byte encoding */
 
-#if defined(MSWIN)
-EXTERN int	wide_WindowProc INIT(= FALSE);	/* use wide WindowProc() */
-#endif
-
 /*
  * To speed up BYTELEN() we fill a table with the byte lengths whenever
  * enc_utf8 or enc_dbcs changes.

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -1152,10 +1152,7 @@ _OnFindRepl(void)
     int	    flags = 0;
     int	    down;
 
-    /* If the OS is Windows NT, and 'encoding' differs from active codepage:
-     * convert text from wide string. */
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	findrep_wtoa(&s_findrep_struct, &s_findrep_struct_w);
+    findrep_wtoa(&s_findrep_struct, &s_findrep_struct_w);
 
     if (s_findrep_struct.Flags & FR_DIALOGTERM)
 	/* Give main window the focus back. */
@@ -2332,21 +2329,15 @@ GetTextWidthEnc(HDC hdc, char_u *str, int len)
     int		n;
     int		wlen = len;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	/* 'encoding' differs from active codepage: convert text and use wide
-	 * function */
-	wstr = enc_to_utf16(str, &wlen);
-	if (wstr != NULL)
-	{
-	    n = GetTextExtentPointW(hdc, wstr, wlen, &size);
-	    vim_free(wstr);
-	    if (n)
-		return size.cx;
-	}
-    }
+    wstr = enc_to_utf16(str, &wlen);
+    if (wstr == NULL)
+	return 0;
 
-    return GetTextWidth(hdc, str, len);
+    n = GetTextExtentPointW(hdc, wstr, wlen, &size);
+    vim_free(wstr);
+    if (n)
+	return size.cx;
+    return 0;
 }
 
 static void get_work_area(RECT *spi_rect);
@@ -2426,9 +2417,9 @@ gui_mch_show_toolbar(int showit)
     /* For older compilers.  We assume this never changes. */
 #  define TB_SETUNICODEFORMAT 0x2005
 # endif
-	/* Enable/disable unicode support */
-	int uu = (enc_codepage >= 0 && (int)GetACP() != enc_codepage);
-	SendMessage(s_toolbarhwnd, TB_SETUNICODEFORMAT, (WPARAM)uu, (LPARAM)0);
+	/* Enable unicode support */
+	SendMessage(s_toolbarhwnd, TB_SETUNICODEFORMAT, (WPARAM)TRUE,
+								(LPARAM)0);
 	ShowWindow(s_toolbarhwnd, SW_SHOW);
     }
     else
@@ -2444,40 +2435,21 @@ gui_mch_show_toolbar(int showit)
     static void
 add_tabline_popup_menu_entry(HMENU pmenu, UINT item_id, char_u *item_text)
 {
-    WCHAR	*wn = NULL;
+    WCHAR	    *wn;
+    MENUITEMINFOW   infow;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	/* 'encoding' differs from active codepage: convert menu name
-	 * and use wide function */
-	wn = enc_to_utf16(item_text, NULL);
-	if (wn != NULL)
-	{
-	    MENUITEMINFOW	infow;
-
-	    infow.cbSize = sizeof(infow);
-	    infow.fMask = MIIM_TYPE | MIIM_ID;
-	    infow.wID = item_id;
-	    infow.fType = MFT_STRING;
-	    infow.dwTypeData = wn;
-	    infow.cch = (UINT)wcslen(wn);
-	    InsertMenuItemW(pmenu, item_id, FALSE, &infow);
-	    vim_free(wn);
-	}
-    }
-
+    wn = enc_to_utf16(item_text, NULL);
     if (wn == NULL)
-    {
-	MENUITEMINFO	info;
+	return;
 
-	info.cbSize = sizeof(info);
-	info.fMask = MIIM_TYPE | MIIM_ID;
-	info.wID = item_id;
-	info.fType = MFT_STRING;
-	info.dwTypeData = (LPTSTR)item_text;
-	info.cch = (UINT)STRLEN(item_text);
-	InsertMenuItem(pmenu, item_id, FALSE, &info);
-    }
+    infow.cbSize = sizeof(infow);
+    infow.fMask = MIIM_TYPE | MIIM_ID;
+    infow.wID = item_id;
+    infow.fType = MFT_STRING;
+    infow.dwTypeData = wn;
+    infow.cch = (UINT)wcslen(wn);
+    InsertMenuItemW(pmenu, item_id, FALSE, &infow);
+    vim_free(wn);
 }
 
     static void
@@ -2573,8 +2545,6 @@ gui_mch_update_tabline(void)
     int		nr = 0;
     int		curtabidx = 0;
     int		tabadded = 0;
-    static int	use_unicode = FALSE;
-    int		uu;
     WCHAR	*wstr = NULL;
 
     if (s_tabhwnd == NULL)
@@ -2584,13 +2554,8 @@ gui_mch_update_tabline(void)
     /* For older compilers.  We assume this never changes. */
 # define CCM_SETUNICODEFORMAT 0x2005
 #endif
-    uu = (enc_codepage >= 0 && (int)GetACP() != enc_codepage);
-    if (uu != use_unicode)
-    {
-	/* Enable/disable unicode support */
-	SendMessage(s_tabhwnd, CCM_SETUNICODEFORMAT, (WPARAM)uu, (LPARAM)0);
-	use_unicode = uu;
-    }
+    /* Enable unicode support */
+    SendMessage(s_tabhwnd, CCM_SETUNICODEFORMAT, (WPARAM)TRUE, (LPARAM)0);
 
     tie.mask = TCIF_TEXT;
     tie.iImage = -1;
@@ -2614,24 +2579,18 @@ gui_mch_update_tabline(void)
 
 	get_tabline_label(tp, FALSE);
 	tie.pszText = (LPSTR)NameBuff;
-	wstr = NULL;
-	if (use_unicode)
-	{
-	    /* Need to go through Unicode. */
-	    wstr = enc_to_utf16(NameBuff, NULL);
-	    if (wstr != NULL)
-	    {
-		TCITEMW		tiw;
 
-		tiw.mask = TCIF_TEXT;
-		tiw.iImage = -1;
-		tiw.pszText = wstr;
-		SendMessage(s_tabhwnd, TCM_SETITEMW, (WPARAM)nr, (LPARAM)&tiw);
-		vim_free(wstr);
-	    }
+	wstr = enc_to_utf16(NameBuff, NULL);
+	if (wstr != NULL)
+	{
+	    TCITEMW		tiw;
+
+	    tiw.mask = TCIF_TEXT;
+	    tiw.iImage = -1;
+	    tiw.pszText = wstr;
+	    SendMessage(s_tabhwnd, TCM_SETITEMW, (WPARAM)nr, (LPARAM)&tiw);
+	    vim_free(wstr);
 	}
-	if (wstr == NULL)
-	    TabCtrl_SetItem(s_tabhwnd, nr, &tie);
     }
 
     /* Remove any old labels. */
@@ -2729,7 +2688,7 @@ initialise_findrep(char_u *initial_string)
     static void
 set_window_title(HWND hwnd, char *title)
 {
-    if (title != NULL && enc_codepage >= 0 && enc_codepage != (int)GetACP())
+    if (title != NULL)
     {
 	WCHAR	*wbuf;
 
@@ -2740,9 +2699,9 @@ set_window_title(HWND hwnd, char *title)
 	    SetWindowTextW(hwnd, wbuf);
 	    vim_free(wbuf);
 	}
-	return;
     }
-    (void)SetWindowText(hwnd, (LPCSTR)title);
+    else
+	(void)SetWindowTextW(hwnd, NULL);
 }
 
     void
@@ -2757,16 +2716,8 @@ gui_mch_find_dialog(exarg_T *eap)
 	if (!IsWindow(s_findrep_hwnd))
 	{
 	    initialise_findrep(eap->arg);
-	    /* If the OS is Windows NT, and 'encoding' differs from active
-	     * codepage: convert text and use wide function. */
-	    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	    {
-		findrep_atow(&s_findrep_struct_w, &s_findrep_struct);
-		s_findrep_hwnd = FindTextW(
-					(LPFINDREPLACEW) &s_findrep_struct_w);
-	    }
-	    else
-		s_findrep_hwnd = FindText((LPFINDREPLACE) &s_findrep_struct);
+	    findrep_atow(&s_findrep_struct_w, &s_findrep_struct);
+	    s_findrep_hwnd = FindTextW((LPFINDREPLACEW) &s_findrep_struct_w);
 	}
 
 	set_window_title(s_findrep_hwnd, _("Find string"));
@@ -2790,15 +2741,9 @@ gui_mch_replace_dialog(exarg_T *eap)
 	if (!IsWindow(s_findrep_hwnd))
 	{
 	    initialise_findrep(eap->arg);
-	    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	    {
-		findrep_atow(&s_findrep_struct_w, &s_findrep_struct);
-		s_findrep_hwnd = ReplaceTextW(
+	    findrep_atow(&s_findrep_struct_w, &s_findrep_struct);
+	    s_findrep_hwnd = ReplaceTextW(
 					(LPFINDREPLACEW) &s_findrep_struct_w);
-	    }
-	    else
-		s_findrep_hwnd = ReplaceText(
-					   (LPFINDREPLACE) &s_findrep_struct);
 	}
 
 	set_window_title(s_findrep_hwnd, _("Find & Replace"));
@@ -6344,49 +6289,26 @@ gui_mch_add_menu(
 
     if (menu_is_menubar(menu->name))
     {
-	WCHAR	*wn = NULL;
+	WCHAR	*wn;
+	MENUITEMINFOW	infow;
 
-	if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	{
-	    /* 'encoding' differs from active codepage: convert menu name
-	     * and use wide function */
-	    wn = enc_to_utf16(menu->name, NULL);
-	    if (wn != NULL)
-	    {
-		MENUITEMINFOW	infow;
-
-		infow.cbSize = sizeof(infow);
-		infow.fMask = MIIM_DATA | MIIM_TYPE | MIIM_ID
-		    | MIIM_SUBMENU;
-		infow.dwItemData = (long_u)menu;
-		infow.wID = menu->id;
-		infow.fType = MFT_STRING;
-		infow.dwTypeData = wn;
-		infow.cch = (UINT)wcslen(wn);
-		infow.hSubMenu = menu->submenu_id;
-		InsertMenuItemW((parent == NULL)
-			? s_menuBar : parent->submenu_id,
-			(UINT)pos, TRUE, &infow);
-		vim_free(wn);
-	    }
-	}
-
+	wn = enc_to_utf16(menu->name, NULL);
 	if (wn == NULL)
-	{
-	    MENUITEMINFO	info;
+	    return;
 
-	    info.cbSize = sizeof(info);
-	    info.fMask = MIIM_DATA | MIIM_TYPE | MIIM_ID | MIIM_SUBMENU;
-	    info.dwItemData = (long_u)menu;
-	    info.wID = menu->id;
-	    info.fType = MFT_STRING;
-	    info.dwTypeData = (LPTSTR)menu->name;
-	    info.cch = (UINT)STRLEN(menu->name);
-	    info.hSubMenu = menu->submenu_id;
-	    InsertMenuItem((parent == NULL)
-		    ? s_menuBar : parent->submenu_id,
-		    (UINT)pos, TRUE, &info);
-	}
+	infow.cbSize = sizeof(infow);
+	infow.fMask = MIIM_DATA | MIIM_TYPE | MIIM_ID
+	    | MIIM_SUBMENU;
+	infow.dwItemData = (long_u)menu;
+	infow.wID = menu->id;
+	infow.fType = MFT_STRING;
+	infow.dwTypeData = wn;
+	infow.cch = (UINT)wcslen(wn);
+	infow.hSubMenu = menu->submenu_id;
+	InsertMenuItemW((parent == NULL)
+		? s_menuBar : parent->submenu_id,
+		(UINT)pos, TRUE, &infow);
+	vim_free(wn);
     }
 
     /* Fix window size if menu may have wrapped */
@@ -6499,27 +6421,17 @@ gui_mch_add_menu_item(
     else
 #endif
     {
-	WCHAR	*wn = NULL;
+	WCHAR	*wn;
 
-	if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
+	wn = enc_to_utf16(menu->name, NULL);
+	if (wn != NULL)
 	{
-	    /* 'encoding' differs from active codepage: convert menu item name
-	     * and use wide function */
-	    wn = enc_to_utf16(menu->name, NULL);
-	    if (wn != NULL)
-	    {
-		InsertMenuW(parent->submenu_id, (UINT)idx,
-			(menu_is_separator(menu->name)
-				 ? MF_SEPARATOR : MF_STRING) | MF_BYPOSITION,
-			(UINT)menu->id, wn);
-		vim_free(wn);
-	    }
+	    InsertMenuW(parent->submenu_id, (UINT)idx,
+		    (menu_is_separator(menu->name)
+		     ? MF_SEPARATOR : MF_STRING) | MF_BYPOSITION,
+		    (UINT)menu->id, wn);
+	    vim_free(wn);
 	}
-	if (wn == NULL)
-	    InsertMenu(parent->submenu_id, (UINT)idx,
-		(menu_is_separator(menu->name) ? MF_SEPARATOR : MF_STRING)
-							      | MF_BYPOSITION,
-		(UINT)menu->id, (LPCTSTR)menu->name);
 #ifdef FEAT_TEAROFF
 	if (IsWindow(parent->tearoff_handle))
 	    rebuild_tearoff(parent);
@@ -6709,22 +6621,14 @@ dialog_callback(
 	/* If the edit box exists, copy the string. */
 	if (s_textfield != NULL)
 	{
-	    /* If the OS is Windows NT, and 'encoding' differs from active
-	     * codepage: use wide function and convert text. */
-	    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	    {
-	       WCHAR  *wp = (WCHAR *)alloc(IOSIZE * sizeof(WCHAR));
-	       char_u *p;
+	    WCHAR  *wp = (WCHAR *)alloc(IOSIZE * sizeof(WCHAR));
+	    char_u *p;
 
-	       GetDlgItemTextW(hwnd, DLG_NONBUTTON_CONTROL + 2, wp, IOSIZE);
-	       p = utf16_to_enc(wp, NULL);
-	       vim_strncpy(s_textfield, p, IOSIZE);
-	       vim_free(p);
-	       vim_free(wp);
-	    }
-	    else
-		GetDlgItemText(hwnd, DLG_NONBUTTON_CONTROL + 2,
-						(LPSTR)s_textfield, IOSIZE);
+	    GetDlgItemTextW(hwnd, DLG_NONBUTTON_CONTROL + 2, wp, IOSIZE);
+	    p = utf16_to_enc(wp, NULL);
+	    vim_strncpy(s_textfield, p, IOSIZE);
+	    vim_free(p);
+	    vim_free(wp);
 	}
 
 	/*
@@ -8411,7 +8315,7 @@ multiline_balloon_available(void)
 }
 
     static void
-make_tooltipw(BalloonEval *beval, char *text, POINT pt)
+make_tooltip(BalloonEval *beval, char *text, POINT pt)
 {
     TOOLINFOW	*pti;
     int		ToolInfoSize;
@@ -8470,77 +8374,6 @@ make_tooltipw(BalloonEval *beval, char *text, POINT pt)
     // I've performed some tests and it seems the longest possible life time
     // of tooltip is 30 seconds.
     SendMessageW(beval->balloon, TTM_SETDELAYTIME, TTDT_AUTOPOP, 30000);
-    /*
-     * HACK: force tooltip to appear, because it'll not appear until
-     * first mouse move. D*mn M$
-     * Amazingly moving (2, 2) and then (-1, -1) the mouse doesn't move.
-     */
-    mouse_event(MOUSEEVENTF_MOVE, 2, 2, 0, 0);
-    mouse_event(MOUSEEVENTF_MOVE, (DWORD)-1, (DWORD)-1, 0, 0);
-    vim_free(pti);
-}
-
-    static void
-make_tooltip(BalloonEval *beval, char *text, POINT pt)
-{
-    TOOLINFO	*pti;
-    int		ToolInfoSize;
-
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	make_tooltipw(beval, text, pt);
-	return;
-    }
-
-    if (multiline_balloon_available() == TRUE)
-	ToolInfoSize = sizeof(TOOLINFO_NEW);
-    else
-	ToolInfoSize = sizeof(TOOLINFO);
-
-    pti = (TOOLINFO *)alloc(ToolInfoSize);
-    if (pti == NULL)
-	return;
-
-    beval->balloon = CreateWindowEx(WS_EX_TOPMOST, TOOLTIPS_CLASS,
-	    NULL, WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP,
-	    CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-	    beval->target, NULL, s_hinst, NULL);
-
-    SetWindowPos(beval->balloon, HWND_TOPMOST, 0, 0, 0, 0,
-	    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
-
-    pti->cbSize = ToolInfoSize;
-    pti->uFlags = TTF_SUBCLASS;
-    pti->hwnd = beval->target;
-    pti->hinst = 0; /* Don't use string resources */
-    pti->uId = ID_BEVAL_TOOLTIP;
-
-    if (multiline_balloon_available() == TRUE)
-    {
-	RECT rect;
-	TOOLINFO_NEW *ptin = (TOOLINFO_NEW *)pti;
-	pti->lpszText = LPSTR_TEXTCALLBACK;
-	beval->tofree = vim_strsave((char_u*)text);
-	ptin->lParam = (LPARAM)beval->tofree;
-	if (GetClientRect(s_textArea, &rect)) /* switch multiline tooltips on */
-	    SendMessage(beval->balloon, TTM_SETMAXTIPWIDTH, 0,
-		    (LPARAM)rect.right);
-    }
-    else
-	pti->lpszText = text; /* do this old way */
-
-    /* Limit ballooneval bounding rect to CursorPos neighbourhood */
-    pti->rect.left = pt.x - 3;
-    pti->rect.top = pt.y - 3;
-    pti->rect.right = pt.x + 3;
-    pti->rect.bottom = pt.y + 3;
-
-    SendMessage(beval->balloon, TTM_ADDTOOL, 0, (LPARAM)pti);
-    /* Make tooltip appear sooner */
-    SendMessage(beval->balloon, TTM_SETDELAYTIME, TTDT_INITIAL, 10);
-    /* I've performed some tests and it seems the longest possible life time
-     * of tooltip is 30 seconds */
-    SendMessage(beval->balloon, TTM_SETDELAYTIME, TTDT_AUTOPOP, 30000);
     /*
      * HACK: force tooltip to appear, because it'll not appear until
      * first mouse move. D*mn M$

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -5784,12 +5784,7 @@ dos_expandpath(
     STRCPY(s, "*.*");
     wn = enc_to_utf16(buf, NULL);
     if (wn != NULL)
-    {
 	hFind = FindFirstFileW(wn, &wfb);
-	if (hFind == INVALID_HANDLE_VALUE
-			  && GetLastError() == ERROR_CALL_NOT_IMPLEMENTED)
-	    VIM_CLEAR(wn);
-    }
     ok = (hFind != INVALID_HANDLE_VALUE);
 
     while (ok)

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -586,7 +586,6 @@ static char *null_libintl_ngettext(const char *, const char *, unsigned long n);
 static char *null_libintl_textdomain(const char *);
 static char *null_libintl_bindtextdomain(const char *, const char *);
 static char *null_libintl_bind_textdomain_codeset(const char *, const char *);
-static int null_libintl_putenv(const char *);
 static int null_libintl_wputenv(const wchar_t *);
 
 static HINSTANCE hLibintlDLL = NULL;
@@ -598,7 +597,6 @@ char *(*dyn_libintl_bindtextdomain)(const char *, const char *)
 						= null_libintl_bindtextdomain;
 char *(*dyn_libintl_bind_textdomain_codeset)(const char *, const char *)
 				       = null_libintl_bind_textdomain_codeset;
-int (*dyn_libintl_putenv)(const char *) = null_libintl_putenv;
 int (*dyn_libintl_wputenv)(const wchar_t *) = null_libintl_wputenv;
 
     int
@@ -666,15 +664,10 @@ dyn_libintl_init(void)
 	dyn_libintl_bind_textdomain_codeset =
 					 null_libintl_bind_textdomain_codeset;
 
-    /* _putenv() function for the libintl.dll is optional. */
+    /* _wputenv() function for the libintl.dll is optional. */
     hmsvcrt = find_imported_module_by_funcname(hLibintlDLL, "getenv");
     if (hmsvcrt != NULL)
-    {
-	dyn_libintl_putenv = (void *)GetProcAddress(hmsvcrt, "_putenv");
 	dyn_libintl_wputenv = (void *)GetProcAddress(hmsvcrt, "_wputenv");
-    }
-    if (dyn_libintl_putenv == NULL || dyn_libintl_putenv == _putenv)
-	dyn_libintl_putenv = null_libintl_putenv;
     if (dyn_libintl_wputenv == NULL || dyn_libintl_wputenv == _wputenv)
 	dyn_libintl_wputenv = null_libintl_wputenv;
 
@@ -692,7 +685,6 @@ dyn_libintl_end(void)
     dyn_libintl_textdomain	= null_libintl_textdomain;
     dyn_libintl_bindtextdomain	= null_libintl_bindtextdomain;
     dyn_libintl_bind_textdomain_codeset = null_libintl_bind_textdomain_codeset;
-    dyn_libintl_putenv		= null_libintl_putenv;
     dyn_libintl_wputenv		= null_libintl_wputenv;
 }
 
@@ -731,12 +723,6 @@ null_libintl_bind_textdomain_codeset(
 null_libintl_textdomain(const char *domainname UNUSED)
 {
     return NULL;
-}
-
-    static int
-null_libintl_putenv(const char *envstring UNUSED)
-{
-    return 0;
 }
 
     static int

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2027,9 +2027,10 @@ theend:
     static int
 executable_exists(char *name, char_u **path, int use_path)
 {
-    char	*dum;
-    char	fname[_MAX_PATH];
-    char	*curpath, *newpath;
+    WCHAR	*p;
+    WCHAR	fnamew[_MAX_PATH];
+    WCHAR	*dumw;
+    WCHAR	*wcurpath, *wnewpath;
     long	n;
 
     if (!use_path)
@@ -2048,49 +2049,26 @@ executable_exists(char *name, char_u **path, int use_path)
 	return FALSE;
     }
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	WCHAR	*p = enc_to_utf16((char_u *)name, NULL);
-	WCHAR	fnamew[_MAX_PATH];
-	WCHAR	*dumw;
-	WCHAR	*wcurpath, *wnewpath;
-
-	if (p != NULL)
-	{
-	    wcurpath = _wgetenv(L"PATH");
-	    wnewpath = (WCHAR*)alloc((unsigned)(wcslen(wcurpath) + 3)
-							    * sizeof(WCHAR));
-	    if (wnewpath == NULL)
-		return FALSE;
-	    wcscpy(wnewpath, L".;");
-	    wcscat(wnewpath, wcurpath);
-	    n = (long)SearchPathW(wnewpath, p, NULL, _MAX_PATH, fnamew, &dumw);
-	    vim_free(wnewpath);
-	    vim_free(p);
-	    if (n == 0)
-		return FALSE;
-	    if (GetFileAttributesW(fnamew) & FILE_ATTRIBUTE_DIRECTORY)
-		return FALSE;
-	    if (path != NULL)
-		*path = utf16_to_enc(fnamew, NULL);
-	    return TRUE;
-	}
-    }
-
-    curpath = getenv("PATH");
-    newpath = (char*)alloc((unsigned)(STRLEN(curpath) + 3));
-    if (newpath == NULL)
+    p = enc_to_utf16((char_u *)name, NULL);
+    if (p == NULL)
 	return FALSE;
-    STRCPY(newpath, ".;");
-    STRCAT(newpath, curpath);
-    n = (long)SearchPath(newpath, name, NULL, _MAX_PATH, fname, &dum);
-    vim_free(newpath);
+
+    wcurpath = _wgetenv(L"PATH");
+    wnewpath = (WCHAR*)alloc((unsigned)(wcslen(wcurpath) + 3)
+	    * sizeof(WCHAR));
+    if (wnewpath == NULL)
+	return FALSE;
+    wcscpy(wnewpath, L".;");
+    wcscat(wnewpath, wcurpath);
+    n = (long)SearchPathW(wnewpath, p, NULL, _MAX_PATH, fnamew, &dumw);
+    vim_free(wnewpath);
+    vim_free(p);
     if (n == 0)
 	return FALSE;
-    if (mch_isdir((char_u *)fname))
+    if (GetFileAttributesW(fnamew) & FILE_ATTRIBUTE_DIRECTORY)
 	return FALSE;
     if (path != NULL)
-	*path = vim_strsave((char_u *)fname);
+	*path = utf16_to_enc(fnamew, NULL);
     return TRUE;
 }
 
@@ -2812,30 +2790,19 @@ mch_get_user_name(
     char_u  *s,
     int	    len)
 {
-    char szUserName[256 + 1];	/* UNLEN is 256 */
-    DWORD cch = sizeof szUserName;
+    WCHAR wszUserName[256 + 1];	/* UNLEN is 256 */
+    DWORD wcch = sizeof(wszUserName) / sizeof(WCHAR);
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
+    if (GetUserNameW(wszUserName, &wcch))
     {
-	WCHAR wszUserName[256 + 1];	/* UNLEN is 256 */
-	DWORD wcch = sizeof(wszUserName) / sizeof(WCHAR);
+	char_u  *p = utf16_to_enc(wszUserName, NULL);
 
-	if (GetUserNameW(wszUserName, &wcch))
+	if (p != NULL)
 	{
-	    char_u  *p = utf16_to_enc(wszUserName, NULL);
-
-	    if (p != NULL)
-	    {
-		vim_strncpy(s, p, len - 1);
-		vim_free(p);
-		return OK;
-	    }
+	    vim_strncpy(s, p, len - 1);
+	    vim_free(p);
+	    return OK;
 	}
-    }
-    if (GetUserName(szUserName, &cch))
-    {
-	vim_strncpy(s, (char_u *)szUserName, len - 1);
-	return OK;
     }
     s[0] = NUL;
     return FAIL;
@@ -2850,27 +2817,20 @@ mch_get_host_name(
     char_u	*s,
     int		len)
 {
-    DWORD cch = len;
+    WCHAR wszHostName[256 + 1];
+    DWORD wcch = sizeof(wszHostName) / sizeof(WCHAR);
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
+    if (GetComputerNameW(wszHostName, &wcch))
     {
-	WCHAR wszHostName[256 + 1];
-	DWORD wcch = sizeof(wszHostName) / sizeof(WCHAR);
+	char_u  *p = utf16_to_enc(wszHostName, NULL);
 
-	if (GetComputerNameW(wszHostName, &wcch))
+	if (p != NULL)
 	{
-	    char_u  *p = utf16_to_enc(wszHostName, NULL);
-
-	    if (p != NULL)
-	    {
-		vim_strncpy(s, p, len - 1);
-		vim_free(p);
-		return;
-	    }
+	    vim_strncpy(s, p, len - 1);
+	    vim_free(p);
+	    return;
 	}
     }
-    if (!GetComputerName((LPSTR)s, &cch))
-	vim_strncpy(s, (char_u *)"PC (Win32 Vim)", len - 1);
 }
 
 
@@ -2893,8 +2853,7 @@ mch_dirname(
     char_u	*buf,
     int		len)
 {
-    char_u  abuf[_MAX_PATH + 1];
-    DWORD   lfnlen;
+    WCHAR   wbuf[_MAX_PATH + 1];
 
     /*
      * Originally this was:
@@ -2902,47 +2861,32 @@ mch_dirname(
      * But the Win32s known bug list says that getcwd() doesn't work
      * so use the Win32 system call instead. <Negri>
      */
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
+    if (GetCurrentDirectoryW(_MAX_PATH, wbuf) != 0)
     {
-	WCHAR	wbuf[_MAX_PATH + 1];
+	WCHAR   wcbuf[_MAX_PATH + 1];
+	char_u  *p = NULL;
 
-	if (GetCurrentDirectoryW(_MAX_PATH, wbuf) != 0)
+	if (GetLongPathNameW(wbuf, wcbuf, _MAX_PATH) != 0)
 	{
-	    WCHAR   wcbuf[_MAX_PATH + 1];
-	    char_u  *p = NULL;
-
-	    if (GetLongPathNameW(wbuf, wcbuf, _MAX_PATH) != 0)
+	    p = utf16_to_enc(wcbuf, NULL);
+	    if (STRLEN(p) >= (size_t)len)
 	    {
-		p = utf16_to_enc(wcbuf, NULL);
-		if (STRLEN(p) >= (size_t)len)
-		{
-		    // long path name is too long, fall back to short one
-		    vim_free(p);
-		    p = NULL;
-		}
-	    }
-	    if (p == NULL)
-		p = utf16_to_enc(wbuf, NULL);
-
-	    if (p != NULL)
-	    {
-		vim_strncpy(buf, p, len - 1);
+		// long path name is too long, fall back to short one
 		vim_free(p);
-		return OK;
+		p = NULL;
 	    }
 	}
-	return FAIL;
-    }
-    if (GetCurrentDirectory(len, (LPSTR)buf) == 0)
-	return FAIL;
-    lfnlen = GetLongPathNameA((LPCSTR)buf, (LPSTR)abuf, _MAX_PATH);
-    if (lfnlen == 0 || lfnlen >= (DWORD)len)
-	// Failed to get long path name or it's too long: fall back to the
-	// short path name.
-	return OK;
+	if (p == NULL)
+	    p = utf16_to_enc(wbuf, NULL);
 
-    STRCPY(buf, abuf);
-    return OK;
+	if (p != NULL)
+	{
+	    vim_strncpy(buf, p, len - 1);
+	    vim_free(p);
+	    return OK;
+	}
+    }
+    return FAIL;
 }
 
 /*
@@ -2968,22 +2912,15 @@ mch_getperm(char_u *name)
     int
 mch_setperm(char_u *name, long perm)
 {
-    long	n = -1;
+    long	n;
+    WCHAR	*p;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	WCHAR *p = enc_to_utf16(name, NULL);
+    p = enc_to_utf16(name, NULL);
+    if (p == NULL)
+	return FAIL;
 
-	if (p != NULL)
-	{
-	    n = _wchmod(p, perm);
-	    vim_free(p);
-	    if (n == -1)
-		return FAIL;
-	}
-    }
-    if (n == -1)
-	n = _chmod((const char *)name, perm);
+    n = _wchmod(p, perm);
+    vim_free(p);
     if (n == -1)
 	return FAIL;
 
@@ -3053,19 +2990,15 @@ mch_isrealdir(char_u *name)
     int
 mch_mkdir(char_u *name)
 {
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	WCHAR	*p;
-	int	retval;
+    WCHAR   *p;
+    int	    retval;
 
-	p = enc_to_utf16(name, NULL);
-	if (p == NULL)
-	    return -1;
-	retval = _wmkdir(p);
-	vim_free(p);
-	return retval;
-    }
-    return _mkdir((const char *)name);
+    p = enc_to_utf16(name, NULL);
+    if (p == NULL)
+	return -1;
+    retval = _wmkdir(p);
+    vim_free(p);
+    return retval;
 }
 
 /*
@@ -3075,19 +3008,15 @@ mch_mkdir(char_u *name)
     int
 mch_rmdir(char_u *name)
 {
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	WCHAR	*p;
-	int	retval;
+    WCHAR   *p;
+    int	    retval;
 
-	p = enc_to_utf16(name, NULL);
-	if (p == NULL)
-	    return -1;
-	retval = _wrmdir(p);
-	vim_free(p);
-	return retval;
-    }
-    return _rmdir((const char *)name);
+    p = enc_to_utf16(name, NULL);
+    if (p == NULL)
+	return -1;
+    retval = _wrmdir(p);
+    vim_free(p);
+    return retval;
 }
 
 /*
@@ -3110,35 +3039,22 @@ mch_is_symbolic_link(char_u *name)
 {
     HANDLE		hFind;
     int			res = FALSE;
-    WIN32_FIND_DATAA	findDataA;
     DWORD		fileFlags = 0, reparseTag = 0;
-    WCHAR		*wn = NULL;
+    WCHAR		*wn;
     WIN32_FIND_DATAW	findDataW;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	wn = enc_to_utf16(name, NULL);
-    if (wn != NULL)
-    {
-	hFind = FindFirstFileW(wn, &findDataW);
-	vim_free(wn);
-	if (hFind != INVALID_HANDLE_VALUE)
-	{
-	    fileFlags = findDataW.dwFileAttributes;
-	    reparseTag = findDataW.dwReserved0;
-	}
-    }
-    else
-    {
-	hFind = FindFirstFile((LPCSTR)name, &findDataA);
-	if (hFind != INVALID_HANDLE_VALUE)
-	{
-	    fileFlags = findDataA.dwFileAttributes;
-	    reparseTag = findDataA.dwReserved0;
-	}
-    }
+    wn = enc_to_utf16(name, NULL);
+    if (wn == NULL)
+	return FALSE;
 
+    hFind = FindFirstFileW(wn, &findDataW);
+    vim_free(wn);
     if (hFind != INVALID_HANDLE_VALUE)
+    {
+	fileFlags = findDataW.dwFileAttributes;
+	reparseTag = findDataW.dwReserved0;
 	FindClose(hFind);
+    }
 
     if ((fileFlags & FILE_ATTRIBUTE_REPARSE_POINT)
 	    && (reparseTag == IO_REPARSE_TAG_SYMLINK
@@ -3172,33 +3088,20 @@ win32_fileinfo(char_u *fname, BY_HANDLE_FILE_INFORMATION *info)
 {
     HANDLE	hFile;
     int		res = FILEINFO_READ_FAIL;
-    WCHAR	*wn = NULL;
+    WCHAR	*wn;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	wn = enc_to_utf16(fname, NULL);
-	if (wn == NULL)
-	    return FILEINFO_ENC_FAIL;
-    }
-    if (wn != NULL)
-    {
-	hFile = CreateFileW(wn,		/* file name */
-		    GENERIC_READ,	/* access mode */
-		    FILE_SHARE_READ | FILE_SHARE_WRITE,	/* share mode */
-		    NULL,		/* security descriptor */
-		    OPEN_EXISTING,	/* creation disposition */
-		    FILE_FLAG_BACKUP_SEMANTICS,	/* file attributes */
-		    NULL);		/* handle to template file */
-	vim_free(wn);
-    }
-    else
-	hFile = CreateFile((LPCSTR)fname,    /* file name */
-		    GENERIC_READ,	    /* access mode */
-		    FILE_SHARE_READ | FILE_SHARE_WRITE,	/* share mode */
-		    NULL,		/* security descriptor */
-		    OPEN_EXISTING,	/* creation disposition */
-		    FILE_FLAG_BACKUP_SEMANTICS,	/* file attributes */
-		    NULL);		/* handle to template file */
+    wn = enc_to_utf16(fname, NULL);
+    if (wn == NULL)
+	return FILEINFO_ENC_FAIL;
+
+    hFile = CreateFileW(wn,	// file name
+	    GENERIC_READ,	// access mode
+	    FILE_SHARE_READ | FILE_SHARE_WRITE,	// share mode
+	    NULL,		// security descriptor
+	    OPEN_EXISTING,	// creation disposition
+	    FILE_FLAG_BACKUP_SEMANTICS,	// file attributes
+	    NULL);		// handle to template file
+    vim_free(wn);
 
     if (hFile != INVALID_HANDLE_VALUE)
     {
@@ -3221,18 +3124,14 @@ win32_fileinfo(char_u *fname, BY_HANDLE_FILE_INFORMATION *info)
 win32_getattrs(char_u *name)
 {
     int		attr;
-    WCHAR	*p = NULL;
+    WCHAR	*p;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	p = enc_to_utf16(name, NULL);
+    p = enc_to_utf16(name, NULL);
+    if (p == NULL)
+	return INVALID_FILE_ATTRIBUTES;
 
-    if (p != NULL)
-    {
-	attr = GetFileAttributesW(p);
-	vim_free(p);
-    }
-    else
-	attr = GetFileAttributes((char *)name);
+    attr = GetFileAttributesW(p);
+    vim_free(p);
 
     return attr;
 }
@@ -3245,19 +3144,15 @@ win32_getattrs(char_u *name)
     static int
 win32_setattrs(char_u *name, int attrs)
 {
-    int res;
-    WCHAR	*p = NULL;
+    int	    res;
+    WCHAR   *p;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	p = enc_to_utf16(name, NULL);
+    p = enc_to_utf16(name, NULL);
+    if (p == NULL)
+	return -1;
 
-    if (p != NULL)
-    {
-	res = SetFileAttributesW(p, attrs);
-	vim_free(p);
-    }
-    else
-	res = SetFileAttributes((char *)name, attrs);
+    res = SetFileAttributesW(p, attrs);
+    vim_free(p);
 
     return res ? 0 : -1;
 }
@@ -3375,7 +3270,7 @@ mch_nodetype(char_u *name)
 {
     HANDLE	hFile;
     int		type;
-    WCHAR	*wn = NULL;
+    WCHAR	*wn;
 
     /* We can't open a file with a name "\\.\con" or "\\.\prn" and trying to
      * read from it later will cause Vim to hang.  Thus return NODE_WRITABLE
@@ -3383,29 +3278,18 @@ mch_nodetype(char_u *name)
     if (STRNCMP(name, "\\\\.\\", 4) == 0)
 	return NODE_WRITABLE;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	wn = enc_to_utf16(name, NULL);
+    wn = enc_to_utf16(name, NULL);
+    if (wn == NULL)
+	return NODE_NORMAL;
 
-    if (wn != NULL)
-    {
-	hFile = CreateFileW(wn,		    /* file name */
-		    GENERIC_WRITE,	    /* access mode */
-		    0,			    /* share mode */
-		    NULL,		    /* security descriptor */
-		    OPEN_EXISTING,	    /* creation disposition */
-		    0,			    /* file attributes */
-		    NULL);		    /* handle to template file */
-	vim_free(wn);
-    }
-    else
-	hFile = CreateFile((LPCSTR)name,    /* file name */
-		    GENERIC_WRITE,	    /* access mode */
-		    0,			    /* share mode */
-		    NULL,		    /* security descriptor */
-		    OPEN_EXISTING,	    /* creation disposition */
-		    0,			    /* file attributes */
-		    NULL);		    /* handle to template file */
-
+    hFile = CreateFileW(wn,	    // file name
+	    GENERIC_WRITE,	    // access mode
+	    0,			    // share mode
+	    NULL,		    // security descriptor
+	    OPEN_EXISTING,	    // creation disposition
+	    0,			    // file attributes
+	    NULL);		    // handle to template file
+    vim_free(wn);
     if (hFile == INVALID_HANDLE_VALUE)
 	return NODE_NORMAL;
 
@@ -3445,81 +3329,45 @@ mch_get_acl(char_u *fname)
     p = (struct my_acl *)alloc_clear((unsigned)sizeof(struct my_acl));
     if (p != NULL)
     {
-	WCHAR	*wn = NULL;
+	WCHAR	*wn;
 
-	if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	    wn = enc_to_utf16(fname, NULL);
-	if (wn != NULL)
+	wn = enc_to_utf16(fname, NULL);
+	if (wn == NULL)
+	    return NULL;
+
+	// Try to retrieve the entire security descriptor.
+	err = GetNamedSecurityInfoW(
+		wn,			// Abstract filename
+		SE_FILE_OBJECT,		// File Object
+		OWNER_SECURITY_INFORMATION |
+		GROUP_SECURITY_INFORMATION |
+		DACL_SECURITY_INFORMATION |
+		SACL_SECURITY_INFORMATION,
+		&p->pSidOwner,		// Ownership information.
+		&p->pSidGroup,		// Group membership.
+		&p->pDacl,		// Discretionary information.
+		&p->pSacl,		// For auditing purposes.
+		&p->pSecurityDescriptor);
+	if (err == ERROR_ACCESS_DENIED ||
+		err == ERROR_PRIVILEGE_NOT_HELD)
 	{
-	    /* Try to retrieve the entire security descriptor. */
-	    err = GetNamedSecurityInfoW(
-		    wn,			// Abstract filename
-		    SE_FILE_OBJECT,	// File Object
-		    OWNER_SECURITY_INFORMATION |
-		    GROUP_SECURITY_INFORMATION |
-		    DACL_SECURITY_INFORMATION |
-		    SACL_SECURITY_INFORMATION,
-		    &p->pSidOwner,	// Ownership information.
-		    &p->pSidGroup,	// Group membership.
-		    &p->pDacl,		// Discretionary information.
-		    &p->pSacl,		// For auditing purposes.
+	    // Retrieve only DACL.
+	    (void)GetNamedSecurityInfoW(
+		    wn,
+		    SE_FILE_OBJECT,
+		    DACL_SECURITY_INFORMATION,
+		    NULL,
+		    NULL,
+		    &p->pDacl,
+		    NULL,
 		    &p->pSecurityDescriptor);
-	    if (err == ERROR_ACCESS_DENIED ||
-		    err == ERROR_PRIVILEGE_NOT_HELD)
-	    {
-		/* Retrieve only DACL. */
-		(void)GetNamedSecurityInfoW(
-			wn,
-			SE_FILE_OBJECT,
-			DACL_SECURITY_INFORMATION,
-			NULL,
-			NULL,
-			&p->pDacl,
-			NULL,
-			&p->pSecurityDescriptor);
-	    }
-	    if (p->pSecurityDescriptor == NULL)
-	    {
-		mch_free_acl((vim_acl_T)p);
-		p = NULL;
-	    }
-	    vim_free(wn);
 	}
-	else
+	if (p->pSecurityDescriptor == NULL)
 	{
-	    /* Try to retrieve the entire security descriptor. */
-	    err = GetNamedSecurityInfo(
-		    (LPSTR)fname,	// Abstract filename
-		    SE_FILE_OBJECT,	// File Object
-		    OWNER_SECURITY_INFORMATION |
-		    GROUP_SECURITY_INFORMATION |
-		    DACL_SECURITY_INFORMATION |
-		    SACL_SECURITY_INFORMATION,
-		    &p->pSidOwner,	// Ownership information.
-		    &p->pSidGroup,	// Group membership.
-		    &p->pDacl,		// Discretionary information.
-		    &p->pSacl,		// For auditing purposes.
-		    &p->pSecurityDescriptor);
-	    if (err == ERROR_ACCESS_DENIED ||
-		    err == ERROR_PRIVILEGE_NOT_HELD)
-	    {
-		/* Retrieve only DACL. */
-		(void)GetNamedSecurityInfo(
-			(LPSTR)fname,
-			SE_FILE_OBJECT,
-			DACL_SECURITY_INFORMATION,
-			NULL,
-			NULL,
-			&p->pDacl,
-			NULL,
-			&p->pSecurityDescriptor);
-	    }
-	    if (p->pSecurityDescriptor == NULL)
-	    {
-		mch_free_acl((vim_acl_T)p);
-		p = NULL;
-	    }
+	    mch_free_acl((vim_acl_T)p);
+	    p = NULL;
 	}
+	vim_free(wn);
     }
 
     return (vim_acl_T)p;
@@ -3560,56 +3408,41 @@ mch_set_acl(char_u *fname, vim_acl_T acl)
 #ifdef HAVE_ACL
     struct my_acl   *p = (struct my_acl *)acl;
     SECURITY_INFORMATION    sec_info = 0;
+    WCHAR	    *wn;
 
-    if (p != NULL)
+    if (p == NULL)
+	return;
+
+    wn = enc_to_utf16(fname, NULL);
+    if (wn == NULL)
+	return;
+
+    // Set security flags
+    if (p->pSidOwner)
+	sec_info |= OWNER_SECURITY_INFORMATION;
+    if (p->pSidGroup)
+	sec_info |= GROUP_SECURITY_INFORMATION;
+    if (p->pDacl)
     {
-	WCHAR	*wn = NULL;
-
-	/* Set security flags */
-	if (p->pSidOwner)
-	    sec_info |= OWNER_SECURITY_INFORMATION;
-	if (p->pSidGroup)
-	    sec_info |= GROUP_SECURITY_INFORMATION;
-	if (p->pDacl)
-	{
-	    sec_info |= DACL_SECURITY_INFORMATION;
-	    /* Do not inherit its parent's DACL.
-	     * If the DACL is inherited, Cygwin permissions would be changed.
-	     */
-	    if (!is_acl_inherited(p->pDacl))
-		sec_info |= PROTECTED_DACL_SECURITY_INFORMATION;
-	}
-	if (p->pSacl)
-	    sec_info |= SACL_SECURITY_INFORMATION;
-
-	if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	    wn = enc_to_utf16(fname, NULL);
-	if (wn != NULL)
-	{
-	    (void)SetNamedSecurityInfoW(
-			wn,			// Abstract filename
-			SE_FILE_OBJECT,		// File Object
-			sec_info,
-			p->pSidOwner,		// Ownership information.
-			p->pSidGroup,		// Group membership.
-			p->pDacl,		// Discretionary information.
-			p->pSacl		// For auditing purposes.
-			);
-	    vim_free(wn);
-	}
-	else
-	{
-	    (void)SetNamedSecurityInfo(
-			(LPSTR)fname,		// Abstract filename
-			SE_FILE_OBJECT,		// File Object
-			sec_info,
-			p->pSidOwner,		// Ownership information.
-			p->pSidGroup,		// Group membership.
-			p->pDacl,		// Discretionary information.
-			p->pSacl		// For auditing purposes.
-			);
-	}
+	sec_info |= DACL_SECURITY_INFORMATION;
+	// Do not inherit its parent's DACL.
+	// If the DACL is inherited, Cygwin permissions would be changed.
+	if (!is_acl_inherited(p->pDacl))
+	    sec_info |= PROTECTED_DACL_SECURITY_INFORMATION;
     }
+    if (p->pSacl)
+	sec_info |= SACL_SECURITY_INFORMATION;
+
+    (void)SetNamedSecurityInfoW(
+	    wn,			// Abstract filename
+	    SE_FILE_OBJECT,	// File Object
+	    sec_info,
+	    p->pSidOwner,	// Ownership information.
+	    p->pSidGroup,	// Group membership.
+	    p->pDacl,		// Discretionary information.
+	    p->pSacl		// For auditing purposes.
+	    );
+    vim_free(wn);
 #endif
 }
 
@@ -3955,51 +3788,34 @@ vim_create_process(
     LPVOID		*env,
     char		*cwd)
 {
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
+    BOOL	ret = FALSE;
+    WCHAR	*wcmd, *wcwd = NULL;
+
+    wcmd = enc_to_utf16((char_u *)cmd, NULL);
+    if (wcmd == NULL)
+	return FALSE;
+    if (cwd != NULL)
     {
-	BOOL	ret;
-	WCHAR	*wcmd, *wcwd = NULL;
-
-	wcmd = enc_to_utf16((char_u *)cmd, NULL);
-	if (wcmd == NULL)
-	    goto fallback;
-	if (cwd != NULL)
-	{
-	    wcwd = enc_to_utf16((char_u *)cwd, NULL);
-	    if (wcwd == NULL)
-	    {
-		vim_free(wcmd);
-		goto fallback;
-	    }
-	}
-
-	ret = CreateProcessW(
-	    NULL,			/* Executable name */
-	    wcmd,			/* Command to execute */
-	    NULL,			/* Process security attributes */
-	    NULL,			/* Thread security attributes */
-	    inherit_handles,	/* Inherit handles */
-	    flags,			/* Creation flags */
-	    env,			/* Environment */
-	    wcwd,			/* Current directory */
-	    (LPSTARTUPINFOW)si,	/* Startup information */
-	    pi);			/* Process information */
-	vim_free(wcmd);
-	vim_free(wcwd);
-	return ret;
+	wcwd = enc_to_utf16((char_u *)cwd, NULL);
+	if (wcwd == NULL)
+	    goto theend;
     }
-fallback:
-    return CreateProcess(
-	NULL,			/* Executable name */
-	cmd,			/* Command to execute */
-	NULL,			/* Process security attributes */
-	NULL,			/* Thread security attributes */
-	inherit_handles,	/* Inherit handles */
-	flags,			/* Creation flags */
-	env,			/* Environment */
-	cwd,			/* Current directory */
-	si,			/* Startup information */
-	pi);			/* Process information */
+
+    ret = CreateProcessW(
+	    NULL,		// Executable name
+	    wcmd,		// Command to execute
+	    NULL,		// Process security attributes
+	    NULL,		// Thread security attributes
+	    inherit_handles,	// Inherit handles
+	    flags,		// Creation flags
+	    env,		// Environment
+	    wcwd,		// Current directory
+	    (LPSTARTUPINFOW)si,	// Startup information
+	    pi);		// Process information
+theend:
+    vim_free(wcmd);
+    vim_free(wcwd);
+    return ret;
 }
 
 
@@ -4008,18 +3824,16 @@ vim_shell_execute(
     char *cmd,
     INT	 n_show_cmd)
 {
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	WCHAR *wcmd = enc_to_utf16((char_u *)cmd, NULL);
-	if (wcmd != NULL)
-	{
-	    HINSTANCE ret;
-	    ret = ShellExecuteW(NULL, NULL, wcmd, NULL, NULL, n_show_cmd);
-	    vim_free(wcmd);
-	    return ret;
-	}
-    }
-    return ShellExecute(NULL, NULL, cmd, NULL, NULL, n_show_cmd);
+    HINSTANCE	ret;
+    WCHAR	*wcmd;
+
+    wcmd = enc_to_utf16((char_u *)cmd, NULL);
+    if (wcmd == NULL)
+	return (HINSTANCE) 0;
+
+    ret = ShellExecuteW(NULL, NULL, wcmd, NULL, NULL, n_show_cmd);
+    vim_free(wcmd);
+    return ret;
 }
 
 
@@ -4582,17 +4396,16 @@ mch_system(char *cmd, int options)
     static int
 mch_system(char *cmd, int options)
 {
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	WCHAR	*wcmd = enc_to_utf16((char_u *)cmd, NULL);
-	if (wcmd != NULL)
-	{
-	    int ret = _wsystem(wcmd);
-	    vim_free(wcmd);
-	    return ret;
-	}
-    }
-    return system(cmd);
+    int		ret;
+    WCHAR	*wcmd;
+
+    wcmd = enc_to_utf16((char_u *)cmd, NULL);
+    if (wcmd == NULL)
+	return -1;
+
+    ret = _wsystem(wcmd);
+    vim_free(wcmd);
+    return ret;
 }
 
 #endif
@@ -4692,51 +4505,29 @@ mch_call_shell(
     int		x = 0;
     int		tmode = cur_tmode;
 #ifdef FEAT_TITLE
-    char	szShellTitle[512];
-    int		did_set_title = FALSE;
+    WCHAR	szShellTitle[512];
 
     /* Change the title to reflect that we are in a subshell. */
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
+    if (GetConsoleTitleW(szShellTitle,
+		sizeof(szShellTitle)/sizeof(WCHAR) - 4) > 0)
     {
-	WCHAR szShellTitle[512];
-
-	if (GetConsoleTitleW(szShellTitle,
-				  sizeof(szShellTitle)/sizeof(WCHAR) - 4) > 0)
+	if (cmd == NULL)
+	    wcscat(szShellTitle, L" :sh");
+	else
 	{
-	    if (cmd == NULL)
-		wcscat(szShellTitle, L" :sh");
-	    else
-	    {
-		WCHAR *wn = enc_to_utf16((char_u *)cmd, NULL);
+	    WCHAR *wn = enc_to_utf16((char_u *)cmd, NULL);
 
-		if (wn != NULL)
-		{
-		    wcscat(szShellTitle, L" - !");
-		    if ((wcslen(szShellTitle) + wcslen(wn) <
-					  sizeof(szShellTitle)/sizeof(WCHAR)))
-			wcscat(szShellTitle, wn);
-		    SetConsoleTitleW(szShellTitle);
-		    vim_free(wn);
-		    did_set_title = TRUE;
-		}
+	    if (wn != NULL)
+	    {
+		wcscat(szShellTitle, L" - !");
+		if ((wcslen(szShellTitle) + wcslen(wn) <
+			    sizeof(szShellTitle)/sizeof(WCHAR)))
+		    wcscat(szShellTitle, wn);
+		SetConsoleTitleW(szShellTitle);
+		vim_free(wn);
 	    }
 	}
     }
-    if (!did_set_title)
-	/* Change the title to reflect that we are in a subshell. */
-	if (GetConsoleTitle(szShellTitle, sizeof(szShellTitle) - 4) > 0)
-	{
-	    if (cmd == NULL)
-		strcat(szShellTitle, " :sh");
-	    else
-	    {
-		strcat(szShellTitle, " - !");
-		if ((strlen(szShellTitle) + strlen((char *)cmd)
-			    < sizeof(szShellTitle)))
-		    strcat(szShellTitle, (char *)cmd);
-	    }
-	    SetConsoleTitle(szShellTitle);
-	}
 #endif
 
     out_flush();
@@ -4936,18 +4727,13 @@ mch_call_shell(
 			"External commands will not pause after completion.\n"
 			"See  :help win32-vimrun  for more information.");
 		    char *title = _("Vim Warning");
-		    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-		    {
-			WCHAR *wmsg = enc_to_utf16((char_u *)msg, NULL);
-			WCHAR *wtitle = enc_to_utf16((char_u *)title, NULL);
+		    WCHAR *wmsg = enc_to_utf16((char_u *)msg, NULL);
+		    WCHAR *wtitle = enc_to_utf16((char_u *)title, NULL);
 
-			if (wmsg != NULL && wtitle != NULL)
-			    MessageBoxW(NULL, wmsg, wtitle, MB_ICONWARNING);
-			vim_free(wmsg);
-			vim_free(wtitle);
-		    }
-		    else
-			MessageBox(NULL, msg, title, MB_ICONWARNING);
+		    if (wmsg != NULL && wtitle != NULL)
+			MessageBoxW(NULL, wmsg, wtitle, MB_ICONWARNING);
+		    vim_free(wmsg);
+		    vim_free(wtitle);
 		    need_vimrun_warning = FALSE;
 		}
 		if (!s_dont_use_vimrun && p_stmp)
@@ -5011,23 +4797,16 @@ job_io_file_open(
 	DWORD dwFlagsAndAttributes)
 {
     HANDLE h;
-    WCHAR *wn = NULL;
+    WCHAR *wn;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	wn = enc_to_utf16(fname, NULL);
-	if (wn != NULL)
-	{
-	    h = CreateFileW(wn, dwDesiredAccess, dwShareMode,
-		    lpSecurityAttributes, dwCreationDisposition,
-		    dwFlagsAndAttributes, NULL);
-	    vim_free(wn);
-	}
-    }
+    wn = enc_to_utf16(fname, NULL);
     if (wn == NULL)
-	h = CreateFile((LPCSTR)fname, dwDesiredAccess, dwShareMode,
-		lpSecurityAttributes, dwCreationDisposition,
-		dwFlagsAndAttributes, NULL);
+	return INVALID_HANDLE_VALUE;
+
+    h = CreateFileW(wn, dwDesiredAccess, dwShareMode,
+	    lpSecurityAttributes, dwCreationDisposition,
+	    dwFlagsAndAttributes, NULL);
+    vim_free(wn);
     return h;
 }
 
@@ -6085,81 +5864,56 @@ write_chars(
     char_u *pchBuf,
     DWORD  cbToWrite)
 {
-    COORD coord = g_coord;
-    DWORD written;
+    COORD	    coord = g_coord;
+    DWORD	    written;
+    DWORD	    n, cchwritten, cells;
+    static WCHAR    *unicodebuf = NULL;
+    static int	    unibuflen = 0;
+    int		    length;
+    int		    cp = enc_utf8 ? CP_UTF8 : enc_codepage;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
+    length = MultiByteToWideChar(cp, 0, (LPCSTR)pchBuf, cbToWrite, 0, 0);
+    if (unicodebuf == NULL || length > unibuflen)
     {
-	static WCHAR	*unicodebuf = NULL;
-	static int	unibuflen = 0;
-	int		length;
-	DWORD		n, cchwritten, cells;
+	vim_free(unicodebuf);
+	unicodebuf = (WCHAR *)lalloc(length * sizeof(WCHAR), FALSE);
+	unibuflen = length;
+    }
+    MultiByteToWideChar(cp, 0, (LPCSTR)pchBuf, cbToWrite,
+			unicodebuf, unibuflen);
 
-	length = MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)pchBuf, cbToWrite, 0, 0);
-	if (unicodebuf == NULL || length > unibuflen)
-	{
-	    vim_free(unicodebuf);
-	    unicodebuf = (WCHAR *)lalloc(length * sizeof(WCHAR), FALSE);
-	    unibuflen = length;
-	}
-	MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)pchBuf, cbToWrite,
-			    unicodebuf, unibuflen);
+    cells = mb_string2cells(pchBuf, cbToWrite);
 
-	cells = mb_string2cells(pchBuf, cbToWrite);
-
-	if (!USE_VTP)
-	{
-	    FillConsoleOutputAttribute(g_hConOut, g_attrCurrent, cells,
-					coord, &written);
-	    /* When writing fails or didn't write a single character, pretend one
-	     * character was written, otherwise we get stuck. */
-	    if (WriteConsoleOutputCharacterW(g_hConOut, unicodebuf, length,
-			coord, &cchwritten) == 0
-		    || cchwritten == 0 || cchwritten == (DWORD)-1)
-		cchwritten = 1;
-	}
-	else
-	{
-	    if (WriteConsoleW(g_hConOut, unicodebuf, length, &cchwritten,
-		    NULL) == 0 || cchwritten == 0)
-		cchwritten = 1;
-	}
-
-	if (cchwritten == length)
-	{
-	    written = cbToWrite;
-	    g_coord.X += (SHORT)cells;
-	}
-	else
-	{
-	    char_u *p = pchBuf;
-	    for (n = 0; n < cchwritten; n++)
-		MB_CPTR_ADV(p);
-	    written = p - pchBuf;
-	    g_coord.X += (SHORT)mb_string2cells(pchBuf, written);
-	}
+    if (!USE_VTP)
+    {
+	FillConsoleOutputAttribute(g_hConOut, g_attrCurrent, cells,
+				    coord, &written);
+	// When writing fails or didn't write a single character, pretend one
+	// character was written, otherwise we get stuck.
+	if (WriteConsoleOutputCharacterW(g_hConOut, unicodebuf, length,
+		    coord, &cchwritten) == 0
+		|| cchwritten == 0 || cchwritten == (DWORD)-1)
+	    cchwritten = 1;
     }
     else
     {
-	if (!USE_VTP)
-	{
-	    FillConsoleOutputAttribute(g_hConOut, g_attrCurrent, cbToWrite,
-					coord, &written);
-	    /* When writing fails or didn't write a single character, pretend one
-	     * character was written, otherwise we get stuck. */
-	    if (WriteConsoleOutputCharacter(g_hConOut, (LPCSTR)pchBuf, cbToWrite,
-			coord, &written) == 0
-		    || written == 0 || written == (DWORD)-1)
-		written = 1;
-	}
-	else
-	{
-	    if (WriteConsole(g_hConOut, (LPCSTR)pchBuf, cbToWrite, &written,
-		    NULL) == 0 || written == 0)
-		written = 1;
-	}
+	if (WriteConsoleW(g_hConOut, unicodebuf, length, &cchwritten,
+		    NULL) == 0 || cchwritten == 0)
+	    cchwritten = 1;
+    }
 
-	g_coord.X += (SHORT) written;
+    if (cchwritten == length)
+    {
+	written = cbToWrite;
+	g_coord.X += (SHORT)cells;
+    }
+    else
+    {
+	char_u *p = pchBuf;
+	for (n = 0; n < cchwritten; n++)
+	    MB_CPTR_ADV(p);
+	written = p - pchBuf;
+	g_coord.X += (SHORT)mb_string2cells(pchBuf, written);
     }
 
     while (g_coord.X > g_srScrollRegion.Right)
@@ -6518,7 +6272,7 @@ mch_delay(
     int
 mch_remove(char_u *name)
 {
-    WCHAR	*wn = NULL;
+    WCHAR	*wn;
     int		n;
 
     /*
@@ -6530,17 +6284,13 @@ mch_remove(char_u *name)
 
     win32_setattrs(name, FILE_ATTRIBUTE_NORMAL);
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	wn = enc_to_utf16(name, NULL);
-	if (wn != NULL)
-	{
-	    n = DeleteFileW(wn) ? 0 : -1;
-	    vim_free(wn);
-	    return n;
-	}
-    }
-    return DeleteFile((LPCSTR)name) ? 0 : -1;
+    wn = enc_to_utf16(name, NULL);
+    if (wn == NULL)
+	return -1;
+
+    n = DeleteFileW(wn) ? 0 : -1;
+    vim_free(wn);
+    return n;
 }
 
 
@@ -6590,62 +6340,7 @@ mch_total_mem(int special UNUSED)
 }
 
 /*
- * Same code as below, but with wide functions and no comments.
- * Return 0 for success, non-zero for failure.
- */
-    int
-mch_wrename(WCHAR *wold, WCHAR *wnew)
-{
-    WCHAR	*p;
-    int		i;
-    WCHAR	szTempFile[_MAX_PATH + 1];
-    WCHAR	szNewPath[_MAX_PATH + 1];
-    HANDLE	hf;
-
-    p = wold;
-    for (i = 0; wold[i] != NUL; ++i)
-	if ((wold[i] == '/' || wold[i] == '\\' || wold[i] == ':')
-		&& wold[i + 1] != 0)
-	    p = wold + i + 1;
-    if ((int)(wold + i - p) < 8 || p[6] != '~')
-	return (MoveFileW(wold, wnew) == 0);
-
-    if (GetFullPathNameW(wnew, _MAX_PATH, szNewPath, &p) == 0 || p == NULL)
-	return -1;
-    *p = NUL;
-
-    if (GetTempFileNameW(szNewPath, L"VIM", 0, szTempFile) == 0)
-	return -2;
-
-    if (!DeleteFileW(szTempFile))
-	return -3;
-
-    if (!MoveFileW(wold, szTempFile))
-	return -4;
-
-    if ((hf = CreateFileW(wold, GENERIC_WRITE, 0, NULL, CREATE_NEW,
-		    FILE_ATTRIBUTE_NORMAL, NULL)) == INVALID_HANDLE_VALUE)
-	return -5;
-    if (!CloseHandle(hf))
-	return -6;
-
-    if (!MoveFileW(szTempFile, wnew))
-    {
-	(void)MoveFileW(szTempFile, wold);
-	return -7;
-    }
-
-    DeleteFileW(szTempFile);
-
-    if (!DeleteFileW(wold))
-	return -8;
-
-    return 0;
-}
-
-
-/*
- * mch_rename() works around a bug in rename (aka MoveFile) in
+ * mch_wrename() works around a bug in rename (aka MoveFile) in
  * Windows 95: rename("foo.bar", "foo.bar~") will generate a
  * file whose short file name is "FOO.BAR" (its long file name will
  * be correct: "foo.bar~").  Because a file can be accessed by
@@ -6664,90 +6359,97 @@ mch_wrename(WCHAR *wold, WCHAR *wnew)
  * Should probably set errno appropriately when errors occur.
  */
     int
-mch_rename(
-    const char	*pszOldFile,
-    const char	*pszNewFile)
+mch_wrename(WCHAR *wold, WCHAR *wnew)
 {
-    char	szTempFile[_MAX_PATH+1];
-    char	szNewPath[_MAX_PATH+1];
-    char	*pszFilePart;
+    WCHAR	*p;
+    int		i;
+    WCHAR	szTempFile[_MAX_PATH + 1];
+    WCHAR	szNewPath[_MAX_PATH + 1];
     HANDLE	hf;
-    WCHAR	*wold = NULL;
-    WCHAR	*wnew = NULL;
-    int		retval = -1;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	wold = enc_to_utf16((char_u *)pszOldFile, NULL);
-	wnew = enc_to_utf16((char_u *)pszNewFile, NULL);
-	if (wold != NULL && wnew != NULL)
-	    retval = mch_wrename(wold, wnew);
-	vim_free(wold);
-	vim_free(wnew);
-	return retval;
-    }
+    // No need to play tricks unless the file name contains a "~" as the
+    // seventh character.
+    p = wold;
+    for (i = 0; wold[i] != NUL; ++i)
+	if ((wold[i] == '/' || wold[i] == '\\' || wold[i] == ':')
+		&& wold[i + 1] != 0)
+	    p = wold + i + 1;
+    if ((int)(wold + i - p) < 8 || p[6] != '~')
+	return (MoveFileW(wold, wnew) == 0);
 
-    /*
-     * No need to play tricks unless the file name contains a "~" as the
-     * seventh character.
-     */
-    pszFilePart = (char *)gettail((char_u *)pszOldFile);
-    if (STRLEN(pszFilePart) < 8 || pszFilePart[6] != '~')
-	return rename(pszOldFile, pszNewFile);
-
-    /* Get base path of new file name.  Undocumented feature: If pszNewFile is
-     * a directory, no error is returned and pszFilePart will be NULL. */
-    if (GetFullPathName(pszNewFile, _MAX_PATH, szNewPath, &pszFilePart) == 0
-	    || pszFilePart == NULL)
+    // Get base path of new file name.  Undocumented feature: If pszNewFile is
+    // a directory, no error is returned and pszFilePart will be NULL.
+    if (GetFullPathNameW(wnew, _MAX_PATH, szNewPath, &p) == 0 || p == NULL)
 	return -1;
-    *pszFilePart = NUL;
+    *p = NUL;
 
-    /* Get (and create) a unique temporary file name in directory of new file */
-    if (GetTempFileName(szNewPath, "VIM", 0, szTempFile) == 0)
+    // Get (and create) a unique temporary file name in directory of new file
+    if (GetTempFileNameW(szNewPath, L"VIM", 0, szTempFile) == 0)
 	return -2;
 
-    /* blow the temp file away */
-    if (!DeleteFile(szTempFile))
+    // blow the temp file away
+    if (!DeleteFileW(szTempFile))
 	return -3;
 
-    /* rename old file to the temp file */
-    if (!MoveFile(pszOldFile, szTempFile))
+    // rename old file to the temp file
+    if (!MoveFileW(wold, szTempFile))
 	return -4;
 
-    /* now create an empty file called pszOldFile; this prevents the operating
-     * system using pszOldFile as an alias (SFN) if we're renaming within the
-     * same directory.  For example, we're editing a file called
-     * filename.asc.txt by its SFN, filena~1.txt.  If we rename filena~1.txt
-     * to filena~1.txt~ (i.e., we're making a backup while writing it), the
-     * SFN for filena~1.txt~ will be filena~1.txt, by default, which will
-     * cause all sorts of problems later in buf_write().  So, we create an
-     * empty file called filena~1.txt and the system will have to find some
-     * other SFN for filena~1.txt~, such as filena~2.txt
-     */
-    if ((hf = CreateFile(pszOldFile, GENERIC_WRITE, 0, NULL, CREATE_NEW,
+    // now create an empty file called pszOldFile; this prevents the operating
+    // system using pszOldFile as an alias (SFN) if we're renaming within the
+    // same directory.  For example, we're editing a file called
+    // filename.asc.txt by its SFN, filena~1.txt.  If we rename filena~1.txt
+    // to filena~1.txt~ (i.e., we're making a backup while writing it), the
+    // SFN for filena~1.txt~ will be filena~1.txt, by default, which will
+    // cause all sorts of problems later in buf_write().  So, we create an
+    // empty file called filena~1.txt and the system will have to find some
+    // other SFN for filena~1.txt~, such as filena~2.txt
+    if ((hf = CreateFileW(wold, GENERIC_WRITE, 0, NULL, CREATE_NEW,
 		    FILE_ATTRIBUTE_NORMAL, NULL)) == INVALID_HANDLE_VALUE)
 	return -5;
     if (!CloseHandle(hf))
 	return -6;
 
-    /* rename the temp file to the new file */
-    if (!MoveFile(szTempFile, pszNewFile))
+    // rename the temp file to the new file
+    if (!MoveFileW(szTempFile, wnew))
     {
-	/* Renaming failed.  Rename the file back to its old name, so that it
-	 * looks like nothing happened. */
-	(void)MoveFile(szTempFile, pszOldFile);
-
+	// Renaming failed.  Rename the file back to its old name, so that it
+	// looks like nothing happened.
+	(void)MoveFileW(szTempFile, wold);
 	return -7;
     }
 
-    /* Seems to be left around on Novell filesystems */
-    DeleteFile(szTempFile);
+    // Seems to be left around on Novell filesystems
+    DeleteFileW(szTempFile);
 
-    /* finally, remove the empty old file */
-    if (!DeleteFile(pszOldFile))
+    // finally, remove the empty old file
+    if (!DeleteFileW(wold))
 	return -8;
 
-    return 0;	/* success */
+    return 0;
+}
+
+
+/*
+ * Converts the filenames to UTF-16, then call mch_wrename().
+ * Like rename(), returns 0 upon success, non-zero upon failure.
+ */
+    int
+mch_rename(
+    const char	*pszOldFile,
+    const char	*pszNewFile)
+{
+    WCHAR	*wold = NULL;
+    WCHAR	*wnew = NULL;
+    int		retval = -1;
+
+    wold = enc_to_utf16((char_u *)pszOldFile, NULL);
+    wnew = enc_to_utf16((char_u *)pszNewFile, NULL);
+    if (wold != NULL && wnew != NULL)
+	retval = mch_wrename(wold, wnew);
+    vim_free(wold);
+    vim_free(wnew);
+    return retval;
 }
 
 /*
@@ -6768,55 +6470,35 @@ mch_access(char *n, int p)
 {
     HANDLE	hFile;
     int		retval = -1;	    /* default: fail */
-    WCHAR	*wn = NULL;
+    WCHAR	*wn;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-	wn = enc_to_utf16((char_u *)n, NULL);
+    wn = enc_to_utf16((char_u *)n, NULL);
+    if (wn == NULL)
+	return -1;
 
     if (mch_isdir((char_u *)n))
     {
-	char TempName[_MAX_PATH + 16] = "";
 	WCHAR TempNameW[_MAX_PATH + 16] = L"";
 
 	if (p & R_OK)
 	{
 	    /* Read check is performed by seeing if we can do a find file on
 	     * the directory for any file. */
-	    if (wn != NULL)
-	    {
-		int		    i;
-		WIN32_FIND_DATAW    d;
+	    int			i;
+	    WIN32_FIND_DATAW    d;
 
-		for (i = 0; i < _MAX_PATH && wn[i] != 0; ++i)
-		    TempNameW[i] = wn[i];
-		if (TempNameW[i - 1] != '\\' && TempNameW[i - 1] != '/')
-		    TempNameW[i++] = '\\';
-		TempNameW[i++] = '*';
-		TempNameW[i++] = 0;
+	    for (i = 0; i < _MAX_PATH && wn[i] != 0; ++i)
+		TempNameW[i] = wn[i];
+	    if (TempNameW[i - 1] != '\\' && TempNameW[i - 1] != '/')
+		TempNameW[i++] = '\\';
+	    TempNameW[i++] = '*';
+	    TempNameW[i++] = 0;
 
-		hFile = FindFirstFileW(TempNameW, &d);
-		if (hFile == INVALID_HANDLE_VALUE)
-		    goto getout;
-		else
-		    (void)FindClose(hFile);
-	    }
+	    hFile = FindFirstFileW(TempNameW, &d);
+	    if (hFile == INVALID_HANDLE_VALUE)
+		goto getout;
 	    else
-	    {
-		char		    *pch;
-		WIN32_FIND_DATA	    d;
-
-		vim_strncpy((char_u *)TempName, (char_u *)n, _MAX_PATH);
-		pch = TempName + STRLEN(TempName) - 1;
-		if (*pch != '\\' && *pch != '/')
-		    *++pch = '\\';
-		*++pch = '*';
-		*++pch = NUL;
-
-		hFile = FindFirstFile(TempName, &d);
-		if (hFile == INVALID_HANDLE_VALUE)
-		    goto getout;
 		(void)FindClose(hFile);
-	    }
 	}
 
 	if (p & W_OK)
@@ -6825,19 +6507,10 @@ mch_access(char *n, int p)
 	     * directories on read-only network shares.  However, in
 	     * directories whose ACL allows writes but denies deletes will end
 	     * up keeping the temporary file :-(. */
-	    if (wn != NULL)
-	    {
-		if (!GetTempFileNameW(wn, L"VIM", 0, TempNameW))
-		    goto getout;
-		else
-		    DeleteFileW(TempNameW);
-	    }
+	    if (!GetTempFileNameW(wn, L"VIM", 0, TempNameW))
+		goto getout;
 	    else
-	    {
-		if (!GetTempFileName(n, "VIM", 0, TempName))
-		    goto getout;
-		mch_remove((char_u *)TempName);
-	    }
+		DeleteFileW(TempNameW);
 	}
     }
     else
@@ -6850,12 +6523,8 @@ mch_access(char *n, int p)
 	DWORD access_mode = ((p & W_OK) ? GENERIC_WRITE : 0)
 					     | ((p & R_OK) ? GENERIC_READ : 0);
 
-	if (wn != NULL)
-	    hFile = CreateFileW(wn, access_mode, share_mode,
-						 NULL, OPEN_EXISTING, 0, NULL);
-	else
-	    hFile = CreateFile(n, access_mode, share_mode,
-						 NULL, OPEN_EXISTING, 0, NULL);
+	hFile = CreateFileW(wn, access_mode, share_mode,
+					     NULL, OPEN_EXISTING, 0, NULL);
 	if (hFile == INVALID_HANDLE_VALUE)
 	    goto getout;
 	CloseHandle(hFile);
@@ -6878,18 +6547,14 @@ mch_open(const char *name, int flags, int mode)
     WCHAR	*wn;
     int		f;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	wn = enc_to_utf16((char_u *)name, NULL);
-	if (wn != NULL)
-	{
-	    f = _wopen(wn, flags, mode);
-	    vim_free(wn);
-	    return f;
-	}
-    }
-#endif
+    wn = enc_to_utf16((char_u *)name, NULL);
+    if (wn == NULL)
+	return -1;
 
+    f = _wopen(wn, flags, mode);
+    vim_free(wn);
+    return f;
+#else
     /* open() can open a file which name is longer than _MAX_PATH bytes
      * and shorter than _MAX_PATH characters successfully, but sometimes it
      * causes unexpected error in another part. We make it an error explicitly
@@ -6898,10 +6563,11 @@ mch_open(const char *name, int flags, int mode)
 	return -1;
 
     return open(name, flags, mode);
+#endif
 }
 
 /*
- * Version of fopen() that may use UTF-16 file name.
+ * Version of fopen() that uses UTF-16 file name.
  */
     FILE *
 mch_fopen(const char *name, const char *mode)
@@ -6909,41 +6575,29 @@ mch_fopen(const char *name, const char *mode)
     WCHAR	*wn, *wm;
     FILE	*f = NULL;
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
 #if defined(DEBUG) && _MSC_VER >= 1400
-	/* Work around an annoying assertion in the Microsoft debug CRT
-	 * when mode's text/binary setting doesn't match _get_fmode(). */
-	char newMode = mode[strlen(mode) - 1];
-	int oldMode = 0;
+    /* Work around an annoying assertion in the Microsoft debug CRT
+     * when mode's text/binary setting doesn't match _get_fmode(). */
+    char newMode = mode[strlen(mode) - 1];
+    int oldMode = 0;
 
-	_get_fmode(&oldMode);
-	if (newMode == 't')
-	    _set_fmode(_O_TEXT);
-	else if (newMode == 'b')
-	    _set_fmode(_O_BINARY);
+    _get_fmode(&oldMode);
+    if (newMode == 't')
+	_set_fmode(_O_TEXT);
+    else if (newMode == 'b')
+	_set_fmode(_O_BINARY);
 #endif
-	wn = enc_to_utf16((char_u *)name, NULL);
-	wm = enc_to_utf16((char_u *)mode, NULL);
-	if (wn != NULL && wm != NULL)
-	    f = _wfopen(wn, wm);
-	vim_free(wn);
-	vim_free(wm);
+    wn = enc_to_utf16((char_u *)name, NULL);
+    wm = enc_to_utf16((char_u *)mode, NULL);
+    if (wn != NULL && wm != NULL)
+	f = _wfopen(wn, wm);
+    vim_free(wn);
+    vim_free(wm);
 
 #if defined(DEBUG) && _MSC_VER >= 1400
-	_set_fmode(oldMode);
+    _set_fmode(oldMode);
 #endif
-	return f;
-    }
-
-    /* fopen() can open a file which name is longer than _MAX_PATH bytes
-     * and shorter than _MAX_PATH characters successfully, but sometimes it
-     * causes unexpected error in another part. We make it an error explicitly
-     * here. */
-    if (strlen(name) >= _MAX_PATH)
-	return NULL;
-
-    return fopen(name, mode);
+    return f;
 }
 
 /*
@@ -7418,6 +7072,7 @@ fix_arg_enc(void)
 mch_setenv(char *var, char *value, int x)
 {
     char_u	*envbuf;
+    WCHAR	*p;
 
     envbuf = alloc((unsigned)(STRLEN(var) + STRLEN(value) + 2));
     if (envbuf == NULL)
@@ -7425,29 +7080,17 @@ mch_setenv(char *var, char *value, int x)
 
     sprintf((char *)envbuf, "%s=%s", var, value);
 
-    if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
-    {
-	WCHAR	    *p = enc_to_utf16(envbuf, NULL);
+    p = enc_to_utf16(envbuf, NULL);
 
-	vim_free(envbuf);
-	if (p == NULL)
-	    return -1;
-	_wputenv(p);
+    vim_free(envbuf);
+    if (p == NULL)
+	return -1;
+    _wputenv(p);
 #ifdef libintl_wputenv
-	libintl_wputenv(p);
+    libintl_wputenv(p);
 #endif
-	/* Unlike Un*x systems, we can free the string for _wputenv(). */
-	vim_free(p);
-    }
-    else
-    {
-	_putenv((char *)envbuf);
-#ifdef libintl_putenv
-	libintl_putenv((char *)envbuf);
-#endif
-	/* Unlike Un*x systems, we can free the string for _putenv(). */
-	vim_free(envbuf);
-    }
+    /* Unlike Un*x systems, we can free the string for _wputenv(). */
+    vim_free(p);
 
     return 0;
 }

--- a/src/vim.h
+++ b/src/vim.h
@@ -536,7 +536,7 @@ extern char *(*dyn_libintl_ngettext)(const char *msgid, const char *msgid_plural
 extern char *(*dyn_libintl_bindtextdomain)(const char *domainname, const char *dirname);
 extern char *(*dyn_libintl_bind_textdomain_codeset)(const char *domainname, const char *codeset);
 extern char *(*dyn_libintl_textdomain)(const char *domainname);
-extern int (*dyn_libintl_putenv)(const char *envstring);
+extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #endif
 
 
@@ -559,7 +559,6 @@ extern int (*dyn_libintl_putenv)(const char *envstring);
 #   define HAVE_BIND_TEXTDOMAIN_CODESET 1
 #  endif
 #  define textdomain(domain) (*dyn_libintl_textdomain)(domain)
-#  define libintl_putenv(envstring) (*dyn_libintl_putenv)(envstring)
 #  define libintl_wputenv(envstring) (*dyn_libintl_wputenv)(envstring)
 # else
 #  include <libintl.h>


### PR DESCRIPTION
`utf16_to_enc()` and other conversion functions are now always available.
We can simplify the source code by removing usage of ANSI APIs.

This also reduces the size of the gvim.exe file about 4.5 KB.