### PR TITLE
Use SGR like mouse reporting for Putty terminals

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -4769,7 +4769,7 @@ not_enough:
 			}
 
 			// Detect terminals that set $TERM to something like
-			// "xterm-256colors"  but are not fully xterm
+			// "xterm-256color"  but are not fully xterm
 			// compatible.
 
 			// Gnome terminal sends 1;3801;0, 1;4402;0 or 1;2501;0.
@@ -4783,7 +4783,13 @@ not_enough:
 			// PuTTY sends 0;136;0
 			// vandyke SecureCRT sends 1;136;0
 			else if (version == 136 && arg[2] == 0)
+			{
 			    is_not_xterm = TRUE;
+			    if (arg[0] == 0)
+				// PuTTY supports sgr like mouse reporting
+				set_option_value((char_u *)"ttym", 0L,
+							(char_u *)"sgr", 0);
+			}
 
 			// Konsole sends 0;115;0
 			else if (version == 115 && arg[0] == 0 && arg[2] == 0)


### PR DESCRIPTION
This is at least supported since Putty 0.65, released 2015-07-25,  (probably older ones as well, but I couldn't make older versions successfully connect to my test server because of cryptographic problems).

So this should be reasonable safe since for security reasons one should keep ssh clients up to date anyhow. Additionally, PuTTY 0.71 includes true color support, which is probably a reason users will install a newer and current version anyhow :)

While at it, also fix a typo