### PR TITLE
Update documents

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -307,13 +307,13 @@ all loaded.  For example, if this command: >
 
 produces this output:
 
-	runtimepath=/etc/vim,~/.vim,/usr/local/share/vim/vim60 ~
+	runtimepath=/etc/vim,~/.vim,/usr/local/share/vim/vim82 ~
 
 then Vim will load all plugins in these directories and below:
 
 	/etc/vim/plugin/  ~
 	~/.vim/plugin/  ~
-	/usr/local/share/vim/vim60/plugin/  ~
+	/usr/local/share/vim/vim82/plugin/  ~
 
 Note that the last one is the value of $VIMRUNTIME which has been expanded.
 

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -106,16 +106,15 @@ when you have got a new version):
 You can also install Vim in the "Send To" menu:
 1. Start a Windows Explorer
 2. Navigate to your sendto directory:
-   Windows NT: %windir%\profiles\%user%\sendto (e.g.
-	       "c:\winnt\profiles\mattha\sendto")
    Windows XP: C:\Documents and Settings\%user%\SendTo
    Windows Vista: C:\Users\%user%\AppData\Roaming\Microsoft\Windows\SendTo .
 3. Right-click in the file pane and select New->Shortcut
 4. Follow the shortcut wizard, using the full path to VIM/GVIM.
 
 When you 'send a file to Vim', Vim changes to that file's directory.  Note,
-however, that any long directory names will appear in their short (MS-Windows)
-form.  This is a limitation of the Windows "Send To" mechanism.
+however, that any long directory names will appear in their short (MS-DOS)
+form on some Windows versions.  This is a limitation of the Windows "Send To"
+mechanism.
 
 						*notepad*
 You could replace notepad.exe with gvim.exe, but that has a few side effects.
@@ -169,8 +168,8 @@ you can.
 					    Vim Shell Extension
    HKEY_LOCAL_MACHINE\Software\Vim\Gvim
 		path			    {path}\gvim.exe
-   HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\vim 5.6
-		DisplayName		    Vim 5.6: Edit with Vim popup menu entry
+   HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\vim 8.2
+		DisplayName		    Vim 8.2: Edit with Vim popup menu entry
 		UninstallString		    {path}\uninstall.exe
 
    Replace {path} with the path that leads to the executable.
@@ -214,7 +213,7 @@ REGEDIT4
 [HKEY_CLASSES_ROOT\Applications\gvim.exe\shell\edit]
 
 [HKEY_CLASSES_ROOT\Applications\gvim.exe\shell\edit\command]
-@="c:\\vim\\vim62\\gvim.exe \"%1\""
+@="c:\\vim\\vim82\\gvim.exe \"%1\""
 
 [HKEY_CLASSES_ROOT\.htm\OpenWithList\gvim.exe]
 
@@ -222,7 +221,7 @@ REGEDIT4
 
 ----------------------------------------------------------
 
-Change the "c:\\vim\\vim62" bit to where gvim.exe is actually located.
+Change the "c:\\vim\\vim82" bit to where gvim.exe is actually located.
 
 To uninstall this run the Vim uninstall program or manually delete the
 registry entries with "regedit".

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -197,7 +197,7 @@ Remarks about specific systems ~
 |os_390.txt|	OS/390 Unix
 |os_amiga.txt|	Amiga
 |os_beos.txt|	BeOS and BeBox
-|os_dos.txt|	MS-DOS and MS-Windows NT/95 common items
+|os_dos.txt|	MS-DOS and MS-Windows common items
 |os_mac.txt|	Macintosh
 |os_mint.txt|	Atari MiNT
 |os_msdos.txt|	MS-DOS (plain DOS and DOS box under Windows)
@@ -206,7 +206,7 @@ Remarks about specific systems ~
 |os_risc.txt|	RISC-OS
 |os_unix.txt|	Unix
 |os_vms.txt|	VMS
-|os_win32.txt|	MS-Windows 95/98/NT
+|os_win32.txt|	MS-Windows
 						*standard-plugin-list*
 Standard plugins ~
 |pi_getscript.txt| Downloading latest version of Vim scripts

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -2009,11 +2009,11 @@ If the 'fileformats' option is not empty Vim tries to recognize the type of
 changed, the detected format is only used while reading the file.
 A similar thing happens with 'fileencodings'.
 
