### PR TITLE
Make the '.' single-repeat command content available via the ',' and ';' registers

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1178,7 +1178,7 @@ Rationale:	In Vi the "y" command followed by a backwards motion would
 With a linewise yank command the cursor is put in the first line, but the
 column is unmodified, thus it may not be on the first yanked character.
 
-There are ten types of registers:		*registers* *{register}* *E354*
+There are eleven types of registers:		*registers* *{register}* *E354*
 1. The unnamed register ""
 2. 10 numbered registers "0 to "9
 3. The small delete register "-
@@ -1189,6 +1189,7 @@ There are ten types of registers:		*registers* *{register}* *E354*
 8. The selection and drop registers "*, "+ and "~ 
 9. The black hole register "_
 10. Last search pattern register "/
+11. Single repeat registers ", and ";
 
 1. Unnamed register ""				*quote_quote* *quotequote*
 Vim fills this register with text deleted with the "d", "c", "s", "x" commands
@@ -1325,6 +1326,13 @@ other matches without actually searching.  You can't yank or delete into this
 register.  The search direction is available in |v:searchforward|.
 Note that the value is restored when returning from a function
 |function-search-undo|.
+
+11. Single repeat registers ", and ";
+
+						*quote_,* *quote,*
+	",      Contains the commands that will be executed for the |single-repeat|
+		command.
+	";      Contains the commands from the previous |single-repeat| command.
 
 							*@/*
 You can write to a register with a `:let` command |:let-@|.  Example: >

--- a/src/edit.c
+++ b/src/edit.c
@@ -408,7 +408,7 @@ edit(
      * Get the current length of the redo buffer, those characters have to be
      * skipped if we want to get to the inserted characters.
      */
-    ptr = get_inserted();
+    ptr = get_inserted(FALSE);
     if (ptr == NULL)
 	new_insert_skip = 0;
     else
@@ -2446,7 +2446,7 @@ stop_insert(
      * Don't do it when "restart_edit" was set and nothing was inserted,
      * otherwise CTRL-O w and then <Left> will clear "last_insert".
      */
-    ptr = get_inserted();
+    ptr = get_inserted(FALSE);
     if (did_restart_edit == 0 || (ptr != NULL
 				       && (int)STRLEN(ptr) > new_insert_skip))
     {

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -180,11 +180,15 @@ get_recorded(void)
 /*
  * Return the contents of the redo buffer as a single string.
  * K_SPECIAL and CSI in the returned string are escaped.
+ * If old is TRUE, use old_redobuff instead of redobuff.
  */
     char_u *
-get_inserted(void)
+get_inserted(int old_redo)
 {
-    return get_buffcont(&redobuff, FALSE);
+	if (old_redo)
+		return get_buffcont(&old_redobuff, FALSE);
+	else
+		return get_buffcont(&redobuff, FALSE);
 }
 
 /*
@@ -480,6 +484,29 @@ CancelRedo(void)
 	while (read_readbuffers(TRUE) != NUL)
 	    ;
     }
+}
+
+/*
+ * Set the contents of the redo buffer as a single string.
+ * K_SPECIAL and CSI should already have been escaped.
+ * If old is TRUE, use old_redobuff instead of redobuff.
+ */
+    void
+set_inserted(
+    int		old_redo,
+    char_u	*s,
+    long		slen)	// length of "s" or -1
+{
+	if (old_redo)
+	{
+		free_buff(&old_redobuff);
+		add_buff(&old_redobuff, s, slen);
+	}
+	else
+	{
+		ResetRedobuff();
+		add_buff(&redobuff, s, slen);
+	}
 }
 
 /*

--- a/src/proto/getchar.pro
+++ b/src/proto/getchar.pro
@@ -1,6 +1,7 @@
 /* getchar.c */
 char_u *get_recorded(void);
-char_u *get_inserted(void);
+char_u *get_inserted(int old_redo);
+void set_inserted(int old_redo, char_u *s, long slen);
 int stuff_empty(void);
 int readbuf1_empty(void);
 void typeahead_noflush(int c);


### PR DESCRIPTION
See #6299 

Supports getreg() and setreg() for ',' and ';' - where ',' is the current and ';' the previous command.

The initial idea was taken from the patch by [Ben Schmidt](https://groups.google.com/forum/#!msg/vim_dev/TIH6wsD4Qo4/msUMWHnWt3oJ). I've updated it and added support for setreg().

Warning: this is my first patch for Vim!