### PR TITLE
print # files to edit message only in verbose mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -376,8 +376,8 @@ main
 #endif
 
     /* This message comes before term inits, but after setting "silent_mode"
-     * when the input is not a tty. */
-    if (GARGCOUNT > 1 && !silent_mode)
+     * when the input is not a tty (suppress with --not-a-term) */
+    if (GARGCOUNT > 1 && !silent_mode && (!is_not_a_term()))
 	printf(_("%d files to edit\n"), GARGCOUNT);
 
     if (params.want_full_screen && !silent_mode)


### PR DESCRIPTION
Currently there's no way to avoid the
X files to edit
message when starting vim with more than one file to edit.
Except when vim runs in silent mode, but that has further implications
(i.e. doesn't work with vimdiff)

The 'shortmess' option is not yet initialized, so it cannot be used
here. Therefore only print the message in verbose mode.