### PR TITLE
Fixed crash when doing :call test_null_function()()

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2179,6 +2179,11 @@ func Test_call()
   call call(test_null_partial(), [])
 endfunc
 
+func Test_test_null_function()
+  " This once caused a crash.
+  call test_null_function()()
+endfunc
+
 func Test_char2nr()
   call assert_equal(12354, char2nr('あ', 1))
   call assert_equal(120, 'x'->char2nr())

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -3099,6 +3099,9 @@ call_func(
     // even when call_func() returns FAIL.
     rettv->v_type = VAR_UNKNOWN;
 
+    if (funcname == NULL)
+	return ret;
+
     if (partial != NULL)
 	fp = partial->pt_func;
     if (fp == NULL)


### PR DESCRIPTION
Fixed crash when doing `:call test_null_function()()`.
Fixes #8367.