### PR TITLE
Save and restore VIsual_active and VIsual_select as curwin and curbuf (E315 error)

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -3979,6 +3979,8 @@ build_stl_str_hl(
 #ifdef FEAT_EVAL
     win_T	*save_curwin;
     buf_T	*save_curbuf;
+    int		save_VIsual_active;
+    int		save_VIsual_select;
 #endif
     int		empty_line;
     colnr_T	virtcol;
@@ -4366,6 +4368,12 @@ build_stl_str_hl(
 	    vim_snprintf((char *)win_tmp, sizeof(win_tmp), "%d", curwin->w_id);
 	    set_internal_string_var((char_u *)"g:actual_curwin", win_tmp);
 
+	    save_VIsual_active = VIsual_active;
+	    save_VIsual_select = VIsual_select;
+	    if (wp != curwin) {
+		VIsual_active = FALSE;
+		VIsual_select = FALSE;
+	    }
 	    save_curbuf = curbuf;
 	    save_curwin = curwin;
 	    curwin = wp;
@@ -4375,6 +4383,8 @@ build_stl_str_hl(
 
 	    curwin = save_curwin;
 	    curbuf = save_curbuf;
+	    VIsual_active = save_VIsual_active;
+	    VIsual_select = save_VIsual_select;
 	    do_unlet((char_u *)"g:actual_curbuf", TRUE);
 	    do_unlet((char_u *)"g:actual_curwin", TRUE);
 


### PR DESCRIPTION
### Version:
8.0.0000+(since wordcount() is introduced)
Confirmed: Vim 8.1.2345/8.0.0000 on MSYS2, GVim/Vim 8.1.2352 on Windows, Vim 8.1.2250 on Mac, Vim 8.1.2198 on Linux

### To reproduce bug:
```
./vim -u ~/a.vim --noplugin
And type <C-V>
```

To get full backtrace I used `:Termdebug` like this:
```
(gdb) file ./vim
(gdb) b siemsg
(gdb) r -u ~/a.vim --noplugin
(Type <C-v> in Vim window)
(gdb) bt full
```

Content of `~/a.vim`:
```
set noswapfile
function CallWordcount()
	set iminsert=0
	call wordcount()
endfunction
setl statusline=otherchars%{CallWordcount()}
normal i ^H
set nomodified
new
setl statusline=NO
normal o
set nomodified
```
`noswapfile` and `nomodified` is not needed but to stop messing up directory with swapfiles.
Two normal commands create two non-empty windows. So input `^H` as `<C-V><C-H>`.

### Bug description
We get `E315` when current window has more lines than other windows in the same tab and set statusline to call wordcount() and other commands.
This bug happens when updating not-current window's statusline.
In backtrace, `ops.c:3659` was called. It's inside `VIsual_active == TRUE` branch.
`VIsual_active` and `VIsual_select` should be saved, reset to `FALSE` when changing `curwin` and restored, when curwin and curbuf are saved/restored around `buffer.c:4374`.
