### PR TITLE
Added syntax for the structurizr DSL

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -538,7 +538,12 @@ au BufNewFile,BufRead *.drac,*.drc,*lvs,*lpe	setf dracula
 au BufNewFile,BufRead *.ds			setf datascript
 
 " dsl
-au BufNewFile,BufRead *.dsl			setf dsl
+au BufNewFile,BufRead *.dsl
+	\ if getline(1) =~ '^<\!' |
+	\   setf dsl |
+	\ else |
+	\   setf structurizr |
+	\ endif
 
 " DTD (Document Type Definition for XML)
 au BufNewFile,BufRead *.dtd			setf dtd

--- a/runtime/syntax/structurizr.vim
+++ b/runtime/syntax/structurizr.vim
@@ -1,5 +1,5 @@
 " Vim syntax file
-" Language:      Structurizr DSL (
+" Language:      Structurizr DSL
 " Maintainer:    Bastian Venthur <venthur@debian.org>
 " Last Change:   2021-08-16
 " Remark:        For a language reference, see

--- a/runtime/syntax/structurizr.vim
+++ b/runtime/syntax/structurizr.vim
@@ -1,0 +1,76 @@
+" Vim syntax file
+" Language:      Structurizr DSL (
+" Maintainer:    Bastian Venthur <venthur@debian.org>
+" Last Change:   2021-08-16
+" Remark:        For a language reference, see
+"                https://github.com/structurizr/dsl
+
+
+if exists("b:current_syntax")
+    finish
+endif
+
+syn case ignore
+
+" comments
+syn match scomment "#.*$"
+syn match scomment "//.*$"
+syn region scomment start="/\*" end="\*/"
+
+" keywords
+syn keyword skeyword animation
+syn keyword skeyword autoLayout
+syn keyword skeyword branding
+syn keyword skeyword component
+syn keyword skeyword configuration
+syn keyword skeyword container
+syn keyword skeyword containerinstance
+syn keyword skeyword custom
+syn keyword skeyword deployment
+syn keyword skeyword deploymentenvironment
+syn keyword skeyword deploymentgroup
+syn keyword skeyword deploymentnode
+syn keyword skeyword dynamic
+syn keyword skeyword element
+syn keyword skeyword enterprise
+syn keyword skeyword exclude
+syn keyword skeyword filtered
+syn keyword skeyword group
+syn keyword skeyword healthcheck
+syn keyword skeyword impliedrelationships
+syn keyword skeyword include
+syn keyword skeyword infrastructurenode
+syn keyword skeyword model
+syn keyword skeyword person
+syn keyword skeyword perspectives
+syn keyword skeyword properties
+syn keyword skeyword relationship
+syn keyword skeyword softwaresystem
+syn keyword skeyword softwaresysteminstance
+syn keyword skeyword styles
+syn keyword skeyword systemcontext
+syn keyword skeyword systemlandscape
+syn keyword skeyword tags
+syn keyword skeyword terminology
+syn keyword skeyword theme
+syn keyword skeyword title
+syn keyword skeyword url
+syn keyword skeyword users
+syn keyword skeyword views
+syn keyword skeyword workspace
+
+syn match skeyword "\!adrs\s\+"
+syn match skeyword "\!constant\s\+"
+syn match skeyword "\!docs\s\+"
+syn match skeyword "\!identifiers\s\+"
+syn match skeyword "\!include\s\+"
+
+syn region sstring oneline start='"' end='"'
+
+syn region sblock start='{' end='}' fold transparent
+
+hi def link sstring string
+hi def link scomment comment
+hi def link skeyword keyword
+
+let b:current_syntax = "structurizr"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -656,8 +656,6 @@ let s:script_checks = {
       \ 'yaml': [['%YAML 1.2']],
       \ 'pascal': [['#!/path/instantfpc']],
       \ 'fennel': [['#!/path/fennel']],
-      \ 'dsl': [['<!doctype dsssl-spec [']],
-      \ 'structurizr': [['workspace {']],
       \ }
 
 " Various forms of "env" optional arguments.
