### PR TITLE
[Small doc patch] make {marker} optional of :let-heredoc

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -11387,7 +11387,7 @@ This does NOT work: >
 			|List| item.
 
 					*:let=<<* *:let-heredoc* *E990* *E991*
-:let {var-name} =<< [trim] {marker}
+:let {var-name} =<< [trim] [{marker}]
 text...
 text...
 {marker}


### PR DESCRIPTION
`{marker}` is optional ("." is used when it was not given).
So `{marker}` should be `[{marker}]`.