### PR TITLE
configure.ac: Avoid mis-detection with -Werror=implicit-function-declaration

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3593,7 +3593,13 @@ fi
 
 AC_MSG_CHECKING(for SVR4 ptys)
 if test -c /dev/ptmx ; then
-  AC_TRY_LINK([], [ptsname(0);grantpt(0);unlockpt(0);],
+  AC_TRY_LINK([], [
+#if STDC_HEADERS
+# include <stdlib.h>
+#endif
+		ptsname(0);
+		grantpt(0);
+		unlockpt(0);],
 	AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SVR4_PTYS),
 	AC_MSG_RESULT(no))
 else


### PR DESCRIPTION
Apple's new ARM silicon chips use a different calling convention for variadic arguments of functions (x86_64 would always use the same registers and then stack to pass arguments, but on arm64, all variadic arguments are always passed on the stack), so the compiler needs to know how a function was declared to correctly invoke it.

For this reason, Apple has made `-Werror=implicit-function-declaration` the default for its clang on macOS now. This affects any configure checks that do not include the headers required for the functions they attempt to locate, since the checks would now fail to compile even though the functions are available.

Fix this by including `stdlib.h` for `ptsname(3)`, `grantpt(3)` and `unlockpt(3)`, which are available on macOS, but are incorrectly detected as missing.