### PR TITLE
if_perl: Fix that Perl 5.32 doesn't work when compiled with MSVC

### DIFF
--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -44,12 +44,13 @@
 # define PERL_NO_INLINE_FUNCTIONS
 #endif
 
-/* Work around for using MSVC and ActivePerl 5.18. */
 #ifdef _MSC_VER
+// Work around for using MSVC and ActivePerl 5.18.
 # define __inline__ __inline
-
 // Work around for using MSVC and Strawberry Perl 5.30.
 # define __builtin_expect(expr, val) (expr)
+// Work around for using MSVC and Strawberry Perl 5.32.
+# define NO_THREAD_SAFE_LOCALE
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
When if_perl is compiled with Perl 5.32 and MSVC x64, the `:perl`
command shows the following error:
```
auto/if_perl.c: loadable library and perl binaries are mismatched (got handshake key 0000000012800080, needed 0000000012900080)
```

This is because the size of the `PerlInterpreter` structure is different
when compiled by MSVC and MinGW.
This fixes it by defining `NO_THREAD_SAFE_LOCALE`.

Also adjust some comments.