### PR TITLE
Fixed memory leak when running :version multiple times

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -285,6 +285,7 @@ NEW_TESTS = \
 	test_utf8 \
 	test_utf8_comparisons \
 	test_vartabs \
+	test_version \
 	$(TEST_VIM9) \
 	test_viminfo \
 	test_vimscript \

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -32,4 +32,5 @@ source test_tabline.vim
 source test_tagcase.vim
 source test_tagfunc.vim
 source test_unlet.vim
+source test_version.vim
 source test_wnext.vim

--- a/src/testdir/test_version.vim
+++ b/src/testdir/test_version.vim
@@ -7,24 +7,4 @@ func Test_version()
   call assert_equal(v1, v2)
 
   call assert_match("^\n\nVIM - Vi IMproved .*", v1)
-
-  " Extract the list of features (e.g.  ['+acl', '-arabic', ...])
-  let features_str = substitute(v1, ".*Features included (+) or not (-):\n", '', '')
-  let features_str = substitute(features_str, "\n   system vimrc file:.*", '', '')
-  let features = split(features_str)
-  call assert_notequal([], features)
-
-  " Check that if a feature in :version shows +xxx then has('xxx') is 1
-  " and if it shows -xxx then has('xxx) is 0.
-  "
-  " Notes:
-  " - the fork feature is displayed in :version as "+fork()" with parentheses
-  " - the builtin_terms feature may be displayed as "++builtin_terms" (2 pluses)
-  for feature_str in features
-    let has_feature = (feature_str[0] == '+')
-    let feature = substitute(substitute(
-          \ feature_str, '^[+-]\+', '', ''), '()$', '', '')
-
-    call assert_equal(has_feature, has(feature), feature)
-  endfor
 endfunc

--- a/src/testdir/test_version.vim
+++ b/src/testdir/test_version.vim
@@ -1,0 +1,30 @@
+" Test :version Ex command
+
+func Test_version()
+  " version should always return the same string.
+  let v1 = execute('version')
+  let v2 = execute('version')
+  call assert_equal(v1, v2)
+
+  call assert_match("^\n\nVIM - Vi IMproved .*", v1)
+
+  " Extract the list of features (e.g.  ['+acl', '-arabic', ...])
+  let features_str = substitute(v1, ".*Features included (+) or not (-):\n", '', '')
+  let features_str = substitute(features_str, "\n   system vimrc file:.*", '', '')
+  let features = split(features_str)
+  call assert_notequal([], features)
+
+  " Check that if a feature in :version shows +xxx then has('xxx') is 1
+  " and if it shows -xxx then has('xxx) is 0.
+  "
+  " Notes:
+  " - the fork feature is displayed in :version as "+fork()" with parentheses
+  " - the builtin_terms feature may be displayed as "++builtin_terms" (2 pluses)
+  for feature_str in features
+    let has_feature = (feature_str[0] == '+')
+    let feature = substitute(substitute(
+          \ feature_str, '^[+-]\+', '', ''), '()$', '', '')
+
+    call assert_equal(has_feature, has(feature), feature)
+  endfor
+endfunc

--- a/src/version.c
+++ b/src/version.c
@@ -61,7 +61,8 @@ init_longVersion(void)
 		+ strlen(VIM_VERSION_DATE_ONLY)
 		+ strlen(date_time);
 
-    longVersion = alloc(len);
+    if (longVersion == NULL)
+	longVersion = alloc(len);
     if (longVersion == NULL)
 	longVersion = VIM_VERSION_LONG;
     else

--- a/src/version.c
+++ b/src/version.c
@@ -54,20 +54,22 @@ init_longVersion(void)
     void
 init_longVersion(void)
 {
-    char *date_time = __DATE__ " " __TIME__;
-    char *msg = _("%s (%s, compiled %s)");
-    size_t len = strlen(msg)
-		+ strlen(VIM_VERSION_LONG_ONLY)
-		+ strlen(VIM_VERSION_DATE_ONLY)
-		+ strlen(date_time);
+    if (longVersion == NULL)
+    {
+	char *date_time = __DATE__ " " __TIME__;
+	char *msg = _("%s (%s, compiled %s)");
+	size_t len = strlen(msg)
+		    + strlen(VIM_VERSION_LONG_ONLY)
+		    + strlen(VIM_VERSION_DATE_ONLY)
+		    + strlen(date_time);
 
-    if (longVersion == NULL)
 	longVersion = alloc(len);
-    if (longVersion == NULL)
-	longVersion = VIM_VERSION_LONG;
-    else
-	vim_snprintf(longVersion, len, msg,
-		      VIM_VERSION_LONG_ONLY, VIM_VERSION_DATE_ONLY, date_time);
+	if (longVersion == NULL)
+	    longVersion = VIM_VERSION_LONG;
+	else
+	    vim_snprintf(longVersion, len, msg,
+			  VIM_VERSION_LONG_ONLY, VIM_VERSION_DATE_ONLY, date_time);
+    }
 }
 # endif
 #else


### PR DESCRIPTION
This PR fixes a memory leak which happens when the `:version`
Ex command is invoked multiple times. 

Example:

```
$ valgrind --leak-check=full ./vim --clean -cver -cver -cq
==10345== Memcheck, a memory error detector
==10345== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10345== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==10345== Command: ./vim --clean -cver -cver -cq
==10345== 
==10345== 
==10345== HEAP SUMMARY:
==10345==     in use at exit: 132,817 bytes in 1,214 blocks
==10345==   total heap usage: 34,139 allocs, 32,925 frees, 16,374,903 bytes allocated
==10345== 
==10345== 72 bytes in 1 blocks are definitely lost in loss record 88 of 136
==10345==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==10345==    by 0x213830: lalloc (misc2.c:925)
==10345==    by 0x2F64CF: init_longVersion (version.c:64)
==10345==    by 0x2F67E2: list_version (version.c:2060)
==10345==    by 0x1B2C44: do_one_cmd (ex_docmd.c:2509)
==10345==    by 0x1B2C44: do_cmdline (ex_docmd.c:978)
==10345==    by 0x33BC17: exe_commands (main.c:3133)
==10345==    by 0x33BC17: vim_main2 (main.c:789)
==10345==    by 0x13ACFC: main (main.c:438)
```