### PR TITLE
Fix fnamemodify()'s handling of :r after :e

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -267,7 +267,7 @@ modify_fname(
 {
     int		valid = 0;
     char_u	*tail;
-    char_u	*s, *p, *pbuf;
+    char_u	*s, *p, *pbuf, *limit;
     char_u	dirname[MAXPATHL];
     int		c;
     int		has_fullname = 0;
@@ -563,7 +563,10 @@ repeat:
 	}
 	else				// :r
 	{
-	    if (s > tail)	// remove one extension
+	    limit = *fnamep;
+	    if (tail > limit)
+		limit = tail;
+	    if (s > limit)	// remove one extension
 		*fnamelen = (int)(s - *fnamep);
 	}
 	*usedlen += 2;

--- a/src/testdir/test_fnamemodify.vim
+++ b/src/testdir/test_fnamemodify.vim
@@ -1,5 +1,32 @@
 " Test filename modifiers.
 
+func Test_fnamemodify_er()
+  call assert_equal("with", fnamemodify("path/to/file.with.extensions", ':e:e:r:r'))
+
+  call assert_equal('c', fnamemodify('a.c', ':e'))
+  call assert_equal('c', fnamemodify('a.c', ':e:e'))
+  call assert_equal('c', fnamemodify('a.c', ':e:e:r'))
+  call assert_equal('c', fnamemodify('a.c', ':e:e:r:r'))
+
+  call assert_equal('rb', fnamemodify('a.spec.rb', ':e:r'))
+  call assert_equal('rb', fnamemodify('a.spec.rb', ':e:r'))
+  call assert_equal('spec', fnamemodify('a.spec.rb', ':e:e:r'))
+  call assert_equal('spec', fnamemodify('a.spec.rb', ':e:e:r:r'))
+  call assert_equal('spec', fnamemodify('a.b.spec.rb', ':e:e:r'))
+  call assert_equal('b.spec', fnamemodify('a.b.spec.rb', ':e:e:e:r'))
+  call assert_equal('b', fnamemodify('a.b.spec.rb', ':e:e:e:r:r'))
+
+  call assert_equal('spec', fnamemodify('a.b.spec.rb', ':r:e'))
+  call assert_equal('b', fnamemodify('a.b.spec.rb', ':r:r:e'))
+
+  call assert_equal('c', fnamemodify('a.b.c.d.e', ':r:r:e'))
+  call assert_equal('b.c', fnamemodify('a.b.c.d.e', ':r:r:e:e'))
+
+  " :e never includes the whole filename, so "a.b":e:e:e --> "b"
+  call assert_equal('b.c', fnamemodify('a.b.c.d.e', ':r:r:e:e:e'))
+  call assert_equal('b.c', fnamemodify('a.b.c.d.e', ':r:r:e:e:e:e'))
+endfunc
+
 func Test_fnamemodify()
   let save_home = $HOME
   let save_shell = &shell
@@ -42,7 +69,7 @@ func Test_fnamemodify()
   set shell=tcsh
   call assert_equal("'abc\\\ndef'",  fnamemodify("abc\ndef", ':S'))
 
-  call assert_equal("with", fnamemodify("path/to/file.with.extensions", ':e:e:r:r'))
+  call Test_fnamemodify_er()
 
   let $HOME = save_home
   let &shell = save_shell

--- a/src/testdir/test_fnamemodify.vim
+++ b/src/testdir/test_fnamemodify.vim
@@ -42,6 +42,8 @@ func Test_fnamemodify()
   set shell=tcsh
   call assert_equal("'abc\\\ndef'",  fnamemodify("abc\ndef", ':S'))
 
+  call assert_equal("with", fnamemodify("path/to/file.with.extensions", ':e:e:r:r'))
+
   let $HOME = save_home
   let &shell = save_shell
 endfunc


### PR DESCRIPTION
During `fnamemodify()`, for `":r"` we will iterate up the filename. Ensuring that we don't go before the filename's first directory separator (the tail) is insufficient in cases where we've already handled a `":e"` modifier, for example:

```
"path/to/this.file.ext" :e:e:r:r
         ^    ^-------- *fnamep
         +------------- tail
```

This means for a `":r"`, we'll go before `*fnamep`, and outside the bounds of the filename. This is both incorrect and causes vim to attempt to allocate a lot of memory, which will either fails and we'll continue with a null string, or we'll get a runtime allocation error.

The large memory allocation comes from calculating `s - *fnamep`. Since `s` is before `*fnamep`, we calculate a negative length, which ends up being interpreted as an amount to allocate, causing the above problem.

We must instead ensure we don't go before `*fnamep` nor `tail`. The check for `tail` is still relevant, for example, here we don't want to go before it:

```
"path/to/this.file.ext" :r:r:r
 ^       ^------------- tail
 +--------------------- *fnamep
```

(This is cloned this [PR to neovim](https://github.com/neovim/neovim/pull/11165))