### PR TITLE
Fix php numeric literal syntax highlighting bugs.

### DIFF
--- a/runtime/syntax/php.vim
+++ b/runtime/syntax/php.vim
@@ -328,14 +328,15 @@ syn keyword phpBoolean true false contained
 
 " Float
 " Refer to: https://www.php.net/manual/en/language.types.float.php
-syn match phpFloat "\%(\w\|\.\)\@<!\%(\d\|\.\)*\d\%(\d\|\.\)*\%([eE][+-]\=\%(\d\|\.\)\+\)\=\%(\w\|\.\)\@!" contained contains=phpFloatError display
-syn match phpFloatError "[eE.].*\." contained display
+" and https://wiki.php.net/rfc/numeric_literal_separator#restrictions
+syn match phpFloat "\%(\w\|\.\)\@<!\%(\d_\?\|\.\)*\d\%(\d\|_\|\.\)*\%([eE][+-]\=\%(\d\|_\|\.\)\+\)\=\%(\w\|\.\)\@!" contained contains=phpFloatError display
+syn match phpFloatError "\%([eE.][0-9._+-]*\.\|__\|_\(\>\|[eE]\)\|\(\>\|[eE]\)_\)" contained display
 
 " Number
-syn match phpNumber "\%(\.\)\@<!\<\%([1-9]\d*\|0\|0[xX]\x\+\)\>\%(\.\)\@!" contained display
+syn match phpNumber "\%(\.\)\@<!\<\%([1-9]\d*\|0\|0[xX]\(\x_\?\)*\x\)\>\%(\.\)\@!" contained display
 syn match phpNumber "\%(\.\)\@<!\<0\d\+\>\%(\.\)\@!" contained contains=phpOctalError display
 syn match phpBinaryError "[2-9]" contained display
-syn match phpNumber "\%(\.\)\@<!\<0[bB]\d\+\>\%(\.\)\@!" contained contains=phpBinaryError display
+syn match phpNumber "\%(\.\)\@<!\<0[bB]\(\d_\?\)*\d\>\%(\.\)\@!" contained contains=phpBinaryError display
 
 " Backslash escapes
 syn case match


### PR DESCRIPTION
In php 7.4, numeric literals are allowed to use `_` as a separator.
https://wiki.php.net/rfc/numeric_literal_separator#restrictions

Also, `2.0, 'some string with a dot.'` would be highlighted as a syntax error
due to the old value of phpFloatError using `[eE.].*\.`, which went
beyond the characters in a valid float.

This commit doesn't fix `1.2+3.` (still incorrectly highlighted as an error), but fixes many other cases.

Sorry if this is the wrong repo, the link in the header is https://jasonwoof.com/gitweb/?p=vim-syntax.git;a=blob;f=php.vim;hb=HEAD (an older revision of this file from 2018)