### PR TITLE
Fix memory leaks

### DIFF
--- a/src/proto/vim9compile.pro
+++ b/src/proto/vim9compile.pro
@@ -9,6 +9,7 @@ imported_T *find_imported(char_u *name, size_t len, cctx_T *cctx);
 char_u *to_name_const_end(char_u *arg);
 int assignment_len(char_u *p, int *heredoc);
 void compile_def_function(ufunc_T *ufunc, int set_return_type);
+void delete_instr(isn_T *isn);
 void delete_def_function(ufunc_T *ufunc);
 void free_def_functions(void);
 /* vim: set ft=c : */

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1526,6 +1526,7 @@ free_scriptnames(void)
 	vim_free(si->sn_vars);
 
 	vim_free(si->sn_name);
+	free_imports(i);
 	free_string_option(si->sn_save_cpo);
 #  ifdef FEAT_PROFILE
 	ga_clear(&si->sn_prl_ga);

--- a/src/structs.h
+++ b/src/structs.h
@@ -1308,6 +1308,7 @@ typedef struct {
     int		cb_free_name;	    // cb_name was allocated
 } callback_T;
 
+typedef struct isn_S isn_T;	    // instruction
 typedef struct dfunc_S dfunc_T;	    // :def function
 
 typedef struct jobvar_S job_T;

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -964,4 +964,24 @@ def Test_substitute_cmd()
   delete('Xvim9lines')
 enddef
 
+def Test_redef_failure()
+  call writefile(['def Func0(): string',  'return "Func0"', 'enddef'], 'Xdef')
+  so Xdef
+  call writefile(['def Func1(): string',  'return "Func1"', 'enddef'], 'Xdef')
+  so Xdef
+  call writefile(['def! Func0(): string', 'enddef'], 'Xdef')
+  call assert_fails('so Xdef', 'E1027:')
+  call writefile(['def Func2(): string',  'return "Func2"', 'enddef'], 'Xdef')
+  so Xdef
+  call delete('Xdef')
+
+  call assert_equal(0, Func0())
+  call assert_equal('Func1', Func1())
+  call assert_equal('Func2', Func2())
+
+  delfunc! Func0
+  delfunc! Func1
+  delfunc! Func2
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -203,7 +203,7 @@ typedef struct {
 /*
  * Instruction
  */
-typedef struct {
+struct isn_S {
     isntype_T	isn_type;
     int		isn_lnum;
     union {
@@ -231,7 +231,7 @@ typedef struct {
 	loadstore_T	    loadstore;
 	script_T	    script;
     } isn_arg;
-} isn_T;
+};
 
 /*
  * Info about a function defined with :def.  Used in "def_functions".

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -5481,6 +5481,7 @@ delete_def_function(ufunc_T *ufunc)
     {
 	dfunc_T *dfunc = ((dfunc_T *)def_functions.ga_data)
 							 + ufunc->uf_dfunc_idx;
+
 	ga_clear(&dfunc->df_def_args_isn);
 
 	for (idx = 0; idx < dfunc->df_instr_count; ++idx)
@@ -5495,6 +5496,19 @@ delete_def_function(ufunc_T *ufunc)
     void
 free_def_functions(void)
 {
+    int i, j;
+
+    for (i = 0; i < def_functions.ga_len; ++i)
+    {
+	dfunc_T *dfunc = ((dfunc_T *)def_functions.ga_data) + i;
+
+	ga_clear(&dfunc->df_def_args_isn);
+
+	for (j = 0; j < dfunc->df_instr_count; ++j)
+	    if (dfunc->df_instr != NULL)
+		delete_instr(dfunc->df_instr + j);
+	VIM_CLEAR(dfunc->df_instr);
+    }
     vim_free(def_functions.ga_data);
 }
 #endif

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1695,6 +1695,20 @@ find_imported(char_u *name, size_t len, cctx_T *cctx)
     return NULL;
 }
 
+    static void
+free_imported(cctx_T *cctx)
+{
+    int idx;
+
+    for (idx = 0; idx < cctx->ctx_imports.ga_len; ++idx)
+    {
+	imported_T *import = ((imported_T *)cctx->ctx_imports.ga_data) + idx;
+
+	vim_free(import->imp_name);
+    }
+    ga_clear(&cctx->ctx_imports);
+}
+
 /*
  * Generate an instruction to load script-local variable "name".
  */
@@ -5354,6 +5368,7 @@ erret:
     }
 
     current_sctx = save_current_sctx;
+    free_imported(&cctx);
     free_local(&cctx);
     ga_clear(&cctx.ctx_type_stack);
 }

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -5362,7 +5362,7 @@ erret:
 /*
  * Delete an instruction, free what it contains.
  */
