### PR TITLE
Add modes to distinguish Insert/Replace mode scrolling

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8083,9 +8083,13 @@ mode([expr])	Return a string that indicates the current mode.
 		   CTRL-Vs  Visual blockwise using |v_CTRL-O| from Select mode
 		   i	    Insert
 		   ic	    Insert mode completion |compl-generic|
+		   is	    Insert mode |i_CTRL-X_CTRL-E| |i_CTRL-X_CTRL-Y|
+		   		scrolling
 		   ix	    Insert mode |i_CTRL-X| completion
 		   R	    Replace |R|
 		   Rc	    Replace mode completion |compl-generic|
+		   Rs	    Replace mode |i_CTRL-X_CTRL-E| |i_CTRL-X_CTRL-Y|
+		   		scrolling
 		   Rv	    Virtual Replace |gR|
 		   Rx	    Replace mode |i_CTRL-X| completion
 		   c	    Command-line editing

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -682,8 +682,11 @@ f_mode(typval_T *argvars, typval_T *rettv)
 		buf[0] = 'R';
 	    else
 		buf[0] = 'i';
+
 	    if (ins_compl_active())
 		buf[1] = 'c';
+	    else if (ctrl_x_mode_scroll())
+		buf[1] = 's';
 	    else if (ctrl_x_mode_not_defined_yet())
 		buf[1] = 'x';
 	}

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -784,6 +784,12 @@ func Test_mode()
   " i_CTRL-X CTRL-L: No match
   exe "normal iabc\<C-X>\<C-L>\<F2>\<Esc>u"
   call assert_equal('i-ic', g:current_modes)
+  " i_CTRL-X CTRL-E
+  exe "normal i\<C-X>\<C-E>\<F2>\<Esc>"
+  call assert_equal('i-is', g:current_modes)
+  " i_CTRL-X CTRL-Y
+  exe "normal i\<C-X>\<C-Y>\<F2>\<Esc>"
+  call assert_equal('i-is', g:current_modes)
 
   " R_CTRL-P: Multiple matches
   exe "normal RBa\<C-P>\<F2>\<Esc>u"
@@ -818,6 +824,12 @@ func Test_mode()
   " R_CTRL-X CTRL-L: No match
   exe "normal Rabc\<C-X>\<C-L>\<F2>\<Esc>u"
   call assert_equal('R-Rc', g:current_modes)
+  " R_CTRL-X CTRL-E
+  exe "normal R\<C-X>\<C-E>\<F2>\<Esc>"
+  call assert_equal('R-Rs', g:current_modes)
+  " R_CTRL-X CTRL-Y
+  exe "normal R\<C-X>\<C-Y>\<F2>\<Esc>"
+  call assert_equal('R-Rs', g:current_modes)
 
   call assert_equal('n', 0->mode())
   call assert_equal('n', 1->mode())


### PR DESCRIPTION
There are some small differences between Insert/Replace mode scrolling and normal Insert/Replace mode: in Insert/Replace mode scrolling `CTRL-E` and `CTRL-Y` behave differently, and mappings do not apply to them either. However I hardly think of a case where such differences matter to plugin, so distinguishing them is not very useful.

Of course, another use case of distinguishing Insert/Replace mode scrolling and normal Insert/Replace mode is to allow showing whether currently in Insert/Replace scrolling mode in `statusline` (for people who don't like `showmode` occupying the cmdline).