### PR TITLE
Add -lole32 to link uninstal.exe with MinGW

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1006,7 +1006,7 @@ install.exe: dosinst.c
 	$(CC) $(CFLAGS) -o install.exe dosinst.c $(LIB) -lole32 -luuid
 
 uninstal.exe: uninstal.c
-	$(CC) $(CFLAGS) -o uninstal.exe uninstal.c $(LIB)
+	$(CC) $(CFLAGS) -o uninstal.exe uninstal.c $(LIB) -lole32
 
 ifeq ($(VIMDLL),yes)
 $(TARGET): $(OUTDIR) $(OBJ)


### PR DESCRIPTION
When I tried to build all vim targets with

     make -f Make_ming.mak

I got the linker error *undefined reference to '_imp__CoTaskMemFree@4'.* for target `uninstal.exe`.