### PR TITLE
Fix prompt for s///c in Ex mode

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4153,6 +4153,7 @@ ex_substitute(exarg_T *eap)
 			    if (curwin->w_cursor.col < 0)
 				curwin->w_cursor.col = 0;
 			    getvcol(curwin, &curwin->w_cursor, NULL, NULL, &ec);
+			    curwin->w_cursor.col = regmatch.startpos[0].col;
 			    if (subflags.do_number || curwin->w_p_nu)
 			    {
 				int numw = number_width(curwin) + 1;

--- a/src/testdir/test_ex_mode.vim
+++ b/src/testdir/test_ex_mode.vim
@@ -77,6 +77,9 @@ func Test_Ex_substitute()
   call WaitForAssert({-> assert_match('  1 foo foo', term_getline(buf, 5))},
         \ 1000)
   call WaitForAssert({-> assert_match('    ^^^', term_getline(buf, 6))}, 1000)
+  call term_sendkeys(buf, "N\<CR>")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_match('    ^^^', term_getline(buf, 6))}, 1000)
   call term_sendkeys(buf, "n\<CR>")
   call WaitForAssert({-> assert_match('        ^^^', term_getline(buf, 6))},
         \ 1000)


### PR DESCRIPTION
Currently when doing `s/foo/bar/c` in Ex mode the substitution prompt `^^^` may shrink to single `^`:

```
Entering Ex mode.  Type "visual" to go to Normal mode.
:print
  1 foo
:s/foo/bar/c
  1 foo
    ^^^x
  1 foo
      ^y
```

