### PR TITLE
Skip checking leading character repeatedly in path_with_url

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2643,7 +2643,7 @@ path_with_url(char_u *fname)
 	return 0;
 
     // check body: alpha or dash
-    for (p = fname; (isalpha(*p) || (*p == '-')); ++p)
+    for (p = fname + 1; isalpha(*p) || (*p == '-'); ++p)
 	;
 
     // check last char is not a dash


### PR DESCRIPTION
Since `isalpha(*fname)` is checked in the above lines, we can skip the check in the for loop.