### PR TITLE
Add a lazy version of get() function (evaluate {default} lazily)

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4727,6 +4727,7 @@ garbagecollect([{atexit}])				*garbagecollect()*
 get_lazy({list}, {idx} [, {defaultfunc}])
 get_lazy({blob}, {idx} [, {defaultfunc}])
 get_lazy({dict}, {key} [, {defaultfunc}])
+get_lazy({func}, {what})
 		Same as |get()| but if {defaultfunc} was given and the item is not
 		available, call {defaultfunc} and return the result.
 >

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4729,7 +4729,31 @@ get_lazy({blob}, {idx} [, {defaultfunc}])
 get_lazy({dict}, {key} [, {defaultfunc}])
 		Same as |get()| but if {defaultfunc} was given and the item is not
 		available, call {defaultfunc} and return the result.
+>
+	function! s:do_heavy_computation(key)
+	    " assume doing some heavy computations here...
+	    return len(a:key) * 2
+	endfunction
 
+	function! s:init_missing(dict, key)
+	    let val = s:do_heavy_computation(a:key)
+	    let a:dict[a:key] = val
+	    return val
+	endfunction
+
+	function! s:main()
+	    " result == 14 == len(a:key) * 2
+	    let dict = {}
+	    let result = get_lazy(dict, 'missing', {-> s:init_missing(dict, 'missing')})
+	    echo result
+
+	    " s:init_missing() is not called here, because dict['missing'] exists
+	    let result = get_lazy(dict, 'missing', {-> s:init_missing(dict, 'missing')})
+	    echo result
+	endfunction
+
+	call s:main()
+<
 get({list}, {idx} [, {default}])			*get()*
 		Get item {idx} from |List| {list}.  When this item is not
 		available return {default}.  Return zero when {default} is

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2392,6 +2392,9 @@ funcref({name} [, {arglist}] [, {dict}])
 function({name} [, {arglist}] [, {dict}])
 				Funcref	named reference to function {name}
 garbagecollect([{atexit}])	none	free memory, breaking cyclic references
+get_lazy({list}, {idx} [, {deffunc}])	any	get item {idx} from {list} or result of {deffunc}
+get_lazy({dict}, {key} [, {deffunc}])	any	get item {key} from {dict} or result of {deffunc}
+get_lazy({func}, {what})		any	same as get({func}, {what})
 get({list}, {idx} [, {def}])	any	get item {idx} from {list} or {def}
 get({dict}, {key} [, {def}])	any	get item {key} from {dict} or {def}
 get({func}, {what})		any	get property of funcref/partial {func}
@@ -4719,6 +4722,13 @@ garbagecollect([{atexit}])				*garbagecollect()*
 		it's safe to perform.  This is when waiting for the user to
 		type a character.  To force garbage collection immediately use
 		|test_garbagecollect_now()|.
+
+							*get_lazy()*
+get_lazy({list}, {idx} [, {defaultfunc}])
+get_lazy({blob}, {idx} [, {defaultfunc}])
+get_lazy({dict}, {key} [, {defaultfunc}])
+		Same as |get()| but if {defaultfunc} was given and the item is not
+		available, call {defaultfunc} and return the result.
 
 get({list}, {idx} [, {default}])			*get()*
 		Get item {idx} from |List| {list}.  When this item is not

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4332,10 +4332,13 @@ common_get(typval_T *argvars, typval_T *rettv, int is_lazy)
 
     if (tv == NULL)
     {
-	if (is_lazy)
-	    eval_expr_typval(&argvars[2], NULL, 0, rettv);
-	else if (argvars[2].v_type != VAR_UNKNOWN)
-	    copy_tv(&argvars[2], rettv);
+	if (argvars[2].v_type != VAR_UNKNOWN)
+	{
+	    if (is_lazy)
+		eval_expr_typval(&argvars[2], NULL, 0, rettv);
+	    else
+		copy_tv(&argvars[2], rettv);
+	}
     }
     else
 	copy_tv(tv, rettv);

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -140,6 +140,7 @@ static void f_funcref(typval_T *argvars, typval_T *rettv);
 static void f_function(typval_T *argvars, typval_T *rettv);
 static void f_garbagecollect(typval_T *argvars, typval_T *rettv);
 static void f_get(typval_T *argvars, typval_T *rettv);
