### PR TITLE
cursor() function accepts string type for line and column numbers

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2767,7 +2767,8 @@ set_cursorpos(typval_T *argvars, typval_T *rettv, int charcol)
     }
     else if ((argvars[0].v_type == VAR_NUMBER ||
 					argvars[0].v_type == VAR_STRING)
-	    && argvars[1].v_type == VAR_NUMBER)
+	    && (argvars[1].v_type == VAR_NUMBER ||
+					argvars[1].v_type == VAR_STRING))
     {
 	line = tv_get_lnum(argvars);
 	if (line < 0)

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -25,6 +25,9 @@ func Test_move_cursor()
   " below last line goes to last line
   eval [9, 1]->cursor()
   call assert_equal([4, 1, 0, 1], getcurpos()[1:])
+  " pass string arguments
+  call cursor('3', '3')
+  call assert_equal([3, 3, 0, 3], getcurpos()[1:])
 
   call setline(1, ["\<TAB>"])
   call cursor(1, 1, 1)


### PR DESCRIPTION
Fix the regression introduced by 8.2.2324.