### PR TITLE
doc: improve help for syn-off  [ci skip]

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5210,6 +5210,15 @@ load the syntax file.
 The command also deletes the "b:current_syntax" variable, since no syntax is
 loaded after this command.
 
+To clean up specific syntax groups for the current buffer: >
+  :syntax clear {group-name} ..
+This removes all patterns and keywords for {group-name}.
+
+To clean up specific syntax group lists for the current buffer: >
+  :syntax clear @{grouplist-name} ..
+This sets {grouplist-name}'s contents to an empty list.
+
+						*:syntax-off* *:syn-off*
 If you want to disable syntax highlighting for all buffers, you need to remove
 the autocommands that load the syntax files: >
   :syntax off
@@ -5218,14 +5227,6 @@ What this command actually does, is executing the command >
   :source $VIMRUNTIME/syntax/nosyntax.vim
 See the "nosyntax.vim" file for details.  Note that for this to work
 $VIMRUNTIME must be valid.  See |$VIMRUNTIME|.
-
-To clean up specific syntax groups for the current buffer: >
-  :syntax clear {group-name} ..
-This removes all patterns and keywords for {group-name}.
-
-To clean up specific syntax group lists for the current buffer: >
-  :syntax clear @{grouplist-name} ..
-This sets {grouplist-name}'s contents to an empty list.
 
 						*:syntax-reset* *:syn-reset*
 If you have changed the colors and messed them up, use this command to get the

--- a/runtime/doc/usr_06.txt
+++ b/runtime/doc/usr_06.txt
@@ -196,13 +196,12 @@ too slow, you might want to disable syntax highlighting for a moment: >
 
 When editing another file (or the same one) the colors will come back.
 
-							*:syn-off*
 If you want to stop highlighting completely use: >
 
 	:syntax off
 
-This will completely disable syntax highlighting and remove it immediately for
-all buffers.
+This will disable syntax highlighting and remove it for all buffers.
+See |:syntax-off| for more details.
 
 							*:syn-manual*
 If you want syntax highlighting only for specific files, use this: >


### PR DESCRIPTION
- move syntax-off to own section, previously it was mixed with syn-clear
- usr_06.txt: move/use syn-off tag to/in syntax.txt