### PR TITLE
Make it more difficult to lose swap modification by accident

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -5936,7 +5936,11 @@ Writing files:
 7   When editing a file, check that it has been change outside of Vim more
     often, not only when writing over it.  E.g., at the time the swap file is
     flushed.  Or every ten seconds or so (use the time of day, check it before
-    waiting for a character to be typed).
+    waiting for a character to be typed).  Don't just check if the file time
+    has changed, but the contents has been changed (compaer to the last save
+    point, not changes since), for example a git rebase can revert, then update
+    the file to the same contents, :! for an unmodified file will detect this,
+    :w will complain even though the contents are identical.
 8   When a file was changed since editing started, show this in the status
     line of the window, like "[time]".
     Make it easier to reload all outdated files that don't have changes.

--- a/src/memline.c
+++ b/src/memline.c
@@ -1682,6 +1682,16 @@ ml_recover(int checkext)
     }
     else
     {
+#if defined(UNIX) || defined(MSWIN)
+	if (mch_process_running(char_to_long(b0p->b0_pid)))
+	{
+	    // Warn there could be an active vim on the same file
+	    // useful for `vim -r file.txt` that doesn't already display it.
+	    msg_puts(_("process ID: "));
+	    msg_outnum(char_to_long(b0p->b0_pid));
+	    msg_puts(_(" (STILL RUNNING)"));
+	}
+#endif
 	if (curbuf->b_changed)
 	{
 	    msg(_("Recovery completed. You should check if everything is OK."));

--- a/src/memline.c
+++ b/src/memline.c
@@ -4978,7 +4978,14 @@ findswapname(
 				    process_still_running
 					? (char_u *)_("&Open Read-Only\n&Edit anyway\n&Recover\n&Quit\n&Abort") :
 # endif
-					(char_u *)_("&Open Read-Only\n&Edit anyway\n&Recover\n&Delete it\n&Quit\n&Abort"), 1, NULL, FALSE);
+					// Give a different hotkey for when the
+					// file has been modified, otherwise it
+					// is easy to delete unrecovered
+					// changes.
+					b0.b0_dirty ?
+					    (char_u *)_("&Open Read-Only\n&Edit anyway\n&Recover\nDelete &Modified\n&Quit\n&Abort") :
+					    (char_u *)_("&Open Read-Only\n&Edit anyway\n&Recover\n&Delete it\n&Quit\n&Abort"),
+					1, NULL, FALSE);
 
 # ifdef HAVE_PROCESS_STILL_RUNNING
 			if (process_still_running && choice >= 4)


### PR DESCRIPTION
I made these changes after a failed hibernation left a bunch of swap files that I wanted to clean up, but not lose any modifications.  I appreciate the 8.2 auto delete unmodified swap files, it will make this kind of clean up quicker.  I think it should check for the hostname, shared files on NFS or a similar setup is the issue here, if it is a different system you can't check the pid.

I've been wanting a different hotkey for (D)elete it, I picked Delete (M)odified, I've been worrying that I hit d so often that even if I see modified: YES, I'll still trash it, this will make that less likely.

I do wish vim stored the current tty to the swap file, that's something another vim could check, is there a process by that pid, is it on the same tty, if no assume it is unrelated.  I didn't make a patch for that because I assume modifying the swap block 0 would not likely be accepted for such a change.