### PR TITLE
test_vim9_disassemble: Fix build failures on 32-bit big-endian platforms

### DIFF
--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -1774,7 +1774,7 @@ ex_disassemble(exarg_T *eap)
 		}
 		break;
 	    case ISN_EXECUTE:
-		smsg("%4d EXECUTE %d", current, iptr->isn_arg.number);
+		smsg("%4d EXECUTE %lld", current, iptr->isn_arg.number);
 		break;
 	    case ISN_LOAD:
 		if (iptr->isn_arg.number < 0)
@@ -1817,7 +1817,7 @@ ex_disassemble(exarg_T *eap)
 		smsg("%4d LOADENV %s", current, iptr->isn_arg.string);
 		break;
 	    case ISN_LOADREG:
-		smsg("%4d LOADREG @%c", current, iptr->isn_arg.number);
+		smsg("%4d LOADREG @%c", current, (int)iptr->isn_arg.number);
 		break;
 
 	    case ISN_STORE:
@@ -1862,7 +1862,7 @@ ex_disassemble(exarg_T *eap)
 		smsg("%4d STOREENV $%s", current, iptr->isn_arg.string);
 		break;
 	    case ISN_STOREREG:
-		smsg("%4d STOREREG @%c", current, iptr->isn_arg.number);
+		smsg("%4d STOREREG @%c", current, (int)iptr->isn_arg.number);
 		break;
 	    case ISN_STORENR:
 		smsg("%4d STORE %lld in $%d", current,
@@ -2153,7 +2153,7 @@ ex_disassemble(exarg_T *eap)
 			    else
 				smsg("%4d 2BOOL (!!val)", current);
 			    break;
-	    case ISN_2STRING: smsg("%4d 2STRING stack[%d]", current,
+	    case ISN_2STRING: smsg("%4d 2STRING stack[%lld]", current,
 							 iptr->isn_arg.number);
 				break;
 


### PR DESCRIPTION
These test failures were rountinely happening on powerpc:

```
From test_vim9_disassemble.vim:
Found errors in Test_disassemble_concat():
function RunTheTest[40]..Test_disassemble_concat line 2: Pattern 'ConcatString.*let res = g:aa .. "bb".*\\d LOADG g:aa.*\\d PUSHS "bb".*\\d 2STRING stack\\[-2].*\\d CONCAT.*\\d STORE $.*' does not match '\nConcatString\n  let res = g:aa .. "bb"\n   0 LOADG g:aa\n   1 PUSHS "bb"\n   2 2STRING stack[-1]\n   3 CONCAT\n   4 STORE $0\n\n\n  return res\n   5 LOAD $0\n   6 RETURN'
Found errors in Test_disassemble_execute():
function RunTheTest[40]..Test_disassemble_execute line 2: Pattern '\\<SNR>\\d*_Execute.*execute ''help vim9.txt''.*\\d PUSHS "help vim9.txt".*\\d EXECUTE 1.*let cmd = ''help vim9.txt''.*\\d PUSHS "help vim9.txt".*\\d STORE $0.*execute cmd.*\\d LOAD $0.*\\d EXECUTE 1.*let tag = ''vim9.txt''.*\\d PUSHS "vim9.txt".*\\d STORE $1.*execute ''help '' .. tag.*\\d PUSHS "help ".*\\d LOAD $1.*\\d CONCAT.*\\d EXECUTE 1.*\\d PUSHNR 0.*\\d RETURN' does not match '\n<SNR>5_Execute\n  execute ''help vim9.txt''\n   0 PUSHS "help vim9.txt"\n   1 EXECUTE 0\n\n\n  let cmd = ''help vim9.txt''\n   2 PUSHS "help vim9.txt"\n   3 STORE $0\n\n\n  execute cmd\n   4 LOAD $0\n   5 EXECUTE 0\n\n\n  let tag = ''vim9.txt''\n   6 PUSHS "vim9.txt"\n   7 STORE $1\n\n\n  execute ''help '' .. tag\n   8 PUSHS "help "\n   9 LOAD $1\n  10 CONCAT\n  11 EXECUTE 0\n  12 PUSHNR 0\n  13 RETURN'
Found errors in Test_disassemble_load():
function RunTheTest[40]..Test_disassemble_load line 9: Pattern '<SNR>\\d*_ScriptFuncLoad.*buffers.* EXEC \\+buffers.* LOAD arg\\[-1\\].* LOAD $0.* LOADV v:version.* LOADS s:scriptvar from .*test_vim9_disassemble.vim.* LOADG g:globalvar.* LOADENV $ENVVAR.* LOADREG @z.*' does not match '\n<SNR>5_ScriptFuncLoad\n  let local = 1\n   0 STORE 1 in $0\n\n\n  buffers\n   1 EXEC   buffers\n\n\n  echo arg\n   2 LOAD arg[-1]\n   3 ECHO 1\n\n\n  echo local\n   4 LOAD $0\n   5 ECHO 1\n\n\n  echo v:version\n   6 LOADV v:version\n   7 ECHO 1\n\n\n  echo s:scriptvar\n   8 LOADS s:scriptvar from /<<PKGBUILDDIR>>/src/vim-basic/testdir/test_vim9_disassemble.vim\n   9 ECHO 1\n\n\n  echo g:globalvar\n  10 LOADG g:globalvar\n  11 ECHO 1\n\n\n  echo &tabstop\n  12 LOADOPT &tabstop\n  13 ECHO 1\n\n\n  echo $ENVVAR\n  14 LOADENV $ENVVAR\n  15 ECHO 1\n\n\n  echo @z\n  16 LOADREG @\n  17 ECHO 1\n  18 PUSHNR 0\n  19 RETURN'
Found errors in Test_disassemble_store():
function RunTheTest[40]..Test_disassemble_store line 2: Pattern '<SNR>\\d*_ScriptFuncStore.*localnr = 2.* STORE 2 in $0.*localstr = ''xyz''.* STORE $1.*v:char = ''abc''.*STOREV v:char.*s:scriptvar = ''sv''.* STORES s:scriptvar in .*test_vim9_disassemble.vim.*g:globalvar = ''gv''.* STOREG g:globalvar.*&tabstop = 8.* STOREOPT &tabstop.*$ENVVAR = ''ev''.* STOREENV $ENVVAR.*@z = ''rv''.* STOREREG @z.*' does not match '\n<SNR>5_ScriptFuncStore\n  let localnr = 1\n   0 STORE 1 in $0\n\n\n  localnr = 2\n   1 STORE 2 in $0\n\n\n  let localstr = ''abc''\n   2 PUSHS "abc"\n   3 STORE $1\n\n\n  localstr = ''xyz''\n   4 PUSHS "xyz"\n   5 STORE $1\n\n\n  v:char = ''abc''\n   6 PUSHS "abc"\n   7 STOREV v:char\n\n\n  s:scriptvar = ''sv''\n   8 PUSHS "sv"\n   9 STORES s:scriptvar in /<<PKGBUILDDIR>>/src/vim-basic/testdir/test_vim9_disassemble.vim\n\n\n  g:globalvar = ''gv''\n  10 PUSHS "gv"\n  11 STOREG g:globalvar\n\n\n  &tabstop = 8\n  12 PUSHNR 8\n  13 STOREOPT &tabstop\n\n\n  $ENVVAR = ''ev''\n  14 PUSHS "ev"\n  15 STOREENV $ENVVAR\n\n\n  @z = ''rv''\n  16 PUSHS "rv"\n  17 STOREREG @\n  18 PUSHNR 0\n  19 RETURN'
```