### PR TITLE
implement reduce function

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2665,6 +2665,7 @@ range({expr} [, {max} [, {stride}]])
 readdir({dir} [, {expr}])	List	file names in {dir} selected by {expr}
 readfile({fname} [, {type} [, {max}]])
 				List	get list of lines from file {fname}
+reduce({list}, {func}, {init})	any	reduce {list} using {func} from {init}
 reg_executing()			String	get the executing register name
 reg_recording()			String	get the recording register name
 reltime([{start} [, {end}]])	List	get time value
@@ -7756,6 +7757,16 @@ readfile({fname} [, {type} [, {max}]])
 
 		Can also be used as a |method|: >
 			GetFileName()->readfile()
+
+reduce({list}, {func}, {init})				*reduce()*
+		Returns a value after reducing the {list} using {func},
+		starting with {init}.
+		Examples: >
+			echo reduce([1, 3, 5], { acc, val -> acc + val }, 1)
+			echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
+<
+		Can also be used as a |method|: >
+			[1, 2, 3]->reduce({ acc, val -> acc + val }, 1)
 
 reg_executing()						*reg_executing()*
 		Returns the single letter name of the register being executed.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2665,7 +2665,8 @@ range({expr} [, {max} [, {stride}]])
 readdir({dir} [, {expr}])	List	file names in {dir} selected by {expr}
 readfile({fname} [, {type} [, {max}]])
 				List	get list of lines from file {fname}
-reduce({list}, {func}, {init})	any	reduce {list} using {func} from {init}
+reduce({object}, {func}, {initial})
+				any	reduce {object} using {func} from {initial}
 reg_executing()			String	get the executing register name
 reg_recording()			String	get the recording register name
 reltime([{start} [, {end}]])	List	get time value
@@ -7758,12 +7759,13 @@ readfile({fname} [, {type} [, {max}]])
 		Can also be used as a |method|: >
 			GetFileName()->readfile()
 
-reduce({list}, {func}, {init})				*reduce()*
-		Returns a value after reducing the {list} using {func},
-		starting with {init}.
+reduce({object}, {func}, {initial})			*reduce()*
+		Returns a value after reducing the |List| or |Blob| {object}
+		using {func}, starting with {initial}.
 		Examples: >
 			echo reduce([1, 3, 5], { acc, val -> acc + val }, 1)
 			echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
+			echo reduce(0z1122, { acc, val -> 2 * acc + val }, 1)
 <
 		Can also be used as a |method|: >
 			[1, 2, 3]->reduce({ acc, val -> acc + val }, 1)

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2665,7 +2665,7 @@ range({expr} [, {max} [, {stride}]])
 readdir({dir} [, {expr}])	List	file names in {dir} selected by {expr}
 readfile({fname} [, {type} [, {max}]])
 				List	get list of lines from file {fname}
-reduce({object}, {func}, {initial})
+reduce({object}, {func} [, {initial}])
 				any	reduce {object} using {func} from {initial}
 reg_executing()			String	get the executing register name
 reg_recording()			String	get the recording register name
@@ -7759,13 +7759,16 @@ readfile({fname} [, {type} [, {max}]])
 		Can also be used as a |method|: >
 			GetFileName()->readfile()
 
-reduce({object}, {func}, {initial})			*reduce()*
+reduce({object}, {func} [, {initial}])			*reduce()* *E998*
 		Returns a value after reducing the |List| or |Blob| {object}
-		using {func}, starting with {initial}.
+		using {func}, starting with {initial}. The {func} is called
+		with two arguments; accumulator and current element. When
+		{initial} is omitted, the first element is used as the initial
+		value.
 		Examples: >
 			echo reduce([1, 3, 5], { acc, val -> acc + val }, 1)
 			echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
