### PR TITLE
GTK 3: Fix undercurled lines starting in wrong place causing artifacts

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -5425,6 +5425,7 @@ draw_under(int flags, int row, int col, int cells)
 	cairo_set_source_rgba(cr,
 		gui.spcolor->red, gui.spcolor->green, gui.spcolor->blue,
 		gui.spcolor->alpha);
+	cairo_move_to(cr, FILL_X(col), y - 2 + 0.5);
 	for (i = FILL_X(col); i < FILL_X(col + cells); ++i)
 	{
 	    offset = val[i % 8];


### PR DESCRIPTION
A long standing bug in the GTK 3 GUI is that undercurled lines(used by the spell checker for example) are starting at the wrong position. This is caused by not moving the cairo "cursor" to the correct starting position. It's really hard to see, look at the beginning of the words in this screenshot. It's enlarged by factor 3:

![vim-wrongstart](https://user-images.githubusercontent.com/1224576/142731319-59d6039c-4c6f-4b76-847c-3174a51a049d.png)

With the recent changes to the GTK 3 GUI this became a problem. Until patch 8.2.3607 nearly all interactions repainted most parts of the GUI. Now only altered parts are repainted. Due to the unpositioned cursor parts of the undercurl line are painted in areas were they don't belong, these areas aren't cleared. This lead to artifacts:

![vim-artefact](https://user-images.githubusercontent.com/1224576/142731435-618534b5-f182-4662-aeab-7b9d4e424653.png)

The fix is easy. Move the cairo cursor to the correct starting position before drawing the line. This is already the case for strikethrough lines and underlines. So this was most likely an oversight. Now the line looks like it should and doesn't cause artifacts:

![vim-fixed](https://user-images.githubusercontent.com/1224576/142731482-338efb15-7171-4700-ad06-54671c8a190e.png)
