### PR TITLE
Heap buffer overflow in test_popupwin which was detected by asan in CI

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -248,6 +248,13 @@ trunc_string(
     int		i;
     int		n;
 
+    if (*s == NUL)
+    {
+	if (buflen > 0)
+	    *buf = NUL;
+	return;
+    }
+
     if (room_in < 3)
 	room = 0;
     half = room / 2;

--- a/src/message_test.c
+++ b/src/message_test.c
@@ -49,6 +49,15 @@ test_trunc_string(void)
     char_u  *buf; /*allocated every time to find uninit errors */
     char_u  *s;
 
+    // Should not write anything to destination if buflen is 0.
+    trunc_string((char_u*)"", NULL, 1, 0);
+
+    // Truncating an empty string does nothing.
+    buf = alloc(1);
+    trunc_string((char_u*)"", buf, 1, 1);
+    assert(buf[0] == NUL);
+    vim_free(buf);
+
     // in place
     buf = alloc(40);
     STRCPY(buf, "text");


### PR DESCRIPTION
Heap buffer overflow in test_popupwin which was detected by asan in CI.

```
==17156==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020003ff8ef at pc 0x000000935b59 bp 0x7fff03e95e80 sp 0x7fff03e95e78
READ of size 1 at 0x6020003ff8ef thread T0
    #0 0x935b58 in utf_head_off /home/runner/work/vim/vim/src/mbyte.c:3828:9
    #1 0x119d45b in trunc_string /home/runner/work/vim/vim/src/message.c:299:17
    #2 0xaffa01 in update_popups /home/runner/work/vim/vim/src/popupwin.c:3834:6
    #3 0x6411eb in update_screen /home/runner/work/vim/vim/src/drawscreen.c:333:5
    #4 0x782f7e in ex_redraw /home/runner/work/vim/vim/src/ex_docmd.c:7903:5
    #5 0x75fdc0 in do_one_cmd /home/runner/work/vim/vim/src/ex_docmd.c:2585:2
    #6 0x755f07 in do_cmdline /home/runner/work/vim/vim/src/ex_docmd.c:1000:17
    #7 0xe706e5 in call_user_func /home/runner/work/vim/vim/src/userfunc.c:1897:2
    #8 0xe6da8c in call_user_func_check /home/runner/work/vim/vim/src/userfunc.c:2038:2
    #9 0xe69b20 in call_func /home/runner/work/vim/vim/src/userfunc.c:2504:11
    #10 0xe68845 in get_func_tv /home/runner/work/vim/vim/src/userfunc.c:919:8
    #11 0xe8a402 in ex_call /home/runner/work/vim/vim/src/userfunc.c:4490:6
    #12 0x75fdc0 in do_one_cmd /home/runner/work/vim/vim/src/ex_docmd.c:2585:2
    #13 0x755f07 in do_cmdline /home/runner/work/vim/vim/src/ex_docmd.c:1000:17
    #14 0x6b3487 in ex_execute /home/runner/work/vim/vim/src/eval.c:6136:6
    #15 0x75fdc0 in do_one_cmd /home/runner/work/vim/vim/src/ex_docmd.c:2585:2
    #16 0x755f07 in do_cmdline /home/runner/work/vim/vim/src/ex_docmd.c:1000:17
    #17 0xe706e5 in call_user_func /home/runner/work/vim/vim/src/userfunc.c:1897:2
    #18 0xe6da8c in call_user_func_check /home/runner/work/vim/vim/src/userfunc.c:2038:2
    #19 0xe69b20 in call_func /home/runner/work/vim/vim/src/userfunc.c:2504:11
    #20 0xe68845 in get_func_tv /home/runner/work/vim/vim/src/userfunc.c:919:8
    #21 0xe8a402 in ex_call /home/runner/work/vim/vim/src/userfunc.c:4490:6
    #22 0x75fdc0 in do_one_cmd /home/runner/work/vim/vim/src/ex_docmd.c:2585:2
    #23 0x755f07 in do_cmdline /home/runner/work/vim/vim/src/ex_docmd.c:1000:17
    #24 0xc1eacc in do_source /home/runner/work/vim/vim/src/scriptfile.c:1404:5
    #25 0xc1c48e in cmd_source /home/runner/work/vim/vim/src/scriptfile.c:971:14
    #26 0xc1c1e3 in ex_source /home/runner/work/vim/vim/src/scriptfile.c:997:2
    #27 0x75fdc0 in do_one_cmd /home/runner/work/vim/vim/src/ex_docmd.c:2585:2
    #28 0x755f07 in do_cmdline /home/runner/work/vim/vim/src/ex_docmd.c:1000:17
    #29 0x759f11 in do_cmdline_cmd /home/runner/work/vim/vim/src/ex_docmd.c:592:12
    #30 0x118cac4 in exe_commands /home/runner/work/vim/vim/src/main.c:3059:2
    #31 0x118a702 in vim_main2 /home/runner/work/vim/vim/src/main.c:760:2
    #32 0x11847e0 in main /home/runner/work/vim/vim/src/main.c:412:12
    #0 0x7f84e1d22bf6 in __libc_start_main ??:?
    #1 0x467ec9 in _start ??:?

0x6020003ff8ef is located 1 bytes to the left of 1-byte region [0x6020003ff8f0,0x6020003ff8f1)
allocated by thread T0 here:
    #0 0x4e1f3d in __interceptor_malloc ??:?
    #1 0x9a0bc7 in lalloc /home/runner/work/vim/vim/src/misc2.c:925:11
    #2 0x9a0b9d in alloc /home/runner/work/vim/vim/src/misc2.c:828:12
    #3 0x9a1778 in vim_strsave /home/runner/work/vim/vim/src/misc2.c:1281:9
    #4 0xb0c1a3 in apply_general_options /home/runner/work/vim/vim/src/popupwin.c:676:22
    #5 0xaf42be in apply_options /home/runner/work/vim/vim/src/popupwin.c:947:5
    #6 0xaedfee in popup_create /home/runner/work/vim/vim/src/popupwin.c:2119:2
    #7 0xaec10a in f_popup_create /home/runner/work/vim/vim/src/popupwin.c:2161:5
    #8 0x6c538b in call_internal_func /home/runner/work/vim/vim/src/evalfunc.c:2065:5
    #9 0xe697b4 in call_func /home/runner/work/vim/vim/src/userfunc.c:2522:14
    #10 0xe68845 in get_func_tv /home/runner/work/vim/vim/src/userfunc.c:919:8
    #11 0xe8a402 in ex_call /home/runner/work/vim/vim/src/userfunc.c:4490:6
    #12 0x75fdc0 in do_one_cmd /home/runner/work/vim/vim/src/ex_docmd.c:2585:2
    #13 0x755f07 in do_cmdline /home/runner/work/vim/vim/src/ex_docmd.c:1000:17
    #14 0xe706e5 in call_user_func /home/runner/work/vim/vim/src/userfunc.c:1897:2
    #15 0xe6da8c in call_user_func_check /home/runner/work/vim/vim/src/userfunc.c:2038:2
    #16 0xe69b20 in call_func /home/runner/work/vim/vim/src/userfunc.c:2504:11
    #17 0xe68845 in get_func_tv /home/runner/work/vim/vim/src/userfunc.c:919:8
    #18 0xe8a402 in ex_call /home/runner/work/vim/vim/src/userfunc.c:4490:6
    #19 0x75fdc0 in do_one_cmd /home/runner/work/vim/vim/src/ex_docmd.c:2585:2
    #20 0x755f07 in do_cmdline /home/runner/work/vim/vim/src/ex_docmd.c:1000:17
    #21 0x6b3487 in ex_execute /home/runner/work/vim/vim/src/eval.c:6136:6
    #22 0x75fdc0 in do_one_cmd /home/runner/work/vim/vim/src/ex_docmd.c:2585:2
    #23 0x755f07 in do_cmdline /home/runner/work/vim/vim/src/ex_docmd.c:1000:17
    #24 0xe706e5 in call_user_func /home/runner/work/vim/vim/src/userfunc.c:1897:2
    #25 0xe6da8c in call_user_func_check /home/runner/work/vim/vim/src/userfunc.c:2038:2
    #26 0xe69b20 in call_func /home/runner/work/vim/vim/src/userfunc.c:2504:11
    #27 0xe68845 in get_func_tv /home/runner/work/vim/vim/src/userfunc.c:919:8
    #28 0xe8a402 in ex_call /home/runner/work/vim/vim/src/userfunc.c:4490:6
    #29 0x75fdc0 in do_one_cmd /home/runner/work/vim/vim/src/ex_docmd.c:2585:2

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/runner/work/vim/vim/src/mbyte.c:3828:9 in utf_head_off
Shadow bytes around the buggy address:
  0x0c0480077ec0: fa fa 01 fa fa fa 01 fa fa fa 03 fa fa fa 01 fa
  0x0c0480077ed0: fa fa 01 fa fa fa 01 fa fa fa 01 fa fa fa 01 fa
  0x0c0480077ee0: fa fa 01 fa fa fa 01 fa fa fa 02 fa fa fa 01 fa
  0x0c0480077ef0: fa fa 05 fa fa fa 00 02 fa fa 00 07 fa fa 00 00
  0x0c0480077f00: fa fa 04 fa fa fa 05 fa fa fa 00 01 fa fa 06 fa
=>0x0c0480077f10: fa fa 05 fa fa fa fd fa fa fa 03 fa fa[fa]01 fa
  0x0c0480077f20: fa fa 01 fa fa fa 00 01 fa fa fd fa fa fa fd fa
  0x0c0480077f30: fa fa 01 fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480077f40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480077f50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480077f60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==17156==ABORTING
```