### PR TITLE
xxd: allow printing bits low order first with -L

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -231,6 +231,7 @@ exit_with_usage(void)
   fprintf(stderr, "    -h          print this summary.\n");
   fprintf(stderr, "    -i          output in C include file style.\n");
   fprintf(stderr, "    -l len      stop after <len> octets.\n");
+  fprintf(stderr, "    -L          print bits in little-endian order (low order first). Implies -b.\n");
   fprintf(stderr, "    -o off      add <off> to the displayed file position.\n");
   fprintf(stderr, "    -ps         output in postscript plain hexdump style.\n");
   fprintf(stderr, "    -r          reverse operation: convert (or patch) hexdump into binary.\n");
@@ -460,6 +461,7 @@ main(int argc, char *argv[])
   int c, e, p = 0, relseek = 1, negseek = 0, revert = 0;
   int cols = 0, nonzero = 0, autoskip = 0, hextype = HEX_NORMAL, capitalize = 0;
   int ebcdic = 0;
+  int loworder = 0;
   int octspergrp = -1;	/* number of octets grouped in output */
   int grplen;		/* total chars per octet group */
   long length = -1, n = 0, seekoff = 0;
@@ -599,6 +601,11 @@ main(int argc, char *argv[])
 	      argc--;
 	    }
 	}
+      else if (!STRNCMP(pp, "-L", 2))
+        {
+          hextype = HEX_BITS;
+          loworder = 1;
+        }
       else if (!strcmp(pp, "--"))	/* end of options */
 	{
 	  argv++;
@@ -838,10 +845,17 @@ main(int argc, char *argv[])
       else /* hextype == HEX_BITS */
 	{
 	  int i;
-
 	  c = (addrlen + 1 + (grplen * p) / octspergrp) - 1;
-	  for (i = 7; i >= 0; i--)
-	    l[++c] = (e & (1 << i)) ? '1' : '0';
+          if (loworder)
+            {
+              for (i = 0; i <= 7; i++)
+                l[++c] = (e & (1 << i)) ? '1' : '0';
+            }
+          else
+            {
+              for (i = 7; i >= 0; i--)
+                l[++c] = (e & (1 << i)) ? '1' : '0';
+            }
 	}
       if (e)
 	nonzero++;


### PR DESCRIPTION
Hi, 

Conventionally when printing a hex dump each byte is printed as an ordinary pair of hexadecimal numbers for easy reading. This makes sense, since for example 0x61 is the ASCII 'a'. Sometimes however one needs a binary representation, for instance when debugging bitfields. Currently in this case xxd will print 01100001, the binary representation of 0x61. This also makes some sense. Most of us read from left to right and since bits aren't usually individually addressable, simply showing the binary representation of the whole byte is a reasonable default.

However, there is some reason to want to print the bits in the opposite order. On modern little endian systems, [the bits are stored](https://www.linuxjournal.com/article/6788) in the CPU in "little endian" bit order, or low order first. (That is, the least significant bit in the least significant byte is the one that comes first.) Likewise, even though the C standard says that the layout of structs is an implementation detail, the well-known compilers also appear to store data low order first on little endian systems. [GCC for example.](https://gcc.gnu.org/ml/gcc/2004-09/msg00527.html) Lastly, some networking hardware also sends data over the wire with the low order bit coming first.

I've occasionally encountered situations where it would be nice to see the way some bit of data *really* looks on the disk or in memory - e.g. when trying to parse an obscure format with bitfields that stretch across multiple bytes. Plus I admit reading little endian hex dumps with the bits printed in big endian order throws me off at times. I couldn't find any open source tools that would do this.

So in short, I added support to xxd. Thanks for reading - if you're interested in pulling this I'm happy to make changes as needed.

Sample output:

    % ./xxd -b endian.txt
    00000000: 00100010 00111000 01001110 00001010                    "8N.
    % ./xxd -L endian.txt
    00000000: 01000100 00011100 01110010 01010000                    "8N.