### PR TITLE
Add compiler scripts for YAML

### DIFF
--- a/runtime/compiler/spectral.vim
+++ b/runtime/compiler/spectral.vim
@@ -1,0 +1,17 @@
+" Vim compiler file
+" Compiler:    Spectral for YAML
+" Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
+" Last Change: 2021 July 21
+
+if exists("current_compiler")
+    finish
+endif
+let current_compiler = "spectral"
+
+if exists(":CompilerSet") != 2
+    command -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet makeprg=spectral\ lint\ %\ -f\ text
+CompilerSet errorformat=%f:%l:%c\ %t%.%\\{-}\ %m
+

--- a/runtime/compiler/yamllint.vim
+++ b/runtime/compiler/yamllint.vim
@@ -1,0 +1,16 @@
+" Vim compiler file
+" Compiler:    Yamllint for YAML
+" Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
+" Last Change: 2021 July 21
+
+if exists("current_compiler")
+    finish
+endif
+let current_compiler = "yamllint"
+
+if exists(":CompilerSet") != 2
+    command -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet makeprg=yamllint\ -f\ parsable
+


### PR DESCRIPTION
[Yamllint](https://github.com/adrienverge/yamllint) and [Spectral](https://stoplight.io/open-source/spectral/) are two YAML linters.

This patch adds compiler scripts for those two tools.