### PR TITLE
Allow to pass lua closures to vim script functions from lua

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -207,6 +207,7 @@ Vim evaluation and command execution, and others.
 	vim.fn			Proxy to call Vim functions. Proxy methods are
 				created on demand.  Example: >
 					:lua print(vim.fn.has('timers'))
+					:lua vim.fn.timer_start(1000, function (timer) print('timer callback') end)
 <
 
 ==============================================================================

--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -207,7 +207,6 @@ Vim evaluation and command execution, and others.
 	vim.fn			Proxy to call Vim functions. Proxy methods are
 				created on demand.  Example: >
 					:lua print(vim.fn.has('timers'))
-					:lua vim.fn.timer_start(1000, function (timer) print('timer callback') end)
 <
 
 ==============================================================================
@@ -334,6 +333,16 @@ Examples:
 	:lua l = d.len -- assign d as 'self'
 	:lua print(l())
 <
+Lua functions and closures are automatically converted to a vim funcref and
+can be accessed in Vim scripts.
+
+Examples:
+>
+	lua <<EOF
+	vim.fn.timer_start(1000, function(timer)
+	    print('timer callback')
+	end)
+	EOF
 
 ==============================================================================
 7. Buffer userdata					*lua-buffer*

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -2443,9 +2443,9 @@ luaV_call_lua_func(int argcount, typval_T *argvars, typval_T *rettv, void *state
     for (i = 0; i < argcount; ++i)
 	luaV_pushtypval(funcstate->L, &argvars[i]);
 
-    if (lua_pcall(funcstate->L, argcount, 1, 0) != 0)
+    if (lua_pcall(funcstate->L, argcount, 1, 0))
     {
-	luaV_emsg("failed to call");
+	luaV_emsg(funcstate->L);
 	return FCERR_OTHER;
     }
 

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -641,6 +641,15 @@ luaV_totypval(lua_State *L, int pos, typval_T *tv)
 		lua_pop(L, 4); // MTs
 	    }
 	}
+	case LUA_TFUNCTION:
+	{
+	    lua_pushvalue(L, pos);
+	    int lua_func_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+	    tv->v_type = VAR_NUMBER;
+	    tv->vval.v_number = 0;
+	    status = FAIL;
+	}
 	// FALLTHROUGH
 	default:
 	    tv->v_type = VAR_NUMBER;

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -604,7 +604,7 @@ luaV_totypval(lua_State *L, int pos, typval_T *tv)
 	    luaV_CFuncState *state = ALLOC_CLEAR_ONE(luaV_CFuncState);
 	    state->index = luaL_ref(L, LUA_REGISTRYINDEX);
 	    state->L = L;
-	    char_u *name = register_cfunc(&luaV_call_lua_func, &luaV_call_lua_func_free, (void*)state);
+	    char_u *name = register_cfunc(&luaV_call_lua_func, &luaV_call_lua_func_free, state);
 	    tv->v_type = VAR_FUNC;
 	    tv->vval.v_string = vim_strsave(name);
 	    break;
@@ -2459,7 +2459,7 @@ luaV_call_lua_func_free(void *state)
     luaV_CFuncState *funcstate = (luaV_CFuncState*)state;
     luaL_unref(L, LUA_REGISTRYINDEX, funcstate->index);
     funcstate->L = NULL;
