### PR TITLE
Fix and Proposal: buffer name scheme part adjust RFC3986 like rule

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2625,7 +2625,6 @@ path_with_url(char_u *fname)
     p = fname;
 
     /* check first alpha */
-    /* if 0 char scheme accept, comment-out this block */
     if (!isalpha(*p))
         return 0;
     ++p;

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2600,6 +2600,19 @@ path_is_url(char_u *p)
 }
 
 /*
+ * Check url scheme charactor.
+ * return 1 is OK. non scheme char return 0.
+ */
+    int
+is_url_scheme(char_u c)
+{
+    /* URL rule in RFC3986 (URI) */
+    /* scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) */
+    return isalnum(c)
+        || c == '+' || c == '-' || c == '.';
+}
+
+/*
  * Check if "fname" starts with "name://".  Return URL_SLASH if it does.
  * Return URL_BACKSLASH for "name:\\".
  * Return zero otherwise.
@@ -2609,7 +2622,16 @@ path_with_url(char_u *fname)
 {
     char_u *p;
 
-    for (p = fname; isalpha(*p); ++p)
-	;
+    p = fname;
+
+    /* check first alpha */
+    /* if 0 char scheme accept, comment-out this block */
+    if (!isalpha(*p))
+        return 0;
+    ++p;
+
+    /* check body */
+    for(; is_url_scheme(*p); ++p)
+        ;
     return path_is_url(p);
 }

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2600,19 +2600,6 @@ path_is_url(char_u *p)
 }
 
 /*
- * Check url scheme charactor.
- * return 1 is OK. non scheme char return 0.
- */
-    int
-is_url_scheme(char_u c)
-{
-    /* URL rule in RFC3986 (URI) */
-    /* scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) */
-    return isalnum(c)
-        || c == '+' || c == '-' || c == '.';
-}
-
-/*
  * Check if "fname" starts with "name://".  Return URL_SLASH if it does.
  * Return URL_BACKSLASH for "name:\\".
  * Return zero otherwise.
@@ -2620,17 +2607,21 @@ is_url_scheme(char_u c)
     int
 path_with_url(char_u *fname)
 {
-    char_u *p;
+    char_u *p = fname;
 
-    p = fname;
+    // We accept alphabetic characters and a dash in scheme part.
+    // RFC 3986 allows for more, but it increases the risk of matching
+    // non-URL text.
 
     /* check first alpha */
     if (!isalpha(*p))
-        return 0;
+	return 0;
     ++p;
 
     /* check body */
