### PR TITLE
Added test for clicking on tabs in tabline

### DIFF
--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -165,7 +165,8 @@ func Test_xterm_mouse_drag_statusline()
   let save_mouse = &mouse
   let save_term = &term
   let save_ttymouse = &ttymouse
-  set mouse=a term=xterm
+  let save_laststatus = &laststatus
+  set mouse=a term=xterm laststatus=2
 
   for ttymouse_val in ['xterm', 'sgr']
     exe 'set ttymouse=' . ttymouse_val
@@ -192,6 +193,55 @@ func Test_xterm_mouse_drag_statusline()
     call MouseLeftRelease(row, col)
     call assert_equal(1, &cmdheight)
     call assert_equal(rowstatusline, winheight(0) + 1)
+  endfor
+
+  let &mouse = save_mouse
+  let &term = save_term
+  let &ttymouse = save_ttymouse
+  let &laststatus = save_laststatus
+endfunc
+
+func Test_xterm_mouse_click_tab()
+  let save_mouse = &mouse
+  let save_term = &term
+  let save_ttymouse = &ttymouse
+  set mouse=a term=xterm
+  let row = 1
+
+  for ttymouse_val in ['xterm', 'sgr']
+    exe 'set ttymouse=' . ttymouse_val
+    e Xfoo
+    tabnew Xbar
+
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '    Xfoo',
+        \              'Tab page 2',
+        \              '>   Xbar'], a)
+
+    " Test clicking on tab names in the tabline at the top.
+    " FIXME: if the redraw! is removed below, valgrind complains
+    " about access to uninitialized memory!?
+    let col = 2
+    redraw!
+    call MouseLeftClick(row, col)
+    call MouseLeftRelease(row, col)
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '>   Xfoo',
+        \              'Tab page 2',
+        \              '    Xbar'], a)
+
+    let col = 9
+    call MouseLeftClick(row, col)
+    call MouseLeftRelease(row, col)
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '    Xfoo',
+        \              'Tab page 2',
+        \              '>   Xbar'], a)
+
+    %bwipe!
   endfor
 
   let &mouse = save_mouse


### PR DESCRIPTION
This PR adds a test for clicking on tabs in tablines.

I put a FIXME comment in `Test_xterm_mouse_click_tab`, because I
had to put a `redraw!` command in the test.  Without the `redraw!`,
valgrind would complain with this error:
```
==23794== Memcheck, a memory error detector
==23794== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==23794== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==23794== Command: ../vim -f -u unix.vim -U NONE --noplugin --not-a-term -S runtest.vim test_termcodes.vim --cmd au\ SwapExists\ *\ let\ v:swapchoice\ =\ "e"
==23794== Parent PID: 23793
==23794== 
==23794== Conditional jump or move depends on uninitialised value(s)
==23794==    at 0x21CE99: do_mouse (normal.c:2535)
==23794==    by 0x21FCBE: normal_cmd (normal.c:1106)
==23794==    by 0x1A03DC: exec_normal (ex_docmd.c:10511)
==23794==    by 0x17DD9B: f_feedkeys (evalfunc.c:3795)
==23794==    by 0x17EFA8: call_internal_func (evalfunc.c:1142)
==23794==    by 0x2E0D67: call_func (userfunc.c:1552)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x2E153C: call_user_func (userfunc.c:999)
==23794==    by 0x2E153C: call_func (userfunc.c:1533)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x2E153C: call_user_func (userfunc.c:999)
==23794==    by 0x2E153C: call_func (userfunc.c:1533)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x2E153C: call_user_func (userfunc.c:999)
==23794==    by 0x2E153C: call_func (userfunc.c:1533)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x1646A6: ex_execute (eval.c:8644)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x2E153C: call_user_func (userfunc.c:999)
==23794==    by 0x2E153C: call_func (userfunc.c:1533)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x194CD6: do_source (ex_cmds2.c:4607)
==23794==    by 0x195AF0: cmd_source (ex_cmds2.c:4227)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x3204CF: exe_commands (main.c:2940)
==23794==    by 0x3204CF: vim_main2 (main.c:795)
==23794==    by 0x139DEC: main (main.c:438)
==23794==  Uninitialised value was created by a heap allocation
==23794==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==23794==    by 0x2052D0: lalloc (misc2.c:942)
==23794==    by 0x274C90: screenalloc (screen.c:8759)
==23794==    by 0x275501: screenclear (screen.c:8959)
==23794==    by 0x2C47F4: set_shellsize (term.c:3393)
==23794==    by 0x2C6291: set_termname (term.c:2046)
==23794==    by 0x139F82: main (main.c:378)
==23794== 
==23794== Conditional jump or move depends on uninitialised value(s)
==23794==    at 0x2EC08D: goto_tabpage (window.c:4003)
==23794==    by 0x21CEB3: do_mouse (normal.c:2548)
==23794==    by 0x21FCBE: normal_cmd (normal.c:1106)
==23794==    by 0x1A03DC: exec_normal (ex_docmd.c:10511)
==23794==    by 0x17DD9B: f_feedkeys (evalfunc.c:3795)
==23794==    by 0x17EFA8: call_internal_func (evalfunc.c:1142)
==23794==    by 0x2E0D67: call_func (userfunc.c:1552)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x2E153C: call_user_func (userfunc.c:999)
==23794==    by 0x2E153C: call_func (userfunc.c:1533)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x2E153C: call_user_func (userfunc.c:999)
==23794==    by 0x2E153C: call_func (userfunc.c:1533)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x2E153C: call_user_func (userfunc.c:999)
==23794==    by 0x2E153C: call_func (userfunc.c:1533)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x1646A6: ex_execute (eval.c:8644)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x2E153C: call_user_func (userfunc.c:999)
==23794==    by 0x2E153C: call_func (userfunc.c:1533)
==23794==    by 0x2E1E0C: get_func_tv (userfunc.c:453)
==23794==    by 0x2E4B1D: ex_call (userfunc.c:3216)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x194CD6: do_source (ex_cmds2.c:4607)
==23794==    by 0x195AF0: cmd_source (ex_cmds2.c:4227)
==23794==    by 0x1A481B: do_one_cmd (ex_docmd.c:2526)
==23794==    by 0x1A481B: do_cmdline (ex_docmd.c:1033)
==23794==    by 0x3204CF: exe_commands (main.c:2940)
==23794==    by 0x3204CF: vim_main2 (main.c:795)
==23794==    by 0x139DEC: main (main.c:438)
==23794==  Uninitialised value was created by a heap allocation
==23794==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==23794==    by 0x2052D0: lalloc (misc2.c:942)
==23794==    by 0x274C90: screenalloc (screen.c:8759)
==23794==    by 0x275501: screenclear (screen.c:8959)
==23794==    by 0x2C47F4: set_shellsize (term.c:3393)
==23794==    by 0x2C6291: set_termname (term.c:2046)
==23794==    by 0x139F82: main (main.c:378)
```