### PR TITLE
gVim: Adjust scrollbar position

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1418,11 +1418,13 @@ gui_position_components(int total_width UNUSED)
     if (gui.which_scrollbars[SBAR_BOTTOM])
 	gui_mch_set_scrollbar_pos(&gui.bottom_sbar,
 				  text_area_x,
-				  text_area_y + text_area_height,
+				  text_area_y + text_area_height
+					+ gui_mch_get_scrollbar_ypadding(),
 				  text_area_width,
 				  gui.scrollbar_height);
     gui.left_sbar_x = 0;
-    gui.right_sbar_x = text_area_x + text_area_width;
+    gui.right_sbar_x = text_area_x + text_area_width
+					+ gui_mch_get_scrollbar_xpadding();
 
     --hold_gui_events;
 }

--- a/src/gui_athena.c
+++ b/src/gui_athena.c
@@ -1889,6 +1889,22 @@ gui_mch_set_scrollbar_pos(
     XtManageChild(sb->id);
 }
 
+    int
+gui_mch_get_scrollbar_xpadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
+    int
+gui_mch_get_scrollbar_ypadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
     void
 gui_mch_enable_scrollbar(scrollbar_T *sb, int flag)
 {

--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -1008,6 +1008,22 @@ gui_mch_set_scrollbar_pos(scrollbar_T *sb, int x, int y, int w, int h)
 	gtk_form_move_resize(GTK_FORM(gui.formwin), sb->id, x, y, w, h);
 }
 
+    int
+gui_mch_get_scrollbar_xpadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
+    int
+gui_mch_get_scrollbar_ypadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
 /*
  * Take action upon scrollbar dragging.
  */

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -3665,6 +3665,22 @@ gui_mch_set_scrollbar_pos(
     }
 }
 
