### PR TITLE
Fix build failures with Perl 5.32

### DIFF
--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -656,6 +656,10 @@ S_SvREFCNT_dec(pTHX_ SV *sv)
 	    Perl_sv_free2(aTHX_ sv, rc);
     }
 }
+/* perl-5.32 needs Perl_SvREFCNT_dec */
+# if (PERL_REVISION == 5) && (PERL_VERSION >= 32)
+#define Perl_SvREFCNT_dec S_SvREFCNT_dec
+# endif
 # endif
 
 /* perl-5.26 also needs S_TOPMARK and S_POPMARK. */
@@ -679,6 +683,21 @@ S_POPMARK(pTHX)
 				  (IV)*(PL_markstack_ptr-1))));
     assert((PL_markstack_ptr > PL_markstack) || !"MARK underflow");
     return *PL_markstack_ptr--;
+}
+/* perl-5.32 needs Perl_POPMARK */
+# if (PERL_REVISION == 5) && (PERL_VERSION >= 32)
+#define Perl_POPMARK S_POPMARK
+# endif
+# endif
+
+/* perl-5.32 needs Perl_SvTRUE */
+# if (PERL_REVISION == 5) && (PERL_VERSION >= 32)
+PERL_STATIC_INLINE bool
+Perl_SvTRUE(pTHX_ SV *sv) {
+    if (!LIKELY(sv))
+        return FALSE;
+    SvGETMAGIC(sv);
+    return SvTRUE_nomg_NN(sv);
 }
 # endif
 


