### PR TITLE
add an option to setting the default statusline of quickfix

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2624,6 +2624,14 @@ Note: only existence of these options matter, not their value. You can replace
       1 above with anything.
 
 
+QF						    *qf.vim* *ft-qf-syntax*
+
+The quickfix syntax includes configuration for displaying the command that
+produced the quickfix list in the |statusline|. To disable this setting,
+configure as follows: >
+	:let g:qf_disable_statusline = 1
+
+
 QUAKE						*quake.vim* *ft-quake-syntax*
 
 The Quake syntax definition should work for most any FPS (First Person

--- a/runtime/ftplugin/qf.vim
+++ b/runtime/ftplugin/qf.vim
@@ -10,7 +10,7 @@ endif
 " Don't load another plugin for this buffer
 let b:did_ftplugin = 1
 
-if get(g:, 'qf_default_statusline')
+if !get(g:, 'qf_disable_statusline')
   let b:undo_ftplugin = "set stl<"
 
   " Display the command that produced the list in the quickfix window:

--- a/runtime/ftplugin/qf.vim
+++ b/runtime/ftplugin/qf.vim
@@ -10,7 +10,9 @@ endif
 " Don't load another plugin for this buffer
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "set stl<"
+if get(g:, 'qf_default_statusline')
+  let b:undo_ftplugin = "set stl<"
 
-" Display the command that produced the list in the quickfix window:
-setlocal stl=%t%{exists('w:quickfix_title')?\ '\ '.w:quickfix_title\ :\ ''}\ %=%-15(%l,%c%V%)\ %P
+  " Display the command that produced the list in the quickfix window:
+  setlocal stl=%t%{exists('w:quickfix_title')?\ '\ '.w:quickfix_title\ :\ ''}\ %=%-15(%l,%c%V%)\ %P
+end


### PR DESCRIPTION
I think setting the statusline in default ftplugin causes many problems.

- User's statusline configuration is overwritten unexpectedly in quickfix/location windows.
- There's FileType event to overwrite the statusline of the ftplugin but this is dirty and introduce some processing time that would be unnecessary if the default ftplugin did not modify the statusline.
- ftplugin/qf.vim is the only default ftplugin which modifies the statusline.

This is a patch to introduce a global flag to enable the statusline in the ftplugin. What do you think @llorens @chrisbra?

Related comment: https://github.com/vim/vim/issues/4278#issuecomment-489654979.