### PR TITLE
logical NOT of v:true and v:false should make a value of bool.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -3323,7 +3323,10 @@ eval7_leader(
 #endif
 	{
 	    clear_tv(rettv);
-	    rettv->v_type = VAR_NUMBER;
+	    if (rettv->v_type == VAR_BOOL)
+		rettv->v_type = VAR_BOOL;
+	    else
+		rettv->v_type = VAR_NUMBER;
 	    rettv->vval.v_number = val;
 	}
     }

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -4019,6 +4019,9 @@ func Test_type()
     call assert_true(v:none == 0)
     call assert_false(v:none != 0)
 
+    call assert_true(!v:true is v:false)
+    call assert_true(!v:false is v:true)
+
     call assert_true(v:false is v:false)
     call assert_true(v:true is v:true)
     call assert_true(v:none is v:none)


### PR DESCRIPTION
Current Vim script is that logical NOT of v:true and v:false make a value of number:
```
!v:true -> 0
!v:false -> 1
```

I think that logical NOT of v:true and v:false should make a value of bool:
```
!v:true -> v:false
!v:false -> v:true
```

@brammool What do you think about this?
