### PR TITLE
Fix docs. (Some suggestions are included)

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -1288,7 +1288,7 @@ prompt. >
 	  " Send the text to a shell with Enter appended.
 	  call ch_sendraw(g:shell_job, a:text .. "\n")
 	endfunc
-		
+
 	" Function handling output from the shell: Added above the prompt.
 	func GotOutput(channel, msg)
 	  call append(line("$") - 1, "- " . a:msg)

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -120,7 +120,7 @@ base, use |str2nr()|.
 
 						*TRUE* *FALSE* *Boolean*
 For boolean operators Numbers are used.  Zero is FALSE, non-zero is TRUE.
-You can also use |v:false| and |v:true|.  In Vim9 script |false| and |true|. 
+You can also use |v:false| and |v:true|.  In Vim9 script |false| and |true|.
 When TRUE is returned from a function it is the Number one, FALSE is the
 number zero.
 
@@ -3125,7 +3125,7 @@ appendbufline({expr}, {lnum}, {text})			*appendbufline()*
 		If {expr} is not a valid buffer or {lnum} is not valid, an
 		error message is given. Example: >
 			:let failed = appendbufline(13, 0, "# THE START")
-<
+
 <		Can also be used as a |method| after a List, the base is
 		passed as the second argument: >
 			mylist->appendbufline(buf, lnum)
@@ -7957,8 +7957,8 @@ printf({fmt}, {expr1} ...)				*printf()*
 
 
 prompt_getprompt({buf})					*prompt_getprompt()*
-		Returns the effective prompt text for buffer {buf}. {buf} can
-		be a buffer name or number. |prompt-buffer|.
+		Returns the effective prompt text for buffer {buf}.  {buf} can
+		be a buffer name or number.  See |prompt-buffer|.
 
 		If the buffer doesn't exist or isn't a prompt buffer, an empty
 		string is returned.
@@ -10694,8 +10694,8 @@ terminalprops()						*terminalprops()*
 		detected from the response to |t_RV| request.  See
 		|v:termresponse| for the response itself.  If |v:termresponse|
 		is empty most values here will be 'u' for unknown.
-		   cursor_style		wether sending |t_RS| works  **
-		   cursor_blink_mode	wether sending |t_RC| works  **
+		   cursor_style		whether sending |t_RS| works  **
+		   cursor_blink_mode	whether sending |t_RC| works  **
 		   underline_rgb	whether |t_8u| works **
 		   mouse		mouse type supported
 

--- a/runtime/doc/if_mzsch.txt
+++ b/runtime/doc/if_mzsch.txt
@@ -43,7 +43,7 @@ To speed up the process, you might also want to use --disable-gracket and
 {script}
 {endmarker}
 			Execute inlined MzScheme script {script}.
-			Note: This command doesn't work if the MzScheme
+			Note: This command doesn't work when the MzScheme
 			feature wasn't compiled in.  To avoid errors, see
 			|script-here|.
 

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -195,8 +195,8 @@ gt					*i_CTRL-<PageDown>* *i_<C-PageDown>*
 		    :+2tabnext	" go to the two next tab page
 		    :1tabnext	" go to the first tab page
 		    :$tabnext	" go to the last tab page
-		    :tabnext #  " go to the last accessed tab page
 		    :tabnext $	" as above
+		    :tabnext #  " go to the last accessed tab page
 		    :tabnext -	" go to the previous tab page
 		    :tabnext -1	" as above
 		    :tabnext +	" go to the next tab page
@@ -225,7 +225,7 @@ gT		Go to the previous tab page.  Wraps around from the first one
 							*:tabl* *:tablast*
 :tabl[ast]	Go to the last tab page.
 
-					    *g<Tab>* *CTRL-W_g<Tab>* *<C-Tab>*
+					*g<Tab>* *CTRL-W_g<Tab>* *<C-Tab>*
 g<Tab>		Go to the last accessed tab page.
 
 Other commands:
@@ -259,7 +259,7 @@ REORDERING TAB PAGES:
 		    :tabmove	" move the tab page to the last
 		    :$tabmove	" as above
 		    :tabmove $	" as above
-		    :tabmove #  " move the tab page after the last accessed
+		    :tabmove #	" move the tab page after the last accessed
 				" tab page
 
 :tabm[ove] +[N]

--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -101,7 +101,7 @@ Manipulating text property types:
 prop_type_add({name}, {props})		define a new property type
 prop_type_change({name}, {props})	change an existing property type
 prop_type_delete({name} [, {props}])	delete a property type
-prop_type_get([{name} [, {props}]])	get property type values
+prop_type_get({name} [, {props}])	get property type values
 prop_type_list([{props}])		get list of property types
 
 
@@ -291,7 +291,7 @@ prop_type_delete({name} [, {props}])			*prop_type_delete()*
 		Can also be used as a |method|: >
 			GetPropName()->prop_type_delete()
 
-prop_type_get([{name} [, {props}]])			*prop_type_get()*
+prop_type_get({name} [, {props}])			*prop_type_get()*
 		Returns the properties of property type {name}.  This is a
 		dictionary with the same fields as was given to
 		prop_type_add().


### PR DESCRIPTION
Remarks:

if_mzsch.txt
- s/if/when/
  The notation is the same as other if_*.txt (if_pyth.txt etc.).

tabpage.txt
- `tabnext $` must immediately follow `$tabnext`.
  Because `as above`.

textprop.txt
- The first argument of `prop_type_get()` is mandatory.

--
Best regards,
Hirohito Higashi (h_east)