### PR TITLE
Add lcs-multispace to show multiple consecutive spaces differently

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4939,16 +4939,24 @@ A jump table for the options with a short description can be found at |Q_op|.
 							*lcs-space*
 	  space:c	Character to show for a space.  When omitted, spaces
 			are left blank.
+							*lcs-multispace*
+	  multispace:c...
+	 		One or more characters to use cyclically to show for
+	 		multiple consecutive spaces.  Overrides the "space"
+			setting.  When omitted, the "space" setting is used.
+			For example, "multispace:---+" shows ten consecutive
+			spaces as:
+				---+---+--
 							*lcs-lead*
 	  lead:c	Character to show for leading spaces.  When omitted,
-			leading spaces are blank.  Overrides the "space"
-			setting for leading spaces.  You can combine it with
-			"tab:", for example: >
+			leading spaces are blank.  Overrides the "space" and
+			"multispace" settings for leading spaces.  You can
+			combine it with "tab:", for example: >
 				:set listchars+=tab:>-,lead:.
 <							*lcs-trail*
 	  trail:c	Character to show for trailing spaces.  When omitted,
-			trailing spaces are blank.  Overrides the "space"
-			setting for trailing spaces.
+			trailing spaces are blank.  Overrides the "space" and
+			"multispace" settings for trailing spaces.
 							*lcs-extends*
 	  extends:c	Character to show in the last column, when 'wrap' is
 			off and the line continues beyond the right of the
@@ -4974,7 +4982,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	    :set lcs=tab:>-,eol:<,nbsp:%
 	    :set lcs=extends:>,precedes:<
 <	The "NonText" highlighting will be used for "eol", "extends" and
-	"precedes".  "SpecialKey" for "nbsp", "space", "tab" and "trail".
+	"precedes".  "SpecialKey" will be used for "tab", "nbsp", "space",
+	"multispace", "lead" and "trail".
 	|hl-NonText| |hl-SpecialKey|
 
 			*'lpl'* *'nolpl'* *'loadplugins'* *'noloadplugins'*

--- a/src/structs.h
+++ b/src/structs.h
@@ -3376,6 +3376,7 @@ typedef struct
     int		tab3;
     int		trail;
     int		lead;
+    int		*multispace;
 #ifdef FEAT_CONCEAL
     int		conceal;
 #endif

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -142,6 +142,93 @@ func Test_listchars()
 
   call assert_equal(expected, split(execute("%list"), "\n"))
 
+  " Test multispace
+  normal ggdG
+  set listchars&
+  set listchars+=multispace:yYzZ
+  set list
+
+  call append(0, [
+	      \ '    ffff    ',
+	      \ '  i i     gg',
+	      \ ' h          ',
+	      \ '          j ',
+	      \ '    0  0    ',
+	      \ ])
+
+  let expected = [
+	      \ 'yYzZffffyYzZ$',
+	      \ 'yYi iyYzZygg$',
+	      \ ' hyYzZyYzZyY$',
+	      \ 'yYzZyYzZyYj $',
+	      \ 'yYzZ0yY0yYzZ$',
+              \ '$'
+	      \ ]
+  redraw!
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+
+  call assert_equal(expected, split(execute("%list"), "\n"))
+
+  " the last occurrence of 'multispace:' is used
+  set listchars+=space:x,multispace:XyY
+
+  let expected = [
+	      \ 'XyYXffffXyYX$',
+	      \ 'XyixiXyYXygg$',
+	      \ 'xhXyYXyYXyYX$',
+	      \ 'XyYXyYXyYXjx$',
+	      \ 'XyYX0Xy0XyYX$',
+              \ '$'
+	      \ ]
+  redraw!
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+
+  call assert_equal(expected, split(execute("%list"), "\n"))
+
+  set listchars+=lead:>,trail:<
+
+  let expected = [
+	      \ '>>>>ffff<<<<$',
+	      \ '>>ixiXyYXygg$',
+	      \ '>h<<<<<<<<<<$',
+	      \ '>>>>>>>>>>j<$',
+	      \ '>>>>0Xy0<<<<$',
+              \ '$'
+	      \ ]
+  redraw!
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+
+  call assert_equal(expected, split(execute("%list"), "\n"))
+
+  " removing 'multispace:'
+  set listchars-=multispace:XyY
+  set listchars-=multispace:yYzZ
+
+  let expected = [
+	      \ '>>>>ffff<<<<$',
+	      \ '>>ixixxxxxgg$',
+	      \ '>h<<<<<<<<<<$',
+	      \ '>>>>>>>>>>j<$',
+	      \ '>>>>0xx0<<<<$',
+              \ '$'
+	      \ ]
+  redraw!
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+
+  call assert_equal(expected, split(execute("%list"), "\n"))
+
   " test nbsp
   normal ggdG
   set listchars=nbsp:X,trail:Y
