### PR TITLE
Do not lose first key after changing buffer in term exit callback

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -4443,6 +4443,7 @@ has_non_ascii(char_u *s)
 parse_queued_messages(void)
 {
     win_T   *old_curwin = curwin;
+    buf_T   *old_curbuf = curbuf;
     int	    i;
     int	    save_may_garbage_collect = may_garbage_collect;
 
@@ -4494,9 +4495,9 @@ parse_queued_messages(void)
 
     may_garbage_collect = save_may_garbage_collect;
 
-    // If the current window changed we need to bail out of the waiting loop.
-    // E.g. when a job exit callback closes the terminal window.
-    if (curwin != old_curwin)
+    // If the current window or buffer changed we need to bail out of the
+    // waiting loop.  E.g. when a job exit callback closes the terminal window.
+    if (curwin != old_curwin || curbuf != old_curbuf)
 	ins_char_typebuf(K_IGNORE);
 }
 #endif

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -4497,7 +4497,7 @@ parse_queued_messages(void)
 
     // If the current window or buffer changed we need to bail out of the
     // waiting loop.  E.g. when a job exit callback closes the terminal window.
-    if (curwin != old_curwin || curbuf != old_curbuf)
+    if (curwin->w_id != old_curwin->w_id || curbuf != old_curbuf)
 	ins_char_typebuf(K_IGNORE);
 }
 #endif


### PR DESCRIPTION
This fixes #3522, which is a lot like #2302, hence the fix is also very similar to f4c8db03218b747f3f4f84e21121ee2723157e70.

It looks as if closing and creating new window goes unnoticed by the `(curwin != old_curwin)`, so I've added ` || curbuf != old_curbuf`, but I suspect that it might fail for some commands as well if the original check fails because pointers of old and new windows are the same even when windows are different (or maybe I'm just misunderstanding something).

I also tried to add a test:
```vim
func Test_terminal_close_from_callback()
    let g:map_worked = 'no'

    nnoremap 1 :let g:map_worked = 'yes'<cr>

    function! TestCb(job, code)
        enew
    endfunction

    let buf = Run_shell_in_terminal({ 'exit_cb': 'TestCb' })
    call StopShellInTerminal(buf)

    " always succeeds
    " call feedkeys("1", 'tx')
    " always fails
    " call test_feedinput("1")

    call assert_equal('yes', g:map_worked)

    nunmap 1
endfunc
```
But as comments suggest, it didn't work. Given that Bram didn't test the previous fix, I guess it's not something that's easy to test.