### PR TITLE
ftplugin/spec.vim: Revert change dropping <SID> from SpecChangelog

### DIFF
--- a/runtime/ftplugin/spec.vim
+++ b/runtime/ftplugin/spec.vim
@@ -18,8 +18,8 @@ if !exists("no_plugin_maps") && !exists("no_spec_maps")
 	endif
 endif
 
-if !hasmapto("call SpecChangelog(\"\")<CR>")
-       noremap <buffer> <unique> <script> <Plug>SpecChangelog :call SpecChangelog("")<CR>
+if !hasmapto("call <SID>SpecChangelog(\"\")<CR>")
+       noremap <buffer> <unique> <script> <Plug>SpecChangelog :call <SID>SpecChangelog("")<CR>
 endif
 
 if !exists("*s:GetRelVer")
@@ -41,8 +41,8 @@ else:
         headers = spec.sourceHeader
         version = headers["Version"]
         release = headers["Release"]
-        vim.command("let ver = " + version)
-        vim.command("let rel = " + release)
+        vim.command("let ver = '" + version + "'")
+        vim.command("let rel = '" + release + "'")
 PYEND
 		endif
 	endfunction


### PR DESCRIPTION
Without this it will return an error when creating a new changelog
entry:
"Unknown function: SpecChangelog"