### PR TITLE
Test Test_fold_relative_move() failed for wide terminal

### DIFF
--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -864,7 +864,7 @@ func Test_fold_relative_move()
   set fdm=indent sw=2 wrap tw=80
 
   let content = [ '  foo', '  bar', '  baz',
-              \   repeat('x', 100),
+              \   repeat('x', &columns + 1),
               \   '  foo', '  bar', '  baz'
               \ ]
   call append(0, content)


### PR DESCRIPTION
Test failed when terminal had 100 or more columns (closes #7731)