### PR TITLE
Test_writefile_fails_conversion2 fail when built under /tmp

### DIFF
--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -38,7 +38,7 @@ func Test_writefile_fails_conversion()
   endif
   " Without a backup file the write won't happen if there is a conversion
   " error.
-  set nobackup nowritebackup
+  set nobackup nowritebackup backupdir=. backupskip=
   new
   let contents = ["line one", "line two"]
   call writefile(contents, 'Xfile')
@@ -49,7 +49,7 @@ func Test_writefile_fails_conversion()
 
   call delete('Xfile')
   bwipe!
-  set backup& writebackup&
+  set backup& writebackup& backupdir&vim backupskip&vim
 endfunc
 
 func Test_writefile_fails_conversion2()
@@ -58,7 +58,7 @@ func Test_writefile_fails_conversion2()
   endif
   " With a backup file the write happens even if there is a conversion error,
   " but then the backup file must remain
-  set nobackup writebackup
+  set nobackup writebackup backupdir=. backupskip=
   let contents = ["line one", "line two"]
   call writefile(contents, 'Xfile_conversion_err')
   edit Xfile_conversion_err
@@ -71,6 +71,7 @@ func Test_writefile_fails_conversion2()
   call delete('Xfile_conversion_err')
   call delete('Xfile_conversion_err~')
   bwipe!
+  set backup& writebackup& backupdir&vim backupskip&vim
 endfunc
 
 func SetFlag(timer)


### PR DESCRIPTION
`Test_writefile_fails_conversion2` fails when Vim built under `/tmp`.

To Reproduce:
1. Build Vim under `/tmp`.
    ```
    $ cd /tmp
    $ git clone -b v8.1.1432 https://github.com/vim/vim.git
    $ cd vim
    $ ./configure --disable-gui
    $ make -j4
    ```
2. Run `test_writefile`.
    ```
    $ cd src/testdir/
    $ make test_writefile
    ```
3. `Test_writefile_fails_conversion2` fails with following messages.
    ```
    ...
    From test_writefile.vim:
    Executing Test_nowrite_quit_split()
    Executing Test_write_quit_split()
    Executing Test_writefile()
    Executing Test_writefile_autowrite()
    Executing Test_writefile_autowrite_nowrite()
    Executing Test_writefile_fails_conversion()
    Executing Test_writefile_fails_conversion2()
    Executing Test_writefile_fails_gently()
    Executing Test_writefile_sync_arg()
    Executing Test_writefile_sync_dev_stdout()
    Executed 10 tests
    1 FAILED:
    Found errors in Test_writefile_fails_conversion2():
    Caught exception in Test_writefile_fails_conversion2(): Vim(call):E484: Can't open file Xfile_conversion_err~ @ function RunTheTest[40]..Test_writefile_fails_conversion2, line 14
    ```

This pull request fixes this problem (ref: https://github.com/vim/vim/issues/3301#issuecomment-411821461).

Environment:
 - Vim version: v8.1.1432
 - OS: Arch Linux
 - Terminal: [termite](https://github.com/thestinger/termite)