### PR TITLE
(nitpick) Remove unnecessary lines

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -260,8 +260,6 @@ main
 
 #ifdef MSWIN
     {
-	extern void set_alist_count(void);
-
 	// Remember the number of entries in the argument list.  If it changes
 	// we don't react on setting 'encoding'.
 	set_alist_count();


### PR DESCRIPTION
set_alist_count is declared in os_win32.pro. No need to declare in
main.c.