### PR TITLE
Fixed memory leak in tag user_data

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -4892,8 +4892,10 @@ win_free(
     win_free_lsize(wp);
 
     for (i = 0; i < wp->w_tagstacklen; ++i)
+    {
 	vim_free(wp->w_tagstack[i].tagname);
-
+	vim_free(wp->w_tagstack[i].user_data);
+    }
     vim_free(wp->w_localdir);
 
     /* Remove the window from the b_wininfo lists, it may happen that the


### PR DESCRIPTION
This PR fixes a memory leak in tag user_data.
The leak was visible when running `make test_tagfunc`
with valgrind:
```
==26436== 10 bytes in 1 blocks are definitely lost in loss record 16 of 145
==26436==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==26436==    by 0x50F2F6: lalloc (misc2.c:924)
==26436==    by 0x50F299: alloc (misc2.c:827)
==26436==    by 0x50FA4C: vim_strnsave (misc2.c:1293)
==26436==    by 0x62222C: do_tag (tag.c:689)
==26436==    by 0x491693: ex_tag_cmd (ex_docmd.c:7882)
==26436==    by 0x48EBD0: ex_tag (ex_docmd.c:7833)
==26436==    by 0x4853F2: do_one_cmd (ex_docmd.c:2470)
==26436==    by 0x482420: do_cmdline (ex_docmd.c:966)
==26436==    by 0x483205: do_cmdline_cmd (ex_docmd.c:567)
==26436==    by 0x529E94: nv_ident (normal.c:5750)
==26436==    by 0x522183: normal_cmd (normal.c:1100)
==26436==    by 0x48BB22: exec_normal (ex_docmd.c:7684)
==26436==    by 0x48B9BA: exec_normal_cmd (ex_docmd.c:7647)
==26436==    by 0x48B8D8: ex_normal (ex_docmd.c:7569)
==26436==    by 0x4853F2: do_one_cmd (ex_docmd.c:2470)
==26436==    by 0x482420: do_cmdline (ex_docmd.c:966)
==26436==    by 0x44CEDC: ex_execute (eval.c:6072)
==26436==    by 0x4853F2: do_one_cmd (ex_docmd.c:2470)
==26436==    by 0x482420: do_cmdline (ex_docmd.c:966)
==26436==    by 0x659C5A: call_user_func (userfunc.c:1054)
==26436==    by 0x657F7D: call_func (userfunc.c:1618)
==26436==    by 0x657812: get_func_tv (userfunc.c:482)
==26436==    by 0x65E000: ex_call (userfunc.c:3149)
==26436==    by 0x4853F2: do_one_cmd (ex_docmd.c:2470)
==26436== 
==26436== 20 bytes in 2 blocks are definitely lost in loss record 30 of 145
==26436==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==26436==    by 0x50F2F6: lalloc (misc2.c:924)
==26436==    by 0x50F299: alloc (misc2.c:827)
==26436==    by 0x50FA4C: vim_strnsave (misc2.c:1293)
==26436==    by 0x62222C: do_tag (tag.c:689)
==26436==    by 0x491693: ex_tag_cmd (ex_docmd.c:7882)
==26436==    by 0x48EBD0: ex_tag (ex_docmd.c:7833)
==26436==    by 0x4853F2: do_one_cmd (ex_docmd.c:2470)
==26436==    by 0x482420: do_cmdline (ex_docmd.c:966)
==26436==    by 0x659C5A: call_user_func (userfunc.c:1054)
==26436==    by 0x657F7D: call_func (userfunc.c:1618)
==26436==    by 0x657812: get_func_tv (userfunc.c:482)
==26436==    by 0x65E000: ex_call (userfunc.c:3149)
==26436==    by 0x4853F2: do_one_cmd (ex_docmd.c:2470)
==26436==    by 0x482420: do_cmdline (ex_docmd.c:966)
==26436==    by 0x44CEDC: ex_execute (eval.c:6072)
==26436==    by 0x4853F2: do_one_cmd (ex_docmd.c:2470)
==26436==    by 0x482420: do_cmdline (ex_docmd.c:966)
==26436==    by 0x659C5A: call_user_func (userfunc.c:1054)
==26436==    by 0x657F7D: call_func (userfunc.c:1618)
==26436==    by 0x657812: get_func_tv (userfunc.c:482)
==26436==    by 0x65E000: ex_call (userfunc.c:3149)
==26436==    by 0x4853F2: do_one_cmd (ex_docmd.c:2470)
==26436==    by 0x482420: do_cmdline (ex_docmd.c:966)
==26436==    by 0x5B7432: do_source (scriptfile.c:1192)
```

The leak was introduced in:
```
commit 45e18cbdc40afd8144d20dcc07ad2d981636f4c9 (tag: v8.1.1228)
Author: Bram Moolenaar <Bram@vim.org>
Date:   Sun Apr 28 18:05:35 2019 +0200

    patch 8.1.1228: not possible to process tags with a function
    
    Problem:    Not possible to process tags with a function.
    Solution:   Add tagfunc() (Christian Brabandt, Andy Massimino, closes #4010)
```