### PR TITLE
Fix failing test for issue #9073

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1871,7 +1871,7 @@ v:colornames    A dictionary that maps color names to hex color strings. These
 		by setting it in their |.vimrc|.
 
 		It is possible to remove entries from this dictionary but
-		doing so is *NOT* recommended. Doing so is disruptive to
+		doing so is NOT recommended. Doing so is disruptive to
 		other scripts. It is also unlikely to achieve the desired
 		result because the |colorscheme| and |highlight| commands will
 		both automatically load all `colors/lists/default.vim` color

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -2332,39 +2332,6 @@ colorname2rgb(char_u *name)
     return INVALCOLOR;
 }
 
-// Maps the given name to the given color value, overwriting any current
-// mapping. If allocation fails the named color will no longer exist in the
-// table and the user will receive an error message.
-    void
-save_colorname_hexstr(int r, int g, int b, char_u *name)
-{
-    int        result;
-    dict_T     *colornames_table;
-    dictitem_T *existing;
-    char_u     hexstr[8];
-
-    if (vim_snprintf((char *)hexstr, sizeof(hexstr),
-						 "#%02x%02x%02x", r, g, b) < 0)
-    {
-	semsg(_(e_cannot_allocate_color_str), name);
-	return;
-    }
-
-    colornames_table = get_vim_var_dict(VV_COLORNAMES);
-    // The colornames_table dict is safe to use here because it is allocated at
-    // startup in evalvars.c
-    existing = dict_find(colornames_table, name, -1);
-    if (existing != NULL)
-    {
-	dictitem_remove(colornames_table, existing);
-	existing = NULL; // dictitem_remove freed the item
-    }
-
-    result = dict_add_string(colornames_table, (char *)name, hexstr);
-    if (result == FAIL)
-	semsg(_(e_cannot_allocate_color_str), name);
-}
-
 /*
  * Load a default color list. Intended to support legacy color names but allows
  * the user to override the color values. Only loaded once.

--- a/src/proto/highlight.pro
+++ b/src/proto/highlight.pro
@@ -16,7 +16,6 @@ void hl_set_fg_color_name(char_u *name);
 guicolor_T color_name2handle(char_u *name);
 guicolor_T decode_hex_color(char_u *hex);
 guicolor_T colorname2rgb(char_u *name);
-void save_colorname_hexstr(int r, int g, int b, char_u *name);
 void load_default_colors_lists(void);
 guicolor_T gui_get_color_cmn(char_u *name);
 guicolor_T gui_get_rgb_color_cmn(int r, int g, int b);

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -6,6 +6,12 @@ source check.vim
 source script_util.vim
 source vim9.vim
 
+func ClearDict(d)
+  for k in keys(a:d)
+    call remove(a:d, k)
+  endfor
+endfunc
+
 func Test_highlight()
   " basic test if ":highlight" doesn't crash
   highlight
@@ -936,19 +942,30 @@ func Test_highlight_default_colorscheme_restores_links()
 endfunc
 
 func Test_colornames_assignment_and_lookup()
+  CheckAnyOf Feature:gui_running Feature:termguicolors
+
   " Ensure highlight command can find custom color.
   let v:colornames['a redish white'] = '#ffeedd'
   highlight Normal guifg='a redish white'
   highlight clear
+  call ClearDict(v:colornames)
 endfunc
 
 func Test_colornames_default_list()
+  CheckAnyOf Feature:gui_running Feature:termguicolors
+
   " Ensure default lists are loaded automatically and can be used for all gui fields.
+  call assert_equal(0, len(v:colornames))
   highlight Normal guifg='rebecca purple' guibg='rebecca purple' guisp='rebecca purple'
+  call assert_notequal(0, len(v:colornames))
+  echo v:colornames['rebecca purple']
   highlight clear
+  call ClearDict(v:colornames)
 endfunc
 
 func Test_colornames_overwrite_default()
+  CheckAnyOf Feature:gui_running Feature:termguicolors
+
   " Ensure entries in v:colornames can be overwritten.
   " Load default color scheme to trigger default color list loading.
   colorscheme default
@@ -961,6 +978,10 @@ func Test_colornames_overwrite_default()
 endfunc
 
 func Test_colornames_assignment_and_unassignment()
+  " No feature check is needed for this test because the v:colornames dict
+  " always exists with +eval. The feature checks are only required for
+  " commands that do color lookup.
+
   " Ensure we cannot overwrite the v:colornames dict.
   call assert_fails("let v:colornames = {}", 'E46:')
 


### PR DESCRIPTION
Problem: v:colornames test failing in some configs.
Solution: Align test feature checks with code.

This fixes issue #9073. The core of the fix is adding `CheckAnyOf Feature:gui_running Feature:termguicolors` to the tests as suggested by @chrisbra. While I was re-reading the tests I noticed that there was an order dependence due to `v:colornames` remaining populated between tests. I was surprised I couldn't find an existing implementation of `ClearDict`. I suspect I've just overlooked it. If anyone knows of something I can re-used for the same purpose please let me know.

While I was examining the code, I also noticed that `save_colorname_hexstr` was unused. It was a remnant of an earlier iteration of the code.
