### PR TITLE
Add term_util.vim for test script

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -124,6 +124,7 @@ SRC_ALL =	\
 		src/testdir/shared.vim \
 		src/testdir/screendump.vim \
 		src/testdir/view_util.vim \
+		src/testdir/term_util.vim \
 		src/testdir/setup.vim \
 		src/testdir/gui_init.vim \
 		src/testdir/setup_gui.vim \

--- a/src/testdir/screendump.vim
+++ b/src/testdir/screendump.vim
@@ -1,104 +1,16 @@
 " Functions shared by tests making screen dumps.
 
 " Only load this script once.
-if exists('*CanRunVimInTerminal')
-  finish
-endif
-
-" For most tests we need to be able to run terminal Vim with 256 colors.  On
-" MS-Windows the console only has 16 colors and the GUI can't run in a
-" terminal.
-func CanRunVimInTerminal()
-  return has('terminal') && !has('win32')
-endfunc
-
-" Skip the rest if there is no terminal feature at all.
-if !has('terminal')
+if exists('*VerifyScreenDump')
   finish
 endif
 
 source shared.vim
 
-" Run Vim with "arguments" in a new terminal window.
-" By default uses a size of 20 lines and 75 columns.
-" Returns the buffer number of the terminal.
-"
-" Options is a dictionary, these items are recognized:
-" "rows" - height of the terminal window (max. 20)
-" "cols" - width of the terminal window (max. 78)
-" "statusoff" - number of lines the status is offset from default
-func RunVimInTerminal(arguments, options)
-  " If Vim doesn't exit a swap file remains, causing other tests to fail.
-  " Remove it here.
-  call delete(".swp")
-
-  if exists('$COLORFGBG')
-    " Clear $COLORFGBG to avoid 'background' being set to "dark", which will
-    " only be corrected if the response to t_RB is received, which may be too
-    " late.
-    let $COLORFGBG = ''
-  endif
-
-  " Make a horizontal and vertical split, so that we can get exactly the right
-  " size terminal window.  Works only when the current window is full width.
-  call assert_equal(&columns, winwidth(0))
-  split
-  vsplit
-
-  " Always do this with 256 colors and a light background.
-  set t_Co=256 background=light
-  hi Normal ctermfg=NONE ctermbg=NONE
-
-  " Make the window 20 lines high and 75 columns, unless told otherwise.
-  let rows = get(a:options, 'rows', 20)
-  let cols = get(a:options, 'cols', 75)
-  let statusoff = get(a:options, 'statusoff', 1)
-
-  let cmd = GetVimCommandClean()
-
-  " Add -v to have gvim run in the terminal (if possible)
-  let cmd .= ' -v ' . a:arguments
-  let buf = term_start(cmd, {
-	\ 'curwin': 1,
-	\ 'term_rows': rows,
-	\ 'term_cols': cols,
-	\ })
-  if &termwinsize == ''
-    " in the GUI we may end up with a different size, try to set it.
-    if term_getsize(buf) != [rows, cols]
-      call term_setsize(buf, rows, cols)
-    endif
-    call assert_equal([rows, cols], term_getsize(buf))
-  else
-    let rows = term_getsize(buf)[0]
-    let cols = term_getsize(buf)[1]
-  endif
-
-  " Wait for "All" or "Top" of the ruler to be shown in the last line or in
-  " the status line of the last window. This can be quite slow (e.g. when
-  " using valgrind).
-  " If it fails then show the terminal contents for debugging.
-  try
-    call WaitFor({-> len(term_getline(buf, rows)) >= cols - 1 || len(term_getline(buf, rows - statusoff)) >= cols - 1})
-  catch /timed out after/
-    let lines = map(range(1, rows), {key, val -> term_getline(buf, val)})
-    call assert_report('RunVimInTerminal() failed, screen contents: ' . join(lines, "<NL>"))
-  endtry
-
-  return buf
-endfunc
-
-" Stop a Vim running in terminal buffer "buf".
-func StopVimInTerminal(buf)
-  call assert_equal("running", term_getstatus(a:buf))
-
-  " CTRL-O : works both in Normal mode and Insert mode to start a command line.
-  " In Command-line it's inserted, the CTRL-U removes it again.
-  call term_sendkeys(a:buf, "\<C-O>:\<C-U>qa!\<cr>")
-
-  call WaitForAssert({-> assert_equal("finished", term_getstatus(a:buf))})
-  only!
-endfunc
+" Skip the rest if there is no terminal feature at all.
+if !has('terminal')
+  finish
+endif
 
 " Verify that Vim running in terminal buffer "buf" matches the screen dump.
 " "options" is passed to term_dumpwrite().

--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -5,6 +5,9 @@ if exists('*WaitFor')
   finish
 endif
 
