### PR TITLE
Fix phpcomplete for patches 8.2.2426 and 8.2.2427

### DIFF
--- a/runtime/autoload/phpcomplete.vim
+++ b/runtime/autoload/phpcomplete.vim
@@ -180,7 +180,6 @@ function! phpcomplete#CompletePHP(findstart, base) " {{{
 				endif
 
 				if filereadable(classlocation)
-					let classfile = readfile(classlocation)
 					let classcontent = ''
 					let classcontent .= "\n".phpcomplete#GetClassContents(classlocation, classname)
 					let sccontent = split(classcontent, "\n")
@@ -2082,8 +2081,6 @@ function! phpcomplete#GetClassContentsStructure(file_path, file_lines, class_nam
 	let full_file_path = fnamemodify(a:file_path, ':p')
 	let result = []
 	let popup_id = popup_create(a:file_lines, {'hidden': v:true})
-    call win_execute(popup_id, 'syntax on')
-	call win_execute(popup_id, 'set ft=phpcompletetempbuffer')
 
 	call win_execute(popup_id, 'call search(''\c\(class\|interface\|trait\)\_s\+'.a:class_name.'\(\>\|$\)'')')
 	call win_execute(popup_id, "let cfline = line('.')")
@@ -2526,8 +2523,6 @@ endfunction
 
 function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 	let popup_id = popup_create(a:file_lines, {'hidden': v:true})
-	call win_execute(popup_id, 'syntax on')
-	call win_execute(popup_id, 'set ft=phpcompletetempbuffer')
 	call win_execute(popup_id, 'normal! G')
 
 	" clear out classes, functions and other blocks

--- a/runtime/autoload/phpcomplete.vim
+++ b/runtime/autoload/phpcomplete.vim
@@ -2533,14 +2533,16 @@ function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 		endif
 		call win_execute(popup_id, 'let block_end_pos = searchpairpos("{", "", ''}\|\%$'', "W", ''synIDattr(synID(line("."), col("."), 0), "name") =~? "string\\|comment"'')')
 
+		let popup_lines = winbufnr(popup_id)->getbufline(1, '$')
 		if block_end_pos != [0, 0]
 			" end of the block found, just delete it
-			call win_execute(popup_id, 'exec "'.block_start_pos[0].','.block_end_pos[0].'d _"')
+			call remove(popup_lines, block_start_pos[0] - 1, block_end_pos[0] - 1)
 		else
 			" block pair not found, use block start as beginning and the end
 			" of the buffer instead
-			call win_execute(popup_id, 'exec "'.block_start_pos[0].',$d _"')
+			call remove(popup_lines, block_start_pos[0] - 1, -1)
 		endif
+		call popup_settext(popup_id, popup_lines)
 	endwhile
 	call win_execute(popup_id, 'normal! G', 'silent!')
 

--- a/runtime/autoload/phpcomplete.vim
+++ b/runtime/autoload/phpcomplete.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Dávid Szabó ( complex857 AT gmail DOT com )
 " Previous Maintainer:	Mikolaj Machowski ( mikmach AT wp DOT pl )
 " URL: https://github.com/shawncplus/phpcomplete.vim
-" Last Change:  2018 Oct 10
+" Last Change:  2021 Feb 08
 "
 "	OPTIONS:
 "
@@ -122,7 +122,6 @@ function! phpcomplete#CompletePHP(findstart, base) " {{{
 		endif
 	endif
 
-
 	" If exists b:php_menu it means completion was already constructed we
 	" don't need to do anything more
 	if exists("b:php_menu")
@@ -148,8 +147,6 @@ function! phpcomplete#CompletePHP(findstart, base) " {{{
 	try
 		let eventignore = &eventignore
 		let &eventignore = 'all'
-		let winheight = winheight(0)
-		let winnr = winnr()
 
 		let [current_namespace, imports] = phpcomplete#GetCurrentNameSpace(getline(0, line('.')))
 
@@ -217,7 +214,6 @@ function! phpcomplete#CompletePHP(findstart, base) " {{{
 			return phpcomplete#CompleteGeneral(a:base, current_namespace, imports)
 		endif
 	finally
-		silent! exec winnr.'resize '.winheight
 		let &eventignore = eventignore
 	endtry
 endfunction
@@ -1025,7 +1021,7 @@ function! phpcomplete#CompleteUserClass(context, base, sccontent, visibility) " 
 				let c_var = '$'.c_var
 			endif
 			let c_variables[c_var] = ''
