### PR TITLE
CI: Organize travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,11 +69,7 @@ _anchors:
           export DISPLAY=:99.0
           sh -e /etc/init.d/xvfb start && sleep 3
         fi
-      # Sound testing works only on amd64
-      - |
-        if [[ "${TRAVIS_CPU_ARCH}" = "amd64" ]]; then
-          sudo modprobe snd-dummy
-        fi
+      - sudo bash ci/load-snd-dummy.sh || true
       - sudo usermod -a -G audio $USER
       - do_test() { sg audio "sg $(id -gn) '$*'"; }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,21 @@ language: c
 _anchors:
   envs:
     - &tiny-nogui
-      BUILD=yes TEST=test COVERAGE=no FEATURES=tiny "CONFOPT='--disable-gui'" SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
+      BUILD=yes TEST=test FEATURES=tiny "CONFOPT='--disable-gui'" SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
     - &tiny
-      BUILD=yes TEST=test COVERAGE=no FEATURES=tiny CONFOPT= SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
+      BUILD=yes TEST=test FEATURES=tiny CONFOPT= SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
     - &small
-      BUILD=yes TEST=test COVERAGE=no FEATURES=small CONFOPT= SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
+      BUILD=yes TEST=test FEATURES=small CONFOPT= SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
     - &normal
-      BUILD=yes TEST=test COVERAGE=no FEATURES=normal CONFOPT= SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
+      BUILD=yes TEST=test FEATURES=normal CONFOPT= SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
     - &linux-huge
-      BUILD=yes TEST="scripttests test_libvterm" COVERAGE=yes CFLAGS=--coverage LDFLAGS=--coverage FEATURES=huge SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
+      BUILD=yes TEST="scripttests test_libvterm" CFLAGS=--coverage LDFLAGS=--coverage FEATURES=huge SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
       "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-python3interp --enable-rubyinterp --enable-luainterp --enable-tclinterp'"
     - &osx-huge # macOS build
-      BUILD=yes TEST=test COVERAGE=no FEATURES=huge SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
+      BUILD=yes TEST=test FEATURES=huge SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=no
       "CONFOPT='--enable-perlinterp --enable-pythoninterp --enable-rubyinterp --enable-luainterp --enable-tclinterp'"
     - &unittests
-      BUILD=no TEST=unittests COVERAGE=yes CFLAGS=--coverage LDFLAGS=--coverage FEATURES=huge SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=yes
+      BUILD=no TEST=unittests CFLAGS=--coverage LDFLAGS=--coverage FEATURES=huge SHADOWOPT= SRCDIR=./src CHECK_AUTOCONF=yes
     - &asan # ASAN build
       SANITIZER_CFLAGS="-g -O1 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize=address -fno-omit-frame-pointer"
       ASAN_OPTIONS="print_stacktrace=1 log_path=asan" LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/src/testdir/lsan-suppress.txt"
@@ -56,32 +56,24 @@ _anchors:
         if [[ "$(which python3)" =~ ^/opt/python/ ]]; then
           export PATH=$(py3=$(which python3); echo ${PATH//${py3%/python3}:/})
         fi
-      - |
-        if [[ "${COVERAGE}" = "yes" ]]; then
-          pip install --user cpp-coveralls
-        fi
-      # needed for https support for coveralls
-      # building cffi only works with gcc, not with clang
-      - |
-        if [[ "${COVERAGE}" = "yes" ]]; then
-          CC=gcc pip install --user pyopenssl ndg-httpsclient pyasn1
-        fi
       # Use llvm-cov instead of gcov when compiler is clang.
       - |
         if [[ "${CC}" = "clang" ]]; then
           ln -sf "$(which llvm-cov)" /home/travis/bin/gcov
         fi
     before_script:
+      # Start virtual framebuffer to be able to test the GUI. For dists newer
+      # than trusty, the "services: xvfb" setting should be used instead
       - |
-        # Start virtual framebuffer to be able to test the GUI. For dists newer
-        # than trusty, the "services: xvfb" setting should be used instead
         if [[ ${TRAVIS_DIST} = trusty ]]; then
           export DISPLAY=:99.0
           sh -e /etc/init.d/xvfb start && sleep 3
         fi
+      # Sound testing works only on amd64
       - |
-        # Sound testing works without this in newer dists
-        [ ${TRAVIS_DIST} != trusty ] || sudo modprobe snd-dummy
+        if [[ "${TRAVIS_CPU_ARCH}" = "amd64" ]]; then
+          sudo modprobe snd-dummy
+        fi
       - sudo usermod -a -G audio $USER
       - do_test() { sg audio "sg $(id -gn) '$*'"; }
 
@@ -106,6 +98,9 @@ _anchors:
       - export LUA_PREFIX=/usr/local
 
   coverage: &coverage
+    # needed for https support for coveralls building cffi only works with gcc,
+    # not with clang
+    - CC=gcc pip install --user cpp-coveralls pyopenssl ndg-httpsclient pyasn1
     - ~/.local/bin/coveralls -b "${SRCDIR}" -x .xs -e "${SRCDIR}"/if_perl.c -e "${SRCDIR}"/xxd -e "${SRCDIR}"/libvterm --encodings utf-8
     - (cd "${SRCDIR}" && bash <(curl -s https://codecov.io/bash))
 
@@ -145,8 +140,8 @@ script:
   - |
     if [[ "${BUILD}" = "yes" ]]; then
       "${SRCDIR}"/vim --version
-      "${SRCDIR}"/vim -u NONE --not-a-term -esNX -V1 -S ci/if_ver-1.vim -c quit
-      "${SRCDIR}"/vim -u NONE --not-a-term -esNX -V1 -S ci/if_ver-2.vim -c quit
+      "${SRCDIR}"/vim -u NONE -i NONE --not-a-term -esNX -V1 -S ci/if_ver-1.vim -c quit
+      "${SRCDIR}"/vim -u NONE -i NONE --not-a-term -esNX -V1 -S ci/if_ver-2.vim -c quit
     fi
   - echo -e "\\033[33;1mTesting Vim\\033[0m" && echo -en "travis_fold:start:test\\r\\033[0K"
   - do_test make ${SHADOWOPT} ${TEST} && FOLD_MARKER=travis_fold
@@ -213,9 +208,7 @@ jobs:
       arch: s390x
       name: huge/gcc-s390x
       compiler: gcc
-      env:
-        - *linux-huge
-        - COVERAGE=no
+      env: *linux-huge
       addons:
         apt:
           packages:

--- a/ci/load-snd-dummy.sh
+++ b/ci/load-snd-dummy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if ! modprobe snd-dummy; then
+    # snd-dummy is contained in linux-modules-extra (if exists)
+    apt install -y "linux-modules-extra-$(uname -r)"
+    modprobe snd-dummy
+fi


### PR DESCRIPTION
* Remove `COVERAGE` variable and summarize coverage processes (installing, executing) into "coverage" anchor.

* Add load-snd-dummy.sh script to load snd-dummy module.
  When could not load, install linux-modules-extra and retry to load.

* Add `-i NONE` to if-ver command in order to suppress messages about viminfo.
```
Reading viminfo file "/home/travis/.viminfo" info oldfiles
```