### PR TITLE
Fix --as-needed in LDFLAGS

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4519,7 +4519,9 @@ AC_MSG_CHECKING(linker --as-needed support)
 LINK_AS_NEEDED=
 # Check if linker supports --as-needed and --no-as-needed options
 if $CC -Wl,--help 2>/dev/null | grep as-needed > /dev/null; then
-  LDFLAGS=`echo "$LDFLAGS" | sed -e 's/ *-Wl,--as-needed//g' | sed -e 's/$/ -Wl,--as-needed/'`
+  if ! echo "$LDFLAGS" | grep -q -- '-Wl,[^[:space:]]*--as-needed'; then
+    LDFLAGS="$LDFLAGS -Wl,--as-needed"
+  fi
   LINK_AS_NEEDED=yes
 fi
 if test "$LINK_AS_NEEDED" = yes; then


### PR DESCRIPTION
Only append -Wl,--as-needed to LDFLAGS when it is not already there.
This solves the problem when LDFLAGS="-Wl,--as-needed,-O1,--sort-common"

fixes commit a6cc03101e30 (updated for version 7.3.1221)
fixes https://github.com/vim/vim/issues/8181