-			if g:phpcomplete_parse_docblock_comments && len(get(variables, var_index)) > 0
+			if g:phpcomplete_parse_docblock_comments && len(get(variables, var_index, '')) > 0
 				let c_doc[c_var] = phpcomplete#GetDocBlock(a:sccontent, variables[var_index])
 			endif
 			let var_index += 1
@@ -2082,26 +2078,19 @@ function! phpcomplete#GetClassContentsStructure(file_path, file_lines, class_nam
 	"	...
 	" ]
 	"
-	let full_file_path = fnamemodify(a:file_path, ':p')
 	let class_name_pattern = '[a-zA-Z_\x7f-\xff\\][a-zA-Z_0-9\x7f-\xff\\]*'
-	let cfile = join(a:file_lines, "\n")
+	let full_file_path = fnamemodify(a:file_path, ':p')
 	let result = []
-	" We use new buffer and (later) normal! because
-	" this is the most efficient way. The other way
-	" is to go through the looong string looking for
-	" matching {}
+	let popup_id = popup_create(a:file_lines, {'hidden': v:true})
+    call win_execute(popup_id, 'syntax on')
+	call win_execute(popup_id, 'set ft=phpcompletetempbuffer')
 
-	" remember the window we started at
-	let phpcomplete_original_window = winnr()
+	call win_execute(popup_id, 'call search(''\c\(class\|interface\|trait\)\_s\+'.a:class_name.'\(\>\|$\)'')')
+	call win_execute(popup_id, "let cfline = line('.')")
+	call win_execute(popup_id, "call search('{')")
+	call win_execute(popup_id, "let endline = line('.')")
 
-	silent! below 1new
-	silent! 0put =cfile
-	call search('\c\(class\|interface\|trait\)\_s\+'.a:class_name.'\(\>\|$\)')
-	let cfline = line('.')
-	call search('{')
-	let endline = line('.')
-
-	let content = join(getline(cfline, endline), "\n")
+	call win_execute(popup_id, 'let content = join(getline('.cfline.', '.endline.'), "\n")')
 	" Catch extends
 	if content =~? 'extends'
 		let extends_string = matchstr(content, '\(class\|interface\)\_s\+'.a:class_name.'\_.\+extends\_s\+\zs\('.class_name_pattern.'\(,\|\_s\)*\)\+\ze\(extends\|{\)')
@@ -2117,14 +2106,16 @@ function! phpcomplete#GetClassContentsStructure(file_path, file_lines, class_nam
 	else
 		let implemented_interfaces = []
 	endif
-	call searchpair('{', '', '}', 'W')
-	let class_closing_bracket_line = line('.')
+
+	call win_execute(popup_id, 'let [class_closing_bracket_line, class_closing_bracket_col] = searchpairpos("{", "", "}", "W")')
 
 	" Include class docblock
 	let doc_line = cfline - 1
-	if getline(doc_line) =~? '^\s*\*/'
+	call win_execute(popup_id, 'let l = getline('.doc_line.')')
+	if l =~? '^\s*\*/'
 		while doc_line != 0
-			if getline(doc_line) =~? '^\s*/\*\*'
+			call win_execute(popup_id, 'let l = getline('.doc_line.')')
+			if l =~? '^\s*/\*\*'
 				let cfline = doc_line
 				break
 			endif
@@ -2132,22 +2123,22 @@ function! phpcomplete#GetClassContentsStructure(file_path, file_lines, class_nam
 		endwhile
 	endif
 
-	let classcontent = join(getline(cfline, class_closing_bracket_line), "\n")
+	call win_execute(popup_id, 'let classcontent = join(getline('.cfline.', '.class_closing_bracket_line.'), "\n")')
 
 	let used_traits = []
 	" move back to the line next to the class's definition
-	call cursor(endline + 1, 1)
+	call win_execute(popup_id, 'call cursor('.(endline + 1).', 1)')
 	let keep_searching = 1
 	while keep_searching != 0
 		" try to grab "use..." keywords
