### PR TITLE
Fix the definition line number

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -3270,7 +3270,8 @@ cmd_source(char_u *fname, exarg_T *eap)
 struct source_cookie
 {
     FILE	*fp;		/* opened file for sourcing */
-    char_u      *nextline;      /* if not NULL: line that was read ahead */
+    char_u	*nextline;      /* if not NULL: line that was read ahead */
+    linenr_T	sourcing_lnum;	/* line number of the source file */
     int		finished;	/* ":finish" used */
 #ifdef USE_CRNL
     int		fileformat;	/* EOL_UNKNOWN, EOL_UNIX or EOL_DOS */
@@ -3345,7 +3346,6 @@ fopen_noinh_readbin(char *filename)
     return fdopen(fd_tmp, READBIN);
 }
 #endif
-
 
 /*
  * do_source: Read the file "fname" and execute its lines as EX commands.
@@ -3495,6 +3495,7 @@ do_source(
 #endif
 
     cookie.nextline = NULL;
+    cookie.sourcing_lnum = 0;
     cookie.finished = FALSE;
 
 #ifdef FEAT_EVAL
@@ -3790,6 +3791,14 @@ free_scriptnames(void)
 
 #endif
 
+    linenr_T
+get_sourced_lnum(char_u *(*fgetline)(int, void *, int, int), void *cookie)
+{
+    return fgetline == getsourceline
+			? ((struct source_cookie *)cookie)->sourcing_lnum
+			: sourcing_lnum;
+}
+
 /*
  * Get one full line from a sourced file.
  * Called by do_cmdline() when it's called from do_source().
@@ -3816,6 +3825,10 @@ getsourceline(int c UNUSED, void *cookie, int indent UNUSED, int do_concat)
 	script_line_end();
 # endif
 #endif
+
+    // Set the current sourcing line numner.
+    sourcing_lnum = sp->sourcing_lnum + 1;
+
     /*
      * Get current line.  If there is a read-ahead line, use it, otherwise get
      * one now.
@@ -3828,7 +3841,7 @@ getsourceline(int c UNUSED, void *cookie, int indent UNUSED, int do_concat)
     {
 	line = sp->nextline;
 	sp->nextline = NULL;
-	++sourcing_lnum;
+	++sp->sourcing_lnum;
     }
 #ifdef FEAT_PROFILE
     if (line != NULL && do_profiling == PROF_YES)
@@ -3840,7 +3853,7 @@ getsourceline(int c UNUSED, void *cookie, int indent UNUSED, int do_concat)
     if (line != NULL && do_concat && vim_strchr(p_cpo, CPO_CONCAT) == NULL)
     {
 	/* compensate for the one line read-ahead */
-	--sourcing_lnum;
+	--sp->sourcing_lnum;
 
 	// Get the next line and concatenate it when it starts with a
 	// backslash. We always need to read the next line, keep it in
@@ -3931,7 +3944,7 @@ get_one_sourceline(struct source_cookie *sp)
     /*
      * Loop until there is a finished line (or end-of-file).
      */
