### PR TITLE
Add the winid item to the argument dict for the quickfix buffer callback function

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1953,6 +1953,9 @@ following fields:
 
     quickfix	set to 1 when called for a quickfix list and 0 when called for
 		a location list.
+    winid	for a location list, set to the id of the window with the
+		location list. For a quickfix list, set to 0. Can be used in
+		getloclist() to get the location list entry.
     id		quickfix or location list identifier
     idx		index of the entry in the quickfix or location list
 

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -4822,7 +4822,7 @@ func Tqfexpr(info)
     let qfl = getqflist({'id' : a:info.id, 'idx' : a:info.idx,
           \ 'items' : 1}).items
   else
-    let qfl = getloclist(0, {'id' : a:info.id, 'idx' : a:info.idx,
+    let qfl = getloclist(a:info.winid, {'id' : a:info.id, 'idx' : a:info.idx,
           \ 'items' : 1}).items
   endif
 
@@ -4863,7 +4863,7 @@ func Xtest_qftextfunc(cchar)
       let qfl = getqflist({'id' : a:info.id, 'idx' : a:info.idx,
             \ 'items' : 1}).items
     else
-      let qfl = getloclist(0, {'id' : a:info.id, 'idx' : a:info.idx,
+      let qfl = getloclist(a:info.winid, {'id' : a:info.id, 'idx' : a:info.idx,
             \ 'items' : 1}).items
     endif
     if empty(qfl)
@@ -4877,6 +4877,11 @@ func Xtest_qftextfunc(cchar)
   Xwindow
   call assert_equal('Line 10, Col 2', getline(1))
   call assert_equal('Line 20, Col 4', getline(2))
+  Xclose
+  " Add entries to the list when the quickfix buffer is hidden
+  Xaddexpr ['F1:30:6:red']
+  Xwindow
+  call assert_equal('Line 30, Col 6', getline(3))
   Xclose
   call g:Xsetlist([], 'r', {'quickfixtextfunc' : ''})
   set quickfixtextfunc&


### PR DESCRIPTION
When the location list buffer is hidden, the 'quickfixtextfunc' cannot get the
location list entry. The following sequence of commands with a custom
'quickfixtextfunc' function will lead to errors:

set qftf=SomeFunc
lexpr ["a.txt:10:Line 10"]
lopen
lclose
lexpr ["a.txt:10:Line 10"]

To address this problem, supply the window id in the dict argument for the
callback function. This will allow the callback function to use the window id
to get the correct location list.

