### PR TITLE
Fixed obsolete syntax in README_VIM9.md

### DIFF
--- a/README_VIM9.md
+++ b/README_VIM9.md
@@ -165,12 +165,12 @@ TypeScript, can work:
 
 ``` vim
 def MyFunction(arg: number): number
-   let local = 1
-   let todo = arg
+   var local = 1
+   var todo = arg
    const ADD = 88
    while todo > 0
       local += ADD
-      --todo
+      todo -= 1
    endwhile
    return local
 enddef
@@ -248,10 +248,10 @@ END
   return luaeval('sum')
 endfunc
 
-def VimNew()
-  let sum = 0
+def VimNew(): number
+  var sum = 0
   for i in range(1, 2999999)
-    let sum += i
+    sum += i
   endfor
   return sum
 enddef
@@ -277,7 +277,7 @@ echo 'Vim new: ' .. reltimestr(reltime(start))
 
 ``` vim
 def VimNew(): number
-  let totallen = 0
+  var totallen = 0
   for i in range(1, 100000)
     setline(i, '    ' .. getline(i))
     totallen += len(getline(i))


### PR DESCRIPTION
This PR fixes obsolete vim9 syntax in `README_VIM9.md`.

After fixing the obsolete syntax, I ran the benchmarks on my Linux x86_64 machine, with vim-8.2.1968 build with -O2. Here are my results.

Script for sum time measurements:
```
4499998500000
Vim old:   3.848740
4499998500000
Python:   0.225727
4499998500000
Lua:   0.062031
4499998500000
Vim new:   0.082380
```

Script for indent time measurements:
```
888890
Vim old:   0.379581
888890
Python:   0.105628
888890
Lua:   0.115477
888890
Vim new:   0.059427
```