### PR TITLE
Italian.nsi _batch fix

### DIFF
--- a/nsis/lang/italian.nsi
+++ b/nsis/lang/italian.nsi
@@ -58,9 +58,9 @@ LangString str_desc_console         ${LANG_ITALIAN} \
     "Versione console di Vim (vim.exe)."
 
 LangString str_section_batch        ${LANG_ITALIAN} \
-    "Crea file di invocazione (MS-DOS) .bat"
+    "Crea file (MS-DOS) .bat"
 LangString str_desc_batch           ${LANG_ITALIAN} \
-    "Crea file di invocazione .bat per varianti di Vim nella directory \
+    "Crea file .bat per varianti di Vim nella directory \
      di Windows, per utilizzo da linea di comando (MS-DOS)."
 
 LangString str_group_icons          ${LANG_ITALIAN} \

--- a/nsis/lang/italian.nsi
+++ b/nsis/lang/italian.nsi
@@ -58,10 +58,10 @@ LangString str_desc_console         ${LANG_ITALIAN} \
     "Versione console di Vim (vim.exe)."
 
 LangString str_section_batch        ${LANG_ITALIAN} \
-    "Crea file (MS-DOS) .bat"
+    "Crea file .bat"
 LangString str_desc_batch           ${LANG_ITALIAN} \
     "Crea file .bat per varianti di Vim nella directory \
-     di Windows, per utilizzo da linea di comando (MS-DOS)."
+     di Windows, per utilizzo da linea di comando."
 
 LangString str_group_icons          ${LANG_ITALIAN} \
     "Crea icone per Vim"

--- a/nsis/lang/italian.nsi
+++ b/nsis/lang/italian.nsi
@@ -61,7 +61,7 @@ LangString str_section_batch        ${LANG_ITALIAN} \
     "Crea file .bat"
 LangString str_desc_batch           ${LANG_ITALIAN} \
     "Crea file .bat per varianti di Vim nella directory \
-     di Windows, per utilizzo da linea di comando."
+     di Windows, per utilizzo da riga di comando."
 
 LangString str_group_icons          ${LANG_ITALIAN} \
     "Crea icone per Vim"


### PR DESCRIPTION
The Italian translation of the NSIS _batch option was incorrect, I submit a correction as asked by Christian Brabandt in the vim_use mailing list (https://groups.google.com/d/msg/vim_use/ueFJ8KK-5WM/ieLS2JH2AwAJ).

I made a series of microscopic commits (with a final merge one) because I'm used to do so, if you prefer to have a single commit if you want I already put one such version in my [italian.nsi_fix-singlecommit](https://github.com/Gabr-F/vim/commits/italian.nsi_fix-singlecommit) branch ([https://github.com/Gabr-F/vim/commit/4391faef9bd3d91ef80f04da78420724a8d5e625](https://github.com/Gabr-F/vim/commit/4391faef9bd3d91ef80f04da78420724a8d5e625))

But I imagine in the official repo you'll just put a standard "patch 8.2.# etc" commit and these ones won't matter much