### PR TITLE
Fixed crash in syn_cmd_sync() after OOM error

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -5764,6 +5764,8 @@ syn_cmd_sync(exarg_T *eap, int syncing UNUSED)
 	next_arg = skipwhite(arg_end);
 	vim_free(key);
 	key = vim_strnsave_up(arg_start, arg_end - arg_start);
+	if (key == NULL)
+	    break;
 	if (STRCMP(key, "CCOMMENT") == 0)
 	{
 	    if (!eap->skip)


### PR DESCRIPTION
Simulating allocation failures, I saw a crash at `syntax.c:5767`:
```
5766    key = vim_strnsave_up(arg_start, arg_end - arg_start);
5767    if (STRCMP(key, "CCOMMENT") == 0)
```
`key` can be `NULL` if `vim_strnsave_up(...)` at `syntax.c:5766` fails and if `NULL` is passed to `STRCMP(...)` int the next line, vim crashes.