+    int
+gui_mch_get_scrollbar_xpadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
+    int
+gui_mch_get_scrollbar_ypadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
 void
 gui_mch_create_scrollbar(
 	scrollbar_T *sb,

--- a/src/gui_mac.c
+++ b/src/gui_mac.c
@@ -4992,6 +4992,22 @@ gui_mch_set_scrollbar_pos(
 #endif
 }
 
+    int
+gui_mch_get_scrollbar_xpadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
+    int
+gui_mch_get_scrollbar_ypadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
     void
 gui_mch_create_scrollbar(
 	scrollbar_T *sb,

--- a/src/gui_motif.c
+++ b/src/gui_motif.c
@@ -1743,6 +1743,22 @@ gui_mch_set_scrollbar_pos(
     }
 }
 
+    int
+gui_mch_get_scrollbar_xpadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
+    int
+gui_mch_get_scrollbar_ypadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
     void
 gui_mch_enable_scrollbar(scrollbar_T *sb, int flag)
 {

--- a/src/gui_photon.c
+++ b/src/gui_photon.c
@@ -1758,6 +1758,22 @@ gui_mch_set_scrollbar_pos(scrollbar_T *sb, int x, int y, int w, int h)
     PtSetResource(sb->id, Pt_ARG_AREA, &area, 0);
 }
 
+    int
+gui_mch_get_scrollbar_xpadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
+    int
+gui_mch_get_scrollbar_ypadding(void)
+{
+    // TODO: Calculate the padding for adjust scrollbar position when the
+    // Window is maximized.
+    return 0;
+}
+
     void
 gui_mch_create_scrollbar(scrollbar_T *sb, int orient)
 {

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -1412,6 +1412,34 @@ gui_mch_set_scrollbar_pos(
 			      SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
 }
 
+    int
+gui_mch_get_scrollbar_xpadding(void)
+{
+    RECT    rcTxt, rcWnd;
+    int	    xpad;
+
+    GetWindowRect(s_textArea, &rcTxt);
+    GetWindowRect(s_hwnd, &rcWnd);
+    xpad = rcWnd.right - rcTxt.right - gui.scrollbar_width
+	- GetSystemMetrics(SM_CXFRAME)
+	- GetSystemMetrics(SM_CXPADDEDBORDER);
+    return (xpad < 0) ? 0 : xpad;
+}
+
+    int
+gui_mch_get_scrollbar_ypadding(void)
+{
+    RECT    rcTxt, rcWnd;
+    int	    ypad;
+
+    GetWindowRect(s_textArea, &rcTxt);
+    GetWindowRect(s_hwnd, &rcWnd);
+    ypad = rcWnd.bottom - rcTxt.bottom - gui.scrollbar_height
+	- GetSystemMetrics(SM_CYFRAME)
+	- GetSystemMetrics(SM_CXPADDEDBORDER);
+    return (ypad < 0) ? 0 : ypad;
+}
+
     void
 gui_mch_create_scrollbar(
     scrollbar_T *sb,

--- a/src/proto/gui_athena.pro
+++ b/src/proto/gui_athena.pro
@@ -21,6 +21,8 @@ void gui_mch_show_popupmenu(vimmenu_T *menu);
 void gui_mch_def_colors(void);
 void gui_mch_set_scrollbar_thumb(scrollbar_T *sb, long val, long size, long max);
 void gui_mch_set_scrollbar_pos(scrollbar_T *sb, int x, int y, int w, int h);
+int gui_mch_get_scrollbar_xpadding(void);
+int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_enable_scrollbar(scrollbar_T *sb, int flag);
 void gui_mch_create_scrollbar(scrollbar_T *sb, int orient);
 void gui_mch_destroy_scrollbar(scrollbar_T *sb);

--- a/src/proto/gui_gtk.pro
+++ b/src/proto/gui_gtk.pro
@@ -9,6 +9,8 @@ void gui_mch_menu_set_tip(vimmenu_T *menu);
 void gui_mch_destroy_menu(vimmenu_T *menu);
 void gui_mch_set_scrollbar_thumb(scrollbar_T *sb, long val, long size, long max);
 void gui_mch_set_scrollbar_pos(scrollbar_T *sb, int x, int y, int w, int h);
+int gui_mch_get_scrollbar_xpadding(void);
+int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_create_scrollbar(scrollbar_T *sb, int orient);
 void gui_mch_destroy_scrollbar(scrollbar_T *sb);
 char_u *gui_mch_browse(int saving, char_u *title, char_u *dflt, char_u *ext, char_u *initdir, char_u *filter);

--- a/src/proto/gui_haiku.pro
+++ b/src/proto/gui_haiku.pro
@@ -33,6 +33,8 @@ void gui_mch_enable_scrollbar(scrollbar_T *sb, int flag);
 void gui_mch_set_scrollbar_thumb(scrollbar_T *sb, int val, int size, int max);
 
 void gui_mch_set_scrollbar_pos(scrollbar_T *sb, int x, int y, int w, int h);
+int gui_mch_get_scrollbar_xpadding(void);
+int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_create_scrollbar(scrollbar_T *sb, int orient);
 void gui_mch_destroy_scrollbar(scrollbar_T *sb);
 

--- a/src/proto/gui_mac.pro
+++ b/src/proto/gui_mac.pro
@@ -36,6 +36,8 @@ void gui_mch_set_text_area_pos(int x, int y, int w, int h);
 void gui_mch_enable_scrollbar(scrollbar_T *sb, int flag);
 void gui_mch_set_scrollbar_thumb(scrollbar_T *sb, long val, long size, long max);
 void gui_mch_set_scrollbar_pos(scrollbar_T *sb, int x, int y, int w, int h);
+int gui_mch_get_scrollbar_xpadding(void);
+int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_create_scrollbar(scrollbar_T *sb, int orient);
 void gui_mch_destroy_scrollbar(scrollbar_T *sb);
 int gui_mch_adjust_charheight(void);

--- a/src/proto/gui_motif.pro
+++ b/src/proto/gui_motif.pro
@@ -23,6 +23,8 @@ void gui_mch_show_popupmenu(vimmenu_T *menu);
 void gui_mch_def_colors(void);
 void gui_mch_set_scrollbar_thumb(scrollbar_T *sb, long val, long size, long max);
 void gui_mch_set_scrollbar_pos(scrollbar_T *sb, int x, int y, int w, int h);
+int gui_mch_get_scrollbar_xpadding(void);
+int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_enable_scrollbar(scrollbar_T *sb, int flag);
 void gui_mch_create_scrollbar(scrollbar_T *sb, int orient);
 void gui_mch_destroy_scrollbar(scrollbar_T *sb);

--- a/src/proto/gui_photon.pro
+++ b/src/proto/gui_photon.pro
@@ -18,6 +18,8 @@ void gui_mch_set_foreground(void);
 void gui_mch_settitle(char_u *title, char_u *icon);
 void gui_mch_set_scrollbar_thumb(scrollbar_T *sb, int val, int size, int max);
 void gui_mch_set_scrollbar_pos(scrollbar_T *sb, int x, int y, int w, int h);
+int gui_mch_get_scrollbar_xpadding(void);
+int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_create_scrollbar(scrollbar_T *sb, int orient);
 void gui_mch_enable_scrollbar(scrollbar_T *sb, int flag);
 void gui_mch_destroy_scrollbar(scrollbar_T *sb);

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -14,6 +14,8 @@ void gui_mch_set_winpos(int x, int y);
 void gui_mch_set_text_area_pos(int x, int y, int w, int h);
 void gui_mch_enable_scrollbar(scrollbar_T *sb, int flag);
 void gui_mch_set_scrollbar_pos(scrollbar_T *sb, int x, int y, int w, int h);
+int gui_mch_get_scrollbar_xpadding(void);
+int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_create_scrollbar(scrollbar_T *sb, int orient);
 int gui_mch_adjust_charheight(void);
 GuiFont gui_mch_get_font(char_u *name, int giveErrorIfMissing);


### PR DESCRIPTION
This fixes #5602 by adjusting the scrollbar position when the GUI window
is maximized. The right or bottom scrollbar will be fit with the edge of
the GUI window.

This only implements the adjustment for MS-Windows. For other platforms,
I just prepared stub functions.