### PR TITLE
Remove twig filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1755,9 +1755,6 @@ au BufNewFile,BufReadPost *.tssop		setf tssop
 " TSS - Command Line (temporary)
 au BufNewFile,BufReadPost *.tsscl		setf tsscl
 
-" TWIG files
-au BufNewFile,BufReadPost *.twig		setf twig
-
 " Typescript
 au BufNewFile,BufReadPost *.ts			setf typescript
 


### PR DESCRIPTION
There is no point setting .twig filetype because there are no runtime files handling it, and it can interfere with plugins that actually handle twig extension and use different filetype (e.g. https://github.com/lumiliet/vim-twig uses html.twig filetype)