### PR TITLE
charclass: return early, if input is NULL

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5587,7 +5587,8 @@ f_setcellwidths(typval_T *argvars, typval_T *rettv UNUSED)
     void
 f_charclass(typval_T *argvars, typval_T *rettv UNUSED)
 {
-    if (check_for_string_arg(argvars, 0) == FAIL)
+    if (check_for_string_arg(argvars, 0) == FAIL ||
+	    argvars[0].vval.v_string == NULL)
 	return;
     rettv->vval.v_number = mb_get_class(argvars[0].vval.v_string);
 }

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2169,6 +2169,8 @@ func Test_charclass()
   call assert_equal(1, charclass('.'))
   call assert_equal(2, charclass('x'))
   call assert_equal(3, charclass("\u203c"))
+  " this used to crash vim
+  call assert_equal(0, "xxx"[-1]->charclass())
 endfunc
 
 func Test_eventhandler()


### PR DESCRIPTION
Return early, if the input is invalid. 

This fixes https://github.com/vim/vim/issues/8260