### PR TITLE
Show "xxx is a directory" if the last is pathsep.

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -318,10 +318,17 @@ readfile(
      */
     if (fname != NULL && *fname != NUL)
     {
-	p = fname + STRLEN(fname);
-	if (after_pathsep(fname, p) || STRLEN(fname) >= MAXPATHL)
+	if (STRLEN(fname) >= MAXPATHL)
 	{
 	    filemess(curbuf, fname, (char_u *)_("Illegal file name"), 0);
+	    msg_end();
+	    msg_scroll = msg_save;
+	    return FAIL;
+	}
+	p = fname + STRLEN(fname);
+	if (after_pathsep(fname, p))
+	{
+	    filemess(curbuf, fname, (char_u *)_("is a directory"), 0);
 	    msg_end();
 	    msg_scroll = msg_save;
 	    return FAIL;

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -1587,7 +1587,7 @@ func Test_edit_illegal_filename()
   close!
 endfunc
 
-" Test for editing a file with a directory
+" Test for editing a directory
 func Test_edit_is_a_directory()
   CheckEnglish
   let dirname = getcwd() . "/Xdir"

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -1587,6 +1587,31 @@ func Test_edit_illegal_filename()
   close!
 endfunc
 
+" Test for editing a file with a directory
+func Test_edit_is_a_directory()
+  CheckEnglish
+  let dirname = getcwd() . "/Xdir"
+  call mkdir(dirname, 'p')
+
+  new
+  redir => msg
+  exe 'edit' dirname
+  redir END
+  call assert_match("is a directory$", split(msg, "\n")[0])
+  close!
+
+  let dirname .= '/'
+
+  new
+  redir => msg
+  exe 'edit' dirname
+  redir END
+  call assert_match("is a directory$", split(msg, "\n")[0])
+  close!
+
+  call delete(dirname, 'rf')
+endfunc
+
 " Test for editing a file using invalid file encoding
 func Test_edit_invalid_encoding()
   CheckEnglish


### PR DESCRIPTION
 When Vim opens a directory path, the messages are different depending on whether it ends with "/".  If it doesn't end with "/", it's "is a directory". if it does, it's "Illegal file name". These are better to be same message.