### PR TITLE
Fixed compilation warning in vim tiny

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -647,9 +647,10 @@ do_cmdline(
 # define cmd_cookie cookie
 #endif
     static int	call_depth = 0;		// recursiveness
-    ESTACK_CHECK_DECLARATION
 
 #ifdef FEAT_EVAL
+    ESTACK_CHECK_DECLARATION
+
     // For every pair of do_cmdline()/do_one_cmd() calls, use an extra memory
     // location for storing error messages to be converted to an exception.
     // This ensures that the do_errthrow() call in do_one_cmd() does not
@@ -1295,7 +1296,7 @@ do_cmdline(
 	/*
 	 * On an interrupt or an aborting error not converted to an exception,
 	 * disable the conversion of errors to exceptions.  (Interrupts are not
-	 * converted any more, here.) This enables also the interrupt message
+	 * converted anymore, here.) This enables also the interrupt message
 	 * when force_abort is set and did_emsg unset in case of an interrupt
 	 * from a finally clause after an error.
 	 */


### PR DESCRIPTION
This PR fixes the following compilation warning in vim tiny.
A local variable is only used when `FEAT_EVAL` is defined:

```
gcc -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_GTK  -pthread -I/usr/include/gtk-2.0 -I/usr/lib/x86_64-linux-gnu/gtk-2.0/include -I/usr/include/gio-unix-2.0/ -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng16 -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/libpng16   -g -O2 -Wall -Wextra -Wshadow -Wunused-result -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1  -g -O0 -fsanitize=address -fno-omit-frame-pointer -DEXITFREE -DABORT_ON_INTERNAL_ERROR    -o objects/ex_docmd.o ex_docmd.c
In file included from vim.h:427:0,
                 from ex_docmd.c:14:
ex_docmd.c: In function ‘do_cmdline’:
macros.h:363:39: warning: unused variable ‘estack_len_before’ [-Wunused-variable]
 # define ESTACK_CHECK_DECLARATION int estack_len_before;
                                       ^
ex_docmd.c:650:5: note: in expansion of macro ‘ESTACK_CHECK_DECLARATION’
     ESTACK_CHECK_DECLARATION
     ^~~~~~~~~~~~~~~~~~~~~~~~
```
