### PR TITLE
Fix encoding of E325 message

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -2142,7 +2142,23 @@ get_ctime(time_t thetime, int add_newline)
     if (curtime == NULL)
 	vim_strncpy((char_u *)buf, (char_u *)_("(Invalid)"), sizeof(buf) - 1);
     else
+    {
 	(void)strftime(buf, sizeof(buf) - 1, "%a %b %d %H:%M:%S %Y", curtime);
+# ifdef MSWIN
+	if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
+	{
+	    char_u	*to_free = NULL;
+	    int		len;
+
+	    acp_to_enc((char_u *)buf, (int)strlen(buf), &to_free, &len);
+	    if (to_free != NULL)
+	    {
+		STRCPY(buf, to_free);
+		vim_free(to_free);
+	    }
+	}
+# endif
+    }
 #else
     STRCPY(buf, "(unknown)");
 #endif

--- a/src/memline.c
+++ b/src/memline.c
@@ -2143,7 +2143,8 @@ get_ctime(time_t thetime, int add_newline)
 	vim_strncpy((char_u *)buf, (char_u *)_("(Invalid)"), sizeof(buf) - 1);
     else
     {
-	(void)strftime(buf, sizeof(buf) - 1, "%a %b %d %H:%M:%S %Y", curtime);
+	(void)strftime(buf, sizeof(buf) - 1, _("%a %b %d %H:%M:%S %Y"),
+								    curtime);
 # ifdef MSWIN
 	if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
 	{


### PR DESCRIPTION
Fixes #4681.

Also make the time format of the E325 message translatable.