### PR TITLE
macOS: Find TCL libraries automatically

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -7417,7 +7417,7 @@ $as_echo_n "checking for location of Tcl include... " >&6; }
       if test "x$MACOS_X" != "xyes"; then
 	tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
       else
-		tclinc="/System/Library/Frameworks/Tcl.framework/Headers"
+				tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /System/Library/Frameworks/Tcl.framework/Headers `xcrun --show-sdk-path`/System/Library/Frameworks/Tcl.framework/Versions/Current/Headers"
       fi
       TCL_INC=
       for try in $tclinc; do
@@ -7440,7 +7440,8 @@ $as_echo_n "checking for location of tclConfig.sh script... " >&6; }
 	  tclcnf=`echo $tclinc | sed s/include/lib/g`
 	  tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
 	else
-	  	  tclcnf="/System/Library/Frameworks/Tcl.framework"
+	  	  	  	  tclcnf=`echo $tclinc | sed s/include/lib/g`
+	  tclcnf="$tclcnf /System/Library/Frameworks/Tcl.framework `xcrun --show-sdk-path`/System/Library/Frameworks/Tcl.framework"
 	fi
 	for try in $tclcnf; do
 	  if test -f "$try/tclConfig.sh"; then

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1820,8 +1820,10 @@ if test "$enable_tclinterp" = "yes" -o "$enable_tclinterp" = "dynamic"; then
       if test "x$MACOS_X" != "xyes"; then
 	tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
       else
+	dnl For all macOS, use the value from TCL in case use of, say, homebrew
 	dnl For Mac OS X 10.3, use the OS-provided framework location
-	tclinc="/System/Library/Frameworks/Tcl.framework/Headers"
+	dnl For Mac OS X 10.14, the OS-provided framework location doesn't contain the headers, so also check the Xcode SDK
+	tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /System/Library/Frameworks/Tcl.framework/Headers `xcrun --show-sdk-path`/System/Library/Frameworks/Tcl.framework/Versions/Current/Headers"
       fi
       TCL_INC=
       for try in $tclinc; do
@@ -1841,8 +1843,11 @@ if test "$enable_tclinterp" = "yes" -o "$enable_tclinterp" = "dynamic"; then
 	  tclcnf=`echo $tclinc | sed s/include/lib/g`
 	  tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
 	else
+	  dnl For all macOS, use the value from TCL in case use of, say, homebrew
 	  dnl For Mac OS X 10.3, use the OS-provided framework location
-	  tclcnf="/System/Library/Frameworks/Tcl.framework"
+	  dnl For Mac OS X 10.14, the OS-provided framework location doesn't contain the headers, so also check the Xcode SDK
+	  tclcnf=`echo $tclinc | sed s/include/lib/g`
+	  tclcnf="$tclcnf /System/Library/Frameworks/Tcl.framework `xcrun --show-sdk-path`/System/Library/Frameworks/Tcl.framework"
 	fi
 	for try in $tclcnf; do
 	  if test -f "$try/tclConfig.sh"; then


### PR DESCRIPTION
Recent versions of macOS do not ship headers for system frameworks anymore; you
have to use the SDK that is installed by `xcode-select --install` (or when
installing Xcode). The way to get the path to this SDK is `xcrun --show-sdk-path`.

It's also possible to have tcl installed elsewhere on the system (such as via
`brew install tcl-tk`). The current configuration script does not respect the
`[info library]` output on macOS, so we use that if it's available.

This change updates the TCL configuraiton to find TCL headers from those
locations. This makes `--enable-tclinterp` work on macOS without additional
arguments.

# Homebrew

```
> PATH=$(brew --prefix tcl-tk)/bin:${PATH} ./configure --with-features=huge --enable-tclinterp --with-tclsh=tclsh --enable-fail-if-missing
```

Result:

```
configure:7153: checking --enable-tclinterp argument
configure:7162: result: yes
configure:7167: checking --with-tclsh argument
configure:7172: result: tclsh
configure:7181: checking for tclsh
configure:7199: found /usr/local/opt/tcl-tk/bin/tclsh
configure:7211: result: /usr/local/opt/tcl-tk/bin/tclsh
configure:7394: checking Tcl version
configure:7398: result: 8.6 - OK
configure:7403: checking for location of Tcl include
configure:7413: result: /usr/local/Cellar/tcl-tk/8.6.10/include/tcl.h
configure:7425: checking for location of tclConfig.sh script
configure:7436: result: /usr/local/Cellar/tcl-tk/8.6.10/lib/tclConfig.sh
```

:tcl info library:

```
/usr/local/Cellar/tcl-tk/8.6.10/lib/tcl8.6
```

# Command Line Tools

```
> sudo xcode-select -s /Library/Developer/CommandLineTools
> ./configure --with-features=huge --enable-tclinterp --enable-fail-if-missing
```

```
configure:7162: result: yes
configure:7167: checking --with-tclsh argument
configure:7175: result: no
configure:7181: checking for tclsh8.5
configure:7199: found /usr/bin/tclsh8.5
configure:7211: result: /usr/bin/tclsh8.5
configure:7394: checking Tcl version
configure:7398: result: 8.5 - OK
configure:7403: checking for location of Tcl include
configure:7413: result: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/Versions/Current/Headers/tcl.h
configure:7425: checking for location of tclConfig.sh script
configure:7436: result: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh
```

```
:tcl info library
/System/Library/Frameworks/Tcl.framework/Versions/8.5/Resources/Scripts
```


# XCode

```
> sudo xcode-select -r
> ./configure --with-features=huge --enable-tclinterp --enable-fail-if-missing
```

```
configure:7153: checking --enable-tclinterp argument
configure:7162: result: yes
configure:7167: checking --with-tclsh argument
configure:7175: result: no
configure:7181: checking for tclsh8.5
configure:7199: found /usr/bin/tclsh8.5
configure:7211: result: /usr/bin/tclsh8.5
configure:7394: checking Tcl version
configure:7398: result: 8.5 - OK
configure:7403: checking for location of Tcl include
configure:7413: result: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/Versions/Current/Headers/tcl.h
configure:7425: checking for location of tclConfig.sh script
configure:7436: result: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/tclConfig.sh
```

```
:tcl info library
/System/Library/Frameworks/Tcl.framework/Versions/8.5/Resources/Scripts
```