### PR TITLE
use attenuated ceil rounding when calculating pango char_height

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4729,15 +4729,17 @@ gui_mch_adjust_charheight(void)
     PangoFontMetrics	*metrics;
     int			ascent;
     int			descent;
+    //int			line_height;
 
     metrics = pango_context_get_metrics(gui.text_context, gui.norm_font,
 				pango_context_get_language(gui.text_context));
     ascent  = pango_font_metrics_get_ascent(metrics);
     descent = pango_font_metrics_get_descent(metrics);
+    // line_height = pango_font_metrics_get_height(metrics); only since pango 1.44
 
     pango_font_metrics_unref(metrics);
 
-    gui.char_height = (ascent + descent + PANGO_SCALE - 1) / PANGO_SCALE
+    gui.char_height = (ascent + descent + PANGO_SCALE - 3) / PANGO_SCALE
 								+ p_linespace;
     // LINTED: avoid warning: bitwise operation on signed value
     gui.char_ascent = PANGO_PIXELS(ascent + p_linespace * PANGO_SCALE / 2);


### PR DESCRIPTION
This helps when the reported pango line height is just an epsilon largerthan the nearest multiple of `PANGO_SCALE`.
This happens frequently for bitmap fonts, whose height is a multiple of `PANGO_SCALE` and will be an epsilon smaller or larger than the nearest multiple of `PANGO_SCALE`.
For example I'm getting these numbers for a bitmap font of pixelsize 15:
```
ascent = 12293
descent = 3068
12293+3068 = 15361
15361/1024 = 15.000976562
15*1024 = 15360
```

this is only 1 larger then the nearest multiple and should _not_ beceil rounded.

Therefore this PR will floor round any value that is at most 2 largerthan the nearest multiple.

Edit:
* related [merge request](https://gitlab.freedesktop.org/xorg/app/fonttosfnt/-/merge_requests/7) on `fonttosfnt`.
* related [issue](https://gitlab.gnome.org/GNOME/pango/-/issues/477) on `pango`, which seems to no longer use bitmap font specific metrics.