### PR TITLE
gtk3 gvim performance improve

### DIFF
--- a/src/gui.h
+++ b/src/gui.h
@@ -393,7 +393,6 @@ typedef struct Gui
 # endif
 # ifdef USE_GTK3
     cairo_surface_t *surface;       // drawarea surface
-    gboolean	     by_signal;     // cause of draw operation
 # else
     GdkGC	*text_gc;	    // cached GC for normal text
 # endif

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -632,7 +632,6 @@ draw_event(GtkWidget *widget UNUSED,
 
     cairo_set_source_surface(cr, gui.surface, 0, 0);
 
-    gui.by_signal = TRUE;
     {
 	cairo_rectangle_list_t *list = NULL;
 
@@ -650,7 +649,6 @@ draw_event(GtkWidget *widget UNUSED,
 	}
 	cairo_rectangle_list_destroy(list);
     }
-    gui.by_signal = FALSE;
 
     return FALSE;
 }
@@ -3715,7 +3713,6 @@ gui_mch_init(void)
     gui.drawarea = gtk_drawing_area_new();
 #if GTK_CHECK_VERSION(3,0,0)
     gui.surface = NULL;
-    gui.by_signal = FALSE;
 #endif
 
     // Determine which events we will filter.
@@ -5906,9 +5903,8 @@ skipitall:
 
 #if GTK_CHECK_VERSION(3,0,0)
     cairo_destroy(cr);
-    if (!gui.by_signal)
-	gtk_widget_queue_draw_area(gui.drawarea, area.x, area.y,
-		area.width, area.height);
+    gtk_widget_queue_draw_area(gui.drawarea, area.x, area.y,
+	    area.width, area.height);
 #else
     gdk_gc_set_clip_rectangle(gui.text_gc, NULL);
 #endif
@@ -6050,9 +6046,8 @@ gui_mch_invert_rectangle(int r, int c, int nr, int nc)
 
     cairo_destroy(cr);
 
-    if (!gui.by_signal)
-	gtk_widget_queue_draw_area(gui.drawarea, rect.x, rect.y,
-		rect.width, rect.height);
+    gtk_widget_queue_draw_area(gui.drawarea, rect.x, rect.y,
+	    rect.width, rect.height);
 #else
     GdkGCValues values;
     GdkGC *invert_gc;
@@ -6387,9 +6382,8 @@ gui_mch_clear_block(int row1arg, int col1arg, int row2arg, int col2arg)
 	cairo_fill(cr);
 	cairo_destroy(cr);
 
-	if (!gui.by_signal)
-	    gtk_widget_queue_draw_area(gui.drawarea,
-		    rect.x, rect.y, rect.width, rect.height);
+	gtk_widget_queue_draw_area(gui.drawarea,
+		rect.x, rect.y, rect.width, rect.height);
     }
 #else // !GTK_CHECK_VERSION(3,0,0)
     gdk_gc_set_foreground(gui.text_gc, &color);
@@ -6425,9 +6419,8 @@ gui_gtk_window_clear(GdkWindow *win)
     cairo_fill(cr);
     cairo_destroy(cr);
 
-    if (!gui.by_signal)
-	gtk_widget_queue_draw_area(gui.drawarea,
-		rect.x, rect.y, rect.width, rect.height);
+    gtk_widget_queue_draw_area(gui.drawarea,
+	    rect.x, rect.y, rect.width, rect.height);
 }
 #else
 # define gui_gtk_window_clear(win)  gdk_window_clear(win)
@@ -6518,10 +6511,9 @@ gui_mch_delete_lines(int row, int num_lines)
     gui_clear_block(
 	    gui.scroll_region_bot - num_lines + 1, gui.scroll_region_left,
 	    gui.scroll_region_bot,		   gui.scroll_region_right);
-    if (!gui.by_signal)
-	gtk_widget_queue_draw_area(gui.drawarea,
-		FILL_X(gui.scroll_region_left), FILL_Y(row),
-		gui.char_width * ncols + 1,	gui.char_height * nrows);
+    gtk_widget_queue_draw_area(gui.drawarea,
+	    FILL_X(gui.scroll_region_left), FILL_Y(row),
+	    gui.char_width * ncols + 1,	gui.char_height * nrows);
 #else
     if (gui.visibility == GDK_VISIBILITY_FULLY_OBSCURED)
 	return;			// Can't see the window
