### PR TITLE
Simplify the sign_place() and sign_unplace() functions

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2639,7 +2639,7 @@ shellescape({string} [, {special}])
 				String	escape {string} for use as shell
 					command argument
 shiftwidth([{col}])		Number	effective value of 'shiftwidth'
-sign_define({name} [, {dict}])	Number	define or update a sign
+sign_define({list})		Number	define or update signs
 sign_getdefined([{name}])	List	get a list of defined signs
 sign_getplaced([{expr} [, {dict}]])
 				List	get a list of placed signs
@@ -8573,16 +8573,15 @@ shiftwidth([{col}])						*shiftwidth()*
 		'vartabstop' feature. If the 'vartabstop' setting is enabled and
 		no {col} argument is given, column 1 will be assumed.
 
-sign_define({name} [, {dict}])				*sign_define()*
-		Define a new sign named {name} or modify the attributes of an
-		existing sign.  This is similar to the |:sign-define| command.
-
-		Prefix {name} with a unique text to avoid name collisions.
-		There is no {group} like with placing signs.
-
-		The {name} can be a String or a Number.  The optional {dict}
-		argument specifies the sign attributes.  The following values
-		are supported:
+sign_define({list})					*sign_define()*
+		Define or modify one or more signs.  This is similar to the
+		|:sign-define| command. The {list} argument specifies the List
+		of signs to define. Each list item is a dict with the
+		following optional sign attributes:
+		   name 	sign name. This can be a String or a Number.
+				Prefix {name} with a unique text to avoid name
+				collisions.  There is no {group} like with
+				placing signs.
 		   icon		full path to the bitmap file for the sign.
 		   linehl	highlight group used for the whole line the
 				sign is placed in.
@@ -8591,13 +8590,15 @@ sign_define({name} [, {dict}])				*sign_define()*
 		   texthl	highlight group used for the text item
 
 		If the sign named {name} already exists, then the attributes
-		of the sign are updated.
+		of the existing sign are updated.
 
-		Returns 0 on success and -1 on failure.
+		Returns a List where an entry is set to 0 if the corresponding
+		sign was successfully defined or -1 on failure.
 
 		Examples: >
-			call sign_define("mySign", {"text" : "=>", "texthl" :
-					\ "Error", "linehl" : "Search"})
+			call sign_define([{'name' : "mySign", "text" : "=>",
+					\ "texthl" : "Error",
+					\ "linehl" : "Search"})
 <
 sign_getdefined([{name}])				*sign_getdefined()*
 		Get a list of defined signs and their attributes.
@@ -8798,7 +8799,8 @@ sign_unplace({list})					*sign_unplace()*
 			id	sign identifier. If not supplied, then all
 				the signs in the specified group are removed.
 
-		Returns 0 on success and -1 on failure.
+		Returns a List where an entry is set to 0 if the corresponding
+		sign was successfully removed or -1 on failure.
 
 		Examples: >
 			" Remove sign 10 from buffer a.vim

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2645,11 +2645,9 @@ sign_getplaced([{expr} [, {dict}]])
 				List	get a list of placed signs
 sign_jump({id}, {group}, {expr})
 				Number	jump to a sign
-sign_place({id}, {group}, {name}, {expr} [, {dict}])
-				Number	place a sign
+sign_place({list})		Number	place one or more signs
 sign_undefine([{name}])		Number	undefine a sign
-sign_unplace({group} [, {dict}])
-				Number	unplace a sign
+sign_unplace({list})		Number	unplace one or more signs
 simplify({filename})		String	simplify filename as much as possible
 sin({expr})			Float	sine of {expr}
 sinh({expr})			Float	hyperbolic sine of {expr}
@@ -8649,13 +8647,8 @@ sign_getplaced([{expr} [, {dict}]])			*sign_getplaced()*
 		See |sign-group|.
 
 		Each list item in the returned value is a dictionary with the
-		following entries:
-			bufnr	number of the buffer with the sign
-			signs	list of signs placed in {bufnr}. Each list
-				item is a dictionary with the below listed
-				entries
-
-		The dictionary for each sign contains the following entries:
+		following sign attributes:
+			buffer	buffer number where the sign is placed.
 			group	sign group. Set to '' for the global group.
 			id	identifier of the sign
 			lnum	line number where the sign is placed
@@ -8704,54 +8697,74 @@ sign_jump({id}, {group}, {expr})
 			" Jump to sign 10 in the current buffer
 			call sign_jump(10, '', '')
 <
-							*sign_place()*
-sign_place({id}, {group}, {name}, {expr} [, {dict}])
-		Place the sign defined as {name} at line {lnum} in file {expr}
-		and assign {id} and {group} to sign.  This is similar to the
-		|:sign-place| command.
-
-		If the sign identifier {id} is zero, then a new identifier is
-		allocated.  Otherwise the specified number is used. {group} is
-		the sign group name. To use the global sign group, use an
-		empty string.  {group} functions as a namespace for {id}, thus
-		two groups can use the same IDs. Refer to |sign-identifier|
-		and |sign-group| for more information.
-
-		{name} refers to a defined sign.
-		{expr} refers to a buffer name or number. For the accepted
-		values, see |bufname()|.
-
-		The optional {dict} argument supports the following entries:
+sign_place({list})					*sign_place()*
+		Place one or more signs.  This is similar to the |:sign-place|
+		command.  The {list} argument specifies the List of signs to
+		place. Each list item is a dict with the following optional
+		sign attributes:
+			buffer		buffer name or number. For the
+					accepted values, see |bufname()|. If
+					not specified, then the current buffer
+					is used.
+			group		sign group. {group} functions as a
+					namespace for {id}, thus two groups
+					can use the same IDs. If not specified
+					or set to an empty string, then the
+					global group is used.   See
+					|sign-group| for more information.
+			id		sign identifier. If not specified or
+					zero, then a new unique identifier is
+					allocated. Otherwise the specified
+					number is used. See |sign-identifier|
+					for more information.
 			lnum		line number in the buffer {expr} where
 					the sign is to be placed. For the
-					accepted values, see |line()|.
-			priority	priority of the sign. See
-					|sign-priority| for more information.
+					accepted values, see |line()|. If not
+					specified, then the current line
+					number is used.
+			name		name of the sign to place. See
+					|sign_define()| for more information.
+			priority	priority of the sign. When multiple
+					signs are placed on a line, the sign
+					with the highest priority is used. If
+					not specified, the default value of 10
+					is used. See |sign-priority| for more
+					information.
 
-		If the optional {dict} is not specified, then it modifies the
-		placed sign {id} in group {group} to use the defined sign
-		{name}.
+		If {id} refers to an existing sign, then the existing sign is
+		modified to use the specified {name} and/or {priority}.
 
-		Returns the sign identifier on success and -1 on failure.
+		Returns a List of sign identifiers. If failed to place a
+		sign, then the corresponding list item is set to 0.
 
 		Examples: >
 			" Place a sign named sign1 with id 5 at line 20 in
-			" buffer json.c
-			call sign_place(5, '', 'sign1', 'json.c',
-							\ {'lnum' : 20})
+			" buffer a.c
+			call sign_place([{'id' : 5, 'group' : '',
+					\ 'name' : 'sign1', 'buffer' : 'a.c',
+					\ 'lnum' : 20}])
+
+			" Place sign s1 in buffer a.c at line 20 and 30
+			" with auto-generated identifiers
+			let [n1, n2] = sign_place([{'name' : 's1',
+					\ 'buffer' : 'a.c', 'lnum' : 20},
+					\ {'name' : 's1', 'buffer' : 'a.c',
+					\ 'lnum' : 30}])
 
 			" Updates sign 5 in buffer json.c to use sign2
-			call sign_place(5, '', 'sign2', 'json.c')
+			call sign_place([{'id' : 5, 'name' : 'sign2',
+						\ 'buffer' : 'json.c'}])
 
 			" Place a sign named sign3 at line 30 in
 			" buffer json.c with a new identifier
-			let id = sign_place(0, '', 'sign3', 'json.c',
-							\ {'lnum' : 30})
+			let id = sign_place([{'name' : 'sign3',
+					\ 'buffer' : 'json.c', 'lnum' : 30}])
 
 			" Place a sign named sign4 with id 10 in group 'g3'
-			" at line 40 in buffer json.c with priority 90
-			call sign_place(10, 'g3', 'sign4', 'json.c',
-					\ {'lnum' : 40, 'priority' : 90})
+			" at line 40 in buffer a.c with priority 90
+			call sign_place([{'id' : 10, 'group' : 'g3',
+					\ 'name' : 'sign4', 'buffer' : 'a.c',
+					\ 'lnum' : 40, 'priority' : 90}])
 <
 sign_undefine([{name}])					*sign_undefine()*
 		Deletes a previously defined sign {name}. This is similar to
@@ -8767,47 +8780,56 @@ sign_undefine([{name}])					*sign_undefine()*
 			" Delete all the signs
 			call sign_undefine()
 <
-sign_unplace({group} [, {dict}])			*sign_unplace()*
-		Remove a previously placed sign in one or more buffers.  This
+sign_unplace({list})					*sign_unplace()*
+		Remove previously placed signs from one or more buffers.  This
 		is similar to the |:sign-unplace| command.
 
-		{group} is the sign group name. To use the global sign group,
-		use an empty string.  If {group} is set to '*', then all the
-		groups including the global group are used.
-		The signs in {group} are selected based on the entries in
-		{dict}.  The following optional entries in {dict} are
-		supported:
-			buffer	buffer name or number. See |bufname()|.
-			id	sign identifier
-		If {dict} is not supplied, then all the signs in {group} are
-		removed.
+		The {list} argument specifies the List of signs to remove.
+		Each list item is a dict with the following optional sign
+		attributes:
+			buffer	buffer name or number. For the accepted
+				values, see |bufname()|. If not supplied, then
+				the specified sign is removed from all the
+				buffers.
+			group	sign group name. If not supplied or set to an
+				empty string, then the global sign group is
+				used. If set to '*', then all the groups
+				including the global group are used.
+			id	sign identifier. If not supplied, then all
+				the signs in the specified group are removed.
 
 		Returns 0 on success and -1 on failure.
 
 		Examples: >
 			" Remove sign 10 from buffer a.vim
-			call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
+			call sign_unplace([{'id' : 10, 'buffer' : "a.vim"}])
+
+			" Remove sign 10 from buffer a.vim and sign 20 from
+			" buffer b.vim
+			call sign_unplace([{'id' : 10, 'buffer' : "a.vim"},
+					\ {'id' : 20, 'buffer' : 'b.vim'}])
 
 			" Remove sign 20 in group 'g1' from buffer 3
-			call sign_unplace('g1', {'buffer' : 3, 'id' : 20})
+			call sign_unplace([{'id' : 20, 'group' : 'g1',
+							\ 'buffer' : 3}])
 
 			" Remove all the signs in group 'g2' from buffer 10
-			call sign_unplace('g2', {'buffer' : 10})
+			call sign_unplace([{'group' : 'g2', 'buffer' : 10}])
 
 			" Remove sign 30 in group 'g3' from all the buffers
-			call sign_unplace('g3', {'id' : 30})
+			call sign_unplace([{'id' : 30, 'group' : 'g3'}])
 
 			" Remove all the signs placed in buffer 5
-			call sign_unplace('*', {'buffer' : 5})
+			call sign_unplace([{'group' : '*', 'buffer' : 5}])
 
 			" Remove the signs in group 'g4' from all the buffers
-			call sign_unplace('g4')
+			call sign_unplace([{'group' : 'g4'}])
 
 			" Remove sign 40 from all the buffers
-			call sign_unplace('*', {'id' : 40})
+			call sign_unplace([{'id' : 40, 'group' : '*'}])
 
 			" Remove all the placed signs from all the buffers
-			call sign_unplace('*')
+			call sign_unplace([{'group' : '*'}])
 <
 simplify({filename})					*simplify()*
 		Simplify the file name as much as possible without changing

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2641,8 +2641,7 @@ shellescape({string} [, {special}])
 shiftwidth([{col}])		Number	effective value of 'shiftwidth'
 sign_define({list})		Number	define or update signs
 sign_getdefined([{name}])	List	get a list of defined signs
-sign_getplaced([{expr} [, {dict}]])
-				List	get a list of placed signs
+sign_getplaced([, {dict}])	List	get a list of placed signs
 sign_jump({id}, {group}, {expr})
 				Number	jump to a sign
 sign_place({list})		Number	place one or more signs
@@ -8628,24 +8627,25 @@ sign_getdefined([{name}])				*sign_getdefined()*
 			" Get the attribute of the sign named mySign
 			echo sign_getdefined("mySign")
 <
-sign_getplaced([{expr} [, {dict}]])			*sign_getplaced()*
+sign_getplaced([{dict}])				*sign_getplaced()*
 		Return a list of signs placed in a buffer or all the buffers.
 		This is similar to the |:sign-place-list| command.
 
-		If the optional buffer name {expr} is specified, then only the
-		list of signs placed in that buffer is returned.  For the use
-		of {expr}, see |bufname()|. The optional {dict} can contain
-		the following entries:
-		   group	select only signs in this group
+		The optional {dict} argument specifies the selection criteria
+		for the signs. The following items are supported:
+		   buffer	select only signs from this buffer.  For the
+				accepted values, see |bufname()|.  If not
+				specified, then the current buffer is used.
+		   group	select only signs in this group. If {group} is
+				'*', then signs in all the groups including
+				the global group are returned. If {group} is
+				not supplied or is an empty string, then only
+				signs in the global group are returned.
 		   id		select sign with this identifier
 		   lnum		select signs placed in this line. For the use
 				of {lnum}, see |line()|.
-		If {group} is '*', then signs in all the groups including the
-		global group are returned. If {group} is not supplied or is an
-		empty string, then only signs in the global group are
-		returned.  If no arguments are supplied, then signs in the
-		global group placed in all the buffers are returned.
-		See |sign-group|.
+		If no arguments are supplied, then signs in the global group
+		placed in all the buffers are returned.  See |sign-group|.
 
 		Each list item in the returned value is a dictionary with the
 		following sign attributes:
@@ -8665,19 +8665,20 @@ sign_getplaced([{expr} [, {dict}]])			*sign_getplaced()*
 		Examples: >
 			" Get a List of signs placed in eval.c in the
 			" global group
-			echo sign_getplaced("eval.c")
+			echo sign_getplaced({'buffer' : "eval.c"})
 
 			" Get a List of signs in group 'g1' placed in eval.c
-			echo sign_getplaced("eval.c", {'group' : 'g1'})
+			echo sign_getplaced({'buffer' : "eval.c",
+						\ 'group' : 'g1'})
 
 			" Get a List of signs placed at line 10 in eval.c
-			echo sign_getplaced("eval.c", {'lnum' : 10})
+			echo sign_getplaced({'buffer' : "eval.c", 'lnum' : 10})
 
 			" Get sign with identifier 10 placed in a.py
-			echo sign_getplaced("a.py", {'id' : 10})
+			echo sign_getplaced({'buffer' : "a.py", 'id' : 10})
 
 			" Get sign with id 20 in group 'g1' placed in a.py
-			echo sign_getplaced("a.py", {'group' : 'g1',
+			echo sign_getplaced({'buffer' : "a.py", 'group' : 'g1',
 							\  'id' : 20})
 
 			" Get a List of all the placed signs

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -25,8 +25,6 @@ typedef enum {
 	aid_sign_getplaced,
 	aid_sign_define_by_name,
 	aid_sign_getlist,
-	aid_sign_getplaced_dict,
-	aid_sign_getplaced_list,
 	aid_insert_sign,
 	aid_sign_getinfo,
 	aid_last

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -888,9 +888,9 @@ static struct fst
     {"sign_getdefined",	0, 1, f_sign_getdefined},
     {"sign_getplaced",	0, 2, f_sign_getplaced},
     {"sign_jump",	3, 3, f_sign_jump},
-    {"sign_place",	4, 5, f_sign_place},
+    {"sign_place",	1, 1, f_sign_place},
     {"sign_undefine",	0, 1, f_sign_undefine},
-    {"sign_unplace",	1, 2, f_sign_unplace},
+    {"sign_unplace",	1, 1, f_sign_unplace},
 #endif
     {"simplify",	1, 1, f_simplify},
 #ifdef FEAT_FLOAT

--- a/src/sign.c
+++ b/src/sign.c
@@ -2156,42 +2156,45 @@ f_sign_getplaced(typval_T *argvars, typval_T *rettv)
 
     if (argvars[0].v_type != VAR_UNKNOWN)
     {
-	// get signs placed in the specified buffer
-	buf = get_buf_arg(&argvars[0]);
-	if (buf == NULL)
-	    return;
-
-	if (argvars[1].v_type != VAR_UNKNOWN)
+	if (argvars[0].v_type != VAR_DICT)
 	{
-	    if (argvars[1].v_type != VAR_DICT ||
-				((dict = argvars[1].vval.v_dict) == NULL))
-	    {
-		emsg(_(e_dictreq));
+	    emsg(_(e_dictreq));
+	    return;
+	}
+	dict = argvars[0].vval.v_dict;
+
+	// get signs placed in the specified buffer
+	buf = curbuf;
+	di = dict_find(dict, (char_u *)"buffer", -1);
+	if (di != NULL)
+	{
+	    buf = get_buf_arg(&di->di_tv);
+	    if (buf == NULL)
 		return;
-	    }
-	    if ((di = dict_find(dict, (char_u *)"lnum", -1)) != NULL)
-	    {
-		// get signs placed at this line
-		(void)tv_get_number_chk(&di->di_tv, &notanum);
-		if (notanum)
-		    return;
-		lnum = tv_get_lnum(&di->di_tv);
-	    }
-	    if ((di = dict_find(dict, (char_u *)"id", -1)) != NULL)
-	    {
-		// get sign placed with this identifier
-		sign_id = (int)tv_get_number_chk(&di->di_tv, &notanum);
-		if (notanum)
-		    return;
-	    }
-	    if ((di = dict_find(dict, (char_u *)"group", -1)) != NULL)
-	    {
-		group = tv_get_string_chk(&di->di_tv);
-		if (group == NULL)
-		    return;
-		if (*group == '\0')	// empty string means global group
-		    group = NULL;
-	    }
+	}
+
+	if ((di = dict_find(dict, (char_u *)"lnum", -1)) != NULL)
+	{
+	    // get signs placed at this line
+	    (void)tv_get_number_chk(&di->di_tv, &notanum);
+	    if (notanum)
+		return;
+	    lnum = tv_get_lnum(&di->di_tv);
+	}
+	if ((di = dict_find(dict, (char_u *)"id", -1)) != NULL)
+	{
+	    // get sign placed with this identifier
+	    sign_id = (int)tv_get_number_chk(&di->di_tv, &notanum);
+	    if (notanum)
+		return;
+	}
+	if ((di = dict_find(dict, (char_u *)"group", -1)) != NULL)
+	{
+	    group = tv_get_string_chk(&di->di_tv);
+	    if (group == NULL)
+		return;
+	    if (*group == '\0')	// empty string means global group
+		group = NULL;
 	}
     }
 
@@ -2358,7 +2361,7 @@ f_sign_place(typval_T *argvars, typval_T *rettv)
 
     if (argvars[0].v_type != VAR_LIST)
     {
-	emsg(_(e_invarg));
+	emsg(_(e_listreq));
 	return;
     }
 
@@ -2474,7 +2477,7 @@ f_sign_unplace(typval_T *argvars, typval_T *rettv)
 
     if (argvars[0].v_type != VAR_LIST)
     {
-	emsg(_(e_invarg));
+	emsg(_(e_listreq));
 	return;
     }
 

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -430,13 +430,14 @@ func Test_sign_funcs()
 	      \ 'name' : 'sign1', 'buffer' : 'Xsign', 'lnum' : 20}]))
   let bnr = bufnr('')
   call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
