### PR TITLE
Fix configure error on macOS with Xcode 12

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -12106,7 +12106,7 @@ if test "x$olibs" = "x$LIBS"; then
 $as_echo_n "checking for tgetent()... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
+int tgetent(char *, const char *);
 int
 main ()
 {

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3510,7 +3510,7 @@ fi
 
 if test "x$olibs" = "x$LIBS"; then
   AC_MSG_CHECKING([for tgetent()])
-  AC_TRY_LINK([],
+  AC_TRY_LINK([int tgetent(char *, const char *);],
       [char s[10000]; int res = tgetent(s, "thisterminaldoesnotexist");],
 	AC_MSG_RESULT(yes),
 	AC_MSG_ERROR([NOT FOUND!


### PR DESCRIPTION
Apple clang in Xcode 12 (now beta) sets "-Werror=implicit-function-declaration" by default,
so it causes the error at checking tgetent when do configure with "--with-tlib=ncurses".
Need to add function prototype declaration.

This will fix #6550.