### PR TITLE
Cirrus CI: add a simple CI using BSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,9 @@
+freebsd_12_task:
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+  install_script:
+    pkg install -y gettext gmake
+  build_script:
+    - gmake
+  test_script:
+    - gmake test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/vim/vim.svg?branch=master)](https://travis-ci.org/vim/vim)
 [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/o2qht2kjm02sgghk?svg=true)](https://ci.appveyor.com/project/chrisbra/vim)
+[![Build Status](https://api.cirrus-ci.com/github/chrisbra/vim.svg)](https://cirrus-ci.com/github/chrisbra/vim)
 [![Coverage Status](https://codecov.io/gh/vim/vim/coverage.svg?branch=master)](https://codecov.io/gh/vim/vim?branch=master)
 [![Coverity Scan](https://scan.coverity.com/projects/241/badge.svg)](https://scan.coverity.com/projects/vim)
 [![Language Grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/vim/vim.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/vim/vim/context:cpp)


### PR DESCRIPTION
Cirrus CI allows to run CI tests in a wide variety of systems, such as
Mac, Windows and FreeBSD. For a starter, add a Cirrus-CI test just for
FreeBSD using version 12, assuming Windows and Linux are already tested
using appveyor and Travis CI

For merging this upstream into vim/vim: do the following:
1) configure Cirrus-CI from github marketplace (https://github.com/marketplace/cirrus-ci) and select only the vim/vim repository
2) change Badge in the README.md file (`:/cirrus/s/chrisbra/vim/g`)