### PR TITLE
Pass v:lnum as an argument to GetJsonIndent

### DIFF
--- a/runtime/indent/json.vim
+++ b/runtime/indent/json.vim
@@ -19,7 +19,7 @@ let b:did_indent = 1
 setlocal nosmartindent
 
 " Now, set up our indentation expression and keys that trigger it.
-setlocal indentexpr=GetJSONIndent()
+setlocal indentexpr=GetJSONIndent(v:lnum)
 setlocal indentkeys=0{,0},0),0[,0],!^F,o,O,e
 
 " Only define the function once.
@@ -86,26 +86,28 @@ endfunction
 " 3. GetJSONIndent Function {{{1
 " =========================
 
-function GetJSONIndent()
+function GetJSONIndent(...)
   " 3.1. Setup {{{2
   " ----------
+  " For the current line, use the first argument if given, else v:lnum
+  let clnum = a:0 ? a:1 : v:lnum
 
-  " Set up variables for restoring position in file.  Could use v:lnum here.
+  " Set up variables for restoring position in file.  Could use clnum here.
   let vcol = col('.')
 
   " 3.2. Work on the current line {{{2
   " -----------------------------
 
   " Get the current line.
-  let line = getline(v:lnum)
+  let line = getline(clnum)
   let ind = -1
 
   " If we got a closing bracket on an empty line, find its match and indent
   " according to it.
   let col = matchend(line, '^\s*[]}]')
 
-  if col > 0 && !s:IsInString(v:lnum, col)
-    call cursor(v:lnum, col)
+  if col > 0 && !s:IsInString(clnum, col)
+    call cursor(clnum, col)
     let bs = strpart('{}[]', stridx('}]', line[col - 1]) * 2, 2)
 
     let pairstart = escape(bs[0], '[')
@@ -122,14 +124,14 @@ function GetJSONIndent()
   endif
 
   " If we are in a multi-line string, don't do anything to it.
-  if s:IsInString(v:lnum, matchend(line, '^\s*') + 1)
+  if s:IsInString(clnum, matchend(line, '^\s*') + 1)
     return indent('.')
   endif
 
   " 3.3. Work on the previous line. {{{2
   " -------------------------------
 
-  let lnum = prevnonblank(v:lnum - 1)
+  let lnum = prevnonblank(clnum - 1)
 
   if lnum == 0
     return 0
@@ -151,7 +153,7 @@ function GetJSONIndent()
     if counts[0] == '1' || counts[1] == '1' || counts[2] == '1'
       return ind + shiftwidth()
     else
-      call cursor(v:lnum, vcol)
+      call cursor(clnum, vcol)
     end
   endif
 


### PR DESCRIPTION
Updated to allow for better debugging.
The indent script should work as it did before, but you'll be able to call the function manually with a line number.

Based on similar commit for vim-ruby https://github.com/vim-ruby/vim-ruby/commit/bcdd3f93e7c4c1aec02131ea8bf9c5afe07bf767