### PR TITLE
Undofile was not cleaned-up by Test_FileChangedShell_reload()

### DIFF
--- a/src/testdir/test_filechanged.vim
+++ b/src/testdir/test_filechanged.vim
@@ -86,6 +86,7 @@ func Test_FileChangedShell_reload()
 
   au! testreload
   bwipe!
+  call delete(undofile('Xchanged_r'))
   call delete('Xchanged_r')
 endfunc
 


### PR DESCRIPTION
This PR cleans up an undo file ".Xchanged_r.un~" that is left in
"vim/src/testdir/" when running "make test_filechanged".