### PR TITLE
Do not trigger TerminalOpen on :!cmd if guioptions contains '!'

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4352,7 +4352,7 @@ build_argv(
     static int
 mch_call_shell_terminal(
     char_u	*cmd,
-    int		options UNUSED)	/* SHELL_*, see vim.h */
+    int		options)	/* SHELL_*, see vim.h */
 {
     jobopt_T	opt;
     char	**argv = NULL;
@@ -4369,7 +4369,8 @@ mch_call_shell_terminal(
 
     init_job_options(&opt);
     ch_log(NULL, "starting terminal for system command '%s'", cmd);
-    buf = term_start(NULL, argv, &opt, TERM_START_SYSTEM);
+    buf = term_start(NULL, argv, &opt, TERM_START_SYSTEM |
+	    (options & SHELL_NOTERMAUTOCMD ? TERM_START_NOAUTOCMD : 0));
     if (buf == NULL)
 	goto theend;
 
@@ -5363,7 +5364,7 @@ mch_call_shell(
 {
 #if defined(FEAT_GUI) && defined(FEAT_TERMINAL)
     if (gui.in_use && vim_strchr(p_go, GO_TERMINAL) != NULL)
-	return mch_call_shell_terminal(cmd, options);
+	return mch_call_shell_terminal(cmd, options | SHELL_NOTERMAUTOCMD);
 #endif
 #ifdef USE_SYSTEM
     return mch_call_shell_system(cmd, options);

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4517,7 +4517,7 @@ mch_system(char *cmd, int options)
     static int
 mch_call_shell_terminal(
     char_u	*cmd,
-    int		options UNUSED)	/* SHELL_*, see vim.h */
+    int		options)	/* SHELL_*, see vim.h */
 {
     jobopt_T	opt;
     char_u	*newcmd = NULL;
@@ -4552,7 +4552,8 @@ mch_call_shell_terminal(
     argvar[0].v_type = VAR_STRING;
     argvar[0].vval.v_string = newcmd;
     argvar[1].v_type = VAR_UNKNOWN;
-    buf = term_start(argvar, NULL, &opt, TERM_START_SYSTEM);
+    buf = term_start(argvar, NULL, &opt, TERM_START_SYSTEM |
+	    (options & SHELL_NOTERMAUTOCMD ? TERM_START_NOAUTOCMD : 0));
     if (buf == NULL)
     {
 	vim_free(newcmd);
@@ -4649,7 +4650,7 @@ mch_call_shell(
 	 && (options & (SHELL_FILTER|SHELL_DOOUT|SHELL_WRITE|SHELL_READ)) == 0)
     {
 	/* Use a terminal window to run the command in. */
-	x = mch_call_shell_terminal(cmd, options);
+	x = mch_call_shell_terminal(cmd, options | SHELL_NOTERMAUTOCMD);
 # ifdef FEAT_TITLE
 	resettitle();
 # endif

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -673,7 +673,8 @@ term_start(
 	return NULL;
     }
 
-    apply_autocmds(EVENT_TERMINALOPEN, NULL, NULL, FALSE, newbuf);
+    if (!(flags & TERM_START_NOAUTOCMD))
+	apply_autocmds(EVENT_TERMINALOPEN, NULL, NULL, FALSE, newbuf);
     return newbuf;
 }
 

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -807,3 +807,20 @@ func Test_gui_dash_y()
   call delete('Xscriptgui')
   call delete('Xtestgui')
 endfunc
+
+" Test for using `guioptions+=!`, should not trigger TerminalOpen autocmd
+func Test_gui_shell()
+  new
+  set number
+  !true
+  call assert_equal(1, &number)
+  autocmd TerminalOpen * :set nonumber
+  !true
+  call assert_equal(1, &number)
+  set guioptions+=!
+  !true
+  call assert_equal(1, &number)
+  autocmd! TerminalOpen
+  set nonumber
+  bw!
+endfunc

--- a/src/vim.h
+++ b/src/vim.h
@@ -928,13 +928,14 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define REMAP_SKIP	-3	/* no remapping for first char */
 
 /* Values for mch_call_shell() second argument */
-#define SHELL_FILTER	1	/* filtering text */
-#define SHELL_EXPAND	2	/* expanding wildcards */
-#define SHELL_COOKED	4	/* set term to cooked mode */
-#define SHELL_DOOUT	8	/* redirecting output */
-#define SHELL_SILENT	16	/* don't print error returned by command */
-#define SHELL_READ	32	/* read lines and insert into buffer */
-#define SHELL_WRITE	64	/* write lines from buffer */
+#define SHELL_FILTER	1	// filtering text
+#define SHELL_EXPAND	2	// expanding wildcards
+#define SHELL_COOKED	4	// set term to cooked mode
+#define SHELL_DOOUT	8	// redirecting output
+#define SHELL_SILENT	16	// don't print error returned by command
+#define SHELL_READ	32	// read lines and insert into buffer
+#define SHELL_WRITE	64	// write lines from buffer
+#define SHELL_NOTERMAUTOCMD	128	// do not trigger TerminalOpen autocommand
 
 /* Values returned by mch_nodetype() */
 #define NODE_NORMAL	0	/* file or directory, check with mch_isdir()*/
@@ -2581,6 +2582,7 @@ long elapsed(DWORD start_tick);
 #define TERM_START_NOJOB	1
 #define TERM_START_FORCEIT	2
 #define TERM_START_SYSTEM	4
+#define TERM_START_NOAUTOCMD    8  // do not trigger TerminalOpen autocmd
 
 // Used for icon/title save and restore.
 #define SAVE_RESTORE_TITLE	1


### PR DESCRIPTION
This fixes #4497 by making sure not to trigger TerminalOpen autocommand when `!` is present in guioptions. I am not sure this is the right approach, but I guess, `TerminalOpen` should not be triggered for simple `!` commands.