### PR TITLE
Test more-prompt to improve test coverage

### DIFF
--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -1,6 +1,7 @@
 " Tests for :messages, :echomsg, :echoerr
 
 source shared.vim
+source term_util.vim
 
 function Test_messages()
   let oldmore = &more
@@ -171,4 +172,103 @@ func Test_echospace()
   call assert_equal(&columns - 29, v:echospace)
 
   set ruler& showcmd&
+endfunc
+
+" Test more-prompt (see :help more-prompt).
+func Test_message_more()
+  if !CanRunVimInTerminal()
+    throw 'Skipped: cannot run vim in terminal'
+  endif
+  let buf = RunVimInTerminal('', {'rows': 6})
+  call term_sendkeys(buf, ":call setline(1, range(1, 100))\n")
+
+  call term_sendkeys(buf, ":%p#\n")
+  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+
+  call term_sendkeys(buf, '?')
+  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More -- SPACE/d/j: screen/page/line down, b/u/k: up, q: quit ', term_getline(buf, 6))})
+
+  " Down a line with j, <CR>, <NL> or <Down>.
+  call term_sendkeys(buf, "j")
+  call WaitForAssert({-> assert_equal('  6 6', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+  call term_sendkeys(buf, "\<NL>")
+  call WaitForAssert({-> assert_equal('  7 7', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<CR>")
+  call WaitForAssert({-> assert_equal('  8 8', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<Down>")
+  call WaitForAssert({-> assert_equal('  9 9', term_getline(buf, 5))})
+
+  " Down a screen with <Space>, f, or <PageDown>.
+  call term_sendkeys(buf, 'f')
+  call WaitForAssert({-> assert_equal(' 14 14', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+  call term_sendkeys(buf, ' ')
+  call WaitForAssert({-> assert_equal(' 19 19', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<PageDown>")
+  call WaitForAssert({-> assert_equal(' 24 24', term_getline(buf, 5))})
+
+  " Down a page (half a screen) with d.
+  call term_sendkeys(buf, 'd')
+  call WaitForAssert({-> assert_equal(' 27 27', term_getline(buf, 5))})
+
+  " Down all the way with 'G'.
+  call term_sendkeys(buf, 'G')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+
+  " Up a line k, <BS> or <Up>.
+  call term_sendkeys(buf, 'k')
+  call WaitForAssert({-> assert_equal(' 99 99', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<BS>")
+  call WaitForAssert({-> assert_equal(' 98 98', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<Up>")
+  call WaitForAssert({-> assert_equal(' 97 97', term_getline(buf, 5))})
+
+  " Up a screen with b or <PageUp>.
+  call term_sendkeys(buf, 'b')
+  call WaitForAssert({-> assert_equal(' 92 92', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<PageUp>")
+  call WaitForAssert({-> assert_equal(' 87 87', term_getline(buf, 5))})
+
+  " Up a page (half a screen) with u.
+  call term_sendkeys(buf, 'u')
+  call WaitForAssert({-> assert_equal(' 84 84', term_getline(buf, 5))})
+
+  " Up all the way with 'g'.
+  call term_sendkeys(buf, 'g')
+  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+
+  " All the way down. Pressing f should do nothing but pressing
+  " space should end the more prompt.
+  call term_sendkeys(buf, 'G')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+  call term_sendkeys(buf, 'f')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call term_sendkeys(buf, ' ')
+  call WaitForAssert({-> assert_equal('100', term_getline(buf, 5))})
+
+  " Pressing g< shows the previous command output.
+  call term_sendkeys(buf, 'g<')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+
+  " Enter Ex command line with :
+  call term_sendkeys(buf, ':foo')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal(':foo', term_getline(buf, 6))})
+  call term_sendkeys(buf, "\<Esc>g<")
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+
+  " Stop command output with q, <Esc> or CTRL-C.
+  call term_sendkeys(buf, 'q')
+  call WaitForAssert({-> assert_equal('100', term_getline(buf, 5))})
+
+  call term_sendkeys(buf, ':q!')
+  call StopVimInTerminal(buf)
 endfunc

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -257,13 +257,9 @@ func Test_message_more()
   call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
   call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
 
-  " Enter Ex command line with :
-  call term_sendkeys(buf, ':foo')
-  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
-  call WaitForAssert({-> assert_equal(':foo', term_getline(buf, 6))})
-  call term_sendkeys(buf, "\<Esc>g<")
-  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
-  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+  call term_sendkeys(buf, ":%p#\n")
+  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
 
   " Stop command output with q, <Esc> or CTRL-C.
   call term_sendkeys(buf, 'q')


### PR DESCRIPTION
This PR adds a test to cover function `do_more_prompt()` in
`message.c`, which was not covered with tests according to codecov.
It's quite a big function:

https://codecov.io/gh/vim/vim/src/8cd6cd8087ccf08e4303dbf5f732fc4b82b917e1/src/message.c#L2690
