### PR TITLE
Handle negative values in urxvt mouse termcodes

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -4554,6 +4554,7 @@ check_termcode(
 			    /* Skip over the digits, the final char must
 			     * follow. */
 			    for (j = slen - 2; j < len && (isdigit(tp[j])
+							 || tp[j] == '-'
 							 || tp[j] == ';'); ++j)
 				;
 			    ++j;


### PR DESCRIPTION
Urxvt can report negative values for rows and cols in a mouse event termcode (for example, in the case of a mouse drag that extends past the top or left side of a terminal window). The negative sign in such a termcode was preventing it from being properly matched (like ^[64;0;-1M, meant to be matched by ^[64*M); This skips over the negative sign and matches properly.