### PR TITLE
Support multibyte character for stl and stlnc items in fillchars

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3262,7 +3262,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	This is similar to the default, except that these characters will also
 	be used when there is highlighting.
 
-	for "stl" and "stlnc" only single-byte values are supported.
+	For "stl" and "stlnc" single-byte and multibyte characters are
+	supported.  But double-width characters are not supported.
 
 	The highlighting used for these items:
 	  item		highlight group ~

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1156,9 +1156,6 @@ timer expires.
 Rule to use "^" for statusline does not work if a space is defined with
 highlighting for both stl and stlnc.  Patch by Ken Hamada (itchyny, 2016 Dec 11)
 
-8   "stl" and "stlnc" in 'fillchars' don't work for multibyte characters.
-    Patch by Christian Wellenbrock, 2013 Jul 5.
-
 Using CTRL-G_U in InsertCharPre causes trouble for redo. (Israel Chauca
 Fuentes, 2017 Feb 12, #1470)
 

--- a/src/macros.h
+++ b/src/macros.h
@@ -252,6 +252,7 @@
 #define MB_CHARLEN(p)	    (has_mbyte ? mb_charlen(p) : (int)STRLEN(p))
 #define MB_CHAR2LEN(c)	    (has_mbyte ? mb_char2len(c) : 1)
 #define PTR2CHAR(p)	    (has_mbyte ? mb_ptr2char(p) : (int)*(p))
+#define MB_CHAR2BYTES(c, b) do { if (has_mbyte) b += (*mb_char2bytes)(c, b); else *b++ = c; } while(0)
 
 #ifdef FEAT_AUTOCHDIR
 # define DO_AUTOCHDIR do { if (p_acd) do_autochdir(); } while (0)

--- a/src/screen.c
+++ b/src/screen.c
@@ -266,7 +266,7 @@ fill_foldcolumn(
     empty = (fdc == 1) ? 0 : 1;
 
     // If the column is too narrow, we start at the lowest level that
-    // fits and use numbers to indicated the depth.
+    // fits and use numbers to indicate the depth.
     first_level = level - fdc - closed + 1 + empty;
     if (first_level < 1)
 	first_level = 1;

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -987,7 +987,66 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
         \ a:fs .. 'six   ',
         \ ], ScreenLines([1, 6], 7))
 
-  setlocal foldcolumn&
+  " Enable number and sign columns and place some signs
+  setlocal fdc=3
+  setlocal number
+  setlocal signcolumn=auto
+  sign define S1 text=->
+  sign place 10 line=3 name=S1
+  call assert_equal([
+        \ a:fo .. '      1 one  ',
+        \ a:fs .. a:fo .. '     2 two  ',
+        \ '2' .. a:fo .. ' ->  3 three',
+        \ '23     4 four ',
+        \ a:fs .. a:fs .. '     5 five ',
+        \ a:fs .. '      6 six  '
+        \ ], ScreenLines([1, 6], 14))
+
+  " Test with 'rightleft'
+  if has('rightleft')
+    setlocal rightleft
+    let lines = ScreenLines([1, 6], winwidth(0))
+    call assert_equal('o 1      ' .. a:fo,
+          \  strcharpart(lines[0], strchars(lines[0]) - 10, 10))
+    call assert_equal('t 2     ' .. a:fo .. a:fs,
+          \  strcharpart(lines[1], strchars(lines[1]) - 10, 10))
+    call assert_equal('t 3  >- ' .. a:fo .. '2',
+          \  strcharpart(lines[2], strchars(lines[2]) - 10, 10))
+    call assert_equal('f 4     32',
+          \  strcharpart(lines[3], strchars(lines[3]) - 10, 10))
+    call assert_equal('f 5     ' .. a:fs .. a:fs,
+          \  strcharpart(lines[4], strchars(lines[4]) - 10, 10))
+    call assert_equal('s 6      ' .. a:fs,
+          \  strcharpart(lines[5], strchars(lines[5]) - 10, 10))
+    setlocal norightleft
+  endif
+
+  sign unplace *
+  sign undefine S1
+  setlocal number& signcolumn&
+
+  " Add a test with more than 9 folds (and then delete some folds)
+  normal zE
+  for i in range(1, 10)
+    normal zfGzo
+  endfor
+  normal zR
+  call assert_equal([
+        \ a:fo .. a:fo .. ' one ',
+        \ '9> two '
+        \ ], ScreenLines([1, 2], 7))
+  normal 1Gzd
+  call assert_equal([
+        \ a:fo .. a:fo .. ' one ',
+        \ '89 two '
+        \ ], ScreenLines([1, 2], 7))
+  normal 1Gzdzdzdzdzdzdzd
+  call assert_equal([
+        \ a:fo .. a:fo .. ' one ',
+        \ a:fs .. a:fs .. ' two '
+        \ ], ScreenLines([1, 2], 7))
+
+  setlocal foldcolumn& number& signcolumn&
 endfunc
 
 func Test_foldcolumn_multibyte_char()

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -464,5 +464,20 @@ func Test_statusline_after_split_vsplit()
   set ls& stl&
 endfunc
 
+" Test using a multibyte character for 'stl' and 'stlnc' items in 'fillchars'
+" with a custom 'statusline'
+func Test_statusline_mbyte_fillchar()
+  only
+  set laststatus=2
+  set fillchars=vert:\|,fold:-,stl:━,stlnc:═
+  set statusline=a%=b
+  call assert_match('^a\+━\+b$', s:get_statusline())
+  vnew
+  call assert_match('^a\+━\+b━a\+═\+b$', s:get_statusline())
+  wincmd w
+  call assert_match('^a\+═\+b═a\+━\+b$', s:get_statusline())
+  set statusline& fillchars& laststatus&
+  %bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Update the patch by Christian Wellenbrock to support multibyte character for stl and 
stlnc items in the 'fillchars' option. Also add additional tests for fold items in fillchars.