### PR TITLE
Fix :filter is not recognized in vim9script

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2763,7 +2763,7 @@ parse_command_modifiers(
 			    }
 #ifdef FEAT_EVAL
 			    // Avoid that "filter(arg)" is recognized.
-			    if (in_vim9script() && !VIM_ISWHITE(*p))
+			    if (in_vim9script() && !VIM_ISWHITE(*(p - 1)))
 				break;
 #endif
 			    if (skip_only)

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -312,6 +312,27 @@ def Test_filter_is_not_modifier()
   assert_equal([#{x: 3, y: 4}], tags)
 enddef
 
+def Test_filter_is_recognized()
+  var lines =<< trim END
+    final expected = "\nType Name Content\n  c  \"c   piyo"
+    final reg_a_save = @a
+    final reg_b_save = @b
+    final reg_c_save = @c
+
+    @a = 'hoge'
+    @b = 'fuga'
+    @c = 'piyo'
+
+    assert_equal(execute('filter /piyo/ registers abc'), expected)
+
+    @a = reg_a_save
+    @b = reg_b_save
+    @c = reg_c_save
+  END
+  CheckDefSuccess(lines)
+  CheckScriptSuccess(['vim9script'] + lines)
+enddef
+
 def Test_eval_command()
   var from = 3
   var to = 5


### PR DESCRIPTION
This PR fixes https://github.com/vim/vim/issues/7216.

`checkforcmd()` has `skipwhite()` calls.
https://github.com/vim/vim/blob/cf4d454df0619ee41ef40e7e91fce3fb061d7d5b/src/ex_docmd.c#L2754

So `!VIM_ISWHITE(*p)` is always true.
https://github.com/vim/vim/blob/cf4d454df0619ee41ef40e7e91fce3fb061d7d5b/src/ex_docmd.c#L2766
(Sorry for my poor English...)