### PR TITLE
Fixed crash after OOM in expand_shellcmd()

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2340,9 +2340,14 @@ expand_shellcmd(
     if (buf == NULL)
 	return FAIL;
 
-    // for ":set path=" and ":set tags=" halve backslashes for escaped
-    // space
+    // for ":set path=" and ":set tags=" halve backslashes for escaped space
     pat = vim_strsave(filepat);
+    if (pat == NULL)
+    {
+	vim_free(buf);
+	return FAIL;
+    }
+
     for (i = 0; pat[i]; ++i)
 	if (pat[i] == '\\' && pat[i + 1] == ' ')
 	    STRMOVE(pat + i, pat + i + 1);


### PR DESCRIPTION
This fixes yet another crash after out-of-memory error in `expand_shellcmd()` in vim-8.2.94.

I think that there are probably many other places where failures to allocate are not gracefully handled.
I'm not sure whether it's really worth fixing them. They are very unlikely to happen.
But at least this one is simple to fix.