### PR TITLE
Renamed dsl syntax and filetype to dsssl.

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -537,8 +537,8 @@ au BufNewFile,BufRead *.drac,*.drc,*lvs,*lpe	setf dracula
 " Datascript
 au BufNewFile,BufRead *.ds			setf datascript
 
-" dsl
-au BufNewFile,BufRead *.dsl			setf dsl
+" dsssl
+au BufNewFile,BufRead *.dsl			setf dsssl
 
 " DTD (Document Type Definition for XML)
 au BufNewFile,BufRead *.dtd			setf dtd

--- a/runtime/syntax/dsssl.vim
+++ b/runtime/syntax/dsssl.vim
@@ -35,4 +35,4 @@ hi def link dslComment		Comment
 " compare the following with xmlCdataStart / xmlCdataEnd
 hi def link dslCondDelim	Type
 
-let b:current_syntax = "dsl"
+let b:current_syntax = "dsssl"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -151,7 +151,7 @@ let s:filename_checks = {
     \ 'dosini': ['.editorconfig', '/etc/pacman.conf', '/etc/yum.conf', 'file.ini', 'npmrc', '.npmrc', 'php.ini', 'php.ini-5', 'php.ini-file', '/etc/yum.repos.d/file', 'any/etc/pacman.conf', 'any/etc/yum.conf', 'any/etc/yum.repos.d/file', 'file.wrap'],
     \ 'dot': ['file.dot', 'file.gv'],
     \ 'dracula': ['file.drac', 'file.drc', 'filelvs', 'filelpe', 'drac.file', 'lpe', 'lvs', 'some-lpe', 'some-lvs'],
-    \ 'dsl': ['file.dsl'],
+    \ 'dsssl': ['file.dsl'],
     \ 'dtd': ['file.dtd'],
     \ 'dts': ['file.dts', 'file.dtsi'],
     \ 'dune': ['jbuild', 'dune', 'dune-project', 'dune-workspace'],


### PR DESCRIPTION
DSSSL stands for Document Style Semantics and Specification Language
(https://en.wikipedia.org/wiki/Document_Style_Semantics_and_Specification_Language)
-- and .dsl is just the file extension associated with it.