### PR TITLE
win32: Fix compilation error with Ruby 3.0

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -524,7 +524,11 @@ static void (*dll_rb_gc_writebarrier_unprotect)(VALUE obj);
 # endif
 
 # if RUBY_VERSION >= 30
+#  ifdef _MSC_VER
 static void (*dll_ruby_malloc_size_overflow)(size_t, size_t);
+#  else
+NORETURN(static void (*dll_ruby_malloc_size_overflow)(size_t, size_t));
+#  endif
 # endif
 
 # if RUBY_VERSION >= 26

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -436,7 +436,7 @@ static VALUE (*dll_rb_hash_new) (void);
 static VALUE (*dll_rb_inspect) (VALUE);
 static VALUE (*dll_rb_int2inum) (long);
 static ID (*dll_rb_intern) (const char*);
-# if VIM_SIZEOF_INT < VIM_SIZEOF_LONG // 64 bits only
+# if RUBY_VERSION >= 30 || VIM_SIZEOF_INT < VIM_SIZEOF_LONG
 static long (*dll_rb_fix2int) (VALUE);
 static long (*dll_rb_num2int) (VALUE);
 static unsigned long (*dll_rb_num2uint) (VALUE);
@@ -524,7 +524,7 @@ static void (*dll_rb_gc_writebarrier_unprotect)(VALUE obj);
 # endif
 
 # if RUBY_VERSION >= 30
-NORETURN(static void (*dll_ruby_malloc_size_overflow)(size_t, size_t));
+static void (*dll_ruby_malloc_size_overflow)(size_t, size_t);
 # endif
 
 # if RUBY_VERSION >= 26
@@ -554,7 +554,7 @@ rb_int2big_stub(SIGNED_VALUE x)
 {
     return dll_rb_int2big(x);
 }
-#   if VIM_SIZEOF_INT < VIM_SIZEOF_LONG
+#   if RUBY_VERSION >= 30 || VIM_SIZEOF_INT < VIM_SIZEOF_LONG
     long
 rb_fix2int_stub(VALUE x)
 {
@@ -612,13 +612,11 @@ rb_check_type_stub(VALUE obj, int t)
 {
     dll_rb_check_type(obj, t);
 }
-#   if VIM_SIZEOF_INT < VIM_SIZEOF_LONG // 64 bits only
     unsigned long
 rb_num2uint_stub(VALUE x)
 {
     return dll_rb_num2uint(x);
 }
-#   endif
     void
 ruby_malloc_size_overflow_stub(size_t x, size_t y)
 {
@@ -695,7 +693,7 @@ static struct
     {"rb_inspect", (RUBY_PROC*)&dll_rb_inspect},
     {"rb_int2inum", (RUBY_PROC*)&dll_rb_int2inum},
     {"rb_intern", (RUBY_PROC*)&dll_rb_intern},
-# if VIM_SIZEOF_INT < VIM_SIZEOF_LONG // 64 bits only
+# if RUBY_VERSION >= 30 || VIM_SIZEOF_INT < VIM_SIZEOF_LONG
     {"rb_fix2int", (RUBY_PROC*)&dll_rb_fix2int},
     {"rb_num2int", (RUBY_PROC*)&dll_rb_num2int},
     {"rb_num2uint", (RUBY_PROC*)&dll_rb_num2uint},


### PR DESCRIPTION
if_ruby couldn't compile with Ruby 3.0 on MS-Windows even after #7564 and #7638.

@ichizok and @zdohnal,
Could you check if this works on your environment?