### PR TITLE
Add per-window and per-tabpage previous directory

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1315,6 +1315,10 @@ present in 'cpoptions' and "!" is not used in the command.
 							*:tch* *:tchdir*
 :tch[dir][!]		Same as |:tcd|.
 
+							*:tcd-*
+:tcd[!] -		Change to the previous current directory (before the
+			previous ":tcd {path}" command).
+
 							*:lc* *:lcd*
 :lc[d][!] {path}	Like |:cd|, but only set the current directory when
 			the cursor is in the current window.  The current
@@ -1323,6 +1327,10 @@ present in 'cpoptions' and "!" is not used in the command.
 
 							*:lch* *:lchdir*
 :lch[dir][!]		Same as |:lcd|.
+
+							*:lcd-*
+:lcd[!] -		Change to the previous current directory (before the
+			previous ":lcd {path}" command).
 
 							*:pw* *:pwd* *E187*
 :pw[d]			Print the current directory name.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2153,7 +2153,10 @@ f_chdir(typval_T *argvars, typval_T *rettv)
     rettv->vval.v_string = NULL;
 
     if (argvars[0].v_type != VAR_STRING)
+    {
+	emsg(_(e_invarg));
 	return;
+    }
 
     // Return the current directory
     cwd = alloc(MAXPATHL);

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7536,6 +7536,19 @@ free_cd_dir(void)
 #endif
 
 /*
+ * Get the previous directory for the given chdir scope.
+ */
+    static char_u *
+get_prevdir(cdscope_T scope)
+{
+    if (scope == CDSCOPE_WINDOW)
+	return curwin->w_prevdir;
+    else if (scope == CDSCOPE_TABPAGE)
+	return curtab->tp_prevdir;
+    return prev_dir;
+}
+
+/*
  * Deal with the side effects of changing the current directory.
  * When 'scope' is CDSCOPE_TABPAGE then this was after an ":tcd" command.
  * When 'scope' is CDSCOPE_WINDOW then this was after an ":lcd" command.
@@ -7549,10 +7562,12 @@ post_chdir(cdscope_T scope)
     VIM_CLEAR(curwin->w_localdir);
     if (scope != CDSCOPE_GLOBAL)
     {
-	/* If still in global directory, need to remember current
-	 * directory as global directory. */
-	if (globaldir == NULL && prev_dir != NULL)
-	    globaldir = vim_strsave(prev_dir);
+	char_u	*pdir = get_prevdir(scope);
+
+	// If still in global directory, need to remember current
+	// directory as global directory.
+	if (globaldir == NULL && pdir != NULL)
+	    globaldir = vim_strsave(pdir);
 	/* Remember this local directory for the window. */
 	if (mch_dirname(NameBuff, MAXPATHL) == OK)
 	{
@@ -7563,11 +7578,8 @@ post_chdir(cdscope_T scope)
 	}
     }
     else
-    {
-	/* We are now in the global directory, no need to remember its
-	 * name. */
+	// We are now in the global directory, no need to remember its name.
 	VIM_CLEAR(globaldir);
-    }
 
     shorten_fnames(TRUE);
 }
