### PR TITLE
filetype: setf json for *.json-patch (RFC 6902)

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -855,6 +855,9 @@ au BufNewFile,BufRead *.jov,*.j73,*.jovial	setf jovial
 " JSON
 au BufNewFile,BufRead *.json,*.jsonp,*.webmanifest	setf json
 
+" JSON Patch (RFC 6902)
+au BufNewFile,BufRead *.json-patch			setf json
+
 " Jupyter Notebook is also json
 au BufNewFile,BufRead *.ipynb				setf json
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -257,7 +257,7 @@ let s:filename_checks = {
     \ 'jgraph': ['file.jgr'],
     \ 'jovial': ['file.jov', 'file.j73', 'file.jovial'],
     \ 'jproperties': ['file.properties', 'file.properties_xx', 'file.properties_xx_xx', 'some.properties_xx_xx_file'],
-    \ 'json': ['file.json', 'file.jsonp', 'file.webmanifest', 'Pipfile.lock', 'file.ipynb'],
+    \ 'json': ['file.json', 'file.jsonp', 'file.json-patch', 'file.webmanifest', 'Pipfile.lock', 'file.ipynb'],
     \ 'jsp': ['file.jsp'],
     \ 'kconfig': ['Kconfig', 'Kconfig.debug', 'Kconfig.file'],
     \ 'kivy': ['file.kv'],


### PR DESCRIPTION
JSON Patch defines a JSON document structure for expressing a sequence of operations to apply to a JavaScript Object Notation (JSON) document.  It is specified by [RFC 6902], which specifies `.json-patch` as the file extension for JSON Patch files in Section 6.  It seems unlikely that the file extension would contain anything other than JSON.  So, this PR adds `setf json` for files with this extension.

Thanks for considering,
Kevin

[RFC 6902]: https://datatracker.ietf.org/doc/html/rfc6902