### PR TITLE
Split GUI balloon test to separate files

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -65,6 +65,7 @@ NEW_TESTS = \
 	test_backspace_opt \
 	test_backup \
 	test_balloon \
+	test_balloon_gui \
 	test_behave \
 	test_blob \
 	test_blockedit \
@@ -296,6 +297,7 @@ NEW_TESTS_RES = \
 	test_autoload.res \
 	test_backspace_opt.res \
 	test_balloon.res \
+	test_balloon_gui.res \
 	test_blob.res \
 	test_blockedit.res \
 	test_breakindent.res \

--- a/src/testdir/test_balloon.vim
+++ b/src/testdir/test_balloon.vim
@@ -1,11 +1,13 @@
 " Tests for 'balloonevalterm'.
+" A few tests only work in the terminal.
+
+if has('gui_running')
+  finish
+endif
 
 if !has('balloon_eval_term')
   throw 'Skipped: balloon_eval_term feature missing'
 endif
-
-" A few tests only work in the terminal.
-if !has('gui_running')
 
 source screendump.vim
 if !CanRunVimInTerminal()
@@ -56,24 +58,3 @@ func Test_balloon_eval_term_visual()
   call StopVimInTerminal(buf)
   call delete('XTest_beval_visual')
 endfunc
-
-endif
-
-" Tests that only work in the GUI
-if has('gui_running')
-
-func Test_balloon_show_gui()
-  let msg = 'this this this this'
-  call balloon_show(msg)
-  call assert_equal(msg, balloon_gettext())
-  sleep 10m
-  call balloon_show('')
-
-  let msg = 'that that'
-  call balloon_show(msg)
-  call assert_equal(msg, balloon_gettext())
-  sleep 10m
-  call balloon_show('')
-endfunc
-
-endif

--- a/src/testdir/test_balloon.vim
+++ b/src/testdir/test_balloon.vim
@@ -2,7 +2,7 @@
 " A few tests only work in the terminal.
 
 if has('gui_running')
-  finish
+  throw 'Skipped: only work in the terminal'
 endif
 
 if !has('balloon_eval_term')

--- a/src/testdir/test_balloon_gui.vim
+++ b/src/testdir/test_balloon_gui.vim
@@ -1,7 +1,7 @@
 " Tests for 'ballooneval' in the GUI.
 
 if !has('gui_running')
-  finish
+  throw 'Skipped: only work in the GUI'
 endif
 
 if !has('balloon_eval')

--- a/src/testdir/test_balloon_gui.vim
+++ b/src/testdir/test_balloon_gui.vim
@@ -1,0 +1,23 @@
+" Tests for 'ballooneval' in the GUI.
+
+if !has('gui_running')
+  finish
+endif
+
+if !has('balloon_eval')
+  throw 'Skipped: balloon_eval feature missing'
+endif
+
+func Test_balloon_show_gui()
+  let msg = 'this this this this'
+  call balloon_show(msg)
+  call assert_equal(msg, balloon_gettext())
+  sleep 10m
+  call balloon_show('')
+
+  let msg = 'that that'
+  call balloon_show(msg)
+  call assert_equal(msg, balloon_gettext())
+  sleep 10m
+  call balloon_show('')
+endfunc

--- a/src/testdir/test_crypt.vim
+++ b/src/testdir/test_crypt.vim
@@ -1,7 +1,7 @@
 " Tests for encryption.
 
 if !has('cryptv')
-  throw 'Skipped, encryption feature missing'
+  throw 'Skipped: encryption feature missing'
 endif
 
 func Common_head_only(text)

--- a/src/testdir/test_cscope.vim
+++ b/src/testdir/test_cscope.vim
@@ -1,10 +1,10 @@
 " Test for cscope commands.
 
 if !has('cscope') || !has('quickfix')
-  throw 'Skipped, cscope or quickfix feature missing'
+  throw 'Skipped: cscope or quickfix feature missing'
 endif
 if !executable('cscope')
-  throw 'Skipped, cscope program missing'
+  throw 'Skipped: cscope program missing'
 endif
 
 func CscopeSetupOrClean(setup)

--- a/src/testdir/test_digraph.vim
+++ b/src/testdir/test_digraph.vim
@@ -1,7 +1,7 @@
 " Tests for digraphs
 
 if !has("digraphs")
-  throw 'Skipped, digraphs feature missing'
+  throw 'Skipped: digraphs feature missing'
 endif
 
 func Put_Dig(chars)

