### PR TITLE
A few vim9 errors are not localized

### DIFF
--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -3312,7 +3312,7 @@ compile_assignment(char_u *arg, exarg_T *eap, cmdidx_T cmdidx, cctx_T *cctx)
     if (oplen == 3 && !heredoc && dest != dest_global
 	    && type->tt_type != VAR_STRING && type->tt_type != VAR_UNKNOWN)
     {
-	emsg("E1019: Can only concatenate to string");
+	emsg(_("E1019: Can only concatenate to string"));
 	goto theend;
     }
 
@@ -4735,7 +4735,7 @@ compile_def_function(ufunc_T *ufunc, int set_return_type)
 	    }
 	    else
 	    {
-		emsg("E1025: using } outside of a block scope");
+		emsg(_("E1025: using } outside of a block scope"));
 		goto erret;
 	    }
 	    if (line != NULL)
@@ -4995,7 +4995,7 @@ erret:
 	if (errormsg != NULL)
 	    emsg(errormsg);
 	else if (called_emsg == called_emsg_before)
-	    emsg("E1028: compile_def_function failed");
+	    emsg(_("E1028: compile_def_function failed"));
 
 	// don't execute this function body
 	ufunc->uf_lines.ga_len = 0;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -1611,12 +1611,12 @@ ex_disassemble(exarg_T *eap)
     vim_free(fname);
     if (ufunc == NULL)
     {
-	semsg("E1061: Cannot find function %s", eap->arg);
+	semsg(_("E1061: Cannot find function %s"), eap->arg);
 	return;
     }
     if (ufunc->uf_dfunc_idx < 0)
     {
-	semsg("E1062: Function %s is not compiled", eap->arg);
+	semsg(_("E1062: Function %s is not compiled"), eap->arg);
 	return;
     }
     if (ufunc->uf_name_exp != NULL)


### PR DESCRIPTION
This PR fixes a few vim9 errors which were not localized with gettext.