### PR TITLE
Use correct format specifier for jump_where

### DIFF
--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -1998,7 +1998,7 @@ ex_disassemble(exarg_T *eap)
 			    when = "JUMP_AND_KEEP_IF_FALSE";
 			    break;
 		    }
-		    smsg("%4d %s -> %lld", current, when,
+		    smsg("%4d %s -> %d", current, when,
 						iptr->isn_arg.jump.jump_where);
 		}
 		break;


### PR DESCRIPTION
All the 32-bit Debian builds failed on the recent upload of 8.2.0368.  Disassemble is using %lld to print the "int" jump_where value, causing test failures like

    From test_vim9_disassemble.vim:
    Found errors in Test_disassemble_compare():
    function RunTheTest[40]..Test_disassemble_compare line 81: Pattern 'TestCase1.*if true == false.*\\d \\(PUSH\\|FUNCREF\\).*\\d \\(PUSH\\|FUNCREF\\|LOADG\\).*\\d COMPAREBOOL ==.*\\d JUMP_IF_FALSE -> \\d\\+.*' does not match '\nTestCase1\n  if true == false\n   0 PUSH v:true\n   1 PUSH v:false\n   2 COMPAREBOOL ==\n   3 JUMP_IF_FALSE -> -4294967290\n\n\n    echo 42\n   4 PUSHNR 42\n   5 ECHO 1\n\n\n  endif\n   6 PUSHNR 0\n   7 RETURN'

Closes #5770