### PR TITLE
Fix crash in clear_tv() when call_callback() returns FAIL as a result of OOM

### DIFF
--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -1501,7 +1501,7 @@ call_func(
     int		argv_base = 0;
     partial_T	*partial = funcexe->partial;
 
-    // Initialize rettv so that it is safe for caller to invoke clear(rettv)
+    // Initialize rettv so that it is safe for caller to invoke clear_tv(rettv)
     // even when call_func() returns FAIL.
     rettv->v_type = VAR_UNKNOWN;
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -1501,6 +1501,10 @@ call_func(
     int		argv_base = 0;
     partial_T	*partial = funcexe->partial;
 
+    // Initialize rettv so that it is safe for caller to invoke clear(rettv)
+    // even when call_func() returns FAIL.
+    rettv->v_type = VAR_UNKNOWN;
+
     // Make a copy of the name, if it comes from a funcref variable it could
     // be changed or deleted in the called function.
     name = len > 0 ? vim_strnsave(funcname, len) : vim_strsave(funcname);
@@ -1530,16 +1534,7 @@ call_func(
 	}
     }
 
-    /*
-     * Execute the function if executing and no errors were detected.
-     */
-    if (!funcexe->evaluate)
-    {
-	// Not evaluating, which means the return value is unknown.  This
-	// matters for giving error messages.
-	rettv->v_type = VAR_UNKNOWN;
-    }
-    else if (error == ERROR_NONE)
+    if (error == ERROR_NONE && funcexe->evaluate)
     {
 	char_u *rfname = fname;
 


### PR DESCRIPTION
Injecting random failures in lalloc(), I encountered a crash
where clear_tv() is involved with a non-initialized pointer
as a result of a OOM:
```
(gdb) bt
#0  0x000055b3a59f4bee in list_unref (l=0x6c17a4cf61fbdc00) at list.c:151
#1  0x000055b3a588c6ad in clear_tv (varp=0x7ffda01c42e0) at eval.c:7735
#2  0x000055b3a5dc8734 in channel_close (channel=0x61a00001d480, invoke_close_cb=1) at channel.c:3047
#3  0x000055b3a5dc9951 in channel_close_now (channel=0x61a00001d480) at channel.c:3393
#4  0x000055b3a5dcd195 in channel_parse_messages () at channel.c:4433
#5  0x000055b3a5a520fa in parse_queued_messages () at misc2.c:4481
#6  0x000055b3a5d0e49b in inchar_loop (buf=0x55b3a6200975 <typebuf_init+53> "", maxlen=70, wtime=-1, tb_change_cnt=139, wait_func=0x55b3a5b21a85 <WaitForChar>, resize_func=0x55b3a5b12e86 <resize_func>) at ui.c:297
#7  0x000055b3a5b12eef in mch_inchar (buf=0x55b3a6200975 <typebuf_init+53> "", maxlen=70, wtime=-1, tb_change_cnt=139) at os_unix.c:388
#8  0x000055b3a5d0e269 in ui_inchar (buf=0x55b3a6200975 <typebuf_init+53> "", maxlen=70, wtime=-1, tb_change_cnt=139) at ui.c:231
#9  0x000055b3a59954f5 in inchar (buf=0x55b3a6200975 <typebuf_init+53> "", maxlen=211, wait_time=-1) at getchar.c:3082
#10 0x000055b3a59945ef in vgetorpeek (advance=1) at getchar.c:2860
#11 0x000055b3a598e076 in vgetc () at getchar.c:1588
#12 0x000055b3a598eb27 in safe_vgetc () at getchar.c:1807
#13 0x000055b3a5e1024e in wait_return (redraw=0) at message.c:1100
#14 0x000055b3a5904722 in do_cmdline (cmdline=0x0, fgetline=0x55b3a5945329 <getexline>, cookie=0x0, flags=0) at ex_docmd.c:1374
#15 0x000055b3a5a94d91 in nv_colon (cap=0x7ffda01c5360) at normal.c:5328
#16 0x000055b3a5a79538 in normal_cmd (oap=0x7ffda01c54c0, toplevel=1) at normal.c:1100
#17 0x000055b3a5dfcbb5 in main_loop (cmdwin=0, noexmode=0) at main.c:1370
#18 0x000055b3a5dfbce5 in vim_main2 () at main.c:903
#19 0x000055b3a5dfb25b in main (argc=1, argv=0x7ffda01c5768) at main.c:444
```
```
list.c:

 148│     void
 149│ list_unref(list_T *l)
 150│ {
 151├>    if (l != NULL && --l->lv_refcount <= 0)
 152│         list_free(l);
 153│ }

(gdb) p l
$3 = (list_T *) 0x6c17a4cf61fbdc00

(gdb) p *l
Cannot access memory at address 0x6c17a4cf61fbdc00
```
It's called from:
```
eval.c;
 7714│ clear_tv(typval_T *varp)
 ....
 7734│             case VAR_LIST:
 7735├>                list_unref(varp->vval.v_list);
 7736│                 varp->vval.v_list = NULL;
 7737│                 break;
```
Which is called from:
```
channel.c:
2996│ channel_close(channel_T *channel, int invoke_close_cb)
....
3046│               call_callback(&channel->ch_close_cb, -1, &rettv, 1, argv);
3047├>              clear_tv(&rettv);
```
If call_callback() called at line channel.c:3046 returns
FAIL as a result of an alloc failure in call_func(), then
output rettv is not initialized and the call to clear(&rettv) at
channel.c:3047 may thus crash trying to free a random
pointer.

This PR should fix it. However, I'm not able to reproduce
it, so I did not verify it.