### PR TITLE
Add turtle filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1731,8 +1731,13 @@ au BufNewFile,BufRead *.tli			setf tli
 " Telix Salt
 au BufNewFile,BufRead *.slt			setf tsalt
 
-" Tera Term Language
-au BufRead,BufNewFile *.ttl			setf teraterm
+" Tera Term Language (or Turtle)
+au BufRead,BufNewFile *.ttl
+	\ if getline(1) =~ '^@\?\(prefix\|base\)' |
+	\   setf turtle |
+	\ else |
+	\   setf teraterm |
+	\ endif
 
 " Terminfo
 au BufNewFile,BufRead *.ti			setf terminfo

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -733,6 +733,23 @@ func Test_ts_file()
   filetype off
 endfunc
 
+func Test_ttl_file()
+  filetype on
+
+  call writefile(['@base <http://example.org/> .'], 'Xfile.ttl')
+  split Xfile.ttl
+  call assert_equal('turtle', &filetype)
+  bwipe!
+
+  call writefile(['looks like Tera Term Language'], 'Xfile.ttl')
+  split Xfile.ttl
+  call assert_equal('teraterm', &filetype)
+  bwipe!
+
+  call delete('Xfile.ttl')
+  filetype off
+endfunc
+
 func Test_pp_file()
   filetype on
 


### PR DESCRIPTION
ttl file suffix should be [turtle](https://www.iana.org/assignments/media-types/text/turtle), but it is already occupied by tera term language.
As a compromise this patch checks for `base` and `prefix` keywords, as most turtle files start with these.