### PR TITLE
Missing test coverage with latin1, mapset(), errors in term_*functions

### DIFF
--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -680,23 +680,26 @@ endfunc
 
 func Test_edit_CTRL_N()
   " Check keyword completion
-  new
-  set complete=.
-  call setline(1, ['INFER', 'loWER', '', '', ])
-  call cursor(3, 1)
-  call feedkeys("Ai\<c-n>\<cr>\<esc>", "tnix")
-  call feedkeys("ILO\<c-n>\<cr>\<esc>", 'tnix')
-  call assert_equal(['INFER', 'loWER', 'i', 'LO', '', ''], getline(1, '$'))
-  %d
-  call setline(1, ['INFER', 'loWER', '', '', ])
-  call cursor(3, 1)
-  set ignorecase infercase
-  call feedkeys("Ii\<c-n>\<cr>\<esc>", "tnix")
-  call feedkeys("ILO\<c-n>\<cr>\<esc>", 'tnix')
-  call assert_equal(['INFER', 'loWER', 'infer', 'LOWER', '', ''], getline(1, '$'))
+  for e in ['latin1', 'utf-8']
+    exe 'set encoding=' .. e
+    new
+    set complete=.
+    call setline(1, ['INFER', 'loWER', '', '', ])
+    call cursor(3, 1)
+    call feedkeys("Ai\<c-n>\<cr>\<esc>", "tnix")
+    call feedkeys("ILO\<c-n>\<cr>\<esc>", 'tnix')
+    call assert_equal(['INFER', 'loWER', 'i', 'LO', '', ''], getline(1, '$'), e)
+    %d
+    call setline(1, ['INFER', 'loWER', '', '', ])
+    call cursor(3, 1)
+    set ignorecase infercase
+    call feedkeys("Ii\<c-n>\<cr>\<esc>", "tnix")
+    call feedkeys("ILO\<c-n>\<cr>\<esc>", 'tnix')
+    call assert_equal(['INFER', 'loWER', 'infer', 'LOWER', '', ''], getline(1, '$'), e)
 
-  set noignorecase noinfercase complete&
-  bw!
+    set noignorecase noinfercase complete&
+    bw!
+  endfor
 endfunc
 
 func Test_edit_CTRL_O()

--- a/src/testdir/test_maparg.vim
+++ b/src/testdir/test_maparg.vim
@@ -240,6 +240,8 @@ func Test_mapset()
   bwipe!
 
   call assert_fails('call mapset([], v:false, {})', 'E730:')
+  call assert_fails('call mapset("i", 0, "")', 'E716:')
+  call assert_fails('call mapset("i", 0, {})', 'E460:')
 endfunc
 
 func Check_ctrlb_map(d, check_alt)

--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -301,6 +301,11 @@ func Test_term_func_invalid_arg()
     call assert_fails('let p = term_getansicolors([])', 'E745:')
     call assert_fails('call term_setansicolors([], [])', 'E745:')
   endif
+  let buf = term_start('echo')
+  call assert_fails('call term_setapi(' .. buf .. ', {})', 'E731:')
+  call assert_fails('call term_setkill(' .. buf .. ', {})', 'E731:')
+  call assert_fails('call term_setrestore(' .. buf .. ', {})', 'E731:')
+  exe buf . "bwipe!"
 endfunc
 
 " Test for sending various special keycodes to a terminal


### PR DESCRIPTION
This PR improve test coverage in various areas: latin1, mapset(), errors in term_*functions