### PR TITLE
Add keyboard layout info for typing $

### DIFF
--- a/runtime/tutor/tutor.tr.utf-8
+++ b/runtime/tutor/tutor.tr.utf-8
@@ -168,7 +168,7 @@ NOT: <ESC> tuşuna basmak sizi Normal kipe götürür ya da istenmeyen tamamlanm
   3. İmleci doğru olan satırın sonuna götürün. (Birinciden SONRA. )
 
   4. Satırı sonuna kadar silmek için   d$   yazın.
-  ( d$  yazarken d'den sonra <ALT> ile beraber $ tuşuna basın)
+  ( d$  yazarken $ kullanmak için Türkçe Q klavyede <ALT GR> 4, Türkçe F klavyede <SHIFT> 4 ikilisini kullanın.)
 
 ---> Birileri bu satırın sonunu iki defa yazmış. Birileri bu satırın sonunu iki defa yazmış.
 


### PR DESCRIPTION
Turkish language is commonly typed by two different keyboard layouts, Q and F. Therefore some symbols are typed by different keyboard combinations. In this case $ is typed by ALT GR + 4 in Turkish Q, and SHIFT + 4 in Turkish F. Original text mistakenly indicated that ALT + 4 would be sufficient, but that is not the case, even CTRL+ALT+4 does not work.