### PR TITLE
add cpp syntax highlight in devicetree files

### DIFF
--- a/runtime/syntax/dts.vim
+++ b/runtime/syntax/dts.vim
@@ -9,7 +9,7 @@ endif
 
 syntax region dtsComment        start="/\*"  end="\*/"
 syntax match  dtsReference      "&[[:alpha:][:digit:]_]\+"
-syntax region dtsBinaryProperty start="\[" end="\]" 
+syntax region dtsBinaryProperty start="\[" end="\]"
 syntax match  dtsStringProperty "\".*\""
 syntax match  dtsKeyword        "/.\{-1,\}/"
 syntax match  dtsLabel          "^[[:space:]]*[[:alpha:][:digit:]_]\+:"
@@ -26,5 +26,5 @@ hi def link dtsLabel            Label
 hi def link dtsNode             Structure
 hi def link dtsReference        Macro
 hi def link dtsComment          Comment
-hi def link dtsCommentInner     Comment 
+hi def link dtsCommentInner     Comment
 hi def link dtsCommentLine      Comment

--- a/runtime/syntax/dts.vim
+++ b/runtime/syntax/dts.vim
@@ -18,6 +18,38 @@ syntax region dtsCellProperty   start="<" end=">" contains=dtsReference,dtsBinar
 syntax region dtsCommentInner   start="/\*"  end="\*/"
 syntax match  dtsCommentLine    "//.*$"
 
