### PR TITLE
Implement focus tracking for terminals

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -373,6 +373,10 @@ Added by Vim (there are no standard codes for these):
 	t_Ri	restore icon text from stack			*t_Ri* *'t_Ri'*
 	t_TE	end of "raw" mode				*t_TE* *'t_TE'*
 	t_TI	put terminal into "raw" mode 			*t_TI* *'t_TI'*
+	t_fd	disable focus-event tracking 			*t_TI* *'t_TI'*
+		|xterm-focus-event|
+	t_fe	enable focus-event tracking 			*t_TI* *'t_TI'*
+		|xterm-focus-event|
 
 Some codes have a start, middle and end part.  The start and end are defined
 by the termcap option, the middle part is text.
@@ -545,6 +549,16 @@ To overrule the default, put this line in your ~/.Xdefaults or
 And run "xrdb -merge .Xresources" to make it effective.  You can check the
 value with the context menu (right mouse button while CTRL key is pressed),
 there should be a tick at allow-window-ops.
+
+							*xterm-focus-event*
+Some terminals including xterm support the focus event tracking feature.
+If this feature is enabled by the 't_fe' sequence, special key sequences are
+sent from the terminal to Vim every time the terminal gains or loses focus.
+Vim fires focus events (|FocusGained|/|FocusLost|) by handling them accordingly.
+Focus event tracking is disabled by a 't_fd' sequence when exiting "raw" mode.
+If you would like to disable this feature, add the following to your .vimrc:
+	`set t_fd=`
+	`set t_fe=`
 
 							*termcap-colors*
 Note about colors: The 't_Co' option tells Vim the number of colors available.

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -2957,6 +2957,8 @@ static struct vimoption options[] =
     p_term("t_EC", T_CEC)
     p_term("t_EI", T_CEI)
     p_term("t_fs", T_FS)
+    p_term("t_fd", T_FD)
+    p_term("t_fe", T_FE)
     p_term("t_GP", T_CGP)
     p_term("t_IE", T_CIE)
     p_term("t_IS", T_CIS)

--- a/src/term.h
+++ b/src/term.h
@@ -109,10 +109,12 @@ enum SpecialKey
     KS_CST,	// save window title
     KS_CRT,	// restore window title
     KS_SSI,	// save icon text
-    KS_SRI	// restore icon text
+    KS_SRI,	// restore icon text
+    KS_FD,	// disable focus event tracking
+    KS_FE	// enable focus event tracking
 };
 
-#define KS_LAST	    KS_SRI
+#define KS_LAST	    KS_FE
 
 /*
  * the terminal capabilities are stored in this array
@@ -212,6 +214,8 @@ extern char_u *(term_strings[]);    // current terminal strings
 #define T_CRT	(TERM_STR(KS_CRT))	// restore window title
 #define T_SSI	(TERM_STR(KS_SSI))	// save icon text
 #define T_SRI	(TERM_STR(KS_SRI))	// restore icon text
+#define T_FD	(TERM_STR(KS_FD))	// disable focus event tracking
+#define T_FE	(TERM_STR(KS_FE))	// enable focus event tracking
 
 typedef enum {
     TMODE_COOK,	    // terminal mode for external cmds and Ex mode


### PR DESCRIPTION
This implements focus tracking for terminals supporting this sequence. See https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-FocusIn_FocusOut for the specification.

This is largely based on the initial patch by saitoha on the mailing list 5 years ago.