### PR TITLE
Fixed Test_setbufline_getbufline() and Test_set_get_bufline()

### DIFF
--- a/src/testdir/test_bufline.vim
+++ b/src/testdir/test_bufline.vim
@@ -40,11 +40,13 @@ func Test_setbufline_getbufline()
   call assert_equal([], getbufline(b, 6))
   call assert_equal([], getbufline(b, 2, 1))
 
-  call setbufline(b, 2, [function('eval'), #{key: 123}, test_null_job()])
-  call assert_equal(["function('eval')",
-                  \ "{'key': 123}",
-                  \ "no process"],
-                  \ getbufline(b, 2, 4))
+  if has('job')
+    call setbufline(b, 2, [function('eval'), #{key: 123}, test_null_job()])
+    call assert_equal(["function('eval')",
+                    \ "{'key': 123}",
+                    \ "no process"],
+                    \ getbufline(b, 2, 4))
+  endif
   exe "bwipe! " . b
 endfunc
 

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -824,11 +824,13 @@ def Test_set_get_bufline()
       assert_equal([], getbufline(b, 6))
       assert_equal([], getbufline(b, 2, 1))
 
-      setbufline(b, 2, [function('eval'), {key: 123}, test_null_job()])
-      assert_equal(["function('eval')",
-                      "{'key': 123}",
-                      "no process"],
-                      getbufline(b, 2, 4))
+      if has('job')
+        setbufline(b, 2, [function('eval'), {key: 123}, test_null_job()])
+        assert_equal(["function('eval')",
+                        "{'key': 123}",
+                        "no process"],
+                        getbufline(b, 2, 4))
+      endif
 
       exe 'bwipe! ' .. b
   END


### PR DESCRIPTION
This PR fixes tests `Test_setbufline_getbufline` and
`Test_set_get_bufline` which fail when the job feature
is not available. They fail because they call
`test_null_job()` which is not available without the
job feature.

Steps to reproduce:

```
$ ./configure --with-features=normal --enable-gui=none --disable-channel
$ make
$ make test
...snip...
Failures: 
	From test_bufline.vim:
	Found errors in Test_setbufline_getbufline():
	Caught exception in Test_setbufline_getbufline(): Vim(call):E117: Unknown function: test_null_job @ command line..script /home/pel/sb/vim/src/testdir/runtest.vim[468]..function RunTheTest[39]..Test_setbufline_getbufline, line 36
	From test_vim9_builtin.vim:
	Found errors in Test_set_get_bufline():
	Caught exception in Test_set_get_bufline(): Vim(defcompile):E117: Unknown function: test_null_job @ command line..script /home/pel/sb/vim/src/testdir/runtest.vim[468]..function RunTheTest[39]..Test_set_get_bufline[45]..CheckDefAndScriptSuccess[1]..CheckDefSuccess[6]..script /home/pel/sb/vim/src/testdir/XdefSuccess84[44]..function Func, line 35
	Found errors in Test_sort_argument():
	Caught exception in Test_sort_argument(): Vim(def):E122: Function Func already exists, add ! to replace it @ command line..script /home/pel/sb/vim/src/testdir/runtest.vim[468]..function RunTheTest[39]..Test_sort_argument[12]..CheckDefAndScriptSuccess[1]..CheckDefSuccess[6]..script /home/pel/sb/vim/src/testdir/XdefSuccess85, line 11
	Found errors in Test_str2nr():
	command line..script /home/pel/sb/vim/src/testdir/runtest.vim[468]..function RunTheTest[39]..Test_str2nr[3]..CheckDefFailure line 6: ['echo str2nr(123)']: Expected 'E1013:' but got 'E122: Function Func already exists, add ! to replace it': ['echo str2nr(123)']

TEST FAILURE
```