### PR TITLE
:reg: display register type for :reg command

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -999,9 +999,13 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			delete and yank) ({.%#:} only work with put).
 
 							*:reg* *:registers*
-:reg[isters]		Display the contents of all numbered and named
-			registers.  If a register is written to for |:redir|
-			it will not be listed.
+:reg[isters]		Display the type and contents of all numbered and
+			named registers.  If a register is written to for
+			|:redir| it will not be listed.
+			Type can be one of:
+			"v"	for |characterwise| text
+			"l"	for |linewise| text
+			"b"	for |blockwise-visual| text
 
 
 :reg[isters] {arg}	Display the contents of the numbered and named

--- a/src/register.c
+++ b/src/register.c
@@ -2526,7 +2526,6 @@ dnd_yank_drag_data(char_u *str, long len)
 #endif
 
 
-#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Return the type of a register.
  * Used for getregtype()
@@ -2571,6 +2570,7 @@ get_reg_type(int regname, long *reglen)
     return MAUTO;
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * When "flags" has GREG_LIST return a list with text "s".
  * Otherwise just return "s".

--- a/src/register.c
+++ b/src/register.c
@@ -2161,16 +2161,23 @@ ex_display(exarg_T *eap)
     int		attr;
     char_u	*arg = eap->arg;
     int		clen;
+    char_u      type[2];
 
     if (arg != NULL && *arg == NUL)
 	arg = NULL;
     attr = HL_ATTR(HLF_8);
 
     // Highlight title
-    msg_puts_title(_("\n--- Registers ---"));
+    msg_puts_title(_("\nType Name Content"));
     for (i = -1; i < NUM_REGISTERS && !got_int; ++i)
     {
 	name = get_register_name(i);
+	switch (get_reg_type(name, NULL))
+	{
+	    case MLINE: type[0] = 'l'; break;
+	    case MCHAR: type[0] = 'v'; break;
+	    default: type[0] = 'b'; break;
+	}
 	if (arg != NULL && vim_strchr(arg, name) == NULL
 #ifdef ONE_CLIPBOARD
 	    // Star register and plus register contain the same thing.
@@ -2207,11 +2214,15 @@ ex_display(exarg_T *eap)
 	if (yb->y_array != NULL)
 	{
 	    msg_putchar('\n');
+	    msg_puts("  ");
+	    //msg_puts((char *)transchar(type[0]));
+	    msg_putchar(type[0]);
+	    msg_puts("  ");
 	    msg_putchar('"');
 	    msg_putchar(name);
 	    msg_puts("   ");
 
-	    n = (int)Columns - 6;
+	    n = (int)Columns - 11;
 	    for (j = 0; j < yb->y_size && n > 1; ++j)
 	    {
 		if (j)
@@ -2237,7 +2248,7 @@ ex_display(exarg_T *eap)
     if ((p = get_last_insert()) != NULL
 		 && (arg == NULL || vim_strchr(arg, '.') != NULL) && !got_int)
     {
-	msg_puts("\n\".   ");
+	msg_puts("\n  v  \".   ");
 	dis_msg(p, TRUE);
     }
 
@@ -2245,7 +2256,7 @@ ex_display(exarg_T *eap)
     if (last_cmdline != NULL && (arg == NULL || vim_strchr(arg, ':') != NULL)
 								  && !got_int)
     {
-	msg_puts("\n\":   ");
+	msg_puts("\n  v  \":   ");
 	dis_msg(last_cmdline, FALSE);
     }
 
@@ -2253,7 +2264,7 @@ ex_display(exarg_T *eap)
     if (curbuf->b_fname != NULL
 	    && (arg == NULL || vim_strchr(arg, '%') != NULL) && !got_int)
     {
-	msg_puts("\n\"%   ");
+	msg_puts("\n  v  \"%   ");
 	dis_msg(curbuf->b_fname, FALSE);
     }
 
@@ -2265,7 +2276,7 @@ ex_display(exarg_T *eap)
 
 	if (buflist_name_nr(0, &fname, &dummy) != FAIL)
 	{
-	    msg_puts("\n\"#   ");
+	    msg_puts("\n  v  \"#   ");
 	    dis_msg(fname, FALSE);
 	}
     }
@@ -2274,7 +2285,7 @@ ex_display(exarg_T *eap)
     if (last_search_pat() != NULL
 		 && (arg == NULL || vim_strchr(arg, '/') != NULL) && !got_int)
     {
-	msg_puts("\n\"/   ");
+	msg_puts("\n  v  \"/   ");
 	dis_msg(last_search_pat(), FALSE);
     }
 
@@ -2283,7 +2294,7 @@ ex_display(exarg_T *eap)
     if (expr_line != NULL && (arg == NULL || vim_strchr(arg, '=') != NULL)
 								  && !got_int)
     {
-	msg_puts("\n\"=   ");
+	msg_puts("\n  v  \"=   ");
 	dis_msg(expr_line, FALSE);
     }
 #endif

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -39,26 +39,26 @@ func Test_display_registers()
     let b = execute('registers')
 
     call assert_equal(a, b)
-    call assert_match('^\n--- Registers ---\n'
-          \ .         '""   a\n'
-          \ .         '"0   ba\n'
-          \ .         '"a   b\n'
+    call assert_match('^\nType Name Content\n'
+          \ .         '  v  ""   a\n'
+          \ .         '  v  "0   ba\n'
+          \ .         '  v  "a   b\n'
           \ .         '.*'
-          \ .         '"-   a\n'
+          \ .         '  v  "-   a\n'
           \ .         '.*'
-          \ .         '":   ls\n'
-          \ .         '"%   file2\n'
-          \ .         '"#   file1\n'
-          \ .         '"/   bar\n'
-          \ .         '"=   2\*4', a)
+          \ .         '  v  ":   ls\n'
+          \ .         '  v  "%   file2\n'
+          \ .         '  v  "#   file1\n'
+          \ .         '  v  "/   bar\n'
+          \ .         '  v  "=   2\*4', a)
 
     let a = execute('registers a')
-    call assert_match('^\n--- Registers ---\n'
-          \ .         '"a   b', a)
+    call assert_match('^\nType Name Content\n'
+          \ .         '  v  "a   b', a)
 
     let a = execute('registers :')
-    call assert_match('^\n--- Registers ---\n'
-          \ .         '":   ls', a)
+    call assert_match('^\nType Name Content\n'
+          \ .         '  v  ":   ls', a)
 
     bwipe!
 endfunc


### PR DESCRIPTION
This has been wished for in  vim/vim#4546

Register type can be one of linewise, charwise or blockwise. So when
outputting the register contents, also indicate in the first column the
type of the register using 'l' for linewise, 'v' for charwise and 'b'
for blockwise.

To be consistent with getregtype(), it might have been better to use
`v`, `V` and `^V` as indicators for the type, however I personally find
those types rather hard to distinguish in the console output, so I took
the liberty to use letters that are more easily distinguishable.

the test test_register.vim has been adjusted  and the documentation
amended.