### PR TITLE
Markdown frontmatter: highlighting & folding

### DIFF
--- a/runtime/ftplugin/markdown.vim
+++ b/runtime/ftplugin/markdown.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:		Markdown
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
-" Last Change:		2019 Dec 05
+" Last Change:		2021 Nov 10
 
 if exists("b:did_ftplugin")
   finish
@@ -31,12 +31,23 @@ function! MarkdownFold() abort
   endif
 
   let nextline = getline(v:lnum + 1)
+
   if (line =~ '^.\+$') && (nextline =~ '^=\+$') && s:NotCodeBlock(v:lnum + 1)
     return ">1"
   endif
 
-  if (line =~ '^.\+$') && (nextline =~ '^-\+$') && s:NotCodeBlock(v:lnum + 1)
+  if (line =~ '^.\+$') && (nextline =~ '^-\+$') && s:NotCodeBlock(v:lnum + 1) && not b:markdown_frontmatter
     return ">2"
+  endif
+
+  if (v:lnum == 1) && (line == '+++' || line == '---')
+    let b:markdown_frontmatter = 1
+    return ">1"
+  endif
+
+  if (line == '+++' || line == '---') && b:markdown_frontmatter
+    unlet b:markdown_frontmatter
+    return '<1'
   endif
 
   return "="

--- a/runtime/syntax/markdown.vim
+++ b/runtime/syntax/markdown.vim
@@ -2,7 +2,7 @@
 " Language:     Markdown
 " Maintainer:   Tim Pope <vimNOSPAM@tpope.org>
 " Filenames:    *.markdown
-" Last Change:  2020 Jan 14
+" Last Change:  2021 Nov 10
 
 if exists("b:current_syntax")
   finish
@@ -165,5 +165,11 @@ let b:current_syntax = "markdown"
 if main_syntax ==# 'markdown'
   unlet main_syntax
 endif
+
+unlet b:current_syntax
+syntax include @Yaml syntax/yaml.vim
+syntax include @Toml syntax/toml.vim
+syntax region yamlFrontmatter start=/\%^---$/ end=/^---$/ keepend contains=@Yaml
+syntax region tomlFrontmatter start=/\%^+++$/ end=/^+++$/ keepend contains=@Toml
 
 " vim:set sw=2:


### PR DESCRIPTION
Added **syntax highlighting** and **folding** specific to the **frontmatter in Yaml or Toml.**

Currently, only the Markdown highlighting was applied to the frontmatter and the folding was wrong and mistook the closure of the frontmatter for markdown.

Most people use Yaml but Toml makes its way and I use it with the static site engine Zola.