### PR TITLE
Support 'template string' ('string interpolation')

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1436,8 +1436,14 @@ Template string helps you to write complex string. Other rules:
 <
 Other exceptions:
 >
-	echo $'${var'  " E451: Unterminated template expression: $'${var'
-	echo $'${}'    " E452: Empty template expression: $'${}'
+	echo $'${$UNDEFINED_ENV_VAR}'
+	" E450: Unknown environment variable: $UNDEFINED_ENV_VAR
+
+	echo $'${var'
+	" E451: Unterminated template expression: $'${var'
+
+	echo $'${}'
+	" E452: Empty template expression: $'${}'
 <
 
 option						*expr-option* *E112* *E113*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1427,9 +1427,6 @@ Template string helps you to write complex string. Other rules:
 	" Quotes in quotes
 	echo $'${'*'}'  " *
 	echo $"${"*"}"  " *
-	"" Meaning escaping is not needed
-	echo $'${''x''}'  " E199: ... (syntax error)
-	echo $"${\"x\"}"  " E199: ... (syntax error)
 
 	echo $'${$UNDEFINED_ENV_VAR}' " (empty string)
 <

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1412,12 +1412,9 @@ These are same as
 Template string helps you to write complex string. Other rules:
 >
 	" Only strings or literal strings doesn't apply string()
-	echo $'I am a ${"vim"}'   " I am a vim
-	                          " not: I am a 'vim'
-	echo $"I am a ${'vim'}"   " I am a vim
-
-	" In template-string, you can write '$' as $$
-	echo $'$$'  " $
+	echo $'I''m ${"000"}'   " I'm 000
+	                          " not: I'm '000'
+	echo $"I'm ${'000'}"    " I'm 000
 
 	" Escaping in template (non-literal) string
 	echo $"${10} \\ \""   " 10 \ "
@@ -1433,12 +1430,12 @@ Template string helps you to write complex string. Other rules:
 	"" Meaning escaping is not needed
 	echo $'${''x''}'  " E199: ... (syntax error)
 	echo $"${\"x\"}"  " E199: ... (syntax error)
+
+	echo $'${$UNDEFINED_ENV_VAR}' " (empty string)
 <
+
 Other exceptions:
 >
-	echo $'${$UNDEFINED_ENV_VAR}'
-	" E450: Unknown environment variable: $UNDEFINED_ENV_VAR
-
 	echo $'${var'
 	" E451: Unterminated template expression: $'${var'
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1389,6 +1389,50 @@ to be doubled.  These two commands are equivalent: >
 	if a =~ '\s*'
 
 
+template-string					*template-string* *E1000*
+---------------
+
+$"string"	template string			*expr-$quote*
+$'string'	template literal string		*expr-$'*
+
+Note that either single quotes or double quotes are used.
+
+These strings support 'string-interpolations'. That embeds any expressions by
+'${}' into a string. For example
+>
+	" Embedding literals
+	echo $'I have ${10}'          " I have 10
+	echo $'I ${{"love": 1000}}'   " I {'love': 1000}
+<
+These are same as
+>
+	echo 'I have ' . string(10)
+	echo 'I ' . string({"love": 1000})
+<
+'string-interpolations' helps you to write complex string. Other rules:
+>
+	" Only strings or literal strings doesn't apply string()
+	echo $'I am a ${"vim"}'   " I am a vim
+	                          " not: I am a 'vim'
+	echo $"I am a ${'vim'}"   " I am a vim
+
+	" Only unscoped variables can omit {}
+	let x = 10
+	echo $'$x'  " 10
+
+	" In template-string, you can write '$' as $$
+	echo $'$$'  " $
+
+	" Escaping in template (non-literal) string
+	echo $"${10} \\ \""   " 10 \ "
+<
+Exceptions:
+>
+	echo $'$10'        " E450: Illegal template literal: $'$10'
+	echo $'${var'      " E451: Unterminated template literal: $'${var'
+	echo $'---${}---'  " E452: Empty template literal: $'---${}---'
+<
+
 option						*expr-option* *E112* *E113*
 ------
 &option			option value, local value if possible

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1400,29 +1400,24 @@ Note that either single quotes or double quotes are used.
 These strings support 'string-interpolations' by prefix $. That embeds any
 expressions by '${}' into a string. For example
 >
-	" Embedding literals
-	echo $'I have ${10}'          " I have 10
-	echo $'I ${{"love": 1000}}'   " I {'love': 1000}
+	let stuff = 10
+	echo $'I have ${stuff}'  " I have 10
+
+	function Func()
+	  return 10
+	endfunction
+	echo $'I have ${Func()}'
 <
 These are same as
 >
-	echo 'I have ' .. string(10)
-	echo 'I ' .. string({"love": 1000})
+	let stuff = 10
+	echo 'I have ' .. string(stuff)
 <
 Template string helps you to write complex string. Other rules:
 >
-	" Only strings or literal strings doesn't apply string()
-	echo $'I''m ${"000"}'   " I'm 000
-	                          " not: I'm '000'
-	echo $"I'm ${'000'}"    " I'm 000
-
-	" Escaping in template (non-literal) string
-	echo $"${10} \\ \""   " 10 \ "
-
-	" In Vim script variable expansions of $foo is not supported
-	let x = 10
-	echo $'$x'    " $x
-	echo $'${x}'  " 10
+	" Only strings doesn't apply string()
+	echo $'${"vim"}'   " vim
+	                   " not: 'vim'
 
 	" Quotes in quotes
 	echo $'${'*'}'  " *
