### PR TITLE
Vimscript "=~" and "!~" operators match the lefthand argument with th…

### DIFF
--- a/runtime/syntax/help_ru.vim
+++ b/runtime/syntax/help_ru.vim
@@ -6,7 +6,7 @@
 
 " Проверяем язык локали и установки опции 'helplang'
 " Если не русский, то выходим из скрипта.
-if ('ru' !~? v:lang || 'russian' !~? v:lang) && 'ru' !~? &helplang
+if (v:lang !~? 'ru' || v:lang !~? 'russian') && &helplang !~? 'ru' 
   finish
 endif
 


### PR DESCRIPTION
From vim help:

> **The "=\~" and "!\~" operators match the lefthand argument with the righthand
argument, which is used as a pattern.**
Examples:
	"foo\nbar" =~ "\n"	evaluates to 1
	"foo\nbar" =~ "\\\n"	evaluates to 0

The pattern is on the _right_, not on the left. I swapped pattern and variables.