### PR TITLE
Reduce number of select() calls during syntax highlighting on macOS

### DIFF
--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -86,9 +86,6 @@
 #define USE_EXE_NAME		    // to find  $VIM
 #define CASE_INSENSITIVE_FILENAME   // ignore case when comparing file names
 #define SPACE_IN_FILENAME
-#define BREAKCHECK_SKIP	   32	    // call mch_breakcheck() each time, it's
-				    // quite fast. Did I forgot to update the
-				    // comment
 
 #define USE_FNAME_CASE		// make ":e os_Mac.c" open the file in its
 				// original case, as "os_mac.c"


### PR DESCRIPTION
Per #4708 , this should apply to mac too.

I still think there's an underlying issue of calls getting slower over time. I am working on a repro case for that, but for now this should hopefully reduce input latency for large/wide terminals.