### PR TITLE
Add pum_getpos() to return the position and size of the popup menu

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -595,6 +595,10 @@ CompleteChanged 					*CompleteChanged*
 				    scrollbar		TRUE if visible
 
 				It is not allowed to change the text |textlock|.
+
+				The size and position of the popup are also
+				available by calling |pum_getpos()|.
+
 							*CompleteDone*
 CompleteDone			After Insert mode completion is done.  Either
 				when something was completed or abandoning

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2613,6 +2613,7 @@ prop_type_delete({name} [, {props}])
 prop_type_get([{name} [, {props}])
 				Dict	get property type values
 prop_type_list([{props}])	List	get list of property types
+pum_getpos()			Dict	position and size of pum if visible
 pumvisible()			Number	whether popup menu is visible
 pyeval({expr})			any	evaluate |Python| expression
 py3eval({expr})			any	evaluate |python3| expression
@@ -3476,6 +3477,9 @@ complete_info([{what}])
 		If the optional {what} list argument is supplied, then only
 		the items listed in {what} are returned.  Unsupported items in
 		{what} are silently ignored.
+
+		To get the position of the popup menu, see |pum_getpos()|. It's
+		also available in |v:event| during the |CompleteChanged| event.
 
 		Examples: >
 			" Get all items
@@ -6976,6 +6980,19 @@ prompt_setprompt({buf}, {text})				*prompt_setprompt()*
 			call prompt_setprompt(bufnr(''), 'command: ')
 <
 prop_ functions are documented here: |text-prop-functions|.
+
+pum_getpos()						*pum_getpos()*
+		If the popup menu (see |ins-completion-menu|) is not visible,
+		returns an empty |Dictionary|, otherwise, returns a
+		|Dictionary| with the following keys:
+			height		nr of items visible
+			width		screen cells
+			row		top screen row (0 first row)
+			col		leftmost screen column (0 first col)
+			size		total nr of items
+			scrollbar	|TRUE| if visible
+
+		The values are the same as in |v:event| during |CompleteChanged|.
 
 pumvisible()						*pumvisible()*
 		Returns non-zero when the popup menu is visible, zero

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -1434,6 +1434,7 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 --ttyfail	starting.txt	/*--ttyfail*
 --version	starting.txt	/*--version*
 --windowid	starting.txt	/*--windowid*
+->	eval.txt	/*->*
 -?	starting.txt	/*-?*
 -A	starting.txt	/*-A*
 -C	starting.txt	/*-C*
@@ -3093,6 +3094,8 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 :spelli	spell.txt	/*:spelli*
 :spellinfo	spell.txt	/*:spellinfo*
 :spellr	spell.txt	/*:spellr*
+:spellra	spell.txt	/*:spellra*
+:spellrare	spell.txt	/*:spellrare*
 :spellrepall	spell.txt	/*:spellrepall*
 :spellu	spell.txt	/*:spellu*
 :spellundo	spell.txt	/*:spellundo*
@@ -4028,6 +4031,7 @@ E271	if_ruby.txt	/*E271*
 E272	if_ruby.txt	/*E272*
 E273	if_ruby.txt	/*E273*
 E274	eval.txt	/*E274*
+E275	textprop.txt	/*E275*
 E277	remote.txt	/*E277*
 E28	syntax.txt	/*E28*
 E280	if_tcl.txt	/*E280*
@@ -8350,6 +8354,7 @@ prop_type_list()	textprop.txt	/*prop_type_list()*
 psql	ft_sql.txt	/*psql*
 ptcap.vim	syntax.txt	/*ptcap.vim*
 pterm-mouse	options.txt	/*pterm-mouse*
+pum_getpos()	eval.txt	/*pum_getpos()*
 pumvisible()	eval.txt	/*pumvisible()*
 put	change.txt	/*put*
 put-Visual-mode	change.txt	/*put-Visual-mode*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -234,6 +234,9 @@ static void f_pow(typval_T *argvars, typval_T *rettv);
 #endif
 static void f_prevnonblank(typval_T *argvars, typval_T *rettv);
 static void f_printf(typval_T *argvars, typval_T *rettv);
+#ifdef FEAT_INS_EXPAND
+static void f_pum_getpos(typval_T *argvars, typval_T *rettv);
+#endif
 static void f_pumvisible(typval_T *argvars, typval_T *rettv);
 #ifdef FEAT_PYTHON3
 static void f_py3eval(typval_T *argvars, typval_T *rettv);
@@ -740,6 +743,9 @@ static funcentry_T global_functions[] =
     {"prop_type_delete", 1, 2, 0,	  f_prop_type_delete},
     {"prop_type_get",	1, 2, 0,	  f_prop_type_get},
     {"prop_type_list",	0, 1, 0,	  f_prop_type_list},
+#endif
+#ifdef FEAT_INS_EXPAND
+    {"pum_getpos",	0, 0, 0,	  f_pum_getpos},
 #endif
     {"pumvisible",	0, 0, 0,	  f_pumvisible},
 #ifdef FEAT_PYTHON3
@@ -7959,6 +7965,20 @@ f_printf(typval_T *argvars, typval_T *rettv)
     }
     did_emsg |= saved_did_emsg;
 }
+
+#ifdef FEAT_INS_EXPAND
+/*
+ * "pum_getpos()" function
+ */
+    static void
+f_pum_getpos(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
+{
+    if (rettv_dict_alloc(rettv) != OK)
+	return;
+
+    pum_set_event_info(rettv->vval.v_dict);
+}
+#endif
 
 /*
  * "pumvisible()" function

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -1033,6 +1033,20 @@ func Test_popup_complete_info_02()
   bwipe!
 endfunc
 
+func Test_popup_complete_info_no_pum()
+  new
+  call assert_false( pumvisible() )
+  let no_pum_info = complete_info()
+  let d = {
+        \   'mode': '',
+        \   'pum_visible': 0,
+        \   'items': [],
+        \   'selected': -1,
+        \  }
+  call assert_equal( d, complete_info() )
+  bwipe!
+endfunc
+
 func Test_CompleteChanged()
   new
   call setline(1, ['foo', 'bar', 'foobar', ''])
@@ -1063,8 +1077,36 @@ func Test_CompleteChanged()
 
   autocmd! AAAAA_Group
   set complete& completeopt&
-  delfunc! OnPumchange
+  delfunc! OnPumChange
   bw!
+endfunc
+
+function! GetPumPosition()
+  call assert_true( pumvisible() )
+  let g:pum_pos = pum_getpos()
+  return ''
+endfunction
+
+func Test_pum_getpos()
+  new
+  inoremap <buffer><F5> <C-R>=GetPumPosition()<CR>
+  setlocal completefunc=UserDefinedComplete
+
+  let d = {
+    \   'height':    5,
+    \   'width':     15,
+    \   'row':       1,
+    \   'col':       0,
+    \   'size':      5,
+    \   'scrollbar': v:false,
+    \ }
+  call feedkeys("i\<C-X>\<C-U>\<F5>", 'tx')
+  call assert_equal(d, g:pum_pos)
+
+  call assert_false( pumvisible() )
+  call assert_equal( {}, pum_getpos() )
+  bw!
+  unlet g:pum_pos
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Replaces #4823 

Add pum_getpos() returning the same size and position information as `CompleteChanged`. 

useful for plugins to avoid overlapping the PUM when placing popup windows. Also useful for testing.