### PR TITLE
Add support for terminal foreground/background responses formatted as rr/gg/bb

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -4961,7 +4961,7 @@ check_termcode(
 
 	    /* Check for fore/background color response from the terminal:
 	     *
-	     *       {lead}{code};rgb:{rrrr}/{gggg}/{bbbb}{tail}
+	     *       {lead}{code};rgb:{rr[rr]}/{gg[gg]}/{bb[bb]}{tail}
 	     *
 	     * {code} is 10 for foreground, 11 for background
 	     * {lead} can be <Esc>] or OSC
@@ -4985,14 +4985,27 @@ check_termcode(
 			: (tp[i] == ESC && i + 1 < len && tp[i + 1] == '\\')))
 		    {
 			int is_bg = argp[1] == '1';
+			// 4-digit hex format: rrrr/gggg/bbbb
+			int is_large_color_format = i - j >= 21
+			    && tp[j + 11] == '/' && tp[j + 16] == '/';
 
-			if (i - j >= 21 && STRNCMP(tp + j + 3, "rgb:", 4) == 0
-			    && tp[j + 11] == '/' && tp[j + 16] == '/')
+			if (i - j >= 14 && STRNCMP(tp + j + 3, "rgb:", 4) == 0
+			    && (is_large_color_format
+				|| tp[j + 9] == '/' && tp[i + 12 == '/']))
 			{
 # ifdef FEAT_TERMINAL
-			    int rval = hexhex2nr(tp + j + 7);
-			    int gval = hexhex2nr(tp + j + 12);
-			    int bval = hexhex2nr(tp + j + 17);
+			    int rval, gval, bval;
+			    rval = hexhex2nr(tp + j + 7);
+			    if (is_large_color_format)
+			    {
+				gval = hexhex2nr(tp + j + 12);
+				bval = hexhex2nr(tp + j + 17);
+			    }
+			    else
+			    {
+				gval = hexhex2nr(tp + j + 10);
+				bval = hexhex2nr(tp + j + 13);
+			    }
 # endif
 			    if (is_bg)
 			    {


### PR DESCRIPTION
Vim sets the 'background' option based on the terminal's response to a request for background color.
Vim only supports the following format for the color from the terminal: `rgb:rrrr/gggg/bbbb`.

This PR adds support for this format: `rgb:rr/gg/bb`.

Context: [this comment on an Alacritty pull request](https://github.com/jwilm/alacritty/pull/2495#discussion_r289637940).
(Summary: the xterm documentation specifies that the response for the foreground/background request is in the same format as setting the color.
Since Alacritty does not support setting the color in the `rrrr/gggg/bbbb` format, it responds with the `rr/gg/bb` format.)

If appropriate, I'm happy to close this PR and redirect another one to Alacritty instead, but I believe that supporting this format will help Vim to support more terminals that interpret the xterm docs in the same way.
