### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           do_test make ${SHADOWOPT} ${TEST}
 
       - name: Coveralls
-        if: matrix.coverage && success()
+        if: matrix.coverage && success() && github.event_name != 'pull_request'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_PARALLEL: true
@@ -228,7 +228,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: linux
-    if: always()
+    if: github.event_name != 'pull_request'
 
     steps:
       - name: Parallel finished

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: GitHub CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ['**']
+  pull_request:
 
 jobs:
   linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,8 +213,11 @@ jobs:
 
       - name: Codecov
         if: matrix.coverage && success()
-        run: |
-          cd "${SRCDIR}" && bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v1
+        with:
+          flags: ${{ matrix.features }}-${{ matrix.compiler }}-${{ matrix.extra }}
+          fail_ci_if_error: true
+          working-directory: ${{ env.SRCDIR }}
 
       - name: ASan logs
         if: contains(matrix.extra, 'asan') && !cancelled()

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,15 +31,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
#7433 

* Sorry, I changed by mistake that CI runs also when a tag pushed... it does not need.

* Fix the warning about codeql-analysis: remove "git checkout HEAD^2" step and checkout action argument. 
https://github.com/vim/vim/pull/7433#issuecomment-747699306