### PR TITLE
fix problem with long highlight group names

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -694,3 +694,5 @@ EXTERN char e_line_number_out_of_range[]
 	INIT(= N_("E1247: Line number out of range"));
 EXTERN char e_closure_called_from_invalid_context[]
 	INIT(= N_("E1248: Closure called from invalid context"));
+EXTERN char e_too_long_highlight_group_name[]
+	INIT(= N_("E1249: Too long highlight group name"));

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -18,6 +18,8 @@
 #define SG_GUI		4	// gui has been set
 #define SG_LINK		8	// link has been set
 
+#define MAX_SYN_NAME	200
+
 /*
  * The "term", "cterm" and "gui" arguments can be any combination of the
  * following names, separated by commas (but no spaces!).
@@ -3328,12 +3330,12 @@ set_hl_attr(
 syn_name2id(char_u *name)
 {
     int		i;
-    char_u	name_u[200];
+    char_u	name_u[MAX_SYN_NAME + 1];
 
     // Avoid using stricmp() too much, it's slow on some systems
     // Avoid alloc()/free(), these are slow too.  ID names over 200 chars
     // don't deserve to be found!
-    vim_strncpy(name_u, name, 199);
+    vim_strncpy(name_u, name, MAX_SYN_NAME);
     vim_strup(name_u);
     for (i = highlight_ga.ga_len; --i >= 0; )
 	if (HL_TABLE()[i].sg_name_u != NULL
@@ -3411,6 +3413,10 @@ syn_check_group(char_u *pp, int len)
     int	    id;
     char_u  *name;
 
+    if (len > MAX_SYN_NAME) {
+	emsg(_(e_too_long_highlight_group_name));
+	return 0;
+    }
     name = vim_strnsave(pp, len);
     if (name == NULL)
 	return 0;

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -740,6 +740,7 @@ func Test_highlight_cmd_errors()
     call assert_fails('hi Xcomment ctermbg=fg', 'E419:')
     call assert_fails('hi Xcomment ctermfg=bg', 'E420:')
     call assert_fails('hi Xcomment ctermfg=ul', 'E453:')
+    call assert_fails('hi ' .. repeat('a', 201) .. ' ctermfg=black', 'E1249:')
   endif
 
   " Try using a very long terminal code. Define a dummy terminal code for this


### PR DESCRIPTION
If you create a highlight group with a highlight group name longer than the buffer length (200 - 1 = 199) in `syn_name2id`, multiple highlight groups with the same name will be created. I think you need to limit the length of the highlight group name or allocate a variable length buffer.

```
vim -u DEFAULTS
:execute 'hi '.repeat('a', 200).' ctermbg=black'
:execute 'hi '.repeat('a', 200).' ctermbg=black'
:hi
...
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa xxx ctermbg=0
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa xxx ctermbg=0
```