### PR TITLE
Add some output processing after running the tests

### DIFF
--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -54,7 +54,7 @@ report:
 	@echo 'Test results:'
 	@/bin/sh -c 'cat test_result.log'
 	@/bin/sh -c "if test -f test.log; \
-		then cat test.log; echo TEST FAILURE; exit 1; \
+		then echo TEST FAILURE; exit 1; \
 		else echo ALL DONE; \
 		fi"
 

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -49,8 +49,10 @@ gui:	nolog $(SCRIPTS_FIRST) $(SCRIPTS) $(SCRIPTS_GUI) newtests report
 benchmark: $(SCRIPTS_BENCH)
 
 report:
+	$(RUN_VIMTEST) $(NO_INITS) -S result.vim messages $(REDIR_TEST_TO_NULL)
 	@echo
 	@echo 'Test results:'
+	@/bin/sh -c 'cat test_result.log'
 	@/bin/sh -c "if test -f test.log; \
 		then cat test.log; echo TEST FAILURE; exit 1; \
 		else echo ALL DONE; \
@@ -77,7 +79,7 @@ RM_ON_START = tiny.vim small.vim mbyte.vim mzscheme.vim test.ok benchmark.out
 RUN_VIM = VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(VALGRIND) $(VIMPROG) -f $(GUI_FLAG) -u unix.vim $(NO_INITS) -s dotest.in
 
 clean:
-	-rm -rf *.out *.failed *.res *.rej *.orig opt_test.vim test.log messages $(RM_ON_RUN) $(RM_ON_START) valgrind.*
+	-rm -rf *.out *.failed *.res *.rej *.orig opt_test.vim test*.log messages $(RM_ON_RUN) $(RM_ON_START) valgrind.*
 
 test1.out: test1.in
 	-rm -rf $*.failed $(RM_ON_RUN) $(RM_ON_START) wrongtermsize

--- a/src/testdir/result.vim
+++ b/src/testdir/result.vim
@@ -1,0 +1,38 @@
+if 1 " eval feature
+  set nocp
+  func CountExecuted(match)
+    let g:executed += (a:match+0)
+  endfunc
+
+  func! CountSkipped(match)
+    let g:skipped += 1
+    call extend(g:skipped_output, ["\t".a:match])
+  endfunc
+
+  let g:executed=0
+  let g:skipped=0
+  let g:skipped_output=[]
+  let g:failed_output=[]
+  let output = [ "",
+        \ "Test results: " . strftime('%Y%m%d %H:%M:%S'),
+        \ "-------------------------------"]
+
+  %s/^Executed\s\+\zs\d\+\ze\s\+tests/\=CountExecuted(submatch(0))/gn
+  %s/^SKIPPED \zs.*/\=CountSkipped(submatch(0))/gn
+
+  call extend(output, [" Skipped: ". g:skipped. " Tests"])
+  call extend(output, ["Executed: ". g:executed. " Tests", ""])
+  call extend(output, [" Skipped:"])
+  call extend(output, skipped_output)
+  if filereadable('test.log')
+    call extend(output, ["", "Failures: "])
+    let failed_output = filter(readfile('test.log'), { v,k -> !empty(k)})
+    call extend(output, map(failed_output, { v,k -> "\t".k}))
+  endif
+
+  call writefile(output, 'test_result.log')
+  q!
+endif
+r test.log
+w test_result.log
+q!

--- a/src/testdir/result.vim
+++ b/src/testdir/result.vim
@@ -1,38 +1,48 @@
 if 1 " eval feature
   set nocp
-  func CountExecuted(match)
-    let g:executed += (a:match+0)
-  endfunc
-
-  func! CountSkipped(match)
-    let g:skipped += 1
-    call extend(g:skipped_output, ["\t".a:match])
+  func Count(match, type)
+    if a:type ==# 'executed'
+      let g:executed += (a:match+0)
+    elseif a:type ==# 'failed'
+      let g:failed = a:match+0
+    elseif a:type ==# 'skipped'
+      let g:skipped += 1
+      call extend(g:skipped_output, ["\t".a:match])
+    endif
   endfunc
 
   let g:executed=0
   let g:skipped=0
+  let g:failed=0
   let g:skipped_output=[]
   let g:failed_output=[]
   let output = [ "",
         \ "Test results: " . strftime('%Y%m%d %H:%M:%S'),
         \ "-------------------------------"]
 
-  %s/^Executed\s\+\zs\d\+\ze\s\+tests/\=CountExecuted(submatch(0))/gn
-  %s/^SKIPPED \zs.*/\=CountSkipped(submatch(0))/gn
+  try
+    %s/^Executed\s\+\zs\d\+\ze\s\+tests/\=Count(submatch(0),'executed')/egn
+    %s/^SKIPPED \zs.*/\=Count(submatch(0), 'skipped')/egn
+    %s/^\(\d\+\)\s\+FAILED:/\=Count(submatch(1), 'failed')/egn
 
