### PR TITLE
Improved runtime/syntax/tcl.vim

### DIFF
--- a/runtime/syntax/tcl.vim
+++ b/runtime/syntax/tcl.vim
@@ -8,7 +8,6 @@
 " Original:	Robin Becker <robin@jessikat.demon.co.uk>
 " Last Change:	2014-02-12
 " Version:	1.14
-" URL:		http://bitbucket.org/taylor_venable/metasyntax/src/tip/Config/vim/syntax/tcl.vim
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -192,18 +191,18 @@ syn region tcltkCommand matchgroup=tcltkCommandColor start="\<lsort\>" matchgrou
 syn keyword tclTodo contained	TODO
 
 " Sequences which are backslash-escaped: http://www.tcl.tk/man/tcl8.5/TclCmd/Tcl.htm#M16
-" Octal, hexadecimal, unicode codepoints, and the classics.
+" Octal, hexadecimal, Unicode codepoints, and the classics.
 " Tcl takes as many valid characters in a row as it can, so \xAZ in a string is newline followed by 'Z'.
-syn match   tclSpecial contained '\\\([0-7]\{1,3}\|x\x\{1,2}\|u\x\{1,4}\|[abfnrtv]\)'
+syn match   tclSpecial contained '\\\(\o\{1,3}\|x\x\{1,2}\|u\x\{1,4}\|[abfnrtv]\)'
 syn match   tclSpecial contained '\\[\[\]\{\}\"\$]'
 
 " Command appearing inside another command or inside a string.
 syn region tclEmbeddedStatement	start='\[' end='\]' contained contains=tclCommand,tclNumber,tclLineContinue,tclString,tclVarRef,tclEmbeddedStatement
 " A string needs the skip argument as it may legitimately contain \".
 " Match at start of line
-syn region  tclString		  start=+^"+ end=+"+ contains=@tclSpecialC skip=+\\\\\|\\"+
+syn region  tclString		  start=+^"+ end=+"+ contains=@tclSpecialC,@Spell skip=+\\\\\|\\"+
 "Match all other legal strings.
-syn region  tclString		  start=+[^\\]"+ms=s+1  end=+"+ contains=@tclSpecialC,@tclVarRefC,tclEmbeddedStatement skip=+\\\\\|\\"+
+syn region  tclString		  start=+[^\\]"+ms=s+1  end=+"+ contains=@tclSpecialC,@tclVarRefC,tclEmbeddedStatement,@Spell skip=+\\\\\|\\"+
 
 " Line continuation is backslash immediately followed by newline.
 syn match tclLineContinue '\\$'
@@ -222,12 +221,12 @@ syn match  tclNumber		"\.\d\+\(e[-+]\=\d\+\)\=[fl]\=\>"
 "floating point number, without dot, with exponent
 syn match  tclNumber		"\<\d\+e[-+]\=\d\+[fl]\=\>"
 "hex number
-syn match  tclNumber		"0x[0-9a-f]\+\(u\=l\=\|lu\)\>"
-"syn match  tclIdentifier	"\<[a-z_][a-z0-9_]*\>"
+syn match  tclNumber		"0x\x\+\(u\=l\=\|lu\)\>"
+"syn match  tclIdentifier	"\<\h\w*\>"
 syn case match
 
-syn region  tclComment		start="^\s*\#" skip="\\$" end="$" contains=tclTodo
-syn region  tclComment		start=/;\s*\#/hs=s+1 skip="\\$" end="$" contains=tclTodo
+syn region  tclComment		start="^\s*\#" skip="\\$" end="$" contains=tclTodo,@Spell
+syn region  tclComment		start=/;\s*\#/hs=s+1 skip="\\$" end="$" contains=tclTodo,@Spell
 
 "syn match tclComment /^\s*\#.*$/
 "syn match tclComment /;\s*\#.*$/hs=s+1


### PR DESCRIPTION
This PR updates the `runtime/syntax/tcl.vim` file:

- added `@Spell` to limit spell checking to Tcl comments and strings
  rather than spelling checking everything.
- removed broken link to source of the upstream `tcl.vim`
- replaced things like `[0-7]` with `\o`, `[0-9a-f]` with `\x` (etc.) as
  the atom from are documented to be faster than the `[..]` alternative,
  at least with `regexepengine=1`