### PR TITLE
Prevent filetype.vim to be loaded twice

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -85,17 +85,6 @@ if has('mouse')
   endif
 endif
 
-" Switch syntax highlighting on when the terminal has colors or when using the
-" GUI (which always has colors).
-if &t_Co > 2 || has("gui_running")
-  " Revert with ":syntax off".
-  syntax on
-
-  " I like highlighting strings inside C comments.
-  " Revert with ":unlet c_comment_strings".
-  let c_comment_strings=1
-endif
-
 " Only do this part when Vim was compiled with the +eval feature.
 if 1
 
@@ -122,6 +111,17 @@ if 1
 
   augroup END
 
+endif
+
+" Switch syntax highlighting on when the terminal has colors or when using the
+" GUI (which always has colors).
+if &t_Co > 2 || has("gui_running")
+  " Revert with ":syntax off".
+  syntax on
+
+  " I like highlighting strings inside C comments.
+  " Revert with ":unlet c_comment_strings".
+  let c_comment_strings=1
 endif
 
 " Convenient command to see the difference between the current buffer and the


### PR DESCRIPTION
Before patch:

```
rm -f foo.log && VIMRUNTIME=$PWD/runtime vim -u DEFAULTS --startuptime foo.log -c q && cat out.log | grep filetype foo.log
022.294  009.135  009.135: sourcing /Users/sheerun/Source/tmp/vim/runtime/filetype.vim
023.031  000.115  000.115: sourcing /Users/sheerun/Source/tmp/vim/runtime/filetype.vim
```

After patch:

```
rm -f foo.log && VIMRUNTIME=$PWD/runtime vim -u DEFAULTS --startuptime foo.log -c q && cat out.log | grep filetype foo.log
019.684  006.940  006.940: sourcing /Users/sheerun/Source/tmp/vim/runtime/filetype.vim
```

This just reorders commands on defaults.vim