### PR TITLE
Add additional tests for menu.c based on code coverage

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2601,6 +2601,7 @@ matchstr({expr}, {pat} [, {start} [, {count}]])
 matchstrpos({expr}, {pat} [, {start} [, {count}]])
 				List	{count}'th match of {pat} in {expr}
 max({expr})			Number	maximum value of items in {expr}
+menu_info({name} [, {mode}])	Dict	get menu item information
 min({expr})			Number	minimum value of items in {expr}
 mkdir({name} [, {path} [, {prot}]])
 				Number	create directory {name}
@@ -7124,6 +7125,64 @@ matchstrpos({expr}, {pat} [, {start} [, {count}]])		*matchstrpos()*
 		Can also be used as a |method|: >
 			GetText()->matchstrpos('word')
 <
+menu_info({name} [, {mode}])				*menu_info()*
+		Return information about the specified menu {name} in
+		mode {mode}. The menu name should be specified without the
+		shortcut character ('&').
+
+		{mode} can be one of these strings:
+			"n"	Normal
+			"v"	Visual (including Select)
+			"o"	Operator-pending
+			"i"	Insert
+			"c"	Cmd-line
+			"s"	Select
+			"x"	Visual
+			"t"	Terminal-Job
+			""	Normal, Visual and Operator-pending
+			"!"	Insert and Cmd-line
+		When {mode} is omitted, the modes for "" are used.
+
+		Returns a |Dictionary| containing the following items:
+		  accel		menu item accelerator text |menu-text|
+		  display	display name (name without '&')
+		  enabled	v:true if this menu item is enabled
+				Refer to |:menu-enable|
+		  icon		name of the icon file (for toolbar)
+				|toolbar-icon|
+		  iconidx	index of a built-in icon
+		  modes		modes for which the menu is defined. In
+				addition to the modes mentioned above, these
+				characters will be used:
+				" "	Normal, Visual and Operator-pending
+		  name		menu item name.
+		  noremenu	v:true if the {rhs} of the menu item is not
+				remappable else v:false.
+		  priority	menu order priority |menu-priority|
+		  rhs		right-hand-side of the menu item. The returned
+				string has special characters translated like
+				in the output of the ":menu" command listing.
+				When the {rhs} of a menu item is empty, then
+				"<Nop>" is returned.
+		  script	v:true if script-local remapping of {rhs} is
+				allowed else v:false.  See |:menu-script|.
+		  shortcut	shortcut key (character after '&' in
+				the menu name) |menu-shortcut|
+		  silent	v:true if the menu item is created
+				with <silent> argument |:menu-silent|
+		  submenus	|List| containing the names of
+				all the submenus.  Present only if the menu
+				item has submenus.
+
+		Returns an empty dictionary if the menu item is not found.
+
+		Examples: >
+			:echo maparg('Edit.Cut')
+			:echo maparg('File.Save', 'n')
+<
+		Can also be used as a |method|: >
+			GetMenuName()->maparg('v')
+
 							*max()*
 max({expr})	Return the maximum value of all items in {expr}.
 		{expr} can be a List or a Dictionary.  For a Dictionary,

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -578,9 +578,11 @@ tooltips for menus. See |terminal-typing|.
 
 Special characters in a menu name:
 
+							*menu-shortcut*
 	&	The next character is the shortcut key.  Make sure each
 		shortcut key is only used once in a (sub)menu.  If you want to
 		insert a literal "&" in the menu name use "&&".
+							*menu-text*
 	<Tab>	Separates the menu name from right-aligned text.  This can be
 		used to show the equivalent typed command.  The text "<Tab>"
 		can be used here for convenience.  If you are using a real
@@ -954,7 +956,7 @@ item for the keyword under the cursor.  The register "z" is used. >
 mappings, or put these lines in your gvimrc; "<C-R>" is CTRL-R, "<CR>" is
 the <CR> key.  |<>|)
 
