### PR TITLE
Re-enable imactivatefunc / imstatusfunc in gvim on other platform than MS-Windows.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4133,7 +4133,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	This option specifies a function that will be called to
 	activate or deactivate the Input Method.
-	It is not used in the GUI.
+	It is not used in the MS-Windows GUI version.
 	The expression will be evaluated in the |sandbox| when set from a
 	modeline, see |sandbox-option|.
 
@@ -4242,7 +4242,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	This option specifies a function that is called to obtain the status
 	of Input Method.  It must return a positive number when IME is active.
-	It is not used in the GUI.
+	It is not used in the MS-Windows GUI version.
 
 	Example: >
 		function ImStatusFunc()

--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -57,7 +57,7 @@ xim_log(char *s, ...)
 }
 #endif
 
-#ifdef FEAT_GUI
+#if defined(FEAT_GUI) && defined(FEAT_GUI_MSWIN)
 # define USE_IMACTIVATEFUNC (!gui.in_use && *p_imaf != NUL)
 # define USE_IMSTATUSFUNC (!gui.in_use && *p_imsf != NUL)
 #else

--- a/src/testdir/test_iminsert.vim
+++ b/src/testdir/test_iminsert.vim
@@ -27,7 +27,7 @@ func Test_iminsert2()
   set imactivatefunc=
   set imstatusfunc=
 
-  let expected = has('gui_running') ? 0 : 1
+  let expected = has('gui_win32') ? 0 : 1
   call assert_equal(expected, s:imactivatefunc_called)
   call assert_equal(expected, s:imstatusfunc_called)
 endfunc
@@ -38,10 +38,7 @@ func Test_getimstatus()
   elseif !has('gui_mac')
     CheckFeature xim
   endif
-  if has('gui_running')
-    if !has('win32')
-      throw 'Skipped: running in the GUI, only works on MS-Windows'
-    endif
+  if has('gui_win32')
     set imactivatefunc=
     set imstatusfunc=
   else


### PR DESCRIPTION
This is re-enable imactivefunc (imaf) and imstatusfunc (imsf) in gvim on other platform than MS-Windows.

Unfortunately, imaf and imsf are disabled in gvim on platforms such as linux since [patch 8.0.1344](https://github.com/vim/vim/commit/2877d334ad1321d1fcd5f903c0493bd0cdd787f8), so I can't control the input method.
This is a very inconvenient situation for gvim and input method users on linux.
