### PR TITLE
reset PROMPT setting

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -117,6 +117,10 @@ set shellslash
 
 let s:srcdir = expand('%:p:h:h')
 
+if has('win32')
+  let $PROMPT = '$P$G'
+endif
+
 " Prepare for calling test_garbagecollect_now().
 let v:testing = 1
 


### PR DESCRIPTION
Tests may be failed when PROMPT is multiple lines. like this:

```bat
PROMPT [32m%USERNAME%@%COMPUTERNAME%[0m [33m$P[0m$_$G 
```

Where `$_` means new line.

![image](https://user-images.githubusercontent.com/468368/88179321-b1351d00-cc66-11ea-8003-d00c9ba99179.png)
