### PR TITLE
Vim9: When the :finally is not produce code, cannot skip :finally 

### DIFF
--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -2018,6 +2018,10 @@ ex_endtry(exarg_T *eap)
 	{
 	    idx = cstack->cs_idx;
 
+	    // Set CSL_HAD_FINA to cstack->cs_lflags in ex_finally() only when
+	    // skip is FALSE, and set CSF_FINALLY to cstack->cs_flags[] in
+	    // do_cmdline() only when cstack->cs_lflags contains CSL_HAD_FINA.
+	    // Thus we need to check if skip is false.
 	    if (!skip && in_vim9script()
 		     && (cstack->cs_flags[idx] & (CSF_CATCH|CSF_FINALLY)) == 0)
 	    {

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -2018,7 +2018,7 @@ ex_endtry(exarg_T *eap)
 	{
 	    idx = cstack->cs_idx;
 
-	    if (in_vim9script()
+	    if (!skip && in_vim9script()
 		     && (cstack->cs_flags[idx] & (CSF_CATCH|CSF_FINALLY)) == 0)
 	    {
 		// try/endtry without any catch or finally: give an error and

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -658,7 +658,7 @@ def Test_try_catch_throw()
       enddef
       s:f()
   END
-  CheckScriptSuccess(lines, 'E607:')
+  CheckScriptSuccess(lines)
 
   lines =<< trim END
       vim9script
@@ -672,7 +672,7 @@ def Test_try_catch_throw()
         endtry
       endif
   END
-  CheckScriptSuccess(lines, 'E1032:')
+  CheckScriptSuccess(lines)
 enddef
 
 def Test_try_in_catch()

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -641,6 +641,21 @@ def Test_try_catch_throw()
       endtry
   END
   CheckScriptFailure(lines, 'E1032:')
+
+  # skipping try-finally-endtry when try-finally-endtry is used in another block
+  lines =<< trim END
+      vim9script
+      if v:true
+        try
+        finally
+        endtry
+      else
+        try
+        finally
+        endtry
+      endif
+  END
+  CheckScriptSuccess(lines, 'E607:')
 enddef
 
 def Test_try_in_catch()

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -645,6 +645,23 @@ def Test_try_catch_throw()
   # skipping try-finally-endtry when try-finally-endtry is used in another block
   lines =<< trim END
       vim9script
+      def s:f()
+        if v:true
+          try
+          finally
+          endtry
+        else
+          try
+          finally
+          endtry
+        endif
+      enddef
+      s:f()
+  END
+  CheckScriptSuccess(lines, 'E607:')
+
+  lines =<< trim END
+      vim9script
       if v:true
         try
         finally
@@ -655,7 +672,7 @@ def Test_try_catch_throw()
         endtry
       endif
   END
-  CheckScriptSuccess(lines, 'E607:')
+  CheckScriptSuccess(lines, 'E1032:')
 enddef
 
 def Test_try_in_catch()

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -8569,49 +8569,52 @@ compile_finally(char_u *arg, cctx_T *cctx)
 	return NULL;
     }
 
-    // End :catch or :finally scope: set value in ISN_TRY instruction
-    isn = ((isn_T *)instr->ga_data) + scope->se_u.se_try.ts_try_label;
-    if (isn->isn_arg.try.try_ref->try_finally != 0)
+    if (cctx->ctx_skip != SKIP_YES)
     {
-	emsg(_(e_finally_dup));
-	return NULL;
-    }
+	// End :catch or :finally scope: set value in ISN_TRY instruction
+	isn = ((isn_T *)instr->ga_data) + scope->se_u.se_try.ts_try_label;
+	if (isn->isn_arg.try.try_ref->try_finally != 0)
+	{
+	    emsg(_(e_finally_dup));
+	    return NULL;
+	}
 
-    this_instr = instr->ga_len;
+	this_instr = instr->ga_len;
 #ifdef FEAT_PROFILE
-    if (cctx->ctx_compile_type == CT_PROFILE
-	    && ((isn_T *)instr->ga_data)[this_instr - 1]
-						   .isn_type == ISN_PROF_START)
-    {
-	// jump to the profile start of the "finally"
-	--this_instr;
-
-	// jump to the profile end above it
-	if (this_instr > 0 && ((isn_T *)instr->ga_data)[this_instr - 1]
-						     .isn_type == ISN_PROF_END)
+	if (cctx->ctx_compile_type == CT_PROFILE
+		&& ((isn_T *)instr->ga_data)[this_instr - 1]
+						       .isn_type == ISN_PROF_START)
+	{
+	    // jump to the profile start of the "finally"
 	    --this_instr;
-    }
+
+	    // jump to the profile end above it
+	    if (this_instr > 0 && ((isn_T *)instr->ga_data)[this_instr - 1]
+							 .isn_type == ISN_PROF_END)
+		--this_instr;
+	}
 #endif
 
-    // Fill in the "end" label in jumps at the end of the blocks.
-    compile_fill_jump_to_end(&scope->se_u.se_try.ts_end_label,
+	// Fill in the "end" label in jumps at the end of the blocks.
+	compile_fill_jump_to_end(&scope->se_u.se_try.ts_end_label,
 							     this_instr, cctx);
 
-    // If there is no :catch then an exception jumps to :finally.
-    if (isn->isn_arg.try.try_ref->try_catch == 0)
-	isn->isn_arg.try.try_ref->try_catch = this_instr;
-    isn->isn_arg.try.try_ref->try_finally = this_instr;
-    if (scope->se_u.se_try.ts_catch_label != 0)
-    {
-	// Previous catch without match jumps here
-	isn = ((isn_T *)instr->ga_data) + scope->se_u.se_try.ts_catch_label;
-	isn->isn_arg.jump.jump_where = this_instr;
-	scope->se_u.se_try.ts_catch_label = 0;
-    }
-    if (generate_instr(cctx, ISN_FINALLY) == NULL)
-	return NULL;
+	// If there is no :catch then an exception jumps to :finally.
+	if (isn->isn_arg.try.try_ref->try_catch == 0)
+	    isn->isn_arg.try.try_ref->try_catch = this_instr;
+	isn->isn_arg.try.try_ref->try_finally = this_instr;
+	if (scope->se_u.se_try.ts_catch_label != 0)
+	{
+	    // Previous catch without match jumps here
+	    isn = ((isn_T *)instr->ga_data) + scope->se_u.se_try.ts_catch_label;
+	    isn->isn_arg.jump.jump_where = this_instr;
+	    scope->se_u.se_try.ts_catch_label = 0;
+	}
+	if (generate_instr(cctx, ISN_FINALLY) == NULL)
+	    return NULL;
 
-    // TODO: set index in ts_finally_label jumps
+	// TODO: set index in ts_finally_label jumps
+    }
 
     return arg;
 }

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -8597,7 +8597,7 @@ compile_finally(char_u *arg, cctx_T *cctx)
 
 	// Fill in the "end" label in jumps at the end of the blocks.
 	compile_fill_jump_to_end(&scope->se_u.se_try.ts_end_label,
-							     this_instr, cctx);
+								this_instr, cctx);
 
 	// If there is no :catch then an exception jumps to :finally.
 	if (isn->isn_arg.try.try_ref->try_catch == 0)


### PR DESCRIPTION
This PR will fix two issues.

* issue 1. following code occurs `E607: multiple :finally`

      vim9script
      def s:f()
        if v:true
          try
          finally
          endtry
        else
          try
          finally
          endtry
        endif
      enddef
      s:f()



* issue 2. following code occurs `E1032: Missing :catch or :finally`

      vim9script
      if v:true
        try
        finally
        endtry
      else
        try
        finally
        endtry
      endif
