### PR TITLE
Fix use after free when autocmd changes the location list

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3264,10 +3264,25 @@ qf_jump_open_window(
 	int		newwin,
 	int		*opened_window)
 {
+    qf_list_T *qfl = qf_get_curlist(qi);
+    int old_qf_curlist = qi->qf_curlist;
+    qfltype_T qfl_type = qfl->qfl_type;
+
     // For ":helpgrep" find a help window or open one.
     if (qf_ptr->qf_type == 1 && (!bt_help(curwin->w_buffer) || cmdmod.tab != 0))
 	if (jump_to_help_window(qi, newwin, opened_window) == FAIL)
 	    return FAIL;
+    if (old_qf_curlist != qi->qf_curlist
+	    || !is_qf_entry_present(qfl, qf_ptr))
+    {
+	if (qfl_type == QFLT_QUICKFIX) {
+	    emsg(_("E925: Current quickfix was changed"));
+	}
+	else {
+	    emsg(_(e_loc_list_changed));
+	}
+	return FAIL;
+    }
 
     // If currently in the quickfix window, find another window to show the
     // file in.
@@ -3281,6 +3296,17 @@ qf_jump_open_window(
 	if (qf_jump_to_usable_window(qf_ptr->qf_fnum, newwin,
 						opened_window) == FAIL)
 	    return FAIL;
+    }
+    if (old_qf_curlist != qi->qf_curlist
+	    || !is_qf_entry_present(qfl, qf_ptr))
+    {
+	if (qfl_type == QFLT_QUICKFIX) {
+	    emsg(_("E925: Current quickfix was changed"));
+	}
+	else {
+	    emsg(_(e_loc_list_changed));
+	}
+	return FAIL;
     }
 
     return OK;


### PR DESCRIPTION
```vim
"  minimum.vim
call setline(1, ['test1', 'test2', 'test3', 'test4', 'test5'])

function! s:setloclist() abort
  call setloclist(1, [
        \  {'bufnr': 1, 'lnum': 1, 'col': 1, 'nr': 1, 'text': 'test error 1', 'type': 'E'},
        \  {'bufnr': 1, 'lnum': 4, 'col': 1, 'nr': 2, 'text': 'test error 2', 'type': 'E'}
        \], 'r')
endfunction

augroup Test_LocList
  autocmd!
  autocmd BufEnter * call s:setloclist()
augroup END
```

```
vim -Nu minimum.vim
:lopen
<C-w>j<Return>
```

```
==17337== Memcheck, a memory error detector
==17337== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17337== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==17337== Command: src/vim -Nu /home/erw7/minimum.vim
==17337== 
==17337== Memcheck, a memory error detector
==17337== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17337== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==17337== Command: src/vim -Nu  /home/erw7/minimum.vim
==17337== 
==17337== Invalid read of size 4
==17337==    at 0x2CB6CB: qf_jump_to_buffer (quickfix.c:3317)
==17337==    by 0x2CB94C: qf_jump_newwin (quickfix.c:3425)
==17337==    by 0x2CB7A9: qf_jump (quickfix.c:3351)
==17337==    by 0x2CEE29: ex_cc (quickfix.c:5178)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==    by 0x1F1590: do_cmdline (ex_docmd.c:983)
==17337==    by 0x1F0AA5: do_cmdline_cmd (ex_docmd.c:591)
==17337== Invalid read of size 4
==17337==    at 0x2CB6CB: qf_jump_to_buffer (quickfix.c:3317)
==17337==    by 0x2CB94C: qf_jump_newwin (quickfix.c:3425)
==17337==    by 0x2CB7A9: qf_jump (quickfix.c:3351)
==17337==    by 0x2CEE29: ex_cc (quickfix.c:5178)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==    by 0x1F1590: do_cmdline (ex_docmd.c:983)
==17337==    by 0x1F0AA5: do_cmdline_cmd (ex_docmd.c:591)
==17337==    by 0x2CCB96: qf_view_result (quickfix.c:3959)
==17337==    by 0x28D304: nv_down (normal.c:4136)
==17337==    by 0x287A29: normal_cmd (normal.c:1097)
==17337==    by 0x427117: main_loop (main.c:1478)
==17337==    by 0x426583: vim_main2 (main.c:868)
==17337==  Address 0x6115fc8 is 24 bytes inside a block of size 72 free'd
==17337==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x278ABA: vim_free (misc2.c:1807)
==17337==    by 0x2CC5FC: qf_free_items (quickfix.c:3786)
==17337==    by 0x2D26FB: qf_add_entries (quickfix.c:7134)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337==    by 0x399032: ex_call (userfunc.c:4083)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==  Block was alloc'd at
==17337==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x277C90: lalloc (misc2.c:925)
==17337==    by 0x277B3B: alloc (misc2.c:828)
==17337==    by 0x2C9735: qf_add_entry (quickfix.c:2062)
==17337==    by 0x2D25D2: qf_add_entry_from_dict (quickfix.c:7077)
==17337==    by 0x2D275F: qf_add_entries (quickfix.c:7147)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337== 
==17337== Invalid read of size 1
==17337==    at 0x2CB193: qf_jump_edit_buffer (quickfix.c:3116)
==17337==    by 0x2CB6EE: qf_jump_to_buffer (quickfix.c:3319)
==17337==    by 0x2CB94C: qf_jump_newwin (quickfix.c:3425)
==17337==    by 0x2CB7A9: qf_jump (quickfix.c:3351)
==17337==    by 0x2CEE29: ex_cc (quickfix.c:5178)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==    by 0x1F1590: do_cmdline (ex_docmd.c:983)
==17337==    by 0x1F0AA5: do_cmdline_cmd (ex_docmd.c:591)
==17337==    by 0x2CCB96: qf_view_result (quickfix.c:3959)
==17337==    by 0x28D304: nv_down (normal.c:4136)
==17337==    by 0x287A29: normal_cmd (normal.c:1097)
==17337==    by 0x427117: main_loop (main.c:1478)
==17337==  Address 0x6115ff2 is 66 bytes inside a block of size 72 free'd
==17337==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x278ABA: vim_free (misc2.c:1807)
==17337==    by 0x2CC5FC: qf_free_items (quickfix.c:3786)
==17337==    by 0x2D26FB: qf_add_entries (quickfix.c:7134)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337==    by 0x399032: ex_call (userfunc.c:4083)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==  Block was alloc'd at
==17337==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x277C90: lalloc (misc2.c:925)
==17337==    by 0x277B3B: alloc (misc2.c:828)
==17337==    by 0x2C9735: qf_add_entry (quickfix.c:2062)
==17337==    by 0x2D25D2: qf_add_entry_from_dict (quickfix.c:7077)
==17337==    by 0x2D275F: qf_add_entries (quickfix.c:7147)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337== 
==17337==    by 0x2CCB96: qf_view_result (quickfix.c:3959)
==17337==    by 0x28D304: nv_down (normal.c:4136)
==17337==    by 0x287A29: normal_cmd (normal.c:1097)
==17337==    by 0x427117: main_loop (main.c:1478)
==17337==    by 0x426583: vim_main2 (main.c:868)
==17337==  Address 0x6115fc8 is 24 bytes inside a block of size 72 free'd
==17337==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x278ABA: vim_free (misc2.c:1807)
==17337==    by 0x2CC5FC: qf_free_items (quickfix.c:3786)
==17337==    by 0x2D26FB: qf_add_entries (quickfix.c:7134)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337==    by 0x399032: ex_call (userfunc.c:4083)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==  Block was alloc'd at
==17337==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x277C90: lalloc (misc2.c:925)
==17337==    by 0x277B3B: alloc (misc2.c:828)
==17337==    by 0x2C9735: qf_add_entry (quickfix.c:2062)
==17337==    by 0x2D25D2: qf_add_entry_from_dict (quickfix.c:7077)
==17337==    by 0x2D275F: qf_add_entries (quickfix.c:7147)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337== 
==17337== Invalid read of size 1
==17337==    at 0x2CB193: qf_jump_edit_buffer (quickfix.c:3116)
==17337==    by 0x2CB6EE: qf_jump_to_buffer (quickfix.c:3319)
==17337==    by 0x2CB94C: qf_jump_newwin (quickfix.c:3425)
==17337==    by 0x2CB7A9: qf_jump (quickfix.c:3351)
==17337==    by 0x2CEE29: ex_cc (quickfix.c:5178)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==    by 0x1F1590: do_cmdline (ex_docmd.c:983)
==17337==    by 0x1F0AA5: do_cmdline_cmd (ex_docmd.c:591)
==17337==    by 0x2CCB96: qf_view_result (quickfix.c:3959)
==17337==    by 0x28D304: nv_down (normal.c:4136)
==17337==    by 0x287A29: normal_cmd (normal.c:1097)
==17337==    by 0x427117: main_loop (main.c:1478)
==17337==  Address 0x6115ff2 is 66 bytes inside a block of size 72 free'd
==17337==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x278ABA: vim_free (misc2.c:1807)
==17337==    by 0x2CC5FC: qf_free_items (quickfix.c:3786)
==17337==    by 0x2D26FB: qf_add_entries (quickfix.c:7134)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337==    by 0x399032: ex_call (userfunc.c:4083)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==  Block was alloc'd at
==17337==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x277C90: lalloc (misc2.c:925)
==17337==    by 0x277B3B: alloc (misc2.c:828)
==17337==    by 0x2C9735: qf_add_entry (quickfix.c:2062)
==17337==    by 0x2D25D2: qf_add_entry_from_dict (quickfix.c:7077)
==17337==    by 0x2D275F: qf_add_entries (quickfix.c:7147)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337== 
==17337== Invalid read of size 4
==17337==    at 0x2CB217: qf_jump_edit_buffer (quickfix.c:3131)
==17337==    by 0x2CB6EE: qf_jump_to_buffer (quickfix.c:3319)
==17337==    by 0x2CB94C: qf_jump_newwin (quickfix.c:3425)
==17337==    by 0x2CB7A9: qf_jump (quickfix.c:3351)
==17337==    by 0x2CEE29: ex_cc (quickfix.c:5178)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==    by 0x1F1590: do_cmdline (ex_docmd.c:983)
==17337==    by 0x1F0AA5: do_cmdline_cmd (ex_docmd.c:591)
==17337==    by 0x2CCB96: qf_view_result (quickfix.c:3959)
==17337==    by 0x28D304: nv_down (normal.c:4136)
==17337==    by 0x287A29: normal_cmd (normal.c:1097)
==17337==    by 0x427117: main_loop (main.c:1478)
==17337==  Address 0x6115fc8 is 24 bytes inside a block of size 72 free'd
==17337==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x278ABA: vim_free (misc2.c:1807)
==17337==    by 0x2CC5FC: qf_free_items (quickfix.c:3786)
==17337==    by 0x2D26FB: qf_add_entries (quickfix.c:7134)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337==    by 0x399032: ex_call (userfunc.c:4083)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==  Block was alloc'd at
==17337==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x277C90: lalloc (misc2.c:925)
==17337==    by 0x277B3B: alloc (misc2.c:828)
==17337==    by 0x2C9735: qf_add_entry (quickfix.c:2062)
==17337==    by 0x2D25D2: qf_add_entry_from_dict (quickfix.c:7077)
==17337==    by 0x2D275F: qf_add_entries (quickfix.c:7147)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337== 
==17337== Invalid read of size 4
==17337==    at 0x2CB217: qf_jump_edit_buffer (quickfix.c:3131)
==17337==    by 0x2CB6EE: qf_jump_to_buffer (quickfix.c:3319)
==17337==    by 0x2CB94C: qf_jump_newwin (quickfix.c:3425)
==17337==    by 0x2CB7A9: qf_jump (quickfix.c:3351)
==17337==    by 0x2CEE29: ex_cc (quickfix.c:5178)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==    by 0x1F1590: do_cmdline (ex_docmd.c:983)
==17337==    by 0x1F0AA5: do_cmdline_cmd (ex_docmd.c:591)
==17337==    by 0x2CCB96: qf_view_result (quickfix.c:3959)
==17337==    by 0x28D304: nv_down (normal.c:4136)
==17337==    by 0x287A29: normal_cmd (normal.c:1097)
==17337==    by 0x427117: main_loop (main.c:1478)
==17337==  Address 0x6115fc8 is 24 bytes inside a block of size 72 free'd
==17337==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x278ABA: vim_free (misc2.c:1807)
==17337==    by 0x2CC5FC: qf_free_items (quickfix.c:3786)
==17337==    by 0x2D26FB: qf_add_entries (quickfix.c:7134)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337==    by 0x399032: ex_call (userfunc.c:4083)
==17337==    by 0x1F4355: do_one_cmd (ex_docmd.c:2537)
==17337==  Block was alloc'd at
==17337==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17337==    by 0x277C90: lalloc (misc2.c:925)
==17337==    by 0x277B3B: alloc (misc2.c:828)
==17337==    by 0x2C9735: qf_add_entry (quickfix.c:2062)
==17337==    by 0x2D25D2: qf_add_entry_from_dict (quickfix.c:7077)
==17337==    by 0x2D275F: qf_add_entries (quickfix.c:7147)
==17337==    by 0x2D3305: set_errorlist (quickfix.c:7537)
==17337==    by 0x2D4942: set_qf_ll_list (quickfix.c:8262)
==17337==    by 0x2D49C5: f_setloclist (quickfix.c:8283)
==17337==    by 0x1CCFC8: call_internal_func (evalfunc.c:1260)
==17337==    by 0x394149: call_func (userfunc.c:2197)
==17337==    by 0x390BBF: get_func_tv (userfunc.c:690)
==17337== 
==17337== 
==17337== 
==17337== HEAP SUMMARY:
==17337==     in use at exit: 246,829 bytes in 748 blocks
==17337==   total heap usage: 3,206 allocs, 2,458 frees, 1,031,233 bytes allocated
==17337== 
==17337== HEAP SUMMARY:
==17337==     in use at exit: 246,829 bytes in 748 blocks
==17337==   total heap usage: 3,206 allocs, 2,458 frees, 1,031,233 bytes allocated
==17337== 
==17337== LEAK SUMMARY:
==17337==    definitely lost: 0 bytes in 0 blocks
==17337==    indirectly lost: 0 bytes in 0 blocks
==17337==      possibly lost: 52 bytes in 2 blocks
==17337==    still reachable: 246,777 bytes in 746 blocks
==17337==         suppressed: 0 bytes in 0 blocks
==17337== Rerun with --leak-check=full to see details of leaked memory
==17337== 
==17337== For counts of detected and suppressed errors, rerun with: -v
==17337== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
==17337== LEAK SUMMARY:
==17337==    definitely lost: 0 bytes in 0 blocks
==17337==    indirectly lost: 0 bytes in 0 blocks
==17337==      possibly lost: 52 bytes in 2 blocks
==17337==    still reachable: 246,777 bytes in 746 blocks
==17337==         suppressed: 0 bytes in 0 blocks
==17337== Rerun with --leak-check=full to see details of leaked memory
==17337== 
==17337== For counts of detected and suppressed errors, rerun with: -v
==17337== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
```