### PR TITLE
Add support for setting an option to a lambda with :let

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -386,10 +386,10 @@ a function name or a function reference or a lambda function.  Examples:
 	let Fn = function('MyTagFunc')
 	let &tagfunc = string(Fn)
 	" set using a lambda expression
-	let &tagfunc = "{t -> MyTagFunc(t)}"
+	let &tagfunc = {t -> MyTagFunc(t)}
 	" set using a variable with lambda expression
 	let L = {a, b, c -> MyTagFunc(a, b , c)}
-	let &tagfunc = string(L)
+	let &tagfunc = L
 <
 
 Setting the filetype

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -1391,11 +1391,14 @@ ex_let_option(
 	char_u	    *stringval = NULL;
 	char_u	    *s = NULL;
 	int	    failed = FALSE;
+	int	    opt_p_flags;
+	char_u	    *tofree = NULL;
 
 	c1 = *p;
 	*p = NUL;
 
-	opt_type = get_option_value(arg, &numval, &stringval, opt_flags);
+	opt_type = get_option_value(arg, &numval, &stringval, &opt_p_flags,
+								opt_flags);
 	if ((opt_type == gov_bool
 		    || opt_type == gov_number
 		    || opt_type == gov_hidden_bool
@@ -1410,9 +1413,20 @@ ex_let_option(
 		n = (long)tv_get_number(tv);
 	}
 
+	if (opt_p_flags & P_FUNC && (tv->v_type == VAR_PARTIAL
+						|| tv->v_type == VAR_FUNC))
+	{
+	    char_u	numbuf[NUMBUFLEN];
+
+	    // If the option can be set to a function reference or a lambda
+	    // and the passed value is a function reference, then convert it to
+	    // the name (string) of the function reference.
+
+	    s = tv2string(tv, &tofree, numbuf, 0);
+	}
 	// Avoid setting a string option to the text "v:false" or similar.
 	// In Vim9 script also don't convert a number to string.
-	if (tv->v_type != VAR_BOOL && tv->v_type != VAR_SPECIAL
+	else if (tv->v_type != VAR_BOOL && tv->v_type != VAR_SPECIAL
 			 && (!in_vim9script() || tv->v_type != VAR_NUMBER))
 	    s = tv_get_string_chk(tv);
 
@@ -1466,6 +1480,7 @@ ex_let_option(
 	}
 	*p = c1;
 	vim_free(stringval);
+	vim_free(tofree);
     }
     return arg_end;
 }

--- a/src/if_mzsch.c
+++ b/src/if_mzsch.c
@@ -1755,7 +1755,7 @@ get_option(void *data, int argc, Scheme_Object **argv)
     }
 
     rc = get_option_value(BYTE_STRING_VALUE(name), &value, (char_u **)&strval,
-								    opt_flags);
+							NULL, opt_flags);
     curbuf = save_curb;
     curwin = save_curw;
 

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -875,7 +875,7 @@ vim_str2rb_enc_str(const char *s)
     char_u *sval;
     rb_encoding *enc;
 
