### PR TITLE
Fix that sometimes E742 occurs when letting a blob

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -63,6 +63,7 @@ blob_copy(typval_T *from, typval_T *to)
     int	    ret = OK;
 
     to->v_type = VAR_BLOB;
+    to->v_lock = 0;
     if (from->vval.v_blob == NULL)
 	to->vval.v_blob = NULL;
     else if (rettv_blob_alloc(to) == FAIL)

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -71,6 +71,10 @@ func Test_blob_assign()
   call assert_fails('let b .= "xx"', 'E734:')
   call assert_fails('let b += "xx"', 'E734:')
   call assert_fails('let b[1:1] .= 0z55', 'E734:')
+
+  let l = [0z12]
+  let m = deepcopy(l)
+  let m[0] = 0z34	" E742 or E741 should not occur.
 endfunc
 
 func Test_blob_get_range()


### PR DESCRIPTION
I had a report that sometimes E742 occurs when letting a blob even when the
destination is not locked.
https://travis-ci.com/tsuyoshicho/vital-codec/jobs/215009949
```
Vim(let):E742: Cannot change value of self.v[1] = 0z646f72616e646f6d
```
(Unfortunately I couldn't reproduce this on my environment, though.)

It seems that the initialization of `to->v_lock` is missing.