### PR TITLE
test_sort still failed with en_CA.UTF-8 or fr_CA.UTF-8 locale (fixes #7609).

### DIFF
--- a/src/testdir/test_sort.vim
+++ b/src/testdir/test_sort.vim
@@ -16,28 +16,31 @@ func Test_sort_strings()
   call assert_equal([1, 2, 3], sort([3, 2, 1]))
   call assert_equal([13, 28, 3], sort([3, 28, 13]))
 
-  call assert_equal(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ'],
-  \            sort(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ']))
+  call assert_equal(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'Œ', 'œ'],
+  \            sort(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'Œ', 'œ']))
 
-  call assert_equal(['A', 'a', 'o', 'O', 'p', 'P', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ'],
-  \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'i'))
+  call assert_equal(['A', 'a', 'o', 'O', 'p', 'P', 'Ä', 'Ô', 'ä', 'ô', 'Œ', 'œ'],
+  \            sort(['A', 'a', 'o', 'O', 'Œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'i'))
 
   " This does not appear to work correctly on Mac.
   if !has('mac')
-    if v:collate =~? '^en_ca.*\.utf-\?8$' && !has('mac')
-      " with Canadian English capitals come before lower case.
-      call assert_equal(['A', 'a', 'Ä', 'ä', 'O', 'o', 'Ô', 'ô', 'œ', 'œ', 'P', 'p'],
-      \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+    if v:collate =~? '^\(en\|fr\)_ca.utf-\?8$'
+      " With Canadian English capitals come before lower case.
+      call assert_equal(['A', 'a', 'Ä', 'ä', 'O', 'o', 'Ô', 'ô', 'Œ', 'œ', 'P', 'p'],
+      \            sort(['A', 'a', 'o', 'O', 'Œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'),
+      \            'unexpected sort with locale ' .. v:collate)
     elseif v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$'
       " With the following locales, the accentuated letters are ordered
       " similarly to the non-accentuated letters...
-      call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'œ', 'p', 'P'],
-      \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+      call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'Œ', 'p', 'P'],
+      \            sort(['A', 'a', 'o', 'O', 'Œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'),
+      \            'unexpected sort with locale ' .. v:collate)
     elseif v:collate =~? '^sv.*utf-\?8$'
       " ... whereas with a Swedish locale, the accentuated letters are ordered
       " after Z.
-      call assert_equal(['a', 'A', 'o', 'O', 'p', 'P', 'ä', 'Ä', 'œ', 'œ', 'ô', 'Ô'],
-      \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+      call assert_equal(['a', 'A', 'o', 'O', 'p', 'P', 'ä', 'Ä', 'œ', 'Œ', 'ô', 'Ô'],
+      \            sort(['A', 'a', 'o', 'O', 'Œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'),
+      \            'unexpected sort with locale ' .. v:collate)
     endif
   endif
 endfunc
@@ -1236,7 +1239,7 @@ func Test_sort_cmd()
 
     " This does not appear to work correctly on Mac.
     if !has('mac')
-      if v:collate =~? '^en_ca.*\.utf-\?8$'
+      if v:collate =~? '^\(en\|fr\)_ca.utf-\?8$'
         " en_CA.utf-8 sorts capitals before lower case
         let tests += [
           \ {
@@ -1277,8 +1280,8 @@ func Test_sort_cmd()
           \	'o',
           \	'Ô',
           \	'ô',
-          \	'œ',
           \	'Œ',
+          \	'œ',
           \	'Z',
           \	'z'
           \    ]


### PR DESCRIPTION
`test_sort` still failed even after patch 8.2.2286
with `en_CA.UTF-8` or `fr_CA.UTF-8` locale (fixes #7609).