### PR TITLE
Explain how to use a literal % in :! doc

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -250,12 +250,17 @@ g8			Print the hex values of the bytes used in the
 			A '|' in {cmd} is passed to the shell, you cannot use
 			it to append a Vim command.  See |:bar|.
 
-			If {cmd} contains "%" it is expanded to the current
-			file name.  Special characters are not escaped, use
-			quotes to avoid their special meaning: >
+			If {cmd} contains "%" or "#" it is expanded to the
+			appropriate file name (|:_%| |:_#|).  Use escaping to
+			avoid this expansion: >
+				:!ls \%
+<			Use |escape()| to prevent expansion within variables: >
+				:exe "grep " . escape(@/, "%#") . " -R ."
+<			Special characters in the file name are not escaped,
+			use double quotes to avoid their special meaning: >
 				:!ls "%"
-<			If the file name contains a "$" single quotes might
-			work better (but a single quote causes trouble): >
+<			If the file name contains a "$", single quotes might
+			work better (except for file names containing a "'"): >
 				:!ls '%'
 <			This should always work, but it's more typing: >
 				:exe "!ls " . shellescape(expand("%"))


### PR DESCRIPTION
Fix confusing and incorrect documentation about % in :!.

Text sounds like it's explaining list a file named `%`. That seems
reasonable since users are likely to want to know how to work around
the specialness of %. The current documentation doesn't accomplish
this goal:

1. These old suggested commands all list the current file (tested in
   vim 7.4.52 on Linux and gvim 8.2.140 on Windows):

    :!ls "%"
    :!ls '%'
    :exe "!ls " . shellescape(expand("%"))

2. A single "$" seems to be irrelevant to the surrounding text.
3. shellescape("%") return '%', so there's no point in mentioning it.

Instead, use two examples for escaping: using backslash and using
escape().