### PR TITLE
Fix ruby/dyn build warnings

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -209,6 +209,14 @@ static int ruby_convert_to_vim_value(VALUE val, typval_T *rettv);
 /*
  * Wrapper defines
  */
+// Ruby 2.7 actually expands the following symbols as macro.
+# if RUBY_VERSION >= 27
+#  undef rb_define_global_function
+#  undef rb_define_method
+#  undef rb_define_module_function
+#  undef rb_define_singleton_method
+# endif
+
 # define rb_assoc_new			dll_rb_assoc_new
 # define rb_cObject			(*dll_rb_cObject)
 # define rb_class_new_instance		dll_rb_class_new_instance
@@ -1228,7 +1236,7 @@ static const rb_data_type_t buffer_type = {
     "vim_buffer",
     {0, 0, buffer_dsize,
 # if RUBY_VERSION >= 27
-	0, 0
+	0, {0}
 # else
 	{0, 0}
 # endif
@@ -1508,7 +1516,7 @@ static const rb_data_type_t window_type = {
     "vim_window",
     {0, 0, window_dsize,
 # if RUBY_VERSION >= 27
-	0, 0
+	0, {0}
 # else
 	{0, 0}
 # endif


### PR DESCRIPTION
Ruby 2.7.0, since several `rb_define_*` functions are expanded as macro in actual use, redefining warnings are reported in if_ruby.c when build as ruby/dyn.
Therefore should undefine them before `#define rb_define_xxx dll_rb_define_xxx`.

e.g. `rb_define_method` (in `ruby/ruby.h`)

```c
void rb_define_method(VALUE,const char*,VALUE(*)(ANYARGS),int);
...
#define rb_define_method(klass, mid, func, arity) rb_define_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));
```

```
gcc -c -I. -DDYNAMIC_RUBY_DLL=\"libruby.so.2.7\" -I/usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0 -I/usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/x86_64-linux -DRUBY_VERSION=27 -Iproto -DHAVE_CONFIG_H   -DWE_ARE_PROFILING  -Wall -Wno-unknown-pragmas -g -ggdb3 -O0 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/if_ruby.o if_ruby.c
if_ruby.c:231:0: warning: "rb_define_global_function" redefined
 # define rb_define_global_function dll_rb_define_global_function

In file included from /usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/ruby.h:33:0,
                 from if_ruby.c:102:
/usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/ruby/ruby.h:2851:0: note: this is the location of the previous definition
 #define rb_define_global_function(mid, func, arity) rb_define_global_function_choose_prototypem3((arity),(func))((mid),(func),(arity));

if_ruby.c:232:0: warning: "rb_define_method" redefined
 # define rb_define_method  dll_rb_define_method

In file included from /usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/ruby.h:33:0,
                 from if_ruby.c:102:
/usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/ruby/ruby.h:2799:0: note: this is the location of the previous definition
 #define rb_define_method(klass, mid, func, arity) rb_define_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));

if_ruby.c:234:0: warning: "rb_define_module_function" redefined
 # define rb_define_module_function dll_rb_define_module_function

In file included from /usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/ruby.h:33:0,
                 from if_ruby.c:102:
/usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/ruby/ruby.h:2825:0: note: this is the location of the previous definition
 #define rb_define_module_function(klass, mid, func, arity) rb_define_module_function_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));

if_ruby.c:235:0: warning: "rb_define_singleton_method" redefined
 # define rb_define_singleton_method dll_rb_define_singleton_method

In file included from /usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/ruby/ruby.h:2148:0,
                 from /usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/ruby.h:33,
                 from if_ruby.c:102:
/usr/local/share/anyenv/envs/rbenv/versions/2.7.0/include/ruby-2.7.0/ruby/intern.h:1218:0: note: this is the location of the previous definition
 #define rb_define_singleton_method(klass, mid, func, arity) rb_define_singleton_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));

if_ruby.c:1227:43: warning: missing braces around initializer [-Wmissing-braces]
 static const rb_data_type_t buffer_type = {
                                           ^
if_ruby.c:1231:5:
  0, 0
     {
if_ruby.c:1235:5:
     },
     }
if_ruby.c:1227:43: warning: missing braces around initializer [-Wmissing-braces]
 static const rb_data_type_t buffer_type = {
                                           ^
if_ruby.c:1231:5:
  0, 0
     {
if_ruby.c:1235:5:
     },
     }
if_ruby.c:1507:43: warning: missing braces around initializer [-Wmissing-braces]
 static const rb_data_type_t window_type = {
                                           ^
if_ruby.c:1511:5:
  0, 0
     {
if_ruby.c:1515:5:
     },
     }
if_ruby.c:1507:43: warning: missing braces around initializer [-Wmissing-braces]
 static const rb_data_type_t window_type = {
                                           ^
if_ruby.c:1511:5:
  0, 0
     {
if_ruby.c:1515:5:
     },
     }
```