### PR TITLE
Fix regression 8.1.1492

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -3251,15 +3251,7 @@ call_shell(char_u *cmd, int opt)
 	/* The external command may update a tags file, clear cached tags. */
 	tag_freematch();
 
-	if (cmd == NULL || *p_sxq == NUL
-#if defined(FEAT_GUI_MSWIN) && defined(FEAT_TERMINAL)
-		|| (
-# ifdef VIMDLL
-		    gui.in_use &&
-# endif
-		    vim_strchr(p_go, GO_TERMINAL) != NULL)
-#endif
-		)
+	if (cmd == NULL || *p_sxq == NUL)
 	    retval = mch_call_shell(cmd, opt);
 	else
 	{

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4651,7 +4651,9 @@ mch_call_shell(
 	char_u	*cmdbase = cmd;
 
 	// Skip a leading quote and (.
-	while (*cmdbase == '"' || *cmdbase == '(')
+	if (*cmdbase == '"' )
+	    ++cmdbase;
+	if (*cmdbase == '(')
 	    ++cmdbase;
 
 	// Check the command does not begin with "start "


### PR DESCRIPTION
Sorry, 8.1.1492 is not completed. Changes for misc2.c is not required. When the first command-name is quoted, `system()` fail. If revert change of misc2.c  `("c:\go\bin\go.exe" "env" "GOPATH")` succeed.