### PR TITLE
Add Emacs file modes like support for C++ standard library headers

### DIFF
--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -371,6 +371,10 @@ else
   elseif s:line1 =~? '-\*-.*erlang.*-\*-'
     set ft=erlang
 
+  " libcxx and libstdc++ standard library headers like <iostream>
+  elseif s:line1 =~? '-\*-.*C++.*-\*-'
+    set ft=cpp
+
   " CVS diff
   else
     let s:lnum = 1

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -586,6 +586,8 @@ let s:script_checks = {
       \ 'cfengine': [['#!/path/cfengine']],
       \ 'erlang': [['#!/path/escript']],
       \ 'haskell': [['#!/path/haskell']],
+      \ 'cpp': [['// Standard iostream objects -*- C++ -*-'],
+      \         ['// -*- C++ -*-']],
       \ }
 
 func Test_script_detection()


### PR DESCRIPTION
It turns out that Vim currently cannot detect filetypes for standard C++ library headers because of a lack of file extensions, for example <iostream> file
My proposal is to add detection using same method as for Erlang sources included already into scripts.vim

Examples for iostream file from gcc and llvm projects accordingly:
https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/iostream
https://github.com/llvm-mirror/libcxx/blob/master/include/iostream