### PR TITLE
Fix typos in optwin.vim

### DIFF
--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -848,7 +848,7 @@ if has("digraphs")
 endif
 call <SID>AddOption("tildeop", gettext("the \"~\" command behaves like an operator"))
 call <SID>BinOptionG("top", &top)
-call <SID>AddOption("operatorfunc", gettext("function called for the \"g@\"  operator"))
+call <SID>AddOption("operatorfunc", gettext("function called for the \"g@\" operator"))
 call <SID>OptionG("opfunc", &opfunc)
 call <SID>AddOption("showmatch", gettext("when inserting a bracket, briefly jump to its match"))
 call <SID>BinOptionG("sm", &sm)
@@ -1267,7 +1267,7 @@ endif
 
 
 call <SID>Header(gettext("multi-byte characters"))
-call <SID>AddOption("encoding", gettext("character encoding used in Vim: \"latin1\", \"utf-8\"\n\"euc-jp\", \"big5\", etc."))
+call <SID>AddOption("encoding", gettext("character encoding used in Vim: \"latin1\", \"utf-8\",\n\"euc-jp\", \"big5\", etc."))
 call <SID>OptionG("enc", &enc)
 call <SID>AddOption("fileencoding", gettext("character encoding for the current file"))
 call append("$", "\t" .. s:local_to_buffer)


### PR DESCRIPTION
@brammool Sorry if you have already included this.
I have already reported this at https://github.com/vim/vim/commit/cb80aa2d53e56d3aba3b3c439fb467f29a750c5e#r43601749, but I create this PR not to forget the changes.