### PR TITLE
Fix some tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,6 +11,8 @@ freebsd_12_task:
     - NPROC=$(getconf _NPROCESSORS_ONLN)
     - ./configure --with-features=${FEATURES}
     - make -j${NPROC}
-    - src/vim --version
   test_script:
-    - make test
+    - src/vim --version
+    - pw useradd cirrus -m
+    - chown -R cirrus:cirrus .
+    - sudo -u cirrus make test

--- a/src/testdir/test_backup.vim
+++ b/src/testdir/test_backup.vim
@@ -19,6 +19,22 @@ func Test_backup()
   call delete('Xbackup.txt~')
 endfunc
 
+func Test_backup_backupskip()
+  set backup backupdir=. backupskip=*.txt
+  new
+  call setline(1, ['line1', 'line2'])
+  :f Xbackup.txt
+  :w! Xbackup.txt
+  " backup file is only created after
+  " writing a second time (before overwriting)
+  :w! Xbackup.txt
+  call assert_false(filereadable('Xbackup.txt~'))
+  bw!
+  set backup&vim backupdir&vim backupskip&vim
+  call delete('Xbackup.txt')
+  call delete('Xbackup.txt~')
+endfunc
+
 func Test_backup2()
   set backup backupdir=.// backupskip=
   new
@@ -30,7 +46,7 @@ func Test_backup2()
   :w! Xbackup.txt
   sp *Xbackup.txt~
   call assert_equal(['line1', 'line2', 'line3'], getline(1,'$'))
-  let f=expand('%')
+  let f = expand('%')
   call assert_match('%testdir%Xbackup.txt\~', f)
   bw!
   bw!
@@ -50,7 +66,7 @@ func Test_backup2_backupcopy()
   :w! Xbackup.txt
   sp *Xbackup.txt~
   call assert_equal(['line1', 'line2', 'line3'], getline(1,'$'))
-  let f=expand('%')
+  let f = expand('%')
   call assert_match('%testdir%Xbackup.txt\~', f)
   bw!
   bw!
@@ -65,7 +81,7 @@ func Test_non_existing_backupdir()
   call writefile(['line1'], 'Xfile')
   new Xfile
   call assert_fails('write', 'E510:')
-  set backupdir& backupskip&
+  set backupdir&vim backupskip&vim
   call delete('Xfile')
 endfunc
 

--- a/src/testdir/test_backup.vim
+++ b/src/testdir/test_backup.vim
@@ -61,14 +61,11 @@ endfunc
 
 " Test for using a non-existing directory as a backup directory
 func Test_non_existing_backupdir()
-  CheckNotBSD
-  let save_backup = &backupdir
-  set backupdir=./non_existing_dir
+  set backupdir=./non_existing_dir backupskip=
   call writefile(['line1'], 'Xfile')
   new Xfile
-  " TODO: write doesn't fail in Cirrus FreeBSD CI test
   call assert_fails('write', 'E510:')
-  let &backupdir = save_backup
+  set backupdir& backupskip&
   call delete('Xfile')
 endfunc
 

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -1682,7 +1682,6 @@ endfunc
 " Test for editing a file without read permission
 func Test_edit_file_no_read_perm()
   CheckUnix
-  CheckNotBSD
   call writefile(['one', 'two'], 'Xfile')
   call setfperm('Xfile', '-w-------')
   new

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -807,7 +807,7 @@ func Test_viminfo_perm()
 
   " Try to write the viminfo to a directory
   call mkdir('Xdir')
-  call assert_fails('wviminfo Xdir', 'E886:')
+  call assert_fails('wviminfo Xdir', 'E137:')
   call delete('Xdir', 'rf')
 endfunc
 

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -136,9 +136,7 @@ func Test_writefile_sync_arg()
 endfunc
 
 func Test_writefile_sync_dev_stdout()
-  if !has('unix')
-    return
-  endif
+  CheckUnix
   if filewritable('/dev/stdout')
     " Just check that this doesn't cause an error.
     call writefile(['one'], '/dev/stdout')
@@ -371,13 +369,10 @@ endfunc
 
 " Test for writing to a readonly file
 func Test_write_readonly()
-  " In Cirrus-CI, the freebsd tests are run under a root account. So this test
-  " doesn't fail.
-  CheckNotBSD
   call writefile([], 'Xfile')
   call setfperm('Xfile', "r--------")
   edit Xfile
-  set noreadonly
+  set noreadonly backupskip=
   call assert_fails('write', 'E505:')
   let save_cpo = &cpo
   set cpo+=W
@@ -386,37 +381,32 @@ func Test_write_readonly()
   call setline(1, ['line1'])
   write!
   call assert_equal(['line1'], readfile('Xfile'))
+  set backupskip&
   call delete('Xfile')
 endfunc
 
 " Test for 'patchmode'
 func Test_patchmode()
-  CheckNotBSD
   call writefile(['one'], 'Xfile')
-  set patchmode=.orig nobackup writebackup
+  set patchmode=.orig nobackup backupskip= writebackup
   new Xfile
   call setline(1, 'two')
   " first write should create the .orig file
   write
-  " TODO: Xfile.orig is not created in Cirrus FreeBSD CI test
   call assert_equal(['one'], readfile('Xfile.orig'))
   call setline(1, 'three')
   " subsequent writes should not create/modify the .orig file
   write
   call assert_equal(['one'], readfile('Xfile.orig'))
-  set patchmode& backup& writebackup&
+  set patchmode& backup& backupskip& writebackup&
   call delete('Xfile')
   call delete('Xfile.orig')
 endfunc
 
 " Test for writing to a file in a readonly directory
 func Test_write_readonly_dir()
-  if !has('unix') || has('bsd')
-    " On MS-Windows, modifying files in a read-only directory is allowed.
-    " In Cirrus-CI for Freebsd, tests are run under a root account where
-    " modifying files in a read-only directory are allowed.
-    return
-  endif
+  " On MS-Windows, modifying files in a read-only directory is allowed.
+  CheckUnix
   call mkdir('Xdir')
   call writefile(['one'], 'Xdir/Xfile1')
   call setfperm('Xdir', 'r-xr--r--')
@@ -426,12 +416,12 @@ func Test_write_readonly_dir()
   call assert_fails('write', 'E212:')
   " try to create a backup file in the directory
   edit! Xdir/Xfile1
-  set backupdir=./Xdir
+  set backupdir=./Xdir backupskip=
   set patchmode=.orig
   call assert_fails('write', 'E509:')
   call setfperm('Xdir', 'rwxr--r--')
   call delete('Xdir', 'rf')
-  set backupdir& patchmode&
+  set backupdir& backupskip& patchmode&
 endfunc
 
 " Test for writing a file using invalid file encoding


### PR DESCRIPTION
### Fix tests about 'backup' feature

Cirrus CI executes tests under /tmp/cirrus-ci-build/ so it matches 'backupskip' and some tests about backup fail.
(Therefore those tests fail on also other OS when do under 'backupskip' directories)

Solution: Set 'backupskip' empty.

### Fix viminfo test on FreeBSD

FreeBSD can do `fread(_, _, fp)` from directory `fp` with no error (maybe reads directory entry data),
so `Test_viminfo_perm` fails with catching unexpected error.

Solution: Check if a specified file is not directory, in `read_viminfo` and `write_viminfo`.

### Cirrus CI do tests with only root user

Solution: Add user `cirrus` before test.