### PR TITLE
MS-Windows: Fix get_short_pathname

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -30,26 +30,51 @@
 get_short_pathname(char_u **fnamep, char_u **bufp, int *fnamelen)
 {
     int		l, len;
-    char_u	*newbuf;
+    WCHAR	*newbuf;
+    WCHAR	*wfname;
 
-    len = *fnamelen;
-    l = GetShortPathName((LPSTR)*fnamep, (LPSTR)*fnamep, len);
+    len = MAXPATHL;
+    newbuf = malloc(len * sizeof(*newbuf));
+    if (newbuf == NULL)
+	return FAIL;
+
+    wfname = enc_to_utf16(*fnamep, NULL);
+    if (wfname == NULL)
+    {
+	vim_free(newbuf);
+	return FAIL;
+    }
+
+    l = GetShortPathNameW(wfname, newbuf, len);
     if (l > len - 1)
     {
 	// If that doesn't work (not enough space), then save the string
 	// and try again with a new buffer big enough.
-	newbuf = vim_strnsave(*fnamep, l);
+	newbuf = vim_realloc(newbuf, (l + 1) * sizeof(*newbuf));
 	if (newbuf == NULL)
+	{
+	    vim_free(wfname);
 	    return FAIL;
-
-	vim_free(*bufp);
-	*fnamep = *bufp = newbuf;
-
+	}
 	// Really should always succeed, as the buffer is big enough.
-	l = GetShortPathName((LPSTR)*fnamep, (LPSTR)*fnamep, l+1);
+	l = GetShortPathNameW(wfname, newbuf, l+1);
     }
+    if (l != 0) {
+	char_u *p = utf16_to_enc(newbuf, NULL);
+	if (p != NULL)
+	{
+	    vim_free(*bufp);
+	    *fnamep = *bufp = p;
+	} else {
+	    vim_free(wfname);
+	    vim_free(newbuf);
+	    return FAIL;
+	}
+    }
+    vim_free(wfname);
+    vim_free(newbuf);
 
-    *fnamelen = l;
+    *fnamelen = l == 0 ? l : STRLEN(*bufp);
     return OK;
 }
 

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -50,22 +50,27 @@ get_short_pathname(char_u **fnamep, char_u **bufp, int *fnamelen)
     {
 	// If that doesn't work (not enough space), then save the string
 	// and try again with a new buffer big enough.
+	WCHAR *newbuf_t = newbuf;
 	newbuf = vim_realloc(newbuf, (l + 1) * sizeof(*newbuf));
 	if (newbuf == NULL)
 	{
 	    vim_free(wfname);
+	    vim_free(newbuf_t);
 	    return FAIL;
 	}
 	// Really should always succeed, as the buffer is big enough.
 	l = GetShortPathNameW(wfname, newbuf, l+1);
     }
-    if (l != 0) {
+    if (l != 0)
+    {
 	char_u *p = utf16_to_enc(newbuf, NULL);
 	if (p != NULL)
 	{
 	    vim_free(*bufp);
 	    *fnamep = *bufp = p;
-	} else {
+	}
+	else
+	{
 	    vim_free(wfname);
 	    vim_free(newbuf);
 	    return FAIL;

--- a/src/testdir/test_shortpathname.vim
+++ b/src/testdir/test_shortpathname.vim
@@ -1,6 +1,9 @@
 " Test for shortpathname ':8' extension.
 " Only for use on Win32 systems!
 
+set encoding=utf-8
+scriptencoding utf-8
+
 source check.vim
 CheckMSWindows
 
@@ -63,6 +66,35 @@ func Test_ColonEight()
   call delete(file2)
   call delete(file1)
   call delete(dir2, 'd')
+  call delete(dir1, 'd')
+
+  exe "cd " . save_dir
+endfunc
+
+func Test_ColonEight_MultiByte()
+  let save_dir = getcwd()
+
+  " This could change for CygWin to //cygdrive/c
+  let dir1 = 'c:/日本語のフォルダ'
+  if filereadable(dir1) || isdirectory(dir1)
+    call assert_report("Fatal: '" . dir1 . "' exists, cannot run test")
+    return
+  endif
+
+  let file1 = dir1 . '/日本語のファイル.txt'
+
+  call mkdir(dir1)
+  let resdir1 = substitute(fnamemodify(dir1, ':p:8'), '/$', '', '')
+  call assert_match('\V\^c:/日本語~1\$', resdir1)
+
+  let resfile1 = resdir1 . '/日本語~1.TXT'
+
+  call writefile([], file1)
+
+  call TestIt(file1, ':p:8', resfile1)
+
+  cd c:/
+  call delete(file1)
   call delete(dir1, 'd')
 
   exe "cd " . save_dir

--- a/src/testdir/test_shortpathname.vim
+++ b/src/testdir/test_shortpathname.vim
@@ -72,30 +72,18 @@ func Test_ColonEight()
 endfunc
 
 func Test_ColonEight_MultiByte()
-  let save_dir = getcwd()
+  let dir = 'Xtest'
 
-  " This could change for CygWin to //cygdrive/c
-  let dir1 = 'c:/日本語のフォルダ'
-  if filereadable(dir1) || isdirectory(dir1)
-    call assert_report("Fatal: '" . dir1 . "' exists, cannot run test")
-    return
-  endif
+  let file = dir . '/日本語のファイル.txt'
 
-  let file1 = dir1 . '/日本語のファイル.txt'
+  call mkdir(dir)
+  call writefile([], file)
 
-  call mkdir(dir1)
-  let resdir1 = substitute(fnamemodify(dir1, ':p:8'), '/$', '', '')
-  call assert_match('\V\^c:/日本語~1\$', resdir1)
+  let sfile = fnamemodify(file, ':8')
 
-  let resfile1 = resdir1 . '/日本語~1.TXT'
+  call assert_notequal(file, sfile)
+  call assert_match('\~', sfile)
 
-  call writefile([], file1)
-
-  call TestIt(file1, ':p:8', resfile1)
-
-  cd c:/
-  call delete(file1)
-  call delete(dir1, 'd')
-
-  exe "cd " . save_dir
+  call delete(file)
+  call delete(dir, 'd')
 endfunc


### PR DESCRIPTION
The current `get_short_pathname()` fails if multibyte characters are passed if the `encoding` is different from the code page. This PR fixes that problem.