### PR TITLE
Correct mode() in operatorfunc

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -3314,6 +3314,7 @@ op_function(oparg_T *oap UNUSED)
 #ifdef FEAT_EVAL
     typval_T	argv[2];
     int		save_virtual_op = virtual_op;
+    int		save_finish_op = finish_op;
     pos_T	orig_start = curbuf->b_op_start;
     pos_T	orig_end = curbuf->b_op_end;
 
@@ -3341,9 +3342,13 @@ op_function(oparg_T *oap UNUSED)
 	// function.
 	virtual_op = MAYBE;
 
+	// Reset finish_op so that mode() returns the right value.
+	finish_op = FALSE;
+
 	(void)call_func_noret(p_opfunc, 1, argv);
 
 	virtual_op = save_virtual_op;
+	finish_op = save_finish_op;
 	if (cmdmod.cmod_flags & CMOD_LOCKMARKS)
 	{
 	    curbuf->b_op_start = orig_start;

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -912,6 +912,20 @@ func Test_mode()
   call assert_equal('c-ce', g:current_modes)
   " How to test Ex mode?
 
+  " Test mode in operatorfunc (it used to be Operator-pending).
+  set operatorfunc=OperatorFunc
+  function OperatorFunc(_)
+    call Save_mode()
+  endfunction
+  execute "normal! g@l\<Esc>"
+  call assert_equal('n-n', g:current_modes)
+  execute "normal! i\<C-o>g@l\<Esc>"
+  call assert_equal('n-niI', g:current_modes)
+  execute "normal! R\<C-o>g@l\<Esc>"
+  call assert_equal('n-niR', g:current_modes)
+  execute "normal! gR\<C-o>g@l\<Esc>"
+  call assert_equal('n-niV', g:current_modes)
+
   if has('terminal')
     term
     call feedkeys("\<C-W>N", 'xt')
@@ -924,6 +938,8 @@ func Test_mode()
   iunmap <F2>
   xunmap <F2>
   set complete&
+  set operatorfunc&
+  delfunction OperatorFunc
 endfunc
 
 " Test for append()


### PR DESCRIPTION
Fixes #8960.

I applied the patch I recieved from Bram as-is, and added a test for it.