### PR TITLE
Problem: Horizontal splits cause both windows to jump downwards (#3973).

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -743,6 +743,32 @@ func Test_relative_cursor_second_line_after_resize()
   let &so = so_save
 endfunc
 
+func Test_split_noscroll()
+  new
+  only
+
+  " Make sure windows can hold 20 lines after split.
+  for i in range(1, 41)
+    wincmd +
+    redraw!
+  endfor
+
+  call setline (1, range(1, 20))
+  normal 100%
+  split
+
+  1wincmd w
+  let winid1 = win_getid()
+  let info1 = getwininfo(winid1)[0]
+
+  2wincmd w
+  let winid2 = win_getid()
+  let info2 = getwininfo(winid2)[0]
+
+  call assert_equal(1, info1.topline)
+  call assert_equal(1, info2.topline)
+endfunc
+
 " Tests for the winnr() function
 func Test_winnr()
   only | tabonly

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -744,11 +744,12 @@ func Test_relative_cursor_second_line_after_resize()
 endfunc
 
 func Test_split_noscroll()
+  let so_save = &so
   new
   only
 
-  " Make sure windows can hold 20 lines after split.
-  for i in range(1, 41)
+  " Make sure windows can hold all content after split.
+  for i in range(1, 50)
     wincmd +
     redraw!
   endfor
@@ -767,6 +768,15 @@ func Test_split_noscroll()
 
   call assert_equal(1, info1.topline)
   call assert_equal(1, info2.topline)
+
+  " Restore original state.
+  for i in range(1, 50)
+    wincmd -
+    redraw!
+  endfor
+  only!
+  bwipe!
+  let &so = so_save
 endfunc
 
 " Tests for the winnr() function

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -749,12 +749,12 @@ func Test_split_noscroll()
   only
 
   " Make sure windows can hold all content after split.
-  for i in range(1, 50)
+  for i in range(1, 20)
     wincmd +
     redraw!
   endfor
 
-  call setline (1, range(1, 20))
+  call setline (1, range(1, 8))
   normal 100%
   split
 
@@ -770,7 +770,7 @@ func Test_split_noscroll()
   call assert_equal(1, info2.topline)
 
   " Restore original state.
-  for i in range(1, 50)
+  for i in range(1, 20)
     wincmd -
     redraw!
   endfor

--- a/src/window.c
+++ b/src/window.c
@@ -5827,9 +5827,13 @@ scroll_to_fraction(win_T *wp, int prev_height)
     int		sline, line_size;
     int		height = wp->w_height;
 
-    // Don't change w_topline when height is zero.  Don't set w_topline when
-    // 'scrollbind' is set and this isn't the current window.
-    if (height > 0 && (!wp->w_p_scb || wp == curwin))
+    // Don't change w_topline in any of these cases:
+    // - window height is 0
+    // - 'scrollbind' is set and this isn't the current window
+    // - window height is sufficient to display the whole buffer
+    if (height > 0
+        && (!wp->w_p_scb || wp == curwin)
+        && (height < wp->w_buffer->b_ml.ml_line_count))
     {
 	/*
 	 * Find a value for w_topline that shows the cursor at the same


### PR DESCRIPTION
Solution: When splitting, don't scroll if the buffer fits in the window.