### PR TITLE
Check for added timer and input in inner loop of gui_mch_wait_for_chars

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -2101,13 +2101,18 @@ gui_mch_wait_for_chars(int wtime)
 
 	    parse_queued_messages();
 
+#ifdef FEAT_TIMERS
+	    if (did_add_timer)
+		break;
+#endif
+
 	    if (pPeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE))
 	    {
 		process_message();
 		break;
 	    }
-	    else if (MsgWaitForMultipleObjects(0, NULL, FALSE, 100, QS_ALLINPUT)
-							       != WAIT_TIMEOUT)
+	    else if (input_available() || MsgWaitForMultipleObjects(0, NULL,
+				      FALSE, 100, QS_ALLINPUT) != WAIT_TIMEOUT)
 		break;
 	}
 #else


### PR DESCRIPTION
This fixes two issues for gVim on Windows. Both reproduce steps are flaky but reproducible after a few tries.

First issue:
1. vim --clean -S reproduce1.vim
2. Enter insert mode and press `<f5>`
3. Exit status is displayed but complete menu is not triggered

Expected behavior:
Complete menu should be triggered immediately after the job has been completed.

```
" reproduce1.vim
setl completeopt-=longest
setl completeopt+=menu,menuone,noinsert,noselect
set  noshowmode
set guicursor=a:blinkon0
set updatetime=10000

function! OutCb(chan, msg)
endfunction

function! ExitCb(job, status)
  let elapsed = reltimestr(reltime(s:starttime))
  echom printf('EXIT: %s', elapsed)
  call timer_start(100, {_-> complete(col('.'), g:suggestions)})
endfunction

function! JobStart(...)
  let s:starttime = reltime()
  let s:job = job_start('cmd /c help', {'out_cb': 'OutCb', 'exit_cb': 'ExitCb'})
  return ''
endfunction

let suggestions =  ['January', 'February', 'March',
      \ 'April', 'May', 'June', 'July', 'August', 'September',
      \ 'October', 'November', 'December']

inoremap <expr> <f5> JobStart()
```

Second issue:

1. vim --clean -S reproduce2.vim
2. Enter insert mode and press `<f5>` and shortly after a `<space>`
3. `<space>` is inserted a few seconds after complete menu is displayed

Expected behavior:
Space should be inserted immediately after complete menu is opened.

```
" reproduce2.vim
setl completeopt-=longest
setl completeopt+=menu,menuone,noinsert,noselect
set guicursor=a:blinkon0

function! OutCb(chan, msg)
endfunction

function! ExitCb(job, status)
  let elapsed = reltimestr(reltime(s:starttime))
  call substitute(repeat('a', 1000000), '.', '', 'g')
  echom printf('EXIT: %s', elapsed)
  call complete(col('.'), g:suggestions)
endfunction

function! JobStart(...)
  let s:starttime = reltime()
  let s:job = job_start('cmd /c help', {'out_cb': 'OutCb', 'exit_cb': 'ExitCb'})
  return ''
endfunction

let suggestions =  ['January', 'February', 'March',
      \ 'April', 'May', 'June', 'July', 'August', 'September',
      \ 'October', 'November', 'December']

inoremap <expr> <f5> JobStart()
```