### PR TITLE
Improve overflow checks in `do_put`

### DIFF
--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -149,8 +149,8 @@ func Test_p_with_count_leaves_mark_at_end()
 endfunc
 
 func Test_very_large_count()
-  if v:sizeofint != 8
-    throw 'Skipped: only works with 64 bit ints'
+  if v:sizeoflong < 8
+    throw 'Skipped: only works with 64 bit long ints'
   endif
 
   new

--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -150,19 +150,40 @@ endfunc
 
 func Test_very_large_count()
   new
-  " total put-length (42949673 * 100) brings 32 bit int overflow
+  " total put-length (21474837 * 100) brings 32 bit int overflow
   let @" = repeat('x', 100)
-  call assert_fails('norm 42949673p', 'E1240:')
+  call assert_fails('norm 21474837p', 'E1240:')
   bwipe!
 endfunc
 
-func Test_very_large_count_64()
+func Test_very_large_count_64bit()
   if v:sizeoflong < 8
     throw 'Skipped: only works with 64 bit long ints'
   endif
 
   new
   let @" = 'x'
+  call assert_fails('norm 44444444444444p', 'E1240:')
+  bwipe!
+endfunc
+
+func Test_very_large_count_block()
+  new
+  " total put-length (21474837 * 100) brings 32 bit int overflow
+  call setline(1, repeat('x', 100))
+  exe "norm \<C-V>99ly"
+  call assert_fails('norm 21474837p', 'E1240:')
+  bwipe!
+endfunc
+
+func Test_very_large_count_block_64bit()
+  if v:sizeoflong < 8
+    throw 'Skipped: only works with 64 bit long ints'
+  endif
+
+  new
+  call setline(1, 'x')
+  exe "norm \<C-V>y"
   call assert_fails('norm 44444444444444p', 'E1240:')
   bwipe!
 endfunc

--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -149,6 +149,14 @@ func Test_p_with_count_leaves_mark_at_end()
 endfunc
 
 func Test_very_large_count()
+  new
+  " total put-length (42949673 * 100) brings 32 bit int overflow
+  let @" = repeat('x', 100)
+  call assert_fails('norm 42949673p', 'E1240:')
+  bwipe!
+endfunc
+
+func Test_very_large_count_64()
   if v:sizeoflong < 8
     throw 'Skipped: only works with 64 bit long ints'
   endif


### PR DESCRIPTION
Ref #8962 #9072

### Improve (fix) overflow check

We must check overflow before operation (multiplication) done, therefore the current checking is not good.

```c
double multlen = (double)count * (double)yanklen;
...
totlen = count * yanklen; // signed integer overflow brings undefined behavior,
if ((double)totlen != multlen) // so too late...
...
```

Why `Test_very_large_count` had failed on Windows is because `sizeof(int)` and `sizeof(long)` are both 4bytes on Windows then `count` argument of `do_put` cannot pass `44444444444444` (over 4bytes number).

https://docs.microsoft.com/en-us/cpp/c-language/storage-of-basic-types?view=msvc-160

### Fix `Test_very_large_count` (and renamed to `Test_very_large_count_64bit`)

Currently this test is always skipped on CI because `sizeof(int)` is 4 on most systems; thus should check `v:sizeoflong < 8`.

### Add new `Test_very_large_count`

For testing the check for overflow of `count * yanklen`.

### Add `Test_very_large_count_block`

Add overflow check for blockwise paste operation and tests.