### PR TITLE
Fix memory leak

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -5818,9 +5818,9 @@ job_start(
     char_u	*cmd = NULL;
     char	**argv = NULL;
     int		argc = 0;
+    int		i;
 #if defined(UNIX)
 # define USE_ARGV
-    int		i;
 #else
     garray_T	ga;
 #endif
@@ -5994,7 +5994,11 @@ theend:
     vim_free(ga.ga_data);
 #endif
     if (argv != job->jv_argv)
+    {
+	for (i = 0; argv[i] != NULL; i++)
+	    vim_free(argv[i]);
 	vim_free(argv);
+    }
     free_job_options(&opt);
     return job;
 }


### PR DESCRIPTION
On Ubuntu 18.04.3, ASAN reports memory leak.

Repro step:

* Start Vim and execute `job_start()` with invalid argument and quit

```
$ vim --clean

:let g:job = job_start([''])
E474: Invalid argument

:q!
```

then, ASAN reports

```
Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7f3fc6f9cb50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x56175291ce88 in lalloc /home/user/vim/src/misc2.c:925
    #2 0x56175291cc8d in alloc /home/user/vim/src/misc2.c:828
    #3 0x56175291d0ad in vim_strsave /home/user/vim/src/misc2.c:1277
    #4 0x5617529270d7 in build_argv_from_list /home/user/vim/src/misc2.c:4444
    #5 0x561752c814e2 in job_start /home/user/vim/src/channel.c:5942
    #6 0x561752c8438f in f_job_start /home/user/vim/src/channel.c:6594
    #7 0x561752780dc0 in call_internal_func /home/user/vim/src/evalfunc.c:986
    #8 0x561752be3795 in call_func /home/user/vim/src/userfunc.c:1654
    #9 0x561752bdd6d0 in get_func_tv /home/user/vim/src/userfunc.c:498
    #10 0x561752764289 in eval_func /home/user/vim/src/eval.c:1695
    #11 0x561752768c96 in eval7 /home/user/vim/src/eval.c:2735
    #12 0x561752766f8c in eval6 /home/user/vim/src/eval.c:2331
    #13 0x561752765ffc in eval5 /home/user/vim/src/eval.c:2122
    #14 0x56175276576b in eval4 /home/user/vim/src/eval.c:2007
    #15 0x561752765309 in eval3 /home/user/vim/src/eval.c:1928
    #16 0x561752764e67 in eval2 /home/user/vim/src/eval.c:1860
    #17 0x5617527648f8 in eval1 /home/user/vim/src/eval.c:1788
    #18 0x561752764608 in eval0 /home/user/vim/src/eval.c:1746
    #19 0x5617527a89b0 in ex_let_const /home/user/vim/src/evalvars.c:776
    #20 0x5617527a7d12 in ex_let /home/user/vim/src/evalvars.c:676
    #21 0x5617527ef6fb in do_one_cmd /home/user/vim/src/ex_docmd.c:2482
    #22 0x5617527e682d in do_cmdline /home/user/vim/src/ex_docmd.c:975
    #23 0x56175296ae80 in nv_colon /home/user/vim/src/normal.c:3318
    #24 0x56175295d9da in normal_cmd /home/user/vim/src/normal.c:1071
    #25 0x561752ca88c5 in main_loop /home/user/vim/src/main.c:1511
    #26 0x561752ca7676 in vim_main2 /home/user/vim/src/main.c:901
    #27 0x561752ca6d56 in main /home/user/vim/src/main.c:444
    #28 0x7f3fc6110b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 1 byte(s) leaked in 1 allocation(s).
```