### PR TITLE
TermDebug Evaluate expression cleanup

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -736,9 +736,11 @@ func s:HandleDisasmMsg(msg)
   else
     let value = substitute(a:msg, '^\~\"[ ]*', '', '')
     let value = substitute(value, '^=>[ ]*', '', '')
-    let value = substitute(value, '\\n\"$', '', '')
+    let value = substitute(value, '\\n\"
+$', '', '')
     let value = substitute(value, '\\n\"$', '', '')
-    let value = substitute(value, '', '', '')
+    let value = substitute(value, '
+', '', '')
     let value = substitute(value, '\\t', ' ', 'g')
 
     if value != '' || !empty(s:asm_lines)
@@ -982,6 +984,18 @@ func s:Run(args)
 endfunc
 
 func s:SendEval(expr)
+  " clean up expression that may got in because of range
+  " (newlines and surrounding spaces)
+  if &filetype ==# 'cobol'
+    " extra cleanup for COBOL: _every: expression ends with a period,
+    " a trailing comma is ignored as it commonly separates multiple expr.
+    let expr = substitute(expr, '\..*', '', '')
+    let expr = substitute(expr, '[;\n]', ' ', 'g')
+    let expr = substitute(expr, ',*$', '', '')
+  else
+    let expr = substitute(expr, '\n', ' ', 'g')
+  endif
+  let expr = substitute(expr, '^ *\(.*\) *', '\1', '')
   call s:SendCommand('-data-evaluate-expression "' . a:expr . '"')
   let s:evalexpr = a:expr
 endfunc


### PR DESCRIPTION
When having a visual mark of a line (or multiple ones) and `Evaluate`ing this, I've seen some issues, which are fixed by this PR.
As I'm inspecting use of TermDebug with COBOL I've also added some special cases for this one, please consider integrating that (in this case there possibly should be addition for other filetypes, too) or remove it at your view.

The cleanup _may_ should be only done when the expression actually was got by a range (so moved to the `elseif a:range == 2`) part.

Note: the changes in line 739+741 are because of GitHub's editor, and aren't an intended part of this PR.

BTW: If anyone could share pointers how to add a `<cobexpr>` similar to `<cexpr>` but with appropriate rules (or adjust `<cexpr>` rules depending on `&filetype`) this would be very useful for my use case. 