### PR TITLE
Fix encoding of runtime files

### DIFF
--- a/runtime/ftplugin/erlang.vim
+++ b/runtime/ftplugin/erlang.vim
@@ -1,7 +1,7 @@
 " Vim ftplugin file
 " Language:     Erlang
-" Author:       Oscar Hellström <oscar@oscarh.net>
-" Contributors: Ricardo Catalinas Jiménez <jimenezrick@gmail.com>
+" Author:       Oscar HellstrÃ¶m <oscar@oscarh.net>
+" Contributors: Ricardo Catalinas JimÃ©nez <jimenezrick@gmail.com>
 "               Eduardo Lopez (http://github.com/tapichu)
 " License:      Vim license
 " Version:      2012/01/25

--- a/runtime/ftplugin/ocaml.vim
+++ b/runtime/ftplugin/ocaml.vim
@@ -521,7 +521,7 @@ endfunction
   "c. link this stuff with what the user wants
   " ie. get the expression selected/under the cursor
 
-    let s:ocaml_word_char = '\w|[À-ÿ]|'''
+    let s:ocaml_word_char = '\w|[\xc0-\xff]|'''
 
       "In:  the current mode (eg. "visual", "normal", etc.)
       "Out: the borders of the expression we are looking for the type

--- a/runtime/ftplugin/rpl.vim
+++ b/runtime/ftplugin/rpl.vim
@@ -1,6 +1,6 @@
 " Vim filetype plugin file
 " Language:     RPL/2
-" Maintainer:   Joël BERTRAND <rpl2@free.fr>
+" Maintainer:   JoÃ«l BERTRAND <rpl2@free.fr>
 " Last Change:	2012 Mar 07
 " Version: 		0.1
 

--- a/runtime/indent/rpl.vim
+++ b/runtime/indent/rpl.vim
@@ -2,7 +2,7 @@
 " Language:	RPL/2
 " Version:	0.2
 " Last Change:	2017 Jun 13
-" Maintainer:	BERTRAND Joël <rpl2@free.fr>
+" Maintainer:	BERTRAND JoÃ«l <rpl2@free.fr>
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/indent/tilde.vim
+++ b/runtime/indent/tilde.vim
@@ -1,5 +1,5 @@
 "Description: Indent scheme for the tilde weblanguage
-"Author: Tobias Rundström <tobi@tobi.nu>
+"Author: Tobias RundstrÃ¶m <tobi@tobi.nu>
 "URL: http://tilde.tildesoftware.net
 "Last Change: May  8 09:15:09 CEST 2002
 

--- a/runtime/syntax/css.vim
+++ b/runtime/syntax/css.vim
@@ -61,7 +61,7 @@ syn match cssClassName "\.-\=[A-Za-z_][A-Za-z0-9_-]*" contains=cssClassNameDot
 syn match cssClassNameDot contained '\.'
 
 try
-syn match cssIdentifier "#[A-Za-zÀ-ÿ_@][A-Za-zÀ-ÿ0-9_@-]*"
+syn match cssIdentifier "#[A-Za-z\xc0-\xff_@][A-Za-z\xc0-\xff0-9_@-]*"
 catch /^.*/
 syn match cssIdentifier "#[A-Za-z_@][A-Za-z0-9_@-]*"
 endtry

--- a/runtime/syntax/elf.vim
+++ b/runtime/syntax/elf.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:    ELF
-" Maintainer:  Christian V. J. Brüssow <cvjb@cvjb.de>
+" Maintainer:  Christian V. J. BrÃ¼ssow <cvjb@cvjb.de>
 " Last Change: Son 22 Jun 2003 20:43:14 CEST
 " Filenames:   *.ab,*.am
 " URL:	       http://www.cvjb.de/comp/vim/elf.vim

--- a/runtime/syntax/forth.vim
+++ b/runtime/syntax/forth.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:    FORTH
 " Current Maintainer:  Johan Kotlinski <kotlinski@gmail.com>
-" Previous Maintainer:  Christian V. J. Brüssow <cvjb@cvjb.de>
+" Previous Maintainer:  Christian V. J. BrÃ¼ssow <cvjb@cvjb.de>
 " Last Change: 2018-03-29
 " Filenames:   *.fs,*.ft
 " URL:	       https://github.com/jkotlinski/forth.vim

