### PR TITLE
Always change the scope shown by :verbose pwd even if the working directory didn't change when using :lcd, :tcd or :cd

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7301,6 +7301,7 @@ post_chdir(cdscope_T scope)
 	VIM_CLEAR(globaldir);
     }
 
+    last_chdir_reason = NULL;
     shorten_fnames(TRUE);
 }
 
@@ -7390,7 +7391,6 @@ changedir_func(
 
 	if (dir_differs)
 	{
-	    last_chdir_reason = NULL;
 	    if (scope == CDSCOPE_WINDOW)
 		acmd_fname = (char_u *)"window";
 	    else if (scope == CDSCOPE_TABPAGE)

--- a/src/testdir/test_autochdir.vim
+++ b/src/testdir/test_autochdir.vim
@@ -40,6 +40,14 @@ func Test_verbose_pwd()
   set acd
   wincmd w
   call assert_match('\[autochdir\].*testdir$', execute('verbose pwd'))
+  execute 'lcd' cwd
+  call assert_match('\[window\].*testdir$', execute('verbose pwd'))
+  execute 'tcd' cwd
+  call assert_match('\[tabpage\].*testdir$', execute('verbose pwd'))
+  execute 'cd' cwd
+  call assert_match('\[global\].*testdir$', execute('verbose pwd'))
+  edit
+  call assert_match('\[autochdir\].*testdir$', execute('verbose pwd'))
   wincmd w
   call assert_match('\[autochdir\].*testdir[/\\]Xautodir', execute('verbose pwd'))
   set noacd


### PR DESCRIPTION
Previously, the scope shown by `:verbose pwd` remains "autochdir" if
`:lcd`, `:tcd` or `:cd` is used to change to the same CWD last set by
'autochdir'.  However, this is inconsistent, as `:lcd`, `:tcd` or `:cd`
changes the scope shown by `:verbose pwd` even when changing to the same
CWD last set by `:lcd`, `:tcd` or `:cd`.