### PR TITLE
Add env overrides

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4948,24 +4948,6 @@ win32_build_env(dict_T *env, garray_T *gap, int is_terminal)
     if (ga_grow(gap, 1) == FAIL)
 	return;
 
-    if (base)
-    {
-	WCHAR	*p = (WCHAR*) base;
-
-	// for last \0
-	if (ga_grow(gap, 1) == FAIL)
-	    return;
-
-	while (*p != 0 || *(p + 1) != 0)
-	{
-	    if (ga_grow(gap, 1) == OK)
-		*((WCHAR*)gap->ga_data + gap->ga_len++) = *p;
-	    p++;
-	}
-	FreeEnvironmentStrings(base);
-	*((WCHAR*)gap->ga_data + gap->ga_len++) = L'\0';
-    }
-
     if (env != NULL)
     {
 	for (hi = env->dv_hashtab.ht_array; todo > 0; ++hi)
@@ -4995,6 +4977,24 @@ win32_build_env(dict_T *env, garray_T *gap, int is_terminal)
 		vim_free(wval);
 	    }
 	}
+    }
+
+    if (base)
+    {
+	WCHAR	*p = (WCHAR*) base;
+
+	// for last \0
+	if (ga_grow(gap, 1) == FAIL)
+	    return;
+
+	while (*p != 0 || *(p + 1) != 0)
+	{
+	    if (ga_grow(gap, 1) == OK)
+		*((WCHAR*)gap->ga_data + gap->ga_len++) = *p;
+	    p++;
+	}
+	FreeEnvironmentStrings(base);
+	*((WCHAR*)gap->ga_data + gap->ga_len++) = L'\0';
     }
 
 # if defined(FEAT_CLIENTSERVER) || defined(FEAT_TERMINAL)

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1991,3 +1991,16 @@ func Test_job_start_fails()
   " this was leaking memory
   call assert_fails("call job_start([''])", "E474:")
 endfunc
+
+func Test_issue_5485()
+  let $VAR1 = 'global'
+  let g:Ch_reply = ""
+  if has('win32')
+    let l:job = job_start(['cmd', '/c', 'echo %VAR1% %VAR2%'], {'env': {'VAR1': 'local', 'VAR2': 'local'}, 'callback': 'Ch_handler'})
+  else
+    let l:job = job_start(['sh', '/c', 'echo $VAR1 $VAR2'], {'env': {'VAR1': 'local', 'VAR2': 'local'}, 'callback': 'Ch_handler'})
+  endif
+  let g:Ch_job = l:job
+  call WaitForAssert({-> assert_equal("local local", trim(g:Ch_reply))})
+  unlet $VAR1
+endfunc

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1995,11 +1995,7 @@ endfunc
 func Test_issue_5485()
   let $VAR1 = 'global'
   let g:Ch_reply = ""
-  if has('win32')
-    let l:job = job_start(['cmd', '/c', 'echo %VAR1% %VAR2%'], {'env': {'VAR1': 'local', 'VAR2': 'local'}, 'callback': 'Ch_handler'})
-  else
-    let l:job = job_start(['sh', '/c', 'echo $VAR1 $VAR2'], {'env': {'VAR1': 'local', 'VAR2': 'local'}, 'callback': 'Ch_handler'})
-  endif
+  let l:job = job_start([&shell, &shellcmdflag, 'echo $VAR1 $VAR2'], {'env': {'VAR1': 'local', 'VAR2': 'local'}, 'callback': 'Ch_handler'})
   let g:Ch_job = l:job
   call WaitForAssert({-> assert_equal("local local", trim(g:Ch_reply))})
   unlet $VAR1

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1995,7 +1995,7 @@ endfunc
 func Test_issue_5485()
   let $VAR1 = 'global'
   let g:Ch_reply = ""
-  let l:job = job_start([&shell, &shellcmdflag, 'echo $VAR1 $VAR2'], {'env': {'VAR1': 'local', 'VAR2': 'local'}, 'callback': 'Ch_handler'})
+  let l:job = job_start([&shell, &shellcmdflag, has('win32') ? 'echo %VAR1% %VAR2%' : 'echo $VAR1 $VAR2'], {'env': {'VAR1': 'local', 'VAR2': 'local'}, 'callback': 'Ch_handler'})
   let g:Ch_job = l:job
   call WaitForAssert({-> assert_equal("local local", trim(g:Ch_reply))})
   unlet $VAR1


### PR DESCRIPTION
The order of environment variables, newer variables should be first in the list (which is separated with NUL).

Fixes #5485