### PR TITLE
Improve the gnuplot syntax

### DIFF
--- a/runtime/syntax/gnuplot.vim
+++ b/runtime/syntax/gnuplot.vim
@@ -37,7 +37,7 @@ syn match gnuplotUnit		"\d+cm"
 syn match gnuplotUnit		"\d+pt"
 
 " external (shell) commands are special
-syn region gnuplotExternal	start="!" end="$"
+syn region gnuplotExternal	start="^\s*!" end="$"
 
 " ---- Comments ---- "
 

--- a/runtime/syntax/gnuplot.vim
+++ b/runtime/syntax/gnuplot.vim
@@ -32,22 +32,22 @@ syn match gnuplotSpecial	"\\." contained
 " syn match gnuplotSpecial	"\\\o\o\o\|\\x\x\x\|\\c[^"]\|\\[a-z\\]" contained
 
 " measurements in the units in, cm and pt are special
-syn match gnuplotUnit		"[0-9]+in"
-syn match gnuplotUnit		"[0-9]+cm"
-syn match gnuplotUnit		"[0-9]+pt"
+syn match gnuplotUnit		"\d+in"
+syn match gnuplotUnit		"\d+cm"
+syn match gnuplotUnit		"\d+pt"
 
 " external (shell) commands are special
 syn region gnuplotExternal	start="!" end="$"
 
 " ---- Comments ---- "
 
-syn region gnuplotComment	start="#" end="$" contains=gnuplotTodo
+syn region gnuplotComment	start="#" end="$" contains=gnuplotTodo,@Spell
 
 " ---- Constants ---- "
 
 " strings
-syn region gnuplotString	start=+"+ skip=+\\"+ end=+"+ contains=gnuplotSpecial
-syn region gnuplotString	start="'" end="'"
+syn region gnuplotString	start=+"+ skip=+\\"+ end=+"+ contains=gnuplotSpecial,@Spell
+syn region gnuplotString	start="'" end="'" contains=@Spell
 
 " built-in variables
 syn keyword gnuplotNumber	GNUTERM GPVAL_TERM GPVAL_TERMOPTIONS GPVAL_SPLOT
@@ -76,7 +76,7 @@ syn keyword gnuplotNumber	GPVAL_TERM_YSIZE GPVAL_VIEW_MAP GPVAL_VIEW_ROT_X
 syn keyword gnuplotNumber	GPVAL_VIEW_ROT_Z GPVAL_VIEW_SCALE
 
 " function name variables
-syn match gnuplotNumber		"GPFUN_[a-zA-Z_]*"
+syn match gnuplotNumber		"GPFUN_\h*"
 
 " stats variables
 syn keyword gnuplotNumber	STATS_records STATS_outofrange STATS_invalid
@@ -104,23 +104,23 @@ syn keyword gnuplotError	FIT_LAMBDA_FACTOR FIT_LOG FIT_SCRIPT
 
 " integer number, or floating point number without a dot and with "f".
 syn case    ignore
-syn match   gnuplotNumber	"\<[0-9]\+\(u\=l\=\|lu\|f\)\>"
+syn match   gnuplotNumber	"\<\d\+\(u\=l\=\|lu\|f\)\>"
 
 " floating point number, with dot, optional exponent
-syn match   gnuplotFloat	"\<[0-9]\+\.[0-9]*\(e[-+]\=[0-9]\+\)\=[fl]\=\>"
+syn match   gnuplotFloat	"\<\d\+\.\d*\(e[-+]\=\d\+\)\=[fl]\=\>"
 
 " floating point number, starting with a dot, optional exponent
-syn match   gnuplotFloat	"\.[0-9]\+\(e[-+]\=[0-9]\+\)\=[fl]\=\>"
+syn match   gnuplotFloat	"\.\d\+\(e[-+]\=\d\+\)\=[fl]\=\>"
 
 " floating point number, without dot, with exponent
-syn match   gnuplotFloat	"\<[0-9]\+e[-+]\=[0-9]\+[fl]\=\>"
+syn match   gnuplotFloat	"\<\d\+e[-+]\=\d\+[fl]\=\>"
 
 " hex number
-syn match   gnuplotNumber	"\<0x[0-9a-f]\+\(u\=l\=\|lu\)\>"
+syn match   gnuplotNumber	"\<0x\x\+\(u\=l\=\|lu\)\>"
 syn case    match
 
 " flag an octal number with wrong digits by not highlighting
-syn match   gnuplotOctalError	"\<0[0-7]*[89]"
+syn match   gnuplotOctalError	"\<0\o*[89]"
 
 " ---- Identifiers: Functions ---- "
 
@@ -374,8 +374,8 @@ syn keyword gnuplotKeyword	nohead nooutliers nowedge off opaque outliers
 syn keyword gnuplotKeyword	palette pattern pi pointinterval pointsize
 syn keyword gnuplotKeyword	pointtype ps pt radius range rectangle
 syn keyword gnuplotKeyword	rowstacked screen separation size solid sorted
-syn keyword gnuplotKeyword	textbox transparent units unsorted userstyles
-syn keyword gnuplotKeyword	wedge x x2 xx xy yy
+syn keyword gnuplotKeyword	textbox units unsorted userstyles wedge
+syn keyword gnuplotKeyword	x x2 xx xy yy
 " set surface
 syn keyword gnuplotKeyword	surface implicit explicit
 " set table
@@ -477,9 +477,13 @@ syn keyword gnuplotKeyword	nooutput
 " keywords for 'test' command
 syn keyword gnuplotKeyword	terminal palette rgb rbg grb gbr brg bgr
 
+" The transparent gnuplot keyword cannot use 'syn keyword' as transparent
+" has a special meaning in :syntax commands.
+syn match gnuplotKeyword	"\<transparent\>"
+
 " ---- Macros ---- "
 
-syn match gnuplotMacro		"@[a-zA-Z0-9_]*"
+syn match gnuplotMacro		"@\w*"
 
 " ---- Todos ---- "
 


### PR DESCRIPTION
Improve the gnuplot syntax:

- only highlight spelling mistakes in comments and strings
- the gnuplot `transparent` keyword was not highlighted as
  a keyword as `transparent` has a special meaning in the
  Vim `:syntax keyword` command
- replaced `[0-9]` with `\d`, `[0-7]` with `\o` (etc.) as those
  regexp atoms are documented to be faster than their `[...]`
  alternative at least with `set regexpengine=1`