### PR TITLE
terminal: Check for valid terminal rows options

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -302,11 +302,12 @@ set_term_and_win_size(term_T *term, jobopt_T *opt)
 	if (term->tl_cols < cols)
 	    term->tl_cols = cols;
     }
-    if ((opt->jo_set2 & JO2_TERM_ROWS))
+    // Make sure, opt->jo_term_rows is valid
+    if ((opt->jo_set2 & JO2_TERM_ROWS) && opt->jo_term_rows > 0)
 	term->tl_rows = opt->jo_term_rows;
     else if (rows != 0)
 	term->tl_rows = rows;
-    if ((opt->jo_set2 & JO2_TERM_COLS))
+    if ((opt->jo_set2 & JO2_TERM_COLS) && opt->jo_term_cols > 0)
 	term->tl_cols = opt->jo_term_cols;
     else if (cols != 0)
 	term->tl_cols = cols;

--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -580,5 +580,16 @@ func Test_term_gettty()
   exe buf . 'bwipe'
 endfunc
 
+func Test_term_invalid_rows()
+  " This caused a segfault
+  if has("win32")
+    call assert_fails('call term_start("cmd", #{ term_rows: 10.0})', 'E805')
+  else
+    call assert_fails('call term_start("sh", #{ term_rows: 10.0})', 'E805')
+  endif
+  call StopShellInTerminal(bufnr('%'))
+  bw!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When calling :call term_start('sh', #{term_rows: 10.0}) the term_row
variable will be checked, that it is of the correct type, but later, it
will be assigned to term_tl_rows, even if it is 0. This causes later
problems when trying to allocate the memory. So make sure the actual
size is larger than zero.

fixes: #9116