### PR TITLE
Help for :* should point at the 'nocompatible' behavior of it.

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -799,17 +799,17 @@ three lines: >
 <
 
 Visual Mode and Range					*v_:*
-							*:star-visual-range*
 {Visual}:	Starts a command-line with the Visual selected lines as a
 		range.  The code `:'<,'>` is used for this range, which makes
 		it possible to select a similar line from the command-line
 		history for repeating a command on different Visually selected
 		lines.
+
+:*						*:star* *:star-visual-range*
 		When Visual mode was already ended, a short way to use the
 		Visual area for a range is `:*`.  This requires that "*" does
 		not appear in 'cpo', see |cpo-star|.  Otherwise you will have
 		to type `:'<,'>`
-
 
 ==============================================================================
 5. Ex command-line flags				*ex-flags*

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -150,15 +150,12 @@ q			Stops recording.  (Implementation note: The 'q' that
 							*@@* *E748*
 @@			Repeat the previous @{0-9a-z":*} [count] times.
 
-:[addr]*{0-9a-z".=+}						*:@* *:star*
-:[addr]@{0-9a-z".=*+}	Execute the contents of register {0-9a-z".=*+} as an Ex
+:[addr]@{0-9a-z".=*+}						*:@*
+			Execute the contents of register {0-9a-z".=*+} as an Ex
 			command.  First set cursor at line [addr] (default is
 			current line).  When the last line in the register does
 			not have a <CR> it will be added automatically when
 			the 'e' flag is present in 'cpoptions'.
-			Note that the ":*" command is only recognized when the
-			'*' flag is present in 'cpoptions'.  This is NOT the
-			default when 'nocompatible' is used.
 			For ":@=" the last used expression is used.  The
 			result of evaluating the expression is executed as an
 			Ex command.
@@ -178,6 +175,13 @@ q			Stops recording.  (Implementation note: The 'q' that
 :[addr]@							*:@@*
 :[addr]@@		Repeat the previous :@{register}.  First set cursor at
 			line [addr] (default is current line).
+
+:[addr]*{0-9a-z".=+}					*:star-compatible*
+			When '*' is present in 'cpoptions' |cpo-star|, use
+			":*" in the same way as ":@".  This is NOT the default
+			when 'nocompatible' is used.  When the '*' flag is not
+			present in 'cpoptions', ":*" is an alias for ":'<,'>",
+			select the Visual area |:star|.
 
 ==============================================================================
 4. Using Vim scripts					*using-scripts*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -3184,7 +3184,8 @@ $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 :st	starting.txt	/*:st*
 :sta	windows.txt	/*:sta*
 :stag	windows.txt	/*:stag*
-:star	repeat.txt	/*:star*
+:star	cmdline.txt	/*:star*
+:star-compatible	repeat.txt	/*:star-compatible*
 :star-visual-range	cmdline.txt	/*:star-visual-range*
 :start	insert.txt	/*:start*
 :startgreplace	insert.txt	/*:startgreplace*
@@ -7205,7 +7206,6 @@ help	helphelp.txt	/*help*
 help-context	help.txt	/*help-context*
 help-curwin	tips.txt	/*help-curwin*
 help-summary	usr_02.txt	/*help-summary*
-help-tags	tags	1
 help-translated	helphelp.txt	/*help-translated*
 help-writing	helphelp.txt	/*help-writing*
 help-xterm-window	helphelp.txt	/*help-xterm-window*


### PR DESCRIPTION
Help for `:*` should point at the `'nocompatible'` behavior of it.

Currently it documents the synonym for `:@`, which only works when `*` is present in `&cpoptions` (which is typically not the case.) The actual behavior of `:*` is documented as a small note under [`:help :star-visual-range`](https://vimhelp.org/cmdline.txt.html#:star-visual-range), which is not really a very obvious place to look for it...
