### PR TITLE
WIP: syntax:bash: Add additional characters to function names

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -456,10 +456,10 @@ if !exists("b:is_posix")
 endif
 
 if exists("b:is_bash")
- ShFoldFunctions syn region shFunctionOne	matchgroup=shFunction start="^\s*[A-Za-z_0-9:][-a-zA-Z_0-9:]*\s*()\_s*{"		end="}"	contains=@shFunctionList		 skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
- ShFoldFunctions syn region shFunctionTwo	matchgroup=shFunction start="\%(do\)\@!\&\<[A-Za-z_0-9:][-a-zA-Z_0-9:]*\>\s*\%(()\)\=\_s*{"	end="}"	contains=shFunctionKey,@shFunctionList contained skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
- ShFoldFunctions syn region shFunctionThree	matchgroup=shFunction start="^\s*[A-Za-z_0-9:][-a-zA-Z_0-9:]*\s*()\_s*("		end=")"	contains=@shFunctionList		 skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
- ShFoldFunctions syn region shFunctionFour	matchgroup=shFunction start="\%(do\)\@!\&\<[A-Za-z_0-9:][-a-zA-Z_0-9:]*\>\s*\%(()\)\=\_s*)"	end=")"	contains=shFunctionKey,@shFunctionList contained skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionOne   matchgroup=shFunction           start="^\s*[][,:+?./^@*=A-Za-z_0-9-][][,:+?./^@*!a-zA-Z_0-9-]*\s*(\s*)\_s*{"        end="}" contains=@shFunctionList                         skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionTwo   matchgroup=shFunction start="\%(do\)\@!\&\<[][,:+?./^@*=A-Za-z_0-9-][][,:+?./^@*!a-zA-Z_0-9-]*\>\s*\%(()\)\=\_s*{"  end="}" contains=shFunctionKey,@shFunctionList contained skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionThree matchgroup=shFunction           start="^\s*[][,:+?./^@*=A-Za-z_0-9-][][,:+?./^@*!a-zA-Z_0-9-]*\s*(\s*)\_s*("        end=")" contains=@shFunctionList                         skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionFour  matchgroup=shFunction start="\%(do\)\@!\&\<[][,:+?./^@*=A-Za-z_0-9-][][,:+?./^@*!a-zA-Z_0-9-]*\>\s*\%(()\)\=\_s*)"  end=")" contains=shFunctionKey,@shFunctionList contained skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
 else
  ShFoldFunctions syn region shFunctionOne	matchgroup=shFunction start="^\s*\h\w*\s*()\_s*{"			end="}"	contains=@shFunctionList		 skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
  ShFoldFunctions syn region shFunctionTwo	matchgroup=shFunction start="\%(do\)\@!\&\<\h\w*\>\s*\%(()\)\=\_s*{"		end="}"	contains=shFunctionKey,@shFunctionList contained skipwhite skipnl nextgroup=shFunctionStart,shQuickComment


### PR DESCRIPTION
Bash gives _a lot_ of freedom when naming functions and many special
characters are allowed like ,:+?@*!. Add a proper matching region.
Also allow spaces in between parentheses `(   )`.

Tested that bash supports all the characters with:

```
$ sed 's/./&\n/g' <<<'[],:+?./^@*=!-' | { a=$(cat); echo "$a"; sed 's/.*/a&]/' <<<"$a"; } |  while IFS= read -r l; do s=":; $l () { echo 2; }; '$l'"; bash -c "$s" && echo "## works: $s"; done 2>/dev/null | grep '##'
## works: :; [ () { echo 2; }; '['
## works: :; ] () { echo 2; }; ']'
## works: :; , () { echo 2; }; ','
## works: :; : () { echo 2; }; ':'
## works: :; + () { echo 2; }; '+'
## works: :; ? () { echo 2; }; '?'
## works: :; . () { echo 2; }; '.'
## works: :; / () { echo 2; }; '/'
## works: :; ^ () { echo 2; }; '^'
## works: :; @ () { echo 2; }; '@'
## works: :; * () { echo 2; }; '*'
## works: :; = () { echo 2; }; '='
## works: :; - () { echo 2; }; '-'
## works: :; a[] () { echo 2; }; 'a[]'
## works: :; a]] () { echo 2; }; 'a]]'
## works: :; a,] () { echo 2; }; 'a,]'
## works: :; a:] () { echo 2; }; 'a:]'
## works: :; a+] () { echo 2; }; 'a+]'
## works: :; a?] () { echo 2; }; 'a?]'
## works: :; a.] () { echo 2; }; 'a.]'
## works: :; a/] () { echo 2; }; 'a/]'
## works: :; a^] () { echo 2; }; 'a^]'
## works: :; a@] () { echo 2; }; 'a@]'
## works: :; a*] () { echo 2; }; 'a*]'
## works: :; a!] () { echo 2; }; 'a!]'
## works: :; a-] () { echo 2; }; 'a-]'
```

I have tested bash5.1.4 and `docker run -ti --rm bash:3.0` - no difference.

I have seen `@:^,!-.` characters used in bash function names, and I personally use `,` a lot, `/` is only abused with like `./dir/script.sh() { echo mock; }`, but I do not think I have ever seen `[]+?*=`. I think I would be totally fine with removing `[]+?*=` characters from the regexes above, they seem like overkill, but tbh I did not notice any drawbacks to including them, so I decided to add them anyway as they are allowed in function names. One thing is not handled in the regex - `a[` is an invalid function name, but `a[]` is valid - the `[` have to match with `]` (dunno why?..) - that's why I test with a trailing `]` as in `a[]` in the script above.

I also changed the indentation from tabs to spaces, cause tabs didn't indent properly at all for me.