### PR TITLE
fix some spelling errors in source code

### DIFF
--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -2138,7 +2138,7 @@ restore_backup:
     if (!checking_conversion)
     {
 #if defined(UNIX) && defined(HAVE_FSYNC)
-	// On many journalling file systems there is a bug that causes both the
+	// On many journaling file systems there is a bug that causes both the
 	// original and the backup file to be lost when halting the system
 	// right after writing the file.  That's because only the meta-data is
 	// journalled.  Syncing the file slows down the system, but assures it

--- a/src/cindent.c
+++ b/src/cindent.c
@@ -2121,7 +2121,7 @@ get_c_indent(void)
     }
 
     // #defines and so on go at the left when included in 'cinkeys',
-    // exluding pragmas when customized in 'cinoptions'
+    // excluding pragmas when customized in 'cinoptions'
     if (*theline == '#' && (*linecopy == '#' || in_cinkeys('#', ' ', TRUE)))
     {
 	char_u *directive = skipwhite(theline + 1);

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1049,7 +1049,7 @@ set_one_cmd_context(
 		++p;
     }
 
-    // If the cursor is touching the command, and it ends in an alpha-numeric
+    // If the cursor is touching the command, and it ends in an alphanumeric
     // character, complete the command name.
     if (*p == NUL && ASCII_ISALNUM(p[-1]))
 	return NULL;

--- a/src/eval.c
+++ b/src/eval.c
@@ -4631,7 +4631,7 @@ set_ref_in_item(
  * "numbuf" is used for a number.
  * When "copyID" is not NULL replace recursive lists and dicts with "...".
  * When both "echo_style" and "composite_val" are FALSE, put quotes around
- * stings as "string()", otherwise does not put quotes around strings, as
+ * strings as "string()", otherwise does not put quotes around strings, as
  * ":echo" displays values.
  * When "restore_copyID" is FALSE, repeated items in dictionaries and lists
  * are replaced with "...".

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2660,7 +2660,7 @@ do_ecmd(
 		    if (tlnum <= 0)
 			tlnum = 1L;
 		}
-		// Add BLN_NOCURWIN to avoid a new wininfo items are assocated
+		// Add BLN_NOCURWIN to avoid a new wininfo items are associated
 		// with the current window.
 		newbuf = buflist_new(ffname, sfname, tlnum,
 						    BLN_LISTED | BLN_NOCURWIN);

--- a/src/feature.h
+++ b/src/feature.h
@@ -937,7 +937,7 @@
  * +mouse_sgr		Unix only: Include code for for SGR-styled mouse.
  * +mouse_sysmouse	Unix only: Include code for FreeBSD and DragonFly
  *			console mouse handling.
- * +mouse_urxvt		Unix only: Include code for for urxvt mosue handling.
+ * +mouse_urxvt		Unix only: Include code for for urxvt mouse handling.
  * +mouse		Any mouse support (any of the above enabled).
  *			Always included, since either FEAT_MOUSE_XTERM or
  *			DOS_MOUSE is defined.

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2264,7 +2264,7 @@ at_ctrl_x_key(void)
 }
 
 /*
- * Check if typebuf.tb_buf[] contains a modifer plus key that can be changed
+ * Check if typebuf.tb_buf[] contains a modifier plus key that can be changed
  * into just a key, apply that.
  * Check from typebuf.tb_buf[typebuf.tb_off] to typebuf.tb_buf[typebuf.tb_off
  * + "max_offset"].

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -3411,7 +3411,7 @@ gui_mch_exit(int vim_exitcode)
 	thread_id tid = gui.vimWindow->Thread();
 	gui.vimWindow->Lock();
 	gui.vimWindow->Quit();
-	// Wait until it is truely gone
+	// Wait until it is truly gone
 	int32 exitcode;
 	wait_for_thread(tid, &exitcode);
     }

--- a/src/gui_xmdlg.c
+++ b/src/gui_xmdlg.c
@@ -497,7 +497,7 @@ fill_lists(enum ListSpecifier fix, SharedFontSelData *data)
     }
 
     /*
-     * Now loop trough the remaining lists and set them up.
+     * Now loop through the remaining lists and set them up.
      */
     for (idx = (int)NAME; idx < (int)NONE; ++idx)
     {

--- a/src/help.c
+++ b/src/help.c
@@ -325,7 +325,7 @@ find_help_tags(
     char_u	*s, *d;
     int		i;
     // Specific tags that either have a specific replacement or won't go
-    // throught the generic rules.
+    // through the generic rules.
     static char *(except_tbl[][2]) = {
 	{"*",		"star"},
 	{"g*",		"gstar"},

--- a/src/if_ole.cpp
+++ b/src/if_ole.cpp
@@ -635,7 +635,7 @@ static void GUIDtochar(const GUID &guid, char *GUID, int length)
     LPOLESTR wGUID = NULL;
     StringFromCLSID(guid, &wGUID);
 
-    // Covert from wide characters to non-wide
+    // Convert from wide characters to non-wide
     wcstombs(GUID, wGUID, length);
 
     // Free memory

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3628,7 +3628,7 @@ ins_complete(int c, int enable_pum)
 		    // line (probably) wrapped, set compl_startpos to the
 		    // first non_blank in the line, if it is not a wordchar
 		    // include it to get a better pattern, but then we don't
-		    // want the "\\<" prefix, check it bellow
+		    // want the "\\<" prefix, check it below
 		    compl_col = (colnr_T)getwhitecols(line);
 		    compl_startpos.col = compl_col;
 		    compl_startpos.lnum = curwin->w_cursor.lnum;

--- a/src/list.c
+++ b/src/list.c
@@ -2693,7 +2693,7 @@ f_reverse(typval_T *argvars, typval_T *rettv)
 }
 
 /*
- * "reduce(list, { accumlator, element -> value } [, initial])" function
+ * "reduce(list, { accumulator, element -> value } [, initial])" function
  */
     void
 f_reduce(typval_T *argvars, typval_T *rettv)

--- a/src/map.c
+++ b/src/map.c
@@ -2221,7 +2221,7 @@ get_maparg(typval_T *argvars, typval_T *rettv, int exact)
     if (did_simplify)
     {
 	// When the lhs is being simplified the not-simplified keys are
-	// preferred for priting, like in do_map().
+	// preferred for printing, like in do_map().
 	// The "rhs" and "buffer_local" values are not expected to change.
 	mp_simplified = mp;
 	(void)replace_termcodes(keys, &alt_keys_buf,

--- a/src/memline.c
+++ b/src/memline.c
@@ -5562,7 +5562,7 @@ ml_updatechunk(
 		     && buf->b_ml.ml_line_count - line <= 1)
 	{
 	    /*
-	     * We are in the last chunk and it is cheap to crate a new one
+	     * We are in the last chunk and it is cheap to create a new one
 	     * after this. Do it now to avoid the loop above later on
 	     */
 	    curchnk = buf->b_ml.ml_chunksize + curix + 1;

--- a/src/normal.c
+++ b/src/normal.c
@@ -5372,7 +5372,7 @@ v_visop(cmdarg_T *cap)
 nv_subst(cmdarg_T *cap)
 {
 #ifdef FEAT_TERMINAL
-    // When showing output of term_dumpdiff() swap the top and botom.
+    // When showing output of term_dumpdiff() swap the top and bottom.
     if (term_swap_diff() == OK)
 	return;
 #endif

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7116,8 +7116,8 @@ mch_fopen(const char *name, const char *mode)
  * NTFS can have sub streams for each file.  Normal contents of file is
  * stored in the main stream, and extra contents (author information and
  * title and so on) can be stored in sub stream.  After Windows 2000, user
- * can access and store those informations in sub streams via explorer's
- * property menuitem in right click menu.  Those informations in sub streams
+ * can access and store those information in sub streams via explorer's
+ * property menuitem in right click menu.  Those information in sub streams
  * were lost when copying only the main stream.  So we have to copy sub
  * streams.
  *

--- a/src/search.c
+++ b/src/search.c
@@ -3753,7 +3753,7 @@ search_line:
 
 		    // we read a line, set "already" to check this "line" later
 		    // if depth >= 0 we'll increase files[depth].lnum far
-		    // bellow  -- Acevedo
+		    // below  -- Acevedo
 		    already = aux = p = skipwhite(line);
 		    p = find_word_start(p);
 		    p = find_word_end(p);

--- a/src/term.c
+++ b/src/term.c
@@ -3744,7 +3744,7 @@ check_terminal_behavior(void)
 #endif
 	LOG_TR(("Sending xterm compatibility test sequence."));
 	// Do this in the third row.  Second row is used by ambiguous
-	// chararacter width check.
+	// character width check.
 	term_windgoto(2, 0);
 	// send the test DCS string.
 	out_str((char_u *)"\033Pzz\033\\");
@@ -4531,7 +4531,7 @@ handle_u7_response(int *arg, char_u *tp UNUSED, int csi_len UNUSED)
 
 /*
  * Handle a response to T_CRV: {lead}{first}{x};{vers};{y}c
- * Xterm and alikes use '>' for {first}.
+ * Xterm and alike use '>' for {first}.
  * Rxvt sends "{lead}?1;2c".
  */
     static void

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -524,7 +524,7 @@ func Test_argdo()
   bwipe Xa.c Xb.c Xc.c
 endfunc
 
-" Test for quiting Vim with unedited files in the argument list
+" Test for quitting Vim with unedited files in the argument list
 func Test_quit_with_arglist()
   CheckRunVimInTerminal
   let buf = RunVimInTerminal('', {'rows': 6})

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2324,7 +2324,7 @@ func Test_autocmd_SafeState()
   call writefile(lines, 'XSafeState')
   let buf = RunVimInTerminal('-S XSafeState', #{rows: 6})
 
-  " Sometimes we loop to handle a K_IGNORE, SafeState may be trigered once or
+  " Sometimes we loop to handle a K_IGNORE, SafeState may be triggered once or
   " more often.
   call term_sendkeys(buf, ":echo g:safe\<CR>")
   call WaitForAssert({-> assert_match('^\d ', term_getline(buf, 6))}, 1000)

--- a/src/testdir/test_debugger.vim
+++ b/src/testdir/test_debugger.vim
@@ -974,7 +974,7 @@ func Test_debug_backtrace_level()
         \ 'line 1: let s:file1_var = ''file1'''
         \ ], #{msec: 5000})
 
-  " step throught the initial declarations
+  " step through the initial declarations
   call RunDbgCmd(buf, 'step', [ 'line 2: let g:global_var = ''global''' ] )
   call RunDbgCmd(buf, 'step', [ 'line 4: func s:File1Func( arg )' ] )
   call RunDbgCmd(buf, 'echo s:file1_var', [ 'file1' ] )

--- a/src/testdir/test_increment.vim
+++ b/src/testdir/test_increment.vim
@@ -284,7 +284,7 @@ endfunc
 " 1
 "     1
 "     1
-"     Expexted:
+"     Expected:
 "     1) g Ctrl-A on block selected indented lines
 "     2
 " 1

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -426,7 +426,7 @@ func Test_menu_special()
   nunmenu Test.Sign
 endfunc
 
-" Test for "icon=filname" in a toolbar
+" Test for "icon=filename" in a toolbar
 func Test_menu_icon()
   CheckFeature toolbar
   nmenu icon=myicon.xpm Toolbar.Foo  :echo "Foo"<CR>

--- a/src/testdir/test_netbeans.vim
+++ b/src/testdir/test_netbeans.vim
@@ -839,7 +839,7 @@ func Test_nb_file_auth()
   call s:run_server('Nb_file_auth')
 endfunc
 
-" Test for quiting Vim with an open netbeans connection
+" Test for quitting Vim with an open netbeans connection
 func Nb_quit_with_conn(port)
   call delete("Xnetbeans")
   call writefile([], "Xnetbeans")

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3308,7 +3308,7 @@ func Test_popupmenu_info_border()
   call term_sendkeys(buf, "cc\<C-X>\<C-U>")
   call VerifyScreenDump(buf, 'Test_popupwin_infopopup_6', {})
 
-  " Hide the info popup, cycle trough buffers, make sure it didn't get
+  " Hide the info popup, cycle through buffers, make sure it didn't get
   " deleted.
   call term_sendkeys(buf, "\<Esc>")
   call term_sendkeys(buf, ":set hidden\<CR>")

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -3692,7 +3692,7 @@ func Test_python_import()
   call assert_equal(expected, getline(2, '$'))
   close!
 
-  " Try to import a non-existing moudle with a dot (.)
+  " Try to import a non-existing module with a dot (.)
   call AssertException(['py import a.b.c'], 'ImportError:')
 endfunc
 

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -3882,7 +3882,7 @@ func Test_python3_import()
   call assert_equal(expected, getline(2, '$'))
   close!
 
-  " Try to import a non-existing moudle with a dot (.)
+  " Try to import a non-existing module with a dot (.)
   call AssertException(['py3 import a.b.c'], "No module named 'a'")
 endfunc
 

--- a/src/testdir/test_sort.vim
+++ b/src/testdir/test_sort.vim
@@ -1328,7 +1328,7 @@ func Test_sort_cmd()
     endif
   endfor
 
-  " Needs atleast two lines for this test
+  " Needs at least two lines for this test
   call setline(1, ['line1', 'line2'])
   call assert_fails('sort no', 'E474:')
   call assert_fails('sort c', 'E475:')

--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -287,7 +287,7 @@ func Test_zz1_terminal_in_gui()
   unlet g:job
 endfunc
 
-" TODO: reenable when this no longer hangs on Travis
+" TODO: re-enable when this no longer hangs on Travis
 "func Test_zz2_terminal_guioptions_bang()
 "  CheckGui
 "  set guioptions+=!
@@ -338,7 +338,7 @@ func Test_terminal_switch_mode()
   let bnr = bufnr('$')
   call WaitForAssert({-> assert_equal('running', term_getstatus(bnr))})
   " In the GUI the first switch sometimes doesn't work.  Switch twice to avoid
-  " flakyness.
+  " flakiness.
   call feedkeys("\<C-W>N", 'xt')
   call feedkeys("A", 'xt')
   call WaitForAssert({-> assert_equal('running', term_getstatus(bnr))})

--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -145,7 +145,7 @@ func Test_terminal_in_popup()
   call delete('XtermPopup')
 endfunc
 
-" Check a terminal in popup window uses the default mininum size.
+" Check a terminal in popup window uses the default minimum size.
 func Test_terminal_in_popup_min_size()
   CheckRunVimInTerminal
 

--- a/src/testdir/test_vartabs.vim
+++ b/src/testdir/test_vartabs.vim
@@ -97,7 +97,7 @@ func Test_vartabs()
   .retab!
   call assert_equal("\t\t\t\tl", getline(1))
 
-  " Test for 'retab' with same vlaues as vts
+  " Test for 'retab' with same values as vts
   set ts=8 sts=0 vts=5,3,6,2 vsts=
   exe "norm! S                l"
   .retab! 5,3,6,2

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -7374,7 +7374,7 @@ func Test_invalid_function_names()
   endtry
   call assert_equal(1, caught_e884)
 
-  " function name folowed by #
+  " function name followed by #
   let caught_e128 = 0
   try
     func! test2() "#

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -302,7 +302,7 @@ prop_add_common(
 	if (length < 0)
 	    length = 0;		// zero-width property
 
-	// Allocate the new line with space for the new proprety.
+	// Allocate the new line with space for the new property.
 	newtext = alloc(buf->b_ml.ml_line_len + sizeof(textprop_T));
 	if (newtext == NULL)
 	    return;
@@ -1485,7 +1485,7 @@ prepend_joined_props(
 	end = !(prop.tp_flags & TP_FLAG_CONT_NEXT);
 
 	adjust_prop(&prop, 0, -removed, 0); // Remove leading spaces
-	adjust_prop(&prop, -1, col, 0); // Make line start at its final colum
+	adjust_prop(&prop, -1, col, 0); // Make line start at its final column
 
 	if (add_all || end)
 	    mch_memmove(new_props + --(*props_remaining) * sizeof(prop),

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -1409,7 +1409,7 @@ funcdepth_get(void)
 
 /*
  * Restore the function call depth.  This is for cases where there is no
- * garantee funcdepth_decrement() can be called exactly the same number of
+ * guarantee funcdepth_decrement() can be called exactly the same number of
  * times as funcdepth_increment().
  */
     void

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -53,7 +53,7 @@ typedef enum {
     // ISN_STOREOTHER, // pop into other script variable isn_arg.other.
 
     ISN_STORENR,    // store number into local variable isn_arg.storenr.stnr_idx
-    ISN_STORELIST,	// store into list, value/index/varable on stack
+    ISN_STORELIST,	// store into list, value/index/variable on stack
     ISN_STOREDICT,	// store into dictionary, value/index/variable on stack
 
     ISN_UNLET,		// unlet variable isn_arg.unlet.ul_name

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -318,7 +318,7 @@ find_script_var(char_u *name, size_t len, cctx_T *cctx)
 }
 
 /*
- * Returnd TRUE if the script context is Vim9 script.
+ * Returned TRUE if the script context is Vim9 script.
  */
     static int
 script_is_vim9()
@@ -1958,7 +1958,7 @@ generate_cmdmods(cctx_T *cctx, cmdmod_T *cmod)
 	if (isn->isn_arg.cmdmod.cf_cmdmod == NULL)
 	    return FAIL;
 	mch_memmove(isn->isn_arg.cmdmod.cf_cmdmod, cmod, sizeof(cmdmod_T));
-	// filter progam now belongs to the instruction
+	// filter program now belongs to the instruction
 	cmod->cmod_filter_regmatch.regprog = NULL;
     }
 
@@ -3507,7 +3507,7 @@ compile_subscript(
 	    }
 	}
 
-	// Do not skip over white space to find the "(", "exeucte 'x' ()" is
+	// Do not skip over white space to find the "(", "execute 'x' ()" is
 	// not a function call.
 	if (**arg == '(')
 	{
@@ -6835,7 +6835,7 @@ compile_endblock(cctx_T *cctx)
  *	    ... try block
  *	" catch {expr}"
  *	    JUMP -> finally
- * catch1:  PUSH exeception
+ * catch1:  PUSH exception
  *	    EVAL {expr}
  *	    MATCH
  *	    JUMP nomatch -> catch2
@@ -7132,7 +7132,7 @@ compile_mult_expr(char_u *arg, int cmdidx, cctx_T *cctx)
 }
 
 /*
- * If "eap" has a range that is not a contstant generate an ISN_RANGE
+ * If "eap" has a range that is not a constant generate an ISN_RANGE
  * instruction to compute it and return OK.
  * Otherwise return FAIL, the caller must deal with any range.
  */

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -3116,7 +3116,7 @@ failed_early:
 }
 
 /*
- * ":dissassemble".
+ * ":disassemble".
  * We don't really need this at runtime, but we do have tests that require it,
  * so always include this.
  */


### PR DESCRIPTION
This PR fixes some spelling errors in the comments of the source code, based on [this report](https://fossies.org/linux/test/vim-master.tar.gz/codespell.html) given in [this comment](https://github.com/vim/vim/issues/5167#issuecomment-748157283).