### PR TITLE
Fixed several inconsistent printf format and its arguments

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -2848,7 +2848,7 @@ eval_lambda(
 	if (verbose)
 	{
 	    if (*skipwhite(*arg) == '(')
-		semsg(_(e_nowhitespace));
+		semsg("%s", _(e_nowhitespace));
 	    else
 		semsg(_(e_missing_paren), "lambda");
 	}
@@ -2910,7 +2910,7 @@ eval_method(
 	else if (VIM_ISWHITE((*arg)[-1]))
 	{
 	    if (verbose)
-		semsg(_(e_nowhitespace));
+		semsg("%s", _(e_nowhitespace));
 	    ret = FAIL;
 	}
 	else

--- a/src/ops.c
+++ b/src/ops.c
@@ -2999,7 +2999,7 @@ op_addsub(
 	    curbuf->b_op_start = startpos;
 
 	if (change_cnt > p_report)
-	    smsg(NGETTEXT("%ld line changed", "%ld lines changed",
+	    smsg(NGETTEXT("%d line changed", "%d lines changed",
 						      change_cnt), change_cnt);
     }
 }

--- a/src/proto.h
+++ b/src/proto.h
@@ -119,7 +119,7 @@ extern int _stricoll(char *a, char *b);
 // These prototypes cannot be produced automatically.
 int smsg(const char *, ...)
 # ifdef USE_PRINTF_FORMAT_ATTRIBUTE
-    __attribute__((format(printf, 1, 0)))
+    __attribute__((format(printf, 1, 2)))
 # endif
     ;
 
@@ -138,14 +138,14 @@ int smsg_attr_keep(int, const char *, ...)
 // These prototypes cannot be produced automatically.
 int semsg(const char *, ...)
 # ifdef USE_PRINTF_FORMAT_ATTRIBUTE
-    __attribute__((format(printf, 1, 0)))
+    __attribute__((format(printf, 1, 2)))
 # endif
     ;
 
 // These prototypes cannot be produced automatically.
 void siemsg(const char *, ...)
 # ifdef USE_PRINTF_FORMAT_ATTRIBUTE
-    __attribute__((format(printf, 1, 0)))
+    __attribute__((format(printf, 1, 2)))
 # endif
     ;
 

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -4115,7 +4115,7 @@ spell_read_wordfile(spellinfo_T *spin, char_u *fname)
 	    pc = string_convert(&spin->si_conv, rline, NULL);
 	    if (pc == NULL)
 	    {
-		smsg(_("Conversion failure for word in %s line %d: %s"),
+		smsg(_("Conversion failure for word in %s line %ld: %s"),
 							   fname, lnum, rline);
 		continue;
 	    }
@@ -4133,10 +4133,10 @@ spell_read_wordfile(spellinfo_T *spin, char_u *fname)
 	    if (STRNCMP(line, "encoding=", 9) == 0)
 	    {
 		if (spin->si_conv.vc_type != CONV_NONE)
-		    smsg(_("Duplicate /encoding= line ignored in %s line %d: %s"),
+		    smsg(_("Duplicate /encoding= line ignored in %s line %ld: %s"),
 						       fname, lnum, line - 1);
 		else if (did_word)
-		    smsg(_("/encoding= line after word ignored in %s line %d: %s"),
+		    smsg(_("/encoding= line after word ignored in %s line %ld: %s"),
 						       fname, lnum, line - 1);
 		else
 		{
@@ -4159,13 +4159,13 @@ spell_read_wordfile(spellinfo_T *spin, char_u *fname)
 	    if (STRNCMP(line, "regions=", 8) == 0)
 	    {
 		if (spin->si_region_count > 1)
-		    smsg(_("Duplicate /regions= line ignored in %s line %d: %s"),
+		    smsg(_("Duplicate /regions= line ignored in %s line %ld: %s"),
 						       fname, lnum, line);
 		else
 		{
 		    line += 8;
 		    if (STRLEN(line) > MAXREGIONS * 2)
-			smsg(_("Too many regions in %s line %d: %s"),
+			smsg(_("Too many regions in %s line %ld: %s"),
 						       fname, lnum, line);
 		    else
 		    {
@@ -4179,7 +4179,7 @@ spell_read_wordfile(spellinfo_T *spin, char_u *fname)
 		continue;
 	    }
 
-	    smsg(_("/ line ignored in %s line %d: %s"),
+	    smsg(_("/ line ignored in %s line %ld: %s"),
 						       fname, lnum, line - 1);
 	    continue;
 	}
@@ -4209,7 +4209,7 @@ spell_read_wordfile(spellinfo_T *spin, char_u *fname)
 		    l = *p - '0';
 		    if (l == 0 || l > spin->si_region_count)
 		    {
-			smsg(_("Invalid region nr in %s line %d: %s"),
+			smsg(_("Invalid region nr in %s line %ld: %s"),
 							  fname, lnum, p);
 			break;
 		    }
@@ -4217,7 +4217,7 @@ spell_read_wordfile(spellinfo_T *spin, char_u *fname)
 		}
 		else
 		{
-		    smsg(_("Unrecognized flags in %s line %d: %s"),
+		    smsg(_("Unrecognized flags in %s line %ld: %s"),
 							      fname, lnum, p);
 		    break;
 		}

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1830,7 +1830,7 @@ compile_load(char_u **arg, char_u *end_arg, cctx_T *cctx, int error)
 	}
 	else
 	{
-	    semsg("Namespace not supported yet: %s", **arg);
+	    semsg("Namespace not supported yet: %s", *arg);
 	    goto theend;
 	}
     }
@@ -2213,7 +2213,7 @@ compile_lambda_call(char_u **arg, cctx_T *cctx)
     if (**arg != '(')
     {
 	if (*skipwhite(*arg) == '(')
-	    semsg(_(e_nowhitespace));
+	    semsg("%s", _(e_nowhitespace));
 	else
 	    semsg(_(e_missing_paren), "lambda");
 	clear_tv(&rettv);

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -1774,14 +1774,14 @@ ex_disassemble(exarg_T *eap)
 		}
 		break;
 	    case ISN_EXECUTE:
-		smsg("%4d EXECUTE %d", current, iptr->isn_arg.number);
+		smsg("%4d EXECUTE %lld", current, (long long)(iptr->isn_arg.number));
 		break;
 	    case ISN_LOAD:
 		if (iptr->isn_arg.number < 0)
 		    smsg("%4d LOAD arg[%lld]", current,
-				      iptr->isn_arg.number + STACK_FRAME_SIZE);
+				      (long long)(iptr->isn_arg.number + STACK_FRAME_SIZE));
 		else
-		    smsg("%4d LOAD $%lld", current, iptr->isn_arg.number);
+		    smsg("%4d LOAD $%lld", current, (long long)(iptr->isn_arg.number));
 		break;
 	    case ISN_LOADV:
 		smsg("%4d LOADV v:%s", current,
@@ -1817,15 +1817,15 @@ ex_disassemble(exarg_T *eap)
 		smsg("%4d LOADENV %s", current, iptr->isn_arg.string);
 		break;
 	    case ISN_LOADREG:
-		smsg("%4d LOADREG @%c", current, iptr->isn_arg.number);
+		smsg("%4d LOADREG @%c", current, (char)(iptr->isn_arg.number));
 		break;
 
 	    case ISN_STORE:
 		if (iptr->isn_arg.number < 0)
 		    smsg("%4d STORE arg[%lld]", current,
-				      iptr->isn_arg.number + STACK_FRAME_SIZE);
+				(long long)(iptr->isn_arg.number + STACK_FRAME_SIZE));
 		else
-		    smsg("%4d STORE $%lld", current, iptr->isn_arg.number);
+		    smsg("%4d STORE $%lld", current, (long long)(iptr->isn_arg.number));
 		break;
 	    case ISN_STOREV:
 		smsg("%4d STOREV v:%s", current,
@@ -1862,7 +1862,7 @@ ex_disassemble(exarg_T *eap)
 		smsg("%4d STOREENV $%s", current, iptr->isn_arg.string);
 		break;
 	    case ISN_STOREREG:
-		smsg("%4d STOREREG @%c", current, iptr->isn_arg.number);
+		smsg("%4d STOREREG @%c", current, (char)iptr->isn_arg.number);
 		break;
 	    case ISN_STORENR:
 		smsg("%4d STORE %lld in $%d", current,
@@ -1872,7 +1872,7 @@ ex_disassemble(exarg_T *eap)
 
 	    // constants
 	    case ISN_PUSHNR:
-		smsg("%4d PUSHNR %lld", current, iptr->isn_arg.number);
+		smsg("%4d PUSHNR %lld", current, (long long)(iptr->isn_arg.number));
 		break;
 	    case ISN_PUSHBOOL:
 	    case ISN_PUSHSPEC:
@@ -1941,10 +1941,10 @@ ex_disassemble(exarg_T *eap)
 		smsg("%4d PUSH v:exception", current);
 		break;
 	    case ISN_NEWLIST:
-		smsg("%4d NEWLIST size %lld", current, iptr->isn_arg.number);
+		smsg("%4d NEWLIST size %lld", current, (long long)(iptr->isn_arg.number));
 		break;
 	    case ISN_NEWDICT:
-		smsg("%4d NEWDICT size %lld", current, iptr->isn_arg.number);
+		smsg("%4d NEWDICT size %lld", current, (long long)(iptr->isn_arg.number));
 		break;
 
 	    // function call
@@ -2153,8 +2153,8 @@ ex_disassemble(exarg_T *eap)
 			    else
 				smsg("%4d 2BOOL (!!val)", current);
 			    break;
-	    case ISN_2STRING: smsg("%4d 2STRING stack[%d]", current,
-							 iptr->isn_arg.number);
+	    case ISN_2STRING: smsg("%4d 2STRING stack[%lld]", current,
+					 (long long)(iptr->isn_arg.number));
 				break;
 
 	    case ISN_DROP: smsg("%4d DROP", current); break;

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -2992,7 +2992,7 @@ read_viminfo(
     if (p_verbose > 0)
     {
 	verbose_enter();
-	smsg(_("Reading viminfo file \"%s\"%s%s%s"),
+	smsg(_("Reading viminfo file \"%s\"%s%s%s%s"),
 		fname,
 		(flags & VIF_WANT_INFO) ? _(" info") : "",
 		(flags & VIF_WANT_MARKS) ? _(" marks") : "",


### PR DESCRIPTION
This PR fixes the incorrect `__attribute__(format(printf, …))`
in declarations of `smsg()`, `semsg()`, `siemsg()`, and fixes
several compilation warnings that it uncovered.

PR is a generalization of the fix at https://github.com/vim/vim/pull/5831
