### PR TITLE
MSWIN: recognize code page 65001 as utf-8

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4470,6 +4470,8 @@ enc_locale(void)
 	STRCPY(buf, "ucs-2le");
     else if (acp == 1252)	    /* cp1252 is used as latin1 */
 	STRCPY(buf, "latin1");
+    else if (acp == 65001)
+	STRCPY(buf, "utf-8");
     else
 	sprintf(buf, "cp%ld", acp);
 


### PR DESCRIPTION
I'm building for a smaller, nanoserver-like SKU, which has a default
console code page of 65001. Previous to this change, vim would not
recognize this code page, resulting in failure to set a proper codepage
(which further resulted in chaos).