### PR TITLE
win32: vimdll: Fix multibyte input

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -3141,7 +3141,7 @@ fix_input_buffer(char_u *buf, int len)
 		    /* Win32 console passes modifiers */
 		    && (
 # ifdef VIMDLL
-			gui.in_use ? 1 :
+			gui.in_use ||
 # endif
 			(i < 2 || p[1] != KS_MODIFIER))
 #endif

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -3138,11 +3138,12 @@ fix_input_buffer(char_u *buf, int len)
 		    /* timeout may generate K_CURSORHOLD */
 		    && (i < 2 || p[1] != KS_EXTRA || p[2] != (int)KE_CURSORHOLD)
 #if defined(MSWIN) && (!defined(FEAT_GUI) || defined(VIMDLL))
-# ifdef VIMDLL
-		    && !gui.in_use
-# endif
 		    /* Win32 console passes modifiers */
-		    && (i < 2 || p[1] != KS_MODIFIER)
+		    && (
+# ifdef VIMDLL
+			gui.in_use ? 1 :
+# endif
+			(i < 2 || p[1] != KS_MODIFIER))
 #endif
 		    ))
 	{


### PR DESCRIPTION
I had a report that the VIMDLL patch still has a problem.

Some multibyte characters which include 0x80 cannot be input on gvim.exe
when compiled with `VIMDLL=yes`.  E.g. `、` and `。` cannot be input when
'enc' is utf-8.  This fixes it.