### PR TITLE
WIP: Improve runtime/syntax/sshconfig.vim (1)

### DIFF
--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -1,37 +1,37 @@
 " Vim syntax file
-" Language:	OpenSSH client configuration file (ssh_config)
-" Author:	David Necas (Yeti)
-" Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
-" Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>
-" Contributor:  Karsten Hopp <karsten@redhat.com>
-" Contributor:  Dean, Adam Kenneth <adam.ken.dean@hpe.com>
-" Last Change:	2020 Feb 12
-"		Added RemoteCommand from pull request #4809
-"		Included additional keywords from Martin.
-" SSH Version:	7.4p1
+" Language:        OpenSSH client configuration file (ssh_config)
 "
+" Author:          David Nečas (Yeti) <yeti@physics.muni.cz>
+" Contributor:     Leonard Ehrenfried <leonard.ehrenfried@web.de>
+" Contributor:     Karsten Hopp <karsten@redhat.com>
+" Contributor:     Dean, Adam Kenneth <adam.ken.dean@hpe.com>
+" Contributor:     Samy Mahmoudi <samy.mahmoudi@gmail.com>
+" Maintainer:      Dominik Fischer <d.f.fischer@web.de>
+"
+" Last Change:     2019 Feb 03
+" OpenSSH Version: 7.9p1
 
 " Setup
-" quit when a syntax file was already loaded
+
+" Quit when a syntax file was already loaded
 if exists("b:current_syntax")
   finish
 endif
 
 setlocal iskeyword=_,-,a-z,A-Z,48-57
 
-
-" case on
+" Case on
 syn case match
 
-
 " Comments
-syn match sshconfigComment "^#.*$" contains=sshconfigTodo
+
+syn match sshconfigComment "^#.*$"  contains=sshconfigTodo
 syn match sshconfigComment "\s#.*$" contains=sshconfigTodo
 
 syn keyword sshconfigTodo TODO FIXME NOTE contained
 
-
 " Constants
+
 syn keyword sshconfigYesNo yes no ask confirm
 syn keyword sshconfigYesNo any auto
 syn keyword sshconfigYesNo force autoask none
@@ -47,13 +47,13 @@ syn keyword sshconfigCiphers arcfour256
 syn keyword sshconfigCiphers aes128-cbc
 syn keyword sshconfigCiphers aes192-cbc
 syn keyword sshconfigCiphers aes256-cbc
-syn match sshconfigCiphers "\<rijndael-cbc@lysator\.liu.se\>"
+syn match   sshconfigCiphers "\<rijndael-cbc@lysator\.liu.se\>"
 syn keyword sshconfigCiphers aes128-ctr
 syn keyword sshconfigCiphers aes192-ctr
 syn keyword sshconfigCiphers aes256-ctr
-syn match sshconfigCiphers "\<aes128-gcm@openssh\.com\>"
-syn match sshconfigCiphers "\<aes256-gcm@openssh\.com\>"
-syn match sshconfigCiphers "\<chacha20-poly1305@openssh\.com\>"
+syn match   sshconfigCiphers "\<aes128-gcm@openssh\.com\>"
+syn match   sshconfigCiphers "\<aes256-gcm@openssh\.com\>"
+syn match   sshconfigCiphers "\<chacha20-poly1305@openssh\.com\>"
 
 syn keyword sshconfigMAC hmac-sha1
 syn keyword sshconfigMAC mac-sha1-96
@@ -76,25 +76,27 @@ syn match   sshconfigMAC "\<umac-64-etm@openssh\.com\>"
 syn match   sshconfigMAC "\<umac-128-etm@openssh\.com\>"
 
 syn keyword sshconfigHostKeyAlgo ssh-ed25519
-syn match sshconfigHostKeyAlgo "\<ssh-ed25519-cert-v01@openssh\.com\>"
+syn match   sshconfigHostKeyAlgo "\<ssh-ed25519-cert-v01@openssh\.com\>"
 syn keyword sshconfigHostKeyAlgo ssh-rsa
 syn keyword sshconfigHostKeyAlgo ssh-dss
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp256
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp384
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp521
-syn match sshconfigHostKeyAlgo "\<ssh-rsa-cert-v01@openssh\.com\>"
-syn match sshconfigHostKeyAlgo "\<ssh-dss-cert-v01@openssh\.com\>"
-syn match sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp256-cert-v01@openssh\.com\>"
-syn match sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp384-cert-v01@openssh\.com\>"
-syn match sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp521-cert-v01@openssh\.com\>"
+syn match   sshconfigHostKeyAlgo "\<ssh-rsa-cert-v01@openssh\.com\>"
+syn match   sshconfigHostKeyAlgo "\<ssh-dss-cert-v01@openssh\.com\>"
+syn match   sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp256-cert-v01@openssh\.com\>"
+syn match   sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp384-cert-v01@openssh\.com\>"
+syn match   sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp521-cert-v01@openssh\.com\>"
 
 syn keyword sshconfigPreferredAuth hostbased publickey password gssapi-with-mic
 syn keyword sshconfigPreferredAuth keyboard-interactive
 
 syn keyword sshconfigLogLevel QUIET FATAL ERROR INFO VERBOSE
 syn keyword sshconfigLogLevel DEBUG DEBUG1 DEBUG2 DEBUG3
