### PR TITLE
Add null checks after memory allocations

### DIFF
--- a/src/beval.c
+++ b/src/beval.c
@@ -127,6 +127,8 @@ get_beval_info(
 #ifdef FEAT_VARTABS
 		vim_free(beval->vts);
 		beval->vts = tabstop_copy(wp->w_buffer->b_p_vts_array);
+        if (wp->w_buffer->b_p_vts_array && (beval->vts == NULL))
+            return FAIL;
 #endif
 		beval->ts = wp->w_buffer->b_p_ts;
 		return OK;

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -636,7 +636,7 @@ crypt_blowfish_decode(
     }
 }
 
-    void
+    int
 crypt_blowfish_init(
     cryptstate_T	*state,
     char_u*		key,
@@ -646,6 +646,8 @@ crypt_blowfish_init(
     int			seed_len)
 {
     bf_state_T	*bfs = (bf_state_T *)alloc_clear(sizeof(bf_state_T));
+    if (bfs == NULL)
+    return FAIL;
 
     state->method_state = bfs;
 
@@ -654,10 +656,12 @@ crypt_blowfish_init(
     bfs->cfb_len = state->method_nr == CRYPT_M_BF ? BF_MAX_CFB_LEN : BF_BLOCK;
 
     if (blowfish_self_test() == FAIL)
-	return;
+	return FAIL;
 
     bf_key_init(bfs, key, salt, salt_len);
     bf_cfb_init(bfs, seed, seed_len);
+
+    return OK;
 }
 
 /*

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -43,7 +43,7 @@ typedef struct {
     int (* self_test_fn)();
 
     // Function pointer for initializing encryption/decryption.
-    void (* init_fn)(cryptstate_T *state, char_u *key,
+    int (* init_fn)(cryptstate_T *state, char_u *key,
 		      char_u *salt, int salt_len, char_u *seed, int seed_len);
 
     /* Function pointers for encoding/decoding from one buffer into another.
@@ -254,9 +254,15 @@ crypt_create(
     int		seed_len)
 {
     cryptstate_T *state = (cryptstate_T *)alloc((int)sizeof(cryptstate_T));
+    if (state == NULL)
+    return state;
 
     state->method_nr = method_nr;
-    cryptmethods[method_nr].init_fn(state, key, salt, salt_len, seed, seed_len);
+    if (cryptmethods[method_nr].init_fn(state, key, salt, salt_len, seed, seed_len) == FAIL)
+    {
+        vim_free(state);
+        return NULL;
+    }
     return state;
 }
 

--- a/src/crypt_zip.c
+++ b/src/crypt_zip.c
@@ -78,7 +78,7 @@ make_crc_tab(void)
 /*
  * Initialize for encryption/decryption.
  */
-    void
+    int
 crypt_zip_init(
     cryptstate_T    *state,
     char_u	    *key,
@@ -92,6 +92,8 @@ crypt_zip_init(
 
     zs = (zip_state_T *)alloc(sizeof(zip_state_T));
     state->method_state = zs;
+    if (zs == NULL)
+    return FAIL;
 
     make_crc_tab();
     zs->keys[0] = 305419896L;
@@ -99,6 +101,8 @@ crypt_zip_init(
     zs->keys[2] = 878082192L;
     for (p = key; *p != NUL; ++p)
 	UPDATE_KEYS_ZIP(zs->keys, (int)*p);
+
+    return OK;
 }
 
 /*

--- a/src/ops.c
+++ b/src/ops.c
@@ -6175,6 +6175,11 @@ handle_viminfo_register(garray_T *values, int force)
     {
 	y_ptr->y_array =
 		   (char_u **)alloc((unsigned)(linecount * sizeof(char_u *)));
+    if (y_ptr->y_array == NULL)
+    {
+        y_ptr->y_size = 0; /* ensure object state is consistent */
+        return;
+    }
 	for (i = 0; i < linecount; i++)
 	{
 	    if (vp[i + 6].bv_allocated)

--- a/src/option.c
+++ b/src/option.c
@@ -13015,6 +13015,8 @@ tabstop_copy(int *oldts)
 	return 0;
 
     newts = (int *) alloc((unsigned) ((oldts[0] + 1) * sizeof(int)));
+    if (newts == NULL)
+    return newts;
     for (t = 0; t <= oldts[0]; ++t)
 	newts[t] = oldts[t];
 

--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -1104,6 +1104,13 @@ split_message(char_u *mesg, pumitem_T **array)
 
 	    /* put indent at the start */
 	    p = alloc(thislen + item->indent * 2 + 1);
+        if (p == NULL)
+        {
+	        for(line = 0; line <= height - 1; ++line)
+	        vim_free((*array)[line].pum_text);
+	        vim_free(*array);
+	        goto failed;
+        }
 	    for (ind = 0; ind < item->indent * 2; ++ind)
 		p[ind] = ' ';
 

--- a/src/proto/blowfish.pro
+++ b/src/proto/blowfish.pro
@@ -1,6 +1,6 @@
 /* blowfish.c */
 void crypt_blowfish_encode(cryptstate_T *state, char_u *from, size_t len, char_u *to);
 void crypt_blowfish_decode(cryptstate_T *state, char_u *from, size_t len, char_u *to);
-void crypt_blowfish_init(cryptstate_T *state, char_u *key, char_u *salt, int salt_len, char_u *seed, int seed_len);
+int crypt_blowfish_init(cryptstate_T *state, char_u *key, char_u *salt, int salt_len, char_u *seed, int seed_len);
 int blowfish_self_test(void);
 /* vim: set ft=c : */

--- a/src/proto/crypt_zip.pro
+++ b/src/proto/crypt_zip.pro
@@ -1,5 +1,5 @@
 /* crypt_zip.c */
-void crypt_zip_init(cryptstate_T *state, char_u *key, char_u *salt, int salt_len, char_u *seed, int seed_len);
+int crypt_zip_init(cryptstate_T *state, char_u *key, char_u *salt, int salt_len, char_u *seed, int seed_len);
 void crypt_zip_encode(cryptstate_T *state, char_u *from, size_t len, char_u *to);
 void crypt_zip_decode(cryptstate_T *state, char_u *from, size_t len, char_u *to);
 /* vim: set ft=c : */


### PR DESCRIPTION
Add null checks when allocating memory in the following files:
src/crypt.c
src/crypt_zip.c
src/blowfish.c
src/ops.c
src/option.c
src/popupmnu.c

This is part of #4174 

I verified that the callers of the functions in question handle NULL properly.