### PR TITLE
Reorder options in mkview output

### DIFF
--- a/src/fold.c
+++ b/src/fold.c
@@ -3526,7 +3526,8 @@ put_folds(FILE *fd, win_T *wp)
     if (foldmethodIsManual(wp))
     {
 	if (put_line(fd, "silent! normal! zE") == FAIL
-		|| put_folds_recurse(fd, &wp->w_folds, (linenr_T)0) == FAIL)
+		|| put_folds_recurse(fd, &wp->w_folds, (linenr_T)0) == FAIL
+		|| put_line(fd, "let &fdl = &fdl") == FAIL)
 	    return FAIL;
     }
 

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -504,6 +504,32 @@ func Test_mkview_terminal_windows()
   call delete('Xtestview')
 endfunc
 
+func Test_mkview_open_folds()
+  enew!
+
+  call append(0, ['a', 'b', 'c'])
+  1,3fold
+  " zR affects 'foldlevel', make sure the option is applied after the folds
+  " have been recreated.
+  normal zR
+  write! Xtestfile
+
+  call assert_equal(-1, foldclosed(1))
+  call assert_equal(-1, foldclosed(2))
+  call assert_equal(-1, foldclosed(3))
+
+  mkview! Xtestview
+  source Xtestview
+
+  call assert_equal(-1, foldclosed(1))
+  call assert_equal(-1, foldclosed(2))
+  call assert_equal(-1, foldclosed(3))
+
+  call delete('Xtestview')
+  call delete('Xtestfile')
+  %bwipe
+endfunc
+
 " Test :mkview with a file argument.
 func Test_mkview_file()
   " Create a view with line number and a fold.


### PR DESCRIPTION
Fold-related options are better set after the folds have been recreated.

Closes #6274