+
 syn keyword sshconfigSysLogFacility DAEMON USER AUTH AUTHPRIV LOCAL0 LOCAL1
 syn keyword sshconfigSysLogFacility LOCAL2 LOCAL3 LOCAL4 LOCAL5 LOCAL6 LOCAL7
+
 syn keyword sshconfigAddressFamily  inet inet6
 
 syn match   sshconfigIPQoS	"af1[123]"
@@ -103,6 +105,7 @@ syn match   sshconfigIPQoS	"af3[123]"
 syn match   sshconfigIPQoS	"af4[123]"
 syn match   sshconfigIPQoS	"cs[0-7]"
 syn keyword sshconfigIPQoS	ef lowdelay throughput reliability
+
 syn keyword sshconfigKbdInteractive bsdauth pam skey
 
 syn keyword sshconfigKexAlgo diffie-hellman-group1-sha1
@@ -112,9 +115,9 @@ syn keyword sshconfigKexAlgo diffie-hellman-group-exchange-sha256
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp256
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp384
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp521
-syn match sshconfigKexAlgo "\<curve25519-sha256@libssh\.org\>"
+syn match   sshconfigKexAlgo "\<curve25519-sha256@libssh\.org\>"
 
-syn keyword sshconfigTunnel	point-to-point ethernet
+syn keyword sshconfigTunnel point-to-point ethernet
 
 syn match sshconfigVar "%[rhplLdun]\>"
 syn match sshconfigSpecial "[*?]"
@@ -125,11 +128,11 @@ syn match sshconfigHostPort "\<\(\x\{,4}:\)\+\x\{,4}[:/]\d\+\>"
 syn match sshconfigHostPort "\(Host \)\@<=.\+"
 syn match sshconfigHostPort "\(HostName \)\@<=.\+"
 
-" case off
+" Case off
 syn case ignore
 
-
 " Keywords
+
 syn keyword sshconfigHostSect Host
 
 syn keyword sshconfigMatch canonical final exec host originalhost user localuser all
@@ -199,7 +202,7 @@ syn keyword sshconfigKeyword Port
 syn keyword sshconfigKeyword PreferredAuthentications
 syn keyword sshconfigKeyword ProxyCommand
 syn keyword sshconfigKeyword ProxyJump
-syn keyword sshconfigKeyword ProxyUseFDPass
+syn keyword sshconfigKeyword ProxyUseFdpass
 syn keyword sshconfigKeyword PubkeyAcceptedKeyTypes
 syn keyword sshconfigKeyword PubkeyAuthentication
 syn keyword sshconfigKeyword RekeyLimit
@@ -230,7 +233,7 @@ syn keyword sshconfigKeyword XAuthLocation
 
 " Deprecated/ignored/remove/unsupported keywords
 
-syn keyword sshConfigDeprecated Cipher
+syn keyword sshconfigDeprecated Cipher
 syn keyword sshconfigDeprecated GSSAPIClientIdentity
 syn keyword sshconfigDeprecated GSSAPIKeyExchange
 syn keyword sshconfigDeprecated GSSAPIRenewalForcesRekey
@@ -246,31 +249,31 @@ syn keyword sshconfigDeprecated UsePrivilegedPort
 
 " Define the default highlighting
 
