### PR TITLE
feat: pathshorten() optional trim length

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7656,13 +7656,17 @@ or({expr}, {expr})					*or()*
 			:let bits = bits->or(0x80)
 
 
-pathshorten({expr})					*pathshorten()*
+pathshorten({expr} [, {len}])				*pathshorten()*
 		Shorten directory names in the path {expr} and return the
 		result.  The tail, the file name, is kept as-is.  The other
-		components in the path are reduced to single letters.  Leading
-		'~' and '.' characters are kept.  Example: >
+		components in the path are reduced to {len} letters in length.
+		{len} defaults to 1 (single letters).  Leading
+		'~' and '.' characters are kept.  Examples: >
 			:echo pathshorten('~/.vim/autoload/myfile.vim')
 <			~/.v/a/myfile.vim ~
+>
+			:echo pathshorten('~/.vim/autoload/myfile.vim', 2)
+<			~/.vi/au/myfile.vim ~
 		It doesn't matter if the path exists or not.
 
 		Can also be used as a |method|: >

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -779,7 +779,7 @@ static funcentry_T global_functions[] =
     {"nextnonblank",	1, 1, FEARG_1,	  ret_number,	f_nextnonblank},
     {"nr2char",		1, 2, FEARG_1,	  ret_string,	f_nr2char},
     {"or",		2, 2, FEARG_1,	  ret_number,	f_or},
