### PR TITLE
Fix flaky test_suspend script test

### DIFF
--- a/src/testdir/test_suspend.vim
+++ b/src/testdir/test_suspend.vim
@@ -54,6 +54,7 @@ func Test_suspend()
   " Quit gracefully to dump coverage information.
   call term_sendkeys(buf, ":qall!\<CR>")
   call term_wait(buf)
+  call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
   call StopShellInTerminal(buf)
 
   exe buf . 'bwipe!'


### PR DESCRIPTION
Sometimes, `test_suspend` would seem to fail in CI for GUI tests in MacVim, when it's waiting for the shell to quit in `StopShellInTerminal()`. The issue seems to be that the test just calls `term_wait(buf)` to make sure the key has been handled, but it doesn't actually properly wait for the shell to come back up (and `term_wait` also has a pretty short default wait time which could also be an issue) before issuing the "exit" command, leading to some odd race conditions.

Add a wait to make sure the shell prompt is up, before issuing the "exit" command. This helps remove potential race conditions.

I didn't look closely enough to see if this was a problem for normal Vim's GUI tests as well.