### PR TITLE
Missing test coverage when doing :confirm w

### DIFF
--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -319,6 +319,61 @@ func Test_confirm_q_wq()
   call delete('Xfoo')
 endfunc
 
+func Test_confirm_write_ro()
+  CheckNotGui
+  CheckRunVimInTerminal
+
+  call writefile(['foo'], 'Xconfirm_write_ro')
+  let lines =<< trim END
+    set nobackup ff=unix cmdheight=2
+    edit Xconfirm_write_ro
+    norm Abar
+  END
+  call writefile(lines, 'Xscript')
+  let buf = RunVimInTerminal('-S Xscript', {'rows': 20})
+
+  " Try to write with 'ro' option.
+  call term_sendkeys(buf, ":set ro | confirm w\n")
+  call WaitForAssert({-> assert_match("^'readonly' option is set for \"Xconfirm_write_ro\"\. *$",
+        \            term_getline(buf, 18))}, 1000)
+  call WaitForAssert({-> assert_match('^Do you wish to write anyway? *$',
+        \            term_getline(buf, 19))}, 1000)
+  call WaitForAssert({-> assert_match('^(Y)es, \[N\]o: *$', term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, 'N')
+  call WaitForAssert({-> assert_match('^ *$', term_getline(buf, 19))}, 1000)
+  call WaitForAssert({-> assert_match('.* All$', term_getline(buf, 20))}, 1000)
+  call assert_equal(['foo'], readfile('Xconfirm_write_ro'))
+
+  call term_sendkeys(buf, ":confirm w\n")
+  call WaitForAssert({-> assert_match("^'readonly' option is set for \"Xconfirm_write_ro\"\. *$",
+        \            term_getline(buf, 18))}, 1000)
+  call WaitForAssert({-> assert_match('^Do you wish to write anyway? *$',
+        \            term_getline(buf, 19))}, 1000)
+  call WaitForAssert({-> assert_match('^(Y)es, \[N\]o: *$', term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, 'Y')
+  call WaitForAssert({-> assert_match('^"Xconfirm_write_ro" 1L, 7B written$',
+        \            term_getline(buf, 19))}, 1000)
+  call assert_equal(['foobar'], readfile('Xconfirm_write_ro'))
+
+  " Try to write with read-only file permissions.
+  call setfperm('Xconfirm_write_ro', 'r--r--r--')
+  call term_sendkeys(buf, ":set noro | undo | confirm w\n")
+  call WaitForAssert({-> assert_match("^File permissions of \"Xconfirm_write_ro\" are read-only\. *$",
+        \            term_getline(buf, 17))}, 1000)
+  call WaitForAssert({-> assert_match('^It may still be possible to write it\. *$',
+        \            term_getline(buf, 18))}, 1000)
+  call WaitForAssert({-> assert_match('^Do you wish to try? *$', term_getline(buf, 19))}, 1000)
+  call WaitForAssert({-> assert_match('^(Y)es, \[N\]o: *$', term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, 'Y')
+  call WaitForAssert({-> assert_match('^"Xconfirm_write_ro" 1L, 4B written$',
+        \            term_getline(buf, 19))}, 1000)
+  call assert_equal(['foo'], readfile('Xconfirm_write_ro'))
+
+  call StopVimInTerminal(buf)
+  call delete('Xscript')
+  call delete('Xconfirm_write_ro')
+endfunc
+
 " Test for the :print command
 func Test_print_cmd()
   call assert_fails('print', 'E749:')


### PR DESCRIPTION
Some lines in `checkreadonly()` for `:confirm w` were not covered with tests.
See:
https://codecov.io/gh/vim/vim/src/4a22897591dc8ff64560bef693af49f171faf557/src/ex_cmds.c#L2323