### PR TITLE
When the defaults.vim file cannot be read, output an error message

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1036,7 +1036,7 @@ giving the mapping.
 
 
 Defaults without a .vimrc file ~
-							*defaults.vim*
+							*defaults.vim* *E1187*
 If Vim is started normally and no user vimrc file is found, the
 $VIMRUNTIME/defaults.vim script is loaded.  This will set 'compatible' off,
 switch on syntax highlighting and a few more things.  See the script for

--- a/src/errors.h
+++ b/src/errors.h
@@ -413,3 +413,5 @@ EXTERN char e_missing_redir_end[]
 	INIT(= N_("E1185: Missing :redir END"));
 EXTERN char e_expression_does_not_result_in_value_str[]
 	INIT(= N_("E1186: Expression does not result in a value: %s"));
+EXTERN char e_failed_to_load_defaults[]
+	INIT(= N_("E1187: Failed to source defaults.vim"));

--- a/src/main.c
+++ b/src/main.c
@@ -3127,9 +3127,11 @@ source_startup_scripts(mparm_T *parmp)
      */
     if (parmp->use_vimrc != NULL)
     {
-	if (STRCMP(parmp->use_vimrc, "DEFAULTS") == 0 &&
-	    do_source((char_u *)VIM_DEFAULTS_FILE, FALSE, DOSO_NONE, NULL) != OK)
-	    semsg(_("EXXX: Failed to load defaults.vim"));
+	if (STRCMP(parmp->use_vimrc, "DEFAULTS") == 0)
+	{
+	    if (do_source((char_u *)VIM_DEFAULTS_FILE, FALSE, DOSO_NONE, NULL) != OK)
+		emsg(e_failed_to_load_defaults);
+	}
 	else if (STRCMP(parmp->use_vimrc, "NONE") == 0
 				     || STRCMP(parmp->use_vimrc, "NORC") == 0)
 	{
@@ -3204,7 +3206,7 @@ source_startup_scripts(mparm_T *parmp)
 		// When no .vimrc file was found: source defaults.vim.
 		ret = do_source((char_u *)VIM_DEFAULTS_FILE, FALSE, DOSO_NONE, NULL);
 		if (ret == FAIL)
-		    semsg(_("Failed to load defaults.vim"));
+		    emsg(e_failed_to_load_defaults);
 	    }
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -3127,8 +3127,9 @@ source_startup_scripts(mparm_T *parmp)
      */
     if (parmp->use_vimrc != NULL)
     {
-	if (STRCMP(parmp->use_vimrc, "DEFAULTS") == 0)
-	    do_source((char_u *)VIM_DEFAULTS_FILE, FALSE, DOSO_NONE, NULL);
+	if (STRCMP(parmp->use_vimrc, "DEFAULTS") == 0 &&
+	    do_source((char_u *)VIM_DEFAULTS_FILE, FALSE, DOSO_NONE, NULL) != OK)
+	    semsg(_("EXXX: Failed to load defaults.vim"));
 	else if (STRCMP(parmp->use_vimrc, "NONE") == 0
 				     || STRCMP(parmp->use_vimrc, "NORC") == 0)
 	{
@@ -3199,8 +3200,11 @@ source_startup_scripts(mparm_T *parmp)
 #endif
 		&& !has_dash_c_arg)
 	    {
+		int ret = OK;
 		// When no .vimrc file was found: source defaults.vim.
-		do_source((char_u *)VIM_DEFAULTS_FILE, FALSE, DOSO_NONE, NULL);
+		ret = do_source((char_u *)VIM_DEFAULTS_FILE, FALSE, DOSO_NONE, NULL);
+		if (ret == FAIL)
+		    semsg(_("Failed to load defaults.vim"));
 	    }
 	}
 

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -280,6 +280,7 @@ endfunc
 func Test_defaults_error()
   " Can't catch the output of gvim.
   CheckNotGui
+  CheckNotMSWindows
 
   let out = system('VIMRUNTIME=/tmp ' .. GetVimCommand() .. ' --clean -cq')
   call assert_match("E1187: Failed to source defaults.vim", out)

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -276,6 +276,15 @@ func Test_V_arg()
    call assert_match("sourcing \"$VIMRUNTIME[\\/]defaults\.vim\"\r\nline 1: \" The default vimrc file\..*  verbose=15\n", out)
 endfunc
 
+" Test that an error is shown when the defaults.vim file could not be read
+func Test_defaults_error()
+  " Can't catch the output of gvim.
+  CheckNotGui
+
+  let out = system('VIMRUNTIME=/tmp ' .. GetVimCommand() .. ' --clean -cq')
+  call assert_match("E1187: Failed to source defaults.vim", out)
+endfunc
+
 " Test the '-q [errorfile]' argument.
 func Test_q_arg()
   CheckFeature quickfix


### PR DESCRIPTION
When running vim --clean and the `defaults.vim` runtime file cannot be
loaded, output an error message instead of silent to continue.

That is because if defaults.vim cannot be loaded, vim will start in
defaults mode, which may be unexpected and have quite some different defaults
and therefore behaves differently.

So make the user aware of this situation.