-
+							*tooltips* *menu-tips*
 5.8 Tooltips & Menu tips
 
 See section |42.4| in the user manual.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -921,6 +921,7 @@ GUI:						*gui-functions*
 	balloon_show()		set the balloon content
 	balloon_split()		split a message for a balloon
 	balloon_gettext()	get the text in the balloon
+	menu_info()		get information about a menu item
 
 Vim server:					*server-functions*
 	serverlist()		return the list of server names

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -646,6 +646,7 @@ static funcentry_T global_functions[] =
     {"matchstr",	2, 4, FEARG_1,	  ret_string,	f_matchstr},
     {"matchstrpos",	2, 4, FEARG_1,	  ret_list_any,	f_matchstrpos},
     {"max",		1, 1, FEARG_1,	  ret_any,	f_max},
+    {"menu_info",	1, 2, FEARG_1,	  ret_dict_any,	f_menu_info},
     {"min",		1, 1, FEARG_1,	  ret_any,	f_min},
     {"mkdir",		1, 3, FEARG_1,	  ret_number,	f_mkdir},
     {"mode",		0, 1, FEARG_1,	  ret_string,	f_mode},

--- a/src/proto/menu.pro
+++ b/src/proto/menu.pro
@@ -23,4 +23,5 @@ void ex_emenu(exarg_T *eap);
 void winbar_click(win_T *wp, int col);
 vimmenu_T *gui_find_menu(char_u *path_name);
 void ex_menutranslate(exarg_T *eap);
