### PR TITLE
Fix that if_xx heredoc doesn't accept a marker with lower case

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -595,7 +595,7 @@ heredoc_get(exarg_T *eap, char_u *cmd, int script_get)
 	    return NULL;
 	}
 	*p = NUL;
-	if (vim_islower(*marker))
+	if (!script_get && vim_islower(*marker))
 	{
 	    emsg(_("E221: Marker cannot start with lower case letter"));
 	    return NULL;

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -623,7 +623,10 @@ vim.command('let s ..= "B"')
   lua << trim
     vim.command('let s ..= "D"')
   .
-  call assert_equal('ABCD', s)
+  lua << trim eof
+    vim.command('let s ..= "E"')
+  eof
+  call assert_equal('ABCDE', s)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_perl.vim
+++ b/src/testdir/test_perl.vim
@@ -305,7 +305,10 @@ VIM::DoCommand('let s ..= "B"')
   perl << trim
     VIM::DoCommand('let s ..= "D"')
   .
-  call assert_equal('ABCD', s)
+  perl << trim eof
+    VIM::DoCommand('let s ..= "E"')
+  eof
+  call assert_equal('ABCDE', s)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -182,7 +182,10 @@ s+='B'
   python << trim
     s+='D'
   .
-  call assert_equal('ABCD', pyxeval('s'))
+  python << trim eof
+    s+='E'
+  eof
+  call assert_equal('ABCDE', pyxeval('s'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -349,7 +349,10 @@ s+='B'
   python3 << trim
     s+='D'
   .
-  call assert_equal('ABCD', pyxeval('s'))
+  python3 << trim eof
+    s+='E'
+  eof
+  call assert_equal('ABCDE', pyxeval('s'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_pyx2.vim
+++ b/src/testdir/test_pyx2.vim
@@ -94,7 +94,10 @@ result+='B'
   pyx << trim
     result+='D'
   .
-  call assert_equal('ABCD', pyxeval('result'))
+  pyx << trim eof
+    result+='E'
+  eof
+  call assert_equal('ABCDE', pyxeval('result'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_pyx3.vim
+++ b/src/testdir/test_pyx3.vim
@@ -94,7 +94,10 @@ result+='B'
   pyx << trim
     result+='D'
   .
-  call assert_equal('ABCD', pyxeval('result'))
+  pyx << trim eof
+    result+='E'
+  eof
+  call assert_equal('ABCDE', pyxeval('result'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -409,7 +409,10 @@ Vim.command('let s ..= "B"')
   ruby << trim
     Vim.command('let s ..= "D"')
   .
-  call assert_equal('ABCD', s)
+  ruby << trim eof
+    Vim.command('let s ..= "E"')
+  eof
+  call assert_equal('ABCDE', s)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
After 8.2.0578, if_xx heredoc doesn't accept a marker with lower case.
This breaks existing scripts.
Accept lower case again.