### PR TITLE
Allow unified diffs

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -1007,10 +1007,12 @@ check_external_diff(diffio_T *diffio)
 
 		    for (;;)
 		    {
-			// There must be a line that contains "1c1".
+			// There must be a line that contains "1c1" when doing a regular
+			// diff, or "@@ -1 +1 @@" when doing a unified one.
 			if (vim_fgets(linebuf, LBUFLEN, fd))
 			    break;
-			if (STRNCMP(linebuf, "1c1", 3) == 0)
+			if (STRNCMP(linebuf, "1c1", 3) == 0
+			    || STRNCMP(linebuf, "@@ -1 +1 @@", 11) == 0)
 			    ok = TRUE;
 		    }
 		    fclose(fd);

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -1196,4 +1196,24 @@ func Test_diff_filler_cursorcolumn()
   call delete('Xtest_diff_cuc')
 endfunc
 
+func Test_external_universal_diffs()
+  function Test_external_universal_diff()
+    silent execute '!diff  -u ' . v:fname_in . ' ' . v:fname_new . ' > ' . v:fname_out
+  endfunction
+  let l:diffexpr=&diffexpr
+  set diffexpr=Test_external_universal_diff()
+
+  call setline(1, 'a')
+  diffthis
+  vnew
+  call setline(2, 'a')
+  diffthis
+
+  call assert_equal(1, &diff)
+
+  execute('set diffexpr=' . l:diffexpr)
+  bwipe!
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: When setting diffexpr to an expression that calls `diff -u`,
         and then using `diffthis`, vim emits an error.
Solution: Check for unified diff pattern when checking whether diffexpr
          works.
Corresponding neovim pull request: https://github.com/neovim/neovim/pull/14530
