### PR TITLE
CI: Remove annoying warning message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,8 +139,8 @@ script:
   - |
     if [[ "${BUILD}" = "yes" ]]; then
       "${SRCDIR}"/vim --version
-      "${SRCDIR}"/vim --clean --not-a-term -esNX -V1 -S ci/if_ver-1.vim -c quit
-      "${SRCDIR}"/vim --clean --not-a-term -esNX -V1 -S ci/if_ver-2.vim -c quit
+      "${SRCDIR}"/vim --clean -u NONE --not-a-term -esNX -V1 -S ci/if_ver-1.vim -c quit
+      "${SRCDIR}"/vim --clean -u NONE --not-a-term -esNX -V1 -S ci/if_ver-2.vim -c quit
     fi
   - echo -e "\\033[33;1mTesting Vim\\033[0m" && echo -en "travis_fold:start:test\\r\\033[0K"
   - do_test make ${SHADOWOPT} ${TEST} && FOLD_MARKER=travis_fold


### PR DESCRIPTION
The annoying warnings is shown when checking if_vers.

```yaml
  - |
    if [[ "${BUILD}" = "yes" ]]; then
      "${SRCDIR}"/vim --version
      "${SRCDIR}"/vim --clean --not-a-term -esNX -V1 -S ci/if_ver-1.vim -c quit
      "${SRCDIR}"/vim --clean --not-a-term -esNX -V1 -S ci/if_ver-2.vim -c quit
    fi
```

```
could not source "$VIMRUNTIME/defaults.vim"
*** Interface versions ***

Lua:
...
could not source "$VIMRUNTIME/defaults.vim"
Python 3:
...
```

