### PR TITLE
docs: rewrite guidelines for plugin helptexts

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -323,16 +323,16 @@ Hints for translators:
 3. Writing help files					*help-writing*
 
 For ease of use, a Vim help file for a plugin should follow the format of the
-standard Vim help files.  If you are writing a new help file it's best to copy
-one of the existing files and use it as a template.
+standard Vim help files, except for the first line.  If you are writing a new
+help file it's best to copy one of the existing files and use it as a
+template.
 
-The first line in a help file should have the following format:
+The first line in a plugin help file should have the following format:
 
-*helpfile_name.txt*	For Vim version 7.3	Last change: 2010 June 4
+*helpfile_name.txt*	<short description of plugin>
 
 The first field is a link to the help file name.  The second field describes
-the applicable Vim version.  The last field specifies the last modification
-date of the file.  Each field is separated by a tab.
+the plugin purpose in a short sentence.  The fields are separated by a tab.
 
 At the bottom of the help file, place a Vim modeline to set the 'textwidth'
 and 'tabstop' options and the 'filetype' to "help".  Never set a global option


### PR DESCRIPTION
Currently, the documentation suggest you put the following format at the first line:

```
helpfile_name.txt       For Vim version 7.3     Last change: 2010 June 4
```

The problem is that this works fine for the official vim documentation but not for external plugins. This makes the LOCAL ADDITIONS section look very jarring. An example is the following:

```
LOCAL ADDITIONS:                                local-additions
easy-align.txt          easy-align      Last change: December 14 2014
dracula.txt           For Vim version 8               Last change: 2021 Oct 22
solarized.vim for Vim version 7.3 or newer. Modified: 2011 May 05
```

Because of this many prolific vim plugin authors, even the tpope himself, are ignoring this recommendation.

Instead, how about recommending that plugin authors write two fields: keep the first field the same (link to the help file name) and have a short plugin description as the second field and omit the third entirely. Many plugin authors have chosen to go this route since it makes LOCAL ADDITIONS look more pleasant, as well as more consistent with the previous help text.