-    VIM_CLEAR(funcstate);
+    VIM_CLEAR(state);
 }
 
 #endif

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -601,7 +601,7 @@ luaV_totypval(lua_State *L, int pos, typval_T *tv)
 	case LUA_TFUNCTION:
 	{
 	    lua_pushvalue(L, pos);
-	    luaV_CFuncState *state = malloc(sizeof(luaV_CFuncState));
+	    luaV_CFuncState *state = ALLOC_CLEAR_ONE(luaV_CFuncState);
 	    state->index = luaL_ref(L, LUA_REGISTRYINDEX);
 	    state->L = L;
 	    char_u *name = register_cfunc(&luaV_call_lua_func, &luaV_call_lua_func_free, (void*)state);
@@ -2458,7 +2458,7 @@ luaV_call_lua_func_free(void *state)
 {
     luaV_CFuncState *funcstate = (luaV_CFuncState*)state;
     luaL_unref(L, LUA_REGISTRYINDEX, funcstate->index);
-    free(funcstate);
+    vim_free(funcstate);
 }
 
 #endif

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -2458,7 +2458,7 @@ luaV_call_lua_func_free(void *state)
 {
     luaV_CFuncState *funcstate = (luaV_CFuncState*)state;
     luaL_unref(L, LUA_REGISTRYINDEX, funcstate->index);
-    vim_free(funcstate);
+    VIM_CLEAR(funcstate);
 }
 
 #endif

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -598,6 +598,17 @@ luaV_totypval(lua_State *L, int pos, typval_T *tv)
 	    tv->vval.v_number = (varnumber_T) lua_tointeger(L, pos);
 #endif
 	    break;
+	case LUA_TFUNCTION:
+	{
+	    lua_pushvalue(L, pos);
+	    luaV_CFuncState *state = malloc(sizeof(luaV_CFuncState));
+	    state->index = luaL_ref(L, LUA_REGISTRYINDEX);
+	    state->L = L;
+	    char_u *name = register_cfunc(&luaV_call_lua_func, &luaV_call_lua_func_free, (void*)state);
+	    tv->v_type = VAR_FUNC;
+	    tv->vval.v_string = vim_strsave(name);
+	    break;
+	}
 	case LUA_TUSERDATA:
 	{
 	    void *p = lua_touserdata(L, pos);
@@ -647,17 +658,6 @@ luaV_totypval(lua_State *L, int pos, typval_T *tv)
 		}
 		lua_pop(L, 4); // MTs
 	    }
-	}
-	case LUA_TFUNCTION:
-	{
-	    lua_pushvalue(L, pos);
-	    luaV_CFuncState *state = malloc(sizeof(luaV_CFuncState));
-	    state->index = luaL_ref(L, LUA_REGISTRYINDEX);
-	    state->L = L;
-	    char_u *name = register_cfunc(&luaV_call_lua_func, &luaV_call_lua_func_free, (void*)state);
-	    tv->v_type = VAR_FUNC;
-	    tv->vval.v_string = vim_strsave(name);
-	    break;
 	}
 	// FALLTHROUGH
 	default:

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -2459,7 +2459,7 @@ luaV_call_lua_func_free(void *state)
     luaV_CFuncState *funcstate = (luaV_CFuncState*)state;
     luaL_unref(L, LUA_REGISTRYINDEX, funcstate->index);
     funcstate->L = NULL;
-    VIM_CLEAR(state);
+    VIM_CLEAR(funcstate);
 }
 
 #endif

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -2458,6 +2458,7 @@ luaV_call_lua_func_free(void *state)
 {
     luaV_CFuncState *funcstate = (luaV_CFuncState*)state;
     luaL_unref(L, LUA_REGISTRYINDEX, funcstate->index);
+    funcstate->L = NULL;
     VIM_CLEAR(funcstate);
 }
 

--- a/src/proto/userfunc.pro
+++ b/src/proto/userfunc.pro
@@ -4,6 +4,7 @@ hashtab_T *func_tbl_get(void);
 int get_function_args(char_u **argp, char_u endchar, garray_T *newargs, garray_T *argtypes, int *varargs, garray_T *default_args, int skip, exarg_T *eap, char_u **line_to_free);
 char_u *get_lambda_name(void);
 int get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate);
+int register_clambda(void (*cb)(typval_T *argvars, typval_T *rettv, void *state), void *state);
 char_u *deref_func_name(char_u *name, int *lenp, partial_T **partialp, int no_autoload);
 void emsg_funcname(char *ermsg, char_u *name);
 int get_func_tv(char_u *name, int len, typval_T *rettv, char_u **arg, funcexe_T *funcexe);

--- a/src/proto/userfunc.pro
+++ b/src/proto/userfunc.pro
@@ -4,7 +4,7 @@ hashtab_T *func_tbl_get(void);
 int get_function_args(char_u **argp, char_u endchar, garray_T *newargs, garray_T *argtypes, int *varargs, garray_T *default_args, int skip, exarg_T *eap, char_u **line_to_free);
 char_u *get_lambda_name(void);
 int get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate);
