### PR TITLE
indent/json.vim: replaced s:LineHasOpeningBrackets with a faster version for long lines

### DIFF
--- a/runtime/indent/json.vim
+++ b/runtime/indent/json.vim
@@ -149,8 +149,7 @@ function GetJSONIndent()
   " If the previous line contained an opening bracket, and we are still in it,
   " add indent depending on the bracket type.
   if line =~ '[[({]'
-    let counts = s:LineHasOpeningBrackets(lnum)
-    if counts[0] == '1' || counts[1] == '1' || counts[2] == '1'
+    if s:LineHasOpeningBrackets(lnum)
       return ind + shiftwidth()
     else
       call cursor(v:lnum, vcol)


### PR DESCRIPTION
It's common to retrieve a JSON file from a computed source (ie a log file) that is entirely on a single line. I found that running the "open a new line" command 'o' while in a file like this (on the order of 1,000,000 characters in a line) could hang vim for several minutes, due to the algorithm used to detect the correct indentation level that is run during the 'o' command. 

The `indentexpr` in `indent/json.vim` checks to see if the previous line had any extra opening brackets (parentheses, square brackets, curly brackets) to decide whether to add to the indent level via a function `s:LineHasOpeningBrackets`, which is roughly O(n<sup>2</sup>), and additionally does not distinguish between semantically meaningful brackets and those that are inside of a quoted string, leading to inaccuracy.

I replaced it with a different algorithm that is closer to O(n*log n), and that also filters out brackets inside of quoted strings. On my machine, with the same test file, 'o' now only takes at most a couple of seconds.

In searching for the solution to this, I came across some comments indicating that `indent/json.vim` has no current maintainer, which is why I am posted this here first -- I can send this directly to someone if that is preferable.

--------------

Also, in doing this I found a few combinations of features that fail to compile, and fixed that -- should I submit that as a separate pull request or add the commits to this one?