### PR TITLE
Fix flakyness of test_channel on FreeBSD

### DIFF
--- a/src/testdir/test_channel.py
+++ b/src/testdir/test_channel.py
@@ -21,6 +21,9 @@ except ImportError:
 
 class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
+    def setup(self):
+        self.request.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
     def handle(self):
         print("=== socket opened ===")
         while True:

--- a/src/testdir/test_netbeans.vim
+++ b/src/testdir/test_netbeans.vim
@@ -609,7 +609,7 @@ func Nb_basic(port)
 
   " detach
   call appendbufline(cmdbufnr, '$', 'detach_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 6)')
+  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 8)')
   call WaitForAssert({-> assert_equal('0:disconnect=91', readfile("Xnetbeans")[-1])})
 
   " the connection was closed


### PR DESCRIPTION
Test_communicate sometimes fails on Cirrus-CI FreeBSD because of so-called "ACK delayed" problem.
Therefore need set "TCP_NODELAY" option to socket.

**Detail**

When vim send `[n,"split"]` message, the test server (test_channel.py) replies 2 messages: `["ex","let ` and `g:split = 123"]`.
After the server sent the first message (and did sleep 10msec), tries to send the second message after receiving ACK from vim (according to Nagle algorithm), but vim will delay ACK corresponding to 1st message, so 2nd message can delay and timeout.

----

In addition, fix the expected value of the line number in Test_nb_basic.