### PR TITLE
Fix unnecessary screen jumping

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -1128,7 +1128,7 @@ curs_columns(
 	if ((colnr_T)n >= curwin->w_height + curwin->w_skipcol / width)
 	    extra += 2;
 
-	if (extra == 3 || p_lines < so * 2)
+	if (extra == 3 || p_lines <= so * 2)
 	{
 	    // not enough room for 'scrolloff', put cursor in the middle
 	    n = curwin->w_virtcol / width;


### PR DESCRIPTION
```
Problem: When p_lines is equal to scrolloff * 2, cursor isn't centered
         in the screen. This results in lots of scrolling when moving the
         cursor horizontally. This is because vim doesn't realize that
         scrolloff * 2 isn't big enough to accomodate the line the
         cursor is on + the scrolloff lines.
Solution: Consider screen not large enough if p_lines is equal to
          scrolloff * 2.
Reproducer:
         - :set lines=3 columns=20
         - :set scrolloff=1
         - :call setline(1, repeat('a', 200))
         - :norm 5gj
         - Press `l` repeatedly
```

Note: this breaks `Test_breakindent19_sbr_nextpage`, however I do not understand the failure nor how to fix it. My testing makes me think that my patch is correct.

Related Neovim PR: https://github.com/neovim/neovim/pull/13909