### PR TITLE
Add GH action to automatically run Coverity scans

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,80 @@
+name: Coverity
+on:
+  schedule:
+    - cron: '42 0 * * *'  # Run once per day, to avoid Coverity's submission limits
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-18.04
+
+    env:
+      CC: gcc
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download Coverity
+        run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=vim" -O coverity_tool.tgz
+          mkdir cov-scan
+          tar ax -f coverity_tool.tgz --strip-components=1 -C cov-scan
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
+      - name: Install packages
+        run: |
+          sudo apt update && sudo apt install -y \
+            autoconf \
+            gettext \
+            libcanberra-dev \
+            libperl-dev \
+            python-dev \
+            python3-dev \
+            liblua5.3-dev \
+            lua5.3 \
+            ruby-dev \
+            tcl-dev \
+            libgtk2.0-dev \
+            desktop-file-utils \
+            libtool-bin \
+            libsodium-dev
+
+      - name: Set up environment
+        run: |
+          echo "$(pwd)/cov-scan/bin" >> $GITHUB_PATH
+          (
+          echo "NPROC=$(getconf _NPROCESSORS_ONLN)"
+          echo "CONFOPT=--enable-perlinterp --enable-pythoninterp --enable-python3interp --enable-rubyinterp --enable-luainterp --enable-tclinterp"
+          ) >> $GITHUB_ENV
+
+      - name: Set up system
+        run: |
+          # Setup lua5.3 manually since its package doesn't provide alternative.
+          # https://bugs.launchpad.net/ubuntu/+source/lua5.3/+bug/1707212
+          sudo update-alternatives --install /usr/bin/lua lua /usr/bin/lua5.3 10
+
+      - name: Configure
+        run: |
+          ./configure --with-features=huge ${CONFOPT} --enable-fail-if-missing
+          # Append various warning flags to CFLAGS.
+          sed -i -f ci/config.mk.sed ${SRCDIR}/auto/config.mk
+          sed -i -f ci/config.mk.${CC}.sed ${SRCDIR}/auto/config.mk
+
+      - name: Build/scan vim
+        run: |
+          cov-build --dir cov-int make -j${NPROC}
+
+      - name: Submit results
+        run: |
+          tar zcf cov-scan.tgz cov-int
+          curl --form token=$TOKEN \
+            --form email=$EMAIL \
+            --form file=@cov-scan.tgz \
+            --form version="$(git rev-parse HEAD)" \
+            --form description="Automatic GHA scan" \
+            'https://scan.coverity.com/builds?project=vim'
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}


### PR DESCRIPTION
This requires adding two new secrets to the [repository settings](https://github.com/vim/vim/settings/secrets/actions).

* COVERITY_SCAN_TOKEN
* COVERITY_SCAN_EMAIL

These are the token and email from the curl command on https://scan.coverity.com/projects/vim/builds/new.