### PR TITLE
fix ifdef when compiling without reltime

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6708,7 +6708,7 @@ syntime_report(void)
     int		idx;
     synpat_T	*spp;
 # ifdef FEAT_FLOAT
-    proftime_T	tm;
+    proftime_T	tm UNUSED;
 # endif
     int		len;
     proftime_T	total_total;
@@ -6737,7 +6737,7 @@ syntime_report(void)
 	    p->match = spp->sp_time.match;
 	    total_count += spp->sp_time.count;
 	    p->slowest = spp->sp_time.slowest;
-# ifdef FEAT_FLOAT
+# if defined(FEAT_RELTIME) && defined(FEAT_FLOAT) && defined(FEAT_PROFILE)
 	    profile_divide(&spp->sp_time.total, spp->sp_time.count, &tm);
 	    p->average = tm;
 # endif


### PR DESCRIPTION
just some adjustments of the `ifdefs` to make sure vim compiles even without `FEAT_RELTIME`