### PR TITLE
Restore code coverage from before s390x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,14 +72,16 @@ _anchors:
           ln -sf "$(which llvm-cov)" /home/travis/bin/gcov
         fi
     before_script:
-      # Start virtual framebuffer to be able to test the GUI. Does not work on OS X.
       - |
-        if [[ "${TEST}" =~ gui ]]; then
+        # Start virtual framebuffer to be able to test the GUI. For dists newer
+        # than trusty, the "services: xvfb" setting should be used instead
+        if [[ ${TRAVIS_DIST} = trusty ]]; then
           export DISPLAY=:99.0
           sh -e /etc/init.d/xvfb start && sleep 3
         fi
       - |
-        [ "${TRAVIS_CPU_ARCH}" = s390x ] || sudo modprobe snd-dummy
+        # Sound testing works without this in newer dists
+        [ ${TRAVIS_DIST} != trusty ] || sudo modprobe snd-dummy
       - sudo usermod -a -G audio $USER
       - do_test() { sg audio "sg $(id -gn) '$*'"; }
 
@@ -213,6 +215,7 @@ jobs:
       compiler: gcc
       env:
         - *linux-huge
+        - COVERAGE=no
       addons:
         apt:
           packages:


### PR DESCRIPTION
The s390x build runs with a newer dist than trusty, and therefore should use "services: xvfb" to get GUI support.  However, test_gui_init.vim hangs there so don't setup xvfb yet.

Also, the snd-dummy module doesn't exist after trusty, so don't try to load it.