### PR TITLE
Test_deadly_signal_TERM() could not be rerun if temporary files exist

### DIFF
--- a/src/testdir/test_signals.vim
+++ b/src/testdir/test_signals.vim
@@ -123,6 +123,12 @@ func Test_deadly_signal_TERM()
   if cmd =~ 'valgrind'
     throw 'Skipped: cannot test signal TERM with valgrind'
   endif
+
+  " If test fails once, it can leave temporary files and trying to rerun
+  " the test would then fail again if they are not deleted first.
+  call delete('.Xsig_TERM.swp')
+  call delete('XsetupAucmd')
+  call delete('XautoOut')
   let lines =<< trim END
     au VimLeave * call writefile(["VimLeave triggered"], "XautoOut", "a")
     au VimLeavePre * call writefile(["VimLeavePre triggered"], "XautoOut", "a")

--- a/src/testdir/test_signals.vim
+++ b/src/testdir/test_signals.vim
@@ -130,8 +130,8 @@ func Test_deadly_signal_TERM()
   call delete('XsetupAucmd')
   call delete('XautoOut')
   let lines =<< trim END
-    au VimLeave * call writefile(["VimLeave triggered"], "XautoOut", "a")
-    au VimLeavePre * call writefile(["VimLeavePre triggered"], "XautoOut", "a")
+    au VimLeave * call writefile(["VimLeave triggered"], "XautoOut", "as")
+    au VimLeavePre * call writefile(["VimLeavePre triggered"], "XautoOut", "as")
   END
   call writefile(lines, 'XsetupAucmd')
 


### PR DESCRIPTION
I ran a script that builds vim and run tests with various configurations.
I noticed that Test_deadly_signal_TERM is flaky, it sometimes fails as follows:
```
From test_signals.vim:
Executed Test_deadly_signal_TERM() in   0.103023 seconds
Found errors in Test_deadly_signal_TERM():
Caught exception in Test_deadly_signal_TERM(): Vim(let):E484: Can't open file XautoOut @ function RunTheTest[39]..Test_deadly_signal_TERM, line 32
Flaky test failed, running it again
Executed Test_deadly_signal_TERM() in  10.092695 seconds
Found errors in Test_deadly_signal_TERM():
function RunTheTest[39]..Test_deadly_signal_TERM[15]..RunVimInTerminal line 60: RunVimInTerminal() failed, screen contents: E325: ATTENTION<NL>Found a swap file by the name ".Xsig_TERM.swp"<NL>          owned by: dope   dated: Mon Jun 01 01:45:11 2020<NL>         file name: /home/dope/sb/vim/src/testdir/Xsig_TERM<NL>          modified: YES<NL>-- More --
function RunTheTest[39]..Test_deadly_signal_TERM[19]..WaitForAssert[2]..<SNR>7_WaitForCommon[11]..<lambda>7 line 1: Expected 'foo' but got '(2) An edit session for this file crashed.'
Caught exception in Test_deadly_signal_TERM(): Vim(let):E484: Can't open file XautoOut @ function RunTheTest[39]..Test_deadly_signal_TERM, line 32
Flaky test failed, running it again
Executed Test_deadly_signal_TERM() in  10.158498 seconds
Found errors in Test_deadly_signal_TERM():
function RunTheTest[39]..Test_deadly_signal_TERM[15]..RunVimInTerminal line 60: RunVimInTerminal() failed, screen contents: E325: ATTENTION<NL>Found a swap file by the name ".Xsig_TERM.swp"<NL>          owned by: dope   dated: Mon Jun 01 01:45:11 2020<NL>         file name: /home/dope/sb/vim/src/testdir/Xsig_TERM<NL>          modified: YES<NL>-- More --
function RunTheTest[39]..Test_deadly_signal_TERM[19]..WaitForAssert[2]..<SNR>7_WaitForCommon[11]..<lambda>12 line 1: Expected 'foo' but got '(2) An edit session for this file crashed.'
Caught exception in Test_deadly_signal_TERM(): Vim(let):E484: Can't open file XautoOut @ function RunTheTest[39]..Test_deadly_signal_TERM, line 32
Executed Test_signal_INT() in   0.275286 seconds
Executed Test_signal_PWR() in   0.016057 seconds
Executed Test_signal_WINCH() in   0.015293 seconds
Executed 6 tests in  24.674458 seconds
1 FAILED:
Found errors in Test_deadly_signal_TERM():
```
There are 2 issues here:
1) file `XautoOut` was somehow not created. I could not reproduce it reliably enough, but I think that test should call `writefile()` with the `s` flag to ensure it is flushed.
2) then, when retrying to run the test, the test would then always fail again with error `Found a swap file by the name ".Xsig_TERM.swp"` because swp file was still present after the first failure. Deleting temporary file before running the test should avoid that.