+void f_menu_info(typval_T *argvars, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -89,6 +89,34 @@ func Test_menu_commands()
   unlet g:did_menu
 endfun
 
+" Test various menu related errors
+func Test_menu_errors()
+  menu Test.Foo  :version<CR>
+
+  " Error cases
+  call assert_fails('menu .Test.Foo :ls<CR>', 'E475:')
+  call assert_fails('menu Test. :ls<CR>', 'E330:')
+  call assert_fails('menu Foo. :ls<CR>', 'E331:')
+  call assert_fails('unmenu Test.Foo abc', 'E488:')
+  call assert_fails('menu <Tab>:ls  :ls<CR>', 'E792:')
+  call assert_fails('menu Test.<Tab>:ls  :ls<CR>', 'E792:')
+  call assert_fails('menu Test.Foo.Bar  :ls<CR>', 'E327:')
+  call assert_fails('menu Test.-Sep-.Baz  :ls<CR>', 'E332:')
+  call assert_fails('menu Foo.Bar.--.Baz  :ls<CR>', 'E332:')
+  call assert_fails('menu disable Test.Foo.Bar', 'E327:')
+  call assert_fails('menu disable T.Foo', 'E329:')
+  call assert_fails('unmenu Test.Foo.Bar', 'E327:')
+  call assert_fails('cunmenu Test.Foo', 'E328:')
+  call assert_fails('unmenu Test.Bar', 'E329:')
+  call assert_fails('menu Test.Foo.Bar', 'E327:')
+  call assert_fails('cmenu Test.Foo', 'E328:')
+  call assert_fails('emenu x Test.Foo', 'E475:')
+  call assert_fails('emenu Test.Foo.Bar', 'E334:')
+  call assert_fails('menutranslate Test', 'E474:')
+
+  unmenu Test
+endfunc
+
 " Test for menu item completion in command line
 func Test_menu_expand()
   " Create the menu itmes for test
@@ -119,8 +147,272 @@ func Test_menu_expand()
         \ "\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"emenu Buffers. Xmenu.', @:)
 
+  " Test for expanding only submenus
+  call feedkeys(":popup Xmenu.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"popup Xmenu.A1 A2 A3 A4', @:)
+
+  " Test for expanding menus after enable/disable
+  call feedkeys(":menu enable Xmenu.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"menu enable Xmenu.A1. A2. A3. A4.', @:)
+  call feedkeys(":menu disable Xmenu.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"menu disable Xmenu.A1. A2. A3. A4.', @:)
+
+  " Test for expanding non-existing menu path
+  call feedkeys(":menu xyz.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"menu xyz.', @:)
+  call feedkeys(":menu Xmenu.A1.A1B1.xyz.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"menu Xmenu.A1.A1B1.xyz.', @:)
+
   set wildmenu&
   unmenu Xmenu
+endfunc
+
+" Test for the menu_info() function
+func Test_menu_info()
+  " Define menus with various attributes
+  10nnoremenu 10.10 T&est.F&oo  :echo 'foo'<CR>
+  10nmenu <silent> 10.20 T&est.B&ar<Tab>:bar  :echo 'bar'<CR>
+  10nmenu <script> 10.30.5 T&est.Ba&z.Qu&x  :echo 'qux'<CR>
+
+  let d = #{name: "B&ar\t:bar", display: 'Bar', modes: 'n', shortcut: 'a',
+        \ accel: ':bar', priority: 20, enabled: v:true, silent: v:true,
+        \ noremenu: v:false, script: v:false, rhs: ":echo 'bar'<CR>"}
+  call assert_equal(d, menu_info('Test.Bar'))
+
+  let d = #{name: 'Ba&z', display: 'Baz', modes: 'n', shortcut: 'z',
+        \ priority: 30, submenus: ['Qux']}
+  call assert_equal(d, menu_info('Test.Baz'))
+
+  let d = #{name: 'T&est', display: 'Test', modes: 'n', shortcut: 'e',
+        \ priority: 10, submenus: ['Foo', 'Bar', 'Baz']}
+  call assert_equal(d, menu_info('Test'))
+  call assert_equal({}, menu_info('Test.Dummy'))
+  call assert_equal({}, menu_info('Dummy'))
+
+  nmenu disable Test.Foo
+  call assert_equal(v:false, menu_info('Test.Foo').enabled)
+  nmenu enable Test.Foo
+  call assert_equal(v:true, menu_info('Test.Foo').enabled)
+
+  call assert_equal(menu_info('Test.Foo'), menu_info('Test.Foo', ''))
+  nmenu Test.abc  <Nop>
+  call assert_equal('<Nop>', menu_info('Test.abc').rhs)
+  call assert_fails('call menu_info([])', 'E730:')
+  nunmenu Test
+
+  " Test for defining menus in different modes
+  menu Test.menu :menu<CR>
+  menu! Test.menu! :menu!<CR>
+  amenu Test.amenu  :amenu<CR>
+  nmenu Test.nmenu  :nmenu<CR>
+  omenu Test.omenu  :omenu<CR>
+  vmenu Test.vmenu  :vmenu<CR>
+  xmenu Test.xmenu  :xmenu<CR>
+  smenu Test.smenu  :smenu<CR>
+  imenu <silent> <script> Test.imenu  :imenu<CR>
+  cmenu Test.cmenu  :cmenu<CR>
+  tlmenu Test.tlmenu  :tlmenu<CR>
+  tmenu Test.nmenu Normal mode menu
+  tmenu Test.omenu Op-pending mode menu
+  noremenu Test.noremenu :noremenu<CR>
+  noremenu! Test.noremenu! :noremenu!<CR>
+  anoremenu Test.anoremenu  :anoremenu<CR>
+  nnoremenu Test.nnoremenu  :nnoremenu<CR>
+  onoremenu Test.onoremenu  :onoremenu<CR>
+  vnoremenu Test.vnoremenu  :vnoremenu<CR>
+  xnoremenu Test.xnoremenu  :xnoremenu<CR>
+  snoremenu Test.snoremenu  :snoremenu<CR>
+  inoremenu <silent> Test.inoremenu  :inoremenu<CR>
+  cnoremenu Test.cnoremenu  :cnoremenu<CR>
+  tlnoremenu Test.tlnoremenu  :tlnoremenu<CR>
+  call assert_equal(#{name: 'menu', priority: 500, shortcut: '',
+        \ display: 'menu', modes: ' ', enabled: v:true, silent: v:false,
+        \ rhs: ":menu<CR>", noremenu: v:false, script: v:false},
+        \ menu_info('Test.menu'))
+  call assert_equal(#{name: 'menu!', priority: 500, shortcut: '',
+        \ display: 'menu!', modes: '!', enabled: v:true, silent: v:false,
+        \ rhs: ":menu!<CR>", noremenu: v:false, script: v:false},
+        \ menu_info('Test.menu!', '!'))
+  call assert_equal(#{name: 'amenu', priority: 500, shortcut: '',
+        \ display: 'amenu', modes: 'a', enabled: v:true, silent: v:false,
+        \ rhs: ":amenu<CR>", noremenu: v:false, script: v:false},
+        \ menu_info('Test.amenu', 'a'))
+  call assert_equal(#{name: 'nmenu', priority: 500, shortcut: '',
+        \ display: 'nmenu', modes: 'n', enabled: v:true, silent: v:false,
+        \ rhs: ':nmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.nmenu', 'n'))
+  call assert_equal(#{name: 'omenu', priority: 500, shortcut: '',
+        \ display: 'omenu', modes: 'o', enabled: v:true, silent: v:false,
+        \ rhs: ':omenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.omenu', 'o'))
+  call assert_equal(#{name: 'vmenu', priority: 500, shortcut: '',
+        \ display: 'vmenu', modes: 'v', enabled: v:true, silent: v:false,
+        \ rhs: ':vmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.vmenu', 'v'))
+  call assert_equal(#{name: 'xmenu', priority: 500, shortcut: '',
+        \ display: 'xmenu', modes: 'x', enabled: v:true, silent: v:false,
+        \ rhs: ':xmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.xmenu', 'x'))
+  call assert_equal(#{name: 'smenu', priority: 500, shortcut: '',
+        \ display: 'smenu', modes: 's', enabled: v:true, silent: v:false,
+        \ rhs: ':smenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.smenu', 's'))
+  call assert_equal(#{name: 'imenu', priority: 500, shortcut: '',
+        \ display: 'imenu', modes: 'i', enabled: v:true, silent: v:true,
+        \ rhs: ':imenu<CR>', noremenu: v:false, script: v:true},
+        \ menu_info('Test.imenu', 'i'))
+  call assert_equal(#{ name: 'cmenu', priority: 500, shortcut: '',
+        \ display: 'cmenu', modes: 'c', enabled: v:true, silent: v:false,
+        \ rhs: ':cmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.cmenu', 'c'))
+  call assert_equal(#{name: 'tlmenu', priority: 500, shortcut: '',
+        \ display: 'tlmenu', modes: 'tl', enabled: v:true, silent: v:false,
+        \ rhs: ':tlmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.tlmenu', 'tl'))
+  call assert_equal(#{name: 'noremenu', priority: 500, shortcut: '',
+        \ display: 'noremenu', modes: ' ', enabled: v:true, silent: v:false,
+        \ rhs: ":noremenu<CR>", noremenu: v:true, script: v:false},
+        \ menu_info('Test.noremenu'))
+  call assert_equal(#{name: 'noremenu!', priority: 500, shortcut: '',
+        \ display: 'noremenu!', modes: '!', enabled: v:true, silent: v:false,
+        \ rhs: ":noremenu!<CR>", noremenu: v:true, script: v:false},
+        \ menu_info('Test.noremenu!', '!'))
+  call assert_equal(#{name: 'anoremenu', priority: 500, shortcut: '',
+        \ display: 'anoremenu', modes: 'a', enabled: v:true, silent: v:false,
+        \ rhs: ":anoremenu<CR>", noremenu: v:true, script: v:false},
+        \ menu_info('Test.anoremenu', 'a'))
+  call assert_equal(#{name: 'nnoremenu', priority: 500, shortcut: '',
+        \ display: 'nnoremenu', modes: 'n', enabled: v:true, silent: v:false,
+        \ rhs: ':nnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.nnoremenu', 'n'))
+  call assert_equal(#{name: 'onoremenu', priority: 500, shortcut: '',
+        \ display: 'onoremenu', modes: 'o', enabled: v:true, silent: v:false,
+        \ rhs: ':onoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.onoremenu', 'o'))
+  call assert_equal(#{name: 'vnoremenu', priority: 500, shortcut: '',
+        \ display: 'vnoremenu', modes: 'v', enabled: v:true, silent: v:false,
+        \ rhs: ':vnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.vnoremenu', 'v'))
+  call assert_equal(#{name: 'xnoremenu', priority: 500, shortcut: '',
+        \ display: 'xnoremenu', modes: 'x', enabled: v:true, silent: v:false,
+        \ rhs: ':xnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.xnoremenu', 'x'))
+  call assert_equal(#{name: 'snoremenu', priority: 500, shortcut: '',
+        \ display: 'snoremenu', modes: 's', enabled: v:true, silent: v:false,
+        \ rhs: ':snoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.snoremenu', 's'))
+  call assert_equal(#{name: 'inoremenu', priority: 500, shortcut: '',
+        \ display: 'inoremenu', modes: 'i', enabled: v:true, silent: v:true,
+        \ rhs: ':inoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.inoremenu', 'i'))
+  call assert_equal(#{ name: 'cnoremenu', priority: 500, shortcut: '',
+        \ display: 'cnoremenu', modes: 'c', enabled: v:true, silent: v:false,
+        \ rhs: ':cnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.cnoremenu', 'c'))
+  call assert_equal(#{name: 'tlnoremenu', priority: 500, shortcut: '',
+        \ display: 'tlnoremenu', modes: 'tl', enabled: v:true, silent: v:false,
+        \ rhs: ':tlnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.tlnoremenu', 'tl'))
+  aunmenu Test
+  tlunmenu Test
+  call assert_equal({}, menu_info('Test'))
+  call assert_equal({}, menu_info('Test', '!'))
+  call assert_equal({}, menu_info('Test', 'a'))
+  call assert_equal({}, menu_info('Test', 'n'))
+  call assert_equal({}, menu_info('Test', 'o'))
+  call assert_equal({}, menu_info('Test', 'v'))
+  call assert_equal({}, menu_info('Test', 'x'))
+  call assert_equal({}, menu_info('Test', 's'))
+  call assert_equal({}, menu_info('Test', 'i'))
+  call assert_equal({}, menu_info('Test', 'c'))
+  call assert_equal({}, menu_info('Test', 't'))
+  call assert_equal({}, menu_info('Test', 'tl'))
+
+  amenu Test.amenu  :amenu<CR>
+  call assert_equal(':amenu<CR>', menu_info('Test.amenu', '').rhs)
+  call assert_equal('<C-\><C-O>:amenu<CR>', menu_info('Test.amenu', '!').rhs)
+  call assert_equal(':amenu<CR>', menu_info('Test.amenu', 'n').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 'o').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 'v').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 'x').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 's').rhs)
+  call assert_equal('<C-\><C-O>:amenu<CR>', menu_info('Test.amenu', 'i').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 'c').rhs)
+  aunmenu Test.amenu
+endfunc
+
+" Test for <special> keyword in a menu with 'cpo' containing '<'
+func Test_menu_special()
+  new
+  set cpo+=<
+  nmenu Test.Sign  am<Tab>n<Esc>
+  call feedkeys(":emenu n Test.Sign\<CR>", 'x')
+  call assert_equal("m<Tab>n<Esc>", getline(1))
+  nunmenu Test.Sign
+  nmenu <special> Test.Sign  am<Tab>n<Esc>
+  call setline(1, '')
+  call feedkeys(":emenu n Test.Sign\<CR>", 'x')
+  call assert_equal("m\tn", getline(1))
+  set cpo-=<
+  close!
+  nunmenu Test.Sign
+endfunc
+
+" Test for "icon=filname" in a toolbar
+func Test_menu_icon()
+  CheckFeature toolbar
+  nmenu icon=myicon.xpm Toolbar.Foo  :echo "Foo"<CR>
+  call assert_equal('myicon.xpm', "Toolbar.Foo"->menu_info().icon)
+  nunmenu Toolbar.Foo
+
+  " Test for using the builtin icon
+  amenu ToolBar.BuiltIn22 :echo "BuiltIn22"<CR>
+  call assert_equal(#{name: 'BuiltIn22', display: 'BuiltIn22',
+        \ enabled: v:true, shortcut: '', modes: 'a', script: v:false,
+        \ iconidx: 22, priority: 500, silent: v:false,
+        \ rhs: ':echo "BuiltIn22"<CR>', noremenu: v:false},
+        \ menu_info("ToolBar.BuiltIn22"))
+  aunmenu ToolBar.BuiltIn22
+endfunc
+
+" Test for ":emenu" command in different modes
+func Test_emenu_cmd()
+  new
+  xmenu Test.foo rx
+  call setline(1, ['aaaa', 'bbbb'])
+  normal ggVj
+  %emenu Test.foo
+  call assert_equal(['xxxx', 'xxxx'], getline(1, 2))
+  call setline(1, ['aaaa', 'bbbb'])
+  exe "normal ggVj\<Esc>"
+  %emenu Test.foo
+  call assert_equal(['xxxx', 'xxxx'], getline(1, 2))
+  call setline(1, ['aaaa', 'bbbb'])
+  exe "normal ggV\<Esc>"
+  2emenu Test.foo
+  call assert_equal(['aaaa', 'xxxx'], getline(1, 2))
+  xunmenu Test.foo
+  close!
+endfunc
+
+" Test for PopUp menus
+func Test_popup_menu()
+  20menu PopUp.foo :echo 'foo'<CR>
+  20menu PopUp.bar :echo 'bar'<CR>
+  call assert_equal(#{name: 'PopUp', display: 'PopUp', priority: 20,
+        \ shortcut: '', modes: ' ', submenus: ['foo', 'bar']},
+        \ menu_info('PopUp'))
+  menu disable PopUp.bar
+  call assert_equal(v:true, "PopUp.foo"->menu_info().enabled)
+  call assert_equal(v:false, "PopUp.bar"->menu_info().enabled)
+  menu enable PopUp.bar
+  call assert_equal(v:true, "PopUp.bar"->menu_info().enabled)
+  unmenu PopUp
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -114,7 +114,7 @@ func Test_menu_errors()
   call assert_fails('emenu Test.Foo.Bar', 'E334:')
   call assert_fails('menutranslate Test', 'E474:')
 
