### PR TITLE
Fixed crash when doing  :echo readfile('./', 'B')

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -1466,6 +1466,12 @@ f_readfile(typval_T *argvars, typval_T *rettv)
     // Always open the file in binary mode, library functions have a mind of
     // their own about CR-LF conversion.
     fname = tv_get_string(&argvars[0]);
+
+    if (mch_isdir(fname))
+    {
+	emsg("cannot read a directory");
+	return;
+    }
     if (*fname == NUL || (fd = mch_fopen((char *)fname, READBIN)) == NULL)
     {
 	semsg(_(e_notopen), *fname == NUL ? (char_u *)_("<empty>") : fname);
@@ -1477,7 +1483,7 @@ f_readfile(typval_T *argvars, typval_T *rettv)
 	if (read_blob(fd, rettv->vval.v_blob) == FAIL)
 	{
 	    emsg("cannot read file");
-	    // Free what was read and return an empty blob in case of error.
+	    // An empty blob is returned on error.
 	    blob_free(rettv->vval.v_blob);
 	    rettv_blob_alloc(rettv);
 	}

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -1477,7 +1477,9 @@ f_readfile(typval_T *argvars, typval_T *rettv)
 	if (read_blob(fd, rettv->vval.v_blob) == FAIL)
 	{
 	    emsg("cannot read file");
+	    // Free what was read and return an empty blob in case of error.
 	    blob_free(rettv->vval.v_blob);
+	    rettv_blob_alloc(rettv);
 	}
 	fclose(fd);
 	return;

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -258,8 +258,8 @@ func Test_blob_read_write()
   call assert_equal(b, br)
   call delete('Xblob')
 
-  " This was crashing at least in Vim-8.2.519 and older.
-  call assert_fails("call readfile('./', 'B')", 'cannot read file')
+  " This was crashing when calling readfile() with a directory.
+  call assert_fails("call readfile('.', 'B')", 'cannot read a directory')
 endfunc
 
 " filter() item in blob

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -257,6 +257,9 @@ func Test_blob_read_write()
   let br = readfile('Xblob', 'B')
   call assert_equal(b, br)
   call delete('Xblob')
+
+  " This was crashing at least in Vim-8.2.519 and older.
+  call assert_fails("call readfile('./', 'B')", 'cannot read file')
 endfunc
 
 " filter() item in blob


### PR DESCRIPTION
This PR fixes a crash reproducible in vim-8.2.519 and
older when doing:
```
$ vim --clean -c 'echo readfile("./", "B")' -cq
Vim: Caught deadly signal SEGV
Segmentation fault (core dumped)
```
Valgrind gives:
```
==12880== Memcheck, a memory error detector
==12880== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12880== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==12880== Command: ./vim --clean -c echo\ readfile("./",\ "B") -cq
==12880== 
==12880== Invalid read of size 4
==12880==    at 0x15045D: blob2string (blob.c:215)
==12880==    by 0x1810DB: echo_string_core (eval.c:4525)
==12880==    by 0x18271F: echo_string (eval.c:4629)
==12880==    by 0x18271F: echo_one (eval.c:5998)
==12880==    by 0x187315: ex_echo (eval.c:6087)
==12880==    by 0x1B25E4: do_one_cmd (ex_docmd.c:2509)
==12880==    by 0x1B25E4: do_cmdline (ex_docmd.c:978)
==12880==    by 0x339D7F: exe_commands (main.c:3133)
==12880==    by 0x339D7F: vim_main2 (main.c:789)
==12880==    by 0x13AB8C: main (main.c:438)
==12880==  Address 0xa6bb6f0 is 0 bytes inside a block of size 32 free'd
==12880==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12880==    by 0x1C7905: f_readfile (filepath.c:1480)
==12880==    by 0x191D7C: call_internal_func (evalfunc.c:1170)
==12880==    by 0x2F04FD: call_func (userfunc.c:1898)
==12880==    by 0x2F0792: get_func_tv (userfunc.c:564)
==12880==    by 0x17FE20: eval_func (eval.c:1724)
==12880==    by 0x186A56: eval7 (eval.c:2679)
==12880==    by 0x186AC3: eval6 (eval.c:2372)
==12880==    by 0x186DA3: eval5 (eval.c:2187)
==12880==    by 0x183503: eval4 (eval.c:2036)
==12880==    by 0x183503: eval3 (eval.c:1957)
==12880==    by 0x1836A3: eval2 (eval.c:1889)
==12880==    by 0x1836A3: eval1 (eval.c:1817)
==12880==    by 0x1872E5: ex_echo (eval.c:6071)
==12880==    by 0x1B25E4: do_one_cmd (ex_docmd.c:2509)
==12880==    by 0x1B25E4: do_cmdline (ex_docmd.c:978)
==12880==    by 0x339D7F: exe_commands (main.c:3133)
==12880==    by 0x339D7F: vim_main2 (main.c:789)
==12880==    by 0x13AB8C: main (main.c:438)
==12880==  Block was alloc'd at
==12880==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12880==    by 0x212FE0: lalloc (misc2.c:925)
==12880==    by 0x21394D: alloc_clear (misc2.c:852)
==12880==    by 0x1500DD: blob_alloc (blob.c:25)
==12880==    by 0x150118: rettv_blob_alloc (blob.c:39)
==12880==    by 0x1C731B: f_readfile (filepath.c:1457)
==12880==    by 0x191D7C: call_internal_func (evalfunc.c:1170)
==12880==    by 0x2F04FD: call_func (userfunc.c:1898)
==12880==    by 0x2F0792: get_func_tv (userfunc.c:564)
==12880==    by 0x17FE20: eval_func (eval.c:1724)
==12880==    by 0x186A56: eval7 (eval.c:2679)
==12880==    by 0x186AC3: eval6 (eval.c:2372)
==12880==    by 0x186DA3: eval5 (eval.c:2187)
==12880==    by 0x183503: eval4 (eval.c:2036)
==12880==    by 0x183503: eval3 (eval.c:1957)
==12880==    by 0x1836A3: eval2 (eval.c:1889)
==12880==    by 0x1836A3: eval1 (eval.c:1817)
==12880==    by 0x1872E5: ex_echo (eval.c:6071)
==12880==    by 0x1B25E4: do_one_cmd (ex_docmd.c:2509)
==12880==    by 0x1B25E4: do_cmdline (ex_docmd.c:978)
==12880==    by 0x339D7F: exe_commands (main.c:3133)
==12880==    by 0x339D7F: vim_main2 (main.c:789)
==12880==    by 0x13AB8C: main (main.c:438)
snip more errors after that....
```