### PR TITLE
Single quotes, not triple double quotes in :h undo

### DIFF
--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -392,7 +392,7 @@ back the text of three deletes ago with '"3P'.
 						*redo-register*
 If you want to get back more than one part of deleted text, you can use a
 special feature of the repeat command ".".  It will increase the number of the
-register used.  So if you first do ""1P", the following "." will result in a
+register used.  So if you first do '"1P', the following "." will result in a
 '"2P'.  Repeating this will result in all numbered registers being inserted.
 
 Example:	If you deleted text with 'dd....' it can be restored with


### PR DESCRIPTION
In `:h undo` most of the examples use single quotes when referring to
registers, e.g. `'"2P'`.

The first example however, uses `""1P"`, which can make the second double
quote (the one that actually needs to be typed) harder to spot. (As seen in
[this reddit post](https://reddit.com/r/vim/comments/jcolg8/repeat_command_increasing_the_number_of_register/).)

This simple change will make it easier to read, and more consistent
with the other examples.