### PR TITLE
Matchfuzzy: Prefer complete matches over separator matches

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -4253,7 +4253,7 @@ typedef struct
 } fuzzyItem_T;
 
 // bonus for adjacent matches
-#define SEQUENTIAL_BONUS 15
+#define SEQUENTIAL_BONUS 40
 // bonus if match occurs after a separator
 #define SEPARATOR_BONUS 30
 // bonus if match is uppercase and prev is lower

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -18,7 +18,7 @@ func Test_matchfuzzy()
   call assert_equal(['aabbaa', 'aaabbbaaa', 'aaaabbbbaaaa', 'aba'], matchfuzzy(['aba', 'aabbaa', 'aaabbbaaa', 'aaaabbbbaaaa'], 'aa'))
   call assert_equal(['one'], matchfuzzy(['one', 'two'], 'one'))
   call assert_equal(['oneTwo', 'onetwo'], matchfuzzy(['onetwo', 'oneTwo'], 'oneTwo'))
-  call assert_equal(['one_two', 'onetwo'], matchfuzzy(['onetwo', 'one_two'], 'oneTwo'))
+  call assert_equal(['onetwo', 'one_two'], matchfuzzy(['onetwo', 'one_two'], 'oneTwo'))
   call assert_equal(['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'], matchfuzzy(['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'], 'aa'))
   call assert_equal(256, matchfuzzy([repeat('a', 256)], repeat('a', 256))[0]->len())
   call assert_equal([], matchfuzzy([repeat('a', 300)], repeat('a', 257)))
@@ -27,7 +27,11 @@ func Test_matchfuzzy()
   " preference for camel case match
   call assert_equal(['oneTwo', 'onetwo'], ['onetwo', 'oneTwo']->matchfuzzy('onetwo'))
   " preference for match after a separator (_ or space)
-  call assert_equal(['one_two', 'one two', 'onetwo'], ['onetwo', 'one_two', 'one two']->matchfuzzy('onetwo'))
+  if has("win32")
+    call assert_equal(['onetwo', 'one two', 'one_two'], ['onetwo', 'one_two', 'one two']->matchfuzzy('onetwo'))
+  else
+    call assert_equal(['onetwo', 'one_two', 'one two'], ['onetwo', 'one_two', 'one two']->matchfuzzy('onetwo'))
+  endif
   " preference for leading letter match
   call assert_equal(['onetwo', 'xonetwo'], ['xonetwo', 'onetwo']->matchfuzzy('onetwo'))
   " preference for sequential match
@@ -36,6 +40,8 @@ func Test_matchfuzzy()
   call assert_equal(['xonetwo', 'xxonetwo'], ['xxonetwo', 'xonetwo']->matchfuzzy('onetwo'))
   " total non-matching letter(s) penalty
   call assert_equal(['one', 'onex', 'onexx'], ['onexx', 'one', 'onex']->matchfuzzy('one'))
+  " prefer complete matches over separator matches
+  call assert_equal(['.vim/vimrc', '.vim/vimrc_colors', '.vim/v_i_m_r_c'], ['.vim/vimrc', '.vim/vimrc_colors', '.vim/v_i_m_r_c']->matchfuzzy('vimrc'))
 
   %bw!
   eval ['somebuf', 'anotherone', 'needle', 'yetanotherone']->map({_, v -> bufadd(v) + bufload(v)})
@@ -133,9 +139,16 @@ func Test_matchfuzzy_mbyte()
   " preference for camel case match
   call assert_equal(['oneĄwo', 'oneąwo'],
         \ ['oneąwo', 'oneĄwo']->matchfuzzy('oneąwo'))
-  " preference for match after a separator (_ or space)
-  call assert_equal(['ⅠⅡa_bㄟㄠ', 'ⅠⅡa bㄟㄠ', 'ⅠⅡabㄟㄠ'],
-        \ ['ⅠⅡabㄟㄠ', 'ⅠⅡa_bㄟㄠ', 'ⅠⅡa bㄟㄠ']->matchfuzzy('ⅠⅡabㄟㄠ'))
+  " preference for complete match then match after separator (_ or space)
+  if has("win32")
+    " order is different between Windows and Unix :(
+    " It's important that the complete match is first
+    call assert_equal(['ⅠⅡabㄟㄠ', 'ⅠⅡa bㄟㄠ', 'ⅠⅡa_bㄟㄠ'],
+          \ ['ⅠⅡabㄟㄠ', 'ⅠⅡa_bㄟㄠ', 'ⅠⅡa bㄟㄠ']->matchfuzzy('ⅠⅡabㄟㄠ'))
+  else
+    call assert_equal(['ⅠⅡabㄟㄠ'] + sort(['ⅠⅡa_bㄟㄠ', 'ⅠⅡa bㄟㄠ']),
+          \ ['ⅠⅡabㄟㄠ', 'ⅠⅡa bㄟㄠ', 'ⅠⅡa_bㄟㄠ']->matchfuzzy('ⅠⅡabㄟㄠ'))
+  endif
   " preference for leading letter match
   call assert_equal(['ŗŝţũŵż', 'xŗŝţũŵż'],
         \ ['xŗŝţũŵż', 'ŗŝţũŵż']->matchfuzzy('ŗŝţũŵż'))


### PR DESCRIPTION
this is a fix for the recently discussed issue of matchfuzzy at vim-dev: https://groups.google.com/forum/#!topic/vim_dev/QQrHWIwI8jM

What this does is, give sequential matches a higher priority than separator matches, so that 

    echo matchfuzzy(['.vim/v_i_m_r_c', '.vim/vimrc', '.vim/vimrc_colors'], 'vimrc')

will return matches in the order of `['.vim/vimrc', '.vim/vimrc_colors', '.vim/v_i_m_r_c']`.

For now this PR still contains the old changes to give an extra bonus for a omplete match. But this is commented out. I just left it in, just in case if we agree that this would be a good idea in general :)

If all agree that this is not needed, I'll remove that part and push up and merge everything into one single commit.