### PR TITLE
docs: Make clear that getenv doesn't use identifiers.

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -9657,7 +9657,9 @@ setcursorcharpos({list})
 setenv({name}, {val})						*setenv()*
 		Set environment variable {name} to {val}.
 		When {val} is |v:null| the environment variable is deleted.
-		See also |expr-env|.
+		Use only the variable name without os specific identifiers
+		See also |expr-env|. For example:
+			setenv('HOME', '/home/myhome')
 
 		Can also be used as a |method|, the base is passed as the
 		second argument: >

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5712,7 +5712,9 @@ getenv({name})						*getenv()*
 		When the variable does not exist |v:null| is returned.  That
 		is different from a variable set to an empty string, although
 		some systems interpret the empty value as the variable being
-		deleted.  See also |expr-env|.
+		deleted. Use only the variable name without os specific 
+		identifiers. See also |expr-env|. For example:
+			`getenv('HOME')`
 
 		Can also be used as a |method|: >
 			GetVarname()->getenv()


### PR DESCRIPTION
Makes it clear that one shouldn't use `getenv('$HOME')`. It's an easy mistake to make, since most of the times one uses an environment variable in unix like systems the `$` is used in front.