### PR TITLE
Ci: Fix coveralls step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,8 @@ jobs:
           COVERALLS_PARALLEL: true
           TRAVIS_JOB_ID: ${{ github.run_id }}
         run: |
-          sudo apt-get install -y python3-setuptools python3-wheel rustc
-          pip3 install --user setuptools-rust
+          sudo apt-get install -y python3-setuptools python3-wheel
+          sudo -H pip3 install pip -U
           # needed for https support for coveralls building cffi only works with gcc, not with clang
           CC=gcc pip3 install --user cpp-coveralls pyopenssl ndg-httpsclient pyasn1
           ~/.local/bin/coveralls -b "${SRCDIR}" -x .xs -e "${SRCDIR}"/if_perl.c -e "${SRCDIR}"/xxd -e "${SRCDIR}"/libvterm --encodings utf-8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       CC: ${{ matrix.compiler }}


### PR DESCRIPTION
* Specify `ubuntu-18.04` to `runs-on` since `ubuntu-latest` will be `ubuntu-20.04` soon and build fails on ubuntu-20.04 
* Upgrade pip to fix the step of install pyopenssl

```
Collecting cryptography>=3.2 (from pyopenssl)
  Downloading https://files.pythonhosted.org/packages/27/5a/007acee0243186123a55423d49cbb5c15cb02d76dd1b6a27659a894b13a2/cryptography-3.4.4.tar.gz (545kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/runner/work/_temp/pip-build-gr51_ccd/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'

            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:

            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================


    ----------------------------------------
```