@@ -832,6 +830,23 @@ func Test_ex_file()
   bwipe!
 
   call delete('Xfile.ex')
+  filetype off
+endfunc
+
+func Test_dsl_file()
+  filetype on
+
+  call writefile(['<!doctype dsssl-spec ['], 'dslfile.dsl')
+  split dslfile.dsl
+  call assert_equal('dsl', &filetype)
+  bwipe!
+
+  call writefile(['workspace {'], 'dslfile.dsl')
+  split dslfile.dsl
+  call assert_equal('structurizr', &filetype)
+  bwipe!
+
+  call delete('dslfile.dsl')
   filetype off
 endfunc
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -151,7 +151,7 @@ let s:filename_checks = {
     \ 'dosini': ['.editorconfig', '/etc/pacman.conf', '/etc/yum.conf', 'file.ini', 'npmrc', '.npmrc', 'php.ini', 'php.ini-5', 'php.ini-file', '/etc/yum.repos.d/file', 'any/etc/pacman.conf', 'any/etc/yum.conf', 'any/etc/yum.repos.d/file', 'file.wrap'],
     \ 'dot': ['file.dot', 'file.gv'],
     \ 'dracula': ['file.drac', 'file.drc', 'filelvs', 'filelpe', 'drac.file', 'lpe', 'lvs', 'some-lpe', 'some-lvs'],
-    \ 'dsl': ['file.dsl'],
+    \ 'structurizr': ['file.dsl'],
     \ 'dtd': ['file.dtd'],
     \ 'dts': ['file.dts', 'file.dtsi'],
     \ 'dune': ['jbuild', 'dune', 'dune-project', 'dune-workspace'],
@@ -657,6 +657,7 @@ let s:script_checks = {
       \ 'yaml': [['%YAML 1.2']],
       \ 'pascal': [['#!/path/instantfpc']],
       \ 'fennel': [['#!/path/fennel']],
+      \ 'dsl': [['<!doctype dsssl-spec [']],
       \ }
 
 " Various forms of "env" optional arguments.

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -151,7 +151,6 @@ let s:filename_checks = {
     \ 'dosini': ['.editorconfig', '/etc/pacman.conf', '/etc/yum.conf', 'file.ini', 'npmrc', '.npmrc', 'php.ini', 'php.ini-5', 'php.ini-file', '/etc/yum.repos.d/file', 'any/etc/pacman.conf', 'any/etc/yum.conf', 'any/etc/yum.repos.d/file', 'file.wrap'],
     \ 'dot': ['file.dot', 'file.gv'],
     \ 'dracula': ['file.drac', 'file.drc', 'filelvs', 'filelpe', 'drac.file', 'lpe', 'lvs', 'some-lpe', 'some-lvs'],
-    \ 'structurizr': ['file.dsl'],
     \ 'dtd': ['file.dtd'],
     \ 'dts': ['file.dts', 'file.dtsi'],
     \ 'dune': ['jbuild', 'dune', 'dune-project', 'dune-workspace'],
@@ -658,6 +657,7 @@ let s:script_checks = {
       \ 'pascal': [['#!/path/instantfpc']],
       \ 'fennel': [['#!/path/fennel']],
       \ 'dsl': [['<!doctype dsssl-spec [']],
+      \ 'structurizr': [['workspace {']],
       \ }
 
 " Various forms of "env" optional arguments.


### PR DESCRIPTION
structurizr DSL is used in structurizr, which is a tool that allows to
model your software architecture according to the c4 model
(https://c4model.com/)

The default file extension is .dsl but it clashes with an existing (but
non-compatible) filetype.

I've added the following test, but I'm not expert in vimscript:

```vim
" dsl
au BufNewFile,BufRead *.dsl
	\ if getline(1) =~ '^<\!' |
	\   setf dsl |
	\ else |
	\   setf structurizr |
	\ endif
```
we test if the `.dsl` file starts with `<!`, in which case it would be a `dsl` file, otherwise it would be `structurizr`

The language reference can be found here:
https://github.com/structurizr/dsl