### PR TITLE
Popupwin title using multibytes cannot be displayed correctly

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3896,7 +3896,7 @@ update_popups(void (*win_update)(win_T *wp))
 	title_wincol = wp->w_wincol + 1;
 	if (wp->w_popup_title != NULL)
 	{
-	    title_len = (int)MB_CHARLEN(wp->w_popup_title);
+	    title_len = (int)vim_strsize(wp->w_popup_title);
 
 	    // truncate the title if too long
 	    if (title_len > total_width - 2)


### PR DESCRIPTION
Popupwin title using multibytes cannot be displayed correctly. This PR will fix it.

__Current__
![image](https://user-images.githubusercontent.com/1595779/128489437-0edb98c4-0522-4390-bd1b-929e8d5cff71.png)

__After this PR__
![image](https://user-images.githubusercontent.com/1595779/128489524-7e519494-0950-47fa-b277-2d1ab14c67a1.png)

I do not add testcases for this PR because there is already the testcase and we cannot test whether popupwin title using multibytes is displayed correctly.

https://github.com/vim/vim/blob/master/src/testdir/test_popupwin.vim#L1820

NOTE:
```
wp->w_popup_title: '▶ÄÖÜ◀'
MB_CHARLEN(wp->w_popup_title): 5
STRLEN(wp->w_popup_title): 12
vim_strsize(wp->w_popup_title): 7
```