### PR TITLE
prop_find implementation

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -620,6 +620,7 @@ static funcentry_T global_functions[] =
 #ifdef FEAT_PROP_POPUP
     {"prop_add",	3, 3, FEARG_1,	  f_prop_add},
     {"prop_clear",	1, 3, FEARG_1,	  f_prop_clear},
+    {"prop_find",   1, 2, FEARG_1,    f_prop_find},
     {"prop_list",	1, 2, FEARG_1,	  f_prop_list},
     {"prop_remove",	1, 3, FEARG_1,	  f_prop_remove},
     {"prop_type_add",	2, 2, FEARG_1,	  f_prop_type_add},

--- a/src/proto/textprop.pro
+++ b/src/proto/textprop.pro
@@ -6,6 +6,7 @@ int get_text_props(buf_T *buf, linenr_T lnum, char_u **props, int will_change);
 int find_visible_prop(win_T *wp, int type_id, int id, textprop_T *prop, linenr_T *found_lnum);
 proptype_T *text_prop_type_by_id(buf_T *buf, int id);
 void f_prop_clear(typval_T *argvars, typval_T *rettv);
+void f_prop_find(typval_T *argvars, typval_T *rettv);
 void f_prop_list(typval_T *argvars, typval_T *rettv);
 void f_prop_remove(typval_T *argvars, typval_T *rettv);
 void f_prop_type_add(typval_T *argvars, typval_T *rettv);

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -207,6 +207,10 @@ func Test_prop_find()
   let result = prop_find({'id': 11, 'lnum': 2, 'col': 3}, 'b')
   call assert_equal({}, result)
 
+  " When lnum is given and col is omitted, use column 1.
+  let result = prop_find({'type': 'prop_name', 'lnum': 1}, 'f')
+  call assert_equal(expected[0], result)
+
   call prop_clear(1,6)
   call prop_type_delete('prop_name')
 endfunc

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -103,6 +103,114 @@ func Get_expected_props()
       \ ]
 endfunc
 
+func Test_prop_find()
+  new
+  call setline(1, ['one one one', 'twotwo', 'three', 'fourfour', 'five', 'sixsix'])
+ 
+  " Add two text props on lines 1 and 5, and one spanning lines 2 to 4. 
+  call prop_type_add('prop_name', {'highlight': 'Directory'})
+  call prop_add(1, 5, {'type': 'prop_name', 'id': 10, 'length': 3})
+  call prop_add(2, 4, {'type': 'prop_name', 'id': 11, 'end_lnum': 4, 'end_col': 9})
+  call prop_add(5, 4, {'type': 'prop_name', 'id': 12, 'length': 1})
+
+  let expected = [
+    \ {'lnum': 1, 'col': 5, 'length': 3, 'id': 10, 'type': 'prop_name', 'start': 1, 'end': 1},
+    \ {'lnum': 2, 'col': 4, 'id': 11, 'type': 'prop_name', 'start': 1, 'end': 0},
+    \ {'lnum': 5, 'col': 4, 'length': 1, 'id': 12, 'type': 'prop_name', 'start': 1, 'end': 1}
+    \ ]
+
+  " Starting at line 5 col 1 this should find the prop at line 5 col 4.
+  call cursor(5,1)
+  let result = prop_find({'type': 'prop_name'}, 'f')
+  call assert_equal(expected[2], result)
+
+  " With skipstart left at false (default), this should find the prop at line
+  " 5 col 4.
+  let result = prop_find({'type': 'prop_name', 'lnum': 5, 'col': 4}, 'b')
+  call assert_equal(expected[2], result)
+
+  " With skipstart set to true, this should skip the prop at line 5 col 4.
+  let result = prop_find({'type': 'prop_name', 'lnum': 5, 'col': 4, 'skipstart': 1}, 'b')
+  unlet result.length
+  call assert_equal(expected[1], result)
+
+  " Search backwards from line 1 col 10 to find the prop on the same line.
+  let result = prop_find({'type': 'prop_name', 'lnum': 1, 'col': 10}, 'b')
+  call assert_equal(expected[0], result)
+
+  " with skipstart set to false, if the start position is anywhere between the
+  " start and end lines of a text prop (searching forward or backward), the
+  " result should be the prop on the first line (the line with 'start' set to 1).
+  call cursor(3,1)
+  let result = prop_find({'type': 'prop_name'}, 'f')
+  unlet result.length
+  call assert_equal(expected[1], result)
+  let result = prop_find({'type': 'prop_name'}, 'b')
+  unlet result.length
+  call assert_equal(expected[1], result)
+
+  " with skipstart set to true, if the start position is anywhere between the
+  " start and end lines of a text prop (searching forward or backward), all lines
+  " of the prop will be skipped.
+  let result = prop_find({'type': 'prop_name', 'skipstart': 1}, 'b')
+  call assert_equal(expected[0], result)
+  let result = prop_find({'type': 'prop_name', 'skipstart': 1}, 'f')
+  call assert_equal(expected[2], result)
+
+  " Use skipstart to search through all props with type name 'prop_name'.
+  " First forward...
+  let lnum = 1
+  let col = 1
+  let i = 0
+  for exp in expected
+    let result = prop_find({'type': 'prop_name', 'lnum': lnum, 'col': col, 'skipstart': 1}, 'f')
+    if !has_key(exp, "length")
+      unlet result.length
+    endif
+    call assert_equal(exp, result)
+    let lnum = result.lnum
+    let col = result.col
+    let i = i + 1
+  endfor
+
+  " ...then backwards.
+  let lnum = 6
+  let col = 4
+  let i = 2
+  while i >= 0
+    let result = prop_find({'type': 'prop_name', 'lnum': lnum, 'col': col, 'skipstart': 1}, 'b')
+    if !has_key(expected[i], "length")
+      unlet result.length
+    endif
+    call assert_equal(expected[i], result)
+    let lnum = result.lnum
+    let col = result.col
+    let i = i - 1
+  endwhile 
+
+  " Starting from line 6 col 1 search backwards for prop with id 10.
+  call cursor(6,1)
+  let result = prop_find({'id': 10, 'skipstart': 1}, 'b')
+  call assert_equal(expected[0], result)
+
+  " Starting from line 1 col 1 search forwards for prop with id 12.
+  call cursor(1,1)
+  let result = prop_find({'id': 12}, 'f')
+  call assert_equal(expected[2], result)
+
+  " Search for a prop with an unknown id.
+  let result = prop_find({'id': 999}, 'f')
+  call assert_equal({}, result)
+
+  " Search backwards from from the proceeding position of the prop with id 11
+  " (at line num 2 col 4). This should return an empty dict.
+  let result = prop_find({'id': 11, 'lnum': 2, 'col': 3}, 'b')
+  call assert_equal({}, result)
+
+  call prop_clear(1,6)
+  call prop_type_delete('prop_name')
+endfunc
+
 func Test_prop_add()
   new
   call AddPropTypes()

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -202,7 +202,7 @@ func Test_prop_find()
   let result = prop_find({'id': 999}, 'f')
   call assert_equal({}, result)
 
