### PR TITLE
new users are confused by command-line window

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -111,6 +111,12 @@ if 1
 
   augroup END
 
+  augroup vimHints
+      autocmd! CmdwinEnter *
+        \ echo 'You discovered a command-line window!' .
+        \ ' Quit with ":q" and see ":h command-line-window".'
+  augroup END
+
 endif
 
 " Switch syntax highlighting on when the terminal has colors or when using the


### PR DESCRIPTION
```
Problem:    Default binding "q:" is easy to hit accidentally when trying
            to quit Vim with ":q" and command-line window has no
            indication of what it is.

Solution:   Add an autocommand to defaults.vim that echoes a helpful
            message upon entering command-line window. (Egor Zvorykin)
```