### PR TITLE
Use the last message in python exception as the Vim exception

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -406,13 +406,18 @@ write_output(OutputObject *self, PyObject *string)
     Py_ssize_t	len = 0;
     char	*str = NULL;
     int		error = self->error;
+    int		save_emsg_severe = 0;
 
     if (!PyArg_Parse(string, "et#", ENC_OPT, &str, &len))
 	return -1;
 
     Py_BEGIN_ALLOW_THREADS
     Python_Lock_Vim();
+    save_emsg_severe = emsg_severe;
+    if (error)
+	emsg_severe = TRUE;
     writer((writefn)(error ? emsg : msg), (char_u *)str, len);
+    emsg_severe = save_emsg_severe;
     Python_Release_Vim();
     Py_END_ALLOW_THREADS
     PyMem_Free(str);

--- a/src/testdir/test86.ok
+++ b/src/testdir/test86.ok
@@ -91,7 +91,7 @@ pyeval("None") = v:none
 0.0
 "\0":	Vim(let):E859:
 {"\0": 1}:	Vim(let):E859:
-undefined_name:	Vim(let):Trace
+undefined_name:	Vim(let):NameE
 vim:	Vim(let):E859:
 [1]
 [1, 10, 11, 10, 11, 10, 11, 10, 11, 10, 11, 10, 1]

--- a/src/testdir/test87.ok
+++ b/src/testdir/test87.ok
@@ -91,7 +91,7 @@ py3eval("None") = v:none
 0.0
 "\0":	Vim(let):E859:
 {"\0": 1}:	Vim(let):E859:
-undefined_name:	Vim(let):Trace
+undefined_name:	Vim(let):NameE
 vim:	Vim(let):E859:
 [1]
 [1, 10, 11, 10, 11, 10, 11, 10, 11, 10, 11, 10, 1]

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -160,3 +160,11 @@ func Test_Write_To_Current_Buffer_Fixes_Cursor_Str()
 
   bwipe!
 endfunction
+
+func Test_Catch_Exception_Message()
+  try
+    py raise RuntimeError( 'TEST' )
+  catch /.*/
+    call assert_match( '^Vim(.*):RuntimeError: TEST$', v:exception )
+  endtry
+endfunc

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -160,3 +160,11 @@ func Test_Write_To_Current_Buffer_Fixes_Cursor_Str()
 
   bwipe!
 endfunction
+
+func Test_Catch_Exception_Message()
+  try
+    py3 raise RuntimeError( 'TEST' )
+  catch /.*/
+    call assert_match( '^Vim(.*):RuntimeError: TEST$', v:exception )
+  endtry
+endfunc

--- a/src/testdir/test_pyx2.vim
+++ b/src/testdir/test_pyx2.vim
@@ -72,3 +72,11 @@ func Test_pyxfile()
     call assert_match(s:py3pattern, split(var)[0])
   endif
 endfunc
+
+func Test_Catch_Exception_Message()
+  try
+    pyx raise RuntimeError( 'TEST' )
+  catch /.*/
+    call assert_match( '^Vim(.*):RuntimeError: TEST$', v:exception )
+  endtry
+endfunc

--- a/src/testdir/test_pyx3.vim
+++ b/src/testdir/test_pyx3.vim
@@ -72,3 +72,11 @@ func Test_pyxfile()
     call assert_match(s:py2pattern, split(var)[0])
   endif
 endfunc
+
+func Test_Catch_Exception_Message()
+  try
+    pyx raise RuntimeError( 'TEST' )
+  catch /.*/
+    call assert_match( '^Vim(.*):RuntimeError: TEST$', v:exception )
+  endtry
+endfunc


### PR DESCRIPTION
Python exception traces are printed bottom-up, with the actual exception
type and message last. However, the way that 'emsg' works is that when
it decides to raise an exception, it treats the _first_ message in a
series of messages within a try as the exception text.

So for python, when printing out the exception trace (or any other error
for that matter), we tell emsg that the message is severe. This forces
it to keep replacing the "exception" message with the traced message.
The last such message (i.e. the one we want) ends up in the Vim exception
message.

Concretely: previously, v:exception would always be "Traceback, most
recent call last", now it's something more like "RuntimeError: this is
the error message", which is much more useful.

This is particularly useful when running Vim's own tests, or tests based
on that, where the actual emesg is suppressed due to the try/catch
handling of the test infrastructure.

RFC because I'm not 100% sure that this won't have unintended side-effects. I don't _think_ it will, but comments welcome!