### PR TITLE
gj may not jump to next screenline correctly

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -2530,7 +2530,7 @@ nv_screengo(oparg_T *oap, int dir, long dist)
     int		col_off1;	// margin offset for first screen line
     int		col_off2;	// margin offset for wrapped screen line
     int		width1;		// text width for first screen line
-    int		width2;		// test width for wrapped screen line
+    int		width2;		// text width for wrapped screen line
 
     oap->motion_type = MCHAR;
     oap->inclusive = (curwin->w_curswant == MAXCOL);
@@ -2668,6 +2668,13 @@ nv_screengo(oparg_T *oap, int dir, long dist)
 	if (virtcol > (colnr_T)width1 && *get_showbreak_value(curwin) != NUL)
 	    virtcol -= vim_strsize(get_showbreak_value(curwin));
 #endif
+	{
+	    int c = (*mb_ptr2char)(ml_get_cursor());
+	    if (dir == FORWARD && virtcol < curwin->w_curswant
+		&& (curwin->w_curswant <= (colnr_T)width1)
+		&& !vim_isprintc(c) && c > 255)
+		oneright();
+	}
 
 	if (virtcol > curwin->w_curswant
 		&& (curwin->w_curswant < (colnr_T)width1

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -3423,4 +3423,16 @@ func Test_normal_count_after_operator()
   bw!
 endfunc
 
+func Test_normal_gj_on_extra_wide_char()
+  new | 25vsp
+  let text='1 foooooooo ar e  ins‍zwe1 foooooooo ins‍zwei' .
+         \ ' i drei vier fünf sechs sieben acht un zehn elf zwöfl' .
+         \ ' dreizehn v ierzehn fünfzehn'
+  put =text
+  call cursor(2,1)
+  norm! gj
+  call assert_equal([0,2,25,0], getpos('.'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
A small bug I noticed while playing with `gj`

When using `gj` it may happen that an extra wide character appears at the soft
line break. In that case, the cursor will be positioned at the beginning
of the several char wide character so the cursor may become stuck on the current screen
line.

Fix this by advancing to the next line if that happens.

Also add a test