### PR TITLE
Modification for vim.h

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -36,7 +36,7 @@
     Error: configure did not run properly.  Check auto/config.log.
 # endif
 
-# if defined(__gnu_linux__) || defined(__CYGWIN__)
+# if (defined(__linux__) && !defined(__ANDROID__)) || defined(__CYGWIN__)
 // Needed for strptime().  Needs to be done early, since header files can
 // include other header files and end up including time.h, where these symbols
 // matter for Vim.

--- a/src/vim.h
+++ b/src/vim.h
@@ -44,9 +44,6 @@
 #  ifndef _XOPEN_SOURCE
 #   define _XOPEN_SOURCE    700
 #  endif
-#  ifndef __USE_XOPEN
-#   define __USE_XOPEN
-#  endif
 # endif
 
 // for INT_MAX, LONG_MAX et al.


### PR DESCRIPTION
* Don't have to define `__USE_XOPEN` and should not do such symbol starting with double-underscore manually.
* Android does not need `_XOPEN_SOURCE` for `strptime`. 