### PR TITLE
Fixed shadowed variable compilation warning

### DIFF
--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -606,7 +606,7 @@ call_ufunc(ufunc_T *ufunc, int argcount, ectx_T *ectx, isn_T *iptr)
 	return FAIL;
     if (ufunc->uf_def_status == UF_COMPILED)
     {
-	int error = check_user_func_argcount(ufunc, argcount);
+	error = check_user_func_argcount(ufunc, argcount);
 
 	if (error != FCERR_UNKNOWN)
 	{


### PR DESCRIPTION
This PR fixes a compilation warning:
```
gcc-10 -c -I. -Iproto -DHAVE_CONFIG_H     -g -O0 -Wall -Wextra -Wshadow -Wmissing-prototypes -Wpedantic -Wunreachable-code -Wunused-result -Wno-deprecated-declarations -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1  -g -O0 -fsanitize=address -fno-omit-frame-pointer -DEXITFREE -DABORT_ON_INTERNAL_ERROR    -o objects/viminfo.o viminfo.c
vim9execute.c: In function ‘call_ufunc’:
vim9execute.c:609:6: warning: declaration of ‘error’ shadows a previous local [-Wshadow]
  609 |  int error = check_user_func_argcount(ufunc, argcount);
      |      ^~~~~
vim9execute.c:600:10: note: shadowed declaration is here
  600 |     int  error;
      |          ^~~~~
```