### PR TITLE
Running tests left 2 temporary files: src/testdir/XTest_block, src/testdir/XtestDebug.vim

### DIFF
--- a/src/testdir/test_debugger.vim
+++ b/src/testdir/test_debugger.vim
@@ -975,8 +975,7 @@ func Test_debug_def_and_legacy_function()
   call RunDbgCmd(buf, 'cont')
 
   call StopVimInTerminal(buf)
-  call delete('Xtest1.vim')
-  call delete('Xtest2.vim')
+  call delete('XtestDebug.vim')
 endfunc
 
 func Test_debug_def_function()

--- a/src/testdir/test_lambda.vim
+++ b/src/testdir/test_lambda.vim
@@ -330,6 +330,7 @@ func Test_closure_error()
     let caught_932 = 1
   endtry
   call assert_equal(1, caught_932)
+  call delete('Xscript')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1262,7 +1262,7 @@ func Test_visual_block_with_virtualedit()
   " clean up
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)
-  call delete('XTest_beval')
+  call delete('XTest_block')
 endfunc
 
 


### PR DESCRIPTION
Running tests left 2 temporary files: `src/testdir/XTest_block` and `src/testdir/XtestDebug.vim`.