### PR TITLE
update docs for netrw-cd bindings (was netrw-c)

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1080,7 +1080,7 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 	   a	Cycles between normal display,                       |netrw-a|
 	    	hiding (suppress display of files matching g:netrw_list_hide)
 	    	and showing (display only files which match g:netrw_list_hide)
-	   c	Make browsing directory the current directory        |netrw-c|
+	   cd	Make browsing directory the current directory        |netrw-cd|
 	   C	Setting the editing window                           |netrw-C|
 	   d	Make a directory                                     |netrw-d|
 	   D	Attempt to remove the file(s)/directory(ies)         |netrw-D|
@@ -2753,7 +2753,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				=0 keep the current directory the same as the
 				   browsing directory.
 				The current browsing directory is contained in
-				b:netrw_curdir (also see |netrw-c|)
+				b:netrw_curdir (also see |netrw-cd|)
 
   *g:netrw_keepj*		="keepj" (default) netrw attempts to keep the
 				         |:jumps| table unaffected.
@@ -3124,7 +3124,7 @@ a file using the local browser (by putting the cursor on it) and pressing
 
 Related topics:
  * To see what the current directory is, use |:pwd|
- * To make the currently browsed directory the current directory, see |netrw-c|
+ * To make the currently browsed directory the current directory, see |netrw-cd|
  * To automatically make the currently browsed directory the current
    directory, see |g:netrw_keepdir|.
 

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -84,7 +84,7 @@ browser.  This is what you get: >
      	 a................Hiding Files or Directories................|netrw-a|
      	 mb...............Bookmarking a Directory....................|netrw-mb|
      	 gb...............Changing to a Bookmarked Directory.........|netrw-gb|
-     	 c................Make Browsing Directory The Current Dir....|netrw-c|
+     	 cd...............Make Browsing Directory The Current Dir....|netrw-cd|
      	 d................Make A New Directory.......................|netrw-d|
      	 D................Deleting Files or Directories..............|netrw-D|
      	 <c-h>............Edit File/Directory Hiding List............|netrw-ctrl-h|
@@ -121,7 +121,7 @@ The following normal-mode commands may be used to control the browser display:
 
 As a sampling of extra normal-mode commands:
 
-	c		Change Vim's notion of the current directory to be
+	cd		Change Vim's notion of the current directory to be
 			the same as the browser directory.  (see
 			|g:netrw_keepdir| to control this, too)
 	R		Rename the file or directory under the cursor; a


### PR DESCRIPTION
Perhaps the note about the renaming can be removed as well, see :help netrw-c