-hi def link sshconfigComment        Comment
-hi def link sshconfigTodo           Todo
-hi def link sshconfigHostPort       sshconfigConstant
-hi def link sshconfigNumber         sshconfigConstant
-hi def link sshconfigConstant       Constant
-hi def link sshconfigYesNo          sshconfigEnum
-hi def link sshconfigCipher         sshconfigDeprecated
-hi def link sshconfigCiphers        sshconfigEnum
-hi def link sshconfigMAC            sshconfigEnum
-hi def link sshconfigHostKeyAlgo    sshconfigEnum
-hi def link sshconfigLogLevel       sshconfigEnum
-hi def link sshconfigSysLogFacility sshconfigEnum
-hi def link sshconfigAddressFamily  sshconfigEnum
-hi def link sshconfigIPQoS          sshconfigEnum
-hi def link sshconfigKbdInteractive sshconfigEnum
-hi def link sshconfigKexAlgo        sshconfigEnum
-hi def link sshconfigTunnel         sshconfigEnum
-hi def link sshconfigPreferredAuth  sshconfigEnum
-hi def link sshconfigVar            sshconfigEnum
-hi def link sshconfigEnum           Identifier
-hi def link sshconfigSpecial        Special
-hi def link sshconfigKeyword        Keyword
-hi def link sshconfigHostSect       Type
-hi def link sshconfigMatch          Type
-hi def link sshconfigDeprecated     Error
+hi def link sshconfigComment         Comment
+hi def link sshconfigTodo            Todo
+hi def link sshconfigHostPort        sshconfigConstant
+hi def link sshconfigNumber          sshconfigConstant
+hi def link sshconfigConstant        Constant
+hi def link sshconfigYesNo           sshconfigEnum
+hi def link sshconfigCipher          sshconfigDeprecated
+hi def link sshconfigCiphers         sshconfigEnum
+hi def link sshconfigMAC             sshconfigEnum
+hi def link sshconfigHostKeyAlgo     sshconfigEnum
+hi def link sshconfigLogLevel        sshconfigEnum
+hi def link sshconfigSysLogFacility  sshconfigEnum
+hi def link sshconfigAddressFamily   sshconfigEnum
+hi def link sshconfigIPQoS           sshconfigEnum
+hi def link sshconfigKbdInteractive  sshconfigEnum
+hi def link sshconfigKexAlgo         sshconfigEnum
+hi def link sshconfigTunnel          sshconfigEnum
+hi def link sshconfigPreferredAuth   sshconfigEnum
+hi def link sshconfigVar             sshconfigEnum
+hi def link sshconfigEnum            Identifier
+hi def link sshconfigSpecial         Special
+hi def link sshconfigKeyword         Keyword
+hi def link sshconfigHostSect        Type
+hi def link sshconfigMatch           Type
+hi def link sshconfigDeprecated      Error
 
 let b:current_syntax = "sshconfig"
 

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -86,7 +86,7 @@ syn keyword sshconfigLogLevel DEBUG DEBUG1 DEBUG2 DEBUG3
 syn keyword sshconfigSysLogFacility DAEMON USER AUTH AUTHPRIV LOCAL0 LOCAL1
 syn keyword sshconfigSysLogFacility LOCAL2 LOCAL3 LOCAL4 LOCAL5 LOCAL6 LOCAL7
 
-syn keyword sshconfigAddressFamily  inet inet6
+syn keyword sshconfigAddressFamily  any inet inet6
 
 syn match   sshconfigIPQoS	"af1[123]"
 syn match   sshconfigIPQoS	"af2[123]"

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -41,16 +41,9 @@ syn keyword sshconfigYesNo yes no ask confirm
 syn keyword sshconfigYesNo any auto
 syn keyword sshconfigYesNo force autoask none
 
-syn keyword sshconfigCiphers 3des-cbc
-syn keyword sshconfigCiphers blowfish-cbc
-syn keyword sshconfigCiphers cast128-cbc
-syn keyword sshconfigCiphers arcfour
-syn keyword sshconfigCiphers arcfour128
-syn keyword sshconfigCiphers arcfour256
 syn keyword sshconfigCiphers aes128-cbc
 syn keyword sshconfigCiphers aes192-cbc
 syn keyword sshconfigCiphers aes256-cbc
-syn match   sshconfigCiphers "\<rijndael-cbc@lysator\.liu.se\>"
 syn keyword sshconfigCiphers aes128-ctr
 syn keyword sshconfigCiphers aes192-ctr
 syn keyword sshconfigCiphers aes256-ctr
@@ -241,6 +234,17 @@ syn keyword sshconfigKeyword XAuthLocation
 syn keyword sshconfigCipher 3des blowfish
 
 " 2) Items (keywords/matches/regions) that are deprecated
