### PR TITLE
Support for JSONC

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -868,6 +868,9 @@ au BufNewFile,BufRead *.json-patch			setf json
 " Jupyter Notebook is also json
 au BufNewFile,BufRead *.ipynb				setf json
 
+" JSONC
+au BufNewFile,BufRead *.jsonc			setf jsonc
+
 " Kixtart
 au BufNewFile,BufRead *.kix			setf kix
 

--- a/runtime/ftplugin/jsonc.vim
+++ b/runtime/ftplugin/jsonc.vim
@@ -6,7 +6,7 @@
 " License:          MIT
 " Last Change:      2021-07-01
 
-runtime ftplugin/json.vim
+runtime! ftplugin/json.vim
 
 if exists('b:did_ftplugin_jsonc')
   finish

--- a/runtime/ftplugin/jsonc.vim
+++ b/runtime/ftplugin/jsonc.vim
@@ -1,0 +1,27 @@
+" Vim filetype plugin
+" Language:         JSONC (JSON with Comments)
+" Original Author:  Izhak Jakov <izhak724@gmail.com>
+" Acknowledgement:  Based off of vim-jsonc maintained by Kevin Locke <kevin@kevinlocke.name>
+"                   https://github.com/kevinoid/vim-jsonc
+" License:          MIT
+" Last Change:      2021-07-01
+
+runtime ftplugin/json.vim
+
+if exists('b:did_ftplugin_jsonc')
+  finish
+else
+  let b:did_ftplugin_jsonc = 1
+endif
+
+" A list of commands that undo buffer local changes made below.
+let s:undo_ftplugin = []
+
+" Set comment (formatting) related options. {{{1
+setlocal commentstring=//%s comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+call add(s:undo_ftplugin, 'commentstring< comments<')
+
+" Let Vim know how to disable the plug-in.
+call map(s:undo_ftplugin, "'execute ' . string(v:val)")
+let b:undo_ftplugin = join(s:undo_ftplugin, ' | ')
+unlet s:undo_ftplugin

