### PR TITLE
Fix missing summary-tag

### DIFF
--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -61,7 +61,8 @@ syn keyword htmlTagName contained datalist details dialog embed figcaption
 syn keyword htmlTagName contained figure footer header hgroup keygen main
 syn keyword htmlTagName contained mark menuitem meter nav output picture
 syn keyword htmlTagName contained progress rb rp rt rtc ruby section
-syn keyword htmlTagName contained slot source template time track video wbr
+syn keyword htmlTagName contained slot source summary template time track
+syn keyword htmlTagName contained video wbr
 
 " legal arg names
 syn keyword htmlArg contained action


### PR DESCRIPTION
HTML5 defines a summary tag in conjunction with the (already present) details tag.

See https://www.w3.org/TR/html52/interactive-elements.html#the-summary-element