### PR TITLE
sshconfig: hmac keyword and autocmd matching improvements

### DIFF
--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -77,16 +77,24 @@ syn match   sshconfigMAC "\<umac-128-etm@openssh\.com\>"
 
 syn keyword sshconfigHostKeyAlgo ssh-ed25519
 syn match sshconfigHostKeyAlgo "\<ssh-ed25519-cert-v01@openssh\.com\>"
+syn match sshconfigHostKeyAlgo "\<sk-ssh-ed25519@openssh\.com\>"
+syn match sshconfigHostKeyAlgo "\<sk-ssh-ed25519-cert-v01@openssh\.com\>"
 syn keyword sshconfigHostKeyAlgo ssh-rsa
+syn keyword sshconfigHostKeyAlgo rsa-sha2-256
+syn keyword sshconfigHostKeyAlgo rsa-sha2-512
 syn keyword sshconfigHostKeyAlgo ssh-dss
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp256
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp384
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp521
+syn match sshconfigHostKeyAlgo "\<sk-ecdsa-sha2-nistp256@openssh\.com\>"
 syn match sshconfigHostKeyAlgo "\<ssh-rsa-cert-v01@openssh\.com\>"
+syn match sshconfigHostKeyAlgo "\<rsa-sha2-256-cert-v01@openssh\.com\>"
+syn match sshconfigHostKeyAlgo "\<rsa-sha2-512-cert-v01@openssh\.com\>"
 syn match sshconfigHostKeyAlgo "\<ssh-dss-cert-v01@openssh\.com\>"
 syn match sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp256-cert-v01@openssh\.com\>"
 syn match sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp384-cert-v01@openssh\.com\>"
 syn match sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp521-cert-v01@openssh\.com\>"
+syn match sshconfigHostKeyAlgo "\<sk-ecdsa-sha2-nistp256-cert-v01@openssh\.com\>"
 
 syn keyword sshconfigPreferredAuth hostbased publickey password gssapi-with-mic
 syn keyword sshconfigPreferredAuth keyboard-interactive

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -56,12 +56,12 @@ syn match sshconfigCiphers "\<aes256-gcm@openssh\.com\>"
 syn match sshconfigCiphers "\<chacha20-poly1305@openssh\.com\>"
 
 syn keyword sshconfigMAC hmac-sha1
-syn keyword sshconfigMAC mac-sha1-96
-syn keyword sshconfigMAC mac-sha2-256
-syn keyword sshconfigMAC mac-sha2-512
-syn keyword sshconfigMAC mac-md5
-syn keyword sshconfigMAC mac-md5-96
-syn keyword sshconfigMAC mac-ripemd160
+syn keyword sshconfigMAC hmac-sha1-96
+syn keyword sshconfigMAC hmac-sha2-256
+syn keyword sshconfigMAC hmac-sha2-512
+syn keyword sshconfigMAC hmac-md5
+syn keyword sshconfigMAC hmac-md5-96
+syn keyword sshconfigMAC hmac-ripemd160
 syn match   sshconfigMAC "\<hmac-ripemd160@openssh\.com\>"
 syn match   sshconfigMAC "\<umac-64@openssh\.com\>"
 syn match   sshconfigMAC "\<umac-128@openssh\.com\>"

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -58,12 +58,12 @@ syn match sshdconfigCiphers "\<aes256-gcm@openssh\.com\>"
 syn match sshdconfigCiphers "\<chacha20-poly1305@openssh\.com\>"
 
 syn keyword sshdconfigMAC hmac-sha1
-syn keyword sshdconfigMAC mac-sha1-96
-syn keyword sshdconfigMAC mac-sha2-256
-syn keyword sshdconfigMAC mac-sha2-512
-syn keyword sshdconfigMAC mac-md5
-syn keyword sshdconfigMAC mac-md5-96
-syn keyword sshdconfigMAC mac-ripemd160
+syn keyword sshdconfigMAC hmac-sha1-96
+syn keyword sshdconfigMAC hmac-sha2-256
+syn keyword sshdconfigMAC hmac-sha2-512
+syn keyword sshdconfigMAC hmac-md5
+syn keyword sshdconfigMAC hmac-md5-96
+syn keyword sshdconfigMAC hmac-ripemd160
 syn match   sshdconfigMAC "\<hmac-ripemd160@openssh\.com\>"
 syn match   sshdconfigMAC "\<umac-64@openssh\.com\>"
 syn match   sshdconfigMAC "\<umac-128@openssh\.com\>"


### PR DESCRIPTION
This PR addresses two issues I noticed with the `sshconfig` and `sshdconfig` filetypes:

The first is that the following `MAC` options are not highlighted:

* `hmac-sha1-96`
* `hmac-sha2-256`
* `hmac-sha2-512`
* `hmac-md5`
* `hmac-md5-96`

Both `sshconfig` and `sshdconfig` have these listed as keywords without the leading "h".  I couldn't find evidence of such options in current or previous versions of SSH/SSHD (using `git log -G '\<mac-sha1-96\>' -- mac.c` and similar), so I assume this was an error rather than the result of a previous version which supported these keywords.  Therefore, this PR replaces "mac" with "hmac" to match them.

The second issue is that `/etc/ssh/ssh_config.d/*.conf` and `/etc/ssh/sshd_config.d/*.conf` are not recognized as `sshconfig` and `sshdconfig` by default.  These files have been automatically loaded by OpenSSH in Debian since 8.2 (1:8.2p1-2).  (As a result of https://bugs.debian.org/845315.)  This PR adds them.

I emailed this patch series to the maintainer on 3/2 but have not received a response.  Thus, this PR.  If you'd prefer separate PRs for each issue, let me know.

Thanks for considering,
Kevin