### PR TITLE
Fix: 'extends' of 'listchars' is used despite 'set nolist'.

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -5596,6 +5596,7 @@ win_line(
 
 	/* line continues beyond line end */
 	if (lcs_ext
+		&& wp->w_p_list
 		&& !wp->w_p_wrap
 #ifdef FEAT_DIFF
 		&& filler_todo <= 0

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -110,6 +110,25 @@ func Test_listchars()
   call cursor(1, 1)
   call assert_equal([expected], ScreenLines(1, virtcol('$')))
 
+  " test extends
+  normal ggdG
+  set listchars=extends:Z
+  set nowrap
+  set nolist
+  call append(0, [ repeat('A', &columns + 1) ])
+
+  let expected = repeat('A', &columns)
+
+  redraw!
+  call cursor(1, 1)
+  call assert_equal([expected], ScreenLines(1, &columns))
+
+  set list
+  let expected = expected[:-2] . 'Z'
+  redraw!
+  call cursor(1, 1)
+  call assert_equal([expected], ScreenLines(1, &columns))
+
   enew!
   set listchars& ff&
 endfunc


### PR DESCRIPTION
Hi Bram and list,

How to reproduce:
- Start Vim with some settings.
  $ vim --clean +"set nowrap listchars=extends:Z"

- Append line that colums longer than 'columns'. 
  :call append(0, repeat('A', &columns + 1))

Expected behavior:
- Screen line's last columns never use 'extends'(Z).

Actual behavior:
- Use 'extends'(Z) despite 'set nolist'.


I wrote a patch and test.
Check it out.

NOTE:
This issue was reported by Hiroyuki Yoshinaga.
https://github.com/vim-jp/issues/issues/1261 (Japanese)

--
Best regards,
Hirohito Higashi (h_east)