### PR TITLE
fix interpretation of `TOP` in `syn include`d file

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -5990,12 +5990,17 @@ get_id_list(
 		    break;
 		}
 		if (name[1] == 'A')
-		    id = SYNID_ALLBUT;
+		    id = SYNID_ALLBUT + current_syn_inc_tag;
 		else if (name[1] == 'T')
-		    id = SYNID_TOP;
+		{
+		    if (curwin->w_s->b_syn_topgrp >= SYNID_CLUSTER)
+			id = curwin->w_s->b_syn_topgrp;
+		    else
+			id = SYNID_TOP + current_syn_inc_tag;
+		}
 		else
-		    id = SYNID_CONTAINED;
-		id += current_syn_inc_tag;
+		    id = SYNID_CONTAINED + current_syn_inc_tag;
+
 	    }
 	    else if (name[1] == '@')
 	    {

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -920,4 +920,19 @@ func Test_syn_contained_transparent()
   bw!
 endfunc
 
+func Test_syn_include_contains_TOP()
+  let l:case = "TOP in included syntax means its group list name"
+  new
+  syntax include @INCLUDED syntax/c.vim
+  syntax region FencedCodeBlockC start=/```c/ end=/```/ contains=@INCLUDED
+
+  call setline(1,  ['```c', '#if 0', 'int', '#else', 'int', '#endif', '```' ])
+  let l:expected = ["cCppOutIf2"]
+  eval AssertHighlightGroups(3, 1, l:expected, 1)
+  " cCppOutElse has contains=TOP
+  let l:expected = ["cType"]
+  eval AssertHighlightGroups(5, 1, l:expected, 1, l:case)
+  syntax clear
+  bw!
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When running `syn include @NAME FILE`, the `TOP` in the sourced `FILE`
should be interpreted as `@NAME`, not the `TOP` of the caller.

For example, consider markdown fenced code block containing C code. To
highlight the C code in the block, we would write something like this in
syntax/markdown.vim:

    syn include @FENCED_C syntax/c.vim
    syn region start="```c" end="```" contains=@FENCED_C

In this case, this line in $VIMRUNTIME/syntax/c.vim

    syn region cCppOutElse ... contains=TOP,...

should be should be interpreted as

    syn region cCppOutElse ... contains=@FENCED_C,...

because we want `cCppOutElse` to contain the `TOP` of C syntax, not the
`TOP` of markdown syntax.