-    if (get_option_value((char_u *)"enc", &lval, &sval, 0) == gov_string)
+    if (get_option_value((char_u *)"enc", &lval, &sval, NULL, 0) == gov_string)
     {
 	enc = rb_enc_find((char *)sval);
 	vim_free(sval);
@@ -895,7 +895,7 @@ eval_enc_string_protect(const char *str, int *state)
     rb_encoding *enc;
     VALUE v;
 
-    if (get_option_value((char_u *)"enc", &lval, &sval, 0) == gov_string)
+    if (get_option_value((char_u *)"enc", &lval, &sval, NULL, 0) == gov_string)
     {
 	enc = rb_enc_find((char *)sval);
 	vim_free(sval);

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -1308,7 +1308,7 @@ tclsetoption(
 
     option = (char_u *)Tcl_GetStringFromObj(objv[objn], NULL);
     ++objn;
-    gov = get_option_value(option, &lval, &sval, 0);
+    gov = get_option_value(option, &lval, &sval, NULL, 0);
     err = TCL_OK;
     switch (gov)
     {

--- a/src/option.c
+++ b/src/option.c
@@ -3937,12 +3937,15 @@ findoption(char_u *arg)
  * Hidden Toggle option: gov_hidden_bool.
  * Hidden String option: gov_hidden_string.
  * Unknown option: gov_unknown.
+ *
+ * 'opt_p_flags' (if not NULL) is set to the option flags (P_xxxx).
  */
     getoption_T
 get_option_value(
     char_u	*name,
     long	*numval,
     char_u	**stringval,	    // NULL when only checking existence
+    int		*opt_p_flags,
     int		opt_flags)
 {
     int		opt_idx;
@@ -3982,6 +3985,10 @@ get_option_value(
     }
 
     varp = get_varp_scope(&(options[opt_idx]), opt_flags);
+
+    if (opt_p_flags != NULL)
+	// Return the P_xxxx option flags.
+	*opt_p_flags = options[opt_idx].flags;
 
     if (options[opt_idx].flags & P_STRING)
     {

--- a/src/option.h
+++ b/src/option.h
@@ -59,6 +59,7 @@
 #define P_NDNAME      0x8000000L // only normal dir name chars allowed
 #define P_RWINONLY   0x10000000L // only redraw current window
 #define P_MLE	     0x20000000L // under control of 'modelineexpr'
+#define P_FUNC	     0x40000000L // accept a function reference or a lambda
 
 // Returned by get_option_value().
 typedef enum {

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -684,7 +684,7 @@ static struct vimoption options[] =
 #endif
 			    {(char_u *)0L, (char_u *)0L}
 			    SCTX_INIT},
-    {"completefunc", "cfu", P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
+    {"completefunc", "cfu", P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE|P_FUNC,
 #ifdef FEAT_COMPL_FUNC
 			    (char_u *)&p_cfu, PV_CFU,
 			    {(char_u *)"", (char_u *)0L}
@@ -1321,7 +1321,7 @@ static struct vimoption options[] =
     {"ignorecase",  "ic",   P_BOOL|P_VI_DEF,
 			    (char_u *)&p_ic, PV_NONE,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
-    {"imactivatefunc","imaf",P_STRING|P_VI_DEF|P_SECURE,
+    {"imactivatefunc","imaf",P_STRING|P_VI_DEF|P_SECURE|P_FUNC,
 #if defined(FEAT_EVAL)
 			    (char_u *)&p_imaf, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
@@ -1356,7 +1356,7 @@ static struct vimoption options[] =
 			    (char_u *)&p_imsearch, PV_IMS,
 			    {(char_u *)B_IMODE_USE_INSERT, (char_u *)0L}
 			    SCTX_INIT},
-    {"imstatusfunc","imsf",P_STRING|P_VI_DEF|P_SECURE,
+    {"imstatusfunc","imsf",P_STRING|P_VI_DEF|P_SECURE|P_FUNC,
 #if defined(FEAT_EVAL)
 			    (char_u *)&p_imsf, PV_NONE,
 			    {(char_u *)"", (char_u *)NULL}
@@ -1822,7 +1822,7 @@ static struct vimoption options[] =
 			    (char_u *)NULL, PV_NONE,
 #endif
 			    {(char_u *)8L, (char_u *)4L} SCTX_INIT},
-    {"omnifunc",    "ofu",  P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
+    {"omnifunc",    "ofu",  P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE|P_FUNC,
 #ifdef FEAT_COMPL_FUNC
 			    (char_u *)&p_ofu, PV_OFU,
 			    {(char_u *)"", (char_u *)0L}
@@ -1842,7 +1842,7 @@ static struct vimoption options[] =
 #endif
 			    {(char_u *)FALSE, (char_u *)FALSE}
 			    SCTX_INIT},
-    {"operatorfunc", "opfunc", P_STRING|P_VI_DEF|P_SECURE,
+    {"operatorfunc", "opfunc", P_STRING|P_VI_DEF|P_SECURE|P_FUNC,
 			    (char_u *)&p_opfunc, PV_NONE,
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"optimize",    "opt",  P_BOOL|P_VI_DEF,
@@ -2055,7 +2055,7 @@ static struct vimoption options[] =
 #endif
 			    {(char_u *)DEFAULT_PYTHON_VER, (char_u *)0L}
 			    SCTX_INIT},
-    {"quickfixtextfunc", "qftf", P_STRING|P_ALLOCED|P_VI_DEF|P_VIM|P_SECURE,
+    {"quickfixtextfunc", "qftf", P_STRING|P_ALLOCED|P_VI_DEF|P_VIM|P_SECURE|P_FUNC,
 #if defined(FEAT_QUICKFIX) && defined(FEAT_EVAL)
 			    (char_u *)&p_qftf, PV_NONE,
 			    {(char_u *)"", (char_u *)0L}
@@ -2507,7 +2507,7 @@ static struct vimoption options[] =
     {"tagcase",	    "tc",   P_STRING|P_VIM,
 			    (char_u *)&p_tc, PV_TC,
 			    {(char_u *)"followic", (char_u *)"followic"} SCTX_INIT},
-    {"tagfunc",    "tfu",   P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
+    {"tagfunc",    "tfu",   P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE|P_FUNC,
 #ifdef FEAT_EVAL
 			    (char_u *)&p_tfu, PV_TFU,
 			    {(char_u *)"", (char_u *)0L}
@@ -2624,7 +2624,7 @@ static struct vimoption options[] =
     {"thesaurus",   "tsr",  P_STRING|P_EXPAND|P_VI_DEF|P_ONECOMMA|P_NODUP|P_NDNAME,
 			    (char_u *)&p_tsr, PV_TSR,
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
-    {"thesaurusfunc", "tsrfu",  P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
+    {"thesaurusfunc", "tsrfu",  P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE|P_FUNC,
 #ifdef FEAT_COMPL_FUNC
 			    (char_u *)&p_tsrfu, PV_TSRFU,
 			    {(char_u *)"", (char_u *)0L}

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -25,7 +25,7 @@ void set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T script_ctx);
 void set_term_option_sctx_idx(char *name, int opt_idx);
 void check_redraw(long_u flags);
 int findoption(char_u *arg);
-getoption_T get_option_value(char_u *name, long *numval, char_u **stringval, int opt_flags);
+getoption_T get_option_value(char_u *name, long *numval, char_u **stringval, int *opt_p_flags, int opt_flags);
 int get_option_value_strict(char_u *name, long *numval, char_u **stringval, int opt_type, void *from);
 char_u *option_iter_next(void **option, int opt_type);
 long_u get_option_flags(int opt_idx);

--- a/src/spell.c
+++ b/src/spell.c
@@ -3830,7 +3830,7 @@ ex_spelldump(exarg_T *eap)
 
     if (no_spell_checking(curwin))
 	return;
-    (void)get_option_value((char_u*)"spl", &dummy, &spl, OPT_LOCAL);
+    (void)get_option_value((char_u*)"spl", &dummy, &spl, NULL, OPT_LOCAL);
 
     // Create a new empty buffer in a new window.
     do_cmdline_cmd((char_u *)"new");

--- a/src/testdir/test_iminsert.vim
+++ b/src/testdir/test_iminsert.vim
@@ -130,12 +130,15 @@ func Test_imactivatefunc_imstatusfunc_callback()
 
   " Using a funcref variable to set 'completefunc'
   let Fn1 = function('IMactivatefunc1')
-  let &imactivatefunc = string(Fn1)
+  let &imactivatefunc = Fn1
   let Fn2 = function('IMstatusfunc1')
+  let &imstatusfunc = Fn2
+  normal! i
+
+  " Using a string(funcref variable) to set 'completefunc'
+  let &imactivatefunc = string(Fn1)
   let &imstatusfunc = string(Fn2)
   normal! i
-  call assert_fails('let &imactivatefunc = Fn1', 'E729:')
-  call assert_fails('let &imstatusfunc = Fn2', 'E729:')
 
   " Test for using a funcref()
   set imactivatefunc=funcref('IMactivatefunc1')
@@ -144,12 +147,15 @@ func Test_imactivatefunc_imstatusfunc_callback()
 
   " Using a funcref variable to set 'imactivatefunc'
   let Fn1 = funcref('IMactivatefunc1')
-  let &imactivatefunc = string(Fn1)
+  let &imactivatefunc = Fn1
   let Fn2 = funcref('IMstatusfunc1')
+  let &imstatusfunc = Fn2
+  normal! i
+
+  " Using a string(funcref variable) to set 'imactivatefunc'
+  let &imactivatefunc = string(Fn1)
   let &imstatusfunc = string(Fn2)
   normal! i
-  call assert_fails('let &imactivatefunc = Fn1', 'E729:')
-  call assert_fails('let &imstatusfunc = Fn2', 'E729:')
 
   " Test for using a lambda function
   set imactivatefunc={a\ ->\ IMactivatefunc1(a)}
@@ -157,6 +163,11 @@ func Test_imactivatefunc_imstatusfunc_callback()
   normal! i
 
   " Set 'imactivatefunc' and 'imstatusfunc' to a lambda expression
+  let &imactivatefunc = {a -> IMactivatefunc1(a)}
+  let &imstatusfunc = { -> IMstatusfunc1()}
+  normal! i
+
+  " Set 'imactivatefunc' and 'imstatusfunc' to a string(lambda expression)
   let &imactivatefunc = '{a -> IMactivatefunc1(a)}'
   let &imstatusfunc = '{ -> IMstatusfunc1()}'
   normal! i
@@ -164,11 +175,15 @@ func Test_imactivatefunc_imstatusfunc_callback()
   " Set 'imactivatefunc' 'imstatusfunc' to a variable with a lambda expression
   let Lambda1 = {a -> IMactivatefunc1(a)}
   let Lambda2 = { -> IMstatusfunc1()}
+  let &imactivatefunc = Lambda1
+  let &imstatusfunc = Lambda2
+  normal! i
+
+  " Set 'imactivatefunc' 'imstatusfunc' to a string(variable with a lambda
+  " expression)
   let &imactivatefunc = string(Lambda1)
   let &imstatusfunc = string(Lambda2)
   normal! i
-  call assert_fails('let &imactivatefunc = Lambda1', 'E729:')
-  call assert_fails('let &imstatusfunc = Lambda2', 'E729:')
 
   " Test for clearing the 'completefunc' option
   set imactivatefunc='' imstatusfunc=''
@@ -179,8 +194,8 @@ func Test_imactivatefunc_imstatusfunc_callback()
   call assert_fails("set imactivatefunc=funcref('abc')", "E700:")
   call assert_fails("set imstatusfunc=funcref('abc')", "E700:")
 
-  call assert_equal(7, g:IMactivatefunc_called)
-  call assert_equal(14, g:IMstatusfunc_called)
+  call assert_equal(11, g:IMactivatefunc_called)
+  call assert_equal(22, g:IMstatusfunc_called)
 
   " Vim9 tests
   let lines =<< trim END
@@ -216,12 +231,17 @@ func Test_imactivatefunc_imstatusfunc_callback()
            g:IMstatusfunc_called += 1
            return 1
         }
+    &imactivatefunc = Fn1
+    &imstatusfunc = Fn2
+    normal! i
+
+    # Test for using a string(variable with a lambda expression)
     &imactivatefunc = string(Fn1)
     &imstatusfunc = string(Fn2)
     normal! i
 
-    assert_equal(3, g:IMactivatefunc_called)
-    assert_equal(6, g:IMstatusfunc_called)
+    assert_equal(4, g:IMactivatefunc_called)
+    assert_equal(8, g:IMstatusfunc_called)
 
     set iminsert=0
     set imactivatefunc=

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -885,13 +885,22 @@ func Test_completefunc_callback()
 
   " Using a funcref variable to set 'completefunc'
   let Fn = function('MycompleteFunc1')
+  let &completefunc = Fn
+  new | only
+  call setline(1, 'two')
+  let g:MycompleteFunc1_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'two']], g:MycompleteFunc1_args)
+  bw!
+
+  " Using string(funcref_variable) to set 'completefunc'
+  let Fn = function('MycompleteFunc1')
   let &completefunc = string(Fn)
   new | only
   call setline(1, 'two')
   let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'two']], g:MycompleteFunc1_args)
-  call assert_fails('let &completefunc = Fn', 'E729:')
   bw!
 
   " Test for using a funcref()
@@ -909,13 +918,22 @@ func Test_completefunc_callback()
 
   " Using a funcref variable to set 'completefunc'
   let Fn = funcref('MycompleteFunc2')
+  let &completefunc = Fn
+  new | only
+  call setline(1, 'four')
+  let g:MycompleteFunc2_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'four']], g:MycompleteFunc2_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'completefunc'
+  let Fn = funcref('MycompleteFunc2')
   let &completefunc = string(Fn)
   new | only
   call setline(1, 'four')
   let g:MycompleteFunc2_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'four']], g:MycompleteFunc2_args)
-  call assert_fails('let &completefunc = Fn', 'E729:')
   bw!
 
   " Test for using a lambda function
@@ -932,6 +950,15 @@ func Test_completefunc_callback()
   bw!
 
   " Set 'completefunc' to a lambda expression
+  let &completefunc = {a, b -> MycompleteFunc3(a, b)}
+  new | only
+  call setline(1, 'six')
+  let g:MycompleteFunc3_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'six']], g:MycompleteFunc3_args)
+  bw!
+
+  " Set 'completefunc' to string(lambda_expression)
   let &completefunc = '{a, b -> MycompleteFunc3(a, b)}'
   new | only
   call setline(1, 'six')
@@ -942,18 +969,27 @@ func Test_completefunc_callback()
 
   " Set 'completefunc' to a variable with a lambda expression
   let Lambda = {a, b -> MycompleteFunc3(a, b)}
+  let &completefunc = Lambda
+  new | only
+  call setline(1, 'seven')
+  let g:MycompleteFunc3_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'seven']], g:MycompleteFunc3_args)
+  bw!
+
+  " Set 'completefunc' to a string(variable with a lambda expression)
+  let Lambda = {a, b -> MycompleteFunc3(a, b)}
   let &completefunc = string(Lambda)
   new | only
   call setline(1, 'seven')
   let g:MycompleteFunc3_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'seven']], g:MycompleteFunc3_args)
