### PR TITLE
Strip duplicate items from environment variables in 'backupskip' default

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -1622,7 +1622,6 @@ do_set(
 #endif
 			unsigned  newlen;
 			int	  comma;
-			int	  bs;
 			int	  new_value_alloced;	// new string option
 							// was allocated
 

--- a/src/option.c
+++ b/src/option.c
@@ -140,7 +140,6 @@ set_init_1(int clean_arg)
 	int		len;
 	garray_T	ga;
 	int		mustfree;
-	int		opt_idx;
 	char		*item;
 
 	opt_idx = findoption((char_u *)"backupskip");

--- a/src/option.c
+++ b/src/option.c
@@ -684,8 +684,6 @@ find_flag(char_u *origval, char_u *newval, long_u flags)
 
     if (!origval)
 	return NULL;
-    if (!newval)
-	return NULL;
 
     i = (int)STRLEN(newval);
 

--- a/src/option.c
+++ b/src/option.c
@@ -37,7 +37,7 @@
 
 static void set_options_default(int opt_flags);
 static void set_string_default_esc(char *name, char_u *val, int escape);
-static char *find_flag(char *origval, char *newval, long_u flags);
+static char_u *find_flag(char_u *origval, char_u *newval, long_u flags);
 static char_u *option_expand(int opt_idx, char_u *val);
 static void didset_options(void);
 static void didset_options2(void);
@@ -140,7 +140,7 @@ set_init_1(int clean_arg)
 	int		len;
 	garray_T	ga;
 	int		mustfree;
-	char		*item;
+	char_u		*item;
 
 	opt_idx = findoption((char_u *)"backupskip");
 
@@ -675,12 +675,12 @@ set_string_default(char *name, char_u *val)
     set_string_default_esc(name, val, FALSE);
 }
 
-    static char *
-find_flag(char *origval, char *newval, long_u flags)
+    static char_u *
+find_flag(char_u *origval, char_u *newval, long_u flags)
 {
     int bs;
     int i;
-    char *s;
+    char_u *s;
 
     if (!origval)
 	return NULL;

--- a/src/option.c
+++ b/src/option.c
@@ -140,6 +140,10 @@ set_init_1(int clean_arg)
 	int		len;
 	garray_T	ga;
 	int		mustfree;
+	int		opt_idx;
+	char		*item;
+
+	opt_idx = findoption((char_u *)"backupskip");
 
 	ga_init2(&ga, 1, 100);
 	for (n = 0; n < (long)(sizeof(names) / sizeof(char *)); ++n)
@@ -159,15 +163,19 @@ set_init_1(int clean_arg)
 	    {
 		// First time count the NUL, otherwise count the ','.
 		len = (int)STRLEN(p) + 3;
-		if (ga_grow(&ga, len) == OK)
+		item = alloc(len - 1);
+		STRCPY(item, p);
+		add_pathsep(item);
+		STRCAT(item, "*");
+		if (!find_flag(ga.ga_data, item, options[opt_idx].flags)
+			&& ga_grow(&ga, len) == OK)
 		{
 		    if (ga.ga_len > 0)
 			STRCAT(ga.ga_data, ",");
-		    STRCAT(ga.ga_data, p);
-		    add_pathsep(ga.ga_data);
-		    STRCAT(ga.ga_data, "*");
+		    STRCAT(ga.ga_data, item);
 		    ga.ga_len += len;
 		}
+		vim_free(item);
 	    }
 	    if (mustfree)
 		vim_free(p);

--- a/src/option.c
+++ b/src/option.c
@@ -162,7 +162,7 @@ set_init_1(int clean_arg)
 	    {
 		// First time count the NUL, otherwise count the ','.
 		len = (int)STRLEN(p) + 3;
-		item = alloc(len - 1);
+		item = alloc(len);
 		STRCPY(item, p);
 		add_pathsep(item);
 		STRCAT(item, "*");


### PR DESCRIPTION
The default value for the `'backupskip'` option on Unix in `nocompatible` mode is `/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*`.  When two or three of these environment variables are set to the same value, duplicate items appear in the resulting `'backupskip'` value.  If using a PAM module like `pam_tmpdir.so` with `systemd`, all three of these variables are set in the environment, which results in `'backupskip'` values like this:

    backupskip=/tmp/*,/tmp/user/1000/*,/tmp/user/1000/*,/tmp/user/1000/*

To demonstrate:

    $ TMPDIR=/tmp TMP=/tmp TEMP=/tmp vim -N --clean
    :set backupskip?
    backupskip=/tmp/*,/tmp/*,/tmp/*,/tmp/*

This turns out to be because the duplicate checking applied in `option.c` `do_set()` is not applied in the block pertaining to `backupskip`'s default values in `set_init_1()`.  I attempted to fix this by factoring out the duplicate checking into a new static function `find_flag()` in eec9db15 that returns a pointer into the original value if a flag is found, and `NULL` otherwise, and then applying it in `set_init_1()` in 24eaf2fc.  On my system, this now yields:

    $ TMPDIR=/tmp TMP=/tmp TEMP=/tmp vim -N --clean
    :set backupskip?
    backupskip=/tmp/*

A test is included.