### PR TITLE
Protect against int overflow

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -976,6 +976,7 @@ ins_typebuf(
     int		newoff;
     int		val;
     int		nrm;
+	int 	safe_add_result;
 
     init_typebuf();
     if (++typebuf.tb_change_cnt == 0)
@@ -1012,7 +1013,7 @@ ins_typebuf(
 	 */
 	newoff = MAXMAPLEN + 4;
 	//Overflow test
-	int safe_add_result;
+
 	
 	safe_add_result=safe_add(newoff,newoff); //newoff*2
 	if(safe_add_result==-1)

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1010,11 +1010,11 @@ ins_typebuf(
 	 */
 	newoff = MAXMAPLEN + 4;
 	
-	int OVERHEAD = 5 * newoff;
+	int overhead = 5 * newoff;
 
 	//Overflow test
-	if (typebuf.tb_len > INT_MAX - OVERHEAD ||
-      addlen > INT_MAX - OVERHEAD - typebuf.tb_len) {
+	if (typebuf.tb_len > INT_MAX - overhead ||
+      addlen > INT_MAX - overhead - typebuf.tb_len) {
       	emsg(_(e_toocompl));    // also calls flush_buffers
 	    setcursor();
 		return FAIL;

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -39,8 +39,6 @@
  */
 
 #define MINIMAL_SIZE 20			// minimal size for b_str
-#define INT_MAX 2147483647
-#define INT_MIN	-2147483648
 
 static buffheader_T redobuff = {{NULL, {NUL}}, NULL, 0, 0};
 static buffheader_T old_redobuff = {{NULL, {NUL}}, NULL, 0, 0};

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -95,6 +95,7 @@ static void	closescript(void);
 static void	updatescript(int c);
 static int	vgetorpeek(int);
 static int	inchar(char_u *buf, int maxlen, long wait_time);
+int will_sum_overflow(int a, int b);
 
 /*
  * Free and clear a buffer.
@@ -973,8 +974,8 @@ ins_typebuf(
     int		newoff;
     int		val;
     int		nrm;
-	int		overhead;
-
+	int 	will_sum_overflow_result;
+	int 	overhead;
     init_typebuf();
     if (++typebuf.tb_change_cnt == 0)
 	typebuf.tb_change_cnt = 1;
@@ -1009,17 +1010,25 @@ ins_typebuf(
 	 * often.
 	 */
 	newoff = MAXMAPLEN + 4;
-	
-	overhead = 5 * newoff;
-
 	//Overflow test
-	if (typebuf.tb_len > INT_MAX - overhead ||
-      addlen > INT_MAX - overhead - typebuf.tb_len) {
-      	emsg(_(e_toocompl));    // also calls flush_buffers
+	overhead = 5 * newoff;
+	
+	will_sum_overflow_result=will_sum_overflow(typebuf.tb_len, overhead); //newoff*2
+	if(will_sum_overflow_result==1)
+	{
+		emsg(_(e_toocompl));    // also calls flush_buffers
 	    setcursor();
 		return FAIL;
-  	}
-	
+	}
+
+	will_sum_overflow_result=will_sum_overflow(addlen, overhead + typebuf.tb_len); //newoff*2
+	if(will_sum_overflow_result==1)
+	{
+		emsg(_(e_toocompl));    // also calls flush_buffers
+	    setcursor();
+		return FAIL;
+	}
+		
 	newlen = typebuf.tb_len + addlen + 5 * newoff;
 
 	s1 = alloc(newlen);
@@ -1102,6 +1111,25 @@ ins_typebuf(
     return OK;
 }
 
+/*
+Detects overflow in a sum of two integers
+Returns 1 if the result of a+b results is an overflow
+Returns 0 otherwise
+
+*/
+int will_sum_overflow(int a, int b) 
+{
+    if (a >= 0) {
+        if (b > (INT_MAX - a)) {
+            return 1;
+        }
+    } else {
+        if (b < (INT_MIN - a)) {
+            return 1;
+        }
+    }
+    return 0;
+}
 
 /*
  * Put character "c" back into the typeahead buffer.

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -39,8 +39,7 @@
  */
 
 #define MINIMAL_SIZE 20			// minimal size for b_str
-#define INT_MAX 2147483647
-#define INT_MIN	-2147483648
+
 
 static buffheader_T redobuff = {{NULL, {NUL}}, NULL, 0, 0};
 static buffheader_T old_redobuff = {{NULL, {NUL}}, NULL, 0, 0};
@@ -1011,8 +1010,8 @@ ins_typebuf(
 	 * often.
 	 */
 	newoff = MAXMAPLEN + 4;
-	//Overflow test
-	int safe_add_result;
+
+	int safe_add_result=0;
 	
 	safe_add_result=safe_add(newoff,newoff); //newoff*2
 	if(safe_add_result==-1)
@@ -1145,12 +1144,14 @@ Returns the sum otherwise
 */
 int safe_add(int a, int b) 
 {
+	int int_max = 2147483647;
+	int int_min	= -2147483648;
     if (a >= 0) {
-        if (b > (INT_MAX - a)) {
+        if (b > (int_max - a)) {
             return -1;
         }
     } else {
-        if (b < (INT_MIN - a)) {
+        if (b < (int_min - a)) {
             return -1;
         }
     }

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -973,7 +973,7 @@ ins_typebuf(
     int		newoff;
     int		val;
     int		nrm;
-	int 	safe_add_result;
+	int		overhead;
 
     init_typebuf();
     if (++typebuf.tb_change_cnt == 0)
@@ -1010,7 +1010,7 @@ ins_typebuf(
 	 */
 	newoff = MAXMAPLEN + 4;
 	
-	int overhead = 5 * newoff;
+	overhead = 5 * newoff;
 
 	//Overflow test
 	if (typebuf.tb_len > INT_MAX - overhead ||

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -975,7 +975,7 @@ ins_typebuf(
     int		newoff;
     int		val;
     int		nrm;
-	int safe_add_result;
+	int 	safe_add_result;
 
     init_typebuf();
     if (++typebuf.tb_change_cnt == 0)

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1142,10 +1142,11 @@ ins_typebuf(
 }
 
 /*
-Safely adds two integers
-
+Detects overflow in a sum of two integers
 Returns -1 if the result of a+b results is an overflow
-Returns the sum otherwise
+Returns 0 otherwise
+
+DOES NOT CALCULATE THE SUM
 */
 int safe_add(int a, int b) 
 {

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -39,7 +39,8 @@
  */
 
 #define MINIMAL_SIZE 20			// minimal size for b_str
-
+#define INT_MAX 2147483647
+#define INT_MIN	-2147483648
 
 static buffheader_T redobuff = {{NULL, {NUL}}, NULL, 0, 0};
 static buffheader_T old_redobuff = {{NULL, {NUL}}, NULL, 0, 0};
@@ -975,7 +976,6 @@ ins_typebuf(
     int		newoff;
     int		val;
     int		nrm;
-	int 	safe_add_result;
 
     init_typebuf();
     if (++typebuf.tb_change_cnt == 0)
@@ -1011,8 +1011,8 @@ ins_typebuf(
 	 * often.
 	 */
 	newoff = MAXMAPLEN + 4;
-
-
+	//Overflow test
+	int safe_add_result;
 	
 	safe_add_result=safe_add(newoff,newoff); //newoff*2
 	if(safe_add_result==-1)
@@ -1021,33 +1021,36 @@ ins_typebuf(
 	    setcursor();
 		return FAIL;
 	}
-		
+	
 
-	safe_add_result=safe_add(safe_add_result,safe_add_result); //newoff*4
+	safe_add_result=safe_add(2*newoff,2*newoff); //newoff*4
 	if(safe_add_result==-1)
 	{
 		emsg(_(e_toocompl));    // also calls flush_buffers
 	    setcursor();
 		return FAIL;
 	}
+	
 
-	safe_add_result=safe_add(safe_add_result,newoff); //newoff*5
+	safe_add_result=safe_add(4*newoff,newoff); //newoff*5
 	if(safe_add_result==-1)
 	{
 		emsg(_(e_toocompl));    // also calls flush_buffers
 	    setcursor();
 		return FAIL;
 	}
+	
 
-	safe_add_result=safe_add(safe_add_result,addlen); //addlen+newoff*5
+	safe_add_result=safe_add(5*newoff,addlen); //addlen+newoff*5
 	if(safe_add_result==-1)
 	{
 		emsg(_(e_toocompl));    // also calls flush_buffers
 	    setcursor();
 		return FAIL;
 	}
+	
 
-	safe_add_result=safe_add(safe_add_result,typebuf.tb_len); //typebuf.tb_len+addlen+newoff*5
+	safe_add_result=safe_add(5*newoff+addlen,typebuf.tb_len); //typebuf.tb_len+addlen+newoff*5
 	if(safe_add_result==-1)
 	{
 		emsg(_(e_toocompl));    // also calls flush_buffers
@@ -1145,18 +1148,16 @@ Returns the sum otherwise
 */
 int safe_add(int a, int b) 
 {
-	int int_max = 2147483647;
-	int int_min	= -2147483648;
     if (a >= 0) {
-        if (b > (int_max - a)) {
+        if (b > (INT_MAX - a)) {
             return -1;
         }
     } else {
-        if (b < (int_min - a)) {
+        if (b < (INT_MIN - a)) {
             return -1;
         }
     }
-    return a + b;
+    return 0;
 }
 
 /*

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -975,6 +975,7 @@ ins_typebuf(
     int		newoff;
     int		val;
     int		nrm;
+	int safe_add_result;
 
     init_typebuf();
     if (++typebuf.tb_change_cnt == 0)
@@ -1011,7 +1012,7 @@ ins_typebuf(
 	 */
 	newoff = MAXMAPLEN + 4;
 
-	int safe_add_result=0;
+
 	
 	safe_add_result=safe_add(newoff,newoff); //newoff*2
 	if(safe_add_result==-1)


### PR DESCRIPTION
Fixes #9043 

The previous solution to integer overflow was flawed and did not provide reliable protection. Now the overflow is tested before the sum is calculated and therefore it is guaranteed to protect against integer overflow in getchar.c