### PR TITLE
Make inserting the small deletion register repeatable with .

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -9,7 +9,7 @@
 
 /*
  * ops.c: implementation of various operators: op_shift, op_delete, op_tilde,
- *	  op_change, op_yank, do_put, do_join
+ *	  op_change, op_yank, do_join
  */
 
 #include "vim.h"

--- a/src/register.c
+++ b/src/register.c
@@ -809,7 +809,14 @@ insert_reg(
 	{
 	    for (i = 0; i < y_current->y_size; ++i)
 	    {
-		stuffescaped(y_current->y_array[i], literally);
+		if (regname == '-')
+		{
+		    AppendCharToRedobuff(Ctrl_R);
+		    AppendCharToRedobuff(regname);
+		    do_put(regname, NULL, BACKWARD, 1L, PUT_CURSEND);
+		}
+		else
+		    stuffescaped(y_current->y_array[i], literally);
 		// Insert a newline between lines and after last line if
 		// y_type is MLINE.
 		if (y_current->y_type == MLINE || i < y_current->y_size - 1)

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -698,4 +698,15 @@ func Test_ve_blockpaste()
   bwipe!
 endfunc
 
+func Test_insert_small_delete()
+  new
+  call setline(1, ['foo foobar bar'])
+  call cursor(1,1)
+  exe ":norm! ciw'\<C-R>-'"
+  call assert_equal(getline(1), "'foo' foobar bar")
+  exe ":norm! w.w."
+  call assert_equal(getline(1), "'foo' 'foobar' 'bar'")
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This was a small annoyance of mine, not being able to repeat inserting the small deletion register using `.`

So now you can use `ciw"<C-R>-"` and surround your word with quotes. This is kind of like what surround provides (I think). After you have done this once, press `.` on a word to have the whole operation repeated for the word under the cursor. 


While at it, I noticed a comment that hasn't been updated, since `do_put` has been put into `registers.c`, so remove mentioning `do_put` in ops.c.