### PR TITLE
Fix cannot get editing buffer-local commands in cmdwin

### DIFF
--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -313,3 +313,21 @@ func Test_compl_feedkeys()
   bwipe!
   set completeopt&
 endfunc
+
+func Test_compl_in_cmdwin()
+  set wildmenu wildchar=<Tab>
+  com! -nargs=1 -complete=command GetInput let input = <q-args>
+  com! -buffer TestCommand echo 'TestCommand'
+
+  let input = ''
+  call feedkeys("q:iGetInput T\<C-x>\<C-v>\<CR>", 'tx!')
+  call assert_equal('TestCommand', input)
+
+  let input = ''
+  call feedkeys("q::GetInput T\<Tab>\<CR>:q\<CR>", 'tx!')
+  call assert_equal('T', input)
+
+  delcom TestCommand
+  delcom GetInput
+  set wildmenu& wildchar&
+endfunc

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -313,3 +313,18 @@ func Test_compl_feedkeys()
   bwipe!
   set completeopt&
 endfunc
+
+func Test_compl_in_cmdwin()
+  com! -buffer TestCommand echo 'TestCommand'
+  func CheckCompletion()
+    " Check if truely this test is carrying out in cmdwin or not.
+    call assert_equal('[Command Line]', bufname('%'))
+    call assert_equal(['TestCommand'], getcompletion('T', 'command'))
+    return ''
+  endfunc
+  nnoremap <expr> @ CheckCompletion()
+  exec "normal q:@\<C-c>\<C-c>"
+  nunmap @
+  delcom TestCommand
+  delfunc CheckCompletion
+endfunc

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -313,18 +313,3 @@ func Test_compl_feedkeys()
   bwipe!
   set completeopt&
 endfunc
-
-func Test_compl_in_cmdwin()
-  com! -buffer TestCommand echo 'TestCommand'
-  func CheckCompletion()
-    " Check if truely this test is carrying out in cmdwin or not.
-    call assert_equal('[Command Line]', bufname('%'))
-    call assert_equal(['TestCommand'], getcompletion('T', 'command'))
-    return ''
-  endfunc
-  nnoremap <expr> @ CheckCompletion()
-  exec "normal q:@\<C-c>\<C-c>"
-  nunmap @
-  delcom TestCommand
-  delfunc CheckCompletion
-endfunc

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -312,7 +312,7 @@ get_user_commands(expand_T *xp UNUSED, int idx)
     /* In cmdwin, the alternative buffer should be used. */
     buf_T *buf =
 #ifdef FEAT_CMDWIN
-	cmdwin_type != 0 ? prevwin->w_buffer :
+	(cmdwin_type != 0 && get_cmdline_type() == NUL) ? prevwin->w_buffer :
 #endif
 	curbuf;
     if (idx < buf->b_ucmds.ga_len)
@@ -404,7 +404,8 @@ uc_list(char_u *name, size_t name_len)
     /* In cmdwin, the alternative buffer should be used. */
     gap =
 #ifdef FEAT_CMDWIN
-	cmdwin_type != 0 ? &prevwin->w_buffer->b_ucmds :
+	(cmdwin_type != 0 && get_cmdline_type() == NUL) ?
+	&prevwin->w_buffer->b_ucmds :
 #endif
 	&curbuf->b_ucmds;
     for (;;)

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -309,9 +309,15 @@ get_user_command_name(int idx)
     char_u *
 get_user_commands(expand_T *xp UNUSED, int idx)
 {
-    if (idx < curbuf->b_ucmds.ga_len)
-	return USER_CMD_GA(&curbuf->b_ucmds, idx)->uc_name;
-    idx -= curbuf->b_ucmds.ga_len;
+    /* In cmdwin, the alternative buffer should be used. */
+    buf_T *buf =
+#ifdef FEAT_CMDWIN
+	cmdwin_type != 0 ? prevwin->w_buffer :
+#endif
+	curbuf;
+    if (idx < buf->b_ucmds.ga_len)
+	return USER_CMD_GA(&buf->b_ucmds, idx)->uc_name;
+    idx -= buf->b_ucmds.ga_len;
     if (idx < ucmds.ga_len)
 	return USER_CMD(idx)->uc_name;
     return NULL;
@@ -395,7 +401,12 @@ uc_list(char_u *name, size_t name_len)
     long	a;
     garray_T	*gap;
 
-    gap = &curbuf->b_ucmds;
+    /* In cmdwin, the alternative buffer should be used. */
+    gap =
+#ifdef FEAT_CMDWIN
+	cmdwin_type != 0 ? &prevwin->w_buffer->b_ucmds :
+#endif
+	&curbuf->b_ucmds;
     for (;;)
     {
 	for (i = 0; i < gap->ga_len; ++i)


### PR DESCRIPTION
# Problem

In cmdwin, we cannot complete editing buffer-local commands.
This behavior is different from cmdline completion's behavior but it should be the same.
![vim-cmdwin](https://user-images.githubusercontent.com/24771416/61587599-212e4480-abc8-11e9-97c9-47e5a35202dd.gif)

Also the result of `execute('command')` becomes different between in cmdline and cmdwin, but it should be the same.  
The following is a sample code to reproduce this problem.

```vim
command! -buffer Test echo 'test-command'

let s:cmds = []
function! StoreUserCmds() abort
  call add(s:cmds, execute('command'))
  return ''
endfunction
function! CheckResult() abort
  call assert_equal(s:cmds[0], s:cmds[1])
  return v:errors
endfunction

cnoremap <expr> @ StoreUserCmds()
nnoremap <expr> @ StoreUserCmds()

let s:script = ":@\<CR>" . "q:@\<C-c>\<C-c>" . ":echomsg CheckResult()\<CR>"

call feedkeys(s:script)

" The output is:
" ['function CheckResult line 1: Expected ''\n    Name              Args Address Complete    Definition\nb   Test              0\[  occurs 24 times]echo ''''test-command'''''' but got ''\nNo user-defined commands found''']
```

# Solution

Use data of the cmdwin's alternative buffer for listing user-defined commands.