### PR TITLE
quote the expansion of %~dpf0 in vimtutor

### DIFF
--- a/vimtutor.bat
+++ b/vimtutor.bat
@@ -11,7 +11,7 @@
 
 :: Use Vim to copy the tutor, it knows the value of $VIMRUNTIME
 FOR %%d in (. %TMP% %TEMP%) DO (
-    call :test_dir_writable %~dpf0 %%d
+    call :test_dir_writable "%~dpf0" %%d
     IF NOT ERRORLEVEL 1 GOTO dir_ok
 )
 


### PR DESCRIPTION

else the expansion will fail if the path of Vim contains spaces like in the default: `c:\Program Files\Vim\vim82`

and running vimtutor will return:
```
C:\windows\system32>vimtutor.bat
No working directory is found       
```