### PR TITLE
win32: Drop support for old msvc

### DIFF
--- a/src/INSTALLpc.txt
+++ b/src/INSTALLpc.txt
@@ -44,7 +44,7 @@ Contents:
 The currently recommended way (that means it has been verified to work) is
 using the "Visual Studio Community 2015" installation.  This includes the SDK
 needed to target Windows XP.  But not older Windows versions (95, 98), see
-|msvc-2008-express| below for that
+"OLDER VERSIONS" below for that.
 
 
 1. Microsoft Visual C++
@@ -62,12 +62,8 @@ under "Universal Windows App Development Tools"
 Visual Studio
 -------------
 
-Building with Visual Studio (VS 98, VS .NET, VS .NET 2003, VS 2005, VS 2008,
-VS2010, VS2012, VS2013 and VS2015) is straightforward. (These instructions
-should also work for VS 4 and VS 5.)
-
-Using VS C++ 2008 Express is recommended if you need the binary to run on
-Windows 95 or 97, see |msvc-2008-express| below.
+Building with Visual Studio (VS2010, VS2012, VS2013, VS2015, VS2017 and VS2019)
+is straightforward.
 
 To build Vim from the command line with MSVC, use Make_mvc.mak.
 Visual Studio installed a batch file called vcvars32.bat, which you must
@@ -82,33 +78,13 @@ nmake -f Make_mvc.mak PERL=C:\Perl PYTHON=C:\Python etc.
 Make_mvc.mak allows a Vim to be built with various different features and
 debug support.
 
-For compiling Gvim with IME support on far-east Windows, add IME=yes
+For compiling gVim with IME support on far-east Windows, add IME=yes
 to the parameters you pass to Make_mvc.mak.
 
 See the specific files for comments and options.
 
 These files have been supplied by George V. Reilly, Ben Singer, Ken Scott and
 Ron Aaron; they have been tested.
-
-
-Visual C++ 2008 Express Edition       *msvc-2008-express*
--------------------------------
-
-Visual C++ 2008 Express Edition can be downloaded for free from:
-    http://www.microsoft.com/express/downloads/
-This includes the IDE and the debugger.
-
-To set the environment execute the msvc2008.bat script.  You can then build
-Vim with Make_mvc.mak.
-
-For building 64 bit binaries you also need to install the SDK:
-"Microsoft Windows SDK for Windows 7 and .NET Framework 3.5 SP1"
-You don't need the examples and documentation.
-
-If you get an error that Win32.mak can't be found, you have to set the
-variable SDK_INCLUDE_DIR.  For example, on Windows 10, installation of MSVC
-puts include files in the following directory:
-    set SDK_INCLUDE_DIR=C:\Program Files\Microsoft SDKs\Windows\v6.0A\Include
 
 
 Visual C++ 2010 Express Edition       *msvc-2010-express*
@@ -162,6 +138,9 @@ compiler by using the "x64" option:
 The following Visual C++ team blog can serve as a reference page:
     http://blogs.msdn.com/b/vcblog/archive/2012/10/08/windows-xp-targeting-with-c-in-visual-studio-2012.aspx
 
+VC 2019 dropped support for targeting Windows XP.  If you want a binary that
+targeting Windows XP, use VC 2017 or earlier.
+
 
 Cross compile support for Windows on ARM64
 ------------------------------------------
@@ -178,7 +157,8 @@ The minimal supported version is Windows XP. Building with older compilers
 might still work, but these instructions might be outdated.
 
 If you need the executable to run on Windows 98 or ME, use the 2003 one
-|msvc-2003-toolkit|.
+|msvc-2003-toolkit| or |msvc-2005-express|, and use the source code before
+8.0.0029.
 
 Visual C++ Toolkit 2003				*msvc-2003-toolkit*
 -----------------------
@@ -263,6 +243,26 @@ This includes the IDE and the debugger. You will also need
 
 Instructions for integrating the Platform SDK into VC Express:
     http://msdn.microsoft.com/vstudio/express/visualc/usingpsdk/default.aspx
+
+
+Visual C++ 2008 Express Edition       *msvc-2008-express*
+-------------------------------
+
+Visual C++ 2008 Express Edition can be downloaded for free from:
+    http://www.microsoft.com/express/downloads/
+This includes the IDE and the debugger.
+
+To set the environment execute the msvc2008.bat script.  You can then build
+Vim with Make_mvc.mak.
+
+For building 64 bit binaries you also need to install the SDK:
+"Microsoft Windows SDK for Windows 7 and .NET Framework 3.5 SP1"
+You don't need the examples and documentation.
+
+If you get an error that Win32.mak can't be found, you have to set the
+variable SDK_INCLUDE_DIR.  For example, on Windows 10, installation of MSVC
+puts include files in the following directory:
+    set SDK_INCLUDE_DIR=C:\Program Files\Microsoft SDKs\Windows\v6.0A\Include
 
 
 2. MSYS2 with MinGW