+
+"   Deprecated ciphers (were in sshconfigCiphers)
+syn keyword sshconfigDeprecated 3des-cbc
+syn keyword sshconfigDeprecated blowfish-cbc
+syn keyword sshconfigDeprecated cast128-cbc
+syn keyword sshconfigDeprecated arcfour
+syn keyword sshconfigDeprecated arcfour128
+syn keyword sshconfigDeprecated arcfour256
+syn match   sshconfigDeprecated "\<rijndael-cbc@lysator\.liu.se\>"
+
+"   Deprecated keywords (were in sshconfigKeyword)
 syn keyword sshconfigDeprecated Cipher
 syn keyword sshconfigDeprecated GSSAPIClientIdentity
 syn keyword sshconfigDeprecated GSSAPIKeyExchange

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -111,14 +111,14 @@ syn match   sshconfigKexAlgo "\<curve25519-sha256@libssh\.org\>"
 
 syn keyword sshconfigTunnel point-to-point ethernet
 
-syn match sshconfigVar "%[rhplLdun]\>"
+syn match sshconfigVar "\W%%\W\|\W%[CdhikLlnprTu]\>"
 syn match sshconfigSpecial "[*?]"
-syn match sshconfigNumber "\d\+"
-syn match sshconfigHostPort "\<\(\d\{1,3}\.\)\{3}\d\{1,3}\(:\d\+\)\?\>"
-syn match sshconfigHostPort "\<\([-a-zA-Z0-9]\+\.\)\+[-a-zA-Z0-9]\{2,}\(:\d\+\)\?\>"
-syn match sshconfigHostPort "\<\(\x\{,4}:\)\+\x\{,4}[:/]\d\+\>"
-syn match sshconfigHostPort "\(Host \)\@<=.\+"
-syn match sshconfigHostPort "\(HostName \)\@<=.\+"
+syn match sshconfigNumber "\<\d\+\>"
+syn match sshconfigHostPort "\<\(\d\{1,3}\.\)\{3}\d\{1,3}\(:\d\{1,5}\)\?\>"
+syn match sshconfigHostPort "\<\([a-zA-Z0-9][-a-zA-Z0-9]\{,62}\.\)\{,126}[a-zA-Z][-a-zA-Z0-9]\{,62}\(:\d\{1,5}\)\?\>"
+syn match sshconfigHostPort "\<\[\(\x\{,4}:\)\+\x\{,4}\(/\d\{1,3}\)\?\]\(:\d\{1,5}\)\?\>"
+syn match sshconfigHostPort "\<\(Host \)\@<=.\+"
+syn match sshconfigHostPort "\<\(Host[nN]ame \)\@<=.\+"
 
 " Case off
 syn case ignore
@@ -167,7 +167,7 @@ syn keyword sshconfigKeyword GlobalKnownHostsFile
 syn keyword sshconfigKeyword HashKnownHosts
 syn keyword sshconfigKeyword HostKeyAlgorithms
 syn keyword sshconfigKeyword HostKeyAlias
-syn keyword sshconfigKeyword HostName
+syn keyword sshconfigKeyword Hostname
 syn keyword sshconfigKeyword HostbasedAuthentication
 syn keyword sshconfigKeyword HostbasedKeyTypes
 syn keyword sshconfigKeyword IPQoS

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -41,8 +41,6 @@ syn keyword sshconfigYesNo yes no ask confirm
 syn keyword sshconfigYesNo any auto
 syn keyword sshconfigYesNo force autoask none
 
-syn keyword sshconfigCipher 3des blowfish
-
 syn keyword sshconfigCiphers 3des-cbc
 syn keyword sshconfigCiphers blowfish-cbc
 syn keyword sshconfigCiphers cast128-cbc
@@ -236,8 +234,12 @@ syn keyword sshconfigKeyword VerifyHostKeyDNS
 syn keyword sshconfigKeyword VisualHostKey
 syn keyword sshconfigKeyword XAuthLocation
 
-" Deprecated/ignored/remove/unsupported keywords
+" Deprecated/ignored/remove/unsupported elements
 
+" 1) Syntax groups that are linked to the highlight group sshconfigDeprecated
+syn keyword sshconfigCipher 3des blowfish
+
+" 2) Items (keywords/matches/regions) that are deprecated
 syn keyword sshconfigDeprecated Cipher
 syn keyword sshconfigDeprecated GSSAPIClientIdentity
 syn keyword sshconfigDeprecated GSSAPIKeyExchange

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -57,19 +57,12 @@ syn keyword sshconfigMAC hmac-sha1
 syn keyword sshconfigMAC mac-sha1-96
 syn keyword sshconfigMAC mac-sha2-256
 syn keyword sshconfigMAC mac-sha2-512
