### PR TITLE
Remove setup.vim from OS-specific setup script

### DIFF
--- a/src/testdir/amiga.vim
+++ b/src/testdir/amiga.vim
@@ -2,5 +2,3 @@
 set shell=csh
 map! /tmp t:
 cmap !rm !Delete all
-
-source setup.vim

--- a/src/testdir/dos.vim
+++ b/src/testdir/dos.vim
@@ -5,5 +5,3 @@ set shell=c:\COMMAND.COM shellquote= shellxquote= shellcmdflag=/c shellredir=>
 if executable("cmd.exe")
    set shell=cmd.exe
 endif
-
-source setup.vim

--- a/src/testdir/unix.vim
+++ b/src/testdir/unix.vim
@@ -9,5 +9,3 @@ if 1
   " where to ask about their own user settings.
   let g:tester_HOME = $HOME
 endif
-
-source setup.vim

--- a/src/testdir/vms.vim
+++ b/src/testdir/vms.vim
@@ -2,5 +2,3 @@
 
 " Do not use any swap files
 set noswapfile
-
-source setup.vim


### PR DESCRIPTION
When `make test` is executed, `src/testdir/XfakeHOME/.viminfo` remains.
This is a file created by [`setup.vim`](https://github.com/vim/vim/blob/e5a3272d32ad52f905ef3e66991871dbef2245e7/src/testdir/setup.vim#L31) called by [`unix.vim`](https://github.com/vim/vim/blob/e5a3272d32ad52f905ef3e66991871dbef2245e7/src/testdir/unix.vim#L13) when [`summarize.vim`](https://github.com/vim/vim/blob/e5a3272d32ad52f905ef3e66991871dbef2245e7/src/testdir/Makefile#L57) is executed.
In the first place, I think `XfakeHOME` does not have to be created when `summarize.vim` is executed.
Moreover, `setup.vim` is also called in [`runtest.vim`](https://github.com/vim/vim/blob/e5a3272d32ad52f905ef3e66991871dbef2245e7/src/testdir/runtest.vim#L55), so it doesn't have to be called in the setup for each OS.
So I deleted the part that calls `setup.vim` from the setup script of each OS.