### PR TITLE
doc: vim_cv_tty_group and vim_cv_tty_mode are useless

### DIFF
--- a/src/INSTALLx.txt
+++ b/src/INSTALLx.txt
@@ -131,14 +131,6 @@ vim_cv_toupper_broken:
 	Whether the "toupper" C library function works correctly. Set to "yes"
 	if you know it's broken, otherwise set to "no".
 
-vim_cv_tty_group:
-	The default group of pseudo terminals. Either set to the numeric value
-	of your tty group or to "world" if they are world accessible.
-
-vim_cv_tty_mode:
-	The default mode of pseudo terminals if they are not world accessible.
-	Most probably the value "0620".
-
 
 4. EXAMPLE:
 ===========
@@ -153,7 +145,6 @@ vim_cv_stat_ignores_slash=yes \
 vim_cv_tgetent=zero \
 vim_cv_terminfo=yes \
 vim_cv_toupper_broken=no \
-vim_cv_tty_group=world \
 ./configure \
 	--build=i586-linux \
 	--host=armeb-xscale-linux-gnu \


### PR DESCRIPTION
vim_cv_tty_group and vim_cv_tty_mode are useless since the
following commit:

* 01f731e97 (tag: v8.2.0680) patch 8.2.0680: PTYGROUP and PTYMODE are unused

Remove them from INSTALLx.txt.

Signed-off-by: Junling Zheng <zhengjunling@huawei.com>