### PR TITLE
Fix ODR violation by au_did_filetype

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -240,16 +240,6 @@ static garray_T augroups = {0, 0, sizeof(char_u *), 10, NULL};
 static char_u *deleted_augroup = NULL;
 
 /*
- * Set by the apply_autocmds_group function if the given event is equal to
- * EVENT_FILETYPE. Used by the readfile function in order to determine if
- * EVENT_BUFREADPOST triggered the EVENT_FILETYPE.
- *
- * Relying on this value requires one to reset it prior calling
- * apply_autocmds_group.
- */
-int au_did_filetype INIT(= FALSE);
-
-/*
  * The ID of the current group.  Group 0 is the default one.
  */
 static int current_augroup = AUGROUP_DEFAULT;

--- a/src/globals.h
+++ b/src/globals.h
@@ -424,7 +424,11 @@ EXTERN int	autocmd_no_leave INIT(= FALSE); // *Leave autocmds disabled
 
 EXTERN int	modified_was_set;		// did ":set modified"
 EXTERN int	did_filetype INIT(= FALSE);	// FileType event found
-EXTERN int	au_did_filetype INIT(= FALSE);
+EXTERN int	au_did_filetype INIT(= FALSE);	// Set by the apply_autocmds_group function if the given event is equal to
+						// EVENT_FILETYPE. Used by the readfile function in order to determine if
+						// EVENT_BUFREADPOST triggered the EVENT_FILETYPE.
+						// Relying on this value requires one to reset it prior calling
+						// apply_autocmds_group.
 EXTERN int	keep_filetype INIT(= FALSE);	// value for did_filetype when
 						// starting to execute
 						// autocommands


### PR DESCRIPTION
## Problem

When I tried to link Vim with `wasm-ld` linker which is based on `lld`, I got following link error.

```
wasm-ld: error: duplicate symbol: au_did_filetype
>>> defined in objects/autocmd.o
>>> defined in objects/main.o
```

Though `/usr/bin/ld` does not raise this error, as far as I checked sources, `au_did_filetype` violates one definition rule. Let me explain.

In `global.h` it is defined as

```c
EXTERN int     au_did_filetype INIT(= FALSE);
```

where `EXTERN` is empty token on `main.c`, otherwise `extern` token. So `au_did_filetype` is defined (not declared) when compiling `main.c`.

In `autocmd.c` it is defined as

```c
int au_did_filetype INIT(= FALSE);
```

So `autocmd.c` also contains `au_did_filetype` definition (not declaration).

When linking all objects into one `vim` executable, the linker complains about there being 2 definitions for the same symbol `au_did_filetype` among objects violating one definition rule in C.

## Solution

As far as I know, global variables have static storage so they are initialized before `main()` is called. So the definition in `autocmd.c` is not necessary. I simply removed it in this patch. Now only `main.o` has a definition of `au_did_filetype` so linker is happy. I confirmed that linking worked fine after applying this patch and built executable run normally.

