### PR TITLE
Port the support for EndOfBuffer (eob) item in 'fillchars' from NeoVim

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3231,7 +3231,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Only normal file name characters can be used, "/\*?[|<>" are illegal.
 
 						*'fillchars'* *'fcs'*
-'fillchars' 'fcs'	string	(default "vert:|,fold:-")
+'fillchars' 'fcs'	string	(default "vert:|,fold:-,eob:~")
 			global
 			{not available when compiled without the |+folding|
 			feature}
@@ -3244,6 +3244,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  vert:c	'|'		vertical separators |:vsplit|
 	  fold:c	'-'		filling 'foldtext'
 	  diff:c	'-'		deleted lines of the 'diff' option
+	  eob:c		'~'		empty lines at the end of a buffer
 
 	Any one that is omitted will fall back to the default.  For "stl" and
 	"stlnc" the space will be used when there is highlighting, '^' or '='
@@ -3263,6 +3264,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  vert:c	VertSplit		|hl-VertSplit|
 	  fold:c	Folded			|hl-Folded|
 	  diff:c	DiffDelete		|hl-DiffDelete|
+	  eob:c		EndOfBuffer		|hl-EndOfBuffer|
 
 		*'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
 'fixendofline' 'fixeol'	boolean	(default on)

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -774,8 +774,6 @@ Add something like 'fillchars' local to window, but allow for specifying a
 highlight name.  Esp. for the statusline.
 And "extends" and "precedes" are also useful without 'list' set.  Also in
 'fillchars' or another option?
-Related: #3820 - Support setting the character displayed below the last line?
-Neovim uses "eob:X" in 'fillchars'.
 
 Sourceforge Vim pages still have content, redirect from empty page.
 Check for PHP errors. (Wayne Davison, 2018 Oct 26)

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -138,10 +138,12 @@ status line is inverted anyway; you will only see this problem on terminals
 that have termcap codes for italics.
 
 							*filler-lines*
-The lines after the last buffer line in a window are called filler lines.
-These lines start with a tilde (~) character. By default, these are
-highlighted as NonText (|hl-NonText|). The EndOfBuffer highlight group
-(|hl-EndOfBuffer|) can be used to change the highlighting of filler lines.
+The lines after the last buffer line in a window are called filler lines.  By
+default, these lines start with a tilde (~) character. The 'eob' item in the
+'fillchars' option can be used to change this character. By default, these
+characters are highlighted as NonText (|hl-NonText|). The EndOfBuffer
+highlight group (|hl-EndOfBuffer|) can be used to change the highlighting of
+the filler characters.
 
 ==============================================================================
 3. Opening and closing a window				*opening-window* *E36*

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -2552,11 +2552,11 @@ win_update(win_T *wp)
 	    wp->w_botline = lnum;
 
 	// Make sure the rest of the screen is blank
-	// put '~'s on rows that aren't part of the file.
+	// write the 'fill_eob' character to rows that aren't part of the file
 	if (WIN_IS_POPUP(wp))
 	    win_draw_end(wp, ' ', ' ', FALSE, row, wp->w_height, HLF_AT);
 	else
-	    win_draw_end(wp, '~', ' ', FALSE, row, wp->w_height, HLF_EOB);
+	    win_draw_end(wp, fill_eob, ' ', FALSE, row, wp->w_height, HLF_EOB);
     }
 
 #ifdef SYN_TIME_LIMIT

--- a/src/globals.h
+++ b/src/globals.h
@@ -1363,6 +1363,7 @@ EXTERN int	fill_stlnc INIT(= ' ');
 EXTERN int	fill_vert INIT(= ' ');
 EXTERN int	fill_fold INIT(= '-');
 EXTERN int	fill_diff INIT(= '-');
+EXTERN int	fill_eob INIT(= '~');
 
 #ifdef FEAT_FOLDING
 EXTERN int	disable_fold_update INIT(= 0);

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -952,7 +952,7 @@ static struct vimoption options[] =
 			    SCTX_INIT},
     {"fillchars",   "fcs",  P_STRING|P_VI_DEF|P_RALL|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_fcs, PV_NONE,
-			    {(char_u *)"vert:|,fold:-", (char_u *)0L}
+			    {(char_u *)"vert:|,fold:-,eob:~", (char_u *)0L}
 			    SCTX_INIT},
     {"fixendofline",  "fixeol", P_BOOL|P_VI_DEF|P_RSTAT,
 			    (char_u *)&p_fixeol, PV_FIXEOL,

--- a/src/screen.c
+++ b/src/screen.c
@@ -4765,6 +4765,7 @@ set_chars_option(char_u **varp)
 	{&fill_vert,	"vert"},
 	{&fill_fold,	"fold"},
 	{&fill_diff,	"diff"},
+	{&fill_eob,	"eob"},
     };
     static struct charstab lcstab[] =
     {
@@ -4812,7 +4813,10 @@ set_chars_option(char_u **varp)
 		lcs_tab3 = NUL;
 	    }
 	    else
+	    {
 		fill_diff = '-';
+		fill_eob = '~';
+	    }
 	}
 	p = *varp;
 	while (*p)

--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -257,4 +257,26 @@ func Test_display_scroll_at_topline()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for 'eob' (EndOfBuffer) item in 'fillchars'
+func Test_eob_fillchars()
+  " default value
+  call assert_match('eob:\~', &fillchars)
+  " invalid values
+  call assert_fails(':set fillchars=eob:', 'E474:')
+  call assert_fails(':set fillchars=eob:xy', 'E474:')
+  call assert_fails(':set fillchars=eob:\255', 'E474:')
+  call assert_fails(':set fillchars=eob:<ff>', 'E474:')
+  " default is ~
+  new
+  call assert_equal('~', Screenline(2))
+  set fillchars=eob:+
+  redraw!
+  call assert_equal('+', Screenline(2))
+  set fillchars=eob:\ 
+  redraw!
+  call assert_equal(' ', nr2char(screenchar(2, 1)))
+  set fillchars&
+  close
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION

Port the support for changing the tilde (~) character displayed at the end of the buffer.
This will address #3820.
