### PR TITLE
CI: fix dir separator failure on Mingw in HandleSwapExists()

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -93,7 +93,12 @@ set encoding=utf-8
 " REDIR_TEST_TO_NULL has a very permissive SwapExists autocommand which is for
 " the test_name.vim file itself. Replace it here with a more restrictive one,
 " so we still catch mistakes.
-let s:test_script_fname = expand('%')
+if has("win32")
+  " replace '/' directory separator by '\\'
+  let s:test_script_fname = substitute(expand('%'), '/', '\\', 'g')
+else
+  let s:test_script_fname = expand('%')
+endif
 au! SwapExists * call HandleSwapExists()
 func HandleSwapExists()
   if exists('g:ignoreSwapExists')


### PR DESCRIPTION
On the Mingw CI system, we may see this error message:
,----
| Unexpected swap file:
| C:\Users\RUNNER~1\AppData\Local\Temp/file_two.txt.swp
`----

This happens, because the directory separator differs, in which case the
HandleSwapExists() function errors out.

So let's unify the expected filename on windows32 and use the `\\` consistently as path
separator for the HandleSwapExists() function.