### PR TITLE
Slightly improve test coverage of ex_cmds.c

### DIFF
--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -382,6 +382,42 @@ func Test_confirm_write_ro()
   call delete('Xconfirm_write_ro')
 endfunc
 
+func Test_confirm_write_partial_file()
+  CheckNotGui
+  CheckRunVimInTerminal
+
+  call writefile(['a', 'b', 'c', 'd'], 'Xwrite_partial')
+  call writefile(['set nobackup ff=unix cmdheight=2',
+        \         'edit Xwrite_partial'], 'Xscript')
+  let buf = RunVimInTerminal('-S Xscript', {'rows': 20})
+
+  call term_sendkeys(buf, ":confirm 2,3w\n")
+  call WaitForAssert({-> assert_match('^Write partial file? *$',
+        \            term_getline(buf, 19))}, 1000)
+  call WaitForAssert({-> assert_match('^(Y)es, \[N\]o: *$',
+        \            term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, 'N')
+  call WaitForAssert({-> assert_match('.* All$', term_getline(buf, 20))}, 1000)
+  call assert_equal(['a', 'b', 'c', 'd'], readfile('Xwrite_partial'))
+  call delete('Xwrite_partial')
+
+  call term_sendkeys(buf, ":confirm 2,3w\n")
+  call WaitForAssert({-> assert_match('^Write partial file? *$',
+        \            term_getline(buf, 19))}, 1000)
+  call WaitForAssert({-> assert_match('^(Y)es, \[N\]o: *$',
+        \            term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, 'Y')
+  call WaitForAssert({-> assert_match('^"Xwrite_partial" \[New\] 2L, 4B written *$',
+        \            term_getline(buf, 19))}, 1000)
+  call WaitForAssert({-> assert_match('^Press ENTER or type command to continue *$',
+        \            term_getline(buf, 20))}, 1000)
+  call assert_equal(['b', 'c'], readfile('Xwrite_partial'))
+
+  call StopVimInTerminal(buf)
+  call delete('Xwrite_partial')
+  call delete('Xscript')
+endfunc
+
 " Test for the :print command
 func Test_print_cmd()
   call assert_fails('print', 'E749:')

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -230,6 +230,14 @@ func Test_saveas()
   close!
   enew | only
   call delete('Xfile')
+
+  " :saveas should detect and set the file type.
+  syntax on
+  saveas! Xsaveas.pl
+  call assert_equal('perl', &filetype)
+  syntax off
+  %bw!
+  call delete('Xsaveas.pl')
 endfunc
 
 func Test_write_errors()


### PR DESCRIPTION
This PR slightly improves test coverage of `ex_cmds.c`, to cover those lines:                                                                           

https://codecov.io/gh/vim/vim/src/ed8b099fd23b20d7b5a436182bde6672c8686189/src/ex_cmds.c#L1981
https://codecov.io/gh/vim/vim/src/ed8b099fd23b20d7b5a436182bde6672c8686189/src/ex_cmds.c#L2051