### PR TITLE
Modify Test_terminal_popup_insert_cmd

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1266,7 +1266,7 @@ func Test_terminal_popup_insert_cmd()
   call assert_equal('n', mode())
 
   call feedkeys("\<C-D>", 'xt')
-  sleep 50m
+  call WaitFor({-> popup_list() == []})
   delfunc StartTermInPopup
   iunmap <F3>
 endfunc


### PR DESCRIPTION
I think better to wait for popup_list() to empty than simply do sleep as the termination condition.