### PR TITLE
Change the way test_memory_usage checks whether vim is built with ASAN

### DIFF
--- a/src/testdir/test_memory_usage.vim
+++ b/src/testdir/test_memory_usage.vim
@@ -6,7 +6,8 @@ endif
 if has('gui_running')
   throw 'Skipped, does not work in GUI'
 endif
-if $ASAN_OPTIONS !=# ''
+
+if execute('version') =~# '-fsanitize=[a-z,]*\<address\>'
   " Skip tests on Travis CI ASAN build because it's difficult to estimate
   " memory usage.
   throw 'Skipped, does not work with ASAN'


### PR DESCRIPTION
This PR changes the way test `test_memory_usage` checks whether
vim is built with asan.

Prior to change, the test was checking the `$ASAN_OPTIONS` environment
variable. But whether  `$ASAN_OPTIONS` is set or not is unrelated to 
whether vim is build with asan.

In my setup, `$ASAN_OPTIONS` is always set in my `~/.bashrc` and the
test was spuriously skipped, even if vim was not build with asan.

Also, if I build vim with asan and unset `$ASAN_OPTIONS`,
then `test_memory_usage` was failing prior to this PR.