### PR TITLE
Added test of right click to extend/shrink the visual area

### DIFF
--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -195,7 +195,7 @@ func Test_xterm_mouse_right_click_extends_visual()
       call MouseRightRelease(5, 5)
       norm! r2
 
-      if visual_mode == 'v'
+      if visual_mode ==# 'v'
         call assert_equal(['-------',
               \            '-111111',
               \            '1122222',
@@ -203,7 +203,7 @@ func Test_xterm_mouse_right_click_extends_visual()
               \            '2222211',
               \            '111111-',
               \            '-------'], getline(1, '$'), msg)
-      elseif visual_mode == 'V'
+      elseif visual_mode ==# 'V'
         call assert_equal(['-------',
               \            '1111111',
               \            '2222222',

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -162,7 +162,7 @@ endfunc
 
 func Test_xterm_mouse_right_click_extends_visual()
   if has('mac')
-    throw "Skipped: test right click in visual modes does not work on macOs (why?)"
+    throw "Skipped: test right click in visual mode does not work on macOs (why?)"
   endif
   let save_mouse = &mouse
   let save_term = &term

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -161,6 +161,9 @@ func Test_term_mouse_left_click()
 endfunc
 
 func Test_xterm_mouse_right_click_extends_visual()
+  if has('mac')
+    throw "Skipped: test right click in visual modes does not work on macOs (why?)"
+  endif
   let save_mouse = &mouse
   let save_term = &term
   let save_ttymouse = &ttymouse

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -72,6 +72,14 @@ func MouseMiddleClick(row, col)
   endif
 endfunc
 
+func MouseRightClick(row, col)
+  if &ttymouse ==# 'dec'
+    call DecEscapeCode(6, 1, a:row, a:col)
+  else
+    call TerminalEscapeCode(2, a:row, a:col, 'M')
+  endif
+endfunc
+
 func MouseCtrlLeftClick(row, col)
   let ctrl = 0x10
   call TerminalEscapeCode(0 + ctrl, a:row, a:col, 'M')
@@ -101,7 +109,11 @@ func MouseMiddleRelease(row, col)
 endfunc
 
 func MouseRightRelease(row, col)
-  call TerminalEscapeCode(3, a:row, a:col, 'm')
+  if &ttymouse ==# 'dec'
+    call DecEscapeCode(7, 0, a:row, a:col)
+  else
+    call TerminalEscapeCode(3, a:row, a:col, 'm')
+  endif
 endfunc
 
 func MouseLeftDrag(row, col)
@@ -139,6 +151,76 @@ func Test_term_mouse_left_click()
     call MouseLeftClick(row, col)
     call MouseLeftRelease(row, col)
     call assert_equal([0, 2, 6, 0], getpos('.'), msg)
+  endfor
+
+  let &mouse = save_mouse
+  let &term = save_term
+  let &ttymouse = save_ttymouse
+  call test_override('no_query_mouse', 0)
+  bwipe!
+endfunc
+
+func Test_xterm_mouse_right_click_extends_visual()
+  let save_mouse = &mouse
+  let save_term = &term
+  let save_ttymouse = &ttymouse
+  call test_override('no_query_mouse', 1)
+  set mouse=a term=xterm
+
+  for visual_mode in ["v", "V", "\<C-V>"]
+    for ttymouse_val in s:ttymouse_values + s:ttymouse_dec
+      let msg = 'visual=' .. visual_mode .. ' ttymouse=' .. ttymouse_val
+      exe 'set ttymouse=' .. ttymouse_val
+
+      call setline(1, repeat([repeat('-', 7)], 7))
+      call MouseLeftClick(4, 4)
+      call MouseLeftRelease(4, 4)
+      exe  "norm! " .. visual_mode
+
+      " Right click extends top left of visual area.
+      call MouseRightClick(2, 2)
+      call MouseRightRelease(2, 2)
+
+      " Right click extends bottom bottom right of visual area.
+      call MouseRightClick(6, 6)
+      call MouseRightRelease(6, 6)
+      norm! r1gv
+
+      " Right click shrinks top left of visual area.
+      call MouseRightClick(3, 3)
+      call MouseRightRelease(3, 3)
+
+      " Right click shrinks bottom right of visual area.
+      call MouseRightClick(5, 5)
+      call MouseRightRelease(5, 5)
+      norm! r2
+
+      if visual_mode == 'v'
+        call assert_equal(['-------',
+              \            '-111111',
+              \            '1122222',
+              \            '2222222',
+              \            '2222211',
+              \            '111111-',
+              \            '-------'], getline(1, '$'), msg)
+      elseif visual_mode == 'V'
+        call assert_equal(['-------',
+              \            '1111111',
+              \            '2222222',
+              \            '2222222',
+              \            '2222222',
+              \            '1111111',
+              \            '-------'], getline(1, '$'), msg)
+      else
+        call assert_equal(['-------',
+              \            '-11111-',
+              \            '-12221-',
+              \            '-12221-',
+              \            '-12221-',
+              \            '-11111-',
+              \            '-------'], getline(1, '$'), msg)
+      endif
+    endfor
   endfor
 
   let &mouse = save_mouse


### PR DESCRIPTION
This PR adds a test of right click to extend or shrink the
visual area, which was not tested according to codecov:

https://codecov.io/gh/vim/vim/src/e8a7dfedfc8ea5c376c7912cb27a9405e4b8c972/src/mouse.c#L742