### PR TITLE
add vim.has() for lua

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -199,6 +199,9 @@ Vim evaluation and command execution, and others.
 				returns it. Note that the buffer is not set as
 				current.
 
+	vim.has({features} [, {check}])
+				See |has()|
+
 
 ==============================================================================
 3. List userdata					*lua-list*

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -1903,6 +1903,37 @@ luaV_type(lua_State *L)
     return 1;
 }
 
+    static int
+luaV_has(lua_State *L)
+{
+    int argcount = lua_gettop(L);
+
+    if (argcount == 0) {
+	lua_pushinteger(L, 0);
+	return 1;
+    }
+
+    typval_T *argvars = (typval_T*)alloc(argcount * sizeof(typval_T));
+    for(int i = 1; i <= argcount; i++) {
+	if (i == 2) {
+	    // luaV_totypeval returns float instead of integer so special handle 2nd arg
+	    argvars[i - 1].v_type = VAR_NUMBER;
+	    argvars[i - 1].vval.v_number = (varnumber_T) lua_tointeger(L, i);
+	} else if (luaV_totypval(L, i, &argvars[i-1]) == FAIL)
+	    emsg("lua: cannot convert value");
+    }
+
+    typval_T rettv;
+    f_has(argvars, &rettv);
+
+    lua_pushinteger(L, (int) rettv.vval.v_number);
+
+    clear_tv(argvars);
+    clear_tv(&rettv);
+
+    return 1;
+}
+
 static const luaL_Reg luaV_module[] = {
     {"command", luaV_command},
     {"eval", luaV_eval},
@@ -1916,6 +1947,7 @@ static const luaL_Reg luaV_module[] = {
     {"window", luaV_window},
     {"open", luaV_open},
     {"type", luaV_type},
+    {"has", luaV_has},
     {NULL, NULL}
 };
 

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -1909,7 +1909,7 @@ luaV_has(lua_State *L)
     int argcount = lua_gettop(L);
 
     if (argcount == 0) {
-	lua_pushinteger(L, 0);
+	lua_pushboolean(L, 0);
 	return 1;
     }
 
@@ -1926,7 +1926,7 @@ luaV_has(lua_State *L)
     typval_T rettv;
     f_has(argvars, &rettv);
 
-    lua_pushinteger(L, (int) rettv.vval.v_number);
+    lua_pushboolean(L, rettv.vval.v_number == 1);
 
     clear_tv(argvars);
     clear_tv(&rettv);

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -542,12 +542,12 @@ endfunc
 
 " Test vim.has()
 func Test_lua_has()
-  call assert_equal(has("unknown_feature"), luaeval("vim.has('unknown_feature')"))
-  call assert_equal(has("lua"), luaeval("vim.has('lua')"))
-  call assert_equal(has("lua", 1), luaeval("vim.has('lua', 1)"))
-  call assert_equal(has("lua", 0), luaeval("vim.has('lua', 0)"))
-  call assert_equal(0, luaeval("vim.has()"))
-  call assert_equal(0, luaeval("vim.has(nil)"))
+  call assert_equal(has("unknown_feature") == 1 ? v:true : v:false, luaeval("vim.has('unknown_feature')"))
+  call assert_equal(has("lua") == 1 ? v:true : v:false, luaeval("vim.has('lua')"))
+  call assert_equal(has("lua", 1) == 1 ? v:true : v:false, luaeval("vim.has('lua', 1)"))
+  call assert_equal(has("lua", 0) == 1 ? v:true : v:false, luaeval("vim.has('lua', 0)"))
+  call assert_equal(v:false, luaeval("vim.has()"))
+  call assert_equal(v:false, luaeval("vim.has(nil)"))
 endfunc
 
 " Test errors in luaeval()

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -540,6 +540,16 @@ func Test_lua_beep()
   call assert_beeps('lua vim.beep()')
 endfunc
 
+" Test vim.has()
+func Test_lua_has()
+  call assert_equal(has("unknown_feature"), luaeval("vim.has('unknown_feature')"))
+  call assert_equal(has("lua"), luaeval("vim.has('lua')"))
+  call assert_equal(has("lua", 1), luaeval("vim.has('lua', 1)"))
+  call assert_equal(has("lua", 0), luaeval("vim.has('lua', 0)"))
+  call assert_equal(0, luaeval("vim.has()"))
+  call assert_equal(0, luaeval("vim.has(nil)"))
+endfunc
+
 " Test errors in luaeval()
 func Test_luaeval_error()
   " Compile error


### PR DESCRIPTION
Feature detection is a must in order to support backwards compatibility. Was writing a plugin in lua and noticed that it is currently not possible to support it without `eval`.

```vim
lua print(vim.has('perl'))
lua print(vim.has('perl', 1))
```

Signature is the same as vim's `has()` function.