### PR TITLE
Dart language syntax files

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1158,6 +1158,26 @@ startup vimrc: >
    :let filetype_w = "cweb"
 
 
+DART						*dart.vim* *ft-dart-syntax*
+
+Dart is an object-oriented, typed, class defined, garbage collected language
+used for developing mobile, desktop, web, and back-end applications.  Dart uses
+a C-like syntax derived from C, Java, and JavaScript, with features adopted
+from Smalltalk, Python, Ruby, and others.
+
+More information about the language and its development environment at the
+official Dart language website at https://dart.dev
+
+dart.vim syntax detects and highlights Dart statements, reserved words,
+type declarations, storage classes, conditionals, loops, interpolated values,
+and comments.  There is no support idioms from Flutter or any other Dart
+framework.
+
+Changes, fixes?  Submit an issue or pull request via:
+
+https://github.com/pr3d4t0r/dart-vim-syntax/
+
+
 DESKTOP					   *desktop.vim* *ft-desktop-syntax*
 
 Primary goal of this syntax file is to highlight .desktop and .directory files

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -426,8 +426,7 @@ au BufNewFile,BufRead *.pld			setf cupl
 au BufNewFile,BufRead *.si			setf cuplsim
 
 " Dart
-au BufRead,BufNewfile *.dart setf dart
-au BufRead,BufNewfile *.drt  set dart
+au BufRead,BufNewfile *.dart,*.drt setf dart
 
 " Debian Control
 au BufNewFile,BufRead */debian/control		setf debcontrol

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -425,6 +425,10 @@ au BufNewFile,BufRead *.csp,*.fdr		setf csp
 au BufNewFile,BufRead *.pld			setf cupl
 au BufNewFile,BufRead *.si			setf cuplsim
 
+" Dart
+au BufRead,BufNewfile *.dart setf dart
+au BufRead,BufNewfile *.drt  set dart
+
 " Debian Control
 au BufNewFile,BufRead */debian/control		setf debcontrol
 au BufNewFile,BufRead control

--- a/runtime/syntax/dart.vim
+++ b/runtime/syntax/dart.vim
@@ -2,17 +2,17 @@
 "
 " Language:     Dart
 " Maintainer:   Eugene 'pr3d4t0r' Ciurana <dart.syntax AT cime.net >
-" URL:          https://github.com/pr3d4t0r/dart-vim-syntax
-" Last Change:  See GitHub URL
+" Source:       https://github.com/pr3d4t0r/dart-vim-syntax
+"
+" License:      Vim is Charityware.  dart.vim syntax is Charityware.
+"               (c) Copyright 2019 by Eugene Ciurana / pr3d4t0r.  Licensed
+"               under the standard VIM LICENSE - Vim command :help uganda.txt
+"               for details.
+"
+" Questions, comments:  <dart.syntax AT cime.net>
+"                       https://ciurana.eu/pgp, https://keybase.io/pr3d4t0r
 "
 " vim: set fileencoding=utf-8:
-
-
-" Support links (remove in a future version of this syntax file):
-"
-" https://github.com/Houl/ExplainPattern-vim
-" http://vimregex.com/
-" http://vimhelp.appspot.com/pattern.txt.html#pattern%2Etxt
 
 
 " Quit when a (custom) syntax file was already loaded

--- a/runtime/syntax/dart.vim
+++ b/runtime/syntax/dart.vim
@@ -1,0 +1,89 @@
+" Vim syntax file
+"
+" Language:     Dart
+" Maintainer:   Eugene 'pr3d4t0r' Ciurana <dart.syntax AT cime.net >
+" URL:          https://github.com/pr3d4t0r/dart-vim-syntax
+" Last Change:  See GitHub URL
+"
+" vim: set fileencoding=utf-8:
+
+
+" Support links (remove in a future version of this syntax file):
+"
+" https://github.com/Houl/ExplainPattern-vim
+" http://vimregex.com/
+" http://vimhelp.appspot.com/pattern.txt.html#pattern%2Etxt
+
+
+" Quit when a (custom) syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+
+syn keyword dartCommentTodo     contained TODO FIXME XXX TBD
+syn match   dartLineComment     "//.*" contains=dartTodo,@Spell
+syn match   dartCommentSkip     "^[ \t]*\*\($\|[ \t]\+\)"
+syn region  dartComment         start="/\*"  end="\*/" contains=@Spell,dartTodo
+syn keyword dartReserved        assert async await class const export extends external final hide import implements interface library mixin on show super sync yield
+syn match   dartNumber          "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
+
+
+syn keyword dartBoolean     false true
+syn keyword dartBranch      break continue
+syn keyword dartConditional if else switch
+syn keyword dartException   catch finally rethrow throw try
+syn keyword dartIdentifier  abstract covariant deferred dynamic factory Function operator part static this typedef var
+syn keyword dartLabel       case default
+syn keyword dartNull        null
+syn keyword dartOperator    is new
+syn keyword dartRepeat      for do in while
+syn keyword dartStatement   return with 
+syn keyword dartType        bool double enum int String StringBuffer void
+syn keyword dartTodo        contained TODO FIXME XXX
+
+
+syn match  dartEscape       contained "\\\([4-9]\d\|[0-3]\d\d\|[\"\\'ntbrf]\|u\x\{4\}\)"
+syn match  dartSpecialError contained "\\."
+syn match  dartStrInterpol  contained "\${[A-Z, 0-9, a-z, _]*\}"
+
+syn region dartDQString     start=+"+ end=+"+ end=+$+ contains=dartEscape,dartStrInterpol,dartSpecialError,@Spell
+syn region dartSQString     start=+'+ end=+'+ end=+$+ contains=dartEscape,dartStrInterpol,dartSpecialError,@Spell
+
+syn match dartBraces        "[{}\[\]]"
+syn match dartParens        "[()]"
+
+
+syn sync fromstart
+syn sync maxlines=100
+
+
+hi def link dartBoolean         Boolean
+hi def link dartBranch          Conditional
+hi def link dartComment         Comment
+hi def link dartConditional     Conditional
+hi def link dartDQString        String
+hi def link dartEscape          SpecialChar
+hi def link dartStrInterpol     Special
+hi def link dartException       Exception
+hi def link dartIdentifier      Identifier
+hi def link dartLabel           Label
+hi def link dartLineComment     Comment
+hi def link dartNull            Keyword
+hi def link dartOperator        Operator
+hi def link dartRepeat          Repeat
+hi def link dartReserved        Keyword
+hi def link dartSQString        String
+hi def link dartSpecialError    Error
+hi def link dartStatement       Statement
+hi def link dartTodo            Todo
+hi def link dartType            Type
+
+
+let b:current_syntax = "dart"
+let &cpo = s:cpo_save
+unlet s:cpo_save
+


### PR DESCRIPTION
Dart language syntax files.  Licensed under Vim license.  Support for latest version of Dart, no support for Flutter by design; a future version may implement common framework names if there's demand.

Tested under the latest Vim fork as of 20191017.

Developer repository at https://github.com/pr3d4t0r/dart-vim-syntax/

Thanks Bram, Vim team!