### PR TITLE
Fixed failing test `Test_getcwd_actual_dir()`

### DIFF
--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -226,6 +226,8 @@ func Test_cd_unknown_dir()
 endfunc
 
 func Test_getcwd_actual_dir()
+  CheckOption autochdir
+
   let startdir = getcwd()
   call mkdir('Xactual')
   call test_autochdir()


### PR DESCRIPTION
This PR fixes test `Test_getcwd_actual_dir()` which failed with
Vim-8.2.3732 when Vim is configured with:
```
$ ./configure --with-features=normal --enable-gui=none --disable-netbeans
```

```
$ make test_cd

1 FAILED:
Found errors in Test_getcwd_actual_dir():
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[455]..function RunTheTest[44]..Test_getcwd_actual_dir line 6: Pattern 'testdir.Xactual$' does not match '/home/pel/sb/vim/src/testdir'
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[455]..function RunTheTest[44]..Test_getcwd_actual_dir line 8: Pattern 'testdir$' does not match '/home/pel/sb/vim/src'
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[455]..function RunTheTest[44]..Test_getcwd_actual_dir line 10: Pattern 'testdir.Xactual$' does not match '/home/pel/sb/vim/src'
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[455]..function RunTheTest[44]..Test_getcwd_actual_dir line 11: Pattern 'testdir$' does not match '/home/pel/sb/vim/src'
Makefile:63: recipe for target 'test_cd' failed
make: *** [test_cd] Error 1
```