### PR TITLE
Acquire BSD lock for tmp files to prevent auto-cleanup by OS when Vim…

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -13823,6 +13823,53 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for dirfd" >&5
+$as_echo_n "checking for dirfd... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <sys/types.h>
+#include <dirent.h>
+int
+main ()
+{
+DIR * dir=opendir("dirname"); dirfd(dir);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }; $as_echo "#define HAVE_DIRFD 1" >>confdefs.h
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: not usable" >&5
+$as_echo "not usable" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for flock" >&5
+$as_echo_n "checking for flock... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <sys/file.h>
+int
+main ()
+{
+flock(10, LOCK_SH);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }; $as_echo "#define HAVE_FLOCK 1" >>confdefs.h
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: not usable" >&5
+$as_echo "not usable" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sysctl" >&5
 $as_echo_n "checking for sysctl... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -484,5 +484,11 @@
 /* Define if we have isnan() */
 #undef HAVE_ISNAN
 
+/* Define if we have dirfd() */
+#undef HAVE_DIRFD
+
+/* Define if we have flock() */
+#undef HAVE_FLOCK
+
 /* Define to inline symbol or empty */
 #undef inline

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4060,6 +4060,21 @@ AC_TRY_LINK([#include <stdio.h>], [rename("this", "that")],
 	AC_MSG_RESULT(yes); AC_DEFINE(HAVE_RENAME),
 	AC_MSG_RESULT(no))
 
+dnl check for dirfd()
+AC_MSG_CHECKING(for dirfd)
+AC_TRY_COMPILE(
+[#include <sys/types.h>
+#include <dirent.h>],
+[DIR * dir=opendir("dirname"); dirfd(dir);],
+AC_MSG_RESULT(yes); AC_DEFINE(HAVE_DIRFD), AC_MSG_RESULT(not usable))
+
+dnl check for flock()
+AC_MSG_CHECKING(for flock)
+AC_TRY_COMPILE(
+[#include <sys/file.h>],
+[flock(10, LOCK_SH);],
+AC_MSG_RESULT(yes); AC_DEFINE(HAVE_FLOCK), AC_MSG_RESULT(not usable))
+
 dnl sysctl() may exist but not the arguments we use
 AC_MSG_CHECKING(for sysctl)
 AC_TRY_COMPILE(

--- a/src/globals.h
+++ b/src/globals.h
@@ -758,6 +758,9 @@ EXTERN int	ru_wid;		// 'rulerfmt' width of ruler when non-zero
 EXTERN int	sc_col;		// column for shown command
 
 #ifdef TEMPDIRNAMES
+# if defined(UNIX) && defined(HAVE_FLOCK) && defined(HAVE_DIRFD)
+EXTERN DIR	*vim_tempdir_dp INIT(= NULL); //File descriptor of temp dir
+# endif
 EXTERN char_u	*vim_tempdir INIT(= NULL); // Name of Vim's own temp dir.
 					   // Ends in a slash.
 #endif

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -204,6 +204,10 @@
 # endif
 #endif
 
+#ifdef HAVE_FLOCK
+# include <sys/file.h>
+#endif
+
 #endif // PROTO
 
 #ifdef VMS


### PR DESCRIPTION
… is opened for long

Hi,

the patch is based on report https://bugzilla.redhat.com/show_bug.cgi?id=1631837 , when the user had opened Vim longer than default age of temporary files, so Vim temp files got cleaned under Vim's hands by systemd-tmpfiles-clean service.

The flexible solution proposed by systemd people is Vim will acquire BSD lock (https://systemd.io/TEMPORARY_DIRECTORIES/), so systemd will not clean them until Vim closes temp file descriptors (the lock is released automatically).

The proposed patch implements the proposal and I tested it by filter command, which calls vim_tempname(). I set the default low age for tmp files, run Vim in gdb, set breakpoint after creation of tmp dir and run filter command - then I wait for aging out the temp file and run systemd-tmpfiles-clean service.

Would it be possible to add the patch to Vim project? Please let me know if I can help in any way.

Thank you in advance!