### PR TITLE
Fix that Test_ruby_p fails on Windows after 8.2.0636

### DIFF
--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -338,4 +338,16 @@ func IsRoot()
   return v:false
 endfunc
 
+" Get all messages but drop the maintainer entry.
+func GetMessages()
+  redir => result
+  redraw | messages
+  redir END
+  let msg_list = split(result, "\n")
+  if msg_list->len() > 0 && msg_list[0] =~ 'Messages maintainer:'
+    return msg_list[1:]
+  endif
+  return msg_list
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -3,18 +3,6 @@
 source shared.vim
 source term_util.vim
 
-" Get all messages but drop the maintainer entry.
-func GetMessages()
-  redir => result
-  redraw | messages
-  redir END
-  let msg_list = split(result, "\n")
-  if msg_list->len() > 0 && msg_list[0] =~ 'Messages maintainer:'
-    return msg_list[1:]
-  endif
-  return msg_list
-endfunc
-
 func Test_messages()
   let oldmore = &more
   try

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -378,7 +378,7 @@ endfunc
 
 func Test_ruby_p()
   ruby p 'Just a test'
-  let messages = split(execute('message'), "\n")
+  let messages = GetMessages()
   call assert_equal('"Just a test"', messages[-1])
 
   " Check return values of p method
@@ -391,7 +391,7 @@ func Test_ruby_p()
   messages clear
   call assert_equal(v:true, rubyeval('p() == nil'))
 
-  let messages = split(execute('message'), "\n")
+  let messages = GetMessages()
   call assert_equal(0, len(messages))
 endfunc
 


### PR DESCRIPTION
Discussed at https://github.com/vim/vim/commit/41f6918bf4545de6a80c96d8c80f5f509f9a647f .