### PR TITLE
Fix #4547 

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -5896,9 +5896,7 @@ set_ref_in_item(
 	    /* Didn't see this dict yet. */
 	    dd->dv_copyID = copyID;
 	    if (ht_stack == NULL)
-	    {
 		abort = set_ref_in_ht(&dd->dv_hashtab, copyID, list_stack);
-	    }
 	    else
 	    {
 		ht_stack_T *newitem = (ht_stack_T*)malloc(sizeof(ht_stack_T));
@@ -5922,9 +5920,7 @@ set_ref_in_item(
 	    /* Didn't see this list yet. */
 	    ll->lv_copyID = copyID;
 	    if (list_stack == NULL)
-	    {
 		abort = set_ref_in_list(ll, copyID, ht_stack);
-	    }
 	    else
 	    {
 		list_stack_T *newitem = (list_stack_T*)malloc(

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -1665,6 +1665,17 @@ func Test_refcount()
     delfunc DictFunc
 endfunc
 
+func! Test_funccall_garbage_collect()
+    func Func(x, ...)
+        call add(a:x, a:000)
+    endfunc
+    call Func([], [])
+    " Must not crash cause by invalid freeing
+    call test_garbagecollect_now()
+    call assert_true(v:true)
+    delfunc Func
+endfunc
+
 "-------------------------------------------------------------------------------
 " Modelines								    {{{1
 " vim: ts=8 sw=4 tw=80 fdm=marker

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -935,12 +935,9 @@ call_user_func(
 	    v->di_flags |= DI_FLAGS_RO | DI_FLAGS_FIX;
 	}
 
-	if (isdefault)
-	    v->di_tv = def_rettv;
-	else
-	    // Note: the values are copied directly to avoid alloc/free.
-	    // "argvars" must have VAR_FIXED for v_lock.
-	    v->di_tv = argvars[i];
+	// Note: the values are copied directly to avoid alloc/free.
+	// "argvars" must have VAR_FIXED for v_lock.
+	v->di_tv = isdefault ? def_rettv : argvars[i];
 	v->di_tv.v_lock = VAR_FIXED;
 
 	if (addlocal)
@@ -3998,13 +3995,13 @@ set_ref_in_previous_funccal(int copyID)
     int		abort = FALSE;
     funccall_T	*fc;
 
-    for (fc = previous_funccal; fc != NULL; fc = fc->caller)
+    for (fc = previous_funccal; !abort && fc != NULL; fc = fc->caller)
     {
 	fc->fc_copyID = copyID + 1;
-	abort = abort || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID + 1,
-									NULL);
-	abort = abort || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID + 1,
-									NULL);
+	abort = abort
+	    || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID + 1, NULL)
+	    || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID + 1, NULL)
+	    || set_ref_in_list(&fc->l_varlist, copyID + 1, NULL);
     }
     return abort;
 }
@@ -4017,9 +4014,11 @@ set_ref_in_funccal(funccall_T *fc, int copyID)
     if (fc->fc_copyID != copyID)
     {
 	fc->fc_copyID = copyID;
-	abort = abort || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID, NULL);
-	abort = abort || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID, NULL);
-	abort = abort || set_ref_in_func(NULL, fc->func, copyID);
+	abort = abort
+	    || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID, NULL)
+	    || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID, NULL)
+	    || set_ref_in_list(&fc->l_varlist, copyID, NULL)
+	    || set_ref_in_func(NULL, fc->func, copyID);
     }
     return abort;
 }


### PR DESCRIPTION
This pull-req fixes #4547 .

It must update the copyID of items of `a:000` in `set_ref_in_funccal()`.

Simple reproducable steps:

test.vim
```vim
function F(x, ...)
  call add(a:x, a:000)
endfunction
call F([], [])
```

`vim --clean -S test.vim`

and leave Vim alone few seconds, then Vim will crash.