### PR TITLE
Fix test_xhelpgrep() for 160 > columns

### DIFF
--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -620,7 +620,8 @@ func s:test_xhelpgrep(cchar)
   call assert_true(&buftype == 'help')
   call assert_true(winnr() == 1)
   " See jump_to_help_window() for details
-  if winwidth(w2) != &columns && winwidth(w2) < 80
+  let w2_width = winwidth(w2)
+  if w2_width != &columns && w2_width < 80
     call assert_equal(['col', [['leaf', w3],
           \ ['row', [['leaf', w2], ['leaf', w1]]]]], winlayout())
   else

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -619,8 +619,14 @@ func s:test_xhelpgrep(cchar)
   let w3 = win_getid()
   call assert_true(&buftype == 'help')
   call assert_true(winnr() == 1)
-  call assert_equal(['col', [['leaf', w3],
-        \ ['row', [['leaf', w2], ['leaf', w1]]]]], winlayout())
+  " See jump_to_help_window() for details
+  if winwidth(w2) != &columns && winwidth(w2) < 80
+    call assert_equal(['col', [['leaf', w3],
+          \ ['row', [['leaf', w2], ['leaf', w1]]]]], winlayout())
+  else
+    call assert_equal(['row', [['col', [['leaf', w3], ['leaf', w2]]],
+          \ ['leaf', w1]]] , winlayout())
+  endif
 
   new | only
   set buftype=help


### PR DESCRIPTION
**Describe the bug**
I found that Test_helpgrep() in testdir/test_quickfix.vim fails on my bench. This causes when &column >= 160.
```
Found errors in Test_helpgrep():
function RunTheTest[40]..Test_helpgrep[1]..<SNR>5_test_xhelpgrep line 42: Expected ['col', [['leaf', 1067], ['row', [['leaf', 1066], ['leaf', 1065]]]]] but got ['row', [['col', [[
'leaf', 1067], ['leaf', 1066]]], ['leaf', 1065]]]
function RunTheTest[40]..Test_helpgrep[3]..<SNR>5_test_xhelpgrep line 42: Expected ['col', [['leaf', 1075], ['row', [['leaf', 1074], ['leaf', 1073]]]]] but got ['row', [['col', [[
'leaf', 1075], ['leaf', 1074]]], ['leaf', 1073]]]                                                                                                                                  Makefile:75: recipe for target 'test_quickfix' failed
make[1]: *** [test_quickfix] Error 1                                                                                                                                               
```

**To Reproduce**
1. Set terminal column size to 160 or more.
2. Type `make test` or `make test_quickfix`

**Expected behavior**
No error regardless of the terminal column size.

**Environment (please complete the following information):**
 - Vim: v8.1.2321
 - OS: Ubuntu 18.04
 - mintty