### PR TITLE
CI: Skip tags build on GHA

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -2,6 +2,8 @@ name: GitHub CI
 
 on:
   push:
+    branches:
+      - '*'
   pull_request:
 
 env:


### PR DESCRIPTION
Currently, the workflow is executed both on branches and tags push.
No need to execute on tags push.