### PR TITLE
src/spellsuggest.c: fix a typo

### DIFF
--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -1619,7 +1619,7 @@ suggest_trie_walk(
 		    // char, e.g., "thes," -> "these".
 		    p = fword + sp->ts_fidx;
 		    MB_PTR_BACK(fword, p);
-		    if (!spell_iswordp(p, curwin) && *preword != NUL)
+		    if (!spell_iswordp(p, curwin) && *preword != NULL)
 		    {
 			p = preword + STRLEN(preword);
 			MB_PTR_BACK(preword, p);


### PR DESCRIPTION
The commit [1] which add the check for preword is used to fix CVE-2021-3928,
fix the typo to let it really check the preword is not empty.

[1] https://github.com/vim/vim/commit/15d9890eee53afc61eb0a03b878a19cb5672f732

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>