### PR TITLE
Fixed compilation warning about unused argument in ui.c

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -1484,7 +1484,7 @@ clip_invert_area(
  */
     static void
 clip_invert_rectangle(
-	Clipboard_T	*cbd,
+	Clipboard_T	*cbd UNUSED,
 	int		row_arg,
 	int		col_arg,
 	int		height_arg,


### PR DESCRIPTION
This PR fixes a compilation warning in vim-8.1.1875:
```
gcc -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_ATHENA     -g -Wall -Wformat=1 -Wextra -Wshadow -Wmissing-prototypes -Wunreachable-code -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/ui.o ui.c
ui.c: In function ‘clip_invert_rectangle’:
ui.c:1487:15: warning: unused parameter ‘cbd’ [-Wunused-parameter]
  Clipboard_T *cbd,
               ^~~
```
The warning happens when Vim is configured with:
```
$ ./configure  --with-features=tiny --enable-gui=athena
```