### PR TITLE
Improve Test_lambda_with_timer

### DIFF
--- a/src/testdir/test_lambda.vim
+++ b/src/testdir/test_lambda.vim
@@ -36,8 +36,8 @@ func Test_lambda_with_timer()
 
   let m = s:n
   " Wait for next timer callback.
-  for i in range(0, 5)
-    sleep 50m
+  for i in range(0, 10)
+    sleep 10m
     if s:n > m
       break
     endif

--- a/src/testdir/test_lambda.vim
+++ b/src/testdir/test_lambda.vim
@@ -26,20 +26,24 @@ func Test_lambda_with_timer()
   let s:n = 0
   let s:timer_id = 0
   func! s:Foo()
-    "let n = 0
-    let s:timer_id = timer_start(50, {-> execute("let s:n += 1 | echo s:n", "")}, {"repeat": -1})
+    let s:timer_id = timer_start(10, {-> execute("let s:n += 1 | echo s:n", "")}, {"repeat": -1})
   endfunc
 
   call s:Foo()
-  sleep 200ms
+
   " do not collect lambda
   call test_garbagecollect_now()
+
   let m = s:n
-  sleep 200ms
+  " Wait for next timer callback.
+  for i in range(0, 5)
+    sleep 50m
+    if s:n > m
+      break
+    endif
+  endfor
   call timer_stop(s:timer_id)
-  call assert_true(m > 1)
-  call assert_true(s:n > m + 1)
-  call assert_true(s:n < 9)
+  call assert_true(s:n > m)
 endfunc
 
 func Test_lambda_with_partial()


### PR DESCRIPTION
The test is only for ensuring that lambdas are not garbage collected,
and can therefore be rewritten without "global" sleep.

This should make it less flaky on CI, and improves its duration from
0.4s to 0.05s in general.

Initially added with lambdas in 069c1e7fa (v7.4.2044).