-	      \ 'name' : 'sign1', 'priority' : 10}], sign_getplaced('Xsign'))
+	      \ 'name' : 'sign1', 'priority' : 10}],
+	      \ sign_getplaced({'buffer' : 'Xsign'}))
   call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
 	      \ 'name' : 'sign1', 'priority' : 10}],
-	      \ sign_getplaced('%', {'lnum' : 20}))
+	      \ sign_getplaced({'buffer' : '%', 'lnum' : 20}))
   call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
 	      \ 'name' : 'sign1', 'priority' : 10}],
-	      \ sign_getplaced('', {'id' : 10}))
+	      \ sign_getplaced({'buffer' : '', 'id' : 10}))
 
   " Tests for invalid arguments to sign_place()
   let attr = {"id" : [], "name" : "mySign", "buffer" : 1}
@@ -474,18 +475,19 @@ func Test_sign_funcs()
   " Tests for sign_getplaced()
   let bnr = bufnr('')
   call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
-	      \ 'name' : 'sign1', 'priority' : 10}], sign_getplaced(bnr))
+	      \ 'name' : 'sign1', 'priority' : 10}],
+	      \ sign_getplaced({'buffer' : bnr}))
   call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
 	      \ 'name' : 'sign1', 'priority' : 10}], sign_getplaced())
-  call assert_fails("call sign_getplaced('dummy.sign')", 'E158:')
-  call assert_fails('call sign_getplaced("&")', 'E158:')
-  call assert_fails('call sign_getplaced(-1)', 'E158:')
-  call assert_fails('call sign_getplaced("Xsign", [])', 'E715:')
-  call assert_equal([], sign_getplaced('Xsign', {'lnum' : 1000000}))
-  call assert_fails("call sign_getplaced('Xsign', {'lnum' : []})",
+  call assert_fails("call sign_getplaced({'buffer' : 'dummy.sign'})", 'E158:')
+  call assert_fails('call sign_getplaced({"buffer" : "&"})', 'E158:')
+  call assert_fails('call sign_getplaced({"buffer" : -1})', 'E158:')
+  call assert_fails('call sign_getplaced([])', 'E715:')
+  call assert_equal([], sign_getplaced({'buffer' : 'Xsign', 'lnum' : 1000000}))
+  call assert_fails("call sign_getplaced({'buffer' : 'Xsign', 'lnum' : []})",
 	      \ 'E745:')
-  call assert_equal([], sign_getplaced('Xsign', {'id' : 44}))
-  call assert_fails("call sign_getplaced('Xsign', {'id' : []})",
+  call assert_equal([], sign_getplaced({'buffer' : 'Xsign', 'id' : 44}))
+  call assert_fails("call sign_getplaced({'buffer' : 'Xsign', 'id' : []})",
 	      \ 'E745:')
 
   " Tests for sign_unplace()
@@ -503,21 +505,21 @@ func Test_sign_funcs()
 	      \ 'buffer' : 200}])", 'E158:')
   call assert_fails("call sign_unplace([{'group' : 'g1', 'id' : 'mySign'}])",
 	      \ 'E474:')
-  call assert_fails("call sign_unplace({})", 'E474:')
+  call assert_fails("call sign_unplace({})", 'E714:')
   " Unplace signs in the current buffer
   call assert_equal([0, 0], sign_unplace([{'id' : 10}, {'id' : 20}]))
-  call assert_equal([], sign_getplaced('Xsign'))
+  call assert_equal([], sign_getplaced({'buffer' : 'Xsign'}))
   " Unplace all signs in the global group
   call sign_place([{'id' : 10, 'name' : 'sign1', 'lnum' : 20},
               \ {'id' : 10, 'name' : 'sign1', 'group' : 'g1', 'lnum' : 21},
               \ {'id' : 10, 'name' : 'sign1', 'group' : 'g2', 'lnum' : 22},
               \ {'id' : 20, 'name' : 'sign1', 'lnum' : 23}])
   call sign_unplace([{}])
-  let l = sign_getplaced(bnr, {'group' : '*'})
+  let l = sign_getplaced({'buffer' : bnr, 'group' : '*'})
   call assert_equal(2, len(l))
   call assert_equal(['g1', 'g2'], [l[0].group, l[1].group])
   call sign_unplace([{'group' : '*'}])
-  call assert_equal([], sign_getplaced(bnr, {'group' : '*'}))
+  call assert_equal([], sign_getplaced({'buffer' : bnr, 'group' : '*'}))
 
   " Tests for sign_undefine()
   call assert_equal(0, sign_undefine("sign1"))
@@ -561,18 +563,18 @@ func Test_sign_group()
 	      \ 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 30}]))
 
   " Test for sign_getplaced() with group
-  let s = sign_getplaced('Xsign')
+  let s = sign_getplaced({'buffer' : 'Xsign'})
   call assert_equal(1, len(s))
   call assert_equal(s[0].group, '')
-  let s = sign_getplaced(bnum, {'group' : ''})
+  let s = sign_getplaced({'group' : ''})
   call assert_equal([{'id' : 5, 'group' : '', 'buffer' : bnum, 'name' : 'sign1',
 	      \ 'lnum' : 10, 'priority' : 10}], s)
   call assert_equal(1, len(s))
-  let s = sign_getplaced(bnum, {'group' : 'g2'})
+  let s = sign_getplaced({'group' : 'g2'})
   call assert_equal('g2', s[0].group)
-  let s = sign_getplaced(bnum, {'group' : 'g3'})
+  let s = sign_getplaced({'group' : 'g3'})
   call assert_equal([], s)
-  let s = sign_getplaced(bnum, {'group' : '*'})
+  let s = sign_getplaced({'group' : '*'})
   call assert_equal([
 	      \ {'id' : 5, 'group' : '', 'buffer' : bnum, 'name' : 'sign1',
 	      \ 'lnum' : 10, 'priority' : 10},
@@ -582,15 +584,15 @@ func Test_sign_group()
 	      \ 'lnum' : 30, 'priority' : 10}], s)
 
   " Test for sign_getplaced() with id
-  let s = sign_getplaced(bnum, {'id' : 5})
+  let s = sign_getplaced({'buffer' : bnum, 'id' : 5})
   call assert_equal([
 	      \ {'id' : 5, 'group' : '', 'buffer' : bnum, 'name' : 'sign1',
 	      \ 'lnum' : 10, 'priority' : 10}], s)
-  let s = sign_getplaced(bnum, {'id' : 5, 'group' : 'g2'})
+  let s = sign_getplaced({'buffer' : bnum, 'id' : 5, 'group' : 'g2'})
   call assert_equal(
 	      \ [{'id' : 5, 'name' : 'sign1', 'group' : 'g2', 'buffer' : bnum,
 	      \ 'lnum' : 30, 'priority' : 10}], s)
-  let s = sign_getplaced(bnum, {'id' : 5, 'group' : '*'})
+  let s = sign_getplaced({'buffer' : bnum, 'id' : 5, 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 5, 'group' : '', 'buffer' : bnum, 'name' : 'sign1',
 	      \ 'lnum' : 10, 'priority' : 10},
@@ -598,30 +600,30 @@ func Test_sign_group()
 	      \ 'lnum' : 20, 'priority' : 10},
 	      \ {'id' : 5, 'group' : 'g2', 'buffer' : bnum, 'name' : 'sign1',
 	      \ 'lnum' : 30, 'priority' : 10}], s)
-  let s = sign_getplaced(bnum, {'id' : 5, 'group' : 'g3'})
+  let s = sign_getplaced({'buffer' : bnum, 'id' : 5, 'group' : 'g3'})
   call assert_equal([], s)
 
   " Test for sign_getplaced() with lnum
-  let s = sign_getplaced(bnum, {'lnum' : 20})
+  let s = sign_getplaced({'buffer' : bnum, 'lnum' : 20})
   call assert_equal([], s)
-  let s = sign_getplaced(bnum, {'lnum' : 20, 'group' : 'g1'})
+  let s = sign_getplaced({'buffer' : bnum, 'lnum' : 20, 'group' : 'g1'})
   call assert_equal([
 	      \ {'id' : 5, 'group' : 'g1', 'name' : 'sign1', 'buffer' : bnum,
 	      \ 'lnum' : 20, 'priority' : 10}], s)
-  let s = sign_getplaced(bnum, {'lnum' : 30, 'group' : '*'})
+  let s = sign_getplaced({'buffer' : bnum, 'lnum' : 30, 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 5, 'group' : 'g2', 'name' : 'sign1', 'buffer' : bnum,
 	      \ 'lnum' : 30, 'priority' : 10}], s)
-  let s = sign_getplaced(bnum, {'lnum' : 40, 'group' : '*'})
+  let s = sign_getplaced({'buffer' : bnum, 'lnum' : 40, 'group' : '*'})
   call assert_equal([], s)
 
   " Error case
