### PR TITLE
if_lua.c: new Lua 5.4.0 defines luaL_typeerror, so don't define it twice

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -120,6 +120,9 @@ static void luaV_call_lua_func_free(void *state);
 #define luaL_loadbufferx dll_luaL_loadbufferx
 #define luaL_argerror dll_luaL_argerror
 #endif
+#if LUA_VERSION_NUM >= 504
+#define luaL_typeerror dll_luaL_typeerror
+#endif
 #define luaL_checkany dll_luaL_checkany
 #define luaL_checklstring dll_luaL_checklstring
 #define luaL_checkinteger dll_luaL_checkinteger
@@ -216,6 +219,9 @@ void (*dll_luaL_setfuncs) (lua_State *L, const luaL_Reg *l, int nup);
 int (*dll_luaL_loadfilex) (lua_State *L, const char *filename, const char *mode);
 int (*dll_luaL_loadbufferx) (lua_State *L, const char *buff, size_t sz, const char *name, const char *mode);
 int (*dll_luaL_argerror) (lua_State *L, int numarg, const char *extramsg);
+#endif
+#if LUA_VERSION_NUM >= 504
+int (*dll_luaL_typeerror) (lua_State *L, int narg, const char *tname);
 #endif
 void (*dll_luaL_checkany) (lua_State *L, int narg);
 const char *(*dll_luaL_checklstring) (lua_State *L, int numArg, size_t *l);
@@ -335,6 +341,9 @@ static const luaV_Reg luaV_dll[] = {
     {"luaL_loadfilex", (luaV_function) &dll_luaL_loadfilex},
     {"luaL_loadbufferx", (luaV_function) &dll_luaL_loadbufferx},
     {"luaL_argerror", (luaV_function) &dll_luaL_argerror},
+#endif
+#if LUA_VERSION_NUM >= 504
+    {"luaL_typeerror", (luaV_function) &dll_luaL_typeerror},
 #endif
     {"luaL_checkany", (luaV_function) &dll_luaL_checkany},
     {"luaL_checklstring", (luaV_function) &dll_luaL_checklstring},
@@ -457,7 +466,7 @@ lua_enabled(int verbose)
 }
 #endif
 
-#if LUA_VERSION_NUM > 501
+#if LUA_VERSION_NUM > 501 && LUA_VERSION_NUM < 504
     static int
 luaL_typeerror(lua_State *L, int narg, const char *tname)
 {


### PR DESCRIPTION
Hi,

Fedora updated Lua to version 5.4.0, where luaL_typeerror is defined, so the compilation now fails with double declaration. We configure Vim to be with dynamic Lua interpreter.

The fix defines an upper border in Lua version ```ifdef```, to prevent defining the function with newer Lua.
Would you mind adding the fix to the project?

Note:
I needed to add ```-llua``` into ```LDFLAGS``` too, because ```src/configure.ac``` clears ```LUA_LIBS``` here:

```
 740         fi
 741       fi
 742       AC_DEFINE(DYNAMIC_LUA)
 743       LUA_LIBS=""
 744       LUA_CFLAGS="-DDYNAMIC_LUA_DLL=\\\"${vi_cv_dll_name_lua}\\\" $LUA_CFLAGS"
 745     fi
```

If clearing of the variable is removed, Vim is linked correctly. But I'm not sure about the reason why clearing was done, so I didn't remove the line in pull request.