### PR TITLE
Fixed clang compilation warning

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2603,9 +2603,9 @@ f_float2nr(typval_T *argvars, typval_T *rettv)
 
     if (get_float_arg(argvars, &f) == OK)
     {
-	if (f <= -VARNUM_MAX + DBL_EPSILON)
+	if (f <= (float_T)-VARNUM_MAX + DBL_EPSILON)
 	    rettv->vval.v_number = -VARNUM_MAX;
-	else if (f >= VARNUM_MAX - DBL_EPSILON)
+	else if (f >= (float_T)VARNUM_MAX - DBL_EPSILON)
 	    rettv->vval.v_number = VARNUM_MAX;
 	else
 	    rettv->vval.v_number = (varnumber_T)f;


### PR DESCRIPTION
This PR fixes the following warning give by clang:
```
clang-11 -c -I. -Iproto -DHAVE_CONFIG_H     -g -O3 -Wall -Wextra -Wshadow -Wmissing-prototypes -Wpedantic -Wunreachable-code -Wunused-result -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/evalfunc.o evalfunc.c
evalfunc.c:2606:11: warning: implicit conversion from 'long long' to 'double' changes value from -9223372036854775807 to -9223372036854775808 [-Wimplicit-const-int-float-conversion]
        if (f <= -VARNUM_MAX + DBL_EPSILON)
                 ^~~~~~~~~~~ ~
evalfunc.c:2608:16: warning: implicit conversion from 'long long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-const-int-float-conversion]
        else if (f >= VARNUM_MAX - DBL_EPSILON)
                      ^~~~~~~~~~ ~
./structs.h:1284:23: note: expanded from macro 'VARNUM_MAX'
#  define VARNUM_MAX            LLONG_MAX
                                ^~~~~~~~~
/usr/lib/llvm-11/lib/clang/11.0.0/include/limits.h:82:20: note: expanded from macro 'LLONG_MAX'
#define LLONG_MAX  __LONG_LONG_MAX__
                   ^~~~~~~~~~~~~~~~~
<built-in>:39:27: note: expanded from here
#define __LONG_LONG_MAX__ 9223372036854775807LL
                          ^~~~~~~~~~~~~~~~~~~~~
```