### PR TITLE
Fix expression register was broken when put was not evaluate

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2382,9 +2382,12 @@ do_one_cmd(
 	    // for '=' register: accept the rest of the line as an expression
 	    if (ea.arg[-1] == '=' && ea.arg[0] != NUL)
 	    {
-		set_expr_line(vim_strsave(ea.arg), &ea);
+		if (!ea.skip)
+		{
+		    set_expr_line(vim_strsave(ea.arg), &ea);
+		    did_set_expr_line = TRUE;
+		}
 		ea.arg += STRLEN(ea.arg);
-		did_set_expr_line = TRUE;
 	    }
 #endif
 	    ea.arg = skipwhite(ea.arg);

--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -647,4 +647,12 @@ func Test_command_not_implemented_E319()
   endif
 endfunc
 
+func Test_not_break_expression_register()
+  call setreg('=', '1+1')
+  if 0
+    put =1
+  endif
+  call assert_equal('1+1', getreg('=', 1))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**Describe the bug**
Expression register was broken when `:put` command was not evaluated.

**To Reproduce**
Detailed steps to reproduce the behavior:
1. Run `vim --clean` (or `gvim --clean`, etc.)
2. Execute following Vim script

```vim
call setreg('=', '1+1')
if 0
  put =1
endif
echo string(getreg('=', 1))
```
3. Displays `''`

**Expected behavior**
Displays `'1+1'`