### PR TITLE
Fixed yaml indent after tag

### DIFF
--- a/runtime/indent/testdir/yaml.in
+++ b/runtime/indent/testdir/yaml.in
@@ -12,3 +12,8 @@ map2:
 map: &anchor
 map: val
 # END_INDENT
+
+# START_INDENT
+map: multiline
+value
+# END_INDENT

--- a/runtime/indent/testdir/yaml.ok
+++ b/runtime/indent/testdir/yaml.ok
@@ -12,3 +12,8 @@ map2:
 map: &anchor
 map: val
 # END_INDENT
+
+# START_INDENT
+map: multiline
+  value
+# END_INDENT

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -53,7 +53,7 @@ let s:c_ns_anchor_name = s:c_ns_anchor_char.'+'
 let s:c_ns_anchor_property =  '\v\&'.s:c_ns_anchor_name
 
 let s:ns_word_char = '\v[[:alnum:]_\-]'
-let s:ns_tag_char  = '\v%(%\x\x|'.s:ns_word_char.'|[#/;?:@&=+$.~*''()])'
+let s:ns_tag_char  = '\v%('.s:ns_word_char.'|[#/;?:@&=+$.~*''()])'
 let s:c_named_tag_handle     = '\v\!'.s:ns_word_char.'+\!'
 let s:c_secondary_tag_handle = '\v\!\!'
 let s:c_primary_tag_handle   = '\v\!'
@@ -62,7 +62,7 @@ let s:c_tag_handle = '\v%('.s:c_named_tag_handle.
             \            '|'.s:c_primary_tag_handle.')'
 let s:c_ns_shorthand_tag = '\v'.s:c_tag_handle . s:ns_tag_char.'+'
 let s:c_non_specific_tag = '\v\!'
-let s:ns_uri_char  = '\v%(%\x\x|'.s:ns_word_char.'\v|[#/;?:@&=+$,.!~*''()[\]])'
+let s:ns_uri_char  = '\v%('.s:ns_word_char.'\v|[#/;?:@&=+$,.!~*''()[\]])'
 let s:c_verbatim_tag = '\v\!\<'.s:ns_uri_char.'+\>'
 let s:c_ns_tag_property = '\v'.s:c_verbatim_tag.
             \               '\v|'.s:c_ns_shorthand_tag.


### PR DESCRIPTION
This fixes yaml indent after a tag

`%\x\x` is not valid regex and throws `E678: Invalid character after %[dxouU]`

I am not sure what the original intent with this code was