### PR TITLE
make popup_filter_menu() support C-n and C-p to select neighbor items

### DIFF
--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -309,8 +309,8 @@ popup_dialog({what}, {options})				*popup_dialog()*
 
 popup_filter_menu({id}, {key})				*popup_filter_menu()*
 		Filter that can be used for a popup. These keys can be used:
-		    j <Down>		select item below
-		    k <Up>		select item above
+		    j <Down> <C-N>	select item below
+		    k <Up> <C-P>	select item above
 		    <Space> <Enter>	accept current selection
 		    x Esc CTRL-C	cancel the menu
 		Other keys are ignored.

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2380,9 +2380,9 @@ f_popup_filter_menu(typval_T *argvars, typval_T *rettv)
     res.v_type = VAR_NUMBER;
 
     old_lnum = wp->w_cursor.lnum;
-    if ((c == 'k' || c == 'K' || c == K_UP) && wp->w_cursor.lnum > 1)
+    if ((c == 'k' || c == 'K' || c == K_UP || c == Ctrl_P) && wp->w_cursor.lnum > 1)
 	--wp->w_cursor.lnum;
-    if ((c == 'j' || c == 'J' || c == K_DOWN)
+    if ((c == 'j' || c == 'J' || c == K_DOWN || c == Ctrl_N)
 		       && wp->w_cursor.lnum < wp->w_buffer->b_ml.ml_line_count)
 	++wp->w_cursor.lnum;
     if (old_lnum != wp->w_cursor.lnum)

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3797,4 +3797,10 @@ func Test_popupwin_exiting_terminal()
   endtry
 endfunc
 
+func Test_popup_filter_menu()
+  let colors = ['red', 'green', 'blue']
+  call popup_menu(colors, #{callback: {_, result -> assert_equal('green', colors[result - 1])}})
+  call feedkeys("\<c-n>\<c-n>\<c-p>\<cr>", 'xt')
+endfunc
+
 " vim: shiftwidth=2 sts=2


### PR DESCRIPTION
The purpose of this PR is to let us press `<C-n>` to select the next item in a popup menu created with `popup_create()`. Similarly, it should let us press `<C-p>` to select the previous item.

I know that the same can be achieved in a custom filter, however this is something that I always want in a popup menu.  It seems inefficient to constantly handle those keys manually, while a builtin filter could do it by default.

Note that we can already press `<C-n>` and `<C-p>` in an insert mode completion popup menu; the kind we can create with `complete()`.  So, I think it makes sense to be able to do the same in a popup menu created with `popup_create()`.

Also, `C-n` and `C-p` are used by other programs to navigate in a menu or some history.  For example, in bash, pressing `C-p` recalls the last executed shell command.  I think most programs using the readline library, or emulating it (like zsh), will provide similar commands on `C-n` and `C-p`.  IOW, they are familiar to many people.

They are especially convenient when we create an interactive fuzzy command.  Because in that case, we can't use `j` and `k` (we could search for some pattern which includes `j` or `k`).  So we have to press `<Down>` or `<Up>`; but that forces us to leave the homerow.  That's why some people prefer `<C-n>` and `<C-p>`.

I've included a test, and updated the documentation.

I wasn't sure whether we should also add `<C-j>` and `<C-k>`, so I didn't.

