### PR TITLE
Ocaml update2

### DIFF
--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -18,6 +18,9 @@ if exists("b:current_syntax") && b:current_syntax == "ocaml"
   finish
 endif
 
+" ' can be used in OCaml identifiers
+set iskeyword+='
+
 " OCaml is case sensitive.
 syn case match
 

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -5,9 +5,9 @@
 "               Karl-Heinz Sylla  <Karl-Heinz.Sylla@gmd.de>
 "               Issac Trotts      <ijtrotts@ucdavis.edu>
 " URL:          http://www.ocaml.info/vim/syntax/ocaml.vim
-" Last Change:  2014 Oct 09 - added generative functors and quoted strings (MM)
+" Last Change:  2015 Jan 21 - Bug fix for comments following included modules (MM)
+"               2014 Oct 09 - added generative functors and quoted strings (MM)
 "               2012 May 12 - Added Dominique Pellé's spell checking patch (MM)
-"               2012 Feb 01 - Improved module path highlighting (MM)
 
 " A minor patch was applied to the official version so that object/end
 " can be distinguished from begin/end, which is used for indentation,
@@ -133,7 +133,7 @@ syn region   ocamlVal matchgroup=ocamlKeyword start="\<val\>" matchgroup=ocamlLC
 syn region   ocamlModRHS start="." end=". *\w\|([^*]"me=e-2 contained contains=ocamlComment skipwhite skipempty nextgroup=ocamlModParam,ocamlFullMod
 syn match    ocamlFullMod "\<\u\(\w\|'\)*\( *\. *\u\(\w\|'\)*\)*" contained skipwhite skipempty nextgroup=ocamlFuncWith
 
-syn region   ocamlFuncWith start="([^*)]\="me=e-1 end=")" contained contains=ocamlComment,ocamlWith,ocamlFuncStruct skipwhite skipempty nextgroup=ocamlFuncWith
+syn region   ocamlFuncWith start="([^*)]"me=e-1 end=")" contained contains=ocamlComment,ocamlWith,ocamlFuncStruct skipwhite skipempty nextgroup=ocamlFuncWith
 syn region   ocamlFuncStruct matchgroup=ocamlModule start="[^a-zA-Z]struct\>"hs=s+1 matchgroup=ocamlModule end="\<end\>" contains=ALLBUT,@ocamlContained,ocamlEndErr
 
 syn match    ocamlModTypeRestr "\<\w\(\w\|'\)*\( *\. *\w\(\w\|'\)*\)*\>" contained

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -5,9 +5,9 @@
 "               Karl-Heinz Sylla  <Karl-Heinz.Sylla@gmd.de>
 "               Issac Trotts      <ijtrotts@ucdavis.edu>
 " URL:          http://www.ocaml.info/vim/syntax/ocaml.vim
-" Last Change:  2012 May 12 - Added Dominique Pellé's spell checking patch (MM)
+" Last Change:  2014 Oct 09 - added generative functors and quoted strings (MM)
+"               2012 May 12 - Added Dominique Pellé's spell checking patch (MM)
 "               2012 Feb 01 - Improved module path highlighting (MM)
-"               2010 Oct 11 - Added highlighting of lnot (MM, thanks to Erick Matsen)
 
 " A minor patch was applied to the official version so that object/end
 " can be distinguished from begin/end, which is used for indentation,
@@ -66,7 +66,7 @@ syn cluster  ocamlAllErrs contains=ocamlBraceErr,ocamlBrackErr,ocamlParenErr,oca
 
 syn cluster  ocamlAENoParen contains=ocamlBraceErr,ocamlBrackErr,ocamlCommentErr,ocamlCountErr,ocamlDoErr,ocamlDoneErr,ocamlEndErr,ocamlThenErr
 
-syn cluster  ocamlContained contains=ocamlTodo,ocamlPreDef,ocamlModParam,ocamlModParam1,ocamlPreMPRestr,ocamlMPRestr,ocamlMPRestr1,ocamlMPRestr2,ocamlMPRestr3,ocamlModRHS,ocamlFuncWith,ocamlFuncStruct,ocamlModTypeRestr,ocamlModTRWith,ocamlWith,ocamlWithRest,ocamlModType,ocamlFullMod,ocamlVal
+syn cluster  ocamlContained contains=ocamlTodo,ocamlPreDef,ocamlModParam,ocamlModParam1,ocamlMPRestr,ocamlMPRestr1,ocamlMPRestr2,ocamlMPRestr3,ocamlModRHS,ocamlFuncWith,ocamlFuncStruct,ocamlModTypeRestr,ocamlModTRWith,ocamlWith,ocamlWithRest,ocamlModType,ocamlFullMod,ocamlVal
 
 
 " Enclosing delimiters
