### PR TITLE
tiny improvement: add space after "if" in 2html JS

### DIFF
--- a/runtime/syntax/2html.vim
+++ b/runtime/syntax/2html.vim
@@ -932,7 +932,7 @@ if s:settings.dynamic_folds
 	\ "{",
 	\ "  var fold;",
 	\ "  fold = document.getElementById(objID);",
-	\ "  if(fold.className == 'closed-fold')",
+	\ "  if (fold.className == 'closed-fold')",
 	\ "  {",
 	\ "    fold.className = 'open-fold';",
 	\ "  }",


### PR DESCRIPTION
Barely worth fixing, but since I noticed...