### PR TITLE
Enable z= even when 'spell' is disabled

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -9537,9 +9537,8 @@ spellbadword([{sentence}])
 			echo spellbadword("the quik brown fox")
 <			['quik', 'bad'] ~
 
-		The spelling information for the current window is used.  The
-		'spell' option must be set and the value of 'spelllang' is
-		used.
+		The spelling information for the current window and the value
+		of 'spelllang' are used.
 
 		Can also be used as a |method|: >
 			GetText()->spellbadword()
@@ -9564,8 +9563,7 @@ spellsuggest({word} [, {max} [, {capital}]])
 		although it may appear capitalized.
 
 		The spelling information for the current window is used.  The
-		'spell' option must be set and the values of 'spelllang' and
-		'spellsuggest' are used.
+		values of 'spelllang' and 'spellsuggest' are used.
 
 		Can also be used as a |method|: >
 			GetWord()->spellsuggest()

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -2107,11 +2107,6 @@ Vim using lots of memory when joining lines. (John Little, 2010 Dec 3)
 BT regexp engine: After trying a \@> match and failing, submatches are not
 cleared.  See test64.
 
-Patch to make "z=" work when 'spell' is off.  Does this have nasty side
-effects?  (Christian Brabandt, 2012 Aug 5, Update 2013 Aug 12)
-Would also need to do this for spellbadword() and spellsuggest().
-https://github.com/chrisbra/vim-mq-patches/blob/master/enable_spellchecking
-
 On 64 bit MS-Windows "long" is only 32 bits, but we sometimes need to store a
 64 bits value.  Change all number options to use nropt_T and define it to the
 right type.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7596,9 +7596,30 @@ f_spellbadword(typval_T *argvars UNUSED, typval_T *rettv)
     char_u	*word = (char_u *)"";
     hlf_T	attr = HLF_COUNT;
     int		len = 0;
+#ifdef FEAT_SPELL
+    int		wo_spell_save = curwin->w_p_spell;
+
+    if (!curwin->w_p_spell)
+    {
+	did_set_spelllang(curwin);
+	curwin->w_p_spell = TRUE;
+    }
+
+    if (*curwin->w_s->b_p_spl == NUL)
+    {
+	emsg(_("E756: Spell checking is not possible"));
+	curwin->w_p_spell = wo_spell_save;
+	return;
+    }
+#endif
 
     if (rettv_list_alloc(rettv) == FAIL)
+    {
+#ifdef FEAT_SPELL
+	curwin->w_p_spell = wo_spell_save;
+#endif
 	return;
+    }
 
 #ifdef FEAT_SPELL
     if (argvars[0].v_type == VAR_UNKNOWN)
@@ -7611,7 +7632,7 @@ f_spellbadword(typval_T *argvars UNUSED, typval_T *rettv)
 	    curwin->w_set_curswant = TRUE;
 	}
     }
-    else if (curwin->w_p_spell && *curbuf->b_s.b_p_spl != NUL)
+    else if (*curbuf->b_s.b_p_spl != NUL)
     {
 	char_u	*str = tv_get_string_chk(&argvars[0]);
 	int	capcol = -1;
@@ -7633,6 +7654,7 @@ f_spellbadword(typval_T *argvars UNUSED, typval_T *rettv)
 	    }
 	}
     }
+    curwin->w_p_spell = wo_spell_save;
 #endif
 
     list_append_string(rettv->vval.v_list, word, len);
@@ -7658,13 +7680,32 @@ f_spellsuggest(typval_T *argvars UNUSED, typval_T *rettv)
     int		i;
     listitem_T	*li;
     int		need_capital = FALSE;
+    int		wo_spell_save = curwin->w_p_spell;
+
+    if (!curwin->w_p_spell)
+    {
+	did_set_spelllang(curwin);
+	curwin->w_p_spell = TRUE;
+    }
+
+    if (*curwin->w_s->b_p_spl == NUL)
+    {
+	emsg(_("E756: Spell checking is not possible"));
+	curwin->w_p_spell = wo_spell_save;
+	return;
+    }
 #endif
 
     if (rettv_list_alloc(rettv) == FAIL)
+    {
+#ifdef FEAT_SPELL
+	curwin->w_p_spell = wo_spell_save;
+#endif
 	return;
+    }
 
 #ifdef FEAT_SPELL
-    if (curwin->w_p_spell && *curwin->w_s->b_p_spl != NUL)
+    if (*curwin->w_s->b_p_spl != NUL)
     {
 	str = tv_get_string(&argvars[0]);
 	if (argvars[1].v_type != VAR_UNKNOWN)
@@ -7701,6 +7742,7 @@ f_spellsuggest(typval_T *argvars UNUSED, typval_T *rettv)
 	}
 	ga_clear(&ga);
     }
