### PR TITLE
tests: use noswapfile by default, only enable it for where it is tested

### DIFF
--- a/src/testdir/setup.vim
+++ b/src/testdir/setup.vim
@@ -30,4 +30,7 @@ if 1
   if !isdirectory($HOME)
     call mkdir($HOME)
   endif
+
+  " Do not create swapfiles by default.
+  set noswapfile
 endif

--- a/src/testdir/test_recover.vim
+++ b/src/testdir/test_recover.vim
@@ -1,5 +1,14 @@
 " Test :recover
 
+func SetUp()
+  let s:save_swapfile = &swapfile
+  set swapfile
+endfunc
+
+func TearDown()
+  let &swapfile = s:save_swapfile
+endfunc
+
 func Test_recover_root_dir()
   " This used to access invalid memory.
   split Xtest

--- a/src/testdir/test_swap.vim
+++ b/src/testdir/test_swap.vim
@@ -1,5 +1,14 @@
 " Tests for the swap feature
 
+func SetUp()
+  let s:save_swapfile = &swapfile
+  set swapfile
+endfunc
+
+func TearDown()
+  let &swapfile = s:save_swapfile
+endfunc
+
 func s:swapname()
   return trim(execute('swapname'))
 endfunc


### PR DESCRIPTION
This avoids leftover files from (failing) tests.