@@ -118,15 +118,14 @@ syn match    ocamlKeyword "\<include\>" skipwhite skipempty nextgroup=ocamlModPa
 
 " "module" - somewhat complicated stuff ;-)
 syn region   ocamlModule matchgroup=ocamlKeyword start="\<module\>" matchgroup=ocamlModule end="\<\u\(\w\|'\)*\>" contains=@ocamlAllErrs,ocamlComment skipwhite skipempty nextgroup=ocamlPreDef
-syn region   ocamlPreDef start="."me=e-1 matchgroup=ocamlKeyword end="\l\|=\|)"me=e-1 contained contains=@ocamlAllErrs,ocamlComment,ocamlModParam,ocamlModTypeRestr,ocamlModTRWith nextgroup=ocamlModPreRHS
-syn region   ocamlModParam start="([^*]" end=")" contained contains=@ocamlAENoParen,ocamlModParam1,ocamlVal
-syn match    ocamlModParam1 "\<\u\(\w\|'\)*\>" contained skipwhite skipempty nextgroup=ocamlPreMPRestr
-
-syn region   ocamlPreMPRestr start="."me=e-1 end=")"me=e-1 contained contains=@ocamlAllErrs,ocamlComment,ocamlMPRestr,ocamlModTypeRestr
+syn region   ocamlPreDef start="."me=e-1 matchgroup=ocamlKeyword end="\l\|=\|)"me=e-1 contained contains=@ocamlAllErrs,ocamlComment,ocamlModParam,ocamlGenMod,ocamlModTypeRestr,ocamlModTRWith nextgroup=ocamlModPreRHS
+syn region   ocamlModParam start="([^*]" end=")" contained contains=ocamlGenMod,ocamlModParam1,ocamlVal
+syn match    ocamlModParam1 "\<\u\(\w\|'\)*\>" contained skipwhite skipempty
+syn match    ocamlGenMod "()" contained skipwhite skipempty
 
 syn region   ocamlMPRestr start=":" end="."me=e-1 contained contains=@ocamlComment skipwhite skipempty nextgroup=ocamlMPRestr1,ocamlMPRestr2,ocamlMPRestr3
 syn region   ocamlMPRestr1 matchgroup=ocamlModule start="\ssig\s\=" matchgroup=ocamlModule end="\<end\>" contained contains=ALLBUT,@ocamlContained,ocamlEndErr,ocamlModule
-syn region   ocamlMPRestr2 start="\sfunctor\(\s\|(\)\="me=e-1 matchgroup=ocamlKeyword end="->" contained contains=@ocamlAllErrs,ocamlComment,ocamlModParam skipwhite skipempty nextgroup=ocamlFuncWith,ocamlMPRestr2
+syn region   ocamlMPRestr2 start="\sfunctor\(\s\|(\)\="me=e-1 matchgroup=ocamlKeyword end="->" contained contains=@ocamlAllErrs,ocamlComment,ocamlModParam,ocamlGenMod skipwhite skipempty nextgroup=ocamlFuncWith,ocamlMPRestr2
 syn match    ocamlMPRestr3 "\w\(\w\|'\)*\( *\. *\w\(\w\|'\)*\)*" contained
 syn match    ocamlModPreRHS "=" contained skipwhite skipempty nextgroup=ocamlModParam,ocamlFullMod
 syn keyword  ocamlKeyword val
@@ -134,7 +133,7 @@ syn region   ocamlVal matchgroup=ocamlKeyword start="\<val\>" matchgroup=ocamlLC
 syn region   ocamlModRHS start="." end=". *\w\|([^*]"me=e-2 contained contains=ocamlComment skipwhite skipempty nextgroup=ocamlModParam,ocamlFullMod
 syn match    ocamlFullMod "\<\u\(\w\|'\)*\( *\. *\u\(\w\|'\)*\)*" contained skipwhite skipempty nextgroup=ocamlFuncWith
 
-syn region   ocamlFuncWith start="([^*]"me=e-1 end=")" contained contains=ocamlComment,ocamlWith,ocamlFuncStruct skipwhite skipempty nextgroup=ocamlFuncWith
+syn region   ocamlFuncWith start="([^*)]\="me=e-1 end=")" contained contains=ocamlComment,ocamlWith,ocamlFuncStruct skipwhite skipempty nextgroup=ocamlFuncWith
 syn region   ocamlFuncStruct matchgroup=ocamlModule start="[^a-zA-Z]struct\>"hs=s+1 matchgroup=ocamlModule end="\<end\>" contains=ALLBUT,@ocamlContained,ocamlEndErr
 
 syn match    ocamlModTypeRestr "\<\w\(\w\|'\)*\( *\. *\w\(\w\|'\)*\)*\>" contained
