### PR TITLE
deleted handing of '%' for environment variables on windows

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1278,11 +1278,7 @@ set_one_cmd_context(
 	}
 
 	// Check for environment variable
-	if (*xp->xp_pattern == '$'
-#if defined(MSWIN)
-		|| *xp->xp_pattern == '%'
-#endif
-		)
+	if (*xp->xp_pattern == '$')
 	{
 	    for (p = xp->xp_pattern + 1; *p != NUL; ++p)
 		if (!vim_isIDc(*p))

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -9,6 +9,10 @@ func Test_complete_tab()
   call writefile(['testfile'], 'Xtestfile')
   call feedkeys(":e Xtest\t\r", "tx")
   call assert_equal('testfile', getline(1))
+
+  " Pressing <Tab> after '%' completes the current file
+  call feedkeys(":e %\t\r", "tx")
+  call assert_equal('e Xtestfile', @:)
   call delete('Xtestfile')
 endfunc
 


### PR DESCRIPTION
When tab expanding commands like `:e <filename>` on Windows, vim tab completes `%` as an environment variable. This prevents tab completion of the `%` as the current file, and also doesn't even work when running the command (the `%` later gets interpreted as the name of the current file anyways).

So for example:
1. User types in `:e %`
2. User presses tab
3. First result is `:e %ALLUSERSPROFILE` - Expected result is `:e current_file`
4. User then completes the environment variable with another `%`, and presses enter
5. Result is the same as doing `:e current_fileALLUSERSPROFILEcurrent_file` - expected result if the environment variable was actually being expanded is the value of `%ALLUSERSPROFILE%`

This PR implements the fix.