### PR TITLE
Fix crash while closing popup from win_execute

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2333,6 +2333,9 @@ f_popup_close(typval_T *argvars, typval_T *rettv UNUSED)
     int		id = (int)tv_get_number(argvars);
     win_T	*wp = find_popup_win(id);
 
+    if (ERROR_IF_POPUP_WINDOW)
+	return;
+
     if (wp != NULL)
 	popup_close_and_callback(wp, &argvars[1]);
 }

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -891,6 +891,10 @@ func Test_win_execute_closing_curwin()
   let winid = popup_create('some text', {})
   call assert_fails('call win_execute(winid, winnr() .. "close")', 'E994')
   call popup_clear()
+
+  let winid = popup_create('some text', {})
+  call assert_fails('call win_execute(winid, printf("normal! :\<C-u>call popup_close(%d)\<CR>", winid))', 'E994')
+  call popup_clear()
 endfunc
 
 func Test_win_execute_not_allowed()


### PR DESCRIPTION
```
let s:w = popup_create('', {})
call win_execute(s:w, printf("normal! :\<C-u>call popup_close(%d)\<CR>", s:w))
```
Closing popup window self from win_execute always crash.