### PR TITLE
Fixed ubsan error when running make test_spell

### DIFF
--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -3719,6 +3719,9 @@ cleanup_suggestions(
     suggest_T   *stp = &SUG(*gap, 0);
     int		i;
 
+    if (gap->ga_len == 0)
+	return maxscore;
+
     // Sort the list.
     qsort(gap->ga_data, (size_t)gap->ga_len, sizeof(suggest_T), sug_compare);
 


### PR DESCRIPTION
When running `make test_spell` with vim-8.2.381 built using
ubsan (undefined behavior sanitizer) I see this error on stderr:
```
spellsuggest.c:3723:5: runtime error: null pointer passed as argument 1, which is declared to never be null
```
This PR fixes it.