--- a/src/testdir/test_float_func.vim
+++ b/src/testdir/test_float_func.vim
@@ -1,7 +1,7 @@
 " test float functions
 
 if !has('float')
-  throw 'Skipped, float feature missing'
+  throw 'Skipped: float feature missing'
 end
 
 func Test_abs()

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -2,7 +2,7 @@
 
 source shared.vim
 if !CanRunGui()
-  throw 'Skipped, cannot run GUI'
+  throw 'Skipped: cannot run GUI'
 endif
 
 source setup_gui.vim

--- a/src/testdir/test_gui_init.vim
+++ b/src/testdir/test_gui_init.vim
@@ -3,7 +3,7 @@
 
 source shared.vim
 if !CanRunGui()
-  throw 'Skipped, cannot run GUI'
+  throw 'Skipped: cannot run GUI'
 endif
 
 source setup_gui.vim

--- a/src/testdir/test_history.vim
+++ b/src/testdir/test_history.vim
@@ -1,7 +1,7 @@
 " Tests for the history functions
 
 if !has('cmdline_hist')
-  throw 'Skipped, cmdline_hist feature missing'
+  throw 'Skipped: cmdline_hist feature missing'
 endif
 
 set history=7

--- a/src/testdir/test_langmap.vim
+++ b/src/testdir/test_langmap.vim
@@ -1,7 +1,7 @@
 " tests for 'langmap'
 
 if !has('langmap')
-  throw 'Skipped, langmap feature missing'
+  throw 'Skipped: langmap feature missing'
 endif
 
 func Test_langmap()

--- a/src/testdir/test_listlbr.vim
+++ b/src/testdir/test_listlbr.vim
@@ -4,10 +4,10 @@ set encoding=latin1
 scriptencoding latin1
 
 if !exists("+linebreak")
-  throw 'Skipped, linebreak option missing'
+  throw 'Skipped: linebreak option missing'
 endif
 if !has("conceal")
-  throw 'Skipped, conceal feature missing'
+  throw 'Skipped: conceal feature missing'
 endif
 
 source view_util.vim

--- a/src/testdir/test_listlbr_utf8.vim
+++ b/src/testdir/test_listlbr_utf8.vim
@@ -4,13 +4,13 @@ set encoding=utf-8
 scriptencoding utf-8
 
 if !exists("+linebreak")
-  throw 'Skipped, linebreak option missing'
+  throw 'Skipped: linebreak option missing'
 endif
 if !has("conceal")
-  throw 'Skipped, conceal feature missing'
+  throw 'Skipped: conceal feature missing'
 endif
 if !has("signs")
-  throw 'Skipped, signs feature missing'
+  throw 'Skipped: signs feature missing'
 endif
 
 source view_util.vim

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -1,7 +1,7 @@
 " Tests for Lua.
 
 if !has('lua')
-  throw 'Skipped, lua feature missing'
+  throw 'Skipped: lua feature missing'
 endif
 
 func TearDown()

--- a/src/testdir/test_makeencoding.vim
+++ b/src/testdir/test_makeencoding.vim
@@ -4,7 +4,7 @@ source shared.vim
 
 let s:python = PythonProg()
 if s:python == ''
-  throw 'Skipped, python program missing'
+  throw 'Skipped: python program missing'
 endif
 
 let s:script = 'test_makeencoding.py'

--- a/src/testdir/test_matchadd_conceal.vim
+++ b/src/testdir/test_matchadd_conceal.vim
@@ -1,7 +1,7 @@
 " Test for matchadd() and conceal feature
 
 if !has('conceal')
-  throw 'Skipped, conceal feature missing'
+  throw 'Skipped: conceal feature missing'
 endif
 
 if !has('gui_running') && has('unix')

--- a/src/testdir/test_matchadd_conceal_utf8.vim
+++ b/src/testdir/test_matchadd_conceal_utf8.vim
@@ -1,7 +1,7 @@
 " Test for matchadd() and conceal feature using utf-8.
 
 if !has('conceal')
-  throw 'Skipped, conceal feature missing'
+  throw 'Skipped: conceal feature missing'
 endif
 
 if !has('gui_running') && has('unix')

--- a/src/testdir/test_memory_usage.vim
+++ b/src/testdir/test_memory_usage.vim
@@ -1,15 +1,15 @@
 " Tests for memory usage.
 
 if !has('terminal')
