### PR TITLE
Fix SEGV in listener, prompt-buffer, and popup-window (with callback)

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5962,3 +5962,48 @@ wipe_buffer(
     if (!aucmd)
 	unblock_autocmds();
 }
+
+#if defined(FEAT_EVAL) || defined(PROTO)
+/*
+ * Mark references in functions of buffers.
+ */
+    int
+set_ref_in_buffer(int copyID)
+{
+    int		abort = FALSE;
+    buf_T	*bp;
+
+    FOR_ALL_BUFFERS(bp)
+    {
+	listener_T *lnr;
+	typval_T tv;
+
+	for (lnr = bp->b_listener; !abort && lnr != NULL; lnr = lnr->lr_next)
+	{
+	    if (lnr->lr_callback.cb_partial != NULL)
+	    {
+		tv.v_type = VAR_PARTIAL;
+		tv.vval.v_partial = lnr->lr_callback.cb_partial;
+		abort = abort || set_ref_in_item(&tv, copyID, NULL, NULL);
+	    }
+	}
+# ifdef FEAT_JOB_CHANNEL
+	if (!abort && bp->b_prompt_callback.cb_partial != NULL)
+	{
+	    tv.v_type = VAR_PARTIAL;
+	    tv.vval.v_partial = bp->b_prompt_callback.cb_partial;
+	    abort = abort || set_ref_in_item(&tv, copyID, NULL, NULL);
+	}
+	if (!abort && bp->b_prompt_interrupt.cb_partial != NULL)
+	{
+	    tv.v_type = VAR_PARTIAL;
+	    tv.vval.v_partial = bp->b_prompt_interrupt.cb_partial;
+	    abort = abort || set_ref_in_item(&tv, copyID, NULL, NULL);
+	}
+# endif
+	if (abort)
+	    break;
+    }
+    return abort;
+}
+#endif

--- a/src/channel.c
+++ b/src/channel.c
@@ -4479,7 +4479,8 @@ set_ref_in_channel(int copyID)
     channel_T	*channel;
     typval_T	tv;
 
