### PR TITLE
Fix Windows build warnings

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4924,7 +4924,7 @@ set_chars_option(win_T *wp, char_u **varp)
 
 	    if (i == entries)
 	    {
-		len = STRLEN("multispace");
+		len = (int)STRLEN("multispace");
 		if ((varp == &p_lcs || varp == &wp->w_p_lcs)
 			&& STRNCMP(p, "multispace", len) == 0
 			&& p[len] == ':'

--- a/src/xdiff/xemit.c
+++ b/src/xdiff/xemit.c
@@ -31,7 +31,7 @@ static long xdl_get_rec(xdfile_t *xdf, long ri, char const **rec) {
 
 
 static int xdl_emit_record(xdfile_t *xdf, long ri, char const *pre, xdemitcb_t *ecb) {
-	long size, psize = strlen(pre);
+	long size, psize = (long)strlen(pre);
 	char const *rec;
 
 	size = xdl_get_rec(xdf, ri, &rec);

--- a/src/xdiff/xutils.c
+++ b/src/xdiff/xutils.c
@@ -47,7 +47,7 @@ int xdl_emit_diffrec(char const *rec, long size, char const *pre, long psize,
 	mb[1].size = size;
 	if (size > 0 && rec[size - 1] != '\n') {
 		mb[2].ptr = (char *) "\n\\ No newline at end of file\n";
-		mb[2].size = strlen(mb[2].ptr);
+		mb[2].size = (long)strlen(mb[2].ptr);
 		i++;
 	}
 	if (ecb->out_line(ecb->priv, mb, i) < 0) {


### PR DESCRIPTION
Resolve warnings for conversions of size_t to int or long.