### PR TITLE
os_unix.c: Use sysconf() to get SIGSTKSZ if available

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -496,3 +496,6 @@
 
 /* Define to inline symbol or empty */
 #undef inline
+
+/* Define if _SC_SIGSTKSZ is available via sysconf() */
+#undef HAVE_SYSCONF_SIGSTKSZ

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4105,6 +4105,15 @@ AC_TRY_COMPILE(
 	AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYSCONF),
 	AC_MSG_RESULT(not usable))
 
+dnl check if we have _SC_SIGSTKSZ via sysconf()
+AC_MSG_CHECKING(for _SC_SIGSTKSZ via sysconf())
+AC_TRY_COMPILE(
+[#include <unistd.h>],
+[	(void)sysconf(_SC_SIGSTKSZ);
+	],
+	AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYSCONF_SIGSTKSZ),
+	AC_MSG_RESULT(not usable))
+
 AC_CHECK_SIZEOF([int])
 AC_CHECK_SIZEOF([long])
 AC_CHECK_SIZEOF([time_t])


### PR DESCRIPTION
Hi all!

The newest glibc - 2.34 - sets SIGSTKSZ constant to -1 when _GNU_SOURCE
or _SC_SIGSTKSZ_SOURCE are defined. This change causes Vim to segfault,
because it now treats the negative -1 as a positive number, which is the
highest number available.

The signal stack size is now available via 'sysconf(_SC_SIGSTKSZ)',
which is used in the commit, but we need to extra check if this way is
available in configure phase. The local SIGSTKSZ #define will be used
only if SIGSTKSZ isn't already defined and if it is not available
through 'sysconf()' at the same time.

Would you mind adding it to the project? Please let me know if I should change something.