### PR TITLE
Don't trigger TextYankPost on X external selections

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -2025,6 +2025,9 @@ clip_get_selection(Clipboard_T *cbd)
 		    && get_y_register(STAR_REGISTER)->y_array != NULL))
 	    return;
 
+	// Avoid triggering autocmds such as TextYankPost.
+	block_autocmds();
+
 	// Get the text between clip_star.start & clip_star.end
 	old_y_previous = get_y_previous();
 	old_y_current = get_y_current();
@@ -2054,6 +2057,8 @@ clip_get_selection(Clipboard_T *cbd)
 	curbuf->b_op_end = old_op_end;
 	VIsual = old_visual;
 	VIsual_mode = old_visual_mode;
+
+	unblock_autocmds();
     }
     else if (!is_clipboard_needs_update())
     {

--- a/src/register.c
+++ b/src/register.c
@@ -322,8 +322,7 @@ put_register(int name, void *reg)
 #endif
 }
 
-#if (defined(FEAT_CLIPBOARD) && defined(FEAT_X11) && defined(USE_SYSTEM)) \
-	|| defined(PROTO)
+#if defined(FEAT_CLIPBOARD) || defined(PROTO)
     void
 free_register(void *reg)
 {

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -1760,6 +1760,28 @@ func Test_TextYankPost()
 
   call assert_equal({}, v:event)
 
+  if has('clipboard_working') && !has('gui_running')
+    " Test that when the visual selection is automatically copied to clipboard
+    " register a TextYankPost is emitted
+    call setline(1, ['foobar'])
+
+    let @* = ''
+    set clipboard=autoselect
+    exe "norm! ggviw\<Esc>"
+    call assert_equal(
+        \{'regcontents': ['foobar'], 'regname': '*', 'operator': 'y', 'regtype': 'v', 'visual': v:true},
+        \g:event)
+
+    let @+ = ''
+    set clipboard=autoselectplus
+    exe "norm! ggviw\<Esc>"
+    call assert_equal(
+        \{'regcontents': ['foobar'], 'regname': '+', 'operator': 'y', 'regtype': 'v', 'visual': v:true},
+        \g:event)
+
+    set clipboard&vim
+  endif
+
   au! TextYankPost
   unlet g:event
   bwipe!


### PR DESCRIPTION
Due to how Xorg clipboards work `clip_get_selection` is be called
whenever another client requests the clipboard content owned by Vim.
Prevent the emission of autocmds when the yank operation is triggered by
some external mechanism, this avoids nasty side-effects such as #4201
beside stopping the emission of spurious TextYankPost events.

A test case to make sure a TextYankPost is triggered when the visual
selection is left (and cb=autoselect or cb=autoselectplus) is also added
to prevent this feature from regressing.

Closes #4201