### PR TITLE
Update docs of i_CTRL-R_CTRL-R

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -154,6 +154,8 @@ CTRL-R CTRL-R {register}			*i_CTRL-R_CTRL-R*
 		you also want to avoid these, use CTRL-R CTRL-O, see below.
 		The '.' register (last inserted text) is still inserted as
 		typed.
+		After this command, the '.' register contains the text from
+		the register as if it was inserted by typing it.
 
 CTRL-R CTRL-O {register}			*i_CTRL-R_CTRL-O*
 		Insert the contents of a register literally and don't
@@ -163,6 +165,9 @@ CTRL-R CTRL-O {register}			*i_CTRL-R_CTRL-O*
 		Does not replace characters!
 		The '.' register (last inserted text) is still inserted as
 		typed.
+		After this command, the '.' register contains the command
+		typed and not the text. I.e., the literals "^R^O" and not the
+		text from the register.
 
 CTRL-R CTRL-P {register}			*i_CTRL-R_CTRL-P*
 		Insert the contents of a register literally and fix the
@@ -170,6 +175,9 @@ CTRL-R CTRL-P {register}			*i_CTRL-R_CTRL-P*
 		Does not replace characters!
 		The '.' register (last inserted text) is still inserted as
 		typed.
+		After this command, the '.' register contains the command
+		typed and not the text. I.e., the literals "^R^P" and not the
+		text from the register.
 
 						*i_CTRL-T*
 CTRL-T		Insert one shiftwidth of indent at the start of the current


### PR DESCRIPTION
The documentation of i_CTRL-R_CTRL-R, i_CTRL-R_CTRL-P and
i_CTRL-R_CTRL-O didn't include an explanation about what stays in the '.'
register after them, and worked differently.

The command of i_CTRL-R_CTRL-R works the same as the command i_CTRL-R in
respect to this register, but the commands of i_CTRL-R_CTRL-P and
i_CTRL-R_CTRL-O inserts the commands to the '.' register, and not the
text produced as a result of this command.

This commit adds this documentation to the documentation in the help of
these commands.

Fixes #5771 