### PR TITLE
CI: Use GitHub Actions along with AppVeyor

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -1,0 +1,208 @@
+name: CI with MSVC and MinGW-w64
+
+on:
+  push:
+  pull_request:
+
+env:
+  VCVARSALL: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
+
+  # Interfaces
+  # Lua
+  LUA_VER: 54
+  LUA_VER_DOT: '5.4'
+  LUA_RELEASE: 5.4.0
+  LUA32_URL: https://downloads.sourceforge.net/luabinaries/lua-%LUA_RELEASE%_Win32_dllw6_lib.zip
+  LUA64_URL: https://downloads.sourceforge.net/luabinaries/lua-%LUA_RELEASE%_Win64_dllw6_lib.zip
+  LUA_DIR: D:\Lua
+  # Python 2
+  PYTHON_VER: 27
+  PYTHON_VER_DOT: '2.7'
+  # Python 3
+  PYTHON3_VER: 38
+  PYTHON3_VER_DOT: '3.8'
+
+  # Other dependencies
+  # winpty
+  WINPTY_URL: https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip
+
+  # Escape sequences
+  COL_RED: "\x1b[31m"
+  COL_GREEN: "\x1b[32m"
+  COL_YELLOW: "\x1b[33m"
+  COL_RESET: "\x1b[m"
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        toolchain: [msvc, mingw]
+        arch: [x64, x86]
+        features: [HUGE, NORMAL]
+        include:
+          - arch: x64
+            vcarch: amd64
+            warch: x64
+            bits: 64
+            msystem: MINGW64
+            cygreg: registry
+            pyreg: ""
+          - arch: x86
+            vcarch: x86
+            warch: ia32
+            bits: 32
+            msystem: MINGW32
+            cygreg: registry32
+            pyreg: "-32"
+        exclude:
+          - toolchain: msvc
+            arch: x64
+            features: NORMAL
+          - toolchain: mingw
+            arch: x86
+            features: NORMAL
+
+    steps:
+    - name: Initalize
+      id: init
+      shell: bash
+      run: |
+        git config --global core.autocrlf input
+        python_dir=$(cat "/proc/${{ matrix.cygreg }}/HKEY_LOCAL_MACHINE/SOFTWARE/Python/PythonCore/${PYTHON_VER_DOT}/InstallPath/@")
+        python3_dir=$(cat "/proc/${{ matrix.cygreg }}/HKEY_LOCAL_MACHINE/SOFTWARE/Python/PythonCore/${PYTHON3_VER_DOT}${{ matrix.pyreg }}/InstallPath/@")
+        echo "::set-env name=PYTHON_DIR::$python_dir"
+        echo "::set-env name=PYTHON3_DIR::$python3_dir"
+
+    - uses: msys2/setup-msys2@v2
+      if: matrix.toolchain == 'mingw'
+      with:
+        msystem: ${{ matrix.msystem }}
+        release: false
+
+    - uses: actions/checkout@v2
+
+    - name: Create a list of download URLs
+      shell: cmd
+      run: |
+        type NUL > urls.txt
+        echo %LUA_RELEASE%>> urls.txt
+        echo %WINPTY_URL%>> urls.txt
+
+    - name: Cache downloaded files
+      uses: actions/cache@v2
+      with:
+        path: downloads
+        key: ${{ runner.os }}-${{ matrix.bits }}-${{ hashFiles('urls.txt') }}
+
+    - name: Download dependencies
+      shell: cmd
+      run: |
+        path C:\Program Files\7-Zip;%path%
+        if not exist downloads mkdir downloads
+
+        echo %COL_GREEN%Download Lua%COL_RESET%
+        call :downloadfile %LUA${{ matrix.bits }}_URL% downloads\lua.zip
+        7z x downloads\lua.zip -o%LUA_DIR% > nul || exit 1
+
+        echo %COL_GREEN%Download winpty%COL_RESET%
+        call :downloadfile %WINPTY_URL% downloads\winpty.zip
+        7z x -y downloads\winpty.zip -oD:\winpty > nul || exit 1
+        copy /Y D:\winpty\${{ matrix.warch }}\bin\winpty.dll        src\winpty${{ matrix.bits }}.dll
+        copy /Y D:\winpty\${{ matrix.warch }}\bin\winpty-agent.exe  src\
+
+        goto :eof
+
+        :downloadfile
+        :: call :downloadfile <URL> <localfile>
+        if not exist %2 (
+          curl -f -L %1 -o %2
+        )
+        if ERRORLEVEL 1 (
+          rem Retry once.
+          curl -f -L %1 -o %2 || exit 1
+        )
+        goto :eof
+
+    - name: Build (MSVC)
+      if: matrix.toolchain == 'msvc'
+      shell: cmd
+      run: |
+        call "%VCVARSALL%" ${{ matrix.vcarch }}
+        cd src
+        :: Filter out the progress bar from the build log
+        sed -e "s/@<<$/@<< | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak
+        if "${{ matrix.features }}"=="HUGE" (
+          nmake -nologo -f Make_mvc2.mak ^
+            FEATURES=${{ matrix.features }} ^
+            GUI=yes IME=yes ICONV=yes VIMDLL=yes ^
+            DYNAMIC_LUA=yes LUA=%LUA_DIR% ^
+            DYNAMIC_PYTHON=yes PYTHON=%PYTHON_DIR% ^
+            DYNAMIC_PYTHON3=yes PYTHON3=%PYTHON3_DIR%
+        ) else (
+          nmake -nologo -f Make_mvc2.mak ^
+            FEATURES=${{ matrix.features }} ^
+            GUI=yes IME=yes ICONV=yes VIMDLL=yes
+        )
+        if not exist vim${{ matrix.bits }}.dll (
+          echo %COL_RED%Build failure.%COL_RESET%
+          exit 1
+        )
+
+    - name: Build (MinGW)
+      if: matrix.toolchain == 'mingw'
+      shell: msys2 {0}
+      run: |
+        cd src
+        if [ "${{ matrix.features }}" = "HUGE" ]; then
+          mingw32-make -f Make_ming.mak -j2 \
+            FEATURES=${{ matrix.features }} \
+            GUI=yes IME=yes ICONV=yes VIMDLL=yes \
+            DYNAMIC_LUA=yes LUA=${LUA_DIR} \
+            DYNAMIC_PYTHON=yes PYTHON=${PYTHON_DIR} \
+            DYNAMIC_PYTHON3=yes PYTHON3=${PYTHON3_DIR} \
+            STATIC_STDCPLUS=yes
+        else
+          mingw32-make -f Make_ming.mak -j2 \
+            FEATURES=${{ matrix.features }} \
+            GUI=yes IME=yes ICONV=yes VIMDLL=yes \
+            STATIC_STDCPLUS=yes
+        fi
+
+#    - name: Prepare Artifact
+#      shell: cmd
+#      run: |
+#        mkdir artifacts
+#        copy src\*vim.exe artifacts
+#        copy src\vim*.dll artifacts
+#
+#    - name: Upload Artifact
+#      uses: actions/upload-artifact@v1
+#      with:
+#        name: vim${{ matrix.bits }}-${{ matrix.toolchain }}
+#        path: ./artifacts
+
+    - name: Test
+      shell: cmd
+      timeout-minutes: 20
+      run: |
+        PATH %LUA_DIR%;C:\msys64\${{ matrix.msystem }}\bin;%PATH%;%PYTHON3_DIR%
+        call "%VCVARSALL%" ${{ matrix.vcarch }}
+        cd src
+        echo.
+        echo %COL_GREEN%vim version:%COL_RESET%
+        .\vim --version || exit 1
+        cd testdir
+        echo %COL_GREEN%Test gvim:%COL_RESET%
+        nmake -nologo -f Make_dos.mak VIMPROG=..\gvim || exit 1
+        nmake -nologo -f Make_dos.mak clean
+        echo %COL_GREEN%Test vim:%COL_RESET%
+        if "${{ matrix.toolchain }}-${{ matrix.arch }}"=="msvc-x64" (
+          rem This test may hang up unless it is executed in a separate console.
+          start /wait cmd /c "nmake -nologo -f Make_dos.mak VIMPROG=..\vim > nul"
+          if exist messages type messages
+          nmake -nologo -f Make_dos.mak report || exit 1
+        ) else (
+          nmake -nologo -f Make_dos.mak VIMPROG=..\vim || exit 1
+        )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,16 +5,17 @@ skip_tags: true
 environment:
   matrix:
     - FEATURE: HUGE
