### PR TITLE
Fix fnamemodify(fname, ':~:.')

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -933,8 +933,7 @@ These modifiers can be given, in this order:
 		directory.
 	:.	Reduce file name to be relative to current directory, if
 		possible.  File name is unmodified if it is not below the
-		current directory, but on MS-Windows the drive is removed if
-		it is the current drive.
+		current directory.
 		For maximum shortness, use ":~:.".
 	:h	Head of the file name (the last component and any separators
 		removed).  Cannot be used with :e, :r or :t.

--- a/src/testdir/test_fnamemodify.vim
+++ b/src/testdir/test_fnamemodify.vim
@@ -37,6 +37,7 @@ func Test_fnamemodify()
   call assert_equal('foo', fnamemodify($HOME . '/XXXXXXXX/a/foo', ':p:~:.'))
   call assert_equal('~/XXXXXXXX/b/foo', fnamemodify($HOME . '/XXXXXXXX/b/foo', ':p:~:.'))
   call chdir(cwd)
+  call delete($HOME . '/XXXXXXXX', 'rf')
 
   call assert_equal('''abc def''', fnamemodify('abc def', ':S'))
   call assert_equal('''abc" "def''', fnamemodify('abc" "def', ':S'))

--- a/src/testdir/test_fnamemodify.vim
+++ b/src/testdir/test_fnamemodify.vim
@@ -3,8 +3,10 @@
 func Test_fnamemodify()
   let save_home = $HOME
   let save_shell = &shell
+  let save_shellslash = &shellslash
   let $HOME = fnamemodify('.', ':p:h:h')
   set shell=sh
+  set shellslash
 
   call assert_equal('/', fnamemodify('.', ':p')[-1:])
   call assert_equal('r', fnamemodify('.', ':p:h')[-1:])
@@ -28,6 +30,14 @@ func Test_fnamemodify()
   call assert_equal('fb2.tar.gz', fnamemodify('abc.fb2.tar.gz', ':e:e:e:e'))
   call assert_equal('tar', fnamemodify('abc.fb2.tar.gz', ':e:e:r'))
 
+  let cwd = getcwd()
+  call mkdir($HOME . '/XXXXXXXX/a', 'p')
+  call mkdir($HOME . '/XXXXXXXX/b', 'p')
+  call chdir($HOME . '/XXXXXXXX/a/')
+  call assert_equal('foo', fnamemodify($HOME . '/XXXXXXXX/a/foo', ':p:~:.'))
+  call assert_equal('~/XXXXXXXX/b/foo', fnamemodify($HOME . '/XXXXXXXX/b/foo', ':p:~:.'))
+  call chdir(cwd)
+
   call assert_equal('''abc def''', fnamemodify('abc def', ':S'))
   call assert_equal('''abc" "def''', fnamemodify('abc" "def', ':S'))
   call assert_equal('''abc"%"def''', fnamemodify('abc"%"def', ':S'))
@@ -44,6 +54,7 @@ func Test_fnamemodify()
 
   let $HOME = save_home
   let &shell = save_shell
+  let &shellslash = save_shellslash
 endfunc
 
 func Test_fnamemodify_er()


### PR DESCRIPTION
If current directory is `~/xxx/a/`, `fnamemodify('/home/mattn/xxx/b/a')` should return `~/xxx/b/a`. But current implementation return `/home/mattn/xxx/b/a`.

And also I think removing current drive with `:.` is not useful since full-path without drive letter is not portable.