### PR TITLE
Skip Test_edit_CTRL_hat which did not pass with athena or motif gui

### DIFF
--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -2037,7 +2037,11 @@ endfunc
 " Test toggling of input method. See :help i_CTRL-^
 func Test_edit_CTRL_hat()
   CheckFeature xim
-  CheckNotGui " FIXME: why does this test fail when running in the GUI?
+
+  " FIXME: test fails with athena or motif GUI.
+  "        test also fails when running in the GUI.
+  CheckFeature gui_gtk
+  CheckNotGui
 
   new
 


### PR DESCRIPTION
Skip `Test_edit_CTRL_hat` which did not pass with athena or motif gui.