### PR TITLE
Fix lua tests

### DIFF
--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -179,12 +179,18 @@ func Test_lua_call()
 
   " Error cases
   call assert_fails("call luaeval('vim.call(\"min\", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)')",
-        \ '[string "luaeval"]:1: Function called with too many arguments')
+        \ s:lua_53_or_later
+        \ ? '[string "luaeval"]:1: Function called with too many arguments'
+        \ : 'Function called with too many arguments')
   lua co = coroutine.create(function () print("hi") end)
   call assert_fails("call luaeval('vim.call(\"type\", co)')",
-        \ '[string "luaeval"]:1: lua: cannot convert value')
+        \ s:lua_53_or_later
+        \ ? '[string "luaeval"]:1: lua: cannot convert value'
+        \ : 'lua: cannot convert value')
   lua co = nil
-  call assert_fails("call luaeval('vim.call(\"abc\")')", ['E117:', '\[string "luaeval"]:1: lua: call_vim_function failed'])
+  call assert_fails("call luaeval('vim.call(\"abc\")')",
+        \ ['E117:', s:lua_53_or_later ? '\[string "luaeval"]:1: lua: call_vim_function failed'
+        \                             : 'lua: call_vim_function failed'])
 endfunc
 
 " Test vim.fn.*
@@ -525,7 +531,9 @@ func Test_lua_dict()
   lua d = {}
   lua d[''] = 10
   call assert_fails("let t = luaeval('vim.dict(d)')",
-        \ '[string "luaeval"]:1: table has empty key')
+        \ s:lua_53_or_later
+        \ ? '[string "luaeval"]:1: table has empty key'
+        \ : 'table has empty key')
   let d = {}
   lua x = vim.eval('d')
   call assert_fails("lua x[''] = 10", '[string "vim chunk"]:1: empty key')


### PR DESCRIPTION
Hi, I found that some tests failed with luajit 5.1. I compiled vim with `--enable-luainterp --with-luajit`.
It seems that the failures are caused by differences in error messages between lua 5.1 and lua 5.3, because they passed without `--with-luajit` (I have luajit 5.1 and lua 5.3 in my machine).

I confirmed the tests passed by this patch both with luajit 5.1 and lua 5.3.


The errors from lua tests with luajit 5.1:
```
Failures: 
	From test_lua.vim:
	Found errors in Test_lua_call():
	function RunTheTest[39]..Test_lua_call line 5: Expected '[string "luaeval"]:1: Function called with too many arguments' but got 'Function called with too many arguments': call luaeval('vim.call("min", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)')
	function RunTheTest[39]..Test_lua_call line 8: Expected '[string "luaeval"]:1: lua: cannot convert value' but got 'lua: cannot convert value': call luaeval('vim.call("type", co)')
	function RunTheTest[39]..Test_lua_call line 11: Expected ['E117:', '\\[string "luaeval"]:1: lua: call_vim_function failed'] but got 'lua: call_vim_function failed': call luaeval('vim.call("abc")')
	Found errors in Test_lua_dict():
	function RunTheTest[39]..Test_lua_dict line 29: Expected '[string "luaeval"]:1: table has empty key' but got 'table has empty key': let t = luaeval('vim.dict(d)')
```

Thanks!