### PR TITLE
Fix: measure a elapsed time in each test

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -133,11 +133,6 @@ func RunTheTest(test)
     endtry
   endif
 
-  let message = 'Executed ' . a:test
-  if has('reltime')
-    let message ..= ' in ' .. reltimestr(reltime(func_start)) .. ' seconds'
-  endif
-  call add(s:messages, message)
   let s:done += 1
 
   if a:test =~ 'Test_nocatch_'
@@ -193,6 +188,12 @@ func RunTheTest(test)
   endwhile
 
   exe 'cd ' . save_cwd
+
+  let message = 'Executed ' . a:test
+  if has('reltime')
+    let message ..= ' in ' .. reltimestr(reltime(func_start)) .. ' seconds'
+  endif
+  call add(s:messages, message)
 endfunc
 
 func AfterTheTest()


### PR DESCRIPTION
Current runtest.vim measures a elapsed time of only its preparation and "SetUp()" in each test.
It should move `reltimestr(reltime(func_start))` to the end of `RunTheTest()`.