### PR TITLE
compiler/gcc.vim: fix Entering/Leaving patterns

### DIFF
--- a/runtime/compiler/gcc.vim
+++ b/runtime/compiler/gcc.vim
@@ -27,10 +27,10 @@ CompilerSet errorformat=
       \%f:%l:\ %m,
       \%f:\\(%*[^\\)]\\):\ %m,
       \\"%f\"\\,\ line\ %l%*\\D%c%*[^\ ]\ %m,
-      \%D%*\\a[%*\\d]:\ Entering\ directory\ [`']%f',
-      \%X%*\\a[%*\\d]:\ Leaving\ directory\ [`']%f',
-      \%D%*\\a:\ Entering\ directory\ [`']%f',
-      \%X%*\\a:\ Leaving\ directory\ [`']%f',
+      \%D%*\\a[%*\\d]:\ Entering\ directory\ %*[`']%f',
+      \%X%*\\a[%*\\d]:\ Leaving\ directory\ %*[`']%f',
+      \%D%*\\a:\ Entering\ directory\ %*[`']%f',
+      \%X%*\\a:\ Leaving\ directory\ %*[`']%f',
       \%DMaking\ %*\\a\ in\ %f
 
 if exists('g:compiler_gcc_ignore_unmatched_lines')


### PR DESCRIPTION
This was fixed for the default errorformat in v7.4.138 (4ea924e0a).