### PR TITLE
Fixed crash when make_extmatch() returns NULL

### DIFF
--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -4568,6 +4568,8 @@ regtry(
 
 	cleanup_zsubexpr();
 	re_extmatch_out = make_extmatch();
+	if (re_extmatch_out == NULL)
+	    return 0;
 	for (i = 0; i < NSUBEXP; i++)
 	{
 	    if (REG_MULTI)

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -7070,6 +7070,8 @@ nfa_regtry(
     {
 	cleanup_zsubexpr();
 	re_extmatch_out = make_extmatch();
+	if (re_extmatch_out == NULL)
+	    return 0;
 	// Loop over \z1, \z2, etc.  There is no \z0.
 	for (i = 1; i < subs.synt.in_use; i++)
 	{


### PR DESCRIPTION
This PR fixes a crash after OOM when `make_extmatch()`
returns `NULL`.

Bug was found by making `lalloc()` return `NULL` randomly
to check where vim does not handle allocation failures
gracefully. I stumbled upon a crash in `vim/src/regexp_bt.c:4579`
with `re_extmatch_out` being `NULL`. Line `regexp_bt.c:4570`
calls `make_extmatch()` to allocate `re_extmatch_out`
without checking whether it returns `NULL`:

`regex_bt.c`:
```
! 4570     re_extmatch_out = make_extmatch();
  4571     for (i = 0; i < NSUBEXP; i++)
  4572     {
  4573         if (REG_MULTI)
  4574         {
  4575             // Only accept single line matches.
  4576             if (reg_startzpos[i].lnum >= 0
  4577                     && reg_endzpos[i].lnum == reg_startzpos[i].lnum
  4578                     && reg_endzpos[i].col >= reg_startzpos[i].col)
!!4579                 re_extmatch_out->matches[i] =
```
