### PR TITLE
Fix screen-line movements when cursor is inside closed fold

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -2570,12 +2570,6 @@ nv_screengo(oparg_T *oap, int dir, long dist)
 	    else
 	    {
 		// to previous line
-		if (curwin->w_cursor.lnum == 1)
-		{
-		    retval = FAIL;
-		    break;
-		}
-		--curwin->w_cursor.lnum;
 #ifdef FEAT_FOLDING
 		// Move to the start of a closed fold.  Don't do that when
 		// 'foldopen' contains "all": it will open in a moment.
@@ -2583,6 +2577,13 @@ nv_screengo(oparg_T *oap, int dir, long dist)
 		    (void)hasFolding(curwin->w_cursor.lnum,
 						&curwin->w_cursor.lnum, NULL);
 #endif
+		if (curwin->w_cursor.lnum == 1)
+		{
+		    retval = FAIL;
+		    break;
+		}
+		--curwin->w_cursor.lnum;
+
 		linelen = linetabsize(ml_get_curline());
 		if (linelen > width1)
 		    curwin->w_curswant += (((linelen - width1 - 1) / width2)
@@ -5957,13 +5958,8 @@ nv_g_cmd(cmdarg_T *cap)
      */
     case 'j':
     case K_DOWN:
-	// with 'nowrap' it works just like the normal "j" command; also when
-	// in a closed fold
-	if (!curwin->w_p_wrap
-#ifdef FEAT_FOLDING
-		|| hasFolding(curwin->w_cursor.lnum, NULL, NULL)
-#endif
-		)
+	// with 'nowrap' it works just like the normal "j" command.
+	if (!curwin->w_p_wrap)
 	{
 	    oap->motion_type = MLINE;
 	    i = cursor_down(cap->count1, oap->op_type == OP_NOP);
@@ -5976,13 +5972,8 @@ nv_g_cmd(cmdarg_T *cap)
 
     case 'k':
     case K_UP:
-	// with 'nowrap' it works just like the normal "k" command; also when
-	// in a closed fold
-	if (!curwin->w_p_wrap
-#ifdef FEAT_FOLDING
-		|| hasFolding(curwin->w_cursor.lnum, NULL, NULL)
-#endif
-	   )
+	// with 'nowrap' it works just like the normal "k" command.
+	if (!curwin->w_p_wrap)
 	{
 	    oap->motion_type = MLINE;
 	    i = cursor_up(cap->count1, oap->op_type == OP_NOP);

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -859,4 +859,39 @@ func Test_fold_create_delete()
   bwipe!
 endfunc
 
+func Test_fold_relative_move()
+  enew!
+  set fdm=indent sw=2 wrap tw=80
+
+  let content = [ '  foo', '  bar', '  baz',
+              \   repeat('x', 100),
+              \   '  foo', '  bar', '  baz'
+              \ ]
+  call append(0, content)
+
+  normal zM
+
+  call cursor(3, 1)
+  call assert_true(foldclosed(line('.')))
+  normal gj
+  call assert_equal(2, winline())
+
+  call cursor(2, 1)
+  call assert_true(foldclosed(line('.')))
+  normal 2gj
+  call assert_equal(3, winline())
+
+  call cursor(5, 1)
+  call assert_true(foldclosed(line('.')))
+  normal gk
+  call assert_equal(3, winline())
+
+  call cursor(6, 1)
+  call assert_true(foldclosed(line('.')))
+  normal 2gk
+  call assert_equal(2, winline())
+
+  set fdm& sw& wrap& tw&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix the logic to make gj/gk behave as expected even when the cursor is
inside a closed fold.

Shuffle some logic a bit for gk, call hasFolding before decrementing the
current line number so that the count reflects the effective number of
screen lines being skipped.

Supersedes #4095