### PR TITLE
Support different line number specifiers for the sign_place() function

### DIFF
--- a/src/sign.c
+++ b/src/sign.c
@@ -2430,9 +2430,12 @@ sign_place_from_dict(
     di = dict_find(dict, (char_u *)"lnum", -1);
     if (di != NULL)
     {
-	lnum = (int)tv_get_number_chk(&di->di_tv, &notanum);
-	if (notanum)
+	lnum = tv_get_lnum(&di->di_tv);
+	if (lnum <= 0)
+	{
+	    emsg(_(e_invarg));
 	    goto cleanup;
+	}
     }
 
     // sign priority

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -457,11 +457,11 @@ func Test_sign_funcs()
   call assert_fails('call sign_place(5, "", "sign1", [], {"lnum" : 10})',
 	      \ 'E158:')
   call assert_fails('call sign_place(21, "", "sign1", "Xsign",
-	      \ {"lnum" : -1})', 'E885:')
+	      \ {"lnum" : -1})', 'E474:')
   call assert_fails('call sign_place(22, "", "sign1", "Xsign",
-	      \ {"lnum" : 0})', 'E885:')
+	      \ {"lnum" : 0})', 'E474:')
   call assert_fails('call sign_place(22, "", "sign1", "Xsign",
-	      \ {"lnum" : []})', 'E745:')
+	      \ {"lnum" : []})', 'E474:')
   call assert_equal(-1, sign_place(1, "*", "sign1", "Xsign", {"lnum" : 10}))
 
   " Tests for sign_getplaced()
@@ -516,6 +516,16 @@ func Test_sign_funcs()
   call assert_equal([], sign_getdefined("sign1"))
   call assert_fails('call sign_undefine("none")', 'E155:')
   call assert_fails('call sign_undefine({})', 'E731:')
+
+  " Test for using '.' as the line number for sign_place()
+  call sign_define("sign1", attr)
+  call cursor(22, 1)
+  call assert_equal(15, sign_place(15, '', 'sign1', 'Xsign',
+	      \ {'lnum' : '.'}))
+  call assert_equal([{'bufnr' : bufnr(''), 'signs' :
+	      \ [{'id' : 15, 'group' : '', 'lnum' : 22, 'name' : 'sign1',
+	      \ 'priority' : 10}]}],
+	      \ sign_getplaced('%', {'lnum' : 22}))
 
   call delete("Xsign")
   call sign_unplace('*')
@@ -1926,6 +1936,14 @@ func Test_sign_funcs_multi()
 	      \ {'id' : 5, 'name' : 'sign1', 'buffer' : 'Xsign'}]))
   let s = sign_getplaced('Xsign', {'id' : 5, 'group' : ''})
   call assert_equal([{'id' : 5, 'name' : 'sign1', 'lnum' : 11,
+	      \ 'group' : '', 'priority' : 10}], s[0].signs)
+
+  " Place a sign using '.' as the line number
+  call cursor(23, 1)
+  call assert_equal([7], sign_placelist([
+	      \ {'id' : 7, 'name' : 'sign1', 'buffer' : '%', 'lnum' : '.'}]))
+  let s = sign_getplaced('%', {'lnum' : '.'})
+  call assert_equal([{'id' : 7, 'name' : 'sign1', 'lnum' : 23,
 	      \ 'group' : '', 'priority' : 10}], s[0].signs)
 
   " Place sign without a sign name


### PR DESCRIPTION
The help text for sign_place() states that the lnum argument accepts values
that are supported by line(). Modify the code to make it so.