### PR TITLE
Use #error

### DIFF
--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -40,8 +40,7 @@ typedef union {
 # ifdef HAVE_CONFIG_H
    // in configure.ac AC_C_BIGENDIAN() defines WORDS_BIGENDIAN when needed
 # else
-   error!
-   Please change this code to define WORDS_BIGENDIAN for big-endian machines.
+#  error Please change this code to define WORDS_BIGENDIAN for big-endian machines.
 # endif
 #endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -33,7 +33,7 @@
  * test program.  Other items from configure may also be wrong then!
  */
 # if (VIM_SIZEOF_INT == 0)
-    Error: configure did not run properly.  Check auto/config.log.
+#  error configure did not run properly.  Check auto/config.log.
 # endif
 
 # if defined(__gnu_linux__) || defined(__CYGWIN__)
@@ -151,7 +151,7 @@
 #endif
 
 #if VIM_SIZEOF_INT < 4 && !defined(PROTO)
-    Error: Vim only works with 32 bit int or larger
+# error Vim only works with 32 bit int or larger
 #endif
 
 /*


### PR DESCRIPTION
We already use C99, so we can use `#error` safely.

Related: #5290