### PR TITLE
vimgrep: properly fail on windows if pattern does not match

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -6122,9 +6122,8 @@ vgr_process_args(
     }
 
     // Parse the list of arguments, wildcards have already been expanded.
-    if (get_arglist_exp(p, &args->fcount, &args->fnames, TRUE) == FAIL)
-	return FAIL;
-    if (args->fcount == 0)
+    if ((get_arglist_exp(p, &args->fcount, &args->fnames, TRUE) == FAIL) ||
+	args->fcount == 0)
     {
 	emsg(_(e_nomatch));
 	return FAIL;

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -5621,4 +5621,19 @@ func Test_win_gettype()
   lclose
 endfunc
 
+fun Test_vimgrep_nomatch()
+  call XexprTests('c')
+  call g:Xsetlist([{'lnum':10,'text':'Line1'}])
+  copen
+  if has("win32")
+    call assert_fails('vimgrep foo *.zzz', 'E479:')
+    let expected = [{'lnum': 10, 'bufnr': 0, 'end_lnum': 0, 'pattern': '', 'valid': 0, 'vcol': 0, 'nr': 0, 'module': '', 'type': '', 'end_col': 0, 'col': 0, 'text': 'Line1'}]
+  else
+    call assert_fails('vimgrep foo *.zzz', 'E480:')
+    let expected = []
+  endif
+  call assert_equal(expected, getqflist())
+  cclose
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
See: vim/vim#8762