-		let [lnum, col] = searchpos('\c^\s\+use\s\+'.class_name_pattern, 'cW', class_closing_bracket_line)
-		let syn_name = synIDattr(synID(lnum, col, 0), "name")
+		call win_execute(popup_id, 'let [lnum, col] = searchpos(''\c^\s\+use\s\+'.class_name_pattern.''', "cW", '.class_closing_bracket_line.')')
+		call win_execute(popup_id, 'let syn_name = synIDattr(synID('.lnum.', '.col.', 0), "name")')
 		if syn_name =~? 'string\|comment'
-			call cursor(lnum + 1, 1)
+			call win_execute(popup_id, 'call cursor('.(lnum + 1).', 1)')
 			continue
 		endif
 
-		let trait_line = getline(lnum)
+		call win_execute(popup_id, 'let trait_line = getline('.lnum.')')
 		if trait_line !~? ';'
 			" try to find the next line containing ';'
 			let l = lnum
@@ -2157,25 +2148,23 @@ function! phpcomplete#GetClassContentsStructure(file_path, file_lines, class_nam
 			while search_line !~? ';' && l > 0
 				" file lines are reversed so we need to go backwards
 				let l += 1
-				let search_line = getline(l)
+				call win_execute(popup_id, 'let search_line = getline('.l.')')
 				let trait_line .= ' '.substitute(search_line, '\(^\s\+\|\s\+$\)', '', 'g')
 			endwhile
 		endif
 		let use_expression = matchstr(trait_line, '^\s*use\s\+\zs.\{-}\ze;')
 		let use_parts = map(split(use_expression, '\s*,\s*'), 'substitute(v:val, "\\s+", " ", "g")')
 		let used_traits += map(use_parts, 'substitute(v:val, "\\s", "", "g")')
-		call cursor(lnum + 1, 1)
+		call win_execute(popup_id, 'call cursor('.(lnum + 1).', 1)')
 
 		if [lnum, col] == [0, 0]
 			let keep_searching = 0
 		endif
 	endwhile
 
-	silent! bw! %
+	call popup_close(popup_id)
 
 	let [current_namespace, imports] = phpcomplete#GetCurrentNameSpace(a:file_lines[0:cfline])
-	" go back to original window
-	exe phpcomplete_original_window.'wincmd w'
 	call add(result, {
 				\ 'class': a:class_name,
 				\ 'content': classcontent,
@@ -2532,40 +2521,37 @@ function! phpcomplete#FormatDocBlock(info) " {{{
 	endif
 
 	return res
-endfunction!
+endfunction
 " }}}
 
 function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
-	let original_window = winnr()
-
-	silent! below 1new
-	silent! 0put =a:file_lines
-	normal! G
+	let popup_id = popup_create(a:file_lines, {'hidden': v:true})
+	call win_execute(popup_id, 'syntax on')
+	call win_execute(popup_id, 'set ft=phpcompletetempbuffer')
+	call win_execute(popup_id, 'normal! G')
 
 	" clear out classes, functions and other blocks
 	while 1
-		let block_start_pos = searchpos('\c\(class\|trait\|function\|interface\)\s\+\_.\{-}\zs{', 'Web')
+		call win_execute(popup_id, 'let block_start_pos = searchpos(''\c\(class\|trait\|function\|interface\)\s\+\_.\{-}\zs{'', "Web")')
 		if block_start_pos == [0, 0]
 			break
 		endif
-		let block_end_pos = searchpairpos('{', '', '}\|\%$', 'W', 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string\\|comment"')
+		call win_execute(popup_id, 'let block_end_pos = searchpairpos("{", "", ''}\|\%$'', "W", ''synIDattr(synID(line("."), col("."), 0), "name") =~? "string\\|comment"'')')
 
 		if block_end_pos != [0, 0]
 			" end of the block found, just delete it
-			silent! exec block_start_pos[0].','.block_end_pos[0].'d _'
+			call win_execute(popup_id, 'exec "'.block_start_pos[0].','.block_end_pos[0].'d _"')
 		else
 			" block pair not found, use block start as beginning and the end
 			" of the buffer instead
-			silent! exec block_start_pos[0].',$d _'
+			call win_execute(popup_id, 'exec "'.block_start_pos[0].',$d _"')
 		endif
 	endwhile
-	normal! G
+	call win_execute(popup_id, 'normal! G', 'silent!')
 
 	" grab the remains
-	let file_lines = reverse(getline(1, line('.') - 1))
-
-	silent! bw! %
-	exe original_window.'wincmd w'
+	call win_execute(popup_id, "let file_lines = reverse(getline(1, line('.')-1))")
+	call popup_close(popup_id)
 
 	let namespace_name_pattern = '[a-zA-Z_\x7f-\xff\\][a-zA-Z_0-9\x7f-\xff\\]*'
 	let i = 0


### PR DESCRIPTION
Changing windows while inside a completion function is forbidden now.
Migrated to use popup windows instead of split windows.

Special thanks to @Roy-Orbison for reporting it and @lacygoill for the
popup window suggestion

Fixes #7783 