### PR TITLE
libvterm failed to compile on Windows in CI

### DIFF
--- a/src/libvterm/src/state.c
+++ b/src/libvterm/src/state.c
@@ -1780,8 +1780,7 @@ static int on_resize(int rows, int cols, void *user)
       }
 
       for( ; row < rows; row++) {
-	VTermLineInfo lineInfo = (VTermLineInfo){0};
-	lineInfo.doublewidth = 0;
+	VTermLineInfo lineInfo = {0};
 	newlineinfo[row] = lineInfo;
       }
 


### PR DESCRIPTION
This PR should fix a build error on Windows CI (AppVeyor).

While looking at this, I also noticed that `struct VTermLineInfo` in `vterm.h` uses bitfields, so I assume saving memory there matters there:
```
typedef struct {
  unsigned int    doublewidth:1;     /* DECDWL or DECDHL line */
  unsigned int    doubleheight:2;    /* DECDHL line (1=top 2=bottom) */
  unsigned int    continuation:1;    /* Line is a flow continuation of the previous */
} VTermLineInfo;
```
Yet `sizeof(VTermLineInfo)` is 4 and could potentially be 1. if we did:

```
typedef struct {
  unsigned char    doublewidth:1;     /* DECDWL or DECDHL line */
  unsigned char    doubleheight:2;    /* DECDHL line (1=top 2=bottom) */
  unsigned char    continuation:1;    /* Line is a flow continuation of the previous */
} VTermLineInfo;
```
That builds with gcc or clang, but I think that to be pedantic, I recall reading that bitfields should use `int` or `unsigned int` so it's maybe not portable (not sure).