### PR TITLE
tests: remove Test_popup_and_window_resize from s:flaky_tests

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -329,7 +329,6 @@ let s:flaky_tests = [
       \ 'Test_paused()',
       \ 'Test_pipe_through_sort_all()',
       \ 'Test_pipe_through_sort_some()',
-      \ 'Test_popup_and_window_resize()',
       \ 'Test_quoteplus()',
       \ 'Test_quotestar()',
       \ 'Test_raw_one_time_callback()',


### PR DESCRIPTION
This should have been fixed in https://github.com/vim/vim/pull/2186 (v8.0.1179).