### PR TITLE
Add v:exiting variable to get the Vim exit code

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1214,6 +1214,7 @@ VimLeave			Before exiting Vim, just after writing the
 				To detect an abnormal exit use |v:dying|.
 				When v:dying is 2 or more this event is not
 				triggered.
+				To get the exit code use |v:exiting|.
 							*VimLeavePre*
 VimLeavePre			Before exiting Vim, just before writing the
 				.viminfo file.  This is executed only once,
@@ -1224,6 +1225,7 @@ VimLeavePre			Before exiting Vim, just before writing the
 <				To detect an abnormal exit use |v:dying|.
 				When v:dying is 2 or more this event is not
 				triggered.
+				To get the exit code use |v:exiting|.
 							*VimResized*
 VimResized			After the Vim window was resized, thus 'lines'
 				and/or 'columns' changed.  Not when starting

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1850,6 +1850,13 @@ v:dying		Normally zero.  When a deadly signal is caught it's set to
 <		Note: if another deadly signal is caught when v:dying is one,
 		VimLeave autocommands will not be executed.
 
+					*v:exiting* *exiting-variable*
+v:exiting	Vim exit code, or v:null if not exiting. Set before calling
+		the |VimLeavePre| and |VimLeave| autocmds. See |:q|, |:x| and
+		|:cquit|.
+		Example: >
+			:au VimLeave * echo "Exit code = " .. v:exiting
+<
 					*v:echospace* *echospace-variable*
 v:echospace	Number of screen cells that can be used for an `:echo` message
 		in the last screen line before causing the |hit-enter-prompt|.
@@ -5052,9 +5059,9 @@ getbufvar({expr}, {varname} [, {def}])				*getbufvar()*
 		The result is the value of option or local buffer variable
 		{varname} in buffer {expr}.  Note that the name without "b:"
 		must be used.
-		When {varname} is empty returns a dictionary with all the
+		When {varname} is empty returns a |Dictionary| with all the
 		buffer-local variables.
-		When {varname} is equal to "&" returns a dictionary with all
+		When {varname} is equal to "&" returns a |Dictionary| with all
 		the buffer-local options.
 		Otherwise, when {varname} starts with "&" returns the value of
 		a buffer-local option.
@@ -5526,8 +5533,8 @@ getloclist({nr} [, {what}])				*getloclist()*
 					|location-list-file-window| for more
 					details.
 
-		Returns a Dictionary with default values if there is no location
-		list for the window {nr}.
+		Returns a |Dictionary| with default values if there is no
+		location list for the window {nr}.
 		Returns an empty Dictionary if window {nr} does not exist.
 
 		Examples (See also |getqflist-examples|): >
@@ -5640,7 +5647,7 @@ getpos({expr})	Get the position for {expr}.  For possible values of {expr}
 
 
 getqflist([{what}])					*getqflist()*
-		Returns a list with all the current quickfix errors.  Each
+		Returns a |List| with all the current quickfix errors.  Each
 		list item is a dictionary with these entries:
 			bufnr	number of buffer that has the file name, use
 				bufname() to get the name
@@ -7375,7 +7382,7 @@ matchend({expr}, {pat} [, {start} [, {count}]])			*matchend()*
 
 
 matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
-		If {list} is a list of strings, then returns a list with all
+		If {list} is a list of strings, then returns a |List| with all
 		the strings in {list} that fuzzy match {str}. The strings in
 		the returned list are sorted based on the matching score.
 
@@ -10653,7 +10660,7 @@ tagfiles()	Returns a |List| with the file names used to search for tags
 
 
 taglist({expr} [, {filename}])				*taglist()*
-		Returns a list of tags matching the regular expression {expr}.
+		Returns a |List| of tags matching the regular expression {expr}.
 
 		If {filename} is passed it is used to prioritize the results
 		in the same way that |:tselect| does. See |tag-priority|.
@@ -10745,7 +10752,7 @@ term_ functions are documented here: |terminal-function-details|
 
 
 terminalprops()						*terminalprops()*
-		Returns a dictionary with properties of the terminal that Vim
+		Returns a |Dictionary| with properties of the terminal that Vim
 		detected from the response to |t_RV| request.  See
 		|v:termresponse| for the response itself.  If |v:termresponse|
 		is empty most values here will be 'u' for unknown.
