### PR TITLE
Fix running configure with Xcode 12 beta and MacOSX11.0.sdk beta

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -14143,8 +14143,8 @@ else
 main() {
   uint32_t nr1 = (uint32_t)-1;
   uint32_t nr2 = (uint32_t)0xffffffffUL;
-  if (sizeof(uint32_t) != 4 || nr1 != 0xffffffffUL || nr2 + 1 != 0) exit(1);
-  exit(0);
+  if (sizeof(uint32_t) != 4 || nr1 != 0xffffffffUL || nr2 + 1 != 0) return 1;
+  return 0;
 }
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :


### PR DESCRIPTION
"checking uint32_t is 32 bits... " was calling `exit()` without including `stdlib.h`,
where the function is declared. On this platform, nothing seems to transitively
include stdlib.h. Just replace exit() with return since we're in main() anyways.