### PR TITLE
Fixed failing tests without the channel or job features

### DIFF
--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -398,9 +398,11 @@ def Test_ch_close_in()
 enddef
 
 def Test_ch_getjob()
-  CheckDefAndScriptFailure2(['ch_getjob(1)'], 'E1013: Argument 1: type mismatch, expected channel but got number', 'E475: Invalid argument:')
-  CheckDefAndScriptFailure2(['ch_getjob({"a": 10})'], 'E1013: Argument 1: type mismatch, expected channel but got dict<number>', 'E731: Using a Dictionary as a String')
-  assert_equal(0, ch_getjob(test_null_channel()))
+  if has('channel')
+    CheckDefAndScriptFailure2(['ch_getjob(1)'], 'E1013: Argument 1: type mismatch, expected channel but got number', 'E475: Invalid argument:')
+    CheckDefAndScriptFailure2(['ch_getjob({"a": 10})'], 'E1013: Argument 1: type mismatch, expected channel but got dict<number>', 'E731: Using a Dictionary as a String')
+    assert_equal(0, ch_getjob(test_null_channel()))
+  endif
 enddef
 
 def Test_ch_info()
@@ -1425,13 +1427,17 @@ def Test_items()
 enddef
 
 def Test_job_getchannel()
-  CheckDefAndScriptFailure2(['job_getchannel("a")'], 'E1013: Argument 1: type mismatch, expected job but got string', 'E475: Invalid argument')
-  assert_fails('job_getchannel(test_null_job())', 'E916: not a valid job')
+  if has('channel')
+    CheckDefAndScriptFailure2(['job_getchannel("a")'], 'E1013: Argument 1: type mismatch, expected job but got string', 'E475: Invalid argument')
+    assert_fails('job_getchannel(test_null_job())', 'E916: not a valid job')
+  endif
 enddef
 
 def Test_job_info()
-  CheckDefAndScriptFailure2(['job_info("a")'], 'E1013: Argument 1: type mismatch, expected job but got string', 'E475: Invalid argument')
-  assert_fails('job_info(test_null_job())', 'E916: not a valid job')
+  if has('job')
+    CheckDefAndScriptFailure2(['job_info("a")'], 'E1013: Argument 1: type mismatch, expected job but got string', 'E475: Invalid argument')
+    assert_fails('job_info(test_null_job())', 'E916: not a valid job')
+  endif
 enddef
 
 def Test_job_info_return_type()
@@ -1445,8 +1451,10 @@ def Test_job_info_return_type()
 enddef
 
 def Test_job_status()
-  CheckDefAndScriptFailure2(['job_status("a")'], 'E1013: Argument 1: type mismatch, expected job but got string', 'E475: Invalid argument')
-  assert_equal('fail', job_status(test_null_job()))
+  if has('job')
+    CheckDefAndScriptFailure2(['job_status("a")'], 'E1013: Argument 1: type mismatch, expected job but got string', 'E475: Invalid argument')
+    assert_equal('fail', job_status(test_null_job()))
+  endif
 enddef
 
 def Test_js_decode()


### PR DESCRIPTION
This PR fixes a few tests that failed without channel or job features.

To reproduce:
```
$ ./configure --with-features=normal --enable-gui=none --disable-channel
$ make -j8
$ make test
...snip...
Executed:  3964 Tests
 Skipped:   374 Tests
  FAILED:     4 Tests


Failures: 
	From test_vim9_builtin.vim:
	Found errors in Test_ch_getjob():
	Caught exception in Test_ch_getjob(): Vim(call):E117: Unknown function: test_null_channel @ command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_ch_getjob, line 3
	Found errors in Test_job_getchannel():
	command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_job_getchannel[1]..CheckDefAndScriptFailure2[1]..CheckDefFailure line 6: ['job_getchannel("a")']: Expected 'E1013: Argument 1: type mismatch, expected job but got string' but got 'E117: Unknown function: job_getchannel': ['job_getchannel("a")']
	command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_job_getchannel[1]..CheckDefAndScriptFailure2[2]..CheckScriptFailure line 6: ['vim9script', 'job_getchannel("a")']: Expected 'E475: Invalid argument' but got 'E117: Unknown function: job_getchannel': ['vim9script', 'job_getchannel("a")']
	command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_job_getchannel line 2: Expected 'E916: not a valid job' but got 'E117: Unknown function: test_null_job': job_getchannel(test_null_job())
	Found errors in Test_job_info():
	command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_job_info[1]..CheckDefAndScriptFailure2[1]..CheckDefFailure line 6: ['job_info("a")']: Expected 'E1013: Argument 1: type mismatch, expected job but got string' but got 'E117: Unknown function: job_info': ['job_info("a")']
	command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_job_info[1]..CheckDefAndScriptFailure2[2]..CheckScriptFailure line 6: ['vim9script', 'job_info("a")']: Expected 'E475: Invalid argument' but got 'E117: Unknown function: job_info': ['vim9script', 'job_info("a")']
	command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_job_info line 2: Expected 'E916: not a valid job' but got 'E117: Unknown function: test_null_job': job_info(test_null_job())
	Found errors in Test_job_status():
	Caught exception in Test_job_status(): Vim(call):E117: Unknown function: test_null_job @ command line..script /home/pel/sb/vim/src/testdir/runtest.vim[473]..function RunTheTest[44]..Test_job_status, line 2

TEST FAILURE
Makefile:43: recipe for target 'report' failed
make: *** [report] Error 1
```