-  call assert_fails('let &completefunc = Lambda', 'E729:')
   bw!
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
-  let &completefunc = string(Lambda)
+  let &completefunc = Lambda
   new | only
   call setline(1, 'eight')
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
@@ -965,7 +1001,7 @@ func Test_completefunc_callback()
 
   call assert_fails("set completefunc=function('abc')", "E700:")
   call assert_fails("set completefunc=funcref('abc')", "E700:")
-  let &completefunc = "{a -> 'abc'}"
+  let &completefunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
 
   " Vim9 tests
@@ -990,6 +1026,15 @@ func Test_completefunc_callback()
       add(g:LambdaComplete1_args, [findstart, base])
       return findstart ? 0 : []
     enddef
+    &completefunc = (a, b) => LambdaComplete1(a, b)
+    new | only
+    setline(1, 'two')
+    g:LambdaComplete1_args = []
+    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'two']], g:LambdaComplete1_args)
+    bw!
+
+    # Test for using a string(lambda)
     &completefunc = '(a, b) => LambdaComplete1(a, b)'
     new | only
     setline(1, 'two')
@@ -1003,6 +1048,15 @@ func Test_completefunc_callback()
             add(g:LambdaComplete2_args, [findstart, base])
             return findstart ? 0 : []
         }
+    &completefunc = Fn
+    new | only
+    setline(1, 'three')
+    g:LambdaComplete2_args = []
+    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'three']], g:LambdaComplete2_args)
+    bw!
+
+    # Test for using a string(variable with a lambda expression)
     &completefunc = string(Fn)
     new | only
     setline(1, 'three')
