### PR TITLE
printf: fix handling of multibyte characters with %.*S

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -4408,8 +4408,12 @@ vim_vsnprintf_typval(
 			    char_u *p1 = (char_u *)str_arg;
 			    size_t i;
 
-			    for (i = 0; i < precision && *p1; i++)
+			    for (i = 0; *p1;) {
+				i += (size_t)mb_ptr2cells(p1);
+				if (i > precision)
+				    break;
 				p1 += mb_ptr2len(p1);
+			    }
 
 			    str_arg_l = precision = p1 - (char_u *)str_arg;
 			}

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -248,6 +248,9 @@ function Test_printf_misc()
   call assert_equal('abc ', printf('%-4s', 'abc'))
   call assert_equal('abc ', printf('%-4S', 'abc'))
 
+  call assert_equal('🐍', printf('%.2S', '🐍🐍'))
+  call assert_equal('', printf('%.1S', '🐍🐍'))
+
   call assert_equal('1%', printf('%d%%', 1))
 endfunc
 


### PR DESCRIPTION
Without this patch the tests would fails:

    Test_printf_misc line 118: Expected '🐍' but got '🐍🐍'
    Test_printf_misc line 119: Expected '' but got '🐍'

From the doc:

>                                         *printf-S*
> S	The text of the String argument is used.  If a
>         precision is specified, no more display cells than the
>         number specified are used.