### PR TITLE
Fix not evaluated dictionary access with `scriptversion 2` is always error

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -4059,7 +4059,7 @@ eval5(char_u **arg, typval_T *rettv, int evaluate)
 	// "." is only string concatenation when scriptversion is 1
 	op = **arg;
 	concat = op == '.'
-			&& (*(*arg + 1) == '.' || current_sctx.sc_version < 2);
+			&& (*(*arg + 1) == '.' || current_sctx.sc_version < 2 || !evaluate);
 	if (op != '+' && op != '-' && !concat)
 	    break;
 

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -176,6 +176,13 @@ func Test_vvar_scriptversion2()
   call assert_true(v:versionlong > 8011525)
 endfunc
 
+func Test_dict_access_scriptversion2()
+  let l:x = {'foo': 1}
+
+  call assert_false(0 && l:x.foo)
+  call assert_true(1 && l:x.foo)
+endfunc
+
 func Test_scriptversion()
   call writefile(['scriptversion 9'], 'Xversionscript')
   call assert_fails('source Xversionscript', 'E999:')


### PR DESCRIPTION
## Problem
An error occurs when run a script containing unevaluated dictionary access with `scriptversion 2`.
## Reproduce step

sample.vim

```viml
scriptversion 2

let x = {'foo': 0}

if 0 && x.foo
  echo 'foo'
endif
```

```
$ vim -u NONE -i NONE -N -S sample.vim
```

## Cause
Unevaluted dot operator is always treated as a string concat.

## How to fix
Skip string concat checking when unevaluating.