### PR TITLE
syntax: Add option to improve folding with attached braces

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3636,6 +3636,26 @@ DEFINING CASE						*:syn-case* *E390*
 :sy[ntax] case
 	Show either "syntax case match" or "syntax case ignore" (translated).
 
+
+DEFINING FOLDLEVEL					*:syn-foldlevel*
+
+:sy[ntax] foldlevel [start | minimum]
+	This defines how the foldlevel of a line is computed when using
+	foldmethod=syntax (see |fold-syntax| and |:syn-fold|):
+
+	start:		Use level of item containing start of line.
+	minimum:	Use lowest local-minimum level of items on line.
+
+	The default is 'start'.  Use 'minimum' to search a line horizontally
+	for the lowest level contained on the line that is followed by a
+	higher level.  This produces more natural folds when syntax items
+	may close and open horizontally within a line.
+
+:sy[ntax] foldlevel
+	Show either "syntax foldlevel start" or "syntax foldlevel minimum".
+
+	{not meaningful when Vim was compiled without |+folding| feature}
+
 SPELL CHECKING						*:syn-spell*
 
 :sy[ntax] spell [toplevel | notoplevel | default]
@@ -4099,6 +4119,8 @@ This will make each {} block form one fold.
 The fold will start on the line where the item starts, and end where the item
 ends.  If the start and end are within the same line, there is no fold.
 The 'foldnestmax' option limits the nesting of syntax folds.
+See |:syn-foldlevel| to control how the foldlevel of a line is computed
+from its syntax items.
 {not available when Vim was compiled without |+folding| feature}
 
 

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -504,6 +504,13 @@ syn match	vimGroupAdd	contained	"add="	nextgroup=vimGroupList
 syn match	vimGroupRem	contained	"remove="	nextgroup=vimGroupList
 syn cluster vimFuncBodyList add=vimSynType,vimGroupAdd,vimGroupRem
 
+" Syntax: foldlevel {{{2
+syn keyword	vimSynType	contained	foldlevel	skipwhite nextgroup=vimSynFoldMethod,vimSynFoldMethodError
+if !exists("g:vimsyn_noerror") && !exists("g:vimsyn_novimsynfoldmethoderror")
+ syn match	vimSynFoldMethodError	contained	"\i\+"
+endif
+syn keyword	vimSynFoldMethod	contained	start	minimum
+
 " Syntax: iskeyword {{{2
 syn keyword	vimSynType	contained	iskeyword	skipwhite nextgroup=vimIskList
 syn match	vimIskList	contained	'\S\+'	contains=vimIskSep
@@ -846,6 +853,7 @@ if !exists("skip_vim_syntax_inits")
   hi def link vimMapModErr	vimError
   hi def link vimSubstFlagErr	vimError
   hi def link vimSynCaseError	vimError
+  hi def link vimSynFoldMethodError	vimError
   hi def link vimBufnrWarn	vimWarn
  endif
 
@@ -973,6 +981,8 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimSyncNone	Type
  hi def link vimSynContains	vimSynOption
  hi def link vimSynError	Error
+ hi def link vimSynFoldMethodError	Error
+ hi def link vimSynFoldMethod	Type
  hi def link vimSynKeyContainedin	vimSynContains
  hi def link vimSynKeyOpt	vimSynOption
  hi def link vimSynMtchGrp	vimSynOption

--- a/src/structs.h
+++ b/src/structs.h
@@ -2248,6 +2248,10 @@ typedef struct
 #define SYNSPL_TOP	1	// spell check toplevel text
 #define SYNSPL_NOTOP	2	// don't spell check toplevel text
 
+// values for b_syn_foldlevel: how to compute foldlevel on a line
+#define SYNFLD_START	0	/* use level of item at start of line */
+#define SYNFLD_MINIMUM	1	/* use lowest local minimum level on line */
+
 // avoid #ifdefs for when b_spell is not available
 #ifdef FEAT_SPELL
 # define B_SPELL(buf)  ((buf)->b_spell)
