### PR TITLE
Remove dead code

### DIFF
--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -268,69 +268,6 @@ pum_display(
 		if (pum_width < p_pw)
 		    pum_width = p_pw;
 	    }
-	    else if (((cursor_col > p_pw || cursor_col > max_width)
-#ifdef FEAT_RIGHTLEFT
-			&& !curwin->w_p_rl)
-		|| (curwin->w_p_rl && (cursor_col < Columns - p_pw
-			|| cursor_col < Columns - max_width)
-#endif
-		    ))
-	    {
-		// align pum edge with "cursor_col"
-#ifdef FEAT_RIGHTLEFT
-		if (curwin->w_p_rl
-			&& W_ENDCOL(curwin) < max_width + pum_scrollbar + 1)
-		{
-		    pum_col = cursor_col + max_width + pum_scrollbar + 1;
-		    if (pum_col >= Columns)
-			pum_col = Columns - 1;
-		}
-		else if (!curwin->w_p_rl)
-#endif
-		{
-		    if (curwin->w_wincol > Columns - max_width - pum_scrollbar
-							  && max_width <= p_pw)
-		    {
-			// use full width to end of the screen
-			pum_col = Columns - max_width - pum_scrollbar;
-			if (pum_col < 0)
-			    pum_col = 0;
-		    }
-		}
-
-#ifdef FEAT_RIGHTLEFT
-		if (curwin->w_p_rl)
-		    pum_width = pum_col - pum_scrollbar + 1;
-		else
-#endif
-		    pum_width = Columns - pum_col - pum_scrollbar;
-
-		if (pum_width < p_pw)
-		{
-		    pum_width = p_pw;
-#ifdef FEAT_RIGHTLEFT
-		    if (curwin->w_p_rl)
-		    {
-			if (pum_width > pum_col)
-			    pum_width = pum_col;
-		    }
-		    else
-#endif
-		    {
-			if (pum_width >= Columns - pum_col)
-			    pum_width = Columns - pum_col - 1;
-		    }
-		}
-		else if (pum_width > max_width + pum_kind_width
-							  + pum_extra_width + 1
-			    && pum_width > p_pw)
-		{
-		    pum_width = max_width + pum_kind_width
-							 + pum_extra_width + 1;
-		    if (pum_width < p_pw)
-			pum_width = p_pw;
-		}
-	    }
 
 	}
 	else if (Columns < def_width)


### PR DESCRIPTION
https://github.com/vim/vim/blob/4882d983397057ea91c584c5a54aaccf15016d18/src/popupmenu.c#L228

∴ curwin->w_wincol <= cursor_col ①

https://github.com/vim/vim/blob/4882d983397057ea91c584c5a54aaccf15016d18/src/popupmenu.c#L242-L243

https://github.com/vim/vim/blob/4882d983397057ea91c584c5a54aaccf15016d18/src/popupmenu.c#L291-L292

∴ Columns - p_pw <= Columns - max_width
∴ cursor_col < Columns - max_width ②

from ① and ②
curwin->w_wincol <= cursor_col < Columns - max_width

pum_scrollbar is 0 or 1
∴ curwin->w_wincol <= cursor_col <= Columns - max_width - pum_scrollbar

For these reasons, the conditions in lines 291 to 292 do not become true. Therefore, since `pum_col` has not been changed, there is no need to execute line 302 and beyond.

Therefore, I think the entire `else if` clause can be removed, am I doing something wrong?