### PR TITLE
Fix issue 3205: Javascript indentation in HTML

### DIFF
--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -587,7 +587,7 @@ func! s:Alien3()
     return eval(b:hi_js1indent)
   endif
   if b:hi_indent.scripttype == "javascript"
-    return GetJavascriptIndent()
+    return eval(b:hi_js1indent) + GetJavascriptIndent()
   else
     return -1
   endif


### PR DESCRIPTION
Discussed in https://github.com/vim/vim/issues/3205

This change fixes indentation issues I had with Javascript embedded in HTML.

At the moment `ggVG=` would format the following HTML like so:

```html
<html>
    <body>
        <style>
            div#d1 { color: red; }
            div#d2 { color: green; }
            div#d3 { color: blue; }
        </style>
        <script>
            var v1="v1";
var v2="v2";
var v3="v3";
        </script>
    </body>
</html>
```

After this patch it looks like this:

```html
<html>
    <body>
        <style>
            div#d1 { color: red; }
            div#d2 { color: green; }
            div#d3 { color: blue; }
        </style>
        <script>
            var v1="v1";
            var v2="v2";
            var v3="v3";
        </script>
    </body>
</html>
```