### PR TITLE
test_filetype: CheckItems: use v:exception  [ci skip]

### DIFF
--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -521,7 +521,7 @@ func CheckItems(checks)
       try
         exe 'edit ' . fnameescape(names[i])
       catch
-	call assert_report('cannot edit "' . names[i] . '": ' . v:errmsg)
+	call assert_report('cannot edit "' . names[i] . '": ' . v:exception)
       endtry
       if &filetype == '' && &readonly
 	" File exists but not able to edit it (permission denied)


### PR DESCRIPTION
"v:errmsg" is empty typically.  Seen this with "set directory=." where
it failed to create the swap file then.