### PR TITLE
Recognize haskell hsig files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -718,7 +718,7 @@ au BufNewFile,BufRead *.haml			setf haml
 au BufNewFile,BufRead *.hsm			setf hamster
 
 " Haskell
-au BufNewFile,BufRead *.hs,*.hsc,*.hs-boot	setf haskell
+au BufNewFile,BufRead *.hs,*.hsc,*.hs-boot,*.hsig setf haskell
 au BufNewFile,BufRead *.lhs			setf lhaskell
 au BufNewFile,BufRead *.chs			setf chaskell
 au BufNewFile,BufRead cabal.project		setf cabalproject

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -211,7 +211,7 @@ let s:filename_checks = {
     \ 'gtkrc': ['.gtkrc', 'gtkrc', '.gtkrc-file', 'gtkrc-file'],
     \ 'haml': ['file.haml'],
     \ 'hamster': ['file.hsm'],
-    \ 'haskell': ['file.hs', 'file.hsc', 'file.hs-boot'],
+    \ 'haskell': ['file.hs', 'file.hsc', 'file.hs-boot', 'file.hsig'],
     \ 'haste': ['file.ht'],
     \ 'hastepreproc': ['file.htpp'],
     \ 'hb': ['file.hb'],


### PR DESCRIPTION
[Signature files](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/separate_compilation.html#module-signatures) are supported by GHC-8.2 (or newer).