### PR TITLE
Fix usercmd

### DIFF
--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -824,10 +824,10 @@ invalid_count:
 		emsg(_("E179: argument required for -addr"));
 		return FAIL;
 	    }
-	    if (parse_addr_type_arg(val, (int)vallen,  addr_type_arg) == FAIL)
+	    if (parse_addr_type_arg(val, (int)vallen, addr_type_arg) == FAIL)
 		return FAIL;
-	    if (addr_type_arg != ADDR_LINES)
-		*argt |= (ZEROR) ;
+	    if (*addr_type_arg != ADDR_LINES)
+		*argt |= ZEROR;
 	}
 	else
 	{


### PR DESCRIPTION
* Add missing `*` to `addr_type_arg`. Compared different types.
* Remove needless spaces and parentheses.