-  " Search backwards from from the proceeding position of the prop with id 11
+  " Search backwards from the proceeding position of the prop with id 11
   " (at line num 2 col 4). This should return an empty dict.
   let result = prop_find({'id': 11, 'lnum': 2, 'col': 3}, 'b')
   call assert_equal({}, result)

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -659,7 +659,6 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
                                 / sizeof(textprop_T));
         int	    i;
         textprop_T  prop;
-        proptype_T  *pt;
         int prop_start;
         int prop_end;
 

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -483,7 +483,7 @@ prop_fill_dict(dict_T *dict, textprop_T *prop, buf_T *buf)
     dict_add_number(dict, "end", !(prop->tp_flags & TP_FLAG_CONT_NEXT));
     pt = text_prop_type_by_id(buf, prop->tp_type);
     if (pt != NULL)
-    dict_add_string(dict, "type", pt->pt_name);
+	dict_add_string(dict, "type", pt->pt_name);
 }
 
 /*
@@ -560,6 +560,11 @@ f_prop_clear(typval_T *argvars, typval_T *rettv UNUSED)
     void
 f_prop_find(typval_T *argvars, typval_T *rettv)
 {
+    pos_T	*cursor = &curwin->w_cursor;
+    char_u	*dir_s;
+    dict_T	*dict;
+    buf_T	*buf = curbuf;
+    dictitem_T	*di;
     int		lnum_start;
     int		start_pos_has_prop = 0;
     int		seen_end = 0;
@@ -568,13 +573,8 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
     int		skipstart = 0;
     int		lnum = -1;
     int		col = -1;
-    pos_T	*cursor = &curwin->w_cursor;
-    char_u	*dir_s;
     int		dir = 1;    // 1 = forward, -1 = backward
-    dict_T	*dict;
-    dictitem_T	*di;
-    buf_T	*buf = curbuf;
-
+ 
     if (argvars[0].v_type != VAR_DICT || argvars[0].vval.v_dict == NULL)
     {
 	emsg(_(e_invarg));
@@ -653,14 +653,14 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
     
     while (1)
     {	
-        char_u	*text = ml_get_buf(buf, lnum, FALSE);
-        size_t	textlen = STRLEN(text) + 1;
-        int	count = (int)((buf->b_ml.ml_line_len - textlen)
+	char_u	*text = ml_get_buf(buf, lnum, FALSE);
+	size_t	textlen = STRLEN(text) + 1;
+	int	count = (int)((buf->b_ml.ml_line_len - textlen)
                                 / sizeof(textprop_T));
-        int i;
-        textprop_T prop;
-        int prop_start;
-        int prop_end;
+	int	    i;
+        textprop_T  prop;
+        int	    prop_start;
+        int	    prop_end;
 
         for (i = 0; i < count; ++i)
         {
@@ -737,7 +737,7 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
 	    if (lnum <= 1)
 		break;
 	    lnum--;
-        }
+	}
     } 
 }
 

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -705,7 +705,7 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
                 if (start_pos_has_prop && skipstart && !seen_end)
                 {
 		    start_pos_has_prop = 0;
-			break;
+		    break;
                 }
 
                 if (dir < 0)

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -568,9 +568,9 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
     int		skipstart = 0;
     int		lnum = -1;
     int		col = -1;
-    pos_T       *cursor = &curwin->w_cursor;
-    char_u      *dir_s;
-    int         dir = 1;    // 1 = forward, -1 = backward
+    pos_T	*cursor = &curwin->w_cursor;
+    char_u	*dir_s;
+    int		dir = 1;    // 1 = forward, -1 = backward
     dict_T	*dict;
     dictitem_T	*di;
     buf_T	*buf = curbuf;
@@ -653,12 +653,12 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
     
     while (1)
     {	
-        char_u	    *text = ml_get_buf(buf, lnum, FALSE);
-        size_t	    textlen = STRLEN(text) + 1;
-        int	    count = (int)((buf->b_ml.ml_line_len - textlen)
+        char_u	*text = ml_get_buf(buf, lnum, FALSE);
+        size_t	textlen = STRLEN(text) + 1;
+        int	count = (int)((buf->b_ml.ml_line_len - textlen)
                                 / sizeof(textprop_T));
-        int	    i;
-        textprop_T  prop;
+        int i;
+        textprop_T prop;
         int prop_start;
         int prop_end;
 

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -769,7 +769,6 @@ f_prop_list(typval_T *argvars, typval_T *rettv)
 							 / sizeof(textprop_T));
 	int	    i;
 	textprop_T  prop;
-	proptype_T  *pt;
 
 	for (i = 0; i < count; ++i)
 	{

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -542,6 +542,9 @@ f_prop_clear(typval_T *argvars, typval_T *rettv UNUSED)
     void
 f_prop_find(typval_T *argvars, typval_T *rettv)
 {
+    int         lnum_start;
+    int         start_pos_has_prop = 0;
+    int         seen_end = 0;
     int         id = -1;
     int         type_id = -1;
     int         skipstart = 0;
@@ -625,9 +628,7 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
 	return;
     }
 
-    int lnum_start = lnum;
-    int start_pos_has_prop = 0;
-    int seen_end = 0;
+    lnum_start = lnum;
 
     if (rettv_dict_alloc(rettv) == OK)
     {

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -560,20 +560,20 @@ f_prop_clear(typval_T *argvars, typval_T *rettv UNUSED)
     void
 f_prop_find(typval_T *argvars, typval_T *rettv)
 {
-    pos_T	*cursor = &curwin->w_cursor;
-    char_u	*dir_s;
-    dict_T	*dict;
-    buf_T	*buf = curbuf;
-    dictitem_T	*di;
-    int		lnum_start;
-    int		start_pos_has_prop = 0;
-    int		seen_end = 0;
-    int		id = -1;
-    int		type_id = -1;
-    int		skipstart = 0;
-    int		lnum = -1;
-    int		col = -1;
-    int		dir = 1;    // 1 = forward, -1 = backward
+    pos_T       *cursor = &curwin->w_cursor;
+    char_u      *dir_s;
+    dict_T      *dict;
+    buf_T       *buf = curbuf;
+    dictitem_T  *di;
+    int         lnum_start;
+    int         start_pos_has_prop = 0;
+    int         seen_end = 0;
+    int         id = -1;
+    int         type_id = -1;
+    int         skipstart = 0;
+    int         lnum = -1;
+    int         col = -1;
+    int         dir = 1;    // 1 = forward, -1 = backward
  
     if (argvars[0].v_type != VAR_DICT || argvars[0].vval.v_dict == NULL)
     {

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -658,82 +658,82 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
 	int	count = (int)((buf->b_ml.ml_line_len - textlen)
                                 / sizeof(textprop_T));
 	int	    i;
-        textprop_T  prop;
-        int	    prop_start;
-        int	    prop_end;
+	textprop_T  prop;
+	int	    prop_start;
+	int	    prop_end;
 
-        for (i = 0; i < count; ++i)
-        {
-            mch_memmove(&prop, text + textlen + i * sizeof(textprop_T),
-                            sizeof(textprop_T));
+	for (i = 0; i < count; ++i)
+	{
+	    mch_memmove(&prop, text + textlen + i * sizeof(textprop_T),
+			    sizeof(textprop_T));
 
-            if (prop.tp_id == id || prop.tp_type == type_id)
-            {
-                // Check if the starting position has text props.
-                if (lnum_start == lnum)
-                {
+	    if (prop.tp_id == id || prop.tp_type == type_id)
+	    {
+		// Check if the starting position has text props.
+		if (lnum_start == lnum)
+		{
 		    if (col >= prop.tp_col && (col <= prop.tp_col + prop.tp_len-1))
 			start_pos_has_prop = 1;
-                }
-                else
-                {
+		}
+		else
+		{
 		    // Not at the first line of the search so adjust col to 
 		    // indicate that we're continuing from prev/next line. 
 		    if (dir < 0)
 			col = buf->b_ml.ml_line_len;
 		    else
 			col = 1;
-                }
+		}
 
-                prop_start = !(prop.tp_flags & TP_FLAG_CONT_PREV);
-                prop_end = !(prop.tp_flags & TP_FLAG_CONT_NEXT);
-                if (!prop_start && prop_end && dir > 0)
+		prop_start = !(prop.tp_flags & TP_FLAG_CONT_PREV);
+		prop_end = !(prop.tp_flags & TP_FLAG_CONT_NEXT);
+		if (!prop_start && prop_end && dir > 0)
 		    seen_end = 1; 
 
-                // Skip lines without the start flag.
-                if (!prop_start)
-                { 
+		// Skip lines without the start flag.
+		if (!prop_start)
+		{ 
 		    // Always search backwards for start when search started
 		    // on a prop and we're not skipping.
 		    if (start_pos_has_prop && !skipstart)
 			dir = -1;
 		    break;
-                }
+		}
                    
-                // If skipstart is true, skip the prop at start pos (even if 
-                // continued from another line). 
-                if (start_pos_has_prop && skipstart && !seen_end)
-                {
+		// If skipstart is true, skip the prop at start pos (even if 
+		// continued from another line). 
+		if (start_pos_has_prop && skipstart && !seen_end)
+		{
 		    start_pos_has_prop = 0;
 		    break;
-                }
+		}
 
-                if (dir < 0)
-                {
+		if (dir < 0)
+		{
 		    if (col < prop.tp_col)
 			break;
-                }
-                else
-                {
+		}
+		else
+		{
 		    if (col > prop.tp_col + prop.tp_len-1)
 			break;
-                }
+		}
                 
-                prop_fill_dict(rettv->vval.v_dict, &prop, buf);
-                dict_add_number(rettv->vval.v_dict, "lnum", lnum);
+		prop_fill_dict(rettv->vval.v_dict, &prop, buf);
+		dict_add_number(rettv->vval.v_dict, "lnum", lnum);
 
-                return;
-            }
-        }
+		return;
+	    }
+	}
 
-        if (dir > 0)
-        {
+	if (dir > 0)
+	{
 	    if (lnum >= buf->b_ml.ml_line_count)
 		break;
 	    lnum++;
-        }
-        else
-        {
+	}
+	else
+	{
 	    if (lnum <= 1)
 		break;
 	    lnum--;


### PR DESCRIPTION
This PR implements the prop_find function as discussed in issue #4970 and provides a test. The function f_prop_find is added in src/textprop.c and Test_prop_find in src/testdir/test_textprop.vim. I followed the documentation closely and the function should behave as intended, but to be specific I'll mention a few points with reference to the docs here.

> skipstart:    do not look for a match at the start position

'skipstart' is treated as a number, 0 being false (default) and 1 being true. If true and the text property at the start position matches the one being searched for (specified by 'id' or 'type'), then this property from its start to end line is ignored. This is the same searching forwards or backwards. 

> {direction} can be "f" for forward and "b" for backward.

This is treated as a string with the first character considered. The default is forward.

If a matching prop is found by prop_find, the first line (with the start flag set to 1) of the prop is returned in a dictionary along with an additional 'lnum' entry, otherwise an empty dict is returned.

The test function tests prop_find fairly thoroughly but may leave out some edge cases (although I've tested these myself by experimentation). More can of course be added.

I hope the code style is ok and I'm happy to document or explain the function better. Sorry for the terrible timing being new year but I thank you for your consideration and feedback. 