### PR TITLE
tests: use v:progpath instead of GetVimProg

### DIFF
--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -220,16 +220,6 @@ func s:feedkeys(timer)
   call feedkeys('x', 'nt')
 endfunc
 
-" Get $VIMPROG to run Vim executable.
-" The Makefile writes it as the first line in the "vimcmd" file.
-func GetVimProg()
-  if !filereadable('vimcmd')
-    " Assume the script was sourced instead of running "make".
-    return '../vim'
-  endif
-  return readfile('vimcmd')[0]
-endfunc
-
 let g:valgrind_cnt = 1
 
 " Get the command to run Vim, with -u NONE and --not-a-term arguments.

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -1867,7 +1867,7 @@ func Test_Changed_FirstTime()
 
   " Prepare file for TextChanged event.
   call writefile([''], 'Xchanged.txt')
-  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': 3})
+  let buf = term_start([v:progpath, '--clean', '-c', 'set noswapfile'], {'term_rows': 3})
   call assert_equal('running', term_getstatus(buf))
   " Wait for the ruler (in the status line) to be shown.
   " In ConPTY, there is additional character which is drawn up to the width of

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1267,7 +1267,7 @@ func Test_libcall_libcallnr()
   elseif has('mac')
     let libc = 'libSystem.B.dylib'
   elseif executable('ldd')
-    let libc = matchstr(split(system('ldd ' . GetVimProg())), '/libc\.so\>')
+    let libc = matchstr(split(system('ldd ' . v:progpath)), '/libc\.so\>')
   endif
   if get(l:, 'libc', '') ==# ''
     " On Unix, libc.so can be in various places.
@@ -1278,7 +1278,7 @@ func Test_libcall_libcallnr()
       let libc = ''
     elseif has('sun')
       " Set the path to libc.so according to the architecture.
-      let test_bits = system('file ' . GetVimProg())
+      let test_bits = system('file ' . v:progpath)
       let test_arch = system('uname -p')
       if test_bits =~ '64-bit' && test_arch =~ 'sparc'
         let libc = '/usr/lib/sparcv9/libc.so'

--- a/src/testdir/test_memory_usage.vim
+++ b/src/testdir/test_memory_usage.vim
@@ -63,7 +63,7 @@ endfunc
 let s:term_vim = {}
 
 func s:term_vim.start(...) abort
-  let self.buf = term_start([GetVimProg()] + a:000)
+  let self.buf = term_start([v:progpath] + a:000)
   let self.job = term_getjob(self.buf)
   call WaitFor({-> job_status(self.job) ==# 'run'})
   let self.pid = job_info(self.job).process

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -112,7 +112,7 @@ func Test_mode_message_at_leaving_insert_by_ctrl_c()
   call writefile(lines, testfile)
 
   let rows = 10
-  let buf = term_start([GetVimProg(), '--clean', '-S', testfile], {'term_rows': rows})
+  let buf = term_start([v:progpath, '--clean', '-S', testfile], {'term_rows': rows})
   call term_wait(buf, 200)
   call assert_equal('run', job_status(term_getjob(buf)))
 
@@ -141,7 +141,7 @@ func Test_mode_message_at_leaving_insert_with_esc_mapped()
   call writefile(lines, testfile)
 
   let rows = 10
-  let buf = term_start([GetVimProg(), '--clean', '-S', testfile], {'term_rows': rows})
+  let buf = term_start([v:progpath, '--clean', '-S', testfile], {'term_rows': rows})
   call term_wait(buf, 200)
   call assert_equal('run', job_status(term_getjob(buf)))
 

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -672,7 +672,7 @@ func Test_popup_and_window_resize()
     return
   endif
   let rows = h / 3
-  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': rows})
+  let buf = term_start([v:progpath, '--clean', '-c', 'set noswapfile'], {'term_rows': rows})
   call term_sendkeys(buf, (h / 3 - 1) . "o\<esc>")
   " Wait for the nested Vim to exit insert mode, where it will show the ruler.
   " Need to trigger a redraw.

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -590,7 +590,7 @@ func Test_search_cmdline8()
   " Prepare buffer text
   let lines = ['abb vim vim vi', 'vimvivim']
   call writefile(lines, 'Xsearch.txt')
-  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
+  let buf = term_start([v:progpath, '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
 
   call WaitForAssert({-> assert_equal(lines, [term_getline(buf, 1), term_getline(buf, 2)])})
 
@@ -716,7 +716,7 @@ func Test_search_cmdline_incsearch_highlight_attr()
   " Prepare buffer text
   let lines = ['abb vim vim vi', 'vimvivim']
   call writefile(lines, 'Xsearch.txt')
-  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
+  let buf = term_start([v:progpath, '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
 
   call WaitForAssert({-> assert_equal(lines, [term_getline(buf, 1), term_getline(buf, 2)])})
   " wait for vim to complete initialization
@@ -1146,7 +1146,7 @@ func Test_search_undefined_behaviour()
     return
   endif
   " did cause an undefined left shift
-  let g:buf = term_start([GetVimProg(), '--clean', '-e', '-s', '-c', 'call search(getline("."))', 'samples/test000'], {'term_rows': 3})
+  let g:buf = term_start([v:progpath, '--clean', '-e', '-s', '-c', 'call search(getline("."))', 'samples/test000'], {'term_rows': 3})
   call assert_equal([''], getline(1, '$'))
   call term_sendkeys(g:buf, ":qa!\<cr>")
   bwipe!

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1989,7 +1989,7 @@ func Test_term_gettitle()
     throw "Skipped: can't get/set title"
   endif
 
-  let term = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'])
+  let term = term_start([v:progpath, '--clean', '-c', 'set noswapfile'])
   if has('autoservername')
     call WaitForAssert({-> assert_match('^\[No Name\] - VIM\d\+$', term_gettitle(term)) })
     call term_sendkeys(term, ":e Xfoo\r")


### PR DESCRIPTION
TODO:

- [ ] do not write it to vimcmd in the first place

Ref: https://github.com/vim/vim/commit/da65058a9c4774dc534c7ae98d24c58b5db669fa#r34658132