### PR TITLE
Fix build if_ruby with Clang

### DIFF
--- a/ci/config.mk.clang.sed
+++ b/ci/config.mk.clang.sed
@@ -1,2 +1,2 @@
 /^CFLAGS[[:blank:]]*=/s/$/ -Wno-error=missing-field-initializers/
-/^RUBY_CFLAGS[[:blank:]]*=/s/$/ -Wno-error=unknown-attributes -Wno-error=ignored-attributes -fms-extensions/
+/^RUBY_CFLAGS[[:blank:]]*=/s/$/ -Wno-error=unknown-attributes -Wno-error=ignored-attributes/

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -7651,6 +7651,9 @@ $as_echo "$rubyhdrdir" >&6; }
 	  RUBY_CFLAGS="-DDYNAMIC_RUBY_DLL=\\\"$libruby_soname\\\" $RUBY_CFLAGS"
 	  RUBY_LIBS=
 	fi
+	if test "X$CLANG_VERSION" != "X" -a "$rubyversion" -ge 30; then
+	  RUBY_CFLAGS="$RUBY_CFLAGS -fdeclspec"
+	fi
       else
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: not found; disabling Ruby" >&5
 $as_echo "not found; disabling Ruby" >&6; }

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2001,6 +2001,9 @@ if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
 	  RUBY_CFLAGS="-DDYNAMIC_RUBY_DLL=\\\"$libruby_soname\\\" $RUBY_CFLAGS"
 	  RUBY_LIBS=
 	fi
+	if test "X$CLANG_VERSION" != "X" -a "$rubyversion" -ge 30; then
+	  RUBY_CFLAGS="$RUBY_CFLAGS -fdeclspec"
+	fi
       else
 	AC_MSG_RESULT(not found; disabling Ruby)
       fi


### PR DESCRIPTION
#7564 Clang always (not only in CI env) needs `-fdeclspec` (or `-fms-extensions`) compiler option to build if_ruby.c.