### PR TITLE
win32: Fix 16-color mode on terminal on vim.exe

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2434,7 +2434,7 @@ color2index(VTermColor *color, int fg, int *boldp)
     {
 	/* First 16 colors and default: use the ANSI index, because these
 	 * colors can be redefined. */
-	if (t_colors >= 16)
+	if (t_colors != 16)
 	    return color->ansi_index;
 	switch (color->ansi_index)
 	{


### PR DESCRIPTION
When using the terminal on vim.exe with `:set t_Co=16` (default), the colors
are shown incorrectly. Red and blue are swapped.

To reproduce:

1. Download `color16.bat` from [here](https://gist.github.com/k-takata/2d4f562bacf8bae6691973a540970117#file-color16-bat).
2. Execute `vim --clean`.
3. Type `:terminal`.
4. Execute `color16.bat` on the terminal.

Color indices between the ANSI escape sequence and the Windows console
(in 16-color mode) are different, so they should be adjusted.
It seems that a condition was wrong. This fixes it.