### PR TITLE
make VISUAL highlight better with bg=dark

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -207,8 +207,8 @@ static char *(highlight_init_light[]) = {
     CENT("SignColumn term=standout ctermbg=Grey ctermfg=DarkBlue",
 	 "SignColumn term=standout ctermbg=Grey ctermfg=DarkBlue guibg=Grey guifg=DarkBlue"),
 #endif
-    CENT("Visual term=reverse",
-	 "Visual term=reverse guibg=LightGrey"),
+    CENT("Visual term=reverse cterm=reverse",
+	 "Visual term=reverse cterm=reverse guibg=LightGrey"),
 #ifdef FEAT_DIFF
     CENT("DiffAdd term=bold ctermbg=LightBlue",
 	 "DiffAdd term=bold ctermbg=LightBlue guibg=LightBlue"),
@@ -298,8 +298,8 @@ static char *(highlight_init_dark[]) = {
     CENT("SignColumn term=standout ctermbg=DarkGrey ctermfg=Cyan",
 	 "SignColumn term=standout ctermbg=DarkGrey ctermfg=Cyan guibg=Grey guifg=Cyan"),
 #endif
-    CENT("Visual term=reverse",
-	 "Visual term=reverse guibg=DarkGrey"),
+    CENT("Visual term=reverse cterm=reverse",
+	 "Visual term=reverse cterm=reverse guibg=DarkGrey"),
 #ifdef FEAT_DIFF
     CENT("DiffAdd term=bold ctermbg=DarkBlue",
 	 "DiffAdd term=bold ctermbg=DarkBlue guibg=DarkBlue"),
@@ -430,8 +430,8 @@ init_highlight(
     // Clear the attributes, needed when changing the t_Co value.
     if (t_colors > 8)
 	do_highlight((char_u *)(*p_bg == 'l'
-		    ? "Visual cterm=NONE ctermbg=LightGrey"
-		    : "Visual cterm=NONE ctermbg=DarkGrey"), FALSE, TRUE);
+		    ? "Visual cterm=NONE cterm=reverse ctermbg=LightGrey"
+		    : "Visual cterm=NONE cterm=reverse ctermbg=DarkGrey"), FALSE, TRUE);
     else
     {
 	do_highlight((char_u *)"Visual cterm=reverse ctermbg=NONE",


### PR DESCRIPTION
I recently setup my work machine and for some reason, when working with
putty and tmux I cannot see the visual highlight if the background
option is set to dark (which is what I use). I noticed that :hi Visual shows

Visual xxx term=reverse ctermbg=242 guibg=DarkGrey

![image](https://user-images.githubusercontent.com/244927/119326392-23f59700-bc82-11eb-9042-2be7c526f589.png)
`:set term? bg?`
```
  background=dark
  term=tmux-256color
```


Adding the attribute `cterm=reverse` helps, so let's make that the
default so that `:hi Visual` shows:

Visual xxx term=reverse cterm=reverse ctermbg=242 guibg=DarkGrey

![image](https://user-images.githubusercontent.com/244927/119326734-85b60100-bc82-11eb-98cb-9f53fd6fe2f2.png)
