### PR TITLE
Fix no 'W' character when top-bottom and more than 99 matches

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -5012,7 +5012,7 @@ search_stat(
 	}
 
 	len = STRLEN(t);
-	if (show_top_bot_msg && len + 3 < SEARCH_STAT_BUF_LEN)
+	if (show_top_bot_msg && len + 2 < SEARCH_STAT_BUF_LEN)
 	{
 	    STRCPY(t + len, " W");
 	    len += 2;

--- a/src/testdir/test_search_stat.vim
+++ b/src/testdir/test_search_stat.vim
@@ -40,11 +40,19 @@ func! Test_search_stat()
   let g:a = execute(':unsilent :norm! n')
   let stat = '\[>99/>99\]'
   call assert_match(pat .. stat, g:a)
+  call cursor(line('$'), 1)
+  let g:a = execute(':unsilent :norm! n')
+  let stat = '\[1/>99\] W'
+  call assert_match(pat .. stat, g:a)
 
   " 5) Many matches
   call cursor(1, 1)
   let g:a = execute(':unsilent :norm! n')
   let stat = '\[2/>99\]'
+  call assert_match(pat .. stat, g:a)
+  call cursor(1, 1)
+  let g:a = execute(':unsilent :norm! N')
+  let stat = '\[>99/>99\] W'
   call assert_match(pat .. stat, g:a)
 
   " 6) right-left


### PR DESCRIPTION
I found that 'W' character for search count message is not shown if there are more than 99 matches and direction is backward due to wrong (?) string length check.

How to recreate:

1. vim -Nu NONE
1. :set wrapscan
1. :set shortmess-=S
1. 100ifoo\<CR>\<ESC>
1. gg
1. ?foo<CR>