### PR TITLE
GHA: Measure the code coverage also on MS-Windows

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -81,7 +81,7 @@ jobs:
       if: matrix.toolchain == 'mingw'
       with:
         msystem: ${{ matrix.msystem }}
-        install: git
+        path-type: inherit
         release: false
 
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -234,4 +234,6 @@ jobs:
       shell: msys2 {0}
       run: |
         cd src
-        bash <(curl -s https://codecov.io/bash)
+        export ARCH=${{ matrix.arch }}
+        export TOOLCHAIN=${{ matrix.toolchain }}
+        bash <(curl -s https://codecov.io/bash) -e TOOLCHAIN,ARCH

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -236,4 +236,4 @@ jobs:
         cd src
         export ARCH=${{ matrix.arch }}
         export TOOLCHAIN=${{ matrix.toolchain }}
-        bash <(curl -s https://codecov.io/bash) -e TOOLCHAIN,ARCH
+        bash <(curl -s https://codecov.io/bash) -e TOOLCHAIN,ARCH -F windows

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -81,6 +81,7 @@ jobs:
       if: matrix.toolchain == 'mingw'
       with:
         msystem: ${{ matrix.msystem }}
+        install: git
         release: false
 
     - uses: actions/checkout@v2
@@ -169,6 +170,7 @@ jobs:
             DYNAMIC_LUA=yes LUA=${LUA_DIR} \
             DYNAMIC_PYTHON=yes PYTHON=${PYTHON_DIR} \
             DYNAMIC_PYTHON3=yes PYTHON3=${PYTHON3_DIR} \
+            COVERAGE=yes \
             STATIC_STDCPLUS=yes
         else
           mingw32-make -f Make_ming.mak -j2 \
@@ -226,3 +228,10 @@ jobs:
           echo %COL_RED%Timed out.%COL_RESET%
           exit 1
         )
+
+    - name: Coverage (MinGW)
+      if: matrix.toolchain == 'mingw'
+      shell: msys2 {0}
+      run: |
+        cd src
+        bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ _anchors:
     # not with clang
     - CC=gcc pip install --user cpp-coveralls pyopenssl ndg-httpsclient pyasn1
     - ~/.local/bin/coveralls -b "${SRCDIR}" -x .xs -e "${SRCDIR}"/if_perl.c -e "${SRCDIR}"/xxd -e "${SRCDIR}"/libvterm --encodings utf-8
-    - (cd "${SRCDIR}" && bash <(curl -s https://codecov.io/bash))
+    - (cd "${SRCDIR}" && bash <(curl -s https://codecov.io/bash) -F linux)
 
   asan_symbolize: &asan_symbolize
     # Update pyenv to fix the error "/opt/pyenv/libexec/pyenv: line 43: cd: asan_symbolize-6.0: Not a directory".


### PR DESCRIPTION
And some improvements to the GHA environment.

* Add `COVERAGE=yes|no` option to `Make_cyg_ming.mak`.
* Enable to measure the code coverage on MinGW HUGE (x86, x64) on GHA and upload the data to codecov.
  (This doesn't upload the data to coveralls. Not sure it is worth doing.)
  Unfortunately, this will drop the code coverage about 3%. :-(
* Fix that some tests were not executed on GHA.
  To fix this, copy all the files in `src/` (not only `src/testdir/`) to `src2/`, and fix some tests.
  (The tests for gvim.exe is run at `src/testdir/`, and the tests for vim.exe is run at `src2/testdir/`.)
* Update the flaky tests list.
  Some tests are flaky on GHA. `Test_BufWrite_lockmarks()` and `Test_bufunload_all()` are added to the list.
  Actually, there are some more flaky tests on GHA, but at least these two tests are often failed.
  (I tried to fix them, but I couldn't. They don't reproduce on my local environment.)