### PR TITLE
Fix for "cursor jumps beyond end of line when pressing `$` and text is concealed #5214"

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -1175,6 +1175,10 @@ curs_columns(
 	redraw_later(SOME_VALID);
 #endif
 
+    // Now w_leftcol corresponds to wrow, wcol and virtcol, no need
+    // to invalidate them just because of its change.
+    curwin->w_valid_leftcol = curwin->w_leftcol;
+
     curwin->w_valid |= VALID_WCOL|VALID_WROW|VALID_VIRTCOL;
 }
 

--- a/src/testdir/test_matchadd_conceal.vim
+++ b/src/testdir/test_matchadd_conceal.vim
@@ -316,3 +316,31 @@ func Test_cursor_column_in_concealed_line_after_window_scroll()
   call StopVimInTerminal(buf)
   call delete('Xcolesearch')
 endfunc
+
+func Test_cursor_column_in_concealed_line_after_leftcol_change()
+  CheckRunVimInTerminal
+
+  " Test for issue #5214 fix.
+  let lines =<< trim END
+    0put = 'ab' .. repeat('-', &columns) .. 'c'
+    call matchadd('Conceal', '-')
+    set nowrap ss=0 cole=3 cocu=n
+  END
+  call writefile(lines, 'Xcurs-columns')
+  let buf = RunVimInTerminal('-S Xcurs-columns', {})
+
+  " Go to the end of the line (3 columns beyond the end of the screen).
+  " Horizontal scroll would center the cursor in the screen line, but conceal
+  " makes it go to screen column 1.
+  call term_sendkeys(buf, "$")
+  call term_wait(buf)
+
+  " Are the concealed parts of the current line really hidden?
+  call assert_equal('c', term_getline(buf, '.'))
+
+  " BugFix check: Is the window's cursor column properly updated for conceal?
+  call assert_equal(1, term_getcursor(buf)[1])
+
+  call StopVimInTerminal(buf)
+  call delete('Xcurs-columns')
+endfunc


### PR DESCRIPTION
To fix the issue I propose this PR. It provides a test too. For mail readers' convenience, the patch is listed below.

Tom

```diff
diff --git a/src/move.c b/src/move.c
index d340f0223..9e9c90e10 100644
--- a/src/move.c
+++ b/src/move.c
@@ -1175,6 +1175,10 @@ curs_columns(
 	redraw_later(SOME_VALID);
 #endif
 
+    // Now w_leftcol corresponds to wrow, wcol and virtcol, no need
+    // to invalidate them just because of its change.
+    curwin->w_valid_leftcol = curwin->w_leftcol;
+
     curwin->w_valid |= VALID_WCOL|VALID_WROW|VALID_VIRTCOL;
 }
 
diff --git a/src/testdir/test_matchadd_conceal.vim b/src/testdir/test_matchadd_conceal.vim
index 83eadce5a..25bff3dea 100644
--- a/src/testdir/test_matchadd_conceal.vim
+++ b/src/testdir/test_matchadd_conceal.vim
@@ -316,3 +316,31 @@ func Test_cursor_column_in_concealed_line_after_window_scroll()
   call StopVimInTerminal(buf)
   call delete('Xcolesearch')
 endfunc
+
+func Test_cursor_column_in_concealed_line_after_leftcol_change()
+  CheckRunVimInTerminal
+
+  " Test for issue #5214 fix.
+  let lines =<< trim END
+    0put = 'ab' .. repeat('-', &columns) .. 'c'
+    call matchadd('Conceal', '-')
+    set nowrap ss=0 cole=3 cocu=n
+  END
+  call writefile(lines, 'Xcurs-columns')
+  let buf = RunVimInTerminal('-S Xcurs-columns', {})
+
+  " Go to the end of the line (3 columns beyond the end of the screen).
+  " Horizontal scroll would center the cursor in the screen line, but conceal
+  " makes it go to screen column 1.
+  call term_sendkeys(buf, "$")
+  call term_wait(buf)
+
+  " Are the concealed parts of the current line really hidden?
+  call assert_equal('c', term_getline(buf, '.'))
+
+  " BugFix check: Is the window's cursor column properly updated for conceal?
+  call assert_equal(1, term_getcursor(buf)[1])
+
+  call StopVimInTerminal(buf)
+  call delete('Xcurs-columns')
+endfunc
```