### PR TITLE
doc: Add clear settagstack example for plugins

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8915,17 +8915,9 @@ settagstack({nr}, {dict} [, {action}])			*settagstack()*
 
 		Returns zero for success, -1 for failure.
 
-		Examples:
-		    Set current index of the tag stack to 4: >
-			call settagstack(1005, {'curidx' : 4})
-
-<		    Empty the tag stack of window 3: >
+		Examples (see also |tagstack-examples||):
+		    Empty the tag stack of window 3: >
 			call settagstack(3, {'items' : []})
-
-<		    Push a new item onto the tag stack: >
-			let pos = [bufnr('myfile.txt'), 10, 1, 0]
-			let newtag = [{'tagname' : 'mytag', 'from' : pos}]
-			call settagstack(2, {'items' : newtag}, 'a')
 
 <		    Save and restore the tag stack: >
 			let stack = gettagstack(1003)

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -185,6 +185,30 @@ commands explained above the tag stack will look like this:
 The |gettagstack()| function returns the tag stack of a specified window. The
 |settagstack()| function modifies the tag stack of a window.
 
+							*tagstack-examples*
+
+Write to the tag stack just like `:tag` but with a user-defined
+jumper#jump_to_tag function: >
+	" Store where we're jumping from before we jump.
+	let tag = expand('<cword>')
+	let pos = [bufnr()] + getcurpos()[1:]
+	let item = {'bufnr': pos[0], 'from': pos, 'tagname': tag}
+	if jumper#jump_to_tag(tag)
+		" Jump was successful, write previous location to tag stack.
+		let winid = win_getid()
+		let stack = gettagstack(winid)
+		let stack['items'] = [item]
+		call settagstack(winid, stack, 't')
+	endif
+<
+Set current index of the tag stack to 4: >
+	call settagstack(1005, {'curidx' : 4})
+<
+Push a new item onto the tag stack: >
+	let pos = [bufnr('myfile.txt'), 10, 1, 0]
+	let newtag = [{'tagname' : 'mytag', 'from' : pos}]
+	call settagstack(2, {'items' : newtag}, 'a')
+<
 							*E73*
 When you try to use the tag stack while it doesn't contain anything you will
 get an error message.


### PR DESCRIPTION
Add an example using 't' which is the simplest way to use settagstack to
implement 'jump to definition' behaviour -- the same behaviour as C-].

None of the examples are very clear about how a plugin author should use
settagstack because they omit handling other tagstack entries.

I've been thinking about this since #3336 was closed because it wasn't clear to me how to use the new functions. Looks like #5417 introduced a simple API. This PR adds an example using that new API.

I applied this pattern to [vim-lookup](https://github.com/idbrii/vim-lookup/commit/9cf7a6e988f94f6f2f212219a1ba97af608cf7ee) and it works correctly in my tests.

(I guess existing implementations like [vim-lsp](https://github.com/prabirshrestha/vim-lsp/blob/8c5ee44eee119e59aa1c7d8a82f082ee21096f28/autoload/lsp/utils/tagstack.vim#L2-L28), [vim-lsc](https://github.com/natebosch/vim-lsc/blob/d4d45eaad88cd1c6acd45e71d0314765d36dc5cf/autoload/lsc/reference.vim#L25-L38), [racer-rust](https://github.com/racer-rust/vim-racer/commit/6fe615ecedce06df9ec2624dd8f2ae0b3b69c4f5) all predate the 't' argument and that's why use a much more convoluted method?)