### PR TITLE
Test startup arguments -T (which sets 'term') and -x (encryption)

### DIFF
--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -741,6 +741,52 @@ func Test_t_arg()
   call delete('Xfile1')
 endfunc
 
+" Test the '-T' argument which sets the 'term' option.
+func Test_T_arg()
+  let after =<< trim [CODE]
+    call writefile([&term], "Xtest_T_arg")
+    qall
+  [CODE]
+
+  for t in ['builtin_dumb', 'builtin_ansi']
+    if RunVim([], after, '-T ' .. t)
+      let lines = readfile('Xtest_T_arg')
+      call assert_equal([t], lines)
+    endif
+  endfor
+
+  call delete('Xtest_T_arg')
+endfunc
+
+" Test the '-x' argument to read/write encrypted files.
+func Test_x_arg()
+  CheckRunVimInTerminal
+  CheckFeature cryptv
+
+  " Create an encrypted file Xtest_x_arg.
+  let buf = RunVimInTerminal('-n -x Xtest_x_arg', #{rows: 10, wait_for_ruler: 0})
+  call WaitForAssert({-> assert_match('^Enter encryption key: ', term_getline(buf, 10))})
+  call term_sendkeys(buf, "foo\n")
+  call WaitForAssert({-> assert_match('^Enter same key again: ', term_getline(buf, 10))})
+  call term_sendkeys(buf, "foo\n")
+  call WaitForAssert({-> assert_match(' All$', term_getline(buf, 10))})
+  call term_sendkeys(buf, "itest\<Esc>:w\<Enter>")
+  call WaitForAssert({-> assert_match('"Xtest_x_arg" \[New\]\[blowfish2\] 1L, 5B written',
+        \            term_getline(buf, 10))})
+  call StopVimInTerminal(buf)
+
+  " Read the encrypted file and check that it contains the expected content "test"
+  let buf = RunVimInTerminal('-n -x Xtest_x_arg', #{rows: 10, wait_for_ruler: 0})
+  call WaitForAssert({-> assert_match('^Enter encryption key: ', term_getline(buf, 10))})
+  call term_sendkeys(buf, "foo\n")
+  call WaitForAssert({-> assert_match('^Enter same key again: ', term_getline(buf, 10))})
+  call term_sendkeys(buf, "foo\n")
+  call WaitForAssert({-> assert_match('^test', term_getline(buf, 1))})
+  call StopVimInTerminal(buf)
+
+  call delete('Xtest_x_arg')
+endfunc
+
 " Test for entering the insert mode on startup
 func Test_start_insertmode()
   let before =<< trim [CODE]

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -743,6 +743,7 @@ endfunc
 
 " Test the '-T' argument which sets the 'term' option.
 func Test_T_arg()
+  CheckNotGui
   let after =<< trim [CODE]
     call writefile([&term], "Xtest_T_arg")
     qall


### PR DESCRIPTION
This PR adds tests for the command line option `-T` (which sets the 'term' option) and `-x` (encryption).
These were not yet tested according to codecov:

https://codecov.io/gh/vim/vim/src/0353f56ddb379e7f1a68172fa4743355e04df21e/src/main.c#L2447
https://codecov.io/gh/vim/vim/src/0353f56ddb379e7f1a68172fa4743355e04df21e/src/main.c#L2297