### PR TITLE
Fix documentation of v_r command

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -209,7 +209,7 @@ gR			Enter Virtual Replace mode: Each character you type
 			start insert (for {Visual} see |Visual-mode|).
 
 							*v_r*
-{Visual}["x]r{char}	Replace all selected characters by {char}.
+{Visual}r{char}	Replace all selected characters by {char}.
 
 							*v_C*
 {Visual}["x]C		Delete the highlighted lines [into register x] and


### PR DESCRIPTION
In the documentation of the v_r command, it says that the command can
get a register. However, the command does nothing with this
register. From the current documentation, it seems that the command
would insert the text into the given register (like the command of v_s
or v_c does), but in practice, the command does nothing with this
register.

Fixes #3247.