-syn keyword sshconfigMAC mac-md5
-syn keyword sshconfigMAC mac-md5-96
-syn keyword sshconfigMAC mac-ripemd160
-syn match   sshconfigMAC "\<hmac-ripemd160@openssh\.com\>"
 syn match   sshconfigMAC "\<umac-64@openssh\.com\>"
 syn match   sshconfigMAC "\<umac-128@openssh\.com\>"
 syn match   sshconfigMAC "\<hmac-sha1-etm@openssh\.com\>"
 syn match   sshconfigMAC "\<hmac-sha1-96-etm@openssh\.com\>"
 syn match   sshconfigMAC "\<hmac-sha2-256-etm@openssh\.com\>"
 syn match   sshconfigMAC "\<hmac-sha2-512-etm@openssh\.com\>"
-syn match   sshconfigMAC "\<hmac-md5-etm@openssh\.com\>"
-syn match   sshconfigMAC "\<hmac-md5-96-etm@openssh\.com\>"
-syn match   sshconfigMAC "\<hmac-ripemd160-etm@openssh\.com\>"
 syn match   sshconfigMAC "\<umac-64-etm@openssh\.com\>"
 syn match   sshconfigMAC "\<umac-128-etm@openssh\.com\>"
 
@@ -243,6 +236,15 @@ syn keyword sshconfigDeprecated arcfour
 syn keyword sshconfigDeprecated arcfour128
 syn keyword sshconfigDeprecated arcfour256
 syn match   sshconfigDeprecated "\<rijndael-cbc@lysator\.liu.se\>"
+
+"   Deprecated message authentication codes (MACs) (were in sshconfigMAC)
+syn keyword sshconfigDeprecated hmac-md5
+syn keyword sshconfigDeprecated hmac-md5-96
+syn match   sshconfigDeprecated "\<hmac-md5-etm@openssh\.com\>"
+syn match   sshconfigDeprecated "\<hmac-md5-96-etm@openssh\.com\>"
+syn keyword sshconfigDeprecated hmac-ripemd160
+syn match   sshconfigDeprecated "\<hmac-ripemd160@openssh\.com\>"
+syn match   sshconfigDeprecated "\<hmac-ripemd160-etm@openssh\.com\>"
 
 "   Deprecated keywords (were in sshconfigKeyword)
 syn keyword sshconfigDeprecated Cipher

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -10,6 +10,11 @@
 "
 " Last Change:     2019 Feb 03
 " OpenSSH Version: 7.9p1
+"
+" NOTE: To ease the maintenance of this file, most
+"       of its elements are ordered exactly like in
+"       the OpenSSH documentation (case-insensitive
+"       lexicographical order).
 
 " Setup
 
@@ -137,8 +142,8 @@ syn keyword sshconfigHostSect Host
 
 syn keyword sshconfigMatch canonical final exec host originalhost user localuser all
 
-syn keyword sshconfigKeyword AddressFamily
 syn keyword sshconfigKeyword AddKeysToAgent
+syn keyword sshconfigKeyword AddressFamily
 syn keyword sshconfigKeyword BatchMode
 syn keyword sshconfigKeyword BindAddress
 syn keyword sshconfigKeyword BindInterface
@@ -214,8 +219,8 @@ syn keyword sshconfigKeyword SecurityKeyProvider
 syn keyword sshconfigKeyword SendEnv
 syn keyword sshconfigKeyword ServerAliveCountMax
 syn keyword sshconfigKeyword ServerAliveInterval
-syn keyword sshconfigKeyword SmartcardDevice
 syn keyword sshconfigKeyword SetEnv
+syn keyword sshconfigKeyword SmartcardDevice
 syn keyword sshconfigKeyword StreamLocalBindMask
 syn keyword sshconfigKeyword StreamLocalBindUnlink
 syn keyword sshconfigKeyword StrictHostKeyChecking
@@ -249,31 +254,31 @@ syn keyword sshconfigDeprecated UsePrivilegedPort
 
 " Define the default highlighting
 
-hi def link sshconfigComment         Comment
-hi def link sshconfigTodo            Todo
-hi def link sshconfigHostPort        sshconfigConstant
-hi def link sshconfigNumber          sshconfigConstant
-hi def link sshconfigConstant        Constant
-hi def link sshconfigYesNo           sshconfigEnum
+hi def link sshconfigAddressFamily   sshconfigEnum
 hi def link sshconfigCipher          sshconfigDeprecated
 hi def link sshconfigCiphers         sshconfigEnum
