### PR TITLE
Termdebug: Only run mapset() if s:k_map_saved is not empty

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -710,7 +710,7 @@ func s:DeleteCommands()
   delcommand Source
   delcommand Winbar
 
-  if exists('s:k_map_saved')
+  if exists('s:k_map_saved') && !empty(s:k_map_saved)
     call mapset('n', 0, s:k_map_saved)
     unlet s:k_map_saved
   endif


### PR DESCRIPTION
If K is not mapped, maparg() will return an empty dictionary and later
mapset() will error out with:
E460: entries missing in mapset() dict argument