### PR TITLE
Don't cast the return of malloc() and friends

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -4352,7 +4352,7 @@ set_ref_in_item(
 	    }
 	    else
 	    {
-		ht_stack_T *newitem = (ht_stack_T*)malloc(sizeof(ht_stack_T));
+		ht_stack_T *newitem = malloc(sizeof(ht_stack_T));
 		if (newitem == NULL)
 		    abort = TRUE;
 		else
@@ -4378,8 +4378,7 @@ set_ref_in_item(
 	    }
 	    else
 	    {
-		list_stack_T *newitem = (list_stack_T*)malloc(
-							sizeof(list_stack_T));
+		list_stack_T *newitem = malloc(sizeof(list_stack_T));
 		if (newitem == NULL)
 		    abort = TRUE;
 		else

--- a/src/memline.c
+++ b/src/memline.c
@@ -5448,7 +5448,7 @@ ml_updatechunk(
 	    chunksize_T *t_chunksize = buf->b_ml.ml_chunksize;
 
 	    buf->b_ml.ml_numchunks = buf->b_ml.ml_numchunks * 3 / 2;
-	    buf->b_ml.ml_chunksize = (chunksize_T *)
+	    buf->b_ml.ml_chunksize =
 		vim_realloc(buf->b_ml.ml_chunksize,
 			    sizeof(chunksize_T) * buf->b_ml.ml_numchunks);
 	    if (buf->b_ml.ml_chunksize == NULL)

--- a/src/vimrun.c
+++ b/src/vimrun.c
@@ -77,7 +77,7 @@ main(void)
     if (cmdlen >= 2 && p[0] == L'"' && p[cmdlen - 1] == L'"')
     {
 	cmdlen += 3;
-	cmd = (wchar_t *)malloc(cmdlen * sizeof(wchar_t));
+	cmd = malloc(cmdlen * sizeof(wchar_t));
 	if (cmd == NULL)
 	{
 	    perror("vimrun malloc(): ");


### PR DESCRIPTION
Other than being superfluous, these few casts were inconsistent with the rest of memory allocation calls in the codebase.