### PR TITLE
propsal: Make "v:" prefix mandatory in scriptversion 2

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -12713,6 +12713,10 @@ instead of failing in mysterious ways. >
 < 	String concatenation with "." is not supported, use ".." instead.
 	This avoids the ambiguity using "." for Dict member access and
 	floating point numbers.  Now ".5" means the number 0.5.
+
+	All |vim-variable|s must be prefixed by "v:".  E.g. "version" doesn't
+	work as |v:version| anymore.  It can be used as a normal variable.
+
 	Test for support with: >
 		has('vimscript-2')
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -7672,10 +7672,13 @@ find_var_ht(char_u *name, char_u **varname)
 	    return NULL;
 	*varname = name;
 
-	/* "version" is "v:version" in all scopes */
-	hi = hash_find(&compat_hashtab, name);
-	if (!HASHITEM_EMPTY(hi))
-	    return &compat_hashtab;
+	// "version" is "v:version" in all scopes if scriptversion is 1.
+	if (current_sctx.sc_version < 2)
+	{
+	    hi = hash_find(&compat_hashtab, name);
+	    if (!HASHITEM_EMPTY(hi))
+		return &compat_hashtab;
+	}
 
 	ht = get_funccal_local_ht();
 	if (ht == NULL)

--- a/src/eval.c
+++ b/src/eval.c
@@ -7672,8 +7672,8 @@ find_var_ht(char_u *name, char_u **varname)
 	    return NULL;
 	*varname = name;
 
-	// "version" is "v:version" in all scopes if scriptversion is 1.
-	if (current_sctx.sc_version < 2)
+	// "version" is "v:version" in all scopes if scriptversion < 3.
+	if (current_sctx.sc_version < 3)
 	{
 	    hi = hash_find(&compat_hashtab, name);
 	    if (!HASHITEM_EMPTY(hi))

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -5127,7 +5127,7 @@ ex_scriptversion(exarg_T *eap UNUSED)
     nr = getdigits(&eap->arg);
     if (nr == 0 || *eap->arg != NUL)
 	emsg(_(e_invarg));
-    else if (nr > 2)
+    else if (nr > 3)
 	semsg(_("E999: scriptversion not supported: %d"), nr);
     else
 	current_sctx.sc_version = nr;

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -133,10 +133,6 @@ func Test_string_concat_scriptversion2()
   call assert_fails('let a .= b', 'E985:')
   call assert_fails('let vers = 1.2.3', 'E15:')
 
-  call assert_fails('echo version', 'E121:')
-  let version = 1
-  call assert_equal(1, version)
-
   if has('float')
     let f = .5
     call assert_equal(0.5, f)
@@ -153,13 +149,23 @@ func Test_string_concat_scriptversion1()
   let vers = 1.2.3
   call assert_equal('123', vers)
 
-  echo version
-  call assert_fails('let version = 1', 'E46:')
-  call assert_equal(v:version, version)
-
   if has('float')
     call assert_fails('let f = .5', 'E15:')
   endif
+endfunc
+
+scriptversion 3
+func Test_vvar_scriptversion3()
+  call assert_fails('echo version', 'E121:')
+  let version = 1
+  call assert_equal(1, version)
+endfunc
+
+scriptversion 2
+func Test_vvar_scriptversion2()
+  echo version
+  call assert_fails('let version = 1', 'E46:')
+  call assert_equal(v:version, version)
 endfunc
 
 func Test_scriptversion()

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -133,6 +133,10 @@ func Test_string_concat_scriptversion2()
   call assert_fails('let a .= b', 'E985:')
   call assert_fails('let vers = 1.2.3', 'E15:')
 
+  call assert_fails('echo version', 'E121:')
+  let version = 1
+  call assert_equal(1, version)
+
   if has('float')
     let f = .5
     call assert_equal(0.5, f)
@@ -148,6 +152,10 @@ func Test_string_concat_scriptversion1()
   let a .= b
   let vers = 1.2.3
   call assert_equal('123', vers)
+
+  echo version
+  call assert_fails('let version = 1', 'E46:')
+  call assert_equal(v:version, version)
 
   if has('float')
     call assert_fails('let f = .5', 'E15:')


### PR DESCRIPTION
With this patch, "version" cannot be used as "v:version" in scriptversion 2 anymore.
It can be used as a normal variable. (Same for "v:count" and other "v:" variables.)

What do you think?