### PR TITLE
Fixed "Vimscript" notation in comments to "Vim script".

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -227,14 +227,14 @@ Vim evaluation and command execution, and others.
                                                         *lua-vim-variables*
 The Vim editor global dictionaries |g:| |w:| |b:| |t:| |v:| can be accessed
 from Lua conveniently and idiomatically by referencing the `vim.*` Lua tables
-described below. In this way you can easily read and modify global Vimscript
+described below. In this way you can easily read and modify global Vim script
 variables from Lua.
 
 Example: >
 
-    vim.g.foo = 5     -- Set the g:foo Vimscript variable.
-    print(vim.g.foo)  -- Get and print the g:foo Vimscript variable.
-    vim.g.foo = nil   -- Delete (:unlet) the Vimscript variable.
+    vim.g.foo = 5     -- Set the g:foo Vim script variable.
+    print(vim.g.foo)  -- Get and print the g:foo Vim script variable.
+    vim.g.foo = nil   -- Delete (:unlet) the Vim script variable.
 
 vim.g                                                   *vim.g*
         Global (|g:|) editor variables.

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2182,7 +2182,7 @@ f_getcharmod(typval_T *argvars UNUSED, typval_T *rettv)
 /*
  * Process messages that have been queued for netbeans or clientserver.
  * Also check if any jobs have ended.
- * These functions can call arbitrary vimscript and should only be called when
+ * These functions can call arbitrary Vim script and should only be called when
  * it is safe to do so.
  */
     void

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -1853,7 +1853,7 @@ luaV_setvar(lua_State *L)
 	// Update the key
 	typval_T	tv;
 
-	// Convert the lua value to a vimscript type in the temporary variable
+	// Convert the lua value to a Vim script type in the temporary variable
 	lua_pushvalue(L, 4);
 	if (luaV_totypval(L, -1, &tv) == FAIL)
 	    return luaL_error(L, "Couldn't convert lua value");


### PR DESCRIPTION
Source: https://groups.google.com/g/vim_dev/c/3Z5yM8KER2w/m/wAqws0QSEAAJ

> "Vim script" is the short form.