### PR TITLE
use nanosecond resolution mtime to detect file changes

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -13149,6 +13149,51 @@ if test "x$vim_cv_stat_ignores_slash" = "xyes" ; then
 
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for nanoseconds field of struct stat" >&5
+$as_echo_n "checking for nanoseconds field of struct stat... " >&6; }
+if ${ac_cv_struct_st_mtim_nsec+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_save_CPPFLAGS="$CPPFLAGS"
+   ac_cv_struct_st_mtim_nsec=no
+   # st_mtim.tv_nsec          -- the usual case
+   # st_mtim._tv_nsec         -- Solaris 2.6, if
+   #	(defined _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED == 1
+   #	 && !defined __EXTENSIONS__)
+   # st_mtim.st__tim.tv_nsec   -- UnixWare 2.1.2
+   # st_mtimespec.tv_nsec     -- 4.4BSD, FreeBSD, NetBSD, OpenBSD, etc.
+   for ac_val in st_mtim.tv_nsec st_mtim._tv_nsec st_mtim.st__tim.tv_nsec st_mtimespec.tv_nsec; do
+     CPPFLAGS="$ac_save_CPPFLAGS -DST_MTIM_NSEC=$ac_val"
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <sys/types.h>
+#include <sys/stat.h>
+int
+main ()
+{
+struct stat s; s.ST_MTIM_NSEC;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_struct_st_mtim_nsec=$ac_val; break
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+   done
+   CPPFLAGS="$ac_save_CPPFLAGS"
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_struct_st_mtim_nsec" >&5
+$as_echo "$ac_cv_struct_st_mtim_nsec" >&6; }
+if test $ac_cv_struct_st_mtim_nsec != no; then
+
+cat >>confdefs.h <<_ACEOF
+#define ST_MTIM_NSEC $ac_cv_struct_st_mtim_nsec
+_ACEOF
+
+fi
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for iconv_open()" >&5
 $as_echo_n "checking for iconv_open()... " >&6; }
 save_LIBS="$LIBS"

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -13156,13 +13156,14 @@ if ${ac_cv_struct_st_mtim_nsec+:} false; then :
 else
   ac_save_CPPFLAGS="$CPPFLAGS"
    ac_cv_struct_st_mtim_nsec=no
-   # st_mtim.tv_nsec          -- the usual case
-   # st_mtim._tv_nsec         -- Solaris 2.6, if
+   # st_mtim.tv_nsec -- the usual case
+   # st_mtim._tv_nsec -- Solaris 2.6, if
    #	(defined _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED == 1
    #	 && !defined __EXTENSIONS__)
-   # st_mtim.st__tim.tv_nsec   -- UnixWare 2.1.2
-   # st_mtimespec.tv_nsec     -- 4.4BSD, FreeBSD, NetBSD, OpenBSD, etc.
-   for ac_val in st_mtim.tv_nsec st_mtim._tv_nsec st_mtim.st__tim.tv_nsec st_mtimespec.tv_nsec; do
+   # st_mtim.st__tim.tv_nsec -- UnixWare 2.1.2
+   # st_mtime_n -- AIX 5.2 and above
+   # st_mtimespec.tv_nsec -- Darwin (Mac OSX)
+   for ac_val in st_mtim.tv_nsec st_mtim._tv_nsec st_mtim.st__tim.tv_nsec st_mtime_n st_mtimespec.tv_nsec; do
      CPPFLAGS="$ac_save_CPPFLAGS -DST_MTIM_NSEC=$ac_val"
      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -527,7 +527,11 @@ buf_write_bytes(struct bw_info *ip)
 check_mtime(buf_T *buf, stat_T *st)
 {
     if (buf->b_mtime_read != 0
-	    && time_differs((long)st->st_mtime, buf->b_mtime_read))
+	    && (time_differs((long)st->st_mtime, buf->b_mtime_read)
+#ifdef ST_MTIM_NSEC
+	        || st->ST_MTIM_NSEC != buf->b_mtime_read_ns
+#endif
+               ))
     {
 	msg_scroll = TRUE;	    // don't overwrite messages here
 	msg_silent = 0;		    // must give this prompt
@@ -2558,6 +2562,7 @@ nofail:
 	    {
 		buf_store_time(buf, &st_old, fname);
 		buf->b_mtime_read = buf->b_mtime;
+		buf->b_mtime_read_ns = buf->b_mtime_ns;
 	    }
 	}
     }

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -144,6 +144,9 @@
 /* Define if stat() ignores a trailing slash */
 #undef STAT_IGNORES_SLASH
 
