### PR TITLE
Fixed memory leak in get_tags()

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -3980,7 +3980,10 @@ get_tags(list_T *list, char_u *pat, char_u *buf_fname)
 
 	    // Skip pseudo-tag lines.
 	    if (STRNCMP(tp.tagname, "!_TAG_", 6) == 0)
+	    {
+		vim_free(matches[i]);
 		continue;
+	    }
 
 	    if ((dict = dict_alloc()) == NULL)
 		ret = FAIL;


### PR DESCRIPTION
This PR fixes a memory leak. The memory leak is reproducible
when running `make test_taglist` with valgrind. It happens
in test `Test_tagfile_ignore_comments`:
```
==11947== 49 bytes in 1 blocks are definitely lost in loss record 57 of 144
==11947==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11947==    by 0x2132F0: lalloc (misc2.c:925)
==11947==    by 0x2CB214: find_tags (tag.c:2610)
==11947==    by 0x2CF0B8: get_tags (tag.c:3972)
==11947==    by 0x191377: call_internal_func (evalfunc.c:1028)
==11947==    by 0x2F2926: call_func (userfunc.c:1859)
==11947==    by 0x2F2BC2: get_func_tv (userfunc.c:556)
==11947==    by 0x17EC10: eval_func (eval.c:1721)
==11947==    by 0x185836: eval7 (eval.c:2676)
==11947==    by 0x1858A3: eval6 (eval.c:2369)
==11947==    by 0x185B83: eval5 (eval.c:2184)
==11947==    by 0x1822E3: eval4 (eval.c:2033)
==11947==    by 0x1822E3: eval3 (eval.c:1954)
==11947==    by 0x182483: eval2 (eval.c:1886)
==11947==    by 0x182483: eval1 (eval.c:1814)
==11947==    by 0x182DCC: eval0 (eval.c:1772)
==11947==    by 0x196246: ex_let_const (evalvars.c:779)
==11947==    by 0x1B2E59: do_one_cmd (ex_docmd.c:2491)
==11947==    by 0x1B2E59: do_cmdline (ex_docmd.c:978)
==11947==    by 0x2F0CC6: call_user_func (userfunc.c:1296)
==11947==    by 0x2F1DDD: call_user_func_check (userfunc.c:1437)
==11947==    by 0x2F2822: call_func (userfunc.c:1841)
==11947==    by 0x2F2BC2: get_func_tv (userfunc.c:556)
==11947==    by 0x2F5EBF: ex_call (userfunc.c:3504)
==11947==    by 0x1B2E59: do_one_cmd (ex_docmd.c:2491)
==11947==    by 0x1B2E59: do_cmdline (ex_docmd.c:978)
==11947==    by 0x182C23: ex_execute (eval.c:6197)
==11947==    by 0x1B2E59: do_one_cmd (ex_docmd.c:2491)
==11947==    by 0x1B2E59: do_cmdline (ex_docmd.c:978)
==11947==    by 0x2F0CC6: call_user_func (userfunc.c:1296)
```
