### PR TITLE
Fixed valgrind uninitialized value in f_term_dumpwrite()

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -351,8 +351,6 @@ work.
 Using "au!" after "filetype on" is a bit slow.  Can the matching of
 autocommands be made faster?  (#7056)
 
-Valgrind warns for uninitialized values in f_term_dumpwrite().
-
 Add the <=> (spaceship) operator and "cond ?< expr ?= expr ?> expr"
     replace this:
 	let left = GetLeftFunc()

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -4718,6 +4718,7 @@ f_term_dumpwrite(typval_T *argvars, typval_T *rettv UNUSED)
 	    {
 		int c = cell.chars[i];
 		int pc = prev_cell.chars[i];
+		int should_break = c == NUL || pc == NUL;
 
 		// For the first character NUL is the same as space.
 		if (i == 0)
@@ -4727,7 +4728,7 @@ f_term_dumpwrite(typval_T *argvars, typval_T *rettv UNUSED)
 		}
 		if (c != pc)
 		    same_chars = FALSE;
-		if (c == NUL || pc == NUL)
+		if (should_break)
 		    break;
 	    }
 	    same_attr = vtermAttr2hl(cell.attrs)


### PR DESCRIPTION
This PR fixes this item in runtime/todo.txt:
```
Valgrind warns for uninitialized values in f_term_dumpwrite().
```

Here is the valgrind warning when running e.g. `make test_statusline`:
```
==22825== Memcheck, a memory error detector
==22825== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==22825== Using Valgrind-3.17.0.GIT and LibVEX; rerun with -h for copyright info
==22825== Command: ../vim -f -u unix.vim -U NONE --noplugin --not-a-term -S runtest.vim test_statusline.vim --cmd au\ SwapExists\ *\ let\ v:swapchoice\ =\ "e"
==22825== Parent PID: 22824
==22825== 
==22825== Conditional jump or move depends on uninitialised value(s)
==22825==    at 0x2E6F1A: f_term_dumpwrite (terminal.c:4737)
==22825==    by 0x19524D: call_internal_func (evalfunc.c:1884)
==22825==    by 0x3032F3: call_func (userfunc.c:2219)
==22825==    by 0x30363B: get_func_tv (userfunc.c:691)
==22825==    by 0x306EC8: ex_call (userfunc.c:4136)
==22825==    by 0x1B3BC7: do_one_cmd (ex_docmd.c:2543)
==22825==    by 0x1B4EF2: do_cmdline (ex_docmd.c:985)
==22825==    by 0x301C45: call_user_func (userfunc.c:1602)
==22825==    by 0x30250E: call_user_func_check (userfunc.c:1743)
==22825==    by 0x302FCB: call_func (userfunc.c:2201)
==22825==    by 0x30363B: get_func_tv (userfunc.c:691)
==22825==    by 0x306EC8: ex_call (userfunc.c:4136)
==22825==    by 0x1B3BC7: do_one_cmd (ex_docmd.c:2543)
==22825==    by 0x1B4EF2: do_cmdline (ex_docmd.c:985)
==22825==    by 0x301C45: call_user_func (userfunc.c:1602)
==22825==    by 0x30250E: call_user_func_check (userfunc.c:1743)
==22825==    by 0x302FCB: call_func (userfunc.c:2201)
==22825==    by 0x30363B: get_func_tv (userfunc.c:691)
==22825==    by 0x306EC8: ex_call (userfunc.c:4136)
==22825==    by 0x1B3BC7: do_one_cmd (ex_docmd.c:2543)
==22825==    by 0x1B4EF2: do_cmdline (ex_docmd.c:985)
==22825==    by 0x18ABAD: ex_execute (eval.c:5916)
==22825==    by 0x1B3BC7: do_one_cmd (ex_docmd.c:2543)
==22825==    by 0x1B4EF2: do_cmdline (ex_docmd.c:985)
==22825==    by 0x301C45: call_user_func (userfunc.c:1602)
==22825==  Uninitialised value was created by a stack allocation
==22825==    at 0x2E6BB4: f_term_dumpwrite (terminal.c:4636)
```

Code in terminal.c:
```
  4714     if (vterm_screen_get_cell(screen, pos, &cell) == 0)
  4715         clear_cell(&cell);
  4716
  4717     for (i = 0; i < VTERM_MAX_CHARS_PER_CELL; ++i)
  4718     {
  4719         int c = cell.chars[i];
  4720         int pc = prev_cell.chars[i];
  4721
  4722         // For the first character NUL is the same as space.
  4723         if (i == 0)
  4724         {
  4725             c = (c == NUL) ? ' ' : c;
  4726             pc = (pc == NUL) ? ' ' : pc;
  4727         }
  4728         if (c != pc)
  4729             same_chars = FALSE;
  4730         if (c == NUL || pc == NUL)
  4731             break;
  4732     }
  4733     same_attr = vtermAttr2hl(cell.attrs)
  4734                                        == vtermAttr2hl(prev_cell.attrs)
  4735                 && vterm_color_is_equal(&cell.fg, &prev_cell.fg)
  4736                 && vterm_color_is_equal(&cell.bg, &prev_cell.bg);
!!4737     if (same_chars && cell.width == prev_cell.width && same_attr
  4738                                                      && !is_cursor_pos)
```

I debugged it and found why it happens.

Call to `vterm_screen_get_cell(screen, pos, &cell)` at line 4714 may not
initialize the entire array `cell.chars[...]` when the first item is `NUL`.

Line 4730 is meant to break the loop when `c` is `NUL` to avoid looking
at uninitialized items in cell.chars[...]. However, line 4725 has
replaced `NUL` with a space ' ', so  line 4730 does not break the loop
as expected.

The bug can cause tests that make screen dumps to be flaky.