### PR TITLE
Fix popupmenu

### DIFF
--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -361,6 +361,8 @@ pum_display(
 	// redo the positioning.  Limit this to two times, when there is not
 	// much room the window size will keep changing.
     } while (pum_set_selected(selected, redo_count) && ++redo_count <= 2);
+
+    pum_redraw();
 }
 
 /*
@@ -541,8 +543,21 @@ pum_redraw(void)
 			{
 			    if (st != NULL)
 			    {
-				screen_puts_len(st, (int)STRLEN(st), row, col,
-									attr);
+				int size = (int)STRLEN(st);
+				int cells = (*mb_string2cells)(st, size);
+				while (size > 0 &&
+				    col + cells > pum_width + pum_col)
+				{
+				    --size;
+				    if (has_mbyte)
+				    {
+					size -= (*mb_head_off)(st, st + size);
+					cells -= (*mb_ptr2cells)(st + size);
+				    }
+				    else
+					--cells;
+				}
+				screen_puts_len(st, size, row, col, attr);
 				vim_free(st);
 			    }
 			    col += width;
@@ -989,9 +1004,6 @@ pum_set_selected(int n, int repeat UNUSED)
 	// hide any popup info window
 	popup_hide_info();
 #endif
-
-    if (!resized)
-	pum_redraw();
 
     return resized;
 }


### PR DESCRIPTION
Current implementation is constantly rewriting the edges of the screen when redrawing the popupmenu. Therefore, the CPU load is high and the number of redraws is large. Also, pum_redraw seems to be called more than necessary.