### PR TITLE
Travis: Can use "sourceline" entry to add apt repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,13 @@ branches:
 
 addons:
   apt:
+    sources:
+      # Need msgfmt 0.19.8 to be able to generate .desktop files
+      - sourceline: 'ppa:ricotz/toolchain'
     packages:
       - autoconf
       - clang
+      - gettext
       - lcov
       - libperl-dev
       - python-dev
@@ -114,13 +118,6 @@ before_install:
   - |
     if [[ "${TRAVIS_OS_NAME}" = "linux" ]] && [[ "${CC}" = "clang" ]]; then
       ln -sf "$(which llvm-cov)" /home/travis/bin/gcov
-    fi
-  # Need msgfmt 0.19.8 to be able to generate .desktop files
-  - |
-    if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
-      sudo add-apt-repository ppa:ricotz/toolchain -y &&
-      sudo apt-get update -q &&
-      sudo apt-get install gettext=0.19.8.1-1ubuntu2~14.04~ricotz1 -y
     fi
 
 before_script:


### PR DESCRIPTION
https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-with-the-apt-addon

Using "sourceline" can avoid using "sudo".