### PR TITLE
ftplugin/dosbatch.vim: setl commentstring

### DIFF
--- a/runtime/ftplugin/dosbatch.vim
+++ b/runtime/ftplugin/dosbatch.vim
@@ -16,6 +16,7 @@ set cpo&vim
 
 " BAT comment formatting
 setlocal comments=b:rem,b:@rem,b:REM,b:@REM,:::
+setlocal commentstring=::\ %s
 setlocal formatoptions-=t formatoptions+=rol
 
 " Define patterns for the browse file filter


### PR DESCRIPTION
This is useful for tpope's commentary plugin.

I used :: rather than REM because of the comments here: https://github.com/neovim/neovim/pull/9837

stackoverflow has some caveats to be aware of: https://stackoverflow.com/questions/11269338/how-to-comment-out-add-comment-in-a-batch-cmd#answer-16839602

> - Inside nested logic (IF/ELSE, FOR loops, etc...) use REM because :: gives an error.
> - :: may fail within setlocal ENABLEDELAYEDEXPANSION 