### PR TITLE
Fix issue 5007: heap buffer overflow with C locale

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -230,11 +230,11 @@
  * PTR2CHAR(): get character from pointer.
  */
 /* Get the length of the character p points to, including composing chars */
-#define MB_PTR2LEN(p)	    (has_mbyte ? (*mb_ptr2len)(p) : 1)
+#define MB_PTR2LEN(p)	    (has_mbyte ? (*mb_ptr2len)(p) : (*p == NUL ? 0 : 1))
 /* Advance multi-byte pointer, skip over composing chars. */
-#define MB_PTR_ADV(p)	    p += has_mbyte ? (*mb_ptr2len)(p) : 1
+#define MB_PTR_ADV(p)	    p += has_mbyte ? (*mb_ptr2len)(p) : (*p == NUL ? 0 : 1)
 /* Advance multi-byte pointer, do not skip over composing chars. */
-#define MB_CPTR_ADV(p)	    p += enc_utf8 ? utf_ptr2len(p) : has_mbyte ? (*mb_ptr2len)(p) : 1
+#define MB_CPTR_ADV(p)	    p += enc_utf8 ? utf_ptr2len(p) : has_mbyte ? (*mb_ptr2len)(p) : (*p == NUL ? 0 : 1)
 /* Backup multi-byte pointer. Only use with "p" > "s" ! */
 #define MB_PTR_BACK(s, p)  p -= has_mbyte ? ((*mb_head_off)(s, p - 1) + 1) : 1
 /* get length of multi-byte char, not including composing chars */


### PR DESCRIPTION
This PR issue #5007. Invalid memory access was reproducible with:
```
$ valgrind ./vim --clean -c 'set enc=latin1' -c 'x`=' 2> vg.log
$ cat vg.log
==23162== Memcheck, a memory error detector
==23162== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==23162== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==23162== Command: ./vim --clean -c set\ enc=latin1 -c x`=
==23162== 
==23162== Invalid read of size 1
==23162==    at 0x1A3357: separate_nextcmd (ex_docmd.c:4302)
==23162==    by 0x1A85A2: do_one_cmd (ex_docmd.c:2142)
==23162==    by 0x1A85A2: do_cmdline (ex_docmd.c:966)
==23162==    by 0x3320FF: exe_commands (main.c:3133)
==23162==    by 0x3320FF: vim_main2 (main.c:795)
==23162==    by 0x13A584: main (main.c:444)
==23162==  Address 0xb32bf84 is 0 bytes after a block of size 4 alloc'd
==23162==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==23162==    by 0x2084F0: lalloc (misc2.c:924)
==23162==    by 0x208F4E: alloc (misc2.c:827)
==23162==    by 0x208F4E: vim_strsave (misc2.c:1276)
==23162==    by 0x1A72CF: do_cmdline (ex_docmd.c:896)
==23162==    by 0x3320FF: exe_commands (main.c:3133)
==23162==    by 0x3320FF: vim_main2 (main.c:795)
==23162==    by 0x13A584: main (main.c:444)
```
The change to macros MB_PTR2LEN, MB_PTR_ADV
and MB_CPPTR_ADV seems risky as it can affect many
pieces of code, but all tests pass at least.