### PR TITLE
Fix set-option line by modeline

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -2460,7 +2460,8 @@ set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T script_ctx)
     int		indir = (int)options[opt_idx].indir;
     sctx_T	new_script_ctx = script_ctx;
 
-    new_script_ctx.sc_lnum += SOURCING_LNUM;
+    if (!(opt_flags & OPT_MODELINE))
+	new_script_ctx.sc_lnum += SOURCING_LNUM;
 
     // Remember where the option was set.  For local options need to do that
     // in the buffer or window structure.

--- a/src/testdir/test_modeline.vim
+++ b/src/testdir/test_modeline.vim
@@ -279,3 +279,59 @@ func Test_modeline_fails_modelineexpr()
   call s:modeline_fails('tabline', 'tabline=Something()', 'E992:')
   call s:modeline_fails('titlestring', 'titlestring=Something()', 'E992:')
 endfunc
+
+func Test_modeline_setoption_verbose()
+  let modeline = &modeline
+  set modeline
+
+  let lines =<< trim END
+  1 vim:ts=2
+  2 two
+  3 three
+  4 four
+  5 five
+  6 six
+  7 seven
+  8 eight
+  END
+  call writefile(lines, 'Xmodeline')
+  edit Xmodeline
+  let info = split(execute('verbose set tabstop?'), "\n")
+  call assert_match('^\s*Last set from modeline line 1$', info[-1])
+  bwipe!
+
+  let lines =<< trim END
+  1 one
+  2 two
+  3 three
+  4 vim:ts=4
+  5 five
+  6 six
+  7 seven
+  8 eight
+  END
+  call writefile(lines, 'Xmodeline')
+  edit Xmodeline
+  let info = split(execute('verbose set tabstop?'), "\n")
+  call assert_match('^\s*Last set from modeline line 4$', info[-1])
+  bwipe!
+
+  let lines =<< trim END
+  1 one
+  2 two
+  3 three
+  4 four
+  5 five
+  6 six
+  7 seven
+  8 vim:ts=8
+  END
+  call writefile(lines, 'Xmodeline')
+  edit Xmodeline
+  let info = split(execute('verbose set tabstop?'), "\n")
+  call assert_match('^\s*Last set from modeline line 8$', info[-1])
+  bwipe!
+
+  let &modeline = modeline
+  call delete('Xmodeline')
+endfunc


### PR DESCRIPTION
When set option in modeline, `:verbose set xxx` reports wrong line number (twice the correct value).

### Repro steps

testfile:
```
hello
vim:tw=80
```

```
vim --clean testfile
:verbose set tw
```

Expect: `Last set from modeline line 2`
Actual: `Last set from modeline line 4`

### Cause

In `set_option_sctx_idx()`;

```c
    new_script_ctx.sc_lnum += SOURCING_LNUM;
```

When `opt_flags` includes `OPT_MODELINE`, both `new_script_ctx.sc_lnum` and `SOURCING_LNUM` represent the same value (the current line) so this operation is not need.