### PR TITLE
Fix: spellcheck technical words

### DIFF
--- a/runtime/doc/xxd-fr.1
+++ b/runtime/doc/xxd-fr.1
@@ -111,7 +111,7 @@ octets.
 .TP
 .IR \-p " | " \-ps " | " \-postscript " | " \-plain
 Produit une conversion continue dans le style Postscript (postscript continuous
-hexdumd style).
+hexdump style).
 Également connu sous le nom de « conversion brute » (plain hexdump style).
 .TP
 .IR \-r " | " \-revert

--- a/runtime/doc/xxd-fr.UTF-8.1
+++ b/runtime/doc/xxd-fr.UTF-8.1
@@ -111,7 +111,7 @@ octets.
 .TP
 .IR \-p " | " \-ps " | " \-postscript " | " \-plain
 Produit une conversion continue dans le style Postscript (postscript continuous
-hexdumd style).
+hexdump style).
 Également connu sous le nom de « conversion brute » (plain hexdump style).
 .TP
 .IR \-r " | " \-revert


### PR DESCRIPTION
French is my native tongue but it's not a necessary skill here: the technical word 'hexdump' is wrongly written in the `xxd` french man pages.
This PR fixes that.