### PR TITLE
Fix match finding halting the whole program (issue #8671)

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2712,7 +2712,7 @@ ins_compl_get_exp(pos_T *ini)
     char_u	*dict = NULL;
     int		dict_f = 0;
     int		set_match_pos;
-    pos_T	prev_pos = {.lnum = 0, .col = 0};
+    pos_T	prev_pos = {0, 0, 0};
     int		looped_around = FALSE;
 
     if (!compl_started)

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2712,8 +2712,8 @@ ins_compl_get_exp(pos_T *ini)
     char_u	*dict = NULL;
     int		dict_f = 0;
     int		set_match_pos;
-    pos_T prev_pos = {.lnum = 0, .col = 0};
-    int looped_around = FALSE;
+    pos_T	prev_pos = {.lnum = 0, .col = 0};
+    int		looped_around = FALSE;
 
     if (!compl_started)
     {
@@ -2966,6 +2966,7 @@ ins_compl_get_exp(pos_T *ini)
 		p_ws = FALSE;
 	    else if (*e_cpt == '.')
 		p_ws = TRUE;
+	    looped_around = FALSE;
 	    for (;;)
 	    {
 		int	cont_s_ipos = FALSE;
@@ -2996,16 +2997,27 @@ ins_compl_get_exp(pos_T *ini)
                                 && first_match_pos.col == last_match_pos.col) {
 		    found_new_match = FAIL;
 		}
-		else if (prev_pos.lnum > last_match_pos.lnum
-			|| (prev_pos.lnum == last_match_pos.lnum
-			    && prev_pos.col >= last_match_pos.col)) {
+		else if ((compl_direction == FORWARD)
+			&& (prev_pos.lnum > pos->lnum
+			    || (prev_pos.lnum == pos->lnum
+				&& prev_pos.col >= pos->col))) {
 		    if (looped_around) {
 			found_new_match = FAIL;
 		    } else {
 			looped_around = TRUE;
 		    }
 		}
-		prev_pos = last_match_pos;
+		else if ((compl_direction != FORWARD)
+			&& (prev_pos.lnum < pos->lnum
+			    || (prev_pos.lnum == pos->lnum
+				&& prev_pos.col <= pos->col))) {
+		    if (looped_around) {
+			found_new_match = FAIL;
+		    } else {
+			looped_around = TRUE;
+		    }
+		}
+		prev_pos = *pos;
 		if (found_new_match == FAIL)
 		{
 		    if (ins_buf == curbuf)

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2712,6 +2712,8 @@ ins_compl_get_exp(pos_T *ini)
     char_u	*dict = NULL;
     int		dict_f = 0;
     int		set_match_pos;
+    pos_T prev_pos;
+    int looped_around = FALSE;
 
     if (!compl_started)
     {
@@ -2991,8 +2993,19 @@ ins_compl_get_exp(pos_T *ini)
 		    set_match_pos = FALSE;
 		}
 		else if (first_match_pos.lnum == last_match_pos.lnum
-				 && first_match_pos.col == last_match_pos.col)
+                                && first_match_pos.col == last_match_pos.col) {
 		    found_new_match = FAIL;
+		}
+		else if (prev_pos.lnum >= last_match_pos.lnum
+			|| (prev_pos.lnum == last_match_pos.lnum
+			    && prev_pos.col >= last_match_pos.col)) {
+		    if (looped_around) {
+			found_new_match = FAIL;
+		    } else {
+			looped_around = TRUE;
+		    }
+		}
+		prev_pos = last_match_pos;
 		if (found_new_match == FAIL)
 		{
 		    if (ins_buf == curbuf)

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2712,7 +2712,7 @@ ins_compl_get_exp(pos_T *ini)
     char_u	*dict = NULL;
     int		dict_f = 0;
     int		set_match_pos;
-    pos_T prev_pos;
+    pos_T prev_pos = {.lnum = 0, .col = 0};
     int looped_around = FALSE;
 
     if (!compl_started)
@@ -2996,7 +2996,7 @@ ins_compl_get_exp(pos_T *ini)
                                 && first_match_pos.col == last_match_pos.col) {
 		    found_new_match = FAIL;
 		}
-		else if (prev_pos.lnum >= last_match_pos.lnum
+		else if (prev_pos.lnum > last_match_pos.lnum
 			|| (prev_pos.lnum == last_match_pos.lnum
 			    && prev_pos.col >= last_match_pos.col)) {
 		    if (looped_around) {

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -58,6 +58,7 @@ NEW_TESTS = \
 	test_arabic \
 	test_arglist \
 	test_assert \
+	test_auto_complete_no_halt \
 	test_autochdir \
 	test_autocmd \
 	test_autoload \
@@ -319,6 +320,7 @@ NEW_TESTS_RES = \
 	test_arabic.res \
 	test_arglist.res \
 	test_assert.res \
+	test_auto_complete_no_halt.res \
 	test_autochdir.res \
 	test_autocmd.res \
 	test_autoload.res \

--- a/src/testdir/test_auto_complete_no_halt.vim
+++ b/src/testdir/test_auto_complete_no_halt.vim
@@ -4,63 +4,43 @@ set completeopt+=menuone
 set completeopt+=noselect
 set completeopt+=noinsert
 let g:autocompletion = v:true
-let g:autocomplete_type = "buffer"
-
-" Omnicomplete
-filetype plugin on
-set omnifunc=syntaxcomplete#Complete
-
-function! OpenCompletion()
-    if pumvisible() && (g:autocompletion == v:true)
-        if g:autocomplete_type == "buffer"
-            call feedkeys("\<C-e>\<C-n>", "i")
-        endif
-        if g:autocomplete_type == "omni"
-            call feedkeys("\<C-e>\<C-x>\<C-o>", "i")
-        endif
-        return
-        redraw
-    endif
-    if ((v:char >= 'a' && v:char <= 'z') || (v:char >= 'A' && v:char <= 'Z')) && (g:autocompletion == v:true)
-        if g:autocomplete_type == "buffer"
-            call feedkeys("\<C-n>", "i")
-        endif
-        if g:autocomplete_type == "omni"
-            call feedkeys("\<C-x>\<C-o>", "i")
-        endif
-        redraw
-    endif
-endfunction
-
-function! ToggleAutocomplete()
-    if g:autocompletion == v:true 
-        echom "Auto-completion disabled"
-        let g:autocompletion = v:false
-    else
-        echom "Auto-completion enabled"
-        let g:autocompletion = v:true
-    endif
-endfunction
-
-function! ToggleCompleteType()
-    if g:autocomplete_type == "buffer" 
-        echom "Auto-completion type set to omnicomplete"
-        let g:autocomplete_type = "omni"
-        return
-    endif
-    if g:autocomplete_type == "omni" 
-        echom "Auto-completion type set to normal"
-        let g:autocomplete_type = "buffer"
-        return
-    endif
-    let g:autocomplete_type = "buffer"
-endfunction
-
-autocmd InsertCharPre * noautocmd call OpenCompletion()
-
-setlocal spell! spelllang=en_us
 
 func Test_auto_complete_no_halt()
+    function! OpenCompletion()
+        if pumvisible() && (g:autocompletion == v:true)
+            call feedkeys("\<C-e>\<C-n>", "i")
+            return
+        endif
+        if ((v:char >= 'a' && v:char <= 'z') || (v:char >= 'A' && v:char <= 'Z')) && (g:autocompletion == v:true)
+            call feedkeys("\<C-n>", "i")
+            redraw
+        endif
+    endfunction
+
+    autocmd InsertCharPre * noautocmd call OpenCompletion()
+
+    setlocal spell! spelllang=en_us
+
+    call feedkeys("iauto-complete-halt-test test test test test test test test test test test test test test test test test test test\<C-c>", "tx!")
+    call assert_equal(["auto-complete-halt-test test test test test test test test test test test test test test test test test test test"], getline(1, "$"))
+endfunc
+
+func Test_auto_complete_backwards_no_halt()
+    function! OpenCompletion()
+        if pumvisible() && (g:autocompletion == v:true)
+            call feedkeys("\<C-e>\<C-p>", "i")
+            return
+        endif
+        if ((v:char >= 'a' && v:char <= 'z') || (v:char >= 'A' && v:char <= 'Z')) && (g:autocompletion == v:true)
+            call feedkeys("\<C-p>", "i")
+            redraw
+        endif
+    endfunction
+
+    autocmd InsertCharPre * noautocmd call OpenCompletion()
+
+    setlocal spell! spelllang=en_us
+
     call feedkeys("iauto-complete-halt-test test test test test test test test test test test test test test test test test test test\<C-c>", "tx!")
     call assert_equal(["auto-complete-halt-test test test test test test test test test test test test test test test test test test test"], getline(1, "$"))
 endfunc

--- a/src/testdir/test_auto_complete_no_halt.vim
+++ b/src/testdir/test_auto_complete_no_halt.vim
@@ -1,0 +1,66 @@
+set complete+=kspell
+set completeopt+=menu
+set completeopt+=menuone
+set completeopt+=noselect
+set completeopt+=noinsert
+let g:autocompletion = v:true
+let g:autocomplete_type = "buffer"
+
+" Omnicomplete
+filetype plugin on
+set omnifunc=syntaxcomplete#Complete
+
+function! OpenCompletion()
+    if pumvisible() && (g:autocompletion == v:true)
+        if g:autocomplete_type == "buffer"
+            call feedkeys("\<C-e>\<C-n>", "i")
+        endif
+        if g:autocomplete_type == "omni"
+            call feedkeys("\<C-e>\<C-x>\<C-o>", "i")
+        endif
+        return
+        redraw
+    endif
+    if ((v:char >= 'a' && v:char <= 'z') || (v:char >= 'A' && v:char <= 'Z')) && (g:autocompletion == v:true)
+        if g:autocomplete_type == "buffer"
+            call feedkeys("\<C-n>", "i")
+        endif
+        if g:autocomplete_type == "omni"
+            call feedkeys("\<C-x>\<C-o>", "i")
+        endif
+        redraw
+    endif
+endfunction
+
+function! ToggleAutocomplete()
+    if g:autocompletion == v:true 
+        echom "Auto-completion disabled"
+        let g:autocompletion = v:false
+    else
+        echom "Auto-completion enabled"
+        let g:autocompletion = v:true
+    endif
+endfunction
+
+function! ToggleCompleteType()
+    if g:autocomplete_type == "buffer" 
+        echom "Auto-completion type set to omnicomplete"
+        let g:autocomplete_type = "omni"
+        return
+    endif
+    if g:autocomplete_type == "omni" 
+        echom "Auto-completion type set to normal"
+        let g:autocomplete_type = "buffer"
+        return
+    endif
+    let g:autocomplete_type = "buffer"
+endfunction
+
+autocmd InsertCharPre * noautocmd call OpenCompletion()
+
+setlocal spell! spelllang=en_us
+
+func Test_auto_complete_no_halt()
+    call feedkeys("iauto-complete-halt-test test test test test test test test test test test test test test test test test test test\<C-c>", "tx!")
+    call assert_equal(["auto-complete-halt-test test test test test test test test test test test test test test test test test test test"], getline(1, "$"))
+endfunc


### PR DESCRIPTION
Match finding algorithm used to halt while looking for matches
in the current buffer if you typed too fast after opening the
auto-complete menu because of the match finder only stopping
after it found the first match again, which never happened again
which resulted in soft halt. Now match finder has an additional
stop condition after it loops around the buffer more than once
which ensures that all matches are found, but buffer is not
parsed infinitely.