@@ -191,18 +278,67 @@ func Test_listchars_unicode()
   set encoding=utf-8
   set ff=unix
 
-  set listchars=eol:⇔,space:␣,nbsp:≠,tab:←↔→
+  set listchars=eol:⇔,space:␣,multispace:≡≢≣,nbsp:≠,tab:←↔→
   set list
 
   let nbsp = nr2char(0xa0)
-  call append(0, ["a\tb c" .. nbsp .. "d"])
-  let expected = ['a←↔↔↔↔↔→b␣c≠d⇔']
+  call append(0, ["        a\tb c" .. nbsp .. "d  "])
+  let expected = ['≡≢≣≡≢≣≡≢a←↔↔↔↔↔→b␣c≠d≡≢⇔']
   redraw!
   call cursor(1, 1)
   call assert_equal(expected, ScreenLines(1, virtcol('$')))
+
+  set listchars+=lead:⇨,trail:⇦
+  let expected = ['⇨⇨⇨⇨⇨⇨⇨⇨a←↔↔↔↔↔→b␣c≠d⇦⇦⇔']
+  redraw!
+  call cursor(1, 1)
+  call assert_equal(expected, ScreenLines(1, virtcol('$')))
+
   let &encoding=oldencoding
   enew!
   set listchars& ff&
+endfunction
+
+func Test_listchars_invalid()
+  enew!
+  set ff=unix
+
+  set listchars&
+  set list
+  set ambiwidth=double
+
+  " No colon
+  call assert_fails('set listchars=x', 'E474:')
+  call assert_fails('set listchars=x', 'E474:')
+  call assert_fails('set listchars=multispace', 'E474:')
+
+  " Too short
+  call assert_fails('set listchars=space:', 'E474:')
+  call assert_fails('set listchars=tab:x', 'E474:')
+  call assert_fails('set listchars=multispace:', 'E474:')
+
+  " One occurrence too short
+  call assert_fails('set listchars=space:,space:x', 'E474:')
+  call assert_fails('set listchars=space:x,space:', 'E474:')
+  call assert_fails('set listchars=tab:x,tab:xx', 'E474:')
+  call assert_fails('set listchars=tab:xx,tab:x', 'E474:')
+  call assert_fails('set listchars=multispace:,multispace:x', 'E474:')
+  call assert_fails('set listchars=multispace:x,multispace:', 'E474:')
+
+  " Too long
+  call assert_fails('set listchars=space:xx', 'E474:')
+  call assert_fails('set listchars=tab:xxxx', 'E474:')
+
+  " Has non-single width character
+  call assert_fails('set listchars=space:·', 'E474:')
+  call assert_fails('set listchars=tab:·x', 'E474:')
+  call assert_fails('set listchars=tab:x·', 'E474:')
+  call assert_fails('set listchars=tab:xx·', 'E474:')
+  call assert_fails('set listchars=multispace:·', 'E474:')
+  call assert_fails('set listchars=multispace:xxx·', 'E474:')
+
+  enew!
+  set ambiwidth& listchars& ff&
 endfunction
 
 " Tests that space characters following composing character won't get replaced


### PR DESCRIPTION
This is useful if one doesn't want to show single spaces (around operators or between words) so that it doesn't hinder code (or text) reading, while still wants to be able to show multiple consecutive spaces to make it easier count the number of spaces in a string or something else. I can recall that some other code editors (maybe VSCode) have this feature.