### PR TITLE
Bugfix - Prevent syntax resets in "less" macro

### DIFF
--- a/runtime/macros/less.vim
+++ b/runtime/macros/less.vim
@@ -36,7 +36,14 @@ if argc() > 0
 endif
 
 set nocp
-syntax on
+
+" Only enable syntax if it hasn't already been enabled.
+"
+" (This prevents clobbering of user-set highlights)
+if !exists("g:syntax_on")
+  syntax on
+endif
+
 set so=0
 set hlsearch
 set incsearch


### PR DESCRIPTION
# What

This PR updates the `less` macro to not reset highlights by changing the `syntax on` call to conditionally call it only if syntax
hasn't already been turned on.


# Why?

I recently started using the `less.sh` macro, and while its great, I noticed that my highlights were being reset, while my other settings were still intact.

I looked at the `less.sh` and `less.vim` source and saw that they are adding the `macros/less.vim` to the runtime, which I then found was resetting styles via the `syntax on` call, similar to how a color-scheme would, which seemed strange.

This PR is a best effort (its my first contribution to Vim...) to remedy that situation in the least amount of code changed.