### PR TITLE
Proposal: Add 'inputsecretopt' option

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5974,6 +5974,8 @@ inputsecret({prompt} [, {text}])			*inputsecret()*
 		|history| stack.
 		The result is a String, which is whatever the user actually
 		typed on the command-line in response to the issued prompt.
+		'inputsecretopt' changes the display state of the input
+		characters.
 		NOTE: Command-line completion is not supported.
 
 insert({object}, {item} [, {idx}])			*insert()*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2302,6 +2302,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'cryptmethod'* *'cm'*
 'cryptmethod' 'cm'	string	(default "blowfish2")
 			global or local to buffer |global-local|
+			{only available when compiled with the |+cryptv|
+			feature}
 	Method used for encryption when the buffer is written to a file:
 							*pkzip*
 	   zip		PkZip compatible method.  A weak kind of encryption.
@@ -4345,6 +4347,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 	has a lowercase letter where the typed text has an uppercase letter,
 	and there is a letter before it, the completed part is made uppercase.
 	With 'noinfercase' the match is used as-is.
+
+						*'inputsecretopt'* *'iscopt'*
+'inputsecretopt' 'iscopt' string (default empty)
+			global
+			{only available when compiled with the |+cryptv|
+			feature}
+	A comma separated list of options for |inputsecret()|.
+	  showlast	Show the last input character.
+	  reveal	Toggle show/mask the input characters by CTRL-X.
 
 			*'insertmode'* *'im'* *'noinsertmode'* *'noim'*
 'insertmode' 'im'	boolean	(default off)

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1107,6 +1107,10 @@ call append("$", "cedit\tkey used to open the command-line window")
 call <SID>OptionG("cedit", &cedit)
 call append("$", "cmdwinheight\theight of the command-line window")
 call <SID>OptionG("cwh", &cwh)
+if has('cryptv') || has('eval')
+  call append("$", "inputsecretopt\toptions for inputsecret()")
+  call <SID>OptionG("iscopt", &iscopt)
+endif
 
 
 call <SID>Header("executing external commands")

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2494,7 +2494,10 @@ returncmd:
 	    }
 	}
 #endif
-
+#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
+	if (inputsecret_show_last || inputsecret_reveal)
+	    redrawcmd();
+#endif
 	if (gotesc)
 	    abandon_cmdline();
     }

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -139,6 +139,18 @@ static int	open_cmdwin(void);
 static int	sort_func_compare(const void *s1, const void *s2);
 #endif
 
+#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
+    static void
+inputsecretopt_was_set()
+{
+    inputsecret_show_last = FALSE;
+    inputsecret_reveal = FALSE;
+    if (strstr((char *)p_iscopt, "showlast") != NULL)
+	inputsecret_show_last = TRUE;
+    if (strstr((char *)p_iscopt, "reveal") != NULL)
+	inputsecret_reveal = TRUE;
+}
+#endif
 
     static void
 trigger_cmd_autocmd(int typechar, int evt)
@@ -924,6 +936,8 @@ getcmdline_int(
 #if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
     ccline.cmdprevlen = ccline.cmdprevpos = 0;
     ccline.hidden = cmdline_star > 0;
+
+    inputsecretopt_was_set();
 #endif
 
 #ifdef FEAT_SEARCH_EXTRA
@@ -1114,7 +1128,7 @@ getcmdline_int(
 		|| c == intr_char
 #endif
 				)
-#if defined(FEAT_EVAL) || defined(FEAT_CRYPT)
+#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
 		&& firstc != '@'
 #endif
 #ifdef FEAT_EVAL
@@ -3851,19 +3865,6 @@ gotocmdline(int clr)
 	msg_clr_eos();	    /* will reset clear_cmdline */
     windgoto(cmdline_row, 0);
 }
-
-#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
-    void
-inputsecretopt_was_set()
-{
-    inputsecret_show_last = FALSE;
-    inputsecret_reveal = FALSE;
-    if (strstr((char *)p_iscopt, "showlast") != NULL)
-	inputsecret_show_last = TRUE;
-    if (strstr((char *)p_iscopt, "reveal") != NULL)
-	inputsecret_reveal = TRUE;
-}
-#endif
 
 /*
  * Check the word in front of the cursor for an abbreviation.

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2442,20 +2442,25 @@ cmdline_changed:
 	may_do_incsearch_highlighting(firstc, count, &is_state);
 #endif
 
+	// Always redraw the whole command line to fix shaping and right-left
+	// typing or to draw the last character when 'inputsecretopt' is set.
+	// Not efficient, but it works.
+	// Do it only when there are no characters left to read to avoid
+	// useless intermediate redraws.
+	if (0
 #ifdef FEAT_RIGHTLEFT
-	if (cmdmsg_rl
+		|| ((cmdmsg_rl
 # ifdef FEAT_ARABIC
-		|| (p_arshape && !p_tbidi
-				       && cmdline_has_arabic(0, ccline.cmdlen))
+			|| (p_arshape && !p_tbidi
+				     && cmdline_has_arabic(0, ccline.cmdlen)))
+		    && vpeekc() == NUL)
 # endif
-		)
-	    /* Always redraw the whole command line to fix shaping and
-	     * right-left typing.  Not efficient, but it works.
-	     * Do it only when there are no characters left to read
-	     * to avoid useless intermediate redraws. */
-	    if (vpeekc() == NUL)
-		redrawcmd();
 #endif
