### PR TITLE
Add dockerfile filetype for Containerfile

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -385,7 +385,7 @@ au BufNewFile,BufRead configure.in,configure.ac setf config
 au BufNewFile,BufRead *.cu,*.cuh		setf cuda
 
 " Dockerfile
-au BufNewFile,BufRead Dockerfile,*.Dockerfile	setf dockerfile
+au BufNewFile,BufRead Containerfile,Dockerfile,*.Dockerfile	setf dockerfile
 
 " WildPackets EtherPeek Decoder
 au BufNewFile,BufRead *.dcd			setf dcd

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -136,7 +136,7 @@ let s:filename_checks = {
     \ 'diff': ['file.diff', 'file.rej'],
     \ 'dircolors': ['.dir_colors', '.dircolors', '/etc/DIR_COLORS'],
     \ 'dnsmasq': ['/etc/dnsmasq.conf'],
-    \ 'dockerfile': ['Dockerfile', 'file.Dockerfile'],
+    \ 'dockerfile': ['Containerfile', 'Dockerfile', 'file.Dockerfile'],
     \ 'dosbatch': ['file.bat', 'file.sys'],
     \ 'dosini': ['.editorconfig', '/etc/yum.conf', 'file.ini'],
     \ 'dot': ['file.dot'],


### PR DESCRIPTION
Podman (https://github.com/containers/libpod) uses the same syntax as docker to specify how to build a container, but the file can be named either `Dockerfile` or `Containerfile` (see https://github.com/containers/libpod/blob/master/docs/podman-build.1.md).
This pull requests adds the `dockerfile` filetype for files named `Containerfile`.