### PR TITLE
Revise version.h

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -9,21 +9,24 @@
 /*
  * Define the version number, name, etc.
  * The patchlevel is in included_patches[], in version.c.
- *
- * This doesn't use string concatenation, some compilers don't support it.
  */
 
-#define VIM_VERSION_MAJOR		 8
-#define VIM_VERSION_MAJOR_STR		"8"
-#define VIM_VERSION_MINOR		 2
-#define VIM_VERSION_MINOR_STR		"2"
+#define VIM_TOSTR_(a)			#a
+#define VIM_TOSTR(a)			VIM_TOSTR_(a)
+
+#define VIM_VERSION_MAJOR		8
+#define VIM_VERSION_MAJOR_STR		VIM_TOSTR(VIM_VERSION_MAJOR)
+#define VIM_VERSION_MINOR		2
+#define VIM_VERSION_MINOR_STR		VIM_TOSTR(VIM_VERSION_MINOR)
 #define VIM_VERSION_100	    (VIM_VERSION_MAJOR * 100 + VIM_VERSION_MINOR)
 
-#define VIM_VERSION_BUILD		 283
+#define VIM_VERSION_BUILD		283
 #define VIM_VERSION_BUILD_BCD		0x11b
-#define VIM_VERSION_BUILD_STR		"283"
-#define VIM_VERSION_PATCHLEVEL		 0
-#define VIM_VERSION_PATCHLEVEL_STR	"0"
+#define VIM_VERSION_BUILD_STR		VIM_TOSTR(VIM_VERSION_BUILD)
+#ifndef VIM_VERSION_PATCHLEVEL
+# define VIM_VERSION_PATCHLEVEL		0
+#endif
+#define VIM_VERSION_PATCHLEVEL_STR	VIM_TOSTR(VIM_VERSION_PATCHLEVEL)
 // Used by MacOS port should be one of: development, alpha, beta, final
 #define VIM_VERSION_RELEASE		final
 
@@ -36,7 +39,9 @@
 #define VIM_VERSION_NODOT	"vim82"
 #define VIM_VERSION_SHORT	"8.2"
 #define VIM_VERSION_MEDIUM	"8.2"
-#define VIM_VERSION_LONG	"VIM - Vi IMproved 8.2 (2019 Dec 12)"
-#define VIM_VERSION_LONG_DATE	"VIM - Vi IMproved 8.2 (2019 Dec 12, compiled "
 #define VIM_VERSION_LONG_ONLY	"VIM - Vi IMproved 8.2"
 #define VIM_VERSION_DATE_ONLY	"2019 Dec 12"
+#define VIM_VERSION_LONG	\
+    VIM_VERSION_LONG_ONLY " (" VIM_VERSION_DATE_ONLY ")"
+#define VIM_VERSION_LONG_DATE	\
+    VIM_VERSION_LONG_ONLY " (" VIM_VERSION_DATE_ONLY ", compiled "


### PR DESCRIPTION
The comment in version.h says:

> This doesn't use string concatenation, some compilers don't support it.

However, we already use C89 and partly C99. I don't think that we still
need to care about such old compilers.
Use string concatenation and stringizing to avoid duplication.

Also add #ifndef around `VIM_VERSION_PATCHLEVEL`. Similar thing was done
at 8.1.1404 for nsis script, but I think this is also useful for version.h
and vim.rc. 8.1.2138 was not enough to set the patchlevel easily.
(See also #5045.)