### PR TITLE
feat: make it possible to restore default highlighting

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4808,7 +4808,8 @@ in their own color.
 :hi[ghlight] clear	Reset all highlighting to the defaults.  Removes all
 			highlighting for groups added by the user!
 			Uses the current value of 'background' to decide which
-			default colors to use.
+			default colors to use. Default highlight links are
+			restored. |:hi-link|
 
 :hi[ghlight] clear {group-name}
 :hi[ghlight] {group-name} NONE

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -73,6 +73,7 @@ typedef struct
     char_u	*sg_gui_sp_name;// GUI special color name
 #endif
     int		sg_link;	// link to this highlight group ID
+    int		sg_deflink;     // default link; restored in highlight_clear()
     int		sg_set;		// combination of SG_* flags
 #ifdef FEAT_EVAL
     sctx_T	sg_script_ctx;	// script in which the group was last set
@@ -738,6 +739,9 @@ do_highlight(
 	    to_id = 0;
 	else
 	    to_id = syn_check_group(to_start, (int)(to_end - to_start));
+
+	if (dodefault && (forceit || HL_TABLE()[from_id - 1].sg_deflink == 0))
+	    HL_TABLE()[from_id - 1].sg_deflink = to_id;
 
 	if (from_id > 0 && (!init || HL_TABLE()[from_id - 1].sg_set == 0))
 	{
@@ -1629,8 +1633,7 @@ restore_cterm_colors(void)
     static int
 hl_has_settings(int idx, int check_link)
 {
-    return HL_TABLE()[idx].sg_cleared == 0 &&
-	    (  HL_TABLE()[idx].sg_term_attr != 0
+    return (   HL_TABLE()[idx].sg_term_attr != 0
 	    || HL_TABLE()[idx].sg_cterm_attr != 0
 	    || HL_TABLE()[idx].sg_cterm_fg != 0
 	    || HL_TABLE()[idx].sg_cterm_bg != 0
@@ -1683,6 +1686,8 @@ highlight_clear(int idx)
     HL_TABLE()[idx].sg_gui_attr = 0;
 #endif
 #ifdef FEAT_EVAL
+    // Restore default link
+    HL_TABLE()[idx].sg_link = HL_TABLE()[idx].sg_deflink;
     // Clear the script ID only when there is no link, since that is not
     // cleared.
     if (HL_TABLE()[idx].sg_link == 0)

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -1629,7 +1629,8 @@ restore_cterm_colors(void)
     static int
 hl_has_settings(int idx, int check_link)
 {
-    return (   HL_TABLE()[idx].sg_term_attr != 0
+    return HL_TABLE()[idx].sg_cleared == 0 &&
+	    (  HL_TABLE()[idx].sg_term_attr != 0
 	    || HL_TABLE()[idx].sg_cterm_attr != 0
 	    || HL_TABLE()[idx].sg_cterm_fg != 0
 	    || HL_TABLE()[idx].sg_cterm_bg != 0

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -796,4 +796,37 @@ func Test_highlight_term_attr()
   hi clear
 endfunc
 
+" Test default highlighting is restored
+func Test_highlight_restore_defaults()
+
+  hi! link TestLink Identifier
+  hi! TestHi ctermbg=red
+
+  let hlTestLinkPre = HighlightArgs('TestLink')
+  let hlTestHiPre = HighlightArgs('TestHi')
+
+  " Test colorscheme
+  hi clear
+  if exists('syntax_on')
+      syntax reset
+  endif
+  let g:colors_name = 'test'
+  hi! link TestLink ErrorMsg
+  hi! TestHi ctermbg=green
+
+  " Restore default highlighting
+  colorscheme default
+  syntax on
+  " 'default' should work no matter if highlight group was cleared
+  hi def link TestLink Identifier
+  hi def TestHi ctermbg=red
+
+  let hlTestLinkPost = HighlightArgs('TestLink')
+  let hlTestHiPost = HighlightArgs('TestHi')
+
+  call assert_equal(hlTestLinkPre, hlTestLinkPost)
+  call assert_equal(hlTestHiPre, hlTestHiPost)
+  hi clear
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -796,14 +796,12 @@ func Test_highlight_term_attr()
   hi clear
 endfunc
 
-" Test default highlighting is restored
-func Test_highlight_restore_defaults()
+" Test default highlighting links are restored
+func Test_highlight_restore_default_links()
 
-  hi! link TestLink Identifier
-  hi! TestHi ctermbg=red
+  hi def link TestLink Identifier
 
   let hlTestLinkPre = HighlightArgs('TestLink')
-  let hlTestHiPre = HighlightArgs('TestHi')
 
   " Test colorscheme
   hi clear
@@ -811,21 +809,14 @@ func Test_highlight_restore_defaults()
     syntax reset
   endif
   let g:colors_name = 'test'
-  hi! link TestLink ErrorMsg
-  hi! TestHi ctermbg=green
+  hi link TestLink ErrorMsg
 
-  " Restore default highlighting
+  " Default links should be restored
   colorscheme default
-  syntax on
-  " 'default' should work no matter if highlight group was cleared
-  hi def link TestLink Identifier
-  hi def TestHi ctermbg=red
 
   let hlTestLinkPost = HighlightArgs('TestLink')
-  let hlTestHiPost = HighlightArgs('TestHi')
 
   call assert_equal(hlTestLinkPre, hlTestLinkPost)
-  call assert_equal(hlTestHiPre, hlTestHiPost)
   hi clear
 endfunc
 

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -808,7 +808,7 @@ func Test_highlight_restore_defaults()
   " Test colorscheme
   hi clear
   if exists('syntax_on')
-      syntax reset
+    syntax reset
   endif
   let g:colors_name = 'test'
   hi! link TestLink ErrorMsg


### PR DESCRIPTION
problem: users are unable to restore default highlighting
solution: save and restore default links

prev solution: treat cleared highlight group as "has no hl-settings"

Fixes #4405