### PR TITLE
New zy command: Yank without trailing whitespace

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1042,6 +1042,9 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			cursor to the end of line (which is more logical,
 			but not Vi-compatible) use ":map Y y$".
 
+["x]zy{motion}		Yank {motion} text [into register x].  Trailing
+			whitespace at the end of the motion won't be yanked.
+
 							*v_y*
 {Visual}["x]y		Yank the highlighted text [into register x] (for
 			{Visual} see |Visual-mode|).

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -878,6 +878,7 @@ tag		char	      note action in Normal mode	~
 |zv|		zv		   open enough folds to view the cursor line
 |zw|		zw		   permanently mark word as incorrectly spelled
 |zx|		zx		   re-apply 'foldlevel' and do "zv"
+|zy|		zy		   yank without trailing spaces
 |zz|		zz		   redraw, cursor line at center of window
 |z<Left>|	z<Left>		   same as "zh"
 |z<Right>|	z<Right>	   same as "zl"

--- a/src/normal.c
+++ b/src/normal.c
@@ -2977,6 +2977,9 @@ dozet:
     case 'P':
     case 'p':  nv_put(cap);
 	       break;
+		// "zy" Yank without trailing spaces
+    case 'y':  nv_operator(cap);
+	       break;
 #ifdef FEAT_FOLDING
 		// "zF": create fold command
 		// "zf": create fold operator

--- a/src/ops.c
+++ b/src/ops.c
@@ -78,6 +78,8 @@ get_op_type(int char1, int char2)
 	return OP_NR_ADD;
     if (char1 == 'g' && char2 == Ctrl_X)	// subtract
 	return OP_NR_SUB;
+    if (char1 == 'z' && char2 == 'y')	// OP_YANK
+	return OP_YANK;
     for (i = 0; ; ++i)
     {
 	if (opchars[i][0] == char1 && opchars[i][1] == char2)
@@ -3893,6 +3895,7 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 #ifdef FEAT_LINEBREAK
 		curwin->w_p_lbr = lbr_saved;
 #endif
+		oap->excl_tr_ws = cap->cmdchar == 'z';
 		(void)op_yank(oap, FALSE, !gui_yank);
 	    }
 	    check_cursor_col();

--- a/src/register.c
+++ b/src/register.c
@@ -32,7 +32,7 @@ static int	stuff_yank(int, char_u *);
 static void	put_reedit_in_typebuf(int silent);
 static int	put_in_typebuf(char_u *s, int esc, int colon,
 								 int silent);
-static int	yank_copy_line(struct block_def *bd, long y_idx);
+static int	yank_copy_line(struct block_def *bd, long y_idx, int exclude_trailing_space);
 #ifdef FEAT_CLIPBOARD
 static void	copy_yank_reg(yankreg_T *reg);
 #endif
@@ -1208,7 +1208,7 @@ op_yank(oparg_T *oap, int deleting, int mess)
 	{
 	    case MBLOCK:
 		block_prep(oap, &bd, lnum, FALSE);
-		if (yank_copy_line(&bd, y_idx) == FAIL)
+		if (yank_copy_line(&bd, y_idx, oap->excl_tr_ws) == FAIL)
 		    goto fail;
 		break;
 
@@ -1282,7 +1282,7 @@ op_yank(oparg_T *oap, int deleting, int mess)
 		    else
 			bd.textlen = endcol - startcol + oap->inclusive;
 		    bd.textstart = p + startcol;
-		    if (yank_copy_line(&bd, y_idx) == FAIL)
+		    if (yank_copy_line(&bd, y_idx, FALSE) == FAIL)
 			goto fail;
 		    break;
 		}
@@ -1443,8 +1443,10 @@ fail:		// free the allocated lines
     return FAIL;
 }
 
+// Copy block range into register
+// if exclude_trailing_space is set, do not copy trailing whitespaces
     static int
-yank_copy_line(struct block_def *bd, long y_idx)
+yank_copy_line(struct block_def *bd, long y_idx, int exclude_trailing_space)
 {
     char_u	*pnew;
 
@@ -1458,6 +1460,17 @@ yank_copy_line(struct block_def *bd, long y_idx)
     pnew += bd->textlen;
     vim_memset(pnew, ' ', (size_t)bd->endspaces);
     pnew += bd->endspaces;
+    if (exclude_trailing_space)
+    {
+	int i = 0;
+	int s = bd->textlen + bd->endspaces;
+	while (VIM_ISWHITE(*(bd->textstart + s - 1)) && s > 1)
+	{
+	    s = s - (*mb_head_off)(bd->textstart, bd->textstart + s - 1) - 1;
+	    i++;
+	}
+	pnew -= i;
+    }
     *pnew = NUL;
     return OK;
 }

