### PR TITLE
Cross-link permission changing feature (netrw-gp) in netrw doc

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -54,7 +54,8 @@ Copyright: Copyright (C) 2017 Charles E Campbell    *netrw-copyright*
       Browsing With A Horizontally Split Window...........|netrw-o|
       Browsing With A New Tab.............................|netrw-t|
       Browsing With A Vertically Split Window.............|netrw-v|
-      Change Listing Style.(thin wide long tree)..........|netrw-i|
+      Change Listing Style (thin wide long tree)..........|netrw-i|
+      Change File Permission..............................|netrw-gp|
       Changing To A Bookmarked Directory..................|netrw-gb|
       Changing To A Predecessor Directory.................|netrw-u|
       Changing To A Successor Directory...................|netrw-U|

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1095,6 +1095,7 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 	   gf	Force treatment as file                              |netrw-gf|
 	   gh	Quick hide/unhide of dot-files                       |netrw-gh|
 	   gn	Make top of tree the directory below the cursor      |netrw-gn|
+	   gp	Change file permission                               |netrw-gp|
 	   i	Cycle between thin, long, wide, and tree listings    |netrw-i|
 	   I	Toggle the displaying of the banner                  |netrw-I|
 	   mb	Bookmark current directory                           |netrw-mb|


### PR DESCRIPTION
netrw can change file permissions via `gp`, which is really neat - if you know about it. 

However, the feature is listed neither in the table of contents nor in the "QUICK REFERENCE: MAPS" section of [pi_netrw.txt](https://github.com/vim/vim/blob/master/runtime/doc/pi_netrw.txt). Therefore people who don't read the documentation top to bottom (like me) can easily miss it.

This PR adds references to `netrw-gp` in both `netrw-contents` and `netrw-quickmaps` (aka. `netrw-browse-maps`) in order to make this (very nice) feature more visible.