### PR TITLE
get_number: add trailing newline with CR etc

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4131,6 +4131,9 @@ f_inputlist(typval_T *argvars, typval_T *rettv)
     selected = prompt_for_number(&mouse_used);
     if (mouse_used)
 	selected -= lines_left;
+    msg_putchar('\n');
+    need_wait_return = FALSE;
+    msg_didany = FALSE;
 
     rettv->vval.v_number = selected;
 }

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1498,7 +1498,7 @@ get_number(
 #endif
 	else if (n == 0 && c == ':' && colon)
 	{
-	    msg_puts("-\n");
+	    msg_putchar('-');
 	    stuffcharReadbuff(':');
 	    if (!exmode_active)
 		cmdline_row = msg_row;
@@ -1507,7 +1507,8 @@ get_number(
 	    break;
 	}
 	else if (c == CAR || c == NL || c == Ctrl_C || c == ESC) {
-	    msg_putchar('\n');
+	    if (!typed)
+		msg_putchar('0');
 	    break;
 	}
     }

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1505,8 +1505,10 @@ get_number(
 	    do_redraw = FALSE;
 	    break;
 	}
-	else if (c == CAR || c == NL || c == Ctrl_C || c == ESC)
+	else if (c == CAR || c == NL || c == Ctrl_C || c == ESC) {
+	    msg_putchar('\n');
 	    break;
+	}
     }
     --no_mapping;
     --allow_keys;

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1498,6 +1498,7 @@ get_number(
 #endif
 	else if (n == 0 && c == ':' && colon)
 	{
+	    msg_puts("-\n");
 	    stuffcharReadbuff(':');
 	    if (!exmode_active)
 		cmdline_row = msg_row;


### PR DESCRIPTION
Fixes https://github.com/vim/vim/issues/4972.

There might be a better way, but the messaging system is not easy to wrap my head around.