-    - FEATURE: NORMAL
 # disabled
 #    - FEATURE: TINY
 #    - FEATURE: SMALL
+#    - FEATURE: NORMAL
 #    - FEATURE: BIG
 
 matrix:
   fast_finish: true
 
 before_build:
+  # Use Windows SDK 7.1 (= MSVC 2010)
   - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release'
   - 'set INCLUDE=%INCLUDE%C:\Program Files (x86)\Windows Kits\8.1\Include\um'
 
@@ -27,7 +28,7 @@ test_script:
   - path C:\Python35-x64;%PATH%
   - nmake -f Make_dos.mak POSTSCRIPT=yes VIMPROG=..\gvim
   - nmake -f Make_dos.mak clean
-    # Testing with MingW console version
+    # Testing with MSVC console version
   - nmake -f Make_dos.mak POSTSCRIPT=yes VIMPROG=..\vim
 
 # vim: sw=2 sts=2 et ts=8 sr

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,9 @@ test_script:
   - cd src/testdir
     # Testing with MSVC gvim
   - path C:\Python35-x64;%PATH%
-  - nmake -f Make_dos.mak POSTSCRIPT=yes VIMPROG=..\gvim
+  - nmake -f Make_dos.mak VIMPROG=..\gvim
   - nmake -f Make_dos.mak clean
     # Testing with MSVC console version
