### PR TITLE
check channel feature availability in a test

### DIFF
--- a/src/testdir/test_source.vim
+++ b/src/testdir/test_source.vim
@@ -1,4 +1,5 @@
 " Tests for the :source command.
+source check.vim
 
 func Test_source_autocmd()
   call writefile([
@@ -50,6 +51,7 @@ endfunc
 " When deleting a file and immediately creating a new one the inode may be
 " recycled.  Vim should not recognize it as the same script.
 func Test_different_script()
+  CheckFeature channel
   call ch_logfile('logfile', 'w')
   call writefile(['let s:var = "asdf"'], 'XoneScript')
   source XoneScript


### PR DESCRIPTION
The patch 8.2.0132 introduced a test which fails with feature=normal (see https://ci.appveyor.com/project/chrisbra/vim/builds/30219167/job/wmrv8pju4xf4m9by).