-  call assert_fails("call sign_getplaced(bnum, {'group' : []})",
+  call assert_fails("call sign_getplaced({'buffer' : bnum, 'group' : []})",
 	      \ 'E730:')
 
   " Clear the sign in global group
   call sign_unplace([{'id' : 5, 'buffer' : bnum}])
-  let s = sign_getplaced(bnum, {'group' : '*'})
+  let s = sign_getplaced({'buffer' : bnum, 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 5, 'group' : 'g1', 'buffer' : bnum, 'name' : 'sign1',
 	      \ 'lnum' : 20, 'priority' : 10},
@@ -630,14 +632,14 @@ func Test_sign_group()
 
   " Clear the sign in one of the groups
   call sign_unplace([{'group' : 'g1', 'buffer' : 'Xsign'}])
-  let s = sign_getplaced(bnum, {'group' : '*'})
+  let s = sign_getplaced({'buffer' : bnum, 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 5, 'group' : 'g2', 'buffer' : bnum, 'name' : 'sign1',
 	      \ 'lnum' : 30, 'priority' : 10}], s)
 
   " Clear all the signs from the buffer
   call sign_unplace([{'group' : '*', 'buffer' : bnum}])
-  call assert_equal([], sign_getplaced(bnum, {'group' : '*'}))
+  call assert_equal([], sign_getplaced({'buffer' : bnum, 'group' : '*'}))
 
   " Clear sign across groups using an identifier
   call sign_place([{'id' : 25, 'group' : '', 'name' : 'sign1',
@@ -647,10 +649,10 @@ func Test_sign_group()
 	      \ {'id' : 25, 'group' : 'g2', 'name' : 'sign1',
 	      \ 'buffer' : bnum, 'lnum' : 12}])
   call assert_equal([0], sign_unplace([{'group' : '*', 'id' : 25}]))
-  call assert_equal([], sign_getplaced(bnum, {'group' : '*'}))
+  call assert_equal([], sign_getplaced({'buffer' : bnum, 'group' : '*'}))
 
   " Error case
-  call assert_fails("call sign_unplace(20)", 'E474:')
+  call assert_fails("call sign_unplace(20)", 'E714:')
 
   " Place a sign in the global group and try to delete it using a group
   call assert_equal([5], sign_place([{'id' : 5, 'group' : '', 'name' : 'sign1',
@@ -672,15 +674,15 @@ func Test_sign_group()
   call assert_equal([6], sign_place([{'id' : 6, 'group' : 'g2',
 	      \ 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 11}]))
   call assert_equal([0], sign_unplace([{'group' : 'g1'}]))
-  let s = sign_getplaced(bnum, {'group' : 'g1'})
+  let s = sign_getplaced({'buffer' : bnum, 'group' : 'g1'})
   call assert_equal([], s)
-  let s = sign_getplaced(bnum)
+  let s = sign_getplaced({'buffer' : bnum})
   call assert_equal(2, len(s))
-  let s = sign_getplaced(bnum, {'group' : 'g2'})
+  let s = sign_getplaced({'buffer' : bnum, 'group' : 'g2'})
   call assert_equal('g2', s[0].group)
   call assert_equal([0], sign_unplace([{'id' : 5}]))
   call assert_equal([0], sign_unplace([{'id' : 6}]))
-  let s = sign_getplaced(bnum, {'group' : 'g2'})
+  let s = sign_getplaced({'buffer' : bnum, 'group' : 'g2'})
   call assert_equal('g2', s[0].group)
   call assert_equal([0], sign_unplace([{'buffer' : bnum}]))
 
@@ -873,11 +875,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3 || val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6 || val.group != ''}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace {id} group={group} file={fname}
   call Place_signs_for_test()
@@ -886,11 +888,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 5 || val.group != 'g2'}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace {id} group=* file={fname}
   call Place_signs_for_test()
@@ -899,11 +901,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace * file={fname}
   call Place_signs_for_test()
@@ -911,8 +913,9 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
-  call assert_equal(signs2, sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
+  call assert_equal(signs2,
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace * group={group} file={fname}
   call Place_signs_for_test()
@@ -921,17 +924,18 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.group != 'g2'}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace * group=* file={fname}
   call Place_signs_for_test()
   sign unplace * group=* file=Xsign2
-  call assert_equal(signs1, sign_getplaced('Xsign1', {'group' : '*'}))
-  call assert_equal([], sign_getplaced('Xsign2', {'group' : '*'}))
+  call assert_equal(signs1,
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
+  call assert_equal([], sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace {id} buffer={nr}
   call Place_signs_for_test()
@@ -940,11 +944,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3 || val.group != ''}),
-	      \ sign_getplaced(bnum1, {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : bnum1, 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6 || val.group != ''}),
-	      \ sign_getplaced(bnum2, {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : bnum2, 'group' : '*'}))
 
   " Test for :sign unplace {id} group={group} buffer={nr}
   call Place_signs_for_test()
@@ -953,11 +957,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != 'g1'}),
-	      \ sign_getplaced(bnum1, {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : bnum1, 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 5 || val.group != 'g2'}),
-	      \ sign_getplaced(bnum2, {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : bnum2, 'group' : '*'}))
 
   " Test for :sign unplace {id} group=* buffer={nr}
   call Place_signs_for_test()
@@ -966,11 +970,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3}),
-	      \ sign_getplaced(bnum1, {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : bnum1, 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6}),
-	      \ sign_getplaced(bnum2, {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : bnum2, 'group' : '*'}))
 
   " Test for :sign unplace * buffer={nr}
   call Place_signs_for_test()
@@ -978,8 +982,8 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced(bnum1, {'group' : '*'}))
-  call assert_equal(signs2, sign_getplaced(bnum2, {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : bnum1, 'group' : '*'}))
+  call assert_equal(signs2, sign_getplaced({'buffer' : bnum2, 'group' : '*'}))
 
   " Test for :sign unplace * group={group} buffer={nr}
   call Place_signs_for_test()
@@ -988,17 +992,17 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != 'g1'}),
-	      \ sign_getplaced(bnum1, {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : bnum1, 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.group != 'g2'}),
-	      \ sign_getplaced(bnum2, {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : bnum2, 'group' : '*'}))
 
   " Test for :sign unplace * group=* buffer={nr}
   call Place_signs_for_test()
   exe 'sign unplace * group=* buffer=' . bnum2
-  call assert_equal(signs1, sign_getplaced(bnum1, {'group' : '*'}))
-  call assert_equal([], sign_getplaced(bnum2, {'group' : '*'}))
+  call assert_equal(signs1, sign_getplaced({'buffer' : bnum1, 'group' : '*'}))
+  call assert_equal([], sign_getplaced({'buffer' : bnum2, 'group' : '*'}))
 
   " Test for :sign unplace {id}
   call Place_signs_for_test()
@@ -1007,11 +1011,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6 || val.group != ''}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace {id} group={group}
   call Place_signs_for_test()
@@ -1020,11 +1024,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6 || val.group != 'g2'}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace {id} group=*
   call Place_signs_for_test()
@@ -1033,11 +1037,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 5}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace *
   call Place_signs_for_test()
@@ -1045,11 +1049,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace * group={group}
   call Place_signs_for_test()
@@ -1057,25 +1061,27 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.group != 'g1'}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Test for :sign unplace * group=*
   call Place_signs_for_test()
   sign unplace * group=*
-  call assert_equal([], sign_getplaced('Xsign1', {'group' : '*'}))
-  call assert_equal([], sign_getplaced('Xsign2', {'group' : '*'}))
+  call assert_equal([], sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
+  call assert_equal([], sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Negative test cases
   call Place_signs_for_test()
   sign unplace 3 group=xy file=Xsign1
   sign unplace * group=xy file=Xsign1
   silent! sign unplace * group=* file=FileNotPresent
-  call assert_equal(signs1, sign_getplaced('Xsign1', {'group' : '*'}))
-  call assert_equal(signs2, sign_getplaced('Xsign2', {'group' : '*'}))
+  call assert_equal(signs1,
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
+  call assert_equal(signs2,
+	      \ sign_getplaced({'buffer' : 'Xsign2', 'group' : '*'}))
 
   " Tests for removing sign at the current cursor position
 
@@ -1101,13 +1107,13 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   " Should remove the second sign in the global group
   sign unplace
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
 
   " Test for ':sign unplace group={group}'
   call Place_signs_at_line_for_test()
@@ -1116,12 +1122,12 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   sign unplace group=g2
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group == ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
 
   " Test for ':sign unplace group=*'
   call Place_signs_at_line_for_test()
@@ -1131,11 +1137,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+	      \ sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
   sign unplace group=*
   sign unplace group=*
   sign unplace group=*
-  call assert_equal([], sign_getplaced('Xsign1', {'group' : '*'}))
+  call assert_equal([], sign_getplaced({'buffer' : 'Xsign1', 'group' : '*'}))
 
   call sign_unplace([{'group' : '*'}])
   call sign_undefine()
@@ -1176,7 +1182,7 @@ func Test_sign_id_autogen()
   call assert_equal([3], sign_place([{'group' : 'g1', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 13}]))
   call assert_equal([0], sign_unplace([{'group' : 'g1', 'id' : 1}]))
-  call assert_equal(10, sign_getplaced('Xsign', {'id' : 1})[0].lnum)
+  call assert_equal(10, sign_getplaced({'buffer' : 'Xsign', 'id' : 1})[0].lnum)
 
   call delete("Xsign")
   call sign_unplace([{'group' : '*'}])
@@ -1209,7 +1215,7 @@ func Test_sign_priority()
 	      \ 'buffer' : 'Xsign', 'lnum' : 11, 'priority' : 100}])
   call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
 	      \ 'buffer' : 'Xsign', 'lnum' : 11}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 11,
 	      \ 'group' : 'g2', 'priority' : 100},
@@ -1233,7 +1239,7 @@ func Test_sign_priority()
 	      \ 'buffer' : 'Xsign', 'lnum' : 13, 'priority' : 30}])
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 11, 'priority' : 50}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 11,
 	      \ 'group' : '', 'priority' : 50},
@@ -1249,7 +1255,7 @@ func Test_sign_priority()
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
   call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 30}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 30},
@@ -1258,7 +1264,7 @@ func Test_sign_priority()
   " Change the priority of the last sign to highest
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 40}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 40},
@@ -1267,7 +1273,7 @@ func Test_sign_priority()
   " Change the priority of the first sign to lowest
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 25}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 30},
@@ -1277,7 +1283,7 @@ func Test_sign_priority()
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 45}])
   call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 55}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 55},
@@ -1293,7 +1299,7 @@ func Test_sign_priority()
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 30}])
   call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 40},
@@ -1305,7 +1311,7 @@ func Test_sign_priority()
   " Change the priority of the middle sign to the highest
   call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 50}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 50},
@@ -1317,7 +1323,7 @@ func Test_sign_priority()
   " Change the priority of the middle sign to the lowest
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 15}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 50},
@@ -1329,7 +1335,7 @@ func Test_sign_priority()
   " Change the priority of the last sign to the highest
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 55}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 55},
@@ -1341,7 +1347,7 @@ func Test_sign_priority()
   " Change the priority of the first sign to the lowest
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 15}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 50},
@@ -1364,7 +1370,7 @@ func Test_sign_priority()
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 25}])
   call sign_place([{'id' : 5, 'group' : '', 'name' : 'sign2',
 	      \ 'buffer' : 'Xsign', 'lnum' : 6, 'priority' : 80}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
 	      \ 'group' : '', 'priority' : 10},
@@ -1380,7 +1386,7 @@ func Test_sign_priority()
   " Change the priority of the first sign to lowest
   call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 15}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
 	      \ 'group' : '', 'priority' : 10},
@@ -1396,7 +1402,7 @@ func Test_sign_priority()
   " Change the priority of the last sign to highest
   call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 30}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
 	      \ 'group' : '', 'priority' : 10},
@@ -1412,7 +1418,7 @@ func Test_sign_priority()
   " Change the priority of the middle sign to lowest
   call sign_place([{'id' : 4, 'group' : '', 'name' : 'sign3',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 15}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
 	      \ 'group' : '', 'priority' : 10},
@@ -1428,7 +1434,7 @@ func Test_sign_priority()
   " Change the priority of the middle sign to highest
   call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign2',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 35}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
 	      \ 'group' : '', 'priority' : 10},
@@ -1450,7 +1456,7 @@ func Test_sign_priority()
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
   call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
               \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 20},
@@ -1461,7 +1467,7 @@ func Test_sign_priority()
   " Place the last sign again with the same priority
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
               \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 20},
@@ -1472,7 +1478,7 @@ func Test_sign_priority()
   " Place the first sign again with the same priority
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
               \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 20},
@@ -1483,7 +1489,7 @@ func Test_sign_priority()
   " Place the middle sign again with the same priority
   call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
 	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
               \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
 	      \ 'group' : '', 'priority' : 20},
@@ -1499,13 +1505,13 @@ func Test_sign_priority()
 	      \ 'buffer' : 'Xsign', 'lnum' : 5, 'priority' : 20}])
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign2',
 	      \ 'buffer' : 'Xsign', 'lnum' : 5, 'priority' : 10}])
-  let s = sign_getplaced('Xsign', {'lnum' : 5})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'lnum' : 5})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 5,
 	      \ 'group' : '', 'priority' : 10}], s)
   call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign2',
 	      \ 'buffer' : 'Xsign', 'lnum' : 5, 'priority' : 5}])
-  let s = sign_getplaced('Xsign', {'lnum' : 5})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'lnum' : 5})
   call assert_equal([
 	      \ {'id' : 1, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 5,
 	      \ 'group' : '', 'priority' : 5}], s)
@@ -1588,27 +1594,27 @@ func Test_sign_lnum_adjust()
   sign define sign1 text=#> linehl=Comment
   call setline(1, ['A', 'B', 'C', 'D', 'E'])
   exe 'sign place 5 line=3 name=sign1 buffer=' . bufnr('')
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal(3, l[0].lnum)
 
   " Add some lines before the sign and check the sign line number
   call append(2, ['BA', 'BB', 'BC'])
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal(6, l[0].lnum)
 
   " Delete some lines before the sign and check the sign line number
   call deletebufline('%', 1, 2)
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal(4, l[0].lnum)
 
   " Insert some lines after the sign and check the sign line number
   call append(5, ['DA', 'DB'])
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal(4, l[0].lnum)
 
   " Delete some lines after the sign and check the sign line number
   call deletebufline('', 6, 7)
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal(4, l[0].lnum)
 
   " Break the undo. Otherwise the undo operation below will undo all the
@@ -1617,12 +1623,12 @@ func Test_sign_lnum_adjust()
 
   " Delete the line with the sign
   call deletebufline('', 4)
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal(4, l[0].lnum)
 
   " Undo the delete operation
   undo
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal(5, l[0].lnum)
 
   " Break the undo
