### PR TITLE
RFC: func_dump_profile: use fname:lnum

### DIFF
--- a/src/profiler.c
+++ b/src/profiler.c
@@ -696,7 +696,7 @@ func_dump_profile(FILE *fd)
 				     get_scriptname(fp->uf_script_ctx.sc_sid));
 		    if (p != NULL)
 		    {
-			fprintf(fd, "    Defined: %s line %ld\n",
+			fprintf(fd, "    Defined: %s:%ld\n",
 					   p, (long)fp->uf_script_ctx.sc_lnum);
 			vim_free(p);
 		    }

--- a/src/testdir/test_profile.vim
+++ b/src/testdir/test_profile.vim
@@ -55,7 +55,7 @@ func Test_profile_func()
   call assert_equal(30, len(lines))
 
   call assert_equal('FUNCTION  Foo1()',                            lines[0])
-  call assert_match('Defined:.*Xprofile_func.vim',                 lines[1])
+  call assert_match('Defined:.*Xprofile_func.vim:3',               lines[1])
   call assert_equal('Called 2 times',                              lines[2])
   call assert_match('^Total time:\s\+\d\+\.\d\+$',                 lines[3])
   call assert_match('^ Self time:\s\+\d\+\.\d\+$',                 lines[4])


### PR DESCRIPTION
This allows to use `gf` on it directly.