### PR TITLE
Test_term_mouse_multiple_clicks_to_select_mode() often failed with ssh

### DIFF
--- a/src/testdir/test_selectmode.vim
+++ b/src/testdir/test_selectmode.vim
@@ -165,7 +165,10 @@ func Test_term_mouse_multiple_clicks_to_select_mode()
   let save_term = &term
   let save_ttymouse = &ttymouse
   call test_override('no_query_mouse', 1)
-  set mouse=a term=xterm mousetime=200
+
+  " 'mousetime' must be sufficiently large, or else the test is flaky when
+  " using a ssh connection with X forwarding; i.e. ssh -X.
+  set mouse=a term=xterm mousetime=1000
   set selectmode=mouse
   new
 


### PR DESCRIPTION
When I ssh to a remote machine with 'ssh -X' and run vim tests,
`Test_term_mouse_multiple_clicks_to_select_mode()`  often fails.
I ran this test 50 times and it failed 10 times.

A similar issue was fixed earlier in issue #7576
in `Test_term_mouse_multiple_clicks_to_visually_select()`.

Increasing `mousetime` makes the test more rubust over `ssh -X`.
Maybe we should make 'mousetime' even bigger as it should
not cause harm for the test.  1sec makes the test pass all the
time for my setup.  But maybe a bigger value is needed for
other users.