+" Accept %: for # (C99)
+syn region	cPreCondit	start="^\s*\zs\(%:\|#\)\s*\(if\|ifdef\|ifndef\|elif\)\>" skip="\\$" end="$" keepend contains=cComment,cCommentL,cCppString,cCharacter,cCppParen,cParenError,cNumbers,cCommentError,cSpaceError
+syn match	cPreConditMatch	display "^\s*\zs\(%:\|#\)\s*\(else\|endif\)\>"
+if !exists("c_no_if0")
+  syn cluster	cCppOutInGroup	contains=cCppInIf,cCppInElse,cCppInElse2,cCppOutIf,cCppOutIf2,cCppOutElse,cCppInSkip,cCppOutSkip
+  syn region	cCppOutWrapper	start="^\s*\zs\(%:\|#\)\s*if\s\+0\+\s*\($\|//\|/\*\|&\)" end=".\@=\|$" contains=cCppOutIf,cCppOutElse,@NoSpell fold
+  syn region	cCppOutIf	contained start="0\+" matchgroup=cCppOutWrapper end="^\s*\(%:\|#\)\s*endif\>" contains=cCppOutIf2,cCppOutElse
+  if !exists("c_no_if0_fold")
+    syn region	cCppOutIf2	contained matchgroup=cCppOutWrapper start="0\+" end="^\s*\(%:\|#\)\s*\(else\>\|elif\s\+\(0\+\s*\($\|//\|/\*\|&\)\)\@!\|endif\>\)"me=s-1 contains=cSpaceError,cCppOutSkip,@Spell fold
+  else
+    syn region	cCppOutIf2	contained matchgroup=cCppOutWrapper start="0\+" end="^\s*\(%:\|#\)\s*\(else\>\|elif\s\+\(0\+\s*\($\|//\|/\*\|&\)\)\@!\|endif\>\)"me=s-1 contains=cSpaceError,cCppOutSkip,@Spell
+  endif
+  syn region	cCppOutElse	contained matchgroup=cCppOutWrapper start="^\s*\(%:\|#\)\s*\(else\|elif\)" end="^\s*\(%:\|#\)\s*endif\>"me=s-1 contains=TOP,cPreCondit
+  syn region	cCppInWrapper	start="^\s*\zs\(%:\|#\)\s*if\s\+0*[1-9]\d*\s*\($\|//\|/\*\||\)" end=".\@=\|$" contains=cCppInIf,cCppInElse fold
+  syn region	cCppInIf	contained matchgroup=cCppInWrapper start="\d\+" end="^\s*\(%:\|#\)\s*endif\>" contains=TOP,cPreCondit
+  if !exists("c_no_if0_fold")
+    syn region	cCppInElse	contained start="^\s*\(%:\|#\)\s*\(else\>\|elif\s\+\(0*[1-9]\d*\s*\($\|//\|/\*\||\)\)\@!\)" end=".\@=\|$" containedin=cCppInIf contains=cCppInElse2 fold
+  else
+    syn region	cCppInElse	contained start="^\s*\(%:\|#\)\s*\(else\>\|elif\s\+\(0*[1-9]\d*\s*\($\|//\|/\*\||\)\)\@!\)" end=".\@=\|$" containedin=cCppInIf contains=cCppInElse2
+  endif
+  syn region	cCppInElse2	contained matchgroup=cCppInWrapper start="^\s*\(%:\|#\)\s*\(else\|elif\)\([^/]\|/[^/*]\)*" end="^\s*\(%:\|#\)\s*endif\>"me=s-1 contains=cSpaceError,cCppOutSkip,@Spell
+  syn region	cCppOutSkip	contained start="^\s*\(%:\|#\)\s*\(if\>\|ifdef\>\|ifndef\>\)" skip="\\$" end="^\s*\(%:\|#\)\s*endif\>" contains=cSpaceError,cCppOutSkip
+  syn region	cCppInSkip	contained matchgroup=cCppInWrapper start="^\s*\(%:\|#\)\s*\(if\s\+\(\d\+\s*\($\|//\|/\*\||\|&\)\)\@!\|ifdef\>\|ifndef\>\)" skip="\\$" end="^\s*\(%:\|#\)\s*endif\>" containedin=cCppOutElse,cCppInIf,cCppInSkip contains=TOP,cPreProc
+endif
+syn region	cIncluded	display contained start=+"+ skip=+\\\\\|\\"+ end=+"+
+syn match	cIncluded	display contained "<[^>]*>"
+syn match	cInclude	display "^\s*\zs\(%:\|#\)\s*include\>\s*["<]" contains=cIncluded
+"syn match cLineSkip	"\\$"
+syn cluster	cPreProcGroup	contains=cPreCondit,cIncluded,cInclude,cDefine,cErrInParen,cErrInBracket,cUserLabel,cSpecial,cOctalZero,cCppOutWrapper,cCppInWrapper,@cCppOutInGroup,cFormat,cNumber,cFloat,cOctal,cOctalError,cNumbersCom,cString,cCommentSkip,cCommentString,cComment2String,@cCommentGroup,cCommentStartError,cParen,cBracket,cMulti,cBadBlock
+syn region	cDefine		start="^\s*\zs\(%:\|#\)\s*\(define\|undef\)\>" skip="\\$" end="$" keepend contains=ALLBUT,@cPreProcGroup,@Spell
+syn region	cPreProc	start="^\s*\zs\(%:\|#\)\s*\(pragma\>\|line\>\|warning\>\|warn\>\|error\>\)" skip="\\$" end="$" keepend contains=ALLBUT,@cPreProcGroup,@Spell
+
 hi def link dtsCellProperty     Number
 hi def link dtsBinaryProperty   Number
 hi def link dtsStringProperty   String
@@ -28,3 +60,19 @@ hi def link dtsReference        Macro
 hi def link dtsComment          Comment
 hi def link dtsCommentInner     Comment
 hi def link dtsCommentLine      Comment
+
+hi def link cInclude		Include
+hi def link cPreProc		PreProc
+hi def link cDefine		Macro
+hi def link cIncluded		cString
+hi def link cString		String
+
+hi def link cCppInWrapper	cCppOutWrapper
+hi def link cCppOutWrapper	cPreCondit
+hi def link cPreConditMatch	cPreCondit
+hi def link cPreCondit		PreCondit
+hi def link cCppOutSkip		cCppOutIf2
+
+hi def link cCppInElse2		cCppOutIf2
+hi def link cCppOutIf2		cCppOut
+hi def link cCppOut		Comment


### PR DESCRIPTION
It's now common to run the C preprocessor on devicetree files in order  
to take advantage of #include and #define statements.                   
                                                                        
Copy CPP section from the C syntax file.                                
