### PR TITLE
Improve json test coverage

### DIFF
--- a/src/testdir/test_json.vim
+++ b/src/testdir/test_json.vim
@@ -62,7 +62,11 @@ let s:jsd3 = '{x:{a:1,b:2},y:{a:1,b:2}}'
 let s:vard4 = {"key": v:none}
 let s:vard4x = {"key": v:null}
 let s:jsond4 = '{"key":null}'
-let s:jsd4 = '{key:null}'
+let s:jsd4 = '{key:null}'    " js_encode puts no quotes around simple key.
+let s:vard5 = {"key!": v:none}
+let s:vard5x = {"key!": v:null}
+let s:jsond5 = '{"key!":null}'
+let s:jsd5 = '{"key!":null}' " js_encode puts quotes around non-simple key.
 
 let s:jsonvals = '[true,false,null,null]'
 let s:varvals = [v:true, v:false, v:null, v:null]
@@ -93,6 +97,7 @@ func Test_json_encode()
   call assert_equal(s:jsond2, json_encode(s:vard2))
   call assert_equal(s:jsond3, json_encode(s:vard3))
   call assert_equal(s:jsond4, json_encode(s:vard4))
+  call assert_equal(s:jsond5, json_encode(s:vard5))
 
   call assert_equal(s:jsonvals, json_encode(s:varvals))
 
@@ -139,6 +144,7 @@ func Test_json_decode()
   call assert_equal(s:vard2x, json_decode(s:jsond2s))
   call assert_equal(s:vard3, json_decode(s:jsond3))
   call assert_equal(s:vard4x, json_decode(s:jsond4))
+  call assert_equal(s:vard5x, json_decode(s:jsond5))
 
   call assert_equal(s:varvals, json_decode(s:jsonvals))
 
@@ -194,6 +200,7 @@ func Test_json_decode()
 
   call assert_fails('call json_decode("{{}:42}")', "E491:")
   call assert_fails('call json_decode("{[]:42}")', "E491:")
+  call assert_fails('call json_decode("{1:1{")', "E491:")
 
   call assert_fails('call json_decode("-")', "E491:")
   call assert_fails('call json_decode("-1x")', "E491:")
@@ -235,6 +242,7 @@ func Test_js_encode()
   call assert_equal(s:jsd2, js_encode(s:vard2))
   call assert_equal(s:jsd3, js_encode(s:vard3))
   call assert_equal(s:jsd4, js_encode(s:vard4))
+  call assert_equal(s:jsd5, js_encode(s:vard5))
 
   call assert_equal(s:jsonvals, js_encode(s:varvals))
 
@@ -281,6 +289,8 @@ func Test_js_decode()
   call assert_equal(s:vard3, js_decode(s:jsd3))
   call assert_equal(s:vard4x, js_decode(s:jsond4))
   call assert_equal(s:vard4x, js_decode(s:jsd4))
+  call assert_equal(s:vard5x, js_decode(s:jsond5))
+  call assert_equal(s:vard5x, js_decode(s:jsd5))
 
   call assert_equal(s:varvals, js_decode(s:jsonvals))
 


### PR DESCRIPTION
This PR improves json test coverage:
* `js_encode()` of non-simple keys were not tested (json.c:178)
* `json_decode()`of invalid json "{1:1{" was not covered by tests (json.c:1037)

It only adds coverage for a few more lines.  I did see how to cover the remaining lines in json.c.