### PR TITLE
Haiku: Fix terminal

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -3940,7 +3940,7 @@ theend:
     free_job_options(&opt);
 }
 
-# if defined(MSWIN) || defined(FEAT_GUI) || defined(PROTO)
+#if defined(MSWIN) || defined(__HAIKU__) || defined(FEAT_GUI) || defined(PROTO)
 /*
  * Check the channels for anything that is ready to be read.
  * The data is put in the read queue.
@@ -3973,9 +3973,23 @@ channel_handle_events(int only_keep_open)
 						     "channel_handle_events");
 	    }
 	}
+
+# ifdef __HAIKU__
+	// Workaround for Haiku: Since select/poll cannot detect EOF from tty,
+	// should close fds when the job has finished if 'channel' connects to
+	// the pty.
+	if (channel->ch_job != NULL)
+	{
+	    job_T *job = channel->ch_job;
+
+	    if (job->jv_tty_out != NULL && job->jv_status == JOB_FINISHED)
+		for (part = PART_SOCK; part < PART_COUNT; ++part)
+		    ch_close_part(channel, part);
+	}
+# endif
     }
 }
-# endif
+#endif
 
 # if defined(FEAT_GUI) || defined(PROTO)
 /*
@@ -4541,6 +4555,20 @@ channel_select_check(int ret_in, void *rfds_in, void *wfds_in)
 	    channel_write_input(channel);
 	    --ret;
 	}
+
+# ifdef __HAIKU__
+	// Workaround for Haiku: Since select/poll cannot detect EOF from tty,
+	// should close fds when the job has finished if 'channel' connects to
+	// the pty.
+	if (channel->ch_job != NULL)
+	{
+	    job_T *job = channel->ch_job;
+
+	    if (job->jv_tty_out != NULL && job->jv_status == JOB_FINISHED)
+		for (part = PART_SOCK; part < PART_COUNT; ++part)
+		    ch_close_part(channel, part);
+	}
+# endif
     }
 
     return ret;

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2147,7 +2147,7 @@ parse_queued_messages(void)
     for (i = 0; i < MAX_REPEAT_PARSE; ++i)
     {
 	// For Win32 mch_breakcheck() does not check for input, do it here.
-# if defined(MSWIN) && defined(FEAT_JOB_CHANNEL)
+# if (defined(MSWIN) || defined(__HAIKU__)) && defined(FEAT_JOB_CHANNEL)
 	channel_handle_events(FALSE);
 # endif
 

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -4438,15 +4438,16 @@ gui_mch_wait_for_chars(
 	int	wtime)
 {
     int		focus;
-    bigtime_t	    until, timeout;
-    status_t	    st;
+    bigtime_t	until, timeout;
+    status_t	st;
 
-    if (wtime >= 0) {
+    if (wtime >= 0)
+    {
 	timeout = wtime * 1000;
 	until = system_time() + timeout;
-    } else {
-	timeout = B_INFINITE_TIMEOUT;
     }
+    else
+	timeout = B_INFINITE_TIMEOUT;
 
     focus = gui.in_focus;
     for (;;)
@@ -4462,6 +4463,28 @@ gui_mch_wait_for_chars(
 	}
 
 	gui_mch_flush();
+
+#ifdef MESSAGE_QUEUE
+# ifdef FEAT_TIMERS
+	did_add_timer = FALSE;
+# endif
+	parse_queued_messages();
+# ifdef FEAT_TIMERS
+	if (did_add_timer)
+	    // Need to recompute the waiting time.
+	    break;
+# endif
+# ifdef FEAT_JOB_CHANNEL
+	if (has_any_channel())
+	{
+	    if (wtime < 0 || timeout > 20000)
+		timeout = 20000;
+	}
+	else if (wtime < 0)
+	    timeout = B_INFINITE_TIMEOUT;
+# endif
+#endif
+
 	/*
 	 * Don't use gui_mch_update() because then we will spin-lock until a
 	 * char arrives, instead we use gui_haiku_process_event() to hang until
@@ -4479,7 +4502,8 @@ gui_mch_wait_for_chars(
 	 * Calculate how much longer we're willing to wait for the
 	 * next event.
 	 */
-	if (wtime >= 0) {
+	if (wtime >= 0)
+	{
 	    timeout = until - system_time();
 	    if (timeout < 0)
 		break;

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -1145,10 +1145,11 @@ VimFormView::FrameResized(float new_width, float new_height)
 VimTextAreaView::VimTextAreaView(BRect frame):
     BView(frame, "VimTextAreaView", B_FOLLOW_ALL_SIDES,
 #ifdef FEAT_MBYTE_IME
-	B_WILL_DRAW | B_FULL_UPDATE_ON_RESIZE | B_INPUT_METHOD_AWARE),
+	B_WILL_DRAW | B_FULL_UPDATE_ON_RESIZE | B_INPUT_METHOD_AWARE
 #else
-	B_WILL_DRAW | B_FULL_UPDATE_ON_RESIZE),
+	B_WILL_DRAW | B_FULL_UPDATE_ON_RESIZE
 #endif
+	),
     mouseDragEventCount(0)
 {
 #ifdef FEAT_MBYTE_IME
@@ -3093,7 +3094,7 @@ gui_haiku_process_event(bigtime_t timeout)
 			}
 		    }
 #else
-		    add_to_input_buf_csi(string, len);
+			add_to_input_buf_csi(string, len);
 #endif
 		    else
 			add_to_input_buf(string, len);

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1666,23 +1666,25 @@ vim_getenv(char_u *name, int *mustfree)
 
     if (p != NULL)
 	return p;
+
+# ifdef __HAIKU__
+    // special handling for user settings directory...
+    if (STRCMP(name, "BE_USER_SETTINGS") == 0)
+    {
+	static char userSettingsPath[MAXPATHL];
+
+	if (find_directory(B_USER_SETTINGS_DIRECTORY, 0, false,
+					   userSettingsPath, MAXPATHL) == B_OK)
+	    return (char_u *)userSettingsPath;
+	else
+	    return NULL;
+    }
+# endif
 #endif
 
     // handling $VIMRUNTIME and $VIM is below, bail out if it's another name.
     vimruntime = (STRCMP(name, "VIMRUNTIME") == 0);
     if (!vimruntime && STRCMP(name, "VIM") != 0)
-#if defined(__HAIKU__)
-	// special handling for user settings directory...
-	if (STRCMP(name, "BE_USER_SETTINGS") == 0)
-	{
-	    static char userSettingsPath[MAXPATHL] = {0};
-
-	    if (B_OK == find_directory(B_USER_SETTINGS_DIRECTORY, 0,
-					    false, userSettingsPath, MAXPATHL))
-		return userSettingsPath;
-	}
-	else
-#endif
 	return NULL;
 
     /*


### PR DESCRIPTION
cc @bitigchi 

Refs #5981 #5982 

As far as I confirmed; Current Haiku OS, since select/poll cannot detect EOF from tty, should close fds when the job has finished if channel connects to the pty.

In addition, this adds to gui_haiku the processing to check channels and timers during waiting for input.