### PR TITLE
Fix "make clean" in runtime/doc and src/tee/ directories

### DIFF
--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -396,7 +396,7 @@ test_urls:
 	vim -S test_urls.vim
 
 clean:
-	-rm doctags *.html tags.ref
+	-rm -f doctags *.html tags.ref
 
 # These files are in the extra archive, skip if not present
 

--- a/src/tee/Makefile
+++ b/src/tee/Makefile
@@ -4,7 +4,7 @@ CC=gcc
 CFLAGS=-O2 -fno-strength-reduce
 
 ifneq (sh.exe, $(SHELL))
-DEL = rm
+DEL = rm -f
 else
 DEL = del
 endif

--- a/src/tee/tee.c
+++ b/src/tee/tee.c
@@ -32,6 +32,8 @@
 #endif
 #include <malloc.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <fcntl.h>
 
 #ifdef _WIN32
@@ -132,9 +134,11 @@ main(int argc, char *argv[])
 			exit(1);
 		}
 	}
+#ifdef _WIN32
 	setmode(fileno(stdin),  O_BINARY);
 	fflush(stdout);	/* needed for _fsetmode(stdout) */
 	setmode(fileno(stdout),  O_BINARY);
+#endif
 
 	while ((n = myfread(buf, sizeof(char), sizeof(buf), stdin)) > 0)
 	{


### PR DESCRIPTION
The PR fixes errors when doing:
```
$ cd vim/runtime/doc
$ make clean
rm doctags *.html tags.ref
rm: cannot remove 'doctags': No such file or directory
rm: cannot remove '*.html': No such file or directory
rm: cannot remove 'tags.ref': No such file or directory
Makefile:399: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
```
Same kind of error in src/tee/.
```
$ src/tee
$ make clean
rm tee.o
rm: cannot remove 'tee.o': No such file or directory
Makefile:19: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
rm tee.exe
rm: cannot remove 'tee.exe': No such file or directory
Makefile:19: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
```
PR also fixes the build of `src/tee/tee.c` on non-Windows systems. Although, I don't think that `tee` is needed anywhere else than maybe windows.
