### PR TITLE
GTK: gvim cannot map ':' in terminal

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2922,8 +2922,8 @@ may_remove_shift_modifier(int modifiers, int key)
     if ((modifiers == MOD_MASK_SHIFT
 		|| modifiers == (MOD_MASK_SHIFT | MOD_MASK_ALT)
 		|| modifiers == (MOD_MASK_SHIFT | MOD_MASK_META))
-	    && ((key >= '@' && key <= 'Z')
-		|| key == '^' || key == '_'
+	    && ((key >= '!' && key <= '/')
+		|| (key >= ':' && key <= '`')
 		|| (key >= '{' && key <= '~')))
 	return modifiers & ~MOD_MASK_SHIFT;
     return modifiers;


### PR DESCRIPTION
GTK gvim cannot map ':' in terminal. `:tnoremap : <C-w>:` never work with GTK gvim.

This removes `MOD_MASK_SHIFT` from `modifier` for `:` and other marks in `may_remove_shift_modifier()`.

Which marks are require SHIFT to typing, are depending on language of keyboard.
For example, `:` requres SHIFT on English keyboard, but Japanese keyboard doesn't.
So I changed that all marks and uppercase alphabets in ASCII, remove SHIFT mask from `modifier`.

fix: https://github.com/vim-jp/issues/issues/1347