### PR TITLE
Reduce sizeof of a few struct using pahole tool

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -332,8 +332,8 @@ struct wininfo_S
     wininfo_T	*wi_prev;	// previous entry or NULL for first entry
     win_T	*wi_win;	// pointer to window that did set wi_fpos
     pos_T	wi_fpos;	// last cursor position in the file
-    int		wi_optset;	// TRUE when wi_opt has useful values
     winopt_T	wi_opt;		// local window options
+    int		wi_optset;	// TRUE when wi_opt has useful values
 #ifdef FEAT_FOLDING
     int		wi_fold_manual;	// copy of w_fold_manual
     garray_T	wi_folds;	// clone of w_folds
@@ -1238,8 +1238,8 @@ struct mapblock
     char	m_silent;	// <silent> used, don't echo commands
     char	m_nowait;	// <nowait> used
 #ifdef FEAT_EVAL
-    sctx_T	m_script_ctx;	// SCTX where map was defined
     char	m_expr;		// <expr> used, m_str is an expression
+    sctx_T	m_script_ctx;	// SCTX where map was defined
 #endif
 };
 
@@ -2017,12 +2017,12 @@ struct outer_S {
 struct partial_S
 {
     int		pt_refcount;	// reference count
+    int		pt_auto;	// when TRUE the partial was created for using
+				// dict.member in handle_subscript()
     char_u	*pt_name;	// function name; when NULL use
 				// pt_func->uf_name
     ufunc_T	*pt_func;	// function pointer; when NULL lookup function
 				// with pt_name
-    int		pt_auto;	// when TRUE the partial was created for using
-				// dict.member in handle_subscript()
 
     // For a compiled closure: the arguments and local variables scope
     outer_T	pt_outer;
@@ -2030,11 +2030,11 @@ struct partial_S
     funcstack_T	*pt_funcstack;	// copy of stack, used after context
 				// function returns
 
-    int		pt_argc;	// number of arguments
     typval_T	*pt_argv;	// arguments in allocated array
+    int		pt_argc;	// number of arguments
 
-    dict_T	*pt_dict;	// dict for "self"
     int		pt_copyID;	// funcstack may contain pointer to partial
+    dict_T	*pt_dict;	// dict for "self"
 };
 
 typedef struct AutoPatCmd_S AutoPatCmd;
@@ -2103,9 +2103,9 @@ struct jobvar_S
     PROCESS_INFORMATION	jv_proc_info;
     HANDLE		jv_job_object;
 #endif
+    jobstatus_T	jv_status;
     char_u	*jv_tty_in;	// controlling tty input, allocated
     char_u	*jv_tty_out;	// controlling tty output, allocated
-    jobstatus_T	jv_status;
     char_u	*jv_stoponexit;	// allocated
 #ifdef UNIX
     char_u	*jv_termsig;	// allocated
@@ -3925,8 +3925,8 @@ struct VimMenu
     char_u	*en_dname;	    // "dname" untranslated, NULL when "dname"
 				    // was not translated
 #endif
-    int		mnemonic;	    // mnemonic key (after '&')
     char_u	*actext;	    // accelerator text (after TAB)
+    int		mnemonic;	    // mnemonic key (after '&')
     int		priority;	    // Menu order priority
 #ifdef FEAT_GUI
     void	(*cb)(vimmenu_T *); // Call-back function

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -456,9 +456,9 @@ struct dfunc_S {
     int		df_refcount;	    // how many ufunc_T point to this dfunc_T
     int		df_idx;		    // index in def_functions
     int		df_deleted;	    // if TRUE function was deleted
-    char_u	*df_name;	    // name used for error messages
     int		df_script_seq;	    // Value of sctx_T sc_seq when the function
 				    // was compiled.
+    char_u	*df_name;	    // name used for error messages
 
     garray_T	df_def_args_isn;    // default argument instructions
     garray_T	df_var_names;	    // names of local vars
@@ -466,12 +466,12 @@ struct dfunc_S {
     // After compiling "df_instr" and/or "df_instr_prof" is not NULL.
     isn_T	*df_instr;	    // function body to be executed
     int		df_instr_count;	    // size of "df_instr"
+    int		df_instr_debug_count; // size of "df_instr_debug"
+    isn_T	*df_instr_debug;      // like "df_instr" with debugging
 #ifdef FEAT_PROFILE
     isn_T	*df_instr_prof;	     // like "df_instr" with profiling
     int		df_instr_prof_count; // size of "df_instr_prof"
 #endif
-    isn_T	*df_instr_debug;      // like "df_instr" with debugging
-    int		df_instr_debug_count; // size of "df_instr_debug"
 
     int		df_varcount;	    // number of local variables
     int		df_has_closure;	    // one if a closure was created

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -85,8 +85,8 @@ struct ectx_S {
 
     garray_T	ec_trystack;	// stack of trycmd_T values
 
-    int		ec_dfunc_idx;	// current function index
     isn_T	*ec_instr;	// array with instructions
+    int		ec_dfunc_idx;	// current function index
     int		ec_iidx;	// index in ec_instr: instruction to execute
 
     garray_T	ec_funcrefs;	// partials that might be a closure


### PR DESCRIPTION
A few fields of structs are reordered in order to
avoid wasting bytes in some padding.

Following table shows the size reduction with
vim-8.2.3301 (huge) on Linux x86_64:
```
struct     sizeof in bytes
name       before  after
------     ------  -----
dfunc_S       144    128 (-16)
partial_S     104     88 (-16)
ectx_S        392    384 ( -8)
jobvar_S      128    120 ( -8)
wininfo_S    1472   1464 ( -8)
mapblock       88     80 ( -8)
VimMenu       240    232 ( -8)
```