### PR TITLE
Fix for Vim crash in MacOS when running the 'browse tabnew' command

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2465,6 +2465,7 @@ do_ecmd(
     bufref_T	old_curbuf;
     char_u	*free_fname = NULL;
 #ifdef FEAT_BROWSE
+    char_u	dot_path[] = ".";
     char_u	*browse_file = NULL;
 #endif
     int		retval = FAIL;
@@ -2511,7 +2512,7 @@ do_ecmd(
 		// No browsing supported but we do have the file explorer:
 		// Edit the directory.
 		if (ffname == NULL || !mch_isdir(ffname))
-		    ffname = (char_u *)".";
+		    ffname = dot_path;
 	    }
 	    else
 	    {

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6084,6 +6084,7 @@ ex_splitview(exarg_T *eap)
     char_u	*fname = NULL;
 #endif
 #ifdef FEAT_BROWSE
+    char_u	dot_path[] = ".";
     int		browse_flag = cmdmod.browse;
 #endif
     int		use_tab = eap->cmdidx == CMD_tabedit
@@ -6136,7 +6137,7 @@ ex_splitview(exarg_T *eap)
 	    // No browsing supported but we do have the file explorer:
 	    // Edit the directory.
 	    if (*eap->arg == NUL || !mch_isdir(eap->arg))
-		eap->arg = (char_u *)".";
+		eap->arg = dot_path;
 	}
 	else
 	{


### PR DESCRIPTION

In a MacVim (built with GUI support) running in a terminal, executing any
of the following commands will crash Vim: "browse enew", "browse split",
"browse edit", "browse view", "browse vsplit", "browse tabedit",
"browse diffsplit", "browse open", "browse visual", "browse vsplit".

I opened the following issue in the MacVim tracker to report this:
https://github.com/macvim-dev/macvim/issues/1107

Upon investigation, it is found that this is not specific to MacVim.

This crash is caused by the fname_case() function trying to copy a
string into a memory allocated for a read-only string.

The attached patch fixes this problem. Thanks to Yee Cheng Chin
and ichizok.

