### PR TITLE
Increase Obj-C++ detection lines from 9 to 19

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -325,7 +325,7 @@ endfunc
 
 func dist#ft#FTmm()
   let n = 1
-  while n < 10
+  while n < 20
     let line = getline(n)
     if line =~ '^\s*\(#\s*\(include\|import\)\>\|@import\>\|/\*\)'
       setf objcpp


### PR DESCRIPTION
It's common for Obj-C++ source files (with a .mm extension) to include
file-level comment blocks at the top. 9 lines is barely sufficient for
the default comment block length. Bumping this scan limit to 20 (19
lines) covers more cases.