### PR TITLE
When ttymouse is 'xterm', col/row > 223 are not supported

### DIFF
--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -118,6 +118,12 @@ func Test_xterm_mouse_drag_window_separator()
     let rowseparator = winheight(0) + 1
     let row = rowseparator
     let col = 1
+
+    if ttymouse_val ==# 'xterm' && row > 223
+      " When 'ttymouse' is 'xterm', row/col bigger than 223 are not supported.
+      continue
+    endif
+
     call MouseLeftClick(row, col)
 
     let row -= 1
@@ -168,6 +174,12 @@ func Test_xterm_mouse_drag_statusline()
     let rowstatusline = winheight(0) + 1
     let row = rowstatusline
     let col = 1
+
+    if ttymouse_val ==# 'xterm' && row > 223
+      " When 'ttymouse' is 'xterm', row/col bigger than 223 are not supported.
+      continue
+    endif
+
     call MouseLeftClick(row, col)
     let row -= 1
     call MouseLeftDrag(row, col)


### PR DESCRIPTION
This PR fixes a bug in `test_termcodes.vim`: col/row > 223 are
are not supported when `ttymouse` is equal to `xterm`.