### PR TITLE
Fixed crash with :disassemble with missing arg

### DIFF
--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -21,6 +21,7 @@ def s:ScriptFuncLoad(arg: string)
 enddef
 
 def Test_disassemble_load()
+  assert_fails('disass', 'E471:')
   assert_fails('disass NoFunc', 'E1061:')
   assert_fails('disass NotCompiled', 'E1062:')
 

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -1598,6 +1598,11 @@ ex_disassemble(exarg_T *eap)
     int		line_idx = 0;
     int		prev_current = 0;
 
+    if (*eap->arg == NUL)
+    {
+	emsg(_(e_argreq));
+	return;
+    }
     fname = trans_function_name(&eap->arg, FALSE,
 	     TFN_INT | TFN_QUIET | TFN_NO_AUTOLOAD | TFN_NO_DEREF, NULL, NULL);
     ufunc = find_func(fname, NULL);


### PR DESCRIPTION
This PR fixes issue https://github.com/vim/vim/issues/5635
i.e. a crash when doing:
```
$ vim --clean -c disassemble
Vim: Caught deadly signal SEGV
```