### PR TITLE
MS-Windows: Improve test running

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1282,6 +1282,14 @@ MAIN_TARGET = $(VIM).exe
 # Target to run individual tests.
 VIMTESTTARGET = $(VIM).exe
 
+OLD_TEST_OUTFILES = \
+	$(SCRIPTS_FIRST) \
+	$(SCRIPTS_ALL) \
+	$(SCRIPTS_MORE1) \
+	$(SCRIPTS_MORE4) \
+	$(SCRIPTS_WIN32) \
+	$(SCRIPTS_GUI)
+
 all:	$(MAIN_TARGET) \
 	vimrun.exe \
 	install.exe \
@@ -1424,6 +1432,18 @@ testclean:
 	$(MAKE) /NOLOGO -f Make_dos.mak clean
 	cd ..
 
+# Run individual OLD style test.
+# These do not depend on the executable, compile it when needed.
+$(OLD_TEST_OUTFILES:.out=):
+	cd testdir
+	- if exist $@.out del $@.out
+	$(MAKE) /NOLOGO -f Make_dos.mak VIMPROG=..\$(VIMTESTTARGET) nolog
+	$(MAKE) /NOLOGO -f Make_dos.mak VIMPROG=..\$(VIMTESTTARGET) $@.out
+	@ if exist test.log ( type test.log & exit /b 1 )
+	cd ..
+
+# Run individual NEW style test.
+# These do not depend on the executable, compile it when needed.
 $(NEW_TESTS):
 	cd testdir
 	- if exist $@.res del $@.res

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1279,6 +1279,9 @@ MAIN_TARGET = $(GVIM).exe $(VIM).exe $(VIMDLLBASE).dll
 MAIN_TARGET = $(VIM).exe
 !endif
 
+# Target to run individual tests.
+VIMTESTTARGET = $(VIM).exe
+
 all:	$(MAIN_TARGET) \
 	vimrun.exe \
 	install.exe \
@@ -1424,9 +1427,9 @@ testclean:
 $(NEW_TESTS):
 	cd testdir
 	- if exist $@.res del $@.res
-	$(MAKE) /NOLOGO -f Make_dos.mak nolog
-	$(MAKE) /NOLOGO -f Make_dos.mak $@.res
-	$(MAKE) /NOLOGO -f Make_dos.mak report
+	$(MAKE) /NOLOGO -f Make_dos.mak VIMPROG=..\$(VIMTESTTARGET) nolog
+	$(MAKE) /NOLOGO -f Make_dos.mak VIMPROG=..\$(VIMTESTTARGET) $@.res
+	$(MAKE) /NOLOGO -f Make_dos.mak VIMPROG=..\$(VIMTESTTARGET) report
 	cd ..
 
 ###########################################################################

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1370,7 +1370,7 @@ tags: notags
 notags:
 	- if exist tags del tags
 
-clean:
+clean: testclean
 	- if exist $(OUTDIR)/nul $(DEL_TREE) $(OUTDIR)
 	- if exist *.obj del *.obj
 	- if exist $(VIM).exe del $(VIM).exe
@@ -1405,7 +1405,6 @@ clean:
 	cd GvimExt
 	$(MAKE) /NOLOGO -f Makefile clean
 	cd ..
-	- if exist testdir\*.out del testdir\*.out
 
 test:
 	cd testdir
@@ -1428,7 +1427,6 @@ $(NEW_TESTS):
 	$(MAKE) /NOLOGO -f Make_dos.mak nolog
 	$(MAKE) /NOLOGO -f Make_dos.mak $@.res
 	$(MAKE) /NOLOGO -f Make_dos.mak report
-	type messages
 	cd ..
 
 ###########################################################################

--- a/src/testdir/Make_dos.mak
+++ b/src/testdir/Make_dos.mak
@@ -70,7 +70,7 @@ $(SCRIPTS) $(SCRIPTS_GUI) $(SCRIPTS_WIN32) $(NEW_TESTS_RES): $(SCRIPTS_FIRST)
 
 report:
 	@rem without the +eval feature test_result.log is a copy of test.log
-	@if exist test.log ( copy test.log test_result.log ) \
+	@if exist test.log ( copy /y test.log test_result.log > nul ) \
 		else ( echo No failures reported > test_result.log )
 	$(VIMPROG) -u NONE $(NO_INITS) -S summarize.vim messages
 	@echo.

--- a/src/testdir/Make_dos.mak
+++ b/src/testdir/Make_dos.mak
@@ -69,9 +69,14 @@ $(TEST_OUTFILES): $(DOSTMP)\$(*B).in
 $(SCRIPTS) $(SCRIPTS_GUI) $(SCRIPTS_WIN32) $(NEW_TESTS_RES): $(SCRIPTS_FIRST)
 
 report:
-	@echo ""
+	@rem without the +eval feature test_result.log is a copy of test.log
+	@if exist test.log ( copy test.log test_result.log ) \
+		else ( echo No failures reported > test_result.log )
+	$(VIMPROG) -u NONE $(NO_INITS) -S summarize.vim messages
+	@echo.
 	@echo Test results:
-	@if exist test.log ( type test.log & echo TEST FAILURE & exit /b 1 ) \
+	@type test_result.log
+	@if exist test.log ( echo TEST FAILURE & exit /b 1 ) \
 		else ( echo ALL DONE )
 
 clean:
@@ -92,12 +97,14 @@ clean:
 	-for /d %i in (X*) do @rmdir /s/q %i
 	-if exist viminfo del viminfo
 	-if exist test.log del test.log
+	-if exist test_result.log del test_result.log
 	-if exist messages del messages
 	-if exist benchmark.out del benchmark.out
 	-if exist opt_test.vim del opt_test.vim
 
 nolog:
 	-if exist test.log del test.log
+	-if exist test_result.log del test_result.log
 	-if exist messages del messages
 
 benchmark:


### PR DESCRIPTION
On Unix, The makefiles of tests have been improved in the past.
But MS-Windows are not the same.

* <del>Avoid swap exists attention prompt.</del>
* Show summary of result.
* Easily to call individual test in *src/Make_mvc.mak*.