### PR TITLE
Add dlerror()/GetWin32Error() info if a dynamic library fails to load

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1632,7 +1632,7 @@ EXTERN char e_fsync[]		INIT(= N_("E667: Fsync failed"));
 	|| defined(DYNAMIC_MZSCHEME) \
 	|| defined(DYNAMIC_LUA) \
 	|| defined(FEAT_TERMINAL)
-EXTERN char e_loadlib[]	INIT(= N_("E370: Could not load library %s"));
+EXTERN char e_loadlib[]	INIT(= N_("E370: Could not load library %s: %s"));
 EXTERN char e_loadfunc[]	INIT(= N_("E448: Could not load library function %s"));
 #endif
 EXTERN char e_nobang[]	INIT(= N_("E477: No ! allowed"));

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1329,24 +1329,6 @@ clear_csinfo(int i)
 #endif
 }
 
-#ifndef UNIX
-    static char *
-GetWin32Error(void)
-{
-    char *msg = NULL;
-    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER|FORMAT_MESSAGE_FROM_SYSTEM,
-	    NULL, GetLastError(), 0, (LPSTR)&msg, 0, NULL);
-    if (msg != NULL)
-    {
-	// remove trailing \r\n
-	char *pcrlf = strstr(msg, "\r\n");
-	if (pcrlf != NULL)
-	    *pcrlf = '\0';
-    }
-    return msg;
-}
-#endif
-
 /*
  * Insert a new cscope database filename into the filelist.
  */

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -105,10 +105,12 @@ static void luaV_call_lua_func_free(void *state);
 # define load_dll(n) dlopen((n), RTLD_LAZY|RTLD_GLOBAL)
 # define symbol_from_dll dlsym
 # define close_dll dlclose
+# define load_dll_error dlerror
 #else
 # define load_dll vimLoadLib
 # define symbol_from_dll GetProcAddress
 # define close_dll FreeLibrary
+# define load_dll_error GetWin32Error
 #endif
 
 // lauxlib
@@ -446,7 +448,7 @@ lua_link_init(char *libname, int verbose)
     if (!hinstLua)
     {
 	if (verbose)
-	    semsg(_(e_loadlib), libname);
+	    semsg(_(e_loadlib), libname, load_dll_error());
 	return FAIL;
     }
     for (reg = luaV_dll; reg->func; reg++)

--- a/src/if_mzsch.c
+++ b/src/if_mzsch.c
@@ -668,14 +668,14 @@ mzscheme_runtime_link_init(char *sch_dll, char *gc_dll, int verbose)
     if (!hMzGC)
     {
 	if (verbose)
-	    semsg(_(e_loadlib), gc_dll);
+	    semsg(_(e_loadlib), gc_dll, GetWin32Error());
 	return FAIL;
     }
 
     if (!hMzSch)
     {
 	if (verbose)
-	    semsg(_(e_loadlib), sch_dll);
+	    semsg(_(e_loadlib), sch_dll, GetWin32Error());
 	return FAIL;
     }
 

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -175,11 +175,13 @@ typedef int perl_key;
 #  define load_dll(n) dlopen((n), RTLD_LAZY|RTLD_GLOBAL)
 #  define symbol_from_dll dlsym
 #  define close_dll dlclose
+#  define load_dll_error dlerror
 # else
 #  define PERL_PROC FARPROC
 #  define load_dll vimLoadLib
 #  define symbol_from_dll GetProcAddress
 #  define close_dll FreeLibrary
