### PR TITLE
Fix typos

### DIFF
--- a/runtime/autoload/decada.vim
+++ b/runtime/autoload/decada.vim
@@ -25,7 +25,7 @@ function decada#Unit_Name () dict				     " {{{1
     "	Convert filename into acs unit:
     "	    1:  remove the file extenstion.
     "	    2:  replace all double '_' or '-' with an dot (which denotes a separate)
-    "	    3:  remove a trailing '_' (wich denotes a specification)
+    "	    3:  remove a trailing '_' (which denotes a specification)
     return substitute (substitute (expand ("%:t:r"), '__\|-', ".", "g"), '_$', "", '')
 endfunction decada#Unit_Name					     " }}}1
 

--- a/runtime/autoload/getscript.vim
+++ b/runtime/autoload/getscript.vim
@@ -129,7 +129,7 @@ fun! getscript#GetLatestVimScripts()
 " insure that wget is executable
   if executable(g:GetLatestVimScripts_wget) != 1
    echoerr "GetLatestVimScripts needs ".g:GetLatestVimScripts_wget." which apparently is not available on your system"
-"   call Dret("GetLatestVimScripts : wget not executable/availble")
+"   call Dret("GetLatestVimScripts : wget not executable/available")
    return
   endif
 

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -1895,7 +1895,7 @@ endfun
 "                        Doing this means that netrw will not come up as having changed a
 "                        setting last when it really didn't actually change it.
 "