-The message "[dos format]" is shown if a file is read in DOS format, to remind
-you that something unusual is done.
+On non-Win32 systems the message "[dos format]" is shown if a file is read in
+DOS format, to remind you that something unusual is done.
 On Macintosh and Win32 the message "[unix format]" is shown if a file is read
 in Unix format.
-On non-Macintosh systems, the message "[Mac format]" is shown if a file is
+On non-Macintosh systems, the message "[mac format]" is shown if a file is
 read in Mac format.
 
 An example on how to use ":r !": >

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -709,9 +709,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	(or Vim is run inside an xterm invoked with "-cjkwidth" option.),
 	this option should be set to "double" to match the width perceived
 	by Vim with the width of glyphs in the font.  Perhaps it also has
-	to be set to "double" under CJK MS-Windows 2k/XP
-	when the system locale is set to one of CJK locales.  See Unicode
-	Standard Annex #11 (http://www.unicode.org/reports/tr11).
+	to be set to "double" under CJK MS-Windows when the system locale is
+	set to one of CJK locales.  See Unicode Standard Annex #11
+	(http://www.unicode.org/reports/tr11).
 
 	Vim may set this option automatically at startup time when Vim is
 	compiled with the |+termresponse| feature and if |t_u7| is set to the
@@ -1018,9 +1018,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  impossible!).  Writing may fail because of this.
 	- A directory "." means to put the backup file in the same directory
 	  as the edited file.
