### PR TITLE
Use f_popup_getpos instead of getposition

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -813,7 +813,7 @@ static struct fst
     {"popup_close",	1, 1, f_popup_close},
     {"popup_create",	2, 2, f_popup_create},
     {"popup_getoptions", 1, 1, f_popup_getoptions},
-    {"popup_getposition", 1, 1, f_popup_getposition},
+    {"popup_getpos", 1, 1, f_popup_getpos},
     {"popup_hide",	1, 1, f_popup_hide},
     {"popup_move",	2, 2, f_popup_move},
     {"popup_show",	1, 1, f_popup_show},


### PR DESCRIPTION
`f_popup_getposition` seems to have been removed in 8.1.1429

switch this method to use `f_popup_getpos` instead