### PR TITLE
fix: set cursor position for completion in getcompletion(..., 'cmdline')

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2922,6 +2922,7 @@ f_getcompletion(typval_T *argvars, typval_T *rettv)
     {
 	set_one_cmd_context(&xpc, tv_get_string(&argvars[0]));
 	xpc.xp_pattern_len = (int)STRLEN(xpc.xp_pattern);
+	xpc.xp_col = (int)STRLEN(tv_get_string(&argvars[0]));
     }
     else
     {

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -424,14 +424,17 @@ func Test_getcompletion()
   call assert_equal([], l)
 
   func T(a, c, p)
+    let g:cmdline_compl_params = [a:a, a:c, a:p]
     return "oneA\noneB\noneC"
   endfunc
   command -nargs=1 -complete=custom,T MyCmd
   let l = getcompletion('MyCmd ', 'cmdline')
   call assert_equal(['oneA', 'oneB', 'oneC'], l)
+  call assert_equal(['', 'MyCmd ', 6], g:cmdline_compl_params)
 
   delcommand MyCmd
   delfunc T
+  unlet g:cmdline_compl_params
 
   " For others test if the name is recognized.
   let names = ['buffer', 'environment', 'file_in_path', 'mapping', 'tag', 'tag_listfiles', 'user']


### PR DESCRIPTION
Custom completion functions are always receiving zero as the cursor
position parameter, making it always wrong and breaking completion
relying on that. Change the cursor position to be the length of the
pattern.