### PR TITLE
Can remove CheckNotBSD from some tests

### DIFF
--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -364,7 +364,6 @@ endfunc
 
 func Test_redir_cmd_readonly()
   CheckNotRoot
-  CheckNotBSD
 
   " Redirecting to a read-only file
   call writefile([], 'Xfile')

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -100,8 +100,6 @@ endfunc
 func Test_helptag_cmd_readonly()
   CheckUnix
   CheckNotRoot
-  " The following tests fail on FreeBSD for some reason
-  CheckNotBSD
 
   " Read-only tags file
   call mkdir('Xdir/doc', 'p')


### PR DESCRIPTION
The failures of `Test_redir_cmd_readonly` and `Test_helptag_cmd_readonly` on BSD seem be caused by running them as root in Cirrus-CI.
Therefore, since there is`CheckNotRoot` now, can remove `CheckNotBSD`.