### PR TITLE
Termdebug :Asm working if opening buffer is nomodifiable

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1098,6 +1098,7 @@ func s:GotoAsmwinOrCreateIt()
     setlocal number
     setlocal noswapfile
     setlocal buftype=nofile
+    setlocal modifiable
 
     let asmbuf = bufnr('Termdebug-asm-listing')
     if asmbuf > 0


### PR DESCRIPTION
previously if `:Asm` was opened from a nomodifiable one only errors about "modifiable is off" were presented