### PR TITLE
Win32: Fix some VIMDLL issues

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3353,7 +3353,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 #ifdef FEAT_SEARCHPATH
 	"file_in_path",
 #endif
-#ifdef FEAT_FILTERPIPE
+#if defined(FEAT_FILTERPIPE) && !defined(VIMDLL)
 	"filterpipe",
 #endif
 #ifdef FEAT_FIND_ID
@@ -3816,6 +3816,10 @@ f_has(typval_T *argvars, typval_T *rettv)
 #ifdef FEAT_CLIPBOARD
 	else if (STRICMP(name, "clipboard_working") == 0)
 	    n = clip_star.available;
+#endif
+#ifdef VIMDLL
+	else if (STRICMP(name, "filterpipe") == 0)
+	    n = gui.in_use || gui.starting;
 #endif
     }
 

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1068,6 +1068,9 @@ do_filter(
     pos_T	orig_start = curbuf->b_op_start;
     pos_T	orig_end = curbuf->b_op_end;
     int		save_lockmarks = cmdmod.lockmarks;
+#ifdef FEAT_FILTERPIPE
+    int		stmp = p_stmp;
+#endif
 
     if (*cmd == NUL)	    /* no filter command */
 	return;
@@ -1100,20 +1103,25 @@ do_filter(
 	shell_flags |= SHELL_DOOUT;
 
 #ifdef FEAT_FILTERPIPE
-    if (!do_in && do_out && !p_stmp)
+# ifdef VIMDLL
+    if (!gui.in_use && !gui.starting)
+	stmp = 1;   // Console mode doesn't support filterpipe.
+# endif
+
+    if (!do_in && do_out && !stmp)
     {
 	/* Use a pipe to fetch stdout of the command, do not use a temp file. */
 	shell_flags |= SHELL_READ;
 	curwin->w_cursor.lnum = line2;
     }
-    else if (do_in && !do_out && !p_stmp)
+    else if (do_in && !do_out && !stmp)
     {
 	/* Use a pipe to write stdin of the command, do not use a temp file. */
 	shell_flags |= SHELL_WRITE;
 	curbuf->b_op_start.lnum = line1;
 	curbuf->b_op_end.lnum = line2;
     }
-    else if (do_in && do_out && !p_stmp)
+    else if (do_in && do_out && !stmp)
     {
 	/* Use a pipe to write stdin and fetch stdout of the command, do not
 	 * use a temp file. */

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -5746,6 +5746,14 @@ im_set_active(int active)
     HIMC	hImc;
     static HIMC	hImcOld = (HIMC)0;
 
+# ifdef VIMDLL
+    if (!gui.in_use && !gui.starting)
+    {
+	mbyte_im_set_active(active);
+	return;
+    }
+# endif
+
     if (pImmGetContext)	    /* if NULL imm32.dll wasn't loaded (yet) */
     {
 	if (p_imdisable)
@@ -5814,6 +5822,11 @@ im_get_status(void)
 {
     int		status = 0;
     HIMC	hImc;
+
+# ifdef VIMDLL
+    if (!gui.in_use && !gui.starting)
+	return mbyte_im_get_status();
+# endif
 
     if (pImmGetContext && (hImc = pImmGetContext(s_hwnd)) != (HIMC)0)
     {

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4789,7 +4789,8 @@ iconv_end(void)
 # define USE_IMSTATUSFUNC (*p_imsf != NUL)
 #endif
 
-#if defined(FEAT_EVAL) && (defined(FEAT_XIM) || defined(IME_WITHOUT_XIM))
+#if defined(FEAT_EVAL) && \
+    (defined(FEAT_XIM) || defined(IME_WITHOUT_XIM) || defined(VIMDLL))
     static void
 call_imactivatefunc(int active)
 {
@@ -6454,11 +6455,15 @@ xim_get_status_area_height(void)
 
 #else /* !defined(FEAT_XIM) */
 
-# ifdef IME_WITHOUT_XIM
+# if defined(IME_WITHOUT_XIM) || defined(VIMDLL)
 static int im_was_set_active = FALSE;
 
     int
+#  ifdef VIMDLL
+mbyte_im_get_status(void)
+#  else
 im_get_status(void)
+#  endif
 {
 #  if defined(FEAT_EVAL)
     if (USE_IMSTATUSFUNC)
@@ -6468,7 +6473,11 @@ im_get_status(void)
 }
 
     void
+#  ifdef VIMDLL
+mbyte_im_set_active(int active_arg)
+#  else
 im_set_active(int active_arg)
+#  endif
 {
 #  if defined(FEAT_EVAL)
     int	    active = !p_imdisable && active_arg;
@@ -6481,7 +6490,7 @@ im_set_active(int active_arg)
 #  endif
 }
 
-#  ifdef FEAT_GUI
+#  if defined(FEAT_GUI) && !defined(VIMDLL)
     void
 im_set_position(int row UNUSED, int col UNUSED)
 {

--- a/src/menu.c
+++ b/src/menu.c
@@ -685,7 +685,11 @@ add_menu_path(
 	    if (	addtearoff
 		    && *next_name
 		    && vim_strchr(p_go, GO_TEAROFF) != NULL
-		    && menu_is_menubar(name))
+		    && menu_is_menubar(name)
+#  ifdef VIMDLL
+		    && (gui.in_use || gui.starting)
+#  endif
+		    )
 	    {
 		char_u		*tearpath;
 

--- a/src/proto.h
+++ b/src/proto.h
@@ -177,6 +177,10 @@ void qsort(void *base, size_t elm_count, size_t elm_size, int (*cmp)(const void 
 # include "mouse.pro"
 # include "move.pro"
 # include "mbyte.pro"
+# ifdef VIMDLL
+int mbyte_im_get_status(void);
+void mbyte_im_set_active(int active_arg);
+# endif
 # include "normal.pro"
 # include "ops.pro"
 # include "option.pro"

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -519,7 +519,7 @@ func Test_termguicolors()
   if !exists('+termguicolors')
     return
   endif
-  if has('vtp') && !has('vcon')
+  if has('vtp') && !has('vcon') && !has('gui_running')
     " Win32: 'guicolors' doesn't work without virtual console.
     call assert_fails('set termguicolors', 'E954:')
     return


### PR DESCRIPTION
When compiled with VIMDLL, some tests fails or hangs. This PR fixes them.

* `Test_termguicolors` failed on GUI. Fixed the test.
* `Test_Filter_noshelltemp` hanged on console.
  * `has('filterpipe')` should return 0 on console, because it is not supported.
  * `set noshelltemp` didn't work on console.
* `Test_menu_only_exists_in_terminal` hanged on console.
  A menu item for tearoff menu was added unintentionally. Stopped adding it.
* `Test_imgetstatus` and `Test_iminsert2` failed on console.
  Call the IM handling code for console.