### PR TITLE
Update the #ifdef check for write_session_file()

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -985,7 +985,7 @@ ex_loadview(exarg_T *eap)
     }
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+# if defined(USE_GNOME_SESSION) || (defined(GUI_MAY_SPAWN) && defined(EXPERIMENTAL_GUI_CMD)) || defined(PROTO)
 /*
  * Generate a script that can be used to restore the current editing session.
  * Save the value of v:this_session before running :mksession in order to make


### PR DESCRIPTION
The write_session_file() function is used only when Gnome session
or experimental GUI command is defined. Update the #ifdef checks
for this function.