### PR TITLE
Fixed use after free when OOM happens in backslash_halve_save()

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -2015,6 +2015,7 @@ backslash_halve(char_u *p)
 
 /*
  * backslash_halve() plus save the result in allocated memory.
+ * Return p when out of memory.
  */
     char_u *
 backslash_halve_save(char_u *p)

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -646,17 +646,19 @@ showmatches(expand_T *xp, int wildmenu UNUSED)
 		    {
 			char_u	*halved_slash;
 			char_u	*exp_path;
+			char_u	*path;
 
 			// Expansion was done before and special characters
 			// were escaped, need to halve backslashes.  Also
 			// $HOME has been replaced with ~/.
 			exp_path = expand_env_save_opt(files_found[k], TRUE);
-			halved_slash = backslash_halve_save(
-				exp_path != NULL ? exp_path : files_found[k]);
+			path = exp_path != NULL ? exp_path : files_found[k];
+			halved_slash = backslash_halve_save(path);
 			j = mch_isdir(halved_slash != NULL ? halved_slash
 							    : files_found[k]);
 			vim_free(exp_path);
-			vim_free(halved_slash);
+			if (halved_slash != path)
+			    vim_free(halved_slash);
 		    }
 		    else
 			// Expansion was done here, file names are literal.

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -4086,7 +4086,9 @@ gen_expand_wildcards(
 		addfile(&ga, t, flags | EW_DIR | EW_FILE);
 	    else
 		addfile(&ga, t, flags);
-	    vim_free(t);
+
+	    if (t != p)
+		vim_free(t);
 	}
 
 #if defined(FEAT_SEARCHPATH)


### PR DESCRIPTION
Function `backslash_halve_save(p)` normally returns an allocated
pointer, but it can also return `p` when out of memory (OOM) happens.
So the caller should only free the returned value of
`backslash_halve_save(p)` when it is different than `p`.

