### PR TITLE
Add test for mouse events in GUI

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3022,6 +3022,8 @@ test_feedinput({string})	none	add key sequence to input buffer
 test_garbagecollect_now()	none	free memory right now for testing
 test_garbagecollect_soon()	none	free memory soon for testing
 test_getvalue({string})		any	get value of an internal variable
+test_gui_mouse_event({button}, {row}, {col}, {repeated}, {mods})
+				none	add a mouse event to the input buffer
 test_ignore_error({expr})	none	ignore a specific error
 test_null_blob()		Blob	null value for testing
 test_null_channel()		Channel	null value for testing

--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -78,6 +78,25 @@ test_getvalue({name})					*test_getvalue()*
 
 		Can also be used as a |method|: >
 			GetName()->test_getvalue()
+<
+						*test_gui_mouse_event()*
+test_gui_mouse_event({button}, {row}, {col}, {multiclick}, {modifiers})
+		Inject a mouse button click event.  This function works only
+		when GUI is running. The supported values for {button} are:
+			0	right mouse button
+			1	middle mouse button
+			2	left mouse button
+			3	mouse button release
+			4	scroll wheel down
+			5	scroll wheel up
+			6	scroll wheel left
+			7	scroll wheel right
+		{row} and {col} specify the location of the mouse click.
+		To inject a multiclick event, set {multiclick} to 1.
+		The supported values for {modifiers} are:
+			4	shift is pressed
+			8	alt is pressed
+			16	ctrl is pressed
 
 test_ignore_error({expr})			 *test_ignore_error()*
 		Ignore any error containing {expr}.  A normal message is given

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1021,6 +1021,7 @@ Testing:				    *test-functions*
 	test_garbagecollect_now()   free memory right now
 	test_garbagecollect_soon()  set a flag to free memory soon
 	test_getvalue()		get value of an internal variable
+	test_gui_mouse_event()	add a GUI mouse event to the input buffer
 	test_ignore_error()	ignore a specific error message
 	test_null_blob()	return a null Blob
 	test_null_channel()	return a null Channel

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1696,6 +1696,8 @@ static funcentry_T global_functions[] =
 			ret_void,	    f_test_garbagecollect_soon},
     {"test_getvalue",	1, 1, FEARG_1,	    NULL,
 			ret_number,	    f_test_getvalue},
+    {"test_gui_mouse_event",	5, 5, 0,	    NULL,
+			ret_void,	    f_test_gui_mouse_event},
     {"test_ignore_error", 1, 1, FEARG_1,    NULL,
 			ret_void,	    f_test_ignore_error},
     {"test_null_blob",	0, 0, 0,	    NULL,

--- a/src/proto/testing.pro
+++ b/src/proto/testing.pro
@@ -34,5 +34,6 @@ void f_test_unknown(typval_T *argvars, typval_T *rettv);
 void f_test_void(typval_T *argvars, typval_T *rettv);
 void f_test_scrollbar(typval_T *argvars, typval_T *rettv);
 void f_test_setmouse(typval_T *argvars, typval_T *rettv);
+void f_test_gui_mouse_event(typval_T *argvars, typval_T *rettv);
 void f_test_settime(typval_T *argvars, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/testing.c
+++ b/src/testing.c
@@ -1216,6 +1216,20 @@ f_test_setmouse(typval_T *argvars, typval_T *rettv UNUSED)
 }
 
     void
+f_test_gui_mouse_event(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
+{
+#ifdef FEAT_GUI
+    int		button = tv_get_number(&argvars[0]);
+    int		row = tv_get_number(&argvars[1]);
+    int		col = tv_get_number(&argvars[2]);
+    int		repeated_click = tv_get_number(&argvars[3]);
+    int_u	mods = tv_get_number(&argvars[4]);
+
+    gui_send_mouse_event(button, TEXT_X(col - 1), TEXT_Y(row - 1), repeated_click, mods);
+#endif
+}
+
+    void
 f_test_settime(typval_T *argvars, typval_T *rettv UNUSED)
 {
     time_for_testing = (time_t)tv_get_number(&argvars[0]);


### PR DESCRIPTION
Add a new test_gui_mouse_event() function to inject mouse events in GUI.
Use the new function to add additional tests for various mouse events.

This is now ready to be merged.