### PR TITLE
Add tests for aborting quickfix commands

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5509,8 +5509,14 @@ ex_cfile(exarg_T *eap)
     int		res;
 
     au_name = cfile_get_auname(eap->cmdidx);
-    if (au_name != NULL)
-	apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name, NULL, FALSE, curbuf);
+    if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
+							NULL, FALSE, curbuf))
+    {
+#ifdef FEAT_EVAL
+	if (aborting())
+	    return;
+#endif
+    }
 
     enc = (*curbuf->b_p_menc != NUL) ? curbuf->b_p_menc : p_menc;
 #ifdef FEAT_BROWSE

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -2701,7 +2701,7 @@ func Test_file_from_copen()
   cclose
 
   augroup! QF_Test
-endfunction
+endfunc
 
 func Test_resize_from_copen()
     augroup QF_Test
@@ -4312,57 +4312,69 @@ func Xtest_qfcmd_abort(cchar)
   call g:Xsetlist([], 'f')
 
   " cexpr/lexpr
+  let e = ''
   try
     Xexpr ["F1:10:Line10", "F2:20:Line20"]
   catch /.*/
-    call assert_equal('AbortCmd', v:exception)
+    let e = v:exception
   endtry
+  call assert_equal('AbortCmd', e)
   call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)
 
   " cfile/lfile
   call writefile(["F1:10:Line10", "F2:20:Line20"], 'Xfile1')
+  let e = ''
   try
     Xfile Xfile1
   catch /.*/
-    call assert_equal('AbortCmd', v:exception)
+    let e = v:exception
   endtry
+  call assert_equal('AbortCmd', e)
   call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)
   call delete('Xfile1')
 
   " cgetbuffer/lgetbuffer
   enew!
   call append(0, ["F1:10:Line10", "F2:20:Line20"])
+  let e = ''
   try
     Xgetbuffer
   catch /.*/
-    call assert_equal('AbortCmd', v:exception)
+    let e = v:exception
   endtry
+  call assert_equal('AbortCmd', e)
   call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)
   enew!
 
   " vimgrep/lvimgrep
+  let e = ''
   try
     Xvimgrep /func/ test_quickfix.vim
   catch /.*/
-    call assert_equal('AbortCmd', v:exception)
+    let e = v:exception
   endtry
+  call assert_equal('AbortCmd', e)
   call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)
 
   " helpgrep/lhelpgrep
+  let e = ''
   try
     Xhelpgrep quickfix
   catch /.*/
-    call assert_equal('AbortCmd', v:exception)
+    let e = v:exception
   endtry
+  call assert_equal('AbortCmd', e)
   call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)
 
   " grep/lgrep
   if has('unix')
+    let e = ''
     try
       silent Xgrep func test_quickfix.vim
     catch /.*/
-      call assert_equal('AbortCmd', v:exception)
+      let e = v:exception
     endtry
+    call assert_equal('AbortCmd', e)
     call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)
   endif
 endfunc
@@ -4380,3 +4392,5 @@ func Test_qfcmd_abort()
     au!
   augroup END
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
 Modify the cfile command to behave like other quickfix commands when aborting the command.