### PR TITLE
Re-enable Travis s390 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -212,13 +212,12 @@ jobs:
       env:
         - *normal
         - *shadowopt
-    # Temporarily disabled, always fails
-    #- <<: *linux
-    #  arch: s390x
-    #  name: huge/gcc-s390x
-    #  compiler: gcc
-    #  env: *linux-huge
-    #  services: []
+    - <<: *linux
+      arch: s390x
+      name: huge/gcc-s390x
+      compiler: gcc
+      env: *linux-huge
+      services: []
     - <<: *linux
       arch: arm64
       name: huge/gcc-arm64


### PR DESCRIPTION
The Travis infrastructure issues that were causing it to fail have been fixed.