### PR TITLE
Reduce memory usage further

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -232,7 +232,7 @@ add_buff(
 	    len = MINIMAL_SIZE;
 	else
 	    len = slen;
-	p = alloc(sizeof(buffblock_T) + len);
+	p = alloc(offsetof(buffblock_T, b_str) + len + 1);
 	if (p == NULL)
 	    return; /* no space, just forget it */
 	buf->bh_space = (int)(len - slen);

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -1319,7 +1319,7 @@ bt_regcomp(char_u *expr, int re_flags)
 	return NULL;
 
     /* Allocate space. */
-    r = alloc(sizeof(bt_regprog_T) + regsize);
+    r = alloc(offsetof(bt_regprog_T, program) + regsize);
     if (r == NULL)
 	return NULL;
     r->re_in_use = FALSE;

--- a/src/sign.c
+++ b/src/sign.c
@@ -85,7 +85,7 @@ sign_group_ref(char_u *groupname)
     if (HASHITEM_EMPTY(hi))
     {
 	// new group
-	group = alloc(sizeof(signgroup_T) + STRLEN(groupname));
+	group = alloc(offsetof(signgroup_T, sg_name) + STRLEN(groupname) + 1);
 	if (group == NULL)
 	    return NULL;
 	STRCPY(group->sg_name, groupname);

--- a/src/structs.h
+++ b/src/structs.h
@@ -742,9 +742,9 @@ typedef struct proptype_S
 // Sign group
 typedef struct signgroup_S
 {
-    short_u	refcount;		// number of signs in this group
     int		next_sign_id;		// next sign id for this group
-    char_u	sg_name[1];		// sign group name
+    short_u	refcount;		// number of signs in this group
+    char_u	sg_name[1];		// sign group name, actually longer
 } signgroup_T;
 
 typedef struct signlist signlist_T;

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -4394,7 +4394,7 @@ add_keyword(
 						 name_folded, MAXKEYWLEN + 1);
     else
 	name_ic = name;
-    kp = alloc(sizeof(keyentry_T) + STRLEN(name_ic));
+    kp = alloc(offsetof(keyentry_T, keyword) + STRLEN(name_ic) + 1);
     if (kp == NULL)
 	return;
     STRCPY(kp->keyword, name_ic);

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -695,7 +695,7 @@ prop_type_set(typval_T *argvars, int add)
 	    semsg(_("E969: Property type %s already defined"), name);
 	    return;
 	}
-	prop = alloc_clear(sizeof(proptype_T) + STRLEN(name));
+	prop = alloc_clear(offsetof(proptype_T, pt_name) + STRLEN(name) + 1);
 	if (prop == NULL)
 	    return;
 	STRCPY(prop->pt_name, name);

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -288,7 +288,7 @@ get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate)
 
 	sprintf((char*)name, "<lambda>%d", ++lambda_no);
 
-	fp = alloc_clear(sizeof(ufunc_T) + STRLEN(name));
+	fp = alloc_clear(offsetof(ufunc_T, uf_name) + STRLEN(name) + 1);
 	if (fp == NULL)
 	    goto errret;
 	pt = ALLOC_CLEAR_ONE(partial_T);
@@ -2631,7 +2631,7 @@ ex_function(exarg_T *eap)
 	    }
 	}
 
-	fp = alloc_clear(sizeof(ufunc_T) + STRLEN(name));
+	fp = alloc_clear(offsetof(ufunc_T, uf_name) + STRLEN(name) + 1);
 	if (fp == NULL)
 	    goto erret;
 


### PR DESCRIPTION
This PR reduces size of allocated block when allocating:
- buffblock_T: -7 bytes
- keyentry_T: -7 bytes
- ufunc_T: -7 bytes
- signgroup_T: -5 bytes
- bt_regprog_T: -3 bytes
- proptype_T: -3 bytes

(measured on x86_64, with printf of what is allocated)

This is a continuation of previous change in vim-8.1.1825

2 benefits:
- reduce memory usage
- make it more likely to detect small memory
  overflows with asan or valgrind as what is
  allocated is now what's really used.

