### PR TITLE
Fixed crash when doing completion of :setfiletype

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2626,13 +2626,12 @@ globpath(
 		{
 		    for (i = 0; i < num_p; ++i)
 		    {
-			((char_u **)ga->ga_data)[ga->ga_len] =
-					vim_strnsave(p[i], (int)STRLEN(p[i]));
+			((char_u **)ga->ga_data)[ga->ga_len] = p[i];
 			++ga->ga_len;
 		    }
 		}
 
-		FreeWild(num_p, p);
+		vim_free(p);
 	    }
 	}
     }


### PR DESCRIPTION
This PR fixes a crash in Vim-8.2.86 and older
when doing completion of `:setfiletype` and 
dynamic allocation fails in `vim_strnsave()`
in `globpath()`.

There actually no need to dynamically allocate there.