@@ -2342,6 +2346,7 @@ typedef struct {
     int		b_syn_slow;		// TRUE when 'redrawtime' reached
 # endif
     int		b_syn_ic;		// ignore case for :syn cmds
+    int		b_syn_foldlevel;	// how to compute foldlevel on a line
     int		b_syn_spell;		// SYNSPL_ values
     garray_T	b_syn_patterns;		// table for syntax patterns
     garray_T	b_syn_clusters;		// table for syntax clusters

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6489,6 +6489,17 @@ syn_get_stack_item(int i)
 #endif
 
 #if defined(FEAT_FOLDING) || defined(PROTO)
+    static int
+syn_cur_foldlevel(void)
+{
+    int		level = 0;
+    int		i;
+    for (i = 0; i < current_state.ga_len; ++i)
+	if (CUR_STATE(i).si_flags & HL_FOLD)
+	    ++level;
+    return level;
+}
+
 /*
  * Function called to get folding level for line "lnum" in window "wp".
  */
@@ -6496,7 +6507,6 @@ syn_get_stack_item(int i)
 syn_get_foldlevel(win_T *wp, long lnum)
 {
     int		level = 0;
-    int		i;
 
     // Return quickly when there are no fold items at all.
     if (wp->w_s->b_syn_folditems != 0
@@ -6508,9 +6518,7 @@ syn_get_foldlevel(win_T *wp, long lnum)
     {
 	syntax_start(wp, lnum);
 
-	for (i = 0; i < current_state.ga_len; ++i)
-	    if (CUR_STATE(i).si_flags & HL_FOLD)
-		++level;
+	level = syn_cur_foldlevel();
     }
     if (level > wp->w_p_fdn)
     {

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -160,7 +160,7 @@ endfunc
 
 func Test_syntax_completion()
   call feedkeys(":syn \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"syn case clear cluster conceal enable include iskeyword keyword list manual match off on region reset spell sync', @:)
+  call assert_equal('"syn case clear cluster conceal enable foldlevel include iskeyword keyword list manual match off on region reset spell sync', @:)
 
   call feedkeys(":syn case \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"syn case ignore match', @:)
@@ -689,6 +689,89 @@ func Test_syntax_after_bufdo()
   call delete('Xbbb.c')
   call delete('Xccc.c')
   call delete('Xddd.c')
+endfunc
+
+func Test_syntax_foldlevel()
+  new
+  call setline(1, [
+   \ 'void f(int a)',
+   \ '{',
+   \ '    if (a == 1) {',
+   \ '        a = 0;',
+   \ '    } else if (a == 2) {',
+   \ '        a = 1;',
+   \ '    } else {',
+   \ '        a = 2;',
+   \ '    }',
+   \ '    if (a > 0) {',
+   \ '        if (a == 1) {',
+   \ '            a = 0;',
+   \ '        } /* missing newline */ } /* end of outer if */ else {',
+   \ '        a = 1;',
+   \ '    }',
+   \ '    if (a == 1)',
+   \ '    {',
+   \ '        a = 0;',
+   \ '    }',
+   \ '    else if (a == 2)',
+   \ '    {',
+   \ '        a = 1;',
+   \ '    }',
+   \ '    else',
+   \ '    {',
+   \ '        a = 2;',
+   \ '    }',
+   \ '}',
+   \ ])
+  setfiletype c
+  syntax on
+  set foldmethod=syntax
+
+  call assert_fails('syn foldlevel start start', 'E390')
+  call assert_fails('syn foldlevel not_an_option', 'E390')
+
+  set foldlevel=1
+
+  syn foldlevel start
+  redir @c
+  syn foldlevel
+  redir END
+  call assert_equal("\nsyntax foldlevel start", @c)
+  syn sync fromstart
+  let a = map(range(3,9), 'foldclosed(v:val)')
+  call assert_equal([3,3,3,3,3,3,3], a) " attached cascade folds together
+  let a = map(range(10,15), 'foldclosed(v:val)')
+  call assert_equal([10,10,10,10,10,10], a) " over-attached 'else' hidden
+  let a = map(range(16,27), 'foldclosed(v:val)')
+  let unattached_results = [-1,17,17,17,-1,21,21,21,-1,25,25,25]
+  call assert_equal(unattached_results, a) " unattached cascade folds separately
+
+  syn foldlevel minimum
+  redir @c
+  syn foldlevel
+  redir END
+  call assert_equal("\nsyntax foldlevel minimum", @c)
+  syn sync fromstart
+  let a = map(range(3,9), 'foldclosed(v:val)')
+  call assert_equal([3,3,5,5,7,7,7], a) " attached cascade folds separately
+  let a = map(range(10,15), 'foldclosed(v:val)')
+  call assert_equal([10,10,10,13,13,13], a) " over-attached 'else' visible
+  let a = map(range(16,27), 'foldclosed(v:val)')
+  call assert_equal(unattached_results, a) " unattached cascade folds separately
+
+  set foldlevel=2
+
+  syn foldlevel start
+  syn sync fromstart
+  let a = map(range(11,14), 'foldclosed(v:val)')
+  call assert_equal([11,11,11,-1], a) " over-attached 'else' hidden
+
+  syn foldlevel minimum
+  syn sync fromstart
+  let a = map(range(11,14), 'foldclosed(v:val)')
+  call assert_equal([11,11,-1,-1], a) " over-attached 'else' visible
+
+  quit!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
With `foldmethod=syntax` the foldlevel of a line is computed based on syntax items on the line.  Previously we always used the level of the syntax item containing the start of the line.  This works well in cases such as:

```c
if (...) {
  ...
}
else if (...) {
  ...
}
else {
  ...
}
```
which folds like this:

```
+---  3 lines: if (...) {---------------------------
+---  3 lines: else if (...) {----------------------
+---  3 lines: else {-------------------------------
```

However, the code:

```c
if (...) {
  ...
} else if (...) {
  ...
} else {
  ...
}
```

folds like this:

```
+---  7 lines: if (...) {---------------------------
```

We can make the latter case fold like this:

```
+---  2 lines: if (...) {---------------------------
+---  2 lines: } else if (...) {--------------------
+---  3 lines: } else {-----------------------------
```

by choosing on each line the lowest fold level that is followed by a higher fold level.

Add a syntax command

```
:syntax foldlevel [start | minimum]
```

to choose between these two methods of computing the `foldlevel` of a line.
