### PR TITLE
Use correct types for e_listidx/e_using_number_as_bool_nr

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -84,7 +84,7 @@ EXTERN char e_const_requires_a_value[]
 EXTERN char e_type_or_initialization_required[]
 	INIT(= N_("E1022: Type or initialization required"));
 EXTERN char e_using_number_as_bool_nr[]
-	INIT(= N_("E1023: Using a Number as a Bool: %d"));
+	INIT(= N_("E1023: Using a Number as a Bool: %lld"));
 EXTERN char e_using_number_as_string[]
 	INIT(= N_("E1024: Using a Number as a String"));
 EXTERN char e_using_rcurly_outside_if_block_scope[]

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2567,7 +2567,7 @@ f_charidx(typval_T *argvars, typval_T *rettv)
 {
     char_u	*str;
     varnumber_T	idx;
-    int		countcc = FALSE;
+    varnumber_T	countcc = FALSE;
     char_u	*p;
     int		len;
     int		(*ptr2len)(char_u *);
@@ -2588,10 +2588,10 @@ f_charidx(typval_T *argvars, typval_T *rettv)
 	return;
 
     if (argvars[2].v_type != VAR_UNKNOWN)
-	countcc = (int)tv_get_bool(&argvars[2]);
+	countcc = tv_get_bool(&argvars[2]);
     if (countcc < 0 || countcc > 1)
     {
-	semsg(_(e_using_number_as_bool_nr), countcc);
+	semsg(_(e_using_number_as_bool_nr), (long long)countcc);
 	return;
     }
 
@@ -2848,13 +2848,13 @@ f_debugbreak(typval_T *argvars, typval_T *rettv)
     static void
 f_deepcopy(typval_T *argvars, typval_T *rettv)
 {
-    int		noref = 0;
+    varnumber_T	noref = 0;
     int		copyID;
 
     if (argvars[1].v_type != VAR_UNKNOWN)
-	noref = (int)tv_get_bool_chk(&argvars[1], NULL);
+	noref = tv_get_bool_chk(&argvars[1], NULL);
     if (noref < 0 || noref > 1)
-	semsg(_(e_using_number_as_bool_nr), noref);
+	semsg(_(e_using_number_as_bool_nr), (long long)noref);
     else
     {
 	copyID = get_copyID();
@@ -9185,14 +9185,14 @@ f_strlen(typval_T *argvars, typval_T *rettv)
 f_strchars(typval_T *argvars, typval_T *rettv)
 {
     char_u		*s = tv_get_string(&argvars[0]);
-    int			skipcc = FALSE;
+    varnumber_T		skipcc = FALSE;
     varnumber_T		len = 0;
     int			(*func_mb_ptr2char_adv)(char_u **pp);
 
     if (argvars[1].v_type != VAR_UNKNOWN)
-	skipcc = (int)tv_get_bool(&argvars[1]);
+	skipcc = tv_get_bool(&argvars[1]);
     if (skipcc < 0 || skipcc > 1)
-	semsg(_(e_using_number_as_bool_nr), skipcc);
+	semsg(_(e_using_number_as_bool_nr), (long long)skipcc);
     else
     {
 	func_mb_ptr2char_adv = skipcc ? mb_ptr2char_adv : mb_cptr2char_adv;

--- a/src/list.c
+++ b/src/list.c
@@ -925,7 +925,7 @@ list_slice_or_index(
 	if (!range)
 	{
 	    if (verbose)
-		semsg(_(e_listidx), n1_arg);
+		semsg(_(e_listidx), (long)n1_arg);
 	    return FAIL;
 	}
 	n1 = n1 < 0 ? 0 : len;
@@ -1452,7 +1452,7 @@ list_remove(typval_T *argvars, typval_T *rettv, char_u *arg_errmsg)
     listitem_T	*item, *item2;
     listitem_T	*li;
     int		error = FALSE;
-    int		idx;
+    long	idx;
 
     if ((l = argvars[0].vval.v_list) == NULL
 			     || value_check_lock(l->lv_lock, arg_errmsg, TRUE))
@@ -1475,7 +1475,7 @@ list_remove(typval_T *argvars, typval_T *rettv, char_u *arg_errmsg)
 	else
 	{
 	    // Remove range of items, return list with values.
-	    int end = (long)tv_get_number_chk(&argvars[2], &error);
+	    long end = (long)tv_get_number_chk(&argvars[2], &error);
 
 	    if (error)
 		;		// type error: do nothing

--- a/src/typval.c
+++ b/src/typval.c
@@ -180,7 +180,7 @@ tv_get_bool_or_number_chk(typval_T *varp, int *denote, int want_bool)
 	    if (in_vim9script() && want_bool && varp->vval.v_number != 0
 						   && varp->vval.v_number != 1)
 	    {
-		semsg(_(e_using_number_as_bool_nr), varp->vval.v_number);
+		semsg(_(e_using_number_as_bool_nr), (long long)varp->vval.v_number);
 		break;
 	    }
 	    return varp->vval.v_number;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -1935,7 +1935,7 @@ call_def_function(
 
 		    if (status == OK && dest_type == VAR_LIST)
 		    {
-			varnumber_T	lidx = tv_idx->vval.v_number;
+			long	lidx = tv_idx->vval.v_number;
 			list_T		*list = tv_dest->vval.v_list;
 
 			if (list == NULL)
@@ -2121,7 +2121,7 @@ call_def_function(
 			else
 			{
 			    list_T	*l = tv_dest->vval.v_list;
-			    varnumber_T	n = tv_idx->vval.v_number;
+			    long	n = tv_idx->vval.v_number;
 			    listitem_T	*li = NULL;
 
 			    li = list_find(l, n);


### PR DESCRIPTION
This fixes test failures encountered armel/armhf/mipsel:

    From test_vim9_expr.vim:
    Found errors in Test_expr3_fails():
    command line..script /<<PKGBUILDDIR>>/src/vim-gtk3/testdir/runtest.vim[468]..function RunTheTest[39]..Test_expr3_fails[8]..CheckDefExecFailure line 7: ['assert_equal(false, Record(1) && Record(4) && Record(0))']: Expected 'E1023: Using a Number as a Bool: 4' but got 'E1023: Using a Number as a Bool: 0': ['assert_equal(false, Record(1) && Record(4) && Record(0))']

    Found errors in Test_expr7_any_index_slice():
    command line..script /<<PKGBUILDDIR>>/src/vim-gtk3/testdir/runtest.vim[468]..function RunTheTest[39]..Test_expr7_any_index_slice[72]..CheckDefExecFailure line 7: ['echo g:testlist[4]']: Expected 'E684: list index out of range: 4' but got 'E684: list index out of range: 0': ['echo g:testlist[4]']
    command line..script /<<PKGBUILDDIR>>/src/vim-gtk3/testdir/runtest.vim[468]..function RunTheTest[39]..Test_expr7_any_index_slice[75]..CheckScriptFailure line 6: ['vim9script', 'echo g:testlist[-5]']: Expected 'E684: list index out of range: -5' but got 'E684: list index out of range: 0': ['vim9script', 'echo g:testlist[-5]']