### PR TITLE
win32: Recognize "default" as the system encoding

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3116,8 +3116,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	because Vim cannot detect an error, thus the encoding is always
 	accepted.
 	The special value "default" can be used for the encoding from the
-	environment.  This is the default value for 'encoding'.  It is useful
-	when 'encoding' is set to "utf-8" and your environment uses a
+	environment.  On MS-Windows this is the system encoding.  Otherwise
+	this is the default value for 'encoding'.  It is useful when
+	'encoding' is set to "utf-8" and your environment uses a
 	non-latin1 encoding, such as Russian.
 	When 'encoding' is "utf-8" and a file contains an illegal byte
 	sequence it won't be recognized as UTF-8.  You can use the |8g8|

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4453,8 +4453,13 @@ enc_canonize(char_u *enc)
 
     if (STRCMP(enc, "default") == 0)
     {
+#ifdef MSWIN
+	// Use the system encoding.
+	r = enc_locale();
+#else
 	// Use the default encoding as it's found by set_init_1().
 	r = get_encoding_default();
+#endif
 	if (r == NULL)
 	    r = (char_u *)ENC_DFLT;
 	return vim_strsave(r);


### PR DESCRIPTION
Fix #8297.

Even after the default value of 'enc' is changed to "utf-8", the
"default" value should be recognized as the system encoding so that Vim
can read a file written in the system encoding.