### PR TITLE
Unwrap terminal buffer

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -440,6 +440,7 @@ SRC_ALL =	\
 		src/libvterm/t/66screen_extent.test \
 		src/libvterm/t/67screen_dbl_wh.test \
 		src/libvterm/t/68screen_termprops.test \
+		src/libvterm/t/69screen_pushline.test \
 		src/libvterm/t/69screen_reflow.test \
 		src/libvterm/t/90vttest_01-movement-1.test \
 		src/libvterm/t/90vttest_01-movement-2.test \

--- a/src/libvterm/include/vterm.h
+++ b/src/libvterm/include/vterm.h
@@ -452,6 +452,8 @@ typedef struct {
   int (*resize)(int rows, int cols, VTermStateFields *fields, void *user);
   int (*setlineinfo)(int row, const VTermLineInfo *newinfo, const VTermLineInfo *oldinfo, void *user);
   int (*sb_clear)(void *user);
+  // ABI-compat only enabled if vterm_state_callbacks_has_premove() is invoked
+  int (*premove)(VTermRect dest, void *user);
 } VTermStateCallbacks;
 
 // VIM: added
@@ -487,6 +489,8 @@ VTermState *vterm_obtain_state(VTerm *vt);
 
 void  vterm_state_set_callbacks(VTermState *state, const VTermStateCallbacks *callbacks, void *user);
 void *vterm_state_get_cbdata(VTermState *state);
+
+void vterm_state_callbacks_has_premove(VTermState *state);
 
 void  vterm_state_set_unrecognised_fallbacks(VTermState *state, const VTermStateFallbacks *fallbacks, void *user);
 void *vterm_state_get_unrecognised_fbdata(VTermState *state);

--- a/src/libvterm/include/vterm.h
+++ b/src/libvterm/include/vterm.h
@@ -582,6 +582,8 @@ typedef struct {
   int (*sb_pushline)(int cols, const VTermScreenCell *cells, void *user);
   int (*sb_popline)(int cols, VTermScreenCell *cells, void *user);
   int (*sb_clear)(void* user);
+  /* ABI-compat this is only used if vterm_screen_callbacks_has_pushline4() is called */
+  int (*sb_pushline4)(int cols, const VTermScreenCell *cells, int continuation, void *user);
 } VTermScreenCallbacks;
 
 // Return the screen of the vterm.
@@ -593,6 +595,8 @@ VTermScreen *vterm_obtain_screen(VTerm *vt);
  */
 void  vterm_screen_set_callbacks(VTermScreen *screen, const VTermScreenCallbacks *callbacks, void *user);
 void *vterm_screen_get_cbdata(VTermScreen *screen);
+
+void vterm_screen_callbacks_has_pushline4(VTermScreen *screen);
 
 void  vterm_screen_set_unrecognised_fallbacks(VTermScreen *screen, const VTermStateFallbacks *fallbacks, void *user);
 void *vterm_screen_get_unrecognised_fbdata(VTermScreen *screen);

--- a/src/libvterm/src/state.c
+++ b/src/libvterm/src/state.c
@@ -78,6 +78,7 @@ static VTermState *vterm_state_new(VTerm *vt)
 
   state->callbacks = NULL;
   state->cbdata    = NULL;
+  state->callbacks_has_premove = 0;
 
   state->selection.callbacks = NULL;
   state->selection.user      = NULL;
