### PR TITLE
Fixed crash in syntax highlighting after OOM

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -5224,8 +5224,11 @@ syn_cmd_region(
 	{
 	    if (!success)
 	    {
-		vim_regfree(ppp->pp_synp->sp_prog);
-		vim_free(ppp->pp_synp->sp_pattern);
+		if (ppp->pp_synp != NULL)
+		{
+		    vim_regfree(ppp->pp_synp->sp_prog);
+		    vim_free(ppp->pp_synp->sp_pattern);
+		}
 	    }
 	    vim_free(ppp->pp_synp);
 	    ppp_next = ppp->pp_next;


### PR DESCRIPTION
This PR fixes a crash in syntax highlighting after OOM
in vim-8.1.1949 (and earlier):
```
Program received signal SIGSEGV, Segmentation fault.
0x000055bd97529e0a in syn_cmd_region (eap=0x7ffc0eec8890, syncing=0) at syntax.c:5227

(gdb) bt
#0  0x000055bd97529e0a in syn_cmd_region (eap=0x7ffc0eec8890, syncing=0) at syntax.c:5227
#1  0x000055bd9752f998 in ex_syntax (eap=0x7ffc0eec8890) at syntax.c:6240
#2  0x000055bd971809a9 in do_one_cmd (cmdlinep=0x7ffc0eec8bd0, sourcing=1, cstack=0x7ffc0eec8d30, fgetline=0x55bd9743a8d5 <getsourceline>, cookie=0x7ffc0eec9440) at ex_docmd.c:2470
#3  0x000055bd97177cd3 in do_cmdline (cmdline=0x6110001ec480 "\" Vim syntax file", fgetline=0x55bd9743a8d5 <getsourceline>, cookie=0x7ffc0eec9440, flags=7) at ex_docmd.c:966
#4  0x000055bd9743948c in do_source (fname=0x604000091290 "/usr/local/share/vim/vim81/syntax/c.vim", check_other=0, is_vimrc=0) at scriptfile.c:1187
...

syntax.c:

5219|     /*
5220|      * Free the allocated memory.
5221|      */
5222|     for (item = ITEM_START; item <= ITEM_END; ++item)
5223|         for (ppp = pat_ptrs[item]; ppp != NULL; ppp = ppp_next)
5224|         {
5225|             if (!success)
5226|             {
5227|>                vim_regfree(ppp->pp_synp->sp_prog);
5228|                 vim_free(ppp->pp_synp->sp_pattern);
5229|             }

(gdb) p ppp->pp_synp
$6 = (synpat_T *) 0x0
```
`ppp->pp_synp` is `NULL` hence crash at line `syntax.c:5227`.

`ppp->pp_synp` can be `NULL` as a result of an allocation
failure at line `syntax.c:5119`:
```
5119|             ppp->pp_synp = ALLOC_CLEAR_ONE(synpat_T);
```
I can reproduce the crash and verify that the change in
this PR fixes it by temporarily replacing line 5119 with:
```
5119|             ppp->pp_synp = NULL; //ALLOC_CLEAR_ONE(synpat_T);
```
Of course Vim does not highlight with colors when such
OOM happens, but it's better than crashing.

I also verified with valgrind that no leak happens in this
error path when allocation fails at `syntax.c:5119`.

I don't consider bugs after OOM as severe, as OOM
should normally not happen to begin with, but if they are
easy to fix like this one, then it's worth fixing, especially
since vim is fairly robust against allocation returning `NULL`.