--- a/runtime/indent/jsonc.vim
+++ b/runtime/indent/jsonc.vim
@@ -1,0 +1,189 @@
+" Vim indent file
+" Language:         JSONC (JSON with Comments)
+" Original Author:  Izhak Jakov <izhak724@gmail.com>
+" Acknowledgement:  Based off of vim-json maintained by Eli Parra <eli@elzr.com>
+"                   https://github.com/elzr/vim-json
+" Last Change:      2021-07-01
+
+" 0. Initialization {{{1
+" =================
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+setlocal nosmartindent
+
+" Now, set up our indentation expression and keys that trigger it.
+setlocal indentexpr=GetJSONCIndent()
+setlocal indentkeys=0{,0},0),0[,0],!^F,o,O,e
+
+" Only define the function once.
+if exists("*GetJSONCIndent")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" 1. Variables {{{1
+" ============
+
+let s:line_term = '\s*\%(\%(\/\/\).*\)\=$'
+" Regex that defines blocks.
+let s:block_regex = '\%({\)\s*\%(|\%([*@]\=\h\w*,\=\s*\)\%(,\s*[*@]\=\h\w*\)*|\)\=' . s:line_term
+
+" 2. Auxiliary Functions {{{1
+" ======================
+
+" Check if the character at lnum:col is inside a string.
+function s:IsInString(lnum, col)
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') == 'jsonString'
+endfunction
+
+" Find line above 'lnum' that isn't empty, or in a string.
+function s:PrevNonBlankNonString(lnum)
+  let lnum = prevnonblank(a:lnum)
+  while lnum > 0
+    " If the line isn't empty or in a string, end search.
+    let line = getline(lnum)
+    if !(s:IsInString(lnum, 1) && s:IsInString(lnum, strlen(line)))
+      break
+    endif
+    let lnum = prevnonblank(lnum - 1)
+  endwhile
+  return lnum
+endfunction
+
+" Check if line 'lnum' has more opening brackets than closing ones.
+function s:LineHasOpeningBrackets(lnum)
+  let open_0 = 0
+  let open_2 = 0
+  let open_4 = 0
+  let line = getline(a:lnum)
+  let pos = match(line, '[][(){}]', 0)
+  while pos != -1
+    let idx = stridx('(){}[]', line[pos])
+    if idx % 2 == 0
+      let open_{idx} = open_{idx} + 1
+    else
+      let open_{idx - 1} = open_{idx - 1} - 1
+    endif
+    let pos = match(line, '[][(){}]', pos + 1)
+  endwhile
+  return (open_0 > 0) . (open_2 > 0) . (open_4 > 0)
+endfunction
+
+function s:Match(lnum, regex)
+  let col = match(getline(a:lnum), a:regex) + 1
+  return col > 0 && !s:IsInString(a:lnum, col) ? col : 0
+endfunction
+
+" 3. GetJSONCIndent Function {{{1
+" =========================
+
+function GetJSONCIndent()
+  if !exists("s:inside_comment")
+    let s:inside_comment = 0
+  endif
+
+  " 3.1. Setup {{{2
+  " ----------
+
+  " Set up variables for restoring position in file.  Could use v:lnum here.
+  let vcol = col('.')
+
+  " 3.2. Work on the current line {{{2
+  " -----------------------------
+
+
+  " Get the current line.
+  let line = getline(v:lnum)
+  let ind = -1
+  if s:inside_comment == 0
+    " TODO iterate through all the matches in a line
+    let col = matchend(line, '\/\*')
+    if col > 0 && !s:IsInString(v:lnum, col)
+      let s:inside_comment = 1
+    endif
+  endif
+  " If we're in the middle of a comment
+  if s:inside_comment == 1
+    let col = matchend(line, '\*\/')
+    if col > 0 && !s:IsInString(v:lnum, col)
+      let s:inside_comment = 0
+    endif
+    return ind
+  endif
+  if line =~ '^\s*//'
+    return ind
+  endif
+
+  " If we got a closing bracket on an empty line, find its match and indent
+  " according to it.
+  let col = matchend(line, '^\s*[]}]')
+
+  if col > 0 && !s:IsInString(v:lnum, col)
+    call cursor(v:lnum, col)
+    let bs = strpart('{}[]', stridx('}]', line[col - 1]) * 2, 2)
+
+    let pairstart = escape(bs[0], '[')
+    let pairend = escape(bs[1], ']')
+    let pairline = searchpair(pairstart, '', pairend, 'bW')
+
+    if pairline > 0 
+      let ind = indent(pairline)
+    else
+      let ind = virtcol('.') - 1
+    endif
+
+    return ind
+  endif
+
+  " If we are in a multi-line string, don't do anything to it.
+  if s:IsInString(v:lnum, matchend(line, '^\s*') + 1)
+    return indent('.')
+  endif
+
+  " 3.3. Work on the previous line. {{{2
+  " -------------------------------
+
+  let lnum = prevnonblank(v:lnum - 1)
+
+  if lnum == 0
+    return 0
+  endif
+
+  " Set up variables for current line.
+  let line = getline(lnum)
+  let ind = indent(lnum)
+
+  " If the previous line ended with a block opening, add a level of indent.
+  " if s:Match(lnum, s:block_regex)
+  " return indent(lnum) + shiftwidth()
+  " endif
+
+  " If the previous line contained an opening bracket, and we are still in it,
+  " add indent depending on the bracket type.
+  if line =~ '[[({]'
+    let counts = s:LineHasOpeningBrackets(lnum)
+    if counts[0] == '1' || counts[1] == '1' || counts[2] == '1'
+      return ind + shiftwidth()
+    else
+      call cursor(v:lnum, vcol)
+    end
+  endif
+
+  " }}}2
+
+  return ind
+endfunction
+
+" }}}1
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim:set sw=2 sts=2 ts=8 noet:

--- a/runtime/syntax/jsonc.vim
+++ b/runtime/syntax/jsonc.vim
@@ -1,8 +1,7 @@
 " Vim syntax file
 " Language:         JSONC (JSON with Comments)
 " Original Author:  Izhak Jakov <izhak724@gmail.com>
-" Acknowledgement:  Based off of vim-jsonc maintained by Kevin Locke
-" <kevin@kevinlocke.name>
+" Acknowledgement:  Based off of vim-jsonc maintained by Kevin Locke <kevin@kevinlocke.name>
 "                   https://github.com/kevinoid/vim-jsonc
 " License:          MIT
 " Last Change:      2021-07-01
@@ -17,7 +16,7 @@ if !exists('g:main_syntax')
 endif
 
 " Based on vim-json syntax
-runtime syntax/json.vim
+runtime! syntax/json.vim
 
 " Remove syntax group for comments treated as errors
 if !exists("g:vim_json_warnings") || g:vim_json_warnings
