### PR TITLE
Fixed crash after OOM when autoload_name() returns NULL

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -9437,7 +9437,7 @@ autoload_name(char_u *name)
     // Get the script file name: replace '#' with '/', append ".vim".
     scriptname = alloc(STRLEN(name) + 14);
     if (scriptname == NULL)
-	return FALSE;
+	return NULL;
     STRCPY(scriptname, "autoload/");
     STRCAT(scriptname, name);
     for (p = scriptname + 9; (p = vim_strchr(p, AUTOLOAD_CHAR)) != NULL;
@@ -9467,6 +9467,8 @@ script_autoload(
 	return FALSE;
 
     tofree = scriptname = autoload_name(name);
+    if (scriptname == NULL)
+	return FALSE;
 
     /* Find the name in the list of previously loaded package names.  Skip
      * "autoload/", it's always the same. */


### PR DESCRIPTION
Inspired by recent crashes after OOM found by @JZuming,
I modified `lalloc()` to return `NULL` at random in rare
cases. Vim-8.1.1888 is quite robust to rare allocation failures,
but I found this crash:

```
(gdb) bt
#0  0x00007fcfa9aa7e20 in ?? () from /usr/lib/x86_64-linux-gnu/libasan.so.4
#1  0x00005563d70cb496 in script_autoload (name=0x611000566ac5 "vundle#begin", reload=0) at eval.c:9474
#2  0x00005563d70c4507 in find_var_in_ht (ht=0x5563d7a8a830 <globvardict+16>, htname=118, varname=0x611000566ac5 "vundle#begin", no_autoload=0) at eval.c:8105
#3  0x00005563d70c4210 in find_var (name=0x611000566ac5 "vundle#begin", htp=0x0, no_autoload=0) at eval.c:8056
#4  0x00005563d7574ff0 in deref_func_name (name=0x611000566ac5 "vundle#begin", lenp=0x7ffc427a67c0, partialp=0x7ffc427a6a60, no_autoload=0) at userfunc.c:374
#5  0x00005563d757d133 in trans_function_name (pp=0x7ffc427a69e0, skip=0, flags=1, fdp=0x7ffc427a6ae0, partial=0x7ffc427a6a60) at userfunc.c:1898
#6  0x00005563d7585dbc in ex_call (eap=0x7ffc427a6cc0) at userfunc.c:3084
#7  0x00005563d7148c4f in do_one_cmd (cmdlinep=0x7ffc427a7000, sourcing=1, cstack=0x7ffc427a7160, fgetline=0x5563d713aae6 <getsourceline>, cookie=0x7ffc427a7870)
    at ex_docmd.c:2471
#8  0x00005563d713ff79 in do_cmdline (cmdline=0x611000677a40 "\" Maintainer:  Dominique Pelle <dominique.pelle at gmail.com>", fgetline=0x5563d713aae6 <getsourceline>, 
    cookie=0x7ffc427a7870, flags=7) at ex_docmd.c:967
#9  0x00005563d7139bed in do_source (fname=0x6030002a1513 "/home/pel/.vimrc", check_other=0, is_vimrc=0) at ex_cmds2.c:2384
#10 0x00005563d71381ea in cmd_source (fname=0x6030002a1513 "/home/pel/.vimrc", eap=0x7ffc427a7b10) at ex_cmds2.c:2003
#11 0x00005563d7137fc5 in ex_source (eap=0x7ffc427a7b10) at ex_cmds2.c:1978
#12 0x00005563d7148c4f in do_one_cmd (cmdlinep=0x7ffc427a7e50, sourcing=0, cstack=0x7ffc427a7fb0, fgetline=0x5563d7187ce4 <getexline>, cookie=0x0) at ex_docmd.c:2471
#13 0x00005563d713ff79 in do_cmdline (cmdline=0x0, fgetline=0x5563d7187ce4 <getexline>, cookie=0x0, flags=0) at ex_docmd.c:967
#14 0x00005563d72d7613 in nv_colon (cap=0x7ffc427a8650) at normal.c:5328
#15 0x00005563d72bbdb2 in normal_cmd (oap=0x7ffc427a87b0, toplevel=1) at normal.c:1100
#16 0x00005563d765c9a1 in main_loop (cmdwin=0, noexmode=0) at main.c:1370
#17 0x00005563d765bad1 in vim_main2 () at main.c:903
#18 0x00005563d765b047 in main (argc=2, argv=0x7ffc427a8a58) at main.c:444
```
`autoload_name()` called at line `eval.c:9469` is documented as returning NULL
when out of memory, but the caller actually crashes in `STRCMP(...)` at line
`eval.c:9474` when `autoload_name()` returns `NULL`:

```
!9469     tofree = scriptname = autoload_name(name);
 9470 
 9471     /* Find the name in the list of previously loaded package names.  Skip
 9472      * "autoload/", it's always the same. */
 9473     for (i = 0; i < ga_loaded.ga_len; ++i)
!9474         if (STRCMP(((char_u **)ga_loaded.ga_data)[i] + 9, scriptname + 9) == 0)
```
This PR fixes it.

Probably I should be able to find other bugs soon using the same method.