### PR TITLE
Flaky test performs better

### DIFF
--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -521,6 +521,8 @@ func Test_popup_select()
 
   call term_sendkeys(buf, ":call popup_close(winid)\<CR>")
   call term_sendkeys(buf, "\"*p")
+  " cleanup it becuase sometimes keystroke remains in commandline.
+  call term_sendkeys(buf, ":\<esc>")
   call VerifyScreenDump(buf, 'Test_popupwin_select_02', {})
 
   " clean up


### PR DESCRIPTION
In some platforms(e.g. MacOS's Terminal) Test_popupwin_select_02 failed. this PR is to succeed it.

```
From test_popupwin.vim:
Found errors in Test_popup_select():
Run 1:
function RunTheTest[40]..Test_popup_select[31]..VerifyScreenDump line 55: See dump file difference: call term_dumpdiff("testdir/failed/Test_popupwin_select_02.dump", "testdir/dumps/Test_popupwin_select_02.dump"); difference in line 1: "|1+0&#ffffff0|w|o|r|d| @69"; difference in line 10: "|:|<|e|s|c|>> @68"
Run 2:
function RunTheTest[40]..Test_popup_select[31]..VerifyScreenDump line 55: See dump file difference: call term_dumpdiff("testdir/failed/Test_popupwin_select_02.dump", "testdir/dumps/Test_popupwin_select_02.dump"); difference in line 1: "|1+0&#ffffff0|w|o|r|d| @69"; difference in line 10: "|:|<|e|s|c|>> @68"
Flaky test failed too often, giving up
```