### PR TITLE
Null-Dereference bug at screen.c

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -8661,10 +8661,12 @@ give_up:
     TabPageIdxs = new_TabPageIdxs;
 #ifdef FEAT_TEXT_PROP
     popup_mask = new_popup_mask;
-    vim_memset(popup_mask, 0, Rows * Columns * sizeof(short));
+    if (popup_mask != NULL)
+        vim_memset(popup_mask, 0, Rows * Columns * sizeof(short));
     popup_mask_next = new_popup_mask_next;
     popup_transparent = new_popup_transparent;
-    vim_memset(popup_transparent, 0, Rows * Columns * sizeof(char));
+    if (popup_transparent != NULL)
+        vim_memset(popup_transparent, 0, Rows * Columns * sizeof(char));
     popup_mask_refresh = TRUE;
 #endif
 


### PR DESCRIPTION
I found a Null-Dereference bug at screen.c.

**Describe the bug：**
The malloc() in the call stack shown below may fail:
#0 Call malloc() in lalloc(), at misc2.c: 924
#1 Call lalloc() in screenalloc(), at screen.c: 8495
#2 Call screenalloc() in screenclear(), at screen.c: 8744
#3 Call screenclear() in set_shellsize(), at term.c: 3466
#4 Call set_shellsize() in set_termname(), at term.c: 2069
#5 Call set_termname() in termcapinit(), at term.c: 2571
#6 Call termcapinit() in main(), at main.c: 384

if the malloc() in this call stack fails, it will finally make the variables popup_mask and popup_transparent in screenalloc() become NULL, and then vim_memset() will memset a space beginning at NULL, and cause crashes.

To fix this bug, checking whether the pointer is NULL is necessary before vim_memset().