### PR TITLE
Provide a way to query the effective prompt text for a prompt buffer

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -1256,7 +1256,9 @@ After setting 'buftype' to "prompt" Vim does not automatically start Insert
 mode, use `:startinsert` if you want to enter Insert mode, so that the user
 can start typing a line.
 
-The text of the prompt can be set with the |prompt_setprompt()| function.
+The text of the prompt can be set with the |prompt_setprompt()| function. If
+no prompt is set with |prompt_setprompt()|, "% " is used. You can get the
+effective prompt text for a buffer, with |prompt_getprompt()|.
 
 The user can go to Normal mode and navigate through the buffer.  This can be
 useful to see older output or copy text.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2684,6 +2684,7 @@ popup_show({id})		none	unhide popup window {id}
 pow({x}, {y})			Float	{x} to the power of {y}
 prevnonblank({lnum})		Number	line nr of non-blank line <= {lnum}
 printf({fmt}, {expr1}...)	String	format text
+prompt_getprompt({buf})		String	get prompt text
 prompt_setcallback({buf}, {expr}) none	set prompt callback function
 prompt_setinterrupt({buf}, {text}) none	set prompt interrupt function
 prompt_setprompt({buf}, {text}) none	set prompt text
@@ -7833,6 +7834,17 @@ printf({fmt}, {expr1} ...)				*printf()*
 		The number of {exprN} arguments must exactly match the number
 		of "%" items.  If there are not sufficient or too many
 		arguments an error is given.  Up to 18 arguments can be used.
+
+
+prompt_getprompt({buf})					*prompt_getprompt()*
+		Returns the effective prompt text for buffer {buf}. {buf} can
+		be a buffer name or number. |prompt-buffer|.
+
+		If the buffer doesn't exist or isn't a prompt buffer, an empty
+		string is returned.
+
+		Can also be used as a |method|: >
+			GetBuffer()->prompt_getprompt()
 
 
 prompt_setcallback({buf}, {expr})			*prompt_setcallback()*

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1118,6 +1118,7 @@ Tags:						*tag-functions*
 	settagstack()		modify the tag stack of a window
 
 Prompt Buffer:					*promptbuffer-functions*
+	prompt_getprompt()	get the effective prompt text for a buffer
 	prompt_setcallback()	set prompt callback for a buffer
 	prompt_setinterrupt()	set interrupt callback for a buffer
 	prompt_setprompt()	set the prompt text for a buffer

--- a/src/channel.c
+++ b/src/channel.c
@@ -6368,6 +6368,29 @@ f_prompt_setinterrupt(typval_T *argvars, typval_T *rettv UNUSED)
     set_callback(&buf->b_prompt_interrupt, &callback);
 }
 
+
+/*
+ * "prompt_getprompt({buffer})" function
+ */
+    void
+f_prompt_getprompt(typval_T *argvars, typval_T *rettv)
+{
+    buf_T	*buf;
+
+    // return an empty string by default, e.g. it's not a prompt buffer
+    rettv->v_type = VAR_STRING;
+    rettv->vval.v_string = NULL;
+
+    buf = tv_get_buf_from_arg(&argvars[0]);
+    if (buf == NULL)
+	return;
+
+    if (!bt_prompt(buf))
+	return;
+
+    rettv->vval.v_string = vim_strsave(buf_prompt_text(buf));
+}
+
 /*
  * "prompt_setprompt({buffer}, {text})" function
  */

--- a/src/edit.c
+++ b/src/edit.c
@@ -1682,15 +1682,25 @@ edit_putchar(int c, int highlight)
 
 #if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
 /*
+ * Return the effective prompt for the specified buffer.
+ */
+    char_u *
+buf_prompt_text(buf_T* buf)
+{
+    if (buf->b_prompt_text == NULL)
+	return (char_u *)"% ";
+    return buf->b_prompt_text;
+}
+
+/*
  * Return the effective prompt for the current buffer.
  */
     char_u *
 prompt_text(void)
 {
-    if (curbuf->b_prompt_text == NULL)
-	return (char_u *)"% ";
-    return curbuf->b_prompt_text;
+    return buf_prompt_text(curbuf);
 }