-char_u *register_cfunc(void (*cb)(typval_T *argvars, typval_T *rettv, void *state), void *state);
+char_u *register_cfunc(cfunc_T cb, void *state);
 char_u *deref_func_name(char_u *name, int *lenp, partial_T **partialp, int no_autoload);
 void emsg_funcname(char *ermsg, char_u *name);
 int get_func_tv(char_u *name, int len, typval_T *rettv, char_u **arg, funcexe_T *funcexe);

--- a/src/proto/userfunc.pro
+++ b/src/proto/userfunc.pro
@@ -4,7 +4,7 @@ hashtab_T *func_tbl_get(void);
 int get_function_args(char_u **argp, char_u endchar, garray_T *newargs, garray_T *argtypes, int *varargs, garray_T *default_args, int skip, exarg_T *eap, char_u **line_to_free);
 char_u *get_lambda_name(void);
 int get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate);
-int register_clambda(void (*cb)(typval_T *argvars, typval_T *rettv, void *state), void *state);
+char_u *register_cfunc(void (*cb)(typval_T *argvars, typval_T *rettv, void *state), void *state);
 char_u *deref_func_name(char_u *name, int *lenp, partial_T **partialp, int no_autoload);
 void emsg_funcname(char *ermsg, char_u *name);
 int get_func_tv(char_u *name, int len, typval_T *rettv, char_u **arg, funcexe_T *funcexe);

--- a/src/proto/userfunc.pro
+++ b/src/proto/userfunc.pro
@@ -4,7 +4,7 @@ hashtab_T *func_tbl_get(void);
 int get_function_args(char_u **argp, char_u endchar, garray_T *newargs, garray_T *argtypes, int *varargs, garray_T *default_args, int skip, exarg_T *eap, char_u **line_to_free);
 char_u *get_lambda_name(void);
 int get_lambda_tv(char_u **arg, typval_T *rettv, int evaluate);
-char_u *register_cfunc(cfunc_T cb, void *state);
+char_u *register_cfunc(cfunc_T cb, cfunc_free_T free_cb, void *state);
 char_u *deref_func_name(char_u *name, int *lenp, partial_T **partialp, int no_autoload);
 void emsg_funcname(char *ermsg, char_u *name);
 int get_func_tv(char_u *name, int len, typval_T *rettv, char_u **arg, funcexe_T *funcexe);

--- a/src/structs.h
+++ b/src/structs.h
@@ -1607,6 +1607,7 @@ typedef struct
 #define FC_EXPORT   0x100	// "export def Func()"
 #define FC_NOARGS   0x200	// no a: variables in lambda
 #define FC_VIM9	    0x400	// defined in vim9 script file
+#define FC_CFUNC    0x800	// defined as C func
 
 #define MAX_FUNC_ARGS	20	// maximum number of function arguments
 #define VAR_SHORT_LEN	20	// short variable name length

--- a/src/structs.h
+++ b/src/structs.h
@@ -1540,6 +1540,7 @@ typedef enum {
 } def_status_T;
 
 typedef void (*cfunc_T)(int argcount, typval_T *argvars, typval_T *rettv, void *state);
+typedef void (*cfunc_free_T)(void *state);
 
 /*
  * Structure to hold info for a user function.
@@ -1565,6 +1566,7 @@ typedef struct
     type_T	*uf_va_type;	// type from "...name: type" or NULL
     type_T	*uf_func_type;	// type of the function, &t_func_any if unknown
     cfunc_T     uf_cb;		// callback function for cfunc
+    cfunc_free_T uf_cb_free;    // callback function to free cfunc
     void        *uf_cb_state;   // state of uf_cb
 
     garray_T	uf_lines;	// function lines

--- a/src/structs.h
+++ b/src/structs.h
@@ -1529,7 +1529,7 @@ struct blobvar_S
     char	bv_lock;	// zero, VAR_LOCKED, VAR_FIXED
 };
 
-typedef void (*cfunc_T)(int argcount, typval_T *argvars, typval_T *rettv, void *state);
+typedef int (*cfunc_T)(int argcount, typval_T *argvars, typval_T *rettv, void *state);
 typedef void (*cfunc_free_T)(void *state);
 
 #if defined(FEAT_EVAL) || defined(PROTO)

--- a/src/structs.h
+++ b/src/structs.h
@@ -1529,6 +1529,9 @@ struct blobvar_S
     char	bv_lock;	// zero, VAR_LOCKED, VAR_FIXED
 };
 
+typedef void (*cfunc_T)(int argcount, typval_T *argvars, typval_T *rettv, void *state);
+typedef void (*cfunc_free_T)(void *state);
+
 #if defined(FEAT_EVAL) || defined(PROTO)
 typedef struct funccall_S funccall_T;
 
@@ -1538,9 +1541,6 @@ typedef enum {
     UF_TO_BE_COMPILED,
     UF_COMPILED
 } def_status_T;
-
-typedef void (*cfunc_T)(int argcount, typval_T *argvars, typval_T *rettv, void *state);
-typedef void (*cfunc_free_T)(void *state);
 
 /*
  * Structure to hold info for a user function.

--- a/src/structs.h
+++ b/src/structs.h
@@ -1597,10 +1597,6 @@ typedef struct
     char_u	uf_name[1];	// name of function (actually longer); can
 				// start with <SNR>123_ (<SNR> is K_SPECIAL
 				// KS_EXTRA KE_SNR)
-    /* void (*cb)(void); */
-    
-    /* void (*cb)(typval_T *argvars, typval_T *rettv, void *state); */
-    /* void *state; */
 } ufunc_T;
 
 // flags used in uf_flags

