### PR TITLE
Fix search pattern on rightleft

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1478,7 +1478,7 @@ do_search(
 			if (r - msgbuf >= pat_len)
 			    vim_memset(r, ' ', pat_len);
 			else
-			    vim_memset(r + pat_len - (r - msgbuf), ' ', r - msgbuf);
+			    vim_memset(msgbuf + pat_len, ' ', r - msgbuf);
 		    }
 		}
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -1462,6 +1462,7 @@ do_search(
 		if (curwin->w_p_rl && *curwin->w_p_rlc == 's')
 		{
 		    char_u *r;
+		    size_t pat_len;
 
 		    r = reverse_text(msgbuf);
 		    if (r != NULL)
@@ -1471,9 +1472,13 @@ do_search(
 			// move reversed text to beginning of buffer
 			while (*r != NUL && *r == ' ')
 			    r++;
-			mch_memmove(msgbuf, r, msgbuf + STRLEN(msgbuf) - r);
+			pat_len = msgbuf + STRLEN(msgbuf) - r;
+			mch_memmove(msgbuf, r, pat_len);
 			// overwrite old text
-			vim_memset(r, ' ', msgbuf + STRLEN(msgbuf) - r);
+			if (r - msgbuf >= pat_len)
+			    vim_memset(r, ' ', pat_len);
+			else
+			    vim_memset(r + pat_len - (r - msgbuf), ' ', r - msgbuf);
 		    }
 		}
 #endif

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -1289,3 +1289,25 @@ func Test_search_match_at_curpos()
 
   close!
 endfunc
+
+func Test_search_display_pattern()
+  new
+  call setline(1, ['foo', 'bar', 'foobar'])
+
+  call cursor(1, 1)
+  let @/ = 'foo'
+  let pat = escape(@/, '()*?'. '\s\+')
+  let g:a = execute(':unsilent :norm! n')
+  call assert_match(pat, g:a)
+
+  " right-left
+  if exists("+rightleft")
+    set rl
+    call cursor(1, 1)
+    let @/ = 'foo'
+    let pat = 'oof/\s\+'
+    let g:a = execute(':unsilent :norm! n')
+    call assert_match(pat, g:a)
+    set norl
+  endif
+endfunc


### PR DESCRIPTION
When overwriting old text, if the text overlaps, it was corrected because it was not considered.

fixes #4488.