### PR TITLE
Highlight line continuation comments in dictionary literals and inside parentheses

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Vim 8.0 script
 " Maintainer:	Charles E. Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
-" Last Change:	December 14, 2020
+" Last Change:	February 28, 2021
 " Version:	8.0-47
 " URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_VIM
 " Automatically generated keyword lists: {{{1
@@ -227,7 +227,7 @@ syn keyword vimAugroupKey contained	aug[roup]
 
 " Operators: {{{2
 " =========
-syn cluster	vimOperGroup	contains=vimEnvvar,vimFunc,vimFuncVar,vimOper,vimOperParen,vimNumber,vimString,vimRegister,vimContinue,vim9Comment
+syn cluster	vimOperGroup	contains=vimEnvvar,vimFunc,vimFuncVar,vimOper,vimOperParen,vimNumber,vimString,vimRegister,vimContinue,vimLineContinuationComment,vim9Comment
 syn match	vimOper	"\%#=1\(==\|!=\|>=\|<=\|=\~\|!\~\|>\|<\|=\)[?#]\{0,2}"	skipwhite nextgroup=vimString,vimSpecFile
 syn match	vimOper	"\(\<is\|\<isnot\)[?#]\{0,2}\>"			skipwhite nextgroup=vimString,vimSpecFile
 syn match	vimOper	"||\|&&\|[-+.!]"				skipwhite nextgroup=vimString,vimSpecFile
@@ -641,6 +641,7 @@ syn match	vimCtrlChar	"[--]"
 " Beginners - Patterns that involve ^ {{{2
 " =========
 syn match	vimLineComment	+^[ \t:]*".*$+	contains=@vimCommentGroup,vimCommentString,vimCommentTitle
+syn match	vimLineContinuationComment	+^[ \t:]*"\\ .*$+	contained contains=@vimCommentGroup,vimCommentString,vimCommentTitle
 syn match	vim9LineComment	+^[ \t:]\+#.*$+	contains=@vimCommentGroup,vimCommentString,vimCommentTitle
 syn match	vimCommentTitle	'"\s*\%([sS]:\|\h\w*#\)\=\u\w*\(\s\+\u\w*\)*:'hs=s+1	contained contains=vimCommentTitleLeader,vimTodo,@vimCommentGroup
 syn match	vimContinue	"^\s*\\"
@@ -928,6 +929,7 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimLetHereDocStop	Special
  hi def link vimLineComment	vimComment
  hi def link vim9LineComment	vimComment
+ hi def link vimLineContinuationComment	vimComment
  hi def link vimMapBang	vimCommand
  hi def link vimMapModKey	vimFuncSID
  hi def link vimMapMod	vimBracket


### PR DESCRIPTION
This fixes a bug in the highlighting script where line continuation comments were not highlighted inside of the `vimOperParen` region.  This is done by adding a new highlighting group named `vimLineContinuationComment` to highlight line continuation comments in the `vimOperParen` region.

The following pictures demonstrate the change of behavior of the highlighting script:

## Before this pull request
<img width="696" alt="before" src="https://user-images.githubusercontent.com/28897513/109434999-53e12580-7a18-11eb-9973-f58c59ee63ff.png">

## After this pull request
<img width="696" alt="after" src="https://user-images.githubusercontent.com/28897513/109435320-39a84700-7a1a-11eb-89b3-7eb2336d63d8.png">

*edit*: updated "after" image