### PR TITLE
Fixing markdown at appending section of tutor.pt

### DIFF
--- a/runtime/tutor/tutor.pt
+++ b/runtime/tutor/tutor.pt
@@ -131,8 +131,8 @@ NOTA: Enquanto segue este tutorial, não tente memorizar, aprenda pelo uso.
 
 ---> Há algum texto faltando nes
      Há algum texto faltando nesta linha.
-     Há algum texto faltan
----> Há algum texto faltando aqui.
+---> Há algum texto faltan
+     Há algum texto faltando aqui.
 
   5. Quando se sentir confortável adicionando texto, vá para a Lição 1.6.
 

--- a/runtime/tutor/tutor.pt.utf-8
+++ b/runtime/tutor/tutor.pt.utf-8
@@ -131,8 +131,8 @@ NOTA: Enquanto segue este tutorial, não tente memorizar, aprenda pelo uso.
 
 ---> Há algum texto faltando nes
      Há algum texto faltando nesta linha.
-     Há algum texto faltan
----> Há algum texto faltando aqui.
+---> Há algum texto faltan
+     Há algum texto faltando aqui.
 
   5. Quando se sentir confortável adicionando texto, vá para a Lição 1.6.
 


### PR DESCRIPTION
Fixing arrows order at portuguese vimtutor (1.5 - Appending section)