### PR TITLE
make myplugin#myfunction() work in vimrc even when myplugin is a package

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -2294,7 +2294,7 @@ script_autoload(
 
 	// Try loading the package from $VIMRUNTIME/autoload/<name>.vim
 	// Use "ret_sid" to avoid loading the same script again.
-	if (source_in_path(p_rtp, scriptname, 0, &ret_sid) == OK)
+	if (source_in_path(p_rtp, scriptname, DIP_START, &ret_sid) == OK)
 	    ret = TRUE;
     }
 

--- a/src/testdir/test_packadd.vim
+++ b/src/testdir/test_packadd.vim
@@ -246,6 +246,17 @@ func Test_packloadall()
   call assert_equal(4321, g:plugin_bar_number)
 endfunc
 
+func Test_start_autoload()
+  " plugin foo with an autoload directory
+  let autodir = &packpath . '/pack/mine/start/foo/autoload'
+  call mkdir(autodir, 'p')
+  call writefile(['func! baz#test()',
+	\ '  return 1666',
+	\ 'endfunc'], autodir . '/baz.vim')
+
+  call assert_equal(1666, baz#test())
+endfunc
+
 func Test_helptags()
   let docdir1 = &packpath . '/pack/mine/start/foo/doc'
   let docdir2 = &packpath . '/pack/mine/start/bar/doc'


### PR DESCRIPTION
Situation:

Create the following file `/home/USER/.vim/pack/foo/start/bar/autoload/testpak.vim` (or elsewhere on `&packpath`):

```
function testpak#testfun()
  return -10
endfunction
```
and somewhere in `vimrc` do

```
call testpak#testfun()
```


problem: autoloading functions from functions before VimEnter does not work
solution: make it work

NB: you can use `packadd! testpak` of course. But I don't think "autoload" means anything if it is not automatic anymore. Then you could just as well make it a single-file plugin already and not use autoload ever again.

If needed, I can make a test.