### PR TITLE
Make running individual tests more robust for GUI/environment overrides

### DIFF
--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -73,7 +73,7 @@ $(SCRIPTS) $(SCRIPTS_GUI) $(NEW_TESTS_RES): $(SCRIPTS_FIRST)
 # 	make test_largefile
 $(NEW_TESTS):
 	rm -f $@.res test.log messages
-	@MAKEFLAGS=--no-print-directory $(MAKE) -f Makefile $@.res
+	@MAKEFLAGS=--no-print-directory $(MAKE) -f Makefile $@.res VIMPROG=$(VIMPROG) XXDPROG=$(XXDPROG) SCRIPTSOURCE=$(SCRIPTSOURCE)
 	@cat messages
 	@if test -f test.log; then \
 		exit 1; \

--- a/src/testdir/README.txt
+++ b/src/testdir/README.txt
@@ -25,6 +25,8 @@ At 2), instead of running the test separately, it can be included in
 bit faster, because Vim doesn't have to be started, one Vim instance runs many
 tests.
 
+At 4), to run a test in GUI, add "GUI_FLAG=-g" to the make command.
+
 
 What you can use (see test_assert.vim for an example):
 


### PR DESCRIPTION
Right now, to run an individual test, you can run `make test_cmdline` in testdir which will clean the .res file and then basically call `make test_cmdline.res`. However, it does not pass through misc variables like "VIMPROG" that could be overriden in command line or by the parent Makefile in src. Pass that through so that the behavior is consistent.

Also, include instructions in the README inside testdir for how to run individual tests in GUI.
