### PR TITLE
Improved test_termcodes

### DIFF
--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -5,39 +5,53 @@ if has('gui_running') || !has('unix')
   finish
 endif
 
+" Helper function to emit a terminal escape code.
+func TerminalEscapeCode(code_xterm, code_sgr, row, col, m)
+  if &ttymouse ==# 'xterm'
+    call feedkeys("\<Esc>[M" .. list2str([a:code_xterm, a:col + 0x20, a:row + 0x20]), 'Lx!')
+  elseif &ttymouse ==# 'sgr'
+    call feedkeys(printf("\<Esc>[<%d;%d;%d%s", a:code_sgr, a:col, a:row, a:m), 'Lx!')
+  endif
+endfunc
+
+func MouseLeftClick(row, col)
+  call TerminalEscapeCode(0x20, 0, a:row, a:col, 'M')
+endfunc
+
+func MouseLeftRelease(row, col)
+  call TerminalEscapeCode(0x23, 3, a:row, a:col, 'm')
+endfunc
+
+func MouseLeftDrag(row, col)
+  call TerminalEscapeCode(0x43, 0x20, a:row, a:col, 'M')
+endfunc
+
+func MouseWheelUp(row, col)
+  call TerminalEscapeCode(0x40, 0x40, a:row, a:col, 'M')
+endfunc
+
+func MouseWheelDown(row, col)
+  call TerminalEscapeCode(0x41, 0x41, a:row, a:col, 'M')
+endfunc
+
 func Test_xterm_mouse_click()
   new
   let save_mouse = &mouse
   let save_term = &term
   let save_ttymouse = &ttymouse
-  set mouse=a
-  set term=xterm
+  set mouse=a term=xterm
   call setline(1, ['line 1', 'line 2', 'line 3 is a bit longer'])
-  redraw
 
-  " Xterm mouse click
-  set ttymouse=xterm
-  let button = 0x20  " left down
-  let row = 2 + 32
-  let col = 6 + 32
-  call feedkeys("\<Esc>[M" .. list2str([button, col, row]), 'Lx!')
-
-  let button = 0x23  " release
-  call feedkeys("\<Esc>[M" .. list2str([button, col, row]), 'Lx!')
-
-  call assert_equal([0, 2, 6, 0], getpos('.'))
-
-  " SGR mouse click
-  set ttymouse=sgr
-  let button = 0  " left down
-  let row = 3
-  let col = 9
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", button, col, row), 'Lx!')
-
-  let button = 3  " release
-  call feedkeys(printf("\<Esc>[<%d;%d;%dm", button, col, row), 'Lx!')
-
-  call assert_equal([0, 3, 9, 0], getpos('.'))
+  for ttymouse_val in ['xterm', 'sgr']
+    exe 'set ttymouse=' . ttymouse_val
+    go
+    call assert_equal([0, 1, 1, 0], getpos('.'))
+    let row = 2
+    let col = 6
+    call MouseLeftClick(row, col)
+    call MouseLeftRelease(row, col)
+    call assert_equal([0, 2, 6, 0], getpos('.'))
+  endfor
 
   let &mouse = save_mouse
   let &term = save_term
@@ -50,61 +64,31 @@ func Test_xterm_mouse_wheel()
   let save_mouse = &mouse
   let save_term = &term
   let save_ttymouse = &ttymouse
-  set mouse=a
-  set term=xterm
+  set mouse=a term=xterm
   call setline(1, range(1, 100))
 
-  " Test Xterm mouse wheel.
-  set ttymouse=xterm
-  let button = 0x41 " wheel down.
-  let row = 1 + 32  " cursor position for mouse wheel is not relevant.
-  let col = 1 + 32
+  for ttymouse_val in ['xterm', 'sgr']
+    exe 'set ttymouse=' . ttymouse_val
+    go
+    call assert_equal(1, line('w0'))
+    call assert_equal([0, 1, 1, 0], getpos('.'))
 
-  call assert_equal(1, line('w0'))
-  call assert_equal([0, 1, 1, 0], getpos('.'))
-  call feedkeys("\<Esc>[M" .. list2str([button, col, row]), 'Lx!')
-  call assert_equal(4, line('w0'))
-  call assert_equal([0, 4, 1, 0], getpos('.'))
-  call feedkeys("\<Esc>[M" .. list2str([button, col, row]), 'Lx!')
-  call assert_equal(7, line('w0'))
-  call assert_equal([0, 7, 1, 0], getpos('.'))
+    call MouseWheelDown(1, 1)
+    call assert_equal(4, line('w0'))
+    call assert_equal([0, 4, 1, 0], getpos('.'))
 
-  let button = 0x40  " wheel up.
+    call MouseWheelDown(1, 1)
+    call assert_equal(7, line('w0'))
+    call assert_equal([0, 7, 1, 0], getpos('.'))
 
-  call feedkeys("\<Esc>[M" .. list2str([button, col, row]), 'Lx!')
-  call assert_equal(4, line('w0'))
-  call assert_equal([0, 7, 1, 0], getpos('.'))
-  call feedkeys("\<Esc>[M" .. list2str([button, col, row]), 'Lx!')
-  call assert_equal(1, line('w0'))
-  call assert_equal([0, 7, 1, 0], getpos('.'))
+    call MouseWheelUp(1, 1)
+    call assert_equal(4, line('w0'))
+    call assert_equal([0, 7, 1, 0], getpos('.'))
 
