### PR TITLE
doc: clarify event dictionary key dependence on the event

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1828,7 +1828,7 @@ v:event		Dictionary containing information about the current
 					operation.
 			regtype		Type of register as returned by
 					|getregtype()|.
-			completed_item    Current selected complete item on
+			completed_item  Current selected complete item on
 					|CompleteChanged|, Is `{}` when no complete
 					item selected.
 			height 		Height of popup menu on |CompleteChanged|

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1811,7 +1811,36 @@ v:event		Dictionary containing information about the current
 		this dictionary.
 		The dictionary is emptied when the |autocommand|
 		finishes, please refer to |dict-identity| for how to get an
-		independent copy of it.
+		independent copy of it. Example using |deepcopy|: >
+			au TextYankPost * let g:foo = deepcopy(v:event)
+<		Keys vary by event; see the documentation for the specific
+		event, e.g. |CompleteChanged| or |TextYankPost|.
+			KEY		DESCRIPTION ~
+			operator	Current |operator|.  Also set for Ex
+					commands (unlike |v:operator|). For
+					example if |TextYankPost| is triggered
+					by the |:yank| Ex command then
+					`v:event.operator` is "y".
+			regcontents	Text stored in the register as a
+					|readfile()|-style list of lines.
+			regname		Requested register (e.g "x" for "xyy)
+					or the empty string for an unnamed
+					operation.
+			regtype		Type of register as returned by
+					|getregtype()|.
+			completed_item    Current selected complete item on
+					|CompleteChanged|, Is `{}` when no complete
+					item selected.
+			height 		Height of popup menu on |CompleteChanged|
+			width   	width of popup menu on |CompleteChanged|
+			row  	 	Row count of popup menu on |CompleteChanged|,
+					relative to screen.
+			col  	 	Col count of popup menu on |CompleteChanged|,
+					relative to screen.
+			size 		Total number of completion items on
+					|CompleteChanged|.
+			scrollbar 	Is |v:true| if popup menu have scrollbar, or
+					|v:false| if not.
 
 					*v:exception* *exception-variable*
 v:exception	The value of the exception most recently caught and not


### PR DESCRIPTION
Addresses #5535 . Add clarification in the documentation that the `v:event` dictionary depends on the event and is often empty. Also added a current list of possible Keys that was inspired by the neovim documentation, but is updated to be valid for vim.