+static void f_get_lazy(typval_T *argvars, typval_T *rettv);
 static void f_getbufinfo(typval_T *argvars, typval_T *rettv);
 static void f_getbufline(typval_T *argvars, typval_T *rettv);
 static void f_getbufvar(typval_T *argvars, typval_T *rettv);
@@ -592,6 +593,7 @@ static struct fst
     {"function",	1, 3, f_function},
     {"garbagecollect",	0, 1, f_garbagecollect},
     {"get",		2, 3, f_get},
+    {"get_lazy",	2, 3, f_get_lazy},
     {"getbufinfo",	0, 1, f_getbufinfo},
     {"getbufline",	2, 3, f_getbufline},
     {"getbufvar",	2, 3, f_getbufvar},
@@ -4227,11 +4229,8 @@ f_garbagecollect(typval_T *argvars, typval_T *rettv UNUSED)
 	garbage_collect_at_exit = TRUE;
 }
 
-/*
- * "get()" function
- */
     static void
-f_get(typval_T *argvars, typval_T *rettv)
+common_get(typval_T *argvars, typval_T *rettv, int is_lazy)
 {
     listitem_T	*li;
     list_T	*l;
@@ -4329,15 +4328,35 @@ f_get(typval_T *argvars, typval_T *rettv)
 	}
     }
     else
-	semsg(_(e_listdictblobarg), "get()");
+	semsg(_(e_listdictblobarg), is_lazy ? "get_lazy()" : "get()");
 
     if (tv == NULL)
     {
-	if (argvars[2].v_type != VAR_UNKNOWN)
+	if (is_lazy)
+	    eval_expr_typval(&argvars[2], NULL, 0, rettv);
+	else if (argvars[2].v_type != VAR_UNKNOWN)
 	    copy_tv(&argvars[2], rettv);
     }
     else
 	copy_tv(tv, rettv);