@@ -7586,6 +7598,7 @@ changedir_func(
 	cdscope_T	scope)
 {
     char_u	*tofree;
+    char_u	*pdir = NULL;
     int		dir_differs;
     int		retval = FALSE;
 
@@ -7601,20 +7614,29 @@ changedir_func(
     // ":cd -": Change to previous directory
     if (STRCMP(new_dir, "-") == 0)
     {
-	if (prev_dir == NULL)
+	pdir = get_prevdir(scope);
+	if (pdir == NULL)
 	{
 	    emsg(_("E186: No previous directory"));
 	    return FALSE;
 	}
-	new_dir = prev_dir;
+	new_dir = pdir;
     }
 
+    // Free the previous directory
+    tofree = get_prevdir(scope);
+
     // Save current directory for next ":cd -"
-    tofree = prev_dir;
     if (mch_dirname(NameBuff, MAXPATHL) == OK)
-	prev_dir = vim_strsave(NameBuff);
+	pdir = vim_strsave(NameBuff);
     else
-	prev_dir = NULL;
+	pdir = NULL;
+    if (scope == CDSCOPE_WINDOW)
+	curwin->w_prevdir = pdir;
+    else if (scope == CDSCOPE_TABPAGE)
+	curtab->tp_prevdir = pdir;
+    else
+	prev_dir = pdir;
 
 #if defined(UNIX) || defined(VMS)
     // for UNIX ":cd" means: go to home directory
@@ -7635,8 +7657,8 @@ changedir_func(
 	new_dir = NameBuff;
     }
 #endif
-    dir_differs = new_dir == NULL || prev_dir == NULL
-	|| pathcmp((char *)prev_dir, (char *)new_dir, -1) != 0;
+    dir_differs = new_dir == NULL || pdir == NULL
+	|| pathcmp((char *)pdir, (char *)new_dir, -1) != 0;
     if (new_dir == NULL || (dir_differs && vim_chdir(new_dir)))
 	emsg(_(e_failed));
     else

--- a/src/structs.h
+++ b/src/structs.h
@@ -2728,6 +2728,8 @@ struct tabpage_S
 
     char_u	    *tp_localdir;	// absolute path of local directory or
 					// NULL
+    char_u	    *tp_prevdir;	// previous directory
+
 #ifdef FEAT_DIFF
     diff_T	    *tp_first_diff;
     buf_T	    *(tp_diffbuf[DB_COUNT]);
@@ -3116,6 +3118,7 @@ struct window_S
 
     char_u	*w_localdir;	    // absolute path of local directory or
 				    // NULL
+    char_u	*w_prevdir;	    // previous directory
 #ifdef FEAT_MENU
     vimmenu_T	*w_winbar;	    // The root of the WinBar menu hierarchy.
     winbar_item_T *w_winbar_items;  // list of items in the WinBar

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -101,6 +101,70 @@ func Test_chdir_func()
   call assert_fails("call chdir('dir-abcd')", 'E472:')
   silent! let d = chdir("dir_abcd")
   call assert_equal("", d)
+  call assert_fails("call chdir({})", 'E474:')
+
+  only | tabonly
+  exe 'cd ' . topdir
+  call delete('Xdir', 'rf')
+endfunc
+
+" Test for changing to the previous directory '-'
+func Test_prev_dir()
+  let topdir = getcwd()
+  call mkdir('Xdir/a/b/c', 'p')
+
+  " Create a few tabpages and windows with different directories
+  new | only
+  tabnew | new
+  tabnew
+  tabfirst
+  cd Xdir
+  tabnext | wincmd t
+  tcd a
+  wincmd w
+  lcd b
+  tabnext
+  tcd a/b/c
+
+  " Change to the previous directory twice in all the windows.
+  tabfirst
+  cd - | cd -
+  tabnext | wincmd t
+  tcd - | tcd -
+  wincmd w
+  lcd - | lcd -
+  tabnext
+  tcd - | tcd -
+
+  " Check the directory of all the windows
+  tabfirst
+  call assert_equal('Xdir', fnamemodify(getcwd(), ':t'))
+  tabnext | wincmd t
+  call assert_equal('a', fnamemodify(getcwd(), ':t'))
+  wincmd w
+  call assert_equal('b', fnamemodify(getcwd(), ':t'))
+  tabnext
+  call assert_equal('c', fnamemodify(getcwd(), ':t'))
+
+  " Change to the previous directory using chdir()
+  tabfirst
+  call chdir("-") | call chdir("-")
+  tabnext | wincmd t
+  call chdir("-") | call chdir("-")
+  wincmd w
+  call chdir("-") | call chdir("-")
+  tabnext
+  call chdir("-") | call chdir("-")
+
+  " Check the directory of all the windows
+  tabfirst
+  call assert_equal('Xdir', fnamemodify(getcwd(), ':t'))
+  tabnext | wincmd t
+  call assert_equal('a', fnamemodify(getcwd(), ':t'))
+  wincmd w
+  call assert_equal('b', fnamemodify(getcwd(), ':t'))
+  tabnext
+  call assert_equal('c', fnamemodify(getcwd(), ':t'))
 
   only | tabonly
   exe 'cd ' . topdir

--- a/src/window.c
+++ b/src/window.c
@@ -3701,6 +3701,7 @@ free_tabpage(tabpage_T *tp)
 #endif
 
     vim_free(tp->tp_localdir);
+    vim_free(tp->tp_prevdir);
 
 #ifdef FEAT_PYTHON
     python_tabpage_free(tp);
@@ -4821,6 +4822,7 @@ win_free(
 	vim_free(wp->w_tagstack[i].tagname);
 
     vim_free(wp->w_localdir);
+    vim_free(wp->w_prevdir);
 
     /* Remove the window from the b_wininfo lists, it may happen that the
      * freed memory is re-used for another window. */


### PR DESCRIPTION

Support a separate previous directory for windows and tab pages with
local directories (:lcd and :tcd).
