### PR TITLE
Fixed memory leak discovered when adding test in patch 8.2.0542

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1416,6 +1416,7 @@ do_search(
 		// Reserve enough space for the search pattern + offset.
 		len = STRLEN(p) + off_len + 3;
 
+	    vim_free(msgbuf);
 	    msgbuf = alloc(len);
 	    if (msgbuf != NULL)
 	    {


### PR DESCRIPTION
Fixed memory leak discovered with asan 
after adding test in patch 8.2.0542.
```
==3306==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x4975fd in malloc (/home/pel/sb/vim/src/vim+0x4975fd)
    #1 0x8a129d in lalloc /home/pel/sb/vim/src/misc2.c:925:11
    #2 0x8a11e9 in alloc /home/pel/sb/vim/src/misc2.c:828:12
    #3 0xaea9fc in do_search /home/pel/sb/vim/src/search.c:1419:15
    #4 0x922f99 in normal_search /home/pel/sb/vim/src/normal.c:4312:9
    #5 0x906b77 in nv_search /home/pel/sb/vim/src/normal.c:4263:11
    #6 0x8edc71 in normal_cmd /home/pel/sb/vim/src/normal.c:1071:5
    #7 0x6f855b in exec_normal /home/pel/sb/vim/src/ex_docmd.c:7797:6
    #8 0x6522c2 in f_feedkeys /home/pel/sb/vim/src/evalfunc.c:2583:3
    #9 0x645131 in call_internal_func /home/pel/sb/vim/src/evalfunc.c:1170:5
    #10 0xca4cfa in call_func /home/pel/sb/vim/src/userfunc.c:1898:14
    #11 0xca386f in get_func_tv /home/pel/sb/vim/src/userfunc.c:564:8
    #12 0xcbe050 in ex_call /home/pel/sb/vim/src/userfunc.c:3582:6
    #13 0x6dbae2 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2509:2
    #14 0x6cd6e6 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:978:17
    #15 0x6d13a3 in do_cmdline_cmd /home/pel/sb/vim/src/ex_docmd.c:589:12
    #16 0xc62149 in f_assert_fails /home/pel/sb/vim/src/testing.c:436:5
    #17 0x645131 in call_internal_func /home/pel/sb/vim/src/evalfunc.c:1170:5
    #18 0xca4cfa in call_func /home/pel/sb/vim/src/userfunc.c:1898:14
    #19 0xca386f in get_func_tv /home/pel/sb/vim/src/userfunc.c:564:8
    #20 0xcbe050 in ex_call /home/pel/sb/vim/src/userfunc.c:3582:6
    #21 0x6dbae2 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2509:2
    #22 0x6cd6e6 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:978:17
    #23 0xca90a6 in call_user_func /home/pel/sb/vim/src/userfunc.c:1332:2
    #24 0xca6122 in call_user_func_check /home/pel/sb/vim/src/userfunc.c:1473:2
    #25 0xca4b69 in call_func /home/pel/sb/vim/src/userfunc.c:1880:11
    #26 0xca386f in get_func_tv /home/pel/sb/vim/src/userfunc.c:564:8
    #27 0xcbe050 in ex_call /home/pel/sb/vim/src/userfunc.c:3582:6
    #28 0x6dbae2 in do_one_cmd /home/pel/sb/vim/src/ex_docmd.c:2509:2
    #29 0x6cd6e6 in do_cmdline /home/pel/sb/vim/src/ex_docmd.c:978:17
```