### PR TITLE
Improved ruby test coverage

### DIFF
--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -26,6 +26,18 @@ func Test_rubydo()
   %bwipe!
 endfunc
 
+func Test_rubydo_dollar_underscore()
+  new
+  call setline(1, ['one', 'two', 'three', 'four'])
+  2,3rubydo $_ = '[' + $_  + ']'
+  call assert_equal(['one', '[two]', '[three]', 'four'], getline(1, '$'))
+  bwipe!
+
+  call assert_fails('rubydo $_ = 0', 'E265:')
+  call assert_fails('rubydo 1+', 'syntax error, unexpected end-of-input')
+  bwipe!
+endfunc
+
 func Test_rubyfile()
   " Check :rubyfile does not SEGV with Ruby level exception but just fails
   let tempfile = tempname() . '.rb'
@@ -393,6 +405,10 @@ func Test_ruby_p()
 
   let messages = GetMessages()
   call assert_equal(0, len(messages))
+endfunc
+
+func Test_rubyeval_error()
+  call assert_fails('call rubyeval("1+")', 'syntax error, unexpected end-of-input')
 endfunc
 
 " Test for various heredoc syntax

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -34,7 +34,7 @@ func Test_rubydo_dollar_underscore()
   bwipe!
 
   call assert_fails('rubydo $_ = 0', 'E265:')
-  call assert_fails('rubydo (', 'syntax error, unexpected end-of-input')
+  call assert_fails('rubydo (')
   bwipe!
 endfunc
 
@@ -408,7 +408,12 @@ func Test_ruby_p()
 endfunc
 
 func Test_rubyeval_error()
-  call assert_fails('call rubyeval("(")', 'syntax error, unexpected end-of-input')
+  " On Linux or Windows the error matches:
+  "   "syntax error, unexpected end-of-input"
+  " whereas on macOS in CI, the error message makes less sense:
+  "   "SyntaxError: array length must be 2"
+  " Unclear why. The test does not check the error message.
+  call assert_fails('call rubyeval("(")')
 endfunc
 
 " Test for various heredoc syntax

--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -34,7 +34,7 @@ func Test_rubydo_dollar_underscore()
   bwipe!
 
   call assert_fails('rubydo $_ = 0', 'E265:')
-  call assert_fails('rubydo 1+', 'syntax error, unexpected end-of-input')
+  call assert_fails('rubydo (', 'syntax error, unexpected end-of-input')
   bwipe!
 endfunc
 
@@ -408,7 +408,7 @@ func Test_ruby_p()
 endfunc
 
 func Test_rubyeval_error()
-  call assert_fails('call rubyeval("1+")', 'syntax error, unexpected end-of-input')
+  call assert_fails('call rubyeval("(")', 'syntax error, unexpected end-of-input')
 endfunc
 
 " Test for various heredoc syntax


### PR DESCRIPTION
This PR slightly improves ruby test coverage.

I did not see a way to trigger ruby errors E267, E268, E269, E270, E271, E272, E273.
which are currently uncovered by tests according to codecov:

https://codecov.io/gh/vim/vim/src/c5b1c20b6b1968873ea31edac1db659773b3b93d/src/if_ruby.c#L1036