-  " Test SGR mouse wheel.
-  set ttymouse=sgr
-  go
-  let button = 0x41 " wheel down.
-  let row = 1       " cursor position for mouse wheel is not relevant.
-  let col = 1
-
-  call assert_equal(1, line('w0'))
-  call assert_equal([0, 1, 1, 0], getpos('.'))
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", button, col, row), 'Lx!')
-  call assert_equal(4, line('w0'))
-  call assert_equal([0, 4, 1, 0], getpos('.'))
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", button, col, row), 'Lx!')
-  call assert_equal(7, line('w0'))
-  call assert_equal([0, 7, 1, 0], getpos('.'))
-
-  let button = 0x40  " wheel up.
-
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", button, col, row), 'Lx!')
-  call assert_equal(4, line('w0'))
-  call assert_equal([0, 7, 1, 0], getpos('.'))
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", button, col, row), 'Lx!')
-  call assert_equal(1, line('w0'))
-  call assert_equal([0, 7, 1, 0], getpos('.'))
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", button, col, row), 'Lx!')
-  call assert_equal(1, line('w0'))
-  call assert_equal([0, 7, 1, 0], getpos('.'))
+    call MouseWheelUp(1, 1)
+    call assert_equal(1, line('w0'))
+    call assert_equal([0, 7, 1, 0], getpos('.'))
+  endfor
 
   let &mouse = save_mouse
   let &term = save_term
@@ -116,55 +100,80 @@ func Test_xterm_mouse_drag_window_separator()
   let save_mouse = &mouse
   let save_term = &term
   let save_ttymouse = &ttymouse
-  set mouse=a
-  set term=xterm
-  set ttymouse=sgr
+  set mouse=a term=xterm
 
-  " Split horizontally and test dragging the horizontal window separator.
-  split
-  let rowseparator = winheight(0) + 1
+  for ttymouse_val in ['xterm', 'sgr']
+    exe 'set ttymouse=' . ttymouse_val
 
-  let button = 0  " left down.
-  let row = rowseparator
-  let col = 1
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", button, col, row), 'Lx!')
+    " Split horizontally and test dragging the horizontal window separator.
+    split
+    let rowseparator = winheight(0) + 1
+    let row = rowseparator
+    let col = 1
+    call MouseLeftClick(row, col)
 
-  let drag = 32
-  let row -= 1
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", drag, col, row), 'Lx!')
-  call assert_equal(rowseparator - 1, winheight(0) + 1)
-  let row += 1
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", drag, col, row), 'Lx!')
-  call assert_equal(rowseparator, winheight(0) + 1)
+    let row -= 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(rowseparator - 1, winheight(0) + 1)
+    let row += 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(rowseparator, winheight(0) + 1)
+    call MouseLeftRelease(row, col)
+    call assert_equal(rowseparator, winheight(0) + 1)
 
-  let release = 3
-  call feedkeys(printf("\<Esc>[<%d;%d;%dm", release, col, row), 'Lx!')
-  call assert_equal(rowseparator, winheight(0) + 1)
+    bwipe!
 
-  bwipe!
+    " Split vertically and test dragging the vertical window separator.
+    vsplit
+    let colseparator = winwidth(0) + 1
 
-  " Split vertically and test dragging the vertical window separator.
-  vsplit
-  let colseparator = winwidth(0) + 1
+    let row = 1
+    let col = colseparator
+    call MouseLeftClick(row, col)
+    let col -= 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(colseparator - 1, winwidth(0) + 1)
+    let col += 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(colseparator, winwidth(0) + 1)
+    call MouseLeftRelease(row, col)
+    call assert_equal(colseparator, winwidth(0) + 1)
 
-  let button = 0
-  let row = 1
-  let col = colseparator
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", button, col, row), 'Lx!')
+    bwipe!
+  endfor
 
-  let drag = 32
-  let col -= 1
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", drag, col, row), 'Lx!')
-  call assert_equal(colseparator - 1, winwidth(0) + 1)
-  let col += 1
-  call feedkeys(printf("\<Esc>[<%d;%d;%dM", drag, col, row), 'Lx!')
-  call assert_equal(colseparator, winwidth(0) + 1)
+  let &mouse = save_mouse
+  let &term = save_term
+  let &ttymouse = save_ttymouse
+endfunc
 
-  let release = 3
-  call feedkeys(printf("\<Esc>[<%d;%d;%dm", release, col, row), 'Lx!')
-  call assert_equal(colseparator, winwidth(0) + 1)
+func Test_xterm_mouse_drag_statusline()
+  let save_mouse = &mouse
+  let save_term = &term
+  let save_ttymouse = &ttymouse
+  set mouse=a term=xterm
 
-  bwipe!
+  for ttymouse_val in ['xterm', 'sgr']
+    exe 'set ttymouse=' . ttymouse_val
+
+    call assert_equal(1, &cmdheight)
+    let rowstatusline = winheight(0) + 1
+    let row = rowstatusline
+    let col = 1
+    call MouseLeftClick(row, col)
+    let row -= 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(2, &cmdheight)
+    call assert_equal(rowstatusline - 1, winheight(0) + 1)
+    let row += 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(1, &cmdheight)
+    call assert_equal(rowstatusline, winheight(0) + 1)
+    call MouseLeftRelease(row, col)
+    call assert_equal(1, &cmdheight)
+    call assert_equal(rowstatusline, winheight(0) + 1)
+  endfor
+
   let &mouse = save_mouse
   let &term = save_term
   let &ttymouse = save_ttymouse


### PR DESCRIPTION
This PR improves tests in src/testdir/test_termcodes.vim:

- Added helper functions to emit terminal escape codes to simplify tests
  and to make it easier to support other values of 'ttymouse'
- Test_xterm_mouse_drag_statusline now done for 'ttymouse' values xterm & sgr
- Added test for dragging statusline