### PR TITLE
Add single quote to `iskeyword`

### DIFF
--- a/runtime/ftplugin/haskell.vim
+++ b/runtime/ftplugin/haskell.vim
@@ -17,6 +17,7 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 setlocal comments=s1fl:{-,mb:-,ex:-},:-- commentstring=--\ %s
 setlocal formatoptions-=t formatoptions+=croql
 setlocal omnifunc=haskellcomplete#Complete
+setlocal iskeyword+='
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
The single quote `'` is a valid character in variable names, so it should be included in `iskeyword`; this change, for instance, makes the <kbd>*</kbd> command behave predictably, which is good.