### PR TITLE
Mention that order matters for filetype / packadd!

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -271,6 +271,9 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			directories are added to 'runtimepath'.  This is
 			useful in your .vimrc.  The plugins will then be
 			loaded during initialization, see |load-plugins|.
+			Please note that for ftdetect scripts to be loaded
+			you will need to write `filetype plugin indent on`
+			after all `packadd!` commands.
 
 			Also see |pack-add|.
 			{only available when compiled with |+eval|}


### PR DESCRIPTION
I've received reports from confused users that ftdetect scripts of vim-polyglot aren't loaded when they use `packadd!` instead of `packadd` in their .vimrc. I think it needs clarification in documentation that they need to use `filetype plugin indent on` only after `packadd!` commands, otherwise ftdetect files won't be loaded.