@@ -1631,12 +1637,12 @@ func Test_sign_lnum_adjust()
   " Delete few lines at the end of the buffer including the line with the sign
   " Sign line number should not change (as it is placed outside of the buffer)
   call deletebufline('', 3, 6)
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal(5, l[0].lnum)
 
   " Undo the delete operation. Sign should be restored to the previous line
   undo
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal(5, l[0].lnum)
 
   sign unplace * group=*
@@ -1653,24 +1659,24 @@ func Test_sign_change_type()
 
   call setline(1, ['A', 'B', 'C', 'D'])
   exe 'sign place 4 line=3 name=sign1 buffer=' . bufnr('')
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal('sign1', l[0].name)
   exe 'sign place 4 name=sign2 buffer=' . bufnr('')
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal('sign2', l[0].name)
   call sign_place([{'id' : 4, 'group' : '', 'name' : 'sign1', 'buffer' : ''}])
-  let l = sign_getplaced(bufnr(''))
+  let l = sign_getplaced({'buffer' : bufnr('')})
   call assert_equal('sign1', l[0].name)
 
   exe 'sign place 4 group=g1 line=4 name=sign1 buffer=' . bufnr('')
-  let l = sign_getplaced(bufnr(''), {'group' : 'g1'})
+  let l = sign_getplaced({'buffer' : bufnr(''), 'group' : 'g1'})
   call assert_equal('sign1', l[0].name)
   exe 'sign place 4 group=g1 name=sign2 buffer=' . bufnr('')
-  let l = sign_getplaced(bufnr(''), {'group' : 'g1'})
+  let l = sign_getplaced({'buffer' : bufnr(''), 'group' : 'g1'})
   call assert_equal('sign2', l[0].name)
   call sign_place([{'id' : 4, 'group' : 'g1', 'name' : 'sign1',
 	      \ 'buffer' : ''}])
-  let l = sign_getplaced(bufnr(''), {'group' : 'g1'})
+  let l = sign_getplaced({'buffer' : bufnr(''), 'group' : 'g1'})
   call assert_equal('sign1', l[0].name)
 
   sign unplace * group=*
@@ -1837,7 +1843,7 @@ func Test_sign_place_multi()
 	      \ {'id' : 3, 'group' : '', 'name' : 'sign3',
 	      \ 'buffer' : 'Xsign', 'lnum' : 11}])
   call assert_equal([1, 2, 3], l)
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnum, 'lnum' : 11,
 	      \ 'group' : 'g2', 'priority' : 100},
@@ -1855,7 +1861,7 @@ func Test_sign_place_multi()
 	      \ {'group' : '', 'name' : 'sign3',
 	      \ 'buffer' : 'Xsign', 'lnum' : 11}])
   call assert_equal([1, 1, 5], l)
-  let s = sign_getplaced('Xsign', {'group' : '*'})
+  let s = sign_getplaced({'buffer' : 'Xsign', 'group' : '*'})
   call assert_equal([
 	      \ {'id' : 5, 'name' : 'sign3', 'buffer' : bnum, 'lnum' : 11,
 	      \ 'group' : '', 'priority' : 10},
@@ -1865,7 +1871,7 @@ func Test_sign_place_multi()
 	      \ 'group' : 'g1', 'priority' : 10}], s)
 
   " Invalid arguments
-  call assert_fails('call sign_place({})', "E474:")
+  call assert_fails('call sign_place({})', "E714:")
   call assert_fails('call sign_place([{}, {}])', 'E474:')
   call assert_fails('call sign_place([1, {}, [], "abc"])', 'E474:')
   call assert_equal([], sign_place([]))

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -384,17 +384,18 @@ func Test_sign_funcs()
   call sign_undefine()
 
   " Tests for sign_define()
-  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
-  call assert_equal(0, sign_define("sign1", attr))
+  let attr = {'name' : 'sign1', 'text' : '=>', 'linehl' : 'Search',
+	      \ 'texthl' : 'Error'}
+  call assert_equal([0], sign_define([attr]))
   call assert_equal([{'name' : 'sign1', 'texthl' : 'Error',
 	      \ 'linehl' : 'Search', 'text' : '=>'}], sign_getdefined())
 
   " Define a new sign without attributes and then update it
-  call sign_define("sign2")
-  let attr = {'text' : '!!', 'linehl' : 'DiffAdd', 'texthl' : 'DiffChange',
-	      \ 'icon' : 'sign2.ico'}
+  call sign_define([{'name' : "sign2"}])
+  let attr = {'name' : 'sign2', 'text' : '!!', 'linehl' : 'DiffAdd',
+	      \ 'texthl' : 'DiffChange', 'icon' : 'sign2.ico'}
   try
-    call sign_define("sign2", attr)
+    call sign_define([attr])
   catch /E255:/
     " ignore error: E255: Couldn't read in sign data!
     " This error can happen when running in gui.
@@ -404,16 +405,18 @@ func Test_sign_funcs()
 	      \ sign_getdefined("sign2"))
 
   " Test for a sign name with digits
-  call assert_equal(0, sign_define(0002, {'linehl' : 'StatusLine'}))
+  call assert_equal([0], sign_define([{'name' : 0002,
+	      \ 'linehl' : 'StatusLine'}]))
   call assert_equal([{'name' : '2', 'linehl' : 'StatusLine'}],
 	      \ sign_getdefined(0002))
   call sign_undefine(0002)
 
   " Tests for invalid arguments to sign_define()
-  call assert_fails('call sign_define("sign4", {"text" : "===>"})', 'E239:')
-  call assert_fails('call sign_define("sign5", {"text" : ""})', 'E239:')
-  call assert_fails('call sign_define([])', 'E730:')
-  call assert_fails('call sign_define("sign6", [])', 'E715:')
+  call assert_fails('call sign_define([{"name" : "sign4", "text" : "===>"}])',
+	      \ 'E239:')
+  call assert_fails('call sign_define([{"name" : "sign5", "text" : ""}])',
+	      \  'E239:')
+  call assert_fails('call sign_define("sign1")', 'E474:')
 
   " Tests for sign_getdefined()
   call assert_equal([], sign_getdefined("none"))
@@ -526,8 +529,9 @@ func Test_sign_group()
 
   call writefile(repeat(["Sun is shining"], 30), "Xsign")
 
-  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
-  call assert_equal(0, sign_define("sign1", attr))
+  let attr = {'name' : 'sign1', 'text' : '=>', 'linehl' : 'Search',
+	      \ 'texthl' : 'Error'}
+  call assert_equal([0], sign_define([attr]))
 
   edit Xsign
   let bnum = bufnr('%')
@@ -817,8 +821,9 @@ func Test_sign_unplace()
   call writefile(repeat(["Sun is shining"], 30), "Xsign1")
   call writefile(repeat(["It is beautiful"], 30), "Xsign2")
 
-  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
-  call sign_define("sign1", attr)
+  let attr = {'name' : 'sign1', 'text' : '=>', 'linehl' : 'Search',
+	      \ 'texthl' : 'Error'}
+  call sign_define([attr])
 
   edit Xsign1
   let bnum1 = bufnr('%')
@@ -1134,8 +1139,9 @@ func Test_sign_id_autogen()
   call sign_unplace([{'group' : '*'}])
   call sign_undefine()
 
-  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
-  call assert_equal(0, sign_define("sign1", attr))
+  let attr = {'name' : 'sign1', 'text' : '=>', 'linehl' : 'Search',
+	      \ 'texthl' : 'Error'}
+  call assert_equal([0], sign_define([attr]))
 
   call writefile(repeat(["Sun is shining"], 30), "Xsign")
   edit Xsign
@@ -1173,10 +1179,13 @@ func Test_sign_priority()
   call sign_unplace([{'group' : '*'}])
   call sign_undefine()
 
-  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Search'}
-  call sign_define("sign1", attr)
-  call sign_define("sign2", attr)
-  call sign_define("sign3", attr)
+  let signlist = [{'name' : 'sign1', 'text' : '=>', 'linehl' : 'Search',
+	      \ 'texthl' : 'Search'},
+	      \ {'name' : 'sign2', 'text' : '=>', 'linehl' : 'Search',
+	      \ 'texthl' : 'Search'},
+	      \ {'name' : 'sign3', 'text' : '=>', 'linehl' : 'Search',
+	      \ 'texthl' : 'Search'}]
+  call assert_equal([0, 0, 0], sign_define(signlist))
 
   " Place three signs with different priority in the same line
   call writefile(repeat(["Sun is shining"], 30), "Xsign")
@@ -1529,11 +1538,13 @@ func Test_sign_memfailures()
   call test_alloc_fail(GetAllocId('sign_getplaced'), 0, 0)
   call assert_fails('call sign_getplaced("Xsign")', 'E342:')
   call test_alloc_fail(GetAllocId('sign_define_by_name'), 0, 0)
-  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
-  call assert_fails('call sign_define("sign1", attr)', 'E342:')
+  let attr = {'name' : 'sign1', 'text' : '=>', 'linehl' : 'Search',
+	      \ 'texthl' : 'Error'}
+  call assert_fails('call sign_define([attr])', 'E342:')
 
-  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
-  call sign_define("sign1", attr)
+  let attr = {'name' : 'sign1', 'text' : '=>', 'linehl' : 'Search',
+	      \ 'texthl' : 'Error'}
+  call sign_define([attr])
   call test_alloc_fail(GetAllocId('sign_getlist'), 0, 0)
   call assert_fails('call sign_getdefined("sign1")', 'E342:')
 
@@ -1798,9 +1809,12 @@ endfunc
 " Test for placing multiple signs using the sign_place() function
 func Test_sign_place_multi()
   let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Search'}
-  call sign_define("sign1", attr)
-  call sign_define("sign2", attr)
-  call sign_define("sign3", attr)
+  let attr.name = 'sign1'
+  call sign_define([attr])
+  let attr.name = 'sign2'
+  call sign_define([attr])
+  let attr.name = 'sign3'
+  call sign_define([attr])
   call writefile(repeat(["Sun is shining"], 30), "Xsign")
   edit Xsign
   let bnum = bufnr('')

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -380,7 +380,7 @@ endfunc
 " Test for Vim script functions for managing signs
 func Test_sign_funcs()
   " Remove all the signs
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
 
   " Tests for sign_define()
@@ -423,83 +423,87 @@ func Test_sign_funcs()
   call writefile(repeat(["Sun is shining"], 30), "Xsign")
   edit Xsign
 
-  call assert_equal(10, sign_place(10, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 20}))
-  call assert_equal([{'bufnr' : bufnr(''), 'signs' :
-	      \ [{'id' : 10, 'group' : '', 'lnum' : 20, 'name' : 'sign1',
-	      \ 'priority' : 10}]}], sign_getplaced('Xsign'))
-  call assert_equal([{'bufnr' : bufnr(''), 'signs' :
-	      \ [{'id' : 10, 'group' : '', 'lnum' : 20, 'name' : 'sign1',
-	      \ 'priority' : 10}]}],
+  call assert_equal([10], sign_place([{'id' : 10, 'group' : '',
+	      \ 'name' : 'sign1', 'buffer' : 'Xsign', 'lnum' : 20}]))
+  let bnr = bufnr('')
+  call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
+	      \ 'name' : 'sign1', 'priority' : 10}], sign_getplaced('Xsign'))
+  call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
+	      \ 'name' : 'sign1', 'priority' : 10}],
 	      \ sign_getplaced('%', {'lnum' : 20}))
-  call assert_equal([{'bufnr' : bufnr(''), 'signs' :
-	      \ [{'id' : 10, 'group' : '', 'lnum' : 20, 'name' : 'sign1',
-	      \ 'priority' : 10}]}],
+  call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
+	      \ 'name' : 'sign1', 'priority' : 10}],
 	      \ sign_getplaced('', {'id' : 10}))
 
   " Tests for invalid arguments to sign_place()
-  call assert_fails('call sign_place([], "", "mySign", 1)', 'E745:')
-  call assert_fails('call sign_place(5, "", "mySign", -1)', 'E158:')
-  call assert_fails('call sign_place(-1, "", "sign1", "Xsign", [])',
-	      \ 'E474:')
-  call assert_fails('call sign_place(-1, "", "sign1", "Xsign",
-	      \ {"lnum" : 30})', 'E474:')
-  call assert_fails('call sign_place(10, "", "xsign1x", "Xsign",
-	      \ {"lnum" : 30})', 'E155:')
-  call assert_fails('call sign_place(10, "", "", "Xsign",
-	      \ {"lnum" : 30})', 'E155:')
-  call assert_fails('call sign_place(10, "", [], "Xsign",
-	      \ {"lnum" : 30})', 'E730:')
-  call assert_fails('call sign_place(5, "", "sign1", "abcxyz.xxx",
-	      \ {"lnum" : 10})', 'E158:')
-  call assert_fails('call sign_place(5, "", "sign1", "@", {"lnum" : 10})',
-	      \ 'E158:')
-  call assert_fails('call sign_place(5, "", "sign1", [], {"lnum" : 10})',
-	      \ 'E158:')
-  call assert_fails('call sign_place(21, "", "sign1", "Xsign",
-	      \ {"lnum" : -1})', 'E885:')
-  call assert_fails('call sign_place(22, "", "sign1", "Xsign",
-	      \ {"lnum" : 0})', 'E885:')
-  call assert_fails('call sign_place(22, "", "sign1", "Xsign",
-	      \ {"lnum" : []})', 'E745:')
-  call assert_equal(-1, sign_place(1, "*", "sign1", "Xsign", {"lnum" : 10}))
+  let attr = {"id" : [], "name" : "mySign", "buffer" : 1}
+  call assert_fails('call sign_place([attr])', 'E745:')
+  let attr = {"id" : 5, "name" : "mySign", "buffer" : -1}
+  call assert_fails('call sign_place([attr])', 'E158:')
+  let attr = {"id" : -1, "name" : "sign1", "buffer" : "Xsign"}
+  call assert_fails('call sign_place([attr])', 'E474:')
+  let attr = {"id" : -1, "name" : "sign1", "buffer" : "Xsign", "lnum" : 30}
+  call assert_fails('call sign_place([attr])', 'E474:')
+  let attr = {"id" : 5, "name" : "mySign", "buffer" : "Xsign", "lnum" : []}
+  call assert_fails('call sign_place([attr])', 'E745:')
+  let attr = {"id" : 10, "name" : "xsign1x", "buffer" : "Xsign", "lnum" : 30}
+  call assert_fails('call sign_place([attr])', 'E155:')
+  let attr = {"id" : 10, "name" : "", "buffer" : "Xsign", "lnum" : 30}
+  call assert_fails('call sign_place([attr])', 'E155:')
+  let attr = {"id" : 10, "name" : [], "buffer" : "Xsign", "lnum" : 30}
+  call assert_fails('call sign_place([attr])', 'E730:')
+  let attr = {"id" : 5, "name" : "sign1", "buffer" : "abxy.xx", "lnum" : 10}
+  call assert_fails('call sign_place([attr])', 'E158:')
+  let attr = {"id" : 5, "name" : "sign1", "buffer" : "@", "lnum" : 10}
+  call assert_fails('call sign_place([attr])', 'E158:')
+  let attr = {"id" : 5, "name" : "sign1", "buffer" : [], "lnum" : 10}
+  call assert_fails('call sign_place([attr])', 'E158:')
+  let attr = {"id" : 21, "name" : "sign1", "buffer" : "Xsign", "lnum" : -1}
+  call assert_fails('call sign_place([attr])', 'E885:')
+  let attr = {"id" : 22, "name" : "sign1", "buffer" : "Xsign", "lnum" : 0}
+  call assert_fails('call sign_place([attr])', 'E885:')
+  let attr = {"id" : 22, "name" : "sign1", "buffer" : "Xsign", "lnum" : []}
+  call assert_fails('call sign_place([attr])', 'E745:')
+  let attr = {"id" : 1, "group" : "*", "name" : "sign1", "buffer" : "Xsign",
+	      \ "lnum" : 10}
+  call assert_equal([0], sign_place([attr]))
 
   " Tests for sign_getplaced()
