### PR TITLE
Recognize elinks.conf in any directory

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -542,7 +542,7 @@ au BufNewFile,BufRead *.ecd			setf ecd
 au BufNewFile,BufRead *.e,*.E			call dist#ft#FTe()
 
 " Elinks configuration
-au BufNewFile,BufRead */etc/elinks.conf,*/.elinks/elinks.conf	setf elinks
+au BufNewFile,BufRead elinks.conf		setf elinks
 
 " ERicsson LANGuage; Yaws is erlang too
 au BufNewFile,BufRead *.erl,*.hrl,*.yaws	setf erlang

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -150,7 +150,7 @@ let s:filename_checks = {
     \ 'dylanlid': ['file.lid'],
     \ 'ecd': ['file.ecd'],
     \ 'edif': ['file.edf', 'file.edif', 'file.edo'],
-    \ 'elinks': ['/etc/elinks.conf', '/.elinks/elinks.conf'],
+    \ 'elinks': ['elinks.conf'],
     \ 'elm': ['file.elm'],
     \ 'elmfilt': ['filter-rules'],
     \ 'erlang': ['file.erl', 'file.hrl', 'file.yaws'],


### PR DESCRIPTION
Recognize `elinks.conf` even if you have set the `ELINKS_CONFDIR` environment variable, for example to `ELINKS_CONFDIR=~/.config/elinks` to make it XDG-compliant.