### PR TITLE
use "more.com" instead of "more(.exe)"

### DIFF
--- a/src/testdir/test_system.vim
+++ b/src/testdir/test_system.vim
@@ -13,9 +13,9 @@ func Test_System()
   else
     call assert_equal("123\n", system('echo 123'))
     call assert_equal(["123\r"], systemlist('echo 123'))
-    call assert_equal("123\n",   system('more', '123'))
-    call assert_equal(["123\r"], systemlist('more', '123'))
-    call assert_equal(["as\r", "df\r"], systemlist('more', ["as\<NL>df"]))
+    call assert_equal("123\n",   system('more.com', '123'))
+    call assert_equal(["123\r"], systemlist('more.com', '123'))
+    call assert_equal(["as\r", "df\r"], systemlist('more.com', ["as\<NL>df"]))
   endif
 
   new Xdummy
@@ -42,7 +42,7 @@ func Test_System()
     let out = systemlist('cat', bufnr('%'))
     call assert_equal(['asdf', "pw\<NL>er", 'xxxx'],  out)
   else
-    let out = systemlist('more', bufnr('%'))
+    let out = systemlist('more.com', bufnr('%'))
     call assert_equal(["asdf\r", "pw\r", "er\r", "xxxx\r"],  out)
   endif
   bwipe!


### PR DESCRIPTION
test_system.vim may fail if more.exe (from msys2 or so) is installed to
Windows box. test_system.vim expects that "more" means Windows's one,
and it can be specified by "more.com" explicitly