### PR TITLE
Fix Termdebug: high CPU usage when no gdb

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -65,8 +65,8 @@ command -nargs=* -complete=file -bang Termdebug call s:StartDebug(<bang>0, <f-ar
 command -nargs=+ -complete=file -bang TermdebugCommand call s:StartDebugCommand(<bang>0, <f-args>)
 
 " Name of the gdb command, defaults to "gdb".
-if !exists('termdebugger')
-  let termdebugger = 'gdb'
+if !exists('g:termdebugger')
+  let g:termdebugger = 'gdb'
 endif
 
 let s:pc_id = 12
@@ -107,6 +107,12 @@ func s:StartDebug_internal(dict)
     echoerr 'Terminal debugger already running'
     return
   endif
+
+  if !executable(g:termdebugger)
+    echoerr 'Cannot execute debugger program "' .. g:termdebugger .. '"'
+    return
+  endif
+
   let s:ptywin = 0
   let s:pid = 0
 


### PR DESCRIPTION
When do `:Termdebug` in the environment which has no gdb installed (e.g. macOS), the following error message and high CPU usage occur.

```
$ vim --clean

:packadd termdebug
:Termdebug
```

```
Error detected while processing function <SNR>9_StartDebug[2]..<SNR>9_StartDebug_internal[40]..<SNR>9_StartDebug_term:
line   66:
'gdb' exited unexpectedly
```

I think should check `g:termdebugger` (gdb) is executable before starting a job.