### PR TITLE
0 ? 0 break next evaluation.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -2178,6 +2178,7 @@ eval1(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	    emsg(_(e_missing_colon));
 	    if (evaluate && result)
 		clear_tv(rettv);
+	    evalarg_used->eval_flags = orig_flags;
 	    return FAIL;
 	}
 	if (getnext)

--- a/src/eval.c
+++ b/src/eval.c
@@ -2189,6 +2189,7 @@ eval1(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	    {
 		error_white_both(p, 1);
 		clear_tv(rettv);
+		evalarg_used->eval_flags = orig_flags;
 		return FAIL;
 	    }
 	    *arg = p;
@@ -2201,6 +2202,7 @@ eval1(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	{
 	    error_white_both(p, 1);
 	    clear_tv(rettv);
+	    evalarg_used->eval_flags = orig_flags;
 	    return FAIL;
 	}
 	*arg = skipwhite_and_linebreak(*arg + 1, evalarg_used);
@@ -2210,6 +2212,7 @@ eval1(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	{
 	    if (evaluate && result)
 		clear_tv(rettv);
+	    evalarg_used->eval_flags = orig_flags;
 	    return FAIL;
 	}
 	if (evaluate && !result)

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -7445,6 +7445,14 @@ func Test_typed_script_var()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for issue6776              {{{1
+func Test_issue6776()
+  try
+    call eval('0 ? 0')
+  catch
+  endtry
+endfunction
+
 "-------------------------------------------------------------------------------
 " Modelines								    {{{1
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
When evaluate broken ternary operator `0 ? 0`, it break next evaluations.

![image](https://user-images.githubusercontent.com/10111/90961387-80553b80-e4e3-11ea-8b26-b3a26203ce80.png)
