### PR TITLE
Fix pattern of definition of the attributes of the Normal highlighting group in check_colors.vim

### DIFF
--- a/runtime/colors/tools/check_colors.vim
+++ b/runtime/colors/tools/check_colors.vim
@@ -185,7 +185,7 @@ func! Test_check_colors()
 
   " 9) Normal should be defined first, not use reverse, fg or bg
   call cursor(1,1)
-  let pat = 'hi\%[light] \+\%(link\|clear\)\@!\w\+\>'
+  let pat = 'hi\%[ghlight] \+\%(link\|clear\)\@!\w\+\>'
   call search(pat, 'cW') " Look for the first hi def, skipping `hi link` and `hi clear`
   if getline('.') !~# '\m\<Normal\>'
     let err['highlight']['Normal'] = 'Should be defined first'


### PR DESCRIPTION
This small commit fixes the pattern defined in `runtime/colors/tools/check_colors.vim`, which rejected the `:highlight` command to define the attributes of the `Normal` highlighting group, but wrongly accepted the `:hilight` command to do so.