### PR TITLE
Solve #5039 by same way as https://github.com/neovim/neovim/pull/11222

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -2206,12 +2206,12 @@ line_read_in:
 		{
 		    /* Get the tag file size (don't use mch_fstat(), it's not
 		     * portable). */
-		    if ((filesize = vim_lseek(fileno(fp),
-						   (off_T)0L, SEEK_END)) <= 0)
+		    if (vim_fseek(fp, 0, SEEK_END) != 0)
 			state = TS_LINEAR;
 		    else
 		    {
-			vim_lseek(fileno(fp), (off_T)0L, SEEK_SET);
+			filesize = vim_ftell(fp);
+			vim_fseek(fp, 0, SEEK_SET);
 
 			/* Calculate the first read offset in the file.  Start
 			 * the search in the middle of the file. */


### PR DESCRIPTION
, using fseek instead of lseek. Workaround for macOS Catalina IO bug.