### PR TITLE
Adjust popup position to the left if run out of space. Add fixed option.

### DIFF
--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -65,8 +65,10 @@ The width of the window is normally equal to the longest line in the buffer.
 It can be limited with the "maxwidth" property.  You can use spaces to
 increase the width or the "minwidth" property.
 
-By default the 'wrap' option is set, so that no text disappears.  However, if
-there is not enough space, some text may be invisible.
+By default the 'wrap' option is set, so that no text disappears.  Otherwise,
+if there is not enough space then the window is shifted left in order to
+display more text. This can be disabled with the "fixed" property. Also
+disabled when right-aligned.
 
 Vim tries to show the popup in the location you specify.  In some cases, e.g.
 when the popup would go outside of the Vim window, it will show it somewhere
@@ -331,18 +333,27 @@ The second argument of |popup_create()| is a dictionary with options:
 			number or "cursor", "cursor+1" or "cursor-1" to use
 			the line of the cursor and add or subtract a number of
 			lines; if omitted the popup is vertically centered,
-			otherwise "pos" is used.
+			otherwise "pos" is used. The first line is 1.
 	col		screen column where to position the popup; can use a
 			number or "cursor" to use the column of the cursor,
 			"cursor+99" and "cursor-99" to add or subtract a
 			number of columns; if omitted the popup is
-			horizontally centered, otherwise "pos" is used
+			horizontally centered, otherwise "pos" is used.
+			The first column is 1.
 	pos		"topleft", "topright", "botleft" or "botright":
 			defines what corner of the popup "line" and "col" are
 			used for.  When not set "topleft" is used.
 			Alternatively "center" can be used to position the
 			popup in the center of the Vim window, in which case
 			"line" and "col" are ignored.
+	fixed		When FALSE (the default), and:
+			 - "pos" is "botleft" or "topleft", and
+			 - "wrap" is off, and
+			 - the popup would be truncated by the right-edge of
+			   the screen, then
+			the popup is moved to the left so as to fit the
+			contents on the screen, like |popupmenu-completion|.
+			Set to TRUE to disable this.
 	flip		when TRUE (the default) and the position is relative
 			to the cursor, flip to below or above the cursor to
 			avoid overlap with the |popupmenu-completion| or

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -84,6 +84,8 @@ get_pos_options(win_T *wp, dict_T *dict)
     if (nr > 0)
 	wp->w_wantcol = nr;
 
+    wp->w_popup_fixed = dict_get_number(dict, (char_u*)"fixed") == TRUE;
+
     str = dict_get_string(dict, (char_u *)"pos", FALSE);
     if (str != NULL)
     {
@@ -379,6 +381,7 @@ popup_adjust_position(win_T *wp)
     int		maxwidth;
     int		center_vert = FALSE;
     int		center_hor = FALSE;
+    int		allow_adjust_left = !wp->w_popup_fixed;
 
     wp->w_winrow = 0;
     wp->w_wincol = 0;
@@ -412,10 +415,14 @@ popup_adjust_position(win_T *wp)
     }
 
     // When centering or right aligned, use maximum width.
-    // When left aligned use the space available.
+    // When left aligned use the space available, but shift to the left when we
+    // hit the right of the screen.
     maxwidth = Columns - wp->w_wincol;
     if (wp->w_maxwidth > 0 && maxwidth > wp->w_maxwidth)
+    {
+	allow_adjust_left = FALSE;
 	maxwidth = wp->w_maxwidth;
+    }
 
     // Compute width based on longest text line and the 'wrap' option.
     // TODO: more accurate wrapping
