### PR TITLE
Removed unused function: has_funcundefined(void)

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -1760,15 +1760,6 @@ has_cmdundefined(void)
     return (first_autopat[(int)EVENT_CMDUNDEFINED] != NULL);
 }
 
-/*
- * Return TRUE when there is an FuncUndefined autocommand defined.
- */
-    int
-has_funcundefined(void)
-{
-    return (first_autopat[(int)EVENT_FUNCUNDEFINED] != NULL);
-}
-
 #if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Return TRUE when there is a TextYankPost autocommand defined.

--- a/src/proto/autocmd.pro
+++ b/src/proto/autocmd.pro
@@ -23,7 +23,6 @@ int has_textchangedI(void);
 int has_textchangedP(void);
 int has_insertcharpre(void);
 int has_cmdundefined(void);
-int has_funcundefined(void);
 int has_textyankpost(void);
 int has_completechanged(void);
 void block_autocmds(void);


### PR DESCRIPTION
PR removes the unused function `has_funcundefined(void)`.