### PR TITLE
Test digraph output with a bang  :digraph!

### DIFF
--- a/src/testdir/test_digraph.vim
+++ b/src/testdir/test_digraph.vim
@@ -434,6 +434,17 @@ func Test_digraphs_output()
   call assert_equal('Z% Ж  1046',  matchstr(out, '\C\<Z%\D*1046\>'))
   call assert_equal('u- ū  363',   matchstr(out, '\C\<u-\D*363\>'))
   call assert_equal('SH ^A   1',   matchstr(out, '\C\<SH\D*1\>'))
+
+  let out_bang_without_custom = execute(':digraph!')
+  digraph lt 60
+  let out_bang_with_custom = execute(':digraph!')
+  call assert_notmatch('lt', out_bang_without_custom)
+  call assert_match("^\n"
+        \        .. "NU ^@  10 .*\n"
+        \        .. "Latin supplement\n"
+        \        .. "!I ¡  161 .*\n"
+        \        .. ".*\n"
+        \        .. 'Custom\n.*\<lt <   60\>', out_bang_with_custom)
   bw!
 endfunc
 


### PR DESCRIPTION
The `:digraph!` command with a bang was not tested according to codecov:

https://codecov.io/gh/vim/vim/src/569cb9d0e4d1df16f30c004b7f881f347e75a0e2/src/digraph.c#L2236