+#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
+		|| (inputsecret_show_last || inputsecret_reveal)
+#endif
+		)
+	    redrawcmd();
     }
 
 returncmd:

--- a/src/option.c
+++ b/src/option.c
@@ -6852,8 +6852,6 @@ did_set_string_option(
     {
 	if (check_opt_strings(*varp, p_iscopt_values, TRUE) != OK)
 	    errmsg = e_invarg;
-	else
-	    inputsecretopt_was_set();
     }
 #endif
 

--- a/src/option.c
+++ b/src/option.c
@@ -1584,6 +1584,15 @@ static struct vimoption options[] =
     {"infercase",   "inf",  P_BOOL|P_VI_DEF,
 			    (char_u *)&p_inf, PV_INF,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
+    {"inputsecretopt", "iscopt", P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
+#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
+			    (char_u *)&p_iscopt, PV_NONE,
+			    {(char_u *)"", (char_u *)0L}
+#else
+			    (char_u *)NULL, PV_NONE,
+			    {(char_u *)0L, (char_u *)0L}
+#endif
+			    SCTX_INIT},
     {"insertmode",  "im",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_im, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
@@ -3229,6 +3238,9 @@ static char *(p_fcl_values[]) = {"all", NULL};
 #endif
 #ifdef FEAT_INS_EXPAND
 static char *(p_cot_values[]) = {"menu", "menuone", "longest", "preview", "noinsert", "noselect", NULL};
+#endif
+#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
+static char *(p_iscopt_values[]) = {"showlast", "reveal", NULL};
 #endif
 #ifdef FEAT_SIGNS
 static char *(p_scl_values[]) = {"yes", "no", "auto", "number", NULL};
@@ -6834,6 +6846,17 @@ did_set_string_option(
     }
 #endif
 
+#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
+    /* 'inputsecretopt' */
+    else if (varp == &p_iscopt)
+    {
+	if (check_opt_strings(*varp, p_iscopt_values, TRUE) != OK)
+	    errmsg = e_invarg;
+	else
+	    inputsecretopt_was_set();
+    }
+#endif
+
     /* 'matchpairs' */
     else if (gvarp == &p_mps)
     {
@@ -7467,7 +7490,6 @@ did_set_string_option(
 	    curwin->w_nrwidth_line_count = 0;
     }
 #endif
-
 
 #if defined(FEAT_TOOLBAR) && !defined(FEAT_GUI_MSWIN)
     /* 'toolbar' */

--- a/src/option.h
+++ b/src/option.h
@@ -570,6 +570,9 @@ EXTERN char_u	*p_imsf;	/* 'imstatusfunc' */
 EXTERN int	p_imcmdline;	/* 'imcmdline' */
 EXTERN int	p_imdisable;	/* 'imdisable' */
 EXTERN int	p_is;		/* 'incsearch' */
+#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
+EXTERN char_u	*p_iscopt;	/* 'inputsecretopt' */
+#endif
 EXTERN int	p_im;		/* 'insertmode' */
 EXTERN char_u	*p_isf;		/* 'isfname' */
 EXTERN char_u	*p_isi;		/* 'isident' */

--- a/src/proto/ex_getln.pro
+++ b/src/proto/ex_getln.pro
@@ -22,6 +22,7 @@ void redrawcmdline_ex(int do_compute_cmdrow);
 void redrawcmd(void);
 void compute_cmdrow(void);
 void gotocmdline(int clr);
+void inputsecretopt_was_set();
 char_u *ExpandOne(expand_T *xp, char_u *str, char_u *orig, int options, int mode);
 void ExpandInit(expand_T *xp);
 void ExpandCleanup(expand_T *xp);

--- a/src/proto/ex_getln.pro
+++ b/src/proto/ex_getln.pro
@@ -22,7 +22,6 @@ void redrawcmdline_ex(int do_compute_cmdrow);
 void redrawcmd(void);
 void compute_cmdrow(void);
 void gotocmdline(int clr);
-void inputsecretopt_was_set();
 char_u *ExpandOne(expand_T *xp, char_u *str, char_u *orig, int options, int mode);
 void ExpandInit(expand_T *xp);
 void ExpandCleanup(expand_T *xp);

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -102,6 +102,7 @@ let test_values = {
       \ 'helplang': [['', 'de', 'de,it'], ['xxx']],
       \ 'highlight': [['', 'e:Error'], ['xxx']],
       \ 'imactivatekey': [['', 'S-space'], ['xxx']],
+      \ 'inputsecretopt': [['', 'showlast', 'showlast,reveal'], ['xxx', 'showlast,,reveal,']],
       \ 'isfname': [['', '@', '@,48-52'], ['xxx', '@48']],
       \ 'isident': [['', '@', '@,48-52'], ['xxx', '@48']],
       \ 'iskeyword': [['', '@', '@,48-52'], ['xxx', '@48']],


### PR DESCRIPTION
I propose to add `'inputsecretopt'` option to improve the usability of `inputsecret()`.

`'inputsecretopt'` (`'iscopt'`) accepts the below one or both string values (or empty).

* `showlast`: Show the last input character
* `reveal`: Can toggle reveal/mask the input characters by Ctrl-X

![ttyrec](https://user-images.githubusercontent.com/943423/61415169-f8d5ea00-a92a-11e9-95c9-db5d5a72c3d8.gif)
