### PR TITLE
Clean up old macOS GUI remaining code and docs

### DIFF
--- a/READMEdir/README_extra.txt
+++ b/READMEdir/README_extra.txt
@@ -16,7 +16,6 @@ src/os_amiga.*		Files for the Amiga port.
 src/os_msdos.*
 src/os_dos.*		Files for the MS-DOS port.
 
-src/gui_mac.*
 src/os_mac.*		Files for the Mac port.
 
 src/os_vms*		Files for the VMS port.

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -1096,8 +1096,9 @@ That's all.  XLFDs are not used.  For Chinese this is reported to work well: >
 
 For Mac OSX you can use something like this: >
     :set guifont=Monaco:h10
-Also see 'macatsui', it can help fix display problems.
-							*E236*
+
+Mono-spaced fonts					*E236*
+
 Note that the fonts must be mono-spaced (all characters have the same width).
 An exception is GTK: all fonts are accepted, but mono-spaced fonts look best.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -727,8 +727,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'antialias' 'anti'	boolean (default: off)
 			global
 			{only available when compiled with GUI enabled
-			on Mac OS X}
-	This option only has an effect in the GUI version of Vim on Mac OS X
+			on macOS}
+	This option only has an effect in the GUI version of Vim on macOS
 	v10.2 or later.  When on, Vim will use smooth ("antialiased") fonts,
 	which can be easier to read at certain sizes on certain displays.
 	Setting this option can sometimes cause problems if 'guifont' is set
@@ -4546,7 +4546,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	set and to the Vim default value when 'compatible' is reset.
 
 						*'isprint'* *'isp'*
-'isprint' 'isp'	string	(default for Win32 and Macintosh:
+'isprint' 'isp'	string	(default for Win32 and macOS:
 				"@,~-255"; otherwise: "@,161-255")
 			global
 	The characters given by this option are displayed directly on the
@@ -4923,7 +4923,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'macatsui'* *'nomacatsui'*
 'macatsui'		boolean	(default on)
 			global
-			{only available in Mac GUI version}
+			{Deprecated}
 	This is a workaround for when drawing doesn't work properly.  When set
 	and compiled with multi-byte support ATSUI text drawing is used.  When
 	not set ATSUI text drawing is not used.  Switch this option off when
@@ -6240,7 +6240,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						$VIMRUNTIME,
 						$VIM/vimfiles/after,
 						$HOME/vimfiles/after"
-					Macintosh: "$VIM:vimfiles,
+					macOS: "$VIM:vimfiles,
 						$VIMRUNTIME,
 						$VIM:vimfiles:after"
 					Haiku: "$BE_USER_SETTINGS/vim,
@@ -7744,14 +7744,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	For further details see |arabic.txt|.
 
 					*'termencoding'* *'tenc'*
-'termencoding' 'tenc'	string	(default ""; with GTK+ GUI: "utf-8"; with
-						    Macintosh GUI: "macroman")
+'termencoding' 'tenc'	string	(default ""; with GTK+ GUI: "utf-8")
 			global
 	Encoding used for the terminal.  This specifies what character
 	encoding the keyboard produces and the display will understand.  For
 	the GUI it only applies to the keyboard ('encoding' is used for the
-	display).  Except for the Mac when 'macatsui' is off, then
-	'termencoding' should be "macroman".
+	display).
 								*E617* *E950*
 	Note: This does not apply to the GTK+ GUI.  After the GUI has been
 	successfully initialized, 'termencoding' is forcibly set to "utf-8".