+}
+
+/*
+ * "get()" function
+ */
+    static void
+f_get(typval_T *argvars, typval_T *rettv)
+{
+    common_get(argvars, rettv, FALSE);
+}
+
+/*
+ * "get_lazy()" function
+ */
+    static void
+f_get_lazy(typval_T *argvars, typval_T *rettv)
+{
+    common_get(argvars, rettv, TRUE);
 }
 
 /*

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -133,6 +133,7 @@ NEW_TESTS = \
 	test_fold \
 	test_functions \
 	test_ga \
+	test_get_lazy \
 	test_getcwd \
 	test_getvar \
 	test_gf \

--- a/src/testdir/test_get_lazy.vim
+++ b/src/testdir/test_get_lazy.vim
@@ -7,6 +7,8 @@ func Test_get_lazy_dict()
   call assert_equal(42, result, 'result == 42')
   let result = get_lazy(d, 'bar', {-> 999})
   call assert_equal(999, result, 'result == 999')
+  let result = get_lazy(d, 'bar', {... -> a:000})
+  call assert_equal([], result, 'result == []')
 endfunc
 
 " get_lazy({list}, {idx} [, {defaultfunc}])
@@ -18,6 +20,8 @@ func Test_get_lazy_list()
   call assert_equal(3, result, 'result == 3')
   let result = get_lazy(l, 3, {-> 999})
   call assert_equal(999, result, 'result == 999')
+  let result = get_lazy(l, 3, {... -> a:000})
+  call assert_equal([], result, 'result == []')
 endfunc
 
 " get_lazy({blob}, {idx} [, {defaultfunc}])
@@ -29,6 +33,8 @@ func Test_get_lazy_blob()
   call assert_equal(0xEF, result, 'result == 0xEF')
   let result = get_lazy(b, 4, {-> 999})
   call assert_equal(999, result, 'result == 999')
+  let result = get_lazy(b, 4, {... -> a:000})
+  call assert_equal([], result, 'result == []')
 endfunc
 
 " get_lazy({lambda}, {what})
@@ -40,7 +46,12 @@ func Test_get_lazy_lambda()
   call assert_equal(l:L, l:Result, "l:Result == l:L")
   " FIXME: weird dict value was returned...
   " let l:Result = get_lazy(l:L, 'dict', {-> {'lambda has': 'no dict'}})
-  " call assert_equal({}, l:Result, "l:Result == {'lambda has': 'no dict'}")
+  " call assert_equal({'lambda has': 'no dict'}, l:Result,
+  "\                 "l:Result == {'lambda has': 'no dict'}")
+  " let l:Result = get_lazy(l:L, 'dict', {... -> a:000})
+  " call assert_equal([], l:Result, "l:Result == []")
+  " let l:Result = get_lazy(l:L, 'dict')
+  " call assert_equal(0, l:Result, 'l:Result == 0')
   let l:Result = get_lazy(l:L, 'args')
   call assert_equal([], l:Result, "l:Result == []")
 endfunc
@@ -54,7 +65,12 @@ func Test_get_lazy_func()
   call assert_equal(l:F, l:Result, "l:Result == l:F")
   " FIXME: weird dict value was returned...
   " let l:Result = get_lazy(l:F, 'dict', {-> {'func has': 'no dict'}})
-  " call assert_equal({}, l:Result, "l:Result == {'func has': 'no dict'}")
+  " call assert_equal({'func has': 'no dict'}, l:Result,
+  "\                 "l:Result == {'func has': 'no dict'}")
+  " let l:Result = get_lazy(l:F, 'dict', {-> a:000})
+  " call assert_equal([], l:Result, "l:Result == []")
+  " let l:Result = get_lazy(l:F, 'dict')
+  " call assert_equal(0, l:Result, 'l:Result == 0')
   let l:Result = get_lazy(l:F, 'args')
   call assert_equal([], l:Result, "l:Result == []")
 endfunc
@@ -68,7 +84,12 @@ func Test_get_lazy_partial()
   call assert_equal(function('substitute'), l:Result, "l:Result == function('substitute')")
   " FIXME: weird dict value was returned...
   " let l:Result = get_lazy(l:P, 'dict', {-> {'partial has': 'no dict'}})
-  " call assert_equal({}, l:Result, "l:Result == {'partial has': 'no dict'}")
+  " call assert_equal({'partial has': 'no dict'}, l:Result,
+  "\                 "l:Result == {'partial has': 'no dict'}")
+  " let l:Result = get_lazy(l:P, 'dict', {-> []})
+  " call assert_equal([], l:Result, "l:Result == []")
+  " let l:Result = get_lazy(l:P, 'dict')
+  " call assert_equal(0, l:Result, 'l:Result == 0')
   let l:Result = get_lazy(l:P, 'args')
   call assert_equal(['hello there', 'there'], l:Result, "l:Result == ['hello there', 'there']")
 endfunc
@@ -87,4 +108,10 @@ func Test_get_lazy_heavy_computation()
   let result = get_lazy(d, key, {-> s:init_missing(d, key)})
   call assert_true(called_init, 's:init_missing() was called')
   call assert_equal({'missing': len('missing') * 2}, d, "d == {'missing': len('missing') * 2}")
+  let prev_dict = deepcopy(d)
+
+  let called_init = 0
+  let result = get_lazy(d, key, {-> s:init_missing(d, key)})
+  call assert_false(called_init, 's:init_missing() was NOT called')
+  call assert_equal(prev_dict, d, "d == prev_dict")
 endfunc

--- a/src/testdir/test_get_lazy.vim
+++ b/src/testdir/test_get_lazy.vim
@@ -34,42 +34,42 @@ endfunc
 " get_lazy({lambda}, {what})
 func Test_get_lazy_lambda()
   let l:L = {-> 42}
-  let l:Result = get_lazy(l:L, 'name', {-> 'unknown'})
+  let l:Result = get_lazy(l:L, 'name')
   call assert_match('^<lambda>', l:Result, "l:Result =~ '^<lambda>'")
-  let l:Result = get_lazy(l:L, 'func', {-> function('function')})
+  let l:Result = get_lazy(l:L, 'func')
   call assert_equal(l:L, l:Result, "l:Result == l:L")
   " FIXME: weird dict value was returned...
   " let l:Result = get_lazy(l:L, 'dict', {-> {'lambda has': 'no dict'}})
   " call assert_equal({}, l:Result, "l:Result == {'lambda has': 'no dict'}")
-  let l:Result = get_lazy(l:L, 'args', {-> ['this', 'array', 'wont', 'be', 'returned']})
+  let l:Result = get_lazy(l:L, 'args')
   call assert_equal([], l:Result, "l:Result == []")
 endfunc
 
 " get_lazy({func}, {what})
 func Test_get_lazy_func()
   let l:F = function('tr')
-  let l:Result = get_lazy(l:F, 'name', {-> 'unknown'})
+  let l:Result = get_lazy(l:F, 'name')
   call assert_equal('tr', l:Result, "l:Result == 'tr'")
-  let l:Result = get_lazy(l:F, 'func', {-> function('function')})
+  let l:Result = get_lazy(l:F, 'func')
   call assert_equal(l:F, l:Result, "l:Result == l:F")
   " FIXME: weird dict value was returned...
   " let l:Result = get_lazy(l:F, 'dict', {-> {'func has': 'no dict'}})
   " call assert_equal({}, l:Result, "l:Result == {'func has': 'no dict'}")
-  let l:Result = get_lazy(l:F, 'args', {-> ['this', 'array', 'wont', 'be', 'returned']})
+  let l:Result = get_lazy(l:F, 'args')
   call assert_equal([], l:Result, "l:Result == []")
 endfunc
 
 " get_lazy({partial}, {what})
 func Test_get_lazy_partial()
   let l:P = function('substitute', ['hello there', 'there'])
-  let l:Result = get_lazy(l:P, 'name', {-> 'unknown'})
+  let l:Result = get_lazy(l:P, 'name')
   call assert_equal('substitute', l:Result, "l:Result == 'substitute'")
-  let l:Result = get_lazy(l:P, 'func', {-> function('function')})
+  let l:Result = get_lazy(l:P, 'func')
   call assert_equal(function('substitute'), l:Result, "l:Result == function('substitute')")
   " FIXME: weird dict value was returned...
   " let l:Result = get_lazy(l:P, 'dict', {-> {'partial has': 'no dict'}})
   " call assert_equal({}, l:Result, "l:Result == {'partial has': 'no dict'}")
-  let l:Result = get_lazy(l:P, 'args', {-> ['this', 'array', 'wont', 'be', 'returned']})
+  let l:Result = get_lazy(l:P, 'args')
   call assert_equal(['hello there', 'there'], l:Result, "l:Result == ['hello there', 'there']")
 endfunc
 

--- a/src/testdir/test_get_lazy.vim
+++ b/src/testdir/test_get_lazy.vim
@@ -1,0 +1,90 @@
+" Test get_lazy() function.
+
+" get_lazy({dict}, {key} [, {defaultfunc}])
+func Test_get_lazy_dict()
+  let d = {'foo': 42}
+  let result = get_lazy(d, 'foo', {-> 999})
+  call assert_equal(42, result, 'result == 42')
+  let result = get_lazy(d, 'bar', {-> 999})
+  call assert_equal(999, result, 'result == 999')
+endfunc
+
+" get_lazy({list}, {idx} [, {defaultfunc}])
+func Test_get_lazy_list()
+  let l = [1,2,3]
+  let result = get_lazy(l, 0, {-> 999})
+  call assert_equal(1, result, 'result == 1')
+  let result = get_lazy(l, -1, {-> 999})
+  call assert_equal(3, result, 'result == 3')
+  let result = get_lazy(l, 3, {-> 999})
+  call assert_equal(999, result, 'result == 999')
+endfunc
+
+" get_lazy({blob}, {idx} [, {defaultfunc}])
+func Test_get_lazy_blob()
+  let b = 0zDEADBEEF
+  let result = get_lazy(b, 0, {-> 999})
+  call assert_equal(0xDE, result, 'result == 0xDE')
+  let result = get_lazy(b, -1, {-> 999})
+  call assert_equal(0xEF, result, 'result == 0xEF')
+  let result = get_lazy(b, 4, {-> 999})
+  call assert_equal(999, result, 'result == 999')
+endfunc
+
+" get_lazy({lambda}, {what})
+func Test_get_lazy_lambda()
+  let l:L = {-> 42}
+  let l:Result = get_lazy(l:L, 'name', {-> 'unknown'})
+  call assert_match('^<lambda>', l:Result, "l:Result =~ '^<lambda>'")
+  let l:Result = get_lazy(l:L, 'func', {-> function('function')})
+  call assert_equal(l:L, l:Result, "l:Result == l:L")
+  " FIXME: weird dict value was returned...
+  " let l:Result = get_lazy(l:L, 'dict', {-> {'lambda has': 'no dict'}})
+  " call assert_equal({}, l:Result, "l:Result == {'lambda has': 'no dict'}")
+  let l:Result = get_lazy(l:L, 'args', {-> ['this', 'array', 'wont', 'be', 'returned']})
+  call assert_equal([], l:Result, "l:Result == []")
+endfunc
+
+" get_lazy({func}, {what})
+func Test_get_lazy_func()
+  let l:F = function('tr')
+  let l:Result = get_lazy(l:F, 'name', {-> 'unknown'})
+  call assert_equal('tr', l:Result, "l:Result == 'tr'")
+  let l:Result = get_lazy(l:F, 'func', {-> function('function')})
+  call assert_equal(l:F, l:Result, "l:Result == l:F")
+  " FIXME: weird dict value was returned...
+  " let l:Result = get_lazy(l:F, 'dict', {-> {'func has': 'no dict'}})
+  " call assert_equal({}, l:Result, "l:Result == {'func has': 'no dict'}")
+  let l:Result = get_lazy(l:F, 'args', {-> ['this', 'array', 'wont', 'be', 'returned']})
+  call assert_equal([], l:Result, "l:Result == []")
+endfunc
+
+" get_lazy({partial}, {what})
+func Test_get_lazy_partial()
+  let l:P = function('substitute', ['hello there', 'there'])
+  let l:Result = get_lazy(l:P, 'name', {-> 'unknown'})
+  call assert_equal('substitute', l:Result, "l:Result == 'substitute'")
+  let l:Result = get_lazy(l:P, 'func', {-> function('function')})
+  call assert_equal(function('substitute'), l:Result, "l:Result == function('substitute')")
+  " FIXME: weird dict value was returned...
+  " let l:Result = get_lazy(l:P, 'dict', {-> {'partial has': 'no dict'}})
+  " call assert_equal({}, l:Result, "l:Result == {'partial has': 'no dict'}")
+  let l:Result = get_lazy(l:P, 'args', {-> ['this', 'array', 'wont', 'be', 'returned']})
+  call assert_equal(['hello there', 'there'], l:Result, "l:Result == ['hello there', 'there']")
+endfunc
+
+func Test_get_lazy_heavy_computation()
+  let called_init = 0
+  let d = {}
+  let key = 'missing'
+  func s:init_missing(dict, key) closure
+    let called_init = 1
+    " assume doing some heavy computations here...
+    let val = len(a:key) * 2
+    let a:dict[a:key] = val
+    return val
+  endfunc
+  let result = get_lazy(d, key, {-> s:init_missing(d, key)})
+  call assert_true(called_init, 's:init_missing() was called')
+  call assert_equal({'missing': len('missing') * 2}, d, "d == {'missing': len('missing') * 2}")
+endfunc


### PR DESCRIPTION
`get()` is used also for initializing global variable when the variable does not exist.

```vim
let g:myplugin_globalvar = get(g:, 'myplugin_globalvar', 42)
```

But when I want to initialize the default value, the arguments for `get()` is evaluated before the initialization. 

```vim
" s:build_lazy() is evaluated even if g:myplugin_globalvar DOES EXIST.
let g:myplugin_globalvar = get(g:, 'myplugin_globalvar', s:build_lazy())
```

So I would like to propose `get_lazy()` which evaluates the 3rd argument lazily.

```vim
" s:build_lazy() is evaluated only when g:myplugin_globalvar does not exist.
let g:myplugin_globalvar = get_lazy(g:, 'myplugin_globalvar', {-> s:build_lazy()})
```

## Ref

https://github.com/vim/vim/pull/4695#issuecomment-513139727