### PR TITLE
Improve rsc syntax highlighting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -231,6 +231,7 @@ runtime/syntax/ps1xml.vim		@heaths
 runtime/syntax/psl.vim			@danielkho
 runtime/syntax/rc.vim			@chrisbra
 runtime/syntax/rpcgen.vim		@cecamp
+runtime/syntax/rsc.vim			@zainin
 runtime/syntax/ruby.vim			@dkearns
 runtime/syntax/sass.vim			@tpope
 runtime/syntax/scss.vim			@tpope

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1493,6 +1493,9 @@ au BufNewFile,BufRead robots.txt		setf robots
 " Rpcgen
 au BufNewFile,BufRead *.x			setf rpcgen
 
+" rsc (RouterOS script)
+au BufRead,BufNewFile *.rsc			setf rsc
+
 " reStructuredText Documentation Format
 au BufNewFile,BufRead *.rst			setf rst
 

--- a/runtime/ftplugin/rsc.vim
+++ b/runtime/ftplugin/rsc.vim
@@ -1,0 +1,6 @@
+" Vim filetype plugin file
+" Language:     RouterOS scripts
+" Maintainer:   zainin
+" Last Change:  2017-07-26
+
+au BufRead,BufNewFile *.rsc set filetype=rsc

--- a/runtime/ftplugin/rsc.vim
+++ b/runtime/ftplugin/rsc.vim
@@ -1,6 +1,0 @@
-" Vim filetype plugin file
-" Language:     RouterOS scripts
-" Maintainer:   zainin
-" Last Change:  2017-07-26
-
-au BufRead,BufNewFile *.rsc set filetype=rsc

--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -190,6 +190,10 @@ if s:line1 =~# "^#!"
   elseif s:name =~# 'fennel\>'
     set ft=fennel
 
+    " rsc (RouterOS script)
+  elseif s:name =~# 'rsc\>'
+    set ft=rsc
+
   endif
   unlet s:name
 
@@ -389,6 +393,10 @@ else
   " YAML
   elseif s:line1 =~# '^%YAML'
     set ft=yaml
+
+  " rsc (RouterOS script)
+  elseif s:line1 =~# '^#.*by RouterOS.*$'
+    set ft=rsc
 
   " CVS diff
   else

--- a/runtime/syntax/rsc.vim
+++ b/runtime/syntax/rsc.vim
@@ -41,10 +41,12 @@ syn keyword   rscBoolean      yes no true false
 syn keyword   rscConditional  if
 
 " operators
-syn match     rscOperator     " [\+\-\*\<\>\=\!\~\^\&\.\,] "
-syn match     rscOperator     "[\<\>\!]="
-syn match     rscOperator     "\(<<\|>>\)"
-syn match     rscOperator     "[\+\-]\(\d\)\@="
+syn match     rscOperator     " \zs[-+*<>=!~^&.,]\ze "
+syn match     rscOperator     "[<>!]="
+syn match     rscOperator     "<<\|>>"
+syn match     rscOperator     "[+-]\d\@="
+
+syn keyword   rscOperator     and or in
 
 " commands
 syn keyword   rscCommands     beep delay put len typeof pick log time set find environment

--- a/runtime/syntax/rsc.vim
+++ b/runtime/syntax/rsc.vim
@@ -11,8 +11,6 @@ endif
 
 syn case ignore
 
-set iskeyword=A-Z,a-z
-
 " comments
 syn match     rscComment      /^\s*#.*/
 

--- a/runtime/syntax/rsc.vim
+++ b/runtime/syntax/rsc.vim
@@ -60,14 +60,18 @@ syn keyword   rscType         global local
 " loop keywords
 syn keyword   rscRepeat       do while for foreach
 
-syn match     rscSpecial      "[():\[\]{|}]"
+syn match     rscSpecial      "[():[\]{|}]"
 
-syn region    rscString       start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=rscSpecial
+syn match     rscEscape       "\\["\\nrt$?_abfv]" contained display
+syn match     rscEscape       "\\\x\x"            contained display
+
+syn region    rscString       start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=rscSpecial,rscEscape
 
 hi link rscComment              Comment
 hi link rscSubMenu              Function
 hi link rscVariable             Identifier
 hi link rscDelimiter            Operator
+hi link rscEscape               Special
 hi link rscService              Type
 hi link rscInterface            Type
 hi link rscBoolean              Boolean

