### PR TITLE
MS-Windows: Fix tests related cmd.exe

### DIFF
--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -408,8 +408,7 @@ func Test_normal10_expand()
 
   if executable('echo')
     " Test expand(`...`) i.e. backticks command expansion.
-    " MS-Windows has a trailing space.
-    call assert_match('^abcde *$', expand('`echo abcde`'))
+    call assert_equal('abcde', expand('`echo abcde`'))
   endif
 
   " Test expand(`=...`) i.e. backticks expression expansion

--- a/src/testdir/test_system.vim
+++ b/src/testdir/test_system.vim
@@ -18,44 +18,24 @@ func Test_System()
     call assert_equal(["as\r", "df\r"], systemlist('more', ["as\<NL>df"]))
   endif
 
-  if !executable('cat') || !executable('wc')
-    return
-  endif
-
-  let out = 'echo 123'->system()
-  " On Windows we may get a trailing space.
-  if out != "123 \n"
-    call assert_equal("123\n", out)
-  endif
-
-  let out = 'echo 123'->systemlist()
-  if !has('win32')
-    call assert_equal(["123"], out)
-  else
-    call assert_equal(["123\r"], out)
-  endif
-
-  if executable('cat')
-    call assert_equal('123',   system('cat', '123'))	
-    call assert_equal(['123'], systemlist('cat', '123'))	
-    call assert_equal(["as\<NL>df"], systemlist('cat', ["as\<NL>df"])) 
-  endif
-
   new Xdummy
   call setline(1, ['asdf', "pw\<NL>er", 'xxxx'])
-  let out = system('wc -l', bufnr('%'))
-  " On OS/X we get leading spaces
-  let out = substitute(out, '^ *', '', '')
-  call assert_equal("3\n", out)
 
-  let out = systemlist('wc -l', bufnr('%'))
-  " On Windows we may get a trailing CR.
-  if out != ["3\r"]
+  if executable('wc')
+    let out = system('wc -l', bufnr('%'))
     " On OS/X we get leading spaces
-    if type(out) == v:t_list
-      let out[0] = substitute(out[0], '^ *', '', '')
+    let out = substitute(out, '^ *', '', '')
+    call assert_equal("3\n", out)
+
+    let out = systemlist('wc -l', bufnr('%'))
+    " On Windows we may get a trailing CR.
+    if out != ["3\r"]
+      " On OS/X we get leading spaces
+      if type(out) == v:t_list
+        let out[0] = substitute(out[0], '^ *', '', '')
+      endif
+      call assert_equal(['3'],  out)
     endif
-    call assert_equal(['3'],  out)
   endif
 
   if !has('win32')

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -546,11 +546,14 @@ func Test_terminal_finish_open_close()
 endfunc
 
 func Test_terminal_cwd()
-  if !executable('pwd')
-    return
+  if has('win32')
+    let cmd = 'cmd /c cd'
+  else
+    CheckExecutable pwd
+    let cmd = 'pwd'
   endif
   call mkdir('Xdir')
-  let buf = term_start('pwd', {'cwd': 'Xdir'})
+  let buf = term_start(cmd, {'cwd': 'Xdir'})
   call WaitForAssert({-> assert_equal('Xdir', fnamemodify(getline(1), ":t"))})
 
   exe buf . 'bwipe'
@@ -1947,7 +1950,13 @@ func Test_terminal_does_not_truncate_last_newlines()
 endfunc
 
 func Test_terminal_no_job()
-  let term = term_start('false', {'term_finish': 'close'})
+  if has('win32')
+    let cmd = 'cmd /c ""'
+  else
+    CheckExecutable false
+    let cmd = 'false'
+  endif
+  let term = term_start(cmd, {'term_finish': 'close'})
   call WaitForAssert({-> assert_equal(v:null, term_getjob(term)) })
 endfunc
 

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -458,7 +458,7 @@ funct Test_undofile()
   " Test undofile() with 'undodir' set to a non-existing directory.
   call assert_equal('', 'Xundofoo'->undofile())
 
-  if isdirectory('/tmp')
+  if !has('win32') && isdirectory('/tmp')
     set undodir=/tmp
     if has('osx')
       call assert_equal('/tmp/%private%tmp%file', undofile('///tmp/file'))


### PR DESCRIPTION
Improved test coverage on Windows.

* Change external commands on Windows.
* Fixed: If exists *C:\tmp*, `isdirectory('/tmp')` returns 1 and get error.
* <ins>Remove duplicate tests (that added at 1a61339).</ins>