### PR TITLE
Fix crash with nested filter,map,readdir (#4890)

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -498,6 +498,8 @@ prepare_vimvar(int idx, typval_T *save_tv)
     *save_tv = vimvars[idx].vv_tv;
     if (vimvars[idx].vv_type == VAR_UNKNOWN)
 	hash_add(&vimvarht, vimvars[idx].vv_di.di_key);
+    // Set v: variable to be empty.
+    vimvars[idx].vv_type = VAR_UNKNOWN;
 }
 
 /*

--- a/src/testdir/test_filter_map.vim
+++ b/src/testdir/test_filter_map.vim
@@ -57,6 +57,8 @@ func Test_filter_map_nested()
   let x = {"x":10}
   let r = map(range(2), 'filter(copy(x), "1")')
   call assert_equal([x, x], r)
+  let r = map(copy(x), 'filter(copy(x), "1")')
+  call assert_equal({"x": x}, r)
 endfunc
 
 " dict with funcref

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1540,8 +1540,12 @@ func Test_readdir()
 
   " Limit to 1 result.
   let l = []
-  let files = readdir('Xdir', {x -> len(add(l, x)) == 2 ? -1 : 1})
+  let files = readdir('Xdir', { x -> len(add(l, x)) == 2 ? -1 : 1 })
   call assert_equal(1, len(files))
+
+  " Nested readdir() must not crash
+  let files = readdir('Xdir', 'readdir("Xdir", "1") != []')
+  call assert_equal(['bar.txt', 'dir', 'foo.txt'], sort(files))
 
   eval 'Xdir'->delete('rf')
 endfunc


### PR DESCRIPTION
fixes #4890 

Double-free occurs in nested map():

```c
// (Concept)
typval_T save_val;

// first map
set_vim_var_string(VV_VAL, (char_u *)"test", -1);
// nested map
prepare_vimvar(VV_VAL, &save_val);
set_vim_var_string(VV_VAL, (char_u *)"test", -1);   // free v:val (==save_val) by clear_tv()
restore_vimvar(VV_VAL, &save_val);                  // set v:val to save_val ... dangling pointer
// return from nested map
set_vim_var_string(VV_VAL, (char_u *)"test", -1);   // free v:val (==save_val) ... double-free!
```

Thus I propose to make `v:` variable disabled once in `prepare_vimvar()` by setting its type to `VAR_UNKNOWN`.