### PR TITLE
[doc] Fix about modifyOtherKeys

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -200,14 +200,14 @@ CTRL-V		Insert next non-digit literally.  For special keys, the
 		is converted back to what it was without |modifyOtherKeys|,
 		unless the Shift key is also pressed.
 
-						*i_CTRL-SHIFT-V*
-CTRL-SHIFT-V	Works just like CTRL-V, unless |modifyOtherKeys| is active,
-		then it inserts the Escape sequence for a key with modifiers.
-
 						*i_CTRL-Q*
 CTRL-Q		Same as CTRL-V.
 		Note: Some terminal connections may eat CTRL-Q, it doesn't
 		work then.  It does work in the GUI.
+
+CTRL-SHIFT-V				*i_CTRL-SHIFT-V* *i_CTRL-SHIFT-Q*
+CTRL-SHIFT-Q	Works just like CTRL-V, unless |modifyOtherKeys| is active,
+		then it inserts the Escape sequence for a key with modifiers.
 
 CTRL-X		Enter CTRL-X mode.  This is a sub-mode where commands can
 		be given to complete words or scroll the window.  See

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -845,8 +845,9 @@ Without modifyOtherKeys <C-[> and <C-S-{> are indistinguishable from Esc.
 
 A known side effect effect is that in Insert mode the raw escape sequence is
 inserted after the CTRL-V key.  This can be used to check whether
-modifyOtherKeys is enabled: In Insert mode type CTRL-V CTRL-V, if you get
-one byte then modifyOtherKeys is off, if you get <1b>27;5;118~ then it is on.
+modifyOtherKeys is enabled: In Insert mode type CTRL-SHIFT-V CTRL-V, if you
+get one byte then modifyOtherKeys is off, if you get <1b>27;5;118~ then it is
+on.
 
 When the 'esckeys' option is off, then modifyOtherKeys will be disabled in
 Insert mode to avoid every key with a modifier causing Insert mode to end.


### PR DESCRIPTION
The behavior of i_CTRL-V has been changed by 8.1.2350, but the document
wasn't updated.  Also fix that `*i_CTRL-SHIFT-Q*` was missing.