### PR TITLE
Fixed a memory leak in term.c

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -4248,6 +4248,7 @@ add_termcode(char_u *name, char_u *string, int flags)
 	if (new_tc == NULL)
 	{
 	    tc_max_len -= 20;
+	    vim_free(s);
 	    return;
 	}
 	for (i = 0; i < tc_len; ++i)


### PR DESCRIPTION
Fixed a memory leak in term.c.

I'm not sure, but it hopefully fixes the leak detected by asan at:
https://github.com/vim/vim/runs/2701417491?check_suite_focus=true