### PR TITLE
Fix: Enable IPv6 channel on Windows

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -624,7 +624,7 @@ NBDEBUG_SRC = nbdebug.c
 endif
 
 ifeq ($(CHANNEL),yes)
-DEFINES += -DFEAT_JOB_CHANNEL
+DEFINES += -DFEAT_JOB_CHANNEL -DFEAT_IPV6
 endif
 
 ifeq ($(TERMINAL),yes)

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -467,7 +467,7 @@ SOUND_LIB	= winmm.lib
 !if "$(CHANNEL)" == "yes"
 CHANNEL_PRO	= proto/channel.pro
 CHANNEL_OBJ	= $(OBJDIR)/channel.obj
-CHANNEL_DEFS	= -DFEAT_JOB_CHANNEL
+CHANNEL_DEFS	= -DFEAT_JOB_CHANNEL -DFEAT_IPV6
 
 NETBEANS_LIB	= WSock32.lib Ws2_32.lib
 !endif


### PR DESCRIPTION
We can add `-DFEAT_IPV6` always since Windows XP and later have `getaddrinfo()` certainly.