### PR TITLE
python indent: do not override after parenthesis

### DIFF
--- a/runtime/indent/python.vim
+++ b/runtime/indent/python.vim
@@ -28,6 +28,11 @@ set cpo&vim
 
 let s:maxoff = 50	" maximum number of lines to look backwards for ()
 
+" See if the specified line is already user-dedented from the expected value.
+function s:Dedented(lnum, expected)
+  return indent(a:lnum) <= a:expected - shiftwidth()
+endfunction
+
 function GetPythonIndent(lnum)
 
   " If this line is explicitly joined: If the previous line was also joined,
@@ -158,12 +163,12 @@ function GetPythonIndent(lnum)
   " If the previous line was a stop-execution statement...
   if getline(plnum) =~ '^\s*\(break\|continue\|raise\|return\|pass\)\>'
     " See if the user has already dedented
-    if indent(a:lnum) > indent(plnum) - shiftwidth()
-      " If not, recommend one dedent
-      return indent(plnum) - shiftwidth()
+    if s:Dedented(a:lnum, indent(plnum))
+      " If so, trust the user
+      return -1
     endif
-    " Otherwise, trust the user
-    return -1
+    " If not, recommend one dedent
+    return indent(plnum) - shiftwidth()
   endif
 
   " If the current line begins with a keyword that lines up with "try"
@@ -191,7 +196,7 @@ function GetPythonIndent(lnum)
     endif
 
     " Or the user has already dedented
-    if indent(a:lnum) <= plindent - shiftwidth()
+    if s:Dedented(a:lnum, plindent)
       return -1
     endif
 
@@ -203,7 +208,12 @@ function GetPythonIndent(lnum)
   "       + c)
   " here
   if parlnum > 0
-    return plindent
+    " ...unless the user has already dedented
+    if s:Dedented(a:lnum, plindent)
+        return -1
+    else
+        return plindent
+    endif
   endif
 
   return -1


### PR DESCRIPTION
Problem:  Vim overrides user-specified dedentation after parenthetical
          statement.
Solution: Check for user-specified dedentation, as is done elsewhere.
          (closes #6060)

Consider:
```
class Foo:
    def foo1():
        return (1
                + 2)

    def bar1():
        pass

    def foo2():
        return (
            1,
            2,
        )

    def bar2():
        pass
```

Without the patch, vim will prefer to indent the `def bar1` and `def
bar2` lines to the same level as the preceding `return` statements, even
though that is clearly not desired.

To fix this, only indent when the user has not dedented. Factor this
common check out into a function rather than repeating it.