-  call assert_equal([{'bufnr' : bufnr(''), 'signs' :
-	      \ [{'id' : 10, 'group' : '', 'lnum' : 20, 'name' : 'sign1',
-	      \ 'priority' : 10}]}],
-	      \ sign_getplaced(bufnr('Xsign')))
-  call assert_equal([{'bufnr' : bufnr(''), 'signs' :
-	      \ [{'id' : 10, 'group' : '', 'lnum' : 20, 'name' : 'sign1',
-	      \ 'priority' : 10}]}],
-	      \ sign_getplaced())
+  let bnr = bufnr('')
+  call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
+	      \ 'name' : 'sign1', 'priority' : 10}], sign_getplaced(bnr))
+  call assert_equal([{'id' : 10, 'group' : '', 'buffer' : bnr, 'lnum' : 20,
+	      \ 'name' : 'sign1', 'priority' : 10}], sign_getplaced())
   call assert_fails("call sign_getplaced('dummy.sign')", 'E158:')
   call assert_fails('call sign_getplaced("&")', 'E158:')
   call assert_fails('call sign_getplaced(-1)', 'E158:')
   call assert_fails('call sign_getplaced("Xsign", [])', 'E715:')
-  call assert_equal([{'bufnr' : bufnr(''), 'signs' : []}],
-	      \ sign_getplaced('Xsign', {'lnum' : 1000000}))
+  call assert_equal([], sign_getplaced('Xsign', {'lnum' : 1000000}))
   call assert_fails("call sign_getplaced('Xsign', {'lnum' : []})",
 	      \ 'E745:')
-  call assert_equal([{'bufnr' : bufnr(''), 'signs' : []}],
-	      \ sign_getplaced('Xsign', {'id' : 44}))
+  call assert_equal([], sign_getplaced('Xsign', {'id' : 44}))
   call assert_fails("call sign_getplaced('Xsign', {'id' : []})",
 	      \ 'E745:')
 
   " Tests for sign_unplace()
-  call sign_place(20, '', 'sign2', 'Xsign', {"lnum" : 30})
-  call assert_equal(0, sign_unplace('',
-	      \ {'id' : 20, 'buffer' : 'Xsign'}))
-  call assert_equal(-1, sign_unplace('',
-	      \ {'id' : 30, 'buffer' : 'Xsign'}))
-  call sign_place(20, '', 'sign2', 'Xsign', {"lnum" : 30})
-  call assert_fails("call sign_unplace('',
-	      \ {'id' : 20, 'buffer' : 'buffer.c'})", 'E158:')
-  call assert_fails("call sign_unplace('',
-	      \ {'id' : 20, 'buffer' : '&'})", 'E158:')
-  call assert_fails("call sign_unplace('g1',
-	      \ {'id' : 20, 'buffer' : 200})", 'E158:')
-  call assert_fails("call sign_unplace('g1', 'mySign')", 'E715:')
+  call sign_place([{'id' : 20, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 30}])
+  call assert_equal([0], sign_unplace([{'group' : '', 'id' : 20,
+	      \ 'buffer' : 'Xsign'}]))
+  call assert_equal([-1], sign_unplace([{'id' : 30, 'buffer' : 'Xsign'}]))
+  call sign_place([{'id' : 20, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 30}])
+  call assert_fails("call sign_unplace([{'id' : 20, 'buffer' : 'buffer.c'}])",
+	      \ 'E158:')
+  call assert_fails("call sign_unplace([{'id' : 20, 'buffer' : '&'}])", 'E158:')
+  call assert_fails("call sign_unplace([{'group' : 'g1', 'id' : 20,
+	      \ 'buffer' : 200}])", 'E158:')
+  call assert_fails("call sign_unplace([{'group' : 'g1', 'id' : 'mySign'}])",
+	      \ 'E474:')
+  call assert_fails("call sign_unplace({})", 'E474:')
+  " Unplace signs in the current buffer
+  call assert_equal([0, 0], sign_unplace([{'id' : 10}, {'id' : 20}]))
+  call assert_equal([], sign_getplaced('Xsign'))
 
   " Tests for sign_undefine()
   call assert_equal(0, sign_undefine("sign1"))
@@ -508,7 +512,7 @@ func Test_sign_funcs()
   call assert_fails('call sign_undefine([])', 'E730:')
 
   call delete("Xsign")
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
   enew | only
 endfunc
@@ -517,7 +521,7 @@ endfunc
 func Test_sign_group()
   enew | only
   " Remove all the signs
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
 
   call writefile(repeat(["Sun is shining"], 30), "Xsign")
@@ -529,136 +533,143 @@ func Test_sign_group()
   let bnum = bufnr('%')
 
   " Error case
-  call assert_fails("call sign_place(5, [], 'sign1', 'Xsign',
-	      \ {'lnum' : 30})", 'E730:')
+  call assert_fails("call sign_place([{'id' : 5, 'group' : [],
+	      \ 'name' : 'sign1', 'buffer' : 'Xsign', 'lnum' : 30}])", 'E730:')
 
   " place three signs with the same identifier. One in the global group and
   " others in the named groups
-  call assert_equal(5, sign_place(5, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 10}))
-  call assert_equal(5, sign_place(5, 'g1', 'sign1', bnum, {'lnum' : 20}))
-  call assert_equal(5, sign_place(5, 'g2', 'sign1', bnum, {'lnum' : 30}))
+  call assert_equal([5], sign_place([{'id' : 5, 'group' : '',
+	      \ 'name' : 'sign1', 'buffer' : 'Xsign', 'lnum' : 10}]))
+  call assert_equal([5], sign_place([{'id' : 5, 'group' : 'g1',
+	      \ 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 20}]))
+  call assert_equal([5], sign_place([{'id' : 5, 'group' : 'g2',
+	      \ 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 30}]))
 
   " Test for sign_getplaced() with group
   let s = sign_getplaced('Xsign')
-  call assert_equal(1, len(s[0].signs))
-  call assert_equal(s[0].signs[0].group, '')
+  call assert_equal(1, len(s))
+  call assert_equal(s[0].group, '')
   let s = sign_getplaced(bnum, {'group' : ''})
-  call assert_equal([{'id' : 5, 'group' : '', 'name' : 'sign1', 'lnum' : 10,
-	      \ 'priority' : 10}], s[0].signs)
-  call assert_equal(1, len(s[0].signs))
+  call assert_equal([{'id' : 5, 'group' : '', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 10, 'priority' : 10}], s)
+  call assert_equal(1, len(s))
   let s = sign_getplaced(bnum, {'group' : 'g2'})
-  call assert_equal('g2', s[0].signs[0].group)
+  call assert_equal('g2', s[0].group)
   let s = sign_getplaced(bnum, {'group' : 'g3'})
-  call assert_equal([], s[0].signs)
+  call assert_equal([], s)
   let s = sign_getplaced(bnum, {'group' : '*'})
-  call assert_equal([{'id' : 5, 'group' : '', 'name' : 'sign1', 'lnum' : 10,
-	      \ 'priority' : 10},
-	      \ {'id' : 5, 'group' : 'g1', 'name' : 'sign1', 'lnum' : 20,
-	      \  'priority' : 10},
-	      \ {'id' : 5, 'group' : 'g2', 'name' : 'sign1', 'lnum' : 30,
-	      \  'priority' : 10}],
-	      \ s[0].signs)
+  call assert_equal([
+	      \ {'id' : 5, 'group' : '', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 10, 'priority' : 10},
+	      \ {'id' : 5, 'group' : 'g1', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 20, 'priority' : 10},
+	      \ {'id' : 5, 'group' : 'g2', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 30, 'priority' : 10}], s)
 
   " Test for sign_getplaced() with id
   let s = sign_getplaced(bnum, {'id' : 5})
-  call assert_equal([{'id' : 5, 'group' : '', 'name' : 'sign1', 'lnum' : 10,
-	      \ 'priority' : 10}],
-	      \ s[0].signs)
+  call assert_equal([
+	      \ {'id' : 5, 'group' : '', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 10, 'priority' : 10}], s)
   let s = sign_getplaced(bnum, {'id' : 5, 'group' : 'g2'})
   call assert_equal(
-	      \ [{'id' : 5, 'name' : 'sign1', 'lnum' : 30, 'group' : 'g2',
-	      \ 'priority' : 10}],
-	      \ s[0].signs)
+	      \ [{'id' : 5, 'name' : 'sign1', 'group' : 'g2', 'buffer' : bnum,
+	      \ 'lnum' : 30, 'priority' : 10}], s)
   let s = sign_getplaced(bnum, {'id' : 5, 'group' : '*'})
-  call assert_equal([{'id' : 5, 'group' : '', 'name' : 'sign1', 'lnum' : 10,
-	      \ 'priority' : 10},
-	      \ {'id' : 5, 'group' : 'g1', 'name' : 'sign1', 'lnum' : 20,
-	      \ 'priority' : 10},
-	      \ {'id' : 5, 'group' : 'g2', 'name' : 'sign1', 'lnum' : 30,
-	      \ 'priority' : 10}],
-	      \ s[0].signs)
+  call assert_equal([
+	      \ {'id' : 5, 'group' : '', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 10, 'priority' : 10},
+	      \ {'id' : 5, 'group' : 'g1', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 20, 'priority' : 10},
+	      \ {'id' : 5, 'group' : 'g2', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 30, 'priority' : 10}], s)
   let s = sign_getplaced(bnum, {'id' : 5, 'group' : 'g3'})
-  call assert_equal([], s[0].signs)
+  call assert_equal([], s)
 
   " Test for sign_getplaced() with lnum
   let s = sign_getplaced(bnum, {'lnum' : 20})
-  call assert_equal([], s[0].signs)
+  call assert_equal([], s)
   let s = sign_getplaced(bnum, {'lnum' : 20, 'group' : 'g1'})
-  call assert_equal(
-	      \ [{'id' : 5, 'name' : 'sign1', 'lnum' : 20, 'group' : 'g1',
-	      \ 'priority' : 10}],
-	      \ s[0].signs)
+  call assert_equal([
+	      \ {'id' : 5, 'group' : 'g1', 'name' : 'sign1', 'buffer' : bnum,
+	      \ 'lnum' : 20, 'priority' : 10}], s)
   let s = sign_getplaced(bnum, {'lnum' : 30, 'group' : '*'})
-  call assert_equal(
-	      \ [{'id' : 5, 'name' : 'sign1', 'lnum' : 30, 'group' : 'g2',
-	      \ 'priority' : 10}],
-	      \ s[0].signs)
+  call assert_equal([
+	      \ {'id' : 5, 'group' : 'g2', 'name' : 'sign1', 'buffer' : bnum,
+	      \ 'lnum' : 30, 'priority' : 10}], s)
   let s = sign_getplaced(bnum, {'lnum' : 40, 'group' : '*'})
-  call assert_equal([], s[0].signs)
+  call assert_equal([], s)
 
   " Error case
   call assert_fails("call sign_getplaced(bnum, {'group' : []})",
 	      \ 'E730:')
 
   " Clear the sign in global group
-  call sign_unplace('', {'id' : 5, 'buffer' : bnum})
+  call sign_unplace([{'id' : 5, 'buffer' : bnum}])
   let s = sign_getplaced(bnum, {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 5, 'name' : 'sign1', 'lnum' : 20, 'group' : 'g1',
-	      \ 'priority' : 10},
-	      \ {'id' : 5, 'name' : 'sign1', 'lnum' : 30, 'group' : 'g2',
-	      \ 'priority' : 10}],
-	      \ s[0].signs)
+	      \ {'id' : 5, 'group' : 'g1', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 20, 'priority' : 10},
+	      \ {'id' : 5, 'group' : 'g2', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 30, 'priority' : 10}], s)
 
   " Clear the sign in one of the groups
-  call sign_unplace('g1', {'buffer' : 'Xsign'})
+  call sign_unplace([{'group' : 'g1', 'buffer' : 'Xsign'}])
   let s = sign_getplaced(bnum, {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 5, 'name' : 'sign1', 'lnum' : 30, 'group' : 'g2',
-	      \ 'priority' : 10}],
-	      \ s[0].signs)
+	      \ {'id' : 5, 'group' : 'g2', 'buffer' : bnum, 'name' : 'sign1',
+	      \ 'lnum' : 30, 'priority' : 10}], s)
 
   " Clear all the signs from the buffer
-  call sign_unplace('*', {'buffer' : bnum})
-  call assert_equal([], sign_getplaced(bnum, {'group' : '*'})[0].signs)
+  call sign_unplace([{'group' : '*', 'buffer' : bnum}])
+  call assert_equal([], sign_getplaced(bnum, {'group' : '*'}))
 
   " Clear sign across groups using an identifier
