### PR TITLE
Fixed compilation warning: implicit declaration of popup_left_extra

### DIFF
--- a/src/proto/popupwin.pro
+++ b/src/proto/popupwin.pro
@@ -7,6 +7,7 @@ void popup_set_firstline(win_T *wp);
 int popup_is_in_scrollbar(win_T *wp, int row, int col);
 void popup_handle_scrollbar_click(win_T *wp, int row, int col);
 int popup_top_extra(win_T *wp);
+int popup_left_extra(win_T *wp);
 int popup_height(win_T *wp);
 int popup_width(win_T *wp);
 int popup_extra_width(win_T *wp);


### PR DESCRIPTION
PR fixes this compilation warning with gcc-7.4:
```
gcc -c -I. -Iproto -DHAVE_CONFIG_H     -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1  -g -O0 -fsanitize=address -fno-omit-frame-pointer -DEXITFREE -DABORT_ON_INTERNAL_ERROR    -o objects/evalfunc.o evalfunc.c
gcc -c -I. -Iproto -DHAVE_CONFIG_H     -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1  -g -O0 -fsanitize=address -fno-omit-frame-pointer -DEXITFREE -DABORT_ON_INTERNAL_ERROR    -o objects/mouse.o mouse.c
mouse.c: In function ‘f_getmousepos’:
mouse.c:3043:17: warning: implicit declaration of function ‘popup_left_extra’; did you mean ‘popup_top_extra’? [-Wimplicit-function-declaration]
      left_off = popup_left_extra(wp);
                 ^~~~~~~~~~~~~~~~
                 popup_top_extra
```