### PR TITLE
fix no space between highlight name and "xxx" with tiny window

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -9440,6 +9440,7 @@ syn_list_header(
 {
     int	    endcol = 19;
     int	    newline = TRUE;
+    int	    name_col = 0;
 
     if (!did_header)
     {
@@ -9447,6 +9448,7 @@ syn_list_header(
 	if (got_int)
 	    return TRUE;
 	msg_outtrans(HL_TABLE()[id - 1].sg_name);
+	name_col = msg_col;
 	endcol = 15;
     }
     else if (msg_col + outlen + 1 >= Columns)
@@ -9471,6 +9473,8 @@ syn_list_header(
     /* Show "xxx" with the attributes. */
     if (!did_header)
     {
+	if (endcol == Columns - 1 && endcol <= name_col)
+	    msg_putchar(' ');
 	msg_puts_attr("xxx", syn_id2attr(id));
 	msg_putchar(' ');
     }

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -607,3 +607,11 @@ func Test_1_highlight_Normalgroup_exists()
     call assert_match('hi Normal\s*clear', hlNormal)
   endif
 endfunc
+
+function Test_no_space_before_xxx()
+  let l:org_columns = &columns
+  set columns=17
+  let l:hi_StatusLineTermNC = join(split(execute('hi StatusLineTermNC')))
+  call assert_match('StatusLineTermNC xxx', l:hi_StatusLineTermNC)
+  let &columns = l:org_columns
+endfunction


### PR DESCRIPTION
**Describe the bug**
The result of `:hi` command has no space between highlight name and "xxx" if the length of the highlight name >= window width - 1.
(I'm not sure if we call this minor issue "bug", though.)

**To Reproduce**
Detailed steps to reproduce the behavior:
1. Set terminal width to 17 (`:echo &columns` should be 17).
1. Run `vim -Nu NONE`
1. `:hi StatusLineTermNC` or `:call setline(1, join(split(execute('hi StatusLineTermNC'))))`
1. It looks like "StatusLineTermNCxxx term=reverse ctermfg=0 ctermbg=2 guifg=bg guibg=LightGreen".

**Expected behavior**
Expected result:  "StatusLineTermNC xxx term=reverse ctermfg=0 ctermbg=2 guifg=bg guibg=LightGreen"

**Cause**
`endcol` is set to the end of highlight name (or lesser one) by the following condition. As a result, no space between the highlight name and "xxx".
```
syn_list_header(
    int     did_header,         /* did header already */
    int     outlen,             /* length of string that comes */
    int     id)                 /* highlight group id */
{
    ...
    if (msg_col  = endcol)      /* output at least one space */
        endcol = msg_col + 1;
    if (Columns <= endcol)      /* avoid hang for tiny window */
        endcol = Columns - 1;
```

**How to fix**
Put a space for header if needed.

**Screenshots**
![2019-06-28](https://user-images.githubusercontent.com/20806102/60317721-40f89100-99ab-11e9-8aea-3cdaafd998ce.png)
![2019-06-28 (1)](https://user-images.githubusercontent.com/20806102/60317737-4ce45300-99ab-11e9-87e1-36999e297e00.png)

**Environment (please complete the following information):**
 - Vim version: v8.1.1601
 - OS: Ubuntu 18.04
 - Terminal: mintty

**Additional context**
I found this issue when I was writing and debugging the following my plugin.
https://github.com/mnishz/colorscheme-preview.vim/blob/92f2627a6da5c6a4c8b3631c3b331888f959c55a/autoload/colorscheme_preview.vim#L80-L83