### PR TITLE
make it easy to import lua modules for plugin authors

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -2075,7 +2075,14 @@ luaV_setref(lua_State *L)
     "local last_vim_paths = {}\n"\
     "vim._update_package_paths = function ()\n"\
     "  local cur_vim_paths = {}\n"\
-    "  local rtps = vim.eval('split(&runtimepath, \",\")')\n"\
+    "  local function split(s, delimiter)\n"\
+    "    result = {}\n"\
+    "    for match in (s..delimiter):gmatch(\"(.-)\"..delimiter) do\n"\
+    "      table.insert(result, match)\n"\
+    "    end\n"\
+    "    return result\n"\
+    "  end\n"\
+    "  local rtps = split(vim.eval('&runtimepath'), ',')\n"\
     "  local sep = package.config:sub(1, 1)\n"\
     "  for _, key in ipairs({'path', 'cpath'}) do\n"\
     "    local orig_str = package[key] .. ';'\n"\

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -2395,4 +2395,17 @@ set_ref_in_lua(int copyID)
     return aborted;
 }
 
+    void
+update_package_paths_in_lua()
+{
+    if (lua_isopen())
+    {
+	lua_getglobal(L, "vim");
+	lua_getfield(L, -1, "_update_package_paths");
+
+	if (lua_pcall(L, 0, 0, 0))
+	    luaV_emsg(L);
+    }
+}
+
 #endif

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -2402,6 +2402,11 @@ did_set_string_option(
 	    setmouse();		    // in case 'mouse' changed
     }
 
+#if defined(FEAT_LUA) || defined(PROTO)
+    if (varp == &p_rtp)
+	update_package_paths_in_lua();
+#endif
+
     if (curwin->w_curswant != MAXCOL
 		   && (get_option_flags(opt_idx) & (P_CURSWANT | P_RALL)) != 0)
 	curwin->w_set_curswant = TRUE;

--- a/src/proto/if_lua.pro
+++ b/src/proto/if_lua.pro
@@ -8,4 +8,5 @@ void lua_buffer_free(buf_T *o);
 void lua_window_free(win_T *o);
 void do_luaeval(char_u *str, typval_T *arg, typval_T *rettv);
 int set_ref_in_lua(int copyID);
+void update_package_paths_in_lua();
 /* vim: set ft=c : */

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -536,6 +536,12 @@ func Test_lua_open()
   %bwipe!
 endfunc
 
+func Test_update_package_paths()
+  set runtimepath+=./testluaplugin
+  lua vim._update_package_paths()
+  call assert_equal("hello from lua", luaeval("require('testluaplugin').hello()"))
+endfunc
+
 " Test vim.line()
 func Test_lua_line()
   new

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -538,7 +538,6 @@ endfunc
 
 func Test_update_package_paths()
   set runtimepath+=./testluaplugin
-  lua vim._update_package_paths()
   call assert_equal("hello from lua", luaeval("require('testluaplugin').hello()"))
 endfunc
 

--- a/src/testdir/testluaplugin/lua/testluaplugin/hello.lua
+++ b/src/testdir/testluaplugin/lua/testluaplugin/hello.lua
@@ -1,0 +1,7 @@
+local function hello()
+    return "hello from lua"
+end
+
+return {
+    hello = hello
+}

--- a/src/testdir/testluaplugin/lua/testluaplugin/init.lua
+++ b/src/testdir/testluaplugin/lua/testluaplugin/init.lua
@@ -1,0 +1,5 @@
+local hello = require('testluaplugin/hello').hello
+
+return {
+    hello = hello
+}


### PR DESCRIPTION
Currently it is difficult to require lua modules for a plugin and requires changing `package.path`. Neovim makes this easy by modifying the `package.path` so the plugin authors don't need to worry about managing that path.

Here is how it looks like before this change.

```vim
let s:is_nvim = has('nvim')
let s:has_lua = has('nvim-0.5.0') || (has('lua') && has('patch-8.2.0782')) " https://github.com/vim/vim/pull/6063

if s:has_lua
    if !s:is_nvim
        " make vim behave like neovim
        let s:plugin_dir = fnamemodify(expand('<sfile>:p:h') . '/../', ':p:h:gs?\\?/?')
        lua package.path = vim.eval("s:plugin_dir") .. '/lua/?.lua;' .. vim.eval("s:plugin_dir") .. '/lua/?/init.lua;' .. package.path
    endif
    lua asyncomplete = require('asyncomplete')
    lua asyncomplete.init()
else
    " TODO: fallback to vimscript so it works when lua is not available
endif
```

After this change it simplifies the code.

```vim
let s:has_lua = has('nvim-0.5.0') || (has('lua') && has('patch-8.2.0782')) " https://github.com/vim/vim/pull/6063

if s:has_lua
    lua asyncomplete = require('asyncomplete')
    lua asyncomplete.init()
else
    " TODO: fallback to vimscript so it works when lua is not available
endif
```

I can then add my lua files as follows for a plugin

```
asyncomplete.vim
  autoload
    asyncomplete.vim
  lua
    asyncomplete
      init.lua
      utils.lua
  plugin
    asyncomplete.vim
```

This allows me to just call `require('asyncomplete')` or `require('asyncomplete/utils')`. As a lua plugin author this simplifies requiring modules a lot.

I also updated `#define` scripts to include `\n` so it aligns with how it looks like. `LUA_VIM_UPDATE_PACKAGE_PATHS` comes from Neovim.