### PR TITLE
Increase BREAKCHECK_SKIP to make syntax highlighting faster

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3183,9 +3183,9 @@ vim_fexists(char_u *fname)
 
 #ifndef BREAKCHECK_SKIP
 # ifdef FEAT_GUI		    /* assume the GUI only runs on fast computers */
-#  define BREAKCHECK_SKIP 200
+#  define BREAKCHECK_SKIP 2000
 # else
-#  define BREAKCHECK_SKIP 32
+#  define BREAKCHECK_SKIP 320
 # endif
 #endif
 

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6487,6 +6487,11 @@ syn_get_stack_item(int i)
 #endif
 
 #if defined(FEAT_FOLDING) || defined(PROTO)
+
+# if defined(FEAT_SYN_HL) && defined(FEAT_RELTIME)
+#  define SYN_TIME_LIMIT 1
+# endif
+
 /*
  * Function called to get folding level for line "lnum" in window "wp".
  */


### PR DESCRIPTION
As pointed out by @chrisbra in https://github.com/vim/vim/issues/2712#issuecomment-373379666, BREAKCHECK_SKIP hasn't been changed in a very long time.  Is it necessary to check so often for a break now?  Especially since breaks are now checked in many places.  Using the script in https://github.com/vim/vim/issues/2712#issuecomment-372909689 does show some benefit.

- Also SYN_TIME_LIMIT is not defined in syntax.c since it's defined in screen.c
- Possibly should update the value for windows and mac.
