### PR TITLE
gui_gtk_x11.c: dont destroy gtk widget if really exiting

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4385,7 +4385,7 @@ gui_mch_open(void)
     void
 gui_mch_exit(int rc UNUSED)
 {
-    if (gui.mainwin != NULL)
+    if (gui.mainwin != NULL && !really_exiting)
 	gtk_widget_destroy(gui.mainwin);
 }
 


### PR DESCRIPTION
Hi,

our customer uses Vim compiled with GTK on the RHEL 7 server via ```Exceed on demand``` remote access client - if the client is closed without closing Vim first, then Vim process will start to eat high CPU amount after some time.

The CPU consumption is caused by infinite loop during destroying GTK widget, which should not happen during handling signals or hard exits. The fix is to check ```really_exiting``` global variable before attempting to destroy the widget.

I wasn't able to reproduce the issue, but this fix was verified by customer (he tried the patched Vim for some time, without any problems) and I ran ```make test``` without any issues reported.

Would you mind adding the fix to the project? Please let me know if I should change something.

Thank you in advance and have a nice day,

Zdenek