### PR TITLE
Fix popup

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -1281,7 +1281,7 @@ popup_adjust_position(win_T *wp)
 							      (colnr_T)MAXCOL);
 	wp->w_width = w_width;
 
-	if (wp->w_p_wrap)
+	if (wp->w_p_wrap && maxwidth > 0)
 	{
 	    while (len > maxwidth)
 	    {


### PR DESCRIPTION
```
func! Test() abort
  call popup_atcursor(repeat('x', 500), {
  \ 'moved': 'any',
  \ 'border': [1, 1, 1, 1],
  \})
endfunc
call cursor([9, 78])
call Test()
"=======================================================================================
```
Please test this. Vim goes in endless loop since popup location does not be found.
