### PR TITLE
Haiku: Fix build warning & simplify GUI code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/xxd/xxd
 src/auto/if_perl.c
 src/auto/gui_gtk_gresources.c
 src/auto/gui_gtk_gresources.h
+src/auto/os_haiku.rdef
 src/objects/.dirstamp
 src/objects
 src/tags

--- a/src/gui.c
+++ b/src/gui.c
@@ -5107,7 +5107,8 @@ gui_find_iconfile(char_u *name, char_u *buffer, char *ext)
 # endif
 #endif
 
-#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_X11) || defined(PROTO)
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_X11) || defined(PROTO) \
+	|| defined(FEAT_GUI_HAIKU)
     void
 display_errors(void)
 {

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -551,7 +551,7 @@ struct VimMsg {
 };
 
 #define RGB(r, g, b)	((char_u)(r) << 16 | (char_u)(g) << 8 | (char_u)(b) << 0)
-#define GUI_TO_RGB(g)	{ (g) >> 16, (g) >> 8, (g) >> 0, 255 }
+#define GUI_TO_RGB(g)	{ (char_u)((g) >> 16), (char_u)((g) >> 8), (char_u)((g) >> 0), 255 }
 
 // ---------------- end of header part ----------------
 
@@ -3989,40 +3989,6 @@ gui_mch_adjust_charheight()
     }
     return OK;
 }
-
-/*
- * Display the saved error message(s).
- */
-#ifdef USE_MCH_ERRMSG
-    void
-display_errors(void)
-{
-    char    *p;
-    char_u  pError[256];
-
-    if (error_ga.ga_data == NULL)
-    return;
-
-    // avoid putting up a message box with blanks only
-    for (p = (char *)error_ga.ga_data; *p; ++p)
-    if (!isspace(*p))
-    {
-	if (STRLEN(p) > 255)
-	pError[0] = 255;
-	else
-	pError[0] = STRLEN(p);
-
-	STRNCPY(&pError[1], p, pError[0]);
-//	ParamText(pError, nil, nil, nil);
-//	Alert(128, nil);
-	break;
-	// TODO: handled message longer than 256 chars
-	//   use auto-sizeable alert
-	//   or dialog with scrollbars (TextEdit zone)
-    }
-    ga_clear(&error_ga);
-}
-#endif
 
     void
 gui_mch_getmouse(int *x, int *y)


### PR DESCRIPTION
This PR fixes below build warnings and simplifies the GUI code a bit:

```gui_haiku.cc: In function 'void display_errors()':
vim.h:1592:36: warning: 'char* strncpy(char*, const char*, size_t)' specified bound depends on the length of the source argument [-Wstringop-overflow=]
 #define STRNCPY(d, s, n)    strncpy((char *)(d), (char *)(s), (size_t)(n))
                             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gui_haiku.cc:4015:2: note: in expansion of macro 'STRNCPY'
  STRNCPY(&pError[1], p, pError[0]);
  ^~~~~~~
vim.h:1590:29: note: length computed here
 #define STRLEN(s)     strlen((char *)(s))
                       ~~~~~~^~~~~~~~~~~~~
gui_haiku.cc:4010:6: note: in expansion of macro 'STRLEN'
  if (STRLEN(p) > 255)
      ^~~~~~
```

also fixing the `char_u` conversion error, credits to @dpelle. Closing haikuports/haikuports#4901, #5977.