### PR TITLE
Add popup menu position info to complete_info()

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -595,6 +595,9 @@ CompleteChanged 					*CompleteChanged*
 				    scrollbar		TRUE if visible
 
 				It is not allowed to change the text |textlock|.
+
+				See also |complete_info()| which can be used to
+				get the poup menu position at any time.
 							*CompleteDone*
 CompleteDone			After Insert mode completion is done.  Either
 				when something was completed or abandoning

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3445,6 +3445,9 @@ complete_info([{what}])
 				See |complete_info_mode| for the values.
 		   pum_visible	|TRUE| if popup menu is visible.
 				See |pumvisible()|.
+		   pum_pos	Position and size of the popup menu, if it
+				is visible. This data is also available in
+				|v:event| during the |CompleteChanged| event.
 		   items	List of completion matches.  Each item is a
 				dictionary containing the entries "word",
 				"abbr", "menu", "kind", "info" and "user_data".
@@ -3472,6 +3475,15 @@ complete_info([{what}])
 		   "spell"	     Spelling suggestions |i_CTRL-X_s|
 		   "eval"            |complete()| completion
 		   "unknown"	     Other internal modes
+
+		When pum_visible is |FALSE|, pum_pos is an empty dict.
+		Otherwise, it is a dictionary containing the following keys:
+		    height		nr of items visible
+		    width		screen cells
+		    row			top screen row (0 first row)
+		    col			leftmost screen column (0 first row)
+		    size		total nr of items
+		    scrollbar		|TRUE| if visible
 
 		If the optional {what} list argument is supplied, then only
 		the items listed in {what} are returned.  Unsupported items in

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1532,6 +1532,7 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 #define CI_WHAT_ITEMS		0x04
 #define CI_WHAT_SELECTED	0x08
 #define CI_WHAT_INSERTED	0x10
+#define CI_WHAT_POSITION	0x20
 #define CI_WHAT_ALL		0xff
     int		what_flag;
 
@@ -1554,6 +1555,8 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 		what_flag |= CI_WHAT_SELECTED;
 	    else if (STRCMP(what, "inserted") == 0)
 		what_flag |= CI_WHAT_INSERTED;
+	    else if (STRCMP(what, "pum_pos") == 0)
+		what_flag |= CI_WHAT_POSITION;
 	}
     }
 
@@ -1606,6 +1609,16 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 
     // TODO
     // if (ret == OK && (what_flag & CI_WHAT_INSERTED))
+
+    if (ret == OK && (what_flag & CI_WHAT_POSITION))
+    {
+	dict_T* d = dict_alloc();
+	if (d == NULL)
+	    return;
+	pum_set_event_info(d);
+	ret = dict_add_dict(retdict, "pum_pos", d);
+    }
+
 }
 
 /*

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -1006,6 +1006,14 @@ func Test_popup_complete_info_02()
   let d = {
     \   'mode': 'function',
     \   'pum_visible': 1,
+    \   'pum_pos': {
+    \      'height':    5,
+    \      'width':     15,
+    \      'row':       1,
+    \      'col':       0,
+    \      'size':      5,
+    \      'scrollbar': v:false,
+    \   },
     \   'items': [
     \     {'word': 'Jan', 'menu': 'January', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''},
     \     {'word': 'Feb', 'menu': 'February', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''},
@@ -1020,7 +1028,7 @@ func Test_popup_complete_info_02()
   call feedkeys("i\<C-X>\<C-U>\<F5>", 'tx')
   call assert_equal(d, g:compl_info)
 
-  let g:compl_what = ['mode', 'pum_visible', 'selected']
+  let g:compl_what = ['mode', 'pum_visible', 'pum_pos', 'selected']
   call remove(d, 'items')
   call feedkeys("i\<C-X>\<C-U>\<F5>", 'tx')
   call assert_equal(d, g:compl_info)
@@ -1028,8 +1036,26 @@ func Test_popup_complete_info_02()
   let g:compl_what = ['mode']
   call remove(d, 'selected')
   call remove(d, 'pum_visible')
+  call remove(d, 'pum_pos')
   call feedkeys("i\<C-X>\<C-U>\<F5>", 'tx')
   call assert_equal(d, g:compl_info)
+
+  bwipe!
+endfunction
+
+
+func Test_popup_complete_info_no_pum()
+  new
+  call assert_false( pumvisible() )
+  let no_pum_info = complete_info()
+  let d = {
+    \   'mode': '',
+    \   'pum_visible': 0,
+    \   'pum_pos': {},
+    \   'items': [],
+    \   'selected': -1,
+    \  }
+  call assert_equal( d, complete_info() )
   bwipe!
 endfunc
 


### PR DESCRIPTION
Add a new key to the dict returned by `complete_info` which contains the same size and position info that's available from `CompleteChanged` auto command when the pum is visible.

The motivation for this change is essentially that the position info in the CompleteCHanged event is useful in other contexts, and having a script function to query it is simpler than having to track it with an autocomand. Primarily, this:

* Allows plugins placing popups to avoid overlapping the pum 
* Allows tests to validate that the pum/popups don't overlap (this was my actual motivation) for YCM

Other things considered:

* Add pum_getpos() to match popup_getpos(). Decided that we already have complete_info() so why not extend that.