### PR TITLE
Fix: File-select dialog can open when going to exit

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3818,13 +3818,9 @@ do_ecmd(
     else
     {
 #ifdef FEAT_BROWSE
-	if (cmdmod.browse)
+	if (cmdmod.browse && !exiting)
 	{
-	    if (
-# ifdef FEAT_GUI
-		!gui.in_use &&
-# endif
-		    au_has_group((char_u *)"FileExplorer"))
+	    if (!gui.in_use && au_has_group((char_u *)"FileExplorer"))
 	    {
 		/* No browsing supported but we do have the file explorer:
 		 * Edit the directory. */

--- a/src/feature.h
+++ b/src/feature.h
@@ -312,7 +312,8 @@
 /*
  * +cscope		Unix only: Cscope support.
  */
-#if defined(UNIX) && defined(FEAT_BIG) && !defined(FEAT_CSCOPE) && !defined(MACOS_X)
+#if !defined(FEAT_CSCOPE) && defined(FEAT_BIG) && defined(UNIX) \
+	&& !defined(MACOS_X)
 # define FEAT_CSCOPE
 #endif
 
@@ -709,7 +710,12 @@
  */
 #if defined(FEAT_NORMAL)
 # define FEAT_BROWSE_CMD
-# if defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA) || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_PHOTON) || defined(FEAT_GUI_MAC)
+# if defined(FEAT_GUI_MSWIN) \
+	|| defined(FEAT_GUI_MOTIF) \
+	|| defined(FEAT_GUI_ATHENA) \
+	|| defined(FEAT_GUI_GTK) \
+	|| defined(FEAT_GUI_PHOTON) \
+	|| defined(FEAT_GUI_MAC)
 #  define FEAT_BROWSE
 # endif
 #endif
@@ -749,9 +755,12 @@
 # define FEAT_GUI_DIALOG
 #endif
 #if defined(FEAT_GUI_DIALOG) && \
-	(defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA) \
-	 || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN) \
-	 || defined(FEAT_GUI_PHOTON) || defined(FEAT_GUI_MAC))
+	(defined(FEAT_GUI_MOTIF) \
+	 || defined(FEAT_GUI_ATHENA) \
+	 || defined(FEAT_GUI_GTK) \
+	 || defined(FEAT_GUI_MSWIN) \
+	 || defined(FEAT_GUI_PHOTON) \
+	 || defined(FEAT_GUI_MAC))
 # define FEAT_GUI_TEXTDIALOG
 # ifndef ALWAYS_USE_GUI
 #  define FEAT_CON_DIALOG
@@ -974,7 +983,8 @@
  * +X11			Unix only.  Include code for xterm title saving and X
  *			clipboard.  Only works if HAVE_X11 is also defined.
  */
-#if (defined(FEAT_NORMAL) || defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA))
+#if (defined(FEAT_NORMAL) \
+	|| defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA))
 # define WANT_X11
 #endif
 
@@ -1167,9 +1177,12 @@
 # define CURSOR_SHAPE
 #endif
 
-#if defined(FEAT_MZSCHEME) && (defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_GTK)    \
-	|| defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA)	\
-	|| defined(FEAT_GUI_MAC))
+#if defined(FEAT_MZSCHEME) \
+	&& (defined(FEAT_GUI_MSWIN) \
+	    || defined(FEAT_GUI_GTK) \
+	    || defined(FEAT_GUI_MOTIF) \
+	    || defined(FEAT_GUI_ATHENA) \
+	    || defined(FEAT_GUI_MAC))
 # define MZSCHEME_GUI_THREADS
 #endif
 
@@ -1263,7 +1276,8 @@
 # endif
 #endif
 
-#if defined(FEAT_BEVAL_GUI) && (defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA))
+#if defined(FEAT_BEVAL_GUI) \
+	&& (defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA))
 # define FEAT_BEVAL_TIP		/* balloon eval used for toolbar tooltip */
 #endif
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -444,7 +444,8 @@ gui_init_check(void)
     gui.menu_width = 0;
 # endif
 #endif
-#if defined(FEAT_TOOLBAR) && (defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA))
+#if defined(FEAT_TOOLBAR) \
+	&& (defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA))
     gui.toolbar_height = 0;
 #endif
 #if defined(FEAT_FOOTER) && defined(FEAT_GUI_MOTIF)
@@ -831,8 +832,12 @@ gui_exit(int rc)
     gui_mch_exit(rc);
 }
 
