### PR TITLE
Revise test_swap

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -215,7 +215,8 @@ jobs:
         :: Wait about 10 minutes.
         for /L %%i in (1,1,60) do (
           if exist done.txt goto exitloop
-          timeout 10
+          timeout 10 > NUL 2>&1
+          if ERRORLEVEL 1 ping -n 11 localhost > NUL
         )
         set timeout=1
         :exitloop

--- a/src/testdir/test_swap.vim
+++ b/src/testdir/test_swap.vim
@@ -403,6 +403,39 @@ func Test_swap_symlink()
   call delete('Xswapdir', 'rf')
 endfunc
 
+func s:get_unused_pid(base)
+  if has('job')
+    " Execute 'echo' as a temporary job, and return its pid as an unused pid.
+    if has('win32')
+      let cmd = 'cmd /c echo'
+    else
+      let cmd = 'echo'
+    endif
+    let j = job_start(cmd)
+    while job_status(j) ==# 'run'
+      sleep 10m
+    endwhile
+    if job_status(j) ==# 'dead'
+      return job_info(j).process
+    endif
+  endif
+  " Must add four for MS-Windows to see it as a different one.
+  return a:base + 4
+endfunc
+
+func s:blob_to_pid(b)
+  return a:b[3] * 16777216 + a:b[2] * 65536 + a:b[1] * 256 + a:b[0]
+endfunc
+
+func s:pid_to_blob(i)
+  let b = 0z
+  let b[0] = and(a:i, 0xff)
+  let b[1] = and(a:i / 256, 0xff)
+  let b[2] = and(a:i / 65536, 0xff)
+  let b[3] = and(a:i / 16777216, 0xff)
+  return b
+endfunc
+
 func Test_swap_auto_delete()
   " Create a valid swapfile by editing a file with a special extension.
   split Xtest.scr
@@ -416,9 +449,9 @@ func Test_swap_auto_delete()
   " Forget about the file, recreate the swap file, then edit it again.  The
   " swap file should be automatically deleted.
   bwipe!
-  " Change the process ID to avoid the "still running" warning.  Must add four
-  " for MS-Windows to see it as a different one.
-  let swapfile_bytes[24] = swapfile_bytes[24] + 4
+  " Change the process ID to avoid the "still running" warning.
+  let swapfile_bytes[24:27] = s:pid_to_blob(s:get_unused_pid(
+        \ s:blob_to_pid(swapfile_bytes[24:27])))
   call writefile(swapfile_bytes, swapfile_name)
   edit Xtest.scr
   " will end up using the same swap file after deleting the existing one


### PR DESCRIPTION
Test_swap_auto_delete() still often fails on MS-Windows.
This executes 'echo' as a temporary job, and uses its pid as an unused pid.
This assumes that a pid which is used once will not be reused soon.
If it fails to execute a job, just add 4 to the current pid.