### PR TITLE
Define and use ARRAY_LENGTH macro

### DIFF
--- a/src/arabic.c
+++ b/src/arabic.c
@@ -163,8 +163,6 @@ static struct achar {
 
 #define a_BYTE_ORDER_MARK		0xfeff
 
-#define ARRAY_SIZE(a)		(sizeof(a) / sizeof((a)[0]))
-
 /*
  * Find the struct achar pointer to the given Arabic char.
  * Returns NULL if not found.
@@ -175,7 +173,7 @@ find_achar(int c)
     int h, m, l;
 
     // using binary search to find c
-    h = ARRAY_SIZE(achars);
+    h = ARRAY_LENGTH(achars);
     l = 0;
     while (l < h)
     {

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -23,8 +23,6 @@
 
 #if defined(FEAT_CRYPT) || defined(PROTO)
 
-#define ARRAY_LENGTH(A)      (sizeof(A)/sizeof(A[0]))
-
 #define BF_BLOCK    8
 #define BF_BLOCK_MASK 7
 #define BF_MAX_CFB_LEN  (8 * BF_BLOCK)

--- a/src/cindent.c
+++ b/src/cindent.c
@@ -718,7 +718,7 @@ cin_isinit(void)
     {
 	int i, l;
 
-	for (i = 0; i < (int)(sizeof(skip) / sizeof(char *)); ++i)
+	for (i = 0; i < (int)ARRAY_LENGTH(skip); ++i)
 	{
 	    l = (int)strlen(skip[i]);
 	    if (cin_starts_with(s, skip[i]))

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2155,7 +2155,7 @@ ExpandFromContext(
 	// Find a context in the table and call the ExpandGeneric() with the
 	// right function to do the expansion.
 	ret = FAIL;
-	for (i = 0; i < (int)(sizeof(tab) / sizeof(struct expgen)); ++i)
+	for (i = 0; i < (int)ARRAY_LENGTH(tab); ++i)
 	    if (xp->xp_context == tab[i].context)
 	    {
 		if (tab[i].ic)

--- a/src/cmdhist.c
+++ b/src/cmdhist.c
@@ -98,7 +98,7 @@ get_history_arg(expand_T *xp UNUSED, int idx)
     static char_u compl[2] = { NUL, NUL };
     char *short_names = ":=@>?/";
     int short_names_count = (int)STRLEN(short_names);
-    int history_name_count = sizeof(history_names) / sizeof(char *) - 1;
+    int history_name_count = ARRAY_LENGTH(history_names) - 1;
 
     if (idx < short_names_count)
     {

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -59,7 +59,7 @@ struct choice
 struct choice	choices[30];		// choices the user can make
 int		choice_count = 0;	// number of choices available
 
-#define TABLE_SIZE(s)	(int)(sizeof(s) / sizeof(*s))
+#define TABLE_SIZE(s)	(int)ARRAYSIZE(s)
 
 enum
 {
@@ -1527,8 +1527,7 @@ register_openwith(
 		"*\\OpenWithList\\gvim.exe",
 	};
 
-	for (i = 0; ERROR_SUCCESS == lRet
-			   && i < sizeof(openwith) / sizeof(openwith[0]); i++)
+	for (i = 0; ERROR_SUCCESS == lRet && i < ARRAYSIZE(openwith); i++)
 	    lRet = reg_create_key_and_value(hRootKey, openwith[i], NULL, "", flag);
     }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -125,7 +125,7 @@ compare_func_name(const void *s1, const void *s2)
     static void
 sortFunctions(void)
 {
-    int		funcCnt = (int)(sizeof(functions) / sizeof(struct fst)) - 1;
+    int		funcCnt = (int)ARRAY_LENGTH(functions) - 1;
 
     qsort(functions, (size_t)funcCnt, sizeof(struct fst), compare_func_name);
 }

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1877,7 +1877,7 @@ get_function_name(expand_T *xp, int idx)
 	    return name;
 	}
     }
-    if (++intidx < (int)(sizeof(global_functions) / sizeof(funcentry_T)))
+    if (++intidx < (int)ARRAY_LENGTH(global_functions))
     {
 	STRCPY(IObuff, global_functions[intidx].f_name);
 	STRCAT(IObuff, "(");
@@ -1923,7 +1923,7 @@ find_internal_func_opt(char_u *name, int implemented)
     int		cmp;
     int		x;
 
-    last = (int)(sizeof(global_functions) / sizeof(funcentry_T)) - 1;
+    last = (int)ARRAY_LENGTH(global_functions) - 1;
 
     // Find the function name in the table. Binary search.
     while (first <= last)

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3735,7 +3735,7 @@ modifier_len(char_u *cmd)
 
     if (VIM_ISDIGIT(*cmd))
 	p = skipwhite(skipdigits(cmd + 1));
-    for (i = 0; i < (int)(sizeof(cmdmods) / sizeof(struct cmdmod)); ++i)
+    for (i = 0; i < (int)ARRAY_LENGTH(cmdmods); ++i)
     {
 	for (j = 0; p[j] != NUL; ++j)
 	    if (p[j] != cmdmods[i].name[j])
@@ -3762,7 +3762,7 @@ cmd_exists(char_u *name)
     char_u	*p;
 
     // Check command modifiers.
-    for (i = 0; i < (int)(sizeof(cmdmods) / sizeof(struct cmdmod)); ++i)
+    for (i = 0; i < (int)ARRAY_LENGTH(cmdmods); ++i)
     {
 	for (j = 0; name[j] != NUL; ++j)
 	    if (name[j] != cmdmods[i].name[j])
@@ -8732,7 +8732,7 @@ find_cmdline_var(char_u *src, int *usedlen)
 #endif
     };
 
-    for (i = 0; i < (int)(sizeof(spec_str) / sizeof(char *)); ++i)
+    for (i = 0; i < (int)ARRAY_LENGTH(spec_str); ++i)
     {
 	len = (int)STRLEN(spec_str[i]);
 	if (STRNCMP(src, spec_str[i], len) == 0)

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5073,7 +5073,7 @@ vim_tempname(
 	/*
 	 * Try the entries in TEMPDIRNAMES to create the temp directory.
 	 */
-	for (i = 0; i < (int)(sizeof(tempdirs) / sizeof(char *)); ++i)
+	for (i = 0; i < (int)ARRAY_LENGTH(tempdirs); ++i)
 	{
 # ifndef HAVE_MKDTEMP
 	    size_t	itmplen;

--- a/src/gui_athena.c
+++ b/src/gui_athena.c
@@ -469,7 +469,7 @@ get_toolbar_pixmap(vimmenu_T *menu, Pixmap *sen)
     if (menu->icon_builtin || gui_find_bitmap(menu->name, buf, "xpm") == FAIL)
     {
 	if (menu->iconidx >= 0 && menu->iconidx
-	      < (int)(sizeof(built_in_pixmaps) / sizeof(built_in_pixmaps[0])))
+	      < (int)ARRAY_LENGTH(built_in_pixmaps))
 	    xpm = built_in_pixmaps[menu->iconidx];
 	else
 	    xpm = tb_blank_xpm;

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -134,7 +134,7 @@ static const GtkTargetEntry selection_targets[] =
     {"TEXT",		0, TARGET_TEXT},
     {"STRING",		0, TARGET_STRING}
 };
-#define N_SELECTION_TARGETS (sizeof(selection_targets) / sizeof(selection_targets[0]))
+#define N_SELECTION_TARGETS ARRAY_LENGTH(selection_targets)
 
 #ifdef FEAT_DND
 /*
@@ -149,7 +149,7 @@ static const GtkTargetEntry dnd_targets[] =
     {"STRING",		0, TARGET_STRING},
     {"text/plain",	0, TARGET_TEXT_PLAIN}
 };
-# define N_DND_TARGETS (sizeof(dnd_targets) / sizeof(dnd_targets[0]))
+# define N_DND_TARGETS ARRAY_LENGTH(dnd_targets)
 #endif
 
 
@@ -6853,7 +6853,7 @@ mch_set_mouse_shape(int shape)
 	    else
 		id &= ~1;	// they are always even (why?)
 	}
-	else if (shape < (int)(sizeof(mshape_ids) / sizeof(int)))
+	else if (shape < (int)ARRAY_LENGTH(mshape_ids))
 	    id = mshape_ids[shape];
 	else
 	    return;

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -638,7 +638,7 @@ static struct specialkey
     {0,		    0, 0}
 };
 
-#define NUM_SPECIAL_KEYS    (sizeof(special_keys)/sizeof(special_keys[0]))
+#define NUM_SPECIAL_KEYS    ARRAY_LENGTH(special_keys)
 
 // ---------------- VimApp ----------------
 

--- a/src/gui_photon.c
+++ b/src/gui_photon.c
@@ -34,7 +34,6 @@
 # define PhImage_t	int
 #endif
 
-#define ARRAY_LENGTH(a) (sizeof(a) / sizeof(a[0]))
 #define RGB(r, g, b) PgRGB(r, g, b)
 
 #define EVENT_BUFFER_SIZE sizeof(PhEvent_t) + 1000

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -1627,7 +1627,7 @@ gui_mch_get_color(char_u *name)
     /*
      * Try to look up a system colour.
      */
-    for (i = 0; i < sizeof(sys_table) / sizeof(sys_table[0]); i++)
+    for (i = 0; i < ARRAY_LENGTH(sys_table); i++)
 	if (STRICMP(name, sys_table[i].name) == 0)
 	    return GetSysColor(sys_table[i].color);
 

--- a/src/gui_xmebw.c
+++ b/src/gui_xmebw.c
@@ -455,7 +455,7 @@ set_pixmap(XmEnhancedButtonWidget eb)
     attr.valuemask = XpmColorSymbols | XpmCloseness | XpmColorKey;
     attr.closeness = 65535;	// accuracy isn't crucial
     attr.colorsymbols = color;
-    attr.numsymbols = sizeof(color) / sizeof(color[0]);
+    attr.numsymbols = ARRAY_LENGTH(color);
     attr.color_key = XPM_MONO;
     status = XpmCreatePixmapFromData(dpy, root, data, &pix, &mask, &attr);
 

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -972,8 +972,6 @@ hardcopy_line(
  * http://www.adobe.com
  */
 
-#define NUM_ELEMENTS(arr)   (sizeof(arr)/sizeof((arr)[0]))
-
 #define PRT_PS_DEFAULT_DPI	    (72)    // Default user space resolution
 #define PRT_PS_DEFAULT_FONTSIZE     (10)
 #define PRT_PS_DEFAULT_BUFFER_SIZE  (80)
@@ -985,7 +983,7 @@ struct prt_mediasize_S
     float	height;
 };
 
-#define PRT_MEDIASIZE_LEN  (sizeof(prt_mediasize) / sizeof(struct prt_mediasize_S))
+#define PRT_MEDIASIZE_LEN  ARRAY_LENGTH(prt_mediasize)
 
 static struct prt_mediasize_S prt_mediasize[] =
 {
@@ -1210,33 +1208,33 @@ struct prt_ps_mbfont_S
 static struct prt_ps_mbfont_S prt_ps_mbfonts[] =
 {
     {
-	NUM_ELEMENTS(j_encodings),
+	ARRAY_LENGTH(j_encodings),
 	j_encodings,
-	NUM_ELEMENTS(j_charsets),
+	ARRAY_LENGTH(j_charsets),
 	j_charsets,
 	"jis_roman",
 	"JIS_X_1983"
     },
     {
-	NUM_ELEMENTS(sc_encodings),
+	ARRAY_LENGTH(sc_encodings),
 	sc_encodings,
-	NUM_ELEMENTS(sc_charsets),
+	ARRAY_LENGTH(sc_charsets),
 	sc_charsets,
 	"gb_roman",
 	"GB_2312-80"
     },
     {
-	NUM_ELEMENTS(tc_encodings),
+	ARRAY_LENGTH(tc_encodings),
 	tc_encodings,
-	NUM_ELEMENTS(tc_charsets),
+	ARRAY_LENGTH(tc_charsets),
 	tc_charsets,
 	"cns_roman",
 	"BIG5"
     },
     {
-	NUM_ELEMENTS(k_encodings),
+	ARRAY_LENGTH(k_encodings),
 	k_encodings,
-	NUM_ELEMENTS(k_charsets),
+	ARRAY_LENGTH(k_charsets),
 	k_charsets,
 	"ks_roman",
 	"KS_X_1992"
@@ -1793,12 +1791,12 @@ prt_next_dsc(struct prt_dsc_line_S *p_dsc_line)
 	return FALSE;
 
     // Find type of DSC comment
-    for (comment = 0; comment < (int)NUM_ELEMENTS(prt_dsc_table); comment++)
+    for (comment = 0; comment < (int)ARRAY_LENGTH(prt_dsc_table); comment++)
 	if (prt_resfile_strncmp(0, prt_dsc_table[comment].string,
 					    prt_dsc_table[comment].len) == 0)
 	    break;
 
-    if (comment != NUM_ELEMENTS(prt_dsc_table))
+    if (comment != ARRAY_LENGTH(prt_dsc_table))
     {
 	// Return type of comment
 	p_dsc_line->type = prt_dsc_table[comment].type;
@@ -2385,7 +2383,7 @@ mch_print_init(
 	int cmap_first = 0;
 
 	p_mbenc_first = NULL;
-	for (cmap = 0; cmap < (int)NUM_ELEMENTS(prt_ps_mbfonts); cmap++)
+	for (cmap = 0; cmap < (int)ARRAY_LENGTH(prt_ps_mbfonts); cmap++)
 	    if (prt_match_encoding((char *)p_encoding, &prt_ps_mbfonts[cmap],
 								    &p_mbenc))
 	    {

--- a/src/help.c
+++ b/src/help.c
@@ -381,7 +381,7 @@ find_help_tags(
 	// When the string starting with "expr-" and containing '?' and matches
 	// the table, it is taken literally (but ~ is escaped).  Otherwise '?'
 	// is recognized as a wildcard.
-	for (i = (int)(sizeof(expr_table) / sizeof(char *)); --i >= 0; )
+	for (i = (int)ARRAY_LENGTH(expr_table); --i >= 0; )
 	    if (STRCMP(arg + 5, expr_table[i]) == 0)
 	    {
 		int si = 0, di = 0;

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -998,7 +998,7 @@ do_highlight(
 	    off = 0;
 	    while (arg[off] != NUL)
 	    {
-		for (i = sizeof(hl_attr_table) / sizeof(int); --i >= 0; )
+		for (i = ARRAY_LENGTH(hl_attr_table); --i >= 0; )
 		{
 		    len = (int)STRLEN(hl_name_table[i]);
 		    if (STRNICMP(arg + off, hl_name_table[i], len) == 0)
@@ -1168,7 +1168,7 @@ do_highlight(
 
 		// reduce calls to STRICMP a bit, it can be slow
 		off = TOUPPER_ASC(*arg);
-		for (i = (sizeof(color_names) / sizeof(char *)); --i >= 0; )
+		for (i = ARRAY_LENGTH(color_names); --i >= 0; )
 		    if (off == color_names[i][0]
 				 && STRICMP(arg + 1, color_names[i] + 1) == 0)
 			break;

--- a/src/if_mzsch.c
+++ b/src/if_mzsch.c
@@ -3799,7 +3799,7 @@ make_modules(void)
     mod = scheme_primitive_module(vimext_symbol, environment);
     MZ_GC_CHECK();
     // all prims made closed so they can access their own names
-    for (i = 0; i < (int)(sizeof(prims)/sizeof(prims[0])); i++)
+    for (i = 0; i < (int)ARRAY_LENGTH(prims); i++)
     {
 	Vim_Prim *prim = prims + i;
 	closed_prim = scheme_make_closed_prim_w_arity(prim->prim, prim, prim->name,

--- a/src/macros.h
+++ b/src/macros.h
@@ -396,3 +396,6 @@
 #ifndef MAX
 # define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
+
+// Length of the array.
+#define ARRAY_LENGTH(a) (sizeof(a) / sizeof((a)[0]))

--- a/src/main.c
+++ b/src/main.c
@@ -3435,7 +3435,7 @@ usage(void)
     {
 	mch_msg(_(" vim [arguments] "));
 	mch_msg(_(use[i]));
-	if (i == (sizeof(use) / sizeof(char_u *)) - 1)
+	if (i == ARRAY_LENGTH(use) - 1)
 	    break;
 	mch_msg(_("\n   or:"));
     }

--- a/src/map.c
+++ b/src/map.c
@@ -2478,13 +2478,12 @@ init_mappings(void)
     if (!gui.starting)
 #  endif
     {
-	for (i = 0;
-		i < (int)(sizeof(cinitmappings) / sizeof(struct initmap)); ++i)
+	for (i = 0; i < (int)ARRAY_LENGTH(cinitmappings); ++i)
 	    add_map(cinitmappings[i].arg, cinitmappings[i].mode);
     }
 # endif
 # if defined(FEAT_GUI_MSWIN) || defined(MACOS_X)
-    for (i = 0; i < (int)(sizeof(initmappings) / sizeof(struct initmap)); ++i)
+    for (i = 0; i < (int)ARRAY_LENGTH(initmappings); ++i)
 	add_map(initmappings[i].arg, initmappings[i].mode);
 # endif
 #endif

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -2850,7 +2850,7 @@ utf_class_buf(int c, buf_T *buf)
     };
 
     int bot = 0;
-    int top = sizeof(classes) / sizeof(struct clinterval) - 1;
+    int top = ARRAY_LENGTH(classes) - 1;
     int mid;
 
     // First quick check for Latin1 characters, use 'iskeyword'.
@@ -3948,7 +3948,7 @@ utf_allow_break_before(int cc)
     };
 
     int first = 0;
-    int last  = sizeof(BOL_prohibition_punct)/sizeof(int) - 1;
+    int last  = ARRAY_LENGTH(BOL_prohibition_punct) - 1;
     int mid   = 0;
 
     while (first < last)
@@ -3998,7 +3998,7 @@ utf_allow_break_after(int cc)
     };
 
     int first = 0;
-    int last  = sizeof(EOL_prohibition_punct)/sizeof(int) - 1;
+    int last  = ARRAY_LENGTH(EOL_prohibition_punct) - 1;
     int mid   = 0;
 
     while (first < last)

--- a/src/memline.c
+++ b/src/memline.c
@@ -1312,7 +1312,7 @@ ml_recover(int checkext)
     }
 
 #ifdef FEAT_CRYPT
-    for (i = 0; i < (int)(sizeof(id1_codes) / sizeof(int)); ++i)
+    for (i = 0; i < (int)ARRAY_LENGTH(id1_codes); ++i)
 	if (id1_codes[i] == b0p->b0_id[1])
 	    b0_cm = i;
     if (b0_cm > 0)

--- a/src/menu.c
+++ b/src/menu.c
@@ -73,7 +73,7 @@ static const char *toolbar_names[] =
     /* 25 */ "Make", "TagJump", "RunCtags", "WinVSplit", "WinMaxWidth",
     /* 30 */ "WinMinWidth", "Exit"
 };
-# define TOOLBAR_NAME_COUNT (sizeof(toolbar_names) / sizeof(char *))
+# define TOOLBAR_NAME_COUNT ARRAY_LENGTH(toolbar_names)
 #endif
 
 /*

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2542,7 +2542,7 @@ static struct key_name_entry
     // NOTE: When adding a long name update MAX_KEY_NAME_LEN.
 };
 
-#define KEY_NAMES_TABLE_LEN (sizeof(key_names_table) / sizeof(struct key_name_entry))
+#define KEY_NAMES_TABLE_LEN ARRAY_LENGTH(key_names_table)
 
 /*
  * Return the modifier mask bit (MOD_MASK_*) which corresponds to the given

--- a/src/normal.c
+++ b/src/normal.c
@@ -379,7 +379,7 @@ static const struct nv_cmd
 };
 
 // Number of commands in nv_cmds[].
-#define NV_CMDS_SIZE (sizeof(nv_cmds) / sizeof(struct nv_cmd))
+#define NV_CMDS_SIZE ARRAY_LENGTH(nv_cmds)
 
 // Sorted index of commands in nv_cmds[].
 static short nv_cmd_idx[NV_CMDS_SIZE];

--- a/src/ops.c
+++ b/src/ops.c
@@ -82,7 +82,7 @@ get_op_type(int char1, int char2)
     {
 	if (opchars[i][0] == char1 && opchars[i][1] == char2)
 	    break;
-	if (i == (int)(sizeof(opchars) / sizeof(char [3]) - 1))
+	if (i == (int)ARRAY_LENGTH(opchars) - 1)
 	{
 	    internal_error("get_op_type()");
 	    break;

--- a/src/option.c
+++ b/src/option.c
@@ -145,7 +145,7 @@ set_init_1(int clean_arg)
 	opt_idx = findoption((char_u *)"backupskip");
 
 	ga_init2(&ga, 1, 100);
-	for (n = 0; n < (long)(sizeof(names) / sizeof(char *)); ++n)
+	for (n = 0; n < (long)ARRAY_LENGTH(names); ++n)
 	{
 	    mustfree = FALSE;
 # ifdef UNIX
@@ -6317,8 +6317,7 @@ ExpandSettings(
 	regmatch->rm_ic = ic;
 	if (xp->xp_context != EXPAND_BOOL_SETTINGS)
 	{
-	    for (match = 0; match < (int)(sizeof(names) / sizeof(char *));
-								      ++match)
+	    for (match = 0; match < (int)ARRAY_LENGTH(names); ++match)
 		if (vim_regexec(regmatch, (char_u *)names[match], (colnr_T)0))
 		{
 		    if (loop == 0)

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -3033,7 +3033,7 @@ static struct vimoption options[] =
     {NULL, NULL, 0, NULL, PV_NONE, {NULL, NULL} SCTX_INIT}
 };
 
-#define OPTION_COUNT (sizeof(options) / sizeof(struct vimoption))
+#define OPTION_COUNT ARRAY_LENGTH(options)
 
 // The following is needed to make the gen_opt_test.vim script work.
 // {"

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -1105,7 +1105,7 @@ decode_key_event(
 	return TRUE;
     }
 
-    for (i = sizeof(VirtKeyMap) / sizeof(VirtKeyMap[0]);  --i >= 0;  )
+    for (i = ARRAY_LENGTH(VirtKeyMap);  --i >= 0;  )
     {
 	if (VirtKeyMap[i].wVirtKey == pker->wVirtualKeyCode)
 	{
@@ -3045,7 +3045,7 @@ mch_get_user_name(
     int	    len)
 {
     WCHAR wszUserName[256 + 1];	// UNLEN is 256
-    DWORD wcch = sizeof(wszUserName) / sizeof(WCHAR);
+    DWORD wcch = ARRAY_LENGTH(wszUserName);
 
     if (GetUserNameW(wszUserName, &wcch))
     {
@@ -3072,7 +3072,7 @@ mch_get_host_name(
     int		len)
 {
     WCHAR wszHostName[256 + 1];
-    DWORD wcch = sizeof(wszHostName) / sizeof(WCHAR);
+    DWORD wcch = ARRAY_LENGTH(wszHostName);
 
     if (GetComputerNameW(wszHostName, &wcch))
     {
@@ -4757,8 +4757,7 @@ mch_call_shell(
     WCHAR	szShellTitle[512];
 
     // Change the title to reflect that we are in a subshell.
-    if (GetConsoleTitleW(szShellTitle,
-		sizeof(szShellTitle)/sizeof(WCHAR) - 4) > 0)
+    if (GetConsoleTitleW(szShellTitle, ARRAY_LENGTH(szShellTitle) - 4) > 0)
     {
 	if (cmd == NULL)
 	    wcscat(szShellTitle, L" :sh");
@@ -4770,7 +4769,7 @@ mch_call_shell(
 	    {
 		wcscat(szShellTitle, L" - !");
 		if ((wcslen(szShellTitle) + wcslen(wn) <
-			    sizeof(szShellTitle)/sizeof(WCHAR)))
+			    ARRAY_LENGTH(szShellTitle)))
 		    wcscat(szShellTitle, wn);
 		SetConsoleTitleW(szShellTitle);
 		vim_free(wn);

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -402,8 +402,7 @@ get_pos_entry(dict_T *d, int give_error)
     if (str == NULL)
 	return POPPOS_NONE;
 
-    for (nr = 0; nr < (int)(sizeof(poppos_entries) / sizeof(poppos_entry_T));
-									  ++nr)
+    for (nr = 0; nr < (int)ARRAY_LENGTH(poppos_entries); ++nr)
 	if (STRCMP(str, poppos_entries[nr].pp_name) == 0)
 	    return poppos_entries[nr].pp_val;
 
@@ -3042,8 +3041,7 @@ f_popup_getoptions(typval_T *argvars, typval_T *rettv)
 	if (wp->w_close_cb.cb_name != NULL)
 	    dict_add_callback(dict, "callback", &wp->w_close_cb);
 
-	for (i = 0; i < (int)(sizeof(poppos_entries) / sizeof(poppos_entry_T));
-									   ++i)
+	for (i = 0; i < (int)ARRAY_LENGTH(poppos_entries); ++i)
 	    if (wp->w_popup_pos == poppos_entries[i].pp_val)
 	    {
 		dict_add_string(dict, "pos",

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5971,7 +5971,7 @@ vgr_match_buflines(
 	    char_u  *str = ml_get_buf(buf, lnum, FALSE);
 	    int	    score;
 	    int_u   matches[MAX_FUZZY_MATCHES];
-	    int_u   sz = sizeof(matches) / sizeof(matches[0]);
+	    int_u   sz = ARRAY_LENGTH(matches);
 
 	    // Fuzzy string match
 	    while (fuzzy_match(str + col, spat, FALSE, &score, matches, sz) > 0)

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -202,7 +202,7 @@ get_char_class(char_u **pp)
 
     if ((*pp)[1] == ':')
     {
-	for (i = 0; i < (int)(sizeof(class_names) / sizeof(*class_names)); ++i)
+	for (i = 0; i < (int)ARRAY_LENGTH(class_names); ++i)
 	    if (STRNCMP(*pp + 2, class_names[i], STRLEN(class_names[i])) == 0)
 	    {
 		*pp += STRLEN(class_names[i]) + 2;

--- a/src/screen.c
+++ b/src/screen.c
@@ -4817,14 +4817,14 @@ set_chars_option(win_T *wp, char_u **varp)
     {
 	tab = lcstab;
 	CLEAR_FIELD(lcs_chars);
-	entries = sizeof(lcstab) / sizeof(struct charstab);
+	entries = ARRAY_LENGTH(lcstab);
 	if (varp == &wp->w_p_lcs && wp->w_p_lcs[0] == NUL)
 	    varp = &p_lcs;
     }
     else
     {
 	tab = filltab;
-	entries = sizeof(filltab) / sizeof(struct charstab);
+	entries = ARRAY_LENGTH(filltab);
     }
 
     // first round: check for valid value, second round: assign values

--- a/src/search.c
+++ b/src/search.c
@@ -4444,7 +4444,7 @@ fuzzy_match_recursive(
 	    if (fuzzy_match_recursive(fuzpat, next_char, strIdx + 1,
 			&recursiveScore, strBegin, strLen, matches,
 			recursiveMatches,
-			sizeof(recursiveMatches)/sizeof(recursiveMatches[0]),
+			ARRAY_LENGTH(recursiveMatches),
 			nextMatch, recursionCount))
 	    {
 		// Pick best recursive score

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -4573,7 +4573,7 @@ get_syn_options(
 	if (strchr(first_letters, *arg) == NULL)
 	    break;
 
-	for (fidx = sizeof(flagtab) / sizeof(struct flag); --fidx >= 0; )
+	for (fidx = ARRAY_LENGTH(flagtab); --fidx >= 0; )
 	{
 	    p = flagtab[fidx].name;
 	    for (i = 0, len = 0; p[i] != NUL; i += 2, ++len)

--- a/src/term.c
+++ b/src/term.c
@@ -6725,7 +6725,7 @@ gui_get_color_cmn(char_u *name)
     }
 
     // Check if the name is one of the colors we know
-    for (i = 0; i < (int)(sizeof(rgb_table) / sizeof(rgb_table[0])); i++)
+    for (i = 0; i < (int)ARRAY_LENGTH(rgb_table); i++)
 	if (STRICMP(name, rgb_table[i].color_name) == 0)
 	    return gui_adjust_rgb(rgb_table[i].color);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -5691,7 +5691,7 @@ f_term_getattr(typval_T *argvars, typval_T *rettv)
 
     if (attr > HL_ALL)
 	attr = syn_attr2attr(attr);
-    for (i = 0; i < sizeof(attrs)/sizeof(attrs[0]); ++i)
+    for (i = 0; i < ARRAY_LENGTH(attrs); ++i)
 	if (STRCMP(name, attrs[i].name) == 0)
 	{
 	    rettv->vval.v_number = (attr & attrs[i].attr) != 0 ? 1 : 0;

--- a/src/time.c
+++ b/src/time.c
@@ -276,8 +276,7 @@ f_strftime(typval_T *argvars, typval_T *rettv)
 
 	wp = enc_to_utf16(p, NULL);
 	if (wp != NULL)
-	    (void)wcsftime(result_buf, sizeof(result_buf) / sizeof(WCHAR),
-								wp, curtime);
+	    (void)wcsftime(result_buf, ARRAY_LENGTH(result_buf), wp, curtime);
 	else
 	    result_buf[0] = NUL;
 	rettv->vval.v_string = utf16_to_enc(result_buf, NULL);

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -339,7 +339,7 @@ get_user_cmd_flags(expand_T *xp UNUSED, int idx)
 	"count", "nargs", "range", "register"
     };
 
-    if (idx >= (int)(sizeof(user_cmd_flags) / sizeof(user_cmd_flags[0])))
+    if (idx >= (int)ARRAY_LENGTH(user_cmd_flags))
 	return NULL;
     return (char_u *)user_cmd_flags[idx];
 }
@@ -352,7 +352,7 @@ get_user_cmd_nargs(expand_T *xp UNUSED, int idx)
 {
     static char *user_cmd_nargs[] = {"0", "1", "*", "?", "+"};
 
-    if (idx >= (int)(sizeof(user_cmd_nargs) / sizeof(user_cmd_nargs[0])))
+    if (idx >= (int)ARRAY_LENGTH(user_cmd_nargs))
 	return NULL;
     return (char_u *)user_cmd_nargs[idx];
 }

--- a/src/version.c
+++ b/src/version.c
@@ -6625,7 +6625,7 @@ has_patch(int n)
 
     // Perform a binary search.
     l = 0;
-    h = (int)(sizeof(included_patches) / sizeof(included_patches[0])) - 1;
+    h = (int)ARRAY_LENGTH(included_patches) - 1;
     while (l < h)
     {
 	m = (l + h) / 2;
@@ -6852,7 +6852,7 @@ list_version(void)
     {
 	msg_puts(_("\nIncluded patches: "));
 	first = -1;
-	i = (int)(sizeof(included_patches) / sizeof(included_patches[0])) - 1;
+	i = (int)ARRAY_LENGTH(included_patches) - 1;
 	while (--i >= 0)
 	{
 	    if (first < 0)
@@ -7143,7 +7143,7 @@ intro_message(
 #endif
 
     // blanklines = screen height - # message lines
-    blanklines = (int)Rows - ((sizeof(lines) / sizeof(char *)) - 1);
+    blanklines = (int)Rows - (ARRAY_LENGTH(lines) - 1);
     if (!p_cp)
 	blanklines += 4;  // add 4 for not showing "Vi compatible" message
 
@@ -7162,7 +7162,7 @@ intro_message(
     row = blanklines / 2;
     if ((row >= 2 && Columns >= 50) || colon)
     {
-	for (i = 0; i < (int)(sizeof(lines) / sizeof(char *)); ++i)
+	for (i = 0; i < (int)ARRAY_LENGTH(lines); ++i)
 	{
 	    p = lines[i];
 #ifdef FEAT_GUI


### PR DESCRIPTION
The `(sizeof(arr) / sizeof((arr)[0]))` idiom was used very often in the
Vim source code.  Also ARRAY_SIZE, NUM_ELEMENTS and some other macros
were defined.  Unify them into ARRAY_LENGTH and use it everywhere when
we need the size of an array.

For MS-Windows, MS defines the ARRAYSIZE macro, so we can use it in the
Windows-specific files. (E.g. dosinst.c and gui_dwrite.cpp.)