### PR TITLE
Fix completions in cmdwin doesn't work properly for arguments of buffer local commands

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4485,6 +4485,16 @@ open_cmdwin(void)
 
     return cmdwin_result;
 }
+
+/*
+ * Check if the user is in cmdwin or not. Returns true if user is in cmdwin
+ * now, otherwise returns false.
+ */
+    int
+is_in_cmdwin(void)
+{
+    return cmdwin_type != 0 && get_cmdline_type() == NUL;
+}
 #endif // FEAT_CMDWIN
 
 /*

--- a/src/proto/ex_getln.pro
+++ b/src/proto/ex_getln.pro
@@ -38,6 +38,7 @@ int get_cmdline_type(void);
 int get_cmdline_firstc(void);
 int get_list_range(char_u **str, int *num1, int *num2);
 char *check_cedit(void);
+int is_in_cmdwin(void);
 char_u *script_get(exarg_T *eap, char_u *cmd);
 void get_user_input(typval_T *argvars, typval_T *rettv, int inputdialog, int secret);
 /* vim: set ft=c : */

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -381,18 +381,6 @@ func s:ComplInCmdwin_LocalCompletion(A, L, P)
   return 'local'
 endfunc
 
-func s:ComplInCmdwin_GlobalCompletionList(A, L, P)
-  return ['global']
-endfunc
-
-func s:ComplInCmdwin_LocalCompletionList(A, L, P)
-  return ['local']
-endfunc
-
-func s:ComplInCmdwin_CheckCompletion(arg)
-  call assert_equal('local', a:arg)
-endfunc
-
 func Test_compl_in_cmdwin()
   CheckFeature cmdwin
 
@@ -433,6 +421,18 @@ func Test_compl_in_cmdwin()
 
 
   " Argument completion of buffer-local command
+  func s:ComplInCmdwin_GlobalCompletionList(A, L, P)
+    return ['global']
+  endfunc
+
+  func s:ComplInCmdwin_LocalCompletionList(A, L, P)
+    return ['local']
+  endfunc
+
+  func s:ComplInCmdwin_CheckCompletion(arg)
+    call assert_equal('local', a:arg)
+  endfunc
+
   com! -nargs=1 -complete=custom,<SID>ComplInCmdwin_GlobalCompletion
        \ TestCommand call s:ComplInCmdwin_CheckCompletion(<q-args>)
   com! -buffer -nargs=1 -complete=custom,<SID>ComplInCmdwin_LocalCompletion
@@ -443,7 +443,16 @@ func Test_compl_in_cmdwin()
        \ TestCommand call s:ComplInCmdwin_CheckCompletion(<q-args>)
   com! -buffer -nargs=1 -complete=customlist,<SID>ComplInCmdwin_LocalCompletionList
        \ TestCommand call s:ComplInCmdwin_CheckCompletion(<q-args>)
+
   call feedkeys("q:iTestCommand \<Tab>\<CR>", 'tx!')
+
+  func! s:ComplInCmdwin_CheckCompletion(arg)
+    call assert_equal('global', a:arg)
+  endfunc
+  new
+  call feedkeys("q:iTestCommand \<Tab>\<CR>", 'tx!')
+  quit
+
   delfunc s:ComplInCmdwin_GlobalCompletion
   delfunc s:ComplInCmdwin_LocalCompletion
   delfunc s:ComplInCmdwin_GlobalCompletionList

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -373,6 +373,26 @@ func Test_compl_feedkeys()
   set completeopt&
 endfunc
 
+func s:ComplInCmdwin_GlobalCompletion(A, L, P)
+  return 'global'
+endfunc
+
+func s:ComplInCmdwin_LocalCompletion(A, L, P)
+  return 'local'
+endfunc
+
+func s:ComplInCmdwin_GlobalCompletionList(A, L, P)
+  return ['global']
+endfunc
+
+func s:ComplInCmdwin_LocalCompletionList(A, L, P)
+  return ['local']
+endfunc
+
+func s:ComplInCmdwin_CheckCompletion(arg)
+  call assert_equal('local', a:arg)
+endfunc
+
 func Test_compl_in_cmdwin()
   CheckFeature cmdwin
 
@@ -411,6 +431,26 @@ func Test_compl_in_cmdwin()
   call feedkeys("q::GetInput b:test_\<Tab>\<CR>:q\<CR>", 'tx!')
   call assert_equal('b:test_', input)
 
