### PR TITLE
shell: only use `nonomatch` for csh like shells

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -6691,10 +6691,18 @@ mch_expand_wildcards(
     }
     else
     {
-	if (flags & EW_NOTFOUND)
-	    STRCPY(command, "set nonomatch; ");
+	if (shell_style == STYLE_GLOB)
+	{
+	    // Assume the nonomatch option is valid only for csh
+	    // like shells, otherwise, this may set the 
+	    // positional parameters for the shell, e.g. $*
+	    if (flags & EW_NOTFOUND)
+		STRCPY(command, "set nonomatch; ");
+	    else
+		STRCPY(command, "unset nonomatch; ");
+	}
 	else
-	    STRCPY(command, "unset nonomatch; ");
+	    STRCPY(command, "");
 	if (shell_style == STYLE_GLOB)
 	    STRCAT(command, "glob >");
 	else if (shell_style == STYLE_PRINT)

--- a/src/testdir/test_expand.vim
+++ b/src/testdir/test_expand.vim
@@ -1,6 +1,7 @@
 " Test for expanding file names
 
 source shared.vim
+source check.vim
 
 func Test_with_directories()
   call mkdir('Xdir1')
@@ -133,6 +134,11 @@ func Test_expand_filename_multicmd()
   call assert_equal('foo', bufname(winbufnr(2)))
   call assert_fails('e %:s/.*//', 'E500:')
   %bwipe!
+endfunc
+
+func Test_expandcmd_shell_nonomatch()
+  CheckNotMSWindows
+  call assert_equal('$*', expandcmd('$*'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
see vim/vim#9153