### PR TITLE
CI: Fix sed script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,12 @@ script:
       # Append various warning flags to CFLAGS.
       # BSD sed needs backup extension specified.
       sed -i.bak -f ci/config.mk.sed ${SRCDIR}/auto/config.mk
-      sed -i.bak -f ci/config.mk.${CC}.sed ${SRCDIR}/auto/config.mk
+      if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
+        # On macOS, the entity of gcc is clang.
+        sed -i.bak -f ci/config.mk.clang.sed ${SRCDIR}/auto/config.mk
+      else
+        sed -i.bak -f ci/config.mk.${CC}.sed ${SRCDIR}/auto/config.mk
+      fi
       make ${SHADOWOPT} -j${NPROC}
     fi
   - echo -en "travis_fold:end:build\\r\\033[0K"
@@ -141,11 +146,6 @@ script:
   - do_test make ${SHADOWOPT} ${TEST} && FOLD_MARKER=travis_fold
   - echo -en "${FOLD_MARKER}:end:test\\r\\033[0K"
 
-
-# instead of a 2*2*8 matrix (2*os + 2*compiler + 8*env),
-# exclude some builds on mac os x and linux
-# on mac os x "tiny" is always without GUI
-# linux: 2*compiler + 5*env + mac: 2*compiler + 2*env
 jobs:
   include:
     - <<: *osx

--- a/ci/config.mk.clang.sed
+++ b/ci/config.mk.clang.sed
@@ -1,1 +1,2 @@
-/^RUBY_CFLAGS\b/s/$/ -Wno-error=unknown-attributes -Wno-error=ignored-attributes/
+/^CFLAGS[[:blank:]]*=/s/$/ -Wno-error=missing-field-initializers/
+/^RUBY_CFLAGS[[:blank:]]*=/s/$/ -Wno-error=unknown-attributes -Wno-error=ignored-attributes/

--- a/ci/config.mk.gcc.sed
+++ b/ci/config.mk.gcc.sed
@@ -1,1 +1,1 @@
-/^CFLAGS\b/s/$/ -Wno-error=maybe-uninitialized/
+/^CFLAGS[[:blank:]]*=/s/$/ -Wno-error=maybe-uninitialized/

--- a/ci/config.mk.sed
+++ b/ci/config.mk.sed
@@ -1,2 +1,2 @@
-/^CFLAGS\b/s/$/ -Wall -Wextra -Wshadow -Werror/
-/^PERL_CFLAGS\b/s/$/ -Wno-error=unused-function/
+/^CFLAGS[[:blank:]]*=/s/$/ -Wall -Wextra -Wshadow -Werror/
+/^PERL_CFLAGS[[:blank:]]*=/s/$/ -Wno-error=unused-function/

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -113,6 +113,11 @@
 # include <st.h>  // for ST_STOP and ST_CONTINUE
 #endif
 
+// See above.
+#ifdef SIZEOF_TIME_T
+# undef SIZEOF_TIME_T
+#endif
+
 #undef off_t	// ruby defines off_t as _int64, Mingw uses long
 #undef EXTERN
 #undef _


### PR DESCRIPTION
Fix the regex pattern to use `[:blank:]` instead of `\b` as word boundary in order to enable BSD sed to interpret.
