### PR TITLE
Add buflines()

### DIFF
--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -545,6 +545,7 @@ get_buffer_info(buf_T *buf)
     dict_add_string(dict, "name", buf->b_ffname);
     dict_add_number(dict, "lnum", buf == curbuf ? curwin->w_cursor.lnum
 						     : buflist_findlnum(buf));
+    dict_add_number(dict, "lines", buf->b_ml.ml_line_count);
     dict_add_number(dict, "loaded", buf->b_ml.ml_mfp != NULL);
     dict_add_number(dict, "listed", buf->b_p_bl);
     dict_add_number(dict, "changed", bufIsChanged(buf));

--- a/src/testdir/test_bufwintabinfo.vim
+++ b/src/testdir/test_bufwintabinfo.vim
@@ -155,12 +155,12 @@ function Test_getbufinfo_lastused()
   call test_settime(0)
 endfunc
 
-func Test_buflines()
+func Test_getbufinfo_lines()
   new Xfoo
   call setline(1, ['a', 'bc', 'd'])
   let bn = bufnr('%')
   hide
-  call assert_equal(3, buflines(bn))
+  call assert_equal(3, getbufinfo(bn)[0]["lines"])
   edit Xfoo
   bw!
 endfunction

--- a/src/testdir/test_bufwintabinfo.vim
+++ b/src/testdir/test_bufwintabinfo.vim
@@ -154,3 +154,13 @@ function Test_getbufinfo_lastused()
   call assert_equal(getbufinfo('Xtestfile2')[0].lastused, 7654321)
   call test_settime(0)
 endfunc
+
+func Test_buflines()
+  new Xfoo
+  call setline(1, ['a', 'bc', 'd'])
+  let bn = bufnr('%')
+  hide
+  call assert_equal(3, buflines(bn))
+  edit Xfoo
+  bw!
+endfunction


### PR DESCRIPTION
Vim does not have a way to get number of lines for the buffer. Yes, we know `len(getbuflines(nr, 1, '$'))` but useless. This change add buflines().