### PR TITLE
Add menu item tooltip & print message at bottom on hover

### DIFF
--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -684,6 +684,20 @@ menu_item_activate(GtkWidget *widget UNUSED, gpointer data)
     gui_menu_cb((vimmenu_T *)data);
 }
 
+    static void
+menu_item_select(GtkWidget *widget UNUSED, gpointer data)
+{
+    char_u *tooltip;
+    vimmenu_T *menu;
+
+    menu = (vimmenu_T *)data;
+    tooltip = CONVERT_TO_UTF8(menu->strings[MENU_INDEX_TIP]);
+    if (tooltip != NULL)
+	msg(tooltip);
+    else
+	msg("");
+}
+
     void
 gui_mch_add_menu_item(vimmenu_T *menu, int idx)
 {
@@ -799,9 +813,12 @@ gui_mch_add_menu_item(vimmenu_T *menu, int idx)
 	gtk_menu_shell_insert(GTK_MENU_SHELL(parent->submenu_id),
 		menu->id, idx);
 
-	if (menu->id != NULL)
+	if (menu->id != NULL) {
 	    g_signal_connect(G_OBJECT(menu->id), "activate",
 			     G_CALLBACK(menu_item_activate), menu);
+	    g_signal_connect(G_OBJECT(menu->id), "select",
+			     G_CALLBACK(menu_item_select), menu);
+	}
     }
 }
 #endif // FEAT_MENU
@@ -892,8 +909,7 @@ get_menu_position(vimmenu_T *menu)
     void
 gui_mch_menu_set_tip(vimmenu_T *menu)
 {
-    if (menu->id != NULL && menu->parent != NULL
-	    && gui.toolbar != NULL && menu_is_toolbar(menu->parent->name))
+    if (menu->id != NULL && menu->parent != NULL && gui.toolbar != NULL)
     {
 	char_u *tooltip;
 


### PR DESCRIPTION
* Add menu_item_select callback on GTK "select" signal to output message in the status line & in menu tooltip.
* Show tips for all menus in addition to toolbar menu.

Fixes vim/vim#7810