### PR TITLE
Add arch (x86_64 / arm64) to :version output for macOS

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -5333,6 +5333,11 @@ list_version(void)
 # else
     msg_puts(_("\nmacOS version w/o darwin feat."));
 # endif
+# if defined(__arm64__)
+    msg_puts(" - arm64");
+# elif defined(__x86_64__)
+    msg_puts(" - x86_64");
+# endif
 #endif
 
 #ifdef VMS


### PR DESCRIPTION
With the introduction of Apple Silicon and Rosetta (x86 translation on ARM), there are now two common architecture for Vim on macOS and it's frequently useful to see which arch Vim is running under to see if it's under Rosetta translation or native ARM. Add architecture info for macOS version output.

Not sure if we should do something like this for Windows eventually as well as ARM builds may be more common.

Also, following VMS's example in using a dash, and didn't localize the text for now (didn't think it is needed).