### PR TITLE
Problem:    Amiga: Can't find plugins

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -432,6 +432,11 @@ vim_main2(void)
     if (p_lpl)
     {
 	char_u *rtp_copy = NULL;
+	char_u *p_path = (char_u *) "plugin/"
+#if !defined(VMS) && !defined(AMIGA) // VMS and Amiga don't handle the "**".
+	"**/"
+#endif
+	"*.vim";
 
 	// First add all package directories to 'runtimepath', so that their
 	// autoload directories can be found.  Only if not done already with a
@@ -444,13 +449,7 @@ vim_main2(void)
 	    add_pack_start_dirs();
 	}
 
-	source_in_path(rtp_copy == NULL ? p_rtp : rtp_copy,
-# ifdef VMS	// Somehow VMS doesn't handle the "**".
-		(char_u *)"plugin/*.vim",
-# else
-		(char_u *)"plugin/**/*.vim",
-# endif
-		DIP_ALL | DIP_NOAFTER, NULL);
+	source_in_path(rtp_copy == NULL ? p_rtp : rtp_copy, p_path, DIP_ALL | DIP_NOAFTER, NULL);
 	TIME_MSG("loading plugins");
 	vim_free(rtp_copy);
 
@@ -460,11 +459,7 @@ vim_main2(void)
 	    load_start_packages();
 	TIME_MSG("loading packages");
 
-# ifdef VMS	// Somehow VMS doesn't handle the "**".
-	source_runtime((char_u *)"plugin/*.vim", DIP_ALL | DIP_AFTER);
-# else
-	source_runtime((char_u *)"plugin/**/*.vim", DIP_ALL | DIP_AFTER);
-# endif
+	source_runtime(p_path, DIP_ALL | DIP_AFTER);
 	TIME_MSG("loading after plugins");
 
     }


### PR DESCRIPTION
Solution:   Use the VMS path on Amiga

Also, I removed one ifdef to make it less intrusive. I put the p_path in the beginning of the if (p_lpl) scope to not break C89 compatibility.