### PR TITLE
Test the -D (debugger) and --serverlist vim arguments

### DIFF
--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -43,11 +43,13 @@ func Test_client_server()
   " When using valgrind it takes much longer.
   call WaitForAssert({-> assert_match(name, serverlist())})
 
-  if RunVim([], [], '--serverlist >Xtest_serverlist')
-    let lines = readfile('Xtest_serverlist')
-    call assert_true(index(lines, 'XVIMTEST') >= 0)
+  if !has('win32')
+    if RunVim([], [], '--serverlist >Xtest_serverlist')
+      let lines = readfile('Xtest_serverlist')
+      call assert_true(index(lines, 'XVIMTEST') >= 0)
+    endif
+    call delete('Xtest_serverlist')
   endif
-  call delete('Xtest_serverlist')
 
   eval name->remote_foreground()
 

--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -43,6 +43,12 @@ func Test_client_server()
   " When using valgrind it takes much longer.
   call WaitForAssert({-> assert_match(name, serverlist())})
 
+  if RunVim([], [], '--serverlist >Xtest_serverlist')
+    let lines = readfile('Xtest_serverlist')
+    call assert_true(index(lines, 'XVIMTEST') >= 0)
+  endif
+  call delete('Xtest_serverlist')
+
   eval name->remote_foreground()
 
   call remote_send(name, ":let testvar = 'yes'\<CR>")

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -1121,6 +1121,21 @@ func Test_E_arg()
   endif
 endfunc
 
+" Test for the "-D" (debugger) argument
+func Test_D_arg()
+  CheckRunVimInTerminal
+
+  let cmd = GetVimCommandCleanTerm() .. ' -D'
+  let buf = term_start(cmd, {'term_rows' : 10})
+  call WaitForAssert({-> assert_equal("running", term_getstatus(buf))})
+
+  call WaitForAssert({-> assert_equal('Entering Debug mode.  Type "cont" to continue.',
+  \                  term_getline(buf, 7))})
+  call WaitForAssert({-> assert_equal('>', term_getline(buf, 10))})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " Test for too many edit argument errors
 func Test_too_many_edit_args()
   " Can't catch the output of gvim.


### PR DESCRIPTION
The `-D` (debugger) and `--serverlist` command line arguments were not tested.
It adds coverage for only a few lines of code.