### PR TITLE
Fixed python tests when channel feature is not available

### DIFF
--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -814,8 +814,12 @@ func Test_python_vim_bindeval()
   call assert_equal(v:none, pyeval("vim.bindeval('v:none')"))
 
   " channel/job
-  call assert_equal(v:none, pyeval("vim.bindeval('test_null_channel()')"))
-  call assert_equal(v:none, pyeval("vim.bindeval('test_null_job()')"))
+  if has('channel')
+    call assert_equal(v:none, pyeval("vim.bindeval('test_null_channel()')"))
+  endif
+  if has('job')
+    call assert_equal(v:none, pyeval("vim.bindeval('test_null_job()')"))
+  endif
 endfunc
 
 " threading

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -1007,8 +1007,12 @@ func Test_python3_vim_bindeval()
   call assert_equal(v:none, py3eval("vim.bindeval('v:none')"))
 
   " channel/job
-  call assert_equal(v:none, py3eval("vim.bindeval('test_null_channel()')"))
-  call assert_equal(v:none, py3eval("vim.bindeval('test_null_job()')"))
+  if has('channel')
+    call assert_equal(v:none, py3eval("vim.bindeval('test_null_channel()')"))
+  endif
+  if has('job')
+    call assert_equal(v:none, py3eval("vim.bindeval('test_null_job()')"))
+  endif
 endfunc
 
 " threading


### PR DESCRIPTION
This PR fixes tests `Test_python_vim_bindeval()` and `Test_python3_vim_bindeval()` which fail when the channel feature is disabled.

To reproduce:
```
$ cd vim/src
$ ./configure --with-features=huge --enable-gui=none --enable-python3interp=yes --enable-pythoninterp=yes --disable-channel
$ make clean ; make -j8
$ make test
...
Executed:  3796 Tests
 Skipped:   259 Tests
  FAILED:     2 Tests


Failures: 
	From test_python2.vim:
	Found errors in Test_python_vim_bindeval():
	Caught exception in Test_python_vim_bindeval(): Vim(call):vim.error: Vim:E117: Unknown function: test_null_channel @ command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_python_vim_bindeval, line 18
	From test_python3.vim:
	Found errors in Test_python3_vim_bindeval():
	Caught exception in Test_python3_vim_bindeval(): Vim(call):vim.error: Vim:E117: Unknown function: test_null_channel @ command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_python3_vim_bindeval, line 18

TEST FAILURE
Makefile:43: recipe for target 'report' failed
make[1]: *** [report] Error 1
make[1]: Leaving directory '/home/pel/sb/vim/src/testdir'
Makefile:2254: recipe for target 'scripttests' failed
make: *** [scripttests] Error 2
```