### PR TITLE
Recognize Arch Linux's pacman's configuration file and hooks

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1134,6 +1134,15 @@ au BufNewFile,BufRead *.ora			setf ora
 " Packet filter conf
 au BufNewFile,BufRead pf.conf			setf pf
 
+" pacman config
+au BufNewFile,BufRead */etc/pacman.conf		setf dosini
+
+" pacman hooks
+au BufNewFile,BufRead *.hook
+	\ if getline(1) == '[Trigger]' |
+	\   setf dosini |
+	\ endif
+
 " Pam conf
 au BufNewFile,BufRead */etc/pam.conf		setf pamconf
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -139,7 +139,7 @@ let s:filename_checks = {
     \ 'dnsmasq': ['/etc/dnsmasq.conf'],
     \ 'dockerfile': ['Containerfile', 'Dockerfile', 'file.Dockerfile'],
     \ 'dosbatch': ['file.bat', 'file.sys'],
-    \ 'dosini': ['.editorconfig', '/etc/yum.conf', 'file.ini'],
+    \ 'dosini': ['.editorconfig', '/etc/pacman.conf', '/etc/yum.conf', 'file.ini'],
     \ 'dot': ['file.dot', 'file.gv'],
     \ 'dracula': ['file.drac', 'file.drc', 'filelvs', 'filelpe'],
     \ 'dsl': ['file.dsl'],


### PR DESCRIPTION
I'm not sure if and how I should add a test for hooks since none of the filetypes detected by both their filename and content are tested.