### PR TITLE
docs: remove caveat about ++shell on Unix

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -240,7 +240,6 @@ Command syntax ~
 			++shell		Instead of executing {command}
 					directly, use a shell, like with
 					`:!command` 		*E279*
-					{only works on Unix currently}
 			++kill={how}	When trying to close the terminal
 					window kill the job with {how}.  See
 					|term_setkill()| for the values.


### PR DESCRIPTION
Running `:term ++shell` has worked on Windows since [version 8.1.2255](https://github.com/vim/vim/commit/2d6d76f9cd3c5dca0676491d7d60ff7685942487), but the docs weren't updated to match that.