### PR TITLE
Use `emsg_silent` instead of `emsg_skip` in JSON channel command

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -2545,7 +2545,8 @@ channel_exe_cmd(channel_T *channel, ch_part_T part, typval_T *argv)
 	    char_u	*json = NULL;
 
 	    // Don't pollute the display with errors.
-	    ++emsg_skip;
+	    // Do generate errors so that try/catch works.
+	    ++emsg_silent;
 	    if (!is_call)
 	    {
 		ch_log(channel, "Evaluating expression '%s'", (char *)arg);
@@ -2581,7 +2582,7 @@ channel_exe_cmd(channel_T *channel, ch_part_T part, typval_T *argv)
 		    vim_free(json);
 		}
 	    }
-	    --emsg_skip;
+	    --emsg_silent;
 	    if (tv == &res_tv)
 		clear_tv(tv);
 	    else


### PR DESCRIPTION
I'm making some kind of RPC mechanisms ([denops.vim](https://github.com/vim-denops/denops.vim) if you are interested) on top of Vim's channel command and found that we cannot get any exceptions occurred in the `call` channel command.

I understand that Vim channel command [tried not to pollute display](https://github.com/vim/vim/blob/108010aa4720ef023a8ac59004fc0f2bc11125af/src/channel.c#L2547) thus I create a wrap function which catch and return errors occured like:

```vim
function! CallWrap(fn, args) abort
  try
    return [call(a:fn, a:args), '']
  catch
    return [v:null, v:exception]
  endtry
endfunction
```

With a wrap function above, I've expected that I can tell if an exception occurs in the `call` channel command by second element of the result like:

1. Get success result of `["call", "CallWrap", ["range", [5]], 100]` as `[100, [[0, 1, 2, 3, 4], '']]`
2. Get error result of `["call", "CallWrap", ["no-such-function", []], 100]` as `[100, [null, 'Vim(return):E117: Unknown function: ...']]`

But unfortunately, in the second case, the return value was `[100, [0, '']]` so I cannot tell the reason of the failure.

That's why I've changed `emsg_skip` to `emsg_silent`. That change makes `CallWrap` work as expected.
To be honest, I've no idea what I've done in this PR. I just found `emsg_silent` from https://github.com/vim/vim/blob/c54f347d63bcca97ead673d01ac6b59914bb04e5/src/clientserver.c#L85 and it seems using `emsg_silent` solved my problem so I made this PR.

Thank you.