### PR TITLE
find: improvements for non searching non-existing directories

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1685,6 +1685,9 @@ The file searching is currently used for the 'path', 'cdpath' and 'tags'
 options, for |finddir()| and |findfile()|.  Other commands use |wildcards|
 which is slightly different.
 
+Note: If your 'path' setting includes an non-existing directory, Vim will skip the
+non-existing directory, but continue searching in the parent of the non-existing directory.
+
 There are three different types of searching:
 
 1) Downward search:					*starstar*

--- a/src/findfile.c
+++ b/src/findfile.c
@@ -578,7 +578,17 @@ vim_findfile_init(
 
 	    if (p > search_ctx->ffsc_fix_path)
 	    {
+		char parent[4];
 		len = (int)(p - search_ctx->ffsc_fix_path) - 1;
+
+		vim_snprintf(parent, (size_t)4, "..%s", PATHSEPSTR);
+		// do not add '..' to the path and start upwards searching
+		if ((len == 2 && STRNCMP(search_ctx->ffsc_fix_path, "..", 2) == 0) ||
+		    (len > 2 && STRNCMP(search_ctx->ffsc_fix_path, parent, 3) == 0))
+		{
+		    vim_free(buf);
+		    goto error_return;
+		}
 		STRNCAT(ff_expand_buffer, search_ctx->ffsc_fix_path, len);
 		add_pathsep(ff_expand_buffer);
 	    }

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -228,4 +228,26 @@ func Test_find_cmd()
   call assert_fails('tabfind', 'E471:')
 endfunc
 
+func Test_find_non_existing_path()
+  new
+  let save_path = &path
+  let save_dir = getcwd()
+  call mkdir('dir1/dir2', 'p')
+  call writefile([], 'dir1/file.txt')
+  call writefile([], 'dir1/dir2/base.txt')
+  call chdir('dir1/dir2')
+  e base.txt
+  set path=../include
+
+  call assert_fails(':find file.txt', 'E345:')
+
+  call chdir(save_dir)
+  bw!
+  call delete('dir1/dir2/base.txt', 'rf')
+  call delete('dir1/dir2', 'rf')
+  call delete('dir1/file.txt', 'rf')
+  call delete('dir1', 'rf')
+  let &path = save_path
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Not sure if the change in behaviour for `:find` is actually wanted. But we may want to at least document the existing behaviour. So feel free to pick what is actually needed.

this is to fix: #8533