### PR TITLE
Fixed memory leak found with "make test_terminal" using valgrind

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -846,6 +846,7 @@ ex_terminal(exarg_T *eap)
 	    term_start(NULL, argv, &opt, eap->forceit ? TERM_START_FORCEIT : 0);
 	vim_free(tofree1);
 	vim_free(tofree2);
+	vim_free(argv);
 	goto theend;
 #else
 # ifdef MSWIN


### PR DESCRIPTION
This PR fixes a memory leak found when running
`make test_terminal` with valgrind:
```
==21966== 40 bytes in 1 blocks are definitely lost in loss record 49 of 142
==21966==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21966==    by 0x51ADA6: lalloc (misc2.c:926)
==21966==    by 0x51AD49: alloc (misc2.c:829)
==21966==    by 0x51FE12: mch_parse_cmd (misc2.c:4383)
==21966==    by 0x567186: unix_build_argv (os_unix.c:4318)
==21966==    by 0x63466A: ex_terminal (terminal.c:845)
==21966==    by 0x494DA1: do_one_cmd (ex_docmd.c:2482)
==21966==    by 0x491CED: do_cmdline (ex_docmd.c:975)
==21966==    by 0x657F6A: call_user_func (userfunc.c:1054)
==21966==    by 0x6562D1: call_func (userfunc.c:1637)
==21966==    by 0x655B42: get_func_tv (userfunc.c:482)
==21966==    by 0x65C340: ex_call (userfunc.c:3175)
==21966==    by 0x494DA1: do_one_cmd (ex_docmd.c:2482)
==21966==    by 0x491CED: do_cmdline (ex_docmd.c:975)
==21966==    by 0x4627EC: ex_execute (eval.c:6083)
==21966==    by 0x494DA1: do_one_cmd (ex_docmd.c:2482)
==21966==    by 0x491CED: do_cmdline (ex_docmd.c:975)
==21966==    by 0x657F6A: call_user_func (userfunc.c:1054)
==21966==    by 0x6562D1: call_func (userfunc.c:1637)
==21966==    by 0x655B42: get_func_tv (userfunc.c:482)
==21966==    by 0x65C340: ex_call (userfunc.c:3175)
==21966==    by 0x494DA1: do_one_cmd (ex_docmd.c:2482)
==21966==    by 0x491CED: do_cmdline (ex_docmd.c:975)
==21966==    by 0x5C5032: do_source (scriptfile.c:1214)
==21966==    by 0x5C4576: cmd_source (scriptfile.c:805)
==21966==    by 0x5C448B: ex_source (scriptfile.c:831)
==21966==    by 0x494DA1: do_one_cmd (ex_docmd.c:2482)
==21966==    by 0x491CED: do_cmdline (ex_docmd.c:975)
==21966==    by 0x492AD5: do_cmdline_cmd (ex_docmd.c:587)
==21966==    by 0x6AF65C: exe_commands (main.c:3130)
==21966==    by 0x6AE5DC: vim_main2 (main.c:795)
==21966==    by 0x6ABCAA: main (main.c:444)
```