### PR TITLE
Vim9: use :legacy for temp internal :let assignments

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7768,11 +7768,11 @@ fix_arg_enc(void)
 	// Also, unset wildignore to not be influenced by this option.
 	// The arguments specified in command-line should be kept even if
 	// encoding options were changed.
-	do_cmdline_cmd((char_u *)":let SaVe_ISF = &isf|set isf+=(,)");
-	do_cmdline_cmd((char_u *)":let SaVe_WIG = &wig|set wig=");
+	do_cmdline_cmd((char_u *)":legacy :let g:SaVe_ISF = &isf|set isf+=(,)");
+	do_cmdline_cmd((char_u *)":legacy :let g:SaVe_WIG = &wig|set wig=");
 	alist_expand(fnum_list, used_alist_count);
-	do_cmdline_cmd((char_u *)":let &isf = SaVe_ISF|unlet SaVe_ISF");
-	do_cmdline_cmd((char_u *)":let &wig = SaVe_WIG|unlet SaVe_WIG");
+	do_cmdline_cmd((char_u *)":legacy :let &isf = g:SaVe_ISF|unlet g:SaVe_ISF");
+	do_cmdline_cmd((char_u *)":legacy :let &wig = g:SaVe_WIG|unlet g:SaVe_WIG");
     }
 
     // If wildcard expansion failed, we are editing the first file of the


### PR DESCRIPTION
When changing the encoding during startup on Windows, Vim will
temporarily reset the 'isfname' and 'wildignore' options values and uses
the `:let` Vimscript command to achieve this.

However, if one is using Vim9Script initialization file, this results
in an error, because `:let` is no longer valid for Vim9Script.

Vim introduced the `:legacy` command modifier in patch 8.2.2805 so make
use of it here.

The scope can be global, since the variables are deleted after expanding
the argument list, so make it explicit as well.

Note: :unlet does not need the `:legacy` modify, as this is supported
for Vim9Script to delete the variables.

fixes: #9068

Note: I also did a quick `git grep ' do_cmdline.*let` but did not notice other places where
`:legacy` would be needed. The only other place seems to be writing the
session file, but that should be safe.