### PR TITLE
E386 was not covered with tests

### DIFF
--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -17,9 +17,9 @@ func Test_search_cmdline()
   set noincsearch
   :1
   call feedkeys("/foobar\<cr>", 'tx')
-  call feedkeys("/the\<cr>",'tx')
+  call feedkeys("/the\<cr>", 'tx')
   call assert_equal('the', @/)
-  call feedkeys("/thes\<C-P>\<C-P>\<cr>",'tx')
+  call feedkeys("/thes\<C-P>\<C-P>\<cr>", 'tx')
   call assert_equal('foobar', @/)
 
   " Test 2
@@ -1351,7 +1351,7 @@ func Test_large_hex_chars2()
 endfunc
 
 func Test_one_error_msg()
-  " This  was also giving an internal error
+  " This was also giving an internal error
   call assert_fails('call search(" \\((\\v[[=P=]]){185}+             ")', 'E871:')
 endfunc
 
@@ -1402,6 +1402,11 @@ func Test_search_errors()
   call assert_fails("call search('pat', 'b', 1, [])", 'E745:')
   call assert_fails("call search('pat', 'ns')", 'E475:')
   call assert_fails("call search('pat', 'mr')", 'E475:')
+
+  new
+  call setline(1, ['foo', 'bar'])
+  call assert_fails('call feedkeys("/foo/;/bar/;\<CR>", "tx")', 'E386:')
+  bwipe!
 endfunc
 
 func Test_search_display_pattern()


### PR DESCRIPTION
E386 was not covered with tests according to codecov:

https://codecov.io/gh/vim/vim/src/004a6781b3cf15ca5dd632c38cc09bb3b253d1f8/src/search.c#L1611

