### PR TITLE
Test fixes for slower systems

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2247,17 +2247,17 @@ func Test_autocmd_SafeState()
 
   " Sometimes we loop to handle an K_IGNORE
   call term_sendkeys(buf, ":echo g:safe\<CR>")
-  call WaitForAssert({-> assert_match('^[12] ', term_getline(buf, 6))}, 1000)
+  call WaitForAssert({-> assert_match('^\d\+ ', term_getline(buf, 6))}, 1000)
 
   call term_sendkeys(buf, ":echo g:again\<CR>")
-  call WaitForAssert({-> assert_match('^xxxx', term_getline(buf, 6))}, 1000)
+  call WaitForAssert({-> assert_match('^xxx', term_getline(buf, 6))}, 1000)
 
   call term_sendkeys(buf, ":let g:again = ''\<CR>:call CallTimer()\<CR>")
   call term_wait(buf, 50)
   call term_sendkeys(buf, ":\<CR>")
   call term_wait(buf, 50)
   call term_sendkeys(buf, ":echo g:again\<CR>")
-  call WaitForAssert({-> assert_match('xtx', term_getline(buf, 6))}, 1000)
+  call WaitForAssert({-> assert_match('xt\+x', term_getline(buf, 6))}, 1000)
 
   call StopVimInTerminal(buf)
   call delete('XSafeState')

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -781,7 +781,7 @@ func Test_terminal_special_chars()
   call writefile(['x'], 'Xdir with spaces/quoted"file')
   term ls Xdir\ with\ spaces/quoted\"file
   call WaitForAssert({-> assert_match('quoted"file', term_getline('', 1))})
-  call term_wait('')
+  call WaitForAssert({-> assert_match('finish', term_getstatus(bufnr()))})
 
   call delete('Xdir with spaces', 'rf')
   bwipe


### PR DESCRIPTION
Couple fixes from investigating test failures on hppa, from the thread ["Test failure E89 in Test_terminal_special_chars() line 11 (bwipe)"](https://groups.google.com/d/msgid/vim_dev/CAON-T_g8-0XrCq7%2BZ0U8Z-XYP%3D9t9dEzYs-S2G8PCtoXcdg0Hg%40mail.gmail.com).