### PR TITLE
Fix signcolumn=number

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -3120,8 +3120,7 @@ get_sign_display_info(
 		{
 		    if (nrcol)
 		    {
-			int n, width = number_width(wp)
-				    - (*mb_string2cells)(*pp_extra, -1);
+			int n, width = number_width(wp) - 2;
 			for (n = 0; n < width; n++)
 			    extra[n] = ' ';
 			extra[n] = 0;

--- a/src/screen.c
+++ b/src/screen.c
@@ -3120,9 +3120,13 @@ get_sign_display_info(
 		{
 		    if (nrcol)
 		    {
-			sprintf((char *)extra, "%*s ",
-			    number_width(wp) + (*mb_ptr2cells)(*pp_extra) - 1,
-				    *pp_extra);
+			int n, width = number_width(wp)
+				    - (*mb_string2cells)(*pp_extra, -1);
+			for (n = 0; n < width; n++)
+			    extra[n] = ' ';
+			extra[n] = 0;
+			strcat((char *) extra, (char *) *pp_extra);
+			strcat((char *) extra, " ");
 			*pp_extra = extra;
 		    }
 		    *c_extrap = NUL;

--- a/src/screen.c
+++ b/src/screen.c
@@ -3120,8 +3120,9 @@ get_sign_display_info(
 		{
 		    if (nrcol)
 		    {
-			sprintf((char *)extra, "%*s ", number_width(wp),
-								*pp_extra);
+			sprintf((char *)extra, "%*s ",
+			    number_width(wp) + (*mb_ptr2cells)(*pp_extra) - 1,
+				    *pp_extra);
 			*pp_extra = extra;
 		    }
 		    *c_extrap = NUL;

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -1766,6 +1766,7 @@ func Test_sign_numcol()
   set number
   set signcolumn=number
   sign define sign1 text==>
+  sign define sign2 text=Ｖ
   sign place 10 line=1 name=sign1
   redraw!
   call assert_equal("=> 01234", s:ScreenLine(1, 1, 8))
@@ -1846,6 +1847,12 @@ func Test_sign_numcol()
   redraw!
   call assert_equal("=> 01234", s:ScreenLine(1, 1, 8))
   call assert_equal(" 2 abcde", s:ScreenLine(2, 1, 8))
+  " Add sign with multi-byte text
+  set numberwidth=4
+  sign place 40 line=2 name=sign2
+  redraw!
+  call assert_equal(" => 01234", s:ScreenLine(1, 1, 9))
+  call assert_equal(" Ｖ abcde", s:ScreenLine(2, 1, 9))
 
   sign unplace * group=*
   sign undefine sign1


### PR DESCRIPTION
When number signcolumn=number, multi-byte sign text is broken.

```vim
set number
set signcolumn=number
sign define test1 text=山
sign define test2 text=a
sign place 2 line=10 name=test1
sign place 2 line=11 name=test2



"xxx
"xxx
"
```

Current behavior
![image](https://user-images.githubusercontent.com/10111/61433075-4b37fa80-a96d-11e9-9ae5-e10b02c3b3f7.png)

Fixed
![image](https://user-images.githubusercontent.com/10111/61433109-6276e800-a96d-11e9-9739-fb1633adc9d2.png)


