### PR TITLE
Test shift with :> and :<

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -227,6 +227,7 @@ NEW_TESTS = \
 	test_searchpos \
 	test_set \
 	test_sha256 \
+	test_shift \
 	test_shortpathname \
 	test_signals \
 	test_signs \

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -52,6 +52,7 @@ source test_rename.vim
 source test_scroll_opt.vim
 source test_searchpos.vim
 source test_set.vim
+source test_shift.vim
 source test_sort.vim
 source test_sha256.vim
 source test_statusline.vim

--- a/src/testdir/test_shift.vim
+++ b/src/testdir/test_shift.vim
@@ -1,0 +1,111 @@
+" Test shifting lines with :> and :<
+
+func Test_ex_shift_right()
+  set shiftwidth=2
+
+  " shift right current line.
+  call setline(1, range(1, 5))
+  2
+  >
+  3
+  >>
+  call assert_equal(['1',
+        \            '  2',
+        \            '    3',
+        \            '4',
+        \            '5'], getline(1, '$'))
+
+  " shift right with range.
+  call setline(1, range(1, 4))
+  2,3>>
+  call assert_equal(['1',
+        \            '    2',
+        \            '    3',
+        \            '4',
+        \            '5'], getline(1, '$'))
+
+  " shift right with range and count.
+  call setline(1, range(1, 4))
+  2>3
+  call assert_equal(['1',
+        \            '  2',
+        \            '  3',
+        \            '  4',
+        \            '5'], getline(1, '$'))
+
+  bw!
+  set shiftwidth&
+endfunc
+
+func Test_ex_shift_left()
+  set shiftwidth=2
+
+  call setline(1, range(1, 5))
+  %>>>
+
+  " left shift current line.
+  2<
+  3<<
+  4<<<<<
+  call assert_equal(['      1',
+        \            '    2',
+        \            '  3',
+        \            '4',
+        \            '      5'], getline(1, '$'))
+
+  " shift right with range.
+  call setline(1, range(1, 5))
+  %>>>
+  2,3<<
+  call assert_equal(['      1',
+        \            '  2',
+        \            '  3',
+        \            '      4',
+        \            '      5'], getline(1, '$'))
+
+  " shift right with range and count.
+  call setline(1, range(1, 5))
+  %>>>
+  2<<3
+  call assert_equal(['      1',
+     \               '  2',
+     \               '  3',
+     \               '  4',
+     \               '      5'], getline(1, '$'))
+
+  bw!
+  set shiftwidth&
+endfunc
+
+func Test_ex_shift_rightleft()
+  bw!
+  set shiftwidth=2
+  set rightleft
+
+  call setline(1, range(1, 4))
+  2,3<<
+  call assert_equal(['1',
+        \             '    2',
+        \             '    3',
+        \             '4'], getline(1, '$'))
+
+  3,4>
+  call assert_equal(['1',
+        \            '    2',
+        \            '  3',
+        \            '4'], getline(1, '$'))
+
+  set rightleft&
+  set shiftwidth&
+endfunc
+
+func Test_ex_shift_errors()
+  call assert_fails('><', 'E488:')
+  call assert_fails('<>', 'E488:')
+
+  call assert_fails('>!', 'E477:')
+  call assert_fails('<!', 'E477:')
+
+  call assert_fails('2,1>', 'E493:')
+  call assert_fails('2,1<', 'E493:')
+endfunc

--- a/src/testdir/test_shift.vim
+++ b/src/testdir/test_shift.vim
@@ -78,6 +78,10 @@ func Test_ex_shift_left()
 endfunc
 
 func Test_ex_shift_rightleft()
+  if !has('rightleft')
+    return
+  endif
+
   set shiftwidth=2 rightleft
 
   call setline(1, range(1, 4))

--- a/src/testdir/test_shift.vim
+++ b/src/testdir/test_shift.vim
@@ -78,9 +78,7 @@ func Test_ex_shift_left()
 endfunc
 
 func Test_ex_shift_rightleft()
-  bw!
-  set shiftwidth=2
-  set rightleft
+  set shiftwidth=2 rightleft
 
   call setline(1, range(1, 4))
   2,3<<
@@ -95,8 +93,8 @@ func Test_ex_shift_rightleft()
         \            '  3',
         \            '4'], getline(1, '$'))
 
-  set rightleft&
-  set shiftwidth&
+  bw!
+  set rightleft& shiftwidth&
 endfunc
 
 func Test_ex_shift_errors()


### PR DESCRIPTION
This PR adds test for the Ex  shift commands `:>`  and `:<`
which were not tested according to codecov:

https://codecov.io/gh/vim/vim/src/0b5dc644465c549ac54fe3c4ad232dd692000d26/src/ex_docmd.c#L7877
