### PR TITLE
Problem:    %v in stl actually is screen col.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7288,9 +7288,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	N N   Printer page number.  (Only works in the 'printheader' option.)
 	l N   Line number.
 	L N   Number of lines in buffer.
-	c N   Column number.
-	v N   Virtual column number.
-	V N   Virtual column number as -{num}.  Not displayed if equal to 'c'.
+	c N   Virtual column number.
+	v N   Screen column number.
+	V N   Screen column number as -{num}.  Not displayed if equal to 'c'.
 	p N   Percentage through file in lines as in |CTRL-G|.
 	P S   Percentage through file of displayed window.  This is like the
 	      percentage described for 'ruler'.  Always 3 in length, unless


### PR DESCRIPTION
Solution:   update the help doc.

please check the screen-cut bellow:
![image](https://user-images.githubusercontent.com/13550529/93176591-13406900-f764-11ea-95fd-56e46865a1e3.png)
when `set ts=4`, and cursor at line#2 on letter 'x' (after a 'tab'), the '%c' showed at stl is 2, '%v' showed at stl is 5.
so looks '%v' in stl actually is screen col.

// refer: #6952 