### PR TITLE
runtime/syntax/vim: Fix vimOper ordinal.

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -228,9 +228,9 @@ syn keyword vimAugroupKey contained	aug[roup]
 " Operators: {{{2
 " =========
 syn cluster	vimOperGroup	contains=vimEnvvar,vimFunc,vimFuncVar,vimOper,vimOperParen,vimNumber,vimString,vimType,vimRegister,vimContinue,vim9Comment
+syn match	vimOper	"||\|&&\|[-+.!]"				skipwhite nextgroup=vimString,vimSpecFile
 syn match	vimOper	"\%#=1\(==\|!=\|>=\|<=\|=\~\|!\~\|>\|<\|=\)[?#]\{0,2}"	skipwhite nextgroup=vimString,vimSpecFile
 syn match	vimOper	"\(\<is\|\<isnot\)[?#]\{0,2}\>"			skipwhite nextgroup=vimString,vimSpecFile
-syn match	vimOper	"||\|&&\|[-+.!]"				skipwhite nextgroup=vimString,vimSpecFile
 syn region	vimOperParen 	matchgroup=vimParenSep	start="(" end=")" contains=vimoperStar,@vimOperGroup
 syn region	vimOperParen	matchgroup=vimSep		start="#\={" end="}" contains=@vimOperGroup nextgroup=vimVar,vimFuncVar
 if !exists("g:vimsyn_noerror") && !exists("g:vimsyn_noopererror")


### PR DESCRIPTION
## Problem

Below code highlight do not work expect result.

```vim
if &filetype !~# '^v'
  echo 1
endif
```

[![Image from Gyazo](https://i.gyazo.com/57c8f897e351a3d2a533ed0d882536dc.png)](https://gyazo.com/57c8f897e351a3d2a533ed0d882536dc)

## Solution

This PR fix below:

- vim operator `!~#` and some do not highlight, fix vimOper order.

---

I'm created PR reason: https://github.com/vim/vim/pull/7464

---

Detected but unfixed issue

- `is` / `isnot` suffix `?` , `#` display is incomplete (iskeyword value problem)
- `==??` and some 2char suffix are nothing problem