### PR TITLE
Fix problems with 'linebreak' and block visual mode

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -2744,7 +2744,12 @@ block_prep(
     char_u	*line;
     char_u	*prev_pstart;
     char_u	*prev_pend;
+#ifdef FEAT_LINEBREAK
+    int		lbr_saved = curwin->w_p_lbr;
 
+    // Avoid a problem with unwanted linebreaks in block mode.
+    curwin->w_p_lbr = FALSE;
+#endif
     bdp->startspaces = 0;
     bdp->endspaces = 0;
     bdp->textlen = 0;
@@ -2863,6 +2868,9 @@ block_prep(
     }
     bdp->textcol = (colnr_T) (pstart - line);
     bdp->textstart = pstart;
+#ifdef FEAT_LINEBREAK
+    curwin->w_p_lbr = lbr_saved;
+#endif
 }
 
 /*
@@ -4556,11 +4564,7 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 #ifdef FEAT_LINEBREAK
 		// Restore linebreak, so that when the user edits it looks as
 		// before.
-		if (curwin->w_p_lbr != lbr_saved)
-		{
-		    curwin->w_p_lbr = lbr_saved;
-		    get_op_vcol(oap, redo_VIsual_mode, FALSE);
-		}
+		curwin->w_p_lbr = lbr_saved;
 #endif
 		// Reset finish_op now, don't want it set inside edit().
 		finish_op = FALSE;
@@ -4663,11 +4667,7 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 #ifdef FEAT_LINEBREAK
 		// Restore linebreak, so that when the user edits it looks as
 		// before.
-		if (curwin->w_p_lbr != lbr_saved)
-		{
-		    curwin->w_p_lbr = lbr_saved;
-		    get_op_vcol(oap, redo_VIsual_mode, FALSE);
-		}
+		curwin->w_p_lbr = lbr_saved;
 #endif
 		op_insert(oap, cap->count1);
 #ifdef FEAT_LINEBREAK
@@ -4698,11 +4698,7 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 #ifdef FEAT_LINEBREAK
 		// Restore linebreak, so that when the user edits it looks as
 		// before.
-		if (curwin->w_p_lbr != lbr_saved)
-		{
-		    curwin->w_p_lbr = lbr_saved;
-		    get_op_vcol(oap, redo_VIsual_mode, FALSE);
-		}
+		curwin->w_p_lbr = lbr_saved;
 #endif
 		op_replace(oap, cap->nchar);
 	    }

--- a/src/testdir/test_listlbr.vim
+++ b/src/testdir/test_listlbr.vim
@@ -100,6 +100,37 @@ func Test_linebreak_with_conceal()
   call s:close_windows()
 endfunc
 
+func Test_linebreak_with_visual_operations()
+  call s:test_windows()
+  let line = '1234567890 2234567890 3234567890'
+  call setline(1, line)
+
+  " yank
+  exec "norm! ^w\<C-V>ey"
+  call assert_equal('2234567890', @@)
+  exec "norm! w\<C-V>ey"
+  call assert_equal('3234567890', @@)
+
+  " increment / decrement
+  exec "norm! ^w\<C-V>\<C-A>w\<C-V>\<C-X>"
+  call assert_equal('1234567890 3234567890 2234567890', getline(1))
+
+  " replace
+  exec "norm! ^w\<C-V>3lraw\<C-V>3lrb"
+  call assert_equal('1234567890 aaaa567890 bbbb567890', getline(1))
+
+  " tilde
+  exec "norm! ^w\<C-V>2l~w\<C-V>2l~"
+  call assert_equal('1234567890 AAAa567890 BBBb567890', getline(1))
+
+  " delete and insert
+  exec "norm! ^w\<C-V>3lc2345\<Esc>w\<C-V>3lc3456\<Esc>"
+  call assert_equal('1234567890 2345567890 3456567890', getline(1))
+  call assert_equal('BBBb', @@)
+
+  call s:close_windows()
+endfunc
+
 func Test_virtual_block()
   call s:test_windows('setl sbr=+')
   call setline(1, [


### PR DESCRIPTION
When 'linebreak' is set, some operators in block visual mode don't work as expected.

1. Create a window with the size 20x10.
   `:10new | 20vnew`
2. Set a line.
   `:call setline(1, '1234567890 2234567890 3234567890')`
3. Set 'linebreak'.
   `:set lbr`
4. Do some blockwise operations.
   E.g. yank:
   ```
   :exec "norm! ^w\<C-V>ey"
   :call assert_equal('2234567890', @@)
   ```
   increment and decrement:
   ```
   :exec "norm! ^w\<C-V>\<C-A>w\<C-V>\<C-X>"
   :call assert_equal('1234567890 3234567890 2234567890', getline(1))
   ```
   replace:
   ```
   :exec "norm! ^w\<C-V>3lraw\<C-V>3lrb"
   :call assert_equal('1234567890 aaaa567890 bbbb567890', getline(1))
   ```

There was a mismatch of `curwin->w_p_lbr` between `do_pending_operator()` and `block_prep()`.
(Not sure whether this is a correct fix.)