### PR TITLE
Haiku: Fix GUI compile

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -607,6 +607,7 @@ SRC_AMI =	\
 
 # source files for Haiku (also in the extra archive)
 SRC_HAIKU =	\
+		README_haiku.txt
 		src/os_haiku.h \
 		src/os_haiku.rdef \
 		src/gui_haiku.cc \

--- a/Filelist
+++ b/Filelist
@@ -607,7 +607,7 @@ SRC_AMI =	\
 
 # source files for Haiku (also in the extra archive)
 SRC_HAIKU =	\
-		README_haiku.txt
+		README_haiku.txt \
 		src/os_haiku.h \
 		src/os_haiku.rdef \
 		src/gui_haiku.cc \

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ All commands are given with normal keyboard characters, so those who can type
 with ten fingers can work very fast.  Additionally, function keys can be
 mapped to commands by the user, and the mouse can be used.
 
-Vim runs under MS-Windows (XP, Vista, 7, 8, 10), macOS, VMS and almost all
-flavours of UNIX.  Porting to other systems should not be very difficult.
+Vim runs under MS-Windows (XP, Vista, 7, 8, 10), macOS, Haiku, VMS and almost
+all flavours of UNIX.  Porting to other systems should not be very difficult.
 Older versions of Vim run on MS-DOS, MS-Windows 95/98/Me/NT/2000, Amiga DOS,
 Atari MiNT, BeOS, RISC OS and OS/2.  These are no longer maintained.
 
@@ -72,6 +72,7 @@ archive):
 	README_unix.txt		Unix
 	README_dos.txt		MS-DOS and MS-Windows
 	README_mac.txt		Macintosh
+	README_haiku.txt	Haiku
 	README_vms.txt		VMS
 
 There are other `README_*.txt` files, depending on the distribution you used.

--- a/READMEdir/README_haiku.txt
+++ b/READMEdir/README_haiku.txt
@@ -1,0 +1,13 @@
+README_haiku.txt for version 8.2 of Vim: Vi IMproved.
+
+This file explains the installation of Vim on Haiku operating system.
+See "README.txt" for general information about Vim.
+
+Preferred (and easy) way to get Vim on Haiku is to use default Haiku
+software repository HaikuPorts. To get Vim:
+
+- Open HaikuDepot application and search for "vim" package, then install,
+- Open a Terminal and type "pkgman install vim", then follow instructions.
+
+If you prefer to install Vim from source, follow the instructions on
+"runtime/doc/os_haiku.txt", "Compiling Haiku" section.

--- a/runtime/doc/os_haiku.txt
+++ b/runtime/doc/os_haiku.txt
@@ -46,8 +46,7 @@ features you can enable/disable.
 
 Haiku uses "ncurses6" as its terminal library, therefore you need to have
 "ncurses6_devel" package installed from HaikuDepot in order to configure
-the Haiku build. Just append "--with-tlib=ncurses6" to ./configure command
-below for the initial build.
+the Haiku build.
 
 Now you should use "make" to compile Vim, then "make install" to install it.
 For seamless integration into Haiku, the GUI-less vim binary should be

--- a/src/Makefile
+++ b/src/Makefile
@@ -1403,8 +1403,8 @@ HAIKUGUI_TESTTARGET = gui
 HAIKUGUI_BUNDLE =
 
 # All GUI files
-ALL_GUI_SRC  = gui.c gui_gtk.c gui_gtk_f.c gui_motif.c gui_xmdlg.c gui_xmebw.c gui_athena.c gui_gtk_x11.c gui_x11.c gui_at_sb.c gui_at_fs.c
-ALL_GUI_PRO  = gui.pro gui_gtk.pro gui_motif.pro gui_xmdlg.pro gui_athena.pro gui_gtk_x11.pro gui_x11.pro gui_w32.pro gui_photon.pro
+ALL_GUI_SRC  = gui.c gui_gtk.c gui_gtk_f.c gui_motif.c gui_xmdlg.c gui_xmebw.c gui_athena.c gui_gtk_x11.c gui_x11.c gui_at_sb.c gui_at_fs.c gui_haiku.cc
+ALL_GUI_PRO  = gui.pro gui_gtk.pro gui_motif.pro gui_xmdlg.pro gui_athena.pro gui_gtk_x11.pro gui_x11.pro gui_w32.pro gui_photon.pro gui_haiku.pro
 
 # }}}
 

