### PR TITLE
Fix crash when closing window in another tab

### DIFF
--- a/src/testdir/test_winbuf_close.vim
+++ b/src/testdir/test_winbuf_close.vim
@@ -192,6 +192,21 @@ func Test_tabwin_close()
   call win_execute(l:wid, 'close')
   " Should not crash.
   call assert_true(v:true)
+
+  " this tests closing a window in another tab, while leaving the tab open
+  " i.e. two windows in another tab
+  tabedit
+  vnew
+  let othertab_wid = win_getid()
+  tabprevious
+  call win_execute(l:othertab_wid, 'q')
+  " drawing the tabline helps check that the other tab's windows and buffers
+  " are still valid
+  redrawtabline
+  " but to be certain, ensure we can focus the other tab too
+  tabnext
+  call assert_true(v:true)
+
   %bwipe!
 endfunc
 

--- a/src/window.c
+++ b/src/window.c
@@ -2752,10 +2752,10 @@ win_free_mem(
     vim_free(frp);
     win_free(win, tp);
 
-    // When deleting the current window of another tab page select a new
-    // current window.
-    if (tp != NULL && win == tp->tp_curwin)
-	tp->tp_curwin = wp;
+    // When deleting the current window, select a new current window,
+    // even if it's the current tab page
+    if (win == (tp ? tp : curtab)->tp_curwin)
+	(tp ? tp : curtab)->tp_curwin = wp;
 
     return wp;
 }


### PR DESCRIPTION
... and the other tab itself isn't closed. The test contains a short repro, but essentially we end up with a tab's `tp_curwin` becoming dangling.

`win_free_mem` already mitigates this when the tab isn't the current tab, so we fix it for the current tab too.
An alternative fix could be to set `tp_curwin` at the end of `win_remove()`, but that would affect all other removals too, which usually have their own code to update the current window.