### PR TITLE
Native vim support for displaying search match index like `[n of N]`

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1789,7 +1789,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	'scrolloff'	+ 0		no scroll offset
 	'shelltemp'	- {unchanged}	{set vim default only on resetting 'cp'}
 	'shiftround'	+ off		indent not rounded to shiftwidth
-	'shortmess'	& ""		no shortening of messages
+	'shortmess'	& "S"		no shortening of messages
 	'showcmd'	& off		command characters not shown
 	'showmode'	& off		current mode not shown
 	'sidescrolloff'	+ 0		cursor moves to edge of screen in scroll
@@ -6563,8 +6563,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	function to get the effective shiftwidth value.
 
 						*'shortmess'* *'shm'*
-'shortmess' 'shm'	string	(Vim default "filnxtToO", Vi default: "",
-							POSIX default: "A")
+'shortmess' 'shm'	string	(Vim default "filnxtToOS", Vi default: "S",
+							POSIX default: "AS")
 			global
 	This option helps to avoid all the |hit-enter| prompts caused by file
 	messages, for example  with CTRL-G, and to avoid some other messages.
@@ -6604,6 +6604,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  q	use "recording" instead of "recording @a"
 	  F	don't give the file info when editing a file, like `:silent`
 		was used for the command
+	  S     don't show search count message when searching, e.g.
+	        "[01/05]"
 
 	This gives you the opportunity to avoid that a change between buffers
 	requires you to hit <Enter>, but still gives as useful a message as

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -152,6 +152,17 @@ use <Esc> to abandon the search.
 All matches for the last used search pattern will be highlighted if you set
 the 'hlsearch' option.  This can be suspended with the |:nohlsearch| command.
 
+When 'shortmess' does not include the "S" flag, Vim will automatically show an
+index, on which the cursor is. This can look like this: >
+
+  [01/05]	Cursor is on first of 5 matches
+  [01/>99]      Cursor is on first of more than 99 matches
+  [>99/>99]     Cursor is after 99 match of more than 99 matches
+  [ ?/??]       Unknown how many matches exists, generating the
+                statistics was aborted because of bad performance.
+
+Note: the count does not take offset into account.
+
 When no match is found you get the error: *E486* Pattern not found
 Note that for the |:global| command this behaves like a normal message, for Vi
 compatibility.  For the |:s| command the "e" flag can be used to avoid the

