### PR TITLE
Fix split/join not updating start/end status of prop

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -3405,7 +3405,6 @@ adjust_text_props_for_delete(
     int		done_del;
     int		done_this;
     textprop_T	prop_del;
-    textprop_T	prop_this;
     bhdr_T	*hp;
     DATA_BL	*dp;
     int		idx;
@@ -3453,22 +3452,18 @@ adjust_text_props_for_delete(
 	    found = FALSE;
 	    for (done_this = 0; done_this < this_props_len; done_this += sizeof(textprop_T))
 	    {
+		int flag = above ? TP_FLAG_CONT_NEXT : TP_FLAG_CONT_PREV;
+		textprop_T prop_this;
 		mch_memmove(&prop_this, text + textlen + done_del, sizeof(textprop_T));
-		if (prop_del.tp_id == prop_this.tp_id
+
+		if (prop_this.tp_flags & flag
+			&& prop_del.tp_id == prop_this.tp_id
 			&& prop_del.tp_type == prop_this.tp_type)
 		{
-		    int flag = above ? TP_FLAG_CONT_NEXT : TP_FLAG_CONT_PREV;
-
 		    found = TRUE;
-		    if (prop_this.tp_flags & flag)
-		    {
-			prop_this.tp_flags &= ~flag;
-			mch_memmove(text + textlen + done_del, &prop_this, sizeof(textprop_T));
-		    }
-		    else if (above)
-			internal_error("text property above deleted line does not continue");
-		    else
-			internal_error("text property below deleted line does not continue");
+		    prop_this.tp_flags &= ~flag;
+		    mch_memmove(text + textlen + done_del, &prop_this, sizeof(textprop_T));
+		    break;
 		}
 	    }
 	    if (!found)

--- a/src/ops.c
+++ b/src/ops.c
@@ -1941,10 +1941,7 @@ do_join(
     int		remove_comments = (use_formatoptions == TRUE)
 				  && has_format_option(FO_REMOVE_COMS);
     int		prev_was_comment;
-#ifdef FEAT_PROP_POPUP
-    textprop_T	**prop_lines = NULL;
-    int		*prop_lengths = NULL;
-#endif
+    int		propcount = 0;	// number of props over all joined lines
 
     if (save_undo && u_save((linenr_T)(curwin->w_cursor.lnum - 1),
 			    (linenr_T)(curwin->w_cursor.lnum + count)) == FAIL)
@@ -1973,6 +1970,9 @@ do_join(
      */
     for (t = 0; t < count; ++t)
     {
+#ifdef FEAT_PROP_POPUP
+	propcount += count_props((linenr_T) (curwin->w_cursor.lnum + t), t > 0);
+#endif
 	curr = curr_start = ml_get((linenr_T)(curwin->w_cursor.lnum + t));
 	if (t == 0 && setmark && !cmdmod.lockmarks)
 	{
@@ -2056,7 +2056,8 @@ do_join(
     col = sumsize - currsize - spaces[count - 1];
 
     // allocate the space for the new line
-    newp = alloc(sumsize + 1);
+    size_t len_newp = sumsize + 1 + propcount * sizeof(textprop_T);
+    newp = alloc(len_newp);
     if (newp == NULL)
     {
 	ret = FAIL;
@@ -2065,70 +2066,47 @@ do_join(
     cend = newp + sumsize;
     *cend = 0;
 
-#ifdef FEAT_PROP_POPUP
-    // We need to move properties of the lines that are going to be deleted to
-    // the new long one.
-    if (curbuf->b_has_textprop && !text_prop_frozen)
-    {
-	// Allocate an array to copy the text properties of joined lines into.
-	// And another array to store the number of properties in each line.
-	prop_lines = ALLOC_CLEAR_MULT(textprop_T *, count - 1);
-	prop_lengths = ALLOC_CLEAR_MULT(int, count - 1);
-	if (prop_lengths == NULL)
-	    VIM_CLEAR(prop_lines);
-    }
-#endif
-
     /*
      * Move affected lines to the new long one.
-     * This loops backwards over the joined lines, including the original line.
+     * This loops forward over the joined lines, including the original line.
      *
      * Move marks from each deleted line to the joined line, adjusting the
      * column.  This is not Vi compatible, but Vi deletes the marks, thus that
      * should not really be a problem.
      */
-    for (t = count - 1; ; --t)
-    {
+    char_u *newp_in = newp;
+    char_u *first_prop = newp + sumsize + 1;
+    int n = 0; // number of currently inserted props
+    for (t = 0; t < count; ++t) {
+	char_u *linestart = newp_in;
 	int spaces_removed;
 
-	cend -= currsize;
-	mch_memmove(cend, curr, (size_t)currsize);
-	if (spaces[t] > 0)
-	{
-	    cend -= spaces[t];
-	    vim_memset(cend, ' ', (size_t)(spaces[t]));
-	}
+	curr = curr_start = ml_get(curwin->w_cursor.lnum + t);
+	if (remove_comments)
+	    curr += comments[t];
+	if (insert_space && t > 0)
+	    curr = skipwhite(curr);
+	currsize = (int)STRLEN(curr);
+
+	vim_memset(newp_in, ' ', (size_t) spaces[t]); // Insert spaces
+	newp_in += spaces[t];
+
+	mch_memmove(newp_in, curr, (size_t) currsize);
+	newp_in += currsize;
 
 	// If deleting more spaces than adding, the cursor moves no more than
 	// what is added if it is inside these spaces.
 	spaces_removed = (curr - curr_start) - spaces[t];
 
 	mark_col_adjust(curwin->w_cursor.lnum + t, (colnr_T)0, (linenr_T)-t,
-			 (long)(cend - newp - spaces_removed), spaces_removed);
-	if (t == 0)
-	    break;
+			 (long)(linestart - newp) - spaces_removed, spaces_removed);
 #ifdef FEAT_PROP_POPUP
-	if (prop_lines != NULL)
-	    adjust_props_for_join(curwin->w_cursor.lnum + t,
-				      prop_lines + t - 1, prop_lengths + t - 1,
-			 (long)(cend - newp - spaces_removed), spaces_removed);
+	append_joined_props(first_prop, &n, curwin->w_cursor.lnum + t, t == 0,
+		(long) (linestart - newp), spaces_removed);
 #endif
-
-	curr = curr_start = ml_get((linenr_T)(curwin->w_cursor.lnum + t - 1));
-	if (remove_comments)
-	    curr += comments[t - 1];
-	if (insert_space && t > 1)
-	    curr = skipwhite(curr);
-	currsize = (int)STRLEN(curr);
     }
 
-#ifdef FEAT_PROP_POPUP
-    if (prop_lines != NULL)
-	join_prop_lines(curwin->w_cursor.lnum, newp,
-					      prop_lines, prop_lengths, count);
-    else
-#endif
-	ml_replace(curwin->w_cursor.lnum, newp, FALSE);
+    ml_replace_len(curwin->w_cursor.lnum, newp, len_newp, propcount > 0, FALSE);
 
     if (setmark && !cmdmod.lockmarks)
     {

--- a/src/ops.c
+++ b/src/ops.c
@@ -1929,6 +1929,7 @@ do_join(
     char_u      *curr_start = NULL;
     char_u	*cend;
     char_u	*newp;
+    size_t	newp_len;
     char_u	*spaces;	// number of spaces inserted before a line
     int		endcurr1 = NUL;
     int		endcurr2 = NUL;
@@ -1971,10 +1972,10 @@ do_join(
      */
     for (t = 0; t < count; ++t)
     {
+	curr = curr_start = ml_get((linenr_T)(curwin->w_cursor.lnum + t));
 #ifdef FEAT_PROP_POPUP
 	propcount += count_props((linenr_T) (curwin->w_cursor.lnum + t), t > 0);
 #endif
-	curr = curr_start = ml_get((linenr_T)(curwin->w_cursor.lnum + t));
 	if (t == 0 && setmark && !cmdmod.lockmarks)
 	{
 	    // Set the '[ mark.
@@ -2057,8 +2058,8 @@ do_join(
     col = sumsize - currsize - spaces[count - 1];
 
     // allocate the space for the new line
-    size_t len_newp = sumsize + 1 + propcount * sizeof(textprop_T);
-    newp = alloc(len_newp);
+    newp_len = sumsize + 1 + propcount * sizeof(textprop_T);
+    newp = alloc(newp_len);
     if (newp == NULL)
     {
 	ret = FAIL;
@@ -2110,7 +2111,7 @@ do_join(
 	currsize = (int)STRLEN(curr);
     }
 
-    ml_replace_len(curwin->w_cursor.lnum, newp, len_newp, TRUE, FALSE);
+    ml_replace_len(curwin->w_cursor.lnum, newp, newp_len, TRUE, FALSE);
 
     if (setmark && !cmdmod.lockmarks)
     {

--- a/src/proto/textprop.pro
+++ b/src/proto/textprop.pro
@@ -3,6 +3,7 @@ int find_prop_type_id(char_u *name, buf_T *buf);
 void f_prop_add(typval_T *argvars, typval_T *rettv);
 void prop_add_common(linenr_T start_lnum, colnr_T start_col, dict_T *dict, buf_T *default_buf, typval_T *dict_arg);
 int get_text_props(buf_T *buf, linenr_T lnum, char_u **props, int will_change);
+int count_props(linenr_T lnum, int only_starting);
 int find_visible_prop(win_T *wp, int type_id, int id, textprop_T *prop, linenr_T *found_lnum);
 proptype_T *text_prop_type_by_id(buf_T *buf, int id);
 void f_prop_clear(typval_T *argvars, typval_T *rettv);
@@ -18,6 +19,5 @@ void clear_global_prop_types(void);
 void clear_buf_prop_types(buf_T *buf);
 int adjust_prop_columns(linenr_T lnum, colnr_T col, int bytes_added, int flags);
 void adjust_props_for_split(linenr_T lnum_props, linenr_T lnum_top, int kept, int deleted);
-void adjust_props_for_join(linenr_T lnum, textprop_T **prop_line, int *prop_length, long col, int removed);
-void join_prop_lines(linenr_T lnum, char_u *newp, textprop_T **prop_lines, int *prop_lengths, int count);
+void append_joined_props(char_u *new_props, int *n, linenr_T lnum, int add_all, long col, int removed);
 /* vim: set ft=c : */

--- a/src/proto/textprop.pro
+++ b/src/proto/textprop.pro
@@ -19,5 +19,5 @@ void clear_global_prop_types(void);
 void clear_buf_prop_types(buf_T *buf);
 int adjust_prop_columns(linenr_T lnum, colnr_T col, int bytes_added, int flags);
 void adjust_props_for_split(linenr_T lnum_props, linenr_T lnum_top, int kept, int deleted);
-void append_joined_props(char_u *new_props, int *n, linenr_T lnum, int add_all, long col, int removed);
+void prepend_joined_props(char_u *new_props, int max_n, int *n, linenr_T lnum, int add_all, long col, int removed);
 /* vim: set ft=c : */

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -1209,17 +1209,22 @@ func Test_find_zerowidth_prop_sol()
   call prop_type_delete('test')
 endfunc
 
-func Test_split()
+func Test_split_join()
   new
   call prop_type_add('test', {'highlight': 'ErrorMsg'})
   call setline(1, 'just some text')
   call prop_add(1, 6, {'length': 4, 'type': 'test'})
-  execute "normal! 8|i\<CR>"
 
+  " Split in middle of "some"
+  execute "normal! 8|i\<CR>"
   call assert_equal([{'id': 0, 'col': 6, 'end': 0, 'type': 'test', 'length': 2, 'start': 1}],
 			  \ prop_list(1))
   call assert_equal([{'id': 0, 'col': 1, 'end': 1, 'type': 'test', 'length': 2, 'start': 0}],
 			  \ prop_list(2))
+
+  " Join the two lines back together
+  normal! 1GJ
+  call assert_equal([{'id': 0, 'col': 6, 'end': 1, 'type': 'test', 'length': 5, 'start': 1}], prop_list(1))
 
   bwipe!
   call prop_type_delete('test')

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -460,9 +460,11 @@ func Test_prop_open_line()
   call assert_equal('nex xtwoxx', getline(2))
   let exp_first = [deepcopy(expected[0])]
   let exp_first[0].length = 1
+  let exp_first[0].end = 0
   call assert_equal(exp_first, prop_list(1))
   let expected[0].col = 1
   let expected[0].length = 2
+  let expected[0].start = 0
   let expected[1].col -= 2
   call assert_equal(expected, prop_list(2))
   call DeletePropTypes()
@@ -575,11 +577,13 @@ func Test_prop_substitute()
 	\ copy(expected_props[3]),
 	\ ]
   let expected_props[0].length = 5
+  let expected_props[0].end = 0
   unlet expected_props[3]
   unlet expected_props[2]
   call assert_equal(expected_props, prop_list(1))
 
   let new_props[0].length = 6
+  let new_props[0].start = 0
   let new_props[1].col = 1
   let new_props[1].length = 1
   let new_props[2].col = 3
@@ -1200,6 +1204,22 @@ func Test_find_zerowidth_prop_sol()
 
   call assert_equal({'id': 0, 'lnum': 1, 'col': 1, 'end': 1, 'type': 'test', 'length': 0, 'start': 1},
 			  \ prop_find(#{type: 'test', lnum: 1}))
+
+  bwipe!
+  call prop_type_delete('test')
+endfunc
+
+func Test_split()
+  new
+  call prop_type_add('test', {'highlight': 'ErrorMsg'})
+  call setline(1, 'just some text')
+  call prop_add(1, 6, {'length': 4, 'type': 'test'})
+  execute "normal! 8|i\<CR>"
+
+  call assert_equal([{'id': 0, 'col': 6, 'end': 0, 'type': 'test', 'length': 2, 'start': 1}],
+			  \ prop_list(1))
+  call assert_equal([{'id': 0, 'col': 1, 'end': 1, 'type': 'test', 'length': 2, 'start': 0}],
+			  \ prop_list(2))
 
   bwipe!
   call prop_type_delete('test')


### PR DESCRIPTION
Some progress on making sure splitting and joining text properties updates the start/end status of the props accordingly.

What does not work is undoing the effects of a join, which add an extra textprop spanning the entire line to the unjoined lines. Would appreciate any pointers on how to fix that.

The new code calls `STRLEN()` a few more times than the old, but does fewer heap allocations per join. I hope this is fine, otherwise there are a few calls to `get_text_props` that can be done manually as we already know `textlen`.

Fixes #5683