### PR TITLE
Make window popup flag logic conditional

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -2455,7 +2455,9 @@ win_line(
 	    wp->w_wrow = row;
 	    did_wcol = TRUE;
 	    curwin->w_valid |= VALID_WCOL|VALID_WROW|VALID_VIRTCOL;
+#    ifdef FEAT_PROP_POPUP
 	    curwin->w_flags &= ~(WFLAG_WCOL_OFF_ADDED | WFLAG_WROW_OFF_ADDED);
+#    endif
 	}
 #endif
 


### PR DESCRIPTION
Patch 8.2.1990 (commit 6a07644) adds some flag switching on the `w_flags` member of the current window, but this member is only part of the relevant struct if Vim is being compiled with `+popupwin`, and so compilation fails if the feature is excluded.  This commit adds a compile-time condition around the new code so that Vim can be built without the feature.