@@ -1045,13 +1099,22 @@ func Test_omnifunc_callback()
 
   " Using a funcref variable to set 'omnifunc'
   let Fn = function('MyomniFunc1')
+  let &omnifunc = Fn
+  new | only
+  call setline(1, 'two')
+  let g:MyomniFunc1_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'two']], g:MyomniFunc1_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'omnifunc'
+  let Fn = function('MyomniFunc1')
   let &omnifunc = string(Fn)
   new | only
   call setline(1, 'two')
   let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'two']], g:MyomniFunc1_args)
-  call assert_fails('let &omnifunc = Fn', 'E729:')
   bw!
 
   " Test for using a funcref()
@@ -1069,13 +1132,22 @@ func Test_omnifunc_callback()
 
   " Using a funcref variable to set 'omnifunc'
   let Fn = funcref('MyomniFunc2')
+  let &omnifunc = Fn
+  new | only
+  call setline(1, 'four')
+  let g:MyomniFunc2_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'four']], g:MyomniFunc2_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'omnifunc'
+  let Fn = funcref('MyomniFunc2')
   let &omnifunc = string(Fn)
   new | only
   call setline(1, 'four')
   let g:MyomniFunc2_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'four']], g:MyomniFunc2_args)
-  call assert_fails('let &omnifunc = Fn', 'E729:')
   bw!
 
   " Test for using a lambda function
