### PR TITLE
Regression: fnamemodify performs simpification with adjacent dir (after 8.2.0208)

### DIFF
--- a/src/testdir/test_fnamemodify.vim
+++ b/src/testdir/test_fnamemodify.vim
@@ -36,6 +36,8 @@ func Test_fnamemodify()
   call chdir($HOME . '/XXXXXXXX/a/')
   call assert_equal('foo', fnamemodify($HOME . '/XXXXXXXX/a/foo', ':p:~:.'))
   call assert_equal('~/XXXXXXXX/b/foo', fnamemodify($HOME . '/XXXXXXXX/b/foo', ':p:~:.'))
+  call mkdir($HOME . '/XXXXXXXX/a.ext', 'p')
+  call assert_equal('~/XXXXXXXX/a.ext/foo', fnamemodify($HOME . '/XXXXXXXX/a.ext/foo', ':p:~:.'))
   call chdir(cwd)
   call delete($HOME . '/XXXXXXXX', 'rf')
 


### PR DESCRIPTION
My automated plugin tests caught a regression caused by #5577
> Vim 8.2.0208  fnamemodify() does not apply ":~" when followed by ":."

When the working directory is `~/XXXXXXXX/a/` and there's a directory `~/XXXXXXXX/a.ext/` next to it, `fnamemodify('foo', ':~:.')` mistakenly shortens to `.ext/foo`. Apparently a simple substring match is used, without taking path separator boundaries into account.

This patch extends the existing test case to highlight the problem. (I don't have enough knowledge of the area to provide a fix; hopefully @mattn will.)