### PR TITLE
Display message when gtk-dev is missing

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2583,6 +2583,7 @@ AC_DEFUN(AM_PATH_GTK,
 	     sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
     }
     else
+      AC_MSG_CHECKING(for GTK+ 2 or 3)
       no_gtk=yes
     fi
 


### PR DESCRIPTION
Fixes issue #5229 

When gtk headers are missing currently no message is displayed: the configure output looks like
```
no
```
This pull request changes this to
```
checking for GTK+ 2 or 3... no
```