### PR TITLE
Fix version check in test_lua

### DIFF
--- a/ci/if_ver-1.vim
+++ b/ci/if_ver-1.vim
@@ -6,7 +6,7 @@ if 1
   echo "*** Interface versions ***\n"
 
   echo 'Lua:'
-  PrintVer lua print(_VERSION)
+  PrintVer lua print(vim.lua_version, jit and "(LuaJIT)" or "")
 
   echo 'MzScheme:'
   PrintVer mzscheme (display (version))

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -13,18 +13,7 @@ CheckFeature lua
 CheckFeature float
 
 " Depending on the lua version, the error messages are different.
-let s:luaver = split(split(systemlist('lua -v')[0], ' ')[1], '\.')
-if len(s:luaver) < 3
-  " Didn't get something that looks like a version, use _VERSION.
-  let s:luaver = split(split(luaeval('_VERSION'), ' ')[1], '\.')
-endif
-let s:major = str2nr(s:luaver[0])
-let s:minor = str2nr(s:luaver[1])
-if len(s:luaver) >= 3
-  let s:patch = str2nr(s:luaver[2])
-else
-  let s:patch = 0
-endif
+let [s:major, s:minor, s:patch] = luaeval('vim.lua_version')->split('\.')->map({-> str2nr(v:val)})
 let s:lua_53_or_later = 0
 let s:lua_543_or_later = 0
 if (s:major == 5 && s:minor >= 3) || s:major > 5


### PR DESCRIPTION
test_lua fetchs Lua version from the result of `lua -v` command, but this may differ from Lua library which Vim links actually.
e.g. When Vim links LuaJIT-2.0.5 library, but command `lua` is original Lua-5.4.3, not an alias of `luajit`.
In this case some tests of test_lua fail. 

This pull-req proposes to add `vim.lua_version` value to Lua module for fetching detailed Lua version from linked library.
Lua global `_VERSION` value tells only `major.minor` version, `vim.lua_version` is `major.minor.patch`. 