### PR TITLE
Handle single byte and multibyte characters properly for fold items in 'fillchars'

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -295,8 +295,13 @@ fill_foldcolumn(
     if (closed)
     {
 	if (symbol != 0)
-	    // rollback length
+	{
+	    // rollback length and the character
 	    byte_counter -= len;
+	    if (len > 1)
+		// for a multibyte character, erase all the bytes
+		vim_memset(&p[byte_counter], ' ', len);
+	}
 	symbol = fill_foldclosed;
 	len = utf_char2bytes(symbol, &p[byte_counter]);
 	byte_counter += len;

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1061,6 +1061,12 @@ func Test_foldcolumn_multibyte_char()
   set fillchars+=foldopen:▾,foldsep:│,foldclose:▸
   call s:mbyte_fillchar_tests('▾', '▸', '│')
 
+  " Use a mix of multi-byte and single-byte characters
+  set fillchars+=foldopen:¬,foldsep:\|,foldclose:+
+  call s:mbyte_fillchar_tests('¬', '+', '|')
+  set fillchars+=foldopen:+,foldsep:\|,foldclose:¬
+  call s:mbyte_fillchar_tests('+', '¬', '|')
+
   bw!
   set foldenable& fdc& fdm& fillchars&
 endfunc


### PR DESCRIPTION

Fixes the issue reported in #7955.
