### PR TITLE
ftplugin: make: Update for GNU make 3.82 and nmake

### DIFF
--- a/runtime/ftplugin/make.vim
+++ b/runtime/ftplugin/make.vim
@@ -29,5 +29,5 @@ let &l:include = '^\s*include'
 
 " For matchit.vim, suggested by Albert Netymk.
 if exists("loaded_matchit")
-  let b:match_words = '\<if\(n\)\=\(eq\|def\)\>:\<else\>:\<endif\>,\<define\>:\<endef\>'
+  let b:match_words = '^ *ifn\=\(eq\|def\)\>:^ *else\(\s\+ifn\=\(eq\|def\)\)\=\>:^ *endif\>,\<define\>:\<endef\>,^!\s*if\(n\=def\)\=\>:^!\s*else\(if\(n\=def\)\=\)\=\>:^!\s*endif\>'
 endif


### PR DESCRIPTION
Improve support for matchit.

* Update for GNU make 3.82:
  - Support `else ifeq` and other directives.
* Support Microsoft nmake directives.