### PR TITLE
Internal errors E38, E43, E44 should use iemsg() instead of emsg()

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -2279,7 +2279,7 @@ vim_regsub_both(
 		    else if (*s == NUL) // we hit NUL.
 		    {
 			if (copy)
-			    emsg(_(e_re_damg));
+			    iemsg(_(e_re_damg));
 			goto exit;
 		    }
 		    else

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -2293,7 +2293,7 @@ bt_regcomp(char_u *expr, int re_flags)
     int		flags;
 
     if (expr == NULL)
-	EMSG_RET_NULL(_(e_null));
+	IEMSG_RET_NULL(_(e_null));
 
     init_class_tab();
 
@@ -2917,7 +2917,7 @@ do_class:
 	break;
 
       default:			// Oh dear.  Called inappropriately.
-	emsg(_(e_re_corr));
+	iemsg(_(e_re_corr));
 #ifdef DEBUG
 	printf("Called regrepeat with op code %d\n", OP(p));
 #endif
@@ -4099,7 +4099,7 @@ regmatch(
 	    break;
 
 	  default:
-	    emsg(_(e_re_corr));
+	    iemsg(_(e_re_corr));
 #ifdef DEBUG
 	    printf("Illegal op code %d\n", op);
 #endif
@@ -4499,7 +4499,7 @@ regmatch(
 	{
 	    // We get here only if there's trouble -- normally "case END" is
 	    // the terminating point.
-	    emsg(_(e_re_corr));
+	    iemsg(_(e_re_corr));
 #ifdef DEBUG
 	    printf("Premature EOL\n");
 #endif
@@ -4649,7 +4649,7 @@ bt_regexec_both(
     // Be paranoid...
     if (prog == NULL || line == NULL)
     {
-	emsg(_(e_null));
+	iemsg(_(e_null));
 	goto theend;
     }
 

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -7147,7 +7147,7 @@ nfa_regexec_both(
     // Be paranoid...
     if (prog == NULL || line == NULL)
     {
-	emsg(_(e_null));
+	iemsg(_(e_null));
 	goto theend;
     }
 


### PR DESCRIPTION
E38, E43, E44 are documented as internal errors, so use
iemsg() to make it easier to find occurrence of them when
building with -DABORT_ON_INTERNAL_ERROR.  
This is in particular useful when fuzzing vim.