### PR TITLE
Fixed 2 ubsan errors

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -3992,9 +3992,10 @@ channel_send(
 		    /* append to the last entry */
 		    if (ga_grow(&last->wq_ga, len) == OK)
 		    {
-			mch_memmove((char *)last->wq_ga.ga_data
+			if (len > 0)
+			   mch_memmove((char *)last->wq_ga.ga_data
 							  + last->wq_ga.ga_len,
-				    buf, len);
+					buf, len);
 			last->wq_ga.ga_len += len;
 		    }
 		}
@@ -4014,7 +4015,8 @@ channel_send(
 			ga_init2(&last->wq_ga, 1, 1000);
 			if (ga_grow(&last->wq_ga, len) == OK)
 			{
-			    mch_memmove(last->wq_ga.ga_data, buf, len);
+			    if (len > 0)
+				mch_memmove(last->wq_ga.ga_data, buf, len);
 			    last->wq_ga.ga_len = len;
 			}
 		    }


### PR DESCRIPTION
The PR fixes 2 errors reported by ubsan (undefined behavior sanitizer)
detected while running vim tests.

```
channel.c:4017:8: runtime error: null pointer passed as argument 1, which is declared to never be null
channel.c:3995:4: runtime error: null pointer passed as argument 1, which is declared to never be null
```

They are admittedly nitpicky as I am not aware of any
implementation where `memmove(NULL, .., 0)` would
cause problems in practise. Nevertheless, it's easy and
safer to fix.

Running tests with ubsan reports another error which
I did not fix as I do not see a simple way to fix 
it and there is a comment in the code that acknowledge
that it is assumed that division by 0 returns infinity:
```
eval.c:4351:15: runtime error: division by zero
```