### PR TITLE
nsis: Do not delete $VIM/_vimrc on silent uninstall

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -1096,7 +1096,9 @@ Section "un.$(str_unsection_rootdir)" id_unsection_rootdir
 	Call un.GetParent
 	Pop $0
 
-	Delete $0\_vimrc
+	${IfNot} ${Silent}
+	  Delete $0\_vimrc
+	${Endif}
 	RMDir $0
 SectionEnd
 


### PR DESCRIPTION
There is a request that not to delete `$VIM/_vimrc` when reinstalling (upgrading) Vim: https://github.com/vim/vim-win32-installer/issues/115

This keeps `$VIM/_vimrc` on silent uninstall mode.