+    curwin->w_p_spell = wo_spell_save;
 #endif
 }
 

--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -471,9 +471,19 @@ spell_suggest(int count)
     int		selected = count;
     int		badlen = 0;
     int		msg_scroll_save = msg_scroll;
+    int		wo_spell_save = curwin->w_p_spell;
 
-    if (no_spell_checking(curwin))
+    if (!curwin->w_p_spell)
+    {
+	did_set_spelllang(curwin);
+	curwin->w_p_spell = TRUE;
+    }
+
+    if (*curwin->w_s->b_p_spl == NUL)
+    {
+	emsg(_("E756: Spell checking is not possible"));
 	return;
+    }
 
     if (VIsual_active)
     {
@@ -686,6 +696,7 @@ spell_suggest(int count)
     spell_find_cleanup(&sug);
 skip:
     vim_free(line);
+    curwin->w_p_spell = wo_spell_save;
 }
 
 /*

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -99,11 +99,11 @@ foobar/?
    set spelllang=Xwords.spl
    call assert_equal(['foobar', 'rare'], spellbadword('foo foobar'))
 
-  " Typo should not be detected without the 'spell' option.
+  " Typo should be detected even without the 'spell' option.
   set spelllang=en_gb nospell
   call assert_equal(['', ''], spellbadword('centre'))
-  call assert_equal(['', ''], spellbadword('My bycycle.'))
-  call assert_equal(['', ''], spellbadword('A sentence. another sentence'))
+  call assert_equal(['bycycle', 'bad'], spellbadword('My bycycle.'))
+  call assert_equal(['another', 'caps'], spellbadword('A sentence. another sentence'))
 
   call delete('Xwords.spl')
   call delete('Xwords')
@@ -130,9 +130,9 @@ endfunc
 
 " Test spellsuggest({word} [, {max} [, {capital}]])
 func Test_spellsuggest()
-  " No suggestions when spell checking is not enabled.
+  " Verify suggestions are given even when spell checking is not enabled.
   set nospell
-  call assert_equal([], spellsuggest('marrch'))
+  call assert_equal(['march', 'March'], spellsuggest('marrch', 2))
 
   set spell
 
@@ -614,6 +614,23 @@ func Test_zeq_crash()
   set maxmem=512 spell
   call feedkeys('iasdz=:\"', 'tx')
 
+  bwipe!
+endfunc
+
+" Check that z= works even when 'nospell' is set.  This test uses one of the
+" tests in Test_spellsuggest_option_number() just to verify that z= basically
+" works and that "E756: Spell checking is not enabled" is not generated.
+func Test_zeq_nospell()
+  new
+  set nospell spellsuggest=1,best
+  call setline(1, 'A baord')
+  try
+    norm $1z=
+    call assert_equal('A board', getline(1))
+  catch
+    call assert_report("Caught exception: " . v:exception)
+  endtry
+  set spell& spellsuggest&
   bwipe!
 endfunc
 

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -105,6 +105,9 @@ foobar/?
   call assert_equal(['bycycle', 'bad'], spellbadword('My bycycle.'))
   call assert_equal(['another', 'caps'], spellbadword('A sentence. another sentence'))
 
+  set spelllang=
+  call assert_fails("call spellbadword('maxch')", 'E756:')
+
   call delete('Xwords.spl')
   call delete('Xwords')
   set spelllang&
@@ -162,6 +165,10 @@ func Test_spellsuggest()
 
   call assert_fails("call spellsuggest('maxch', [])", 'E745:')
   call assert_fails("call spellsuggest('maxch', 2, [])", 'E745:')
+
+  set spelllang=
+  call assert_fails("call spellsuggest('maxch')", 'E756:')
+  set spelllang&
 
   set spell&
 endfunc
@@ -631,6 +638,17 @@ func Test_zeq_nospell()
     call assert_report("Caught exception: " . v:exception)
   endtry
   set spell& spellsuggest&
+  bwipe!
+endfunc
+
+" Check that "E756: Spell checking is not possible" is reported when z= is
+" executed and 'spelllang' is empty.
+func Test_zeq_no_spelllang()
+  new
+  set spelllang= spellsuggest=1,best
+  call setline(1, 'A baord')
+  call assert_fails('normal $1z=', 'E756:')
+  set spelllang& spellsuggest&
   bwipe!
 endfunc
 


### PR DESCRIPTION
The spell command z= and functions spellbadword() and spellsuggest() are
now functional even when 'spell' is disabled.  Documentation and tests
have been updated and the issue has been removed from todo.txt.