### PR TITLE
Added a tag property to the job_info object.

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -5298,6 +5298,10 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		opt->jo_set |= JO_BLOCK_WRITE;
 		opt->jo_block_write = tv_get_number(item);
 	    }
+	    else if (STRCMP(hi->hi_key, "tag") == 0)
+	    {
+		opt->tag = tv_get_number(item);
+	    }
 	    else
 		break;
 	    --todo;
@@ -5769,6 +5773,7 @@ job_set_options(job_T *job, jobopt_T *opt)
 	else
 	    copy_callback(&job->jv_exit_cb, &opt->jo_exit_cb);
     }
+    job->tag = opt->tag;
 }
 
 /*
@@ -6538,6 +6543,7 @@ job_info(job_T *job, dict_T *dict)
     int		i;
 
     dict_add_string(dict, "status", (char_u *)job_status(job));
+    dict_add_number(dict, "tag", job->tag);
 
     item = dictitem_alloc((char_u *)"channel");
     if (item == NULL)

--- a/src/structs.h
+++ b/src/structs.h
@@ -1848,6 +1848,7 @@ struct jobvar_S
 
     channel_T	*jv_channel;	// channel for I/O, reference counted
     char	**jv_argv;	// command line used to start the job
+    int tag;
 };
 
 /*
@@ -2150,6 +2151,7 @@ typedef struct
     char_u	jo_term_api_buf[NUMBUFLEN];
     char_u	*jo_term_api;
 #endif
+    int		tag;
 } jobopt_T;
 
 #ifdef FEAT_EVAL


### PR DESCRIPTION
With this it is possible to supply additional parameters to the exit
callback in exit_cb via a dictionary. A simple use case would be to echo
a message in the exit callback that tells the user which job has just
exited.

Using the job as the key does not work for very short lived jobs, because
the exit handler could already be called before the initiating caller has
the chance to place the parameters in the dictionary.