### PR TITLE
Don't call test_signals in GUI

### DIFF
--- a/src/testdir/test_signals.vim
+++ b/src/testdir/test_signals.vim
@@ -4,6 +4,11 @@ if !has('unix')
   finish
 endif
 
+if has('gui_running')
+  " Signals only work for terminals, and won't work for GUI.
+  finish
+endif
+
 source shared.vim
 
 " Test signal WINCH (window resize signal)


### PR DESCRIPTION
test_signals tests signals that are only relevant in terminal. In `testgui` the WINCH signal wouldn't affect the GUI and therefore fail. Just disable this test when the GUI is running.

Note: I noticed that the CI configs (.travis.yml) doesn't call `testgui`, which is probably why this issue didn't get caught in CI.