### PR TITLE
Improve the algorithm in rand() and srand()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7641,9 +7641,9 @@ range({expr} [, {max} [, {stride}]])				*range()*
 <
 
 rand([{expr}])						*rand()*
-		Return a pseudo-random Number generated with an xorshift
-		algorithm using seed {expr}.  The returned number is 32 bits,
-		also on 64 bits systems, for consistency.
+		Return a pseudo-random Number generated with an
+		xoroshiro128** algorithm using seed {expr}.  The returned number
+		is 32 bits, also on 64 bits systems, for consistency.
 		{expr} can be initialized by |srand()| and will be updated by
 		rand().  If {expr} is omitted, an internal seed value is used
 		and updated.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7641,9 +7641,9 @@ range({expr} [, {max} [, {stride}]])				*range()*
 <
 
 rand([{expr}])						*rand()*
-		Return a pseudo-random Number generated with an
-		xoroshiro128** algorithm using seed {expr}.  The returned number
-		is 32 bits, also on 64 bits systems, for consistency.
+		Return a pseudo-random Number generated with an xoshiro128**
+		algorithm using seed {expr}.  The returned number is 32 bits,
+		also on 64 bits systems, for consistency.
 		{expr} can be initialized by |srand()| and will be updated by
 		rand().  If {expr} is omitted, an internal seed value is used
 		and updated.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5145,7 +5145,7 @@ f_rand(typval_T *argvars, typval_T *rettv)
 
 #define ROTL(x, k) ((x << k) | (x >> (32 - k)))
 
-#define SHUFFLE_XOROSHIRO128STARSTAR \
+#define SHUFFLE_XOSHIRO128STARSTAR \
     result = ROTL(y * 5, 7) * 9; \
     t = y << 9; \
     z ^= x; w ^= y; y ^= z, x ^= w; \
@@ -5185,7 +5185,7 @@ f_rand(typval_T *argvars, typval_T *rettv)
 	y = xyzw[1];
 	z = xyzw[2];
 	w = xyzw[3];
-	SHUFFLE_XOROSHIRO128STARSTAR;
+	SHUFFLE_XOSHIRO128STARSTAR;
 	xyzw[0] = x;
 	xyzw[1] = y;
 	xyzw[2] = z;
@@ -5211,7 +5211,7 @@ f_rand(typval_T *argvars, typval_T *rettv)
 	y = (UINT32_T)ly->li_tv.vval.v_number;
 	z = (UINT32_T)lz->li_tv.vval.v_number;
 	w = (UINT32_T)lw->li_tv.vval.v_number;
-	SHUFFLE_XOROSHIRO128STARSTAR;
+	SHUFFLE_XOSHIRO128STARSTAR;
 	lx->li_tv.vval.v_number = (varnumber_T)x;
 	ly->li_tv.vval.v_number = (varnumber_T)y;
 	lz->li_tv.vval.v_number = (varnumber_T)z;

--- a/src/testdir/test_random.vim
+++ b/src/testdir/test_random.vim
@@ -2,12 +2,12 @@
 
 func Test_Rand()
   let r = srand(123456789)
-  call assert_equal([123456789, 362436069, 521288629, 88675123], r)
-  call assert_equal(3701687786, rand(r))
-  call assert_equal(458299110, rand(r))
-  call assert_equal(2500872618, rand(r))
-  call assert_equal(3633119408, rand(r))
-  call assert_equal(516391518, rand(r))
+  call assert_equal([1573771921, 319883699, 2742014374, 1324369493], r)
+  call assert_equal(4284103975, rand(r))
+  call assert_equal(1001954530, rand(r))
+  call assert_equal(2701803082, rand(r))
+  call assert_equal(2658065534, rand(r))
+  call assert_equal(3104308804, rand(r))
 
   call test_settime(12341234)
   let s = srand()


### PR DESCRIPTION
- The algorithm is changed from Marsaglia's xorshift128 to [xoshiro128**](http://prng.di.unimi.it/xoshiro128starstar.c): the improved version of Marsalia's xorshift128.
- `srand()` instead of `time()` is called in the first `rand()` call.
- [SplitMix32](https://github.com/umireon/my-random-stuff/blob/master/xorshift/splitmix32.c) is used to fill the initial state in `srand()`.