### PR TITLE
Fix motion on nested XML/HTML tagblock

### DIFF
--- a/src/testdir/test_textobjects.vim
+++ b/src/testdir/test_textobjects.vim
@@ -169,6 +169,18 @@ func Test_string_html_objects()
   normal! k$vaty
   call assert_equal("<html>\n<title>welcome\n</html>", @")
 
+  " nested tag that has < in a different line from >
+  let t = "<div><div\n></div></div>"
+  $put =t
+  normal! k0vaty
+  call assert_equal("<div><div\n></div></div>", @")
+
+  " nested tag with attribute that has < in a different line from >
+  let t = "<div><div\nattr=\"attr\"\n></div></div>"
+  $put =t
+  normal! 2k0vaty
+  call assert_equal("<div><div\nattr=\"attr\"\n></div></div>", @")
+
   set quoteescape&
   enew!
 endfunc

--- a/src/textobject.c
+++ b/src/textobject.c
@@ -1347,7 +1347,7 @@ again:
 	curwin->w_cursor = old_pos;
 	goto theend;
     }
-    spat = alloc(len + 31);
+    spat = alloc(len + 39);
     epat = alloc(len + 9);
     if (spat == NULL || epat == NULL)
     {
@@ -1356,7 +1356,7 @@ again:
 	curwin->w_cursor = old_pos;
 	goto theend;
     }
-    sprintf((char *)spat, "<%.*s\\>\\%%(\\s\\_[^>]\\{-}[^/]>\\|>\\)\\c", len, p);
+    sprintf((char *)spat, "<%.*s\\>\\%%(\\_s\\_[^>]\\{-}\\_[^/]>\\|\\_s\\?>\\)\\c", len, p);
     sprintf((char *)epat, "</%.*s>\\c", len, p);
 
     r = do_searchpair(spat, (char_u *)"", epat, FORWARD, NULL,


### PR DESCRIPTION
Tag block motion on the following content does not properly move the cursor to the matching pair. To reproduce, copy one of the following content and from the first tag type `vat`. 


```
<div><div
></div></div>
```

```
<div><div
attr="attr"
></div></div>
```

Expected behavior is to have the whole content selected.

The actual behavior is that the selection stops after the first closing tag.