### PR TITLE
Clear and redraw all when the number, relativenumber or signcolumn options are changed

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2253,6 +2253,7 @@ gui_outstr_nowrap(
     int		col = gui.col;
 #ifdef FEAT_SIGN_ICONS
     int		draw_sign = FALSE;
+    int		signcol = 0;
     char_u	extra[18];
 # ifdef FEAT_NETBEANS_INTG
     int		multi_sign = FALSE;
@@ -2287,6 +2288,8 @@ gui_outstr_nowrap(
 	if (len == 1 && col > 0)
 	    --col;
 	len = (int)STRLEN(s);
+	if (len > 2)
+	    signcol = len - 3;	// Right align sign icon in the number column
 	draw_sign = TRUE;
 	highlight_mask = 0;
     }
@@ -2612,7 +2615,7 @@ gui_outstr_nowrap(
 #ifdef FEAT_SIGN_ICONS
     if (draw_sign)
 	/* Draw the sign on top of the spaces. */
-	gui_mch_drawsign(gui.row, col, gui.highlight_mask);
+	gui_mch_drawsign(gui.row, signcol, gui.highlight_mask);
 # if defined(FEAT_NETBEANS_INTG) && (defined(FEAT_GUI_X11) \
 	|| defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN))
     if (multi_sign)

--- a/src/option.c
+++ b/src/option.c
@@ -1985,7 +1985,7 @@ static struct vimoption options[] =
 			    (char_u *)&p_nf, PV_NF,
 			    {(char_u *)"bin,octal,hex", (char_u *)0L}
 			    SCTX_INIT},
-    {"number",	    "nu",   P_BOOL|P_VI_DEF|P_RWIN,
+    {"number",	    "nu",   P_BOOL|P_VI_DEF|P_RCLR,
 			    (char_u *)VAR_WIN, PV_NU,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"numberwidth", "nuw",  P_NUM|P_RWIN|P_VIM,
@@ -2252,7 +2252,7 @@ static struct vimoption options[] =
     {"regexpengine", "re",  P_NUM|P_VI_DEF,
 			    (char_u *)&p_re, PV_NONE,
 			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
-    {"relativenumber", "rnu", P_BOOL|P_VI_DEF|P_RWIN,
+    {"relativenumber", "rnu", P_BOOL|P_VI_DEF|P_RCLR,
 			    (char_u *)VAR_WIN, PV_RNU,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"remap",	    NULL,   P_BOOL|P_VI_DEF,
@@ -2497,7 +2497,7 @@ static struct vimoption options[] =
     {"sidescrolloff", "siso", P_NUM|P_VI_DEF|P_VIM|P_RBUF,
 			    (char_u *)&p_siso, PV_SISO,
 			    {(char_u *)0L, (char_u *)0L} SCTX_INIT},
-    {"signcolumn",   "scl",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
+    {"signcolumn",   "scl",  P_STRING|P_ALLOCED|P_VI_DEF|P_RCLR,
 #ifdef FEAT_SIGNS
 			    (char_u *)VAR_WIN, PV_SCL,
 			    {(char_u *)"auto", (char_u *)0L}


### PR DESCRIPTION

When using sign icons with 'signcolumn' set to 'number', if the 'number' option
is disabled and then enabled or if the 'signcolumn' option is set to 'auto'
and then 'number', the sign icons are not properly redrawn.
Change the redraw setting for these options.