### PR TITLE
force menu in English

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -104,6 +104,12 @@ set nomore
 
 " Output all messages in English.
 lang mess C
+" suppress menu translation
+if has('gui_running')
+  source $VIMRUNTIME/delmenu.vim
+  set langmenu=none
+  source $VIMRUNTIME/menu.vim
+endif
 
 " Always use forward slashes.
 set shellslash


### PR DESCRIPTION
On Windows environments ohter than English
Test_menu() in test.gui.vim is failed
because menu is translated.

This PR forces Vim uses English menu for tests.