### PR TITLE
Null-Dereference bug at message.c

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -2586,16 +2586,18 @@ msg_puts_printf(char_u *str, int maxlen)
 		int n = (int)(s - p);
 
 		buf = alloc(n + 3);
-		memcpy(buf, p, n);
-		if (!info_message)
-		    buf[n++] = CAR;
-		buf[n++] = NL;
-		buf[n++] = NUL;
-		if (info_message)   // informative message, not an error
-		    mch_msg((char *)buf);
-		else
-		    mch_errmsg((char *)buf);
-		vim_free(buf);
+		if (buf != NULL) {
+		    memcpy(buf, p, n);
+		    if (!info_message)
+		        buf[n++] = CAR;
+		    buf[n++] = NL;
+		    buf[n++] = NUL;
+		    if (info_message)   // informative message, not an error
+		        mch_msg((char *)buf);
+		    else
+		        mch_errmsg((char *)buf);
+		    vim_free(buf);
+		}
 		p = s + 1;
 	    }
 	}


### PR DESCRIPTION
I found a Null-Dereference bug at message.c.

When the alloc() at message.c:2588 fails and returns NULL, the variable buf in msg_puts_printf() will become NULL. And then the memcpy() will copy data to a space beginning at NULL, and cause crashes.

To fix this bug, it should be checked whether the buf is NULL after alloc().