### PR TITLE
Normalize result to -1/0/1 by compare function of sort.

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -1951,8 +1951,6 @@ item_compare2(const void *s1, const void *s2)
 	    res = 1;
 	else if (res < 0)
 	    res = -1;
-	else
-	    res = 0;
     }
     if (sortinfo->item_compare_func_err)
 	res = ITEM_COMPARE_FAIL;  // return value has wrong type

--- a/src/list.c
+++ b/src/list.c
@@ -1945,7 +1945,15 @@ item_compare2(const void *s1, const void *s2)
     if (res == FAIL)
 	res = ITEM_COMPARE_FAIL;
     else
+    {
 	res = (int)tv_get_number_chk(&rettv, &sortinfo->item_compare_func_err);
+	if (res > 0)
+	    res = 1;
+	else if (res < 0)
+	    res = -1;
+	else
+	    res = 0;
+    }
     if (sortinfo->item_compare_func_err)
 	res = ITEM_COMPARE_FAIL;  // return value has wrong type
     clear_tv(&rettv);

--- a/src/testdir/test_sort.vim
+++ b/src/testdir/test_sort.vim
@@ -58,6 +58,7 @@ endfunc
 func Test_sort_numbers()
   call assert_equal([3, 13, 28], sort([13, 28, 3], 'N'))
   call assert_equal(['3', '13', '28'], sort(['13', '28', '3'], 'N'))
+  call assert_equal([3997, 4996], sort([4996, 3997], 'Compare1'))
 endfunc
 
 func Test_sort_float()


### PR DESCRIPTION
This sort function always be failed since the number 999 is reserved for `ITEM_COMPARE_FAIL`.

```vim
function s:comp(lhs, rhs) abort
  return a:lhs - a:rhs
endfunction

echo sort([4995, 3996], 's:comp')
```