### PR TITLE
Replace security_context_t with char *

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2832,8 +2832,8 @@ mch_copy_sec(char_u *from_file, char_u *to_file)
 
     if (selinux_enabled > 0)
     {
-	security_context_t from_context = NULL;
-	security_context_t to_context = NULL;
+	char *from_context = NULL;
+	char *to_context = NULL;
 
 	if (getfilecon((char *)from_file, &from_context) < 0)
 	{


### PR DESCRIPTION
security_context_t has always been a typedef for `char *`, but the typedef led to incorrect application of const (as described in https://github.com/SELinuxProject/selinux/commit/9eb9c9327563014ad6a807814e7975424642d5b9).

In 2014, the SELinux APIs were switched to using `char *`, leaving the typedef defined to avoid breaking callers.

As of SELinux 3.1 (released July 2020), security_context_t is marked as deprecated to help transition users of SELinux to switch away from the typedef.