### PR TITLE
Read and write eml files with DOS line endings

### DIFF
--- a/runtime/ftplugin/mail.vim
+++ b/runtime/ftplugin/mail.vim
@@ -26,6 +26,11 @@ setlocal fo+=tcql
 " Add n:> to 'comments, in case it was removed elsewhere
 setlocal comments+=n:>
 
+" .eml files are universally formatted with DOS line-endings, per RFC5322.
+if expand('%:e') is# 'eml'
+    setlocal fileformat=dos
+endif
+
 " Add mappings, unless the user doesn't want this.
 if !exists("no_plugin_maps") && !exists("no_mail_maps")
   " Quote text by inserting "> "


### PR DESCRIPTION
These are "raw" dumps of emails, and pretty much everyone uses and
expects DOS line endings, as specified in RFC5322.