### PR TITLE
Add test function for clearing the last used search and substitute patterns

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2848,6 +2848,7 @@ term_wait({buf} [, {time}])	Number  wait for screen to be updated
 test_alloc_fail({id}, {countdown}, {repeat})
 				none	make memory allocation fail
 test_autochdir()		none	enable 'autochdir' during startup
+test_clear_search_pat()		none	clears the last used search pattern
 test_feedinput({string})	none	add key sequence to input buffer
 test_garbagecollect_now()	none	free memory right now for testing
 test_garbagecollect_soon()	none	free memory soon for testing

--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -52,6 +52,11 @@ test_autochdir()					*test_autochdir()*
 		startup has finished.
 
 
+test_clear_search_pat()				*test_clear_search_pat()*
+		Clears the last used search pattern (|/|) and the substitute
+		pattern (|:s|). This is useful for testing conditions where
+		these patterns are not set previously.
+
 test_feedinput({string})				*test_feedinput()*
 		Characters in {string} are queued for processing as if they
 		were typed by the user. This uses a low level input buffer.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -963,6 +963,7 @@ Testing:				    *test-functions*
 	assert_report()		report a test failure
 	test_alloc_fail()	make memory allocation fail
 	test_autochdir()	enable 'autochdir' during startup
+	test_clear_search_pat() clears the last used search pattern
 	test_override()		test with Vim internal overrides
 	test_garbagecollect_now()   free memory right now
 	test_getvalue()		get value of an internal variable

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -810,6 +810,7 @@ static funcentry_T global_functions[] =
 #endif
     {"test_alloc_fail",	3, 3, FEARG_1,	  &t_void,	f_test_alloc_fail},
     {"test_autochdir",	0, 0, 0,	  &t_void,	f_test_autochdir},
+    {"test_clear_search_pat",	0, 0, 0,  &t_void,	f_test_clear_search_pat},
     {"test_feedinput",	1, 1, FEARG_1,	  &t_void,	f_test_feedinput},
     {"test_garbagecollect_now",	0, 0, 0,  &t_void,	f_test_garbagecollect_now},
     {"test_garbagecollect_soon", 0, 0, 0, &t_void,	f_test_garbagecollect_soon},

--- a/src/proto/regexp.pro
+++ b/src/proto/regexp.pro
@@ -12,6 +12,7 @@ int vim_regcomp_had_eol(void);
 regprog_T *vim_regcomp(char_u *expr_arg, int re_flags);
 void vim_regfree(regprog_T *prog);
 void free_regexp_stuff(void);
+void free_regexp_prev_sub(void);
 int regprog_in_use(regprog_T *prog);
 int vim_regexec_prog(regprog_T **prog, int ignore_case, char_u *line, colnr_T col);
 int vim_regexec(regmatch_T *rmp, char_u *line, colnr_T col);

--- a/src/proto/search.pro
+++ b/src/proto/search.pro
@@ -9,6 +9,7 @@ void free_search_patterns(void);
 void save_last_search_pattern(void);
 void restore_last_search_pattern(void);
 char_u *last_search_pattern(void);
+void free_last_pat(int idx);
 int ignorecase(char_u *pat);
 int ignorecase_opt(char_u *pat, int ic_in, int scs);
 int pat_has_uppercase(char_u *pat);

--- a/src/proto/testing.pro
+++ b/src/proto/testing.pro
@@ -13,6 +13,7 @@ void f_assert_report(typval_T *argvars, typval_T *rettv);
 void f_assert_true(typval_T *argvars, typval_T *rettv);
 void f_test_alloc_fail(typval_T *argvars, typval_T *rettv);
 void f_test_autochdir(typval_T *argvars, typval_T *rettv);
+void f_test_clear_search_pat(typval_T *argvars, typval_T *rettv);
 void f_test_feedinput(typval_T *argvars, typval_T *rettv);
 void f_test_getvalue(typval_T *argvars, typval_T *rettv);
 void f_test_option_not_set(typval_T *argvars, typval_T *rettv);

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -2663,6 +2663,15 @@ free_regexp_stuff(void)
 }
 #endif
 
+/*
+ * Free the previously used substitute search pattern.
+ */
+    void
+free_regexp_prev_sub(void)
+{
+    VIM_CLEAR(reg_prev_sub);
+}
+
 #ifdef FEAT_EVAL
     static void
 report_re_switch(char_u *pat)

--- a/src/search.c
+++ b/src/search.c
@@ -380,6 +380,13 @@ last_search_pattern(void)
 }
 #endif
 
