### PR TITLE
filetype: setf xml for *.atom Atom files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -168,6 +168,9 @@ au BufNewFile,BufRead *.mar			setf vmasm
 " Atlas
 au BufNewFile,BufRead *.atl,*.as		setf atlas
 
+" Atom
+au BufNewFile,BufRead *.atom			setf xml
+
 " Autoit v3
 au BufNewFile,BufRead *.au3			setf autoit
 


### PR DESCRIPTION
*.atom files are likely to use the Atom Syndication Format ([RFC 4287]), which is an XML-based format.  The .atom extension is registered in RFC 4287 and is the only used for application/atom+xml in mime.types from [Apache], [Debian], and [Fedora].

Since Atom files do not always include an XML prolog, it's useful to match the file extension for syntax highlighting as well.

Thanks for considering,
Kevin

[RFC 4287]: https://tools.ietf.org/html/rfc4287
[Apache]: https://svn.apache.org/viewvc/httpd/httpd/tags/2.4.46/docs/conf/mime.types?revision=1880504&view=markup#l37
[Debian]: https://salsa.debian.org/debian/media-types/-/blob/4.0.0/mime.types#L54
[Fedora]: https://pagure.io/mailcap/blob/r2-1-52/f/mime.types#_38