### PR TITLE
Improve autoload_name() processing

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -9219,23 +9219,25 @@ find_option_end(char_u **arg, int *opt_flags)
 /*
  * Return the autoload script name for a function or variable name.
  * Returns NULL when out of memory.
+ * Caller must make sure that "name" contains AUTOLOAD_CHAR.
  */
     char_u *
 autoload_name(char_u *name)
 {
-    char_u	*p;
+    char_u	*p, *q = NULL;
     char_u	*scriptname;
 
-    /* Get the script file name: replace '#' with '/', append ".vim". */
+    // Get the script file name: replace '#' with '/', append ".vim".
     scriptname = alloc(STRLEN(name) + 14);
     if (scriptname == NULL)
 	return FALSE;
     STRCPY(scriptname, "autoload/");
     STRCAT(scriptname, name);
-    *vim_strrchr(scriptname, AUTOLOAD_CHAR) = NUL;
-    STRCAT(scriptname, ".vim");
-    while ((p = vim_strchr(scriptname, AUTOLOAD_CHAR)) != NULL)
-	*p = '/';
+    p = scriptname + 9;
+    while ((p = vim_strchr(p, AUTOLOAD_CHAR)) != NULL)
+	*(q = p++) = '/';
+    if (q != NULL)
+	STRCPY(q, ".vim");
     return scriptname;
 }
 


### PR DESCRIPTION
* Can use `p` instead of `scriptname` as the next start position of `vim_strchr()`.

```c
    while ((p = vim_strchr(scriptname, AUTOLOAD_CHAR)) != NULL)
	*p = '/';
```

* Can use the last non-null `p` as the position of appending ".vim" by `STRCPY()`.