### PR TITLE
Ocaml ftplugin update and add Dune buildsystem syntax support

### DIFF
--- a/runtime/compiler/ocaml.vim
+++ b/runtime/compiler/ocaml.vim
@@ -1,7 +1,11 @@
 " Vim Compiler File
-" Compiler:	ocaml
-" Maintainer:	See ftplugin/ocaml.vim (?)
-" Last Change:	June 2013 by Marc Weber
+" Compiler:    ocaml
+" Maintainer:  Markus Mottl <markus.mottl@gmail.com>
+" URL:         https://github.com/rgrinberg/vim-ocaml
+" Last Change:
+"              2017 Nov 26 - Improved error format (Markus Mottl)
+"              2013 Aug 27 - Added a new OCaml error format (Markus Mottl)
+"              2013 Jun 30 - Initial version (Marc Weber)
 "
 " Marc Weber's comments:
 " Setting makeprg doesn't make sense, because there is ocamlc, ocamlopt,
@@ -17,7 +21,6 @@
 "
 " So having it here makes people opt-in
 
-
 if exists("current_compiler")
     finish
 endif
@@ -28,6 +31,7 @@ set cpo&vim
 
 CompilerSet errorformat =
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d:,
+      \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d\ %.%#,
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ character\ %c:%m,
       \%+EReference\ to\ unbound\ regexp\ name\ %m,
       \%Eocamlyacc:\ e\ -\ line\ %l\ of\ \"%f\"\\,\ %m,
