### PR TITLE
Don't spellcheck symbols such as emojis

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -2836,6 +2836,10 @@ utf_class_buf(int c, buf_T *buf)
 	{0xff1a, 0xff20, 1},		/* half/fullwidth ASCII */
 	{0xff3b, 0xff40, 1},		/* half/fullwidth ASCII */
 	{0xff5b, 0xff65, 1},		/* half/fullwidth ASCII */
+	{0x1d000, 0x1d24f, 1},		/* Musical notation */
+	{0x1d400, 0x1d7ff, 1},		/* Mathematical Alphanumeric Symbols */
+	{0x1f000, 0x1f2ff, 1},		/* Game pieces; enclosed characters */
+	{0x1f300, 0x1f9ff, 1},		/* Many symbol blocks */
 	{0x20000, 0x2a6df, 0x4e00},	/* CJK Ideographs */
 	{0x2a700, 0x2b73f, 0x4e00},	/* CJK Ideographs */
 	{0x2b740, 0x2b81f, 0x4e00},	/* CJK Ideographs */


### PR DESCRIPTION
Previously various "emoji" symbols would get marked as bad by the spell
checker as it didn't recognize it as a non-word character.

Examples: 🚀, 🇳🇿(should render as New Zealand flag), ♔, and a whole
bunch more.

This adds the following blocks from the supplementary multilingual
plane:

	https://codepoints.net/byzantine_musical_symbols
	https://codepoints.net/musical_symbols
	https://codepoints.net/ancient_greek_musical_notation

	https://codepoints.net/mathematical_alphanumeric_symbols

	https://codepoints.net/mahjong_tiles
	https://codepoints.net/domino_tiles
	https://codepoints.net/playing_cards
	https://codepoints.net/enclosed_alphanumeric_supplement
	https://codepoints.net/enclosed_ideographic_supplement

	https://codepoints.net/miscellaneous_symbols_and_pictographs
	https://codepoints.net/emoticons
	https://codepoints.net/ornamental_dingbats
	https://codepoints.net/transport_and_map_symbols
	https://codepoints.net/alchemical_symbols
	https://codepoints.net/geometric_shapes_extended
	https://codepoints.net/supplemental_arrows-c
	https://codepoints.net/supplemental_symbols_and_pictographs

Note this is not intended as a fully comprehensive list, just a list of
common Emojis that were added to the Unicode spec in recent years.