### PR TITLE
Cancelling inputlist() should always return 0

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -946,7 +946,12 @@ get_number(
 	    do_redraw = FALSE;
 	    break;
 	}
-	else if (c == CAR || c == NL || c == Ctrl_C || c == ESC || c == 'q')
+	else if (c == Ctrl_C || c == ESC || c == 'q')
+	{
+	    n = 0;
+	    break;
+	}
+	else if (c == CAR || c == NL )
 	    break;
     }
     --no_mapping;

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1480,6 +1480,10 @@ func Test_inputlist()
   call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>q", 'tx')
   call assert_equal(0, c)
 
+  " Cancel after inputting a number
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>5q", 'tx')
+  call assert_equal(0, c)
+
   " Use backspace to delete characters in the prompt
   call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>1\<BS>3\<BS>2\<cr>", 'tx')
   call assert_equal(2, c)


### PR DESCRIPTION
User's input should be discarded if the `inputlist()` call is cancelled, otherwise there is no way to discern if the input was confirmed or cancelled.