### PR TITLE
Extend filetype detection to include shebangs which use env -S

### DIFF
--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -35,10 +35,12 @@ let s:line1 = getline(1)
 if s:line1 =~# "^#!"
   " A script that starts with "#!".
 
-  " Check for a line like "#!/usr/bin/env VAR=val bash".  Turn it into
-  " "#!/usr/bin/bash" to make matching easier.
+  " Check for a line like "#!/usr/bin/env VAR=val bash" and/or
+  " "#!/usr/bin/env -S bash --norc".  Turn it into "#!/usr/bin/bash"
+  " to make matching easier.
   if s:line1 =~# '^#!\s*\S*\<env\s'
     let s:line1 = substitute(s:line1, '\S\+=\S\+', '', 'g')
+    let s:line1 = substitute(s:line1, '\(-S\|--split-string\)', '', '')
     let s:line1 = substitute(s:line1, '\<env\s\+', '', '')
   endif
 


### PR DESCRIPTION
As of [GNU coreutils 8.30](https://savannah.gnu.org/forum/forum.php?forum_id=9187) (July 2018), env(1) supports an `-S`/`--split-string` option, e.g.:

```
#!/usr/bin/env -S ruby --disable=gems
```

This allows multiple parameters to be passed to a command rather than processing the whole command as a single argument. This is also supported on FreeBSD (and [macOS](https://apple.stackexchange.com/a/297535)), which [inspired the feature](https://lists.gnu.org/r/coreutils/2018-04/msg00011.html).

This patch allows Vim to detect (i.e. skip/ignore) this option so that filetype detection continues to work for shebangs which use this option on Linux/FreeBSD.