### PR TITLE
Add AS keyword in Dockerfile syntax

### DIFF
--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -14,6 +14,7 @@ let b:current_syntax = "dockerfile"
 syntax case ignore
 
 syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\s/
+syntax match dockerfileKeyword /\v(AS)/
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/
 


### PR DESCRIPTION
It is used in a FROM construction to alias the name:
```Dockerfile
FROM alpine:edge AS builder
```
See https://docs.docker.com/engine/reference/builder/#from for the reference.