### PR TITLE
Quickfix buffer is not updated correctly

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -4674,14 +4674,17 @@ qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int qf_winid)
 	*dirname = NUL;
 
 	// Add one line for each error
-	if (old_last == NULL || old_last->qf_next == NULL)
+	if (old_last == NULL)
 	{
 	    qfp = qfl->qf_start;
 	    lnum = 0;
 	}
 	else
 	{
-	    qfp = old_last->qf_next;
+	    if (old_last->qf_next != NULL)
+		qfp = old_last->qf_next;
+	    else
+		qfp = old_last;
 	    lnum = buf->b_ml.ml_line_count;
 	}
 

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -5145,4 +5145,17 @@ func Test_setloclist_crash()
   %bw!
 endfunc
 
+" Test for adding an invalid entry with the quickfix window open and making
+" sure that the window contents are not changed
+func Test_add_invalid_entry_with_qf_window()
+  call setqflist([], 'f')
+  cexpr "Xfile1:10:aa"
+  copen
+  call setqflist(['bb'], 'a')
+  call assert_equal(1, line('$'))
+  call assert_equal(['Xfile1|10| aa'], getline(1, '$'))
+  call assert_equal([{'lnum': 10, 'bufnr': bufnr('Xfile1'), 'col': 0, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': 'aa'}], getqflist())
+  cclose
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When invalid entries are added to the quickfix list with the quickfix window open, update
the quickfix buffer correctly. Fixes the issue reported in #7271 

This is a regression introduced by the changes made for 8.2.0241 (https://github.com/vim/vim/commit/99234f29aa8767f2e71bb1f5db6ee0131bc8e64e)
