### PR TITLE
tests: make output with "make -C src/testdir …" more silent

### DIFF
--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -71,10 +71,11 @@ $(SCRIPTS) $(SCRIPTS_GUI) $(NEW_TESTS_RES): $(SCRIPTS_FIRST)
 
 # Execute an individual new style test, e.g.:
 # 	make test_largefile
+$(NEW_TESTS): MAKEFLAGS+=--no-print-directory
 $(NEW_TESTS):
-	rm -f $@.res test.log messages
-	$(MAKE) -f Makefile $@.res
-	cat messages
+	@rm -f $@.res test.log messages
+	@$(MAKE) -f Makefile $@.res
+	@cat messages
 	@if test -f test.log; then \
 		exit 1; \
 	fi


### PR DESCRIPTION
E.g. with `make -C src/testdir test_wnext`:

Before:

    make: Entering directory '…/Vcs/vim/src/testdir'
    rm -f test_wnext.res test.log messages
    make -f Makefile test_wnext.res
    make[1]: Entering directory '…/Vcs/vim/src/testdir'
    VIMRUNTIME=../../runtime  ../vim -f  -u unix.vim -U NONE --noplugin --not-a-term -S runtest.vim test_wnext.vim --cmd 'au SwapExists * let v:swapchoice = "e"' > /dev/null
    make[1]: Leaving directory '…/Vcs/vim/src/testdir'
    cat messages

    From test_wnext.vim:
    Executed Test_wnext() in   1.084915 seconds
    Executed Test_wprevious() in   0.109806 seconds
    Executed 2 tests in   1.205020 seconds
    make: Leaving directory '…/Vcs/vim/src/testdir'

New:

    make: Entering directory '…/Vcs/vim/src/testdir'
    VIMRUNTIME=../../runtime  ../vim -f  -u unix.vim -U NONE --noplugin --not-a-term -S runtest.vim test_wnext.vim --cmd 'au SwapExists * let v:swapchoice = "e"' > /dev/null

    From test_wnext.vim:
    Executed Test_wnext() in   1.079318 seconds
    Executed Test_wprevious() in   0.103404 seconds
    Executed 2 tests in   1.193495 seconds
    make: Leaving directory '…/Vcs/vim/src/testdir'

And from the testdir:

    % make test_wnext
    VIMRUNTIME=../../runtime  ../vim -f  -u unix.vim -U NONE --noplugin --not-a-term -S runtest.vim test_wnext.vim --cmd 'au SwapExists * let v:swapchoice = "e"' > /dev/null

    From test_wnext.vim:
    Executed Test_wnext() in   1.087869 seconds
    Executed Test_wprevious() in   0.117928 seconds
    Executed 2 tests in   1.215164 seconds

I've tested that GNU Make would ignore an unknown MAKEFLAGS entry, but
am not sure about other make programs.  `--no-print-directory` appears
to be a GNU extension(?).