### PR TITLE
Fix vim9 mul

### DIFF
--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -478,6 +478,10 @@ def Test_expr6()
   assert_equal(2, g:anint % g:alsoint)
 
   assert_equal(4, 6 * 4 / 6)
+
+  let x = [2.0]
+  let y = [3.0]
+  assert_equal(6.0, x[0] * y[0])
 enddef
 
 def Test_expr6_float()

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -481,6 +481,7 @@ def Test_expr6()
 
   let x = [2.0]
   let y = [3.0]
+  assert_equal(5.0, x[0] + y[0])
   assert_equal(6.0, x[0] * y[0])
 enddef
 

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -373,14 +373,9 @@ generate_two_op(cctx_T *cctx, char_u *op)
 
     switch (*op)
     {
-	case '+': if (vartype != VAR_LIST && vartype != VAR_BLOB
-			  && check_number_or_float(
-				   type1->tt_type, type2->tt_type, op) == FAIL)
-		      return FAIL;
+	case '+':
 		  isn = generate_instr_drop(cctx,
 			    vartype == VAR_NUMBER ? ISN_OPNR
-			  : vartype == VAR_LIST ? ISN_ADDLIST
-			  : vartype == VAR_BLOB ? ISN_ADDBLOB
 #ifdef FEAT_FLOAT
 			  : vartype == VAR_FLOAT ? ISN_OPFLOAT
 #endif

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -391,9 +391,7 @@ generate_two_op(cctx_T *cctx, char_u *op)
 
 	case '-':
 	case '*':
-	case '/': if (check_number_or_float(type1->tt_type, type2->tt_type,
-								   op) == FAIL)
-		      return FAIL;
+	case '/': 
 		  if (vartype == VAR_NUMBER)
 		      isn = generate_instr_drop(cctx, ISN_OPNR, 1);
 #ifdef FEAT_FLOAT

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -391,7 +391,7 @@ generate_two_op(cctx_T *cctx, char_u *op)
 
 	case '-':
 	case '*':
-	case '/': 
+	case '/':
 		  if (vartype == VAR_NUMBER)
 		      isn = generate_instr_drop(cctx, ISN_OPNR, 1);
 #ifdef FEAT_FLOAT


### PR DESCRIPTION
```
def Proc(x: list<float>, y: list<float>)
  let r = x[0] * y[0]
enddef
call Proc([1.0], [2.0])
```
This does not work.