### PR TITLE
override 'iskeyword' in classes_test for Windows

### DIFF
--- a/src/testdir/test_regexp_utf8.vim
+++ b/src/testdir/test_regexp_utf8.vim
@@ -32,6 +32,9 @@ func Test_equivalence_re2()
 endfunc
 
 func s:classes_test()
+  if has('win32')
+    set iskeyword=@,48-57,_,192-255
+  endif
   set isprint=@,161-255
   call assert_equal('Motörhead', matchstr('Motörhead', '[[:print:]]\+'))
 


### PR DESCRIPTION
`Test_classes_re1()` and `Test_classes_re2()` are failed on Windows.
This PR will fix those.

Vim uses special `'iskeyword'` for Windows: `@,48-57,_,128-167,224-235`
It works well for native encodings (CP932 or so), but doesn't for UTF-8