### PR TITLE
vim/vim#5948: Add brackets around if statements in gui_mch_add_menu 

### DIFF
--- a/src/gui_motif.c
+++ b/src/gui_motif.c
@@ -916,9 +916,13 @@ gui_mch_add_menu(vimmenu_T *menu, int idx)
 # endif
 	{
 	    if (gui.menu_bg_pixel != INVALCOLOR)
+	    {
 		XtSetArg(arg[0], XmNbackground, gui.menu_bg_pixel); n++;
+	    }
 	    if (gui.menu_fg_pixel != INVALCOLOR)
+	    {
 		XtSetArg(arg[1], XmNforeground, gui.menu_fg_pixel); n++;
+	    }
 	    menu->submenu_id = XmCreatePopupMenu(textArea, "contextMenu",
 								      arg, n);
 	    menu->id = (Widget)0;


### PR DESCRIPTION
The lack of brackets around these two if statements was causing undefined behaviour.

This was causing undefined behaviour as n was being incremented if the statement(s) evaluated to false, meaning XmCreatePopupMenu was being called with an uninitialized arg[2], but with n != 0.  Depending on the compiler used, this was either benign (gcc), or could cause a SIGBUS or SIGSEGV (clang).

Fixes: #5948 