### PR TITLE
appveyor: Build failure was not detected

### DIFF
--- a/ci/appveyor.bat
+++ b/ci/appveyor.bat
@@ -11,7 +11,11 @@ sed -e "s/@<<$/@<< | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak
 echo "Building MSVC 64bit console Version"
 nmake -f Make_mvc2.mak CPU=AMD64 ^
     OLE=no GUI=no IME=yes ICONV=yes DEBUG=no ^
-    FEATURES=%FEATURE% || exit 1
+    FEATURES=%FEATURE%
+if not exist vim.exe (
+    echo Build failure.
+    exit 1
+)
 
 :: build MSVC huge version with python and channel support
 :: GUI needs to be last, so that testing works
@@ -21,16 +25,20 @@ if "%FEATURE%" == "HUGE" (
         OLE=no GUI=yes IME=yes ICONV=yes DEBUG=no POSTSCRIPT=yes ^
         PYTHON_VER=27 DYNAMIC_PYTHON=yes PYTHON=C:\Python27-x64 ^
         PYTHON3_VER=35 DYNAMIC_PYTHON3=yes PYTHON3=C:\Python35-x64 ^
-        FEATURES=%FEATURE% || exit 1
+        FEATURES=%FEATURE%
 ) ELSE (
     nmake -f Make_mvc2.mak CPU=AMD64 ^
         OLE=no GUI=yes IME=yes ICONV=yes DEBUG=no ^
-        FEATURES=%FEATURE% || exit 1
+        FEATURES=%FEATURE%
 )
-.\gvim -u NONE -c "redir @a | ver |0put a | wq" ver_msvc.txt
+if not exist gvim.exe (
+    echo Build failure.
+    exit 1
+)
+.\gvim -u NONE -c "redir @a | ver |0put a | wq" ver_msvc.txt || exit 1
 
 echo "version output MSVC console"
-.\vim --version
+.\vim --version || exit 1
 echo "version output MSVC GUI"
-type ver_msvc.txt
+type ver_msvc.txt || exit 1
 cd ..


### PR DESCRIPTION
`nmake ... || exit 1` didn't work because we use sed to filter out the
progress of linking. Nmake returns 0 even if linking failed.
E.g. https://ci.appveyor.com/project/chrisbra/vim/builds/39369855

Instead, check the existence of vim.exe and gvim.exe explicitly.
Also, check the result of `(g)vim --version`.