### PR TITLE
Recognise files like "DEBIAN/control" as debcontrol

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -430,6 +430,7 @@ au BufRead,BufNewfile *.dart,*.drt		setf dart
 
 " Debian Control
 au BufNewFile,BufRead */debian/control		setf debcontrol
+au BufNewFile,BufRead */DEBIAN/control		setf debcontrol
 au BufNewFile,BufRead control
 	\  if getline(1) =~ '^Source:'
 	\|   setf debcontrol

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -125,7 +125,7 @@ let s:filename_checks = {
     \ 'dart': ['file.dart', 'file.drt'],
     \ 'datascript': ['file.ds'],
     \ 'dcd': ['file.dcd'],
-    \ 'debcontrol': ['/debian/control'],
+    \ 'debcontrol': ['/debian/control', '/DEBIAN/control'],
     \ 'debsources': ['/etc/apt/sources.list', '/etc/apt/sources.list.d/file.list'],
     \ 'def': ['file.def'],
     \ 'denyhosts': ['denyhosts.conf'],


### PR DESCRIPTION
It's possible for such a control file to be located at `DEBIAN/control` (see e.g. https://www.debian.org/doc/debian-policy/ch-controlfields.html#binary-package-control-files-debian-control), but previously Vim wasn't aware of this fact.