### PR TITLE
doc: Use gender-neutral pronouns in the docs.

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -34,7 +34,7 @@ balance must be found between them.
 VIM IS... VI COMPATIBLE					*design-compatible*
 
 First of all, it should be possible to use Vim as a drop-in replacement for
-Vi.  When the user wants to, he can use Vim in compatible mode and hardly
+Vi.  When the user wants to, they can use Vim in compatible mode and hardly
 notice any difference with the original Vi.
 
 Exceptions:

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1547,7 +1547,7 @@ Notes:
 - Text you copy or delete goes to the numbered registers.  The registers can
   be saved in the .viminfo file, where they could be read.  Change your
   'viminfo' option to be safe.
-- Someone can type commands in Vim when you walk away for a moment, he should
+- Someone can type commands in Vim when you walk away for a moment, they should
   not be able to get the key.
 - If you make a typing mistake when entering the key, you might not be able to
   get your text back!

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -368,15 +368,5 @@ highlighting.  So do these:
 
 You can find the details in $VIMRUNTIME/syntax/help.vim
 
-							*inclusion*
-Some people make a big deal about using "his" when referring to the user,
-thinking it means we assume the user is male.  That is of course not the case,
-it's just a habit of writing help text, which quite often is many years old.
-Also, a lot of the text is written by contributors for who English is not
-their first language.  We do not make any assumptions about the gender of the
-user, no matter how the text is phrased.  And we do not want to waste time on
-this discussion.  The goal is that the reader understands how Vim works, the
-exact wording is secondary.
-
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -918,8 +918,8 @@ Note that for `has('pythonx')` to work it may try to dynamically load Python 3
 or 2.  This may have side effects, especially when Vim can only load one of
 the two.
 
-If a user prefers Python 2 and want to fallback to Python 3, he needs to set
-'pyxversion' explicitly in his |.vimrc|.  E.g.: >
+If a user prefers Python 2 and wants to fallback to Python 3, they need to set
+'pyxversion' explicitly in their |.vimrc|.  E.g.: >
 	if has('python')
 	  set pyx=2
 	elseif has('python3')

--- a/runtime/doc/pi_getscript.txt
+++ b/runtime/doc/pi_getscript.txt
@@ -149,7 +149,7 @@ vim.sf.net; whenever it is greater than the one stored in the
 GetLatestVimScripts.dat file, the script will be downloaded
 (see |GetLatestVimScripts_dat|).
 
-If your script's author has included a special comment line in his/her plugin,
+If your script's author has included a special comment line in their plugin,
 the plugin itself will be used by GetLatestVimScripts to build your
 <GetLatestVimScripts.dat> file, including any dependencies on other scripts it
 may have.  As an example, consider: >
@@ -177,7 +177,7 @@ In summary:
 <   in an already-downloaded plugin constitutes the concurrence of the
     plugin author that getscript may do AutoInstall.  Not all plugins
     may be AutoInstall-able, and the plugin's author is best situated
-    to know whether or not his/her plugin will AutoInstall properly.
+    to know whether or not their plugin will AutoInstall properly.
 
   * A line such as >
 	884 1 :AutoInstall: AutoAlign.vim
@@ -334,9 +334,9 @@ after/syntax/c.vim contained in it to overwrite a user's c.vim.
 <	default= 1
 		This variable indicates whether GetLatestVimScripts is allowed
 		to attempt to automatically install scripts.  Furthermore, the
-		plugin author has to have explicitly indicated that his/her
-		plugin is automatically installable (via the :AutoInstall:
-		keyword in the GetLatestVimScripts comment line).
+		plugin author has to have explicitly indicated that their plugin
+		is automatically installable (via the :AutoInstall: keyword in
+		the GetLatestVimScripts comment line).
 >
 	g:GetLatestVimScripts_autoinstalldir
 <	default= $HOME/.vim     (linux)

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -3175,8 +3175,8 @@ window, then the one window will be horizontally split (by default).
 If there's more than one window, the previous window will be re-used on
 the selected file/directory.  If the previous window's associated buffer
 has been modified, and there's only one window with that buffer, then
-the user will be asked if s/he wishes to save the buffer first (yes,
-no, or cancel).
+the user will be asked if they wish to save the buffer first (yes, no, or
+cancel).
 
 Related Actions |netrw-cr| |netrw-o| |netrw-t| |netrw-v|
 Associated setting variables:

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -64,7 +64,7 @@ Disadvantages:
   directories (although Vim tries to avoid that by comparing the path name).
   This will result in bogus ATTENTION warning messages.
 - When you use your home directory, and somebody else tries to edit the same
