### PR TITLE
Fixed use of uninitialized memory when running "make test_undo"

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -1586,7 +1586,7 @@ decodeModifyOtherKeys(int c)
     // Recognize:
     // form 0: {lead}{key};{modifier}u
     // form 1: {lead}27;{modifier};{key}~
-    if ((c == CSI || (c == ESC && *p == '[')) && typebuf.tb_len >= 4)
+    if (typebuf.tb_len >= 4 && (c == CSI || (c == ESC && *p == '[')))
     {
 	idx = (*p == '[');
 	if (p[idx] == '2' && p[idx + 1] == '7' && p[idx + 2] == ';')


### PR DESCRIPTION
Running `make test_undo` with valgrind shows use of uninitialized memory:
```
==7832== Memcheck, a memory error detector
==7832== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==7832== Using Valgrind-3.17.0.GIT and LibVEX; rerun with -h for copyright info
==7832== Command: ../vim -f -u unix.vim -U NONE --noplugin --not-a-term -S runtest.vim test_undo.vim --cmd au\ SwapExists\ *\ let\ v:swapchoice\ =\ "e"
==7832== Parent PID: 7831
==7832== 
==7832== Conditional jump or move depends on uninitialised value(s)
==7G832==    at 0x45A1E1: decodeModifyOtherKeys (edit.c:1589)
==7832==    by 0x45AE3B: get_literal (edit.c:1880)
==7832==    by 0x5454B6: nv_replace (normal.c:4930)
==7832==    by 0x53BB97: normal_cmd (normal.c:1098)
==7832==    by 0x49E4DA: exec_normal (ex_docmd.c:8302)
==7832==    by 0x49E385: exec_normal_cmd (ex_docmd.c:8265)
==7832==    by 0x49E2A9: ex_normal (ex_docmd.c:8183)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x4677EA: ex_execute (eval.c:6108)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x662571: call_user_func (userfunc.c:1885)
==7832==    by 0x66188A: call_user_func_check (userfunc.c:2039)
==7832==    by 0x660846: call_func (userfunc.c:2505)
==7832==    by 0x66011F: get_func_tv (userfunc.c:906)
==7832==    by 0x6689EB: ex_call (userfunc.c:4480)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x4677EA: ex_execute (eval.c:6108)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x662571: call_user_func (userfunc.c:1885)
==7832==    by 0x66188A: call_user_func_check (userfunc.c:2039)
==7832==    by 0x660846: call_func (userfunc.c:2505)
==7832==    by 0x66011F: get_func_tv (userfunc.c:906)
==7832==    by 0x6689EB: ex_call (userfunc.c:4480)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x5D39F0: do_source (scriptfile.c:1401)
==7832==    by 0x5D2E45: cmd_source (scriptfile.c:971)
==7832==    by 0x5D2D5B: ex_source (scriptfile.c:997)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x4945F0: do_cmdline_cmd (ex_docmd.c:592)
==7832==    by 0x6DD3CC: exe_commands (main.c:3056)
==7832==    by 0x6DC484: vim_main2 (main.c:760)
==7832==    by 0x6D9EC7: main (main.c:412)
==7832==  Uninitialised value was created by a heap allocation
==7832==    at 0x4C31F1B: malloc (vg_replace_malloc.c:307)
==7832==    by 0x529816: lalloc (misc2.c:925)
==7832==    by 0x5297B9: alloc (misc2.c:828)
==7832==    by 0x4CFD31: alloc_typebuf (getchar.c:1328)
==7832==    by 0x4CFEA8: save_typeahead (getchar.c:1397)
==7832==    by 0x49DE44: save_current_state (ex_docmd.c:8055)
==7832==    by 0x49E201: ex_normal (ex_docmd.c:8167)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x4677EA: ex_execute (eval.c:6108)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x662571: call_user_func (userfunc.c:1885)
==7832==    by 0x66188A: call_user_func_check (userfunc.c:2039)
==7832==    by 0x660846: call_func (userfunc.c:2505)
==7832==    by 0x66011F: get_func_tv (userfunc.c:906)
==7832==    by 0x6689EB: ex_call (userfunc.c:4480)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x4677EA: ex_execute (eval.c:6108)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x662571: call_user_func (userfunc.c:1885)
==7832==    by 0x66188A: call_user_func_check (userfunc.c:2039)
==7832==    by 0x660846: call_func (userfunc.c:2505)
==7832==    by 0x66011F: get_func_tv (userfunc.c:906)
==7832==    by 0x6689EB: ex_call (userfunc.c:4480)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x5D39F0: do_source (scriptfile.c:1401)
==7832==    by 0x5D2E45: cmd_source (scriptfile.c:971)
==7832==    by 0x5D2D5B: ex_source (scriptfile.c:997)
==7832==    by 0x496894: do_one_cmd (ex_docmd.c:2588)
==7832==    by 0x4937B5: do_cmdline (ex_docmd.c:1003)
==7832==    by 0x4945F0: do_cmdline_cmd (ex_docmd.c:592)
==7832==    by 0x6DD3CC: exe_commands (main.c:3056)
==7832==    by 0x6DC484: vim_main2 (main.c:760)
==7832==    by 0x6D9EC7: main (main.c:412)
```
Error happens at `edit.c:1589`:
```
  1577     int
  1578 decodeModifyOtherKeys(int c)
  1579 {
  1580     char_u  *p = typebuf.tb_buf + typebuf.tb_off;
  1581     int     idx;
  1582     int     form = 0;
  1583     int     argidx = 0;
  1584     int     arg[2] = {0, 0};
  1585 
  1586     // Recognize:
  1587     // form 0: {lead}{key};{modifier}u
  1588     // form 1: {lead}27;{modifier};{key}~
!!1589     if ((c == CSI || (c == ESC && *p == '[')) && typebuf.tb_len >= 4) 
```

The problem happens because `*p == '['` is looking at a byte inside
`typebuf.tb_buf` when there is nothing in `typbuf` (i.e. when `typebuf.tb_len` is 0).

Inverting the 2 conditions at line edit.c:1589 as follows fixes problem:
```
!!1589     if (typebuf.tb_len >= 4 && (c == CSI || (c == ESC && *p == '[')) 
```
