### PR TITLE
allow passing lambdas from vimscript to lua

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -568,6 +568,9 @@ luaV_pushtypval(lua_State *L, typval_T *tv)
 	case VAR_FUNC:
 	    luaV_pushfuncref(L, tv->vval.v_string);
 	    break;
+	case VAR_PARTIAL:
+	    luaV_pushfuncref(L, partial_name(tv->vval.v_partial));
+	    break;
 	case VAR_BLOB:
 	    luaV_pushblob(L, tv->vval.v_blob);
 	    break;

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -121,6 +121,13 @@ func Test_lua_eval()
   lua v = nil
 endfunc
 
+" Test luaeval() with lambda
+func Test_luaeval_with_lambda()
+  lua function hello_luaeval_lambda(a, cb) return a .. cb() end
+  call assert_equal('helloworld', luaeval('hello_luaeval_lambda(_A[1], _A[2])', ['hello', {->'world'}]))
+  lua hello_luaeval_lambda = nil
+endfunc
+
 " Test vim.window()
 func Test_lua_window()
   e Xfoo2


### PR DESCRIPTION
Fix for https://github.com/vim/vim/issues/7936

- [x] allow passing lambdas from vimscript to lua
- [x] add tests

This below code should now work.

```vim
lua <<EOF
    function hello(a, cb)
        print(a .. cb())
    end
EOF

let s:world = {->'world'}
call luaeval('hello(_A[1], _A[2])', ['hello', s:world])
``` 