### PR TITLE
add support for focusing in popup

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -11206,7 +11206,7 @@ win_gettype([{nr}])					*win_gettype()*
 
 win_gotoid({expr})					*win_gotoid()*
 		Go to window with ID {expr}.  This may also change the current
-		tabpage.
+		tabpage. This can also be used to focus on a focusable popup.
 		Return 1 if successful, 0 if the window cannot be found.
 
 		Can also be used as a |method|: >

--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -606,6 +606,9 @@ The second argument of |popup_create()| is a dictionary with options:
 			horizontally centered.  The first column is 1.
 			When using "textprop" the number is relative to the
 			text property and can be negative.
+	focusable	When FALSE (the default) the popup is not focusable.
+			When TRUE the popup is focusable. Popup can be focused
+			using |win_gotoid| function.
 	pos		"topleft", "topright", "botleft" or "botright":
 			defines what corner of the popup "line" and "col" are
 			used for.  When not set "topleft" is used.

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -737,7 +737,11 @@ f_win_gotoid(typval_T *argvars, typval_T *rettv)
 #if defined(FEAT_PROP_POPUP) || defined(PROTO)
     wp = win_id2wp(id);
     if (wp != NULL && WIN_IS_POPUP(wp) && wp->w_popup_flags & POPF_FOCUSABLE)
+    {
 	win_enter(wp, TRUE);
+	rettv->vval.v_number = 1;
+	return;
+    }
 #endif
 }
 

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -734,9 +734,11 @@ f_win_gotoid(typval_T *argvars, typval_T *rettv)
 	    return;
 	}
 
+#if defined(FEAT_PROP_POPUP) || defined(PROTO)
     wp = win_id2wp(id);
-    if (wp != NULL && WIN_IS_POPUP(wp))
+    if (wp != NULL && WIN_IS_POPUP(wp) && wp->w_popup_flags & POPF_FOCUSABLE)
 	win_enter(wp, TRUE);
+#endif
 }
 
 /*

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -733,6 +733,10 @@ f_win_gotoid(typval_T *argvars, typval_T *rettv)
 	    rettv->vval.v_number = 1;
 	    return;
 	}
+
+    wp = win_id2wp(id);
+    if (wp != NULL && WIN_IS_POPUP(wp))
+	win_enter(wp, TRUE);
 }
 
 /*

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -689,6 +689,15 @@ apply_general_options(win_T *wp, dict_T *dict)
 	    wp->w_popup_flags &= ~POPF_DRAG;
     }
 
+    nr = dict_get_bool(dict, (char_u *)"focusable", -1);
+    if (nr != -1)
+    {
+	if (nr)
+	    wp->w_popup_flags |= POPF_FOCUSABLE;
+	else
+	    wp->w_popup_flags &= ~POPF_FOCUSABLE;
+    }
+
     nr = dict_get_bool(dict, (char_u *)"posinvert", -1);
     if (nr != -1)
     {
@@ -2996,6 +3005,7 @@ f_popup_getoptions(typval_T *argvars, typval_T *rettv)
 	dict_add_string(dict, "title", wp->w_popup_title);
 	dict_add_number(dict, "wrap", wp->w_p_wrap);
 	dict_add_number(dict, "drag", (wp->w_popup_flags & POPF_DRAG) != 0);
+	dict_add_number(dict, "focusable", (wp->w_popup_flags & POPF_FOCUSABLE) != 0);
 	dict_add_number(dict, "mapping",
 				      (wp->w_popup_flags & POPF_MAPPING) != 0);
 	dict_add_number(dict, "resize", (wp->w_popup_flags & POPF_RESIZE) != 0);

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3741,12 +3741,23 @@ func Test_popupwin_latin1_encoding()
   call delete('Xmultibyte')
 endfunc
 
-func Test_popupwin_focus()
+func Test_popupwin_non_focusable()
   let winid = win_getid()
   let popup_winid = popup_create(['hello', 'world'], #{line: 1, col: 2})
+  call assert_equal(0, popup_getoptions(popup_winid)['focusable'])
+  call assert_equal(winid, win_getid())
+  call win_gotoid(popup_winid)
+  call assert_equal(winid, win_getid())
+  call popup_close(popup_winid)
+endfunc
+
+func Test_popupwin_focus()
+  let winid = win_getid()
+  let popup_winid = popup_create(['hello', 'world'], #{line: 1, col: 2, focusable: 1})
+  call assert_equal(1, popup_getoptions(popup_winid)['focusable'])
   call assert_equal(winid, win_getid())
 
-  " first focus to popup
+  " first focus to popup window
   call win_gotoid(popup_winid)
   call assert_equal(popup_winid, win_getid())
 

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3758,15 +3758,18 @@ func Test_popupwin_focus()
   call assert_equal(winid, win_getid())
 
   " first focus to popup window
-  call win_gotoid(popup_winid)
+  let win_gotoid_result = win_gotoid(popup_winid)
+  call assert_equal(1, win_gotoid_result)
   call assert_equal(popup_winid, win_getid())
 
   " focus back to main window
-  call win_gotoid(winid)
+  let win_gotoid_result = win_gotoid(winid)
+  call assert_equal(1, win_gotoid_result)
   call assert_equal(winid, win_getid())
 
   " second focus to popup window
-  call win_gotoid(popup_winid)
+  let win_gotoid_result = win_gotoid(popup_winid)
+  call assert_equal(1, win_gotoid_result)
   call assert_equal(popup_winid, win_getid())
 
   " TODO: we shouldn't be needing this.

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3758,6 +3758,8 @@ func Test_popupwin_focus()
   call win_gotoid(popup_winid)
   call assert_equal(popup_winid, win_getid())
 
+  " TODO: we shouldn't be needing this.
+  " popup_close should automatically go to the correct last winid.
   call win_gotoid(winid)
   call popup_close(popup_winid)
 endfunc

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3741,6 +3741,27 @@ func Test_popupwin_latin1_encoding()
   call delete('Xmultibyte')
 endfunc
 
+func Test_popupwin_focus()
+  let winid = win_getid()
+  let popup_winid = popup_create(['hello', 'world'], #{line: 1, col: 2})
+  call assert_equal(winid, win_getid())
+
+  " first focus to popup
+  call win_gotoid(popup_winid)
+  call assert_equal(popup_winid, win_getid())
+
+  " focus back to main window
+  call win_gotoid(winid)
+  call assert_equal(winid, win_getid())
+
+  " second focus to popup window
+  call win_gotoid(popup_winid)
+  call assert_equal(popup_winid, win_getid())
+
+  call win_gotoid(winid)
+  call popup_close(popup_winid)
+endfunc
+
 func Test_popupwin_atcursor_far_right()
   new
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -623,6 +623,8 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define POPF_INFO	0x80	// used for info of popup menu
 #define POPF_INFO_MENU	0x100	// align info popup with popup menu
 #define POPF_POSINVERT	0x200	// vertical position can be inverted
+#define POPF_FOCUSABLE	0x400	// popup can be focused
+
 
 // flags used in w_popup_handled
 #define POPUP_HANDLED_1	    0x01    // used by mouse_find_win()


### PR DESCRIPTION
Fixes https://github.com/vim/vim/issues/5639 which has been a common request.

- [x] allow `win_gotoid()` to focus inside a popup
- [x] add a flag called `focusable` in `popup_create`. If `focusable` is false `win_gotoid()` should fail with error.
- [x] update docs
- [x] add tests

Demo can be found at https://asciinema.org/a/381243

One thing I noticed is that `:qa!` didn't work inside the popup but everything else seems to be working well such inside the popp such as editing, yanking, moving around, searching.