### PR TITLE
Do not recognize floating point literals without radix separator in C

### DIFF
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -196,7 +196,6 @@ syn match	cNumber		display contained "0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
 " Flag the first zero of an octal number as something special
 syn match	cOctal		display contained "0\o\+\(u\=l\{0,2}\|ll\=u\)\>" contains=cOctalZero
 syn match	cOctalZero	display contained "\<0"
-syn match	cFloat		display contained "\d\+f"
 "floating point number, with dot, optional exponent
 syn match	cFloat		display contained "\d\+\.\d*\(e[-+]\=\d\+\)\=[fl]\="
 "floating point number, starting with a dot, optional exponent


### PR DESCRIPTION
Floating point literals in C must contain a radix separator (dot), even if they have an explicit `f` suffix. I.e. `1f` is not a legal floating point literal.

Neither clang nor gcc accept it:
https://godbolt.org/z/PefbcKaWY (clang)
https://godbolt.org/z/vGYn3zP5Y (gcc)
