### PR TITLE
Test_term_gettitle fails if compiled with +autoservername but not usable

### DIFF
--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -521,7 +521,8 @@ func Test_term_gettitle()
   endif
 
   let term = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', '-c', 'set title'])
-  if has('autoservername')
+  if has('autoservername') &&
+        \ ((has('x11') && !empty($DISPLAY)) || has('win32'))
     call WaitForAssert({-> assert_match('^\[No Name\] - VIM\d\+$', term_gettitle(term)) })
     call term_sendkeys(term, ":e Xfoo\r")
     call WaitForAssert({-> assert_match('^Xfoo (.*[/\\]testdir) - VIM\d\+$', term_gettitle(term)) })


### PR DESCRIPTION
`Test_term_gettitle` fails if compiled with `+autoservername` but not usable for some reason (e.g. `$DISPLAY` environment variable not set).

```
Failures:
	From test_terminal2.vim:
	Found errors in Test_term_gettitle():
	command line..script /build/vim/src/vim/src/testdir/runtest.vim[455]..function RunTheTest[44]..Test_term_gettitle[12]..WaitForAssert[2]..<SNR>6_WaitForCommon[11]..<lambda>14 line 1: Pattern '^\\[No Name\\] - VIM\\d\\+$' does not match '[No Name] - VIM'
	command line..script /build/vim/src/vim/src/testdir/runtest.vim[455]..function RunTheTest[44]..Test_term_gettitle[14]..WaitForAssert[2]..<SNR>6_WaitForCommon[11]..<lambda>15 line 1: Pattern '^Xfoo (.*[/\\\\]testdir) - VIM\\d\\+$' does not match 'Xfoo (/build/vim/src/vim/src/testdir) - VIM'

TEST FAILURE
```

Alternatively, I think this would be fine if we just test `term_gettitle()` function here.
```diff
diff --git a/src/testdir/test_terminal2.vim b/src/testdir/test_terminal2.vim
index 68f9ad868..409f0f78e 100644
--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -521,15 +521,9 @@ func Test_term_gettitle()
   endif

   let term = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', '-c', 'set title'])
-  if has('autoservername')
-    call WaitForAssert({-> assert_match('^\[No Name\] - VIM\d\+$', term_gettitle(term)) })
-    call term_sendkeys(term, ":e Xfoo\r")
-    call WaitForAssert({-> assert_match('^Xfoo (.*[/\\]testdir) - VIM\d\+$', term_gettitle(term)) })
-  else
-    call WaitForAssert({-> assert_equal('[No Name] - VIM', term_gettitle(term)) })
-    call term_sendkeys(term, ":e Xfoo\r")
-    call WaitForAssert({-> assert_match('^Xfoo (.*[/\\]testdir) - VIM$', term_gettitle(term)) })
-  endif
+  call WaitForAssert({-> assert_match('^\[No Name\] - VIM\d*$', term_gettitle(term)) })
+  call term_sendkeys(term, ":e Xfoo\r")
+  call WaitForAssert({-> assert_match('^Xfoo (.*[/\\]testdir) - VIM\d*$', term_gettitle(term)) })

   call term_sendkeys(term, ":set titlestring=foo\r")
   call WaitForAssert({-> assert_equal('foo', term_gettitle(term)) })
```