@@ -424,10 +431,32 @@ popup_adjust_position(win_T *wp)
     {
 	int len = vim_strsize(ml_get_buf(wp->w_buffer, lnum, FALSE));
 
-	while (wp->w_p_wrap && len > maxwidth)
+	if (wp->w_p_wrap)
 	{
-	    ++wrapped;
-	    len -= maxwidth;
+	    while (len > maxwidth)
+	    {
+		++wrapped;
+		len -= maxwidth;
+		wp->w_width = maxwidth;
+	    }
+	}
+	else if ( len > maxwidth &&
+		  allow_adjust_left &&
+		  ( wp->w_popup_pos == POPPOS_TOPLEFT ||
+		    wp->w_popup_pos == POPPOS_BOTLEFT ) )
+	{
+	    // adjust leftwise to fit text on screen
+	    int shift_by = ( len - maxwidth );
+
+	    if ( shift_by > wp->w_wincol )
+	    {
+		int truncate_shift = shift_by - wp->w_wincol;
+		len -= truncate_shift;
+		shift_by -= truncate_shift;
+	    }
+
+	    wp->w_wincol -= shift_by;
+	    maxwidth += shift_by;
 	    wp->w_width = maxwidth;
 	}
 	if (wp->w_width < len)
@@ -896,6 +925,7 @@ f_popup_getoptions(typval_T *argvars, typval_T *rettv)
 	dict_add_number(dict, "maxheight", wp->w_maxheight);
 	dict_add_number(dict, "maxwidth", wp->w_maxwidth);
 	dict_add_number(dict, "zindex", wp->w_zindex);
+	dict_add_number(dict, "fixed", wp->w_popup_fixed);
 
 	for (i = 0; i < (int)(sizeof(poppos_entries) / sizeof(poppos_entry_T));
 									   ++i)

--- a/src/structs.h
+++ b/src/structs.h
@@ -2881,6 +2881,7 @@ struct window_S
 #ifdef FEAT_TEXT_PROP
     int		w_popup_flags;	    // POPF_ values
     poppos_T	w_popup_pos;
+    int 	w_popup_fixed;	    // Don't shift popup to fit on screen
     int		w_zindex;
     int		w_minheight;	    // "minheight" for popup window
     int		w_minwidth;	    // "minwidth" for popup window

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -422,6 +422,7 @@ func Test_popup_getoptions()
     \ 'maxheight': 21,
     \ 'zindex': 100,
     \ 'time': 5000,
+    \ 'fixed': 1
     \})
   redraw
   let res = popup_getoptions(winid)
@@ -432,6 +433,7 @@ func Test_popup_getoptions()
   call assert_equal(20, res.maxwidth)
   call assert_equal(21, res.maxheight)
   call assert_equal(100, res.zindex)
+  call assert_equal(1, res.fixed)
   if has('timers')
     call assert_equal(5000, res.time)
   endif
@@ -447,6 +449,7 @@ func Test_popup_getoptions()
   call assert_equal(0, res.maxwidth)
   call assert_equal(0, res.maxheight)
   call assert_equal(50, res.zindex)
+  call assert_equal(0, res.fixed)
   if has('timers')
     call assert_equal(0, res.time)
   endif
@@ -596,3 +599,183 @@ func Test_popup_close_callback()
   call popup_close(winid, 'done')
   call assert_equal('done', g:result)
 endfunc
