### PR TITLE
replaced some emsg() with iemsg() for internal errors

### DIFF
--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -1531,7 +1531,7 @@ tclsetdelcmd(
 	reflist = reflist->next;
     }
     // This should never happen.  Famous last word?
-    emsg(_("E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim.org"));
+    iemsg(_("E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim.org"));
     Tcl_SetResult(interp, _("cannot register callback command: buffer/window reference not found"), TCL_STATIC);
     return TCL_ERROR;
 }

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -375,7 +375,7 @@ set_string_option_direct(
 	idx = findoption(name);
 	if (idx < 0)	// not found (should not happen)
 	{
-	    semsg(_(e_intern2), "set_string_option_direct()");
+	    siemsg(_(e_intern2), "set_string_option_direct()");
 	    siemsg(_("For option %s"), name);
 	    return;
 	}


### PR DESCRIPTION
Using `iemsg()` improves the chance of detecting bugs
for users who build with `-DABORT_ON_INTERNAL_ERROR` in
particular for developers using fuzzing.