### PR TITLE
Test Test_popup_atcursor_pos failed when +conceal feature not available

### DIFF
--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -1437,6 +1437,7 @@ endfunc
 
 func Test_popup_atcursor_pos()
   CheckScreendump
+  CheckFeature conceal
 
   let lines =<< trim END
 	call setline(1, repeat([repeat('-', 60)], 15))


### PR DESCRIPTION
This PR fixes `Test_popup_atcursor_pos` which failed when the `+conceal` feature is not available.
This happens at least with Vim-8.2.3089.

The test used the conceal feature without checking whether the feature is available.

To reproduce:
```
$ ./configure --with-features=normal --enable-gui=none --enable-terminal
$ make - j8
$ make test_popupwin
...snip...
Executed 103 tests                       in  14.698552 seconds
1 FAILED:
Found errors in Test_popup_atcursor_pos():
Run 1:
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_popup_atcursor_pos[37]..VerifyScreenDump line 58: See dump file difference: call term_dumpdiff("testdir/failed/Test_popupwin_atcursor_pos.dump", "testdir/dumps/Test_popupwin_atcursor_pos.dump"); difference in line 8: "|-@1|s+0#0000001#ffd7ff255|e|c|o|n|d|-+0#0000000#ffffff0@6|S+0#0000001#ffd7ff255|E|c|o|N|D|-+0#0000000#ffffff0@15|m+0#0000001#ffd7ff255|a|r|k|-+0#0000000#ffffff0@18| @14"; difference in line 9: "|-@1|#|-@16|&|-@4|c|o|n|c|e|a|l|e|d| @1>X|-@21| @14"
Run 2:
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[507]..function RunTheTest[44]..Test_popup_atcursor_pos[37]..VerifyScreenDump line 58: See dump file difference: call term_dumpdiff("testdir/failed/Test_popupwin_atcursor_pos.dump", "testdir/dumps/Test_popupwin_atcursor_pos.dump"); difference in line 8: "|-@1|s+0#0000001#ffd7ff255|e|c|o|n|d|-+0#0000000#ffffff0@6|S+0#0000001#ffd7ff255|E|c|o|N|D|-+0#0000000#ffffff0@15|m+0#0000001#ffd7ff255|a|r|k|-+0#0000000#ffffff0@18| @14"; difference in line 9: "|-@1|#|-@16|&|-@4|c|o|n|c|e|a|l|e|d| @1>X|-@21| @14"
Run 3:
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[507]..function RunTheTest[44]..Test_popup_atcursor_pos[37]..VerifyScreenDump line 58: See dump file difference: call term_dumpdiff("testdir/failed/Test_popupwin_atcursor_pos.dump", "testdir/dumps/Test_popupwin_atcursor_pos.dump"); difference in line 8: "|-@1|s+0#0000001#ffd7ff255|e|c|o|n|d|-+0#0000000#ffffff0@6|S+0#0000001#ffd7ff255|E|c|o|N|D|-+0#0000000#ffffff0@15|m+0#0000001#ffd7ff255|a|r|k|-+0#0000000#ffffff0@18| @14"; difference in line 9: "|-@1|#|-@16|&|-@4|c|o|n|c|e|a|l|e|d| @1>X|-@21| @14"
Flaky test failed too often, giving up
SKIPPED Test_popup_beval(): balloon_eval_term feature missing
Makefile:63: recipe for target 'test_popupwin' failed
make[1]: *** [test_popupwin] Error 1
make[1]: Leaving directory '/home/pel/sb/vim/src/testdir'
Makefile:2325: recipe for target 'test_popupwin' failed
make: *** [test_popupwin] Error 2
```