### PR TITLE
Fixed read beyond end of string with incomplete backtick (issue #7204)

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -4695,6 +4695,8 @@ separate_nextcmd(exarg_T *eap)
 	else if (p[0] == '`' && p[1] == '=' && (eap->argt & EX_XFILE))
 	{
 	    p += 2;
+	    if (*p == NUL)
+		break;
 	    (void)skip_expr(&p, NULL);
 	}
 #endif

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1287,6 +1287,22 @@ func Test_cmd_backtick()
   %argd
 endfunc
 
+" Test for incomplete backtick expression.
+" This used to access invalid memory with C locale.
+func Test_cmd_backtick_incomplete()
+  let encoding_save = &encoding
+  new
+
+  let encodings = ['latin1', 'utf8']
+  for e in encodings
+    exe 'set encoding=' . e
+    call assert_fails('r`=', 'E484:')
+  endfor
+
+  let &encoding = encoding_save
+  bwipe!
+endfunc
+
 " Test for the :! command
 func Test_cmd_bang()
   CheckUnix


### PR DESCRIPTION
This PR fixes issue #7204:

Invalid memory access when doing the following Ex command with C locale:
```
r`=
```