### PR TITLE
Fix test_mapping / test_timers broken in GUI tests

### DIFF
--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -284,6 +284,13 @@ func GetVimCommandClean()
   return cmd
 endfunc
 
+" Get the command to run Vim, with --clean, and force to run in terminal so it
+" won't start a new GUI.
+func GetVimCommandCleanTerm()
+  " Add -v to have gvim run in the terminal (if possible)
+  return GetVimCommandClean() .. ' -v '
+endfunc
+
 " Run Vim, using the "vimcmd" file and "-u NORC".
 " "before" is a list of Vim commands to be executed before loading plugins.
 " "after" is a list of Vim commands to be executed after loading plugins.

--- a/src/testdir/term_util.vim
+++ b/src/testdir/term_util.vim
@@ -59,10 +59,9 @@ func RunVimInTerminal(arguments, options)
   let cols = get(a:options, 'cols', 75)
   let statusoff = get(a:options, 'statusoff', 1)
 
-  let cmd = GetVimCommandClean()
+  let cmd = GetVimCommandCleanTerm()
 
-  " Add -v to have gvim run in the terminal (if possible)
-  let cmd .= ' -v ' . a:arguments
+  let cmd .= a:arguments
   let buf = term_start(cmd, {
 	\ 'curwin': 1,
 	\ 'term_rows': rows,

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -413,7 +413,7 @@ func Test_error_in_map_expr()
   [CODE]
   call writefile(lines, 'Xtest.vim')
 
-  let buf = term_start(GetVimCommandClean() .. ' -S Xtest.vim', {'term_rows': 8})
+  let buf = term_start(GetVimCommandCleanTerm() .. ' -S Xtest.vim', {'term_rows': 8})
   let job = term_getjob(buf)
   call WaitForAssert({-> assert_notequal('', term_getline(buf, 8))})
 

--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -348,7 +348,7 @@ func Test_error_in_timer_callback()
   [CODE]
   call writefile(lines, 'Xtest.vim')
 
-  let buf = term_start(GetVimCommandClean() .. ' -S Xtest.vim', {'term_rows': 8})
+  let buf = term_start(GetVimCommandCleanTerm() .. ' -S Xtest.vim', {'term_rows': 8})
   let job = term_getjob(buf)
   call WaitForAssert({-> assert_notequal('', term_getline(buf, 8))})
 


### PR DESCRIPTION
Previously, the test `Test_error_in_map_expr` (`test_mapping.vim`) and `Test_error_in_timer_callback` (`test_timers`) were broken in GUI (`make testgui`), because they were using `term_start` to start Vim but `GetVimCommandClean()` returns a command that will start a GUI version of Vim . Add a new utility `GetVimCommandCleanTerm()` that will add "-v" to the Vim command to force it to start in terminal mode, similar to `RunVimInTerminal()`.

Another option is to either just use `RunVimInTerminal()` but that function does more than simply running a Vim command in terminal and requires more changes than this.
