### PR TITLE
win32: Fix that ADS is not preserved when backupcopy=yes

### DIFF
--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1497,6 +1497,9 @@ buf_write(
 #if defined(HAVE_SELINUX) || defined(HAVE_SMACK)
 			mch_copy_sec(fname, backup);
 #endif
+#ifdef MSWIN
+			(void)mch_copy_file_attribute(fname, backup);
+#endif
 			break;
 		    }
 		}
@@ -1909,12 +1912,7 @@ restore_backup:
 
 #if defined(MSWIN)
 	    if (backup != NULL && overwriting && !append)
-	    {
-		if (backup_copy)
-		    (void)mch_copy_file_attribute(wfname, backup);
-		else
-		    (void)mch_copy_file_attribute(backup, wfname);
-	    }
+		(void)mch_copy_file_attribute(backup, wfname);
 
 	    if (!overwriting && !append)
 	    {


### PR DESCRIPTION
Alternate Data Stream (ADS) on NTFS was not preserved when `backupcopy=yes`.
It seems that ADS is erased when a file is opened with `O_TRUNC`.
Copy the ADS to the backup file, and restore it from the backup after
the file is opened.