### PR TITLE
Add additional tests for setting 'tagfunc' to a funcref

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -379,7 +379,15 @@ or a function reference or a lambda function.  Examples:
 	set opfunc=MyOpFunc
 	set opfunc=function('MyOpFunc')
 	set opfunc=funcref('MyOpFunc')
-	let &opfunc = "{t -> MyOpFunc(t)}"
+	set opfunc={a\ ->\ MyOpFunc(a)}
+	" set using a funcref variable
+	let Fn = function('MyTagFunc')
+	let &tagfunc = string(Fn)
+	" set using a lambda expression
+	let &tagfunc = "{t -> MyTagFunc(t)}"
+	" set using a variable with lambda expression
+	let L = {a, b, c -> MyTagFunc(a, b , c)}
+	let &tagfunc = string(L)
 <
 
 Setting the filetype

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2257,13 +2257,12 @@ get_complete_funcname(int type)
 }
 
 /*
- * Execute user defined complete function 'completefunc' or 'omnifunc', and
- * get matches in "matches".
+ * Execute user defined complete function 'completefunc' or 'omnifunc' or
+ * 'thesaurusfunc', and get matches in "matches".
+ * 'type' is either CTRL_X_OMNI or CTRL_X_FUNCTION or CTRL_X_THESAURUS.
  */
     static void
-expand_by_function(
-    int		type,	    // CTRL_X_OMNI or CTRL_X_FUNCTION
-    char_u	*base)
+expand_by_function(int type, char_u *base)
 {
     list_T      *matchlist = NULL;
     dict_T	*matchdict = NULL;

--- a/src/option.c
+++ b/src/option.c
@@ -7187,7 +7187,7 @@ option_set_callback_func(char_u *optval UNUSED, callback_T *optcb UNUSED)
 	return OK;
     }
 
