### PR TITLE
filetype: setf xml for *.rss RSS files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1425,6 +1425,9 @@ au BufNewFile,BufRead robots.txt		setf robots
 " Rpcgen
 au BufNewFile,BufRead *.x			setf rpcgen
 
+" RSS
+au BufNewFile,BufRead *.rss			setf xml
+
 " reStructuredText Documentation Format
 au BufNewFile,BufRead *.rst			setf rst
 


### PR DESCRIPTION
*.rss files are likely to be [RSS] (RDF Site Summary/Really Simple Syndication), which is an XML-based format.  Although the .rss extension is not registered with the IETF (there is a [draft registration]), it is a popular and long-standing format.  *.rss is only used for RSS in mime.types from [Apache], [Debian], and [Fedora].

Since RSS files do not always include an XML prolog, it's useful to match the file extension for syntax highlighting as well.

Thanks for considering,
Kevin

[RSS]: https://www.rssboard.org/rss-specification
[draft registration]: https://tools.ietf.org/html/draft-nottingham-rss-media-type-00
[Apache]: https://svn.apache.org/viewvc/httpd/httpd/tags/2.4.46/docs/conf/mime.types?revision=1880504&view=markup#l283
[Debian]: https://salsa.debian.org/debian/media-types/-/blob/4.0.0/mime.types#L1518
[Fedora]: https://pagure.io/mailcap/blob/r2-1-52/f/mime.types#_2001