-  unmenu Foo
+  silent! unmenu Foo
   unmenu Test
 endfunc
 

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -435,11 +435,14 @@ endfunc
 
 " Test for listing the menus using the :menu command
 func Test_show_menus()
+  " In the GUI, tear-off menu items are present in the output below
+  " So skip this test
+  CheckNotGui
   aunmenu *
   call assert_equal(['--- Menus ---'], split(execute('menu'), "\n"))
   nmenu <script> 200.10 Test.nmenu1 :nmenu1<CR>
   nmenu 200.20 Test.nmenu2 :nmenu2<CR>
-  noremenu 200.30 Test.nmenu3 :nmenu3<CR>
+  nnoremenu 200.30 Test.nmenu3 :nmenu3<CR>
   nmenu 200.40 Test.nmenu4 :nmenu4<CR>
   nmenu 200.50 disable Test.nmenu4
   let exp =<< trim [TEXT]
@@ -466,7 +469,7 @@ func Test_tmenu()
   tmenu Test.nmenu2.sub1 nmenu2.sub1
   let exp =<< trim [TEXT]
   --- Menus ---
-  200 Test
+  500 Test
     500 nmenu1
         t  - nmenu1
     500 nmenu2

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -114,6 +114,7 @@ func Test_menu_errors()
   call assert_fails('emenu Test.Foo.Bar', 'E334:')
   call assert_fails('menutranslate Test', 'E474:')
 
