### PR TITLE
Add functions to set/get cursor and mark position using character count

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2475,6 +2475,7 @@ ch_status({handle} [, {options}])
 changenr()			Number	current change number
 char2nr({expr} [, {utf8}])	Number	ASCII/UTF8 value of first char in {expr}
 charclass({string})		Number	character class of {string}
+charcol({expr})			Number	column nr of cursor or mark
 charidx({string}, {idx} [, {countcc}])
 				Number  char index of byte {idx} in {string}
 chdir({dir})			String	change current working directory
@@ -2558,6 +2559,7 @@ getbufvar({expr}, {varname} [, {def}])
 getchangelist([{expr}])		List	list of change list items
 getchar([expr])			Number	get one character from the user
 getcharmod()			Number	modifiers for the last typed character
+getcharpos({expr})		List	position of cursor, mark, etc.
 getcharsearch()			Dict	last character search
 getcmdline()			String	return the current command-line
 getcmdpos()			Number	return cursor position in command-line
@@ -2566,6 +2568,7 @@ getcmdwintype()			String	return current command-line window type
 getcompletion({pat}, {type} [, {filtered}])
 				List	list of cmdline completion matches
 getcurpos([{winnr}])		List	position of the cursor
+getcursorcharpos([{winnr}])	List	character position of the cursor
 getcwd([{winnr} [, {tabnr}]])	String	get the current working directory
 getenv({name})			String	return environment variable
 getfontname([{name}])		String	name of font being used
@@ -2828,8 +2831,10 @@ setbufline({expr}, {lnum}, {text})
 setbufvar({expr}, {varname}, {val})
 				none	set {varname} in buffer {expr} to {val}
 setcellwidths({list})		none	set character cell width overrides
+setcharpos({expr}, {list})	Number	set the {expr} position to {list}
 setcharsearch({dict})		Dict	set character search from {dict}
 setcmdpos({pos})		Number	set cursor position in command-line
+setcursorcharpos({list})	Number	move cursor to position in {list}
 setenv({name}, {val})		none	set environment variable
 setfperm({fname}, {mode})	Number	set {fname} file permissions to {mode}
 setline({lnum}, {line})		Number	set line {lnum} to {line}
@@ -3590,6 +3595,18 @@ charclass({string})					*charclass()*
 			other	specific Unicode class
 		The class is used in patterns and word motions.
 
+							*charcol()*
+charcol({expr})	Same as |col()| but returns the character index of the column
+		position given with {expr} instead of the byte position.
+
+		Example:
+		With the cursor on '세' in line 5 with text "여보세요": >
+			charcol('.')		returns 3
+			col('.')		returns 7
+
+<		Can also be used as a |method|: >
+			GetPos()->col()
+<
 							*charidx()*
 charidx({string}, {idx} [, {countcc}])
 		Return the character index of the byte at {idx} in {string}.
@@ -3680,7 +3697,8 @@ col({expr})	The result is a Number, which is the byte index of the column
 		out of range then col() returns zero.
 		To get the line number use |line()|.  To get both use
 		|getpos()|.
-		For the screen column position use |virtcol()|.
+		For the screen column position use |virtcol()|.  For the
+		character position use |charcol()|.
 		Note that only marks in the current file can be used.
 		Examples: >
 			col(".")		column of cursor
@@ -3980,6 +3998,9 @@ cursor({list})
 			[{lnum}, {col}, {off}, {curswant}]
 		This is like the return value of |getpos()| or |getcurpos()|,
 		but without the first item.
+
+		To position the cursor using the character count, use
+		|setcursorcharpos()|.
 
 		Does not change the jumplist.
 		If {lnum} is greater than the number of lines in the buffer,
@@ -5220,6 +5241,20 @@ getcharmod()						*getcharmod()*
 		character itself are obtained.  Thus Shift-a results in "A"
 		without a modifier.
 
+							*getcharpos()*
+getcharpos({expr})
+		Get the position for {expr}. Same as |getpos()| but the column
+		number in the returned List is a character index instead of
+		a byte index.
+
+		Example:
+		With the cursor on '세' in line 5 with text "여보세요": >
+			getcharpos('.')		returns [0, 5, 3, 0]
+			getpos('.')		returns [0, 5, 7, 0]
+<
+		Can also be used as a |method|: >
+			GetMark()->getcharpos()
+
 getcharsearch()						*getcharsearch()*
 		Return the current character search information as a {dict}
 		with the following entries:
@@ -5345,8 +5380,11 @@ getcurpos([{winid}])
 		includes an extra "curswant" item in the list:
 		    [0, lnum, col, off, curswant] ~
 		The "curswant" number is the preferred column when moving the
-		cursor vertically.  Also see |getpos()|.
-		The first "bufnum" item is always zero.
+		cursor vertically.  Also see |getcursorcharpos()| and
+		|getpos()|.
+		The first "bufnum" item is always zero. The byte position of
+		the cursor is returned in 'col'. To get the character
+		position, use |getcursorcharpos()|.
 
 		The optional {winid} argument can specify the window.  It can
 		be the window number or the |window-ID|.  The last known
@@ -5360,6 +5398,23 @@ getcurpos([{winid}])
 			call setpos('.', save_cursor)
 <		Note that this only works within the window.  See
 		|winrestview()| for restoring more state.
+
+		Can also be used as a |method|: >
+			GetWinid()->getcurpos()
+
+							*getcursorcharpos()*
+getcursorcharpos([{winid}])
+		Same as |getcurpos()| but the column number in the returned
+		List is a character index instead of a byte index.
+
+		Example:
+		With the cursor on '보' in line 3 with text "여보세요": >
+			getcursorcharpos()	returns [0, 3, 2, 0, 3]
+			getcurpos()		returns [0, 3, 4, 0, 3]
+
+<		Can also be used as a |method|: >
+			GetWinid()->getcursorcharpos()
+
 							*getcwd()*
 getcwd([{winnr} [, {tabnr}]])
 		The result is a String, which is the name of the current
@@ -5667,15 +5722,17 @@ getpos({expr})	Get the position for {expr}.  For possible values of {expr}
 		Note that for '< and '> Visual mode matters: when it is "V"
 		(visual line mode) the column of '< is zero and the column of
 		'> is a large number.
+		The column number in the returned List is the byte position
+		within the line. To get the character position in the line,
+		use |getcharpos()|
 		This can be used to save and restore the position of a mark: >
 			let save_a_mark = getpos("'a")
 			...
 			call setpos("'a", save_a_mark)
-<		Also see |getcurpos()| and |setpos()|.
+<		Also see |getcharpos()|, |getcurpos()| and |setpos()|.
 
 		Can also be used as a |method|: >
 			GetMark()->getpos()
-
 
 getqflist([{what}])					*getqflist()*
 		Returns a |List| with all the current quickfix errors.  Each
@@ -9200,6 +9257,19 @@ setcellwidths({list})					*setcellwidths()*
 <		You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
 		the effect for known emoji characters.
 
+setcharpos({expr}, {list})				*setcharpos()*
+		Same as |setpos()| but uses the specified column number as the
+		character index instead of the byte index in the line.
+
+		Example:
+		With the text "여보세요" in line 8: >
+			call setcharpos('.', [0, 8, 4, 0])
+<		positions the cursor on the fourth character '요'. >
+			call setpos('.', [0, 8, 4, 0])
+<		positions the cursor on the second character '보'.
+
+		Can also be used as a |method|: >
+			GetPosition()->setcharpos('.')
 
 setcharsearch({dict})					*setcharsearch()*
 		Set the current character search information to {dict},
@@ -9241,6 +9311,21 @@ setcmdpos({pos})					*setcmdpos()*
 
 		Can also be used as a |method|: >
 			GetPos()->setcmdpos()
+
+setcursorcharpos({lnum}, {col} [, {off}])		*setcursorcharpos()*
+setcursorcharpos({list})
+		Same as |cursor()| but uses the specified column number as the
+		character index instead of the byte index in the line.
+
+		Example:
+		With the text "여보세요" in line 4: >
+			call setcursorcharpos(4, 3)
+<		positions the cursor on the third character '세'. >
+			call cursor(4, 3)
+<		positions the cursor on the first character '여'.
+
+		Can also be used as a |method|: >
+			GetCursorPos()->setcursorcharpos()
 
 setenv({name}, {val})						*setenv()*
 		Set environment variable {name} to {val}.
@@ -9353,7 +9438,8 @@ setpos({expr}, {list})
 
 		"lnum" and "col" are the position in the buffer.  The first
 		column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
-		smaller than 1 then 1 is used.
+		smaller than 1 then 1 is used. To use the character count
+		instead of the byte count, use |setcharpos()|.
 
 		The "off" number is only used when 'virtualedit' is set. Then
 		it is the offset in screen columns from the start of the
