### PR TITLE
Temporary file Xdone was not removed + cleanups

### DIFF
--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -2412,7 +2412,7 @@ def Test_vim9_comment()
       'delcommand Echo',
       ])
   CheckScriptSuccess([
-      'vim9script'
+      'vim9script',
       'command Echo cd # comment',
       'Echo',
       'delcommand Echo',
@@ -2949,6 +2949,7 @@ def Test_restoring_cpo()
   endif
   delete('Xsourced')
   delete('Xclose')
+  delete('Xdone')
 enddef
 
 

--- a/src/testdir/vim9.vim
+++ b/src/testdir/vim9.vim
@@ -5,7 +5,7 @@ let s:sequence = 1
 
 " Check that "lines" inside a ":def" function has no error.
 func CheckDefSuccess(lines)
-  let fname = 'Xdef' .. s:sequence
+  let fname = 'XdefSuccess' .. s:sequence
   let s:sequence += 1
   call writefile(['def Func()'] + a:lines + ['enddef', 'defcompile'], fname)
   exe 'so ' .. fname
@@ -19,7 +19,7 @@ endfunc
 " Add a line before and after to make it less likely that the line number is
 " accidentally correct.
 func CheckDefFailure(lines, error, lnum = -3)
-  let fname = 'Xdef' .. s:sequence
+  let fname = 'XdefFailure' .. s:sequence
   call writefile(['def Func()', '# comment'] + a:lines + ['#comment', 'enddef', 'defcompile'], fname)
   call assert_fails('so ' .. fname, a:error, a:lines, a:lnum + 1)
   delfunc! Func
@@ -32,7 +32,7 @@ endfunc
 " Add a line before and after to make it less likely that the line number is
 " accidentally correct.
 func CheckDefExecFailure(lines, error, lnum = -3)
-  let fname = 'Xdef' .. s:sequence
+  let fname = 'XdefExecFailure' .. s:sequence
   let s:sequence += 1
   call writefile(['def Func()', '# comment'] + a:lines + ['#comment', 'enddef'], fname)
   exe 'so ' .. fname
@@ -42,7 +42,7 @@ func CheckDefExecFailure(lines, error, lnum = -3)
 endfunc
 
 def CheckScriptFailure(lines: list<string>, error: string, lnum = -3)
-  var fname = 'Xdef' .. s:sequence
+  var fname = 'XScriptFailure' .. s:sequence
   s:sequence += 1
   writefile(lines, fname)
   assert_fails('so ' .. fname, error, lines, lnum)
@@ -50,7 +50,7 @@ def CheckScriptFailure(lines: list<string>, error: string, lnum = -3)
 enddef
 
 def CheckScriptSuccess(lines: list<string>)
-  var fname = 'Xdef' .. s:sequence
+  var fname = 'XScriptSuccess' .. s:sequence
   s:sequence += 1
   writefile(lines, fname)
   exe 'so ' .. fname


### PR DESCRIPTION
This PR removes temporary file Xdone which was not deleted
when running:
```
$ make test_vim9_script
```
I also see a temporary file `Xdef185`, which is not deleted.
I renamed `Xdef*` as it was used in several functions to help
find where it came from. After my change it's file 
`XScriptSuccess185` which is not deleted.

In `vim9.vim`, line 56 is executed, but line 57 is not
executed somehow:
```
 52 def CheckScriptSuccess(lines: list<string>)
 53   var fname = 'XScriptSuccess' .. s:sequence
 54   s:sequence += 1
 55   writefile(lines, fname)
 56   exe 'so ' .. fname
 57   delete(fname)
 58 enddef
```
I don't understand why.