### PR TITLE
Fix completeslash

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -5096,7 +5096,7 @@ ExpandFromContext(
 	if (free_pat)
 	    vim_free(pat);
 #ifdef BACKSLASH_IN_FILENAME
-	if (p_csl[0] != NUL)
+	if (KeyTyped && p_csl[0] != NUL)
 	{
 	    int	    i;
 

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -374,6 +374,9 @@ func Test_ins_completeslash()
   call assert_equal('Xdir/', getline('.'))
   %bw!
   call delete('Xdir', 'rf')
+
+  set noshellslash
+  set completeslash=slash
   call assert_true(stridx(globpath(&rtp, 'syntax/*.vim', 1, 1)[0], '\') != -1)
 
   let &shellslash = orig_shellslash

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -374,6 +374,7 @@ func Test_ins_completeslash()
   call assert_equal('Xdir/', getline('.'))
   %bw!
   call delete('Xdir', 'rf')
+  call assert_true(stridx(globpath(&rtp, 'syntax/*.vim', 1, 1)[0], '\') != -1)
 
   let &shellslash = orig_shellslash
 endfunc


### PR DESCRIPTION
completeslash must be affect to only command-line completetion with keytyped. Current implementation break globpath().