### PR TITLE
CI: Fix Test_ignore_dec_mouse on FreeBSD

### DIFF
--- a/src/testdir/test_autochdir.vim
+++ b/src/testdir/test_autochdir.vim
@@ -43,12 +43,12 @@ func Test_set_filename_other_window()
   finally
     set noacd
     call chdir(cwd)
-    call delete('Xa', 'rf')
-    call delete('Xb', 'rf')
-    call delete('Xc', 'rf')
     bwipe! aaa.txt
     bwipe! bbb.txt
     bwipe! ccc.txt
+    call delete('Xa', 'rf')
+    call delete('Xb', 'rf')
+    call delete('Xc', 'rf')
   endtry
 endfunc
 

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2041,6 +2041,10 @@ endfunc
 
 " Check that when DEC mouse codes are recognized a special key is handled.
 func Test_ignore_dec_mouse()
+  silent !infocmp gnome >/dev/null 2>&1
+  if v:shell_error != 0
+    throw 'Skipped: gnome entry missing in the terminfo db'
+  endif
 
   new
   let save_mouse = &mouse


### PR DESCRIPTION
### Test_ignore_dec_mouse

FreeBSD doesn't have 'gnome' entry in the termcap db by default, so should check if 'gnome' entry exists by `infocmp gnome` command.

### Test_set_filename_other_window

On Windows must wipe out the buffer to cleanup file handles before delete directory.