### PR TITLE
Consider a buffer changed, if encryption key is changed

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1157,8 +1157,11 @@ did_set_string_option(
 
 	if (STRCMP(curbuf->b_p_key, oldval) != 0)
 	    // Need to update the swapfile.
+	{
 	    ml_set_crypt_key(curbuf, oldval,
 			      *curbuf->b_p_cm == NUL ? p_cm : curbuf->b_p_cm);
+	    changed_internal();
+	}
     }
 
     else if (gvarp == &p_cm)

--- a/src/testdir/test_crypt.vim
+++ b/src/testdir/test_crypt.vim
@@ -110,3 +110,29 @@ func Test_crypt_key_mismatch()
   bwipe!
 endfunc
 
+func Test_crypt_set_key_changes_buffer()
+
+  new Xtest1.txt
+  call setline(1, 'nothing')
+  set cryptmethod=blowfish2
+  call feedkeys(":X\<CR>foobar\<CR>foobar\<CR>", 'xt')
+  call assert_fails(":q", "E37:")
+  w
+  set key=anotherkey
+  call assert_fails(":bw")
+  w
+  call feedkeys(":X\<CR>foobar\<CR>foobar\<CR>", 'xt')
+  call assert_fails(":bw")
+  w
+  let winnr=winnr()
+  wincmd p
+  call setwinvar(winnr, '&key', 'yetanotherkey')
+  wincmd p
+  call assert_fails(":bw")
+  w
+
+  set cryptmethod&
+  set key=
+  bwipe!
+  call delete('Xtest1.txt')
+endfunc


### PR DESCRIPTION
This is for fixing the issue mentioned in the vim_use group: https://groups.google.com/forum/#!topic/vim_use/3FRz6yBNYtg