### PR TITLE
Change Dockerfile syntax not to match "as" out of context.

### DIFF
--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -1,7 +1,7 @@
 " dockerfile.vim - Syntax highlighting for Dockerfiles
 " Maintainer:   Honza Pokorny <https://honza.ca>
 " Version:      0.6
-" Last Change:  2019 Aug 16
+" Last Change:  2019 Oct 31
 " License:      BSD
 
 
@@ -15,7 +15,7 @@ syntax case ignore
 
 syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\s/
 
-syntax match dockerfileKeyword /\v(AS)/
+syntax match dockerfileKeyword /\(^\s*FROM\s\+\S\+\s\+\)\@<=AS\ze /
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/
 


### PR DESCRIPTION
`AS` is only a keyword when used as `FROM image AS alias`, but the current syntax matches it anywhere not already matched, including inside of words. (For instance, it maches `as` in `RUN chpasswd`.)