### PR TITLE
vim9: Fix `:echo`

### DIFF
--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -527,6 +527,8 @@ call_def_function(
 							   &atstart, &needclr);
 			clear_tv(tv);
 		    }
+		    if (needclr)
+			msg_clr_eos();
 		    ectx.ec_stack.ga_len -= count;
 		}
 		break;


### PR DESCRIPTION
`:echo` didn't clear the right part of output.  Clear it.