### PR TITLE
Runtime: vim python syntax supports <<trim

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -763,10 +763,10 @@ if g:vimsyn_embed =~# 'P' && has("pythonx") && filereadable(s:pythonpath)
  unlet! b:current_syntax
  syn cluster vimFuncBodyList	add=vimPythonRegion
  exe "syn include @vimPythonScript ".s:pythonpath
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon][3x]\=\s*<<\s*\z(\S*\)\ze\(\s*#.*\)\=$+ end=+^\z1\ze\(\s*".*\)\=$+	contains=@vimPythonScript
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon][3x]\=\s*<<\s*$+ end=+\.$+				contains=@vimPythonScript
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+Py\%[thon]2or3\s*<<\s*\z(\S*\)\ze\(\s*#.*\)\=$+ end=+^\z1\ze\(\s*".*\)\=$+	contains=@vimPythonScript
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+Py\%[thon]2or3\=\s*<<\s*$+ end=+\.$+				contains=@vimPythonScript
+ VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon][3x]\=\s*<<\s*\%(trim\s*\)\?\z(\S*\)\ze\(\s*#.*\)\=$+ end=+^\z1\ze\(\s*".*\)\=$+	contains=@vimPythonScript
+ VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon][3x]\=\s*<<\s*\%(trim\s*\)\?$+ end=+\.$+			contains=@vimPythonScript
+ VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+Py\%[thon]2or3\s*<<\s*\%(trim\s*\)\?\z(\S*\)\ze\(\s*#.*\)\=$+ end=+^\z1\ze\(\s*".*\)\=$+	contains=@vimPythonScript
+ VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+Py\%[thon]2or3\=\s*<<\s*\%(trim\s*\)\?$+ end=+\.$+			contains=@vimPythonScript
  syn cluster vimFuncBodyList	add=vimPythonRegion
 else
  syn region vimEmbedError start=+py\%[thon]3\=\s*<<\s*\z(.*\)$+ end=+^\z1$+


### PR DESCRIPTION
```
Problem: vim syntax highlighting does not recognise trim in py heredocs
Solution: recognise optional "trim" argument
```

Before:

<img width="243" alt="Screenshot 2021-11-25 at 13 12 57" src="https://user-images.githubusercontent.com/10584846/143447832-3a76a625-0a16-49cb-b801-625dcffd1436.png">

After:

<img width="224" alt="Screenshot 2021-11-25 at 13 15 57" src="https://user-images.githubusercontent.com/10584846/143448313-0943ef58-f76a-40b4-9538-a5e6db02245f.png">

test file:

```viml
py3 << EOF
import os
pass
EOF

py3 << trim EOF
import os
pass
EOF

pyx <<EOF
import os
pass
EOF

python <<EOF
import os
pass
EOF

python << trim EOF
import os
pass
EOF

pyx <<trimEOF
import os
pass
EOF

pyx <<
import os
pass
.

Py2or3 <<MARKER
import os
pass
MARKER

Py2or3 <<
import os
pass
.

py3 pass
```

I believe @cecamp is the owner for this runtime file.
