### PR TITLE
Allow :filter on :display/:registers

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -575,6 +575,8 @@ N  *+X11*		Unix only: can restore window title |X11|
 			   |:marks|      - filter by text in the current file,
 					   or file name for other files
 			   |:oldfiles|   - filter by file name
+			   |:registers|  - filter by register contents
+					   (does not work multi-line)
 			   |:set|        - filter by variable name
 
 			Only normal messages are filtered, error messages are

--- a/src/testdir/test_filter_cmd.vim
+++ b/src/testdir/test_filter_cmd.vim
@@ -145,3 +145,27 @@ func Test_filter_commands()
   bwipe! file.h
   bwipe! file.hs
 endfunc
+
+func Test_filter_display()
+  edit Xdoesnotmatch
+  let @a = '!!willmatch'
+  let @b = '!!doesnotmatch'
+  let @/ = '!!doesnotmatch'
+  call feedkeys(":echo '!!doesnotmatch:'\<CR>", 'ntx')
+  let lines = map(split(execute('filter /willmatch/ display'), "\n"), 'v:val[5:6]')
+
+  call assert_true(index(lines, '"a') >= 0)
+  call assert_false(index(lines, '"b') >= 0)
+  call assert_false(index(lines, '"/') >= 0)
+  call assert_false(index(lines, '":') >= 0)
+  call assert_false(index(lines, '"%') >= 0)
+
+  let lines = map(split(execute('filter /doesnotmatch/ display'), "\n"), 'v:val[5:6]')
+  call assert_true(index(lines, '"a') < 0)
+  call assert_false(index(lines, '"b') < 0)
+  call assert_false(index(lines, '"/') < 0)
+  call assert_false(index(lines, '":') < 0)
+  call assert_false(index(lines, '"%') < 0)
+
+  bwipe!
+endfunc


### PR DESCRIPTION
Useful to find a register that contains some text.

I didn't figure out how to make it work across lines of register content though.