@@ -132,6 +133,33 @@ static void scroll(VTermState *state, VTermRect rect, int downward, int rightwar
     rightward = cols;
   else if(rightward < -cols)
     rightward = -cols;
+
+  if(state->callbacks_has_premove && state->callbacks && state->callbacks->premove) {
+    // TODO: technically this logic is wrong if both downward != 0 and rightward != 0
+
+    /* Work out what subsection of the destination area is about to be destroyed */
+    if(downward > 0)
+      /* about to destroy the top */
+      (*state->callbacks->premove)((VTermRect){
+          .start_row = rect.start_row, .end_row = rect.start_row + downward,
+          .start_col = rect.start_col, .end_col = rect.end_col}, state->cbdata);
+    else if(downward < 0)
+      /* about to destroy the bottom */
+      (*state->callbacks->premove)((VTermRect){
+          .start_row = rect.end_row + downward, .end_row = rect.end_row,
+          .start_col = rect.start_col,          .end_col = rect.end_col}, state->cbdata);
+
+    if(rightward > 0)
+      /* about to destroy the left */
+      (*state->callbacks->premove)((VTermRect){
+          .start_row = rect.start_row, .end_row = rect.end_row,
+          .start_col = rect.start_col, .end_col = rect.start_col + rightward}, state->cbdata);
+    else if(rightward < 0)
+      /* about to destroy the right */
+      (*state->callbacks->premove)((VTermRect){
+          .start_row = rect.start_row,           .end_row = rect.end_row,
+          .start_col = rect.end_col + rightward, .end_col = rect.end_col}, state->cbdata);
+  }
 
   // Update lineinfo if full line
   if(rect.start_col == 0 && rect.end_col == state->cols && rightward == 0) {
@@ -2317,6 +2345,11 @@ void vterm_state_set_callbacks(VTermState *state, const VTermStateCallbacks *cal
     state->callbacks = NULL;
     state->cbdata = NULL;
   }
+}
+
+void vterm_state_callbacks_has_premove(VTermState *state)
+{
+  state->callbacks_has_premove = 1;
 }
 
 void *vterm_state_get_cbdata(VTermState *state)

--- a/src/libvterm/src/vterm_internal.h
+++ b/src/libvterm/src/vterm_internal.h
@@ -70,6 +70,7 @@ struct VTermState
 
   const VTermStateCallbacks *callbacks;
   void *cbdata;
+  int callbacks_has_premove;
 
   const VTermStateFallbacks *fallbacks;
   void *fbdata;

--- a/src/libvterm/t/12state_scroll.test
+++ b/src/libvterm/t/12state_scroll.test
@@ -127,24 +127,28 @@ PUSH "\e[100;105r\eD"
 PUSH "\e[5;2r\eD"
 
 RESET
-WANTSTATE -s+me
+WANTSTATE -s+Pme
 
 !Scroll Down move+erase emulation
 PUSH "\e[S"
+  premove 0..1,0..80
   moverect 1..25,0..80 -> 0..24,0..80
   erase 24..25,0..80
   ?cursor = 0,0
 PUSH "\e[2S"
+  premove 0..2,0..80
   moverect 2..25,0..80 -> 0..23,0..80
   erase 23..25,0..80
   ?cursor = 0,0
 
 !Scroll Up move+erase emulation
 PUSH "\e[T"
+  premove 24..25,0..80
   moverect 0..24,0..80 -> 1..25,0..80
   erase 0..1,0..80
   ?cursor = 0,0
 PUSH "\e[2T"
+  premove 23..25,0..80
   moverect 0..23,0..80 -> 2..25,0..80
   erase 0..2,0..80
   ?cursor = 0,0

--- a/src/libvterm/t/13state_edit.test
+++ b/src/libvterm/t/13state_edit.test
@@ -268,7 +268,7 @@ PUSH "\e[2\"q"
 PUSH "\eP\$q\"q\e\\"
   output "\eP1\$r2\"q\e\\"
 
-WANTSTATE -s+m
+WANTSTATE -s+Pm
 
 !ICH move+erase emuation
 RESET
@@ -278,12 +278,14 @@ PUSH "ACD"
 PUSH "\e[2D"
   ?cursor = 0,1
 PUSH "\e[@"
+  premove 0..1,79..80
   moverect 0..1,1..79 -> 0..1,2..80
   erase 0..1,1..2
   ?cursor = 0,1
 PUSH "B"
   ?cursor = 0,2
 PUSH "\e[3@"
+  premove 0..1,77..80
   moverect 0..1,2..77 -> 0..1,5..80
   erase 0..1,2..5
 
@@ -295,10 +297,12 @@ PUSH "ABBC"
 PUSH "\e[3D"
   ?cursor = 0,1
 PUSH "\e[P"
+  premove 0..1,1..2
   moverect 0..1,2..80 -> 0..1,1..79
   erase 0..1,79..80
   ?cursor = 0,1
 PUSH "\e[3P"
+  premove 0..1,1..4
   moverect 0..1,4..80 -> 0..1,1..77
   erase 0..1,77..80
   ?cursor = 0,1

--- a/src/libvterm/t/62screen_damage.test
+++ b/src/libvterm/t/62screen_damage.test
@@ -146,9 +146,9 @@ PUSH "\e[25H\r\nABCDE\b\b\b\e[2P\r\n"
   sb_pushline 80 =
   moverect 1..25,0..80 -> 0..24,0..80
   damage 24..25,0..80 = 24<41 42 43 44 45>
+  sb_pushline 80 =
   moverect 24..25,4..80 -> 24..25,2..78
   damage 24..25,78..80
-  sb_pushline 80 =
 DAMAGEFLUSH
   moverect 1..25,0..80 -> 0..24,0..80
   damage 24..25,0..80

--- a/src/libvterm/t/69screen_pushline.test
+++ b/src/libvterm/t/69screen_pushline.test
@@ -1,0 +1,17 @@
+INIT
+WANTSTATE
+WANTSCREEN b
+
+RESET
+
+!Spillover text marks continuation on second line
+PUSH "A"x85
+PUSH "\r\n"
+  ?lineinfo 0 =
+  ?lineinfo 1 = cont
+
+!Continuation mark sent to sb_pushline
+PUSH "\n"x23
+  sb_pushline 80 = 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41
+PUSH "\n"
+  sb_pushline 80 cont = 41 41 41 41 41

--- a/src/libvterm/t/harness.c
+++ b/src/libvterm/t/harness.c
@@ -603,7 +603,7 @@ static int screen_damage(VTermRect rect, void *user UNUSED)
 }
 
 static int want_screen_scrollback = 0;
