### PR TITLE
`set spell` was not well handled in xpm syntax file

### DIFF
--- a/runtime/syntax/xpm.vim
+++ b/runtime/syntax/xpm.vim
@@ -10,10 +10,12 @@ if exists("b:current_syntax")
   finish
 endif
 
+syn spell notoplevel
+
 syn keyword xpmType		char
 syn keyword xpmStorageClass	static
 syn keyword xpmTodo		TODO FIXME XXX  contained
-syn region  xpmComment		start="/\*"  end="\*/"  contains=xpmTodo
+syn region  xpmComment		start="/\*"  end="\*/"  contains=xpmTodo,@Spell
 syn region  xpmPixelString	start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=@xpmColors
 
 if has("gui_running") || has("termguicolors") && &termguicolors


### PR DESCRIPTION
When opening an xpm file with Vim with "set spell", I see that misspelled words are highlighted outside of comments which does not make sense. This PR fixes that.

**Screenshot before fix**:
![xpm-with-set-spell-before](https://user-images.githubusercontent.com/2261629/135730243-0e2bf65b-25c0-4b31-bb4e-3eb9c3c3311f.png)

Notice e.g. that colors like `FFFFFF` were highlighted as syntax errors (undercurl).

*Screenshot after fix*:
![xpm-with-set-spell-after](https://user-images.githubusercontent.com/2261629/135730246-15a4f66d-cab2-4bfd-bfec-387dffff0864.png)

I emailed the maintainer of `runtime/syntax/xpm.vim`.
