### PR TITLE
Fix Buffers menu not adding new buffers to menu

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -672,7 +672,7 @@ func s:BMAdd()
       call s:BMShow()
     else
       let name = expand("<afile>")
-      let num = expand("<abuf>")
+      let num = expand("<abuf>") + 0 " +0 to convert 'num' to a number type
       if s:BMCanAdd(name, num)
 	call <SID>BMFilename(name, num)
 	let s:bmenu_count += 1

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -33,10 +33,17 @@ func Test_buffer_menu_special_buffers()
 
   let orig_buffer_menus = execute("nmenu Buffers")
 
+  " Test that regular new buffer results in a new buffer menu item.
+  new
+  let new_buffer_menus = execute('nmenu Buffers')
+  call assert_equal(len(split(orig_buffer_menus, "\n")) + 2, len(split(new_buffer_menus, "\n")))
+  bwipe!
+  call assert_equal(orig_buffer_menus, execute("nmenu Buffers"))
+
   " Make a new command-line window, test that it does not create a new buffer
   " menu.
   call feedkeys("q::let cmdline_buffer_menus=execute('nmenu Buffers')\<CR>:q\<CR>", 'ntx')
-  call assert_equal(len(split(orig_buffer_menus, "\n")), len(split(cmdline_buffer_menus, "\n")))
+  call assert_equal(len(split(orig_buffer_menus, "\n")) + 2, len(split(cmdline_buffer_menus, "\n")))
   call assert_equal(orig_buffer_menus, execute("nmenu Buffers"))
 
   if has('terminal')
@@ -44,7 +51,7 @@ func Test_buffer_menu_special_buffers()
     " item.
     terminal
     let term_buffer_menus = execute('nmenu Buffers')
-    call assert_equal(len(split(orig_buffer_menus, "\n")), len(split(term_buffer_menus, "\n")))
+    call assert_equal(len(split(orig_buffer_menus, "\n")) + 2, len(split(term_buffer_menus, "\n")))
     bwipe!
     call assert_equal(orig_buffer_menus, execute("nmenu Buffers"))
   endif
@@ -155,6 +162,9 @@ endfunc
 
 " Test for menu item completion in command line
 func Test_menu_expand()
+  " Make sure we don't have stale menu items like Buffers menu.
+  source $VIMRUNTIME/delmenu.vim
+
   " Create the menu itmes for test
   menu Dummy.Nothing lll
   for i in range(1, 4)


### PR DESCRIPTION
v8.2.0413 (see #5787) attempted to fix an issue with special buffers leaving stale Buffers menu items. Unfortunately, it had a bug where it use passing a string to `buflisted()` and `bufexists()` for checking whether buffer can be added to menu which leads to the logic not working (as those functions behave differently on string vs number types). As a result *no* buffer is currently added to the Buffers menu. Fix this by doing a number type coersion by doing a "+ 0".

A caveat of this is that the logic to check special buffers (using `buftype`) actually also does not work, because the code triggers the BufAdd autocommand event before setting the buftype, meaning it's always '' when we handle the autocmd. I think this is acceptable for now, unless we refactor code around such that `buftype` is set before the autocommand.

Also, update tests so that:
1. Check that making a new buffer actually adds a new item to Buffers menu to prevent future regression.
2. Fix up Test_menu_expand() to behave properly again by calling delmenu.vim at beginning of test. We have to do this because even though we clearn up by calling delmenu.vim in earlier tests, that's not sufficient, as delmenu.vim doesn't actually clear the Buffers menu's autocmd (BMAdd).
3. Fix up the test to expect that command-line window and terminal windows *do* in fact create new buffer menu items, because of the 'buftype' bug that I mentioned above.
