### PR TITLE
Suppress Python 3.9 warning

### DIFF
--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -1002,11 +1002,13 @@ Python3_Init(void)
 	reset_stdin();
 	Py_Initialize();
 
+#if PY_VERSION_HEX < 0x03090000
 	// Initialise threads, and below save the state using
 	// PyEval_SaveThread.  Without the call to PyEval_SaveThread, thread
 	// specific state (such as the system trace hook), will be lost
 	// between invocations of Python code.
 	PyEval_InitThreads();
+#endif
 #ifdef DYNAMIC_PYTHON3
 	get_py3_exceptions();
 #endif


### PR DESCRIPTION
Reported at #7112.

See: https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads
PyEval_InitThreads() is deprecated in Python 3.9.
Stop calling it if Python is 3.9 or later.