### PR TITLE
Add events when starting/stopping termdebug

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1352,6 +1352,41 @@ Other commands ~
  *:Asm*	     jump to the window with the disassembly, create it if there
 	     isn't one
 
+Events ~
+						*termdebug-events*
+The plugin provides a set of events to run custom commands upon
+starting or ending a debugging session.
+
+Name				triggered by ~
+
+|TermdebugStartPre|		before starting debugging
+|TermdebugStartPost|		after debugging has initialized
+|TermdebugStopPre|		before debugging ends
+|TermdebugStopPost|		after debugging has ended
+
+						*TermdebugStopPost*
+TermdebugStopPost		After debugging has ended, gdb-related windows
+				are closed, buffers wiped out and Vim is
+				reverted back to its original state before the
+				debugging was started.
+						*TermdebugStopPre*
+TermdebugStopPre		Before debugging ends, when gdb is terminated,
+				most likely by issuing a "quit" command in the
+				gdb window.
+						*TermdebugStartPost*
+TermdebugStartPost		After debugging has initialized.
+				If a "!" bang is passed to `:Termdebug` or
+				`:TermdebugCommand` the event is triggered
+				before running the provided command in gdb.
+						*TermdebugStartPre*
+TermdebugStartPre		Before starting debugging.
+				Not triggered if the debugger is already
+				running or |g:termdebugger| cannot be
+				executed.
+
+Autocommands can be set for these by using the |User| event: >
+	autocmd User TermdebugStartPre set number
+<
 
 Prompt mode ~
 						*termdebug-prompt*

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -117,6 +117,10 @@ func s:StartDebug_internal(dict)
     return
   endif
 
+  if exists('#User#TermdebugStartPre')
+    doautocmd <nomodeline> User TermdebugStartPre
+  endif
+
   let s:ptywin = 0
   let s:pid = 0
   let s:asmwin = 0
@@ -455,6 +459,10 @@ func s:StartDebugCommon(dict)
     au OptionSet background call s:Highlight(0, v:option_old, v:option_new)
   augroup END
 
+  if exists('#User#TermdebugStartPost')
+    doautocmd <nomodeline> User TermdebugStartPost
+  endif
+
   " Run the command if the bang attribute was given and got to the debug
   " window.
   if get(a:dict, 'bang', 0)
@@ -596,7 +604,12 @@ func s:GetAsmAddr(msg)
   let addr = s:DecodeMessage(substitute(a:msg, '.*addr=', '', ''))
   return addr
 endfunc
+
 func s:EndTermDebug(job, status)
+  if exists('#User#TermdebugStopPre')
+    doautocmd <nomodeline> User TermdebugStopPre
+  endif
+
   exe 'bwipe! ' . s:commbuf
   unlet s:gdbwin
 
@@ -643,9 +656,17 @@ func s:EndDebugCommon()
   endif
 
   au! TermDebug
+
+  if exists('#User#TermdebugStopPost')
+    doautocmd <nomodeline> User TermdebugStopPost
+  endif
 endfunc
 
 func s:EndPromptDebug(job, status)
+  if exists('#User#TermdebugStopPre')
+    doautocmd <nomodeline> User TermdebugStopPre
+  endif
+
   let curwinid = win_getid(winnr())
   call win_gotoid(s:gdbwin)
   set nomodified


### PR DESCRIPTION
This is *almost* working. 

Currently for `TermdebugStopPost`, commands that are local to a window (e.g., `set number`) do not have the expected result (i.e., execute the command on the "source" window).

This is due to line 642 in termdebug.vim (`call win_gotoid(curwinid)`) that sets the focus on a possibly non existing window. Removing the line solves the problem for my limited tests, but since I'm not sure what that line does it might be safer to chance it to something like
```
if ! win_gotoid(curwinid)
  win_gotoid(s:sourcewin)
endif
```

Closes #8709