### PR TITLE
win32: Adjust version format of properties dialog box

### DIFF
--- a/src/vim.rc
+++ b/src/vim.rc
@@ -94,7 +94,7 @@ BEGIN
     BEGIN
 	VALUE "CompanyName",		"Vim Developers\0"
 	VALUE "FileDescription",	"Vi Improved - A Text Editor\0"
-	VALUE "FileVersion",		VIM_VERSION_MAJOR_STR ", " VIM_VERSION_MINOR_STR ", " VIM_VERSION_PATCHLEVEL_STR  "\0"
+	VALUE "FileVersion",		VIM_VERSION_MAJOR_STR "." VIM_VERSION_MINOR_STR "." VIM_VERSION_PATCHLEVEL_STR "\0"
 	VALUE "InternalName",		"VIM\0"
 	VALUE "LegalCopyright",		"Copyright \251 1996\0"
 	VALUE "LegalTrademarks",	"Vim\0"
@@ -106,7 +106,7 @@ BEGIN
 	VALUE "OriginalFilename",	"vim.exe\0"
 #endif
 	VALUE "ProductName",		"Vim\0"
-	VALUE "ProductVersion",		VIM_VERSION_MAJOR_STR ", " VIM_VERSION_MINOR_STR ", " VIM_VERSION_PATCHLEVEL_STR "\0"
+	VALUE "ProductVersion",		VIM_VERSION_MAJOR_STR "." VIM_VERSION_MINOR_STR "." VIM_VERSION_PATCHLEVEL_STR "\0"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Currently the product version in the properties dialog box is shown as "8, 1, 0". I think it is better to be shown as "8.1.0".

Before this fix:
![gvim-prop3](https://user-images.githubusercontent.com/840186/70535190-eee5a980-1b9f-11ea-8fb5-63b676ddfae3.png)

After this fix:
![gvim-prop4](https://user-images.githubusercontent.com/840186/70535204-f7d67b00-1b9f-11ea-9c5a-6c65f2062b2e.png)