-"                        Used by s:NetrwOptionsRestore() to restore each netrw-senstive setting
+"                        Used by s:NetrwOptionsRestore() to restore each netrw-sensitive setting
 "                        keepvars are set up by s:NetrwOptionsSave
 fun! s:NetrwRestoreSetting(keepvar,setting)
 """  call Dfunc("s:NetrwRestoreSetting(a:keepvar<".a:keepvar."> a:setting<".a:setting.">)")

--- a/runtime/autoload/python3complete.vim
+++ b/runtime/autoload/python3complete.vim
@@ -172,7 +172,7 @@ class Completer(object):
                 pass
         if len(arg_text) == 0:
             # The doc string sometimes contains the function signature
-            #  this works for alot of C modules that are part of the
+            #  this works for a lot of C modules that are part of the
             #  standard library
             doc = func_obj.__doc__
             if doc:

--- a/runtime/autoload/pythoncomplete.vim
+++ b/runtime/autoload/pythoncomplete.vim
@@ -190,7 +190,7 @@ class Completer(object):
                 pass
         if len(arg_text) == 0:
             # The doc string sometimes contains the function signature
-            #  this works for alot of C modules that are part of the
+            #  this works for a lot of C modules that are part of the
             #  standard library
             doc = func_obj.__doc__
             if doc:

--- a/runtime/autoload/sqlcomplete.vim
+++ b/runtime/autoload/sqlcomplete.vim
@@ -617,7 +617,7 @@ function! sqlcomplete#DrillIntoTable()
     else
 	" If the popup is not visible, simple perform the normal
 	" key behaviour.
-	" Must use exec since they key must be preceeded by "\"
+	" Must use exec since they key must be preceded by "\"
 	" or feedkeys will simply push each character of the string
 	" rather than the "key press".
         exec 'call feedkeys("\'.g:ftplugin_sql_omni_key_right.'", "n")'
@@ -634,7 +634,7 @@ function! sqlcomplete#DrillOutOfColumns()
     else
 	" If the popup is not visible, simple perform the normal
 	" key behaviour.
-	" Must use exec since they key must be preceeded by "\"
+	" Must use exec since they key must be preceded by "\"
 	" or feedkeys will simply push each character of the string
 	" rather than the "key press".
         exec 'call feedkeys("\'.g:ftplugin_sql_omni_key_left.'", "n")'

--- a/runtime/autoload/syntaxcomplete.vim
+++ b/runtime/autoload/syntaxcomplete.vim
@@ -548,7 +548,7 @@ function! s:SyntaxCSyntaxGroupItems( group_name, syntax_full )
         " let syn_list = substitute( @l, '^.*xxx\s*\%(contained\s*\)\?', "", '' )
         " let syn_list = substitute( @l, '^.*xxx\s*', "", '' )
 
-        " We only want the words for the lines begining with
+        " We only want the words for the lines beginning with
         " containedin, but there could be other items.
 
         " Tried to remove all lines that do not begin with contained

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -595,7 +595,7 @@ fun! tar#Vimuntar(...)
    elseif executable("gzip")
     silent exe "!gzip -d ".shellescape(tartail)
    else
-    echoerr "unable to decompress<".tartail."> on this sytem"
+    echoerr "unable to decompress<".tartail."> on this system"
     if simplify(curdir) != simplify(tarhome)
      " remove decompressed tarball, restore directory
 "     call Decho("delete(".tartail.".tar)")

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -81,7 +81,7 @@ fun! zip#Browse(zipfile)
   " sanity checks
   if !exists("*fnameescape")
    if &verbose > 1
-    echoerr "the zip plugin is not available (your vim doens't support fnameescape())"
+    echoerr "the zip plugin is not available (your vim doesn't support fnameescape())"
    endif
    return
   endif

--- a/runtime/compiler/checkstyle.vim
+++ b/runtime/compiler/checkstyle.vim
@@ -14,6 +14,6 @@ endif
 
 CompilerSet makeprg=java\ com.puppycrawl.tools.checkstyle.Main\ -f\ plain
 
-" sample error: WebTable.java:282: '+=' is not preceeded with whitespace.
+" sample error: WebTable.java:282: '+=' is not preceded with whitespace.
 "		WebTable.java:201:1: '{' should be on the previous line.
 CompilerSet errorformat=%f:%l:%v:\ %m,%f:%l:\ %m,%-G%.%#

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1147,7 +1147,7 @@ properties can be changed with |popup_setoptions()|.
 
 						*complete-popuphidden*
 If the information for the popup is obtained asynchronously, use "popuphidden"
-in 'completeopt'.  The info popup will then be initally hidden and
+in 'completeopt'.  The info popup will then be initially hidden and
 |popup_show()| must be called once it has been filled with the info.  This can
 be done with a |CompleteChanged| autocommand, something like this: >
 	set completeopt+=popuphidden

--- a/runtime/indent/ada.vim
+++ b/runtime/indent/ada.vim
@@ -219,7 +219,7 @@ function GetAdaIndent()
       " Move indent in twice (next 'when' will move back)
       let ind = ind + 2 * shiftwidth()
    elseif line =~ '^\s*end\s*record\>'
-      " Move indent back to tallying 'type' preceeding the 'record'.
+      " Move indent back to tallying 'type' preceding the 'record'.
       " Allow indent to be equal to 'end record's.
       let ind = s:MainBlockIndent( ind+shiftwidth(), lnum, 'type\>', '' )
    elseif line =~ '\(^\s*new\>.*\)\@<!)\s*[;,]\s*$'

--- a/runtime/indent/tex.vim
+++ b/runtime/indent/tex.vim
@@ -280,7 +280,7 @@ function! GetTeXIndent() " {{{
             let ind = ind - shiftwidth()
             let stay = 0
         endif
-        " lines following to '\item' are intented once again:
+        " lines following to '\item' are indented once again:
         if line =~ g:tex_items
             let ind = ind + shiftwidth()
             let stay = 0

--- a/runtime/pack/dist/opt/justify/plugin/justify.vim
+++ b/runtime/pack/dist/opt/justify/plugin/justify.vim
@@ -31,7 +31,7 @@
 " An argument of '' is accepted, should the user  like  to  specify  all
 " arguments.
 "
-" To aid user defined commands, negative  values  are  accepted  aswell.
+" To aid user defined commands, negative  values  are  accepted  as well.
 " Using a negative value specifies the default behaviour: any length  of
 " space runs will be used to justify the text.
 

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -261,7 +261,7 @@ func s:StartDebug_term(dict)
     sleep 10m
   endwhile
 
-  " Interpret commands while the target is running.  This should usualy only be
+  " Interpret commands while the target is running.  This should usually only be
   " exec-interrupt, since many commands don't work properly while the target is
   " running.
   call s:SendCommand('-gdb-set mi-async on')
@@ -317,7 +317,7 @@ func s:StartDebug_prompt(dict)
   set modified
   let s:gdb_channel = job_getchannel(s:gdbjob)  
 
-  " Interpret commands while the target is running.  This should usualy only
+  " Interpret commands while the target is running.  This should usually only
   " be exec-interrupt, since many commands don't work properly while the
   " target is running.
   call s:SendCommand('-gdb-set mi-async on')

--- a/runtime/spell/pt/main.aap
+++ b/runtime/spell/pt/main.aap
@@ -59,7 +59,7 @@ pt_PT.aff pt_PT.dic: {buildcheck=}
         :delete {f} description.xml
         :delete {f} dictionaries.xcu
         :delete {f} LICENSES.txt
-        # Remove grammer items and the duplicates this causes
+        # Remove grammar items and the duplicates this causes
         :sys $VIM pt_PT.dic -u NONE -e -c "%s/\t.*//" -c "2,$$ sort u" -c update -c q
         :sys $VIM pt_PT.aff -u NONE -e -c "%s/\S\+=\S\+$$//" -c update -c q
         @if not os.path.exists('pt_PT.orig.aff'):

--- a/runtime/syntax/asciidoc.vim
+++ b/runtime/syntax/asciidoc.vim
@@ -93,7 +93,7 @@ syn region asciidocListingBlock start=/^-\{4,}$/ end=/^-\{4,}$/ contains=asciido
 syn region asciidocCommentBlock start="^/\{4,}$" end="^/\{4,}$" contains=asciidocToDo
 syn region asciidocPassthroughBlock start="^+\{4,}$" end="^+\{4,}$"
 
-" Allowing leading \w characters in the filter delimiter is to accomodate
+" Allowing leading \w characters in the filter delimiter is to accommodate
 " the pre version 8.2.7 syntax and may be removed in future releases.
 syn region asciidocFilterBlock start=/^\w*\~\{4,}$/ end=/^\w*\~\{4,}$/
 

--- a/runtime/syntax/ch.vim
+++ b/runtime/syntax/ch.vim
@@ -17,7 +17,7 @@ endif
 runtime! syntax/c.vim
 unlet b:current_syntax
 
-" Ch extentions
+" Ch extensions
 
 syn keyword	chStatement	new delete this foreach
 syn keyword	chAccess	public private

--- a/runtime/syntax/chill.vim
+++ b/runtime/syntax/chill.vim
@@ -24,7 +24,7 @@ syn keyword	chillLogical	NOT not
 syn keyword	chillRepeat	while WHILE for FOR do DO od OD TO to
 syn keyword	chillProcess	START start STACKSIZE stacksize PRIORITY priority THIS this STOP stop
 syn keyword	chillBlock		PROC proc PROCESS process
-syn keyword	chillSignal	RECEIVE receive SEND send NONPERSISTENT nonpersistent PERSISTENT peristent SET set EVER ever
+syn keyword	chillSignal	RECEIVE receive SEND send NONPERSISTENT nonpersistent PERSISTENT persistent SET set EVER ever
 
 syn keyword	chillTodo		contained TODO FIXME XXX
 

--- a/runtime/syntax/clipper.vim
+++ b/runtime/syntax/clipper.vim
@@ -106,7 +106,7 @@ else
 endif
 syntax match clipperCommentError	"\*/"
 
-" Lines beggining with an "*" are comments too
+" Lines beginning with an "*" are comments too
 syntax match clipperComment		"^\*.*"
 
 

--- a/runtime/syntax/cuda.vim
+++ b/runtime/syntax/cuda.vim
@@ -11,7 +11,7 @@ endif
 " Read the C++ syntax to start with
 runtime! syntax/cpp.vim
 
-" CUDA extentions
+" CUDA extensions
 syn keyword cudaStorageClass	__device__ __global__ __host__
 syn keyword cudaStorageClass	__constant__ __shared__
 syn keyword cudaStorageClass	__inline__ __align__ __thread__

--- a/runtime/syntax/d.vim
+++ b/runtime/syntax/d.vim
@@ -395,7 +395,7 @@ hi def link dPragmaIdentifier    Identifier
 hi def link dExtern              dExternal
 hi def link dExternIdentifier    Identifier
 
-" Marks contents of the asm statment body as special
+" Marks contents of the asm statement body as special
 
 syn match dAsmStatement "\<asm\>"
 syn region dAsmBody start="asm[\n]*\s*{"hs=e+1 end="}"he=e-1 contains=dAsmStatement,dAsmOpCode,@dComment,DUserLabel

--- a/runtime/syntax/dtrace.vim
+++ b/runtime/syntax/dtrace.vim
@@ -42,7 +42,7 @@ exec 'syn match dtraceProbe "'.s:oneProbe.'\%(,\_s*'.s:oneProbe.'\)*\ze\_s\%({\|
 " Also be careful not to eat `c = a / b; b = a / 2;`. We use the same
 " technique as the dtrace lexer: a predicate has to be followed by {, ;, or
 " EOF. Also note that dtrace doesn't allow an empty predicate // (we do).
-" This regex doesn't allow a divison operator in the predicate.
+" This regex doesn't allow a division operator in the predicate.
 " Make sure that this matches the empty predicate as well.
 " XXX: This doesn't work if followed by a comment.
 syn match dtracePredicate "/\*\@!\_[^/]*/\ze\_s*\%({\|;\|\%$\)"

--- a/runtime/syntax/esqlc.vim
+++ b/runtime/syntax/esqlc.vim
@@ -11,7 +11,7 @@ endif
 " Read the C++ syntax to start with
 runtime! syntax/cpp.vim
 
-" ESQL-C extentions
+" ESQL-C extensions
 
 syntax keyword esqlcPreProc	EXEC SQL INCLUDE
 

--- a/runtime/syntax/ia64.vim
+++ b/runtime/syntax/ia64.vim
@@ -49,7 +49,7 @@ syn keyword ia64opcode pshradd2 psub4 rfi rsm rum shl shladd shladdp4
 syn keyword ia64opcode shrp ssm sub sum sync.i tak thash
 syn keyword ia64opcode tpa ttag xor
 
-"put to override these being recognized as floats. They are orignally from masm.vim
+"put to override these being recognized as floats. They are originally from masm.vim
 "put here to avoid confusion with float
 syn match   ia64Directive       "\.186"
 syn match   ia64Directive       "\.286"

--- a/runtime/syntax/kix.vim
+++ b/runtime/syntax/kix.vim
@@ -10,7 +10,7 @@
 " 26 April 2001: RMH
 "    Removed development comments from distro version
 "    Renamed "Kix*" to "kix*" for consistancy
-"    Changes made in preperation for VIM version 5.8/6.00
+"    Changes made in preparation for VIM version 5.8/6.00
 
 " TODO:
 "	Handle arrays highlighting

--- a/runtime/syntax/kwt.vim
+++ b/runtime/syntax/kwt.vim
@@ -12,7 +12,7 @@ endif
 runtime! syntax/cpp.vim
 unlet b:current_syntax
 
-" kimwitu++ extentions
+" kimwitu++ extensions
 
 " Don't stop at eol, messes around with CPP mode, but gives line spanning
 " strings in unparse rules

--- a/runtime/syntax/matlab.vim
+++ b/runtime/syntax/matlab.vim
@@ -53,7 +53,7 @@ syn match matlabFloat		"\<\d\+\(\.\d*\)\=\([edED][-+]\=\d\+\)\=[ij]\=\>"
 " floating point number, starting with a dot, optional exponent
 syn match matlabFloat		"\.\d\+\([edED][-+]\=\d\+\)\=[ij]\=\>"
 
-" Transpose character and delimiters: Either use just [...] or (...) aswell
+" Transpose character and delimiters: Either use just [...] or (...) as well
 syn match matlabDelimiter		"[][]"
 "syn match matlabDelimiter		"[][()]"
 syn match matlabTransposeOperator	"[])a-zA-Z0-9.]'"lc=1

--- a/runtime/syntax/mel.vim
+++ b/runtime/syntax/mel.vim
@@ -15,7 +15,7 @@ if exists("mel_space_errors")
   sy match	melSpaceError	" \+\t"me=e-1
 endif
 
-" A bunch of usefull MEL keyworks
+" A bunch of useful MEL keyworks
 sy keyword	melBoolean	true false yes no on off
 
 sy keyword	melFunction	proc

--- a/runtime/syntax/nasm.vim
+++ b/runtime/syntax/nasm.vim
@@ -19,7 +19,7 @@ syn case ignore
 
 
 
-" Vim search and movement commands on identifers
+" Vim search and movement commands on identifiers
 "  Comments at start of a line inside which to skip search for indentifiers
 setlocal comments=:;
 "  Identifier Keyword characters (defines \k)

--- a/runtime/syntax/php.vim
+++ b/runtime/syntax/php.vim
@@ -91,7 +91,7 @@ if exists( "php_htmlInStrings")
   syn cluster phpAddStrings add=@htmlTop
 endif
 
-" make sure we can use \ at the begining of the line to do a continuation
+" make sure we can use \ at the beginning of the line to do a continuation
 let s:cpo_save = &cpo
 set cpo&vim
 

--- a/runtime/syntax/postscr.vim
+++ b/runtime/syntax/postscr.vim
@@ -496,15 +496,15 @@ if postscr_level == 2 || postscr_level == 3
 " Page duplexing operators
   syn keyword postscrL2Operator   duplexmode firstside newsheet setduplexmode settumble tumble
 
-" Device compatability operators
+" Device compatibility operators
   syn keyword postscrL2Operator   devdismount devformat devmount devstatus
   syn keyword postscrL2Repeat     devforall
 
-" Imagesetter compatability operators
+" Imagesetter compatibility operators
   syn keyword postscrL2Operator   accuratescreens checkscreen pagemargin pageparams setaccuratescreens setpage
   syn keyword postscrL2Operator   setpagemargin setpageparams
 
-" Misc compatability operators
+" Misc compatibility operators
   syn keyword postscrL2Operator   appletalktype buildtime byteorder checkpassword defaulttimeouts diskonline
   syn keyword postscrL2Operator   diskstatus manualfeed manualfeedtimeout margins mirrorprint pagecount
   syn keyword postscrL2Operator   pagestackorder printername processcolors sethardwareiomode setjobtimeout

--- a/runtime/syntax/pyrex.vim
+++ b/runtime/syntax/pyrex.vim
@@ -13,7 +13,7 @@ endif
 runtime! syntax/python.vim
 unlet b:current_syntax
 
-" Pyrex extentions
+" Pyrex extensions
 syn keyword pyrexStatement      cdef typedef ctypedef sizeof
 syn keyword pyrexType		int long short float double char object void
 syn keyword pyrexType		signed unsigned

--- a/runtime/syntax/redif.vim
+++ b/runtime/syntax/redif.vim
@@ -932,7 +932,7 @@ highlight redifFieldDeprecated term=undercurl cterm=undercurl gui=undercurl guis
 " Sync: The template-type (ReDIF-Paper, ReDIF-Archive, etc.) influences which
 " fields can follow. Thus sync must search backwards for it.
 "
-" I would like to simply ask VIM to search backward for the first occurence of
+" I would like to simply ask VIM to search backward for the first occurrence of
 " /^Template-Type:/, but it does not seem to be possible, so I have to start
 " from the beginning of the file... This might slow down a lot for files that
 " contain a lot of Template-Type statements.

--- a/runtime/syntax/sather.vim
+++ b/runtime/syntax/sather.vim
@@ -4,7 +4,7 @@
 " URL:		http://www.fleiner.com/vim/syntax/sather.vim
 " Last Change:	2003 May 11
 
-" Sather is a OO-language developped at the International Computer Science
+" Sather is a OO-language developed at the International Computer Science
 " Institute (ICSI) in Berkeley, CA. pSather is a parallel extension to Sather.
 " Homepage: http://www.icsi.berkeley.edu/~sather
 " Sather files use .sa as suffix

--- a/runtime/syntax/spup.vim
+++ b/runtime/syntax/spup.vim
@@ -35,7 +35,7 @@ endif
 
 " one line comment syntax (# comments)
 " 1. allow appended code after comment, do not complain
-" 2. show code beginnig with the second # as an error
+" 2. show code beginning with the second # as an error
 " 3. show whole lines with more than one # as an error
 if !exists("oneline_comments")
     let oneline_comments = 2

--- a/runtime/syntax/sqlj.vim
+++ b/runtime/syntax/sqlj.vim
@@ -16,7 +16,7 @@ endif
 " Read the Java syntax to start with
 source <sfile>:p:h/java.vim
 
-" SQLJ extentions
+" SQLJ extensions
 " The SQL reserved words, defined as keywords.
 
 syn case ignore

--- a/runtime/syntax/tmux.vim
+++ b/runtime/syntax/tmux.vim
@@ -8,7 +8,7 @@ if exists("b:current_syntax")
     finish
 endif
 
-" Explicitly change compatiblity options to Vim's defaults because this file
+" Explicitly change compatibility options to Vim's defaults because this file
 " uses line continuations.
 let s:original_cpo = &cpo
 set cpo&vim

--- a/runtime/tools/shtags.pl
+++ b/runtime/tools/shtags.pl
@@ -72,7 +72,7 @@ if( ! $explicit && open( TAGS, "< $tags_file" ) )
 
 #
 # for each line of every file listed on the command line, look for a
-# 'sub' definition, or, if variables are wanted aswell, look for a
+# 'sub' definition, or, if variables are wanted as well, look for a
 # variable definition at the start of a line
 #
 while( <> )

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -2585,7 +2585,7 @@ win_update(win_T *wp)
 						    != (VALID_WCOL|VALID_WROW))
 	    {
 		// A win_line() call applied a fix to screen cursor column to
-		// accomodate concealment of cursor line, but in this call to
+		// accommodate concealment of cursor line, but in this call to
 		// update_topline() the cursor's row or column got invalidated.
 		// If they are left invalid, setcursor() will recompute them
 		// but there won't be any further win_line() call to re-fix the

--- a/src/edit.c
+++ b/src/edit.c
@@ -4807,7 +4807,7 @@ ins_bs(
 	}
 
 	/*
-	 * Delete upto starting point, start of line or previous word.
+	 * Delete up to starting point, start of line or previous word.
 	 */
 	else
 	{

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1078,7 +1078,7 @@ retry:
 	 * We allocate as much space for the file as we can get, plus
 	 * space for the old line plus room for one terminating NUL.
 	 * The amount is limited by the fact that read() only can read
-	 * upto max_unsigned characters (and other things).
+	 * up to max_unsigned characters (and other things).
 	 */
 	if (!skip_read)
 	{

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -3378,7 +3378,7 @@ highlight_changed(void)
 	     * bold-underlined.
 	     */
 	    attr = 0;
-	    for ( ; *p && *p != ','; ++p)	    // parse upto comma
+	    for ( ; *p && *p != ','; ++p)	    // parse up to comma
 	    {
 		if (VIM_ISWHITE(*p))		    // ignore white space
 		    continue;

--- a/src/json_test.c
+++ b/src/json_test.c
@@ -23,7 +23,7 @@
 
 #if defined(FEAT_EVAL)
 /*
- * Test json_find_end() with imcomplete items.
+ * Test json_find_end() with incomplete items.
  */
     static void
 test_decode_find_end(void)

--- a/src/message.c
+++ b/src/message.c
@@ -1455,7 +1455,7 @@ msg_home_replace_attr(char_u *fname, int attr)
 
 /*
  * Output 'len' characters in 'str' (including NULs) with translation
- * if 'len' is -1, output upto a NUL character.
+ * if 'len' is -1, output up to a NUL character.
  * Use attributes 'attr'.
  * Return the number of characters it takes on the screen.
  */
@@ -1599,7 +1599,7 @@ msg_make(char_u *arg)
 #endif
 
 /*
- * Output the string 'str' upto a NUL character.
+ * Output the string 'str' up to a NUL character.
  * Return the number of characters it takes on the screen.
  *
  * If K_SPECIAL is encountered, then it is taken in conjunction with the

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -6257,7 +6257,7 @@ select_eintr:
 		maxfd = ConnectionNumber(xterm_dpy);
 
 	    /* An event may have already been read but not handled.  In
-	     * particulary, XFlush may cause this. */
+	     * particularly, XFlush may cause this. */
 	    xterm_update();
 	}
 # endif

--- a/src/search.c
+++ b/src/search.c
@@ -2863,7 +2863,7 @@ findsent(int dir, long count)
     while (count--)
     {
 	/*
-	 * if on an empty line, skip upto a non-empty line
+	 * if on an empty line, skip up to a non-empty line
 	 */
 	if (gchar_pos(&pos) == NUL)
 	{

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -3,7 +3,7 @@
 " Errors are appended to the test.log file.
 "
 " To execute only specific test functions, add a second argument.  It will be
-" matched against the names of the Test_ funtion.  E.g.:
+" matched against the names of the Test_ function.  E.g.:
 "	../vim -u NONE -S runtest.vim test_channel.vim open_delay
 " The output can be found in the "messages" file.
 "

--- a/src/testdir/test49.vim
+++ b/src/testdir/test49.vim
@@ -178,7 +178,7 @@ endif
 "		next Xpath value.  No new Xnext value is prepared.  The argument
 "		should be 2^(n-1) for the nth Xloop command inside the loop.
 "		If the loop has only one Xloop command, the argument can be
-"		ommitted (default: 1).
+"		omitted (default: 1).
 "
 "	- Use XloopNEXT before ":continue" and ":endwhile".  This computes a new
 "	  Xnext value for the next execution of the loop by multiplying the old


### PR DESCRIPTION
Attempted to keep changes non-semantic. (I would highlight runtime/syntax/chill.vim as one change that might particularly warrant expert eyes.)

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.