### PR TITLE
Fixed and speed up flaky sound test

### DIFF
--- a/src/testdir/test_sound.vim
+++ b/src/testdir/test_sound.vim
@@ -47,7 +47,6 @@ func Test_play_silent()
   sleep 20m
   call sound_clear()
   call WaitForAssert({-> assert_equal(id2, g:id)})
-  call assert_equal(id2, g:id)
   call assert_equal(1, g:result)  " sound was aborted
 
   " recursive use was causing a crash

--- a/src/testdir/test_sound.vim
+++ b/src/testdir/test_sound.vim
@@ -1,5 +1,7 @@
 " Tests for the sound feature
 
+source shared.vim
+
 if !has('sound')
   throw 'Skipped: sound feature not available'
 endif
@@ -13,6 +15,7 @@ func Test_play_event()
   if has('win32')
     throw 'Skipped: Playing event with callback is not supported on Windows'
   endif
+  let g:id = 0
   let id = 'bell'->sound_playevent('PlayCallback')
   if id == 0
     throw 'Skipped: bell event not available'
@@ -20,8 +23,7 @@ func Test_play_event()
   " Stop it quickly, avoid annoying the user.
   sleep 20m
   eval id->sound_stop()
-  sleep 30m
-  call assert_equal(id, g:id)
+  call WaitForAssert({-> assert_equal(id, g:id)})
   call assert_equal(1, g:result)  " sound was aborted
 endfunc
 
@@ -37,17 +39,16 @@ func Test_play_silent()
   " play until the end
   let id2 = fname->sound_playfile('PlayCallback')
   call assert_true(id2 > 0)
-  sleep 500m
-  call assert_equal(id2, g:id)
+  call WaitForAssert({-> assert_equal(id2, g:id)})
   call assert_equal(0, g:result)
 
   let id2 = sound_playfile(fname, 'PlayCallback')
   call assert_true(id2 > 0)
   sleep 20m
   call sound_clear()
-  sleep 30m
+  call WaitForAssert({-> assert_equal(id2, g:id)})
   call assert_equal(id2, g:id)
-  call assert_equal(1, g:result)
+  call assert_equal(1, g:result)  " sound was aborted
 
   " recursive use was causing a crash
   func PlayAgain(id, fname)
@@ -59,8 +60,7 @@ func Test_play_silent()
   call assert_true(id3 > 0)
   sleep 50m
   call sound_clear()
-  sleep 30m
-  call assert_true(g:id_again > 0)
+  call WaitForAssert({-> assert_true(g:id > 0)})
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
I noticed that the sound test is flaky.   I have a script that runs vim tests
with various vim configurations and the sound tests sometimes fail, always
with the same error:

```
1 FAILED:
Found errors in Test_play_silent():
command line..script /home/dope/sb/vim/src/testdir/runtest.vim[468]..function RunTheTest[39]..Test_play_silent line 13: Expected 3 but got 1
command line..script /home/dope/sb/vim/src/testdir/runtest.vim[468]..function RunTheTest[39]..Test_play_silent line 14: Expected 0 but got 1
```
I think it fails because the test relies on a sleep duration.
I don't see any test failure anymore after this proposed fix.

The sound tests are also a bit faster after fix:

Before:
```
  Executed Test_play_event()                         in   0.061738 seconds
  Executed Test_play_silent()                        in   1.371140 seconds
```
After:
```
Executed Test_play_event()                         in   0.040143 seconds
Executed Test_play_silent()                        in   1.167930 seconds
```