### PR TITLE
src/configure.ac: fix gcc-10 pattern detection

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4447,7 +4447,7 @@ dnl the number before the version number.
 DEPEND_CFLAGS_FILTER=
 if test "$GCC" = yes; then
   AC_MSG_CHECKING(for GCC 3 or later)
-  gccmajor=`echo "$gccversion" | sed -e 's/^\([[1-9]]\)\..*$/\1/g'`
+  gccmajor=`echo "$gccversion" | sed -e 's/^\([[0-9]]\+\)\..*$/\1/g'`
   if test "$gccmajor" -gt "2"; then
     DEPEND_CFLAGS_FILTER="| sed 's+-I */+-isystem /+g'"
     AC_MSG_RESULT(yes)


### PR DESCRIPTION
On gcc-10 `./configure` can't detect correct value of `-D_FORTIFY_SOURCE=`:

```
$ ./configure
...
checking for GCC 3 or later... auto/configure: line 14735:
  test: 10.0.1: integer expression expected
no
checking whether we need -D_FORTIFY_SOURCE=1... auto/configure: line 14745:
  test: 10.0.1: integer expression expected
no
```

```
$ gcc -dumpversion
10.0.1
```

It was noticed as vim buffer overflow detection as gentoo default to
`-D_FORTIFY_SOURCE=2`: https://bugs.gentoo.org/706324#c2

The fix extends sed regex to catch multiple digits in major version.

Reported-by: lekto@o2.pl
Bug: https://bugs.gentoo.org/706324