### PR TITLE
msg_puts_display: skip successive more prompts with quit_more

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -134,6 +134,9 @@ msg_attr_keep(
     int		retval;
     char_u	*buf = NULL;
 
+    if (quit_more)
+	return TRUE;
+
     /* Skip messages not matching ":filter pattern".
      * Don't filter when there is an error. */
     if (!emsg_on_display && message_filtered((char_u *)s))

--- a/src/message.c
+++ b/src/message.c
@@ -2107,14 +2107,14 @@ msg_puts_display(
 	    if (p_more && lines_left == 0 && State != HITRETURN
 					    && !msg_no_more && !exmode_active)
 	    {
-		if (quit_more)
-		    return;
 #ifdef FEAT_CON_DIALOG
 		if (do_more_prompt(NUL))
 		    s = confirm_msg_tail;
 #else
 		(void)do_more_prompt(NUL);
 #endif
+		if (quit_more)
+		    return;
 	    }
 
 	    /* When we displayed a char in last column need to check if there

--- a/src/message.c
+++ b/src/message.c
@@ -2107,14 +2107,14 @@ msg_puts_display(
 	    if (p_more && lines_left == 0 && State != HITRETURN
 					    && !msg_no_more && !exmode_active)
 	    {
+		if (quit_more)
+		    return;
 #ifdef FEAT_CON_DIALOG
 		if (do_more_prompt(NUL))
 		    s = confirm_msg_tail;
 #else
 		(void)do_more_prompt(NUL);
 #endif
-		if (quit_more)
-		    return;
 	    }
 
 	    /* When we displayed a char in last column need to check if there


### PR DESCRIPTION
Fixes displaying more prompt again when using `q` with e.g.

    :exe 'py print("\n".join(str(x) for x in range(0, '.&lines*3.')))'

TODO:

- [ ] test (if ok with existing tests etc)