### PR TITLE
Removed legacy dependency on win32.mak

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -15,10 +15,6 @@
 # This will build the console version of Vim with no additional interfaces.
 # To add features, define any of the following:
 #
-# 	For MSVC 11, if you want to include Win32.mak, you need to specify
-# 	where the file is, e.g.:
-# 	   SDK_INCLUDE_DIR="C:\Program Files\Microsoft SDKs\Windows\v7.1\Include"
-#
 #	!!!!  After changing features do "nmake clean" first  !!!!
 #
 #	Feature Set: FEATURES=[TINY, SMALL, NORMAL, BIG, HUGE] (default is HUGE)
@@ -209,9 +205,6 @@ OBJDIR = $(OBJDIR)V
 OBJDIR = $(OBJDIR)d
 !endif
 
-# If you include Win32.mak, it requires that CPU be set appropriately.
-# To cross-compile for Win64, set CPU=AMD64 or CPU=IA64.
-
 !ifdef PROCESSOR_ARCHITECTURE
 # We're on Windows NT or using VC 6+
 ! ifdef CPU
@@ -251,18 +244,7 @@ NODEBUG = 1
 MAKEFLAGS_GVIMEXT = DEBUG=yes
 !endif
 
-
-# Get all sorts of useful, standard macros from the Platform SDK,
-# if SDK_INCLUDE_DIR is set or USE_WIN32MAK is set to "yes".
-
-!ifdef SDK_INCLUDE_DIR
-! include $(SDK_INCLUDE_DIR)\Win32.mak
-!elseif "$(USE_WIN32MAK)"=="yes"
-! include <Win32.mak>
-!else
 link = link
-!endif
-
 
 # Check VC version.
 !if [echo MSVCVER=_MSC_VER> msvcver.c && $(CC) /EP msvcver.c > msvcver.~ 2> nul]


### PR DESCRIPTION
In the prior version of this makefile there was a reference to win32.mak.   I went down a rabbit hole of trying to find this file because I was led to believe (from other sources) that it was important.  This file - win32.mak - is not part of the last 2 major releases of Windows SDK and they are no longer making a downloadable version of Windows 7 SDK so finding it will be non-trivial for most folks.

As it turns out from the comment by k-takata in
  https://github.com/vim/vim/issues/3023

none of the useful variables defined in win32.mak are actually used in make_mvc.mak anymore so for general code hygiene I've removed it.   I've confirmed that it still builds on my setup here and am taking k-takata's comment as the truth for all of the other build variants that might currently be supported.