### PR TITLE
Remove duplicated line in syntax/yaml.vim

### DIFF
--- a/runtime/syntax/yaml.vim
+++ b/runtime/syntax/yaml.vim
@@ -150,7 +150,6 @@ syn match yamlBlockMappingMerge /^\s*\zs<<\ze:\%(\s\|$\)/ nextgroup=yamlKeyValue
 syn match yamlBlockMappingMerge /<<\ze\s*:\%(\s\|$\)/ nextgroup=yamlKeyValueDelimiter contained
 
 syn match   yamlKeyValueDelimiter /\s*:/ contained
-syn match   yamlKeyValueDelimiter /\s*:/ contained
 
 syn cluster yamlScalarWithSpecials contains=yamlPlainScalar,yamlBlockMappingKey,yamlFlowMappingKey
 


### PR DESCRIPTION
I found duplicated line in syntax/yaml.vim file.