### PR TITLE
add new python keywords

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -77,13 +77,14 @@ endif
 "
 " The list can be checked using:
 "
-" python3 -c 'import keyword, pprint; pprint.pprint(keyword.kwlist, compact=True)'
+" python3 -c 'import keyword, pprint; pprint.pprint(keyword.kwlist + keyword.softkwlist, compact=True)'
 "
 syn keyword pythonStatement	False None True
 syn keyword pythonStatement	as assert break continue del global
 syn keyword pythonStatement	lambda nonlocal pass return with yield
 syn keyword pythonStatement	class def nextgroup=pythonFunction skipwhite
 syn keyword pythonConditional	elif else if
+syn keyword pythonConditional	case match
 syn keyword pythonRepeat	for while
 syn keyword pythonOperator	and in is not or
 syn keyword pythonException	except finally raise try


### PR DESCRIPTION
Python 3.10 introduces the match and case keywords to make long
if...elif...elif chains easier to read and write. Other languages use
switch/case for this.