### PR TITLE
Problem: Function call error code names are too generic.

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -976,14 +976,14 @@ call_internal_func(
 
     i = find_internal_func(name);
     if (i < 0)
-	return ERROR_UNKNOWN;
+	return FNC_ERROR_UNKNOWN;
     if (argcount < global_functions[i].f_min_argc)
-	return ERROR_TOOFEW;
+	return FNC_ERROR_TOOFEW;
     if (argcount > global_functions[i].f_max_argc)
-	return ERROR_TOOMANY;
+	return FNC_ERROR_TOOMANY;
     argvars[argcount].v_type = VAR_UNKNOWN;
     global_functions[i].f_func(argvars, rettv);
-    return ERROR_NONE;
+    return FNC_ERROR_NONE;
 }
 
 /*
@@ -1003,13 +1003,13 @@ call_internal_method(
 
     fi = find_internal_func(name);
     if (fi < 0)
-	return ERROR_UNKNOWN;
+	return FNC_ERROR_UNKNOWN;
     if (global_functions[fi].f_argtype == 0)
-	return ERROR_NOTMETHOD;
+	return FNC_ERROR_NOTMETHOD;
     if (argcount + 1 < global_functions[fi].f_min_argc)
-	return ERROR_TOOFEW;
+	return FNC_ERROR_TOOFEW;
     if (argcount + 1 > global_functions[fi].f_max_argc)
-	return ERROR_TOOMANY;
+	return FNC_ERROR_TOOMANY;
 
     if (global_functions[fi].f_argtype == FEARG_LAST)
     {
@@ -1055,7 +1055,7 @@ call_internal_method(
     argv[argcount + 1].v_type = VAR_UNKNOWN;
 
     global_functions[fi].f_func(argv, rettv);
-    return ERROR_NONE;
+    return FNC_ERROR_NONE;
 }
 
 /*

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -533,7 +533,7 @@ fname_trans_sid(char_u *name, char_u *fname_buf, char_u **tofree, int *error)
 	if (eval_fname_sid(name))	// "<SID>" or "s:"
 	{
 	    if (current_sctx.sc_sid <= 0)
-		*error = ERROR_SCRIPT;
+		*error = FNC_ERROR_SCRIPT;
 	    else
 	    {
 		sprintf((char *)fname_buf + 3, "%ld_",
@@ -550,7 +550,7 @@ fname_trans_sid(char_u *name, char_u *fname_buf, char_u **tofree, int *error)
 	{
 	    fname = alloc(i + STRLEN(name + llen) + 1);
 	    if (fname == NULL)
-		*error = ERROR_OTHER;
+		*error = FNC_ERROR_OTHER;
 	    else
 	    {
 		*tofree = fname;
@@ -1490,7 +1490,7 @@ call_func(
     funcexe_T	*funcexe)	// more arguments
 {
     int		ret = FAIL;
-    int		error = ERROR_NONE;
+    int		error = FNC_ERROR_NONE;
     int		i;
     ufunc_T	*fp;
     char_u	fname_buf[FLEN_FIXED + 1];
@@ -1528,13 +1528,13 @@ call_func(
 	// When the dict was bound explicitly use the one from the partial.
 	if (partial->pt_dict != NULL && (selfdict == NULL || !partial->pt_auto))
 	    selfdict = partial->pt_dict;
-	if (error == ERROR_NONE && partial->pt_argc > 0)
+	if (error == FNC_ERROR_NONE && partial->pt_argc > 0)
 	{
 	    for (argv_clear = 0; argv_clear < partial->pt_argc; ++argv_clear)
 	    {
 		if (argv_clear + argcount_in >= MAX_FUNC_ARGS)
 		{
-		    error = ERROR_TOOMANY;
+		    error = FNC_ERROR_TOOMANY;
 		    goto theend;
 		}
 		copy_tv(&partial->pt_argv[argv_clear], &argv[argv_clear]);
@@ -1546,7 +1546,7 @@ call_func(
 	}
     }
 
-    if (error == ERROR_NONE && funcexe->evaluate)
+    if (error == FNC_ERROR_NONE && funcexe->evaluate)
     {
 	char_u *rfname = fname;
 
@@ -1556,7 +1556,7 @@ call_func(
 
 	rettv->v_type = VAR_NUMBER;	// default rettv is number zero
 	rettv->vval.v_number = 0;
-	error = ERROR_UNKNOWN;
+	error = FNC_ERROR_UNKNOWN;
 
 	if (!builtin_function(rfname, -1))
 	{
@@ -1585,7 +1585,7 @@ call_func(
 	    }
 
 	    if (fp != NULL && (fp->uf_flags & FC_DELETED))
-		error = ERROR_DELETED;
+		error = FNC_ERROR_DELETED;
 	    else if (fp != NULL)
 	    {
 		if (funcexe->argv_func != NULL)
@@ -1606,11 +1606,11 @@ call_func(
 		if (fp->uf_flags & FC_RANGE && funcexe->doesrange != NULL)
 		    *funcexe->doesrange = TRUE;
 		if (argcount < fp->uf_args.ga_len - fp->uf_def_args.ga_len)
-		    error = ERROR_TOOFEW;
+		    error = FNC_ERROR_TOOFEW;
 		else if (!fp->uf_varargs && argcount > fp->uf_args.ga_len)
-		    error = ERROR_TOOMANY;
+		    error = FNC_ERROR_TOOMANY;
 		else if ((fp->uf_flags & FC_DICT) && selfdict == NULL)
-		    error = ERROR_DICT;
+		    error = FNC_ERROR_DICT;
 		else
 		{
 		    int did_save_redo = FALSE;
@@ -1638,7 +1638,7 @@ call_func(
 		    if (did_save_redo)
 			restoreRedobuff(&save_redo);
 		    restore_search_patterns();
-		    error = ERROR_NONE;
+		    error = FNC_ERROR_NONE;
 		}
 	    }
 	}
@@ -1670,7 +1670,7 @@ call_func(
 	 */
 	update_force_abort();
     }
