### PR TITLE
`Test_hlset` failed when the terminal has > 105 columns

### DIFF
--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -1025,6 +1025,9 @@ endfunc
 
 " Test for the hlset() function
 func Test_hlset()
+  let save_columns = &columns
+  let &columns = 80
+
   let lines =<< trim END
     call assert_equal(0, hlset(test_null_list()))
     call assert_equal(0, hlset([]))
@@ -1129,6 +1132,8 @@ func Test_hlset()
                       \ 'term': attr, 'cterm': attr}], hlget('myhlg2'))
   END
   call CheckLegacyAndVim9Success(lines)
+
+  let &columns = save_columns
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
`Test_hlset` failed when the terminal has > 105 columns.

Fixes issue #9100.