-  throw 'Skipped, terminal feature missing'
+  throw 'Skipped: terminal feature missing'
 endif
 if has('gui_running')
-  throw 'Skipped, does not work in GUI'
+  throw 'Skipped: does not work in GUI'
 endif
 if $ASAN_OPTIONS !=# ''
   " Skip tests on Travis CI ASAN build because it's difficult to estimate
   " memory usage.
-  throw 'Skipped, does not work with ASAN'
+  throw 'Skipped: does not work with ASAN'
 endif
 
 source shared.vim
@@ -20,7 +20,7 @@ endfunc
 
 if has('win32')
   if !executable('wmic')
-    throw 'Skipped, wmic program missing'
+    throw 'Skipped: wmic program missing'
   endif
   func s:memory_usage(pid) abort
     let cmd = printf('wmic process where processid=%d get WorkingSetSize', a:pid)
@@ -28,13 +28,13 @@ if has('win32')
   endfunc
 elseif has('unix')
   if !executable('ps')
-    throw 'Skipped, ps program missing'
+    throw 'Skipped: ps program missing'
   endif
   func s:memory_usage(pid) abort
     return s:pick_nr(system('ps -o rss= -p ' . a:pid))
   endfunc
 else
-  throw 'Skipped, not win32 or unix'
+  throw 'Skipped: not win32 or unix'
 endif
 
 " Wait for memory usage to level off.

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -1,7 +1,7 @@
 " Test that the system menu can be loaded.
 
 if !has('menu')
-  throw 'Skipped, menu feature missing'
+  throw 'Skipped: menu feature missing'
 endif
 
 func Test_load_menu()

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -4,7 +4,7 @@ set encoding=latin1
 scriptencoding latin1
 
 if !has('mksession')
-  throw 'Skipped, mksession feature missing'
+  throw 'Skipped: mksession feature missing'
 endif
 
 source shared.vim

--- a/src/testdir/test_mksession_utf8.vim
+++ b/src/testdir/test_mksession_utf8.vim
@@ -4,7 +4,7 @@ set encoding=utf-8
 scriptencoding utf-8
 
 if !has('mksession')
-  throw 'Skipped, mksession feature missing'
+  throw 'Skipped: mksession feature missing'
 endif
 
 func Test_mksession_utf8()

--- a/src/testdir/test_netbeans.vim
+++ b/src/testdir/test_netbeans.vim
@@ -1,14 +1,14 @@
 " Test the netbeans interface.
 
 if !has('netbeans_intg')
-  throw 'Skipped, netbeans_intg feature missing'
+  throw 'Skipped: netbeans_intg feature missing'
 endif
 
 source shared.vim
 
 let s:python = PythonProg()
 if s:python == ''
-  throw 'Skipped, python program missing'
+  throw 'Skipped: python program missing'
 endif
 
 " Run "testfunc" after sarting the server and stop the server afterwards.

--- a/src/testdir/test_paste.vim
+++ b/src/testdir/test_paste.vim
@@ -2,10 +2,10 @@
 
 " Bracketed paste only works with "xterm".  Not in GUI or Windows console.
 if has('win32')
-  throw 'Skipped, does not work on MS-Windows'
+  throw 'Skipped: does not work on MS-Windows'
 endif
 if has('gui_running')
-  throw 'Skipped, does not work in the GUI'
+  throw 'Skipped: does not work in the GUI'
 endif
 set term=xterm
 

--- a/src/testdir/test_perl.vim
+++ b/src/testdir/test_perl.vim
@@ -1,7 +1,7 @@
 " Tests for Perl interface
 
 if !has('perl')
-  throw 'Skipped, perl feature missing'
+  throw 'Skipped: perl feature missing'
 end
 
 " FIXME: RunTest don't see any error when Perl abort...

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -448,7 +448,7 @@ endfunc
 
 func Test_popup_time()
   if !has('timers')
-    throw 'Skipped, timer feature not supported'
+    throw 'Skipped: timer feature not supported'
   endif
   topleft vnew
   call setline(1, 'hello')
@@ -1109,7 +1109,7 @@ endfunc
 
 func Test_notifications()
   if !has('timers')
-    throw 'Skipped, timer feature not supported'
+    throw 'Skipped: timer feature not supported'
   endif
   if !CanRunVimInTerminal()
     throw 'Skipped: cannot make screendumps'

