### PR TITLE
Fix if_ruby build warnings

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -7617,11 +7617,10 @@ $as_echo "$rubyhdrdir" >&6; }
 	librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print $ruby_rbconfig.expand($ruby_rbconfig::CONFIG['LIBRUBYARG'])"`
 	librubya=`$vi_cv_path_ruby -r rbconfig -e "print $ruby_rbconfig.expand($ruby_rbconfig::CONFIG['LIBRUBY_A'])"`
 	rubylibdir=`$vi_cv_path_ruby -r rbconfig -e "print $ruby_rbconfig.expand($ruby_rbconfig::CONFIG['libdir'])"`
-	if test -f "$rubylibdir/$librubya"; then
-	  librubyarg="$librubyarg"
+	if test -f "$rubylibdir/$librubya" || expr "$librubyarg" : "-lruby"; then
 	  RUBY_LIBS="$RUBY_LIBS -L$rubylibdir"
 	elif test "$librubyarg" = "libruby.a"; then
-	  	  librubyarg="-lruby"
+	  librubyarg="-lruby"
 	  RUBY_LIBS="$RUBY_LIBS -L$rubylibdir"
 	fi
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1965,8 +1965,7 @@ if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
 	librubyarg=`$vi_cv_path_ruby -r rbconfig -e "print $ruby_rbconfig.expand($ruby_rbconfig::CONFIG[['LIBRUBYARG']])"`
 	librubya=`$vi_cv_path_ruby -r rbconfig -e "print $ruby_rbconfig.expand($ruby_rbconfig::CONFIG[['LIBRUBY_A']])"`
 	rubylibdir=`$vi_cv_path_ruby -r rbconfig -e "print $ruby_rbconfig.expand($ruby_rbconfig::CONFIG[['libdir']])"`
-	if test -f "$rubylibdir/$librubya"; then
-	  librubyarg="$librubyarg"
+	if test -f "$rubylibdir/$librubya" || expr "$librubyarg" : "-lruby"; then
 	  RUBY_LIBS="$RUBY_LIBS -L$rubylibdir"
 	elif test "$librubyarg" = "libruby.a"; then
 	  dnl required on Mac OS 10.3 where libruby.a doesn't exist

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -1300,13 +1300,19 @@ vim_blob(VALUE self UNUSED, VALUE str)
 }
 
     static VALUE
-buffer_s_current(void)
+buffer_s_current(VALUE self UNUSED)
 {
     return buffer_new(curbuf);
 }
 
     static VALUE
-buffer_s_count(void)
+buffer_s_current_getter(ID id UNUSED, VALUE *x UNUSED)
+{
+    return buffer_new(curbuf);
+}
+
+    static VALUE
+buffer_s_count(VALUE self UNUSED)
 {
     buf_T *b;
     int n = 0;
@@ -1566,7 +1572,13 @@ get_win(VALUE obj)
 }
 
     static VALUE
-window_s_current(void)
+window_s_current(VALUE self UNUSED)
+{
+    return window_new(curwin);
+}
+
+    static VALUE
+window_s_current_getter(ID id UNUSED, VALUE *x UNUSED)
 {
     return window_new(curwin);
 }
@@ -1576,7 +1588,7 @@ window_s_current(void)
  *    SegPhault - 03/07/05
  */
     static VALUE
-line_s_current(void)
+line_s_current(VALUE self UNUSED)
 {
     return get_buffer_line(curbuf, curwin->w_cursor.lnum);
 }
@@ -1588,13 +1600,13 @@ set_current_line(VALUE self UNUSED, VALUE str)
 }
 
     static VALUE
-current_line_number(void)
+current_line_number(VALUE self UNUSED)
 {
     return INT2FIX((int)curwin->w_cursor.lnum);
 }
 
     static VALUE
-window_s_count(void)
+window_s_count(VALUE self UNUSED)
 {
     win_T	*w;
     int n = 0;
@@ -1794,8 +1806,8 @@ ruby_vim_init(void)
     rb_define_method(cVimWindow, "cursor", window_cursor, 0);
     rb_define_method(cVimWindow, "cursor=", window_set_cursor, 1);
 
-    rb_define_virtual_variable("$curbuf", buffer_s_current, 0);
-    rb_define_virtual_variable("$curwin", window_s_current, 0);
+    rb_define_virtual_variable("$curbuf", buffer_s_current_getter, 0);
+    rb_define_virtual_variable("$curwin", window_s_current_getter, 0);
 }
 
     void