+source view_util.vim
+source term_util.vim
+
 " Get the name of the Python executable.
 " Also keeps it in s:python.
 func PythonProg()
@@ -326,32 +329,4 @@ func WorkingClipboard()
     return $DISPLAY != ""
   endif
   return 1
-endfunc
-
-" Get line "lnum" as displayed on the screen.
-" Trailing white space is trimmed.
-func Screenline(lnum)
-  let chars = []
-  for c in range(1, winwidth(0))
-    call add(chars, nr2char(screenchar(a:lnum, c)))
-  endfor
-  let line = join(chars, '')
-  return matchstr(line, '^.\{-}\ze\s*$')
-endfunc
-
-" Stops the shell running in terminal "buf".
-func Stop_shell_in_terminal(buf)
-  call term_sendkeys(a:buf, "exit\r")
-  let job = term_getjob(a:buf)
-  call WaitFor({-> job_status(job) == "dead"})
-endfunc
-
-" Gets the text of a terminal line, using term_scrape()
-func Get_terminal_text(bufnr, row)
-  let list = term_scrape(a:bufnr, a:row)
-  let text = ''
-  for item in list
-    let text .= item.chars
-  endfor
-  return text
 endfunc

--- a/src/testdir/term_util.vim
+++ b/src/testdir/term_util.vim
@@ -1,0 +1,116 @@
+" Functions about terminal shared by several tests
+
+" Only load this script once.
+if exists('*CanRunVimInTerminal')
+  finish
+endif
+
+" For most tests we need to be able to run terminal Vim with 256 colors.  On
+" MS-Windows the console only has 16 colors and the GUI can't run in a
+" terminal.
+func CanRunVimInTerminal()
+  return has('terminal') && !has('win32')
+endfunc
+
+" Skip the rest if there is no terminal feature at all.
+if !has('terminal')
+  finish
+endif
+
+" Stops the shell running in terminal "buf".
+func StopShellInTerminal(buf)
+  call term_sendkeys(a:buf, "exit\r")
+  let job = term_getjob(a:buf)
+  call WaitFor({-> job_status(job) == "dead"})
+endfunc
+
+" Gets the text of a terminal line, using term_scrape()
+func GetTerminalText(bufnr, row)
+  let list = term_scrape(a:bufnr, a:row)
+  let text = ''
+  for item in list
+    let text .= item.chars
+  endfor
+  return text
+endfunc
+
+" Run Vim with "arguments" in a new terminal window.
+" By default uses a size of 20 lines and 75 columns.
+" Returns the buffer number of the terminal.
+"
+" Options is a dictionary, these items are recognized:
+" "rows" - height of the terminal window (max. 20)
+" "cols" - width of the terminal window (max. 78)
+" "statusoff" - number of lines the status is offset from default
+func RunVimInTerminal(arguments, options)
+  " If Vim doesn't exit a swap file remains, causing other tests to fail.
+  " Remove it here.
+  call delete(".swp")
+
+  if exists('$COLORFGBG')
+    " Clear $COLORFGBG to avoid 'background' being set to "dark", which will
+    " only be corrected if the response to t_RB is received, which may be too
+    " late.
+    let $COLORFGBG = ''
+  endif
+
+  " Make a horizontal and vertical split, so that we can get exactly the right
+  " size terminal window.  Works only when the current window is full width.
+  call assert_equal(&columns, winwidth(0))
+  split
+  vsplit
+
+  " Always do this with 256 colors and a light background.
+  set t_Co=256 background=light
+  hi Normal ctermfg=NONE ctermbg=NONE
+
+  " Make the window 20 lines high and 75 columns, unless told otherwise.
+  let rows = get(a:options, 'rows', 20)
+  let cols = get(a:options, 'cols', 75)
+  let statusoff = get(a:options, 'statusoff', 1)
+
+  let cmd = GetVimCommandClean()
+
+  " Add -v to have gvim run in the terminal (if possible)
+  let cmd .= ' -v ' . a:arguments
+  let buf = term_start(cmd, {
+	\ 'curwin': 1,
+	\ 'term_rows': rows,
+	\ 'term_cols': cols,
+	\ })
+  if &termwinsize == ''
+    " in the GUI we may end up with a different size, try to set it.
+    if term_getsize(buf) != [rows, cols]
+      call term_setsize(buf, rows, cols)
+    endif
+    call assert_equal([rows, cols], term_getsize(buf))
+  else
+    let rows = term_getsize(buf)[0]
+    let cols = term_getsize(buf)[1]
+  endif
+
+  " Wait for "All" or "Top" of the ruler to be shown in the last line or in
+  " the status line of the last window. This can be quite slow (e.g. when
+  " using valgrind).
+  " If it fails then show the terminal contents for debugging.
+  try
+    call WaitFor({-> len(term_getline(buf, rows)) >= cols - 1 || len(term_getline(buf, rows - statusoff)) >= cols - 1})
+  catch /timed out after/
+    let lines = map(range(1, rows), {key, val -> term_getline(buf, val)})
+    call assert_report('RunVimInTerminal() failed, screen contents: ' . join(lines, "<NL>"))
+  endtry
+
+  return buf
+endfunc
+
+" Stop a Vim running in terminal buffer "buf".
+func StopVimInTerminal(buf)
+  call assert_equal("running", term_getstatus(a:buf))
+
+  " CTRL-O : works both in Normal mode and Insert mode to start a command line.
+  " In Command-line it's inserted, the CTRL-U removes it again.
+  call term_sendkeys(a:buf, "\<C-O>:\<C-U>qa!\<cr>")
+
+  call WaitForAssert({-> assert_equal("finished", term_getstatus(a:buf))})
+  only!
+endfunc

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -338,7 +338,7 @@ func Test_mksession_terminal_shell()
   endfor
   call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+\s*.*$', term_cmd)
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 
@@ -353,7 +353,7 @@ func Test_mksession_terminal_no_restore_cmdarg()
     endif
   endfor
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 
@@ -368,7 +368,7 @@ func Test_mksession_terminal_no_restore_funcarg()
     endif
   endfor
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 
@@ -384,7 +384,7 @@ func Test_mksession_terminal_no_restore_func()
     endif
   endfor
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 
@@ -400,7 +400,7 @@ func Test_mksession_terminal_no_ssop()
     endif
   endfor
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
   set sessionoptions&
 endfunc
