### PR TITLE
Skip (portions of) tests that do not work as root

### DIFF
--- a/src/testdir/check.vim
+++ b/src/testdir/check.vim
@@ -1,3 +1,5 @@
+source shared.vim
+
 " Command to check for the presence of a feature.
 command -nargs=1 CheckFeature call CheckFeature(<f-args>)
 func CheckFeature(name)
@@ -100,5 +102,13 @@ command CheckNotGui call CheckNotGui()
 func CheckNotGui()
   if has('gui_running')
     throw 'Skipped: only works in the terminal'
+  endif
+endfunc
+
+" Command to check that test is not running as root
+command CheckNotRoot call CheckNotRoot()
+func CheckNotRoot()
+  if IsRoot()
+    throw 'Skipped: cannot run test as root'
   endif
 endfunc

--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -325,3 +325,12 @@ func RunVimPiped(before, after, arguments, pipecmd)
   endif
   return 1
 endfunc
+
+func IsRoot()
+  if !has('unix')
+    return v:false
+  elseif $USER == 'root' || system('id -un') =~ '\<root\>'
+    return v:true
+  endif
+  return v:false
+endfunc

--- a/src/testdir/test_rename.vim
+++ b/src/testdir/test_rename.vim
@@ -1,5 +1,7 @@
 " Test rename()
 
+source shared.vim
+
 func Test_rename_file_to_file()
   call writefile(['foo'], 'Xrename1')
 
@@ -81,7 +83,7 @@ func Test_rename_copy()
 
   call assert_equal(0, rename('Xrenamedir/Xrenamefile', 'Xrenamefile'))
 
-  if !has('win32')
+  if !has('win32') && !IsRoot()
     " On Windows, the source file is removed despite
     " its directory being made not writable.
     call assert_equal(['foo'], readfile('Xrenamedir/Xrenamefile'))

--- a/src/testdir/test_swap.vim
+++ b/src/testdir/test_swap.vim
@@ -1,5 +1,7 @@
 " Tests for the swap feature
 
+source shared.vim
+
 func s:swapname()
   return trim(execute('swapname'))
 endfunc
@@ -196,14 +198,17 @@ func Test_swapfile_delete()
   quit
   call assert_equal(fnamemodify(swapfile_name, ':t'), fnamemodify(s:swapname, ':t'))
 
-  " Write the swapfile with a modified PID, now it will be automatically
-  " deleted. Process one should never be Vim.
-  let swapfile_bytes[24:27] = 0z01000000
-  call writefile(swapfile_bytes, swapfile_name)
-  let s:swapname = ''
-  split XswapfileText
-  quit
-  call assert_equal('', s:swapname)
+  " This test won't work as root because root can successfully run kill(1, 0)
+  if !IsRoot()
+    " Write the swapfile with a modified PID, now it will be automatically
+    " deleted. Process one should never be Vim.
+    let swapfile_bytes[24:27] = 0z01000000
+    call writefile(swapfile_bytes, swapfile_name)
+    let s:swapname = ''
+    split XswapfileText
+    quit
+    call assert_equal('', s:swapname)
+  endif
 
   " Now set the modified flag, the swap file will not be deleted
   let swapfile_bytes[28 + 80 + 899] = 0x55

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -570,7 +570,7 @@ func Test_terminal_cwd_failure()
 
   " Case 3: Directory exists but is not accessible.
   " Skip this for root, it will be accessible anyway.
-  if $USER != 'root'
+  if !IsRoot()
     call mkdir('XdirNoAccess', '', '0600')
     " return early if the directory permissions could not be set properly
     if getfperm('XdirNoAccess')[2] == 'x'

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -1,5 +1,7 @@
 " Test for reading and writing .viminfo
 
+source check.vim
+
 function Test_viminfo_read_and_write()
   " First clear 'history', so that "hislen" is zero.  Then set it again,
   " simulating Vim starting up.
@@ -730,9 +732,8 @@ endfunc
 
 " Test for an unwritable 'viminfo' file
 func Test_viminfo_readonly()
-  if !has('unix')
-      return
-  endif
+  CheckUnix
+  CheckNotRoot
   call writefile([''], 'Xviminfo')
   call setfperm('Xviminfo', 'r-x------')
   call assert_fails('wviminfo Xviminfo', 'E137:')


### PR DESCRIPTION
Added IsRoot() function to check for root, so that portions of a test can be skipped, and :CheckNotRoot to entirely skip a test.