### PR TITLE
Vim9: skip white spaces on compiling unary operators

### DIFF
--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -2299,6 +2299,9 @@ def Test_expr7_negate()
   var nr = 88
   assert_equal(-88, -nr)
   assert_equal(88, --nr)
+  assert_equal(-88, - nr)
+  assert_equal(88, - - nr)
+  assert_equal(88, + nr)
 enddef
 
 def Echo(arg: any): string

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -3362,6 +3362,8 @@ compile_leader(cctx_T *cctx, int numeric_only, char_u *start, char_u **end)
     while (p > start)
     {
 	--p;
+	while (VIM_ISWHITE(*p))
+	    --p;
 	if (*p == '-' || *p == '+')
 	{
 	    int	    negate = *p == '-';


### PR DESCRIPTION
Currently the following script aborts with `E39: Number expected`. The variable `x` is actually a number.
```
def F()
  var x: number = 10
  echo - x
enddef
disassemble F
echo F()
```
```
<SNR>206_F
  var x: number = 10
   0 STORE 10 in $0


  echo - x
   1 LOAD $0
   2 2BOOL (!!val)    # WHY?
   3 NEGATENR
   4 ECHO 1
   5 PUSHNR 0
   6 RETURN

E39: Number expected
```
Currently, white spaces after an unary operator is allowed.
https://github.com/vim/vim/blob/v8.2.2004/src/vim9compile.c#L3741-L3747
But on compilation it fails to skip the white spaces and generates unexpected 2BOOL instruction.
https://github.com/vim/vim/blob/v8.2.2004/src/vim9compile.c#L3352-L3365