### PR TITLE
Test_term_getansicolors() failed when termguicolors feature not available

### DIFF
--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -2217,6 +2217,7 @@ enddef
 
 def Test_term_getansicolors()
   CheckRunVimInTerminal
+  CheckFeature termguicolors
   CheckDefAndScriptFailure2(['term_getansicolors(["a"])'], 'E1013: Argument 1: type mismatch, expected string but got list<string>', 'E745: Using a List as a Number')
 enddef
 


### PR DESCRIPTION
This PR fixes test `Test_term_getansicolors()` which failed when
the `terminal` feature is available but the `termguicolors` feature
is not available.

The test fails because it calls `term_getansicolors()`
which is not available when the feature `termguicolors`
is not available

Steps to reproduce:
```
$ ./configure --with-features=normal --enable-gui=none --enable-terminal
$ make -j8
$ make test_vim9_builtin
..snip...
Executed 292 tests                       in   2.500907 seconds
1 FAILED:
Found errors in Test_term_getansicolors():
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_term_getansicolors[2]..CheckDefAndScriptFailure2[1]..CheckDefFailure line 6: ['term_getansicolors(["a"])']: Expected 'E1013: Argument 1: type mismatch, expected string but got list<string>' but got 'E117: Unknown function: term_getansicolors': ['term_getansicolors(["a"])']
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_term_getansicolors[2]..CheckDefAndScriptFailure2[2]..CheckScriptFailure line 6: ['vim9script', 'term_getansicolors(["a"])']: Expected 'E745: Using a List as a Number' but got 'E117: Unknown function: term_getansicolors': ['vim9script', 'term_getansicolors(["a"])']
SKIPPED Test_balloon_show(): only works in the GUI
SKIPPED Test_balloon_split(): balloon_eval_term feature missing
SKIPPED Test_browse(): browse feature missing
SKIPPED Test_debugbreak(): only works on MS-Windows
SKIPPED Test_sound_stop(): sound feature missing
Makefile:63: recipe for target 'test_vim9_builtin' failed
make: *** [test_vim9_builtin] Error 1
```