@@ -31,7 +30,7 @@ syn match jsonTrailingCommaError /\(,\)\+\ze\_s*\/\*\_.*\*\/\_s*[}\]]/
 
 " Define syntax matching comments and their contents
 syn keyword jsonCommentTodo  FIXME NOTE TBD TODO XXX
-syn region  jsonLineComment  start=+\/\/+ end=+$+   contains=@Spell,jsonCommentTodo
+syn region  jsonLineComment  start=+\/\/+ end=+$+   contains=@Spell,jsonCommentTodo keepend
 syn region  jsonComment      start='/\*'  end='\*/' contains=@Spell,jsonCommentTodo fold
 
 " Link comment syntax comment to highlighting

--- a/runtime/syntax/jsonc.vim
+++ b/runtime/syntax/jsonc.vim
@@ -1,0 +1,45 @@
+" Vim syntax file
+" Language:         JSONC (JSON with Comments)
+" Original Author:  Izhak Jakov <izhak724@gmail.com>
+" Acknowledgement:  Based off of vim-jsonc maintained by Kevin Locke
+" <kevin@kevinlocke.name>
+"                   https://github.com/kevinoid/vim-jsonc
+" License:          MIT
+" Last Change:      2021-07-01
+
+" Ensure syntax is loaded once, unless nested inside another (main) syntax
+" For description of main_syntax, see https://stackoverflow.com/q/16164549
+if !exists('g:main_syntax')
+  if exists('b:current_syntax') && b:current_syntax ==# 'jsonc'
+    finish
+  endif
+  let g:main_syntax = 'jsonc'
+endif
+
+" Based on vim-json syntax
+runtime syntax/json.vim
+
+" Remove syntax group for comments treated as errors
+if !exists("g:vim_json_warnings") || g:vim_json_warnings
+  syn clear jsonCommentError
+endif
+
+syn match jsonStringMatch /"\([^"]\|\\\"\)\+"\ze\(\_s*\/\/.*\_s*\)*[}\]]/ contains=jsonString
+syn match jsonStringMatch /"\([^"]\|\\\"\)\+"\ze\_s*\/\*\_.*\*\/\_s*[}\]]/ contains=jsonString
+syn match jsonTrailingCommaError /\(,\)\+\ze\(\_s*\/\/.*\_s*\)*[}\]]/
+syn match jsonTrailingCommaError /\(,\)\+\ze\_s*\/\*\_.*\*\/\_s*[}\]]/
+
+" Define syntax matching comments and their contents
+syn keyword jsonCommentTodo  FIXME NOTE TBD TODO XXX
+syn region  jsonLineComment  start=+\/\/+ end=+$+   contains=@Spell,jsonCommentTodo
+syn region  jsonComment      start='/\*'  end='\*/' contains=@Spell,jsonCommentTodo fold
+
+" Link comment syntax comment to highlighting
+hi! def link jsonLineComment    Comment
+hi! def link jsonComment        Comment
+
+" Set/Unset syntax to avoid duplicate inclusion and correctly handle nesting
+let b:current_syntax = 'jsonc'
+if g:main_syntax ==# 'jsonc'
+  unlet g:main_syntax
+endif

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -260,6 +260,7 @@ let s:filename_checks = {
     \ 'jovial': ['file.jov', 'file.j73', 'file.jovial'],
     \ 'jproperties': ['file.properties', 'file.properties_xx', 'file.properties_xx_xx', 'some.properties_xx_xx_file'],
     \ 'json': ['file.json', 'file.jsonp', 'file.json-patch', 'file.webmanifest', 'Pipfile.lock', 'file.ipynb'],
+    \ 'jsonc': ['file.jsonc'],
     \ 'jsp': ['file.jsp'],
     \ 'kconfig': ['Kconfig', 'Kconfig.debug', 'Kconfig.file'],
     \ 'kivy': ['file.kv'],


### PR DESCRIPTION
## Description from issue https://github.com/vim/vim/issues/8499

I see more and more tools using jsonc format for their configuration files.  I believe this trend will only increase and VIM should consider supporting these formats

### [jsonc](https://komkom.github.io)
Basically a JSON with C-style line (`//`) and block (`/**/`) comments.
Exiting vim plugin: https://github.com/kevinoid/vim-jsonc

### Steps to reproduce using `vim -u NONE`

```
$ vim -u NONE sample.jsonc
<opened as a plain text>
```

### Actual behaviour
opens up as a plain text

### Expected behaviour
Opened as a jsonc file:
- proper syntax highlighting
- proper error messages
- proper indentation and formatting