### PR TITLE
Fix shifting commands in makefiles.

### DIFF
--- a/runtime/ftplugin/make.vim
+++ b/runtime/ftplugin/make.vim
@@ -9,10 +9,10 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "setl et< sts< fo< com< cms< inc<"
+let b:undo_ftplugin = "setl et< sts< sw< fo< com< cms< inc<"
 
 " Make sure a hard tab is used, required for most make programs
-setlocal noexpandtab softtabstop=0
+setlocal noexpandtab softtabstop=0 shiftwidth=0
 
 " Set 'formatoptions' to break comment lines but not other lines,
 " and insert the comment leader when hitting <CR> or using "o".


### PR DESCRIPTION
Set shiftwidth to 0 in ftplugin/make.vim so that a user can press >> and
get the correct indent level. This also reduces the chance of mixing
tabs and spaces.

If I missed something please let me know. The maintainer is Bram so I think I'm fine sending this to the upstream repo?