### PR TITLE
define %dnl comment syntax

### DIFF
--- a/runtime/syntax/spec.vim
+++ b/runtime/syntax/spec.vim
@@ -128,6 +128,7 @@ syn case match
 "sh-like comment stile, only valid in script part
 syn match shComment contained '#.*$'
 
+syn region dnlComment matchgroup=specComment start=+%dnl+ end=+$+
 syn region shQuote1 contained matchgroup=shQuoteDelim start=+'+ skip=+\\'+ end=+'+ contains=specMacroIdentifier
 syn region shQuote2 contained matchgroup=shQuoteDelim start=+"+ skip=+\\"+ end=+"+ contains=specVariables,specMacroIdentifier
 
@@ -173,6 +174,7 @@ endif
 
 "sh colors
 hi def link shComment			Comment
+hi def link dnlComment			Comment
 hi def link shIf				Statement
 hi def link shOperator			Special
 hi def link shQuote1			String


### PR DESCRIPTION
Hi,

we got a [report](https://bugzilla.redhat.com/show_bug.cgi?id=1827908) in Fedora that spec syntax file doesn't highlight %dnl comments as comments.
The following patch adds syntax highlighting for those comments, would you mind merging it?

I contacted @ignatenkobrain, the owner of spec syntax file and it looks good to him.