### PR TITLE
Fixed 2 tests that failed when rightleft feature is not enabled

### DIFF
--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -1147,6 +1147,7 @@ endfunc
 
 " Test for the popup menu with the 'rightleft' option set
 func Test_pum_rightleft()
+  CheckFeature rightleft
   CheckScreendump
   let lines =<< trim END
     abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
@@ -1204,11 +1205,13 @@ func Test_pum_scrollbar()
   call term_sendkeys(buf, "\<C-E>\<Esc>dd")
   call term_wait(buf)
 
-  call term_sendkeys(buf, ":set rightleft\<CR>")
-  call term_wait(buf)
-  call term_sendkeys(buf, "Go\<C-P>\<C-P>\<C-P>")
-  call term_wait(buf)
-  call VerifyScreenDump(buf, 'Test_pum_scrollbar_02', {'rows': 7})
+  if has('rightleft')
+    call term_sendkeys(buf, ":set rightleft\<CR>")
+    call term_wait(buf)
+    call term_sendkeys(buf, "Go\<C-P>\<C-P>\<C-P>")
+    call term_wait(buf)
+    call VerifyScreenDump(buf, 'Test_pum_scrollbar_02', {'rows': 7})
+  endif
 
   call StopVimInTerminal(buf)
   call delete('Xtest1')


### PR DESCRIPTION
`Test_pum_rightleft` and `Test_pum_scrollbar` were failing when Vim is configured as follows:
```
$ ./configure --enable-gui=none --with-features=normal --enable-terminal
```
The 2 tests failed because they used the `rightleft` feature without checking that the feature was enabled.