### PR TITLE
Fix chdir() may crash

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6572,6 +6572,8 @@ changedir_func(
     int		dir_differs;
     int		retval = FALSE;
 
+    if (new_dir == NULL)
+	return FALSE;
     if (allbuf_locked())
 	return FALSE;
 

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -101,6 +101,8 @@ func Test_chdir_func()
   call assert_fails("call chdir('dir-abcd')", 'E472:')
   silent! let d = chdir("dir_abcd")
   call assert_equal("", d)
+  " Should not crash
+  call chdir(d)
 
   only | tabonly
   call chdir(topdir)


### PR DESCRIPTION
This crashes.

```vim
let pwd = chdir('non-existing-dir')
call chdir(pwd)
```