### PR TITLE
feat: use 'formatlistpat' length for breakindent

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1326,9 +1326,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 			    continuation (positive).
 		sbr	    Display the 'showbreak' value before applying the
 			    additional indent.
-		list:{n}    Adds an additional indent for lines that match a 
+		list:{n}    Adds an additional indent for lines that match a
 			    numbered or bulleted list (using the
 			    'formatlistpat' setting).
+			    With list:-1 length of matched 'formatlistpat' is
+			    used for indentation.
 	The default value for min is 20, shift and list is 0.
 
 						*'browsedir'* *'bsdir'*

--- a/src/indent.c
+++ b/src/indent.c
@@ -941,10 +941,6 @@ get_breakindent_win(
     }
     bri = prev_indent + wp->w_briopt_shift;
 
-    // indent minus the length of the showbreak string
-    if (wp->w_briopt_sbr)
-	bri -= vim_strsize(get_showbreak_value(wp));
-
     // Add offset for number column, if 'n' is in 'cpoptions'
     bri += win_col_off2(wp);
 
@@ -961,10 +957,15 @@ get_breakindent_win(
 		if (wp->w_briopt_list > 0)
 		    bri += wp->w_briopt_list;
 		else
-		    bri += (*regmatch.endp - *regmatch.startp);
+		    bri = (*regmatch.endp - *regmatch.startp);
 	    vim_regfree(regmatch.regprog);
 	}
     }
+
+    // indent minus the length of the showbreak string
+    if (wp->w_briopt_sbr)
+	bri -= vim_strsize(get_showbreak_value(wp));
+
 
     // never indent past left window margin
     if (bri < 0)

