### PR TITLE
Create pbtxt syntax files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1305,6 +1305,7 @@ au BufNewFile,BufRead *.pml			setf promela
 
 " Google protocol buffers
 au BufNewFile,BufRead *.proto			setf proto
+au BufNewFile,BufRead *.pbtxt			setf pbtxt
 
 " Protocols
 au BufNewFile,BufRead */etc/protocols		setf protocols

--- a/runtime/ftplugin/pbtxt.vim
+++ b/runtime/ftplugin/pbtxt.vim
@@ -1,0 +1,21 @@
+" Vim filetype plugin file
+" Language:             Protobuf Text Format
+" Maintainer:           Lakshay Garg <lakshayg@outlook.in>
+" Last Change:          2020 Nov 17
+" Homepage:             https://github.com/lakshayg/vim-pbtxt
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal commentstring=#\ %s
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8 noet

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -404,6 +404,7 @@ an 50.90.120 &Syntax.PQ.Pam\ config :cal SetSyn("pamconf")<CR>
 an 50.90.130 &Syntax.PQ.PApp :cal SetSyn("papp")<CR>
 an 50.90.140 &Syntax.PQ.Pascal :cal SetSyn("pascal")<CR>
 an 50.90.150 &Syntax.PQ.Password\ file :cal SetSyn("passwd")<CR>
+an 50.90.490 &Syntax.PQ.Pbtxt :cal SetSyn("pbtxt")<CR>
 an 50.90.160 &Syntax.PQ.PCCTS :cal SetSyn("pccts")<CR>
 an 50.90.170 &Syntax.PQ.PDF :cal SetSyn("pdf")<CR>
 an 50.90.180 &Syntax.PQ.Perl.Perl :cal SetSyn("perl")<CR>

--- a/runtime/syntax/pbtxt.vim
+++ b/runtime/syntax/pbtxt.vim
@@ -1,0 +1,44 @@
+" Vim syntax file
+" Language:             Protobuf Text Format
+" Maintainer:           Lakshay Garg <lakshayg@outlook.in>
+" Last Change:          2020 Nov 17
+" Homepage:             https://github.com/lakshayg/vim-pbtxt
+
+if exists("b:current_syntax")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+syn case ignore
+
+syn keyword pbtxtTodo     TODO FIXME contained
+syn keyword pbtxtBool     true false contained
+
+syn match   pbtxtInt      display   "\<\(0\|[1-9]\d*\)\>"
+syn match   pbtxtHex      display   "\<0[xX]\x\+\>"
+syn match   pbtxtFloat    display   "\(0\|[1-9]\d*\)\=\.\d*"
+syn match   pbtxtMessage  display   "^\s*\w\+\s*{"me=e-1
+syn match   pbtxtField    display   "^\s*\w\+:"me=e-1
+syn match   pbtxtEnum     display   ":\s*\a\w\+"ms=s+1   contains=pbtxtBool
+syn region  pbtxtString   start=+"+ skip=+\\"+ end=+"+   contains=@Spell
+syn region  pbtxtComment  start="#" end="$"      keepend contains=pbtxtTodo,@Spell
+
+hi def link pbtxtTodo     Todo
+hi def link pbtxtBool     Boolean
+hi def link pbtxtInt      Number
+hi def link pbtxtHex      Number
+hi def link pbtxtFloat    Float
+hi def link pbtxtMessage  Structure
+hi def link pbtxtField    Identifier
+hi def link pbtxtEnum     Define
+hi def link pbtxtString   String
+hi def link pbtxtComment  Comment
+
+let b:current_syntax = "pbtxt"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8 noet

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -345,6 +345,7 @@ let s:filename_checks = {
     \ 'papp': ['file.papp', 'file.pxml', 'file.pxsl'],
     \ 'pascal': ['file.pas', 'file.pp', 'file.dpr', 'file.lpr'],
     \ 'passwd': ['any/etc/passwd', 'any/etc/passwd-', 'any/etc/passwd.edit', 'any/etc/shadow', 'any/etc/shadow-', 'any/etc/shadow.edit', 'any/var/backups/passwd.bak', 'any/var/backups/shadow.bak', '/etc/passwd', '/etc/passwd-', '/etc/passwd.edit', '/etc/shadow', '/etc/shadow-', '/etc/shadow.edit', '/var/backups/passwd.bak', '/var/backups/shadow.bak'],
+    \ 'pbtxt': ['file.pbtxt'],
     \ 'pccts': ['file.g'],
     \ 'pdf': ['file.pdf'],
     \ 'perl': ['file.plx', 'file.al', 'file.psgi', 'gitolite.rc', '.gitolite.rc', 'example.gitolite.rc'],


### PR DESCRIPTION
This PR adds support for protobuf text buffers (pbtxt)

* Register .pbtxt file extension
* Add filetype plugin files
* Add syntax file
* `make test` runs fine