### PR TITLE
add v:lua support to directly interface with lua global vars from vimscript

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -44,6 +44,7 @@ dict_alloc(void)
 	d->dv_scope = 0;
 	d->dv_refcount = 0;
 	d->dv_copyID = 0;
+	d->dv_flags = 0;
     }
     return d;
 }
@@ -594,6 +595,21 @@ dict_len(dict_T *d)
     dictitem_T *
 dict_find(dict_T *d, char_u *key, int len)
 {
+#if defined(FEAT_LUA) || defined(PROTO)
+    dictitem_T	*item;
+    item = dictitem_alloc(key);
+    if (item == NULL)
+	return NULL;
+
+    if (d->dv_flags && d->dv_flags & DV_FLAGS_VLUA)
+    {
+	if (lua_dict_get_tv(d, key, &item->di_tv))
+	    return item;
+	else
+	    return NULL;
+    }
+#endif
+
 #define AKEYLEN 200
     char_u	buf[AKEYLEN];
     char_u	*akey;

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -149,6 +149,7 @@ static struct vimvar
     {VV_NAME("argv",		 VAR_LIST), VV_RO},
     {VV_NAME("collate",		 VAR_STRING), VV_RO},
     {VV_NAME("exiting",		 VAR_SPECIAL), VV_RO},
+    {VV_NAME("lua",		 VAR_DICT), VV_RO},
 };
 
 // shorthand
@@ -187,6 +188,9 @@ evalvars_init(void)
 {
     int		    i;
     struct vimvar   *p;
+#if defined(FEAT_LUA) || defined(PROTO)
+    dict_T	    *vlua;
+#endif
 
     init_var_dict(&globvardict, &globvars_var, VAR_DEF_SCOPE);
     init_var_dict(&vimvardict, &vimvars_var, VAR_SCOPE);
@@ -225,6 +229,14 @@ evalvars_init(void)
     set_vim_var_dict(VV_COMPLETED_ITEM, dict_alloc_lock(VAR_FIXED));
     set_vim_var_list(VV_ERRORS, list_alloc());
     set_vim_var_dict(VV_EVENT, dict_alloc_lock(VAR_FIXED));
+
+#if defined(FEAT_LUA) || defined(PROTO)
+    vlua = dict_alloc_lock(VAR_FIXED);
+    if (vlua != NULL) {
+	vlua->dv_flags |= DV_FLAGS_VLUA;
+	set_vim_var_dict(VV_LUA, vlua);
+    }
+#endif
 
     set_vim_var_nr(VV_FALSE, VVAL_FALSE);
     set_vim_var_nr(VV_TRUE, VVAL_TRUE);

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -2568,4 +2568,22 @@ luaV_call_lua_func_free(void *state)
     VIM_CLEAR(funcstate);
 }
 
+/*
+ * Get a typval_T item from a dictionary and copy it into "rettv".
+ * Returns FAIL if the entry doesn't exist or out of memory.
+ */
+    int
+lua_dict_get_tv(dict_T *d, char_u *key, typval_T *rettv)
+{
+    if (lua_init())
+    {
+	lua_getglobal(L, key);
+	if (luaV_totypval(L, -1, rettv) == FAIL)
+	    emsg("luaeval: cannot convert value");
+	else
+	    return OK;
+    }
+    return FAIL;
+}
+
 #endif

--- a/src/proto/if_lua.pro
+++ b/src/proto/if_lua.pro
@@ -9,4 +9,5 @@ void lua_window_free(win_T *o);
 void do_luaeval(char_u *str, typval_T *arg, typval_T *rettv);
 int set_ref_in_lua(int copyID);
 void update_package_paths_in_lua(void);
+int lua_dict_get_tv(dict_T *d, char_u *key, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/structs.h
+++ b/src/structs.h
@@ -1530,6 +1530,9 @@ struct dictitem16_S
 };
 typedef struct dictitem16_S dictitem16_T;
 
+// Flags for "dv_flags"
+#define DV_FLAGS_VLUA	   0x01	    // v:lua
+
 // Flags for "di_flags"
 #define DI_FLAGS_RO	   0x01	    // read-only variable
 #define DI_FLAGS_RO_SBX	   0x02	    // read-only in the sandbox
@@ -1552,6 +1555,7 @@ struct dictvar_S
     dict_T	*dv_copydict;	// copied dict used by deepcopy()
     dict_T	*dv_used_next;	// next dict in used dicts list
     dict_T	*dv_used_prev;	// previous dict in used dicts list
+    int		dv_flags;	// DV_FLAGS_ flags
 };
 
 /*

--- a/src/vim.h
+++ b/src/vim.h
@@ -2008,7 +2008,8 @@ typedef int sock_T;
 #define VV_ARGV		96
 #define VV_COLLATE      97
 #define VV_EXITING	98
-#define VV_LEN		99	// number of v: vars
+#define VV_LUA		99
+#define VV_LEN		100	// number of v: vars
 
 // used for v_number in VAR_BOOL and VAR_SPECIAL
 #define VVAL_FALSE	0L	// VAR_BOOL


### PR DESCRIPTION
This is an inspiration from https://github.com/neovim/neovim/pull/11338 but different implementation and unfortunatly not 100% compatible. It will be good to hear @bfredl thoughts on the neovim implementation and this one.

Here is the list of differences with neovim.
* Neovim only seems to support function call while this PR supports all types that can be converted.
* Neovim seems to detect `v:lua` in parser while this PR uses it as a readonly dict with a flag to mark it as a `v:lua`.
* In neovim `echo v:lua.vim.fn.has('timer')` works but `echo v:lua['vim'].fn.has('timer')`  doesn't work. In this PR it won't work at all since we can never translate lua tables to vim type as it is required to use `vim.dict()` or `vim.list({})`.
* Neovim only supports functions so `:echo v:lua._VERSION` will not work. In this PR you can do `:echo v:lua['_VERSION']`. 
* In vim `:echo v:lua.print('hello')` doesn't work at all and requires explicit brackets use i.e. `echo v:lua['print']('hello')`. This to me seems like a vim parser bug.

- [x] implement `v:lua`
- [ ] add tests
- [ ] update docs

```vim
lua <<EOF
function hello()
    return 'hello'
end

function world()
    return 'world'
end
EOF

echom v:lua['hello']() . v:lua['world']()
```