### PR TITLE
Problem:    Amiga: FEAT_ARP defined when it should not.

### DIFF
--- a/src/feature.h
+++ b/src/feature.h
@@ -1090,7 +1090,7 @@
  * +ARP			Amiga only. Use arp.library, DOS 2.0 is not required.
  */
 #if defined(AMIGA) && !defined(NO_ARP) && !defined(__amigaos4__) \
-	&& !defined(__MORPHOS__) || !defined(__AROS__)
+	&& !defined(__MORPHOS__) && !defined(__AROS__)
 # define FEAT_ARP
 #endif
 


### PR DESCRIPTION
Solution:   Adjust #ifdef.

Unfortunately I did a silly mistake in PR #7370. I'm sorry about that. This is the way it's supposed to be.