-  - nmake -f Make_dos.mak POSTSCRIPT=yes VIMPROG=..\vim
+  - nmake -f Make_dos.mak VIMPROG=..\vim
 
 # vim: sw=2 sts=2 et ts=8 sr

--- a/ci/appveyor.bat
+++ b/ci/appveyor.bat
@@ -9,15 +9,23 @@ cd src
 sed -e "s/@<<$/@<< | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak
 
 echo "Building MSVC 64bit console Version"
-nmake -f Make_mvc2.mak CPU=AMD64 OLE=no GUI=no IME=yes ICONV=yes DEBUG=no FEATURES=%FEATURE% || exit 1
+nmake -f Make_mvc2.mak CPU=AMD64 ^
+    OLE=no GUI=no IME=yes ICONV=yes DEBUG=no ^
+    FEATURES=%FEATURE% || exit 1
 
 :: build MSVC huge version with python and channel support
 :: GUI needs to be last, so that testing works
 echo "Building MSVC 64bit GUI Version"
 if "%FEATURE%" == "HUGE" (
-    nmake -f Make_mvc2.mak DIRECTX=yes CPU=AMD64 CHANNEL=yes OLE=no GUI=yes IME=yes ICONV=yes DEBUG=no PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27-x64 PYTHON3_VER=35 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python35-x64 FEATURES=%FEATURE% || exit 1
+    nmake -f Make_mvc2.mak CPU=AMD64 ^
+        OLE=no GUI=yes IME=yes ICONV=yes DEBUG=no POSTSCRIPT=yes ^
+        PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27-x64 ^
+        PYTHON3_VER=35 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python35-x64 ^
+        FEATURES=%FEATURE% || exit 1
 ) ELSE (
-    nmake -f Make_mvc2.mak CPU=AMD64 OLE=no GUI=yes IME=yes ICONV=yes DEBUG=no FEATURES=%FEATURE% || exit 1
+    nmake -f Make_mvc2.mak CPU=AMD64 ^
+        OLE=no GUI=yes IME=yes ICONV=yes DEBUG=no ^
+        FEATURES=%FEATURE% || exit 1
 )
 .\gvim -u NONE -c "redir @a | ver |0put a | wq" ver_msvc.txt
 

