### PR TITLE
Skip E303 errors with empty 'directory' (no swap files)

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -767,6 +767,11 @@ ml_open_file(buf_T *buf)
      * Try all directories in 'directory' option.
      */
     dirp = p_dir;
+    // Empty 'directory' setting: do not use swap files.
+    if (*dirp == NUL) {
+	buf->b_may_swap = FALSE;
+	return;
+    }
     for (;;)
     {
 	if (*dirp == NUL)

--- a/src/testdir/test_recover.vim
+++ b/src/testdir/test_recover.vim
@@ -12,6 +12,12 @@ func Test_recover_root_dir()
     set dir=/notexist/
   endif
   call assert_fails('split Xtest', 'E303:')
+
+  " No error with empty 'directory' setting.
+  set directory=
+  split XtestOK
+  close!
+
   set dir&
 endfunc
 


### PR DESCRIPTION
The help for 'dir' says:

> 	- Empty means that no swap file will be used (recovery is impossible!).

I think it is good to not emit E303 errors then.


AppVeyor failure appears to be unrelated:
```
From test_alot.vim:
Found errors in Test_list_mappings():
function RunTheTest[40]..Test_list_mappings line 4: Expected ['i  <S-/>       * ShiftSlash', 'i  <M-S>       * AltS', 'i  <C-M>       * CtrlM'] but got ['i  <S-/>       * ShiftSlash', 'i  <M-S>       * AltS', 'i  <C-M>       * CtrlM', '!  <S-Insert>    <C-R><C-O>*', 'i  <Char-0b1z> * b']
function RunTheTest[40]..Test_list_mappings line 11: Expected ['i  <S-/>       * ShiftSlash'] but got ['i  <S-/>       * ShiftSlash', '!  <S-Insert>    <C-R><C-O>*', 'i  <Char-0b1z> * b']
function RunTheTest[40]..Test_list_mappings line 13: Expected ['No mapping found'] but got ['!  <S-Insert>    <C-R><C-O>*', 'i  <Char-0b1z> * b']
TEST FAILURE 
NMAKE : fatal error U1077: 'if' : return code '0x1'
Stop.
```