### PR TITLE
Fix popup close with mouse click

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -1630,7 +1630,8 @@ retnomove:
 	{
 	    on_sep_line = 0;
 	    in_popup_win = TRUE;
-	    if (which_button == MOUSE_LEFT && popup_close_if_on_X(wp, row, col))
+	    if (which_button == MOUSE_LEFT && (popup_close_if_on_X(wp, row, col)
+					       || popup_close_if_mouse_click(wp, row, col)))
 	    {
 		return IN_UNKNOWN;
 	    }

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -207,6 +207,27 @@ popup_close_if_on_X(win_T *wp, int row, int col)
     return FALSE;
 }
 
+
+/*
+ * Return TRUE and close the popup if "row"/"col" is inside
+ * popup area but not on popup border and w_popup_close is POPCLOSE_CLICK.
+ * The values are relative to the top-left corner.
+ * Caller should check the left mouse button was clicked.
+ * Return TRUE if the popup was closed.
+ */
+    int
+popup_close_if_mouse_click(win_T *wp, int row, int col)
+{
+    if (wp->w_popup_close == POPCLOSE_CLICK
+	    && !popup_on_border(wp, row, col)
+	    && row < popup_height(wp) && col < popup_width(wp) - 1)
+    {
+	popup_close_for_mouse_click(wp);
+	return TRUE;
+    }
+    return FALSE;
+}
+
 // Values set when dragging a popup window starts.
 static int drag_start_row;
 static int drag_start_col;
@@ -2960,7 +2981,8 @@ popup_do_filter(int c)
 	int col = mouse_col;
 
 	wp = mouse_find_win(&row, &col, FIND_POPUP);
-	if (wp != NULL && popup_close_if_on_X(wp, row, col))
+	if (wp != NULL && (popup_close_if_on_X(wp, row, col) ||
+			   popup_close_if_mouse_click(wp, row, col)))
 	    res = TRUE;
     }
 

--- a/src/proto/popupwin.pro
+++ b/src/proto/popupwin.pro
@@ -1,6 +1,7 @@
 /* popupwin.c */
 int popup_on_border(win_T *wp, int row, int col);
 int popup_close_if_on_X(win_T *wp, int row, int col);
+int popup_close_if_mouse_click(win_T *wp, int row, int col);
 void popup_start_drag(win_T *wp, int row, int col);
 void popup_drag(win_T *wp);
 void popup_set_firstline(win_T *wp);


### PR DESCRIPTION
Fixes the issue that popup cannot be closed with a mouse click.

**To Reproduce**
1. Create a popup with
```vim
call popup_create("the text", #{
    \ border: [],
    \ close: 'click',
    \ padding: [0,1,0,1],
    \ })
```
2. Mouse click in the popup

**Expected behavior**
Popup should close.