### PR TITLE
Termdebug: recognize pending breakpoints

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -762,7 +762,7 @@ func s:CommOutput(chan, msg)
     elseif msg != ''
       if msg =~ '^\(\*stopped\|\*running\|=thread-selected\)'
 	call s:HandleCursor(msg)
-      elseif msg =~ '^\^done,bkpt=' || msg =~ '^=breakpoint-created,'
+      elseif msg =~ '^\^done,bkpt=' || msg =~ '^=breakpoint-created,' || msg =~ '^=breakpoint-modified,'
 	call s:HandleNewBreakpoint(msg)
       elseif msg =~ '^=breakpoint-deleted,'
 	call s:HandleBreakpointDelete(msg)


### PR DESCRIPTION
Now a breakpoint that GDB notes as "pending" (so Vim has no chance to set it useful into its internal list) is added to the list as soon as GDB modifies it to a "real" breakpoint (commonly because the matching symbol file is loaded).

_May_ help with #3924, too.