+
 
 /*
  * Prepare for prompt mode: Make sure the last line has the prompt text.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -806,6 +806,7 @@ static funcentry_T global_functions[] =
     {"pow",		2, 2, FEARG_1,	  ret_float,	FLOAT_FUNC(f_pow)},
     {"prevnonblank",	1, 1, FEARG_1,	  ret_number,	f_prevnonblank},
     {"printf",		1, 19, FEARG_2,	  ret_string,	f_printf},
+    {"prompt_getprompt", 1, 1, FEARG_1,	  ret_string,	JOB_FUNC(f_prompt_getprompt)},
     {"prompt_setcallback", 2, 2, FEARG_1, ret_void,	JOB_FUNC(f_prompt_setcallback)},
     {"prompt_setinterrupt", 2, 2, FEARG_1,ret_void,	JOB_FUNC(f_prompt_setinterrupt)},
     {"prompt_setprompt", 2, 2, FEARG_1,	  ret_void,	JOB_FUNC(f_prompt_setprompt)},

--- a/src/proto/channel.pro
+++ b/src/proto/channel.pro
@@ -56,6 +56,7 @@ char *job_status(job_T *job);
 int job_stop(job_T *job, typval_T *argvars, char *type);
 void invoke_prompt_callback(void);
 int invoke_prompt_interrupt(void);
+void f_prompt_getprompt(typval_T *argvars, typval_T *rettv);
 void f_prompt_setcallback(typval_T *argvars, typval_T *rettv);
 void f_prompt_setinterrupt(typval_T *argvars, typval_T *rettv);
 void f_prompt_setprompt(typval_T *argvars, typval_T *rettv);

--- a/src/proto/edit.pro
+++ b/src/proto/edit.pro
@@ -4,6 +4,7 @@ int ins_need_undo_get(void);
 void ins_redraw(int ready);
 int decodeModifyOtherKeys(int c);
 void edit_putchar(int c, int highlight);
+char_u *buf_prompt_text(buf_T* buf);
 char_u *prompt_text(void);
 int prompt_curpos_editable(void);
 void edit_unputchar(void);

--- a/src/testdir/test_prompt_buffer.vim
+++ b/src/testdir/test_prompt_buffer.vim
@@ -148,4 +148,38 @@ func Test_prompt_buffer_edit()
   call assert_equal(0, prompt_setprompt([], ''))
 endfunc
 
+func Test_prompt_buffer_getbufinfo()
+  new
+  call assert_equal('', prompt_getprompt('%'))
+  call assert_equal('', prompt_getprompt(bufnr('%')))
+  let another_buffer = bufnr('%')
+
+  set buftype=prompt
+  call assert_equal('% ', prompt_getprompt('%'))
+  call prompt_setprompt( bufnr( '%' ), 'This is a test: ' )
+  call assert_equal('This is a test: ', prompt_getprompt('%'))
+
+  call prompt_setprompt( bufnr( '%' ), '' )
+  call assert_equal('', '%'->prompt_getprompt())
+
+  call prompt_setprompt( bufnr( '%' ), 'Another: ' )
+  call assert_equal('Another: ', prompt_getprompt('%'))
+  let another = bufnr('%')
+
+  new
+
+  call assert_equal('', prompt_getprompt('%'))
+  call assert_equal('Another: ', prompt_getprompt(another))
+
+  " Doesn't exist
+  let buffers_before = len( getbufinfo() )
+  call assert_equal('', prompt_getprompt( bufnr('$') + 1))
+  call assert_equal(buffers_before, len( getbufinfo()))
+
+  " invalid type
+  call assert_fails('call prompt_getprompt({})', 'E728:')
+
+  %bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This adds the (optional) `prompt` key to the return from `getbufinfo()` in order to see the effective prompt text for a prompt buffer.

This is useful when writing an `omnifunc` for prompt buffers, i.e. you can find the real text being entered with something like:

```
let line = getline( line( '.' ) )[ len( getbufinfo( '%' )[ 0 ].prompt ) : ]
```

This means that you don't have to know a-priori what the prompt will be and/or don't need to find a way to push this into your omnifunc callback.