### PR TITLE
Invalid release bug at fileio.c

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -891,7 +891,10 @@ readfile(
     {
 	fenc_next = p_fencs;		/* try items in 'fileencodings' */
 	fenc = next_fenc(&fenc_next);
-	fenc_alloced = TRUE;
+        if (STRCMP(fenc, "") != 0)
+	    fenc_alloced = TRUE;
+        else
+            fenc_alloced = FALSE;
     }
 
     /*


### PR DESCRIPTION
I found a invalid release bug at fileio.c.

The malloc() in the call stack shown below may fail:
#0 Call malloc() in lalloc(), at misc2.c: 924
#1 Call lalloc() in alloc(), at misc2.c: 827
#2 Call alloc() in enc_canonize(), at mbyte.c: 4323
#3 Call enc_canonize() in next_fenc(), at fileio.c: 2789
#4 Call next_fenc() in readfile(), at fileio.c: 893
#5 Call readfile() in open_buffer(), at buffer.c: 233
#6 Call open_buffer() in create_windows(), at main.c: 2750
#7 Call create_windows() in vim_main2(), at main.c: 728
#8 Call vim_main2() in main(), at main.c: 444

If the malloc() in this call stack fails, it will finally make the variable fenc in readfile() become "", and then the variable fenc_alloced in readfile() is TRUE. At fileio.c: 2319, because fenc_alloced is TRUE, vim_free(fenc) will be executed. However, fenc is "" so vim_free() free an invalid pointer and cause a crash.

To fix this bug, the program should assign fenc_alloced FALSE when fenc is "".