### PR TITLE
Fix `netrw_gitignore` for unix hidden files

### DIFF
--- a/runtime/autoload/netrw_gitignore.vim
+++ b/runtime/autoload/netrw_gitignore.vim
@@ -71,6 +71,7 @@ function! netrw_gitignore#Hide(...)
     let escaped = substitute(escaped, '\(\[[^]]*\)\zs\\\.', '\.', 'g')
     let escaped = substitute(escaped, '\(\[[^]]*\)\zs\\\$', '\$', 'g')
     let escaped = substitute(escaped, '\(\[[^]]*\)\zs\.\*', '*', 'g')
+    let escaped = '^' . escaped . '$'
     let escaped_lines = add(escaped_lines, escaped)
   endfor
 


### PR DESCRIPTION
Support for `.*` pattern in .gitignore files.

This rule is used (for example) in the linux repository:
https://github.com/torvalds/linux/blob/fec88ab0af9706b2201e5daf377c5031c62d11f7/.gitignore#L12

I haven't found an email or repository for this runtime file. The author (Bruno Sutic) is different from the netrw author.

Close: #4678 