### PR TITLE
make sure Xfile is removed on Windows

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -808,6 +808,12 @@ func Test_terminal_redir_file()
   endif
   let g:job = term_getjob(buf)
   call WaitForAssert({-> assert_equal("dead", job_status(g:job))})
+  if has('win32')
+    " On Windows, can't delete files which are being used by process.  When
+    " job_status() returns "dead", a process of job remains for ashort time.
+    " So we need to wait a little.
+    sleep 50m
+  endif
   call delete('Xfile')
   bwipe
 


### PR DESCRIPTION
On Windows, removing file which used by job process may fail.
Because the process may not end when `job_status()` returns `"dead"`.
It takes a short time to finish process completely.

If `Xfile` is remained, it causes a failure on `Test_undofile_earlier()` in test_undo.vim
(when running all tests with `nmake -f Make_dos.mak default` in src/testdir)
