### PR TITLE
Fix FreeBSD build that it does not have <sys/sysinfo.h>

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -1109,7 +1109,7 @@ add_b0_fenc(
     static int
 swapfile_process_running(ZERO_BL *b0p, char_u *swap_fname UNUSED)
 {
-# ifdef HAVE_SYSINFO_UPTIME
+# if defined(HAVE_SYS_SYSINFO_H) && defined(HAVE_SYSINFO_UPTIME)
     stat_T	    st;
     struct sysinfo  sinfo;
 


### PR DESCRIPTION
FreeBSD does not have <sys/sysinfo.h> (unless port libsysinfo is installed), the incorrect conditional compile (without checking for HAVE_SYS_SYSINFO_H) causes compile error.