### PR TITLE
Fixing buffer menu having stale items with terminal / cmdline window

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4194,7 +4194,9 @@ open_cmdwin(void)
 
     // Create the command-line buffer empty.
     (void)do_ecmd(0, NULL, NULL, NULL, ECMD_ONE, ECMD_HIDE, NULL);
+    apply_autocmds(EVENT_BUFFILEPRE, NULL, NULL, FALSE, curbuf);
     (void)setfname(curbuf, (char_u *)"[Command Line]", NULL, TRUE);
+    apply_autocmds(EVENT_BUFFILEPOST, NULL, NULL, FALSE, curbuf);
     set_option_value((char_u *)"bt", 0L, (char_u *)"nofile", OPT_LOCAL);
     curbuf->b_p_ma = TRUE;
 #ifdef FEAT_FOLDING

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -523,6 +523,8 @@ term_start(
     term->tl_next = first_term;
     first_term = term;
 
+    apply_autocmds(EVENT_BUFFILEPRE, NULL, NULL, FALSE, curbuf);
+
     if (opt->jo_term_name != NULL)
 	curbuf->b_ffname = vim_strsave(opt->jo_term_name);
     else if (argv != NULL)
@@ -570,6 +572,8 @@ term_start(
     vim_free(curbuf->b_sfname);
     curbuf->b_sfname = vim_strsave(curbuf->b_ffname);
     curbuf->b_fname = curbuf->b_ffname;
+
+    apply_autocmds(EVENT_BUFFILEPOST, NULL, NULL, FALSE, curbuf);
 
     if (opt->jo_term_opencmd != NULL)
 	term->tl_opencmd = vim_strsave(opt->jo_term_opencmd);


### PR DESCRIPTION
Currently, when using special buffers like terminals / command-line window / quickfix / location list, these buffers will get added to the "Buffers" menu, but they don't get removed when the buffers are gone, leaving stale menu items. Fix buffer menu to be more robust.

1. Currently the buffer menu works by using the buffer name to add/remove the entries, but it's error-prone because the buffer could have been renamed under-the-hood. While it uses BufFilePre/Post autocommands to handle normal buffer renames, it doesn't work for the command-line window (accessible via `q:`) which gets renamed without sending the autocommand. Instead, change the menus to cached a dictionary a bufnum -> menu name, so it will always know how to remove a buffer from itself.
2. Add BufFilePre/Post autocommands to command-line windows when it changes the buffer name to "[Command Line]".
3. Add BufFilePre/Post autocommands to terminal windows when it changes the buffer name to the command, e.g. "!/bin/zsh".

Either (1) or (2)+(3) will fix the issue, but just doing all of them as this seems like the right thing to do (2 + 3) also means the menu items show the correct names instead of just saying "[No Name]".

This doesn't fix the following which needs to be fixed later:
1. Quickfix and Location List don't send BufDeleted autocmds. This leads to them also leaving stale buffer menu items as there's no way for the script to know that those buffers are gone.
