### PR TITLE
Fixed ubsan errors in spellfile.c, spellsuggest.c and viminfo.c

### DIFF
--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -816,11 +816,14 @@ read_cnt_string(FILE *fd, int cnt_bytes, int *cntp)
 
     // read the length bytes, MSB first
     for (i = 0; i < cnt_bytes; ++i)
-	cnt = (cnt << 8) + (unsigned)getc(fd);
-    if (cnt < 0)
     {
-	*cntp = SP_TRUNCERROR;
-	return NULL;
+	int c = getc(fd);
+	if (c == EOF)
+	{
+	    *cntp = SP_TRUNCERROR;
+	    return NULL;
+	}
+	cnt = (cnt << 8) + (unsigned)c;
     }
     *cntp = cnt;
     if (cnt == 0)

--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -3731,9 +3731,6 @@ cleanup_suggestions(
     int		maxscore,
     int		keep)		// nr of suggestions to keep
 {
-    suggest_T   *stp = &SUG(*gap, 0);
-    int		i;
-
     if (gap->ga_len > 0)
     {
 	// Sort the list.
@@ -3744,6 +3741,9 @@ cleanup_suggestions(
 	// displayed.
 	if (gap->ga_len > keep)
 	{
+	    int		i;
+	    suggest_T   *stp = &SUG(*gap, 0);
+
 	    for (i = keep; i < gap->ga_len; ++i)
 		vim_free(stp[i].st_word);
 	    gap->ga_len = keep;

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -2183,7 +2183,7 @@ write_viminfo_filemarks(FILE *fp)
 	xfmark_T	*vi_fm;
 
 	fm = idx >= 0 ? &curwin->w_jumplist[idx] : NULL;
-	vi_fm = (vi_jumplist && vi_idx < vi_jumplist_len)
+	vi_fm = (vi_jumplist != NULL && vi_idx < vi_jumplist_len)
 					? &vi_jumplist[vi_idx] : NULL;
 	if (fm == NULL && vi_fm == NULL)
 	    break;

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -2183,7 +2183,8 @@ write_viminfo_filemarks(FILE *fp)
 	xfmark_T	*vi_fm;
 
 	fm = idx >= 0 ? &curwin->w_jumplist[idx] : NULL;
-	vi_fm = vi_idx < vi_jumplist_len ? &vi_jumplist[vi_idx] : NULL;
+	vi_fm = (vi_jumplist && vi_idx < vi_jumplist_len)
+					? &vi_jumplist[vi_idx] : NULL;
 	if (fm == NULL && vi_fm == NULL)
 	    break;
 	if (fm == NULL || (vi_fm != NULL && fm->time_set < vi_fm->time_set))


### PR DESCRIPTION
The PR fixes the last 3 remaining ubsan errors in spellfile.c, spellsuggest.c and viminfo.c.

See ubsan errors at the bottom of https://api.travis-ci.org/v3/job/723283618/log.txt
