### PR TITLE
Fix several terminal-option problems

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -5824,7 +5824,7 @@ job_start(
 	typval_T    *argvars,
 	char	    **argv_arg UNUSED,
 	jobopt_T    *opt_arg,
-	int	    is_terminal UNUSED)
+	job_T	    **term_job)
 {
     job_T	*job;
     char_u	*cmd = NULL;
@@ -5975,6 +5975,9 @@ job_start(
     // Save the command used to start the job.
     job->jv_argv = argv;
 
+    if (term_job != NULL)
+	*term_job = job;
+
 #ifdef USE_ARGV
     if (ch_log_active())
     {
@@ -5991,7 +5994,7 @@ job_start(
 	ch_log(NULL, "Starting job: %s", (char *)ga.ga_data);
 	ga_clear(&ga);
     }
-    mch_job_start(argv, job, &opt, is_terminal);
+    mch_job_start(argv, job, &opt, term_job != NULL);
 #else
     ch_log(NULL, "Starting job: %s", (char *)cmd);
     mch_job_start((char *)cmd, job, &opt);
@@ -6607,7 +6610,7 @@ f_job_start(typval_T *argvars, typval_T *rettv)
     rettv->v_type = VAR_JOB;
     if (check_restricted() || check_secure())
 	return;
-    rettv->vval.v_job = job_start(argvars, NULL, NULL, FALSE);
+    rettv->vval.v_job = job_start(argvars, NULL, NULL, NULL);
 }
 
 /*

--- a/src/channel.c
+++ b/src/channel.c
@@ -4784,8 +4784,8 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		if (!(supported & JO_OUT_IO))
 		    break;
 		opt->jo_set |= JO_OUT_NAME << (part - PART_OUT);
-		opt->jo_io_name[part] =
-		       tv_get_string_buf_chk(item, opt->jo_io_name_buf[part]);
+		opt->jo_io_name[part] = tv_get_string_buf_chk(item,
+						   opt->jo_io_name_buf[part]);
 	    }
 	    else if (STRCMP(hi->hi_key, "pty") == 0)
 	    {
@@ -4950,7 +4950,8 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		if (!(supported2 & JO2_TERM_NAME))
 		    break;
 		opt->jo_set2 |= JO2_TERM_NAME;
-		opt->jo_term_name = tv_get_string_chk(item);
+		opt->jo_term_name = tv_get_string_buf_chk(item,
+						       opt->jo_term_name_buf);
 		if (opt->jo_term_name == NULL)
 		{
 		    semsg(_(e_invargval), "term_name");
@@ -4977,7 +4978,8 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		if (!(supported2 & JO2_TERM_OPENCMD))
 		    break;
 		opt->jo_set2 |= JO2_TERM_OPENCMD;
-		p = opt->jo_term_opencmd = tv_get_string_chk(item);
+		p = opt->jo_term_opencmd = tv_get_string_buf_chk(item,
+						    opt->jo_term_opencmd_buf);
 		if (p != NULL)
 		{
 		    // Must have %d and no other %.
@@ -4994,13 +4996,12 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 	    }
 	    else if (STRCMP(hi->hi_key, "eof_chars") == 0)
 	    {
-		char_u *p;
-
 		if (!(supported2 & JO2_EOF_CHARS))
 		    break;
 		opt->jo_set2 |= JO2_EOF_CHARS;
-		p = opt->jo_eof_chars = tv_get_string_chk(item);
-		if (p == NULL)
+		opt->jo_eof_chars = tv_get_string_buf_chk(item,
+						       opt->jo_eof_chars_buf);
+		if (opt->jo_eof_chars == NULL)
 		{
 		    semsg(_(e_invargval), "eof_chars");
 		    return FAIL;
@@ -5079,7 +5080,13 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		if (!(supported2 & JO2_TERM_KILL))
 		    break;
 		opt->jo_set2 |= JO2_TERM_KILL;
-		opt->jo_term_kill = tv_get_string_chk(item);
+		opt->jo_term_kill = tv_get_string_buf_chk(item,
+						       opt->jo_term_kill_buf);
+		if (opt->jo_term_kill == NULL)
+		{
+		    semsg(_(e_invargval), "term_kill");
+		    return FAIL;
+		}
 	    }
 	    else if (STRCMP(hi->hi_key, "tty_type") == 0)
 	    {
@@ -5153,7 +5160,12 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		    break;
 		opt->jo_set2 |= JO2_TERM_API;
 		opt->jo_term_api = tv_get_string_buf_chk(item,
-							 opt->jo_term_api_buf);
+							opt->jo_term_api_buf);
+		if (opt->jo_term_api == NULL)
+		{
+		    semsg(_(e_invargval), "term_api");
+		    return FAIL;
+		}
 	    }
 #endif
 	    else if (STRCMP(hi->hi_key, "env") == 0)
@@ -5243,7 +5255,7 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		    break;
 		opt->jo_set |= JO_STOPONEXIT;
 		opt->jo_stoponexit = tv_get_string_buf_chk(item,
-							     opt->jo_soe_buf);
+						      opt->jo_stoponexit_buf);
 		if (opt->jo_stoponexit == NULL)
 		{
 		    semsg(_(e_invargval), "stoponexit");

--- a/src/proto/channel.pro
+++ b/src/proto/channel.pro
@@ -51,7 +51,7 @@ void job_set_options(job_T *job, jobopt_T *opt);
 void job_stop_on_exit(void);
 int has_pending_job(void);
 int job_check_ended(void);
-job_T *job_start(typval_T *argvars, char **argv_arg, jobopt_T *opt_arg, int is_terminal);
+job_T *job_start(typval_T *argvars, char **argv_arg, jobopt_T *opt_arg, job_T **term_job);
 char *job_status(job_T *job);
 int job_stop(job_T *job, typval_T *argvars, char *type);
 void invoke_prompt_callback(void);

--- a/src/structs.h
+++ b/src/structs.h
@@ -2036,7 +2036,7 @@ typedef struct
     int		jo_block_write;	// for testing only
     int		jo_part;
     int		jo_id;
-    char_u	jo_soe_buf[NUMBUFLEN];
+    char_u	jo_stoponexit_buf[NUMBUFLEN];
     char_u	*jo_stoponexit;
     dict_T	*jo_env;	// environment variables
     char_u	jo_cwd_buf[NUMBUFLEN];
@@ -2051,17 +2051,21 @@ typedef struct
     buf_T	*jo_bufnr_buf;
     int		jo_hidden;
     int		jo_term_norestore;
+    char_u	jo_term_name_buf[NUMBUFLEN];
     char_u	*jo_term_name;
+    char_u	jo_term_opencmd_buf[NUMBUFLEN];
     char_u	*jo_term_opencmd;
     int		jo_term_finish;
+    char_u	jo_eof_chars_buf[NUMBUFLEN];
     char_u	*jo_eof_chars;
+    char_u	jo_term_kill_buf[NUMBUFLEN];
     char_u	*jo_term_kill;
 # if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
     long_u	jo_ansi_colors[16];
 # endif
     int		jo_tty_type;	    // first character of "tty_type"
-    char_u	*jo_term_api;
     char_u	jo_term_api_buf[NUMBUFLEN];
+    char_u	*jo_term_api;
 #endif
 } jobopt_T;
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -6695,7 +6695,7 @@ term_and_job_init(
 #endif
 
     // This may change a string in "argvar".
-    term->tl_job = job_start(argvar, argv, opt, TRUE);
+    term->tl_job = job_start(argvar, argv, opt, &term->tl_job);
     if (term->tl_job != NULL)
 	++term->tl_job->jv_refcount;
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -640,7 +640,11 @@ term_start(
     }
 
     if (opt->jo_term_api != NULL)
-	term->tl_api = vim_strsave(opt->jo_term_api);
+    {
+	char_u *p = skiptowhite(opt->jo_term_api);
+
+	term->tl_api = vim_strnsave(opt->jo_term_api, p - opt->jo_term_api);
+    }
     else
 	term->tl_api = vim_strsave((char_u *)"Tapi_");
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -776,6 +776,7 @@ ex_terminal(exarg_T *eap)
 	    char_u *buf = NULL;
 	    char_u *keys;
 
+	    vim_free(opt.jo_eof_chars);
 	    p = skiptowhite(cmd);
 	    *p = NUL;
 	    keys = replace_termcodes(ep + 1, &buf,

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -591,9 +591,7 @@ term_start(
 #if defined(FEAT_SESSION)
     // Remember the command for the session file.
     if (opt->jo_term_norestore || argv != NULL)
-    {
 	term->tl_command = vim_strsave((char_u *)"NONE");
-    }
     else if (argvar->v_type == VAR_STRING)
     {
 	char_u	*cmd = argvar->vval.v_string;

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -712,15 +712,16 @@ func Test_terminal_eof_arg()
   CheckExecutable python
 
   call setline(1, ['print("hello")'])
-  1term ++eof=exit() python
+  1term ++eof=exit(123) python
   " MS-Windows echoes the input, Unix doesn't.
   if has('win32')
-    call WaitFor({-> getline('$') =~ 'exit()'})
+    call WaitFor({-> getline('$') =~ 'exit(123)'})
     call assert_equal('hello', getline(line('$') - 1))
   else
     call WaitFor({-> getline('$') =~ 'hello'})
     call assert_equal('hello', getline('$'))
   endif
+  call assert_equal(123, bufnr()->term_getjob()->job_info().exitval)
   %bwipe!
 endfunc
 
@@ -741,15 +742,16 @@ func Test_terminal_duplicate_eof_arg()
   " Check the last specified ++eof arg is used and should not memory leak.
   new
   call setline(1, ['print("hello")'])
-  1term ++eof=<C-Z> ++eof=exit() python
+  1term ++eof=<C-Z> ++eof=exit(123) python
   " MS-Windows echoes the input, Unix doesn't.
   if has('win32')
-    call WaitFor({-> getline('$') =~ 'exit()'})
-    call assert_match('exit()', getline('$'))
+    call WaitFor({-> getline('$') =~ 'exit(123)'})
+    call assert_equal('hello', getline(line('$') - 1))
   else
     call WaitFor({-> getline('$') =~ 'hello'})
     call assert_equal('hello', getline('$'))
   endif
+  call assert_equal(123, bufnr()->term_getjob()->job_info().exitval)
   %bwipe!
 endfunc
 


### PR DESCRIPTION
## Wrong `++api=` parsing

When any arguments follow `++api=`, `term->tl_api` value is set wrong.

```
:term ++api=Tapi_ /bin/sh
```

`term->tl_api` is:
Expected: `Tapi_`
Actual: `Tapi_ /bin/sh`

### Solution

* Skip to whitespace just before copying to `term->tl_api` (the same as `term->tl_kll`)

## `++eof` doesn't work on unix

```
:1term ++eof=exit(123) python
```

The exit-val of process (`bufnr()->term_getjob()->job_info().exitval`) is:
Expected: 123
Actual: 0

### Cause

`term->tl_eof_chars` is sent to process in `job_start()` (by `term_send_eof()`), but at that time `term->tl_job` is not set yet and ignored.

### Solution

* Pass the pointer `term->tl_job` to `job_start()` (replace `is_terminal`) and set `job` early.

## Memory leak when giving multiple `++eof`

```
:term ++eof=exit(1) ++eof=exit() python
```

and then, in `ex_terminal`, the storage which allocated for first `++eof` leaks.

### Solution

* Do `vim_free(opt.jo_eof_chars)` before set a new value

## Option value is overwritten

The option values which are set by using `tv_get_string_chk()` in `get_job_options` (e.g. `jo_term_name`, `jo_term_kill`) are overwritten by other when giving the number value.

```
:call term_start(['/bin/sh'], #{term_name: 123, term_kill: 456})
```

and then terminal buffer name becomes "456", because `jo_term_name` and `jo_term_kill` points the same storage, which is the internal static buffer in `tv_get_string_chk()`.

### Solution

* Add the storage members to `jobopt_T` (the same as `jo_cwd_buf`) and use `tv_get_string_buf_chk()`

In addition, rename `jo_soe_buf` to `jo_stoponexit_buf` since unify the format of the name of `jo_xxx_buf` variables.

## Not enough tests for `++eof` on win32

The test for `++eof` is only `Test_terminal_write_stdin`, but on win32 this is skipped.

### Solution

* Separate `++eof` testing from `Test_terminal_write_stdin`

