### PR TITLE
Update the titls when dragging the scrollbars

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -4412,6 +4412,8 @@ gui_update_scrollbars(
 					    val, size, max);
 	}
     }
+    // Update the title
+    maketitle();
     prev_curwin = curwin;
     --hold_gui_events;
 }


### PR DESCRIPTION
as mentioned on vim/vim#5383 dragging the scrollbars does not update the
title and iconstring options.

So enable this, by calling maketitle() if the scrollbars are moved with
the mouse.