### PR TITLE
Fix wrong color assignation

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -524,7 +524,7 @@ static int color_numbers_88[28] = {0, 4, 2, 6,
 				 75, 11, 78, 15, -1};
 // for xterm with 256 colors...
 static int color_numbers_256[28] = {0, 4, 2, 6,
-				 1, 5, 130, 130,
+				 1, 5, 130, 3,
 				 248, 248, 7, 7,
 				 242, 242,
 				 12, 81, 10, 121,


### PR DESCRIPTION
Most terminal emulators allow users to customize their colors by
selecting a predefined palette and/or by picking individual colors.

This means that colors 0-15 can't be expected to have a fixed value and,
therefore, that no attempt should be made to map them to hardcoded ones.

Even if such an attempt is made, mapping "dark yellow" (`808000` by default) to
a brownish orange (`AF5F00`) makes no sense when there are much more 
mathematically and perceptually accurate choices anyway, like `100` (`878700`), 
`142` (`AFAF00`), or `184` (`DFDF00`).

With `&t_Co=256`,

* `darkred` is correctly mapped to `1`,
* `darkgreen` is correctly mapped to `2`,
* `darkblue` is correctly mapped to `4`,
* `darkmagenta` is correctly mapped to `5`,
* `darkcyan` is correctly mapped to `6`,

but `darkyellow` is incorrectly mapped to `130`, a brownish orange,
instead of the expected `3`.

**Problem:** `darkyellow` items look brownish orange instead of the expected color.

**Cause:** `darkyellow` is mapped to non-user-customisable xterm color `130`.

**Solution:** map `darkyellow` to user-customisable xterm color `3`.