### PR TITLE
Fix indent for bzl files.

### DIFF
--- a/runtime/indent/bzl.vim
+++ b/runtime/indent/bzl.vim
@@ -41,30 +41,41 @@ function GetBzlIndent(lnum) abort
     if exists('g:pyindent_open_paren')
       let l:pyindent_open_paren = g:pyindent_open_paren
     endif
-    let g:pyindent_nested_paren = 'shiftwidth() * 2'
-    let g:pyindent_open_paren = 'shiftwidth() * 2'
+    let g:pyindent_nested_paren = 'shiftwidth()'
+    let g:pyindent_open_paren = 'shiftwidth()'
   endif
 
   let l:indent = -1
 
-  " Indent inside parens.
-  " Align with the open paren unless it is at the end of the line.
-  " E.g.
-  "   open_paren_not_at_EOL(100,
-  "                         (200,
-  "                          300),
-  "                         400)
-  "   open_paren_at_EOL(
-  "       100, 200, 300, 400)
   call cursor(a:lnum, 1)
   let [l:par_line, l:par_col] = searchpairpos('(\|{\|\[', '', ')\|}\|\]', 'bW',
       \ "line('.') < " . (a:lnum - s:maxoff) . " ? dummy :" .
       \ " synIDattr(synID(line('.'), col('.'), 1), 'name')" .
       \ " =~ '\\(Comment\\|String\\)$'")
   if l:par_line > 0
-    call cursor(l:par_line, 1)
-    if l:par_col != col('$') - 1
-      let l:indent = l:par_col
+    " Indent inside parens.
+    if searchpair('(\|{\|\[', '', ')\|}\|\]', 'W',
+      \ "line('.') < " . (a:lnum - s:maxoff) . " ? dummy :" .
+      \ " synIDattr(synID(line('.'), col('.'), 1), 'name')" .
+      \ " =~ '\\(Comment\\|String\\)$'") && line('.') == a:lnum
+      " If cursor is at close parens, match indent with open parens.
+      " E.g.
+      "   foo(
+      "   )
+      let l:indent = indent(l:par_line)
+    else
+      " Align with the open paren unless it is at the end of the line.
+      " E.g.
+      "   open_paren_not_at_EOL(100,
+      "                         (200,
+      "                          300),
+      "                         400)
+      "   open_paren_at_EOL(
+      "       100, 200, 300, 400)
+      call cursor(l:par_line, 1)
+      if l:par_col != col('$') - 1
+        let l:indent = l:par_col
+      endif
     endif
   endif
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/vim-ft-bzl/issues/1.

Before this change:
```
cc_binary(
        name = "hello-world",
        srcs = ["hello-world.cc"],
        deps = [
                ":hello-time",
                "//lib:hello-greet",
                ],
        )
```
Indent is `shiftwidth() * 2` and the closing `)`/`]` don't match the
opening `(`/`[`.

After this change:
```
cc_binary(
    name = "hello-world",
    srcs = ["hello-world.cc"],
    deps = [
        ":hello-time",
        "//lib:hello-greet",
    ],
)
```

@dbarnett for maintainer approval.