### PR TITLE
ftplugin/markdown: indent footnotes further

### DIFF
--- a/runtime/ftplugin/markdown.vim
+++ b/runtime/ftplugin/markdown.vim
@@ -11,7 +11,7 @@ runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim
 
 setlocal comments=fb:*,fb:-,fb:+,n:> commentstring=<!--%s-->
 setlocal formatoptions+=tcqln formatoptions-=r formatoptions-=o
-setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^[-*+]\\s\\+\\\|^\\[^\\ze[^\\]]\\+\\]:
+setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^[-*+]\\s\\+\\\|^\\[^\[^\\]]\\+\\]:\\&^.\\{4}
 
 if exists('b:undo_ftplugin')
   let b:undo_ftplugin .= "|setl cms< com< fo< flp<"


### PR DESCRIPTION
Currently, the `formatlistpat` regex that applies list indenting to Markdown footnotes ends the match after the first two characters, causing subsequent lines to be indented by only two spaces. Some real-world Markdown implementations (for example, Jekyll in its default configuration) require at least a 4-space indent for subsequent lines to be considered part of the footnote, however.

To fix this, add a second piece to this branch of the regex that matches any four characters at the start of the line. If the existing regex matches, this piece will be what determines the returned match, meaning we can arbitrarily control the indent simply by changing the multi expression of the new piece.  This prevents us from having to add extra redundant branches that only differ in their positioning of a `\ze`.

Here is the same file, wrapped using `gq` (with `ai` set) before and after this change.

Before:
```
[^a]: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dapibus
  ullamcorper euismod. Vivamus purus arcu, porta quis lectus et, tempor
  pulvinar odio. Curabitur posuere magna vel nibh suscipit, nec commodo orci
  pretium. Pellentesque pharetra, quam quis ornare accumsan, velit lorem
  egestas orci, sit amet consectetur arcu lectus pulvinar orci. Etiam aliquam
  nisi nec ante efficitur, ullamcorper ultricies mi cursus. Aliquam urna
  tortor, sodales vel enim eget, accumsan facilisis nisi. Nunc facilisis nisl
  tincidunt eros vehicula, nec blandit odio rhoncus. Mauris quis est vitae quam
  placerat fringilla sit amet id dui. Sed blandit est a purus consequat, eget
  tristique sapien ornare. Donec vitae urna justo.  Etiam eget sem sem. Etiam
  ac nunc vitae neque pellentesque blandit.

[^very-long-footnote-name]: Lorem ipsum dolor sit amet, consectetur adipiscing
  elit. Proin dapibus ullamcorper euismod. Vivamus purus arcu, porta quis
  lectus et, tempor pulvinar odio. Curabitur posuere magna vel nibh suscipit,
  nec commodo orci pretium. Pellentesque pharetra, quam quis ornare accumsan,
  velit lorem egestas orci, sit amet consectetur arcu lectus pulvinar orci.
  Etiam aliquam nisi nec ante efficitur, ullamcorper ultricies mi cursus.
  Aliquam urna tortor, sodales vel enim eget, accumsan facilisis nisi. Nunc
  facilisis nisl tincidunt eros vehicula, nec blandit odio rhoncus. Mauris quis
  est vitae quam placerat fringilla sit amet id dui. Sed blandit est a purus
  consequat, eget tristique sapien ornare. Donec vitae urna justo. Etiam eget
  sem sem. Etiam ac nunc vitae neque pellentesque blandit.
```

After:
```
[^a]: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dapibus
    ullamcorper euismod. Vivamus purus arcu, porta quis lectus et, tempor
    pulvinar odio. Curabitur posuere magna vel nibh suscipit, nec commodo orci
    pretium. Pellentesque pharetra, quam quis ornare accumsan, velit lorem
    egestas orci, sit amet consectetur arcu lectus pulvinar orci. Etiam aliquam
    nisi nec ante efficitur, ullamcorper ultricies mi cursus. Aliquam urna
    tortor, sodales vel enim eget, accumsan facilisis nisi. Nunc facilisis nisl
    tincidunt eros vehicula, nec blandit odio rhoncus. Mauris quis est vitae
    quam placerat fringilla sit amet id dui. Sed blandit est a purus consequat,
    eget tristique sapien ornare. Donec vitae urna justo.  Etiam eget sem sem.
    Etiam ac nunc vitae neque pellentesque blandit.

[^very-long-footnote-name]: Lorem ipsum dolor sit amet, consectetur adipiscing
    elit. Proin dapibus ullamcorper euismod. Vivamus purus arcu, porta quis
    lectus et, tempor pulvinar odio. Curabitur posuere magna vel nibh suscipit,
    nec commodo orci pretium. Pellentesque pharetra, quam quis ornare accumsan,
    velit lorem egestas orci, sit amet consectetur arcu lectus pulvinar orci.
    Etiam aliquam nisi nec ante efficitur, ullamcorper ultricies mi cursus.
    Aliquam urna tortor, sodales vel enim eget, accumsan facilisis nisi. Nunc
    facilisis nisl tincidunt eros vehicula, nec blandit odio rhoncus. Mauris
    quis est vitae quam placerat fringilla sit amet id dui. Sed blandit est a
    purus consequat, eget tristique sapien ornare. Donec vitae urna justo.
    Etiam eget sem sem. Etiam ac nunc vitae neque pellentesque blandit.
```