### PR TITLE
Fix parallel compilation might fail with MinGW

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1055,12 +1055,18 @@ install.exe: dosinst.c dosinst.h version.h
 uninstall.exe: uninstall.c dosinst.h version.h
 	$(CC) $(CFLAGS) -o uninstall.exe uninstall.c $(LIB) -lole32
 
+$(OBJ): $(OUTDIR)
+
 ifeq ($(VIMDLL),yes)
 $(TARGET): $(OUTDIR) $(OBJ)
 	$(LINK) $(CFLAGS) $(LFLAGS) -o $@ $(OBJ) $(LIB) -lole32 -luuid -lgdi32 $(LUA_LIB) $(MZSCHEME_LIBDIR) $(MZSCHEME_LIB) $(PYTHONLIB) $(PYTHON3LIB) $(RUBYLIB)
 
+$(EXEOBJG): $(OUTDIR)
+
 $(GVIMEXE): $(OUTDIR) $(EXEOBJG) $(VIMDLLBASE).dll
 	$(CC) -L. $(EXELFLAGS) -mwindows -o $@ $(EXEOBJG) -l$(VIMDLLBASE)
+
+$(EXEOBJC): $(OUTDIR)
 
 $(VIMEXE): $(OUTDIR) $(EXEOBJC) $(VIMDLLBASE).dll
 	$(CC) -L. $(EXELFLAGS) -o $@ $(EXEOBJC) -l$(VIMDLLBASE)
@@ -1280,7 +1286,7 @@ $(OUTDIR)/%.o : xdiff/%.c $(XDIFF_DEPS)
 	$(CC) -c $(CFLAGS) $< -o $@
 
 
-$(PATHDEF_SRC): Make_cyg_ming.mak Make_cyg.mak Make_ming.mak
+$(PATHDEF_SRC): $(OUTDIR) Make_cyg_ming.mak Make_cyg.mak Make_ming.mak
 ifneq (sh.exe, $(SHELL))
 	@echo creating $(PATHDEF_SRC)
 	@echo '/* pathdef.c */' > $(PATHDEF_SRC)


### PR DESCRIPTION
Parallel compilation with MinGW has chance to fail.

Dependencies on $(OUTDIR) of object files are no defined,
so compilation of an object file might be executing before $(OUTDIR) making.

In Make_mvc.mak, the dependency is added each objects.

Solution:
        Add dependency on $(OUTDIR) to object files.