### PR TITLE
strptime() ignores DST

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -280,6 +280,10 @@ func Test_strptime()
 
   call assert_equal(1484653763, strptime('%Y-%m-%d %T', '2017-01-17 11:49:23'))
 
+  " Force DST and check that it's considered
+  let $TZ = 'WINTER0SUMMER,J1,J365'
+  call assert_equal(1484653763 - 3600, strptime('%Y-%m-%d %T', '2017-01-17 11:49:23'))
+
   call assert_fails('call strptime()', 'E119:')
   call assert_fails('call strptime("xxx")', 'E119:')
   call assert_equal(0, strptime("%Y", ''))

--- a/src/time.c
+++ b/src/time.c
@@ -314,6 +314,7 @@ f_strptime(typval_T *argvars, typval_T *rettv)
     char_u	*enc;
 
     CLEAR_FIELD(tmval);
+    tmval.tm_isdst = -1;
     fmt = tv_get_string(&argvars[0]);
     str = tv_get_string(&argvars[1]);
 


### PR DESCRIPTION
The strptime() function uses winter time all year long. Examples:

    :echo strptime('%F %T', strftime('%F %T')) - localtime() | " run this in summer
    3600

    :echo strftime('%F %T', strptime('%F', '2020-06-01'))
    2020-06-01 01:00:00

    :echo strftime('%F %T', strptime('%F', '2020-01-01'))
    2020-01-01 00:00:00

The fix is to set tm_isdst to -1 and let mktime(3) determine it from the
time zone.