-#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_X11) || defined(FEAT_GUI_MSWIN) \
-	|| defined(FEAT_GUI_PHOTON) || defined(FEAT_GUI_MAC) || defined(PROTO)
+#if defined(FEAT_GUI_GTK) \
+	|| defined(FEAT_GUI_X11) \
+	|| defined(FEAT_GUI_MSWIN) \
+	|| defined(FEAT_GUI_PHOTON) \
+	|| defined(FEAT_GUI_MAC) \
+	|| defined(PROTO)
 # define NEED_GUI_UPDATE_SCREEN 1
 /*
  * Called when the GUI shell is closed by the user.  If there are no changed
@@ -1389,7 +1394,8 @@ gui_position_components(int total_width UNUSED)
 	text_area_y += gui.tabline_height;
 #endif
 
-#if defined(FEAT_TOOLBAR) && (defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA))
+#if defined(FEAT_TOOLBAR) \
+	&& (defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA))
     if (vim_strchr(p_go, GO_TOOLBAR) != NULL)
     {
 # ifdef FEAT_GUI_ATHENA
@@ -4273,12 +4279,16 @@ gui_update_scrollbars(
 	    /* Calculate height and position in pixels */
 	    h = (sb->height + sb->status_height) * gui.char_height;
 	    y = sb->top * gui.char_height + gui.border_offset;
-#if defined(FEAT_MENU) && !defined(FEAT_GUI_GTK) && !defined(FEAT_GUI_MOTIF) && !defined(FEAT_GUI_PHOTON)
+#if defined(FEAT_MENU) \
+	&& !(defined(FEAT_GUI_GTK) \
+	     || defined(FEAT_GUI_MOTIF) \
+	     || defined(FEAT_GUI_PHOTON))
 	    if (gui.menu_is_active)
 		y += gui.menu_height;
 #endif
 
-#if defined(FEAT_TOOLBAR) && (defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_ATHENA))
+#if defined(FEAT_TOOLBAR) \
+	&& (defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_ATHENA))
 	    if (vim_strchr(p_go, GO_TOOLBAR) != NULL)
 # ifdef FEAT_GUI_ATHENA
 		y += gui.toolbar_height;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3064,7 +3064,7 @@ term_channel_closed(channel_T *ch)
     for (term = first_term; term != NULL; term = next_term)
     {
 	next_term = term->tl_next;
-	if (term->tl_job == ch->ch_job)
+	if (term->tl_job == ch->ch_job && !term->tl_channel_closed)
 	{
 	    term->tl_channel_closed = TRUE;
 	    did_one = TRUE;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -358,6 +358,16 @@ setup_job_options(jobopt_T *opt, int rows, int cols)
 }
 
 /*
+ * Flush messages on channels.
+ */
+    static void
+term_flush_messages()
+{
+    mch_check_messages();
+    parse_queued_messages();
+}
+
+/*
  * Close a terminal buffer (and its window).  Used when creating the terminal
  * fails.
  */
@@ -1455,8 +1465,7 @@ term_try_stop_job(buf_T *buf)
 	    return OK;
 
 	ui_delay(10L, FALSE);
-	mch_check_messages();
-	parse_queued_messages();
+	term_flush_messages();
     }
     return FAIL;
 }
@@ -5628,33 +5637,31 @@ f_term_wait(typval_T *argvars, typval_T *rettv UNUSED)
 	ch_log(NULL, "term_wait(): waiting for channel to close");
 	while (buf->b_term != NULL && !buf->b_term->tl_channel_closed)
 	{
-	    mch_check_messages();
-	    parse_queued_messages();
+	    term_flush_messages();
+
 	    ui_delay(10L, FALSE);
 	    if (!buf_valid(buf))
 		/* If the terminal is closed when the channel is closed the
 		 * buffer disappears. */
 		break;
 	}
-	mch_check_messages();
-	parse_queued_messages();
+
+	term_flush_messages();
     }
     else
     {
 	long wait = 10L;
 
-	mch_check_messages();
-	parse_queued_messages();
+	term_flush_messages();
 
 	/* Wait for some time for any channel I/O. */
 	if (argvars[1].v_type != VAR_UNKNOWN)
 	    wait = tv_get_number(&argvars[1]);
 	ui_delay(wait, TRUE);
-	mch_check_messages();
 
 	/* Flushing messages on channels is hopefully sufficient.
 	 * TODO: is there a better way? */
-	parse_queued_messages();
+	term_flush_messages();
     }
 }
 


### PR DESCRIPTION
## Environment

gVim v8.1.1587 (with GTK3) on Ubuntu 18.04

## Repro steps

```
$ gvim --clean
:set nobuflisted
:terminal
```

