### PR TITLE
Use a binary search on looking for the patch version.

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -4723,11 +4723,21 @@ highest_patch(void)
     int
 has_patch(int n)
 {
-    int		i;
+    int		h, m, l;
 
-    for (i = 0; included_patches[i] != 0; ++i)
-	if (included_patches[i] == n)
+    // Perform a binary search.
+    l = 0;
+    h = (int)(sizeof(included_patches) / sizeof(included_patches[0])) - 1;
+    while (l < h)
+    {
+	m = (l + h) / 2;
+	if (included_patches[m] == n)
 	    return TRUE;
+	if (included_patches[m] < n)
+	    h = m;
+	else
+	    l = m + 1;
+    }
     return FALSE;
 }
 #endif
@@ -4939,9 +4949,7 @@ list_version(void)
     {
 	msg_puts(_("\nIncluded patches: "));
 	first = -1;
-	// find last one
-	for (i = 0; included_patches[i] != 0; ++i)
-	    ;
+	i = (int)(sizeof(included_patches) / sizeof(included_patches[0])) - 1;
 	while (--i >= 0)
 	{
 	    if (first < 0)


### PR DESCRIPTION
Given the fact that `included_patches` is sorted, we can perform a binary search on looking for the patch version; `has('patch-8.2.100')` and `has('patch100')`. Also improve `:version` slightly.