### PR TITLE
put assert_equal() arguments into correct order for 8.2.2189

### DIFF
--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -703,9 +703,9 @@ func Test_insert_small_delete()
   call setline(1, ['foo foobar bar'])
   call cursor(1,1)
   exe ":norm! ciw'\<C-R>-'"
-  call assert_equal(getline(1), "'foo' foobar bar")
+  call assert_equal("'foo' foobar bar", getline(1))
   exe ":norm! w.w."
-  call assert_equal(getline(1), "'foo' 'foobar' 'bar'")
+  call assert_equal("'foo' 'foobar' 'bar'", getline(1))
   bwipe!
 endfunc
 


### PR DESCRIPTION
sorry, the PR had the arguments for assert_equal() in the wrong order. I had fixed it locally, but forgot to push :(

So here is it again.