### PR TITLE
Fix sign icons not displayed correctly when foldcolumn is not 0

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2253,7 +2253,7 @@ gui_outstr_nowrap(
     int		col = gui.col;
 #ifdef FEAT_SIGN_ICONS
     int		draw_sign = FALSE;
-    int		signcol = 0;
+    int		signcol = col;
     char_u	extra[18];
 # ifdef FEAT_NETBEANS_INTG
     int		multi_sign = FALSE;
@@ -2289,7 +2289,7 @@ gui_outstr_nowrap(
 	    --col;
 	len = (int)STRLEN(s);
 	if (len > 2)
-	    signcol = len - 3;	// Right align sign icon in the number column
+	    signcol = col + len - 3;	// Right align sign icon in the number column
 	draw_sign = TRUE;
 	highlight_mask = 0;
     }


### PR DESCRIPTION
v8.1.1587 / #4578 introduced right-aligning of sign icons to the number columns, but it didn't properly take the original "col" variable into account, and initialized it to 0 instead. This disregards the fact that "col" can be non-zero, e.g. when foldcolumns != 0.

To see this issue, simply call `set foldcolumn=2` and then create a GUI sign icon. Note that the icon is not correctly pushed to the right by 2 columns and therefore overlap the fold column region. This fix will make sure that's taken into account.