### PR TITLE
Fix can't work list2blob() with range()

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -526,6 +526,7 @@ f_list2blob(typval_T *argvars, typval_T *rettv)
     if (l == NULL)
 	return;
 
+    CHECK_LIST_MATERIALIZE(l);
     FOR_ALL_LIST_ITEMS(l, li)
     {
 	int		error;

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -678,4 +678,8 @@ func Test_list2blob()
   call assert_equal(0z, list2blob(test_null_list()))
 endfunc
 
+func Test_list2blob_with_range()
+  call assert_equal(list2blob(range(4)), 0z00010203)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
### Steps to reproduce

1. launch vim with `vim --clean`
2. execute `:echo list2blob(range(4))`

### Expected behaviour

Displays `0z00010203`

### Operating system

Arch Linux

### Version of Vim

v8.2.3724

### Logs and stack traces

```shell
E685: Internal error: tv_get_number(UNKNOWN)
0z
```