### PR TITLE
Fixed 2 crashes with call()

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -4284,10 +4284,13 @@ eval_index_inner(
     char_u *
 partial_name(partial_T *pt)
 {
-    if (pt->pt_name != NULL)
-	return pt->pt_name;
-    if (pt->pt_func != NULL)
-	return pt->pt_func->uf_name;
+    if (pt != NULL)
+    {
+	if (pt->pt_name != NULL)
+	    return pt->pt_name;
+	if (pt->pt_func != NULL)
+	    return pt->pt_func->uf_name;
+    }
     return (char_u *)"";
 }
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2475,8 +2475,8 @@ f_call(typval_T *argvars, typval_T *rettv)
     }
     else
 	func = tv_get_string(&argvars[0]);
-    if (*func == NUL)
-	return;		// type error or empty name
+    if (func == NULL || *func == NUL)
+	return;		// type error, empty name or null function
 
     if (argvars[2].v_type != VAR_UNKNOWN)
     {

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1971,7 +1971,7 @@ internal_func_name(int idx)
 }
 
 /*
- * Check the argument types for builting function "idx".
+ * Check the argument types for builtin function "idx".
  * Uses the list of types on the type stack: "types".
  * Return FAIL and gives an error message when a type is wrong.
  */
@@ -2779,7 +2779,7 @@ f_cosh(typval_T *argvars, typval_T *rettv)
 
 /*
  * Set the cursor position.
- * If 'charcol' is TRUE, then use the column number as a character offet.
+ * If 'charcol' is TRUE, then use the column number as a character offset.
  * Otherwise use the column number as a byte offset.
  */
     static void

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2150,6 +2150,10 @@ func Test_call()
   eval mydict.len->call([], mydict)->assert_equal(4)
   call assert_fails("call call('Mylen', [], 0)", 'E715:')
   call assert_fails('call foo', 'E107:')
+
+  " This once caused a crash.
+  call call(test_null_function(), [])
+  call call(test_null_partial(), [])
 endfunc
 
 func Test_char2nr()

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -743,6 +743,7 @@ func Test_reduce()
 
   " should not crash
   call assert_fails('echo reduce([1], test_null_function())', 'E1132:')
+  call assert_fails('echo reduce([1], test_null_partial())', 'E1132:')
 endfunc
 
 " splitting a string to a List using split()


### PR DESCRIPTION
Both these commands caused Vim-8.2.2847 to crash:

```
$ vim --clean -c'call call(test_null_function(), [])'
Vim: Caught deadly signal SEGV
Vim: Finished.
Segmentation fault (core dumped)
```

```
$ vim --clean -c'call call(test_null_partial(), [])'
Vim: Caught deadly signal SEGV
Vim: Finished.
Segmentation fault (core dumped)
```