### PR TITLE
Fix crash after OOM in f_resolve()

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -1658,6 +1658,8 @@ f_resolve(typval_T *argvars, typval_T *rettv)
 	int	limit = 100;
 
 	p = vim_strsave(p);
+	if (p == NULL)
+	    goto fail;
 
 	if (p[0] == '.' && (vim_ispathsep(p[1])
 				   || (p[1] == '.' && (vim_ispathsep(p[2])))))


### PR DESCRIPTION
This PR fixes a crash after OOM in `f_resolve()`:
`p` is allocated at line `filepath.c:1660` and dereferenced
immediately without checking whether allocation succeeded:
```
!!1660         p = vim_strsave(p);
  1661                                                                                                                     
!!1662         if (p[0] == '.' && (vim_ispathsep(p[1])
  1663                                    || (p[1] == '.' && (vim_ispathsep(p[2])))))
```