### PR TITLE
Fixed compiler warning with gcc-10

### DIFF
--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -198,11 +198,11 @@ find_exported(
 	char_u	*funcname;
 
 	// it could be a user function.
-	if (STRLEN(name) < sizeof(buffer) - 10)
+	if (STRLEN(name) < sizeof(buffer) - 15)
 	    funcname = buffer;
 	else
 	{
-	    funcname = alloc(STRLEN(name) + 10);
+	    funcname = alloc(STRLEN(name) + 15);
 	    if (funcname == NULL)
 		return -1;
 	}


### PR DESCRIPTION
Compiling vim-8.2.1273 with gcc-10, I get this warning:
```
gcc-10 -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_GTK  -pthread -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gtk-3.0 -I/usr/include/gio-unix-2.0/ -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng16 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include   -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/vim9script.o vim9script.c
vim9script.c: In function ‘find_exported’:
vim9script.c:212:37: warning: ‘%s’ directive writing up to 189 bytes into a region of size between 185 and 195 [-Wformat-overflow=]
  212 |  sprintf((char *)funcname + 3, "%ld_%s", (long)sid, name);
      |                                     ^~
In file included from /usr/include/stdio.h:862,
                 from os_unix.h:21,
                 from vim.h:230,
                 from vim9script.c:14:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:33:10: note: ‘__builtin_sprintf’ output between 3 and 202 bytes into a destination of size 197
   33 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   34 |       __bos (__s), __fmt, __va_arg_pack ());
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Replacing 10 with 15 at vim9script.c:201 & vim9script:205 fixes it (15 being the smallest value which fixes the warning).