### PR TITLE
fix map() and filter() for blob

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -1711,11 +1711,12 @@ filter_map(typval_T *argvars, typval_T *rettv, int map)
 		{
 		    char_u *p = (char_u *)argvars[0].vval.v_blob->bv_ga.ga_data;
 
-		    mch_memmove(p + idx, p + i + 1,
+		    mch_memmove(p + i, p + i + 1,
 					      (size_t)b->bv_ga.ga_len - i - 1);
 		    --b->bv_ga.ga_len;
 		    --i;
 		}
+		++idx;
 	    }
 	}
 	else // argvars[0].v_type == VAR_LIST

--- a/src/list.c
+++ b/src/list.c
@@ -1705,9 +1705,9 @@ filter_map(typval_T *argvars, typval_T *rettv, int map)
 		    emsg(_(e_invalblob));
 		    break;
 		}
-		tv.v_type = VAR_NUMBER;
-		blob_set(b, i, tv.vval.v_number);
-		if (!map && rem)
+		if (map)
+		    blob_set(b, i, tv.vval.v_number);
+		else if (rem)
 		{
 		    char_u *p = (char_u *)argvars[0].vval.v_blob->bv_ga.ga_data;
 

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -260,18 +260,22 @@ endfunc
 
 " filter() item in blob
 func Test_blob_filter()
-  let b = 0zDEADBEEF
-  call filter(b, 'v:val != 0xEF')
-  call assert_equal(0zDEADBE, b)
+  call assert_equal(0z, filter(0zDEADBEEF, '0'))
+  call assert_equal(0zADBEEF, filter(0zDEADBEEF, 'v:val != 0xDE'))
+  call assert_equal(0zDEADEF, filter(0zDEADBEEF, 'v:val != 0xBE'))
+  call assert_equal(0zDEADBE, filter(0zDEADBEEF, 'v:val != 0xEF'))
+  call assert_equal(0zDEADBEEF, filter(0zDEADBEEF, '1'))
+  call assert_equal(0z01030103, filter(0z010203010203, 'v:val != 0x02'))
+  call assert_equal(0zADEF, filter(0zDEADBEEF, 'v:key % 2'))
 endfunc
 
 " map() item in blob
 func Test_blob_map()
-  let b = 0zDEADBEEF
-  call map(b, 'v:val + 1')
-  call assert_equal(0zDFAEBFF0, b)
+  call assert_equal(0zDFAEBFF0, map(0zDEADBEEF, 'v:val + 1'))
+  call assert_equal(0z00010203, map(0zDEADBEEF, 'v:key'))
+  call assert_equal(0zDEAEC0F2, map(0zDEADBEEF, 'v:key + v:val'))
 
-  call assert_fails("call map(b, '[9]')", 'E978:')
+  call assert_fails("call map(0z00, '[9]')", 'E978:')
 endfunc
 
 func Test_blob_index()


### PR DESCRIPTION
`map` and `filter` against blob is broken.
```vim
:echo map(0zDEADBEEF, 'v:key')
0z00000000 " should be 0z00010203
:echo filter(0z010203010203, 'v:val != 0x02')
0z0302 " should be 0z01030103
```
