### PR TITLE
Fix "WINVER" check in Make_cyg_ming

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -625,7 +625,7 @@ endif
 
 ifeq ($(CHANNEL),yes)
 DEFINES += -DFEAT_JOB_CHANNEL -DFEAT_IPV6
- ifeq ($(shell expr "$(WINVER)" \>= 0x600),1)
+ ifeq ($(shell expr "$$(($(WINVER)))" \>= "$$((0x600))"),1)
 DEFINES += -DHAVE_INET_NTOP
  endif
 endif


### PR DESCRIPTION
When `WINVER` is set to 0-prepended (e.g. 0x0600: has "0" before "6"), does not make `HAVE_INET_NTOP` defined since `expr` interprets hex number expression as simply string (I misunderstood...).
Should convert hex-expression to decimal by arithmetic expansion `$((...))`.