### PR TITLE
Vim9: Fix E611 message for boolean

### DIFF
--- a/src/typval.c
+++ b/src/typval.c
@@ -210,6 +210,12 @@ tv_get_bool_or_number_chk(typval_T *varp, int *denote, int want_bool)
 	    emsg(_("E728: Using a Dictionary as a Number"));
 	    break;
 	case VAR_BOOL:
+	    if (!want_bool && in_vim9script())
+	    {
+		emsg(_("E611: Using a Bool as a Number"));
+		break;
+	    }
+	    return varp->vval.v_number == VVAL_TRUE ? 1 : 0;
 	case VAR_SPECIAL:
 	    if (!want_bool && in_vim9script())
 	    {


### PR DESCRIPTION
This pull request fixes an error message on using a bool as a number.
```
vim9script

echo 1 + v:none  # E611: Using a Special as a Number
echo 1 + v:true  # E611: Using a Special as a Number WHY??? v:true IS NOT A SPECIAL!

echo 1 == v:none # E1072: Cannot compare number with special
echo 1 == v:true # E1072: Cannot compare number with bool
```