### PR TITLE
Fix broken build when +beval is disabled and +textprop is enabled

### DIFF
--- a/src/beval.h
+++ b/src/beval.h
@@ -7,7 +7,8 @@
  * Do ":help credits" in Vim to see a list of people who contributed.
  */
 
-#if !defined(BEVAL__H) && (defined(FEAT_BEVAL) || defined(PROTO))
+#if !defined(BEVAL__H) && \
+    (defined(FEAT_BEVAL) || defined(FEAT_TEXT_PROP) || defined(PROTO))
 #define BEVAL__H
 
 #ifdef FEAT_GUI_GTK

--- a/src/proto.h
+++ b/src/proto.h
@@ -232,7 +232,7 @@ void qsort(void *base, size_t elm_count, size_t elm_size, int (*cmp)(const void 
 
 /* Ugly solution for "BalloonEval" not being defined while it's used in some
  * .pro files. */
-# ifdef FEAT_BEVAL
+# if defined(FEAT_BEVAL) || defined(FEAT_TEXT_PROP)
 #  include "beval.pro"
 # else
 #  define BalloonEval int


### PR DESCRIPTION
I found that build was broken when `FEAT_BEVAL` is not defined but `FEAT_TEXTPROP` is defined (for popup).

This is because popup implementation is depending on `beval.c` to use `find_word_under_cursor()` but `proto.h` and `beval.h` don't consider that. I updated them to consider `FEAT_TEXTPROP` with this patch.