### PR TITLE
Fix no_check_timestamps compile option

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1871,7 +1871,8 @@ enter_buffer(buf_T *buf)
 	    need_fileinfo = TRUE;	// display file info after redraw
 
 	// check if file changed
-	(void)buf_check_timestamp(curbuf, FALSE);
+	if (!no_check_timestamps)
+	    (void)buf_check_timestamp(curbuf, FALSE);
 
 	curwin->w_topline = 1;
 #ifdef FEAT_DIFF


### PR DESCRIPTION
While trying to reduce disk i/o operations (sshfs introduced delay on every i/o) I had to compile VIM with [no_check_timestamps](https://github.com/vim/vim/blob/efc5db5215b4efc424b2de34613525d729a05c93/src/globals.h#L487) option enabled. But still I can't get rid of one final unnecessary disk read operation during buffer change. This is fix for it.

Disk access can be monitored using strace:
strace -p <pid> -e trace=file

You also need to implement this settings:
set noswapfile
set nobackup
set hidden
let loaded_netrwPlugin = 1

netrw plugin introduces autocmd file operations on BufEnter and BufLeave so it has to be disabled for testing.
How to view this autocmds:
autocmd FileExplorer BufEnter
autocmd FileExplorer BufLeave
Another way to disable them:
autocmd! FileExplorer BufEnter *
autocmd! FileExplorer BufLeave *