### PR TITLE
Remove redundant close(0) and dup(2)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2710,15 +2710,6 @@ read_stdin(void)
     TIME_MSG("reading stdin");
 
     check_swap_exists_action();
-#if !(defined(AMIGA) || defined(MACOS_X))
-    /*
-     * Close stdin and dup it from stderr.  Required for GPM to work
-     * properly, and for running external commands.
-     * Is there any other system that cannot do this?
-     */
-    close(0);
-    vim_ignored = dup(2);
-#endif
 }
 
 /*


### PR DESCRIPTION
`close(0)` and `dup(2)` are already executed in fileio.c:
https://github.com/vim/vim/blob/c6ed254d9fda0ff54cdedce5597ff3e0d0218d18/src/fileio.c#L2290-L2295
I think there's no need to execute them again in main.c.
@brammool What do you think?