### PR TITLE
Skip "symbol" regions when matching parentheses

### DIFF
--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -107,9 +107,10 @@ func s:Highlight_Matching_Pair()
     " Build an expression that detects whether the current cursor position is
     " in certain syntax types (string, comment, etc.), for use as
     " searchpairpos()'s skip argument.
-    " We match "escape" for special items, such as lispEscapeSpecial.
+    " We match "escape" and "symbol" for special items, such as
+    " lispEscapeSpecial or lispBarSymbol.
     let s_skip = '!empty(filter(map(synstack(line("."), col(".")), ''synIDattr(v:val, "name")''), ' .
-	\ '''v:val =~? "string\\|character\\|singlequote\\|escape\\|comment"''))'
+	\ '''v:val =~? "string\\|character\\|singlequote\\|escape\\|symbol\\|comment"''))'
     " If executing the expression determines that the cursor is currently in
     " one of the syntax types, then we want searchpairpos() to find the pair
     " within those syntax types (i.e., not skip).  Otherwise, the cursor is


### PR DESCRIPTION
Lisp symbols can contain parenthesis when surrounded by vertical bars (i.e. `|Symbol-Name|`), and in case of _unbalanced_ parenthesis matchparen.vim would fail to highlight the "right" pair:

    (foo |)-close|)
    |     `-- highlighted
    `-- cursor position

After "symbol" is added to the list of regions to test against, matchparen.vim will highlight the _expected_ closing pair:

    (foo |)-close|)
    |             `-- highlighted
    `-- cursor position

I know it's very unlikely for one to define a symbol with such a name, but should that ever happen, this fix will make matchparen.vim behave properly.