@@ -1092,6 +1164,15 @@ func Test_omnifunc_callback()
   bw!
 
   " Set 'omnifunc' to a lambda expression
+  let &omnifunc = {a, b -> MyomniFunc3(a, b)}
+  new | only
+  call setline(1, 'six')
+  let g:MyomniFunc3_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'six']], g:MyomniFunc3_args)
+  bw!
+
+  " Set 'omnifunc' to a string(lambda_expression)
   let &omnifunc = '{a, b -> MyomniFunc3(a, b)}'
   new | only
   call setline(1, 'six')
@@ -1102,18 +1183,27 @@ func Test_omnifunc_callback()
 
   " Set 'omnifunc' to a variable with a lambda expression
   let Lambda = {a, b -> MyomniFunc3(a, b)}
+  let &omnifunc = Lambda
+  new | only
+  call setline(1, 'seven')
+  let g:MyomniFunc3_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'seven']], g:MyomniFunc3_args)
+  bw!
+
+  " Set 'omnifunc' to a string(variable with a lambda expression)
+  let Lambda = {a, b -> MyomniFunc3(a, b)}
   let &omnifunc = string(Lambda)
   new | only
   call setline(1, 'seven')
   let g:MyomniFunc3_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'seven']], g:MyomniFunc3_args)
