### PR TITLE
fix issue where creating highlight with empty string

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -3434,6 +3434,9 @@ syn_add_group(char_u *name)
     char_u	*p;
     char_u	*name_up;
 
+    if (*name == '\0')
+	return 0;
+
     // Check that the name is ASCII letters, digits and underscore.
     for (p = name; *p != NUL; ++p)
     {


### PR DESCRIPTION
Follow the steps below to create a highlight group with an empty string as the highlight group name. I can't determine if this is a bug in vim, but this highlight group can be treated the same as `syn_id==0` since there is no way to change it with the `:hi` command. Therefore, I don't think it is necessary to create a highlight group with such an empty string in its name.

```
vim -u DEFAULTS
:sign define ReproSign text=R  texthl=
:hi
...
               xxx cleared
```