### PR TITLE
Improve test coverage of python3 vim.eval()

### DIFF
--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -193,13 +193,13 @@ func Test_python3_vim_val()
   call assert_equal("\n8",             execute('py3 print(vim.eval("3+5"))'))
   if has('float')
     call assert_equal("\n3.140000",    execute('py3 print(vim.eval("1.01+2.13"))'))
-    call assert_equal("\ninf",         execute('py3 print(vim.eval("1.0/0.0"))'))
-    call assert_equal("\n-inf",        execute('py3 print(vim.eval("-1.0/0.0"))'))
+    call assert_equal("\n0.000000",    execute('py3 print(vim.eval("0.0/(1.0/0.0)"))'))
     call assert_equal("\n0.000000",    execute('py3 print(vim.eval("0.0/(1.0/0.0)"))'))
     call assert_equal("\n-0.000000",   execute('py3 print(vim.eval("0.0/(-1.0/0.0)"))'))
-    call assert_equal("\n0.000000",    execute('py3 print(vim.eval("0.0/(1.0/0.0)"))'))
-    " Why there is a minus sign "-nan" as opposed to "nan"?
-    call assert_equal("\n-nan",        execute('py3 print(vim.eval("0.0/0.0"))'))
+    " Commented out: output of infinity and nan depend on platforms.
+    " call assert_equal("\ninf",         execute('py3 print(vim.eval("1.0/0.0"))'))
+    " call assert_equal("\n-inf",        execute('py3 print(vim.eval("-1.0/0.0"))'))
+    " call assert_equal("\n-nan",        execute('py3 print(vim.eval("0.0/0.0"))'))
   endif
   call assert_equal("\nabc",           execute('py3 print(vim.eval("\"abc\""))'))
   call assert_equal("\n['1', '2']",    execute('py3 print(vim.eval("[1, 2]"))'))

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -188,6 +188,31 @@ func Test_unicode()
   set encoding=utf8
 endfunc
 
+" Test vim.eval() with various types.
+func Test_python3_vim_val()
+  call assert_equal("\n8",             execute('py3 print(vim.eval("3+5"))'))
+  if has('float')
+    call assert_equal("\n3.140000",    execute('py3 print(vim.eval("1.01+2.13"))'))
+    call assert_equal("\ninf",         execute('py3 print(vim.eval("1.0/0.0"))'))
+    call assert_equal("\n-inf",        execute('py3 print(vim.eval("-1.0/0.0"))'))
+    call assert_equal("\n0.000000",    execute('py3 print(vim.eval("0.0/(1.0/0.0)"))'))
+    call assert_equal("\n-0.000000",   execute('py3 print(vim.eval("0.0/(-1.0/0.0)"))'))
+    call assert_equal("\n0.000000",    execute('py3 print(vim.eval("0.0/(1.0/0.0)"))'))
+    " Why there is a minus sign "-nan" as opposed to "nan"?
+    call assert_equal("\n-nan",        execute('py3 print(vim.eval("0.0/0.0"))'))
+  endif
+  call assert_equal("\nabc",           execute('py3 print(vim.eval("\"abc\""))'))
+  call assert_equal("\n['1', '2']",    execute('py3 print(vim.eval("[1, 2]"))'))
+  call assert_equal("\n{'1': '2'}",    execute('py3 print(vim.eval("{1:2}"))'))
+  call assert_equal("\nTrue",          execute('py3 print(vim.eval("v:true"))'))
+  call assert_equal("\nFalse",         execute('py3 print(vim.eval("v:false"))'))
+  call assert_equal("\nNone",          execute('py3 print(vim.eval("v:null"))'))
+  call assert_equal("\nNone",          execute('py3 print(vim.eval("v:none"))'))
+  call assert_equal("\nb'\\xab\\x12'", execute('py3 print(vim.eval("0zab12"))'))
+
+  call assert_fails('py3 vim.eval("1+")', 'vim.error: invalid expression')
+endfunc
+
 " Test range objects, see :help python-range
 func Test_python3_range()
   new


### PR DESCRIPTION
This PR improves test coverage of python3 vim.eval().

See uncovered code at:
https://codecov.io/gh/vim/vim/src/8b430b4c1df74bde757a7e5ee0ee2854fdad6472/src/if_py_both.h#L763