### PR TITLE
Vim9: Fix :def and :function with ! doesn't work

### DIFF
--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -802,5 +802,42 @@ def Test_call_closure_not_compiled()
   assert_equal('sometext', GetResult(g:Ref))
 enddef
 
+def Test_def_with_bang()
+  let script =<< trim END
+    vim9script
+
+    def! FuncWithBang(): void
+    enddef
+  END
+  CheckScriptSuccess(script)
+
+  script =<< trim END
+    vim9script
+
+    def! Func(): string
+      return 'first'
+    enddef
+    def! Func(): string
+      return 'replaced'
+    enddef
+
+    assert_equal('replaced', Func())
+  END
+  CheckScriptSuccess(script)
+
+  script =<< trim END
+    vim9script
+
+    def! Func(): string
+      return 'first'
+    enddef
+    def! Func(arg: string): string
+      return 'replaced ' .. arg
+    enddef
+
+    assert_equal('replaced arg', Func('arg'))
+  END
+  CheckScriptSuccess(script)
+enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -88,8 +88,14 @@ ex_vim9script(exarg_T *eap)
 	    // It will read upto the matching :endded or :endfunction.
 	    eap->cmdidx = *line == 'f' ? CMD_function : CMD_def;
 	    eap->cmd = line;
+	    if (*p == '!')
+	    {
+		eap->forceit = TRUE;
+		p = skipwhite(++p);
+	    }
+	    else
+		eap->forceit = FALSE;
 	    eap->arg = p;
-	    eap->forceit = FALSE;
 	    ufunc = def_function(eap, NULL, NULL, FALSE);
 
 	    if (ufunc != NULL && *line == 'd' && ga_grow(&func_ga, 1) == OK)


### PR DESCRIPTION
**Problem**
The E129 error is given when using `:def!` or `:function!` in vim9script files.

```vim
vim9script  " This line is necessary.

def! Func1()  " ==> E129: Function name required
enddef

function! Func2()  " ==> E129: Function name required
endfunction
```

**Solution**
Handle `!`.