### PR TITLE
Fixed Windows wildcard tab expansion problem that was reported in #5879

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3179,7 +3179,10 @@ dos_expandpath(
 			     && p[1] != NUL && (p[1] != '.' || p[2] != NUL)))
 		&& (matchname == NULL
 		  || (regmatch.regprog != NULL
-				     && (vim_regexec(&regmatch, p, (colnr_T)0) || vim_regexec(&regmatch, current_file_short_name, (colnr_T)0)))
+		     && (
+			 vim_regexec(&regmatch, p, (colnr_T)0) 
+		     || (vim_regexec(&regmatch, current_file_short_name, (colnr_T)0))
+		     ))
 		  || ((flags & EW_NOTWILD)
 		     && fnamencmp(path + (s - buf), p, e - s) == 0)))
 	{
@@ -3198,19 +3201,15 @@ dos_expandpath(
 		--stardepth;
 	    }
 
-	    if ((wfb.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == FILE_ATTRIBUTE_DIRECTORY)
+	    STRCPY(buf + len, path_end);
+
+	    if (mch_has_exp_wildcard(path_end))
 	    {
-		STRCPY(buf + len, path_end);
-
-		if (mch_has_exp_wildcard(path_end))
-		{
-		    // need to expand another component of the path
-		    // remove backslashes for the remaining components only
-		    (void)dos_expandpath(gap, buf, len + 1, flags, FALSE);
-		}
+		// need to expand another component of the path
+		// remove backslashes for the remaining components only
+		(void)dos_expandpath(gap, buf, len + 1, flags, FALSE);
 	    }
-
-	    if (!mch_has_exp_wildcard(path_end))
+	    else
 	    {
 		// no more wildcards, check if there is a match
 		// remove backslashes for the remaining components only

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3220,8 +3220,8 @@ dos_expandpath(
 	    }
 	}
 
-	vim_free(p);
 	vim_free(current_file_short_name);
+	vim_free(p);
 	ok = FindNextFileW(hFind, &wfb);
     }
 

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3171,7 +3171,6 @@ dos_expandpath(
 	if (current_file_short_name == NULL)
 	    break;
 
-
 	// Ignore entries starting with a dot, unless when asked for.  Accept
 	// all entries found with "matchname".
 	if ((p[0] != '.' || starts_with_dot


### PR DESCRIPTION
In the dos_expandpath function I have removed code that in case the match was not found, caused the file path match loop to repeat file paths it has already went through, 

This is because it is calling FindFirstFileW again which restarts the search, but the FindFirstFile is called with one of the matches (according to the comment above the code it does so to find the long name, but there is no need since what is passed is already a long name) which causes it to pointlessly continue looping over files it already looped through.

I did a couple of tests to see that the expansion still works correctly after my change and that the speed is dramatically improved (I have tested with the example given in #5879 as well and it expands instantly), and it all looks good.