-    static void
+    void
 delete_instr(isn_T *isn)
 {
     switch (isn->isn_type)

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2151,7 +2151,10 @@ compile_lambda(char_u **arg, cctx_T *cctx)
     // Get the funcref in "rettv".
     if (get_lambda_tv(arg, &rettv, TRUE) == FAIL)
 	return FAIL;
+
     ufunc = rettv.vval.v_partial->pt_func;
+    ++ufunc->uf_refcount;
+    clear_tv(&rettv);
 
     // The function will have one line: "return {expr}".
     // Compile it into instructions.
@@ -2193,10 +2196,12 @@ compile_lambda_call(char_u **arg, cctx_T *cctx)
 	return FAIL;
     }
 
-    // The function will have one line: "return {expr}".
-    // Compile it into instructions.
     ufunc = rettv.vval.v_partial->pt_func;
     ++ufunc->uf_refcount;
+    clear_tv(&rettv);
+
+    // The function will have one line: "return {expr}".
+    // Compile it into instructions.
     compile_def_function(ufunc, TRUE);
 
     // compile the arguments
@@ -2205,7 +2210,6 @@ compile_lambda_call(char_u **arg, cctx_T *cctx)
 	// call the compiled function
 	ret = generate_CALL(cctx, ufunc, argcount);
 
-    clear_tv(&rettv);
     return ret;
 }
 

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -5346,6 +5346,16 @@ compile_def_function(ufunc_T *ufunc, int set_return_type)
 	generate_instr(&cctx, ISN_RETURN);
     }
 
+    // Free old instructions.
+    if (dfunc->df_instr != NULL)
+    {
+	int idx;
+
+	for (idx = 0; idx < dfunc->df_instr_count; ++idx)
+	    delete_instr(dfunc->df_instr + idx);
+	vim_free(dfunc->df_instr);
+    }
+
     dfunc->df_instr = instr->ga_data;
     dfunc->df_instr_count = instr->ga_len;
     dfunc->df_varcount = cctx.ctx_max_local;
@@ -5355,6 +5365,10 @@ compile_def_function(ufunc_T *ufunc, int set_return_type)
 erret:
     if (ret == FAIL)
     {
+	int idx;
+
+	for (idx = 0; idx < instr->ga_len; ++idx)
+	    delete_instr(((isn_T *)instr->ga_data) + idx);
 	ga_clear(instr);
 	ufunc->uf_dfunc_idx = -1;
 	--def_functions.ga_len;

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -5364,7 +5364,7 @@ erret:
 	    emsg(_("E1028: compile_def_function failed"));
 
 	// don't execute this function body
-	ufunc->uf_lines.ga_len = 0;
+	ga_clear_strings(&ufunc->uf_lines);
     }
 
     current_sctx = save_current_sctx;

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -3426,7 +3426,6 @@ compile_assignment(char_u *arg, exarg_T *eap, cmdidx_T cmdidx, cctx_T *cctx)
 	{
 	    int	    cc;
 	    long	    numval;
-	    char_u	    *stringval = NULL;
 
 	    dest = dest_option;
 	    if (cmdidx == CMD_const)
@@ -3448,7 +3447,7 @@ compile_assignment(char_u *arg, exarg_T *eap, cmdidx_T cmdidx, cctx_T *cctx)
 	    }
 	    cc = *p;
 	    *p = NUL;