-hi def link sshconfigMAC             sshconfigEnum
+hi def link sshconfigComment         Comment
+hi def link sshconfigConstant        Constant
+hi def link sshconfigDeprecated      Error
+hi def link sshconfigEnum            Identifier
 hi def link sshconfigHostKeyAlgo     sshconfigEnum
-hi def link sshconfigLogLevel        sshconfigEnum
-hi def link sshconfigSysLogFacility  sshconfigEnum
-hi def link sshconfigAddressFamily   sshconfigEnum
+hi def link sshconfigHostPort        sshconfigConstant
+hi def link sshconfigHostSect        Type
 hi def link sshconfigIPQoS           sshconfigEnum
 hi def link sshconfigKbdInteractive  sshconfigEnum
 hi def link sshconfigKexAlgo         sshconfigEnum
-hi def link sshconfigTunnel          sshconfigEnum
-hi def link sshconfigPreferredAuth   sshconfigEnum
-hi def link sshconfigVar             sshconfigEnum
-hi def link sshconfigEnum            Identifier
-hi def link sshconfigSpecial         Special
 hi def link sshconfigKeyword         Keyword
-hi def link sshconfigHostSect        Type
+hi def link sshconfigLogLevel        sshconfigEnum
+hi def link sshconfigMAC             sshconfigEnum
 hi def link sshconfigMatch           Type
-hi def link sshconfigDeprecated      Error
+hi def link sshconfigNumber          sshconfigConstant
+hi def link sshconfigPreferredAuth   sshconfigEnum
+hi def link sshconfigSpecial         Special
+hi def link sshconfigSysLogFacility  sshconfigEnum
+hi def link sshconfigTodo            Todo
+hi def link sshconfigTunnel          sshconfigEnum
+hi def link sshconfigVar             sshconfigEnum
+hi def link sshconfigYesNo           sshconfigEnum
 
 let b:current_syntax = "sshconfig"
 

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -54,9 +54,9 @@ syn match   sshconfigCiphers "\<chacha20-poly1305@openssh\.com\>"
 syn keyword sshconfigFingerprintHash md5 sha256
 
 syn keyword sshconfigMAC hmac-sha1
-syn keyword sshconfigMAC mac-sha1-96
-syn keyword sshconfigMAC mac-sha2-256
-syn keyword sshconfigMAC mac-sha2-512
+syn keyword sshconfigMAC hmac-sha1-96
+syn keyword sshconfigMAC hmac-sha2-256
+syn keyword sshconfigMAC hmac-sha2-512
 syn match   sshconfigMAC "\<umac-64@openssh\.com\>"
 syn match   sshconfigMAC "\<umac-128@openssh\.com\>"
 syn match   sshconfigMAC "\<hmac-sha1-etm@openssh\.com\>"

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -93,7 +93,8 @@ syn match   sshconfigIPQoS	"af2[123]"
 syn match   sshconfigIPQoS	"af3[123]"
 syn match   sshconfigIPQoS	"af4[123]"
 syn match   sshconfigIPQoS	"cs[0-7]"
-syn keyword sshconfigIPQoS	ef lowdelay throughput reliability
+syn match   sshconfigIPQoS      "\<\d\+\>"
+syn keyword sshconfigIPQoS	ef le lowdelay throughput reliability none
 
 syn keyword sshconfigKbdInteractive bsdauth pam skey
 

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -96,11 +96,9 @@ syn keyword sshconfigIPQoS	ef le lowdelay throughput reliability none
 
 syn keyword sshconfigKbdInteractive bsdauth pam skey
 
-syn keyword sshconfigKexAlgo diffie-hellman-group1-sha1
 syn keyword sshconfigKexAlgo diffie-hellman-group14-sha256
 syn keyword sshconfigKexAlgo diffie-hellman-group16-sha512
 syn keyword sshconfigKexAlgo diffie-hellman-group18-sha512
-syn keyword sshconfigKexAlgo diffie-hellman-group-exchange-sha1
 syn keyword sshconfigKexAlgo diffie-hellman-group-exchange-sha256
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp256
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp384

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -103,6 +103,7 @@ syn keyword sshconfigKexAlgo diffie-hellman-group-exchange-sha256
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp256
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp384
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp521
+syn keyword sshconfigKexAlgo curve25519-sha256
 syn match   sshconfigKexAlgo "\<curve25519-sha256@libssh\.org\>"
 
 syn keyword sshconfigTunnel point-to-point ethernet

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -8,8 +8,8 @@
 " Contributor:     Samy Mahmoudi <samy.mahmoudi@gmail.com>
 " Maintainer:      Dominik Fischer <d.f.fischer@web.de>
 "
