### PR TITLE
crypt: reset undofile option when writing files without encrypting undofile

### DIFF
--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1982,8 +1982,6 @@ restore_backup:
 	write_info.bw_start_lnum = start;
 
 #ifdef FEAT_PERSISTENT_UNDO
-	// TODO: if the selected crypt method prevents the undo file from being
-	// written, and existing undo file should be deleted.
 	write_undo_file = (buf->b_p_udf
 			    && overwriting
 			    && !append
@@ -1991,11 +1989,22 @@ restore_backup:
 # ifdef CRYPT_NOT_INPLACE
 			    // writing undo file requires
 			    // crypt_encode_inplace()
-			    && (curbuf->b_cryptstate == NULL
-				|| crypt_works_inplace(curbuf->b_cryptstate))
+			    && (buf->b_cryptstate == NULL
+				|| crypt_works_inplace(buf->b_cryptstate))
 # endif
 			    && reset_changed
 			    && !checking_conversion);
+# ifdef CRYPT_NOT_INPLACE
+	// remove undofile, if undo-file encryption is not possible
+	if (buf->b_p_udf
+		&& overwriting
+		&& !append
+		&& !filtering
+		&& !checking_conversion
+		&& buf->b_cryptstate != NULL
+		&& !crypt_works_inplace(buf->b_cryptstate))
+	    u_undofile_reset_and_delete(buf);
+# endif
 	if (write_undo_file)
 	    // Prepare for computing the hash value of the text.
 	    sha256_start(&sha_ctx);

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -616,11 +616,8 @@ crypt_check_swapfile_curbuf(void)
 	// swap and undo files, so disable them
 	mf_close_file(curbuf, TRUE);	// remove the swap file
 	set_option_value((char_u *)"swf", 0, NULL, OPT_LOCAL);
-#ifdef FEAT_PERSISTENT_UNDO
-	set_option_value((char_u *)"udf", 0, NULL, OPT_LOCAL);
-#endif
 	msg_scroll = TRUE;
-	msg(_("Note: Encryption of swapfile not supported, disabling swap- and undofile"));
+	msg(_("Note: Encryption of swapfile not supported, disabling swap file"));
     }
 }
 #endif

--- a/src/proto/undo.pro
+++ b/src/proto/undo.pro
@@ -28,4 +28,5 @@ int bufIsChangedNotTerm(buf_T *buf);
 int curbufIsChanged(void);
 void f_undofile(typval_T *argvars, typval_T *rettv);
 void f_undotree(typval_T *argvars, typval_T *rettv);
+void u_undofile_reset_and_delete(buf_T *buf);
 /* vim: set ft=c : */

--- a/src/testdir/test_crypt.vim
+++ b/src/testdir/test_crypt.vim
@@ -133,7 +133,7 @@ func Test_uncrypt_xchacha20_invalid()
   catch
     call assert_exception('pre-mature')
   endtry
-  call assert_match("Note: Encryption of swapfile not supported, disabling swap- and undofile", execute(':5messages'))
+  call assert_match("Note: Encryption of swapfile not supported, disabling swap file", execute(':5messages'))
 
   call assert_equal(0, &swapfile)
   call assert_equal("xchacha20", &cryptmethod)
@@ -152,7 +152,7 @@ func Test_uncrypt_xchacha20_2()
   call feedkeys(":X\<CR>sodium\<CR>sodium\<CR>", 'xt')
   " swapfile disabled
   call assert_equal(0, &swapfile)
-  call assert_match("Note: Encryption of swapfile not supported, disabling swap- and undofile", execute(':messages'))
+  call assert_match("Note: Encryption of swapfile not supported, disabling swap file", execute(':messages'))
   w!
   " encrypted using xchacha20
   call assert_match("\[xchacha20\]", execute(':messages'))
@@ -176,7 +176,7 @@ func Test_uncrypt_xchacha20_3_persistent_undo()
   sp Xcrypt_sodium_undo.txt
   set cryptmethod=xchacha20 undofile
   call feedkeys(":X\<CR>sodium\<CR>sodium\<CR>", 'xt')
-  call assert_equal(0, &undofile)
+  call assert_equal(1, &undofile)
   let ufile=undofile(@%)
   call append(0, ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'])
   call cursor(1, 1)
@@ -189,6 +189,7 @@ func Test_uncrypt_xchacha20_3_persistent_undo()
   normal dd
   set undolevels=100
   w!
+  call assert_equal(0, &undofile)
   bw!
   call feedkeys(":sp Xcrypt_sodium_undo.txt\<CR>sodium\<CR>", 'xt')
   " should fail

--- a/src/undo.c
+++ b/src/undo.c
@@ -3669,6 +3669,29 @@ f_undofile(typval_T *argvars UNUSED, typval_T *rettv)
     rettv->vval.v_string = NULL;
 #endif
 }
+#ifdef FEAT_PERSISTENT_UNDO
+/*
+ * Reset undofile option and delete the undofile
+ */
+    void
+u_undofile_reset_and_delete(buf_T *buf)
+{
+    char_u *file_name;
+
+    if (!buf->b_p_udf)
+	return;
+   
+    file_name = u_get_undo_file_name(buf->b_ffname, TRUE);
+
+    if (file_name != NULL)
+    {
+	mch_remove(file_name);
+	vim_free(file_name);
+    }
+
+    set_option_value((char_u *)"undofile", 0L, NULL, OPT_LOCAL);
+}
+ #endif
 
 /*
  * "undotree()" function


### PR DESCRIPTION
This is left over from the new sodium feature (see
https://github.com/vim/vim/issues/8467#issuecomment-872971450)

So let's reset the undofile option when actually writing the buffer and
delete an existing undo file in case it exists. This is so, that no
information is leaked from the undo file.

While looking at it, slightly adjust the logic from commit
65aee0b714e809b9f19862f3decd35055ed4de10 (v8.2.3063) and use the buf
pointer instead of the curbuf).

This fixes #8467