### PR TITLE
Improve further test coverage of spellfile.c

### DIFF
--- a/src/testdir/test_spellfile.vim
+++ b/src/testdir/test_spellfile.vim
@@ -583,6 +583,13 @@ func Test_mkspell()
   call assert_fails('mkspell! Xtest.spl Xtest.dic', 'E17:')
   call delete('Xtest.spl', 'rf')
 
+  " can't write the .spl file as its directory does not exist
+  call writefile([], 'Xtest.aff')
+  call writefile([], 'Xtest.dic')
+  call assert_fails('mkspell DOES_NOT_EXIT/Xtest.spl Xtest.dic', 'E484:')
+  call delete('Xtest.aff')
+  call delete('Xtest.dic')
+
   call assert_fails('mkspell en en_US abc_xyz', 'E755:')
 endfunc
 
@@ -842,6 +849,47 @@ func Test_spell_add_word()
   %bw!
 endfunc
 
+func Test_spellfile_verbose()
+  call writefile(['1', 'one'], 'XtestVerbose.dic')
+  call writefile([], 'XtestVerbose.aff')
+  mkspell! XtestVerbose-utf8.spl XtestVerbose
+  set spell
+
+  " First time: the spl file should be read.
+  let a = execute('3verbose set spelllang=XtestVerbose-utf8.spl')
+  call assert_match('Reading spell file "XtestVerbose-utf8.spl"', a)
+
+  " Second time time: the spl file should not be read (already read).
+  let a = execute('3verbose set spelllang=XtestVerbose-utf8.spl')
+  call assert_notmatch('Reading spell file "XtestVerbose-utf8.spl"', a)
+
+  set spell& spelllang&
+  call delete('XtestVerbose.dic')
+  call delete('XtestVerbose.aff')
+  call delete('XtestVerbose-utf8.spl')
+endfunc
+
+" Test NOBREAK (see :help spell-NOBREAK)
+func Test_NOBREAK()
+  call writefile(['3', 'one', 'two', 'three' ], 'XtestNOBREAK.dic')
+  call writefile(['NOBREAK' ], 'XtestNOBREAK.aff')
+
+  mkspell! XtestNOBREAK-utf8.spl XtestNOBREAK
+  set spell spelllang=XtestNOBREAK-utf8.spl
+
+  call assert_equal(['', ''], spellbadword('One two three onetwo onetwothree threetwoone'))
+
+  call assert_equal(['x', 'bad'], spellbadword('x'))
+  call assert_equal(['y', 'bad'], spellbadword('yone'))
+  call assert_equal(['z', 'bad'], spellbadword('onez'))
+  call assert_equal(['zero', 'bad'], spellbadword('Onetwozerothree'))
+
+  set spell& spelllang&
+  call delete('XtestNOBREAK.dic')
+  call delete('XtestNOBREAK.aff')
+  call delete('XtestNOBREAK-utf8.spl')
+endfunc
+
 " Test CHECKCOMPOUNDPATTERN (see :help spell-CHECKCOMPOUNDPATTERN)
 func Test_spellfile_CHECKCOMPOUNDPATTERN()
   call writefile(['4',
@@ -854,7 +902,7 @@ func Test_spellfile_CHECKCOMPOUNDPATTERN()
         \         'CHECKCOMPOUNDPATTERN wo on',
         \         'COMPOUNDFLAG c'], 'XtestCHECKCOMPOUNDPATTERN.aff')
 
-  let output = execute('mkspell! XtestCHECKCOMPOUNDPATTERN-utf8.spl XtestCHECKCOMPOUNDPATTERN')
+  mkspell! XtestCHECKCOMPOUNDPATTERN-utf8.spl XtestCHECKCOMPOUNDPATTERN
   set spell spelllang=XtestCHECKCOMPOUNDPATTERN-utf8.spl
 
   " Check valid words with and without valid compounds.
@@ -893,7 +941,7 @@ func Test_spellfile_COMMON()
         \         'ted'], 'XtestCOMMON.dic')
   call writefile(['COMMON the and'], 'XtestCOMMON.aff')
 
-  let output = execute('mkspell! XtestCOMMON-utf8.spl XtestCOMMON')
+  mkspell! XtestCOMMON-utf8.spl XtestCOMMON
   set spell spelllang=XtestCOMMON-utf8.spl
 
   " COMMON words 'and' and 'the' should be the top suggestions.
@@ -906,6 +954,49 @@ func Test_spellfile_COMMON()
   call delete('XtestCOMMON.dic')
   call delete('XtestCOMMON.aff')
   call delete('XtestCOMMON-utf8.spl')
+endfunc
+
+" Test CIRCUMFIX (see: :help spell-CIRCUMFIX)
+func Test_spellfile_CIRCUMFIX()
+  " Example taken verbatim from https://github.com/hunspell/hunspell/tree/master/tests
+  call writefile(['1',
+        \         'nagy/C	po:adj'], 'XtestCIRCUMFIX.dic')
+  call writefile(['# circumfixes: ~ obligate prefix/suffix combinations',
+        \         '# superlative in Hungarian: leg- (prefix) AND -bb (suffix)',
+        \         '',
+        \         'CIRCUMFIX X',
+        \         '',
+        \         'PFX A Y 1',
+        \         'PFX A 0 leg/X .',
+        \         '',
+        \         'PFX B Y 1',
+        \         'PFX B 0 legesleg/X .',
+        \         '',
+        \         'SFX C Y 3',
+        \         'SFX C 0 obb . is:COMPARATIVE',
+        \         'SFX C 0 obb/AX . is:SUPERLATIVE',
+        \         'SFX C 0 obb/BX . is:SUPERSUPERLATIVE'], 'XtestCIRCUMFIX.aff')
+
+  mkspell! XtestCIRCUMFIX-utf8.spl XtestCIRCUMFIX
+  set spell spelllang=XtestCIRCUMFIX-utf8.spl
+
+  " From https://catalog.ldc.upenn.edu/docs/LDC2008T01/acta04.pdf:
+  " Hungarian       English
+  " ---------       -------
+  " nagy            great
+  " nagyobb         greater
+  " legnagyobb      greatest
+  " legeslegnagyob  most greatest
+  call assert_equal(['', ''], spellbadword('nagy nagyobb legnagyobb legeslegnagyobb'))
+
+  for badword in ['legnagy', 'legeslegnagy', 'legobb', 'legeslegobb']
+    call assert_equal([badword, 'bad'], spellbadword(badword))
+  endfor
+
+  set spell& spelllang&
+  call delete('XtestCIRCUMFIX.dic')
+  call delete('XtestCIRCUMFIX.aff')
+  call delete('XtestCIRCUMFIX-utf8.spl')
 endfunc
 
 " When 'spellfile' is not set, adding a new good word will automatically set


### PR DESCRIPTION
Add test for:
- CIRCUMFIX
- NOBREAK
- error when spl file can't be written
- verbose output