### PR TITLE
win32: Fix that 8.2.0329 fails when VIMDLL is enabled

### DIFF
--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3284,7 +3284,7 @@ func Test_popupwin_filter_input_multibyte()
   call feedkeys("\u3000", 'xt')
   call assert_equal([0xe3, 0x80, 0x80], g:bytes)
 
-  if has('gui')
+  if has('gui_running')
     " UTF-8: E3 80 9B, including CSI(0x9B)
     call feedkeys("\u301b", 'xt')
     call assert_equal([0xe3, 0x80, 0x9b], g:bytes)


### PR DESCRIPTION
If vim.exe is built with VIMDLL, the following error occurs:

	From test_popupwin.vim:
	Found errors in Test_popupwin_filter_input_multibyte():
	function RunTheTest[40]..Test_popupwin_filter_input_multibyte line 14: Expected [227, 128, 155] but got [195, 189]

The test checks `has('gui')`, but it should be `has('gui_running')`.