### PR TITLE
Detect *.cjs files as JavaScript

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -801,7 +801,7 @@ au BufNewFile,BufRead *.java,*.jav		setf java
 au BufNewFile,BufRead *.jj,*.jjt		setf javacc
 
 " JavaScript, ECMAScript
-au BufNewFile,BufRead *.js,*.javascript,*.es,*.mjs   setf javascript
+au BufNewFile,BufRead *.js,*.javascript,*.es,*.mjs,*.cjs	setf javascript
 
 " JavaScript with React
 au BufNewFile,BufRead *.jsx			setf javascriptreact


### PR DESCRIPTION
Node.js, the most famous JavaScript runtime outside browser, now [ships ES Modules](https://medium.com/@nodejs/announcing-core-node-js-support-for-ecmascript-modules-c5d6dc29b663) at v13.2.

Due to the ESM support, now 3 file extensions are used for JavaScript sources

- `.js`: Either ES Module script or CommonJS script. It depends on the `type` of the package
- `.mjs`: Always ES Module script
- `.cjs`: Always CommonJS script

Vim already detects `.mjs` files as JavaScript source, but doesn't detect `.cjs` files. This patch adds the missing detection.