### PR TITLE
Add "vs", "Vs" and "CTRL-Vs" to mode() result

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7978,6 +7978,10 @@ mode([expr])	Return a string that indicates the current mode.
 		   s	    Select by character
 		   S	    Select by line
 		   CTRL-S   Select blockwise
+		   vs	    Visual by character using |v_CTRL-O| from
+				Select mode
+		   Vs	    Visual by line using |v_CTRL-O| from Select mode
+		   CTRL-Vs  Visual blockwise using |v_CTRL-O| from Select mode
 		   i	    Insert
 		   ic	    Insert mode completion |compl-generic|
 		   ix	    Insert mode |i_CTRL-X| completion

--- a/src/globals.h
+++ b/src/globals.h
@@ -882,6 +882,8 @@ EXTERN int	VIsual_active INIT(= FALSE);
 				// whether Visual mode is active
 EXTERN int	VIsual_select INIT(= FALSE);
 				// whether Select mode is active
+EXTERN int	restart_VIsual_select INIT(= 0);
+				// restart Select mode when next cmd finished
 EXTERN int	VIsual_reselect;
 				// whether to restart the selection after a
 				// Select mode mapping or menu

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -652,7 +652,11 @@ f_mode(typval_T *argvars, typval_T *rettv)
 	if (VIsual_select)
 	    buf[0] = VIsual_mode + 's' - 'v';
 	else
+	{
 	    buf[0] = VIsual_mode;
+	    if (restart_VIsual_select)
+	        buf[1] = 's';
+	}
     }
     else if (State == HITRETURN || State == ASKMORE || State == SETWSIZE
 		|| State == CONFIRM)

--- a/src/normal.c
+++ b/src/normal.c
@@ -15,7 +15,6 @@
 #include "vim.h"
 
 static int	VIsual_mode_orig = NUL;		// saved Visual mode
-static int	restart_VIsual_select = 0;
 
 #ifdef FEAT_EVAL
 static void	set_vcount_ca(cmdarg_T *cap, int *set_prevcount);

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -746,6 +746,7 @@ func Test_mode()
   set complete=.
 
   inoremap <F2> <C-R>=Save_mode()<CR>
+  xnoremap <F2> <Cmd>call Save_mode()<CR>
 
   normal! 3G
   exe "normal i\<F2>\<Esc>"
@@ -857,6 +858,14 @@ func Test_mode()
   call assert_equal("\<C-S>", mode(1))
   call feedkeys("\<Esc>", 'xt')
 
+  " v_CTRL-O
+  exe "normal gh\<C-O>\<F2>\<Esc>"
+  call assert_equal("v-vs", g:current_modes)
+  exe "normal gH\<C-O>\<F2>\<Esc>"
+  call assert_equal("V-Vs", g:current_modes)
+  exe "normal g\<C-H>\<C-O>\<F2>\<Esc>"
+  call assert_equal("\<C-V>-\<C-V>s", g:current_modes)
+
   call feedkeys(":echo \<C-R>=Save_mode()\<C-U>\<CR>", 'xt')
   call assert_equal('c-c', g:current_modes)
   call feedkeys("gQecho \<C-R>=Save_mode()\<CR>\<CR>vi\<CR>", 'xt')
@@ -867,6 +876,7 @@ func Test_mode()
 
   bwipe!
   iunmap <F2>
+  xunmap <F2>
   set complete&
 endfunc
 


### PR DESCRIPTION
`mode()` returns `viS` for Visual using v_CTRL-O in Select mode.