### PR TITLE
Correctly check for editing the last file in the argument list. Add a test

### DIFF
--- a/src/arglist.c
+++ b/src/arglist.c
@@ -314,6 +314,7 @@ alist_check_arg_idx(void)
     win_T	*win;
     tabpage_T	*tp;
 
+    arg_had_last = FALSE;
     FOR_ALL_TAB_WINDOWS(tp, win)
 	if (win->w_alist == curwin->w_alist)
 	    check_arg_idx(win);

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -512,9 +512,6 @@ func Test_quit_with_arglist()
   argadd Y Z
   argdelete Z
   call assert_fails('quit', 'E173:')
-  " Opening a new window should make quit fail again
-  new | close
-  call assert_fails('quit', 'E173:')
   call Reset_arglist()
   %bwipe!
 endfunc

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -505,3 +505,16 @@ func Test_argdo()
   call assert_equal(['Xa.c', 'Xb.c', 'Xc.c'], l)
   bwipe Xa.c Xb.c Xc.c
 endfunc
+
+" Test for quiting Vim when the argument list has more files to edit
+func Test_quit_with_arglist()
+  args X
+  argadd Y Z
+  argdelete Z
+  call assert_fails('quit', 'E173:')
+  " Opening a new window should make quit fail again
+  new | close
+  call assert_fails('quit', 'E173:')
+  call Reset_arglist()
+  %bwipe!
+endfunc


### PR DESCRIPTION
When quitting Vim using the :quit command, if there are still files in the argument
list to edit, then the E173: error message is displayed. The following commands
will produce this error:

args a b c
quit

This error is not displayed if the argument list is set using only a single file and
then files are added to the argument list using argadd:

args a
argadd b c
quit

The attached patch fixes this issue. The error message is now displayed if
the argument list has still files to edit.