@@ -1431,7 +1426,7 @@ Template string helps you to write complex string. Other rules:
 	echo $'${$UNDEFINED_ENV_VAR}' " (empty string)
 <
 
-Other exceptions:
+Exceptions:
 >
 	echo $'${var'
 	" E451: Unterminated template expression: $'${var'

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1397,8 +1397,8 @@ $'string'	template literal string		*expr-$'*
 
 Note that either single quotes or double quotes are used.
 
-These strings support 'string-interpolations'. That embeds any expressions by
-'${}' into a string. For example
+These strings support 'string-interpolations' by prefix $. That embeds any
+expressions by '${}' into a string. For example
 >
 	" Embedding literals
 	echo $'I have ${10}'          " I have 10
@@ -1406,31 +1406,38 @@ These strings support 'string-interpolations'. That embeds any expressions by
 <
 These are same as
 >
-	echo 'I have ' . string(10)
-	echo 'I ' . string({"love": 1000})
+	echo 'I have ' .. string(10)
+	echo 'I ' .. string({"love": 1000})
 <
-'string-interpolations' helps you to write complex string. Other rules:
+Template string helps you to write complex string. Other rules:
 >
 	" Only strings or literal strings doesn't apply string()
 	echo $'I am a ${"vim"}'   " I am a vim
 	                          " not: I am a 'vim'
 	echo $"I am a ${'vim'}"   " I am a vim
 
-	" Only unscoped variables can omit {}
-	let x = 10
-	echo $'$x'  " 10
-
 	" In template-string, you can write '$' as $$
 	echo $'$$'  " $
 
 	" Escaping in template (non-literal) string
 	echo $"${10} \\ \""   " 10 \ "
+
+	" In Vim script variable expansions of $foo is not supported
+	let x = 10
+	echo $'$x'    " $x
+	echo $'${x}'  " 10
+
+	" Quotes in quotes
+	echo $'${'*'}'  " *
+	echo $"${"*"}"  " *
+	"" Meaning escaping is not needed
+	echo $'${''x''}'  " E199: ... (syntax error)
+	echo $"${\"x\"}"  " E199: ... (syntax error)
 <
-Exceptions:
+Other exceptions:
 >
-	echo $'$10'        " E450: Illegal template literal: $'$10'
-	echo $'${var'      " E451: Unterminated template literal: $'${var'
-	echo $'---${}---'  " E452: Empty template literal: $'---${}---'
+	echo $'${var'  " E451: Unterminated template expression: $'${var'
+	echo $'${}'    " E452: Empty template expression: $'${}'
 <
 
 option						*expr-option* *E112* *E113*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1389,7 +1389,7 @@ to be doubled.  These two commands are equivalent: >
 	if a =~ '\s*'
 
 
-template-string					*template-string* *E1000*
+template-string				*template-string* *E451* *E452*
 ---------------
 
 $"string"	template string			*expr-$quote*

--- a/src/eval.c
+++ b/src/eval.c
@@ -3408,6 +3408,8 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
     ga_init2(&current, 1, 80);
     ga_append(&current, quote);
 
