### PR TITLE
Set NULL for string result of libcall

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6691,7 +6691,10 @@ libcall_common(typval_T *argvars UNUSED, typval_T *rettv, int type)
 	if (type == VAR_NUMBER)
 	    string_result = NULL;
 	else
+	{
+	    rettv->vval.v_string = NULL;
 	    string_result = &rettv->vval.v_string;
+	}
 	if (mch_libcall(argvars[0].vval.v_string,
 			     argvars[1].vval.v_string,
 			     string_in,


### PR DESCRIPTION
If the function is called via libcall, and returned NULL pointer. Vim possibly free invalid pointer.