### PR TITLE
win32: Revise gui_w32.c

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -240,6 +240,7 @@ gui_mch_set_rendering_options(char_u *s)
 # define CONST
 # define FAR
 # define NEAR
+# define WINAPI
 # undef _cdecl
 # define _cdecl
 typedef int BOOL;
@@ -320,9 +321,6 @@ static int		s_findrep_is_find;	// TRUE for find dialog, FALSE
 						// for find/replace dialog
 #endif
 
-#if !defined(FEAT_GUI)
-static
-#endif
 HWND			s_hwnd = NULL;
 static HDC		s_hdc = NULL;
 static HBRUSH		s_brush = NULL;
@@ -389,7 +387,7 @@ directx_binddc(void)
 #endif
 
 // use of WindowProc depends on Global IME
-#define MyWindowProc vim_WindowProc
+static LRESULT WINAPI MyWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 extern int current_font_height;	    // this is in os_mswin.c
 
@@ -1259,12 +1257,8 @@ _TextAreaWndProc(
     }
 }
 
-#ifdef PROTO
-typedef int WINAPI;
-#endif
-
-    LRESULT WINAPI
-vim_WindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+    static LRESULT WINAPI
+MyWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 #ifdef GLOBAL_IME
     return global_ime_DefWindowProc(hwnd, message, wParam, lParam);
@@ -3794,10 +3788,6 @@ _OnScroll(
 
 #ifdef FEAT_XPM_W32
 # include "xpm_w32.h"
-#endif
-
-#ifdef PROTO
-# define WINAPI
 #endif
 
 #ifdef __MINGW32__

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -5,7 +5,6 @@ int gui_mch_is_blink_off(void);
 void gui_mch_set_blinking(long wait, long on, long off);
 void gui_mch_stop_blink(int may_call_gui_update_cursor);
 void gui_mch_start_blink(void);
-LRESULT WINAPI vim_WindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 void gui_mch_new_colors(void);
 void gui_mch_def_colors(void);
 int gui_mch_open(void);


### PR DESCRIPTION
* FEAT_GUI is always defined in this file. `#if !defined(FEAT_GUI)` is
  useless.
* The function `vim_WindowProc` is used only in this file. Make it
  static and change the name to `MyWindowProc`.
* Adjust some part for cproto.