### PR TITLE
Expanding special characters anywhere in a command string

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2326,6 +2326,7 @@ extend({expr1}, {expr2} [, {expr3}])
 exp({expr})			Float	exponential of {expr}
 expand({expr} [, {nosuf} [, {list}]])
 				any	expand special keywords in {expr}
+expandcmd({expr})		any	expand special keywords in {expr}
 feedkeys({string} [, {mode}])	Number	add key sequence to typeahead buffer
 filereadable({file})		Number	|TRUE| if {file} is a readable file
 filewritable({file})		Number	|TRUE| if {file} is a writable file
@@ -4212,6 +4213,14 @@ expand({expr} [, {nosuf} [, {list}]])				*expand()*
 		See |glob()| for finding existing files.  See |system()| for
 		getting the raw output of an external command.
 
+expandcmd({expr})					*expandcmd()*
+		Expand special keywords in {expr}.  See |expand()| for the
+		list of special keywords. The special keywords anywhere in
+		{expr} are expanded. Environment variables in {expr} are also
+		expanded.  Returns the expanded string.
+		Example: >
+			:echo expandcmd('make %<.o')
+<
 extend({expr1}, {expr2} [, {expr3}])			*extend()*
 		{expr1} and {expr2} must be both |Lists| or both
 		|Dictionaries|.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -609,6 +609,7 @@ String manipulation:					*string-functions*
 	strcharpart()		get part of a string using char index
 	strgetchar()		get character from a string using char index
 	expand()		expand special keywords
+	expandcmd()		expand all the special keywords in a string
 	iconv()			convert text from one encoding to another
 	byteidx()		byte index of a character in a string
 	byteidxcomp()		like byteidx() but count composing characters

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -149,6 +149,7 @@ static void f_exists(typval_T *argvars, typval_T *rettv);
 static void f_exp(typval_T *argvars, typval_T *rettv);
 #endif
 static void f_expand(typval_T *argvars, typval_T *rettv);
+static void f_expandcmd(typval_T *argvars, typval_T *rettv);
 static void f_extend(typval_T *argvars, typval_T *rettv);
 static void f_feedkeys(typval_T *argvars, typval_T *rettv);
 static void f_filereadable(typval_T *argvars, typval_T *rettv);
@@ -646,6 +647,7 @@ static struct fst
     {"exp",		1, 1, f_exp},
 #endif
     {"expand",		1, 3, f_expand},
+    {"expandcmd",	1, 1, f_expandcmd},
     {"extend",		2, 3, f_extend},
     {"feedkeys",	1, 2, f_feedkeys},
     {"file_readable",	1, 1, f_filereadable},	/* obsolete */
@@ -3782,6 +3784,33 @@ f_expand(typval_T *argvars, typval_T *rettv)
 	else
 	    rettv->vval.v_string = NULL;
     }
+}
+
+/*
+ * "expandcmd()" function
+ * Expand all the special characters in a command string.
+ */
+    static void
+f_expandcmd(typval_T *argvars, typval_T *rettv)
+{
+    exarg_T	eap;
+    char_u	*cmdstr;
+    char	*errormsg;
+
+    rettv->v_type = VAR_STRING;
+    cmdstr = vim_strsave(tv_get_string(&argvars[0]));
+
+    memset(&eap, 0, sizeof(eap));
+    eap.cmd = cmdstr;
+    eap.arg = cmdstr;
+    eap.argt |= NOSPC;
+    eap.usefilter = FALSE;
+    eap.nextcmd = NULL;
+    eap.cmdidx = CMD_USER;
+
+    expand_filename(&eap, &cmdstr, &errormsg);
+
+    rettv->vval.v_string = cmdstr;
 }
 
 /*

--- a/src/testdir/test_expand.vim
+++ b/src/testdir/test_expand.vim
@@ -73,8 +73,6 @@ func Test_expandcmd()
   call assert_equal('make abc.java', expandcmd('make abc.%:e'))
   call assert_equal('make Xabc.java', expandcmd('make %:s?file?abc?'))
   edit a1a2a3.rb
-  call assert_equal('make b1b2b3.rb', expandcmd('make %:gs?a?b?'))
-  call assert_equal('make a1a2a3', expandcmd('make %<'))
-  call assert_equal('make Xfile.o', expandcmd('make #<.o'))
+  call assert_equal('make b1b2b3.rb a1a2a3 Xfile.o', expandcmd('make %:gs?a?b? %< #<.o'))
   close
 endfunc

--- a/src/testdir/test_expand.vim
+++ b/src/testdir/test_expand.vim
@@ -47,3 +47,34 @@ func Test_expand_tilde_filename()
   call assert_match('\~', expand('%:p')) 
   bwipe!
 endfunc
+
+func Test_expandcmd()
+  let $FOO = 'Test'
+  call assert_equal('e x/Test/y', expandcmd('e x/$FOO/y'))
+  unlet $FOO
+
+  new
+  edit Xfile1
+  call assert_equal('e Xfile1', expandcmd('e %'))
+  edit Xfile2
+  edit Xfile1
+  call assert_equal('e Xfile2', expandcmd('e #'))
+  edit Xfile2
+  edit Xfile3
+  edit Xfile4
+  let bnum = bufnr('Xfile2')
+  call assert_equal('e Xfile2', expandcmd('e #' . bnum))
+  call setline('.', 'Vim!@#')
+  call assert_equal('e Vim', expandcmd('e <cword>'))
+  call assert_equal('e Vim!@#', expandcmd('e <cWORD>'))
+  enew!
+  edit Xfile.java
+  call assert_equal('e Xfile.py', expandcmd('e %:r.py'))
+  call assert_equal('make abc.java', expandcmd('make abc.%:e'))
+  call assert_equal('make Xabc.java', expandcmd('make %:s?file?abc?'))
+  edit a1a2a3.rb
+  call assert_equal('make b1b2b3.rb', expandcmd('make %:gs?a?b?'))
+  call assert_equal('make a1a2a3', expandcmd('make %<'))
+  call assert_equal('make Xfile.o', expandcmd('make #<.o'))
+  close
+endfunc


### PR DESCRIPTION
The expand() function can be used to expand special characters. If the special
characters appears anywhere in the command string, then this cannot be used.

Vim supports expanding special characters anywhere in a command string
for internal commands. For example, the 'makeprg' option accepts a command
string where special characters can occur anywhere in the string.
But a Vim plugin cannot support this. So plugins like dispatch.vim use a complicated
function to expand the special characters (look at the dispatch#expand() function in
https://github.com/tpope/vim-dispatch/blob/master/autoload/dispatch.vim).

This patch adds a expandcmd() function that can be used to expand all the
special characters in a command string.