### PR TITLE
Installer improvements

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -126,10 +126,11 @@ RequestExecutionLevel highest
 # This adds '\Vim' to the user choice automagically.  The actual value is
 # obtained below with CheckOldVim.
 !ifdef WIN64
-InstallDir "$PROGRAMFILES64\Vim"
+  !define DEFAULT_INSTDIR "$PROGRAMFILES64\Vim"
 !else
-InstallDir "$PROGRAMFILES\Vim"
+  !define DEFAULT_INSTDIR "$PROGRAMFILES\Vim"
 !endif
+InstallDir ${DEFAULT_INSTDIR}
 
 # Types of installs we can perform:
 InstType $(str_type_typical)
@@ -710,8 +711,13 @@ Function .onInit
   !insertmacro MUI_LANGDLL_DISPLAY
 !endif
 
-  # Check $VIM
-  ReadEnvStr $INSTDIR "VIM"
+  ${If} $INSTDIR == ${DEFAULT_INSTDIR}
+    # Check $VIM
+    ReadEnvStr $3 "VIM"
+    ${If} $3 != ""
+      StrCpy $INSTDIR $3
+    ${EndIf}
+  ${EndIf}
 
   call CheckOldVim
   Pop $3
@@ -721,18 +727,9 @@ Function .onInit
     SectionSetInstTypes ${id_section_old_ver} 0
     SectionSetText ${id_section_old_ver} ""
   ${Else}
-    ${If} $INSTDIR == ""
+    ${If} $INSTDIR == ${DEFAULT_INSTDIR}
       StrCpy $INSTDIR $3
     ${EndIf}
-  ${EndIf}
-
-  # If did not find a path: use the default dir.
-  ${If} $INSTDIR == ""
-!ifdef WIN64
-    StrCpy $INSTDIR "$PROGRAMFILES64\Vim"
-!else
-    StrCpy $INSTDIR "$PROGRAMFILES\Vim"
-!endif
   ${EndIf}
 
   ${If} ${RunningX64}

--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -18,7 +18,8 @@ The 32 bit version also runs on 64 bit MS-Windows systems.
 4. Using the mouse		|win32-mouse|
 5. Running under Windows 95	|win32-win95|
 6. Running under Windows 3.1	|win32-win3.1|
-7. Win32 mini FAQ		|win32-faq|
+7. Installation package		|win32-installer|
+8. Win32 mini FAQ		|win32-faq|
 
 Additionally, there are a number of common Win32 and DOS items:
 File locations			|dos-locations|
@@ -175,7 +176,29 @@ There was a special version of gvim that runs under Windows 3.1 and 3.11.
 Support was removed in patch 7.4.1364.
 
 ==============================================================================
-7. Win32 mini FAQ					*win32-faq*
+7. Installation package					*win32-installer*
+
+A simple installer for windows is available at http://www.vim.org/download.php
+(stable version) and nightly builds are also available at
+https://github.com/vim/vim-win32-installer/releases/
+
+The nightly builds include 32bit and 64bit builds, have most features enabled
+and usually also contain an extra cryptographic signed installer, so Windows
+will not complain.
+
+To use the installer, simply run the exe file.  The following switches are
+also supported: >
+
+    gvim_<version>.exe /S           -> silent install without any dialogues
+    gvim_<version>.exe /D=C:\vim    -> Install into directory c:\vim
+                                    -> /D must be the last argument
+    gvim_<version>.exe /S /D=c:\vim -> silent install into c:\vim
+<
+The default installation directory can alternatively be given by setting the
+$VIM environment variable.
+
+==============================================================================
+8. Win32 mini FAQ					*win32-faq*
 
 Q. How do I change the font?
 A. In the GUI version, you can use the 'guifont' option.  Example: >


### PR DESCRIPTION
This is another approach to fix https://github.com/vim/vim-win32-installer/issues/219. 

This time, setting $VIM prior to running the installer is honored. However, when using the `/D=c:\vim` command line argument, that one has a higher priority. 

While at it, I also added a small section at the help that explains where to get an installer and how to use those switches.

CC @k-takata 