### PR TITLE
refactor: remove redundant casts with help of clang-tidy

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -386,7 +386,7 @@ au_cleanup(void)
 	return;
 
     // loop over all events
-    for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+    for (event = (event_T)0; (int)event < NUM_EVENTS;
 					    event = (event_T)((int)event + 1))
     {
 	// loop over all autocommand patterns
@@ -460,7 +460,7 @@ aubuflocal_remove(buf_T *buf)
 	    apc->arg_bufnr = 0;
 
     // invalidate buflocals looping through events
-    for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+    for (event = (event_T)0; (int)event < NUM_EVENTS;
 					    event = (event_T)((int)event + 1))
 	// loop over all autocommand patterns
 	FOR_ALL_AUTOCMD_PATTERNS(event, ap)
@@ -523,7 +523,7 @@ au_del_group(char_u *name)
 	AutoPat	*ap;
 	int	in_use = FALSE;
 
-	for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+	for (event = (event_T)0; (int)event < NUM_EVENTS;
 					    event = (event_T)((int)event + 1))
 	{
 	    FOR_ALL_AUTOCMD_PATTERNS(event, ap)
@@ -695,7 +695,7 @@ find_end_event(
     {
 	for (pat = arg; *pat && *pat != '|' && !VIM_ISWHITE(*pat); pat = p)
 	{
-	    if ((int)event_name2nr(pat, &p) >= (int)NUM_EVENTS)
+	    if ((int)event_name2nr(pat, &p) >= NUM_EVENTS)
 	    {
 		if (have_group)
 		    semsg(_("E216: No such event: %s"), pat);
@@ -967,7 +967,7 @@ do_autocmd(exarg_T *eap, char_u *arg_in, int forceit)
 	if (!forceit && *cmd != NUL)
 	    emsg(_(e_cannot_define_autocommands_for_all_events));
 	else
-	    for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+	    for (event = (event_T)0; (int)event < NUM_EVENTS;
 					     event = (event_T)((int)event + 1))
 		if (do_autocmd_event(event, pat,
 			     once, nested, cmd, forceit, group, flags) == FAIL)
@@ -1708,7 +1708,7 @@ apply_autocmds_retval(
     static int
 has_cursorhold(void)
 {
-    return (first_autopat[(int)(get_real_state() == NORMAL_BUSY
+    return (first_autopat[(get_real_state() == NORMAL_BUSY
 			    ? EVENT_CURSORHOLD : EVENT_CURSORHOLDI)] != NULL);
 }
 
@@ -1739,7 +1739,7 @@ trigger_cursorhold(void)
     int
 has_cursormoved(void)
 {
-    return (first_autopat[(int)EVENT_CURSORMOVED] != NULL);
+    return (first_autopat[EVENT_CURSORMOVED] != NULL);
 }
 
 /*
@@ -1748,7 +1748,7 @@ has_cursormoved(void)
     int
 has_cursormovedI(void)
 {
-    return (first_autopat[(int)EVENT_CURSORMOVEDI] != NULL);
+    return (first_autopat[EVENT_CURSORMOVEDI] != NULL);
 }
 
 /*
@@ -1757,7 +1757,7 @@ has_cursormovedI(void)
     int
 has_textchanged(void)
 {
-    return (first_autopat[(int)EVENT_TEXTCHANGED] != NULL);
+    return (first_autopat[EVENT_TEXTCHANGED] != NULL);
 }
 
 /*
@@ -1766,7 +1766,7 @@ has_textchanged(void)
     int
 has_textchangedI(void)
 {
-    return (first_autopat[(int)EVENT_TEXTCHANGEDI] != NULL);
+    return (first_autopat[EVENT_TEXTCHANGEDI] != NULL);
 }
 
 /*
@@ -1775,7 +1775,7 @@ has_textchangedI(void)
     int
 has_textchangedP(void)
 {
-    return (first_autopat[(int)EVENT_TEXTCHANGEDP] != NULL);
+    return (first_autopat[EVENT_TEXTCHANGEDP] != NULL);
 }
 
 /*
@@ -1784,7 +1784,7 @@ has_textchangedP(void)
     int
 has_insertcharpre(void)
 {
-    return (first_autopat[(int)EVENT_INSERTCHARPRE] != NULL);
+    return (first_autopat[EVENT_INSERTCHARPRE] != NULL);
 }
 
 /*
@@ -1793,7 +1793,7 @@ has_insertcharpre(void)
     int
 has_cmdundefined(void)
 {
-    return (first_autopat[(int)EVENT_CMDUNDEFINED] != NULL);
+    return (first_autopat[EVENT_CMDUNDEFINED] != NULL);
 }
 
 #if defined(FEAT_EVAL) || defined(PROTO)
@@ -1803,7 +1803,7 @@ has_cmdundefined(void)
     int
 has_textyankpost(void)
 {
-    return (first_autopat[(int)EVENT_TEXTYANKPOST] != NULL);
+    return (first_autopat[EVENT_TEXTYANKPOST] != NULL);
 }
 #endif
 
@@ -1814,7 +1814,7 @@ has_textyankpost(void)
     int
 has_completechanged(void)
 {
-    return (first_autopat[(int)EVENT_COMPLETECHANGED] != NULL);
+    return (first_autopat[EVENT_COMPLETECHANGED] != NULL);
 }
 #endif
 
@@ -1825,7 +1825,7 @@ has_completechanged(void)
     int
 has_modechanged(void)
 {
-    return (first_autopat[(int)EVENT_MODECHANGED] != NULL);
+    return (first_autopat[EVENT_MODECHANGED] != NULL);
 }
 #endif
 

--- a/src/blob.c
+++ b/src/blob.c
@@ -237,7 +237,7 @@ blob2string(blob_T *blob, char_u **tofree, char_u *numbuf)
     {
 	if (i > 0 && (i & 3) == 0)
 	    ga_concat(&ga, (char_u *)".");
-	vim_snprintf((char *)numbuf, NUMBUFLEN, "%02X", (int)blob_get(blob, i));
+	vim_snprintf((char *)numbuf, NUMBUFLEN, "%02X", blob_get(blob, i));
 	ga_concat(&ga, numbuf);
     }
     *tofree = ga.ga_data;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -103,7 +103,7 @@ read_buffer(
     retval = readfile(
 	    read_stdin ? NULL : curbuf->b_ffname,
 	    read_stdin ? NULL : curbuf->b_fname,
-	    (linenr_T)line_count, (linenr_T)0, (linenr_T)MAXLNUM, eap,
+	    line_count, (linenr_T)0, (linenr_T)MAXLNUM, eap,
 	    flags | READ_BUFFER);
     if (retval == OK)
     {
@@ -1657,7 +1657,7 @@ do_bufdel(
 	     */
 	    if (bnr == curbuf->b_fnum)
 		do_current = bnr;
-	    else if (do_buffer_ext(command, DOBUF_FIRST, FORWARD, (int)bnr,
+	    else if (do_buffer_ext(command, DOBUF_FIRST, FORWARD, bnr,
 			  DOBUF_NOPOPUP | (forceit ? DOBUF_FORCEIT : 0)) == OK)
 		++deleted;
 
@@ -3775,7 +3775,7 @@ fileinfo(
     }
     else
     {
-	p = (char *)msg_trunc_attr(buffer, FALSE, 0);
+	p = msg_trunc_attr(buffer, FALSE, 0);
 	if (restart_edit != 0 || (msg_scrolled && !need_wait_return))
 	    // Need to repeat the message after redrawing when:
 	    // - When restart_edit is set (otherwise there will be a delay
@@ -4364,7 +4364,7 @@ build_stl_str_hl(
 		    }
 		}
 		else
-		    n = (long)(p - t) - stl_items[stl_groupitem[groupdepth]]
+		    n = (p - t) - stl_items[stl_groupitem[groupdepth]]
 							       .stl_maxwid + 1;
 
 		*t = '<';
@@ -4400,7 +4400,7 @@ build_stl_str_hl(
 		    l = (n - l) * MB_CHAR2LEN(fillchar);
 		    mch_memmove(t + l, t, (size_t)(p - t));
 		    if (p + l >= out + outlen)
-			l = (long)((out + outlen) - p - 1);
+			l = ((out + outlen) - p - 1);
 		    p += l;
 		    for (n = stl_groupitem[groupdepth] + 1; n < curitem; n++)
 			stl_items[n].stl_start += l;

--- a/src/change.c
+++ b/src/change.c
@@ -790,7 +790,7 @@ deleted_lines(linenr_T lnum, long count)
     void
 deleted_lines_mark(linenr_T lnum, long count)
 {
-    mark_adjust(lnum, (linenr_T)(lnum + count - 1), (long)MAXLNUM, -count);
+    mark_adjust(lnum, (linenr_T)(lnum + count - 1), MAXLNUM, -count);
     changed_lines(lnum, 0, lnum + count, -count);
 }
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -634,7 +634,7 @@ channel_gui_register_one(channel_T *channel, ch_part_T part UNUSED)
 	channel->ch_part[part].ch_inputHandler = gdk_input_add(
 		(gint)channel->ch_part[part].ch_fd,
 		(GdkInputCondition)
-			     ((int)GDK_INPUT_READ + (int)GDK_INPUT_EXCEPTION),
+			     (GDK_INPUT_READ + GDK_INPUT_EXCEPTION),
 		messageFromServerGtk2,
 		(gpointer)(long)channel->ch_part[part].ch_fd);
 #   endif
@@ -818,7 +818,7 @@ channel_connect(
 	    ch_log(channel,
 		      "Waiting for connection (waiting %d msec)...", waitnow);
 
-	    ret = select((int)sd + 1, &rfds, &wfds, NULL, &tv);
+	    ret = select(sd + 1, &rfds, &wfds, NULL, &tv);
 	    if (ret < 0)
 	    {
 		SOCK_ERRNO;
@@ -1669,7 +1669,7 @@ channel_write_in(channel_T *channel)
     }
     else
 	ch_log(channel, "Still %ld more lines to write",
-				   (long)(buf->b_ml.ml_line_count - lnum + 1));
+				   (buf->b_ml.ml_line_count - lnum + 1));
 }
 
 /*
@@ -1763,7 +1763,7 @@ channel_write_new_lines(buf_T *buf)
 		ch_log(channel, "written %d lines to channel", written);
 	    if (lnum < buf->b_ml.ml_line_count)
 		ch_log(channel, "Still %ld more lines to write",
-				       (long)(buf->b_ml.ml_line_count - lnum));
+				       (buf->b_ml.ml_line_count - lnum));
 
 	    in_part->ch_buf_bot = lnum;
 	}

--- a/src/charset.c
+++ b/src/charset.c
@@ -715,7 +715,7 @@ ptr2cells(char_u *p)
     int
 vim_strsize(char_u *s)
 {
-    return vim_strnsize(s, (int)MAXCOL);
+    return vim_strnsize(s, MAXCOL);
 }
 
 /*

--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -34,7 +34,7 @@ server_to_input_buf(char_u *str)
     //  The last but one parameter of replace_termcodes() is TRUE so that the
     //  <lt> sequence is recognised - needed for a real backslash.
     p_cpo = (char_u *)"Bk";
-    str = replace_termcodes((char_u *)str, &ptr, REPTERM_DO_LT, NULL);
+    str = replace_termcodes(str, &ptr, REPTERM_DO_LT, NULL);
     p_cpo = cpo_save;
 
     if (*ptr != NUL)	// trailing CTRL-V results in nothing
@@ -55,7 +55,7 @@ server_to_input_buf(char_u *str)
 	// buffer.
 	typebuf_was_filled = TRUE;
     }
-    vim_free((char_u *)ptr);
+    vim_free(ptr);
 }
 
 /*

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -792,7 +792,7 @@ clip_process_selection(
 			    && cb->end.col - col > col - cb->start.col))
 			|| ((diff = (cb->end.lnum - row) -
 						   (row - cb->start.lnum)) > 0
-			    || (diff == 0 && col < (int)(cb->start.col +
+			    || (diff == 0 && col < (cb->start.col +
 							 cb->end.col) / 2)))))
 	{
 	    cb->origin_row = (short_u)cb->end.lnum;
@@ -1162,7 +1162,7 @@ clip_copy_modeless_selection(int both UNUSED)
     clip_own_selection(&clip_star);
 
     // Yank the text into the '*' register.
-    clip_yank_selection(MCHAR, buffer, (long)(bufp - buffer), &clip_star);
+    clip_yank_selection(MCHAR, buffer, (bufp - buffer), &clip_star);
 
     // Make the register contents available to the outside world.
     clip_gen_set_selection(&clip_star);
@@ -1173,7 +1173,7 @@ clip_copy_modeless_selection(int both UNUSED)
 	// Do the same for the '+' register.
 	clip_free_selection(&clip_plus);
 	clip_own_selection(&clip_plus);
-	clip_yank_selection(MCHAR, buffer, (long)(bufp - buffer), &clip_plus);
+	clip_yank_selection(MCHAR, buffer, (bufp - buffer), &clip_plus);
 	clip_gen_set_selection(&clip_plus);
     }
 #endif
@@ -1487,7 +1487,7 @@ clip_x11_convert_selection_cb(
 	// create NUL terminated string which XmbTextListToTextProperty wants
 	mch_memmove(string_nt, string, (size_t)*length);
 	string_nt[*length] = NUL;
-	conv_result = XmbTextListToTextProperty(X_DISPLAY, (char **)&string_nt,
+	conv_result = XmbTextListToTextProperty(X_DISPLAY, &string_nt,
 					   1, XCompoundTextStyle, &text_prop);
 	if (conv_result != Success)
 	{

--- a/src/crypt_zip.c
+++ b/src/crypt_zip.c
@@ -148,7 +148,7 @@ crypt_zip_decode(
     for (i = 0; i < len; ++i)
     {
 	temp = (short_u)zs->keys[2] | 2;
-	temp = (int)(((unsigned)(temp * (temp ^ 1U)) >> 8) & 0xff);
+	temp = (int)(((temp * (temp ^ 1U)) >> 8) & 0xff);
 	UPDATE_KEYS_ZIP(zs->keys, to[i] = from[i] ^ temp);
     }
 }

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -389,7 +389,7 @@ do_showbacktrace(char_u *cmd)
     }
 
     if (SOURCING_LNUM != 0)
-       smsg(_("line %ld: %s"), (long)SOURCING_LNUM, cmd);
+       smsg(_("line %ld: %s"), SOURCING_LNUM, cmd);
     else
        smsg(_("cmd: %s"), cmd);
 }
@@ -440,7 +440,7 @@ dbg_check_breakpoint(exarg_T *eap)
 	    // replace K_SNR with "<SNR>"
 	    if (debug_breakpoint_name[0] == K_SPECIAL
 		    && debug_breakpoint_name[1] == KS_EXTRA
-		    && debug_breakpoint_name[2] == (int)KE_SNR)
+		    && debug_breakpoint_name[2] == KE_SNR)
 		p = (char_u *)"<SNR>";
 	    else
 		p = (char_u *)"";

--- a/src/diff.c
+++ b/src/diff.c
@@ -2844,7 +2844,7 @@ ex_diffgetput(exarg_T *eap)
 	    // Adjust marks.  This will change the following entries!
 	    if (added != 0)
 	    {
-		mark_adjust(lnum, lnum + count - 1, (long)MAXLNUM, (long)added);
+		mark_adjust(lnum, lnum + count - 1, MAXLNUM, (long)added);
 		if (curwin->w_cursor.lnum >= lnum)
 		{
 		    // Adjust the cursor position if it's in/after the changed

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -904,7 +904,7 @@ win_line(
 #ifdef FEAT_SEARCH_EXTRA
     if (!number_only)
     {
-	v = (long)(ptr - line);
+	v = (ptr - line);
 	area_highlighting |= prepare_search_hl_line(wp, lnum, (colnr_T)v,
 					      &line, &screen_search_hl,
 					      &search_attr);
@@ -1322,7 +1322,7 @@ win_line(
 #endif
 		)
 	{
-	    screen_line(screen_row, wp->w_wincol, col, -(int)wp->w_width,
+	    screen_line(screen_row, wp->w_wincol, col, -wp->w_width,
 							    screen_line_flags);
 	    // Pretend we have finished updating the window.  Except when
 	    // 'cursorcolumn' is set.
@@ -1356,7 +1356,7 @@ win_line(
 		// Check for start/end of 'hlsearch' and other matches.
 		// After end, check for start/end of next match.
 		// When another match, have to check for start again.
-		v = (long)(ptr - line);
+		v = (ptr - line);
 		search_attr = update_search_hl(wp, lnum, (colnr_T)v, &line,
 				      &screen_search_hl, &has_match_conc,
 				      &match_conc, did_line_attr, lcs_eol_one);
@@ -1473,7 +1473,7 @@ win_line(
 		    save_did_emsg = did_emsg;
 		    did_emsg = FALSE;
 
-		    v = (long)(ptr - line);
+		    v = (ptr - line);
 		    if (v == prev_syntax_col)
 			// at same column again
 			syntax_attr = prev_syntax_attr;
@@ -1883,7 +1883,7 @@ win_line(
 		// Only do this when there is no syntax highlighting, the
 		// @Spell cluster is not used or the current syntax item
 		// contains the @Spell cluster.
-		v = (long)(ptr - line);
+		v = (ptr - line);
 		if (has_spell && v >= word_end && v > cur_checked_col)
 		{
 		    spell_attr = 0;
@@ -2627,7 +2627,7 @@ win_line(
 	    // flag to indicate whether prevcol equals startcol of search_hl or
 	    // one of the matches
 	    int prevcol_hl_flag = get_prevcol_hl_flag(wp, &screen_search_hl,
-					      (long)(ptr - line) - (c == NUL));
+					      (ptr - line) - (c == NUL));
 #endif
 	    // Invert at least one char, used for Visual and empty line or
 	    // highlight match at end of line. If it's beyond the last
@@ -2690,7 +2690,7 @@ win_line(
 		    // Use attributes from match with highest priority among
 		    // 'search_hl' and the match list.
 		    get_search_match_hl(wp, &screen_search_hl,
-					       (long)(ptr - line), &char_attr);
+					       (ptr - line), &char_attr);
 		}
 #endif
 		ScreenAttrs[off] = char_attr;
@@ -2783,7 +2783,7 @@ win_line(
 #endif
 
 	    screen_line(screen_row, wp->w_wincol, col,
-					  (int)wp->w_width, screen_line_flags);
+					  wp->w_width, screen_line_flags);
 	    row++;
 
 	    // Update w_cline_height and w_cline_folded if the cursor line was
@@ -3084,7 +3084,7 @@ win_line(
 	{
 #ifdef FEAT_CONCEAL
 	    screen_line(screen_row, wp->w_wincol, col - boguscols,
-					  (int)wp->w_width, screen_line_flags);
+					  wp->w_width, screen_line_flags);
 	    boguscols = 0;
 #else
 	    screen_line(screen_row, wp->w_wincol, col,

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -530,7 +530,7 @@ win_redr_status(win_T *wp, int ignore_pum UNUSED)
 			this_ru_col + wp->w_wincol, fillchar, fillchar, attr);
 
 	if (get_keymap_str(wp, (char_u *)"<%s>", NameBuff, MAXPATHL)
-		&& (int)(this_ru_col - len) > (int)(STRLEN(NameBuff) + 1))
+		&& (this_ru_col - len) > (int)(STRLEN(NameBuff) + 1))
 	    screen_puts(NameBuff, row, (int)(this_ru_col - STRLEN(NameBuff)
 						   - 1 + wp->w_wincol), attr);
 
@@ -790,7 +790,7 @@ win_redr_ruler(win_T *wp, int always, int ignore_pum)
 	i = redraw_cmdline;
 	screen_fill(row, row + 1,
 		this_ru_col + off + (int)STRLEN(buffer),
-		(int)(off + width),
+		(off + width),
 		fillchar, fillchar, attr);
 	// don't redraw the cmdline because of showing the ruler
 	redraw_cmdline = i;
@@ -1031,8 +1031,8 @@ redraw_win_toolbar(win_T *wp)
     }
     wp->w_winbar_items[item_idx].wb_menu = NULL; // end marker
 
-    screen_line(wp->w_winrow, wp->w_wincol, (int)wp->w_width,
-							  (int)wp->w_width, 0);
+    screen_line(wp->w_winrow, wp->w_wincol, wp->w_width,
+							  wp->w_width, 0);
 }
 #endif
 
@@ -1365,8 +1365,8 @@ fold_line(
     }
 #endif
 
-    screen_line(row + W_WINROW(wp), wp->w_wincol, (int)wp->w_width,
-						     (int)wp->w_width, 0);
+    screen_line(row + W_WINROW(wp), wp->w_wincol, wp->w_width,
+						     wp->w_width, 0);
 
     // Update w_cline_height and w_cline_folded if the cursor line was
     // updated (saves a call to plines() later).
@@ -2599,7 +2599,7 @@ win_update(win_T *wp)
 	    screen_puts_len((char_u *)"@@", 2, scr_row, wp->w_wincol,
 							      HL_ATTR(HLF_AT));
 	    screen_fill(scr_row, scr_row + 1,
-		    (int)wp->w_wincol + 2, (int)W_ENDCOL(wp),
+		    wp->w_wincol + 2, W_ENDCOL(wp),
 		    '@', ' ', HL_ATTR(HLF_AT));
 	    set_empty_rows(wp, srow);
 	    wp->w_botline = lnum;
@@ -2609,7 +2609,7 @@ win_update(win_T *wp)
 	    // Last line isn't finished: Display "@@@" at the end.
 	    screen_fill(W_WINROW(wp) + wp->w_height - 1,
 		    W_WINROW(wp) + wp->w_height,
-		    (int)W_ENDCOL(wp) - 3, (int)W_ENDCOL(wp),
+		    W_ENDCOL(wp) - 3, W_ENDCOL(wp),
 		    '@', '@', HL_ATTR(HLF_AT));
 	    set_empty_rows(wp, srow);
 	    wp->w_botline = lnum;

--- a/src/edit.c
+++ b/src/edit.c
@@ -523,7 +523,7 @@ edit(
 
 	    if (
 #ifdef FEAT_VARTABS
-		(int)curwin->w_wcol < mincol - tabstop_at(
+		curwin->w_wcol < mincol - tabstop_at(
 					  get_nolist_virtcol(), curbuf->b_p_ts,
 							 curbuf->b_p_vts_array)
 #else
@@ -2109,7 +2109,7 @@ insertchar(
 	return;
 
     // Check whether this character should end a comment.
-    if (did_ai && (int)c == end_comment_pending)
+    if (did_ai && c == end_comment_pending)
     {
 	char_u  *line;
 	char_u	lead_end[COM_MAX_LEN];	    // end-comment string
@@ -2596,7 +2596,7 @@ add_char2buf(int c, char_u *s)
 	{
 	    *s++ = CSI;
 	    *s++ = KS_EXTRA;
-	    *s++ = (int)KE_CSI;
+	    *s++ = KE_CSI;
 	}
 #endif
 	else
@@ -2882,7 +2882,7 @@ stuff_inserted(
     // may want to stuff the command character, to start Insert mode
     if (c != NUL)
 	stuffcharReadbuff(c);
-    if ((esc_ptr = (char_u *)vim_strrchr(ptr, ESC)) != NULL)
+    if ((esc_ptr = vim_strrchr(ptr, ESC)) != NULL)
 	*esc_ptr = NUL;	    // remove the ESC
 
     // when the last char is either "0" or "^" it will be quoted if no ESC

--- a/src/eval.c
+++ b/src/eval.c
@@ -4278,7 +4278,7 @@ eval_index_inner(
 			return FAIL;
 		}
 
-		item = dict_find(rettv->vval.v_dict, key, (int)keylen);
+		item = dict_find(rettv->vval.v_dict, key, keylen);
 
 		if (item == NULL && verbose)
 		    semsg(_(e_dictkey), key);
@@ -5502,7 +5502,7 @@ get_name_len(
     *alias = NULL;  // default to no alias
 
     if ((*arg)[0] == K_SPECIAL && (*arg)[1] == KS_EXTRA
-						  && (*arg)[2] == (int)KE_SNR)
+						  && (*arg)[2] == KE_SNR)
     {
 	// hard coded <SNR>, already translated
 	*arg += 3;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6971,7 +6971,7 @@ find_some_match(typval_T *argvars, typval_T *rettv, matchtype_T type)
 		    break;
 	    }
 
-	    match = vim_regexec_nl(&regmatch, str, (colnr_T)startcol);
+	    match = vim_regexec_nl(&regmatch, str, startcol);
 
 	    if (match && --nth <= 0)
 		break;
@@ -7756,7 +7756,7 @@ range_list_materialize(list_T *list)
     list->lv_len = 0;
     list->lv_u.mat.lv_idx_item = NULL;
     for (i = start; stride > 0 ? i <= end : i >= end; i += stride)
-	if (list_append_number(list, (varnumber_T)i) == FAIL)
+	if (list_append_number(list, i) == FAIL)
 	    break;
 }
 
@@ -9625,7 +9625,7 @@ f_synID(typval_T *argvars UNUSED, typval_T *rettv)
 
     if (!transerr && lnum >= 1 && lnum <= curbuf->b_ml.ml_line_count
 	    && col >= 0 && col < (long)STRLEN(ml_get(lnum)))
-	id = syn_get_id(curwin, lnum, (colnr_T)col, trans, NULL, FALSE);
+	id = syn_get_id(curwin, lnum, col, trans, NULL, FALSE);
 #endif
 
     rettv->vval.v_number = id;
@@ -9846,7 +9846,7 @@ f_synstack(typval_T *argvars UNUSED, typval_T *rettv)
 	    && col >= 0 && col <= (long)STRLEN(ml_get(lnum))
 	    && rettv_list_alloc(rettv) != FAIL)
     {
-	(void)syn_get_id(curwin, lnum, (colnr_T)col, FALSE, NULL, TRUE);
+	(void)syn_get_id(curwin, lnum, col, FALSE, NULL, TRUE);
 	for (i = 0; ; ++i)
 	{
 	    id = syn_get_stack_item(i);

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -646,7 +646,7 @@ ex_sort(exarg_T *eap)
     deleted = (long)(count - (lnum - eap->line2));
     if (deleted > 0)
     {
-	mark_adjust(eap->line2 - deleted, eap->line2, (long)MAXLNUM, -deleted);
+	mark_adjust(eap->line2 - deleted, eap->line2, MAXLNUM, -deleted);
 	msgmore(-deleted);
     }
     else if (deleted < 0)
@@ -1183,7 +1183,7 @@ do_filter(
 
     if (do_out)
     {
-	if (u_save((linenr_T)(line2), (linenr_T)(line2 + 1)) == FAIL)
+	if (u_save((line2), (linenr_T)(line2 + 1)) == FAIL)
 	{
 	    vim_free(cmd_buf);
 	    goto error;
@@ -3424,7 +3424,7 @@ ex_change(exarg_T *eap)
 
     // make sure the cursor is not beyond the end of the file now
     check_cursor_lnum();
-    deleted_lines_mark(eap->line1, (long)(eap->line2 - lnum));
+    deleted_lines_mark(eap->line1, (eap->line2 - lnum));
 
     // ":append" on the line above the deleted lines.
     eap->line2 = eap->line1;
@@ -4660,7 +4660,7 @@ skip:
 			    for (i = 0; i < nmatch_tl; ++i)
 				ml_delete(lnum);
 			    mark_adjust(lnum, lnum + nmatch_tl - 1,
-						   (long)MAXLNUM, -nmatch_tl);
+						   MAXLNUM, -nmatch_tl);
 			    if (subflags.do_ask)
 				deleted_lines(lnum, nmatch_tl);
 			    --lnum;

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3688,7 +3688,7 @@ find_ex_command(
 	    int c1 = eap->cmd[0];
 	    int c2 = len == 1 ? NUL : eap->cmd[1];
 
-	    if (command_count != (int)CMD_SIZE)
+	    if (command_count != CMD_SIZE)
 	    {
 		iemsg(_("E943: Command table needs to be updated, run 'make cmdidxs'"));
 		getout(1);
@@ -3705,7 +3705,7 @@ find_ex_command(
 	else
 	    eap->cmdidx = CMD_bang;
 
-	for ( ; (int)eap->cmdidx < (int)CMD_SIZE;
+	for ( ; (int)eap->cmdidx < CMD_SIZE;
 			       eap->cmdidx = (cmdidx_T)((int)eap->cmdidx + 1))
 	    if (STRNCMP(cmdnames[(int)eap->cmdidx].cmd_name, (char *)eap->cmd,
 							    (size_t)len) == 0)
@@ -3906,7 +3906,7 @@ excmd_get_cmdidx(char_u *cmd, int len)
 {
     cmdidx_T idx;
 
-    for (idx = (cmdidx_T)0; (int)idx < (int)CMD_SIZE;
+    for (idx = (cmdidx_T)0; (int)idx < CMD_SIZE;
 	    idx = (cmdidx_T)((int)idx + 1))
 	if (STRNCMP(cmdnames[(int)idx].cmd_name, cmd, (size_t)len) == 0)
 	    break;
@@ -5519,7 +5519,7 @@ check_more(
     char_u *
 get_command_name(expand_T *xp UNUSED, int idx)
 {
-    if (idx >= (int)CMD_SIZE)
+    if (idx >= CMD_SIZE)
 	return expand_user_command_name(idx);
     return cmdnames[idx].cmd_name;
 }
@@ -6749,7 +6749,7 @@ ex_resize(exarg_T *eap)
 	    n += wp->w_width;
 	else if (n == 0 && eap->arg[0] == NUL)	// default is very wide
 	    n = 9999;
-	win_setwidth_win((int)n, wp);
+	win_setwidth_win(n, wp);
     }
     else
     {
@@ -6757,7 +6757,7 @@ ex_resize(exarg_T *eap)
 	    n += wp->w_height;
 	else if (n == 0 && eap->arg[0] == NUL)	// default is very high
 	    n = 9999;
-	win_setheight_win((int)n, wp);
+	win_setheight_win(n, wp);
     }
 }
 
@@ -7472,7 +7472,7 @@ ex_sleep(exarg_T *eap)
     {
 	n = W_WINROW(curwin) + curwin->w_wrow - msg_scrolled;
 	if (n >= 0)
-	    windgoto((int)n, curwin->w_wincol + curwin->w_wcol);
+	    windgoto(n, curwin->w_wincol + curwin->w_wcol);
     }
 
     len = eap->line2;
@@ -8407,7 +8407,7 @@ ex_normal(exarg_T *eap)
 		    if (*p == CSI)
 		    {
 			arg[len++] = KS_EXTRA;
-			arg[len++] = (int)KE_CSI;
+			arg[len++] = KE_CSI;
 		    }
 #endif
 		    for (l = (*mb_ptr2len)(p) - 1; l > 0; --l)
@@ -8422,7 +8422,7 @@ ex_normal(exarg_T *eap)
 			else if (*p == CSI)
 			{
 			    arg[len++] = KS_EXTRA;
-			    arg[len++] = (int)KE_CSI;
+			    arg[len++] = KE_CSI;
 			}
 #endif
 		    }

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -808,7 +808,7 @@ report_pending(int action, int pending, void *value)
 		vim_snprintf((char *)IObuff, IOSIZE, mesg, _("Exception"));
 		mesg = (char *)vim_strnsave(IObuff, STRLEN(IObuff) + 4);
 		STRCAT(mesg, ": %s");
-		s = (char *)((except_T *)value)->value;
+		s = ((except_T *)value)->value;
 	    }
 	    else if ((pending & CSTP_ERROR) && (pending & CSTP_INTERRUPT))
 		s = _("Error and interrupt");
@@ -2262,7 +2262,7 @@ leave_cleanup(cleanup_T *csp)
     {
 	if (pending & CSTP_THROW)
 	    // Cancel the pending exception (includes report).
-	    discard_exception((except_T *)csp->exception, FALSE);
+	    discard_exception(csp->exception, FALSE);
 	else
 	    report_discard_pending(pending, NULL);
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1580,7 +1580,7 @@ retry:
 		// move the linerest to before the converted characters
 		line_start = ptr - linerest;
 		mch_memmove(line_start, buffer, (size_t)linerest);
-		size = (long)((char_u *)top - ptr);
+		size = ((char_u *)top - ptr);
 	    }
 #endif
 
@@ -1978,7 +1978,7 @@ retry:
 		// move the linerest to before the converted characters
 		line_start = dest - linerest;
 		mch_memmove(line_start, buffer, (size_t)linerest);
-		size = (long)((ptr + real_size) - dest);
+		size = ((ptr + real_size) - dest);
 		ptr = dest;
 	    }
 	    else if (enc_utf8 && !curbuf->b_p_bin)
@@ -2253,7 +2253,7 @@ rewind_retry:
 		}
 	    }
 	}
-	linerest = (long)(ptr - line_start);
+	linerest = (ptr - line_start);
 	ui_breakcheck();
     }
 
@@ -4932,10 +4932,10 @@ readdir_core(
 # ifdef FEAT_EVAL
 	readdirex_sort = sort;
 	if (withattr)
-	    qsort((void*)gap->ga_data, (size_t)gap->ga_len, sizeof(dict_T*),
+	    qsort(gap->ga_data, (size_t)gap->ga_len, sizeof(dict_T*),
 		    compare_readdirex_item);
 	else
-	    qsort((void*)gap->ga_data, (size_t)gap->ga_len, sizeof(char_u *),
+	    qsort(gap->ga_data, (size_t)gap->ga_len, sizeof(char_u *),
 		    compare_readdir_item);
 # else
 	    sort_strings((char_u **)gap->ga_data, gap->ga_len);

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -1905,11 +1905,11 @@ read_file_or_blob(typval_T *argvars, typval_T *rettv, int always_blob)
 		// small, to avoid repeatedly 'allocing' large and
 		// 'reallocing' small.
 		if (prevsize == 0)
-		    prevsize = (long)(p - start);
+		    prevsize = (p - start);
 		else
 		{
 		    long grow50pc = (prevsize * 3) / 2;
-		    long growmin  = (long)((p - start) * 2 + prevlen);
+		    long growmin  = ((p - start) * 2 + prevlen);
 		    prevsize = grow50pc > growmin ? grow50pc : growmin;
 		}
 		newprev = vim_realloc(prev, prevsize);
@@ -1923,7 +1923,7 @@ read_file_or_blob(typval_T *argvars, typval_T *rettv, int always_blob)
 	    }
 	    // Add the line part to end of "prev".
 	    mch_memmove(prev + prevlen, start, p - start);
-	    prevlen += (long)(p - start);
+	    prevlen += (p - start);
 	}
     } // while
 

--- a/src/fold.c
+++ b/src/fold.c
@@ -296,7 +296,7 @@ foldedCount(win_T *win, linenr_T lnum, foldinfo_T *infop)
     linenr_T	last;
 
     if (hasFoldingWin(win, lnum, NULL, &last, FALSE, infop))
-	return (long)(last - lnum + 1);
+	return (last - lnum + 1);
     return 0;
 }
 
@@ -1999,7 +1999,7 @@ get_foldtext(
     if (text == NULL)
 #endif
     {
-	long count = (long)(lnume - lnum + 1);
+	long count = (lnume - lnum + 1);
 
 	vim_snprintf((char *)buf, FOLD_TEXT_LEN,
 		     NGETTEXT("+--%3ld line folded ",
@@ -2548,14 +2548,14 @@ foldUpdateIEMSRecurse(
 				// like lines are inserted
 				foldMarkAdjustRecurse(&fp->fd_nested,
 					(linenr_T)0, (linenr_T)MAXLNUM,
-					(long)(fp->fd_top - firstlnum), 0L);
+					(fp->fd_top - firstlnum), 0L);
 			    else
 				// like lines are deleted
 				foldMarkAdjustRecurse(&fp->fd_nested,
 					(linenr_T)0,
-					(long)(firstlnum - fp->fd_top - 1),
+					(firstlnum - fp->fd_top - 1),
 					(linenr_T)MAXLNUM,
-					(long)(fp->fd_top - firstlnum));
+					(fp->fd_top - firstlnum));
 			    fp->fd_len += fp->fd_top - firstlnum;
 			    fp->fd_top = firstlnum;
 			    fold_changed = TRUE;
@@ -2636,7 +2636,7 @@ foldUpdateIEMSRecurse(
 			// to stop just above startlnum.
 			fp->fd_len = startlnum - fp->fd_top;
 			foldMarkAdjustRecurse(&fp->fd_nested,
-				(linenr_T)fp->fd_len, (linenr_T)MAXLNUM,
+				fp->fd_len, (linenr_T)MAXLNUM,
 						       (linenr_T)MAXLNUM, 0L);
 			fold_changed = TRUE;
 		    }
@@ -2828,8 +2828,8 @@ foldUpdateIEMSRecurse(
 	    {
 		// Make fold that includes lnum start at lnum.
 		foldMarkAdjustRecurse(&fp2->fd_nested,
-			(linenr_T)0, (long)(flp->lnum - fp2->fd_top - 1),
-			(linenr_T)MAXLNUM, (long)(fp2->fd_top - flp->lnum));
+			(linenr_T)0, (flp->lnum - fp2->fd_top - 1),
+			(linenr_T)MAXLNUM, (fp2->fd_top - flp->lnum));
 		fp2->fd_len -= flp->lnum - fp2->fd_top;
 		fp2->fd_top = flp->lnum;
 		fold_changed = TRUE;
@@ -2990,8 +2990,8 @@ foldRemove(garray_T *gap, linenr_T top, linenr_T bot)
 	    {
 		// 5: Make fold that includes bot start below bot.
 		foldMarkAdjustRecurse(&fp->fd_nested,
-			(linenr_T)0, (long)(bot - fp->fd_top),
-			(linenr_T)MAXLNUM, (long)(fp->fd_top - bot - 1));
+			(linenr_T)0, (bot - fp->fd_top),
+			(linenr_T)MAXLNUM, (fp->fd_top - bot - 1));
 		fp->fd_len -= bot - fp->fd_top + 1;
 		fp->fd_top = bot + 1;
 		break;
@@ -3759,7 +3759,7 @@ f_foldtext(typval_T *argvars UNUSED, typval_T *rettv)
 		    s = skipwhite(s + 1);
 	    }
 	}
-	count = (long)(foldend - foldstart + 1);
+	count = (foldend - foldstart + 1);
 	txt = NGETTEXT("+-%s%3ld line: ", "+-%s%3ld lines: ", count);
 	r = alloc(STRLEN(txt)
 		    + STRLEN(dashes)	    // for %s

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -293,7 +293,7 @@ add_char_buff(buffheader_T *buf, int c)
 	    // Translate a CSI to a CSI - KS_EXTRA - KE_CSI sequence
 	    temp[0] = CSI;
 	    temp[1] = KS_EXTRA;
-	    temp[2] = (int)KE_CSI;
+	    temp[2] = KE_CSI;
 	    temp[3] = NUL;
 	}
 #endif
@@ -564,7 +564,7 @@ AppendToRedobuffLit(
 	if (*s == NUL && (s[-1] == '0' || s[-1] == '^'))
 	    --s;
 	if (s > start)
-	    add_buff(&redobuff, start, (long)(s - start));
+	    add_buff(&redobuff, start, (s - start));
 
 	if (*s == NUL || (len >= 0 && s - str >= len))
 	    break;
@@ -710,7 +710,7 @@ stuffescaped(char_u *arg, int literally)
 		|| (*arg == K_SPECIAL && !literally))
 	    ++arg;
 	if (arg > start)
-	    stuffReadbuffLen(start, (long)(arg - start));
+	    stuffReadbuffLen(start, (arg - start));
 
 	// stuff a single special character
 	if (*arg != NUL)
@@ -1853,7 +1853,7 @@ vgetc(void)
 			// or a K_SPECIAL - KS_EXTRA - KE_CSI, which is CSI
 			// too.
 			c = vgetorpeek(TRUE);
-			if (vgetorpeek(TRUE) == (int)KE_CSI && c == KS_EXTRA)
+			if (vgetorpeek(TRUE) == KE_CSI && c == KS_EXTRA)
 			    buf[i] = CSI;
 		    }
 		}
@@ -2521,7 +2521,7 @@ handle_mapping(
 		    if (*s == RM_SCRIPT
 			    && (mp->m_keys[0] != K_SPECIAL
 				|| mp->m_keys[1] != KS_EXTRA
-				|| mp->m_keys[2] != (int)KE_SNR))
+				|| mp->m_keys[2] != KE_SNR))
 			continue;
 
 		    // If one of the typed keys cannot be remapped, skip the
@@ -3139,7 +3139,7 @@ vgetorpeek(int advance)
 				    if (!VIM_ISWHITE(ptr[col]))
 					curwin->w_wcol = vcol;
 				    vcol += lbr_chartabsize(ptr, ptr + col,
-							       (colnr_T)vcol);
+							       vcol);
 				    if (has_mbyte)
 					col += (*mb_ptr2len)(ptr + col);
 				    else
@@ -3612,7 +3612,7 @@ fix_input_buffer(char_u *buf, int len)
 	    mch_memmove(p + 3, p + 1, (size_t)i);
 	    *p++ = K_SPECIAL;
 	    *p++ = KS_EXTRA;
-	    *p = (int)KE_CSI;
+	    *p = KE_CSI;
 	    len += 2;
 	}
 # endif
@@ -3620,7 +3620,7 @@ fix_input_buffer(char_u *buf, int len)
 #endif
 	if (p[0] == NUL || (p[0] == K_SPECIAL
 		    // timeout may generate K_CURSORHOLD
-		    && (i < 2 || p[1] != KS_EXTRA || p[2] != (int)KE_CURSORHOLD)
+		    && (i < 2 || p[1] != KS_EXTRA || p[2] != KE_CURSORHOLD)
 #if defined(MSWIN) && (!defined(FEAT_GUI) || defined(VIMDLL))
 		    // Win32 console passes modifiers
 		    && (

--- a/src/gui.c
+++ b/src/gui.c
@@ -4837,7 +4837,7 @@ gui_focus_change(int in_focus)
 
 	bytes[0] = CSI;
 	bytes[1] = KS_EXTRA;
-	bytes[2] = in_focus ? (int)KE_FOCUSGAINED : (int)KE_FOCUSLOST;
+	bytes[2] = in_focus ? KE_FOCUSGAINED : KE_FOCUSLOST;
 	add_to_input_buf(bytes, 3);
     }
 #endif
@@ -4966,7 +4966,7 @@ gui_mouse_correct(void)
     if (wp != curwin && wp != NULL)	// If in other than current window
     {
 	validate_cline_row();
-	gui_mch_setmouse((int)W_ENDCOL(curwin) * gui.char_width - 3,
+	gui_mch_setmouse(W_ENDCOL(curwin) * gui.char_width - 3,
 		(W_WINROW(curwin) + curwin->w_wrow) * gui.char_height
 						     + (gui.char_height) / 2);
     }
@@ -5373,7 +5373,7 @@ gui_do_findrepl(
 		    // A button was pressed thus undo should be synced.
 		    u_sync(FALSE);
 
-		    del_bytes((long)(regmatch.endp[0] - regmatch.startp[0]),
+		    del_bytes((regmatch.endp[0] - regmatch.startp[0]),
 								FALSE, FALSE);
 		    ins_str(repl_text);
 		}

--- a/src/gui_at_sb.c
+++ b/src/gui_at_sb.c
@@ -387,7 +387,7 @@ PaintArrows(ScrollbarWidget sbw)
 	if ((int)thickness * 2 > (int)sbw->scrollbar.length)
 	{
 	    size = sbw->scrollbar.length / 2;
-	    off = (int)(thickness - size) / 2;
+	    off = (thickness - size) / 2;
 	}
 	else
 	{

--- a/src/gui_beval.c
+++ b/src/gui_beval.c
@@ -393,13 +393,13 @@ pointer_event(BalloonEval *beval, int x, int y, unsigned state)
 	cancelBalloon(beval);
 
 	// Mouse buttons are pressed - no balloon now
-	if (!(state & ((int)GDK_BUTTON1_MASK | (int)GDK_BUTTON2_MASK
-						    | (int)GDK_BUTTON3_MASK)))
+	if (!(state & (GDK_BUTTON1_MASK | GDK_BUTTON2_MASK
+						    | GDK_BUTTON3_MASK)))
 	{
 	    beval->x = x;
 	    beval->y = y;
 
-	    if (state & (int)GDK_MOD1_MASK)
+	    if (state & GDK_MOD1_MASK)
 	    {
 		/*
 		 * Alt is pressed -- enter super-evaluate-mode,
@@ -431,13 +431,13 @@ key_event(BalloonEval *beval, unsigned keyval, int is_keypress)
 	    case GDK_Shift_R:
 		beval->showState = ShS_UPDATE_PENDING;
 		(*beval->msgCB)(beval, (is_keypress)
-						   ? (int)GDK_SHIFT_MASK : 0);
+						   ? GDK_SHIFT_MASK : 0);
 		break;
 	    case GDK_Control_L:
 	    case GDK_Control_R:
 		beval->showState = ShS_UPDATE_PENDING;
 		(*beval->msgCB)(beval, (is_keypress)
-						 ? (int)GDK_CONTROL_MASK : 0);
+						 ? GDK_CONTROL_MASK : 0);
 		break;
 	    default:
 		// Don't do this for key release, we apparently get these with

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -765,7 +765,7 @@ property_event(GtkWidget *widget,
 	       gpointer data UNUSED)
 {
     if (event->type == GDK_PROPERTY_NOTIFY
-	    && event->state == (int)GDK_PROPERTY_NEW_VALUE
+	    && event->state == GDK_PROPERTY_NEW_VALUE
 	    && GDK_WINDOW_XID(event->window) == commWindow
 	    && GET_X_ATOM(event->atom) == commProperty)
     {
@@ -1160,7 +1160,7 @@ key_press_event(GtkWidget *widget UNUSED,
 	    {
 		// Turn CSI into K_CSI.
 		*d++ = KS_EXTRA;
-		*d++ = (int)KE_CSI;
+		*d++ = KE_CSI;
 	    }
 	}
 	len = d - string;
@@ -3471,13 +3471,13 @@ gui_gtk_set_selection_targets(void)
 	    targets[j++] = selection_targets[i];
     }
 
-    gtk_selection_clear_targets(gui.drawarea, (GdkAtom)GDK_SELECTION_PRIMARY);
-    gtk_selection_clear_targets(gui.drawarea, (GdkAtom)clip_plus.gtk_sel_atom);
+    gtk_selection_clear_targets(gui.drawarea, GDK_SELECTION_PRIMARY);
+    gtk_selection_clear_targets(gui.drawarea, clip_plus.gtk_sel_atom);
     gtk_selection_add_targets(gui.drawarea,
-			      (GdkAtom)GDK_SELECTION_PRIMARY,
+			      GDK_SELECTION_PRIMARY,
 			      targets, n_targets);
     gtk_selection_add_targets(gui.drawarea,
-			      (GdkAtom)clip_plus.gtk_sel_atom,
+			      clip_plus.gtk_sel_atom,
 			      targets, n_targets);
 }
 

--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -725,16 +725,16 @@ translate_pango_attributes(PangoAttrIterator *iter)
 
     attr = pango_attr_iterator_get(iter, PANGO_ATTR_UNDERLINE);
     if (attr != NULL && ((PangoAttrInt *)attr)->value
-						 != (int)PANGO_UNDERLINE_NONE)
+						 != PANGO_UNDERLINE_NONE)
 	char_attr |= HL_UNDERLINE;
 
     attr = pango_attr_iterator_get(iter, PANGO_ATTR_WEIGHT);
-    if (attr != NULL && ((PangoAttrInt *)attr)->value >= (int)PANGO_WEIGHT_BOLD)
+    if (attr != NULL && ((PangoAttrInt *)attr)->value >= PANGO_WEIGHT_BOLD)
 	char_attr |= HL_BOLD;
 
     attr = pango_attr_iterator_get(iter, PANGO_ATTR_STYLE);
     if (attr != NULL && ((PangoAttrInt *)attr)->value
-						   != (int)PANGO_STYLE_NORMAL)
+						   != PANGO_STYLE_NORMAL)
 	char_attr |= HL_ITALIC;
 
     attr = pango_attr_iterator_get(iter, PANGO_ATTR_BACKGROUND);
@@ -1044,8 +1044,8 @@ xim_queue_key_press_event(GdkEventKey *event, int down)
 	    // Otherwise e.g. <S-C-space> would be unusable for other purposes
 	    // if the IM activate key is <S-space>.
 	    state_mask  = im_activatekey_state;
-	    state_mask |= ((int)GDK_SHIFT_MASK | (int)GDK_CONTROL_MASK
-							| (int)GDK_MOD1_MASK);
+	    state_mask |= (GDK_SHIFT_MASK | GDK_CONTROL_MASK
+							| GDK_MOD1_MASK);
 
 	    if ((event->state & state_mask) != im_activatekey_state)
 		return FALSE;

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -588,7 +588,7 @@ ex_hardcopy(exarg_T *eap)
      */
     if (mch_print_init(&settings,
 			curbuf->b_fname == NULL
-			    ? (char_u *)buf_spname(curbuf)
+			    ? buf_spname(curbuf)
 			    : curbuf->b_sfname == NULL
 				? curbuf->b_fname
 				: curbuf->b_sfname,

--- a/src/help.c
+++ b/src/help.c
@@ -561,7 +561,7 @@ find_help_tags(
     flags = TAG_HELP | TAG_REGEXP | TAG_NAMES | TAG_VERBOSE | TAG_NO_TAGFUNC;
     if (keep_lang)
 	flags |= TAG_KEEP_LANG;
-    if (find_tags(IObuff, num_matches, matches, flags, (int)MAXCOL, NULL) == OK
+    if (find_tags(IObuff, num_matches, matches, flags, MAXCOL, NULL) == OK
 	    && *num_matches > 0)
     {
 	// Sort the matches found on the heuristic number that is after the

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -3413,7 +3413,7 @@ highlight_changed(void)
     /*
      * Clear all attributes.
      */
-    for (hlf = 0; hlf < (int)HLF_COUNT; ++hlf)
+    for (hlf = 0; hlf < HLF_COUNT; ++hlf)
 	highlight_attr[hlf] = 0;
 
     /*
@@ -3431,11 +3431,11 @@ highlight_changed(void)
 
 	while (*p)
 	{
-	    for (hlf = 0; hlf < (int)HLF_COUNT; ++hlf)
+	    for (hlf = 0; hlf < HLF_COUNT; ++hlf)
 		if (hl_flags[hlf] == *p)
 		    break;
 	    ++p;
-	    if (hlf == (int)HLF_COUNT || *p == NUL)
+	    if (hlf == HLF_COUNT || *p == NUL)
 		return FAIL;
 
 	    /*
@@ -3482,15 +3482,15 @@ highlight_changed(void)
 				attr = syn_id2attr(id);
 				p = end - 1;
 #if defined(FEAT_STL_OPT) && defined(USER_HIGHLIGHT)
-				if (hlf == (int)HLF_SNC)
+				if (hlf == HLF_SNC)
 				    id_SNC = syn_get_final_id(id);
 # ifdef FEAT_TERMINAL
-				else if (hlf == (int)HLF_ST)
+				else if (hlf == HLF_ST)
 				    id_ST = syn_get_final_id(id);
-				else if (hlf == (int)HLF_STNC)
+				else if (hlf == HLF_STNC)
 				    id_STNC = syn_get_final_id(id);
 # endif
-				else if (hlf == (int)HLF_S)
+				else if (hlf == HLF_S)
 				    id_S = syn_get_final_id(id);
 #endif
 				break;

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -872,7 +872,7 @@ err_closing:
 	    goto err_closing;
 #endif
 	}
-	expand_env((char_u *)p_csprg, (char_u *)prog, MAXPATHL);
+	expand_env(p_csprg, (char_u *)prog, MAXPATHL);
 
 	// alloc space to hold the cscope command
 	len = (int)(strlen(prog) + strlen(csinfo[i].fname) + 32);
@@ -1253,7 +1253,7 @@ cs_find_common(
 	int matched = 0;
 
 	// read output
-	cs_fill_results((char *)pat, totmatches, nummatches, &matches,
+	cs_fill_results(pat, totmatches, nummatches, &matches,
 							 &contexts, &matched);
 	vim_free(nummatches);
 	if (matches == NULL)
@@ -1745,7 +1745,7 @@ cs_parse_results(
      *
      *	<filename> <context> <line number> <pattern>
      */
-    if ((name = strtok((char *)buf, (const char *)" ")) == NULL)
+    if ((name = strtok(buf, (const char *)" ")) == NULL)
 	return NULL;
     if ((*context = strtok(NULL, (const char *)" ")) == NULL)
 	return NULL;

--- a/src/indent.c
+++ b/src/indent.c
@@ -112,12 +112,12 @@ tabstop_padding(colnr_T col, int ts_arg, int *vts)
 	tabcol += vts[t];
 	if (tabcol > col)
 	{
-	    padding = (int)(tabcol - col);
+	    padding = (tabcol - col);
 	    break;
 	}
     }
     if (t > tabcount)
-	padding = vts[tabcount] - (int)((col - tabcol) % vts[tabcount]);
+	padding = vts[tabcount] - ((col - tabcol) % vts[tabcount]);
 
     return padding;
 }
@@ -224,12 +224,12 @@ tabstop_fromto(
 	tabcol += vts[t];
 	if (tabcol > start_col)
 	{
-	    padding = (int)(tabcol - start_col);
+	    padding = (tabcol - start_col);
 	    break;
 	}
     }
     if (t > tabcount)
-	padding = vts[tabcount] - (int)((start_col - tabcol) % vts[tabcount]);
+	padding = vts[tabcount] - ((start_col - tabcol) % vts[tabcount]);
 
     // If the space needed is less than the padding no tabs can be used.
     if (spaces < padding)

--- a/src/json.c
+++ b/src/json.c
@@ -217,7 +217,7 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 
 	case VAR_NUMBER:
 	    vim_snprintf((char *)numbuf, NUMBUFLEN, "%lld",
-					      (varnumber_T)val->vval.v_number);
+					      val->vval.v_number);
 	    ga_concat(gap, numbuf);
 	    break;
 
@@ -246,7 +246,7 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 		    if (i > 0)
 			ga_concat(gap, (char_u *)",");
 		    vim_snprintf((char *)numbuf, NUMBUFLEN, "%d",
-			    (int)blob_get(b, i));
+			    blob_get(b, i));
 		    ga_concat(gap, numbuf);
 		}
 		ga_append(gap, ']');

--- a/src/map.c
+++ b/src/map.c
@@ -1703,7 +1703,7 @@ vim_unescape_csi(char_u *p)
 	    s += 3;
 	}
 	else if ((s[0] == K_SPECIAL || s[0] == CSI)
-				   && s[1] == KS_EXTRA && s[2] == (int)KE_CSI)
+				   && s[1] == KS_EXTRA && s[2] == KE_CSI)
 	{
 	    *d++ = CSI;
 	    s += 3;
@@ -1766,7 +1766,7 @@ makemap(
 		// they probably don't work when loaded again
 		for (p = mp->m_str; *p != NUL; ++p)
 		    if (p[0] == K_SPECIAL && p[1] == KS_EXTRA
-						       && p[2] == (int)KE_SNR)
+						       && p[2] == KE_SNR)
 			break;
 		if (*p != NUL)
 		    continue;

--- a/src/match.c
+++ b/src/match.c
@@ -1032,7 +1032,7 @@ f_getmatches(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 	{
 	    char_u buf[MB_MAXBYTES + 1];
 
-	    buf[(*mb_char2bytes)((int)cur->conceal_char, buf)] = NUL;
+	    buf[(*mb_char2bytes)(cur->conceal_char, buf)] = NUL;
 	    dict_add_string(dict, "conceal", (char_u *)&buf);
 	}
 #  endif
@@ -1305,7 +1305,7 @@ f_matcharg(typval_T *argvars UNUSED, typval_T *rettv)
 	id = (int)tv_get_number(&argvars[0]);
 	if (id >= 1 && id <= 3)
 	{
-	    if ((m = (matchitem_T *)get_match(curwin, id)) != NULL)
+	    if ((m = get_match(curwin, id)) != NULL)
 	    {
 		list_append_string(rettv->vval.v_list,
 						syn_id2name(m->hlg_id), -1);

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4380,7 +4380,7 @@ mb_unescape(char_u **pp)
 # endif
 		 )
 		&& str[n + 1] == KS_EXTRA
-		&& str[n + 2] == (int)KE_CSI)
+		&& str[n + 2] == KE_CSI)
 	{
 	    buf[m++] = CSI;
 	    n += 2;

--- a/src/memline.c
+++ b/src/memline.c
@@ -334,7 +334,7 @@ ml_open(buf_T *buf)
 
     b0p->b0_id[0] = BLOCK0_ID0;
     b0p->b0_id[1] = BLOCK0_ID1;
-    b0p->b0_magic_long = (long)B0_MAGIC_LONG;
+    b0p->b0_magic_long = B0_MAGIC_LONG;
     b0p->b0_magic_int = (int)B0_MAGIC_INT;
     b0p->b0_magic_short = (short)B0_MAGIC_SHORT;
     b0p->b0_magic_char = B0_MAGIC_CHAR;
@@ -550,7 +550,7 @@ ml_set_crypt_key(
 		mf_put(mfp, hp, FALSE, FALSE);	// release previous block
 
 	    // get the block (pointer or data)
-	    if ((hp = mf_get(mfp, (blocknr_T)bnum, page_count)) == NULL)
+	    if ((hp = mf_get(mfp, bnum, page_count)) == NULL)
 	    {
 		if (bnum == 1)
 		    break;
@@ -1507,7 +1507,7 @@ ml_recover(int checkext)
 	/*
 	 * get block
 	 */
-	if ((hp = mf_get(mfp, (blocknr_T)bnum, page_count)) == NULL)
+	if ((hp = mf_get(mfp, bnum, page_count)) == NULL)
 	{
 	    if (bnum == 1)
 	    {
@@ -3661,7 +3661,7 @@ ml_delete_int(buf_T *buf, linenr_T lnum, int flags)
 
 #ifdef FEAT_NETBEANS_INTG
     if (netbeans_active())
-	netbeans_removed(buf, lnum, 0, (long)line_size);
+	netbeans_removed(buf, lnum, 0, line_size);
 #endif
 #ifdef FEAT_PROP_POPUP
     // If there are text properties, make a copy, so that we can update
@@ -5160,7 +5160,7 @@ findswapname(
     static int
 b0_magic_wrong(ZERO_BL *b0p)
 {
-    return (b0p->b0_magic_long != (long)B0_MAGIC_LONG
+    return (b0p->b0_magic_long != B0_MAGIC_LONG
 	    || b0p->b0_magic_int != (int)B0_MAGIC_INT
 	    || b0p->b0_magic_short != (short)B0_MAGIC_SHORT
 	    || b0p->b0_magic_char != B0_MAGIC_CHAR);

--- a/src/message.c
+++ b/src/message.c
@@ -164,7 +164,7 @@ msg_attr_keep(
 #ifdef FEAT_JOB_CHANNEL
     if (emsg_to_channel_log)
 	// Write message in the channel log.
-	ch_log(NULL, "ERROR: %s", (char *)s);
+	ch_log(NULL, "ERROR: %s", s);
 #endif
 
     // Truncate the message if needed.
@@ -891,7 +891,7 @@ emsg_invreg(int name)
     void
 emsg_namelen(char *msg, char_u *name, int len)
 {
-    char_u *copy = vim_strnsave((char_u *)name, len);
+    char_u *copy = vim_strnsave(name, len);
 
     semsg(msg, copy == NULL ? "NULL" : (char *)copy);
     vim_free(copy);
@@ -2438,7 +2438,7 @@ inc_msg_scrolled(void)
 	    if (tofree != NULL)
 	    {
 		vim_snprintf((char *)tofree, len, _("%s line %ld"),
-						      p, (long)SOURCING_LNUM);
+						      p, SOURCING_LNUM);
 		p = tofree;
 	    }
 	}
@@ -3681,7 +3681,7 @@ give_warning2(char_u *message, char_u *a1, int hl)
     {
 	// Very early in initialisation and already something wrong, just give
 	// the raw message so the user at least gets a hint.
-	give_warning((char_u *)message, hl);
+	give_warning(message, hl);
     }
     else
     {

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -379,7 +379,7 @@ plines_win_nofill(
 
     lines = plines_win_nofold(wp, lnum);
     if (winheight > 0 && lines > wp->w_height)
-	return (int)wp->w_height;
+	return wp->w_height;
     return lines;
 }
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -806,15 +806,15 @@ static char_u modifier_keys_table[] =
     MOD_MASK_SHIFT, '*', '4',			'k', 'D',	// delete char
     MOD_MASK_SHIFT, '*', '5',			'k', 'L',	// delete line
     MOD_MASK_SHIFT, '*', '7',			'@', '7',	// end
-    MOD_MASK_CTRL,  KS_EXTRA, (int)KE_C_END,	'@', '7',	// end
+    MOD_MASK_CTRL,  KS_EXTRA, KE_C_END,	'@', '7',	// end
     MOD_MASK_SHIFT, '*', '9',			'@', '9',	// exit
     MOD_MASK_SHIFT, '*', '0',			'@', '0',	// find
     MOD_MASK_SHIFT, '#', '1',			'%', '1',	// help
     MOD_MASK_SHIFT, '#', '2',			'k', 'h',	// home
-    MOD_MASK_CTRL,  KS_EXTRA, (int)KE_C_HOME,	'k', 'h',	// home
+    MOD_MASK_CTRL,  KS_EXTRA, KE_C_HOME,	'k', 'h',	// home
     MOD_MASK_SHIFT, '#', '3',			'k', 'I',	// insert
     MOD_MASK_SHIFT, '#', '4',			'k', 'l',	// left arrow
-    MOD_MASK_CTRL,  KS_EXTRA, (int)KE_C_LEFT,	'k', 'l',	// left arrow
+    MOD_MASK_CTRL,  KS_EXTRA, KE_C_LEFT,	'k', 'l',	// left arrow
     MOD_MASK_SHIFT, '%', 'a',			'%', '3',	// message
     MOD_MASK_SHIFT, '%', 'b',			'%', '4',	// move
     MOD_MASK_SHIFT, '%', 'c',			'%', '5',	// next
@@ -824,63 +824,63 @@ static char_u modifier_keys_table[] =
     MOD_MASK_SHIFT, '%', 'g',			'%', '0',	// redo
     MOD_MASK_SHIFT, '%', 'h',			'&', '3',	// replace
     MOD_MASK_SHIFT, '%', 'i',			'k', 'r',	// right arr.
-    MOD_MASK_CTRL,  KS_EXTRA, (int)KE_C_RIGHT,	'k', 'r',	// right arr.
+    MOD_MASK_CTRL,  KS_EXTRA, KE_C_RIGHT,	'k', 'r',	// right arr.
     MOD_MASK_SHIFT, '%', 'j',			'&', '5',	// resume
     MOD_MASK_SHIFT, '!', '1',			'&', '6',	// save
     MOD_MASK_SHIFT, '!', '2',			'&', '7',	// suspend
     MOD_MASK_SHIFT, '!', '3',			'&', '8',	// undo
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_UP,	'k', 'u',	// up arrow
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_DOWN,	'k', 'd',	// down arrow
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_UP,	'k', 'u',	// up arrow
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_DOWN,	'k', 'd',	// down arrow
 
 								// vt100 F1
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_XF1,	KS_EXTRA, (int)KE_XF1,
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_XF2,	KS_EXTRA, (int)KE_XF2,
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_XF3,	KS_EXTRA, (int)KE_XF3,
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_XF4,	KS_EXTRA, (int)KE_XF4,
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_XF1,	KS_EXTRA, KE_XF1,
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_XF2,	KS_EXTRA, KE_XF2,
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_XF3,	KS_EXTRA, KE_XF3,
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_XF4,	KS_EXTRA, KE_XF4,
 
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F1,	'k', '1',	// F1
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F2,	'k', '2',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F3,	'k', '3',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F4,	'k', '4',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F5,	'k', '5',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F6,	'k', '6',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F7,	'k', '7',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F8,	'k', '8',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F9,	'k', '9',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F10,	'k', ';',	// F10
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F1,	'k', '1',	// F1
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F2,	'k', '2',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F3,	'k', '3',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F4,	'k', '4',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F5,	'k', '5',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F6,	'k', '6',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F7,	'k', '7',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F8,	'k', '8',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F9,	'k', '9',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F10,	'k', ';',	// F10
 
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F11,	'F', '1',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F12,	'F', '2',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F13,	'F', '3',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F14,	'F', '4',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F15,	'F', '5',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F16,	'F', '6',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F17,	'F', '7',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F18,	'F', '8',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F19,	'F', '9',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F20,	'F', 'A',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F11,	'F', '1',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F12,	'F', '2',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F13,	'F', '3',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F14,	'F', '4',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F15,	'F', '5',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F16,	'F', '6',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F17,	'F', '7',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F18,	'F', '8',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F19,	'F', '9',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F20,	'F', 'A',
 
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F21,	'F', 'B',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F22,	'F', 'C',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F23,	'F', 'D',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F24,	'F', 'E',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F25,	'F', 'F',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F26,	'F', 'G',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F27,	'F', 'H',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F28,	'F', 'I',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F29,	'F', 'J',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F30,	'F', 'K',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F21,	'F', 'B',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F22,	'F', 'C',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F23,	'F', 'D',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F24,	'F', 'E',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F25,	'F', 'F',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F26,	'F', 'G',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F27,	'F', 'H',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F28,	'F', 'I',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F29,	'F', 'J',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F30,	'F', 'K',
 
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F31,	'F', 'L',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F32,	'F', 'M',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F33,	'F', 'N',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F34,	'F', 'O',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F35,	'F', 'P',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F36,	'F', 'Q',
-    MOD_MASK_SHIFT, KS_EXTRA, (int)KE_S_F37,	'F', 'R',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F31,	'F', 'L',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F32,	'F', 'M',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F33,	'F', 'N',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F34,	'F', 'O',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F35,	'F', 'P',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F36,	'F', 'Q',
+    MOD_MASK_SHIFT, KS_EXTRA, KE_S_F37,	'F', 'R',
 
 							    // TAB pseudo code
-    MOD_MASK_SHIFT, 'k', 'B',			KS_EXTRA, (int)KE_TAB,
+    MOD_MASK_SHIFT, 'k', 'B',			KS_EXTRA, KE_TAB,
 
     NUL
 };

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -692,8 +692,8 @@ do_mouse(
     {
 	int key = KEY2TERMCAP1(c);
 
-	if (key == (int)KE_LEFTRELEASE || key == (int)KE_MIDDLERELEASE
-					       || key == (int)KE_RIGHTRELEASE)
+	if (key == KE_LEFTRELEASE || key == KE_MIDDLERELEASE
+					       || key == KE_RIGHTRELEASE)
 	    netbeans_button_release(which_button);
     }
 #endif
@@ -1102,7 +1102,7 @@ ins_mousescroll(int dir)
 	{
 	    if (mod_mask & (MOD_MASK_SHIFT | MOD_MASK_CTRL))
 		scroll_redraw(dir,
-			(long)(curwin->w_botline - curwin->w_topline));
+			(curwin->w_botline - curwin->w_topline));
 	    else
 		scroll_redraw(dir, 3L);
 # ifdef FEAT_PROP_POPUP
@@ -1187,31 +1187,31 @@ static struct mousetable
     int	    is_drag;		// Is it a mouse drag event?
 } mouse_table[] =
 {
-    {(int)KE_LEFTMOUSE,		MOUSE_LEFT,	TRUE,	FALSE},
+    {KE_LEFTMOUSE,		MOUSE_LEFT,	TRUE,	FALSE},
 #ifdef FEAT_GUI
-    {(int)KE_LEFTMOUSE_NM,	MOUSE_LEFT,	TRUE,	FALSE},
+    {KE_LEFTMOUSE_NM,	MOUSE_LEFT,	TRUE,	FALSE},
 #endif
-    {(int)KE_LEFTDRAG,		MOUSE_LEFT,	FALSE,	TRUE},
-    {(int)KE_LEFTRELEASE,	MOUSE_LEFT,	FALSE,	FALSE},
+    {KE_LEFTDRAG,		MOUSE_LEFT,	FALSE,	TRUE},
+    {KE_LEFTRELEASE,	MOUSE_LEFT,	FALSE,	FALSE},
 #ifdef FEAT_GUI
-    {(int)KE_LEFTRELEASE_NM,	MOUSE_LEFT,	FALSE,	FALSE},
+    {KE_LEFTRELEASE_NM,	MOUSE_LEFT,	FALSE,	FALSE},
 #endif
-    {(int)KE_MIDDLEMOUSE,	MOUSE_MIDDLE,	TRUE,	FALSE},
-    {(int)KE_MIDDLEDRAG,	MOUSE_MIDDLE,	FALSE,	TRUE},
-    {(int)KE_MIDDLERELEASE,	MOUSE_MIDDLE,	FALSE,	FALSE},
-    {(int)KE_RIGHTMOUSE,	MOUSE_RIGHT,	TRUE,	FALSE},
-    {(int)KE_RIGHTDRAG,		MOUSE_RIGHT,	FALSE,	TRUE},
-    {(int)KE_RIGHTRELEASE,	MOUSE_RIGHT,	FALSE,	FALSE},
-    {(int)KE_X1MOUSE,		MOUSE_X1,	TRUE,	FALSE},
-    {(int)KE_X1DRAG,		MOUSE_X1,	FALSE,	TRUE},
-    {(int)KE_X1RELEASE,		MOUSE_X1,	FALSE,	FALSE},
-    {(int)KE_X2MOUSE,		MOUSE_X2,	TRUE,	FALSE},
-    {(int)KE_X2DRAG,		MOUSE_X2,	FALSE,	TRUE},
-    {(int)KE_X2RELEASE,		MOUSE_X2,	FALSE,	FALSE},
+    {KE_MIDDLEMOUSE,	MOUSE_MIDDLE,	TRUE,	FALSE},
+    {KE_MIDDLEDRAG,	MOUSE_MIDDLE,	FALSE,	TRUE},
+    {KE_MIDDLERELEASE,	MOUSE_MIDDLE,	FALSE,	FALSE},
+    {KE_RIGHTMOUSE,	MOUSE_RIGHT,	TRUE,	FALSE},
+    {KE_RIGHTDRAG,		MOUSE_RIGHT,	FALSE,	TRUE},
+    {KE_RIGHTRELEASE,	MOUSE_RIGHT,	FALSE,	FALSE},
+    {KE_X1MOUSE,		MOUSE_X1,	TRUE,	FALSE},
+    {KE_X1DRAG,		MOUSE_X1,	FALSE,	TRUE},
+    {KE_X1RELEASE,		MOUSE_X1,	FALSE,	FALSE},
+    {KE_X2MOUSE,		MOUSE_X2,	TRUE,	FALSE},
+    {KE_X2DRAG,		MOUSE_X2,	FALSE,	TRUE},
+    {KE_X2RELEASE,		MOUSE_X2,	FALSE,	FALSE},
     // DRAG without CLICK
-    {(int)KE_MOUSEMOVE,		MOUSE_RELEASE,	FALSE,	TRUE},
+    {KE_MOUSEMOVE,		MOUSE_RELEASE,	FALSE,	TRUE},
     // RELEASE without CLICK
-    {(int)KE_IGNORE,		MOUSE_RELEASE,	FALSE,	FALSE},
+    {KE_IGNORE,		MOUSE_RELEASE,	FALSE,	FALSE},
     {0,				0,		0,	0},
 };
 
@@ -1262,15 +1262,15 @@ get_pseudo_mouse_code(
 		    mouse_col = 0;
 		else
 		    mouse_col -= MOUSE_COLOFF;
-		if (mouse_table[i].pseudo_code == (int)KE_LEFTMOUSE)
-		    return (int)KE_LEFTMOUSE_NM;
-		if (mouse_table[i].pseudo_code == (int)KE_LEFTRELEASE)
-		    return (int)KE_LEFTRELEASE_NM;
+		if (mouse_table[i].pseudo_code == KE_LEFTMOUSE)
+		    return KE_LEFTMOUSE_NM;
+		if (mouse_table[i].pseudo_code == KE_LEFTRELEASE)
+		    return KE_LEFTRELEASE_NM;
 	    }
 #endif
 	    return mouse_table[i].pseudo_code;
 	}
-    return (int)KE_IGNORE;	    // not recognized, ignore it
+    return KE_IGNORE;	    // not recognized, ignore it
 }
 
 # define HMT_NORMAL	1
@@ -2818,13 +2818,13 @@ check_termcode_mouse(
 	    *modifiers |= MOD_MASK_ALT;
 
 	if (wheel_code & 1 && wheel_code & 2)
-	    key_name[1] = (int)KE_MOUSELEFT;
+	    key_name[1] = KE_MOUSELEFT;
 	else if (wheel_code & 2)
-	    key_name[1] = (int)KE_MOUSERIGHT;
+	    key_name[1] = KE_MOUSERIGHT;
 	else if (wheel_code & 1)
-	    key_name[1] = (int)KE_MOUSEUP;
+	    key_name[1] = KE_MOUSEUP;
 	else
-	    key_name[1] = (int)KE_MOUSEDOWN;
+	    key_name[1] = KE_MOUSEDOWN;
 
 	held_button = MOUSE_RELEASE;
     }

--- a/src/move.c
+++ b/src/move.c
@@ -1028,7 +1028,7 @@ curs_columns(
 	    // column
 	    sbr = get_showbreak_value(curwin);
 	    if (*sbr && *ml_get_cursor() == NUL
-				    && curwin->w_wcol == (int)vim_strsize(sbr))
+				    && curwin->w_wcol == vim_strsize(sbr))
 		curwin->w_wcol = 0;
 #endif
 	}

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -937,7 +937,7 @@ nb_partialremove(linenr_T lnum, colnr_T first, colnr_T last)
 	return;
     if (lastbyte >= oldlen)
 	lastbyte = oldlen - 1;
-    newtext = alloc(oldlen - (int)(lastbyte - first));
+    newtext = alloc(oldlen - (lastbyte - first));
     if (newtext != NULL)
     {
 	mch_memmove(newtext, oldtext, first);

--- a/src/normal.c
+++ b/src/normal.c
@@ -3393,7 +3393,7 @@ nv_colon(cmdarg_T *cap)
 	    if (cap->count0 > 1)
 	    {
 		stuffReadbuff((char_u *)",.+");
-		stuffnumReadbuff((long)cap->count0 - 1L);
+		stuffnumReadbuff(cap->count0 - 1L);
 	    }
 	}
 
@@ -4304,7 +4304,7 @@ nv_dollar(cmdarg_T *cap)
     if (!virtual_active() || gchar_cursor() != NUL
 					       || cap->oap->op_type == OP_NOP)
 	curwin->w_curswant = MAXCOL;	// so we stay at the end
-    if (cursor_down((long)(cap->count1 - 1),
+    if (cursor_down((cap->count1 - 1),
 					 cap->oap->op_type == OP_NOP) == FAIL)
 	clearopbeep(cap->oap);
 #ifdef FEAT_FOLDING
@@ -5127,7 +5127,7 @@ nv_replace(cmdarg_T *cap)
 		colnr_T  start = (colnr_T)(curwin->w_cursor.col - cap->count1);
 
 		netbeans_removed(curbuf, curwin->w_cursor.lnum, start,
-							   (long)cap->count1);
+							   cap->count1);
 		netbeans_inserted(curbuf, curwin->w_cursor.lnum, start,
 					       &ptr[start], (int)cap->count1);
 	    }
@@ -6095,7 +6095,7 @@ nv_g_cmd(cmdarg_T *cap)
 	cap->oap->motion_type = MCHAR;
 	cap->oap->inclusive = TRUE;
 	curwin->w_curswant = MAXCOL;
-	if (cursor_down((long)(cap->count1 - 1),
+	if (cursor_down((cap->count1 - 1),
 					 cap->oap->op_type == OP_NOP) == FAIL)
 	    clearopbeep(cap->oap);
 	else

--- a/src/ops.c
+++ b/src/ops.c
@@ -335,7 +335,7 @@ shift_block(oparg_T *oap, int amount)
 	{
 	    // TODO: is passing bd.textstart for start of the line OK?
 	    incr = lbr_chartabsize_adv(bd.textstart, &bd.textstart,
-						    (colnr_T)(bd.start_vcol));
+						    (bd.start_vcol));
 	    total += incr;
 	    bd.start_vcol += incr;
 	}
@@ -460,7 +460,7 @@ shift_block(oparg_T *oap, int amount)
     }
     // replace the line
     ml_replace(curwin->w_cursor.lnum, newp, FALSE);
-    changed_bytes(curwin->w_cursor.lnum, (colnr_T)bd.textcol);
+    changed_bytes(curwin->w_cursor.lnum, bd.textcol);
     State = oldstate;
     curwin->w_cursor.col = oldcol;
 #ifdef FEAT_RIGHTLEFT
@@ -819,7 +819,7 @@ op_delete(oparg_T *oap)
 	    {
 		lnum = curwin->w_cursor.lnum;
 		++curwin->w_cursor.lnum;
-		del_lines((long)(oap->line_count - 1), TRUE);
+		del_lines((oap->line_count - 1), TRUE);
 		curwin->w_cursor.lnum = lnum;
 	    }
 	    if (u_save_cursor() == FAIL)
@@ -934,7 +934,7 @@ op_delete(oparg_T *oap)
 
 	    curpos = curwin->w_cursor;	// remember curwin->w_cursor
 	    ++curwin->w_cursor.lnum;
-	    del_lines((long)(oap->line_count - 2), FALSE);
+	    del_lines((oap->line_count - 2), FALSE);
 
 	    // delete from start of line until op_end
 	    n = (oap->end.col + 1 - !oap->inclusive);
@@ -2110,12 +2110,12 @@ do_join(
 	// what is added if it is inside these spaces.
 	spaces_removed = (curr - curr_start) - spaces[t];
 
-	mark_col_adjust(curwin->w_cursor.lnum + t, (colnr_T)0, (linenr_T)-t,
-			 (long)(cend - newp - spaces_removed), spaces_removed);
+	mark_col_adjust(curwin->w_cursor.lnum + t, (colnr_T)0, -t,
+			 (cend - newp - spaces_removed), spaces_removed);
 #ifdef FEAT_PROP_POPUP
 	prepend_joined_props(newp + sumsize + 1, propcount, &props_remaining,
 		curwin->w_cursor.lnum + t, t == count - 1,
-		(long)(cend - newp), spaces_removed);
+		(cend - newp), spaces_removed);
 #endif
 
 	if (t == 0)
@@ -2220,7 +2220,7 @@ block_prep(
     while (bdp->start_vcol < oap->start_vcol && *pstart)
     {
 	// Count a tab for what it's worth (if list mode not on)
-	incr = lbr_chartabsize(line, pstart, (colnr_T)bdp->start_vcol);
+	incr = lbr_chartabsize(line, pstart, bdp->start_vcol);
 	bdp->start_vcol += incr;
 	if (VIM_ISWHITE(*pstart))
 	{
@@ -2283,7 +2283,7 @@ block_prep(
 	    {
 		// Count a tab for what it's worth (if list mode not on)
 		prev_pend = pend;
-		incr = lbr_chartabsize_adv(line, &pend, (colnr_T)bdp->end_vcol);
+		incr = lbr_chartabsize_adv(line, &pend, bdp->end_vcol);
 		bdp->end_vcol += incr;
 	    }
 	    if (bdp->end_vcol <= oap->end_vcol
@@ -2843,13 +2843,13 @@ do_addsub(
 	    buf2[i] = '\0';
 	}
 	else if (pre == 0)
-	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llu", (uvarnumber_T)n);
+	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llu", n);
 	else if (pre == '0')
-	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llo", (uvarnumber_T)n);
+	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llo", n);
 	else if (pre && hexupper)
-	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llX", (uvarnumber_T)n);
+	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llX", n);
 	else
-	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llx", (uvarnumber_T)n);
+	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llx", n);
 	length -= (int)STRLEN(buf2);
 
 	/*
@@ -3168,21 +3168,21 @@ cursor_pos_info(dict_T *dict)
 			    _("Selected %s%ld of %ld Lines; %lld of %lld Words; %lld of %lld Bytes"),
 			    buf1, line_count_selected,
 			    (long)curbuf->b_ml.ml_line_count,
-			    (varnumber_T)word_count_cursor,
-			    (varnumber_T)word_count,
-			    (varnumber_T)byte_count_cursor,
-			    (varnumber_T)byte_count);
+			    word_count_cursor,
+			    word_count,
+			    byte_count_cursor,
+			    byte_count);
 		else
 		    vim_snprintf((char *)IObuff, IOSIZE,
 			    _("Selected %s%ld of %ld Lines; %lld of %lld Words; %lld of %lld Chars; %lld of %lld Bytes"),
 			    buf1, line_count_selected,
 			    (long)curbuf->b_ml.ml_line_count,
-			    (varnumber_T)word_count_cursor,
-			    (varnumber_T)word_count,
-			    (varnumber_T)char_count_cursor,
-			    (varnumber_T)char_count,
-			    (varnumber_T)byte_count_cursor,
-			    (varnumber_T)byte_count);
+			    word_count_cursor,
+			    word_count,
+			    char_count_cursor,
+			    char_count,
+			    byte_count_cursor,
+			    byte_count);
 	    }
 	    else
 	    {
@@ -3200,17 +3200,17 @@ cursor_pos_info(dict_T *dict)
 			(char *)buf1, (char *)buf2,
 			(long)curwin->w_cursor.lnum,
 			(long)curbuf->b_ml.ml_line_count,
-			(varnumber_T)word_count_cursor, (varnumber_T)word_count,
-			(varnumber_T)byte_count_cursor, (varnumber_T)byte_count);
+			word_count_cursor, word_count,
+			byte_count_cursor, byte_count);
 		else
 		    vim_snprintf((char *)IObuff, IOSIZE,
 			_("Col %s of %s; Line %ld of %ld; Word %lld of %lld; Char %lld of %lld; Byte %lld of %lld"),
 			(char *)buf1, (char *)buf2,
 			(long)curwin->w_cursor.lnum,
 			(long)curbuf->b_ml.ml_line_count,
-			(varnumber_T)word_count_cursor, (varnumber_T)word_count,
-			(varnumber_T)char_count_cursor, (varnumber_T)char_count,
-			(varnumber_T)byte_count_cursor, (varnumber_T)byte_count);
+			word_count_cursor, word_count,
+			char_count_cursor, char_count,
+			byte_count_cursor, byte_count);
 	    }
 	}
 
@@ -3220,7 +3220,7 @@ cursor_pos_info(dict_T *dict)
 	    size_t len = STRLEN(IObuff);
 
 	    vim_snprintf((char *)IObuff + len, IOSIZE - len,
-				 _("(+%lld for BOM)"), (varnumber_T)bom_count);
+				 _("(+%lld for BOM)"), bom_count);
 	}
 	if (dict == NULL)
 	{
@@ -3273,7 +3273,7 @@ op_colon(oparg_T *oap)
 	    else if (oap->start.lnum == curwin->w_cursor.lnum)
 	    {
 		stuffReadbuff((char_u *)".+");
-		stuffnumReadbuff((long)oap->line_count - 1);
+		stuffnumReadbuff(oap->line_count - 1);
 	    }
 	    else
 		stuffnumReadbuff((long)oap->end.lnum);

--- a/src/option.c
+++ b/src/option.c
@@ -3694,7 +3694,7 @@ set_num_option(
     {
 	if (errbuf != NULL)
 	{
-	    vim_snprintf((char *)errbuf, errbuflen,
+	    vim_snprintf(errbuf, errbuflen,
 			       _("E593: Need at least %d lines"), min_rows());
 	    errmsg = errbuf;
 	}
@@ -3704,7 +3704,7 @@ set_num_option(
     {
 	if (errbuf != NULL)
 	{
-	    vim_snprintf((char *)errbuf, errbuflen,
+	    vim_snprintf(errbuf, errbuflen,
 			    _("E594: Need at least %d columns"), MIN_COLUMNS);
 	    errmsg = errbuf;
 	}

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -181,7 +181,7 @@ trigger_optionsset_string(
 	    set_vim_var_string(VV_OPTION_OLDLOCAL, oldval, -1);
 	}
 	apply_autocmds(EVENT_OPTIONSET,
-		       (char_u *)get_option_fullname(opt_idx), NULL, FALSE,
+		       get_option_fullname(opt_idx), NULL, FALSE,
 		       NULL);
 	reset_v_option_vars();
     }

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -5625,7 +5625,7 @@ mch_job_start(char **argv, job_T *job, jobopt_T *options, int is_terminal)
 		{
 		    typval_T *item = &dict_lookup(hi)->di_tv;
 
-		    vim_setenv((char_u*)hi->hi_key, tv_get_string(item));
+		    vim_setenv(hi->hi_key, tv_get_string(item));
 		    --todo;
 		}
 	}
@@ -7429,7 +7429,7 @@ mch_libcall(
     if (hinstLib == NULL)
     {
 	// "dlerr" must be used before dlclose()
-	dlerr = (char *)dlerror();
+	dlerr = dlerror();
 	if (dlerr != NULL)
 	    semsg(_("dlerror = \"%s\""), dlerr);
     }
@@ -7464,7 +7464,7 @@ mch_libcall(
 	    {
 # if defined(USE_DLOPEN)
 		*(void **)(&ProcAdd) = dlsym(hinstLib, (const char *)funcname);
-		dlerr = (char *)dlerror();
+		dlerr = dlerror();
 # else
 		if (shl_findsym(&hinstLib, (const char *)funcname,
 					TYPE_PROCEDURE, (void *)&ProcAdd) < 0)
@@ -7486,7 +7486,7 @@ mch_libcall(
 	    {
 # if defined(USE_DLOPEN)
 		*(void **)(&ProcAddI) = dlsym(hinstLib, (const char *)funcname);
-		dlerr = (char *)dlerror();
+		dlerr = dlerror();
 # else
 		if (shl_findsym(&hinstLib, (const char *)funcname,
 				       TYPE_PROCEDURE, (void *)&ProcAddI) < 0)

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3131,7 +3131,7 @@ f_popup_getoptions(typval_T *argvars, typval_T *rettv)
 
 # if defined(FEAT_TIMERS)
 	dict_add_number(dict, "time", wp->w_popup_timer != NULL
-				 ?  (long)wp->w_popup_timer->tr_interval : 0L);
+				 ?  wp->w_popup_timer->tr_interval : 0L);
 # endif
     }
 }

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -128,7 +128,7 @@ profile_setlimit(long msec, proftime_T *tm)
 	long	    usec;
 
 	gettimeofday(tm, NULL);
-	usec = (long)tm->tv_usec + (long)msec * 1000;
+	usec = (long)tm->tv_usec + msec * 1000;
 	tm->tv_usec = usec % 1000000L;
 	tm->tv_sec += usec / 1000000L;
 # endif

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -4744,7 +4744,7 @@ qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int qf_winid)
 	    lnum = buf->b_ml.ml_line_count;
 	}
 
-	qftf_list = call_qftf_func(qfl, qf_winid, (long)(lnum + 1),
+	qftf_list = call_qftf_func(qfl, qf_winid, (lnum + 1),
 							(long)qfl->qf_count);
 	if (qftf_list != NULL)
 	    qftf_li = qftf_list->lv_first;

--- a/src/register.c
+++ b/src/register.c
@@ -1844,7 +1844,7 @@ do_put(
 	    for (ptr = oldp; vcol < col && *ptr; )
 	    {
 		// Count a tab for what it's worth (if list mode not on)
-		incr = lbr_chartabsize_adv(oldp, &ptr, (colnr_T)vcol);
+		incr = lbr_chartabsize_adv(oldp, &ptr, vcol);
 		vcol += incr;
 	    }
 	    bd.textcol = (colnr_T)(ptr - oldp);

--- a/src/screen.c
+++ b/src/screen.c
@@ -153,13 +153,13 @@ screen_fill_end(
     if (wp->w_p_rl)
     {
 	screen_fill(W_WINROW(wp) + row, W_WINROW(wp) + endrow,
-		W_ENDCOL(wp) - nn, (int)W_ENDCOL(wp) - off,
+		W_ENDCOL(wp) - nn, W_ENDCOL(wp) - off,
 		c1, c2, attr);
     }
     else
 #endif
 	screen_fill(W_WINROW(wp) + row, W_WINROW(wp) + endrow,
-		wp->w_wincol + off, (int)wp->w_wincol + nn,
+		wp->w_wincol + off, wp->w_wincol + nn,
 		c1, c2, attr);
     return nn;
 }
@@ -222,7 +222,7 @@ win_draw_end(
 #endif
     {
 	screen_fill(W_WINROW(wp) + row, W_WINROW(wp) + endrow,
-		wp->w_wincol + n, (int)W_ENDCOL(wp),
+		wp->w_wincol + n, W_ENDCOL(wp),
 		c1, c2, attr);
     }
 
@@ -3363,7 +3363,7 @@ setcursor_mayforce(int force)
 #ifdef FEAT_RIGHTLEFT
 		// With 'rightleft' set and the cursor on a double-wide
 		// character, position it on the leftmost column.
-		curwin->w_p_rl ? ((int)curwin->w_width - curwin->w_wcol
+		curwin->w_p_rl ? (curwin->w_width - curwin->w_wcol
 		    - ((has_mbyte
 			   && (*mb_ptr2cells)(ml_get_cursor()) == 2
 			   && vim_isprintc(gchar_cursor())) ? 2 : 1)) :
@@ -3433,7 +3433,7 @@ win_ins_lines(
 	if (lastrow > Rows)
 	    lastrow = Rows;
 	screen_fill(nextrow - line_count, lastrow - line_count,
-		  wp->w_wincol, (int)W_ENDCOL(wp),
+		  wp->w_wincol, W_ENDCOL(wp),
 		  ' ', ' ', 0);
     }
 
@@ -3548,7 +3548,7 @@ win_do_lines(
     if (row + line_count >= wp->w_height)
     {
 	screen_fill(W_WINROW(wp) + row, W_WINROW(wp) + wp->w_height,
-		wp->w_wincol, (int)W_ENDCOL(wp),
+		wp->w_wincol, W_ENDCOL(wp),
 		' ', ' ', 0);
 	return OK;
     }
@@ -4202,7 +4202,7 @@ showmode(void)
 		    if (edit_submode_extra != NULL)
 		    {
 			msg_puts_attr(" ", attr);  // add a space in between
-			if ((int)edit_submode_highl < (int)HLF_COUNT)
+			if ((int)edit_submode_highl < HLF_COUNT)
 			    sub_attr = HL_ATTR(edit_submode_highl);
 			else
 			    sub_attr = attr;

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1330,7 +1330,7 @@ do_source(
 	// It's new, generate a new SID.
 	current_sctx.sc_sid = ++last_current_SID;
 	if (ga_grow(&script_items,
-		     (int)(current_sctx.sc_sid - script_items.ga_len)) == FAIL)
+		     (current_sctx.sc_sid - script_items.ga_len)) == FAIL)
 	    goto almosttheend;
 	while (script_items.ga_len < current_sctx.sc_sid)
 	{

--- a/src/search.c
+++ b/src/search.c
@@ -3035,7 +3035,7 @@ current_search(
 
 	result = searchit(curwin, curbuf, &pos, &end_pos,
 		(dir ? FORWARD : BACKWARD),
-		spats[last_idx].pat, (long) (i ? count : 1),
+		spats[last_idx].pat, (i ? count : 1),
 		SEARCH_KEEP | flags, RE_SEARCH, NULL);
 
 	p_ws = old_p_ws;

--- a/src/session.c
+++ b/src/session.c
@@ -464,7 +464,7 @@ put_view(
 	else if (fprintf(fd,
 		    "let s:l = %ld - ((%ld * winheight(0) + %ld) / %ld)",
 		    (long)wp->w_cursor.lnum,
-		    (long)(wp->w_cursor.lnum - wp->w_topline),
+		    (wp->w_cursor.lnum - wp->w_topline),
 		    (long)wp->w_height / 2, (long)wp->w_height) < 0)
 	    return FAIL;
 

--- a/src/sign.c
+++ b/src/sign.c
@@ -1693,24 +1693,24 @@ sign_getinfo(sign_T *sp, dict_T *retdict)
 {
     char_u	*p;
 
-    dict_add_string(retdict, "name", (char_u *)sp->sn_name);
+    dict_add_string(retdict, "name", sp->sn_name);
     if (sp->sn_icon != NULL)
-	dict_add_string(retdict, "icon", (char_u *)sp->sn_icon);
+	dict_add_string(retdict, "icon", sp->sn_icon);
     if (sp->sn_text != NULL)
-	dict_add_string(retdict, "text", (char_u *)sp->sn_text);
+	dict_add_string(retdict, "text", sp->sn_text);
     if (sp->sn_line_hl > 0)
     {
 	p = get_highlight_name_ext(NULL, sp->sn_line_hl - 1, FALSE);
 	if (p == NULL)
 	    p = (char_u *)"NONE";
-	dict_add_string(retdict, "linehl", (char_u *)p);
+	dict_add_string(retdict, "linehl", p);
     }
     if (sp->sn_text_hl > 0)
     {
 	p = get_highlight_name_ext(NULL, sp->sn_text_hl - 1, FALSE);
 	if (p == NULL)
 	    p = (char_u *)"NONE";
-	dict_add_string(retdict, "texthl", (char_u *)p);
+	dict_add_string(retdict, "texthl", p);
     }
 }
 

--- a/src/spell.c
+++ b/src/spell.c
@@ -650,7 +650,7 @@ find_word(matchinf_T *mip, int mode)
 		// Makes you wonder why someone puts a compound flag on a word
 		// that's too short...  Myspell compatibility requires this
 		// anyway.
-		if (((unsigned)flags >> 24) == 0
+		if ((flags >> 24) == 0
 			     || wlen - mip->mi_compoff < slang->sl_compminlen)
 		    continue;
 		// For multi-byte chars check character length against
@@ -679,7 +679,7 @@ find_word(matchinf_T *mip, int mode)
 		if (!byte_in_str(mip->mi_complen == 0
 					? slang->sl_compstartflags
 					: slang->sl_compallflags,
-					    ((unsigned)flags >> 24)))
+					    (flags >> 24)))
 		    continue;
 
 		// If there is a match with a CHECKCOMPOUNDPATTERN rule
@@ -726,7 +726,7 @@ find_word(matchinf_T *mip, int mode)
 		// If the word ends the sequence of compound flags of the
 		// words must match with one of the COMPOUNDRULE items and
 		// the number of syllables must not be too large.
-		mip->mi_compflags[mip->mi_complen] = ((unsigned)flags >> 24);
+		mip->mi_compflags[mip->mi_complen] = (flags >> 24);
 		mip->mi_compflags[mip->mi_complen + 1] = NUL;
 		if (word_ends)
 		{

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -3621,7 +3621,7 @@ spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
 	}
 
 	// Store the word in the hashtable to be able to find duplicates.
-	dw = (char_u *)getroom_save(spin, w);
+	dw = getroom_save(spin, w);
 	if (dw == NULL)
 	{
 	    retval = FAIL;
@@ -3922,7 +3922,7 @@ store_aff_word(
 			    {
 				// Remove chop string.
 				p = newword + STRLEN(newword);
-				i = (int)MB_CHARLEN(ae->ae_chop);
+				i = MB_CHARLEN(ae->ae_chop);
 				for ( ; i > 0; --i)
 				    MB_PTR_BACK(newword, p);
 				*p = NUL;

--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -1350,7 +1350,7 @@ suggest_trie_walk(
 
 		// At end of a prefix or at start of prefixtree: check for
 		// following word.
-		if (byts[arridx] == 0 || n == (int)STATE_NOPREFIX)
+		if (byts[arridx] == 0 || n == STATE_NOPREFIX)
 		{
 		    // Set su->su_badflags to the caps type at this position.
 		    // Use the caps type until here for the prefix itself.
@@ -2999,7 +2999,7 @@ stp_sal_score(
     char_u	goodword[MAXWLEN];
     int		lendiff;
 
-    lendiff = (int)(su->su_badlen - stp->st_orglen);
+    lendiff = (su->su_badlen - stp->st_orglen);
     if (lendiff >= 0)
 	pbad = badsound;
     else

--- a/src/tag.c
+++ b/src/tag.c
@@ -1225,7 +1225,7 @@ tag_strnicmp(char_u *s1, char_u *s2, size_t len)
 
     while (len > 0)
     {
-	i = (int)TOUPPER_ASC(*s1) - (int)TOUPPER_ASC(*s2);
+	i = TOUPPER_ASC(*s1) - TOUPPER_ASC(*s2);
 	if (i != 0)
 	    return i;			// this character different
 	if (*s1 == NUL)
@@ -2293,7 +2293,7 @@ parse_line:
 		     */
 		    i = (int)tagp.tagname[0];
 		    if (sortic)
-			i = (int)TOUPPER_ASC(tagp.tagname[0]);
+			i = TOUPPER_ASC(tagp.tagname[0]);
 		    if (i < search_info.low_char || i > search_info.high_char)
 			sort_error = TRUE;
 
@@ -2802,7 +2802,7 @@ findtag_end:
 			if (*p == TAG_SEP)
 			    *p = NUL;
 		}
-		matches[match_count++] = (char_u *)mfp;
+		matches[match_count++] = mfp;
 	    }
 	}
 
@@ -3735,7 +3735,7 @@ expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
     {
 	ExpandInit(&xpc);
 	xpc.xp_context = EXPAND_FILES;
-	expanded_fname = ExpandOne(&xpc, (char_u *)fname, NULL,
+	expanded_fname = ExpandOne(&xpc, fname, NULL,
 			    WILD_LIST_NOTFOUND|WILD_SILENT, WILD_EXPAND_FREE);
 	if (expanded_fname != NULL)
 	    fname = expanded_fname;
@@ -4004,7 +4004,7 @@ get_tags(list_T *list, char_u *pat, char_u *buf_fname)
     long	is_static;
 
     ret = find_tags(pat, &num_matches, &matches,
-				TAG_REGEXP | TAG_NOIC, (int)MAXCOL, buf_fname);
+				TAG_REGEXP | TAG_NOIC, MAXCOL, buf_fname);
     if (ret == OK && num_matches > 0)
     {
 	for (i = 0; i < num_matches; ++i)

--- a/src/term.c
+++ b/src/term.c
@@ -221,47 +221,47 @@ static struct builtin_term builtin_termcaps[] =
 /*
  * GUI pseudo term-cap.
  */
-    {(int)KS_NAME,	"gui"},
-    {(int)KS_CE,	IF_EB("\033|$", ESC_STR "|$")},
-    {(int)KS_AL,	IF_EB("\033|i", ESC_STR "|i")},
+    {KS_NAME,	"gui"},
+    {KS_CE,	IF_EB("\033|$", ESC_STR "|$")},
+    {KS_AL,	IF_EB("\033|i", ESC_STR "|i")},
 # ifdef TERMINFO
-    {(int)KS_CAL,	IF_EB("\033|%p1%dI", ESC_STR "|%p1%dI")},
+    {KS_CAL,	IF_EB("\033|%p1%dI", ESC_STR "|%p1%dI")},
 # else
     {(int)KS_CAL,	IF_EB("\033|%dI", ESC_STR "|%dI")},
 # endif
-    {(int)KS_DL,	IF_EB("\033|d", ESC_STR "|d")},
+    {KS_DL,	IF_EB("\033|d", ESC_STR "|d")},
 # ifdef TERMINFO
-    {(int)KS_CDL,	IF_EB("\033|%p1%dD", ESC_STR "|%p1%dD")},
-    {(int)KS_CS,	IF_EB("\033|%p1%d;%p2%dR", ESC_STR "|%p1%d;%p2%dR")},
-    {(int)KS_CSV,	IF_EB("\033|%p1%d;%p2%dV", ESC_STR "|%p1%d;%p2%dV")},
+    {KS_CDL,	IF_EB("\033|%p1%dD", ESC_STR "|%p1%dD")},
+    {KS_CS,	IF_EB("\033|%p1%d;%p2%dR", ESC_STR "|%p1%d;%p2%dR")},
+    {KS_CSV,	IF_EB("\033|%p1%d;%p2%dV", ESC_STR "|%p1%d;%p2%dV")},
 # else
     {(int)KS_CDL,	IF_EB("\033|%dD", ESC_STR "|%dD")},
     {(int)KS_CS,	IF_EB("\033|%d;%dR", ESC_STR "|%d;%dR")},
     {(int)KS_CSV,	IF_EB("\033|%d;%dV", ESC_STR "|%d;%dV")},
 # endif
-    {(int)KS_CL,	IF_EB("\033|C", ESC_STR "|C")},
+    {KS_CL,	IF_EB("\033|C", ESC_STR "|C")},
 			// attributes switched on with 'h', off with * 'H'
-    {(int)KS_ME,	IF_EB("\033|31H", ESC_STR "|31H")}, // HL_ALL
-    {(int)KS_MR,	IF_EB("\033|1h", ESC_STR "|1h")},   // HL_INVERSE
-    {(int)KS_MD,	IF_EB("\033|2h", ESC_STR "|2h")},   // HL_BOLD
-    {(int)KS_SE,	IF_EB("\033|16H", ESC_STR "|16H")}, // HL_STANDOUT
-    {(int)KS_SO,	IF_EB("\033|16h", ESC_STR "|16h")}, // HL_STANDOUT
-    {(int)KS_UE,	IF_EB("\033|8H", ESC_STR "|8H")},   // HL_UNDERLINE
-    {(int)KS_US,	IF_EB("\033|8h", ESC_STR "|8h")},   // HL_UNDERLINE
-    {(int)KS_UCE,	IF_EB("\033|8C", ESC_STR "|8C")},   // HL_UNDERCURL
-    {(int)KS_UCS,	IF_EB("\033|8c", ESC_STR "|8c")},   // HL_UNDERCURL
-    {(int)KS_STE,	IF_EB("\033|4C", ESC_STR "|4C")},   // HL_STRIKETHROUGH
-    {(int)KS_STS,	IF_EB("\033|4c", ESC_STR "|4c")},   // HL_STRIKETHROUGH
-    {(int)KS_CZR,	IF_EB("\033|4H", ESC_STR "|4H")},   // HL_ITALIC
-    {(int)KS_CZH,	IF_EB("\033|4h", ESC_STR "|4h")},   // HL_ITALIC
-    {(int)KS_VB,	IF_EB("\033|f", ESC_STR "|f")},
-    {(int)KS_MS,	"y"},
-    {(int)KS_UT,	"y"},
-    {(int)KS_XN,	"y"},
-    {(int)KS_LE,	"\b"},		// cursor-left = BS
-    {(int)KS_ND,	"\014"},	// cursor-right = CTRL-L
+    {KS_ME,	IF_EB("\033|31H", ESC_STR "|31H")}, // HL_ALL
+    {KS_MR,	IF_EB("\033|1h", ESC_STR "|1h")},   // HL_INVERSE
+    {KS_MD,	IF_EB("\033|2h", ESC_STR "|2h")},   // HL_BOLD
+    {KS_SE,	IF_EB("\033|16H", ESC_STR "|16H")}, // HL_STANDOUT
+    {KS_SO,	IF_EB("\033|16h", ESC_STR "|16h")}, // HL_STANDOUT
+    {KS_UE,	IF_EB("\033|8H", ESC_STR "|8H")},   // HL_UNDERLINE
+    {KS_US,	IF_EB("\033|8h", ESC_STR "|8h")},   // HL_UNDERLINE
+    {KS_UCE,	IF_EB("\033|8C", ESC_STR "|8C")},   // HL_UNDERCURL
+    {KS_UCS,	IF_EB("\033|8c", ESC_STR "|8c")},   // HL_UNDERCURL
+    {KS_STE,	IF_EB("\033|4C", ESC_STR "|4C")},   // HL_STRIKETHROUGH
+    {KS_STS,	IF_EB("\033|4c", ESC_STR "|4c")},   // HL_STRIKETHROUGH
+    {KS_CZR,	IF_EB("\033|4H", ESC_STR "|4H")},   // HL_ITALIC
+    {KS_CZH,	IF_EB("\033|4h", ESC_STR "|4h")},   // HL_ITALIC
+    {KS_VB,	IF_EB("\033|f", ESC_STR "|f")},
+    {KS_MS,	"y"},
+    {KS_UT,	"y"},
+    {KS_XN,	"y"},
+    {KS_LE,	"\b"},		// cursor-left = BS
+    {KS_ND,	"\014"},	// cursor-right = CTRL-L
 # ifdef TERMINFO
-    {(int)KS_CM,	IF_EB("\033|%p1%d;%p2%dM", ESC_STR "|%p1%d;%p2%dM")},
+    {KS_CM,	IF_EB("\033|%p1%d;%p2%dM", ESC_STR "|%p1%d;%p2%dM")},
 # else
     {(int)KS_CM,	IF_EB("\033|%d;%dM", ESC_STR "|%d;%dM")},
 # endif
@@ -275,33 +275,33 @@ static struct builtin_term builtin_termcaps[] =
 /*
  * Amiga console window, default for Amiga
  */
-    {(int)KS_NAME,	"amiga"},
-    {(int)KS_CE,	"\033[K"},
-    {(int)KS_CD,	"\033[J"},
-    {(int)KS_AL,	"\033[L"},
+    {KS_NAME,	"amiga"},
+    {KS_CE,	"\033[K"},
+    {KS_CD,	"\033[J"},
+    {KS_AL,	"\033[L"},
 #  ifdef TERMINFO
-    {(int)KS_CAL,	"\033[%p1%dL"},
+    {KS_CAL,	"\033[%p1%dL"},
 #  else
     {(int)KS_CAL,	"\033[%dL"},
 #  endif
-    {(int)KS_DL,	"\033[M"},
+    {KS_DL,	"\033[M"},
 #  ifdef TERMINFO
-    {(int)KS_CDL,	"\033[%p1%dM"},
+    {KS_CDL,	"\033[%p1%dM"},
 #  else
     {(int)KS_CDL,	"\033[%dM"},
 #  endif
-    {(int)KS_CL,	"\014"},
-    {(int)KS_VI,	"\033[0 p"},
-    {(int)KS_VE,	"\033[1 p"},
-    {(int)KS_ME,	"\033[0m"},
-    {(int)KS_MR,	"\033[7m"},
-    {(int)KS_MD,	"\033[1m"},
-    {(int)KS_SE,	"\033[0m"},
-    {(int)KS_SO,	"\033[33m"},
-    {(int)KS_US,	"\033[4m"},
-    {(int)KS_UE,	"\033[0m"},
-    {(int)KS_CZH,	"\033[3m"},
-    {(int)KS_CZR,	"\033[0m"},
+    {KS_CL,	"\014"},
+    {KS_VI,	"\033[0 p"},
+    {KS_VE,	"\033[1 p"},
+    {KS_ME,	"\033[0m"},
+    {KS_MR,	"\033[7m"},
+    {KS_MD,	"\033[1m"},
+    {KS_SE,	"\033[0m"},
+    {KS_SO,	"\033[33m"},
+    {KS_US,	"\033[4m"},
+    {KS_UE,	"\033[0m"},
+    {KS_CZH,	"\033[3m"},
+    {KS_CZR,	"\033[0m"},
 #if defined(__amigaos4__) || defined(__MORPHOS__) || defined(__AROS__)
     {(int)KS_CCO,	"8"},		// allow 8 colors
 #  ifdef TERMINFO
@@ -313,11 +313,11 @@ static struct builtin_term builtin_termcaps[] =
 #  endif
     {(int)KS_OP,	"\033[m"},	// reset colors
 #endif
-    {(int)KS_MS,	"y"},
-    {(int)KS_UT,	"y"},		// guessed
-    {(int)KS_LE,	"\b"},
+    {KS_MS,	"y"},
+    {KS_UT,	"y"},		// guessed
+    {KS_LE,	"\b"},
 #  ifdef TERMINFO
-    {(int)KS_CM,	"\033[%i%p1%d;%p2%dH"},
+    {KS_CM,	"\033[%i%p1%d;%p2%dH"},
 #  else
     {(int)KS_CM,	"\033[%i%d;%dH"},
 #  endif
@@ -325,7 +325,7 @@ static struct builtin_term builtin_termcaps[] =
     {(int)KS_SR,	"\033M"},
 #endif
 #  ifdef TERMINFO
-    {(int)KS_CRI,	"\033[%p1%dC"},
+    {KS_CRI,	"\033[%p1%dC"},
 #  else
     {(int)KS_CRI,	"\033[%dC"},
 #  endif
@@ -375,54 +375,54 @@ static struct builtin_term builtin_termcaps[] =
 /*
  * almost standard ANSI terminal
  */
-    {(int)KS_CE,	"\033[K"},
-    {(int)KS_CD,	"\033[J"},
-    {(int)KS_AL,	"\033[L"},
+    {KS_CE,	"\033[K"},
+    {KS_CD,	"\033[J"},
+    {KS_AL,	"\033[L"},
 #  ifdef TERMINFO
-    {(int)KS_CAL,	"\033[%p1%dL"},
+    {KS_CAL,	"\033[%p1%dL"},
 #  else
     {(int)KS_CAL,	"\033[%dL"},
 #  endif
-    {(int)KS_DL,	"\033[M"},
+    {KS_DL,	"\033[M"},
 #  ifdef TERMINFO
-    {(int)KS_CDL,	"\033[%p1%dM"},
+    {KS_CDL,	"\033[%p1%dM"},
 #  else
     {(int)KS_CDL,	"\033[%dM"},
 #  endif
-    {(int)KS_CL,	"\033[H\033[2J"},
+    {KS_CL,	"\033[H\033[2J"},
 #ifdef notyet
     {(int)KS_VI,	"[VI]"}, // cursor invisible, VT320: CSI ? 25 l
     {(int)KS_VE,	"[VE]"}, // cursor visible, VT320: CSI ? 25 h
 #endif
-    {(int)KS_ME,	"\033[m"},	// normal mode
-    {(int)KS_MR,	"\033[7m"},	// reverse
-    {(int)KS_MD,	"\033[1m"},	// bold
-    {(int)KS_SO,	"\033[31m"},	// standout mode: red
-    {(int)KS_SE,	"\033[m"},	// standout end
-    {(int)KS_CZH,	"\033[35m"},	// italic: purple
-    {(int)KS_CZR,	"\033[m"},	// italic end
-    {(int)KS_US,	"\033[4m"},	// underscore mode
-    {(int)KS_UE,	"\033[m"},	// underscore end
-    {(int)KS_CCO,	"8"},		// allow 8 colors
+    {KS_ME,	"\033[m"},	// normal mode
+    {KS_MR,	"\033[7m"},	// reverse
+    {KS_MD,	"\033[1m"},	// bold
+    {KS_SO,	"\033[31m"},	// standout mode: red
+    {KS_SE,	"\033[m"},	// standout end
+    {KS_CZH,	"\033[35m"},	// italic: purple
+    {KS_CZR,	"\033[m"},	// italic end
+    {KS_US,	"\033[4m"},	// underscore mode
+    {KS_UE,	"\033[m"},	// underscore end
+    {KS_CCO,	"8"},		// allow 8 colors
 #  ifdef TERMINFO
-    {(int)KS_CAB,	"\033[4%p1%dm"},// set background color
-    {(int)KS_CAF,	"\033[3%p1%dm"},// set foreground color
+    {KS_CAB,	"\033[4%p1%dm"},// set background color
+    {KS_CAF,	"\033[3%p1%dm"},// set foreground color
 #  else
     {(int)KS_CAB,	"\033[4%dm"},	// set background color
     {(int)KS_CAF,	"\033[3%dm"},	// set foreground color
 #  endif
-    {(int)KS_OP,	"\033[m"},	// reset colors
-    {(int)KS_MS,	"y"},		// safe to move cur in reverse mode
-    {(int)KS_UT,	"y"},		// guessed
-    {(int)KS_LE,	"\b"},
+    {KS_OP,	"\033[m"},	// reset colors
+    {KS_MS,	"y"},		// safe to move cur in reverse mode
+    {KS_UT,	"y"},		// guessed
+    {KS_LE,	"\b"},
 #  ifdef TERMINFO
-    {(int)KS_CM,	"\033[%i%p1%d;%p2%dH"},
+    {KS_CM,	"\033[%i%p1%d;%p2%dH"},
 #  else
     {(int)KS_CM,	"\033[%i%d;%dH"},
 #  endif
-    {(int)KS_SR,	"\033M"},
+    {KS_SR,	"\033M"},
 #  ifdef TERMINFO
-    {(int)KS_CRI,	"\033[%p1%dC"},
+    {KS_CRI,	"\033[%p1%dC"},
 #  else
     {(int)KS_CRI,	"\033[%dC"},
 #  endif
@@ -437,33 +437,33 @@ static struct builtin_term builtin_termcaps[] =
 /*
  * standard ANSI terminal, default for unix
  */
-    {(int)KS_NAME,	"ansi"},
-    {(int)KS_CE,	IF_EB("\033[K", ESC_STR "[K")},
-    {(int)KS_AL,	IF_EB("\033[L", ESC_STR "[L")},
+    {KS_NAME,	"ansi"},
+    {KS_CE,	IF_EB("\033[K", ESC_STR "[K")},
+    {KS_AL,	IF_EB("\033[L", ESC_STR "[L")},
 #  ifdef TERMINFO
-    {(int)KS_CAL,	IF_EB("\033[%p1%dL", ESC_STR "[%p1%dL")},
+    {KS_CAL,	IF_EB("\033[%p1%dL", ESC_STR "[%p1%dL")},
 #  else
     {(int)KS_CAL,	IF_EB("\033[%dL", ESC_STR "[%dL")},
 #  endif
-    {(int)KS_DL,	IF_EB("\033[M", ESC_STR "[M")},
+    {KS_DL,	IF_EB("\033[M", ESC_STR "[M")},
 #  ifdef TERMINFO
-    {(int)KS_CDL,	IF_EB("\033[%p1%dM", ESC_STR "[%p1%dM")},
+    {KS_CDL,	IF_EB("\033[%p1%dM", ESC_STR "[%p1%dM")},
 #  else
     {(int)KS_CDL,	IF_EB("\033[%dM", ESC_STR "[%dM")},
 #  endif
-    {(int)KS_CL,	IF_EB("\033[H\033[2J", ESC_STR "[H" ESC_STR_nc "[2J")},
-    {(int)KS_ME,	IF_EB("\033[0m", ESC_STR "[0m")},
-    {(int)KS_MR,	IF_EB("\033[7m", ESC_STR "[7m")},
-    {(int)KS_MS,	"y"},
-    {(int)KS_UT,	"y"},		// guessed
-    {(int)KS_LE,	"\b"},
+    {KS_CL,	IF_EB("\033[H\033[2J", ESC_STR "[H" ESC_STR_nc "[2J")},
+    {KS_ME,	IF_EB("\033[0m", ESC_STR "[0m")},
+    {KS_MR,	IF_EB("\033[7m", ESC_STR "[7m")},
+    {KS_MS,	"y"},
+    {KS_UT,	"y"},		// guessed
+    {KS_LE,	"\b"},
 #  ifdef TERMINFO
-    {(int)KS_CM,	IF_EB("\033[%i%p1%d;%p2%dH", ESC_STR "[%i%p1%d;%p2%dH")},
+    {KS_CM,	IF_EB("\033[%i%p1%d;%p2%dH", ESC_STR "[%i%p1%d;%p2%dH")},
 #  else
     {(int)KS_CM,	IF_EB("\033[%i%d;%dH", ESC_STR "[%i%d;%dH")},
 #  endif
 #  ifdef TERMINFO
-    {(int)KS_CRI,	IF_EB("\033[%p1%dC", ESC_STR "[%p1%dC")},
+    {KS_CRI,	IF_EB("\033[%p1%dC", ESC_STR "[%p1%dC")},
 #  else
     {(int)KS_CRI,	IF_EB("\033[%dC", ESC_STR "[%dC")},
 #  endif
@@ -476,39 +476,39 @@ static struct builtin_term builtin_termcaps[] =
  * K_NUL '\316' in mch_inchar(), because we cannot handle NULs in key codes.
  * CTRL-arrow is used instead of SHIFT-arrow.
  */
-    {(int)KS_NAME,	"pcansi"},
-    {(int)KS_DL,	"\033[M"},
-    {(int)KS_AL,	"\033[L"},
-    {(int)KS_CE,	"\033[K"},
-    {(int)KS_CL,	"\033[2J"},
-    {(int)KS_ME,	"\033[0m"},
-    {(int)KS_MR,	"\033[5m"},	// reverse: black on lightgrey
-    {(int)KS_MD,	"\033[1m"},	// bold: white text
-    {(int)KS_SE,	"\033[0m"},	// standout end
-    {(int)KS_SO,	"\033[31m"},	// standout: white on blue
-    {(int)KS_CZH,	"\033[34;43m"},	// italic mode: blue text on yellow
-    {(int)KS_CZR,	"\033[0m"},	// italic mode end
-    {(int)KS_US,	"\033[36;41m"},	// underscore mode: cyan text on red
-    {(int)KS_UE,	"\033[0m"},	// underscore mode end
-    {(int)KS_CCO,	"8"},		// allow 8 colors
+    {KS_NAME,	"pcansi"},
+    {KS_DL,	"\033[M"},
+    {KS_AL,	"\033[L"},
+    {KS_CE,	"\033[K"},
+    {KS_CL,	"\033[2J"},
+    {KS_ME,	"\033[0m"},
+    {KS_MR,	"\033[5m"},	// reverse: black on lightgrey
+    {KS_MD,	"\033[1m"},	// bold: white text
+    {KS_SE,	"\033[0m"},	// standout end
+    {KS_SO,	"\033[31m"},	// standout: white on blue
+    {KS_CZH,	"\033[34;43m"},	// italic mode: blue text on yellow
+    {KS_CZR,	"\033[0m"},	// italic mode end
+    {KS_US,	"\033[36;41m"},	// underscore mode: cyan text on red
+    {KS_UE,	"\033[0m"},	// underscore mode end
+    {KS_CCO,	"8"},		// allow 8 colors
 #  ifdef TERMINFO
-    {(int)KS_CAB,	"\033[4%p1%dm"},// set background color
-    {(int)KS_CAF,	"\033[3%p1%dm"},// set foreground color
+    {KS_CAB,	"\033[4%p1%dm"},// set background color
+    {KS_CAF,	"\033[3%p1%dm"},// set foreground color
 #  else
     {(int)KS_CAB,	"\033[4%dm"},	// set background color
     {(int)KS_CAF,	"\033[3%dm"},	// set foreground color
 #  endif
-    {(int)KS_OP,	"\033[0m"},	// reset colors
-    {(int)KS_MS,	"y"},
-    {(int)KS_UT,	"y"},		// guessed
-    {(int)KS_LE,	"\b"},
+    {KS_OP,	"\033[0m"},	// reset colors
+    {KS_MS,	"y"},
+    {KS_UT,	"y"},		// guessed
+    {KS_LE,	"\b"},
 #  ifdef TERMINFO
-    {(int)KS_CM,	"\033[%i%p1%d;%p2%dH"},
+    {KS_CM,	"\033[%i%p1%d;%p2%dH"},
 #  else
     {(int)KS_CM,	"\033[%i%d;%dH"},
 #  endif
 #  ifdef TERMINFO
-    {(int)KS_CRI,	"\033[%p1%dC"},
+    {KS_CRI,	"\033[%p1%dC"},
 #  else
     {(int)KS_CRI,	"\033[%dC"},
 #  endif
@@ -556,70 +556,70 @@ static struct builtin_term builtin_termcaps[] =
  * ESC | are translated into console calls in os_win32.c.  The function keys
  * are also translated in os_win32.c.
  */
-    {(int)KS_NAME,	"win32"},
-    {(int)KS_CE,	"\033|K"},	// clear to end of line
-    {(int)KS_AL,	"\033|L"},	// add new blank line
+    {KS_NAME,	"win32"},
+    {KS_CE,	"\033|K"},	// clear to end of line
+    {KS_AL,	"\033|L"},	// add new blank line
 #  ifdef TERMINFO
-    {(int)KS_CAL,	"\033|%p1%dL"},	// add number of new blank lines
+    {KS_CAL,	"\033|%p1%dL"},	// add number of new blank lines
 #  else
     {(int)KS_CAL,	"\033|%dL"},	// add number of new blank lines
 #  endif
-    {(int)KS_DL,	"\033|M"},	// delete line
+    {KS_DL,	"\033|M"},	// delete line
 #  ifdef TERMINFO
-    {(int)KS_CDL,	"\033|%p1%dM"},	// delete number of lines
-    {(int)KS_CSV,	"\033|%p1%d;%p2%dV"},
+    {KS_CDL,	"\033|%p1%dM"},	// delete number of lines
+    {KS_CSV,	"\033|%p1%d;%p2%dV"},
 #  else
     {(int)KS_CDL,	"\033|%dM"},	// delete number of lines
     {(int)KS_CSV,	"\033|%d;%dV"},
 #  endif
-    {(int)KS_CL,	"\033|J"},	// clear screen
-    {(int)KS_CD,	"\033|j"},	// clear to end of display
-    {(int)KS_VI,	"\033|v"},	// cursor invisible
-    {(int)KS_VE,	"\033|V"},	// cursor visible
+    {KS_CL,	"\033|J"},	// clear screen
+    {KS_CD,	"\033|j"},	// clear to end of display
+    {KS_VI,	"\033|v"},	// cursor invisible
+    {KS_VE,	"\033|V"},	// cursor visible
 
-    {(int)KS_ME,	"\033|0m"},	// normal
-    {(int)KS_MR,	"\033|112m"},	// reverse: black on lightgray
-    {(int)KS_MD,	"\033|15m"},	// bold: white on black
+    {KS_ME,	"\033|0m"},	// normal
+    {KS_MR,	"\033|112m"},	// reverse: black on lightgray
+    {KS_MD,	"\033|15m"},	// bold: white on black
 #if 1
-    {(int)KS_SO,	"\033|31m"},	// standout: white on blue
-    {(int)KS_SE,	"\033|0m"},	// standout end
+    {KS_SO,	"\033|31m"},	// standout: white on blue
+    {KS_SE,	"\033|0m"},	// standout end
 #else
     {(int)KS_SO,	"\033|F"},	// standout: high intensity
     {(int)KS_SE,	"\033|f"},	// standout end
 #endif
-    {(int)KS_CZH,	"\033|225m"},	// italic: blue text on yellow
-    {(int)KS_CZR,	"\033|0m"},	// italic end
-    {(int)KS_US,	"\033|67m"},	// underscore: cyan text on red
-    {(int)KS_UE,	"\033|0m"},	// underscore end
-    {(int)KS_CCO,	"16"},		// allow 16 colors
+    {KS_CZH,	"\033|225m"},	// italic: blue text on yellow
+    {KS_CZR,	"\033|0m"},	// italic end
+    {KS_US,	"\033|67m"},	// underscore: cyan text on red
+    {KS_UE,	"\033|0m"},	// underscore end
+    {KS_CCO,	"16"},		// allow 16 colors
 #  ifdef TERMINFO
-    {(int)KS_CAB,	"\033|%p1%db"},	// set background color
-    {(int)KS_CAF,	"\033|%p1%df"},	// set foreground color
+    {KS_CAB,	"\033|%p1%db"},	// set background color
+    {KS_CAF,	"\033|%p1%df"},	// set foreground color
 #  else
     {(int)KS_CAB,	"\033|%db"},	// set background color
     {(int)KS_CAF,	"\033|%df"},	// set foreground color
 #  endif
 
-    {(int)KS_MS,	"y"},		// save to move cur in reverse mode
-    {(int)KS_UT,	"y"},
-    {(int)KS_XN,	"y"},
-    {(int)KS_LE,	"\b"},
+    {KS_MS,	"y"},		// save to move cur in reverse mode
+    {KS_UT,	"y"},
+    {KS_XN,	"y"},
+    {KS_LE,	"\b"},
 #  ifdef TERMINFO
-    {(int)KS_CM,	"\033|%i%p1%d;%p2%dH"}, // cursor motion
+    {KS_CM,	"\033|%i%p1%d;%p2%dH"}, // cursor motion
 #  else
     {(int)KS_CM,	"\033|%i%d;%dH"}, // cursor motion
 #  endif
-    {(int)KS_VB,	"\033|B"},	// visual bell
-    {(int)KS_TI,	"\033|S"},	// put terminal in termcap mode
-    {(int)KS_TE,	"\033|E"},	// out of termcap mode
+    {KS_VB,	"\033|B"},	// visual bell
+    {KS_TI,	"\033|S"},	// put terminal in termcap mode
+    {KS_TE,	"\033|E"},	// out of termcap mode
 #  ifdef TERMINFO
-    {(int)KS_CS,	"\033|%i%p1%d;%p2%dr"}, // scroll region
+    {KS_CS,	"\033|%i%p1%d;%p2%dr"}, // scroll region
 #  else
     {(int)KS_CS,	"\033|%i%d;%dr"}, // scroll region
 #  endif
 #  ifdef FEAT_TERMGUICOLORS
-    {(int)KS_8F,	"\033|38;2;%lu;%lu;%lum"},
-    {(int)KS_8B,	"\033|48;2;%lu;%lu;%lum"},
+    {KS_8F,	"\033|38;2;%lu;%lu;%lum"},
+    {KS_8B,	"\033|48;2;%lu;%lu;%lum"},
 #  endif
 
     {K_UP,		"\316H"},
@@ -690,47 +690,47 @@ static struct builtin_term builtin_termcaps[] =
  * TODO:- rewrite ESC[ codes to CSI
  *      - keyboard languages (CSI ? 26 n)
  */
-    {(int)KS_NAME,	"vt320"},
-    {(int)KS_CE,	IF_EB("\033[K", ESC_STR "[K")},
-    {(int)KS_AL,	IF_EB("\033[L", ESC_STR "[L")},
+    {KS_NAME,	"vt320"},
+    {KS_CE,	IF_EB("\033[K", ESC_STR "[K")},
+    {KS_AL,	IF_EB("\033[L", ESC_STR "[L")},
 #  ifdef TERMINFO
-    {(int)KS_CAL,	IF_EB("\033[%p1%dL", ESC_STR "[%p1%dL")},
+    {KS_CAL,	IF_EB("\033[%p1%dL", ESC_STR "[%p1%dL")},
 #  else
     {(int)KS_CAL,	IF_EB("\033[%dL", ESC_STR "[%dL")},
 #  endif
-    {(int)KS_DL,	IF_EB("\033[M", ESC_STR "[M")},
+    {KS_DL,	IF_EB("\033[M", ESC_STR "[M")},
 #  ifdef TERMINFO
-    {(int)KS_CDL,	IF_EB("\033[%p1%dM", ESC_STR "[%p1%dM")},
+    {KS_CDL,	IF_EB("\033[%p1%dM", ESC_STR "[%p1%dM")},
 #  else
     {(int)KS_CDL,	IF_EB("\033[%dM", ESC_STR "[%dM")},
 #  endif
-    {(int)KS_CL,	IF_EB("\033[H\033[2J", ESC_STR "[H" ESC_STR_nc "[2J")},
-    {(int)KS_CD,	IF_EB("\033[J", ESC_STR "[J")},
-    {(int)KS_CCO,	"8"},			// allow 8 colors
-    {(int)KS_ME,	IF_EB("\033[0m", ESC_STR "[0m")},
-    {(int)KS_MR,	IF_EB("\033[7m", ESC_STR "[7m")},
-    {(int)KS_MD,	IF_EB("\033[1m", ESC_STR "[1m")},  // bold mode
-    {(int)KS_SE,	IF_EB("\033[22m", ESC_STR "[22m")},// normal mode
-    {(int)KS_UE,	IF_EB("\033[24m", ESC_STR "[24m")},// exit underscore mode
-    {(int)KS_US,	IF_EB("\033[4m", ESC_STR "[4m")},  // underscore mode
-    {(int)KS_CZH,	IF_EB("\033[34;43m", ESC_STR "[34;43m")},  // italic mode: blue text on yellow
-    {(int)KS_CZR,	IF_EB("\033[0m", ESC_STR "[0m")},	    // italic mode end
-    {(int)KS_CAB,	IF_EB("\033[4%dm", ESC_STR "[4%dm")},	    // set background color (ANSI)
-    {(int)KS_CAF,	IF_EB("\033[3%dm", ESC_STR "[3%dm")},	    // set foreground color (ANSI)
-    {(int)KS_CSB,	IF_EB("\033[102;%dm", ESC_STR "[102;%dm")},	// set screen background color
-    {(int)KS_CSF,	IF_EB("\033[101;%dm", ESC_STR "[101;%dm")},	// set screen foreground color
-    {(int)KS_MS,	"y"},
-    {(int)KS_UT,	"y"},
-    {(int)KS_XN,	"y"},
-    {(int)KS_LE,	"\b"},
+    {KS_CL,	IF_EB("\033[H\033[2J", ESC_STR "[H" ESC_STR_nc "[2J")},
+    {KS_CD,	IF_EB("\033[J", ESC_STR "[J")},
+    {KS_CCO,	"8"},			// allow 8 colors
+    {KS_ME,	IF_EB("\033[0m", ESC_STR "[0m")},
+    {KS_MR,	IF_EB("\033[7m", ESC_STR "[7m")},
+    {KS_MD,	IF_EB("\033[1m", ESC_STR "[1m")},  // bold mode
+    {KS_SE,	IF_EB("\033[22m", ESC_STR "[22m")},// normal mode
+    {KS_UE,	IF_EB("\033[24m", ESC_STR "[24m")},// exit underscore mode
+    {KS_US,	IF_EB("\033[4m", ESC_STR "[4m")},  // underscore mode
+    {KS_CZH,	IF_EB("\033[34;43m", ESC_STR "[34;43m")},  // italic mode: blue text on yellow
+    {KS_CZR,	IF_EB("\033[0m", ESC_STR "[0m")},	    // italic mode end
+    {KS_CAB,	IF_EB("\033[4%dm", ESC_STR "[4%dm")},	    // set background color (ANSI)
+    {KS_CAF,	IF_EB("\033[3%dm", ESC_STR "[3%dm")},	    // set foreground color (ANSI)
+    {KS_CSB,	IF_EB("\033[102;%dm", ESC_STR "[102;%dm")},	// set screen background color
+    {KS_CSF,	IF_EB("\033[101;%dm", ESC_STR "[101;%dm")},	// set screen foreground color
+    {KS_MS,	"y"},
+    {KS_UT,	"y"},
+    {KS_XN,	"y"},
+    {KS_LE,	"\b"},
 #  ifdef TERMINFO
-    {(int)KS_CM,	IF_EB("\033[%i%p1%d;%p2%dH",
+    {KS_CM,	IF_EB("\033[%i%p1%d;%p2%dH",
 						  ESC_STR "[%i%p1%d;%p2%dH")},
 #  else
     {(int)KS_CM,	IF_EB("\033[%i%d;%dH", ESC_STR "[%i%d;%dH")},
 #  endif
 #  ifdef TERMINFO
-    {(int)KS_CRI,	IF_EB("\033[%p1%dC", ESC_STR "[%p1%dC")},
+    {KS_CRI,	IF_EB("\033[%p1%dC", ESC_STR "[%p1%dC")},
 #  else
     {(int)KS_CRI,	IF_EB("\033[%dC", ESC_STR "[%dC")},
 #  endif
@@ -790,19 +790,19 @@ static struct builtin_term builtin_termcaps[] =
 /*
  * Ordinary vt52
  */
-    {(int)KS_NAME,	"vt52"},
-    {(int)KS_CE,	IF_EB("\033K", ESC_STR "K")},
-    {(int)KS_CD,	IF_EB("\033J", ESC_STR "J")},
+    {KS_NAME,	"vt52"},
+    {KS_CE,	IF_EB("\033K", ESC_STR "K")},
+    {KS_CD,	IF_EB("\033J", ESC_STR "J")},
 #  ifdef TERMINFO
-    {(int)KS_CM,	IF_EB("\033Y%p1%' '%+%c%p2%' '%+%c",
+    {KS_CM,	IF_EB("\033Y%p1%' '%+%c%p2%' '%+%c",
 			    ESC_STR "Y%p1%' '%+%c%p2%' '%+%c")},
 #  else
     {(int)KS_CM,	IF_EB("\033Y%+ %+ ", ESC_STR "Y%+ %+ ")},
 #  endif
-    {(int)KS_LE,	"\b"},
-    {(int)KS_SR,	IF_EB("\033I", ESC_STR "I")},
-    {(int)KS_AL,	IF_EB("\033L", ESC_STR "L")},
-    {(int)KS_DL,	IF_EB("\033M", ESC_STR "M")},
+    {KS_LE,	"\b"},
+    {KS_SR,	IF_EB("\033I", ESC_STR "I")},
+    {KS_AL,	IF_EB("\033L", ESC_STR "L")},
+    {KS_DL,	IF_EB("\033M", ESC_STR "M")},
     {K_UP,		IF_EB("\033A", ESC_STR "A")},
     {K_DOWN,		IF_EB("\033B", ESC_STR "B")},
     {K_LEFT,		IF_EB("\033D", ESC_STR "D")},
@@ -810,112 +810,112 @@ static struct builtin_term builtin_termcaps[] =
     {K_F1,		IF_EB("\033P", ESC_STR "P")},
     {K_F2,		IF_EB("\033Q", ESC_STR "Q")},
     {K_F3,		IF_EB("\033R", ESC_STR "R")},
-    {(int)KS_CL,	IF_EB("\033H\033J", ESC_STR "H" ESC_STR_nc "J")},
-    {(int)KS_MS,	"y"},
+    {KS_CL,	IF_EB("\033H\033J", ESC_STR "H" ESC_STR_nc "J")},
+    {KS_MS,	"y"},
 # endif
 
 # if defined(UNIX) || defined(ALL_BUILTIN_TCAPS) || defined(SOME_BUILTIN_TCAPS)
-    {(int)KS_NAME,	"xterm"},
-    {(int)KS_CE,	IF_EB("\033[K", ESC_STR "[K")},
-    {(int)KS_AL,	IF_EB("\033[L", ESC_STR "[L")},
+    {KS_NAME,	"xterm"},
+    {KS_CE,	IF_EB("\033[K", ESC_STR "[K")},
+    {KS_AL,	IF_EB("\033[L", ESC_STR "[L")},
 #  ifdef TERMINFO
-    {(int)KS_CAL,	IF_EB("\033[%p1%dL", ESC_STR "[%p1%dL")},
+    {KS_CAL,	IF_EB("\033[%p1%dL", ESC_STR "[%p1%dL")},
 #  else
     {(int)KS_CAL,	IF_EB("\033[%dL", ESC_STR "[%dL")},
 #  endif
-    {(int)KS_DL,	IF_EB("\033[M", ESC_STR "[M")},
+    {KS_DL,	IF_EB("\033[M", ESC_STR "[M")},
 #  ifdef TERMINFO
-    {(int)KS_CDL,	IF_EB("\033[%p1%dM", ESC_STR "[%p1%dM")},
+    {KS_CDL,	IF_EB("\033[%p1%dM", ESC_STR "[%p1%dM")},
 #  else
     {(int)KS_CDL,	IF_EB("\033[%dM", ESC_STR "[%dM")},
 #  endif
 #  ifdef TERMINFO
-    {(int)KS_CS,	IF_EB("\033[%i%p1%d;%p2%dr",
+    {KS_CS,	IF_EB("\033[%i%p1%d;%p2%dr",
 						  ESC_STR "[%i%p1%d;%p2%dr")},
 #  else
     {(int)KS_CS,	IF_EB("\033[%i%d;%dr", ESC_STR "[%i%d;%dr")},
 #  endif
-    {(int)KS_CL,	IF_EB("\033[H\033[2J", ESC_STR "[H" ESC_STR_nc "[2J")},
-    {(int)KS_CD,	IF_EB("\033[J", ESC_STR "[J")},
-    {(int)KS_ME,	IF_EB("\033[m", ESC_STR "[m")},
-    {(int)KS_MR,	IF_EB("\033[7m", ESC_STR "[7m")},
-    {(int)KS_MD,	IF_EB("\033[1m", ESC_STR "[1m")},
-    {(int)KS_UE,	IF_EB("\033[m", ESC_STR "[m")},
-    {(int)KS_US,	IF_EB("\033[4m", ESC_STR "[4m")},
-    {(int)KS_STE,	IF_EB("\033[29m", ESC_STR "[29m")},
-    {(int)KS_STS,	IF_EB("\033[9m", ESC_STR "[9m")},
-    {(int)KS_MS,	"y"},
-    {(int)KS_UT,	"y"},
-    {(int)KS_LE,	"\b"},
-    {(int)KS_VI,	IF_EB("\033[?25l", ESC_STR "[?25l")},
-    {(int)KS_VE,	IF_EB("\033[?25h", ESC_STR "[?25h")},
-    {(int)KS_VS,	IF_EB("\033[?12h", ESC_STR "[?12h")},
-    {(int)KS_CVS,	IF_EB("\033[?12l", ESC_STR "[?12l")},
+    {KS_CL,	IF_EB("\033[H\033[2J", ESC_STR "[H" ESC_STR_nc "[2J")},
+    {KS_CD,	IF_EB("\033[J", ESC_STR "[J")},
+    {KS_ME,	IF_EB("\033[m", ESC_STR "[m")},
+    {KS_MR,	IF_EB("\033[7m", ESC_STR "[7m")},
+    {KS_MD,	IF_EB("\033[1m", ESC_STR "[1m")},
+    {KS_UE,	IF_EB("\033[m", ESC_STR "[m")},
+    {KS_US,	IF_EB("\033[4m", ESC_STR "[4m")},
+    {KS_STE,	IF_EB("\033[29m", ESC_STR "[29m")},
+    {KS_STS,	IF_EB("\033[9m", ESC_STR "[9m")},
+    {KS_MS,	"y"},
+    {KS_UT,	"y"},
+    {KS_LE,	"\b"},
+    {KS_VI,	IF_EB("\033[?25l", ESC_STR "[?25l")},
+    {KS_VE,	IF_EB("\033[?25h", ESC_STR "[?25h")},
+    {KS_VS,	IF_EB("\033[?12h", ESC_STR "[?12h")},
+    {KS_CVS,	IF_EB("\033[?12l", ESC_STR "[?12l")},
 #  ifdef TERMINFO
-    {(int)KS_CSH,	IF_EB("\033[%p1%d q", ESC_STR "[%p1%d q")},
+    {KS_CSH,	IF_EB("\033[%p1%d q", ESC_STR "[%p1%d q")},
 #  else
     {(int)KS_CSH,	IF_EB("\033[%d q", ESC_STR "[%d q")},
 #  endif
-    {(int)KS_CRC,	IF_EB("\033[?12$p", ESC_STR "[?12$p")},
-    {(int)KS_CRS,	IF_EB("\033P$q q\033\\", ESC_STR "P$q q" ESC_STR "\\")},
+    {KS_CRC,	IF_EB("\033[?12$p", ESC_STR "[?12$p")},
+    {KS_CRS,	IF_EB("\033P$q q\033\\", ESC_STR "P$q q" ESC_STR "\\")},
 #  ifdef TERMINFO
-    {(int)KS_CM,	IF_EB("\033[%i%p1%d;%p2%dH",
+    {KS_CM,	IF_EB("\033[%i%p1%d;%p2%dH",
 						  ESC_STR "[%i%p1%d;%p2%dH")},
 #  else
     {(int)KS_CM,	IF_EB("\033[%i%d;%dH", ESC_STR "[%i%d;%dH")},
 #  endif
-    {(int)KS_SR,	IF_EB("\033M", ESC_STR "M")},
+    {KS_SR,	IF_EB("\033M", ESC_STR "M")},
 #  ifdef TERMINFO
-    {(int)KS_CRI,	IF_EB("\033[%p1%dC", ESC_STR "[%p1%dC")},
+    {KS_CRI,	IF_EB("\033[%p1%dC", ESC_STR "[%p1%dC")},
 #  else
     {(int)KS_CRI,	IF_EB("\033[%dC", ESC_STR "[%dC")},
 #  endif
-    {(int)KS_KS,	IF_EB("\033[?1h\033=", ESC_STR "[?1h" ESC_STR_nc "=")},
-    {(int)KS_KE,	IF_EB("\033[?1l\033>", ESC_STR "[?1l" ESC_STR_nc ">")},
+    {KS_KS,	IF_EB("\033[?1h\033=", ESC_STR "[?1h" ESC_STR_nc "=")},
+    {KS_KE,	IF_EB("\033[?1l\033>", ESC_STR "[?1l" ESC_STR_nc ">")},
 #  ifdef FEAT_XTERM_SAVE
     {(int)KS_TI,	IF_EB("\0337\033[?47h", ESC_STR "7" ESC_STR_nc "[?47h")},
     {(int)KS_TE,	IF_EB("\033[?47l\0338",
 					   ESC_STR_nc "[?47l" ESC_STR_nc "8")},
 #  endif
-    {(int)KS_CTI,	IF_EB("\033[>4;2m", ESC_STR_nc "[>4;2m")},
-    {(int)KS_CTE,	IF_EB("\033[>4;m", ESC_STR_nc "[>4;m")},
-    {(int)KS_CIS,	IF_EB("\033]1;", ESC_STR "]1;")},
-    {(int)KS_CIE,	"\007"},
-    {(int)KS_TS,	IF_EB("\033]2;", ESC_STR "]2;")},
-    {(int)KS_FS,	"\007"},
-    {(int)KS_CSC,	IF_EB("\033]12;", ESC_STR "]12;")},
-    {(int)KS_CEC,	"\007"},
+    {KS_CTI,	IF_EB("\033[>4;2m", ESC_STR_nc "[>4;2m")},
+    {KS_CTE,	IF_EB("\033[>4;m", ESC_STR_nc "[>4;m")},
+    {KS_CIS,	IF_EB("\033]1;", ESC_STR "]1;")},
+    {KS_CIE,	"\007"},
+    {KS_TS,	IF_EB("\033]2;", ESC_STR "]2;")},
+    {KS_FS,	"\007"},
+    {KS_CSC,	IF_EB("\033]12;", ESC_STR "]12;")},
+    {KS_CEC,	"\007"},
 #  ifdef TERMINFO
-    {(int)KS_CWS,	IF_EB("\033[8;%p1%d;%p2%dt",
+    {KS_CWS,	IF_EB("\033[8;%p1%d;%p2%dt",
 						  ESC_STR "[8;%p1%d;%p2%dt")},
-    {(int)KS_CWP,	IF_EB("\033[3;%p1%d;%p2%dt",
+    {KS_CWP,	IF_EB("\033[3;%p1%d;%p2%dt",
 						  ESC_STR "[3;%p1%d;%p2%dt")},
-    {(int)KS_CGP,	IF_EB("\033[13t", ESC_STR "[13t")},
+    {KS_CGP,	IF_EB("\033[13t", ESC_STR "[13t")},
 #  else
     {(int)KS_CWS,	IF_EB("\033[8;%d;%dt", ESC_STR "[8;%d;%dt")},
     {(int)KS_CWP,	IF_EB("\033[3;%d;%dt", ESC_STR "[3;%d;%dt")},
     {(int)KS_CGP,	IF_EB("\033[13t", ESC_STR "[13t")},
 #  endif
-    {(int)KS_CRV,	IF_EB("\033[>c", ESC_STR "[>c")},
-    {(int)KS_RFG,	IF_EB("\033]10;?\007", ESC_STR "]10;?\007")},
-    {(int)KS_RBG,	IF_EB("\033]11;?\007", ESC_STR "]11;?\007")},
-    {(int)KS_U7,	IF_EB("\033[6n", ESC_STR "[6n")},
+    {KS_CRV,	IF_EB("\033[>c", ESC_STR "[>c")},
+    {KS_RFG,	IF_EB("\033]10;?\007", ESC_STR "]10;?\007")},
+    {KS_RBG,	IF_EB("\033]11;?\007", ESC_STR "]11;?\007")},
+    {KS_U7,	IF_EB("\033[6n", ESC_STR "[6n")},
 #  ifdef FEAT_TERMGUICOLORS
     // These are printf strings, not terminal codes.
-    {(int)KS_8F,	IF_EB("\033[38;2;%lu;%lu;%lum", ESC_STR "[38;2;%lu;%lu;%lum")},
-    {(int)KS_8B,	IF_EB("\033[48;2;%lu;%lu;%lum", ESC_STR "[48;2;%lu;%lu;%lum")},
-    {(int)KS_8U,	IF_EB("\033[58;2;%lu;%lu;%lum", ESC_STR "[58;2;%lu;%lu;%lum")},
+    {KS_8F,	IF_EB("\033[38;2;%lu;%lu;%lum", ESC_STR "[38;2;%lu;%lu;%lum")},
+    {KS_8B,	IF_EB("\033[48;2;%lu;%lu;%lum", ESC_STR "[48;2;%lu;%lu;%lum")},
+    {KS_8U,	IF_EB("\033[58;2;%lu;%lu;%lum", ESC_STR "[58;2;%lu;%lu;%lum")},
 #  endif
-    {(int)KS_CAU,	IF_EB("\033[58;5;%dm", ESC_STR "[58;5;%dm")},
-    {(int)KS_CBE,	IF_EB("\033[?2004h", ESC_STR "[?2004h")},
-    {(int)KS_CBD,	IF_EB("\033[?2004l", ESC_STR "[?2004l")},
-    {(int)KS_CST,	IF_EB("\033[22;2t", ESC_STR "[22;2t")},
-    {(int)KS_CRT,	IF_EB("\033[23;2t", ESC_STR "[23;2t")},
-    {(int)KS_SSI,	IF_EB("\033[22;1t", ESC_STR "[22;1t")},
-    {(int)KS_SRI,	IF_EB("\033[23;1t", ESC_STR "[23;1t")},
+    {KS_CAU,	IF_EB("\033[58;5;%dm", ESC_STR "[58;5;%dm")},
+    {KS_CBE,	IF_EB("\033[?2004h", ESC_STR "[?2004h")},
+    {KS_CBD,	IF_EB("\033[?2004l", ESC_STR "[?2004l")},
+    {KS_CST,	IF_EB("\033[22;2t", ESC_STR "[22;2t")},
+    {KS_CRT,	IF_EB("\033[23;2t", ESC_STR "[23;2t")},
+    {KS_SSI,	IF_EB("\033[22;1t", ESC_STR "[22;1t")},
+    {KS_SRI,	IF_EB("\033[23;1t", ESC_STR "[23;1t")},
 #  if (defined(UNIX) || defined(VMS))
-    {(int)KS_FD,	IF_EB("\033[?1004l", ESC_STR "[?1004l")},
-    {(int)KS_FE,	IF_EB("\033[?1004h", ESC_STR "[?1004h")},
+    {KS_FD,	IF_EB("\033[?1004l", ESC_STR "[?1004l")},
+    {KS_FE,	IF_EB("\033[?1004h", ESC_STR "[?1004h")},
 #  endif
 
     {K_UP,		IF_EB("\033O*A", ESC_STR "O*A")},
@@ -1017,18 +1017,18 @@ static struct builtin_term builtin_termcaps[] =
 /*
  * iris-ansi for Silicon Graphics machines.
  */
-    {(int)KS_NAME,	"iris-ansi"},
-    {(int)KS_CE,	"\033[K"},
-    {(int)KS_CD,	"\033[J"},
-    {(int)KS_AL,	"\033[L"},
+    {KS_NAME,	"iris-ansi"},
+    {KS_CE,	"\033[K"},
+    {KS_CD,	"\033[J"},
+    {KS_AL,	"\033[L"},
 #  ifdef TERMINFO
-    {(int)KS_CAL,	"\033[%p1%dL"},
+    {KS_CAL,	"\033[%p1%dL"},
 #  else
     {(int)KS_CAL,	"\033[%dL"},
 #  endif
-    {(int)KS_DL,	"\033[M"},
+    {KS_DL,	"\033[M"},
 #  ifdef TERMINFO
-    {(int)KS_CDL,	"\033[%p1%dM"},
+    {KS_CDL,	"\033[%p1%dM"},
 #  else
     {(int)KS_CDL,	"\033[%dM"},
 #  endif
@@ -1039,53 +1039,53 @@ static struct builtin_term builtin_termcaps[] =
     {(int)KS_CS,	"\033[%i%d;%dr"},
 #  endif
 #endif
-    {(int)KS_CL,	"\033[H\033[2J"},
-    {(int)KS_VE,	"\033[9/y\033[12/y"},	// These aren't documented
-    {(int)KS_VS,	"\033[10/y\033[=1h\033[=2l"}, // These aren't documented
-    {(int)KS_TI,	"\033[=6h"},
-    {(int)KS_TE,	"\033[=6l"},
-    {(int)KS_SE,	"\033[21;27m"},
-    {(int)KS_SO,	"\033[1;7m"},
-    {(int)KS_ME,	"\033[m"},
-    {(int)KS_MR,	"\033[7m"},
-    {(int)KS_MD,	"\033[1m"},
-    {(int)KS_CCO,	"8"},			// allow 8 colors
-    {(int)KS_CZH,	"\033[3m"},		// italic mode on
-    {(int)KS_CZR,	"\033[23m"},		// italic mode off
-    {(int)KS_US,	"\033[4m"},		// underline on
-    {(int)KS_UE,	"\033[24m"},		// underline off
+    {KS_CL,	"\033[H\033[2J"},
+    {KS_VE,	"\033[9/y\033[12/y"},	// These aren't documented
+    {KS_VS,	"\033[10/y\033[=1h\033[=2l"}, // These aren't documented
+    {KS_TI,	"\033[=6h"},
+    {KS_TE,	"\033[=6l"},
+    {KS_SE,	"\033[21;27m"},
+    {KS_SO,	"\033[1;7m"},
+    {KS_ME,	"\033[m"},
+    {KS_MR,	"\033[7m"},
+    {KS_MD,	"\033[1m"},
+    {KS_CCO,	"8"},			// allow 8 colors
+    {KS_CZH,	"\033[3m"},		// italic mode on
+    {KS_CZR,	"\033[23m"},		// italic mode off
+    {KS_US,	"\033[4m"},		// underline on
+    {KS_UE,	"\033[24m"},		// underline off
 #  ifdef TERMINFO
-    {(int)KS_CAB,	"\033[4%p1%dm"},    // set background color (ANSI)
-    {(int)KS_CAF,	"\033[3%p1%dm"},    // set foreground color (ANSI)
-    {(int)KS_CSB,	"\033[102;%p1%dm"}, // set screen background color
-    {(int)KS_CSF,	"\033[101;%p1%dm"}, // set screen foreground color
+    {KS_CAB,	"\033[4%p1%dm"},    // set background color (ANSI)
+    {KS_CAF,	"\033[3%p1%dm"},    // set foreground color (ANSI)
+    {KS_CSB,	"\033[102;%p1%dm"}, // set screen background color
+    {KS_CSF,	"\033[101;%p1%dm"}, // set screen foreground color
 #  else
     {(int)KS_CAB,	"\033[4%dm"},	    // set background color (ANSI)
     {(int)KS_CAF,	"\033[3%dm"},	    // set foreground color (ANSI)
     {(int)KS_CSB,	"\033[102;%dm"},    // set screen background color
     {(int)KS_CSF,	"\033[101;%dm"},    // set screen foreground color
 #  endif
-    {(int)KS_MS,	"y"},		// guessed
-    {(int)KS_UT,	"y"},		// guessed
-    {(int)KS_LE,	"\b"},
+    {KS_MS,	"y"},		// guessed
+    {KS_UT,	"y"},		// guessed
+    {KS_LE,	"\b"},
 #  ifdef TERMINFO
-    {(int)KS_CM,	"\033[%i%p1%d;%p2%dH"},
+    {KS_CM,	"\033[%i%p1%d;%p2%dH"},
 #  else
     {(int)KS_CM,	"\033[%i%d;%dH"},
 #  endif
-    {(int)KS_SR,	"\033M"},
+    {KS_SR,	"\033M"},
 #  ifdef TERMINFO
-    {(int)KS_CRI,	"\033[%p1%dC"},
+    {KS_CRI,	"\033[%p1%dC"},
 #  else
     {(int)KS_CRI,	"\033[%dC"},
 #  endif
-    {(int)KS_CIS,	"\033P3.y"},
-    {(int)KS_CIE,	"\234"},    // ST "String Terminator"
-    {(int)KS_TS,	"\033P1.y"},
-    {(int)KS_FS,	"\234"},    // ST "String Terminator"
+    {KS_CIS,	"\033P3.y"},
+    {KS_CIE,	"\234"},    // ST "String Terminator"
+    {KS_TS,	"\033P1.y"},
+    {KS_FS,	"\234"},    // ST "String Terminator"
 #  ifdef TERMINFO
-    {(int)KS_CWS,	"\033[203;%p1%d;%p2%d/y"},
-    {(int)KS_CWP,	"\033[205;%p1%d;%p2%d/y"},
+    {KS_CWS,	"\033[203;%p1%d;%p2%d/y"},
+    {KS_CWP,	"\033[205;%p1%d;%p2%d/y"},
 #  else
     {(int)KS_CWS,	"\033[203;%d;%d/y"},
     {(int)KS_CWP,	"\033[205;%d;%d/y"},
@@ -1133,97 +1133,97 @@ static struct builtin_term builtin_termcaps[] =
 /*
  * for debugging
  */
-    {(int)KS_NAME,	"debug"},
-    {(int)KS_CE,	"[CE]"},
-    {(int)KS_CD,	"[CD]"},
-    {(int)KS_AL,	"[AL]"},
+    {KS_NAME,	"debug"},
+    {KS_CE,	"[CE]"},
+    {KS_CD,	"[CD]"},
+    {KS_AL,	"[AL]"},
 #  ifdef TERMINFO
-    {(int)KS_CAL,	"[CAL%p1%d]"},
+    {KS_CAL,	"[CAL%p1%d]"},
 #  else
     {(int)KS_CAL,	"[CAL%d]"},
 #  endif
-    {(int)KS_DL,	"[DL]"},
+    {KS_DL,	"[DL]"},
 #  ifdef TERMINFO
-    {(int)KS_CDL,	"[CDL%p1%d]"},
+    {KS_CDL,	"[CDL%p1%d]"},
 #  else
     {(int)KS_CDL,	"[CDL%d]"},
 #  endif
 #  ifdef TERMINFO
-    {(int)KS_CS,	"[%p1%dCS%p2%d]"},
+    {KS_CS,	"[%p1%dCS%p2%d]"},
 #  else
     {(int)KS_CS,	"[%dCS%d]"},
 #  endif
 #  ifdef TERMINFO
-    {(int)KS_CSV,	"[%p1%dCSV%p2%d]"},
+    {KS_CSV,	"[%p1%dCSV%p2%d]"},
 #  else
     {(int)KS_CSV,	"[%dCSV%d]"},
 #  endif
 #  ifdef TERMINFO
-    {(int)KS_CAB,	"[CAB%p1%d]"},
-    {(int)KS_CAF,	"[CAF%p1%d]"},
-    {(int)KS_CSB,	"[CSB%p1%d]"},
-    {(int)KS_CSF,	"[CSF%p1%d]"},
+    {KS_CAB,	"[CAB%p1%d]"},
+    {KS_CAF,	"[CAF%p1%d]"},
+    {KS_CSB,	"[CSB%p1%d]"},
+    {KS_CSF,	"[CSF%p1%d]"},
 #  else
     {(int)KS_CAB,	"[CAB%d]"},
     {(int)KS_CAF,	"[CAF%d]"},
     {(int)KS_CSB,	"[CSB%d]"},
     {(int)KS_CSF,	"[CSF%d]"},
 #  endif
-    {(int)KS_CAU,	"[CAU%d]"},
-    {(int)KS_OP,	"[OP]"},
-    {(int)KS_LE,	"[LE]"},
-    {(int)KS_CL,	"[CL]"},
-    {(int)KS_VI,	"[VI]"},
-    {(int)KS_VE,	"[VE]"},
-    {(int)KS_VS,	"[VS]"},
-    {(int)KS_ME,	"[ME]"},
-    {(int)KS_MR,	"[MR]"},
-    {(int)KS_MB,	"[MB]"},
-    {(int)KS_MD,	"[MD]"},
-    {(int)KS_SE,	"[SE]"},
-    {(int)KS_SO,	"[SO]"},
-    {(int)KS_UE,	"[UE]"},
-    {(int)KS_US,	"[US]"},
-    {(int)KS_UCE,	"[UCE]"},
-    {(int)KS_UCS,	"[UCS]"},
-    {(int)KS_STE,	"[STE]"},
-    {(int)KS_STS,	"[STS]"},
-    {(int)KS_MS,	"[MS]"},
-    {(int)KS_UT,	"[UT]"},
-    {(int)KS_XN,	"[XN]"},
+    {KS_CAU,	"[CAU%d]"},
+    {KS_OP,	"[OP]"},
+    {KS_LE,	"[LE]"},
+    {KS_CL,	"[CL]"},
+    {KS_VI,	"[VI]"},
+    {KS_VE,	"[VE]"},
+    {KS_VS,	"[VS]"},
+    {KS_ME,	"[ME]"},
+    {KS_MR,	"[MR]"},
+    {KS_MB,	"[MB]"},
+    {KS_MD,	"[MD]"},
+    {KS_SE,	"[SE]"},
+    {KS_SO,	"[SO]"},
+    {KS_UE,	"[UE]"},
+    {KS_US,	"[US]"},
+    {KS_UCE,	"[UCE]"},
+    {KS_UCS,	"[UCS]"},
+    {KS_STE,	"[STE]"},
+    {KS_STS,	"[STS]"},
+    {KS_MS,	"[MS]"},
+    {KS_UT,	"[UT]"},
+    {KS_XN,	"[XN]"},
 #  ifdef TERMINFO
-    {(int)KS_CM,	"[%p1%dCM%p2%d]"},
+    {KS_CM,	"[%p1%dCM%p2%d]"},
 #  else
     {(int)KS_CM,	"[%dCM%d]"},
 #  endif
-    {(int)KS_SR,	"[SR]"},
+    {KS_SR,	"[SR]"},
 #  ifdef TERMINFO
-    {(int)KS_CRI,	"[CRI%p1%d]"},
+    {KS_CRI,	"[CRI%p1%d]"},
 #  else
     {(int)KS_CRI,	"[CRI%d]"},
 #  endif
-    {(int)KS_VB,	"[VB]"},
-    {(int)KS_KS,	"[KS]"},
-    {(int)KS_KE,	"[KE]"},
-    {(int)KS_TI,	"[TI]"},
-    {(int)KS_TE,	"[TE]"},
-    {(int)KS_CIS,	"[CIS]"},
-    {(int)KS_CIE,	"[CIE]"},
-    {(int)KS_CSC,	"[CSC]"},
-    {(int)KS_CEC,	"[CEC]"},
-    {(int)KS_TS,	"[TS]"},
-    {(int)KS_FS,	"[FS]"},
+    {KS_VB,	"[VB]"},
+    {KS_KS,	"[KS]"},
+    {KS_KE,	"[KE]"},
+    {KS_TI,	"[TI]"},
+    {KS_TE,	"[TE]"},
+    {KS_CIS,	"[CIS]"},
+    {KS_CIE,	"[CIE]"},
+    {KS_CSC,	"[CSC]"},
+    {KS_CEC,	"[CEC]"},
+    {KS_TS,	"[TS]"},
+    {KS_FS,	"[FS]"},
 #  ifdef TERMINFO
-    {(int)KS_CWS,	"[%p1%dCWS%p2%d]"},
-    {(int)KS_CWP,	"[%p1%dCWP%p2%d]"},
+    {KS_CWS,	"[%p1%dCWS%p2%d]"},
+    {KS_CWP,	"[%p1%dCWP%p2%d]"},
 #  else
     {(int)KS_CWS,	"[%dCWS%d]"},
     {(int)KS_CWP,	"[%dCWP%d]"},
 #  endif
-    {(int)KS_CRV,	"[CRV]"},
-    {(int)KS_U7,	"[U7]"},
-    {(int)KS_RFG,	"[RFG]"},
-    {(int)KS_RBG,	"[RBG]"},
+    {KS_CRV,	"[CRV]"},
+    {KS_U7,	"[U7]"},
+    {KS_RFG,	"[RFG]"},
+    {KS_RBG,	"[RBG]"},
     {K_UP,		"[KU]"},
     {K_DOWN,		"[KD]"},
     {K_LEFT,		"[KL]"},
@@ -1320,10 +1320,10 @@ static struct builtin_term builtin_termcaps[] =
  * The most minimal terminal: only clear screen and cursor positioning
  * Always included.
  */
-    {(int)KS_NAME,	"dumb"},
-    {(int)KS_CL,	"\014"},
+    {KS_NAME,	"dumb"},
+    {KS_CL,	"\014"},
 #ifdef TERMINFO
-    {(int)KS_CM,	IF_EB("\033[%i%p1%d;%p2%dH",
+    {KS_CM,	IF_EB("\033[%i%p1%d;%p2%dH",
 						  ESC_STR "[%i%p1%d;%p2%dH")},
 #else
     {(int)KS_CM,	IF_EB("\033[%i%d;%dH", ESC_STR "[%i%d;%dH")},
@@ -1332,7 +1332,7 @@ static struct builtin_term builtin_termcaps[] =
 /*
  * end marker
  */
-    {(int)KS_NAME,	NULL}
+    {KS_NAME,	NULL}
 
 };	// end of builtin_termcaps
 
@@ -1397,7 +1397,7 @@ termgui_mch_get_rgb(guicolor_T color)
  * It is initialized with the default values by parse_builtin_tcap().
  * The values can be changed by setting the option with the same name.
  */
-char_u *(term_strings[(int)KS_LAST + 1]);
+char_u *(term_strings[KS_LAST + 1]);
 
 static int	need_gather = FALSE;	    // need to fill termleader[]
 static char_u	termleader[256 + 1];	    // for check_termcode()
@@ -1493,7 +1493,7 @@ find_builtin_term(char_u *term)
     p = builtin_termcaps;
     while (p->bt_string != NULL)
     {
-	if (p->bt_entry == (int)KS_NAME)
+	if (p->bt_entry == KS_NAME)
 	{
 #ifdef UNIX
 	    if (STRCMP(p->bt_string, "iris-ansi") == 0 && vim_is_iris(term))
@@ -1534,9 +1534,9 @@ parse_builtin_tcap(char_u *term)
     if (p->bt_string == NULL)
 	return;
 
-    for (++p; p->bt_entry != (int)KS_NAME && p->bt_entry != BT_EXTRA_KEYS; ++p)
+    for (++p; p->bt_entry != KS_NAME && p->bt_entry != BT_EXTRA_KEYS; ++p)
     {
-	if ((int)p->bt_entry >= 0)	// KS_xx entry
+	if (p->bt_entry >= 0)	// KS_xx entry
 	{
 	    // Only set the value if it wasn't set yet.
 	    if (term_strings[p->bt_entry] == NULL
@@ -1786,7 +1786,7 @@ report_term_error(char *error_msg, char_u *term)
     mch_errmsg("\r\n");
     for (termp = &(builtin_termcaps[0]); termp->bt_string != NULL; ++termp)
     {
-	if (termp->bt_entry == (int)KS_NAME
+	if (termp->bt_entry == KS_NAME
 		&& STRCMP(termp->bt_string, "gui") != 0)
 	{
 #ifdef HAVE_TGETENT
@@ -2007,7 +2007,7 @@ set_termname(char_u *term)
 	    add_termcode((char_u *)"kb", (bs_p = (char_u *)CTRL_H_STR), FALSE);
 	if ((del_p == NULL || *del_p == NUL) &&
 					    (bs_p == NULL || *bs_p != DEL))
-	    add_termcode((char_u *)"kD", (char_u *)DEL_STR, FALSE);
+	    add_termcode((char_u *)"kD", DEL_STR, FALSE);
     }
 
 #if defined(UNIX) || defined(VMS)
@@ -2325,9 +2325,9 @@ add_termcap_entry(char_u *name, int force)
 	    {
 		key = TERMCAP2KEY(name[0], name[1]);
 		++termp;
-		while (termp->bt_entry != (int)KS_NAME)
+		while (termp->bt_entry != KS_NAME)
 		{
-		    if ((int)termp->bt_entry == key)
+		    if (termp->bt_entry == key)
 		    {
 			add_termcode(name, (char_u *)termp->bt_string,
 							  term_is_8bit(term));
@@ -3310,15 +3310,15 @@ get_bytes_from_buf(char_u *buf, char_u *bytes, int num_bytes)
 	{
 	    if (buf[len] == NUL || buf[len + 1] == NUL)	    // cannot happen?
 		return -1;
-	    if (buf[len++] == (int)KS_ZERO)
+	    if (buf[len++] == KS_ZERO)
 		c = NUL;
 	    // else it should be KS_SPECIAL; when followed by KE_FILLER c is
 	    // K_SPECIAL, or followed by KE_CSI and c must be CSI.
-	    if (buf[len++] == (int)KE_CSI)
+	    if (buf[len++] == KE_CSI)
 		c = CSI;
 	}
 	else if (c == CSI && buf[len] == KS_EXTRA
-					       && buf[len + 1] == (int)KE_CSI)
+					       && buf[len + 1] == KE_CSI)
 	    // CSI is stored as CSI KS_SPECIAL KE_CSI to avoid confusion with
 	    // the start of a special key, see add_to_input_buf_csi().
 	    len += 2;
@@ -4561,7 +4561,7 @@ modifiers2keycode(int modifiers, int *key, char_u *string)
 	if (modifiers != 0)
 	{
 	    string[new_slen++] = K_SPECIAL;
-	    string[new_slen++] = (int)KS_MODIFIER;
+	    string[new_slen++] = KS_MODIFIER;
 	    string[new_slen++] = modifiers;
 	}
     }
@@ -4989,8 +4989,8 @@ handle_csi(
     {
 	handle_u7_response(arg, tp, csi_len);
 
-	key_name[0] = (int)KS_EXTRA;
-	key_name[1] = (int)KE_IGNORE;
+	key_name[0] = KS_EXTRA;
+	key_name[1] = KE_IGNORE;
 	*slen = csi_len;
     }
 
@@ -5006,8 +5006,8 @@ handle_csi(
 # endif
 	apply_autocmds(EVENT_TERMRESPONSE,
 					NULL, NULL, FALSE, curbuf);
-	key_name[0] = (int)KS_EXTRA;
-	key_name[1] = (int)KE_IGNORE;
+	key_name[0] = KS_EXTRA;
+	key_name[1] = KE_IGNORE;
     }
 
     // Check blinking cursor from xterm:
@@ -5025,8 +5025,8 @@ handle_csi(
 	initial_cursor_blink = (arg[1] == '1');
 	rbm_status.tr_progress = STATUS_GOT;
 	LOG_TR(("Received cursor blinking mode response: %s", tp));
-	key_name[0] = (int)KS_EXTRA;
-	key_name[1] = (int)KE_IGNORE;
+	key_name[0] = KS_EXTRA;
+	key_name[1] = KE_IGNORE;
 	*slen = csi_len;
 # ifdef FEAT_EVAL
 	set_vim_var_string(VV_TERMBLINKRESP, tp, *slen);
@@ -5041,8 +5041,8 @@ handle_csi(
 	winpos_x = arg[1];
 	winpos_y = arg[2];
 	// got finished code: consume it
-	key_name[0] = (int)KS_EXTRA;
-	key_name[1] = (int)KE_IGNORE;
+	key_name[0] = KS_EXTRA;
+	key_name[1] = KE_IGNORE;
 	*slen = csi_len;
 
 	if (--did_request_winpos <= 0)
@@ -5145,8 +5145,8 @@ handle_osc(char_u *tp, char_u *argp, int len, char_u *key_name, int *slen)
 		}
 
 		// got finished code: consume it
-		key_name[0] = (int)KS_EXTRA;
-		key_name[1] = (int)KE_IGNORE;
+		key_name[0] = KS_EXTRA;
+		key_name[1] = KE_IGNORE;
 		*slen = i + 1 + (tp[i] == ESC);
 # ifdef FEAT_EVAL
 		set_vim_var_string(is_bg ? VV_TERMRBGRESP
@@ -5197,8 +5197,8 @@ handle_dcs(char_u *tp, char_u *argp, int len, char_u *key_name, int *slen)
 	    {
 		if (i - j >= 3)
 		    got_code_from_term(tp + j, i);
-		key_name[0] = (int)KS_EXTRA;
-		key_name[1] = (int)KE_IGNORE;
+		key_name[0] = KS_EXTRA;
+		key_name[1] = KE_IGNORE;
 		*slen = i + 1 + (tp[i] == ESC);
 		break;
 	    }
@@ -5235,8 +5235,8 @@ handle_dcs(char_u *tp, char_u *argp, int len, char_u *key_name, int *slen)
 		rcs_status.tr_progress = STATUS_GOT;
 		LOG_TR(("Received cursor shape response: %s", tp));
 
-		key_name[0] = (int)KS_EXTRA;
-		key_name[1] = (int)KE_IGNORE;
+		key_name[0] = KS_EXTRA;
+		key_name[1] = KE_IGNORE;
 		*slen = i + 1;
 # ifdef FEAT_EVAL
 		set_vim_var_string(VV_TERMSTYLERESP, tp, *slen);
@@ -5586,14 +5586,14 @@ check_termcode(
 	 * so that we know which window to scroll later.
 	 */
 	if (gui.in_use
-		&& key_name[0] == (int)KS_EXTRA
-		&& (key_name[1] == (int)KE_X1MOUSE
-		    || key_name[1] == (int)KE_X2MOUSE
-		    || key_name[1] == (int)KE_MOUSEMOVE_XY
-		    || key_name[1] == (int)KE_MOUSELEFT
-		    || key_name[1] == (int)KE_MOUSERIGHT
-		    || key_name[1] == (int)KE_MOUSEDOWN
-		    || key_name[1] == (int)KE_MOUSEUP))
+		&& key_name[0] == KS_EXTRA
+		&& (key_name[1] == KE_X1MOUSE
+		    || key_name[1] == KE_X2MOUSE
+		    || key_name[1] == KE_MOUSEMOVE_XY
+		    || key_name[1] == KE_MOUSELEFT
+		    || key_name[1] == KE_MOUSERIGHT
+		    || key_name[1] == KE_MOUSEDOWN
+		    || key_name[1] == KE_MOUSEUP))
 	{
 	    char_u	bytes[6];
 	    int		num_bytes = get_bytes_from_buf(tp + slen, bytes, 4);
@@ -5604,8 +5604,8 @@ check_termcode(
 	    mouse_row = 128 * (bytes[2] - ' ' - 1) + bytes[3] - ' ' - 1;
 	    slen += num_bytes;
 	    // equal to K_MOUSEMOVE
-	    if (key_name[1] == (int)KE_MOUSEMOVE_XY)
-		key_name[1] = (int)KE_MOUSEMOVE;
+	    if (key_name[1] == KE_MOUSEMOVE_XY)
+		key_name[1] = KE_MOUSEMOVE;
 	}
 	else
 #endif
@@ -5659,7 +5659,7 @@ check_termcode(
 	 * new value of the scrollbar.
 	 */
 # ifdef FEAT_MENU
-	else if (key_name[0] == (int)KS_MENU)
+	else if (key_name[0] == KS_MENU)
 	{
 	    long_u	val;
 	    int		num_bytes = get_long_from_buf(tp + slen, &val);
@@ -5674,12 +5674,12 @@ check_termcode(
 	    if (check_menu_pointer(root_menu, current_menu) == FAIL)
 	    {
 		key_name[0] = KS_EXTRA;
-		key_name[1] = (int)KE_IGNORE;
+		key_name[1] = KE_IGNORE;
 	    }
 	}
 # endif
 # ifdef FEAT_GUI_TABLINE
-	else if (key_name[0] == (int)KS_TABLINE)
+	else if (key_name[0] == KS_TABLINE)
 	{
 	    // Selecting tabline tab or using its menu.
 	    char_u	bytes[6];
@@ -5692,7 +5692,7 @@ check_termcode(
 		current_tab = -1;
 	    slen += num_bytes;
 	}
-	else if (key_name[0] == (int)KS_TABMENU)
+	else if (key_name[0] == KS_TABMENU)
 	{
 	    // Selecting tabline tab or using its menu.
 	    char_u	bytes[6];
@@ -5780,7 +5780,7 @@ check_termcode(
 		    did_cursorhold = TRUE;
 		    focus_state = TRUE;
 		}
-		key_name[1] = (int)KE_IGNORE;
+		key_name[1] = KE_IGNORE;
 	    }
 	    else if (key_name[1] == KE_FOCUSLOST)
 	    {
@@ -5790,7 +5790,7 @@ check_termcode(
 		    did_cursorhold = TRUE;
 		    focus_state = FALSE;
 		}
-		key_name[1] = (int)KE_IGNORE;
+		key_name[1] = KE_IGNORE;
 	    }
 	}
 #endif
@@ -5973,8 +5973,8 @@ replace_termcodes(
 		{
 		    src += 5;
 		    result[dlen++] = K_SPECIAL;
-		    result[dlen++] = (int)KS_EXTRA;
-		    result[dlen++] = (int)KE_SNR;
+		    result[dlen++] = KS_EXTRA;
+		    result[dlen++] = KE_SNR;
 		    sprintf((char *)result + dlen, "%ld",
 						    (long)current_sctx.sc_sid);
 		    dlen += (int)STRLEN(result + dlen);
@@ -6091,7 +6091,7 @@ replace_termcodes(
 	    {
 		result[dlen++] = K_SPECIAL;
 		result[dlen++] = KS_EXTRA;
-		result[dlen++] = (int)KE_CSI;
+		result[dlen++] = KE_CSI;
 	    }
 # endif
 	    else

--- a/src/time.c
+++ b/src/time.c
@@ -689,11 +689,11 @@ add_timer_info(typval_T *rettv, timer_T *timer)
     list_append_dict(list, dict);
 
     dict_add_number(dict, "id", timer->tr_id);
-    dict_add_number(dict, "time", (long)timer->tr_interval);
+    dict_add_number(dict, "time", timer->tr_interval);
 
     profile_start(&now);
     remaining = proftime_time_left(&timer->tr_due, &now);
-    dict_add_number(dict, "remaining", (long)remaining);
+    dict_add_number(dict, "remaining", remaining);
 
     dict_add_number(dict, "repeat",
 		    (long)(timer->tr_repeat < 0 ? -1 : timer->tr_repeat + 1));
@@ -1106,7 +1106,7 @@ add_time(char_u *buf, size_t buflen, time_t tt)
     else
 #endif
     {
-	long seconds = (long)(vim_time() - tt);
+	long seconds = (vim_time() - tt);
 
 	vim_snprintf((char *)buf, buflen,
 		NGETTEXT("%ld second ago", "%ld seconds ago", seconds),

--- a/src/typval.c
+++ b/src/typval.c
@@ -920,7 +920,7 @@ tv_get_string_buf_chk_strict(typval_T *varp, char_u *buf, int strict)
 		break;
 	    }
 	    vim_snprintf((char *)buf, NUMBUFLEN, "%lld",
-					    (varnumber_T)varp->vval.v_number);
+					    varp->vval.v_number);
 	    return buf;
 	case VAR_FUNC:
 	case VAR_PARTIAL:

--- a/src/ui.c
+++ b/src/ui.c
@@ -337,14 +337,14 @@ inchar_loop(
 
 			ibuf[0] = CSI;
 			ibuf[1] = KS_EXTRA;
-			ibuf[2] = (int)KE_CURSORHOLD;
+			ibuf[2] = KE_CURSORHOLD;
 			add_to_input_buf(ibuf, 3);
 		    }
 		    else
 		    {
 			buf[0] = K_SPECIAL;
 			buf[1] = KS_EXTRA;
-			buf[2] = (int)KE_CURSORHOLD;
+			buf[2] = KE_CURSORHOLD;
 		    }
 		    return 3;
 		}
@@ -869,7 +869,7 @@ add_to_input_buf_csi(char_u *str, int len)
 	{
 	    // Turn CSI into K_CSI.
 	    buf[0] = KS_EXTRA;
-	    buf[1] = (int)KE_CSI;
+	    buf[1] = KE_CSI;
 	    add_to_input_buf(buf, 2);
 	}
     }
@@ -1101,8 +1101,8 @@ check_col(int col)
 {
     if (col < 0)
 	return 0;
-    if (col >= (int)screen_Columns)
-	return (int)screen_Columns - 1;
+    if (col >= screen_Columns)
+	return screen_Columns - 1;
     return col;
 }
 
@@ -1114,8 +1114,8 @@ check_row(int row)
 {
     if (row < 0)
 	return 0;
-    if (row >= (int)screen_Rows)
-	return (int)screen_Rows - 1;
+    if (row >= screen_Rows)
+	return screen_Rows - 1;
     return row;
 }
 

--- a/src/undo.c
+++ b/src/undo.c
@@ -1146,7 +1146,7 @@ undo_read(bufinfo_T *bi, char_u *buffer, size_t size)
     }
     else
 #endif
-    if (fread(buffer, (size_t)size, 1, bi->bi_fp) != 1)
+    if (fread(buffer, size, 1, bi->bi_fp) != 1)
 	retval = FAIL;
 
     if (retval == FAIL)
@@ -2395,7 +2395,7 @@ undo_time(
 	else
 	{
 	    if (dosec)
-		closest = (long)(vim_time() + 1);
+		closest = (vim_time() + 1);
 	    else if (dofile)
 		closest = curbuf->b_u_save_nr_last + 2;
 	    else
@@ -2821,7 +2821,7 @@ u_undoredo(int undo)
 	// adjust marks
 	if (oldsize != newsize)
 	{
-	    mark_adjust(top + 1, top + oldsize, (long)MAXLNUM,
+	    mark_adjust(top + 1, top + oldsize, MAXLNUM,
 					       (long)newsize - (long)oldsize);
 	    if (curbuf->b_op_start.lnum > top + oldsize)
 		curbuf->b_op_start.lnum += newsize - oldsize;
@@ -3708,10 +3708,10 @@ f_undotree(typval_T *argvars UNUSED, typval_T *rettv)
 
 	dict_add_number(dict, "synced", (long)curbuf->b_u_synced);
 	dict_add_number(dict, "seq_last", curbuf->b_u_seq_last);
-	dict_add_number(dict, "save_last", (long)curbuf->b_u_save_nr_last);
+	dict_add_number(dict, "save_last", curbuf->b_u_save_nr_last);
 	dict_add_number(dict, "seq_cur", curbuf->b_u_seq_cur);
 	dict_add_number(dict, "time_cur", (long)curbuf->b_u_time_cur);
-	dict_add_number(dict, "save_cur", (long)curbuf->b_u_save_nr_cur);
+	dict_add_number(dict, "save_cur", curbuf->b_u_save_nr_cur);
 
 	list = list_alloc();
 	if (list != NULL)

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -291,7 +291,7 @@ set_context_in_user_cmd(expand_T *xp, char_u *arg_in)
     char_u *
 expand_user_command_name(int idx)
 {
-    return get_user_commands(NULL, idx - (int)CMD_SIZE);
+    return get_user_commands(NULL, idx - CMD_SIZE);
 }
 
 /*
@@ -1697,7 +1697,7 @@ do_ucmd(exarg_T *eap)
 			&& (start == NULL || ksp < start || end == NULL)
 			&& ((ksp[1] == KS_SPECIAL && ksp[2] == KE_FILLER)
 # ifdef FEAT_GUI
-			    || (ksp[1] == KS_EXTRA && ksp[2] == (int)KE_CSI)
+			    || (ksp[1] == KS_EXTRA && ksp[2] == KE_CSI)
 # endif
 			    ))
 		{

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -1761,7 +1761,7 @@ fname_trans_sid(char_u *name, char_u *fname_buf, char_u **tofree, int *error)
     {
 	fname_buf[0] = K_SPECIAL;
 	fname_buf[1] = KS_EXTRA;
-	fname_buf[2] = (int)KE_SNR;
+	fname_buf[2] = KE_SNR;
 	i = 3;
 	if (eval_fname_sid(name))	// "<SID>" or "s:"
 	{
@@ -1808,7 +1808,7 @@ find_func_with_sid(char_u *name, int sid)
 
     buffer[0] = K_SPECIAL;
     buffer[1] = KS_EXTRA;
-    buffer[2] = (int)KE_SNR;
+    buffer[2] = KE_SNR;
     vim_snprintf((char *)buffer + 3, sizeof(buffer) - 3, "%ld_%s",
 							      (long)sid, name);
     hi = hash_find(&func_hashtab, buffer);
@@ -2903,7 +2903,7 @@ delete_script_functions(int sid)
 
     buf[0] = K_SPECIAL;
     buf[1] = KS_EXTRA;
-    buf[2] = (int)KE_SNR;
+    buf[2] = KE_SNR;
     sprintf((char *)buf + 3, "%d_", sid);
     len = STRLEN(buf);
 
@@ -3520,7 +3520,7 @@ trans_function_name(
     // Check for hard coded <SNR>: already translated function ID (from a user
     // command).
     if ((*pp)[0] == K_SPECIAL && (*pp)[1] == KS_EXTRA
-						   && (*pp)[2] == (int)KE_SNR)
+						   && (*pp)[2] == KE_SNR)
     {
 	*pp += 3;
 	len = get_id_len(pp) + 3;
@@ -3626,7 +3626,7 @@ trans_function_name(
 	    // Change "<SNR>" to the byte sequence.
 	    name[0] = K_SPECIAL;
 	    name[1] = KS_EXTRA;
-	    name[2] = (int)KE_SNR;
+	    name[2] = KE_SNR;
 	    mch_memmove(name + 3, name + 5, STRLEN(name + 5) + 1);
 	}
 	goto theend;
@@ -3729,7 +3729,7 @@ trans_function_name(
 	{
 	    name[0] = K_SPECIAL;
 	    name[1] = KS_EXTRA;
-	    name[2] = (int)KE_SNR;
+	    name[2] = KE_SNR;
 	    if (vim9script || lead > 3)	// If it's "<SID>"
 		STRCPY(name + 3, sid_buf);
 	}

--- a/src/version.c
+++ b/src/version.c
@@ -7738,7 +7738,7 @@ ex_version(exarg_T *eap)
     static void
 version_msg_wrap(char_u *s, int wrap)
 {
-    int		len = (int)vim_strsize(s) + (wrap ? 2 : 0);
+    int		len = vim_strsize(s) + (wrap ? 2 : 0);
 
     if (!got_int && len < (int)Columns && msg_col + len >= (int)Columns
 								&& *s != '\n')
@@ -7790,7 +7790,7 @@ list_in_columns(char_u **items, int size, int current)
     // width.
     for (i = 0; size < 0 ? items[i] != NULL : i < size; ++i)
     {
-	int l = (int)vim_strsize(items[i]) + (i == current ? 2 : 0);
+	int l = vim_strsize(items[i]) + (i == current ? 2 : 0);
 
 	if (l > width)
 	    width = l;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -5099,7 +5099,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 		break;
 	    case ISN_EXECCONCAT:
 		smsg("%s%4d EXECCONCAT %lld", pfx, current,
-					      (varnumber_T)iptr->isn_arg.number);
+					      iptr->isn_arg.number);
 		break;
 	    case ISN_ECHO:
 		{
@@ -5112,19 +5112,19 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 		break;
 	    case ISN_EXECUTE:
 		smsg("%s%4d EXECUTE %lld", pfx, current,
-					  (varnumber_T)(iptr->isn_arg.number));
+					  (iptr->isn_arg.number));
 		break;
 	    case ISN_ECHOMSG:
 		smsg("%s%4d ECHOMSG %lld", pfx, current,
-					  (varnumber_T)(iptr->isn_arg.number));
+					  (iptr->isn_arg.number));
 		break;
 	    case ISN_ECHOCONSOLE:
 		smsg("%s%4d ECHOCONSOLE %lld", pfx, current,
-					  (varnumber_T)(iptr->isn_arg.number));
+					  (iptr->isn_arg.number));
 		break;
 	    case ISN_ECHOERR:
 		smsg("%s%4d ECHOERR %lld", pfx, current,
-					  (varnumber_T)(iptr->isn_arg.number));
+					  (iptr->isn_arg.number));
 		break;
 	    case ISN_LOAD:
 		{
@@ -5134,7 +5134,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 							  + STACK_FRAME_SIZE));
 		    else
 			smsg("%s%4d LOAD $%lld", pfx, current,
-					  (varnumber_T)(iptr->isn_arg.number));
+					  (iptr->isn_arg.number));
 		}
 		break;
 	    case ISN_LOADOUTER:
@@ -5312,7 +5312,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 	    // constants
 	    case ISN_PUSHNR:
 		smsg("%s%4d PUSHNR %lld", pfx, current,
-					    (varnumber_T)(iptr->isn_arg.number));
+					    (iptr->isn_arg.number));
 		break;
 	    case ISN_PUSHBOOL:
 	    case ISN_PUSHSPEC:
@@ -5397,11 +5397,11 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 		break;
 	    case ISN_NEWLIST:
 		smsg("%s%4d NEWLIST size %lld", pfx, current,
-					    (varnumber_T)(iptr->isn_arg.number));
+					    (iptr->isn_arg.number));
 		break;
 	    case ISN_NEWDICT:
 		smsg("%s%4d NEWDICT size %lld", pfx, current,
-					    (varnumber_T)(iptr->isn_arg.number));
+					    (iptr->isn_arg.number));
 		break;
 
 	    // function call

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -712,7 +712,7 @@ find_exported(
 	}
 	funcname[0] = K_SPECIAL;
 	funcname[1] = KS_EXTRA;
-	funcname[2] = (int)KE_SNR;
+	funcname[2] = KE_SNR;
 	sprintf((char *)funcname + 3, "%ld_%s", (long)sid, name);
 	*ufunc = find_func(funcname, FALSE, NULL);
 	if (funcname != buffer)

--- a/src/window.c
+++ b/src/window.c
@@ -6418,7 +6418,7 @@ command_height(void)
 
 	    // clear the lines added to cmdline
 	    if (full_screen)
-		screen_fill((int)(cmdline_row), (int)Rows, 0,
+		screen_fill((cmdline_row), (int)Rows, 0,
 						   (int)Columns, ' ', ' ', 0);
 	    msg_row = cmdline_row;
 	    redraw_cmdline = TRUE;


### PR DESCRIPTION
I used clang-tidy to automatically remove all redundant casts. It uses a compilation database `compile_commands.json` which was generated with `bear`. Not even sure if this is a wanted change, just thought I'd try to fix the source of warning messages before suppressing them :+1: . Thanks for your time.