### PR TITLE
Remove references to OS/2 and MS-DOS from the help files

### DIFF
--- a/READMEdir/README_extra.txt
+++ b/READMEdir/README_extra.txt
@@ -24,9 +24,6 @@ src/os_mac.*		Files for the Mac port.
 
 src/os_mint.8		Files for the Atari Mint port.
 
-src/os_os2*		Files for the OS/2 port.
-src/tee/*		Extra program for OS/2.
-
 src/os_vms*		Files for the VMS port.
 
 src/os_w32*

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1288,9 +1288,9 @@ The pattern is interpreted like mostly used in file names:
 	[ch]	matches 'c' or 'h'
 	[^ch]   match any character but 'c' and 'h'
 
-Note that for all systems the '/' character is used for path separator (even
-MS-DOS and OS/2).  This was done because the backslash is difficult to use
-in a pattern and to make the autocommands portable across different systems.
+Note that for all systems the '/' character is used for path separator.  This
+was done because the backslash is difficult to use in a pattern and to make
+the autocommands portable across different systems.
 
 It is possible to use |pattern| items, but they may not work as expected,
 because of the translation done for the above.

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -611,7 +611,7 @@ attack or other people reading your file).  When Vim exits the directory and
 all files in it are deleted.  When Vim has the setuid bit set this may cause
 problems, the temp file is owned by the setuid user but the filter command
 probably runs as the original user.
-On MS-DOS and OS/2 the first of these directories that works is used: $TMP,
+On MS-Windows the first of these directories that works is used: $TMP,
 $TEMP, c:\TMP, c:\TEMP.
 For Unix the list of directories is: $TMPDIR, /tmp, current-dir, $HOME.
 For MS-Windows the GetTempFileName() system function is used.

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -943,9 +943,9 @@ These modifiers can be given, in this order:
 		separator is removed.  Thus ":p:h" on a directory name results
 		on the directory name itself (without trailing slash).
 		When the file name is an absolute path (starts with "/" for
-		Unix; "x:\" for MS-DOS, WIN32, OS/2; "drive:" for Amiga), that
-		part is not removed.  When there is no head (path is relative
-		to current directory) the result is empty.
+		Unix; "x:\" for WIN32; "drive:" for Amiga), that part is not
+		removed.  When there is no head (path is relative to current
+		directory) the result is empty.
 	:t	Tail of the file name (last component of the name).  Must
 		precede any :r or :e.
 	:r	Root of the file name (the last extension removed).  When
@@ -1042,12 +1042,12 @@ option contains "sh", this is done twice, to avoid the shell trying to expand
 the "!".
 
 							*filename-backslash*
-For filesystems that use a backslash as directory separator (MS-DOS, Windows,
-OS/2), it's a bit difficult to recognize a backslash that is used to escape
-the special meaning of the next character.  The general rule is: If the
-backslash is followed by a normal file name character, it does not have a
-special meaning.  Therefore "\file\foo" is a valid file name, you don't have
-to type the backslash twice.
+For filesystems that use a backslash as directory separator (Windows), it's a
+bit difficult to recognize a backslash that is used to escape the special
+meaning of the next character.  The general rule is: If the backslash is
+followed by a normal file name character, it does not have a special meaning.
+Therefore "\file\foo" is a valid file name, you don't have to type the
+backslash twice.
 
 An exception is the '$' sign.  It is a valid character in a file name.  But
 to avoid a file name like "$home" to be interpreted as an environment variable,

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -519,9 +519,9 @@ The 'fileformat' option sets the <EOL> style for a file:
 Previously 'textmode' was used.  It is obsolete now.
 
 When reading a file, the mentioned characters are interpreted as the <EOL>.
-In DOS format (default for MS-DOS, OS/2 and Win32), <CR><NL> and <NL> are both
-interpreted as the <EOL>.  Note that when writing the file in DOS format,
-<CR> characters will be added for each single <NL>.  Also see |file-read|.
+In DOS format (default for Win32), <CR><NL> and <NL> are both interpreted as
+the <EOL>.  Note that when writing the file in DOS format, <CR> characters
+will be added for each single <NL>.  Also see |file-read|.
 
 When writing a file, the mentioned characters are used for <EOL>.  For DOS
 format <CR><NL> is used.  Also see |DOS-format-write|.
@@ -1023,11 +1023,11 @@ lost the original file.
 
 						*DOS-format-write*
 If the 'fileformat' is "dos", <CR> <NL> is used for <EOL>.  This is default
-for MS-DOS, Win32 and OS/2.  On other systems the message "[dos format]" is
-shown to remind you that an unusual <EOL> was used.
+for Win32.  On other systems the message "[dos format]" is shown to remind you
+that an unusual <EOL> was used.
 						*Unix-format-write*
-If the 'fileformat' is "unix", <NL> is used for <EOL>.  On MS-DOS, Win32 and
-OS/2 the message "[unix format]" is shown.
+If the 'fileformat' is "unix", <NL> is used for <EOL>.  On Win32 the message
+"[unix format]" is shown.
 						*Mac-format-write*
 If the 'fileformat' is "mac", <CR> is used for <EOL>.  On non-Mac systems the
 message "[mac format]" is shown.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -9753,7 +9753,7 @@ system({expr} [, {input}])				*system()* *E677*
 		The command executed is constructed using several options:
 	'shell' 'shellcmdflag' 'shellxquote' {expr} 'shellredir' {tmp} 'shellxquote'
 		({tmp} is an automatically generated file name).
-		For Unix and OS/2 braces are put around {expr} to allow for
+		For Unix, braces are put around {expr} to allow for
 		concatenated commands.
 
 		The command will be executed in "cooked" mode, so that a

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -95,9 +95,7 @@ terminal version.
 
 Recommended place for your personal GUI initializations:
 	Unix		    $HOME/.gvimrc or $HOME/.vim/gvimrc
-	OS/2		    $HOME/.gvimrc, $HOME/vimfiles/gvimrc
-			    or $VIM/.gvimrc
-	MS-DOS and Win32    $HOME/_gvimrc, $HOME/vimfiles/gvimrc
+	Win32    	    $HOME/_gvimrc, $HOME/vimfiles/gvimrc
 			    or $VIM/_gvimrc
 	Amiga		    s:.gvimrc, home:.gvimrc, home:vimfiles:gvimrc
 			    or $VIM/.gvimrc

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -2008,10 +2008,10 @@ If the 'fileformats' option is not empty Vim tries to recognize the type of
 changed, the detected format is only used while reading the file.
 A similar thing happens with 'fileencodings'.
 
-On non-MS-DOS, Win32, and OS/2 systems the message "[dos format]" is shown if
-a file is read in DOS format, to remind you that something unusual is done.
-On Macintosh, MS-DOS, Win32, and OS/2 the message "[unix format]" is shown if
-a file is read in Unix format.
+On non-MS-DOS and Win32 systems the message "[dos format]" is shown if a file
+is read in DOS format, to remind you that something unusual is done.  On
+Macintosh and Win32 the message "[unix format]" is shown if a file is read in
+Unix format.
 On non-Macintosh systems, the message "[Mac format]" is shown if a file is
 read in Mac format.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -876,7 +876,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	putting a ":gui" command in the .gvimrc file, before where the value
 	of 'background' is used (e.g., before ":syntax on").
 
-	For MS-DOS, Windows and OS/2 the default is "dark".
+	For MS-Windows the default is "dark".
 	For other systems "dark" is used when 'term' is "linux",
 	"screen.linux", "cygwin" or "putty", or $COLORFGBG suggests a dark
 	background.  Otherwise the default is "light".
@@ -1770,7 +1770,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	'esckeys'	& off		no <Esc>-keys in Insert mode
 	'expandtab'	+ off		tabs not expanded to spaces
 	'fileformats'	& ""		no automatic file format detection,
-			  "dos,unix"	except for DOS, Windows and OS/2
+			  "dos,unix"	except for Windows
 	'formatexpr'	+ ""		use 'formatprg' for auto-formatting
 	'formatoptions'	& "vt"		Vi compatible formatting
 	'gdefault'	+ off		no default 'g' flag for ":s"
@@ -4442,7 +4442,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	NOTE: This option is reset when 'compatible' is set.
 
 						*'isfname'* *'isf'*
-'isfname' 'isf'		string	(default for MS-DOS, Win32 and OS/2:
+'isfname' 'isf'		string	(default for Win32:
 			     "@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,="
 			    for AMIGA: "@,48-57,/,.,-,_,+,,,$,:"
 			    for VMS: "@,48-57,/,.,-,_,+,,,#,$,%,<,>,[,],:,;,~"
@@ -4496,7 +4496,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |option-backslash| about including spaces and backslashes.
 
 						*'isident'* *'isi'*
-'isident' 'isi'		string	(default for MS-DOS, Win32 and OS/2:
+'isident' 'isi'		string	(default for Win32:
 					   "@,48-57,_,128-167,224-235"
 				otherwise: "@,48-57,_,192-255")
 			global
@@ -4510,7 +4510,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	expand "$HOME/.viminfo".  Maybe you should change 'iskeyword' instead.
 
 						*'iskeyword'* *'isk'*
-'iskeyword' 'isk'	string (Vim default for MS-DOS and Win32:
+'iskeyword' 'isk'	string (Vim default for Win32:
 					    "@,48-57,_,128-167,224-235"
 				   otherwise:  "@,48-57,_,192-255"
 				Vi default: "@,48-57,_")
@@ -4530,7 +4530,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	set and to the Vim default value when 'compatible' is reset.
 
 						*'isprint'* *'isp'*
-'isprint' 'isp'	string	(default for MS-DOS, Win32, OS/2 and Macintosh:
+'isprint' 'isp'	string	(default for Win32 and Macintosh:
 				"@,~-255"; otherwise: "@,161-255")
 			global
 	The characters given by this option are displayed directly on the
@@ -5484,7 +5484,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			    *'opendevice'* *'odev'* *'noopendevice'* *'noodev'*
 'opendevice' 'odev'	boolean	(default off)
 			global
-			{only for MS-DOS, MS-Windows and OS/2}
+			{only for MS-Windows}
 	Enable reading and writing from devices.  This may get Vim stuck on a
 	device that can be opened but doesn't actually do the I/O.  Therefore
 	it is off by default.
@@ -5616,7 +5616,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 				*'path'* *'pa'* *E343* *E345* *E347* *E854*
 'path' 'pa'		string	(default on Unix: ".,/usr/include,,"
-				   on OS/2:	  ".,/emx/include,,"
 				   other systems: ".,,")
 			global or local to buffer |global-local|
 	This is a list of directories which will be searched when using the
@@ -6195,7 +6194,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						$VIMRUNTIME,
 						$VIM/vimfiles/after,
 						home:vimfiles/after"
-					PC, OS/2: "$HOME/vimfiles,
+					PC:    "$HOME/vimfiles,
 						$VIM/vimfiles,
 						$VIMRUNTIME,
 						$VIM/vimfiles/after,
@@ -6465,7 +6464,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'shell'* *'sh'* *E91*
 'shell' 'sh'		string	(default $SHELL or "sh",
 					MS-DOS and Win32: "command.com" or
-					"cmd.exe", OS/2: "cmd")
+					"cmd.exe")
 			global
 	Name of the shell to use for ! and :! commands.  When changing the
 	value also check these options: 'shelltype', 'shellpipe', 'shellslash'
@@ -6592,7 +6591,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'shellslash'* *'ssl'* *'noshellslash'* *'nossl'*
 'shellslash' 'ssl'	boolean	(default off)
 			global
-			{only for MSDOS, MS-Windows and OS/2}
+			{only for MS-Windows}
 	When set, a forward slash is used when expanding file names.  This is
 	useful when a Unix-like shell is used instead of command.com or
 	cmd.exe.  Backward slashes can still be typed, but they are changed to
@@ -7668,7 +7667,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 					  on Mac: "mac-ansi"
 					 on MiNT: "vt52"
 				       on MS-DOS: "pcterm"
-					 on OS/2: "os2ansi"
 					 on Unix: "ansi"
 					  on VMS: "ansi"
 				       on Win 32: "win32")
@@ -7827,7 +7825,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	set and to the Vim default value when 'compatible' is reset.
 
 				   *'textmode'* *'tx'* *'notextmode'* *'notx'*
-'textmode' 'tx'		boolean	(MS-DOS, Win32 and OS/2: default on,
+'textmode' 'tx'		boolean	(Win32: default on,
 				 others: default off)
 			local to buffer
 	This option is obsolete.  Use 'fileformat'.
@@ -8215,8 +8213,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	NOTE: This option is reset when 'compatible' is set.
 
 						*'undolevels'* *'ul'*
-'undolevels' 'ul'	number	(default 100, 1000 for Unix, VMS,
-						Win32 and OS/2)
+'undolevels' 'ul'	number	(default 100, 1000 for Unix, VMS, Win32)
 			global or local to buffer |global-local|
 	Maximum number of changes that can be undone.  Since undo information
 	is kept in memory, higher numbers will cause more memory to be used.
@@ -8343,7 +8340,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	displayed when 'verbosefile' is set.
 
 						*'viewdir'* *'vdir'*
-'viewdir' 'vdir'	string	(default for Amiga, MS-DOS, OS/2 and Win32:
+'viewdir' 'vdir'	string	(default for Amiga and Win32:
 							 "$VIM/vimfiles/view",
 				 for Unix: "~/.vim/view",
 				 for Macintosh: "$VIM:vimfiles:view"
@@ -8381,8 +8378,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	but the Windows version of Vim can source unix format scripts.
 
 				*'viminfo'* *'vi'* *E526* *E527* *E528*
-'viminfo' 'vi'		string	(Vi default: "", Vim default for MS-DOS,
-				   Windows and OS/2: '100,<50,s10,h,rA:,rB:,
+'viminfo' 'vi'		string	(Vi default: "", Vim default for
+				   Windows: '100,<50,s10,h,rA:,rB:,
 				   for Amiga: '100,<50,s10,h,rdf0:,rdf1:,rdf2:
 				   for others: '100,<50,s10,h)
 			global

--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -94,7 +94,7 @@ If the option is empty, then vim will use the system default printer for
 
 							*penc-option* *E620*
 'printencoding' 'penc'	String	(default empty, except for:
-					Windows, OS/2: cp1252,
+					Windows: cp1252,
 					Macintosh: mac-roman,
 					VMS: dec-mcs,
 					HPUX: hp-roman8,
@@ -124,7 +124,7 @@ cannot be converted will be replaced with upside down question marks.
 Four print character encoding files are provided to support default Mac, VMS,
 HPUX, and EBCDIC character encodings and are used by default on these
 platforms.  Code page 1252 print character encoding is used by default on
-Windows and OS/2 platforms.
+Windows platform.
 
 							*pexpr-option*
 'printexpr' 'pexpr'	String	(default: see below)
@@ -142,8 +142,8 @@ the file: >
     system('lpr' . (&printdevice == '' ? '' : ' -P' . &printdevice)
 	. ' ' . v:fname_in) . delete(v:fname_in) + v:shell_error
 
-On MS-Dos, MS-Windows and OS/2 machines the default is to copy the file to the
-currently specified printdevice: >
+On MS-Windows machines the default is to copy the file to the currently
+specified printdevice: >
 
     system('copy' . ' ' . v:fname_in . (&printdevice == ''
 		? ' LPT1:' : (' \"' . &printdevice . '\"')))
@@ -621,7 +621,7 @@ OpenVMS
 
     http://wwwthep.physik.uni-mainz.de/~plass/gv/
 
-Windows and OS/2
+Windows
 
 - GSview.  Obtainable from:
 

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -935,11 +935,11 @@ or simpler >
 "$*" can be given multiple times, for example: >
    :set makeprg=gcc\ -o\ $*\ $*
 
-The 'shellpipe' option defaults to ">" for the Amiga, MS-DOS and Win32.  This
-means that the output of the compiler is saved in a file and not shown on the
-screen directly.  For Unix "| tee" is used.  The compiler output is shown on
-the screen and saved in a file the same time.  Depending on the shell used
-"|& tee" or "2>&1| tee" is the default, so stderr output will be included.
+The 'shellpipe' option defaults to ">" for the Amiga and Win32.  This means
+that the output of the compiler is saved in a file and not shown on the screen
+directly.  For Unix "| tee" is used.  The compiler output is shown on the
+screen and saved in a file the same time.  Depending on the shell used "|&
+tee" or "2>&1| tee" is the default, so stderr output will be included.
 
 If 'shellpipe' is empty, the {errorfile} part will be omitted.  This is useful
 for compilers that write to an errorfile themselves (e.g., Manx's Amiga C).
@@ -1384,9 +1384,9 @@ normally happens by matching following characters and items.  When nothing is
 following the rest of the line is matched.  If "%f" is followed by a '%' or a
 backslash, it will look for a sequence of 'isfname' characters.
 
-On MS-DOS, MS-Windows and OS/2 a leading "C:" will be included in "%f", even
-when using "%f:".  This means that a file name which is a single alphabetical
-letter will not be detected.
+On MS-Windows a leading "C:" will be included in "%f", even when using "%f:".
+This means that a file name which is a single alphabetical letter will not be
+detected.
 
 The "%p" conversion is normally followed by a "^".  It's used for compilers
 that output a line like: >

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -414,13 +414,13 @@ with CTRL-V followed by the three digit decimal code.  This does NOT work for
 the <t_xx> termcap codes, these can only be used in mappings.
 
 							*:source_crnl* *W15*
-MS-DOS, Win32 and OS/2: Files that are read with ":source" normally have
-<CR><NL> <EOL>s.  These always work.  If you are using a file with <NL> <EOL>s
-(for example, a file made on Unix), this will be recognized if 'fileformats'
-is not empty and the first line does not end in a <CR>.  This fails if the
-first line has something like ":map <F1> :help^M", where "^M" is a <CR>.  If
-the first line ends in a <CR>, but following ones don't, you will get an error
-message, because the <CR> from the first lines will be lost.
+Win32: Files that are read with ":source" normally have <CR><NL> <EOL>s.
+These always work.  If you are using a file with <NL> <EOL>s (for example, a
+file made on Unix), this will be recognized if 'fileformats' is not empty and
+the first line does not end in a <CR>.  This fails if the first line has
+something like ":map <F1> :help^M", where "^M" is a <CR>.  If the first line
+ends in a <CR>, but following ones don't, you will get an error message,
+because the <CR> from the first lines will be lost.
 
 Mac Classic: Files that are read with ":source" normally have <CR> <EOL>s.
 These always work.  If you are using a file with <NL> <EOL>s (for example, a

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -784,8 +784,6 @@ accordingly.  Vim proceeds in this order:
 
 	Places for your personal initializations:
 		Unix		$HOME/.vimrc or $HOME/.vim/vimrc
-		OS/2		$HOME/.vimrc, $HOME/vimfiles/vimrc
-				or $VIM/.vimrc (or _vimrc)
 		MS-Windows	$HOME/_vimrc, $HOME/vimfiles/vimrc
 				or $VIM/_vimrc
 		Amiga		s:.vimrc, home:.vimrc, home:vimfiles:vimrc
@@ -811,7 +809,7 @@ accordingly.  Vim proceeds in this order:
      a. If vim was started as |evim| or |eview| or with the |-y| argument, the
 	script $VIMRUNTIME/evim.vim will be loaded.
 							*system-vimrc*
-     b. For Unix, MS-DOS, MS-Windows, OS/2, VMS, Macintosh, RISC-OS and Amiga
+     b. For Unix, MS-Windows, VMS, Macintosh, RISC-OS and Amiga
 	the system vimrc file is read for initializations.  The path of this
 	file is shown with the ":version" command.  Mostly it's "$VIM/vimrc".
 	Note that this file is ALWAYS read in 'compatible' mode, since the
@@ -827,22 +825,22 @@ accordingly.  Vim proceeds in this order:
 	I   The environment variable VIMINIT (see also |compatible-default|) (*)
 	    The value of $VIMINIT is used as an Ex command line.
 	II  The user vimrc file(s):
-		    "$HOME/.vimrc"	   (for Unix and OS/2) (*)
-		    "$HOME/.vim/vimrc"	   (for Unix and OS/2) (*)
+		    "$HOME/.vimrc"	   (for Unix) (*)
+		    "$HOME/.vim/vimrc"	   (for Unix) (*)
 		    "s:.vimrc"		   (for Amiga) (*)
 		    "home:.vimrc"	   (for Amiga) (*)
 		    "home:vimfiles:vimrc"  (for Amiga) (*)
-		    "$VIM/.vimrc"	   (for OS/2 and Amiga) (*)
-		    "$HOME/_vimrc"	   (for MS-DOS and Win32) (*)
-		    "$HOME/vimfiles/vimrc" (for MS-DOS and Win32) (*)
-		    "$VIM/_vimrc"	   (for MS-DOS and Win32) (*)
-		Note: For Unix, OS/2 and Amiga, when ".vimrc" does not exist,
+		    "$VIM/.vimrc"	   (for Amiga) (*)
+		    "$HOME/_vimrc"	   (for Win32) (*)
+		    "$HOME/vimfiles/vimrc" (for Win32) (*)
+		    "$VIM/_vimrc"	   (for Win32) (*)
+		Note: For Unix and Amiga, when ".vimrc" does not exist,
 		"_vimrc" is also tried, in case an MS-DOS compatible file
-		system is used.  For MS-DOS and Win32 ".vimrc" is checked
-		after "_vimrc", in case long file names are used.
-		Note: For MS-DOS and Win32, "$HOME" is checked first.  If no
-		"_vimrc" or ".vimrc" is found there, "$VIM" is tried.
-		See |$VIM| for when $VIM is not set.
+		system is used.  For MS-Windows ".vimrc" is checked after
+		"_vimrc", in case long file names are used.
+		Note: For Win32, "$HOME" is checked first.  If no "_vimrc" or
+		".vimrc" is found there, "$VIM" is tried.  See |$VIM| for when
+		$VIM is not set.
 	III The environment variable EXINIT.
 	    The value of $EXINIT is used as an Ex command line.
 	IV  The user exrc file(s).  Same as for the user vimrc file, but with
@@ -855,12 +853,12 @@ accordingly.  Vim proceeds in this order:
      d. If the 'exrc' option is on (which is NOT the default), the current
 	directory is searched for three files.  The first that exists is used,
 	the others are ignored.
-	-  The file ".vimrc" (for Unix, Amiga and OS/2) (*)
-		    "_vimrc" (for MS-DOS and Win32) (*)
-	-  The file "_vimrc" (for Unix, Amiga and OS/2) (*)
-		    ".vimrc" (for MS-DOS and Win32) (*)
-	-  The file ".exrc"  (for Unix, Amiga and OS/2)
-		    "_exrc"  (for MS-DOS and Win32)
+	-  The file ".vimrc" (for Unix, Amiga) (*)
+		    "_vimrc" (for Win32) (*)
+	-  The file "_vimrc" (for Unix, Amiga) (*)
+		    ".vimrc" (for Win32) (*)
+	-  The file ".exrc"  (for Unix, Amiga)
+		    "_exrc"  (for Win32)
 
      (*) Using this file or environment variable will cause 'compatible' to be
 	 off by default.  See |compatible-default|.
@@ -948,9 +946,9 @@ Some hints on using initializations ~
 Standard setup:
 Create a vimrc file to set the default settings and mappings for all your edit
 sessions.  Put it in a place so that it will be found by 3b:
-	~/.vimrc	(Unix and OS/2)
+	~/.vimrc	(Unix)
 	s:.vimrc	(Amiga)
-	$VIM\_vimrc	(MS-DOS and Win32)
+	$VIM\_vimrc	(Win32)
 Note that creating a vimrc file will cause the 'compatible' option to be off
 by default.  See |compatible-default|.
 
@@ -990,10 +988,9 @@ version 5.0) are not recognized.
 
 MS-DOS line separators ~
 
-On MS-DOS-like systems (MS-DOS itself, Win32, and OS/2), Vim assumes that all
-the vimrc files have <CR> <NL> pairs as line separators.  This will give
-problems if you have a file with only <NL>s and have a line like
-":map xx yy^M".  The trailing ^M will be ignored.
+On MS-Windows, Vim assumes that all the vimrc files have <CR> <NL> pairs as
+line separators.  This will give problems if you have a file with only <NL>s
+and have a line like ":map xx yy^M".  The trailing ^M will be ignored.
 
 
 Vi compatible default value ~
@@ -1145,11 +1142,11 @@ will try to get the value for $VIM in this order:
    problem).  The file name ("help.txt" or any other) is removed.  Then
    trailing directory names are removed, in this order: "doc", "runtime" and
    "vim{version}" (e.g., "vim54").
-3. For MSDOS, Win32 and OS/2 Vim tries to use the directory name of the
-   executable.  If it ends in "/src", this is removed.  This is useful if you
-   unpacked the .zip file in some directory, and adjusted the search path to
-   find the vim executable.  Trailing directory names are removed, in this
-   order: "runtime" and "vim{version}" (e.g., "vim54").
+3. For Win32 Vim tries to use the directory name of the executable.  If it
+   ends in "/src", this is removed.  This is useful if you unpacked the .zip
+   file in some directory, and adjusted the search path to find the vim
+   executable.  Trailing directory names are removed, in this order: "runtime"
+   and "vim{version}" (e.g., "vim54").
 4. For Unix the compile-time defined installation directory is used (see the
    output of ":version").
 
@@ -1573,11 +1570,10 @@ remembered.
 
 VIMINFO FILE NAME					*viminfo-file-name*
 
-- The default name of the viminfo file is "$HOME/.viminfo" for Unix and OS/2,
-  "s:.viminfo" for Amiga, "$HOME\_viminfo" for MS-DOS and Win32.  For the last
-  two, when $HOME is not set, "$VIM\_viminfo" is used.  When $VIM is also not
-  set, "c:\_viminfo" is used.  For OS/2 "$VIM/.viminfo" is used when $HOME is
-  not set and $VIM is set.
+- The default name of the viminfo file is "$HOME/.viminfo" for Unix,
+  "s:.viminfo" for Amiga, "$HOME\_viminfo" for Win32.  For the last two, when
+  $HOME is not set, "$VIM\_viminfo" is used.  When $VIM is also not set,
+  "c:\_viminfo" is used.
 - The 'n' flag in the 'viminfo' option can be used to specify another viminfo
   file name |'viminfo'|.
 - The "-i" Vim argument can be used to set another file name, |-i|.  When the

--- a/runtime/doc/usr_01.txt
+++ b/runtime/doc/usr_01.txt
@@ -71,7 +71,7 @@ you are using:
 
 Unix: >
 	:!cp -i $VIMRUNTIME/vimrc_example.vim ~/.vimrc
-MS-DOS, MS-Windows, OS/2: >
+MS-Windows: >
 	:!copy $VIMRUNTIME/vimrc_example.vim $VIM/_vimrc
 Amiga: >
 	:!copy $VIMRUNTIME/vimrc_example.vim $VIM/.vimrc

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -472,7 +472,7 @@ Then copy the file to your plugin directory:
 
 	system		plugin directory ~
 	Unix		~/.vim/plugin/
-	PC and OS/2	$HOME/vimfiles/plugin or $VIM/vimfiles/plugin
+	PC		$HOME/vimfiles/plugin or $VIM/vimfiles/plugin
 	Amiga		s:vimfiles/plugin
 	Macintosh	$VIM:vimfiles:plugin
 	Mac OS X	~/.vim/plugin/

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1699,8 +1699,8 @@ Here is a summary of items that apply to Vim scripts.  They are also mentioned
 elsewhere, but form a nice checklist.
 
 The end-of-line character depends on the system.  For Unix a single <NL>
-character is used.  For MS-DOS, Windows, OS/2 and the like, <CR><LF> is used.
-This is important when using mappings that end in a <CR>.  See |:source_crnl|.
+character is used.  For Windows and the like, <CR><LF> is used.  This is
+important when using mappings that end in a <CR>.  See |:source_crnl|.
 
 
 WHITE SPACE

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -139,7 +139,6 @@ Support for different systems.
 	- MS-DOS in real-mode (no additional drivers required).
 	- In protected mode on Windows 3.1 and MS-DOS (DPMI driver required).
 	- Windows 95 and Windows NT, with support for long file names.
-	- OS/2 (needs emx.dll)
 	- Atari MiNT
 	- VMS
 	- BeOS

--- a/runtime/gvimrc_example.vim
+++ b/runtime/gvimrc_example.vim
@@ -6,7 +6,7 @@
 " Last change:	2016 Apr 05
 "
 " To use it, copy it to
-"     for Unix and OS/2:  ~/.gvimrc
+"	       for Unix:  ~/.gvimrc
 "	      for Amiga:  s:.gvimrc
 "  for MS-DOS and Win32:  $VIM\_gvimrc
 "	    for OpenVMS:  sys$login:.gvimrc

--- a/runtime/tools/README.txt
+++ b/runtime/tools/README.txt
@@ -34,4 +34,4 @@ xcmdsrv_client.c:  Example for a client program that communicates with a Vim
 
 unicode.vim	Vim script to generate tables for src/mbyte.c.
 
-[xxd (and tee for OS/2) can be found in the src directory]
+[xxd can be found in the src directory]

--- a/runtime/vimrc_example.vim
+++ b/runtime/vimrc_example.vim
@@ -4,7 +4,7 @@
 " Last change:	2019 Jan 26
 "
 " To use it, copy it to
-"     for Unix and OS/2:  ~/.vimrc
+"	       for Unix:  ~/.vimrc
 "	      for Amiga:  s:.vimrc
 "  for MS-DOS and Win32:  $VIM\_vimrc
 "	    for OpenVMS:  sys$login:.vimrc

--- a/src/feature.h
+++ b/src/feature.h
@@ -944,7 +944,7 @@
  *			Always included, since either FEAT_MOUSE_XTERM or
  *			DOS_MOUSE is defined.
  */
-// OS/2 and Amiga console have no mouse support
+// Amiga console has no mouse support
 #if defined(UNIX) || defined(VMS)
 # define FEAT_MOUSE_XTERM
 # ifdef FEAT_BIG


### PR DESCRIPTION

The OS/2 support was removed in patch 7.4.1008. Remove references to OS/2
from the help files. Also remove some references to MS-DOS from the help files.