### PR TITLE
Fix double free due to unexpected nesting list arg for job_start()

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -4356,7 +4356,10 @@ build_argv_from_list(list_T *l, char ***argv, int *argc)
 	    int i;
 
 	    for (i = 0; i < *argc; ++i)
+	    {
 		vim_free((*argv)[i]);
+		(*argv)[i] = NULL;
+	    }
 	    return FAIL;
 	}
 	(*argv)[*argc] = (char *)vim_strsave(s);

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1681,6 +1681,7 @@ func Test_job_start_fails()
   call assert_fails('let job = job_start(["   "])', 'E474:')
   call assert_fails('let job = job_start("")', 'E474:')
   call assert_fails('let job = job_start("   ")', 'E474:')
+  call assert_fails('let job = job_start(["ls", []])', 'E730:')
   %bw!
 endfunc
 


### PR DESCRIPTION
```
Problem:    job_start() doesn't know if each argv element has already
            been freed.
Solution:   Set NULL to each argv element.
```

**Describe the bug**
Vim is halted by SIGSEGV.

**To Reproduce**
1. Run `vim -Nu NONE`
2. Type `:call job_start(['grep', '-nE', ['foo', 'bar'], '.vimrc'])`
3. Type `:new` or some another operation
4. SIGSEGV is caused

**Expected behavior**
No SIGSEGV

**Screenshots**
![vim_SIGSEGV](https://user-images.githubusercontent.com/20806102/79129944-11ebc880-7de1-11ea-8733-e95b54c09e28.gif)

**Environment (please complete the following information):**
 - Vim version: v8.2.0566
 - OS: Ubuntu 18.04
 - Terminal: mintty