### PR TITLE
CI: Update Cirrus-CI config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,8 @@ env:
   FEATURES: huge
 
 freebsd_12_task:
+  only_if: $CIRRUS_TAG == ''
+  timeout_in: 20m
   freebsd_instance:
     image: freebsd-12-1-release-amd64
   install_script:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: linux
-    if: github.event_name != 'pull_request'
+    if: always() && github.event_name != 'pull_request'
 
     steps:
       - name: Parallel finished


### PR DESCRIPTION
Cirrus-CI:

* Set timeout to 20min. same as other tasks on GitHub Actions.
* Don't run task on a tag pushed. (currently runs on both branch and tag pushed)

GitHub Actions:

* Fix the condition of running coveralls job; run also when linux task fails.