### PR DESCRIPTION
More functions are needed in latest Perl 5.32. This patch fixes the following build failures:
```
In file included from /usr/lib/perl5/5.32/core_perl/CORE/perl.h:3909,
                 from if_perl.xs:61:
if_perl.xs: In function ‘perl_win_free’:
/usr/lib/perl5/5.32/core_perl/CORE/sv.h:351:26: warning: implicit declaration of function ‘Perl_SvREFCNT_dec’; did you mean ‘S_SvREFCNT_dec’? [-Wimplicit-function-declaration]
  351 | #define SvREFCNT_dec(sv) Perl_SvREFCNT_dec(aTHX_ MUTABLE_SV(sv))
      |                          ^~~~~~~~~~~~~~~~~
/usr/lib/perl5/5.32/core_perl/CORE/sv.h:351:26: note: in definition of macro ‘SvREFCNT_dec’
  351 | #define SvREFCNT_dec(sv) Perl_SvREFCNT_dec(aTHX_ MUTABLE_SV(sv))
      |                          ^~~~~~~~~~~~~~~~~
if_perl.xs: In function ‘ex_perl’:
/usr/lib/perl5/5.32/core_perl/CORE/sv.h:1842:28: warning: implicit declaration of function ‘Perl_SvTRUE’ [-Wimplicit-function-declaration]
 1842 | #define SvTRUE(sv)         Perl_SvTRUE(aTHX_ sv)
      |                            ^~~~~~~~~~~
/usr/lib/perl5/5.32/core_perl/CORE/sv.h:1842:28: note: in definition of macro ‘SvTRUE’
 1842 | #define SvTRUE(sv)         Perl_SvTRUE(aTHX_ sv)
      |                            ^~~~~~~~~~~
In file included from /usr/lib/perl5/5.32/core_perl/CORE/perl.h:5544,
                 from if_perl.xs:61:
if_perl.c: In function ‘XS_VIM_Msg’:
/usr/lib/perl5/5.32/core_perl/CORE/pp.h:71:17: warning: implicit declaration of function ‘Perl_POPMARK’; did you mean ‘S_POPMARK’? [-Wimplicit-function-declaration]
   71 | #define POPMARK Perl_POPMARK(aTHX)
      |                 ^~~~~~~~~~~~
/usr/lib/perl5/5.32/core_perl/CORE/pp.h:71:17: note: in definition of macro ‘POPMARK’
   71 | #define POPMARK Perl_POPMARK(aTHX)
      |                 ^~~~~~~~~~~~
/usr/lib/perl5/5.32/core_perl/CORE/XSUB.h:157:7: note: in expansion of macro ‘dAXMARK’
  157 |  dSP; dAXMARK; dITEMS
      |       ^~~~~~~
if_perl.c:1661:11: note: in expansion of macro ‘dXSARGS’
gcc -c -I. -Iproto -DHAVE_CONFIG_H     -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        version.c -o objects/version.o
link.sh: $LINK_AS_NEEDED set to 'yes': invoking linker directly.
  gcc   -L. -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -fstack-protector-strong -rdynamic -Wl,-export-dynamic -Wl,-E -Wl,-rpath,/usr/lib/perl5/5.32/core_perl/CORE  -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -L/usr/local/lib -Wl,--as-needed    -o vim objects/arabic.o objects/arglist.o objects/autocmd.o objects/beval.o objects/buffer.o objects/change.o objects/blob.o objects/blowfish.o objects/cindent.o objects/clientserver.o objects/clipboard.o objects/cmdexpand.o objects/cmdhist.o objects/crypt.o objects/crypt_zip.o objects/debugger.o objects/dict.o objects/diff.o objects/digraph.o objects/drawline.o objects/drawscreen.o objects/edit.o objects/eval.o objects/evalbuffer.o objects/evalfunc.o objects/evalvars.o objects/evalwindow.o objects/ex_cmds.o objects/ex_cmds2.o objects/ex_docmd.o objects/ex_eval.o objects/ex_getln.o objects/fileio.o objects/filepath.o objects/findfile.o objects/fold.o objects/getchar.o objects/hardcopy.o objects/hashtab.o objects/highlight.o objects/if_cscope.o objects/if_xcmdsrv.o objects/indent.o objects/insexpand.o objects/list.o objects/map.o objects/mark.o objects/mbyte.o objects/memline.o objects/menu.o objects/misc1.o objects/misc2.o objects/mouse.o objects/move.o objects/normal.o objects/ops.o objects/option.o objects/optionstr.o objects/os_unix.o objects/pathdef.o objects/popupmenu.o objects/popupwin.o objects/profiler.o objects/pty.o objects/quickfix.o objects/regexp.o objects/register.o objects/screen.o objects/scriptfile.o objects/search.o objects/session.o objects/sha256.o objects/sign.o objects/sound.o objects/spell.o objects/spellfile.o objects/spellsuggest.o objects/syntax.o objects/tag.o objects/term.o objects/terminal.o objects/testing.o objects/textformat.o objects/textobject.o objects/textprop.o objects/time.o objects/ui.o objects/undo.o objects/usercmd.o objects/userfunc.o objects/version.o objects/vim9compile.o objects/vim9execute.o objects/vim9script.o objects/viminfo.o objects/window.o objects/bufwrite.o  objects/vterm_encoding.o objects/vterm_keyboard.o objects/vterm_mouse.o objects/vterm_parser.o objects/vterm_pen.o objects/vterm_screen.o objects/vterm_state.o objects/vterm_unicode.o objects/vterm_vterm.o objects/if_lua.o  objects/if_perl.o objects/if_perlsfio.o objects/if_python.o objects/if_python3.o objects/if_tcl.o objects/if_ruby.o  objects/netbeans.o objects/channel.o objects/xdiffi.o objects/xemit.o objects/xprepare.o objects/xutils.o objects/xhistogram.o objects/xpatience.o  objects/charset.o objects/json.o objects/main.o objects/memfile.o objects/message.o        -lm -ltinfo -lelf    -lacl -lattr -lgpm -ldl   -Wl,-E -Wl,-rpath,/usr/lib/perl5/5.32/core_perl/CORE -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -fstack-protector-strong -L/usr/local/lib  -L/usr/lib/perl5/5.32/core_perl/CORE -lperl -lpthread -ldl -lm -lcrypt -lutil -lc   -L/usr/lib -ltclstub8.6 -ldl -lz -lpthread -lm
/usr/bin/ld: objects/if_perl.o: in function `cur_val':
if_perl.c:(.text+0xaee): undefined reference to `Perl_SvREFCNT_dec'
/usr/bin/ld: objects/if_perl.o: in function `XS_VIBUF_Count':
if_perl.c:(.text+0xc29): undefined reference to `Perl_POPMARK'
/usr/bin/ld: objects/if_perl.o: in function `XS_VIBUF_Number':
if_perl.c:(.text+0xe89): undefined reference to `Perl_POPMARK'
/usr/bin/ld: objects/if_perl.o: in function `XS_VIBUF_Name':
if_perl.c:(.text+0x10e9): undefined reference to `Perl_POPMARK'
/usr/bin/ld: objects/if_perl.o: in function `XS_VIBUF_DESTROY':
if_perl.c:(.text+0x13f5): undefined reference to `Perl_POPMARK'
/usr/bin/ld: objects/if_perl.o: in function `XS_VIBUF_Append':
if_perl.c:(.text+0x15ea): undefined reference to `Perl_POPMARK'
/usr/bin/ld: objects/if_perl.o:if_perl.c:(.text+0x1a4a): more undefined references to `Perl_POPMARK' follow
/usr/bin/ld: objects/if_perl.o: in function `perl_win_free':
if_perl.c:(.text+0x4bb7): undefined reference to `Perl_SvREFCNT_dec'
/usr/bin/ld: objects/if_perl.o: in function `perl_buf_free':
if_perl.c:(.text+0x4c27): undefined reference to `Perl_SvREFCNT_dec'
/usr/bin/ld: objects/if_perl.o: in function `ex_perl':
if_perl.c:(.text+0x4d58): undefined reference to `Perl_SvTRUE'
/usr/bin/ld: if_perl.c:(.text+0x4d8a): undefined reference to `Perl_SvREFCNT_dec'
/usr/bin/ld: objects/if_perl.o: in function `do_perleval':
if_perl.c:(.text+0x51f7): undefined reference to `Perl_SvTRUE'
/usr/bin/ld: if_perl.c:(.text+0x5433): undefined reference to `Perl_SvREFCNT_dec'
/usr/bin/ld: objects/if_perl.o: in function `ex_perldo':
if_perl.c:(.text+0x577c): undefined reference to `Perl_SvREFCNT_dec'
/usr/bin/ld: if_perl.c:(.text+0x5943): undefined reference to `Perl_SvTRUE'
collect2: error: ld returned 1 exit status
link.sh: Linking failed
```