### PR TITLE
Added test of signal INT.

### DIFF
--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -192,8 +192,6 @@ func Test_edit_long_file_name()
 
   call VerifyScreenDump(buf, 'Test_long_file_name_1', {})
 
-  call term_sendkeys(buf, ":q\<cr>")
-
   " clean up
   call StopVimInTerminal(buf)
   call delete(longName)

--- a/src/testdir/test_ex_mode.vim
+++ b/src/testdir/test_ex_mode.vim
@@ -92,7 +92,6 @@ func Test_Ex_substitute()
   call term_sendkeys(buf, ":vi\<CR>")
   call WaitForAssert({-> assert_match('foo bar', term_getline(buf, 1))}, 1000)
 
-  call term_sendkeys(buf, ":q!\n")
   call StopVimInTerminal(buf)
 endfunc
 

--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -255,7 +255,6 @@ func Test_confirm_cmd()
   call WaitForAssert({-> assert_match('^\[Y\]es, (N)o, (C)ancel: *$',
         \ term_getline(buf, 20))}, 1000)
   call term_sendkeys(buf, "N")
-  call term_sendkeys(buf, ":quit\n")
   call StopVimInTerminal(buf)
 
   call delete('foo')

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -265,7 +265,6 @@ func Test_message_more()
   call term_sendkeys(buf, 'q')
   call WaitForAssert({-> assert_equal('100', term_getline(buf, 5))})
 
-  call term_sendkeys(buf, ":q!\n")
   call StopVimInTerminal(buf)
 endfunc
 
@@ -295,7 +294,6 @@ func Test_ask_yesno()
   call WaitForAssert({-> assert_equal('y1', term_getline(buf, 1))})
   call WaitForAssert({-> assert_equal('y2', term_getline(buf, 2))})
 
-  call term_sendkeys(buf, ":q!\n")
   call StopVimInTerminal(buf)
 endfunc
 

--- a/src/testdir/test_signals.vim
+++ b/src/testdir/test_signals.vim
@@ -108,6 +108,5 @@ func Test_signal_INT()
   call term_sendkeys(buf, ":call setline(1, 'INTERUPTED')\n")
   call WaitForAssert({-> assert_equal('INTERUPTED', term_getline(buf, 1))})
 
-  call term_sendkeys(buf, ":q!\n")
   call StopVimInTerminal(buf)
 endfunc

--- a/src/testdir/test_signals.vim
+++ b/src/testdir/test_signals.vim
@@ -95,16 +95,12 @@ func Test_signal_INT()
     throw 'Skipped: cannot run vim in terminal'
   endif
   let buf = RunVimInTerminal('', {'rows': 6})
-
-  " Get the PID of Vim running in terminal.
-  call term_sendkeys(buf, ":echo '<' .. getpid() .. '>'\n")
-  call WaitForAssert({-> assert_match('^<\d\+>', term_getline(buf, 6))})
-  let pid = substitute(term_getline(buf, 6), '^<\(\d\+\)>.*', '\=submatch(1)', '')
+  let pid_vim = term_getjob(buf)->job_info().process
 
   " Check that an endless loop in Vim is interrupted by signal INT.
   call term_sendkeys(buf, ":while 1 | endwhile\n")
   call WaitForAssert({-> assert_equal(':while 1 | endwhile', term_getline(buf, 6))})
-  exe 'silent !kill -s INT ' .. pid
+  exe 'silent !kill -s INT ' .. pid_vim
   call term_sendkeys(buf, ":call setline(1, 'INTERUPTED')\n")
   call WaitForAssert({-> assert_equal('INTERUPTED', term_getline(buf, 1))})
 


### PR DESCRIPTION
This PR adds a test of signal INT, which was not covered yet according to codecov:

https://codecov.io/gh/vim/vim/src/5080b0a0470511bae6176a704d4591d1caba0d07/src/os_unix.c#L831