### PR TITLE
Update the PHP indent script to version 1.70 (from 1.66)

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -831,7 +831,7 @@ PHP indenting can be altered in several ways by modifying the values of some
 global variables:
 
 					*php-comment* *PHP_autoformatcomment*
-To not enable auto-formatting of comments by default (if you want to use your
+To not enable auto-formating of comments by default (if you want to use your
 own 'formatoptions'): >
     :let g:PHP_autoformatcomment = 0
 
@@ -928,6 +928,41 @@ You will obtain the following result: >
         ->age()
         ->info();
 
+-------------
+
+							*PHP_IndentFunctionCallParameters*
+Extra indentation levels to add to parameters in multi-line function calls. >
+    let g:PHP_IndentFunctionCallParameters = 1
+
+Function call arguments will indent 1 extra level. For two-space indentation: >
+
+    function call_the_thing(
+      $with_this,
+      $and_that
+    ) {
+      $this->do_the_thing(
+          $with_this,
+          $and_that
+      );
+    }
+
+-------------
+
+							*PHP_IndentFunctionDeclarationParameters*
+Extra indentation levels to add to arguments in multi-line function definitions. >
+    let g:PHP_IndentFunctionDeclarationParameters = 1
+
+Function arguments in declarations will indent 1 extra level. For two-space indentation: >
+
+    function call_the_thing(
+        $with_this,
+        $and_that
+    ) {
+      $this->do_the_thing(
+        $with_this,
+        $and_that
+      );
+    }
 
 
 PYTHON							*ft-python-indent*


### PR DESCRIPTION
- Fix vim/vim#4562 where Vim would freeze on multiline-string declarations ending with a comma.
- Fix 2072/PHP-Indenting-for-VIm#69: Indenting was incorrect for closures with single-line `use` statements.
- Always indent `^\s*[)\]]` according to their opening counterpart.
- Implement feature request 2072/PHP-Indenting-for-VIm#71: added option PHP_IndentFunctionCallParameters and PHP_IndentFunctionDeclarationParameters to be set to the number of additional indents you want for your function parameters.
- Fix 2072/PHP-Indenting-for-VIm#60 where multiline-string declarations endings with nothing else before would break indentation.
- Fix unreported issue where a comment ending with a ('), (") or (`) would stop indentation after this line.
- Fix 2072/PHP-Indenting-for-VIm#68: end(if|for|foreach|while|switch) identifiers were treated as HereDoc ending indentifiers and set at column 0.
- Several enhancements to arrow matching (->)
- Fix 2072/PHP-Indenting-for-VIm#67: chained calls indentation was aligning on the first matching '->' instead of the last one.
