### PR TITLE
Fix freeing dict

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -43,6 +43,7 @@ dict_alloc(void)
 	d->dv_scope = 0;
 	d->dv_refcount = 0;
 	d->dv_copyID = 0;
+	d->dv_copydict = NULL;
     }
     return d;
 }

--- a/src/dict.c
+++ b/src/dict.c
@@ -812,7 +812,7 @@ dict_get_tv(char_u **arg, typval_T *rettv, int evaluate)
     {
 	semsg(_("E723: Missing end of Dictionary '}': %s"), *arg);
 failret:
-	if (evaluate)
+	if (evaluate && d == first_dict)
 	    dict_free(d);
 	return FAIL;
     }

--- a/src/list.c
+++ b/src/list.c
@@ -924,7 +924,7 @@ get_list_tv(char_u **arg, typval_T *rettv, int evaluate)
     {
 	semsg(_("E697: Missing end of List ']': %s"), *arg);
 failret:
-	if (evaluate)
+	if (evaluate && l == first_list)
 	    list_free(l);
 	return FAIL;
     }


### PR DESCRIPTION
When the script is broken like below.

```
let a = {'foo', 'bar'}
```
And E723 occur and Vim crash in sometime.