### PR TITLE
doautoall: Execute autocommands for the current buffer at last

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2670,6 +2670,9 @@ func Test_autocmd_window()
   %bw!
   edit one.txt
   tabnew two.txt
+  vnew three.txt
+  tabnew four.txt
+  tabprevious
   let g:blist = []
   augroup aucmd_win_test1
     au!
@@ -2678,7 +2681,12 @@ func Test_autocmd_window()
   augroup END
 
   doautoall BufEnter
-  call assert_equal([['one.txt', 'autocmd'], ['two.txt', '']], g:blist)
+  call assert_equal([
+        \ ['one.txt', 'autocmd'],
+        \ ['two.txt', ''],
+        \ ['four.txt', 'autocmd'],
+        \ ['three.txt', ''],
+        \ ], g:blist)
 
   augroup aucmd_win_test1
     au!


### PR DESCRIPTION
The doautoall command invokes an event on all the buffers, but some event
listener may store the current window. For example, doautoall WinEnter confuses
some plugin detecting the current window for changing the statusline.
The document of doautoall command does not mention the order of the buffers so
moving the invocation on the current buffer at last will help various plugins.