### PR TITLE
Fixed crash in make_filter_cmd() after out-of-memory

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1543,6 +1543,9 @@ make_filter_cmd(
     int		is_fish_shell;
     char_u	*shell_name = get_isolated_shell_name();
 
+    if (shell_name == NULL)
+	return NULL;
+
     // Account for fish's different syntax for subshells
     is_fish_shell = (fnamecmp(shell_name, "fish") == 0);
     vim_free(shell_name);


### PR DESCRIPTION
This PR fixes a crash when running out of memory.

Code in `ex_cmds.c` in `make_filter_cmd()`:
```
!!1544     char_u      *shell_name = get_isolated_shell_name();                   
  1545 
  1546     // Account for fish's different syntax for subshells
!!1547     is_fish_shell = (fnamecmp(shell_name, "fish") == 0);
```
`get_isolated_shell_name()` may return `NULL` at line 1544 when
running out of memory.  `shell_name` is thus `NULL` and is
dereferenced at line 1547 causing a segfault.

Bug was found by making `lalloc()` returns NULL randomly once in a while.

