### PR TITLE
Fix variable completion in cmdwin

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -1981,7 +1981,13 @@ get_user_var_name(expand_T *xp, int idx)
     }
 
     // b: variables
-    ht = &curbuf->b_vars->dv_hashtab;
+    ht =
+#ifdef FEAT_CMDWIN
+	// In cmdwin, the alternative buffer should be used.
+	(cmdwin_type != 0 && get_cmdline_type() == NUL) ?
+	&prevwin->w_buffer->b_vars->dv_hashtab :
+#endif
+	&curbuf->b_vars->dv_hashtab;
     if (bdone < ht->ht_used)
     {
 	if (bdone++ == 0)
@@ -1994,7 +2000,13 @@ get_user_var_name(expand_T *xp, int idx)
     }
 
     // w: variables
-    ht = &curwin->w_vars->dv_hashtab;
+    ht =
+#ifdef FEAT_CMDWIN
+	// In cmdwin, the alternative window should be used.
+	(cmdwin_type != 0 && get_cmdline_type() == NUL) ?
+	&prevwin->w_vars->dv_hashtab :
+#endif
+	&curwin->w_vars->dv_hashtab;
     if (wdone < ht->ht_used)
     {
 	if (wdone++ == 0)

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -346,7 +346,10 @@ func Test_compl_in_cmdwin()
   set wildmenu wildchar=<Tab>
   com! -nargs=1 -complete=command GetInput let input = <q-args>
   com! -buffer TestCommand echo 'TestCommand'
+  let w:test_winvar = 'winvar'
+  let b:test_bufvar = 'bufvar'
 
+  " User-defined commands
   let input = ''
   call feedkeys("q:iGetInput T\<C-x>\<C-v>\<CR>", 'tx!')
   call assert_equal('TestCommand', input)
@@ -355,8 +358,30 @@ func Test_compl_in_cmdwin()
   call feedkeys("q::GetInput T\<Tab>\<CR>:q\<CR>", 'tx!')
   call assert_equal('T', input)
 
+
+  com! -nargs=1 -complete=var GetInput let input = <q-args>
+  " Window-local variables
+  let input = ''
+  call feedkeys("q:iGetInput w:test_\<C-x>\<C-v>\<CR>", 'tx!')
+  call assert_equal('w:test_winvar', input)
+
+  let input = ''
+  call feedkeys("q::GetInput w:test_\<Tab>\<CR>:q\<CR>", 'tx!')
+  call assert_equal('w:test_', input)
+
+  " Buffer-local variables
+  let input = ''
+  call feedkeys("q:iGetInput b:test_\<C-x>\<C-v>\<CR>", 'tx!')
+  call assert_equal('b:test_bufvar', input)
+
+  let input = ''
+  call feedkeys("q::GetInput b:test_\<Tab>\<CR>:q\<CR>", 'tx!')
+  call assert_equal('b:test_', input)
+
   delcom TestCommand
   delcom GetInput
+  unlet w:test_winvar
+  unlet b:test_bufvar
   set wildmenu& wildchar&
 endfunc
 


### PR DESCRIPTION
**Problem**
Cannot complete buffer-local/window-local variables in cmdwin.

**To reproduce**
 - Open Vim with `vim -u NONE`
 - Declare buffer-local and window-local variables:
```vim
let b:bufvar = 'bufvar'
let w:winvar = 'winvar'
```
 - Open cmdwin and do 
ins-completion with `<C-x><C-v>`


<img width="573" alt="screenshot1" src="https://user-images.githubusercontent.com/24771416/97099765-04889280-16d0-11eb-967c-efabec8eb8de.png">
<img width="573" alt="screenshot2" src="https://user-images.githubusercontent.com/24771416/97099747-e0c54c80-16cf-11eb-90c5-ad26c9803977.png">

**Solution**
Use the alternative buffer/window to get completion items.
