### PR TITLE
Swift: Change tabstop and shiftwidth to 4

### DIFF
--- a/runtime/ftplugin/swift.vim
+++ b/runtime/ftplugin/swift.vim
@@ -10,6 +10,6 @@
 
 setlocal comments=s1:/*,mb:*,ex:*/,:///,://
 setlocal expandtab
-setlocal ts=2
-setlocal sw=2
+setlocal ts=4
+setlocal sw=4
 setlocal smartindent

--- a/runtime/ftplugin/swift.vim
+++ b/runtime/ftplugin/swift.vim
@@ -10,6 +10,5 @@
 
 setlocal comments=s1:/*,mb:*,ex:*/,:///,://
 setlocal expandtab
-setlocal ts=4
-setlocal sw=4
+setlocal sw=4 sts=4
 setlocal smartindent


### PR DESCRIPTION
Due to Swift project's code indentation settings, Swift filetype plugin uses 2 spaces for `ts` and `sw`. This conflicts with Xcode, which uses 4 by default (and generally Swift projects use 4), and if same file is opened via Vim or vice versa, it's always extra steps to fix indentation. This PR sets `ts` and `sw` to 4, for a more unified environment.

I've brought this up to Swift team, but they prefer to keep it 2.