### PR TITLE
MSVC: Revise usage of _CRT_SECURE_NO_DEPRECATE

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -657,6 +657,8 @@ OPTFLAG = /Ox
 !  if "$(OPTIMIZE)" != "SPACE"
 OPTFLAG = $(OPTFLAG) /GL
 !  endif
+# Visual Studio 2005 has 'deprecated' many of the standard CRT functions
+CFLAGS = $(CFLAGS) /D_CRT_SECURE_NO_DEPRECATE /D_CRT_NONSTDC_NO_DEPRECATE
 ! endif
 
 # (/Wp64 is deprecated in VC9 and generates an obnoxious warning.)

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -21,7 +21,7 @@
 
 #ifdef _WIN32
 # if !defined(DYNAMIC_RUBY) || (RUBY_VERSION < 18)
-#   define NT
+#  define NT
 # endif
 # ifndef DYNAMIC_RUBY
 #  define IMPORT // For static dll usage __declspec(dllimport)
@@ -300,8 +300,8 @@ static int ruby_convert_to_vim_value(VALUE val, typval_T *rettv);
 #  define rb_float_new			dll_rb_float_new
 #  define rb_ary_new			dll_rb_ary_new
 #  ifdef rb_ary_new4
-#    define RB_ARY_NEW4_MACRO 1
-#    undef rb_ary_new4
+#   define RB_ARY_NEW4_MACRO 1
+#   undef rb_ary_new4
 #  endif
 #  define rb_ary_new4			dll_rb_ary_new4
 #  define rb_ary_push			dll_rb_ary_push
@@ -1071,15 +1071,15 @@ error_print(int state)
 	    }
 
 	    attr = syn_name2attr((char_u *)"Error");
-# if RUBY_VERSION >= 21
+#if RUBY_VERSION >= 21
 	    bt = rb_funcallv(error, rb_intern("backtrace"), 0, 0);
 	    for (i = 0; i < RARRAY_LEN(bt); i++)
 		msg_attr(RSTRING_PTR(RARRAY_AREF(bt, i)), attr);
-# else
+#else
 	    bt = rb_funcall2(error, rb_intern("backtrace"), 0, 0);
 	    for (i = 0; i < RARRAY_LEN(bt); i++)
 		msg_attr(RSTRING_PTR(RARRAY_PTR(bt)[i]), attr);
-# endif
+#endif
 	    break;
 	default:
 	    vim_snprintf(buff, BUFSIZ, _("E273: unknown longjmp status %d"), state);

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -18,12 +18,6 @@
 # endif
 #endif
 
-// Stop the VC2005 compiler from nagging.
-#if _MSC_VER >= 1400
-# define _CRT_SECURE_NO_DEPRECATE
-# define _CRT_NONSTDC_NO_DEPRECATE
-#endif
-
 #define BINARY_FILE_IO
 #define USE_EXE_NAME		// use argv[0] for $VIM
 #define USE_TERM_CONSOLE

--- a/src/vim.h
+++ b/src/vim.h
@@ -119,12 +119,6 @@
 # endif
 #endif
 
-// Visual Studio 2005 has 'deprecated' many of the standard CRT functions
-#if _MSC_VER >= 1400
-# define _CRT_SECURE_NO_DEPRECATE
-# define _CRT_NONSTDC_NO_DEPRECATE
-#endif
-
 /*
  * VIM_SIZEOF_INT is used in feature.h, and the system-specific included files
  * need items from feature.h.  Therefore define VIM_SIZEOF_INT here.

--- a/src/vimio.h
+++ b/src/vimio.h
@@ -7,12 +7,6 @@
  * See README.txt for an overview of the Vim source code.
  */
 
-// Visual Studio 2005 has 'deprecated' many of the standard CRT functions
-#if _MSC_VER >= 1400
-# define _CRT_SECURE_NO_DEPRECATE
-# define _CRT_NONSTDC_NO_DEPRECATE
-#endif
-
 // cproto fails on missing include files
 #ifndef PROTO
 # include <io.h>


### PR DESCRIPTION
Deprecated warnings were shown when if_ruby was enabled. Suppress it by
defining _CRT_SECURE_NO_DEPRECATE in Make_mvc.mak.

Then the definitions of _CRT_SECURE_NO_DEPRECATE in os_win32.h, vim.h
and vimio.h become useless. Remove them.
(The definition in dosinst.h is still needed.)
(Maybe vimio.h becomes useless and we can simply use io.h?)