### PR TITLE
Fix duplicate documentation tag ":spellr"

### DIFF
--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -198,8 +198,8 @@ z=			For the word under/after the cursor suggest correctly
 			the good word and <Esc>.  This does NOT work for Thai
 			and other languages without spaces between words.
 
-					*:spellr* *:spellrepall* *E752* *E753*
-:spellr[epall]		Repeat the replacement done by |z=| for all matches
+					*:spellre* *:spellrepall* *E752* *E753*
+:spellre[pall]		Repeat the replacement done by |z=| for all matches
 			with the replaced word in the current window.
 
 In Insert mode, when the cursor is after a badly spelled word, you can use


### PR DESCRIPTION
There was an inconsistency introduced with this patch. When building
helptags this causes the error

  E154: Duplicate tag ":spellr" in file .../vim/vim81/doc/spell.txt

**spellrare** uses the same tag `:spellr` like the command **spellrepall**.
Entering `:spellr` executes **spellrare** so the documentation for
**spellrepall** needs to be changed.