### PR TITLE
Fix documentation to mention new Octal notations

### DIFF
--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -117,9 +117,12 @@ FOUR KINDS OF NUMBERS
 
 Numbers can be decimal, hexadecimal, octal or binary.  A hexadecimal number
 starts with "0x" or "0X".  For example "0x1f" is decimal 31.  An octal number
-starts with a zero.  "017" is decimal 15.  A binary number starts with "0b" or
-"0B".  For example "0b101" is decimal 5.  Careful: don't put a zero before a
-decimal number, it will be interpreted as an octal number!
+starts with "0o" or "0O".  For example "0o17" is decimal 15.  An octal number
+can also start with a zero. "017 is decimal 15".  Though the latter octal
+notation is supported, it is good practice to be explicit and use the former
+octal notation.  A binary number starts with "0b" or "0B".  For example
+"0b101" is decimal 5.  Careful: don't put a zero before a decimal number, it
+will be interpreted as an octal number!
    The ":echo" command always prints decimal numbers.  Example: >
 
 	:echo 0x7f 0o36


### PR DESCRIPTION
Octal notation was updated to support the "0o" and the "0O" prefixes.
Updated documentation to reflect the same.

## Reference:
1. Introduced in commit? c17e66c5c0acd5038f1eb3d7b3049b64bb6ea30b
2. Where in code? https://github.com/vim/vim/blob/e8209b91b9974da95899b51dba4058b411d04d5b/src/charset.c#L1849-L1871

---
## To Discuss
1. Do we plan to deprecate the zero prefix for octal numbers?
2. If yes, can we add a warning of some sorts to indicate this?