### PR TITLE
Set filetype html for Vue.js files.

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -707,6 +707,9 @@ au BufNewFile,BufRead *.t.html			setf tilde
 " HTML (.shtml and .stm for server side)
 au BufNewFile,BufRead *.html,*.htm,*.shtml,*.stm  call dist#ft#FThtml()
 
+" Vue.js Single File Component
+au BufNewFile,BufRead *.vue			setf html
+
 " HTML with Ruby - eRuby
 au BufNewFile,BufRead *.erb,*.rhtml		setf eruby
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -708,7 +708,7 @@ au BufNewFile,BufRead *.t.html			setf tilde
 au BufNewFile,BufRead *.html,*.htm,*.shtml,*.stm  call dist#ft#FThtml()
 
 " Vue.js Single File Component
-au BufNewFile,BufRead *.vue			setf html
+au BufNewFile,BufRead *.vue			setf vuejs
 
 " HTML with Ruby - eRuby
 au BufNewFile,BufRead *.erb,*.rhtml		setf eruby

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -272,6 +272,7 @@ SynMenu HIJK.HTML.HTML\ with\ M4:htmlm4
 SynMenu HIJK.HTML.HTML\ with\ Ruby\ (eRuby):eruby
 SynMenu HIJK.HTML.Cheetah\ HTML\ template:htmlcheetah
 SynMenu HIJK.HTML.Django\ HTML\ template:htmldjango
+SynMenu HIJK.HTML.Vue.js\ HTML\ template:vuejs
 SynMenu HIJK.HTML.HTML/OS:htmlos
 SynMenu HIJK.HTML.XHTML:xhtml
 SynMenu HIJK.Host\.conf:hostconf

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -252,6 +252,7 @@ an 50.50.220 &Syntax.HIJK.HTML.HTML\ with\ M4 :cal SetSyn("htmlm4")<CR>
 an 50.50.230 &Syntax.HIJK.HTML.HTML\ with\ Ruby\ (eRuby) :cal SetSyn("eruby")<CR>
 an 50.50.240 &Syntax.HIJK.HTML.Cheetah\ HTML\ template :cal SetSyn("htmlcheetah")<CR>
 an 50.50.250 &Syntax.HIJK.HTML.Django\ HTML\ template :cal SetSyn("htmldjango")<CR>
+an 50.50.250 &Syntax.HIJK.HTML.Vue.js\ Vue.js component :cal SetSyn("vuejs")<CR>
 an 50.50.260 &Syntax.HIJK.HTML.HTML/OS :cal SetSyn("htmlos")<CR>
 an 50.50.270 &Syntax.HIJK.HTML.XHTML :cal SetSyn("xhtml")<CR>
 an 50.50.280 &Syntax.HIJK.Host\.conf :cal SetSyn("hostconf")<CR>

--- a/runtime/syntax/vuejs.vim
+++ b/runtime/syntax/vuejs.vim
@@ -1,0 +1,14 @@
+" Vim syntax file
+" Language:	Vue.js Single File Component
+" Maintainer:	Ralph Giles <giles@thaumas.net>
+" URL:		https://vuejs.org/v2/guide/single-file-components.html
+" Last Change:	2019 Jul 8
+
+" Quit if a syntax file was already loaded.
+if exists("b:current_syntax")
+  finish
+endif
+
+" We have a collection of html, css and javascript wrapped in
+" tags. The default HTML syntax highlight works well enough.
+runtime! syntax/html.vim


### PR DESCRIPTION
Identify Vue.js Single File Component source files by their .vue
filename extension and set the filetype to html. They're a mixture
of html templates, css, and javascript. The html syntax highlighting
works well enough.