### PR TITLE
Add object keys shorthand to #{} literal

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -489,6 +489,17 @@ does require the key to consist only of ASCII letters, digits, '-' and '_'.
 Example: >
 	let mydict = #{zero: 0, one_key: 1, two-key: 2, 333: 3}
 Note that 333 here is the string "333".  Empty keys are not possible with #{}.
+						*literal-Dict-shorthand*
+When a value in item of #{} is omitted, a variable which has the same name is
+set to the value. If such a variable does not exist, |E121| error is thrown.
+Example: >
+	let zero = 0
+	let one_key = 1
+	let mydict = #{zero, one_key, two-key: 2}
+This example is the same as: >
+	let zero = 0
+	let one_key = 1
+	let mydict = #{zero: zero, one_key: one_key, two-key: 2}
 
 A value can be any expression.  Using a Dictionary for a value creates a
 nested Dictionary: >

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -785,3 +785,43 @@ func Test_scope_dict()
   " Test for v:
   call s:check_scope_dict('v', v:true)
 endfunc
+
+func Test_dict_item_shorthands()
+    let l:x1 = 1
+    let x2 = 2
+
+    " One shorthand only. This is edge case for first check of curly-braces
+    " thing
+    call assert_equal({'x1': x1}, #{x1})
+    " Trailing comma
+    call assert_equal({'x1': x1}, #{x1,})
+    " Multiple shorthands
+    call assert_equal({'x1': x1, 'x2': x2}, #{x1, x2})
+    " Shofthand at first
+    call assert_equal({'x1': x1, 'b': 3}, #{x1, b: 3})
+    " Shofthand at last
+    call assert_equal({'b': 3, 'x1': x1}, #{b: 3, x1})
+    " Multiple shorthands mixed with normal items
+    call assert_equal({'b': 3, 'x1': x1, 'x2': x2}, #{b: 3, x1, x2})
+    call assert_equal({'b': 3, 'x1': x1, 'x2': x2}, #{x1, b: 3, x2})
+    call assert_equal({'b': 3, 'x1': x1, 'x2': x2}, #{x1, x2, b: 3})
+    " The same names as existing variables are still available
+    call assert_equal({'x1': 3, 'x2': 4}, #{x1: 3, x2: 4})
+
+    " Error cases
+
+    " Undefined variable
+    call assert_fails('echo #{x3}', 'E121: Undefined variable: x3')
+    call assert_fails('echo #{b: 3, x3}', 'E121: Undefined variable: x3')
+    call assert_fails('echo #{x3, b: 3}', 'E121: Undefined variable: x3')
+    call assert_fails('echo #{3x}', 'E121: Undefined variable: 3x')
+    call assert_fails('echo #{123}', 'E121: Undefined variable: 123')
+    " Duplicate key
+    call assert_fails('echo #{x1, x1}', 'E721: Duplicate key in Dictionary: "x1"')
+    call assert_fails('echo #{x1: 3, x1}', 'E721: Duplicate key in Dictionary: "x1"')
+    call assert_fails('echo #{x1, x1: 3}', 'E721: Duplicate key in Dictionary: "x1"')
+
+    unlet l:x1
+    unlet x2
+endfunc
+


### PR DESCRIPTION
This patch adds 'object keys shorthand' notation syntax to `#{}` literal.

## Problem

Sometimes object literal tends to be bigger (e.g. job's options dict, popup's options dict, ...). This is because dict is used for optional named argument passed to a function.

Here is a small example with `popup_create()`:

```vim
call popup_create('awesome popup', #{
    \ pos: 'center',
    \ drag: 1,
    \ wrap: 0,
    \ border: [],
    \ cursorline: 1,
    \ padding: [0,1,0,1],
    \ })
```

It is much better than using `{}` literal thanks to `#{}` but it`s still big.

## Solution

Using object keys shorthand this patch offers, the big dict can be decomposed as follows:

```vim
let pos = 'center'
let drag = 1
let wrap = 0
let border = []
let padding = [0, 1, 0, 1]

call popup_create('awesome popup', #{ pos, drag, wrap, border, padding, cursorline: 1 })
```

This is even more convenient when the optional values are configurable or validated or when complicated initialization is needed for some optional values.

```vim
" Example: Validation
let pos = config.border_position
if index(['topleft', 'topright', 'botleft', 'botright', 'center'], pos) < 0
    throw 'Invalid popup postion: ' . string(pos)
endif

" Example: User configuration
let padding = [0, 0, 0, 0]
if config.border
    let padding = [1, 1, 1, 1]
endif

" Example: A bit complicated initialization
let title = s:get_current_file(config)
if !filereadable(title)
    let title = '[NEW FILE]'
endif

call popup_create('awesome popup', #{ pos, padding, title })
```

I was inspired by [ECMAScript shorthand property names](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#Property_definitions). The syntax was introduced at ES2015 and now it is quite popular. As the evidence of that, [eslint](https://eslint.org), the most popular JavaScript linter, supports [`object-shorthand` fix rule](https://eslint.org/docs/rules/object-shorthand) to promote usage of the syntax. I thought having the same functionality in Vim script would be useful so I implemented this patch.