### PR TITLE
Add win_splitmove function, to move a window into split of a given window

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2875,6 +2875,8 @@ win_gotoid({expr})		Number	go to window with ID {expr}
 win_id2tabwin({expr})		List	get tab and window nr from window ID
 win_id2win({expr})		Number	get window nr from window ID
 win_screenpos({nr})		List	get screen position of window {nr}
+win_splitmove({nr}, {target} [, {options}])
+				none	move window {nr} to split of {target}
 winbufnr({nr})			Number	buffer number of window {nr}
 wincol()			Number	window column of the cursor
 winheight({nr})			Number	height of window {nr}
@@ -10143,6 +10145,26 @@ win_screenpos({nr})					*win_screenpos()*
 
 		Can also be used as a |method|: >
 			GetWinid()->win_screenpos()
+<
+win_splitmove({nr}, {target} [, {options}])		*win_splitmove()*
+	        Move the window {nr} to a new split of the window {target}.
+		This is similar to moving to {target}, creating a new window
+		using |:split| but having the same contents as window {nr}, and
+		then closing {nr}.
+
+		Both {nr} and {target} can be window numbers or |window-ID|s.
+
+		{options} is a Dictionary with the following optional entries:
+		  "vertical"	When TRUE, the split is created vertically,
+				like with |:vsplit|.
+		  "rightbelow"	When TRUE, the split is made below or to the
+				right (if vertical).  When FALSE, it is done
+				above or to the left (if vertical).  When not
+				present, the values of 'splitbelow' and
+				'splitright' are used.
+
+		Can also be used as a |method|: >
+			GetWinid()->win_splitmove(target)
 <
 							*winbufnr()*
 winbufnr({nr})	The result is a Number, which is the number of the buffer

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -850,6 +850,7 @@ static funcentry_T global_functions[] =
     {"win_id2tabwin",	1, 1, FEARG_1,	  f_win_id2tabwin},
     {"win_id2win",	1, 1, FEARG_1,	  f_win_id2win},
     {"win_screenpos",	1, 1, FEARG_1,	  f_win_screenpos},
+    {"win_splitmove",   2, 3, FEARG_1,    f_win_splitmove},
     {"winbufnr",	1, 1, FEARG_1,	  f_winbufnr},
     {"wincol",		0, 0, 0,	  f_wincol},
     {"winheight",	1, 1, FEARG_1,	  f_winheight},

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -744,6 +744,46 @@ f_win_screenpos(typval_T *argvars, typval_T *rettv)
 }
 
 /*
+ * "win_splitmove()" function
+ */
+    void
+f_win_splitmove(typval_T *argvars, typval_T *rettv)
+{
+    win_T   *wp;
+    win_T   *targetwin;
+    int     flags = 0, size = 0;
+
+    wp = find_win_by_nr_or_id(&argvars[0]);
+    targetwin = find_win_by_nr_or_id(&argvars[1]);
+
+    if (wp == NULL || targetwin == NULL || wp == targetwin)
+    {
+        emsg(_(e_invalwindow));
+        return;
+    }
+
+    if (argvars[2].v_type != VAR_UNKNOWN)
+    {
+        dict_T      *d;
+        dictitem_T  *di;
+        if (argvars[2].v_type != VAR_DICT || argvars[2].vval.v_dict == NULL)
+        {
+            emsg(_(e_invarg));
+            return;
+        }
+
+        d = argvars[2].vval.v_dict;
+        if (dict_get_number(d, (char_u *)"vertical"))
+            flags |= WSP_VERT;
+        if ((di = dict_find(d, (char_u *)"rightbelow", -1)) != NULL)
+            flags |= tv_get_number(&di->di_tv) ? WSP_BELOW : WSP_ABOVE;
+        size = (int)dict_get_number(d, (char_u *)"size");
+    }
+
+    win_move_into_split(wp, targetwin, size, flags);
+}
+
+/*
  * "winbufnr(nr)" function
  */
     void

