### PR TITLE
Add SystemVerilog keywords for matchit plugin

### DIFF
--- a/runtime/ftplugin/systemverilog.vim
+++ b/runtime/ftplugin/systemverilog.vim
@@ -23,7 +23,7 @@ if exists("loaded_matchit")
     \ '\<specify\>:\<endspecify\>,' .
     \ '\<config\>:\<endconfig\>,' .
     \ '\<generate\>:\<endgenerate\>,' .
-    \ '\<fork\>:\<join\>,' .
+    \ '\<fork\>:\<join\>\|\<join_any\>\|\<join_none\>,' .
     \ '\<primitive\>:\<endprimitive\>,' .
     \ '\<table\>:\<endtable\>,' .
     \ '\<checker\>:\<endchecker\>,' .

--- a/runtime/ftplugin/systemverilog.vim
+++ b/runtime/ftplugin/systemverilog.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:    SystemVerilog
 " Maintainer:  kocha <kocha.lsifrontend@gmail.com>
-" Last Change: 12-Aug-2013. 
+" Last Change: 07-May-2021
 
 if exists("b:did_ftplugin")
   finish
@@ -9,3 +9,30 @@ endif
 
 " Behaves just like Verilog
 runtime! ftplugin/verilog.vim
+
+" Add SystemVerilog keywords for matchit plugin.
+if exists("loaded_matchit")
+  let b:match_words =
+    \ '\<begin\>:\<end\>,' .
+    \ '\<case\>\|\<casex\>\|\<casez\>:\<endcase\>,' .
+    \ '\<module\>:\<endmodule\>,' .
+    \ '\<if\>:`\@<!\<else\>,' .
+    \ '\<function\>:\<endfunction\>,' .
+    \ '`ifn\?def\>:`elsif\>:`else\>:`endif\>,' .
+    \ '\<task\>:\<endtask\>,' .
+    \ '\<specify\>:\<endspecify\>,' .
+    \ '\<config\>:\<endconfig\>,' .
+    \ '\<generate\>:\<endgenerate\>,' .
+    \ '\<fork\>:\<join\>,' .
+    \ '\<primitive\>:\<endprimitive\>,' .
+    \ '\<table\>:\<endtable\>,' .
+    \ '\<checker\>:\<endchecker\>,' .
+    \ '\<class\>:\<endclass\>,' .
+    \ '\<clocking\>:\<endclocking\>,' .
+    \ '\<gruop\>:\<endgruop\>,' .
+    \ '\<interface\>:\<endinterface\>,' .
+    \ '\<package\>:\<endpackage\>,' .
+    \ '\<program\>:\<endprogram\>,' .
+    \ '\<property\>:\<endproperty\>,' .
+    \ '\<sequence\>:\<endsequence\>'
+endif


### PR DESCRIPTION
Vim's matchit plugin cannot match some SystemVerilog keywords like class/endclass due to missing config. This PR aims to support it.