### PR TITLE
stabilize netbeans test on GUI env

### DIFF
--- a/src/testdir/test_netbeans.vim
+++ b/src/testdir/test_netbeans.vim
@@ -31,6 +31,14 @@ func WaitForError(errcode)
   call assert_match(a:errcode, save_exception)
 endfunc
 
+func ReadXnetbeans()
+  let l = readfile("Xnetbeans")
+  " Xnetbeans may include '0:geometry=' messages on GUI environment if window
+  " position, size, or z order are changed.  Remove these messages because
+  " will causes troubles on check.
+  return filter(l, 'v:val !~ "^0:geometry="')
+endfunc
+
 func Nb_basic(port)
   call delete("Xnetbeans")
   call writefile([], "Xnetbeans")
@@ -42,8 +50,8 @@ func Nb_basic(port)
   " Establish the connection with the netbeans server
   exe 'nbstart :localhost:' .. a:port .. ':bunny'
   call assert_true(has("netbeans_enabled"))
-  call WaitFor('len(readfile("Xnetbeans")) > (g:last + 2)')
-  let l = readfile("Xnetbeans")
+  call WaitFor('len(ReadXnetbeans()) > (g:last + 2)')
+  let l = ReadXnetbeans()
   call assert_equal(['AUTH bunny',
         \ '0:version=0 "2.5"',
         \ '0:startupDone=0'], l[-3:])
@@ -55,8 +63,8 @@ func Nb_basic(port)
   " Open the command buffer to communicate with the server
   split Xcmdbuf
   let cmdbufnr = bufnr()
-  call WaitFor('len(readfile("Xnetbeans")) > (g:last + 2)')
-  let l = readfile("Xnetbeans")
+  call WaitFor('len(ReadXnetbeans()) > (g:last + 2)')
+  let l = ReadXnetbeans()
   call assert_equal('0:fileOpened=0 "Xcmdbuf" T F',
         \ substitute(l[-3], '".*/', '"', ''))
   call assert_equal('send: 1:putBufferNumber!15 "Xcmdbuf"',
@@ -75,120 +83,120 @@ func Nb_basic(port)
   call cursor(3, 4)
   sleep 10m
   call appendbufline(cmdbufnr, '$', 'getCursor_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 5)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 5)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:getCursor/30', '30 -1 3 3 19'], l[-2:])
   let g:last += 5
 
   " Test for E627
   call appendbufline(cmdbufnr, '$', 'E627_Test')
   call WaitForError('E627:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0 setReadOnly!31', l[-1])
   let g:last += 3
 
   " Test for E628
   call appendbufline(cmdbufnr, '$', 'E628_Test')
   call WaitForError('E628:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:setReadOnly 32', l[-1])
   let g:last += 3
 
   " Test for E632
   call appendbufline(cmdbufnr, '$', 'E632_Test')
   call WaitForError('E632:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:getLength/33', '33 0'], l[-2:])
   let g:last += 4
 
   " Test for E633
   call appendbufline(cmdbufnr, '$', 'E633_Test')
   call WaitForError('E633:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:getText/34', '34 '], l[-2:])
   let g:last += 4
 
   " Test for E634
   call appendbufline(cmdbufnr, '$', 'E634_Test')
   call WaitForError('E634:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:remove/35 1 1', '35'], l[-2:])
   let g:last += 4
 
   " Test for E635
   call appendbufline(cmdbufnr, '$', 'E635_Test')
   call WaitForError('E635:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:insert/36 0 "line1\n"', '36'], l[-2:])
   let g:last += 4
 
   " Test for E636
   call appendbufline(cmdbufnr, '$', 'E636_Test')
   call WaitForError('E636:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:create!37', l[-1])
   let g:last += 3
 
   " Test for E637
   call appendbufline(cmdbufnr, '$', 'E637_Test')
   call WaitForError('E637:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:startDocumentListen!38', l[-1])
   let g:last += 3
 
   " Test for E638
   call appendbufline(cmdbufnr, '$', 'E638_Test')
   call WaitForError('E638:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:stopDocumentListen!39', l[-1])
   let g:last += 3
 
   " Test for E639
   call appendbufline(cmdbufnr, '$', 'E639_Test')
   call WaitForError('E639:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:setTitle!40 "Title"', l[-1])
   let g:last += 3
 
   " Test for E640
   call appendbufline(cmdbufnr, '$', 'E640_Test')
   call WaitForError('E640:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:initDone!41', l[-1])
   let g:last += 3
 
   " Test for E641
   call appendbufline(cmdbufnr, '$', 'E641_Test')
   call WaitForError('E641:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:putBufferNumber!42 "XSomeBuf"', l[-1])
   let g:last += 3
 
   " Test for E642
   call appendbufline(cmdbufnr, '$', 'E642_Test')
   call WaitForError('E642:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 9:putBufferNumber!43 "XInvalidBuf"', l[-1])
   let g:last += 3
 
   " Test for E643
   call appendbufline(cmdbufnr, '$', 'E643_Test')
   call WaitForError('E643:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:setFullName!44 "XSomeBuf"', l[-1])
   let g:last += 3
 
