### PR TITLE
Fix expandcmd()

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -4200,7 +4200,7 @@ expand_filename(
 			    || vim_strchr(eap->arg, '~') != NULL)
 		    {
 			expand_env_esc(eap->arg, NameBuff, MAXPATHL,
-							    TRUE, TRUE, NULL);
+							    TRUE, FALSE, NULL);
 			has_wildcards = mch_has_wildcard(NameBuff);
 			p = NameBuff;
 		    }

--- a/src/testdir/test_expand.vim
+++ b/src/testdir/test_expand.vim
@@ -79,5 +79,7 @@ func Test_expandcmd()
   call assert_fails('call expandcmd("make <afile>")', 'E495:')
   enew
   call assert_fails('call expandcmd("make %")', 'E499:')
+  let home = expand("~"). '.bar'
+  call assert_match(home .. ' '.. home, expandcmd('~/bar ~/bar'))
   close
 endfunc


### PR DESCRIPTION
This should fix #5120 by flipping the flag `one` to `expand_env_esc()` from true to false.

As far as I can see, `one` is not used for environment variables, so flipping it should only affect tilde expansion. Let's see if this is true :/

fixes #5120 