### PR TITLE
Update src/INSTALL

### DIFF
--- a/src/INSTALL
+++ b/src/INSTALL
@@ -44,6 +44,7 @@ To build Vim on Ubuntu from scratch on a clean system using git:
 	% sudo apt install git
 	% sudo apt install make
 	% sudo apt install clang
+	% sudo apt install libtool-bin
 	
 	Build Vim with default features:
 	% git clone https://github.com/vim/vim.git


### PR DESCRIPTION
When running `make test` during installation on Ubuntu 20.04 LTS Desktop, we get an error: 
```
bin/sh: 1: libtool: not found
make[1]: *** [Makefile:64: src/encoding.lo] Error 127
make[1]: Leaving directory '/tmp/vim/src/libvterm'
make: *** [Makefile:2313: test_libvterm] Error 2
```
This error can be solved by installing `libtool-bin`.  
So added `sudo apt install libtool-bin` to required install tools.