### PR TITLE
The wrap option in diff mode

### DIFF
--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -59,7 +59,7 @@ In each of the edited files these options are set:
 	'scrollbind'	on
 	'cursorbind'	on
 	'scrollopt'	includes "hor"
-	'wrap'		off
+	'wrap'		off or leave as it is if 'diffopt' includes "wrapasis"
 	'foldmethod'	"diff"
 	'foldcolumn'	value from 'diffopt', default is 2
 

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -59,7 +59,7 @@ In each of the edited files these options are set:
 	'scrollbind'	on
 	'cursorbind'	on
 	'scrollopt'	includes "hor"
-	'wrap'		off or leave as it is if 'diffopt' includes "wrapasis"
+	'wrap'		off, or leave as-is if 'diffopt' includes "followwrap"
 	'foldmethod'	"diff"
 	'foldcolumn'	value from 'diffopt', default is 2
 
@@ -144,7 +144,7 @@ Otherwise they are set to their default value:
 	'scrollbind'	off
 	'cursorbind'	off
 	'scrollopt'	without "hor"
-	'wrap'		on
+	'wrap'		on, or leave as-is if 'diffopt' includes "followwrap"
 	'foldmethod'	"manual"
 	'foldcolumn'	0
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2677,6 +2677,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		foldcolumn:{n}	Set the 'foldcolumn' option to {n} when
 				starting diff mode.  Without this 2 is used.
 
+		wrapasis	Leave the 'wrap' option as it is.
+
 		internal	Use the internal diff library.  This is
 				ignored when 'diffexpr' is set.  *E960*
 				When running out of memory when writing a

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2677,7 +2677,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		foldcolumn:{n}	Set the 'foldcolumn' option to {n} when
 				starting diff mode.  Without this 2 is used.
 
-		wrapasis	Leave the 'wrap' option as it is.
+		followwrap	Follow the 'wrap' option and leave as it is.
 
 		internal	Use the internal diff library.  This is
 				ignored when 'diffexpr' is set.  *E960*

--- a/src/diff.c
+++ b/src/diff.c
@@ -36,6 +36,7 @@ static int diff_need_update = FALSE; // ex_diffupdate needs to be called
 #define DIFF_HIDDEN_OFF	0x100	// diffoff when hidden
 #define DIFF_INTERNAL	0x200	// use internal xdiff algorithm
 #define DIFF_CLOSE_OFF	0x400	// diffoff when closing window
+#define DIFF_WRAPASIS	0x800	// leave wrap option as it is
 #define ALL_WHITE_DIFF (DIFF_IWHITE | DIFF_IWHITEALL | DIFF_IWHITEEOL)
 static int	diff_flags = DIFF_INTERNAL | DIFF_FILLER | DIFF_CLOSE_OFF;
 
