### PR TITLE
Problem: Amiga: Out of stack in common use cases.

### DIFF
--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -61,6 +61,17 @@
 #endif /* PROTO */
 
 /*
+ * Set stack size to 1 MiB on NG systems. This should be enough even for
+ * hungry syntax HL / plugin combinations. Leave the stack alone on OS 3
+ * and below, those systems might be low on memory.
+ */
+#if defined(__amigaos4__)
+static const char* __attribute__((used)) stackcookie = "$STACK: 1048576";
+#elif defined(__AROS__) || defined(__MORPHOS__)
+unsigned long __stack = 1048576;
+#endif
+
+/*
  * At this point TRUE and FALSE are defined as 1L and 0L, but we want 1 and 0.
  */
 #undef	TRUE


### PR DESCRIPTION
Solution: Add stack cookie on systems that can afford it.