### PR TITLE
Replace equivocal use of "will become" with "is set to"

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1329,12 +1329,12 @@ present in 'cpoptions' and "!" is not used in the command.
 			other tabs and for windows in the current tab that
 			have their own window-local directory.
 
-							*:tch* *:tchdir*
-:tch[dir][!]		Same as |:tcd|.
-
 							*:tcd-*
 :tc[d][!] -		Change to the previous current directory, before the
 			last ":tcd {path}" command.
+
+							*:tch* *:tchdir*
+:tch[dir][!]		Same as |:tcd|.
 
 							*:lc* *:lcd*
 :lc[d][!] {path}	Like |:cd|, but only set the current directory when
@@ -1342,12 +1342,12 @@ present in 'cpoptions' and "!" is not used in the command.
 			directory for other windows is not changed, switching
 			to another window will stop using {path}.
 
-							*:lch* *:lchdir*
-:lch[dir][!]		Same as |:lcd|.
-
 							*:lcd-*
 :lcd[!] -		Change to the previous current directory, before the
 			last ":lcd {path}" command.
+
+							*:lch* *:lchdir*
+:lch[dir][!]		Same as |:lcd|.
 
 							*:pw* *:pwd* *E187*
 :pw[d]			Print the current directory name.
@@ -1375,15 +1375,15 @@ change anything for the current directory.
 When a |:lcd| command has been used for a window, the specified directory
 becomes the current directory for that window.  Windows where the |:lcd|
 command has not been used stick to the global or tab-local current directory.
-When jumping to another window the current directory will become the last
-specified local current directory.  If none was specified, the global or
-tab-local current directory is used.
+When jumping to another window the current directory is set to the last
+specified local current directory for that window.  If that window has no local
+current directory the tab-local or global current directory is used.
 
 When a |:tcd| command has been used for a tab page, the specified directory
 becomes the current directory for the current tab page and the current window.
 The current directory of other tab pages is not affected.  When jumping to
-another tab page, the current directory will become the last specified local
-directory for that tab page. If the current tab has no local current directory
+another tab page, the current directory is set to the last specified local
+directory for that tab page.  If that tab page has no local current directory
 the global current directory is used.
 
 When a |:cd| command is used, the current window and tab page will lose the


### PR DESCRIPTION
"the current directory will become the last specified directory" is equivocal: it can either mean "the current directory is set to the last specified directory" or "the last specified directory is set to the current directory".