### PR TITLE
Fix: Missing "ipv6" in `:version`

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10869,6 +10869,7 @@ hpux			HP-UX version of Vim.
 iconv			Can use iconv() for conversion.
 insert_expand		Compiled with support for CTRL-X expansion commands in
 			Insert mode. (always true)
+ipv6			Compiled with support for IPv6 networking in |channel|.
 job			Compiled with support for |channel| and |job|
 jumplist		Compiled with |jumplist| support.
 keymap			Compiled with 'keymap' support.

--- a/src/version.c
+++ b/src/version.c
@@ -293,6 +293,11 @@ static char *(features[]) =
 	"-iconv",
 #endif
 	"+insert_expand",
+#ifdef FEAT_IPV6
+	"+ipv6",
+#else
+	"-ipv6",
+#endif
 #ifdef FEAT_JOB_CHANNEL
 	"+job",
 #else


### PR DESCRIPTION
Sorry, I added "ipv6" to feature-list in document but forgot to add it to the output of ":version".