### PR TITLE
Allow completion of locales on Windows

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -273,6 +273,7 @@ nextwild(
  * options = WILD_SILENT:	    don't print warning messages
  * options = WILD_ESCAPE:	    put backslash before special chars
  * options = WILD_ICASE:	    ignore case for files
+ * options = WILD_ALLLINKS;         keep broken links
  *
  * The variables xp->xp_context and xp->xp_backslash must have been set!
  */

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -609,20 +609,16 @@ func Test_cmdline_complete_languages()
   call feedkeys(":language \<c-a>\<c-b>\"\<cr>", 'tx')
   call assert_match('^"language .*\<ctype\>.*\<messages\>.*\<time\>', @:)
 
-  if has('unix')
-    " TODO: these tests don't work on Windows. lang appears to be 'C'
-    " but C does not appear in the completion. Why?
-    call assert_match('^"language .*\<' . lang . '\>', @:)
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 
-    call feedkeys(":language messages \<c-a>\<c-b>\"\<cr>", 'tx')
-    call assert_match('^"language .*\<' . lang . '\>', @:)
+  call feedkeys(":language messages \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 
-    call feedkeys(":language ctype \<c-a>\<c-b>\"\<cr>", 'tx')
-    call assert_match('^"language .*\<' . lang . '\>', @:)
+  call feedkeys(":language ctype \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 
-    call feedkeys(":language time \<c-a>\<c-b>\"\<cr>", 'tx')
-    call assert_match('^"language .*\<' . lang . '\>', @:)
-  endif
+  call feedkeys(":language time \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 endfunc
 
 func Test_cmdline_complete_env_variable()


### PR DESCRIPTION
On Unix we use the output of `:locale -a` to generate the completion
list.

On Windows, we currently have only expansion of the arguments `mess time
and ctype` for the :lang command.

This patch examines the directory structure of $VIMRUNTIME/lang/ and
uses that as valid locales (and in addition it adds the value of C). As
a side effect, we can then also enable the :lang completion test for
Windows.

There is one specialty however, do not add locales that contain the `.`
which is used delimit the encoding from the locale. So if we have directories 'ja',
'ja.euc-jp' and 'ja.sjis' only allow completion for 'ja'. I am not sure
this is correct however(?)