### PR TITLE
GHA: Disable swapfile on filetype tests

### DIFF
--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -549,6 +549,7 @@ let s:filename_case_checks = {
     \ }
 
 func CheckItems(checks)
+  set noswapfile
   for [ft, names] in items(a:checks)
     for i in range(0, len(names) - 1)
       new
@@ -565,6 +566,7 @@ func CheckItems(checks)
       bwipe!
     endfor
   endfor
+  set swapfile&
 endfunc
 
 func Test_filetype_detection()


### PR DESCRIPTION
Test_filetype_detection() often fails on GHA. E.g.:
https://github.com/vim/vim/pull/7182/checks?check_run_id=1290747127

	Found errors in Test_filetype_detection():
	command line..script D:/a/vim/vim/src2/testdir/runtest.vim[461]..function RunTheTest[39]..Test_filetype_detection[2]..CheckItems[5]..SwapExists Autocommands for "*"..function HandleSwapExists line 10: Unexpected swap file: C:\Users\RUNNER~1\AppData\Local\Temp/file.cfg.swp

Disable swapfile to work around this.
(Not sure why this test is flaky on GHA, though.)