### PR TITLE
print # files to edit message to stderr

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -371,7 +371,7 @@ main
     /* This message comes before term inits, but after setting "silent_mode"
      * when the input is not a tty. */
     if (GARGCOUNT > 1 && !silent_mode)
-	printf(_("%d files to edit\n"), GARGCOUNT);
+	fprintf(stderr, _("%d files to edit\n"), GARGCOUNT);
 
     if (params.want_full_screen && !silent_mode)
     {


### PR DESCRIPTION
Currently there's no way to avoid the
X files to edit
message when starting vim with more than one file to edit.
Except when vim runs in silent mode, but that has further implications.

The 'shortmess' option is not yet initialized, so it cannot be used
here. Therefore print the message to stderr instead of stdout.

Then stderr can be redirected to avoid showing the message.