### PR TITLE
`Test_set_filename_other_window` failed without the channel feature

### DIFF
--- a/src/testdir/test_autochdir.vim
+++ b/src/testdir/test_autochdir.vim
@@ -26,7 +26,9 @@ func Test_set_filename()
 endfunc
 
 func Test_set_filename_other_window()
-  call ch_logfile('logfile', 'w')
+  if has('channel')
+    call ch_logfile('logfile', 'w')
+  endif
   let cwd = getcwd()
   call test_autochdir()
   call mkdir('Xa')


### PR DESCRIPTION
`Test_set_filename_other_window` failed without the channel feature
as it calls `ch_logfile()` without checking that the channel feature is enabled.

Steps to reproduce:
```
$./configure --with-features=huge --disable-channel
$ make -j8
$ make test_autochdir
rm -f test_autochdir.res test.log messages
VIMRUNTIME=../../runtime  ../vim -f  -u unix.vim -U NONE --noplugin --not-a-term -S runtest.vim test_autochdir.vim --cmd 'au SwapExists * let v:swapchoice = "e"' | LC_ALL=C LANG=C LANGUAGE=C awk '/Executing Test_/{match($0, "Executing Test_[^\\)]*\\)"); print substr($0, RSTART, RLENGTH) "\r"; fflush()}'
Executing Test_set_filename()
Executing Test_set_filename_other_window()
Executing Test_verbose_pwd()


From test_autochdir.vim:
Executed Test_set_filename()                       in   0.005778 seconds
Executed Test_set_filename_other_window()          in   0.000336 seconds
Executed Test_verbose_pwd()                        in   0.002099 seconds
Executed 3 tests                         in   0.015260 seconds
1 FAILED:
Found errors in Test_set_filename_other_window():
Caught exception in Test_set_filename_other_window(): Vim(call):E117: Unknown function: ch_logfile @ command line..script /home/pel/sb/vim/src/testdir/runtest.vim[455]..function RunTheTest[44]..Test_set_filename_other_window, line 1
Makefile:63: recipe for target 'test_autochdir' failed
make: *** [test_autochdir] Error 1
```