### PR TITLE
Add support for conditional assignment using ?=

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -11245,6 +11245,16 @@ This does NOT work: >
 			from the {expr}.  If {var-name} didn't exist yet, it
 			is created.
 
+:let {var-name} ?= {expr1}				*:let?=*
+			Set internal variable {var-name} to the result of the
+			expression {expr1} only if {var-name} doesn't exist.
+			This statement: >
+			  let foo ?= "bar"
+<			is equivalent to this: >
+			  if !exists("foo")
+			    let foo = "bar"
+			  endif
+<
 :let {var-name}[{idx}] = {expr1}			*E689*
 			Set a list item to the result of the expression
 			{expr1}.  {var-name} must refer to a list and {idx}
@@ -11286,6 +11296,10 @@ This does NOT work: >
 :let ${env-name} = {expr1}			*:let-environment* *:let-$*
 			Set environment variable {env-name} to the result of
 			the expression {expr1}.  The type is always String.
+:let ${env-name} ?= {expr}
+			Set environment variable {env-name} to the result of
+			the expression {expr1} if {env-name} doesn't exist.
+			The type is always String.
 :let ${env-name} .= {expr1}
 			Append {expr1} to the environment variable {env-name}.
 			If the environment variable didn't exist yet this

--- a/src/eval.c
+++ b/src/eval.c
@@ -1489,7 +1489,7 @@ ex_let_const(exarg_T *eap, int is_const)
  * Handles both "var" with any type and "[var, var; var]" with a list type.
  * When "op" is not NULL it points to a string with characters that
  * must appear after the variable(s).  Use "+", "-", "." or "?" for add,
- * subtract or concatenate or conditionally assign.
+ * subtract, concatenate or conditionally assign.
  * Returns OK or FAIL;
  */
     static int

--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -152,6 +152,32 @@ func Test_let_utf8_environment()
   call assert_equal('ĀĒĪŌŪあいうえお', $a)
 endfunc
 
+" Test for conditional assignment
+func Test_let_cond()
+  let var1 ?= 10
+  call assert_equal(10, var1)
+  let var1 ?= 20
+  call assert_equal(10, var1)
+
+  let [var1, var2] ?= [30, 40]
+  call assert_equal([10, 40], [var1, var2])
+
+  let var3 ?= [1, 2]
+  call assert_equal([1, 2], var3)
+
+  let var4 = {}
+  let var4.a ?= 'vim'
+  call assert_equal({'a' : 'vim'}, var4)
+  let var4.a ?= 'edit'
+  call assert_equal({'a' : 'vim'}, var4)
+
+  let $TESTVAR ?= 'linux'
+  call assert_equal('linux', $TESTVAR)
+  let $TESTVAR ?= 'window'
+  call assert_equal('linux', $TESTVAR)
+  unlet $TESTVAR
+endfunc
+
 func Test_let_heredoc_fails()
   call assert_fails('let v =<< marker', 'E991:')
 


### PR DESCRIPTION
I have ported the diff sent by Dave Eggum in 2006 to add support
for conditional assignment using ?=.

The following item in the todo list refers to this:

-   Add ":let var ?= value", conditional assignment.  Patch by Dave Eggum,
    2006 Dec 11.

The e-mail thread is here:

https://marc.info/?l=vim-dev&m=116591795423455&w=2