+
+func s:VerifyPosition( p, msg, line, col, width, height )
+  call assert_equal( a:line,   popup_getpos( a:p ).line,   a:msg . ' (l)' )
+  call assert_equal( a:col,    popup_getpos( a:p ).col,    a:msg . ' (c)' )
+  call assert_equal( a:width,  popup_getpos( a:p ).width,  a:msg . ' (w)' )
+  call assert_equal( a:height, popup_getpos( a:p ).height, a:msg . ' (h)' )
+endfunc
+
+func Test_popup_position_adjust()
+  " Anything placed past 2 cells from of the right of the screen is moved to the
+  " left.
+  "
+  " When wrapping is disabled, we also shift to the left to display on the
+  " screen, unless fixed is set.
+
+  " Entries for cases which don't vary based on wrapping.
+  " Format is per tests described below
+  let both_wrap_tests = [
+        \       [ 'a', 5, &columns,        5, &columns - 2, 1, 1 ],
+        \       [ 'b', 5, &columns + 1,    5, &columns - 2, 1, 1 ],
+        \       [ 'c', 5, &columns - 1,    5, &columns - 2, 1, 1 ],
+        \       [ 'd', 5, &columns - 2,    5, &columns - 2, 1, 1 ],
+        \       [ 'e', 5, &columns - 3,    5, &columns - 3, 1, 1 ],
+        \
+        \       [ 'aa', 5, &columns,        5, &columns - 2, 2, 1 ],
+        \       [ 'bb', 5, &columns + 1,    5, &columns - 2, 2, 1 ],
+        \       [ 'cc', 5, &columns - 1,    5, &columns - 2, 2, 1 ],
+        \       [ 'dd', 5, &columns - 2,    5, &columns - 2, 2, 1 ],
+        \       [ 'ee', 5, &columns - 3,    5, &columns - 3, 2, 1 ],
+        \
+        \       [ 'aaa', 5, &columns,        5, &columns - 2, 3, 1 ],
+        \       [ 'bbb', 5, &columns + 1,    5, &columns - 2, 3, 1 ],
+        \       [ 'ccc', 5, &columns - 1,    5, &columns - 2, 3, 1 ],
+        \       [ 'ddd', 5, &columns - 2,    5, &columns - 2, 3, 1 ],
+        \       [ 'eee', 5, &columns - 3,    5, &columns - 3, 3, 1 ],
+        \ ]
+
+  " these test groups are dicts with:
+  "  - comment: something to identify the group of tests by
+  "  - options: dict of options to merge with the row/col in tests
+  "  - tests: list of cases. Each one is a list with elements:
+  "     - text
+  "     - row
+  "     - col
+  "     - expected row
+  "     - expected col
+  "     - expected width
+  "     - expected height
+  let tests = [
+        \ {
+        \   'comment': 'left-aligned with wrapping',
+        \   'options': {
+        \     'wrap': 1,
+        \     'pos': 'botleft',
+        \   },
+        \   'tests': both_wrap_tests + [
+        \       [ 'aaaa', 5, &columns,        4, &columns - 2, 3, 2 ],
+        \       [ 'bbbb', 5, &columns + 1,    4, &columns - 2, 3, 2 ],
+        \       [ 'cccc', 5, &columns - 1,    4, &columns - 2, 3, 2 ],
+        \       [ 'dddd', 5, &columns - 2,    4, &columns - 2, 3, 2 ],
+        \       [ 'eeee', 5, &columns - 3,    5, &columns - 3, 4, 1 ],
+        \   ],
+        \ },
+        \ {
+        \   'comment': 'left aligned without wrapping',
+        \   'options': {
+        \     'wrap': 0,
+        \     'pos': 'botleft',
+        \   },
+        \   'tests': both_wrap_tests + [
+        \       [ 'aaaa', 5, &columns,        5, &columns - 3, 4, 1 ],
+        \       [ 'bbbb', 5, &columns + 1,    5, &columns - 3, 4, 1 ],
+        \       [ 'cccc', 5, &columns - 1,    5, &columns - 3, 4, 1 ],
+        \       [ 'dddd', 5, &columns - 2,    5, &columns - 3, 4, 1 ],
+        \       [ 'eeee', 5, &columns - 3,    5, &columns - 3, 4, 1 ],
+        \   ],
+        \ },
+        \ {
+        \   'comment': 'left aligned with fixed position',
+        \   'options': {
+        \     'wrap': 0,
+        \     'fixed': 1,
+        \     'pos': 'botleft',
+        \   },
+        \   'tests': both_wrap_tests + [
+        \       [ 'aaaa', 5, &columns,        5, &columns - 2, 3, 1 ],
+        \       [ 'bbbb', 5, &columns + 1,    5, &columns - 2, 3, 1 ],
+        \       [ 'cccc', 5, &columns - 1,    5, &columns - 2, 3, 1 ],
+        \       [ 'dddd', 5, &columns - 2,    5, &columns - 2, 3, 1 ],
+        \       [ 'eeee', 5, &columns - 3,    5, &columns - 3, 4, 1 ],
+        \   ],
+        \ },
+      \ ]
+
+  for test_group in tests
+    for test in test_group.tests
+      let [ text, line, col, e_line, e_col, e_width, e_height ] = test
+      let options = {
+            \ 'line': line,
+            \ 'col': col,
+            \ }
+      call extend( options, test_group.options )
+
+      let p = popup_create( text, options )
+
+      let msg = string( extend( options, { 'text': text } ) )
+      call s:VerifyPosition( p, msg, e_line, e_col, e_width, e_height )
+      call popup_close( p )
+    endfor
+  endfor
+
+  popupclear
+  %bwipe!
+endfunc
+
+function Test_adjust_left_past_screen_width()
+  " width of screen
+  let X = join(map(range(&columns), {->'X'}), '')
+
+  let p = popup_create( X, { 'line': 1, 'col': 1, 'wrap': 0 } )
+  call s:VerifyPosition( p, 'full width topleft', 1, 1, &columns, 1 )
+
+  redraw
+  let line = join(map(range(1, &columns + 1), 'screenstring(1, v:val)'), '')
+  call assert_equal(X, line)
+
+  call popup_close( p )
+  redraw
+
+  " Same if placed on the right hand side
+  let p = popup_create( X, { 'line': 1, 'col': &columns, 'wrap': 0 } )
+  call s:VerifyPosition( p, 'full width topright', 1, 1, &columns, 1 )
+
+  redraw
+  let line = join(map(range(1, &columns + 1), 'screenstring(1, v:val)'), '')
+  call assert_equal(X, line)
+
+  call popup_close( p )
+  redraw
+
+  " Extend so > window width
+  let X .= 'x'
+
+  let p = popup_create( X, { 'line': 1, 'col': 1, 'wrap': 0 } )
+  call s:VerifyPosition( p, 'full width +  1 topleft', 1, 1, &columns, 1 )
+
+  redraw
+  let line = join(map(range(1, &columns + 1), 'screenstring(1, v:val)'), '')
+  call assert_equal(X[ : -2 ], line)
+
+  call popup_close( p )
+  redraw
+
+  " Shifted then truncated (the x is not visible)
+  let p = popup_create( X, { 'line': 1, 'col': &columns - 3, 'wrap': 0 } )
+  call s:VerifyPosition( p, 'full width + 1 topright', 1, 1, &columns, 1 )
+
+  redraw
+  let line = join(map(range(1, &columns + 1), 'screenstring(1, v:val)'), '')
+  call assert_equal(X[ : -2 ], line)
+
+  call popup_close( p )
+  redraw
+
+  " Not shifted, just truncated
+  let p = popup_create( X,
+        \ { 'line': 1, 'col': 2, 'wrap': 0, 'fixed': 1 } )
+  call s:VerifyPosition( p, 'full width + 1 fixed', 1, 2, &columns - 1, 1)
+
+  redraw
+  let line = join(map(range(1, &columns + 1), 'screenstring(1, v:val)'), '')
+  let e_line = ' ' . X[ 1 : -2 ]
+  call assert_equal(e_line, line)
+
+  call popup_close( p )
+  redraw
+
+  popupclear
+  %bwipe!
+endfunction


### PR DESCRIPTION
When the popup is left-aligned and run out of screen columns to display
it, and wrapping is not enabled, adjust the position left in order to
disaply as much of the popup contents as possible, much like the
completion PUM.

this is particularly useful for argument hints becuase it allows the
maximum amound of hinting visible while remaining
one-signature-per-line.

Maybe this is controversial, so I guess discuss.

Demo shows the adjustment (the plugin is setting the wantcol to the position of the `(` and having it automatically adjusted):

![YCM-popup-win-adjust](https://user-images.githubusercontent.com/10584846/58746944-39050a00-845c-11e9-8910-31dc9a9a8dbb.gif)


