### PR TITLE
vim.1: Add --startuptime option

### DIFF
--- a/runtime/doc/vim.1
+++ b/runtime/doc/vim.1
@@ -400,6 +400,9 @@ Use encryption when writing files.  Will prompt for a crypt key.
 Don't connect to the X server.  Shortens startup time in a terminal, but the
 window title and clipboard will not be used.
 .TP
+\--startuptime {file}
+Write startup timing messages into file.
+.TP
 \-y
 Start
 .B Vim


### PR DESCRIPTION
Hi,

our QE did a man page checks in the past and found some [issues](https://bugzilla.redhat.com/show_bug.cgi?id=1711396) in Vim.

In fact, the only missing is ```--startuptime <file>``` from Vim's manpage. This PR fixes it.

Would you mind adding it to the project? Please let me know if I should change something.


Thank you in advance,

Zdenek