--- a/src/structs.h
+++ b/src/structs.h
@@ -1539,6 +1539,8 @@ typedef enum {
     UF_COMPILED
 } def_status_T;
 
+typedef void (*cfunc_T)(int argcount, typval_T *argvars, typval_T *rettv, void *state);
+
 /*
  * Structure to hold info for a user function.
  */
@@ -1562,6 +1564,8 @@ typedef struct
     char_u	*uf_va_name;	// name from "...name" or NULL
     type_T	*uf_va_type;	// type from "...name: type" or NULL
     type_T	*uf_func_type;	// type of the function, &t_func_any if unknown
+    cfunc_T     uf_cb;		// callback function for cfunc
+    void        *uf_cb_state;   // state of uf_cb
 
     garray_T	uf_lines;	// function lines
 # ifdef FEAT_PROFILE
@@ -1593,6 +1597,10 @@ typedef struct
     char_u	uf_name[1];	// name of function (actually longer); can
 				// start with <SNR>123_ (<SNR> is K_SPECIAL
 				// KS_EXTRA KE_SNR)
+    /* void (*cb)(void); */
+    
+    /* void (*cb)(typval_T *argvars, typval_T *rettv, void *state); */
+    /* void *state; */
 } ufunc_T;
 
 // flags used in uf_flags

--- a/src/testdir/Xscript
+++ b/src/testdir/Xscript
@@ -1,3 +1,0 @@
-func F1() closure
-  return 1
-endfunc

--- a/src/testdir/Xscript
+++ b/src/testdir/Xscript
@@ -1,0 +1,3 @@
+func F1() closure
+  return 1
+endfunc

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -566,7 +566,7 @@ func Vim_func_call_metatable_lua_callback(Greet)
 endfunc
 
 func Test_pass_lua_metatable_callback_to_vim_from_lua()
-  let result = luaeval("vim.funcref('Vim_func_call_metatable_lua_callback')(setmetatable({}, { __call = function(tbl, msg) return 'hello ' .. msg  end }) )")
+  let result = luaeval("vim.funcref('Vim_func_call_metatable_lua_callback')(setmetatable({ space = ' '}, { __call = function(tbl, msg) return 'hello' .. tbl.space .. msg  end }) )")
   call assert_equal("hello world", result)
 endfunc
 

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -541,6 +541,26 @@ func Test_update_package_paths()
   call assert_equal("hello from lua", luaeval("require('testluaplugin').hello()"))
 endfunc
 
+func Vim_func_call_lua_callback(Concat, Cb)
+  let l:message = a:Concat("hello", "vim")
+  call a:Cb(l:message)
+endfunc
+
+func Test_pass_lua_callback_to_vim_from_lua()
+  lua pass_lua_callback_to_vim_from_lua_result = ""
+  call assert_equal("", luaeval("pass_lua_callback_to_vim_from_lua_result"))
+  lua <<EOF
+  vim.funcref('Vim_func_call_lua_callback')(
+    function(greeting, message)
+      return greeting .. " " .. message
+    end,
+    function(message)
+      pass_lua_callback_to_vim_from_lua_result = message
+    end)
+EOF
+  call assert_equal("hello vim", luaeval("pass_lua_callback_to_vim_from_lua_result"))
+endfunc
+
 " Test vim.line()
 func Test_lua_line()
   new

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -566,7 +566,7 @@ func Vim_func_call_metatable_lua_callback(Greet)
 endfunc
 
 func Test_pass_lua_metatable_callback_to_vim_from_lua()
