### PR TITLE
cygwin: Fix strptime warning

### DIFF
--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -129,13 +129,6 @@
 
 // on some systems time.h should not be included together with sys/time.h
 #if !defined(HAVE_SYS_TIME_H) || defined(TIME_WITH_SYS_TIME)
-// Needed for strptime()
-# ifndef _XOPEN_SOURCE
-#  define _XOPEN_SOURCE
-# endif
-# ifndef __USE_XOPEN
-#  define __USE_XOPEN
-# endif
 # include <time.h>
 #endif
 #ifdef HAVE_SYS_TIME_H

--- a/src/vim.h
+++ b/src/vim.h
@@ -36,8 +36,18 @@
     Error: configure did not run properly.  Check auto/config.log.
 # endif
 
+# ifdef UNIX
+// Needed for strptime()
+#  ifndef _XOPEN_SOURCE
+#   define _XOPEN_SOURCE    600
+#  endif
+#  ifndef __USE_XOPEN
+#   define __USE_XOPEN
+#  endif
+# endif
+
 // for INT_MAX, LONG_MAX et al.
-#include <limits.h>
+# include <limits.h>
 
 /*
  * Cygwin may have fchdir() in a newer release, but in most versions it


### PR DESCRIPTION
After 8.1.2326, cygwin warns this:

```
evalfunc.c: In function 'f_strptime':
evalfunc.c:7452:9: warning: implicit declaration of function 'strptime'; did you mean 'strftime'? [-Wimplicit-function-declaration]
      || strptime((char *)str, (char *)fmt, &tmval) == NULL
         ^~~~~~~~
         strftime
evalfunc.c:7452:52: warning: comparison between pointer and integer
      || strptime((char *)str, (char *)fmt, &tmval) == NULL
                                                    ^~
```

This is caused that some headers are included before defining
_XOPEN_SOURCE, then define _XOPEN_SOURCE and include time.h, but it is
too late for strptime().

This patch seems to fix the problem. (But not sure if this is the best fix.)