### PR TITLE
asciidoc.vim: speed up the refresh process for big files

### DIFF
--- a/runtime/syntax/asciidoc.vim
+++ b/runtime/syntax/asciidoc.vim
@@ -25,8 +25,6 @@ if exists("b:current_syntax")
   finish
 endif
 
-syn clear
-
 " Run :help syn-priority to review syntax matching priority.
 syn keyword asciidocToDo TODO FIXME CHECK TEST XXX ZZZ DEPRECATED
 syn match asciidocBackslash /\\/

--- a/runtime/syntax/asciidoc.vim
+++ b/runtime/syntax/asciidoc.vim
@@ -1,11 +1,13 @@
 " Vim syntax file
-" Language:     AsciiDoc
-" Author:       Stuart Rackham <srackham@gmail.com> (inspired by Felix
-"               Obenhuber's original asciidoc.vim script).
-" URL:          http://asciidoc.org/
-" Licence:      GPL (http://www.gnu.org)
-" Remarks:      Vim 6 or greater
-" Last Update:  2014 Aug 29 (see Issue 240)
+" Language:        AsciiDoc
+" Maintainer:      @aerostitch on GitHub (tag me in your issue in the
+"                  github/vim/vim repository and I'll answer when available)
+" Original author: Stuart Rackham <srackham@gmail.com> (inspired by Felix
+"                  Obenhuber's original asciidoc.vim script).
+" URL:             http://asciidoc.org/
+" Licence:         GPL (http://www.gnu.org)
+" Remarks:         Vim 6 or greater
+" Last Update:     2020 May 03 (see Issue 240)
 " Limitations:
 "
 " - Nested quoted text formatting is highlighted according to the outer

--- a/runtime/syntax/asciidoc.vim
+++ b/runtime/syntax/asciidoc.vim
@@ -7,7 +7,7 @@
 " Remarks:      Vim 6 or greater
 " Last Update:  2014 Aug 29 (see Issue 240)
 " Limitations:
-" 
+"
 " - Nested quoted text formatting is highlighted according to the outer
 "   format.
 " - If a closing Example Block delimiter may be mistaken for a title
@@ -24,8 +24,6 @@ if exists("b:current_syntax")
 endif
 
 syn clear
-syn sync fromstart
-syn sync linebreaks=100
 
 " Run :help syn-priority to review syntax matching priority.
 syn keyword asciidocToDo TODO FIXME CHECK TEST XXX ZZZ DEPRECATED


### PR DESCRIPTION
Hi everyone,

The removal of those lines speeds up vim's refresh process on big files for the asciidoc format.

This was first raised in https://bugs.debian.org/767179 and then integrated in the asciidoc repository in https://github.com/asciidoc/asciidoc-py3/pull/91.

As I just discovered that vim had this file in its runtime, I thought it might be good to have that change here and remove it from the asciidoc repo itself as it doesn't make sense to manage separate versions. See https://github.com/asciidoc/asciidoc-py3/pull/100 (just as an FYI).

Thanks for your time,
Joseph