### PR TITLE
add vim.timer_stop({timer}) for lua

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -195,6 +195,11 @@ Vim evaluation and command execution, and others.
 
 	vim.beep()		Beeps.
 
+	vim.timer_stop({timer}) Stop a timer. (see |timer_stop|)
+				{timer} is an ID returned by timer_start().
+
+				{only available when compiled with the |+timers| feature}
+
 	vim.open({fname})	Opens a new buffer for file {fname} and
 				returns it. Note that the buffer is not set as
 				current.

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -1903,6 +1903,28 @@ luaV_type(lua_State *L)
     return 1;
 }
 
+#ifdef FEAT_TIMERS
+    static int
+luaV_timer_stop(lua_State *L)
+{
+    if (lua_gettop(L) != 1)
+	return luaL_error(L, "lua: 1 argugment required");
+
+    if (!lua_isnumber(L, 1))
+	return luaL_error(L, "lua: invalid number");
+
+    typval_T tv;
+    tv.v_type = VAR_NUMBER;
+    tv.vval.v_number = (varnumber_T) lua_tointeger(L, 1);
+
+    f_timer_stop(&tv, NULL);
+
+    clear_tv(&tv);
+
+    return 0;
+}
+#endif
+
 static const luaL_Reg luaV_module[] = {
     {"command", luaV_command},
     {"eval", luaV_eval},
@@ -1916,6 +1938,9 @@ static const luaL_Reg luaV_module[] = {
     {"window", luaV_window},
     {"open", luaV_open},
     {"type", luaV_type},
+#ifdef FEAT_TIMERS
+    {"timer_stop", luaV_timer_stop},
+#endif
     {NULL, NULL}
 };
 


### PR DESCRIPTION
I was planning to use `luaV_totypval` but by default it seems to prefer float when float exists so call to `timer_stop(float)` fails. 

I couldn't get `vim.timer_start()` to work since `luaV_totypval` doesn't seem to handle `LUA_TFUNCTION`. If there is any lua expert to help out would be great. It would be good to make functions work seamless with vimscript and lua. I believe neovim supports this.

Timers are heavily used in autocomplete plugins to delay sorting or requesting new completion requests so having it as first class in lua interface would be great.

It uses the same infrastructure underneath so one can start a timer in vimscript and stop it in lua.

```vim
let s:v = 0
function! s:log(x) 
    let s:v += 1
    echom s:v
endfunction

let s:id = timer_start(1000, {t->s:log(t)}, { 'repeat': -1 })

call timer_start(5000, {t->luaeval('vim.timer_stop(vim.eval("s:id"))')})
```

Here is an api I was thinking for timers which looks exactly like vimscript timers.

```lua
vim.timer_start(1000, function(timer)
    print("hi from timer")
end, { repeat = -1 })
```

