### PR TITLE
DirectWrite: Fix scrolling when part of a window is off-screen

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -2986,6 +2986,42 @@ gui_mch_flash(int msec)
 }
 
 /*
+ * Check if the specified point is on-screen. (multi-monitor aware)
+ */
+    static BOOL
+is_point_onscreen(int x, int y)
+{
+    POINT   pt = {x, y};
+
+    return MonitorFromPoint(pt, MONITOR_DEFAULTTONULL) != NULL;
+}
+
+/*
+ * Check if the whole area of the specified window is on-screen.
+ *
+ * Note about DirectX: Windows 10 1809 or above no longer maintains image of
+ * the window portion that is off-screen.  Scrolling by DWriteContext_Scroll()
+ * only works when the whole window is on-screen.
+ */
+    static BOOL
+is_window_onscreen(HWND hwnd)
+{
+    RECT    rc;
+
+    GetWindowRect(hwnd, &rc);
+
+    if (!is_point_onscreen(rc.left, rc.top))
+	return FALSE;
+    if (!is_point_onscreen(rc.left, rc.bottom))
+	return FALSE;
+    if (!is_point_onscreen(rc.right, rc.top))
+	return FALSE;
+    if (!is_point_onscreen(rc.right, rc.bottom))
+	return FALSE;
+    return TRUE;
+}
+
+/*
  * Return flags used for scrolling.
  * The SW_INVALIDATE is required when part of the window is covered or
  * off-screen. Refer to MS KB Q75236.
@@ -2996,15 +3032,12 @@ get_scroll_flags(void)
     HWND	hwnd;
     RECT	rcVim, rcOther, rcDest;
 
-    GetWindowRect(s_hwnd, &rcVim);
-
-    // Check if the window is partly above or below the screen.  We don't care
-    // about partly left or right of the screen, it is not relevant when
-    // scrolling up or down.
-    if (rcVim.top < 0 || rcVim.bottom > GetSystemMetrics(SM_CYFULLSCREEN))
+    // Check if the window is (partly) off-screen.
+    if (!is_window_onscreen(s_hwnd))
 	return SW_INVALIDATE;
 
     // Check if there is an window (partly) on top of us.
+    GetWindowRect(s_hwnd, &rcVim);
     for (hwnd = s_hwnd; (hwnd = GetWindow(hwnd, GW_HWNDPREV)) != (HWND)0; )
 	if (IsWindowVisible(hwnd))
 	{
@@ -3014,45 +3047,6 @@ get_scroll_flags(void)
 	}
     return 0;
 }
-
-#if defined(FEAT_DIRECTX)
-/*
- * Check if the whole area of the specified window is on-screen.
- * Windows 10 1809 or above no longer maintains image of the window portion
- * that is off-screen.  Scrolling by DWriteContext_Scroll() only works when
- * the whole window is on-screen.
- */
-    static BOOL
-is_window_onscreen(HWND hwnd)
-{
-    RECT    rc;
-    POINT   pt;
-
-    GetWindowRect(hwnd, &rc);
-
-    pt.x = rc.left;
-    pt.y = rc.top;
-    if (MonitorFromPoint(pt, MONITOR_DEFAULTTONULL) == NULL)
-	return FALSE;
-
-    pt.x = rc.left;
-    pt.y = rc.bottom;
-    if (MonitorFromPoint(pt, MONITOR_DEFAULTTONULL) == NULL)
-	return FALSE;
-
-    pt.x = rc.right;
-    pt.y = rc.top;
-    if (MonitorFromPoint(pt, MONITOR_DEFAULTTONULL) == NULL)
-	return FALSE;
-
-    pt.x = rc.right;
-    pt.y = rc.bottom;
-    if (MonitorFromPoint(pt, MONITOR_DEFAULTTONULL) == NULL)
-	return FALSE;
-
-    return TRUE;
-}
-#endif
 
 /*
  * On some Intel GPUs, the regions drawn just prior to ScrollWindowEx()


### PR DESCRIPTION
This fixes #5688.
Check if the whole area of the window is on-screen.
If not, fall back to the GDI scrolling.