### PR TITLE
vim9: Fix handling of empty list and dict

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -400,6 +400,8 @@ EXTERN type_T t_partial_any INIT4(VAR_PARTIAL, -1, &t_any, NULL);
 
 EXTERN type_T t_list_any INIT4(VAR_LIST, 0, &t_any, NULL);
 EXTERN type_T t_dict_any INIT4(VAR_DICT, 0, &t_any, NULL);
+EXTERN type_T t_list_void INIT4(VAR_LIST, 0, &t_void, NULL);
+EXTERN type_T t_dict_void INIT4(VAR_DICT, 0, &t_void, NULL);
 
 EXTERN type_T t_list_number INIT4(VAR_LIST, 0, &t_number, NULL);
 EXTERN type_T t_list_string INIT4(VAR_LIST, 0, &t_string, NULL);


### PR DESCRIPTION
This causes an error:

```
let li: list<string> = []
```

Because currently the type of `[]` is `list<any>`.
I think this should not be an error.

Not sure whether this is the right fix.