### PR TITLE
Problem: Term mode is set using DOS packets on MorphOS

### DIFF
--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -982,7 +982,7 @@ mch_exit(int r)
     void
 mch_settmode(tmode_T tmode)
 {
-#if defined(__AROS__) || defined(__amigaos4__)
+#if defined(__AROS__) || defined(__amigaos4__) || defined(__MORPHOS__)
     if (!SetMode(raw_in, tmode == TMODE_RAW ? 1 : 0))
 #else
     if (dos_packet(MP(raw_in), (long)ACTION_SCREEN_MODE,


### PR DESCRIPTION
Solution: Use the same way of setting term mode on all next
gen Amiga-like systems. Instead of DOS packets, use SetTerm.