### PR TITLE
Fix 'wildmode' documentation to be clearer in behavior

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8790,23 +8790,31 @@ A jump table for the options with a short description can be found at |Q_op|.
 	part specifies what to do for each consecutive use of 'wildchar'.  The
 	first part specifies the behavior for the first use of 'wildchar',
 	The second part for the second use, etc.
-	These are the possible values for each part:
+	Each part consists of a colon separated list consisting of the
+	following possible values:
 	""		Complete only the first match.
 	"full"		Complete the next full match.  After the last match,
 			the original string is used and then the first match
-			again.
+			again.  Will also start 'wildmenu' if it is enabled.
 	"longest"	Complete till longest common string.  If this doesn't
-			result in a longer string, use the next part.
-	"longest:full"	Like "longest", but also start 'wildmenu' if it is
-			enabled.
+			result in a longer string, use the next part.  Will
+			override "full" when specified together.
 	"list"		When more than one match, list all matches.
+	"lastused"	When completing buffer names and more than one buffer
+			matches, sort buffers by time last used (other than
+			the current buffer).
+	When there is only a single match, it is fully completed in all cases.
+
+	Some examples of possible colon-separated values:
+	"longest:full"	Like "longest", but also start 'wildmenu' if it is
+			enabled.  Wil not complete to the next full match.
 	"list:full"	When more than one match, list all matches and
 			complete first match.
 	"list:longest"	When more than one match, list all matches and
 			complete till longest common string.
-	"list:lastused" When more than one buffer matches, sort buffers
-			by time last used (other than the current buffer).
-	When there is only a single match, it is fully completed in all cases.
+	"list:lastused" When more than one buffer matches, list all matches
+			and sort buffers by time last used (other than the
+			current buffer).
 
 	Examples: >
 		:set wildmode=full


### PR DESCRIPTION
Make the doc explain the full functionality of how to join the different distinct values. For example, reading the current doc, it's not clear one could actually do `set wildmode=full:lastused` or that any value can be joined with any value.

1. Describe empty/full/longest/list independently and mention that they can be joined by using a colon.
2. Mention that setting "full" will activate wildmenu if enabled.
3. Make sure longest:full is given as an example as the "longest" overrides "full".
4. Elaborate on "lastused" and mention that it's only for buffer listing commands (since other usage of wildmenu like :edit won't be affected).