### PR TITLE
Make i_CTRL-G_CTRL_G stop ins-completion without changing the match

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -52,6 +52,7 @@ tag		char		action in Insert mode	~
 |i_CTRL-G_k|	CTRL-G <Up>	line up, to column where inserting started
 |i_CTRL-G_u|	CTRL-G u	start new undoable edit
 |i_CTRL-G_U|	CTRL-G U	don't break undo with next cursor movement
+|i_CTRL-G_CTRL-G| CTRL-G CTRL-G	stop |ins-completion| without changing the match
 |i_<BS>|	<BS>		delete character before the cursor
 |i_digraph|	{char1}<BS>{char2}
 				enter digraph (only when 'digraph' option set)

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -390,6 +390,8 @@ CTRL-G u	break undo sequence, start new change	     *i_CTRL-G_u*
 CTRL-G U	don't break undo with next left/right cursor *i_CTRL-G_U*
 		movement, if the cursor stays within the
 		same line
+CTRL-G CTRL-G	stop |ins-completion| without changing the      *i_CTRL-G_CTRL-G*
+		match
 -----------------------------------------------------------------------
 
 Note: If the cursor keys take you out of Insert mode, check the 'noesckeys'
@@ -1311,6 +1313,7 @@ CTRL-E		  End completion, go back to what was there before selecting a
 		  insert it.
 <Space> or <Tab>  Stop completion without changing the match and insert the
 		  typed character.
+CTRL-G CTRL-G	  Stop completion without changing the match.
 
 The behavior of the <Enter> key depends on the state you are in:
 first state:	  Use the text as it is and insert a line break.

--- a/src/edit.c
+++ b/src/edit.c
@@ -3510,6 +3510,10 @@ ins_ctrl_g(void)
 		  dont_sync_undo = MAYBE;
 		  break;
 
+	// CTRL-G CTRL-G: stop ins-completion or i_CTRL-X without inserting or removing text
+	case Ctrl_G:
+		  break;
+
 	// Unknown CTRL-G command, reserved for future expansion.
 	default:  vim_beep(BO_CTRLG);
     }

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -1756,6 +1756,8 @@ func Test_edit_insertmode_esc_beeps()
   set insertmode&
   " unsupported CTRL-G command should beep in insert mode.
   call assert_beeps("normal i\<C-G>l")
+  " CTRL-G CTRL-G should not beep
+  call assert_nobeep("normal i\<C-G>\<C-G>")
   close!
 endfunc
 

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -733,6 +733,47 @@ func Test_complete_cmdline()
   close!
 endfunc
 
+" Test for <CTRL-G> <CTRL-G> stopping completion without changing the match
+func Test_complete_CTRL_G_CTRL_G()
+  new
+  func Save_mode1()
+    let g:mode1 = mode(1)
+    return ''
+  endfunc
+  func Save_mode2()
+    let g:mode2 = mode(1)
+    return ''
+  endfunc
+  inoremap <F1> <C-R>=Save_mode1()<CR>
+  inoremap <F2> <C-R>=Save_mode2()<CR>
+  call setline(1, ['aaa bbb ccc '])
+  exe "normal A\<C-N>\<C-P>\<F1>\<C-G>\<C-G>\<F2>\<Esc>"
+  call assert_equal('ic', g:mode1)
+  call assert_equal('i', g:mode2)
+  call assert_equal('aaa bbb ccc ', getline(1))
+  exe "normal A\<C-N>\<Down>\<F1>\<C-G>\<C-G>\<F2>\<Esc>"
+  call assert_equal('ic', g:mode1)
+  call assert_equal('i', g:mode2)
+  call assert_equal('aaa bbb ccc aaa', getline(1))
+  set completeopt+=noselect
+  exe "normal A \<C-N>\<Down>\<Down>\<C-L>\<C-L>\<F1>\<C-G>\<C-G>\<F2>\<Esc>"
+  call assert_equal('ic', g:mode1)
+  call assert_equal('i', g:mode2)
+  call assert_equal('aaa bbb ccc aaa bb', getline(1))
+  exe "normal A d\<C-N>\<F1>\<C-G>\<C-G>\<F2>\<Esc>"
+  call assert_equal('ic', g:mode1)
+  call assert_equal('i', g:mode2)
+  call assert_equal('aaa bbb ccc aaa bb d', getline(1))
+  set completeopt&
+  unlet g:mode1
+  unlet g:mode2
+  iunmap <F1>
+  iunmap <F2>
+  delfunc Save_mode1
+  delfunc Save_mode2
+  close!
+endfunc
+
 func Test_issue_7021()
   CheckMSWindows
 


### PR DESCRIPTION
This is a result of discussion in #8784. It just prevents `i_CTRL-G_CTRL-G` from beeping as it already stops `ins-completion` or `i_CTRL-X`. Currently I have only added one test as I have some trouble deciding where to put more tests (there are too many functions in `test_popup.vim`). (Are more tests needed?)