### PR TITLE
Port the support for jumping to the last used tab page from neovim

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10357,8 +10357,13 @@ tabpagebuflist([{arg}])					*tabpagebuflist()*
 tabpagenr([{arg}])					*tabpagenr()*
 		The result is a Number, which is the number of the current
 		tab page.  The first tab page has number 1.
-		When the optional argument is "$", the number of the last tab
-		page is returned (the tab page count).
+
+		The optional argument {arg} supports the following values:
+			$	the number of the last tab page (the tab page
+				count).
+			#	the number of the last accessed tab page
+				(where |g<Tab>| goes to). if there is no
+				previous tab page 0 is returned.
 		The number can be used with the |:tab| command.
 
 

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -440,6 +440,7 @@ tag		char	      note action in Normal mode	~
 |<C-LeftMouse>|	<C-LeftMouse>	   ":ta" to the keyword at the mouse click
 |<C-Right>|	<C-Right>	1  same as "w"
 |<C-RightMouse>| <C-RightMouse>	   same as "CTRL-T"
+|<C-Tab>|	<C-Tab>		   same as "g<Tab>"
 |<Del>|		["x]<Del>	2  same as "x"
 |N<Del>|	{count}<Del>	   remove the last digit from {count}
 |<Down>|	<Down>		1  same as "j"
@@ -587,6 +588,8 @@ tag		command		   action in Normal mode	~
 				   following the file name.
 |CTRL-W_gt|	CTRL-W g t	   same as `gt`: go to next tab page
 |CTRL-W_gT|	CTRL-W g T	   same as `gT`: go to previous tab page
+|CTRL-W_g<Tab>|	CTRL-W g <Tab>	   same as |g<Tab>|: go to last accessed tab
+				   page.
 |CTRL-W_h|	CTRL-W h	   go to Nth left window (stop at first window)
 |CTRL-W_i|	CTRL-W i	   split window and jump to declaration of
 				   identifier under the cursor
@@ -805,6 +808,7 @@ tag		char	      note action in Normal mode	~
 |g<LeftMouse>|	g<LeftMouse>	   same as <C-LeftMouse>
 		g<MiddleMouse>	   same as <C-MiddleMouse>
 |g<RightMouse>|	g<RightMouse>	   same as <C-RightMouse>
+|g<Tab>|	g<Tab>		   go to the last accessed tab page.
 |g<Up>|		g<Up>		1  same as "gk"
 
 ==============================================================================

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -221,6 +221,8 @@ gT		Go to the previous tab page.  Wraps around from the first one
 							*:tabl* *:tablast*
 :tabl[ast]	Go to the last tab page.
 
+					    *g<Tab>* *CTRL-W_g<Tab>* *<C-Tab>*
+g<Tab>		Go to the last accessed tab page.
 
 Other commands:
 							*:tabs*

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -616,6 +616,9 @@ f_tabpagenr(typval_T *argvars UNUSED, typval_T *rettv)
 	{
 	    if (STRCMP(arg, "$") == 0)
 		nr = tabpage_index(NULL) - 1;
+	    else if (STRCMP(arg, "#") == 0)
+		nr = valid_tabpage(lastused_tabpage) ?
+					tabpage_index(lastused_tabpage) : 0;
 	    else
 		semsg(_(e_invexpr2), arg);
 	}

--- a/src/globals.h
+++ b/src/globals.h
@@ -725,10 +725,12 @@ EXTERN frame_T	*topframe;	// top of the window frame tree
 
 /*
  * Tab pages are alternative topframes.  "first_tabpage" points to the first
- * one in the list, "curtab" is the current one.
+ * one in the list, "curtab" is the current one. "lastused_tabpage" is the
+ * last used one.
  */
 EXTERN tabpage_T    *first_tabpage;
 EXTERN tabpage_T    *curtab;
+EXTERN tabpage_T    *lastused_tabpage;
 EXTERN int	    redraw_tabline INIT(= FALSE);  // need to redraw tabline
 
 /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -5442,7 +5442,7 @@ nv_gomark(cmdarg_T *cap)
 }
 
 /*
- * Handle CTRL-O, CTRL-I, "g;" and "g," commands.
+ * Handle CTRL-O, CTRL-I, "g;", "g," and "CTRL-Tab" commands.
  */
     static void
 nv_pcmark(cmdarg_T *cap)
