### PR TITLE
Fixed gcc warning (textprop.c:666:9: warning: suggest explicit braces to avoid ambiguous ‘else’)

### DIFF
--- a/src/textprop.c
+++ b/src/textprop.c
@@ -664,6 +664,7 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
 			    sizeof(textprop_T));
 
 	    if (lnum == lnum_start)
+	    {
 		if (dir < 0)
 		{
 		    if (col < prop.tp_col)
@@ -671,7 +672,7 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
 		}
 		else if (prop.tp_col + prop.tp_len - (prop.tp_len != 0) < col)
 		    continue;
-
+	    }
 	    if (prop.tp_id == id || prop.tp_type == type_id)
 	    {
 		// Check if the starting position has text props.


### PR DESCRIPTION
This PR fixes a gcc compilation warning with vim-8.2.378:
```
textprop.c: In function ‘f_prop_find’:
textprop.c:666:9: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
      if (lnum == lnum_start)
         ^
```