### PR TITLE
Add tests for empty environment variables

### DIFF
--- a/src/testdir/test_environ.vim
+++ b/src/testdir/test_environ.vim
@@ -9,6 +9,16 @@ func Test_environ()
   call assert_equal('こんにちわ', environ()['TESTENV'])
 endfunc
 
+func Test_environ_empty()
+  let $TESTENV = ''
+  if has('win32')
+    " Setting an environment to an empty value unsets it on Windows.
+    call assert_false(has_key(environ(), 'TESTENV'))
+  else
+    call assert_equal('', environ()['TESTENV'])
+  endif
+endfunc
+
 func Test_getenv()
   unlet! $TESTENV
   call assert_equal(v:null, getenv('TESTENV'))

--- a/src/testdir/test_exists.vim
+++ b/src/testdir/test_exists.vim
@@ -70,6 +70,14 @@ func Test_exists()
   call assert_equal(1, exists('$EDITOR_NAME'))
   " Non-existing environment variable
   call assert_equal(0, exists('$NON_ENV_VAR'))
+  " Empty environment variable
+  let $EDITOR_NAME = ''
+  if has('win32')
+    " Setting an environment to an empty value unsets it on Windows.
+    call assert_equal(0, exists('$EDITOR_NAME'))
+  else
+    call assert_equal(1, exists('$EDITOR_NAME'))
+  endif
 
   " Valid internal function
   call assert_equal(1, exists('*bufnr'))


### PR DESCRIPTION
This adds coverage for this in general, and tests the specific/current
behavior on Windows.

Ref: https://github.com/vim/vim/pull/4750#issuecomment-516582306

@brammool 
Feel free to close it, but wanted to offer it as a complete patch at least.