### PR TITLE
Delete swap file after asking for permission

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -1692,12 +1692,12 @@ ml_recover(void)
 	else
 	    msg(_("Recovery completed. Buffer contents equals file contents."));
 
-	choice = do_dialog(VIM_QUESTION,
+	choice = vim_dialog_yesno(VIM_QUESTION,
 		NULL,
 		(char_u *)_("Delete the swap file now?"),
-		(char_u *)_("&Yes\n&No"), 1, NULL, FALSE);
+		1);
 
-	if (choice == 1)
+	if (choice == VIM_YES)
 	{
 		mch_remove(fname_used);
 	}

--- a/src/memline.c
+++ b/src/memline.c
@@ -1681,7 +1681,9 @@ ml_recover(void)
     }
     else
     {
+#if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG)
 	int choice;
+#endif
 
 	if (curbuf->b_changed)
 	{
@@ -1692,6 +1694,7 @@ ml_recover(void)
 	else
 	    msg(_("Recovery completed. Buffer contents equals file contents."));
 
+#if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG)
 	choice = vim_dialog_yesno(VIM_QUESTION,
 		NULL,
 		(char_u *)_("Delete the swap file now?"),
@@ -1701,6 +1704,7 @@ ml_recover(void)
 	{
 		mch_remove(fname_used);
 	}
+#endif
 
 	cmdline_row = msg_row;
     }

--- a/src/memline.c
+++ b/src/memline.c
@@ -1681,6 +1681,8 @@ ml_recover(void)
     }
     else
     {
+	int choice;
+
 	if (curbuf->b_changed)
 	{
 	    msg(_("Recovery completed. You should check if everything is OK."));
@@ -1689,7 +1691,17 @@ ml_recover(void)
 	}
 	else
 	    msg(_("Recovery completed. Buffer contents equals file contents."));
-	msg_puts(_("\nYou may want to delete the .swp file now.\n\n"));
+
+	choice = do_dialog(VIM_QUESTION,
+		NULL,
+		(char_u *)_("Delete the swap file now?"),
+		(char_u *)_("&Yes\n&No"), 1, NULL, FALSE);
+
+	if (choice == 1)
+	{
+		mch_remove(fname_used);
+	}
+
 	cmdline_row = msg_row;
     }
 #ifdef FEAT_CRYPT


### PR DESCRIPTION
When vim crashes and is able to recover edits from a swap file, the swap file is left on the file system. Vim advises to remove it, but this leaves a burden on the user to find and delete the file.

This code change asks the user if the swap file should be deleted. If the user selects that, the swap file is deleted. Fixes #1237