### PR TITLE
Don't call spell_suggest_intern more than necessary

### DIFF
--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -863,7 +863,7 @@ spell_find_suggest(
 	else if (STRNCMP(buf, "file:", 5) == 0)
 	    // Use list of suggestions in a file.
 	    spell_suggest_file(su, buf + 5);
-	else
+	else if (!VIM_ISDIGIT(*buf))
 	{
 	    // Use internal method.
 	    spell_suggest_intern(su, interactive);


### PR DESCRIPTION
Adding a number to spellsuggest makes the loop execute
spell_suggest_intern twice, producing a long list full of duplicates
that increased the execution time by a lot.

Closes #4087