-  call assert_fails('let &omnifunc = Lambda', 'E729:')
   bw!
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
-  let &omnifunc = string(Lambda)
+  let &omnifunc = Lambda
   new | only
   call setline(1, 'eight')
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
@@ -1125,7 +1215,7 @@ func Test_omnifunc_callback()
 
   call assert_fails("set omnifunc=function('abc')", "E700:")
   call assert_fails("set omnifunc=funcref('abc')", "E700:")
-  let &omnifunc = "{a -> 'abc'}"
+  let &omnifunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
 
   " Vim9 tests
@@ -1150,6 +1240,15 @@ func Test_omnifunc_callback()
       add(g:MyomniFunc2_args, [findstart, base])
       return findstart ? 0 : []
     enddef
+    &omnifunc = (a, b) => MyomniFunc2(a, b)
+    new | only
+    setline(1, 'two')
+    g:MyomniFunc2_args = []
+    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'two']], g:MyomniFunc2_args)
+    bw!
+
+    # Test for using a string(lambda)
     &omnifunc = '(a, b) => MyomniFunc2(a, b)'
     new | only
     setline(1, 'two')
@@ -1160,6 +1259,15 @@ func Test_omnifunc_callback()
 
     # Test for using a variable with a lambda expression
     var Fn: func = (a, b) => MyomniFunc2(a, b)
+    &omnifunc = Fn
+    new | only
+    setline(1, 'three')
+    g:MyomniFunc2_args = []
+    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'three']], g:MyomniFunc2_args)
+    bw!
+
+    # Test for using a string(variable with a lambda expression)
     &omnifunc = string(Fn)
     new | only
     setline(1, 'three')
@@ -1202,13 +1310,22 @@ func Test_thesaurusfunc_callback()
 
   " Using a funcref variable to set 'thesaurusfunc'
   let Fn = function('MytsrFunc1')
+  let &thesaurusfunc = Fn
+  new | only
+  call setline(1, 'two')
+  let g:MytsrFunc1_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'two']], g:MytsrFunc1_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'thesaurusfunc'
+  let Fn = function('MytsrFunc1')
   let &thesaurusfunc = string(Fn)
   new | only
   call setline(1, 'two')
   let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'two']], g:MytsrFunc1_args)
-  call assert_fails('let &thesaurusfunc = Fn', 'E729:')
   bw!
 
   " Test for using a funcref()
@@ -1226,13 +1343,22 @@ func Test_thesaurusfunc_callback()
 
   " Using a funcref variable to set 'thesaurusfunc'
   let Fn = funcref('MytsrFunc2')
+  let &thesaurusfunc = Fn
+  new | only
+  call setline(1, 'four')
+  let g:MytsrFunc2_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'four']], g:MytsrFunc2_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'thesaurusfunc'
+  let Fn = funcref('MytsrFunc2')
   let &thesaurusfunc = string(Fn)
   new | only
   call setline(1, 'four')
   let g:MytsrFunc2_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'four']], g:MytsrFunc2_args)
-  call assert_fails('let &thesaurusfunc = Fn', 'E729:')
   bw!
 
   " Test for using a lambda function
@@ -1249,6 +1375,15 @@ func Test_thesaurusfunc_callback()
   bw!
 
   " Set 'thesaurusfunc' to a lambda expression
+  let &thesaurusfunc = {a, b -> MytsrFunc3(a, b)}
+  new | only
+  call setline(1, 'six')
+  let g:MytsrFunc3_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'six']], g:MytsrFunc3_args)
+  bw!
+
+  " Set 'thesaurusfunc' to a string(lambda expression)
   let &thesaurusfunc = '{a, b -> MytsrFunc3(a, b)}'
   new | only
   call setline(1, 'six')
@@ -1259,18 +1394,27 @@ func Test_thesaurusfunc_callback()
 
   " Set 'thesaurusfunc' to a variable with a lambda expression
   let Lambda = {a, b -> MytsrFunc3(a, b)}
