### PR TITLE
tabline: fix overflow

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4235,6 +4235,11 @@ build_stl_str_hl(
 		    for (n = groupitem[groupdepth] + 1; n < curitem; n++)
 			if (item[n].type == Highlight)
 			    item[n].type = Empty;
+		    // Adjust the start position of TabPage to the next item
+		    // position.
+		    for (n = groupitem[groupdepth] + 1; n < curitem; n++)
+			if (item[n].type == TabPage)
+			    item[n].start = p;
 		}
 	    }
 	    if (l > item[groupitem[groupdepth]].maxwid)


### PR DESCRIPTION
**Describe the bug**
When creating a tabline, an overflow of the `TabPageIdxs` array occurs.

**To Reproduce**
minimal.vim
```vim
function! MyTabname(n) abort
  return ""
endfunction

function! MakeTabLine() abort
  let titles = map(range(1, tabpagenr('$')), '"%( %".v:val."T%{MyTabname(".v:val.")}%T %)"')
  let sep = 'あ'
  let tabpages = join(titles, sep)
  return tabpages . sep . '%=%999X X'
endfunction

set tabline=%!MakeTabLine()
tabnew
```

```
valgrind --log-file=vim.log src/vim -Nu NORC
:so minimal.vim
```
vim.log
```
==4399== Invalid write of size 2
==4399==    at 0x30061D: win_redr_custom (screen.c:1351)
==4399==    by 0x306124: draw_tabline (screen.c:4399)
==4399==    by 0x1AD6C2: update_screen (drawscreen.c:258)
==4399==    by 0x41DA33: main_loop (main.c:1398)
==4399==    by 0x41D0DC: vim_main2 (main.c:898)
==4399==    by 0x41C8F2: main (main.c:442)
==4399==  Address 0x6078280 is 0 bytes after a block of size 320 alloc'd
==4399==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4399==    by 0x273A1D: lalloc (misc2.c:925)
==4399==    by 0x302C82: screenalloc (screen.c:2644)
==4399==    by 0x303A44: screenclear (screen.c:2897)
==4399==    by 0x35BCE0: set_shellsize (term.c:3424)
==4399==    by 0x35A1DC: set_termname (term.c:2106)
==4399==    by 0x35A88B: termcapinit (term.c:2482)
==4399==    by 0x41C794: main (main.c:378)
```

**Environment (please complete the following information):**
 - Vim version 8.2.1258
 - OS: N/A
 - Terminal: N/A

**Additional context**
The output of `Columns`, `tabtab` and `len` by gdb at the point of overflow is as follows.
```
Breakpoint 1 at 0x1f85a6: file screen.c, line 1346.
Type commands for breakpoint(s) 1, one per line.
End with a line saying just "end".
Breakpoint 2 at 0x1f85f7: file screen.c, line 1350.
Type commands for breakpoint(s) 2, one per line.
End with a line saying just "end".
Starting program: /home/erw7/src/github.com/vim/vim/src/vim -Nu NORC
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Breakpoint 1, win_redr_custom (wp=0x0, draw_ruler=0) at screen.c:1346
1346		fillchar = 0;
$1 = 80

Breakpoint 2, win_redr_custom (wp=0x0, draw_ruler=0) at screen.c:1350
1350		    while (col < len)
$2 = {start = 0x7ffffffed2f1 "\201\202あ", ' ' <repeats 75 times>, "X", 
  userhl = 1}
$3 = 2

Breakpoint 2, win_redr_custom (wp=0x0, draw_ruler=0) at screen.c:1350
1350		    while (col < len)
$4 = {start = 0x7ffffffed2f1 "\201\202あ", ' ' <repeats 75 times>, "X", 
  userhl = 0}
$5 = 2

Breakpoint 2, win_redr_custom (wp=0x0, draw_ruler=0) at screen.c:1350
1350		    while (col < len)
$6 = {start = 0x7ffffffed2f4 "\201\202", ' ' <repeats 75 times>, "X", 
  userhl = 2}
$7 = 12

Breakpoint 2, win_redr_custom (wp=0x0, draw_ruler=0) at screen.c:1350
1350		    while (col < len)
$8 = {start = 0x7ffffffed2f4 "\201\202", ' ' <repeats 75 times>, "X", 
  userhl = 0}
$9 = 12

Breakpoint 2, win_redr_custom (wp=0x0, draw_ruler=0) at screen.c:1350
1350		    while (col < len)
$10 = {start = 0x7ffffffed340 " X", userhl = -999}
$11 = 94
[Inferior 1 (process 6417) exited normally]
quit
```

It may be an issue with `vim_strnsize`, but adjusting the start position of the `TabPage` when deleting an empty group in `build_stl_str_hl` solves this problem. In the case of `%( %1T %)foo%T`, it is unclear from reading `h: 'statusline'` whether it should be removed or not, so it should remain in this PR. If you want to delete it, just set `item[n].type=Empty;` instead of `item[n].start = p;`.