### PR TITLE
Support getbufinfo() as a method

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4931,6 +4931,9 @@ getbufinfo([{dict}])
 			getbufvar({bufnr}, '&option_name')
 
 <
+		Can also be used as a |method|: >
+			GetBufnr()->getbufinfo()
+
 							*getbufline()*
 getbufline({expr}, {lnum} [, {end}])
 		Return a |List| with the lines starting from {lnum} to {end}

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -611,7 +611,7 @@ static funcentry_T global_functions[] =
     {"function",	1, 3, FEARG_1,	  ret_f_function, f_function},
     {"garbagecollect",	0, 1, 0,	  ret_void,	f_garbagecollect},
     {"get",		2, 3, FEARG_1,	  ret_any,	f_get},
-    {"getbufinfo",	0, 1, 0,	  ret_list_dict_any, f_getbufinfo},
+    {"getbufinfo",	0, 1, FEARG_1,	  ret_list_dict_any, f_getbufinfo},
     {"getbufline",	2, 3, FEARG_1,	  ret_list_string, f_getbufline},
     {"getbufvar",	2, 3, FEARG_1,	  ret_any,	f_getbufvar},
     {"getchangelist",	0, 1, FEARG_1,	  ret_list_any,	f_getchangelist},

--- a/src/testdir/test_bufwintabinfo.vim
+++ b/src/testdir/test_bufwintabinfo.vim
@@ -10,7 +10,7 @@ func Test_getbufwintabinfo()
   call assert_equal(2, len(buflist))
   call assert_match('Xtestfile1', buflist[0].name)
   call assert_match('Xtestfile2', getbufinfo('Xtestfile2')[0].name)
-  call assert_equal([], getbufinfo(2016))
+  call assert_equal([], 2016->getbufinfo())
   edit Xtestfile1
   hide edit Xtestfile2
   hide enew


### PR DESCRIPTION
This PR tries to allow `getbufinfo()` to be used as a method; that's already possible for the similar functions `getwininfo()` and `gettabinfo()`.  I don't know C; I just copied the PR #6176.