@@ -9373,7 +9459,7 @@ setpos({expr}, {list})
 		Returns 0 when the position could be set, -1 otherwise.
 		An error message is given if {expr} is invalid.
 
-		Also see |getpos()| and |getcurpos()|.
+		Also see |setcharpos()|, |getpos()| and |getcurpos()|.
 
 		This does not restore the preferred column for moving
 		vertically; if you set the cursor position with this, |j| and

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -753,6 +753,11 @@ Cursor and mark position:		*cursor-functions* *mark-functions*
 	screenchar()		get character code at a screen line/row
 	screenchars()		get character codes at a screen line/row
 	screenstring()		get string of characters at a screen line/row
+	charcol()		character number of the cursor or a mark
+	getcharpos()		get character position of cursor, mark, etc.
+	setcharpos()		set character position of cursor, mark, etc.
+	getcursorcharpos()	get character position of the cursor
+	setcursorcharpos()	set character position of the cursor
 
 Working with text in the current buffer:		*text-functions*
 	getline()		get a line or list of lines from the buffer

--- a/src/eval.c
+++ b/src/eval.c
@@ -5054,6 +5054,61 @@ string2float(
 #endif
 
 /*
+ * Convert the specified byte index of line 'lnum' in buffer 'buf' into a
+ * character index. Works only for loaded buffers. Returns -1 on failure.
+ * The index of the first character is one.
+ */
+    int
+buf_byteidx_to_charidx(buf_T *buf, int lnum, int byteidx)
+{
+    char_u	*str;
+
+    if (buf == NULL || buf->b_ml.ml_mfp == NULL)
+	return -1;
+
+    if (lnum > buf->b_ml.ml_line_count)
+	lnum = buf->b_ml.ml_line_count;
+
+    str = ml_get_buf(buf, lnum, FALSE);
+    if (str == NULL)
+	return -1;
+
+    if (*str == NUL)
+	return 1;
+
+    return mb_charlen_len(str, byteidx + 1);
+}
+
+/*
+ * Convert the specified character index of line 'lnum' in buffer 'buf' into a
+ * byte index. Works only for loaded buffers. Returns -1 on failure. The index
+ * of the first byte and the first character is one.
+ */
+    int
+buf_charidx_to_byteidx(buf_T *buf, int lnum, int charidx)
+{
+    char_u	*str;
+    char_u	*t;
+
+    if (buf == NULL || buf->b_ml.ml_mfp == NULL)
+	return -1;
+
+    if (lnum > buf->b_ml.ml_line_count)
+	lnum = buf->b_ml.ml_line_count;
+
+    str = ml_get_buf(buf, lnum, FALSE);
+    if (str == NULL)
+	return -1;
+
+    // Convert the character offset to a byte offset
+    t = str;
+    while (*t != NUL && --charidx > 0)
+	t += mb_ptr2len(t);
+
+    return t - str + 1;
+}
+
+/*
  * Translate a String variable into a position.
  * Returns NULL when there is an error.
  */
@@ -5061,7 +5116,8 @@ string2float(
 var2fpos(
     typval_T	*varp,
     int		dollar_lnum,	// TRUE when $ is last line
-    int		*fnum)		// set to fnum for '0, 'A, etc.
+    int		*fnum,		// set to fnum for '0, 'A, etc.
+    int		charcol)	// return character column
 {
     char_u		*name;
     static pos_T	pos;
@@ -5083,7 +5139,10 @@ var2fpos(
 	pos.lnum = list_find_nr(l, 0L, &error);
 	if (error || pos.lnum <= 0 || pos.lnum > curbuf->b_ml.ml_line_count)
 	    return NULL;	// invalid line number
-	len = (long)STRLEN(ml_get(pos.lnum));
+	if (charcol)
+	    len = (long)mb_charlen(ml_get(pos.lnum));
+	else
+	    len = (long)STRLEN(ml_get(pos.lnum));
 
 	// Get the column number
 	// We accept "$" for the column number: last column.
@@ -5118,18 +5177,29 @@ var2fpos(
     if (name == NULL)
 	return NULL;
     if (name[0] == '.')				// cursor
-	return &curwin->w_cursor;
+    {
+	pos = curwin->w_cursor;
+	if (charcol)
+	    pos.col = buf_byteidx_to_charidx(curbuf, pos.lnum, pos.col) - 1;
+	return &pos;
+    }
     if (name[0] == 'v' && name[1] == NUL)	// Visual start
     {
 	if (VIsual_active)
-	    return &VIsual;
-	return &curwin->w_cursor;
+	    pos = VIsual;
+	else
+	    pos = curwin->w_cursor;
+	if (charcol)
+	    pos.col = buf_byteidx_to_charidx(curbuf, pos.lnum, pos.col) - 1;
+	return &pos;
     }
     if (name[0] == '\'')			// mark
     {
 	pp = getmark_buf_fnum(curbuf, name[1], FALSE, fnum);
 	if (pp == NULL || pp == (pos_T *)-1 || pp->lnum <= 0)
 	    return NULL;
+	if (charcol)
+	    pp->col = buf_byteidx_to_charidx(curbuf, pp->lnum, pp->col) - 1;
 	return pp;
     }
 
@@ -5164,7 +5234,10 @@ var2fpos(
 	else
 	{
 	    pos.lnum = curwin->w_cursor.lnum;
-	    pos.col = (colnr_T)STRLEN(ml_get_curline());
+	    if (charcol)
+		pos.col = (colnr_T)mb_charlen(ml_get_curline());
+	    else
+		pos.col = (colnr_T)STRLEN(ml_get_curline());
 	}
 	return &pos;
     }
@@ -5184,7 +5257,8 @@ list2fpos(
     typval_T	*arg,
     pos_T	*posp,
     int		*fnump,
-    colnr_T	*curswantp)
+    colnr_T	*curswantp,
+    int		charcol)
 {
     list_T	*l = arg->vval.v_list;
     long	i = 0;
@@ -5216,6 +5290,18 @@ list2fpos(
     n = list_find_nr(l, i++, NULL);	// col
     if (n < 0)
 	return FAIL;
+    // If character position is specified, then convert to byte position
+    if (charcol)
+    {
+	buf_T	*buf;
+
+	// Get the text for the specified line in a loaded buffer
+	buf = buflist_findnr(fnump == NULL ? curbuf->b_fnum : *fnump);
+	if (buf == NULL || buf->b_ml.ml_mfp == NULL)
+	    return FAIL;
+
+	n = buf_charidx_to_byteidx(buf, posp->lnum, n);
+    }
     posp->col = n;
 
     n = list_find_nr(l, i, NULL);	// off

--- a/src/proto/eval.pro
+++ b/src/proto/eval.pro
@@ -55,8 +55,10 @@ char_u *echo_string_core(typval_T *tv, char_u **tofree, char_u *numbuf, int copy
 char_u *echo_string(typval_T *tv, char_u **tofree, char_u *numbuf, int copyID);
 char_u *string_quote(char_u *str, int function);
 int string2float(char_u *text, float_T *value);
-pos_T *var2fpos(typval_T *varp, int dollar_lnum, int *fnum);
-int list2fpos(typval_T *arg, pos_T *posp, int *fnump, colnr_T *curswantp);
+int buf_byteidx_to_charidx(buf_T *buf, int lnum, int byteidx);
+int buf_charidx_to_byteidx(buf_T *buf, int lnum, int charidx);
+pos_T *var2fpos(typval_T *varp, int dollar_lnum, int *fnum, int charcol);
+int list2fpos(typval_T *arg, pos_T *posp, int *fnump, colnr_T *curswantp, int char_col);
 int get_env_len(char_u **arg);
 int get_id_len(char_u **arg);
 int get_name_len(char_u **arg, char_u **alias, int evaluate, int verbose);

--- a/src/tag.c
+++ b/src/tag.c
@@ -4201,7 +4201,7 @@ tagstack_push_items(win_T *wp, list_T *l)
 	// parse 'from' for the cursor position before the tag jump
 	if ((di = dict_find(itemdict, (char_u *)"from", -1)) == NULL)
 	    continue;
-	if (list2fpos(&di->di_tv, &mark, &fnum, NULL) != OK)
+	if (list2fpos(&di->di_tv, &mark, &fnum, NULL, FALSE) != OK)
 	    continue;
 	if ((tagname =
 		dict_get_string(itemdict, (char_u *)"tagname", TRUE)) == NULL)

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -1,4 +1,4 @@
-" Tests for cursor().
+" Tests for cursor() and other functions that get/set the cursor position
 
 func Test_wrong_arguments()
   call assert_fails('call cursor(1. 3)', 'E474:')
@@ -121,6 +121,189 @@ func Test_screenpos_number()
   call assert_equal(wincol + 66 + 3, pos.col)
   close
   bwipe!
+endfunc
+
+func SaveVisualStartCharPos()
+  call add(g:VisualStartPos, getcharpos('v'))
+  return ''
+endfunc
+
+" Test for the getcharpos() function
+func Test_getcharpos()
+  call assert_fails('call getcharpos({})', 'E731:')
+  call assert_equal([0, 0, 0, 0], getcharpos(0))
+  new
+  call setline(1, ['', "01\tà4è678", 'Ⅵ', '012345678'])
+
+  " Test for '.' and '$'
+  normal 1G
+  call assert_equal([0, 1, 1, 0], getcharpos('.'))
+  call assert_equal([0, 4, 1, 0], getcharpos('$'))
+  normal 2G6l
+  call assert_equal([0, 2, 7, 0], getcharpos('.'))
+  normal 3G$
+  call assert_equal([0, 3, 1, 0], getcharpos('.'))
+  normal 4G$
+  call assert_equal([0, 4, 9, 0], getcharpos('.'))
+
+  " Test for a mark
+  normal 2G7lmmgg
+  call assert_equal([0, 2, 8, 0], getcharpos("'m"))
+  delmarks m
+  call assert_equal([0, 0, 0, 0], getcharpos("'m"))
+
+  " Test for the visual start column
+  vnoremap <expr> <F3> SaveVisualStartCharPos()
+  let g:VisualStartPos = []
+  exe "normal 2G6lv$\<F3>ohh\<F3>o\<F3>"
+  call assert_equal([[0, 2, 7, 0], [0, 2, 9, 0], [0, 2, 5, 0]], g:VisualStartPos)
+  call assert_equal([0, 2, 9, 0], getcharpos('v'))
+  let g:VisualStartPos = []
+  exe "normal 3Gv$\<F3>o\<F3>"
+  call assert_equal([[0, 3, 1, 0], [0, 3, 1, 0]], g:VisualStartPos)
+  let g:VisualStartPos = []
+  exe "normal 1Gv$\<F3>o\<F3>"
+  call assert_equal([[0, 1, 1, 0], [0, 1, 1, 0]], g:VisualStartPos)
+  vunmap <F3>
+
+  %bw!
+endfunc
+
+" Test for the setcharpos() function
+func Test_setcharpos()
+  call assert_equal(-1, setcharpos('.', test_null_list()))
+  new
+  call setline(1, ['', "01\tà4è678", 'Ⅵ', '012345678'])
+  call setcharpos('.', [0, 1, 1, 0])
+  call assert_equal([1, 1], [line('.'), col('.')])
+  call setcharpos('.', [0, 2, 7, 0])
+  call assert_equal([2, 9], [line('.'), col('.')])
+  call setcharpos('.', [0, 3, 4, 0])
+  call assert_equal([3, 1], [line('.'), col('.')])
+  call setcharpos('.', [0, 3, 1, 0])
+  call assert_equal([3, 1], [line('.'), col('.')])
+  call setcharpos('.', [0, 4, 0, 0])
+  call assert_equal([4, 1], [line('.'), col('.')])
+  call setcharpos('.', [0, 4, 20, 0])
+  call assert_equal([4, 9], [line('.'), col('.')])
+
+  " Test for mark
+  delmarks m
+  call setcharpos("'m", [0, 2, 9, 0])
+  normal `m
+  call assert_equal([2, 11], [line('.'), col('.')])
+
+  %bw!
+  call assert_equal(-1, setcharpos('.', [10, 3, 1, 0]))
+endfunc
+
+func SaveVisualStartCharCol()
+  call add(g:VisualStartCol, charcol('v'))
+  return ''
+endfunc
+
+" Test for the charcol() function
+func Test_charcol()
+  call assert_fails('call charcol({})', 'E731:')
+  call assert_equal(0, charcol(0))
+  new
+  call setline(1, ['', "01\tà4è678", 'Ⅵ', '012345678'])
+
+  " Test for '.' and '$'
+  normal 1G
+  call assert_equal(1, charcol('.'))
+  call assert_equal(1, charcol('$'))
+  normal 2G6l
+  call assert_equal(7, charcol('.'))
+  call assert_equal(10, charcol('$'))
+  normal 3G$
+  call assert_equal(1, charcol('.'))
+  call assert_equal(2, charcol('$'))
+  normal 4G$
+  call assert_equal(9, charcol('.'))
+  call assert_equal(10, charcol('$'))
+
+  " Test for [lnum, '$']
+  call assert_equal(1, charcol([1, '$']))
+  call assert_equal(10, charcol([2, '$']))
+  call assert_equal(2, charcol([3, '$']))
+  call assert_equal(0, charcol([5, '$']))
+
+  " Test for a mark
+  normal 2G7lmmgg
+  call assert_equal(8, charcol("'m"))
+  delmarks m
+  call assert_equal(0, charcol("'m"))
+
+  " Test for the visual start column
+  vnoremap <expr> <F3> SaveVisualStartCharCol()
+  let g:VisualStartCol = []
+  exe "normal 2G6lv$\<F3>ohh\<F3>o\<F3>"
+  call assert_equal([7, 9, 5], g:VisualStartCol)
+  call assert_equal(9, charcol('v'))
+  let g:VisualStartCol = []
+  exe "normal 3Gv$\<F3>o\<F3>"
+  call assert_equal([1, 1], g:VisualStartCol)
+  let g:VisualStartCol = []
+  exe "normal 1Gv$\<F3>o\<F3>"
+  call assert_equal([1, 1], g:VisualStartCol)
+  vunmap <F3>
+
+  %bw!
+endfunc
+
+" Test for getcursorcharpos()
+func Test_getcursorcharpos()
+  call assert_equal(getcursorcharpos(), getcursorcharpos(0))
+  call assert_equal([0, 0, 0, 0, 0], getcursorcharpos(-1))
+  call assert_equal([0, 0, 0, 0, 0], getcursorcharpos(1999))
+
+  new
+  call setline(1, ['', "01\tà4è678", 'Ⅵ', '012345678'])
+  normal 1G9l
+  call assert_equal([0, 1, 1, 0, 1], getcursorcharpos())
+  normal 2G9l
+  call assert_equal([0, 2, 9, 0, 14], getcursorcharpos())
+  normal 3G9l
+  call assert_equal([0, 3, 1, 0, 1], getcursorcharpos())
+  normal 4G9l
+  call assert_equal([0, 4, 9, 0, 9], getcursorcharpos())
+
+  let winid = win_getid()
+  normal 2G5l
+  wincmd w
+  call assert_equal([0, 2, 6, 0, 11], getcursorcharpos(winid))
+  %bw!
+endfunc
+
+" Test for setcursorcharpos()
+func Test_setcursorcharpos()
+  call assert_fails('call setcursorcharpos(test_null_list())', 'E474:')
+  call assert_fails('call setcursorcharpos([1])', 'E474:')
+  call assert_fails('call setcursorcharpos([1, 1, 1, 1, 1])', 'E474:')
+  new
+  call setline(1, ['', "01\tà4è678", 'Ⅵ', '012345678'])
+  normal G
+  call setcursorcharpos([1, 1])
+  call assert_equal([1, 1], [line('.'), col('.')])
+  call setcursorcharpos([2, 7, 0])
+  call assert_equal([2, 9], [line('.'), col('.')])
+  call setcursorcharpos(3, 4)
+  call assert_equal([3, 1], [line('.'), col('.')])
+  call setcursorcharpos([3, 1])
+  call assert_equal([3, 1], [line('.'), col('.')])
+  call setcursorcharpos([4, 0, 0, 0])
+  call assert_equal([4, 1], [line('.'), col('.')])
+  call setcursorcharpos([4, 20])
+  call assert_equal([4, 9], [line('.'), col('.')])
+  normal 1G
+  call setcursorcharpos([100, 100, 100, 100])
+  call assert_equal([4, 9], [line('.'), col('.')])
+  normal 1G
+  call setcursorcharpos('$', 1)
+  call assert_equal([4, 1], [line('.'), col('.')])
+
+  %bw!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/typval.c
+++ b/src/typval.c
@@ -1579,7 +1579,7 @@ tv_get_lnum(typval_T *argvars)
     if (lnum <= 0)  // no valid number, try using arg like line()
     {
 	int	fnum;
-	pos_T	*fp = var2fpos(&argvars[0], TRUE, &fnum);
+	pos_T	*fp = var2fpos(&argvars[0], TRUE, &fnum, FALSE);
 
 	if (fp != NULL)
 	    lnum = fp->lnum;


### PR DESCRIPTION
Add the following functions:

  getcharpos()  -  Get the character position of the cursor or a mark. For non multibyte text, same as getpos().
  setcharpos()  -  Set the character position of the cursor or a mark. For non multibyte text, same as setpos().
  charcol()  -  Get the character count of the cursor or a mark in a line. For non multibyte text, same as col().
  getcursorcharpos()  -  Get the character position of the cursor. For non multibyte text, same as getcurpos().
  setcursorcharpos()  -  Set the character position of the cursor. For non multibyte text, same as cursor().
