### PR TITLE
docs: make doc text for 'list' more correct

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4906,9 +4906,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'list'* *'nolist'*
 'list'			boolean	(default off)
 			local to window
-	List mode: Show tabs as CTRL-I is displayed, display $ after end of
-	line.  Useful to see the difference between tabs and spaces and for
-	trailing blanks.  Further changed by the 'listchars' option.
+	List mode: Display non-printable characters according to the
+	'listchars' option.  Useful to see the difference between tabs and
+	spaces and for trailing blanks.
 
 	The cursor is displayed at the start of the space a Tab character
 	occupies, not at the end as usual in Normal mode.  To get this cursor


### PR DESCRIPTION
The current description is no longer correct if 'listchars' changes.
