### PR TITLE
Added command line completion for :diffget and :diffput

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5058,6 +5058,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		command		Ex command (and arguments)
 		compiler	compilers
 		cscope		|:cscope| suboptions
+		diff_buffer     |:diffget| and |:diffput| completion
 		dir		directory names
 		environment	environment variable names
 		event		autocommand events

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2702,12 +2702,14 @@ ExpandBufnames(
 	    {
 		if (!buf->b_p_bl)	// skip unlisted buffers
 		    continue;
+#ifdef FEAT_DIFF
 		if (options & BUF_DIFF_FILTER)
 		    // Skip buffers not suitable for
 		    // :diffget or :diffput completion.
 		    if (buf == curbuf
 			    || !diff_mode_buf(curbuf) || !diff_mode_buf(buf))
 			continue;
+#endif
 
 		p = buflist_match(&regmatch, buf, p_wic);
 		if (p != NULL)

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2702,6 +2702,13 @@ ExpandBufnames(
 	    {
 		if (!buf->b_p_bl)	// skip unlisted buffers
 		    continue;
+		if (options & BUF_DIFF_FILTER)
+		    // Skip buffers not suitable for
+		    // :diffget or :diffput completion.
+		    if (buf == curbuf
+			    || !diff_mode_buf(curbuf) || !diff_mode_buf(buf))
+			continue;
+
 		p = buflist_match(&regmatch, buf, p_wic);
 		if (p != NULL)
 		{

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1582,7 +1582,13 @@ set_one_cmd_context(
 	    xp->xp_context = EXPAND_BUFFERS;
 	    xp->xp_pattern = arg;
 	    break;
-
+	case CMD_diffget:
+	case CMD_diffput:
+	    // If current buffer is in diff mode, complete buffer names
+	    // which are in diff mode, and different than current buffer.
+	    xp->xp_context = EXPAND_DIFF_BUFFERS;
+	    xp->xp_pattern = arg;
+	    break;
 	case CMD_USER:
 	case CMD_USER_BUF:
 	    if (compl != EXPAND_NOTHING)
@@ -2069,6 +2075,8 @@ ExpandFromContext(
 	return ExpandOldSetting(num_file, file);
     if (xp->xp_context == EXPAND_BUFFERS)
 	return ExpandBufnames(pat, num_file, file, options);
+    if (xp->xp_context == EXPAND_DIFF_BUFFERS)
+	return ExpandBufnames(pat, num_file, file, options | BUF_DIFF_FILTER);
     if (xp->xp_context == EXPAND_TAGS
 	    || xp->xp_context == EXPAND_TAGS_LISTFILES)
 	return expand_tags(xp->xp_context == EXPAND_TAGS, pat, num_file, file);

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1582,6 +1582,7 @@ set_one_cmd_context(
 	    xp->xp_context = EXPAND_BUFFERS;
 	    xp->xp_pattern = arg;
 	    break;
+#ifdef FEAT_DIFF
 	case CMD_diffget:
 	case CMD_diffput:
 	    // If current buffer is in diff mode, complete buffer names
@@ -1589,6 +1590,7 @@ set_one_cmd_context(
 	    xp->xp_context = EXPAND_DIFF_BUFFERS;
 	    xp->xp_pattern = arg;
 	    break;
+#endif
 	case CMD_USER:
 	case CMD_USER_BUF:
 	    if (compl != EXPAND_NOTHING)
@@ -2075,8 +2077,10 @@ ExpandFromContext(
 	return ExpandOldSetting(num_file, file);
     if (xp->xp_context == EXPAND_BUFFERS)
 	return ExpandBufnames(pat, num_file, file, options);
+#ifdef FEAT_DIFF
     if (xp->xp_context == EXPAND_DIFF_BUFFERS)
 	return ExpandBufnames(pat, num_file, file, options | BUF_DIFF_FILTER);
+#endif
     if (xp->xp_context == EXPAND_TAGS
 	    || xp->xp_context == EXPAND_TAGS_LISTFILES)
 	return expand_tags(xp->xp_context == EXPAND_TAGS, pat, num_file, file);

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -242,6 +242,46 @@ func Test_diffput_two()
   bwipe! b
 endfunc
 
+func Test_diffget_diffput_completion()
+  new Xdiff1 | diffthis
+  new Xdiff2 | diffthis
+  new Xdiff3 | diffthis
+  new Xdiff4
+
+  " :diffput and :diffget completes names of buffers which
+  " are in diff mode and which are different then current buffer.
+  b Xdiff1
+  call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffput Xdiff2 Xdiff3', @:)
+  call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffget Xdiff2 Xdiff3', @:)
+  call assert_equal(['Xdiff2', 'Xdiff3'], getcompletion('', 'diff_buffer'))
+
+  b Xdiff2
+  call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffput Xdiff1 Xdiff3', @:)
+  call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffget Xdiff1 Xdiff3', @:)
+  call assert_equal(['Xdiff1', 'Xdiff3'], getcompletion('', 'diff_buffer'))
+
+  b Xdiff3
+  call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffput Xdiff1 Xdiff2', @:)
+  call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffget Xdiff1 Xdiff2', @:)
+  call assert_equal(['Xdiff1', 'Xdiff2'], getcompletion('', 'diff_buffer'))
+
+  " No completion when in Xdiff4, it's not in diff mode.
+  b Xdiff4
+  call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffput ', @:)
+  call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffget ', @:)
+  call assert_equal([], getcompletion('', 'diff_buffer'))
+
+  %bwipe
+endfunc
+
 func Test_dp_do_buffer()
   e! one
   let bn1=bufnr('%')

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -57,6 +57,7 @@ static struct
     {EXPAND_USER_DEFINED, "custom"},
     {EXPAND_USER_LIST, "customlist"},
 #endif
+    {EXPAND_DIFF_BUFFERS, "diff_buffer"},
     {EXPAND_DIRECTORIES, "dir"},
     {EXPAND_ENV_VARS, "environment"},
     {EXPAND_EVENTS, "event"},

--- a/src/vim.h
+++ b/src/vim.h
@@ -801,6 +801,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define EXPAND_MESSAGES		46
 #define EXPAND_MAPCLEAR		47
 #define EXPAND_ARGLIST		48
+#define EXPAND_DIFF_BUFFERS	49
 
 // Values for exmode_active (0 is no exmode)
 #define EXMODE_NORMAL		1
@@ -829,6 +830,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define WILD_IGNORE_COMPLETESLASH   0x400
 #define WILD_NOERROR		    0x800  // sets EW_NOERROR
 #define WILD_BUFLASTUSED	    0x1000
+#define BUF_DIFF_FILTER		    0x2000
 
 // Flags for expand_wildcards()
 #define EW_DIR		0x01	// include directory names


### PR DESCRIPTION
`:diffget` and `:diffput` now complete file names which are in
diff mode and which are different than the current buffer.
No completion when current buffer is not in diff mode.