### PR TITLE
Do not load after/syntax/css.vim 2 times for less

### DIFF
--- a/runtime/syntax/less.vim
+++ b/runtime/syntax/less.vim
@@ -9,7 +9,6 @@ if exists("b:current_syntax")
 endif
 
 runtime! syntax/css.vim
-runtime! after/syntax/css.vim
 
 syn case ignore
 


### PR DESCRIPTION
`runtime! syntax/css.vim` already loads `after/syntax/css.vim` because `after` is in &rtp. This change prevents `after/syntax/css.vim` to be loaded two times for less filetype if it is present in user vimruntime directory