### PR TITLE
bufname() doesn't follow the description

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3446,8 +3446,7 @@ bufloaded({expr})					*bufloaded()*
 			let loaded = 'somename'->bufloaded()
 
 bufname([{expr}])					*bufname()*
-		The result is the name of a buffer, as it is displayed by the
-		":ls" command.
+		The result is the name of a buffer.
 		If {expr} is omitted the current buffer is used.
 		If {expr} is a Number, that buffer number's name is given.
 		Number zero is the alternate buffer for the current window.
@@ -3481,9 +3480,8 @@ bufname([{expr}])					*bufname()*
 
 							*bufnr()*
 bufnr([{expr} [, {create}]])
-		The result is the number of a buffer, as it is displayed by
-		the ":ls" command.  For the use of {expr}, see |bufname()|
-		above.
+		The result is the number of a buffer.
+		For the use of {expr}, see |bufname()| above.
 
 		If the buffer doesn't exist, -1 is returned.  Or, if the
 		{create} argument is present and TRUE, a new, unlisted,

--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -365,21 +365,16 @@ f_bufname(typval_T *argvars, typval_T *rettv)
 {
     buf_T	*buf;
     typval_T	*tv = &argvars[0];
-    char_u	*name;
 
     if (tv->v_type == VAR_UNKNOWN)
 	buf = curbuf;
     else
 	buf = tv_get_buf_from_arg(tv);
     rettv->v_type = VAR_STRING;
-    if (buf == NULL)
+    if (buf != NULL && buf->b_fname != NULL)
+	rettv->vval.v_string = vim_strsave(buf->b_fname);
+    else
 	rettv->vval.v_string = NULL;
-    else {
-	name = buf_spname(buf);
-	if (name == NULL)
-	    name = buf->b_fname;
-	rettv->vval.v_string = vim_strsave(name);
-    }
 }
 
 /*

--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -365,16 +365,21 @@ f_bufname(typval_T *argvars, typval_T *rettv)
 {
     buf_T	*buf;
     typval_T	*tv = &argvars[0];
+    char_u	*name;
 
     if (tv->v_type == VAR_UNKNOWN)
 	buf = curbuf;
     else
 	buf = tv_get_buf_from_arg(tv);
     rettv->v_type = VAR_STRING;
-    if (buf != NULL && buf->b_fname != NULL)
-	rettv->vval.v_string = vim_strsave(buf->b_fname);
-    else
+    if (buf == NULL)
 	rettv->vval.v_string = NULL;
+    else {
+	name = buf_spname(buf);
+	if (name == NULL)
+	    name = buf->b_fname;
+	rettv->vval.v_string = vim_strsave(name);
+    }
 }
 
 /*


### PR DESCRIPTION
Problem: bufname() does not return the name displayed by the ":ls" command, in contrary to the documentation.

Some tests are failing because of this change. While they can be fixed easily, it seems likely that some plugins might be relying on this "wrong" behavior. What do you think?
