### PR TITLE
Fix the pattern for gcc version matching in configure script

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -14762,7 +14762,7 @@ DEPEND_CFLAGS_FILTER=
 if test "$GCC" = yes; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for GCC 3 or later" >&5
 $as_echo_n "checking for GCC 3 or later... " >&6; }
-  gccmajor=`echo "$gccversion" | sed -e 's/^\([0-9]\+\)\..*$/\1/g'`
+  gccmajor=`echo "$gccversion" | sed -e 's/^\([0-9][0-9]*\)\..*$/\1/g'`
   if test "$gccmajor" -gt "2"; then
     DEPEND_CFLAGS_FILTER="| sed 's+-I */+-isystem /+g'"
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4447,7 +4447,7 @@ dnl the number before the version number.
 DEPEND_CFLAGS_FILTER=
 if test "$GCC" = yes; then
   AC_MSG_CHECKING(for GCC 3 or later)
-  gccmajor=`echo "$gccversion" | sed -e 's/^\([[0-9]]\+\)\..*$/\1/g'`
+  gccmajor=`echo "$gccversion" | sed -e 's/^\([[0-9]][[0-9]]*\)\..*$/\1/g'`
   if test "$gccmajor" -gt "2"; then
     DEPEND_CFLAGS_FILTER="| sed 's+-I */+-isystem /+g'"
     AC_MSG_RESULT(yes)


### PR DESCRIPTION
Checking gcc version In configure script,

```
gccmajor=`echo "$gccversion" | sed -e 's/^\([0-9]\+\)\..*$/\1/g'`
```

but BSD sed doesn't recognize `\+`, so `gccmajor` is set to exactly `$gccversion` and then configure reports the following errors.

```
checking for GCC 3 or later... auto/configure: line 14766: test: 4.2.1: integer expression expected
no
checking whether we need -D_FORTIFY_SOURCE=1... auto/configure: line 14776: test: 4.2.1: integer expression expected
no
```

Therefore should use `*` instead of `\+`.