### PR TITLE
Fix memory leak

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -526,9 +526,15 @@ term_start(
     apply_autocmds(EVENT_BUFFILEPRE, NULL, NULL, FALSE, curbuf);
 
     if (opt->jo_term_name != NULL)
+    {
+	vim_free(curbuf->b_ffname);
 	curbuf->b_ffname = vim_strsave(opt->jo_term_name);
+    }
     else if (argv != NULL)
+    {
+	vim_free(curbuf->b_ffname);
 	curbuf->b_ffname = vim_strsave((char_u *)"!system");
+    }
     else
     {
 	int	i;


### PR DESCRIPTION
In `term_start()`, `curbuf->b_ffname` can be updated without freeing old value.

When:

* Do `:!cmd` with `set guioptions+=!`
* Do `:term` with both `++hidden` and `++shell`
* Call `term_start()` with both `hidden` and `term_name` options