### PR TITLE
test_termcodes was flaky when using ssh with X forwarding (ssh -X) (fixes issue #7563)

### DIFF
--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -851,7 +851,10 @@ func Test_term_mouse_multiple_clicks_to_visually_select()
   let save_term = &term
   let save_ttymouse = &ttymouse
   call test_override('no_query_mouse', 1)
-  set mouse=a term=xterm mousetime=200
+
+  " 'mousetime' must be sufficiently large, or else test is flaky when
+  " using a ssh connection with X forwarding i.e. ssh -X (issue #7563).
+  set mouse=a term=xterm mousetime=600
   new
 
   for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec


### PR DESCRIPTION
PR fixes flay test test_termcodes when using ssh with X forwarding (ssh -X).
It fixes issue https://github.com/vim/vim/issues/7563
More details in comments of that ticket.
