### PR TITLE
runtime/syntax/c.vim: Link cOctalZero to Number instead of PreProc

### DIFF
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -461,7 +461,7 @@ hi def link cCharacter		Character
 hi def link cSpecialCharacter	cSpecial
 hi def link cNumber		Number
 hi def link cOctal		Number
-hi def link cOctalZero		PreProc	 " link this to Error if you want
+hi def link cOctalZero		Number
 hi def link cFloat		Float
 hi def link cOctalError		cError
 hi def link cParenError		cError


### PR DESCRIPTION
Because:

- it is part of a number, not a preprocessor directive;

- this is more consistent with integer character constants encoded as an octal value (e.g. `\037`) and hexadecimal integer constants (e.g. `0xFFFF`), whose leading 0 is not highlighted.