### PR TITLE
Fix bri with cpo-n

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1177,6 +1177,12 @@ win_line(
 		    c_final = NUL;
 		    n_extra = get_breakindent_win(wp,
 				       ml_get_buf(wp->w_buffer, lnum, FALSE));
+		    if (row == startrow)
+		    {
+			n_extra -= win_col_off2(wp);
+			if (n_extra < 0)
+			    n_extra = 0;
+		    }
 		    if (wp->w_skipcol > 0 && wp->w_p_wrap && wp->w_briopt_sbr)
 			need_showbreak = FALSE;
 		    // Correct end of highlighted area for 'breakindent',

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -696,4 +696,51 @@ func Test_breakindent19_sbr_nextpage()
   call s:close_windows('set breakindent& briopt& sbr&')
 endfunc
 
+func Test_breakindent20_cpo_n_nextpage()
+  let s:input = ""
+  call s:test_windows('setl breakindent briopt=min:14 cpo+=n number')
+  call setline(1, repeat('a', 200))
+  norm! 1gg
+  redraw!
+  let lines = s:screen_lines(1, 20)
+  let expect = [
+	\ "  1 aaaaaaaaaaaaaaaa",
+	\ "    aaaaaaaaaaaaaaaa",
+	\ "    aaaaaaaaaaaaaaaa",
+	\ ]
+  call s:compare_lines(expect, lines)
+  " Scroll down one screen line
+  setl scrolloff=5
+  norm! 5gj
+  redraw!
+  let lines = s:screen_lines(1, 20)
+  let expect = [
+	\ "--1 aaaaaaaaaaaaaaaa",
+	\ "    aaaaaaaaaaaaaaaa",
+	\ "    aaaaaaaaaaaaaaaa",
+	\ ]
+  call s:compare_lines(expect, lines)
+
+  setl briopt+=shift:2
+  norm! 1gg
+  let lines = s:screen_lines(1, 20)
+  let expect = [
+	\ "  1 aaaaaaaaaaaaaaaa",
+	\ "      aaaaaaaaaaaaaa",
+	\ "      aaaaaaaaaaaaaa",
+	\ ]
+  call s:compare_lines(expect, lines)
+  " Scroll down one screen line
+  norm! 5gj
+  let lines = s:screen_lines(1, 20)
+  let expect = [
+	\ "--1   aaaaaaaaaaaaaa",
+	\ "      aaaaaaaaaaaaaa",
+	\ "      aaaaaaaaaaaaaa",
+	\ ]
+  call s:compare_lines(expect, lines)
+
+  call s:close_windows('set breakindent& briopt& cpo& number&')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #5986.

Adjust extra spaces in the first row.
(Not sure this should be adjusted in this function (win_line()) or in get_breakindent_win().)