### PR TITLE
Fix for gprof syntax and ftplugin

### DIFF
--- a/runtime/ftplugin/gprof.vim
+++ b/runtime/ftplugin/gprof.vim
@@ -1,6 +1,6 @@
 " Language:    gprof
 " Maintainer:  Dominique Pelle <dominique.pelle@gmail.com>
-" Last Change: 2013 Jun 09
+" Last Change: 2021 Apr 08
 
 " When cursor is on one line of the gprof call graph,
 " calling this function jumps to this function in the call graph.
@@ -16,7 +16,7 @@ fun! <SID>GprofJumpToFunctionIndex()
     norm! $y%
     call search('^' . escape(@", '[]'), 'sw')
     norm! zz
-  elseif l:line =~ '^\(\s\+[0-9\.]\+\)\{3}\s\+'
+  elseif l:line =~ '^\(\s*[0-9\.]\+\)\{3}\s\+'
     " We're in line in the flat profile.
     norm! 55|eby$
     call search('^\[\d\+\].*\d\s\+' .  escape(@", '[]*.') . '\>', 'sW')

--- a/runtime/syntax/gprof.vim
+++ b/runtime/syntax/gprof.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: Syntax for Gprof Output
 " Maintainer: Dominique Pelle <dominique.pelle@gmail.com>
-" Last Change: 2013 Jun 09
+" Last Change: 2021 Apr 08
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -28,7 +28,7 @@ syn match gprofCallGraphTitle "Call graph (explanation follows)"
 syn region gprofCallGraphHeader
   \ start="^granularity: each sample hit covers.*"
   \ end="^\s*index % time\s\+self\s\+children\s\+called\s\+name$"
-syn match gprofCallGraphFunction "\s\+\(\d\+\.\d\+\s\+\)\{3}\([0-9+]\+\)\?\s\+[a-zA-Z_<].*\ze\["
+syn match gprofCallGraphFunction "\<\(\d\+\.\d\+\s\+\)\{3}\([0-9+]\+\)\?\s\+[a-zA-Z_<].*\ze\["
 syn match gprofCallGraphSeparator "^-\+$"
 syn region gprofCallGraphTrailer
   \ start="This table describes the call tree of the program"
@@ -41,7 +41,7 @@ syn region gprofIndex
 
 syn match gprofIndexFunctionTitle "^Index by function name$"
 
-syn match gprofNumbers "^\s\+[0-9 ./+]\+"
+syn match gprofNumbers "^\s*[0-9 ./+]\+"
 syn match gprofFunctionIndex "\[\d\+\]"
 syn match gprofSpecial "<\(spontaneous\|cycle \d\+\)>"
 


### PR DESCRIPTION
gprof syntax and ftplugin did not work on the first line
(i.e. the one showing call_def_function) in the flat
profile of the gprof profile at:
  https://github.com/vim/vim/files/6277991/slow.log

Syntax highlighting of that line was wrong, and pressing
`CTRL-]`  on `call_def_function` on that line did not jump
to its call graph.