-  call sign_place(25, '', 'sign1', bnum, {'lnum' : 10})
-  call sign_place(25, 'g1', 'sign1', bnum, {'lnum' : 11})
-  call sign_place(25, 'g2', 'sign1', bnum, {'lnum' : 12})
-  call assert_equal(0, sign_unplace('*', {'id' : 25}))
-  call assert_equal([], sign_getplaced(bnum, {'group' : '*'})[0].signs)
+  call sign_place([{'id' : 25, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : bnum, 'lnum' : 10},
+	      \ {'id' : 25, 'group' : 'g1', 'name' : 'sign1',
+	      \ 'buffer' : bnum, 'lnum' : 11},
+	      \ {'id' : 25, 'group' : 'g2', 'name' : 'sign1',
+	      \ 'buffer' : bnum, 'lnum' : 12}])
+  call assert_equal([0], sign_unplace([{'group' : '*', 'id' : 25}]))
+  call assert_equal([], sign_getplaced(bnum, {'group' : '*'}))
 
   " Error case
-  call assert_fails("call sign_unplace([])", 'E474:')
+  call assert_fails("call sign_unplace(20)", 'E474:')
 
   " Place a sign in the global group and try to delete it using a group
-  call assert_equal(5, sign_place(5, '', 'sign1', bnum, {'lnum' : 10}))
-  call assert_equal(-1, sign_unplace('g1', {'id' : 5}))
+  call assert_equal([5], sign_place([{'id' : 5, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : bnum, 'lnum' : 10}]))
+  call assert_equal([-1], sign_unplace([{'group' : 'g1', 'id' : 5}]))
 
   " Place signs in multiple groups and delete all the signs in one of the
   " group
-  call assert_equal(5, sign_place(5, '', 'sign1', bnum, {'lnum' : 10}))
-  call assert_equal(6, sign_place(6, '', 'sign1', bnum, {'lnum' : 11}))
-  call assert_equal(5, sign_place(5, 'g1', 'sign1', bnum, {'lnum' : 10}))
-  call assert_equal(5, sign_place(5, 'g2', 'sign1', bnum, {'lnum' : 10}))
-  call assert_equal(6, sign_place(6, 'g1', 'sign1', bnum, {'lnum' : 11}))
-  call assert_equal(6, sign_place(6, 'g2', 'sign1', bnum, {'lnum' : 11}))
-  call assert_equal(0, sign_unplace('g1'))
+  call assert_equal([5], sign_place([{'id' : 5, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : bnum, 'lnum' : 10}]))
+  call assert_equal([6], sign_place([{'id' : 6, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : bnum, 'lnum' : 11}]))
+  call assert_equal([5], sign_place([{'id' : 5, 'group' : 'g1',
+	      \ 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 10}]))
+  call assert_equal([5], sign_place([{'id' : 5, 'group' : 'g2',
+	      \ 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 10}]))
+  call assert_equal([6], sign_place([{'id' : 6, 'group' : 'g1',
+	      \ 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 11}]))
+  call assert_equal([6], sign_place([{'id' : 6, 'group' : 'g2',
+	      \ 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 11}]))
+  call assert_equal([0], sign_unplace([{'group' : 'g1'}]))
   let s = sign_getplaced(bnum, {'group' : 'g1'})
-  call assert_equal([], s[0].signs)
+  call assert_equal([], s)
   let s = sign_getplaced(bnum)
-  call assert_equal(2, len(s[0].signs))
+  call assert_equal(2, len(s))
   let s = sign_getplaced(bnum, {'group' : 'g2'})
-  call assert_equal('g2', s[0].signs[0].group)
-  call assert_equal(0, sign_unplace('', {'id' : 5}))
-  call assert_equal(0, sign_unplace('', {'id' : 6}))
+  call assert_equal('g2', s[0].group)
+  call assert_equal([0], sign_unplace([{'id' : 5}]))
+  call assert_equal([0], sign_unplace([{'id' : 6}]))
   let s = sign_getplaced(bnum, {'group' : 'g2'})
-  call assert_equal('g2', s[0].signs[0].group)
-  call assert_equal(0, sign_unplace('', {'buffer' : bnum}))
+  call assert_equal('g2', s[0].group)
+  call assert_equal([0], sign_unplace([{'buffer' : bnum}]))
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
 
   " Test for :sign command and groups
   sign place 5 line=10 name=sign1 file=Xsign
@@ -688,7 +699,7 @@ func Test_sign_group()
   let a = execute('sign place group=xyz file=Xsign')
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n", a)
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   let bnum = bufnr('Xsign')
   exe 'sign place 5 line=10 name=sign1 buffer=' . bnum
   exe 'sign place 5 group=g1 line=11 name=sign1 buffer=' . bnum
@@ -761,14 +772,14 @@ func Test_sign_group()
   call assert_fails("sign place 3 group= name=sign1 buffer=" . bnum, 'E474:')
 
   call delete("Xsign")
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
   enew | only
 endfunc
 
 " Place signs used for ":sign unplace" command test
 func Place_signs_for_test()
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
 
   sign place 3 line=10 name=sign1 file=Xsign1
   sign place 3 group=g1 line=11 name=sign1 file=Xsign1
@@ -786,7 +797,7 @@ endfunc
 
 " Place multiple signs in a single line for test
 func Place_signs_at_line_for_test()
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   sign place 3 line=13 name=sign1 file=Xsign1
   sign place 3 group=g1 line=13 name=sign1 file=Xsign1
   sign place 3 group=g2 line=13 name=sign1 file=Xsign1
@@ -799,7 +810,7 @@ endfunc
 func Test_sign_unplace()
   enew | only
   " Remove all the signs
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
 
   " Create two files and define signs
@@ -814,30 +825,30 @@ func Test_sign_unplace()
   split Xsign2
   let bnum2 = bufnr('%')
 
-  let signs1 = [{'id' : 3, 'name' : 'sign1', 'lnum' : 10, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 3, 'name' : 'sign1', 'lnum' : 11, 'group' : 'g1',
-	      \ 'priority' : 10},
-	      \ {'id' : 3, 'name' : 'sign1', 'lnum' : 12, 'group' : 'g2',
-	      \ 'priority' : 10},
-	      \ {'id' : 4, 'name' : 'sign1', 'lnum' : 15, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 4, 'name' : 'sign1', 'lnum' : 16, 'group' : 'g1',
-	      \ 'priority' : 10},
-	      \ {'id' : 4, 'name' : 'sign1', 'lnum' : 17, 'group' : 'g2',
-	      \ 'priority' : 10},]
-  let signs2 = [{'id' : 5, 'name' : 'sign1', 'lnum' : 20, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 5, 'name' : 'sign1', 'lnum' : 21, 'group' : 'g1',
-	      \ 'priority' : 10},
-	      \ {'id' : 5, 'name' : 'sign1', 'lnum' : 22, 'group' : 'g2',
-	      \ 'priority' : 10},
-	      \ {'id' : 6, 'name' : 'sign1', 'lnum' : 25, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 6, 'name' : 'sign1', 'lnum' : 26, 'group' : 'g1',
-	      \ 'priority' : 10},
-	      \ {'id' : 6, 'name' : 'sign1', 'lnum' : 27, 'group' : 'g2',
-	      \ 'priority' : 10},]
+  let signs1 = [{'id' : 3, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 10,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 3, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 11,
+	      \ 'group' : 'g1', 'priority' : 10},
+	      \ {'id' : 3, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 12,
+	      \ 'group' : 'g2', 'priority' : 10},
+	      \ {'id' : 4, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 15,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 4, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 16,
+	      \ 'group' : 'g1', 'priority' : 10},
+	      \ {'id' : 4, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 17,
+	      \ 'group' : 'g2', 'priority' : 10},]
+  let signs2 = [{'id' : 5, 'name' : 'sign1', 'buffer' : bnum2, 'lnum' : 20,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 5, 'name' : 'sign1', 'buffer' : bnum2, 'lnum' : 21,
+	      \ 'group' : 'g1', 'priority' : 10},
+	      \ {'id' : 5, 'name' : 'sign1', 'buffer' : bnum2, 'lnum' : 22,
+	      \ 'group' : 'g2', 'priority' : 10},
+	      \ {'id' : 6, 'name' : 'sign1', 'buffer' : bnum2, 'lnum' : 25,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 6, 'name' : 'sign1', 'buffer' : bnum2, 'lnum' : 26,
+	      \ 'group' : 'g1', 'priority' : 10},
+	      \ {'id' : 6, 'name' : 'sign1', 'buffer' : bnum2, 'lnum' : 27,
+	      \ 'group' : 'g2', 'priority' : 10},]
 
   " Test for :sign unplace {id} file={fname}
   call Place_signs_for_test()
@@ -846,11 +857,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3 || val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6 || val.group != ''}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace {id} group={group} file={fname}
   call Place_signs_for_test()
@@ -859,11 +870,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 5 || val.group != 'g2'}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace {id} group=* file={fname}
   call Place_signs_for_test()
@@ -872,11 +883,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace * file={fname}
   call Place_signs_for_test()
@@ -884,8 +895,8 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
-  call assert_equal(signs2, sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
+  call assert_equal(signs2, sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace * group={group} file={fname}
   call Place_signs_for_test()
@@ -894,17 +905,17 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.group != 'g2'}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace * group=* file={fname}
   call Place_signs_for_test()
   sign unplace * group=* file=Xsign2
-  call assert_equal(signs1, sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
-  call assert_equal([], sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+  call assert_equal(signs1, sign_getplaced('Xsign1', {'group' : '*'}))
+  call assert_equal([], sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace {id} buffer={nr}
   call Place_signs_for_test()
@@ -913,11 +924,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3 || val.group != ''}),
-	      \ sign_getplaced(bnum1, {'group' : '*'})[0].signs)
+	      \ sign_getplaced(bnum1, {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6 || val.group != ''}),
-	      \ sign_getplaced(bnum2, {'group' : '*'})[0].signs)
+	      \ sign_getplaced(bnum2, {'group' : '*'}))
 
   " Test for :sign unplace {id} group={group} buffer={nr}
   call Place_signs_for_test()
@@ -926,11 +937,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != 'g1'}),
-	      \ sign_getplaced(bnum1, {'group' : '*'})[0].signs)
+	      \ sign_getplaced(bnum1, {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 5 || val.group != 'g2'}),
-	      \ sign_getplaced(bnum2, {'group' : '*'})[0].signs)
+	      \ sign_getplaced(bnum2, {'group' : '*'}))
 
   " Test for :sign unplace {id} group=* buffer={nr}
   call Place_signs_for_test()
@@ -939,11 +950,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3}),
-	      \ sign_getplaced(bnum1, {'group' : '*'})[0].signs)
+	      \ sign_getplaced(bnum1, {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6}),
-	      \ sign_getplaced(bnum2, {'group' : '*'})[0].signs)
+	      \ sign_getplaced(bnum2, {'group' : '*'}))
 
   " Test for :sign unplace * buffer={nr}
   call Place_signs_for_test()
@@ -951,8 +962,8 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced(bnum1, {'group' : '*'})[0].signs)
-  call assert_equal(signs2, sign_getplaced(bnum2, {'group' : '*'})[0].signs)
+	      \ sign_getplaced(bnum1, {'group' : '*'}))
+  call assert_equal(signs2, sign_getplaced(bnum2, {'group' : '*'}))
 
   " Test for :sign unplace * group={group} buffer={nr}
   call Place_signs_for_test()
@@ -961,17 +972,17 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != 'g1'}),
-	      \ sign_getplaced(bnum1, {'group' : '*'})[0].signs)
+	      \ sign_getplaced(bnum1, {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.group != 'g2'}),
-	      \ sign_getplaced(bnum2, {'group' : '*'})[0].signs)
+	      \ sign_getplaced(bnum2, {'group' : '*'}))
 
   " Test for :sign unplace * group=* buffer={nr}
   call Place_signs_for_test()
   exe 'sign unplace * group=* buffer=' . bnum2
-  call assert_equal(signs1, sign_getplaced(bnum1, {'group' : '*'})[0].signs)
-  call assert_equal([], sign_getplaced(bnum2, {'group' : '*'})[0].signs)
+  call assert_equal(signs1, sign_getplaced(bnum1, {'group' : '*'}))
+  call assert_equal([], sign_getplaced(bnum2, {'group' : '*'}))
 
   " Test for :sign unplace {id}
   call Place_signs_for_test()
@@ -980,11 +991,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6 || val.group != ''}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace {id} group={group}
   call Place_signs_for_test()
@@ -993,11 +1004,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 6 || val.group != 'g2'}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace {id} group=*
   call Place_signs_for_test()
@@ -1006,11 +1017,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 3}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.id != 5}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace *
   call Place_signs_for_test()
@@ -1018,11 +1029,11 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace * group={group}
   call Place_signs_for_test()
