### PR TITLE
Add modeline to ccomplete.vim

### DIFF
--- a/runtime/autoload/ccomplete.vim
+++ b/runtime/autoload/ccomplete.vim
@@ -635,3 +635,5 @@ endfunc
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
+
+" vim: noet sw=2 ts=8


### PR DESCRIPTION
Problems: Not indented properly when tabstop != 8. Style not matched
while editing if shiftwidth != 2.
Solution: Set modeline to match style.