### PR TITLE
Add support for elixir filetypes

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -176,7 +176,7 @@ func dist#ft#ExCheck()
   let lines = getline(1, min([line("$"), 100]))
   if exists('g:filetype_euphoria')
     exe 'setf ' . g:filetype_euphoria
-  elseif match(lines, '^--\>\|^--\s*\>\|^ifdef\>\|^include\>\|') > -1
+  elseif match(lines, '^--\|^ifdef\>\|^include\>') > -1
     setf euphoria3
   else
     setf elixir

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -172,6 +172,17 @@ func dist#ft#FTent()
   setf dtd
 endfunc
 
+func dist#ft#ExCheck()
+  let lines = getline(1, min([line("$"), 100]))
+  if exists('g:filetype_euphoria')
+    exe 'setf ' . g:filetype_euphoria
+  elseif match(lines, '^--\>\|^include\>\|') > -1
+    setf euphoria3
+  else
+    setf elixir
+  endif
+endfunc
+
 func dist#ft#EuphoriaCheck()
   if exists('g:filetype_euphoria')
     exe 'setf ' . g:filetype_euphoria

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -176,7 +176,7 @@ func dist#ft#ExCheck()
   let lines = getline(1, min([line("$"), 100]))
   if exists('g:filetype_euphoria')
     exe 'setf ' . g:filetype_euphoria