-	- A directory starting with "./" (or ".\" for MS-Windows et al.) means
-	  to put the backup file relative to where the edited file is.  The
-	  leading "." is replaced with the path name of the edited file.
+	- A directory starting with "./" (or ".\" for MS-Windows) means to put
+	  the backup file relative to where the edited file is.  The leading
+	  "." is replaced with the path name of the edited file.
 	  ("." inside a directory name has no special meaning).
 	- Spaces after the comma are ignored, other spaces are considered part
 	  of the directory name.  To have a space at the start of a directory
@@ -2712,9 +2712,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  the edited file.  On Unix, a dot is prepended to the file name, so
 	  it doesn't show in a directory listing.  On MS-Windows the "hidden"
 	  attribute is set and a dot prepended if possible.
-	- A directory starting with "./" (or ".\" for MS-Windows et al.) means
-	  to put the swap file relative to where the edited file is.  The
-	  leading "." is replaced with the path name of the edited file.
+	- A directory starting with "./" (or ".\" for MS-Windows) means to put
+	  the swap file relative to where the edited file is.  The leading "."
+	  is replaced with the path name of the edited file.
 	- For Unix and Win32, if a directory ends in two path separators "//",
 	  the swap file name will be built from the complete path to the file
 	  with all path separators substituted to percent '%' signs. This will
@@ -3593,7 +3593,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			{only available when compiled with GUI enabled, and
 			for Win32 console}
 	This option tells Vim what the cursor should look like in different
-	modes.  It fully works in the GUI.  In an Win32 console, only the
+	modes.  It fully works in the GUI.  In a Win32 console, only the
 	height of the cursor can be changed.  This can be done by specifying a
 	block cursor, or a percentage for a vertical or horizontal cursor.
 	For a console the 't_SI', 't_SR', and 't_EI' escape sequences are
@@ -6075,7 +6075,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			 *'restorescreen'* *'rs'* *'norestorescreen'* *'nors'*
 'restorescreen' 'rs'	boolean	(default on)
 			global
-			{only in Windows 95/NT console version}
+			{only in MS-Windows console version}
 	When set, the screen contents is restored when exiting Vim.  This also
 	happens when executing external commands.
 
@@ -6497,9 +6497,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 somewhere: "/c")
 			global
 	Flag passed to the shell to execute "!" and ":!" commands; e.g.,
-	"bash.exe -c ls" or "command.com /c dir".  For the MS-Windows-like
-	systems, the default is set according to the value of 'shell', to
-	reduce the need to set this option by the user.
+	"bash.exe -c ls" or "cmd.exe /c dir".  For MS-Windows, the default is
+	set according to the value of 'shell', to reduce the need to set this
+	option by the user.
 	On Unix it can have more than one flag.  Each white space separated
 	part is passed as an argument to the shell command.
 	See |option-backslash| about including spaces and backslashes.
@@ -6508,7 +6508,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 						*'shellpipe'* *'sp'*
-'shellpipe' 'sp'	string	(default ">", "| tee", "|& tee" or "2>&1| tee")
+'shellpipe' 'sp'	string	(default ">", ">%s 2>&1", "| tee", "|& tee" or
+				 "2>&1| tee")
 			global
 			{not available when compiled without the |+quickfix|
 			feature}
@@ -6518,8 +6519,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The name of the temporary file can be represented by "%s" if necessary
 	(the file name is appended automatically if no %s appears in the value
 	of this option).
-	For the Amiga the default is ">".  The output is directly saved in a
-	file and not echoed to the screen.
+	For the Amiga the default is ">".  For MS-Windows the default is
+	">%s 2>&1".  The output is directly saved in a file and not echoed to
+	the screen.
 	For Unix the default it "| tee".  The stdout of the compiler is saved
 	in a file and echoed to the screen.  If the 'shell' option is "csh" or
 	"tcsh" after initializations, the default becomes "|& tee".  If the
@@ -6587,9 +6589,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 			{only for MS-Windows}
 	When set, a forward slash is used when expanding file names.  This is
-	useful when a Unix-like shell is used instead of command.com or
-	cmd.exe.  Backward slashes can still be typed, but they are changed to
-	forward slashes by Vim.
+	useful when a Unix-like shell is used instead of cmd.exe.  Backward
+	slashes can still be typed, but they are changed to forward slashes by
+	Vim.
 	Note that setting or resetting this option has no effect for some
 	existing file names, thus this option needs to be set before opening
 	any file for best results.  This might change in the future.
@@ -8205,7 +8207,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	NOTE: This option is reset when 'compatible' is set.
 
 						*'undolevels'* *'ul'*
-'undolevels' 'ul'	number	(default 100, 1000 for Unix, VMS, Win32)
+'undolevels' 'ul'	number	(default 100, 1000 for Unix, VMS and Win32)
 			global or local to buffer |global-local|
 	Maximum number of changes that can be undone.  Since undo information
 	is kept in memory, higher numbers will cause more memory to be used.

--- a/runtime/doc/os_dos.txt
+++ b/runtime/doc/os_dos.txt
@@ -39,7 +39,7 @@ If you move the executable to another location, you also need to set the $VIM
 environment variable.  The runtime files will be found in "$VIM/vim{version}".
 Example: >
 	set VIM=E:\vim
-Will find the version 5.4 runtime files in "e:\vim\vim54".
+Will find the version 8.2 runtime files in "e:\vim\vim82".
 Note: This is _not_ recommended.  The preferred way is to keep the executable
 in the runtime directory.
 
@@ -47,8 +47,8 @@ If you move your executable AND want to put your "_vimrc" and "_gvimrc" files
 somewhere else, you must set $VIM to where you vimrc files are, and set
 $VIMRUNTIME to the runtime files.  Example: >
 	set VIM=C:\usr\piet
-	set VIMRUNTIME=E:\vim\vim54
-Will find "c:\user\piet\_vimrc" and the runtime files in "e:\vim\vim54".
+	set VIMRUNTIME=E:\vim\vim82
+Will find "c:\user\piet\_vimrc" and the runtime files in "e:\vim\vim82".
 
 See |$VIM| and |$VIMRUNTIME| for more information.
 

--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -627,16 +627,9 @@ MS-Windows
 
     http://www.cs.wisc.edu/~ghost/gsview/
 
-DOS
-
-- ps_view.  Obtainable from:
-
-    ftp://ftp.pg.gda.pl/pub/TeX/support/ps_view/
-    ftp://ftp.dante.de/tex-archive/support/ps_view/
-
 Linux
 
-- GSview.  Linux version of the popular MS-Windows.
+- GSview.  Linux version of the popular MS-Windows previewer.
   Obtainable from:
 
     http://www.cs.wisc.edu/~ghost/gsview/

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -944,11 +944,11 @@ or simpler >
 "$*" can be given multiple times, for example: >
    :set makeprg=gcc\ -o\ $*\ $*
 
-The 'shellpipe' option defaults to ">" for the Amiga and Win32.  This means
-that the output of the compiler is saved in a file and not shown on the screen
-directly.  For Unix "| tee" is used.  The compiler output is shown on the
-screen and saved in a file the same time.  Depending on the shell used "|&
-tee" or "2>&1| tee" is the default, so stderr output will be included.
+The 'shellpipe' option defaults to ">" for the Amiga and ">%s 2>&1" for Win32.
+This means that the output of the compiler is saved in a file and not shown on
+the screen directly.  For Unix "| tee" is used.  The compiler output is shown
+on the screen and saved in a file the same time.  Depending on the shell used
+"|& tee" or "2>&1| tee" is the default, so stderr output will be included.
 
 If 'shellpipe' is empty, the {errorfile} part will be omitted.  This is useful
 for compilers that write to an errorfile themselves (e.g., Manx's Amiga C).

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -326,25 +326,25 @@ Exceptions:
   spell file is used.
 
 For example, with these values:
-	'runtimepath' is "~/.vim,/usr/share/vim81,~/.vim/after"
+	'runtimepath' is "~/.vim,/usr/share/vim82,~/.vim/after"
 	'encoding'    is "iso-8859-2"
 	'spelllang'   is "pl"
 
 Vim will look for:
 1. ~/.vim/spell/pl.iso-8859-2.spl
-2. /usr/share/vim81/spell/pl.iso-8859-2.spl
+2. /usr/share/vim82/spell/pl.iso-8859-2.spl
 3. ~/.vim/spell/pl.iso-8859-2.add.spl
-4. /usr/share/vim81/spell/pl.iso-8859-2.add.spl
+4. /usr/share/vim82/spell/pl.iso-8859-2.add.spl
 5. ~/.vim/after/spell/pl.iso-8859-2.add.spl
 
 This assumes 1. is not found and 2. is found.
 
 If 'encoding' is "latin1" Vim will look for:
 1. ~/.vim/spell/pl.latin1.spl
-2. /usr/share/vim81/spell/pl.latin1.spl
+2. /usr/share/vim82/spell/pl.latin1.spl
 3. ~/.vim/after/spell/pl.latin1.spl
 4. ~/.vim/spell/pl.ascii.spl
-5. /usr/share/vim81/spell/pl.ascii.spl
+5. /usr/share/vim82/spell/pl.ascii.spl
 6. ~/.vim/after/spell/pl.ascii.spl
 
 This assumes none of them are found (Polish doesn't make sense when leaving

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -108,7 +108,7 @@ vimdiff vim -d	    Start in diff mode |diff-mode|
 gvimdiff vim -gd    Start in diff mode |diff-mode|
 
 Additional characters may follow, they are ignored.  For example, you can have
-"gvim-5" to start the GUI.  You must have an executable by that name then, of
+"gvim-8" to start the GUI.  You must have an executable by that name then, of
 course.
 
 On Unix, you would normally have one executable called Vim, and links from the
@@ -1140,12 +1140,12 @@ will try to get the value for $VIM in this order:
    variable too (the default is "$VIMRUNTIME/doc/help.txt": chicken-egg
    problem).  The file name ("help.txt" or any other) is removed.  Then
    trailing directory names are removed, in this order: "doc", "runtime" and
-   "vim{version}" (e.g., "vim54").
+   "vim{version}" (e.g., "vim82").
 3. For Win32 Vim tries to use the directory name of the executable.  If it
    ends in "/src", this is removed.  This is useful if you unpacked the .zip
    file in some directory, and adjusted the search path to find the vim
    executable.  Trailing directory names are removed, in this order: "runtime"
-   and "vim{version}" (e.g., "vim54").
+   and "vim{version}" (e.g., "vim82").
 4. For Unix the compile-time defined installation directory is used (see the
    output of ":version").
 
@@ -1163,7 +1163,7 @@ is the order used to find the value of $VIMRUNTIME:
 1. If the environment variable $VIMRUNTIME is set, it is used.  You can use
    this when the runtime files are in an unusual location.
 2. If "$VIM/vim{version}" exists, it is used.  {version} is the version
-   number of Vim, without any '-' or '.'.  For example: "$VIM/vim54".  This is
+   number of Vim, without any '-' or '.'.  For example: "$VIM/vim82".  This is
    the normal value for $VIMRUNTIME.
 3. If "$VIM/runtime" exists, it is used.
 4. The value of $VIM is used.  This is for backwards compatibility with older
@@ -1175,11 +1175,11 @@ For Unix, when there is a compiled-in default for $VIMRUNTIME (check the
 output of ":version"), steps 2, 3 and 4 are skipped, and the compiled-in
 default is used after step 5.  This means that the compiled-in default
 overrules the value of $VIM.  This is useful if $VIM is "/etc" and the runtime
-files are in "/usr/share/vim/vim54".
+files are in "/usr/share/vim/vim82".
 
 Once Vim has done this once, it will set the $VIMRUNTIME environment variable.
 To change it later, use a ":let" command like this: >
-	:let $VIMRUNTIME = "/home/piet/vim/vim54"
+	:let $VIMRUNTIME = "/home/piet/vim/vim82"
 
 In case you need the value of $VIMRUNTIME in a shell (e.g., for a script that
 greps in the help files) you might be able to use this: >
@@ -1208,8 +1208,8 @@ CTRL-Z			Suspend Vim, like ":stop".
 			buffers are not written, don't forget to bring Vim
 			back to the foreground later!
 
-In the GUI, suspending is implemented as iconising gvim.  In Windows 95/NT,
-gvim is minimized.
+In the GUI, suspending is implemented as iconising gvim.  In MS-Windows, gvim
+is minimized.
 
 On many Unix systems, it is possible to suspend Vim with CTRL-Z.  This is only
 possible in Normal and Visual mode (see next chapter, |vim-modes|).  Vim will

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -60,8 +60,8 @@ If the VIM environment variable is not set, Vim will try to find
 the path in another way (see |$VIMRUNTIME|).  Usually this works just
 fine.  If it doesn't, try setting the VIM environment variable to the
 directory where the Vim stuff is located.  For example, if your syntax files
-are in the "/usr/vim/vim81/syntax" directory, set $VIMRUNTIME to
-"/usr/vim/vim81".  You must do this in the shell, before starting Vim.
+are in the "/usr/vim/vim82/syntax" directory, set $VIMRUNTIME to
+"/usr/vim/vim82".  You must do this in the shell, before starting Vim.
 This command also sources the |menu.vim| script when the GUI is running or
 will start soon.  See |'go-M'| about avoiding that.
 

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -579,7 +579,7 @@ remove highlighting from a line.  This is required for "hpterm".  Setting the
 versa.
 
 							*scroll-region*
-Some termcaps do not include an entry for 'cs' (scroll region), although the
+Some termcaps do not include an entry for "cs" (scroll region), although the
 terminal does support it.  For example: xterm on a Sun.  You can use the
 builtin_xterm or define t_cs yourself.  For example: >
 	:set t_cs=^V^[[%i%d;%dr
@@ -596,11 +596,9 @@ cleared when scrolling).
 Unfortunately it is not possible to deduce from the termcap how cursor
 positioning should be done when using a scrolling region: Relative to the
 beginning of the screen or relative to the beginning of the scrolling region.
-Most terminals use the first method.  A known exception is the MS-Windows
-console (pcterm).  The 't_CS' option should be set to any string when cursor
-positioning is relative to the start of the scrolling region.  It should be
-set to an empty string otherwise.  It defaults to "yes" when 'term' is
-"pcterm".
+Most terminals use the first method.  The 't_CS' option should be set to any
+string when cursor positioning is relative to the start of the scrolling
+region.  It should be set to an empty string otherwise.
 
 Note for xterm users: The shifted cursor keys normally don't work.  You can
 	make them work with the xmodmap command and some mappings in Vim.
@@ -652,15 +650,7 @@ One command can be used to set the screen size:
 :mod[e] [mode]
 
 Without argument this only detects the screen size and redraws the screen.
-With MS-Windows it is possible to switch screen mode.  [mode] can be one of
-these values:
-	"bw40"		40 columns black&white
-	"c40"		40 columns color
-	"bw80"		80 columns black&white
-	"c80"		80 columns color (most people use this)
-	"mono"		80 columns monochrome
-	"c4350"		43 or 50 lines EGA/VGA mode
-	number		mode number to use, depends on your video card
+[mode] was used on MS-DOS, but it doesn't work anymore.
 
 ==============================================================================
 4. Slow and fast terminals			*slow-fast-terminal*
@@ -911,8 +901,8 @@ A double click on a word selects that word.  'iskeyword' is used to specify
 which characters are included in a word.  A double click on a character
 that has a match selects until that match (like using "v%").  If the match is
 an #if/#else/#endif block, the selection becomes linewise.
-For xterm the time for double clicking can be set with the 'mousetime' option.
-For the other systems this time is defined outside of Vim.
+For MS-Windows and xterm the time for double clicking can be set with the
+'mousetime' option.  For the other systems this time is defined outside of Vim.
 An example, for using a double click to jump to the tag under the cursor: >
 	:map <2-LeftMouse> :exe "tag ". expand("<cword>")<CR>
 

--- a/runtime/doc/usr_44.txt
+++ b/runtime/doc/usr_44.txt
@@ -673,20 +673,9 @@ syntax file, earlier in 'runtimepath' was already loaded: >
 	  finish
 	endif
 
-To be compatible with Vim 5.8 use: >
-
-	if version < 600
-	  syntax clear
-	elseif exists("b:current_syntax")
-	  finish
-	endif
-
 Set "b:current_syntax" to the name of the syntax at the end.  Don't forget
 that included files do this too, you might have to reset "b:current_syntax" if
 you include two files.
-
-If you want your syntax file to work with Vim 5.x, add a check for v:version.
-Find an syntax file in the Vim 7.2 distribution for an example.
 
 Do not include anything that is a user preference.  Don't set 'tabstop',
 'expandtab', etc.  These belong in a filetype plugin.

--- a/runtime/doc/usr_90.txt
+++ b/runtime/doc/usr_90.txt
@@ -64,20 +64,11 @@ provide the fastest download:
 Or use the home site ftp.vim.org, if you think it's fast enough.  Go to the
 "unix" directory and you'll find a list of files there.  The version number is
 embedded in the file name.  You will want to get the most recent version.
-   You can get the files for Unix in two ways: One big archive that contains
-everything, or four smaller ones that each fit on a floppy disk.  For version
-6.1 the single big one is called:
+   You can get the files for Unix in one big archive that contains everything:
 
-	vim-6.1.tar.bz2 ~
+	vim-8.2.tar.bz2 ~
 
-You need the bzip2 program to uncompress it.  If you don't have it, get the
-four smaller files, which can be uncompressed with gzip.  For Vim 6.1 they are
-called:
-
-	vim-6.1-src1.tar.gz ~
-	vim-6.1-src2.tar.gz ~
-	vim-6.1-rt1.tar.gz ~
-	vim-6.1-rt2.tar.gz ~
+You need the bzip2 program to uncompress it.
 
 
 COMPILING
@@ -87,22 +78,19 @@ First create a top directory to work in, for example: >
 	mkdir ~/vim
 	cd ~/vim
 
-Then unpack the archives there.  If you have the one big archive, you unpack
-it like this: >
+Then unpack the archives there.  You can unpack it like this: >
 
-	bzip2 -d -c path/vim-6.1.tar.bz2 | tar xf -
+	tar xf path/vim-8.2.tar.bz2
 
-Change "path" to where you have downloaded the file. >
+If your tar command doesn't support bz2 directly: >
 
-	gzip -d -c path/vim-6.1-src1.tar.gz | tar xf -
-	gzip -d -c path/vim-6.1-src2.tar.gz | tar xf -
-	gzip -d -c path/vim-6.1-rt1.tar.gz | tar xf -
-	gzip -d -c path/vim-6.1-rt2.tar.gz | tar xf -
+	bzip2 -d -c path/vim-8.2.tar.bz2 | tar xf -
 
+Change "path" to where you have downloaded the file.
 If you are satisfied with getting the default features, and your environment
 is setup properly, you should be able to compile Vim with just this: >
 
-	cd vim61/src
+	cd vim82/src
 	make
 
 The make program will run configure and compile everything.  Further on we
@@ -231,9 +219,9 @@ provide the fastest download:
 Or use the home site ftp.vim.org, if you think it's fast enough.  Go to the
 "pc" directory and you'll find a list of files there.  The version number is
 embedded in the file name.  You will want to get the most recent version.
-We will use "61" here, which is version 6.1.
+We will use "82" here, which is version 8.2.
 
-	gvim61.exe		The self-installing archive.
+	gvim82.exe		The self-installing archive.
 
 This is all you need for the second method.  Just launch the executable, and
 follow the prompts.
@@ -241,30 +229,28 @@ follow the prompts.
 For the first method you must chose one of the binary archives.  These are
 available:
 
-	gvim61.zip		The normal MS-Windows GUI version.
-	gvim61ole.zip		The MS-Windows GUI version with OLE support.
+	gvim82.zip		The normal MS-Windows GUI version.
+	gvim82ole.zip		The MS-Windows GUI version with OLE support.
 				Uses more memory, supports interfacing with
 				other OLE applications.
-	vim61w32.zip		32 bit MS-Windows console version.  For use in
-				a Win NT/2000/XP console.  Does not work well
-				on Win 95/98.
+	vim82w32.zip		32 bit MS-Windows console version.
 
 You only need one of them.  Although you could install both a GUI and a
 console version.  You always need to get the archive with runtime files.
 
-	vim61rt.zip		The runtime files.
+	vim82rt.zip		The runtime files.
 
 Use your un-zip program to unpack the files.  For example, using the "unzip"
 program: >
 
 	cd c:\
-	unzip path\gvim61.zip
-	unzip path\vim61rt.zip
+	unzip path\gvim82.zip
+	unzip path\vim82rt.zip
 
-This will unpack the files in the directory "c:\vim\vim61".  If you already
+This will unpack the files in the directory "c:\vim\vim82".  If you already
 have a "vim" directory somewhere, you will want to move to the directory just
 above it.
-   Now change to the "vim\vim61" directory and run the install program: >
+   Now change to the "vim\vim82" directory and run the install program: >
 
 	install
 
@@ -277,8 +263,8 @@ unpacked them.
 In case you are not satisfied with the features included in the supplied
 binaries, you could try compiling Vim yourself.  Get the source archive from
 the same location as where the binaries are.  You need a compiler for which a
-makefile exists.  Microsoft Visual C works, but is expensive.  The free MinGW
-and Cygwin compilers can be used.  Check the file src/INSTALLpc.txt for hints.
+makefile exists.  Microsoft Visual C, MinGW and Cygwin compilers can be used.
+Check the file src/INSTALLpc.txt for hints.
 
 ==============================================================================
 *90.3*	Upgrading
@@ -298,7 +284,7 @@ about keeping the old version, running "make install" will work fine.  You can
 delete the old runtime files manually.  Just delete the directory with the
 version number in it and all files below it.  Example: >
 
-	rm -rf /usr/local/share/vim/vim58
+	rm -rf /usr/local/share/vim/vim74
 
 There are normally no changed files below this directory.  If you did change
 the "filetype.vim" file, for example, you better merge the changes into the
@@ -308,21 +294,21 @@ If you are careful and want to try out the new version for a while before
 switching to it, install the new version under another name.  You need to
 specify a configure argument.  For example: >
 
-	./configure --with-vim-name=vim6
+	./configure --with-vim-name=vim8
 
 Before running "make install", you could use "make -n install" to check that
 no valuable existing files are overwritten.
    When you finally decide to switch to the new version, all you need to do is
 to rename the binary to "vim".  For example: >
 
-	mv /usr/local/bin/vim6 /usr/local/bin/vim
+	mv /usr/local/bin/vim8 /usr/local/bin/vim
 
 
 MS-WINDOWS
 
 Upgrading is mostly equal to installing a new version.  Just unpack the files
 in the same place as the previous version.  A new directory will be created,
-e.g., "vim61", for the files of the new version.  Your runtime files, vimrc
+e.g., "vim82", for the files of the new version.  Your runtime files, vimrc
 file, viminfo, etc. will be left alone.
    If you want to run the new version next to the old one, you will have to do
 some handwork.  Don't run the install program, it will overwrite a few files
@@ -428,7 +414,7 @@ However, if you have deleted the original files or you used an archive that
 someone supplied, you can't do this.  Do delete the files manually, here is an
 example for when "/usr/local" was used as the root: >
 
-	rm -rf /usr/local/share/vim/vim61
+	rm -rf /usr/local/share/vim/vim82
 	rm /usr/local/bin/eview
 	rm /usr/local/bin/evim
 	rm /usr/local/bin/ex
@@ -467,7 +453,7 @@ MS-WINDOWS
 
 If you installed Vim with the self-installing archive you can run
 the "uninstall-gui" program located in the same directory as the other Vim
-programs, e.g. "c:\vim\vim61".  You can also launch it from the Start menu if
+programs, e.g. "c:\vim\vim82".  You can also launch it from the Start menu if
 installed the Vim entries there.  This will remove most of the files, menu
 entries and desktop shortcuts.  Some files may remain however, as they need a
 Windows restart before being deleted.
@@ -477,10 +463,10 @@ be careful.
 
 Else, if you installed Vim with the zip archives, the preferred way is to use
 the "uninstall" program.  You can find it in the same directory as the
-"install" program, e.g., "c:\vim\vim61".  This should also work from the usual
+"install" program, e.g., "c:\vim\vim82".  This should also work from the usual
 "install/remove software" page.
    However, this only removes the registry entries for Vim.  You have to
-delete the files yourself.  Simply select the directory "vim\vim61" and delete
+delete the files yourself.  Simply select the directory "vim\vim82" and delete
 it recursively.  There should be no files there that you changed, but you
 might want to check that first.
    The "vim" directory probably contains your vimrc file and other runtime

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -133,14 +133,10 @@ Support for different systems.
 	- All Unix systems (it works on all systems it was tested on, although
 	  the GUI and Perl interface may not work everywhere).
 	- Amiga (500, 1000, 1200, 2000, 3000, 4000, ...).
-	- MS-DOS in real-mode (no additional drivers required).
-	- In protected mode on Windows 3.1 and MS-DOS (DPMI driver required).
-	- Windows 95 and Windows NT, with support for long file names.
-	- OS/2 (needs emx.dll)
+	- MS-Windows
 	- VMS
 	- BeOS
 	- Macintosh
-	- Risc OS
 	- IBM OS/390
 	Note that on some systems features need to be disabled to reduce
 	resource usage.  For some outdated systems you need to use an older


### PR DESCRIPTION
* Update Vim version to 8.2 (or 82).
* Remove description about old Windows. (We have already dropped support
  for Windows 2000 or earlier.)
* Update some parts from #5397:
  - gui_w32.txt: "short form" means "MS-DOS form", not "MS-Windows form".
    BTW, it seems that it is not applicable to the recent Windows
    version.
  - insert.txt: add "On non-Win32 systems" back.
  - options.txt: remove 2k/XP.
  - printer.txt: add "previewer" back.
  - term.txt:
    - Remove about pc_term. It is for MS-DOS only.
    - `:mode` with argument doesn't work anymore.
    - Add "MS-Windows" back for 'mousetime'.
* options.txt:
  - Use cmd.exe instead of command.com.
  - Update the default value of 'shellpipe' on Windows.
* usr_44.txt: remove description about compatibility with Vim 5.  Such
  codes have been removed from runtime files.
* usr_90.txt:
  - We don't have separate source archives anymore.
  - Recent GNU tar automatically detects the archive type, so normally
    `tar xf filename` is enough.
  - MSVC is not expensive now.
* vi_diff.txt:
  - Remove MS-DOS, Windows 3.1/95, OS/2 and Risc OS.
  - No need to mention long file names nowadays.