@@ -38,6 +42,12 @@ CompilerSet errorformat =
       \%X%*\\a[%*\\d]:\ Leaving\ directory\ `%f',
       \%D%*\\a:\ Entering\ directory\ `%f',
       \%X%*\\a:\ Leaving\ directory\ `%f',
+      \%D%*\\a[%*\\d]:\ Entering\ directory\ '%f',
+      \%X%*\\a[%*\\d]:\ Leaving\ directory\ '%f',
+      \%D%*\\a:\ Entering\ directory\ '%f',
+      \%X%*\\a:\ Leaving\ directory\ '%f',
+      \%DEntering\ directory\ '%f',
+      \%XLeaving\ directory\ '%f',
       \%DMaking\ %*\\a\ in\ %f
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/dune.vim
+++ b/runtime/ftplugin/dune.vim
@@ -1,0 +1,20 @@
+" Language:    Dune buildsystem
+" Maintainer:  Markus Mottl        <markus.mottl@gmail.com>
+"              Anton Kochkov       <anton.kochkov@gmail.com>
+" URL:         https://github.com/rgrinberg/vim-ocaml
+" Last Change:
+"              2018 Nov 3 - Added commentstring (Markus Mottl)
+"              2017 Sep 6 - Initial version (Etienne Millon)
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin=1
+
+set lisp
+
+" Comment string
+setl commentstring=;\ %s
+setl comments=:;
+
+setl iskeyword+=#,?,.,/

--- a/runtime/ftplugin/ocaml.vim
+++ b/runtime/ftplugin/ocaml.vim
@@ -5,12 +5,12 @@
 "              Pierre Vittet       <pierre-vittet@pvittet.com>
 "              Stefano Zacchiroli  <zack@bononia.it>
 "              Vincent Aravantinos <firstname.name@imag.fr>
-" URL:         http://www.ocaml.info/vim/ftplugin/ocaml.vim
+" URL:         https://github.com/rgrinberg/vim-ocaml
 " Last Change:
+"              2013 Oct 27 - Added commentstring (MM)
 "              2013 Jul 26 - load default compiler settings (MM)
 "              2013 Jul 24 - removed superfluous efm-setting (MM)
 "              2013 Jul 22 - applied fixes supplied by Hirotaka Hamada (MM)
-"              2013 Mar 15 - Improved error format (MM)
 
 if exists("b:did_ftplugin")
   finish
@@ -37,6 +37,10 @@ endif
 let s:cposet=&cpoptions
 set cpo&vim
 
+" Comment string
+setlocal comments=
+setlocal commentstring=(*%s*)
+
 " Add mappings, unless the user didn't want this.
 if !exists("no_plugin_maps") && !exists("no_ocaml_maps")
   " (un)commenting
@@ -60,15 +64,38 @@ if !exists("no_plugin_maps") && !exists("no_ocaml_maps")
 endif
 
 " Let % jump between structure elements (due to Issac Trotts)
-let b:mw = ''
-let b:mw = b:mw . ',\<let\>:\<and\>:\(\<in\>\|;;\)'
+let b:mw =         '\<let\>:\<and\>:\(\<in\>\|;;\)'
 let b:mw = b:mw . ',\<if\>:\<then\>:\<else\>'
-let b:mw = b:mw . ',\<\(for\|while\)\>:\<do\>:\<done\>,'
+let b:mw = b:mw . ',\<\(for\|while\)\>:\<do\>:\<done\>'
 let b:mw = b:mw . ',\<\(object\|sig\|struct\|begin\)\>:\<end\>'
 let b:mw = b:mw . ',\<\(match\|try\)\>:\<with\>'
 let b:match_words = b:mw
 
 let b:match_ignorecase=0
+
+function! s:OcpGrep(bang,args) abort
+  let grepprg = &l:grepprg
+  let grepformat = &l:grepformat
+  let shellpipe = &shellpipe
+  try
+    let &l:grepprg = "ocp-grep -c never"
+    setlocal grepformat=%f:%l:%m
+    if &shellpipe ==# '2>&1| tee' || &shellpipe ==# '|& tee'
+      let &shellpipe = "| tee"
+    endif
+    execute 'grep! '.a:args
+    if empty(a:bang) && !empty(getqflist())
+      return 'cfirst'
+    else
+      return ''
+    endif
+  finally
+    let &l:grepprg = grepprg
+    let &l:grepformat = grepformat
+    let &shellpipe = shellpipe
+  endtry
+endfunction
+command! -bar -bang -complete=file -nargs=+ Ocpgrep exe s:OcpGrep(<q-bang>, <q-args>)
 
 " switching between interfaces (.mli) and implementations (.ml)
 if !exists("g:did_ocaml_switch")
@@ -97,15 +124,8 @@ endif
 " Folding support
 
 " Get the modeline because folding depends on indentation
-let s:s = line2byte(line('.'))+col('.')-1
-if search('^\s*(\*:o\?caml:')
-  let s:modeline = getline(".")
-else
-  let s:modeline = ""
-endif
-if s:s > 0
-  exe 'goto' s:s
-endif
+let lnum = search('^\s*(\*:o\?caml:', 'n')
+let s:modeline = lnum? getline(lnum): ""
 
 " Get the indentation params
 let s:m = matchstr(s:modeline,'default\s*=\s*\d\+')
@@ -372,8 +392,8 @@ endfunction
   endfun
 
   " This variable contain a dictionnary of list. Each element of the dictionnary
-  " represent an annotation system. An annotation system is a list with:
-  " - annotation file name as its key
+  " represent an annotation system. An annotation system is a list with :
+  " - annotation file name as it's key
   " - annotation file path as first element of the contained list
   " - build path as second element of the contained list
   " - annot_file_last_mod (contain the date of .annot file) as third element

--- a/runtime/syntax/dune.vim
+++ b/runtime/syntax/dune.vim
@@ -1,0 +1,46 @@
+" Language:    Dune buildsystem
+" Maintainer:  Markus Mottl        <markus.mottl@gmail.com>
+"              Anton Kochkov       <anton.kochkov@gmail.com>
+" URL:         https://github.com/rgrinberg/vim-ocaml
+" Last Change:
+"              2019 Feb 27 - Add newer keywords to the syntax (Simon Cruanes)
+"              2018 May 8 - Check current_syntax (Kawahara Satoru)
+"              2018 Mar 29 - Extend jbuild syntax with more keywords (Petter A. Urkedal)
+"              2017 Sep 6 - Initial version (Etienne Millon)
+
+if exists("b:current_syntax")
+    finish
+endif
+
+set syntax=lisp
+syn case match
+
+" The syn-iskeyword setting lacks #,? from the iskeyword setting here.
+" Clearing it avoids maintaining keyword characters in multiple places.
+syn iskeyword clear
+
+syn keyword lispDecl jbuild_version library executable executables rule ocamllex ocamlyacc menhir alias install
+
+syn keyword lispKey name public_name synopsis modules libraries wrapped
+syn keyword lispKey preprocess preprocessor_deps optional c_names cxx_names
+syn keyword lispKey install_c_headers modes no_dynlink self_build_stubs_archive
+syn keyword lispKey ppx_runtime_libraries virtual_deps js_of_ocaml link_flags
+syn keyword lispKey javascript_files flags ocamlc_flags ocamlopt_flags pps staged_pps
+syn keyword lispKey library_flags c_flags c_library_flags kind package action
+syn keyword lispKey deps targets locks fallback
+syn keyword lispKey inline_tests tests names
+
+syn keyword lispAtom true false
+
+syn keyword lispFunc cat chdir copy# diff? echo run setenv
+syn keyword lispFunc ignore-stdout ignore-stderr ignore-outputs
+syn keyword lispFunc with-stdout-to with-stderr-to with-outputs-to
+syn keyword lispFunc write-file system bash
+
+syn cluster lispBaseListCluster add=duneVar
+syn match duneVar '\${[@<^]}' containedin=lispSymbol
+syn match duneVar '\${\k\+\(:\k\+\)\?}' containedin=lispSymbol
+
+hi def link duneVar Identifier
+
+let b:current_syntax = "dune"

--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -4,7 +4,7 @@
 " Maintainers:  Markus Mottl      <markus.mottl@gmail.com>
 "               Karl-Heinz Sylla  <Karl-Heinz.Sylla@gmd.de>
 "               Issac Trotts      <ijtrotts@ucdavis.edu>
-" URL:          http://www.ocaml.info/vim/syntax/ocaml.vim
+" URL:          https://github.com/rgrinberg/vim-ocaml
 " Last Change:
 "               2018 Nov 08 - Improved highlighting of operators (Maëlan)
 "               2018 Apr 22 - Improved support for PPX (Andrey Popp)


### PR DESCRIPTION
Follow up to https://github.com/vim/vim/pull/4445
I updated also the `runtime/ftplugin/ocaml.vim` from https://github.com/rgrinberg/vim-ocaml
Also added a [Dune buildsystem](https://dune.build) syntax support, because it became de-facto standard building system in the OCamlverse. So it makes sense to have the support mainstream as well.
On the opposite side, syntaxes like Oasis or OMake are being deprecated and abandoned, so there is no reason to add them whatsoever.

See also https://github.com/rgrinberg/vim-ocaml/issues/33

cc @rgrinberg @mmottl