### PR TITLE
fix wrong search count when search offset or n command with count

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1219,6 +1219,7 @@ do_search(
     char_u	    *ps;
     char_u	    *msgbuf = NULL;
     size_t	    len;
+    int		    has_offset = FALSE;
 #define SEARCH_STAT_BUF_LEN 12
 
     /*
@@ -1542,7 +1543,6 @@ do_search(
 	/*
 	 * Add character and/or line offset
 	 */
-	int has_offset = FALSE;
 	if (!(options & SEARCH_NOOF) || (pat != NULL && *pat == ';'))
 	{
 	    pos_T const org_pos = pos;

--- a/src/search.c
+++ b/src/search.c
@@ -26,7 +26,7 @@ static void show_pat_in_path(char_u *, int,
 #ifdef FEAT_VIMINFO
 static void wvsp_one(FILE *fp, int idx, char *s, int sc);
 #endif
-static void search_stat(int dirc, pos_T *pos, int show_top_bot_msg, char_u  *msgbuf);
+static void search_stat(int dirc, pos_T *pos, int show_top_bot_msg, char_u *msgbuf, int recompute);
 
 /*
  * This file contains various searching-related routines. These fall into
@@ -1542,8 +1542,10 @@ do_search(
 	/*
 	 * Add character and/or line offset
 	 */
+	int has_offset = FALSE;
 	if (!(options & SEARCH_NOOF) || (pat != NULL && *pat == ';'))
 	{
+	    pos_T const org_pos = pos;
 	    if (spats[0].off.line)	/* Add the offset to the line number. */
 	    {
 		c = pos.lnum + spats[0].off.off;
@@ -1575,6 +1577,8 @@ do_search(
 			    break;
 		}
 	    }
+	    if (!EQUAL_POS(pos, org_pos))
+		has_offset = TRUE;
 	}
 
 	// Show [1/15] if 'S' is not in 'shortmess'.
@@ -1584,7 +1588,7 @@ do_search(
 		&& c != FAIL
 		&& !shortmess(SHM_SEARCHCOUNT)
 		&& msgbuf != NULL)
-	    search_stat(dirc, &pos, show_top_bot_msg, msgbuf);
+	    search_stat(dirc, &pos, show_top_bot_msg, msgbuf, (count != 1 || has_offset));
 
 	/*
 	 * The search command can be followed by a ';' to do another search.
@@ -4915,7 +4919,8 @@ search_stat(
     int	    dirc,
     pos_T   *pos,
     int	    show_top_bot_msg,
-    char_u  *msgbuf)
+    char_u  *msgbuf,
+    int	    recompute)
 {
     int		    save_ws = p_ws;
     int		    wraparound = FALSE;
@@ -4941,7 +4946,7 @@ search_stat(
 	&& MB_STRNICMP(lastpat, spats[last_idx].pat, STRLEN(lastpat)) == 0
 	&& STRLEN(lastpat) == STRLEN(spats[last_idx].pat)
 	&& EQUAL_POS(lastpos, curwin->w_cursor)
-	&& lbuf == curbuf) || wraparound || cur < 0 || cur > 99)
+	&& lbuf == curbuf) || wraparound || cur < 0 || cur > 99 || recompute)
     {
 	cur = 0;
 	cnt = 0;

--- a/src/testdir/test_search_stat.vim
+++ b/src/testdir/test_search_stat.vim
@@ -114,7 +114,26 @@ func! Test_search_stat()
     call assert_false(1)
   endtry
 
-  " 11) normal, n comes from a mapping
+  " 11) with count
+  call cursor(1, 1)
+  let @/ = 'fo*\(bar\?\)\?'
+  let g:a = execute(':unsilent :norm! 2n')
+  let stat = '\[3/50\]'
+  let pat = escape(@/, '()*?'). '\s\+'
+  call assert_match(pat .. stat, g:a)
+  let g:a = execute(':unsilent :norm! 2n')
+  let stat = '\[5/50\]'
+  call assert_match(pat .. stat, g:a)
+
+  " 12) with offset
+  call cursor(1, 1)
+  call feedkeys("/fo*\\(bar\\?\\)\\?/+1\<cr>", 'tx')
+  let g:a = execute(':unsilent :norm! n')
+  let stat = '\[5/50\]'
+  let pat = escape(@/ .. '/+1', '()*?'). '\s\+'
+  call assert_match(pat .. stat, g:a)
+
+  " 13) normal, n comes from a mapping
   "     Need to move over more than 64 lines to trigger char_avail(.
   nnoremap n nzv
   call cursor(1,1)
@@ -130,7 +149,7 @@ func! Test_search_stat()
   call assert_match(pat .. stat, g:b)
   unmap n
 
-  " 11) normal, but silent
+  " 14) normal, but silent
   call cursor(1,1)
   let @/ = 'find this'
   let pat = '/find this\s\+'


### PR DESCRIPTION
I found that search count message gets wrong if n command has 2 or more counts (like 2n) or search pattern has offset (like "/foo/+1").

How to recreate:
1. vim -Nu NONE
1. :set shortmess-=S
1. 10ifoo\<CR>\<ESC>
1. gg
1. /foo\<CR>
1. 2n
 (Added test will fail without the patch.)

How to fix: Recompute search count if count != 1 or search pattern has offset.