-    {"pathshorten",	1, 1, FEARG_1,	  ret_string,	f_pathshorten},
+    {"pathshorten",	1, 2, FEARG_1,	  ret_string,	f_pathshorten},
     {"perleval",	1, 1, FEARG_1,	  ret_any,
 #ifdef FEAT_PERL
 	    f_perleval

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -1360,12 +1360,14 @@ f_pathshorten(typval_T *argvars, typval_T *rettv)
     char_u	*p;
     int		trim_len;
 
-    if (argvars[1].v_type != VAR_UNKNOWN) {
-	trim_len = (int)tv_get_number(&argvars[1]);
-	if (trim_len < 1) trim_len = 1;
-    } else {
-	trim_len = (int)1;
+    if (argvars[1].v_type != VAR_UNKNOWN)
+    {
+        trim_len = (int)tv_get_number(&argvars[1]);
+        if (trim_len < 1)
+            trim_len = 1;
     }
+    else
+        trim_len = 1;
 
     rettv->v_type = VAR_STRING;
     p = tv_get_string_chk(&argvars[0]);
@@ -2736,7 +2738,8 @@ shorten_dir2(char_u *str, int trim_len)
     int		skip = FALSE;
     int		dirchunk_len = 0;
 
-    if (trim_len < 1) trim_len = 1; // defaults
+    if (trim_len < 1)
+        trim_len = 1; // less than 1 doesn't make sense
 
     tail = gettail(str);
     d = str;
@@ -2757,7 +2760,8 @@ shorten_dir2(char_u *str, int trim_len)
 	else if (!skip)
 	{
 	    *d++ = *s;		    // copy next char
-	    if (*s != '~' && *s != '.') {// and leading "~" and "."
+	    if (*s != '~' && *s != '.') // and leading "~" and "."
+	    {
 		++dirchunk_len; // only count wordy chars to the size
 
 		// keep copying next chars until we have our preferred length (or

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -1358,9 +1358,18 @@ f_mkdir(typval_T *argvars, typval_T *rettv)
 f_pathshorten(typval_T *argvars, typval_T *rettv)
 {
     char_u	*p;
+    size_t	trim_len;
+
+    if (argvars[1].v_type != VAR_UNKNOWN) {
+	trim_len = (size_t)tv_get_number(&argvars[1]);
+	if (trim_len < 1) trim_len = 1;
+    } else {
+	trim_len = (size_t)1;
+    }
 
     rettv->v_type = VAR_STRING;
     p = tv_get_string_chk(&argvars[0]);
+
     if (p == NULL)
 	rettv->vval.v_string = NULL;
     else
@@ -1368,7 +1377,7 @@ f_pathshorten(typval_T *argvars, typval_T *rettv)
 	p = vim_strsave(p);
 	rettv->vval.v_string = p;
 	if (p != NULL)
-	    shorten_dir(p);
+	    shorten_dir2(p, trim_len);
     }
 }
 

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -1358,13 +1358,13 @@ f_mkdir(typval_T *argvars, typval_T *rettv)
 f_pathshorten(typval_T *argvars, typval_T *rettv)
 {
     char_u	*p;
-    size_t	trim_len;
+    int		trim_len;
 
     if (argvars[1].v_type != VAR_UNKNOWN) {
-	trim_len = (size_t)tv_get_number(&argvars[1]);
+	trim_len = (int)tv_get_number(&argvars[1]);
 	if (trim_len < 1) trim_len = 1;
     } else {
-	trim_len = (size_t)1;
+	trim_len = (int)1;
     }
 
     rettv->v_type = VAR_STRING;
@@ -2730,7 +2730,7 @@ shorten_dir(char_u *str)
  * It's done in-place.
  */
     void
-shorten_dir2(char_u *str, size_t trim_len)
+shorten_dir2(char_u *str, int trim_len)
 {
     char_u	*tail, *s, *d;
     int		skip = FALSE;

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -2722,6 +2722,10 @@ vim_ispathsep_nocolon(int c)
     void
 shorten_dir(char_u *str)
 {
+    shorten_dir2(str, 1);
+}
+
+{
     char_u	*tail, *s, *d;
     int		skip = FALSE;
 

--- a/src/proto/filepath.pro
+++ b/src/proto/filepath.pro
@@ -41,7 +41,7 @@ char_u *get_past_head(char_u *path);
 int vim_ispathsep(int c);
 int vim_ispathsep_nocolon(int c);
 void shorten_dir(char_u *str);
-void shorten_dir2(char_u *str, size_t trim_len);
+void shorten_dir2(char_u *str, int trim_len);
 int dir_of_file_exists(char_u *fname);
 int vim_fnamecmp(char_u *x, char_u *y);
 int vim_fnamencmp(char_u *x, char_u *y, size_t len);

--- a/src/proto/filepath.pro
+++ b/src/proto/filepath.pro
@@ -41,6 +41,7 @@ char_u *get_past_head(char_u *path);
 int vim_ispathsep(int c);
 int vim_ispathsep_nocolon(int c);
 void shorten_dir(char_u *str);
+void shorten_dir2(char_u *str, size_t trim_len);
 int dir_of_file_exists(char_u *fname);
 int vim_fnamecmp(char_u *x, char_u *y);
 int vim_fnamencmp(char_u *x, char_u *y, size_t len);

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -517,6 +517,7 @@ func Test_pathshorten()
   call assert_fails('call pathshorten([],2)', 'E730:')
   call assert_notequal('~/fo/bar', pathshorten('~/foo/bar', 3))
   call assert_equal('~/foo/bar', pathshorten('~/foo/bar', 3))
+  call assert_equal('~/f/bar', pathshorten('~/foo/bar', 0))
 endfunc
 
 func Test_strpart()

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -500,6 +500,23 @@ func Test_pathshorten()
   call assert_equal('.~f/bar', pathshorten('.~foo/bar'))
   call assert_equal('~/f/bar', pathshorten('~/foo/bar'))
   call assert_fails('call pathshorten([])', 'E730:')
+
+  " test pathshorten with optional variable to set preferred size of shortening
+  call assert_equal('', pathshorten('', 2))
+  call assert_equal('foo', pathshorten('foo', 2))
+  call assert_equal('/foo', pathshorten('/foo', 2))
+  call assert_equal('fo/', pathshorten('foo/', 2))
+  call assert_equal('fo/bar', pathshorten('foo/bar', 2))
+  call assert_equal('fo/ba/foobar', pathshorten('foo/bar/foobar', 2))
+  call assert_equal('/fo/ba/foobar', pathshorten('/foo/bar/foobar', 2))
+  call assert_equal('.fo/bar', pathshorten('.foo/bar', 2))
+  call assert_equal('~fo/bar', pathshorten('~foo/bar', 2))
+  call assert_equal('~.fo/bar', pathshorten('~.foo/bar', 2))
+  call assert_equal('.~fo/bar', pathshorten('.~foo/bar', 2))
+  call assert_equal('~/fo/bar', pathshorten('~/foo/bar', 2))
+  call assert_fails('call pathshorten([],2)', 'E730:')
+  call assert_notequal('~/fo/bar', pathshorten('~/foo/bar', 3))
+  call assert_equal('~/foo/bar', pathshorten('~/foo/bar', 3))
 endfunc
 
 func Test_strpart()


### PR DESCRIPTION
##### What
Second optional argument for pathshorten() to specify preferred trimming length.

##### Example:
`echo pathshorten("/Users/mollie/Documents/some-file.txt", 3)`

###### output 
`/Use/mol/Doc/some-file.txt`

##### Why
Sometimes pathshorten is too short.

For example when pathshortening filenames in the qf/loc list (using the qf/loc entry "module" field added in __v8.0.1782__). The single character shortenings is a bit too much. But limiting it to maybe 3-5 chars would be really nice.

##### Changes
* tests added to `/src/testdir/test_functions.vim` within existing `func Test_pathshorten()` block.
* shorten_dir2 fn added (`src/filepath.c`)
* shorten_dir refactored to use shorten_dir2 with optional trim_len variable set to 1 by default resulting in the same behaviour as before.
*  `src/proto/filepath.pro` and `src/evalfunc.c` updated.

#### How to build and test

##### from scratch
```bash
git clone --branch talmobi/feat/pathshorten-trim-size https://github.com/talmobi/vim
cd vim
./configure
make
cd src
make test_functions
```

##### existing clone
```bash
git checkout -b talmobi/feat/pathshorten-trim-size
git pull https://github.com/talmobi/vim talmobi/feat/pathshorten-trim-size
make distclean
./configure
make
cd src
make test_functions
```