### PR TITLE
mac: Fix Command-V mapping in Insert mode

### DIFF
--- a/runtime/doc/os_mac.txt
+++ b/runtime/doc/os_mac.txt
@@ -79,7 +79,7 @@ files.
 The following mappings are available for cut/copy/paste from/to clipboard.
 
 key		Normal	Visual	  Insert	Description ~
-Command-v	"*P	"-d"*P    <C-R>*	paste text       *<D-v>*
+Command-v	"*P	"-d"*P    <C-R><C-O>*	paste text       *<D-v>*
 Command-c		"*y			copy Visual text *<D-c>*
 Command-x		"*d			cut Visual text  *<D-x>*
 Backspace		"*d			cut Visual text

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -5286,7 +5286,7 @@ static struct initmap
 	/* paste, copy and cut */
 	{(char_u *)"<D-v> \"*P", NORMAL},
 	{(char_u *)"<D-v> \"-d\"*P", VIS_SEL},
-	{(char_u *)"<D-v> <C-R>*", INSERT+CMDLINE},
+	{(char_u *)"<D-v> <C-R><C-O>*", INSERT+CMDLINE},
 	{(char_u *)"<D-c> \"*y", VIS_SEL},
 	{(char_u *)"<D-x> \"*d", VIS_SEL},
 	{(char_u *)"<Backspace> \"-d", VIS_SEL},


### PR DESCRIPTION
As `:help mac-standard-mappings` says, currently Command-V in Insert mode is
mapped to `<C-R>*`, however I think this should be mapped to `<C-R><C-O>*`.

On Windows, Shift-Insert was mapped to `<C-R>*` at first.  But it was changed
to `<C-R><C-O>*` in Vim 6.0.  I think that the mapping on mac should be also
changed.

Actually, I'm not a mac user.  I want to hear mac users' opinion.