### PR TITLE
Update configure.ac for Racket 6.1+

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -880,6 +880,9 @@ if test "$enable_mzschemeinterp" = "yes"; then
 	  MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
 	elif test -f "${path}/libracket3m.a"; then
 	  MZSCHEME_LIBS="${path}/libracket3m.a"
+	  if test -f "${path}/librktio.a"; then
+	    MZSCHEME_LIBS="${MZSCHEME_LIBS} ${path}/librktio.a"
+	  fi
 	  MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
 	elif test -f "${path}/libracket.a"; then
 	  MZSCHEME_LIBS="${path}/libracket.a ${path}/libmzgc.a"


### PR DESCRIPTION
https://download.racket-lang.org/v6.10.html

A part of racket library was separated to `rktio` since Racket 6.1.

I checked the operation with a Racket 7.8.