-			echo reduce(0z1122, { acc, val -> 2 * acc + val }, 1)
+			echo reduce(0z1122, { acc, val -> 2 * acc + val })
 <
 		Can also be used as a |method|: >
 			[1, 2, 3]->reduce({ acc, val -> acc + val }, 1)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -718,6 +718,7 @@ static funcentry_T global_functions[] =
     {"range",		1, 3, FEARG_1,	  ret_list_number, f_range},
     {"readdir",		1, 2, FEARG_1,	  ret_list_string, f_readdir},
     {"readfile",	1, 3, FEARG_1,	  ret_any,	f_readfile},
+    {"reduce",		3, 3, FEARG_1,	  ret_any,	f_reduce},
     {"reg_executing",	0, 0, 0,	  ret_string,	f_reg_executing},
     {"reg_recording",	0, 0, 0,	  ret_string,	f_reg_recording},
     {"reltime",		0, 2, FEARG_1,	  ret_list_any,	f_reltime},

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -718,7 +718,7 @@ static funcentry_T global_functions[] =
     {"range",		1, 3, FEARG_1,	  ret_list_number, f_range},
     {"readdir",		1, 2, FEARG_1,	  ret_list_string, f_readdir},
     {"readfile",	1, 3, FEARG_1,	  ret_any,	f_readfile},
-    {"reduce",		3, 3, FEARG_1,	  ret_any,	f_reduce},
+    {"reduce",		2, 3, FEARG_1,	  ret_any,	f_reduce},
     {"reg_executing",	0, 0, 0,	  ret_string,	f_reg_executing},
     {"reg_recording",	0, 0, 0,	  ret_string,	f_reg_recording},
     {"reltime",		0, 2, FEARG_1,	  ret_list_any,	f_reltime},