--- a/src/beval.h
+++ b/src/beval.h
@@ -79,6 +79,10 @@ typedef struct BalloonEvalStruct
 #ifdef FEAT_GUI_MSWIN
     void		*tofree;
 #endif
+#ifdef FEAT_GUI_HAIKU
+    int			x;
+    int			y;
+#endif
 } BalloonEval;
 
 #define EVAL_OFFSET_X 15 // displacement of beval topleft corner from pointer

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -3563,7 +3563,7 @@ gui_mch_set_text_area_pos(
 		gui.vimTextArea->MoveTo(x, y);
 		gui.vimTextArea->ResizeTo(w - PEN_WIDTH, h - PEN_WIDTH);
 
-/*#ifdef FEAT_GUI_TABLINE
+#ifdef FEAT_GUI_TABLINE
 		if(gui.vimForm->TabLine() != NULL) {
 			gui.vimForm->TabLine()->ResizeTo(w, gui.vimForm->TablineHeight());
 		}

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -3870,7 +3870,7 @@ gui_mch_get_font(
 		hl_set_font_name((char_u*)font_name);
 
 		//  Set guifont to the name of the selected font.
-		char_u* new_p_guifont = alloc(STRLEN(font_name) + 1);
+		char_u* new_p_guifont = (char_u*)alloc(STRLEN(font_name) + 1);
 		if (new_p_guifont != NULL) {
 			STRCPY(new_p_guifont, font_name);
 			vim_free(p_guifont);

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -2916,6 +2916,7 @@ VimToolbar::RemoveButton(vimmenu_T *menu)
 			menu->button = NULL;
 		}
 	}
+	return true;
 }
 
 	bool
@@ -2926,6 +2927,7 @@ VimToolbar::GrayButton(vimmenu_T *menu, int grey)
 		if(index >= 0)
 			menu->button->SetEnabled(grey ? false : true);
 	}
+	return true;
 }
 
 	void

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -3679,7 +3679,7 @@ gui_mch_create_scrollbar(
 	}
 }
 
-#if defined(FEAT_WINDOWS) || defined(PROTO)
+#if defined(FEAT_WINDOWS) || defined(PROTO) || defined(FEAT_GUI_HAIKU)
 void
 gui_mch_destroy_scrollbar(
 		scrollbar_T	*sb)
@@ -3736,7 +3736,7 @@ gui_mch_set_blinking(
  * Stop the cursor blinking.  Show the cursor if it wasn't shown.
  */
 	void
-gui_mch_stop_blink()
+gui_mch_stop_blink(int may_call_gui_update_cursor)
 {
 	// TODO
 	if (blink_timer != 0)
@@ -4488,7 +4488,7 @@ gui_mch_wait_for_chars(
 			if (gui.in_focus)
 				gui_mch_start_blink();
 			else
-				gui_mch_stop_blink();
+				gui_mch_stop_blink(TRUE);
 			focus = gui.in_focus;
 		}
 

--- a/src/proto/gui_haiku.pro
+++ b/src/proto/gui_haiku.pro
@@ -6,7 +6,7 @@ int gui_mch_open(void);
 void gui_mch_exit(int vim_exitcode);
 int gui_mch_init_check(void);
 void gui_mch_flush(void);
-
+int gui_mch_is_blink_off(void);
 void gui_mch_new_colors(void);
 void gui_mch_set_bg_color(guicolor_T color);
 void gui_mch_set_fg_color(guicolor_T color);


### PR DESCRIPTION
Please see #5700.

This PR fixes Haiku GUI build. It is not possible to do `make install` from source just yet, but it builds fine. However, these fixes will enable Haikuporter to update gVim/Vim to current version, since the current Haiku code was designed to work in accordance with Haikuporter from the start, which is the de-facto standard way to get software on Haiku. To enable from-source built gVim, it needs a more fundamental change involving handling processes and assets.