### PR TITLE
gui_gtk_x11.c: use gtk_image_new_from_icon_name ()

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3093,7 +3093,7 @@ icon_size_changed_foreach(GtkWidget *widget, gpointer user_data)
 
 	    gtk_image_get_icon_name(image, &icon_name, NULL);
 
-	    gtk_image_set_from_icon_name(image, icon_name, icon_size);
+	    image = gtk_image_new_from_icon_name(icon_name, icon_size);
 	}
 # else
 	// User-defined icons are stored in a GtkIconSet


### PR DESCRIPTION
Hi,

we have [bugzilla ticket](https://bugzilla.redhat.com/show_bug.cgi?id=1643799) for Fedora and I found the same ticket here on [Vim github](https://github.com/vim/vim/issues/3602).

The issue happens if Vim is compiled with GTK3, Vim cannot resize icons if they are changed - they became broken images.

The reason of the problem is Vim is using older GTK3 API - ```gtk_image_set_from_icon_name()``` instead of ```gtk_image_new_from_icon_name ()``` - the old API frees ```image``` struct inside itself, and by that it unintentionally frees ```icon_name``` too, because it was a pointer from ```image``` struct. The pointer becomes invalid and leads to broken images.

Using the 'new' API (available since gtk-2.6) fixes the issue. Would you mind adding it to the project?

Please let me know if I should change something too.

Thank you in advance!

Zdenek  