### PR TITLE
Fixed compilation warnings about variable which may be uninitialized

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -2634,7 +2634,7 @@ add_text_props_for_append(
     int		n;
     char_u	*props;
     int		new_len = 0;  // init for gcc
-    char_u	*new_line;
+    char_u	*new_line = NULL;
     textprop_T	prop;
 
     // Make two rounds:

--- a/src/option.c
+++ b/src/option.c
@@ -683,7 +683,7 @@ set_string_default(char *name, char_u *val)
     static char_u *
 find_dup_item(char_u *origval, char_u *newval, long_u flags)
 {
-    int	    bs;
+    int	    bs = 0;
     size_t  newlen;
     char_u  *s;
 


### PR DESCRIPTION
PR fixes the following compilation warnings in vim-8.2.1669:
```
gcc-10 -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_GTK  -pthread -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gtk-3.0 -I/usr/include/gio-unix-2.0/ -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng16 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include   -g -O3 -Wall -Wextra -Wshadow -Wmissing-prototypes -Wpedantic -Wunreachable-code -Wno-cast-function-type -Wunused-result -Wno-deprecated-declarations -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1   -DEXITFREE -DABORT_ON_INTERNAL_ERROR    -o objects/move.o move.c
memline.c: In function ‘ml_append_int’:
memline.c:3187:6: warning: ‘line’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3187 |      netbeans_inserted(buf, lnum+1, (colnr_T)0, line, (int)STRLEN(line));
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
memline.c:3200:5: warning: ‘tofree’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 3200 |     vim_free(tofree);
      |     ^~~~~~~~~~~~~~~~

gcc-10 -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_GTK  -pthread -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gtk-3.0 -I/usr/include/gio-unix-2.0/ -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng16 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include   -g -O3 -Wall -Wextra -Wshadow -Wmissing-prototypes -Wpedantic -Wunreachable-code -Wno-cast-function-type -Wunused-result -Wno-deprecated-declarations -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1   -DEXITFREE -DABORT_ON_INTERNAL_ERROR    -o objects/profiler.o profiler.c
option.c: In function ‘find_dup_item’:
option.c:712:6: warning: ‘bs’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  712 |      ++bs;
      |      ^~~~
```