### PR TITLE
Have ci[ look for next [ like ci" does for next "

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -2145,6 +2145,8 @@ findmatchlimit(
     else if (initc != '#' && initc != NUL)
     {
 	find_mps_values(&initc, &findc, &backwards, TRUE);
+	if (dir)
+	    backwards = (dir == FORWARD) ? FALSE : TRUE;
 	if (findc == NUL)
 	    return NULL;
     }

--- a/src/testdir/test_textobjects.vim
+++ b/src/testdir/test_textobjects.vim
@@ -564,4 +564,36 @@ func Test_textobj_quote()
   close!
 endfunc
 
+" Test for i(, i<, etc. when cursor is in front of a block
+func Test_textobj_find_paren_forward()
+  new
+
+  " i< and a> when cursor is in front of a block
+  call setline(1, '#include <foo.h>')
+  normal 0yi<
+  call assert_equal('foo.h', @")
+  normal 0ya>
+  call assert_equal('<foo.h>', @")
+
+  " 2i(, 3i( in front of a block enters second/third nested '('
+  call setline(1, 'foo (bar (baz (quux)))')
+  normal 0yi)
+  call assert_equal('bar (baz (quux))', @")
+  normal 02yi)
+  call assert_equal('baz (quux)', @")
+  normal 03yi)
+  call assert_equal('quux', @")
+
+  " 3i( in front of a block doesn't enter third but un-nested '('
+  call setline(1, 'foo (bar (baz) (quux))')
+  normal 03di)
+  call assert_equal('foo (bar (baz) (quux))', getline(1))
+  normal 02di)
+  call assert_equal('foo (bar () (quux))', getline(1))
+  normal 0di)
+  call assert_equal('foo ()', getline(1))
+
+  close!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/textobject.c
+++ b/src/textobject.c
@@ -1079,13 +1079,25 @@ current_block(
      */
     save_cpo = p_cpo;
     p_cpo = (char_u *)(vim_strchr(p_cpo, CPO_MATCHBSL) != NULL ? "%M" : "%");
-    while (count-- > 0)
+    if ((pos = findmatch(NULL, what)) != NULL)
     {
-	if ((pos = findmatch(NULL, what)) == NULL)
+	while (count-- > 0)
+	{
+	    if ((pos = findmatch(NULL, what)) == NULL)
+		break;
+	    curwin->w_cursor = *pos;
+	    start_pos = *pos;   // the findmatch for end_pos will overwrite *pos
+	}
+    }
+    else
+    {
+	while (count-- > 0)
+	{
 	    if ((pos = findmatchlimit(NULL, what, FM_FORWARD, 0)) == NULL)
 		break;
-	curwin->w_cursor = *pos;
-	start_pos = *pos;   // the findmatch for end_pos will overwrite *pos
+	    curwin->w_cursor = *pos;
+	    start_pos = *pos;   // the findmatch for end_pos will overwrite *pos
+	}
     }
     p_cpo = save_cpo;
 

--- a/src/textobject.c
+++ b/src/textobject.c
@@ -1082,7 +1082,8 @@ current_block(
     while (count-- > 0)
     {
 	if ((pos = findmatch(NULL, what)) == NULL)
-	    break;
+	    if ((pos = findmatchlimit(NULL, what, FM_FORWARD, 0)) == NULL)
+		break;
 	curwin->w_cursor = *pos;
 	start_pos = *pos;   // the findmatch for end_pos will overwrite *pos
     }


### PR DESCRIPTION
In runtime/doc/todo.txt is a known issue:

> "ci[" does not look for next [ like ci" does look for next ".
> (J.F. 2017 Jan 7)

For instance, if you are at the beginning of a line that reads `#include "foo.h"` then `ci"` will change the contents of the string, but if it reads `#include <foo.h>` then `ci<` will fail to find and change the contents of the angle brackets.

This patch has `ci[` search forward for a bracket like `ci"` does.

There are two commits. The first is sufficient for a plain `i[` or `1i[`, but behaves a little strangely with numbers greater than 1. Specifically, `di[` before `a[b[c]d]e` leaves `a[]e`, and `2di[` leaves `a[b[]d]e`, but any odd does the same as 1, and any even 2. This is just an artefact of the way it searches for a match. `i"` doesn't have this problem as 2+ is just a single special case.

The second commit fixes this so that `3i[` for example will enter the third nested bracket it finds, in a sort of inside-out version of what it would do if you were inside the brackets rather than outside of them. A higher number than there are nested brackets will fail. It's not entirely clear that this is the ideal behaviour, and it's a bit more code which is why I've kept it separate, but it seemed fairly reasonable.

This patch does not handle tag-blocks (`it`), only 'regular' blocks of '(', '{', etc.

Please let me know if there are any issues. Thanks.