### PR TITLE
Remain third character(`z`) of listchars'tab(`tab:xy[z]`) on breakindenting first line

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1175,6 +1175,7 @@ win_line(
 # endif
 		    p_extra = NULL;
 		    c_extra = ' ';
+		    c_final = NUL;
 		    n_extra = get_breakindent_win(wp,
 				       ml_get_buf(wp->w_buffer, lnum, FALSE));
 		    // Correct end of highlighted area for 'breakindent',

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -31,6 +31,7 @@ func s:close_windows(...)
   exe get(a:000, 0, '')
 endfunc
 
+if 0
 func Test_breakindent01()
   " simple breakindent test
   call s:test_windows('setl briopt=min:0')
@@ -614,3 +615,45 @@ func Test_breakindent16_vartabs()
   call s:compare_lines(expect, lines)
   call s:close_windows('set vts&')
 endfunc
+endif
+
+func Test_breakindent17_vartabs()
+  if !has("vartabs")
+    return
+  endif
+  let s:input = ""
+  call s:test_windows('setl breakindent list listchars=tab:<-> showbreak=+++')
+  call setline(1, "\t" . repeat('a', 63))
+  vert resize 30
+  norm! 1gg$
+  redraw!
+  let lines = s:screen_lines(1, 30)
+  let expect = [
+	\ "<-->aaaaaaaaaaaaaaaaaaaaaaaaaa",
+	\ "    +++aaaaaaaaaaaaaaaaaaaaaaa",
+	\ "    +++aaaaaaaaaaaaaa         ",
+	\ ]
+  call s:compare_lines(expect, lines)
+  call s:close_windows('set breakindent& list& listchars& showbreak&')
+endfunc
+
+func Test_breakindent18_vartabs()
+  if !has("vartabs")
+    return
+  endif
+  let s:input = ""
+  call s:test_windows('setl breakindent list listchars=tab:<->')
+  call setline(1, "\t" . repeat('a', 63))
+  vert resize 30
+  norm! 1gg$
+  redraw!
+  let lines = s:screen_lines(1, 30)
+  let expect = [
+	\ "<-->aaaaaaaaaaaaaaaaaaaaaaaaaa",
+	\ "    aaaaaaaaaaaaaaaaaaaaaaaaaa",
+	\ "    aaaaaaaaaaa               ",
+	\ ]
+  call s:compare_lines(expect, lines)
+  call s:close_windows('set breakindent& list& listchars&')
+endfunc
+

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -31,7 +31,6 @@ func s:close_windows(...)
   exe get(a:000, 0, '')
 endfunc
 
-if 0
 func Test_breakindent01()
   " simple breakindent test
   call s:test_windows('setl briopt=min:0')
@@ -615,7 +614,6 @@ func Test_breakindent16_vartabs()
   call s:compare_lines(expect, lines)
   call s:close_windows('set vts&')
 endfunc
-endif
 
 func Test_breakindent17_vartabs()
   if !has("vartabs")


### PR DESCRIPTION

__to reproduce__
```
>gvim -N -u NONE
:set breakindent list listchars=tab:<-> showbreak=+++
:call setline(1, "\t" . repeat('a', 300))
```

__before__
![before](https://user-images.githubusercontent.com/1595779/68078861-6b0f0380-fe22-11e9-960d-91877f6b6b4d.png)

__after__
![after](https://user-images.githubusercontent.com/1595779/68078847-326f2a00-fe22-11e9-8385-d6056b941a99.png)

I'll add this test. Please wait marging this PR.