### PR TITLE
remark about a vertical separator workaround for BiDi

### DIFF
--- a/runtime/doc/arabic.txt
+++ b/runtime/doc/arabic.txt
@@ -176,6 +176,13 @@ o  Enable Arabic settings [short-cut]
 	 and its support is preferred due to its level of offerings.
 	 'arabic' when 'termbidi' is enabled only sets the keymap.
 
+	 For vertical window isolation while setting 'termbidi'
+	   An LTR vertical separator like "l" or "𝖨" may be used
+	   It may also be hidden by changing its color to the foreground color
+>
+		:set fillchars=vert:l
+		:hi VertSplit ctermbg=White
+<
    If, on the other hand, you'd like to be verbose and explicit and
    are opting not to use the 'arabic' short-cut command, here's what
    is needed (i.e. if you use ':set arabic' you can skip this section) -


### PR DESCRIPTION
#### Problem
As in #7148, splitting windows vertically with BiDi enabled causes the text to leak to the other side

#### Solution
This workaround suggests changing the vertical separator in the arabic.txt doc