### PR TITLE
GTK3: fix white space around text in another way

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3816,11 +3816,11 @@ gui_mch_init(void)
 #if !GTK_CHECK_VERSION(3,0,0)
     gtk_widget_set_events(gui.formwin, GDK_EXPOSURE_MASK);
 #endif
+#if GTK_CHECK_VERSION(3,22,2)
+    gtk_widget_set_name(gui.formwin, "vim-gtk-form");
+#endif
 
     gui.drawarea = gtk_drawing_area_new();
-#if GTK_CHECK_VERSION(3,22,2)
-    gtk_widget_set_name(gui.drawarea, "vim-gui-drawarea");
-#endif
 #if GTK_CHECK_VERSION(3,0,0)
     gui.surface = NULL;
     gui.by_signal = FALSE;
@@ -4031,18 +4031,18 @@ set_cairo_source_rgba_from_color(cairo_t *cr, guicolor_T color)
     void
 gui_mch_new_colors(void)
 {
-    if (gui.drawarea != NULL && gtk_widget_get_window(gui.drawarea) != NULL)
+    if (gui.formwin != NULL && gtk_widget_get_window(gui.formwin) != NULL)
     {
 #if !GTK_CHECK_VERSION(3,22,2)
-	GdkWindow * const da_win = gtk_widget_get_window(gui.drawarea);
+	GdkWindow * const da_win = gtk_widget_get_window(gui.formwin);
 #endif
 
 #if GTK_CHECK_VERSION(3,22,2)
 	GtkStyleContext * const context
-	    = gtk_widget_get_style_context(gui.mainwin);
+	    = gtk_widget_get_style_context(gui.formwin);
 	GtkCssProvider * const provider = gtk_css_provider_new();
 	gchar * const css = g_strdup_printf(
-		"widget#vim-gui-drawarea, #vim-main-window {\n"
+		"widget#vim-gtk-form {\n"
 		"  background-color: #%.2lx%.2lx%.2lx;\n"
 		"}\n",
 		 (gui.back_pixel >> 16) & 0xff,


### PR DESCRIPTION
In the old way setting background color for the whole window affects
menubar background.

The white space belongs to the GtkForm containing the drawarea, so let's
set background color on that. The GtkForm also contains those scrollbars
but they have their own background color and thus not affected. (Whoever
changes part of the scrollbars to transparent should have considered the
background color of widget below since scrollbars can appear on vast
kinds of widgets.)

This fixes #7427.