### PR TITLE
popupwin is always in front and never behind anything such as statusline and vertsplit.

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -987,6 +987,11 @@ update_debug_sign(buf_T *buf, linenr_T lnum)
 	    win_redr_status(wp, FALSE);
     }
 
+#ifdef FEAT_TEXT_PROP
+    // Display popup windows on top of the others.
+    update_popups();
+#endif
+
     update_finish();
 }
 #endif
@@ -1068,6 +1073,11 @@ updateWindow(win_T *wp)
 # endif
 	    )
 	win_redr_status(wp, FALSE);
+
+#ifdef FEAT_TEXT_PROP
+    // Display popup windows on top of the others.
+    update_popups();
+#endif
 
     update_finish();
 }
@@ -6653,6 +6663,11 @@ redraw_statuslines(void)
 	    win_redr_status(wp, FALSE);
     if (redraw_tabline)
 	draw_tabline();
+
+#ifdef FEAT_TEXT_PROP
+    // Display popup windows on top of the others.
+    update_popups();
+#endif
 }
 
 #if defined(FEAT_WILDMENU) || defined(PROTO)
@@ -10959,6 +10974,11 @@ showruler(int always)
     /* Redraw the tab pages line if needed. */
     if (redraw_tabline)
 	draw_tabline();
+
+#ifdef FEAT_TEXT_PROP
+    // Display popup windows on top of the others.
+    update_popups();
+#endif
 }
 
 #ifdef FEAT_CMDL_INFO

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -539,6 +539,7 @@ func Test_popup_never_behind()
             \   'line' : line,
             \   'col' : col,
             \ })
+  redraw
   let s = ''
   for i in range(0, 4)
       let s .= nr2char(screenchar(line + 1, col + i))

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -540,6 +540,7 @@ func Test_popup_never_behind()
             \   'col' : col,
             \ })
   redraw
+  1wincmd w
   let s = ''
   for i in range(0, 4)
       let s .= nr2char(screenchar(line + 1, col + i))

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -547,4 +547,3 @@ func Test_popup_never_behind()
   popupclear
 endfunc
 
-call Test_popup_never_behind()

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4,7 +4,7 @@ if !has('textprop')
   finish
 endif
 
-"source screendump.vim
+source screendump.vim
 
 func Test_simple_popup()
   if !CanRunVimInTerminal()

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4,7 +4,7 @@ if !has('textprop')
   finish
 endif
 
-source screendump.vim
+"source screendump.vim
 
 func Test_simple_popup()
   if !CanRunVimInTerminal()
@@ -516,3 +516,35 @@ func Test_popup_filter()
   delfunc MyPopupFilter
   popupclear
 endfunc
+
+func Test_popup_never_behind()
+  " +-----------------------------+
+  " |             |               |
+  " |             |               |
+  " |             |               |
+  " |            line1            |
+  " |------------line2------------|
+  " |            line3            |
+  " |            line4            |
+  " |                             |
+  " |                             |
+  " +-----------------------------+
+  only 
+  split
+  vsplit
+  let info_window1 = getwininfo()[0]
+  let line = info_window1['height']
+  let col = info_window1['width']
+  call popup_create(['line1', 'line2', 'line3', 'line4'], {
+            \   'line' : line,
+            \   'col' : col,
+            \ })
+  let s = ''
+  for i in range(0, 4)
+      let s .= nr2char(screenchar(line + 1, col + i))
+  endfor
+  call assert_equal('line2', s)
+  popupclear
+endfunc
+
+call Test_popup_never_behind()


### PR DESCRIPTION
__before__
![before](https://user-images.githubusercontent.com/1595779/58752381-ede50880-84e8-11e9-9bac-ad8d81a599d7.jpg)

__after__
![after](https://user-images.githubusercontent.com/1595779/58752419-7499e580-84e9-11e9-9a5f-fff2d1bd810b.jpg)
