### PR TITLE
Add some tests for estack/debug backtrace

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -443,6 +443,7 @@ for g:testfunc in sort(s:tests)
   " - it fails again with the same message
   " - it fails five times (with a different message)
   if len(v:errors) > 0
+        \ && !exists( '$VIM_TEST_NO_RETRY' )
         \ && (index(s:flaky_tests, g:testfunc) >= 0
         \      || g:test_is_flaky)
     while 1

--- a/src/testdir/test_debugger.vim
+++ b/src/testdir/test_debugger.vim
@@ -664,6 +664,8 @@ func Test_Backtrace_CmdLine()
 endfunc
 
 func Test_Backtrace_DefFunction()
+  CheckRunVimInTerminal
+
   let file1 =<< trim END
     vim9script
     import File2Function from './Xtest2.vim'

--- a/src/testdir/test_debugger.vim
+++ b/src/testdir/test_debugger.vim
@@ -373,14 +373,16 @@ func Test_Backtrace_Through_Source()
   " Step into the 'source' command. This will reset the estack that is printed
   " for the backtrace (traces don't pass "through" source commands)
   call RunDbgCmd( buf, 'step', [ 'line 1: func DoAThing()' ] )
-  call RunDbgCmd( buf, 'backtrace', [ '->0 ' .. getcwd() .. '/Xtest2.vim',
-                                    \ 'line 1: func DoAThing()' ] )
+  call RunDbgCmd( buf, 'backtrace', [
+        \ '->0 script ' .. getcwd() .. '/Xtest2.vim',
+        \ 'line 1: func DoAThing()' ] )
 
   " step until we have another meaninfgul trace
   call RunDbgCmd( buf, 'step', [ 'line 5: func File2Function()' ] )
   call RunDbgCmd( buf, 'step', [ 'line 9: call File2Function()' ] )
-  call RunDbgCmd( buf, 'backtrace', [ '->0 ' .. getcwd() .. '/Xtest2.vim',
-                                    \ 'line 9: call File2Function()' ] )
+  call RunDbgCmd( buf, 'backtrace', [
+        \ '->0 script ' .. getcwd() .. '/Xtest2.vim',
+        \ 'line 9: call File2Function()' ] )
 
   call RunDbgCmd( buf, 'step', [ 'line 1: call DoAThing()' ] )
   call RunDbgCmd( buf, 'step', [ 'line 1: echo "DoAThing"' ] )
@@ -474,14 +476,16 @@ func Test_Backtrace_Autocmd()
   " Step into the 'source' command. This will reset the estack that is printed
   " for the backtrace (traces don't pass "through" source commands)
   call RunDbgCmd( buf, 'step', [ 'line 1: func DoAThing()' ] )
-  call RunDbgCmd( buf, 'backtrace', [ '->0 ' .. getcwd() .. '/Xtest2.vim',
-                                    \ 'line 1: func DoAThing()' ] )
+  call RunDbgCmd( buf, 'backtrace', [
+        \ '->0 script ' .. getcwd() .. '/Xtest2.vim',
+        \ 'line 1: func DoAThing()' ] )
 
   " step until we have another meaninfgul trace
   call RunDbgCmd( buf, 'step', [ 'line 5: func File2Function()' ] )
   call RunDbgCmd( buf, 'step', [ 'line 9: call File2Function()' ] )
-  call RunDbgCmd( buf, 'backtrace', [ '->0 ' .. getcwd() .. '/Xtest2.vim',
-                                    \ 'line 9: call File2Function()' ] )
+  call RunDbgCmd( buf, 'backtrace', [
+        \ '->0 script ' .. getcwd() .. '/Xtest2.vim',
+        \ 'line 9: call File2Function()' ] )
 
   call RunDbgCmd( buf, 'step', [ 'line 1: call DoAThing()' ] )
   call RunDbgCmd( buf, 'step', [ 'line 1: echo "DoAThing"' ] )

--- a/src/testdir/test_debugger.vim
+++ b/src/testdir/test_debugger.vim
@@ -574,6 +574,7 @@ func Test_Backtrace_CmdLine()
         \ '-S Xtest1.vim -c "debug call GlobalFunction()"',
         \ { 'wait_for_ruler': 0 } )
 
+  " Need to wait for the vim-in-terminal to be ready
   call CheckDbgOutput( buf, [ 'command line',
                             \ 'cmd: call GlobalFunction()' ] )
 
@@ -583,9 +584,6 @@ func Test_Backtrace_CmdLine()
 
   " And now we're back into the call stack
   call RunDbgCmd( buf, 'step', [ 'line 1: call CallAFunction()' ] )
-
-  " The rest is the same as Test_Backtrace_Through_Source, but we unwind the
-  " stack all the way back to the above autocommand
   call RunDbgCmd( buf, 'backtrace', [ '->0 function GlobalFunction',
                                     \ 'line 1: call CallAFunction()' ] )
 

--- a/src/testdir/test_debugger.vim
+++ b/src/testdir/test_debugger.vim
@@ -567,9 +567,8 @@ func Test_Backtrace_CmdLine()
         \ { 'wait_for_ruler': 0 } )
 
   " At this point the ontly thing in the stack is the cmdline
-  call RunDbgCmd( buf, 'backtrace', [
-        \ 'command line',
-        \ 'cmd: call GlobalFunction()' ] )
+  call RunDbgCmd( buf, 'backtrace', [ '->0 command line',
+                                    \ 'cmd: call GlobalFunction()' ] )
 
   " And now we're back into the call stack
   call RunDbgCmd( buf, 'step', [ 'line 1: call CallAFunction()' ] )


### PR DESCRIPTION
As the (very) first step in improving vimscript debugger support, just adding some tests for the current backtrace and estack behaviour.

this demonstrates how we show the traceback, and how it behaves through `source <file>`, `autocmd` and command lines. There are other entries in the estack that aren't tested, and I haven't added anything for exceptions.

THere's also a little change to `runtest.vim` to allow skipping the flaky-test-retry. When developing tests, this is useful to avoid having to wait for the test to fail 5 times because you made a typo :)

---

### Background

I'll soon submit a PR which enhances the available information in the estack to allow much richer backtraces of the full execution stack. This will be useful for vimscript debugging (related to this RFC: https://groups.google.com/d/msg/vim_dev/Xzb0a3bTg1U/m3WMcOu2BAAJ) and in general I think including more detail in the backtraces will be useful:

* For running tests (you can have the file/line of the test file which failed picked up in the Quickfix list by an `errorformat`)
* For general diagnostics (while it's possible to reverse the `function A[AL]..B[BL]..C[CL]..E Line EL` output, having the full traceback and the file/line numbers will be useful
* etc.