-" Last Change:     2019 Feb 03
-" OpenSSH Version: 7.9p1
+" Last Change:     2020 Oct 08
+" OpenSSH Version: 8.3p1
 "
 " NOTE: To ease the maintenance of this file, most
 "       of its elements are ordered exactly like in
@@ -243,6 +243,8 @@ syn match   sshconfigDeprecated "\<hmac-md5-96-etm@openssh\.com\>"
 syn keyword sshconfigDeprecated hmac-ripemd160
 syn match   sshconfigDeprecated "\<hmac-ripemd160@openssh\.com\>"
 syn match   sshconfigDeprecated "\<hmac-ripemd160-etm@openssh\.com\>"
+syn keyword sshconfigDeprecated hmac-sha2-256-96
+syn keyword sshconfigDeprecated hmac-sha2-512-96
 
 "   Deprecated host key algorithms (were in sshconfigHostKeyAlgo)
 syn keyword sshconfigDeprecated ssh-rsa

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -100,7 +100,6 @@ syn keyword sshconfigIPQoS	ef lowdelay throughput reliability
 syn keyword sshconfigKbdInteractive bsdauth pam skey
 
 syn keyword sshconfigKexAlgo diffie-hellman-group1-sha1
-syn keyword sshconfigKexAlgo diffie-hellman-group14-sha1
 syn keyword sshconfigKexAlgo diffie-hellman-group-exchange-sha1
 syn keyword sshconfigKexAlgo diffie-hellman-group-exchange-sha256
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp256
@@ -245,6 +244,9 @@ syn match   sshconfigDeprecated "\<hmac-md5-96-etm@openssh\.com\>"
 syn keyword sshconfigDeprecated hmac-ripemd160
 syn match   sshconfigDeprecated "\<hmac-ripemd160@openssh\.com\>"
 syn match   sshconfigDeprecated "\<hmac-ripemd160-etm@openssh\.com\>"
+
+"   Deprecated key exchange algorithms (were in sshconfigKexAlgo)
+syn keyword sshconfigDeprecated diffie-hellman-group14-sha1
 
 "   Deprecated keywords (were in sshconfigKeyword)
 syn keyword sshconfigDeprecated Cipher

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -58,6 +58,8 @@ syn match   sshconfigCiphers "\<aes128-gcm@openssh\.com\>"
 syn match   sshconfigCiphers "\<aes256-gcm@openssh\.com\>"
 syn match   sshconfigCiphers "\<chacha20-poly1305@openssh\.com\>"
 
+syn keyword sshconfigFingerprintHash md5 sha256
+
 syn keyword sshconfigMAC hmac-sha1
 syn keyword sshconfigMAC mac-sha1-96
 syn keyword sshconfigMAC mac-sha2-256
@@ -263,6 +265,7 @@ hi def link sshconfigComment         Comment
 hi def link sshconfigConstant        Constant
 hi def link sshconfigDeprecated      Error
 hi def link sshconfigEnum            Identifier
+hi def link sshconfigFingerprintHash sshconfigEnum
 hi def link sshconfigHostKeyAlgo     sshconfigEnum
 hi def link sshconfigHostPort        sshconfigConstant
 hi def link sshconfigHostSect        Type

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -98,6 +98,9 @@ syn keyword sshconfigIPQoS	ef lowdelay throughput reliability
 syn keyword sshconfigKbdInteractive bsdauth pam skey
 
 syn keyword sshconfigKexAlgo diffie-hellman-group1-sha1
+syn keyword sshconfigKexAlgo diffie-hellman-group14-sha256
+syn keyword sshconfigKexAlgo diffie-hellman-group16-sha512
+syn keyword sshconfigKexAlgo diffie-hellman-group18-sha512
 syn keyword sshconfigKexAlgo diffie-hellman-group-exchange-sha1
 syn keyword sshconfigKexAlgo diffie-hellman-group-exchange-sha256
 syn keyword sshconfigKexAlgo ecdh-sha2-nistp256

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -226,7 +226,6 @@ syn keyword sshconfigKeyword SyslogFacility
 syn keyword sshconfigKeyword TCPKeepAlive
 syn keyword sshconfigKeyword Tunnel
 syn keyword sshconfigKeyword TunnelDevice
-syn keyword sshconfigKeyword UseBlacklistedKeys
 syn keyword sshconfigKeyword UpdateHostKeys
 syn keyword sshconfigKeyword User
 syn keyword sshconfigKeyword UserKnownHostsFile
