### PR TITLE
[WIP/RFC] Fix yaml indent: look at previous mapping keys

### DIFF
--- a/runtime/indent/testdir/yaml.in
+++ b/runtime/indent/testdir/yaml.in
@@ -1,4 +1,4 @@
-# vim: set ft=yaml sw=2 :
+# vim: set ft=yaml sw=2 et :
 
 # START_INDENT
 map1:
@@ -6,4 +6,9 @@ map1:
     - list item
 map2:
   - another list
+# END_INDENT
+
+# START_INDENT
+map: &anchor
+  map: val
 # END_INDENT

--- a/runtime/indent/testdir/yaml.in
+++ b/runtime/indent/testdir/yaml.in
@@ -1,0 +1,9 @@
+# vim: set ft=yaml sw=2 :
+
+# START_INDENT
+map1:
+  sub1:
+    - list item
+map2:
+  - another list
+# END_INDENT

--- a/runtime/indent/testdir/yaml.ok
+++ b/runtime/indent/testdir/yaml.ok
@@ -1,4 +1,4 @@
-# vim: set ft=yaml sw=2 :
+# vim: set ft=yaml sw=2 et :
 
 # START_INDENT
 map1:
@@ -6,4 +6,9 @@ map1:
     - list item
 map2:
   - another list
+# END_INDENT
+
+# START_INDENT
+map: &anchor
+  map: val
 # END_INDENT

--- a/runtime/indent/testdir/yaml.ok
+++ b/runtime/indent/testdir/yaml.ok
@@ -1,0 +1,9 @@
+# vim: set ft=yaml sw=2 :
+
+# START_INDENT
+map1:
+  sub1:
+    - list item
+map2:
+  - another list
+# END_INDENT

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -29,7 +29,7 @@ function s:FindPrevLessIndentedLine(lnum, ...)
     let curindent = a:0 ? a:1 : indent(a:lnum)
     while           prevlnum
                 \&&  indent(prevlnum) >=  curindent
-                \&& getline(prevlnum) =~# '^\s*#'
+                \&& getline(prevlnum) !~# '^\s*#'
         let prevlnum = prevnonblank(prevlnum-1)
     endwhile
     return prevlnum
@@ -132,25 +132,10 @@ function GetYAMLIndent(lnum)
         " Same for line containing mapping key
         let prevmapline = s:FindPrevLEIndentedLineMatchingRegex(a:lnum,
                     \                                           s:mapkeyregex)
-        " Look for any previous mapping with the same indent.
-        " (https://github.com/neovim/neovim/issues/11039).
-        let cur_indent = indent(a:lnum)
-        while 1
-          let prev_indent = indent(prevmapline)
-          if prev_indent <= cur_indent
-            break
-          endif
-          let abovemapline = s:FindPrevLEIndentedLineMatchingRegex(prevmapline,
-                    \                                              s:mapkeyregex)
-          if !abovemapline
-            break
-          endif
-          let prevmapline = abovemapline
-        endwhile
         if getline(prevmapline) =~# '^\s*- '
-            return prev_indent + 2
+            return indent(prevmapline) + 2
         else
-            return prev_indent
+            return indent(prevmapline)
         endif
     elseif prevline =~# '^\s*- '
         " - List with

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -132,10 +132,25 @@ function GetYAMLIndent(lnum)
         " Same for line containing mapping key
         let prevmapline = s:FindPrevLEIndentedLineMatchingRegex(a:lnum,
                     \                                           s:mapkeyregex)
+        " Look for any previous mapping with the same indent.
+        " (https://github.com/neovim/neovim/issues/11039).
+        let cur_indent = indent(a:lnum)
+        while 1
+          let prev_indent = indent(prevmapline)
+          if prev_indent <= cur_indent
+            break
+          endif
+          let abovemapline = s:FindPrevLEIndentedLineMatchingRegex(prevmapline,
+                    \                                              s:mapkeyregex)
+          if !abovemapline
+            break
+          endif
+          let prevmapline = abovemapline
+        endwhile
         if getline(prevmapline) =~# '^\s*- '
-            return indent(prevmapline) + 2
+            return prev_indent + 2
         else
-            return indent(prevmapline)
+            return prev_indent
         endif
     elseif prevline =~# '^\s*- '
         " - List with


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/11039.

Not tested much, but added an indent test for it already.

As per https://github.com/neovim/neovim/issues/11039#issuecomment-532131153 the file is not maintained currently externally, due to inactivity of @ZyX-I.