### PR TITLE
Handle regex search flag in tagfunc

### DIFF
--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -888,19 +888,25 @@ like |CTRL-]|.
 
 The function used for generating the taglist is specified by setting the
 'tagfunc' option.  The function will be called with three arguments:
-   a:pattern	The tag identifier used during the tag search.
-   a:flags	List of flags to control the function behavior.
+   a:pattern	The tag identifier or pattern used during the tag search.
+   a:flags	String containing flags to control the function behavior.
    a:info	Dict containing the following entries:
 		    buf_ffname	  Full filename which can be used for priority.
 		    user_data	  Custom data String, if stored in the tag
 				  stack previously by tagfunc.
 
-Currently two flags may be passed to the tag function:
+Currently up to three flags may be passed to the tag function:
   'c'		The function was invoked by a normal command being processed
 	        (mnemonic: the tag function may use the context around the
 		cursor to perform a better job of generating the tag list.)
   'i'		In Insert mode, the user was completing a tag (with
-		|i_CTRL-X_CTRL-]|).
+		|i_CTRL-X_CTRL-]| or 'completeopt' contains `t`).
+  'r'		The first argument to tagfunc should be interpreted as a
+		|pattern| (see |tag-regexp|), such as when using: >
+		  :tag /pat
+<		It is also given when completing in insert mode.
+		If this flag is not present, the argument is usually taken
+		literally as the full tag name.
 
 Note that when 'tagfunc' is set, the priority of the tags described in
 |tag-priority| does not apply.  Instead, the priority is exactly as the

--- a/src/tag.c
+++ b/src/tag.c
@@ -1308,7 +1308,7 @@ find_tagfunc_tags(
     int         result = FAIL;
     typval_T	args[4];
     typval_T	rettv;
-    char_u      flagString[3];
+    char_u      flagString[4];
     dict_T	*d;
     taggy_T	*tag = &curwin->w_tagstack[curwin->w_tagstackidx];
 
@@ -1335,9 +1335,10 @@ find_tagfunc_tags(
     args[3].v_type = VAR_UNKNOWN;
 
     vim_snprintf((char *)flagString, sizeof(flagString),
-		 "%s%s",
+		 "%s%s%s",
 		 g_tag_at_cursor      ? "c": "",
-		 flags & TAG_INS_COMP ? "i": "");
+		 flags & TAG_INS_COMP ? "i": "",
+		 flags & TAG_REGEXP   ? "r": "");
 
     save_pos = curwin->w_cursor;
     result = call_vim_function(curbuf->b_p_tfu, 3, args, &rettv);

--- a/src/testdir/test_tagfunc.vim
+++ b/src/testdir/test_tagfunc.vim
@@ -43,11 +43,23 @@ func Test_tagfunc()
   call assert_equal('one', g:tagfunc_args[0])
   call assert_equal('c', g:tagfunc_args[1])
 
+  let g:tagfunc_args=[]
+  execute "tag /foo$"
+  call assert_equal('foo$', g:tagfunc_args[0])
+  call assert_equal('r', g:tagfunc_args[1])
+
   set cpt=t
   let g:tagfunc_args=[]
   execute "normal! i\<c-n>\<c-y>"
-  call assert_equal('ci', g:tagfunc_args[1])
+  call assert_equal('\<\k\k', g:tagfunc_args[0])
+  call assert_equal('cir', g:tagfunc_args[1])
   call assert_equal('nothing1', getline('.')[0:7])
+
+  let g:tagfunc_args=[]
+  execute "normal! ono\<c-n>\<c-n>\<c-y>"
+  call assert_equal('\<no', g:tagfunc_args[0])
+  call assert_equal('cir', g:tagfunc_args[1])
+  call assert_equal('nothing2', getline('.')[0:7])
 
   func BadTagFunc1(...)
     return 0


### PR DESCRIPTION
When using `:tag /regex` this looks to tagfunc like the same as `:tag regex` with a literal string, so a plugin can't react to this differently.  So, we should pass 'r' flag when regex is active.