### PR TITLE
Allow to set v:false to number options

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -1291,6 +1291,9 @@ ex_let_one(
 	    }
 	    if (s != NULL)
 	    {
+		if (n == 0 && STRCMP(s, "v:false") == 0)
+		    s = NULL;
+
 		set_option_value(arg, n, s, opt_flags);
 		arg_end = p;
 	    }

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -899,4 +899,18 @@ func Test_opt_num_op()
   set shiftwidth&
 endfunc
 
+" Test for setting option values using v:false and v:true
+func Test_opt_boolean()
+  set number&
+  set number
+  call assert_equal(1, &nu)
+  set nonu
+  call assert_equal(0, &nu)
+  let &nu=v:true
+  call assert_equal(1, &nu)
+  let &nu=v:false
+  call assert_equal(0, &nu)
+  set number&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Noticed at https://github.com/neovim/neovim/issues/12174

Trying to do `:let &number=v:false` will error out with `E521: Number required`, while `:let &number=v:true` works as expected.

I believe the problem is, that when we convert v:false it to number zero correctly at

https://github.com/vim/vim/blob/e71ebb46a252cd1cdfb075e6014c2b13c580bf3f/src/evalvars.c#L1259-L1260

when we further down call `set_option_value(arg, n, s, opt_flags)` with `n=0, s=v:false`, `set_option_value()` wrongly assumes to use the string value instead of the number value, because the number value is zero:

https://github.com/vim/vim/blob/e71ebb46a252cd1cdfb075e6014c2b13c580bf3f/src/option.c#L4233-L4254

So make sure, to set the string pointer to NULL, if `n==0 and s==v:false`.

