### PR TITLE
Fixed crash cpp indentation of switch case.

### DIFF
--- a/src/cindent.c
+++ b/src/cindent.c
@@ -582,6 +582,8 @@ cin_iscase(
 	for (s += 4; *s; ++s)
 	{
 	    s = cin_skipcomment(s);
+	    if (*s == NUL)
+		break;
 	    if (*s == ':')
 	    {
 		if (s[1] == ':')	// skip over "::" for C++


### PR DESCRIPTION
This PR fixes an invalid memory access in vim-8.2.111 and older,
which causes a crash with asan build.  Bug is also detected by valgrind.

To reproduce:
```
$ echo "case x: // x" > foo.cpp
$ vim --clean -c'filetype plugin indent on' -c'norm f:a:' foo.cpp
```
And observe this error with asan (same with valgrind):
```
==6299==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200007265e at pc 0x55f98409674c bp 0x7ffe842729b0 sp 0x7ffe842729a0
READ of size 1 at 0x60200007265e thread T0
    #0 0x55f98409674b in cin_iscase /home/pel/sb/vim/src/cindent.c:582
    #1 0x55f9840aa68b in in_cinkeys /home/pel/sb/vim/src/cindent.c:3963
    #2 0x55f98410bc16 in edit /home/pel/sb/vim/src/edit.c:1379
    #3 0x55f984358b70 in invoke_edit /home/pel/sb/vim/src/normal.c:7075
    #4 0x55f9843589a1 in nv_edit /home/pel/sb/vim/src/normal.c:7045
    #5 0x55f98433122b in normal_cmd /home/pel/sb/vim/src/normal.c:1071
    #6 0x55f9841d741c in exec_normal /home/pel/sb/vim/src/ex_docmd.c:7691
    #7 0x55f9841d71f8 in exec_normal_cmd /home/pel/sb/vim/src/ex_docmd.c:7654
    #8 0x55f9841d6b4b in ex_normal /home/pel/sb/vim/src/ex_docmd.c:7580
    #9 0x55f9841ba7cf in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2483
    #10 0x55f9841b1878 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:976
    #11 0x55f9841afd8c in do_cmdline_cmd /home/pel/sb/vim/src/ex_docmd.c:587
    #12 0x55f9846c0ea4 in exe_commands /home/pel/sb/vim/src/main.c:3135
    #13 0x55f9846b981c in vim_main2 /home/pel/sb/vim/src/main.c:795
    #14 0x55f9846b900f in main /home/pel/sb/vim/src/main.c:444
    #15 0x7f2a7b0b1b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #16 0x55f98404c469 in _start (/home/pel/sb/vim/src/vim+0x10e469)

0x60200007265e is located 0 bytes to the right of 14-byte region [0x602000072650,0x60200007265e)
allocated by thread T0 here:
    #0 0x7f2a7d801b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x55f9842ef833 in lalloc /home/pel/sb/vim/src/misc2.c:925
    #2 0x55f9842ef630 in alloc /home/pel/sb/vim/src/misc2.c:828
    #3 0x55f984086a0a in ins_char_bytes /home/pel/sb/vim/src/change.c:1059
    #4 0x55f984086085 in ins_char /home/pel/sb/vim/src/change.c:974
    #5 0x55f9841108e0 in insertchar /home/pel/sb/vim/src/edit.c:2296
    #6 0x55f98410f494 in insert_special /home/pel/sb/vim/src/edit.c:2049
    #7 0x55f98410baa7 in edit /home/pel/sb/vim/src/edit.c:1342
    #8 0x55f984358b70 in invoke_edit /home/pel/sb/vim/src/normal.c:7075
    #9 0x55f9843589a1 in nv_edit /home/pel/sb/vim/src/normal.c:7045
    #10 0x55f98433122b in normal_cmd /home/pel/sb/vim/src/normal.c:1071
    #11 0x55f9841d741c in exec_normal /home/pel/sb/vim/src/ex_docmd.c:7691
    #12 0x55f9841d71f8 in exec_normal_cmd /home/pel/sb/vim/src/ex_docmd.c:7654
    #13 0x55f9841d6b4b in ex_normal /home/pel/sb/vim/src/ex_docmd.c:7580
    #14 0x55f9841ba7cf in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2483
    #15 0x55f9841b1878 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:976
    #16 0x55f9841afd8c in do_cmdline_cmd /home/pel/sb/vim/src/ex_docmd.c:587
    #17 0x55f9846c0ea4 in exe_commands /home/pel/sb/vim/src/main.c:3135
    #18 0x55f9846b981c in vim_main2 /home/pel/sb/vim/src/main.c:795
    #19 0x55f9846b900f in main /home/pel/sb/vim/src/main.c:444
    #20 0x7f2a7b0b1b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/pel/sb/vim/src/cindent.c:582 in cin_iscase
Shadow bytes around the buggy address:
  0x0c0480006470: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x0c0480006480: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fa
  0x0c0480006490: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x0c04800064a0: fa fa fd fd fa fa fd fa fa fa 00 02 fa fa 01 fa
  0x0c04800064b0: fa fa 02 fa fa fa 02 fa fa fa fd fa fa fa 00 05
=>0x0c04800064c0: fa fa 00 00 fa fa 00 05 fa fa 00[06]fa fa fa fa
  0x0c04800064d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c04800064e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c04800064f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480006500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480006510: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==6299==ABORTING
```