### PR TITLE
GHA: Some improvements to the GHA environemnt

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -127,6 +127,11 @@ jobs:
         )
         goto :eof
 
+    - name: Copy src directory to src2
+      shell: cmd
+      run: |
+        xcopy src src2\ /E > nul
+
     - name: Build (MSVC)
       if: matrix.toolchain == 'msvc'
       shell: cmd
@@ -195,10 +200,6 @@ jobs:
         echo.
         echo %COL_GREEN%vim version:%COL_RESET%
         .\vim --version || exit 1
-
-        mkdir ..\src2
-        xcopy testdir ..\src2\testdir\ /E > nul || exit 1
-        copy evalfunc.c ..\src2 > nul
 
         echo %COL_GREEN%Start testing vim in background.%COL_RESET%
         start cmd /c "cd ..\src2\testdir & nmake -nologo -f Make_dos.mak VIMPROG=..\..\src\vim > nul & echo done>done.txt"

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -382,7 +382,9 @@ endif
 
 " Names of flaky tests.
 let s:flaky_tests = [
+      \ 'Test_BufWrite_lockmarks()',
       \ 'Test_autocmd_SafeState()',
+      \ 'Test_bufunload_all()',
       \ 'Test_client_server()',
       \ 'Test_close_and_exit_cb()',
       \ 'Test_close_output_buffer()',

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -2412,7 +2412,7 @@ func Test_python_chdir()
     cb.append(vim.eval('@%'))
     os.chdir('..')
     path = fnamemodify('.', ':p:h:t')
-    if path != 'src':
+    if path != 'src' and path != 'src2':
       # Running tests from a shadow directory, so move up another level
       # This will result in @% looking like shadow/testdir/Xfile, hence the
       # extra fnamemodify
@@ -2422,7 +2422,8 @@ func Test_python_chdir()
       os.chdir(path)
       del path
     else:
-      cb.append(fnamemodify('.', ':p:h:t'))
+      # Also accept running from src2/testdir/ for MS-Windows CI.
+      cb.append(fnamemodify('.', ':p:h:t').replace('src2', 'src'))
       cb.append(vim.eval('@%').replace(os.path.sep, '/'))
     os.chdir('testdir')
     cb.append(fnamemodify('.', ':p:h:t'))

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -2591,7 +2591,7 @@ func Test_python3_chdir()
     cb.append(vim.eval('@%'))
     os.chdir('..')
     path = fnamemodify('.', ':p:h:t')
-    if path != b'src':
+    if path != b'src' and path != b'src2':
       # Running tests from a shadow directory, so move up another level
       # This will result in @% looking like shadow/testdir/Xfile, hence the
       # slicing to remove the leading path and path separator
@@ -2600,7 +2600,8 @@ func Test_python3_chdir()
       cb.append(vim.eval('@%')[len(path)+1:].replace(os.path.sep, '/'))
       os.chdir(path)
     else:
-      cb.append(str(fnamemodify('.', ':p:h:t')))
+      # Also accept running from src2/testdir/ for MS-Windows CI.
+      cb.append(str(fnamemodify('.', ':p:h:t').replace(b'src2', b'src')))
       cb.append(vim.eval('@%').replace(os.path.sep, '/'))
     del path
     os.chdir('testdir')


### PR DESCRIPTION
Extracted from #6795.

* Fix that some tests were not executed on GHA.
  To fix this, copy all the files in `src/` (not only `src/testdir/`) to `src2/`, and fix some tests.
  (The tests for gvim.exe is run at `src/testdir/`, and the tests for vim.exe is run at `src2/testdir/`.)
* Update the flaky tests list.
  Some tests are flaky on GHA. `Test_BufWrite_lockmarks()` and `Test_bufunload_all()` are added to the list.
  Actually, there are some more flaky tests on GHA, but at least these two tests are often failed.
  (I tried to fix them, but I couldn't. They don't reproduce in my local environment.)