### PR TITLE
Fixed compilation warning with function fish_like_shell

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -127,7 +127,7 @@ csh_like_shell(void)
 /*
  * Return TRUE when 'shell' has "fish" in the tail.
  */
-    int
+    static int
 fish_like_shell(void)
 {
     return (strstr((char *)gettail(p_sh), "fish") != NULL);


### PR DESCRIPTION
This PR fixes a compilation warning in vim-8.2.3385:
```
clang-12 -c -I. -Iproto -DHAVE_CONFIG_H     -g -O0 -Wall -Wextra -Wshadow -Wmissing-prototypes -Wpedantic -Wunreachable:-code -Wunused-result -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1   -DEXITFREE -DABORT_ON_INTERNAL_ERROR    -o objects/strin:gs.o strings.c                                                                                                        
strings.c:131:1: warning: no previous prototype for function 'fish_like_shell' [-Wmissing-prototypes]
fish_like_shell(void)
^
strings.c:130:5: note: declare 'static' if the function is not intended to be used outside of this translation unit
    int
    ^   
    static
```
