### PR TITLE
runtime: Set commentstring correctly in diffs

### DIFF
--- a/runtime/ftplugin/diff.vim
+++ b/runtime/ftplugin/diff.vim
@@ -13,3 +13,4 @@ let b:undo_ftplugin = "setl modeline<"
 
 " Don't use modelines in a diff, they apply to the diffed file
 setlocal nomodeline
+let &commentstring="# %s"


### PR DESCRIPTION
Allows external plugins to correctly comment and uncomment lines
in diffs. The syntax file already correctly supports comments.