### PR TITLE
Fix config of old systems for nanosecond-resolution timestamps

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -43,6 +43,21 @@
 // 700 is needed for mkdtemp().
 #  ifndef _XOPEN_SOURCE
 #   define _XOPEN_SOURCE    700
+
+// On old systems, defining _XOPEN_SOURCE causes _BSD_SOURCE and/or
+// _SVID_SOURCE not to be defined, so do that here.  Those are needed to
+// include nanosecond-resolution timestamps in struct stat.  On new systems,
+// _DEFAULT_SOURCE is needed to avoid warning messages about using deprecated
+// _BSD_SOURCE or _SVID_SOURCE.
+#   ifndef _BSD_SOURCE
+#    define _BSD_SOURCE 1
+#   endif
+#   ifndef _SVID_SOURCE
+#    define _SVID_SOURCE 1
+#   endif
+#   ifndef _DEFAULT_SOURCE
+#    define _DEFAULT_SOURCE 1
+#   endif
 #  endif
 # endif
 


### PR DESCRIPTION
On old systems (e.g. 32-bit systems running Ubuntu 10.4), defining
_XOPEN_SOURCE causes _BSD_SOURCE and _SVID_SOURCE not to be defined,
which causes nanosecond-resolution timestamps not to be included in
struct stat, which causes the build of fileio.c to fail.

_XOPEN_SOURCE is defined for some systems in vim.h.

A solution is to define _BSD_SOURCE and _SVID_SOURCE whenever
_XOPEN_SOURCE is defined.

On new systems, defining either _BSD_SOURCE or _SVID_SOURCE causes
/usr/include/features.h to issue a warning message about _BSD_SOURCE and
_SVID_SOURCE being deprecated and to use _DEFAULT_SOURCE instead.

A solution for that is to also define _DEFAULT_SOURCE when _BSD_SOURCE
and _SVID_SOURCE are defined.