### PR TITLE
doc: Mention that getcurpos always uses bufnr=0

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5136,8 +5136,8 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 <
 							*getcurpos()*
 getcurpos()	Get the position of the cursor.  This is like getpos('.'), but
-		includes an extra item in the list:
-		    [bufnum, lnum, col, off, curswant] ~
+		includes an extra item in the list and bufnum is always 0:
+		    [0, lnum, col, off, curswant] ~
 		The "curswant" number is the preferred column when moving the
 		cursor vertically.  Also see |getpos()|.
 


### PR DESCRIPTION
For #1621.

I got bit by the first part of that bug and the fix only applied to the second part. So here's my fix for the first part.

Reading the docs for getcurpos, you'd expect that the first element in
the list is the current buffer number and you'd have to check the help
for getpos to see what's gone wrong.

I'm not really clear on *why* we use 0, so I think this is nonobvious
enough that it merits a mention here too.