### PR TITLE
Fixed access to uninitialized memory when running "make test_gn"

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -4888,7 +4888,8 @@ is_one_char(char_u *pattern, int move, pos_T *cur, int direction)
 		&& regmatch.startpos[0].lnum == regmatch.endpos[0].lnum
 		&& regmatch.startpos[0].col == regmatch.endpos[0].col);
 	    /* one char width */
-	    if (!result && inc(&pos) >= 0 && pos.col == regmatch.endpos[0].col)
+	    if (!result && nmatched != 0 && inc(&pos) >= 0
+				&& pos.col == regmatch.endpos[0].col)
 		result = TRUE;
 	}
     }


### PR DESCRIPTION
This PR fixed a use of uninitialized memory in search.c
detected by valgrind when running `make test_gn`:
```
==13457== Memcheck, a memory error detector
==13457== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==13457== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==13457== Command: ../vim -f -u unix.vim -U NONE --noplugin --not-a-term -S runtest.vim test_gn.vim --cmd au\ SwapExists\ *\ let\ v:swapchoice\ =\ "e"
==13457== Parent PID: 13456
==13457==
==13457== Conditional jump or move depends on uninitialised value(s)
==13457==    at 0x578237: current_search (search.c:4731)
==13457==    by 0x4EBBB6: nv_g_cmd (normal.c:5885)
==13457==    by 0x4E5997: normal_cmd (normal.c:1073)
==13457==    by 0x47254C: exec_normal (ex_docmd.c:0)
==13457==    by 0x472431: exec_normal_cmd (ex_docmd.c:7655)
==13457==    by 0x472431: ex_normal (ex_docmd.c:7581)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x5D4FDC: call_user_func (userfunc.c:1054)
==13457==    by 0x5D4FDC: call_func (userfunc.c:1629)
==13457==    by 0x5D3DAF: get_func_tv (userfunc.c:482)
==13457==    by 0x5D902A: ex_call (userfunc.c:3160)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x44AAD5: ex_execute (eval.c:6083)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x5D4FDC: call_user_func (userfunc.c:1054)
==13457==    by 0x5D4FDC: call_func (userfunc.c:1629)
==13457==    by 0x5D3DAF: get_func_tv (userfunc.c:482)
==13457==    by 0x5D902A: ex_call (userfunc.c:3160)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x56762B: do_source (scriptfile.c:1214)
==13457==    by 0x566E07: cmd_source (scriptfile.c:805)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x61064C: exe_commands (main.c:3133)
==13457==    by 0x61064C: vim_main2 (main.c:795)
==13457==    by 0x60F2C4: main (main.c:444)
==13457==
==13457== Conditional jump or move depends on uninitialised value(s)
==13457==    at 0x5718EA: searchit (search.c:875)
==13457==    by 0x578296: current_search (search.c:4754)
==13457==    by 0x4EBBB6: nv_g_cmd (normal.c:5885)
==13457==    by 0x4E5997: normal_cmd (normal.c:1073)
==13457==    by 0x47254C: exec_normal (ex_docmd.c:0)
==13457==    by 0x472431: exec_normal_cmd (ex_docmd.c:7655)
==13457==    by 0x472431: ex_normal (ex_docmd.c:7581)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x5D4FDC: call_user_func (userfunc.c:1054)
==13457==    by 0x5D4FDC: call_func (userfunc.c:1629)
==13457==    by 0x5D3DAF: get_func_tv (userfunc.c:482)
==13457==    by 0x5D902A: ex_call (userfunc.c:3160)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x44AAD5: ex_execute (eval.c:6083)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x5D4FDC: call_user_func (userfunc.c:1054)
==13457==    by 0x5D4FDC: call_func (userfunc.c:1629)
==13457==    by 0x5D3DAF: get_func_tv (userfunc.c:482)
==13457==    by 0x5D902A: ex_call (userfunc.c:3160)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x56762B: do_source (scriptfile.c:1214)
==13457==    by 0x566E07: cmd_source (scriptfile.c:805)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x61064C: exe_commands (main.c:3133)
==13457==    by 0x61064C: vim_main2 (main.c:795)
==13457==    by 0x60F2C4: main (main.c:444)
==13457==
==13457== Conditional jump or move depends on uninitialised value(s)
==13457==    at 0x571B52: searchit (search.c:977)
==13457==    by 0x578296: current_search (search.c:4754)
==13457==    by 0x4EBBB6: nv_g_cmd (normal.c:5885)
==13457==    by 0x4E5997: normal_cmd (normal.c:1073)
==13457==    by 0x47254C: exec_normal (ex_docmd.c:0)
==13457==    by 0x472431: exec_normal_cmd (ex_docmd.c:7655)
==13457==    by 0x472431: ex_normal (ex_docmd.c:7581)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x5D4FDC: call_user_func (userfunc.c:1054)
==13457==    by 0x5D4FDC: call_func (userfunc.c:1629)
==13457==    by 0x5D3DAF: get_func_tv (userfunc.c:482)
==13457==    by 0x5D902A: ex_call (userfunc.c:3160)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x44AAD5: ex_execute (eval.c:6083)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x5D4FDC: call_user_func (userfunc.c:1054)
==13457==    by 0x5D4FDC: call_func (userfunc.c:1629)
==13457==    by 0x5D3DAF: get_func_tv (userfunc.c:482)
==13457==    by 0x5D902A: ex_call (userfunc.c:3160)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x56762B: do_source (scriptfile.c:1214)
==13457==    by 0x566E07: cmd_source (scriptfile.c:805)
==13457==    by 0x46C6AD: do_one_cmd (ex_docmd.c:2483)
==13457==    by 0x46C6AD: do_cmdline (ex_docmd.c:976)
==13457==    by 0x61064C: exe_commands (main.c:3133)
==13457==    by 0x61064C: vim_main2 (main.c:795)
==13457==    by 0x60F2C4: main (main.c:444)
```
The bug happens when `nmatched` is 0, `regmatch.endpos[0].col`
should then not be accessed, yet it is accessed at line
`search:4891`, causing `result` to have an undefined value:
```
  4875  do
  4876  {
  4877      regmatch.startpos[0].col++;
  4878      nmatched = vim_regexec_multi(&regmatch, curwin, curbuf,
  4879                         pos.lnum, regmatch.startpos[0].col, NULL, NULL);
  4880      if (!nmatched)
  4881          break;
  4882  } while (direction == FORWARD ? regmatch.startpos[0].col < pos.col
  4883                                : regmatch.startpos[0].col > pos.col);
  4884
  4885  if (!called_emsg)
  4886  {
  4887      result = (nmatched != 0
  4888          && regmatch.startpos[0].lnum == regmatch.endpos[0].lnum
  4889          && regmatch.startpos[0].col == regmatch.endpos[0].col);
  4890      /* one char width */
!!4891      if (!result && inc(&pos) >= 0 && pos.col == regmatch.endpos[0].col)
  4892          result = TRUE;
  4893  }
```
Please check the proposed patch. It fixes the issue and all tests
pass, but I'm not sure whether checking for `nmamed != 0` should
be done before or after doing `inc(&pos) >= 0` at line 4891.