### PR TITLE
Fix set command contains escaped spaces with isfname+=32

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -1763,6 +1763,7 @@ do_set(
 #ifdef BACKSLASH_IN_FILENAME
 					&& !((flags & P_EXPAND)
 						&& vim_isfilec(arg[1])
+						&& !VIM_ISWHITE(arg[1])
 						&& (arg[1] != '\\'
 						    || (s == newval
 							&& arg[2] != '\\')))

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -973,4 +973,12 @@ func Test_opt_winminwidth()
   set winwidth&
 endfunc
 
+" Test for setting option value contains spaces with isfname+=32
+func Test_isfname_with_options()
+  set isfname+=32
+  setlocal keywordprg=:term\ help.exe
+  set isfname&
+  setlocal keywordprg&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When adding whitespace to isfname, `set` command fail with escaped-spaces. Repro steps:

```
set isfname+=32
set keywordprg=:term\ help.exe
```

I think set command should handle isfname since it enable completion of filename for option-value. But the whitespaces should not be handled in this part (handle `\ `).