### PR TITLE
installer: Fix default _vimrc settings

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -687,6 +687,15 @@ SectionEnd
 	${EndIf}
 !macroend
 
+!macro LoadDefaultVimrc out_var reg_value default_value
+	ClearErrors
+	ReadRegStr ${out_var} HKLM "${UNINST_REG_KEY_VIM}" ${reg_value}
+	${If} ${Errors}
+	${OrIf} ${out_var} == ""
+	  StrCpy ${out_var} ${default_value}
+	${EndIf}
+!macroend
+
 Function .onInit
 !ifdef HAVE_MULTI_LANG
   # Select a language (or read from the registry).
@@ -718,10 +727,10 @@ Function .onInit
 !endif
   ${EndIf}
 
-# Load the selections from the registry (if any).
   ${If} ${RunningX64}
     SetRegView 64
   ${EndIf}
+  # Load the selections from the registry (if any).
   !insertmacro LoadSectionSelection ${id_section_console}    "select_console"
   !insertmacro LoadSectionSelection ${id_section_batch}      "select_batch"
   !insertmacro LoadSectionSelection ${id_section_desktop}    "select_desktop"
@@ -736,6 +745,10 @@ Function .onInit
 !ifdef HAVE_NLS
   !insertmacro LoadSectionSelection ${id_section_nls}        "select_nls"
 !endif
+  # Load the default _vimrc settings from the registry (if any).
+  !insertmacro LoadDefaultVimrc $vim_compat_stat "vim_compat" "all"
+  !insertmacro LoadDefaultVimrc $vim_keymap_stat "vim_keyremap" "default"
+  !insertmacro LoadDefaultVimrc $vim_mouse_stat "vim_mouse" "default"
   ${If} ${RunningX64}
     SetRegView lastused
   ${EndIf}
@@ -799,17 +812,11 @@ Function SetCustom
 	${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_defaults)
 	${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_all)
 
-	# Default selection
-	${If} $vim_compat_stat == ""
-	  ReadRegStr $3 HKLM "${UNINST_REG_KEY_VIM}" "vim_compat"
-	${Else}
-	  StrCpy $3 $vim_compat_stat
-	${EndIf}
-	${If} $3 == "defaults"
+	${If} $vim_compat_stat == "defaults"
 	  StrCpy $4 2
-	${ElseIf} $3 == "vim"
+	${ElseIf} $vim_compat_stat == "vim"
 	  StrCpy $4 1
-	${ElseIf} $3 == "vi"
+	${ElseIf} $vim_compat_stat == "vi"
 	  StrCpy $4 0
 	${Else} # default
 	  StrCpy $4 3
@@ -828,13 +835,7 @@ Function SetCustom
 	${NSD_CB_AddString} $vim_nsd_keymap $(str_msg_keymap_default)
 	${NSD_CB_AddString} $vim_nsd_keymap $(str_msg_keymap_windows)
 
-	# Default selection
-	${If} $vim_keymap_stat == ""
-	  ReadRegStr $3 HKLM "${UNINST_REG_KEY_VIM}" "vim_keyremap"
-	${Else}
-	  StrCpy $3 $vim_keymap_stat
-	${EndIf}
-	${If} $3 == "windows"
+	${If} $vim_keymap_stat == "windows"
 	  StrCpy $4 1
 	${Else} # default
 	  StrCpy $4 0
@@ -854,15 +855,9 @@ Function SetCustom
 	${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_windows)
 	${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_unix)
 
-	# Default selection
-	${If} $vim_mouse_stat == ""
-	  ReadRegStr $3 HKLM "${UNINST_REG_KEY_VIM}" "vim_mouse"
-	${Else}
-	  StrCpy $3 $vim_mouse_stat
-	${EndIf}
-	${If} $3 == "xterm"
+	${If} $vim_mouse_stat == "xterm"
 	  StrCpy $4 2
-	${ElseIf} $3 == "windows"
+	${ElseIf} $vim_mouse_stat == "windows"
 	  StrCpy $4 1
 	${Else} # default
 	  StrCpy $4 0


### PR DESCRIPTION
The installer didn't create the default _vimrc correctly when installed
with the silent install mode (`/S`).
The silent install mode doesn't call `SetCustom` and `ValidateCustom`
functions, so, set the default values in `.onInit` function.