@@ -1454,9 +1455,12 @@ diff_win_options(
     if (!wp->w_p_diff)
 	wp->w_p_crb_save = wp->w_p_crb;
     wp->w_p_crb = TRUE;
-    if (!wp->w_p_diff)
-	wp->w_p_wrap_save = wp->w_p_wrap;
-    wp->w_p_wrap = FALSE;
+    if (!(diff_flags & DIFF_WRAPASIS))
+    {
+        if (!wp->w_p_diff)
+	    wp->w_p_wrap_save = wp->w_p_wrap;
+        wp->w_p_wrap = FALSE;
+    }
 # ifdef FEAT_FOLDING
     if (!wp->w_p_diff)
     {
@@ -1517,8 +1521,11 @@ ex_diffoff(exarg_T *eap)
 		    wp->w_p_scb = wp->w_p_scb_save;
 		if (wp->w_p_crb)
 		    wp->w_p_crb = wp->w_p_crb_save;
-		if (!wp->w_p_wrap)
-		    wp->w_p_wrap = wp->w_p_wrap_save;
+		if (!(diff_flags & DIFF_WRAPASIS))
+		{
+		    if (!wp->w_p_wrap)
+		        wp->w_p_wrap = wp->w_p_wrap_save;
+		}
 #ifdef FEAT_FOLDING
 		free_string_option(wp->w_p_fdm);
 		wp->w_p_fdm = vim_strsave(
@@ -2244,6 +2251,11 @@ diffopt_changed(void)
 	{
 	    p += 8;
 	    diff_flags_new |= DIFF_CLOSE_OFF;
+	}
+	else if (STRNCMP(p, "wrapasis", 8) == 0)
+	{
+	    p += 8;
+	    diff_flags_new |= DIFF_WRAPASIS;
 	}
 	else if (STRNCMP(p, "indent-heuristic", 16) == 0)
 	{

--- a/src/diff.c
+++ b/src/diff.c
@@ -36,7 +36,7 @@ static int diff_need_update = FALSE; // ex_diffupdate needs to be called
 #define DIFF_HIDDEN_OFF	0x100	// diffoff when hidden
 #define DIFF_INTERNAL	0x200	// use internal xdiff algorithm
 #define DIFF_CLOSE_OFF	0x400	// diffoff when closing window
-#define DIFF_WRAPASIS	0x800	// leave wrap option as it is
+#define DIFF_FOLLOWWRAP	0x800	// follow the wrap option
 #define ALL_WHITE_DIFF (DIFF_IWHITE | DIFF_IWHITEALL | DIFF_IWHITEEOL)
 static int	diff_flags = DIFF_INTERNAL | DIFF_FILLER | DIFF_CLOSE_OFF;
 
@@ -1455,7 +1455,7 @@ diff_win_options(
     if (!wp->w_p_diff)
 	wp->w_p_crb_save = wp->w_p_crb;
     wp->w_p_crb = TRUE;
-    if (!(diff_flags & DIFF_WRAPASIS))
+    if (!(diff_flags & DIFF_FOLLOWWRAP))
     {
         if (!wp->w_p_diff)
 	    wp->w_p_wrap_save = wp->w_p_wrap;
@@ -1521,7 +1521,7 @@ ex_diffoff(exarg_T *eap)
 		    wp->w_p_scb = wp->w_p_scb_save;
 		if (wp->w_p_crb)
 		    wp->w_p_crb = wp->w_p_crb_save;
-		if (!(diff_flags & DIFF_WRAPASIS))
+		if (!(diff_flags & DIFF_FOLLOWWRAP))
 		{
 		    if (!wp->w_p_wrap)
 		        wp->w_p_wrap = wp->w_p_wrap_save;
@@ -2252,10 +2252,10 @@ diffopt_changed(void)
 	    p += 8;
 	    diff_flags_new |= DIFF_CLOSE_OFF;
 	}
-	else if (STRNCMP(p, "wrapasis", 8) == 0)
+	else if (STRNCMP(p, "followwrap", 10) == 0)
 	{
-	    p += 8;
-	    diff_flags_new |= DIFF_WRAPASIS;
+	    p += 10;
+	    diff_flags_new |= DIFF_FOLLOWWRAP;
 	}
 	else if (STRNCMP(p, "indent-heuristic", 16) == 0)
 	{

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -1045,9 +1045,9 @@ func Test_diff_closeoff()
   enew!
 endfunc
 
-func Test_diff_wrapasis()
+func Test_diff_followwrap()
   new
-  set diffopt+=wrapasis
+  set diffopt+=followwrap
   set wrap
   diffthis
   call assert_equal(1, &wrap)

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -1045,6 +1045,21 @@ func Test_diff_closeoff()
   enew!
 endfunc
 
+func Test_diff_wrapasis()
+  new
+  set diffopt+=wrapasis
+  set wrap
+  diffthis
+  call assert_equal(1, &wrap)
+  diffoff
+  set nowrap
+  diffthis
+  call assert_equal(0, &wrap)
+  diffoff
+  set diffopt&
+  bwipe!
+endfunc
+
 func Test_diff_maintains_change_mark()
   enew!
   call setline(1, ['a', 'b', 'c', 'd'])


### PR DESCRIPTION
This is a proposal for [#6639](https://github.com/vim/vim/issues/6639).

"wrapasis" is added in the 'diffopt' option. The default is still to set the wrap off but if it is present, the wrap will be left as it is.

If the wrap is on, the text can not be aligned properly. But no text will be hidden and all text is visible.

As of now, there is no choice and we need to set wrap option every time, that is a problem.

Please review and let me know if it is reasonable and appropriate.