### PR TITLE
Not to unload if_lang/dyn libraries when ASan is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,10 +101,7 @@ _anchors:
     - (cd "${SRCDIR}" && bash <(curl -s https://codecov.io/bash))
 
   asan_symbolize: &asan_symbolize
-    - |
-      while read log; do
-        asan_symbolize < "${log}"
-      done < <(find . -type f -name 'asan.*' -size +0)
+    - find . -type f -name 'asan.*' -size +0 2>/dev/null | xargs -I{} -n1 -t asan_symbolize -l{}
 
 branches:
   except:

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -401,13 +401,13 @@ static HANDLE hinstLua = NULL;
     static void
 end_dynamic_lua(void)
 {
-#if !USE_ADDRESS_SANITIZER
+# if defined(EXITFREE) && !USE_ADDRESS_SANITIZER
     if (hinstLua)
     {
 	close_dll(hinstLua);
 	hinstLua = 0;
     }
-#endif
+# endif
 }
 
     static int

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -401,11 +401,13 @@ static HANDLE hinstLua = NULL;
     static void
 end_dynamic_lua(void)
 {
+#if !USE_ADDRESS_SANITIZER
     if (hinstLua)
     {
 	close_dll(hinstLua);
 	hinstLua = 0;
     }
+#endif
 }
 
     static int

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -679,6 +679,21 @@ S_POPMARK(pTHX)
 # endif
 
 /*
+ * Free perl.dll
+ */
+    static void
+end_dynamic_perl(void)
+{
+#if !USE_ADDRESS_SANITIZER
+    if (hPerlLib)
+    {
+	close_dll(hPerlLib);
+	hPerlLib = NULL;
+    }
+#endif
+}
+
+/*
  * Make all runtime-links of perl.
  *
  * 1. Get module handle using dlopen() or vimLoadLib().
@@ -777,12 +792,9 @@ perl_end(void)
 	Perl_sys_term();
 #endif
     }
-#if defined(DYNAMIC_PERL) && !USE_ADDRESS_SANITIZER
-    if (hPerlLib)
-    {
-	close_dll(hPerlLib);
-	hPerlLib = NULL;
-    }
+
+#ifdef DYNAMIC_PERL
+    end_dynamic_perl();
 #endif
 }
 

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -777,7 +777,7 @@ perl_end(void)
 	Perl_sys_term();
 #endif
     }
-#ifdef DYNAMIC_PERL
+#if defined(DYNAMIC_PERL) && !USE_ADDRESS_SANITIZER
     if (hPerlLib)
     {
 	close_dll(hPerlLib);

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -684,13 +684,13 @@ S_POPMARK(pTHX)
     static void
 end_dynamic_perl(void)
 {
-#if !USE_ADDRESS_SANITIZER
+# if defined(EXITFREE) && !USE_ADDRESS_SANITIZER
     if (hPerlLib)
     {
 	close_dll(hPerlLib);
 	hPerlLib = NULL;
     }
-#endif
+# endif
 }
 
 /*

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -660,11 +660,13 @@ static struct
     static void
 end_dynamic_python(void)
 {
+#if !USE_ADDRESS_SANITIZER
     if (hinstPython)
     {
 	close_dll(hinstPython);
 	hinstPython = 0;
     }
+#endif
 }
 
 /*

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -881,27 +881,22 @@ python_end(void)
     python_end_called = TRUE;
     ++recurse;
 
+    if (
 #ifdef DYNAMIC_PYTHON
-    if (hinstPython && Py_IsInitialized())
+	hinstPython &&
+#endif
+	Py_IsInitialized())
     {
-# ifdef PY_CAN_RECURSE
+#ifdef PY_CAN_RECURSE
 	PyGILState_Ensure();
-# else
-	Python_RestoreThread();	    // enter python
-# endif
-	Py_Finalize();
-    }
-    end_dynamic_python();
 #else
-    if (Py_IsInitialized())
-    {
-# ifdef PY_CAN_RECURSE
-	PyGILState_Ensure();
-# else
 	Python_RestoreThread();	    // enter python
-# endif
+#endif
 	Py_Finalize();
     }
+
+#ifdef DYNAMIC_PYTHON
+    end_dynamic_python();
 #endif
 
     --recurse;

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -660,13 +660,13 @@ static struct
     static void
 end_dynamic_python(void)
 {
-#if !USE_ADDRESS_SANITIZER
+# if defined(EXITFREE) && !USE_ADDRESS_SANITIZER
     if (hinstPython)
     {
 	close_dll(hinstPython);
 	hinstPython = 0;
     }
-#endif
+# endif
 }
 
 /*

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -864,10 +864,11 @@ python3_end(void)
     python_end_called = TRUE;
     ++recurse;
 
+    if (
 #ifdef DYNAMIC_PYTHON3
-    if (hinstPy3)
+	hinstPy3 &&
 #endif
-    if (Py_IsInitialized())
+	Py_IsInitialized())
     {
 	// acquire lock before finalizing
 	PyGILState_Ensure();

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -640,11 +640,13 @@ py3__Py_XDECREF(PyObject *op)
     static void
 end_dynamic_python3(void)
 {
+#if !USE_ADDRESS_SANITIZER
     if (hinstPy3 != 0)
     {
 	close_dll(hinstPy3);
 	hinstPy3 = 0;
     }
+#endif
 }
 
 /*

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -640,13 +640,13 @@ py3__Py_XDECREF(PyObject *op)
     static void
 end_dynamic_python3(void)
 {
-#if !USE_ADDRESS_SANITIZER
+# if defined(EXITFREE) && !USE_ADDRESS_SANITIZER
     if (hinstPy3 != 0)
     {
 	close_dll(hinstPy3);
 	hinstPy3 = 0;
     }
-#endif
+# endif
 }
 
 /*

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -741,11 +741,13 @@ static struct
     static void
 end_dynamic_ruby(void)
 {
+#if !USE_ADDRESS_SANITIZER
     if (hinstRuby)
     {
 	close_dll(hinstRuby);
 	hinstRuby = NULL;
     }
+#endif
 }
 
 /*

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -741,13 +741,13 @@ static struct
     static void
 end_dynamic_ruby(void)
 {
-#if !USE_ADDRESS_SANITIZER
+# if defined(EXITFREE) && !USE_ADDRESS_SANITIZER
     if (hinstRuby)
     {
 	close_dll(hinstRuby);
 	hinstRuby = NULL;
     }
-#endif
+# endif
 }
 
 /*

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -280,7 +280,7 @@ tcl_enabled(int verbose)
     void
 tcl_end(void)
 {
-#ifdef DYNAMIC_TCL
+#if defined(DYNAMIC_TCL) && !USE_ADDRESS_SANITIZER
     if (hTclLib)
     {
 	close_dll(hTclLib);

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -199,7 +199,7 @@ static struct {
     static void
 end_dynamic_tcl(void)
 {
-# if !USE_ADDRESS_SANITIZER
+# if defined(EXITFREE) && !USE_ADDRESS_SANITIZER
     if (hTclLib)
     {
 	close_dll(hTclLib);

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -194,6 +194,21 @@ static struct {
 };
 
 /*
+ * Free tcl.dll
+ */
+    static void
+end_dynamic_tcl(void)
+{
+# if !USE_ADDRESS_SANITIZER
+    if (hTclLib)
+    {
+	close_dll(hTclLib);
+	hTclLib = NULL;
+    }
+# endif
+}
+
+/*
  * Make all runtime-links of tcl.
  *
  * 1. Get module handle using LoadLibraryEx.
@@ -280,12 +295,8 @@ tcl_enabled(int verbose)
     void
 tcl_end(void)
 {
-#if defined(DYNAMIC_TCL) && !USE_ADDRESS_SANITIZER
-    if (hTclLib)
-    {
-	close_dll(hTclLib);
-	hTclLib = NULL;
-    }
+#ifdef DYNAMIC_TCL
+    end_dynamic_tcl();
 #endif
 }
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -2657,4 +2657,13 @@ long elapsed(DWORD start_tick);
 #define REPTERM_SPECIAL		4
 #define REPTERM_NO_SIMPLIFY	8
 
+// Build with ASan (Address Sanitizer)
+#ifdef __clang__
+# define USE_ADDRESS_SANITIZER __has_feature(address_sanitizer)
+#elif defined(__SANITIZE_ADDRESS__) // gcc
+# define USE_ADDRESS_SANITIZER 1
+#else
+# define USE_ADDRESS_SANITIZER 0
+#endif
+
 #endif // VIM__H


### PR DESCRIPTION
When if_language dynamic-loaded library (e.g. `+python/dyn`) leaks their resources internally,
want to suppress the ASan assertion about them but cannot; because the library is unloaded at
finishing and its information is gone.

Example: There are leaks in libpython but cannot identify it, printed `<unknown module>`.

```
Direct leak of 32 byte(s) in 1 object(s) allocated from:                                                                                                        [1/27795]
    #0 0x7f501fbf7b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f5011467f84  (<unknown module>)
    ...
```

Therefore should not unload the libraries when ASan is enabled.