### PR TITLE
reset script_context if scroll option was reset

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6321,7 +6321,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			local to window
 	Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
 	set to half the number of lines in the window when the window size
-	changes.  If you give a count to the CTRL-U or CTRL-D command it will
+	changes.  This may happen when enabling the |status-line| or
+	'tabline' option after setting the 'scroll' option.
+	If you give a count to the CTRL-U or CTRL-D command it will
 	be used as the new value for 'scroll'.  Reset to half the window
 	height with ":set scroll=0".
 

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1553,6 +1553,7 @@ scriptnames_slash_adjust(void)
 
 /*
  * Get a pointer to a script name.  Used for ":verbose set".
+ * Message appended to "Last set from "
  */
     char_u *
 get_scriptname(scid_T id)
@@ -1567,6 +1568,8 @@ get_scriptname(scid_T id)
 	return (char_u *)_("environment variable");
     if (id == SID_ERROR)
 	return (char_u *)_("error handler");
+    if (id == SID_WINLAYOUT)
+	return (char_u *)_("changed window size");
     return SCRIPT_ITEM(id)->sn_name;
 }
 

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1013,4 +1013,21 @@ func Test_isfname_with_options()
   setlocal keywordprg&
 endfunc
 
+" Test that resetting laststatus does change scroll option
+func Test_opt_reset_scroll()
+  CheckRunVimInTerminal
+  let vimrc =<< trim [CODE]
+    set scroll=2
+    set laststatus=2
+  [CODE]
+  call writefile(vimrc, 'Xscroll')
+  let buf = RunVimInTerminal('-S Xscroll', {'rows': 16, 'cols': 40})
+  call term_sendkeys(buf, ":verbose set scroll?\n")
+  call WaitForAssert({-> assert_match('^\s*scroll=7$', term_getline(buf, 16))})
+  call StopVimInTerminal(buf)
+
+  " clean up
+  call delete('Xscroll')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1021,9 +1021,10 @@ func Test_opt_reset_scroll()
     set laststatus=2
   [CODE]
   call writefile(vimrc, 'Xscroll')
-  let buf = RunVimInTerminal('-S Xscroll', {'rows': 16, 'cols': 40})
+  let buf = RunVimInTerminal('-S Xscroll', {'rows': 16, 'cols': 45})
   call term_sendkeys(buf, ":verbose set scroll?\n")
-  call WaitForAssert({-> assert_match('^\s*scroll=7$', term_getline(buf, 16))})
+  call WaitForAssert({-> assert_match('Last set.*window size', term_getline(buf, 15))})
+  call assert_match('^\s*scroll=7$', term_getline(buf, 14))
   call StopVimInTerminal(buf)
 
   " clean up

--- a/src/vim.h
+++ b/src/vim.h
@@ -1232,6 +1232,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define SID_ENV		-4	// for sourcing environment variable
 #define SID_ERROR	-5	// option was reset because of an error
 #define SID_NONE	-6	// don't set scriptID
+#define SID_WINLAYOUT	-7	// changing window size
 
 /*
  * Events for autocommands.

--- a/src/window.c
+++ b/src/window.c
@@ -6325,9 +6325,13 @@ win_new_width(win_T *wp, int width)
     void
 win_comp_scroll(win_T *wp)
 {
+    int old_w_p_scr = wp->w_p_scr;
+
     wp->w_p_scr = ((unsigned)wp->w_height >> 1);
     if (wp->w_p_scr == 0)
 	wp->w_p_scr = 1;
+    if (wp->w_p_scr != old_w_p_scr)
+	CLEAR_FIELD(wp->w_p_script_ctx[WV_SCROLL]);
 }
 
 /*

--- a/src/window.c
+++ b/src/window.c
@@ -6325,13 +6325,20 @@ win_new_width(win_T *wp, int width)
     void
 win_comp_scroll(win_T *wp)
 {
+#if defined(FEAT_EVAL)
     int old_w_p_scr = wp->w_p_scr;
+#endif
 
     wp->w_p_scr = ((unsigned)wp->w_height >> 1);
     if (wp->w_p_scr == 0)
 	wp->w_p_scr = 1;
+#if defined(FEAT_EVAL)
     if (wp->w_p_scr != old_w_p_scr)
-	CLEAR_FIELD(wp->w_p_script_ctx[WV_SCROLL]);
+    {
+	wp->w_p_script_ctx[WV_SCROLL].sc_sid = SID_WINLAYOUT;
+	wp->w_p_script_ctx[WV_SCROLL].sc_lnum = 0;
+    }
+#endif
 }
 
 /*


### PR DESCRIPTION
If a user is setting the 'scroll' option and later enables the statusline or tabline (even via plugins), this will change the 'scroll' option to the default of half the window size. 

More importantly, running `:verbose :set scroll` will show the new value, while pointing to the vimrc option that contains the old value.  This is confusing at least.  See the following example:

```bash
vim -Nu NONE -S <(cat <<'EOF'
set scroll=3
set laststatus=2
EOF
) -c 'verbose set scroll?'
  scroll=11
        Last set from /proc/213428/fd/16 line 1
```

So reset the script context, if the scroll value has been adjusted, add a test and amend the documentation a bit.