### PR TITLE
Fix user manual on using count with "/"

### DIFF
--- a/runtime/doc/usr_03.txt
+++ b/runtime/doc/usr_03.txt
@@ -346,7 +346,7 @@ to find the first #include after the cursor: >
 
 And then type "n" several times.  You will move to each #include in the text.
 You can also use a count if you know which match you want.  Thus "3n" finds
-the third match.  Using a count with "/" doesn't work.
+the third match.  You can also use a count with "/".
 
 The "?" command works like "/" but searches backwards: >
 


### PR DESCRIPTION
The manual says that using count with "/" doesn't work, but it actually does work as you expected to move to the nth match.