### PR TITLE
Fix indents of preprocessor directives in some files

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1940,11 +1940,11 @@ win_line(
 		    c_final = NUL;
 		    if (VIM_ISWHITE(c))
 		    {
-#ifdef FEAT_CONCEAL
+# ifdef FEAT_CONCEAL
 			if (c == TAB)
 			    // See "Tab alignment" below.
 			    FIX_FOR_BOGUSCOLS;
-#endif
+# endif
 			if (!wp->w_p_list)
 			    c = ' ';
 		    }

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -187,17 +187,17 @@ gui_mch_set_rendering_options(char_u *s)
 /* cproto fails on missing include files */
 #ifndef PROTO
 
-#ifndef __MINGW32__
-# include <shellapi.h>
-#endif
-#if defined(FEAT_TOOLBAR) || defined(FEAT_BEVAL_GUI) || defined(FEAT_GUI_TABLINE)
-# include <commctrl.h>
-#endif
-#include <windowsx.h>
+# ifndef __MINGW32__
+#  include <shellapi.h>
+# endif
+# if defined(FEAT_TOOLBAR) || defined(FEAT_BEVAL_GUI) || defined(FEAT_GUI_TABLINE)
+#  include <commctrl.h>
+# endif
+# include <windowsx.h>
 
-#ifdef GLOBAL_IME
-# include "glbl_ime.h"
-#endif
+# ifdef GLOBAL_IME
+#  include "glbl_ime.h"
+# endif
 
 #endif /* PROTO */
 
@@ -2106,10 +2106,10 @@ gui_mch_wait_for_chars(int wtime)
 	    MSG msg;
 
 	    parse_queued_messages();
-#ifdef FEAT_TIMERS
+# ifdef FEAT_TIMERS
 	    if (did_add_timer)
 		break;
-#endif
+# endif
 	    if (pPeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE))
 	    {
 		process_message();
@@ -2392,7 +2392,7 @@ gui_mch_show_toolbar(int showit)
 }
 
 /* The number of bitmaps is fixed.  Exit is missing! */
-#define TOOLBAR_BITMAP_COUNT 31
+# define TOOLBAR_BITMAP_COUNT 31
 
 #endif
 
@@ -2515,10 +2515,10 @@ gui_mch_update_tabline(void)
     if (s_tabhwnd == NULL)
 	return;
 
-#ifndef CCM_SETUNICODEFORMAT
+# ifndef CCM_SETUNICODEFORMAT
     /* For older compilers.  We assume this never changes. */
-# define CCM_SETUNICODEFORMAT 0x2005
-#endif
+#  define CCM_SETUNICODEFORMAT 0x2005
+# endif
     // Enable unicode support
     SendMessage(s_tabhwnd, CCM_SETUNICODEFORMAT, (WPARAM)TRUE, (LPARAM)0);
 
@@ -3502,12 +3502,12 @@ gui_mch_browse(
     filterp = convert_filterW(filter);
 
     vim_memset(&fileStruct, 0, sizeof(OPENFILENAMEW));
-#  ifdef OPENFILENAME_SIZE_VERSION_400W
+# ifdef OPENFILENAME_SIZE_VERSION_400W
     /* be compatible with Windows NT 4.0 */
     fileStruct.lStructSize = OPENFILENAME_SIZE_VERSION_400W;
-#  else
+# else
     fileStruct.lStructSize = sizeof(fileStruct);
-#  endif
+# endif
 
     if (title != NULL)
 	titlep = enc_to_utf16(title, NULL);
@@ -3544,10 +3544,10 @@ gui_mch_browse(
      * Don't use OFN_OVERWRITEPROMPT, Vim has its own ":confirm" dialog.
      */
     fileStruct.Flags = (OFN_NOCHANGEDIR | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY);
-#  ifdef FEAT_SHORTCUT
+# ifdef FEAT_SHORTCUT
     if (curbuf->b_p_bin)
 	fileStruct.Flags |= OFN_NODEREFERENCELINKS;
-#  endif
+# endif
     if (saving)
     {
 	if (!GetSaveFileNameW(&fileStruct))
@@ -3915,7 +3915,7 @@ _OnScroll(
 
 /* For the Intellimouse: */
 #ifndef WM_MOUSEWHEEL
-#define WM_MOUSEWHEEL	0x20a
+# define WM_MOUSEWHEEL	0x20a
 #endif
 
 
@@ -3923,12 +3923,12 @@ _OnScroll(
 # define ID_BEVAL_TOOLTIP   200
 # define BEVAL_TEXT_LEN	    MAXPATHL
 
-#if (defined(_MSC_VER) && _MSC_VER < 1300) || !defined(MAXULONG_PTR)
+# if (defined(_MSC_VER) && _MSC_VER < 1300) || !defined(MAXULONG_PTR)
 /* Work around old versions of basetsd.h which wrongly declares
  * UINT_PTR as unsigned long. */
-# undef  UINT_PTR
-# define UINT_PTR UINT
-#endif
+#  undef  UINT_PTR
+#  define UINT_PTR UINT
+# endif
 
 static BalloonEval  *cur_beval = NULL;
 static UINT_PTR	    BevalTimerId = 0;
@@ -3936,15 +3936,15 @@ static DWORD	    LastActivity = 0;
 
 
 /* cproto fails on missing include files */
-#ifndef PROTO
+# ifndef PROTO
 
 /*
  * excerpts from headers since this may not be presented
  * in the extremely old compilers
  */
-# include <pshpack1.h>
+#  include <pshpack1.h>
 
-#endif
+# endif
 
 typedef struct _DllVersionInfo
 {
@@ -3955,9 +3955,9 @@ typedef struct _DllVersionInfo
     DWORD dwPlatformID;
 } DLLVERSIONINFO;
 
-#ifndef PROTO
-# include <poppack.h>
-#endif
+# ifndef PROTO
+#  include <poppack.h>
+# endif
 
 typedef struct tagTOOLINFOA_NEW
 {
@@ -4006,17 +4006,17 @@ typedef struct tagNMTTDISPINFOW_NEW
 
 
 typedef HRESULT (WINAPI* DLLGETVERSIONPROC)(DLLVERSIONINFO *);
-#ifndef TTM_SETMAXTIPWIDTH
-# define TTM_SETMAXTIPWIDTH	(WM_USER+24)
-#endif
+# ifndef TTM_SETMAXTIPWIDTH
+#  define TTM_SETMAXTIPWIDTH	(WM_USER+24)
+# endif
 
-#ifndef TTF_DI_SETITEM
-# define TTF_DI_SETITEM		0x8000
-#endif
+# ifndef TTF_DI_SETITEM
+#  define TTF_DI_SETITEM		0x8000
+# endif
 
-#ifndef TTN_GETDISPINFO
-# define TTN_GETDISPINFO	(TTN_FIRST - 0)
-#endif
+# ifndef TTN_GETDISPINFO
+#  define TTN_GETDISPINFO	(TTN_FIRST - 0)
+# endif
 
 #endif /* defined(FEAT_BEVAL_GUI) */
 
@@ -5570,7 +5570,7 @@ _OnImeNotify(HWND hWnd, DWORD dwCommand, DWORD dwData UNUSED)
 		State &= ~LANGMAP;
 		if (State & INSERT)
 		{
-#if defined(FEAT_KEYMAP)
+# if defined(FEAT_KEYMAP)
 		    /* Unshown 'keymap' in status lines */
 		    if (curbuf->b_p_iminsert == B_IMODE_LMAP)
 		    {
@@ -5588,7 +5588,7 @@ _OnImeNotify(HWND hWnd, DWORD dwCommand, DWORD dwData UNUSED)
 			gui.row = old_row;
 			gui.col = old_col;
 		    }
-#endif
+# endif
 		}
 	    }
 	    gui_update_cursor(TRUE, FALSE);
@@ -6388,10 +6388,10 @@ gui_mch_add_menu(
     /* Fix window size if menu may have wrapped */
     if (parent == NULL)
 	gui_mswin_get_menu_height(!gui.starting);
-#ifdef FEAT_TEAROFF
+# ifdef FEAT_TEAROFF
     else if (IsWindow(parent->tearoff_handle))
 	rebuild_tearoff(parent);
-#endif
+# endif
 }
 
     void
@@ -6432,7 +6432,7 @@ gui_make_popup(char_u *path_name, int mouse_pos)
     }
 }
 
-#if defined(FEAT_TEAROFF) || defined(PROTO)
+# if defined(FEAT_TEAROFF) || defined(PROTO)
 /*
  * Given a menu descriptor, e.g. "File.New", find it in the menu hierarchy and
  * create it as a pseudo-"tearoff menu".
@@ -6446,7 +6446,7 @@ gui_make_tearoff(char_u *path_name)
     if (menu != NULL)
 	gui_mch_tearoff(menu->dname, menu, 0xffffL, 0xffffL);
 }
-#endif
+# endif
 
 /*
  * Add a menu item to a menu
@@ -6461,15 +6461,15 @@ gui_mch_add_menu_item(
     menu->id = s_menu_id++;
     menu->submenu_id = NULL;
 
-#ifdef FEAT_TEAROFF
+# ifdef FEAT_TEAROFF
     if (STRNCMP(menu->name, TEAR_STRING, TEAR_LEN) == 0)
     {
 	InsertMenu(parent->submenu_id, (UINT)idx, MF_BITMAP|MF_BYPOSITION,
 		(UINT)menu->id, (LPCTSTR) s_htearbitmap);
     }
     else
-#endif
-#ifdef FEAT_TOOLBAR
+# endif
+# ifdef FEAT_TOOLBAR
     if (menu_is_toolbar(parent->name))
     {
 	TBBUTTON newtb;
@@ -6493,7 +6493,7 @@ gui_mch_add_menu_item(
 	menu->submenu_id = (HMENU)-1;
     }
     else
-#endif
+# endif
     {
 	WCHAR	*wn;
 
@@ -6506,10 +6506,10 @@ gui_mch_add_menu_item(
 		    (UINT)menu->id, wn);
 	    vim_free(wn);
 	}
-#ifdef FEAT_TEAROFF
+# ifdef FEAT_TEAROFF
 	if (IsWindow(parent->tearoff_handle))
 	    rebuild_tearoff(parent);
-#endif
+# endif
     }
 }
 
@@ -6519,7 +6519,7 @@ gui_mch_add_menu_item(
     void
 gui_mch_destroy_menu(vimmenu_T *menu)
 {
-#ifdef FEAT_TOOLBAR
+# ifdef FEAT_TOOLBAR
     /*
      * is this a toolbar button?
      */
@@ -6532,7 +6532,7 @@ gui_mch_destroy_menu(vimmenu_T *menu)
 	SendMessage(s_toolbarhwnd, TB_DELETEBUTTON, (WPARAM)iButton, 0);
     }
     else
-#endif
+# endif
     {
 	if (menu->parent != NULL
 		&& menu_is_popup(menu->parent->dname)
@@ -6542,7 +6542,7 @@ gui_mch_destroy_menu(vimmenu_T *menu)
 	    RemoveMenu(s_menuBar, menu->id, MF_BYCOMMAND);
 	if (menu->submenu_id != NULL)
 	    DestroyMenu(menu->submenu_id);
-#ifdef FEAT_TEAROFF
+# ifdef FEAT_TEAROFF
 	if (IsWindow(menu->tearoff_handle))
 	    DestroyWindow(menu->tearoff_handle);
 	if (menu->parent != NULL
@@ -6553,11 +6553,11 @@ gui_mch_destroy_menu(vimmenu_T *menu)
 	    menu->modes = 0;
 	    rebuild_tearoff(menu->parent);
 	}
-#endif
+# endif
     }
 }
 
-#ifdef FEAT_TEAROFF
+# ifdef FEAT_TEAROFF
     static void
 rebuild_tearoff(vimmenu_T *menu)
 {
@@ -6595,7 +6595,7 @@ rebuild_tearoff(vimmenu_T *menu)
 				SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
     }
 }
-#endif /* FEAT_TEAROFF */
+# endif /* FEAT_TEAROFF */
 
 /*
  * Make a menu either grey or not grey.
@@ -6605,7 +6605,7 @@ gui_mch_menu_grey(
     vimmenu_T	*menu,
     int	    grey)
 {
-#ifdef FEAT_TOOLBAR
+# ifdef FEAT_TOOLBAR
     /*
      * is this a toolbar button?
      */
@@ -6615,11 +6615,11 @@ gui_mch_menu_grey(
 	    (WPARAM)menu->id, (LPARAM) MAKELONG((grey ? FALSE : TRUE), 0) );
     }
     else
