### PR TITLE
Fix test_libvterm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -240,8 +240,6 @@ jobs:
       env:
         - *linux-huge
         - *coverage
-        # Clang cannot compile test_libvterm with "--coverage" flag.
-        - TEST=scripttests
       after_success: *eval-coverage
     - <<: *linux
       name: huge+coverage/gcc

--- a/src/Makefile
+++ b/src/Makefile
@@ -2293,8 +2293,11 @@ run_message_test: $(MESSAGE_TEST_TARGET)
 	$(VALGRIND) ./$(MESSAGE_TEST_TARGET) || exit 1; echo $* passed;
 
 # Run the libvterm tests.
+# This works only on GNU make, not on BSD make.
 test_libvterm:
-	cd libvterm; $(MAKE) -f Makefile test CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)"
+	@if $(MAKE) --version 2>/dev/null | grep -qs "GNU Make"; then \
+		cd libvterm; $(MAKE) -f Makefile test CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)"; \
+	fi
 
 # Run individual OLD style test.
 # These do not depend on the executable, compile it when needed.

--- a/src/Makefile
+++ b/src/Makefile
@@ -2293,12 +2293,8 @@ run_message_test: $(MESSAGE_TEST_TARGET)
 	$(VALGRIND) ./$(MESSAGE_TEST_TARGET) || exit 1; echo $* passed;
 
 # Run the libvterm tests.
-# This currently doesn't work on Mac, only run on Linux for now.
 test_libvterm:
-	@if test `uname` = "Linux"; then \
-		cd libvterm; $(MAKE) -f Makefile test \
-			CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)"; \
-	fi
+	cd libvterm; $(MAKE) -f Makefile test CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)"
 
 # Run individual OLD style test.
 # These do not depend on the executable, compile it when needed.

--- a/src/libvterm/Makefile
+++ b/src/libvterm/Makefile
@@ -78,7 +78,7 @@ t/harness.lo: t/harness.c $(HFILES)
 	$(LIBTOOL) --mode=compile --tag=CC $(CC) $(CFLAGS) -o $@ -c $<
 
 t/harness: t/harness.lo $(LIBRARY)
-	$(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	$(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -static
 
 .PHONY: test
 test: $(LIBRARY) t/harness

--- a/src/libvterm/t/run-test.pl
+++ b/src/libvterm/t/run-test.pl
@@ -8,7 +8,7 @@ use IPC::Open2 qw( open2 );
 use POSIX qw( WIFEXITED WEXITSTATUS WIFSIGNALED WTERMSIG );
 
 my $VALGRIND = 0;
-my $EXECUTABLE = "t/.libs/harness";
+my $EXECUTABLE = "t/harness";
 GetOptions(
    'valgrind|v+' => \$VALGRIND,
    'executable|e=s' => \$EXECUTABLE,
@@ -17,7 +17,6 @@ GetOptions(
 
 my ( $hin, $hout, $hpid );
 {
-   local $ENV{LD_LIBRARY_PATH} = ".libs";
    my @command = $EXECUTABLE;
    unshift @command, "valgrind", "--tool=memcheck", "--leak-check=yes", "--num-callers=25", "--log-file=valgrind.out", "--error-exitcode=126" if $VALGRIND;
 


### PR DESCRIPTION
Now there are 2 problem about test_libvterm:

1. Cannot build by clang with coverage option on Linux

 DSO are built by clang but shared library is by gcc so llvm_gcda_*
 (hidden symbols in libclang_rt) are unresolved in the library and
 then the linkage error occurs at building the executable.

2. Cannot run on macOS

 In run-test.pl, set "LD_LIBRARY_PATH" to ".libs" in order to link
 with the shared library at invoking the executable, but macOS doesn't
 interpret it; macOS uses "DYLD_LIBRARY_PATH".

Can solve them by linking a static library instead of shared.

I think we only have to test it as a static library, since Vim uses libvterm as embedded objects, not as a shared library.