### PR TITLE
Move a comment in getchar.c to the correct position

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2677,7 +2677,7 @@ handle_mapping(
 		if (mp == NULL)
 		{
 		    *keylenp = keylen;
-		    return map_result_get;    // got character, break for loop
+		    return map_result_get;    // got character
 		}
 	}
 
@@ -3060,7 +3060,7 @@ vgetorpeek(int advance)
 						      typebuf.tb_off];
 			    del_typebuf(1, 0);
 			}
-			break;
+			break;  // got character, break for loop
 		    }
 
 		    // not enough characters, get more


### PR DESCRIPTION
In line 2680 of getchar.c there is a comment saying "break for loop", but it is a return statement. I believe the "break for loop" belongs to line 3063.