### PR TITLE
Add support for dark GTK theme variant in GVim

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3740,6 +3740,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 								*'go-c'*
 	  'c'	Use console dialogs instead of popup dialogs for simple
 		choices.
+								*'go-d'*
+	  'd'	Use dark theme variant if available. Currently only works for
+		GTK+ GUI.
 								*'go-e'*
 	  'e'	Add tab pages when indicated with 'showtabline'.
 		'guitablabel' can be used to change the text in the labels.

--- a/src/feature.h
+++ b/src/feature.h
@@ -647,6 +647,13 @@
 #endif
 
 /*
+ * GUI dark theme variant
+ */
+#if defined(FEAT_GUI_GTK) && defined(USE_GTK3)
+# define FEAT_GUI_DARKTHEME
+#endif
+
+/*
  * GUI tabline
  */
 #if defined(FEAT_NORMAL) \

--- a/src/gui.c
+++ b/src/gui.c
@@ -3425,6 +3425,10 @@ static int	prev_which_scrollbars[3];
     void
 gui_init_which_components(char_u *oldval UNUSED)
 {
+#ifdef FEAT_GUI_DARKTHEME
+    static int	prev_dark_theme = -1;
+    int		using_dark_theme = FALSE;
+#endif
 #ifdef FEAT_MENU
     static int	prev_menu_is_active = -1;
 #endif
@@ -3495,6 +3499,11 @@ gui_init_which_components(char_u *oldval UNUSED)
 	    case GO_BOT:
 		gui.which_scrollbars[SBAR_BOTTOM] = TRUE;
 		break;
+#ifdef FEAT_GUI_DARKTHEME
+	    case GO_DARKTHEME:
+		using_dark_theme = TRUE;
+		break;
+#endif
 #ifdef FEAT_MENU
 	    case GO_MENUS:
 		gui.menu_is_active = TRUE;
@@ -3527,6 +3536,14 @@ gui_init_which_components(char_u *oldval UNUSED)
     {
 	need_set_size = 0;
 	fix_size = FALSE;
+
+#ifdef FEAT_GUI_DARKTHEME
+	if (using_dark_theme != prev_dark_theme)
+	{
+	    gui_mch_set_dark_theme(using_dark_theme);
+	    prev_dark_theme = using_dark_theme;
+	}
+#endif
 
 #ifdef FEAT_GUI_TABLINE
 	/* Update the GUI tab line, it may appear or disappear.  This may

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3130,6 +3130,19 @@ update_window_manager_hints(int force_width, int force_height)
     }
 }
 
+#if defined(FEAT_GUI_DARKTHEME) || defined(PROTO)
+    void
+gui_mch_set_dark_theme(int dark)
+{
+# if GTK_CHECK_VERSION(3,0,0)
+    GtkSettings *gtk_settings;
+
+    gtk_settings = gtk_settings_get_for_screen(gdk_screen_get_default());
+    g_object_set(gtk_settings, "gtk-application-prefer-dark-theme", (gboolean)dark, NULL);
+# endif
+}
+#endif /* FEAT_GUI_DARKTHEME */
+
 #ifdef FEAT_TOOLBAR
 
 /*

--- a/src/option.h
+++ b/src/option.h
@@ -213,6 +213,7 @@
 #define GO_ASELML	'A'		// autoselect modeless selection
 #define GO_BOT		'b'		// use bottom scrollbar
 #define GO_CONDIALOG	'c'		// use console dialog
+#define GO_DARKTHEME	'd'		// use dark theme variant
 #define GO_TABLINE	'e'		// may show tabline
 #define GO_FORG		'f'		// start GUI in foreground
 #define GO_GREY		'g'		// use grey menu items
@@ -231,7 +232,7 @@
 #define GO_FOOTER	'F'		// add footer
 #define GO_VERTICAL	'v'		// arrange dialog buttons vertically
 #define GO_KEEPWINSIZE	'k'		// keep GUI window size
-#define GO_ALL		"!aAbcefFghilmMprtTvk" // all possible flags for 'go'
+#define GO_ALL		"!aAbcdefFghilmMprtTvk" // all possible flags for 'go'
 
 // flags for 'comments' option
 #define COM_NEST	'n'		// comments strings nest

--- a/src/proto/gui_gtk_x11.pro
+++ b/src/proto/gui_gtk_x11.pro
@@ -8,6 +8,7 @@ void gui_mch_stop_blink(int may_call_gui_update_cursor);
 void gui_mch_start_blink(void);
 int gui_mch_early_init_check(int give_message);
 int gui_mch_init_check(void);
+void gui_mch_set_dark_theme(int dark);
 void gui_mch_show_tabline(int showit);
 int gui_mch_showing_tabline(void);
 void gui_mch_update_tabline(void);

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -643,6 +643,15 @@ func Test_set_guioptions()
       call assert_equal('aegi', &guioptions)
     endif
 
+    if has('gui_gtk3')
+      set guioptions+=d
+      exec 'sleep' . duration
+      call assert_equal('aegid', &guioptions)
+      set guioptions-=d
+      exec 'sleep' . duration
+      call assert_equal('aegi', &guioptions)
+    endif
+
     " Restore GUI ornaments to the default state.
     set guioptions+=m
     exec 'sleep' . duration


### PR DESCRIPTION
GTK+ 3 supports light and dark themes for widgets, see https://developer.gnome.org/gtk3/3.2/GtkSettings.html#GtkSettings--gtk-application-prefer-dark-theme

This code applies a dark theme to GVim on startup, if the user's colour scheme is also dark. Ideally this would be updated dynamically, but the static approach is a lot more self-contained, and I don't imagine that users change their colour scheme very often.