### PR TITLE
Fix block pasting from the clipboard

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -2090,7 +2090,7 @@ clip_yank_selection(
 
     clip_free_selection(cbd);
 
-    str_to_reg(y_ptr, type, str, len, 0L, FALSE);
+    str_to_reg(y_ptr, type, str, len, -1, FALSE);
 }
 
 /*

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4308,7 +4308,6 @@ mb_charlen(char_u *str)
     return count;
 }
 
-#if (defined(FEAT_SPELL) || defined(FEAT_EVAL)) || defined(PROTO)
 /*
  * Like mb_charlen() but for a string with specified length.
  */
@@ -4323,7 +4322,6 @@ mb_charlen_len(char_u *str, int len)
 
     return count;
 }
-#endif
 
 /*
  * Try to un-escape a multi-byte character.

--- a/src/register.c
+++ b/src/register.c
@@ -2836,6 +2836,7 @@ str_to_reg(
     char_u	**ss;
     char_u	**pp;
     long	maxlen;
+    int	charlen;
 
     if (y_ptr->y_array == NULL)		// NULL means empty register
 	y_ptr->y_size = 0;
@@ -2894,22 +2895,25 @@ str_to_reg(
     {
 	for (ss = (char_u **) str; *ss != NULL; ++ss, ++lnum)
 	{
+	    charlen = MB_CHARLEN(*ss);
 	    i = (long)STRLEN(*ss);
 	    pp[lnum] = vim_strnsave(*ss, i);
-	    if (i > maxlen)
-		maxlen = i;
+	    if (charlen > maxlen)
+		maxlen = charlen;
 	}
     }
     else
     {
 	for (start = 0; start < len + extraline; start += i + 1)
 	{
+	    charlen = 0;
 	    for (i = start; i < len; ++i)	// find the end of the line
 		if (str[i] == '\n')
 		    break;
 	    i -= start;			// i is now length of line
-	    if (i > maxlen)
-		maxlen = i;
+	    charlen = mb_charlen_len(str + start, i);
+	    if (charlen > maxlen)
+		maxlen = charlen;
 	    if (append)
 	    {
 		--lnum;

--- a/src/register.c
+++ b/src/register.c
@@ -2911,7 +2911,8 @@ str_to_reg(
 		if (str[i] == '\n')
 		    break;
 	    i -= start;			// i is now length of line
-	    charlen = mb_charlen_len(str + start, i);
+	    if (start < len)
+		charlen = mb_charlen_len(str + start, i);
 	    if (charlen > maxlen)
 		maxlen = charlen;
 	    if (append)


### PR DESCRIPTION
When block-pasting from the clipboard, calculate the width of the block
correctly and update the register width to the correct size.

fixes: vim/vim#8301

No test, because this depends on the clipboard property.