### PR TITLE
start lua list index with 1 instead of 0 to align with lua arrays

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -221,7 +221,7 @@ Properties
 ----------
 	o "#l" is the number of items in list "l", equivalent to "len(l)"
 	    in Vim.
-	o "l[k]" returns the k-th item in "l"; "l" is zero-indexed, as in Vim.
+	o "l[k]" returns the k-th item in "l"; "l" is one-indexed, as in Lua.
 	    To modify the k-th item, simply do "l[k] = newitem"; in
 	    particular, "l[k] = nil" removes the k-th item from "l".
 	o "l()" returns an iterator for "l".
@@ -237,11 +237,11 @@ Examples:
 	:let l = [1, 'item']
 	:lua l = vim.eval('l') -- same 'l'
 	:lua l:add(vim.list())
-	:lua l[0] = math.pi
+	:lua l[1] = math.pi
 	:echo l[0] " 3.141593
-	:lua l[0] = nil -- remove first item
+	:lua l[1] = nil -- remove first item
 	:lua l:insert(true, 1)
-	:lua print(l, #l, l[0], l[1], l[-1])
+	:lua print(l, #l, l[1], l[2])
 	:lua for item in l() do print(item) end
 <
 

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -872,7 +872,7 @@ luaV_list_index(lua_State *L)
     if (lua_isnumber(L, 2)) // list item?
     {
 	long n = (long) luaL_checkinteger(L, 2);
-	n -= 1; // lua array index starts with 1 while vim starts with 0 of -1 to normalize
+	n -= 1; // lua array index starts with 1 while vim starts with 0, -1 to normalize
 	listitem_T *li = list_find(l, n);
 	if (li == NULL)
 	    lua_pushnil(L);
@@ -901,7 +901,7 @@ luaV_list_newindex(lua_State *L)
 {
     list_T *l = luaV_unbox(L, luaV_List, 1);
     long n = (long) luaL_checkinteger(L, 2);
-    n -= 1; // lua array index starts with 1 while vim starts with 0 of -1 to normalize
+    n -= 1; // lua array index starts with 1 while vim starts with 0, -1 to normalize
     listitem_T *li;
     if (l->lv_lock)
 	luaL_error(L, "list is locked");

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -871,7 +871,9 @@ luaV_list_index(lua_State *L)
     list_T *l = luaV_unbox(L, luaV_List, 1);
     if (lua_isnumber(L, 2)) // list item?
     {
-	listitem_T *li = list_find(l, (long) luaL_checkinteger(L, 2));
+	long n = (long) luaL_checkinteger(L, 2);
+	n -= 1; // lua array index starts with 1 while vim starts with 0 of -1 to normalize
+	listitem_T *li = list_find(l, n);
 	if (li == NULL)
 	    lua_pushnil(L);
 	else
@@ -899,6 +901,7 @@ luaV_list_newindex(lua_State *L)
 {
     list_T *l = luaV_unbox(L, luaV_List, 1);
     long n = (long) luaL_checkinteger(L, 2);
+    n -= 1; // lua array index starts with 1 while vim starts with 0 of -1 to normalize
     listitem_T *li;
     if (l->lv_lock)
 	luaL_error(L, "list is locked");

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -327,8 +327,8 @@ func Test_lua_list()
   call assert_equal(7, luaeval('#l'))
   call assert_match('^list: \%(0x\)\?\x\+$', luaeval('tostring(l)'))
 
-  lua l[0] = 124
-  lua l[5] = nil
+  lua l[1] = 124
+  lua l[6] = nil
   lua l:insert('first')
   lua l:insert('xx', 3)
   call assert_equal(['first', 124, 'abc', 'xx', v:true, v:false, v:null, {'a': 1, 'b': 2, 'c': 3}], l)
@@ -367,22 +367,22 @@ func Test_lua_recursive_list()
   lua l = vim.list():add(1):add(2)
   lua l = l:add(l)
 
-  call assert_equal(1, luaeval('l[0]'))
-  call assert_equal(2, luaeval('l[1]'))
+  call assert_equal(1, luaeval('l[1]'))
+  call assert_equal(2, luaeval('l[2]'))
 
-  call assert_equal(1, luaeval('l[2][0]'))
-  call assert_equal(2, luaeval('l[2][1]'))
+  call assert_equal(1, luaeval('l[3][1]'))
+  call assert_equal(2, luaeval('l[3][2]'))
 
-  call assert_equal(1, luaeval('l[2][2][0]'))
-  call assert_equal(2, luaeval('l[2][2][1]'))
+  call assert_equal(1, luaeval('l[3][3][1]'))
+  call assert_equal(2, luaeval('l[3][3][2]'))
 
   call assert_equal('[1, 2, [...]]', string(luaeval('l')))
 
   call assert_match('^list: \%(0x\)\?\x\+$', luaeval('tostring(l)'))
-  call assert_equal(luaeval('tostring(l)'), luaeval('tostring(l[2])'))
+  call assert_equal(luaeval('tostring(l)'), luaeval('tostring(l[3])'))
 
-  call assert_equal(luaeval('l'), luaeval('l[2]'))
-  call assert_equal(luaeval('l'), luaeval('l[2][2]'))
+  call assert_equal(luaeval('l'), luaeval('l[3]'))
+  call assert_equal(luaeval('l'), luaeval('l[3][3]'))
 
   lua l = nil
 endfunc


### PR DESCRIPTION
PR for https://github.com/vim/vim/issues/6342

vim list index starts with 0 but lua index starts with 1 causing lot of bugs and also making it impossible to use lua libraries that are not written for  vim. This PR fixes such that vim lists are treated similar to lua list.

While looking at the list compatibility I also noticed that `vim.list` seems to add `add` and `insert` method which I think we should remove it and let users instead use the `table.insert(table, [pos,] value)` api which is more idiomatic lua api. http://lua-users.org/wiki/TableLibraryTutorial. I did not remove it but more than happy to remove it in the same api. I don't have context on why it was added so left it untouched.