### PR TITLE
fixes for `gn` operator

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -4676,7 +4676,7 @@ abort_search:
 
 #endif /* FEAT_TEXTOBJ */
 
-static int is_one_char(char_u *pattern, int move, pos_T *cur, int direction);
+static int is_zero_width(char_u *pattern, int move, pos_T *cur, int direction);
 
 /*
  * Find next search match under cursor, cursor at end.
@@ -4697,7 +4697,7 @@ current_search(
     char_u	old_p_ws = p_ws;
     int		flags = 0;
     pos_T	save_VIsual = VIsual;
-    int		one_char;
+    int		zero_width;
 
     /* wrapping should not occur */
     p_ws = FALSE;
@@ -4726,9 +4726,9 @@ current_search(
 
     /* Is the pattern is zero-width?, this time, don't care about the direction
      */
-    one_char = is_one_char(spats[last_idx].pat, TRUE, &curwin->w_cursor,
+    zero_width = is_zero_width(spats[last_idx].pat, TRUE, &curwin->w_cursor,
 								      FORWARD);
-    if (one_char == -1)
+    if (zero_width == -1)
     {
 	p_ws = old_p_ws;
 	return FAIL;  /* pattern not found */
@@ -4747,7 +4747,7 @@ current_search(
 	    dir = !i;
 
 	flags = 0;
-	if (!dir && !one_char)
+	if (!dir && !zero_width)
 	    flags = SEARCH_END;
 	end_pos = pos;
 
@@ -4800,7 +4800,6 @@ current_search(
     VIsual_active = TRUE;
     VIsual_mode = 'v';
 
-    redraw_curbuf_later(INVERTED);	/* update the inversion */
     if (*p_sel == 'e')
     {
 	/* Correction for exclusive selection depends on the direction. */
@@ -4836,7 +4835,7 @@ current_search(
  * Returns TRUE, FALSE or -1 for failure.
  */
     static int
-is_one_char(char_u *pattern, int move, pos_T *cur, int direction)
+is_zero_width(char_u *pattern, int move, pos_T *cur, int direction)
 {
     regmmatch_T	regmatch;
     int		nmatched = 0;
@@ -4887,10 +4886,6 @@ is_one_char(char_u *pattern, int move, pos_T *cur, int direction)
 	    result = (nmatched != 0
 		&& regmatch.startpos[0].lnum == regmatch.endpos[0].lnum
 		&& regmatch.startpos[0].col == regmatch.endpos[0].col);
-	    // one char width
-	    if (!result && nmatched != 0
-			&& inc(&pos) >= 0 && pos.col == regmatch.endpos[0].col)
-		result = TRUE;
 	}
     }
 

--- a/src/search.c
+++ b/src/search.c
@@ -4775,7 +4775,6 @@ current_search(
 				ml_get(curwin->w_buffer->b_ml.ml_line_count));
 	    }
 	}
-	p_ws = old_p_ws;
     }
 
     start_pos = pos;

--- a/src/search.c
+++ b/src/search.c
@@ -4787,6 +4787,8 @@ current_search(
     curwin->w_cursor = end_pos;
     if (LT_POS(VIsual, end_pos))
 	dec_cursor();
+    else if (VIsual_active && LT_POS(curwin->w_cursor, VIsual))
+	curwin->w_cursor = pos;   // put the cursor on the start of the match
     VIsual_active = TRUE;
     VIsual_mode = 'v';
 

--- a/src/search.c
+++ b/src/search.c
@@ -4706,23 +4706,14 @@ current_search(
     if (VIsual_active && *p_sel == 'e' && LT_POS(VIsual, curwin->w_cursor))
 	dec_cursor();
 
+    orig_pos = pos = curwin->w_cursor;
     if (VIsual_active)
     {
-	orig_pos = curwin->w_cursor;
-
-	pos = curwin->w_cursor;
-
-	/* make sure, searching further will extend the match */
-	if (VIsual_active)
-	{
-	    if (forward)
-		incl(&pos);
-	    else
-		decl(&pos);
-	}
+	if (forward)
+	    incl(&pos);
+	else
+	    decl(&pos);
     }
-    else
-	orig_pos = pos = curwin->w_cursor;
 
     /* Is the pattern is zero-width?, this time, don't care about the direction
      */

--- a/src/testdir/test_gn.vim
+++ b/src/testdir/test_gn.vim
@@ -143,6 +143,11 @@ func Test_gn_command()
   exe "norm! 0vllgngU"
   call assert_equal(['ABCDEFghi'], getline(1,'$'))
   sil! %d _
+  call setline('.', ['12345678'])
+  let @/ = '5'
+  norm! gg0f7vhhhhgnd
+  call assert_equal(['12348'], getline(1,'$'))
+  sil! %d _
 
   set wrapscan&vim
 endfu

--- a/src/testdir/test_gn.vim
+++ b/src/testdir/test_gn.vim
@@ -128,6 +128,21 @@ func Test_gn_command()
   call assert_equal([' nnoremap', '', 'match'], getline(1,'$'))
   sil! %d_
 
+  " make sure it works correctly for one-char wide search items
+  call setline('.', ['abcdefghi'])
+  let @/ = 'a'
+  exe "norm! 0fhvhhgNgU"
+  call assert_equal(['ABCDEFGHi'], getline(1,'$'))
+  call setline('.', ['abcdefghi'])
+  let @/ = 'b'
+  exe "norm! 0fhvhhgngU"
+  call assert_equal(['aBCDEFGHi'], getline(1,'$'))
+  call setline('.', ['abcdefghi'])
+  let @/ = 'f'
+  exe "norm! 0vllgngU"
+  call assert_equal(['ABCDEFghi'], getline(1,'$'))
+  sil! %d _
+
   set wrapscan&vim
 endfu
 

--- a/src/testdir/test_gn.vim
+++ b/src/testdir/test_gn.vim
@@ -136,7 +136,8 @@ func Test_gn_command()
   call setline('.', ['abcdefghi'])
   let @/ = 'b'
   exe "norm! 0fhvhhgngU"
-  call assert_equal(['aBCDEFGHi'], getline(1,'$'))
+  call assert_equal(['abcdefghi'], getline(1,'$'))
+  sil! %d _
   call setline('.', ['abcdefghi'])
   let @/ = 'f'
   exe "norm! 0vllgngU"


### PR DESCRIPTION
Fixes for vim/vim#5075

Also cleans up some of the logic for the `current_search()`. Some assignments could be simplified, remove an extra call to `redraw_buf_later` that is called later again.

I tried to make the commit as granular as possible, and document the logic changes clearly.