### PR TITLE
Fixed memory leak when re-assigning w_border_highlight

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -755,12 +755,18 @@ apply_general_options(win_T *wp, dict_T *dict)
 	    {
 		str = tv_get_string(&li->li_tv);
 		if (*str != NUL)
+		{
+		    vim_free(wp->w_border_highlight[i]);
 		    wp->w_border_highlight[i] = vim_strsave(str);
+		}
 	    }
 	    if (list->lv_len == 1 && wp->w_border_highlight[0] != NULL)
 		for (i = 1; i < 4; ++i)
+		{
+		    vim_free(wp->w_border_highlight[i]);
 		    wp->w_border_highlight[i] =
 					vim_strsave(wp->w_border_highlight[0]);
+		}
 	}
     }
 


### PR DESCRIPTION
This PR fixes a memory leak detected when running `make test_popwin` with valgrind:
```
==7403== 22 bytes in 4 blocks are definitely lost in loss record 29 of 140
==7403==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7403==    by 0x51AEE6: lalloc (misc2.c:926)
==7403==    by 0x51AE89: alloc (misc2.c:829)
==7403==    by 0x51B5E5: vim_strsave (misc2.c:1278)
==7403==    by 0x57594E: apply_general_options (popupwin.c:758)
==7403==    by 0x57533A: f_popup_setoptions (popupwin.c:2515)
==7403==    by 0x467F90: call_internal_func (evalfunc.c:968)
==7403==    by 0x6564BA: call_func (userfunc.c:1665)
==7403==    by 0x655C62: get_func_tv (userfunc.c:482)
==7403==    by 0x65C460: ex_call (userfunc.c:3175)
==7403==    by 0x494EA1: do_one_cmd (ex_docmd.c:2482)
==7403==    by 0x491DED: do_cmdline (ex_docmd.c:975)
==7403==    by 0x65808A: call_user_func (userfunc.c:1054)
==7403==    by 0x6563F1: call_func (userfunc.c:1637)
==7403==    by 0x655C62: get_func_tv (userfunc.c:482)
==7403==    by 0x65C460: ex_call (userfunc.c:3175)
==7403==    by 0x494EA1: do_one_cmd (ex_docmd.c:2482)
==7403==    by 0x491DED: do_cmdline (ex_docmd.c:975)
==7403==    by 0x46287C: ex_execute (eval.c:6083)
==7403==    by 0x494EA1: do_one_cmd (ex_docmd.c:2482)
==7403==    by 0x491DED: do_cmdline (ex_docmd.c:975)
==7403==    by 0x65808A: call_user_func (userfunc.c:1054)
==7403==    by 0x6563F1: call_func (userfunc.c:1637)
==7403==    by 0x655C62: get_func_tv (userfunc.c:482)
==7403==    by 0x65C460: ex_call (userfunc.c:3175)
==7403==    by 0x494EA1: do_one_cmd (ex_docmd.c:2482)
==7403==    by 0x491DED: do_cmdline (ex_docmd.c:975)
==7403==    by 0x5C5142: do_source (scriptfile.c:1214)
==7403==    by 0x5C4686: cmd_source (scriptfile.c:805)
==7403==    by 0x5C459B: ex_source (scriptfile.c:831)
==7403==    by 0x494EA1: do_one_cmd (ex_docmd.c:2482)
==7403==    by 0x491DED: do_cmdline (ex_docmd.c:975)
==7403==    by 0x492BD5: do_cmdline_cmd (ex_docmd.c:587)
==7403==    by 0x6AF7AC: exe_commands (main.c:3130)
==7403==    by 0x6AE72C: vim_main2 (main.c:795)
```