### PR TITLE
Fixed crash in case of allocation failure in ExpandGeneric()

### DIFF
--- a/src/proto/cmdexpand.pro
+++ b/src/proto/cmdexpand.pro
@@ -8,7 +8,6 @@ char_u *sm_gettail(char_u *s);
 char_u *addstar(char_u *fname, int len, int context);
 void set_cmd_context(expand_T *xp, char_u *str, int len, int col, int use_ccline);
 int expand_cmdline(expand_T *xp, char_u *str, int col, int *matchcount, char_u ***matches);
-int ExpandGeneric(expand_T *xp, regmatch_T *regmatch, int *num_file, char_u ***file, char_u *((*func)(expand_T *, int)), int escaped);
 void globpath(char_u *path, char_u *file, garray_T *ga, int expand_options);
 void f_getcompletion(typval_T *argvars, typval_T *rettv);
 /* vim: set ft=c : */


### PR DESCRIPTION
This PR fixes a crash in Vim-8.2.86 and older in case of allocation
failure in `ExpandGeneric(...)`:

The crash occurs here:
```
(gdb) bt
#0  0x00007f3cbacafe1a in  () at /usr/lib/x86_64-linux-gnu/libasan.so.4
#1  0x000055f52633c494 in sort_compare (s1=0x6220004da110, s2=0x6220004da118) at misc2.c:3854
#2  0x00007f3cb702c1f2 in msort_with_tmp (p=p@entry=0x7fff1bf7d680, b=b@entry=0x6220004da110, n=n@entry=3) at msort.c:83
#3  0x00007f3cb702c15e in msort_with_tmp (n=3, b=0x6220004da110, p=0x7fff1bf7d680) at msort.c:117
#4  0x00007f3cb702c15e in msort_with_tmp (p=0x7fff1bf7d680, b=0x6220004da100, n=n@entry=5) at msort.c:54
#5  0x00007f3cb702c170 in msort_with_tmp (n=5, b=0x6220004da100, p=0x7fff1bf7d680) at msort.c:117
#6  0x00007f3cb702c170 in msort_with_tmp (p=0x7fff1bf7d680, b=0x6220004da100, n=n@entry=11) at msort.c:53
#7  0x00007f3cb702c170 in msort_with_tmp (n=11, b=0x6220004da100, p=0x7fff1bf7d680) at msort.c:117
#8  0x00007f3cb702c170 in msort_with_tmp (p=0x7fff1bf7d680, b=0x6220004da100, n=n@entry=22) at msort.c:53
#9  0x00007f3cb702c170 in msort_with_tmp (n=22, b=0x6220004da100, p=0x7fff1bf7d680) at msort.c:117
#10 0x00007f3cb702c170 in msort_with_tmp (p=0x7fff1bf7d680, b=0x6220004da100, n=n@entry=45) at msort.c:53
#11 0x00007f3cb702c170 in msort_with_tmp (n=45, b=0x6220004da100, p=0x7fff1bf7d680) at msort.c:117
#12 0x00007f3cb702c170 in msort_with_tmp (p=0x7fff1bf7d680, b=0x6220004da100, n=n@entry=91) at msort.c:53
#13 0x00007f3cb702c170 in msort_with_tmp (n=91, b=0x6220004da100, p=0x7fff1bf7d680) at msort.c:117
#14 0x00007f3cb702c170 in msort_with_tmp (p=0x7fff1bf7d680, b=0x6220004da100, n=n@entry=182) at msort.c:53
#15 0x00007f3cb702c170 in msort_with_tmp (n=182, b=0x6220004da100, p=0x7fff1bf7d680) at msort.c:117
#16 0x00007f3cb702c170 in msort_with_tmp (p=0x7fff1bf7d680, b=0x6220004da100, n=n@entry=365) at msort.c:53
#17 0x00007f3cb702c170 in msort_with_tmp (n=365, b=0x6220004da100, p=0x7fff1bf7d680) at msort.c:117
#18 0x00007f3cb702c170 in msort_with_tmp (p=p@entry=0x7fff1bf7d680, b=b@entry=0x6220004da100, n=n@entry=731) at msort.c:53
#19 0x00007f3cb702c596 in msort_with_tmp (n=731, b=0x6220004da100, p=0x7fff1bf7d680) at msort.c:45
#20 0x00007f3cb702c596 in __GI___qsort_r (b=0x6220004da100, n=731, s=8, cmp=0x55f52633c429 <sort_compare>, arg=<optimized out>) at msort.c:297
#21 0x000055f52633c4c3 in sort_strings (files=0x6220004da100, count=731) at misc2.c:3862
#22 0x000055f5260ee22e in ExpandGeneric (xp=0x7fff1bf7dc60, regmatch=0x7fff1bf7d8e0, num_file=0x7fff1bf7dc98, file=0x7fff1bf7dca0, func=0x55f5262020c7 <get_command_name>, escaped=1) at cmdexpand.c:2292
#23 0x000055f5260edcd1 in ExpandFromContext (xp=0x7fff1bf7dc60, pat=0x602000163f50 "^", num_file=0x7fff1bf7dc98, file=0x7fff1bf7dca0, options=218) at cmdexpand.c:2197
#24 0x000055f5260e4177 in ExpandOne (xp=0x7fff1bf7dc60, str=0x602000163f50 "^", orig=0x602000163f70 "", options=218, mode=7) at cmdexpand.c:354
#25 0x000055f5260e3779 in nextwild (xp=0x7fff1bf7dc60, type=7, options=8, escape=1) at cmdexpand.c:186
#26 0x000055f52622ac90 in getcmdline_int (firstc=58, count=1, indent=0, init_ccline=1) at ex_getln.c:1448
#27 0x000055f526226ff0 in getcmdline (firstc=58, count=1, indent=0, do_concat=1) at ex_getln.c:784
#28 0x000055f526230a3a in getexline (c=58, cookie=0x0, indent=0, do_concat=1) at ex_getln.c:2690
#29 0x000055f5261ea717 in do_cmdline (cmdline=0x0, fgetline=0x55f5262309bd <getexline>, cookie=0x0, flags=0) at ex_docmd.c:882
#30 0x000055f526387faa in nv_colon (cap=0x7fff1bf7e7c0) at normal.c:3318
#31 0x000055f52637a2d9 in normal_cmd (oap=0x7fff1bf7e920, toplevel=1) at normal.c:1071
#32 0x000055f52672551e in main_loop (cmdwin=0, noexmode=0) at main.c:1511
#33 0x000055f526724086 in vim_main2 () at main.c:901
#34 0x000055f5267233d2 in main (argc=1, argv=0x7fff1bf7ebc8) at main.c:444
```