### PR TITLE
tests: init g:run_nr if not set

### DIFF
--- a/src/testdir/term_util.vim
+++ b/src/testdir/term_util.vim
@@ -28,6 +28,9 @@ endfunc
 " The second argument is the minimum time to wait in msec, 10 if omitted.
 func TermWait(buf, ...)
   let wait_time = a:0 ? a:1 : 10
+  if !exists("g:run_nr")
+    let g:run_nr = 1
+  endif
   if g:run_nr == 2
     let wait_time *= 4
   elseif g:run_nr > 2


### PR DESCRIPTION
When running tests interactively, initialize g:run_nr if it has not been
set. This does not happen when running the complete testsuite, but when
debugging tests, Vim won't spit  E121: undefined variable messages at
me.