+/* Define to nanoseconds field of struct stat */
+#undef ST_MTIM_NSEC
+
 /* Define if tgetstr() has a second argument that is (char *) */
 #undef TGETSTR_CHAR_P
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3843,6 +3843,30 @@ main() {struct stat st;  exit(stat("configure/", &st) != 0); }
 if test "x$vim_cv_stat_ignores_slash" = "xyes" ; then
   AC_DEFINE(STAT_IGNORES_SLASH)
 fi
+
+dnl nanoseconds field of struct stat
+AC_CACHE_CHECK([for nanoseconds field of struct stat],
+  ac_cv_struct_st_mtim_nsec,
+  [ac_save_CPPFLAGS="$CPPFLAGS"
+   ac_cv_struct_st_mtim_nsec=no
+   # st_mtim.tv_nsec          -- the usual case
+   # st_mtim._tv_nsec         -- Solaris 2.6, if
+   #	(defined _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED == 1
+   #	 && !defined __EXTENSIONS__)
+   # st_mtim.st__tim.tv_nsec   -- UnixWare 2.1.2
+   # st_mtimespec.tv_nsec     -- 4.4BSD, FreeBSD, NetBSD, OpenBSD, etc.
+   for ac_val in st_mtim.tv_nsec st_mtim._tv_nsec st_mtim.st__tim.tv_nsec st_mtimespec.tv_nsec; do
+     CPPFLAGS="$ac_save_CPPFLAGS -DST_MTIM_NSEC=$ac_val"
+     AC_TRY_COMPILE([#include <sys/types.h>
+#include <sys/stat.h>], [struct stat s; s.ST_MTIM_NSEC;],
+       [ac_cv_struct_st_mtim_nsec=$ac_val; break])
+   done
+   CPPFLAGS="$ac_save_CPPFLAGS"
+])
+if test $ac_cv_struct_st_mtim_nsec != no; then
+  AC_DEFINE_UNQUOTED([ST_MTIM_NSEC], [$ac_cv_struct_st_mtim_nsec],
+  [Define if struct stat contains a nanoseconds field])
+fi
   
 dnl Link with iconv for charset translation, if not found without library.
 dnl check for iconv() requires including iconv.h

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3849,13 +3849,14 @@ AC_CACHE_CHECK([for nanoseconds field of struct stat],
   ac_cv_struct_st_mtim_nsec,
   [ac_save_CPPFLAGS="$CPPFLAGS"
    ac_cv_struct_st_mtim_nsec=no
-   # st_mtim.tv_nsec          -- the usual case
-   # st_mtim._tv_nsec         -- Solaris 2.6, if
+   # st_mtim.tv_nsec -- the usual case
+   # st_mtim._tv_nsec -- Solaris 2.6, if
    #	(defined _XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED == 1
    #	 && !defined __EXTENSIONS__)
-   # st_mtim.st__tim.tv_nsec   -- UnixWare 2.1.2
-   # st_mtimespec.tv_nsec     -- 4.4BSD, FreeBSD, NetBSD, OpenBSD, etc.
-   for ac_val in st_mtim.tv_nsec st_mtim._tv_nsec st_mtim.st__tim.tv_nsec st_mtimespec.tv_nsec; do
+   # st_mtim.st__tim.tv_nsec -- UnixWare 2.1.2
+   # st_mtime_n -- AIX 5.2 and above
+   # st_mtimespec.tv_nsec -- Darwin (Mac OSX)
+   for ac_val in st_mtim.tv_nsec st_mtim._tv_nsec st_mtim.st__tim.tv_nsec st_mtime_n st_mtimespec.tv_nsec; do
      CPPFLAGS="$ac_save_CPPFLAGS -DST_MTIM_NSEC=$ac_val"
      AC_TRY_COMPILE([#include <sys/types.h>
 #include <sys/stat.h>], [struct stat s; s.ST_MTIM_NSEC;],

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4194,10 +4194,12 @@ buf_check_timestamp(
 			mesg2 = _("See \":help W16\" for more info.");
 		    }
 		    else
+		    {
 			// Only timestamp changed, store it to avoid a warning
 			// in check_mtime() later.
 			buf->b_mtime_read = buf->b_mtime;
 			buf->b_mtime_read_ns = buf->b_mtime_ns;
+		    }
 		}
 	    }
 	}

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -408,6 +408,7 @@ readfile(
 	{
 	    buf_store_time(curbuf, &st, fname);
 	    curbuf->b_mtime_read = curbuf->b_mtime;
+	    curbuf->b_mtime_read_ns = curbuf->b_mtime_ns;
 	    filesize_disk = st.st_size;
 #ifdef UNIX
 	    /*
@@ -434,6 +435,7 @@ readfile(
 	    curbuf->b_mtime = 0;
 	    curbuf->b_mtime_ns = 0;
 	    curbuf->b_mtime_read = 0;
+	    curbuf->b_mtime_read_ns = 0;
 	    curbuf->b_orig_size = 0;
 	    curbuf->b_orig_mode = 0;
 	}
@@ -2570,6 +2572,7 @@ failed:
 	{
 	    buf_store_time(curbuf, &st, fname);
 	    curbuf->b_mtime_read = curbuf->b_mtime;
+	    curbuf->b_mtime_read_ns = curbuf->b_mtime_ns;
 	}
 #endif
     }
@@ -4194,6 +4197,7 @@ buf_check_timestamp(
 			// Only timestamp changed, store it to avoid a warning
 			// in check_mtime() later.
 			buf->b_mtime_read = buf->b_mtime;
+			buf->b_mtime_read_ns = buf->b_mtime_ns;
 		}
 	    }
 	}

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -432,6 +432,7 @@ readfile(
 	else
 	{
 	    curbuf->b_mtime = 0;
+	    curbuf->b_mtime_ns = 0;
 	    curbuf->b_mtime_read = 0;
 	    curbuf->b_orig_size = 0;
 	    curbuf->b_orig_mode = 0;
@@ -4073,6 +4074,9 @@ buf_check_timestamp(
 	    && buf->b_mtime != 0
 	    && ((stat_res = mch_stat((char *)buf->b_ffname, &st)) < 0
 		|| time_differs((long)st.st_mtime, buf->b_mtime)
+#ifdef ST_MTIM_NSEC
+		|| (long)st.ST_MTIM_NSEC != buf->b_mtime_ns
+#endif
 		|| st.st_size != buf->b_orig_size
 #ifdef HAVE_ST_MODE
 		|| (int)st.st_mode != buf->b_orig_mode
@@ -4468,6 +4472,11 @@ buf_reload(buf_T *buf, int orig_mode)
 buf_store_time(buf_T *buf, stat_T *st, char_u *fname UNUSED)
 {
     buf->b_mtime = (long)st->st_mtime;
+#ifdef ST_MTIM_NSEC
+    buf->b_mtime_ns = (long)st->ST_MTIM_NSEC;
+#else
+    buf->b_mtime_ns = 0;
+#endif
     buf->b_orig_size = st->st_size;
 #ifdef HAVE_ST_MODE
     buf->b_orig_mode = (int)st->st_mode;

--- a/src/memline.c
+++ b/src/memline.c
@@ -1032,6 +1032,7 @@ set_b0_fname(ZERO_BL *b0p, buf_T *buf)
 #endif
 	    buf_store_time(buf, &st, buf->b_ffname);
 	    buf->b_mtime_read = buf->b_mtime;
+	    buf->b_mtime_read_ns = buf->b_mtime_ns;
 	}
 	else
 	{
@@ -1042,6 +1043,7 @@ set_b0_fname(ZERO_BL *b0p, buf_T *buf)
 	    buf->b_mtime = 0;
 	    buf->b_mtime_ns = 0;
 	    buf->b_mtime_read = 0;
+	    buf->b_mtime_read_ns = 0;
 	    buf->b_orig_size = 0;
 	    buf->b_orig_mode = 0;
 	}
@@ -2438,6 +2440,9 @@ ml_sync_all(int check_file, int check_char)
 	     */
 	    if (mch_stat((char *)buf->b_ffname, &st) == -1
 		    || st.st_mtime != buf->b_mtime_read
+#ifdef ST_MTIM_NSEC
+		    || st.ST_MTIM_NSEC != buf->b_mtime_read_ns
+#endif
 		    || st.st_size != buf->b_orig_size)
 	    {
 		ml_preserve(buf, FALSE);

--- a/src/memline.c
+++ b/src/memline.c
@@ -1040,6 +1040,7 @@ set_b0_fname(ZERO_BL *b0p, buf_T *buf)
 	    long_to_char(0L, b0p->b0_ino);
 #endif
 	    buf->b_mtime = 0;
+	    buf->b_mtime_ns = 0;
 	    buf->b_mtime_read = 0;
 	    buf->b_orig_size = 0;
 	    buf->b_orig_mode = 0;

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -1760,7 +1760,10 @@ nb_do_cmd(
 	    if (buf == NULL || buf->bufp == NULL)
 		nbdebug(("    invalid buffer identifier in setModtime\n"));
 	    else
+	    {
 		buf->bufp->b_mtime = atoi((char *)args);
+		buf->bufp->b_mtime_ns = 0;
+	    }
 // =====================================================================
 	}
 	else if (streq((char *)cmd, "setReadOnly"))

--- a/src/structs.h
+++ b/src/structs.h
@@ -2725,6 +2725,7 @@ struct file_buffer
     long	b_mtime;	// last change time of original file
     long	b_mtime_ns;	// nanoseconds of last change time
     long	b_mtime_read;	// last change time when reading
+    long	b_mtime_read_ns;  // nanoseconds of last read time
     off_T	b_orig_size;	// size of original file in bytes
     int		b_orig_mode;	// mode of original file
 #ifdef FEAT_VIMINFO

--- a/src/structs.h
+++ b/src/structs.h
@@ -2723,6 +2723,7 @@ struct file_buffer
     wininfo_T	*b_wininfo;	// list of last used info for each window
 
     long	b_mtime;	// last change time of original file
+    long	b_mtime_ns;	// nanoseconds of last change time
     long	b_mtime_read;	// last change time when reading
     off_T	b_orig_size;	// size of original file in bytes
     int		b_orig_mode;	// mode of original file

--- a/src/testdir/test_stat.vim
+++ b/src/testdir/test_stat.vim
@@ -76,6 +76,35 @@ func Test_checktime()
   call delete(fname)
 endfunc
 
+func Test_checktime_fast()
+  let fname = 'Xtest.tmp'
+
+  let fl = ['Hello World!']
+  call writefile(fl, fname)
+  set autoread
+  exec 'e' fname
+  let fl = readfile(fname)
+  let fl[0] .= ' - checktime'
+  call writefile(fl, fname)
+  checktime
+  call assert_equal(fl[0], getline(1))
+
+  call delete(fname)
+endfunc
+
+func Test_autoread_fast()
+  new Xautoread
+  set autoread
+  call setline(1, 'foo')
+
+  w!
+  silent !echo bar > Xautoread
+  checktime
+
+  call assert_equal('bar', trim(getline(1)))
+  call delete('Xautoread')
+endfunc
+
 func Test_autoread_file_deleted()
   new Xautoread
   set autoread


### PR DESCRIPTION
This addresses issue #8873.

The autoconf test is stolen from GNU make.

time_differs only has 2s resolution on Windows and Linux(!), but on Linux the nanoseconds are very likely to differ between two writes.  On Linux, the nanoseconds are 0 for FAT mtime.