### PR TITLE
Fix testing with alternative VIMPROG/SCRIPTSOURCE settings

### DIFF
--- a/src/testdir/test49.vim
+++ b/src/testdir/test49.vim
@@ -456,7 +456,7 @@ function ExtraVim(...)
     " messing up the user's viminfo file.
     let redirect = a:0 ?
 	\ " -c 'au VimLeave * redir END' -c 'redir\\! >" . a:1 . "'" : ""
-    exec "!echo '" . debug_quits . "q' | ../vim -u NONE -N -Xes" . redirect .
+    exec "!echo '" . debug_quits . "q' | " . v:progpath . " -u NONE -N -Xes" . redirect .
 	\ " -c 'debuggreedy|set viminfo+=nviminfo'" .
 	\ " -c 'let ExtraVimBegin = " . extra_begin . "'" .
 	\ " -c 'let ExtraVimResult = \"" . resultfile . "\"'" . breakpoints .

--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -39,9 +39,9 @@ endfunc
 
 func Test_compiler_without_arg()
   let a=split(execute('compiler'))
-  call assert_match('^.*runtime/compiler/ant.vim$',   a[0])
-  call assert_match('^.*runtime/compiler/bcc.vim$',   a[1])
-  call assert_match('^.*runtime/compiler/xmlwf.vim$', a[-1])
+  call assert_match('^'.expand('$VIMRUNTIME').'/compiler/ant.vim$',   a[0])
+  call assert_match('^'.expand('$VIMRUNTIME').'/compiler/bcc.vim$',   a[1])
+  call assert_match('^'.expand('$VIMRUNTIME').'/compiler/xmlwf.vim$', a[-1])
 endfunc
 
 func Test_compiler_completion()

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -130,18 +130,18 @@ func Test_spellinfo()
   new
 
   set enc=latin1 spell spelllang=en
-  call assert_match("^\nfile: .*/runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
+  call assert_match("^\nfile: ".expand('$VIMRUNTIME')."/spell/en.latin1.spl\n$", execute('spellinfo'))
 
   set enc=cp1250 spell spelllang=en
-  call assert_match("^\nfile: .*/runtime/spell/en.ascii.spl\n$", execute('spellinfo'))
+  call assert_match("^\nfile: ".expand('$VIMRUNTIME')."/spell/en.ascii.spl\n$", execute('spellinfo'))
 
   set enc=utf-8 spell spelllang=en
-  call assert_match("^\nfile: .*/runtime/spell/en.utf-8.spl\n$", execute('spellinfo'))
+  call assert_match("^\nfile: ".expand('$VIMRUNTIME')."/spell/en.utf-8.spl\n$", execute('spellinfo'))
 
   set enc=latin1 spell spelllang=en_us,en_nz
   call assert_match("^\n" .
-                 \  "file: .*/runtime/spell/en.latin1.spl\n" .
-                 \  "file: .*/runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
+                 \  "file: ".expand('$VIMRUNTIME')."/spell/en.latin1.spl\n" .
+                 \  "file: ".expand('$VIMRUNTIME')."/spell/en.latin1.spl\n$", execute('spellinfo'))
 
   set spell spelllang=
   call assert_fails('spellinfo', 'E756:')


### PR DESCRIPTION
The test infrastructure allows being run with different paths for the vim executable or the runtimepath, however some tests had hard-coded values preventing that from working.  This is addressed by using `v:progpath` (in a legacy test) to know the executable path and `expand('$VIMRUNTIME')` instead of assuming the in-source runtime.

These changes will enable running Vim's test suite with an already installed Vim, as part of Debian's [continuous integration](https://ci.debian.net/doc/) to validate Vim isn't broken when dependency packages are updated.