### PR TITLE
Don't unlist a quickfix buffer if it is still displayed in a window

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2818,7 +2818,7 @@ qf_get_entry(
 }
 
 /*
- * Find a window displaying a Vim help file.
+ * Find a window displaying a Vim help file in the current tab page.
  */
     static win_T *
 qf_find_help_win(void)
@@ -2893,8 +2893,8 @@ jump_to_help_window(qf_info_T *qi, int newwin, int *opened_window)
 }
 
 /*
- * Find a non-quickfix window in the current tabpage using the given location
- * list stack.
+ * Find a non-quickfix window using the given location list stack in the
+ * current tabpage.
  * Returns NULL if a matching window is not found.
  */
     static win_T *
@@ -2910,7 +2910,7 @@ qf_find_win_with_loclist(qf_info_T *ll)
 }
 
 /*
- * Find a window containing a normal buffer
+ * Find a window containing a normal buffer in the current tab page.
  */
     static win_T *
 qf_find_win_with_normal_buf(void)
@@ -2981,7 +2981,7 @@ qf_goto_win_with_ll_file(win_T *use_win, int qf_fnum, qf_info_T *ll_ref)
 
     if (win == NULL)
     {
-	// Find the window showing the selected file
+	// Find the window showing the selected file in the current tab page.
 	FOR_ALL_WINDOWS(win)
 	    if (win->w_buffer->b_fnum == qf_fnum)
 		break;
@@ -4394,8 +4394,8 @@ is_qf_win(win_T *win, qf_info_T *qi)
 }
 
 /*
- * Find a window displaying the quickfix/location stack 'qi'
- * Only searches in the current tabpage.
+ * Find a window displaying the quickfix/location stack 'qi' in the current tab
+ * page.
  */
     static win_T *
 qf_find_win(qf_info_T *qi)
@@ -4410,7 +4410,7 @@ qf_find_win(qf_info_T *qi)
 
 /*
  * Find a quickfix buffer.
- * Searches in windows opened in all the tabs.
+ * Searches in windows opened in all the tab pages.
  */
     static buf_T *
 qf_find_buf(qf_info_T *qi)

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -5636,4 +5636,40 @@ fun Test_vimgrep_nomatch()
   cclose
 endfunc
 
+" Test for opening the quickfix window in two tab pages and then closing one
+" of the quickfix windows. This should not make the quickfix buffer unlisted.
+" (github issue #9300).
+func Test_two_qf_windows()
+  cexpr "F1:1:line1"
+  copen
+  tabnew
+  copen
+  call assert_true(&buflisted)
+  cclose
+  tabfirst
+  call assert_true(&buflisted)
+  let bnum = bufnr()
+  cclose
+  " if all the quickfix windows are closed, then buffer should be unlisted.
+  call assert_false(buflisted(bnum))
+  %bw!
+
+  " Repeat the test for a location list
+  lexpr "F2:2:line2"
+  lopen
+  let bnum = bufnr()
+  tabnew
+  exe "buffer" bnum
+  tabfirst
+  lclose
+  tablast
+  call assert_true(buflisted(bnum))
+  tabclose
+  lopen
+  call assert_true(buflisted(bnum))
+  lclose
+  call assert_false(buflisted(bnum))
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -2433,8 +2433,10 @@ win_close_buffer(win_T *win, int action, int abort_if_last)
 #endif
 
 #ifdef FEAT_QUICKFIX
-    // When the quickfix/location list window is closed, unlist the buffer.
-    if (win->w_buffer != NULL && bt_quickfix(win->w_buffer))
+    // When a quickfix/location list window is closed and the buffer is
+    // displayed in only one window, then unlist the buffer.
+    if (win->w_buffer != NULL && bt_quickfix(win->w_buffer)
+					&& win->w_buffer->b_nwindows == 1)
 	win->w_buffer->b_p_bl = FALSE;
 #endif
 


### PR DESCRIPTION
Fixes #9300.