### PR TITLE
Fix "make vimtags" to actually return error code if it failed

### DIFF
--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -325,7 +325,9 @@ all: tags vim.man evim.man vimdiff.man vimtutor.man xxd.man $(CONVERTED)
 vimtags: $(DOCS)
 	@if which $(VIMEXE) >/dev/null; then \
 	  $(VIMEXE) --clean -eX -u doctags.vim >/dev/null; \
+	  EXIT_CODE=$$?; \
 	  echo "help tags updated"; \
+	  exit $$EXIT_CODE; \
 	  else echo "vim executable $(VIMEXE) not found; help tags not updated"; fi
 
 # Use "doctags" to generate the tags file.  Only works for English!


### PR DESCRIPTION
Seems like `make vimtags` suffered some regressions in that it no longer exits with the proper exit code meaning it always suceeds.

Make sure to exit with an error code if generating tags failed so we can fail CI properly. The previous Makefile rule ignores the exit code of the `vimtags` script and will only print out a message but exit with a non-zero error code.