### PR TITLE
Fix Test_gui_run_cmd_in_terminal

### DIFF
--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -841,6 +841,7 @@ endfunc
 " Test for "!" option in 'guioptions'. Use a terminal for running external
 " commands
 func Test_gui_run_cmd_in_terminal()
+  CheckFeature terminal
   let save_guioptions = &guioptions
   set guioptions+=!
   if has('win32')


### PR DESCRIPTION
When the terminal feature is not available (e.g. winpty.dll is missing),
the Test_gui_run_cmd_in_terminal test fails.
Check the terminal feature.