Code was unconditionally freeing the returned value of `backslash_halve_save(p)`,
causing a use after free detected by asan in Vim-8.1.1894 when an OOM
happens in `backslash_halve_save(p)`:
```
=================================================================
==14963==ERROR: AddressSanitizer: heap-use-after-free on address 0x621000778900 at pc 0x55903b685846 bp 0x7fffca411010 sp 0x7fffca411000
WRITE of size 1 at 0x621000778900 thread T0
    #0 0x55903b685845 in copy_option_part /home/pel/sb/vim/src/misc2.c:1777
    #1 0x55903b52e514 in do_in_path /home/pel/sb/vim/src/ex_cmds2.c:1263
    #2 0x55903b52ecdb in do_in_path_and_pp /home/pel/sb/vim/src/ex_cmds2.c:1369
    #3 0x55903b52ef70 in source_in_path /home/pel/sb/vim/src/ex_cmds2.c:1428
    #4 0x55903b52ef3b in source_runtime /home/pel/sb/vim/src/ex_cmds2.c:1419
    #5 0x55903b4c4519 in script_autoload /home/pel/sb/vim/src/eval.c:9490
    #6 0x55903b974378 in call_func /home/pel/sb/vim/src/userfunc.c:1574
    #7 0x55903b96e8c6 in get_func_tv /home/pel/sb/vim/src/userfunc.c:482
    #8 0x55903b4a836a in eval_func /home/pel/sb/vim/src/eval.c:3686
    #9 0x55903b4acd89 in eval7 /home/pel/sb/vim/src/eval.c:4728
    #10 0x55903b4ab09d in eval6 /home/pel/sb/vim/src/eval.c:4326
    #11 0x55903b4aa10d in eval5 /home/pel/sb/vim/src/eval.c:4117
    #12 0x55903b4a9869 in eval4 /home/pel/sb/vim/src/eval.c:3999
    #13 0x55903b4a93fd in eval3 /home/pel/sb/vim/src/eval.c:3919
    #14 0x55903b4a8f5b in eval2 /home/pel/sb/vim/src/eval.c:3851
    #15 0x55903b4a89e4 in eval1 /home/pel/sb/vim/src/eval.c:3779
    #16 0x55903b4a86e9 in eval0 /home/pel/sb/vim/src/eval.c:3737
    #17 0x55903b498f7c in eval_expr /home/pel/sb/vim/src/eval.c:1078
    #18 0x55903b9e3122 in VimEval /home/pel/sb/vim/src/if_py_both.h:895
    #19 0x7fd1dcce6eaa in _PyCFunction_FastCallDict (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x147eaa)
    #20 0x7fd1dcdbb392  (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x21c392)
    #21 0x7fd1dcd86b6f in _PyEval_EvalFrameDefault (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x1e7b6f)
    #22 0x7fd1dcdb9952  (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x21a952)
    #23 0x7fd1dcdbb471  (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x21c471)
    #24 0x7fd1dcd86b6f in _PyEval_EvalFrameDefault (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x1e7b6f)
    #25 0x7fd1dcdb9952  (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x21a952)
    #26 0x7fd1dcdbb471  (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x21c471)
    #27 0x7fd1dcd86b6f in _PyEval_EvalFrameDefault (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x1e7b6f)
    #28 0x7fd1dcdbabaa  (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x21bbaa)
    #29 0x7fd1dcdbb67d in PyEval_EvalCodeEx (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x21c67d)
    #30 0x7fd1dcd8180a in PyEval_EvalCode (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x1e280a)
    #31 0x7fd1dccb928e in PyRun_StringFlags (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x11a28e)
    #32 0x55903b9facd1 in run_cmd /home/pel/sb/vim/src/if_py_both.h:5659
    #33 0x55903ba02764 in DoPyCommand /home/pel/sb/vim/src/if_python3.c:986
    #34 0x55903ba02a1d in ex_py3 /home/pel/sb/vim/src/if_python3.c:1020
    #35 0x55903b541c1f in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2471
    #36 0x55903b538f49 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:967
    #37 0x55903b4c2a78 in ex_execute /home/pel/sb/vim/src/eval.c:9132
    #38 0x55903b541c1f in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2471
    #39 0x55903b538f49 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:967
    #40 0x55903b9718ae in call_user_func /home/pel/sb/vim/src/userfunc.c:1054
    #41 0x55903b974a36 in call_func /home/pel/sb/vim/src/userfunc.c:1625
    #42 0x55903b96e8c6 in get_func_tv /home/pel/sb/vim/src/userfunc.c:482
    #43 0x55903b97f5f3 in ex_call /home/pel/sb/vim/src/userfunc.c:3156
    #44 0x55903b541c1f in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2471
    #45 0x55903b538f49 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:967
    #46 0x55903b412a99 in apply_autocmds_group /home/pel/sb/vim/src/autocmd.c:2110
    #47 0x55903b4112ae in apply_autocmds /home/pel/sb/vim/src/autocmd.c:1605
    #48 0x55903b9a2fe3 in win_close /home/pel/sb/vim/src/window.c:2605
    #49 0x55903b5562dd in ex_win_close /home/pel/sb/vim/src/ex_docmd.c:5857
    #50 0x55903b555d74 in ex_close /home/pel/sb/vim/src/ex_docmd.c:5777
    #51 0x55903b541c1f in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2471
    #52 0x55903b538f49 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:967
    #53 0x55903b9718ae in call_user_func /home/pel/sb/vim/src/userfunc.c:1054
    #54 0x55903b974a36 in call_func /home/pel/sb/vim/src/userfunc.c:1625
    #55 0x55903b96e8c6 in get_func_tv /home/pel/sb/vim/src/userfunc.c:482
    #56 0x55903b97f5f3 in ex_call /home/pel/sb/vim/src/userfunc.c:3156
    #57 0x55903b541c1f in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2471
    #58 0x55903b538f49 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:967
    #59 0x55903b9718ae in call_user_func /home/pel/sb/vim/src/userfunc.c:1054
    #60 0x55903b974a36 in call_func /home/pel/sb/vim/src/userfunc.c:1625
    #61 0x55903b96e8c6 in get_func_tv /home/pel/sb/vim/src/userfunc.c:482
    #62 0x55903b97f5f3 in ex_call /home/pel/sb/vim/src/userfunc.c:3156
    #63 0x55903b541c1f in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2471
    #64 0x55903b538f49 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:967
    #65 0x55903b96b749 in do_ucmd /home/pel/sb/vim/src/usercmd.c:1652
    #66 0x55903b541b54 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2463
    #67 0x55903b538f49 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:967
    #68 0x55903b6d059f in nv_colon /home/pel/sb/vim/src/normal.c:5328
    #69 0x55903b6b4d3e in normal_cmd /home/pel/sb/vim/src/normal.c:1100
    #70 0x55903ba5592d in main_loop /home/pel/sb/vim/src/main.c:1370
    #71 0x55903ba54a5d in vim_main2 /home/pel/sb/vim/src/main.c:903
    #72 0x55903ba53fd3 in main /home/pel/sb/vim/src/main.c:444
    #73 0x7fd1dc5b0b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #74 0x55903b401b29 in _start (/home/pel/sb/vim/src/vim+0x10bb29)

0x621000778900 is located 0 bytes inside of 4096-byte region [0x621000778900,0x621000779900)
freed by thread T0 here:
    #0 0x7fd1ded077b8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7b8)
    #1 0x55903b6859e5 in vim_free /home/pel/sb/vim/src/misc2.c:1805
    #2 0x55903b67d6bb in gen_expand_wildcards /home/pel/sb/vim/src/misc1.c:4089
    #3 0x55903b52e815 in do_in_path /home/pel/sb/vim/src/ex_cmds2.c:1304
    #4 0x55903b52ecdb in do_in_path_and_pp /home/pel/sb/vim/src/ex_cmds2.c:1369
    #5 0x55903b52ef70 in source_in_path /home/pel/sb/vim/src/ex_cmds2.c:1428
    #6 0x55903b52ef3b in source_runtime /home/pel/sb/vim/src/ex_cmds2.c:1419
    #7 0x55903b4c4519 in script_autoload /home/pel/sb/vim/src/eval.c:9490
    #8 0x55903b974378 in call_func /home/pel/sb/vim/src/userfunc.c:1574
    #9 0x55903b96e8c6 in get_func_tv /home/pel/sb/vim/src/userfunc.c:482
    #10 0x55903b4a836a in eval_func /home/pel/sb/vim/src/eval.c:3686
    #11 0x55903b4acd89 in eval7 /home/pel/sb/vim/src/eval.c:4728
    #12 0x55903b4ab09d in eval6 /home/pel/sb/vim/src/eval.c:4326
    #13 0x55903b4aa10d in eval5 /home/pel/sb/vim/src/eval.c:4117
    #14 0x55903b4a9869 in eval4 /home/pel/sb/vim/src/eval.c:3999
    #15 0x55903b4a93fd in eval3 /home/pel/sb/vim/src/eval.c:3919
    #16 0x55903b4a8f5b in eval2 /home/pel/sb/vim/src/eval.c:3851
    #17 0x55903b4a89e4 in eval1 /home/pel/sb/vim/src/eval.c:3779
    #18 0x55903b4a86e9 in eval0 /home/pel/sb/vim/src/eval.c:3737
    #19 0x55903b498f7c in eval_expr /home/pel/sb/vim/src/eval.c:1078
    #20 0x55903b9e3122 in VimEval /home/pel/sb/vim/src/if_py_both.h:895
    #21 0x7fd1dcce6eaa in _PyCFunction_FastCallDict (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x147eaa)

previously allocated by thread T0 here:
    #0 0x7fd1ded07b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x55903b682d0f in lalloc /home/pel/sb/vim/src/misc2.c:930
    #2 0x55903b682acd in alloc /home/pel/sb/vim/src/misc2.c:827
    #3 0x55903b52e3e8 in do_in_path /home/pel/sb/vim/src/ex_cmds2.c:1245
    #4 0x55903b52ecdb in do_in_path_and_pp /home/pel/sb/vim/src/ex_cmds2.c:1369
    #5 0x55903b52ef70 in source_in_path /home/pel/sb/vim/src/ex_cmds2.c:1428
    #6 0x55903b52ef3b in source_runtime /home/pel/sb/vim/src/ex_cmds2.c:1419
    #7 0x55903b4c4519 in script_autoload /home/pel/sb/vim/src/eval.c:9490
    #8 0x55903b974378 in call_func /home/pel/sb/vim/src/userfunc.c:1574
    #9 0x55903b96e8c6 in get_func_tv /home/pel/sb/vim/src/userfunc.c:482
    #10 0x55903b4a836a in eval_func /home/pel/sb/vim/src/eval.c:3686
    #11 0x55903b4acd89 in eval7 /home/pel/sb/vim/src/eval.c:4728
    #12 0x55903b4ab09d in eval6 /home/pel/sb/vim/src/eval.c:4326
    #13 0x55903b4aa10d in eval5 /home/pel/sb/vim/src/eval.c:4117
    #14 0x55903b4a9869 in eval4 /home/pel/sb/vim/src/eval.c:3999
    #15 0x55903b4a93fd in eval3 /home/pel/sb/vim/src/eval.c:3919
    #16 0x55903b4a8f5b in eval2 /home/pel/sb/vim/src/eval.c:3851
    #17 0x55903b4a89e4 in eval1 /home/pel/sb/vim/src/eval.c:3779
    #18 0x55903b4a86e9 in eval0 /home/pel/sb/vim/src/eval.c:3737
    #19 0x55903b498f7c in eval_expr /home/pel/sb/vim/src/eval.c:1078
    #20 0x55903b9e3122 in VimEval /home/pel/sb/vim/src/if_py_both.h:895
    #21 0x7fd1dcce6eaa in _PyCFunction_FastCallDict (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x147eaa)

SUMMARY: AddressSanitizer: heap-use-after-free /home/pel/sb/vim/src/misc2.c:1777 in copy_option_part
Shadow bytes around the buggy address:
  0x0c42800e70d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c42800e70e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c42800e70f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c42800e7100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c42800e7110: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c42800e7120:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c42800e7130: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c42800e7140: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c42800e7150: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c42800e7160: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c42800e7170: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==14963==ABORTING
```
This PR fixes it.
