### PR TITLE
python3: Fix test_python3 when used with Python 3.10

### DIFF
--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -25,6 +25,7 @@ func Test_AAA_python3_setup()
     py33_type_error_pattern = re.compile('^__call__\(\) takes (\d+) positional argument but (\d+) were given$')
     py37_exception_repr = re.compile(r'([^\(\),])(\)+)$')
     py39_type_error_pattern = re.compile('\w+\.([^(]+\(\) takes)')
+    py310_type_error_pattern = re.compile('takes (\d+) positional argument but (\d+) were given')
 
     def emsg(ei):
       return ei[0].__name__ + ':' + repr(ei[1].args)
@@ -60,6 +61,7 @@ func Test_AAA_python3_setup()
                             msg = msg.replace(newmsg2, oldmsg2)
                         # Python 3.9 reports errors like "vim.command() takes ..." instead of "command() takes ..."
                         msg = py39_type_error_pattern.sub(r'\1', msg)
+                        msg = py310_type_error_pattern.sub(r'takes exactly \1 positional argument (\2 given)', msg)
                 elif sys.version_info >= (3, 5) and e.__class__ is ValueError and str(e) == 'embedded null byte':
                     msg = repr((TypeError, TypeError('expected bytes with no null')))
                 else:
@@ -2639,6 +2641,7 @@ func Test_python3_errors()
   py3 cb = vim.current.buffer
 
   py3 << trim EOF
+    import os
     d = vim.Dictionary()
     ned = vim.Dictionary(foo='bar', baz='abcD')
     dl = vim.Dictionary(a=1)


### PR DESCRIPTION
When I tried to run `test_python3` with Python 3.10 on MS-Windows, I got the following error:

```
Failures:
	From test_python3.vim:
	Found errors in Test_python3_errors():
	command line..script D:/a/vim-kt/vim-kt/vim/src/testdir/runtest.vim[455]..function RunTheTest[44]..Test_python3_errors line 1204: Expected 'vim.foreach_rtp(NoArgsCall()):(<class ''TypeError''>, TypeError(''__call__() takes exactly 1 positional argument (2 given)'',))' but got 'vim.foreach_rtp(NoArgsCall()):(<class ''TypeError''>, TypeError(''__call__() takes 1 positional argument but 2 were given'',))'
```

Add a pattern to replace the error message.

Also add `import os` to fix an error when running `Test_python3_errors` separately:

```
> nmake -f Make_dos.mak test_python3 "TEST_FILTER=Test_AAA_python3_setup\|Test_python3_errors"
...
Found errors in Test_python3_errors():
Caught exception in Test_python3_errors(): Vim(py3):NameError: name 'os' is not defined @ command line..script C:/work/vim-msvc/src/testdir/runtest.vim[455]..function RunTheTest[44]..Test_python3_errors, line 392
```