### PR TITLE
Make sure viminfo file is written when creating a new file

### DIFF
--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -2579,6 +2579,13 @@ nofail:
 #endif
     }
 
+#ifdef FEAT_VIMINFO
+    /*
+     * Make sure, marks will be written out to viminfo file later, even when creating a new file
+     */
+    curbuf->b_marks_read = TRUE;
+#endif
+
     got_int |= prev_got_int;
 
     return retval;

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -1,6 +1,8 @@
 " Test for reading and writing .viminfo
 
 source check.vim
+source term_util.vim
+source shared.vim
 
 function Test_viminfo_read_and_write()
   " First clear 'history', so that "hislen" is zero.  Then set it again,
@@ -877,6 +879,30 @@ func Test_viminfo_option_error()
 
   " Missing ' setting
   call assert_fails('set viminfo=%10', 'E528:')
+endfunc
+
+func Test_viminfo_oldfiles_newfile()
+  let save_viminfo = &viminfo
+  let save_viminfofile = &viminfofile
+  set viminfo&vim
+  let v:oldfiles = []
+  let commands =<< trim [CODE]
+    set viminfofile=Xviminfofile
+    set viminfo&vim
+    w! Xnew-file.txt
+    qall
+  [CODE]
+  call writefile(commands, 'Xviminfotest')
+  let buf = RunVimInTerminal('-S Xviminfotest', #{wait_for_ruler: 0})
+  let &viminfofile = 'Xviminfofile'
+  rviminfo! Xviminfofile
+  call assert_match('Xnew-file.txt$', v:oldfiles[0])
+  call assert_equal(1, len(v:oldfiles))
+  call delete('Xviminfofile')
+  call delete('Xviminfotest')
+  call delete('Xnew-file.txt')
+  let &viminfo = save_viminfo
+  let &viminfofile = save_viminfofile
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -882,6 +882,7 @@ func Test_viminfo_option_error()
 endfunc
 
 func Test_viminfo_oldfiles_newfile()
+  CheckRunVimInTerminal
   let save_viminfo = &viminfo
   let save_viminfofile = &viminfofile
   set viminfo&vim


### PR DESCRIPTION
When creating a new file, `v:oldfiles` might not be updated. So make sure the filemarks will be written out correctly, by setting curbuf->b_marks_read is set even when writing the buffer. 

Note sure this is the right approach.

On a related note, I noticed that `rviminfo <file>` will fail if the viminfofile option has not been set. I wonder if that is correct.

