### PR TITLE
Test double/triple/quadruple left click to visually select.

### DIFF
--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -744,6 +744,82 @@ func Test_term_mouse_double_click_to_create_tab()
   set mousetime&
 endfunc
 
+" Test double/triple/quadruple click in normal mode to visually select.
+func Test_term_mouse_multiple_clicks_to_visually_select()
+  let save_mouse = &mouse
+  let save_term = &term
+  let save_ttymouse = &ttymouse
+  call test_override('no_query_mouse', 1)
+  set mouse=a term=xterm
+  new
+
+  for ttymouse_val in s:ttymouse_values + s:ttymouse_dec
+    let msg = 'ttymouse=' .. ttymouse_val
+    exe 'set ttymouse=' .. ttymouse_val
+    call setline(1, ['foo [foo bar] foo', 'foo'])
+
+    " Double-click on word should visually select the word.
+    call MouseLeftClick(1, 2)
+    call assert_equal(0, getcharmod(), msg)
+    call MouseLeftRelease(1, 2)
+    call MouseLeftClick(1, 2)
+    call assert_equal(32, getcharmod(), msg) " double-click
+    call MouseLeftRelease(1, 2)
+    call assert_equal('v', mode(), msg)
+    norm! r1
+    call assert_equal(['111 [foo bar] foo', 'foo'], getline(1, '$'), msg)
+
+    " Double-click on opening square bracket should visually
+    " select the whole [foo bar].
+    call MouseLeftClick(1, 5)
+    call assert_equal(0, getcharmod(), msg)
+    call MouseLeftRelease(1, 5)
+    call MouseLeftClick(1, 5)
+    call assert_equal(32, getcharmod(), msg) " double-click
+    call MouseLeftRelease(1, 5)
+    call assert_equal('v', mode(), msg)
+    norm! r2
+    call assert_equal(['111 222222222 foo', 'foo'], getline(1, '$'), msg)
+
+    " Triple-click should visually select the whole line.
+    call MouseLeftClick(1, 3)
+    call assert_equal(0, getcharmod(), msg)
+    call MouseLeftRelease(1, 3)
+    call MouseLeftClick(1, 3)
+    call assert_equal(32, getcharmod(), msg) " double-click
+    call MouseLeftRelease(1, 3)
+    call MouseLeftClick(1, 3)
+    call assert_equal(64, getcharmod(), msg) " triple-click
+    call MouseLeftRelease(1, 3)
+    call assert_equal('V', mode(), msg)
+    norm! r3
+    call assert_equal(['33333333333333333', 'foo'], getline(1, '$'), msg)
+
+    " Quadruple-click should start visual block select.
+    call MouseLeftClick(1, 2)
+    call assert_equal(0, getcharmod(), msg)
+    call MouseLeftRelease(1, 2)
+    call MouseLeftClick(1, 2)
+    call assert_equal(32, getcharmod(), msg) " double-click
+    call MouseLeftRelease(1, 2)
+    call MouseLeftClick(1, 2)
+    call assert_equal(64, getcharmod(), msg) " triple-click
+    call MouseLeftRelease(1, 2)
+    call MouseLeftClick(1, 2)
+    call assert_equal(96, getcharmod(), msg) " quadruple-click
+    call MouseLeftRelease(1, 2)
+    call assert_equal("\<c-v>", mode(), msg)
+    norm! r4
+    call assert_equal(['34333333333333333', 'foo'], getline(1, '$'), msg)
+  endfor
+
+  let &mouse = save_mouse
+  let &term = save_term
+  let &ttymouse = save_ttymouse
+  call test_override('no_query_mouse', 0)
+  bwipe!
+endfunc
+
 func Test_xterm_mouse_click_in_fold_columns()
   new
   let save_mouse = &mouse

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -674,7 +674,7 @@ func Test_term_mouse_drag_to_move_tab()
         \              'Tab page 2',
         \              '    Xtab1'], a, msg)
 
-    " Click elsewhere than so that click in next iteration is not
+    " Click elsewhere so that click in next iteration is not
     " interpreted as unwanted double-click.
     call MouseLeftClick(row, 11)
     call MouseLeftRelease(row, 11)

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -674,8 +674,11 @@ func Test_term_mouse_drag_to_move_tab()
         \              'Tab page 2',
         \              '    Xtab1'], a, msg)
 
-    " brief sleep to avoid causing a double-click
-    sleep 20m
+    " Click elsewhere than so that click in next iteration is not
+    " interpreted as unwanted double-click.
+    call MouseLeftClick(row, 11)
+    call MouseLeftRelease(row, 11)
+
     %bwipe!
   endfor
 
@@ -693,23 +696,15 @@ func Test_term_mouse_double_click_to_create_tab()
   call test_override('no_query_mouse', 1)
   " Set 'mousetime' to a small value, so that double-click works but we don't
   " have to wait long to avoid a triple-click.
-  set mouse=a term=xterm mousetime=100
+  set mouse=a term=xterm mousetime=200
   let row = 1
   let col = 10
 
-  let round = 0
   for ttymouse_val in s:ttymouse_values + s:ttymouse_dec
     let msg = 'ttymouse=' .. ttymouse_val
     exe 'set ttymouse=' .. ttymouse_val
     e Xtab1
     tabnew Xtab2
-
-    if round > 0
-      " We need to sleep, or else the first MouseLeftClick() will be
-      " interpreted as a spurious triple-click.
-      sleep 100m
-    endif
-    let round += 1
 
     let a = split(execute(':tabs'), "\n")
     call assert_equal(['Tab page 1',
@@ -734,6 +729,11 @@ func Test_term_mouse_double_click_to_create_tab()
         \              'Tab page 3',
         \              '    Xtab2'], a, msg)
 
+    " Click elsewhere so that click in next iteration is not
+    " interpreted as unwanted double click.
+    call MouseLeftClick(row, col + 1)
+    call MouseLeftRelease(row, col + 1)
+
     %bwipe!
   endfor
 
@@ -750,7 +750,7 @@ func Test_term_mouse_multiple_clicks_to_visually_select()
   let save_term = &term
   let save_ttymouse = &ttymouse
   call test_override('no_query_mouse', 1)
-  set mouse=a term=xterm
+  set mouse=a term=xterm mousetime=200
   new
 
   for ttymouse_val in s:ttymouse_values + s:ttymouse_dec
@@ -816,6 +816,7 @@ func Test_term_mouse_multiple_clicks_to_visually_select()
   let &mouse = save_mouse
   let &term = save_term
   let &ttymouse = save_ttymouse
+  set mousetime&
   call test_override('no_query_mouse', 0)
   bwipe!
 endfunc


### PR DESCRIPTION
This PR tests double, triple and quadruple clicks to visually select:
- double-click visually selects a word or matching pairs like [...] ("v" mode)
- triple-click visually selects the line ("V" mode)
- quadruple-click starts block visual mode (CTRL-V mode)
