### PR TITLE
Do not force screen redraw while peeking input in Windows console

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -1648,7 +1648,7 @@ WaitForChar(long msec, int ignore_input)
 	peek_console_input(g_hConIn, &ir, 1, &cRecords);
 
 # ifdef FEAT_MBYTE_IME
-	if (State & CMDLINE && msg_row == Rows - 1)
+	if (State & CMDLINE && msg_row == Rows - 1 && msec != 0)
 	{
 	    CONSOLE_SCREEN_BUFFER_INFO csbi;
 


### PR DESCRIPTION
Fixes #8211. 

I'm not sure that it's the best possible solution yet it seems more or less logical: we only force redraw if we are in CMDLINE mode _and_ cursor is not on the command-line _and_ we're actually trying to read input, not just peeking it.