-  file, he will not see your swap file and will not get the ATTENTION warning
+  file, they will not see your swap file and will not get the ATTENTION warning
   message.
 On the Amiga you can also use a recoverable ram disk, but there is no 100%
 guarantee that this works.  Putting swap files in a normal ram disk (like RAM:

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -643,7 +643,7 @@ This assumes you write one or more plugins that you distribute as a package.
 
 If you have two unrelated plugins you would use two packages, so that Vim
 users can chose what they include or not.  Or you can decide to use one
-package with optional plugins, and tell the user to add the ones he wants with
+package with optional plugins, and tell the user to add the ones they want with
 `:packadd`.
 
 Decide how you want to distribute the package.  You can create an archive or
@@ -679,9 +679,9 @@ You could add this packadd command in one of your plugins, to be executed when
 the optional plugin is needed.
 
 Run the `:helptags` command to generate the doc/tags file.  Including this
-generated file in the package means that the user can drop the package in his
-pack directory and the help command works right away.  Don't forget to re-run
-the command after changing the plugin help: >
+generated file in the package means that the user can drop the package in
+their pack directory and the help command works right away.  Don't forget to
+re-run the command after changing the plugin help: >
 	:helptags path/start/foobar/doc
 	:helptags path/opt/fooextra/doc
 

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1445,7 +1445,7 @@ are spelling mistakes this may not be quite right.
 Common words can be specified with the COMMON item.  This will give better
 suggestions when editing a short file.  Example:
 
-	COMMON  the of to and a in is it you that he was for on are ~
+	COMMON  the of to and a in is it you that he she they was for on are ~
 
 The words must be separated by white space, up to 25 per line.
 When multiple regions are specified in a ":mkspell" command the common words

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2000,7 +2000,7 @@ LEX						*lex.vim* *ft-lex-syntax*
 Lex uses brute-force synchronizing as the "^%%$" section delimiter
 gives no clue as to what section follows.  Consequently, the value for >
 	:syn sync minlines=300
-may be changed by the user if s/he is experiencing synchronization
+may be changed by the user if they are experiencing synchronization
 difficulties (such as may happen with large lex files).
 
 
@@ -3039,11 +3039,11 @@ variables in your <.vimrc>:
 
 <   (dash users should use posix)
 
-If there's no "#! ..." line, and the user hasn't availed himself/herself of a
-default sh.vim syntax setting as just shown, then syntax/sh.vim will assume
-the Bourne shell syntax.  No need to quote RFCs or market penetration
-statistics in error reports, please -- just select the default version of the
-sh your system uses and install the associated "let..." in your <.vimrc>.
+If there's no "#! ..." line, and the user hasn't availed themself of a default
+sh.vim syntax setting as just shown, then syntax/sh.vim will assume the Bourne
+shell syntax.  No need to quote RFCs or market penetration statistics in error
+reports, please -- just select the default version of the sh your system uses
+and install the associated "let..." in your <.vimrc>.
 
 The syntax/sh.vim file provides several levels of syntax-based folding: >
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7399,7 +7399,6 @@ in_name	channel.txt	/*in_name*
 in_top	channel.txt	/*in_top*
 inactive-buffer	windows.txt	/*inactive-buffer*
 include-search	tagsrch.txt	/*include-search*
-inclusion	helphelp.txt	/*inclusion*
 inclusive	motion.txt	/*inclusive*
 incomp-small-6	version6.txt	/*incomp-small-6*
 incompatible-5	version5.txt	/*incompatible-5*

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -3810,7 +3810,7 @@ Macintosh:
     two lines at a time.  "k" doesn't do this. (Cory T. Echols)
 8   When write_viminfo() is used while there are many orphaned viminfo
     tempfiles writing the viminfo file fails.  Give a clear error message so
-    that the user knows he has to delete the files.
+    that the user knows they have to delete the files.
 7   It's possible to redefine a script-local function with ":func
     <SNR>123_Test()". (Krishna)  Disallow this.
 
@@ -3983,8 +3983,8 @@ Help:
 -   Support a way to view (and edit) .info files.
 -   Implement a "sticky" help window, some help text lines that are always
     displayed in a window with fixed height. (Guckes)  Use "~/.vimhelp" file,
-    user can edit it to insert his favorite commands, new account can contain a
-    default contents.
+    user can edit it to insert their favorite commands, new account can
+    contain a default contents.
 -   Make 'winminheight' a local option, so that the user can set a minimal
     height for the help window (and other windows).
 -   ":help :s^I" should expand to ":help :substitute".
@@ -5750,8 +5750,8 @@ Modelines:
     .cpp files.
 -   Support the "abbreviate" command in modelines (Kearns).  Careful for
     characters after <Esc>, that is a security leak.
--   Add option setting to ask user if he wants to have the modelines executed
-    or not.  Same for .exrc in local dir.
+-   Add option setting to ask the user if they want to have the modelines
+    executed or not.  Same for .exrc in local dir.
 
 
 Sessions:

--- a/runtime/doc/usr_23.txt
+++ b/runtime/doc/usr_23.txt
@@ -210,7 +210,7 @@ LIMITS ON ENCRYPTION
 
 The encryption algorithm used by Vim is not very strong.  It is good enough to
 keep out the casual prowler, but not good enough to keep out a cryptology
-expert with lots of time on his hands.  The text in the swap file and the undo
+expert with lots of time on their hands.  The text in the swap file and the undo
 file is also encrypted.  However, this is done block-by-block and may reduce
 the time needed to crack a password.  You can disable the swap file, but then
 a crash will cause you to lose your work, since Vim keeps all the text in

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -370,8 +370,8 @@ displaying the line.  The text in the file remains unchanged.
 	|letter generation program for a b|
 	|ank.  They wanted to send out a s|
 	|pecial, personalized letter to th|
-	|eir richest 1000 customers.  Unfo|
-	|rtunately for the programmer, he |
+	|eir richest 1000 customers.  Lame|
+	|ntably for the programmer, they  |
 	+---------------------------------+
 After: >
 
@@ -384,7 +384,7 @@ it looks like this:
 	|bank.  They wanted to send out a |
 	|special, personalized letter to  |
 	|their richest 1000 customers.    |
-	|Unfortunately for the programmer,|
+	|Lamentably for the programmer,   |
 	+---------------------------------+
 
 Related options:

--- a/runtime/doc/usr_28.txt
+++ b/runtime/doc/usr_28.txt
@@ -342,8 +342,8 @@ by a ">" before the line.  To fold these quotes use this: >
 
 You can try it out on this text:
 
-> quoted text he wrote
-> quoted text he wrote
+> quoted text they wrote
+> quoted text they wrote
 > > double quoted text I wrote
 > > double quoted text I wrote
 

--- a/runtime/doc/usr_40.txt
+++ b/runtime/doc/usr_40.txt
@@ -335,7 +335,7 @@ Now when you type >
 Vim echoes "Hello World".  However, if you add a double quote, it won't work.
 For example: >
 
-	:Say he said "hello"
+	:Say they said "hello"
 
 To get special characters turned into a string, properly escaped to use as an
 expression, use "<q-args>": >
@@ -344,7 +344,7 @@ expression, use "<q-args>": >
 
 Now the above ":Say" command will result in this to be executed: >
 
-	:echo "he said \"hello\""
+	:echo "they said \"hello\""
 
 The <f-args> keyword contains the same information as the <args> keyword,
 except in a format suitable for use as function call arguments.  For example:

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -2015,7 +2015,7 @@ NOT LOADING
 
 It's possible that a user doesn't always want to load this plugin.  Or the
 system administrator has dropped it in the system-wide plugin directory, but a
-user has his own plugin he wants to use.  Then the user must have a chance to
+user has their own plugin they want to use.  Then the user must have a chance to
 disable loading this specific plugin.  This will make it possible: >
 
   6	if exists("g:loaded_typecorr")
@@ -2048,7 +2048,7 @@ item can be used: >
 
 The "<Plug>TypecorrAdd" thing will do the work, more about that further on.
 
-The user can set the "mapleader" variable to the key sequence that he wants
+The user can set the "mapleader" variable to the key sequence that they want
 this mapping to start with.  Thus if the user has done: >
 
 	let mapleader = "_"
@@ -2059,7 +2059,7 @@ will be used, which is a backslash.  Then a map for "\a" will be defined.
 Note that <unique> is used, this will cause an error message if the mapping
 already happened to exist. |:map-<unique>|
 
-But what if the user wants to define his own key sequence?  We can allow that
+But what if the user wants to define their own key sequence?  We can allow that
 with this mechanism: >
 
  21	if !hasmapto('<Plug>TypecorrAdd')
@@ -2068,7 +2068,7 @@ with this mechanism: >
 
 This checks if a mapping to "<Plug>TypecorrAdd" already exists, and only
 defines the mapping from "<Leader>a" if it doesn't.  The user then has a
-chance of putting this in his vimrc file: >
+chance of putting this in their vimrc file: >
 
 	map ,c  <Plug>TypecorrAdd
 
@@ -2173,7 +2173,7 @@ Now let's add a user command to add a correction: >
 The user command is defined only if no command with the same name already
 exists.  Otherwise we would get an error here.  Overriding the existing user
 command with ":command!" is not a good idea, this would probably make the user
-wonder why the command he defined himself doesn't work.  |:command|
+wonder why the command they defined themself doesn't work.  |:command|
 
 
 SCRIPT VARIABLES
@@ -2425,7 +2425,7 @@ An example of how to define functionality in a filetype plugin: >
 |hasmapto()| is used to check if the user has already defined a map to
 <Plug>JavaImport.  If not, then the filetype plugin defines the default
 mapping.  This starts with |<LocalLeader>|, which allows the user to select
-the key(s) he wants filetype plugin mappings to start with.  The default is a
+the key(s) they want filetype plugin mappings to start with.  The default is a
 backslash.
 "<unique>" is used to give an error message if the mapping already exists or
 overlaps with an existing mapping.

--- a/runtime/doc/usr_42.txt
+++ b/runtime/doc/usr_42.txt
@@ -211,7 +211,7 @@ argument: >
 
 Don't use "<silent>" too often.  It is not needed for short commands.  If you
 make a menu for someone else, being able the see the executed command will
-give him a hint about what he could have typed, instead of using the mouse.
+give them a hint about what they could have typed, instead of using the mouse.
 
 
 LISTING MENUS

--- a/runtime/doc/version6.txt
+++ b/runtime/doc/version6.txt
@@ -1867,7 +1867,7 @@ Highlighting:
 - Added "default" argument for ":highlight".  When included, the command is
   ignored if highlighting for the group was already defined.
   All syntax files now use ":hi default ..." to allow the user to specify
-  colors in his vimrc file.  Also, the "if did_xxx_syntax_inits" is not needed
+  colors in their vimrc file.  Also, the "if did_xxx_syntax_inits" is not needed
   anymore.  This greatly simplifies using non-default colors for a specific
   language.
 - Adjusted colortest.vim: Included colors on normal background and reduced the
@@ -2101,7 +2101,7 @@ Added src/README.txt to give an overview of the main parts of the source code.
 The Unix Makefile now fully supports using $(DESTDIR) to install to a specific
 location.  Replaces the manual setting of *ENDLOC variables.
 
-Added the possibility for a maintainer of a binary version to include his
+Added the possibility for a maintainer of a binary version to include their
 e-mail address with the --with-compiledby configure argument.
 
 Included features are now grouped in "tiny", "small", "normal", "big" and

--- a/runtime/doc/version8.txt
+++ b/runtime/doc/version8.txt
@@ -22293,7 +22293,7 @@ Solution:   Add it to the list of flaky tests.
 Files:      src/testdir/runtest.vim
 
 Patch 8.0.1263
-Problem:    Others can read the swap file if a user is careless with his
+Problem:    Others can read the swap file if a user is careless with their
             primary group.
 Solution:   If the group permission allows for reading but the world
             permissions doesn't, make sure the group is right.


### PR DESCRIPTION
This pull request replaces gendered pronouns in the documentation with gender-neutral ones. I've followed the [Google developer documentation style guide](https://developers.google.com/style/pronouns) on how to write gender-neutral technical documentation, and to find instances of gendered language in the documentation, I've been running the following commands:
```
rg '\bhe\b' runtime/doc
rg '\bhim\b' runtime/doc
rg '\bhis\b' runtime/doc
rg '\bhimself\b' runtime/doc
rg '\bshe\b' runtime/doc
rg '\bher\b' runtime/doc
rg '\bhers\b' runtime/doc
rg '\bherself\b' runtime/doc
```

In addition, I think the section about inclusion in [`runtime/doc/helphelp.txt`](https://github.com/vim/vim/blob/master/runtime/doc/helphelp.txt#L371-L379) which was added in eab6dff19f387469a200011bc6cf3508f5e43a4a causes unnecessary harm, and I'd suggest that it is either removed from the documentation or updated to encourage people to create pull requests when they stumble upon gendered language in the documentation. If there is any interest in the latter, I am more than happy to help out.