### PR TITLE
Add g:json_no_conceal to disable conceal for json filetype

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1923,6 +1923,18 @@ displayed line.  The default value is 10.  The disadvantage of using a larger
 number is that redrawing can become slow.
 
 
+JSON						*json.vim* *ft-json-syntax*
+
+The json syntax file provides syntax highlighting with conceal support by
+default. To disable concealment: >
+
+	let g:vim_json_conceal = 0
+
+To disable syntax highlighting of errors: >
+
+	let g:vim_json_warnings = 0
+
+
 LACE						*lace.vim* *ft-lace-syntax*
 
 Lace (Language for Assembly of Classes in Eiffel) is case insensitive, but the

--- a/runtime/syntax/json.vim
+++ b/runtime/syntax/json.vim
@@ -20,7 +20,7 @@ syntax match   jsonNoise           /\%(:\|,\)/
 " Syntax: JSON Keywords
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
-if has('conceal') && (!exists('g:json_no_conceal') || g:json_no_conceal == 0)
+if has('conceal') && (!exists("g:vim_json_conceal") || g:vim_json_conceal==1)
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contained
 else
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contained
@@ -31,7 +31,7 @@ endif
 " Needs to come after keywords or else a json encoded string will break the
 " syntax
 syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
-if has('conceal') && (!exists('g:json_no_conceal') || g:json_no_conceal == 0)
+if has('conceal') && (!exists("g:vim_json_conceal") || g:vim_json_conceal==1)
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
 else
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=jsonEscape contained

--- a/runtime/syntax/json.vim
+++ b/runtime/syntax/json.vim
@@ -20,7 +20,7 @@ syntax match   jsonNoise           /\%(:\|,\)/
 " Syntax: JSON Keywords
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
-if has('conceal')
+if has('conceal') && (!exists('g:json_no_conceal') || g:json_no_conceal == 0)
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contained
 else
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contained
@@ -31,7 +31,7 @@ endif
 " Needs to come after keywords or else a json encoded string will break the
 " syntax
 syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
-if has('conceal')
+if has('conceal') && (!exists('g:json_no_conceal') || g:json_no_conceal == 0)
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
 else
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=jsonEscape contained


### PR DESCRIPTION
This PR is about vim syntax file, json.vim
I opened this PR because the maintainer's email is not on json.vim.
Currently json syntax file is [unmaintained](https://groups.google.com/d/msg/vim_dev/HU4t34WYauU/UPPkKFZaAgAJ).
This PR is not about the syntax, but syntax file's option. So please merge.

Vim's conceal feature is used at many places and I want a option to disable json's conceal.
For example, I use vim plugin indentLine(https://github.com/Yggdroot/indentLine). This plugin uses conceal feature to display indent.
I can't disable json.vim's conceal while using indentLine's conceal with conceallevel.