### PR TITLE
win32: Use wide entry points

### DIFF
--- a/src/Make_cyg.mak
+++ b/src/Make_cyg.mak
@@ -37,13 +37,12 @@
 #RUBY=/cygdribe/c/ruby
 
 
-# Use MinGW(-w64) cross compiler.
-# There are three MinGW packages in Cygwin:
-#   32-bit: mingw-gcc-g++ and mingw64-i686-gcc-g++
+# Use MinGW-w64 cross compiler.
+# There are two MinGW-w64 packages in Cygwin:
+#   32-bit: mingw64-i686-gcc-g++
 #   64-bit: mingw64-x86_64-gcc-g++
 # You may also need to set 'ARCH' in Make_cyg_ming.mak.
-CROSS_COMPILE = i686-pc-mingw32-
-#CROSS_COMPILE = i686-w64-mingw32-
+CROSS_COMPILE = i686-w64-mingw32-
 #CROSS_COMPILE = x86_64-w64-mingw32-
 
 

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -691,7 +691,7 @@ CFLAGS += -s
 endif
 
 LIB = -lkernel32 -luser32 -lgdi32 -ladvapi32 -lcomdlg32 -lcomctl32 -lnetapi32 -lversion
-GUIOBJ =  $(OUTDIR)/gui.o $(OUTDIR)/gui_w32.o $(OUTDIR)/gui_beval.o $(OUTDIR)/os_w32exe.o
+GUIOBJ =  $(OUTDIR)/gui.o $(OUTDIR)/gui_w32.o $(OUTDIR)/gui_beval.o
 CUIOBJ = $(OUTDIR)/iscygpty.o
 OBJ = \
 	$(OUTDIR)/arabic.o \
@@ -737,9 +737,9 @@ OBJ = \
 	$(OUTDIR)/normal.o \
 	$(OUTDIR)/ops.o \
 	$(OUTDIR)/option.o \
-	$(OUTDIR)/os_win32.o \
 	$(OUTDIR)/os_mswin.o \
-	$(OUTDIR)/winclip.o \
+	$(OUTDIR)/os_w32exe.o \
+	$(OUTDIR)/os_win32.o \
 	$(OUTDIR)/pathdef.o \
 	$(OUTDIR)/popupmnu.o \
 	$(OUTDIR)/quickfix.o \
@@ -759,6 +759,7 @@ OBJ = \
 	$(OUTDIR)/userfunc.o \
 	$(OUTDIR)/version.o \
 	$(OUTDIR)/vimrc.o \
+	$(OUTDIR)/winclip.o \
 	$(OUTDIR)/window.o
 
 ifdef PERL
@@ -864,6 +865,8 @@ XDIFF_DEPS = \
 ifdef MZSCHEME
 MZSCHEME_SUFFIX = Z
 endif
+
+LFLAGS += -municode
 
 ifeq ($(GUI),yes)
 TARGET := gvim$(DEBUG_SUFFIX).exe

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -742,7 +742,7 @@ OBJ = \
 	$(OUTDIR)\ops.obj \
 	$(OUTDIR)\option.obj \
 	$(OUTDIR)\os_mswin.obj \
-	$(OUTDIR)\winclip.obj \
+	$(OUTDIR)\os_w32exe.obj \
 	$(OUTDIR)\os_win32.obj \
 	$(OUTDIR)\pathdef.obj \
 	$(OUTDIR)\popupmnu.obj \
@@ -761,6 +761,7 @@ OBJ = \
 	$(OUTDIR)\ui.obj \
 	$(OUTDIR)\undo.obj \
 	$(OUTDIR)\userfunc.obj \
+	$(OUTDIR)\winclip.obj \
 	$(OUTDIR)\window.obj \
 	$(OUTDIR)\vim.res
 
@@ -799,8 +800,7 @@ GUI_INCL = \
 GUI_OBJ = \
 	$(OUTDIR)\gui.obj \
 	$(OUTDIR)\gui_beval.obj \
-	$(OUTDIR)\gui_w32.obj \
-	$(OUTDIR)\os_w32exe.obj
+	$(OUTDIR)\gui_w32.obj
 GUI_LIB = \
 	gdi32.lib version.lib $(IME_LIB) \
 	winspool.lib comctl32.lib advapi32.lib shell32.lib netapi32.lib \

--- a/src/main.c
+++ b/src/main.c
@@ -96,7 +96,7 @@ static char_u *start_dir = NULL;	/* current working dir on startup */
 static int has_dash_c_arg = FALSE;
 
     int
-# ifdef FEAT_GUI_MSWIN
+# ifdef MSWIN
 #  ifdef __BORLANDC__
 _cdecl
 #  endif

--- a/src/os_w32exe.c
+++ b/src/os_w32exe.c
@@ -28,20 +28,22 @@ void _cdecl SaveInst(HINSTANCE hInst);
 #endif
 
 #ifndef PROTO
+# ifdef FEAT_GUI
     int WINAPI
-WinMain(
+wWinMain(
     HINSTANCE	hInstance,
     HINSTANCE	hPrevInst UNUSED,
-    LPSTR	lpszCmdLine UNUSED,
+    LPWSTR	lpszCmdLine UNUSED,
     int		nCmdShow UNUSED)
+# else
+    int
+wmain(int argc UNUSED, wchar_t **argv UNUSED)
+# endif
 {
-    int		argc = 0;
-    char	**argv = NULL;
-
 # ifdef FEAT_GUI
     SaveInst(hInstance);
 # endif
-    VimMain(argc, argv);
+    VimMain(0, NULL);
 
     return 0;
 }


### PR DESCRIPTION
The patch 8.1.1091 enables to support Unicode environment variables
inside Vim. However, we still cannot access external Unicode env var.
E.g.:

```
> set a=Ā
> gvim --clean --cmd "set enc=utf-8"
:echo $a
?  " should be Ā
```

This is because we use ANSI entry points: WinMain() for GUI and main()
for CUI. To fix this, we need to use wide entry points: wWinMain() for
GUI and wmain() for CUI.

This also moves the entry point for CUI from main.c to os_w32exe.c to
make the code simple.

Note: This requires the `-municode` option to MinGW, which means now
MinGW-w64 is needed.