--- a/runtime/syntax/rsc.vim
+++ b/runtime/syntax/rsc.vim
@@ -1,0 +1,82 @@
+" Vim syntax file
+" Language:        RouterOS scripts
+" Maintainer:      zainin
+" Original Author: ndbjorne @ MikroTik forums
+" Last Change:     2017-07-26
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+syn case ignore
+
+set iskeyword=A-Z,a-z
+
+" comments
+syn match     rscComment      /^\s*#.*/
+
+" options submenus: /interface ether1 etc
+syn match     rscSubMenu      "\([a-z]\)\@<!/[a-zA-Z0-9-]*"
+
+" variables are matched by looking at strings ending with "=", e.g. var=
+syn match     rscVariable     "[a-zA-Z0-9-/]*\(=\)\@="
+syn match     rscVariable     "$[a-zA-Z0-9-]*"
+
+" colored for clarity
+syn match     rscDelimiter    "[,=]"
+" match slash in CIDR notation (1.2.3.4/24, 2001:db8::/48, ::1/128)
+syn match     rscDelimiter    "\(\x\|:\)\@<=\/\(\d\)\@="
+" dash in IP ranges
+syn match     rscDelimiter    "\(\x\|:\)\@<=-\(\x\|:\)\@="
+
+" match service names after "set", like in original routeros syntax
+syn match     rscService      "\(set\)\@<=\s\(api-ssl\|api\|dns\|ftp\|http\|https\|pim\|ntp\|smb\|ssh\|telnet\|winbox\|www\|www-ssl\)"
+
+" colors various interfaces
+syn match     rscInterface    "bridge\d\+\|ether\d\+\|wlan\d\+\|pppoe-\(out\|in\)\d\+"
+
+syn keyword   rscBoolean      yes no
+
+syn keyword   rscConditional  if
+
+" operators
+syn match     rscOperator     " [\+\-\*\<\>\=\!\~\^\&\.\,] "
+syn match     rscOperator     "[\<\>\!]="
+syn match     rscOperator     "\(<<\|>>\)"
+syn match     rscOperator     "[\+\-]\(\d\)\@="
+
+" commands
+syn keyword   rscCommands     beep delay put len typeof pick log time set find environment
+syn keyword   rscCommands     terminal error parse resolve toarray tobool toid toip toip6
+syn keyword   rscCommands     tonum tostr totime add remove enable disable set get print
+syn keyword   rscCommands     export edit find append as-value brief detail count-only file
+syn keyword   rscCommands     follow follow-only from interval terse value-list without-paging
+syn keyword   rscCommands     where
+
+" variable types
+syn keyword   rscType         global local
+
+" loop keywords
+syn keyword   rscRepeat       do while for foreach
+
+syn match     rscSpecial      "[():\[\]{|}]"
+
+syn region    rscString       start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=rscSpecial
+
+hi link rscComment              Comment
+hi link rscSubMenu              Function
+hi link rscVariable             Identifier
+hi link rscDelimiter            Operator
+hi link rscService              Type
+hi link rscInterface            Type
+hi link rscBoolean              Boolean
+hi link rscConditional          Conditional
+hi link rscOperator             Operator
+hi link rscCommands             Operator
+hi link rscType                 Type
+hi link rscRepeat               Repeat
+hi link rscSpecial              Delimiter
+hi link rscString               String
+
+let b:current_syntax = "rsc"

--- a/runtime/syntax/rsc.vim
+++ b/runtime/syntax/rsc.vim
@@ -11,6 +11,8 @@ endif
 
 syn case ignore
 
+syn iskeyword @,-
+
 " comments
 syn match     rscComment      /^\s*#.*/
 
@@ -34,7 +36,7 @@ syn match     rscService      "\(set\)\@<=\s\(api-ssl\|api\|dns\|ftp\|http\|http
 " colors various interfaces
 syn match     rscInterface    "bridge\d\+\|ether\d\+\|wlan\d\+\|pppoe-\(out\|in\)\d\+"
 
-syn keyword   rscBoolean      yes no
+syn keyword   rscBoolean      yes no true false
 
 syn keyword   rscConditional  if
 
@@ -47,10 +49,10 @@ syn match     rscOperator     "[\+\-]\(\d\)\@="
 " commands
 syn keyword   rscCommands     beep delay put len typeof pick log time set find environment
 syn keyword   rscCommands     terminal error parse resolve toarray tobool toid toip toip6
-syn keyword   rscCommands     tonum tostr totime add remove enable disable set get print
+syn keyword   rscCommands     tonum tostr totime add remove enable disable where get print
 syn keyword   rscCommands     export edit find append as-value brief detail count-only file
 syn keyword   rscCommands     follow follow-only from interval terse value-list without-paging
-syn keyword   rscCommands     where
+syn keyword   rscCommands     return
 
 " variable types
 syn keyword   rscType         global local

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -422,6 +422,7 @@ let s:filename_checks = {
     \ 'robots': ['robots.txt'],
     \ 'rpcgen': ['file.x'],
     \ 'rpl': ['file.rpl'],
+    \ 'rsc': ['file.rsc'],
     \ 'rst': ['file.rst'],
     \ 'rtf': ['file.rtf'],
     \ 'ruby': ['.irbrc', 'irbrc', 'file.rb', 'file.rbw', 'file.gemspec', 'file.ru', 'Gemfile', 'file.builder', 'file.rxml', 'file.rjs', 'file.rant', 'file.rake', 'rakefile', 'Rakefile', 'rantfile', 'Rantfile', 'rakefile-file', 'Rakefile-file', 'Puppetfile'],


### PR DESCRIPTION
Here's a couple of small improvements.

- escape sequence highlighting
- and or in operator highlighting

Is it intentional that rscSpecial is included in rscString?