### PR TITLE
:args: do not add trailing newline(s)

### DIFF
--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -140,10 +140,7 @@ func Test_argument()
 
   call assert_equal(['d', 'c', 'b', 'a', 'c'], g:buffers)
 
-  redir => result
-  args
-  redir END
-  call assert_equal('a   b   [c] d', trim(result))
+  call assert_equal("\na   b   [c] d   ", execute(':args'))
 
   .argd
   call assert_equal(['a', 'b', 'd'], argv())

--- a/src/version.c
+++ b/src/version.c
@@ -4337,6 +4337,7 @@ list_in_columns(char_u **items, int size, int current)
     int		i;
     int		ncol;
     int		nrow;
+    int		crow = 1;
     int		item_count = 0;
     int		width = 0;
 #ifdef FEAT_SYN_HL
@@ -4393,19 +4394,15 @@ list_in_columns(char_u **items, int size, int current)
 		msg_putchar(']');
 	    if (last_col)
 	    {
-		if (msg_col > 0)
+		if (msg_col > 0 && crow < nrow)
 		    msg_putchar('\n');
+		++crow;
 	    }
 	    else
 	    {
 		while (msg_col % width)
 		    msg_putchar(' ');
 	    }
-	}
-	else
-	{
-	    if (msg_col > 0)
-		msg_putchar('\n');
 	}
     }
 }


### PR DESCRIPTION
Since v8.0.1738 (5d69da462) `:args` with only a single argument would
cause a hit-enter message:

    [/etc/fstab]

    Press ENTER or type command to continue

This patch changes it to not add a trailing newline.

It adds `crow` for "current row", which could be calculated as
`last_row` instead similar to `last_col` maybe, but I found this easier,
and the patch is only meant as a suggestion and will be edited anyway.

Likely also needs a test adjustment then (or should have a test).