### PR TITLE
make ceil-rounding of the char-box height less aggressive

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4726,9 +4726,9 @@ gui_mch_adjust_charheight(void)
 
     pango_font_metrics_unref(metrics);
 
-    // Round up, but not when the value is very close (e.g. 15.0009).
-    gui.char_height = (ascent + descent + PANGO_SCALE - 3) / PANGO_SCALE
-								+ p_linespace;
+    // Round. But round up not at 1/2 pixel, but already at 1/16 pixel.
+    gui.char_height = (ascent + descent + PANGO_SCALE - PANGO_SCALE / 16 )
+	/ PANGO_SCALE + p_linespace;
     // LINTED: avoid warning: bitwise operation on signed value
     gui.char_ascent = PANGO_PIXELS(ascent + p_linespace * PANGO_SCALE / 2);
 


### PR DESCRIPTION
Turns out, the 3‰ tolerance added in #6168 for ceil-rounding is too little.
I did some calculations about possible rounding errors:
Since OpenType fonts use a typical em-size of 2048 and pango uses 1024 units per pixel, the rounding error in each of ascent and descent may be up to half the size of the font in pixels, adding up errors in ascent and descent, we need to expect rounding errors up to the font size in pixels.

I would suggest increasing the tolerance margin to 64. This would be safe up to a font size of about 64 pixels. Larger bitmap fonts are unlikely and an additional line spacing of one pixel won't be easily noticed. On the other hand, for non-bitmap fonts we might miss out 6% of a single pixel. This seems to be a sensible trade-off to me.