### PR TITLE
Double-click was sometimes not recognized as double-click

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -13,6 +13,22 @@
 
 #include "vim.h"
 
+#ifdef CHECK_DOUBLE_CLICK
+/*
+ * Return the duration from t1 to t2 in milliseconds.
+ */
+    static long
+time_diff_ms(struct timeval *t1, struct timeval *t2)
+{
+    // This handles wrapping of tv_usec correctly without any special case.
+    // Example of 2 pairs (tv_sec, tv_usec) with a duration of 5 ms:
+    //	   t1 = (1, 998000) t2 = (2, 3000) gives:
+    //	   (2 - 1) * 1000 + (3000 - 998000) / 1000 -> 5 ms.
+    return (t2->tv_sec - t1->tv_sec) * 1000
+	 + (t2->tv_usec - t1->tv_usec) / 1000;
+}
+#endif
+
 /*
  * Get class of a character for selection: same class means same word.
  * 0: blank
@@ -2713,14 +2729,7 @@ check_termcode_mouse(
 			timediff = p_mouset;
 		    }
 		    else
-		    {
-			timediff = (mouse_time.tv_usec
-				- orig_mouse_time.tv_usec) / 1000;
-			if (timediff < 0)
-			    --orig_mouse_time.tv_sec;
-			timediff += (mouse_time.tv_sec
-				- orig_mouse_time.tv_sec) * 1000;
-		    }
+			timediff = time_diff_ms(&orig_mouse_time, &mouse_time);
 		    orig_mouse_time = mouse_time;
 		    if (mouse_code == orig_mouse_code
 			    && timediff < p_mouset

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -343,8 +343,6 @@ let s:flaky_tests = [
       \ 'Test_reltime()',
       \ 'Test_server_crash()',
       \ 'Test_state()',
-      \ 'Test_term_mouse_double_click_to_create_tab()',
-      \ 'Test_term_mouse_multiple_clicks_to_visually_select()',
       \ 'Test_terminal_ansicolors_default()',
       \ 'Test_terminal_ansicolors_func()',
       \ 'Test_terminal_ansicolors_global()',


### PR DESCRIPTION
This PR fixes a bug with double-click which was not always 
recognized as a double click. It caused flackyness in tests 
`Test_term_mouse_multiple_clicks_to_visually_select` and
`Test_term_mouse_double_click_to_create_tab()`. The tests
were fine and detected a real bug in Vim.

The time difference between 2 `timeval` was incorrectly computed.
For example, a double click of duration 20ms was prior to the fix
sometimes wrongly interpreted as 1020ms between
the 2 clicks when `tv_usec` was wrapping, causing to exceed
`'mousetime'` threshold and then double-click was not recognized
as a double-click.

This happened more frequently when Vim is slow, in particular
when running with asan or valgrind.  I could fairly frequently
reproduce the test failures with `make test_termcodes` with
valgrind, especially when adding such options to valgrind to make
it even slower `valgrind --leak-check=yes --track-origins=yes --num-callers=60`.

After the fix, `make test_termcodes` always passes. 