--- a/runtime/syntax/fortran.vim
+++ b/runtime/syntax/fortran.vim
@@ -10,9 +10,9 @@
 "  Fortran 77 syntax file by Mario Eusebio and Preben Guldberg.
 "  Since then, useful suggestions and contributions have been made, in order, by:
 "  Andrej Panjkov, Bram Moolenaar, Thomas Olsen, Michael Sternberg, Christian Reile,
-"  Walter Dieudonné, Alexander Wagner, Roman Bertle, Charles Rendleman,
+"  Walter DieudonnÃ©, Alexander Wagner, Roman Bertle, Charles Rendleman,
 "  Andrew Griffiths, Joe Krahn, Hendrik Merx, Matt Thompson, Jan Hermann,
-"  Stefano Zaghi, Vishnu V. Krishnan, Judicaël Grasset, and Takuma Yoshida
+"  Stefano Zaghi, Vishnu V. Krishnan, JudicaÃ«l Grasset, and Takuma Yoshida
 
 if exists("b:current_syntax")
   finish

--- a/runtime/syntax/groff.vim
+++ b/runtime/syntax/groff.vim
@@ -1,6 +1,6 @@
 " VIM syntax file
 " Language:	groff
-" Maintainer:	Alejandro López-Valencia <dradul@yahoo.com>
+" Maintainer:	Alejandro LÃ³pez-Valencia <dradul@yahoo.com>
 " URL:		http://dradul.tripod.com/vim
 " Last Change:	2003-05-08-12:41:13 GMT-5.
 

--- a/runtime/syntax/initng.vim
+++ b/runtime/syntax/initng.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:	initng .i files
-" Maintainer:	Elan Ruusam‰e <glen@pld-linux.org>
+" Maintainer:	Elan Ruusam√§e <glen@pld-linux.org>
 " URL:		http://glen.alkohol.ee/pld/initng/
 " License:	GPL v2
 " Version:	0.13

--- a/runtime/syntax/iss.vim
+++ b/runtime/syntax/iss.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:             Inno Setup File (iss file) and My InnoSetup extension
 " Maintainer:           Jason Mills (jmills@cs.mun.ca)
-" Previous Maintainer:  Dominique Stéphan (dominique@mggen.com)
+" Previous Maintainer:  Dominique StÃ©phan (dominique@mggen.com)
 " Last Change:          2019 Sep 27
 "
 " Todo:

--- a/runtime/syntax/lout.vim
+++ b/runtime/syntax/lout.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:    Lout
-" Maintainer:  Christian V. J. Brüssow <cvjb@cvjb.de>
+" Maintainer:  Christian V. J. BrÃ¼ssow <cvjb@cvjb.de>
 " Last Change: So 12 Feb 2012 15:15:03 CET
 " Filenames:   *.lout,*.lt
 " URL:         http://www.cvjb.de/comp/vim/lout.vim

--- a/runtime/syntax/mmix.vim
+++ b/runtime/syntax/mmix.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:	MMIX
-" Maintainer:	Dirk Hüsken, <huesken@informatik.uni-tuebingen.de>
+" Maintainer:	Dirk HÃ¼sken, <huesken@informatik.uni-tuebingen.de>
 " Last Change:	2012 Jun 01
 " 		(Dominique Pelle added @Spell)
 " Filenames:	*.mms

--- a/runtime/syntax/moo.vim
+++ b/runtime/syntax/moo.vim
@@ -95,7 +95,7 @@ if exists("moo_unknown_builtin_functions")
   syn keyword mooKnownBuiltinFunction abs acos add_property add_verb asin atan binary_hash boot_player buffered_output_length callers caller_perms call_function ceil children chparent clear_property connected_players connected_seconds connection_name connection_option connection_options cos cosh create crypt ctime db_disk_size decode_binary delete_property delete_verb disassemble dump_database encode_binary equal eval exp floatstr floor flush_input force_input function_info idle_seconds index is_clear_property is_member is_player kill_task length listappend listdelete listen listeners listinsert listset log log10 match max max_object memory_usage min move notify object_bytes open_network_connection output_delimiters parent pass players properties property_info queued_tasks queue_info raise random read recycle renumber reset_max_object resume rindex rmatch seconds_left server_log server_version setadd setremove set_connection_option set_player_flag set_property_info set_task_perms set_verb_args set_verb_code set_verb_info shutdown sin sinh sqrt strcmp string_hash strsub substitute suspend tan tanh task_id task_stack ticks_left time tofloat toint toliteral tonum toobj tostr trunc typeof unlisten valid value_bytes value_hash verbs verb_args verb_code verb_info contained
 endif
 
