### PR TITLE
Highlighting the match list in a popup window yet.

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4426,7 +4426,7 @@ win_line(
 		area_attr = 0;			/* stop highlighting */
 
 #ifdef FEAT_SEARCH_EXTRA
-	    if (!n_extra)
+	    if (!n_extra && !(screen_line_flags & SLF_POPUP))
 	    {
 		/*
 		 * Check for start/end of search pattern match.
@@ -4435,6 +4435,7 @@ win_line(
 		 * Watch out for matching an empty string!
 		 * Do this for 'search_hl' and the match list (ordered by
 		 * priority).
+		 * Not in a popup window.
 		 */
 		v = (long)(ptr - line);
 		cur = wp->w_match_head;


### PR DESCRIPTION
Highlighting the match list in a popup window yet such as the following:

![a](https://user-images.githubusercontent.com/1595779/59157719-95b29580-8aea-11e9-8a8b-ce057efe3511.jpg)

```

scriptencoding utf-8

function! AddMatches() abort
    call matchadd('ErrorMsg', '111')
    call matchadd('ErrorMsg', '222')
    call matchadd('ErrorMsg', '333')
endfunction

function! s:main() abort
    let lines = ['111 222 333', '444 555 666']
    new
    for lnum in range(1, len(lines))
        call setline(lnum, lines[lnum - 1])
    endfor
    setlocal buftype=nofile
    call AddMatches()

    let winid = popup_atcursor(lines, {
            \  'border' : [],
            \ })
    call win_execute(winid, 'call AddMatches()')
endfunction

call s:main()
```

