### PR TITLE
Update Python keywords and builtins.

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2016 Oct 29
+" Last Change:	2021 Feb 15
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "
@@ -71,30 +71,17 @@ endif
 
 " Keep Python keywords in alphabetical order inside groups for easy
 " comparison with the table in the 'Python Language Reference'
-" https://docs.python.org/2/reference/lexical_analysis.html#keywords,
-" https://docs.python.org/3/reference/lexical_analysis.html#keywords.
+" https://docs.python.org/reference/lexical_analysis.html#keywords.
 " Groups are in the order presented in NAMING CONVENTIONS in syntax.txt.
 " Exceptions come last at the end of each group (class and def below).
 "
-" Keywords 'with' and 'as' are new in Python 2.6
-" (use 'from __future__ import with_statement' in Python 2.5).
+" The list can be checked using:
 "
-" Some compromises had to be made to support both Python 3 and 2.
-" We include Python 3 features, but when a definition is duplicated,
-" the last definition takes precedence.
-"
-" - 'False', 'None', and 'True' are keywords in Python 3 but they are
-"   built-ins in 2 and will be highlighted as built-ins below.
-" - 'exec' is a built-in in Python 3 and will be highlighted as
-"   built-in below.
-" - 'nonlocal' is a keyword in Python 3 and will be highlighted.
-" - 'print' is a built-in in Python 3 and will be highlighted as
-"   built-in below (use 'from __future__ import print_function' in 2)
-" - async and await were added in Python 3.5 and are soft keywords.
+" python3 -c 'import keyword, pprint; pprint.pprint(keyword.kwlist, compact=True)'
 "
 syn keyword pythonStatement	False None True
-syn keyword pythonStatement	as assert break continue del exec global
-syn keyword pythonStatement	lambda nonlocal pass print return with yield
+syn keyword pythonStatement	as assert break continue del global
+syn keyword pythonStatement	lambda nonlocal pass return with yield
 syn keyword pythonStatement	class def nextgroup=pythonFunction skipwhite
 syn keyword pythonConditional	elif else if
 syn keyword pythonRepeat	for while
@@ -103,7 +90,7 @@ syn keyword pythonException	except finally raise try
 syn keyword pythonInclude	from import
 syn keyword pythonAsync		async await
 
-" Decorators (new in Python 2.4)
+" Decorators
 " A dot must be allowed because of @MyClass.myfunc decorators.
 syn match   pythonDecorator	"@" display contained
 syn match   pythonDecoratorName	"@\s*\h\%(\w\|\.\)*" display contains=pythonDecorator
@@ -168,8 +155,7 @@ syn match   pythonEscape	"\\$"
 " - 08e0 or 08j are highlighted,
 "
 " and so on, as specified in the 'Python Language Reference'.
-" https://docs.python.org/2/reference/lexical_analysis.html#numeric-literals
-" https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
+" https://docs.python.org/reference/lexical_analysis.html#numeric-literals
 if !exists("python_no_number_highlight")
   " numbers (including longs and complex)
   syn match   pythonNumber	"\<0[oO]\=\o\+[Ll]\=\>"
@@ -186,37 +172,37 @@ endif
 
 " Group the built-ins in the order in the 'Python Library Reference' for
 " easier comparison.
-" https://docs.python.org/2/library/constants.html
-" https://docs.python.org/3/library/constants.html
-" http://docs.python.org/2/library/functions.html
-" http://docs.python.org/3/library/functions.html
-" http://docs.python.org/2/library/functions.html#non-essential-built-in-functions
-" http://docs.python.org/3/library/functions.html#non-essential-built-in-functions
+" https://docs.python.org/library/constants.html
+" http://docs.python.org/library/functions.html
 " Python built-in functions are in alphabetical order.
+"
+" The list can be checked using:
+"
+" python3 -c 'import builtins, pprint; pprint.pprint(dir(builtins), compact=True)'
+"
+" The constants added by the `site` module are not listed below because they
+" should not be used in programs, only in interactive interpreter.
+" Similarly for some other attributes and functions `__`-enclosed from the
+" output of the above command.
+"
 if !exists("python_no_builtin_highlight")
   " built-in constants
   " 'False', 'True', and 'None' are also reserved words in Python 3
   syn keyword pythonBuiltin	False True None
   syn keyword pythonBuiltin	NotImplemented Ellipsis __debug__
+  " constants added by the `site` module
+  syn keyword pythonBuiltin	quit exit copyright credits license
   " built-in functions
-  syn keyword pythonBuiltin	abs all any bin bool bytearray callable chr
-  syn keyword pythonBuiltin	classmethod compile complex delattr dict dir
-  syn keyword pythonBuiltin	divmod enumerate eval filter float format
-  syn keyword pythonBuiltin	frozenset getattr globals hasattr hash
-  syn keyword pythonBuiltin	help hex id input int isinstance
+  syn keyword pythonBuiltin	abs all any ascii bin bool breakpoint bytearray
+  syn keyword pythonBuiltin	bytes callable chr classmethod compile complex
+  syn keyword pythonBuiltin	delattr dict dir divmod enumerate eval exec
+  syn keyword pythonBuiltin	filter float format frozenset getattr globals
+  syn keyword pythonBuiltin	hasattr hash help hex id input int isinstance
   syn keyword pythonBuiltin	issubclass iter len list locals map max
   syn keyword pythonBuiltin	memoryview min next object oct open ord pow
   syn keyword pythonBuiltin	print property range repr reversed round set
