### PR TITLE
refactor: remove redundant casts

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -386,7 +386,7 @@ au_cleanup(void)
 	return;
 
     // loop over all events
-    for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+    for (event = (event_T)0; (int)event < NUM_EVENTS;
 					    event = (event_T)((int)event + 1))
     {
 	// loop over all autocommand patterns
@@ -460,7 +460,7 @@ aubuflocal_remove(buf_T *buf)
 	    apc->arg_bufnr = 0;
 
     // invalidate buflocals looping through events
-    for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+    for (event = (event_T)0; (int)event < NUM_EVENTS;
 					    event = (event_T)((int)event + 1))
 	// loop over all autocommand patterns
 	FOR_ALL_AUTOCMD_PATTERNS(event, ap)
@@ -523,7 +523,7 @@ au_del_group(char_u *name)
 	AutoPat	*ap;
 	int	in_use = FALSE;
 
-	for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+	for (event = (event_T)0; (int)event < NUM_EVENTS;
 					    event = (event_T)((int)event + 1))
 	{
 	    FOR_ALL_AUTOCMD_PATTERNS(event, ap)
@@ -695,7 +695,7 @@ find_end_event(
     {
 	for (pat = arg; *pat && *pat != '|' && !VIM_ISWHITE(*pat); pat = p)
 	{
-	    if ((int)event_name2nr(pat, &p) >= (int)NUM_EVENTS)
+	    if ((int)event_name2nr(pat, &p) >= NUM_EVENTS)
 	    {
 		if (have_group)
 		    semsg(_("E216: No such event: %s"), pat);
@@ -967,7 +967,7 @@ do_autocmd(exarg_T *eap, char_u *arg_in, int forceit)
 	if (!forceit && *cmd != NUL)
 	    emsg(_(e_cannot_define_autocommands_for_all_events));
 	else
-	    for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+	    for (event = (event_T)0; (int)event < NUM_EVENTS;
 					     event = (event_T)((int)event + 1))
 		if (do_autocmd_event(event, pat,
 			     once, nested, cmd, forceit, group, flags) == FAIL)

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -103,7 +103,7 @@ read_buffer(
     retval = readfile(
 	    read_stdin ? NULL : curbuf->b_ffname,
 	    read_stdin ? NULL : curbuf->b_fname,
-	    (linenr_T)line_count, (linenr_T)0, (linenr_T)MAXLNUM, eap,
+	    line_count, (linenr_T)0, (linenr_T)MAXLNUM, eap,
 	    flags | READ_BUFFER);
     if (retval == OK)
     {

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -440,7 +440,7 @@ dbg_check_breakpoint(exarg_T *eap)
 	    // replace K_SNR with "<SNR>"
 	    if (debug_breakpoint_name[0] == K_SPECIAL
 		    && debug_breakpoint_name[1] == KS_EXTRA
-		    && debug_breakpoint_name[2] == (int)KE_SNR)
+		    && debug_breakpoint_name[2] == KE_SNR)
 		p = (char_u *)"<SNR>";
 	    else
 		p = (char_u *)"";

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1853,7 +1853,7 @@ vgetc(void)
 			// or a K_SPECIAL - KS_EXTRA - KE_CSI, which is CSI
 			// too.
 			c = vgetorpeek(TRUE);
-			if (vgetorpeek(TRUE) == (int)KE_CSI && c == KS_EXTRA)
+			if (vgetorpeek(TRUE) == KE_CSI && c == KS_EXTRA)
 			    buf[i] = CSI;
 		    }
 		}
@@ -2521,7 +2521,7 @@ handle_mapping(
 		    if (*s == RM_SCRIPT
 			    && (mp->m_keys[0] != K_SPECIAL
 				|| mp->m_keys[1] != KS_EXTRA
-				|| mp->m_keys[2] != (int)KE_SNR))
+				|| mp->m_keys[2] != KE_SNR))
 			continue;
 
 		    // If one of the typed keys cannot be remapped, skip the
@@ -3139,7 +3139,7 @@ vgetorpeek(int advance)
 				    if (!VIM_ISWHITE(ptr[col]))
 					curwin->w_wcol = vcol;
 				    vcol += lbr_chartabsize(ptr, ptr + col,
-							       (colnr_T)vcol);
+							       vcol);
 				    if (has_mbyte)
 					col += (*mb_ptr2len)(ptr + col);
 				    else

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -588,7 +588,7 @@ ex_hardcopy(exarg_T *eap)
      */
     if (mch_print_init(&settings,
 			curbuf->b_fname == NULL
-			    ? (char_u *)buf_spname(curbuf)
+			    ? buf_spname(curbuf)
 			    : curbuf->b_sfname == NULL
 				? curbuf->b_fname
 				: curbuf->b_sfname,

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1253,7 +1253,7 @@ cs_find_common(
 	int matched = 0;
 
 	// read output
-	cs_fill_results((char *)pat, totmatches, nummatches, &matches,
+	cs_fill_results(pat, totmatches, nummatches, &matches,
 							 &contexts, &matched);
 	vim_free(nummatches);
 	if (matches == NULL)
@@ -1745,7 +1745,7 @@ cs_parse_results(
      *
      *	<filename> <context> <line number> <pattern>
      */
-    if ((name = strtok((char *)buf, (const char *)" ")) == NULL)
+    if ((name = strtok(buf, (const char *)" ")) == NULL)
 	return NULL;
     if ((*context = strtok(NULL, (const char *)" ")) == NULL)
 	return NULL;

--- a/src/move.c
+++ b/src/move.c
@@ -1028,7 +1028,7 @@ curs_columns(
 	    // column
 	    sbr = get_showbreak_value(curwin);
 	    if (*sbr && *ml_get_cursor() == NUL
-				    && curwin->w_wcol == (int)vim_strsize(sbr))
+				    && curwin->w_wcol == vim_strsize(sbr))
 		curwin->w_wcol = 0;
 #endif
 	}

--- a/src/tag.c
+++ b/src/tag.c
@@ -2802,7 +2802,7 @@ findtag_end:
 			if (*p == TAG_SEP)
 			    *p = NUL;
 		}
-		matches[match_count++] = (char_u *)mfp;
+		matches[match_count++] = mfp;
 	    }
 	}
 

--- a/src/version.c
+++ b/src/version.c
@@ -7746,7 +7746,7 @@ ex_version(exarg_T *eap)
     static void
 version_msg_wrap(char_u *s, int wrap)
 {
-    int		len = (int)vim_strsize(s) + (wrap ? 2 : 0);
+    int		len = vim_strsize(s) + (wrap ? 2 : 0);
 
     if (!got_int && len < (int)Columns && msg_col + len >= (int)Columns
 								&& *s != '\n')
@@ -7798,7 +7798,7 @@ list_in_columns(char_u **items, int size, int current)
     // width.
     for (i = 0; size < 0 ? items[i] != NULL : i < size; ++i)
     {
-	int l = (int)vim_strsize(items[i]) + (i == current ? 2 : 0);
+	int l = vim_strsize(items[i]) + (i == current ? 2 : 0);
 
 	if (l > width)
 	    width = l;


### PR DESCRIPTION
Tried to be more conservative this time around: aka not removing `(long)` casts from pointer arithmetic.