### PR TITLE
win32: Mitigate temp file name confliction

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5167,17 +5167,22 @@ vim_tempname(
 # ifdef MSWIN
     WCHAR	wszTempFile[_MAX_PATH + 1];
     WCHAR	buf4[4];
+    WCHAR	*chartab = L"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_";
     char_u	*retval;
     char_u	*p;
+    long	i;
 
     wcscpy(itmp, L"");
     if (GetTempPathW(_MAX_PATH, wszTempFile) == 0)
     {
 	wszTempFile[0] = L'.';	// GetTempPathW() failed, use current dir
-	wszTempFile[1] = NUL;
+	wszTempFile[1] = L'\\';
+	wszTempFile[2] = NUL;
     }
     wcscpy(buf4, L"VIM");
-    buf4[2] = extra_char;   // make it "VIa", "VIb", etc.
+    i = mch_get_pid() + extra_char;
+    buf4[1] = chartab[i % 37];		// make it a bit random
+    buf4[2] = chartab[101 * i % 37];
     if (GetTempFileNameW(wszTempFile, buf4, 0, itmp) == 0)
 	return NULL;
     if (!keep)

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5167,7 +5167,7 @@ vim_tempname(
 # ifdef MSWIN
     WCHAR	wszTempFile[_MAX_PATH + 1];
     WCHAR	buf4[4];
-    WCHAR	*chartab = L"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_";
+    WCHAR	*chartab = L"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     char_u	*retval;
     char_u	*p;
     long	i;
@@ -5181,8 +5181,8 @@ vim_tempname(
     }
     wcscpy(buf4, L"VIM");
     i = mch_get_pid() + extra_char;
-    buf4[1] = chartab[i % 37];		// make it a bit random
-    buf4[2] = chartab[101 * i % 37];
+    buf4[1] = chartab[i % 36];		// make it a bit random
+    buf4[2] = chartab[101 * i % 36];
     if (GetTempFileNameW(wszTempFile, buf4, 0, itmp) == 0)
 	return NULL;
     if (!keep)


### PR DESCRIPTION
On GHA, some tests fail once in a while.
E.g.:
```
Found errors in Test_autocmd_bufwipe_in_SessLoadPost():
Caught exception in Test_autocmd_bufwipe_in_SessLoadPost(): Vim(let):E484: Can't open file Xerrors @ command line..script D:/a/vim/vim/src/testdir/runtest.vim[468]..function RunTheTest[39]..Test_autocmd_bufwipe_in_SessLoadPost, line 24
```

This is caused by the confliction of temp file names between two running
vim processes. (Note that we execute gvim.exe and vim.exe in parallel on
GHA.)
We use GetTempFileNameW() in vim_tempname() to create a temp file name,
but GetTempFileNameW() creates the name based on the current system time.
And we delete the temp file in vim_tempname(). So, GetTempFileNameW()
can create the same file name.

Create a temp file name based on the PID to mitigate the confliction.