### PR TITLE
Running lhelpgrep more than once in a help window doesn't jump to the help topic

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -7957,9 +7957,10 @@ ex_helpgrep(exarg_T *eap)
     {
 	apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name,
 					       curbuf->b_fname, TRUE, curbuf);
-	if (!new_qi && IS_LL_STACK(qi) && qf_find_buf(qi) == NULL)
+	// When adding a location list to an existing location list stack,
+	// if the autocmd made the stack invalid, then just return.
+	if (!new_qi && IS_LL_STACK(qi) && qf_find_win_with_loclist(qi) == NULL)
 	{
-	    // autocommands made "qi" invalid
 	    decr_quickfix_busy();
 	    return;
 	}

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -4913,4 +4913,22 @@ func Test_qftextfunc()
   call Xtest_qftextfunc('l')
 endfunc
 
+" Running :lhelpgrep command more than once in a help window, doesn't jump to
+" the help topic
+func Test_lhelpgrep_from_help_window()
+  call mkdir('Xtestdir/doc', 'p')
+  call writefile(['window'], 'Xtestdir/doc/a.txt')
+  call writefile(['buffer'], 'Xtestdir/doc/b.txt')
+  let save_rtp = &rtp
+  let &rtp = 'Xtestdir'
+  lhelpgrep window
+  lhelpgrep buffer
+  call assert_equal('b.txt', fnamemodify(@%, ":p:t"))
+  lhelpgrep window
+  call assert_equal('a.txt', fnamemodify(@%, ":p:t"))
+  let &rtp = save_rtp
+  call delete('Xtestdir', 'rf')
+  new | only!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Instead of checking whether a location list window is present, check whether
any window with the location list is present.

Also, add additional tests for bufwrite.c