### PR TITLE
vim9: Fix has('gui_running') with VIMDLL

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5513,7 +5513,7 @@ dynamic_feature(char_u *feature)
 #ifdef VIMDLL
 	    || STRICMP(feature, "filterpipe") == 0
 #endif
-#if defined(FEAT_GUI) && !defined(ALWAYS_USE_GUI)
+#if defined(FEAT_GUI) && !defined(ALWAYS_USE_GUI) && !defined(VIMDLL)
 	    // this can only change on Unix where the ":gui" command could be
 	    // used.
 	    || (STRICMP(feature, "gui_running") == 0 && !gui.in_use)


### PR DESCRIPTION
Fix the following error:
https://github.com/vim/vim/runs/1376263498#step:11:10433
`RunTheTest[39]..Test_disassemble_const_expr line 107: Pattern 'HasGuiRunning.*if has("gui_running")\\_s*  echo "yes"\\_s*else\\_s*  echo "no"\\_s*\\d PUSHS "no"\\_s*\\d ECHO 1\\_s*endif' does not match '\nHasGuiRunning\n  if has("gui_running")\n   0 PUSHS "gui_running"\n   1 BCALL has(argc 1)\n   2 JUMP_IF_FALSE -> 6\n\n\n    echo "yes"\n   3 PUSHS "yes"\n   4 ECHO 1\n\n\n  else\n   5 JUMP -> 8\n\n\n    echo "no"\n   6 PUSHS "no"\n   7 ECHO 1\n\n\n  endif\n   8 PUSHNR 0\n   9 RETURN'`