-  call extend(output, [" Skipped: ". g:skipped. " Tests"])
-  call extend(output, ["Executed: ". g:executed. " Tests", ""])
-  call extend(output, [" Skipped:"])
-  call extend(output, skipped_output)
-  if filereadable('test.log')
-    call extend(output, ["", "Failures: "])
-    let failed_output = filter(readfile('test.log'), { v,k -> !empty(k)})
-    call extend(output, map(failed_output, { v,k -> "\t".k}))
-  endif
+    call extend(output, ["Executed: ". printf("%5d", g:executed). " Tests"])
+    call extend(output, [" Skipped: ". printf("%5d", g:skipped).  " Tests"])
+    call extend(output, ["  Failed: ". printf("%5d", g:failed).   " Tests", ""])
+    call extend(output, [" Skipped:"])
+    call extend(output, skipped_output)
+    if filereadable('test.log')
+      call extend(output, ["", "Failures: "])
+      let failed_output = filter(readfile('test.log'), { v,k -> !empty(k)})
+      call extend(output, map(failed_output, { v,k -> "\t".k}) + [""])
+    endif
 
-  call writefile(output, 'test_result.log')
-  q!
-endif
+  catch  " Catch-all
+  finally
+    call writefile(output, 'test_result.log')  " overwrites an existing file
+    q!
+  endtry
+endif  " end eval
+%d
 r test.log
 w test_result.log
 q!

--- a/src/testdir/result.vim
+++ b/src/testdir/result.vim
@@ -21,19 +21,26 @@ if 1 " eval feature
         \ "-------------------------------"]
 
   try
+    " This uses the :s command to just fetch and process the output of the
+    " tests, it doesn't acutally replay anything
     %s/^Executed\s\+\zs\d\+\ze\s\+tests/\=Count(submatch(0),'executed')/egn
     %s/^SKIPPED \zs.*/\=Count(submatch(0), 'skipped')/egn
     %s/^\(\d\+\)\s\+FAILED:/\=Count(submatch(1), 'failed')/egn
 
-    call extend(output, ["Executed: ". printf("%5d", g:executed). " Tests"])
-    call extend(output, [" Skipped: ". printf("%5d", g:skipped).  " Tests"])
-    call extend(output, ["  Failed: ". printf("%5d", g:failed).   " Tests", ""])
-    call extend(output, [" Skipped:"])
+    call extend(output, [
+          \ printf("Executed: %5d Tests", g:executed),
+          \ printf(" Skipped: %5d Tests", g:skipped),
+          \ printf("  Failed: %5d Tests", g:failed),
+          \ "",
+          \ " Skipped: "]) 
     call extend(output, skipped_output)
     if filereadable('test.log')
+      " outputs and indents the failed test result
       call extend(output, ["", "Failures: "])
       let failed_output = filter(readfile('test.log'), { v,k -> !empty(k)})
-      call extend(output, map(failed_output, { v,k -> "\t".k}) + [""])
+      call extend(output, map(failed_output, { v,k -> "\t".k}))
+      " Add a final newline
+      call extend(output, [""])
     endif
 
   catch  " Catch-all


### PR DESCRIPTION
Output will look like this when no failure occurred:

Test results:
------------
Vim Test Log: 20190518 13:04:39
 Skipped: 9 Tests
Executed: 1510 Tests

 Skipped:
        Test_normal30_changecase(): Turkish locale not available
        Test_normal35_g_cmd4(): output of g< can't be tested currently
        Test_normal47_autocmd(): not possible to test cursorhold autocmd while waiting for input in normal_cmd
        Test_restricted_mzscheme(): MzScheme is not supported
        Test_restricted_python3(): Python3 is not supported
        Test_restricted_ruby(): Ruby is not supported
        Test_restricted_tcl(): Tcl is not supported
        Test_term_mouse_middle_click(): No working clipboard
        Test_term_gettitle(): can't get/set title

ALL DONE

However when an error occurred, it will look like this:

Test results: 20190518 13:15:57
-------------------------------
 Skipped: 9 Tests
Executed: 1510 Tests

 Skipped:
        Test_normal30_changecase(): Turkish locale not available
        Test_normal35_g_cmd4(): output of g< can't be tested currently
        Test_normal47_autocmd(): not possible to test cursorhold autocmd while waiting for input in normal_cmd
        Test_restricted_mzscheme(): MzScheme is not supported
        Test_restricted_python3(): Python3 is not supported
        Test_restricted_ruby(): Ruby is not supported
        Test_restricted_tcl(): Tcl is not supported
        Test_term_mouse_middle_click(): No working clipboard
        Test_term_gettitle(): can't get/set title

Failures:
        From test_alot.vim:
        Found errors in Test_reltime():
        Run 1:
        function RunTheTest[40]..Test_reltime line 5: Expected True but got 0
        Run 2:
        function RunTheTest[40]..Test_reltime line 5: Expected True but got 0
        Flaky test failed too often, giving up

TEST_FAILURE