### PR DESCRIPTION
Building if_ruby with Ruby 2.7 and non-dynamic (`--enable-rubyinterp=yes`) shows the following warnings:

```
gcc -c -I. -I/usr/include/ruby-2.7.0 -I/usr/include/x86_64-linux-gnu/ruby-2.7.0 -DRUBY_VERSION=27 -Iproto -DHAVE_CONFIG_H   -DWE_ARE_PROFILING  -Wall -Wextra -Wshadow -Wno-unknown-pragmas -g -ggdb3 -O0 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/if_ruby.o if_ruby.c
In file included from /usr/include/ruby-2.7.0/ruby/ruby.h:2148,
                 from /usr/include/ruby-2.7.0/ruby.h:33,
                 from if_ruby.c:109:
if_ruby.c: In function ‘ruby_vim_init’:
/usr/include/ruby-2.7.0/ruby/intern.h:1218:137: warning: passing argument 3 of ‘rb_define_singleton_method0’ from incompatible pointer type [-Wincompatible-pointer-types]
 1218 | #define rb_define_singleton_method(klass, mid, func, arity) rb_define_singleton_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));
      |                                                                                                                                         ^~~~~~
      |                                                                                                                                         |
      |                                                                                                                                         VALUE (*)(void) {aka long unsigned int (*)(void)}
if_ruby.c:1766:5: note: in expansion of macro ‘rb_define_singleton_method’
 1766 |     rb_define_singleton_method(cBuffer, "current", buffer_s_current, 0);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1195:27: note: expected ‘VALUE (*)(VALUE)’ {aka ‘long unsigned int (*)(long unsigned int)’} but argument is of type ‘VALUE (*)(void)’ {aka ‘long unsigned int (*)(void)’}
 1195 | RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1042:82: note: in definition of macro ‘RB_METHOD_DEFINITION_DECL_C’
 1042 |     __attribute__((__unused__,__weakref__(#def),__nonnull__ nonnull))static void defname(RB_UNWRAP_MACRO decl,VALUE(*func)funcargs,int arity);
      |                                                                                  ^~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1074:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL_1’
 1074 | RB_METHOD_DEFINITION_DECL_1(def,nonnull,def##0 ,0 ,decl,vars,(VALUE)) \
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1195:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL’
 1195 | RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1218:137: warning: passing argument 3 of ‘rb_define_singleton_method0’ from incompatible pointer type [-Wincompatible-pointer-types]
 1218 | #define rb_define_singleton_method(klass, mid, func, arity) rb_define_singleton_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));
      |                                                                                                                                         ^~~~~~
      |                                                                                                                                         |
      |                                                                                                                                         VALUE (*)(void) {aka long unsigned int (*)(void)}
if_ruby.c:1767:5: note: in expansion of macro ‘rb_define_singleton_method’
 1767 |     rb_define_singleton_method(cBuffer, "count", buffer_s_count, 0);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1195:27: note: expected ‘VALUE (*)(VALUE)’ {aka ‘long unsigned int (*)(long unsigned int)’} but argument is of type ‘VALUE (*)(void)’ {aka ‘long unsigned int (*)(void)’}
 1195 | RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1042:82: note: in definition of macro ‘RB_METHOD_DEFINITION_DECL_C’
 1042 |     __attribute__((__unused__,__weakref__(#def),__nonnull__ nonnull))static void defname(RB_UNWRAP_MACRO decl,VALUE(*func)funcargs,int arity);
      |                                                                                  ^~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1074:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL_1’
 1074 | RB_METHOD_DEFINITION_DECL_1(def,nonnull,def##0 ,0 ,decl,vars,(VALUE)) \
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1195:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL’
 1195 | RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/ruby-2.7.0/ruby.h:33,
                 from if_ruby.c:109:
/usr/include/ruby-2.7.0/ruby/ruby.h:2799:117: warning: passing argument 3 of ‘rb_define_method0’ from incompatible pointer type [-Wincompatible-pointer-types]
 2799 | #define rb_define_method(klass, mid, func, arity) rb_define_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));
      |                                                                                                                     ^~~~~~
      |                                                                                                                     |
      |                                                                                                                     VALUE (*)(void) {aka long unsigned int (*)(void)}
if_ruby.c:1780:5: note: in expansion of macro ‘rb_define_method’
 1780 |     rb_define_method(cBuffer, "line_number", current_line_number, 0);
      |     ^~~~~~~~~~~~~~~~
In file included from /usr/include/ruby-2.7.0/ruby/ruby.h:2148,
                 from /usr/include/ruby-2.7.0/ruby.h:33,
                 from if_ruby.c:109:
/usr/include/ruby-2.7.0/ruby/ruby.h:2775:27: note: expected ‘VALUE (*)(VALUE)’ {aka ‘long unsigned int (*)(long unsigned int)’} but argument is of type ‘VALUE (*)(void)’ {aka ‘long unsigned int (*)(void)’}
 2775 | RB_METHOD_DEFINITION_DECL(rb_define_method, (2,3), (VALUE klass, const char *name), (klass, name))
      |                           ^~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1042:82: note: in definition of macro ‘RB_METHOD_DEFINITION_DECL_C’
 1042 |     __attribute__((__unused__,__weakref__(#def),__nonnull__ nonnull))static void defname(RB_UNWRAP_MACRO decl,VALUE(*func)funcargs,int arity);
      |                                                                                  ^~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1074:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL_1’
 1074 | RB_METHOD_DEFINITION_DECL_1(def,nonnull,def##0 ,0 ,decl,vars,(VALUE)) \
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/ruby.h:2775:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL’
 2775 | RB_METHOD_DEFINITION_DECL(rb_define_method, (2,3), (VALUE klass, const char *name), (klass, name))
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/ruby-2.7.0/ruby.h:33,
                 from if_ruby.c:109:
/usr/include/ruby-2.7.0/ruby/ruby.h:2799:117: warning: passing argument 3 of ‘rb_define_method0’ from incompatible pointer type [-Wincompatible-pointer-types]
 2799 | #define rb_define_method(klass, mid, func, arity) rb_define_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));
      |                                                                                                                     ^~~~~~
      |                                                                                                                     |
      |                                                                                                                     VALUE (*)(void) {aka long unsigned int (*)(void)}
if_ruby.c:1781:5: note: in expansion of macro ‘rb_define_method’
 1781 |     rb_define_method(cBuffer, "line", line_s_current, 0);
      |     ^~~~~~~~~~~~~~~~
In file included from /usr/include/ruby-2.7.0/ruby/ruby.h:2148,
                 from /usr/include/ruby-2.7.0/ruby.h:33,
                 from if_ruby.c:109:
/usr/include/ruby-2.7.0/ruby/ruby.h:2775:27: note: expected ‘VALUE (*)(VALUE)’ {aka ‘long unsigned int (*)(long unsigned int)’} but argument is of type ‘VALUE (*)(void)’ {aka ‘long unsigned int (*)(void)’}
 2775 | RB_METHOD_DEFINITION_DECL(rb_define_method, (2,3), (VALUE klass, const char *name), (klass, name))
      |                           ^~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1042:82: note: in definition of macro ‘RB_METHOD_DEFINITION_DECL_C’
 1042 |     __attribute__((__unused__,__weakref__(#def),__nonnull__ nonnull))static void defname(RB_UNWRAP_MACRO decl,VALUE(*func)funcargs,int arity);
      |                                                                                  ^~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1074:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL_1’
 1074 | RB_METHOD_DEFINITION_DECL_1(def,nonnull,def##0 ,0 ,decl,vars,(VALUE)) \
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/ruby.h:2775:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL’
 2775 | RB_METHOD_DEFINITION_DECL(rb_define_method, (2,3), (VALUE klass, const char *name), (klass, name))
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1218:137: warning: passing argument 3 of ‘rb_define_singleton_method0’ from incompatible pointer type [-Wincompatible-pointer-types]
 1218 | #define rb_define_singleton_method(klass, mid, func, arity) rb_define_singleton_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));
      |                                                                                                                                         ^~~~~~
      |                                                                                                                                         |
      |                                                                                                                                         VALUE (*)(void) {aka long unsigned int (*)(void)}
if_ruby.c:1786:5: note: in expansion of macro ‘rb_define_singleton_method’
 1786 |     rb_define_singleton_method(cVimWindow, "current", window_s_current, 0);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1195:27: note: expected ‘VALUE (*)(VALUE)’ {aka ‘long unsigned int (*)(long unsigned int)’} but argument is of type ‘VALUE (*)(void)’ {aka ‘long unsigned int (*)(void)’}
 1195 | RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1042:82: note: in definition of macro ‘RB_METHOD_DEFINITION_DECL_C’
 1042 |     __attribute__((__unused__,__weakref__(#def),__nonnull__ nonnull))static void defname(RB_UNWRAP_MACRO decl,VALUE(*func)funcargs,int arity);
      |                                                                                  ^~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1074:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL_1’
 1074 | RB_METHOD_DEFINITION_DECL_1(def,nonnull,def##0 ,0 ,decl,vars,(VALUE)) \
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1195:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL’
 1195 | RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1218:137: warning: passing argument 3 of ‘rb_define_singleton_method0’ from incompatible pointer type [-Wincompatible-pointer-types]
 1218 | #define rb_define_singleton_method(klass, mid, func, arity) rb_define_singleton_method_choose_prototypem3((arity),(func))((klass),(mid),(func),(arity));
      |                                                                                                                                         ^~~~~~
      |                                                                                                                                         |
      |                                                                                                                                         VALUE (*)(void) {aka long unsigned int (*)(void)}
if_ruby.c:1787:5: note: in expansion of macro ‘rb_define_singleton_method’
 1787 |     rb_define_singleton_method(cVimWindow, "count", window_s_count, 0);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1195:27: note: expected ‘VALUE (*)(VALUE)’ {aka ‘long unsigned int (*)(long unsigned int)’} but argument is of type ‘VALUE (*)(void)’ {aka ‘long unsigned int (*)(void)’}
 1195 | RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1042:82: note: in definition of macro ‘RB_METHOD_DEFINITION_DECL_C’
 1042 |     __attribute__((__unused__,__weakref__(#def),__nonnull__ nonnull))static void defname(RB_UNWRAP_MACRO decl,VALUE(*func)funcargs,int arity);
      |                                                                                  ^~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1074:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL_1’
 1074 | RB_METHOD_DEFINITION_DECL_1(def,nonnull,def##0 ,0 ,decl,vars,(VALUE)) \
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/ruby-2.7.0/ruby/intern.h:1195:1: note: in expansion of macro ‘RB_METHOD_DEFINITION_DECL’
 1195 | RB_METHOD_DEFINITION_DECL(rb_define_singleton_method, (2,3), (VALUE klass, const char *name), (klass, name))
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
if_ruby.c:1797:43: warning: passing argument 2 of ‘rb_define_virtual_variable’ from incompatible pointer type [-Wincompatible-pointer-types]
 1797 |     rb_define_virtual_variable("$curbuf", buffer_s_current, 0);
      |                                           ^~~~~~~~~~~~~~~~
      |                                           |
      |                                           VALUE (*)(void) {aka long unsigned int (*)(void)}
In file included from /usr/include/ruby-2.7.0/ruby.h:33,
                 from if_ruby.c:109:
/usr/include/ruby-2.7.0/ruby/ruby.h:1801:45: note: expected ‘VALUE (*)(ID,  VALUE *)’ {aka ‘long unsigned int (*)(long unsigned int,  long unsigned int *)’} but argument is of type ‘VALUE (*)(void)’ {aka ‘long unsigned int (*)(void)’}
 1801 | void rb_define_virtual_variable(const char*,rb_gvar_getter_t*,rb_gvar_setter_t*);
      |                                             ^~~~~~~~~~~~~~~~~
if_ruby.c:1798:43: warning: passing argument 2 of ‘rb_define_virtual_variable’ from incompatible pointer type [-Wincompatible-pointer-types]
 1798 |     rb_define_virtual_variable("$curwin", window_s_current, 0);
      |                                           ^~~~~~~~~~~~~~~~
      |                                           |
      |                                           VALUE (*)(void) {aka long unsigned int (*)(void)}
In file included from /usr/include/ruby-2.7.0/ruby.h:33,
                 from if_ruby.c:109:
/usr/include/ruby-2.7.0/ruby/ruby.h:1801:45: note: expected ‘VALUE (*)(ID,  VALUE *)’ {aka ‘long unsigned int (*)(long unsigned int,  long unsigned int *)’} but argument is of type ‘VALUE (*)(void)’ {aka ‘long unsigned int (*)(void)’}
 1801 | void rb_define_virtual_variable(const char*,rb_gvar_getter_t*,rb_gvar_setter_t*);
      |                                             ^~~~~~~~~~~~~~~~~
```