### PR TITLE
add vim.call() for lua and vim.fn.*

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -199,6 +199,13 @@ Vim evaluation and command execution, and others.
 				returns it. Note that the buffer is not set as
 				current.
 
+	vim.fn			Proxy to call vim functions. Proxy methods are
+				created on demand.
+				Examples: >
+					:lua print(vim.fn.has('timers'))
+<
+
+
 
 ==============================================================================
 3. List userdata					*lua-list*

--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -199,13 +199,18 @@ Vim evaluation and command execution, and others.
 				returns it. Note that the buffer is not set as
 				current.
 
+	vim.call({name} [,{args}])
+				Proxy to call vim function named {name} with 
+				{args} as arguments.
+
+				Examples: >
+					:lua print(vim.call('has', 'timers'))
+<
 	vim.fn			Proxy to call vim functions. Proxy methods are
 				created on demand.
 				Examples: >
 					:lua print(vim.fn.has('timers'))
 <
-
-
 
 ==============================================================================
 3. List userdata					*lua-list*

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -2042,6 +2042,17 @@ luaV_setref(lua_State *L)
     return 1;
 }
 
+#define LUA_VIM_FN_CODE \
+    "vim.fn = setmetatable({}, {"\
+    "  __index = function (t, key)"\
+    "    local function _fn(...)"\
+    "      return vim.call(key, ...)"\
+    "    end"\
+    "    t[key] = _fn"\
+    "    return _fn"\
+    "  end"\
+    "})"
+
     static int
 luaopen_vim(lua_State *L)
 {
@@ -2097,6 +2108,8 @@ luaopen_vim(lua_State *L)
     lua_pushvalue(L, 1); // cache table
     luaV_openlib(L, luaV_module, 1);
     lua_setglobal(L, LUAVIM_NAME);
+    // custom code
+    luaL_dostring(L, LUA_VIM_FN_CODE);
     return 0;
 }
 

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -568,8 +568,17 @@ luaV_totypval(lua_State *L, int pos, typval_T *tv)
 	    break;
 	case LUA_TNUMBER:
 #ifdef FEAT_FLOAT
-	    tv->v_type = VAR_FLOAT;
-	    tv->vval.v_float = (float_T) lua_tonumber(L, pos);
+	{
+	    const lua_Number n = lua_tonumber(L, pos);
+	    if (n > (lua_Number)INT64_MAX || n < (lua_Number)INT64_MIN
+		|| ((lua_Number)((varnumber_T)n)) != n) {
+		tv->v_type = VAR_FLOAT;
+		tv->vval.v_float = (float_T)n;
+	    } else {
+		tv->v_type = VAR_NUMBER;
+		tv->vval.v_number = (varnumber_T)n;
+	    }
+	}
 #else
 	    tv->v_type = VAR_NUMBER;
 	    tv->vval.v_number = (varnumber_T) lua_tointeger(L, pos);

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -33,7 +33,7 @@ func Test_lua_eval()
   " lua.eval with a number
   lua v = vim.eval('123')
   call assert_equal('number', luaeval('vim.type(v)'))
-  call assert_equal(123.0, luaeval('v'))
+  call assert_equal(123, luaeval('v'))
 
   " lua.eval with a string
   lua v = vim.eval('"abc"')
@@ -119,6 +119,12 @@ func Test_lua_window_line_col()
   call assert_fails('lua vim.window().line = 10',
         \           '[string "vim chunk"]:1: line out of range')
   bwipe!
+endfunc
+
+" Test vim.fn.*
+func Test_lua_fn()
+  call assert_equal(has('lua'), luaeval('vim.fn.has("lua")'))
+  call assert_equal(printf("Hello %s", "vim"), luaeval('vim.fn.printf("Hello %s", "vim")'))
 endfunc
 
 " Test setting the current window
@@ -252,7 +258,7 @@ endfunc
 func Test_lua_buffer_number_lines()
   new
   call setline(1, ['a', 'b', 'c'])
-  call assert_equal(3.0, luaeval('#vim.buffer()'))
+  call assert_equal(3, luaeval('#vim.buffer()'))
   bwipe!
 endfunc
 
@@ -311,15 +317,15 @@ func Test_lua_list()
   lua l:add(nil)
   lua l:add(vim.eval("[1, 2, 3]"))
   lua l:add(vim.eval("{'a':1, 'b':2, 'c':3}"))
-  call assert_equal([123.0, 'abc', v:true, v:false, v:null, [1, 2, 3], {'a': 1, 'b': 2, 'c': 3}], l)
-  call assert_equal(7.0, luaeval('#l'))
+  call assert_equal([123, 'abc', v:true, v:false, v:null, [1, 2, 3], {'a': 1, 'b': 2, 'c': 3}], l)
+  call assert_equal(7, luaeval('#l'))
   call assert_match('^list: \%(0x\)\?\x\+$', luaeval('tostring(l)'))
 
   lua l[0] = 124
   lua l[5] = nil
   lua l:insert('first')
   lua l:insert('xx', 3)
-  call assert_equal(['first', 124.0, 'abc', 'xx', v:true, v:false, v:null, {'a': 1, 'b': 2, 'c': 3}], l)
+  call assert_equal(['first', 124, 'abc', 'xx', v:true, v:false, v:null, {'a': 1, 'b': 2, 'c': 3}], l)
 
   lockvar 1 l
   call assert_fails('lua l:add("x")', '[string "vim chunk"]:1: list is locked')
@@ -355,16 +361,16 @@ func Test_lua_recursive_list()
   lua l = vim.list():add(1):add(2)
   lua l = l:add(l)
 
-  call assert_equal(1.0, luaeval('l[0]'))
-  call assert_equal(2.0, luaeval('l[1]'))
+  call assert_equal(1, luaeval('l[0]'))
+  call assert_equal(2, luaeval('l[1]'))
 
