### PR TITLE
Fix access beyond end of string when SmcOpenConnection() truncates error message

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -8068,10 +8068,11 @@ xsmp_init(void)
 	    errorstring);
     if (xsmp.smcconn == NULL)
     {
-	char errorreport[132];
-
 	if (p_verbose > 0)
 	{
+	    char errorreport[132];
+
+	    errorstring[sizeof(errorstring) - 1] = NUL;
 	    vim_snprintf(errorreport, sizeof(errorreport),
 			 _("XSMP SmcOpenConnection failed: %s"), errorstring);
 	    verb_msg(errorreport);


### PR DESCRIPTION
Running `make test_startup` with valgrind, I see this error:
```
==10232== Memcheck, a memory error detector
==10232== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10232== Using Valgrind-3.17.0.GIT and LibVEX; rerun with -h for copyright info
==10232== Command: ../vim -f -u NONE --not-a-term --clean -V2Xverbosefile -c set\ verbose?\ verbosefile? -cq
==10232== Parent PID: 10231
==10232== 
==10232== Conditional jump or move depends on uninitialised value(s)
==10232==    at 0x4C332A8: strlen (vg_replace_strmem.c:459)
==10232==    by 0x366557: vim_vsnprintf_typval (message.c:4487)
==10232==    by 0x367DD1: vim_vsnprintf (message.c:4238)
==10232==    by 0x367DD1: vim_snprintf (message.c:4226)
==10232==    by 0x252CF2: xsmp_init (os_unix.c:8075)
==10232==    by 0x13F1D3: main (main.c:323)
==10232==  Uninitialised value was created by a stack allocation
==10232==    at 0x252B72: xsmp_init (os_unix.c:8023)
```
Error happens in `Test_V_file_arg()`. Apparently, function...
```
extern SmcConn SmcOpenConnection (
    char *              /* networkIdsList */,
    SmPointer           /* context */,
    int                 /* xsmpMajorRev */,
    int                 /* xsmpMinorRev */,
    unsigned long       /* mask */,
    SmcCallbacks *      /* callbacks */,
    const char *        /* previousId */,
    char **             /* clientIdRet */,
    int                 /* errorLength */,
    char *              /* errorStringRet */
);
```
... called in `xsmp_init()` in `os_unix.c:8057` does not `NUL`
terminate the `errorStringRet` string argument when the error
string is truncated to `errorLength` bytes. I did not find
accurate documentation about its behavior when truncation
happens, but the PR fixes the bug anyway.