### PR TITLE
TermDebug expression cleanup

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1049,8 +1049,7 @@ func s:CleanupExpr(expr)
     " a semicolon nmay be used instead of a space
     " a trailing comma or period is ignored as it commonly separates/ends multiple expr
     let expr = substitute(expr, ';', ' ', 'g')
-    let expr = substitute(expr, '\. *$', '', '')
-    let expr = substitute(expr, ',\+ *$', '', '')
+    let expr = substitute(expr, '[,.]\+ *$', '', '')
   endif
 
   " get rid of surrounding spaces

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1042,19 +1042,21 @@ endfunc
 " (newlines and surrounding whitespace)
 func s:CleanupExpr(expr)
   " replace all embedded newlines/tabs/...
-  let expr = substitute( a:expr, '\s', ' ', 'g')
+  let expr = substitute(a:expr, '\n', ' ', 'g')
+  let expr = substitute(expr, '\s+', ' ', 'g')
 
   if &filetype ==# 'cobol'
-    " extra cleanup for COBOL: _every: expression ends with a period,
+    " extra cleanup for COBOL:
     " a semicolon nmay be used instead of a space
-    " a trailing comma is ignored as it commonly separates multiple expr
-    let expr = substitute(expr, '\..*', '', '')
+    " a trailing comma or period is ignored as it commonly separates/ends multiple expr
     let expr = substitute(expr, ';', ' ', 'g')
-    let expr = substitute(expr, ',*$', '', '')
+    let expr = substitute(expr, '\. *$', '', '')
+    let expr = substitute(expr, ',+ *$', '', '')
   endif
 
   " get rid of surrounding spaces
-  let expr = substitute(expr, '^ *\(.*\) *', '\1', '')
+  let expr = substitute(expr, '^ *', '', '')
+  let expr = substitute(expr, ' *$', '', '')
   return expr
 endfunc
 

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1042,8 +1042,7 @@ endfunc
 " (newlines and surrounding whitespace)
 func s:CleanupExpr(expr)
   " replace all embedded newlines/tabs/...
-  let expr = substitute(a:expr, '\n', ' ', 'g')
-  let expr = substitute(expr, '\s\+', ' ', 'g')
+  let expr = substitute(a:expr, '\_s\+', ' ', 'g')
 
   if &filetype ==# 'cobol'
     " extra cleanup for COBOL:

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1043,7 +1043,7 @@ endfunc
 func s:CleanupExpr(expr)
   " replace all embedded newlines/tabs/...
   let expr = substitute(a:expr, '\n', ' ', 'g')
-  let expr = substitute(expr, '\s+', ' ', 'g')
+  let expr = substitute(expr, '\s\+', ' ', 'g')
 
   if &filetype ==# 'cobol'
     " extra cleanup for COBOL:
@@ -1051,7 +1051,7 @@ func s:CleanupExpr(expr)
     " a trailing comma or period is ignored as it commonly separates/ends multiple expr
     let expr = substitute(expr, ';', ' ', 'g')
     let expr = substitute(expr, '\. *$', '', '')
-    let expr = substitute(expr, ',+ *$', '', '')
+    let expr = substitute(expr, ',\+ *$', '', '')
   endif
 
   " get rid of surrounding spaces

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1040,9 +1040,11 @@ endfunc
 
 " clean up expression that may got in because of range
 " (newlines and surrounding whitespace)
+" As it can also be specified via ex-command for assignments this function
+" may not change the "content" parts (like replacing contained spaces
 func s:CleanupExpr(expr)
   " replace all embedded newlines/tabs/...
-  let expr = substitute(a:expr, '\_s\+', ' ', 'g')
+  let expr = substitute(a:expr, '\_s', ' ', 'g')
 
   if &filetype ==# 'cobol'
     " extra cleanup for COBOL:


### PR DESCRIPTION
General:
* `\s` in vim only matches space and tabs, so extra check for newlines (hopefully matches both unix and dos eol)
* trailing spaces fixed again (those are consumed by the group, so don't use that)

COBOL: included periods may occur in numeric assignments, so only drop trailing ones