### PR TITLE
g:terminal_ansi_colors does not work in some environments

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -4130,6 +4130,7 @@ set_vterm_palette(VTerm *vterm, long_u *rgb)
     {
 	VTermColor	color;
 
+	color.type = VTERM_COLOR_RGB;
 	color.red = (unsigned)(rgb[index] >> 16);
 	color.green = (unsigned)(rgb[index] >> 8) & 255;
 	color.blue = (unsigned)rgb[index] & 255;


### PR DESCRIPTION
`VTermColor.type` is not cleared, so a random initial value is stored.
Therefore, it may or may not work correctly in some environments.

This fixes #9197.