### PR TITLE
Add function `getimstatus()`.

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2468,6 +2468,7 @@ getfperm({fname})		String	file permissions of file {fname}
 getfsize({fname})		Number	size in bytes of file {fname}
 getftime({fname})		Number	last modification time of file
 getftype({fname})		String	description of type of file {fname}
+getimstatus()			Number	|TRUE| if the IME status is active
 getjumplist([{winnr} [, {tabnr}]])
 				List	list of jump list items
 getline({lnum})			String	line {lnum} of current buffer
@@ -5201,6 +5202,11 @@ getftype({fname})					*getftype()*
 
 		Can also be used as a |method|: >
 			GetFilename()->getftype()
+
+getimstatus()						*getimstatus()*
+		The result is a Number, which is |TRUE| when the IME status is
+		active.
+		See 'imstatusfunc'.
 
 getjumplist([{winnr} [, {tabnr}]])			*getjumplist()*
 		Returns the |jumplist| for the specified window.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -110,6 +110,7 @@ static void f_getcharsearch(typval_T *argvars, typval_T *rettv);
 static void f_getcmdwintype(typval_T *argvars, typval_T *rettv);
 static void f_getenv(typval_T *argvars, typval_T *rettv);
 static void f_getfontname(typval_T *argvars, typval_T *rettv);
+static void f_getimstatus(typval_T *argvars, typval_T *rettv);
 static void f_getjumplist(typval_T *argvars, typval_T *rettv);
 static void f_getline(typval_T *argvars, typval_T *rettv);
 static void f_getpid(typval_T *argvars, typval_T *rettv);
@@ -507,6 +508,7 @@ static funcentry_T global_functions[] =
     {"getfsize",	1, 1, FEARG_1,	  f_getfsize},
     {"getftime",	1, 1, FEARG_1,	  f_getftime},
     {"getftype",	1, 1, FEARG_1,	  f_getftype},
+    {"getimstatus",	0, 0, 0,	  f_getimstatus},
     {"getjumplist",	0, 2, FEARG_1,	  f_getjumplist},
     {"getline",		1, 2, FEARG_1,	  f_getline},
     {"getloclist",	1, 2, 0,	  f_getloclist},
@@ -3789,6 +3791,15 @@ f_getfontname(typval_T *argvars UNUSED, typval_T *rettv)
 	    gui_mch_free_font(font);
     }
 #endif
+}
+
+/*
+ * "getimstatus()" function
+ */
+    static void
+f_getimstatus(typval_T *argvars UNUSED, typval_T *rettv)
+{
+    rettv->vval.v_number = im_get_status();
 }
 
 /*

--- a/src/testdir/test_iminsert.vim
+++ b/src/testdir/test_iminsert.vim
@@ -2,17 +2,22 @@ source view_util.vim
 
 let s:imactivatefunc_called = 0
 let s:imstatusfunc_called = 0
+let s:imstatus_active = 0
 
 func IM_activatefunc(active)
   let s:imactivatefunc_called = 1
+let s:imstatus_active = a:active
 endfunc
 
 func IM_statusfunc()
   let s:imstatusfunc_called = 1
-  return 0
+  return s:imstatus_active
 endfunc
 
 func Test_iminsert2()
+  let s:imactivatefunc_called = 0
+  let s:imstatusfunc_called = 0
+
   set imactivatefunc=IM_activatefunc
   set imstatusfunc=IM_statusfunc
   set iminsert=2
@@ -24,4 +29,27 @@ func Test_iminsert2()
   let expected = has('gui_running') ? 0 : 1
   call assert_equal(expected, s:imactivatefunc_called)
   call assert_equal(expected, s:imstatusfunc_called)
+endfunc
+
+func Test_imgetstatus()
+  if has('gui_running')
+    set imactivatefunc=
+    set imstatusfunc=
+  else
+    set imactivatefunc=IM_activatefunc
+    set imstatusfunc=IM_statusfunc
+    let s:imstatus_active = 0
+  endif
+
+  new
+  set iminsert=2
+  call feedkeys("i\<C-R>=getimstatus()\<CR>\<ESC>", 'nx')
+  call assert_equal('1', getline(1))
+  set iminsert=0
+  call feedkeys("o\<C-R>=getimstatus()\<CR>\<ESC>", 'nx')
+  call assert_equal('0', getline(2))
+  bw!
+
+  set imactivatefunc=
+  set imstatusfunc=
 endfunc

--- a/src/testdir/test_iminsert.vim
+++ b/src/testdir/test_iminsert.vim
@@ -33,6 +33,9 @@ endfunc
 
 func Test_imgetstatus()
   if has('gui_running')
+    if !has('win32')
+      throw 'Skipped: running in the GUI, only works on MS-Windows'
+    endif
     set imactivatefunc=
     set imstatusfunc=
   else


### PR DESCRIPTION
Add a function to get the IME status.

Plugins that divide control according to the IME status can be developed.
For example: input completion plugin may break by IME.

On Windows, it is difficult to get the IME status by external program.
So it had to be implemented in vim.