### PR TITLE
Updated gprof ftplugin

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -545,6 +545,14 @@ One command, :DiffGitCached, is provided to show a diff of the current commit
 in the preview window.  It is equivalent to calling "git diff --cached" plus
 any arguments given to the command.
 
+GPROF
+
+The gprof filetype plugin defines a mapping <C-]> to jump from a function
+entry in the gprof flat profile or from a function entry in the call graph
+to the details of that function in the call graph.
+
+The mapping can be disabled with: >
+	let g:no_gprof_maps = 1
 
 MAIL							*ft-mail-plugin*
 

--- a/runtime/ftplugin/gprof.vim
+++ b/runtime/ftplugin/gprof.vim
@@ -1,6 +1,7 @@
-" Language:    gprof
-" Maintainer:  Dominique Pelle <dominique.pelle@gmail.com>
-" Last Change: 2021 Apr 08
+" Language:     gprof
+" Maintainer:   Dominique Pelle <dominique.pelle@gmail.com>
+" Contributors: Doug Kearns <dougkearns@gmail.com>
+" Last Change:  2021 Sep 19
 
 " When cursor is on one line of the gprof call graph,
 " calling this function jumps to this function in the call graph.
@@ -9,7 +10,7 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin=1
 
-fun! <SID>GprofJumpToFunctionIndex()
+func! <SID>GprofJumpToFunctionIndex()
   let l:line = getline('.')
   if l:line =~ '[\d\+\]$'
     " We're in a line in the call graph.
@@ -22,11 +23,14 @@ fun! <SID>GprofJumpToFunctionIndex()
     call search('^\[\d\+\].*\d\s\+' .  escape(@", '[]*.') . '\>', 'sW')
     norm! zz
   endif
-endfun
+endfunc
 
-" Pressing <C-]> on a line in the gprof flat profile or in
-" the call graph, jumps to the corresponding function inside
-" the flat profile.
-map <buffer> <silent> <C-]> :call <SID>GprofJumpToFunctionIndex()<CR>
+if !exists("no_plugin_maps") && !exists("no_gprof_maps")
+  " Pressing <C-]> on a line in the gprof flat profile or in
+  " the call graph, jumps to the corresponding function inside
+  " the flat profile.
+  map <buffer> <silent> <C-]> :call <SID>GprofJumpToFunctionIndex()<CR>
+  let b:undo_ftplugin = "silent! unmap <buffer> <C-]>"
+endif
 
 " vim:sw=2 fdm=indent

--- a/runtime/syntax/gprof.vim
+++ b/runtime/syntax/gprof.vim
@@ -1,15 +1,16 @@
 " Vim syntax file
 " Language: Syntax for Gprof Output
 " Maintainer: Dominique Pelle <dominique.pelle@gmail.com>
-" Last Change: 2021 Apr 08
+" Last Change: 2021 Sep 19
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
-	finish
+  finish
 endif
 let s:keepcpo= &cpo
 set cpo&vim
 
+syn spell notoplevel
 syn case match
 syn sync minlines=100
 


### PR DESCRIPTION
- turn spelling off as it does not make sense in a gprof file
- gprof ftplugin was not setting b:undo_ftplugin (kudos to Doug Kearns)
- document gprof ftplugin in runtime/doc/filetype.txt