### PR TITLE
Improve test coverage of 'smartcase'

### DIFF
--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -608,7 +608,7 @@ func Test_search_cmdline6()
 endfunc
 
 func Test_search_cmdline7()
-  " Test that an pressing <c-g> in an empty command line
+  " Test that pressing <c-g> in an empty command line
   " does not move the cursor
   CheckOption incsearch
 
@@ -1640,7 +1640,19 @@ func Test_search_smartcase()
   call feedkeys('/\_.\%(\uello\)\' .. "\<CR>", 'xt')
   call assert_equal([2, 4], [line('.'), col('.')])
 
+  " Test 'smartcase' with utf-8.
+  let save_enc = &encoding
+  set encoding=utf8 ignorecase smartcase
+  call setline(1, 'Café cafÉ')
+  1s/café/x/g
+  call assert_equal('x x', getline(1))
+
+  call setline(1, 'Café cafÉ')
+  1s/cafÉ/x/g
+  call assert_equal('Café x', getline(1))
+
   set ignorecase& smartcase&
+  let &encoding = save_enc
   close!
 endfunc
 

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -1640,9 +1640,16 @@ func Test_search_smartcase()
   call feedkeys('/\_.\%(\uello\)\' .. "\<CR>", 'xt')
   call assert_equal([2, 4], [line('.'), col('.')])
 
-  " Test 'smartcase' with utf-8.
+  set ignorecase& smartcase&
+  close!
+endfun
+
+" Test 'smartcase' with utf-8.
+func Test_search_smartcase_utf8()
+  new
   let save_enc = &encoding
   set encoding=utf8 ignorecase smartcase
+
   call setline(1, 'Café cafÉ')
   1s/café/x/g
   call assert_equal('x x', getline(1))


### PR DESCRIPTION
3 lines were not covered by tests in pat_has_uppercase() according to codecov [1] when first uppercase of pattern is a multibyte character.

[1] https://codecov.io/gh/vim/vim/src/37394ff75270877a032422abcd079a6732a29730/src/search.c#L439