### PR TITLE
Fix sign icons not aligned properly with cursorline

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -2253,7 +2253,7 @@ gui_outstr_nowrap(
     int		col = gui.col;
 #ifdef FEAT_SIGN_ICONS
     int		draw_sign = FALSE;
-    int		signcol = col;
+    int		signcol;
     char_u	extra[18];
 # ifdef FEAT_NETBEANS_INTG
     int		multi_sign = FALSE;
@@ -2290,6 +2290,8 @@ gui_outstr_nowrap(
 	len = (int)STRLEN(s);
 	if (len > 2)
 	    signcol = col + len - 3;	// Right align sign icon in the number column
+	else
+	    signcol = col;
 	draw_sign = TRUE;
 	highlight_mask = 0;
     }


### PR DESCRIPTION
A previous change (#4627) fixed an issue where sign icons were not displayed correctly with non-zero foldcolumn setting, but it introduced a small regression where it sometimes causes the sign icon to be mis-aligned by one column if cursorline is on, and the cursor is on the line where there's a sign icon.

Fix the regression by making sure we assign `signcol` to `col` only after it's been fully calculated.
