### PR TITLE
Fix vim.find_module to satisfy PEP 451, so setuptools will work properly

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -1222,6 +1222,13 @@ FinderFindSpec(PyObject *self, PyObject *args)
 
     return spec;
 }
+
+    static PyObject *
+FinderFindModule(PyObject* self, PyObject* args)
+{
+    Py_INCREF(Py_None);
+    return Py_None;
+}
 #else
     static PyObject *
 call_load_module(char *name, int len, PyObject *find_module_result)
@@ -1400,9 +1407,8 @@ static struct PyMethodDef VimMethods[] = {
     {"foreach_rtp", VimForeachRTP,		METH_O,				"Call given callable for each path in &rtp"},
 #if PY_VERSION_HEX >= 0x030700f0
     {"find_spec",   FinderFindSpec,		METH_VARARGS,			"Internal use only, returns spec object for any input it receives"},
-#else
-    {"find_module", FinderFindModule,		METH_VARARGS,			"Internal use only, returns loader object for any input it receives"},
 #endif
+    {"find_module", FinderFindModule,		METH_VARARGS,			"Internal use only, returns loader object for any input it receives"},
     {"path_hook",   VimPathHook,		METH_VARARGS,			"Hook function to install in sys.path_hooks"},
     {"_get_paths",  (PyCFunction)Vim_GetPaths,	METH_NOARGS,			"Get &rtp-based additions to sys.path"},
     { NULL,	    NULL,			0,				NULL}


### PR DESCRIPTION
This should/may fix #3984. It works for `import google.protobuf`, others should test their use cases if possible.

Returning `None` appears to be the behavior of the default implementation of the abstract base class. It appears to work. I'm not sure why exactly but I am happy for a solution.

See: https://docs.python.org/3/library/importlib.html#importlib.abc.MetaPathFinder.find_module