### PR TITLE
Use `#error` directive

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -7,7 +7,7 @@
  */
 
 #ifndef VIM__H
-# define VIM__H
+#define VIM__H
 
 #include "protodef.h"
 
@@ -33,7 +33,7 @@
  * test program.  Other items from configure may also be wrong then!
  */
 # if (VIM_SIZEOF_INT == 0)
-    Error: configure did not run properly.  Check auto/config.log.
+#  error configure did not run properly.  Check auto/config.log.
 # endif
 
 # if (defined(__linux__) && !defined(__ANDROID__)) || defined(__CYGWIN__)
@@ -148,7 +148,7 @@
 #endif
 
 #if VIM_SIZEOF_INT < 4 && !defined(PROTO)
-    Error: Vim only works with 32 bit int or larger
+# error Vim only works with 32 bit int or larger
 #endif
 
 /*


### PR DESCRIPTION
I think should use `#error` preprocessor directive.
This can abort compiling immediately in the noted case.