### PR TITLE
Termdebug encoding - again

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1090,18 +1090,19 @@ let s:evalFromBalloonExpr = 0
 
 " Handle the result of data-evaluate-expression
 func s:HandleEvaluate(msg)
-  let value = substitute(a:msg, '.*value="\(.*\)"', '\1', '')
-  let value = substitute(value, '\\"', '"', 'g')
-  let value = substitute(value, '\\\\', '\\', 'g')
-  " multi-byte characters arrive in octal form, replace everthing but NULL values
-  let value = substitute(value, '\\000', s:NullRepl, 'g')
-  let value = substitute(value, '\\\o\o\o', {-> eval('"' .. submatch(0) .. '"')}, 'g')
-  " Note: GDB docs also mention hex encodings - the translations below work
-  "       but we keep them out for performance-reasons until we actually see
-  "       those in mi-returns
-  "let value = substitute(value, '\\0x00', s:NullRep, 'g')
-  "let value = substitute(value, '\\0x\(\x\x\)', {-> eval('"\x' .. submatch(1) .. '"')}, 'g')
-  let value = substitute(value, s:NullRepl, '\\000', 'g')
+  let value = a:msg
+    \->substitute('.*value="\(.*\)"', '\1', '')
+    \->substitute('\\"', '"', 'g')
+    \->substitute('\\\\', '\\', 'g')
+    "\ multi-byte characters arrive in octal form, replace everthing but NULL values
+    \->substitute('\\000', s:NullRepl, 'g')
+    \->substitute('\\\o\o\o', {-> eval('"' .. submatch(0) .. '"')}, 'g')
+    "\ Note: GDB docs also mention hex encodings - the translations below work
+    "\       but we keep them out for performance-reasons until we actually see
+    "\       those in mi-returns
+    "\ ->substitute('\\0x00', s:NullRep, 'g')
+    "\ ->substitute('\\0x\(\x\x\)', {-> eval('"\x' .. submatch(1) .. '"')}, 'g')
+    \->substitute(s:NullRepl, '\\000', 'g')
   if s:evalFromBalloonExpr
     if s:evalFromBalloonExprResult == ''
       let s:evalFromBalloonExprResult = s:evalexpr . ': ' . value


### PR DESCRIPTION
* let the expression replacement actually work (there is a double `\\`  in there - removed before applying the previous replacements)
* don't replace NULL values with NULLs as those either "cut" the string or are removed

Test case in GDB:

```c
char buff[12] = {0};
memcpy(buff,"TST",3);
buff[5] = '"';
buff[7] = '\n';
// evaluate buff here
```

GDB shows: `"TST\000\000\"\000\n\000\000\000"`, without those changes we had `"TST\\000\\000\\"\\000\\n\\000\\000\\000"`, after applying the missing `\\` conversion we had `"TST\"\n"` - with those changes `:Evaluate` shows the data correctly.

Beware:
* I have no clue if vim operates on non-ascii, non-utf8 data - UTF16 and UTF32 with its included null bytes would be broken by the `NullRepl` stuff [if in question you may want to comment that out]
* I was told that does a conversion on print _if_ the data is actually _defined_ as wide char, not sure if this is the case and/if Vim could do the same

Things I originally wanted to but did not get it working (maybe @lacygoill could kick in):
* in `s:HandleEvaluate()`: use `->substitute` syntax
* move most of the decoding stuff out into a `s:DecodeText()`, so only the initial value (ending at first `"` / within `value=""`) and the "special" handling (like `\n`) is in `s:DecodeMessage()` / `s:HandleEvaluate()`