### PR TITLE
Improve accuracy of the normal % command when buffer has many lines

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -4769,9 +4769,11 @@ nv_percent(cmdarg_T *cap)
 	{
 	    cap->oap->motion_type = MLINE;
 	    setpcmark();
-	    // Round up, so CTRL-G will give same value.  Watch out for a
-	    // large line count, the line number must not go negative!
-	    if (curbuf->b_ml.ml_line_count > 1000000)
+	    // Round up, so 'normal 100%' always jumps at the line line.
+	    // Beyond 21474836 lines, (ml_line_count * 100 + 99) would
+	    // overflow on 32-bits, so use a formula with less accuracy
+	    // to avoid overflows.
+	    if (curbuf->b_ml.ml_line_count >= 21474836)
 		curwin->w_cursor.lnum = (curbuf->b_ml.ml_line_count + 99L)
 							 / 100L * cap->count0;
 	    else


### PR DESCRIPTION
The normal `{count}%` command uses the following formula to
jump to a percentage of lines with rounding up (so 100% jumps
to the last line):
```
  ({count} * number-of-lines + 99) / 100
```

The above formula can cause 32-bits overflows for large number
of lines, so vim uses another formula, with degraded accuracy,
when the buffer has > 1,000,000 lines:
```
(number-of-lines + 99) / 100 * {count}
```

As a result, the following command jumps to line 500050 instead
of the more accurate rounded up line 500001:
```
$ vim --clean -c'call setline(1,range(1,1000001))' -c'normal 50%'
```
Yet 1,000,001 lines would not cause a 32-bits. Overflow would
happen starting with the much larger 21,474,836 lines threshold.
So this PR changes `nv_percent()` to use a larger threshold beyond
which to use the formula with degraded accuracy.

After this change, the above command jumps to line 500001
as expected rather than 500050.

I did not add a test with 21,474,836 lines because it would
consume too much memory and would be slow.