@@ -8397,7 +8395,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'viewdir' 'vdir'	string	(default for Amiga and Win32:
 							 "$VIM/vimfiles/view",
 				 for Unix: "~/.vim/view",
-				 for Macintosh: "$VIM:vimfiles:view"
+				 for macOS: "$VIM:vimfiles:view"
 				 for VMS: "sys$login:vimfiles/view")
 			global
 			{not available when compiled without the |+mksession|

--- a/src/Makefile
+++ b/src/Makefile
@@ -375,9 +375,6 @@ CClink = $(CC)
 #CONF_OPT_GUI = --enable-gui=athena
 #CONF_OPT_GUI = --enable-gui=nextaw
 
-# Carbon GUI for Mac OS X
-#CONF_OPT_GUI = --enable-gui=carbon
-
 # Uncomment this line to run an individual test with gvim.
 #GUI_TESTARG = GUI_FLAG=-g 
 
@@ -3303,9 +3300,6 @@ objects/gui_xim.o: gui_xim.c
 objects/gui_photon.o: gui_photon.c
 	$(CCC) -o $@ gui_photon.c
 
-objects/gui_mac.o: gui_mac.c
-	$(CCC) -o $@ gui_mac.c
-
 objects/highlight.o: highlight.c
 	$(CCC) -o $@ highlight.c
 
@@ -3689,13 +3683,6 @@ bundle-rsrc: os_mac.rsr.hqx
 	rm -f gui_mac.rsrc
 	mv gui_mac.rsrc.rsrcfork $(RESDIR)/$(VIMNAME).rsrc
 
-# po/Make_osx.pl says something about generating a Mac message file
-# for Ukrainian.  Would somebody using Mac OS X in Ukrainian
-# *really* be upset that Carbon Vim was not localised in
-# Ukrainian?
-#
-#bundle-language: bundle-dir po/Make_osx.pl
-#	cd po && perl Make_osx.pl --outdir ../$(RESDIR) $(MULTILANG)
 bundle-language: bundle-dir
 
 $(APPDIR)/Contents:

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2434,7 +2434,6 @@ elif test "x$MACOS_X" = "xyes" -a "x$with_x" = "xno" ; then
     		gui_auto=yes ;;
     auto)	AC_MSG_RESULT(auto - disable GUI support for Mac OS) ;;
     *)		AC_MSG_RESULT([Sorry, $enable_gui GUI is not supported])
-		SKIP_CARBON=YES ;;
   esac
 else
 

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -654,7 +654,7 @@ docd(BPath &path)
 drop_callback(void *cookie)
 {
     // TODO here we could handle going to a specific position in the dropped
-    // file (see src/gui_mac.c)
+    // file (see the deleted src/gui_mac.c)
     // Update the screen display
     update_screen(NOT_VALID);
 }

--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -29,11 +29,8 @@
 
 /*
  * Clipboard support for the console.
- * Don't include this when building the GUI version, the functions in
- * gui_mac.c are used then.  TODO: remove those instead?
- * But for MacVim we do need these ones.
  */
-#if defined(FEAT_CLIPBOARD) && (!defined(FEAT_GUI_ENABLED))
+#if defined(FEAT_CLIPBOARD)
 
 /* Used to identify clipboard data copied from Vim. */
 

--- a/src/testdir/test_iminsert.vim
+++ b/src/testdir/test_iminsert.vim
@@ -37,7 +37,7 @@ endfunc
 func Test_getimstatus()
   if has('win32')
     CheckFeature multi_byte_ime
-  elseif !has('gui_mac')
+  else
     CheckFeature xim
   endif
   if has('win32') && has('gui_running')
@@ -87,7 +87,7 @@ func Test_iminsert_toggle()
   CheckGui
   if has('win32')
     CheckFeature multi_byte_ime
-  elseif !has('gui_mac')
+  else
     CheckFeature xim
   endif
   if has('gui_running') && !has('win32')

--- a/src/vim.h
+++ b/src/vim.h
@@ -2155,8 +2155,6 @@ typedef enum {
 	     || !(defined(FEAT_MBYTE_IME) || defined(GLOBAL_IME)))
 // Whether IME is supported by im_get_status() defined in mbyte.c.
 // For Win32 GUI it's in gui_w32.c when FEAT_MBYTE_IME or GLOBAL_IME is defined.
-// for Mac it is in gui_mac.c for the GUI or in os_mac_conv.c when
-// MACOS_CONVERT is defined.
 # define IME_WITHOUT_XIM
 #endif
 


### PR DESCRIPTION
gui_mac.c was removed in v8.2.1422, but there are still a fair bit of stale remaining references to it and misc unused Mac GUI code/features.  Clean up those references to a reasonable degree here.

Minor fixes:
- macOS Clipboard support in os_macosx.m should not check for GUI. This way MacVim can just tap into it without needing downstream changes.

Cleanups / misc comments fixes:
- Remove stale SKIP_CARBON in configure.ac
- Remove gui_mac.o rule in Makefile
- README_extra cleanup
- Code comments in gui_haiku.cc and IME code

Documentation:
- Indicate 'macatsui' is deprecated and don't tell people to set it.  ATSUI is an old text rendering technology that Apple replaced more than 10 years ago when they introduced Core Text. It's unlikely new Vim macOS GUI will use it.
- Remove 'termencoding' macOS default value in docs.
- Unify on "macOS" name and remove references to "OS X", "Macintosh", etc.

Small questions:
- Not sure how to mark `macatsui` as deprecated. I don't think Vim tends to remove options (since there may be some folks with that set in vimrc), but not sure how to indicate in docs that it should not be set by anyone. I just changed the platforms text to say it's "Deprecated" for now.
- The 'antialias' option is no longer used by anything in Vim, but MacVim does use it downstream. I think we could just keep it so MacVim can use it as-is instead of needing to add more downstream forks to add support for it.
