### PR TITLE
Add bufmode() function.

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2341,6 +2341,8 @@ bufexists({expr})		Number	|TRUE| if buffer {expr} exists
 buflisted({expr})		Number	|TRUE| if buffer {expr} is listed
 bufload({expr})			Number	load buffer {expr} if not loaded yet
 bufloaded({expr})		Number	|TRUE| if buffer {expr} is loaded
+bufmode([{expr} [, {tostring} [, {raw}]]])
+				Number or String  File mode of buffer {expr}
 bufname([{expr}])		String	Name of the buffer {expr}
 bufnr([{expr} [, {create}]])	Number	Number of the buffer {expr}
 bufwinid({expr})		Number	window ID of buffer {expr}
@@ -3238,6 +3240,25 @@ bufloaded({expr})					*bufloaded()*
 
 		Can also be used as a |method|: >
 			let loaded = 'somename'->bufloaded()
+
+bufmode([{expr} [, {tostring} [, {raw}]]])		*bufmode()*
+		The result is the file mode of the buffer {expr}.
+		If {tostring} is 1, the result is formatted as octal and
+		returned.
+		If {raw} is 1, the result includes the high bits returned by
+		the stat() system call that indicate file type.
+
+		Examples: >
+		    if bufmode() & 02
+			echomsg "File is world-writable."
+		    endif
+
+		    let &stl = "%<%f #%n %{'['.bufmode('', 1)}]%w%q%y%m%r " .
+			     \ "%=%-14.(%l,%c%V%) %P"
+<
+		Can also be used as a |method|: >
+			GetBufname()->bufmode()
+<
 
 bufname([{expr}])					*bufname()*
 		The result is the name of a buffer, as it is displayed by the

--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -344,6 +344,52 @@ f_bufloaded(typval_T *argvars, typval_T *rettv)
 }
 
 /*
+ * "bufmode(expr)" function
+ */
+    void
+f_bufmode(typval_T *argvars, typval_T *rettv)
+{
+    buf_T *buf;
+    int mode;
+    char_u formatted[8];
+    int show_raw = FALSE;
+    int to_string = FALSE;
+
+    if (argvars[0].v_type == VAR_UNKNOWN) {
+        buf = curbuf;
+    } else {
+        /* Issue type error if not a Number or String. */
+        tv_get_number(&argvars[0]);
+
+        emsg_off++;
+        buf = tv_get_buf(&argvars[0], FALSE);
+        emsg_off--;
+    }
+
+    if (argvars[1].v_type != VAR_UNKNOWN) {
+        to_string = tv_get_number_chk(&argvars[1], NULL);
+    }
+
+    if (argvars[2].v_type != VAR_UNKNOWN) {
+        show_raw = tv_get_number_chk(&argvars[2], NULL);
+    }
+
+    if (buf == NULL) {
+        rettv->vval.v_number = -1;
+    } else {
+        mode = show_raw ? buf->b_orig_mode :
+                          buf->b_orig_mode & 07777;
+        if (to_string) {
+            snprintf(formatted, sizeof(formatted), "%#o", mode);
+            rettv->v_type = VAR_STRING;
+            rettv->vval.v_string = vim_strsave(formatted);
+        } else {
+            rettv->vval.v_number = mode;
+        }
+    }
+}
+
+/*
  * "bufname(expr)" function
  */
     void

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -351,6 +351,7 @@ static funcentry_T global_functions[] =
     {"buflisted",	1, 1, FEARG_1,	  f_buflisted},
     {"bufload",		1, 1, FEARG_1,	  f_bufload},
     {"bufloaded",	1, 1, FEARG_1,	  f_bufloaded},
+    {"bufmode",		0, 3, FEARG_1,	  f_bufmode},
     {"bufname",		0, 1, FEARG_1,	  f_bufname},
     {"bufnr",		0, 2, FEARG_1,	  f_bufnr},
     {"bufwinid",	1, 1, FEARG_1,	  f_bufwinid},

--- a/src/proto/evalbuffer.pro
+++ b/src/proto/evalbuffer.pro
@@ -9,6 +9,7 @@ void f_bufexists(typval_T *argvars, typval_T *rettv);
 void f_buflisted(typval_T *argvars, typval_T *rettv);
 void f_bufload(typval_T *argvars, typval_T *rettv);
 void f_bufloaded(typval_T *argvars, typval_T *rettv);
+void f_bufmode(typval_T *argvars, typval_T *rettv);
 void f_bufname(typval_T *argvars, typval_T *rettv);
 void f_bufnr(typval_T *argvars, typval_T *rettv);
 void f_bufwinid(typval_T *argvars, typval_T *rettv);

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -4,6 +4,7 @@
 source test_backup.vim
 source test_behave.vim
 source test_bufline.vim
+source test_bufmode.vim
 source test_cd.vim
 source test_changedtick.vim
 source test_compiler.vim

--- a/src/testdir/test_bufmode.vim
+++ b/src/testdir/test_bufmode.vim
@@ -1,0 +1,40 @@
+" Test getting file mode of current buffer.
+
+func Test_bufmode()
+    " The mode of an unwritten buffer should be 0.
+    call assert_equal(0, bufmode())
+
+    " Using an invalid type for bufname ought to throw an exception.
+    try
+        call bufmode([])
+        call assert_report("should have thrown E745")
+    catch
+        call assert_exception("E745:")
+    endtry
+
+    " The mode of a file buffer should match its file on disk.
+    call writefile(["line"], "Xtest1")
+    call writefile(["line"], "Xtest2")
+    call setfperm("Xtest1", "rw-------")
+    call setfperm("Xtest2", "rwx--xr--")
+    e Xtest1
+    call assert_equal(0600, bufmode())
+    e Xtest2
+    call assert_equal(0714, bufmode())
+
+    " Mode of a different buffer.
+    call assert_equal(0600, bufmode("#"))
+
+    " Mode of the current buffer without masking.
+    call assert_equal(0100714, bufmode("%", 0, 1))
+
+    " Mode of a buffer formatted.
+    call assert_equal("0714", bufmode("%", 1, 0))
+
+    " Mode of a buffer unmasked and formatted.
+    call assert_equal("0100714", bufmode("%", 1, 1))
+
+    %bwipe!
+    call delete("Xtest1")
+    call delete("Xtest2")
+endfunc


### PR DESCRIPTION
Vim keeps track of the file mode of each buffer. It would be nice to be able to access that directly, rather than calling `getfperm({file})` and necessitating a redundant `stat`. This change adds a function to access the file mode of a given buffer (defaulting to the current buffer), with optional flags to format the number as octal (*e.g.*, for showing in the status bar) and to include the file type bits returned by `stat`.