### PR TITLE
Fix maparg() to use 't' as terminal mode character

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -4009,6 +4009,8 @@ map_mode_to_chars(int mode)
 	    ga_append(&mapmode, 'n');			/* :nmap */
 	if (mode & OP_PENDING)
 	    ga_append(&mapmode, 'o');			/* :omap */
+	if (mode & TERMINAL)
+	    ga_append(&mapmode, 't');			/* :tmap */
 	if ((mode & (VISUAL + SELECTMODE)) == VISUAL + SELECTMODE)
 	    ga_append(&mapmode, 'v');			/* :vmap */
 	else

--- a/src/testdir/test_maparg.vim
+++ b/src/testdir/test_maparg.vim
@@ -29,6 +29,12 @@ function Test_maparg()
         \ 'nowait': 1, 'expr': 0, 'sid': sid, 'lnum': lnum + 1, 'rhs': 'bar',
 	\ 'buffer': 1},
         \ maparg('foo', '', 0, 1))
+  let lnum = expand('<sflnum>')
+  tmap baz foo
+  call assert_equal({'silent': 0, 'noremap': 0, 'lhs': 'baz', 'mode': 't',
+        \ 'nowait': 0, 'expr': 0, 'sid': sid, 'lnum': lnum + 1, 'rhs': 'foo',
+	\ 'buffer': 0},
+        \ maparg('baz', 't', 0, 1))
 
   map abc x<char-114>x
   call assert_equal("xrx", maparg('abc'))


### PR DESCRIPTION
This PR will fix a character that represents terminal mode from '' to 't'.

## Problem
- `maparg()` doesn't return the mode as 't' for the terminal mode mappings
- `:tmap` and `:tnoremap` doesn't display the mode character

## Before

Terminal map's mode char is ''.
```
$ vim -es -c "tnoremap hoge foo" -c "call append(0, string(maparg('hoge', 't', 0, 1)))" -c "%print" -c q!
{'lnum': 0, 'silent': 0, 'noremap': 1, 'lhs': 'hoge', 'mode': '', 'nowait': 0, 'expr': 0, 'sid': -3, 'rhs': 'foo', 'buffer': 0}

$ vim -es -c "tnoremap hoge foo" -c "call append(0, execute('tmap'))" -c "%print" -c q!
^@^@   hoge        * foo
```

## After

Terminal map's mode char is 't'.
```
$ ./vim/src/vim -es -c "tnoremap hoge foo" -c "call append(0, string(maparg('hoge', 't', 0, 1)))" -c "%print" -c q!
{'lnum': 0, 'silent': 0, 'noremap': 1, 'lhs': 'hoge', 'mode': 't', 'nowait': 0, 'expr': 0, 'sid': -3, 'rhs': 'foo', 'buffer': 0}

$ ./vim/src/vim -es -c "tnoremap hoge foo" -c "call append(0, execute('tmap'))" -c "%print" -c q!
^@^@t  hoge        * foo
```

————————
Best regards,
Haruki Tomono