### PR TITLE
Fixed build error: sn_prl_ga only defined when FEAT_PROFILE is enabled

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1360,7 +1360,9 @@ free_scriptnames(void)
     for (i = script_items.ga_len; i > 0; --i)
     {
 	vim_free(SCRIPT_ITEM(i).sn_name);
+#  ifdef FEAT_PROFILE
 	ga_clear(&SCRIPT_ITEM(i).sn_prl_ga);
+#  endif
     }
     ga_clear(&script_items);
 }


### PR DESCRIPTION
Vim fails to build when configured with:
```
$ ./configure --with-features=normal --enable-gui=none --disable-netbeans
$ make
...snip...
scriptfile.c:1363:27: error: no member named 'sn_prl_ga' in 'struct scriptitem_S'
        ga_clear(&SCRIPT_ITEM(i).sn_prl_ga);
                  ~~~~~~~~~~~~~~ ^
```
Field `sn_prl_ga` is only defined when `FEAT_PROFILE` is defined.
This PR fixes it.