### PR TITLE
win32: Fix test_swap after 8.2.2016

### DIFF
--- a/src/testdir/test_swap.vim
+++ b/src/testdir/test_swap.vim
@@ -417,7 +417,7 @@ func Test_swap_auto_delete()
   " swap file should be automatically deleted.
   bwipe!
   " change the process ID to avoid the "still running" warning
-  let swapfile_bytes[24] = swapfile_bytes[24] + 1
+  let swapfile_bytes[24] = swapfile_bytes[24] + 4
   call writefile(swapfile_bytes, swapfile_name)
   edit Xtest.scr
   " will end up using the same swap file after deleting the existing one


### PR DESCRIPTION
It seems that PIDs on Windows is always multiple of 4 and the lower 2
bits are ignored.  Adding 1 to the current PID results in that the PID
is still running, and it makes the test fail.

Add 4 instead of 1 to the PID.