@@ -253,6 +252,7 @@ syn keyword sshconfigDeprecated RhostsRSAAuthentication
 syn keyword sshconfigDeprecated CompressionLevel
 syn keyword sshconfigDeprecated UseRoaming
 syn keyword sshconfigDeprecated UsePrivilegedPort
+syn keyword sshconfigDeprecated UseBlacklistedKeys
 
 " Define the default highlighting
 

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -68,12 +68,10 @@ syn match   sshconfigMAC "\<umac-128-etm@openssh\.com\>"
 
 syn keyword sshconfigHostKeyAlgo ssh-ed25519
 syn match   sshconfigHostKeyAlgo "\<ssh-ed25519-cert-v01@openssh\.com\>"
-syn keyword sshconfigHostKeyAlgo ssh-rsa
 syn keyword sshconfigHostKeyAlgo ssh-dss
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp256
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp384
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp521
-syn match   sshconfigHostKeyAlgo "\<ssh-rsa-cert-v01@openssh\.com\>"
 syn match   sshconfigHostKeyAlgo "\<ssh-dss-cert-v01@openssh\.com\>"
 syn match   sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp256-cert-v01@openssh\.com\>"
 syn match   sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp384-cert-v01@openssh\.com\>"
@@ -244,6 +242,10 @@ syn match   sshconfigDeprecated "\<hmac-md5-96-etm@openssh\.com\>"
 syn keyword sshconfigDeprecated hmac-ripemd160
 syn match   sshconfigDeprecated "\<hmac-ripemd160@openssh\.com\>"
 syn match   sshconfigDeprecated "\<hmac-ripemd160-etm@openssh\.com\>"
+
+"   Deprecated host key algorithms (were in sshconfigHostKeyAlgo)
+syn keyword sshconfigDeprecated ssh-rsa
+syn match   sshconfigDeprecated "\<ssh-rsa-cert-v01@openssh\.com\>"
 
 "   Deprecated key exchange algorithms (were in sshconfigKexAlgo)
 syn keyword sshconfigDeprecated diffie-hellman-group14-sha1

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -68,11 +68,9 @@ syn match   sshconfigMAC "\<umac-128-etm@openssh\.com\>"
 
 syn keyword sshconfigHostKeyAlgo ssh-ed25519
 syn match   sshconfigHostKeyAlgo "\<ssh-ed25519-cert-v01@openssh\.com\>"
-syn keyword sshconfigHostKeyAlgo ssh-dss
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp256
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp384
 syn keyword sshconfigHostKeyAlgo ecdsa-sha2-nistp521
-syn match   sshconfigHostKeyAlgo "\<ssh-dss-cert-v01@openssh\.com\>"
 syn match   sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp256-cert-v01@openssh\.com\>"
 syn match   sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp384-cert-v01@openssh\.com\>"
 syn match   sshconfigHostKeyAlgo "\<ecdsa-sha2-nistp521-cert-v01@openssh\.com\>"
@@ -250,7 +248,9 @@ syn match   sshconfigDeprecated "\<hmac-ripemd160-etm@openssh\.com\>"
 
 "   Deprecated host key algorithms (were in sshconfigHostKeyAlgo)
 syn keyword sshconfigDeprecated ssh-rsa
+syn keyword sshconfigDeprecated ssh-dss
 syn match   sshconfigDeprecated "\<ssh-rsa-cert-v01@openssh\.com\>"
+syn match   sshconfigDeprecated "\<ssh-dss-cert-v01@openssh\.com\>"
 
 "   Deprecated key exchange algorithms (were in sshconfigKexAlgo)
 syn keyword sshconfigDeprecated diffie-hellman-group14-sha1


### PR DESCRIPTION
Problem: Syntax file sshconfig.vim is outdated.
Solution: Update sshconfig.vim partially (with no intention to be exhaustive). (Samy Mahmoudi)

Note: I started this work long ago, after creating pull request #3258. Recently, Bram Moolenaar made me notice Kevin Locke's pull request #5753, so I decided to push my changes even if they will not be reviewed (maintainer timeout) to avoid such duplicate efforts.

WIP: Some changes conflict with Kevin's first commit (Kevin adds some MACs to sshdconfigMAC while I add the same MACs to sshconfigDeprecated to mark them as deprecated) but I am sure we will sort this out quickly. Besides, I also came to the conclusion that some MACs were inserted and have been kept in the file whereas they were erroneous (written as mac-* instead of hmac-*) from the beginning ;-)
