### PR TITLE
Update runtime/syntax/sudoers.vim

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -142,6 +142,7 @@ runtime/syntax/csh.vim			@cecamp
 runtime/syntax/cucumber.vim		@tpope
 runtime/syntax/datascript.vim		@dpelle
 runtime/syntax/dcl.vim			@cecamp
+runtime/syntax/desktop.vim		@e-kwsm
 runtime/syntax/doxygen.vim		@frogonwheels
 runtime/syntax/dtd.vim			@chrisbra
 runtime/syntax/elmfilt.vim		@cecamp
@@ -162,7 +163,6 @@ runtime/syntax/lisp.vim			@cecamp
 runtime/syntax/lynx.vim			@dkearns
 runtime/syntax/mailcap.vim		@dkearns
 runtime/syntax/make.vim			@rohieb
-runtime/syntax/make.vim			@rohieb
 runtime/syntax/maple.vim		@cecamp
 runtime/syntax/markdown.vim		@tpope
 runtime/syntax/netrw.vim		@cecamp
@@ -181,6 +181,7 @@ runtime/syntax/sm.vim			@cecamp
 runtime/syntax/spec.vim			@ignatenkobrain
 runtime/syntax/sqloracle.vim		@chrisbra
 runtime/syntax/sshdconfig.vim		@Jakuje
+runtime/syntax/sudoers.vim		@e-kwsm
 runtime/syntax/tags.vim			@cecamp
 runtime/syntax/teraterm.vim		@k-takata
 runtime/syntax/tex.vim			@cecamp

--- a/runtime/syntax/sudoers.vim
+++ b/runtime/syntax/sudoers.vim
@@ -26,7 +26,7 @@ syn cluster sudoersCmndSpecList       contains=sudoersUserRunasBegin,sudoersPASS
 syn keyword sudoersTodo               contained TODO FIXME XXX NOTE
 
 syn region  sudoersComment            display oneline start='#' end='$' contains=sudoersTodo
-syn region  sudoersInclude            display oneline start='#\(include\|includedir\)' end='$'
+syn region  sudoersInclude            display oneline start='[#@]\%(include\|includedir\)\>' end='$'
 
 syn keyword sudoersAlias              User_Alias Runas_Alias nextgroup=sudoersUserAlias skipwhite skipnl
 syn keyword sudoersAlias              Host_Alias nextgroup=sudoersHostAlias skipwhite skipnl

--- a/runtime/syntax/sudoers.vim
+++ b/runtime/syntax/sudoers.vim
@@ -1,5 +1,6 @@
 " Vim syntax file
 " Language:             sudoers(5) configuration files
+" Maintainer:           Eisuke Kawashima ( e.kawaschima+vim AT gmail.com )
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2018-08-18
 " Recent Changes:	Support for #include and #includedir.


### PR DESCRIPTION
Version 1.9.1 added `@include` and `@includedir` directives (https://www.sudo.ws/stable.html#1.9.1).

I believe @now is the maintainer.