### PR TITLE
Problem: Amiga version string doesn't include build date like expected by the 'version full' command.

### DIFF
--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -116,6 +116,9 @@ static char version[] __attribute__((used)) =
 # ifdef PATCHLEVEL
     "." PATCHLEVEL
 # endif
+# ifdef BUILDDATE
+    " (" BUILDDATE ")"
+# endif
     ;
 #endif
 


### PR DESCRIPTION
Solution: Use BUILDDATE define if provided when building.