@@ -5456,6 +5456,13 @@ nv_pcmark(cmdarg_T *cap)
 
     if (!checkclearopq(cap->oap))
     {
+	if (cap->cmdchar == TAB && mod_mask == MOD_MASK_CTRL) {
+	    if (!valid_tabpage(lastused_tabpage))
+		clearopbeep(cap->oap);
+	    else
+		goto_tabpage_lastused();
+	    return;
+	}
 	if (cap->cmdchar == 'g')
 	    pos = movechangelist((int)cap->count1);
 	else
@@ -6308,6 +6315,16 @@ nv_g_cmd(cmdarg_T *cap)
     case 'T':
 	if (!checkclearop(oap))
 	    goto_tabpage(-(int)cap->count1);
+	break;
+
+    case TAB:
+	if (!checkclearop(oap))
+	{
+	    if (!valid_tabpage(lastused_tabpage))
+		clearopbeep(oap);
+	    else
+		goto_tabpage_lastused();
+	}
 	break;
 
     case '+':

--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -32,6 +32,7 @@ tabpage_T *find_tabpage(int n);
 int tabpage_index(tabpage_T *ftp);
 void goto_tabpage(int n);
 void goto_tabpage_tp(tabpage_T *tp, int trigger_enter_autocmds, int trigger_leave_autocmds);
+void goto_tabpage_lastused(void);
 void goto_tabpage_win(tabpage_T *tp, win_T *wp);
 void tabpage_move(int nr);
 void win_goto(win_T *wp);

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -130,7 +130,7 @@ function Test_tabpage()
   1tabmove
   call assert_equal(2, tabpagenr())
 
-  call assert_fails('let t = tabpagenr("#")', 'E15:')
+  call assert_fails('let t = tabpagenr("@")', 'E15:')
   call assert_equal(0, tabpagewinnr(-1))
   call assert_fails("99tabmove", 'E16:')
   call assert_fails("+99tabmove", 'E16:')
@@ -775,6 +775,50 @@ func Test_tabpage_close_on_switch()
   augroup END
   augroup! T2
   %bw!
+endfunc
+
+" Test for jumping to last accessed tabpage
+func Test_lastused_tabpage()
+  tabonly!
+  call assert_equal(0, tabpagenr('#'))
+  call assert_beeps('call feedkeys("g\<Tab>", "xt")')
+  call assert_beeps('call feedkeys("\<C-Tab>", "xt")')
+  call assert_beeps('call feedkeys("\<C-W>g\<Tab>", "xt")')
+
+  " open four tab pages
+  tabnew
+  tabnew
+  tabnew
+
+  2tabnext
+
+  " Test for g<Tab>
+  call assert_equal(4, tabpagenr('#'))
+  call feedkeys("g\<Tab>", "xt")
+  call assert_equal(4, tabpagenr())
+  call assert_equal(2, tabpagenr('#'))
+
+  " Test for <C-Tab>
+  call feedkeys("\<C-Tab>", "xt")
+  call assert_equal(2, tabpagenr())
+  call assert_equal(4, tabpagenr('#'))
+
+  " Test for <C-W>g<Tab>
+  call feedkeys("\<C-W>g\<Tab>", "xt")
+  call assert_equal(4, tabpagenr())
+  call assert_equal(2, tabpagenr('#'))
+
+  " Try to jump to a closed tab page
+  tabclose 2
+  call assert_equal(0, tabpagenr('#'))
+  call feedkeys("g\<Tab>", "xt")
+  call assert_equal(3, tabpagenr())
+  call feedkeys("\<C-Tab>", "xt")
+  call assert_equal(3, tabpagenr())
+  call feedkeys("\<C-W>g\<Tab>", "xt")
+  call assert_equal(3, tabpagenr())
+
+  tabclose!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Ported the support for jumping to the last used tabpage from neovim:

https://github.com/neovim/neovim/commit/cbc8d72fde4b19176028490934ff7a447afe523c

The commands `g<Tab>` or `<C-W>g<Tab>` or `<C-Tab>` can be used to
jump to the last accessed tab page. I am not sure whether we need to
create all these commands and whether this is consistent with other
commands.

Modified the diff to beep if the previously accessed tab page is not found
(to be consistent with the CTRL-W p command which beeps if the last
accessed window is not present).

Added tests for the new commands and tabpagenr().
