### PR TITLE
win32: vimdll: Some error messages are not shown on gvim.exe

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -4827,6 +4827,10 @@ ole_error(char *arg)
 {
     char buf[IOSIZE];
 
+# ifdef VIMDLL
+    gui.in_use = mch_is_gui_executable();
+# endif
+
     /* Can't use emsg() here, we have not finished initialisation yet. */
     vim_snprintf(buf, IOSIZE,
 	    _("E243: Argument not supported: \"-%s\"; Use the OLE version."),

--- a/src/main.c
+++ b/src/main.c
@@ -178,6 +178,8 @@ main
 #ifdef VIMDLL
     // Check if the current executable file is for the GUI subsystem.
     gui.starting = mch_is_gui_executable();
+#elif defined(FEAT_GUI_MSWIN)
+    gui.starting = TRUE;
 #endif
 
 #ifdef FEAT_CLIENTSERVER
@@ -3240,6 +3242,14 @@ mainerr(
 {
 #if defined(UNIX) || defined(VMS)
     reset_signals();		/* kill us with CTRL-C here, if you like */
+#endif
+
+    // If this is a Windows GUI executable, show an error dialog box.
+#ifdef VIMDLL
+    gui.in_use = mch_is_gui_executable();
+#endif
+#ifdef FEAT_GUI_MSWIN
+    gui.starting = FALSE;   // Needed to show as error.
 #endif
 
     init_longVersion();

--- a/src/message.c
+++ b/src/message.c
@@ -2977,7 +2977,7 @@ mch_errmsg(char *str)
     int		len;
 #endif
 
-#if (defined(UNIX) || defined(FEAT_GUI)) && (!defined(ALWAYS_USE_GUI) || !defined(VIMDLL))
+#if (defined(UNIX) || defined(FEAT_GUI)) && !defined(ALWAYS_USE_GUI) && !defined(VIMDLL)
     /* On Unix use stderr if it's a tty.
      * When not going to start the GUI also use stderr.
      * On Mac, when started from Finder, stderr is the console. */
@@ -3080,7 +3080,7 @@ mch_msg_c(char *str)
     void
 mch_msg(char *str)
 {
-#if (defined(UNIX) || defined(FEAT_GUI)) && (!defined(ALWAYS_USE_GUI) || !defined(VIMDLL))
+#if (defined(UNIX) || defined(FEAT_GUI)) && !defined(ALWAYS_USE_GUI) && !defined(VIMDLL)
     /* On Unix use stdout if we have a tty.  This allows "vim -h | more" and
      * uses mch_errmsg() when started from the desktop.
      * When not going to start the GUI also use stdout.


### PR DESCRIPTION
Some error messages output via `mainerr()` in main.c are not shown or just
shown as informative messages when gvim is compiled with VIMDLL.

When `mainerr()` is called from `early_arg_scan()`, messages are not shown
at all.  This is because both `gui.starting` and `gui.in_use` are FALSE,
so `mch_errmsg()` tries to output the message to stderr and a dialog box
is not shown.
E.g.: `gvim --servername` shows nothing.
It is the same for the `ole_error()` in gui_w32.c.

When `mainerr()` is called from `command_line_scan()`, messages are shown
as non-error messages.  This is because `gui.starting` is set, and
`display_errors()` in os_mswin.c checks it.  When the flag is set, the
dialog box is shown as an informative dialog, not an error dialog.
E.g.: `gvim --windowid` opens an informative dialog.

To work around them, this PR sets `gui.in_use` and unsets `gui.starting`
at the top of the `mainerr()`.

This also fixes that `gvim --serverlist` opened an error dialog when
compiled without VIMDLL.  It is not an error, so it should be shown
as an informative dialog.  Set `gui.starting` earlier (before
`exec_on_server()`) on non-VIMDLL to show as an informative dialog.

Also fixes wrong conditions in messages.c.
E.g.: `gvim --servername` shows nothing because of this even without
VIMDLL.