### PR TITLE
winlayout() returns different results depending on the screen width

### DIFF
--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -619,15 +619,10 @@ func s:test_xhelpgrep(cchar)
   let w3 = win_getid()
   call assert_true(&buftype == 'help')
   call assert_true(winnr() == 1)
-  " See jump_to_help_window() for details
-  let w2_width = winwidth(w2)
-  if w2_width != &columns && w2_width < 80
-    call assert_equal(['col', [['leaf', w3],
-          \ ['row', [['leaf', w2], ['leaf', w1]]]]], winlayout())
-  else
-    call assert_equal(['row', [['col', [['leaf', w3], ['leaf', w2]]],
-          \ ['leaf', w1]]] , winlayout())
-  endif
+  call win_gotoid(w1)
+  call assert_equal(w3, win_getid(winnr('k')))
+  call win_gotoid(w2)
+  call assert_equal(w3, win_getid(winnr('k')))
 
   new | only
   set buftype=help


### PR DESCRIPTION
The quickfix test using winlayout() is failing when run on windows with width greater
than 80 columns. Use another method to assert that the help window is the top window.