+    void
+free_last_pat(int idx)
+{
+    vim_free(spats[idx].pat);
+    spats[idx].pat = NULL;
+}
+
 /*
  * Return TRUE when case should be ignored for search pattern "pat".
  * Uses the 'ignorecase' and 'smartcase' options.

--- a/src/search.c
+++ b/src/search.c
@@ -383,8 +383,7 @@ last_search_pattern(void)
     void
 free_last_pat(int idx)
 {
-    vim_free(spats[idx].pat);
-    spats[idx].pat = NULL;
+    VIM_CLEAR(spats[idx].pat);
 }
 
 /*

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -2718,6 +2718,10 @@ func XvimgrepTests(cchar)
   call assert_equal(0, getbufinfo('Xtestfile1')[0].loaded)
   call assert_equal([], getbufinfo('Xtestfile2'))
 
+  " Test with the last search pattern not set
+  call test_clear_search_pat()
+  call assert_fails('Xvimgrep // *', 'E35:')
+
   call delete('Xtestfile1')
   call delete('Xtestfile2')
 endfunc

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -1456,9 +1456,8 @@ func Test_search_special()
   exe "norm /\x80PS"
 endfunc
 
-" Test for command failures when the last search pattern and the last
-" substitute pattern are not set.
-func Test_no_last_pat()
+" Test for command failures when the last search pattern is not set.
+func Test_search_with_no_last_pat()
   call test_clear_search_pat()
   call assert_fails("normal i\<C-R>/\e", 'E35:')
   call assert_fails("exe '/'", 'E35:')
@@ -1479,17 +1478,21 @@ func Test_no_last_pat()
   call assert_fails(";//p", 'E35:')
   call assert_fails("??p", 'E35:')
   call assert_fails(";??p", 'E35:')
-  call assert_fails('~', 'E33:')
-  call assert_fails('s//abc/g', 'E476:')
-  call assert_fails('s\/bar', 'E476:')
-  call assert_fails('s\&bar&', 'E476:')
-  call test_clear_search_pat()
-  let save_cpo = &cpo
-  set cpo+=/
-  call assert_fails('s/abc/%/', 'E33:')
-  let &cpo = save_cpo
   call assert_fails('g//p', 'E476:')
   call assert_fails('v//p', 'E476:')
+endfunc
+
+" Test for using tilde (~) atom in search. This should use the last used
+" substitute pattern
+func Test_search_tilde_pat()
+  call test_clear_search_pat()
+  set regexpengine=1
+  call assert_fails('exe "normal /~\<CR>"', 'E33:')
+  call assert_fails('exe "normal ?~\<CR>"', 'E33:')
+  set regexpengine=2
+  call assert_fails('exe "normal /~\<CR>"', 'E383:')
+  call assert_fails('exe "normal ?~\<CR>"', 'E383:')
+  set regexpengine&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -1455,3 +1455,41 @@ func Test_search_special()
   set t_PE=
   exe "norm /\x80PS"
 endfunc
+
+" Test for command failures when the last search pattern and the last
+" substitute pattern are not set.
+func Test_no_last_pat()
+  call test_clear_search_pat()
+  call assert_fails("normal i\<C-R>/\e", 'E35:')
+  call assert_fails("exe '/'", 'E35:')
+  call assert_fails("exe '?'", 'E35:')
+  call assert_fails("/", 'E35:')
+  call assert_fails("?", 'E35:')
+  call assert_fails("normal n", 'E35:')
+  call assert_fails("normal N", 'E35:')
+  call assert_fails("normal gn", 'E35:')
+  call assert_fails("normal gN", 'E35:')
+  call assert_fails("normal cgn", 'E35:')
+  call assert_fails("normal cgN", 'E35:')
+  let p = []
+  let p = @/
+  call assert_equal('', p)
+  call assert_fails("normal :\<C-R>/", 'E35:')
+  call assert_fails("//p", 'E35:')
+  call assert_fails(";//p", 'E35:')
+  call assert_fails("??p", 'E35:')
+  call assert_fails(";??p", 'E35:')
+  call assert_fails('~', 'E33:')
+  call assert_fails('s//abc/g', 'E476:')
+  call assert_fails('s\/bar', 'E476:')
+  call assert_fails('s\&bar&', 'E476:')
+  call test_clear_search_pat()
+  let save_cpo = &cpo
+  set cpo+=/
+  call assert_fails('s/abc/%/', 'E33:')
+  let &cpo = save_cpo
+  call assert_fails('g//p', 'E476:')
+  call assert_fails('v//p', 'E476:')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_sort.vim
+++ b/src/testdir/test_sort.vim
@@ -1383,6 +1383,8 @@ func Test_sort_last_search_pat()
   call setline(1, ['3b', '1c', '2a'])
   sort //
   call assert_equal(['2a', '3b', '1c'], getline(1, '$'))
+  call test_clear_search_pat()
+  call assert_fails('sort //', 'E35:')
   close!
 endfunc
 

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -803,4 +803,19 @@ func Test_sub_expand_text()
   close!
 endfunc
 
+" Test for command failures when the last substitute pattern is not set.
+func Test_sub_with_no_last_pat()
+  call test_clear_search_pat()
+  call assert_fails('~', 'E33:')
+  call assert_fails('s//abc/g', 'E476:')
+  call assert_fails('s\/bar', 'E476:')
+  call assert_fails('s\&bar&', 'E476:')
+
+  call test_clear_search_pat()
+  let save_cpo = &cpo
+  set cpo+=/
+  call assert_fails('s/abc/%/', 'E33:')
+  let &cpo = save_cpo
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testing.c
+++ b/src/testing.c
@@ -632,6 +632,18 @@ f_test_autochdir(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 }
 
 /*
+ * "test_clear_search_pat()"
+ * Free the last search and substitute patterns
+ */
+    void
+f_test_clear_search_pat(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
+{
+    free_last_pat(RE_SUBST);
+    free_last_pat(RE_SEARCH);
+    set_old_sub(NULL);
+}
+
+/*
  * "test_feedinput()"
  */
     void

--- a/src/testing.c
+++ b/src/testing.c
@@ -641,6 +641,7 @@ f_test_clear_search_pat(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     free_last_pat(RE_SUBST);
     free_last_pat(RE_SEARCH);
     set_old_sub(NULL);
+    free_regexp_prev_sub();
 }
 
 /*


### PR DESCRIPTION
Use the new test function to add additional tests after clearing the last used search/substitute patterns.