### PR TITLE
Fixed failing tests Test_range() and Test_wincolor_listchars()

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1999,7 +1999,7 @@ func Test_range()
   set tagfunc=
   
   " term_start()
-  if has('terminal')
+  if has('terminal') && has('termguicolors')
     call assert_fails('call term_start(range(3, 4))', 'E474:')
     let g:terminal_ansi_colors = range(16)
     call assert_fails('call term_start("ls", #{term_finish: "close"})', 'E475:')

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -622,6 +622,7 @@ endfunc
 
 func Test_wincolor_listchars()
   CheckScreendump
+  CheckFeature conceal
 
   let lines =<< trim END
 	call setline(1, ["one","\t\tsome random text enough long to show 'extends' and 'precedes' includingnbsps, preceding tabs and trailing spaces    ","three"])


### PR DESCRIPTION
2 tests fail on Linux when vim is configured with:
```
$ ./configure --with-features=normal --enable-gui=none --enable-terminal
$ make
$ make test
...snip...
-------------------------------
Executed:  2398 Tests
 Skipped:    54 Tests
  FAILED:     2 Tests


Failures: 
	From test_functions.vim:
	Found errors in Test_range():
	function RunTheTest[40]..Test_range line 248: command did not fail: call term_start("ls", #{term_finish: "close"})
	From test_highlight.vim:
	Found errors in Test_wincolor_listchars():
	Run 1:
	function RunTheTest[40]..Test_wincolor_listchars[14]..VerifyScreenDump line 55: See dump file difference: call term_dumpdiff("testdir/failed/Test_wincolor_lcs.dump", "testdir/dumps/Test_wincolor_lcs.dump"); difference in line 2: "|-+0#0000e05&@2|>|-@6>s+0#0000001&|o|m|e|.+0#0000e05&|r+0#0000001&|a|n|d|o|m|.+0#0000e05&|t+0#0000001&|e|x|t|.+0#0000e05&|e+0#0000001&|n|o|u|g|h|.+0#0000e05&|l+0#0000001&|o|n|g|.+0#0000e05&|t+0#0000001&|o|.+0#0000e05&|s+0#0000001&|h|o|w|.+0#0000e05&|'+0#0000001&|e|x|t|e|n|d|s|'|.+0#0000e05&|a+0#0000001&|n|d|.+0#0000e05&|'+0#0000001&|p|r|e|c|e|d|e|s|'|.+0#0000e05&|i+0#0000001&|>+0#4040ff13&"
	Run 2:
	function RunTheTest[40]..Test_wincolor_listchars[14]..VerifyScreenDump line 55: See dump file difference: call term_dumpdiff("testdir/failed/Test_wincolor_lcs.dump", "testdir/dumps/Test_wincolor_lcs.dump"); difference in line 2: "|-+0#0000e05&@2|>|-@6>s+0#0000001&|o|m|e|.+0#0000e05&|r+0#0000001&|a|n|d|o|m|.+0#0000e05&|t+0#0000001&|e|x|t|.+0#0000e05&|e+0#0000001&|n|o|u|g|h|.+0#0000e05&|l+0#0000001&|o|n|g|.+0#0000e05&|t+0#0000001&|o|.+0#0000e05&|s+0#0000001&|h|o|w|.+0#0000e05&|'+0#0000001&|e|x|t|e|n|d|s|'|.+0#0000e05&|a+0#0000001&|n|d|.+0#0000e05&|'+0#0000001&|p|r|e|c|e|d|e|s|'|.+0#0000e05&|i+0#0000001&|>+0#4040ff13&"
	Flaky test failed too often, giving up

TEST FAILURE
make: *** [Makefile:58: report] Error 1
```
Test `Test_range()` fails because the `termguicolors` feature is missing.
Test `Test_wincolor_listchars()` fails because the `conceal` feature is missing.