### PR TITLE
Improve the pre-conditions of some tests in test_startup

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -11849,6 +11849,8 @@ gui_haiku		Compiled with Haiku GUI.
 gui_mac			Compiled with Macintosh GUI.
 gui_motif		Compiled with Motif GUI.
 gui_photon		Compiled with Photon GUI.
+gui_x11			Compiled with X11 (currently for Athena GUI and Motif
+			GUI).
 gui_running		Vim is running in the GUI, or it will start soon.
 gui_win32		Compiled with MS Windows Win32 GUI.
 gui_win32s		idem, and Win32s system being used (Windows 3.1)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4926,6 +4926,13 @@ f_has(typval_T *argvars, typval_T *rettv)
 		0
 #endif
 		},
+	{"gui_x11",
+#ifdef FEAT_GUI_X11
+		1
+#else
+		0
+#endif
+		},
 	{"gui_win32",
 #ifdef FEAT_GUI_MSWIN
 		1

--- a/src/main.c
+++ b/src/main.c
@@ -3542,8 +3542,11 @@ usage(void)
 #endif // FEAT_GUI_X11
 #ifdef FEAT_GUI_GTK
     mch_msg(_("\nArguments recognised by gvim (GTK+ version):\n"));
+    main_msg(_("-background <color>\tUse <color> for the background (also: -bg)"));
+    main_msg(_("-foreground <color>\tUse <color> for normal text (also: -fg)"));
     main_msg(_("-font <font>\t\tUse <font> for normal text (also: -fn)"));
     main_msg(_("-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"));
+    main_msg(_("-iconic\t\tStart Vim iconified"));
     main_msg(_("-reverse\t\tUse reverse video (also: -rv)"));
     main_msg(_("-display <display>\tRun Vim on <display> (also: --display)"));
     main_msg(_("--role <role>\tSet a unique role to identify the main window"));

--- a/src/testdir/check.vim
+++ b/src/testdir/check.vim
@@ -199,4 +199,29 @@ func CheckNotAsan()
   endif
 endfunc
 
+" Command to check for satisfaction of any of the conditions
+" e.g. CheckAnyOf Feature:bsd Feature:sun Linux
+command -nargs=+ CheckAnyOf call CheckAnyOf(<f-args>)
+func CheckAnyOf(...)
+  let excp = []
+  for arg in a:000
+    try
+      exe 'Check' .. substitute(arg, ':', ' ', '')
+      return
+    catch /^Skipped:/
+      let excp += [substitute(v:exception, '^Skipped:\s*', '', '')]
+    endtry
+  endfor
+  throw 'Skipped: ' .. join(excp, '; ')
+endfunc
+
+" Command to check for satisfaction of all of the conditions
+" e.g. CheckAllOf Unix Gui Option:ballooneval
+command -nargs=+ CheckAllOf call CheckAllOf(<f-args>)
+func CheckAllOf(...)
+  for arg in a:000
+    exe 'Check' .. substitute(arg, ':', ' ', '')
+  endfor
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -109,9 +109,7 @@ func Test_pack_in_rtp_when_plugins_run()
 endfunc
 
 func Test_help_arg()
-  if !has('unix') && has('gui_running')
-    throw 'Skipped: does not work with gvim on MS-Windows'
-  endif
+  CheckAnyOf Unix NotGui
 
   if RunVim([], [], '--help >Xtestout')
     let lines = readfile('Xtestout')

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -426,7 +426,7 @@ endfunction
 " Test the -reverse and +reverse arguments (for GUI only).
 func Test_reverse()
   CheckCanRunGui
-  CheckNotMSWindows
+  CheckAnyOf Feature:gui_gtk Feature:gui_x11
 
   let after =<< trim [CODE]
     call writefile([&background], "Xtest_reverse")
@@ -447,7 +447,7 @@ endfunc
 " Test the -background and -foreground arguments (for GUI only).
 func Test_background_foreground()
   CheckCanRunGui
-  CheckNotMSWindows
+  CheckAnyOf Feature:gui_gtk Feature:gui_x11
 
   " Is there a better way to check the effect of -background & -foreground
   " other than merely looking at &background (dark or light)?
@@ -496,7 +496,7 @@ endfunc
 " Test the -geometry argument (for GUI only).
 func Test_geometry()
   CheckCanRunGui
-  CheckNotMSWindows
+  CheckAnyOf Feature:gui_gtk Feature:gui_x11
 
   if has('gui_motif') || has('gui_athena')
     " FIXME: With GUI Athena or Motif, the value of getwinposx(),
@@ -528,7 +528,7 @@ endfunc
 " Test the -iconic argument (for GUI only).
 func Test_iconic()
   CheckCanRunGui
-  CheckNotMSWindows
+  CheckAnyOf Feature:gui_gtk Feature:gui_x11
 
   call RunVim([], [], '-f -g -iconic -cq')
 


### PR DESCRIPTION
Ref: #7962 #7970

In test_startup.vim, `Test_background_foreground` `Test_reverse` `Test_geometory` `Test_iconic` requires `FEAT_GUI_GTK` or `FEAT_GUI_X11` is defined.
(and `FEAT_GUI_X11` is equivalent to `FEAT_GUI_MOTIF` or`FEAT_GUI_ATHENA`)
Therefore `CheckNotMSWindows` is not appropriate condition; e.g. on Haiku GUI, these tests fail.

I propose the following:

* Add pre-condition checker commands: `CheckAnyOf` and `CheckAllOf`
* Add `gui_x11` feature, it means `gui_motif` or `gui_athena`, for convenience

It can rewrite the pre-conditions of above tests as:

```vim
CheckAnyOf Feature:gui_gtk Feature:gui_x11
```  

or, when defining `gui_x11` is not preferred:

```
CheckAnyOf Feature:gui_gtk Feature:gui_motif Feature:gui_athena
```