### PR TITLE
Fixed failing test Test_compiling_error() when it ran with valgrind

### DIFF
--- a/src/testdir/term_util.vim
+++ b/src/testdir/term_util.vim
@@ -179,5 +179,9 @@ func Run_shell_in_terminal(options)
   return buf
 endfunc
 
+" Return concatenated lines in terminal.
+func Term_getlines(buf, lines)
+  return join(map(a:lines, 'term_getline(a:buf, v:val)'), '')
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -31,18 +31,8 @@ def TestCompilingError()
   call writefile(lines, 'XTest_compile_error')
   var buf = RunVimInTerminal('-S XTest_compile_error',
               {rows: 10, wait_for_ruler: 0})
-  var text = ''
-  for loop in range(100)
-    text = ''
-    for i in range(1, 9)
-      text ..= term_getline(buf, i)
-    endfor
-    if text =~ 'Variable not found: nothing'
-      break
-    endif
-    sleep 20m
-  endfor
-  assert_match('Error detected while compiling command line.*Fails.*Variable not found: nothing', text)
+  call WaitForAssert(() => assert_match('Error detected while compiling command line.*Fails.*Variable not found: nothing',
+                     Term_getlines(buf, range(1, 9))))
 
   # clean up
   call StopVimInTerminal(buf)

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -755,7 +755,7 @@ def Test_throw_vimscript()
 enddef
 
 def Test_error_in_nested_function()
-  # an error in a nested :function aborts executin in the calling :def function
+  # an error in a nested :function aborts executing in the calling :def function
   var lines =<< trim END
       vim9script
       def Func()


### PR DESCRIPTION
The test `Test_compiling_error()` always fails for me
when running with valgrind but passes without valgrind.
```
$ cd vim/src/Makefile
$ make test_vim9
...snip...
Executed 106 tests                       in  38.721105 seconds
1 FAILED:
Found errors in Test_compiling_error():
Run 1:
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[468]..function RunTheTest[39]..Test_compiling_error[4]..TestCompilingError line 22: Pattern 'Error detected while compiling command line.*Fails.*Variable not found: nothing' does not match ''
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[468]..function RunTheTest[39]..Test_compiling_error[4]..TestCompilingError[25]..StopVimInTerminal[14]..WaitForAssert[2]..<SNR>6_WaitForCommon[11]..<lambda>21 line 1: Expected 'finished' but got 'running'
Run 2:
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[502]..function RunTheTest[39]..Test_compiling_error[4]..TestCompilingError line 22: Pattern 'Error detected while compiling command line.*Fails.*Variable not found: nothing' does not match ''
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[502]..function RunTheTest[39]..Test_compiling_error[4]..TestCompilingError[25]..StopVimInTerminal[14]..WaitForAssert[2]..<SNR>6_WaitForCommon[11]..<lambda>22 line 1: Expected 'finished' but got 'running'
Run 3:
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[502]..function RunTheTest[39]..Test_compiling_error[4]..TestCompilingError line 22: Pattern 'Error detected while compiling command line.*Fails.*Variable not found: nothing' does not match ''
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[502]..function RunTheTest[39]..Test_compiling_error[4]..TestCompilingError[25]..StopVimInTerminal[14]..WaitForAssert[2]..<SNR>6_WaitForCommon[11]..<lambda>23 line 1: Expected 'finished' but got 'running'
Flaky test failed too often, giving up
```
It's a timing issue because increasing the duration of sleep
(from 20ms to 30ms) is enough to make it pass all the time. 
Actually 30ms is still not enough if I add valgrind options
`--num-callers=50 --track-origins=yes'  as it makes valgrind
slower (40ms is then enough to pass).

Anyway, it's better if the test does not rely on a sleep as
in proposed PR.