### PR TITLE
GVim/Motif: Do not reset font when dialog cancelled

### DIFF
--- a/src/gui_x11.c
+++ b/src/gui_x11.c
@@ -1752,8 +1752,12 @@ gui_mch_init_font(
 #ifdef FEAT_GUI_MOTIF
     // A font name equal "*" is indicating, that we should activate the font
     // selection dialogue to get a new font name. So let us do it here.
-    if (font_name != NULL && STRCMP(font_name, "*") == 0)
+    if (font_name != NULL && STRCMP(font_name, "*") == 0) {
 	font_name = gui_xm_select_font(hl_get_font_name());
+	// Do not reset default font except on GUI startup. Closes #7825.
+	if (font_name == NULL && !gui.starting)
+	    return OK;
+    }
 #endif
 
 #ifdef FEAT_XFONTSET


### PR DESCRIPTION
If Motif font selection dialog is cancelled by user then we should keep current font. Closes #7825.