### PR TITLE
`i_CTRL-^` to toggle input method was not tested

### DIFF
--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -2037,6 +2037,8 @@ endfunc
 " Test toggling of input method. See :help i_CTRL-^
 func Test_edit_CTRL_hat()
   CheckFeature xim
+  CheckNotGui " FIXME: why does this test fail when running in the GUI?
+
   new
 
   call assert_equal(0, &iminsert)

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -2034,4 +2034,18 @@ func Test_mode_changes()
   unlet! g:i_to_any
 endfunc
 
+" Test toggling of input method. See :help i_CTRL-^
+func Test_edit_CTRL_hat()
+  CheckFeature xim
+  new
+
+  call assert_equal(0, &iminsert)
+  call feedkeys("i\<C-^>", 'xt')
+  call assert_equal(2, &iminsert)
+  call feedkeys("i\<C-^>", 'xt')
+  call assert_equal(0, &iminsert)
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
`i_CTRL-^` to toggle input method was not tested.

Test added in PR should cover these lines:
https://codecov.io/gh/vim/vim/src/464393a6961d9b9de2bfe9c05f8e2ae5bdec0293/src/edit.c#L3545