### PR TITLE
vimdll: Solarized doesn't work well

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -9554,6 +9554,9 @@ set_hl_attr(
 	at_en.ae_u.cterm.bg_color = sgp->sg_cterm_bg;
 # ifdef FEAT_TERMGUICOLORS
 #  ifdef MSWIN
+#   ifdef VIMDLL
+	if (!gui.in_use && !gui.starting)
+#   endif
 	{
 	    int id;
 	    guicolor_T fg, bg;


### PR DESCRIPTION
I had a report that when VIMDLL is used, the Solarized colorscheme with dark
background doesn't work well with GUI.

To reproduce:
1. Install https://github.com/altercation/vim-colors-solarized
2. `gvim -N -u NONE --cmd "set background=dark | colorscheme solarized"`

The background becomes dark orange, not dark gray.
This PR fixes the problem.