### PR TITLE
Test_colorscheme fails when $COLORS is not 16777216

### DIFF
--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -31,7 +31,11 @@ func Test_balloon_show()
 endfunc
 
 func Test_colorscheme()
-  call assert_equal('16777216', &t_Co)
+  if exists('$COLORS')
+    call assert_equal($COLORS, &t_Co)
+  else
+    call assert_equal('16777216', &t_Co)
+  endif
 
   let colorscheme_saved = exists('g:colors_name') ? g:colors_name : 'default'
   let g:color_count = 0


### PR DESCRIPTION
Problem:    Test_colorscheme fails when $COLORS is not 16777216
Solution:   Compare &t_Co with $COLORS if it's defined

**Describe the bug**
Test_colorscheme fails when $COLORS is not 16777216

**To Reproduce**
1. `$ export COLORS=256`
2. `$ make test_gui`

**Expected behavior**
No error

**Environment (please complete the following information):**
 - Vim version: 8.2.640
 - OS: Ubuntu 18.04
 - Terminal: mintty