### PR TITLE
if_ruby.c: Define rb_num2uint_stub only on 64bits

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -612,11 +612,13 @@ rb_check_type_stub(VALUE obj, int t)
 {
     dll_rb_check_type(obj, t);
 }
+#   if VIM_SIZEOF_INT < VIM_SIZEOF_LONG // 64 bits only
     unsigned long
 rb_num2uint_stub(VALUE x)
 {
     return dll_rb_num2uint(x);
 }
+#   endif
     void
 ruby_malloc_size_overflow_stub(size_t x, size_t y)
 {


### PR DESCRIPTION
If Vim is compiled with new Ruby 3.0 on 32b archs, it ends with linking error (see [build log](https://kojipkgs.fedoraproject.org//work/tasks/104/59170104/build.log)):

```
/usr/bin/ld: /tmp/ccFjbDS8.ltrans62.ltrans.o: in function `rb_num2uint_stub':
/builddir/build/BUILD/vim82/src/if_ruby.c:618: undefined reference to `dll_rb_num2uint'
collect2: error: ld returned 1 exit status
link.sh: Linking failed
make: *** [Makefile:2134: vim] Error 1
```

With this patch, the build passes - the mentioned function supposes to be run only under 64b, but its definition for Ruby 3.0 was missing ```#ifdef ``` guards.

Would you mind adding it to the project?