### PR TITLE
Fix: Popupwin-filter alters UTF-8 sequence of input character

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2977,7 +2977,7 @@ invoke_popup_filter(win_T *wp, int c)
 
     // Convert the number to a string, so that the function can use:
     //	    if a:c == "\<F2>"
-    buf[special_to_buf(c, mod_mask, TRUE, buf)] = NUL;
+    buf[special_to_buf(c, mod_mask, FALSE, buf)] = NUL;
     argv[1].v_type = VAR_STRING;
     argv[1].vval.v_string = vim_strsave(buf);
 

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3271,4 +3271,26 @@ func Test_popupwin_bufnr()
   bwipe!
 endfunc
 
+func Test_popupwin_filter_input_multibyte()
+  func MyPopupFilter(winid, c)
+    let g:bytes = range(a:c->strlen())->map({i -> char2nr(a:c[i])})
+    return 0
+  endfunc
+  let winid = popup_create('', #{mapping: 0, filter: 'MyPopupFilter'})
+
+  " UTF-8: E3 80 80, including K_SPECIAL(0x80)
+  call feedkeys("\u3000", 'xt')
+  call assert_equal([0xe3, 0x80, 0x80], g:bytes)
+
+  if has('gui')
+    " UTF-8: E3 80 9B, including CSI(0x9B)
+    call feedkeys("\u301b", 'xt')
+    call assert_equal([0xe3, 0x80, 0x9b], g:bytes)
+  endif
+
+  call popup_clear()
+  delfunc MyPopupFilter
+  unlet g:bytes
+endfunc
+
 " vim: shiftwidth=2 sts=2


### PR DESCRIPTION
Popupwin-filter escapes 0x80 (K_SPECIAL) and 0x9b (CSI) included in UTF-8 sequence of a multibyte character, against user expectations.

### Repro steps

test.vim:
```vim
func! MyPopupFilter(winid, c)
  echom range(a:c->strlen())->map({i -> char2nr(a:c[i])->printf('%02X')})
  return 0
endfunc
call popup_create('', #{mapping: 0, filter: 'MyPopupFilter'})

" UTF-8: E3 81 80, including K_SPECIAL(0x80)
call feedkeys("\u3040", 'xt')

" Expected: ['E3', '81', '80']
" Actual: ['E3', '81', '80', 'FE', '58']

" UTF-8: E3 81 9B, including CSI(0x9B)
call feedkeys("\u305b", 'xt')

" Expected: ['E3', '81', '9B']
" Actual(GUI): ['E3', '81', '9B', 'FD', '51']

call popup_clear()
```

```
vim --clean
:so test.vim
```

