### PR TITLE
Test v:register, fix not cleared sometimes

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -1190,6 +1190,11 @@ normal_end:
 
     msg_nowait = FALSE;
 
+#ifdef FEAT_EVAL
+    if (finish_op)
+	set_reg_var(0);
+#endif
+
     // Reset finish_op, in case it was set
 #ifdef CURSOR_SHAPE
     c = finish_op;

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -416,4 +416,73 @@ func Test_execute_register()
   call assert_beeps('normal! c@r')
 endfunc
 
+func Test_v_register()
+  enew
+  call setline(1, 'nothing')
+
+  func s:Put()
+    let s:register = v:register
+    exec 'normal! "' .. v:register .. 'P'
+  endfunc
+  nnoremap <buffer> <plug>(test) :<c-u>call s:Put()<cr>
+  nmap <buffer> S <plug>(test)
+
+  let @z = "testz\n"
+  let @" = "test@\n"
+
+  let s:register = ''
+  call feedkeys('"_ddS', 'mx')
+  call assert_equal('test@', getline('.'))  " fails in 8.2
+  call assert_equal('"', s:register)        " fails in 8.2
+
+  let s:register = ''
+  call feedkeys('"zS', 'mx')
+  call assert_equal('z', s:register)
+
+  let s:register = ''
+  call feedkeys('"zSS', 'mx')
+  call assert_equal('"', s:register)
+
+  let s:register = ''
+  call feedkeys('"_S', 'mx')
+  call assert_equal('_', s:register)
+
+  let s:register = ''
+  normal "_ddS
+  call assert_equal('"', s:register)        " fails in 8.2
+  call assert_equal('test@', getline('.'))  " fails in 8.2
+
+  let s:register = ''
+  execute 'normal "z:call' "s:Put()\n"
+  call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
+
+  " Test operator and omap
+  let @b = 'testb'
+  func s:OpFunc(...)
+    let s:register2 = v:register
+  endfunc
+  set opfunc=s:OpFunc
+
+  normal "bg@l
+  normal S
+  call assert_equal('"', s:register)        " fails in 8.2
+  call assert_equal('b', s:register2)
+
+  func s:Motion()
+    let s:register1 = v:register
+    normal! l
+  endfunc
+  onoremap <buffer> Q :<c-u>call s:Motion()<cr>
+
+  normal "bg@Q
+  normal S
+  call assert_equal('"', s:register)
+  call assert_equal('b', s:register1)
+  call assert_equal('"', s:register2)
+
+  set opfunc&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
v:register is not tested, and also seems buggy (see #5294).  Not sure if this is the right fix, so adding test cases for what I think should be expected behavior.

The last test case (opfunc+omap) could be considered a bug but it passes before and after the patch.
