### PR TITLE
WIP: Make :version compiler flags output prettier by stripping whitespace

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3079,6 +3079,12 @@ auto/os_haiku.rdef: os_haiku.rdef.in
 	sed -i "s|@MAJOR@|$(VIMMAJOR)|" auto/os_haiku.rdef
 	sed -i "s|@MINOR@|$(VIMMINOR)|" auto/os_haiku.rdef
 
+# Reformat the compiler flags by stripping out extra whitespace so they look
+# prettier in :version output.
+ALL_CFLAGS_PRETTY=$(shell sh -c 'printf "%q" "$$1" && shift && printf " %q" "$$@"' -- $(ALL_CFLAGS))
+ALL_LFLAGS=$(ALL_LIB_DIRS) $(LDFLAGS) -o $(VIMTARGET) $(ALL_LIBS)
+ALL_LFLAGS_PRETTY=$(shell sh -c 'printf "%q" "$$1" && shift && printf " %q" "$$@"' -- $(ALL_LFLAGS))
+
 auto/pathdef.c: Makefile auto/config.mk
 	-@echo creating $@
 	-@echo '/* pathdef.c */' > $@
@@ -3087,8 +3093,8 @@ auto/pathdef.c: Makefile auto/config.mk
 	-@echo '#include "vim.h"' >> $@
 	-@echo 'char_u *default_vim_dir = (char_u *)"$(VIMRCLOC)";' | $(QUOTESED) >> $@
 	-@echo 'char_u *default_vimruntime_dir = (char_u *)"$(VIMRUNTIMEDIR)";' | $(QUOTESED) >> $@
-	-@echo 'char_u *all_cflags = (char_u *)"$(CC) -c -I$(srcdir) $(ALL_CFLAGS)";' | $(QUOTESED) >>  $@
-	-@echo 'char_u *all_lflags = (char_u *)"$(CC) $(ALL_LIB_DIRS) $(LDFLAGS) -o $(VIMTARGET) $(ALL_LIBS) ";' | $(QUOTESED) >>  $@
+	-@echo 'char_u *all_cflags = (char_u *)"$(CC) -c -I$(srcdir) $(ALL_CFLAGS_PRETTY)";' | $(QUOTESED) >>  $@
+	-@echo 'char_u *all_lflags = (char_u *)"$(CC) $(ALL_LFLAGS_PRETTY)";' | $(QUOTESED) >>  $@
 	-@echo 'char_u *compiled_user = (char_u *)"' | tr -d $(NL) >> $@
 	-@if test -n "$(COMPILEDBY)"; then \
 		echo "$(COMPILEDBY)" | tr -d $(NL) >> $@; \


### PR DESCRIPTION
This is a minor thing, but right now `:version` outputs the compiler flags, and they have all sorts of weird whitespaces in them, so here's a change to make them trimmed and look more intentional.

For example, on macOS, this is what it looks like for me:

```
Compilation: gcc -c -I. -Iproto -DHAVE_CONFIG_H   -DMACOS_X -DMACOS_X_DARWIN  -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1       
Linking: gcc   -L/usr/local/lib -o vim        -lm -lncurses  -liconv -framework AppKit           
```

These whitespaces are there due to how we construct the flags programmatically, and in order to be safe we always want to leave a space between two composed variables, even if one or both of them are empty.

With this fix, the extra white spaces will be stripped out.

```
Compilation: gcc -c -I. -Iproto -DHAVE_CONFIG_H -DMACOS_X -DMACOS_X_DARWIN -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
Linking: gcc -L/usr/local/lib -o vim -lm -lncurses -liconv -framework AppKit
```

Note that the code here is using `sh` and printf's `%q` (outputs an escaped output that can be passed to shell) in order to create a realistic representation of compiler flags that could be copy and pasted to a shell without escaping issues. I originally was going to just do something along the lines of replacing 2 or more spaces into one space (I think this is [what Neovim does](https://github.com/neovim/neovim/blob/master/cmake/GetCompileFlags.cmake) actually), but I think there could be weird issues if someone's flags have spaces in them (although I don't know why someone would compile Vim like that…). E.g if `LDFLAGS` is as follows:
```
-L/tmp/weird\ trailing\ space\        -L/usr/local/lib
```
this commit will still respect that and generate the correct output in `:version`:

```
Compilation: gcc -c -I. -Iproto -DHAVE_CONFIG_H -DMACOS_X -DMACOS_X_DARWIN -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
Linking: gcc -L/tmp/weird\ trailing\ space\  -L/usr/local/lib -o vim -lm -lncurses -liconv -framework AppKit
```

I'm using GNU Make's [`shell`](https://www.gnu.org/software/make/manual/html_node/Shell-Function.html) function which I think could be non-standard, but I couldn't find out what Make variant does not support this.