### PR TITLE
Errorformat: %v may fail for multi-line messages

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1362,9 +1362,10 @@ qf_parse_multiline_pfx(
 	if (!qfprev->qf_lnum)
 	    qfprev->qf_lnum = fields->lnum;
 	if (!qfprev->qf_col)
+	{
 	    qfprev->qf_col = fields->col;
-        if (!qfprev->qf_viscol)
-            qfprev->qf_viscol = fields->use_viscol;
+	    qfprev->qf_viscol = fields->use_viscol;
+	}
 	if (!qfprev->qf_fnum)
 	    qfprev->qf_fnum = qf_get_fnum(qfl,
 		    qfl->qf_directory,

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1363,7 +1363,8 @@ qf_parse_multiline_pfx(
 	    qfprev->qf_lnum = fields->lnum;
 	if (!qfprev->qf_col)
 	    qfprev->qf_col = fields->col;
-	qfprev->qf_viscol = fields->use_viscol;
+        if (!qfprev->qf_viscol)
+            qfprev->qf_viscol = fields->use_viscol;
 	if (!qfprev->qf_fnum)
 	    qfprev->qf_fnum = qf_get_fnum(qfl,
 		    qfl->qf_directory,

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -4427,6 +4427,13 @@ func Test_viscol()
   call assert_equal('Xfile1', @%)
   call assert_equal([0, 1, 4, 0], getpos('.'))
 
+  " Repeat previous test with byte offset %c: ensure that fix to issue #7145
+  " does not break this
+  set efm=%E===\ %f\ ===,%C%l:%c,%Z%m
+  cexpr ["=== Xfile1 ===", "1:3", "errormsg"]
+  call assert_equal('Xfile1', @%)
+  call assert_equal([0, 1, 3, 0], getpos('.'))
+
   enew | only
   set efm&
   call delete('Xfile1')

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -4419,6 +4419,14 @@ func Test_viscol()
   cnext
   call assert_equal([16, 25], [col('.'), virtcol('.')])
 
+  " Use screen column number with a multi-line error message
+  enew
+  call writefile(["à test"], 'Xfile1')
+  set efm=%E===\ %f\ ===,%C%l:%v,%Z%m
+  cexpr ["=== Xfile1 ===", "1:3", "errormsg"]
+  call assert_equal('Xfile1', @%)
+  call assert_equal([0, 1, 4, 0], getpos('.'))
+
   enew | only
   set efm&
   call delete('Xfile1')


### PR DESCRIPTION
This relates to Issue #7145. If placed somewhere before %Z, then %v behaves like %c.

With the small change in quickfix.c, the problems described in the issue are solved.

Although all tests on Travis CI passed, I have a bad feeling with this PR. The change is more an "educated guess", as I do not really understand the machinery at work. There seem to be no tests for %v with multi-line massages in test\_quickfix.c.