@@ -11152,7 +11159,7 @@ win_execute({id}, {command} [, {silent}])		*win_execute()*
 			GetCommand()->win_execute(winid)
 
 win_findbuf({bufnr})					*win_findbuf()*
-		Returns a list with |window-ID|s for windows that contain
+		Returns a |List| with |window-ID|s for windows that contain
 		buffer {bufnr}.  When there is none the list is empty.
 
 		Can also be used as a |method|: >

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -146,6 +146,7 @@ static struct vimvar
     {VV_NAME("echospace",	 VAR_NUMBER), VV_RO},
     {VV_NAME("argv",		 VAR_LIST), VV_RO},
     {VV_NAME("collate",		 VAR_STRING), VV_RO},
+    {VV_NAME("exiting",		 VAR_SPECIAL), VV_RO},
 };
 
 // shorthand
@@ -218,6 +219,7 @@ evalvars_init(void)
 
     set_vim_var_nr(VV_SEARCHFORWARD, 1L);
     set_vim_var_nr(VV_HLSEARCH, 1L);
+    set_vim_var_nr(VV_EXITING, VVAL_NULL);
     set_vim_var_dict(VV_COMPLETED_ITEM, dict_alloc_lock(VAR_FIXED));
     set_vim_var_list(VV_ERRORS, list_alloc());
     set_vim_var_dict(VV_EVENT, dict_alloc_lock(VAR_FIXED));

--- a/src/main.c
+++ b/src/main.c
@@ -1521,6 +1521,11 @@ getout(int exitval)
     if (exmode_active)
 	exitval += ex_exitval;
 
+#ifdef FEAT_EVAL
+    set_vim_var_type(VV_EXITING, VAR_NUMBER);
+    set_vim_var_nr(VV_EXITING, exitval);
+#endif
+
     // Position the cursor on the last screen line, below all the text
 #ifdef FEAT_GUI
     if (!gui.in_use)

--- a/src/testdir/test_exit.vim
+++ b/src/testdir/test_exit.vim
@@ -82,4 +82,31 @@ func Test_exiting()
   call delete('Xtestout')
 endfunc
 
+" Test for getting the Vim exit code from v:exiting
+func Test_exit_code()
+  call assert_equal(v:null, v:exiting)
+
+  let before =<< trim [CODE]
+    au QuitPre * call writefile(['qp = ' .. v:exiting], 'Xtestout', 'a')
+    au ExitPre * call writefile(['ep = ' .. v:exiting], 'Xtestout', 'a')
+    au VimLeavePre * call writefile(['lp = ' .. v:exiting], 'Xtestout', 'a')
+    au VimLeave * call writefile(['l = ' .. v:exiting], 'Xtestout', 'a')
+  [CODE]
+
+  if RunVim(before, ['quit'], '')
+    call assert_equal(['qp = v:null', 'ep = v:null', 'lp = 0', 'l = 0'], readfile('Xtestout'))
+  endif
+  call delete('Xtestout')
+
+  if RunVim(before, ['cquit'], '')
+    call assert_equal(['lp = 1', 'l = 1'], readfile('Xtestout'))
+  endif
+  call delete('Xtestout')
+
+  if RunVim(before, ['cquit 4'], '')
+    call assert_equal(['lp = 4', 'l = 4'], readfile('Xtestout'))
+  endif
+  call delete('Xtestout')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -5253,7 +5253,7 @@ func Test_quickfix_window_fails_to_open()
   call delete('XquickfixFails')
 endfunc
 
-" Test for updating the quickfix buffer whenever the assocaited quickfix list
+" Test for updating the quickfix buffer whenever the associated quickfix list
 " is changed.
 func Xqfbuf_update(cchar)
   call s:setup_commands(a:cchar)

--- a/src/vim.h
+++ b/src/vim.h
@@ -1996,7 +1996,8 @@ typedef int sock_T;
 #define VV_ECHOSPACE	93
 #define VV_ARGV		94
 #define VV_COLLATE      95
-#define VV_LEN		96	// number of v: vars
+#define VV_EXITING	96
+#define VV_LEN		97	// number of v: vars
 
 // used for v_number in VAR_BOOL and VAR_SPECIAL
 #define VVAL_FALSE	0L	// VAR_BOOL


### PR DESCRIPTION
Port the support for v:exiting variable from Neovim:

https://github.com/neovim/neovim/pull/5651
https://github.com/neovim/neovim/commit/d2e8c76dc22460ddfde80477dd93aab3d5866506
