### PR TITLE
win32: Fix a flaky test Test_terminal_shell_option

### DIFF
--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -43,15 +43,18 @@ func Test_terminal_shell_option()
     bwipe!
   elseif has('win32')
     " dir is a shell builtin command, should fail without a shell.
+    " However, if dir.exe (which might be provided by Cygwin/MSYS2) exists in
+    " the %PATH%, "term dir" succeeds unintentionally.  Use dir.com instead.
     try
-      term dir /b runtest.vim
-      call WaitForAssert({-> assert_match('job failed\|cannot access .*: No such file or directory', term_getline(bufnr(), 1))})
+      term dir.com /b runtest.vim
+      call WaitForAssert({-> assert_match('job failed', term_getline(bufnr(), 1))})
     catch /CreateProcess/
       " ignore
     endtry
     bwipe!
 
-    term ++shell dir /b runtest.vim
+    " This should execute the dir builtin command even with ".com".
+    term ++shell dir.com /b runtest.vim
     call WaitForAssert({-> assert_match('runtest.vim', term_getline(bufnr(), 1))})
     bwipe!
   endif


### PR DESCRIPTION
Cygwin/MSYS2 provides dir.exe, and if it existed in the %PATH%,
"term dir" succeeded unintentionally. That can make the test flaky.
Use dir.com instead of dir to fix this.

"term dir.com" should fail. (Assuming dir.com doesn't exist.)
"term ++shell dir.com" should execute the dir builtin command even with
the extension ".com".