### PR TITLE
Fix failures with new python 3.10

### DIFF
--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -12,7 +12,7 @@ func Create_vim_dict()
   return {'a': 1}
 endfunction
 
-let s:system_error_pat = 'Vim(py3):SystemError: \(<built-in function eval> returned NULL without setting an error\|error return without exception set\)'
+let s:system_error_pat = 'Vim(py3):SystemError: \(<built-in function eval> returned NULL without setting an \(error\|exception\)\|error return without exception set\)'
 
 " This function should be called first. This sets up python functions used by
 " the other tests.

--- a/src/version.c
+++ b/src/version.c
@@ -758,6 +758,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    3484,
+/**/
     3483,
 /**/
     3482,


### PR DESCRIPTION
Problem:   Test suite fails with python 3.10
Solution:   Update the system error pattern. (Zdenek Dohnal, partially
                  fixes #8959)