### PR TITLE
Fix random characters appear in error messages

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -2358,7 +2358,7 @@ eval1(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	    ++*arg;
 	if (evaluate && vim9script && !IS_WHITE_OR_NUL((*arg)[1]))
 	{
-	    error_white_both(p, op_falsy ? 2 : 1);
+	    error_white_both(*arg - (op_falsy ? 1 : 0), op_falsy ? 2 : 1);
 	    clear_tv(rettv);
 	    return FAIL;
 	}
@@ -2406,7 +2406,7 @@ eval1(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	     */
 	    if (evaluate && vim9script && !IS_WHITE_OR_NUL((*arg)[1]))
 	    {
-		error_white_both(p, 1);
+		error_white_both(*arg, 1);
 		clear_tv(rettv);
 		evalarg_used->eval_flags = orig_flags;
 		return FAIL;
@@ -2511,7 +2511,7 @@ eval2(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	     */
 	    if (evaluate && in_vim9script() && !IS_WHITE_OR_NUL((*arg)[2]))
 	    {
-		error_white_both(p, 2);
+		error_white_both(*arg, 2);
 		clear_tv(rettv);
 		return FAIL;
 	    }
@@ -2637,7 +2637,7 @@ eval3(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	     */
 	    if (evaluate && in_vim9script() && !IS_WHITE_OR_NUL((*arg)[2]))
 	    {
-		error_white_both(p, 2);
+		error_white_both(*arg, 2);
 		clear_tv(rettv);
 		return FAIL;
 	    }
@@ -2738,7 +2738,7 @@ eval4(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	    *arg = eval_next_line(evalarg);
 	else if (evaluate && vim9script && !VIM_ISWHITE(**arg))
 	{
-	    error_white_both(p, len);
+	    error_white_both(*arg, len);
 	    clear_tv(rettv);
 	    return FAIL;
 	}
@@ -2898,7 +2898,7 @@ eval5(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	{
 	    if (evaluate && vim9script && !VIM_ISWHITE(**arg))
 	    {
-		error_white_both(p, oplen);
+		error_white_both(*arg, oplen);
 		clear_tv(rettv);
 		return FAIL;
 	    }
@@ -3130,7 +3130,7 @@ eval6(
 	{
 	    if (evaluate && in_vim9script() && !VIM_ISWHITE(**arg))
 	    {
-		error_white_both(p, 1);
+		error_white_both(*arg, 1);
 		clear_tv(rettv);
 		return FAIL;
 	    }

--- a/src/eval.c
+++ b/src/eval.c
@@ -2734,8 +2734,10 @@ eval4(char_u **arg, typval_T *rettv, evalarg_T *evalarg)
 	int	    evaluate = evalarg == NULL
 				   ? 0 : (evalarg->eval_flags & EVAL_EVALUATE);
 
-	if (getnext)
+	if (getnext) {
 	    *arg = eval_next_line(evalarg);
+	    p = *arg;
+	}
 	else if (evaluate && vim9script && !VIM_ISWHITE(**arg))
 	{
 	    error_white_both(*arg, len);

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -1603,7 +1603,7 @@ func Test_expr6_fails()
     call CheckDefAndScriptFailure2(["var x = 0.7[1]"], 'E1107:', 'E806:', 1)
   endif
 
-  for op in ['+', '-']
+  for op in ['*', '/', '%']
     let lines =<< trim END
       vim9script
       var x = 1

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -172,11 +172,25 @@ func Test_expr1_trinary_fails()
   call CheckDefAndScriptFailure(["var x = 1? 'one' : 'two'"], msg, 1)
   call CheckDefAndScriptFailure(["var x = 1 ?'one' : 'two'"], msg, 1)
   call CheckDefAndScriptFailure(["var x = 1?'one' : 'two'"], msg, 1)
+  let lines =<< trim END
+    vim9script
+    var x = 1
+     ?'one' : 'two'
+     # comment
+  END
+  call CheckScriptFailure(lines, msg, 3)
 
   let msg = "White space required before and after ':'"
   call CheckDefAndScriptFailure(["var x = 1 ? 'one': 'two'"], msg, 1)
   call CheckDefAndScriptFailure(["var x = 1 ? 'one' :'two'"], msg, 1)
   call CheckDefAndScriptFailure(["var x = 1 ? 'one':'two'"], msg, 1)
+  let lines =<< trim END
+    vim9script
+    var x = 1 ? 'one'
+          :'two'
+          # Comment
+  END
+  call CheckScriptFailure(lines, msg, 3)
 
   call CheckDefAndScriptFailure(["var x = 'x' ? 'one' : 'two'"], 'E1135:', 1)
   call CheckDefAndScriptFailure(["var x = 0z1234 ? 'one' : 'two'"], 'E974:', 1)
@@ -229,6 +243,13 @@ def Test_expr1_falsy()
   call CheckDefAndScriptFailure(["var x = 1?? 'one' : 'two'"], msg, 1)
   call CheckDefAndScriptFailure(["var x = 1 ??'one' : 'two'"], msg, 1)
   call CheckDefAndScriptFailure(["var x = 1??'one' : 'two'"], msg, 1)
+  lines =<< trim END
+    vim9script
+    var x = 1
+      ??'one' : 'two'
+      #comment
+  END
+  CheckScriptFailure(lines, msg, 3)
 enddef
 
 def Record(val: any): any
@@ -376,6 +397,13 @@ def Test_expr2_fails()
 
   call CheckDefAndScriptFailure2(["var x = [] || false"], 'E1012: Type mismatch; expected bool but got list<unknown>', 'E745:', 1)
 
+  var lines =<< trim END
+    vim9script
+    echo false
+      ||true
+    # comment
+  END
+  CheckScriptFailure(lines, 'E1004: White space required before and after ''||'' at "||true"', 3)
 enddef
 
 " test &&
@@ -476,13 +504,20 @@ def Test_expr3_fails()
   CheckDefAndScriptFailure(["var x = 1&&2"], msg, 1)
   CheckDefAndScriptFailure(["var x = 1 &&2"], msg, 1)
   CheckDefAndScriptFailure(["var x = 1&& 2"], msg, 1)
+  var lines =<< trim END
+    vim9script
+    var x = 1
+      &&2
+    # comment
+  END
+  CheckScriptFailure(lines, msg, 3)
 
   g:vals = []
   CheckDefAndScriptFailure2(["if 'yes' && 0", 'echo 0', 'endif'], 'E1012: Type mismatch; expected bool but got string', 'E1135: Using a String as a Bool', 1)
 
   CheckDefExecAndScriptFailure(['assert_equal(false, Record(1) && Record(4) && Record(0))'], 'E1023: Using a Number as a Bool: 4', 1)
 
-  var lines =<< trim END
+  lines =<< trim END
       if 3
           && true
       endif
@@ -976,6 +1011,17 @@ def Test_expr4_vim9script()
   END
   CheckDefAndScriptFailure(lines, 'E1004:', 1)
 
+  for op in ['==', '>', '>=', '<', '<=', '=~', '!~', 'is', 'isnot']
+    lines =<< trim END
+      vim9script
+      echo 'aaa'
+      # comment
+    END
+    lines->insert(op .. "'bbb'", 2)
+    var msg = printf("E1004: White space required before and after '%s'", op)
+    CheckScriptFailure(lines, msg, 3)
+  endfor
+
   lines =<< trim END
     echo len('xxx') == 3
   END
@@ -1264,6 +1310,17 @@ def Test_expr5_vim9script()
       bwipe!
   END
   CheckDefAndScriptFailure(lines, "E1004: White space required before and after '/' at \"/pattern", 3)
+
+  for op in ['+', '-']
+    lines =<< trim END
+      vim9script
+      var x = 1
+      # comment
+    END
+    lines->insert(op .. '2', 2)
+    var msg = printf("E1004: White space required before and after '%s' at \"%s2\"", op, op)
+    CheckScriptFailure(lines, msg, 3)
+  endfor
 enddef
 
 def Test_expr5_vim9script_channel()
@@ -1545,6 +1602,17 @@ func Test_expr6_fails()
   if has('float')
     call CheckDefAndScriptFailure2(["var x = 0.7[1]"], 'E1107:', 'E806:', 1)
   endif
+
+  for op in ['+', '-']
+    let lines =<< trim END
+      vim9script
+      var x = 1
+      # comment
+    END
+    call insert(lines, op .. '2', 2)
+    let msg = printf("E1004: White space required before and after '%s' at \"%s2\"", op, op)
+    call CheckScriptFailure(lines, msg, 3)
+  endfor
 endfunc
 
 func Test_expr6_float_fails()


### PR DESCRIPTION
The same problem of #8263 occurs with other operators: `:`, `?`, `??`, `&&`, `||`, `==`, `!=`, `=~`, `!~`, `>`, `<`, `>=`, `<=` `+`, and `-`  (expr1 to expr5).
This PR fixes them.

Solutions:
- expr1, 2, 3, and 5
Use the right pointer.
- expr 4
Update the pointer `p`.
