### PR TITLE
Fix escape from terminal when executed `:tab drop` (Fix #6077)

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -6349,6 +6349,9 @@ ex_drop(exarg_T *eap)
     buf_T	*buf;
     tabpage_T	*tp;
 
+    if (ERROR_IF_POPUP_WINDOW || ERROR_IF_TERM_POPUP_WINDOW)
+	return;
+
     /*
      * Check if the first argument is already being edited in a window.  If
      * so, jump to that window.

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -2445,6 +2445,9 @@ func Test_popupwin_terminal_buffer()
   call assert_fails('call feedkeys("gf", "xt")', 'E863:')
   call feedkeys("a\<C-U>", 'xt')
 
+  " Cannot escape from terminal window
+  call assert_fails('tab drop xxx', 'E863:')
+
   " Cannot open a second one.
   let termbuf2 = term_start(&shell, #{hidden: 1})
   call assert_fails('call popup_create(termbuf2, #{})', 'E861:')


### PR DESCRIPTION
Add popup judgement to `:drop`