### PR TITLE
Fix getcompletion() behavior

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -978,6 +978,7 @@ set_one_cmd_context(
 
     ExpandInit(xp);
     xp->xp_pattern = buff;
+    xp->xp_line = buff;
     xp->xp_context = EXPAND_COMMANDS;	// Default until we get past command
     ea.argt = 0;
 
@@ -2891,7 +2892,7 @@ f_getcompletion(typval_T *argvars, typval_T *rettv)
     expand_T	xpc;
     int		filtered = FALSE;
     int		options = WILD_SILENT | WILD_USE_NL | WILD_ADD_SLASH
-								| WILD_NO_BEEP;
+					| WILD_NO_BEEP | WILD_HOME_REPLACE;
 
     if (in_vim9script()
 	    && (check_for_string_arg(argvars, 0) == FAIL

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -305,6 +305,11 @@ func Test_getcompletion()
   let l = getcompletion('NoMatch', 'dir')
   call assert_equal([], l)
 
+  if glob('~/*') !=# ''
+    let l = getcompletion('~/', 'dir')
+    call assert_true(l[0][0] ==# '~')
+  endif
+
   let l = getcompletion('exe', 'expression')
   call assert_true(index(l, 'executable(') >= 0)
   let l = getcompletion('kill', 'expression')
@@ -417,6 +422,16 @@ func Test_getcompletion()
   call assert_true(index(l, 'taglist(') >= 0)
   let l = getcompletion('call paint', 'cmdline')
   call assert_equal([], l)
+
+  func T(a, c, p)
+    return "oneA\noneB\noneC"
+  endfunc
+  command -nargs=1 -complete=custom,T MyCmd
+  let l = getcompletion('MyCmd ', 'cmdline')
+  call assert_equal(['oneA', 'oneB', 'oneC'], l)
+
+  delcommand MyCmd
+  delfunc T
 
   " For others test if the name is recognized.
   let names = ['buffer', 'environment', 'file_in_path', 'mapping', 'tag', 'tag_listfiles', 'user']


### PR DESCRIPTION
I have fixed two problems of `getcompletion()`.

1. `~` is expanded.  It is not expanded from real command line completion.

2. custom list/custom completions do not work from `getcompletion()`.

It is fixed by the two lines fix.