### PR TITLE
CI: Remove gcc test from macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      CC: ${{ matrix.compiler }}
+      CC: clang
       TEST: test
       SRCDIR: ./src
       LEAK_CFLAGS: -DEXITFREE
@@ -265,7 +265,6 @@ jobs:
       fail-fast: false
       matrix:
         features: [tiny, huge]
-        compiler: [clang, gcc]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
CI on macOS does not need gcc test for the following reasons:

* System-installed gcc (currently used in CI) is identical with clang
* Official gcc (gcc-11, installed in macos-latest env) cannot compile os_macosx.m nor os_mac_conv.c since they includes the headers using Objective-C features which gcc does not support.