### PR TITLE
Escape backslash in fish shell with shellescape()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10111,6 +10111,10 @@ shellescape({string} [, {special}])			*shellescape()*
 		escaped.  When 'shell' containing "csh" in the tail it's
 		escaped a second time.
 
+		The "\" character will be escaped when 'shell' contains "fish"
+		in the tail. That is because for fish "\" is used as an escape
+		character inside single quotes.
+
 		Example of use with a |:!| command: >
 		    :exe '!dir ' . shellescape(expand('<cfile>'), 1)
 <		This results in a directory listing for the file under the

--- a/src/strings.c
+++ b/src/strings.c
@@ -125,6 +125,15 @@ csh_like_shell(void)
 }
 
 /*
+ * Return TRUE when 'shell' has "fish" in the tail.
+ */
+    int
+fish_like_shell(void)
+{
+    return (strstr((char *)gettail(p_sh), "fish") != NULL);
+}
+
+/*
  * Escape "string" for use as a shell argument with system().
  * This uses single quotes, except when we know we need to use double quotes
  * (MS-DOS and MS-Windows not using PowerShell and without 'shellslash' set).
@@ -145,6 +154,7 @@ vim_strsave_shellescape(char_u *string, int do_special, int do_newline)
     char_u	*escaped_string;
     int		l;
     int		csh_like;
+    int		fish_like;
     char_u	*shname;
     int		powershell;
 # ifdef MSWIN
@@ -156,6 +166,10 @@ vim_strsave_shellescape(char_u *string, int do_special, int do_newline)
     // literally.  If do_special is set the '!' will be escaped twice.
     // Csh also needs to have "\n" escaped twice when do_special is set.
     csh_like = csh_like_shell();
+
+    // Fish shell uses '\' as an escape character within single quotes, so '\'
+    // itself must be escaped to get a literal '\'.
+    fish_like = fish_like_shell();
 
     // PowerShell uses it's own version for quoting single quotes
     shname = gettail(p_sh);
@@ -196,6 +210,10 @@ vim_strsave_shellescape(char_u *string, int do_special, int do_newline)
 	{
 	    ++length;			// insert backslash
 	    p += l - 1;
+	}
+	if (*p == '\\' && fish_like)
+	{
+	    ++length;			// insert backslash
 	}
     }
 
@@ -260,6 +278,11 @@ vim_strsave_shellescape(char_u *string, int do_special, int do_newline)
 		while (--l >= 0)	// copy the var
 		    *d++ = *p++;
 		continue;
+	    }
+	    if (*p == '\\' && fish_like)
+	    {
+		*d++ = '\\';
+		*d++ = *p++;
 	    }
 
 	    MB_COPY_CHAR(p, d);

--- a/src/testdir/test_shell.vim
+++ b/src/testdir/test_shell.vim
@@ -61,18 +61,21 @@ func Test_shell_options()
   for e in shells
     exe 'set shell=' .. e[0]
     if e[0] =~# '.*csh$' || e[0] =~# '.*csh.exe$'
-      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' \\!%#'"
-      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\\\!\\%\\#'"
+      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' \\!%# \\'"
+      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\\\!\\%\\# \\'"
     elseif e[0] =~# '.*powershell$' || e[0] =~# '.*powershell.exe$'
           \ || e[0] =~# '.*pwsh$' || e[0] =~# '.*pwsh.exe$'
-      let str1 = "'cmd \"arg1\" ''arg2'' !%#'"
-      let str2 = "'cmd \"arg1\" ''arg2'' \\!\\%\\#'"
+      let str1 = "'cmd \"arg1\" ''arg2'' !%# \\'"
+      let str2 = "'cmd \"arg1\" ''arg2'' \\!\\%\\# \\'"
+    elseif e[0] =~# '.*fish$' || e[0] =~# '.*fish.exe$'
+      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' !%# \\\\'"
+      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\!\\%\\# \\\\'"
     else
-      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' !%#'"
-      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\!\\%\\#'"
+      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' !%# \\'"
+      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\!\\%\\# \\'"
     endif
-    call assert_equal(str1, shellescape("cmd \"arg1\" 'arg2' !%#"), e[0])
-    call assert_equal(str2, shellescape("cmd \"arg1\" 'arg2' !%#", 1), e[0])
+    call assert_equal(str1, shellescape("cmd \"arg1\" 'arg2' !%# \\"), e[0])
+    call assert_equal(str2, shellescape("cmd \"arg1\" 'arg2' !%# \\", 1), e[0])
 
     " Try running an external command with the shell.
     if executable(e[0])


### PR DESCRIPTION
Fish shell uses backslash as an escape character in single quotes, so
the backslash must be escaped in order to produce a literal backslash.
This change modifies the `shellescape()` function to escape backslash in
Fish shell only.

Note that Fish's backslash behavior is a bit odd in that it does what it
thinks you mean. Only `'` really needs to be escaped (`echo '\''` prints
`'`), so if the backslash precedes other characters, it will not be
treated as an escape character (`echo '\a'` prints `\a`). However, all
backslashes within single quotes can safely be escaped because two
consecutive backslashes always produce a single literal backslash
(`echo '\\a'` also prints `\a`).