### PR TITLE
Remove the test_clear_search_pat() function

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2848,7 +2848,6 @@ term_wait({buf} [, {time}])	Number  wait for screen to be updated
 test_alloc_fail({id}, {countdown}, {repeat})
 				none	make memory allocation fail
 test_autochdir()		none	enable 'autochdir' during startup
-test_clear_search_pat()		none	clears the last used search pattern
 test_feedinput({string})	none	add key sequence to input buffer
 test_garbagecollect_now()	none	free memory right now for testing
 test_garbagecollect_soon()	none	free memory soon for testing

--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -52,11 +52,6 @@ test_autochdir()					*test_autochdir()*
 		startup has finished.
 
 
-test_clear_search_pat()				*test_clear_search_pat()*
-		Clears the last used search pattern (|/|) and the substitute
-		pattern (|:s|). This is useful for testing conditions where
-		these patterns are not set previously.
-
 test_feedinput({string})				*test_feedinput()*
 		Characters in {string} are queued for processing as if they
 		were typed by the user. This uses a low level input buffer.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -963,7 +963,6 @@ Testing:				    *test-functions*
 	assert_report()		report a test failure
 	test_alloc_fail()	make memory allocation fail
 	test_autochdir()	enable 'autochdir' during startup
-	test_clear_search_pat() clears the last used search pattern
 	test_override()		test with Vim internal overrides
 	test_garbagecollect_now()   free memory right now
 	test_getvalue()		get value of an internal variable

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -811,7 +811,6 @@ static funcentry_T global_functions[] =
 #endif
     {"test_alloc_fail",	3, 3, FEARG_1,	  &t_void,	f_test_alloc_fail},
     {"test_autochdir",	0, 0, 0,	  &t_void,	f_test_autochdir},
-    {"test_clear_search_pat",	0, 0, 0,  &t_void,	f_test_clear_search_pat},
     {"test_feedinput",	1, 1, FEARG_1,	  &t_void,	f_test_feedinput},
     {"test_garbagecollect_now",	0, 0, 0,  &t_void,	f_test_garbagecollect_now},
     {"test_garbagecollect_soon", 0, 0, 0, &t_void,	f_test_garbagecollect_soon},

--- a/src/proto/regexp.pro
+++ b/src/proto/regexp.pro
@@ -12,7 +12,6 @@ int vim_regcomp_had_eol(void);
 regprog_T *vim_regcomp(char_u *expr_arg, int re_flags);
 void vim_regfree(regprog_T *prog);
 void free_regexp_stuff(void);
-void free_regexp_prev_sub(void);
 int regprog_in_use(regprog_T *prog);
 int vim_regexec_prog(regprog_T **prog, int ignore_case, char_u *line, colnr_T col);
 int vim_regexec(regmatch_T *rmp, char_u *line, colnr_T col);

--- a/src/proto/search.pro
+++ b/src/proto/search.pro
@@ -9,7 +9,6 @@ void free_search_patterns(void);
 void save_last_search_pattern(void);
 void restore_last_search_pattern(void);
 char_u *last_search_pattern(void);
-void free_last_pat(int idx);
 int ignorecase(char_u *pat);
 int ignorecase_opt(char_u *pat, int ic_in, int scs);
 int pat_has_uppercase(char_u *pat);

--- a/src/proto/testing.pro
+++ b/src/proto/testing.pro
@@ -13,7 +13,6 @@ void f_assert_report(typval_T *argvars, typval_T *rettv);
 void f_assert_true(typval_T *argvars, typval_T *rettv);
 void f_test_alloc_fail(typval_T *argvars, typval_T *rettv);
 void f_test_autochdir(typval_T *argvars, typval_T *rettv);
-void f_test_clear_search_pat(typval_T *argvars, typval_T *rettv);
 void f_test_feedinput(typval_T *argvars, typval_T *rettv);
 void f_test_getvalue(typval_T *argvars, typval_T *rettv);
 void f_test_option_not_set(typval_T *argvars, typval_T *rettv);

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -2663,15 +2663,6 @@ free_regexp_stuff(void)
 }
 #endif
 
-/*
- * Free the previously used substitute search pattern.
- */
-    void
-free_regexp_prev_sub(void)
-{
-    VIM_CLEAR(reg_prev_sub);
-}
-
 #ifdef FEAT_EVAL
     static void
 report_re_switch(char_u *pat)

--- a/src/search.c
+++ b/src/search.c
@@ -380,12 +380,6 @@ last_search_pattern(void)
 }
 #endif
 
-    void
-free_last_pat(int idx)
-{
-    VIM_CLEAR(spats[idx].pat);
-}
-
 /*
  * Return TRUE when case should be ignored for search pattern "pat".
  * Uses the 'ignorecase' and 'smartcase' options.

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -214,6 +214,8 @@ func Test_write_errors()
   call assert_fails('1,2write', 'E140:')
   close!
 
+  call assert_fails('w > Xtest', 'E494:')
+
   " Try to overwrite a directory
   if has('unix')
     call mkdir('Xdir1')

--- a/src/testing.c
+++ b/src/testing.c
@@ -632,19 +632,6 @@ f_test_autochdir(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 }
 
 /*
- * "test_clear_search_pat()"
- * Free the last search and substitute patterns
- */
-    void
-f_test_clear_search_pat(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
-{
-    free_last_pat(RE_SUBST);
-    free_last_pat(RE_SEARCH);
-    set_old_sub(NULL);
-    free_regexp_prev_sub();
-}
-
-/*
  * "test_feedinput()"
  */
     void


### PR DESCRIPTION
The tests for using the last search pattern has been changed to not use the
recently introduced test_clear_search_pat() function. Instead a separate Vim
instance is used to run the test. So the test_clear_search_pat() function
can be removed.
