### PR TITLE
Issue #5001 - fix inittab syntax highlighting

### DIFF
--- a/runtime/syntax/inittab.vim
+++ b/runtime/syntax/inittab.vim
@@ -1,5 +1,4 @@
 " Vim syntax file
-" This is a GENERATED FILE. Please always refer to source file at the URI below.
 " Language: SysV-compatible init process control file `inittab'
 " Maintainer: David Ne\v{c}as (Yeti) <yeti@physics.muni.cz>
 " Last Change: 2002-09-13

--- a/runtime/syntax/inittab.vim
+++ b/runtime/syntax/inittab.vim
@@ -3,7 +3,6 @@
 " Language: SysV-compatible init process control file `inittab'
 " Maintainer: David Ne\v{c}as (Yeti) <yeti@physics.muni.cz>
 " Last Change: 2002-09-13
-" URL: http://physics.muni.cz/~yeti/download/syntax/inittab.vim
 
 " Setup
 " quit when a syntax file was already loaded

--- a/runtime/syntax/inittab.vim
+++ b/runtime/syntax/inittab.vim
@@ -2,7 +2,7 @@
 " Language: SysV-compatible init process control file `inittab'
 " Maintainer: Donovan Keohane <donovan.keohane@gmail.com>
 " Previous Maintainer: David Ne\v{c}as (Yeti) <yeti@physics.muni.cz>
-" Last Change: 2002-09-13
+" Last Change: 2019-11-19
 
 " Setup
 " quit when a syntax file was already loaded

--- a/runtime/syntax/inittab.vim
+++ b/runtime/syntax/inittab.vim
@@ -1,6 +1,7 @@
 " Vim syntax file
 " Language: SysV-compatible init process control file `inittab'
-" Maintainer: David Ne\v{c}as (Yeti) <yeti@physics.muni.cz>
+" Maintainer: Donovan Keohane <donovan.keohane@gmail.com>
+" Previous Maintainer: David Ne\v{c}as (Yeti) <yeti@physics.muni.cz>
 " Last Change: 2002-09-13
 
 " Setup

--- a/runtime/syntax/inittab.vim
+++ b/runtime/syntax/inittab.vim
@@ -25,7 +25,7 @@ syn region inittabShString start=+"+ end=+"+ skip=+\\\\\|\\\"+ contained
 syn region inittabShString start=+'+ end=+'+ contained
 syn match inittabShOption "\s[-+][[:alnum:]]\+"ms=s+1 contained
 syn match inittabShOption "\s--[:alnum:][-[:alnum:]]*"ms=s+1 contained
-syn match inittabShCommand "/\S\+" contained
+syn match inittabShCommand "\S\+" contained
 syn cluster inittabSh add=inittabShOption,inittabShString,inittabShCommand
 
 " Keywords
@@ -39,7 +39,7 @@ syn match inittabColonAction ":" contained nextgroup=inittabAction,inittabError
 syn match inittabAction "\w\+" contained nextgroup=inittabColonProcess,inittabError contains=inittabActionName
 syn match inittabColonProcess ":" contained nextgroup=inittabProcessPlus,inittabProcess,inittabError
 syn match inittabProcessPlus "+" contained nextgroup=inittabProcess,inittabError
-syn region inittabProcess start="/" end="$" transparent oneline contained contains=@inittabSh,inittabComment
+syn region inittabProcess start="\S" end="$" transparent oneline contained contains=@inittabSh,inittabComment
 
 " Define the default highlighting
 


### PR DESCRIPTION
## Problem
The syntax highlighting for inittab requires that the process field has a leading slash, else it will be highlighted as an error.
See #5001 

## Solution
* Replaced the required leading slash from the `inittabProcess` region with `\S`.
* Removed the required leading slash from the `inittabShCommand` match.