+    init_tv(&current_result);
+
     // Continue while it is not NULL and it is not a closing quote.
     for (; (**arg != NUL) &&
 	    !is_closing_quote(*arg, is_literal_string, &is_skipping_needed);
@@ -3504,8 +3506,7 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 
 /*
  * Refreshes previous_quote with NUL
- *	if the closing quote of
- *	the opening quote (previous_quote) found on **source.
+ *	if the closing quote of the opening quote (previous_quote) found on **source.
  * Refreshes previous_quote with ' or "
  *	if a opening quote is never found and that quote found.
  * Doesn't Refresh if no quotes found.
@@ -3620,10 +3621,7 @@ stringify_expr(char_u *expr)
 	result = string_result;
     }
     else if (result.vval.v_string == NULL)
-    {
-	result.vval.v_string = (char_u *) alloc(1);  // meaning success of this function
-	result.vval.v_string[0] = '\0';
-    }
+	result.vval.v_string = ALLOC_CLEAR_ONE(char_u);  // meaning success of this function
 
     return result.vval.v_string;
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -3447,37 +3447,6 @@ is_escaped_quote(int is_literal_string, char_u *p)
 	(!is_literal_string && *p == '\\' && *(p + 1) == '"');
 }
 
-    static char_u*
-escape_quotes_in_quote(char_u *x, int is_literal_string)
-{
-    garray_T	result;
-    char_u	*p;
-
-    ga_init2(&result, 1, 80);
-
-    for (p = x; *p != NUL; MB_PTR_ADV(p))
-    {
-	if (is_literal_string && *p == '\'')
-	{
-	    ga_concat(&result, (char_u *) "''");
-	    continue;
-	}
-	else if (!is_literal_string && *p == '"')
-	{
-	    ga_concat(&result, (char_u *) "\\\"");
-	    continue;
-	}
-	else if (!is_literal_string && *p == '\\')
-	{
-	    ga_concat(&result, (char_u *) "\\\\");
-	    continue;
-	}
-	ga_concatn(&result, p, mb_ptr2len(p));
-    }
-
-    return (char_u *) result.ga_data;
-}
-
 /*
  * Finds closing '}' of taken expr
  */
@@ -3590,7 +3559,7 @@ stringify_expr(char_u *expr)
     // e.g.
     // string(function("function")) => "function('function')"
     // string({"x": "x"}) => "{'x': 'x'}"
-    sprintf((char *) result, "\"%s\"", stringified.vval);
+    sprintf((char *) result, "\"%s\"", (char *) stringified.vval.v_string);
     vim_free(stringified.vval.v_string);
 
     return result;

--- a/src/eval.c
+++ b/src/eval.c
@@ -3476,7 +3476,7 @@ read_template_string_intervals(
 
     *arg += 2;  // $' or $"
 
-    ga_init2(result, sizeof(template_string_interval*), 10);
+    ga_init2(result, sizeof(template_string_interval*), 80);
     current = *arg;
 
     // Continue while it is not NULL and it is not a closing quote.
@@ -3681,7 +3681,7 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 	    char_u	*to_eval;
 	    int		is_evaluating_success;
 
-	    ga_init2(&interval, sizeof(char_u), 80);
+	    ga_init2(&interval, sizeof(char_u), 40);
 	    ga_append(&interval, quote);
 	    ga_concatn(&interval, x->s->value, x->s->length);
 	    ga_append(&interval, quote);

--- a/src/eval.c
+++ b/src/eval.c
@@ -3350,6 +3350,8 @@ eval_template_current(garray_T *current, int evaluate)
     typval_T	result;
     char_u	*to_eval_current = (char_u *) current->ga_data;
 
+    init_tv(&result);
+
     if (!eval1(&to_eval_current, &result, evaluate))
     {
 	ga_clear(current);

--- a/src/eval.c
+++ b/src/eval.c
@@ -3357,13 +3357,10 @@ eval_template_current_into_result(
     init_tv(&current_result);
 
     if (!eval1(&to_eval_current, &current_result, evaluate))
-    {
-	ga_clear(current);
 	return FAIL;
-    }
 
-    if (current_result.vval.v_string == NULL)
-	current_result.vval.v_string = "";
+    if (!evaluate)
+	return OK;
 
     ga_concat(result, current_result.vval.v_string);
     vim_free(current_result.vval.v_string);

--- a/src/eval.c
+++ b/src/eval.c
@@ -3568,16 +3568,18 @@ get_stringifying(char_u *expr)
     static char_u*
 stringify_expr(char_u *expr)
 {
+    const size_t    ENCOSING_QUOTES_NUM = 2;
+    char_u	    *result;
     char_u	    *stringifying = get_stringifying(expr);
     char_u	    *to_free_stringifying = stringifying;
     typval_T	    stringified = { VAR_UNKNOWN, VAR_LOCKED, { 0 } };
-    int		    is_stringifying_success = eval1(&stringifying, &stringified, TRUE);
-    char_u	    *result;
-    const size_t    ENCOSING_QUOTES_NUM = 2;
+    int		    is_stringifying_success;
+
+    is_stringifying_success = eval1(&stringifying, &stringified, TRUE);
+    vim_free(to_free_stringifying);
 
     if (!is_stringifying_success)
     {
-	vim_free(to_free_stringifying);
 	vim_free(stringified.vval.v_string);
 	return NULL;
     }

--- a/src/eval.c
+++ b/src/eval.c
@@ -3492,6 +3492,11 @@ escape_quotes_in_quote(char_u *x, int is_literal_string)
 	    ga_concat(&result, (char_u *) "\\\"");
 	    continue;
 	}
+	else if (!is_literal_string && *p == '\\')
+	{
+	    ga_concat(&result, (char_u *) "\\\\");
+	    continue;
+	}
 	ga_concatn(&result, p, mb_ptr2len(p));
     }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -3419,14 +3419,13 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 		    quote,
 		    evaluate);
 	    ga_clear(&current);
-	    ga_append(&current, quote);  // open quotation
 
 	    if (!is_eval_current_success)
 	    {
-		ga_clear(&current);
 		ga_clear(&result);
 		return FAIL;
 	    }
+	    ga_append(&current, quote);  // open quotation
 
 	    is_eval_expr_success =
 		eval_next_template_expr_into_result(

--- a/src/eval.c
+++ b/src/eval.c
@@ -3338,35 +3338,13 @@ is_closing_quote(
 }
 
 /*
- * Consumes current to evaluate.
+ * Consumes current to evaluate,
+ * and joins its result into result.
+ * 
  * current will be initialized.
  *
  * Returns the result of evaluating current.
  * Or return NULL if evaluating is FAIL.
- */
-    static char_u*
-eval_template_current(garray_T *current, int evaluate)
-{
-    typval_T	result;
-    char_u	*to_eval_current = (char_u *) current->ga_data;
-
-    init_tv(&result);
-
-    if (!eval1(&to_eval_current, &result, evaluate))
-    {
-	ga_clear(current);
-	return NULL;
-    }
-    ga_clear(current);
-
-    return result.vval.v_string;
-}
-
-/*
- * Consumes current to evaluate,
- * and joins its result into result.
- *
- * Please also see eval_template_current().
  */
     static int
 eval_template_current_into_result(
@@ -3375,14 +3353,23 @@ eval_template_current_into_result(
 	char_u quote,
 	int evaluate)
 {
-    char_u  *current_result;
+    typval_T	current_result;
+    char_u	*to_eval_current = (char_u *) current->ga_data;
 
-    current_result = eval_template_current(current, evaluate);
-    if (current_result == NULL)
+    init_tv(&current_result);
+
+    if (!eval1(&to_eval_current, &current_result, evaluate))
+    {
+	ga_clear(current);
+	return FAIL;
+    }
+    ga_clear(current);
+
+    if (current_result.vval.v_string == NULL)
 	return FAIL;
 
-    ga_concat(result, current_result);
-    vim_free(current_result);
+    ga_concat(result, current_result.vval.v_string);
+    vim_free(current_result.vval.v_string);
 
     return OK;
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -2659,13 +2659,9 @@ eval7(
      * Environment variable: $VAR.
      */
     case '$':	if (*(*arg + 1) == '"' || *(*arg + 1) == '\'')
-		{
 		    ret = get_template_string_tv(arg, rettv, evaluate);
-		}
 		else
-		{
 		    ret = get_env_tv(arg, rettv, evaluate);
-		}
 		break;
 
     /*
@@ -3325,7 +3321,10 @@ eval_index(
 }
 
     static int
-is_closing_quote(char_u *template, int is_literal_string, int *is_skipping_needed)
+is_closing_quote(
+	char_u *template,
+	int is_literal_string,
+	int *is_skipping_needed)
 {
     char_u quote = is_literal_string ? '\'' : '"';
 
@@ -3358,7 +3357,9 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
     ga_append(&result, quote);
 
     // Continue while it is not NULL and it is not a closing quote.
-    for (; (**arg != NUL) && !is_closing_quote(*arg, is_literal_string, &is_skipping_needed); ++*arg)
+    for (; (**arg != NUL) &&
+	    !is_closing_quote(*arg, is_literal_string, &is_skipping_needed);
+	    ++*arg)
     {
 	if (is_skipping_needed)
 	{
@@ -3372,7 +3373,8 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 	    int success;
 	    int does_expect_embraced = *(*arg + 1) == '{';
 
-	    *arg += does_expect_embraced ? 2 : 1;  // forward to beginning of the template literal
+	    // forward to beginning of the template literal
+	    *arg += does_expect_embraced ? 2 : 1;
 	    success = does_expect_embraced
 		? read_template_expr(&result, arg, is_literal_string)
 		: read_template_var(&result, arg);
@@ -3430,9 +3432,7 @@ did_encount_string_quote(char_u **expr, int is_literal_string)
 	did_encount_escaped_quote;
 
     if (did_encount_escaped_quote)
-    {
 	++*expr;
-    }
 
     return result;
 }
@@ -3477,10 +3477,12 @@ escape_quotes_in_quote(char_u *x, int is_literal_string)
 
     for (p = x; *p != NUL; MB_PTR_ADV(p))
     {
-	if (is_literal_string && *p == '\'') {
+	if (is_literal_string && *p == '\'')
+	{
 	    ga_concat(&result, (char_u *) "''");
 	    continue;
-	} else if (!is_literal_string && *p == '"')
+	}
+	else if (!is_literal_string && *p == '"')
 	{
 	    ga_concat(&result, (char_u *) "\\\"");
 	    continue;
@@ -3501,31 +3503,27 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
     size_t	    nested_blocks = 0;
     int		    is_in_quote = FALSE;
 
-    // While the closing '}' encounted. The '}' is neither '}' of a dict nor '}' in a string.
-    for (; !(!is_in_quote && **expr == '}' && nested_blocks == 0); MB_PTR_ADV(*expr))
+    // While the closing '}' encounted. The '}' is neither '}' of a dict nor
+    // '}' in a string.
+    for (; !(!is_in_quote && **expr == '}' && nested_blocks == 0);
+							MB_PTR_ADV(*expr))
     {
 	switch (**expr)
 	{
 	    case '{':
 		if (!is_in_quote)
-		{
 		    ++nested_blocks;
-		}
 		break;
 	    case '}':
 		if (!is_in_quote)
-		{
 		    --nested_blocks;
-		}
 		break;
 	    case NUL:
 		semsg(_("E451: Unterminated template literal: %s"), expr_head);
 		return FAIL;
 	    default:
 		if (did_encount_string_quote(expr, is_literal_string))
-		{
 		    is_in_quote = !is_in_quote;
-		}
 		break;
 	}
     }
@@ -3563,12 +3561,11 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
 	success = eval1(&stringified, &var_value, TRUE);
 	vim_free(to_free_stringified);
 	if (!success)
-	{
 	    return FAIL;
-	}
 
 	// Evaluate the lambda call
-	escaped = escape_quotes_in_quote(var_value.vval.v_string, is_literal_string);
+	escaped = escape_quotes_in_quote(var_value.vval.v_string,
+							is_literal_string);
 	ga_concat(result, escaped);
 	vim_free(var_value.vval.v_string);
 	vim_free(escaped);

--- a/src/eval.c
+++ b/src/eval.c
@@ -3642,7 +3642,10 @@ eval_next_template_expr_into_result(
 	return FAIL;
 
     if (!evaluate)
+    {
+	vim_free(expr);
 	return OK;
+    }
 
     /*
      * Evaluate the source

--- a/src/eval.c
+++ b/src/eval.c
@@ -3552,6 +3552,12 @@ stringify_expr(char_u *expr)
 	vim_free(stringified.vval.v_string);
 	return NULL;
     }
+    // If $UNDEFINED_ENV_VAR evaluated
+    if (stringified.vval.v_string == NULL)
+    {
+	stringified.vval.v_string = "";
+    }
+
     result = (char_u *) alloc(STRLEN(stringified.vval.v_string) + ENCOSING_QUOTES_NUM + 1);
 
     // Use '"' to make a string correctly.

--- a/src/eval.c
+++ b/src/eval.c
@@ -3340,8 +3340,6 @@ is_closing_quote(
 /*
  * Consumes current to evaluate,
  * and joins its result into result.
- * 
- * current will be initialized.
  *
  * Returns the result of evaluating current.
  * Or return NULL if evaluating is FAIL.
@@ -3363,7 +3361,6 @@ eval_template_current_into_result(
 	ga_clear(current);
 	return FAIL;
     }
-    ga_clear(current);
 
     if (current_result.vval.v_string == NULL)
 	return FAIL;
@@ -3421,6 +3418,7 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 		    &result,
 		    quote,
 		    evaluate);
+	    ga_clear(&current);
 	    ga_append(&current, quote);  // open quotation
 
 	    if (!is_eval_current_success)

--- a/src/eval.c
+++ b/src/eval.c
@@ -3496,7 +3496,7 @@ read_template_string_intervals(
 	    if (ga_grow(result, 2) == FAIL)
 	    {
 		intervals_free(result);
-		semsg(_("Internal error!"));
+		emsg(_(e_outofmem));
 		return FAIL;
 	    }
 	    result->ga_len += 2;
@@ -3510,7 +3510,7 @@ read_template_string_intervals(
 	    if (x == NULL)
 	    {
 		intervals_free(result);
-		semsg(_("Internal error!"));
+		emsg(_(e_outofmem));
 		return FAIL;
 	    }
 	    ((template_string_interval **)result->ga_data)[result->ga_len - 2] =
@@ -3529,7 +3529,7 @@ read_template_string_intervals(
 	    if (x == NULL)
 	    {
 		intervals_free(result);
-		semsg(_("Internal error!"));
+		emsg(_(e_outofmem));
 		return FAIL;
 	    }
 	    x->is_expr = 1;
@@ -3550,7 +3550,7 @@ read_template_string_intervals(
 	if (ga_grow(result, 1) == FAIL)
 	{
 	    intervals_free(result);
-	    semsg(_("Internal error!"));
+	    emsg(_(e_outofmem));
 	    return FAIL;
 	}
 	result->ga_len += 1;
@@ -3583,7 +3583,7 @@ make_interval_between_not_expr(char_u *start, char_u *end)
     s = alloc(sizeof(string_like));
     if (s == NULL)
     {
-	semsg(_("Internal error!"));
+	emsg(_(e_outofmem));
 	return NULL;
     }
     s->value = start;
@@ -3592,7 +3592,7 @@ make_interval_between_not_expr(char_u *start, char_u *end)
     x = alloc(sizeof(template_string_interval));
     if (x == NULL)
     {
-	semsg(_("Internal error!"));
+	emsg(_(e_outofmem));
 	return NULL;
     }
     x->is_expr = 0;

--- a/src/eval.c
+++ b/src/eval.c
@@ -3463,12 +3463,17 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
      */
     ga_append(&current, quote);  // closing quotation
     to_eval_current = (char_u *) current.ga_data;
-    if (!eval1(&to_eval_current, &current_result, evaluate))
     {
-	ga_clear(&current);
-	ga_clear(&result);
-	clear_tv(&current_result);
-	return FAIL;
+	int eval_result = is_literal_string
+	    ? get_lit_string_tv(&to_eval_current, &current_result, evaluate)
+	    : get_string_tv(&to_eval_current, &current_result, evaluate);
+	if (!eval_result)
+	{
+	    ga_clear(&current);
+	    ga_clear(&result);
+	    clear_tv(&current_result);
+	    return FAIL;
+	}
     }
     ga_concat(&result, current_result.vval.v_string);
     clear_tv(&current_result);

--- a/src/eval.c
+++ b/src/eval.c
@@ -3363,7 +3363,7 @@ eval_template_current_into_result(
     }
 
     if (current_result.vval.v_string == NULL)
-	return FAIL;
+	current_result.vval.v_string = "";
 
     ga_concat(result, current_result.vval.v_string);
     vim_free(current_result.vval.v_string);

--- a/src/eval.c
+++ b/src/eval.c
@@ -3413,25 +3413,26 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 }
 
     static int
-did_encount_string_quote(char_u **expr, int is_literal_string)
+did_encounter_string_quote(char_u **expr, int is_literal_string)
 {
-    // encounted a double quote in the single quoted string (lit str),
-    int did_encount_double_in_single =
+    // encountered a double quote in the single quoted string (lit str),
+    int did_encounter_double_in_single =
 	(is_literal_string && **expr == '"');
 
     // a single quote in the double quoted string,
-    int did_encount_single_in_double =
+    int did_encounter_single_in_double =
 	(!is_literal_string && **expr == '\'');
 
     // or a single quote in the double quoted string?
-    int did_encount_escaped_quote = is_escaped_quote(is_literal_string, *expr);
+    int did_encounter_escaped_quote =
+				is_escaped_quote(is_literal_string, *expr);
 
     int result =
-	did_encount_double_in_single ||
-	did_encount_single_in_double ||
-	did_encount_escaped_quote;
+	did_encounter_double_in_single ||
+	did_encounter_single_in_double ||
+	did_encounter_escaped_quote;
 
-    if (did_encount_escaped_quote)
+    if (did_encounter_escaped_quote)
 	++*expr;
 
     return result;
@@ -3503,7 +3504,7 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
     size_t	    nested_blocks = 0;
     int		    is_in_quote = FALSE;
 
-    // While the closing '}' encounted. The '}' is neither '}' of a dict nor
+    // While the closing '}' encountered. The '}' is neither '}' of a dict nor
     // '}' in a string.
     for (; !(!is_in_quote && **expr == '}' && nested_blocks == 0);
 							MB_PTR_ADV(*expr))
@@ -3522,7 +3523,7 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
 		semsg(_("E451: Unterminated template literal: %s"), expr_head);
 		return FAIL;
 	    default:
-		if (did_encount_string_quote(expr, is_literal_string))
+		if (did_encounter_string_quote(expr, is_literal_string))
 		    is_in_quote = !is_in_quote;
 		break;
 	}

--- a/src/eval.c
+++ b/src/eval.c
@@ -3458,10 +3458,10 @@ remove_all_quote_escaping(char_u *expr, int is_literal_string)
 	if (is_escaped_quote(is_literal_string, p))
 	{
 	    ga_append(&result, *(p + 1));
-	    MB_PTR_ADV(p);
+	    ++p;
 	    continue;
 	}
-	ga_append(&result, *p);
+	ga_concatn(&result, p, mb_ptr2len(p));
     }
 
     return (char_u *) result.ga_data;
@@ -3487,7 +3487,7 @@ escape_quotes_in_quote(char_u *x, int is_literal_string)
 	    ga_concat(&result, (char_u *) "\\\"");
 	    continue;
 	}
-	ga_append(&result, *p);
+	ga_concatn(&result, p, mb_ptr2len(p));
     }
 
     return (char_u *) result.ga_data;

--- a/src/eval.c
+++ b/src/eval.c
@@ -3415,9 +3415,8 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
     {
 	if (is_skipping_needed)
 	{
-	    ga_append(&current, (int) **arg);
+	    ga_concatn(&current, *arg, 2);
 	    ++*arg;
-	    ga_append(&current, (int) **arg);
 	    continue;
 	}
 	else if (**arg == '$' && *(*arg + 1) == '{')
@@ -3595,7 +3594,6 @@ forward_to_end_of_template_expr(char_u **expr, int is_literal_string)
 read_template_expr(char_u **source, int is_literal_string)
 {
     char_u  *expr_head;
-    char_u  *expr;
 
     *source += 2;  // forward with beginning '${'
     expr_head = *source;
@@ -3603,12 +3601,7 @@ read_template_expr(char_u **source, int is_literal_string)
     if (!forward_to_end_of_template_expr(source, is_literal_string))
 	return NULL;
 
-    **source = NUL;
-    expr = (char_u *) alloc(STRLEN(expr_head) + 1);
-    STRCPY(expr, expr_head);
-    **source = '}';
-
-    return expr;
+    return vim_strnsave(expr_head, (int)(*source - expr_head));
 }
 
     static char_u*

--- a/src/eval.c
+++ b/src/eval.c
@@ -55,7 +55,6 @@ static int eval7_leader(typval_T *rettv, char_u *start_leader, char_u **end_lead
 
 static int get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate);
 static int read_template_expr(garray_T *result, char_u **expr, int is_literal_string, int evaluate);
-static int read_template_var(garray_T *result, char_u **expr, int is_literal_string, int evaluate);
 static int is_escaped_quote(int is_literal_string, char_u *quotes);
 static int free_unref_items(int copyID);
 static char_u *make_expanded_name(char_u *in_start, char_u *expr_start, char_u *expr_end, char_u *in_end);
@@ -3368,16 +3367,16 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 	    ga_append(&result, (int) **arg);
 	    continue;
 	}
-	else if (**arg == '$')
+	else if (**arg == '$' && *(*arg + 1) == '{')
 	{
 	    int success;
-	    int does_expect_embraced = *(*arg + 1) == '{';
 
-	    // forward to beginning of the template literal
-	    *arg += does_expect_embraced ? 2 : 1;
-	    success = does_expect_embraced
-		? read_template_expr(&result, arg, is_literal_string, evaluate)
-		: read_template_var(&result, arg, is_literal_string, evaluate);
+	    *arg += 2;  // forward to beginning of the template literal
+	    success = read_template_expr(
+		    &result,
+		    arg,
+		    is_literal_string,
+		    evaluate);
 	    if (!success)
 	    {
 		ga_clear(&result);
@@ -3669,7 +3668,7 @@ read_template_var(
 }
 
 /*
- * Return the function name of partial "pt".
+ * Return the function name of the partial.
  */
     char_u *
 partial_name(partial_T *pt)

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2152,11 +2152,19 @@ ga_add_string(garray_T *gap, char_u *p)
     void
 ga_concat(garray_T *gap, char_u *s)
 {
-    int    len;
-
     if (s == NULL || *s == NUL)
 	return;
-    len = (int)STRLEN(s);
+    ga_concatn(gap, s, (int)STRLEN(s));
+}
+
+/*
+ * Similar to ga_concat(), but concatenate only specified length.
+ */
+    void
+ga_concatn(garray_T *gap, char_u *s, int len)
+{
+    if (s == NULL || len <= 0)
+	return;
     if (ga_grow(gap, len) == OK)
     {
 	mch_memmove((char *)gap->ga_data + gap->ga_len, s, (size_t)len);

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -63,6 +63,7 @@ int ga_grow_inner(garray_T *gap, int n);
 char_u *ga_concat_strings(garray_T *gap, char *sep);
 void ga_add_string(garray_T *gap, char_u *p);
 void ga_concat(garray_T *gap, char_u *s);
+void ga_concatn(garray_T *gap, char_u *s, int len);
 void ga_append(garray_T *gap, int c);
 void append_ga_line(garray_T *gap);
 int simplify_key(int key, int *modifiers);

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -272,6 +272,7 @@ NEW_TESTS = \
 	test_tagjump \
 	test_taglist \
 	test_tcl \
+	test_template_string \
 	test_termcodes \
 	test_termencoding \
 	test_terminal \

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -488,6 +488,7 @@ NEW_TESTS_RES = \
 	test_tagjump.res \
 	test_taglist.res \
 	test_tcl.res \
+	test_template_string.res \
 	test_termcodes.res \
 	test_termencoding.res \
 	test_terminal.res \

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -31,6 +31,7 @@ source test_sha256.vim
 source test_tabline.vim
 source test_tagcase.vim
 source test_tagfunc.vim
+source test_template_string.vim
 source test_unlet.vim
 source test_version.vim
 source test_wnext.vim

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -31,7 +31,6 @@ source test_sha256.vim
 source test_tabline.vim
 source test_tagcase.vim
 source test_tagfunc.vim
-source test_template_string.vim
 source test_unlet.vim
 source test_version.vim
 source test_wnext.vim

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -5,6 +5,7 @@ scriptencoding utf-8
 func Test_template_string_basic()
   " Literals - (non string) literals will be applied by string()
   call assert_equal('I have 10', $'I have ${10}')
+  call assert_equal('10!', $'${10}!')
   call assert_equal(string(function("function")), $'${function("function")}')
   call assert_equal(string([10, 20]), $'${[10, 20]}')
   call assert_equal(string({"x": 10}), $'${{"x": 10}}')

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -102,6 +102,13 @@ func Test_template_string_illformed()
   endtry
 
   try
+    let _ = $'${$UNDEFINED_ENV_VAR}'
+    call assert_report('Should throw an exception.')
+  catch
+    call assert_exception('E450:')
+  endtry
+
+  try
     let _ = $'${10'
     call assert_report('Should throw an exception.')
   catch

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -65,6 +65,8 @@ func Test_template_string_appendix()
   call assert_equal('''', $'${''''}')
   call assert_equal("", $"${""}")
   call assert_equal("x", $"${"x"}")
+  call assert_equal("a\"b", $"${'a"b'}")
+  call assert_equal('a''b', $'${"a'b"}')
 
   " Escaping '}'
   call assert_equal("}", $'${"}"}')

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -30,6 +30,8 @@ func Test_template_string_basic()
   call assert_equal("'", $'$x')
   let x = '"'
   call assert_equal('"', $"$x")
+  let x = '\x31'
+  call assert_equal('\x31', $"$x")
   let x20 = 20
   call assert_equal('20', $'$x20')
   let Fo_O0O = 30

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -23,9 +23,13 @@ func Test_template_string_basic()
   " Variables
   let x = 10
   call assert_equal('I have 10', $'I have ${x}')
-  "" Only variables can be ommt "{}"
+  "" Only variables can be omit "{}"
   call assert_equal('I have 10', $'I have $x')
   call assert_equal('10 and me', $'$x and me')
+  let x = "'"
+  call assert_equal("'", $'$x')
+  let x = '"'
+  call assert_equal('"', $"$x")
   let x20 = 20
   call assert_equal('20', $'$x20')
   let Fo_O0O = 30
@@ -73,6 +77,7 @@ func Test_template_string_appendix()
 
   " Multi byte string
   call assert_equal('こんにちは Vim', $'こんにちは ${"Vim"}')
+  call assert_equal('あ', $'${"あ"}')
 endfunc
 
 " These should be an exception, should not be a 'Segmentation fault'.

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -27,6 +27,10 @@ func Test_template_string_basic()
   let x = 10
   call assert_equal('$x', $'$x')
 
+  " Environment variables
+  call assert_equal($HOME, $'${$HOME}')
+  call assert_equal($UNDEFINED_ENV_VAR, $'${$UNDEFINED_ENV_VAR}')
+
   " Another types (compound tests)
   if exists('*job_start')
     let x = job_start('ls', {})
@@ -104,13 +108,6 @@ func Test_template_string_illformed()
   endtry
 
   try
-    let _ = $'${$UNDEFINED_ENV_VAR}'
-    call assert_report('Should throw an exception.')
-  catch
-    call assert_exception('E450:')
-  endtry
-
-  try
     let _ = $'${10'
     call assert_report('Should throw an exception.')
   catch
@@ -136,6 +133,6 @@ func Test_template_string_illformed()
     let _ = $'missing closing of ${function(}'
     call assert_report('Should throw an exception.')
   catch
-    call assert_exception('E119:')
+    call assert_exception('E116:')
   endtry
 endfunc

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -20,6 +20,12 @@ func Test_template_string_basic()
   call assert_equal('I''m a vim', $'I''m a ${"vim"}')
   call assert_equal('You are a vim', $'You are a ${"vim"}')
 
+  " Nested
+  call assert_equal('x', $'${$'x'}')
+  call assert_equal('10', $'${$'${10}'}')
+  call assert_equal("x", $"${$"x"}")
+  call assert_equal("10", $"${$"${10}"}")
+
   " Variables
   let x = 10
   call assert_equal('I have 10', $'I have ${x}')

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -1,0 +1,136 @@
+" Test for template strings $'${x} ${y.z}' $"$var"
+
+scriptencoding utf-8
+
+func Test_template_string_basic()
+  " Literals - (non string) literals will be applied by string()
+  call assert_equal('I have 10', $'I have ${10}')
+  call assert_equal(string(function("function")), $'${function("function")}')
+  call assert_equal(string([10, 20]), $'${[10, 20]}')
+  call assert_equal(string({"x": 10}), $'${{"x": 10}}')
+  call assert_equal(string(42.1), $'${42.1}')
+
+  call assert_equal(string(v:false), $'${v:false}')
+  call assert_equal(string(v:true), $'${v:true}')
+
+  call assert_equal(string(v:null), $'${v:null}')
+  call assert_equal(string(v:none), $'${v:none}')
+
+  " string literals expanded directly without string()
+  call assert_equal('I''m a vim', $'I''m a ${"vim"}')
+  call assert_equal('You are a vim', $'You are a ${"vim"}')
+
+  " Variables
+  let x = 10
+  call assert_equal('I have 10', $'I have ${x}')
+  "" Only variables can be ommt "{}"
+  call assert_equal('I have 10', $'I have $x')
+  call assert_equal('10 and me', $'$x and me')
+  let x20 = 20
+  call assert_equal('20', $'$x20')
+  let Fo_O0O = 30
+  call assert_equal('30', $'$Fo_O0O')
+
+  " Another types (compound tests)
+  if exists('*job_start')
+    let x = job_start('ls', {})
+    call assert_equal(string(x), $'${x}')
+  endif
+
+  if exists('*ch_open')
+    let x = ch_open('localhost:25252')  " dummy
+    call assert_equal(string(x), $'${x}')
+  endif
+
+  " Lambda
+  let F = {x -> x}
+  call assert_equal(string(F), $'${F}')
+
+  " Partial
+  call assert_equal(
+    \ string(function("has_key", [{"x": 10}])),
+    \ $'${function("has_key", [{"x": 10}])}'
+  \ )
+
+  " echo
+  echo $'${10}'
+  " let
+  let x = $'${10}'
+endfunc
+
+func Test_template_string_appendix()
+  " Double quoted
+  call assert_equal("10 } '' \\ \"", $"${10} ${'}'} '' \\ \"")
+
+  " Escape '}'
+  call assert_equal("}", $'${"}"}')
+  call assert_equal('}', $'${''}''}')
+  call assert_equal('}', $"${'}'}")
+  call assert_equal("}", $"${\"}\"}")
+
+  " Independent '$'
+  call assert_equal('$', $'${"$"}')
+
+  " Multi byte string
+  call assert_equal('こんにちは Vim', $'こんにちは ${"Vim"}')
+endfunc
+
+" These should be an exception, should not be a 'Segmentation fault'.
+func Test_template_string_illformed()
+  try
+    let _ = $'missing closing quote
+    call assert_report('Should throw an exception.')
+  catch
+    call assert_exception('E115:')
+  endtry
+
+  try
+    let _ = $"missing closing double quote
+    call assert_report('Should throw an exception.')
+  catch
+    call assert_exception('E115:')
+  endtry
+
+  try
+    let _ = $'$10'
+    call assert_report('Should throw an exception.')
+  catch
+    call assert_exception('E450:')
+  endtry
+
+  try
+    let _ = $'---$---'
+    call assert_report('Should throw an exception.')
+  catch
+    call assert_exception('E450:')
+  endtry
+
+  try
+    let _ = $'${10'
+    call assert_report('Should throw an exception.')
+  catch
+    call assert_exception('E451:')
+  endtry
+
+  try
+    let _ = $'---${}---'
+    call assert_report('Should throw an exception.')
+  catch
+    call assert_exception('E452:')
+  endtry
+
+  try
+    let _ = $'I have ${nothing}'
+    call assert_report('Should throw an exception.')
+  catch
+    call assert_exception('E121:')
+  endtry
+
+  try
+    " syntax error in a embedding
+    let _ = $'missing closing of ${function(}'
+    call assert_report('Should throw an exception.')
+  catch
+    call assert_exception('E119:')
+  endtry
+endfunc

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -65,8 +65,10 @@ func Test_template_string_appendix()
   call assert_equal('''', $'${''''}')
   call assert_equal("", $"${""}")
   call assert_equal("x", $"${"x"}")
-  call assert_equal("a\"b", $"${'a"b'}")
-  call assert_equal('a''b', $'${"a'b"}')
+  call assert_equal('a"b', $"${'a"b'}")
+  call assert_equal("a'b", $"${"a'b"}")
+  call assert_equal('a"b', $'${'a"b'}')
+  call assert_equal("a'b", $'${"a'b"}')
 
   " Escaping '}'
   call assert_equal("}", $'${"}"}')

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -64,7 +64,43 @@ func Test_template_string_basic()
   let _ = $'${10}'
 endfunc
 
+let s:count = [0, 0]
+
+func s:increment_count0() abort
+  let s:count[0] += 1
+endfunc
+
+func s:increment_count1() abort
+  let s:count[1] += 1
+endfunc
+
+func s:throw_exception() abort
+  throw 'exception'
+endfunc
+
 func Test_template_string_appendix()
+  " Lambda scopes
+  call assert_equal('10', call({ x -> $'${x}' }, [10]))
+
+  " evaluate == 0
+  if 0
+    call assert_equal('10', $'${10}')
+  endif
+
+  " Catching exceptions in ${}
+  try
+    let _ = $'${s:throw_exception()}'
+  catch
+    call assert_exception('exception')
+  endtry
+
+  " Evaluate ${expressions} before an exception threw
+  try
+    let _ = $'${s:increment_count0()}, ${s:throw_exception()}, ${s:increment_count1()}'
+  catch
+    call assert_equal(s:count, [1, 0])
+  endtry
+
   " Escaping of string
   call assert_equal("\\ \"", $"\\ \"")
   call assert_equal('''', $'''')


### PR DESCRIPTION
This motivation is here => #4491 :)

This is a version that omitted the '_' support.
(Please see https://github.com/vim/vim/issues/4491#issuecomment-509065896)
Please take this patch if you agree to this :+1:

Or let's discuss again at #4491 if Bram really want to '\_' :D