### PR TITLE
Add job_getcwd()

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -793,6 +793,10 @@ job_getchannel({job})					 *job_getchannel()*
 			if string(job_getchannel()) == 'channel fail'
 <
 
+job_getcwd({job})					*job_getcwd()*
+		Returns the current working directory path of {job}.
+
+
 job_info([{job}])					*job_info()*
 		Returns a Dictionary with information about {job}:
 		   "status"	what |job_status()| returns

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2500,6 +2500,7 @@ islocked({expr})		Number	|TRUE| if {expr} is locked
 isnan({expr})			Number	|TRUE| if {expr} is NaN
 items({dict})			List	key-value pairs in {dict}
 job_getchannel({job})		Channel	get the channel handle for {job}
+job_getcwd({job})		String	the current working directory of {job}
 job_info([{job}])		Dict	get information about {job}
 job_setoptions({job}, {options}) none	set options for {job}
 job_start({command} [, {options}])

--- a/src/channel.c
+++ b/src/channel.c
@@ -6436,6 +6436,22 @@ f_job_getchannel(typval_T *argvars, typval_T *rettv)
 }
 
 /*
+ * "job_getcwd()" function
+ */
+    void
+f_job_getcwd(typval_T *argvars, typval_T *rettv)
+{
+    job_T	*job = get_job_arg(&argvars[0]);
+
+    if (job != NULL)
+    {
+	rettv->v_type = VAR_STRING;
+	rettv->vval.v_string = NULL;
+	mch_get_job_cwd(job, &rettv->vval.v_string);
+    }
+}
+
+/*
  * Implementation of job_info().
  */
     static void

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -655,6 +655,7 @@ static funcentry_T global_functions[] =
     {"items",		1, 1, FEARG_1,	  f_items},
 #ifdef FEAT_JOB_CHANNEL
     {"job_getchannel",	1, 1, 0,	  f_job_getchannel},
+    {"job_getcwd",	1, 1, 0,	  f_job_getcwd},
     {"job_info",	0, 1, 0,	  f_job_info},
     {"job_setoptions",	2, 2, 0,	  f_job_setoptions},
     {"job_start",	1, 2, 0,	  f_job_start},

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -5495,7 +5495,7 @@ typedef struct
 /*
  * Get the working directory of "job".
  */
-int
+    int
 mch_get_job_cwd(job_T *job, char_u **cwd)
 {
     DWORD		pid = job->jv_proc_info.dwProcessId;

--- a/src/proto/channel.pro
+++ b/src/proto/channel.pro
@@ -91,6 +91,7 @@ void f_ch_sendraw(typval_T *argvars, typval_T *rettv);
 void f_ch_setoptions(typval_T *argvars, typval_T *rettv);
 void f_ch_status(typval_T *argvars, typval_T *rettv);
 void f_job_getchannel(typval_T *argvars, typval_T *rettv);
+void f_job_getcwd(typval_T *argvars, typval_T *rettv);
 void f_job_info(typval_T *argvars, typval_T *rettv);
 void f_job_setoptions(typval_T *argvars, typval_T *rettv);
 void f_job_start(typval_T *argvars, typval_T *rettv);

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -66,6 +66,7 @@ char *mch_job_status(job_T *job);
 job_T *mch_detect_ended_job(job_T *job_list);
 int mch_signal_job(job_T *job, char_u *how);
 void mch_clear_job(job_T *job);
+int mch_get_job_cwd(job_T *job, char_u **cwd);
 int mch_create_pty_channel(job_T *job, jobopt_T *options);
 void mch_breakcheck(int force);
 int mch_expandpath(garray_T *gap, char_u *path, int flags);

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -51,6 +51,7 @@ char *mch_job_status(job_T *job);
 job_T *mch_detect_ended_job(job_T *job_list);
 int mch_signal_job(job_T *job, char_u *how);
 void mch_clear_job(job_T *job);
+int mch_get_job_cwd(job_T *job, char_u **cwd);
 void mch_set_normal_colors(void);
 void mch_write(char_u *s, int len);
 void mch_delay(long msec, int ignoreinput);

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1980,3 +1980,21 @@ func Test_zz_ch_log()
   call assert_match("%s%s", text[2])
   call delete('Xlog')
 endfunc
+
+func Test_job_getcwd()
+  if has('win32')
+    let dir = $TEMP
+    let cmd = ['cmd', '/C', 'start /wait ' . $windir . '\system32\timeout /T 3 /NOBREAK']
+  else
+    let dir = $HOME
+    let cmd = ['sleep', '3']
+  endif
+  let job = job_start(cmd, {'cwd': dir})
+  call WaitFor({-> job_status(job) == "run"})
+  call WaitFor({-> job_getcwd(job) != getcwd(-1)})
+  let cwd = job_getcwd(job)
+  let dir = substitute(dir, '[/\\]*$', '', '')
+  let cwd = substitute(cwd, '[/\\]*$', '', '')
+  call assert_equal(dir, cwd)
+  call job_stop(job)
+endfunc


### PR DESCRIPTION
`job_getcwd({job})` is to get the current working directory of `{job}`.

For example, this can be useful to restore the working directory of the shell of `:terminal` when using `:mksession`.