### PR TITLE
Don't complete :diffput :diffget when the current window is not in di…

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2661,6 +2661,11 @@ ExpandBufnames(
     *num_file = 0;		    // return values in case of FAIL
     *file = NULL;
 
+#ifdef FEAT_DIFF
+    if ((options & BUF_DIFF_FILTER) && !curwin->w_p_diff)
+	return FAIL;
+#endif
+
     // Make a copy of "pat" and change "^" to "\(^\|[\/]\)".
     if (*pat == '^')
     {
@@ -2706,8 +2711,7 @@ ExpandBufnames(
 		if (options & BUF_DIFF_FILTER)
 		    // Skip buffers not suitable for
 		    // :diffget or :diffput completion.
-		    if (buf == curbuf
-			    || !diff_mode_buf(curbuf) || !diff_mode_buf(buf))
+		    if (buf == curbuf || !diff_mode_buf(buf))
 			continue;
 #endif
 

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -242,42 +242,59 @@ func Test_diffput_two()
   bwipe! b
 endfunc
 
+" :diffput and :diffget completes names of buffers which
+" are in diff mode and which are different then current buffer.
+" No completion when the current window is not in diff mode.
 func Test_diffget_diffput_completion()
-  new Xdiff1 | diffthis
-  new Xdiff2 | diffthis
-  new Xdiff3 | diffthis
-  new Xdiff4
+  e            Xdiff1 | diffthis
+  botright new Xdiff2
+  botright new Xdiff3 | split | diffthis
+  botright new Xdiff4 | diffthis
 
-  " :diffput and :diffget completes names of buffers which
-  " are in diff mode and which are different then current buffer.
-  b Xdiff1
+  wincmd t
+  call assert_equal('Xdiff1', bufname('%'))
   call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"diffput Xdiff2 Xdiff3', @:)
+  call assert_equal('"diffput Xdiff3 Xdiff4', @:)
   call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"diffget Xdiff2 Xdiff3', @:)
-  call assert_equal(['Xdiff2', 'Xdiff3'], getcompletion('', 'diff_buffer'))
+  call assert_equal('"diffget Xdiff3 Xdiff4', @:)
+  call assert_equal(['Xdiff3', 'Xdiff4'], getcompletion('', 'diff_buffer'))
 
-  b Xdiff2
-  call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"diffput Xdiff1 Xdiff3', @:)
-  call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"diffget Xdiff1 Xdiff3', @:)
-  call assert_equal(['Xdiff1', 'Xdiff3'], getcompletion('', 'diff_buffer'))
-
-  b Xdiff3
-  call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"diffput Xdiff1 Xdiff2', @:)
-  call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"diffget Xdiff1 Xdiff2', @:)
-  call assert_equal(['Xdiff1', 'Xdiff2'], getcompletion('', 'diff_buffer'))
-
-  " No completion when in Xdiff4, it's not in diff mode.
-  b Xdiff4
+  " Xdiff2 is not in diff mode, so no completion for :diffput, :diffget
+  wincmd j
+  call assert_equal('Xdiff2', bufname('%'))
   call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"diffput ', @:)
   call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"diffget ', @:)
   call assert_equal([], getcompletion('', 'diff_buffer'))
+
+  " Xdiff3 is split in 2 windows, only the top one is in diff mode.
+  " So completion of :diffput :diffget only happens in the top window.
+  wincmd j
+  call assert_equal('Xdiff3', bufname('%'))
+  call assert_equal(1, &diff)
+  call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffput Xdiff1 Xdiff4', @:)
+  call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffget Xdiff1 Xdiff4', @:)
+  call assert_equal(['Xdiff1', 'Xdiff4'], getcompletion('', 'diff_buffer'))
+
+  wincmd j
+  call assert_equal('Xdiff3', bufname('%'))
+  call assert_equal(0, &diff)
+  call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffput ', @:)
+  call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffget ', @:)
+  call assert_equal([], getcompletion('', 'diff_buffer'))
+
+  wincmd j
+  call assert_equal('Xdiff4', bufname('%'))
+  call feedkeys(":diffput \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffput Xdiff1 Xdiff3', @:)
+  call feedkeys(":diffget \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"diffget Xdiff1 Xdiff3', @:)
+  call assert_equal(['Xdiff1', 'Xdiff3'], getcompletion('', 'diff_buffer'))
 
   %bwipe
 endfunc


### PR DESCRIPTION
Completion for `:diffput` and `:diffget` was recently added in 8.2.54.

In Vim-8.2.54, completion was not proposed when current **buffer** is not in diff mode.  With this PR, completion is instead not proposed when the current **window** is not in diff mode.

It matters when a buffer is split into multiple windows and only some of the windows are in diff mode.

`Test_diffget_diffput_completion` was updated to check with multiple buffers and one of the buffers split into 2 windows (with only one of 2 windows in diff mode).