### PR TITLE
Fix indent tests on Cirrus-CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,5 +13,4 @@ freebsd_12_task:
     - make -j${NPROC}
     - src/vim --version
   test_script:
-    # Runtime Indent tests do not work, run only the normal test suite
-    - cd src && make test
+    - make test

--- a/runtime/indent/testdir/runtest.vim
+++ b/runtime/indent/testdir/runtest.vim
@@ -10,6 +10,7 @@ filetype indent on
 syn on
 set nowrapscan
 set report=9999
+set modeline
 
 au! SwapExists * call HandleSwapExists()
 func HandleSwapExists()


### PR DESCRIPTION
On Cirrus-CI, as with #6036, indent tests needs set 'modeline' on.