### PR TITLE
runtime/syntax: Numeric separator for JavaScript

### DIFF
--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -40,7 +40,7 @@ syn region  javaScriptStringT	       start=+`+  skip=+\\\\\|\\`+  end=+`+	contai
 syn region  javaScriptEmbed	       start=+${+  end=+}+	contains=@javaScriptEmbededExpr
 
 syn match   javaScriptSpecialCharacter "'\\.'"
-syn match   javaScriptNumber	       "-\=\<[0-9_]\+L\=\>\|0[xX][0-9a-fA-F_]\+\>"
+syn match   javaScriptNumber	       "-\=\<\d\(_\?\d\)*\>\|0[xX][0-9a-fA-F_]\+\>"
 syn region  javaScriptRegexpString     start=+[,(=+]\s*/[^/*]+ms=e-1,me=e-1 skip=+\\\\\|\\/+ end=+/[gimuys]\{0,2\}\s*$+ end=+/[gimuys]\{0,2\}\s*[+;.,)\]}]+me=e-1 end=+/[gimuys]\{0,2\}\s\+\/+me=e-1 contains=@htmlPreproc,javaScriptComment oneline
 
 syn keyword javaScriptConditional	if else switch

--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -40,7 +40,7 @@ syn region  javaScriptStringT	       start=+`+  skip=+\\\\\|\\`+  end=+`+	contai
 syn region  javaScriptEmbed	       start=+${+  end=+}+	contains=@javaScriptEmbededExpr
 
 syn match   javaScriptSpecialCharacter "'\\.'"
-syn match   javaScriptNumber	       "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F_]\+\>"
+syn match   javaScriptNumber	       "-\=\<[0-9_]\+L\=\>\|0[xX][0-9a-fA-F_]\+\>"
 syn region  javaScriptRegexpString     start=+[,(=+]\s*/[^/*]+ms=e-1,me=e-1 skip=+\\\\\|\\/+ end=+/[gimuys]\{0,2\}\s*$+ end=+/[gimuys]\{0,2\}\s*[+;.,)\]}]+me=e-1 end=+/[gimuys]\{0,2\}\s\+\/+me=e-1 contains=@htmlPreproc,javaScriptComment oneline
 
 syn keyword javaScriptConditional	if else switch

--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -40,7 +40,7 @@ syn region  javaScriptStringT	       start=+`+  skip=+\\\\\|\\`+  end=+`+	contai
 syn region  javaScriptEmbed	       start=+${+  end=+}+	contains=@javaScriptEmbededExpr
 
 syn match   javaScriptSpecialCharacter "'\\.'"
-syn match   javaScriptNumber	       "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
+syn match   javaScriptNumber	       "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F_]\+\>"
 syn region  javaScriptRegexpString     start=+[,(=+]\s*/[^/*]+ms=e-1,me=e-1 skip=+\\\\\|\\/+ end=+/[gimuys]\{0,2\}\s*$+ end=+/[gimuys]\{0,2\}\s*[+;.,)\]}]+me=e-1 end=+/[gimuys]\{0,2\}\s\+\/+me=e-1 contains=@htmlPreproc,javaScriptComment oneline
 
 syn keyword javaScriptConditional	if else switch

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -159,9 +159,9 @@ syn match   pythonEscape	"\\$"
 if !exists("python_no_number_highlight")
   " numbers (including longs and complex)
   syn match   pythonNumber	"\<0[oO]\=\o\+[Ll]\=\>"
-  syn match   pythonNumber	"\<0[xX]\x\+[Ll]\=\>"
+  syn match   pythonNumber	"\<0[xX][0-9A-F_]\+[Ll]\=\>"
   syn match   pythonNumber	"\<0[bB][01]\+[Ll]\=\>"
-  syn match   pythonNumber	"\<\%([1-9]\d*\|0\)[Ll]\=\>"
+  syn match   pythonNumber	"\<\%([1-9][0-9_]*\|0\)[Ll]\=\>"
   syn match   pythonNumber	"\<\d\+[jJ]\>"
   syn match   pythonNumber	"\<\d\+[eE][+-]\=\d\+[jJ]\=\>"
   syn match   pythonNumber

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -159,9 +159,9 @@ syn match   pythonEscape	"\\$"
 if !exists("python_no_number_highlight")
   " numbers (including longs and complex)
   syn match   pythonNumber	"\<0[oO]\=\o\+[Ll]\=\>"
-  syn match   pythonNumber	"\<0[xX][0-9A-F_]\+[Ll]\=\>"
+  syn match   pythonNumber	"\<0[xX]\x\+[Ll]\=\>"
   syn match   pythonNumber	"\<0[bB][01]\+[Ll]\=\>"
-  syn match   pythonNumber	"\<\%([1-9][0-9_]*\|0\)[Ll]\=\>"
+  syn match   pythonNumber	"\<\%([1-9]\d*\|0\)[Ll]\=\>"
   syn match   pythonNumber	"\<\d\+[jJ]\>"
   syn match   pythonNumber	"\<\d\+[eE][+-]\=\d\+[jJ]\=\>"
   syn match   pythonNumber


### PR DESCRIPTION
Shown here:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Numeric_separators

I did contact the maintainer:

https://github.com/fleiner/vim/issues/2

However the maintainer has not been active at GitHub in over a year.