@@ -359,38 +359,36 @@ that.
 3. MinGW
 ========
 
-(written by Ron Aaron: <ronaharon@yahoo.com>)
+(written by Ron Aaron: <ronaharon@yahoo.com>, updated by Ken Takata, et al.)
 
-This is about how to produce a Win32 binary of gvim with MinGW.
+This is about how to produce a Win32 binary of gvim with MinGW from the normal
+Command Prompt window.  (To use MSYS2 console, see above.)
 
-First, you need to get the 'mingw32' compiler, which is free for the download
-at:
-
-    http://www.mingw.org/
-
-or you can use 'MinGW-w64' compiler.
+First, you need to get the 'MinGW-w64' compiler, which is free for the
+download at:
 
     http://mingw-w64.sourceforge.net/
 
 Or a compiler provided on msys2:
 
-    https://msys2.github.io/
+    https://www.msys2.org/
+
+The original 'mingw32' compiler is outdated, and may no longer work:
+
+    http://www.mingw.org/
 
 Once you have downloaded the compiler binaries, unpack them on your hard disk
-somewhere, and put them on your PATH.  If you are on Win95/98 you can edit
-your AUTOEXEC.BAT file with a line like:
-
-    set PATH=C:\MinGW\bin;%PATH%
-
-or on NT/2000/XP, go to the Control Panel, (Performance and Maintenance),
-System, Advanced, and edit the environment from there. If you use msys2
-compilers, set your installed paths (normally one of the following):
+somewhere, and put them on your PATH.  Go to the Control Panel, (Performance
+and Maintenance), System, Advanced, and edit the environment from there.  If
+you use the standalone MinGW-w64 compiler, the path may depends on your
+installation.  If you use msys2 compilers, set your installed paths (normally
+one of the following):
 
     C:\msys32\mingw32\bin   (32-bit msys2, targeting 32-bit builds)
     C:\msys64\mingw32\bin   (64-bit msys2, targeting 32-bit builds)
     C:\msys64\mingw64\bin   (64-bit msys2, targeting 64-bit builds)
 
-Test if gcc is on your path.  From a CMD (or COMMAND on '95/98) window:
+Test if gcc is on your path.  From a Command Prompt window:
 
     C:\> gcc --version
     gcc (GCC) 4.8.1
@@ -473,8 +471,7 @@ Now you have created the Windows binary from your Linux box!  Have fun...
 6. Building with Python support
 ===============================
 
-For building with MSVC 2008 the "Windows Installer" from www.python.org
-works fine.
+For building with MSVC the "Windows Installer" from www.python.org works fine.
 
 When building, you need to set the following variables at least:
 
@@ -534,8 +531,8 @@ You will end up with a Python-enabled, Win32 version. Enjoy!
 7. Building with Python3 support
 ================================
 
-For building with MSVC 2008 the "Windows Installer" from www.python.org
-works fine.  Python 3.6 is recommended.
+For building with MSVC the "Windows Installer" from www.python.org works fine.
+Python 3.6 is recommended.
 
 When building, you need to set the following variables at least:
 
@@ -569,7 +566,7 @@ libstdc++-6.dll.)
 
 
 8. Building with Racket or MzScheme support
-========================================
+===========================================
 
 1) Building with Racket support (newest)
 

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1,7 +1,7 @@
 # Makefile for Vim on Win32 (Windows XP/2003/Vista/7/8/10) and Win64,
-# using the Microsoft Visual C++ compilers. Known to work with VC5, VC6 (VS98),
-# VC7.0 (VS2002), VC7.1 (VS2003), VC8 (VS2005), VC9 (VS2008), VC10 (VS2010),
-# VC11 (VS2012), VC12 (VS2013), VC14 (VS2015) and VC15 (VS2017)
+# using the Microsoft Visual C++ compilers. Known to work with VC10 (VS2010),
+# VC11 (VS2012), VC12 (VS2013), VC14 (VS2015), VC14.1 (VS2017) and
+# VC14.2 (VS2019).
 #
 # To build using other Windows compilers, see INSTALLpc.txt
 #