-    if (*optval == '{'
+    if (*optval == '{' || (in_vim9script() && *optval == '(')
 	    || (STRNCMP(optval, "function(", 9) == 0)
 	    || (STRNCMP(optval, "funcref(", 8) == 0))
 	// Lambda expression or a funcref

--- a/src/testdir/test_tagfunc.vim
+++ b/src/testdir/test_tagfunc.vim
@@ -239,10 +239,18 @@ func Test_tagfunc_callback()
   END
   call CheckScriptSuccess(lines)
 
+  " Using Vim9 lambda expression in legacy context should fail
+  set tagfunc=(a,\ b,\ c)\ =>\ g:MytagFunc2(a,\ b,\ c)
+  new | only
+  let g:MytagFunc3_args = []
+  call assert_fails("tag a17", "E117:")
+  call assert_equal([], g:MytagFunc3_args)
+
   " cleanup
   delfunc MytagFunc1
   delfunc MytagFunc2
   delfunc MytagFunc3
+  set tagfunc&
   %bw!
 endfunc
 

--- a/src/testdir/test_tagfunc.vim
+++ b/src/testdir/test_tagfunc.vim
@@ -1,5 +1,7 @@
 " Test 'tagfunc'
 
+source vim9.vim
+
 func TagFunc(pat, flag, info)
   let g:tagfunc_args = [a:pat, a:flag, a:info]
   let tags = []
@@ -124,32 +126,73 @@ func Test_tagfunc_callback()
     let g:MytagFunc1_args = [a:pat, a:flags, a:info]
     return v:null
   endfunc
-  let g:MytagFunc1_args = []
   set tagfunc=function('MytagFunc1')
-  call assert_fails('tag abc', 'E433:')
-  call assert_equal(['abc', '', {}], g:MytagFunc1_args)
+  new | only
+  let g:MytagFunc1_args = []
+  call assert_fails('tag a11', 'E433:')
+  call assert_equal(['a11', '', {}], g:MytagFunc1_args)
+
+  " Using a funcref variable to set 'tagfunc'
+  let Fn = function('MytagFunc1')
+  let &tagfunc = string(Fn)
+  new | only
+  let g:MytagFunc1_args = []
+  call assert_fails('tag a12', 'E433:')
+  call assert_equal(['a12', '', {}], g:MytagFunc1_args)
+  call assert_fails('let &tagfunc = Fn', 'E729:')
 
   " Test for using a funcref()
-  new
   func MytagFunc2(pat, flags, info)
     let g:MytagFunc2_args = [a:pat, a:flags, a:info]
     return v:null
   endfunc
-  let g:MytagFunc2_args = []
   set tagfunc=funcref('MytagFunc2')
-  call assert_fails('tag def', 'E433:')
-  call assert_equal(['def', '', {}], g:MytagFunc2_args)
+  new | only
+  let g:MytagFunc2_args = []
+  call assert_fails('tag a13', 'E433:')
+  call assert_equal(['a13', '', {}], g:MytagFunc2_args)
+
+  " Using a funcref variable to set 'tagfunc'
+  let Fn = funcref('MytagFunc2')
+  let &tagfunc = string(Fn)
+  new | only
+  let g:MytagFunc2_args = []
+  call assert_fails('tag a14', 'E433:')
+  call assert_equal(['a14', '', {}], g:MytagFunc2_args)
+  call assert_fails('let &tagfunc = Fn', 'E729:')
 
   " Test for using a lambda function
-  new
   func MytagFunc3(pat, flags, info)
     let g:MytagFunc3_args = [a:pat, a:flags, a:info]
     return v:null
   endfunc
+  set tagfunc={a,\ b,\ c\ ->\ MytagFunc3(a,\ b,\ c)}
+  new | only
   let g:MytagFunc3_args = []
-  let &tagfunc= '{a, b, c -> MytagFunc3(a, b, c)}'
-  call assert_fails('tag ghi', 'E433:')
-  call assert_equal(['ghi', '', {}], g:MytagFunc3_args)
+  call assert_fails('tag a15', 'E433:')
+  call assert_equal(['a15', '', {}], g:MytagFunc3_args)
+
+  " Set 'tagfunc' to a lambda expression
+  let &tagfunc = '{a, b, c -> MytagFunc3(a, b, c)}'
+  new | only
+  let g:MytagFunc3_args = []
+  call assert_fails('tag a16', 'E433:')
+  call assert_equal(['a16', '', {}], g:MytagFunc3_args)
+
+  " Set 'tagfunc' to a variable with a lambda expression
+  let Lambda = {a, b, c -> MytagFunc3(a, b, c)}
+  let &tagfunc = string(Lambda)
+  new | only
+  let g:MytagFunc3_args = []
+  call assert_fails("tag a17", "E433:")
+  call assert_equal(['a17', '', {}], g:MytagFunc3_args)
+  call assert_fails('let &tagfunc = Lambda', 'E729:')
+
+  " Test for using a lambda function with incorrect return value
+  let Lambda = {s -> strlen(s)}
+  let &tagfunc = string(Lambda)
+  new | only
+  call assert_fails("tag a17", "E987:")
 
   " Test for clearing the 'tagfunc' option
   set tagfunc=''
@@ -159,6 +202,42 @@ func Test_tagfunc_callback()
   call assert_fails("set tagfunc=funcref('abc')", "E700:")
   let &tagfunc = "{a -> 'abc'}"
   call assert_fails("echo taglist('a')", "E987:")
+
+  " Vim9 tests
+  let lines =<< trim END
+    vim9script
+
+    # Test for using function()
+    def MytagFunc1(pat: string, flags: string, info: dict<any>): any
+      g:MytagFunc1_args = [pat, flags, info]
+      return null
+    enddef
+    set tagfunc=function('MytagFunc1')
+    new | only
+    g:MytagFunc1_args = []
+    assert_fails('tag a10', 'E433:')
+    assert_equal(['a10', '', {}], g:MytagFunc1_args)
+
+    # Test for using a lambda
+    def MytagFunc2(pat: string, flags: string, info: dict<any>): any
+      g:MytagFunc2_args = [pat, flags, info]
+      return null
+    enddef
+    &tagfunc = '(a, b, c) => MytagFunc2(a, b, c)'
+    new | only
+    g:MytagFunc2_args = []
+    assert_fails('tag a20', 'E433:')
+    assert_equal(['a20', '', {}], g:MytagFunc2_args)
+
+    # Test for using a variable with a lambda expression
+    var Fn: func = (a, b, c) => MytagFunc2(a, b, c)
+    &tagfunc = string(Fn)
+    new | only
+    g:MytagFunc2_args = []
+    assert_fails('tag a30', 'E433:')
+    assert_equal(['a30', '', {}], g:MytagFunc2_args)
+  END
+  call CheckScriptSuccess(lines)
 
   " cleanup
   delfunc MytagFunc1


### PR DESCRIPTION
Add Vim9 lambda expression support. Update the help text.