+  let &thesaurusfunc = Lambda
+  new | only
+  call setline(1, 'seven')
+  let g:MytsrFunc3_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'seven']], g:MytsrFunc3_args)
+  bw!
+
+  " Set 'thesaurusfunc' to a string(variable with a lambda expression)
+  let Lambda = {a, b -> MytsrFunc3(a, b)}
   let &thesaurusfunc = string(Lambda)
   new | only
   call setline(1, 'seven')
   let g:MytsrFunc3_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'seven']], g:MytsrFunc3_args)
-  call assert_fails('let &thesaurusfunc = Lambda', 'E729:')
   bw!
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
-  let &thesaurusfunc = string(Lambda)
+  let &thesaurusfunc = Lambda
   new | only
   call setline(1, 'eight')
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
@@ -1282,7 +1426,7 @@ func Test_thesaurusfunc_callback()
 
   call assert_fails("set thesaurusfunc=function('abc')", "E700:")
   call assert_fails("set thesaurusfunc=funcref('abc')", "E700:")
-  let &thesaurusfunc = "{a -> 'abc'}"
+  let &thesaurusfunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
 
   " Vim9 tests
@@ -1307,6 +1451,15 @@ func Test_thesaurusfunc_callback()
       add(g:MytsrFunc2_args, [findstart, base])
       return findstart ? 0 : []
     enddef
+    &thesaurusfunc = (a, b) => MytsrFunc2(a, b)
+    new | only
+    setline(1, 'two')
+    g:MytsrFunc2_args = []
+    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'two']], g:MytsrFunc2_args)
+    bw!
+
+    # Test for using a string(lambda)
     &thesaurusfunc = '(a, b) => MytsrFunc2(a, b)'
     new | only
     setline(1, 'two')
@@ -1317,6 +1470,15 @@ func Test_thesaurusfunc_callback()
 
     # Test for using a variable with a lambda expression
     var Fn: func = (a, b) => MytsrFunc2(a, b)
+    &thesaurusfunc = Fn
+    new | only
+    setline(1, 'three')
+    g:MytsrFunc2_args = []
+    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'three']], g:MytsrFunc2_args)
+    bw!
+
+    # Test for using a string(variable with a lambda expression)
     &thesaurusfunc = string(Fn)
     new | only
     setline(1, 'three')

--- a/src/testdir/test_tagfunc.vim
+++ b/src/testdir/test_tagfunc.vim
@@ -140,12 +140,19 @@ func Test_tagfunc_callback()
 
   " Using a funcref variable to set 'tagfunc'
   let Fn = function('MytagFunc1')
+  let &tagfunc = Fn
+  new | only
+  let g:MytagFunc1_args = []
+  call assert_fails('tag a12', 'E433:')
+  call assert_equal(['a12', '', {}], g:MytagFunc1_args)
+
+  " Using a string(funcref_variable) to set 'tagfunc'
+  let Fn = function('MytagFunc1')
   let &tagfunc = string(Fn)
   new | only
   let g:MytagFunc1_args = []
   call assert_fails('tag a12', 'E433:')
   call assert_equal(['a12', '', {}], g:MytagFunc1_args)
-  call assert_fails('let &tagfunc = Fn', 'E729:')
 
   " Test for using a funcref()
   func MytagFunc2(pat, flags, info)
@@ -160,12 +167,19 @@ func Test_tagfunc_callback()
 
   " Using a funcref variable to set 'tagfunc'
   let Fn = funcref('MytagFunc2')
+  let &tagfunc = Fn
+  new | only
+  let g:MytagFunc2_args = []
+  call assert_fails('tag a14', 'E433:')
+  call assert_equal(['a14', '', {}], g:MytagFunc2_args)
+
+  " Using a string(funcref_variable) to set 'tagfunc'
+  let Fn = funcref('MytagFunc2')
   let &tagfunc = string(Fn)
   new | only
   let g:MytagFunc2_args = []
   call assert_fails('tag a14', 'E433:')
   call assert_equal(['a14', '', {}], g:MytagFunc2_args)
-  call assert_fails('let &tagfunc = Fn', 'E729:')
 
   " Test for using a script local function
   set tagfunc=<SID>ScriptLocalTagFunc
@@ -175,6 +189,14 @@ func Test_tagfunc_callback()
   call assert_equal(['a15', '', {}], g:ScriptLocalFuncArgs)
 
   " Test for using a script local funcref variable
+  let Fn = function("s:ScriptLocalTagFunc")
+  let &tagfunc= Fn
+  new | only
+  let g:ScriptLocalFuncArgs = []
+  call assert_fails('tag a16', 'E433:')
+  call assert_equal(['a16', '', {}], g:ScriptLocalFuncArgs)
+
+  " Test for using a string(script local funcref variable)
   let Fn = function("s:ScriptLocalTagFunc")
   let &tagfunc= string(Fn)
   new | only
