### PR TITLE
Add XTest_tabpage_cmdheight to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ src/testdir/dostmp/*
 src/testdir/messages
 src/testdir/viminfo
 src/testdir/opt_test.vim
+src/testdir/XTest_tabpage_cmdheight
 runtime/indent/testdir/*.out
 src/memfile_test
 src/json_test


### PR DESCRIPTION
Running `make test` generates `src/testdir/XTest_tabpage_cmdheight`.
Add this to `.gitignore` and ignore it.

```console
$ cat src/testdir/XTest_tabpage_cmdheight
set laststatus=2
set cmdheight=2
tabnew
set cmdheight=3
tabnext
redraw!
echo "hello\nthere"
tabnext
redraw
```