### PR TITLE
Evaluate results of %{%expr%} blocks in statusline

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7339,6 +7339,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	      Note that there is no '%' before the closing '}'.  The
 	      expression cannot contain a '}' character, call a function to
 	      work around that.  See |stl-%{| below.
+	[ NF  Same as `%{expr}` except the result of expr is also evaluated
+	      as normal statusline string. So result of expr can contain
+	      % items. Even %[] blocks can be returned by exp which will then
+	      be evaluated . Though note they are only evaluated upto
+	      lavel 100 depth.
 	( -   Start of item group.  Can be used for setting the width and
 	      alignment of a section.  Must be followed by %) somewhere.
 	) -   End of item group.  No width fields allowed.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7340,7 +7340,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	      expression cannot contain a '}' character, call a function to
 	      work around that.  See |stl-%{| below. The result of expression
 	      doesn't get evaluated by default. But if the expression is 
-	      presided by ':' then the result of expression will be evaluated
+	      presided by '%' then the result of expression will be evaluated
 	      regular statusline format string. Means the return value of
 	      expr can contain % items. For example:
 >
@@ -7349,7 +7349,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		endf
 <
 	      `stl=%{Stl_filename()}`  displayed as `"%t"`
-	      `stl=%{:Stl_filename()}` displayed as  `"Name of current file"`
+	      `stl=%{%Stl_filename()}` displayed as  `"Name of current file"`
 		  
 	( -   Start of item group.  Can be used for setting the width and
 	      alignment of a section.  Must be followed by %) somewhere.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7338,19 +7338,21 @@ A jump table for the options with a short description can be found at |Q_op|.
 	{ NF  Evaluate expression between '%{' and '}' and substitute result.
 	      Note that there is no '%' before the closing '}'.  The
 	      expression cannot contain a '}' character, call a function to
-	      work around that.  See |stl-%{| below. The result of expression
-	      doesn't get evaluated by default. But if the expression is 
-	      presided by '%' then the result of expression will be evaluated
-	      regular statusline format string. Means the return value of
-	      expr can contain % items. For example:
+	      work around that.  See |stl-%{| below.
+	{% -  This is almost same as { except the result of expression is
+	      evaluated as regular statusline format string. Means the 
+	      return value of expr can contain % items. Note in this case
+	      the expression can contain `}` as the end of expression is
+	      denoted by `%}`
+	      The For example:
 >
 		func! Stl_filename() abort
 		    return "%t"
 		endf
 <
-	      `stl=%{Stl_filename()}`  displayed as `"%t"`
-	      `stl=%{%Stl_filename()}` displayed as  `"Name of current file"`
-		  
+	      `stl=%{Stl_filename()}`   is displayed as `"%t"`
+	      `stl=%{%Stl_filename()%}` is displayed as  `"Name of current file"`
+	} -   End of `{%` expression
 	( -   Start of item group.  Can be used for setting the width and
 	      alignment of a section.  Must be followed by %) somewhere.
 	) -   End of item group.  No width fields allowed.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7338,12 +7338,19 @@ A jump table for the options with a short description can be found at |Q_op|.
 	{ NF  Evaluate expression between '%{' and '}' and substitute result.
 	      Note that there is no '%' before the closing '}'.  The
 	      expression cannot contain a '}' character, call a function to
-	      work around that.  See |stl-%{| below.
-	[ NF  Same as `%{expr}` except the result of expr is also evaluated
-	      as normal statusline string. So result of expr can contain
-	      % items. Even %[] blocks can be returned by exp which will then
-	      be evaluated . Though note they are only evaluated upto
-	      lavel 100 depth.
+	      work around that.  See |stl-%{| below. The result of expression
+	      doesn't get evaluated by default. But if the expression is 
+	      presided by ':' then the result of expression will be evaluated
+	      regular statusline format string. Means the return value of
+	      expr can contain % items. For example:
+>
+		func! Stl_filename() abort
+		    return "%t"
+		endf
+<
+	      `stl=%{Stl_filename()}`  displayed as `"%t"`
+	      `stl=%{:Stl_filename()}` displayed as  `"Name of current file"`
+		  
 	( -   Start of item group.  Can be used for setting the width and
 	      alignment of a section.  Must be followed by %) somewhere.
 	) -   End of item group.  No width fields allowed.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4550,7 +4550,7 @@ build_stl_str_hl(
 	    }
 
 	    // If the output of the expression needs to be evaluated
-	    // replace the %{} block with the result of evaluation
+	    // replace the %[] block with the result of evaluation
 	    if (opt == STL_VIM_EVAL_EXPR &&str != NULL && *str != 0 
 		&& strchr((const char *)str, '%') != NULL
 		&& evaldepth < MAX_STL_EVAL_DEPTH) {
@@ -4559,13 +4559,15 @@ build_stl_str_hl(
 		size_t fmt_length = strlen((const char *)s);
 
 		size_t new_fmt_len = parsed_usefmt + str_length + fmt_length + 3;
-		char_u * new_fmt = (char_u *)alloc(new_fmt_len * sizeof(char_u));
+		char_u *new_fmt = (char_u *)alloc(new_fmt_len * sizeof(char_u));
 
-		memcpy(new_fmt, usefmt, parsed_usefmt);
-		memcpy(new_fmt + parsed_usefmt, str, str_length);
-		memcpy(new_fmt + parsed_usefmt + str_length, "%]", 2);
-		memcpy(new_fmt + parsed_usefmt + str_length + 2, s, fmt_length);
-		new_fmt[new_fmt_len - 1] = 0;
+		char_u *p = new_fmt;
+		p = memcpy(p, usefmt, parsed_usefmt) + parsed_usefmt;
+		p = memcpy(p , str, str_length) + str_length;
+		p = memcpy(p, "%]", 2) + 2;
+		p = memcpy(p , s, fmt_length) + fmt_length;
+		*p = 0;
+		p = NULL;
 
 		if (usefmt != fmt) {
 		    vim_free(usefmt);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4568,10 +4568,13 @@ build_stl_str_hl(
 		char_u *new_fmt = (char_u *)alloc(new_fmt_len * sizeof(char_u));
 
 		char_u *new_fmt_p = new_fmt;
-		new_fmt_p = memcpy(new_fmt_p, usefmt, parsed_usefmt) + parsed_usefmt;
-		new_fmt_p = memcpy(new_fmt_p , str, str_length) + str_length;
-		new_fmt_p = memcpy(new_fmt_p, "%}", 2) + 2;
-		new_fmt_p = memcpy(new_fmt_p , s, fmt_length) + fmt_length;
+		new_fmt_p = (char_u *)memcpy(new_fmt_p, usefmt, parsed_usefmt)
+			      + parsed_usefmt;
+		new_fmt_p = (char_u *)memcpy(new_fmt_p , str, str_length)
+			      + str_length;
+		new_fmt_p = (char_u *)memcpy(new_fmt_p, "%}", 2) + 2;
+		new_fmt_p = (char_u *)memcpy(new_fmt_p , s, fmt_length)
+			      + fmt_length;
 		*new_fmt_p = 0;
 		new_fmt_p = NULL;
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4120,6 +4120,9 @@ build_stl_str_hl(
     int		group_end_userhl;
     int		group_start_userhl;
     int		groupdepth;
+#ifdef FEAT_EVAL
+    int		evaldepth;
+#endif
     int		minwid;
     int		maxwid;
     int		zeropad;
@@ -4195,7 +4198,7 @@ build_stl_str_hl(
 
     groupdepth = 0;
 #ifdef FEAT_EVAL
-    int evaldepth = 0;
+    evaldepth = 0;
 #endif
     p = out;
     curitem = 0;
@@ -4500,12 +4503,13 @@ build_stl_str_hl(
 	    break;
 
 	case STL_VIM_EXPR: // '{'
-	    itemisflag = TRUE;
-	    t = p;
+	{
 #ifdef FEAT_EVAL
 	    char_u *block_start = s - 1;
 #endif
 	    int evaluate = (*s == '%') ? TRUE : FALSE;
+	    itemisflag = TRUE;
+	    t = p;
 	    if (evaluate) {
 		s++;
 	    }
@@ -4589,7 +4593,7 @@ build_stl_str_hl(
 	    }
 #endif
 	    break;
-
+	}
 	case STL_LINE:
 	    num = (wp->w_buffer->b_ml.ml_flags & ML_EMPTY)
 		  ? 0L : (long)(wp->w_cursor.lnum);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4515,7 +4515,7 @@ build_stl_str_hl(
 	    p = t;
 
 #ifdef FEAT_EVAL
-	    if (*p == ':') {
+	    if (*p == '%') {
 		evaluate = TRUE;
 		p++;
 	    }

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4458,8 +4458,8 @@ build_stl_str_hl(
 	    continue;
 	}
 #ifdef FEAT_EVAL
-	// Denotes end of expanded %{} block
-	if (*s == '}' && evaldepth > 0) {
+	// Denotes end of expanded %[] block
+	if (*s == ']' && evaldepth > 0) {
 	    s++;
 	    evaldepth--;
 	    continue;
@@ -4500,14 +4500,16 @@ build_stl_str_hl(
 	    break;
 
 	case STL_VIM_EXPR: // '{'
+	case STL_VIM_EVAL_EXPR: // '['
 	    itemisflag = TRUE;
 	    t = p;
 #ifdef FEAT_EVAL
 	    char_u *block_start = s;
 #endif
-	    while (*s != '}' && *s != NUL && p + 1 < out + outlen)
+	    char_u end_symbol = (opt == STL_VIM_EXPR) ? '}' : ']' ;
+	    while (*s != end_symbol && *s != NUL && p + 1 < out + outlen)
 		*p++ = *s++;
-	    if (*s != '}')	// missing '}' or out of space
+	    if (*s != end_symbol)	// missing end_symbol or out of space
 		break;
 	    s++;
 	    *p = 0;
@@ -4549,8 +4551,9 @@ build_stl_str_hl(
 
 	    // If the output of the expression needs to be evaluated
 	    // replace the %{} block with the result of evaluation
-	    if (str != NULL && *str != 0 && strchr((const char *)str, '%') != NULL &&
-		    evaldepth < MAX_STL_EVAL_DEPTH) {
+	    if (opt == STL_VIM_EVAL_EXPR &&str != NULL && *str != 0 
+		&& strchr((const char *)str, '%') != NULL
+		&& evaldepth < MAX_STL_EVAL_DEPTH) {
 		size_t parsed_usefmt = (size_t)(block_start - usefmt - 1);
 		size_t str_length = strlen((const char *)str);
 		size_t fmt_length = strlen((const char *)s);
@@ -4560,7 +4563,7 @@ build_stl_str_hl(
 
 		memcpy(new_fmt, usefmt, parsed_usefmt);
 		memcpy(new_fmt + parsed_usefmt, str, str_length);
-		memcpy(new_fmt + parsed_usefmt + str_length, "%}", 2);
+		memcpy(new_fmt + parsed_usefmt + str_length, "%]", 2);
 		memcpy(new_fmt + parsed_usefmt + str_length + 2, s, fmt_length);
 		new_fmt[new_fmt_len - 1] = 0;
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4462,7 +4462,8 @@ build_stl_str_hl(
 	}
 #ifdef FEAT_EVAL
 	// Denotes end of expanded %{} block
-	if (*s == '}' && evaldepth > 0) {
+	if (*s == '}' && evaldepth > 0)
+	{
 	    s++;
 	    evaldepth--;
 	    continue;
@@ -4508,22 +4509,21 @@ build_stl_str_hl(
 	    char_u *block_start = s - 1;
 #endif
 	    int evaluate = (*s == '%') ? TRUE : FALSE;
+
 	    itemisflag = TRUE;
 	    t = p;
-	    if (evaluate) {
+	    if (evaluate)
 		s++;
-	    }
 	    while ((*s != '}' || (evaluate && *(s-1) != '%'))
 		   && *s != NUL && p + 1 < out + outlen)
 		*p++ = *s++;
 	    if (*s != '}')	// missing '}' or out of space
 		break;
 	    s++;
-	    if (evaluate) {
-		*(p-1) = 0;
-	    } else {
+	    if (evaluate) // When evaluate is true expr contains % at end.
+		*(p-1) = 0; // Remove that
+	    else
 		*p = 0;
-	    }
 	    p = t;
 #ifdef FEAT_EVAL
 	    vim_snprintf((char *)buf_tmp, sizeof(buf_tmp),
@@ -4563,15 +4563,15 @@ build_stl_str_hl(
 	    // replace the %{} block with the result of evaluation
 	    if (evaluate && str != NULL && *str != 0 
 		&& strchr((const char *)str, '%') != NULL
-		&& evaldepth < MAX_STL_EVAL_DEPTH) {
+		&& evaldepth < MAX_STL_EVAL_DEPTH)
+	    {
 		size_t parsed_usefmt = (size_t)(block_start - usefmt);
 		size_t str_length = strlen((const char *)str);
 		size_t fmt_length = strlen((const char *)s);
-
 		size_t new_fmt_len = parsed_usefmt + str_length + fmt_length + 3;
 		char_u *new_fmt = (char_u *)alloc(new_fmt_len * sizeof(char_u));
-
 		char_u *new_fmt_p = new_fmt;
+
 		new_fmt_p = (char_u *)memcpy(new_fmt_p, usefmt, parsed_usefmt)
 			      + parsed_usefmt;
 		new_fmt_p = (char_u *)memcpy(new_fmt_p , str, str_length)
@@ -4582,9 +4582,8 @@ build_stl_str_hl(
 		*new_fmt_p = 0;
 		new_fmt_p = NULL;
 
-		if (usefmt != fmt) {
+		if (usefmt != fmt)
 		    vim_free(usefmt);
-		}
 		VIM_CLEAR(str);
 		usefmt = new_fmt;
 		s = usefmt + parsed_usefmt;

--- a/src/option.h
+++ b/src/option.h
@@ -341,13 +341,14 @@ typedef enum {
 #define STL_ARGLISTSTAT	'a'		// argument list status as (x of y)
 #define STL_PAGENUM	'N'		// page number (when printing)
 #define STL_VIM_EXPR	'{'		// start of expression to substitute
+#define STL_VIM_EVAL_EXPR '['		// start of recursivly evaluated expression to substitute
 #define STL_MIDDLEMARK	'='		// separation between left and right
 #define STL_TRUNCMARK	'<'		// truncation mark if line is too long
 #define STL_USER_HL	'*'		// highlight from (User)1..9 or 0
 #define STL_HIGHLIGHT	'#'		// highlight name
 #define STL_TABPAGENR	'T'		// tab page label nr
 #define STL_TABCLOSENR	'X'		// tab page close nr
-#define STL_ALL		((char_u *) "fFtcvVlLknoObBrRhHmYyWwMqpPaN{#")
+#define STL_ALL		((char_u *) "fFtcvVlLknoObBrRhHmYyWwMqpPaN{[#")
 
 // flags used for parsed 'wildmode'
 #define WIM_FULL	0x01

--- a/src/option.h
+++ b/src/option.h
@@ -341,14 +341,13 @@ typedef enum {
 #define STL_ARGLISTSTAT	'a'		// argument list status as (x of y)
 #define STL_PAGENUM	'N'		// page number (when printing)
 #define STL_VIM_EXPR	'{'		// start of expression to substitute
-#define STL_VIM_EVAL_EXPR '['		// start of recursivly evaluated expression to substitute
 #define STL_MIDDLEMARK	'='		// separation between left and right
 #define STL_TRUNCMARK	'<'		// truncation mark if line is too long
 #define STL_USER_HL	'*'		// highlight from (User)1..9 or 0
 #define STL_HIGHLIGHT	'#'		// highlight name
 #define STL_TABPAGENR	'T'		// tab page label nr
 #define STL_TABCLOSENR	'X'		// tab page close nr
-#define STL_ALL		((char_u *) "fFtcvVlLknoObBrRhHmYyWwMqpPaN{[#")
+#define STL_ALL		((char_u *) "fFtcvVlLknoObBrRhHmYyWwMqpPaN{#")
 
 // flags used for parsed 'wildmode'
 #define WIM_FULL	0x01

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -618,8 +618,8 @@ check_stl_option(char_u *s)
 	}
 	if (*s == '{')
 	{
-	    s++;
 	    int evaluate = (*(s) == '%');
+	    s++;
 	    while ((*s != '}' || (evaluate && *(s-1) != '%')) && *s)
 		s++;
 	    if (*s != '}')

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -619,7 +619,8 @@ check_stl_option(char_u *s)
 	if (*s == '{')
 	{
 	    s++;
-	    while (*s != '}' && *s)
+	    int evaluate = (*(s) == '%');
+	    while ((*s != '}' || (evaluate && *(s-1) != '%')) && *s)
 		s++;
 	    if (*s != '}')
 		return N_("E540: Unclosed expression sequence");

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -256,9 +256,9 @@ func Test_statusline()
     return '%n some other text'
   endfunc
   func! Outer_eval()
-    return 'some text %{%Inner_eval()}'
+    return 'some text %{%Inner_eval()%}'
   endfunc
-  set statusline=%{%Outer_eval()}
+  set statusline=%{%Outer_eval()%}
   call assert_match('^some text ' . bufnr() . ' some other text\s*$', s:get_statusline())
   delfunc Inner_eval
   delfunc Outer_eval

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -256,9 +256,9 @@ func Test_statusline()
     return '%n some other text'
   endfunc
   func! Outer_eval()
-    return 'some text %[Inner_eval()]'
+    return 'some text %{:Inner_eval()}'
   endfunc
-  set statusline=%[Outer_eval()]
+  set statusline=%{:Outer_eval()}
   call assert_match('^some text ' . bufnr() . ' some other text\s*$', s:get_statusline())
   delfunc Inner_eval
   delfunc Outer_eval

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -251,7 +251,7 @@ func Test_statusline()
   call assert_match('^vimLineComment\s*$', s:get_statusline())
   syntax off
 
-  "%{: evaluates enxpressions present in result of %{} expression
+  "%{%expr%}: evaluates enxpressions present in result of expr
   func! Inner_eval()
     return '%n some other text'
   endfunc
@@ -262,6 +262,14 @@ func Test_statusline()
   call assert_match('^some text ' . bufnr() . ' some other text\s*$', s:get_statusline())
   delfunc Inner_eval
   delfunc Outer_eval
+
+  "%{%expr%}: Doesn't get stuck for recursion
+  func! Recurse_eval()
+    return '%{%Recurse_eval()%}'
+  endfunc
+  set statusline=%{%Recurse_eval()%}
+  call assert_match('^%{%Recurse_eval()%}\s*$', s:get_statusline())
+  delfunc Recurse_eval
 
   "%(: Start of item group.
   set statusline=ab%(cd%q%)de

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -251,6 +251,18 @@ func Test_statusline()
   call assert_match('^vimLineComment\s*$', s:get_statusline())
   syntax off
 
+  "%{: evaluates enxpressions present in result of %{} expression
+  func! Inner_eval()
+    return '%n some other text'
+  endfunc
+  func! Outer_eval()
+    return 'some text %{Inner_eval()}'
+  endfunc
+  set statusline=%{Outer_eval()}
+  call assert_match('^some text ' . bufnr() . ' some other text\s*$', s:get_statusline())
+  delfunc Inner_eval
+  delfunc Outer_eval
+
   "%(: Start of item group.
   set statusline=ab%(cd%q%)de
   call assert_match('^abde\s*$', s:get_statusline())

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -256,9 +256,9 @@ func Test_statusline()
     return '%n some other text'
   endfunc
   func! Outer_eval()
-    return 'some text %{:Inner_eval()}'
+    return 'some text %{%Inner_eval()}'
   endfunc
-  set statusline=%{:Outer_eval()}
+  set statusline=%{%Outer_eval()}
   call assert_match('^some text ' . bufnr() . ' some other text\s*$', s:get_statusline())
   delfunc Inner_eval
   delfunc Outer_eval

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -256,9 +256,9 @@ func Test_statusline()
     return '%n some other text'
   endfunc
   func! Outer_eval()
-    return 'some text %{Inner_eval()}'
+    return 'some text %[Inner_eval()]'
   endfunc
-  set statusline=%{Outer_eval()}
+  set statusline=%[Outer_eval()]
   call assert_match('^some text ' . bufnr() . ' some other text\s*$', s:get_statusline())
   delfunc Inner_eval
   delfunc Outer_eval


### PR DESCRIPTION
Currently results of %{} blocks gets directly displayed in statusline.
Because of results of %{} blocks cann't contain expressions like
%#highlight# or %f etc . This pr changes that .

The idea is simple it just replaces the %{} block with it's result and continue evaluating.

Without the patch
![Screenshot_without](https://user-images.githubusercontent.com/13149513/117556125-6070a280-b087-11eb-944d-3913aa042db6.png)

With the patch
![Screenshot_with](https://user-images.githubusercontent.com/13149513/117556121-551d7700-b087-11eb-8dba-5ac7dbdf8c78.png)


Edit:
The idea has changed. Current plan is to evaluate %{} blocks only when expr starts with a '%' to remain backword compatable. So format will be %{%expr%}