### PR TITLE
src/vim9compile.c: Fixing 'key' issues in compile_dict()

### DIFF
--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1184,6 +1184,7 @@ generate_PUSHS(cctx_T *cctx, char_u *str)
 	vim_free(str);
 	return OK;
     }
+
     if ((isn = generate_instr_type(cctx, ISN_PUSHS, &t_string)) == NULL)
 	return FAIL;
     isn->isn_arg.string = str;
@@ -3838,7 +3839,13 @@ compile_dict(char_u **arg, cctx_T *cctx, ppconst_T *ppconst)
 	    if (key == NULL)
 		return FAIL;
 	    if (generate_PUSHS(cctx, key) == FAIL)
+	    {
+		vim_free(key);
 		return FAIL;
+	    }
+
+	    if (cctx->ctx_skip == SKIP_YES)
+		key = NULL;
 	}
 
 	// Check for duplicate keys, if using string keys.


### PR DESCRIPTION
We run our coverity scans during CentOS Stream 9 development and
coverity reported several issues on Vim. Then the issues are divided by
importance (USE_AFTER_FREEs, RESOURCE_LEAKs, BUFFER_OVERFLOWs etc. have
a priority) and the important ones are reviewed further.

I reviewed Vim's important issues - they were false positives in most
cases, but I found the following issue as real:

```
 Error: USE_AFTER_FREE (CWE-416):
 vim82/src/vim9compile.c:3304: freed_arg: "generate_PUSHS" frees "key".
 vim82/src/vim9compile.c:3311: deref_arg: Calling "dict_find"
 dereferences freed pointer "key".
 # 3309|       if (key != NULL)
 # 3310|       {
 # 3311|->         item = dict_find(d, key, -1);
 # 3312|           if (item != NULL)
 # 3313|           {
```

'key' is freed in 'generate_PUSHS()' if 'cctx->ctx_skip' is 'SKIP_YES',
but the pointer is not set to NULL afterwards, so it can be accessed
further down.
Also, if 'generate_PUSHS()' returns FAIL, 'key' is not freed.

The PR fixes both issues.

[Important issues](https://github.com/vim/vim/files/6930310/covscan9-imp.txt) from Coverity scan
[All issues](https://github.com/vim/vim/files/6930373/scan-results.txt) from Coverity scan.
