### PR TITLE
Transparent background of :terminal with 'termguicolors'

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -168,9 +168,6 @@ terminal window will start with a white or black background.
 To use a different color the Terminal highlight group can be used, for
 example: >
     hi Terminal ctermbg=lightgrey ctermfg=blue guibg=lightgrey guifg=blue
-The highlight needs to be defined before the terminal is created.  Doing it
-later, or setting 'wincolor', will only have effect when the program running
-in the terminal displays text or clears the terminal.
 Instead of Terminal another group can be specified with the "term_highlight"
 option for `term_start()`.
 

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -641,9 +641,6 @@ do_highlight(
     int		error = FALSE;
     int		color;
     int		is_normal_group = FALSE;	// "Normal" group
-#ifdef FEAT_TERMINAL
-    int		is_terminal_group = FALSE;	// "Terminal" group
-#endif
 #ifdef FEAT_GUI_X11
     int		is_menu_group = FALSE;		// "Menu" group
     int		is_scrollbar_group = FALSE;	// "Scrollbar" group
@@ -882,10 +879,6 @@ do_highlight(
 
     if (STRCMP(HL_TABLE()[idx].sg_name_u, "NORMAL") == 0)
 	is_normal_group = TRUE;
-#ifdef FEAT_TERMINAL
-    else if (STRCMP(HL_TABLE()[idx].sg_name_u, "TERMINAL") == 0)
-	is_terminal_group = TRUE;
-#endif
 #ifdef FEAT_GUI_X11
     else if (STRCMP(HL_TABLE()[idx].sg_name_u, "MENU") == 0)
 	is_menu_group = TRUE;
@@ -1534,11 +1527,6 @@ do_highlight(
 	    control_console_color_rgb();
 #endif
 	}
-#ifdef FEAT_TERMINAL
-	else if (is_terminal_group)
-	    set_terminal_default_colors(
-		    HL_TABLE()[idx].sg_cterm_fg, HL_TABLE()[idx].sg_cterm_bg);
-#endif
 #ifdef FEAT_GUI_X11
 # ifdef FEAT_MENU
 	else if (is_menu_group)

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -19,7 +19,6 @@ cursorentry_T *term_get_cursor_shape(guicolor_T *fg, guicolor_T *bg);
 int term_use_loop(void);
 void term_win_entered(void);
 int terminal_loop(int blocking);
-void set_terminal_default_colors(int cterm_fg, int cterm_bg);
 int may_close_term_popup(void);
 void term_channel_closed(channel_T *ch);
 void term_check_channel_closed_recently(void);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2909,10 +2909,34 @@ cell2attr(
 #ifdef FEAT_TERMGUICOLORS
     if (p_tgc)
     {
-	guicolor_T fg, bg;
+	guicolor_T fg = INVALCOLOR;
+	guicolor_T bg = INVALCOLOR;
 
-	fg = gui_get_rgb_color_cmn(cellfg.red, cellfg.green, cellfg.blue);
-	bg = gui_get_rgb_color_cmn(cellbg.red, cellbg.green, cellbg.blue);
+	// Use the 'wincolor' or "Terminal" highlighting for the default
+	// colors.
+	if (VTERM_COLOR_IS_DEFAULT_FG(&cellfg)
+		|| VTERM_COLOR_IS_DEFAULT_BG(&cellbg))
+	{
+	    int id = 0;
+
+	    if (wp != NULL && *wp->w_p_wcr != NUL)
+		id = syn_name2id(wp->w_p_wcr);
+	    if (id == 0)
+		id = syn_name2id(term_get_highlight_name(term));
+	    if (id > 0)
+		syn_id2colors(id, &fg, &bg);
+	    if (!VTERM_COLOR_IS_DEFAULT_FG(&cellfg))
+		fg = gui_get_rgb_color_cmn(cellfg.red, cellfg.green,
+					   cellfg.blue);
+	    if (!VTERM_COLOR_IS_DEFAULT_BG(&cellbg))
+		bg = gui_get_rgb_color_cmn(cellbg.red, cellbg.green,
+					   cellbg.blue);
+	}
+	else
+	{
+	    fg = gui_get_rgb_color_cmn(cellfg.red, cellfg.green, cellfg.blue);
+	    bg = gui_get_rgb_color_cmn(cellbg.red, cellbg.green, cellbg.blue);
+	}
 
 	return get_tgc_attr_idx(attr, fg, bg);
     }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -204,10 +204,6 @@ static void handle_postponed_scrollback(term_T *term);
 // backspace key.
 static int term_backspace_char = BS;
 
-// "Terminal" highlight group colors.
-static int term_default_cterm_fg = -1;
-static int term_default_cterm_bg = -1;
-
 // Store the last set and the desired cursor properties, so that we only update
 // them when needed.  Doing it unnecessary may result in flicker.
 static char_u	*last_set_cursor_color = NULL;
@@ -2719,16 +2715,6 @@ may_toggle_cursor(term_T *term)
 	else
 	    cursor_off();
     }
-}
-
-/*
- * Cache "Terminal" highlight group colors.
- */
-    void
-set_terminal_default_colors(int cterm_fg, int cterm_bg)
-{
-    term_default_cterm_fg = cterm_fg - 1;
-    term_default_cterm_bg = cterm_bg - 1;
 }
 
 /*


### PR DESCRIPTION
Fixed the background of `:terminal` to be transparent when `termguicolors` is set.

This PR fixes #2361

* `hi Terminal` and `wincolor` will be applied immediately when `tgc`.
  (When `notgc`, it is from before.)
* Removed the cache of terminal colors. It is unnecessary.