--- a/src/testdir/test_profile.vim
+++ b/src/testdir/test_profile.vim
@@ -1,7 +1,7 @@
 " Test Vim profiler
 
 if !has('profile')
-  throw 'Skipped, profile feature missing'
+  throw 'Skipped: profile feature missing'
 endif
 
 func Test_profile_func()

--- a/src/testdir/test_prompt_buffer.vim
+++ b/src/testdir/test_prompt_buffer.vim
@@ -1,7 +1,7 @@
 " Tests for setting 'buftype' to "prompt"
 
 if !has('channel')
-  throw 'Skipped, channel feature missing'
+  throw 'Skipped: channel feature missing'
 endif
 
 source shared.vim

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -2,7 +2,7 @@
 " TODO: move tests from test87.in here.
 
 if !has('python')
-  throw 'Skipped, python feature missing'
+  throw 'Skipped: python feature missing'
 endif
 
 func Test_pydo()

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -2,7 +2,7 @@
 " TODO: move tests from test88.in here.
 
 if !has('python3')
-  throw 'Skipped, python3 feature missing'
+  throw 'Skipped: python3 feature missing'
 endif
 
 func Test_py3do()

--- a/src/testdir/test_pyx2.vim
+++ b/src/testdir/test_pyx2.vim
@@ -2,7 +2,7 @@
 
 set pyx=2
 if !has('python')
-  throw 'Skipped, python feature missing'
+  throw 'Skipped: python feature missing'
 endif
 
 let s:py2pattern = '^2\.[0-7]\.\d\+'

--- a/src/testdir/test_pyx3.vim
+++ b/src/testdir/test_pyx3.vim
@@ -2,7 +2,7 @@
 
 set pyx=3
 if !has('python3')
-  throw 'Skipped, python3 feature missing'
+  throw 'Skipped: python3 feature missing'
 endif
 
 let s:py2pattern = '^2\.[0-7]\.\d\+'

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1,7 +1,7 @@
 " Test for the quickfix feature.
 
 if !has('quickfix')
-  throw 'Skipped, quickfix feature missing'
+  throw 'Skipped: quickfix feature missing'
 endif
 
 set encoding=utf-8

--- a/src/testdir/test_quotestar.vim
+++ b/src/testdir/test_quotestar.vim
@@ -2,7 +2,7 @@
 
 source shared.vim
 if !WorkingClipboard()
-  throw 'Skipped, no working clipboard'
+  throw 'Skipped: no working clipboard'
 endif
 
 source shared.vim

--- a/src/testdir/test_reltime.vim
+++ b/src/testdir/test_reltime.vim
@@ -1,10 +1,10 @@
 " Tests for reltime()
 
 if !has('reltime')
-  throw 'Skipped, reltime feature missing'
+  throw 'Skipped: reltime feature missing'
 endif
 if !has('float')
-  throw 'Skipped, float feature missing'
+  throw 'Skipped: float feature missing'
 endif
 
 func Test_reltime()

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -1,7 +1,7 @@
 " Tests for ruby interface
 
 if !has('ruby')
-  throw 'Skipped, ruby feature missing'
+  throw 'Skipped: ruby feature missing'
 end
 
 func Test_ruby_change_buffer()

--- a/src/testdir/test_sha256.vim
+++ b/src/testdir/test_sha256.vim
@@ -1,10 +1,10 @@
 " Tests for the sha256() function.
 
 if !has('cryptv')
-  throw 'Skipped, cryptv feature missing'
+  throw 'Skipped: cryptv feature missing'
 endif
 if !exists('*sha256')
-  throw 'Skipped, sha256 function missing'
+  throw 'Skipped: sha256 function missing'
 endif
 
 function Test_sha256()

--- a/src/testdir/test_shortpathname.vim
+++ b/src/testdir/test_shortpathname.vim
@@ -2,7 +2,7 @@
 " Only for use on Win32 systems!
 
 if !has('win32')
-  throw 'Skipped, not on MS-Windows'
+  throw 'Skipped: not on MS-Windows'
 endif
 
 func TestIt(file, bits, expected)

--- a/src/testdir/test_signals.vim
+++ b/src/testdir/test_signals.vim
@@ -1,7 +1,7 @@
 " Test signal handling.
 
 if !has('unix')
-  throw 'Skipped, not on Unix'
+  throw 'Skipped: not on Unix'
 endif
 
 source shared.vim

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -1,7 +1,7 @@
 " Test for signs
 
 if !has('signs')
