### PR TITLE
Fix crash when drawing the empty location-list window

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -4520,7 +4520,7 @@ qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last)
 	*dirname = NUL;
 
 	// Add one line for each error
-	if (old_last == NULL)
+	if (old_last == NULL || old_last->qf_next == NULL)
 	{
 	    qfp = qfl->qf_start;
 	    lnum = 0;

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1628,6 +1628,13 @@ func Test_setqflist_invalid_nr()
   eval []->setqflist(' ', {'nr' : $XXX_DOES_NOT_EXIST})
 endfunc
 
+func Test_setqflist_user_sets_buftype()
+  call setqflist([{'text': 'foo'}, {'text': 'bar'}])
+  set buftype=quickfix
+  call setqflist([], 'a')
+  enew
+endfunc
+
 func Test_quickfix_set_list_with_act()
   call XquickfixSetListWithAct('c')
   call XquickfixSetListWithAct('l')


### PR DESCRIPTION
**Describe the bug**
`setqflist()` with `'a'` flag causes crash if qflist has two lines or more and user sets `buftype=quickfix` on normal windows.

**To Reproduce**
Detailed steps to reproduce the behavior:
1. Run `vim --clean` (or `gvim --clean`, etc.)
2. Execute `call setqflist([{'text': 'foo'}, {'text': 'bar'}])`
3. Execute `set buftype=quickfix`
4. Execute `call setqflist([], 'a')`

**Expected behavior**
Vim shouldn't crash.
