### PR TITLE
Change K&R style function declaration to ANSI style

### DIFF
--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -96,11 +96,11 @@
 #ifdef SIGHASARG
 # ifdef SIGHAS3ARGS
 #  define SIGPROTOARG	(int, int, struct sigcontext *)
-#  define SIGDEFARG(s)	(s, sig2, scont) int s, sig2; struct sigcontext *scont;
+#  define SIGDEFARG(s)	(int s, int sig2, struct sigcontext *scont)
 #  define SIGDUMMYARG	0, 0, (struct sigcontext *)0
 # else
 #  define SIGPROTOARG	(int)
-#  define SIGDEFARG(s)	(s) int s UNUSED;
+#  define SIGDEFARG(s)	(int s UNUSED)
 #  define SIGDUMMYARG	0
 # endif
 #else


### PR DESCRIPTION

Building Vim with "-std=c2x" results in warnings about K&R style declaration in os_unix.h