### PR TITLE
Use `gq` instead of `q` in `man.vim`

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -589,7 +589,6 @@ Global mapping:
 Local mappings:
 CTRL-]		Jump to the manual page for the word under the cursor.
 CTRL-T		Jump back to the previous manual page.
-q		Same as the |:quit| command.
 
 To use a vertical split instead of horizontal: >
 	let g:ft_man_open_mode = 'vert'

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -36,14 +36,12 @@ if &filetype == "man"
 
     nnoremap <buffer> <silent> <c-]> :call <SID>PreGetPage(v:count)<CR>
     nnoremap <buffer> <silent> <c-t> :call <SID>PopPage()<CR>
-    nnoremap <buffer> <silent> q :q<CR>
 
     " Add undo commands for the maps
     let b:undo_ftplugin = b:undo_ftplugin
 	  \ . '|silent! nunmap <buffer> <Plug>ManBS'
 	  \ . '|silent! nunmap <buffer> <c-]>'
 	  \ . '|silent! nunmap <buffer> <c-t>'
-	  \ . '|silent! nunmap <buffer> q'
   endif
 
   if exists('g:ft_man_folding_enable') && (g:ft_man_folding_enable == 1)


### PR DESCRIPTION
Using `q` in `man.vim` prevents `q/`, `q?` from working.
It would be convenient to use `gq` as a shortcut to close `man` window - the same way as `vim-fugitive` does.