### PR TITLE
formatting: use correct indenting for first line

### DIFF
--- a/src/testdir/test_indent.vim
+++ b/src/testdir/test_indent.vim
@@ -142,4 +142,77 @@ func Test_modeline_indent_expr()
   call delete('Xfile.txt')
 endfunc
 
+func Test_indent_func_with_gq()
+  
+  function GetTeXIndent()
+    " Sample indent expression for TeX files
+    let lnum = prevnonblank(v:lnum - 1)
+    " At the start of the file use zero indent.
+    if lnum == 0
+        return 0
+    endif
+    let line = getline(lnum)
+    let ind = indent(lnum)
+    " Add a 'shiftwidth' after beginning of environments.
+    if line =~ '\\begin{center}' 
+      let ind = ind + shiftwidth()
+    endif
+    return ind
+  endfunction
+  new
+  setl et sw=2 sts=2 ts=2 tw=50 indentexpr=GetTeXIndent()
+  put =[  '\documentclass{article}', '', '\begin{document}', '',
+        \ 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce ut enim non',
+        \ 'libero efficitur aliquet. Maecenas metus justo, facilisis convallis blandit',
+        \ 'non, semper eu urna. Suspendisse diam diam, iaculis faucibus lorem eu,',
+        \ 'fringilla condimentum lectus. Quisque euismod diam at convallis vulputate.',
+        \ 'Pellentesque laoreet tortor sit amet mauris euismod ornare. Sed varius',
+        \ 'bibendum orci vel vehicula. Pellentesque tempor, ipsum et auctor accumsan,',
+        \ 'metus lectus ultrices odio, sed elementum mi ante at arcu.', '', '\begin{center}', '',
+        \ 'Proin nec risus consequat nunc dapibus consectetur. Mauris lacinia est a augue',
+        \ 'tristique accumsan. Morbi pretium, felis molestie eleifend condimentum, arcu',
+        \ 'ipsum congue nisl, quis euismod purus libero in ante. Donec id semper purus.',
+        \ 'Suspendisse eget aliquam nunc. Maecenas fringilla mauris vitae maximus',
+        \ 'condimentum. Cras a quam in mi dictum eleifend at a lorem. Sed convallis',
+        \ 'ante a commodo facilisis. Nam suscipit vulputate odio, vel dapibus nisl',
+        \ 'dignissim facilisis. Vestibulum ante ipsum primis in faucibus orci luctus et',
+        \ 'ultrices posuere cubilia curae;', '', '']
+  1d_
+  call cursor(5, 1)
+  ka
+  call cursor(15, 1)
+  kb
+  norm! 'agqap
+  norm! 'bgqap
+  let expected = [ '\documentclass{article}', '', '\begin{document}', '',
+        \ 'Lorem ipsum dolor sit amet, consectetur adipiscing',
+        \ 'elit. Fusce ut enim non libero efficitur aliquet.',
+        \ 'Maecenas metus justo, facilisis convallis blandit',
+        \ 'non, semper eu urna. Suspendisse diam diam,',
+        \ 'iaculis faucibus lorem eu, fringilla condimentum',
+        \ 'lectus. Quisque euismod diam at convallis',
+        \ 'vulputate.  Pellentesque laoreet tortor sit amet',
+        \ 'mauris euismod ornare. Sed varius bibendum orci',
+        \ 'vel vehicula. Pellentesque tempor, ipsum et auctor',
+        \ 'accumsan, metus lectus ultrices odio, sed',
+        \ 'elementum mi ante at arcu.', '', '\begin{center}', '',
+        \ '  Proin nec risus consequat nunc dapibus',
+        \ '  consectetur. Mauris lacinia est a augue',
+        \ '  tristique accumsan. Morbi pretium, felis',
+        \ '  molestie eleifend condimentum, arcu ipsum congue',
+        \ '  nisl, quis euismod purus libero in ante. Donec',
+        \ '  id semper purus.  Suspendisse eget aliquam nunc.',
+        \ '  Maecenas fringilla mauris vitae maximus',
+        \ '  condimentum. Cras a quam in mi dictum eleifend',
+        \ '  at a lorem. Sed convallis ante a commodo',
+        \ '  facilisis. Nam suscipit vulputate odio, vel',
+        \ '  dapibus nisl dignissim facilisis. Vestibulum',
+        \ '  ante ipsum primis in faucibus orci luctus et',
+        \ '  ultrices posuere cubilia curae;', '', '']
+  call assert_equal(expected, getline(1,'$'))
+  bw!
+  delmark ab
+  delfunction GetTeXIndent 
+endfu
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -956,7 +956,6 @@ format_lines(
     int		need_set_indent = TRUE;	// set indent of next paragraph
     int		force_format = FALSE;
     int		old_State = State;
-    int		indent = 0; // amount of indent needed
 
     // length of a line to force formatting: 3 * 'tw'
     max_len = comp_textwidth(TRUE) * 3;
@@ -1072,6 +1071,8 @@ format_lines(
 	    {
 		if (need_set_indent)
 		{
+		    int		indent = 0; // amount of indent needed
+
 		    // replace indent in first line with minimal number of
 		    // tabs and spaces, according to current options
 # ifdef FEAT_LISP

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -956,6 +956,9 @@ format_lines(
     int		need_set_indent = TRUE;	// set indent of next paragraph
     int		force_format = FALSE;
     int		old_State = State;
+#if defined(FEAT_CINDENT) || defined(FEAT_EVAL) || defined(FEAT_LISP)
+    int		indent = 0; // amount of indent needed
+#endif
 
     // length of a line to force formatting: 3 * 'tw'
     max_len = comp_textwidth(TRUE) * 3;
@@ -1070,9 +1073,31 @@ format_lines(
 	    if (is_end_par || force_format)
 	    {
 		if (need_set_indent)
+		{
 		    // replace indent in first line with minimal number of
 		    // tabs and spaces, according to current options
-		    (void)set_indent(get_indent(), SIN_CHANGED);
+# ifdef FEAT_LISP
+		    if (curbuf->b_p_lisp)
+			indent = get_lisp_indent();
+		    else
+# endif
+		    {
+#ifdef FEAT_CINDENT
+			if (cindent_on())
+			{
+			    indent = 
+#ifdef FEAT_EVAL
+			    *curbuf->b_p_inde != NUL ?
+				get_expr_indent() :
+#endif
+				get_c_indent();
+			}
+			else
+#endif
+			    indent = get_indent();
+		    }
+		    (void)set_indent(indent, SIN_CHANGED);
+		}
 
 		// put cursor on last non-space
 		State = NORMAL;	// don't go past end-of-line

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -956,9 +956,7 @@ format_lines(
     int		need_set_indent = TRUE;	// set indent of next paragraph
     int		force_format = FALSE;
     int		old_State = State;
-#if defined(FEAT_CINDENT) || defined(FEAT_EVAL) || defined(FEAT_LISP)
     int		indent = 0; // amount of indent needed
-#endif
 
     // length of a line to force formatting: 3 * 'tw'
     max_len = comp_textwidth(TRUE) * 3;


### PR DESCRIPTION
If the buffer to be re-formatted, uses a custom indent expression,
it may happen that reformatting using e.g. `gqap` for the current
paragraph will indent the first line according to the current indent
setting (e.g. zero indent), while all the other lines will be
reformatted by using the indent expression.

This is because Vim will first join the whole paragraph into a long line
then add line breaks and reformat using the buffers current indenting
options.

This causes a nasty indent, of the first line being not indent, while
all the other ones are.

Fix this, by making sure, that even for the first line in the range,
apply the correct indenting function. That is, if an indent expression
has been set, use this, instead of the very simple get_indent() that
only indents according to the existing current indent.

Add a test to demonstrate the problem.

This fixes #9056