### PR TITLE
Remove "mappings and abbreviations" from description of getchar.c

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -13,7 +13,6 @@
  * functions related with getting a character from the user/mapping/redo/...
  *
  * manipulations with redo buffer and stuff buffer
- * mappings and abbreviations
  */
 
 #include "vim.h"


### PR DESCRIPTION
They have been moved to map.c