### PR TITLE
Added more concise `.sc` filename for Scala source

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1497,6 +1497,7 @@ au BufNewFile,BufRead *.sa			setf sather
 
 " Scala
 au BufNewFile,BufRead *.scala			setf scala
+au BufNewFile,BufRead *.sc			setf scala
 
 " SBT - Scala Build Tool
 au BufNewFile,BufRead *.sbt			setf sbt


### PR DESCRIPTION
The file extension is recognized by some other text editors (e.g. VS Code) as a shorter extension for Scala source files. There are some like myself who prefer `.sc`, as `.scala` is really long and clunky and `.sc` is not in use for any other popular languages.