### PR TITLE
win32: Reenable Test_help_arg on console version

### DIFF
--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -109,7 +109,9 @@ func Test_pack_in_rtp_when_plugins_run()
 endfunc
 
 func Test_help_arg()
-  CheckNotMSWindows
+  if !has('unix') && has('gui_running')
+    throw 'Skipped: does not work with gvim on MS-Windows'
+  endif
 
   if RunVim([], [], '--help >Xtestout')
     let lines = readfile('Xtestout')


### PR DESCRIPTION
See #7962.