@@ -192,6 +191,7 @@ syn match    ocamlCharacter    "'\\x\x\x'"
 syn match    ocamlCharErr      "'\\\d\d'\|'\\\d'"
 syn match    ocamlCharErr      "'\\[^\'ntbr]'"
 syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
+syn match    ocamlString       "{\(\w*\)|\(.\|\n\)*|\1}" contains=@Spell
 
 syn match    ocamlFunDef       "->"
 syn match    ocamlRefAssign    ":="
@@ -311,7 +311,6 @@ hi def link ocamlType	   Type
 hi def link ocamlTodo	   Todo
 
 hi def link ocamlEncl	   Keyword
-
 
 let b:current_syntax = "ocaml"
 

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -5,9 +5,13 @@
 "               Karl-Heinz Sylla  <Karl-Heinz.Sylla@gmd.de>
 "               Issac Trotts      <ijtrotts@ucdavis.edu>
 " URL:          http://www.ocaml.info/vim/syntax/ocaml.vim
-" Last Change:  2015 Jan 21 - Bug fix for comments following included modules (MM)
-"               2014 Oct 09 - added generative functors and quoted strings (MM)
-"               2012 May 12 - Added Dominique Pellé's spell checking patch (MM)
+" Last Change:
+"               2018 Apr 22 - Improved support for PPX (Andrey Popp)
+"               2018 Mar 16 - Remove raise, lnot and not from keywords (Étienne Millon, "copy")
+"               2017 Apr 11 - Improved matching of negative numbers (MM)
+"               2016 Mar 11 - Improved support for quoted strings (Glen Mével)
+"               2015 Aug 13 - Allow apostrophes in identifiers (Jonathan Chan, Einar Lielmanis)
+"               2015 Jun 17 - Added new "nonrec" keyword (MM)
 
 " A minor patch was applied to the official version so that object/end
 " can be distinguished from begin/end, which is used for indentation,
