### PR TITLE
CI: Fix sed error on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
 
       - name: Build
         env:
-          LANG: C
+          LC_ALL: C
         run: |
           make -j${NPROC}
 


### PR DESCRIPTION
GitHub Actions has set `LC_ALL` to `en_US.UTF-8` by default on macOS, so `LANG` has no effect and we need overwrite `LC_ALL`.