+
+  " Argument completion of buffer-local command
+  com! -nargs=1 -complete=custom,<SID>ComplInCmdwin_GlobalCompletion
+       \ TestCommand call s:ComplInCmdwin_CheckCompletion(<q-args>)
+  com! -buffer -nargs=1 -complete=custom,<SID>ComplInCmdwin_LocalCompletion
+       \ TestCommand call s:ComplInCmdwin_CheckCompletion(<q-args>)
+  call feedkeys("q:iTestCommand \<Tab>\<CR>", 'tx!')
+
+  com! -nargs=1 -complete=customlist,<SID>ComplInCmdwin_GlobalCompletionList
+       \ TestCommand call s:ComplInCmdwin_CheckCompletion(<q-args>)
+  com! -buffer -nargs=1 -complete=customlist,<SID>ComplInCmdwin_LocalCompletionList
+       \ TestCommand call s:ComplInCmdwin_CheckCompletion(<q-args>)
+  call feedkeys("q:iTestCommand \<Tab>\<CR>", 'tx!')
+  delfunc s:ComplInCmdwin_GlobalCompletion
+  delfunc s:ComplInCmdwin_LocalCompletion
+  delfunc s:ComplInCmdwin_GlobalCompletionList
+  delfunc s:ComplInCmdwin_LocalCompletionList
+  delfunc s:ComplInCmdwin_CheckCompletion
+
+  delcom -buffer TestCommand
   delcom TestCommand
   delcom GetInput
   unlet w:test_winvar

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -141,7 +141,11 @@ find_ucmd(
     /*
      * Look for buffer-local user commands first, then global ones.
      */
-    gap = &curbuf->b_ucmds;
+    gap =
+#ifdef FEAT_CMDWIN
+	is_in_cmdwin() ? &prevwin->w_buffer->b_ucmds :
+#endif
+	&curbuf->b_ucmds;
     for (;;)
     {
 	for (j = 0; j < gap->ga_len; ++j)
@@ -303,7 +307,7 @@ get_user_commands(expand_T *xp UNUSED, int idx)
     // In cmdwin, the alternative buffer should be used.
     buf_T *buf =
 #ifdef FEAT_CMDWIN
-	(cmdwin_type != 0 && get_cmdline_type() == NUL) ? prevwin->w_buffer :
+	is_in_cmdwin() ? prevwin->w_buffer :
 #endif
 	curbuf;
 
@@ -330,8 +334,7 @@ get_user_command_name(int idx, int cmdidx)
 	// In cmdwin, the alternative buffer should be used.
 	buf_T *buf =
 #ifdef FEAT_CMDWIN
-		    (cmdwin_type != 0 && get_cmdline_type() == NUL)
-							  ? prevwin->w_buffer :
+		    is_in_cmdwin() ? prevwin->w_buffer :
 #endif
 	    curbuf;
 
@@ -420,8 +423,7 @@ uc_list(char_u *name, size_t name_len)
     // In cmdwin, the alternative buffer should be used.
     gap =
 #ifdef FEAT_CMDWIN
-	(cmdwin_type != 0 && get_cmdline_type() == NUL) ?
-	&prevwin->w_buffer->b_ucmds :
+	is_in_cmdwin() ? &prevwin->w_buffer->b_ucmds :
 #endif
 	&curbuf->b_ucmds;
     for (;;)


### PR DESCRIPTION
## Problem
If there are both global and buffer local commands for the same name, completion for command arguments will be of the global command, not of the buffer local command when in command-line window.

## To reproduce

1. Save this script to `~/reproduce.vim`:

```vim
set wildmenu
set wildchar=<Tab>

function GlobalCompl(A, L, P)
  return 'global'
endfunction

function LocalCompl(A, L, P)
  return 'local'
endfunction

command! -nargs=1 -complete=custom,GlobalCompl TestCommand echo <q-args>
command! -buffer -nargs=1 -complete=custom,LocalCompl TestCommand echo <q-args>
```

2. Open Vim with `$ vim -u NONE -S ~/reproduce.vim`.
3. Type `q:iTestCommand <Tab>` to enter the command-line window and invoke completion for the arguments of the `TestCommand`.

4. The command-line text will be `TestCommand global`.

## Expected behavior
The command-line text will be `TestCommand local` at step 4 above.

## Environment
- Vim 8.2.3623
- Arch Linux

## Screenshots
- In command-line

![screenshot-2021-11-20-21:35:14](https://user-images.githubusercontent.com/24771416/142727857-65550138-8880-4c56-9629-7b9a579668c6.png)

- In command-line window

![screenshot-2021-11-20-21:35:55](https://user-images.githubusercontent.com/24771416/142727863-3818c4ce-7e02-4ca4-912d-7430bc0e6bfd.png)

