### PR TITLE
Add translate keyword to django

### DIFF
--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -31,6 +31,7 @@ syn keyword djangoStatement contained closecomment widthratio url with endwith
 syn keyword djangoStatement contained get_current_language trans noop blocktrans
 syn keyword djangoStatement contained endblocktrans get_available_languages
 syn keyword djangoStatement contained get_current_language_bidi plural
+syn keyword djangoStatement contained translate blocktranslate endblocktranslate
 
 " Django templete built-in filters
 syn keyword djangoFilter contained add addslashes capfirst center cut date


### PR DESCRIPTION
Since Django 3.1 support translate, blocktranslate and endblocktranslate tag.
So, I add new keyword to runtime/syntax/django.vim

https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#translate-template-tag
https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#blocktranslate-template-tag

before
<img width="730" alt="スクリーンショット 2021-11-24 23 13 16" src="https://user-images.githubusercontent.com/56591/143255642-df7caf95-224c-4f0c-9adb-546b8ddd7360.png">

after
<img width="732" alt="スクリーンショット 2021-11-24 23 16 36" src="https://user-images.githubusercontent.com/56591/143255685-b6762de2-c016-45cf-9b82-9020c56104d5.png">

P.S.
Sorry, I don't know way to contact maintainer.