### PR TITLE
Line of code commented by accident

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1661,7 +1661,7 @@ getout(int exitval)
     {
 	// give the user a chance to read the (error) message
 	no_wait_return = FALSE;
-//	wait_return(FALSE);
+ 	wait_return(FALSE);
     }
 
     // Position the cursor again, the autocommands may have moved it


### PR DESCRIPTION
Problem: line of code commented by accident
Solution: remove comment

I think that wasn't an intentional change in https://github.com/vim/vim/pull/8305?