### PR TITLE
Follow up for :const patch

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -11622,7 +11622,6 @@ text...
 						*:cons* *:const* *E996*
 :cons[t] {var-name} = {expr1}
 :cons[t] [{name1}, {name2}, ...] = {expr1}
-:cons[t] [{name1}, {name2}, ...] .= {expr1}
 :cons[t] [{name}, ..., ; {lastname}] = {expr1}
 :cons[t] {var-name} =<< [trim] {marker}
 text...
@@ -11641,7 +11640,10 @@ text...
 			|:const| does not allow to for changing a variable. >
 				:let x = 1
 				:const x = 2  " Error!
-<
+<			Note that environment variable, option values nor
+			register values are not permitted to be modified.
+							*E996*
+
 :lockv[ar][!] [depth] {name} ...			*:lockvar* *:lockv*
 			Lock the internal variable {name}.  Locking means that
 			it can no longer be changed (until it is unlocked).

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -367,7 +367,7 @@ syn match	vimSetMod	contained	"&vim\=\|[!&?<]\|all&"
 
 " Let {{{2
 " ===
-syn keyword	vimLet	let	unl[et]	skipwhite nextgroup=vimVar,vimFuncVar
+syn keyword	vimLet	let	unl[et]	cons[t]	skipwhite nextgroup=vimVar,vimFuncVar
 
 " Abbreviations {{{2
 " =============

--- a/src/testdir/test_const.vim
+++ b/src/testdir/test_const.vim
@@ -21,6 +21,21 @@ func Test_define_var_with_lock()
     hello
     EOS
 
+    call assert_true(exists('i'))
+    call assert_true(exists('f'))
+    call assert_true(exists('s'))
+    call assert_true(exists('F'))
+    call assert_true(exists('l'))
+    call assert_true(exists('d'))
+    if has('channel')
+        call assert_true(exists('j'))
+        call assert_true(exists('c'))
+    endif
+    call assert_true(exists('b'))
+    call assert_true(exists('n'))
+    call assert_true(exists('bl'))
+    call assert_true(exists('here'))
+
     call assert_fails('let i = 1', 'E741:')
     call assert_fails('let f = 1.1', 'E741:')
     call assert_fails('let s = "vim"', 'E741:')
@@ -216,6 +231,17 @@ func Test_const_with_special_variables()
     call assert_fails('const &filetype = "vim"', 'E996:')
     call assert_fails('const &l:filetype = "vim"', 'E996:')
     call assert_fails('const &g:encoding = "utf-8"', 'E996:')
+endfunc
+
+func Test_const_with_eval_name()
+    let s = 'foo'
+
+    " eval name with :const should work
+    const abc_{s} = 1
+    const {s}{s} = 1
+
+    let s2 = 'abc_foo'
+    call assert_fails('const {s2} = "bar"', 'E995:')
 endfunc
 
 func Test_lock_depth_is_1()


### PR DESCRIPTION
Hi all,

This patch adds small fixes and additions for `:const` implemented at #4541.

Changes:

- Fixed and improved documentation. Command signature was incorrect and it lacks description for E996.
- More test cases were added. Test for var name with brace such as `const foo_{bar} =` was added. And also assertions to check that variables are really defined were added.
- Added missing highlight for `:const` to `syntax/vim.vim`