### PR TITLE
Add angle brackets to matchpairs for c++

### DIFF
--- a/runtime/ftplugin/cpp.vim
+++ b/runtime/ftplugin/cpp.vim
@@ -10,4 +10,7 @@ endif
 
 " Behaves just like C
 runtime! ftplugin/c.vim ftplugin/c_*.vim ftplugin/c/*.vim
+
+" C++ uses <things>
 set matchpairs+=<:>
+let b:undo_ftplugin ..= ' | setl matchpairs<'

--- a/runtime/ftplugin/cpp.vim
+++ b/runtime/ftplugin/cpp.vim
@@ -10,3 +10,4 @@ endif
 
 " Behaves just like C
 runtime! ftplugin/c.vim ftplugin/c_*.vim ftplugin/c/*.vim
+set matchpairs+=<:>


### PR DESCRIPTION
C++ uses '<' and '>' in pairs quite often.  Adding `<:>` to `matchpairs` in the C++ filetype plugin makes matching these on complex types easier.