### PR TITLE
Running "make test_put" failed

### DIFF
--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -1,5 +1,7 @@
 " Tests for put commands, e.g. ":put", "p", "gp", "P", "gP", etc.
 
+source check.vim
+
 func Test_put_block()
   new
   call feedkeys("i\<C-V>u2500\<CR>x\<ESC>", 'x')


### PR DESCRIPTION
"make test_alot" ran tests test_put.vim fine, but running
"make test_put" alone failed because it did not source check.vim.
```
$ cd vim/src/testdir
$ make test_put 
rm -f test_put.res test.log messages
VIMRUNTIME=../../runtime  ../vim -f  -u unix.vim -U NONE --noplugin --not-a-term -S runtest.vim test_put.vim --cmd 'au SwapExists * let v:swapchoice = "e"' | LC_ALL=C LANG=C LANGUAGE=C awk '/Executing Test_/{match($0, "Executing Test_[^\\)]*\\)"); print substr($0, RSTART, RLENGTH) "\r"; fflush()}'
Executing Test_gp_with_count_leaves_cursor_at_end()
Executing Test_put_block()
Executing Test_put_char_block()
Executing Test_put_char_block2()
Executing Test_put_expr()
Executing Test_put_fails_when_nomodifiable()
Executing Test_put_lines()
Executing Test_put_p_errmsg_nodup()
Executing Test_put_p_indent_visual()
Executing Test_put_visual_delete_all_lines()
Executing Test_very_large_count()


From test_put.vim:
Executed Test_gp_with_count_leaves_cursor_at_end() in   0.000942 seconds
Executed Test_put_block()                          in   0.000831 seconds
Executed Test_put_char_block()                     in   0.001138 seconds
Executed Test_put_char_block2()                    in   0.000771 seconds
Executed Test_put_expr()                           in   0.000835 seconds
Executed Test_put_fails_when_nomodifiable()        in   0.000742 seconds
Executed Test_put_lines()                          in   0.000666 seconds
Executed Test_put_p_errmsg_nodup()                 in   0.000506 seconds
Executed Test_put_p_indent_visual()                in   0.000577 seconds
Executed Test_put_visual_delete_all_lines()        in   0.000773 seconds
Executed Test_very_large_count()                   in   0.000502 seconds
Executed 11 tests                        in   0.017145 seconds
1 FAILED:
Found errors in Test_very_large_count():
Caught exception in Test_very_large_count(): Vim:E492: Not an editor command:   CheckNotMSWindows @ command line..script /home/pel/sb/vim/src/testdir/runtest.vim[486]..function RunTheTest[44]..Test_very_large_count, line 2
Makefile:63: recipe for target 'test_put' failed
make: *** [test_put] Error 1
```