-  call assert_equal(1.0, luaeval('l[2][0]'))
-  call assert_equal(2.0, luaeval('l[2][1]'))
+  call assert_equal(1, luaeval('l[2][0]'))
+  call assert_equal(2, luaeval('l[2][1]'))
 
-  call assert_equal(1.0, luaeval('l[2][2][0]'))
-  call assert_equal(2.0, luaeval('l[2][2][1]'))
+  call assert_equal(1, luaeval('l[2][2][0]'))
+  call assert_equal(2, luaeval('l[2][2][1]'))
 
-  call assert_equal('[1.0, 2.0, [...]]', string(luaeval('l')))
+  call assert_equal('[1, 2, [...]]', string(luaeval('l')))
 
   call assert_match('^list: \%(0x\)\?\x\+$', luaeval('tostring(l)'))
   call assert_equal(luaeval('tostring(l)'), luaeval('tostring(l[2])'))
@@ -386,15 +392,15 @@ func Test_lua_dict()
   lua d[3] = false
   lua d[4] = vim.eval("[1, 2, 3]")
   lua d[5] = vim.eval("{'a':1, 'b':2, 'c':3}")
-  call assert_equal({'0':123.0, '1':'abc', '2':v:true, '3':v:false, '4': [1, 2, 3], '5': {'a':1, 'b':2, 'c':3}}, d)
-  call assert_equal(6.0, luaeval('#d'))
+  call assert_equal({'0':123, '1':'abc', '2':v:true, '3':v:false, '4': [1, 2, 3], '5': {'a':1, 'b':2, 'c':3}}, d)
+  call assert_equal(6, luaeval('#d'))
   call assert_match('^dict: \%(0x\)\?\x\+$', luaeval('tostring(d)'))
 
   call assert_equal('abc', luaeval('d[1]'))
 
   lua d[0] = 124
   lua d[4] = nil
-  call assert_equal({'0':124.0, '1':'abc', '2':v:true, '3':v:false, '5': {'a':1, 'b':2, 'c':3}}, d)
+  call assert_equal({'0':124, '1':'abc', '2':v:true, '3':v:false, '5': {'a':1, 'b':2, 'c':3}}, d)
 
   lockvar 1 d
   call assert_fails('lua d[6] = 1', '[string "vim chunk"]:1: dict is locked')
@@ -441,16 +447,16 @@ func Test_lua_blob()
 
   lua b = vim.blob("\x00\x00\x00\x00")
   call assert_equal(0z00000000, luaeval('b'))
-  call assert_equal(4.0, luaeval('#b'))
+  call assert_equal(4, luaeval('#b'))
   lua b[0], b[1], b[2], b[3] = 1, 32, 256, 0xff
   call assert_equal(0z012000ff, luaeval('b'))
   lua b[4] = string.byte("z", 1)
   call assert_equal(0z012000ff.7a, luaeval('b'))
-  call assert_equal(5.0, luaeval('#b'))
+  call assert_equal(5, luaeval('#b'))
   call assert_fails('lua b[#b+1] = 0x80', '[string "vim chunk"]:1: index out of range')
   lua b:add("12ab")
   call assert_equal(0z012000ff.7a313261.62, luaeval('b'))
-  call assert_equal(9.0, luaeval('#b'))
+  call assert_equal(9, luaeval('#b'))
   call assert_fails('lua b:add(nil)', '[string "vim chunk"]:1: string expected, got nil')
   call assert_fails('lua b:add(true)', '[string "vim chunk"]:1: string expected, got boolean')
   call assert_fails('lua b:add({})', '[string "vim chunk"]:1: string expected, got table')
@@ -552,12 +558,12 @@ endfunc
 " Test :luafile foo.lua
 func Test_luafile()
   call delete('Xlua_file')
-  call writefile(["str = 'hello'", "num = 123.0" ], 'Xlua_file')
+  call writefile(["str = 'hello'", "num = 123" ], 'Xlua_file')
   call setfperm('Xlua_file', 'r-xr-xr-x')
 
   luafile Xlua_file
   call assert_equal('hello', luaeval('str'))
-  call assert_equal(123.0, luaeval('num'))
+  call assert_equal(123, luaeval('num'))
 
   lua str, num = nil
   call delete('Xlua_file')

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -121,6 +121,12 @@ func Test_lua_window_line_col()
   bwipe!
 endfunc
 
+" Test vim.call
+func Test_lua_call()
+  call assert_equal(has('lua'), luaeval('vim.call("has", "lua")'))
+  call assert_equal(printf("Hello %s", "vim"), luaeval('vim.call("printf", "Hello %s", "vim")'))
+endfunc
+
 " Test vim.fn.*
 func Test_lua_fn()
   call assert_equal(has('lua'), luaeval('vim.fn.has("lua")'))


### PR DESCRIPTION
Based on https://github.com/vim/vim/pull/6056#issuecomment-626442530 neovim > v0.5.0 will have support for `vim.fn` which is already in their master.

There are two new apis exposed to lua interface i.e. `vim.call` and `vim.fn`.

- [x] `:lua print(vim.call('has', 'nvim'))`
- [x] `:lua vim.fn.has('nvim')`
- [x] document `vim.call`
- [x] document `vim.fn`
- [x] add tests for `vim.call`
- [x] add tests for `vim.fn`

Additional features that can be done in different PR:

- [x] currently all everything from lua to vim is always converted to flow so certain functions such as `timer_stop` which only takes integer doesn't work. neovim seems to handle it correctly already.
- [ ] `luaV_totypval` needs to be able to convert lua functions to vimfunc. This will allow us to use functions such as `timer_start` which takes in function.