### PR TITLE
Mention that 'autowrite' does not affect hidden buffers

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -867,7 +867,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Note that for some commands the 'autowrite' option is not used, see
 	'autowriteall' for that.
 	Some buffers will not be written, specifically when 'buftype' is
-	"nowrite", "nofile", "terminal" or "prompt".
+	"nowrite", "nofile", "terminal" or "prompt", or if 'bufhidden' is
+	"hide".
 
 			 *'autowriteall'* *'awa'* *'noautowriteall'* *'noawa'*
 'autowriteall' 'awa'	boolean	(default off)


### PR DESCRIPTION
Update the docs for 'autowrite' to mention that buffers with 'bufhidden' set to
"hide" (and, by extension, when 'hidden' is set) are not automatically written.
