### PR TITLE
Use better assert functions

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -300,28 +300,28 @@ func Test_augroup_warning()
   augroup TheWarning
     au VimEnter * echo 'entering'
   augroup END
-  call assert_true(match(execute('au VimEnter'), "TheWarning.*VimEnter") >= 0)
+  call assert_match("TheWarning.*VimEnter", execute('au VimEnter'))
   redir => res
   augroup! TheWarning
   redir END
-  call assert_true(match(res, "W19:") >= 0)
-  call assert_true(match(execute('au VimEnter'), "-Deleted-.*VimEnter") >= 0)
+  call assert_match("W19:", res)
+  call assert_match("-Deleted-.*VimEnter", execute('au VimEnter'))
 
   " check "Another" does not take the pace of the deleted entry
   augroup Another
   augroup END
-  call assert_true(match(execute('au VimEnter'), "-Deleted-.*VimEnter") >= 0)
+  call assert_match("-Deleted-.*VimEnter", execute('au VimEnter'))
   augroup! Another
 
   " no warning for postpone aucmd delete
   augroup StartOK
     au VimEnter * call RemoveGroup()
   augroup END
-  call assert_true(match(execute('au VimEnter'), "StartOK.*VimEnter") >= 0)
+  call assert_match("StartOK.*VimEnter", execute('au VimEnter'))
   redir => res
   doautocmd VimEnter
   redir END
-  call assert_true(match(res, "W19:") < 0)
+  call assert_notmatch("W19:", res)
   au! VimEnter
 
   call assert_fails('augroup!', 'E471:')
@@ -351,7 +351,7 @@ func Test_augroup_deleted()
     au VimEnter * echo
   augroup end
   augroup! x
-  call assert_true(match(execute('au VimEnter'), "-Deleted-.*VimEnter") >= 0)
+  call assert_match("-Deleted-.*VimEnter", execute('au VimEnter'))
   au! VimEnter
 endfunc
 

--- a/src/testdir/test_backspace_opt.vim
+++ b/src/testdir/test_backspace_opt.vim
@@ -1,15 +1,5 @@
 " Tests for 'backspace' settings
 
-func Exec(expr)
-  let str=''
-  try
-    exec a:expr
-  catch /.*/
-    let str=v:exception
-  endtry
-  return str
-endfunc
-
 func Test_backspace_option()
   set backspace=
   call assert_equal('', &backspace)
@@ -41,10 +31,10 @@ func Test_backspace_option()
   set backspace-=eol
   call assert_equal('', &backspace)
   " Check the error
-  call assert_equal(0, match(Exec('set backspace=ABC'), '.*E474:'))
-  call assert_equal(0, match(Exec('set backspace+=def'), '.*E474:'))
+  call assert_fails('set backspace=ABC', 'E474:')
+  call assert_fails('set backspace+=def', 'E474:')
   " NOTE: Vim doesn't check following error...
-  "call assert_equal(0, match(Exec('set backspace-=ghi'), '.*E474:'))
+  "call assert_fails('set backspace-=ghi', 'E474:')
 
   " Check backwards compatibility with version 5.4 and earlier
   set backspace=0
@@ -55,8 +45,8 @@ func Test_backspace_option()
   call assert_equal('2', &backspace)
   set backspace=3
   call assert_equal('3', &backspace)
-  call assert_false(match(Exec('set backspace=4'), '.*E474:'))
-  call assert_false(match(Exec('set backspace=10'), '.*E474:'))
+  call assert_fails('set backspace=4', 'E474:')
+  call assert_fails('set backspace=10', 'E474:')
 
   " Cleared when 'compatible' is set
   set compatible


### PR DESCRIPTION
Combining assert_true/false() and match() makes harder to understand
what is happening when an error occurs.
Use better assert functions.