### PR TITLE
Miscellaneous code coverage improvement

### DIFF
--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -591,4 +591,10 @@ func Test_sandbox()
   sandbox call Sandbox_tests()
 endfunc
 
+func Test_command_not_implemented_E319()
+  if !has('mzscheme')
+    call assert_fails('mzscheme', 'E319:')
+  endif
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1148,7 +1148,9 @@ func Test_charidx()
   call assert_equal(2, charidx(a, 4))
   call assert_equal(3, charidx(a, 7))
   call assert_equal(-1, charidx(a, 8))
+  call assert_equal(-1, charidx(a, -1))
   call assert_equal(-1, charidx('', 0))
+  call assert_equal(-1, charidx(test_null_string(), 0))
 
   " count composing characters
   call assert_equal(0, charidx(a, 0, 1))

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1093,4 +1093,32 @@ func Test_opt_reset_scroll()
   call delete('Xscroll')
 endfunc
 
+" Check that VIM_POSIX env variable influences default value of 'cpo' and 'shm'
+func Test_VIM_POSIX()
+  let saved_VIM_POSIX = getenv("VIM_POSIX")
+
+  call setenv('VIM_POSIX', "1")
+  let after =<< trim [CODE]
+    call writefile([&cpo, &shm], 'X_VIM_POSIX')
+    qall
+  [CODE]
+  if RunVim([], after, '')
+    call assert_equal(['aAbBcCdDeEfFgHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>#{|&/\.;',
+          \            'AS'], readfile('X_VIM_POSIX'))
+  endif
+
+  call setenv('VIM_POSIX', v:null)
+  let after =<< trim [CODE]
+    call writefile([&cpo, &shm], 'X_VIM_POSIX')
+    qall
+  [CODE]
+  if RunVim([], after, '')
+    call assert_equal(['aAbBcCdDeEfFgHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>;',
+          \            'S'], readfile('X_VIM_POSIX'))
+  endif
+
+  call delete('X_VIM_POSIX')
+  call setenv('VIM_POSIX', saved_VIM_POSIX)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -622,6 +622,12 @@ func Test_invalid_args()
   endfor
 
   if has('gui_gtk')
+    let out = split(system(GetVimCommand() .. ' --socketid'), "\n")
+    call assert_equal(1, v:shell_error)
+    call assert_match('^VIM - Vi IMproved .* (.*)$',          out[0])
+    call assert_equal('Argument missing after: "--socketid"', out[1])
+    call assert_equal('More info with: "vim -h"',             out[2])
+
     for opt in ['--socketid x', '--socketid 0xg']
       let out = split(system(GetVimCommand() .. ' ' .. opt), "\n")
       call assert_equal(1, v:shell_error)
@@ -629,6 +635,7 @@ func Test_invalid_args()
       call assert_equal('Invalid argument for: "--socketid"', out[1])
       call assert_equal('More info with: "vim -h"',           out[2])
     endfor
+
   endif
 endfunc
 

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -111,6 +111,9 @@ func Test_syntime()
   let a = execute('syntime report')
   call assert_equal("\nNo Syntax items defined for this buffer", a)
 
+  let a = execute('syntime clear')
+  call assert_equal("\nNo Syntax items defined for this buffer", a)
+
   view ../memfile_test.c
   setfiletype cpp
   redraw

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -13,6 +13,7 @@ def Test_vim9cmd()
     vim9cm assert_equal('yes', y)
   END
   CheckScriptSuccess(lines)
+  assert_fails('vim9cmd', 'E1164:')
 enddef
 
 def Test_edit_wildcards()


### PR DESCRIPTION
Each improvement only improves code coverage by 1 or a few lines of code:

- test effect of environment variable `VIM_POSIX`
- test E319  (command not available)
- improve test coverage for `charidx()`
- test `syntime clear` with no syntax items
- test `vim9cmd` with no argument
- test `--socketid` with no argument