### PR TITLE
Fixed compilation warning with clang -Wpedantic

### DIFF
--- a/src/message_test.c
+++ b/src/message_test.c
@@ -127,7 +127,7 @@ test_vim_snprintf(void)
     int		n;
     size_t	bsize;
     int		bsize_int;
-    char	*ptr = (char *)0x87654321;
+    void	*ptr = (void *)0x87654321;
 
     // Loop on various buffer sizes to make sure that truncation of
     // vim_snprintf() is correct.


### PR DESCRIPTION
PR fixes the following compilation warning when using `clang -Wpedantic`:
```
clang -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_GTK  -pthread -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gtk-3.0 -I/usr/include/gio-unix-2.0/ -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng16 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include   -g -O2 -Wall -Wextra -Wshadow -Wmissing-prototypes -Wpedantic -Wunreachable-code -Wunused-result -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/message_test.o message_test.c
message_test.c:253:37: warning: format specifies type 'void *' but the argument has type 'char *' [-Wformat-pedantic]
        n = vim_snprintf(buf, bsize, "%p", ptr);
                                      ~~   ^~~
                                      %s
```