### PR TITLE
Session script overwrites local values of so and siso options

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1216,7 +1216,7 @@ ex_mkrc(exarg_T	*eap)
 #ifdef FEAT_SESSION
 	if (!failed && view_session)
 	{
-	    if (put_line(fd, "let s:so_save = &so | let s:siso_save = &siso | set so=0 siso=0") == FAIL)
+	    if (put_line(fd, "let s:so_save = &g:so | let s:siso_save = &g:siso | setg so=0 siso=0 | setl so=-1 siso=-1") == FAIL)
 		failed = TRUE;
 	    if (eap->cmdidx == CMD_mksession)
 	    {
@@ -1261,7 +1261,7 @@ ex_mkrc(exarg_T	*eap)
 		failed |= (put_view(fd, curwin, !using_vdir, flagp, -1, NULL)
 								      == FAIL);
 	    }
-	    if (put_line(fd, "let &so = s:so_save | let &siso = s:siso_save")
+	    if (put_line(fd, "let &g:so = s:so_save | let &g:siso = s:siso_save")
 								      == FAIL)
 		failed = TRUE;
 #ifdef FEAT_SEARCH_EXTRA

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -859,4 +859,17 @@ func Test_mkvimrc()
   call delete('Xtestvimrc')
 endfunc
 
+func Test_scrolloff()
+  set sessionoptions+=localoptions
+  setlocal so=1 siso=1
+  mksession! Xtest_mks.out
+  setlocal so=-1 siso=-1
+  source Xtest_mks.out
+  call assert_equal(1, &l:so)
+  call assert_equal(1, &l:siso)
+  call delete('Xtest_mks.out')
+  setlocal so& siso&
+  set sessionoptions&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Currently `:mksession` generated script overwrites local values of `&scrolloff` and `&sidescrolloff` in the current window (the only window to survive session load sequence) by assigning global values to them (it uses `:set` / `:let` while the window is still active).

The workaround is to save/restore only global values of `&g:scrolloff` and `&g:sidescrolloff`, while clearing local ones (`setlocal` to -1). This allows the local values to be restored later with `localoptions` or any `autocmd` / `ftplugin` command sequence. And even if they never restored then they at least will match other (newly created) windows.