-    if (error == ERROR_NONE)
+    if (error == FNC_ERROR_NONE)
 	ret = OK;
 
 theend:
@@ -1682,31 +1682,31 @@ theend:
     {
 	switch (error)
 	{
-	    case ERROR_UNKNOWN:
+	    case FNC_ERROR_UNKNOWN:
 		    emsg_funcname(N_("E117: Unknown function: %s"), name);
 		    break;
-	    case ERROR_NOTMETHOD:
+	    case FNC_ERROR_NOTMETHOD:
 		    emsg_funcname(
 			       N_("E276: Cannot use function as a method: %s"),
 									 name);
 		    break;
-	    case ERROR_DELETED:
+	    case FNC_ERROR_DELETED:
 		    emsg_funcname(N_("E933: Function was deleted: %s"), name);
 		    break;
-	    case ERROR_TOOMANY:
+	    case FNC_ERROR_TOOMANY:
 		    emsg_funcname((char *)e_toomanyarg, name);
 		    break;
-	    case ERROR_TOOFEW:
+	    case FNC_ERROR_TOOFEW:
 		    emsg_funcname(
 			     N_("E119: Not enough arguments for function: %s"),
 									name);
 		    break;
-	    case ERROR_SCRIPT:
+	    case FNC_ERROR_SCRIPT:
 		    emsg_funcname(
 			   N_("E120: Using <SID> not in a script context: %s"),
 									name);
 		    break;
-	    case ERROR_DICT:
+	    case FNC_ERROR_DICT:
 		    emsg_funcname(
 		      N_("E725: Calling dict function without Dictionary: %s"),
 									name);
@@ -3858,7 +3858,7 @@ set_ref_in_func(char_u *name, ufunc_T *fp_in, int copyID)
 {
     ufunc_T	*fp = fp_in;
     funccall_T	*fc;
-    int		error = ERROR_NONE;
+    int		error = FNC_ERROR_NONE;
     char_u	fname_buf[FLEN_FIXED + 1];
     char_u	*tofree = NULL;
     char_u	*fname;

--- a/src/vim.h
+++ b/src/vim.h
@@ -2551,15 +2551,15 @@ typedef enum {
 				// be freed.
 
 // errors for when calling a function
-#define ERROR_UNKNOWN	0
-#define ERROR_TOOMANY	1
-#define ERROR_TOOFEW	2
-#define ERROR_SCRIPT	3
-#define ERROR_DICT	4
-#define ERROR_NONE	5
-#define ERROR_OTHER	6
-#define ERROR_DELETED	7
-#define ERROR_NOTMETHOD	8   // function cannot be used as a method
+#define FNC_ERROR_UNKNOWN	0
+#define FNC_ERROR_TOOMANY	1
+#define FNC_ERROR_TOOFEW	2
+#define FNC_ERROR_SCRIPT	3
+#define FNC_ERROR_DICT	4
+#define FNC_ERROR_NONE	5
+#define FNC_ERROR_OTHER	6
+#define FNC_ERROR_DELETED	7
+#define FNC_ERROR_NOTMETHOD	8   // function cannot be used as a method
 
 // flags for find_name_end()
 #define FNE_INCL_BR	1	// include [] in name


### PR DESCRIPTION
Solution: Add prefix to error code names.

ERROR_UNKNOWN causes a name clash on AROS and MorphOS. My guess is that ERROR_NONE and ERROR_OTHER are strong clashing candidates as well.