### PR TITLE
Add syntax highlighting for C11 atomic types

### DIFF
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -297,6 +297,14 @@ if !exists("c_no_c11")
   syn keyword	cType		atomic_int_least8_t atomic_uint_least8_t
   syn keyword	cType		atomic_int_least16_t atomic_uint_least16_t
   syn keyword	cType		atomic_int_least32_t atomic_uint_least32_t
+  syn keyword	cType		atomic_int_least64_t atomic_uint_least64_t
+  syn keyword	cType		atomic_int_fast8_t atomic_uint_fast8_t
+  syn keyword	cType		atomic_int_fast16_t atomic_uint_fast16_t
+  syn keyword	cType		atomic_int_fast32_t atomic_uint_fast32_t
+  syn keyword	cType		atomic_int_fast64_t atomic_uint_fast64_t
+  syn keyword	cType		atomic_intptr_t atomic_uintptr_t
+  syn keyword	cType		atomic_size_t atomic_ptrdiff_t
+  syn keyword	cType		atomic_intmax_t atomic_uintmax_t
 endif
 
 if !exists("c_no_ansi") || exists("c_ansi_constants") || exists("c_gnu")

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -289,6 +289,14 @@ if !exists("c_no_c11")
   syn keyword	cOperator	_Static_assert static_assert
   syn keyword	cStorageClass	_Thread_local thread_local
   syn keyword   cType		char16_t char32_t
+  " C11 atomics
+  syn keyword	cType		atomic_bool atomic_char atomic_schar atomic_uchar
+  syn keyword	Ctype		atomic_short atomic_ushort atomic_int atomic_uint
+  syn keyword	cType		atomic_long atomic_ulong atomic_llong atomic_ullong
+  syn keyword	cType		atomic_char16_t atomic_char32_t atomic_wchar_t
+  syn keyword	cType		atomic_int_least8_t atomic_uint_least8_t
+  syn keyword	cType		atomic_int_least16_t atomic_uint_least16_t
+  syn keyword	cType		atomic_int_least32_t atomic_uint_least32_t
 endif
 
 if !exists("c_no_ansi") || exists("c_ansi_constants") || exists("c_gnu")


### PR DESCRIPTION
Problem:    Syntax highlighting for C11 atomic types is not working
Soltuion:   Added missing cType keywords to runtime/syntax/c.vim