+#  define load_dll_error GetWin32Error
 # endif
 /*
  * Wrapper defines

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -141,10 +141,12 @@ struct PyMethodDef { Py_ssize_t a; };
 #  endif
 #  define close_dll dlclose
 #  define symbol_from_dll dlsym
+#  define load_dll_error dlerror
 # else
 #  define load_dll vimLoadLib
 #  define close_dll FreeLibrary
 #  define symbol_from_dll GetProcAddress
+#  define load_dll_error GetWin32Error
 # endif
 
 // This makes if_python.c compile without warnings against Python 2.5
@@ -688,7 +690,7 @@ python_runtime_link_init(char *libname, int verbose)
     if (!hinstPython)
     {
 	if (verbose)
-	    semsg(_(e_loadlib), libname);
+	    semsg(_(e_loadlib), libname, load_dll_error());
 	return FAIL;
     }
 

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -125,10 +125,12 @@ typedef PySliceObject PySliceObject_T;
 #  endif
 #  define close_dll dlclose
 #  define symbol_from_dll dlsym
+#  define load_dll_error dlerror
 # else
 #  define load_dll vimLoadLib
 #  define close_dll FreeLibrary
 #  define symbol_from_dll GetProcAddress
+#  define load_dll_error GetWin32Error
 # endif
 /*
  * Wrapper defines
@@ -795,7 +797,7 @@ py3_runtime_link_init(char *libname, int verbose)
     if (!hinstPy3)
     {
 	if (verbose)
-	    semsg(_(e_loadlib), libname);
+	    semsg(_(e_loadlib), libname, load_dll_error());
 	return FAIL;
     }
 

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -184,11 +184,13 @@
 #  define load_dll(n) dlopen((n), RTLD_LAZY|RTLD_GLOBAL)
 #  define symbol_from_dll dlsym
 #  define close_dll dlclose
+#  define load_dll_error dlerror
 # else
 #  define RUBY_PROC FARPROC
 #  define load_dll vimLoadLib
 #  define symbol_from_dll GetProcAddress
 #  define close_dll FreeLibrary
+#  define load_dll_error GetWin32Error
 # endif
 #endif
 
@@ -806,7 +808,7 @@ ruby_runtime_link_init(char *libname, int verbose)
     if (!hinstRuby)
     {
 	if (verbose)
-	    semsg(_(e_loadlib), libname);
+	    semsg(_(e_loadlib), libname, load_dll_error());
 	return FAIL;
     }
 

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -167,11 +167,13 @@ typedef int HANDLE;
 #  define load_dll(n) dlopen((n), RTLD_LAZY|RTLD_GLOBAL)
 #  define symbol_from_dll dlsym
 #  define close_dll dlclose
+#  define load_dll_error dlerror
 # else
 #  define TCL_PROC FARPROC
 #  define load_dll vimLoadLib
 #  define symbol_from_dll GetProcAddress
 #  define close_dll FreeLibrary
+#  define load_dll_error GetWin32Error
 # endif
 
 /*
@@ -213,7 +215,7 @@ tcl_runtime_link_init(char *libname, int verbose)
     if (!(hTclLib = load_dll(libname)))
     {
 	if (verbose)
-	    semsg(_(e_loadlib), libname);
+	    semsg(_(e_loadlib), libname, load_dll_error());
 	return FAIL;
     }
     for (i = 0; tcl_funcname_table[i].ptr; ++i)

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4902,7 +4902,8 @@ iconv_enabled(int verbose)
 	{
 	    verbose_enter();
 	    semsg(_(e_loadlib),
-		    hIconvDLL == 0 ? DYNAMIC_ICONV_DLL : DYNAMIC_MSVCRT_DLL);
+		    hIconvDLL == 0 ? DYNAMIC_ICONV_DLL : DYNAMIC_MSVCRT_DLL,
+		    GetWin32Error());
 	    verbose_leave();
 	}
 	iconv_end();

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -716,7 +716,7 @@ dyn_libintl_init(void)
 	if (p_verbose > 0)
 	{
 	    verbose_enter();
-	    semsg(_(e_loadlib), GETTEXT_DLL);
+	    semsg(_(e_loadlib), GETTEXT_DLL, GetWin32Error());
 	    verbose_leave();
 	}
 	return 0;
@@ -8353,3 +8353,19 @@ resize_console_buf(void)
     }
 }
 #endif
+
+    char *
+GetWin32Error(void)
+{
+    char *msg = NULL;
+    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER|FORMAT_MESSAGE_FROM_SYSTEM,
+	    NULL, GetLastError(), 0, (LPSTR)&msg, 0, NULL);
+    if (msg != NULL)
+    {
+	// remove trailing \r\n
+	char *pcrlf = strstr(msg, "\r\n");
+	if (pcrlf != NULL)
+	    *pcrlf = '\0';
+    }
+    return msg;
+}

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -83,4 +83,5 @@ int get_conpty_type(void);
 int is_conpty_stable(void);
 int get_conpty_fix_type(void);
 void resize_console_buf(void);
+char * GetWin32Error(void);
 /* vim: set ft=c : */

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -6862,8 +6862,9 @@ dyn_winpty_init(int verbose)
     if (!hWinPtyDLL)
     {
 	if (verbose)
-	    semsg(_(e_loadlib), *p_winptydll != NUL ? p_winptydll
-						       : (char_u *)WINPTY_DLL);
+	    semsg(_(e_loadlib),
+		    (*p_winptydll != NUL ? p_winptydll : (char_u *)WINPTY_DLL),
+		    GetWin32Error());
 	return FAIL;
     }
     for (i = 0; winpty_entry[i].name != NULL


### PR DESCRIPTION
This may clarify a bit what exactly failed.

Before:

	E370: Could not load library libpython3.9.so.1.0

Now:

	E370: Could not load library libpython3.9.so.1.0: Dynamic loading not supported

I moved the GetWin32Error() function as if_cscope.c seemed like a bit of
an odd location for it.

*Note*: I don't have a Windows machine so this wasn't tested on Windows:
I just mucked about until the CI build passed.