### PR TITLE
modeline: allow disabling modeline halfway

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -541,6 +541,14 @@ chance that a normal word like "lex:" is caught.  There is one exception:
 version 3.0).  Using "ex:" at the start of the line will be ignored (this
 could be short for "example:").
 
+If modeline is disabled within a modeline, subsequent modelines will be
+ignored. This is to allow turning off modeline on a per-file basis. For
+example, it would be good to prepend a YAML file containing strings like "vim:"
+with
+    # vim: nomodeline ~
+so as to avoid modeline misdetection. Subsequent trailing commands on the same
+line after modeline deactivation, if any, are still evaluated.
+
 							*modeline-local*
 The options are set like with ":setlocal": The new value only applies to the
 buffer and window that contain the file.  Although it's possible to set global

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5446,12 +5446,12 @@ do_modelines(int flags)
 	return;
 
     ++entered;
-    for (lnum = 1; lnum <= curbuf->b_ml.ml_line_count && lnum <= nmlines;
+    for (lnum = 1; curbuf->b_p_ml && lnum <= curbuf->b_ml.ml_line_count && lnum <= nmlines;
 								       ++lnum)
 	if (chk_modeline(lnum, flags) == FAIL)
 	    nmlines = 0;
 
-    for (lnum = curbuf->b_ml.ml_line_count; lnum > 0 && lnum > nmlines
+    for (lnum = curbuf->b_ml.ml_line_count; curbuf->b_p_ml && lnum > 0 && lnum > nmlines
 		       && lnum > curbuf->b_ml.ml_line_count - nmlines; --lnum)
 	if (chk_modeline(lnum, flags) == FAIL)
 	    nmlines = 0;

--- a/src/testdir/test_modeline.vim
+++ b/src/testdir/test_modeline.vim
@@ -362,8 +362,9 @@ endfunc
 
 func Test_modeline_disable()
   set modeline
-  call writefile(['vim: nomodeline: sw=3'], 'Xmodeline_disable')
-  call assert_equal(8, &sw)
+  call writefile(['vim: sw=2', 'vim: nomodeline', 'vim: sw=3'], 'Xmodeline_disable')
+  edit Xmodeline_disable
+  call assert_equal(2, &sw)
   call delete('Xmodeline_disable')
 endfunc
 

--- a/src/testdir/test_modeline.vim
+++ b/src/testdir/test_modeline.vim
@@ -360,4 +360,11 @@ func Test_modeline_diff_buffer()
   bw
 endfunc
 
+func Test_modeline_disable()
+  set modeline
+  call writefile(['vim: nomodeline: sw=3'], 'Xmodeline_disable')
+  call assert_equal(8, &sw)
+  call delete('Xmodeline_disable')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
There is no way to disable modeline on a per-file basis, making it difficult to include literal strings such as `vi:` without triggering warnings. Including `nomodeline` in the modeline has no effect due to the setting being checked only once before proceeding with all modelines.

This commit fixes this and enables modeline to be disabled halfway by checking the setting at each loop iteration.