### PR TITLE
Set correct highlight group for escaped characters

### DIFF
--- a/runtime/syntax/scala.vim
+++ b/runtime/syntax/scala.vim
@@ -66,7 +66,7 @@ syn match scalaChar /'\\u[A-Fa-f0-9]\{4}'/ contains=scalaUnicodeChar
 syn match scalaEscapedChar /\\[\\"'ntbrf]/
 syn match scalaUnicodeChar /\\u[A-Fa-f0-9]\{4}/
 hi link scalaChar Character
-hi link scalaEscapedChar Function
+hi link scalaEscapedChar Special
 hi link scalaUnicodeChar Special
 
 syn match scalaOperator "||"


### PR DESCRIPTION
`scalaEscapedChar` should be set to `Special`, not `Function`.

To recreate the issue that this is fixing run:

```sh
echo "a\nb" > ~/foo.txt
```

Then use `:setfiletype` to change the filetype to various other
languages like c, java, perl, python, ruby, javascript, and finally
scala.  Notice that the `\n` is a different color only in scala.  It is
the color used for functions and it is the only outlier here.

This commit fixes that.

![Screenshot showcasing the issue](https://user-images.githubusercontent.com/1005550/128949773-29465a51-e051-4482-8ffc-ac224db2925c.png)

Please note I also opened a PR in the vim-scala repo that this
syntax appears to be taken from, however that repo hasn't seen any
activing or updates in over two years and appears abandoned.
See: https://github.com/derekwyatt/vim-scala/pull/164