--- a/src/globals.h
+++ b/src/globals.h
@@ -1653,6 +1653,7 @@ EXTERN char e_inval_string[]	INIT(= N_("E908: using an invalid value as a String
 EXTERN char e_const_option[]	INIT(= N_("E996: Cannot lock an option"));
 EXTERN char e_unknown_option[]	INIT(= N_("E113: Unknown option: %s"));
 EXTERN char e_letunexp[]	INIT(= N_("E18: Unexpected characters in :let"));
+EXTERN char e_reduceempty[]	INIT(= N_("E998: Reduce of an empty %s with no initial value"));
 #endif
 #ifdef FEAT_QUICKFIX
 EXTERN char e_readerrf[]	INIT(= N_("E47: Error while reading errorfile"));

--- a/src/list.c
+++ b/src/list.c
@@ -2294,7 +2294,7 @@ f_reverse(typval_T *argvars, typval_T *rettv)
 }
 
 /*
- * "reduce(list, { accumlator, element -> value }, initial)" function
+ * "reduce(list, { accumlator, element -> value } [, initial])" function
  */
     void
 f_reduce(typval_T *argvars, typval_T *rettv)
@@ -2331,11 +2331,26 @@ f_reduce(typval_T *argvars, typval_T *rettv)
 	list_T	*l = argvars[0].vval.v_list;
 	listitem_T	*li;
 
-	accum = argvars[2];
+	if (argvars[2].v_type == VAR_UNKNOWN)
+	{
+	    if (l == NULL || l->lv_first == NULL)
+	    {
+		semsg(_(e_reduceempty), "List");
+		return;
+	    }
+	    accum = l->lv_first->li_tv;
+	    li = l->lv_first->li_next;
+	}
+	else
+	{
+	    accum = argvars[2];
+	    li = l->lv_first;
+	}
+
 	copy_tv(&accum, rettv);
 	if (l != NULL)
 	{
-	    for (li = l->lv_first; li != NULL; li = li->li_next)
+	    for ( ; li != NULL; li = li->li_next)
 	    {
 		argv[0] = accum;
 		argv[1] = li->li_tv;
@@ -2350,11 +2365,27 @@ f_reduce(typval_T *argvars, typval_T *rettv)
 	blob_T	*b = argvars[0].vval.v_blob;
 	int 	i;
 
-	accum = argvars[2];
+	if (argvars[2].v_type == VAR_UNKNOWN)
+	{
+	    if (b == NULL || b->bv_ga.ga_len == 0)
+	    {
+		semsg(_(e_reduceempty), "Blob");
+		return;
+	    }
+	    accum.v_type = VAR_NUMBER;
+	    accum.vval.v_number = blob_get(b, 0);
+	    i = 1;
+	}
+	else
+	{
+	    accum = argvars[2];
+	    i = 0;
+	}
+
 	copy_tv(&accum, rettv);
 	if (b != NULL)
 	{
-	    for (i = 0; i < b->bv_ga.ga_len; i++)
+	    for ( ; i < b->bv_ga.ga_len; i++)
 	    {
 		argv[0] = accum;
 		argv[1].v_type = VAR_NUMBER;

--- a/src/list.c
+++ b/src/list.c
@@ -2331,6 +2331,7 @@ f_reduce(typval_T *argvars, typval_T *rettv)
 	list_T	*l = argvars[0].vval.v_list;
 	listitem_T	*li = NULL;
 
+	range_list_materialize(l);
 	if (argvars[2].v_type == VAR_UNKNOWN)
 	{
 	    if (l == NULL || l->lv_first == NULL)

--- a/src/list.c
+++ b/src/list.c
@@ -2329,7 +2329,7 @@ f_reduce(typval_T *argvars, typval_T *rettv)
     if (argvars[0].v_type == VAR_LIST)
     {
 	list_T	*l = argvars[0].vval.v_list;
-	listitem_T	*li;
+	listitem_T	*li = NULL;
 
 	if (argvars[2].v_type == VAR_UNKNOWN)
 	{
@@ -2344,7 +2344,8 @@ f_reduce(typval_T *argvars, typval_T *rettv)
 	else
 	{
 	    accum = argvars[2];
-	    li = l->lv_first;
+	    if (l != NULL)
+		li = l->lv_first;
 	}
 
 	copy_tv(&accum, rettv);

--- a/src/proto/list.pro
+++ b/src/proto/list.pro
@@ -53,4 +53,5 @@ void f_extend(typval_T *argvars, typval_T *rettv);
 void f_insert(typval_T *argvars, typval_T *rettv);
 void f_remove(typval_T *argvars, typval_T *rettv);
 void f_reverse(typval_T *argvars, typval_T *rettv);
+void f_reduce(typval_T *argvars, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -621,6 +621,8 @@ func Test_reduce()
   call assert_equal(2 * (2 * ((2 * 1) + 2) + 3) + 4, reduce([2, 3, 4], { acc, val -> 2 * acc + val }, 1))
   call assert_equal('a x y z', ['x', 'y', 'z']->reduce({ acc, val -> acc .. ' ' .. val}, 'a'))
   call assert_equal(#{ x: 1, y: 1, z: 1 }, ['x', 'y', 'z']->reduce({ acc, val -> extend(acc, { val: 1 }) }, {}))
+  call assert_equal([0, 1, 2, 3], reduce([1, 2, 3], function('add'), [0]))
+  call assert_equal(42, reduce(['x', 'y', 'z'], function('get'), #{ x: #{ y: #{ z: 42 } } }))
 
   call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E714:')
   call assert_fails("call reduce(0, { acc, val -> acc + val }, 1)", 'E714:')

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -629,7 +629,7 @@ func Test_reduce()
 
   call assert_equal(1, reduce([1], { acc, val -> acc + val }))
   call assert_equal('x y z', reduce(['x', 'y', 'z'], { acc, val -> acc .. ' ' .. val }))
-  call assert_equal(2 * (2 * ((2 * 1) + 2) + 3) + 4, reduce([1, 2, 3, 4], { acc, val -> 2 * acc + val }))
+  call assert_equal(120, range(1, 5)->reduce({ acc, val -> acc * val }))
   call assert_fails("call reduce([], { acc, val -> acc + val })", 'E998: Reduce of an empty List with no initial value')
 
   call assert_equal(1, reduce(0z, { acc, val -> acc + val }, 1))

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -614,7 +614,7 @@ func Test_reverse_sort_uniq()
   call assert_fails('call reverse("")', 'E899:')
 endfunc
 
-" reduce a list
+" reduce a list or a blob
 func Test_reduce()
   call assert_equal(1, reduce([], { acc, val -> acc + val }, 1))
   call assert_equal(10, reduce([1, 3, 5], { acc, val -> acc + val }, 1))
@@ -622,11 +622,18 @@ func Test_reduce()
   call assert_equal('a x y z', ['x', 'y', 'z']->reduce({ acc, val -> acc .. ' ' .. val}, 'a'))
   call assert_equal(#{ x: 1, y: 1, z: 1 }, ['x', 'y', 'z']->reduce({ acc, val -> extend(acc, { val: 1 }) }, {}))
   call assert_equal([0, 1, 2, 3], reduce([1, 2, 3], function('add'), [0]))
-  call assert_equal(42, reduce(['x', 'y', 'z'], function('get'), #{ x: #{ y: #{ z: 42 } } }))
 
-  call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E714:')
-  call assert_fails("call reduce(0, { acc, val -> acc + val }, 1)", 'E714:')
-  call assert_fails("call reduce('', { acc, val -> acc + val }, 1)", 'E714:')
+  let l = ['x', 'y', 'z']
+  call assert_equal(42, reduce(l, function('get'), #{ x: #{ y: #{ z: 42 } } }))
+  call assert_equal(['x', 'y', 'z'], l)
+
+  call assert_equal(1, reduce(0z, { acc, val -> acc + val }, 1))
+  call assert_equal(1 + 0xaa + 0xbb + 0xcc, reduce(0zaabbcc, { acc, val -> acc + val }, 1))
+  call assert_equal(2 * (2 * 1 + 0xff) + 0xff, 0zffff->reduce({ acc, val -> 2 * acc + val }, 1))
+
+  call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E897:')
+  call assert_fails("call reduce(0, { acc, val -> acc + val }, 1)", 'E897:')
+  call assert_fails("call reduce('', { acc, val -> acc + val }, 1)", 'E897:')
 endfunc
 
 " splitting a string to a List

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -627,9 +627,18 @@ func Test_reduce()
   call assert_equal(42, reduce(l, function('get'), #{ x: #{ y: #{ z: 42 } } }))
   call assert_equal(['x', 'y', 'z'], l)
 
+  call assert_equal(1, reduce([1], { acc, val -> acc + val }))
+  call assert_equal('x y z', reduce(['x', 'y', 'z'], { acc, val -> acc .. ' ' .. val }))
+  call assert_equal(2 * (2 * ((2 * 1) + 2) + 3) + 4, reduce([1, 2, 3, 4], { acc, val -> 2 * acc + val }))
+  call assert_fails("call reduce([], { acc, val -> acc + val })", 'E998: Reduce of an empty List with no initial value')
+
   call assert_equal(1, reduce(0z, { acc, val -> acc + val }, 1))
   call assert_equal(1 + 0xaa + 0xbb + 0xcc, reduce(0zaabbcc, { acc, val -> acc + val }, 1))
   call assert_equal(2 * (2 * 1 + 0xff) + 0xff, 0zffff->reduce({ acc, val -> 2 * acc + val }, 1))
+
+  call assert_equal(0xff, reduce(0zff, { acc, val -> acc + val }))
+  call assert_equal(2 * (2 * 0xff + 0xff) + 0xff, reduce(0zffffff, { acc, val -> 2 * acc + val }))
+  call assert_fails("call reduce(0z, { acc, val -> acc + val })", 'E998: Reduce of an empty Blob with no initial value')
 
   call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E897:')
   call assert_fails("call reduce(0, { acc, val -> acc + val }, 1)", 'E897:')

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -614,6 +614,19 @@ func Test_reverse_sort_uniq()
   call assert_fails('call reverse("")', 'E899:')
 endfunc
 
+" reduce a list
+func Test_reduce()
+  call assert_equal(1, reduce([], { acc, val -> acc + val }, 1))
+  call assert_equal(10, reduce([1, 3, 5], { acc, val -> acc + val }, 1))
+  call assert_equal(2 * (2 * ((2 * 1) + 2) + 3) + 4, reduce([2, 3, 4], { acc, val -> 2 * acc + val }, 1))
+  call assert_equal('a x y z', ['x', 'y', 'z']->reduce({ acc, val -> acc .. ' ' .. val}, 'a'))
+  call assert_equal(#{ x: 1, y: 1, z: 1 }, ['x', 'y', 'z']->reduce({ acc, val -> extend(acc, { val: 1 }) }, {}))
+
+  call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E714:')
+  call assert_fails("call reduce(0, { acc, val -> acc + val }, 1)", 'E714:')
+  call assert_fails("call reduce('', { acc, val -> acc + val }, 1)", 'E714:')
+endfunc
+
 " splitting a string to a List
 func Test_str_split()
   call assert_equal(['aa', 'bb'], split('  aa  bb '))

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -633,11 +633,11 @@ func Test_reduce()
   call assert_fails("call reduce([], { acc, val -> acc + val })", 'E998: Reduce of an empty List with no initial value')
 
   call assert_equal(1, reduce(0z, { acc, val -> acc + val }, 1))
-  call assert_equal(1 + 0xaa + 0xbb + 0xcc, reduce(0zaabbcc, { acc, val -> acc + val }, 1))
-  call assert_equal(2 * (2 * 1 + 0xff) + 0xff, 0zffff->reduce({ acc, val -> 2 * acc + val }, 1))
+  call assert_equal(1 + 0xaf + 0xbf + 0xcf, reduce(0zAFBFCF, { acc, val -> acc + val }, 1))
+  call assert_equal(2 * (2 * 1 + 0xaf) + 0xbf, 0zAFBF->reduce({ acc, val -> 2 * acc + val }, 1))
 
   call assert_equal(0xff, reduce(0zff, { acc, val -> acc + val }))
-  call assert_equal(2 * (2 * 0xff + 0xff) + 0xff, reduce(0zffffff, { acc, val -> 2 * acc + val }))
+  call assert_equal(2 * (2 * 0xaf + 0xbf) + 0xcf, reduce(0zAFBFCF, { acc, val -> 2 * acc + val }))
   call assert_fails("call reduce(0z, { acc, val -> acc + val })", 'E998: Reduce of an empty Blob with no initial value')
 
   call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E897:')


### PR DESCRIPTION
## Summary
This pull request introduces `reduce` function for list and blob.

## Why
I think list reducing (folding) is one of the important operations in functional programming style (map, filter and reduce is the top three important operations in my opinion). Many calculation using for loop can be rewritten using reducing. Statistical calculations (sum, product, length, minimum, maximum), concatenation, list and object construction. Reducing is also used for collecting the calculation results; the number of successful operation, or the list of error messages.

## Interface
```vim
reduce({object}, {func} [, {initial}])
```

- `{object}`: can be List or Blob. Throw exception for other types.
- `{func}`: this function is called with two arguments, `accumulator` and `element`
- `{initial}`: the initial value for reducing

For a `list` of size 3,
```vim
reduce(list, f, init) = f(f(f(init, list[0]), list[1]), list[2])
reduce(list, f) = f(f(list[0], list[1]), list[2])
```

The function is sometimes called as `fold`, but Vim has fold for different operation so I chose `reduce`.

### Examples
```vim
:echo reduce([1, 3, 5], { acc, val -> acc + val }, 1)
10 " 1 + 1 + 3 + 5
:echo reduce([1, 2, 3], { acc, val -> acc + val })
6 " 1 + 2 + 3
:echo ['x', 'y', 'z']->reduce({ acc, val -> acc .. ' ' .. val}, 'a')
a x y z
:echo reduce(['x', 'y', 'z'], function('get'), #{ x: #{ y: #{ z: 42 } } })
42
:echo 0zAFBFCF->reduce({ acc, val -> acc + val }, 1)
574 " 1 + 0xaf + 0xbf + 0xcf
:echo range(1, 5)->reduce({ acc, val -> acc * val })
120 " 1 * 2 * 3 * 4 * 5
```
### Reduce of an empty list/blob with no initial value
The initial value can be omitted (like JavaScript or Python), but when the first argument is an empty list (or blob), an exception is thrown.
```vim
:echo reduce([], { acc, val -> acc + val })
E998: Reduce of an empty List with no initial value
0
:echo reduce(0z, { acc, val -> acc + val })
E998: Reduce of an empty Blob with no initial value
0
```

## Performance comparison
|(in seconds)|1st|2nd|3rd|4th|5th|avg|
|--|--|--|--|--|--|--|
|Vim script|3.374393|3.456406|3.458587|3.675047|3.532724|3.499431|
|Native (this p/r)|1.520092|1.572436|1.487109|1.534966|1.518574|1.526635 (-56.4%)|


```vim
function! Reduce(xs, f, i) abort
  let s = a:i
  for x in a:xs
    let s = a:f(s, x)
  endfor
  return s
endfunction

let n = 1000000
let r = range(n)

for i in range(5)
  let l = reltime()
  echo Reduce(r, { acc, val -> acc + val }, 0)
  echo reltimefloat(reltime(l))

  let l = reltime()
  echo reduce(r, { acc, val -> acc + val }, 0)
  echo reltimefloat(reltime(l))
endfor
```

## Future work
- Do we need `reduce_right` as well? Reducing from right is not that important than it is in lazy evaluation languages. Actually some languages does not provide right-to-left folding while they provide left-to-right folding; Python, Rust. Maybe we can use `reverse(list)->reduce(...)`.
- Do we need the dual operation, `unfold`? Unfolding is significantly useful for list construction (as per my experience of Haskell), but does not seem that popular, as JavaScript does not have this. Also there's difficulty in the interface, how to tell the termination (Haskell has Maybe).

## Comparison to other languages
I listed reducing functions from some languages for reference.

|language|syntax|omit initial value|empty array without initial value|right to left fold|
|--|--|--|--|--|
|Vim script (this p/r)|`reduce(list, { acc, val -> acc + val }, 1)`<br>`list->reduce({ acc, val -> acc + val }, 1)`|ok|Exception: `Reduce of an empty List with no initial value`|_not provided_|
|JavaScript|`array.reduce((acc, val) => acc + val, 1)`|ok|Exception: `Reduce of empty array with no initial value`|`reduceRight`|
|Python|`reduce(lambda x, y: x + y, array, 1)`<br>(`from functools import reduce`)|ok|Exception: `reduce() of empty sequence with no initial value`|_not provided_|
|Perl|`reduce { $a + $b } 1 @array` <br>(`use List::Util qw(reduce)`)|ok|`undef`|_not provided_|
|Scala|`list.foldLeft(1){(acc, v) => acc + v}`<br>`list.reduceLeft{(acc, v) => acc + v}`|ok (different function name)|Exception: `empty.reduceLeft`|`foldRight`|
|Rust|`array.fold(1, \|acc, val\| acc + val)`|_not provided_|_not provided_|_not provided_|
|Haskell|`foldl 1 (+) list`|`foldl1` (different function name)|Exception: `foldl1: empty structure`|`foldr`, `foldr1`|

ref: https://en.wikipedia.org/wiki/Fold_(higher-order_function)