### PR TITLE
Add support for Pipfiles

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1268,6 +1268,10 @@ au BufNewFile,BufRead *.pyx,*.pxd		setf pyrex
 " Quixote (Python-based web framework)
 au BufNewFile,BufRead *.py,*.pyw,.pythonstartup,.pythonrc,*.ptl,*.pyi  setf python
 
+" Pipenv Pipfiles
+au BufNewFile,BufRead Pipfile.lock	setf json
+au BufNewFile,BufRead Pipfile	setf config
+
 " Radiance
 au BufNewFile,BufRead *.rad,*.mat		setf radiance
 


### PR DESCRIPTION
Pipfiles are generated by [Pipenv](http://github.com/pypa/pipenv) to store Python dependencies. `Pipfile` is in `conf` format while `Pipfile.lock` is stored as `json`.