### PR TITLE
win32: Fix command execution without vimrun.exe

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4827,11 +4827,14 @@ mch_call_shell(
 	}
 	else
 	{
-	    cmdlen = (
+	    cmdlen =
 #ifdef FEAT_GUI_MSWIN
-		(gui.in_use ? (!p_stmp ? 0 : STRLEN(vimrun_path)) : 0) +
+		(gui.in_use ?
+		    (!s_dont_use_vimrun && p_stmp ?
+			STRLEN(vimrun_path) : STRLEN(p_sh) + STRLEN(p_shcf))
+		    : 0) +
 #endif
-		STRLEN(p_sh) + STRLEN(p_shcf) + STRLEN(cmd) + 10);
+		STRLEN(p_sh) + STRLEN(p_shcf) + STRLEN(cmd) + 10;
 
 	    newcmd = lalloc(cmdlen, TRUE);
 	    if (newcmd != NULL)
@@ -4869,9 +4872,19 @@ mch_call_shell(
 								 ? "-s " : "",
 			    p_sh, p_shcf, cmd);
 		else
+# ifdef VIMDLL
+		if (gui.in_use)
+# endif
+		    vim_snprintf((char *)newcmd, cmdlen, "%s %s %s %s %s",
+					   p_sh, p_shcf, p_sh, p_shcf, cmd);
+# ifdef VIMDLL
+		else
+# endif
 #endif
+#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
 		    vim_snprintf((char *)newcmd, cmdlen, "%s %s %s",
 							   p_sh, p_shcf, cmd);
+#endif
 		x = mch_system((char *)newcmd, options);
 		vim_free(newcmd);
 	    }


### PR DESCRIPTION
`:help win32-vimrun` says that:

> If "vimrun" cannot be found, the command is executed directly, but
> then the DOS window closes immediately after the external command
> has finished.

This implies that external commands can be executed even without
vimrun.exe.  However, currently `:echo system('dir')` causes E484 if
vimrun.exe doesn't exist.  The vimrun.exe itself uses `_wsystem()` to
execute the external command.  It means that the command line is parsed
twice by cmd.exe; first by `cmd /c` because of the 'shell' and
'shellcmdflag' options, second by _wsystem() in vimrun.exe.  However, if
the vimrun.exe doesn't exists, the command line is parsed only once.
This difference caused the E484 error.

An easy way to fix this is using `cmd /c cmd /c` to execute external
commands if the vimrun.exe doesn't exist.  The command line is parsed
twice by cmd, so the problem doesn't occur.