### PR TITLE
Problem: Build error on non Windows / Unix-like systems.

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -1109,6 +1109,7 @@ add_b0_fenc(
  * "swap_fname" is the name of the swap file, if it's from before a reboot then
  * the result is FALSE;
  */
+#if defined(UNIX) || defined(MSWIN)
     static int
 swapfile_process_running(ZERO_BL *b0p, char_u *swap_fname UNUSED)
 {
@@ -1129,6 +1130,7 @@ swapfile_process_running(ZERO_BL *b0p, char_u *swap_fname UNUSED)
 #endif
     return mch_process_running(char_to_long(b0p->b0_pid));
 }
+#endif
 
 /*
  * Try to recover curbuf from the .swp file.


### PR DESCRIPTION
Solution: Only build swapfile_process_running(...) on Windows and Unix-like systems.