### PR TITLE
Fix empty argument passed to job if command has a trailing space

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -4251,6 +4251,8 @@ mch_parse_cmd(char_u *cmd, int use_shcf, char ***argv, int *argc)
 	{
 	    if (i == 1)
 		(*argv)[*argc] = (char *)p;
+	    if (*p == NUL)
+		break;
 	    ++*argc;
 	    d = p;
 	    while (*p != NUL && (inquote || (*p != ' ' && *p != TAB)))

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -2035,4 +2035,12 @@ func Test_issue_5485()
   unlet $VAR1
 endfunc
 
+func Test_job_trailing_space_unix()
+  CheckUnix
+  CheckExecutable cat
+  let job = job_start("cat ", #{in_io: 'null'})
+  call WaitForAssert({-> assert_equal("dead", job_status(job))})
+  call assert_equal(0, job_info(job).exitval)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**Describe the bug**
Empty argument passed to job if command has a trailing space.
Perhaps cause this problem in unix only.

**To Reproduce**
```vim
func JobTest()
  let job = job_start("cat ", {"in_io": "null"})
  while job_status(job) != "dead"
  endwhile
  return job_info(job).exitval
endfunc
```
Run this function in `vim --clean`, returns 1.