--- a/ci/appveyor.bat
+++ b/ci/appveyor.bat
@@ -5,31 +5,11 @@ setlocal ENABLEDELAYEDEXPANSION
 cd %APPVEYOR_BUILD_FOLDER%
 
 cd src
-echo "Building MinGW 32bit console version"
-set PATH=c:\msys64\mingw32\bin;%PATH%
-mingw32-make.exe -f Make_ming.mak GUI=no OPTIMIZE=speed IME=yes ICONV=yes DEBUG=no FEATURES=%FEATURE% || exit 1
-.\vim -u NONE -c "redir @a | ver |0put a | wq" ver_ming.txt
-:: Save vim.exe before Make clean, moved back below.
-copy vim.exe testdir
-mingw32-make.exe -f Make_ming.mak clean
-
-:: Build Mingw huge version with python and channel support, or
-:: with specified features without python.
-echo "Building MinGW 32bit GUI version"
-if "%FEATURE%" == "HUGE" (
-    mingw32-make.exe -f Make_ming.mak OPTIMIZE=speed CHANNEL=yes GUI=yes IME=yes ICONV=yes DEBUG=no PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27 PYTHON3_VER=35 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python35 FEATURES=%FEATURE% || exit 1
-) ELSE (
-    mingw32-make.exe -f Make_ming.mak OPTIMIZE=speed GUI=yes IME=yes ICONV=yes DEBUG=no FEATURES=%FEATURE% || exit 1
-)
-.\gvim -u NONE -c "redir @a | ver |0put a | wq" ver_ming_gui.txt
-
 :: Filter out the progress bar from the build log
 sed -e "s/@<<$/@<< | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak
 
 echo "Building MSVC 64bit console Version"
 nmake -f Make_mvc2.mak CPU=AMD64 OLE=no GUI=no IME=yes ICONV=yes DEBUG=no FEATURES=%FEATURE% || exit 1
-:: The executable is not used
-nmake -f Make_mvc2.mak clean
 
 :: build MSVC huge version with python and channel support
 :: GUI needs to be last, so that testing works
@@ -41,12 +21,8 @@ if "%FEATURE%" == "HUGE" (
 )
 .\gvim -u NONE -c "redir @a | ver |0put a | wq" ver_msvc.txt
 
-:: Restore vim.exe, tests will run with this.
-move /Y testdir\vim.exe .
-echo "version output MinGW"
-type ver_ming.txt
-echo "version output MinGW GUI"
-type ver_ming_gui.txt
-echo "version output MVC"
+echo "version output MSVC console"
+.\vim --version
+echo "version output MSVC GUI"
 type ver_msvc.txt
 cd ..


### PR DESCRIPTION
Currently, we use AppVeyor for Windows CI, but it takes about 20 minutes, and the test combination is not enough.

This PR enables GitHub Actions. The advantage of GHA is that it can run multiple jobs parallelly even with the free plan.
This tests the following combinations:

* Compiler: MSVC 2019, MinGW-w64
* Architecture: x64, x86
* Features: HUGE, NORMAL
 (Actually, two combinations are excluded from NORMAL to reduce the jobs.)

Other conditions are:

* Enabled interfaces are Lua 5.4, Python 2.7, Python 3.8.
* winpty is used for the terminal feature.
* VIMDLL is enabled.

Each test takes less than 10 minutes. Here is the result:
https://github.com/k-takata/vim/actions/runs/186751314

The AppVeyor job is now simplified. It only tests MSVC 2010, x64, HUGE.
Now it takes about only 6 minutes.
https://ci.appveyor.com/project/k-takata/vim/builds/34360477
Note that GHA doesn't have MSVC 2010 installed. That's why we still need to use AppVeyor.

This also fixes v8.2.0388 which intended to enable PostScript but actually failed to enable it.