### PR TITLE
fix asan error when closing window causes buffer-overflow

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -3411,9 +3411,9 @@ set_shellsize(int width, int height, int mustset)
 	return;
 
     // curwin->w_buffer can be NULL when we are closing a window and the
-    // buffer has already been closed and removing a scrollbar causes a resize
+    // buffer (or window) has already been closed and removing a scrollbar causes a resize
     // event. Don't resize then, it will happen after entering another buffer.
-    if (curwin->w_buffer == NULL)
+    if (curwin->w_buffer == NULL || curwin->w_lines == NULL)
 	return;
 
     ++busy;


### PR DESCRIPTION
As can be seen here:
https://github.com/vim/vim/runs/1623161184?check_suite_focus=true

ASAN still reports an error, when closing a window, which causes a
destroy scrollbar event, which in turn will cause a resize event which
will finally try to set the shell window and might access already freed
variables.

So fix this by checking, whether the current window is still valid. If
the current window is in the process of being freed, wp->w_lines will be
set to null by win_free before handling the scrollbar event.

That should fix the ASAN error hopefully.