### PR TITLE
MSVC: Suppress some warnings

### DIFF
--- a/src/GvimExt/Makefile
+++ b/src/GvimExt/Makefile
@@ -10,6 +10,9 @@ TARGETOS = WINNT
 !ifndef APPVER
 APPVER = 5.01
 !endif
+!ifndef WINVER
+WINVER = 0x0501
+!endif
 
 !if "$(DEBUG)" != "yes"
 NODEBUG = 1
@@ -52,6 +55,13 @@ olelibsdll = ole32.lib uuid.lib oleaut32.lib user32.lib gdi32.lib advapi32.lib
 
 # include CPUARG
 cflags = $(cflags) $(CPUARG)
+
+# set WINVER and _WIN32_WINNT
+cflags = $(cflags) -DWINVER=$(WINVER) -D_WIN32_WINNT=$(WINVER)
+
+!if "$(CL)" == "/D_USING_V110_SDK71_"
+rcflags = $(rcflags) /D_USING_V110_SDK71_
+!endif
 
 SUBSYSTEM = console
 !if "$(SUBSYSTEM_VER)" != ""

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -626,6 +626,12 @@ NODEFAULTLIB =
 NODEFAULTLIB = /nodefaultlib
 !endif
 
+# Specify source code charset to suppress warning C4819 on non-English
+# environment. Only available from MSVC 14.
+!if $(MSVC_MAJOR) >= 14
+CFLAGS = $(CFLAGS) /source-charset:utf-8
+!endif
+
 # Use multiprocess build on MSVC 10
 !if ("$(USE_MP)" == "yes") && ($(MSVC_MAJOR) >= 10)
 CFLAGS = $(CFLAGS) /MP
@@ -668,6 +674,9 @@ CFLAGS = $(CFLAGS) $(WP64CHECK)
 
 CFLAGS = $(CFLAGS) $(OPTFLAG) -DNDEBUG $(CPUARG)
 RCFLAGS = $(rcflags) $(rcvars) -DNDEBUG
+! if "$(CL)" == "/D_USING_V110_SDK71_"
+RCFLAGS = $(RCFLAGS) /D_USING_V110_SDK71_
+! endif
 ! ifdef USE_MSVCRT
 CFLAGS = $(CFLAGS) /MD
 LIBC = msvcrt.lib


### PR DESCRIPTION
1. C4819

When compiling digraph.c on non-English environment, the following warning may be shown:

    digraph.c: warning C4819: The file contains a character that cannot be represented in the current code page (932).

Suppress the warning by specifying the charset explicitly to utf-8.

2. C4091

The following warning will be shown when compiling gvimext with VC2015 and Windows SDK 7.1A:

    C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Include\shlobj.h(1151): warning C4091: 'typedef ': ignored on left of 'tagGPFIDL_FLAGS' when no variable is declared

Suppress the warning by setting `_WIN32_WINNT`.

3. RC4005

The following warnings will be shown when compiling rc files with VC2015 and Windows SDK 7.1A:

    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\sal.h(2866) : warning RC4005: '__useHeader' : redefinition
    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\sal.h(2876) : warning RC4005: '__on_failure' : redefinition

Suppress the warnings by defining `_USING_V110_SDK71_`.