### PR TITLE
Temporary file Xfile.pp was not deleted when running test Test_pp_file()

### DIFF
--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -757,7 +757,7 @@ func Test_pp_file()
   call assert_equal('pascal', &filetype)
   bwipe!
 
-  call delete('Xfile.ts')
+  call delete('Xfile.pp')
   filetype off
 endfunc
 


### PR DESCRIPTION
Temporary file `Xfile.pp` was not deleted when running test `Test_pp_file()`.