### PR TITLE
Match word boundaries in Dockerfile syntax

### DIFF
--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -22,12 +22,12 @@ syntax region dockerfileFrom matchgroup=dockerfileKeyword start=/\v^\s*(FROM)\ze
 syntax keyword dockerfileKeyword contained ADD ARG CMD COPY ENTRYPOINT ENV EXPOSE HEALTHCHECK LABEL MAINTAINER ONBUILD RUN SHELL STOPSIGNAL USER VOLUME WORKDIR
 syntax match dockerfileOption contained /\v(^|\s)\zs--\S+/
 
-syntax match dockerfileInstruction contained /\v(\S+)(\s+--\S+)*/             contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileValue
-syntax match dockerfileInstruction contained /\v(ADD|COPY)(\s+--\S+)*/        contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileJSON
-syntax match dockerfileInstruction contained /\v(HEALTHCHECK)(\s+--\S+)*/     contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileInstruction
-syntax match dockerfileInstruction contained /\v(CMD|ENTRYPOINT|RUN)/         contains=dockerfileKeyword skipwhite nextgroup=dockerfileShell
-syntax match dockerfileInstruction contained /\v(CMD|ENTRYPOINT|RUN)\ze\s+\[/ contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
-syntax match dockerfileInstruction contained /\v(SHELL|VOLUME)/               contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
+syntax match dockerfileInstruction contained /\v<(\S+)>(\s+--\S+)*/             contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileValue
+syntax match dockerfileInstruction contained /\v<(ADD|COPY)>(\s+--\S+)*/        contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileJSON
+syntax match dockerfileInstruction contained /\v<(HEALTHCHECK)>(\s+--\S+)*/     contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileInstruction
+syntax match dockerfileInstruction contained /\v<(CMD|ENTRYPOINT|RUN)>/         contains=dockerfileKeyword skipwhite nextgroup=dockerfileShell
+syntax match dockerfileInstruction contained /\v<(CMD|ENTRYPOINT|RUN)>\ze\s+\[/ contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
+syntax match dockerfileInstruction contained /\v<(SHELL|VOLUME)>/               contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
 
 syntax region dockerfileString contained start=/\v"/ skip=/\v\\./ end=/\v"/
 syntax region dockerfileJSON   contained keepend start=/\v\[/ skip=/\v\\\_./ end=/\v$/ contains=@JSON


### PR DESCRIPTION
Without these assertions, an instruction group could match words that aren't instructions.

For example, despite not starting with an instruction, `CMDx echo 1` would match and highlight `echo 1` as shell script:

| before | after |
| --- | --- |
| ![Screenshot 2020-02-08 at 1 36 41 PM](https://user-images.githubusercontent.com/106560/74091014-88ceb300-4a78-11ea-8a9d-af624d6ed4ef.png) | ![Screenshot 2020-02-08 at 1 37 23 PM](https://user-images.githubusercontent.com/106560/74091021-9126ee00-4a78-11ea-8a77-16f9848b4005.png) |



Follow-up to #5539.
\cc @honza @k-takata