### PR TITLE
Fixed badly indented dangling 'else'

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -2305,8 +2305,8 @@ win_update(win_T *wp)
 			    ++new_rows;
 			else
 #endif
-#ifdef FEAT_DIFF
 			{
+#ifdef FEAT_DIFF
 			    if (l == wp->w_topline)
 				new_rows += plines_win_nofill(wp, l, TRUE)
 							  + wp->w_topfill;

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -2306,12 +2306,14 @@ win_update(win_T *wp)
 			else
 #endif
 #ifdef FEAT_DIFF
+			{
 			    if (l == wp->w_topline)
-			    new_rows += plines_win_nofill(wp, l, TRUE)
-							      + wp->w_topfill;
-			else
+				new_rows += plines_win_nofill(wp, l, TRUE)
+							  + wp->w_topfill;
+			    else
 #endif
-			    new_rows += plines_win(wp, l, TRUE);
+				new_rows += plines_win(wp, l, TRUE);
+			}
 			++j;
 			if (new_rows > wp->w_height - row - 2)
 			{


### PR DESCRIPTION
This PR fixes a badly indented dangling `else` at `drawscreen.c:2312`.
The `else` should correspond to the nested `if` at line 2309 but it is indented as if it was corresponding to the outer `if` at line 2306.

Code before change:
![drawscreen-badly-indented-else](https://user-images.githubusercontent.com/2261629/137647053-918171f6-6278-4cd7-a482-a526da857b65.png)

