### PR TITLE
Fix Test_job_start_in_timer

### DIFF
--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1775,7 +1775,7 @@ endfunc
 
 func Test_job_start_in_timer()
   CheckFeature timers
-  CheckFeature reltimefloat
+  CheckFunction reltimefloat
 
   func OutCb(chan, msg)
     let g:val += 1


### PR DESCRIPTION
Now Test_job_start_in_timer is never executed because it checks the existence of `reltimefloat` in the wrong way (using `CheckFeature`).