### PR TITLE
Fix Test_confirm_cmd_cancel

### DIFF
--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -259,7 +259,7 @@ func Test_confirm_cmd_cancel()
   call WaitForAssert({-> assert_match('^\[Y\]es, (N)o, (C)ancel: *$',
         \ term_getline(buf, 20))}, 1000)
   call term_sendkeys(buf, "C")
-  call term_wait(buf, 50)
+  call WaitForAssert({-> assert_equal('', term_getline(buf, 20))}, 1000)
   call term_sendkeys(buf, ":confirm close\n")
   call WaitForAssert({-> assert_match('^\[Y\]es, (N)o, (C)ancel: *$',
         \ term_getline(buf, 20))}, 1000)


### PR DESCRIPTION
In Test_confirm_cmd_cancel sequence,

out: bottom line (cmdline) text of vim run by `RunVimInTerminal()`
in: user input (`term_sendkey()`)

```
[1] out> [Y]es, (N)o, (C)ancel: 
[2] in > C
[3] out> 
[4] in > :confirm close<CR>
[5] out> [Y]es, (N)o, (C)ancel: 
[6] in >N
[7] out>              0,0-1         All
```

When system performs slowly, receiving above [2] and [4] input is delayed so then the second cmdline checking (the following `WaitForAssert()` after sending "N") can detect [1] state against test intention (detect [5]).

```
  call WaitForAssert({-> assert_match('^\[Y\]es, (N)o, (C)ancel: *$',
        \ term_getline(buf, 20))}, 1000)
```

Therefore should check the cmdline is cleared after sending "C".