### PR TITLE
Don't append "(" or "()" to function name in ":disassemble" completion

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -833,13 +833,15 @@ func Test_cmdline_complete_various()
   call assert_equal("\"disas debug", @:)
   call feedkeys(":disas pro\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"disas profile", @:)
+  call feedkeys(":disas Test_cmdline_complete_var\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"disas Test_cmdline_complete_various", @:)
   call feedkeys(":disas debug Test_cmdline_complete_var\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"disas debug Test_cmdline_complete_various", @:)
   call feedkeys(":disas profile Test_cmdline_complete_var\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"disas profile Test_cmdline_complete_various", @:)
 
   call feedkeys(":disas s:WeirdF\<C-A>\<C-B>\"\<CR>", 'xt')
-  call assert_match('"disas <SNR>\d\+_WeirdFunc()', @:)
+  call assert_match('^"disas <SNR>\d\+_WeirdFunc$', @:)
 
   " completion for the :match command
   call feedkeys(":match Search /pat/\<C-A>\<C-B>\"\<CR>", 'xt')

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -4625,7 +4625,8 @@ get_user_func_name(expand_T *xp, int idx)
 	    return fp->uf_name;	// prevents overflow
 
 	cat_func_name(IObuff, fp);
-	if (xp->xp_context != EXPAND_USER_FUNC)
+	if (xp->xp_context != EXPAND_USER_FUNC
+					&& xp->xp_context != EXPAND_DISASSEMBLE)
 	{
 	    STRCAT(IObuff, "(");
 	    if (!has_varargs(fp) && fp->uf_args.ga_len == 0)


### PR DESCRIPTION
**Problem**

When completing a function name as the first argument of `:disassemble`, an unnecessary `(` or `()` is appended to the end of the function name.


**To Reproduce**

1. Run `vim -Nu NONE`.

2. Source this script:

    ```vim
    def Hello(name: string)
      echo 'Hello' name
    enddef
    call feedkeys(":disassemble Hel\<Tab>", 'nt')
    ```
    
    The command-line contains this text:
    
    ```
    :disassemble Hello(
    ```


**Expected behavior**

The command-line contains this text:

```
:disassemble Hello
```

Because the extra `(` is not necessary for executing `:disassemble`:

```vim
def Hello(name: string)
  echo 'Hello' name
enddef
disassemble Hello
```

```
Hello
  echo 'Hello' name
   0 PUSHS "Hello"
   1 LOAD arg[-1]
   2 ECHO 2
   3 RETURN void
```

And maybe for the reason, `(` is not appended when completing as the second argument:

```vim
def Hello(name: string)
  echo 'Hello' name
enddef
call feedkeys(":disassemble debug Hel\<Tab>", 'nt')
```

```
:disassemble debug Hello
```

I think we should do the same thing for the first argument as for the second argument.


**Environment**

- Vim 8.2.3377
- macOS 10.15.7
- iTerm2


**Solution**

Don't append "(" or "()".