### PR TITLE
Reduce allocations on map(), filter(), mapnew() against non-materialized list.

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -2164,7 +2164,7 @@ filter_map(typval_T *argvars, typval_T *rettv, filtermap_T filtermap)
 	    int	    prev_lock = l->lv_lock;
 	    list_T  *l_ret = NULL;
 
-	    if (filtermap == FILTERMAP_MAPNEW || l->lv_first == &range_list_item)
+	    if (filtermap == FILTERMAP_MAPNEW)
 	    {
 		if (rettv_list_alloc(rettv) == FAIL)
 		    return;
@@ -2179,8 +2179,15 @@ filter_map(typval_T *argvars, typval_T *rettv, filtermap_T filtermap)
 	    if (l->lv_first == &range_list_item)
 	    {
 		varnumber_T	val = l->lv_u.nonmat.lv_start;
+		int		len = l->lv_len;
+		int	    	stride = l->lv_u.nonmat.lv_stride;
 
-		for (idx = 0; idx < l->lv_len; ++idx)
+		l->lv_first = NULL;
+		l->lv_u.mat.lv_last = NULL;
+		l->lv_len = 0;
+		l->lv_u.mat.lv_idx_item = NULL;
+
+		for (idx = 0; idx < len; ++idx)
 		{
 		    typval_T tv;
 		    typval_T newtv;
@@ -2199,17 +2206,17 @@ filter_map(typval_T *argvars, typval_T *rettv, filtermap_T filtermap)
 		    if (filtermap != FILTERMAP_FILTER)
 		    {
 			// map(), mapnew(): always append the new value to the list
-			if (list_append_tv_move(l_ret, &newtv) == FAIL)
+			if (list_append_tv_move(filtermap == FILTERMAP_MAP ? l : l_ret, &newtv) == FAIL)
 			    break;
 		    }
 		    else if (!rem)
 		    {
 			// filter(): append the list item value when not rem
-			if (list_append_tv_move(l_ret, &tv) == FAIL)
+			if (list_append_tv_move(l, &tv) == FAIL)
 			    break;
 		    }
 
-		    val += l->lv_u.nonmat.lv_stride;
+		    val += stride;
 		}
 	    }
 	    else

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2302,6 +2302,7 @@ func Test_range()
 
   " filter()
   call assert_equal([1, 3], filter(range(5), 'v:val % 2'))
+  call assert_equal([1, 5, 7, 11, 13], filter(filter(range(15), 'v:val % 2'), 'v:val % 3'))
 
   " funcref()
   call assert_equal([0, 1], funcref('TwoArgs', range(2))())
@@ -2358,6 +2359,9 @@ func Test_range()
 
   " map()
   call assert_equal([0, 2, 4, 6, 8], map(range(5), 'v:val * 2'))
+  call assert_equal([3, 5, 7, 9, 11], map(map(range(5), 'v:val * 2'), 'v:val + 3'))
+  call assert_equal([2, 6], map(filter(range(5), 'v:val % 2'), 'v:val * 2'))
+  call assert_equal([2, 4, 8], filter(map(range(5), 'v:val * 2'), 'v:val % 3'))
 
   " match()
   call assert_equal(3, match(range(5), 3))


### PR DESCRIPTION
I noticed that we can skip materializing the `range()` list in the argument of
`map()`, `filter()` and `mapnew()`. This patch builds the result list without
materializing the `range()` list. I think the `map(range(` pattern appears
often in plugins.
