### PR TITLE
duplicate use of articles results in invalid grammar

### DIFF
--- a/runtime/tutor/tutor.utf-8
+++ b/runtime/tutor/tutor.utf-8
@@ -789,7 +789,7 @@ NOTE:  Replace mode is like Insert mode, but every typed character deletes an
 
   1. Move to the line below marked ---> and place the cursor after "a)".
 
-  2. Start Visual mode with  v  and move the cursor to just before "first".
+  2. Start Visual mode with  v  and move the cursor to just before "the".
 
   3. Type  y  to yank (copy) the highlighted text.
 


### PR DESCRIPTION
Currently, the instructions in Lesson 6.4 result in
```
---> a) this is the first item.
---> b) this is the a second item.
```
when I believe the desired output to be
```
---> a) this is the first item.
---> b) this is a second item.
```
.
Someone might argue that `a` should be dropped and only "second" should be replaced.
I agree, however that would make the use of vim's `v` suboptimal, instead `yw` should be used in the example.