### PR TITLE
Cut off multiline conceals at end of line

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1336,7 +1336,7 @@ win_line(
 		ptr = line + v;  // "line" may have been changed
 
 		// Do not allow a conceal over EOL otherwise EOL will be missed
-		// at bad things happen.
+		// and bad things happen.
 		if (*ptr == NUL)
 		    has_match_conc = 0;
 	    }

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1335,7 +1335,8 @@ win_line(
 				      &match_conc, did_line_attr, lcs_eol_one);
 		ptr = line + v;  // "line" may have been changed
 
-		// Multiline conceals are end at EOL.
+		// Do not allow a conceal over EOL otherwise EOL will be missed
+		// at bad things happen.
 		if (*ptr == NUL)
 		    has_match_conc = 0;
 	    }

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1334,6 +1334,10 @@ win_line(
 				      &screen_search_hl, &has_match_conc,
 				      &match_conc, did_line_attr, lcs_eol_one);
 		ptr = line + v;  // "line" may have been changed
+
+		// Multiline conceals are end at EOL.
+		if (*ptr == NUL)
+		    has_match_conc = 0;
 	    }
 #endif
 

--- a/src/testdir/test_conceal.vim
+++ b/src/testdir/test_conceal.vim
@@ -254,4 +254,26 @@ func Test_conceal_cursor_pos()
   call delete('XTest_conceal_curpos')
 endfunc
 
+func Test_conceal_eol()
+  new!
+  setlocal concealcursor=n conceallevel=1
+  call setline(1, ["x", ""])
+  call matchaddpos('Conceal', [[2, 1, 1]], 2, -1, {'conceal': 1})
+  redraw!
+
+  call assert_notequal(screenchar(1, 1), screenchar(2, 2))
+  call assert_equal(screenattr(1, 1), screenattr(1, 2))
+  call assert_equal(screenattr(1, 2), screenattr(2, 2))
+  call assert_equal(screenattr(2, 1), screenattr(2, 2))
+
+  set list
+  redraw!
+
+  call assert_equal(screenattr(1, 1), screenattr(2, 2))
+  call assert_notequal(screenattr(1, 1), screenattr(1, 2))
+  call assert_notequal(screenattr(1, 2), screenattr(2, 1))
+
+  set nolist
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -1127,6 +1127,7 @@ func Test_diff_multilineconceal()
   set cole=2 cocu=n
   call setline(1, ["a", "b"])
   diffthis
+  redraw
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -1118,4 +1118,15 @@ func Test_diff_rnu()
   call delete('Xtest_diff_rnu')
 endfunc
 
+func Test_diff_multilineconceal()
+  new
+  diffthis
+
+  new
+  call matchadd('Conceal', 'a\nb', 9, -1, {'conceal': 'Y'})
+  set cole=2 cocu=n
+  call setline(1, ["a", "b"])
+  diffthis
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Multiline conceals can cause issues for example in diff mode where remaining of the line should be filled, but `c` never will be `NUL` because `c` will be overwritten by fill char so column numbers never will be increased after `\n`.

Should fix #4854, #6302.