@@ -6565,10 +6557,9 @@ gui_mch_insert_lines(int row, int num_lines)
     gui_mch_clear_block(
 	    row,		 gui.scroll_region_left,
 	    row + num_lines - 1, gui.scroll_region_right);
-    if (!gui.by_signal)
-	gtk_widget_queue_draw_area(gui.drawarea,
-		FILL_X(gui.scroll_region_left), FILL_Y(row),
-		gui.char_width * ncols + 1,	gui.char_height * nrows);
+    gtk_widget_queue_draw_area(gui.drawarea,
+	    FILL_X(gui.scroll_region_left), FILL_Y(row),
+	    gui.char_width * ncols + 1,	gui.char_height * nrows);
 #else
     if (gui.visibility == GDK_VISIBILITY_FULLY_OBSCURED)
 	return;			// Can't see the window
@@ -7010,9 +7001,8 @@ gui_mch_drawsign(int row, int col, int typenr)
 	    cairo_surface_destroy(bg_surf);
 	    cairo_destroy(cr);
 
-	    if (!gui.by_signal)
-		gtk_widget_queue_draw_area(gui.drawarea,
-			FILL_X(col), FILL_Y(col), width, height);
+	    gtk_widget_queue_draw_area(gui.drawarea,
+		    FILL_X(col), FILL_Y(col), width, height);
 
 	}
 # else // !GTK_CHECK_VERSION(3,0,0)

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -618,37 +618,6 @@ visibility_event(GtkWidget *widget UNUSED,
  * Redraw the corresponding portions of the screen.
  */
 #if GTK_CHECK_VERSION(3,0,0)
-static gboolean is_key_pressed = FALSE;
-static gboolean blink_mode = TRUE;
-
-static gboolean gui_gtk_is_blink_on(void);
-
-    static void
-gui_gtk3_update_cursor(cairo_t *cr)
-{
-    if (gui.row == gui.cursor_row)
-    {
-	gui.by_signal = TRUE;
-	if (State & CMDLINE)
-	    gui_update_cursor(TRUE, FALSE);
-	else
-	    gui_update_cursor(TRUE, TRUE);
-	gui.by_signal = FALSE;
-	cairo_paint(cr);
-    }
-}
-
-    static gboolean
-gui_gtk3_should_draw_cursor(void)
-{
-    unsigned int cond = 0;
-    cond |= gui_gtk_is_blink_on();
-    if (gui.cursor_col >= gui.col)
-	cond |= is_key_pressed;
-    cond |= gui.in_focus == FALSE;
-    return  cond;
-}
-
     static gboolean
 draw_event(GtkWidget *widget UNUSED,
 	   cairo_t   *cr,
@@ -663,7 +632,6 @@ draw_event(GtkWidget *widget UNUSED,
 
     cairo_set_source_surface(cr, gui.surface, 0, 0);
 
-    // Draw the window without the cursor.
     gui.by_signal = TRUE;
     {
 	cairo_rectangle_list_t *list = NULL;
@@ -681,13 +649,8 @@ draw_event(GtkWidget *widget UNUSED,
 	    }
 	}
 	cairo_rectangle_list_destroy(list);
-
     }
     gui.by_signal = FALSE;
-
-    // Add the cursor to the window if necessary.
-    if (gui_gtk3_should_draw_cursor() && blink_mode)
-	gui_gtk3_update_cursor(cr);
 
     return FALSE;
 }
@@ -812,14 +775,6 @@ static long_u blink_ontime = 400;
 static long_u blink_offtime = 250;
 static guint blink_timer = 0;
 
-#if GTK_CHECK_VERSION(3,0,0)
-    static gboolean
-gui_gtk_is_blink_on(void)
-{
-    return blink_state == BLINK_ON;
-}
-#endif
-
     int
 gui_mch_is_blinking(void)
 {
@@ -838,16 +793,12 @@ gui_mch_set_blinking(long waittime, long on, long off)
 #if GTK_CHECK_VERSION(3,0,0)
     if (waittime == 0 || on == 0 || off == 0)
     {
-	blink_mode = FALSE;
-
 	blink_waittime = 700;
 	blink_ontime = 400;
 	blink_offtime = 250;
     }
     else
     {
-	blink_mode = TRUE;
-
 	blink_waittime = waittime;
 	blink_ontime = on;
 	blink_offtime = off;
@@ -1085,7 +1036,6 @@ key_press_event(GtkWidget *widget UNUSED,
     char_u	*s, *d;
 
 #if GTK_CHECK_VERSION(3,0,0)
-    is_key_pressed = TRUE;
     gui_mch_stop_blink(TRUE);
 #endif
 
@@ -1246,7 +1196,6 @@ key_release_event(GtkWidget *widget UNUSED,
 		  gpointer data UNUSED)
 {
 # if GTK_CHECK_VERSION(3,0,0)
-    is_key_pressed = FALSE;
     gui_mch_start_blink();
 # endif
 # if defined(FEAT_XIM)

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -807,7 +807,9 @@ gui_mch_stop_blink(int may_call_gui_update_cursor)
     if (blink_state == BLINK_OFF && may_call_gui_update_cursor)
     {
 	gui_update_cursor(TRUE, FALSE);
+#if !GTK_CHECK_VERSION(3,0,0)
 	gui_mch_flush();
+#endif
     }
     blink_state = BLINK_NONE;
 }
@@ -827,7 +829,9 @@ blink_cb(gpointer data UNUSED)
 	blink_state = BLINK_ON;
 	blink_timer = timeout_add(blink_ontime, blink_cb, NULL);
     }
+#if !GTK_CHECK_VERSION(3,0,0)
     gui_mch_flush();
+#endif
 
     return FALSE;		// don't happen again
 }
@@ -850,7 +854,9 @@ gui_mch_start_blink(void)
 	blink_timer = timeout_add(blink_waittime, blink_cb, NULL);
 	blink_state = BLINK_ON;
 	gui_update_cursor(TRUE, FALSE);
+#if !GTK_CHECK_VERSION(3,0,0)
 	gui_mch_flush();
+#endif
     }
 }
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -5907,8 +5907,8 @@ skipitall:
 #if GTK_CHECK_VERSION(3,0,0)
     cairo_destroy(cr);
     if (!gui.by_signal)
