### PR TITLE
Added test which triggers asan error with text property (issue #4412)

### DIFF
--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -768,6 +768,14 @@ func Test_textprop_empty_buffer()
   close
 endfunc
 
+" This test currently triggers global memory overflows which
+" is detected by asan (valgrind can't detect such bugs).
+func Test_textprop_invalid_memory_access()
+  call prop_type_add("xxx", {})
+  call prop_add(1, 1, {"type": "xxx"})
+  next X
+endfunc
+
 func Test_textprop_remove_from_buf()
   new
   let buf = bufnr('')


### PR DESCRIPTION
This PR adds a test which triggers an global memory overflow
detected by asan when using text property (see issue #4412).
Valgrind can't detect such bugs.

I'd expect Travis CI to detect this bug with the asan build.

PR should not be merged until there is a fix for the bug.