### PR TITLE
Remove incompatible flags from WINDRES_FLAGS

### DIFF
--- a/src/GvimExt/Make_ming.mak
+++ b/src/GvimExt/Make_ming.mak
@@ -49,8 +49,7 @@ WINVER = 0x0501
 endif
 CXX := $(CROSS_COMPILE)g++
 WINDRES := $(CROSS_COMPILE)windres
-WINDRES_CXX = $(CXX)
-WINDRES_FLAGS = --preprocessor="$(WINDRES_CXX) -E -xc" -DRC_INVOKED
+WINDRES_FLAGS =
 LIBS :=  -luuid -lgdi32
 RES  := gvimext.res
 DEFFILE = gvimext_ming.def

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -220,7 +220,6 @@ WINDRES := $(CROSS_COMPILE)windres
 else
 WINDRES := windres
 endif
-WINDRES_CC = $(CC)
 
 # Get the default ARCH.
 ifndef ARCH
@@ -514,7 +513,7 @@ endif
 
 CFLAGS = -I. -Iproto $(DEFINES) -pipe -march=$(ARCH) -Wall
 CXXFLAGS = -std=gnu++11
-WINDRES_FLAGS = --preprocessor="$(WINDRES_CC) -E -xc" -DRC_INVOKED
+WINDRES_FLAGS =
 EXTRA_LIBS =
 
 ifdef GETTEXT


### PR DESCRIPTION
The just-released Binutils 2.36 no longer accepts preprocessor flags via the windres `--preprocessor` option (see [Binutils bug 26865](https://sourceware.org/bugzilla/show_bug.cgi?id=26865)). The correct way to pass additional arguments is via `--preprocessor-arg`. However, the currently-specified options are already the windres defaults, so the simplest solution is to just accept the defaults by default.

The `WINDRES_FLAGS` macro remains available for overriding the defaults.