### PR TITLE
Clean-ups related to sort

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1809,13 +1809,14 @@ found here: |sort()|, |uniq()|.
 
 			With [i] case is ignored.
 
-			With [l] sort uses the current locale. See
-			`language collate` to check or set the locale used
-			for ordering. For example, with "en_US.UTF8",
-			Ö will be ordered after O and before P,
-			whereas with the Swedish locale "sv_SE.UTF8",
-			it will be after Z.
-			Case is typically ignored by the locale.
+			With [l] sort uses the current collation locale.
+			Implementation details: strcoll() is used to compare
+			strings. See |:language| to check or set the collation
+			locale. Example: >
+				:language collate en_US.UTF-8
+				:%sort l
+<			|v:collate| can also used to check the current locale.
+			Sorting using the locale typically ignores case.
 
 			Options [n][f][x][o][b] are mutually exclusive.
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -9700,15 +9700,24 @@ sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 		When {func} is given and it is '1' or 'i' then case is
 		ignored.
 
-		When {func} is given and it is 'l' then the current locale
-		is used for ordering. See `language collate` to check or set
-		the locale used for ordering.  For example, with "en_US.UTF8",
-		Ö will be ordered after O and before P, whereas with the
-		Swedish locale "sv_SE.UTF8", it will be after Z.
-		Case is typically ignored by the locale.
+		When {func} is given and it is 'l' then the current collation
+		locale is used for ordering. Implementation details: strcoll()
+		is used to compare strings. See |:language| check or set the
+		collation locale. |v:collate| can also be used to check the
+		current locale. Sorting using the locale typically ignores
+		case. Example: >
+			" ö is sorted similarly to o with English locale.
+			:language collate en_US.UTF8
+			:echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+<			['n', 'o', 'O', 'ö', 'p', 'z'] ~
+>
+			" ö is sorted after z with Swedish locale.
+			:language collate sv_SE.UTF8
+			:echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+<			['n', 'o', 'O', 'p', 'z', 'ö'] ~
 
 		When {func} is given and it is 'n' then all items will be
-		sorted numerical (Implementation detail: This uses the
+		sorted numerical (Implementation detail: this uses the
 		strtod() function to parse numbers, Strings, Lists, Dicts and
 		Funcrefs will be considered as being 0).
 

--- a/src/testdir/test_sort.vim
+++ b/src/testdir/test_sort.vim
@@ -31,7 +31,7 @@ func Test_sort_strings()
       \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
     " ... whereas with a Swedish locale, the accentuated letters are ordered
     " after Z.
-    elseif lc =~? '"sv.*utf-\?8"'
+    elseif v:collate =~? '^sv.*utf-\?8$'
       call assert_equal(['a', 'A', 'o', 'O', 'p', 'P', 'ä', 'Ä', 'œ', 'œ', 'ô', 'Ô'],
       \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
     endif

--- a/src/testdir/test_sort.vim
+++ b/src/testdir/test_sort.vim
@@ -24,10 +24,9 @@ func Test_sort_strings()
 
   " This does not appear to work correctly on Mac.
   if !has('mac')
-    let lc = execute('language collate')
     " With the following locales, the accentuated letters are ordered
     " similarly to the non-accentuated letters...
-    if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"'
+    if v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$'
       call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'œ', 'p', 'P'],
       \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
     " ... whereas with a Swedish locale, the accentuated letters are ordered
@@ -37,6 +36,11 @@ func Test_sort_strings()
       \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
     endif
   endif
+endfunc
+
+func Test_sort_null_string()
+  " null strings are sorted as empty strings.
+  call assert_equal(['', 'a', 'b'], sort(['b', test_null_string(), 'a'])
 endfunc
 
 func Test_sort_numeric()
@@ -1229,8 +1233,7 @@ func Test_sort_cmd()
     " With the following locales, the accentuated letters are ordered
     " similarly to the non-accentuated letters.
     " This does not appear to work on Mac
-    let lc = execute('language collate')
-    if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"' && !has('mac')
+    if v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$' && !has('mac')
       let tests += [
 	\ {
 	\    'name' : 'sort with locale',

--- a/src/testdir/test_sort.vim
+++ b/src/testdir/test_sort.vim
@@ -40,7 +40,7 @@ endfunc
 
 func Test_sort_null_string()
   " null strings are sorted as empty strings.
-  call assert_equal(['', 'a', 'b'], sort(['b', test_null_string(), 'a'])
+  call assert_equal(['', 'a', 'b'], sort(['b', test_null_string(), 'a']))
 endfunc
 
 func Test_sort_numeric()


### PR DESCRIPTION
- improved test coverage: sort with null strings was not tested
- improved documentation of :sort and sort()
- use v:collate instead of execute('language collate') in tests