-    for(; is_url_scheme(*p); ++p)
-        ;
-    return path_is_url(p);
+    for (; isalpha(*p) || (*p == '-'); ++p)
+	;
+
+    /* scheme last char is not '-' */
+    return (p[-1] == '-') ? 0 : path_is_url(p);
 }

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2607,19 +2607,18 @@ path_is_url(char_u *p)
     int
 path_with_url(char_u *fname)
 {
-    char_u *p = fname;
+    char_u *p;
 
     // We accept alphabetic characters and a dash in scheme part.
     // RFC 3986 allows for more, but it increases the risk of matching
     // non-URL text.
 
-    /* check first alpha */
-    if (!isalpha(*p))
+    /* check first alpha only */
+    if (!isalpha(*fname))
 	return 0;
-    ++p;
 
     /* check body */
-    for (; isalpha(*p) || (*p == '-'); ++p)
+    for (p = fname; (isalpha(*p) || (*p == '-')); ++p)
 	;
 
     /* scheme last char is not '-' */

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -381,33 +381,18 @@ func Test_balt()
   call assert_equal('OtherBuffer', bufname())
 endfunc
 
-func s:Test_buffer_scheme_open(url)
-  echomsg 'open:' a:url
-endfunc
-
+" Test for buffer match URL(scheme) check
+" scheme is alpha and inner hyphen only.
 func Test_buffer_scheme()
-  CheckMSWindows
-  set noshellslash
   %bwipe!
   let bufnames = [
-    \ {'id':'b0', 'name':'test/abc/b0'          , 'match': 0},
-    \ {'id':'b1', 'name':'test://xyz/foo/b1'    , 'match': 1},
-    \ {'id':'b2', 'name':'test:/xyz/foo/b2'     , 'match': 0},
-    \ {'id':'b3', 'name':'test+abc://xyz/foo/b3', 'match': 0},
-    \ {'id':'b4', 'name':'test_abc://xyz/foo/b4', 'match': 0},
-    \ {'id':'b5', 'name':'test-abc://xyz/foo/b5', 'match': 1},
-    \ {'id':'b6', 'name':'-test://xyz/foo/b6'   , 'match': 0},
-    \ {'id':'b7', 'name':'test-://xyz/foo/b7'   , 'match': 0},
+    \ {'id':'b0', 'name':'test://xyz/foo/b0'    , 'match': 1},
+    \ {'id':'b1', 'name':'test+abc://xyz/foo/b1', 'match': 0},
+    \ {'id':'b2', 'name':'test_abc://xyz/foo/b2', 'match': 0},
+    \ {'id':'b3', 'name':'test-abc://xyz/foo/b3', 'match': 1},
+    \ {'id':'b4', 'name':'-test://xyz/foo/b4'   , 'match': 0},
+    \ {'id':'b5', 'name':'test-://xyz/foo/b5'   , 'match': 0},
     \]
-  augroup Bufname_scheme
-    au!
-    autocmd BufReadCmd test://*     call s:Test_buffer_scheme_open(expand('<amatch>'))
-    autocmd BufReadCmd test+abc://* call s:Test_buffer_scheme_open(expand('<amatch>'))
-    autocmd BufReadCmd test_abc://* call s:Test_buffer_scheme_open(expand('<amatch>'))
-    autocmd BufReadCmd test-abc://* call s:Test_buffer_scheme_open(expand('<amatch>'))
-    autocmd BufReadCmd -test://*    call s:Test_buffer_scheme_open(expand('<amatch>'))
-    autocmd BufReadCmd test-://*    call s:Test_buffer_scheme_open(expand('<amatch>'))
-  augroup END
   for buf in bufnames
     new `=buf.name`
     if buf.match

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -384,6 +384,8 @@ endfunc
 " Test for buffer match URL(scheme) check
 " scheme is alpha and inner hyphen only.
 func Test_buffer_scheme()
+  CheckMSWindows
+  set noshellslash
   %bwipe!
   let bufnames = [
     \ {'id':'b0', 'name':'test://xyz/foo/b0'    , 'match': 1},

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -381,6 +381,43 @@ func Test_balt()
   call assert_equal('OtherBuffer', bufname())
 endfunc
 
+func s:Test_buffer_scheme_open(url)
+  echomsg 'open:' a:url
+endfunc
+
+func Test_buffer_scheme()
+  CheckMSWindows
+  set noshellslash
+  %bwipe!
+  let bufnames = [
+    \ {'id':'b0', 'name':'test/abc/b0'          , 'match': 0},
+    \ {'id':'b1', 'name':'test://xyz/foo/b1'    , 'match': 1},
+    \ {'id':'b2', 'name':'test:/xyz/foo/b2'     , 'match': 0},
+    \ {'id':'b3', 'name':'test+abc://xyz/foo/b3', 'match': 0},
+    \ {'id':'b4', 'name':'test_abc://xyz/foo/b4', 'match': 0},
+    \ {'id':'b5', 'name':'test-abc://xyz/foo/b5', 'match': 1},
+    \ {'id':'b6', 'name':'-test://xyz/foo/b6'   , 'match': 0},
+    \ {'id':'b7', 'name':'test-://xyz/foo/b7'   , 'match': 0},
+    \]
+  augroup Bufname_scheme
+    au!
+    autocmd BufReadCmd test://*     call s:Test_buffer_scheme_open(expand('<amatch>'))
+    autocmd BufReadCmd test+abc://* call s:Test_buffer_scheme_open(expand('<amatch>'))
+    autocmd BufReadCmd test_abc://* call s:Test_buffer_scheme_open(expand('<amatch>'))
+    autocmd BufReadCmd test-abc://* call s:Test_buffer_scheme_open(expand('<amatch>'))
+    autocmd BufReadCmd -test://*    call s:Test_buffer_scheme_open(expand('<amatch>'))
+    autocmd BufReadCmd test-://*    call s:Test_buffer_scheme_open(expand('<amatch>'))
+  augroup END
+  for buf in bufnames
+    new `=buf.name`
+    if buf.match
+      call assert_equal(buf.name,    getbufinfo(buf.id)[0].name)
+    else
+      call assert_notequal(buf.name, getbufinfo(buf.id)[0].name)
+    endif
+  endfor
+endfunc
+
 " Test for the 'maxmem' and 'maxmemtot' options
 func Test_buffer_maxmem()
   " use 1KB per buffer and 2KB for all the buffers


### PR DESCRIPTION
# Problem

Currently scheme check is not support symbol char  `.`, `+` and `-`

# Solution

This PR is fix above problem under RFC 3986 like scheme rule.
ref : [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1)

## Details

<details>
<summary>old suggest</summary>
Scheme is defined in RFC 1738 and successor RFC 3986 (supplement RFC 2234)

RFC 1738 rule:
```
scheme = 1*[ lowalpha | digit | "+" | "-" | "." ]
```

RFC 3986 rule:
```
scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
```

---

This PR based on RFC 3986.
</details>

new suggest

Add support `-` in scheme string (start and end do not support).

## Test

Later

related issue : https://github.com/vim-jp/issues/issues/1341