### PR TITLE
travis,doc: Check duplicated document tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ script:
       "${SRCDIR}"/vim --not-a-term -u NONE -S "${SRCDIR}"/testdir/if_ver-2.vim -c quit > /dev/null
       cat if_ver.txt
     fi
-  - do_test make ${SHADOWOPT} ${TEST} && FOLD_MARKER=travis_fold
+  - do_test make ${SHADOWOPT} ${TEST} && make -C runtime/doc vimtags VIMEXE=../../"${SRCDIR}"/vim && FOLD_MARKER=travis_fold
   - echo -en "${FOLD_MARKER}:end:test\\r\\033[0K"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,10 @@ script:
       "${SRCDIR}"/vim --not-a-term -u NONE -S "${SRCDIR}"/testdir/if_ver-2.vim -c quit > /dev/null
       cat if_ver.txt
     fi
-  - do_test make ${SHADOWOPT} ${TEST} && make -C runtime/doc vimtags VIMEXE=../../"${SRCDIR}"/vim && FOLD_MARKER=travis_fold
+  - >
+    do_test make ${SHADOWOPT} ${TEST} &&
+    make -C runtime/doc vimtags VIMEXE=../../"${SRCDIR}"/vim &&
+    FOLD_MARKER=travis_fold
   - echo -en "${FOLD_MARKER}:end:test\\r\\033[0K"
 
 

--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -323,7 +323,7 @@ all: tags vim.man evim.man vimdiff.man vimtutor.man xxd.man $(CONVERTED)
 # Use Vim to generate the tags file.  Can only be used when Vim has been
 # compiled and installed.  Supports multiple languages.
 vimtags: $(DOCS)
-	$(VIMEXE) -u NONE -esX -c "helptags ++t ." -c quit
+	$(VIMEXE) -eX -u doctags.vim
 
 # Use "doctags" to generate the tags file.  Only works for English!
 tags: doctags $(DOCS)

--- a/runtime/doc/doctags.vim
+++ b/runtime/doc/doctags.vim
@@ -1,0 +1,6 @@
+" This script makes a tags file for help text.
+"
+" Usage: vim -eX -u doctags.vim
+
+helptags ++t .
+qa!


### PR DESCRIPTION
Add a script to make doc tags and report an error when duplicated tags are found.
Use it from Travis CI.

See also #5149.