### PR TITLE
8.2.837 breaks channel_open() in the environment without inet_ntop

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -999,9 +999,10 @@ channel_open(
     for (addr = res; addr != NULL; addr = addr->ai_next)
     {
 	const char  *dst = hostname;
+	const void  *src UNUSED = NULL;
 # ifdef HAVE_INET_NTOP
-	const void  *src = NULL;
 	char	    buf[NUMBUFLEN];
+# endif
 
 	if (addr->ai_family == AF_INET6)
 	{
@@ -1017,6 +1018,7 @@ channel_open(
 	    sai->sin_port = htons(port);
 	    src = &sai->sin_addr;
 	}
+# ifdef HAVE_INET_NTOP
 	if (src != NULL)
 	{
 	    dst = inet_ntop(addr->ai_family, src, buf, sizeof(buf));


### PR DESCRIPTION
AppVeyor fails since 8.2.837 (https://github.com/vim/vim/commit/b60db8ba149b26024e6d871e8634d7fea639252a).
Vim has to set `sockaddr_in.sin_port`, but that commit wrongly made it commented out in the environment without `inet_ntop`.
I think, as another solution, should set UNUSED to `src` variable.
