### PR TITLE
Use filereadable instead of obsolete name file_readable

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -898,7 +898,7 @@ makeopens(
 
     // Lastly, execute the x.vim file if it exists.
     if (put_line(fd, "let s:sx = expand(\"<sfile>:p:r\").\"x.vim\"") == FAIL
-	    || put_line(fd, "if file_readable(s:sx)") == FAIL
+	    || put_line(fd, "if filereadable(s:sx)") == FAIL
 	    || put_line(fd, "  exe \"source \" . fnameescape(s:sx)") == FAIL
 	    || put_line(fd, "endif") == FAIL)
 	return FAIL;


### PR DESCRIPTION
The function `file_readable` is obsoleted in favor of `filereadable` back in 5.2. But `:mksession` still emits a code using the legacy name. I fixed the code to use the new name.