-#endif
+# endif
     (void)EnableMenuItem(menu->parent ? menu->parent->submenu_id : s_menuBar,
 		    menu->id, MF_BYCOMMAND | (grey ? MF_GRAYED : MF_ENABLED));
 
-#ifdef FEAT_TEAROFF
+# ifdef FEAT_TEAROFF
     if ((menu->parent != NULL) && (IsWindow(menu->parent->tearoff_handle)))
     {
 	WORD menuID;
@@ -6637,7 +6637,7 @@ gui_mch_menu_grey(
 	    EnableWindow(menuHandle, !grey);
 
     }
-#endif
+# endif
 }
 
 #endif /* FEAT_MENU */
@@ -6792,21 +6792,21 @@ gui_mch_dialog(
     int		vertical;
     int		dlgPaddingX;
     int		dlgPaddingY;
-#ifdef USE_SYSMENU_FONT
+# ifdef USE_SYSMENU_FONT
     LOGFONTW	lfSysmenu;
     int		use_lfSysmenu = FALSE;
-#endif
+# endif
     garray_T	ga;
     int		l;
 
-#ifndef NO_CONSOLE
+# ifndef NO_CONSOLE
     /* Don't output anything in silent mode ("ex -s") */
-# ifdef VIMDLL
+#  ifdef VIMDLL
     if (!(gui.in_use || gui.starting))
-# endif
+#  endif
 	if (silent_mode)
 	    return dfltbutton;   /* return default option */
-#endif
+# endif
 
     if (s_hwnd == NULL)
 	get_dialog_font_metrics();
@@ -6858,14 +6858,14 @@ gui_mch_dialog(
      */
     hwnd = GetDesktopWindow();
     hdc = GetWindowDC(hwnd);
-#ifdef USE_SYSMENU_FONT
+# ifdef USE_SYSMENU_FONT
     if (gui_w32_get_menu_font(&lfSysmenu) == OK)
     {
 	font = CreateFontIndirectW(&lfSysmenu);
 	use_lfSysmenu = TRUE;
     }
     else
-#endif
+# endif
     font = CreateFont(-DLG_FONT_POINT_SIZE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		      VARIABLE_PITCH , DLG_FONT_NAME);
     if (s_usenewlook)
@@ -7084,7 +7084,7 @@ gui_mch_dialog(
     if (s_usenewlook)
     {
 	/* do the font, since DS_3DLOOK doesn't work properly */
-#ifdef USE_SYSMENU_FONT
+# ifdef USE_SYSMENU_FONT
 	if (use_lfSysmenu)
 	{
 	    /* point size */
@@ -7094,7 +7094,7 @@ gui_mch_dialog(
 	    nchar = (int)wcslen(lfSysmenu.lfFaceName) + 1;
 	}
 	else
-#endif
+# endif
 	{
 	    *p++ = DLG_FONT_POINT_SIZE;		// point size
 	    nchar = nCopyAnsiToWideChar(p, DLG_FONT_NAME, FALSE);
@@ -7530,10 +7530,10 @@ gui_mch_tearoff(
     int		sepPadding=0;
     int		x;
     int		y;
-#ifdef USE_SYSMENU_FONT
+# ifdef USE_SYSMENU_FONT
     LOGFONTW	lfSysmenu;
     int		use_lfSysmenu = FALSE;
-#endif
+# endif
 
     /*
      * If this menu is already torn off, move it to the mouse position.
@@ -7564,14 +7564,14 @@ gui_mch_tearoff(
 
     hwnd = GetDesktopWindow();
     hdc = GetWindowDC(hwnd);
-#ifdef USE_SYSMENU_FONT
+# ifdef USE_SYSMENU_FONT
     if (gui_w32_get_menu_font(&lfSysmenu) == OK)
     {
 	font = CreateFontIndirectW(&lfSysmenu);
 	use_lfSysmenu = TRUE;
     }
     else
-#endif
+# endif
     font = CreateFont(-DLG_FONT_POINT_SIZE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		      VARIABLE_PITCH , DLG_FONT_NAME);
     if (s_usenewlook)
@@ -7670,7 +7670,7 @@ gui_mch_tearoff(
     if (s_usenewlook)
     {
 	/* do the font, since DS_3DLOOK doesn't work properly */
-#ifdef USE_SYSMENU_FONT
+# ifdef USE_SYSMENU_FONT
 	if (use_lfSysmenu)
 	{
 	    /* point size */
@@ -7680,7 +7680,7 @@ gui_mch_tearoff(
 	    nchar = (int)wcslen(lfSysmenu.lfFaceName) + 1;
 	}
 	else
-#endif
+# endif
 	{
 	    *p++ = DLG_FONT_POINT_SIZE;		// point size
 	    nchar = nCopyAnsiToWideChar(p, DLG_FONT_NAME, FALSE);
@@ -7832,7 +7832,7 @@ gui_mch_tearoff(
 #endif
 
 #if defined(FEAT_TOOLBAR) || defined(PROTO)
-#include "gui_w32_rc.h"
+# include "gui_w32_rc.h"
 
 /* This not defined in older SDKs */
 # ifndef TBSTYLE_FLAT
@@ -7918,9 +7918,9 @@ get_toolbar_bitmap(vimmenu_T *menu)
 	 */
 	if (hbitmap == NULL
 		&& (gui_find_bitmap(
-#ifdef FEAT_MULTI_LANG
+# ifdef FEAT_MULTI_LANG
 			    menu->en_dname != NULL ? menu->en_dname :
-#endif
+# endif
 					menu->dname, fname, "bmp") == OK))
 	    hbitmap = LoadImage(
 		    NULL,
@@ -8156,9 +8156,9 @@ typedef struct _signicon_t
 {
     HANDLE	hImage;
     UINT	uType;
-#ifdef FEAT_XPM_W32
+# ifdef FEAT_XPM_W32
     HANDLE	hShape;	/* Mask bitmap handle */
-#endif
+# endif
 } signicon_t;
 
     void
@@ -8170,10 +8170,10 @@ gui_mch_drawsign(int row, int col, int typenr)
     if (!gui.in_use || (sign = (signicon_t *)sign_get_image(typenr)) == NULL)
 	return;
 
-#if defined(FEAT_DIRECTX)
+# if defined(FEAT_DIRECTX)
     if (IS_ENABLE_DIRECTX())
 	DWriteContext_Flush(s_dwc);
-#endif
+# endif
 
     x = TEXT_X(col);
     y = TEXT_Y(row);
@@ -8197,7 +8197,7 @@ gui_mch_drawsign(int row, int col, int typenr)
 	case IMAGE_CURSOR:
 	    DrawIconEx(s_hdc, x, y, (HICON)sign->hImage, w, h, 0, NULL, DI_NORMAL);
 	    break;
-#ifdef FEAT_XPM_W32
+# ifdef FEAT_XPM_W32
 	case IMAGE_XPM:
 	    {
 		HDC hdcMem;
@@ -8215,7 +8215,7 @@ gui_mch_drawsign(int row, int col, int typenr)
 		DeleteDC(hdcMem);
 	    }
 	    break;
-#endif
+# endif
     }
 }
 
@@ -8234,12 +8234,12 @@ close_signicon_image(signicon_t *sign)
 	    case IMAGE_ICON:
 		DestroyIcon((HICON)sign->hImage);
 		break;
-#ifdef FEAT_XPM_W32
+# ifdef FEAT_XPM_W32
 	    case IMAGE_XPM:
 		DeleteObject((HBITMAP)sign->hImage);
 		DeleteObject((HBITMAP)sign->hShape);
 		break;
-#endif
+# endif
 	}
 }
 
@@ -8268,14 +8268,14 @@ gui_mch_register_sign(char_u *signfile)
 	    sign.hImage = (HANDLE)LoadImage(NULL, (LPCSTR)signfile, sign.uType,
 		    gui.char_width * 2, gui.char_height,
 		    LR_LOADFROMFILE | LR_CREATEDIBSECTION);
-#ifdef FEAT_XPM_W32
+# ifdef FEAT_XPM_W32
 	if (!STRICMP(ext, ".xpm"))
 	{
 	    sign.uType = IMAGE_XPM;
 	    LoadXpmImage((char *)signfile, (HBITMAP *)&sign.hImage,
 		    (HBITMAP *)&sign.hShape);
 	}
-#endif
+# endif
     }
 
     psign = NULL;
@@ -8650,9 +8650,9 @@ TrackUserActivity(UINT uMsg)
     void
 gui_mch_destroy_beval_area(BalloonEval *beval)
 {
-#ifdef FEAT_VARTABS
+# ifdef FEAT_VARTABS
     vim_free(beval->vts);
-#endif
+# endif
     vim_free(beval->tofree);
     vim_free(beval);
 }
@@ -8676,10 +8676,10 @@ netbeans_draw_multisign_indicator(int row)
     x = 0;
     y = TEXT_Y(row);
 
-#if defined(FEAT_DIRECTX)
+# if defined(FEAT_DIRECTX)
     if (IS_ENABLE_DIRECTX())
 	DWriteContext_Flush(s_dwc);
-#endif
+# endif
 
     for (i = 0; i < gui.char_height - 3; i++)
 	SetPixel(s_hdc, x+2, y++, gui.currFgColor);

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -77,8 +77,8 @@
  * errors disappear.  They do not need to be correct.
  */
 #ifdef PROTO
-#define WINAPI
-#define WINBASEAPI
+# define WINAPI
+# define WINBASEAPI
 typedef int BOOL;
 typedef int CALLBACK;
 typedef int COLORREF;
@@ -211,16 +211,16 @@ mch_exit_g(int r)
 	WSACleanup();
     }
 # endif
-#ifdef DYNAMIC_GETTEXT
+# ifdef DYNAMIC_GETTEXT
     dyn_libintl_end();
-#endif
+# endif
 
     if (gui.in_use)
 	gui_exit(r);
 
-#ifdef EXITFREE
+# ifdef EXITFREE
     free_all_mem();
-#endif
+# endif
 
     exit(r);
 }
@@ -309,12 +309,12 @@ mch_settitle(
     void
 mch_restore_title(int which UNUSED)
 {
-#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
-# ifdef VIMDLL
+# if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
+#  ifdef VIMDLL
     if (!gui.in_use)
-# endif
+#  endif
 	SetConsoleTitle(g_szOrigTitle);
-#endif
+# endif
 }
 
 
@@ -663,11 +663,11 @@ mch_has_wildcard(char_u *p)
     for ( ; *p; MB_PTR_ADV(p))
     {
 	if (vim_strchr((char_u *)
-#  ifdef VIM_BACKTICK
+#ifdef VIM_BACKTICK
 				    "?*$[`"
-#  else
+#else
 				    "?*$["
-#  endif
+#endif
 						, *p) != NULL
 		|| (*p == '~' && p[1] != NUL))
 	    return TRUE;
@@ -854,10 +854,10 @@ mch_libcall(
     // If the handle is valid, try to get the function address.
     if (hinstLib != NULL)
     {
-#ifdef HAVE_TRY_EXCEPT
+# ifdef HAVE_TRY_EXCEPT
 	__try
 	{
-#endif
+# endif
 	if (argstring != NULL)
 	{
 	    /* Call with string argument */
@@ -895,7 +895,7 @@ mch_libcall(
 		mch_memmove(*string_result, retval_str, len);
 	}
 
-#ifdef HAVE_TRY_EXCEPT
+# ifdef HAVE_TRY_EXCEPT
 	}
 	__except(EXCEPTION_EXECUTE_HANDLER)
 	{
@@ -903,7 +903,7 @@ mch_libcall(
 		RESETSTKOFLW();
 	    fRunTimeLinkSuccess = 0;
 	}
-#endif
+# endif
 
 	// Free the DLL module.
 	(void)FreeLibrary(hinstLib);
@@ -925,7 +925,7 @@ mch_libcall(
     void
 DumpPutS(const char *psz UNUSED)
 {
-# ifdef MCH_WRITE_DUMP
+#ifdef MCH_WRITE_DUMP
     if (fdDump)
     {
 	fputs(psz, fdDump);
@@ -933,7 +933,7 @@ DumpPutS(const char *psz UNUSED)
 	    fputc('\n', fdDump);
 	fflush(fdDump);
     }
-# endif
+#endif
 }
 
 #ifdef _DEBUG
@@ -1032,10 +1032,10 @@ static int		*bUserAbort = NULL;
 static char_u		*prt_name = NULL;
 
 /* Defines which are also in vim.rc. */
-#define IDC_BOX1		400
-#define IDC_PRINTTEXT1		401
-#define IDC_PRINTTEXT2		402
-#define IDC_PROGRESS		403
+# define IDC_BOX1		400
+# define IDC_PRINTTEXT1		401
+# define IDC_PRINTTEXT2		402
+# define IDC_PROGRESS		403
 
     static BOOL
 vimSetDlgItemText(HWND hDlg, int nIDDlgItem, char_u *s)
@@ -1068,11 +1068,11 @@ swap_me(COLORREF colorref)
 }
 
 /* Attempt to make this work for old and new compilers */
-#if !defined(_WIN64) && (!defined(_MSC_VER) || _MSC_VER < 1300)
-# define PDP_RETVAL BOOL
-#else
-# define PDP_RETVAL INT_PTR
-#endif
+# if !defined(_WIN64) && (!defined(_MSC_VER) || _MSC_VER < 1300)
+#  define PDP_RETVAL BOOL
+# else
+#  define PDP_RETVAL INT_PTR
+# endif
 
     static PDP_RETVAL CALLBACK
 PrintDlgProc(
@@ -1081,15 +1081,15 @@ PrintDlgProc(
 	WPARAM wParam UNUSED,
 	LPARAM lParam UNUSED)
 {
-#ifdef FEAT_GETTEXT
+# ifdef FEAT_GETTEXT
     NONCLIENTMETRICS nm;
     static HFONT hfont;
-#endif
+# endif
 
     switch (message)
     {
 	case WM_INITDIALOG:
-#ifdef FEAT_GETTEXT
+# ifdef FEAT_GETTEXT
 	    nm.cbSize = sizeof(NONCLIENTMETRICS);
 	    if (SystemParametersInfo(
 			SPI_GETNONCLIENTMETRICS,
@@ -1113,7 +1113,7 @@ PrintDlgProc(
 		if (GetDlgItemText(hDlg,IDCANCEL, buff, sizeof(buff)))
 		    vimSetDlgItemText(hDlg,IDCANCEL, (char_u *)_(buff));
 	    }
-#endif
+# endif
 	    SetWindowText(hDlg, (LPCSTR)szAppName);
 	    if (prt_name != NULL)
 	    {
@@ -1121,12 +1121,12 @@ PrintDlgProc(
 		VIM_CLEAR(prt_name);
 	    }
 	    EnableMenuItem(GetSystemMenu(hDlg, FALSE), SC_CLOSE, MF_GRAYED);
-#if !defined(FEAT_GUI) || defined(VIMDLL)
-# ifdef VIMDLL
+# if !defined(FEAT_GUI) || defined(VIMDLL)
+#  ifdef VIMDLL
 	    if (!gui.in_use)
-# endif
+#  endif
 		BringWindowToTop(s_hwnd);
-#endif
+# endif
 	    return TRUE;
 
 	case WM_COMMAND:
@@ -1134,9 +1134,9 @@ PrintDlgProc(
 	    EnableWindow(GetParent(hDlg), TRUE);
 	    DestroyWindow(hDlg);
 	    hDlgPrint = NULL;
-#ifdef FEAT_GETTEXT
+# ifdef FEAT_GETTEXT
 	    DeleteObject(hfont);
-#endif
+# endif
 	    return TRUE;
     }
     return FALSE;
@@ -1158,7 +1158,7 @@ AbortProc(HDC hdcPrn UNUSED, int iCode UNUSED)
     return !*bUserAbort;
 }
 
-#if !defined(FEAT_GUI) || defined(VIMDLL)
+# if !defined(FEAT_GUI) || defined(VIMDLL)
 
     static UINT_PTR CALLBACK
 PrintHookProc(
@@ -1212,7 +1212,7 @@ PrintHookProc(
 
     return FALSE;
 }
-#endif
+# endif
 
     void
 mch_print_cleanup(void)
@@ -1352,12 +1352,12 @@ mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
     bUserAbort = &(psettings->user_abort);
     vim_memset(&prt_dlg, 0, sizeof(PRINTDLGW));
     prt_dlg.lStructSize = sizeof(PRINTDLGW);
-#if !defined(FEAT_GUI) || defined(VIMDLL)
-# ifdef VIMDLL
+# if !defined(FEAT_GUI) || defined(VIMDLL)
+#  ifdef VIMDLL
     if (!gui.in_use)
-# endif
+#  endif
 	GetConsoleHwnd();	    /* get value of s_hwnd */
-#endif
+# endif
     prt_dlg.hwndOwner = s_hwnd;
     prt_dlg.Flags = PD_NOPAGENUMS | PD_NOSELECTION | PD_RETURNDC;
     if (!forceit)
@@ -1365,10 +1365,10 @@ mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
 	prt_dlg.hDevMode = stored_dm;
 	prt_dlg.hDevNames = stored_devn;
 	prt_dlg.lCustData = stored_nCopies; // work around bug in print dialog
-#if !defined(FEAT_GUI) || defined(VIMDLL)
-# ifdef VIMDLL
+# if !defined(FEAT_GUI) || defined(VIMDLL)
+#  ifdef VIMDLL
 	if (!gui.in_use)
-# endif
+#  endif
 	{
 	    /*
 	     * Use hook to prevent console window being sent to back
@@ -1376,7 +1376,7 @@ mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
 	    prt_dlg.lpfnPrintHook = PrintHookProc;
 	    prt_dlg.Flags |= PD_ENABLEPRINTHOOK;
 	}
-#endif
+# endif
 	prt_dlg.Flags |= stored_nFlags;
     }
 
@@ -1385,13 +1385,13 @@ mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
      * never show dialog if we are running over telnet
      */
     if (forceit
-#if !defined(FEAT_GUI) || defined(VIMDLL)
-# ifdef VIMDLL
+# if !defined(FEAT_GUI) || defined(VIMDLL)
+#  ifdef VIMDLL
 	    || (!gui.in_use && !term_console)
-# else
+#  else
 	    || !term_console
+#  endif
 # endif
-#endif
 	    )
     {
 	prt_dlg.Flags |= PD_RETURNDEFAULT;
@@ -1581,13 +1581,13 @@ mch_print_begin(prt_settings_T *psettings)
 	vim_free(wp);
     }
 
-#ifdef FEAT_GUI
+# ifdef FEAT_GUI
     /* Give focus back to main window (when using MDI). */
-# ifdef VIMDLL
+#  ifdef VIMDLL
     if (gui.in_use)
-# endif
+#  endif
 	SetFocus(s_hwnd);
-#endif
+# endif
 
     return (ret > 0);
 }
@@ -1929,17 +1929,17 @@ win32_set_foreground(void)
  */
 HWND message_window = 0;	    /* window that's handling messages */
 
-#define VIM_CLASSNAME      "VIM_MESSAGES"
-#define VIM_CLASSNAME_LEN  (sizeof(VIM_CLASSNAME) - 1)
+# define VIM_CLASSNAME      "VIM_MESSAGES"
+# define VIM_CLASSNAME_LEN  (sizeof(VIM_CLASSNAME) - 1)
 
 /* Communication is via WM_COPYDATA messages. The message type is send in
  * the dwData parameter. Types are defined here. */
-#define COPYDATA_KEYS		0
-#define COPYDATA_REPLY		1
-#define COPYDATA_EXPR		10
-#define COPYDATA_RESULT		11
-#define COPYDATA_ERROR_RESULT	12
-#define COPYDATA_ENCODING	20
+# define COPYDATA_KEYS		0
+# define COPYDATA_REPLY		1
+# define COPYDATA_EXPR		10
+# define COPYDATA_RESULT	11
+# define COPYDATA_ERROR_RESULT	12
+# define COPYDATA_ENCODING	20
 
 /* This is a structure containing a server HWND and its name. */
 struct server_id
@@ -2116,12 +2116,12 @@ Messaging_WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     {
 	/* When the message window is activated (brought to the foreground),
 	 * this actually applies to the text window. */
-#if !defined(FEAT_GUI) || defined(VIMDLL)
-# ifdef VIMDLL
+# if !defined(FEAT_GUI) || defined(VIMDLL)
+#  ifdef VIMDLL
 	if (!gui.in_use)
-# endif
+#  endif
 	    GetConsoleHwnd();	    /* get value of s_hwnd */
-#endif
+# endif
 	if (s_hwnd != 0)
 	{
 	    SetForegroundWindow(s_hwnd);
@@ -2323,17 +2323,17 @@ serverSetName(char_u *name)
     {
 	/* Remember the name */
 	serverName = ok_name;
-#ifdef FEAT_TITLE
+# ifdef FEAT_TITLE
 	need_maketitle = TRUE;	/* update Vim window title later */
-#endif
+# endif
 
 	/* Update the message window title */
 	SetWindowText(message_window, (LPCSTR)ok_name);
 
-#ifdef FEAT_EVAL
+# ifdef FEAT_EVAL
 	/* Set the servername variable */
 	set_vim_var_string(VV_SEND_SERVER, serverName, -1);
-#endif
+# endif
     }
 }
 
@@ -2473,8 +2473,8 @@ typedef struct
 
 static garray_T reply_list = {0, 0, sizeof(reply_T), 5, 0};
 
-#define REPLY_ITEM(i) ((reply_T *)(reply_list.ga_data) + (i))
-#define REPLY_COUNT (reply_list.ga_len)
+# define REPLY_ITEM(i) ((reply_T *)(reply_list.ga_data) + (i))
+# define REPLY_COUNT (reply_list.ga_len)
 
 /* Flag which is used to wait for a reply */
 static int reply_received = 0;
@@ -2574,10 +2574,10 @@ serverGetReply(HWND server, int *expr_res, int remove, int wait, int timeout)
 	/* Loop until we receive a reply */
 	while (reply_received == 0)
 	{
-#ifdef FEAT_TIMERS
+# ifdef FEAT_TIMERS
 	    /* TODO: use the return value to decide how long to wait. */
 	    check_due_timer();
-#endif
+# endif
 	    time(&now);
 	    if (timeout > 0 && (now - start) >= timeout)
 		break;
@@ -2645,9 +2645,9 @@ charset_pairs[] =
     {"RUSSIAN",		RUSSIAN_CHARSET},
     {"THAI",		THAI_CHARSET},
     {"TURKISH",		TURKISH_CHARSET},
-#ifdef VIETNAMESE_CHARSET
+# ifdef VIETNAMESE_CHARSET
     {"VIETNAMESE",	VIETNAMESE_CHARSET},
-#endif
+# endif
     {NULL,		0}
 };
 
@@ -2659,21 +2659,21 @@ struct quality_pair
 
 static struct quality_pair
 quality_pairs[] = {
-#ifdef CLEARTYPE_QUALITY
+# ifdef CLEARTYPE_QUALITY
     {"CLEARTYPE",	CLEARTYPE_QUALITY},
-#endif
-#ifdef ANTIALIASED_QUALITY
+# endif
+# ifdef ANTIALIASED_QUALITY
     {"ANTIALIASED",	ANTIALIASED_QUALITY},
-#endif
-#ifdef NONANTIALIASED_QUALITY
+# endif
+# ifdef NONANTIALIASED_QUALITY
     {"NONANTIALIASED",	NONANTIALIASED_QUALITY},
-#endif
-#ifdef PROOF_QUALITY
+# endif
+# ifdef PROOF_QUALITY
     {"PROOF",		PROOF_QUALITY},
-#endif
-#ifdef DRAFT_QUALITY
+# endif
+# ifdef DRAFT_QUALITY
     {"DRAFT",		DRAFT_QUALITY},
-#endif
+# endif
     {"DEFAULT",		DEFAULT_QUALITY},
     {NULL,		0}
 };
@@ -2799,11 +2799,11 @@ font_enumproc(
 
     LOGFONTW *lf = (LOGFONTW *)(lparam);
 
-#ifndef FEAT_PROPORTIONAL_FONTS
+# ifndef FEAT_PROPORTIONAL_FONTS
     /* Ignore non-monospace fonts without further ado */
     if ((ntm->tmPitchAndFamily & 1) != 0)
 	return 1;
-#endif
+# endif
 
     /* Remember this LOGFONTW as a "possible" */
     *lf = elf->elfLogFont;
@@ -2895,7 +2895,7 @@ get_logfont(
 
     if (wcscmp(wname, L"*") == 0)
     {
-#if defined(FEAT_GUI_MSWIN)
+# if defined(FEAT_GUI_MSWIN)
 	CHOOSEFONTW	cf;
 	/* if name is "*", bring up std font dialog: */
 	vim_memset(&cf, 0, sizeof(cf));
@@ -2908,7 +2908,7 @@ get_logfont(
 	cf.nFontType = 0 ; //REGULAR_FONTTYPE;
 	if (ChooseFontW(&cf))
 	    ret = OK;
-#endif
+# endif
 	goto theend;
     }
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -94,7 +94,7 @@ FILE* fdDump = NULL;
  * errors disappear.  They do not need to be correct.
  */
 #ifdef PROTO
-#define WINAPI
+# define WINAPI
 typedef char * LPCSTR;
 typedef char * LPWSTR;
 typedef int ACCESS_MASK;
@@ -257,7 +257,7 @@ static BOOL has_csbiex = FALSE;
  * Get version number including build number
  */
 typedef BOOL (WINAPI *PfnRtlGetVersion)(LPOSVERSIONINFOW);
-# define MAKE_VER(major, minor, build) \
+#define MAKE_VER(major, minor, build) \
     (((major) << 24) | ((minor) << 16) | (build))
 
     static DWORD
@@ -641,14 +641,14 @@ dyn_libintl_init(void)
 	return 1;
     // Load gettext library (libintl.dll and other names).
     hLibintlDLL = vimLoadLib(GETTEXT_DLL);
-#ifdef GETTEXT_DLL_ALT1
+# ifdef GETTEXT_DLL_ALT1
     if (!hLibintlDLL)
 	hLibintlDLL = vimLoadLib(GETTEXT_DLL_ALT1);
-#endif
-#ifdef GETTEXT_DLL_ALT2
+# endif
+# ifdef GETTEXT_DLL_ALT2
     if (!hLibintlDLL)
 	hLibintlDLL = vimLoadLib(GETTEXT_DLL_ALT2);
-#endif
+# endif
     if (!hLibintlDLL)
     {
 	if (p_verbose > 0)
@@ -837,10 +837,10 @@ PlatformId(void)
 
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
 
-#define SHIFT  (SHIFT_PRESSED)
-#define CTRL   (RIGHT_CTRL_PRESSED | LEFT_CTRL_PRESSED)
-#define ALT    (RIGHT_ALT_PRESSED  | LEFT_ALT_PRESSED)
-#define ALT_GR (RIGHT_ALT_PRESSED  | LEFT_CTRL_PRESSED)
+# define SHIFT  (SHIFT_PRESSED)
+# define CTRL   (RIGHT_CTRL_PRESSED | LEFT_CTRL_PRESSED)
+# define ALT    (RIGHT_ALT_PRESSED  | LEFT_ALT_PRESSED)
+# define ALT_GR (RIGHT_ALT_PRESSED  | LEFT_CTRL_PRESSED)
 
 
 /* When uChar.AsciiChar is 0, then we need to look at wVirtualKeyCode.
@@ -891,7 +891,7 @@ static const struct
 
     { VK_SNAPSHOT,TRUE,	0,	0,	0,	    'r', }, // PrtScrn
 
-#if 0
+# if 0
     // Most people don't have F13-F20, but what the hell...
     { VK_F13,	TRUE,	'\332',	'\333',	'\334',	    '\335', },
     { VK_F14,	TRUE,	'\336',	'\337',	'\340',	    '\341', },
@@ -901,7 +901,7 @@ static const struct
     { VK_F18,	TRUE,	'\356',	'\357',	'\360',	    '\361', },
     { VK_F19,	TRUE,	'\362',	'\363',	'\364',	    '\365', },
     { VK_F20,	TRUE,	'\366',	'\367',	'\370',	    '\371', },
-#endif
+# endif
     { VK_ADD,	TRUE,   'N',    'N',    'N',	'N',	}, // keyp '+'
     { VK_SUBTRACT, TRUE,'J',	'J',    'J',	'J',	}, // keyp '-'
  // { VK_DIVIDE,   TRUE,'N',	'N',    'N',	'N',	}, // keyp '/'
@@ -921,11 +921,11 @@ static const struct
 };
 
 
-#if defined(__GNUC__) && !defined(__MINGW32__)  && !defined(__CYGWIN__)
-# define UChar UnicodeChar
-#else
-# define UChar uChar.UnicodeChar
-#endif
+# if defined(__GNUC__) && !defined(__MINGW32__)  && !defined(__CYGWIN__)
+#  define UChar UnicodeChar
+# else
+#  define UChar uChar.UnicodeChar
+# endif
 
 /* The return code indicates key code size. */
     static int
@@ -1489,9 +1489,9 @@ WaitForChar(long msec, int ignore_input)
     INPUT_RECORD    ir;
     DWORD	    cRecords;
     WCHAR	    ch, ch2;
-#ifdef FEAT_TIMERS
+# ifdef FEAT_TIMERS
     int		    tb_change_cnt = typebuf.tb_change_cnt;
-#endif
+# endif
 
     if (msec > 0)
 	/* Wait until the specified time has elapsed. */
@@ -1507,21 +1507,21 @@ WaitForChar(long msec, int ignore_input)
 	// Only process messages when waiting.
 	if (msec != 0)
 	{
-#ifdef MESSAGE_QUEUE
+# ifdef MESSAGE_QUEUE
 	    parse_queued_messages();
-#endif
-#ifdef FEAT_MZSCHEME
+# endif
+# ifdef FEAT_MZSCHEME
 	    mzvim_check_threads();
-#endif
-#ifdef FEAT_CLIENTSERVER
+# endif
+# ifdef FEAT_CLIENTSERVER
 	    serverProcessPendingMessages();
-#endif
+# endif
 	}
 
 	if (g_nMouseClick != -1
-#ifdef FEAT_CLIENTSERVER
+# ifdef FEAT_CLIENTSERVER
 		|| (!ignore_input && input_available())
-#endif
+# endif
 	   )
 	    return TRUE;
 
@@ -1537,7 +1537,7 @@ WaitForChar(long msec, int ignore_input)
 	{
 	    DWORD dwWaitTime = dwEndTime - dwNow;
 
-#ifdef FEAT_JOB_CHANNEL
+# ifdef FEAT_JOB_CHANNEL
 	    /* Check channel while waiting for input. */
 	    if (dwWaitTime > 100)
 	    {
@@ -1547,19 +1547,19 @@ WaitForChar(long msec, int ignore_input)
 		if (channel_any_readahead())
 		    dwWaitTime = 10;
 	    }
-#endif
-#ifdef FEAT_BEVAL_GUI
+# endif
+# ifdef FEAT_BEVAL_GUI
 	    if (p_beval && dwWaitTime > 100)
 		/* The 'balloonexpr' may indirectly invoke a callback while
 		 * waiting for a character, need to check often. */
 		dwWaitTime = 100;
-#endif
-#ifdef FEAT_MZSCHEME
+# endif
+# ifdef FEAT_MZSCHEME
 	    if (mzthreads_allowed() && p_mzq > 0
 				    && (msec < 0 || (long)dwWaitTime > p_mzq))
 		dwWaitTime = p_mzq; /* don't wait longer than 'mzquantum' */
-#endif
-#ifdef FEAT_TIMERS
+# endif
+# ifdef FEAT_TIMERS
 	    // When waiting very briefly don't trigger timers.
 	    if (dwWaitTime > 10)
 	    {
@@ -1576,17 +1576,17 @@ WaitForChar(long msec, int ignore_input)
 		if (due_time > 0 && dwWaitTime > (DWORD)due_time)
 		    dwWaitTime = due_time;
 	    }
-#endif
+# endif
 	    if (
-#ifdef FEAT_CLIENTSERVER
+# ifdef FEAT_CLIENTSERVER
 		    // Wait for either an event on the console input or a
 		    // message in the client-server window.
 		    msg_wait_for_multiple_objects(1, &g_hConIn, FALSE,
 				  dwWaitTime, QS_SENDMESSAGE) != WAIT_OBJECT_0
-#else
+# else
 		    wait_for_single_object(g_hConIn, dwWaitTime)
 							      != WAIT_OBJECT_0
-#endif
+# endif
 		    )
 		continue;
 	}
@@ -1594,7 +1594,7 @@ WaitForChar(long msec, int ignore_input)
 	cRecords = 0;
 	peek_console_input(g_hConIn, &ir, 1, &cRecords);
 
-#ifdef FEAT_MBYTE_IME
+# ifdef FEAT_MBYTE_IME
 	if (State & CMDLINE && msg_row == Rows - 1)
 	{
 	    CONSOLE_SCREEN_BUFFER_INFO csbi;
@@ -1611,13 +1611,13 @@ WaitForChar(long msec, int ignore_input)
 		}
 	    }
 	}
-#endif
+# endif
 
 	if (cRecords > 0)
 	{
 	    if (ir.EventType == KEY_EVENT && ir.Event.KeyEvent.bKeyDown)
 	    {
-#ifdef FEAT_MBYTE_IME
+# ifdef FEAT_MBYTE_IME
 		/* Windows IME sends two '\n's with only one 'ENTER'.  First:
 		 * wVirtualKeyCode == 13. second: wVirtualKeyCode == 0 */
 		if (ir.Event.KeyEvent.UChar == 0
@@ -1626,7 +1626,7 @@ WaitForChar(long msec, int ignore_input)
 		    read_console_input(g_hConIn, &ir, 1, &cRecords);
 		    continue;
 		}
-#endif
+# endif
 		if (decode_key_event(&ir.Event.KeyEvent, &ch, &ch2,
 								 NULL, FALSE))
 		    return TRUE;
@@ -1641,7 +1641,7 @@ WaitForChar(long msec, int ignore_input)
 		COORD dwSize = ir.Event.WindowBufferSizeEvent.dwSize;
 
 		// Only call shell_resized() when the size actually change to
-		// avoid the screen is cleard.
+		// avoid the screen is cleared.
 		if (dwSize.X != Columns || dwSize.Y != Rows)
 		{
 		    CONSOLE_SCREEN_BUFFER_INFO csbi;
@@ -1659,11 +1659,11 @@ WaitForChar(long msec, int ignore_input)
 	    break;
     }
 
-#ifdef FEAT_CLIENTSERVER
+# ifdef FEAT_CLIENTSERVER
     /* Something might have been received while we were waiting. */
     if (input_available())
 	return TRUE;
-#endif
+# endif
 
     return FALSE;
 }
@@ -1722,13 +1722,13 @@ tgetch(int *pmodifiers, WCHAR *pch2)
 	INPUT_RECORD ir;
 	DWORD cRecords = 0;
 
-#ifdef FEAT_CLIENTSERVER
+# ifdef FEAT_CLIENTSERVER
 	(void)WaitForChar(-1L, FALSE);
 	if (input_available())
 	    return 0;
 	if (g_nMouseClick != -1)
 	    return 0;
-#endif
+# endif
 	if (read_console_input(g_hConIn, &ir, 1, &cRecords) == 0)
 	{
 	    if (did_create_conin)
@@ -1776,7 +1776,7 @@ mch_inchar(
 
     int		len;
     int		c;
-#define TYPEAHEADLEN 20
+# define TYPEAHEADLEN 20
     static char_u   typeahead[TYPEAHEADLEN];	/* previously typed bytes. */
     static int	    typeaheadlen = 0;
 
@@ -1823,10 +1823,10 @@ mch_inchar(
     /* we will get at least one key. Get more if they are available. */
     g_fCBrkPressed = FALSE;
 
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
     if (fdDump)
 	fputc('[', fdDump);
-#endif
+# endif
 
     /* Keep looping until there is something in the typeahead buffer and more
      * to get and still room in the buffer (up to two bytes for a char and
@@ -1843,11 +1843,11 @@ mch_inchar(
 	}
 	if (g_nMouseClick != -1)
 	{
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	    if (fdDump)
 		fprintf(fdDump, "{%02x @ %d, %d}",
 			g_nMouseClick, g_xMouse, g_yMouse);
-#endif
+# endif
 	    typeahead[typeaheadlen++] = ESC + 128;
 	    typeahead[typeaheadlen++] = 'M';
 	    typeahead[typeaheadlen++] = g_nMouseClick;
@@ -1872,9 +1872,9 @@ mch_inchar(
 
 	    if (c == Ctrl_C && ctrl_c_interrupts)
 	    {
-#if defined(FEAT_CLIENTSERVER)
+# if defined(FEAT_CLIENTSERVER)
 		trash_input_buf();
-#endif
+# endif
 		got_int = TRUE;
 	    }
 
@@ -1960,21 +1960,21 @@ mch_inchar(
 
 		typeaheadlen += n;
 
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 		if (fdDump)
 		    fputc(c, fdDump);
-#endif
+# endif
 	    }
 	}
     }
 
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
     if (fdDump)
     {
 	fputs("]\n", fdDump);
 	fflush(fdDump);
     }
-#endif
+# endif
 
 theend:
     /* Move typeahead to "buf", as much as fits. */
@@ -2088,9 +2088,9 @@ bad_param_handler(const wchar_t *expression,
     static void
 mch_init_g(void)
 {
-#ifndef __MINGW32__
+# ifndef __MINGW32__
     extern int _fmode;
-#endif
+# endif
 
     /* Silently handle invalid parameters to CRT functions */
     SET_INVALID_PARAM_HANDLER;
@@ -2145,9 +2145,9 @@ mch_init_g(void)
     if (!executable_exists("findstr.exe", NULL, TRUE))
 	set_option_value((char_u *)"grepprg", 0, (char_u *)"grep -n", 0);
 
-#ifdef FEAT_CLIPBOARD
+# ifdef FEAT_CLIPBOARD
     win_clip_init();
-#endif
+# endif
 
     vtp_flag_init();
 }
@@ -2157,8 +2157,8 @@ mch_init_g(void)
 
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
 
-#define SRWIDTH(sr) ((sr).Right - (sr).Left + 1)
-#define SRHEIGHT(sr) ((sr).Bottom - (sr).Top + 1)
+# define SRWIDTH(sr) ((sr).Right - (sr).Left + 1)
+# define SRHEIGHT(sr) ((sr).Bottom - (sr).Top + 1)
 
 /*
  * ClearConsoleBuffer()
@@ -2429,14 +2429,14 @@ RestoreConsoleBuffer(
     return TRUE;
 }
 
-#define FEAT_RESTORE_ORIG_SCREEN
-#ifdef FEAT_RESTORE_ORIG_SCREEN
+# define FEAT_RESTORE_ORIG_SCREEN
+# ifdef FEAT_RESTORE_ORIG_SCREEN
 static ConsoleBuffer g_cbOrig = { 0 };
-#endif
+# endif
 static ConsoleBuffer g_cbNonTermcap = { 0 };
 static ConsoleBuffer g_cbTermcap = { 0 };
 
-#ifdef FEAT_TITLE
+# ifdef FEAT_TITLE
 char g_szOrigTitle[256] = { 0 };
 HWND g_hWnd = NULL;	/* also used in os_mswin.c */
 static HICON g_hOrigIconSmall = NULL;
@@ -2445,12 +2445,12 @@ static HICON g_hVimIcon = NULL;
 static BOOL g_fCanChangeIcon = FALSE;
 
 /* ICON* are not defined in VC++ 4.0 */
-#ifndef ICON_SMALL
-#define ICON_SMALL 0
-#endif
-#ifndef ICON_BIG
-#define ICON_BIG 1
-#endif
+#  ifndef ICON_SMALL
+#   define ICON_SMALL 0
+#  endif
+#  ifndef ICON_BIG
+#   define ICON_BIG 1
+#  endif
 /*
  * GetConsoleIcon()
  * Description:
@@ -2542,7 +2542,7 @@ SaveConsoleTitleAndIcon(void)
     if (g_hVimIcon != NULL)
 	g_fCanChangeIcon = TRUE;
 }
-#endif
+# endif
 
 static int g_fWindInitCalled = FALSE;
 static int g_fTermcapMode = FALSE;
@@ -2556,12 +2556,12 @@ static DWORD g_cmodeout = 0;
     static void
 mch_init_c(void)
 {
-#ifndef FEAT_RESTORE_ORIG_SCREEN
+# ifndef FEAT_RESTORE_ORIG_SCREEN
     CONSOLE_SCREEN_BUFFER_INFO csbi;
-#endif
-#ifndef __MINGW32__
+# endif
+# ifndef __MINGW32__
     extern int _fmode;
-#endif
+# endif
 
     /* Silently handle invalid parameters to CRT functions */
     SET_INVALID_PARAM_HANDLER;
@@ -2580,15 +2580,15 @@ mch_init_c(void)
 	create_conin();
     g_hConOut = GetStdHandle(STD_OUTPUT_HANDLE);
 
-#ifdef FEAT_RESTORE_ORIG_SCREEN
+# ifdef FEAT_RESTORE_ORIG_SCREEN
     /* Save the initial console buffer for later restoration */
     SaveConsoleBuffer(&g_cbOrig);
     g_attrCurrent = g_attrDefault = g_cbOrig.Info.wAttributes;
-#else
+# else
     /* Get current text attributes */
     GetConsoleScreenBufferInfo(g_hConOut, &csbi);
     g_attrCurrent = g_attrDefault = csbi.wAttributes;
-#endif
+# endif
     if (cterm_normal_fg_color == 0)
 	cterm_normal_fg_color = (g_attrCurrent & 0xf) + 1;
     if (cterm_normal_bg_color == 0)
@@ -2605,7 +2605,7 @@ mch_init_c(void)
     GetConsoleMode(g_hConIn,  &g_cmodein);
     GetConsoleMode(g_hConOut, &g_cmodeout);
 
-#ifdef FEAT_TITLE
+# ifdef FEAT_TITLE
     SaveConsoleTitleAndIcon();
     /*
      * Set both the small and big icons of the console window to Vim's icon.
@@ -2614,11 +2614,11 @@ mch_init_c(void)
      */
     if (g_fCanChangeIcon)
 	SetConsoleIcon(g_hWnd, g_hVimIcon, g_hVimIcon);
-#endif
+# endif
 
     ui_get_shellsize();
 
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
     fdDump = fopen("dump", "wt");
 
     if (fdDump)
@@ -2629,15 +2629,15 @@ mch_init_c(void)
 	fputs(ctime(&t), fdDump);
 	fflush(fdDump);
     }
-#endif
+# endif
 
     g_fWindInitCalled = TRUE;
 
     g_fMouseAvail = GetSystemMetrics(SM_MOUSEPRESENT);
 
-#ifdef FEAT_CLIPBOARD
+# ifdef FEAT_CLIPBOARD
     win_clip_init();
-#endif
+# endif
 
     vtp_flag_init();
     vtp_init();
@@ -2663,7 +2663,7 @@ mch_exit_c(int r)
 
     if (g_fWindInitCalled)
     {
-#ifdef FEAT_TITLE
+# ifdef FEAT_TITLE
 	mch_restore_title(SAVE_RESTORE_BOTH);
 	/*
 	 * Restore both the small and big icons of the console window to
@@ -2672,9 +2672,9 @@ mch_exit_c(int r)
 	 */
 	if (g_fCanChangeIcon && !g_fForceExit)
 	    SetConsoleIcon(g_hWnd, g_hOrigIconSmall, g_hOrigIcon);
-#endif
+# endif
 
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	if (fdDump)
 	{
 	    time_t t;
@@ -2684,16 +2684,16 @@ mch_exit_c(int r)
 	    fclose(fdDump);
 	}
 	fdDump = NULL;
-#endif
+# endif
     }
 
     SetConsoleCursorInfo(g_hConOut, &g_cci);
     SetConsoleMode(g_hConIn,  g_cmodein);
     SetConsoleMode(g_hConOut, g_cmodeout);
 
-#ifdef DYNAMIC_GETTEXT
+# ifdef DYNAMIC_GETTEXT
     dyn_libintl_end();
-#endif
+# endif
 
     exit(r);
 }
@@ -3104,7 +3104,7 @@ mch_is_linked(char_u *fname)
 /*
  * Get the by-handle-file-information for "fname".
  * Returns FILEINFO_OK when OK.
- * returns FILEINFO_ENC_FAIL when enc_to_utf16() failed.
+ * Returns FILEINFO_ENC_FAIL when enc_to_utf16() failed.
  * Returns FILEINFO_READ_FAIL when CreateFile() failed.
  * Returns FILEINFO_INFO_FAIL when GetFileInformationByHandle() failed.
  */
@@ -3531,9 +3531,9 @@ handler_routine(
 		     : dwCtrlType == CTRL_LOGOFF_EVENT
 			 ? _("logoff")
 			 : _("shutdown")));
-#ifdef DEBUG
+# ifdef DEBUG
 	OutputDebugString(IObuff);
-#endif
+# endif
 
 	preserve_exit();	/* output IObuff, preserve files and exit */
 
@@ -3568,13 +3568,13 @@ mch_settmode(int tmode)
 	if (g_fMouseActive)
 	    cmodein |= ENABLE_MOUSE_INPUT;
 	cmodeout &= ~(
-#ifdef FEAT_TERMGUICOLORS
+# ifdef FEAT_TERMGUICOLORS
 	    /* Do not turn off the ENABLE_PROCESSED_OUTPUT flag when using
 	     * VTP. */
 	    ((vtp_working) ? 0 : ENABLE_PROCESSED_OUTPUT) |
-#else
+# else
 	    ENABLE_PROCESSED_OUTPUT |
-#endif
+# endif
 	    ENABLE_WRAP_AT_EOL_OUTPUT);
 	bEnableHandler = TRUE;
     }
@@ -3589,7 +3589,7 @@ mch_settmode(int tmode)
     SetConsoleMode(g_hConOut, cmodeout);
     SetConsoleCtrlHandler(handler_routine, bEnableHandler);
 
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
     if (fdDump)
     {
 	fprintf(fdDump, "mch_settmode(%s, in = %x, out = %x)\n",
@@ -3598,7 +3598,7 @@ mch_settmode(int tmode)
 		cmodein, cmodeout);
 	fflush(fdDump);
     }
-#endif
+# endif
 }
 
 
@@ -3649,14 +3649,14 @@ ResizeConBuf(
 {
     if (!SetConsoleScreenBufferSize(hConsole, coordScreen))
     {
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	if (fdDump)
 	{
 	    fprintf(fdDump, "SetConsoleScreenBufferSize failed: %lx\n",
 		    GetLastError());
 	    fflush(fdDump);
 	}
-#endif
+# endif
     }
 }
 
@@ -3670,14 +3670,14 @@ ResizeWindow(
 {
     if (!SetConsoleWindowInfo(hConsole, TRUE, &srWindowRect))
     {
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	if (fdDump)
 	{
 	    fprintf(fdDump, "SetConsoleWindowInfo failed: %lx\n",
 		    GetLastError());
 	    fflush(fdDump);
 	}
-#endif
+# endif
     }
 }
 
@@ -3696,13 +3696,13 @@ ResizeConBufAndWindow(
     COORD	    cursor;
     static int	    resized = FALSE;
 
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
     if (fdDump)
     {
 	fprintf(fdDump, "ResizeConBufAndWindow(%d, %d)\n", xSize, ySize);
 	fflush(fdDump);
     }
-#endif
+# endif
 
     /* get the largest size we can size the console window to */
     coordScreen = GetLargestConsoleWindowSize(hConsole);
@@ -3923,7 +3923,7 @@ mch_system_classic(char *cmd, int options)
 
     /* Wait for the command to terminate before continuing */
     {
-#ifdef FEAT_GUI
+# ifdef FEAT_GUI
 	int	    delay = 1;
 
 	/* Keep updating the window while waiting for the shell to finish. */
@@ -3947,9 +3947,9 @@ mch_system_classic(char *cmd, int options)
 	    if (delay < 50)
 		delay += 10;
 	}
-#else
+# else
 	WaitForSingleObject(pi.hProcess, INFINITE);
-#endif
+# endif
 
 	/* Get the command exit code */
 	GetExitCodeProcess(pi.hProcess, &ret);
@@ -5450,9 +5450,9 @@ termcap_mode_start(void)
 	ResizeConBufAndWindow(g_hConOut, Columns, Rows);
     }
 
-#ifdef FEAT_TITLE
+# ifdef FEAT_TITLE
     resettitle();
-#endif
+# endif
 
     GetConsoleMode(g_hConIn, &cmodein);
     if (g_fMouseActive)
@@ -5487,11 +5487,11 @@ termcap_mode_end(void)
     cmodein &= ~(ENABLE_MOUSE_INPUT | ENABLE_WINDOW_INPUT);
     SetConsoleMode(g_hConIn, cmodein);
 
-#ifdef FEAT_RESTORE_ORIG_SCREEN
+# ifdef FEAT_RESTORE_ORIG_SCREEN
     cb = exiting ? &g_cbOrig : &g_cbNonTermcap;
-#else
+# else
     cb = &g_cbNonTermcap;
-#endif
+# endif
     RestoreConsoleBuffer(cb, p_rs);
     reset_console_color_rgb();
     SetConsoleCursorInfo(g_hConOut, &g_cci);
@@ -5921,9 +5921,9 @@ mch_set_normal_colors(void)
     cterm_normal_fg_color = (g_attrDefault & 0xf) + 1;
     cterm_normal_bg_color = ((g_attrDefault >> 4) & 0xf) + 1;
     if (
-#ifdef FEAT_TERMGUICOLORS
+# ifdef FEAT_TERMGUICOLORS
 	!p_tgc &&
-#endif
+# endif
 	T_ME[0] == ESC && T_ME[1] == '|')
     {
 	p = T_ME + 2;
@@ -5934,10 +5934,10 @@ mch_set_normal_colors(void)
 	    cterm_normal_bg_color = ((n >> 4) & 0xf) + 1;
 	}
     }
-#ifdef FEAT_TERMGUICOLORS
+# ifdef FEAT_TERMGUICOLORS
     cterm_normal_fg_gui_color = INVALCOLOR;
     cterm_normal_bg_gui_color = INVALCOLOR;
-#endif
+# endif
 }
 
 
@@ -5975,9 +5975,9 @@ visual_bell(void)
 cursor_visible(BOOL fVisible)
 {
     s_cursor_visible = fVisible;
-#ifdef MCH_CURSOR_SHAPE
+# ifdef MCH_CURSOR_SHAPE
     mch_update_cursor();
-#endif
+# endif
 }
 
 
@@ -6096,14 +6096,14 @@ mch_write(
 	    DWORD nWritten;
 
 	    nWritten = write_chars(s, prefix);
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	    if (fdDump)
 	    {
 		fputc('>', fdDump);
 		fwrite(s, sizeof(char_u), nWritten, fdDump);
 		fputs("<\n", fdDump);
 	    }
-#endif
+# endif
 	    len -= (nWritten - 1);
 	    s += nWritten;
 	}
@@ -6119,20 +6119,20 @@ mch_write(
 	    {
 		gotoxy(g_srScrollRegion.Left + 1, g_coord.Y + 2);
 	    }
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	    if (fdDump)
 		fputs("\\n\n", fdDump);
-#endif
+# endif
 	    s++;
 	}
 	else if (s[0] == '\r')
 	{
 	    /* \r, carriage return: go to beginning of line */
 	    gotoxy(g_srScrollRegion.Left+1, g_coord.Y + 1);
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	    if (fdDump)
 		fputs("\\r\n", fdDump);
-#endif
+# endif
 	    s++;
 	}
 	else if (s[0] == '\b')
@@ -6146,27 +6146,27 @@ mch_write(
 		g_coord.Y--;
 	    }
 	    gotoxy(g_coord.X + 1, g_coord.Y + 1);
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	    if (fdDump)
 		fputs("\\b\n", fdDump);
-#endif
+# endif
 	    s++;
 	}
 	else if (s[0] == '\a')
 	{
 	    /* \a, bell */
 	    MessageBeep(0xFFFFFFFF);
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	    if (fdDump)
 		fputs("\\a\n", fdDump);
-#endif
+# endif
 	    s++;
 	}
 	else if (s[0] == ESC && len >= 3-1 && s[1] == '|')
 	{
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	    char_u  *old_s = s;
-#endif
+# endif
 	    char_u  *p;
 	    int	    arg1 = 0, arg2 = 0, argc = 0, args[16];
 
@@ -6321,14 +6321,14 @@ mch_write(
 		len -= 2;
 	    }
 
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	    if (fdDump)
 	    {
 		fputs("ESC | ", fdDump);
 		fwrite(old_s + 2, sizeof(char_u), s - old_s - 2, fdDump);
 		fputc('\n', fdDump);
 	    }
-#endif
+# endif
 	}
 	else
 	{
@@ -6336,24 +6336,24 @@ mch_write(
 	    DWORD nWritten;
 
 	    nWritten = write_chars(s, 1);
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
 	    if (fdDump)
 	    {
 		fputc('>', fdDump);
 		fwrite(s, sizeof(char_u), nWritten, fdDump);
 		fputs("<\n", fdDump);
 	    }
-#endif
+# endif
 
 	    len -= (nWritten - 1);
 	    s += nWritten;
 	}
     }
 
-#ifdef MCH_WRITE_DUMP
+# ifdef MCH_WRITE_DUMP
     if (fdDump)
 	fflush(fdDump);
-#endif
+# endif
 }
 
 #endif /* FEAT_GUI_MSWIN */
@@ -7135,7 +7135,7 @@ fix_arg_enc(void)
 	{
 	    int literal = used_file_literal;
 
-# ifdef FEAT_DIFF
+#ifdef FEAT_DIFF
 	    /* When using diff mode may need to concatenate file name to
 	     * directory name.  Just like it's done in main(). */
 	    if (used_file_diff_mode && mch_isdir(str) && GARGCOUNT > 0
@@ -7150,7 +7150,7 @@ fix_arg_enc(void)
 		    str = r;
 		}
 	    }
-# endif
+#endif
 	    /* Re-use the old buffer by renaming it.  When not using literal
 	     * names it's done by alist_expand() below. */
 	    if (used_file_literal)

--- a/src/proto.h
+++ b/src/proto.h
@@ -113,52 +113,52 @@ extern int _stricoll(char *a, char *b);
 #  include "arabic.pro"
 # endif
 # ifdef FEAT_VIMINFO
-# include "viminfo.pro"
+#  include "viminfo.pro"
 # endif
 
 // These prototypes cannot be produced automatically.
 int smsg(const char *, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+# ifdef USE_PRINTF_FORMAT_ATTRIBUTE
     __attribute__((format(printf, 1, 0)))
-#endif
+# endif
     ;
 
 int smsg_attr(int, const char *, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+# ifdef USE_PRINTF_FORMAT_ATTRIBUTE
     __attribute__((format(printf, 2, 3)))
-#endif
+# endif
     ;
 
 int smsg_attr_keep(int, const char *, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+# ifdef USE_PRINTF_FORMAT_ATTRIBUTE
     __attribute__((format(printf, 2, 3)))
-#endif
+# endif
     ;
 
 // These prototypes cannot be produced automatically.
 int semsg(const char *, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+# ifdef USE_PRINTF_FORMAT_ATTRIBUTE
     __attribute__((format(printf, 1, 0)))
-#endif
+# endif
     ;
 
 // These prototypes cannot be produced automatically.
 void siemsg(const char *, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+# ifdef USE_PRINTF_FORMAT_ATTRIBUTE
     __attribute__((format(printf, 1, 0)))
-#endif
+# endif
     ;
 
 int vim_snprintf_add(char *, size_t, const char *, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+# ifdef USE_PRINTF_FORMAT_ATTRIBUTE
     __attribute__((format(printf, 3, 4)))
-#endif
+# endif
     ;
 
 int vim_snprintf(char *, size_t, const char *, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+# ifdef USE_PRINTF_FORMAT_ATTRIBUTE
     __attribute__((format(printf, 3, 4)))
-#endif
+# endif
     ;
 
 int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap);
@@ -167,13 +167,13 @@ int vim_vsnprintf_typval(char *str, size_t str_m, const char *fmt, va_list ap, t
 # include "message.pro"
 # include "misc1.pro"
 # include "misc2.pro"
-#ifndef HAVE_STRPBRK	    // not generated automatically from misc2.c
+# ifndef HAVE_STRPBRK	    // not generated automatically from misc2.c
 char_u *vim_strpbrk(char_u *s, char_u *charset);
-#endif
-#ifndef HAVE_QSORT
+# endif
+# ifndef HAVE_QSORT
 // Use our own qsort(), don't define the prototype when not used.
 void qsort(void *base, size_t elm_count, size_t elm_size, int (*cmp)(const void *, const void *));
-#endif
+# endif
 # include "mouse.pro"
 # include "move.pro"
 # include "mbyte.pro"
@@ -188,7 +188,7 @@ void mbyte_im_set_active(int active_arg);
 # include "optionstr.pro"
 # include "popupmenu.pro"
 # if defined(FEAT_PROFILE) || defined(FEAT_RELTIME)
-# include "profiler.pro"
+#  include "profiler.pro"
 # endif
 # include "quickfix.pro"
 # include "regexp.pro"
@@ -269,9 +269,9 @@ void mbyte_im_set_active(int active_arg);
 
 // Not generated automatically, to add extra attribute.
 void ch_log(channel_T *ch, const char *fmt, ...)
-#ifdef USE_PRINTF_FORMAT_ATTRIBUTE
+#  ifdef USE_PRINTF_FORMAT_ATTRIBUTE
     __attribute__((format(printf, 2, 3)))
-#endif
+#  endif
     ;
 
 # endif
@@ -332,20 +332,20 @@ extern char *vim_SelFile(Widget toplevel, char *prompt, char *init_path, int (*s
  * not included here for the perl files.  Use a dummy define for CV for the
  * other files.
  */
-#if defined(FEAT_PERL) && !defined(IN_PERL_FILE)
-# define CV void
-# include "if_perl.pro"
-# include "if_perlsfio.pro"
-#endif
+# if defined(FEAT_PERL) && !defined(IN_PERL_FILE)
+#  define CV void
+#  include "if_perl.pro"
+#  include "if_perlsfio.pro"
+# endif
 
-#ifdef MACOS_CONVERT
-# include "os_mac_conv.pro"
-#endif
-#if defined(MACOS_X_DARWIN) && defined(FEAT_CLIPBOARD) && !defined(FEAT_GUI)
+# ifdef MACOS_CONVERT
+#  include "os_mac_conv.pro"
+# endif
+# if defined(MACOS_X_DARWIN) && defined(FEAT_CLIPBOARD) && !defined(FEAT_GUI)
 // functions in os_macosx.m
 void clip_mch_lose_selection(Clipboard_T *cbd);
 int clip_mch_own_selection(Clipboard_T *cbd);
 void clip_mch_request_selection(Clipboard_T *cbd);
 void clip_mch_set_selection(Clipboard_T *cbd);
-#endif
+# endif
 #endif // !PROTO && !NOPROTO


### PR DESCRIPTION
Fix indents of `#if` and so on.
Also fix some typos in comments in os_win32.c.