--- a/src/register.c
+++ b/src/register.c
@@ -1462,14 +1462,12 @@ yank_copy_line(struct block_def *bd, long y_idx, int exclude_trailing_space)
     pnew += bd->endspaces;
     if (exclude_trailing_space)
     {
-	int i = 0;
 	int s = bd->textlen + bd->endspaces;
-	while (VIM_ISWHITE(*(bd->textstart + s - 1)) && s > 1)
+	while (VIM_ISWHITE(*(bd->textstart + s - 1)) && s > 0)
 	{
 	    s = s - (*mb_head_off)(bd->textstart, bd->textstart + s - 1) - 1;
-	    i++;
+	    pnew--;
 	}
-	pnew -= i;
     }
     *pnew = NUL;
     return OK;

--- a/src/structs.h
+++ b/src/structs.h
@@ -3772,7 +3772,7 @@ typedef struct oparg_S
     int		use_reg_one;	// TRUE if delete uses reg 1 even when not
 				// linewise
     int		inclusive;	// TRUE if char motion is inclusive (only
-				// valid when motion_type is MCHAR
+				// valid when motion_type is MCHAR)
     int		end_adjusted;	// backuped b_op_end one char (only used by
 				// do_format())
     pos_T	start;		// start of the operator
@@ -3789,6 +3789,7 @@ typedef struct oparg_S
     colnr_T	end_vcol;	// end col for block mode operator
     long	prev_opcount;	// ca.opcount saved for K_CURSORHOLD
     long	prev_count0;	// ca.count0 saved for K_CURSORHOLD
+    int		excl_tr_ws;	// exclude trailing whitespace for yank of block
 } oparg_T;
 
 /*

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1104,6 +1104,15 @@ func Test_visual_put_in_block_using_zy_and_zp()
   exe "normal! 5G0f/\<c-v>2jezy"
   norm! 1G0f;P
   call assert_equal(['/path/subdir        ;text', '/path/longsubdir    ;text', '/path/longlongsubdir;text'], getline(1, 3))
+  " 5) Yank with spaces inside the block
+  %d
+  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+    \ 'texttext  /sub    dir/           columntext',
+    \ 'texttext  /lon    gsubdir/       columntext',
+    \ 'texttext  /lon    glongsubdir/   columntext'])
+  exe "normal! 5G0f/\<c-v>2jf/zy"
+  norm! 1G0f;zP
+  call assert_equal(['/path/sub    dir/;text', '/path/lon    gsubdir/;text', '/path/lon    glongsubdir/;text'], getline(1, 3))
   bwipe!
 endfunc
 

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1066,4 +1066,45 @@ func Test_visual_put_in_block_using_zp()
   bwipe!
 endfunc
 
+func Test_visual_put_in_block_using_zy_and_zp()
+  new
+  " Tests:
+  " 1) Paste using zp - after the cursor without trailing spaces
+  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+    \ 'texttext  /subdir           columntext',
+		\ 'texttext  /longsubdir       columntext',
+    \ 'texttext  /longlongsubdir   columntext'])
+  exe "normal! 5G0f/\<c-v>2jezy"
+  norm! 1G0f;hzp
+  call assert_equal(['/path/subdir;text', '/path/longsubdir;text', '/path/longlongsubdir;text'], getline(1, 3))
+  " 2) Paste using zP - in front of the cursor without trailing spaces
+  %d
+  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+    \ 'texttext  /subdir           columntext',
+		\ 'texttext  /longsubdir       columntext',
+    \ 'texttext  /longlongsubdir   columntext'])
+  exe "normal! 5G0f/\<c-v>2jezy"
+  norm! 1G0f;zP
+  call assert_equal(['/path/subdir;text', '/path/longsubdir;text', '/path/longlongsubdir;text'], getline(1, 3))
+  " 3) Paste using p - with trailing spaces
+  %d
+  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+    \ 'texttext  /subdir           columntext',
+		\ 'texttext  /longsubdir       columntext',
+    \ 'texttext  /longlongsubdir   columntext'])
+  exe "normal! 5G0f/\<c-v>2jezy"
+  norm! 1G0f;hp
+  call assert_equal(['/path/subdir        ;text', '/path/longsubdir    ;text', '/path/longlongsubdir;text'], getline(1, 3))
+  " 4) Paste using P - with trailing spaces
+  %d
+  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+    \ 'texttext  /subdir           columntext',
+		\ 'texttext  /longsubdir       columntext',
+    \ 'texttext  /longlongsubdir   columntext'])
+  exe "normal! 5G0f/\<c-v>2jezy"
+  norm! 1G0f;P
+  call assert_equal(['/path/subdir        ;text', '/path/longsubdir    ;text', '/path/longlongsubdir;text'], getline(1, 3))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
So with 2fa9384ca1b600b934bec81a72c5fb7ce757503a we can now paste without adding trailing whitespaces.

So let's add an new command 'zy' to yank text, but leave trailing whitespace out. This allows to yank whitespace delimited text like in a visual table:

column      column2     col3
text            /dir                               trailing text
text            /longer/dir/here            trailing text
text           /even/longer/dir/here     trailing text

So you can now block select using `Ctrl-V` the second column and use `zy` to only copy the non-whitespace characters as a new block.

This makes it easier to paste them later using e.g. `zp`.

Add a test and documentation to it.