### PR TITLE
vimdll: SUBSYSTEM version was not set on vim.exe

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -847,7 +847,7 @@ XDIFF_DEPS = \
 !if "$(SUBSYSTEM_VER)" != ""
 SUBSYSTEM = $(SUBSYSTEM),$(SUBSYSTEM_VER)
 SUBSYSTEM_TOOLS = $(SUBSYSTEM_TOOLS),$(SUBSYSTEM_VER)
-! if "$(VIMDLL)" != "yes"
+! if "$(VIMDLL)" == "yes"
 SUBSYSTEM_CON = $(SUBSYSTEM_CON),$(SUBSYSTEM_VER)
 ! endif
 # Pass SUBSYSTEM_VER to GvimExt and other tools


### PR DESCRIPTION
SUBSYSTEM version was not set only on vim.exe when `VIMDLL=yes`.