### PR TITLE
Vim9: Support namespace b:/w:/t: in :def function

### DIFF
--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -8,6 +8,9 @@ endfunc
 
 let s:scriptvar = 4
 let g:globalvar = 'g'
+let b:buffervar = 'b'
+let w:windowvar = 'w'
+let t:tabpagevar = 't'
 
 def s:ScriptFuncLoad(arg: string)
   let local = 1
@@ -17,6 +20,9 @@ def s:ScriptFuncLoad(arg: string)
   echo v:version
   echo s:scriptvar
   echo g:globalvar
+  echo b:buffervar
+  echo w:windowvar
+  echo t:tabpagevar
   echo &tabstop
   echo $ENVVAR
   echo @z
@@ -39,6 +45,9 @@ def Test_disassemble_load()
         ' LOADV v:version.*' ..
         ' LOADS s:scriptvar from .*test_vim9_disassemble.vim.*' ..
         ' LOADG g:globalvar.*' ..
+        ' LOADB b:buffervar.*' ..
+        ' LOADW w:windowvar.*' ..
+        ' LOADT t:tabpagevar.*' ..
         ' LOADENV $ENVVAR.*' ..
         ' LOADREG @z.*',
         res)
@@ -79,6 +88,9 @@ def s:ScriptFuncStore()
   v:char = 'abc'
   s:scriptvar = 'sv'
   g:globalvar = 'gv'
+  b:buffervar = 'bv'
+  w:windowvar = 'wv'
+  t:tabpagevar = 'tv'
   &tabstop = 8
   $ENVVAR = 'ev'
   @z = 'rv'
@@ -99,6 +111,12 @@ def Test_disassemble_store()
         ' STORES s:scriptvar in .*test_vim9_disassemble.vim.*' ..
         'g:globalvar = ''gv''.*' ..
         ' STOREG g:globalvar.*' ..
+        'b:buffervar = ''bv''.*' ..
+        ' STOREB b:buffervar.*' ..
+        'w:windowvar = ''wv''.*' ..
+        ' STOREW w:windowvar.*' ..
+        't:tabpagevar = ''tv''.*' ..
+        ' STORET t:tabpagevar.*' ..
         '&tabstop = 8.*' ..
         ' STOREOPT &tabstop.*' ..
         '$ENVVAR = ''ev''.*' ..

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -931,11 +931,6 @@ func Test_expr7_fails()
   call CheckDefFailure("echo l:somevar", 'E1075:')
   call CheckDefFailure("echo x:somevar", 'E1075:')
 
-  " TODO
-  call CheckDefFailure("echo b:somevar", 'not supported yet')
-  call CheckDefFailure("echo w:somevar", 'not supported yet')
-  call CheckDefFailure("echo t:somevar", 'not supported yet')
-
   call CheckDefExecFailure("let x = +g:astring", 'E1030:')
   call CheckDefExecFailure("let x = +g:ablob", 'E974:')
   call CheckDefExecFailure("let x = +g:alist", 'E745:')

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -135,6 +135,38 @@ def Test_assignment()
   call CheckDefFailure(['v:errmsg += 123'], 'E1013:')
 enddef
 
+def Test_assignment_local()
+  " Test in a separated file in order not to the current buffer/window/tab is
+  " changed.
+  let script_lines: list<string> =<< trim END
+    let b:existing = 'yes'
+    let w:existing = 'yes'
+    let t:existing = 'yes'
+
+    def Test_assignment_local_internal()
+      b:newvar = 'new'
+      assert_equal('new', b:newvar)
+      assert_equal('yes', b:existing)
+      b:existing = 'no'
+      assert_equal('no', b:existing)
+
+      w:newvar = 'new'
+      assert_equal('new', w:newvar)
+      assert_equal('yes', w:existing)
+      w:existing = 'no'
+      assert_equal('no', w:existing)
+
+      t:newvar = 'new'
+      assert_equal('new', t:newvar)
+      assert_equal('yes', t:existing)
+      t:existing = 'no'
+      assert_equal('no', t:existing)
+    enddef
+    call Test_assignment_local_internal()
+  END
+  call CheckScriptSuccess(script_lines)
+enddef
+
 def Test_assignment_default()
 
   # Test default values.

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -20,6 +20,9 @@ typedef enum {
     ISN_LOAD,	    // push local variable isn_arg.number
     ISN_LOADV,	    // push v: variable isn_arg.number
     ISN_LOADG,	    // push g: variable isn_arg.string
+    ISN_LOADB,	    // push b: variable isn_arg.string
+    ISN_LOADW,	    // push w: variable isn_arg.string
+    ISN_LOADT,	    // push t: variable isn_arg.string
     ISN_LOADS,	    // push s: variable isn_arg.loadstore
     ISN_LOADSCRIPT, // push script-local variable isn_arg.script.
     ISN_LOADOPT,    // push option isn_arg.string
@@ -29,6 +32,9 @@ typedef enum {
     ISN_STORE,	    // pop into local variable isn_arg.number
     ISN_STOREV,	    // pop into v: variable isn_arg.number
     ISN_STOREG,	    // pop into global variable isn_arg.string
+    ISN_STOREB,	    // pop into buffer-local variable isn_arg.string
+    ISN_STOREW,	    // pop into window-local variable isn_arg.string
+    ISN_STORET,	    // pop into tab-local variable isn_arg.string
     ISN_STORES,	    // pop into script variable isn_arg.loadstore
     ISN_STORESCRIPT, // pop into script variable isn_arg.script
     ISN_STOREOPT,   // pop into option isn_arg.string


### PR DESCRIPTION
**Problem**
We cannot use buffer-local, window-local, and tab-local variables in `:def` function.

**Solution**
Implement `ISN_LOADB`, `ISN_LOADW`, `ISN_LOADT`, `ISN_STOREB`, `ISN_STOREW`, and `ISN_STORET` operators.