### PR TITLE
win32: Fix Ctrl-X mapping in Visual mode on vim.exe

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -5269,7 +5269,7 @@ static struct initmap
 	{(char_u *)"\316\325 \"*y", VIS_SEL},	    /* CTRL-Insert is "*y */
 	{(char_u *)"\316\327 \"*d", VIS_SEL},	    /* SHIFT-Del is "*d */
 	{(char_u *)"\316\330 \"*d", VIS_SEL},	    /* CTRL-Del is "*d */
-	{(char_u *)"\030 \"-d", VIS_SEL},	    /* CTRL-X is "-d */
+	{(char_u *)"\030 \"*d", VIS_SEL},	    /* CTRL-X is "*d */
 #  else
 	{(char_u *)"\316\324 P", NORMAL},	    /* SHIFT-Insert is P */
 	{(char_u *)"\316\324 \"-dP", VIS_SEL},	    /* SHIFT-Insert is "-dP */


### PR DESCRIPTION
`:help dos-standard-mappings` describes that Ctrl-X in Visual mode is mapped
to `"*d`.  It is correct on gvim.exe, however, not correct on vim.exe.  It is
mapped to `"-d` on vim.exe.  So, Ctrl-X doesn't cut the selected text into the
clipboard.

I think this is wrong and Ctrl-X should be mapped to `"*d` even on vim.exe.