### PR TITLE
Handle ignored signals correctly

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -14,6 +14,8 @@
 
 #include "vim.h"
 
+int ignore_sigtstp = 0;
+
 static int	VIsual_mode_orig = NUL;		// saved Visual mode
 static int	restart_VIsual_select = 0;
 
@@ -5723,10 +5725,11 @@ nv_window(cmdarg_T *cap)
     static void
 nv_suspend(cmdarg_T *cap)
 {
+    if (ignore_sigtstp) return;
     clearop(cap->oap);
     if (VIsual_active)
 	end_visual_mode();		// stop Visual mode
-    do_cmdline_cmd((char_u *)"st");
+    do_cmdline_cmd((char_u *)"stop");
 }
 
 /*

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -129,6 +129,9 @@ Window	    x11_window = 0;
 Display	    *x11_display = NULL;
 #endif
 
+int ignore_sigtstp;
+typedef void (*sighandler_t)(int);
+
 #ifdef FEAT_TITLE
 static int get_x11_title(int);
 
@@ -1306,12 +1309,20 @@ set_signals(void)
     signal(SIGWINCH, (RETSIGTYPE (*)())sig_winch);
 #endif
 
+#ifdef SIGTSTP
     /*
      * We want the STOP signal to work, to make mch_suspend() work.
      * For "rvim" the STOP signal is ignored.
+     *
+     * If we're started with SIGTSTP ignored keep it that setting as that is
+     * the standard way for our parent process/shell to indicate they do not
+     * handle tty job control. Thus we can't really safely suspend.
      */
-#ifdef SIGTSTP
-    signal(SIGTSTP, restricted ? SIG_IGN : SIG_DFL);
+    sighandler_t osig = signal(SIGTSTP, restricted ? SIG_IGN : SIG_DFL);
+    if (osig == SIG_IGN) {
+	signal(SIGTSTP, SIG_IGN);
+	ignore_sigtstp = 1;
+    }
 #endif
 #if defined(SIGCONT)
     signal(SIGCONT, sigcont_handler);
@@ -1385,11 +1396,11 @@ catch_signals(
 {
     int	    i;
 
-    for (i = 0; signal_info[i].sig != -1; i++)
+    for (i = 0; signal_info[i].sig != -1; i++) {
 	if (signal_info[i].deadly)
 	{
 #if defined(HAVE_SIGALTSTACK) && defined(HAVE_SIGACTION)
-	    struct sigaction sa;
+	    struct sigaction sa, oact;
 
 	    // Setup to use the alternate stack for the signal function.
 	    sa.sa_handler = func_deadly;
@@ -1404,23 +1415,50 @@ catch_signals(
 # else
 	    sa.sa_flags = SA_ONSTACK;
 # endif
-	    sigaction(signal_info[i].sig, &sa, NULL);
+	    sigaction(signal_info[i].sig, &sa, &oact);
+	    if (oact.sa_handler == SIG_IGN) {
+		sigaction(signal_info[i].sig, &oact, NULL);
+#ifdef SIGTSTP
+		if (signal_info[i].sig == SIGTSTP) ignore_sigtstp = 1;
+#endif
+	    }
 #else
 # if defined(HAVE_SIGALTSTACK) && defined(HAVE_SIGVEC)
-	    struct sigvec sv;
+	    struct sigvec sv, ovec;
 
 	    // Setup to use the alternate stack for the signal function.
 	    sv.sv_handler = func_deadly;
 	    sv.sv_mask = 0;
 	    sv.sv_flags = SV_ONSTACK;
-	    sigvec(signal_info[i].sig, &sv, NULL);
+	    sigvec(signal_info[i].sig, &sv, &ovec);
+	    if (ovec.sv_handler == SIG_IGN) {
+		sigvec(signal_info[i].sig, &ovec, NULL);
+#ifdef SIGTSTP
+		if (signal_info[i].sig == SIGTSTP) ignore_sigtstp = 1;
+#endif
+	    }
 # else
-	    signal(signal_info[i].sig, func_deadly);
+	    sighandler_t osig = signal(signal_info[i].sig, func_deadly);
+	    if (osig == SIG_IGN) {
+		signal(signal_info[i].sig, SIG_IGN);
+#ifdef SIGTSTP
+		if (signal_info[i].sig == SIGTSTP) ignore_sigtstp = 1;
+#endif
+	    }
 # endif
 #endif
 	}
 	else if (func_other != SIG_ERR)
-	    signal(signal_info[i].sig, func_other);
+	{
+	    sighandler_t osig = signal(signal_info[i].sig, func_other);
+	    if (osig == SIG_IGN) {
+		signal(signal_info[i].sig, SIG_IGN);
+#ifdef SIGTSTP
+		if (signal_info[i].sig == SIGTSTP) ignore_sigtstp = 1;
+#endif
+	    }
+	}
+    }
 }
 
 #ifdef HAVE_SIGPROCMASK

--- a/src/testdir/test_channel_pipe.py
+++ b/src/testdir/test_channel_pipe.py
@@ -29,6 +29,8 @@ if __name__ == "__main__":
 
     while True:
         typed = sys.stdin.readline()
+        if typed == "":  # EOF -- stop
+            break
         if typed.startswith("quit"):
             print("Goodbye!")
             sys.stdout.flush()
@@ -63,4 +65,3 @@ if __name__ == "__main__":
             print(typed, end='')
             sys.stderr.flush()
             break
-


### PR DESCRIPTION
If Vim is started with some signals ignored they should remain ignored.
This is particularly important for the tty job control signals such as
SIGTSTP which might be marked as ignored by a shell that does not
implement tty job control.

I verified this on macOS and Linux with bash (which implements tty job
control) and elvish (which does not).

Lastly, this fixes a bug in test_channel_pipe.py that can leave spinning
processes when `make test` is run. Sorry for including an unrelated change
but it's two lines and keeps systems from accumulating spinning versions
of that program when `make test` is run.

Fixes #5990