### PR TITLE
 Add "both" item to {props} argument of prop_find()

### DIFF
--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -175,6 +175,7 @@ prop_find({props} [, {direction}])
 		Search for a text property as specified with {props}:
 		   id		property with this ID
 		   type		property with this type name
+		   both		"id" and "type" must both match
 		   bufnr	buffer to search in; when present a
 				start position with "lnum" and "col"
 				must be given; when omitted the
@@ -187,6 +188,7 @@ prop_find({props} [, {direction}])
 		   skipstart	do not look for a match at the start
 				position
 
+		A property matches when either "id" or "type" matches.
 		{direction} can be "f" for forward and "b" for backward.  When
 		omitted forward search is performed.
 

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -245,6 +245,25 @@ func Test_prop_find_smaller_len_than_match_col()
   call prop_type_delete('test')
 endfunc
 
+func Test_prop_find_with_both_option_enabled()
+  " Initialize
+  new
+  call AddPropTypes()
+  call SetupPropsInFirstLine()
+  let props = Get_expected_props()->map({_, v -> extend(v, {'lnum': 1})})
+  " Test
+  call assert_fails("call prop_find({'both': 1})", 'E968:')
+  call assert_fails("call prop_find({'id': 11, 'both': 1})", 'E860:')
+  call assert_fails("call prop_find({'type': 'three', 'both': 1})", 'E860:')
+  call assert_equal({}, prop_find({'id': 11, 'type': 'three', 'both': 1}))
+  call assert_equal({}, prop_find({'id': 130000, 'type': 'one', 'both': 1}))
+  call assert_equal(props[2], prop_find({'id': 12, 'type': 'two', 'both': 1}))
+  call assert_equal(props[0], prop_find({'id': 14, 'type': 'whole', 'both': 1}))
+  " Clean up
+  call DeletePropTypes()
+  bwipe!
+endfunc
+
 func Test_prop_add()
   new
   call AddPropTypes()

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -600,6 +600,7 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
     int		lnum = -1;
     int		col = -1;
     int		dir = 1;    // 1 = forward, -1 = backward
+    int		both;
 
     if (argvars[0].v_type != VAR_DICT || argvars[0].vval.v_dict == NULL)
     {
@@ -661,9 +662,15 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
 	    return;
 	type_id = type->pt_id;
     }
+    both = dict_get_bool(dict, (char_u *)"both", FALSE);
     if (id == -1 && type_id == -1)
     {
 	emsg(_("E968: Need at least one of 'id' or 'type'"));
+	return;
+    }
+    if (both && (id == -1 || type_id == -1))
+    {
+	emsg(_("E860: Need 'id' and 'type' with 'both'"));
 	return;
     }
 
@@ -698,7 +705,8 @@ f_prop_find(typval_T *argvars, typval_T *rettv)
 		else if (prop.tp_col + prop.tp_len - (prop.tp_len != 0) < col)
 		    continue;
 	    }
-	    if (prop.tp_id == id || prop.tp_type == type_id)
+	    if (both ? prop.tp_id == id && prop.tp_type == type_id
+		     : prop.tp_id == id || prop.tp_type == type_id)
 	    {
 		// Check if the starting position has text props.
 		if (lnum_start == lnum


### PR DESCRIPTION
 I added a `both` item to `{props}` argument of the `prop_find()` function.

I refered the implementation of `prop_remove()` function.