-    sourcing_lnum++;
+    ++sp->sourcing_lnum;
     for (;;)
     {
 	/* make room to read at least 120 (more) characters */
@@ -4001,7 +4014,7 @@ get_one_sourceline(struct source_cookie *sp)
 		;
 	    if ((len & 1) != (c & 1))	/* escaped NL, read more */
 	    {
-		sourcing_lnum++;
+		++sp->sourcing_lnum;
 		continue;
 	    }
 

--- a/src/proto/ex_cmds2.pro
+++ b/src/proto/ex_cmds2.pro
@@ -81,6 +81,7 @@ void ex_scriptnames(exarg_T *eap);
 void scriptnames_slash_adjust(void);
 char_u *get_scriptname(scid_T id);
 void free_scriptnames(void);
+linenr_T get_sourced_lnum(char_u *(*fgetline)(int, void *, int, int), void *cookie);
 char_u *getsourceline(int c, void *cookie, int indent, int do_concat);
 void script_line_start(void);
 void script_line_exec(void);

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -1676,6 +1676,76 @@ func Test_funccall_garbage_collect()
     delfunc Func
 endfunc
 
+func Test_function_defined_line()
+    if has('gui_running')
+        " Can't catch the output of gvim.
+        return
+    endif
+
+    let lines =<< trim [CODE]
+    " F1
+    func F1()
+        " F2
+        func F2()
+            "
+            "
+            "
+            return
+        endfunc
+        " F3
+        execute "func F3()\n\n\n\nreturn\nendfunc"
+        " F4
+        execute "func F4()\n
+                    \\n
+                    \\n
+                    \\n
+                    \return\n
+                    \endfunc"
+    endfunc
+    " F5
+    execute "func F5()\n\n\n\nreturn\nendfunc"
+    " F6
+    execute "func F6()\n
+                \\n
+                \\n
+                \\n
+                \return\n
+                \endfunc"
+    call F1()
+    verbose func F1
+    verbose func F2
+    verbose func F3
+    verbose func F4
+    verbose func F5
+    verbose func F6
+    qall!
+    [CODE]
+
+    call writefile(lines, 'Xtest.vim')
+    let res = system(v:progpath .. ' --clean -es -X -S Xtest.vim')
+    call assert_equal(0, v:shell_error)
+
+    let m = matchstr(res, 'function F1()[^[:print:]]*[[:print:]]*')
+    call assert_match(' line 2$', m)
+
+    let m = matchstr(res, 'function F2()[^[:print:]]*[[:print:]]*')
+    call assert_match(' line 4$', m)
+
+    let m = matchstr(res, 'function F3()[^[:print:]]*[[:print:]]*')
+    call assert_match(' line 11$', m)
+
+    let m = matchstr(res, 'function F4()[^[:print:]]*[[:print:]]*')
+    call assert_match(' line 13$', m)
+
+    let m = matchstr(res, 'function F5()[^[:print:]]*[[:print:]]*')
+    call assert_match(' line 21$', m)
+
+    let m = matchstr(res, 'function F6()[^[:print:]]*[[:print:]]*')
+    call assert_match(' line 23$', m)
+
+    call delete('Xtest.vim')
+endfunc
+
 "-------------------------------------------------------------------------------
 " Modelines								    {{{1
 " vim: ts=8 sw=4 tw=80 fdm=marker

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2008,8 +2008,8 @@ ex_function(exarg_T *eap)
     int		todo;
     hashitem_T	*hi;
     int		do_concat = TRUE;
-    int		sourcing_lnum_off;
-    int		sourcing_lnum_top = sourcing_lnum;
+    linenr_T	sourcing_lnum_off;
+    linenr_T	sourcing_lnum_top;
 
     /*
      * ":function" without argument: list functions.
@@ -2276,6 +2276,9 @@ ex_function(exarg_T *eap)
 	cmdline_row = msg_row;
     }
 
+    // Save the starting line number.
+    sourcing_lnum_top = sourcing_lnum;
+
     indent = 2;
     nesting = 0;
     for (;;)
@@ -2286,7 +2289,6 @@ ex_function(exarg_T *eap)
 	    saved_wait_return = FALSE;
 	}
 	need_wait_return = FALSE;
-	sourcing_lnum_off = sourcing_lnum;
 
 	if (line_arg != NULL)
 	{
@@ -2319,8 +2321,9 @@ ex_function(exarg_T *eap)
 	}
 
 	/* Detect line continuation: sourcing_lnum increased more than one. */
-	if (sourcing_lnum > sourcing_lnum_off + 1)
-	    sourcing_lnum_off = sourcing_lnum - sourcing_lnum_off - 1;
+	sourcing_lnum_off = get_sourced_lnum(eap->getline, eap->cookie);
+	if (sourcing_lnum < sourcing_lnum_off)
+	    sourcing_lnum_off -= sourcing_lnum;
 	else
 	    sourcing_lnum_off = 0;
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2009,6 +2009,7 @@ ex_function(exarg_T *eap)
     hashitem_T	*hi;
     int		do_concat = TRUE;
     int		sourcing_lnum_off;
+    int		sourcing_lnum_top = sourcing_lnum;
 
     /*
      * ":function" without argument: list functions.
@@ -2670,7 +2671,7 @@ ex_function(exarg_T *eap)
     fp->uf_flags = flags;
     fp->uf_calls = 0;
     fp->uf_script_ctx = current_sctx;
-    fp->uf_script_ctx.sc_lnum += sourcing_lnum - newlines.ga_len - 1;
+    fp->uf_script_ctx.sc_lnum += sourcing_lnum_top;
     goto ret_free;
 
 erret:


### PR DESCRIPTION
Fixes #4511 

## Case 1: Defining function in function

case1.vim
```vim
func! F1()
  let x =<< trim [CODE]
  func! F2()
    return
  endfunc
  [CODE]
  call execute(join(x, "\n"))
endfunc
call F1()
```

```
vim --clean -S case1.vim
:verbose func F2
   function F2()
        Last set from /path/to/case1.vim line 5
1    return
   endfunction
```

but expected is line 7.

### Cause

The definition line is calculated as below (in `ex_function()`):
```c
    fp->uf_script_ctx.sc_lnum += sourcing_lnum - newlines.ga_len - 1;
```

On case1.vim, `sourcing_lnum` points to the line of `call execute(...)` (line 7) and `newlines.ga_len` is 1, then we get the wrong value.

### Solution

Save the first value of `sourcing_lnum` when entering into `ex_function()` and use it.

## Case 2: Defining function (and command, map, ...) with line-continuation on top-level of the source

case2.vim
```vim
execute "func F1()\n
      \  return\n
      \endfunc\n"
execute "func F2()\nreturn\nendfunc"
command
      \ F
      \ echo "hello"
map
      \ F
      \ :echo "hello"<CR>
set
      \ autochdir
```

```
vim --clean -S case2.vim
:verbose func F1
   function F1()
        Last set from /path/to/case2.vim line 1
1    return
   endfunction

:verbose func F2
   function F2()
        Last set from /path/to/case2.vim line 2
1  return
   endfunction

:verbose command F
    Name              Args Address Complete    Definition
    F                 0                        echo "hello"
        Last set from /path/to/case2.vim line 7

:verbose map F
   F             :echo "hello"<CR>
        Last set from /path/to/case2.vim line 10

:verbose set autochdir?
  autochdir
        Last set from /path/to/case2.vim line 12
```

`verbose func F1` is OK, but others are not... I think each of the expected (reasonable) values are line 4, 5, 8, 11. These are the first line of line-continuation.

```vim
command                 " L5 <- expected
      \ F               " L6
      \ echo "hello"    " L7 <- actual
```

And when applying the solution of case 1, the result of F1 and F2 change:

```
:verbose func F1
   function F1()
        Last set from /path/to/case2.vim line 3
1    return
   endfunction

:verbose func F2
   function F2()
        Last set from /path/to/case2.vim line 4
1  return
   endfunction
```

`verbose func F2` becomes OK, but `verbose func F1` is not.

### Cause

When evaluating the line(s), `sourcing_lnum` points to the last line of line-continuation:

```vim
execute "func F1()\n    " L1
      \  return\n       " L2
      \endfunc\n"       " L3 <- sourcing_lnum
```

## Solution

Add `sourcing_lnum` to `struct source_cookie` and make the global `sourcing_lnum` points to the first line of line-continuation when evaluating the script.

```vim
execute "func F1()\n    " L1 <- sourcing_lnum (global)
      \  return\n       " L2
      \endfunc\n"       " L3 <- source_cookie.sourcing_lnum
```