### PR TITLE
Fix: Crash by GC during specific processing

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -811,7 +811,7 @@ dict_get_tv(char_u **arg, typval_T *rettv, int evaluate)
     {
 	semsg(_("E723: Missing end of Dictionary '}': %s"), *arg);
 failret:
-	if (d != NULL)
+	if (evaluate)
 	    dict_free(d);
 	return FAIL;
     }

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -367,9 +367,10 @@ check_due_timer(void)
 	    int save_vgetc_busy = vgetc_busy;
 	    int save_did_emsg = did_emsg;
 	    int save_called_emsg = called_emsg;
-	    int	save_must_redraw = must_redraw;
-	    int	save_trylevel = trylevel;
+	    int save_must_redraw = must_redraw;
+	    int save_trylevel = trylevel;
 	    int save_did_throw = did_throw;
+	    int save_may_garbage_collect = may_garbage_collect;
 	    int save_ex_pressedreturn = get_pressedreturn();
 	    except_T *save_current_exception = current_exception;
 	    vimvars_save_T vvsave;
@@ -384,14 +385,17 @@ check_due_timer(void)
 	    must_redraw = 0;
 	    trylevel = 0;
 	    did_throw = FALSE;
+	    may_garbage_collect = FALSE;
 	    current_exception = NULL;
 	    save_vimvars(&vvsave);
+
 	    timer->tr_firing = TRUE;
 	    timer_callback(timer);
 	    timer->tr_firing = FALSE;
 
 	    timer_next = timer->tr_next;
 	    did_one = TRUE;
+
 	    timer_busy = save_timer_busy;
 	    vgetc_busy = save_vgetc_busy;
 	    if (did_uncaught_emsg)
@@ -400,6 +404,7 @@ check_due_timer(void)
 	    called_emsg = save_called_emsg;
 	    trylevel = save_trylevel;
 	    did_throw = save_did_throw;
+	    may_garbage_collect = save_may_garbage_collect;
 	    current_exception = save_current_exception;
 	    restore_vimvars(&vvsave);
 	    if (must_redraw != 0)

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2540,13 +2540,18 @@ vgetorpeek(int advance)
 			 */
 			if (mp->m_expr)
 			{
-			    int		save_vgetc_busy = vgetc_busy;
+			    int save_vgetc_busy = vgetc_busy;
+			    int save_may_garbage_collect = may_garbage_collect;
 
 			    vgetc_busy = 0;
+			    may_garbage_collect = FALSE;
+
 			    save_m_keys = vim_strsave(mp->m_keys);
 			    save_m_str = vim_strsave(mp->m_str);
 			    s = eval_map_expr(save_m_str, NUL);
+
 			    vgetc_busy = save_vgetc_busy;
+			    may_garbage_collect = save_may_garbage_collect;
 			}
 			else
 #endif

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -397,3 +397,39 @@ func Test_motionforce_omap()
   delfunc Select
   delfunc GetCommand
 endfunc
