### PR TITLE
Support left/right mouse wheel in terminal emulators

### DIFF
--- a/src/libvterm/src/mouse.c
+++ b/src/libvterm/src/mouse.c
@@ -83,7 +83,7 @@ void vterm_mouse_button(VTerm *vt, int button, int pressed, VTermModifier mod)
       state->mouse_buttons &= ~(1 << (button-1));
   }
 
-  /* Most of the time we don't get button releases from 4/5 */
+  /* Most of the time we don't get button releases from 4/5/6/7 */
   if(state->mouse_buttons == old_buttons && button < 4)
     return;
   if (!(state->mouse_flags & MOUSE_WANT_CLICK))
@@ -92,7 +92,7 @@ void vterm_mouse_button(VTerm *vt, int button, int pressed, VTermModifier mod)
   if(button < 4) {
     output_mouse(state, button-1, pressed, mod, state->mouse_col, state->mouse_row);
   }
-  else if(button < 6) {
+  else if(button < 8) {
     output_mouse(state, button-4 + 0x40, pressed, mod, state->mouse_col, state->mouse_row);
   }
 }

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -2801,8 +2801,16 @@ check_termcode_mouse(
 	    *modifiers |= MOD_MASK_CTRL;
 	if (wheel_code & MOUSE_ALT)
 	    *modifiers |= MOD_MASK_ALT;
-	key_name[1] = (wheel_code & 1)
-	    ? (int)KE_MOUSEUP : (int)KE_MOUSEDOWN;
+
+	if (wheel_code & 1 && wheel_code & 2)
+	    key_name[1] = (int)KE_MOUSELEFT;
+	else if (wheel_code & 2)
+	    key_name[1] = (int)KE_MOUSERIGHT;
+	else if (wheel_code & 1)
+	    key_name[1] = (int)KE_MOUSEUP;
+	else
+	    key_name[1] = (int)KE_MOUSEDOWN;
+
 	held_button = MOUSE_RELEASE;
     }
     else

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1389,8 +1389,8 @@ term_convert_key(term_T *term, int c, int modmask, char *buf)
 
 	case K_MOUSEUP:		other = term_send_mouse(vterm, 5, 1); break;
 	case K_MOUSEDOWN:	other = term_send_mouse(vterm, 4, 1); break;
-	case K_MOUSELEFT:	/* TODO */ return 0;
-	case K_MOUSERIGHT:	/* TODO */ return 0;
+	case K_MOUSELEFT:	other = term_send_mouse(vterm, 7, 1); break;
+	case K_MOUSERIGHT:	other = term_send_mouse(vterm, 6, 1); break;
 
 	case K_LEFTMOUSE:
 	case K_LEFTMOUSE_NM:

--- a/src/testdir/mouse.vim
+++ b/src/testdir/mouse.vim
@@ -169,4 +169,20 @@ func MouseWheelDown(row, col)
   call feedkeys(MouseWheelDownCode(a:row, a:col), 'Lx!')
 endfunc
 
+func MouseWheelLeftCode(row, col)
+  return TerminalEscapeCode(0x42, a:row, a:col, 'M')
+endfunc
+
+func MouseWheelLeft(row, col)
+  call feedkeys(MouseWheelLeftCode(a:row, a:col), 'Lx!')
+endfunc
+
+func MouseWheelRightCode(row, col)
+  return TerminalEscapeCode(0x43, a:row, a:col, 'M')
+endfunc
+
+func MouseWheelRight(row, col)
+  call feedkeys(MouseWheelRightCode(a:row, a:col), 'Lx!')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -194,9 +194,10 @@ func Test_1xterm_mouse_wheel()
   new
   let save_mouse = &mouse
   let save_term = &term
+  let save_wrap = &wrap
   let save_ttymouse = &ttymouse
-  set mouse=a term=xterm
-  call setline(1, range(1, 100))
+  set mouse=a term=xterm nowrap
+  call setline(1, range(100000000000000, 100000000000100))
 
   for ttymouse_val in g:Ttymouse_values
     let msg = 'ttymouse=' .. ttymouse_val
@@ -220,10 +221,31 @@ func Test_1xterm_mouse_wheel()
     call MouseWheelUp(1, 1)
     call assert_equal(1, line('w0'), msg)
     call assert_equal([0, 7, 1, 0], getpos('.'), msg)
+
+    if has('gui')
+      " Horizontal wheel scrolling currently only works when vim is
+      " compiled with gui enabled.
+      call MouseWheelRight(1, 1)
+      call assert_equal(7, 1 + virtcol(".") - wincol(), msg)
+      call assert_equal([0, 7, 7, 0], getpos('.'), msg)
+
+      call MouseWheelRight(1, 1)
+      call assert_equal(13, 1 + virtcol(".") - wincol(), msg)
+      call assert_equal([0, 7, 13, 0], getpos('.'), msg)
+
+      call MouseWheelLeft(1, 1)
+      call assert_equal(7, 1 + virtcol(".") - wincol(), msg)
+      call assert_equal([0, 7, 13, 0], getpos('.'), msg)
+
+      call MouseWheelLeft(1, 1)
+      call assert_equal(1, 1 + virtcol(".") - wincol(), msg)
+      call assert_equal([0, 7, 13, 0], getpos('.'), msg)
+    endif
   endfor
 
   let &mouse = save_mouse
   let &term = save_term
+  let &wrap = save_wrap
   let &ttymouse = save_ttymouse
   bwipe!
 endfunc


### PR DESCRIPTION
This adds support for left/right mouse wheel when running in a terminal emulator, for terminal emulators that supports it (e.g. xterm and urxvt).

The support is the same as in gvim, i.e.:
- When nowrap is set, they will scroll the window sideways.
- They can be mapped with `<ScrollWheelLeft>` and `<ScrollWheelRight>`.

Additionally, they are now supported as mouse events in `:terminal`, when an application running in it enables mouse.