### PR TITLE
Improve test coverage of gf normal command

### DIFF
--- a/src/testdir/test_gf.vim
+++ b/src/testdir/test_gf.vim
@@ -99,3 +99,28 @@ func Test_gf()
   call delete('Xtest1')
   call delete('Xtestgf')
 endfunc
+
+func Test_gf_visual()
+  call writefile([], "Xtest_gf_visual")
+  new
+  call setline(1, 'XXXtest_gf_visualXXX')
+  set hidden
+
+  " Visually select Xtest_gf_visual and use gf to go to that file
+  norm! ttvtXgf
+  call assert_equal('Xtest_gf_visual', bufname('%'))
+
+  bwipe!
+  call delete('Xtest_gf_visual')
+  set hidden&
+endfunc
+
+func Test_gf_error()
+  new
+  call assert_fails('normal gf', 'E446:')
+  call assert_fails('normal gF', 'E446:')
+  call setline(1, '/doesnotexist')
+  call assert_fails('normal gf', 'E447:')
+  call assert_fails('normal gF', 'E447:')
+  bwipe!
+endfunc


### PR DESCRIPTION
This PR improves test coverage of the normal `gf` command to:
* test `gf` in visual mode
* and test errors `E446` and `E447`

Those were not tested according to codecov:

https://codecov.io/gh/vim/vim/src/3b991527e8167f25ad1dfe780b9633c153600955/src/findfile.c#L1936
https://codecov.io/gh/vim/vim/src/3b991527e8167f25ad1dfe780b9633c153600955/src/findfile.c#L1991
https://codecov.io/gh/vim/vim/src/3b991527e8167f25ad1dfe780b9633c153600955/src/findfile.c#L2134