### PR TITLE
win32: vimdll: Fix feedkeys() on vim.exe

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1623,7 +1623,7 @@ vgetc(void)
 	    // Get two extra bytes for special keys
 	    if (c == K_SPECIAL
 #ifdef FEAT_GUI
-		    || (gui.in_use && c == CSI)
+		    || (c == CSI)
 #endif
 	       )
 	    {
@@ -1678,23 +1678,19 @@ vgetc(void)
 		}
 #endif
 #ifdef FEAT_GUI
-		if (gui.in_use)
+		// Handle focus event here, so that the caller doesn't need to
+		// know about it.  Return K_IGNORE so that we loop once (needed
+		// if 'lazyredraw' is set).
+		if (c == K_FOCUSGAINED || c == K_FOCUSLOST)
 		{
-		    // Handle focus event here, so that the caller doesn't
-		    // need to know about it.  Return K_IGNORE so that we loop
-		    // once (needed if 'lazyredraw' is set).
-		    if (c == K_FOCUSGAINED || c == K_FOCUSLOST)
-		    {
-			ui_focus_change(c == K_FOCUSGAINED);
-			c = K_IGNORE;
-		    }
-
-		    // Translate K_CSI to CSI.  The special key is only used
-		    // to avoid it being recognized as the start of a special
-		    // key.
-		    if (c == K_CSI)
-			c = CSI;
+		    ui_focus_change(c == K_FOCUSGAINED);
+		    c = K_IGNORE;
 		}
+
+		// Translate K_CSI to CSI.  The special key is only used to
+		// avoid it being recognized as the start of a special key.
+		if (c == K_CSI)
+		    c = CSI;
 #endif
 	    }
 	    // a keypad or special function key was not mapped, use it like
@@ -1772,11 +1768,7 @@ vgetc(void)
 		    buf[i] = vgetorpeek(TRUE);
 		    if (buf[i] == K_SPECIAL
 #ifdef FEAT_GUI
-			    || (
-# ifdef VIMDLL
-				gui.in_use &&
-# endif
-				buf[i] == CSI)
+			    || (buf[i] == CSI)
 #endif
 			    )
 		    {

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3284,11 +3284,9 @@ func Test_popupwin_filter_input_multibyte()
   call feedkeys("\u3000", 'xt')
   call assert_equal([0xe3, 0x80, 0x80], g:bytes)
 
-  if has('gui')
-    " UTF-8: E3 80 9B, including CSI(0x9B)
-    call feedkeys("\u301b", 'xt')
-    call assert_equal([0xe3, 0x80, 0x9b], g:bytes)
-  endif
+  " UTF-8: E3 80 9B, including CSI(0x9B)
+  call feedkeys("\u301b", 'xt')
+  call assert_equal([0xe3, 0x80, 0x9b], g:bytes)
 
   call popup_clear()
   delfunc MyPopupFilter


### PR DESCRIPTION
8.2.0329 revealed that feedkeys() on vim.exe with VIMDLL has an issue with
handling 0x9b bytes. (Related: https://github.com/vim/vim/pull/5716)

This reverts [8.1.1358](https://github.com/vim/vim/pull/4396) and [8.1.1239](https://github.com/vim/vim/pull/4318), and modifies mch_inchar() to encode 0x9b
bytes so that the keys can be handled in the same way as unix version.

Thanks to @ichizok for investigating the issue.