+  unmenu Foo
   unmenu Test
 endfunc
 
@@ -376,7 +377,7 @@ func Test_menu_icon()
         \ enabled: v:true, shortcut: '', modes: 'a', script: v:false,
         \ iconidx: 22, priority: 500, silent: v:false,
         \ rhs: ':echo "BuiltIn22"<CR>', noremenu: v:false},
-        \ menu_info("ToolBar.BuiltIn22"))
+        \ menu_info("ToolBar.BuiltIn22"))
   aunmenu ToolBar.BuiltIn22
 endfunc
 

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -851,6 +851,12 @@ func Test_popup_command()
   CheckScreendump
   CheckFeature menu
 
+  menu Test.Foo Foo
+  call assert_fails('popup Test.Foo', 'E336:')
+  call assert_fails('popup Test.Foo.X', 'E327:')
+  call assert_fails('popup Foo', 'E337:')
+  unmenu Test.Foo
+
   let lines =<< trim END
 	one two three four five
 	and one two Xthree four five

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -981,13 +981,15 @@ endfunc
 
 " Test for displaying the popup menu using the right mouse click
 func Test_mouse_popup_menu()
+  CheckFeature menu
   new
   call setline(1, 'popup menu test')
   let save_mouse = &mouse
   let save_term = &term
   let save_ttymouse = &ttymouse
