### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,78 @@
+VIM LICENSE
+
+I)  There are no restrictions on distributing unmodified copies of Vim except
+    that they must include this license text.  You can also distribute
+    unmodified parts of Vim, likewise unrestricted except that they must
+    include this license text.  You are also allowed to include executables
+    that you made from the unmodified Vim sources, plus your own usage
+    examples and Vim scripts.
+
+II) It is allowed to distribute a modified (or extended) version of Vim,
+    including executables and/or source code, when the following four
+    conditions are met:
+    1) This license text must be included unmodified.
+    2) The modified Vim must be distributed in one of the following five ways:
+       a) If you make changes to Vim yourself, you must clearly describe in
+          the distribution how to contact you.  When the maintainer asks you
+          (in any way) for a copy of the modified Vim you distributed, you
+          must make your changes, including source code, available to the
+          maintainer without fee.  The maintainer reserves the right to
+          include your changes in the official version of Vim.  What the
+          maintainer will do with your changes and under what license they
+          will be distributed is negotiable.  If there has been no negotiation
+          then this license, or a later version, also applies to your changes.
+          The current maintainer is Bram Moolenaar <Bram@vim.org>.  If this
+          changes it will be announced in appropriate places (most likely
+          vim.sf.net, www.vim.org and/or comp.editors). When it is completely
+          impossible to contact the maintainer, the obligation to send him
+          your changes ceases.  Once the maintainer has confirmed that he has
+          received your changes they will not have to be sent again.
+       b) If you have received a modified Vim that was distributed as
+          mentioned under a) you are allowed to further distribute it
+          unmodified, as mentioned at I).  If you make additional changes the
+          text under a) applies to those changes.
+       c) Provide all the changes, including source code, with every copy of
+          the modified Vim you distribute.  This may be done in the form of a
+          context diff.  You can choose what license to use for new code you
+          add.  The changes and their license must not restrict others from
+          making their own changes to the official version of Vim.
+       d) When you have a modified Vim which includes changes as mentioned
+          under c), you can distribute it without the source code for the
+          changes if the following three conditions are met:
+          - The license that applies to the changes permits you to distribute
+            the changes to the Vim maintainer without fee or restriction, and
+            permits the Vim maintainer to include the changes in the official
+            version of Vim without fee or restriction.
+          - You keep the changes for at least three years after last
+            distributing the corresponding modified Vim.  When the maintainer
+            or someone who you distributed the modified Vim to asks you (in
+            any way) for the changes within this period, you must make them
+            available to him.
+          - You clearly describe in the distribution how to contact you.  This
+            contact information must remain valid for at least three years
+            after last distributing the corresponding modified Vim, or as long
+            as possible.
+       e) When the GNU General Public License (GPL) applies to the changes,
+          you can distribute the modified Vim under the GNU GPL version 2 or
+          any later version.
+    3) A message must be added, at least in the output of the ":version"
+       command and in the intro screen, such that the user of the modified Vim
+       is able to see that it was modified.  When distributing as mentioned
+       under 2)e) adding the message is only required for as far as this does
+       not conflict with the license used for the changes.
+    4) The contact information as required under 2)a) and 2)d) must not be
+       removed or changed, except that the person himself can make
+       corrections.
+
+III) If you distribute a modified version of Vim, you are encouraged to use
+     the Vim license for your changes and make them available to the
+     maintainer, including the source code.  The preferred way to do this is
+     by e-mail or by uploading the files to a server and e-mailing the URL. If
+     the number of changes is small (e.g., a modified Makefile) e-mailing a
+     context diff will do.  The e-mail address to be used is
+     <maintainer@vim.org>
+
+IV)  It is not allowed to remove this license from the distribution of the Vim
+     sources, parts of it or from a modified version.  You may use this
+     license for previous Vim releases instead of the license that they came
+     with, at your option.


### PR DESCRIPTION
As I talked at vim_dev last year[[1][1]]. I am working on making GitHub able to recognize Vim License. After some communication and contribution. The Licensee(used by GitHub) can detect Vim License with supporting project name field now.

The next step is to add the license to choosealicense[[2][2]]. To do that I need provide three notable project[[3][3]] using Vim License which can be detect by Licensee. I believe Vim itself should be the first item of the list. So this PR is to submit the LICENSE file to Vim code repository. It is required for the Licensee to detect the license in use.

[1]:https://groups.google.com/forum/#!searchin/vim_dev/vim$20license%7Csort:date/vim_dev/DlTVMew1ZSo/b9QCTlXgEAAJ
[2]:https://github.com/github/choosealicense.com/
[3]:https://github.com/github/choosealicense.com/blob/gh-pages/CONTRIBUTING.md#adding-a-license