### PR TITLE
Fix Test_python3_errors test failure with Python 3.9

### DIFF
--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -3815,7 +3815,16 @@ func Test_python3_errors()
     vim.current.xxx = True:(<class 'AttributeError'>, AttributeError('xxx',))
   END
 
-  call assert_equal(expected, getline(2, '$'))
+  let actual = getline(2, '$')
+  let n_expected = len(expected)
+  let n_actual = len(actual)
+
+  call assert_equal(n_expected, n_actual)
+  let n = n_expected <= n_actual ? n_expected : n_actual
+  " Compare line by line so the errors are easier to understand
+  for i in range(n)
+    call assert_equal(expected[i], actual[i])
+  endfor
   close!
 endfunc
 

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -23,6 +23,7 @@ func Test_AAA_python3_setup()
 
     py33_type_error_pattern = re.compile('^__call__\(\) takes (\d+) positional argument but (\d+) were given$')
     py37_exception_repr = re.compile(r'([^\(\),])(\)+)$')
+    py39_type_error_pattern = re.compile('\w+\.([^(]+\(\) takes)')
 
     def emsg(ei):
       return ei[0].__name__ + ':' + repr(ei[1].args)
@@ -56,6 +57,8 @@ func Test_AAA_python3_setup()
                         oldmsg2 = '''"Can't convert 'int' object to str implicitly"'''
                         if msg.find(newmsg2) > -1:
                             msg = msg.replace(newmsg2, oldmsg2)
+                        # Python 3.9 reports errors like "vim.command() takes ..." instead of "command() takes ..."
+                        msg = py39_type_error_pattern.sub(r'\1', msg)
                 elif sys.version_info >= (3, 5) and e.__class__ is ValueError and str(e) == 'embedded null byte':
                     msg = repr((TypeError, TypeError('expected bytes with no null')))
                 else:


### PR DESCRIPTION
In Python 3.9, the TypeError exception for calling a function with the wrong number of arguments is also including the class name (e.g. `vim.command() takes ...` rather than `command() takes ...`).  This PR adjusts the error message massaging to account for this.

In order to ease debugging future issues, I also changed the test to assert on a per-line basis that the expected and actual messages match.  The previous method of asserting the entire buffer matches the expected output made it tedious to see what _actually_ failed.  It now looks like

    Found errors in Test_python3_errors():
    command line..script /path/to/vim/src/testdir/runtest.vim[461]..function RunTheTest[39]..Test_python3_errors line 1199: Expected 'vim.command("", 2):(<class ''TypeError''>, TypeError(''command() takes exactly one argument (2 given)'',))' but got 'vim.command("", 2):(<class ''TypeError''>, TypeError(''vim.command() takes exactly one argument (2 given)'',))'
    command line..script /path/to/vim/src/testdir/runtest.vim[461]..function RunTheTest[39]..Test_python3_errors line 1199: Expected 'vim.foreach_rtp(int, 2):(<class ''TypeError''>, TypeError(''foreach_rtp() takes exactly one argument (2 given)'',))' but got 'vim.foreach_rtp(int, 2):(<class ''TypeError''>, TypeError(''vim.foreach_rtp() takes exactly one argument (2 given)'',))'
    command line..script /path/to/vim/src/testdir/runtest.vim[461]..function RunTheTest[39]..Test_python3_errors line 1199: Expected 'd.popitem(1, 2):(<class ''TypeError''>, TypeError(''popitem() takes no arguments (2 given)'',))' but got 'd.popitem(1, 2):(<class ''TypeError''>, TypeError(''dictionary.popitem() takes no arguments (2 given)'',))'
    command line..script /path/to/vim/src/testdir/runtest.vim[461]..function RunTheTest[39]..Test_python3_errors line 1199: Expected 'd.has_key():(<class ''TypeError''>, TypeError(''has_key() takes exactly one argument (0 given)'',))' but got 'd.has_key():(<class ''TypeError''>, TypeError(''dictionary.has_key() takes exactly one argument (0 given)'',))'

instead of reporting that there are differences between two ~800 element lists.