### PR TITLE
Problem: Amiga: Not all colors are used on OS4.

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -297,7 +297,7 @@ static struct builtin_term builtin_termcaps[] =
     {(int)KS_UE,	"\033[0m"},
     {(int)KS_CZH,	"\033[3m"},
     {(int)KS_CZR,	"\033[0m"},
-#if defined(__MORPHOS__) || defined(__AROS__)
+#if defined(__amigaos4__) || defined(__MORPHOS__) || defined(__AROS__)
     {(int)KS_CCO,	"8"},		// allow 8 colors
 #  ifdef TERMINFO
     {(int)KS_CAB,	"\033[4%p1%dm"},// set background color


### PR DESCRIPTION
Solution: Use the same TCAP as Morphos and AROS.