### PR TITLE
Fix travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,12 +142,8 @@ script:
       "${SRCDIR}"/vim --not-a-term -u NONE -S "${SRCDIR}"/testdir/if_ver-2.vim -c quit > /dev/null
       cat if_ver.txt
     fi
-  - |
-    if do_test make ${SHADOWOPT} ${TEST}; then
-      echo -en "travis_fold:end:test\\r\\033[0K"
-    else
-      exit 1
-    fi
+  - do_test make ${SHADOWOPT} ${TEST} && FOLD_MARKER=travis_fold
+  - echo -en "${FOLD_MARKER}:end:test\\r\\033[0K"
 
 
 # instead of a 2*2*8 matrix (2*os + 2*compiler + 8*env),


### PR DESCRIPTION
## Problems:

### All `make test` log is shown regardless of test success or failure

Should separate fold-end marker from `make test` line.

### ASAN log is not shown

When doing `exit`, `after_failure` commands isn't executed. 