### PR TITLE
recognize .conf files in .ssh directory

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1761,8 +1761,8 @@ au BufNewFile,BufRead *.sqr,*.sqi		setf sqr
 au BufNewFile,BufRead *.nut			setf squirrel
 
 " OpenSSH configuration
-au BufNewFile,BufRead ssh_config,*/.ssh/config		setf sshconfig
-au BufNewFile,BufRead */etc/ssh/ssh_config.d/*.conf	setf sshconfig
+au BufNewFile,BufRead ssh_config,*/.ssh/config,*/.ssh/*.conf	setf sshconfig
+au BufNewFile,BufRead */etc/ssh/ssh_config.d/*.conf		setf sshconfig
 
 " OpenSSH server configuration
 au BufNewFile,BufRead sshd_config			setf sshdconfig

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -479,7 +479,7 @@ let s:filename_checks = {
     \ 'squid': ['squid.conf'],
     \ 'squirrel': ['file.nut'],
     \ 'srec': ['file.s19', 'file.s28', 'file.s37', 'file.mot', 'file.srec'],
-    \ 'sshconfig': ['ssh_config', '/.ssh/config', '/etc/ssh/ssh_config.d/file.conf', 'any/etc/ssh/ssh_config.d/file.conf', 'any/.ssh/config'],
+    \ 'sshconfig': ['ssh_config', '/.ssh/config', '/etc/ssh/ssh_config.d/file.conf', 'any/etc/ssh/ssh_config.d/file.conf', 'any/.ssh/config', 'any/.ssh/file.conf'],
     \ 'sshdconfig': ['sshd_config', '/etc/ssh/sshd_config.d/file.conf', 'any/etc/ssh/sshd_config.d/file.conf'],
     \ 'st': ['file.st'],
     \ 'stata': ['file.ado', 'file.do', 'file.imata', 'file.mata'],


### PR DESCRIPTION
I and my colleagues put ssh configurations for different projects in separate files, but vim doesn't recognize them as sshconfig. With this PR, vim considers all files matching `*/.ssh/*.conf` to be sshconfig files. I believe that this will not generate any false positives as there is no reason to put any other .conf files in that directory or its subdirectories.

However, I do understand if you consider this to be an edge case and therefore don't want it in the general filetype configuration. I'm aware that I can also add this to my personal `.vimrc` but thought there would be others out there with the same issue.