-	gdk_window_invalidate_rect(gtk_widget_get_window(gui.drawarea),
-		&area, FALSE);
+	gtk_widget_queue_draw_area(gui.drawarea, area.x, area.y,
+		area.width, area.height);
 #else
     gdk_gc_set_clip_rectangle(gui.text_gc, NULL);
 #endif
@@ -6388,7 +6388,8 @@ gui_mch_clear_block(int row1arg, int col1arg, int row2arg, int col2arg)
 	cairo_destroy(cr);
 
 	if (!gui.by_signal)
-	    gdk_window_invalidate_rect(win, &rect, FALSE);
+	    gtk_widget_queue_draw_area(gui.drawarea,
+		    rect.x, rect.y, rect.width, rect.height);
     }
 #else // !GTK_CHECK_VERSION(3,0,0)
     gdk_gc_set_foreground(gui.text_gc, &color);
@@ -6425,7 +6426,8 @@ gui_gtk_window_clear(GdkWindow *win)
     cairo_destroy(cr);
 
     if (!gui.by_signal)
-	gdk_window_invalidate_rect(win, &rect, FALSE);
+	gtk_widget_queue_draw_area(gui.drawarea,
+		rect.x, rect.y, rect.width, rect.height);
 }
 #else
 # define gui_gtk_window_clear(win)  gdk_window_clear(win)

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -790,24 +790,9 @@ gui_mch_is_blink_off(void)
     void
 gui_mch_set_blinking(long waittime, long on, long off)
 {
-#if GTK_CHECK_VERSION(3,0,0)
-    if (waittime == 0 || on == 0 || off == 0)
-    {
-	blink_waittime = 700;
-	blink_ontime = 400;
-	blink_offtime = 250;
-    }
-    else
-    {
-	blink_waittime = waittime;
-	blink_ontime = on;
-	blink_offtime = off;
-    }
-#else
     blink_waittime = waittime;
     blink_ontime = on;
     blink_offtime = off;
-#endif
 }
 
 /*
@@ -1035,10 +1020,6 @@ key_press_event(GtkWidget *widget UNUSED,
     guint	state;
     char_u	*s, *d;
 
-#if GTK_CHECK_VERSION(3,0,0)
-    gui_mch_stop_blink(TRUE);
-#endif
-
     gui.event_time = event->time;
     key_sym = event->keyval;
     state = event->state;
@@ -1195,9 +1176,6 @@ key_release_event(GtkWidget *widget UNUSED,
 		  GdkEventKey *event,
 		  gpointer data UNUSED)
 {
-# if GTK_CHECK_VERSION(3,0,0)
-    gui_mch_start_blink();
-# endif
 # if defined(FEAT_XIM)
     gui.event_time = event->time;
     /*

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6554,7 +6554,7 @@ gui_mch_insert_lines(int row, int num_lines)
 	    FILL_X(gui.scroll_region_left), FILL_Y(row + num_lines),
 	    FILL_X(gui.scroll_region_left), FILL_Y(row),
 	    gui.char_width * ncols + 1,     gui.char_height * src_nrows);
-    gui_mch_clear_block(
+    gui_clear_block(
 	    row,		 gui.scroll_region_left,
 	    row + num_lines - 1, gui.scroll_region_right);
     gtk_widget_queue_draw_area(gui.drawarea,

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -682,13 +682,6 @@ draw_event(GtkWidget *widget UNUSED,
 	}
 	cairo_rectangle_list_destroy(list);
 
-	if (get_real_state() & VISUAL)
-	{
-	    if (gui.cursor_row == gui.row && gui.cursor_col >= gui.col)
-		gui_update_cursor(TRUE, TRUE);
-	}
-
-	cairo_paint(cr);
     }
     gui.by_signal = FALSE;
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6041,7 +6041,7 @@ gui_mch_invert_rectangle(int r, int c, int nr, int nc)
 # else
     // Give an implementation for older cairo versions if necessary.
 # endif
-    gdk_cairo_rectangle(cr, &rect);
+    cairo_rectangle(cr, rect.x, rect.y, rect.width, rect.height);
     cairo_fill(cr);
 
     cairo_destroy(cr);
@@ -6378,7 +6378,7 @@ gui_mch_clear_block(int row1arg, int col1arg, int row2arg, int col2arg)
 	else
 	    set_cairo_source_rgba_from_color(cr, gui.back_pixel);
 # endif
-	gdk_cairo_rectangle(cr, &rect);
+	cairo_rectangle(cr, rect.x, rect.y, rect.width, rect.height);
 	cairo_fill(cr);
 	cairo_destroy(cr);
 
@@ -6415,7 +6415,7 @@ gui_gtk_window_clear(GdkWindow *win)
     else
 	set_cairo_source_rgba_from_color(cr, gui.back_pixel);
 # endif
-    gdk_cairo_rectangle(cr, &rect);
+    cairo_rectangle(cr, rect.x, rect.y, rect.width, rect.height);
     cairo_fill(cr);
     cairo_destroy(cr);
 


### PR DESCRIPTION
I remove many gtk3 specific redrawing and fix about gtk3 cursor blinking, so it become faster than original gtk3 gvim.
I used gtk3 gvim with this pr for a few days, but I haven't seen any GUI glitches in my environment.

Small benchmark result:

* Test 1 scrolling netrw.vim

  * test-scroll.vim

    ```viml
    e runtime/autoload/netrw.vim

    call feedkeys('zR')
    for i in range(1, 5000)
      call feedkeys('j')
    endfor

    call feedkeys(":q\<CR>")
    ```

  * gtk2

    ```
    ❯ /usr/bin/time -f '%E' ./src/vim-gtk2 -f -g --clean -S test-scroll.vim
    0:26.86
    ```

  * gtk3 orignal

    ```
    ❯ /usr/bin/time -f '%E' ./src/vim-gtk3-orig -f -g --clean -S test-scroll.vim 
    0:35.01
    ```

  * gtk3 with this pr

    ```
    ❯ /usr/bin/time -f '%E' ./src/vim-gtk3-fixed -f -g --clean -S test-scroll.vim
    0:04.77
    ```

* Test 2 - `!seq 4000`

  * gtk2

    ```
    ❯ /usr/bin/time -f '%E' ./src/vim-gtk2 -f -g --clean -c '!seq 4000' -c 'q'
    0:01.91
    ```

  * gtk3 orignal

    ```
    ❯ /usr/bin/time -f '%E' ./src/vim-gtk3-orig -f -g --clean -c '!seq 4000' -c 'q' 
    0:04.76
    
    ```

  * gtk3 with this pr

    ```
    ❯ /usr/bin/time -f '%E' ./src/vim-gtk3-fixed -f -g --clean -c '!seq 4000' -c 'q'
    0:02.93
    ```
