### PR TITLE
Fix build error on QNX 6.5 SP1

### DIFF
--- a/src/beval.c
+++ b/src/beval.c
@@ -150,7 +150,7 @@ get_beval_info(
     int		row = mouse_row;
     int		col = mouse_col;
 
-# ifdef FEAT_GUI
+# ifdef FEAT_GUI_HAIKU
     if (gui.in_use)
     {
 	row = Y_2_ROW(beval->y);

--- a/src/beval.c
+++ b/src/beval.c
@@ -150,7 +150,7 @@ get_beval_info(
     int		row = mouse_row;
     int		col = mouse_col;
 
-# ifdef FEAT_GUI_HAIKU
+# if defined(FEAT_BEVAL_GUI) || defined(FEAT_GUI_HAIKU)
     if (gui.in_use)
     {
 	row = Y_2_ROW(beval->y);


### PR DESCRIPTION
Build error occurs on QNX 6.5 SP1.

```
# ./configure
........
# make
Starting make in the src directory.
If there are problems, cd to the src directory and run make there
cd src && make first
make[1]: Entering directory `/root/temp/vim/src'
/bin/sh install-sh -c -d objects
touch objects/.dirstamp
CC="gcc -std=gnu99 -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_PHOTON  -I/usr/local/include    " srcdir=. sh ./osdef.sh
gcc -std=gnu99 -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_PHOTON  -I/usr/local/include  -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/alloc.o alloc.c
gcc -std=gnu99 -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_PHOTON  -I/usr/local/include  -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/arabic.o arabic.c
gcc -std=gnu99 -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_PHOTON  -I/usr/local/include  -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/arglist.o arglist.c
gcc -std=gnu99 -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_PHOTON  -I/usr/local/include  -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/autocmd.o autocmd.c
gcc -std=gnu99 -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_PHOTON  -I/usr/local/include  -g -O2 -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/beval.o beval.c
beval.c: In function 'get_beval_info':
beval.c:156: error: 'BalloonEval' has no member named 'y'
beval.c:157: error: 'BalloonEval' has no member named 'x'
make[1]: *** [objects/beval.o] Error 1
make[1]: Leaving directory `/root/temp/vim/src'
make: *** [first] Error 2
```

```
# uname -snmr
QNX QNX_650_sp1 6.5.0 x86pc
```

--
Best regards,
Hirohito Higashi (h_east)