### PR TITLE
Use a grow array for Lua print

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -1723,8 +1723,9 @@ luaV_print(lua_State *L)
     int i, n = lua_gettop(L); // nargs
     const char *s;
     size_t l;
-    luaL_Buffer b;
-    luaL_buffinit(L, &b);
+    garray_T	msg_ga;
+
+    ga_init2(&msg_ga, 1, 128);
     lua_getglobal(L, "tostring");
     for (i = 1; i <= n; i++)
     {
@@ -1735,13 +1736,18 @@ luaV_print(lua_State *L)
 	if (s == NULL)
 	    return luaL_error(L, "cannot convert to string");
 	if (i > 1)
-	    luaL_addchar(&b, ' '); // use space instead of tab
-	luaV_addlstring(&b, s, l, 0);
+	    ga_append(&msg_ga, ' '); // use space instead of tab
+	ga_concat_len(&msg_ga, (char_u *)s, l);
 	lua_pop(L, 1);
     }
-    luaL_pushresult(&b);
+    // Replace any "\n" with "\0"
+    for (i = 0; i < msg_ga.ga_len; i++)
+	if (((char *)msg_ga.ga_data)[i] == '\n')
+	    ((char *)msg_ga.ga_data)[i] = '\0';
+    lua_pushlstring(L, msg_ga.ga_data, msg_ga.ga_len);
     if (!got_int)
 	luaV_msg(L);
+    ga_clear(&msg_ga);
     return 0;
 }
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1566,6 +1566,22 @@ ga_concat(garray_T *gap, char_u *s)
 }
 
 /*
+ * Concatenate 'len' bytes from string 's' to a growarray.
+ * When "s" is NULL does not do anything.
+ */
+    void
+ga_concat_len(garray_T *gap, char_u *s, size_t len)
+{
+    if (s == NULL || *s == NUL)
+	return;
+    if (ga_grow(gap, len) == OK)
+    {
+	mch_memmove((char *)gap->ga_data + gap->ga_len, s, (size_t)len);
+	gap->ga_len += len;
+    }
+}
+
+/*
  * Append one byte to a growarray which contains bytes.
  */
     void

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -45,6 +45,7 @@ int ga_grow_inner(garray_T *gap, int n);
 char_u *ga_concat_strings(garray_T *gap, char *sep);
 int ga_add_string(garray_T *gap, char_u *p);
 void ga_concat(garray_T *gap, char_u *s);
+void ga_concat_len(garray_T *gap, char_u *s, size_t len);
 void ga_append(garray_T *gap, int c);
 void append_ga_line(garray_T *gap);
 int simplify_key(int key, int *modifiers);


### PR DESCRIPTION
Fix for the issue reported in #8648.

The size of the internal buffer used by luaL_Buffer (init.b) is 1024 bytes (LUAL_BUFFERSIZE).
So instead of using the luaL_Buffer for storing the string, use a Vim grow array and then
use lua_pushlstring() to store the string in the stack.
