### PR TITLE
PVS/V547: Expression 'eap->line2 < 0' is always false.

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -4523,9 +4523,6 @@ invalid_range(exarg_T *eap)
 #endif
 		break;
 	    case ADDR_UNSIGNED:
-		if (eap->line2 < 0)
-		    return _(e_invrange);
-		break;
 	    case ADDR_NONE:
 		// Will give an error elsewhere.
 		break;


### PR DESCRIPTION
PVS gave this warning and janlazo suggested that I should upstream this
fix https://github.com/neovim/neovim/pull/14854#issuecomment-864326507 .