### PR TITLE
Properly escape character after backslash in fish

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -281,6 +281,7 @@ vim_strsave_shellescape(char_u *string, int do_special, int do_newline)
 	    {
 		*d++ = '\\';
 		*d++ = *p++;
+		continue;
 	    }
 
 	    MB_COPY_CHAR(p, d);

--- a/src/testdir/test_shell.vim
+++ b/src/testdir/test_shell.vim
@@ -61,21 +61,21 @@ func Test_shell_options()
   for e in shells
     exe 'set shell=' .. e[0]
     if e[0] =~# '.*csh$' || e[0] =~# '.*csh.exe$'
-      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' \\!%# \\'"
-      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\\\!\\%\\# \\'"
+      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' \\!%# \\'\\'' \\\\! \\% \\#'"
+      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\\\!\\%\\# \\'\\'' \\\\\\! \\\\% \\\\#'"
     elseif e[0] =~# '.*powershell$' || e[0] =~# '.*powershell.exe$'
           \ || e[0] =~# '.*pwsh$' || e[0] =~# '.*pwsh.exe$'
-      let str1 = "'cmd \"arg1\" ''arg2'' !%# \\'"
-      let str2 = "'cmd \"arg1\" ''arg2'' \\!\\%\\# \\'"
+      let str1 = "'cmd \"arg1\" ''arg2'' !%# \\'' \\! \\% \\#'"
+      let str2 = "'cmd \"arg1\" ''arg2'' \\!\\%\\# \\'' \\\\! \\\\% \\\\#'"
     elseif e[0] =~# '.*fish$' || e[0] =~# '.*fish.exe$'
-      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' !%# \\\\'"
-      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\!\\%\\# \\\\'"
+      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' !%# \\\\'\\'' \\\\! \\\\% \\\\#'"
+      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\!\\%\\# \\\\'\\'' \\\\\\! \\\\\\% \\\\\\#'"
     else
-      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' !%# \\'"
-      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\!\\%\\# \\'"
+      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' !%# \\'\\'' \\! \\% \\#'"
+      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\!\\%\\# \\'\\'' \\\\! \\\\% \\\\#'"
     endif
-    call assert_equal(str1, shellescape("cmd \"arg1\" 'arg2' !%# \\"), e[0])
-    call assert_equal(str2, shellescape("cmd \"arg1\" 'arg2' !%# \\", 1), e[0])
+    call assert_equal(str1, shellescape("cmd \"arg1\" 'arg2' !%# \\' \\! \\% \\#"), e[0])
+    call assert_equal(str2, shellescape("cmd \"arg1\" 'arg2' !%# \\' \\! \\% \\#", 1), e[0])
 
     " Try running an external command with the shell.
     if executable(e[0])


### PR DESCRIPTION
I recently added a fix to make `shellescape()` properly escape
backslashes for fish shell (see 6e82351130d, patch 8.2.3385). However,
that fix added a bug where the character following the backslash was
always added to the string as-is, even if it was a special character
that should have been escaped. This change fixes that bug.