### PR TITLE
Fix test failures on platforms where char is unsigned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
             compiler: gcc
             coverage: true
             extra: testgui
+            uchar: true
           - features: huge
             compiler: clang
             extra: asan
@@ -111,9 +112,13 @@ jobs:
             ;;
           esac
 
+          CFLAGS=""
           if ${{ matrix.coverage == true }}; then
-            echo "CFLAGS=--coverage -DUSE_GCOV_FLUSH"
+            CFLAGS="$CFLAGS --coverage -DUSE_GCOV_FLUSH"
             echo "LDFLAGS=--coverage"
+          fi
+          if ${{ matrix.uchar == true }}; then
+            CFLAGS="$CFLAGS -funsigned-char"
           fi
           if ${{ contains(matrix.extra, 'testgui') }}; then
             echo "TEST=-C src testgui"
@@ -130,6 +135,7 @@ jobs:
           if ${{ contains(matrix.extra, 'vimtags') }}; then
             echo "TEST=-C runtime/doc vimtags VIMEXE=../../${SRCDIR}/vim"
           fi
+          echo "CFLAGS=$CFLAGS"
           ) >> $GITHUB_ENV
 
       - name: Set up system

--- a/src/structs.h
+++ b/src/structs.h
@@ -1405,8 +1405,8 @@ typedef struct type_S type_T;
 struct type_S {
     vartype_T	    tt_type;
     int8_T	    tt_argcount;    // for func, incl. vararg, -1 for unknown
-    char	    tt_min_argcount; // number of non-optional arguments
-    char	    tt_flags;	    // TTFLAG_ values
+    int8_T	    tt_min_argcount; // number of non-optional arguments
+    char_u	    tt_flags;	    // TTFLAG_ values
     type_T	    *tt_member;	    // for list, dict, func return type
     type_T	    **tt_args;	    // func argument types, allocated
 };


### PR DESCRIPTION
Since this has come up before, I've also added `-funsigned-char` to one of the CI jobs to try and catch this earlier.  It would have caught this failure:

    vim9type.c: In function ‘check_type’:
    vim9type.c:576:34: error: comparison is always true due to limited range of data type [-Werror=type-limits]
           && actual->tt_min_argcount != -1
                                      ^~