@@ -418,7 +418,7 @@ func Test_mksession_terminal_restore_other()
   endfor
   call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+.*other', term_cmd)
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 

--- a/src/testdir/test_suspend.vim
+++ b/src/testdir/test_suspend.vim
@@ -53,7 +53,7 @@ func Test_suspend()
   " Quit gracefully to dump coverage information.
   call term_sendkeys(buf, ":qall!\<CR>")
   call term_wait(buf)
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
 
   exe buf . 'bwipe!'
   call delete('Xfoo')

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -52,7 +52,7 @@ func Test_terminal_basic()
   call assert_notmatch('%[^\n]*running]', execute('ls F'))
   call assert_notmatch('%[^\n]*running]', execute('ls ?'))
 
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   call assert_equal('n', mode())
   call assert_match('%aF[^\n]*finished]', execute('ls'))
@@ -70,7 +70,7 @@ endfunc
 
 func Test_terminal_make_change()
   let buf = Run_shell_in_terminal({})
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
 
   setlocal modifiable
@@ -134,7 +134,7 @@ func Test_terminal_hide_buffer()
   call assert_true(buflisted(buf))
 
   exe 'split ' . buf . 'buf'
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   exe buf . 'bwipe'
 
   unlet g:job
@@ -310,7 +310,7 @@ func Test_terminal_scrollback()
   let lines = line('$')
   call assert_inrange(91, 100, lines)
 
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   exe buf . 'bwipe'
   set termwinscroll&
@@ -487,7 +487,7 @@ func Test_terminal_finish_open_close()
   call assert_equal(2, winnr('$'))
   " Wait for the shell to display a prompt
   call WaitForAssert({-> assert_notequal('', term_getline(buf, 1))})
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call WaitForAssert({-> assert_equal(1, winnr('$'))}, waittime)
 
   " shell terminal that does not close automatically
@@ -496,7 +496,7 @@ func Test_terminal_finish_open_close()
   call assert_equal(2, winnr('$'))
   " Wait for the shell to display a prompt
   call WaitForAssert({-> assert_notequal('', term_getline(buf, 1))})
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call assert_equal(2, winnr('$'))
   quit
   call assert_equal(1, winnr('$'))
@@ -602,7 +602,7 @@ func s:test_environment(name, value)
     call term_sendkeys(buf, "echo $" . a:name . "\r")
   endif
   call term_wait(buf)
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call WaitForAssert({-> assert_equal(a:value, getline(2))})
 
   exe buf . 'bwipe'
@@ -619,7 +619,7 @@ func Test_terminal_env()
     call term_sendkeys(buf, "echo $TESTENV\r")
   endif
   call term_wait(buf)
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call WaitForAssert({-> assert_equal('correct', getline(2))})
 
   exe buf . 'bwipe'
@@ -661,7 +661,7 @@ func Test_terminal_noblock()
   call assert_match('done', line)
 
   let g:job = term_getjob(buf)
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   unlet g:job
   bwipe
@@ -816,7 +816,7 @@ func TerminalTmap(remap)
   endif
 
   call term_sendkeys(buf, "\r")
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
 
   tunmap 123
@@ -834,7 +834,7 @@ endfunc
 func Test_terminal_wall()
   let buf = Run_shell_in_terminal({})
   wall
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   exe buf . 'bwipe'
   unlet g:job
