### PR TITLE
fix for DirectX scrolling when part of window is off-screen

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -382,6 +382,14 @@ directx_binddc(void)
     if (s_textArea != NULL)
     {
 	RECT	rect;
+
+	// Win 10 1809 stopped maintaining off-screen area, so using CopyFromRenderTarget()
+	// for scrolling breaks. Using a layered child window for text area restores the
+	// previous behavior. This isn't supported on earlier than Win 8, but no ill effect
+	// is observed from making these API calls regardless.
+	SetWindowLongPtr(s_textArea, GWL_EXSTYLE, WS_EX_LAYERED);
+	SetLayeredWindowAttributes(s_textArea, RGB(0, 0, 0), 255, LWA_ALPHA);
+
 	GetClientRect(s_textArea, &rect);
 	DWriteContext_BindDC(s_dwc, s_hdc, &rect);
     }


### PR DESCRIPTION
## Scrolling Corruption with DirectX

With `set renderoptions=directx` scrolling corrupts the display if part of the window is offscreen at the top or bottom.

See screenshot:
![screenshot](https://user-images.githubusercontent.com/42079499/75145081-2c001780-575d-11ea-8faf-7b104527a399.png)

Reason is that Windows 10 1809 and above no longer maintains image of the window portion that is off-screen.

https://stackoverflow.com/questions/54572498/manipulate-system-visible-clipping-region-in-windows-1809

https://stackoverflow.com/questions/53710135/printwindow-and-bitblt-of-hidden-windows/55759779#55759779

https://social.msdn.microsoft.com/Forums/en-US/c3ae68d1-2bad-475d-8e20-b7838ef6f57c/windows-10-build-1809-breaks-windows-api-user32-printwindow-functionality-for-offscreen-window?forum=windowsgeneraldevelopmentissues

Vim using DirectX scrolls by calling `CopyFromRenderTarget()` then `DrawBitmap()` with what will remain after scrolling - see `DWriteContext::Scroll()`. But `CopyFromRenderTarget()` won't return anything useful for part of window that is off-screen.

Windows 1809 *does* seem to maintain image of the window portion that is off-screen with layered window enabled.

https://docs.microsoft.com/en-us/windows/win32/winmsg/window-features#layered-windows

This patch just enables layered window for the text area. Fixes scrolling corruption. I haven't noticed any adverse effects to doing this. Layered child windows are only supported on Win8+ - test on Win7 and it failed gracefully.

Obviously another possible fix would be to redraw the lines that were previously off-screen.

