### PR TITLE
Fix a problem with 'breakindent' and 'showbreak'

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1176,6 +1176,8 @@ win_line(
 		    c_final = NUL;
 		    n_extra = get_breakindent_win(wp,
 				       ml_get_buf(wp->w_buffer, lnum, FALSE));
+		    if (wp->w_skipcol > 0 && wp->w_p_wrap)
+			need_showbreak = FALSE;
 		    // Correct end of highlighted area for 'breakindent',
 		    // required when 'linebreak' is also set.
 		    if (tocol == vcol)
@@ -1222,7 +1224,8 @@ win_line(
 		    c_extra = NUL;
 		    c_final = NUL;
 		    n_extra = (int)STRLEN(sbr);
-		    need_showbreak = FALSE;
+		    if (wp->w_skipcol == 0 || !wp->w_p_wrap)
+			need_showbreak = FALSE;
 		    vcol_sbr = vcol + MB_CHARLEN(sbr);
 		    // Correct end of highlighted area for 'showbreak',
 		    // required when 'linebreak' is also set.

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -658,3 +658,29 @@ func Test_breakindent18_vartabs()
   call s:close_windows('set breakindent& list& listchars&')
 endfunc
 
+func Test_breakindent19_sbr_nextpage()
+  let s:input = ""
+  call s:test_windows('setl breakindent briopt=shift:2,sbr,min:18 sbr=>')
+  call setline(1, repeat('a', 200))
+  norm! 1gg
+  redraw!
+  let lines = s:screen_lines(1, 20)
+  let expect = [
+	\ "aaaaaaaaaaaaaaaaaaaa",
+	\ "> aaaaaaaaaaaaaaaaaa",
+	\ "> aaaaaaaaaaaaaaaaaa",
+	\ ]
+  call s:compare_lines(expect, lines)
+  " Scroll down one screen line
+  setl scrolloff=5
+  norm! 5gj
+  redraw!
+  let lines = s:screen_lines(1, 20)
+  let expect = [
+	\ "> aaaaaaaaaaaaaaaaaa",
+	\ "> aaaaaaaaaaaaaaaaaa",
+	\ "> aaaaaaaaaaaaaaaaaa",
+	\ ]
+  call s:compare_lines(expect, lines)
+  call s:close_windows('set breakindent& briopt& sbr&')
+endfunc


### PR DESCRIPTION
When both 'breakindent' and 'showbreak' are set and 'briopt' includes "sbr",
a very long line that overflows a window may not shown correctly.

1. Create a window with the size 20x10.
   `:10new | 20vnew`
2. Set a very long line. (200 "a"s.)
   `200aa<Esc>`
3. Set some options.
   `:set breakindent breakindentopt=shift:2,sbr,min:18 showbreak=>`

   The text will be shown as:
   ```
   aaaaaaaaaaaaaaaaaaaa
   > aaaaaaaaaaaaaaaaaa
   > aaaaaaaaaaaaaaaaaa
   ...
   ```
4. Scroll one screen line.
   `:set scrolloff=5`
   `5gj`

   The text will be shown as:
   ```
   >aaaaaaaaaaaaaaaaaaa
   > aaaaaaaaaaaaaaaaaa
   > aaaaaaaaaaaaaaaaaa
   ...
   ```

   However, it should be:
   ```
   > aaaaaaaaaaaaaaaaaa
   > aaaaaaaaaaaaaaaaaa
   > aaaaaaaaaaaaaaaaaa
   ...
   ```

   Yank and some operations may not work properly as well.

(Not sure whether this is a correct fix.)