-  let result = luaeval("vim.funcref('Vim_func_call_metatable_lua_callback')(setmetatable({}, { __call = function(msg) return 'hello ' .. msg  end }) )")
+  let result = luaeval("vim.funcref('Vim_func_call_metatable_lua_callback')(setmetatable({}, { __call = function(tbl, msg) return 'hello ' .. msg  end }) )")
   call assert_equal("hello world", result)
 endfunc
 

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -561,6 +561,15 @@ EOF
   call assert_equal("hello vim", luaeval("pass_lua_callback_to_vim_from_lua_result"))
 endfunc
 
+func Vim_func_call_metatable_lua_callback(Greet)
+  return a:Greet("world")
+endfunc
+
+func Test_pass_lua_metatable_callback_to_vim_from_lua()
+  let result = luaeval("vim.funcref('Vim_func_call_metatable_lua_callback')(setmetatable({}, { __call = function(msg) return 'hello ' .. msg  end }) )")
+  call assert_equal("hello world", result)
+endfunc
+
 " Test vim.line()
 func Test_lua_line()
   new

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -342,7 +342,7 @@ get_lambda_name(void)
 }
 
     char_u *
-register_cfunc(cfunc_T cb, void *state)
+register_cfunc(cfunc_T cb, cfunc_free_T cb_free, void *state)
 {
     char_u *name = get_lambda_name();
     ufunc_T *fp = NULL;
@@ -370,6 +370,7 @@ register_cfunc(cfunc_T cb, void *state)
     fp->uf_lines = newlines;
     fp->uf_args = newargs;
     fp->uf_cb = cb;
+    fp->uf_cb_free = cb_free;
     fp->uf_cb_state = state;
 
     set_ufunc_name(fp, name);
@@ -3682,7 +3683,11 @@ func_unref(char_u *name)
 	// Only delete it when it's not being used.  Otherwise it's done
 	// when "uf_calls" becomes zero.
 	if (fp->uf_calls == 0)
+	{
+	    if (fp->uf_cb_free != NULL)
+		fp->uf_cb_free(fp->uf_cb_state);
 	    func_clear_free(fp, FALSE);
+	}
     }
 }
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -344,6 +344,21 @@ get_lambda_name(void)
     int
 register_clambda(void (*cb)(typval_T *argvars, typval_T *rettv, void *state), void *state)
 {
+    char_u *name = get_lambda_name();
+    ufunc_T *fp = NULL;
+    partial_T *pt = NULL;
+    int flags = FC_NOARGS;
+
+    fp = alloc_clear(offsetof(ufunc_T, uf_name) + STRLEN(name) + 1);
+    if (fp == NULL)
+        goto errret;
+    pt = ALLOC_CLEAR_ONE(partial_T);
+    if (pt == NULL)
+        goto errret;
+
+errret:
+    vim_free(fp);
+    vim_free(pt);
     return FAIL;
 }
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2021,7 +2021,7 @@ call_func(
 
 	    if (fp != NULL && (fp->uf_flags & FC_DELETED))
 		error = FCERR_DELETED;
-	    if (fp != NULL && (fp->uf_flags & FC_CFUNC))
+	    else if (fp != NULL && (fp->uf_flags & FC_CFUNC))
 	    {
 		cfunc_T cb = fp->uf_cb;
 		error = (*cb)(argcount, argvars, rettv, fp->uf_cb_state);

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -1075,6 +1075,15 @@ func_clear_items(ufunc_T *fp)
 	vim_free(((type_T **)fp->uf_type_list.ga_data)
 						  [--fp->uf_type_list.ga_len]);
     ga_clear(&fp->uf_type_list);
+
+    if (fp->uf_cb_free != NULL)
+    {
+	fp->uf_cb_free(fp->uf_cb_state);
+	fp->uf_cb_free = NULL;
+    }
+
+    fp->uf_cb_state = NULL;
+    fp->uf_cb = NULL;
 #ifdef FEAT_PROFILE
     VIM_CLEAR(fp->uf_tml_count);
     VIM_CLEAR(fp->uf_tml_total);
@@ -3682,11 +3691,7 @@ func_unref(char_u *name)
 	// Only delete it when it's not being used.  Otherwise it's done
 	// when "uf_calls" becomes zero.
 	if (fp->uf_calls == 0)
-	{
-	    if (fp->uf_cb_free != NULL)
-		fp->uf_cb_free(fp->uf_cb_state);
 	    func_clear_free(fp, FALSE);
-	}
     }
 }
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2024,8 +2024,7 @@ call_func(
 	    if (fp != NULL && (fp->uf_flags & FC_CFUNC))
 	    {
 		cfunc_T cb = fp->uf_cb;
-		(*cb)(argcount, argvars, rettv, fp->uf_cb_state);
-		error = FCERR_NONE;
+		error = (*cb)(argcount, argvars, rettv, fp->uf_cb_state);
 	    }
 	    else if (fp != NULL)
 	    {

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -346,7 +346,6 @@ register_cfunc(cfunc_T cb, cfunc_free_T cb_free, void *state)
 {
     char_u *name = get_lambda_name();
     ufunc_T *fp = NULL;
-    partial_T *pt = NULL;
     int flags = FC_CFUNC;
     garray_T newargs;
     garray_T newlines;
@@ -356,9 +355,6 @@ register_cfunc(cfunc_T cb, cfunc_free_T cb_free, void *state)
 
     fp = alloc_clear(offsetof(ufunc_T, uf_name) + STRLEN(name) + 1);
     if (fp == NULL)
-        goto errret;
-    pt = ALLOC_CLEAR_ONE(partial_T);
-    if (pt == NULL)
         goto errret;
 
     fp->uf_dfunc_idx = UF_NOT_COMPILED;
@@ -376,16 +372,12 @@ register_cfunc(cfunc_T cb, cfunc_free_T cb_free, void *state)
     set_ufunc_name(fp, name);
     hash_add(&func_hashtab, UF2HIKEY(fp));
 
-    pt->pt_func = fp;
-    pt->pt_refcount = 1;
-
     return name;
 
 errret:
     ga_clear_strings(&newargs);
     ga_clear_strings(&newlines);
     vim_free(fp);
-    vim_free(pt);
     return NULL;
 }
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -341,6 +341,12 @@ get_lambda_name(void)
     return name;
 }
 
+    int
+register_clambda(void (*cb)(typval_T *argvars, typval_T *rettv, void *state), void *state)
+{
+    return FAIL;
+}
+
 /*
  * Parse a lambda expression and get a Funcref from "*arg".
  * Return OK or FAIL.  Returns NOTDONE for dict or {expr}.

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -341,6 +341,10 @@ get_lambda_name(void)
     return name;
 }
 
+/*
+ * Registers a native c callback which can be called from Vim script.
+ * Returns the name of the Vim script function.
+ */
     char_u *
 register_cfunc(cfunc_T cb, cfunc_free_T cb_free, void *state)
 {


### PR DESCRIPTION
This is work in progress but lays the foundation to pass lua closures to a vim function in pure lua.  Over the next couple of days will be working on the remaining tasks but please feel free to review and provide feedback.

Here is a working demo:

![image](https://user-images.githubusercontent.com/287744/84467724-d11dfd80-ac31-11ea-847e-c8d0f15f7c40.png)

This introduces `register_cfunc` api in c which takes a c callback and state and converts it to a vimscript lambda which can then be called by any vimscript.

Here are remaining work:
- [x] add tests
- [x] update documentation with example
- [x] update `register_cfunc` to take a dectructor c callback so when the lambda gets freed it can go ahead and do cleanup such as calling `lua_unref()` and calling `free(state)`.
- [x] update callback to return int such as `FCERR_NONE` instead of void.
- [x] convert vim args to lua args before calling lua closure
- [x] convert lua return values to vim return value. 

Based on looking at neovim source code it seems to treat lua functions as first class so `register_cfunc` doesn't exist in neovim.