-	    opt_type = get_option_value(arg + 1, &numval, &stringval, opt_flags);
+	    opt_type = get_option_value(arg + 1, &numval, NULL, opt_flags);
 	    *p = cc;
 	    if (opt_type == -3)
 	    {

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -783,8 +783,9 @@ call_def_function(
 	    // store $ENV
 	    case ISN_STOREENV:
 		--ectx.ec_stack.ga_len;
-		vim_setenv_ext(iptr->isn_arg.string,
-					       tv_get_string(STACK_TV_BOT(0)));
+		tv = STACK_TV_BOT(0);
+		vim_setenv_ext(iptr->isn_arg.string, tv_get_string(tv));
+		clear_tv(tv);
 		break;
 
 	    // store @r

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -283,6 +283,7 @@ call_ufunc(ufunc_T *ufunc, int argcount, ectx_T *ectx, isn_T *iptr)
 	// that was defined later: we can call it directly next time.
 	if (iptr != NULL)
 	{
+	    delete_instr(iptr);
 	    iptr->isn_type = ISN_DCALL;
 	    iptr->isn_arg.dfunc.cdf_idx = ufunc->uf_dfunc_idx;
 	    iptr->isn_arg.dfunc.cdf_argcount = argcount;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -1678,6 +1678,7 @@ failed:
     for (idx = 0; idx < ectx.ec_stack.ga_len; ++idx)
 	clear_tv(STACK_TV(idx));
     vim_free(ectx.ec_stack.ga_data);
+    vim_free(ectx.ec_trystack.ga_data);
     return ret;
 }
 

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -119,11 +119,13 @@ free_imports(int sid)
 
     for (idx = 0; idx < si->sn_imports.ga_len; ++idx)
     {
-	imported_T *imp = ((imported_T *)si->sn_imports.ga_data + idx);
+	imported_T *imp = ((imported_T *)si->sn_imports.ga_data) + idx;
 
 	vim_free(imp->imp_name);
     }
     ga_clear(&si->sn_imports);
+    ga_clear(&si->sn_var_vals);
+    ga_clear(&si->sn_type_list);
 }
 
 /*


### PR DESCRIPTION
### Release imported items

Add calling `free_imports() in `free_scriptnames()`.

### `free_imports()`

Release `scriptitem_T::sn_var_vals` and `scriptitem_T::sn_type_list`.

### Release local variables (`ctx_locals`) when they are popped

Add `unwind_local()` and `free_local()`.
Call `unwind_local()` when updating `ctx_locals.ga_len`.

### Release the resource fetched from `get_lambda_tv()`

In `compile_lambda()`, need to release `rettv` after capturing its `vval.v_partial`.

### `compile_assignment()`

Calling `get_option_value()` to get the type of option value, so `stringval` is unused.
It is enough to NULL (or need release `stringval`).

### Release various resources in `compile_def_function()`

Need to release:

* Old instructions: when redefining function
* Generated instructions: when jumped to `erret`.
* Function lines (`ufunc->uf_lines`): when jumped to `erret`.
* Imported items
  Add `free_imported()` to release them
* Local variables
  Add `free_local()` as mentioned above

### Overwrite `dfunc` unexpectedly in `compile_def_function()`

test.vim
```vim
def F0(): number
  return 0
enddef
" new func: ufunc->uf_dfunc_idx = 0
" def_functions.ga_len: 0 -> 1

def F1(): number
  return 1
enddef
" new func: ufunc->uf_dfunc_idx = 1
" def_functions.ga_len: 1 -> 2

try
  def! F0(): number
  enddef
catch
endtry
" overwrite F0 but failed, def_functions.ga_len: 2 -> 1

def F2(): number
  return 2
enddef
" new func: ufunc->uf_dfunc_idx = 1
" Overwrite F1 instructions!
" def_functions.ga_len: 1 -> 2

echo F1()
" Output:
"   Expected: 1
"   Actual: 2
echo F2()
" Output: 2
```

```
vim --clean
:so test.vim
```

Therefore, must not decrease `def_functions.ga_len` when redefining fails.

### `free_def_functions()`

Need to release each `dfunc` (to fix ASAN detections).

### `call_ufunc()`

* Release the existing instruction before overwrite by `ISN_DCALL`.
* Release `STACK_TV_BOT(0)` value after `vim_setenv_ext()`, at `ISN_STOREENV`.

### `call_def_function()`

Release `ectx.ec_trystack`.