### PR TITLE
popup: set width based on longest line

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -154,6 +154,9 @@ add_popup_dicts(buf_T *buf, list_T *l)
     static void
 popup_adjust_position(win_T *wp)
 {
+    int i = 0;
+    int len = 0;
+
     // TODO: Compute the size and position properly.
     if (wp->w_wantline > 0)
 	wp->w_winrow = wp->w_wantline - 1;
@@ -171,8 +174,15 @@ popup_adjust_position(win_T *wp)
     if (wp->w_wincol >= Columns - 3)
 	wp->w_wincol = Columns - 3;
 
-    // TODO: set width based on longest text line and the 'wrap' option
-    wp->w_width = vim_strsize(ml_get_buf(wp->w_buffer, 1, FALSE));
+    // set width based on longest text line
+    // TODO: and the 'wrap' option
+    wp->w_width = 0;
+    for ( i = 1; i <= wp->w_buffer->b_ml.ml_line_count; ++i ) {
+	len = vim_strsize( ml_get_buf( wp->w_buffer, i, FALSE ) );
+	if ( len > wp->w_width )
+	    wp->w_width = len;
+    }
+
     if (wp->w_minwidth > 0 && wp->w_width < wp->w_minwidth)
 	wp->w_width = wp->w_minwidth;
     if (wp->w_maxwidth > 0 && wp->w_width > wp->w_maxwidth)

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -176,3 +176,21 @@ func Test_popup_getposition()
 
   call popup_close(winid)
 endfunc
+
+func Test_popup_width()
+  let tests = [
+    \ [ [ 'hello', 'this', 'window', 'displays', 'all of its text' ], 15 ],
+    \ [ [ 'hello', 'this', 'window', 'all of its text', 'displays' ], 15 ],
+    \ [ [ 'hello', 'this', 'all of its text', 'window', 'displays' ], 15 ],
+    \ [ [ 'hello', 'all of its text', 'this', 'window', 'displays' ], 15 ],
+    \ [ [ 'all of its text', 'hello', 'this', 'window', 'displays' ], 15 ],
+  \ ]
+
+  for test in tests
+    let winid = popup_create( test[ 0 ], { 'line': 2, 'col': 3 } )
+    redraw
+    let position = popup_getposition(winid)
+    call assert_equal(test[ 1 ], position.width)
+    call popup_close( winid )
+  endfor
+endfunc


### PR DESCRIPTION
This is really necessary for parameter hint prototyping.

Before:

<img width="419" alt="Screenshot 2019-05-29 at 21 22 38" src="https://user-images.githubusercontent.com/10584846/58588591-e8bd5a80-8257-11e9-93d8-770433278f1e.png">

After:

<img width="719" alt="Screenshot 2019-05-29 at 21 22 19" src="https://user-images.githubusercontent.com/10584846/58588586-e5c26a00-8257-11e9-82f0-68aaf3823889.png">
