### PR TITLE
Complete *func and *expr options

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2068,7 +2068,7 @@ ExpandFromContext(
 
     // When expanding a function name starting with s:, match the <SNR>nr_
     // prefix.
-    if (xp->xp_context == EXPAND_USER_FUNC && STRNCMP(pat, "^s:", 3) == 0)
+    if ((xp->xp_context == EXPAND_USER_FUNC || xp->xp_context == EXPAND_EXPRESSION_SET) && STRNCMP(pat, "^s:", 3) == 0)
     {
 	int len = (int)STRLEN(pat) + 20;
 
@@ -2118,6 +2118,7 @@ ExpandFromContext(
 	    {EXPAND_FUNCTIONS, get_function_name, FALSE, TRUE},
 	    {EXPAND_USER_FUNC, get_user_func_name, FALSE, TRUE},
 	    {EXPAND_EXPRESSION, get_expr_name, FALSE, TRUE},
+	    {EXPAND_EXPRESSION_SET, get_user_func_name, FALSE, TRUE},
 # endif
 # ifdef FEAT_MENU
 	    {EXPAND_MENUS, get_menu_name, FALSE, TRUE},
@@ -2258,7 +2259,8 @@ ExpandGeneric(
     {
 	if (xp->xp_context == EXPAND_EXPRESSION
 		|| xp->xp_context == EXPAND_FUNCTIONS
-		|| xp->xp_context == EXPAND_USER_FUNC)
+		|| xp->xp_context == EXPAND_USER_FUNC
+		|| xp->xp_context == EXPAND_EXPRESSION_SET)
 	    // <SNR> functions should be sorted to the end.
 	    qsort((void *)*file, (size_t)*num_file, sizeof(char_u *),
 							   sort_func_compare);

--- a/src/option.h
+++ b/src/option.h
@@ -453,7 +453,7 @@ EXTERN int	p_beval;	// 'ballooneval'
 # endif
 EXTERN long	p_bdlay;	// 'balloondelay'
 # ifdef FEAT_EVAL
-EXTERN char_u	*p_bexpr;
+EXTERN char_u	*p_bexpr;	// 'balloonexpr'
 # endif
 # ifdef FEAT_BEVAL_TERM
 EXTERN int	p_bevalterm;	// 'balloonevalterm'

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -458,7 +458,7 @@ static struct vimoption options[] =
 			    {(char_u *)0L, (char_u *)0L}
 #endif
 			    SCTX_INIT},
-    {"balloonexpr", "bexpr", P_STRING|P_ALLOCED|P_VI_DEF|P_VIM|P_MLE,
+    {"balloonexpr", "bexpr", P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_VIM|P_MLE,
 #if defined(FEAT_BEVAL) && defined(FEAT_EVAL)
 			    (char_u *)&p_bexpr, PV_BEXPR,
 			    {(char_u *)"", (char_u *)0L}
@@ -553,7 +553,7 @@ static struct vimoption options[] =
 			    {(char_u *)0L, (char_u *)0L}
 #endif
 			    SCTX_INIT},
-    {"charconvert",  "ccv", P_STRING|P_VI_DEF|P_SECURE,
+    {"charconvert",  "ccv", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(FEAT_EVAL)
 			    (char_u *)&p_ccv, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
@@ -670,7 +670,7 @@ static struct vimoption options[] =
 #endif
 			    {(char_u *)0L, (char_u *)0L}
 			    SCTX_INIT},
-    {"completefunc", "cfu", P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
+    {"completefunc", "cfu", P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_SECURE,
 #ifdef FEAT_COMPL_FUNC
 			    (char_u *)&p_cfu, PV_CFU,
 			    {(char_u *)"", (char_u *)0L}
@@ -829,7 +829,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 #endif
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
-    {"diffexpr",    "dex",  P_STRING|P_VI_DEF|P_SECURE|P_CURSWANT,
+    {"diffexpr",    "dex",  P_STRING|P_EXPAND|P_VI_DEF|P_SECURE|P_CURSWANT,
 #if defined(FEAT_DIFF) && defined(FEAT_EVAL)
 			    (char_u *)&p_dex, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
@@ -990,7 +990,7 @@ static struct vimoption options[] =
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCTX_INIT},
-    {"foldexpr",    "fde",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN|P_MLE,
+    {"foldexpr",    "fde",  P_STRING|P_EXPAND|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN|P_MLE,
 #if defined(FEAT_FOLDING) && defined(FEAT_EVAL)
 			    (char_u *)VAR_WIN, PV_FDE,
 			    {(char_u *)"0", (char_u *)NULL}
@@ -1073,7 +1073,7 @@ static struct vimoption options[] =
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCTX_INIT},
-    {"foldtext",    "fdt",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN|P_MLE,
+    {"foldtext",    "fdt",  P_STRING|P_EXPAND|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN|P_MLE,
 #if defined(FEAT_FOLDING) && defined(FEAT_EVAL)
 			    (char_u *)VAR_WIN, PV_FDT,
 			    {(char_u *)"foldtext()", (char_u *)NULL}
@@ -1082,7 +1082,7 @@ static struct vimoption options[] =
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCTX_INIT},
-    {"formatexpr", "fex",   P_STRING|P_ALLOCED|P_VI_DEF|P_VIM|P_MLE,
+    {"formatexpr", "fex",   P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_VIM|P_MLE,
 #ifdef FEAT_EVAL
 			    (char_u *)&p_fex, PV_FEX,
 			    {(char_u *)"", (char_u *)0L}
@@ -1302,7 +1302,7 @@ static struct vimoption options[] =
     {"ignorecase",  "ic",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_ic, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
-    {"imactivatefunc","imaf",P_STRING|P_VI_DEF|P_SECURE,
+    {"imactivatefunc","imaf",P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(FEAT_EVAL)
 			    (char_u *)&p_imaf, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
@@ -1337,7 +1337,7 @@ static struct vimoption options[] =
 			    (char_u *)&p_imsearch, PV_IMS,
 			    {(char_u *)B_IMODE_USE_INSERT, (char_u *)0L}
 			    SCTX_INIT},
-    {"imstatusfunc","imsf",P_STRING|P_VI_DEF|P_SECURE,
+    {"imstatusfunc","imsf",P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(FEAT_EVAL)
 			    (char_u *)&p_imsf, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
@@ -1364,7 +1364,7 @@ static struct vimoption options[] =
 			    {(char_u *)0L, (char_u *)0L}
 #endif
 			    SCTX_INIT},
-    {"includeexpr", "inex", P_STRING|P_ALLOCED|P_VI_DEF|P_MLE,
+    {"includeexpr", "inex", P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_MLE,
 #if defined(FEAT_FIND_ID) && defined(FEAT_EVAL)
 			    (char_u *)&p_inex, PV_INEX,
 			    {(char_u *)"", (char_u *)0L}
@@ -1376,7 +1376,7 @@ static struct vimoption options[] =
     {"incsearch",   "is",   P_BOOL|P_VI_DEF|P_VIM,
 			    (char_u *)&p_is, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
-    {"indentexpr", "inde",  P_STRING|P_ALLOCED|P_VI_DEF|P_VIM|P_MLE,
+    {"indentexpr", "inde",  P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_VIM|P_MLE,
 #if defined(FEAT_CINDENT) && defined(FEAT_EVAL)
 			    (char_u *)&p_inde, PV_INDE,
 			    {(char_u *)"", (char_u *)0L}
@@ -1803,7 +1803,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 #endif
 			    {(char_u *)8L, (char_u *)4L} SCTX_INIT},
-    {"omnifunc",    "ofu",  P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
+    {"omnifunc",    "ofu",  P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_SECURE,
 #ifdef FEAT_COMPL_FUNC
 			    (char_u *)&p_ofu, PV_OFU,
 			    {(char_u *)"", (char_u *)0L}
@@ -1823,7 +1823,7 @@ static struct vimoption options[] =
 #endif
 			    {(char_u *)FALSE, (char_u *)FALSE}
 			    SCTX_INIT},
-    {"operatorfunc", "opfunc", P_STRING|P_VI_DEF|P_SECURE,
+    {"operatorfunc", "opfunc", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 			    (char_u *)&p_opfunc, PV_NONE,
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"optimize",    "opt",  P_BOOL|P_VI_DEF,
@@ -1847,7 +1847,7 @@ static struct vimoption options[] =
     {"pastetoggle", "pt",   P_STRING|P_VI_DEF,
 			    (char_u *)&p_pt, PV_NONE,
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
-    {"patchexpr",   "pex",  P_STRING|P_VI_DEF|P_SECURE,
+    {"patchexpr",   "pex",  P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #if defined(FEAT_DIFF) && defined(FEAT_EVAL)
 			    (char_u *)&p_pex, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
@@ -1921,7 +1921,7 @@ static struct vimoption options[] =
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCTX_INIT},
-    {"printexpr", "pexpr",  P_STRING|P_VI_DEF|P_SECURE,
+    {"printexpr", "pexpr",  P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
 #ifdef FEAT_POSTSCRIPT
 			    (char_u *)&p_pexpr, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
@@ -2036,7 +2036,7 @@ static struct vimoption options[] =
 #endif
 			    {(char_u *)DEFAULT_PYTHON_VER, (char_u *)0L}
 			    SCTX_INIT},
-    {"quickfixtextfunc", "qftf", P_STRING|P_ALLOCED|P_VI_DEF|P_VIM|P_SECURE,
+    {"quickfixtextfunc", "qftf", P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_VIM|P_SECURE,
 #if defined(FEAT_QUICKFIX) && defined(FEAT_EVAL)
 			    (char_u *)&p_qftf, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
@@ -2488,7 +2488,7 @@ static struct vimoption options[] =
     {"tagcase",	    "tc",   P_STRING|P_VIM,
 			    (char_u *)&p_tc, PV_TC,
 			    {(char_u *)"followic", (char_u *)"followic"} SCTX_INIT},
-    {"tagfunc",    "tfu",   P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
+    {"tagfunc",    "tfu",   P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_SECURE,
 #ifdef FEAT_EVAL
 			    (char_u *)&p_tfu, PV_TFU,
 			    {(char_u *)"", (char_u *)0L}

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -338,6 +338,22 @@ func Test_set_completion()
   call assert_equal('"set filetype=sshdconfig', @:)
   call feedkeys(":set filetype=a\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set filetype=' .. getcompletion('a*', 'filetype')->join(), @:)
+
+  " Expand '*func' values.
+  let funcs = ['completefunc', 'imactivatefunc', 'imstatusfunc', 'omnifunc',
+			 \ 'operatorfunc', 'quickfixtextfunc', 'tagfunc']
+  for f in funcs
+    call feedkeys(printf(":set %s=Test_set_compl\<Tab>\<C-B>\"\<CR>", f), 'xt')
+    call assert_equal(printf('"set %s=Test_set_completion', f), @:)
+  endfor
+
+  " Expand '*expr' values.
+  let funcs = ['balloonexpr', 'charconvert', 'diffexpr', 'foldexpr', 'foldtext',
+			 \ 'formatexpr', 'includeexpr', 'indentexpr', 'patchexpr', 'printexpr']
+  for f in funcs
+    call feedkeys(printf(":set %s=Test_set_compl\<Tab>\<C-B>\"\<CR>", f), 'xt')
+    call assert_equal(printf('"set %s=Test_set_completion()', f), @:)
+  endfor
 endfunc
 
 func Test_set_errors()

--- a/src/vim.h
+++ b/src/vim.h
@@ -777,6 +777,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define EXPAND_MAPCLEAR		47
 #define EXPAND_ARGLIST		48
 #define EXPAND_DIFF_BUFFERS	49
+#define EXPAND_EXPRESSION_SET	50
 
 // Values for exmode_active (0 is no exmode)
 #define EXMODE_NORMAL		1


### PR DESCRIPTION
All options that take a function as their value:

	completefunc
	imactivatefunc
	imstatusfunc
	omnifunc
	operatorfunc
	quickfixtextfunc
	tagfunc

Now complete with with EXPAND_USER_FUNC, which excludes built-in
functions as this probably makes the most sense.

And all options that take an expression:

	balloonexpr
	charconvert
	diffexpr
	foldexpr
	foldtext
	formatexpr
	includeexpr
	indentexpr
	patchexpr
	printexpr

Complete with the new EXPAND_EXPRESSION_SET; this is mostly identical to
EXPAND_USER_FUNC except that it adds "()" at the end.

There is already EXPAND_EXPRESSION, but in my testing I didn't really
find that too useful since it can't deal with :set's syntax; neither of
these work for completing F2():

	:set balloonexpr=F1()\ ..\ F2()
	:set balloonexpr=F1()..F2()

It only completes the F2 when you add spaces:

	:set balloonexpr=F1() .. F2()

But that's not valid syntax for :set.

This could be expanded later on to deal with all of this, but IMO this
is already an improvement over not having any completion at all.