### PR TITLE
Remove references to MS-DOS in the help files

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -639,7 +639,7 @@ CursorHold			When the user doesn't press a key for the time
 				Hint: to force an update of the status lines
 				use: >
 					:let &ro = &ro
-<				{only on Amiga, Unix, Win32, MSDOS and all GUI
+<				{only on Amiga, Unix, Win32 and all GUI
 				versions}
 							*CursorHoldI*
 CursorHoldI			Just like CursorHold, but in Insert mode.

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -943,7 +943,7 @@ These modifiers can be given, in this order:
 		separator is removed.  Thus ":p:h" on a directory name results
 		on the directory name itself (without trailing slash).
 		When the file name is an absolute path (starts with "/" for
-		Unix; "x:\" for WIN32; "drive:" for Amiga), that part is not
+		Unix; "x:\" for Win32; "drive:" for Amiga), that part is not
 		removed.  When there is no head (path is relative to current
 		directory) the result is empty.
 	:t	Tail of the file name (last component of the name).  Must

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -131,7 +131,7 @@ You can use this file if you discover that you need the original file.  See
 also the 'patchmode' option.  The name of the backup file is normally the same
 as the original file with 'backupext' appended.  The default "~" is a bit
 strange to avoid accidentally overwriting existing files.  If you prefer ".bak"
-change the 'backupext' option.  Extra dots are replaced with '_' on MS-DOS
+change the 'backupext' option.  Extra dots are replaced with '_' on MS-Windows
 machines, when Vim has detected that an MS-DOS-like filesystem is being used
 (e.g., messydos or crossdos) or when the 'shortname' option is on.  The
 backup file can be placed in another directory by setting 'backupdir'.
@@ -542,15 +542,16 @@ If you start editing a new file and the 'fileformats' option is not empty
 (which is the default), Vim will try to detect whether the lines in the file
 are separated by the specified formats.  When set to "unix,dos", Vim will
 check for lines with a single <NL> (as used on Unix and Amiga) or by a <CR>
-<NL> pair (MS-DOS).  Only when ALL lines end in <CR><NL>, 'fileformat' is set
-to "dos", otherwise it is set to "unix".  When 'fileformats' includes "mac",
-and no <NL> characters are found in the file, 'fileformat' is set to "mac".
+<NL> pair (MS-Windows).  Only when ALL lines end in <CR><NL>, 'fileformat' is
+set to "dos", otherwise it is set to "unix".  When 'fileformats' includes
+"mac", and no <NL> characters are found in the file, 'fileformat' is set to
+"mac".
 
-If the 'fileformat' option is set to "dos" on non-MS-DOS systems the message
-"[dos format]" is shown to remind you that something unusual is happening.  On
-MS-DOS systems you get the message "[unix format]" if 'fileformat' is set to
-"unix".  On all systems but the Macintosh you get the message "[mac format]"
-if 'fileformat' is set to "mac".
+If the 'fileformat' option is set to "dos" on non-MS-Windows systems the
+message "[dos format]" is shown to remind you that something unusual is
+happening.  On MS-Windows systems you get the message "[unix format]" if
+'fileformat' is set to "unix".  On all systems but the Macintosh you get the
+message "[mac format]" if 'fileformat' is set to "mac".
 
 If the 'fileformats' option is empty and DOS format is used, but while reading
 a file some lines did not end in <CR><NL>, "[CR missing]" will be included in
@@ -1056,11 +1057,11 @@ When the file name is actually a device name, Vim will not make a backup (that
 would be impossible).  You need to use "!", since the device already exists.
 Example for Unix: >
 	:w! /dev/lpt0
-and for MS-DOS or MS-Windows: >
+and for MS-Windows: >
 	:w! lpt0
 For Unix a device is detected when the name doesn't refer to a normal file or
 a directory.  A fifo or named pipe also looks like a device to Vim.
-For MS-DOS and MS-Windows the device is detected by its name:
+For MS-Windows the device is detected by its name:
 	AUX
 	CON
 	CLOCK$
@@ -1294,7 +1295,7 @@ present in 'cpoptions' and "!" is not used in the command.
 			Does not change the meaning of an already opened file,
 			because its full path name is remembered.  Files from
 			the |arglist| may change though!
-			On MS-DOS this also changes the active drive.
+			On MS-Windows this also changes the active drive.
 			To change to the directory of the current file: >
 				:cd %:h
 <

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3993,16 +3993,15 @@ executable({expr})					*executable()*
 		arguments.
 		executable() uses the value of $PATH and/or the normal
 		searchpath for programs.		*PATHEXT*
-		On MS-DOS and MS-Windows the ".exe", ".bat", etc. can
-		optionally be included.  Then the extensions in $PATHEXT are
-		tried.  Thus if "foo.exe" does not exist, "foo.exe.bat" can be
-		found.  If $PATHEXT is not set then ".exe;.com;.bat;.cmd" is
-		used.  A dot by itself can be used in $PATHEXT to try using
-		the name without an extension.  When 'shell' looks like a
-		Unix shell, then the name is also tried without adding an
-		extension.
-		On MS-DOS and MS-Windows it only checks if the file exists and
-		is not a directory, not if it's really executable.
+		On MS-Windows the ".exe", ".bat", etc. can optionally be
+		included.  Then the extensions in $PATHEXT are tried.  Thus if
+		"foo.exe" does not exist, "foo.exe.bat" can be found.  If
+		$PATHEXT is not set then ".exe;.com;.bat;.cmd" is used.  A dot
+		by itself can be used in $PATHEXT to try using the name
+		without an extension.  When 'shell' looks like a Unix shell,
+		then the name is also tried without adding an extension.
+		On MS-Windows it only checks if the file exists and is not a
+		directory, not if it's really executable.
 		On MS-Windows an executable in the same directory as Vim is
 		always found.  Since this directory is added to $PATH it
 		should also work to execute it |win32-PATH|.
@@ -5371,7 +5370,7 @@ getmousepos()						*getmousepos()*
 							*getpid()*
 getpid()	Return a Number which is the process ID of the Vim process.
 		On Unix and MS-Windows this is a unique number, until Vim
-		exits.  On MS-DOS it's always zero.
+		exits.
 
 							*getpos()*
 getpos({expr})	Get the position for {expr}.  For possible values of {expr}
@@ -10685,8 +10684,8 @@ filterpipe		When 'shelltemp' is off pipes are used for shell
 find_in_path		Compiled with support for include file searches
 			|+find_in_path|.
 float			Compiled with support for |Float|.
-fname_case		Case in file names matters (for Amiga, MS-DOS, and
-			Windows this is not present).
+fname_case		Case in file names matters (for Amiga and MS-Windows
+			this is not present).
 folding			Compiled with |folding| support.
 footer			Compiled with GUI footer support. |gui-footer|
 fork			Compiled to use fork()/exec() instead of system().

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -34,7 +34,6 @@ if you didn't do that already.
 Detail: The ":filetype on" command will load one of these files:
 		Amiga	    $VIMRUNTIME/filetype.vim
 		Mac	    $VIMRUNTIME:filetype.vim
-		MS-DOS	    $VIMRUNTIME\filetype.vim
 		RiscOS	    Vim:Filetype
 		Unix	    $VIMRUNTIME/filetype.vim
 		VMS	    $VIMRUNTIME/filetype.vim

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -34,7 +34,7 @@ if you didn't do that already.
 Detail: The ":filetype on" command will load one of these files:
 		Amiga	    $VIMRUNTIME/filetype.vim
 		Mac	    $VIMRUNTIME:filetype.vim
-		RiscOS	    Vim:Filetype
+		MS-Windows  $VIMRUNTIME\filetype.vim
 		Unix	    $VIMRUNTIME/filetype.vim
 		VMS	    $VIMRUNTIME/filetype.vim
 	This file is a Vim script that defines autocommands for the

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -114,7 +114,7 @@ You can also install Vim in the "Send To" menu:
 4. Follow the shortcut wizard, using the full path to VIM/GVIM.
 
 When you 'send a file to Vim', Vim changes to that file's directory.  Note,
-however, that any long directory names will appear in their short (MS-DOS)
+however, that any long directory names will appear in their short (MS-Windows)
 form.  This is a limitation of the Windows "Send To" mechanism.
 
 						*notepad*

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -2008,10 +2008,10 @@ If the 'fileformats' option is not empty Vim tries to recognize the type of
 changed, the detected format is only used while reading the file.
 A similar thing happens with 'fileencodings'.
 
-On non-MS-DOS and Win32 systems the message "[dos format]" is shown if a file
-is read in DOS format, to remind you that something unusual is done.  On
-Macintosh and Win32 the message "[unix format]" is shown if a file is read in
-Unix format.
+The message "[dos format]" is shown if a file is read in DOS format, to remind
+you that something unusual is done.
+On Macintosh and Win32 the message "[unix format]" is shown if a file is read
+in Unix format.
 On non-Macintosh systems, the message "[Mac format]" is shown if a file is
 read in Mac format.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -196,11 +196,11 @@ the option value, use '\"' instead.  This example sets the 'titlestring'
 option to 'hi "there"': >
    :set titlestring=hi\ \"there\"
 
-For MS-DOS and WIN32 backslashes in file names are mostly not removed.  More
-precise: For options that expect a file name (those where environment
-variables are expanded) a backslash before a normal file name character is not
-removed.  But a backslash before a special character (space, backslash, comma,
-etc.) is used like explained above.
+For Win32 backslashes in file names are mostly not removed.  More precise: For
+options that expect a file name (those where environment variables are
+expanded) a backslash before a normal file name character is not removed.  But
+a backslash before a special character (space, backslash, comma, etc.) is used
+like explained above.
 There is one special situation, when the value starts with "\\": >
    :set dir=\\machine\path	    results in "\\machine\path"
    :set dir=\\\\machine\\path	    results in "\\machine\path"
@@ -652,7 +652,7 @@ supported use something like this: >
 A jump table for the options with a short description can be found at |Q_op|.
 
 					*'aleph'* *'al'* *aleph* *Aleph*
-'aleph' 'al'		number	(default 128 for MS-DOS, 224 otherwise)
+'aleph' 'al'		number	(default 128 for MS-Windows, 224 otherwise)
 			global
 			{only available when compiled with the |+rightleft|
 			feature}
@@ -1007,7 +1007,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'backupdir'* *'bdir'*
 'backupdir' 'bdir'	string	(default for Amiga: ".,t:",
-				 for MS-DOS and Win32: ".,$TEMP,c:/tmp,c:/temp"
+				 for Win32: ".,$TEMP,c:/tmp,c:/temp"
 				 for Unix: ".,~/tmp,~/")
 			global
 	List of directories for the backup file, separated with commas.
@@ -1018,8 +1018,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  impossible!).  Writing may fail because of this.
 	- A directory "." means to put the backup file in the same directory
 	  as the edited file.
-	- A directory starting with "./" (or ".\" for MS-DOS et al.) means to
-	  put the backup file relative to where the edited file is.  The
+	- A directory starting with "./" (or ".\" for MS-Windows et al.) means
+	  to put the backup file relative to where the edited file is.  The
 	  leading "." is replaced with the path name of the edited file.
 	  ("." inside a directory name has no special meaning).
 	- Spaces after the comma are ignored, other spaces are considered part
@@ -2700,7 +2700,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'directory'* *'dir'*
 'directory' 'dir'	string	(default for Amiga: ".,t:",
-				 for MS-DOS and Win32: ".,$TEMP,c:\tmp,c:\temp"
+				 for Win32: ".,$TEMP,c:\tmp,c:\temp"
 				 for Unix: ".,~/tmp,/var/tmp,/tmp")
 			global
 	List of directory names for the swap file, separated with commas.
@@ -2712,9 +2712,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  the edited file.  On Unix, a dot is prepended to the file name, so
 	  it doesn't show in a directory listing.  On MS-Windows the "hidden"
 	  attribute is set and a dot prepended if possible.
-	- A directory starting with "./" (or ".\" for MS-DOS et al.) means to
-	  put the swap file relative to where the edited file is.  The leading
-	  "." is replaced with the path name of the edited file.
+	- A directory starting with "./" (or ".\" for MS-Windows et al.) means
+	  to put the swap file relative to where the edited file is.  The
+	  leading "." is replaced with the path name of the edited file.
 	- For Unix and Win32, if a directory ends in two path separators "//",
 	  the swap file name will be built from the complete path to the file
 	  with all path separators substituted to percent '%' signs. This will
@@ -3586,17 +3586,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 					r-cr:hor20-Cursor/lCursor,
 					sm:block-Cursor
 					-blinkwait175-blinkoff150-blinkon175",
-				for MS-DOS and Win32 console:
+				for Win32 console:
 					"n-v-c:block,o:hor50,i-ci:hor15,
 					r-cr:hor30,sm:block")
 			global
 			{only available when compiled with GUI enabled, and
-			for MS-DOS and Win32 console}
+			for Win32 console}
 	This option tells Vim what the cursor should look like in different
-	modes.  It fully works in the GUI.  In an MSDOS or Win32 console, only
-	the height of the cursor can be changed.  This can be done by
-	specifying a block cursor, or a percentage for a vertical or
-	horizontal cursor.
+	modes.  It fully works in the GUI.  In an Win32 console, only the
+	height of the cursor can be changed.  This can be done by specifying a
+	block cursor, or a percentage for a vertical or horizontal cursor.
 	For a console the 't_SI', 't_SR', and 't_EI' escape sequences are
 	used.
 
@@ -3873,7 +3872,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 
 						*'helpfile'* *'hf'*
-'helpfile' 'hf'		string	(default (MSDOS)  "$VIMRUNTIME\doc\help.txt"
+'helpfile' 'hf'		string	(default (MS-Windows) "$VIMRUNTIME\doc\help.txt"
 					 (others) "$VIMRUNTIME/doc/help.txt")
 			global
 	Name of the main help file.  All distributed help files should be
@@ -5205,13 +5204,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	set and to the Vim default value when 'compatible' is reset.
 
 						*'mouse'* *E538*
-'mouse'			string	(default "", "a" for GUI, MS-DOS and Win32,
+'mouse'			string	(default "", "a" for GUI and Win32,
 					set to "a" or "nvi" in |defaults.vim|)
 			global
-	Enable the use of the mouse.  Works for most terminals (xterm, MS-DOS,
-	Win32 |win32-mouse|, QNX pterm, *BSD console with sysmouse and Linux
-	console with gpm).  For using the mouse in the GUI, see |gui-mouse|.
-	The mouse can be enabled for different modes:
+	Enable the use of the mouse.  Works for most terminals (xterm, Win32
+	|win32-mouse|, QNX pterm, *BSD console with sysmouse and Linux console
+	with gpm).  For using the mouse in the GUI, see |gui-mouse|.  The
+	mouse can be enabled for different modes:
 		n	Normal mode and Terminal modes
 		v	Visual mode
 		i	Insert mode
@@ -5259,7 +5258,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The mouse pointer is restored when the mouse is moved.
 
 						*'mousemodel'* *'mousem'*
-'mousemodel' 'mousem'	string	(default "extend", "popup" for MS-DOS and Win32)
+'mousemodel' 'mousem'	string	(default "extend", "popup" for Win32)
 			global
 	Sets the model to use for the mouse.  The name mostly specifies what
 	the right mouse button is used for:
@@ -5362,7 +5361,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'mousetime'* *'mouset'*
 'mousetime' 'mouset'	number	(default 500)
 			global
-	Only for GUI, MS-DOS, Win32 and Unix with xterm.  Defines the maximum
+	Only for GUI, Win32 and Unix with xterm.  Defines the maximum
 	time in msec between two mouse clicks for the second click to be
 	recognized as a multi click.
 
@@ -6497,17 +6496,17 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'shellcmdflag'* *'shcf'*
 'shellcmdflag' 'shcf'	string	(default: "-c";
-				 MS-DOS and Win32, when 'shell' does not
-				 contain "sh" somewhere: "/c")
+				 Win32, when 'shell' does not contain "sh"
+				 somewhere: "/c")
 			global
 	Flag passed to the shell to execute "!" and ":!" commands; e.g.,
-	"bash.exe -c ls" or "command.com /c dir".  For the MS-DOS-like
+	"bash.exe -c ls" or "command.com /c dir".  For the MS-Windows-like
 	systems, the default is set according to the value of 'shell', to
 	reduce the need to set this option by the user.
 	On Unix it can have more than one flag.  Each white space separated
 	part is passed as an argument to the shell command.
 	See |option-backslash| about including spaces and backslashes.
-	Also see |dos-shell| for MS-DOS and MS-Windows.
+	Also see |dos-shell| for MS-Windows.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -6522,8 +6521,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The name of the temporary file can be represented by "%s" if necessary
 	(the file name is appended automatically if no %s appears in the value
 	of this option).
-	For the Amiga and MS-DOS the default is ">".  The output is directly
-	saved in a file and not echoed to the screen.
+	For the Amiga the default is ">".  The output is directly saved in a
+	file and not echoed to the screen.
 	For Unix the default it "| tee".  The stdout of the compiler is saved
 	in a file and echoed to the screen.  If the 'shell' option is "csh" or
 	"tcsh" after initializations, the default becomes "|& tee".  If the
@@ -6546,7 +6545,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 						*'shellquote'* *'shq'*
-'shellquote' 'shq'	string	(default: ""; MS-DOS and Win32, when 'shell'
+'shellquote' 'shq'	string	(default: ""; Win32, when 'shell'
 					contains "sh" somewhere: "\"")
 			global
 	Quoting character(s), put around the command passed to the shell, for
@@ -6554,10 +6553,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	quoting.  See 'shellxquote' to include the redirection.  It's
 	probably not useful to set both options.
 	This is an empty string by default.  Only known to be useful for
-	third-party shells on MS-DOS-like systems, such as the MKS Korn Shell
-	or bash, where it should be "\"".  The default is adjusted according
-	the value of 'shell', to reduce the need to set this option by the
-	user.  See |dos-shell|.
+	third-party shells on MS-Windows-like systems, such as the MKS Korn
+	Shell or bash, where it should be "\"".  The default is adjusted
+	according the value of 'shell', to reduce the need to set this option
+	by the user.  See |dos-shell|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -6638,7 +6637,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'shellxescape'* *'sxe'*
 'shellxescape' 'sxe'	string	(default: "";
-				 for MS-DOS and MS-Windows: "\"&|<>()@^")
+				 for MS-Windows: "\"&|<>()@^")
 			global
 	When 'shellxquote' is set to "(" then the characters listed in this
 	option will be escaped with a '^' character.  This makes it possible
@@ -6748,8 +6747,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Filenames are assumed to be 8 characters plus one extension of 3
 	characters.  Multiple dots in file names are not allowed.  When this
 	option is on, dots in file names are replaced with underscores when
-	adding an extension (".~" or ".swp").  This option is not available
-	for MS-DOS, because then it would always be on.  This option is useful
+	adding an extension (".~" or ".swp").  This option is useful
 	when editing files on an MS-DOS compatible filesystem, e.g., messydos
 	or crossdos.  When running the Win32 GUI version under Win32s, this
 	option is always on by default.
@@ -7664,7 +7662,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 					 on BeOS: "beos-ansi"
 					  on Mac: "mac-ansi"
 					 on MiNT: "vt52"
-				       on MS-DOS: "pcterm"
 					 on Unix: "ansi"
 					  on VMS: "ansi"
 				       on Win 32: "win32")
@@ -8459,7 +8456,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	r	Removable media.  The argument is a string (up to the next
 		',').  This parameter can be given several times.  Each
 		specifies the start of a path for which no marks will be
-		stored.  This is to avoid removable media.  For MS-DOS you
+		stored.  This is to avoid removable media.  For MS-Windows you
 		could use "ra:,rb:", for Amiga "rdf0:,rdf1:,rdf2:".  You can
 		also use it for temp files, e.g., for Unix: "r/tmp".  Case is
 		ignored.  Maximum length of each 'r' argument is 50
@@ -8956,6 +8953,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	The number of milliseconds to wait for each character sent to the
 	screen.  When non-zero, characters are sent to the terminal one by
-	one.  For MS-DOS pcterm this does not work.  For debugging purposes.
+	one.  For debugging purposes.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6201,9 +6201,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 					Macintosh: "$VIM:vimfiles,
 						$VIMRUNTIME,
 						$VIM:vimfiles:after"
-					RISC-OS: "Choices:vimfiles,
-						$VIMRUNTIME,
-						Choices:vimfiles/after"
 					VMS: "sys$login:vimfiles,
 						$VIM/vimfiles,
 						$VIMRUNTIME,
@@ -8339,8 +8336,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 							 "$VIM/vimfiles/view",
 				 for Unix: "~/.vim/view",
 				 for Macintosh: "$VIM:vimfiles:view"
-				 for VMS: "sys$login:vimfiles/view"
-				 for RiscOS: "Choices:vimfiles/view")
+				 for VMS: "sys$login:vimfiles/view")
 			global
 			{not available when compiled without the |+mksession|
 			feature}

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -131,7 +131,7 @@ gD			Goto global Declaration.  When the cursor is on a
 
 							*CTRL-C*
 CTRL-C			Interrupt current (search) command.  Use CTRL-Break on
-			MS-DOS |dos-CTRL-Break|.
+			MS-Windows |dos-CTRL-Break|.
 			In Normal mode, any pending command is aborted.
 
 							*:noh* *:nohlsearch*

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -891,7 +891,7 @@ Short explanation of each option:		*option-list*
 'shiftround'	  'sr'	    round indent to multiple of shiftwidth
 'shiftwidth'	  'sw'	    number of spaces to use for (auto)indent step
 'shortmess'	  'shm'     list of flags, reduce length of messages
-'shortname'	  'sn'	    non-MS-DOS: Filenames assumed to be 8.3 chars
+'shortname'	  'sn'	    Filenames assumed to be 8.3 chars
 'showbreak'	  'sbr'     string to use at the start of wrapped lines
 'showcmd'	  'sc'	    show (partial) command in status line
 'showfulltag'	  'sft'     show full tag pattern when completing tag
@@ -1053,11 +1053,12 @@ Short explanation of each option:		*option-list*
 |g_CTRL-G|	   g CTRL-G	show cursor column, line, and character
 				   position
 |CTRL-C|	   CTRL-C	during searches: Interrupt the search
-|dos-CTRL-Break|   CTRL-Break	MS-DOS: during searches: Interrupt the search
+|dos-CTRL-Break|   CTRL-Break	MS-Windows: during searches: Interrupt the
+				   search
 |<Del>|		   <Del>	while entering a count: delete last character
 |:version|	:ve[rsion]	show version information
-|:mode|		:mode N		MS-DOS: set screen mode to N (number, C80,
-				   C4350, etc.)
+|:mode|		:mode N		MS-Windows: set screen mode to N (number, C80,
+				C4350, etc.)
 |:normal|	:norm[al][!] {commands}
 				execute Normal mode commands
 |Q|		   Q		switch to "Ex" mode

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -36,7 +36,7 @@ with the extension ".swp".
 - On Unix, a '.' is prepended to swap file names in the same directory as the
   edited file.  This avoids that the swap file shows up in a directory
   listing.
-- On MS-DOS machines and when the 'shortname' option is on, any '.' in the
+- On MS-Windows machines and when the 'shortname' option is on, any '.' in the
   original file name is replaced with '_'.
 - If this file already exists (e.g., when you are recovering from a crash) a
   warning is given and another extension is used, ".swo", ".swn", etc.
@@ -75,7 +75,7 @@ If you want to put swap files in a fixed place, put a command resembling the
 following ones in your .vimrc:
 	:set dir=dh2:tmp	(for Amiga)
 	:set dir=~/tmp		(for Unix)
-	:set dir=c:\\tmp	(for MS-DOS and Win32)
+	:set dir=c:\\tmp	(for Win32)
 This is also very handy when editing files on floppy.  Of course you will have
 to create that "tmp" directory for this to work!
 
@@ -110,7 +110,7 @@ the time with the 'updatetime' option.  The time is given in milliseconds.
 After writing to the swap file Vim syncs the file to disk.  This takes some
 time, especially on busy Unix systems.  If you don't want this you can set the
 'swapsync' option to an empty string.  The risk of losing work becomes bigger
-though.  On some non-Unix systems (MS-DOS, Amiga) the swap file won't be
+though.  On some non-Unix systems (MS-Windows, Amiga) the swap file won't be
 written at all.
 
 If the writing to the swap file is not wanted, it can be switched off by

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -430,7 +430,7 @@ linebreaks which has a <CR> in first line.
 
 On other systems, Vim expects ":source"ed files to end in a <NL>.  These
 always work.  If you are using a file with <CR><NL> <EOL>s (for example, a
-file made on MS-DOS), all lines will have a trailing <CR>.  This may cause
+file made on MS-Windows), all lines will have a trailing <CR>.  This may cause
 problems for some commands (e.g., mappings).  There is no automatic <EOL>
 detection, because it's common to start with a line that defines a mapping
 that ends in a <CR>, which will confuse the automaton.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -809,13 +809,12 @@ accordingly.  Vim proceeds in this order:
      a. If vim was started as |evim| or |eview| or with the |-y| argument, the
 	script $VIMRUNTIME/evim.vim will be loaded.
 							*system-vimrc*
-     b. For Unix, MS-Windows, VMS, Macintosh, RISC-OS and Amiga
-	the system vimrc file is read for initializations.  The path of this
-	file is shown with the ":version" command.  Mostly it's "$VIM/vimrc".
-	Note that this file is ALWAYS read in 'compatible' mode, since the
-	automatic resetting of 'compatible' is only done later.  Add a ":set
-	nocp" command if you like.
-	For the Macintosh the $VIMRUNTIME/macmap.vim is read.
+     b. For Unix, MS-Windows, VMS, Macintosh and Amiga the system vimrc file
+	is read for initializations.  The path of this file is shown with the
+	":version" command.  Mostly it's "$VIM/vimrc".  Note that this file is
+	ALWAYS read in 'compatible' mode, since the automatic resetting of
+	'compatible' is only done later.  Add a ":set nocp" command if you
+	like.  For the Macintosh the $VIMRUNTIME/macmap.vim is read.
 
 	  *VIMINIT* *.vimrc* *_vimrc* *EXINIT* *.exrc* *_exrc* *$MYVIMRC*
      c. Five places are searched for initializations.  The first that exists

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -760,7 +760,7 @@ accordingly.  Vim proceeds in this order:
 
 1. Set the 'shell' and 'term' option		*SHELL* *COMSPEC* *TERM*
 	The environment variable SHELL, if it exists, is used to set the
-	'shell' option.  On MS-DOS and Win32, the COMSPEC variable is used
+	'shell' option.  On Win32, the COMSPEC variable is used
 	if SHELL is not set.
 	The environment variable TERM, if it exists, is used to set the 'term'
 	option.  However, 'term' will change later when starting the GUI (step
@@ -955,8 +955,8 @@ by default.  See |compatible-default|.
 Local setup:
 Put all commands that you need for editing a specific directory only into a
 vimrc file and place it in that directory under the name ".vimrc" ("_vimrc"
-for MS-DOS and Win32).  NOTE: To make Vim look for these special files you
-have to turn on the option 'exrc'.  See |trojan-horse| too.
+for Win32).  NOTE: To make Vim look for these special files you have to turn
+on the option 'exrc'.  See |trojan-horse| too.
 
 System setup:
 This only applies if you are managing a Unix system with several users and
@@ -986,7 +986,7 @@ manual.  The environment variables set with the old Manx Set command (before
 version 5.0) are not recognized.
 
 
-MS-DOS line separators ~
+MS-Windows line separators ~
 
 On MS-Windows, Vim assumes that all the vimrc files have <CR> <NL> pairs as
 line separators.  This will give problems if you have a file with only <NL>s
@@ -1277,7 +1277,7 @@ with ":map" and ":set" commands and write the modified file.  First read the
 default ".vimrc" in with a command like ":source ~piet/.vimrc.Cprogs", change
 the settings and then save them in the current directory with ":mkvimrc!".  If
 you want to make this file your default .vimrc, move it to your home directory
-(on Unix), s: (Amiga) or $VIM directory (MS-DOS).  You could also use
+(on Unix), s: (Amiga) or $VIM directory (MS-Windows).  You could also use
 autocommands |autocommand| and/or modelines |modeline|.
 
 						*vimrc-option-example*
@@ -1538,8 +1538,8 @@ about to abandon with ":bdel", use ":wv".  The '[' and ']' marks are not
 stored, but the '"' mark is.  The '"' mark is very useful for jumping to the
 cursor position when the file was last exited.  No marks are saved for files
 that start with any string given with the "r" flag in 'viminfo'.  This can be
-used to avoid saving marks for files on removable media (for MS-DOS you would
-use "ra:,rb:", for Amiga "rdf0:,rdf1:,rdf2:").
+used to avoid saving marks for files on removable media (for MS-Windows you
+would use "ra:,rb:", for Amiga "rdf0:,rdf1:,rdf2:").
 The |v:oldfiles| variable is filled with the file names that the viminfo file
 has marks for.
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -79,9 +79,9 @@ with: >
 For a color terminal see |:hi-normal-cterm|.
 For setting up your own colors syntax highlighting see |syncolor|.
 
-NOTE: The syntax files on MS-DOS and Windows have lines that end in <CR><NL>.
+NOTE: The syntax files on MS-Windows have lines that end in <CR><NL>.
 The files for Unix end in <NL>.  This means you should use the right type of
-file for your system.  Although on MS-DOS and Windows the right format is
+file for your system.  Although on MS-Windows the right format is
 automatically selected if the 'fileformats' option is not empty.
 
 NOTE: When using reverse video ("gvim -fg white -bg black"), the default value
@@ -4827,7 +4827,7 @@ mentioned for the default values. See |:verbose-cmd| for more information.
 					*highlight-args* *E416* *E417* *E423*
 There are three types of terminals for highlighting:
 term	a normal terminal (vt100, xterm)
-cterm	a color terminal (MS-DOS console, color-xterm, these have the "Co"
+cterm	a color terminal (MS-Windows console, color-xterm, these have the "Co"
 	termcap entry)
 gui	the GUI
 
@@ -4914,9 +4914,9 @@ ctermbg={color-nr}				*highlight-ctermbg*
 	Unfortunately this means that it's not possible to get the same colors
 	for each user.	See |xterm-color| for info about color xterms.
 
-	The MSDOS standard colors are fixed (in a console window), so these
-	have been used for the names.  But the meaning of color names in X11
-	are fixed, so these color settings have been used, to make the
+	The MS-Windows standard colors are fixed (in a console window), so
+	these have been used for the names.  But the meaning of color names in
+	X11 are fixed, so these color settings have been used, to make the
 	highlighting settings portable (complicated, isn't it?).  The
 	following names are recognized, with the color number used:
 
@@ -4981,8 +4981,8 @@ ctermbg={color-nr}				*highlight-ctermbg*
 							*E419* *E420*
 	When Vim knows the normal foreground and background colors, "fg" and
 	"bg" can be used as color names.  This only works after setting the
-	colors for the Normal group and for the MS-DOS console.  Example, for
-	reverse video: >
+	colors for the Normal group and for the MS-Windows console.  Example,
+	for reverse video: >
 	    :highlight Visual ctermfg=bg ctermbg=fg
 <	Note that the colors are used that are valid at the moment this
 	command are given.  If the Normal group colors are changed later, the

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -25,8 +25,9 @@ NOTE: Most of this is not used when running the |GUI|.
 1. Startup						*startup-terminal*
 
 When Vim is started a default terminal type is assumed.  For the Amiga this is
-a standard CLI window, for MS-DOS the pc terminal, for Unix an ansi terminal.
-A few other terminal types are always available, see below |builtin-terms|.
+a standard CLI window, for MS-Windows the pc terminal, for Unix an ansi
+terminal.  A few other terminal types are always available, see below
+|builtin-terms|.
 
 You can give the terminal name with the '-T' Vim argument.  If it is not given
 Vim will try to get the name from the TERM environment variable.
@@ -595,8 +596,8 @@ cleared when scrolling).
 Unfortunately it is not possible to deduce from the termcap how cursor
 positioning should be done when using a scrolling region: Relative to the
 beginning of the screen or relative to the beginning of the scrolling region.
-Most terminals use the first method.  A known exception is the MS-DOS console
-(pcterm).  The 't_CS' option should be set to any string when cursor
+Most terminals use the first method.  A known exception is the MS-Windows
+console (pcterm).  The 't_CS' option should be set to any string when cursor
 positioning is relative to the start of the scrolling region.  It should be
 set to an empty string otherwise.  It defaults to "yes" when 'term' is
 "pcterm".
@@ -651,8 +652,8 @@ One command can be used to set the screen size:
 :mod[e] [mode]
 
 Without argument this only detects the screen size and redraws the screen.
-With MS-DOS it is possible to switch screen mode.  [mode] can be one of these
-values:
+With MS-Windows it is possible to switch screen mode.  [mode] can be one of
+these values:
 	"bw40"		40 columns black&white
 	"c40"		40 columns color
 	"bw80"		80 columns black&white
@@ -699,10 +700,10 @@ If you are using Vim over a slow serial line, you might want to try running
 Vim inside the "screen" program.  Screen will optimize the terminal I/O quite
 a bit.
 
-If you are testing termcap options, but you cannot see what is happening,
-you might want to set the 'writedelay' option.  When non-zero, one character
-is sent to the terminal at a time (does not work for MS-DOS).  This makes the
-screen updating a lot slower, making it possible to see what is happening.
+If you are testing termcap options, but you cannot see what is happening, you
+might want to set the 'writedelay' option.  When non-zero, one character is
+sent to the terminal at a time.  This makes the screen updating a lot slower,
+making it possible to see what is happening.
 
 ==============================================================================
 5. Using the mouse					*mouse-using*
@@ -716,8 +717,8 @@ Don't forget to enable the mouse with this command: >
 Otherwise Vim won't recognize the mouse in all modes (See 'mouse').
 
 Currently the mouse is supported for Unix in an xterm window, in a *BSD
-console with |sysmouse|, in a Linux console (with GPM |gpm-mouse|), for
-MS-DOS and in a Windows console.
+console with |sysmouse|, in a Linux console (with GPM |gpm-mouse|), and
+in a Windows console.
 Mouse clicks can be used to position the cursor, select an area and paste.
 
 These characters in the 'mouse' option tell in which situations the mouse will
@@ -881,10 +882,9 @@ border, the text is scrolled.
 A selection can be started by pressing the left mouse button on the first
 character, moving the mouse to the last character, then releasing the mouse
 button.  You will not always see the selection until you release the button,
-only in some versions (GUI, MS-DOS, WIN32) will the dragging be shown
-immediately.  Note that you can make the text scroll by moving the mouse at
-least one character in the first/last line in the window when 'scrolloff' is
-non-zero.
+only in some versions (GUI, Win32) will the dragging be shown immediately.
+Note that you can make the text scroll by moving the mouse at least one
+character in the first/last line in the window when 'scrolloff' is non-zero.
 
 In Normal, Visual and Select mode clicking the right mouse button causes the
 Visual area to be extended.  When 'mousemodel' is "popup", the left button has
@@ -898,9 +898,9 @@ work on systems where the window manager consumes the mouse events when the
 alt key is pressed (it may move the window).
 
 							*double-click*
-Double, triple and quadruple clicks are supported when the GUI is active,
-for MS-DOS and Win32, and for an xterm (if the gettimeofday() function is
-available).  For selecting text, extra clicks extend the selection:
+Double, triple and quadruple clicks are supported when the GUI is active, for
+Win32, and for an xterm (if the gettimeofday() function is available).  For
+selecting text, extra clicks extend the selection:
 	click		select ~
 	double		word or % match		*<2-LeftMouse>*
 	triple		line			*<3-LeftMouse>*
@@ -911,9 +911,8 @@ A double click on a word selects that word.  'iskeyword' is used to specify
 which characters are included in a word.  A double click on a character
 that has a match selects until that match (like using "v%").  If the match is
 an #if/#else/#endif block, the selection becomes linewise.
-For MS-DOS and xterm the time for double clicking can be set with the
-'mousetime' option.  For the other systems this time is defined outside of
-Vim.
+For xterm the time for double clicking can be set with the 'mousetime' option.
+For the other systems this time is defined outside of Vim.
 An example, for using a double click to jump to the tag under the cursor: >
 	:map <2-LeftMouse> :exe "tag ". expand("<cword>")<CR>
 

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -30,7 +30,7 @@ To start Vim, enter this command: >
 	gvim file.txt
 
 In UNIX you can type this at any command prompt.  If you are running Microsoft
-Windows, open an MS-DOS prompt window and enter the command.
+Windows, open a Command Prompt and enter the command.
    In either case, Vim starts editing a file called file.txt.  Because this
 is a new file, you get a blank window. This is what your screen will look
 like:
@@ -61,10 +61,9 @@ use this command: >
 
 the editing occurs inside your command window.  In other words, if you are
 running inside an xterm, the editor uses your xterm window.  If you are using
-an MS-DOS command prompt window under Microsoft Windows, the editing occurs
-inside this window.  The text in the window will look the same for both
-versions, but with gvim you have extra features, like a menu bar.  More about
-that later.
+an MS-Windows command prompt window, the editing occurs inside this window.
+The text in the window will look the same for both versions, but with gvim you
+have extra features, like a menu bar.  More about that later.
 
 ==============================================================================
 *02.2*	Inserting text

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -476,7 +476,6 @@ Then copy the file to your plugin directory:
 	Amiga		s:vimfiles/plugin
 	Macintosh	$VIM:vimfiles:plugin
 	Mac OS X	~/.vim/plugin/
-	RISC-OS		Choices:vimfiles.plugin
 
 Example for Unix (assuming you didn't have a plugin directory yet): >
 

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -44,7 +44,7 @@ For Unix and Macintosh this file is always used and is recommended:
 
 	~/.vimrc ~
 
-For MS-DOS and MS-Windows you can use one of these:
+For MS-Windows you can use one of these:
 
 	$HOME/_vimrc ~
 	$VIM/_vimrc ~
@@ -535,9 +535,9 @@ The underscore is used to separate the name of the filetype from the rest,
 which can be anything.  If you use "otherstuff.vim" it wouldn't work, it would
 be loaded for the "otherstuff" filetype.
 
-On MS-DOS you cannot use long filenames.  You would run into trouble if you
-add a second plugin and the filetype has more than six characters.  You can
-use an extra directory to get around this: >
+On MS-DOS like filesystems you cannot use long filenames.  You would run into
+trouble if you add a second plugin and the filetype has more than six
+characters.  You can use an extra directory to get around this: >
 
 	mkdir $VIM/vimfiles/ftplugin/fortran
 	copy thefile $VIM/vimfiles/ftplugin/fortran/too.vim
@@ -586,7 +586,7 @@ the "mkdir" commands if you already have the directory.) >
 	:!mkdir ~/.vim/plugin
 	:!cp /tmp/doit.vim ~/.vim/plugin
 
-The "cp" command is for Unix, on MS-DOS you can use "copy".
+The "cp" command is for Unix, on MS-Windows you can use "copy".
 
 Now create a "doc" directory in one of the directories in 'runtimepath'. >
 

--- a/runtime/doc/usr_23.txt
+++ b/runtime/doc/usr_23.txt
@@ -29,8 +29,8 @@ start a new line.  One to move the carriage back to the first position
    When computers came out, storage was expensive.  Some people decided that
 they did not need two characters for end-of-line.  The UNIX people decided
 they could use <Line Feed> only for end-of-line.  The Apple people
-standardized on <CR>.  The MS-DOS (and Microsoft Windows) folks decided to
-keep the old <CR><LF>.
+standardized on <CR>.  The Microsoft Windows folks decided to keep
+the old <CR><LF>.
    This means that if you try to move a file from one system to another, you
 have line-break problems.  The Vim editor automatically recognizes the
 different file formats and handles things properly behind your back.

--- a/runtime/doc/usr_24.txt
+++ b/runtime/doc/usr_24.txt
@@ -564,8 +564,8 @@ that combination.  Thus CTRL-K dP also works.  Since there is no digraph for
 
 	Note:
 	The digraphs depend on the character set that Vim assumes you are
-	using.  On MS-DOS they are different from MS-Windows.  Always use
-	":digraphs" to find out which digraphs are currently available.
+	using.  Always use ":digraphs" to find out which digraphs are currently
+	available.
 
 You can define your own digraphs.  Example: >
 

--- a/runtime/doc/usr_27.txt
+++ b/runtime/doc/usr_27.txt
@@ -83,7 +83,7 @@ matter if 'ignorecase' or 'smartcase' was changed.
 
 	Note:
 	If your search takes much longer than you expected, you can interrupt
-	it with CTRL-C on Unix and  CTRL-Break on MS-DOS and MS-Windows.
+	it with CTRL-C on Unix and CTRL-Break on MS-Windows.
 
 ==============================================================================
 *27.2*	Wrapping around the file end

--- a/runtime/doc/usr_90.txt
+++ b/runtime/doc/usr_90.txt
@@ -248,10 +248,6 @@ available:
 	vim61w32.zip		32 bit MS-Windows console version.  For use in
 				a Win NT/2000/XP console.  Does not work well
 				on Win 95/98.
-	vim61d32.zip		32 bit MS-DOS version.  For use in the
-				Win 95/98 console window.
-	vim61d16.zip		16 bit MS-DOS version.  Only for old systems.
-				Does not support long filenames.
 
 You only need one of them.  Although you could install both a GUI and a
 console version.  You always need to get the archive with runtime files.

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -702,8 +702,8 @@ K			Run a program to lookup the keyword under the
 			     :5sleep	     "sleep for five seconds
 			     :sleep 100m     "sleep for a hundred milliseconds
 			     10gs	     "sleep for ten seconds
-<			Can be interrupted with CTRL-C (CTRL-Break on MS-DOS).
-			"gs" stands for "goto sleep".
+<			Can be interrupted with CTRL-C (CTRL-Break on
+			MS-Windows).  "gs" stands for "goto sleep".
 			While sleeping the cursor is positioned in the text,
 			if at a visible position.
 			Also process the received netbeans messages. {only

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -133,7 +133,10 @@ Support for different systems.
 	- All Unix systems (it works on all systems it was tested on, although
 	  the GUI and Perl interface may not work everywhere).
 	- Amiga (500, 1000, 1200, 2000, 3000, 4000, ...).
-	- Windows NT, with support for long file names.
+	- MS-DOS in real-mode (no additional drivers required).
+	- In protected mode on Windows 3.1 and MS-DOS (DPMI driver required).
+	- Windows 95 and Windows NT, with support for long file names.
+	- OS/2 (needs emx.dll)
 	- VMS
 	- BeOS
 	- Macintosh

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -74,9 +74,7 @@ Vim has only a few limits for the files that can be edited {Vi: can not handle
 <Nul> characters and characters above 128, has limited line length, many other
 limits}.
 							*E340*
-Maximum line length	   On machines with 16-bit ints (Amiga and MS-DOS real
-			   mode): 32767, otherwise 2147483647 characters.
-			   Longer lines are split.
+Maximum line length	   2147483647 characters.  Longer lines are split.
 Maximum number of lines	   2147483647 lines.
 Maximum file size	   2147483647 bytes (2 Gbyte) when a long integer is
 			   32 bits.  Much more for 64 bit longs.  Also limited
@@ -106,8 +104,7 @@ Memory usage limits
 The option 'maxmem' ('mm') is used to set the maximum memory used for one
 buffer (in kilobytes).  'maxmemtot' is used to set the maximum memory used for
 all buffers (in kilobytes).  The defaults depend on the system used.  For the
-Amiga and MS-DOS, 'maxmemtot' is set depending on the amount of memory
-available.
+Amiga, 'maxmemtot' is set depending on the amount of memory available.
 These are not hard limits, but tell Vim when to move text into a swap file.
 If you don't like Vim to swap to a file, set 'maxmem' and 'maxmemtot' to a
 very large value.  The swap file will then only be used for recovery.  If you
@@ -143,8 +140,8 @@ Support for different systems.
 	- Risc OS
 	- IBM OS/390
 	Note that on some systems features need to be disabled to reduce
-	resource usage, esp. on MS-DOS.  For some outdated systems you need to
-	use an older Vim version.
+	resource usage.  For some outdated systems you need to use an older
+	Vim version.
 
 Multi level persistent undo.					|undo|
 	'u' goes backward in time, 'CTRL-R' goes forward again.  Set option
@@ -456,9 +453,8 @@ Printing.						|printing|
 
 Mouse support.						|mouse-using|
 	The mouse is supported in the GUI version, in an xterm for Unix, for
-	BSDs with sysmouse, for Linux with gpm, for MS-DOS, and Win32.  It
-	can be used to position the cursor, select the visual area, paste a
-	register, etc.
+	BSDs with sysmouse, for Linux with gpm, and Win32.  It can be used to
+	position the cursor, select the visual area, paste a register, etc.
 
 Usage of key names.					|<>| |key-notation|
 	Special keys now all have a name like <Up>, <End>, etc.
@@ -778,8 +774,8 @@ If the 'insertmode' option is set (e.g. in .exrc), Vim starts in insert mode.
 And it comes back there, when pressing <Esc>.
 
 Undo information is kept in memory.  Available memory limits the number and
-size of change that can be undone.  This may be a problem with MS-DOS, is
-hardly a problem on the Amiga and almost never with Unix and Win32.
+size of change that can be undone.  This is hardly a problem on the Amiga and
+almost never with Unix and Win32.
 
 If the 'backup' or 'writebackup' option is set: Before a file is overwritten,
 a backup file (.bak) is made.  If the "backup" option is set it is left


### PR DESCRIPTION
Patch 7.4.1399 removed the support for MS-DOS and patch 7.3.187 removed the support
for RISC-OS. Update the help files to remove references to MS-DOS and RISC-OS.