### PR TITLE
Fix testdir/summarize.vim for single test

### DIFF
--- a/src/testdir/summarize.vim
+++ b/src/testdir/summarize.vim
@@ -21,9 +21,9 @@ if 1
 
   try
     " This uses the :s command to just fetch and process the output of the
-    " tests, it doesn't acutally replace anything.
+    " tests, it doesn't actually replace anything.
     " And it uses "silent" to avoid reporting the number of matches.
-    silent %s/^Executed\s\+\zs\d\+\ze\s\+tests/\=Count(submatch(0),'executed')/egn
+    silent %s/^Executed\s\+\zs\d\+\ze\s\+tests\?/\=Count(submatch(0),'executed')/egn
     silent %s/^SKIPPED \zs.*/\=Count(submatch(0), 'skipped')/egn
     silent %s/^\(\d\+\)\s\+FAILED:/\=Count(submatch(1), 'failed')/egn
 


### PR DESCRIPTION
E.g. with `make -C src/testdir test_reltime report`.