### PR TITLE
Workaround for vim.exe

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3737,7 +3737,7 @@ ResizeConBufAndWindow(
 {
     CONSOLE_SCREEN_BUFFER_INFO csbi;	/* hold current console buffer info */
     SMALL_RECT	    srWindowRect;	/* hold the new console size */
-    COORD	    coordScreen;
+    COORD	    coordScreen, cursor;
     static int	    resized = FALSE;
 
 #ifdef MCH_WRITE_DUMP
@@ -3792,6 +3792,9 @@ ResizeConBufAndWindow(
     }
     else
     {
+	cursor.X = srWindowRect.Left;
+	cursor.Y = srWindowRect.Top;
+	SetConsoleCursorPosition(hConsole, cursor);
 	ResizeConBuf(hConsole, coordScreen);
 	ResizeWindow(hConsole, srWindowRect);
 	resized = TRUE;


### PR DESCRIPTION
When start vim.exe at the bottom line of the command prompt on Windows 10, vim always hangs. As far as I looked the cause of this crash, this seems to be a bug of Windows 10. I made a patch for workaround to fix this crash.

If the cursor location is at bottom line and call SetConsoleScreenBufferSize, this bug occur.