### PR TITLE
runtime: Python: correct wrong indent after elif-oneliner

### DIFF
--- a/runtime/indent/python.vim
+++ b/runtime/indent/python.vim
@@ -191,7 +191,7 @@ function GetPythonIndent(lnum)
   if getline(a:lnum) =~ '^\s*\(elif\|else\)\>'
 
     " Unless the previous line was a one-liner
-    if getline(plnumstart) =~ '^\s*\(for\|if\|try\)\>'
+    if getline(plnumstart) =~ '^\s*\(for\|if\|elif\|try\)\>'
       return plindent
     endif
 


### PR DESCRIPTION
Implementing the 7 year old known fix for this 7 year old known bug:
https://stackoverflow.com/questions/20427649/autoindenting-with-vim-for-python-else-statement

Before, Python code like this
```Python
def a():
    if a: pass
    elif b: pass
    else: pass
```
got indented as
```Python
def a():
    if a: pass
    elif b: pass
else: pass
```