### PR TITLE
Exiting a terminal window, Enter a popup window.

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -1572,7 +1572,7 @@ win_found:
     else
     {
 	// restore curwin
-	if (win_valid(aco->save_curwin))
+	if (win_valid(aco->save_curwin) && !WIN_IS_POPUP(aco->save_curwin))
 	{
 	    // Restore the buffer which was previously edited by curwin, if
 	    // it was changed, we are still the same window and the buffer is

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3737,5 +3737,25 @@ func Test_popupwin_splitmove()
   bwipe
 endfunc
 
+func Test_popupwin_exiting_terminal()
+  " This is a test of https://github.com/vim/vim/pull/7272 .
+  CheckFeature terminal
+  try
+    augroup Test_popupwin_exiting_terminal
+      autocmd!
+      autocmd WinEnter * :call popup_create('test', {})
+    augroup END
+    let bnr = term_start(&shell, #{ term_finish: 'close', })
+    call term_sendkeys(bnr, "exit\r\n")
+    call term_wait(bnr)
+    sleep 100m
+    call assert_equal(win_gettype(), '')
+  finally
+    call popup_clear(1)
+    augroup Test_popupwin_exiting_terminal
+      autocmd!
+    augroup END
+  endtry
+endfunc
 
 " vim: shiftwidth=2 sts=2


### PR DESCRIPTION
1. Open Vim
2. Execute following code

```
augroup main
    autocmd!
    autocmd WinEnter * :call popup_create('test', {})
augroup END
let bnr = term_start(&shell, #{ term_finish: 'close', })
call term_sendkeys(bnr, "exit\r\n")
```

3. Enter a popup window. And then never move to other window and never close the popup window because of `E994: Not allowed in a popup window`.

![image](https://user-images.githubusercontent.com/1595779/98440145-54d50b00-213a-11eb-828b-f21d281a52a8.png)
