### PR TITLE
Fix build if_ruby/dyn with Ruby 3.0

### DIFF
--- a/ci/config.mk.clang.sed
+++ b/ci/config.mk.clang.sed
@@ -1,2 +1,2 @@
 /^CFLAGS[[:blank:]]*=/s/$/ -Wno-error=missing-field-initializers/
-/^RUBY_CFLAGS[[:blank:]]*=/s/$/ -Wno-error=unknown-attributes -Wno-error=ignored-attributes/
+/^RUBY_CFLAGS[[:blank:]]*=/s/$/ -Wno-error=unknown-attributes -Wno-error=ignored-attributes -fms-extensions/

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -32,8 +32,9 @@
 # define RUBYEXTERN extern
 #endif
 
-#if defined(DYNAMIC_RUBY) && RUBY_VERSION >= 24
-# define USE_RUBY_INTEGER
+// suggested by Ariya Mizutani
+#if (_MSC_VER == 1200)
+# undef _WIN32_WINNT
 #endif
 
 #ifdef DYNAMIC_RUBY
@@ -42,6 +43,10 @@
  * definition.  This function use these variables.  But we want function to
  * use dll_* variables.
  */
+# if RUBY_VERSION >= 24
+#  define USE_RUBY_INTEGER
+# endif
+
 # define rb_cFalseClass		(*dll_rb_cFalseClass)
 # define rb_cFixnum		(*dll_rb_cFixnum)
 # if defined(USE_RUBY_INTEGER)
@@ -54,6 +59,7 @@
 # define rb_cString		(*dll_rb_cString)
 # define rb_cSymbol		(*dll_rb_cSymbol)
 # define rb_cTrueClass		(*dll_rb_cTrueClass)
