### PR TITLE
CI: Load snd-dummy module on only amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,11 @@ _anchors:
         fi
     before_script:
       - sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0
-      - sudo bash ci/load-snd-dummy.sh || true
+      # It appears we can load "snd-dummy" on only amd64.
+      - |
+        if [[ "${TRAVIS_CPU_ARCH}" = amd64 ]]; then
+          sudo bash ci/load-snd-dummy.sh || true
+        fi
       - sudo usermod -a -G audio $USER
       - do_test() { sg audio "sg $(id -gn) '$*'"; }
 
@@ -208,13 +212,13 @@ jobs:
       env:
         - *normal
         - *shadowopt
-          # Temporarily disabled, always fails
-          #- <<: *linux
-          #  arch: s390x
-          #  name: huge/gcc-s390x
-          #  compiler: gcc
-          #  env: *linux-huge
-          #  services: []
+    # Temporarily disabled, always fails
+    #- <<: *linux
+    #  arch: s390x
+    #  name: huge/gcc-s390x
+    #  compiler: gcc
+    #  env: *linux-huge
+    #  services: []
     - <<: *linux
       arch: arm64
       name: huge/gcc-arm64

--- a/ci/load-snd-dummy.sh
+++ b/ci/load-snd-dummy.sh
@@ -3,6 +3,6 @@ set -e
 
 if ! modprobe snd-dummy; then
     # snd-dummy is contained in linux-modules-extra (if exists)
-    apt install -y "linux-modules-extra-$(uname -r)"
+    apt-get install -yq --no-install-suggests --no-install-recommends "linux-modules-extra-$(uname -r)"
     modprobe snd-dummy
 fi


### PR DESCRIPTION
It appears currently we can load snd-dummy on only amd64 env, thus on arm64 can shorten the time of the job by skipping trying to load snd-dummy.