### PR TITLE
Fixed issue #5095

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -253,6 +253,9 @@ linelen(int *has_tab)
 
     /* find the first non-blank character */
     line = ml_get_curline();
+    if (*line == NUL)
+	return 0;
+
     first = skipwhite(line);
 
     /* find the character after the last non-blank character */

--- a/src/testdir/test_textformat.vim
+++ b/src/testdir/test_textformat.vim
@@ -489,3 +489,21 @@ func Test_format_list_auto()
   bwipe!
   set fo& ai& bs&
 endfunc
+
+func Test_crash_5095()
+  if !has('autocmd')
+    return
+  endif
+
+  " This used to segfault, see https://github.com/vim/vim/issues/5095
+  augroup testing
+    au BufNew x center
+  augroup END
+
+  next! x
+
+  bw
+  augroup testing
+    au!
+  augroup END
+endfunc

--- a/src/testdir/test_textformat.vim
+++ b/src/testdir/test_textformat.vim
@@ -506,4 +506,5 @@ func Test_crash_5095()
   augroup testing
     au!
   augroup END
+  augroup! testing
 endfunc


### PR DESCRIPTION
This PR fixes issue #5095. 
The following command was causing a segfault:
```
$ vim --clean -c 'au BufNew x center' -c 'next x'
Vim: Caught deadly signal SEGV
Vim: Finished.
Segmentation fault (core dumped)
```