### PR TITLE
valgrind syntax update

### DIFF
--- a/runtime/syntax/valgrind.vim
+++ b/runtime/syntax/valgrind.vim
@@ -26,7 +26,7 @@ syn match valgrindSpecLine "^[+-]\{2}\d\+[+-]\{2}.*$"
 
 syn region valgrindRegion
 	\ start=+^==\z(\d\+\)== \w.*$+
-	\ skip=+^==\z1==\( \|    .*\)$+
+	\ skip=+^==\z1==\( \|    .*\|  \S.*\)$+
 	\ end=+^+
 	\ fold
 	\ keepend
@@ -70,7 +70,7 @@ syn match valgrindLoc "\s\+\(by\|at\|Address\).*$" contained
 syn match valgrindAt "at\s\@=" contained
 syn match valgrindAddr "\W\zs0x\x\+" contained
 
-syn match valgrindFunc ": \zs\h[a-zA-Z0-9_:\[\]()<>&*+\-,=%!|^ ]*\ze([^)]*)$" contained
+syn match valgrindFunc ": \zs\h[a-zA-Z0-9_:\[\]()<>&*+\-,=%!|^ @.]*\ze([^)]*)$" contained
 syn match valgrindBin "(\(with\)\=in \zs\S\+)\@=" contained
 syn match valgrindSrc "(\zs[^)]*:\d\+)\@=" contained
 


### PR DESCRIPTION
This patch addresses two things:

1) Lines like

==1234==  Address 0x112aad48 is 16 bytes after a block of size 600 alloc'd

terminate the highlighted block because they do not conform to any of
the allowed patterns.

2) Functions with library version

==1234==    by 0x785BA47: fnmatch@@GLIBC_2.2.5 (fnmatch.c:434)

are not highlighted as functions at all.  The patch simply allows ‘@’
and ‘.’ in function names, resulting in the entire
‘fnmatch@@GLIBC_2.2.5’ becoming the function name.