### PR TITLE
Fix undefined variable with csscomplete.vim

### DIFF
--- a/runtime/autoload/csscomplete.vim
+++ b/runtime/autoload/csscomplete.vim
@@ -38,12 +38,12 @@ function! csscomplete#CompleteCSS(findstart, base)
   if exists("b:compl_context")
     let line = getline('.')
     let compl_begin = col('.') - 2
-    let after = line[compl_begin:]
+    let b:after = line[compl_begin:]
     let line = b:compl_context
     unlet! b:compl_context
   else
     let line = a:base
-    let after = ''
+    let b:after = ''
   endif
 
   let res = []


### PR DESCRIPTION
This plugin defines a `after` variable but [reads `b:after` later on](https://github.com/vim/vim/blob/820d5525cae707f39571c6abc2aa6a9e66ed171e/runtime/autoload/csscomplete.vim#L708) which causes crashes in rare occurrences.

To be fair I cannot repro it without a carefully crafted selection of `vimrc` settings and autocomplete plugins, and an input that consists into typing `@import "x` where `x` is the first letter of a file that's in the current directory.

That being said this patch do fix the issue and it should be clear from looking at the source of this plugin that the `after` variable is defined without ever being used while `b:after` is read without being defined.

Note that the opposite patch works too, e.g. leaving those 2 lines alone but replacing `if b:after =~? '"'` by `if after =~? '"'` later on. If that makes more sense I'll be happy to update this PR.

Cheers!