### PR TITLE
Trigger TextChanged after TextChangedI correctly

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -327,6 +327,7 @@ open_buffer(
     // Set last_changedtick to avoid triggering a TextChanged autocommand right
     // after it was added.
     curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
+    curbuf->b_last_changedtick_i = CHANGEDTICK(curbuf);
     curbuf->b_last_changedtick_pum = CHANGEDTICK(curbuf);
 
     // require "!" to overwrite the file, because it wasn't read completely

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -2422,7 +2422,7 @@ restore_backup:
 	    && (overwriting || vim_strchr(p_cpo, CPO_PLUS) != NULL))
     {
 	unchanged(buf, TRUE, FALSE);
-	// b:changedtick is may be incremented in unchanged() but that
+	// b:changedtick may be incremented in unchanged() but that
 	// should not trigger a TextChanged event.
 	if (buf->b_last_changedtick + 1 == CHANGEDTICK(buf))
 	    buf->b_last_changedtick = CHANGEDTICK(buf);

--- a/src/edit.c
+++ b/src/edit.c
@@ -1477,9 +1477,9 @@ ins_redraw(int ready)	    // not busy with something
 	last_cursormoved = curwin->w_cursor;
     }
 
-    // Trigger TextChangedI if b_changedtick differs.
+    // Trigger TextChangedI if b_changedtick_i differs.
     if (ready && has_textchangedI()
-	    && curbuf->b_last_changedtick != CHANGEDTICK(curbuf)
+	    && curbuf->b_last_changedtick_i != CHANGEDTICK(curbuf)
 	    && !pum_visible())
     {
 	aco_save_T	aco;
@@ -1489,13 +1489,13 @@ ins_redraw(int ready)	    // not busy with something
 	aucmd_prepbuf(&aco, curbuf);
 	apply_autocmds(EVENT_TEXTCHANGEDI, NULL, NULL, FALSE, curbuf);
 	aucmd_restbuf(&aco);
-	curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
+	curbuf->b_last_changedtick_i = CHANGEDTICK(curbuf);
 	if (tick != CHANGEDTICK(curbuf))  // see ins_apply_autocmds()
 	    u_save(curwin->w_cursor.lnum,
 					(linenr_T)(curwin->w_cursor.lnum + 1));
     }
 
-    // Trigger TextChangedP if b_changedtick differs. When the popupmenu closes
+    // Trigger TextChangedP if b_changedtick_pum differs. When the popupmenu closes
     // TextChangedI will need to trigger for backwards compatibility, thus use
     // different b_last_changedtick* variables.
     if (ready && has_textchangedP()

--- a/src/structs.h
+++ b/src/structs.h
@@ -2701,10 +2701,12 @@ struct file_buffer
 				// incremented for each change, also for undo
 #define CHANGEDTICK(buf) ((buf)->b_ct_di.di_tv.vval.v_number)
 
-    varnumber_T	b_last_changedtick; // b:changedtick when TextChanged or
-				    // TextChangedI was last triggered.
+    varnumber_T	b_last_changedtick; // b:changedtick when TextChanged
+				    // was last triggered.
+
     varnumber_T	b_last_changedtick_pum; // b:changedtick when TextChangedP was
 					// last triggered.
+    varnumber_T	b_last_changedtick_i;   // b:changedtick for TextChangedI
 
     int		b_saving;	// Set to TRUE if we are in the middle of
 				// saving the buffer.

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2863,5 +2863,43 @@ func Test_autocmd_with_block()
   augroup END
 endfunc
 
+" Test TextChangedI and TextChanged
+func Test_Changed_ChangedI()
+  new
+  call test_override("char_avail", 1)
+  let [g:autocmd_i, g:autocmd_n] = ['','']
+
+  func! TextChangedAutocmdI(char)
+    let g:autocmd_{tolower(a:char)} = a:char .. b:changedtick
+  endfunc
+
+  augroup Test_TextChanged
+    au!
+    au TextChanged  <buffer> :call TextChangedAutocmdI('N')
+    au TextChangedI <buffer> :call TextChangedAutocmdI('I')
+  augroup END
+
+  call feedkeys("ifoo\<esc>", 'tnix')
+  " TODO: Test test does not seem to trigger TextChanged autocommand, why?
+  " It works, when running interactively.
+  " call assert_equal('N3', g:autocmd_n)
+  call assert_equal('I3', g:autocmd_i)
+
+  call feedkeys("yyp", 'tnix')
+  " TODO: Test test does not seem to trigger TextChanged autocommand, why?
+  " It works, when running interactively.
+  " call assert_equal('N4', g:autocmd_n)
+  call assert_equal('I3', g:autocmd_i)
+
+  " CleanUp
+  call test_override("char_avail", 0)
+  au! TextChanged  <buffer>
+  au! TextChangedI <buffer>
+  augroup! Test_TextChanged
+  delfu TextChangedAutocmdI
+  unlet! g:autocmd_i g:autocmd_n
+
+  bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Use a separate variable for deciding whether or not to trigger
TextChangedI autocommand or not. Else we may skip an existing
TextChanged autocommand, just because TextChangedI triggered right
before.

fixes #8932

Note the test: For some reason, evaluating the g:autocmd_n variable was
never performed, therefore currently disabled. I tried different variations
of `feedkeys()` with different flags and `:norm!` commands. I could never make it trigger 
when run automatically... 

Not sure why, it works when running the test interactively, so probably something with
type-ahead?

I also verified, it fixes the issue mentioned in #8932. 

If anybody has an idea to trigger TextChanged correctly in the test, please let me know.