### PR TITLE
Revisit src/testdir/summarize.vim

### DIFF
--- a/src/testdir/summarize.vim
+++ b/src/testdir/summarize.vim
@@ -1,7 +1,6 @@
-set nocp
+set nocompatible
 if 1
   " This is executed with the eval feature
-  set nocp
   func Count(match, type)
     if a:type ==# 'executed'
       let g:executed += (a:match+0)
@@ -18,33 +17,34 @@ if 1
   let g:failed = 0
   let g:skipped_output = []
   let g:failed_output = []
-  let output = [""]
+  let output = ['']
 
   try
     " This uses the :s command to just fetch and process the output of the
-    " tests, it doesn't acutally replay anything
-    %s/^Executed\s\+\zs\d\+\ze\s\+tests/\=Count(submatch(0),'executed')/egn
-    %s/^SKIPPED \zs.*/\=Count(submatch(0), 'skipped')/egn
-    %s/^\(\d\+\)\s\+FAILED:/\=Count(submatch(1), 'failed')/egn
+    " tests, it doesn't actually replay anything.
+    " Uses ":silent" to avoid "X matches on X lines" messages.
+    silent %s/^Executed\s\+\zs\d\+\ze\s\+tests/\=Count(submatch(0),'executed')/egn
+    silent %s/^SKIPPED \zs.*/\=Count(submatch(0), 'skipped')/egn
+    silent %s/^\(\d\+\)\s\+FAILED:/\=Count(submatch(1), 'failed')/egn
 
-    call extend(output, ["Skipped:"]) 
+    call extend(output, ['Skipped:'])
     call extend(output, skipped_output)
 
     call extend(output, [
-          \ "",
-          \ "-------------------------------",
-          \ printf("Executed: %5d Tests", g:executed),
-          \ printf(" Skipped: %5d Tests", g:skipped),
-          \ printf("  %s: %5d Tests", g:failed == 0 ? 'Failed' : 'FAILED', g:failed),
-          \ "",
-          \ ]) 
+          \ '',
+          \ '-------------------------------',
+          \ printf('Executed: %5d Tests', g:executed),
+          \ printf(' Skipped: %5d Tests', g:skipped),
+          \ printf('  %s: %5d Tests', g:failed == 0 ? 'Failed' : 'FAILED', g:failed),
+          \ '',
+          \ ])
     if filereadable('test.log')
       " outputs and indents the failed test result
-      call extend(output, ["", "Failures: "])
+      call extend(output, ['', 'Failures: '])
       let failed_output = filter(readfile('test.log'), { v,k -> !empty(k)})
       call extend(output, map(failed_output, { v,k -> "\t".k}))
       " Add a final newline
-      call extend(output, [""])
+      call extend(output, [''])
     endif
 
   catch  " Catch-all


### PR DESCRIPTION
- use `:silent` for `:substitute` commands to avoid
  "X matches on X lines" messages.  This is not really an issue in Vim,
  but Neovim displays them in headless mode.

Fixes recommended by Vint:

- remove duplicate settings (`cp`), and use long name for it.
- use single quotes