+
+func Test_error_in_map_expr()
+  if !has('terminal') || (has('win32') && has('gui_running'))
+    throw 'Skipped: cannot run Vim in a terminal window'
+  endif
+
+  let lines =<< trim [CODE]
+  func Func()
+    " fail to create list
+    let x = [
+  endfunc
+  nmap <expr> ! Func()
+  set updatetime=50
+  [CODE]
+  call writefile(lines, 'Xtest.vim')
+
+  let buf = term_start(GetVimCommandClean() .. ' -S Xtest.vim', {'term_rows': 8})
+  let job = term_getjob(buf)
+  call WaitForAssert({-> assert_notequal('', term_getline(buf, 8))})
+
+  " GC must not run during map-expr processing, which can make Vim crash.
+  call term_sendkeys(buf, '!')
+  call term_wait(buf, 100)
+  call term_sendkeys(buf, "\<CR>")
+  call term_wait(buf, 100)
+  call assert_equal('run', job_status(job))
+
+  call term_sendkeys(buf, ":qall!\<CR>")
+  call WaitFor({-> job_status(job) ==# 'dead'})
+  if has('unix')
+    call assert_equal('', job_info(job).termsig)
+  endif
+
+  call delete('Xtest.vim')
+  exe buf .. 'bwipe!'
+endfunc

--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -333,4 +333,39 @@ func Test_nocatch_garbage_collect()
   delfunc FeedChar
 endfunc
 
+func Test_error_in_timer_callback()
+  if !has('terminal') || (has('win32') && has('gui_running'))
+    throw 'Skipped: cannot run Vim in a terminal window'
+  endif
+
+  let lines =<< trim [CODE]
+  func Func(timer)
+    " fail to create list
+    let x = [
+  endfunc
+  set updatetime=50
+  call timer_start(1, 'Func')
+  [CODE]
+  call writefile(lines, 'Xtest.vim')
+
+  let buf = term_start(GetVimCommandClean() .. ' -S Xtest.vim', {'term_rows': 8})
+  let job = term_getjob(buf)
+  call WaitForAssert({-> assert_notequal('', term_getline(buf, 8))})
+
+  " GC must not run during timer callback, which can make Vim crash.
+  call term_wait(buf, 100)
+  call term_sendkeys(buf, "\<CR>")
+  call term_wait(buf, 100)
+  call assert_equal('run', job_status(job))
+
+  call term_sendkeys(buf, ":qall!\<CR>")
+  call WaitFor({-> job_status(job) ==# 'dead'})
+  if has('unix')
+    call assert_equal('', job_info(job).termsig)
+  endif
+
+  call delete('Xtest.vim')
+  exe buf .. 'bwipe!'
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -1665,7 +1665,7 @@ func Test_refcount()
     delfunc DictFunc
 endfunc
 
-func! Test_funccall_garbage_collect()
+func Test_funccall_garbage_collect()
     func Func(x, ...)
         call add(a:x, a:000)
     endfunc


### PR DESCRIPTION
Ref #4571 

## Repro steps

### Case 1. Error in timer callback

timer.vim
```vim
func Func(timer)
  " fail to create list
  let x = [
endfunc
call timer_start(1, 'Func')
```

`vim --clean -S timer.vim`

### Case 2. Error in map-expr

mapexpr.vim
```vim
func Func()
  " fail to create list
  let x = [
endfunc
nmap <expr> ! Func()
```

`vim --clean -S mapexpr.vim` and input `!`

In both case, the error message is shown:

```
Error detected while processing function Func:
line    2:
E697: Missing end of List ']':
Press ENTER or type command to continue
```

and leave Vim alone (with keep shown) few seconds (>= 4sec, GC runs), then Vim will crash.

## Cause

ASAN log (case 1):

```
=================================================================
==6424==ERROR: AddressSanitizer: heap-use-after-free on address 0x6070000030b0 at pc 0x55a15a89bd0a bp 0x7ffcc07dbea0 sp 0x7ffcc07dbe90
READ of size 8 at 0x6070000030b0 thread T0
    #0 0x55a15a89bd09 in list_free_contents /workspace/vim/src/list.c:164
    #1 0x55a15a89c18e in list_free /workspace/vim/src/list.c:235
    #2 0x55a15a89ec23 in get_list_tv /workspace/vim/src/list.c:928
    #3 0x55a15a6ff628 in eval7 /workspace/vim/src/eval.c:4575
    #4 0x55a15a6fdfc6 in eval6 /workspace/vim/src/eval.c:4260
    #5 0x55a15a6fd036 in eval5 /workspace/vim/src/eval.c:4051
    #6 0x55a15a6fc792 in eval4 /workspace/vim/src/eval.c:3933
    #7 0x55a15a6fc326 in eval3 /workspace/vim/src/eval.c:3853
    #8 0x55a15a6fbe84 in eval2 /workspace/vim/src/eval.c:3785
    #9 0x55a15a6fb915 in eval1 /workspace/vim/src/eval.c:3713
    #10 0x55a15a6fb625 in eval0 /workspace/vim/src/eval.c:3671
    #11 0x55a15a6ee7d8 in ex_let_const /workspace/vim/src/eval.c:1470
    #12 0x55a15a6edb82 in ex_let /workspace/vim/src/eval.c:1371
    #13 0x55a15a7aba5d in do_one_cmd /workspace/vim/src/ex_docmd.c:2500
    #14 0x55a15a7a2d7a in do_cmdline /workspace/vim/src/ex_docmd.c:995
    #15 0x55a15abb8045 in call_user_func /workspace/vim/src/userfunc.c:1063
    #16 0x55a15abba9dd in call_func /workspace/vim/src/userfunc.c:1621
    #17 0x55a15abb9c0b in call_callback /workspace/vim/src/userfunc.c:1465
    #18 0x55a15a78c4b5 in timer_callback /workspace/vim/src/ex_cmds2.c:328
    #19 0x55a15a78cd5d in check_due_timer /workspace/vim/src/ex_cmds2.c:390
    #20 0x55a15ab91ebf in ui_wait_for_chars_or_timer /workspace/vim/src/ui.c:454
    #21 0x55a15a9ba859 in WaitForChar /workspace/vim/src/os_unix.c:5940
    #22 0x55a15ab91ca7 in inchar_loop /workspace/vim/src/ui.c:383
    #23 0x55a15a9ade0a in mch_inchar /workspace/vim/src/os_unix.c:388
    #24 0x55a15ab91755 in ui_inchar /workspace/vim/src/ui.c:231
    #25 0x55a15a850b81 in inchar /workspace/vim/src/getchar.c:3092
    #26 0x55a15a84fd1d in vgetorpeek /workspace/vim/src/getchar.c:2870
    #27 0x55a15a849e00 in vgetc /workspace/vim/src/getchar.c:1602
    #28 0x55a15a84a8a5 in safe_vgetc /workspace/vim/src/getchar.c:1821
    #29 0x55a15a912e40 in normal_cmd /workspace/vim/src/normal.c:596
    #30 0x55a15ac657e4 in main_loop /workspace/vim/src/main.c:1370
    #31 0x55a15ac64a9d in vim_main2 /workspace/vim/src/main.c:903
    #32 0x55a15ac6417d in main /workspace/vim/src/main.c:444
    #33 0x7fa4a728bb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #34 0x55a15a66c779 in _start (/workspace/vim/src/vim+0xf8779)

0x6070000030b0 is located 0 bytes inside of 80-byte region [0x6070000030b0,0x607000003100)
freed by thread T0 here:
    #0 0x7fa4a81177b8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7b8)
    #1 0x55a15a8e8786 in vim_free /workspace/vim/src/misc2.c:1805
    #2 0x55a15a89c043 in list_free_list /workspace/vim/src/list.c:208
    #3 0x55a15a89c11c in list_free_items /workspace/vim/src/list.c:225
    #4 0x55a15a705b99 in free_unref_items /workspace/vim/src/eval.c:5802
    #5 0x55a15a705a9c in garbage_collect /workspace/vim/src/eval.c:5748
    #6 0x55a15a8499d3 in before_blocking /workspace/vim/src/getchar.c:1520
    #7 0x55a15ab91c3d in inchar_loop /workspace/vim/src/ui.c:354
    #8 0x55a15a9ade0a in mch_inchar /workspace/vim/src/os_unix.c:388
    #9 0x55a15ab91755 in ui_inchar /workspace/vim/src/ui.c:231
    #10 0x55a15a850b81 in inchar /workspace/vim/src/getchar.c:3092
    #11 0x55a15a84fd1d in vgetorpeek /workspace/vim/src/getchar.c:2870
    #12 0x55a15a849e00 in vgetc /workspace/vim/src/getchar.c:1602
    #13 0x55a15a84a8a5 in safe_vgetc /workspace/vim/src/getchar.c:1821
    #14 0x55a15ac75dd1 in wait_return /workspace/vim/src/message.c:1098
    #15 0x55a15ac7fbc0 in msg_end /workspace/vim/src/message.c:3290
    #16 0x55a15ac72324 in msg_attr_keep /workspace/vim/src/message.c:182
    #17 0x55a15ac720b7 in msg_attr /workspace/vim/src/message.c:122
    #18 0x55a15ac744a2 in emsg_core /workspace/vim/src/message.c:701
    #19 0x55a15ac746b9 in semsg /workspace/vim/src/message.c:737
    #20 0x55a15a89ec08 in get_list_tv /workspace/vim/src/list.c:925
    #21 0x55a15a6ff628 in eval7 /workspace/vim/src/eval.c:4575
    #22 0x55a15a6fdfc6 in eval6 /workspace/vim/src/eval.c:4260
    #23 0x55a15a6fd036 in eval5 /workspace/vim/src/eval.c:4051
    #24 0x55a15a6fc792 in eval4 /workspace/vim/src/eval.c:3933
    #25 0x55a15a6fc326 in eval3 /workspace/vim/src/eval.c:3853
    #26 0x55a15a6fbe84 in eval2 /workspace/vim/src/eval.c:3785
    #27 0x55a15a6fb915 in eval1 /workspace/vim/src/eval.c:3713
    #28 0x55a15a6fb625 in eval0 /workspace/vim/src/eval.c:3671
    #29 0x55a15a6ee7d8 in ex_let_const /workspace/vim/src/eval.c:1470

previously allocated by thread T0 here:
    #0 0x7fa4a8117b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x55a15a8e641a in lalloc /workspace/vim/src/misc2.c:924
    #2 0x55a15a8e62bc in alloc_clear /workspace/vim/src/misc2.c:851
    #3 0x55a15a89b982 in list_alloc /workspace/vim/src/list.c:75
    #4 0x55a15a89e7c3 in get_list_tv /workspace/vim/src/list.c:890
    #5 0x55a15a6ff628 in eval7 /workspace/vim/src/eval.c:4575
    #6 0x55a15a6fdfc6 in eval6 /workspace/vim/src/eval.c:4260
    #7 0x55a15a6fd036 in eval5 /workspace/vim/src/eval.c:4051
    #8 0x55a15a6fc792 in eval4 /workspace/vim/src/eval.c:3933
    #9 0x55a15a6fc326 in eval3 /workspace/vim/src/eval.c:3853
    #10 0x55a15a6fbe84 in eval2 /workspace/vim/src/eval.c:3785
    #11 0x55a15a6fb915 in eval1 /workspace/vim/src/eval.c:3713
    #12 0x55a15a6fb625 in eval0 /workspace/vim/src/eval.c:3671
    #13 0x55a15a6ee7d8 in ex_let_const /workspace/vim/src/eval.c:1470
    #14 0x55a15a6edb82 in ex_let /workspace/vim/src/eval.c:1371
    #15 0x55a15a7aba5d in do_one_cmd /workspace/vim/src/ex_docmd.c:2500
    #16 0x55a15a7a2d7a in do_cmdline /workspace/vim/src/ex_docmd.c:995
    #17 0x55a15abb8045 in call_user_func /workspace/vim/src/userfunc.c:1063
    #18 0x55a15abba9dd in call_func /workspace/vim/src/userfunc.c:1621
    #19 0x55a15abb9c0b in call_callback /workspace/vim/src/userfunc.c:1465
    #20 0x55a15a78c4b5 in timer_callback /workspace/vim/src/ex_cmds2.c:328
    #21 0x55a15a78cd5d in check_due_timer /workspace/vim/src/ex_cmds2.c:390
    #22 0x55a15ab91ebf in ui_wait_for_chars_or_timer /workspace/vim/src/ui.c:454
    #23 0x55a15a9ba859 in WaitForChar /workspace/vim/src/os_unix.c:5940
    #24 0x55a15ab91ca7 in inchar_loop /workspace/vim/src/ui.c:383
    #25 0x55a15a9ade0a in mch_inchar /workspace/vim/src/os_unix.c:388
    #26 0x55a15ab91755 in ui_inchar /workspace/vim/src/ui.c:231
    #27 0x55a15a850b81 in inchar /workspace/vim/src/getchar.c:3092
    #28 0x55a15a84fd1d in vgetorpeek /workspace/vim/src/getchar.c:2870
    #29 0x55a15a849e00 in vgetc /workspace/vim/src/getchar.c:1602
```

When invoking timer-callback and handling map-expr `vgetc_busy` is set to 0 (save/restore), thus GC can run during them.
I propose should save/restore also `may_garbase_collect`.