### PR TITLE
Can't scroll with border.

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -317,7 +317,7 @@ popup_handle_scrollbar_click(win_T *wp, int row, int col)
 	return;
     if (row >= wp->w_popup_border[0]
 	    && row < height - wp->w_popup_border[2]
-	    && col == popup_width(wp) - 1)
+	    && col == popup_width(wp) - wp->w_popup_border[1] - 1)
     {
 	if (row >= height / 2)
 	{


### PR DESCRIPTION
Can't scroll with border such as following case:
```vim:
call popup_menu(repeat(['123456789'], 10), {
            \ 'maxheight' : 5,
            \ 'close' : 'button',
            \ })
```

![popup](https://user-images.githubusercontent.com/1595779/61056361-2bb14700-a42e-11e9-9e11-f10b0c428bc2.jpg)

