### PR TITLE
Check for a valid tagfunc callback function before calling it.

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2329,14 +2329,12 @@ set_thesaurusfunc_option(void)
     if (*curbuf->b_p_tsrfu != NUL)
     {
 	// buffer-local option set
-	free_callback(&curbuf->b_tsrfu_cb);
 	retval = option_set_callback_func(curbuf->b_p_tsrfu,
 							&curbuf->b_tsrfu_cb);
     }
     else
     {
 	// global option set
-	free_callback(&tsrfu_cb);
 	retval = option_set_callback_func(p_tsrfu, &tsrfu_cb);
     }
 
@@ -2393,7 +2391,7 @@ expand_by_function(int type, char_u *base)
     callback_T	*cb;
     typval_T	rettv;
     int		save_State = State;
-    int		retval;
+    int		retval = FAIL;
 
     funcname = get_complete_funcname(type);
     if (*funcname == NUL)
@@ -2413,7 +2411,8 @@ expand_by_function(int type, char_u *base)
     ++textwinlock;
 
     cb = get_insert_callback(type);
-    retval = call_callback(cb, 0, &rettv, 2, args);
+    if (cb->cb_name != NULL && *cb->cb_name != NUL)
+	retval = call_callback(cb, 0, &rettv, 2, args);
 
     // Call a function, which returns a list or dict.
     if (retval == OK)
@@ -4093,7 +4092,7 @@ ins_complete(int c, int enable_pum)
 	    // Call user defined function 'completefunc' with "a:findstart"
 	    // set to 1 to obtain the length of text to use for completion.
 	    typval_T	args[3];
-	    int		col;
+	    int		col = -2;
 	    char_u	*funcname;
 	    pos_T	pos;
 	    int		save_State = State;
@@ -4119,7 +4118,8 @@ ins_complete(int c, int enable_pum)
 	    pos = curwin->w_cursor;
 	    ++textwinlock;
 	    cb = get_insert_callback(ctrl_x_mode);
-	    col = call_callback_retnr(cb, 2, args);
+	    if (cb->cb_name != NULL && *cb->cb_name != NUL)
+		col = call_callback_retnr(cb, 2, args);
 	    --textwinlock;
 
 	    State = save_State;

--- a/src/option.c
+++ b/src/option.c
@@ -7210,7 +7210,7 @@ option_set_callback_func(char_u *optval UNUSED, callback_T *optcb UNUSED)
 	return FAIL;
 
     cb = get_callback(tv);
-    if (cb.cb_name == NULL)
+    if (cb.cb_name == NULL || *cb.cb_name == NUL)
     {
 	free_tv(tv);
 	return FAIL;

--- a/src/tag.c
+++ b/src/tag.c
@@ -1361,7 +1361,8 @@ find_tagfunc_tags(
     dict_T	*d;
     taggy_T	*tag = &curwin->w_tagstack[curwin->w_tagstackidx];
 
-    if (*curbuf->b_p_tfu == NUL)
+    if (*curbuf->b_p_tfu == NUL || curbuf->b_tfu_cb.cb_name == NULL ||
+					*curbuf->b_tfu_cb.cb_name == NUL)
 	return FAIL;
 
     args[0].v_type = VAR_STRING;

--- a/src/testdir/test_iminsert.vim
+++ b/src/testdir/test_iminsert.vim
@@ -257,6 +257,19 @@ func Test_imactivatefunc_imstatusfunc_callback()
   set imstatusfunc=()\ =>\ IMstatusfunc1(a)
   call assert_fails('normal! i', 'E117:')
 
+  " set 'imactivatefunc' and 'imstatusfunc' to a non-existing function
+  set imactivatefunc=IMactivatefunc1
+  set imstatusfunc=IMstatusfunc1
+  call assert_fails("set imactivatefunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("set imstatusfunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &imactivatefunc = function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &imstatusfunc = function('NonExistingFunc')", 'E700:')
+  let g:IMactivatefunc_called = 0
+  let g:IMstatusfunc_called = 0
+  normal! i
+  call assert_equal(2, g:IMactivatefunc_called)
+  call assert_equal(2, g:IMstatusfunc_called)
+
   " cleanup
   delfunc IMactivatefunc1
   delfunc IMstatusfunc1

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -1074,6 +1074,15 @@ func Test_completefunc_callback()
   call assert_fails('call feedkeys("A\<C-X>\<C-U>\<Esc>", "x")', 'E117:')
   call assert_equal([], g:MycompleteFunc2_args)
 
+  " set 'completefunc' to a non-existing function
+  set completefunc=MycompleteFunc2
+  call setline(1, 'five')
+  call assert_fails("set completefunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &completefunc = function('NonExistingFunc')", 'E700:')
+  let g:MycompleteFunc2_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'five']], g:MycompleteFunc2_args)
+
   " cleanup
   delfunc MycompleteFunc1
   delfunc MycompleteFunc2
@@ -1284,6 +1293,15 @@ func Test_omnifunc_callback()
   let g:MyomniFunc2_args = []
   call assert_fails('call feedkeys("A\<C-X>\<C-O>\<Esc>", "x")', 'E117:')
   call assert_equal([], g:MyomniFunc2_args)
+
+  " set 'omnifunc' to a non-existing function
+  set omnifunc=MyomniFunc2
+  call setline(1, 'nine')
+  call assert_fails("set omnifunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &omnifunc = function('NonExistingFunc')", 'E700:')
+  let g:MyomniFunc2_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'nine']], g:MyomniFunc2_args)
 
   " cleanup
   delfunc MyomniFunc1
@@ -1522,6 +1540,16 @@ func Test_thesaurusfunc_callback()
   call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
   call assert_equal('sunday', getline(1))
   call assert_equal([[1, ''], [0, 'sun']], g:MytsrFunc4_args)
+  %bw!
+
+  " set 'thesaurusfunc' to a non-existing function
+  set thesaurusfunc=MytsrFunc2
+  call setline(1, 'ten')
+  call assert_fails("set thesaurusfunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &thesaurusfunc = function('NonExistingFunc')", 'E700:')
+  let g:MytsrFunc2_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'ten']], g:MytsrFunc2_args)
 
   " cleanup
   set thesaurusfunc&

--- a/src/testdir/test_tagfunc.vim
+++ b/src/testdir/test_tagfunc.vim
@@ -317,6 +317,11 @@ func Test_tagfunc_callback()
   call assert_fails("tag a17", "E117:")
   call assert_equal([], g:MytagFunc3_args)
 
+  " set 'tagfunc' to a non-existing function
+  call assert_fails("set tagfunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &tagfunc = function('NonExistingFunc')", 'E700:')
+  call assert_fails("tag axb123", 'E426:')
+
   " cleanup
   delfunc MytagFunc1
   delfunc MytagFunc2


### PR DESCRIPTION
Apply the same check for other callback functions. Fixes #9290 