@@ -197,8 +205,8 @@ func Nb_basic(port)
   " Test for E644
   call appendbufline(cmdbufnr, '$', 'E644_Test')
   call WaitForError('E644:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:editFile!45 "Xfile3"', l[-1])
   let g:last += 3
 
@@ -207,8 +215,8 @@ func Nb_basic(port)
   set verbose=1
   call WaitForError('E645:')
   set verbose&
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:setVisible!46 T', l[-1])
   let g:last += 3
 
@@ -217,56 +225,56 @@ func Nb_basic(port)
   set verbose=1
   call WaitForError('E646:')
   set verbose&
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:setModified!47 T', l[-1])
   let g:last += 3
 
   " Test for E647
   call appendbufline(cmdbufnr, '$', 'E647_Test')
   call WaitForError('E647:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:setDot!48 1/1', l[-1])
   let g:last += 3
 
   " Test for E648
   call appendbufline(cmdbufnr, '$', 'E648_Test')
   call WaitForError('E648:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:close!49', l[-1])
   let g:last += 3
 
   " Test for E650
   call appendbufline(cmdbufnr, '$', 'E650_Test')
   call WaitForError('E650:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:defineAnnoType!50 1 "abc" "a" "a" 1 1', l[-1])
   let g:last += 3
 
   " Test for E651
   call appendbufline(cmdbufnr, '$', 'E651_Test')
   call WaitForError('E651:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:addAnno!51 1 1 1 1', l[-1])
   let g:last += 3
 
   " Test for E652
   call appendbufline(cmdbufnr, '$', 'E652_Test')
   call WaitForError('E652:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:getAnno/52 8', '52 0'], l[-2:])
   let g:last += 4
 
   " editFile test
   call writefile(['foo bar1', 'foo bar2', 'foo bar3'], 'Xfile3')
   call appendbufline(cmdbufnr, '$', 'editFile_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 2:editFile!53 "Xfile3"', l[-2])
   call assert_match('0:fileOpened=0 ".*/Xfile3" T F', l[-1])
   call assert_equal('Xfile3', bufname())
@@ -274,37 +282,37 @@ func Nb_basic(port)
 
   " getLength test
   call appendbufline(cmdbufnr, '$', 'getLength_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 2:getLength/54', '54 27'], l[-2:])
   let g:last += 4
 
   " getModified test
   call appendbufline(cmdbufnr, '$', 'getModified_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 2:getModified/55', '55 0'], l[-2:])
   let g:last += 4
 
   " getText test
   call appendbufline(cmdbufnr, '$', 'getText_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 2:getText/56',
         \ '56 "foo bar1\nfoo bar2\nfoo bar3\n"'], l[-2:])
   let g:last += 4
 
   " setDot test
   call appendbufline(cmdbufnr, '$', 'setDot_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 2:setDot!57 3/6', l[-1])
   let g:last += 3
 
   " startDocumentListen test
   call appendbufline(cmdbufnr, '$', 'startDocumentListen_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 2:startDocumentListen!58', l[-1])
   let g:last += 3
 
