### PR TITLE
Remove Test_geometry

### DIFF
--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -508,38 +508,6 @@ func Test_font()
   call delete('Xtest_font')
 endfunc
 
-" Test the -geometry argument (for GUI only).
-func Test_geometry()
-  CheckCanRunGui
-  CheckAnyOf Feature:gui_gtk Feature:gui_motif Feature:gui_athena
-
-  if has('gui_motif') || has('gui_athena')
-    " FIXME: With GUI Athena or Motif, the value of getwinposx(),
-    "        getwinposy() and getwinpos() do not match exactly the
-    "        value given in -geometry. Why?
-    "        So only check &columns and &lines for those GUIs.
-    let after =<< trim [CODE]
-      call writefile([&columns, &lines], "Xtest_geometry")
-      qall
-    [CODE]
-    if RunVim([], after, '-f -g -geometry 31x13+41+43')
-      let lines = readfile('Xtest_geometry')
-      call assert_equal(['31', '13'], lines)
-    endif
-  else
-    let after =<< trim [CODE]
-      call writefile([&columns, &lines, getwinposx(), getwinposy(), string(getwinpos())], "Xtest_geometry")
-      qall
-    [CODE]
-    if RunVim([], after, '-f -g -geometry 31x13+41+43')
-      let lines = readfile('Xtest_geometry')
-      call assert_equal(['31', '13', '41', '43', '[41, 43]'], lines)
-    endif
-  endif
-
-  call delete('Xtest_geometry')
-endfunc
-
 " Test the -iconic argument (for GUI only).
 func Test_iconic()
   CheckCanRunGui

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -508,6 +508,38 @@ func Test_font()
   call delete('Xtest_font')
 endfunc
 
+" Test the -geometry argument (for GUI only).
+func Test_geometry()
+  CheckCanRunGui
+  CheckAnyOf Feature:gui_gtk Feature:gui_motif Feature:gui_athena
+
+  if has('gui_motif') || has('gui_athena')
+    " FIXME: With GUI Athena or Motif, the value of getwinposx(),
+    "        getwinposy() and getwinpos() do not match exactly the
+    "        value given in -geometry. Why?
+    "        So only check &columns and &lines for those GUIs.
+    let after =<< trim [CODE]
+      call writefile([&columns, &lines], "Xtest_geometry")
+      qall
+    [CODE]
+    if RunVim([], after, '-f -g -geometry 31x13+41+43')
+      let lines = readfile('Xtest_geometry')
+      call assert_equal(['31', '13'], lines)
+    endif
+  else
+    let after =<< trim [CODE]
+      call writefile([&columns, &lines, getwinposx(), getwinposy(), string(getwinpos())], "Xtest_geometry")
+      qall
+    [CODE]
+    if RunVim([], after, '-f -g -geometry 31x13+41+43')
+      let lines = readfile('Xtest_geometry')
+      call assert_equal(['31', '13', '41', '43', '[41, 43]'], lines)
+    endif
+  endif
+
+  call delete('Xtest_geometry')
+endfunc
+
 " Test the -iconic argument (for GUI only).
 func Test_iconic()
   CheckCanRunGui


### PR DESCRIPTION
Problem: Requests for X size and position are unreliable.
Solution: Avoid too-precise testing for -geometry flag. Closes #8815