### PR TITLE
f_spellbadword: set len=0 for non-found word

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -10755,6 +10755,7 @@ f_spellbadword(typval_T *argvars UNUSED, typval_T *rettv)
 		}
 		str += len;
 		capcol -= len;
+		len = 0;
 	    }
 	}
     }


### PR DESCRIPTION
`len` is used with `list_append_string` later, and should reflect the
length of `word` (i.e. 0 when not setting word / breaking above).

Ref: https://github.com/neovim/neovim/pull/9782#issuecomment-519281098