### PR TITLE
CI: Fix 404 error by updating the package cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install packages
         run: |
-          sudo apt-get install -y \
+          sudo apt update && sudo apt install -y \
             autoconf \
             lcov \
             gettext \


### PR DESCRIPTION
CI seems to fail with 404 errors when trying to install additional packages. So update the available package information before trying to install new packages.