-" Enclosed expressions
+"Â Enclosed expressions
 syn match mooUnenclosedError display ~[')\]|}]~
 syn match mooParenthesesError display ~[';\]|}]~ contained
 syn region mooParentheses start=~(~ end=~)~ transparent contains=@mooEnclosedContents,mooParenthesesError

--- a/runtime/syntax/nroff.vim
+++ b/runtime/syntax/nroff.vim
@@ -1,6 +1,6 @@
 " VIM syntax file
 " Language:	nroff/groff
-" Maintainer:	Pedro Alejandro López-Valencia <palopezv@gmail.com>
+" Maintainer:	Pedro Alejandro LÃ³pez-Valencia <palopezv@gmail.com>
 " URL:		http://vorbote.wordpress.com/
 " Last Change:	2012 Feb 2
 "
@@ -8,7 +8,7 @@
 "
 " ACKNOWLEDGEMENTS:
 "
-" My thanks to Jérôme Plût <Jerome.Plut@ens.fr>, who was the
+" My thanks to JÃ©rÃ´me PlÃ»t <Jerome.Plut@ens.fr>, who was the
 " creator and maintainer of this syntax file for several years.
 " May I be as good at it as he has been.
 "

--- a/runtime/syntax/pascal.vim
+++ b/runtime/syntax/pascal.vim
@@ -2,7 +2,7 @@
 " Language:	Pascal
 " Version: 2.8
 " Last Change:	2004/10/17 17:47:30
-" Maintainer:  Xavier Crégut <xavier.cregut@enseeiht.fr>
+" Maintainer:  Xavier CrÃ©gut <xavier.cregut@enseeiht.fr>
 " Previous Maintainer:	Mario Eusebio <bio@dq.fct.unl.pt>
 
 " Contributors: Tim Chase <tchase@csc.com>,

--- a/runtime/syntax/robots.vim
+++ b/runtime/syntax/robots.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	"Robots.txt" files
 " Robots.txt files indicate to WWW robots which parts of a web site should not be accessed.
-" Maintainer:	Dominique Stéphan (dominique@mggen.com)
+" Maintainer:	Dominique StÃ©phan (dominique@mggen.com)
 " URL: http://www.mggen.com/vim/syntax/robots.zip
 " Last change:	2001 May 09
 

--- a/runtime/syntax/rpl.vim
+++ b/runtime/syntax/rpl.vim
@@ -2,7 +2,7 @@
 " Language:	RPL/2
 " Version:	0.15.15 against RPL/2 version 4.00pre7i
 " Last Change:	2012 Feb 03 by Thilo Six
-" Maintainer:	Joël BERTRAND <rpl2@free.fr>
+" Maintainer:	JoÃ«l BERTRAND <rpl2@free.fr>
 " URL:		http://www.makalis.fr/~bertrand/rpl2/download/vim/indent/rpl.vim
 " Credits:	Nothing
 

--- a/runtime/syntax/rtf.vim
+++ b/runtime/syntax/rtf.vim
@@ -7,7 +7,7 @@
 " .hlp (windows help files) use compiled rtf files
 " rtf documentation at http://night.primate.wisc.edu/software/RTF/
 "
-" Maintainer:	Dominique Stéphan (dominique@mggen.com)
+" Maintainer:	Dominique StÃ©phan (dominique@mggen.com)
 " URL: http://www.mggen.com/vim/syntax/rtf.zip
 " Last change:	2001 Mai 02
 

--- a/runtime/syntax/tilde.vim
+++ b/runtime/syntax/tilde.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " This file works only for Vim6.x
 " Language:	Tilde
-" Maintainer:	Tobias Rundström <tobi@tildesoftware.net>
+" Maintainer:	Tobias RundstrÃ¶m <tobi@tildesoftware.net>
 " URL:		http://www.tildesoftware.net
 " CVS:		$Id: tilde.vim,v 1.1 2004/06/13 19:31:51 vimboss Exp $
 


### PR DESCRIPTION
Many runtime files in this repository are invalid utf-8 files (mainly iso-8859-1).

You can see all invalid files with:

```sh
find . -name '*.vim' | while read f; do if ! iconv -f UTF-8 $f &> /dev/null; then echo $f; fi; done
```

Ruby script used to fix it:

```ruby
Dir["{indent,syntax,ftplugin}/*.vim"].each { |f| File.read(f).gsub(/foo/, "") rescue File.write(f, File.read(f).force_encoding('iso-8859-1').encode('utf-8')) }
```