### PR TITLE
Fix sourcing tests on FreeBSD

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -397,6 +397,7 @@ NEW_TESTS_RES = \
 	test_mapping.res \
 	test_marks.res \
 	test_match.res \
+	test_matchadd_conceal_utf8.res \
 	test_matchadd_conceal.res \
 	test_memory_usage.res \
 	test_messages.res \

--- a/src/testdir/test_alot_utf8.vim
+++ b/src/testdir/test_alot_utf8.vim
@@ -7,7 +7,6 @@
 source test_charsearch_utf8.vim
 source test_expr_utf8.vim
 source test_listlbr_utf8.vim
-source test_matchadd_conceal_utf8.vim
 source test_mksession_utf8.vim
 source test_regexp_utf8.vim
 source test_source_utf8.vim

--- a/src/testdir/test_source_utf8.vim
+++ b/src/testdir/test_source_utf8.vim
@@ -3,8 +3,6 @@ source check.vim
 
 func Test_source_utf8()
   " check that sourcing a script with 0x80 as second byte works
-  " does not work correctly on BSD
-  CheckNotBSD
   new
   call setline(1, [':%s/àx/--à1234--/g', ':%s/Àx/--À1234--/g'])
   write! Xscript
@@ -34,25 +32,24 @@ endfunc
 
 " Test for sourcing a file with CTRL-V's at the end of the line
 func Test_source_ctrl_v()
-    CheckNotBSD
-    call writefile(['map __1 afirst',
-		\ 'map __2 asecond',
-		\ 'map __3 athird',
-		\ 'map __4 afourth',
-		\ 'map __5 afifth',
-		\ "map __1 asd\<C-V>",
-		\ "map __2 asd\<C-V>\<C-V>",
-		\ "map __3 asd\<C-V>\<C-V>",
-		\ "map __4 asd\<C-V>\<C-V>\<C-V>",
-		\ "map __5 asd\<C-V>\<C-V>\<C-V>",
-		\ ], 'Xtestfile')
+  call writefile(['map __1 afirst',
+        \ 'map __2 asecond',
+        \ 'map __3 athird',
+        \ 'map __4 afourth',
+        \ 'map __5 afifth',
+        \ "map __1 asd\<C-V>",
+        \ "map __2 asd\<C-V>\<C-V>",
+        \ "map __3 asd\<C-V>\<C-V>",
+        \ "map __4 asd\<C-V>\<C-V>\<C-V>",
+        \ "map __5 asd\<C-V>\<C-V>\<C-V>",
+        \ ], 'Xtestfile')
   source Xtestfile
   enew!
   exe "normal __1\<Esc>\<Esc>__2\<Esc>__3\<Esc>\<Esc>__4\<Esc>__5\<Esc>"
   exe "%s/\<C-J>/0/g"
   call assert_equal(['sd',
-	      \ "map __2 asd\<Esc>secondsd\<Esc>sd0map __5 asd0fifth"],
-	      \ getline(1, 2))
+        \ "map __2 asd\<Esc>secondsd\<Esc>sd0map __5 asd0fifth"],
+        \ getline(1, 2))
 
   enew!
   call delete('Xtestfile')


### PR DESCRIPTION
On FreeBSD, `:set term=ansi` sets "t_kd" to "\n", so `:source! ...` interprets `<LF>` in file as `<Down>`. As a result, `:source! ...` cannot finish reading one line and stops until some input occurs.

```
:set term=ansi
:set t_kd
t_kd <Down>      ^@
```

Therefore the testfiles executing `:set term=...` should run separately from other tests.