### PR TITLE
testing: Always show messages

### DIFF
--- a/src/testdir/Make_dos.mak
+++ b/src/testdir/Make_dos.mak
@@ -117,7 +117,7 @@ $(TEST_OUTFILES): $(DOSTMP)\$(*B).in
 # Limitation: Only works with the +eval feature.
 
 newtests: newtestssilent
-	@if exist messages (findstr "SKIPPED FAILED" messages > nul) && type messages
+	@if exist messages type messages
 
 newtestssilent: $(NEW_TESTS_RES)
 

--- a/src/testdir/Make_ming.mak
+++ b/src/testdir/Make_ming.mak
@@ -129,7 +129,7 @@ $(DOSTMP)/%.in : %.in
 # Limitation: Only works with the +eval feature.
 
 newtests: newtestssilent
-	@if exist messages (findstr "SKIPPED FAILED" messages > nul) && type messages
+	@if exist messages type messages
 
 newtestssilent: $(NEW_TESTS_RES)
 

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -126,7 +126,7 @@ tinytests: $(SCRIPTS_TINY_OUT)
 RUN_VIMTEST = VIMRUNTIME=$(SCRIPTSOURCE) $(VALGRIND) $(VIMPROG) -f $(GUI_FLAG) -u unix.vim
 
 newtests: newtestssilent
-	@/bin/sh -c "if test -f messages && grep -q 'SKIPPED\|FAILED' messages; then cat messages; fi"
+	@/bin/sh -c "if test -f messages; then cat messages; fi"
 
 newtestssilent: $(NEW_TESTS_RES)
 


### PR DESCRIPTION
"messages" was shown only if it contained "SKIPPED" or "FAILED".
However, now "messages" contains information about execution time.
It is useful always to show "messages".

Also there was an issue in Make_dos.mak and Make_ming.mak.
If either "SKIPPED" or "FILED" was not found in "messages", `findstr`
returned 1, then the test was treated as it was failed.

Actually, these issues will not happen in the current environment,
because "messages" always contains "SKIPPED", but they might matter
when someone wants to reuse the makefiles to another project.