### PR TITLE
syntax/javascript: Do not override syn sync when included

### DIFF
--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -77,10 +77,10 @@ else
     syn match	javaScriptParens	   "[()]"
 endif
 
-syn sync fromstart
-syn sync maxlines=100
-
 if main_syntax == "javascript"
+  syn sync fromstart
+  syn sync maxlines=100
+
   syn sync ccomment javaScriptComment
 endif
 


### PR DESCRIPTION
It's very surprising that including syntax/javascript.vim (or some other
syntax that includes it, e.g. syntax/html.vim) sets some syn sync
parameters (fromstart, maxlines). Additionally, there's no point in
overriding these unless javascript.vim also tells vim how to sync, which
is correctly guarded by main_syntax already.

Be a good citizen and avoid touching syn sync unless
main_syntax == "javascript".