### PR TITLE
Update ssh and sshd config highlighter from last release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,6 +180,7 @@ runtime/syntax/sh.vim			@cecamp
 runtime/syntax/sm.vim			@cecamp
 runtime/syntax/spec.vim			@ignatenkobrain
 runtime/syntax/sqloracle.vim		@chrisbra
+runtime/syntax/sshconfig.vim		@Jakuje
 runtime/syntax/sshdconfig.vim		@Jakuje
 runtime/syntax/tags.vim			@cecamp
 runtime/syntax/teraterm.vim		@k-takata

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	OpenSSH client configuration file (ssh_config)
 " Author:	David Necas (Yeti)
-" Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
+" Maintainer:	Jakub Jelen <jakuje at gmail dot com>
+" Previous Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
 " Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>
 " Contributor:  Karsten Hopp <karsten@redhat.com>
 " Contributor:  Dean, Adam Kenneth <adam.ken.dean@hpe.com>

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -5,10 +5,10 @@
 " Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>
 " Contributor:  Karsten Hopp <karsten@redhat.com>
 " Contributor:  Dean, Adam Kenneth <adam.ken.dean@hpe.com>
-" Last Change:	2020 Feb 12
+" Last Change:	2021 Mar 29
 "		Added RemoteCommand from pull request #4809
 "		Included additional keywords from Martin.
-" SSH Version:	7.4p1
+" SSH Version:	8.5p1
 "
 
 " Setup
@@ -174,6 +174,7 @@ syn keyword sshconfigKeyword HostKeyAlgorithms
 syn keyword sshconfigKeyword HostKeyAlias
 syn keyword sshconfigKeyword HostName
 syn keyword sshconfigKeyword HostbasedAuthentication
+syn keyword sshconfigKeyword HostbasedAcceptedAlgorithms
 syn keyword sshconfigKeyword HostbasedKeyTypes
 syn keyword sshconfigKeyword IPQoS
 syn keyword sshconfigKeyword IdentitiesOnly
@@ -185,9 +186,11 @@ syn keyword sshconfigKeyword IPQoS
 syn keyword sshconfigKeyword KbdInteractiveAuthentication
 syn keyword sshconfigKeyword KbdInteractiveDevices
 syn keyword sshconfigKeyword KexAlgorithms
+syn keyword sshconfigKeyword KnownHostsCommand
 syn keyword sshconfigKeyword LocalCommand
 syn keyword sshconfigKeyword LocalForward
 syn keyword sshconfigKeyword LogLevel
+syn keyword sshconfigKeyword LogVerbose
 syn keyword sshconfigKeyword MACs
 syn keyword sshconfigKeyword Match
 syn keyword sshconfigKeyword NoHostAuthenticationForLocalhost
@@ -195,11 +198,13 @@ syn keyword sshconfigKeyword NumberOfPasswordPrompts
 syn keyword sshconfigKeyword PKCS11Provider
 syn keyword sshconfigKeyword PasswordAuthentication
 syn keyword sshconfigKeyword PermitLocalCommand
+syn keyword sshconfigKeyword PermitRemoteOpen
 syn keyword sshconfigKeyword Port
 syn keyword sshconfigKeyword PreferredAuthentications
 syn keyword sshconfigKeyword ProxyCommand
 syn keyword sshconfigKeyword ProxyJump
 syn keyword sshconfigKeyword ProxyUseFDPass
+syn keyword sshconfigKeyword PubkeyAcceptedAlgorithms
 syn keyword sshconfigKeyword PubkeyAcceptedKeyTypes
 syn keyword sshconfigKeyword PubkeyAuthentication
 syn keyword sshconfigKeyword RekeyLimit

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -7,8 +7,8 @@
 " Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>	
 " Contributor:  Karsten Hopp <karsten@redhat.com>
 " Originally:	2009-07-09
-" Last Change:	2020-10-20
-" SSH Version:	8.4p1
+" Last Change:	2021-03-29
+" SSH Version:	8.5p1
 "
 
 " Setup
@@ -195,6 +195,7 @@ syn keyword sshdconfigKeyword HostCertificate
 syn keyword sshdconfigKeyword HostKey
 syn keyword sshdconfigKeyword HostKeyAgent
 syn keyword sshdconfigKeyword HostKeyAlgorithms
+syn keyword sshdconfigKeyword HostbasedAcceptedAlgorithms
 syn keyword sshdconfigKeyword HostbasedAcceptedKeyTypes
 syn keyword sshdconfigKeyword HostbasedAuthentication
 syn keyword sshdconfigKeyword HostbasedUsesNameFromPacketOnly
@@ -213,6 +214,7 @@ syn keyword sshdconfigKeyword KexAlgorithms
 syn keyword sshdconfigKeyword KeyRegenerationInterval
 syn keyword sshdconfigKeyword ListenAddress
 syn keyword sshdconfigKeyword LogLevel
+syn keyword sshdconfigKeyword LogVerbose
 syn keyword sshdconfigKeyword LoginGraceTime
 syn keyword sshdconfigKeyword MACs
 syn keyword sshdconfigKeyword Match
@@ -220,6 +222,8 @@ syn keyword sshdconfigKeyword MaxAuthTries
 syn keyword sshdconfigKeyword MaxSessions
 syn keyword sshdconfigKeyword MaxStartups
 syn keyword sshdconfigKeyword PasswordAuthentication
+syn keyword sshdconfigKeyword PerSourceMaxStartups
+syn keyword sshdconfigKeyword PerSourceNetBlockSize
 syn keyword sshdconfigKeyword PermitBlacklistedKeys
 syn keyword sshdconfigKeyword PermitEmptyPasswords
 syn keyword sshdconfigKeyword PermitListen
@@ -234,6 +238,7 @@ syn keyword sshdconfigKeyword Port
 syn keyword sshdconfigKeyword PrintLastLog
 syn keyword sshdconfigKeyword PrintMotd
 syn keyword sshdconfigKeyword Protocol
+syn keyword sshdconfigKeyword PubkeyAcceptedAlgorithms
 syn keyword sshdconfigKeyword PubkeyAcceptedKeyTypes
 syn keyword sshdconfigKeyword PubkeyAuthentication
 syn keyword sshdconfigKeyword PubkeyAuthOptions


### PR DESCRIPTION
I am already maintainer for the sshdconfig because the previous maintainer was not responsive. We have the same maintainer for the sshconfig, which is more updated, but is missing the latest changes too.