@@ -155,6 +159,9 @@ syn region   ocamlStruct matchgroup=ocamlModule start="\<\(module\s\+\)\=struct\
 syn region   ocamlKeyword start="\<module\>\s*\<type\>\(\s*\<of\>\)\=" matchgroup=ocamlModule end="\<\w\(\w\|'\)*\>" contains=ocamlComment skipwhite skipempty nextgroup=ocamlMTDef
 syn match    ocamlMTDef "=\s*\w\(\w\|'\)*\>"hs=s+1,me=s+1 skipwhite skipempty nextgroup=ocamlFullMod
 
+" Quoted strings
+syn region ocamlString matchgroup=ocamlQuotedStringDelim start="{\z\([a-z_]*\)|" end="|\z1}" contains=@Spell
+
 syn keyword  ocamlKeyword  and as assert class
 syn keyword  ocamlKeyword  constraint else
 syn keyword  ocamlKeyword  exception external fun
@@ -198,7 +205,6 @@ syn match    ocamlCharacter    "'\\x\x\x'"
 syn match    ocamlCharErr      "'\\\d\d'\|'\\\d'"
 syn match    ocamlCharErr      "'\\[^\'ntbr]'"
 syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
-syn match    ocamlString       "{\(\w*\)|\(.\|\n\)\{-}|\1}" contains=@Spell
 
 syn match    ocamlFunDef       "->"
 syn match    ocamlRefAssign    ":="
@@ -223,11 +229,11 @@ else
   syn match    ocamlOperator   "<-"
 endif
 
-syn match    ocamlNumber        "\<-\=\d\(_\|\d\)*[l|L|n]\?\>"
-syn match    ocamlNumber        "\<-\=0[x|X]\(\x\|_\)\+[l|L|n]\?\>"
-syn match    ocamlNumber        "\<-\=0[o|O]\(\o\|_\)\+[l|L|n]\?\>"
-syn match    ocamlNumber        "\<-\=0[b|B]\([01]\|_\)\+[l|L|n]\?\>"
-syn match    ocamlFloat         "\<-\=\d\(_\|\d\)*\.\?\(_\|\d\)*\([eE][-+]\=\d\(_\|\d\)*\)\=\>"
+syn match    ocamlNumber        "-\=\<\d\(_\|\d\)*[l|L|n]\?\>"
+syn match    ocamlNumber        "-\=\<0[x|X]\(\x\|_\)\+[l|L|n]\?\>"
+syn match    ocamlNumber        "-\=\<0[o|O]\(\o\|_\)\+[l|L|n]\?\>"
+syn match    ocamlNumber        "-\=\<0[b|B]\([01]\|_\)\+[l|L|n]\?\>"
+syn match    ocamlFloat         "-\=\<\d\(_\|\d\)*\.\?\(_\|\d\)*\([eE][-+]\=\d\(_\|\d\)*\)\=\>"
 
 " Labels
 syn match    ocamlLabel        "\~\(\l\|_\)\(\w\|'\)*"lc=1
@@ -310,6 +316,7 @@ hi def link ocamlCharacter    Character
 hi def link ocamlNumber	   Number
 hi def link ocamlFloat	   Float
 hi def link ocamlString	   String
+hi def link ocamlQuotedStringDelim  Identifier
 
 hi def link ocamlLabel	   Identifier
 

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -238,7 +238,7 @@ syn match    ocamlFloat         "-\=\<\d\(_\|\d\)*\.\?\(_\|\d\)*\([eE][-+]\=\d\(
 " Labels
 syn match    ocamlLabel        "\~\(\l\|_\)\(\w\|'\)*"lc=1
 syn match    ocamlLabel        "?\(\l\|_\)\(\w\|'\)*"lc=1
-syn region   ocamlLabel transparent matchgroup=ocamlLabel start="?(\(\l\|_\)\(\w\|'\)*"lc=2 end=")"me=e-1 contains=ALLBUT,@ocamlContained,ocamlParenErr
+syn region   ocamlLabel transparent matchgroup=ocamlLabel start="[~?](\(\l\|_\)\(\w\|'\)*"lc=2 end=")"me=e-1 contains=ALLBUT,@ocamlContained,ocamlParenErr
 
 
 " Synchronization

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -35,7 +35,7 @@ syn match    ocamlMethod       "#"
 syn match    ocamlComment   "^#!.*" contains=@Spell
 
 " Scripting directives
-syn match    ocamlScript "^#\<\(quit\|labels\|warnings\|directory\|cd\|load\|use\|install_printer\|remove_printer\|require\|thread\|trace\|untrace\|untrace_all\|print_depth\|print_length\|camlp4o\)\>"
+syn match    ocamlScript "^#\<\(quit\|labels\|warnings\|directory\|cd\|load\|load_rec\|use\|mod_use\|install_printer\|remove_printer\|require\|list\|predicates\|thread\|trace\|untrace\|untrace_all\|print_depth\|print_length\|camlp4o\|camlp4r\)\>"
 
 " lowercase identifier - the standard way to match
 syn match    ocamlLCIdentifier /\<\(\l\|_\)\(\w\|'\)*\>/

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -6,6 +6,7 @@
 "               Issac Trotts      <ijtrotts@ucdavis.edu>
 " URL:          http://www.ocaml.info/vim/syntax/ocaml.vim
 " Last Change:
+"               2018 Nov 08 - Improved highlighting of operators (Maëlan)
 "               2018 Apr 22 - Improved support for PPX (Andrey Popp)
 "               2018 Mar 16 - Remove raise, lnot and not from keywords (Étienne Millon, "copy")
 "               2017 Apr 11 - Improved matching of negative numbers (MM)
@@ -167,7 +168,7 @@ syn keyword  ocamlKeyword  constraint else
 syn keyword  ocamlKeyword  exception external fun
 
 syn keyword  ocamlKeyword  in inherit initializer
-syn keyword  ocamlKeyword  land lazy let match
+syn keyword  ocamlKeyword  lazy let match
 syn keyword  ocamlKeyword  method mutable new nonrec of
 syn keyword  ocamlKeyword  parser private rec
 syn keyword  ocamlKeyword  try type
@@ -179,14 +180,11 @@ if exists("ocaml_revised")
 else
   syn keyword  ocamlKeyword  function
   syn keyword  ocamlBoolean  true false
-  syn match    ocamlKeyChar  "!"
 endif
 
 syn keyword  ocamlType     array bool char exn float format format4
 syn keyword  ocamlType     int int32 int64 lazy_t list nativeint option
 syn keyword  ocamlType     string unit
-
-syn keyword  ocamlOperator asr lor lsl lsr lxor mod
 
 syn match    ocamlConstructor  "(\s*)"
 syn match    ocamlConstructor  "\[\s*\]"
@@ -206,27 +204,49 @@ syn match    ocamlCharErr      "'\\\d\d'\|'\\\d'"
 syn match    ocamlCharErr      "'\\[^\'ntbr]'"
 syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
 
-syn match    ocamlFunDef       "->"
-syn match    ocamlRefAssign    ":="
 syn match    ocamlTopStop      ";;"
-syn match    ocamlOperator     "\^"
-syn match    ocamlOperator     "::"
 
-syn match    ocamlOperator     "&&"
-syn match    ocamlOperator     "<"
-syn match    ocamlOperator     ">"
 syn match    ocamlAnyVar       "\<_\>"
 syn match    ocamlKeyChar      "|[^\]]"me=e-1
 syn match    ocamlKeyChar      ";"
 syn match    ocamlKeyChar      "\~"
 syn match    ocamlKeyChar      "?"
-syn match    ocamlKeyChar      "\*"
-syn match    ocamlKeyChar      "="
 
+"" Operators
+
+" The grammar of operators is found there:
+"     https://caml.inria.fr/pub/docs/manual-ocaml/names.html#operator-name
+"     https://caml.inria.fr/pub/docs/manual-ocaml/extn.html#s:ext-ops
+"     https://caml.inria.fr/pub/docs/manual-ocaml/extn.html#s:index-operators
+" =, *, < and > are both operator names and keywords, we let the user choose how
+" to display them (has to be declared before regular infix operators):
+syn match    ocamlEqual        "="
+syn match    ocamlStar         "*"
+syn match    ocamlAngle        "<"
+syn match    ocamlAngle        ">"
+" Custom indexing operators:
+syn match    ocamlIndexingOp   "\.[~?!:|&$%=>@^/*+-][~?!.:|&$%<=>@^*/+-]*\(()\|\[]\|{}\)\(<-\)\?"
+" Extension operators (has to be declared before regular infix operators):
+syn match    ocamlExtensionOp          "#[#~?!.:|&$%<=>@^*/+-]\+"
+" Infix and prefix operators:
+syn match    ocamlPrefixOp              "![~?!.:|&$%<=>@^*/+-]*"
+syn match    ocamlPrefixOp           "[~?][~?!.:|&$%<=>@^*/+-]\+"
+syn match    ocamlInfixOp      "[&$%@^/+-][~?!.:|&$%<=>@^*/+-]*"
+syn match    ocamlInfixOp         "[|<=>*][~?!.:|&$%<=>@^*/+-]\+"
+syn match    ocamlInfixOp               "#[~?!.:|&$%<=>@^*/+-]\+#\@!"
+syn match    ocamlInfixOp              "!=[~?!.:|&$%<=>@^*/+-]\@!"
+syn keyword  ocamlInfixOp      asr land lor lsl lsr lxor mod or
+" := is technically an infix operator, but we may want to show it as a keyword
+" (somewhat analogously to = for let‐bindings and <- for assignations):
+syn match    ocamlRefAssign    ":="
+" :: is technically not an operator, but we may want to show it as such:
+syn match    ocamlCons         "::"
+" -> and <- are keywords, not operators (but can appear in longer operators):
+syn match    ocamlArrow        "->[~?!.:|&$%<=>@^*/+-]\@!"
 if exists("ocaml_revised")
-  syn match    ocamlErr        "<-"
+  syn match    ocamlErr        "<-[~?!.:|&$%<=>@^*/+-]\@!"
 else
-  syn match    ocamlOperator   "<-"
+  syn match    ocamlKeyChar    "<-[~?!.:|&$%<=>@^*/+-]\@!"
 endif
 
 syn match    ocamlNumber        "-\=\<\d\(_\|\d\)*[l|L|n]\?\>"
@@ -306,12 +326,22 @@ hi def link ocamlModPreRHS    Keyword
 hi def link ocamlMPRestr2	   Keyword
 hi def link ocamlKeyword	   Keyword
 hi def link ocamlMethod	   Include
-hi def link ocamlFunDef	   Keyword
-hi def link ocamlRefAssign    Keyword
 hi def link ocamlKeyChar	   Keyword
 hi def link ocamlAnyVar	   Keyword
 hi def link ocamlTopStop	   Keyword
-hi def link ocamlOperator	   Keyword
+
+hi def link ocamlRefAssign  ocamlKeyChar
+hi def link ocamlEqual	    ocamlKeyChar
+hi def link ocamlStar	    ocamlInfixOp
+hi def link ocamlAngle	    ocamlInfixOp
+hi def link ocamlCons	    ocamlInfixOp
+
+hi def link ocamlPrefixOp   ocamlOperator
+hi def link ocamlInfixOp    ocamlOperator
+hi def link ocamlExtensionOp	ocamlOperator
+hi def link ocamlIndexingOp	ocamlOperator
+
+hi def link ocamlOperator   Operator
 
 hi def link ocamlBoolean	   Boolean
 hi def link ocamlCharacter    Character

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -19,7 +19,7 @@ if exists("b:current_syntax") && b:current_syntax == "ocaml"
 endif
 
 " ' can be used in OCaml identifiers
-set iskeyword+='
+setlocal iskeyword+='
 
 " OCaml is case sensitive.
 syn case match

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -118,7 +118,7 @@ syn region ocamlPpx matchgroup=ocamlPpxEncl start="\[@\{1,3\}" contains=TOP end=
 "" Modules
 
 " "sig"
-syn region   ocamlSig matchgroup=ocamlModule start="\<sig\>" matchgroup=ocamlModule end="\<end\>" contains=ALLBUT,@ocamlContained,ocamlEndErr,ocamlModule
+syn region   ocamlSig matchgroup=ocamlSigEncl start="\<sig\>" matchgroup=ocamlSigEncl end="\<end\>" contains=ALLBUT,@ocamlContained,ocamlEndErr,ocamlModule
 syn region   ocamlModSpec matchgroup=ocamlKeyword start="\<module\>" matchgroup=ocamlModule end="\<\u\(\w\|'\)*\>" contained contains=@ocamlAllErrs,ocamlComment skipwhite skipempty nextgroup=ocamlModTRWith,ocamlMPRestr
 
 " "open"
@@ -130,12 +130,12 @@ syn match    ocamlKeyword "\<include\>" skipwhite skipempty nextgroup=ocamlModPa
 " "module" - somewhat complicated stuff ;-)
 syn region   ocamlModule matchgroup=ocamlKeyword start="\<module\>" matchgroup=ocamlModule end="\<\u\(\w\|'\)*\>" contains=@ocamlAllErrs,ocamlComment skipwhite skipempty nextgroup=ocamlPreDef
 syn region   ocamlPreDef start="."me=e-1 matchgroup=ocamlKeyword end="\l\|=\|)"me=e-1 contained contains=@ocamlAllErrs,ocamlComment,ocamlModParam,ocamlGenMod,ocamlModTypeRestr,ocamlModTRWith nextgroup=ocamlModPreRHS
-syn region   ocamlModParam start="([^*]" end=")" contained contains=ocamlGenMod,ocamlModParam1,ocamlVal
+syn region   ocamlModParam start="([^*]" end=")" contained contains=ocamlGenMod,ocamlModParam1,ocamlSig,ocamlVal
 syn match    ocamlModParam1 "\<\u\(\w\|'\)*\>" contained skipwhite skipempty
 syn match    ocamlGenMod "()" contained skipwhite skipempty
 
 syn region   ocamlMPRestr start=":" end="."me=e-1 contained contains=@ocamlComment skipwhite skipempty nextgroup=ocamlMPRestr1,ocamlMPRestr2,ocamlMPRestr3
-syn region   ocamlMPRestr1 matchgroup=ocamlModule start="\ssig\s\=" matchgroup=ocamlModule end="\<end\>" contained contains=ALLBUT,@ocamlContained,ocamlEndErr,ocamlModule
+syn region   ocamlMPRestr1 matchgroup=ocamlSigEncl start="\ssig\s\=" matchgroup=ocamlSigEncl end="\<end\>" contained contains=ALLBUT,@ocamlContained,ocamlEndErr,ocamlModule
 syn region   ocamlMPRestr2 start="\sfunctor\(\s\|(\)\="me=e-1 matchgroup=ocamlKeyword end="->" contained contains=@ocamlAllErrs,ocamlComment,ocamlModParam,ocamlGenMod skipwhite skipempty nextgroup=ocamlFuncWith,ocamlMPRestr2
 syn match    ocamlMPRestr3 "\w\(\w\|'\)*\( *\. *\w\(\w\|'\)*\)*" contained
 syn match    ocamlModPreRHS "=" contained skipwhite skipempty nextgroup=ocamlModParam,ocamlFullMod
@@ -145,7 +145,7 @@ syn region   ocamlModRHS start="." end=". *\w\|([^*]"me=e-2 contained contains=o
 syn match    ocamlFullMod "\<\u\(\w\|'\)*\( *\. *\u\(\w\|'\)*\)*" contained skipwhite skipempty nextgroup=ocamlFuncWith
 
 syn region   ocamlFuncWith start="([^*)]"me=e-1 end=")" contained contains=ocamlComment,ocamlWith,ocamlFuncStruct skipwhite skipempty nextgroup=ocamlFuncWith
-syn region   ocamlFuncStruct matchgroup=ocamlModule start="[^a-zA-Z]struct\>"hs=s+1 matchgroup=ocamlModule end="\<end\>" contains=ALLBUT,@ocamlContained,ocamlEndErr
+syn region   ocamlFuncStruct matchgroup=ocamlStructEncl start="[^a-zA-Z]struct\>"hs=s+1 matchgroup=ocamlStructEncl end="\<end\>" contains=ALLBUT,@ocamlContained,ocamlEndErr
 
 syn match    ocamlModTypeRestr "\<\w\(\w\|'\)*\( *\. *\w\(\w\|'\)*\)*\>" contained
 syn region   ocamlModTRWith start=":\s*("hs=s+1 end=")" contained contains=@ocamlAENoParen,ocamlWith
@@ -153,7 +153,7 @@ syn match    ocamlWith "\<\(\u\(\w\|'\)* *\. *\)*\w\(\w\|'\)*\>" contained skipw
 syn region   ocamlWithRest start="[^)]" end=")"me=e-1 contained contains=ALLBUT,@ocamlContained
 
 " "struct"
-syn region   ocamlStruct matchgroup=ocamlModule start="\<\(module\s\+\)\=struct\>" matchgroup=ocamlModule end="\<end\>" contains=ALLBUT,@ocamlContained,ocamlEndErr
+syn region   ocamlStruct matchgroup=ocamlStructEncl start="\<\(module\s\+\)\=struct\>" matchgroup=ocamlStructEncl end="\<end\>" contains=ALLBUT,@ocamlContained,ocamlEndErr
 
 " "module type"
 syn region   ocamlKeyword start="\<module\>\s*\<type\>\(\s*\<of\>\)\=" matchgroup=ocamlModule end="\<\w\(\w\|'\)*\>" contains=ocamlComment skipwhite skipempty nextgroup=ocamlMTDef
@@ -294,6 +294,8 @@ hi def link ocamlFullMod	   Include
 hi def link ocamlModTypeRestr Include
 hi def link ocamlWith	   Include
 hi def link ocamlMTDef	   Include
+hi def link ocamlSigEncl    ocamlModule
+hi def link ocamlStructEncl ocamlModule
 
 hi def link ocamlScript	   Include
 

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -106,6 +106,10 @@ endif
 " "if"
 syn region   ocamlNone matchgroup=ocamlKeyword start="\<if\>" matchgroup=ocamlKeyword end="\<then\>" contains=ALLBUT,@ocamlContained,ocamlThenErr
 
+"" PPX nodes
+
+syn match ocamlPpxIdentifier /\(\[@\{1,3\}\)\@<=\w\+\(\.\w\+\)*/
+syn region ocamlPpx matchgroup=ocamlPpxEncl start="\[@\{1,3\}" contains=TOP end="\]"
 
 "" Modules
 
@@ -314,6 +318,8 @@ hi def link ocamlType	   Type
 hi def link ocamlTodo	   Todo
 
 hi def link ocamlEncl	   Keyword
+
+hi def link ocamlPpxEncl    ocamlEncl
 
 let b:current_syntax = "ocaml"
 

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -158,7 +158,7 @@ syn keyword  ocamlKeyword  exception external fun
 syn keyword  ocamlKeyword  in inherit initializer
 syn keyword  ocamlKeyword  land lazy let match
 syn keyword  ocamlKeyword  method mutable new nonrec of
-syn keyword  ocamlKeyword  parser private raise rec
+syn keyword  ocamlKeyword  parser private rec
 syn keyword  ocamlKeyword  try type
 syn keyword  ocamlKeyword  virtual when while with
 

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -235,7 +235,7 @@ syn match    ocamlInfixOp      "[&$%@^/+-][~?!.:|&$%<=>@^*/+-]*"
 syn match    ocamlInfixOp         "[|<=>*][~?!.:|&$%<=>@^*/+-]\+"
 syn match    ocamlInfixOp               "#[~?!.:|&$%<=>@^*/+-]\+#\@!"
 syn match    ocamlInfixOp              "!=[~?!.:|&$%<=>@^*/+-]\@!"
-syn keyword  ocamlInfixOp      asr land lor lsl lsr lxor mod or
+syn keyword  ocamlInfixOpKeyword      asr land lor lsl lsr lxor mod or
 " := is technically an infix operator, but we may want to show it as a keyword
 " (somewhat analogously to = for let‐bindings and <- for assignations):
 syn match    ocamlRefAssign    ":="
@@ -336,8 +336,9 @@ hi def link ocamlStar	    ocamlInfixOp
 hi def link ocamlAngle	    ocamlInfixOp
 hi def link ocamlCons	    ocamlInfixOp
 
-hi def link ocamlPrefixOp   ocamlOperator
-hi def link ocamlInfixOp    ocamlOperator
+hi def link ocamlPrefixOp	ocamlOperator
+hi def link ocamlInfixOp	ocamlOperator
+hi def link ocamlInfixOpKeyword	ocamlOperator
 hi def link ocamlExtensionOp	ocamlOperator
 hi def link ocamlIndexingOp	ocamlOperator
 

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -191,7 +191,7 @@ syn match    ocamlCharacter    "'\\x\x\x'"
 syn match    ocamlCharErr      "'\\\d\d'\|'\\\d'"
 syn match    ocamlCharErr      "'\\[^\'ntbr]'"
 syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
-syn match    ocamlString       "{\(\w*\)|\(.\|\n\)*|\1}" contains=@Spell
+syn match    ocamlString       "{\(\w*\)|\(.\|\n\)\{-}|\1}" contains=@Spell
 
 syn match    ocamlFunDef       "->"
 syn match    ocamlRefAssign    ":="

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -184,7 +184,7 @@ endif
 
 syn keyword  ocamlType     array bool char exn float format format4
 syn keyword  ocamlType     int int32 int64 lazy_t list nativeint option
-syn keyword  ocamlType     string unit
+syn keyword  ocamlType     bytes string unit
 
 syn match    ocamlConstructor  "(\s*)"
 syn match    ocamlConstructor  "\[\s*\]"

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -175,7 +175,7 @@ syn keyword  ocamlType     array bool char exn float format format4
 syn keyword  ocamlType     int int32 int64 lazy_t list nativeint option
 syn keyword  ocamlType     string unit
 
-syn keyword  ocamlOperator asr lnot lor lsl lsr lxor mod not
+syn keyword  ocamlOperator asr lor lsl lsr lxor mod
 
 syn match    ocamlConstructor  "(\s*)"
 syn match    ocamlConstructor  "\[\s*\]"

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -338,11 +338,15 @@ hi def link ocamlCons	    ocamlInfixOp
 
 hi def link ocamlPrefixOp	ocamlOperator
 hi def link ocamlInfixOp	ocamlOperator
-hi def link ocamlInfixOpKeyword	ocamlOperator
 hi def link ocamlExtensionOp	ocamlOperator
 hi def link ocamlIndexingOp	ocamlOperator
 
-hi def link ocamlOperator   Operator
+if exists("ocaml_highlight_operators")
+    hi def link ocamlInfixOpKeyword ocamlOperator
+    hi def link ocamlOperator	    Operator
+else
+    hi def link ocamlInfixOpKeyword Keyword
+endif
 
 hi def link ocamlBoolean	   Boolean
 hi def link ocamlCharacter    Character

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -154,7 +154,7 @@ syn keyword  ocamlKeyword  exception external fun
 
 syn keyword  ocamlKeyword  in inherit initializer
 syn keyword  ocamlKeyword  land lazy let match
-syn keyword  ocamlKeyword  method mutable new of
+syn keyword  ocamlKeyword  method mutable new nonrec of
 syn keyword  ocamlKeyword  parser private raise rec
 syn keyword  ocamlKeyword  try type
 syn keyword  ocamlKeyword  virtual when while with

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -35,7 +35,7 @@ syn match    ocamlMethod       "#"
 syn match    ocamlComment   "^#!.*" contains=@Spell
 
 " Scripting directives
-syn match    ocamlScript "^#\<\(quit\|labels\|warnings\|directory\|cd\|load\|load_rec\|use\|mod_use\|install_printer\|remove_printer\|require\|list\|predicates\|thread\|trace\|untrace\|untrace_all\|print_depth\|print_length\|camlp4o\|camlp4r\)\>"
+syn match    ocamlScript "^#\<\(quit\|labels\|warnings\|warn_error\|directory\|remove_directory\|cd\|load\|load_rec\|use\|mod_use\|install_printer\|remove_printer\|require\|list\|ppx\|principal\|predicates\|rectypes\|thread\|trace\|untrace\|untrace_all\|print_depth\|print_length\|camlp4o\|camlp4r\|topfind_log\|topfind_verbose\)\>"
 
 " lowercase identifier - the standard way to match
 syn match    ocamlLCIdentifier /\<\(\l\|_\)\(\w\|'\)*\>/


### PR DESCRIPTION
Imported changes (saving the history) from https://github.com/rgrinberg/vim-ocaml

cc @chrisbra @mmottl @rgrinberg @copy @hcarty

Follow up of https://github.com/vim/vim/pull/4443

I did a git filter-branch of `runtime/syntax/ocaml.vim`, separated the file history from the rest of the files, grafted it to the https://github.com/vim/vim/commit/16ea3676db939c9cc326d3707cf9a0e1023ba9cd, and rebased after, tranforming changes to the appropriate syntax. On top of that added my small `bytes` keyword change.