@@ -1030,41 +1041,41 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   call assert_equal(
 	      \ filter(copy(signs2),
 	      \     {idx, val -> val.group != 'g1'}),
-	      \ sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Test for :sign unplace * group=*
   call Place_signs_for_test()
   sign unplace * group=*
-  call assert_equal([], sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
-  call assert_equal([], sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+  call assert_equal([], sign_getplaced('Xsign1', {'group' : '*'}))
+  call assert_equal([], sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Negative test cases
   call Place_signs_for_test()
   sign unplace 3 group=xy file=Xsign1
   sign unplace * group=xy file=Xsign1
   silent! sign unplace * group=* file=FileNotPresent
-  call assert_equal(signs1, sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
-  call assert_equal(signs2, sign_getplaced('Xsign2', {'group' : '*'})[0].signs)
+  call assert_equal(signs1, sign_getplaced('Xsign1', {'group' : '*'}))
+  call assert_equal(signs2, sign_getplaced('Xsign2', {'group' : '*'}))
 
   " Tests for removing sign at the current cursor position
 
   " Test for ':sign unplace'
-  let signs1 = [{'id' : 4, 'name' : 'sign1', 'lnum' : 13, 'group' : 'g2',
-	      \ 'priority' : 10},
-	      \ {'id' : 4, 'name' : 'sign1', 'lnum' : 13, 'group' : 'g1',
-	      \ 'priority' : 10},
-	      \ {'id' : 4, 'name' : 'sign1', 'lnum' : 13, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 3, 'name' : 'sign1', 'lnum' : 13, 'group' : 'g2',
-	      \ 'priority' : 10},
-	      \ {'id' : 3, 'name' : 'sign1', 'lnum' : 13, 'group' : 'g1',
-	      \ 'priority' : 10},
-	      \ {'id' : 3, 'name' : 'sign1', 'lnum' : 13, 'group' : '',
-	      \ 'priority' : 10},]
+  let signs1 = [{'id' : 4, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 13,
+	      \ 'group' : 'g2', 'priority' : 10},
+	      \ {'id' : 4, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 13,
+	      \ 'group' : 'g1', 'priority' : 10},
+	      \ {'id' : 4, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 13,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 3, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 13,
+	      \ 'group' : 'g2', 'priority' : 10},
+	      \ {'id' : 3, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 13,
+	      \ 'group' : 'g1', 'priority' : 10},
+	      \ {'id' : 3, 'name' : 'sign1', 'buffer' : bnum1, 'lnum' : 13,
+	      \ 'group' : '', 'priority' : 10},]
   exe bufwinnr('Xsign1') . 'wincmd w'
   call cursor(13, 1)
 
@@ -1074,13 +1085,13 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   " Should remove the second sign in the global group
   sign unplace
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.group != ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
 
   " Test for ':sign unplace group={group}'
   call Place_signs_at_line_for_test()
@@ -1089,12 +1100,12 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group != 'g1'}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   sign unplace group=g2
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4 || val.group == ''}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
 
   " Test for ':sign unplace group=*'
   call Place_signs_at_line_for_test()
@@ -1104,13 +1115,13 @@ func Test_sign_unplace()
   call assert_equal(
 	      \ filter(copy(signs1),
 	      \     {idx, val -> val.id != 4}),
-	      \ sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+	      \ sign_getplaced('Xsign1', {'group' : '*'}))
   sign unplace group=*
   sign unplace group=*
   sign unplace group=*
-  call assert_equal([], sign_getplaced('Xsign1', {'group' : '*'})[0].signs)
+  call assert_equal([], sign_getplaced('Xsign1', {'group' : '*'}))
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
   enew | only
   call delete("Xsign1")
@@ -1120,7 +1131,7 @@ endfunc
 " Tests for auto-generating the sign identifier
 func Test_sign_id_autogen()
   enew | only
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
 
   let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
@@ -1129,27 +1140,29 @@ func Test_sign_id_autogen()
   call writefile(repeat(["Sun is shining"], 30), "Xsign")
   edit Xsign
 
-  call assert_equal(1, sign_place(0, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 10}))
-  call assert_equal(2, sign_place(2, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 12}))
-  call assert_equal(3, sign_place(0, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 14}))
-  call sign_unplace('', {'buffer' : 'Xsign', 'id' : 2})
-  call assert_equal(4, sign_place(0, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 12}))
+  call assert_equal([1], sign_place([{'id' : 0, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 10}]))
+  call assert_equal([2], sign_place([{'id' : 2, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 12}]))
+  call assert_equal([3], sign_place([{'name' : 'sign1', 'buffer' : 'Xsign',
+	      \ 'lnum' : 14}]))
+  call sign_unplace([{'buffer' : 'Xsign', 'id' : 2}])
+  call assert_equal([4], sign_place([{'id' : 0, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 12}]))
 
-  call assert_equal(1, sign_place(0, 'g1', 'sign1', 'Xsign',
-	      \ {'lnum' : 11}))
+  call assert_equal([1], sign_place([{'id' : 0, 'group' : 'g1',
+	      \ 'name' : 'sign1', 'buffer' : 'Xsign', 'lnum' : 11}]))
   " Check for the next generated sign id in this group
-  call assert_equal(2, sign_place(0, 'g1', 'sign1', 'Xsign',
-	      \ {'lnum' : 12}))
-  call assert_equal(0, sign_unplace('g1', {'id' : 1}))
-  call assert_equal(10,
-	      \ sign_getplaced('Xsign', {'id' : 1})[0].signs[0].lnum)
+  call assert_equal([2], sign_place([{'id' : 0, 'group' : 'g1',
+	      \ 'name' : 'sign1', 'buffer' : 'Xsign', 'lnum' : 12}]))
+  " Call sign_place() without 'id'
+  call assert_equal([3], sign_place([{'group' : 'g1', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 13}]))
+  call assert_equal([0], sign_unplace([{'group' : 'g1', 'id' : 1}]))
+  call assert_equal(10, sign_getplaced('Xsign', {'id' : 1})[0].lnum)
 
   call delete("Xsign")
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
   enew | only
 endfunc
@@ -1157,7 +1170,7 @@ endfunc
 " Test for sign priority
 func Test_sign_priority()
   enew | only
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
 
   let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Search'}
@@ -1168,341 +1181,322 @@ func Test_sign_priority()
   " Place three signs with different priority in the same line
   call writefile(repeat(["Sun is shining"], 30), "Xsign")
   edit Xsign
+  let bnr = bufnr('')
 
-  call sign_place(1, 'g1', 'sign1', 'Xsign',
-	      \ {'lnum' : 11, 'priority' : 50})
-  call sign_place(2, 'g2', 'sign2', 'Xsign',
-	      \ {'lnum' : 11, 'priority' : 100})
-  call sign_place(3, '', 'sign3', 'Xsign', {'lnum' : 11})
+  call sign_place([{'id' : 1, 'group' : 'g1', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11, 'priority' : 50}])
+  call sign_place([{'id' : 2, 'group' : 'g2', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11, 'priority' : 100}])
+  call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 11, 'group' : 'g2',
-	      \ 'priority' : 100},
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 11, 'group' : 'g1',
-	      \ 'priority' : 50},
-	      \ {'id' : 3, 'name' : 'sign3', 'lnum' : 11, 'group' : '',
-	      \ 'priority' : 10}],
-	      \ s[0].signs)
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 11,
+	      \ 'group' : 'g2', 'priority' : 100},
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 11,
+	      \ 'group' : 'g1', 'priority' : 50},
+	      \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 11,
+	      \ 'group' : '', 'priority' : 10}], s)
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
 
   " Three signs on different lines with changing priorities
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 11, 'priority' : 50})
-  call sign_place(2, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 12, 'priority' : 60})
-  call sign_place(3, '', 'sign3', 'Xsign',
-	      \ {'lnum' : 13, 'priority' : 70})
-  call sign_place(2, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 12, 'priority' : 40})
-  call sign_place(3, '', 'sign3', 'Xsign',
-	      \ {'lnum' : 13, 'priority' : 30})
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 11, 'priority' : 50})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11, 'priority' : 50}])
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 12, 'priority' : 60}])
+  call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 13, 'priority' : 70}])
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 12, 'priority' : 40}])
+  call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 13, 'priority' : 30}])
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11, 'priority' : 50}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 11, 'group' : '',
-	      \ 'priority' : 50},
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 12, 'group' : '',
-	      \ 'priority' : 40},
-	      \ {'id' : 3, 'name' : 'sign3', 'lnum' : 13, 'group' : '',
-	      \ 'priority' : 30}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 11,
+	      \ 'group' : '', 'priority' : 50},
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 12,
+	      \ 'group' : '', 'priority' : 40},
+	      \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 13,
+	      \ 'group' : '', 'priority' : 30}], s)
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
 
   " Two signs on the same line with changing priorities
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 20})
-  call sign_place(2, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 30})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 30}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 30},
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20}],
-	      \ s[0].signs)
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 30},
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20}], s)
   " Change the priority of the last sign to highest
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 40})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 40}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 40},
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 30}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 40},
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 30}], s)
   " Change the priority of the first sign to lowest
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 25})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 25}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 30},
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 25}],
-	      \ s[0].signs)
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 45})
-  call sign_place(2, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 55})
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 30},
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 25}], s)
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 45}])
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 55}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 55},
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 45}],
-	      \ s[0].signs)
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 55},
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 45}], s)
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
 
   " Three signs on the same line with changing priorities
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 40})
-  call sign_place(2, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 30})
-  call sign_place(3, '', 'sign3', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 20})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 40}])
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 30}])
+  call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 40},
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 30},
-	      \ {'id' : 3, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 40},
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 30},
+	      \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20}], s)
 
   " Change the priority of the middle sign to the highest
-  call sign_place(2, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 50})
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 50}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 50},
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 40},
-	      \ {'id' : 3, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20}],
-	      \ s[0].signs)
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 50},
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 40},
+	      \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20}], s)
 
   " Change the priority of the middle sign to the lowest
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 15})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 15}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 50},
-	      \ {'id' : 3, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20},
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 15}],
-	      \ s[0].signs)
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 50},
+	      \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 15}], s)
 
   " Change the priority of the last sign to the highest
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 55})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 55}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 55},
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 50},
-	      \ {'id' : 3, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 55},
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 50},
+	      \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20}], s)
 
   " Change the priority of the first sign to the lowest
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 15})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 15}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 50},
-	      \ {'id' : 3, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20},
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 15}],
-	      \ s[0].signs)
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 50},
+	      \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 15}], s)
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
 
   " Three signs on the same line with changing priorities along with other
   " signs
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 2, 'priority' : 10})
-  call sign_place(2, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 30})
-  call sign_place(3, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 20})
-  call sign_place(4, '', 'sign3', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 25})
-  call sign_place(5, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 6, 'priority' : 80})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 2, 'priority' : 10}])
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 30}])
+  call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
+  call sign_place([{'id' : 4, 'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 25}])
+  call sign_place([{'id' : 5, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 6, 'priority' : 80}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 2, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 2, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 30},
-	      \ {'id' : 4, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 25},
-	      \ {'id' : 3, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20},
-	      \ {'id' : 5, 'name' : 'sign2', 'lnum' : 6, 'group' : '',
-	      \ 'priority' : 80}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 2, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 30},
+	      \ {'id' : 4, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 25},
+	      \ {'id' : 3, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+	      \ {'id' : 5, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 6,
+	      \ 'group' : '', 'priority' : 80}], s)
 
   " Change the priority of the first sign to lowest
-  call sign_place(2, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 15})
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 15}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 2, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 4, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 25},
-	      \ {'id' : 3, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20},
-	      \ {'id' : 2, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 15},
-	      \ {'id' : 5, 'name' : 'sign2', 'lnum' : 6, 'group' : '',
-	      \ 'priority' : 80}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 4, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 25},
+	      \ {'id' : 3, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+	      \ {'id' : 2, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 15},
+	      \ {'id' : 5, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 6,
+	      \ 'group' : '', 'priority' : 80}], s)
 
   " Change the priority of the last sign to highest
-  call sign_place(2, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 30})
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 30}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 2, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 2, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 30},
-	      \ {'id' : 4, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 25},
-	      \ {'id' : 3, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20},
-	      \ {'id' : 5, 'name' : 'sign2', 'lnum' : 6, 'group' : '',
-	      \ 'priority' : 80}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 2, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 30},
+	      \ {'id' : 4, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 25},
+	      \ {'id' : 3, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+	      \ {'id' : 5, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 6,
+	      \ 'group' : '', 'priority' : 80}], s)
 
   " Change the priority of the middle sign to lowest
-  call sign_place(4, '', 'sign3', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 15})
+  call sign_place([{'id' : 4, 'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 15}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 2, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 2, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 30},
-	      \ {'id' : 3, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 20},
-	      \ {'id' : 4, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 15},
-	      \ {'id' : 5, 'name' : 'sign2', 'lnum' : 6, 'group' : '',
-	      \ 'priority' : 80}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 2, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 30},
+	      \ {'id' : 3, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+	      \ {'id' : 4, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 15},
+	      \ {'id' : 5, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 6,
+	      \ 'group' : '', 'priority' : 80}], s)
 
   " Change the priority of the middle sign to highest
-  call sign_place(3, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 4, 'priority' : 35})
+  call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 35}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign1', 'lnum' : 2, 'group' : '',
-	      \ 'priority' : 10},
-	      \ {'id' : 3, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 35},
-	      \ {'id' : 2, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 30},
-	      \ {'id' : 4, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-	      \ 'priority' : 15},
-	      \ {'id' : 5, 'name' : 'sign2', 'lnum' : 6, 'group' : '',
-	      \ 'priority' : 80}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 2,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 3, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 35},
+	      \ {'id' : 2, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 30},
+	      \ {'id' : 4, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 15},
+	      \ {'id' : 5, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 6,
+	      \ 'group' : '', 'priority' : 80}], s)
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
 
   " Multiple signs with the same priority on the same line
-  call sign_place(1, '', 'sign1', 'Xsign',
-              \ {'lnum' : 4, 'priority' : 20})
-  call sign_place(2, '', 'sign2', 'Xsign',
-              \ {'lnum' : 4, 'priority' : 20})
-  call sign_place(3, '', 'sign3', 'Xsign',
-              \ {'lnum' : 4, 'priority' : 20})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
+  call sign_place([{'id' : 2, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
+  call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-              \ {'id' : 3, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20},
-              \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20},
-              \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20}],
-              \ s[0].signs)
+              \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+              \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+              \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20}], s)
   " Place the last sign again with the same priority
-  call sign_place(1, '', 'sign1', 'Xsign',
-              \ {'lnum' : 4, 'priority' : 20})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-              \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20},
-              \ {'id' : 3, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20},
-              \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20}],
-              \ s[0].signs)
+              \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+              \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+              \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20}], s)
   " Place the first sign again with the same priority
-  call sign_place(1, '', 'sign1', 'Xsign',
-              \ {'lnum' : 4, 'priority' : 20})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-              \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20},
-              \ {'id' : 3, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20},
-              \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20}],
-              \ s[0].signs)
+              \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+              \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+              \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20}], s)
   " Place the middle sign again with the same priority
-  call sign_place(3, '', 'sign3', 'Xsign',
-              \ {'lnum' : 4, 'priority' : 20})
+  call sign_place([{'id' : 3, 'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 4, 'priority' : 20}])
   let s = sign_getplaced('Xsign', {'group' : '*'})
   call assert_equal([
-              \ {'id' : 3, 'name' : 'sign3', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20},
-              \ {'id' : 1, 'name' : 'sign1', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20},
-              \ {'id' : 2, 'name' : 'sign2', 'lnum' : 4, 'group' : '',
-              \ 'priority' : 20}],
-              \ s[0].signs)
+              \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+              \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20},
+              \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 4,
+	      \ 'group' : '', 'priority' : 20}], s)
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
 
   " Place multiple signs with same id on a line with different priority
-  call sign_place(1, '', 'sign1', 'Xsign',
-	      \ {'lnum' : 5, 'priority' : 20})
-  call sign_place(1, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 5, 'priority' : 10})
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 5, 'priority' : 20}])
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 5, 'priority' : 10}])
   let s = sign_getplaced('Xsign', {'lnum' : 5})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign2', 'lnum' : 5, 'group' : '',
