### PR TITLE
Fixed build failure

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -479,7 +479,9 @@ ui_wait_for_chars_or_timer(
 	    // There is a pending job or channel, should return soon in order
 	    // to handle them ASAP.  Do check for input briefly.
 	    due_time = 10L;
+# ifdef FEAT_JOB_CHANNEL
 	    brief_wait = TRUE;
+# endif
 	}
 # endif
 	if (wait_func(due_time, interrupted, ignore_input))


### PR DESCRIPTION
This PR fixes a build failure in vim-8.1.2003 with the following configuration:
```
$ cd vim/src
$ ./configure --with-features=huge --enable-gui=none --disable-channel
$ make -j8
...snip...
gcc -c -I. -Iproto -DHAVE_CONFIG_H     -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/ui.o ui.c
ui.c: In function ‘ui_wait_for_chars_or_timer’:
ui.c:482:6: error: ‘brief_wait’ undeclared (first use in this function); did you mean ‘buf_write’?
      brief_wait = TRUE;
      ^~~~~~~~~~
      buf_write
ui.c:482:6: note: each undeclared identifier is reported only once for each function it appears in
```