@@ -843,7 +843,7 @@ endfunc
 func Test_terminal_wqall()
   let buf = Run_shell_in_terminal({})
   call assert_fails('wqall', 'E948')
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   exe buf . 'bwipe'
   unlet g:job
@@ -969,7 +969,7 @@ func Test_terminal_response_to_control_sequence()
   " End "cat" gently.
   call term_sendkeys(buf, "\<CR>\<C-D>")
 
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   exe buf . 'bwipe'
   unlet g:job
 endfunc
@@ -1448,7 +1448,7 @@ func Test_terminal_ansicolors_default()
 
   let buf = Run_shell_in_terminal({})
   call assert_equal(colors, term_getansicolors(buf))
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
 
   exe buf . 'bwipe'
@@ -1469,7 +1469,7 @@ func Test_terminal_ansicolors_global()
   let g:terminal_ansi_colors = reverse(copy(s:test_colors))
   let buf = Run_shell_in_terminal({})
   call assert_equal(g:terminal_ansi_colors, term_getansicolors(buf))
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
 
   exe buf . 'bwipe'
@@ -1499,7 +1499,7 @@ func Test_terminal_ansicolors_func()
   let colors[4] = 'Invalid'
   call assert_fails('call term_setansicolors(buf, colors)', 'E474:')
 
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   exe buf . 'bwipe'
 endfunc
@@ -1599,7 +1599,7 @@ func Test_terminal_termwinsize_option_zero()
   let buf = Run_shell_in_terminal({})
   let win = bufwinid(buf)
   call assert_equal([winheight(win), winwidth(win)], term_getsize(buf))
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   exe buf . 'bwipe'
 
@@ -1607,7 +1607,7 @@ func Test_terminal_termwinsize_option_zero()
   let buf = Run_shell_in_terminal({})
   let win = bufwinid(buf)
   call assert_equal([7, winwidth(win)], term_getsize(buf))
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   exe buf . 'bwipe'
 
@@ -1615,7 +1615,7 @@ func Test_terminal_termwinsize_option_zero()
   let buf = Run_shell_in_terminal({})
   let win = bufwinid(buf)
   call assert_equal([winheight(win), 33], term_getsize(buf))
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   exe buf . 'bwipe'
 
@@ -1645,7 +1645,7 @@ func Test_terminal_termwinsize_minimum()
   call assert_equal(7, winheight(win))
   call assert_equal(30, winwidth(win))
 
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   exe buf . 'bwipe'
 
@@ -1653,7 +1653,7 @@ func Test_terminal_termwinsize_minimum()
   let buf = Run_shell_in_terminal({})
   let win = bufwinid(buf)
   call assert_equal([winheight(win), winwidth(win)], term_getsize(buf))
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
   exe buf . 'bwipe'
 
@@ -1791,7 +1791,7 @@ func Test_zz1_terminal_in_gui()
 
   call assert_equal(1, winnr('$'))
   let buf = Run_shell_in_terminal({'term_finish': 'close'})
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
   call term_wait(buf)
 
   " closing window wipes out the terminal buffer a with finished job
@@ -1972,7 +1972,7 @@ func Test_term_getcursor()
   call WaitForAssert({-> assert_equal([0, 3],
   \ [term_getcursor(buf)[2].blink, term_getcursor(buf)[2].shape])})
 
-  call Stop_shell_in_terminal(buf)
+  call StopShellInTerminal(buf)
 endfunc
 
 func Test_term_gettitle()

--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -4,7 +4,6 @@ source check.vim
 CheckFeature timers
 
 source shared.vim
-source screendump.vim
 
 func MyHandler(timer)
   let g:val += 1

--- a/src/testdir/view_util.vim
+++ b/src/testdir/view_util.vim
@@ -1,9 +1,20 @@
 " Functions about view shared by several tests
 
 " Only load this script once.
-if exists('*ScreenLines')
+if exists('*ScreenLine')
   finish
 endif
+
+" Get line "lnum" as displayed on the screen.
+" Trailing white space is trimmed.
+func Screenline(lnum)
+  let chars = []
+  for c in range(1, winwidth(0))
+    call add(chars, nr2char(screenchar(a:lnum, c)))
+  endfor
+  let line = join(chars, '')
+  return matchstr(line, '^.\{-}\ze\s*$')
+endfunc
 
 " Get text on the screen, including composing characters.
 " ScreenLines(lnum, width) or


### PR DESCRIPTION
This pull-req puts together the functions about terminal into term_util.vim.

* `CanRunVimInTerminal()`
* `RunVimInTerminal()`
* `StopVimInTerminal()`
* `StopShellInTerminal()` (rename `Stop_shell_in_terminal()`. it uses `term_sendkeys()`)
* `GetTerminalText()` (rename `Get_terminal_text()`. it uses `term_scrape()`)