--- a/src/indent.c
+++ b/src/indent.c
@@ -949,7 +949,7 @@ get_breakindent_win(
     bri += win_col_off2(wp);
 
     // add additional indent for numbered lists
-    if (wp->w_briopt_list > 0)
+    if (wp->w_briopt_list > 0 || wp->w_briopt_list == -1)
     {
 	regmatch_T	    regmatch;
 
@@ -958,7 +958,10 @@ get_breakindent_win(
 	if (regmatch.regprog != NULL)
 	{
 	    if (vim_regexec(&regmatch, line, 0))
-		bri += wp->w_briopt_list;
+		if (wp->w_briopt_list > 0)
+		    bri += wp->w_briopt_list;
+		else
+		    bri += (*regmatch.endp - *regmatch.startp);
 	    vim_regfree(regmatch.regprog);
 	}
     }

--- a/src/indent.c
+++ b/src/indent.c
@@ -945,7 +945,7 @@ get_breakindent_win(
     bri += win_col_off2(wp);
 
     // add additional indent for numbered lists
-    if (wp->w_briopt_list > 0 || wp->w_briopt_list == -1)
+    if (wp->w_briopt_list != 0)
     {
 	regmatch_T	    regmatch;
 
@@ -954,10 +954,12 @@ get_breakindent_win(
 	if (regmatch.regprog != NULL)
 	{
 	    if (vim_regexec(&regmatch, line, 0))
+	    {
 		if (wp->w_briopt_list > 0)
 		    bri += wp->w_briopt_list;
 		else
 		    bri = (*regmatch.endp - *regmatch.startp);
+	    }
 	    vim_regfree(regmatch.regprog);
 	}
     }

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -813,7 +813,22 @@ func Test_breakindent20_list()
   let lines = s:screen_lines2(1, 6, 20)
   call s:compare_lines(expect, lines)
 
-  call s:close_windows('set breakindent& briopt& linebreak& list& listchars&')
+  " check formatlistpat indent with different list level
+  " showbreak and sbr
+  setl briopt+=sbr
+  setl showbreak=>
+  redraw!
+  let expect = [
+	\ "* Congress shall    ",
+	\ "> make no law       ",
+	\ "*** Congress shall  ",
+	\ ">   make no law     ",
+	\ "**** Congress shall ",
+	\ ">    make no law    ",
+	\ ]
+  let lines = s:screen_lines2(1, 6, 20)
+  call s:compare_lines(expect, lines)
+  call s:close_windows('set breakindent& briopt& linebreak& list& listchars& showbreak&')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -815,7 +815,7 @@ func Test_breakindent20_list()
 
   " check formatlistpat indent with different list level
   " showbreak and sbr
-  setl briopt+=sbr
+  setl briopt+=sbr,shift:2
   setl showbreak=>
   redraw!
   let expect = [

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -761,7 +761,7 @@ func Test_breakindent20_list()
   call s:compare_lines(expect, lines)
   " check formatlistpat indent
   setl briopt+=list:-1
-  let &flp= '^\s*\d\+\.\?[\]:)}\t ]\s*'
+  let &l:flp = '^\s*\d\+\.\?[\]:)}\t ]\s*'
   redraw!
   let expect = [
 	\ "  1.  Congress      ",

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -776,9 +776,34 @@ func Test_breakindent20_list()
 	\ ]
   let lines = s:screen_lines2(1, 9, 20)
   call s:compare_lines(expect, lines)
-  " reset linebreak option
+  " check formatlistpat indent with different list levels
+  let &l:flp = '^\s*\*\+\s\+'
+  redraw!
+  %delete _
+  call setline(1, ['* Congress shall make no law',
+        \ '*** Congress shall make no law',
+        \ '**** Congress shall make no law'])
+  norm! 1gg
+  let expect = [
+	\ "* Congress shall    ",
+	\ "  make no law       ",
+	\ "*** Congress shall  ",
+	\ "    make no law     ",
+	\ "**** Congress       ",
+	\ "     shall make no  ",
+	\ "     law            ",
+	\ ]
+  let lines = s:screen_lines2(1, 7, 20)
+  call s:compare_lines(expect, lines)
+
+  " reset linebreak option and restore default input
   " Note: it indents by one additional
   " space, because of the leading space.
+  %delete _
+  call setline(1, ['  1.  Congress shall make no law',
+        \ '  2.) Congress shall make no law',
+        \ '  3.] Congress shall make no law'])
+  norm! 1gg
   setl linebreak&vim list listchars=eol:$,space:_
   redraw!
   let expect = [

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -759,6 +759,23 @@ func Test_breakindent20_list()
 	\ ]
   let lines = s:screen_lines2(1, 9, 20)
   call s:compare_lines(expect, lines)
+  " check formatlistpat indent
+  setl briopt+=list:-1
+  let &flp= '^\s*\d\+\.\?[\]:)}\t ]\s*'
+  redraw!
+  let expect = [
+	\ "  1.  Congress      ",
+	\ "      shall make no ",
+	\ "      law           ",
+	\ "  2.) Congress      ",
+	\ "      shall make no ",
+	\ "      law           ",
+	\ "  3.] Congress      ",
+	\ "      shall make no ",
+	\ "      law           ",
+	\ ]
+  let lines = s:screen_lines2(1, 9, 20)
+  call s:compare_lines(expect, lines)
   " reset linebreak option
   " Note: it indents by one additional
   " space, because of the leading space.

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -777,7 +777,7 @@ func Test_breakindent20_list()
   call s:compare_lines(expect, lines)
 
   " check formatlistpat indent
-  setl briopt+=list:-1
+  setl briopt=min:5,list:-1
   setl linebreak list&vim listchars&vim
   let &l:flp = '^\s*\d\+\.\?[\]:)}\t ]\s*'
   redraw!
@@ -815,7 +815,7 @@ func Test_breakindent20_list()
 
   " check formatlistpat indent with different list level
   " showbreak and sbr
-  setl briopt+=sbr,shift:2
+  setl briopt=min:5,sbr,list:-1,shift:2
   setl showbreak=>
   redraw!
   let expect = [

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -759,8 +759,26 @@ func Test_breakindent20_list()
 	\ ]
   let lines = s:screen_lines2(1, 9, 20)
   call s:compare_lines(expect, lines)
+
+  " reset linebreak option
+  " Note: it indents by one additional
+  " space, because of the leading space.
+  setl linebreak&vim list listchars=eol:$,space:_
+  redraw!
+  let expect = [
+	\ "__1.__Congress_shall",
+	\ "      _make_no_law$ ",
+	\ "__2.)_Congress_shall",
+	\ "      _make_no_law$ ",
+	\ "__3.]_Congress_shall",
+	\ "      _make_no_law$ ",
+	\ ]
+  let lines = s:screen_lines2(1, 6, 20)
+  call s:compare_lines(expect, lines)
+
   " check formatlistpat indent
   setl briopt+=list:-1
+  setl linebreak list&vim listchars&vim
   let &l:flp = '^\s*\d\+\.\?[\]:)}\t ]\s*'
   redraw!
   let expect = [
@@ -789,30 +807,8 @@ func Test_breakindent20_list()
 	\ "  make no law       ",
 	\ "*** Congress shall  ",
 	\ "    make no law     ",
-	\ "**** Congress       ",
-	\ "     shall make no  ",
-	\ "     law            ",
-	\ ]
-  let lines = s:screen_lines2(1, 7, 20)
-  call s:compare_lines(expect, lines)
-
-  " reset linebreak option and restore default input
-  " Note: it indents by one additional
-  " space, because of the leading space.
-  %delete _
-  call setline(1, ['  1.  Congress shall make no law',
-        \ '  2.) Congress shall make no law',
-        \ '  3.] Congress shall make no law'])
-  norm! 1gg
-  setl linebreak&vim list listchars=eol:$,space:_
-  redraw!
-  let expect = [
-	\ "__1.__Congress_shall",
-	\ "      _make_no_law$ ",
-	\ "__2.)_Congress_shall",
-	\ "      _make_no_law$ ",
-	\ "__3.]_Congress_shall",
-	\ "      _make_no_law$ ",
+	\ "**** Congress shall ",
+	\ "     make no law    ",
 	\ ]
   let lines = s:screen_lines2(1, 6, 20)
   call s:compare_lines(expect, lines)


### PR DESCRIPTION
Provided 'set briopt+=list:-1' use length of the matched 'formatlistpat' as additional indent to align contents of the list item.

@chrisbra pls check it, related to your PR #8564 

PS, not sure how to write a proper test though. 