### PR TITLE
Prevent extra CmdlineChanged event when using <C-r>{reg} on cmdline.

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1193,6 +1193,7 @@ cmdline_insert_reg(int *gotesc UNUSED)
 {
     int		i;
     int		c;
+    int		clen = ccline.cmdlen;
 
 #ifdef USE_ON_FLY_SCROLL
     dont_scroll = TRUE;	// disallow scrolling here
@@ -1254,7 +1255,7 @@ cmdline_insert_reg(int *gotesc UNUSED)
 #endif
     }
     redrawcmd();
-    return CMDLINE_CHANGED;
+    return (clen == ccline.cmdlen) ? CMDLINE_NOT_CHANGED : CMDLINE_CHANGED;
 }
 
 /*

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1817,5 +1817,24 @@ func Test_cmd_map_cmdlineChanged()
   augroup END
 endfunc
 
+func Test_ctrl_r_cmdlineChanged()
+  let g:log = []
+  cnoremap <F1> a<C-r>b
+  augroup test
+    autocmd!
+    autocmd CmdlineChanged : let g:log += [getcmdline()]
+  augroup END
+
+  let @b = 'b'
+  call feedkeys(":\<F1>\<Esc>", 'xt')
+  call assert_equal(['a', 'ab'], g:log)
+
+  unlet g:log
+  cunmap <F1>
+  augroup test
+    autocmd!
+  augroup END
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #8219