### PR TITLE
Fix resource leak by closing file descriptor in mch_FullName

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2653,8 +2653,15 @@ mch_FullName(
 			// the current directory and append the file name.
 			if (mch_isFullName(fname))
 			    retval = FAIL;
-			else
+			else {
 			    p = NULL;
+#ifdef HAVE_FCHDIR
+			    if (fd >= 0) {
+				close(fd);
+				fd = -1;
+			    }
+#endif
+			}
 		    }
 		    else if (*p == '/')
 			fname = p + 1;


### PR DESCRIPTION
Since 8.2.3468 (https://github.com/vim/vim/commit/c6376c798433bcb9ee38a8664299d11454546950), getting the absolute path of non-existing paths leaks file descriptors. The file descriptor for `fchdir` is left unclosed in specific code path. Steps to reproduce is `:edit notexist/x.txt` and look into `lsof -p $(pgrep vim | tail -n1)`.