### PR TITLE
Fix !start with guioptions+=!

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -3251,7 +3251,11 @@ call_shell(char_u *cmd, int opt)
 	/* The external command may update a tags file, clear cached tags. */
 	tag_freematch();
 
-	if (cmd == NULL || *p_sxq == NUL)
+	if (cmd == NULL || *p_sxq == NUL
+#if defined(FEAT_GUI) && defined(FEAT_TERMINAL)
+		|| vim_strchr(p_go, GO_TERMINAL) != NULL
+#endif
+		)
 	    retval = mch_call_shell(cmd, opt);
 	else
 	{

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -3252,7 +3252,7 @@ call_shell(char_u *cmd, int opt)
 	tag_freematch();
 
 	if (cmd == NULL || *p_sxq == NUL
-#if defined(FEAT_GUI) && defined(FEAT_TERMINAL)
+#if defined(MSWIN) && defined(FEAT_GUI) && defined(FEAT_TERMINAL)
 		|| vim_strchr(p_go, GO_TERMINAL) != NULL
 #endif
 		)

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4648,12 +4648,24 @@ mch_call_shell(
 	vim_strchr(p_go, GO_TERMINAL) != NULL
 	 && (options & (SHELL_FILTER|SHELL_DOOUT|SHELL_WRITE|SHELL_READ)) == 0)
     {
-	/* Use a terminal window to run the command in. */
-	x = mch_call_shell_terminal(cmd, options);
+	char_u	*cmdbase = cmd;
+
+	/* Skip a leading ", ( and "(. */
+	if (*cmdbase == '"' )
+	    ++cmdbase;
+	if (*cmdbase == '(')
+	    ++cmdbase;
+
+	/* Check the command is not start with "start " */
+	if ((STRNICMP(cmdbase, "start", 5) != 0) || !VIM_ISWHITE(cmdbase[5]))
+	{
+	    /* Use a terminal window to run the command in. */
+	    x = mch_call_shell_terminal(cmd, options);
 # ifdef FEAT_TITLE
-	resettitle();
+	    resettitle();
 # endif
-	return x;
+	    return x;
+	}
     }
 #endif
 


### PR DESCRIPTION
If guioptions contains `!`,  run `!start C:\Program Files\xxx\yyy.exe` always fail since it is spawned via cmd.exe. This fix spawn the executable directly as same as guioptions does not contain `!`. Sorry, it is hard to add test.