### PR TITLE
Allow table.insert() and table.remove() to work with vim lists in lua

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -227,8 +227,15 @@ Properties
 	    in Vim.
 	o "l[k]" returns the k-th item in "l"; "l" is one-indexed, as in Lua.
 	    To modify the k-th item, simply do "l[k] = newitem"; in
-	    particular, "l[k] = nil" removes the k-th item from "l".
+	    particular, "l[k] = nil" removes the k-th item from "l". Item can
+	    be added to the end of the list by "l[#l + 1] = newitem"
 	o "l()" returns an iterator for "l".
+	o "table.insert(l, newitem)" inserts an item at the end of the list.
+	o "table.insert(l, position, newitem)" inserts an item at the
+	    specified position. "position" is one-indexed.
+	o "table.remove(l, position)" removes an item at the specified
+	    position. "position" is one-indexed.
+
 
 Methods
 -------
@@ -246,8 +253,11 @@ Examples:
 	:lua l[1] = nil -- remove first item
 	:lua l:insert(true, 1)
 	:lua print(l, #l, l[1], l[2])
+	:lua l[#l + 1] = 'value'
+	:lua table.insert(l, 100)
+	:lua table.insert(l, 2, 200)
+	:lua table.remove(l, 1)
 	:lua for item in l() do print(item) end
-<
 
 ==============================================================================
 4. Dict userdata					*lua-dict*

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -913,19 +913,32 @@ luaV_list_newindex(lua_State *L)
     if (l->lv_lock)
 	luaL_error(L, "list is locked");
     li = list_find(l, n);
-    if (li == NULL) return 0;
-    if (lua_isnil(L, 3)) // remove?
+    if (li == NULL)
     {
-	vimlist_remove(l, li, li);
-	listitem_free(l, li);
+        if (!lua_isnil(L, 3))
+        {
+	   typval_T v;
+	   luaV_checktypval(L, 3, &v, "inserting list item");
+	   if (list_insert_tv(l, &v, li) == FAIL)
+	        luaL_error(L, "failed to add item to list");
+	   clear_tv(&v);
+        }
     }
     else
     {
-	typval_T v;
-	luaV_checktypval(L, 3, &v, "setting list item");
-	clear_tv(&li->li_tv);
-	copy_tv(&v, &li->li_tv);
-	clear_tv(&v);
+        if (lua_isnil(L, 3)) // remove?
+        {
+	    vimlist_remove(l, li, li);
+	    listitem_free(l, li);
+        }
+        else
+        {
+	    typval_T v;
+	    luaV_checktypval(L, 3, &v, "setting list item");
+	    clear_tv(&li->li_tv);
+	    copy_tv(&v, &li->li_tv);
+	    clear_tv(&v);
+        }
     }
     return 0;
 }

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -353,6 +353,24 @@ func Test_lua_list_table()
   call assert_fails('lua vim.list(true)', '[string "vim chunk"]:1: table expected, got boolean')
 endfunc
 
+func Test_lua_list_table_insert_remove()
+  let l = [1, 2] 
+  lua t = vim.eval('l')
+  lua table.insert(t, 10)
+  lua t[#t + 1] = 20
+  lua table.insert(t, 2, 30)
+  call assert_equal(l, [1, 30, 2, 10, 20])
+  lua table.remove(t, 2)
+  call assert_equal(l, [1, 2, 10, 20])
+  lua t[3] = nil
+  call assert_equal(l, [1, 2, 20])
+  lua removed_value = table.remove(t, 3)
+  call assert_equal(luaeval('removed_value'), 20)
+  lua t = nil
+  lua removed_value = nil
+  unlet l
+endfunc
+
 " Test l() i.e. iterator on list
 func Test_lua_list_iter()
   lua l = vim.list():add('foo'):add('bar')

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -354,6 +354,14 @@ func Test_lua_list_table()
 endfunc
 
 func Test_lua_list_table_insert_remove()
+  let luaver = split(split(luaeval('_VERSION'), ' ')[1], '\.')
+  let major = str2nr(luaver[0])
+  let minor = str2nr(luaver[1])
+
+  if major < 5 || (major == 5 && minor < 3)
+    throw 'Skipped: Lua version < 5.3'
+  endif
+
   let l = [1, 2] 
   lua t = vim.eval('l')
   lua table.insert(t, 10)


### PR DESCRIPTION
Currently we need to use special methods for `vim.list` inside of lua. This makes the `vim.list` incompatible with rest of the lua ecosystem. This PR allows to use normal `table.insert()` and `table.remove()`.

This also means we can completely remove `:add()` and `:insert()` method if needed. This would be a breaking change so I'm leaving it is for now but something to think about.