### PR TITLE
gui_mch_new_colors: don't touch code path for earlier gtk3 versions

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4031,13 +4031,14 @@ set_cairo_source_rgba_from_color(cairo_t *cr, guicolor_T color)
     void
 gui_mch_new_colors(void)
 {
-    if (gui.formwin != NULL && gtk_widget_get_window(gui.formwin) != NULL)
+    if (gui.drawarea != NULL && gtk_widget_get_window(gui.drawarea) != NULL)
     {
 #if !GTK_CHECK_VERSION(3,22,2)
-	GdkWindow * const da_win = gtk_widget_get_window(gui.formwin);
+	GdkWindow * const da_win = gtk_widget_get_window(gui.drawarea);
 #endif
 
 #if GTK_CHECK_VERSION(3,22,2)
+	if (gui.formwin == NULL) return;
 	GtkStyleContext * const context
 	    = gtk_widget_get_style_context(gui.formwin);
 	GtkCssProvider * const provider = gtk_css_provider_new();


### PR DESCRIPTION
The earlier fix [caused issues for earlier version of gtk3](https://github.com/vim/vim/pull/7437#issuecomment-741378368). I don't have such an environment available for testing so let's keep the behavior before the fix.