### PR TITLE
Clear viminfo filemarks

### DIFF
--- a/src/mark.c
+++ b/src/mark.c
@@ -854,6 +854,7 @@ ex_delmarks(exarg_T *eap)
 			else
 			    n = i - 'A';
 			namedfm[n].fmark.mark.lnum = 0;
+			namedfm[n].fmark.fnum = 0;
 			VIM_CLEAR(namedfm[n].fname);
 #ifdef FEAT_VIMINFO
 			namedfm[n].time_set = 0;

--- a/src/mark.c
+++ b/src/mark.c
@@ -857,7 +857,7 @@ ex_delmarks(exarg_T *eap)
 			namedfm[n].fmark.fnum = 0;
 			VIM_CLEAR(namedfm[n].fname);
 #ifdef FEAT_VIMINFO
-			namedfm[n].time_set = 0;
+			namedfm[n].time_set = digit ? 0 : vim_time();
 #endif
 		    }
 		}

--- a/src/testdir/test_marks.vim
+++ b/src/testdir/test_marks.vim
@@ -144,6 +144,11 @@ func Test_delmarks()
   " Deleting an already deleted mark should not fail.
   delmarks x
 
+  " getpos() should return all zeros after deleting a filemark.
+  norm mA
+  delmarks A
+  call assert_equal([0, 0, 0, 0], getpos("'A"))
+
   " Test deleting a range of marks.
   norm ma
   norm mb

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -323,6 +323,23 @@ func Test_viminfo_marks()
   call assert_equal([bufb, 22, 1, 0], getpos("'3")) " time 30
   call assert_equal([bufb, 12, 1, 0], getpos("'4")) " time 25
 
+  " deleted file marks are removed from viminfo
+  delmark C
+  wviminfo Xviminfo
+  rviminfo Xviminfo
+  call assert_equal([0, 0, 0, 0], getpos("'C"))
+
+  " deleted file marks stay in viminfo if defined in another vim later
+  call test_settime(70)
+  call setpos("'D", [bufb, 8, 1, 0])
+  wviminfo Xviminfo
+  call test_settime(65)
+  delmark D
+  call assert_equal([0, 0, 0, 0], getpos("'D"))
+  call test_settime(75)
+  rviminfo Xviminfo
+  call assert_equal([bufb, 8, 1, 0], getpos("'D"))
+
   call delete('Xviminfo')
   exe 'bwipe ' . bufa
   exe 'bwipe ' . bufb

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -2055,8 +2055,7 @@ write_viminfo_filemarks(FILE *fp)
     for (i = 0; i < NMARKS; i++)
     {
 	if (vi_namedfm != NULL
-			&& (vi_namedfm[i].time_set > namedfm_p[i].time_set
-			    || namedfm_p[i].fmark.mark.lnum == 0))
+			&& (vi_namedfm[i].time_set > namedfm_p[i].time_set))
 	    fm = &vi_namedfm[i];
 	else
 	    fm = &namedfm_p[i];


### PR DESCRIPTION
Support deletion of A-Z file marks in viminfo, while preserving such marks from a parallel vim session.
Also fix bug in getpos return, which has nonzero buffer index for a deleted file mark.

Resolves https://github.com/vim/vim/issues/1339.