### PR TITLE
Fix terminal test when feature 'termguicolors' is not available

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1009,7 +1009,7 @@ func Test_terminal_term_start_empty_command()
   call assert_fails(cmd, 'E475:')
   let cmd = "call term_start('', {'term_highlight' : []})"
   call assert_fails(cmd, 'E475:')
-  if has('gui')
+  if has('gui') && has ('termguicolors')
     let cmd = "call term_start('', {'ansi_colors' : 'abc'})"
     call assert_fails(cmd, 'E475:')
     let cmd = "call term_start('', {'ansi_colors' : [[]]})"
@@ -2668,7 +2668,6 @@ endfunc
 " Test for passing invalid arguments to terminal functions
 func Test_term_func_invalid_arg()
   call assert_fails('let b = term_getaltscreen([])', 'E745:')
-  call assert_fails('let p = term_getansicolors([])', 'E745:')
   call assert_fails('let a = term_getattr(1, [])', 'E730:')
   call assert_fails('let c = term_getcursor([])', 'E745:')
   call assert_fails('let l = term_getline([], 1)', 'E745:')
@@ -2677,10 +2676,13 @@ func Test_term_func_invalid_arg()
   call assert_fails('let s = term_getstatus([])', 'E745:')
   call assert_fails('let s = term_scrape([], 1)', 'E745:')
   call assert_fails('call term_sendkeys([], "a")', 'E745:')
-  call assert_fails('call term_setansicolors([], [])', 'E745:')
   call assert_fails('call term_setapi([], "")', 'E745:')
   call assert_fails('call term_setrestore([], "")', 'E745:')
   call assert_fails('call term_setkill([], "")', 'E745:')
+  if has('termguicolors')
+    call assert_fails('let p = term_getansicolors([])', 'E745:')
+    call assert_fails('call term_setansicolors([], [])', 'E745:')
+  endif
 endfunc
 
 " Test for sending various special keycodes to a terminal


### PR DESCRIPTION
This PR fixes issue #5928 i.e. failing terminal tests when the 'termguicolors' feature is not available.

I'm not sure whether it's enough or whether it's the best way to fix it.
Help files are unclear about the behavior of `term_getansicolors()` and
`term_setansicolors)`.  It merely says:
```
{only available with GUI enabled and/or the |+termguicolor| feature}
```
Yet I can call those functions and `term_getansicolors()` seems even to work
when configuring vim as follows without the 'termguicolors' feature using:
```
./configure --with-features=normal --enable-gui=gtk3 --enable-terminal
```

Also, shouldn't `:help term_start()` indicate that its "ansi_colors" option is only
available when 'termguicolors' feature is available?

The following command does nothing without 'termguicolors',
whereas it gives E475 with 'termguicolors':
```
:call term_start('', {'ansi_colors' : repeat(['blue'], 18)})
```
Perhaps it should also give an error without the 'termguicolors'?