-    for (channel = first_channel; channel != NULL; channel = channel->ch_next)
+    for (channel = first_channel; !abort && channel != NULL;
+						   channel = channel->ch_next)
 	if (channel_still_useful(channel))
 	{
 	    tv.v_type = VAR_CHANNEL;
@@ -5568,7 +5569,7 @@ set_ref_in_job(int copyID)
     job_T	*job;
     typval_T	tv;
 
-    for (job = first_job; job != NULL; job = job->jv_next)
+    for (job = first_job; !abort && job != NULL; job = job->jv_next)
 	if (job_still_useful(job))
 	{
 	    tv.v_type = VAR_JOB;

--- a/src/eval.c
+++ b/src/eval.c
@@ -5678,6 +5678,8 @@ garbage_collect(int testing)
     /* v: vars */
     abort = abort || set_ref_in_ht(&vimvarht, copyID, NULL);
 
+    abort = abort || set_ref_in_buffer(copyID);
+
 #ifdef FEAT_LUA
     abort = abort || set_ref_in_lua(copyID);
 #endif
@@ -5708,6 +5710,10 @@ garbage_collect(int testing)
 
 #ifdef FEAT_TERMINAL
     abort = abort || set_ref_in_term(copyID);
+#endif
+
+#ifdef FEAT_TEXT_PROP
+    abort = abort || set_ref_in_popup(copyID);
 #endif
 
     if (!abort)

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -566,7 +566,7 @@ set_ref_in_timer(int copyID)
     timer_T	*timer;
     typval_T	tv;
 
-    for (timer = first_timer; timer != NULL; timer = timer->tr_next)
+    for (timer = first_timer; !abort && timer != NULL; timer = timer->tr_next)
     {
 	if (timer->tr_callback.cb_partial != NULL)
 	{

--- a/src/proto/buffer.pro
+++ b/src/proto/buffer.pro
@@ -74,4 +74,5 @@ int find_win_for_buf(buf_T *buf, win_T **wp, tabpage_T **tp);
 void set_buflisted(int on);
 int buf_contents_changed(buf_T *buf);
 void wipe_buffer(buf_T *buf, int aucmd);
+int set_ref_in_buffer(int copyID);
 /* vim: set ft=c : */

--- a/src/proto/popupwin.pro
+++ b/src/proto/popupwin.pro
@@ -31,4 +31,5 @@ int popup_do_filter(int c);
 void popup_check_cursor_pos(void);
 void may_update_popup_mask(int type);
 void update_popups(void (*win_update)(win_T *wp));
+int set_ref_in_popup(int copyID);
 /* vim: set ft=c : */

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -4051,7 +4051,7 @@ set_ref_in_term(int copyID)
     term_T	*term;
     typval_T	tv;
 
-    for (term = first_term; term != NULL; term = term->tl_next)
+    for (term = first_term; !abort && term != NULL; term = term->tl_next)
 	if (term->tl_job != NULL)
 	{
 	    tv.v_type = VAR_JOB;

--- a/src/testdir/test_listener.vim
+++ b/src/testdir/test_listener.vim
@@ -225,3 +225,20 @@ func Test_listening_other_buf()
   exe "buf " .. bufnr
   bwipe!
 endfunc
+
+func Test_listener_garbage_collect()
+  func MyListener(x, bufnr, start, end, added, changes)
+    " NOP
+  endfunc
+
+  new
+  let id = listener_add(function('MyListener', [{}]), bufnr(''))
+  call test_garbagecollect_now()
+  " must not crach caused by invalid memory access
+  normal ia
+  call assert_true(v:true)
+
+  call listener_remove(id)
+  delfunc MyListener
+  bwipe!
+endfunc

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -1453,3 +1453,19 @@ func Test_set_get_options()
 
   call popup_close(winid)
 endfunc
+
+func Test_popupwin_garbage_collect()
+  func MyPopupFilter(x, winid, c)
+    " NOP
+  endfunc
+
+  let winid = popup_create('something', {'filter': function('MyPopupFilter', [{}])})
+  call test_garbagecollect_now()
+  redraw
+  " Must not crach caused by invalid memory access
+  call feedkeys('j', 'xt')
+  call assert_true(v:true)
+
+  call popup_close(winid)
+  delfunc MyPopupFilter
+endfunc

--- a/src/testdir/test_prompt_buffer.vim
+++ b/src/testdir/test_prompt_buffer.vim
@@ -102,3 +102,24 @@ func Test_prompt_editing()
   call StopVimInTerminal(buf)
   call delete(scriptName)
 endfunc
+
+func Test_prompt_garbage_collect()
+  func MyPromptCallback(x, text)
+    " NOP
+  endfunc
+  func MyPromptInterrupt(x)
+    " NOP
+  endfunc
+
+  new
+  set buftype=prompt
+  call prompt_setcallback(bufnr(''), function('MyPromptCallback', [{}]))
+  call prompt_setinterrupt(bufnr(''), function('MyPromptInterrupt', [{}]))
+  call test_garbagecollect_now()
+  " Must not crash
+  call feedkeys("\<CR>\<C-C>", 'xt')
+  call assert_true(v:true)
+
+  delfunc MyPromptCallback
+  bwipe!
+endfunc

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -4032,12 +4032,12 @@ set_ref_in_call_stack(int copyID)
     funccall_T		*fc;
     funccal_entry_T	*entry;
 
-    for (fc = current_funccal; fc != NULL; fc = fc->caller)
+    for (fc = current_funccal; !abort && fc != NULL; fc = fc->caller)
 	abort = abort || set_ref_in_funccal(fc, copyID);
 
     // Also go through the funccal_stack.
-    for (entry = funccal_stack; entry != NULL; entry = entry->next)
-	for (fc = entry->top_funccal; fc != NULL; fc = fc->caller)
+    for (entry = funccal_stack; !abort && entry != NULL; entry = entry->next)
+	for (fc = entry->top_funccal; !abort && fc != NULL; fc = fc->caller)
 	    abort = abort || set_ref_in_funccal(fc, copyID);
 
     return abort;


### PR DESCRIPTION
Must update copyID of callback for listener, prompt-buffer, and popup-window.

Repro samples:

listener.vim
```vim
func Listener(x, bufnr, start, end, added, changes)
  " NOP
endfunc
call listener_add(function('Listener', [{}]), bufnr('%'))
```

prompt.vim
```vim
func Callback(x, text)
  " NOP
endfunc
func Interrupt(x)
  " NOP
endfunc
new
set buftype=prompt
call prompt_setcallback(bufnr(''), function('Callback', [{}]))
call prompt_setinterrupt(bufnr(''), function('Interrupt', [{}]))
```

popupwin.vim
```vim
func MyPopupFilter(x, winid, c)
  " NOP
endfunc
let winid = popup_create('something', {'filter': function('MyPopupFilter', [{}])})
```

After `:source` each sample, leave Vim alone few seconds (> 4sec.: GC has run) and feed keys, then Vim will crash.
 