### PR TITLE
Fix: assert_fails doesn't work properly in try block

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -9916,6 +9916,7 @@ assert_fails(typval_T *argvars)
     called_emsg = FALSE;
     suppress_errthrow = TRUE;
     emsg_silent = TRUE;
+
     do_cmdline_cmd(cmd);
     if (!called_emsg)
     {
@@ -9941,7 +9942,7 @@ assert_fails(typval_T *argvars)
 	    assert_append_cmd_or_arg(&ga, argvars, cmd);
 	    assert_error(&ga);
 	    ga_clear(&ga);
-	ret = 1;
+	    ret = 1;
 	}
     }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -9910,7 +9910,9 @@ assert_fails(typval_T *argvars)
     char_u	*cmd = tv_get_string_chk(&argvars[0]);
     garray_T	ga;
     int		ret = 0;
+    int		save_trylevel = trylevel;
 
+    trylevel = 0;
     called_emsg = FALSE;
     suppress_errthrow = TRUE;
     emsg_silent = TRUE;
@@ -9943,6 +9945,7 @@ assert_fails(typval_T *argvars)
 	}
     }
 
+    trylevel = save_trylevel;
     called_emsg = FALSE;
     suppress_errthrow = FALSE;
     emsg_silent = FALSE;

--- a/src/testdir/test_assert.vim
+++ b/src/testdir/test_assert.vim
@@ -166,6 +166,12 @@ func Test_assert_fail_fails()
   call remove(v:errors, 0)
 endfunc
 
+func Test_assert_fails_in_try_block()
+  try
+    call assert_equal(0, assert_fails('throw "error"'))
+  endtry
+endfunc
+
 func Test_assert_beeps()
   new
   call assert_equal(0, assert_beeps('normal h'))


### PR DESCRIPTION
## Problem (reported by @bmtsstl)

In try block, `assert_fails(cmd)` cannot handle the user-exception thrown from "cmd".

test.vim
```vim
try
  call assert_fails('throw "error"')
endtry
```

```
vim --clean

:so test.vim
Error detected while processing /path/to/test.vim:
line    2:
E605: Exception not caught: error

:echo v:errors
['/path/to/test.vim line 2: command did not fail: throw "error"']
```

Expected: No error shown (i.e. `assert_fails()` succeeds)
```
:so test.vim
:echo v:errors
[]
```

## Cause

In try block (`trylevel > 0`) the user-exception is handled after evaluating the line of `assert_fails(cmd)`.
https://github.com/vim/vim/blob/master/src/ex_docmd.c#L1247

## Solution

I think should reset `trylevel` in `assert_fails()`.