### PR TITLE
Fix popupwin list iteration in popup_getoptions

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2638,7 +2638,7 @@ f_popup_getoptions(typval_T *argvars, typval_T *rettv)
 	{
 	    win_T *p;
 
-	     for (p = tp->tp_first_popupwin; p != NULL; p = wp->w_next)
+	     for (p = tp->tp_first_popupwin; p != NULL; p = p->w_next)
 		 if (p->w_id == id)
 		     break;
 	     if (p != NULL)


### PR DESCRIPTION
The function popup_getoptions hangs when iterating the list of popup windows because it is using the next pointer from a wrong variable.