### PR TITLE
sound_playevent() and sound_playfile() did not return 0 on failure

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -351,7 +351,6 @@ f_sound_playevent(typval_T *argvars, typval_T *rettv)
 {
     WCHAR	    *wp;
 
-    rettv->vval.v_number = 0;
     wp = enc_to_utf16(tv_get_string(&argvars[0]), NULL);
     if (wp == NULL)
 	return;
@@ -373,7 +372,6 @@ f_sound_playfile(typval_T *argvars, typval_T *rettv)
     char	buf[32];
     MCIERROR	err;
 
-    rettv->vval.v_number = 0;
     esc = vim_strsave_shellescape(tv_get_string(&argvars[0]), FALSE, FALSE);
 
     len = STRLEN(esc) + 5 + 18 + 1;

--- a/src/sound.c
+++ b/src/sound.c
@@ -355,10 +355,12 @@ f_sound_playevent(typval_T *argvars, typval_T *rettv)
     if (wp == NULL)
 	return;
 
-    PlaySoundW(wp, NULL, SND_ASYNC | SND_ALIAS);
+    if (PlaySoundW(wp, NULL, SND_ASYNC | SND_ALIAS))
+	rettv->vval.v_number = ++sound_id;
+    else
+	rettv->vval.v_number = 0;
     free(wp);
 
-    rettv->vval.v_number = ++sound_id;
 }
 
     void
@@ -414,6 +416,7 @@ f_sound_playfile(typval_T *argvars, typval_T *rettv)
 failure:
     vim_snprintf(buf, sizeof(buf), "close sound%06ld", newid);
     mciSendString(buf, NULL, 0, NULL);
+    rettv->vval.v_number = 0;
 }
 
     void

--- a/src/sound.c
+++ b/src/sound.c
@@ -351,14 +351,13 @@ f_sound_playevent(typval_T *argvars, typval_T *rettv)
 {
     WCHAR	    *wp;
 
+    rettv->vval.v_number = 0;
     wp = enc_to_utf16(tv_get_string(&argvars[0]), NULL);
     if (wp == NULL)
 	return;
 
     if (PlaySoundW(wp, NULL, SND_ASYNC | SND_ALIAS))
 	rettv->vval.v_number = ++sound_id;
-    else
-	rettv->vval.v_number = 0;
     free(wp);
 
 }
@@ -374,6 +373,7 @@ f_sound_playfile(typval_T *argvars, typval_T *rettv)
     char	buf[32];
     MCIERROR	err;
 
+    rettv->vval.v_number = 0;
     esc = vim_strsave_shellescape(tv_get_string(&argvars[0]), FALSE, FALSE);
 
     len = STRLEN(esc) + 5 + 18 + 1;
@@ -416,7 +416,6 @@ f_sound_playfile(typval_T *argvars, typval_T *rettv)
 failure:
     vim_snprintf(buf, sizeof(buf), "close sound%06ld", newid);
     mciSendString(buf, NULL, 0, NULL);
-    rettv->vval.v_number = 0;
 }
 
     void

--- a/src/testdir/test_sound.vim
+++ b/src/testdir/test_sound.vim
@@ -75,12 +75,15 @@ func Test_play_silent()
 endfunc
 
 func Test_play_event_error()
-  call assert_equal(0, sound_playevent(''))
-  call assert_equal(0, sound_playevent(test_null_string()))
-  call assert_equal(0, sound_playevent('doesnotexist'))
-  call assert_equal(0, sound_playevent('doesnotexist', 'doesnotexist'))
-  call assert_equal(0, sound_playevent(test_null_string(), test_null_string()))
-  call assert_equal(0, sound_playevent(test_null_string(), test_null_function()))
+  " FIXME: sound_playevent() don't return 0 in case of error on Windows?!
+  if !has('win32')
+    call assert_equal(0, sound_playevent(''))
+    call assert_equal(0, sound_playevent(test_null_string()))
+    call assert_equal(0, sound_playevent('doesnotexist'))
+    call assert_equal(0, sound_playevent('doesnotexist', 'doesnotexist'))
+    call assert_equal(0, sound_playevent(test_null_string(), test_null_string()))
+    call assert_equal(0, sound_playevent(test_null_string(), test_null_function()))
+  endif
 
   call assert_equal(0, sound_playfile(''))
   call assert_equal(0, sound_playfile(test_null_string()))

--- a/src/testdir/test_sound.vim
+++ b/src/testdir/test_sound.vim
@@ -75,11 +75,6 @@ func Test_play_silent()
 endfunc
 
 func Test_play_event_error()
-  " Do not run test on Windows as:
-  " - playing event with callback is not supported on Windows.
-  " - FIXME: even without callback, sound_playevent('') does not return 0 on Windows. Bug?
-  CheckNotMSWindows
-
   call assert_equal(0, sound_playevent(''))
   call assert_equal(0, sound_playevent(test_null_string()))
   call assert_equal(0, sound_playevent('doesnotexist'))


### PR DESCRIPTION
Functions sound_playevent() and sound_playfile() are documented
as returning 0 on error, but that was not the case on Windows.

I don't have a Windows machine to verify so I will rely on CI.