### PR TITLE
Test hardcopy with 'printmbcharset' to improve coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,9 @@ test_script:
   - cd src/testdir
     # Testing with MSVC gvim
   - path C:\Python35-x64;%PATH%
-  - nmake -f Make_dos.mak VIMPROG=..\gvim
+  - nmake -f Make_dos.mak POSTSCRIPT=yes VIMPROG=..\gvim
   - nmake -f Make_dos.mak clean
     # Testing with MingW console version
-  - nmake -f Make_dos.mak VIMPROG=..\vim
+  - nmake -f Make_dos.mak POSTSCRIPT=yes VIMPROG=..\vim
 
 # vim: sw=2 sts=2 et ts=8 sr

--- a/src/testdir/test_hardcopy.vim
+++ b/src/testdir/test_hardcopy.vim
@@ -28,7 +28,7 @@ func Test_printoptions()
         \     '']
     exe 'set printoptions=' .. opt
     if has('postscript')
-      hardcopy > Xhardcopy_printoptions
+      1,50hardcopy > Xhardcopy_printoptions
       let lines = readfile('Xhardcopy_printoptions')
       call assert_true(len(lines) > 20, opt)
       call assert_true(lines[0] =~ 'PS-Adobe', opt)
@@ -60,6 +60,30 @@ func Test_printmbfont()
     endif
   endfor
   set printmbfont&
+  bwipe
+endfunc
+
+func Test_printmbcharset()
+  " digraph.txt has plenty of non-latin1 characters.
+  help digraph.txt
+
+  set printmbcharset=ISO10646 printencoding=utf-8 printmbfont=r:WadaMin-Regular
+  hardcopy > Xhardcopy_printmbcharset
+  let lines = readfile('Xhardcopy_printmbcharset')
+  call assert_true(len(lines) > 20)
+  call assert_true(lines[0] =~ 'PS-Adobe')
+
+  set printmbcharset=does-not-exist printencoding=utf-8 printmbfont=r:WadaMin-Regular
+  call assert_fails('hardcopy > Xhardcopy_printmbcharset', 'E456:')
+
+  set printmbcharset=GB_2312-80 printencoding=utf-8 printmbfont=r:WadaMin-Regular
+  call assert_fails('hardcopy > Xhardcopy_printmbcharset', 'E673:')
+
+  set printmbcharset=ISO10646 printencoding=utf-8 printmbfont=
+  call assert_fails('hardcopy > Xhardcopy_printmbcharset', 'E675:')
+
+  call delete('Xhardcopy_printmbcharset')
+  set printmbcharset& printencoding& printmbfont&
   bwipe
 endfunc
 

--- a/src/testdir/test_hardcopy.vim
+++ b/src/testdir/test_hardcopy.vim
@@ -64,6 +64,11 @@ func Test_printmbfont()
 endfunc
 
 func Test_printmbcharset()
+  " FIXME: Unclear why this fails on Windows.
+  if !has('unix')
+    return
+  endif
+
   " digraph.txt has plenty of non-latin1 characters.
   help digraph.txt
 
@@ -108,7 +113,7 @@ func Test_printexpr()
   \                 readfile('Xhardcopy_printexpr'))
   call delete('Xhardcopy_printexpr')
 
-  " Function return 1 to test print failure.
+  " Function returns 1 to test print failure.
   function PrintFails(fname)
     call delete(a:fname)
     return 1

--- a/src/testdir/test_hardcopy.vim
+++ b/src/testdir/test_hardcopy.vim
@@ -64,15 +64,14 @@ func Test_printmbfont()
 endfunc
 
 func Test_printmbcharset()
-  " FIXME: Unclear why this fails on Windows.
-  if !has('unix')
+  if !has('postscript')
     return
   endif
 
   " digraph.txt has plenty of non-latin1 characters.
   help digraph.txt
-
   set printmbcharset=ISO10646 printencoding=utf-8 printmbfont=r:WadaMin-Regular
+
   hardcopy > Xhardcopy_printmbcharset
   let lines = readfile('Xhardcopy_printmbcharset')
   call assert_true(len(lines) > 20)
@@ -93,7 +92,7 @@ func Test_printmbcharset()
 endfunc
 
 func Test_printexpr()
-  if !has('unix')
+  if !has('postscript')
     return
   endif
 
@@ -126,8 +125,7 @@ func Test_printexpr()
 endfunc
 
 func Test_errors()
-  " FIXME: Windows fails differently than Unix.
-  if has('unix')
+  if has('postscript')
     edit test_hardcopy.vim
     call assert_fails('hardcopy >', 'E324:')
     bwipe
@@ -155,8 +153,7 @@ func Test_dark_background()
 endfun
 
 func Test_empty_buffer()
-  " FIXME: Unclear why this fails on Windows.
-  if has('unix')
+  if has('postscript')
     new
     call assert_equal("\nNo text to be printed", execute('hardcopy'))
     bwipe

--- a/src/testdir/test_hardcopy.vim
+++ b/src/testdir/test_hardcopy.vim
@@ -194,3 +194,5 @@ func Test_illegal_byte()
   bwipe!
   call delete('Xpstest')
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This PR improves test coverage of `:hardcopy` by 
testing with `'printmbcharset'`. 

It also speeds up test `Test_printoptions()` by limiting the range
of lines to print.