@@ -312,8 +320,8 @@ func Nb_basic(port)
   " received the notifications
   call append(2, 'blue sky')
   1d
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_match('2:insert=\d\+ 18 "blue sky"', l[-3])
   call assert_match('2:insert=\d\+ 26 "\\n"', l[-2])
   call assert_match('2:remove=\d\+ 0 9', l[-1])
@@ -321,8 +329,8 @@ func Nb_basic(port)
 
   " stopDocumentListen test
   call appendbufline(cmdbufnr, '$', 'stopDocumentListen_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 2:stopDocumentListen!59', l[-1])
   let g:last += 3
 
@@ -335,8 +343,8 @@ func Nb_basic(port)
 
   " defineAnnoType test
   call appendbufline(cmdbufnr, '$', 'define_anno_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 2:defineAnnoType!60 1 "s1" "x" "=>" blue none', l[-1])
   sleep 1m
   call assert_equal({'name': '1', 'texthl': 'NB_s1', 'text': '=>'},
@@ -346,15 +354,15 @@ func Nb_basic(port)
   " defineAnnoType with a long color name
   call appendbufline(cmdbufnr, '$', 'E532_Test')
   call WaitForError('E532:')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 2:defineAnnoType!61 1 "s1" "x" "=>" aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa none', l[-1])
   let g:last += 3
 
   " addAnno test
   call appendbufline(cmdbufnr, '$', 'add_anno_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 2:addAnno!62 1 1 2/1 0', l[-1])
   sleep 1m
   call assert_equal([{'lnum': 2, 'id': 1, 'name': '1', 'priority': 10,
@@ -363,15 +371,15 @@ func Nb_basic(port)
 
   " getAnno test
   call appendbufline(cmdbufnr, '$', 'get_anno_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 2:getAnno/63 1', '63 2'], l[-2:])
   let g:last += 4
 
   " removeAnno test
   call appendbufline(cmdbufnr, '$', 'remove_anno_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 2:removeAnno!64 1', l[-1])
   sleep 1m
   call assert_equal([], sign_getplaced())
@@ -379,8 +387,8 @@ func Nb_basic(port)
 
   " getModified test to get the number of modified buffers
   call appendbufline(cmdbufnr, '$', 'getModifiedAll_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:getModified/65', '65 2'], l[-2:])
   let g:last += 4
 
@@ -388,8 +396,8 @@ func Nb_basic(port)
 
   " create test to create a new buffer
   call appendbufline(cmdbufnr, '$', 'create_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:create!66', l[-1])
   " Wait for vim to process the previous netbeans message
   sleep 10m
@@ -398,15 +406,15 @@ func Nb_basic(port)
 
   " setTitle test
   call appendbufline(cmdbufnr, '$', 'setTitle_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:setTitle!67 "Xfile4"', l[-1])
   let g:last += 3
 
   " setFullName test
   call appendbufline(cmdbufnr, '$', 'setFullName_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 5)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 5)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:setFullName!68 "Xfile4"', l[-3])
   call assert_match('0:fileOpened=0 ".*/Xfile4" T F', l[-1])
   call assert_equal('Xfile4', bufname())
@@ -414,65 +422,65 @@ func Nb_basic(port)
 
   " initDone test
   call appendbufline(cmdbufnr, '$', 'initDone_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:initDone!69', l[-1])
   let g:last += 3
 
   " setVisible test
   hide enew
   call appendbufline(cmdbufnr, '$', 'setVisible_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:setVisible!70 T', l[-1])
   let g:last += 3
 
   " setModtime test
   call appendbufline(cmdbufnr, '$', 'setModtime_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:setModtime!71 6', l[-1])
   let g:last += 3
 
   " insert test
   call appendbufline(cmdbufnr, '$', 'insert_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 3:insert/72 0 "line1\nline2\n"', '72'], l[-2:])
   call assert_equal(['line1', 'line2'], getline(1, '$'))
   let g:last += 4
 
   " remove test
   call appendbufline(cmdbufnr, '$', 'remove_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 3:remove/73 3 4', '73'], l[-2:])
   call assert_equal(['linine2'], getline(1, '$'))
   let g:last += 4
 
   " remove with invalid offset
   call appendbufline(cmdbufnr, '$', 'remove_invalid_offset_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 3:remove/74 900 4', '74 !bad position'], l[-2:])
   let g:last += 4
 
   " remove with invalid count
   call appendbufline(cmdbufnr, '$', 'remove_invalid_count_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 3:remove/75 1 800', '75 !bad count'], l[-2:])
   let g:last += 4
 
   " guard test
   %d
   call setline(1, ['foo bar', 'foo bar', 'foo bar'])
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 8)')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 8)')
   let g:last += 8
 
   call appendbufline(cmdbufnr, '$', 'guard_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:guard!76 8 7', l[-1])
   sleep 1m
   " second line is guarded. Try modifying the line
