### PR TITLE
Do not use completeslash for expand('~')

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2436,6 +2436,9 @@ f_expand(typval_T *argvars, typval_T *rettv)
     expand_T	xpc;
     int		error = FALSE;
     char_u	*result;
+    char_u	*p_csl_save = p_csl;
+
+    p_csl = (char_u*) "";
 
     rettv->v_type = VAR_STRING;
     if (argvars[1].v_type != VAR_UNKNOWN
@@ -2488,6 +2491,7 @@ f_expand(typval_T *argvars, typval_T *rettv)
 	else
 	    rettv->vval.v_string = NULL;
     }
+    p_csl = p_csl_save;
 }
 
 /*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2436,9 +2436,11 @@ f_expand(typval_T *argvars, typval_T *rettv)
     expand_T	xpc;
     int		error = FALSE;
     char_u	*result;
+#ifdef BACKSLASH_IN_FILENAME
     char_u	*p_csl_save = p_csl;
 
     p_csl = (char_u*) "";
+#endif
 
     rettv->v_type = VAR_STRING;
     if (argvars[1].v_type != VAR_UNKNOWN
@@ -2491,7 +2493,9 @@ f_expand(typval_T *argvars, typval_T *rettv)
 	else
 	    rettv->vval.v_string = NULL;
     }
+#ifdef BACKSLASH_IN_FILENAME
     p_csl = p_csl_save;
+#endif
 }
 
 /*

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -363,12 +363,12 @@ endfunc
 " Test for insert path completion with completeslash option
 func Test_ins_completeslash()
   CheckMSWindows
-  
+
   call mkdir('Xdir')
   let orig_shellslash = &shellslash
   set cpt&
   new
-  
+
   set noshellslash
 
   set completeslash=
@@ -652,6 +652,20 @@ func Test_complete_cmdline()
   exe "normal oabcxyz(\<C-X>\<C-V>"
   call assert_equal('abcxyz(', getline(3))
   close!
+endfunc
+
+func Test_issue_7021()
+  CheckMSWindows
+
+  let orig_shellslash = &shellslash
+
+  set noshellslash
+
+  set completeslash=slash
+  call assert_false(expand('~') =~# '/')
+
+  let &shellslash = orig_shellslash
+  set completeslash=
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When completeslash=slash and noshellslash on Windows, expand('~') return `C:/Users/mattn`. 