### PR TITLE
Rename the "tab" entry of the second argument {options} of popup_create() to "tabpage".

### DIFF
--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -291,7 +291,7 @@ popup_notification({text}, {options})			 *popup_notification()*
 				\ 'line': 1,
 				\ 'col': 10,
 				\ 'time': 3000,
-				\ 'tab': -1,
+				\ 'tabpage': -1,
 				\ 'zindex': 200,
 				\ 'drag': 1,
 				\ 'highlight': 'WarningMsg',
@@ -402,9 +402,9 @@ The second argument of |popup_create()| is a dictionary with options:
 	hidden		When TRUE the popup exists but is not displayed; use
 			`popup_show()` to unhide it.
 			{not implemented yet}
-	tab		When -1: display the popup on all tabs.
+	tabpage		When -1: display the popup on all tab pages.
 			When 0 (the default): display the popup on the current
-			tab.
+			tab page.
 			Otherwise the number of the tab page the popup is
 			displayed on; when invalid the current tab is used.
 			{only -1 and 0 are implemented}

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -748,8 +748,8 @@ popup_create(typval_T *argvars, typval_T *rettv, create_type_T type)
     // Avoid that 'buftype' is reset when this buffer is entered.
     buf->b_p_initialized = TRUE;
 
-    if (dict_find(d, (char_u *)"tab", -1) != NULL)
-	nr = (int)dict_get_number(d, (char_u *)"tab");
+    if (dict_find(d, (char_u *)"tabpage", -1) != NULL)
+	nr = (int)dict_get_number(d, (char_u *)"tabpage");
     else if (type == TYPE_NOTIFICATION)
 	nr = -1;  // notifications are global by default
     else
@@ -757,7 +757,7 @@ popup_create(typval_T *argvars, typval_T *rettv, create_type_T type)
 
     if (nr == 0)
     {
-	// popup on current tab
+	// popup on current tab page
 	wp->w_next = curtab->tp_first_popupwin;
 	curtab->tp_first_popupwin = wp;
     }
@@ -1245,7 +1245,7 @@ not_in_popup_window()
 
 /*
  * Reset all the POPF_HANDLED flags in global popup windows and popup windows
- * in the current tab.
+ * in the current tab page.
  */
     void
 popup_reset_handled()

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -305,7 +305,7 @@ func Test_popup_in_tab()
   call assert_equal(0, bufexists(bufnr))
 
   " global popup is visible in any tab
-  let winid = popup_create("text", {'tab': -1})
+  let winid = popup_create("text", {'tabpage': -1})
   call assert_equal(1, popup_getpos(winid).visible)
   tabnew
   call assert_equal(1, popup_getpos(winid).visible)


### PR DESCRIPTION
Hi Bram and list,

"tab" has two meanings (Tab code [0x09] and Vim's Tab page).
in this case, it's a tab page.
So, I propose to rename the entry name from "tab" to "tabpage" for clarity.
How about it?

--
Best regards,
Hirohito Higashi (h_east)