### PR TITLE
Introduce cindent cinoptions entry to treat pragmas as normal code

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -570,9 +570,15 @@ The examples below assume a 'shiftwidth' of 4.
 	      with "#" does not work.
 
 
+	PN    When N is non-zero recognize C pragmas, and indent them like any
+	      other code; does not concern other preprocessor directives.
+	      When N is zero (default): don't recognize C pragmas, treating
+	      them like every other preprocessor directive.
+
+
 The defaults, spelled out in full, are:
 	cinoptions=>s,e0,n0,f0,{0,}0,^0,L-1,:s,=s,l0,b0,gs,hs,N0,E0,ps,ts,is,+s,
-			c3,C0,/0,(2s,us,U0,w0,W0,k0,m0,j0,J0,)20,*70,#0
+			c3,C0,/0,(2s,us,U0,w0,W0,k0,m0,j0,J0,)20,*70,#0,P0
 
 Vim puts a line in column 1 if:
 - It starts with '#' (preprocessor directives), if 'cinkeys' contains '#0'.

--- a/src/structs.h
+++ b/src/structs.h
@@ -2732,6 +2732,7 @@ struct file_buffer
     int		b_ind_cpp_namespace;
     int		b_ind_if_for_while;
     int		b_ind_cpp_extern_c;
+    int		b_ind_pragma;
 #endif
 
     linenr_T	b_no_eol_lnum;	// non-zero lnum when last line of next binary

--- a/src/testdir/test_cindent.vim
+++ b/src/testdir/test_cindent.vim
@@ -5272,4 +5272,40 @@ func Test_cindent_change_multline()
   close!
 endfunc
 
+func Test_cindent_pragma()
+  new
+  setl cindent ts=4 sw=4
+  setl cino=Ps
+
+  let code =<< trim [CODE]
+  {
+  #pragma omp parallel
+  {
+  #pragma omp task
+  foo();
+  # pragma omp taskwait
+  }
+  }
+  [CODE]
+
+  call append(0, code)
+  normal gg
+  normal =G
+
+  let expected =<< trim [CODE]
+  {
+	#pragma omp parallel
+	{
+		#pragma omp task
+		foo();
+		# pragma omp taskwait
+	}
+  }
+
+  [CODE]
+
+  call assert_equal(expected, getline(1, '$'))
+  enew! | close
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
The new option `cinpragma` or `cinp` allows pragma directives, e.g. for OpenMP,
to be treated as normal code, and have indented like the rest of the
program.

Compare the following two examples:

The first is formatted with the current implementation, or with `cinpragma` set to `"false"`. As you can see, the `#pragma` directives are treated like any other directive, and moved to the start of the line.

```c
int fib(int n) {
    int i, j;

    if (n < 2) { 
        return n;
    } else {
#pragma omp parallel
        {
#pragma omp single
            {
#pragma omp task shared(i)
                i = fib(n - 1);
#pragma omp task shared(j)
                j = fib(n - 2);
#pragma omp taskwait
            }
        }
        return i + j;
    }
}
```

In the second example, `cinpragma` is set to `"true"`. Note how the pragmas are now part of the normal code, and indented like it as well. This highly improves the readability _in that case_, and thus makes a lot of sense for such OpenMP code.

```c
int fib(int n) {
    int i, j;

    if (n < 2) { 
        return n;
    } else {
        #pragma omp parallel
        {
            #pragma omp single
            {
                #pragma omp task shared(i)
                i = fib(n - 1);
                #pragma omp task shared(j)
                j = fib(n - 2);
                #pragma omp taskwait
            }
        }
        return i + j;
    }
}
```

This PR adds the aforementioned option, which is off by default though, to be as little intrusive as possible. What's obviously still missing is some documentation for the option, and possibly a better name for it. Also, I'm not 100% sure that my codestyle is right, so I'll gladly take any feedback and suggestions for improvement.