### PR TITLE
Add support for # argument to the :tabnext, :tabclose, :tabmove and :tabonly commands

### DIFF
--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -142,6 +142,7 @@ something else.
 		    :tabclose +	    " close the next tab page
 		    :tabclose 3	    " close the third tab page
 		    :tabclose $	    " close the last tab page
+		    :tabclose #     " close the last accessed tab page
 <
 							*:tabo* *:tabonly*
 :tabo[nly][!]	Close all other tab pages.
@@ -170,6 +171,8 @@ something else.
 				    " one
 		    :tabonly 1	    " close all tab pages except the first one
 		    :tabonly $	    " close all tab pages except the last one
+		    :tabonly #	    " close all tab pages except the last
+				    " accssed one
 
 
 SWITCHING TO ANOTHER TAB PAGE:
@@ -192,6 +195,7 @@ gt					*i_CTRL-<PageDown>* *i_<C-PageDown>*
 		    :+2tabnext	" go to the two next tab page
 		    :1tabnext	" go to the first tab page
 		    :$tabnext	" go to the last tab page
+		    :tabnext #  " go to the last accessed tab page
 		    :tabnext $	" as above
 		    :tabnext -	" go to the previous tab page
 		    :tabnext -1	" as above
@@ -255,6 +259,8 @@ REORDERING TAB PAGES:
 		    :tabmove	" move the tab page to the last
 		    :$tabmove	" as above
 		    :tabmove $	" as above
+		    :tabmove #  " move the tab page after the last accessed
+				" tab page
 
 :tabm[ove] +[N]
 :tabm[ove] -[N]

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5412,6 +5412,15 @@ get_tabpage_arg(exarg_T *eap)
 	{
 	    if (STRCMP(p, "$") == 0)
 		tab_number = LAST_TAB_NR;
+	    else if (STRCMP(p, "#") == 0)
+		if (valid_tabpage(lastused_tabpage))
+		    tab_number = tabpage_index(lastused_tabpage);
+		else
+		{
+		    eap->errmsg = ex_errmsg(e_invargval, eap->arg);
+		    tab_number = 0;
+		    goto theend;
+		}
 	    else if (p == p_save || *p_save == '-' || *p != NUL
 		    || tab_number > LAST_TAB_NR)
 	    {

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -784,6 +784,7 @@ func Test_lastused_tabpage()
   call assert_beeps('call feedkeys("g\<Tab>", "xt")')
   call assert_beeps('call feedkeys("\<C-Tab>", "xt")')
   call assert_beeps('call feedkeys("\<C-W>g\<Tab>", "xt")')
+  call assert_fails('tabnext #', 'E475:')
 
   " open four tab pages
   tabnew
@@ -808,17 +809,41 @@ func Test_lastused_tabpage()
   call assert_equal(4, tabpagenr())
   call assert_equal(2, tabpagenr('#'))
 
+  " Test for :tabnext #
+  tabnext #
+  call assert_equal(2, tabpagenr())
+  call assert_equal(4, tabpagenr('#'))
+
   " Try to jump to a closed tab page
-  tabclose 2
+  tabclose #
   call assert_equal(0, tabpagenr('#'))
   call feedkeys("g\<Tab>", "xt")
-  call assert_equal(3, tabpagenr())
+  call assert_equal(2, tabpagenr())
   call feedkeys("\<C-Tab>", "xt")
-  call assert_equal(3, tabpagenr())
+  call assert_equal(2, tabpagenr())
   call feedkeys("\<C-W>g\<Tab>", "xt")
-  call assert_equal(3, tabpagenr())
+  call assert_equal(2, tabpagenr())
+  call assert_fails('tabnext #', 'E475:')
+  call assert_equal(2, tabpagenr())
 
-  tabclose!
+  " Test for :tabonly #
+  let wnum = win_getid()
+  $tabnew
+  tabonly #
+  call assert_equal(wnum, win_getid())
+  call assert_equal(1, tabpagenr('$'))
+
+  " Test for :tabmove #
+  tabnew
+  let wnum = win_getid()
+  tabnew
+  tabnew
+  tabnext 2
+  tabmove #
+  call assert_equal(4, tabpagenr())
+  call assert_equal(wnum, win_getid())
+
+  tabonly!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -3844,6 +3844,7 @@ free_tabpage(tabpage_T *tp)
 win_new_tabpage(int after)
 {
     tabpage_T	*tp = curtab;
+    tabpage_T	*prev_tp = curtab;
     tabpage_T	*newtp;
     int		n;
 
@@ -3893,7 +3894,7 @@ win_new_tabpage(int after)
 	newtp->tp_topframe = topframe;
 	last_status(FALSE);
 
-	lastused_tabpage = tp;
+	lastused_tabpage = prev_tp;
 
 #if defined(FEAT_GUI)
 	// When 'guioptions' includes 'L' or 'R' may have to remove or add


### PR DESCRIPTION

Add support for using the last accessed tab page in Ex commands.
Also fix a problem in setting the correct last tabpage after using a
count with tabnew to create a new tabpage.
