### PR TITLE
test_compiler: Match any line number for perl's clist output

### DIFF
--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -28,8 +28,8 @@ func Test_compiler()
   w!
   call feedkeys(":make\<CR>\<CR>", 'tx')
   let a=execute('clist')
-  call assert_match("\n 1 Xfoo.pl:3: Global symbol \"\$foo\" "
-  \ .               "requires explicit package name", a)
+  call assert_match('\n \d\+ Xfoo.pl:3: Global symbol "$foo" '
+  \ .               'requires explicit package name', a)
 
   let &shellslash = save_shellslash
   call delete('Xfoo.pl')


### PR DESCRIPTION
In certain circumstanes (e.g., `$LANG` doesn't match an installed locale), the expected line could be on a line other than line 1.