### PR TITLE
vimdll: Fix that some characters cannot input on Linux

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1753,7 +1753,11 @@ vgetc(void)
 		    buf[i] = vgetorpeek(TRUE);
 		    if (buf[i] == K_SPECIAL
 #ifdef FEAT_GUI
-			    || (gui.in_use && buf[i] == CSI)
+			    || (
+# ifdef VIMDLL
+				gui.in_use &&
+# endif
+				buf[i] == CSI)
 #endif
 			    )
 		    {


### PR DESCRIPTION
I had a report that some characters (e.g. `更`) cannot be input on Linux built with GUI and running
on console after 8.1.1239. The `gui.in_use` check is only needed on Windows.

Ref: https://github.com/vim/vim/pull/4318