+  let save_mousemodel = &mousemodel
   call test_override('no_query_mouse', 1)
-  set mouse=a term=xterm
+  set mouse=a term=xterm mousemodel=popup
 
   menu PopUp.foo :let g:menustr = 'foo'<CR>
   menu PopUp.bar :let g:menustr = 'bar'<CR>
@@ -1005,6 +1007,7 @@ func Test_mouse_popup_menu()
   let &mouse = save_mouse
   let &term = save_term
   let &ttymouse = save_ttymouse
+  let &mousemodel = save_mousemodel
   call test_override('no_query_mouse', 0)
   close!
 endfunc
@@ -1531,3 +1534,5 @@ func Test_cmdline_literal()
 
   set timeoutlen&
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -979,6 +979,36 @@ func Test_term_mouse_middle_click_in_cmdline_to_paste()
   call test_override('no_query_mouse', 0)
 endfunc
 
+" Test for displaying the popup menu using the right mouse click
+func Test_mouse_popup_menu()
+  new
+  call setline(1, 'popup menu test')
+  let save_mouse = &mouse
+  let save_term = &term
+  let save_ttymouse = &ttymouse
+  call test_override('no_query_mouse', 1)
+  set mouse=a term=xterm
+
+  menu PopUp.foo :let g:menustr = 'foo'<CR>
+  menu PopUp.bar :let g:menustr = 'bar'<CR>
+  menu PopUp.baz :let g:menustr = 'baz'<CR>
+
+  for ttymouse_val in s:ttymouse_values
+    exe 'set ttymouse=' .. ttymouse_val
+    let g:menustr = ''
+    call feedkeys(MouseRightClickCode(1, 4)
+		\ .. MouseRightReleaseCode(1, 4) .. "\<Down>\<Down>\<CR>", "x")
+    call assert_equal('bar', g:menustr)
+  endfor
+
+  unmenu PopUp
+  let &mouse = save_mouse
+  let &term = save_term
+  let &ttymouse = save_ttymouse
+  call test_override('no_query_mouse', 0)
+  close!
+endfunc
+
 " This only checks if the sequence is recognized.
 func Test_term_rgb_response()
   set t_RF=x


### PR DESCRIPTION
It is difficult to test the menu functionality without a function to return information
about menus. Add the menu_getprop() function to get information about
menus. Use this function to add additional tests for the menu functionality.

This is ready to be merged.