@@ -488,8 +496,8 @@ func Nb_basic(port)
 
   " setModified test
   call appendbufline(cmdbufnr, '$', 'setModified_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:setModified!77 T', l[-1])
   call assert_equal(1, &modified)
   let g:last += 3
@@ -497,8 +505,8 @@ func Nb_basic(port)
   " insertDone test
   let v:statusmsg = ''
   call appendbufline(cmdbufnr, '$', 'insertDone_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:insertDone!78 T F', l[-1])
   sleep 1m
   call assert_match('.*/Xfile4" 3L, 0B', v:statusmsg)
@@ -507,8 +515,8 @@ func Nb_basic(port)
   " saveDone test
   let v:statusmsg = ''
   call appendbufline(cmdbufnr, '$', 'saveDone_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:saveDone!79', l[-1])
   sleep 1m
   call assert_match('.*/Xfile4" 3L, 0B', v:statusmsg)
@@ -516,51 +524,51 @@ func Nb_basic(port)
 
   " unimplemented command test
   call appendbufline(cmdbufnr, '$', 'invalidcmd_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:invalidcmd!80', l[-1])
   let g:last += 3
 
   " unimplemented function test
   call appendbufline(cmdbufnr, '$', 'invalidfunc_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 3:invalidfunc/81', '81'], l[-2:])
   let g:last += 4
 
   " Test for removeAnno cmd failure
   call appendbufline(cmdbufnr, '$', 'removeAnno_fail_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:removeAnno/82 1', '82'], l[-2:])
   let g:last += 4
 
   " Test for guard cmd failure
   call appendbufline(cmdbufnr, '$', 'guard_fail_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:guard/83 1 1', '83'], l[-2:])
   let g:last += 4
 
   " Test for save cmd failure
   call appendbufline(cmdbufnr, '$', 'save_fail_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:save/84', '84'], l[-2:])
   let g:last += 4
 
   " Test for netbeansBuffer cmd failure
   call appendbufline(cmdbufnr, '$', 'netbeansBuffer_fail_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal(['send: 0:netbeansBuffer/85 T', '85'], l[-2:])
   let g:last += 4
 
   " nbkey test
   call cursor(3, 3)
   nbkey "\<C-F2>"
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal(['3:newDotAndMark=85 18 18',
         \ '3:keyCommand=85 ""\<C-F2>""',
         \ '3:keyAtPos=85 ""\<C-F2>"" 18 3/2'], l[-3:])
@@ -568,22 +576,22 @@ func Nb_basic(port)
 
   " setExitDelay test
   call appendbufline(cmdbufnr, '$', 'setExitDelay_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:setExitDelay!86 2', l[-1])
   let g:last += 3
 
   " setReadonly test
   call appendbufline(cmdbufnr, '$', 'setReadOnly_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:setReadOnly!87', l[-1])
   let g:last += 3
 
   " close test. Don't use buffer 10 after this
   call appendbufline(cmdbufnr, '$', 'close_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 4)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 4)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 3:close!88', l[-2])
   call assert_equal('3:killed=88', l[-1])
   call assert_equal(1, winnr('$'))
@@ -591,8 +599,8 @@ func Nb_basic(port)
 
   " specialKeys test
   call appendbufline(cmdbufnr, '$', 'specialKeys_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 3)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 3)')
+  let l = ReadXnetbeans()
   call assert_equal('send: 0:specialKeys!89 "F12 F13"', l[-1])
   sleep 1m
   call assert_equal(':nbkey F12<CR>', maparg('<F12>', 'n'))
@@ -602,25 +610,25 @@ func Nb_basic(port)
   " Open a buffer not monitored by netbeans
   enew | only!
   nbkey "\<C-F3>"
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 1)')
-  let l = readfile('Xnetbeans')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 1)')
+  let l = ReadXnetbeans()
   call assert_equal('0:fileOpened=0 "" T F', l[-1])
   let g:last += 1
 
   " Test for writing a netbeans buffer
   call appendbufline(cmdbufnr, '$', 'nbbufwrite_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 5)')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 5)')
   call assert_fails('write', 'E656:')
   call setline(1, ['one', 'two'])
   call assert_fails('1write!', 'E657:')
   write
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 10)')
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 10)')
   let g:last += 10
 
   " detach
   call appendbufline(cmdbufnr, '$', 'detach_Test')
