### PR TITLE
Fix Test_term_nasty_callback to be more robust to timing issues

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -2536,16 +2536,20 @@ func Test_term_nasty_callback()
     let g:buf1 = term_start('sh', #{hidden: 1, term_finish: 'close'})
     call popup_create(g:buf1, {})
     let g:buf2 = term_start(['sh', '-c'], #{curwin: 1, exit_cb: function('TermExit')})
+    call term_wait(g:buf2)
     sleep 100m
     call popup_close(win_getid())
   endfunc
   func TermExit(...)
-    call term_sendkeys(bufnr('#'), "exit\<CR>")
+    let altbuf = bufnr('#')
+    call term_sendkeys(altbuf, "exit\<CR>")
+    call term_wait(altbuf)
     call popup_close(win_getid())
   endfunc
   call OpenTerms()
 
   call term_sendkeys(g:buf0, "exit\<CR>")
+  call term_wait(g:buf0)
   sleep 100m
   exe g:buf0 .. 'bwipe!'
   set hidden&


### PR DESCRIPTION
Use term_wait() instead of relying on sleep, which makes sure the terminal exit command is processed. Otherwise there could be timing flakes leading to occasional CI failures.