### PR TITLE
Fix spelling, change indentation for 'if...then' and 'for...loop'.

### DIFF
--- a/runtime/indent/sqlanywhere.vim
+++ b/runtime/indent/sqlanywhere.vim
@@ -67,68 +67,73 @@ set cpo&vim
 " IS is excluded, since it is difficult to determine when the
 " ending block is (especially for procedures/functions).
 let s:SQLBlockStart = '^\s*\%('.
-                \ 'if\|else\|elseif\|elsif\|'.
-                \ 'while\|loop\|do\|for\|'.
-                \ 'begin\|'.
+                \ 'if\>.*\<then\|'.
+                \ 'then\|else\>\|'.
+                \ 'elseif\>.*\<then\|'.
+                \ 'elsif\>.(\<then\|'.
+                \ 'while\>.*\<loop\|'.
+                \ 'for\>.*\<loop\|'.
+                \ 'foreach\>.*\<loop\|'. 
+                \ 'loop\|do\|declare\|begin\|'.
                 \ 'case\|when\|merge\|exception'.
                 \ '\)\>'
 let s:SQLBlockEnd = '^\s*\(end\)\>'
 
-" The indent level is also based on unmatched paranethesis
+" The indent level is also based on unmatched parentheses
 " If a line has an extra "(" increase the indent
 " If a line has an extra ")" decrease the indent
-function! s:CountUnbalancedParan( line, paran_to_check )
+function! s:CountUnbalancedParen( line, paren_to_check )
     let l = a:line
     let lp = substitute(l, '[^(]', '', 'g')
     let l = a:line
     let rp = substitute(l, '[^)]', '', 'g')
 
-    if a:paran_to_check =~ ')'
-        " echom 'CountUnbalancedParan ) returning: ' .
+    if a:paren_to_check =~ ')'
+        " echom 'CountUnbalancedParen ) returning: ' .
         " \ (strlen(rp) - strlen(lp))
         return (strlen(rp) - strlen(lp))
-    elseif a:paran_to_check =~ '('
-        " echom 'CountUnbalancedParan ( returning: ' .
+    elseif a:paren_to_check =~ '('
+        " echom 'CountUnbalancedParen ( returning: ' .
         " \ (strlen(lp) - strlen(rp))
         return (strlen(lp) - strlen(rp))
     else
-        " echom 'CountUnbalancedParan unknown paran to check: ' .
-        " \ a:paran_to_check
+        " echom 'CountUnbalancedParen unknown paren to check: ' .
+        " \ a:paren_to_check
         return 0
     endif
 endfunction
 
 " Unindent commands based on previous indent level
-function! s:CheckToIgnoreRightParan( prev_lnum, num_levels )
+function! s:CheckToIgnoreRightParen( prev_lnum, num_levels )
     let lnum = a:prev_lnum
     let line = getline(lnum)
     let ends = 0
-    let num_right_paran = a:num_levels
-    let ignore_paran = 0
+    let num_right_paren = a:num_levels
+    let ignore_paren = 0
     let vircol = 1
 
-    while num_right_paran > 0
+    while num_right_paren > 0
         silent! exec 'norm! '.lnum."G\<bar>".vircol."\<bar>"
-        let right_paran = search( ')', 'W' )
-        if right_paran != lnum
+        let right_paren = search( ')', 'W' )
+        if right_paren != lnum
             " This should not happen since there should be at least
-            " num_right_paran matches for this line
+            " num_right_paren matches for this line
             break
         endif
         let vircol      = virtcol(".")
 
         " if getline(".") =~ '^)'