@@ -194,6 +216,13 @@ func Test_tagfunc_callback()
   call assert_equal(['a17', '', {}], g:MytagFunc3_args)
 
   " Set 'tagfunc' to a lambda expression
+  let &tagfunc = {a, b, c -> MytagFunc3(a, b, c)}
+  new | only
+  let g:MytagFunc3_args = []
+  call assert_fails('tag a18', 'E433:')
+  call assert_equal(['a18', '', {}], g:MytagFunc3_args)
+
+  " Set 'tagfunc' to a string(lambda expression)
   let &tagfunc = '{a, b, c -> MytagFunc3(a, b, c)}'
   new | only
   let g:MytagFunc3_args = []
@@ -202,12 +231,19 @@ func Test_tagfunc_callback()
 
   " Set 'tagfunc' to a variable with a lambda expression
   let Lambda = {a, b, c -> MytagFunc3(a, b, c)}
+  let &tagfunc = Lambda
+  new | only
+  let g:MytagFunc3_args = []
+  call assert_fails("tag a19", "E433:")
+  call assert_equal(['a19', '', {}], g:MytagFunc3_args)
+
+  " Set 'tagfunc' to a string(variable with a lambda expression)
+  let Lambda = {a, b, c -> MytagFunc3(a, b, c)}
   let &tagfunc = string(Lambda)
   new | only
   let g:MytagFunc3_args = []
   call assert_fails("tag a19", "E433:")
   call assert_equal(['a19', '', {}], g:MytagFunc3_args)
-  call assert_fails('let &tagfunc = Lambda', 'E729:')
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
@@ -244,6 +280,13 @@ func Test_tagfunc_callback()
       g:MytagFunc2_args = [pat, flags, info]
       return null
     enddef
+    &tagfunc = (a, b, c) => MytagFunc2(a, b, c)
+    new | only
+    g:MytagFunc2_args = []
+    assert_fails('tag a20', 'E433:')
+    assert_equal(['a20', '', {}], g:MytagFunc2_args)
+
+    # Test for using a string(lambda)
     &tagfunc = '(a, b, c) => MytagFunc2(a, b, c)'
     new | only
     g:MytagFunc2_args = []
@@ -252,6 +295,13 @@ func Test_tagfunc_callback()
 
     # Test for using a variable with a lambda expression
     var Fn: func = (a, b, c) => MytagFunc2(a, b, c)
+    &tagfunc = Fn
+    new | only
+    g:MytagFunc2_args = []
+    assert_fails('tag a30', 'E433:')
+    assert_equal(['a30', '', {}], g:MytagFunc2_args)
+
+    # Test for using a variable with a lambda expression
     &tagfunc = string(Fn)
     new | only
     g:MytagFunc2_args = []

--- a/src/typval.c
+++ b/src/typval.c
@@ -1659,7 +1659,7 @@ eval_option(
     c = *option_end;
     *option_end = NUL;
     opt_type = get_option_value(*arg, &numval,
-			       rettv == NULL ? NULL : &stringval, opt_flags);
+			rettv == NULL ? NULL : &stringval, NULL, opt_flags);
 
     if (opt_type == gov_unknown)
     {

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -6112,7 +6112,7 @@ get_var_dest(
 	cc = *p;
 	*p = NUL;
 	opt_type = get_option_value(skip_option_env_lead(name),
-						    &numval, NULL, *opt_flags);
+					    &numval, NULL, NULL, *opt_flags);
 	*p = cc;
 	switch (opt_type)
 	{


### PR DESCRIPTION
Before this patch, the 'completefunc', 'imactivatefunc', 'imstatusfunc', 'omnifunc', 'operatorfunc', 'quickfixtextfunc',
'tagfunc' and 'thesaurusfunc' options can be set only to a string value using the :let command. For example,

let Fn = function('Mytagfunc')
let &tagfunc = string(Fn)
let &tagfunc = '{a, b, c -> Mytagfunc(a, b, c)}'
let Lambda = {a, b, c -> Mytagfunc(a, b, c)}
let &tagfunc = string(Lambda)

With this patch, these options can also be set to a function reference or lambda without converting it to a string type:

let Fn = function('Mytagfunc')
let &tagfunc = Fn
let &tagfunc = {a, b, c -> Mytagfunc(a, b, c)}
let Lambda = {a, b, c -> Mytagfunc(a, b, c)}
let &tagfunc = Lambda
