### PR TITLE
fix printf() with %{n}.{m}S format didn't handle multibyte character

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -2142,9 +2142,8 @@ vim_vsnprintf_typval(
 		    }
 		    if (fmt_spec == 'S')
 		    {
-			if (min_field_width != 0)
-			    min_field_width += STRLEN(str_arg)
-				     - mb_string2cells((char_u *)str_arg, -1);
+			size_t base_width = min_field_width;
+			size_t pad_cell = 0;
 			if (precision)
 			{
 			    char_u  *p1;
@@ -2157,8 +2156,11 @@ vim_vsnprintf_typval(
 				if (i > precision)
 				    break;
 			    }
-			    str_arg_l = precision = p1 - (char_u *)str_arg;
+			    pad_cell = min_field_width - precision;
+			    base_width = str_arg_l = precision = p1 - (char_u *)str_arg;
 			}
+			if (min_field_width != 0)
+			    min_field_width = base_width + pad_cell;
 		    }
 		    break;
 

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -297,6 +297,11 @@ function Test_printf_misc()
   call assert_equal('🐍', printf('%.2S', '🐍🐍'))
   call assert_equal('', printf('%.1S', '🐍🐍'))
 
+  call assert_equal('[    あいう]', printf('[%10.6S]', 'あいうえお'))
+  call assert_equal('[  あいうえ]', printf('[%10.8S]', 'あいうえお'))
+  call assert_equal('[あいうえお]', printf('[%10.10S]', 'あいうえお'))
+  call assert_equal('[あいうえお]', printf('[%10.12S]', 'あいうえお'))
+
   call assert_equal('1%', printf('%d%%', 1))
 endfunc
 


### PR DESCRIPTION
fix printf() with %{n}.{m}S format didn't handle multibyte character correctly issue at #7486.