### PR TITLE
Identify *.gv files as DOT language

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -491,7 +491,7 @@ au BufNewFile,BufRead *.rul
 au BufNewFile,BufRead *.com			call dist#ft#BindzoneCheck('dcl')
 
 " DOT
-au BufNewFile,BufRead *.dot			setf dot
+au BufNewFile,BufRead *.dot,*.gv		setf dot
 
 " Dylan - lid files
 au BufNewFile,BufRead *.lid			setf dylanlid


### PR DESCRIPTION
For some time now, the preferred filename extension for DOT language is `.gv`.

- https://en.wikipedia.org/wiki/DOT_(graph_description_language)
- https://gitlab.com/graphviz/graphviz/blob/2.42.2/cmd/dot/dot.1#L153-154
  > ... the graph file language, normally using the extension **.gv**, for graphs ...
- https://marc.info/?l=graphviz-interest&m=128830369531560
  > A year and a half ago, in version 2.22.0, the preferred Graphviz file extension was changed from .dot to .gv ...