Click GUI window-close button and click "Yes" button on popup "Kill job in ...", then file-select dialog can open (or gVim finishes normally. Please try several times).
When click "Cancel", the dialog closes but opens again promptly.

## Cause

Stacktrace when file-select dialog is shown:

```
(gdb) bt
#0  0x00007fbb55debbf9 in __GI___poll (fds=0x5612fa8a0400, nfds=4, timeout=19989) at ../sysdeps/unix/sysv/linux/poll.c:29
#1  0x00007fbb574b64c9 in  () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#2  0x00007fbb574b6862 in g_main_loop_run () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#3  0x00007fbb58ba2db3 in gtk_dialog_run () at /usr/lib/x86_64-linux-gnu/libgtk-3.so.0
#4  0x00005612f9a709cc in gui_mch_browse (saving=0, title=0x5612f9ac5723 "Edit File", dflt=0x0, ext=0x0, initdir=0x0, filter=0x5612f9ae7412 "") at gui_gtk.c:1271
#5  0x00005612f9abcca4 in do_browse (flags=0, title=0x5612f9ac5723 "Edit File", dflt=0x0, ext=0x0, initdir=0x0, filter=0x5612f9ae7388 "All Files (*)\t*\nC source (*.c, *
.h)\t*.c;*.h\nC++ source (*.cpp, *.hpp)\t*.cpp;*.hpp\nVim files (*.vim, _vimrc, _gvimrc)\t*.vim;_vimrc;_gvimrc\n", buf=0x5612fa922000) at message.c:4074
#6  0x00005612f989debc in do_ecmd (fnum=0, ffname=0x0, sfname=0x0, eap=0x0, newlnum=1, flags=0, oldwin=0x5612fa8e3000) at ex_cmds.c:3836
#7  0x00005612f983fd65 in empty_curbuf (close_others=1, forceit=0, action=4) at buffer.c:1231
#8  0x00005612f98401be in do_buffer (action=4, start=1, dir=1, count=2, forceit=0) at buffer.c:1413
#9  0x00005612f983fb19 in do_bufdel (command=4, arg=0x5612f9addbf8 "", addr_count=1, start_bnr=2, end_bnr=2, forceit=0) at buffer.c:1173
#10 0x00005612f9a38896 in term_after_channel_closed (term=0x5612fa8986d0) at terminal.c:3026
#11 0x00005612f9a38a67 in term_channel_closed (ch=0x5612fa8f7400) at terminal.c:3090
#12 0x00005612f9a9a3a2 in channel_close (channel=0x5612fa8f7400, invoke_close_cb=1) at channel.c:3056
#13 0x00005612f9a9ab76 in channel_close_now (channel=0x5612fa8f7400) at channel.c:3378
#14 0x00005612f9a9c87f in channel_parse_messages () at channel.c:4418
#15 0x00005612f99349ed in parse_queued_messages () at misc2.c:4470
#16 0x00005612f9a3587f in term_try_stop_job (buf=0x5612fa922000) at terminal.c:1459
#17 0x00005612f98a8074 in check_changed_any (hidden=0, unload=0) at ex_cmds2.c:1340
#18 0x00005612f9a68188 in gui_shell_closed () at gui.c:860
#19 0x00005612f9a76ec2 in delete_event_cb (widget=0x5612fa6f4270, event=0x5612fa72ed40, data=0x0) at gui_gtk_x11.c:2941
...
```

In `term_try_stop_job()`, `job->jv_status >= JOB_END` cannot hold necessarily just after `job_end()` called (except Windows gVim).
https://github.com/vim/vim/blob/master/src/terminal.c#L1451-L1459

Therefore, `do_browse()` is called as above trace, file-select dialog opens.
When click "Cancel", `do_browse()` returns FAIL, so delete-buffer doesn't complete and `first_term` remains then the loop in `term_channel_closed()` isn't finished.
https://github.com/vim/vim/blob/master/src/terminal.c#L3064-L3093

## Solution proposal

* Don't open file-select dialog when going to exit
* Check `term->tl_channel_closed` in `term_channel_closed()`

## In addition

https://github.com/vim/vim/blob/master/src/ex_cmds.c#L3820-L3828

```c
#ifdef FEAT_BROWSE
        if (cmdmod.browse)
        {
            if (
# ifdef FEAT_GUI
                !gui.in_use &&
# endif
                    au_has_group((char_u *)"FileExplorer"))
            {
```

It appears this `FEAT_GUI` isn't need since `FEAT_BROWSE` includes `FEAT_GUI`.