### PR TITLE
Fix: Crash when do `win_execute(id, 'close')` just after `tabedit`

### DIFF
--- a/src/testdir/test_winbuf_close.vim
+++ b/src/testdir/test_winbuf_close.vim
@@ -160,7 +160,7 @@ func Test_winfixwidth_on_close()
 endfunction
 
 " Test that 'winfixheight' will be respected even there is non-leaf frame
-fun! Test_winfixheight_non_leaf_frame()
+func Test_winfixheight_non_leaf_frame()
   vsplit
   botright 11new
   let l:wid = win_getid()
@@ -173,7 +173,7 @@ fun! Test_winfixheight_non_leaf_frame()
 endf
 
 " Test that 'winfixwidth' will be respected even there is non-leaf frame
-fun! Test_winfixwidth_non_leaf_frame()
+func Test_winfixwidth_non_leaf_frame()
   split
   topleft 11vnew
   let l:wid = win_getid()
@@ -184,3 +184,13 @@ fun! Test_winfixwidth_non_leaf_frame()
   call assert_equal(11, winwidth(l:wid))
   %bwipe!
 endf
+
+func Test_tabwin_close()
+  enew
+  let l:wid = win_getid()
+  tabedit
+  call win_execute(l:wid, 'close')
+  " Should not crash.
+  call assert_true(v:true)
+  %bwipe!
+endfunc

--- a/src/window.c
+++ b/src/window.c
@@ -3616,6 +3616,9 @@ win_alloc_first(void)
 	return FAIL;
     first_tabpage->tp_topframe = topframe;
     curtab = first_tabpage;
+    curtab->tp_firstwin = firstwin;
+    curtab->tp_lastwin = lastwin;
+    curtab->tp_curwin = curwin;
 
     return OK;
 }
@@ -3854,6 +3857,8 @@ win_new_tabpage(int after)
 	    newtp->tp_next = tp->tp_next;
 	    tp->tp_next = newtp;
 	}
+	newtp->tp_firstwin = newtp->tp_lastwin = newtp->tp_curwin = curwin;
+
 	win_init_size();
 	firstwin->w_winrow = tabline_height();
 	win_comp_scroll(curwin);


### PR DESCRIPTION
Reported by @tyru.

Repro steps:

```
$ vim --clean
:let wid = win_getid()
:tabedit
:call win_execute(wid, 'close')
```

then crashes by SEGV.

```
(gdb) bt
#0  0x0000560eb8982323 in goto_tabpage_tp (tp=0x560eba9aee40, trigger_enter_autocmds=0, trigger_leave_autocmds=1) at window.c:4246
#1  0x0000560eb897f423 in close_last_window_tabpage (win=0x560eba9672a0, free_buf=1, prev_curtab=0x560eba96c340) at window.c:2357
#2  0x0000560eb897f779 in win_close (win=0x560eba9672a0, free_buf=1) at window.c:2470
#3  0x0000560eb87ec374 in ex_win_close (forceit=0, win=0x560eba9672a0, tp=0x0) at ex_docmd.c:5070
#4  0x0000560eb87ec18a in ex_close (eap=0x7ffc98a72840) at ex_docmd.c:4990
#5  0x0000560eb87e709c in do_one_cmd (cmdlinep=0x7ffc98a72a78, sourcing=1, cstack=0x7ffc98a72b60, fgetline=0x0, cookie=0x0) at ex_docmd.c:2482
#6  0x0000560eb87e445c in do_cmdline (cmdline=0x560ebab9bb30 "close", fgetline=0x0, cookie=0x0, flags=11) at ex_docmd.c:975
#7  0x0000560eb87e39f6 in do_cmdline_cmd (cmd=0x560ebab9bb30 "close") at ex_docmd.c:586
#8  0x0000560eb87c04c9 in execute_common (argvars=0x7ffc98a734a0, rettv=0x7ffc98a73660, arg_off=1) at evalfunc.c:2062
#9  0x0000560eb87d35ab in f_win_execute (argvars=0x7ffc98a734a0, rettv=0x7ffc98a73660) at evalwindow.c:665
#10 0x0000560eb87be1fe in call_internal_func (name=0x560ebab9e1d0 "win_execute", argcount=2, argvars=0x7ffc98a734a0, rettv=0x7ffc98a73660) at evalfunc.c:986
#11 0x0000560eb896e1ee in call_func (funcname=0x560ebab95070 "win_execute", len=-1, rettv=0x7ffc98a73660, argcount_in=2, argvars_in=0x7ffc98a734a0,
    funcexe=0x7ffc98a73690) at userfunc.c:1654
#12 0x0000560eb896ba37 in get_func_tv (name=0x560ebab95070 "win_execute", len=-1, rettv=0x7ffc98a73660, arg=0x7ffc98a73630, funcexe=0x7ffc98a73690) at userfunc.c:498
#13 0x0000560eb8971e2b in ex_call (eap=0x7ffc98a73770) at userfunc.c:3165
#14 0x0000560eb87e709c in do_one_cmd (cmdlinep=0x7ffc98a739a8, sourcing=0, cstack=0x7ffc98a73a90, fgetline=0x560eb87faa65 <getexline>, cookie=0x0) at ex_docmd.c:2482
#15 0x0000560eb87e445c in do_cmdline (cmdline=0x0, fgetline=0x560eb87faa65 <getexline>, cookie=0x0, flags=0) at ex_docmd.c:975
#16 0x0000560eb8874bb5 in nv_colon (cap=0x7ffc98a74010) at normal.c:3318
#17 0x0000560eb8870ce3 in normal_cmd (oap=0x7ffc98a740b0, toplevel=1) at normal.c:1071
#18 0x0000560eb89ba75a in main_loop (cmdwin=0, noexmode=0) at main.c:1511
#19 0x0000560eb89b9bc6 in vim_main2 () at main.c:901
#20 0x0000560eb89b9404 in main (argc=2, argv=0x7ffc98a74298) at main.c:444
```

Cause:

* `tp_firstwin`, `tp_lastwin`, and `tp_curwin` of new tabpage_T object have pointed to NULL just after created.