### PR TITLE
Error out on :command with -complete but without -nargs

### DIFF
--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -270,6 +270,8 @@ func Test_CmdErrors()
   call assert_fails('com! -complete=custom DoCmd :', 'E467:')
   call assert_fails('com! -complete=customlist DoCmd :', 'E467:')
   call assert_fails('com! -complete=behave,CustomComplete DoCmd :', 'E468:')
+  call assert_fails('com! -complete=file DoCmd :', 'E1208:')
+  call assert_fails('com! -nargs=0 -complete=file DoCmd :', 'E1208:')
   call assert_fails('com! -nargs=x DoCmd :', 'E176:')
   call assert_fails('com! -count=1 -count=2 DoCmd :', 'E177:')
   call assert_fails('com! -count=x DoCmd :', 'E178:')
@@ -338,34 +340,30 @@ func Test_CmdCompletion()
   call feedkeys(":com DoC\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"com DoC', @:)
 
-  com! -complete=behave DoCmd :
+  com! -nargs=1 -complete=behave DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd mswin xterm', @:)
 
-  " This does not work. Why?
-  "call feedkeys(":DoCmd x\<C-A>\<C-B>\"\<CR>", 'tx')
-  "call assert_equal('"DoCmd xterm', @:)
-
-  com! -complete=custom,CustomComplete DoCmd :
+  com! -nargs=* -complete=custom,CustomComplete DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd January February Mars', @:)
 
-  com! -complete=customlist,CustomCompleteList DoCmd :
+  com! -nargs=? -complete=customlist,CustomCompleteList DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd Monday Tuesday Wednesday', @:)
 
-  com! -complete=custom,CustomCompleteList DoCmd :
+  com! -nargs=+ -complete=custom,CustomCompleteList DoCmd :
   call assert_fails("call feedkeys(':DoCmd \<C-D>', 'tx')", 'E730:')
 
-  com! -complete=customlist,CustomComp DoCmd :
+  com! -nargs=+ -complete=customlist,CustomComp DoCmd :
   call assert_fails("call feedkeys(':DoCmd \<C-D>', 'tx')", 'E117:')
 
   " custom completion without a function
-  com! -complete=custom, DoCmd
+  com! -nargs=? -complete=custom, DoCmd
   call assert_beeps("call feedkeys(':DoCmd \t', 'tx')")
 
   " custom completion failure with the wrong function
-  com! -complete=custom,min DoCmd
+  com! -nargs=? -complete=custom,min DoCmd
   call assert_fails("call feedkeys(':DoCmd \t', 'tx')", 'E118:')
 
   delcom DoCmd
@@ -500,21 +498,21 @@ func Test_command_list()
         \           execute('command DoCmd'))
 
   " Test with various -complete= argument values (non-exhaustive list)
-  command! -complete=arglist DoCmd :
+  command! -nargs=1 -complete=arglist DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"
-        \        .. "\n    DoCmd             0            arglist     :",
+        \        .. "\n    DoCmd             1            arglist     :",
         \           execute('command DoCmd'))
-  command! -complete=augroup DoCmd :
+  command! -nargs=* -complete=augroup DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"
-        \        .. "\n    DoCmd             0            augroup     :",
+        \        .. "\n    DoCmd             *            augroup     :",
         \           execute('command DoCmd'))
-  command! -complete=custom,CustomComplete DoCmd :
+  command! -nargs=? -complete=custom,CustomComplete DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"
-        \        .. "\n    DoCmd             0            custom      :",
+        \        .. "\n    DoCmd             ?            custom      :",
         \           execute('command DoCmd'))
-  command! -complete=customlist,CustomComplete DoCmd :
+  command! -nargs=+ -complete=customlist,CustomComplete DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"
-        \        .. "\n    DoCmd             0            customlist  :",
+        \        .. "\n    DoCmd             +            customlist  :",
         \           execute('command DoCmd'))
 
   " Test with various -narg= argument values.

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -1025,14 +1025,16 @@ ex_command(exarg_T *eap)
     else if (!ASCII_ISUPPER(*name))
     {
 	emsg(_("E183: User defined commands must start with an uppercase letter"));
-	return;
     }
     else if ((name_len == 1 && *name == 'X')
 	  || (name_len <= 4
 		  && STRNCMP(name, "Next", name_len > 4 ? 4 : name_len) == 0))
     {
 	emsg(_("E841: Reserved name, cannot be used for user defined command"));
-	return;
+    }
+    else if (compl > 0 && (argt & EX_EXTRA) == 0)
+    {
+	emsg(_("E1208: -complete used without -nargs"));
     }
     else
 	uc_add_command(name, end - name, p, argt, def, flags, compl, compl_arg,


### PR DESCRIPTION
Previously this would kind-of work: if there's nothing on the cmdline it
works, but if you type anything and press Tab you get a literal tab
character.

This can be confusing, especially if you use -complete=custom, since you
might be thinking you somehow implemented this wrong.

Fixes #8541