### PR TITLE
syntax improvements for scons, sh

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1296,7 +1296,7 @@ au BufNewFile,BufRead *.pyx,*.pxd		setf pyrex
 
 " Python, Python Shell Startup and Python Stub Files
 " Quixote (Python-based web framework)
-au BufNewFile,BufRead *.py,*.pyw,.pythonstartup,.pythonrc,*.ptl,*.pyi  setf python
+au BufNewFile,BufRead *.py,*.pyw,.pythonstartup,.pythonrc,*.ptl,*.pyi,SConstruct  setf python
 
 " Radiance
 au BufNewFile,BufRead *.rad,*.mat		setf radiance

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -15,6 +15,9 @@ endif
 
 " trying to answer the question: which shell is /bin/sh, really?
 " If the user has not specified any of g:is_kornshell, g:is_bash, g:is_posix, g:is_sh, then guess.
+if exists("b:is_kornshell") | unlet b:is_kornshell | endif
+if exists("b:is_bash")      | unlet b:is_bash      | endif
+if exists("b:is_posix")     | unlet b:is_posix     | endif
 if getline(1) =~ '\<ksh$'
  let b:is_kornshell = 1
 elseif getline(1) =~ '\<bash$'


### PR DESCRIPTION
The first commit lets vim detect [scons](https://scons.org/) files as python,
the second one lets vim re-detect the shell subtype when the shebang in a shell
script is changed. For the last one, I tried to contact the maintainer for
runtime/syntax/sh.vim, but the mail address did not exist anymore.