@@ -276,15 +276,9 @@ link = link
 !if $(MSVCVER) < 1900
 MSVC_MAJOR = ($(MSVCVER) / 100 - 6)
 MSVCRT_VER = ($(MSVCVER) / 10 - 60)
-# Visual C++ 2017 needs special handling
-# it has an _MSC_VER of 1910->14.1, but is actually v15 with runtime v140
-# TODO: what's the maximum value?
-!elseif $(MSVCVER) >= 1910
-MSVC_MAJOR = 15
-MSVCRT_VER = 140
 !else
 MSVC_MAJOR = ($(MSVCVER) / 100 - 5)
-MSVCRT_VER = ($(MSVCVER) / 10 - 50)
+MSVCRT_VER = ($(MSVCVER) / 100 * 10 - 50)
 !endif
 
 # Calculate MSVC_FULL for Visual C++ 8 and up.

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -1285,13 +1285,8 @@ gui_mch_new_colors(void)
     HBRUSH prevBrush;
 
     s_brush = CreateSolidBrush(gui.back_pixel);
-#ifdef SetClassLongPtr
     prevBrush = (HBRUSH)SetClassLongPtr(
 				s_hwnd, GCLP_HBRBACKGROUND, (LONG_PTR)s_brush);
-#else
-    prevBrush = (HBRUSH)SetClassLong(
-				   s_hwnd, GCL_HBRBACKGROUND, (long_u)s_brush);
-#endif
     InvalidateRect(s_hwnd, NULL, TRUE);
     DeleteObject(prevBrush);
 }
@@ -3422,11 +3417,7 @@ mch_set_mouse_shape(int shape)
 	    idc = IDC_ARROW;
 	else
 	    idc = mshape_idcs[shape];
-#ifdef SetClassLongPtr
-	SetClassLongPtr(s_textArea, GCLP_HCURSOR, (__int3264)(LONG_PTR)LoadCursor(NULL, idc));
-#else
-	SetClassLong(s_textArea, GCL_HCURSOR, (long_u)LoadCursor(NULL, idc));
-#endif
+	SetClassLongPtr(s_textArea, GCLP_HCURSOR, (LONG_PTR)LoadCursor(NULL, idc));
 	if (!p_mh)
 	{
 	    POINT mp;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -921,14 +921,6 @@ static const struct
 };
 
 
-#ifdef _MSC_VER
-// The ToAscii bug destroys several registers.	Need to turn off optimization
-// or the GetConsoleKeyboardLayoutName hack will fail in non-debug versions
-# pragma warning(push)
-# pragma warning(disable: 4748)
-# pragma optimize("", off)
-#endif
-
 #if defined(__GNUC__) && !defined(__MINGW32__)  && !defined(__CYGWIN__)
 # define UChar UnicodeChar
 #else
@@ -980,20 +972,6 @@ win32_kbd_patch_key(
 
     return s_iIsDead;
 }
-
-#ifdef _MSC_VER
-/* MUST switch optimization on again here, otherwise a call to
- * decode_key_event() may crash (e.g. when hitting caps-lock) */
-# pragma optimize("", on)
-# pragma warning(pop)
-
-# if (_MSC_VER < 1100)
-/* MUST turn off global optimisation for this next function, or
- * pressing ctrl-minus in insert mode crashes Vim when built with
- * VC4.1. -- negri. */
-#  pragma optimize("g", off)
-# endif
-#endif
 
 static BOOL g_fJustGotFocus = FALSE;
 
@@ -1119,10 +1097,6 @@ decode_key_event(
 
     return (*pch != NUL);
 }
-
-#ifdef _MSC_VER
-# pragma optimize("", on)
-#endif
 
 #endif /* FEAT_GUI_MSWIN */
 


### PR DESCRIPTION
Currently we use VC2010 on AppVeyor on this repository. VC2008 and older are not tested now.
Dropping support for VC2008 and older might be a good choice. It can make the source code a bit simpler.
(Updating the CI to use VC2015 and dropping support for older MSVC than that might be another choice, but I don't do it in this PR.)

* Update INSTALLpc.txt
  - Drop support for VC2008 and earlier.
  - Drop support for the original MinGW compiler. (#5241)
* Update Make_mvc.mak
  - Fix version calculation and support VC2019.
  - Remove comment for VC2008 or older.
* Remove #ifdef for SetClassLongPtr().
* Remove a workaround for very old MSVC.

See also: https://groups.google.com/d/msg/vim_dev/sSG-2f25l08/nnnpgm5oBQAJ