### PR TITLE
Increase max number of items in statusline

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7225,7 +7225,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	normal text.  Each status line item is of the form:
 	  %-0{minwid}.{maxwid}{item}
 	All fields except the {item} are optional.  A single percent sign can
-	be given as "%%".  Up to 80 items can be specified.  *E541*
+	be given as "%%".
 
 	When the option starts with "%!" then it is used as an expression,
 	evaluated and the result is used as the option value.  Example: >

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -3998,6 +3998,17 @@ free_titles(void)
 #endif // FEAT_TITLE
 
 #if defined(FEAT_STL_OPT) || defined(FEAT_GUI_TABLINE) || defined(PROTO)
+
+static size_t           stl_items_len = 80;
+static struct stl_item *stl_items = NULL;
+static int             *stl_groupitem = NULL;
+struct stl_hlrec       *stl_hltab = NULL;
+struct stl_hlrec       *stl_tabtab = NULL;
+
+size_t get_stl_items_len() {
+    return stl_items_len;
+}
+
 /*
  * Build a string from the status line items in "fmt".
  * Return length of string in screen cells.
@@ -4021,9 +4032,16 @@ build_stl_str_hl(
     int		use_sandbox UNUSED, // "fmt" was set insecurely, use sandbox
     int		fillchar,
     int		maxwidth,
-    struct stl_hlrec *hltab,	// return: HL attributes (can be NULL)
-    struct stl_hlrec *tabtab)	// return: tab page nrs (can be NULL)
+    struct stl_hlrec **hltab,	// return: HL attributes (can be NULL)
+    struct stl_hlrec **tabtab)	// return: tab page nrs (can be NULL)
 {
+    if (stl_items == NULL) {
+        stl_items = malloc(sizeof(struct stl_item) * stl_items_len);
+        stl_groupitem = malloc(sizeof(struct stl_item) * stl_items_len);
+        stl_hltab  = malloc(sizeof(struct stl_hlrec) * stl_items_len);
+        stl_tabtab = malloc(sizeof(struct stl_hlrec) * stl_items_len);
+    }
+
     linenr_T	lnum;
     size_t	len;
     char_u	*p;
@@ -4050,24 +4068,7 @@ build_stl_str_hl(
     int		curitem;
     int		group_end_userhl;
     int		group_start_userhl;
-    int		groupitem[STL_MAX_ITEM];
     int		groupdepth;
-    struct stl_item
-    {
-	char_u		*start;
-	int		minwid;
-	int		maxwid;
-	enum
-	{
-	    Normal,
-	    Empty,
-	    Group,
-	    Middle,
-	    Highlight,
-	    TabPage,
-	    Trunc
-	}		type;
-    }		item[STL_MAX_ITEM];
     int		minwid;
     int		maxwid;
     int		zeropad;
@@ -4143,16 +4144,13 @@ build_stl_str_hl(
     prevchar_isitem = FALSE;
     for (s = usefmt; *s; )
     {
-	if (curitem == STL_MAX_ITEM)
+	if (curitem == stl_items_len)
 	{
-	    // There are too many items.  Add the error code to the statusline
-	    // to give the user a hint about what went wrong.
-	    if (p + 6 < out + outlen)
-	    {
-		mch_memmove(p, " E541", (size_t)5);
-		p += 5;
-	    }
-	    break;
+	    stl_items_len = stl_items_len * 1.5;
+	    stl_items = vim_realloc(stl_items, sizeof(struct stl_item) * stl_items_len);
+	    stl_groupitem = vim_realloc(stl_items, sizeof(struct stl_item) * stl_items_len);
+	    stl_hltab  = vim_realloc(stl_hltab, sizeof(struct stl_hlrec) * stl_items_len);
+	    stl_tabtab = vim_realloc(stl_tabtab, sizeof(struct stl_hlrec) * stl_items_len);
 	}
 
 	if (*s != NUL && *s != '%')
@@ -4185,15 +4183,15 @@ build_stl_str_hl(
 	    s++;
 	    if (groupdepth > 0)
 		continue;
-	    item[curitem].type = Middle;
-	    item[curitem++].start = p;
+	    stl_items[curitem].type = Middle;
+	    stl_items[curitem++].start = p;
 	    continue;
 	}
 	if (*s == STL_TRUNCMARK)
 	{
 	    s++;
-	    item[curitem].type = Trunc;
-	    item[curitem++].start = p;
+	    stl_items[curitem].type = Trunc;
+	    stl_items[curitem++].start = p;
 	    continue;
 	}
 	if (*s == ')')
@@ -4203,83 +4201,83 @@ build_stl_str_hl(
 		continue;
 	    groupdepth--;
 
-	    t = item[groupitem[groupdepth]].start;
+	    t = stl_items[stl_groupitem[groupdepth]].start;
 	    *p = NUL;
 	    l = vim_strsize(t);
-	    if (curitem > groupitem[groupdepth] + 1
-		    && item[groupitem[groupdepth]].minwid == 0)
+	    if (curitem > stl_groupitem[groupdepth] + 1
+		    && stl_items[stl_groupitem[groupdepth]].minwid == 0)
 	    {
 		// remove group if all items are empty and highlight group
 		// doesn't change
 		group_start_userhl = group_end_userhl = 0;
-		for (n = groupitem[groupdepth] - 1; n >= 0; n--)
+		for (n = stl_groupitem[groupdepth] - 1; n >= 0; n--)
 		{
-		    if (item[n].type == Highlight)
+		    if (stl_items[n].type == Highlight)
 		    {
-			group_start_userhl = group_end_userhl = item[n].minwid;
+			group_start_userhl = group_end_userhl = stl_items[n].minwid;
 			break;
 		    }
 		}
-		for (n = groupitem[groupdepth] + 1; n < curitem; n++)
+		for (n = stl_groupitem[groupdepth] + 1; n < curitem; n++)
 		{
-		    if (item[n].type == Normal)
+		    if (stl_items[n].type == Normal)
 			break;
-		    if (item[n].type == Highlight)
-			group_end_userhl = item[n].minwid;
+		    if (stl_items[n].type == Highlight)
+			group_end_userhl = stl_items[n].minwid;
 		}
 		if (n == curitem && group_start_userhl == group_end_userhl)
 		{
 		    // empty group
 		    p = t;
 		    l = 0;
-		    for (n = groupitem[groupdepth] + 1; n < curitem; n++)
+		    for (n = stl_groupitem[groupdepth] + 1; n < curitem; n++)
 		    {
 			// do not use the highlighting from the removed group
-			if (item[n].type == Highlight)
-			    item[n].type = Empty;
+			if (stl_items[n].type == Highlight)
+			    stl_items[n].type = Empty;
 			// adjust the start position of TabPage to the next
 			// item position
-			if (item[n].type == TabPage)
-			    item[n].start = p;
+			if (stl_items[n].type == TabPage)
+			    stl_items[n].start = p;
 		    }
 		}
 	    }
-	    if (l > item[groupitem[groupdepth]].maxwid)
+	    if (l > stl_items[stl_groupitem[groupdepth]].maxwid)
 	    {
 		// truncate, remove n bytes of text at the start
 		if (has_mbyte)
 		{
 		    // Find the first character that should be included.
 		    n = 0;
-		    while (l >= item[groupitem[groupdepth]].maxwid)
+		    while (l >= stl_items[stl_groupitem[groupdepth]].maxwid)
 		    {
 			l -= ptr2cells(t + n);
 			n += (*mb_ptr2len)(t + n);
 		    }
 		}
 		else
-		    n = (long)(p - t) - item[groupitem[groupdepth]].maxwid + 1;
+		    n = (long)(p - t) - stl_items[stl_groupitem[groupdepth]].maxwid + 1;
 
 		*t = '<';
 		mch_memmove(t + 1, t + n, (size_t)(p - (t + n)));
 		p = p - n + 1;
 
 		// Fill up space left over by half a double-wide char.
-		while (++l < item[groupitem[groupdepth]].minwid)
+		while (++l < stl_items[stl_groupitem[groupdepth]].minwid)
 		    *p++ = fillchar;
 
 		// correct the start of the items for the truncation
-		for (l = groupitem[groupdepth] + 1; l < curitem; l++)
+		for (l = stl_groupitem[groupdepth] + 1; l < curitem; l++)
 		{
-		    item[l].start -= n;
-		    if (item[l].start < t)
-			item[l].start = t;
+		    stl_items[l].start -= n;
+		    if (stl_items[l].start < t)
+			stl_items[l].start = t;
 		}
 	    }
-	    else if (abs(item[groupitem[groupdepth]].minwid) > l)
+	    else if (abs(stl_items[stl_groupitem[groupdepth]].minwid) > l)
 	    {
 		// fill
-		n = item[groupitem[groupdepth]].minwid;
+		n = stl_items[stl_groupitem[groupdepth]].minwid;
 		if (n < 0)
 		{
 		    // fill by appending characters
@@ -4295,8 +4293,8 @@ build_stl_str_hl(
 		    if (p + l >= out + outlen)
 			l = (long)((out + outlen) - p - 1);
 		    p += l;
-		    for (n = groupitem[groupdepth] + 1; n < curitem; n++)
-			item[n].start += l;
+		    for (n = stl_groupitem[groupdepth] + 1; n < curitem; n++)
+			stl_items[n].start += l;
 		    for ( ; l > 0; l--)
 			*t++ = fillchar;
 		}
@@ -4325,9 +4323,9 @@ build_stl_str_hl(
 	}
 	if (*s == STL_USER_HL)
 	{
-	    item[curitem].type = Highlight;
-	    item[curitem].start = p;
-	    item[curitem].minwid = minwid > 9 ? 1 : minwid;
+	    stl_items[curitem].type = Highlight;
+	    stl_items[curitem].start = p;
+	    stl_items[curitem].minwid = minwid > 9 ? 1 : minwid;
 	    s++;
 	    curitem++;
 	    continue;
@@ -4341,9 +4339,9 @@ build_stl_str_hl(
 		    // %X ends the close label, go back to the previously
 		    // define tab label nr.
 		    for (n = curitem - 1; n >= 0; --n)
-			if (item[n].type == TabPage && item[n].minwid >= 0)
+			if (stl_items[n].type == TabPage && stl_items[n].minwid >= 0)
 			{
-			    minwid = item[n].minwid;
+			    minwid = stl_items[n].minwid;
 			    break;
 			}
 		}
@@ -4351,9 +4349,9 @@ build_stl_str_hl(
 		    // close nrs are stored as negative values
 		    minwid = - minwid;
 	    }
-	    item[curitem].type = TabPage;
-	    item[curitem].start = p;
-	    item[curitem].minwid = minwid;
+	    stl_items[curitem].type = TabPage;
+	    stl_items[curitem].start = p;
+	    stl_items[curitem].minwid = minwid;
 	    s++;
 	    curitem++;
 	    continue;
@@ -4371,11 +4369,11 @@ build_stl_str_hl(
 	minwid = (minwid > 50 ? 50 : minwid) * l;
 	if (*s == '(')
 	{
-	    groupitem[groupdepth++] = curitem;
-	    item[curitem].type = Group;
-	    item[curitem].start = p;
-	    item[curitem].minwid = minwid;
-	    item[curitem].maxwid = maxwid;
+	    stl_groupitem[groupdepth++] = curitem;
+	    stl_items[curitem].type = Group;
+	    stl_items[curitem].start = p;
+	    stl_items[curitem].minwid = minwid;
+	    stl_items[curitem].maxwid = maxwid;
 	    s++;
 	    curitem++;
 	    continue;
@@ -4628,9 +4626,9 @@ build_stl_str_hl(
 		++s;
 	    if (*s == '#')
 	    {
-		item[curitem].type = Highlight;
-		item[curitem].start = p;
-		item[curitem].minwid = -syn_namen2id(t, (int)(s - t));
+		stl_items[curitem].type = Highlight;
+		stl_items[curitem].start = p;
+		stl_items[curitem].minwid = -syn_namen2id(t, (int)(s - t));
 		curitem++;
 	    }
 	    if (*s != NUL)
@@ -4638,8 +4636,8 @@ build_stl_str_hl(
 	    continue;
 	}
 
-	item[curitem].start = p;
-	item[curitem].type = Normal;
+	stl_items[curitem].start = p;
+	stl_items[curitem].type = Normal;
 	if (str != NULL && *str)
 	{
 	    t = str;
@@ -4738,7 +4736,7 @@ build_stl_str_hl(
 	    p += STRLEN(p);
 	}
 	else
-	    item[curitem].type = Empty;
+	    stl_items[curitem].type = Empty;
 
 	if (opt == STL_VIM_EXPR)
 	    vim_free(str);
@@ -4765,16 +4763,16 @@ build_stl_str_hl(
 	else
 	{
 	    for ( ; l < itemcnt; l++)
-		if (item[l].type == Trunc)
+		if (stl_items[l].type == Trunc)
 		{
 		    // Truncate at %< item.
-		    s = item[l].start;
+		    s = stl_items[l].start;
 		    break;
 		}
 	    if (l == itemcnt)
 	    {
 		// No %< item, truncate first item.
-		s = item[0].start;
+		s = stl_items[0].start;
 		l = 0;
 	    }
 	}
@@ -4800,7 +4798,7 @@ build_stl_str_hl(
 	    else
 		s = out + maxwidth - 1;
 	    for (l = 0; l < itemcnt; l++)
-		if (item[l].start > s)
+		if (stl_items[l].start > s)
 		    break;
 	    itemcnt = l;
 	    *s++ = '>';
@@ -4834,10 +4832,10 @@ build_stl_str_hl(
 	    --n;	// count the '<'
 	    for (; l < itemcnt; l++)
 	    {
-		if (item[l].start - n >= s)
-		    item[l].start -= n;
+		if (stl_items[l].start - n >= s)
+		    stl_items[l].start -= n;
 		else
-		    item[l].start = s;
+		    stl_items[l].start = s;
 	    }
 	}
 	width = maxwidth;
@@ -4846,16 +4844,16 @@ build_stl_str_hl(
     {
 	// Apply STL_MIDDLE if any
 	for (l = 0; l < itemcnt; l++)
-	    if (item[l].type == Middle)
+	    if (stl_items[l].type == Middle)
 		break;
 	if (l < itemcnt)
 	{
-	    p = item[l].start + maxwidth - width;
-	    STRMOVE(p, item[l].start);
-	    for (s = item[l].start; s < p; s++)
+	    p = stl_items[l].start + maxwidth - width;
+	    STRMOVE(p, stl_items[l].start);
+	    for (s = stl_items[l].start; s < p; s++)
 		*s = fillchar;
 	    for (l++; l < itemcnt; l++)
-		item[l].start += maxwidth - width;
+		stl_items[l].start += maxwidth - width;
 	    width = maxwidth;
 	}
     }
@@ -4863,13 +4861,14 @@ build_stl_str_hl(
     // Store the info about highlighting.
     if (hltab != NULL)
     {
-	sp = hltab;
+	*hltab = stl_hltab;
+	sp = stl_hltab;
 	for (l = 0; l < itemcnt; l++)
 	{
-	    if (item[l].type == Highlight)
+	    if (stl_items[l].type == Highlight)
 	    {
-		sp->start = item[l].start;
-		sp->userhl = item[l].minwid;
+		sp->start = stl_items[l].start;
+		sp->userhl = stl_items[l].minwid;
 		sp++;
 	    }
 	}
@@ -4880,13 +4879,14 @@ build_stl_str_hl(
     // Store the info about tab pages labels.
     if (tabtab != NULL)
     {
-	sp = tabtab;
+	*tabtab = stl_tabtab;
+	sp = stl_tabtab;
 	for (l = 0; l < itemcnt; l++)
 	{
-	    if (item[l].type == TabPage)
+	    if (stl_items[l].type == TabPage)
 	    {
-		sp->start = item[l].start;
-		sp->userhl = item[l].minwid;
+		sp->start = stl_items[l].start;
+		sp->userhl = stl_items[l].minwid;
 		sp++;
 	    }
 	}

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4035,13 +4035,6 @@ build_stl_str_hl(
     struct stl_hlrec **hltab,	// return: HL attributes (can be NULL)
     struct stl_hlrec **tabtab)	// return: tab page nrs (can be NULL)
 {
-    if (stl_items == NULL) {
-        stl_items = malloc(sizeof(struct stl_item) * stl_items_len);
-        stl_groupitem = malloc(sizeof(struct stl_item) * stl_items_len);
-        stl_hltab  = malloc(sizeof(struct stl_hlrec) * stl_items_len);
-        stl_tabtab = malloc(sizeof(struct stl_hlrec) * stl_items_len);
-    }
-
     linenr_T	lnum;
     size_t	len;
     char_u	*p;
@@ -4081,6 +4074,13 @@ build_stl_str_hl(
     struct stl_hlrec *sp;
     int		save_must_redraw = must_redraw;
     int		save_redr_type = curwin->w_redr_type;
+
+    if (stl_items == NULL) {
+        stl_items = malloc(sizeof(struct stl_item) * stl_items_len);
+        stl_groupitem = malloc(sizeof(struct stl_item) * stl_items_len);
+        stl_hltab  = malloc(sizeof(struct stl_hlrec) * stl_items_len);
+        stl_tabtab = malloc(sizeof(struct stl_hlrec) * stl_items_len);
+    }
 
 #ifdef FEAT_EVAL
     /*

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4144,7 +4144,7 @@ build_stl_str_hl(
     prevchar_isitem = FALSE;
     for (s = usefmt; *s; )
     {
-	if (curitem == stl_items_len)
+	if (curitem == (int)stl_items_len)
 	{
 	    stl_items_len = stl_items_len * 1.5;
 	    stl_items = vim_realloc(stl_items, sizeof(struct stl_item) * stl_items_len);

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -575,7 +575,7 @@ check_stl_option(char_u *s)
     int		groupdepth = 0;
     static char errbuf[80];
 
-    while (*s && itemcnt < STL_MAX_ITEM)
+    while (*s && itemcnt < get_stl_items_len())
     {
 	// Check for valid keys after % sequences
 	while (*s && *s != '%')
@@ -627,7 +627,7 @@ check_stl_option(char_u *s)
 		return N_("E540: Unclosed expression sequence");
 	}
     }
-    if (itemcnt >= STL_MAX_ITEM)
+    if (itemcnt >= get_stl_items_len())
 	return N_("E541: too many items");
     if (groupdepth != 0)
 	return N_("E542: unbalanced groups");

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -571,11 +571,10 @@ valid_filetype(char_u *val)
     static char *
 check_stl_option(char_u *s)
 {
-    int		itemcnt = 0;
     int		groupdepth = 0;
     static char errbuf[80];
 
-    while (*s && itemcnt < get_stl_items_len())
+    while (*s)
     {
 	// Check for valid keys after % sequences
 	while (*s && *s != '%')
@@ -583,8 +582,6 @@ check_stl_option(char_u *s)
 	if (!*s)
 	    break;
 	s++;
-	if (*s != '%' && *s != ')')
-	    ++itemcnt;
 	if (*s == '%' || *s == STL_TRUNCMARK || *s == STL_MIDDLEMARK)
 	{
 	    s++;
@@ -627,8 +624,6 @@ check_stl_option(char_u *s)
 		return N_("E540: Unclosed expression sequence");
 	}
     }
-    if (itemcnt >= get_stl_items_len())
-	return N_("E541: too many items");
     if (groupdepth != 0)
 	return N_("E542: unbalanced groups");
     return NULL;

--- a/src/po/af.po
+++ b/src/po/af.po
@@ -3557,8 +3557,6 @@ msgstr "E538: Geen muisondersteuning nie"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Onvoltooide uitdrukkingreeks"
 
-msgid "E541: too many items"
-msgstr "E541: te veel items"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: ongebalanseerde groepe"

--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -4253,8 +4253,6 @@ msgstr "E538: No hi ha suport per a ratolí"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Seqüència d'expressions no tancada"
 
-msgid "E541: too many items"
-msgstr "E541: massa ítems"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: grups desequilibrats"

--- a/src/po/da.po
+++ b/src/po/da.po
@@ -4346,8 +4346,6 @@ msgstr "E538: Ingen understøttelse af mus"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Ulukket udtryk-sekvens"
 
-msgid "E541: too many items"
-msgstr "E541: for mange punkter"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: ubalancerede grupper"

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -4098,8 +4098,6 @@ msgstr "Für Option %s"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Nicht-geschlossene Ausdrucksfolge"
 
-msgid "E541: too many items"
-msgstr "E541: Zu viele Elemente"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Unausgewogene Gruppen"

--- a/src/po/en_GB.po
+++ b/src/po/en_GB.po
@@ -557,8 +557,6 @@ msgid "E536: comma required"
 msgstr "E536: Comma required"
 
 
-msgid "E541: too many items"
-msgstr "E541: Too many items"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Unbalanced groups"

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -4041,8 +4041,6 @@ msgstr "Por opcio %s"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: '}' mankas"
 
-msgid "E541: too many items"
-msgstr "E541: tro da elementoj"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: misekvilibraj grupoj"

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -4266,8 +4266,6 @@ msgstr "E538: No hay soporte para el ratón"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Secuencia de expresión sin cerrar"
 
-msgid "E541: too many items"
-msgstr "E541: Demasiados elementos"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Grupos sin equilibrar"

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -4297,8 +4297,6 @@ msgstr "E538: Hiirtä ei tueta"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Sulkematon lausekesarja"
 
-msgid "E541: too many items"
-msgstr "E541: liikaa kohteita"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: epätasapainoisia ryhmiä"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -4380,8 +4380,6 @@ msgstr "Pour l'option %s"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: '}' manquant"
 
-msgid "E541: too many items"
-msgstr "E541: trop d'éléments"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: parenthèses non équilibrées"

--- a/src/po/ga.po
+++ b/src/po/ga.po
@@ -4375,8 +4375,6 @@ msgstr "E538: Gan tacaíocht luiche"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Seicheamh gan dúnadh"
 
-msgid "E541: too many items"
-msgstr "E541: an iomarca míreanna"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: grúpaí neamhchothromaithe"

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -4136,8 +4136,6 @@ msgstr "E538: Manca supporto mouse"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Espressione non terminata"
 
-msgid "E541: too many items"
-msgstr "E541: troppi elementi"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: gruppi sbilanciati"

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -4142,8 +4142,6 @@ msgstr "オプション: %s"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 式が終了していません"
 
-msgid "E541: too many items"
-msgstr "E541: 要素が多過ぎます"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: グループが釣合いません"

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -4142,8 +4142,6 @@ msgstr "オプション: %s"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 式が終了していません"
 
-msgid "E541: too many items"
-msgstr "E541: 要素が多過ぎます"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: グループが釣合いません"

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -4142,8 +4142,6 @@ msgstr "オプション: %s"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 式が終了していません"
 
-msgid "E541: too many items"
-msgstr "E541: 要素が多過ぎます"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: グループが釣合いません"

--- a/src/po/ko.UTF-8.po
+++ b/src/po/ko.UTF-8.po
@@ -4282,8 +4282,6 @@ msgstr "E538: 마우스를 지원하지 않습니다"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 닫히지 않은 표현식 배열"
 
-msgid "E541: too many items"
-msgstr "E541: 너무 많은 항목"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: 균형이 안 잡힌 그룹"

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -4282,8 +4282,6 @@ msgstr "E538: 마우스를 지원하지 않습니다"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 닫히지 않은 표현식 배열"
 
-msgid "E541: too many items"
-msgstr "E541: 너무 많은 항목"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: 균형이 안 잡힌 그룹"

--- a/src/po/nb.po
+++ b/src/po/nb.po
@@ -4124,8 +4124,6 @@ msgstr "E538: Ingen støtte for mus"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Uttrykkssekvens som ikke er lukket"
 
-msgid "E541: too many items"
-msgstr "E541: For mange elementer"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Ubalanserte grupper"

--- a/src/po/nl.po
+++ b/src/po/nl.po
@@ -3715,8 +3715,6 @@ msgstr "E538: geen muisondersteuning"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: ongepaarde expressie-volgorde"
 
-msgid "E541: too many items"
-msgstr "E541: teveel items"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: ongepaarde groepen"

--- a/src/po/no.po
+++ b/src/po/no.po
@@ -4124,8 +4124,6 @@ msgstr "E538: Ingen støtte for mus"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Uttrykkssekvens som ikke er lukket"
 
-msgid "E541: too many items"
-msgstr "E541: For mange elementer"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Ubalanserte grupper"

--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -4308,8 +4308,6 @@ msgstr "E538: Brak wspomagania myszki"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Niedomknięty ciąg wyrażeń"
 
-msgid "E541: too many items"
-msgstr "E541: zbyt wiele elementów"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: niezbalansowane grupy"

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -4308,8 +4308,6 @@ msgstr "E538: Brak wspomagania myszki"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Niedomkniêty ci¹g wyra¿eñ"
 
-msgid "E541: too many items"
-msgstr "E541: zbyt wiele elementów"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: niezbalansowane grupy"

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -4308,8 +4308,6 @@ msgstr "E538: Brak wspomagania myszki"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Niedomkniêty ci±g wyra¿eñ"
 
-msgid "E541: too many items"
-msgstr "E541: zbyt wiele elementów"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: niezbalansowane grupy"

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -4308,8 +4308,6 @@ msgstr "E538: Não há suporte a mouse"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Expressão não terminada com '}'"
 
-msgid "E541: too many items"
-msgstr "E541: itens demais"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: parênteses desequilibrados"

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -4249,8 +4249,6 @@ msgstr "Для опции %s"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Незакрытая последовательность выражения"
 
-msgid "E541: too many items"
-msgstr "E541: Слишком много элементов"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Несбалансированные группы"

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -4249,8 +4249,6 @@ msgstr "Для опции %s"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Незакрытая последовательность выражения"
 
-msgid "E541: too many items"
-msgstr "E541: Слишком много элементов"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Несбалансированные группы"

--- a/src/po/sk.cp1250.po
+++ b/src/po/sk.cp1250.po
@@ -3897,8 +3897,6 @@ msgstr "E538: Bez podpory myši"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Neuzatvorené zoskupenie výrazov"
 
-msgid "E541: too many items"
-msgstr "E541: príliš mnoho položiek"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: nevyvážené skupiny"

--- a/src/po/sk.po
+++ b/src/po/sk.po
@@ -3897,8 +3897,6 @@ msgstr "E538: Bez podpory my¹i"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Neuzatvorené zoskupenie výrazov"
 
-msgid "E541: too many items"
-msgstr "E541: príli¹ mnoho polo¾iek"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: nevyvá¾ené skupiny"

--- a/src/po/sr.po
+++ b/src/po/sr.po
@@ -4205,8 +4205,6 @@ msgstr "За опцију %s"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Низ израза није затворен"
 
-msgid "E541: too many items"
-msgstr "E541: превише ставки"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: неуравнотежене групе"

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -4103,8 +4103,6 @@ msgstr "E538: Inget musstöd"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Ostängd uttryckssekvens"
 
-msgid "E541: too many items"
-msgstr "E541: för många föremål"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: obalanserade grupper"

--- a/src/po/tr.po
+++ b/src/po/tr.po
@@ -3990,8 +3990,6 @@ msgstr "%s seçeneği için"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Kapatılmamış ifade sıralaması"
 
-msgid "E541: too many items"
-msgstr "E541: Çok fazla öge"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Dengelenmemiş gruplar"

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -4458,8 +4458,6 @@ msgstr "E538: Миша не підтримується"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Послідовність виразів не завершено"
 
-msgid "E541: too many items"
-msgstr "E541: Забагато елементів"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Групи не збалансовано"

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -4458,8 +4458,6 @@ msgstr "E538: Миша не підтримується"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Послідовність виразів не завершено"
 
-msgid "E541: too many items"
-msgstr "E541: Забагато елементів"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: Групи не збалансовано"

--- a/src/po/vi.po
+++ b/src/po/vi.po
@@ -3602,8 +3602,6 @@ msgstr "E538: Chuột không được hỗ trợ"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Dãy các biểu thức không đóng"
 
-msgid "E541: too many items"
-msgstr "E541: quá nhiều phần tử"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: các nhóm không cân bằng"

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -4028,8 +4028,6 @@ msgstr "E538: 不支持鼠标"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 没有结束的表达式序列"
 
-msgid "E541: too many items"
-msgstr "E541: 项目过多"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: 错乱的组"

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -4028,8 +4028,6 @@ msgstr "E538: 不支持鼠标"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 没有结束的表达式序列"
 
-msgid "E541: too many items"
-msgstr "E541: 项目过多"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: 错乱的组"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -4028,8 +4028,6 @@ msgstr "E538: 不支持鼠标"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 没有结束的表达式序列"
 
-msgid "E541: too many items"
-msgstr "E541: 项目过多"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: 错乱的组"

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -3587,8 +3587,6 @@ msgstr "E538: 不支援滑鼠"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 沒有結束的運算式: "
 
-msgid "E541: too many items"
-msgstr "E541: 太多項目"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: 不對稱的 group"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -3580,8 +3580,6 @@ msgstr "E538: 不支援滑鼠"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: 沒有結束的運算式: "
 
-msgid "E541: too many items"
-msgstr "E541: 太多項目"
 
 msgid "E542: unbalanced groups"
 msgstr "E542: 不對稱的 group"

--- a/src/proto/buffer.pro
+++ b/src/proto/buffer.pro
@@ -47,7 +47,7 @@ void col_print(char_u *buf, size_t buflen, int col, int vcol);
 void maketitle(void);
 void resettitle(void);
 void free_titles(void);
-int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use_sandbox, int fillchar, int maxwidth, struct stl_hlrec *hltab, struct stl_hlrec *tabtab);
+int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use_sandbox, int fillchar, int maxwidth, struct stl_hlrec **hltab, struct stl_hlrec **tabtab);
 void get_rel_pos(win_T *wp, char_u *buf, int buflen);
 char_u *fix_fname(char_u *fname);
 void fname_expand(buf_T *buf, char_u **ffname, char_u **sfname);

--- a/src/screen.c
+++ b/src/screen.c
@@ -1196,8 +1196,8 @@ win_redr_custom(
     char_u	buf[MAXPATHL];
     char_u	*stl;
     char_u	*p;
-    struct	stl_hlrec hltab[STL_MAX_ITEM];
-    struct	stl_hlrec tabtab[STL_MAX_ITEM];
+    struct	stl_hlrec *hltab;
+    struct	stl_hlrec *tabtab;
     int		use_sandbox = FALSE;
     win_T	*ewp;
     int		p_crb_save;
@@ -1287,7 +1287,7 @@ win_redr_custom(
     stl = vim_strsave(stl);
     width = build_stl_str_hl(ewp, buf, sizeof(buf),
 				stl, use_sandbox,
-				fillchar, maxwidth, hltab, tabtab);
+				fillchar, maxwidth, &hltab, &tabtab);
     vim_free(stl);
     ewp->w_p_crb = p_crb_save;
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -1222,6 +1222,25 @@ struct stl_hlrec
     int		userhl;		// 0: no HL, 1-9: User HL, < 0 for syn ID
 };
 
+/*
+ * Used for building in the status line.
+ */
+struct stl_item {
+    char_u	*start;
+    int		minwid;
+    int		maxwid;
+    enum
+    {
+        Normal,
+        Empty,
+        Group,
+        Middle,
+        Highlight,
+        TabPage,
+        Trunc
+    }           type;
+};
+
 
 /*
  * Syntax items - usually buffer-specific.

--- a/src/structs.h
+++ b/src/structs.h
@@ -1216,30 +1216,30 @@ struct mapblock
 /*
  * Used for highlighting in the status line.
  */
