### PR TITLE
undefined behavior detected when running "make test_search"

### DIFF
--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1549,7 +1549,7 @@ nfa_regatom(void)
 			while (VIM_ISDIGIT(c))
 			{
 			    long_u tmp = n * 10 + (c - '0');
-			    if (tmp <= n)
+			    if (tmp < n)
 			    {
 				// overflow.
 				emsg(_("E951: \\% value too large"));

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1541,14 +1541,21 @@ nfa_regatom(void)
 
 		default:
 		    {
-			long	n = 0;
+			long_u	n = 0;
 			int	cmp = c;
 
 			if (c == '<' || c == '>')
 			    c = getchr();
 			while (VIM_ISDIGIT(c))
 			{
-			    n = n * 10 + (c - '0');
+			    long_u tmp = n * 10 + (c - '0');
+			    if (tmp <= n)
+			    {
+				// overflow.
+				emsg(_("E951: \\% value too large"));
+				return FAIL;
+			    }
+			    n = tmp;
 			    c = getchr();
 			}
 			if (c == 'l' || c == 'c' || c == 'v')

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1560,7 +1560,7 @@ nfa_regatom(void)
 			}
 			if (c == 'l' || c == 'c' || c == 'v')
 			{
-			    int limit = INT_MAX;
+			    long_u limit = INT_MAX;
 
 			    if (c == 'l')
 			    {


### PR DESCRIPTION
This PR fixes the following error detected by ubsan (undefined behavior sanitizer) when running "make test_search" with vim-8.2.890:
```
regexp_nfa.c:1551:14: runtime error: signed integer overflow: 999999999999999999 * 10 cannot be represented in type 'long int'
```
Unsigned must be used as overflow with signed integer is undefined behavior.