-  syn keyword pythonBuiltin	setattr slice sorted staticmethod str
-  syn keyword pythonBuiltin	sum super tuple type vars zip __import__
-  " Python 2 only
-  syn keyword pythonBuiltin	basestring cmp execfile file
-  syn keyword pythonBuiltin	long raw_input reduce reload unichr
-  syn keyword pythonBuiltin	unicode xrange
-  " Python 3 only
-  syn keyword pythonBuiltin	ascii bytes exec
-  " non-essential built-in functions; Python 2 only
-  syn keyword pythonBuiltin	apply buffer coerce intern
+  syn keyword pythonBuiltin	setattr slice sorted staticmethod str sum super
+  syn keyword pythonBuiltin	tuple type vars zip __import__
   " avoid highlighting attributes as builtins
   syn match   pythonAttribute	/\.\h\w*/hs=s+1
 	\ contains=ALLBUT,pythonBuiltin,pythonFunction,pythonAsync
@@ -224,28 +210,27 @@ if !exists("python_no_builtin_highlight")
 endif
 
 " From the 'Python Library Reference' class hierarchy at the bottom.
-" http://docs.python.org/2/library/exceptions.html
-" http://docs.python.org/3/library/exceptions.html
+" http://docs.python.org/library/exceptions.html
 if !exists("python_no_exception_highlight")
   " builtin base exceptions (used mostly as base classes for other exceptions)
   syn keyword pythonExceptions	BaseException Exception
-  syn keyword pythonExceptions	ArithmeticError BufferError
-  syn keyword pythonExceptions	LookupError
-  " builtin base exceptions removed in Python 3
-  syn keyword pythonExceptions	EnvironmentError StandardError
+  syn keyword pythonExceptions	ArithmeticError BufferError LookupError
   " builtin exceptions (actually raised)
-  syn keyword pythonExceptions	AssertionError AttributeError
-  syn keyword pythonExceptions	EOFError FloatingPointError GeneratorExit
-  syn keyword pythonExceptions	ImportError IndentationError
-  syn keyword pythonExceptions	IndexError KeyError KeyboardInterrupt
-  syn keyword pythonExceptions	MemoryError NameError NotImplementedError
-  syn keyword pythonExceptions	OSError OverflowError ReferenceError
-  syn keyword pythonExceptions	RuntimeError StopIteration SyntaxError
+  syn keyword pythonExceptions	AssertionError AttributeError EOFError
+  syn keyword pythonExceptions	FloatingPointError GeneratorExit ImportError
+  syn keyword pythonExceptions	IndentationError IndexError KeyError
+  syn keyword pythonExceptions	KeyboardInterrupt MemoryError
+  syn keyword pythonExceptions	ModuleNotFoundError NameError
+  syn keyword pythonExceptions	NotImplementedError OSError OverflowError
+  syn keyword pythonExceptions	RecursionError ReferenceError RuntimeError
+  syn keyword pythonExceptions	StopAsyncIteration StopIteration SyntaxError
   syn keyword pythonExceptions	SystemError SystemExit TabError TypeError
-  syn keyword pythonExceptions	UnboundLocalError UnicodeError
-  syn keyword pythonExceptions	UnicodeDecodeError UnicodeEncodeError
+  syn keyword pythonExceptions	UnboundLocalError UnicodeDecodeError
+  syn keyword pythonExceptions	UnicodeEncodeError UnicodeError
   syn keyword pythonExceptions	UnicodeTranslateError ValueError
   syn keyword pythonExceptions	ZeroDivisionError
+  " builtin exception aliases for OSError
+  syn keyword pythonExceptions	EnvironmentError IOError WindowsError
   " builtin OS exceptions in Python 3
   syn keyword pythonExceptions	BlockingIOError BrokenPipeError
   syn keyword pythonExceptions	ChildProcessError ConnectionAbortedError
@@ -253,18 +238,13 @@ if !exists("python_no_exception_highlight")
   syn keyword pythonExceptions	ConnectionResetError FileExistsError
   syn keyword pythonExceptions	FileNotFoundError InterruptedError
   syn keyword pythonExceptions	IsADirectoryError NotADirectoryError
-  syn keyword pythonExceptions	PermissionError ProcessLookupError
-  syn keyword pythonExceptions	RecursionError StopAsyncIteration
-  syn keyword pythonExceptions	TimeoutError
-  " builtin exceptions deprecated/removed in Python 3
-  syn keyword pythonExceptions	IOError VMSError WindowsError
+  syn keyword pythonExceptions	PermissionError ProcessLookupError TimeoutError
   " builtin warnings
   syn keyword pythonExceptions	BytesWarning DeprecationWarning FutureWarning
   syn keyword pythonExceptions	ImportWarning PendingDeprecationWarning
-  syn keyword pythonExceptions	RuntimeWarning SyntaxWarning UnicodeWarning
+  syn keyword pythonExceptions	ResourceWarning RuntimeWarning
+  syn keyword pythonExceptions	SyntaxWarning UnicodeWarning
   syn keyword pythonExceptions	UserWarning Warning
-  " builtin warnings in Python 3
-  syn keyword pythonExceptions	ResourceWarning
 endif
 
 if exists("python_space_error_highlight")


### PR DESCRIPTION
This change updates Python keywords and builtins to match Python 3.9.
All references and support for Python 2 specific keywords/builtins have
been removed.

Other updates to the syntax file are coming up in separate changes.