### PR TITLE
Update jargon syntax

### DIFF
--- a/runtime/syntax/jargon.vim
+++ b/runtime/syntax/jargon.vim
@@ -1,23 +1,24 @@
 " Vim syntax file
 " Language:	Jargon File
 " Maintainer:	Dan Church (https://github.com/h3xx)
-" Last Change:	2019 Sep 27
+" Last Change:	2020 Mar 16
 "
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
 	finish
 endif
 
-syn match jargonChaptTitle	/:[^:]*:/
-syn match jargonEmailAddr	/[^<@ ^I]*@[^ ^I>]*/
-syn match jargonUrl	 +\(http\|ftp\)://[^\t )"]*+
-syn region jargonMark	 start="{"  end="}"
+syn region jargonHeader start="^:" end="$" contains=jargonChaptTitle
+syn match jargonChaptTitle /:[^:]*:/ contained
+syn match jargonEmailAddr /[+._A-Za-z0-9-]\+@[+._A-Za-z0-9-]\+/
+syn match jargonUrl +\(https\?\|ftp\)://[^\t )"]*+
+syn region jargonMark start="{[^\t {}]" end="}"
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
-hi def link jargonChaptTitle	Title
-hi def link jargonEmailAddr	 Comment
-hi def link jargonUrl	 Comment
-hi def link jargonMark	Label
+hi def link jargonChaptTitle Title
+hi def link jargonEmailAddr Comment
+hi def link jargonUrl Comment
+hi def link jargonMark Label
 
 let b:current_syntax = "jargon"


### PR DESCRIPTION
- Fix entry title highlighting
- Fix jargon mark highlighting
- Fix email address regex
- Fix URL regex to allow https

The current title highlight allowed headers everywhere, was especially bad in the `:ASCII:` section.

The marks were incorrectly highlighting in the sections of C code.

The email regex was highlighting inside pronunciation guides, which the first fix I mentioned fixing it in the entry headers.