### PR TITLE
syntax: pamconf: recognize '-' at the beginning

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1144,7 +1144,7 @@ au BufNewFile,BufRead *.hook
 	\ endif
 
 " Pam conf
-au BufNewFile,BufRead */etc/pam.conf			setf pamconf
+au BufNewFile,BufRead */etc/pam.conf			let b:pamconf_has_service_field = 1 | setf pamconf
 
 " Pam environment
 au BufNewFile,BufRead pam_env.conf,.pam_environment	setf pamenv

--- a/runtime/syntax/pamconf.vim
+++ b/runtime/syntax/pamconf.vim
@@ -11,22 +11,27 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-syn match   pamconfService          '^[[:graph:]]\+'
-                                    \ nextgroup=pamconfType,
-                                    \ pamconfServiceLineCont skipwhite
+syn match   pamconfType             '-\?[[:alpha:]]\+'
+                                    \ contains=pamconfTypeKeyword
+                                    \ nextgroup=pamconfControl,
+                                    \ pamconfTypeLineCont skipwhite
+
+syn keyword pamconfTypeKeyword      contained account auth password session
+
+if exists("b:pamconf_has_service_field") && b:pamconf_has_service_field != 0
+    syn match   pamconfService          '^[[:graph:]]\+'
+                                        \ nextgroup=pamconfType,
+                                        \ pamconfServiceLineCont skipwhite
+
+    syn match   pamconfServiceLineCont  contained '\\$'
+                                        \ nextgroup=pamconfType,
+                                        \ pamconfServiceLineCont skipwhite skipnl
+endif
 
 syn keyword pamconfTodo             contained TODO FIXME XXX NOTE
 
 syn region  pamconfComment          display oneline start='#' end='$'
                                     \ contains=pamconfTodo,@Spell
-
-syn match   pamconfServiceLineCont  contained '\\$'
-                                    \ nextgroup=pamconfType,
-                                    \ pamconfServiceLineCont skipwhite skipnl
-
-syn keyword pamconfType             account auth password session
-                                    \ nextgroup=pamconfControl,
-                                    \ pamconfTypeLineCont skipwhite
 
 syn match   pamconfTypeLineCont     contained '\\$'
                                     \ nextgroup=pamconfControl,
@@ -98,7 +103,8 @@ hi def link pamconfTodo             Todo
 hi def link pamconfComment          Comment
 hi def link pamconfService          Statement
 hi def link pamconfServiceLineCont  Special
-hi def link pamconfType             Type
+hi def link pamconfType             Special
+hi def link pamconfTypeKeyword      Type
 hi def link pamconfTypeLineCont     pamconfServiceLineCont
 hi def link pamconfControl          Macro
 hi def link pamconfControlBegin     Delimiter


### PR DESCRIPTION
Let vim recognize `-` at the beginning of a line in `pam.conf`. See `PAM.CONF(5)` for the relevant documentation.