### PR TITLE
CI: Use clang-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,16 +75,16 @@ jobs:
             libtool-bin \
             libsodium-dev
 
-      - name: Install clang-11
+      - name: Install clang-13
         if: matrix.compiler == 'clang'
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           . /etc/lsb-release
-          sudo add-apt-repository -y "deb http://apt.llvm.org/${DISTRIB_CODENAME}/ llvm-toolchain-${DISTRIB_CODENAME}-11 main"
-          sudo apt-get install -y clang-11 llvm-11
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 100
-          sudo update-alternatives --set clang /usr/bin/clang-11
-          sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-11 100
+          sudo add-apt-repository -y "deb http://apt.llvm.org/${DISTRIB_CODENAME}/ llvm-toolchain-${DISTRIB_CODENAME}-13 main"
+          sudo apt-get install -y clang-13 llvm-13
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
+          sudo update-alternatives --set clang /usr/bin/clang-13
+          sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-13 100
 
       - name: Set up environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,10 @@ jobs:
           # Append various warning flags to CFLAGS.
           sed -i -f ci/config.mk.sed ${SRCDIR}/auto/config.mk
           sed -i -f ci/config.mk.${CC}.sed ${SRCDIR}/auto/config.mk
+          if [[ ${CC} = clang ]]; then
+            # Suppress some warnings occurred by newer clang.
+            sed -i -f ci/config.mk.clang-12.sed ${SRCDIR}/auto/config.mk
+          fi
 
       - name: Build
         if: (!contains(matrix.extra, 'unittests'))
@@ -296,6 +300,10 @@ jobs:
           sed -i.bak -f ci/config.mk.sed ${SRCDIR}/auto/config.mk
           # On macOS, the entity of gcc is clang.
           sed -i.bak -f ci/config.mk.clang.sed ${SRCDIR}/auto/config.mk
+          # Suppress some warnings occurred by newer clang.
+          if clang --version | grep -qs 'Apple clang version \(1[3-9]\|[2-9]\)\.'; then
+            sed -i.bak -f ci/config.mk.clang-12.sed ${SRCDIR}/auto/config.mk
+          fi
 
       - name: Build
         env:

--- a/ci/config.mk.clang-12.sed
+++ b/ci/config.mk.clang-12.sed
@@ -1,0 +1,3 @@
+# Clang 12 (or Apple clang 13) and later makes a warning '-Wcompound-token-split-by-macro' enable by default.
+/^PERL_CFLAGS[[:blank:]]*=/s/$/ -Wno-error=compound-token-split-by-macro/
+/^RUBY_CFLAGS[[:blank:]]*=/s/$/ -Wno-error=compound-token-split-by-macro/

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -3375,7 +3375,15 @@ exit_scroll(void)
 }
 
 #ifdef USE_GCOV_FLUSH
-extern void __gcov_flush();
+# if (defined(__GNUC__) \
+	    && ((__GNUC__ == 11 && __GNUC_MINOR__ >= 1) || (__GNUC__ >= 12))) \
+	|| (defined(__clang__) && (__clang_major__ >= 12))
+extern void __gcov_dump(void);
+extern void __gcov_reset(void);
+#  define __gcov_flush() do { __gcov_dump(); __gcov_reset(); } while (0)
+# else
+extern void __gcov_flush(void);
+# endif
 #endif
 
     void

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -6576,7 +6576,7 @@ write_spell_prefcond(FILE *fd, garray_T *gap)
     char_u	*p;
     int		len;
     int		totlen;
-    size_t	x = 1;  // collect return value of fwrite()
+    size_t	x UNUSED = 1;  // collect return value of fwrite()
 
     if (fd != NULL)
 	put_bytes(fd, (long_u)gap->ga_len, 2);	    // <prefcondcnt>


### PR DESCRIPTION
We need handle the below changes in clang-12 (or Apple clang-13).

### The warnings added or enabled since clang-12

* `compound-token-split-by-macro` (new warning): it affects the build of if_perl and if_ruby.

* `unused-but-set-variable` (changed to enabled by default):  it reports the warning in `write_spell_prefcond`.

### Replace `__gcov_flush` by `__gcov_dump` and `__gcov_reset`

In gcc >= 11.1.0 and clang >= 12 `__gcov_flush` has removed.