### PR TITLE
Fix leak of terminal_bufs

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1319,6 +1319,9 @@ theend:
 #ifdef FEAT_SESSION
     vim_free(viewFile);
 #endif
+#ifdef FEAT_TERMINAL
+    hash_clear_all(&terminal_bufs, 0);
+#endif
 }
 
 #if (defined(FEAT_VIMINFO) || defined(FEAT_SESSION)) || defined(PROTO)


### PR DESCRIPTION
A follow-up to #6930 / 0e655111e9dbdbdf69fee1b199f2b9c355bf4a10 - fix the leak of the second `terminal_bufs`