### PR TITLE
Keywords 'of' and 'yield' for Javascript.

### DIFF
--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -44,7 +44,7 @@ syn match   javaScriptNumber	       "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
 syn region  javaScriptRegexpString     start=+[,(=+]\s*/[^/*]+ms=e-1,me=e-1 skip=+\\\\\|\\/+ end=+/[gimuys]\{0,2\}\s*$+ end=+/[gimuys]\{0,2\}\s*[+;.,)\]}]+me=e-1 end=+/[gimuys]\{0,2\}\s\+\/+me=e-1 contains=@htmlPreproc,javaScriptComment oneline
 
 syn keyword javaScriptConditional	if else switch
-syn keyword javaScriptRepeat		while for do in
+syn keyword javaScriptRepeat		while for do in of
 syn keyword javaScriptBranch		break continue
 syn keyword javaScriptOperator		new delete instanceof typeof
 syn keyword javaScriptType		Array Boolean Date Function Number Object String RegExp

--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -48,7 +48,7 @@ syn keyword javaScriptRepeat		while for do in of
 syn keyword javaScriptBranch		break continue
 syn keyword javaScriptOperator		new delete instanceof typeof
 syn keyword javaScriptType		Array Boolean Date Function Number Object String RegExp
-syn keyword javaScriptStatement		return with await
+syn keyword javaScriptStatement		return with await yield
 syn keyword javaScriptBoolean		true false
 syn keyword javaScriptNull		null undefined
 syn keyword javaScriptIdentifier	arguments this var let


### PR DESCRIPTION
New Javascript language keywords '`of`' (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of) and '`yield`' (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield) are added to syntax file `runtime/syntax/javascript.vim`.