### PR TITLE
Sort <SNR> functions after others in first argument completion of ":disassemble"

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2262,7 +2262,8 @@ ExpandGeneric(
     {
 	if (xp->xp_context == EXPAND_EXPRESSION
 		|| xp->xp_context == EXPAND_FUNCTIONS
-		|| xp->xp_context == EXPAND_USER_FUNC)
+		|| xp->xp_context == EXPAND_USER_FUNC
+		|| xp->xp_context == EXPAND_DISASSEMBLE)
 	    // <SNR> functions should be sorted to the end.
 	    qsort((void *)*file, (size_t)*num_file, sizeof(char_u *),
 							   sort_func_compare);

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -854,6 +854,11 @@ func Test_cmdline_complete_various()
   call feedkeys(":disas s:WeirdF\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_match('"disas <SNR>\d\+_WeirdFunc', @:)
 
+  call feedkeys(":disas \<S-Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_match('"disas <SNR>\d\+_', @:)
+  call feedkeys(":disas debug \<S-Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_match('"disas debug <SNR>\d\+_', @:)
+
   " completion for the :match command
   call feedkeys(":match Search /pat/\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"match Search /pat/\<C-A>", @:)


### PR DESCRIPTION
**Problem**

`<SNR>` functions are sorted - before - others in the first argument completion of `:disassemble`.


**To Reproduce**

1. Run `vim -Nu NONE`.

1. `:source` this script:

    ```vim
    vim9script
    for scope in 'gs' | for name in 'ABC'
      execute printf('def %s:%s()', scope, name)
      enddef
    endfor | endfor
    feedkeys(":disassemble \<C-a>", 'nt')
    ```

    The command-line contains this text:

    ```
    :disassemble <SNR>1_A <SNR>1_B <SNR>1_C A B C debug profile
    ```


**Expected behavior**

`<SNR>` functinon are sorted - after - others; i.e. the command-line contains this text:

```
:disassemble A B C debug profile <SNR>1_A <SNR>1_B <SNR>1_C
```

Because they are sorted that way for the second argument:

```vim
vim9script
for scope in 'gs' | for name in 'ABC'
  execute printf('def %s:%s()', scope, name)
  enddef
endfor | endfor
feedkeys(":disassemble debug \<C-a>", 'nt')
```

```
:disassemble debug A B C <SNR>1_A <SNR>1_B <SNR>1_C
```

Also this sorting rule can be seen when completing for `:function` and `:delfunction`:

```vim
vim9script
for scope in 'gs' | for name in 'ABC'
  execute printf('def %s:%s()', scope, name)
  enddef
endfor | endfor
feedkeys(":function \<C-a>", 'nt')
```

```
:function A B C <SNR>1_A <SNR>1_B <SNR>1_C
```

```vim
vim9script
for scope in 'gs' | for name in 'ABC'
  execute printf('def %s:%s()', scope, name)
  enddef
endfor | endfor
feedkeys(":delfunction \<C-a>", 'nt')
```

```
:delfunction A B C <SNR>1_A <SNR>1_B <SNR>1_C
```

It would be more consistent if we do the same for the first argument of `:disassemble`.


**Environment**

- Vim 8.2.3416
- macOS 10.15.7
- iTerm2


**Solution**

Sort `<SNR>` functions after others like in the other completions.
