### PR TITLE
Add documentation for :const with no argument or one name argument

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -11502,6 +11502,10 @@ text...
 			Note that environment variables, option values and
 			register values cannot be used here, since they cannot
 			be locked.
+:cons[t]
+:cons[t] {var-name}
+			If no argument is given or only {var-name} is given,
+			the behavior is the same as |:let|.
 
 :lockv[ar][!] [depth] {name} ...			*:lockvar* *:lockv*
 			Lock the internal variable {name}.  Locking means that


### PR DESCRIPTION
[Some people reported](https://github.com/vim-jp/issues/issues/1289) that `:const` with no argument is undocumented. This patch adds the documentation for `:const` without argument.