### PR TITLE
Update compiler/eslint.vim and compiler/standard.vim to use npx

### DIFF
--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:    ESLint for JavaScript
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
-" Last Change: 2020 May 17
+" Last Change: 2020 August 20
 
 if exists("current_compiler")
   finish
@@ -12,5 +12,5 @@ if exists(":CompilerSet") != 2
   command -nargs=* CompilerSet setlocal <args>
 endif
 
-CompilerSet makeprg=eslint\ --format\ compact
+CompilerSet makeprg=npx\ eslint\ --format\ compact
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m,%-G%.%#

--- a/runtime/compiler/standard.vim
+++ b/runtime/compiler/standard.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:    Standard for JavaScript
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
-" Last Change: 2020 May 17
+" Last Change: 2020 August 20
 
 if exists("current_compiler")
   finish
@@ -12,5 +12,5 @@ if exists(":CompilerSet") != 2
   command -nargs=* CompilerSet setlocal <args>
 endif
 
-CompilerSet makeprg=standard
-CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m,%-G%.%#
+CompilerSet makeprg=npx\ standard
+CompilerSet errorformat=%f:%l:%c:\ %m,%-G%.%#


### PR DESCRIPTION
Problem 1: compilers incorrectly assume binary to be somewhere in $PATH
Solution: use npx

This is a follow-up to the discussion in https://github.com/vim/vim/pull/6320 about the use of $PATH.

Problem 2: standard errorformat is wrong
Solution: rewrite it to match output of standard