-  call WaitFor('len(readfile("Xnetbeans")) >= (g:last + 8)')
-  call WaitForAssert({-> assert_equal('0:disconnect=93', readfile("Xnetbeans")[-1])})
+  call WaitFor('len(ReadXnetbeans()) >= (g:last + 8)')
+  call WaitForAssert({-> assert_equal('0:disconnect=93', ReadXnetbeans()[-1])})
 
   " the connection was closed
   call assert_false(has("netbeans_enabled"))
@@ -649,9 +657,9 @@ func Nb_file_auth(port)
   exe 'nbstart =Xnbauth'
   call assert_true(has("netbeans_enabled"))
 
-  call WaitFor('len(readfile("Xnetbeans")) > 2')
+  call WaitFor('len(ReadXnetbeans()) > 2')
   nbclose
-  let lines = readfile("Xnetbeans")
+  let lines = ReadXnetbeans()
   call assert_equal('AUTH bunny', lines[0])
   call assert_equal('0:version=0 "2.5"', lines[1])
   call assert_equal('0:startupDone=0', lines[2])
@@ -675,16 +683,16 @@ func Nb_quit_with_conn(port)
     " Establish the connection with the netbeans server
     exe 'nbstart :localhost:' .. g:port .. ':star'
     call assert_true(has("netbeans_enabled"))
-    call WaitFor('len(readfile("Xnetbeans")) >= 3')
-    let l = readfile("Xnetbeans")
+    call WaitFor('len(ReadXnetbeans()) >= 3')
+    let l = ReadXnetbeans()
     call assert_equal(['AUTH star',
       \ '0:version=0 "2.5"',
       \ '0:startupDone=0'], l[-3:])
 
     " Open the command buffer to communicate with the server
     split Xcmdbuf
-    call WaitFor('len(readfile("Xnetbeans")) >= 6')
-    let l = readfile("Xnetbeans")
+    call WaitFor('len(ReadXnetbeans()) >= 6')
+    let l = ReadXnetbeans()
     call assert_equal('0:fileOpened=0 "Xcmdbuf" T F',
           \ substitute(l[-3], '".*/', '"', ''))
     call assert_equal('send: 1:putBufferNumber!15 "Xcmdbuf"',
@@ -696,8 +704,8 @@ func Nb_quit_with_conn(port)
     quit!
   END
   if RunVim(['let g:port = ' .. a:port], after, '')
-    call WaitFor('len(readfile("Xnetbeans")) >= 9')
-    let l = readfile('Xnetbeans')
+    call WaitFor('len(ReadXnetbeans()) >= 9')
+    let l = ReadXnetbeans()
     call assert_equal('1:unmodified=16', l[-3])
     call assert_equal('1:killed=16', l[-2])
     call assert_equal('0:disconnect=16', l[-1])


### PR DESCRIPTION
netbeans.c sends "0:geometry=..." messages when window's position, size,
or Z order are changed on Windows GUI.  It adds unexpected lines in
"Xnetbeans" file, and causes failures on check.

This change wraps to reading "Xnetbeans" and removes "0:geometry="
lines. It makes stabilize tests for netbeans.