### PR TITLE
Remove test file `XTest_tabpage_cmdheight`

### DIFF
--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -573,7 +573,7 @@ func Test_tabpage_cmdheight()
   call VerifyScreenDump(buf, 'Test_tabpage_cmdheight', {})
 
   call StopVimInTerminal(buf)
-  call delete('XTest_conceal')
+  call delete('XTest_tabpage_cmdheight')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Running `make test` generates `src/testdir/XTest_tabpage_cmdheight`.
I found in the test a code that was deleting the wrong file.
And fixed it.