### PR TITLE
Fix memory leaks

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1346,6 +1346,18 @@ do_cmdline(
 	restore_dbg_stuff(&debug_saved);
 
     msg_list = saved_msg_list;
+
+    // Cleanup if "cs_emsg_silent_list" remains.
+    if (cstack.cs_emsg_silent_list != NULL)
+    {
+	eslist_T *elem, *temp;
+
+	for (elem = cstack.cs_emsg_silent_list; elem != NULL; elem = temp)
+	{
+	    temp = elem->next;
+	    vim_free(elem);
+	}
+    }
 #endif // FEAT_EVAL
 
     /*

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4188,6 +4188,7 @@ open_cmdwin(void)
     if (win_split((int)p_cwh, WSP_BOT) == FAIL)
     {
 	beep_flush();
+	ga_clear(&winsizes);
 	return K_IGNORE;
     }
     cmdwin_type = get_cmdline_type();

--- a/src/menu.c
+++ b/src/menu.c
@@ -2882,10 +2882,16 @@ menuitem_getinfo(vimmenu_T *menu, int modes, dict_T *dict)
 	if (bit < MENU_MODES) // just in case, avoid Coverity warning
 	{
 	    if (menu->strings[bit] != NULL)
+	    {
+		char_u *tofree = NULL;
+
 		status = dict_add_string(dict, "rhs",
 			*menu->strings[bit] == NUL
-				? vim_strsave((char_u *)"<Nop>")
-				: str2special_save(menu->strings[bit], FALSE));
+				? (char_u *)"<Nop>"
+				: (tofree = str2special_save(
+						  menu->strings[bit], FALSE)));
+		vim_free(tofree);
+	    }
 	    if (status == OK)
 		status = dict_add_bool(dict, "noremenu",
 					     menu->noremap[bit] == REMAP_NONE);

--- a/src/message.c
+++ b/src/message.c
@@ -857,17 +857,6 @@ emsg_invreg(int name)
 }
 
 /*
- * Give an error message which contains %s for "name[len]".
- */
-    void
-emsg_namelen(char *msg, char_u *name, int len)
-{
-    char_u *copy = vim_strnsave((char_u *)name, len);
-
-    semsg(msg, copy == NULL ? "NULL" : (char *)copy);
-}
-
-/*
  * Like msg(), but truncate to a single line if p_shm contains 't', or when
  * "force" is TRUE.  This truncates in another way as for normal messages.
  * Careful: The string may be changed by msg_may_trunc()!

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -6482,8 +6482,8 @@ msgid "E1004: white space required before and after '%s'"
 msgstr "E1004: Leerzeichen vor und nach '%s' benötigt"
 
 #, c-format
-msgid "E1006: %s is used as an argument"
-msgstr "E1006: %s wird als Argument verwendet"
+msgid "E1006: %.*s is used as an argument"
+msgstr "E1006: %.*s wird als Argument verwendet"
 
 msgid "E1007: No white space allowed before <"
 msgstr "E1007: Keine Leerzeichen vor < erlaubt"

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -6419,8 +6419,8 @@ msgid "E1004: white space required before and after '%s'"
 msgstr "E1004: spacetoj bezonataj ĉirkaŭ '%s'"
 
 #, c-format
-msgid "E1006: %s is used as an argument"
-msgstr "E1006: %s estas uzata kiel argumento"
+msgid "E1006: %.*s is used as an argument"
+msgstr "E1006: %.*s estas uzata kiel argumento"
 
 msgid "E1007: No white space allowed before <"
 msgstr "E1007: Neniu spaceto permesebla antaŭ ol <"

--- a/src/proto/message.pro
+++ b/src/proto/message.pro
@@ -14,7 +14,6 @@ void iemsg(char *s);
 void internal_error(char *where);
 void internal_error_no_abort(char *where);
 void emsg_invreg(int name);
-void emsg_namelen(char *msg, char_u *name, int len);
 char *msg_trunc_attr(char *s, int force, int attr);
 char_u *msg_may_trunc(int force, char_u *s);
 int delete_first_msg(void);

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1133,7 +1133,8 @@ do_source(
     {
 	// Already loaded and no need to load again, return here.
 	*ret_sid = sid;
-	return OK;
+	retval = OK;
+	goto theend;
     }
 #endif
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -3086,11 +3086,11 @@ ex_function(exarg_T *eap)
 
 erret:
     ga_clear_strings(&newargs);
-    ga_clear_strings(&argtypes);
     ga_clear_strings(&default_args);
 errret_2:
     ga_clear_strings(&newlines);
 ret_free:
+    ga_clear_strings(&argtypes);
     vim_free(skip_until);
     vim_free(line_to_free);
     vim_free(fudi.fd_newkey);

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -943,6 +943,7 @@ func_clear_items(ufunc_T *fp)
     VIM_CLEAR(fp->uf_name_exp);
     VIM_CLEAR(fp->uf_arg_types);
     VIM_CLEAR(fp->uf_def_arg_idx);
+    VIM_CLEAR(fp->uf_va_name);
     ga_clear(&fp->uf_type_list);
 #ifdef FEAT_PROFILE
     VIM_CLEAR(fp->uf_tml_count);

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -942,6 +942,7 @@ func_clear_items(ufunc_T *fp)
     ga_clear_strings(&(fp->uf_lines));
     VIM_CLEAR(fp->uf_name_exp);
     VIM_CLEAR(fp->uf_arg_types);
+    VIM_CLEAR(fp->uf_def_arg_idx);
     ga_clear(&fp->uf_type_list);
 #ifdef FEAT_PROFILE
     VIM_CLEAR(fp->uf_tml_count);

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1286,7 +1286,7 @@ reserve_local(cctx_T *cctx, char_u *name, size_t len, int isConst, type_T *type)
 
     if (lookup_arg(name, len, cctx) >= 0 || lookup_vararg(name, len, cctx))
     {
-	emsg_namelen(_("E1006: %s is used as an argument"), name, (int)len);
+	semsg(_("E1006: %.*s is used as an argument"), (int)len, name);
 	return -1;
     }
 


### PR DESCRIPTION
A part of leaks reported by ASAN on Ubuntu 18.04.

### `do_cmdline`

Must release the contents of`cstack.cs_emsg_silent_list`.

### `open_cmdwin`

Must release `winsize` garray after allocating it.

### `menuitem_getinfo`

Must keep the return-value of `str2special_save()` in order to release it.

### `emsg_namelen`

Must release `copy` allocated in this function. 
However, I don't think this function is necessary; can use `%.*s` printf-format.

### `do_source`

After allocating `fname_exp`, does not return directly but use `goto theend` to release it.

### `func_clear_items`

Add the items which must be released.

### `ex_function`

Must release `argtypes` always (at also normal termination).