### PR TITLE
Vim9: can not assign a lambda to a variable which type is func

### DIFF
--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -1688,7 +1688,7 @@ def Test_expr7_lambda_vim9script()
   END
   CheckScriptSuccess(lines)
 
-  # check if assign a lambda to variable which type is func or any.
+  # check if assign a lambda to a variable which type is func or any.
   lines =<< trim END
       vim9script
       let FuncRef = {->123}

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -1698,7 +1698,7 @@ def Test_expr7_lambda_vim9script()
       let FuncRef_Any: any = {->123}
       assert_equal(123, FuncRef_Any())
   END
-  CheckDefAndScriptSuccess(lines)
+  CheckScriptSuccess(lines)
 enddef
 
 def Test_epxr7_funcref()

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -1687,6 +1687,18 @@ def Test_expr7_lambda_vim9script()
 	->map({_, v -> synIDattr(v, 'name')})->len()})
   END
   CheckScriptSuccess(lines)
+
+  # check if assign a lambda to variable whitch type is func or any.
+  lines =<< trim END
+      vim9script
+      let FuncRef = {->123}
+      assert_equal(123, FuncRef())
+      let FuncRef_Func: func = {->123}
+      assert_equal(123, FuncRef_Func())
+      let FuncRef_Any: any = {->123}
+      assert_equal(123, FuncRef_Any())
+  END
+  CheckDefAndScriptSuccess(lines)
 enddef
 
 def Test_epxr7_funcref()

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -1688,7 +1688,7 @@ def Test_expr7_lambda_vim9script()
   END
   CheckScriptSuccess(lines)
 
-  # check if assign a lambda to variable whitch type is func or any.
+  # check if assign a lambda to variable which type is func or any.
   lines =<< trim END
       vim9script
       let FuncRef = {->123}

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -463,7 +463,7 @@ check_type(type_T *expected, type_T *actual, int give_msg, int argidx)
 	    && !(expected->tt_type == VAR_ANY && actual->tt_type != VAR_VOID))
 
     {
-	if (expected->tt_type != actual->tt_type)
+	if (expected->tt_type != (actual->tt_type == VAR_PARTIAL ? VAR_FUNC : actual->tt_type))
 	{
 	    if (expected->tt_type == VAR_BOOL
 					&& (actual->tt_flags & TTFLAG_BOOL_OK))


### PR DESCRIPTION

In Vim9 script, can not assign a lambda to a variable which type is func. This PR make to assign.

```
vim9script
let F: func = {->123}
# -> E1012: Type mismatch; expected func(...): unknown but got func
```

```
vim9script
let F: func
F = {->123}
# -> E1012: Type mismatch; expected func(...): unknown but got func
```

