### PR TITLE
Correctly handle precedes char in list mode for long lines

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4842,9 +4842,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			off and the line continues beyond the right of the
 			screen.
 							*lcs-precedes*
-	  precedes:c	Character to show in the first column, when 'wrap'
-			is off and there is text preceding the character
-			visible in the first column.
+	  precedes:c	Character to show in the first visible column of the
+			physical line, when there is text preceding the
+			character visible in the first column.
 							*lcs-conceal*
 	  conceal:c	Character to show in place of concealed text, when
 			'conceallevel' is set to 1.

--- a/src/screen.c
+++ b/src/screen.c
@@ -5443,7 +5443,9 @@ win_line(
 	 */
 	if (lcs_prec_todo != NUL
 		&& wp->w_p_list
-		&& (wp->w_p_wrap ? wp->w_skipcol > 0 : wp->w_leftcol > 0)
+		&& (wp->w_p_wrap ?
+		    (wp->w_skipcol > 0  && row == 0) :
+		    wp->w_leftcol > 0)
 #ifdef FEAT_DIFF
 		&& filler_todo <= 0
 #endif

--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -103,3 +103,58 @@ func Test_scroll_without_region()
   call StopVimInTerminal(buf)
   call delete('Xtestscroll')
 endfunc
+
+func Test_display_listchars_precedes()
+  call NewWindow(10, 10)
+  " Need a physical line that wraps over the complete
+  " window size
+  call append(0, repeat('aaa aaa aa ', 10))
+  call append(1, repeat(['bbb bbb bbb bbb'], 2))
+  " remove blank trailing line
+  $d
+  set list nowrap
+  call cursor(1, 1)
+  " move to end of line and scroll 2 characters back
+  norm! $2zh
+  let lines=ScreenLines([1,4], winwidth(0)+1)
+  let expect=[
+        \ " aaa aa $ |",
+        \ "$         |",
+        \ "$         |",
+        \ "~         |",
+        \ ]
+  call assert_equal(expect, lines)
+  set list listchars+=precedes:< nowrap
+  call cursor(1, 1)
+  " move to end of line and scroll 2 characters back
+  norm! $2zh
+  let lines=ScreenLines([1,4], winwidth(0)+1)
+  let expect=[
+        \ "<aaa aa $ |",
+        \ "<         |",
+        \ "<         |",
+        \ "~         |",
+        \ ]
+  call assert_equal(expect, lines)
+  set wrap
+  call cursor(1, 1)
+  " the complete line should be displayed in the window
+  norm! $
+
+  let lines=ScreenLines([1,10], winwidth(0)+1)
+  let expect=[
+        \ "<aaa aaa a|",
+        \ "a aaa aaa |",
+        \ "aa aaa aaa|",
+        \ " aa aaa aa|",
+        \ "a aa aaa a|",
+        \ "aa aa aaa |",
+        \ "aaa aa aaa|",
+        \ " aaa aa aa|",
+        \ "a aaa aa a|",
+        \ "aa aaa aa |",
+        \ ]
+  call assert_equal(expect, lines)
+  set list& listchars& wrap&
+  bw!
+endfunc

--- a/src/testdir/view_util.vim
+++ b/src/testdir/view_util.vim
@@ -54,6 +54,7 @@ endfunction
 function! NewWindow(height, width) abort
   exe a:height . 'new'
   exe a:width . 'vsp'
+  set winfixwidth winfixheight
   redraw!
 endfunction
 


### PR DESCRIPTION
The 'precedes' value for the listchars option should only be drawn when
the list option is on and wrapping is off (and there is text preceeding
the first column) OR when list option is on and wrapping is on and the
line is longer than the complete window (and there is still text
preceeding the first column). But in the latter case, only
draw the precedes value in the first column visible for the physical
line, not in every first column of the screen line.

Add a test to verify the behaviour.

related: neovim/neovim#11034

(Note: the change to view_util is actually unrelated, but makes debugging 
easier as the window size does not change unexpectedly when trying to
run the test interactively and switching between windows).