### PR TITLE
testdir/unix.vim: set shell related options with shell=sh for win32

### DIFF
--- a/src/testdir/unix.vim
+++ b/src/testdir/unix.vim
@@ -10,4 +10,10 @@ if 1
   let g:tester_HOME = $HOME
 endif
 
+if has('win32')
+  set shellcmdflag=-c shellxquote= shellxescape= shellquote=
+  let &shellredir = '>%s 2>&1'
+  set shellslash
+endif
+
 source setup.vim


### PR DESCRIPTION
This appears to make sense for when `-u unix.vim` is used on Windows
(for non-native builds).

Ref: https://github.com/neovim/neovim/pull/10650