--- a/src/proto/evalwindow.pro
+++ b/src/proto/evalwindow.pro
@@ -19,6 +19,7 @@ void f_win_gotoid(typval_T *argvars, typval_T *rettv);
 void f_win_id2tabwin(typval_T *argvars, typval_T *rettv);
 void f_win_id2win(typval_T *argvars, typval_T *rettv);
 void f_win_screenpos(typval_T *argvars, typval_T *rettv);
+void f_win_splitmove(typval_T *argvars, typval_T *rettv);
 void f_winbufnr(typval_T *argvars, typval_T *rettv);
 void f_wincol(typval_T *argvars, typval_T *rettv);
 void f_winheight(typval_T *argvars, typval_T *rettv);

--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -9,6 +9,7 @@ int win_valid_any_tab(win_T *win);
 int win_count(void);
 int make_windows(int count, int vertical);
 void win_move_after(win_T *win1, win_T *win2);
+void win_move_into_split(win_T *wp, win_T *targetwin, int size, int flags);
 void win_equal(win_T *next_curwin, int current, int dir);
 void close_windows(buf_T *buf, int keep_curwin);
 int one_window(void);

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -857,4 +857,33 @@ func Test_winrestview()
   bwipe!
 endfunc
 
+func Test_win_splitmove()
+  edit a
+  leftabove split b
+  leftabove vsplit c
+  leftabove split d
+  call win_splitmove(winnr(), winnr('l'))
+  call assert_equal(bufname(winbufnr(1)), 'c')
+  call assert_equal(bufname(winbufnr(2)), 'd')
+  call assert_equal(bufname(winbufnr(3)), 'b')
+  call assert_equal(bufname(winbufnr(4)), 'a')
+  call win_splitmove(winnr(), winnr('j'), {'vertical': 1})
+  call win_splitmove(winnr(), winnr('j'), {'vertical': 1})
+  call assert_equal(bufname(winbufnr(1)), 'c')
+  call assert_equal(bufname(winbufnr(2)), 'b')
+  call assert_equal(bufname(winbufnr(3)), 'd')
+  call assert_equal(bufname(winbufnr(4)), 'a')
+  call win_splitmove(winnr(), winnr('k'), {'vertical': 1})
+  call assert_equal(bufname(winbufnr(1)), 'd')
+  call assert_equal(bufname(winbufnr(2)), 'c')
+  call assert_equal(bufname(winbufnr(3)), 'b')
+  call assert_equal(bufname(winbufnr(4)), 'a')
+  call win_splitmove(winnr(), winnr('j'), {'rightbelow': v:true})
+  call assert_equal(bufname(winbufnr(1)), 'c')
+  call assert_equal(bufname(winbufnr(2)), 'b')
+  call assert_equal(bufname(winbufnr(3)), 'a')
+  call assert_equal(bufname(winbufnr(4)), 'd')
+  only | bd
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This essentially exposes the internal function `win_split_ins()`.

Allows complex modifications of window layouts, for example, converting vertical splits to horizontal splits and moving a window from left stack of panes to a right stack of panes.

```text
win_splitmove({nr}, {target} [, {options}])		*win_splitmove()*
	        Move the window {nr} to a new split of the window {target}.
		This is similar to moving to {target}, creating a new window
		using |:split| but having the same contents as window {nr}, and
		then closing {nr}.

		Both {nr} and {target} can be window numbers or |window-ID|s.

		{options} is a Dictionary with the following optional entries:
		  "vertical"	When TRUE, the split is created vertically,
				like with |:vsplit|.
		  "rightbelow"	When TRUE, the split is made below or to the
				right (if vertical).  When FALSE, it is done
				above or to the left (if vertical).  When not
				present, the values of 'splitbelow' and
				'splitright' are used.
```

There is also a "size" parameter to `win_split_ins()`, but it doesn't look like it doesn't even work e.g., `30wincmd K`.