-        let matching_paran = searchpair('(', '', ')', 'bW',
+        let matching_paren = searchpair('(', '', ')', 'bW',
                     \ 's:IsColComment(line("."), col("."))')
 
-        if matching_paran < 1
+        if matching_paren < 1
             " No match found
             " echom 'CTIRP - no match found, ignoring'
             break
         endif
 
-        if matching_paran == lnum
-            " This was not an unmatched parantenses, start the search again
+        if matching_paren == lnum
+            " This was not an unmatched parentheses, start the search again
             " again after this column
             " echom 'CTIRP - same line match, ignoring'
             continue
@@ -136,23 +141,23 @@ function! s:CheckToIgnoreRightParan( prev_lnum, num_levels )
 
         " echom 'CTIRP - match: ' . line(".") . '  ' . getline(".")
 
-        if getline(matching_paran) =~? '\(if\|while\)\>'
+        if getline(matching_paren) =~? '\(if\|while\)\>'
             " echom 'CTIRP - if/while ignored: ' . line(".") . '  ' . getline(".")
-            let ignore_paran = ignore_paran + 1
+            let ignore_paren = ignore_paren + 1
         endif
 
         " One match found, decrease and check for further matches
-        let num_right_paran = num_right_paran - 1
+        let num_right_paren = num_right_paren - 1
 
     endwhile
 
     " Fallback - just move back one
     " return a:prev_indent - shiftwidth()
-    return ignore_paran
+    return ignore_paren
 endfunction
 
 " Based on the keyword provided, loop through previous non empty
-" non comment lines to find the statement that initated the keyword.
+" non comment lines to find the statement that initiated the keyword.
 " Return its indent level
 "    CASE ..
 "    WHEN ...
@@ -295,26 +300,26 @@ function! GetSQLIndent()
         " echom 'prevl - SQLBlockStart - indent ' . ind . '  line: ' . prevline
     elseif prevline =~ '[()]'
         if prevline =~ '('
-            let num_unmatched_left = s:CountUnbalancedParan( prevline, '(' )
+            let num_unmatched_left = s:CountUnbalancedParen( prevline, '(' )
         else
             let num_unmatched_left = 0
         endif
         if prevline =~ ')'
-            let num_unmatched_right  = s:CountUnbalancedParan( prevline, ')' )
+            let num_unmatched_right  = s:CountUnbalancedParen( prevline, ')' )
         else
             let num_unmatched_right  = 0
-            " let num_unmatched_right  = s:CountUnbalancedParan( prevline, ')' )
+            " let num_unmatched_right  = s:CountUnbalancedParen( prevline, ')' )
         endif
         if num_unmatched_left > 0
-            " There is a open left paranethesis
+            " There is a open left parenthesis
             " increase indent
             let ind = ind + ( shiftwidth() * num_unmatched_left )
         elseif num_unmatched_right > 0
-            " if it is an unbalanced paranethesis only unindent if
+            " if it is an unbalanced parenthesis only unindent if
             " it was part of a command (ie create table(..)  )
             " instead of part of an if (ie if (....) then) which should
             " maintain the indent level
-            let ignore = s:CheckToIgnoreRightParan( prevlnum, num_unmatched_right )
+            let ignore = s:CheckToIgnoreRightParen( prevlnum, num_unmatched_right )
             " echom 'prevl - ) unbalanced - CTIRP - ignore: ' . ignore
 
             if prevline =~ '^\s*)'
@@ -357,8 +362,8 @@ function! GetSQLIndent()
         " elseif line =~ '^\s*)\s*;\?\s*$'
         " elseif line =~ '^\s*)'
     elseif line =~ '^\s*)'
-        let num_unmatched_right  = s:CountUnbalancedParan( line, ')' )
-        let ignore = s:CheckToIgnoreRightParan( v:lnum, num_unmatched_right )
+        let num_unmatched_right  = s:CountUnbalancedParen( line, ')' )
+        let ignore = s:CheckToIgnoreRightParen( v:lnum, num_unmatched_right )
         " If the line ends in a ), then reduce the indent
         " This catches items like:
         " CREATE TABLE T1(
@@ -368,7 +373,7 @@ function! GetSQLIndent()
         " But we do not want to unindent a line like:
         " IF ( c1 = 1
         " AND  c2 = 3 ) THEN
-        " let num_unmatched_right  = s:CountUnbalancedParan( line, ')' )
+        " let num_unmatched_right  = s:CountUnbalancedParen( line, ')' )
         " if num_unmatched_right > 0
         " elseif strpart( line, strlen(line)-1, 1 ) =~ ')'
         " let ind = ind - shiftwidth()


### PR DESCRIPTION
Change indention rule for 'if' statements and loops to format them like this:

    IF some condition
    THEN
        -- Do some cool statements
        INSERT blah blah blah;
    END IF;