### PR TITLE
Double edit through symlink not detected when dir=foo//

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -4368,6 +4368,13 @@ makeswapname(
     char_u	fname_buf[MAXPATHL];
 #endif
 
+#ifdef HAVE_READLINK
+    // Expand symlink in the file name, so that we put the swap file with the
+    // actual file instead of with the symlink.
+    if (resolve_symlink(fname, fname_buf) == OK)
+	fname_res = fname_buf;
+#endif
+
 #if defined(UNIX) || defined(MSWIN)  // Need _very_ long file names
     int		len = (int)STRLEN(dir_name);
 
@@ -4375,20 +4382,13 @@ makeswapname(
     if (after_pathsep(dir_name, s) && len > 1 && s[-1] == s[-2])
     {			       // Ends with '//', Use Full path
 	r = NULL;
-	if ((s = make_percent_swname(dir_name, fname)) != NULL)
+	if ((s = make_percent_swname(dir_name, fname_res)) != NULL)
 	{
 	    r = modname(s, (char_u *)".swp", FALSE);
 	    vim_free(s);
 	}
 	return r;
     }
-#endif
-
-#ifdef HAVE_READLINK
-    // Expand symlink in the file name, so that we put the swap file with the
-    // actual file instead of with the symlink.
-    if (resolve_symlink(fname, fname_buf) == OK)
-	fname_res = fname_buf;
 #endif
 
     r = buf_modname(

--- a/src/testdir/test_swap.vim
+++ b/src/testdir/test_swap.vim
@@ -377,4 +377,34 @@ func Test_swap_prompt_splitwin()
   call delete('Xfile1')
 endfunc
 
+func Test_swap_symlink()
+  if !has("unix")
+    return
+  endif
+
+  call writefile(['text'], 'Xtestfile')
+  silent !ln -s -f Xtestfile Xtestlink
+
+  set dir=.
+
+  " Test that swap file uses the name of the file when editing through a
+  " symbolic link (so that editing the file twice is detected)
+  edit Xtestlink
+  call assert_match('Xtestfile\.swp$', s:swapname())
+  bwipe!
+
+  call mkdir('Xswapdir')
+  exe 'set dir=' . getcwd() . '/Xswapdir//'
+
+  " Check that this also works when 'directory' ends with '//'
+  edit Xtestlink
+  call assert_match('Xtestfile\.swp$', s:swapname())
+  bwipe!
+
+  set dir&
+  call delete('Xtestfile')
+  call delete('Xtestlink')
+  call delete('Xswapdir', 'rf')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Since 900b4d77f00b3ab7503d5e2865eca61ce5005c69, editing a file that's already open in another instance of vim is detected even if editing said file through a symbolic link. This doesn't work after `set dir=/path//`, however. Resolving the symlink before generating the percent-escaped filename fixes this.

Added a test for both the simple case that worked fine `dir=.` and the problematic one `dir=/path//`.