### PR TITLE
make exists("+cdhome") return 0 on Unix

### DIFF
--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -550,7 +550,11 @@ static struct vimoption options[] =
 			    {(char_u *)"internal,keepascii", (char_u *)0L}
 			    SCTX_INIT},
     {"cdhome",	    "cdh",  P_BOOL|P_VI_DEF|P_VIM|P_SECURE,
+#if !defined(UNIX) && !defined(VMS)
 			    (char_u *)&p_cdh, PV_NONE,
+#else
+			    (char_u *)NULL, PV_NONE,
+#endif
 			    {(char_u *)FALSE, (char_u *)0L}
 			    SCTX_INIT},
     {"cdpath",	    "cd",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE|P_COMMA|P_NODUP,

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1202,8 +1202,11 @@ endfunc
 " Test for the 'cdhome' option
 func Test_opt_cdhome()
   if has('unix') || has('vms')
+    call assert_equal(0, exists('+cdhome'))
     throw 'Skipped: only works on non-Unix'
   endif
+
+  call assert_equal(1, exists('+cdhome'))
 
   set cdhome&
   call assert_equal(0, &cdhome)


### PR DESCRIPTION
I believe this still allows setting 'cdhome' on all systems without checking.