### PR TITLE
sodium: use memory locking for the keys

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2306,6 +2306,10 @@ free_buf_options(
     clear_string_option(&buf->b_p_fex);
 #endif
 #ifdef FEAT_CRYPT
+#ifdef FEAT_SODIUM
+    if (buf->b_p_key != NULL && (crypt_get_method_nr(buf) == CRYPT_M_SOD))
+	sodium_munlock(buf->b_p_key, STRLEN(buf->b_p_key));
+#endif
     clear_string_option(&buf->b_p_key);
 #endif
     clear_string_option(&buf->b_p_kp);

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -12,10 +12,6 @@
  */
 #include "vim.h"
 
-#ifdef FEAT_SODIUM
-# include <sodium.h>
-#endif
-
 #if defined(FEAT_CRYPT) || defined(PROTO)
 /*
  * Optional encryption support.

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -447,6 +447,7 @@ crypt_free_state(cryptstate_T *state)
 #ifdef FEAT_SODIUM
     if (state->method_nr == CRYPT_M_SOD)
     {
+	sodium_munlock(((sodium_state_T *)state->method_state)->key, crypto_box_SEEDBYTES);
 	sodium_memzero(state->method_state, sizeof(sodium_state_T));
 	sodium_free(state->method_state);
     }
@@ -726,6 +727,7 @@ crypt_sodium_init(
     // crypto_box_SEEDBYTES ==  crypto_secretstream_xchacha20poly1305_KEYBYTES
     unsigned char	dkey[crypto_box_SEEDBYTES]; // 32
     sodium_state_T	*sd_state;
+    int			retval = 0; 
 
     if (sodium_init() < 0)
 	return FAIL;
@@ -743,6 +745,16 @@ crypt_sodium_init(
 	return FAIL;
     }
     memcpy(sd_state->key, dkey, crypto_box_SEEDBYTES);
+
+    retval += sodium_mlock(sd_state->key, crypto_box_SEEDBYTES);
+    retval += sodium_mlock(key, STRLEN(key));
+
+    if (retval < 0)
+    {
+	emsg(e_libsodium_error_mlock);
+	sodium_free(sd_state);
+	return FAIL;
+    }
     sd_state->count = 0;
     state->method_state = sd_state;
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -641,3 +641,5 @@ EXTERN char e_list_or_dict_or_blob_required_for_argument_nr[]
 	INIT(= N_("E1228: List or Dictionary or Blob required for argument %d"));
 EXTERN char e_expected_dictionary_for_using_key_str_but_got_str[]
 	INIT(= N_("E1229: Expected dictionary for using key \"%s\", but got %s"));
+EXTERN char e_libsodium_error_mlock[]
+	INIT(= N_("E1217: encryption: sodium_mlock() failed"));

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -13,10 +13,6 @@
 
 #include "vim.h"
 
-#ifdef FEAT_SODIUM
-# include <sodium.h>
-#endif
-
 #if defined(__TANDEM)
 # include <limits.h>		// for SSIZE_MAX
 #endif

--- a/src/memline.c
+++ b/src/memline.c
@@ -48,11 +48,6 @@
 # include <time.h>
 #endif
 
-// for randombytes_buf
-#ifdef FEAT_SODIUM
-# include <sodium.h>
-#endif
-
 #if defined(SASC) || defined(__amigaos4__)
 # include <proto/dos.h>	    // for Open() and Close()
 #endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -486,6 +486,10 @@ typedef unsigned int u8char_T;	// int is 32 bits or more
 # endif
 #endif
 
+#ifdef HAVE_SODIUM
+# include <sodium.h>
+#endif
+
 // ================ end of the header file puzzle ===============
 
 /*


### PR DESCRIPTION
when enabling the sodium feature, use `sodium_mlock()` to lock the keys. 

while at it, put the sodium.h header file into vim.h and remove all the other includes.