### PR TITLE
Fixed typo in channel.c

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1906,7 +1906,7 @@ channel_save(channel_T *channel, ch_part_T part, char_u *buf, int len,
 
     if (prepend)
     {
-	/* preend node to the head of the queue */
+	/* prepend node to the head of the queue */
 	node->rq_next = head->rq_next;
 	node->rq_prev = NULL;
 	if (head->rq_next == NULL)


### PR DESCRIPTION
Changed "preend" to "prepend".