+
 # if RUBY_VERSION >= 18
 /*
  * On ver 1.8, all Ruby functions are exported with "__declspec(dllimport)"
@@ -64,40 +70,41 @@
 #  define RUBY_EXPORT
 # endif
 
-#endif  // ifdef DYNAMIC_RUBY
-
-// suggested by Ariya Mizutani
-#if (_MSC_VER == 1200)
-# undef _WIN32_WINNT
-#endif
-
-#if defined(DYNAMIC_RUBY) && RUBY_VERSION >= 19
+# if RUBY_VERSION >= 19
 // Ruby 1.9 defines a number of static functions which use rb_num2long and
 // rb_int2big
-# define rb_num2long rb_num2long_stub
-# define rb_int2big rb_int2big_stub
-#endif
+#  define rb_num2long rb_num2long_stub
+#  define rb_int2big rb_int2big_stub
 
-#if defined(DYNAMIC_RUBY) && RUBY_VERSION >= 19 \
-	&& VIM_SIZEOF_INT < VIM_SIZEOF_LONG
+#  if RUBY_VERSION >= 30 || VIM_SIZEOF_INT < VIM_SIZEOF_LONG
 // Ruby 1.9 defines a number of static functions which use rb_fix2int and
 // rb_num2int if VIM_SIZEOF_INT < VIM_SIZEOF_LONG (64bit)
-# define rb_fix2int rb_fix2int_stub
-# define rb_num2int rb_num2int_stub
-#endif
+#   define rb_fix2int rb_fix2int_stub
+#   define rb_num2int rb_num2int_stub
+#  endif
+# endif
 
-#if defined(DYNAMIC_RUBY) && RUBY_VERSION == 21
+# if RUBY_VERSION == 21
 // Ruby 2.1 adds new GC called RGenGC and RARRAY_PTR uses
 // rb_gc_writebarrier_unprotect_promoted if USE_RGENGC
-# define rb_gc_writebarrier_unprotect_promoted rb_gc_writebarrier_unprotect_promoted_stub
-#endif
-#if defined(DYNAMIC_RUBY) && RUBY_VERSION >= 22
-# define rb_gc_writebarrier_unprotect rb_gc_writebarrier_unprotect_stub
-#endif
+#  define rb_gc_writebarrier_unprotect_promoted rb_gc_writebarrier_unprotect_promoted_stub
+# endif
 
-#if defined(DYNAMIC_RUBY) && RUBY_VERSION >= 26
-# define rb_ary_detransient rb_ary_detransient_stub
-#endif
+# if RUBY_VERSION >= 22
+#  define rb_gc_writebarrier_unprotect rb_gc_writebarrier_unprotect_stub
+# endif
+
+# if RUBY_VERSION >= 26
+#  define rb_ary_detransient rb_ary_detransient_stub
+# endif
+
+# if RUBY_VERSION >= 30
+#  define rb_check_type rb_check_type_stub
+#  define rb_num2uint rb_num2uint_stub
+#  define ruby_malloc_size_overflow ruby_malloc_size_overflow_stub
+# endif
+
+#endif  // ifdef DYNAMIC_RUBY
 
 // On macOS pre-installed Ruby defines "SIZEOF_TIME_T" as "SIZEOF_LONG" so it
 // conflicts with the definition in config.h then causes a macro-redefined
@@ -232,7 +239,9 @@ static int ruby_convert_to_vim_value(VALUE val, typval_T *rettv);
 # define rb_assoc_new			dll_rb_assoc_new
 # define rb_cObject			(*dll_rb_cObject)
 # define rb_class_new_instance		dll_rb_class_new_instance
-# define rb_check_type			dll_rb_check_type
+# if RUBY_VERSION <= 29
+#  define rb_check_type			dll_rb_check_type
+# endif
 # ifdef USE_TYPEDDATA
 #  define rb_check_typeddata		dll_rb_check_typeddata
 # endif
@@ -283,7 +292,9 @@ static int ruby_convert_to_vim_value(VALUE val, typval_T *rettv);
 #   define rb_fix2int			dll_rb_fix2int
 #   define rb_num2int			dll_rb_num2int
 #  endif
-#  define rb_num2uint			dll_rb_num2uint
+#  if RUBY_VERSION <= 29
+#   define rb_num2uint			dll_rb_num2uint
+#  endif
 # endif
 # define rb_num2dbl			dll_rb_num2dbl
 # define rb_lastline_get			dll_rb_lastline_get
@@ -501,7 +512,7 @@ static rb_encoding* (*dll_rb_enc_find) (const char*);
 static VALUE (*dll_rb_enc_str_new) (const char*, long, rb_encoding*);
 static VALUE (*dll_rb_sprintf) (const char*, ...);
 static VALUE (*dll_rb_require) (const char*);
-static void* (*ruby_options)(int, char**);
+static void* (*dll_ruby_options)(int, char**);
 # endif
 
 # if defined(USE_RGENGC) && USE_RGENGC
@@ -510,6 +521,10 @@ static void (*dll_rb_gc_writebarrier_unprotect_promoted)(VALUE);
 #  else
 static void (*dll_rb_gc_writebarrier_unprotect)(VALUE obj);
 #  endif
+# endif
+
+# if RUBY_VERSION >= 30
+NORETURN(static void (*dll_ruby_malloc_size_overflow)(size_t, size_t));
 # endif
 
 # if RUBY_VERSION >= 26
@@ -585,11 +600,29 @@ rb_gc_writebarrier_unprotect_stub(VALUE obj)
 #  endif
 # endif
 
-# if RUBY_VERSION >= 26
+# if RUBY_VERSION >= 26 && !defined(PROTO)
     void
 rb_ary_detransient_stub(VALUE x)
 {
     dll_rb_ary_detransient(x);
+}
+# endif
+
+# if RUBY_VERSION >= 30 && !defined(PROTO)
+    void
+rb_check_type_stub(VALUE obj, int t)
+{
+    dll_rb_check_type(obj, t);
+}
+    unsigned long
+rb_num2uint_stub(VALUE x)
+{
+    return dll_rb_num2uint(x);
+}
+    void
+ruby_malloc_size_overflow_stub(size_t x, size_t y)
+{
+    dll_ruby_malloc_size_overflow(x, y);
 }
 # endif
 
@@ -747,6 +780,9 @@ static struct
 #  else
     {"rb_gc_writebarrier_unprotect", (RUBY_PROC*)&dll_rb_gc_writebarrier_unprotect},
 #  endif
+# endif
+# if RUBY_VERSION >= 30
+    {"ruby_malloc_size_overflow", (RUBY_PROC*)&dll_ruby_malloc_size_overflow},
 # endif
     {"", NULL},
 };
@@ -1827,7 +1863,7 @@ convert_hash2dict(VALUE key, VALUE val, VALUE arg)
     dict_T *d = (dict_T *)arg;
     dictitem_T *di;
 
-    di = dictitem_alloc((char_u *)RSTRING_PTR(RSTRING(rb_obj_as_string(key))));
+    di = dictitem_alloc((char_u *)RSTRING_PTR(rb_obj_as_string(key)));
     if (di == NULL || ruby_convert_to_vim_value(val, &di->di_tv) != OK
 						     || dict_add(d, di) != OK)
     {

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -239,7 +239,7 @@ static int ruby_convert_to_vim_value(VALUE val, typval_T *rettv);
 # define rb_assoc_new			dll_rb_assoc_new
 # define rb_cObject			(*dll_rb_cObject)
 # define rb_class_new_instance		dll_rb_class_new_instance
-# if RUBY_VERSION <= 29
+# if RUBY_VERSION < 30
 #  define rb_check_type			dll_rb_check_type
 # endif
 # ifdef USE_TYPEDDATA
@@ -292,7 +292,7 @@ static int ruby_convert_to_vim_value(VALUE val, typval_T *rettv);
 #   define rb_fix2int			dll_rb_fix2int
 #   define rb_num2int			dll_rb_num2int
 #  endif
-#  if RUBY_VERSION <= 29
+#  if RUBY_VERSION < 30
 #   define rb_num2uint			dll_rb_num2uint
 #  endif
 # endif
@@ -531,28 +531,30 @@ NORETURN(static void (*dll_ruby_malloc_size_overflow)(size_t, size_t));
 void rb_ary_detransient_stub(VALUE x);
 # endif
 
-# if (RUBY_VERSION >= 19) && !defined(PROTO)
-#  if RUBY_VERSION >= 22
+// Do not generate a prototype here, VALUE isn't always defined.
+# ifndef PROTO
+#  if RUBY_VERSION >= 19
+#   if RUBY_VERSION >= 22
     long
 rb_num2long_stub(VALUE x)
-#  else
+#   else
     SIGNED_VALUE
 rb_num2long_stub(VALUE x)
-#  endif
+#   endif
 {
     return dll_rb_num2long(x);
 }
-#  if RUBY_VERSION >= 26
+#   if RUBY_VERSION >= 26
     VALUE
 rb_int2big_stub(intptr_t x)
-#  else
+#   else
     VALUE
 rb_int2big_stub(SIGNED_VALUE x)
-#  endif
+#   endif
 {
     return dll_rb_int2big(x);
 }
-#  if (RUBY_VERSION >= 19) && (VIM_SIZEOF_INT < VIM_SIZEOF_LONG)
+#   if VIM_SIZEOF_INT < VIM_SIZEOF_LONG
     long
 rb_fix2int_stub(VALUE x)
 {
@@ -563,52 +565,48 @@ rb_num2int_stub(VALUE x)
 {
     return dll_rb_num2int(x);
 }
-#  endif
-#  if RUBY_VERSION >= 20
+#   endif
+#   if RUBY_VERSION >= 20
     VALUE
 rb_float_new_in_heap(double d)
 {
     return dll_rb_float_new(d);
 }
-#   if RUBY_VERSION >= 22
+#    if RUBY_VERSION >= 22
     unsigned long
 rb_num2ulong(VALUE x)
-#   else
+#    else
     VALUE
 rb_num2ulong(VALUE x)
-#   endif
+#    endif
 {
     return (long)RSHIFT((SIGNED_VALUE)(x),1);
 }
+#   endif
 #  endif
-# endif
-
-   // Do not generate a prototype here, VALUE isn't always defined.
-# if defined(USE_RGENGC) && USE_RGENGC && !defined(PROTO)
-#  if RUBY_VERSION == 21
+#  if defined(USE_RGENGC) && USE_RGENGC
+#   if RUBY_VERSION == 21
     void
 rb_gc_writebarrier_unprotect_promoted_stub(VALUE obj)
 {
     dll_rb_gc_writebarrier_unprotect_promoted(obj);
 }
-#  else
+#   else
     void
 rb_gc_writebarrier_unprotect_stub(VALUE obj)
 {
     dll_rb_gc_writebarrier_unprotect(obj);
 }
+#   endif
 #  endif
-# endif
-
-# if RUBY_VERSION >= 26 && !defined(PROTO)
+#  if RUBY_VERSION >= 26
     void
 rb_ary_detransient_stub(VALUE x)
 {
     dll_rb_ary_detransient(x);
 }
-# endif
-
-# if RUBY_VERSION >= 30 && !defined(PROTO)
+#  endif
+#  if RUBY_VERSION >= 30
     void
 rb_check_type_stub(VALUE obj, int t)
 {
@@ -624,7 +622,8 @@ ruby_malloc_size_overflow_stub(size_t x, size_t y)
 {
     dll_ruby_malloc_size_overflow(x, y);
 }
-# endif
+#  endif
+# endif // ifndef PROTO
 
 static HINSTANCE hinstRuby = NULL; // Instance of ruby.dll
 


### PR DESCRIPTION
Error at if_ruby.c:
```
gcc -c -I. -DDYNAMIC_RUBY_DLL=\"libruby.so.3.0\" -I/usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0 -I/usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/x86_64-linux -DRUBY_VERSION=30 -Iproto -DHAVE_CONFIG_H   -DWE_ARE_PROFILING  -Wall -Wextra -Wshadow -Wno-unknown-pragmas -g -ggdb3 -O0 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/if_ruby.o if_ruby.c
In file included from /usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/internal/assume.h:29,
                 from /usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/backward/2/assume.h:24,
                 from /usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/defines.h:72,
                 from /usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/ruby.h:23,
                 from /usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby.h:38,
                 from if_ruby.c:109:
if_ruby.c: In function ‘ convert_hash2dict’ :
/usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/internal/core/rstring.h:35:45: warning: passing argument 1 of ‘ RSTRING_PTR’  makes integer from pointer without a cast [-Wint-conversion]
   35 | #define RSTRING(obj)            RBIMPL_CAST((struct RString *)(obj))
/usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/internal/cast.h:33:29: note: in definition of macro ‘ RBIMPL_CAST’
   33 | # define RBIMPL_CAST(expr) (expr)
      |                             ^~~~
if_ruby.c:1830:47: note: in expansion of macro ‘ RSTRING’
 1830 |     di = dictitem_alloc((char_u *)RSTRING_PTR(RSTRING(rb_obj_as_string(key))));
      |                                               ^~~~~~~
In file included from /usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/internal/arithmetic/char.h:29,
                 from /usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/internal/arithmetic.h:23,
                 from /usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/ruby.h:25,
                 from /usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby.h:38,
                 from if_ruby.c:109:
/usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/internal/core/rstring.h:151:19: note: expected ‘ VALUE’  {aka ‘ long unsigned int’ } but argument is of type ‘ struct RString *’
  151 | RSTRING_PTR(VALUE str)
      |             ~~~~~~^~~
```

Error at linking:
```
gcc -c -I. -Iproto -DHAVE_CONFIG_H   -DWE_ARE_PROFILING  -Wall -Wextra -Wshadow -Wno-unknown-pragmas -g -ggdb3 -O0 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        version.c -o objects/version.o
link.sh: $LINK_AS_NEEDED set to 'yes': invoking linker directly.
  gcc   -L. -L/usr/local/share/anyenv/envs/rbenv/versions/3.0.0/lib  -fstack-protector-strong -rdynamic -Wl,-export-dynamic -Wl,-E   -L/usr/local/lib -Wl,--as-needed   -o vim objects/arabic.o objects/arglist.o objects/autocmd.o objects/beval.o objects/buffer.o objects/change.o objects/blob.o objects/blowfish.o objects/cindent.o objects/clientserver.o objects/clipboard.o objects/cmdexpand.o objects/cmdhist.o objects/crypt.o objects/crypt_zip.o objects/debugger.o objects/dict.o objects/diff.o objects/digraph.o objects/drawline.o objects/drawscreen.o objects/edit.o objects/eval.o objects/evalbuffer.o objects/evalfunc.o objects/evalvars.o objects/evalwindow.o objects/ex_cmds.o objects/ex_cmds2.o objects/ex_docmd.o objects/ex_eval.o objects/ex_getln.o objects/fileio.o objects/filepath.o objects/findfile.o objects/fold.o objects/getchar.o objects/gui_xim.o objects/hardcopy.o objects/hashtab.o objects/help.o objects/highlight.o objects/if_cscope.o objects/if_xcmdsrv.o objects/indent.o objects/insexpand.o objects/list.o objects/locale.o objects/map.o objects/mark.o objects/match.o objects/mbyte.o objects/memline.o objects/menu.o objects/misc1.o objects/misc2.o objects/mouse.o objects/move.o objects/normal.o objects/ops.o objects/option.o objects/optionstr.o objects/os_unix.o objects/pathdef.o objects/popupmenu.o objects/popupwin.o objects/profiler.o objects/pty.o objects/quickfix.o objects/regexp.o objects/register.o objects/screen.o objects/scriptfile.o objects/search.o objects/session.o objects/sha256.o objects/sign.o objects/sound.o objects/spell.o objects/spellfile.o objects/spellsuggest.o objects/syntax.o objects/tag.o objects/term.o objects/terminal.o objects/testing.o objects/textformat.o objects/textobject.o objects/textprop.o objects/time.o objects/typval.o objects/ui.o objects/undo.o objects/usercmd.o objects/userfunc.o objects/version.o objects/vim9compile.o objects/vim9execute.o objects/vim9script.o objects/vim9type.o objects/viminfo.o objects/window.o objects/bufwrite.o  objects/vterm_encoding.o objects/vterm_keyboard.o objects/vterm_mouse.o objects/vterm_parser.o objects/vterm_pen.o objects/vterm_screen.o objects/vterm_state.o objects/vterm_unicode.o objects/vterm_vterm.o objects/if_lua.o  objects/if_perl.o objects/if_perlsfio.o  objects/if_python3.o  objects/if_ruby.o  objects/netbeans.o objects/job.o objects/channel.o objects/xdiffi.o objects/xemit.o objects/xprepare.o objects/xutils.o objects/xhistogram.o objects/xpatience.o  objects/charset.o objects/json.o objects/main.o objects/memfile.o objects/message.o        -lm -ltinfo  -lselinux  -lcanberra -ldl   -Wl,-E  -fstack-protector-strong -L/usr/local/lib  -L/usr/local/share/anyenv/envs/plenv/versions/5.30.3/lib/perl5/5.30.3/x86_64-linux/CORE -lperl -lpthread -lnsl -ldl -lm -lcrypt -lutil -lc
/usr/bin/ld: objects/if_ruby.o: in function `RB_NUM2UINT':
/usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/internal/arithmetic/int.h:108: undefined reference to `rb_num2uint'
/usr/bin/ld: objects/if_ruby.o: in function `Check_Type':
/usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/internal/value_type.h:351: undefined reference to `rb_check_type'
/usr/bin/ld: objects/if_ruby.o: in function `rbimpl_size_mul_or_raise':
/usr/local/share/anyenv/envs/rbenv/versions/3.0.0/include/ruby-3.0.0/ruby/internal/memory.h:245: undefined reference to `ruby_malloc_size_overflow'
collect2: error: ld returned 1 exit status
```