### PR TITLE
MS-Windows: external commands cannot be executed if &shell contains a space

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -126,7 +126,26 @@ set_init_1(int clean_arg)
 	    || ((p = (char_u *)default_shell()) != NULL && *p != NUL)
 #endif
 	    )
+#if defined(MSWIN)
+    {
+	/* For MS-Windows, Quoting path instead of escape spaces. */
+	char_u	    *cmd;
+	size_t	    len;
+
+	if (vim_strchr(p, ' ') != NULL)
+	{
+	    len = STRLEN(p) + 3;  /* two quotes and a trailing NUL */
+	    cmd = alloc(len);
+	    vim_snprintf((char *)cmd, len, "\"%s\"", p);
+	    set_string_default("sh", cmd);
+	    vim_free(cmd);
+	}
+	else
+	    set_string_default("sh", p);
+    }
+#else
 	set_string_default_esc("sh", p, TRUE);
+#endif
 
 #ifdef FEAT_WILDIGN
     /*

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4489,8 +4489,25 @@ mch_system_c(char *cmd, int options)
 {
     int		ret;
     WCHAR	*wcmd;
+    char_u	*buf;
+    size_t	len;
 
-    wcmd = enc_to_utf16((char_u *)cmd, NULL);
+    /* If the command starts and ends with double quotes,
+     * Enclose the command in parentheses. */
+    len = STRLEN(cmd);
+    if (len >= 2 && cmd[0] == '"' && cmd[len - 1] == '"')
+    {
+	len += 3;
+	buf = alloc(len);
+	if (buf == NULL)
+	    return -1;
+	vim_snprintf((char *)buf, len, "(%s)", cmd);
+	wcmd = enc_to_utf16(buf, NULL);
+	free(buf);
+    }
+    else
+	wcmd = enc_to_utf16((char_u *)cmd, NULL);
+
     if (wcmd == NULL)
 	return -1;
 

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -574,11 +574,17 @@ func Test_set_shell()
     quit!
   [CODE]
 
-  let $SHELL = '/bin/with space/sh'
+  if has('win32')
+    let $SHELL = 'C:\with space\cmd.exe'
+    let expected = '"C:\with space\cmd.exe"'
+  else
+    let $SHELL = '/bin/with space/sh'
+    let expected = '/bin/with\ space/sh'
+  endif
+
   if RunVimPiped([], after, '', '')
     let lines = readfile('Xtestout')
-    " MS-Windows adds a space after the word
-    call assert_equal('/bin/with\ space/sh', lines[0])
+    call assert_equal(expected, lines[0])
   endif
   call delete('Xtestout')
 endfunc

--- a/src/vimrun.c
+++ b/src/vimrun.c
@@ -27,6 +27,8 @@
 main(void)
 {
     const wchar_t   *p;
+    wchar_t	    *cmd;
+    size_t	    cmdlen;
     int		    retval;
     int		    inquote = 0;
     int		    silent = 0;
@@ -68,10 +70,30 @@ main(void)
     WriteConsoleW(hstdout, p, wcslen(p), &written, NULL);
     WriteConsoleW(hstdout, L"\r\n", 2, &written, NULL);
 
+    /* If the command starts and ends with double quotes,
+     * Enclose the command in parentheses. */
+    cmd = NULL;
+    cmdlen = wcslen(p);
+    if (cmdlen >= 2 && p[0] == L'"' && p[cmdlen - 1] == L'"')
+    {
+	cmdlen += 3;
+	cmd = (wchar_t *)malloc(cmdlen * sizeof(wchar_t));
+	if (cmd == NULL)
+	{
+	    perror("vimrun malloc(): ");
+	    return -1;
+	}
+	_snwprintf(cmd, cmdlen, L"(%s)", p);
+	p = cmd;
+    }
+
     /*
      * Do it!
      */
     retval = _wsystem(p);
+
+    if (cmd)
+	free(cmd);
 
     if (retval == -1)
 	perror("vimrun system(): ");


### PR DESCRIPTION
## `&shell` is incorrect escaped in init

On Windows, Use double-quoting instead escape spaces with backslash.

Ex. Using [Git bash](https://gitforwindows.org) installed in path that contains a space.

in bash.exe:
```sh
$ cmd.exe /c "echo %SHELL%"
C:\Program Files\Git\usr\bin\bash.exe
$ /path/to/ms-win-vim/gvim.exe -u NONE -U NONE
```

in gvim.exe:
```vim
:echo &shell
C:\Program\ Files\Git\usr\bin\bash.exe
          ^ Incorrect backslash here
```

## Enclose the command in parentheses, when `_wsystem()`

If `&shell` is double-quoted, `_wsystem()` call will fail.

`:!echo ok` is converted to `"C:\Program Files\Git\usr\bin\bash.exe" -c "echo ok"` and execute,
but cmd.exe (called internally by `_wsystem()`) deletes double quotes at first and last,
resulting `C:\Program Files\Git\usr\bin\bash.exe" -c "echo ok` and fails.

```
:!echo ok
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```

To resolve, enclose the command in parentheses,
like `("C:\Program Files\Git\usr\bin\bash.exe" -c "echo ok")`.