### PR TITLE
doc: Update description for has('pythonx')

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10821,7 +10821,7 @@ python_dynamic		Python 2.x interface is dynamically loaded. |has-python|
 python3			Python 3.x interface available. |has-python|
 python3_compiled	Compiled with Python 3.x interface. |has-python|
 python3_dynamic		Python 3.x interface is dynamically loaded. |has-python|
-pythonx			Compiled with |python_x| interface. |has-pythonx|
+pythonx			|python_x| interface available. |has-pythonx|
 qnx			QNX version of Vim.
 quickfix		Compiled with |quickfix| support.
 reltime			Compiled with |reltime()| support.


### PR DESCRIPTION
The description for `has('pythonx')` became inconsistent with `has('python')` and `has('python3')` after [8.0.1436](https://github.com/vim/vim/commit/84b242c369a22b581c43de9de0152f0baedd71ab).

Make them consistent.