### PR TITLE
crypt: another small fix for the sodium test on windows

### DIFF
--- a/src/testdir/test_crypt.vim
+++ b/src/testdir/test_crypt.vim
@@ -162,8 +162,8 @@ func Test_uncrypt_xchacha20_2()
   call assert_equal(range(1, 4000)->map( {_, v -> string(v)}), getline(1,'$'))
   set key=
   w! ++ff=unix
-  " enryption removed
-  call assert_match('"Xcrypt_sodium.txt" 4000L, 18893B written', execute(':message'))
+  " enryption removed (on windows, it includes [unix])
+  call assert_match('"Xcrypt_sodium.txt".*4000L, 18893B written', execute(':message'))
   bw!
   call delete('Xcrypt_sodium.txt')
   set cryptmethod&vim


### PR DESCRIPTION
Another minor change to the crypt test to make sure it passes on windows.

The status message on windows includes the [unix] when writing the file.
So account for that in test_crypt and match anything until the line
number appears.