### PR TITLE
Add runtime files for scdoc

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1526,6 +1526,9 @@ au BufNewFile,BufRead *.sbt			setf sbt
 " Scilab
 au BufNewFile,BufRead *.sci,*.sce		setf scilab
 
+" scdoc
+au BufNewFile,BufRead *.scd			setf scdoc
+
 " SCSS
 au BufNewFile,BufRead *.scss			setf scss
 

--- a/runtime/ftplugin/scdoc.vim
+++ b/runtime/ftplugin/scdoc.vim
@@ -1,0 +1,26 @@
+" scdoc filetype plugin
+" Maintainer: Gregory Anders <greg@gpanders.com>
+" Last Updated: 2021-08-04
+
+" Only do this when not done yet for this buffer
+if exists('b:did_ftplugin')
+    finish
+endif
+
+" Don't load another plugin for this buffer
+let b:did_ftplugin = 1
+
+setlocal comments=b:;
+setlocal commentstring=;%s
+setlocal formatoptions+=t
+setlocal noexpandtab
+setlocal shiftwidth=0
+setlocal softtabstop=0
+setlocal textwidth=80
+
+let b:undo_ftplugin = 'setl com< cms< fo< et< sw< sts< tw<'
+
+if has('conceal')
+    setlocal conceallevel=2
+    let b:undo_ftplugin .= ' cole<'
+endif

--- a/runtime/syntax/scdoc.vim
+++ b/runtime/syntax/scdoc.vim
@@ -1,0 +1,52 @@
+" Syntax file for scdoc files
+" Maintainer: Gregory Anders <greg@gpanders.com>
+" Last Updated: 2021-08-04
+
+if exists('b:current_syntax')
+    finish
+endif
+let b:current_syntax = 'scdoc'
+
+syntax match scdocFirstLineError "\%^.*$"
+syntax match scdocFirstLineValid "\%^\S\+(\d[0-9A-Za-z]*)\%(\s\+\"[^"]*\"\%(\s\+\"[^"]*\"\)\=\)\=$"
+
+syntax region scdocCommentError start="^;\S" end="$" keepend
+syntax region scdocComment start="^; " end="$" keepend
+
+syntax region scdocHeaderError start="^#\{3,}" end="$" keepend
+syntax region scdocHeader start="^#\{1,2}" end="$" keepend
+
+syntax match scdocIndentError "^[ ]\+"
+
+syntax match scdocLineBreak "++$"
+
+syntax match scdocOrderedListMarker "^\s*\.\%(\s\+\S\)\@="
+syntax match scdocListMarker "^\s*-\%(\s\+\S\)\@="
+
+syntax match scdocTableStartMarker "^[\[|\]][\[\-\]]"
+syntax match scdocTableMarker "^[|:][\[\-\] ]"
+
+syntax region scdocBold concealends matchgroup=scdocBoldDelimiter start="\\\@<!\*" end="\\\@<!\*"
+syntax region scdocUnderline concealends matchgroup=scdocUnderlineDelimiter start="\<\\\@<!_" end="\\\@<!_\>"
+syntax region scdocPre matchgroup=scdocPreDelimiter start="^\t*```" end="^\t*```"
+
+hi link scdocFirstLineValid     Comment
+hi link scdocComment            Comment
+hi link scdocHeader             Title
+hi link scdocOrderedListMarker  Statement
+hi link scdocListMarker         scdocOrderedListMarker
+hi link scdocLineBreak          Special
+hi link scdocTableMarker        Statement
+hi link scdocTableStartMarker   scdocTableMarker
+
+hi link scdocFirstLineError     Error
+hi link scdocCommentError       Error
+hi link scdocHeaderError        Error
+hi link scdocIndentError        Error
+
+hi link scdocPreDelimiter       Delimiter
+
+hi scdocBold term=bold cterm=bold gui=bold
+hi scdocUnderline term=underline cterm=underline gui=underline
+hi link scdocBoldDelimiter scdocBold
+hi link scdocUnderlineDelimiter scdocUnderline

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -433,6 +433,7 @@ let s:filename_checks = {
     \ 'scilab': ['file.sci', 'file.sce'],
     \ 'screen': ['.screenrc', 'screenrc'],
     \ 'sexplib': ['file.sexp'],
+    \ 'scdoc': ['file.scd'],
     \ 'scss': ['file.scss'],
     \ 'sd': ['file.sd'],
     \ 'sdc': ['file.sdc'],


### PR DESCRIPTION
I am the author and maintainer of the [vim-scdoc](https://github.com/gpanders/vim-scdoc) plugin. [scdoc] is a (stable) lightweight manpage generator.

[scdoc]: https://sr.ht/~sircmpwn/scdoc

I sent a patch to the vim-dev mailing list as well, but I'm not sure if it went through (it's not appearing on the Google Group), so apologies if this gets posted twice.
