### PR TITLE
Fix duplicate help tag, and re-generate help tags

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -312,14 +312,6 @@ triggered.  In most cases this should be fine, but if a pattern is in use when
 it's used again it fails.  Usually this means there is something wrong with
 the pattern.
 
-								*E956*
-In very rare cases a regular expression is used recursively.  This can happen
-when executing a pattern takes a long time and when checking for messages on
-channels a callback is invoked that also uses a pattern or an autocommand is
-triggered.  In most cases this should be fine, but if a pattern is in use when
-it's used again it fails.  Usually this means there is something wrong with
-the pattern.
-
 ==============================================================================
 2. The definition of a pattern		*search-pattern* *pattern* *[pattern]*
 					*regular-expression* *regexp* *Pattern*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -1075,6 +1075,7 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 'tag'	options.txt	/*'tag'*
 'tagbsearch'	options.txt	/*'tagbsearch'*
 'tagcase'	options.txt	/*'tagcase'*
+'tagfunc'	options.txt	/*'tagfunc'*
 'taglength'	options.txt	/*'taglength'*
 'tagrelative'	options.txt	/*'tagrelative'*
 'tags'	options.txt	/*'tags'*
@@ -1101,6 +1102,7 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 'textmode'	options.txt	/*'textmode'*
 'textwidth'	options.txt	/*'textwidth'*
 'tf'	options.txt	/*'tf'*
+'tfu'	options.txt	/*'tfu'*
 'tgc'	options.txt	/*'tgc'*
 'tgst'	options.txt	/*'tgst'*
 'thesaurus'	options.txt	/*'thesaurus'*
@@ -2133,6 +2135,8 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 :cabbrev	map.txt	/*:cabbrev*
 :cabc	map.txt	/*:cabc*
 :cabclear	map.txt	/*:cabclear*
+:cabo	quickfix.txt	/*:cabo*
+:cabove	quickfix.txt	/*:cabove*
 :cad	quickfix.txt	/*:cad*
 :caddbuffer	quickfix.txt	/*:caddbuffer*
 :cadde	quickfix.txt	/*:cadde*
@@ -2144,6 +2148,8 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 :cat	eval.txt	/*:cat*
 :catch	eval.txt	/*:catch*
 :cb	quickfix.txt	/*:cb*
+:cbe	quickfix.txt	/*:cbe*
+:cbelow	quickfix.txt	/*:cbelow*
 :cbo	quickfix.txt	/*:cbo*
 :cbottom	quickfix.txt	/*:cbottom*
 :cbuffer	quickfix.txt	/*:cbuffer*
@@ -2491,6 +2497,8 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 :lNf	quickfix.txt	/*:lNf*
 :lNfile	quickfix.txt	/*:lNfile*
 :la	editing.txt	/*:la*
+:lab	quickfix.txt	/*:lab*
+:labove	quickfix.txt	/*:labove*
 :lad	quickfix.txt	/*:lad*
 :laddb	quickfix.txt	/*:laddb*
 :laddbuffer	quickfix.txt	/*:laddbuffer*
@@ -2504,6 +2512,8 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 :lat	undo.txt	/*:lat*
 :later	undo.txt	/*:later*
 :lb	quickfix.txt	/*:lb*
+:lbe	quickfix.txt	/*:lbe*
+:lbelow	quickfix.txt	/*:lbelow*
 :lbo	quickfix.txt	/*:lbo*
 :lbottom	quickfix.txt	/*:lbottom*
 :lbuffer	quickfix.txt	/*:lbuffer*
@@ -3185,6 +3195,9 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 :tag	tagsrch.txt	/*:tag*
 :tags	tagsrch.txt	/*:tags*
 :tc	if_tcl.txt	/*:tc*
+:tcd	editing.txt	/*:tcd*
+:tch	editing.txt	/*:tch*
+:tchdir	editing.txt	/*:tchdir*
 :tcl	if_tcl.txt	/*:tcl*
 :tcld	if_tcl.txt	/*:tcld*
 :tcldo	if_tcl.txt	/*:tcldo*
@@ -3918,7 +3931,7 @@ E232	message.txt	/*E232*
 E233	gui.txt	/*E233*
 E234	options.txt	/*E234*
 E235	options.txt	/*E235*
-E236	options.txt	/*E236*
+E236	gui.txt	/*E236*
 E237	print.txt	/*E237*
 E238	print.txt	/*E238*
 E239	sign.txt	/*E239*
@@ -3926,8 +3939,8 @@ E24	message.txt	/*E24*
 E240	remote.txt	/*E240*
 E241	eval.txt	/*E241*
 E243	if_ole.txt	/*E243*
-E244	options.txt	/*E244*
-E245	options.txt	/*E245*
+E244	gui.txt	/*E244*
+E245	gui.txt	/*E245*
 E246	autocmd.txt	/*E246*
 E247	remote.txt	/*E247*
 E248	remote.txt	/*E248*
@@ -4699,6 +4712,9 @@ E982	terminal.txt	/*E982*
 E983	message.txt	/*E983*
 E984	repeat.txt	/*E984*
 E985	eval.txt	/*E985*
+E986	tagsrch.txt	/*E986*
+E987	tagsrch.txt	/*E987*
+E988	gui_w32.txt	/*E988*
 E99	diff.txt	/*E99*
 E999	repeat.txt	/*E999*
 EX	intro.txt	/*EX*
@@ -6824,6 +6840,8 @@ gui-IME	gui.txt	/*gui-IME*
 gui-clipboard	gui_w32.txt	/*gui-clipboard*
 gui-colors	syntax.txt	/*gui-colors*
 gui-extras	gui.txt	/*gui-extras*
+gui-font	gui.txt	/*gui-font*
+gui-fontwide	gui.txt	/*gui-fontwide*
 gui-footer	debugger.txt	/*gui-footer*
 gui-fork	gui_x11.txt	/*gui-fork*
 gui-functions	usr_41.txt	/*gui-functions*
@@ -6875,8 +6893,8 @@ gui-x11-various	gui_x11.txt	/*gui-x11-various*
 gui.txt	gui.txt	/*gui.txt*
 gui_w32.txt	gui_w32.txt	/*gui_w32.txt*
 gui_x11.txt	gui_x11.txt	/*gui_x11.txt*
-guifontwide_gtk	options.txt	/*guifontwide_gtk*
-guifontwide_win_mbyte	options.txt	/*guifontwide_win_mbyte*
+guifontwide_gtk	gui.txt	/*guifontwide_gtk*
+guifontwide_win_mbyte	gui.txt	/*guifontwide_win_mbyte*
 guu	change.txt	/*guu*
 gv	visual.txt	/*gv*
 gview	starting.txt	/*gview*
@@ -9049,6 +9067,7 @@ tag-binary-search	tagsrch.txt	/*tag-binary-search*
 tag-blocks	motion.txt	/*tag-blocks*
 tag-commands	tagsrch.txt	/*tag-commands*
 tag-details	tagsrch.txt	/*tag-details*
+tag-function	tagsrch.txt	/*tag-function*
 tag-functions	usr_41.txt	/*tag-functions*
 tag-highlight	syntax.txt	/*tag-highlight*
 tag-matchlist	tagsrch.txt	/*tag-matchlist*
@@ -9226,6 +9245,7 @@ test_option_not_set()	eval.txt	/*test_option_not_set()*
 test_override()	eval.txt	/*test_override()*
 test_refcount()	eval.txt	/*test_refcount()*
 test_scrollbar()	eval.txt	/*test_scrollbar()*
+test_setmouse()	eval.txt	/*test_setmouse()*
 test_settime()	eval.txt	/*test_settime()*
 testing	eval.txt	/*testing*
 testing-variable	eval.txt	/*testing-variable*
@@ -9624,6 +9644,7 @@ version8.1	version8.txt	/*version8.1*
 version8.txt	version8.txt	/*version8.txt*
 vi	intro.txt	/*vi*
 vi-differences	vi_diff.txt	/*vi-differences*
+vi-features	vi_diff.txt	/*vi-features*
 vi:	options.txt	/*vi:*
 vi_diff.txt	vi_diff.txt	/*vi_diff.txt*
 vib	motion.txt	/*vib*


### PR DESCRIPTION
Fix a duplicate help tag "E956" which makes the command `helptags ALL` fail. Remove the dup, and also re-generate help tags so they are up-to-date.

The documentation bug was introduced in 9dfa3139198b38b28673e251a3756430065914e9 where another `*E956*` was added.