### PR TITLE
win32: Fix average font width

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -1455,10 +1455,16 @@ GetFontSize(GuiFont font)
     HWND    hwnd = GetDesktopWindow();
     HDC	    hdc = GetWindowDC(hwnd);
     HFONT   hfntOld = SelectFont(hdc, (HFONT)font);
+    SIZE    size;
     TEXTMETRIC tm;
 
     GetTextMetrics(hdc, &tm);
-    gui.char_width = tm.tmAveCharWidth + tm.tmOverhang;
+    // GetTextMetrics() may not return the right value in tmAveCharWidth
+    // for some fonts.
+    GetTextExtentPoint(hdc,
+	    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+	    52, &size);
+    gui.char_width = (size.cx / 26 + 1) / 2 + tm.tmOverhang;
 
     gui.char_height = tm.tmHeight + p_linespace;
 


### PR DESCRIPTION
It seems that some kind of font doesn't return the right value in
tmAveCharWidth by GetTextMetrics(). It returns about the double width of the
expected value. So the screen width becomes wider. This patch works around it
by calculating the average character size. (The same method has already been
used in another part of gui_w32.c.)

Screenshot before the fix:

<img width="814" alt="ud-font" src="https://user-images.githubusercontent.com/840186/53162806-2898f400-3610-11e9-8472-ee5081972f98.png">