-	      \ 'priority' : 10}],
-	      \ s[0].signs)
-  call sign_place(1, '', 'sign2', 'Xsign',
-	      \ {'lnum' : 5, 'priority' : 5})
+	      \ {'id' : 1, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 5,
+	      \ 'group' : '', 'priority' : 10}], s)
+  call sign_place([{'id' : 1, 'group' : '', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 5, 'priority' : 5}])
   let s = sign_getplaced('Xsign', {'lnum' : 5})
   call assert_equal([
-	      \ {'id' : 1, 'name' : 'sign2', 'lnum' : 5, 'group' : '',
-	      \ 'priority' : 5}],
-	      \ s[0].signs)
+	      \ {'id' : 1, 'name' : 'sign2', 'buffer' : bnr, 'lnum' : 5,
+	      \ 'group' : '', 'priority' : 5}], s)
 
   " Error case
-  call assert_fails("call sign_place(1, 'g1', 'sign1', 'Xsign',
-	      \ [])", 'E715:')
-  call assert_fails("call sign_place(1, 'g1', 'sign1', 'Xsign',
-	      \ {'priority' : []})", 'E745:')
-  call sign_unplace('*')
+  call assert_fails("call sign_place([{'id' : 1, 'group' : 'g1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 10, 'priority' : 1.2}])", 'E805:')
+  call assert_fails("call sign_place([{'id' : 1, 'group' : 'g1',
+	      \ 'name' : 'sign1', 'buffer' : 'Xsign', 'priority' : []}])",
+	      \ 'E745:')
+  call sign_unplace([{'group' : '*'}])
 
   " Tests for the :sign place command with priority
   sign place 5 line=10 name=sign1 priority=30 file=Xsign
@@ -1519,7 +1513,7 @@ func Test_sign_priority()
   call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
 	      \ "    line=10  id=5  group=g1  name=sign1  priority=20\n", a)
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
   enew | only
   call delete("Xsign")
@@ -1543,25 +1537,23 @@ func Test_sign_memfailures()
   call test_alloc_fail(GetAllocId('sign_getlist'), 0, 0)
   call assert_fails('call sign_getdefined("sign1")', 'E342:')
 
-  call sign_place(3, 'g1', 'sign1', 'Xsign', {'lnum' : 10})
-  call test_alloc_fail(GetAllocId('sign_getplaced_dict'), 0, 0)
-  call assert_fails('call sign_getplaced("Xsign")', 'E342:')
-  call test_alloc_fail(GetAllocId('sign_getplaced_list'), 0, 0)
-  call assert_fails('call sign_getplaced("Xsign")', 'E342:')
+  call sign_place([{'id' : 3, 'group' : 'g1', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 10}])
 
   call test_alloc_fail(GetAllocId('insert_sign'), 0, 0)
-  call assert_fails('call sign_place(4, "g1", "sign1", "Xsign", {"lnum" : 11})',
-								\ 'E342:')
+  call assert_fails('call sign_place([{"id" : 4, "group" : "g1", "name" :
+	      \ "sign1", "buffer" : "Xsign", "lnum" : 11}])', 'E342:')
 
   call test_alloc_fail(GetAllocId('sign_getinfo'), 0, 0)
   call assert_fails('call getbufinfo()', 'E342:')
-  call sign_place(4, 'g1', 'sign1', 'Xsign', {'lnum' : 11})
+  call sign_place([{'id' : 4, 'group' : 'g1', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11}])
   call test_alloc_fail(GetAllocId('sign_getinfo'), 0, 0)
   call assert_fails('let binfo=getbufinfo("Xsign")', 'E342:')
   call assert_equal([{'lnum': 11, 'id': 4, 'name': 'sign1',
 	      \ 'priority': 10, 'group': 'g1'}], binfo[0].signs)
 
-  call sign_unplace('*')
+  call sign_unplace([{'group' : '*'}])
   call sign_undefine()
   enew | only
   call delete("Xsign")
@@ -1575,27 +1567,27 @@ func Test_sign_lnum_adjust()
   call setline(1, ['A', 'B', 'C', 'D', 'E'])
   exe 'sign place 5 line=3 name=sign1 buffer=' . bufnr('')
   let l = sign_getplaced(bufnr(''))
-  call assert_equal(3, l[0].signs[0].lnum)
+  call assert_equal(3, l[0].lnum)
 
   " Add some lines before the sign and check the sign line number
   call append(2, ['BA', 'BB', 'BC'])
   let l = sign_getplaced(bufnr(''))
-  call assert_equal(6, l[0].signs[0].lnum)
+  call assert_equal(6, l[0].lnum)
 
   " Delete some lines before the sign and check the sign line number
   call deletebufline('%', 1, 2)
   let l = sign_getplaced(bufnr(''))
-  call assert_equal(4, l[0].signs[0].lnum)
+  call assert_equal(4, l[0].lnum)
 
   " Insert some lines after the sign and check the sign line number
   call append(5, ['DA', 'DB'])
   let l = sign_getplaced(bufnr(''))
-  call assert_equal(4, l[0].signs[0].lnum)
+  call assert_equal(4, l[0].lnum)
 
   " Delete some lines after the sign and check the sign line number
   call deletebufline('', 6, 7)
   let l = sign_getplaced(bufnr(''))
-  call assert_equal(4, l[0].signs[0].lnum)
+  call assert_equal(4, l[0].lnum)
 
   " Break the undo. Otherwise the undo operation below will undo all the
   " changes made by this function.
@@ -1604,12 +1596,12 @@ func Test_sign_lnum_adjust()
   " Delete the line with the sign
   call deletebufline('', 4)
   let l = sign_getplaced(bufnr(''))
-  call assert_equal(4, l[0].signs[0].lnum)
+  call assert_equal(4, l[0].lnum)
 
   " Undo the delete operation
   undo
   let l = sign_getplaced(bufnr(''))
-  call assert_equal(5, l[0].signs[0].lnum)
+  call assert_equal(5, l[0].lnum)
 
   " Break the undo
   let &undolevels=&undolevels
@@ -1618,12 +1610,12 @@ func Test_sign_lnum_adjust()
   " Sign line number should not change (as it is placed outside of the buffer)
   call deletebufline('', 3, 6)
   let l = sign_getplaced(bufnr(''))
-  call assert_equal(5, l[0].signs[0].lnum)
+  call assert_equal(5, l[0].lnum)
 
   " Undo the delete operation. Sign should be restored to the previous line
   undo
   let l = sign_getplaced(bufnr(''))
-  call assert_equal(5, l[0].signs[0].lnum)
+  call assert_equal(5, l[0].lnum)
 
   sign unplace * group=*
   sign undefine sign1
@@ -1640,23 +1632,24 @@ func Test_sign_change_type()
   call setline(1, ['A', 'B', 'C', 'D'])
   exe 'sign place 4 line=3 name=sign1 buffer=' . bufnr('')
   let l = sign_getplaced(bufnr(''))
-  call assert_equal('sign1', l[0].signs[0].name)
+  call assert_equal('sign1', l[0].name)
   exe 'sign place 4 name=sign2 buffer=' . bufnr('')
   let l = sign_getplaced(bufnr(''))
-  call assert_equal('sign2', l[0].signs[0].name)
-  call sign_place(4, '', 'sign1', '')
+  call assert_equal('sign2', l[0].name)
+  call sign_place([{'id' : 4, 'group' : '', 'name' : 'sign1', 'buffer' : ''}])
   let l = sign_getplaced(bufnr(''))
-  call assert_equal('sign1', l[0].signs[0].name)
+  call assert_equal('sign1', l[0].name)
 
   exe 'sign place 4 group=g1 line=4 name=sign1 buffer=' . bufnr('')
   let l = sign_getplaced(bufnr(''), {'group' : 'g1'})
-  call assert_equal('sign1', l[0].signs[0].name)
+  call assert_equal('sign1', l[0].name)
   exe 'sign place 4 group=g1 name=sign2 buffer=' . bufnr('')
   let l = sign_getplaced(bufnr(''), {'group' : 'g1'})
-  call assert_equal('sign2', l[0].signs[0].name)
-  call sign_place(4, 'g1', 'sign1', '')
+  call assert_equal('sign2', l[0].name)
+  call sign_place([{'id' : 4, 'group' : 'g1', 'name' : 'sign1',
+	      \ 'buffer' : ''}])
   let l = sign_getplaced(bufnr(''), {'group' : 'g1'})
-  call assert_equal('sign1', l[0].signs[0].name)
+  call assert_equal('sign1', l[0].name)
 
   sign unplace * group=*
   sign undefine sign1
@@ -1673,17 +1666,25 @@ func Test_sign_jump_func()
   edit foo
   set buftype=nofile
   call setline(1, ['A', 'B', 'C', 'D', 'E'])
-  call sign_place(5, '', 'sign1', '', {'lnum' : 2})
-  call sign_place(5, 'g1', 'sign1', '', {'lnum' : 3})
-  call sign_place(6, '', 'sign1', '', {'lnum' : 4})
-  call sign_place(6, 'g1', 'sign1', '', {'lnum' : 5})
+  call sign_place([{'id' : 5, 'group' : '', 'name' : 'sign1', 'buffer' : '',
+	      \ 'lnum' : 2}])
+  call sign_place([{'id' : 5, 'group' : 'g1', 'name' : 'sign1', 'buffer' : '',
+	      \ 'lnum' : 3}])
+  call sign_place([{'id' : 6, 'group' : '', 'name' : 'sign1', 'buffer' : '',
+	      \ 'lnum' : 4}])
+  call sign_place([{'id' : 6, 'group' : 'g1', 'name' : 'sign1', 'buffer' : '',
+	      \ 'lnum' : 5}])
   split bar
   set buftype=nofile
   call setline(1, ['P', 'Q', 'R', 'S', 'T'])
-  call sign_place(5, '', 'sign1', '', {'lnum' : 2})
-  call sign_place(5, 'g1', 'sign1', '', {'lnum' : 3})
-  call sign_place(6, '', 'sign1', '', {'lnum' : 4})
-  call sign_place(6, 'g1', 'sign1', '', {'lnum' : 5})
+  call sign_place([{'id' : 5, 'group' : '', 'name' : 'sign1', 'buffer' : '',
+	      \ 'lnum' : 2}])
+  call sign_place([{'id' : 5, 'group' : 'g1', 'name' : 'sign1', 'buffer' : '',
+	      \ 'lnum' : 3}])
+  call sign_place([{'id' : 6, 'group' : '', 'name' : 'sign1', 'buffer' : '',
+	      \ 'lnum' : 4}])
+  call sign_place([{'id' : 6, 'group' : 'g1', 'name' : 'sign1', 'buffer' : '',
+	      \ 'lnum' : 5}])
 
   let r = sign_jump(5, '', 'foo')
   call assert_equal(2, r)
@@ -1792,4 +1793,60 @@ func Test_sign_numcol()
   set signcolumn&
   set number&
   enew!  | close
+endfunc
+
+" Test for placing multiple signs using the sign_place() function
+func Test_sign_place_multi()
+  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Search'}
+  call sign_define("sign1", attr)
+  call sign_define("sign2", attr)
+  call sign_define("sign3", attr)
+  call writefile(repeat(["Sun is shining"], 30), "Xsign")
+  edit Xsign
+  let bnum = bufnr('')
+
+  let l = sign_place([{'id' : 1, 'group' : 'g1', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11, 'priority' : 50},
+	      \ {'id' : 2, 'group' : 'g2', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11, 'priority' : 100},
+	      \ {'id' : 3, 'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11}])
+  call assert_equal([1, 2, 3], l)
+  let s = sign_getplaced('Xsign', {'group' : '*'})
+  call assert_equal([
+	      \ {'id' : 2, 'name' : 'sign2', 'buffer' : bnum, 'lnum' : 11,
+	      \ 'group' : 'g2', 'priority' : 100},
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 11,
+	      \ 'group' : 'g1', 'priority' : 50},
+	      \ {'id' : 3, 'name' : 'sign3', 'buffer' : bnum, 'lnum' : 11,
+	      \ 'group' : '', 'priority' : 10}], s)
+
+  call sign_unplace([{'group' : '*'}])
+
+  let l = sign_place([{'group' : 'g1', 'name' : 'sign1',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11},
+	      \ {'group' : 'g2', 'name' : 'sign2',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11},
+	      \ {'group' : '', 'name' : 'sign3',
+	      \ 'buffer' : 'Xsign', 'lnum' : 11}])
+  call assert_equal([1, 1, 5], l)
+  let s = sign_getplaced('Xsign', {'group' : '*'})
+  call assert_equal([
+	      \ {'id' : 5, 'name' : 'sign3', 'buffer' : bnum, 'lnum' : 11,
+	      \ 'group' : '', 'priority' : 10},
+	      \ {'id' : 1, 'name' : 'sign2', 'buffer' : bnum, 'lnum' : 11,
+	      \ 'group' : 'g2', 'priority' : 10},
+	      \ {'id' : 1, 'name' : 'sign1', 'buffer' : bnum, 'lnum' : 11,
+	      \ 'group' : 'g1', 'priority' : 10}], s)
+
+  " Invalid arguments
+  call assert_fails('call sign_place({})', "E474:")
+  call assert_fails('call sign_place([{}, {}])', 'E474:')
+  call assert_fails('call sign_place([1, {}, [], "abc"])', 'E474:')
+  call assert_equal([], sign_place([]))
+
+  call sign_unplace([{'group' : '*'}])
+  call sign_undefine()
+  enew!
+  call delete("Xsign")
 endfunc

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -507,6 +507,17 @@ func Test_sign_funcs()
   " Unplace signs in the current buffer
   call assert_equal([0, 0], sign_unplace([{'id' : 10}, {'id' : 20}]))
   call assert_equal([], sign_getplaced('Xsign'))
+  " Unplace all signs in the global group
+  call sign_place([{'id' : 10, 'name' : 'sign1', 'lnum' : 20},
+              \ {'id' : 10, 'name' : 'sign1', 'group' : 'g1', 'lnum' : 21},
+              \ {'id' : 10, 'name' : 'sign1', 'group' : 'g2', 'lnum' : 22},
+              \ {'id' : 20, 'name' : 'sign1', 'lnum' : 23}])
+  call sign_unplace([{}])
+  let l = sign_getplaced(bnr, {'group' : '*'})
+  call assert_equal(2, len(l))
+  call assert_equal(['g1', 'g2'], [l[0].group, l[1].group])
+  call sign_unplace([{'group' : '*'}])
+  call assert_equal([], sign_getplaced(bnr, {'group' : '*'}))
 
   " Tests for sign_undefine()
   call assert_equal(0, sign_undefine("sign1"))


### PR DESCRIPTION
Add support for adding multiple signs using sign_place() and removing multiple signs
using sign_unplace().  Modify the return value of sign_getplaced() to match that of 
the argument passed to sign_place().

Note that this is not a backward compatible changes.
