### PR TITLE
minor gdb syntax update

### DIFF
--- a/runtime/syntax/gdb.vim
+++ b/runtime/syntax/gdb.vim
@@ -24,8 +24,8 @@ syn keyword gdbStatement contained actions apply attach awatch backtrace break b
 syn keyword gdbStatement contained complete condition continue delete detach directory disable disassemble display down
 syn keyword gdbStatement contained echo else enable end file finish frame handle hbreak help if ignore
 syn keyword gdbStatement contained inspect jump kill list load maintenance make next nexti ni output overlay
-syn keyword gdbStatement contained passcount path print printf ptype pwd quit rbreak remote return run rwatch
-syn keyword gdbStatement contained search section set sharedlibrary shell show si signal source step stepi stepping
+syn keyword gdbStatement contained passcount path print printf ptype python pwd quit rbreak remote return run rwatch
+syn keyword gdbStatement contained search section set sharedlibrary shell show si signal skip source step stepi stepping
 syn keyword gdbStatement contained stop target tbreak tdump tfind thbreak thread tp trace tstart tstatus tstop
 syn keyword gdbStatement contained tty undisplay unset until up watch whatis where while ws x
 syn match gdbFuncDef "\<define\>.*"
@@ -33,7 +33,7 @@ syn match gdbStatmentContainer "^\s*\S\+" contains=gdbStatement,gdbFuncDef
 syn match gdbStatement "^\s*info" nextgroup=gdbInfo skipwhite skipempty
 
 " some commonly used abbreviations
-syn keyword gdbStatement c disp undisp disas p
+syn keyword gdbStatement c disp undisp disas p py
 
 syn region gdbDocument matchgroup=gdbFuncDef start="\<document\>.*$" matchgroup=gdbFuncDef end="^end\s*$"
 


### PR DESCRIPTION
There are two things that I wasn't sure how to add:

* `alias` - actually a statement, but wants a statement name behind (maybe ignore that and just add as statement)?
* `server` only usable in GDB scripts (kind of  aprefix, not a command) to not ask yes/no and to not pollute the history, can take "anything" afterwards and should ideally not interfere with the syntax highlighting (example: `server source myfile` - "source" should be highlighted as it commonly is

Things that are completely unknown to me:
* Would it by possible to have a python range (`python\n...\nend`) highlighted with the python highlighter?
* Would it be possible to fold define/if/python?

Forgot to add `save`:
```text
(gdb) help save
Save breakpoint definitions as a script.

List of save subcommands:

save breakpoints -- Save current breakpoint definitions as a script.
save gdb-index -- Save a gdb-index file.
save tracepoints -- Save current tracepoint definitions as a script.
```