### PR TITLE
channel: pass AI_V4MAPPED flag to getaddrinfo

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -977,8 +977,8 @@ channel_open(
     CLEAR_FIELD(hints);
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
-# ifdef AI_ADDRCONFIG
-    hints.ai_flags = AI_ADDRCONFIG;
+# if defined(AI_ADDRCONFIG) && defined(AI_V4MAPPED)
+    hints.ai_flags = AI_ADDRCONFIG | AI_V4MAPPED;
 # endif
     // Set port number manually in order to prevent name resolution services
     // from being invoked in the environment where AI_NUMERICSERV is not


### PR DESCRIPTION
**Problem**:    When a host only has IPv6 addresses configured on its public interfaces, connecting to 127.0.0.1 does not work.

**Solution**:   Pass both `AI_ADDRCONFIG` and `AI_V4MAPPED` in `hints.ai_flags` to `getaddrinfo()`.

See https://man7.org/linux/man-pages/man3/getaddrinfo.3.html:

> If `hints.ai_flags` specifies the `AI_V4MAPPED` flag [...], and no matching IPv6 addresses could be found, then return IPv4-mapped IPv6 addresses in the list pointed to by `res`.

Address 127.0.0.1 is explicitly used by some plug-ins, such as vim-hug-neovim-rpc, which is used by deoplete. Including `AI_V4MAPPED` in the flags makes resolution of that address for the loopback work again.

The default when no hints are passed is also `AI_ADDRCONFIG | AI_V4MAPPED`.