### PR TITLE
Make runtime/syntax/nroff.vim cooperate with spell checking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,6 +152,7 @@ runtime/syntax/gitcommit.vim		@tpope
 runtime/syntax/gitconfig.vim		@tpope
 runtime/syntax/gitrebase.vim		@tpope
 runtime/syntax/gprof.vim		@dpelle
+runtime/syntax/groff.vim		@jmarshall
 runtime/syntax/haml.vim			@tpope
 runtime/syntax/haskell.vim		@coot
 runtime/syntax/hgcommit.vim		@k-takata
@@ -166,6 +167,7 @@ runtime/syntax/make.vim			@rohieb
 runtime/syntax/maple.vim		@cecamp
 runtime/syntax/markdown.vim		@tpope
 runtime/syntax/netrw.vim		@cecamp
+runtime/syntax/nroff.vim		@jmarshall
 runtime/syntax/nsis.vim			@k-takata
 runtime/syntax/pdf.vim			@tpope
 runtime/syntax/php.vim			@TysonAndre

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2236,9 +2236,10 @@ can use them.
 
 For example, Linux and BSD distributions use groff as their default text
 processing package.  In order to activate the extra syntax highlighting
-features for groff, add the following option to your start-up files: >
+features for groff, arrange for files to be recognized as groff (see
+|ft-groff-syntax|) or add the following option to your start-up files: >
 
-  :let b:nroff_is_groff = 1
+  :let nroff_is_groff = 1
 
 Groff is different from the old AT&T n/troff that you may still find in
 Solaris.  Groff macro and request names can be longer than 2 characters and

--- a/runtime/syntax/groff.vim
+++ b/runtime/syntax/groff.vim
@@ -1,7 +1,7 @@
 " VIM syntax file
 " Language:	groff
-" Maintainer:	Alejandro López-Valencia <dradul@yahoo.com>
-" URL:		http://dradul.tripod.com/vim
+" Maintainer:	John Marshall <jmarshall@hey.com>
+" Previous Maintainer:	Pedro Alejandro López-Valencia <palopezv@gmail.com>
 " Last Change:	2003-05-08-12:41:13 GMT-5.
 
 " This uses the nroff.vim syntax file.

--- a/runtime/syntax/nroff.vim
+++ b/runtime/syntax/nroff.vim
@@ -48,7 +48,7 @@ endif
 "
 setlocal paragraphs+=XP
 "
-" {{{2 Activate navigation to preporcessor sections.
+" {{{2 Activate navigation to preprocessor sections.
 "
 if exists("b:preprocs_as_sections")
 	setlocal sections=EQTSPS[\ G1GS
@@ -198,7 +198,7 @@ syn keyword nroffTodo TODO XXX FIXME contained
 "
 
 hi def link nroffEscChar nroffSpecialChar
-hi def link nroffEscCharAr nroffSpecialChar
+hi def link nroffEscCharArg nroffSpecialChar
 hi def link nroffSpecialChar SpecialChar
 hi def link nroffSpace Delimiter
 
@@ -211,7 +211,7 @@ hi def link nroffEscPar nroffEscape
 hi def link nroffEscRegPar nroffEscape
 hi def link nroffEscArg nroffEscape
 hi def link nroffSize nroffEscape
-hi def link nroffEscape Preproc
+hi def link nroffEscape PreProc
 
 hi def link nroffIgnore Comment
 hi def link nroffComment Comment

--- a/runtime/syntax/nroff.vim
+++ b/runtime/syntax/nroff.vim
@@ -31,6 +31,10 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
+if exists("nroff_is_groff")
+	let b:nroff_is_groff = 1
+endif
+
 "
 " {{{1 plugin settings...
 "

--- a/runtime/syntax/nroff.vim
+++ b/runtime/syntax/nroff.vim
@@ -35,6 +35,9 @@ if exists("nroff_is_groff")
 	let b:nroff_is_groff = 1
 endif
 
+syn spell toplevel
+syn case match
+
 "
 " {{{1 plugin settings...
 "
@@ -173,9 +176,9 @@ endif
 " <jp />
 
 syn region nroffEquation start=/^\.\s*EQ\>/ end=/^\.\s*EN\>/
-syn region nroffTable start=/^\.\s*TS\>/ end=/^\.\s*TE\>/
+syn region nroffTable start=/^\.\s*TS\>/ end=/^\.\s*TE\>/ contains=@Spell
 syn region nroffPicture start=/^\.\s*PS\>/ end=/^\.\s*PE\>/
-syn region nroffRefer start=/^\.\s*\[\>/ end=/^\.\s*\]\>/
+syn region nroffRefer start=/^\.\s*\[\>/ end=/^\.\s*\]\>/ contains=@Spell
 syn region nroffGrap start=/^\.\s*G1\>/ end=/^\.\s*G2\>/
 syn region nroffGremlin start=/^\.\s*GS\>/ end=/^\.\s*GE|GF\>/
 
@@ -183,11 +186,11 @@ syn region nroffGremlin start=/^\.\s*GS\>/ end=/^\.\s*GE|GF\>/
 " ------------------------------------------------------------
 
 syn region nroffIgnore start=/^[.']\s*ig/ end=/^['.]\s*\./
-syn match nroffComment /\(^[.']\s*\)\=\\".*/ contains=nroffTodo
-syn match nroffComment /^'''.*/  contains=nroffTodo
+syn match nroffComment /\(^[.']\s*\)\=\\".*/ contains=nroffTodo,@Spell
+syn match nroffComment /^'''.*/  contains=nroffTodo,@Spell
 
 if exists("b:nroff_is_groff")
-	syn match nroffComment "\\#.*$" contains=nroffTodo
+	syn match nroffComment "\\#.*$" contains=nroffTodo,@Spell
 endif
 
 syn keyword nroffTodo TODO XXX FIXME contained

--- a/runtime/syntax/nroff.vim
+++ b/runtime/syntax/nroff.vim
@@ -1,16 +1,9 @@
 " VIM syntax file
 " Language:	nroff/groff
-" Maintainer:	Pedro Alejandro López-Valencia <palopezv@gmail.com>
-" URL:		http://vorbote.wordpress.com/
-" Last Change:	2012 Feb 2
-"
-" {{{1 Acknowledgements
-"
-" ACKNOWLEDGEMENTS:
-"
-" My thanks to Jérôme Plût <Jerome.Plut@ens.fr>, who was the
-" creator and maintainer of this syntax file for several years.
-" May I be as good at it as he has been.
+" Maintainer:	John Marshall <jmarshall@hey.com>
+" Previous Maintainer:	Pedro Alejandro López-Valencia <palopezv@gmail.com>
+" Previous Maintainer:	Jérôme Plût <Jerome.Plut@ens.fr>
+" Last Change:	2021 Mar 28
 "
 " {{{1 Todo
 "


### PR DESCRIPTION
This improves spelling checking for nroff files (e.g. manual page source) by making nroff requests, special characters, etc not participate in spell checking. In particular, e.g. `\fIword\fR` is seen as `word` rather than a `fIword` misspelling. Also some other minor fixes.

The maintainer listed in _nroff.vim_, @palopezv, has an “upstream repository” at [palopezv/vim-nroff](https://github.com/palopezv/vim-nroff). However it has not been updated in eight years and has diverged from this repository's _runtime/syntax/nroff.vim_ — both in that its minor changes (e.g., email address changes) have not been sent to vim/vim, and changes from vim/vim (e.g., removal of `HiLink` commands) have not been incorporated. Hence I've prepared this patch against this repository's _runtime/syntax/nroff.vim_ as that's actually in use, and present the PR here.