--- a/src/option.c
+++ b/src/option.c
@@ -2449,7 +2449,7 @@ static struct vimoption options[] =
 			    {(char_u *)8L, (char_u *)0L} SCTX_INIT},
     {"shortmess",   "shm",  P_STRING|P_VIM|P_FLAGLIST,
 			    (char_u *)&p_shm, PV_NONE,
-			    {(char_u *)"", (char_u *)"filnxtToO"}
+			    {(char_u *)"S", (char_u *)"filnxtToOS"}
 			    SCTX_INIT},
     {"shortname",   "sn",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_sn, PV_SN,
@@ -3311,7 +3311,7 @@ set_init_1(int clean_arg)
     if (mch_getenv((char_u *)"VIM_POSIX") != NULL)
     {
 	set_string_default("cpo", (char_u *)CPO_ALL);
-	set_string_default("shm", (char_u *)"A");
+	set_string_default("shm", (char_u *)SHM_POSIX);
     }
 
     /*

--- a/src/option.h
+++ b/src/option.h
@@ -203,7 +203,9 @@
 #define SHM_COMPLETIONMENU  'c'		/* completion menu messages */
 #define SHM_RECORDING	'q'		/* short recording message */
 #define SHM_FILEINFO	'F'		/* no file info messages */
-#define SHM_ALL		"rmfixlnwaWtToOsAIcqF" /* all possible flags for 'shm' */
+#define SHM_SEARCHCOUNT  'S'	        /* search stats: '[ 1/10 ]' when searching */
+#define SHM_POSIX       "AS"            /* POSIX value */
+#define SHM_ALL		"rmfixlnwaWtToOsAIcqFS" /* all possible flags for 'shm' */
 
 /* characters for p_go: */
 #define GO_TERMINAL	'!'		/* use terminal for system commands */

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -388,6 +388,7 @@ NEW_TESTS_RES = \
 	test_scriptnames.res \
 	test_scrollbind.res \
 	test_search.res \
+	test_search_stat.res \
 	test_shortpathname.res \
 	test_signals.res \
 	test_signs.res \

--- a/src/testdir/test_search_stat.vim
+++ b/src/testdir/test_search_stat.vim
@@ -1,0 +1,107 @@
+" Tests for search_stats
+"
+" This test is fragile, it might not work interactively, but it works when run
+" as test!
+
+func! Test_search_stat()
+  new
+  set shortmess-=S
+  call append(0, repeat(['foobar', 'foo', 'fooooobar', 'foba', 'foobar'], 10))
+  " 1) match at second line
+  call cursor(1, 1)
+  let @/='fo*\(bar\?\)\?'
+  let g:a = execute(':unsilent :norm! n')
+  let stat='\[02/50\]'
+  let pat = escape(@/, '()*?'). '\s\+'
+  call assert_match(pat.stat, g:a)
+
+  " 2) Match at last line
+  call cursor(line('$')-2, 1)
+  let g:a = execute(':unsilent :norm! n')
+  let stat='\[50/50\]'
+  call assert_match(pat.stat, g:a)
+
+  " 3) No search stat
+  set shortmess+=S
+  call cursor(1, 1)
+  let stat='\[02/50\]'
+  let g:a = execute(':unsilent :norm! n')
+  call assert_notmatch(pat.stat, g:a)
+  set shortmess-=S
+
+  " 4) Many matches
+  call cursor(line('$')-2, 1)
+  let @/='.'
+  let pat = escape(@/, '()*?'). '\s\+'
+  let g:a = execute(':unsilent :norm! n')
+  let stat='\[>99/>99\]'
+  call assert_match(pat.stat, g:a)
+
+  " 5) Many matches
+  call cursor(1, 1)
+  let g:a = execute(':unsilent :norm! n')
+  let stat='\[02/>99\]'
+  call assert_match(pat.stat, g:a)
+
+  " 6) right-left
+  if exists("+rightleft")
+    set rl
+    call cursor(1,1)
+    let @/='foobar'
+    let pat = 'raboof/\s\+'
+    let g:a = execute(':unsilent :norm! n')
+    let stat='\[20/02\]'
+    call assert_match(pat.stat, g:a)
+    set norl
+  endif
+
+  " 7) right-left bottom
+  if exists("+rightleft")
+    set rl
+    call cursor('$',1)
+    let pat = 'raboof?\s\+'
+    let g:a = execute(':unsilent :norm! N')
+    let stat='\[20/20\]'
+    call assert_match(pat.stat, g:a)
+    set norl
+  endif
+
+  " 8) right-left back at top
+  if exists("+rightleft")
+    set rl
+    call cursor('$',1)
+    let pat = 'raboof/\s\+'
+    let g:a = execute(':unsilent :norm! n')
+    let stat='\[20/01\]'
+    call assert_match(pat.stat, g:a)
+    call assert_match('search hit BOTTOM, continuing at TOP', g:a)
+    set norl
+  endif
+
+  " 9) normal, back at top
+  call cursor(1,1)
+  let @/='foobar'
+  let pat = '?foobar\s\+'
+  let g:a = execute(':unsilent :norm! N')
+  let stat='\[20/20\]'
+  call assert_match(pat.stat, g:a)
+  call assert_match('search hit TOP, continuing at BOTTOM', g:a)
+
+  " 10) normal, no match
+  call cursor(1,1)
+  let @/ = 'zzzzzz'
+  let g:a = ''
+  try
+    let g:a = execute(':unsilent :norm! n')
+  catch /^Vim\%((\a\+)\)\=:E486/
+    let stat=''
+    " error message is not redir'ed to g:a, it is empty
+    call assert_true(empty(g:a))
+  catch
+    call assert_false(1)
+  endtry
+
+  " close the window
+  set shortmess+=S
+  bd!
+endfunc


### PR DESCRIPTION
1) output search statistics like requested in vim/vim/#453

When 'shortmess' does not include the "S" flag, Vim will automatically show an
index, on which the cursor is. This can look like this: >

    [01/05]	Cursor is on first of 5 matches
    [01/>99]      Cursor is on first of more than 99 matches
    [>99/>99]     Cursor is after 99 match of more than 99 matches
    [ ?/??]       Unknown how many matches exists, generating the
		statistics was aborted because of bad performance.

Note: the count does not take offset into account.

2) Updated documentation
3) Add tests

This implements issue #453.

History:
Version 8: 20190429
        - Updated for Vim 8.1.1234
        - Adjust searchit() calls
        - Remove FEAT_MBYTE

Version 7: 20181211
        - Updated for Vim 8.1.576
        - Make the stats survive a redraw (after pressing n and cursor
          is moved to a line below the screen)

Version 6: 20170725
        - Updated for Vim 8.0.0993
        - make feature opt-in (`:set shortmess-=S`)
        - add new_test

Version 5:
        - Updated for latest Vim 7.4.2085
        - fix many bugs
        - enabled by default
        - make rightleft work correctly
        - add tests

Version 4:
	- Add Time Limit 20ms

Version 3:
	- Cache values

Version 2:
	- works correctly upwards and downwards
	- works correctly when 'rl' is set
	- works correctly when cmdline is truncated
	- shows first search string and later the stat (once it is available)

Patch:      search_stat
Repository: https://github.com/chrisbra/vim-mq-patches
Vim ticket: https://github.com/vim/vim/issues/453

Copyright & License:
© 2015-2019 C.Brabandt Vim
──────────────────────────────────────────────────────────────────────────