### PR TITLE
win32: Fix warning of GvimExt with VS2019

### DIFF
--- a/src/GvimExt/Makefile
+++ b/src/GvimExt/Makefile
@@ -58,7 +58,7 @@ SUBSYSTEM = console
 SUBSYSTEM = $(SUBSYSTEM),$(SUBSYSTEM_VER)
 !endif
 
-!if "$(CPU)" == "ARM64"
+!if "$(CPU)" == "AMD64" || "$(CPU)" == "ARM64"
 OFFSET = 0x11C000000
 !else
 OFFSET = 0x1C000000


### PR DESCRIPTION
VS2019 shows the following warning when linking GvimExt:

> warning LNK4281: undesirable base address 0x1C000000 for x64 image; set base
> address above 4GB for best ASLR optimization.

This fixes the warning.