-static int screen_sb_pushline(int cols, const VTermScreenCell *cells, void *user UNUSED)
+static int screen_sb_pushline4(int cols, const VTermScreenCell *cells, int continuation, void *user UNUSED)
 {
   int eol;
   int c;
@@ -615,7 +615,7 @@ static int screen_sb_pushline(int cols, const VTermScreenCell *cells, void *user
   while(eol && !cells[eol-1].chars[0])
     eol--;
 
-  printf("sb_pushline %d =", cols);
+  printf("sb_pushline %d%s =", cols, continuation ? " cont" : "");
   for(c = 0; c < eol; c++)
     printf(" %02X", cells[c].chars[0]);
   printf("\n");
@@ -660,9 +660,10 @@ VTermScreenCallbacks screen_cbs = {
   settermprop, // settermprop
   NULL, // bell
   NULL, // resize
-  screen_sb_pushline, // sb_pushline
+  NULL, // sb_pushline
   screen_sb_popline, // sb_popline
   screen_sb_clear, // sb_clear
+  screen_sb_pushline4, // sb_pushline4
 };
 
 int main(int argc UNUSED, char **argv UNUSED)
@@ -757,6 +758,7 @@ int main(int argc UNUSED, char **argv UNUSED)
       if(!screen)
         screen = vterm_obtain_screen(vt);
       vterm_screen_set_callbacks(screen, &screen_cbs, NULL);
+      vterm_screen_callbacks_has_pushline4(screen);
 
       while(line[i] == ' ')
         i++;

--- a/src/libvterm/t/harness.c
+++ b/src/libvterm/t/harness.c
@@ -326,6 +326,18 @@ static int movecursor(VTermPos pos, VTermPos oldpos UNUSED, int visible UNUSED, 
   return 1;
 }
 
+static int want_premove = 0;
+static int premove(VTermRect rect, void *user UNUSED)
+{
+  if(!want_premove)
+    return 0;
+
+  printf("premove %d..%d,%d..%d\n",
+      rect.start_row, rect.end_row, rect.start_col, rect.end_col);
+
+  return 1;
+}
+
 static int want_scrollrect = 0;
 static int scrollrect(VTermRect rect, int downward, int rightward, void *user UNUSED)
 {
@@ -509,6 +521,7 @@ VTermStateCallbacks state_cbs = {
   NULL, // resize
   state_setlineinfo, // setlineinfo
   state_sb_clear, // sb_clear
+  premove, // premove
 };
 
 static int selection_set(VTermSelectionMask mask, VTermStringFragment frag, void *user UNUSED)
@@ -689,6 +702,7 @@ int main(int argc UNUSED, char **argv UNUSED)
       if(!state) {
         state = vterm_obtain_state(vt);
         vterm_state_set_callbacks(state, &state_cbs, NULL);
+        vterm_state_callbacks_has_premove(state);
         /* In some tests we want to check the behaviour of overflowing the
          * buffer, so make it nicely small
          */
@@ -712,6 +726,9 @@ int main(int argc UNUSED, char **argv UNUSED)
           break;
         case 's':
           want_scrollrect = sense;
+          break;
+        case 'P':
+          want_premove = sense;
           break;
         case 'm':
           want_moverect = sense;

--- a/src/libvterm/t/run-test.pl
+++ b/src/libvterm/t/run-test.pl
@@ -124,7 +124,7 @@ sub do_line
       elsif( $line =~ m/^putglyph (\S+) (.*)$/ ) {
          $line = "putglyph " . join( ",", map sprintf("%x", $_), eval($1) ) . " $2";
       }
-      elsif( $line =~ m/^(?:movecursor|scrollrect|moverect|erase|damage|sb_pushline|sb_popline|sb_clear|settermprop|setmousefunc|selection-query) ?/ ) {
+      elsif( $line =~ m/^(?:movecursor|scrollrect|premove|moverect|erase|damage|sb_pushline|sb_popline|sb_clear|settermprop|setmousefunc|selection-query) ?/ ) {
          # no conversion
       }
       elsif( $line =~ m/^(selection-set) (.*?) (\[?)(.*?)(\]?)$/ ) {

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -149,6 +149,7 @@ struct terminal_S {
     garray_T	tl_scrollback;
     int		tl_scrollback_scrolled;
     garray_T	tl_scrollback_postponed;
+    int		tl_scrollback_snapshot;
 
     char_u	*tl_highlight_name; // replaces "Terminal"; allocated
 
@@ -2024,16 +2025,31 @@ cleanup_scrollback(term_T *term)
 {
     sb_line_T	*line;
     garray_T	*gap;
+    char_u	*bufline;
+    size_t      bufline_length;
 
     curbuf = term->tl_buffer;
     gap = &term->tl_scrollback;
-    while (curbuf->b_ml.ml_line_count > term->tl_scrollback_scrolled
-							    && gap->ga_len > 0)
+    bufline = ml_get_buf(curbuf, curbuf->b_ml.ml_line_count, FALSE);
+    bufline_length = STRLEN(bufline);
+    while (term->tl_scrollback_snapshot && gap->ga_len > 0)
     {
-	ml_delete(curbuf->b_ml.ml_line_count);
 	line = (sb_line_T *)gap->ga_data + gap->ga_len - 1;
+	bufline_length -= line->sb_cols;
+	if (!bufline_length)
+	{
+	    ml_delete(curbuf->b_ml.ml_line_count);
+	    bufline = ml_get_buf(curbuf, curbuf->b_ml.ml_line_count, FALSE);
+	    bufline_length = STRLEN(bufline);
+	}
 	vim_free(line->sb_cells);
 	--gap->ga_len;
+	--term->tl_scrollback_snapshot;
+    }
+    if (bufline_length < STRLEN(bufline))
+    {
+	char_u *shortened = vim_strnsave(bufline, bufline_length);
+	ml_replace(curbuf->b_ml.ml_line_count, shortened, FALSE);
     }
     curbuf = curwin->w_buffer;
     if (curbuf == term->tl_buffer)
@@ -2088,7 +2104,10 @@ update_snapshot(term_T *term)
 		// Line was skipped, add an empty line.
 		--lines_skipped;
 		if (add_empty_scrollback(term, &fill_attr, 0) == OK)
+		{
 		    add_scrollback_line_to_buffer(term, (char_u *)"", 0, 0);
+		    ++term->tl_scrollback_snapshot;
+		}
 	    }
 
 	    if (len == 0)
@@ -2145,6 +2164,7 @@ update_snapshot(term_T *term)
 		line->continuation = lineinfo->continuation;
 		fill_attr = new_fill_attr;
 		++term->tl_scrollback.ga_len;
+		++term->tl_scrollback_snapshot;
 
 		if (ga_grow(&ga, 1) == FAIL)
 		    add_scrollback_line_to_buffer(term, (char_u *)"", 0, 0);
@@ -2167,7 +2187,10 @@ update_snapshot(term_T *term)
 	    ++pos.row)
     {
 	if (add_empty_scrollback(term, &fill_attr, 0) == OK)
+	{
 	    add_scrollback_line_to_buffer(term, (char_u *)"", 0, 0);
+	    ++term->tl_scrollback_snapshot;
+	}
     }
 
     term->tl_dirty_snapshot = FALSE;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -61,6 +61,7 @@ typedef struct {
 
 typedef struct sb_line_S {
     int		sb_cols;	// can differ per line
+    int         sb_bytes;	// length in bytes of text
     cellattr_T	*sb_cells;	// allocated
     cellattr_T	sb_fill_attr;	// for short line
     char_u	*sb_text;	// for tl_scrollback_postponed
@@ -150,6 +151,7 @@ struct terminal_S {
     int		tl_scrollback_scrolled;
     garray_T	tl_scrollback_postponed;
     int		tl_scrollback_snapshot;
+    int         tl_buffer_scrolled;
 
     char_u	*tl_highlight_name; // replaces "Terminal"; allocated
 
@@ -1389,6 +1391,113 @@ update_cursor(term_T *term, int redraw)
 }
 
 /*
+ * Find the location of a scrollbackline in the buffer
+ */
+    static void
+scrollbackline_pos_in_buf(term_T *term, int row, linenr_T *lnum, int *start_col, size_t *start_pos)
+{
+    sb_line_T	*lines = (sb_line_T *)term->tl_scrollback.ga_data;
+    linenr_T    calc_lnum = term->tl_buffer_scrolled;
+    size_t      calc_pos = 0;
+    int         calc_col = 0;
+    int         i;
+
+    if (row < 0 || row >= term->tl_scrollback.ga_len)
+	return;
+
+    if (row > term->tl_scrollback_scrolled)
+    {
+	// Lookback how far along in the top line we are
+	for (i = term->tl_scrollback_scrolled + 1; i > 0 && lines[i].continuation; --i)
+	{
+	    calc_pos += lines[i - 1].sb_bytes;
+	    calc_col += lines[i - 1].sb_cols;
+	}
+	i = term->tl_scrollback_scrolled + 1;
+	calc_lnum = term->tl_buffer_scrolled + 1;
+	// Do not count this line's bytes/cols twice
+	if (lines[i].continuation)
+	    ++i;
+    }
+    else
+    {
+	i = 1;
+	calc_lnum = 1;
+    }
+
+    for (; i <= row; ++i)
+    {
+	if (!lines[i].continuation)
+	{
+	    ++calc_lnum;
+	    calc_pos = 0;
+	    calc_col = 0;
+	}
+	else
+	{
+	    calc_pos += lines[i - 1].sb_bytes;
+	    calc_col += lines[i - 1].sb_cols;
+	}
+    }
+
+    *lnum = calc_lnum;
+    if (start_col)
+	*start_col = calc_col;
+    if (start_pos)
+	*start_pos = calc_pos;
+}
+
+/*
+ * Find the location of a buffer line in the scrollback
+ */
+    static void
+bufline_pos_in_scrollback(term_T *term, linenr_T lnum, int col, int *row, int *wrapped_col)
+{
+    buf_T	*buf = term->tl_buffer;
+    sb_line_T	*lines = (sb_line_T *)term->tl_scrollback.ga_data;
+    linenr_T    calc_row = term->tl_scrollback_scrolled;
+    int         calc_col = col;
+    linenr_T    l;
+
+    if (lnum > buf->b_ml.ml_line_count)
+	return;
+
+    if (lnum > term->tl_buffer_scrolled)
+    {
+	calc_row = term->tl_scrollback_scrolled;
+	l = term->tl_buffer_scrolled + 1;
+
+	while (calc_row < term->tl_scrollback.ga_len && lines[calc_row].continuation)
+	    ++calc_row;
+    }
+    else
+    {
+	calc_row = 0;
+	l = 1;
+    }
+
+    while (calc_row < term->tl_scrollback.ga_len && l < lnum)
+    {
+	++calc_row;
+	if (!lines[calc_row].continuation)
+	    ++l;
+    }
+
+    while (calc_row + 1 < term->tl_scrollback.ga_len && lines[calc_row + 1].continuation
+	    && calc_col >= lines[calc_row].sb_cols)
+    {
+	calc_col -= lines[calc_row].sb_cols;
+	++calc_row;
+    }
+
+    if (row)
+	*row = calc_row;
+    if (wrapped_col)
+	*wrapped_col = calc_col;
+}
+
+
+/*
  * Invoked when "msg" output from a job was received.  Write it to the terminal
  * of "buffer".
  */
@@ -2009,6 +2118,7 @@ add_empty_scrollback(term_T *term, cellattr_T *fill_attr, int lnum)
 	}
     }
     line->sb_cols = 0;
+    line->sb_bytes = 0;
     line->sb_cells = NULL;
     line->sb_fill_attr = *fill_attr;
     ++term->tl_scrollback.ga_len;
@@ -2035,7 +2145,7 @@ cleanup_scrollback(term_T *term)
     while (term->tl_scrollback_snapshot && gap->ga_len > 0)
     {
 	line = (sb_line_T *)gap->ga_data + gap->ga_len - 1;
-	bufline_length -= line->sb_cols;
+	bufline_length -= line->sb_bytes;
 	if (!bufline_length)
 	{
 	    ml_delete(curbuf->b_ml.ml_line_count);
@@ -2159,6 +2269,7 @@ update_snapshot(term_T *term)
 		    }
 		}
 		line->sb_cols = len;
+		line->sb_bytes = ga.ga_len;
 		line->sb_cells = p;
 		line->sb_fill_attr = new_fill_attr;
 		line->continuation = lineinfo->continuation;
@@ -2235,7 +2346,7 @@ may_move_terminal_to_buffer(term_T *term, int redraw)
     // Update the snapshot only if something changes or the buffer does not
     // have all the lines.
     if (term->tl_dirty_snapshot || term->tl_buffer->b_ml.ml_line_count
-					       <= term->tl_scrollback_scrolled)
+					       <= term->tl_buffer_scrolled)
 	update_snapshot(term);
 
     if (redraw)
@@ -2331,7 +2442,9 @@ cleanup_vterm(term_T *term)
     static void
 term_enter_normal_mode(void)
 {
-    term_T *term = curbuf->b_term;
+    term_T     *term = curbuf->b_term;
+    linenr_T   lnum;
+    int        col;
 
     set_terminal_mode(term, TRUE);
 
@@ -2340,15 +2453,16 @@ term_enter_normal_mode(void)
 
     // Move the window cursor to the position of the cursor in the
     // terminal.
-    curwin->w_cursor.lnum = term->tl_scrollback_scrolled
-					     + term->tl_cursor_pos.row + 1;
+    lnum = term->tl_buffer_scrolled + 1 + term->tl_cursor_pos.row;
+    col = term->tl_cursor_pos.col;
+    scrollbackline_pos_in_buf(term, term->tl_cursor_pos.row + term->tl_scrollback_scrolled, &lnum, &col, NULL);
+
+    curwin->w_cursor.lnum = lnum;
     check_cursor();
-    if (coladvance(term->tl_cursor_pos.col) == FAIL)
+    if (coladvance(col) == FAIL)
 	coladvance(MAXCOL);
     curwin->w_set_curswant = TRUE;
-
-    // Display the same lines as in the terminal.
-    curwin->w_topline = term->tl_scrollback_scrolled + 1;
+    curwin->w_topline = term->tl_buffer_scrolled + 1;
 }
 
 /*
@@ -3532,25 +3646,27 @@ limit_scrollback(term_T *term, garray_T *gap, int update_buffer)
     int	todo = MAX(term->tl_buffer->b_p_twsl / 10,
 				     gap->ga_len - term->tl_buffer->b_p_twsl);
     int	i;
-    sb_line_T **sb_lines = (sb_line_T **)gap->ga_data;
+    sb_line_T *sb_lines = (sb_line_T *)gap->ga_data;
 
     curbuf = term->tl_buffer;
     for (i = 0; i < todo; ++i)
     {
-	if (update_buffer && (!sb_lines[i]->continuation || !i))
+	if (update_buffer && (!sb_lines[i].continuation || !i))
+	{
 	    ml_delete(1);
-	vim_free(sb_lines[i]->sb_cells);
+	    --term->tl_buffer_scrolled;
+	}
+	vim_free(sb_lines[i].sb_cells);
     }
     // Continue until end of wrapped line
-    for (; todo < gap->ga_len && sb_lines[todo]->continuation; ++todo) {
-	vim_free(sb_lines[todo]->sb_cells);
-    }
+    for (; todo < gap->ga_len && sb_lines[todo].continuation; ++todo)
+	vim_free(sb_lines[todo].sb_cells);
     curbuf = curwin->w_buffer;
 
     gap->ga_len -= todo;
     mch_memmove(gap->ga_data,
-	    (sb_line_T *)gap->ga_data + todo,
-	    sizeof(sb_line_T) * gap->ga_len);
+		(sb_line_T *)gap->ga_data + todo,
+		sizeof(sb_line_T) * gap->ga_len);
     if (update_buffer)
     {
 	win_T *curwin_save = curwin;
@@ -3658,6 +3774,7 @@ handle_pushline(int cols, const VTermScreenCell *cells, int continuation, void *
 
     line = (sb_line_T *)gap->ga_data + gap->ga_len;
     line->sb_cols = len;
+    line->sb_bytes = text_len;
     line->sb_cells = p;
     line->sb_fill_attr = fill_attr;
     line->continuation = continuation;
@@ -3665,6 +3782,8 @@ handle_pushline(int cols, const VTermScreenCell *cells, int continuation, void *
     {
 	line->sb_text = NULL;
 	++term->tl_scrollback_scrolled;
+	if (!continuation)
+	    ++term->tl_buffer_scrolled;
 	ga_clear(&ga);  // free the text
     }
     else
@@ -3712,11 +3831,14 @@ handle_postponed_scrollback(term_T *term)
 	line = (sb_line_T *)term->tl_scrollback.ga_data
 						 + term->tl_scrollback.ga_len;
 	line->sb_cols = pp_line->sb_cols;
+	line->sb_bytes = pp_line->sb_bytes;
 	line->sb_cells = pp_line->sb_cells;
 	line->sb_fill_attr = pp_line->sb_fill_attr;
 	line->sb_text = NULL;
 	++term->tl_scrollback_scrolled;
 	++term->tl_scrollback.ga_len;
+	if (!pp_line->continuation)
+	    ++term->tl_buffer_scrolled;
     }
 
     ga_clear(&term->tl_scrollback_postponed);
@@ -4299,16 +4421,21 @@ term_get_attr(win_T *wp, linenr_T lnum, int col)
     term_T	*term = buf->b_term;
     sb_line_T	*line;
     cellattr_T	*cellattr;
+    int         sb_line = -1;
+    int         sb_col;
 
-    if (lnum > term->tl_scrollback.ga_len)
+    if (term->tl_scrollback.ga_len)
+	bufline_pos_in_scrollback(term, lnum, col, &sb_line, &sb_col);
+
+    if (sb_line < 0)
 	cellattr = &term->tl_default_color;
     else
     {
-	line = (sb_line_T *)term->tl_scrollback.ga_data + lnum - 1;
-	if (col < 0 || col >= line->sb_cols)
+	line = (sb_line_T *)term->tl_scrollback.ga_data + sb_line;
+	if (sb_col < 0 || sb_col >= line->sb_cols)
 	    cellattr = &line->sb_fill_attr;
 	else
-	    cellattr = line->sb_cells + col;
+	    cellattr = line->sb_cells + sb_col;
     }
     return cell2attr(term, wp, &cellattr->attrs, &cellattr->fg, &cellattr->bg);
 }
@@ -5535,6 +5662,7 @@ read_dump_file(FILE *fd, VTermPos *cursor_pos)
 		if (max_cells < ga_cell.ga_len)
 		    max_cells = ga_cell.ga_len;
 		line->sb_cols = ga_cell.ga_len;
+		line->sb_bytes = ga_text.ga_len;
 		line->sb_cells = ga_cell.ga_data;
 		line->sb_fill_attr = term->tl_default_color;
 		++term->tl_scrollback.ga_len;
@@ -6357,11 +6485,19 @@ f_term_getline(typval_T *argvars, typval_T *rettv)
 
     if (term->tl_vterm == NULL)
     {
-	linenr_T lnum = row + term->tl_scrollback_scrolled + 1;
+	linenr_T  lnum = 0;
+	size_t	  offset = 0;
+	sb_line_T *line = (sb_line_T *)term->tl_scrollback.ga_data + term->tl_scrollback_scrolled + row;
+
+	scrollbackline_pos_in_buf(term, row + term->tl_scrollback_scrolled, &lnum, NULL, &offset);
 
 	// vterm is finished, get the text from the buffer
 	if (lnum > 0 && lnum <= buf->b_ml.ml_line_count)
-	    rettv->vval.v_string = vim_strsave(ml_get_buf(buf, lnum, FALSE));
+	{
+	    char_u *p = ml_get_buf(buf, lnum, FALSE);
+	    if (STRLEN(p) >= offset + line->sb_bytes)
+		rettv->vval.v_string = vim_strnsave(p + offset, line->sb_bytes);
+	}
     }
     else
     {
@@ -6400,7 +6536,7 @@ f_term_getscrolled(typval_T *argvars, typval_T *rettv)
     buf = term_get_buf(argvars, "term_getscrolled()");
     if (buf == NULL)
 	return;
-    rettv->vval.v_number = buf->b_term->tl_scrollback_scrolled;
+    rettv->vval.v_number = buf->b_term->tl_buffer_scrolled;
 }
 
 /*
@@ -6614,12 +6750,22 @@ f_term_scrape(typval_T *argvars, typval_T *rettv)
     }
     else
     {
-	linenr_T	lnum = pos.row + term->tl_scrollback_scrolled;
+	int	  sb_row = term->tl_scrollback_scrolled + pos.row;
+	linenr_T  lnum = 0;
+	size_t	  offset = 0;
 
-	if (lnum < 0 || lnum >= term->tl_scrollback.ga_len)
+	scrollbackline_pos_in_buf(term, sb_row, &lnum, NULL, &offset);
+
+	if (sb_row >= term->tl_scrollback.ga_len || lnum <= 0 || lnum > buf->b_ml.ml_line_count)
 	    return;
-	p = ml_get_buf(buf, lnum + 1, FALSE);
-	line = (sb_line_T *)term->tl_scrollback.ga_data + lnum;
+
+	line = (sb_line_T *)term->tl_scrollback.ga_data + sb_row;
+	p = ml_get_buf(buf, lnum, FALSE);
+
+	if (STRLEN(p) < offset + line->sb_bytes)
+	    return;
+
+	p += offset;
     }
 
     for (pos.col = 0; pos.col < term->tl_cols; )

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3521,7 +3521,7 @@ limit_scrollback(term_T *term, garray_T *gap, int update_buffer)
  * Handle a line that is pushed off the top of the screen.
  */
     static int
-handle_pushline(int cols, const VTermScreenCell *cells, void *user)
+handle_pushline(int cols, const VTermScreenCell *cells, int continuation, void *user)
 {
     term_T	*term = (term_T *)user;
     garray_T	*gap;
@@ -3685,9 +3685,10 @@ static VTermScreenCallbacks screen_callbacks = {
     handle_settermprop,		// settermprop
     handle_bell,		// bell
     handle_resize,		// resize
-    handle_pushline,		// sb_pushline
+    NULL,			// sb_pushline
     NULL,			// sb_popline
-    NULL			// sb_clear
+    NULL,			// sb_clear
+    handle_pushline	// sb_pushline4
 };
 
 /*
@@ -4964,6 +4965,7 @@ create_vterm(term_T *term, int rows, int cols)
 
     vterm_screen_set_callbacks(screen, &screen_callbacks, term);
     vterm_screen_set_damage_merge(screen, VTERM_DAMAGE_SCROLL);
+    vterm_screen_callbacks_has_pushline4(screen);
     // TODO: depends on 'encoding'.
     vterm_set_utf8(vterm, 1);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3532,13 +3532,18 @@ limit_scrollback(term_T *term, garray_T *gap, int update_buffer)
     int	todo = MAX(term->tl_buffer->b_p_twsl / 10,
 				     gap->ga_len - term->tl_buffer->b_p_twsl);
     int	i;
+    sb_line_T **sb_lines = (sb_line_T **)gap->ga_data;
 
     curbuf = term->tl_buffer;
     for (i = 0; i < todo; ++i)
     {
-	vim_free(((sb_line_T *)gap->ga_data + i)->sb_cells);
-	if (update_buffer)
+	if (update_buffer && (!sb_lines[i]->continuation || !i))
 	    ml_delete(1);
+	vim_free(sb_lines[i]->sb_cells);
+    }
+    // Continue until end of wrapped line
+    for (; todo < gap->ga_len && sb_lines[todo]->continuation; ++todo) {
+	vim_free(sb_lines[todo]->sb_cells);
     }
     curbuf = curwin->w_buffer;
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -61,7 +61,7 @@ typedef struct {
 
 typedef struct sb_line_S {
     int		sb_cols;	// can differ per line
-    int         sb_bytes;	// length in bytes of text
+    int		sb_bytes;	// length in bytes of text
     cellattr_T	*sb_cells;	// allocated
     cellattr_T	sb_fill_attr;	// for short line
     char_u	*sb_text;	// for tl_scrollback_postponed
@@ -151,7 +151,7 @@ struct terminal_S {
     int		tl_scrollback_scrolled;
     garray_T	tl_scrollback_postponed;
     int		tl_scrollback_snapshot;
-    int         tl_buffer_scrolled;
+    int		tl_buffer_scrolled;
 
     char_u	*tl_highlight_name; // replaces "Terminal"; allocated
 
@@ -1496,7 +1496,6 @@ bufline_pos_in_scrollback(term_T *term, linenr_T lnum, int col, int *row, int *w
 	*wrapped_col = calc_col;
 }
 
-
 /*
  * Invoked when "msg" output from a job was received.  Write it to the terminal
  * of "buffer".
@@ -2049,6 +2048,8 @@ add_scrollback_line_to_buffer(term_T *term, char_u *text, int len, int append)
 	size_t prev_len = STRLEN(prev_text);
 
 	char_u *both = alloc(len + prev_len + 2);
+	if (both == NULL)
+	    return;
 	vim_strncpy(both, prev_text, prev_len + 1);
 	vim_strncpy(both + prev_len, text, len + 1);
 
@@ -2145,6 +2146,8 @@ cleanup_scrollback(term_T *term)
     while (term->tl_scrollback_snapshot && gap->ga_len > 0)
     {
 	line = (sb_line_T *)gap->ga_data + gap->ga_len - 1;
+	if (line->sb_bytes < 0 || (size_t)line->sb_bytes > bufline_length)
+	    break;
 	bufline_length -= line->sb_bytes;
 	if (!bufline_length)
 	{
@@ -2272,7 +2275,7 @@ update_snapshot(term_T *term)
 		line->sb_bytes = ga.ga_len;
 		line->sb_cells = p;
 		line->sb_fill_attr = new_fill_attr;
-		line->continuation = lineinfo->continuation;
+		line->continuation = (char_u)lineinfo->continuation;
 		fill_attr = new_fill_attr;
 		++term->tl_scrollback.ga_len;
 		++term->tl_scrollback_snapshot;
@@ -3777,7 +3780,7 @@ handle_pushline(int cols, const VTermScreenCell *cells, int continuation, void *
     line->sb_bytes = text_len;
     line->sb_cells = p;
     line->sb_fill_attr = fill_attr;
-    line->continuation = continuation;
+    line->continuation = (char_u)continuation;
     if (update_buffer)
     {
 	line->sb_text = NULL;
@@ -4422,7 +4425,7 @@ term_get_attr(win_T *wp, linenr_T lnum, int col)
     sb_line_T	*line;
     cellattr_T	*cellattr;
     int         sb_line = -1;
-    int         sb_col;
+    int         sb_col = col;
 
     if (term->tl_scrollback.ga_len)
 	bufline_pos_in_scrollback(term, lnum, col, &sb_line, &sb_col);
@@ -5665,6 +5668,7 @@ read_dump_file(FILE *fd, VTermPos *cursor_pos)
 		line->sb_bytes = ga_text.ga_len;
 		line->sb_cells = ga_cell.ga_data;
 		line->sb_fill_attr = term->tl_default_color;
+		line->continuation = 0;
 		++term->tl_scrollback.ga_len;
 		ga_init(&ga_cell);
 
@@ -6487,9 +6491,14 @@ f_term_getline(typval_T *argvars, typval_T *rettv)
     {
 	linenr_T  lnum = 0;
 	size_t	  offset = 0;
-	sb_line_T *line = (sb_line_T *)term->tl_scrollback.ga_data + term->tl_scrollback_scrolled + row;
+	int	  sb_row = term->tl_scrollback_scrolled + row;
+	sb_line_T *line;
 
-	scrollbackline_pos_in_buf(term, row + term->tl_scrollback_scrolled, &lnum, NULL, &offset);
+	if (sb_row < 0 || sb_row >= term->tl_scrollback.ga_len)
+	    return;
+	line = (sb_line_T *)term->tl_scrollback.ga_data + sb_row;
+
+	scrollbackline_pos_in_buf(term, sb_row, &lnum, NULL, &offset);
 
 	// vterm is finished, get the text from the buffer
 	if (lnum > 0 && lnum <= buf->b_ml.ml_line_count)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -64,6 +64,7 @@ typedef struct sb_line_S {
     cellattr_T	*sb_cells;	// allocated
     cellattr_T	sb_fill_attr;	// for short line
     char_u	*sb_text;	// for tl_scrollback_postponed
+    char_u	continuation;
 } sb_line_T;
 
 #ifdef MSWIN
@@ -1908,13 +1909,14 @@ term_try_stop_job(buf_T *buf)
  * Add the last line of the scrollback buffer to the buffer in the window.
  */
     static void
-add_scrollback_line_to_buffer(term_T *term, char_u *text, int len)
+add_scrollback_line_to_buffer(term_T *term, char_u *text, int len, int append)
 {
     buf_T	*buf = term->tl_buffer;
     int		empty = (buf->b_ml.ml_flags & ML_EMPTY);
     linenr_T	lnum = buf->b_ml.ml_line_count;
 
 #ifdef MSWIN
+    char_u *tmp = text;
     if (!enc_utf8 && enc_codepage > 0)
     {
 	WCHAR   *ret = NULL;
@@ -1927,13 +1929,30 @@ add_scrollback_line_to_buffer(term_T *term, char_u *text, int len)
 	    WideCharToMultiByte_alloc(enc_codepage, 0,
 				      ret, length, (char **)&text, &len, 0, 0);
 	    vim_free(ret);
-	    ml_append_buf(term->tl_buffer, lnum, text, len, FALSE);
-	    vim_free(text);
 	}
     }
-    else
 #endif
-	ml_append_buf(term->tl_buffer, lnum, text, len + 1, FALSE);
+
+    if (append)
+    {
+	char_u *prev_text = ml_get_buf(buf, lnum, FALSE);
+	size_t prev_len = STRLEN(prev_text);
+
+	char_u *both = alloc(len + prev_len + 2);
+	vim_strncpy(both, prev_text, prev_len + 1);
+	vim_strncpy(both + prev_len, text, len + 1);
+
+	curbuf = buf;
+	ml_replace(lnum, both, FALSE);
+	curbuf = curwin->w_buffer;
+    }
+    else
+	ml_append_buf(buf, lnum, text, len + 1, FALSE);
+
+#ifdef MSWIN
+    if (tmp != text)
+	vim_free(text);
+#endif
     if (empty)
     {
 	// Delete the empty line that was in the empty buffer.
@@ -2028,6 +2047,7 @@ cleanup_scrollback(term_T *term)
 update_snapshot(term_T *term)
 {
     VTermScreen	    *screen;
+    VTermState	    *state;
     int		    len;
     int		    lines_skipped = 0;
     VTermPos	    pos;
@@ -2043,6 +2063,7 @@ update_snapshot(term_T *term)
     cleanup_scrollback(term);
 
     screen = vterm_obtain_screen(term->tl_vterm);
+    state = vterm_obtain_state(term->tl_vterm);
     fill_attr = new_fill_attr = term->tl_default_color;
     for (pos.row = 0; pos.row < term->tl_rows; ++pos.row)
     {
@@ -2067,7 +2088,7 @@ update_snapshot(term_T *term)
 		// Line was skipped, add an empty line.
 		--lines_skipped;
 		if (add_empty_scrollback(term, &fill_attr, 0) == OK)
-		    add_scrollback_line_to_buffer(term, (char_u *)"", 0);
+		    add_scrollback_line_to_buffer(term, (char_u *)"", 0, 0);
 	    }
 
 	    if (len == 0)
@@ -2079,8 +2100,11 @@ update_snapshot(term_T *term)
 	    {
 		garray_T    ga;
 		int	    width;
+		const VTermLineInfo *lineinfo;
 		sb_line_T   *line = (sb_line_T *)term->tl_scrollback.ga_data
 						  + term->tl_scrollback.ga_len;
+
+		lineinfo = vterm_state_get_lineinfo(state, pos.row);
 
 		ga_init2(&ga, 1, 100);
 		for (pos.col = 0; pos.col < len; pos.col += width)
@@ -2118,15 +2142,17 @@ update_snapshot(term_T *term)
 		line->sb_cols = len;
 		line->sb_cells = p;
 		line->sb_fill_attr = new_fill_attr;
+		line->continuation = lineinfo->continuation;
 		fill_attr = new_fill_attr;
 		++term->tl_scrollback.ga_len;
 
 		if (ga_grow(&ga, 1) == FAIL)
-		    add_scrollback_line_to_buffer(term, (char_u *)"", 0);
+		    add_scrollback_line_to_buffer(term, (char_u *)"", 0, 0);
 		else
 		{
 		    *((char_u *)ga.ga_data + ga.ga_len) = NUL;
-		    add_scrollback_line_to_buffer(term, ga.ga_data, ga.ga_len);
+		    add_scrollback_line_to_buffer(term, ga.ga_data, ga.ga_len,
+						  lineinfo->continuation);
 		}
 		ga_clear(&ga);
 	    }
@@ -2141,7 +2167,7 @@ update_snapshot(term_T *term)
 	    ++pos.row)
     {
 	if (add_empty_scrollback(term, &fill_attr, 0) == OK)
-	    add_scrollback_line_to_buffer(term, (char_u *)"", 0);
+	    add_scrollback_line_to_buffer(term, (char_u *)"", 0, 0);
     }
 
     term->tl_dirty_snapshot = FALSE;
@@ -3600,12 +3626,13 @@ handle_pushline(int cols, const VTermScreenCell *cells, int continuation, void *
 	*(text + text_len) = NUL;
     }
     if (update_buffer)
-	add_scrollback_line_to_buffer(term, text, text_len);
+	add_scrollback_line_to_buffer(term, text, text_len, continuation);
 
     line = (sb_line_T *)gap->ga_data + gap->ga_len;
     line->sb_cols = len;
     line->sb_cells = p;
     line->sb_fill_attr = fill_attr;
+    line->continuation = continuation;
     if (update_buffer)
     {
 	line->sb_text = NULL;
@@ -3651,7 +3678,7 @@ handle_postponed_scrollback(term_T *term)
 	text = pp_line->sb_text;
 	if (text == NULL)
 	    text = (char_u *)"";
-	add_scrollback_line_to_buffer(term, text, (int)STRLEN(text));
+	add_scrollback_line_to_buffer(term, text, (int)STRLEN(text), pp_line->continuation);
 	vim_free(pp_line->sb_text);
 
 	line = (sb_line_T *)term->tl_scrollback.ga_data

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -2452,6 +2452,8 @@ func Test_terminal_disable_kitty_keyboard()
 endfunc
 
 func Test_terminal_unwraps()
+  CheckNotMSWindows
+
   30vnew
 
   redraw

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -2451,4 +2451,27 @@ func Test_terminal_disable_kitty_keyboard()
   bwipe!
 endfunc
 
+func Test_terminal_unwraps()
+  30vnew
+
+  redraw
+  let buf = term_start("echo 1+2+3+4+5+6+7+8+9+10+11+12+13+14+15")
+  " Wait until both wrapped lines have appeared in the terminal
+  call WaitForAssert({-> assert_equal('14+15', term_getline(buf, 2))})
+
+  " A long wrapped line appears as 2 lines in libvterm
+  let l = term_getline(buf, 1)
+  call assert_equal('1+2+3+4+5+6+7+8+9+10+11+12+13+', l)
+
+  let l = term_getline(buf, 2)
+  call assert_equal('14+15', l)
+
+  call TermWait(buf)
+  " It should appear as a single buffer line in vim
+  let lastline = getline('$')
+  call assert_equal('1+2+3+4+5+6+7+8+9+10+11+12+13+14+15', lastline)
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This PR attempts to fix #2865 by removing newlines marked as « continuation » line feeds from the terminal output, when pushing these lines to the buffer.

This allows e.g. to open a file with `gf` when the file name is long and split across several lines. Also nice visually because the wrapping of broken lines is ugly

The good:
- it compiles
- it doesn’t segfault
- it works for me: long lines are now a single line in the buffer (whether they are added when scrollback is enabled or paused etc.), and the buffer wrapping mechanism takes care of the displaying them nicely. See screenshots below.

The bad:
- absolutely not sure this is how it should be implemented. In particular:
  - the changes inside `add_scrollback_line_to_buffer()`: Is `ml_replace` the correct approach ?
  - Is it OK to modify the `sb_pushline` callback ? It seems to be a minimal change and I’ve checked other occurrences of this callback.
- no test cases
- might have messed up code-style or code-quality wise, I’m unsure
- resizing the terminal window still causes loss of data. Not a lot that can be done about this until proper terminal reflowing gets implemented.

I'd like some feedback before continuing to work on this. 

Finally, I’ve added the `continuation` info to the scrollback lines, which may not be 100% necessary (there could be a work-around) at this time − however I believe this will be useful to « reflow » lines, that is move the continuation line breaks on window resizes. See discussion in #2865.

---

Terminal mode: long line causing « continuation » line feeds (same for both vim version):
![image](https://user-images.githubusercontent.com/6126377/121714792-7a663080-cade-11eb-96a1-fac5001f68b3.png)

Switching to normal mode (current vim master), long output line is artifically split, causes problems to select as 1 word and messy display:
![image](https://user-images.githubusercontent.com/6126377/121715399-20199f80-cadf-11eb-981d-3b686307c360.png)


Switching to normal mode (vim built from this PR), long output line appears as a single line (see line numbers), line split is moved due to gutter size (now in `53` instead of after `54`) single word split across displayed lines is really a single word:

![image](https://user-images.githubusercontent.com/6126377/121715333-07a98500-cadf-11eb-8711-1a5ba7aed84f.png)
