### PR TITLE
win32: Fix encoding of file properties

### DIFF
--- a/src/vim.rc
+++ b/src/vim.rc
@@ -14,6 +14,9 @@
 #include "gui_w32_rc.h"
 #include <winresrc.h>
 
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
 //
 // Icons
 //


### PR DESCRIPTION
When compiling Vim on non-English environment, the copyright mark © is not shown correctly on Windows' properties dialog box. This PR sets the encoding of the Windows resource file explicitly to cp1252 to fix it.

Example on Japanese Windows (before this fix):
![gvim-prop1](https://user-images.githubusercontent.com/840186/70446106-fba2c880-1adf-11ea-885d-5374198aa58d.png)

After this fix:
![gvim-prop2](https://user-images.githubusercontent.com/840186/70446238-1f660e80-1ae0-11ea-817e-4776a279dda7.png)
