### PR TITLE
add vim.sleep() for lua

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -195,6 +195,18 @@ Vim evaluation and command execution, and others.
 
 	vim.beep()		Beeps.
 
+	vim.sleep({N})		Sleep for {N} milliseconds.
+
+				Can be interrupted with CTRL-C (CTRL-Break on
+				MS-Windows).
+				While sleeping the cursor is positioned in the text,
+				if at a visible position.
+				Also process the received netbeans messages. {only
+				available when compiled with the |+netbeans_intg|
+				feature}
+				Examples: >
+					:lua vim.sleep(5000)
+<
 	vim.open({fname})	Opens a new buffer for file {fname} and
 				returns it. Note that the buffer is not set as
 				current.

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -1903,6 +1903,21 @@ luaV_type(lua_State *L)
     return 1;
 }
 
+    static int
+luaV_sleep(lua_State *L)
+{
+    if (lua_gettop(L) != 1)
+	return luaL_error(L, "lua: 1 argument required");
+
+    if (!lua_isnumber(L, 1))
+	return luaL_error(L, "lua: invalid number");
+
+    long msec = (long)lua_tointeger(L, 1);
+    do_sleep(msec);
+
+    return 0;
+}
+
 static const luaL_Reg luaV_module[] = {
     {"command", luaV_command},
     {"eval", luaV_eval},
@@ -1916,6 +1931,7 @@ static const luaL_Reg luaV_module[] = {
     {"window", luaV_window},
     {"open", luaV_open},
     {"type", luaV_type},
+    {"sleep", luaV_sleep},
     {NULL, NULL}
 };
 

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -540,6 +540,11 @@ func Test_lua_beep()
   call assert_beeps('lua vim.beep()')
 endfunc
 
+" Test vim.sleep()
+func Test_lua_beep()
+  lua vim.sleep(100)
+endfunc
+
 " Test errors in luaeval()
 func Test_luaeval_error()
   " Compile error


### PR DESCRIPTION
 [vim-lsp](https://github.com/prabirshrestha/vim-lsp) by nature is async but in order to support features such as format document during save it requires us to be sync. We hack around this vimscript by using sleep so others can events in queue can be preprocessed. I would like to do something similar in lua.

Here is a vimscript pattern we currently use.

```vim
let data = {}
let req_id = s:send_requesst({ 'on_response': {res->data[res]=res} })
while !s:is_done(req_id)
   sleep 10ms
endwhile
echom json_encode(data['res'])
```

This now allows use to use `vim.sleep(1000)` directly from lua. VimScript supports some advanced features such as using minutes or milliseconds but when looking at `do_sleep` I noticed it takes only long which is milliseconds. And since I'm looking for perf, it only supports ms. converting from min to ms should be a simple math so don't think it will be an issue.

I currently don't see this api neovim except via `require('luv').sleep(1000)`. If both parties agree might be good to also support `vim.sleep()` for neovim which will internally use luv.