-  throw 'Skipped, signs feature missing'
+  throw 'Skipped: signs feature missing'
 endif
 
 func Test_sign()

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -1,7 +1,7 @@
 " Test spell checking
 
 if !has('spell')
-  throw 'Skipped, spell feature missing'
+  throw 'Skipped: spell feature missing'
 endif
 
 func TearDown()

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -1,7 +1,7 @@
 " Test for syntax and syntax iskeyword option
 
 if !has("syntax")
-  throw 'Skipped, syntax feature missing'
+  throw 'Skipped: syntax feature missing'
 endif
 
 source view_util.vim

--- a/src/testdir/test_tcl.vim
+++ b/src/testdir/test_tcl.vim
@@ -1,7 +1,7 @@
 " Tests for the Tcl interface.
 
 if !has('tcl')
-  throw 'Skipped, tcl feature missing'
+  throw 'Skipped: tcl feature missing'
 end
 
 " Helper function as there is no builtin tcleval() function similar

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2,10 +2,10 @@
 
 " This only works for Unix in a terminal
 if has('gui_running')
-  throw 'Skipped, does not work in the GUI'
+  throw 'Skipped: does not work in the GUI'
 endif
 if !has('unix')
-  throw 'Skipped, not on Unix'
+  throw 'Skipped: not on Unix'
 endif
 
 source shared.vim

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1,7 +1,7 @@
 " Tests for the terminal window.
 
 if !has('terminal')
-  throw 'Skipped, terminal feature missing'
+  throw 'Skipped: terminal feature missing'
 endif
 
 source shared.vim

--- a/src/testdir/test_terminal_fail.vim
+++ b/src/testdir/test_terminal_fail.vim
@@ -3,7 +3,7 @@
 " freed.  Since the process exists right away it's not a real leak.
 
 if !has('terminal')
-  throw 'Skipped, terminal feature missing'
+  throw 'Skipped: terminal feature missing'
 endif
 
 source shared.vim

--- a/src/testdir/test_textobjects.vim
+++ b/src/testdir/test_textobjects.vim
@@ -1,7 +1,7 @@
 " Test for textobjects
 
 if !has('textobjects')
-  throw 'Skipped, textobjects feature missing'
+  throw 'Skipped: textobjects feature missing'
 endif
 
 func CpoM(line, useM, expected)

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -2,7 +2,7 @@
 " buffer.
 
 if !has('textprop')
-  throw 'Skipped, textprop feature missing'
+  throw 'Skipped: textprop feature missing'
 endif
 
 source screendump.vim

--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -1,7 +1,7 @@
 " Test for timers
 
 if !has('timers')
-  throw 'Skipped, timers feature missing'
+  throw 'Skipped: timers feature missing'
 endif
 
 source shared.vim

--- a/src/testdir/test_vartabs.vim
+++ b/src/testdir/test_vartabs.vim
@@ -1,7 +1,7 @@
 " Test for variable tabstops
 
 if !has("vartabs")
-  throw 'Skipped, vartabs feature missing'
+  throw 'Skipped: vartabs feature missing'
 endif
 
 source view_util.vim

--- a/src/testdir/test_winbar.vim
+++ b/src/testdir/test_winbar.vim
@@ -1,7 +1,7 @@
 " Test WinBar
 
 if !has('menu')
-  throw 'Skipped, menu feature missing'
+  throw 'Skipped: menu feature missing'
 endif
 
 source shared.vim

--- a/src/testdir/test_windows_home.vim
+++ b/src/testdir/test_windows_home.vim
@@ -1,7 +1,7 @@
 " Test for $HOME on Windows.
 
 if !has('win32')
-  throw 'Skipped, not on MS-Windows'
+  throw 'Skipped: not on MS-Windows'
 endif
 
 let s:env = {}

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -2,7 +2,7 @@
 if empty($XXD) && executable('..\xxd\xxd.exe')
   let s:xxd_cmd = '..\xxd\xxd.exe'
 elseif empty($XXD) || !executable($XXD)
-  throw 'Skipped, xxd program missing'
+  throw 'Skipped: xxd program missing'
 else
   let s:xxd_cmd = $XXD
 endif


### PR DESCRIPTION
`Test_balloon_show_gui()` does not need "balloon_eval_term" feature but test_balloon.vim requires it.
I think should split balloon tests for terminal/GUI to separate files.

In addition, this patch includes the fix for the skip messages; unify message format.