### PR TITLE
Fixed link error in vim tiny with -DEXITFREE

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1193,7 +1193,9 @@ free_all_mem(void)
 	    buf = firstbuf;
     }
 
+#ifdef FEAT_ARABIC
     free_cmdline_buf();
+#endif
 
     /* Clear registers. */
     clear_registers();


### PR DESCRIPTION
This PR fixes the following link error in Vim tiny 8.1.1631
when building with -DEXITFREE:

```
misc2.c:1196: undefined reference to `free_cmdline_buf'
```