### PR TITLE
Fixed gcc-9 compilation warning

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4561,7 +4561,8 @@ f_has(typval_T *argvars, typval_T *rettv)
     if (x == TRUE && n == FALSE)
     {
 	if (0)
-	    ;
+	{
+	}
 #if defined(FEAT_BEVAL) && defined(FEAT_GUI_MSWIN)
 	else if (STRICMP(name, "balloon_multiline") == 0)
 	    n = multiline_balloon_available();


### PR DESCRIPTION
This PR fixes a gcc-9 compilation warning:
```
gcc-9 -c -I. -Iproto -DHAVE_CONFIG_H -g -O2 -Wall -Wextra -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -o objects/evalwindow.o evalwindow.c
evalfunc.c: In function ‘f_has’:
evalfunc.c:4564:6: warning: suggest braces around empty body in an ‘if’ statement [-Wempty-body]
 4564 |      ;
      |      ^
```