### PR TITLE
Fix ":vim9*" commands completion

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1031,6 +1031,13 @@ set_one_cmd_context(
 	    while (ASCII_ISALPHA(*p) || *p == '*')
 		++p;
 	}
+	// "vim9*" commands completion
+	else if (*p == '9' && STRNCMP("vim9", cmd, 4) == 0)
+	{
+	    ++p;
+	    while (ASCII_ISALPHA(*p))
+		++p;
+	}
 	// check for non-alpha command
 	if (p == cmd && vim_strchr((char_u *)"@*!=><&~#", *p) != NULL)
 	    ++p;

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1031,9 +1031,9 @@ set_one_cmd_context(
 	    while (ASCII_ISALPHA(*p) || *p == '*')
 		++p;
 	}
-	// "vim9*" commands completion
 	else if (*p == '9' && STRNCMP("vim9", cmd, 4) == 0)
 	{
+	    // include "9" for "vim9*" commands; "vim9cmd" and "vim9script".
 	    ++p;
 	    while (ASCII_ISALPHA(*p))
 		++p;

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3553,7 +3553,7 @@ find_ex_command(
 	}
 	else if (*p == '9' && STRNCMP("vim9", eap->cmd, 4) == 0)
 	{
-	    // include "9" for "vim9script"
+	    // include "9" for "vim9*" commands; "vim9cmd" and "vim9script".
 	    ++p;
 	    while (ASCII_ISALPHA(*p))
 		++p;

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -871,6 +871,10 @@ func Test_cmdline_complete_various()
   call feedkeys(":py3\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"py3 py3do py3file', @:)
 
+  " completion for the :vim9 commands
+  call feedkeys(":vim9\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"vim9cmd vim9script', @:)
+
   " redir @" is not the start of a comment. So complete after that
   call feedkeys(":redir @\" | cwin\t\<C-B>\"\<CR>", 'xt')
   call assert_equal('"redir @" | cwindow', @:)


### PR DESCRIPTION
**Describe the bug**
The `vim9*` commands, `vim9cmd` and `vim9script`, may not suggested by cmdline completion.

**To Reproduce**

1. Run `vim --clean`.
1. Type `:vim9`.
    ```
    :vim9
    ```

1. Press <kbd>Tab</kbd>.
    ```
    :vim9
    ```

    Bell rings. Nothing is suggested.

**Expected behavior**
`vim9cmd` and `vim9script` are suggested.

**Environment**
- Vim 8.2.2668
- macOS Catalina (version 10.15.7)
- iTerm2

**Solution**
Check `9` following `vim`.