### PR TITLE
Don't record "Scanning..." in messages history

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3426,9 +3426,11 @@ ins_compl_next(
 		    MB_PTR_ADV(s);
 		}
 	    }
+	    msg_hist_off = TRUE;
 	    vim_snprintf((char *)IObuff, IOSIZE, "%s %s%s", lead,
 				s > compl_shown_match->cp_fname ? "<" : "", s);
 	    msg((char *)IObuff);
+	    msg_hist_off = FALSE;
 	    redraw_cmdline = FALSE;	    // don't overwrite!
 	}
     }

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1298,6 +1298,7 @@ ins_compl_files(
 	fp = mch_fopen((char *)files[i], "r");  // open dictionary file
 	if (flags != DICT_EXACT)
 	{
+	    msg_hist_off = TRUE;	// reset in msg_trunc_attr()
 	    vim_snprintf((char *)IObuff, IOSIZE,
 			      _("Scanning dictionary: %s"), (char *)files[i]);
 	    (void)msg_trunc_attr((char *)IObuff, TRUE, HL_ATTR(HLF_R));
@@ -2778,6 +2779,7 @@ ins_compl_get_exp(pos_T *ini)
 		    dict = ins_buf->b_fname;
 		    dict_f = DICT_EXACT;
 		}
+		msg_hist_off = TRUE;	// reset in msg_trunc_attr()
 		vim_snprintf((char *)IObuff, IOSIZE, _("Scanning: %s"),
 			ins_buf->b_fname == NULL
 			    ? buf_spname(ins_buf)
@@ -2812,6 +2814,7 @@ ins_compl_get_exp(pos_T *ini)
 #endif
 		else if (*e_cpt == ']' || *e_cpt == 't')
 		{
+		    msg_hist_off = TRUE;	// reset in msg_trunc_attr()
 		    type = CTRL_X_TAGS;
 		    vim_snprintf((char *)IObuff, IOSIZE, _("Scanning tags."));
 		    (void)msg_trunc_attr((char *)IObuff, TRUE, HL_ATTR(HLF_R));

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4082,6 +4082,7 @@ ins_complete(int c, int enable_pum)
 		// Space for 10 text chars. + 2x10-digit no.s = 31.
 		// Translations may need more than twice that.
 		static char_u match_ref[81];
+		msg_hist_off = TRUE;
 
 		if (compl_matches > 0)
 		    vim_snprintf((char *)match_ref, sizeof(match_ref),
@@ -4091,6 +4092,7 @@ ins_complete(int c, int enable_pum)
 		    vim_snprintf((char *)match_ref, sizeof(match_ref),
 				_("match %d"),
 				compl_curr_match->cp_number);
+		msg_hist_off = FALSE;
 		edit_submode_extra = match_ref;
 		edit_submode_highl = HLF_R;
 		if (dollar_vcol >= 0)

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -720,12 +720,10 @@ func Test_z1_complete_no_history()
   messages clear
   let currmess = execute('messages')
   setlocal dictionary=README.txt
-  setlocal tags=./tags;
   " without 'c', messages of the type "match n of N" are still recorded
   let oldshm = &shortmess
   set shortmess+=c
   exe "normal owh\<C-X>\<C-K>"
-  exe "normal owh\<C-X>\<C-]>"
   exe "normal owh\<C-N>"
   call assert_equal(currmess, execute('messages'))
   let &shortmess = oldshm

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -714,4 +714,21 @@ func Test_issue_7021()
   set completeslash=
 endfunc
 
+" Test to ensure 'Scanning...' messages are not recorded in messages history
+func Test_z1_complete_no_history()
+  new
+  messages clear
+  let currmess = execute('messages')
+  setlocal dictionary=README.txt
+  setlocal tags=./tags;
+  " without 'c', messages of the type "match n of N" are still recorded
+  let oldshm = &shortmess
+  set shortmess+=c
+  exe "normal owh\<C-X>\<C-K>"
+  exe "normal owh\<C-X>\<C-]>"
+  exe "normal owh\<C-N>"
+  call assert_equal(currmess, execute('messages'))
+  let &shortmess = oldshm
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -729,6 +729,7 @@ func Test_z1_complete_no_history()
   exe "normal owh\<C-N>"
   call assert_equal(currmess, execute('messages'))
   let &shortmess = oldshm
+  close!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This was already the behaviour for scanning included files, I extended
the same logic to other completion methods, using the same approach of
setting the variable msg_hist_off to TRUE just before the message is
printed.

For reference:

https://github.com/vim/vim/blob/08597875b2a1e7d118b0346c652a96e7527e7d8b/src/search.c#L3608

it's where the message for included files is printed.

Related issue:  #3412