-  elseif match(lines, '^--\>\|^include\>\|') > -1
+  elseif match(lines, '^--\>\|^--\s*\>\|^ifdef\>\|^include\>\|') > -1
     setf euphoria3
   else
     setf elixir

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -412,8 +412,8 @@ au BufNewFile,BufRead *Eterm/*.cfg		setf eterm
 au BufNewFile,BufRead *.ex call dist#ft#ExCheck()
 
 " Elixir
-autocmd BufRead,BufNewFile mix.lock,*.exs setf=elixir
-autocmd BufRead,BufNewFile *.eex,*.leex setf=eelixir
+au BufRead,BufNewFile mix.lock,*.exs setf elixir
+au BufRead,BufNewFile *.eex,*.leex setf eelixir
 
 " Euphoria 3 or 4
 au BufNewFile,BufRead *.eu,*.ew,*.exu,*.exw  call dist#ft#EuphoriaCheck()

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -393,7 +393,7 @@ au BufNewFile,BufRead *.cfm,*.cfi,*.cfc		setf cf
 " Configure scripts
 au BufNewFile,BufRead configure.in,configure.ac setf config
 
-" CUDA  Cumpute Unified Device Architecture
+" CUDA Compute Unified Device Architecture
 au BufNewFile,BufRead *.cu,*.cuh		setf cuda
 
 " Dockerfile; Podman uses the same syntax with name Containerfile
@@ -408,8 +408,15 @@ au BufNewFile,BufRead *enlightenment/*.cfg	setf c
 " Eterm
 au BufNewFile,BufRead *Eterm/*.cfg		setf eterm
 
+" Elixir or Euphoria
+au BufNewFile,BufRead *.ex call dist#ft#ExCheck()
+
+" Elixir
+autocmd BufRead,BufNewFile mix.lock,*.exs setf=elixir
+autocmd BufRead,BufNewFile *.eex,*.leex setf=eelixir
+
 " Euphoria 3 or 4
-au BufNewFile,BufRead *.eu,*.ew,*.ex,*.exu,*.exw  call dist#ft#EuphoriaCheck()
+au BufNewFile,BufRead *.eu,*.ew,*.exu,*.exw  call dist#ft#EuphoriaCheck()
 if has("fname_case")
    au BufNewFile,BufRead *.EU,*.EW,*.EX,*.EXU,*.EXW  call dist#ft#EuphoriaCheck()
 endif

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -161,6 +161,8 @@ let s:filename_checks = {
     \ 'ecd': ['file.ecd'],
     \ 'edif': ['file.edf', 'file.edif', 'file.edo'],
     \ 'elinks': ['elinks.conf'],
+    \ 'elixir': ['file.exs', 'mix.lock'],
+    \ 'eelixir': ['file.eex', 'file.leex'],
     \ 'elm': ['file.elm'],
     \ 'elmfilt': ['filter-rules'],
     \ 'epuppet': ['file.epp'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -161,7 +161,7 @@ let s:filename_checks = {
     \ 'ecd': ['file.ecd'],
     \ 'edif': ['file.edf', 'file.edif', 'file.edo'],
     \ 'elinks': ['elinks.conf'],
-    \ 'elixir': ['file.exs', 'mix.lock'],
+    \ 'elixir': ['file.ex', 'file.exs', 'mix.lock'],
     \ 'eelixir': ['file.eex', 'file.leex'],
     \ 'elm': ['file.elm'],
     \ 'elmfilt': ['filter-rules'],
@@ -794,6 +794,16 @@ endfunc
 
 func Test_ex_file()
   filetype on
+
+  call writefile(['arbitrary content'], 'Xfile.ex')
+  split Xfile.ex
+  call assert_equal('elixir', &filetype)
+  bwipe!
+  let g:filetype_euphoria = 'euphoria4'
+  split Xfile.ex
+  call assert_equal('euphoria4', &filetype)
+  bwipe!
+  unlet g:filetype_euphoria
 
   call writefile(['-- filetype euphoria comment'], 'Xfile.ex')
   split Xfile.ex

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -792,5 +792,31 @@ func Test_pp_file()
   filetype off
 endfunc
 
+func Test_ex_file()
+  filetype on
+
+  call writefile(['-- filetype euphoria comment'], 'Xfile.ex')
+  split Xfile.ex
+  call assert_equal('euphoria3', &filetype)
+  bwipe!
+
+  call writefile(['--filetype euphoria comment'], 'Xfile.ex')
+  split Xfile.ex
+  call assert_equal('euphoria3', &filetype)
+  bwipe!
+
+  call writefile(['ifdef '], 'Xfile.ex')
+  split Xfile.ex
+  call assert_equal('euphoria3', &filetype)
+  bwipe!
+
+  call writefile(['include '], 'Xfile.ex')
+  split Xfile.ex
+  call assert_equal('euphoria3', &filetype)
+  bwipe!
+
+  call delete('Xfile.ex')
+  filetype off
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
resolves #8401 

In this PR description I'm using `^[text] ` to signify a line in the file starting with "text" and followed by a space. I.e., column 1 is occupied by a non-whitespace character.

### Notes

- I removed `*.sface` as an elixir filetype, which was listed as such in the issue. While [Surface](https://github.com/surface-ui/surface) is a relatively popular UI library for Elixir/Phoenix/LiveView, it's not part of elixir core. All the other filetypes are.

- I checked the first 10 lines of every `.ex` file in OpenEuphoria and found that almost every file had a line either starting with `^-- ` or `^include `. I added a regex check for these most common lines in the first commit. (One interesting result in GitHub search is `"--" extension:ex language:elixir`.  One of the top results is a self-identified Euphoria4 file incorrectly identified by GitHub as an elixir file.)

- There were only 3 of out 40+ `.ex` euphoria files in OpenEuphoria that were _not_ correctly identified by `^-- ` or `^include `
    - One could be detected via `^ifdef ` (in fact, top advanced GitHub results for this show misidentified euphoria files). 
    - The other two could be detected via `^--[text] `, where [text] is any word.
    
    I included checks against both of these scenarios in the second commit.

- Other Euphoria keywords that likely _never_ begin a line of elixir code are `^without `, `^constant `, and `^integer `. I corroborated this via a brief advanced GitHub search of type `[keyword] extension:ex language:elixir`. I left these out of `dist#ft#ExCheck` because I worry about being too expansive in our regex checks, which could risk edge-case misidentification.

- I was unsure how to best test `dist#ft#ExCheck`, though I did add tests for the other elixir filetypes.

### Questions

Lastly, do you recommend this PR include updates to `vim/runtime/doc/syntax.txt` and `vim/runtime/doc/tags`?