### PR TITLE
vim9: Fix :execute {variable} does not work

### DIFF
--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -690,4 +690,37 @@ def Test_disassemble_compare()
   " delete('Xdisassemble')
 enddef
 
+def s:Execute()
+  execute 'help vim9.txt'
+  let cmd = 'help vim9.txt'
+  execute cmd
+  let tag = 'vim9.txt'
+  execute 'help ' .. tag
+enddef
+
+def Test_disassemble_execute()
+  let res = execute('disass s:Execute')
+  assert_match('\<SNR>\d*_Execute.*'
+        \ .. "execute 'help vim9.txt'.*"
+        \ .. '\d PUSHS "help vim9.txt".*'
+        \ .. '\d EXECUTE 1.*'
+        \ .. "let cmd = 'help vim9.txt'.*"
+        \ .. '\d PUSHS "help vim9.txt".*'
+        \ .. '\d STORE $0.*'
+        \ .. 'execute cmd.*'
+        \ .. '\d LOAD $0.*'
+        \ .. '\d EXECUTE 1.*'
+        \ .. "let tag = 'vim9.txt'.*"
+        \ .. '\d PUSHS "vim9.txt".*'
+        \ .. '\d STORE $1.*'
+        \ .. "execute 'help ' .. tag.*"
+        \ .. '\d PUSHS "help ".*'
+        \ .. '\d LOAD $1.*'
+        \ .. '\d CONCAT.*'
+        \ .. '\d EXECUTE 1.*'
+        \ .. '\d PUSHNR 0.*'
+        \ .. '\d RETURN'
+        \, res)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -702,6 +702,10 @@ def Test_execute_cmd()
   assert_equal('execute-var', getline(1))
   execute cmd .. '|call setline(1, "execute-var-string")'
   assert_equal('execute-var-string', getline(1))
+  let cmd_first = 'call '
+  let cmd_last = 'setline(1, "execute-var-var")'
+  execute cmd_first .. cmd_last
+  assert_equal('execute-var-var', getline(1))
 enddef
 
 

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -692,5 +692,17 @@ def Test_substitute_cmd()
   delete('Xvim9lines')
 enddef
 
+def Test_execute_cmd()
+  new
+  setline(1, 'default')
+  execute 'call setline(1, "execute-string")'
+  assert_equal('execute-string', getline(1))
+  let cmd = 'call setline(1, "execute-var")'
+  execute cmd
+  assert_equal('execute-var', getline(1))
+  execute cmd .. '|call setline(1, "execute-var-string")'
+  assert_equal('execute-var-string', getline(1))
+enddef
+
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -14,6 +14,8 @@
 typedef enum {
     ISN_EXEC,	    // execute Ex command line isn_arg.string
     ISN_ECHO,	    // echo isn_arg.number items on top of stack
+    ISN_EXECUTE,    // execute Ex commands isn_arg.execute.execute_count
+		    // items on top of stack
 
     // get and set variables
     ISN_LOAD,	    // push local variable isn_arg.number
@@ -159,6 +161,11 @@ typedef struct {
     int	    echo_count;		// number of expressions
 } echo_T;
 
+// arguments to ISN_EXEC
+typedef struct {
+    int	    execute_count;	// number of expressions
+} execute_T;
+
 // arguments to ISN_OPNR, ISN_OPFLOAT, etc.
 typedef struct {
     exptype_T	op_type;
@@ -216,6 +223,7 @@ typedef struct {
 	cpfunc_T	    pfunc;
 	cufunc_T	    ufunc;
 	echo_T		    echo;
+	execute_T   	    execute;
 	opexpr_T	    op;
 	checktype_T	    type;
 	storenr_T	    storenr;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -533,6 +533,21 @@ call_def_function(
 		}
 		break;
 
+	    // execute :execute {string} ...
+	    case ISN_EXECUTE:
+		{
+		    int count = iptr->isn_arg.execute.execute_count;
+
+		    for (idx = 0; idx < count; ++idx)
+		    {
+			tv = STACK_TV_BOT(idx - count);
+			do_cmdline_cmd(tv_get_string_chk(tv));
+			clear_tv(tv);
+		    }
+		    ectx.ec_stack.ga_len -= count;
+		}
+		break;
+
 	    // load local variable or argument
 	    case ISN_LOAD:
 		if (ga_grow(&ectx.ec_stack, 1) == FAIL)
@@ -1664,6 +1679,13 @@ ex_disassemble(exarg_T *eap)
 		    smsg("%4d %s %d", current,
 			    echo->echo_with_white ? "ECHO" : "ECHON",
 			    echo->echo_count);
+		}
+		break;
+	    case ISN_EXECUTE:
+		{
+		    execute_T *execute = &iptr->isn_arg.execute;
+
+		    smsg("%4d EXECUTE %d", current, execute->execute_count);
 		}
 		break;
 	    case ISN_LOAD:


### PR DESCRIPTION
Currently, `:execute` doesn't work with variables:

```vim
def Execute()
  let cmd = 'help vim9.txt'
  execute cmd
enddef
call Execute() "=> E121: Undefined variable: cmd
```

This PR fixes it.