### PR TITLE
CI: Organize travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 
-anchors:
+_anchors:
   envs:
     - &tiny-nogui
       BUILD=yes TEST=test COVERAGE=no FEATURES=tiny "CONFOPT='--disable-gui'" SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
@@ -88,7 +88,7 @@ anchors:
     before_script:
       - do_test() { "$@"; }
 
-  homebrew: &homebrew
+  homebrew: &osx-homebrew
     addons:
       homebrew:
         packages:
@@ -112,8 +112,6 @@ anchors:
       while read log; do
         asan_symbolize < "${log}"
       done < <(find . -type f -name 'asan.*' -size +0)
-
-sudo: false
 
 branches:
   except:
@@ -157,7 +155,7 @@ script:
 # exclude some builds on mac os x and linux
 # on mac os x "tiny" is always without GUI
 # linux: 2*compiler + 5*env + mac: 2*compiler + 2*env
-matrix:
+jobs:
   include:
     - <<: *osx
       name: tiny-nogui/clang
@@ -168,12 +166,12 @@ matrix:
       compiler: gcc
       env: *tiny-nogui
     - <<: *osx
-      <<: *homebrew
+      <<: *osx-homebrew
       name: huge/clang
       compiler: clang
       env: *osx-huge
     - <<: *osx
-      <<: *homebrew
+      <<: *osx-homebrew
       name: huge/gcc
       compiler: gcc
       env: *osx-huge

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,10 @@ anchors:
 
   osx: &osx
     os: osx
+    before_script:
+      - do_test() { "$@"; }
+
+  homebrew: &homebrew
     addons:
       homebrew:
         packages:
@@ -98,8 +102,6 @@ anchors:
       - rvm reset
       # Lua is not installed on Travis OSX
       - export LUA_PREFIX=/usr/local
-    before_script:
-      - do_test() { "$@"; }
 
   coverage: &coverage
     - ~/.local/bin/coveralls -b "${SRCDIR}" -x .xs -e "${SRCDIR}"/if_perl.c -e "${SRCDIR}"/xxd -e "${SRCDIR}"/libvterm --encodings utf-8
@@ -166,10 +168,12 @@ matrix:
       compiler: gcc
       env: *tiny-nogui
     - <<: *osx
+      <<: *homebrew
       name: huge/clang
       compiler: clang
       env: *osx-huge
     - <<: *osx
+      <<: *homebrew
       name: huge/gcc
       compiler: gcc
       env: *osx-huge

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ anchors:
     cache:
       directories:
         - /usr/local/Homebrew/Library/Homebrew/vendor/
-        - /usr/local/Homebrew/Library/Taps/
+        - /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/
     before_install:
       - rvm reset
       # Lua is not installed on Travis OSX


### PR DESCRIPTION
## Fix config warnings

https://travis-ci.org/github/vim/vim/builds/662439586/config

```
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: unknown key anchors ([object Object])
root: missing dist, using the default xenial
jobs.include: duplicate values: name: tiny-nogui/clang, tiny-n ...
root: key matrix is an alias for jobs, using jobs
root: missing os, using the default linux
jobs.include.cache: missing timeout, using the default 3
```

* Remove  `sudo` key
* Rename `anchor` to `_anchor` (private key style)
* Rename `matrix` to `jobs`

## Disable homebrew on tiny build

Tiny build on osx does not need homebrew. This can make tiny-build time shorten. 

## Cache only homebrew-core tap

Current setting caches homebrew-core and homebrew-cask taps, but cask is no need (and huge size) so should remove it.