-struct stl_hlrec
+typedef struct stl_hlrec
 {
     char_u	*start;
     int		userhl;		// 0: no HL, 1-9: User HL, < 0 for syn ID
-};
+} stl_hlrec_T;
 
 /*
  * Used for building in the status line.
  */
-struct stl_item {
-    char_u	*start;
-    int		minwid;
-    int		maxwid;
-    enum
-    {
-        Normal,
-        Empty,
-        Group,
-        Middle,
-        Highlight,
-        TabPage,
-        Trunc
-    }           type;
-};
+typedef struct stl_item
+{
+  char_u 	*stl_start;
+  int 		stl_minwid;
+  int 		stl_maxwid;
+  enum {
+      Normal,
+      Empty,
+      Group,
+      Middle,
+      Highlight,
+      TabPage,
+      Trunc
+  }		stl_type;
+} stl_item_T;
 
 
 /*

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -372,7 +372,6 @@ func Test_set_errors()
   call assert_fails('set commentstring=x', 'E537:')
   call assert_fails('set complete=x', 'E539:')
   call assert_fails('set statusline=%{', 'E540:')
-  call assert_fails('set statusline=' . repeat("%p", 81), 'E541:')
   call assert_fails('set statusline=%(', 'E542:')
   if has('cursorshape')
     " This invalid value for 'guicursor' used to cause Vim to crash.

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -376,6 +376,9 @@ func Test_statusline()
   delfunc GetNested
   delfunc GetStatusLine
 
+  " Test statusline works with 80+ items
+  let &statusline = join(map(range(200), {i-> '%#' . (i % 2 == 0 ? 'Normal' : 'TabLineSel' ) . '#' . i}), '')
+
   " Check statusline in current and non-current window
   " with the 'fillchars' option.
   set fillchars=stl:^,stlnc:=,vert:\|,fold:-,diff:-

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -377,7 +377,19 @@ func Test_statusline()
   delfunc GetStatusLine
 
   " Test statusline works with 80+ items
-  let &statusline = join(map(range(200), {i-> '%#' . (i % 2 == 0 ? 'Normal' : 'TabLineSel' ) . '#' . i}), '')
+  function! StatusLabel()
+    redrawstatus
+    return '[label]'	
+  endfunc
+  let statusline = '%{StatusLabel()}'
+  for i in range(150)
+    let statusline .= '%#TabLine' . (i % 2 == 0 ? 'Fill' : 'Sel') . '#' . string(i)[0]
+  endfor
+  let &statusline = statusline
+  redrawstatus
+  set statusline&
+  delfunc StatusLabel
+
 
   " Check statusline in current and non-current window
   " with the 'fillchars' option.

--- a/src/vim.h
+++ b/src/vim.h
@@ -1698,7 +1698,6 @@ typedef unsigned short disptick_T;	// display tick type
 #endif
 
 #define SHOWCMD_COLS 10			// columns needed by shown command
-#define STL_MAX_ITEM 300		// max nr of %<flag> in statusline
 
 typedef void	    *vim_acl_T;		// dummy to pass an ACL to a function
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -1698,7 +1698,7 @@ typedef unsigned short disptick_T;	// display tick type
 #endif
 
 #define SHOWCMD_COLS 10			// columns needed by shown command
-#define STL_MAX_ITEM 80			// max nr of %<flag> in statusline
+#define STL_MAX_ITEM 300		// max nr of %<flag> in statusline
 
 typedef void	    *vim_acl_T;		// dummy to pass an ACL to a function
 


### PR DESCRIPTION
Vim throws `E541` when there are too many items in the tabline or statusline, which happens often when using tabline or statusline plugins. This PR increase the number of items from 80 to 300. I have chosen 300 because it seems like a fine number to me, isn't exagerated in terms of memory, and will probably satisfy the needs of everyone. Also because I want to stop seing that error therefore an arbitrary number is better than the current *status quo*.

Example: https://github.com/itchyny/lightline.vim/issues/220