### PR TITLE
Use encoding= instead of fileencoding=

### DIFF
--- a/runtime/ftplugin/falcon.vim
+++ b/runtime/ftplugin/falcon.vim
@@ -14,7 +14,7 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-setlocal softtabstop=4 shiftwidth=4 fileencoding=utf-8
+setlocal softtabstop=4 shiftwidth=4 encoding=utf-8
 setlocal suffixesadd=.fal,.ftd
 
 " Matchit support

--- a/runtime/ftplugin/flexwiki.vim
+++ b/runtime/ftplugin/flexwiki.vim
@@ -30,7 +30,7 @@ setlocal noexpandtab
 " 4-char tabstops, per flexwiki.el
 setlocal tabstop=4
 " Save *.wiki files in UTF-8
-setlocal fileencoding=utf-8
+setlocal encoding=utf-8
 " Add the UTF-8 Byte Order Mark to the beginning of the file
 setlocal bomb
 " Save <EOL>s as \n, not \r\n

--- a/runtime/syntax/2html.vim
+++ b/runtime/syntax/2html.vim
@@ -779,7 +779,7 @@ let s:old_magic = &magic
 set magic
 
 " set the fileencoding to match the charset we'll be using
-let &l:fileencoding=s:settings.vim_encoding
+let &l:encoding=s:settings.vim_encoding
 
 " According to http://www.w3.org/TR/html4/charset.html#doc-char-set, the byte
 " order mark is highly recommend on the web when using multibyte encodings. But,

--- a/runtime/syntax/dart.vim
+++ b/runtime/syntax/dart.vim
@@ -13,7 +13,7 @@
 " Questions, comments:  <dart.syntax AT cime.net>
 "                       https://ciurana.eu/pgp, https://keybase.io/pr3d4t0r
 "
-" vim: set fileencoding=utf-8:
+" vim: set encoding=utf-8:
 
 
 " Quit when a (custom) syntax file was already loaded

--- a/runtime/syntax/n1ql.vim
+++ b/runtime/syntax/n1ql.vim
@@ -12,7 +12,7 @@
 " Questions, comments:  <n1ql AT cime.net>
 "                       https://ciurana.eu/pgp, https://keybase.io/pr3d4t0r
 "
-" vim: set fileencoding=utf-8:
+" vim: set encoding=utf-8:
 
 
 if exists("b:current_syntax")


### PR DESCRIPTION
`fileencoding=utf-8` has unfortunate sideeffect of setting buffer state to changed. To reproduce bug:

```
vim -u DEFAULTS
:set ft=falcon
:q
```

currently vim warns:

```
E37: No write since last change (add ! to override)
```