### PR TITLE
Reduced memory usage of vim dictionaries: -6 bytes for each key.

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -209,8 +209,7 @@ dict_free_items(int copyID)
 dictitem_alloc(char_u *key)
 {
     dictitem_T *di;
-
-    di = alloc(sizeof(dictitem_T) + STRLEN(key));
+    di = alloc(offsetof(dictitem_T, di_key) + STRLEN(key) + 1);
     if (di != NULL)
     {
 	STRCPY(di->di_key, key);
@@ -228,7 +227,7 @@ dictitem_copy(dictitem_T *org)
 {
     dictitem_T *di;
 
-    di = alloc(sizeof(dictitem_T) + STRLEN(org->di_key));
+    di = alloc(offsetof(dictitem_T, di_key) + STRLEN(org->di_key) + 1);
     if (di != NULL)
     {
 	STRCPY(di->di_key, org->di_key);


### PR DESCRIPTION
This PR reduces size of dynamically allocated
blocks by 6 bytes for each dictionary key allocation.

The same kind of optimizations can be made in several
other data structures of Vim that use an array of 
variable size at the end of a struct. I assume that it's
better to do remaining optimizations little by little in
separate changes.