### PR TITLE
Modify the type check to include string type for map()/filter()

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -760,3 +760,5 @@ EXTERN char e_highlight_group_name_too_long[]
 	INIT(= N_("E1249: Highlight group name too long"));
 EXTERN char e_argument_of_str_must_be_list_string_dictionary_or_blob[]
 	INIT(= N_("E1250: Argument of %s must be a List, String, Dictionary or Blob"));
+EXTERN char e_list_dict_blob_or_string_required_for_argument_nr[]
+	INIT(= N_("E1228: List, Dictionary, Blob or String required for argument %d"));

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -449,6 +449,22 @@ arg_list_or_dict_or_blob(type_T *type, argcontext_T *context)
 }
 
 /*
+ * Check "type" is a list of 'any' or a dict of 'any' or a blob or a string.
+ */
+    static int
+arg_list_or_dict_or_blob_or_string(type_T *type, argcontext_T *context)
+{
+    if (type->tt_type == VAR_ANY
+		     || type->tt_type == VAR_LIST
+		     || type->tt_type == VAR_DICT
+		     || type->tt_type == VAR_BLOB
+		     || type->tt_type == VAR_STRING)
+	return OK;
+    arg_type_mismatch(&t_list_any, type, context->arg_idx + 1);
+    return FAIL;
+}
+
+/*
  * Check "type" is a job.
  */
     static int
@@ -797,7 +813,7 @@ static argcheck_T arg23_insert[] = {arg_list_or_blob, arg_item_of_prev, arg_numb
 static argcheck_T arg1_len[] = {arg_len1};
 static argcheck_T arg3_libcall[] = {arg_string, arg_string, arg_string_or_nr};
 static argcheck_T arg14_maparg[] = {arg_string, arg_string, arg_bool, arg_bool};
-static argcheck_T arg2_mapfilter[] = {arg_list_or_dict_or_blob, NULL};
+static argcheck_T arg2_mapfilter[] = {arg_list_or_dict_or_blob_or_string, NULL};
 static argcheck_T arg25_matchadd[] = {arg_string, arg_string, arg_number, arg_number, arg_dict_any};
 static argcheck_T arg25_matchaddpos[] = {arg_string, arg_list_any, arg_number, arg_number, arg_dict_any};
 static argcheck_T arg119_printf[] = {arg_string_or_nr, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};

--- a/src/list.c
+++ b/src/list.c
@@ -2281,11 +2281,12 @@ filter_map(typval_T *argvars, typval_T *rettv, filtermap_T filtermap)
     garray_T	type_list;
 
     // map() and filter() return the first argument, also on failure.
-    if (filtermap != FILTERMAP_MAPNEW)
+    if (filtermap != FILTERMAP_MAPNEW && argvars[0].v_type != VAR_STRING)
 	copy_tv(&argvars[0], rettv);
 
     if (in_vim9script()
-	    && (check_for_list_or_dict_or_blob_arg(argvars, 0) == FAIL))
+	    && (check_for_list_or_dict_or_blob_or_string_arg(argvars, 0)
+								== FAIL))
 	return;
 
     if (filtermap == FILTERMAP_MAP && in_vim9script())

--- a/src/proto/typval.pro
+++ b/src/proto/typval.pro
@@ -42,6 +42,7 @@ int check_for_string_or_list_or_dict_arg(typval_T *args, int idx);
 int check_for_list_or_blob_arg(typval_T *args, int idx);
 int check_for_list_or_dict_arg(typval_T *args, int idx);
 int check_for_list_or_dict_or_blob_arg(typval_T *args, int idx);
+int check_for_list_or_dict_or_blob_or_string_arg(typval_T *args, int idx);
 int check_for_opt_buffer_or_dict_arg(typval_T *args, int idx);
 char_u *tv_get_string(typval_T *varp);
 char_u *tv_get_string_strict(typval_T *varp);

--- a/src/testdir/test_filter_map.vim
+++ b/src/testdir/test_filter_map.vim
@@ -1,5 +1,7 @@
 " Test filter() and map()
 
+source vim9.vim
+
 " list with expression string
 func Test_filter_map_list_expr_string()
   " filter()
@@ -143,68 +145,88 @@ func Test_mapnew_blob()
   call assert_equal(0z129956, bout)
 endfunc
 
+" Test for using map(), filter() and mapnew() with a string
 func Test_filter_map_string()
-  let s = "abc"
-
   " filter()
-  call filter(s, '"b" != v:val')
-  call assert_equal(s, s)
-  call assert_equal('ac', filter('abc', '"b" != v:val'))
-  call assert_equal('あいうえお', filter('あxいxうxえxお', '"x" != v:val'))
-  call assert_equal('あa😊💕💕b💕', filter('あxax😊x💕💕b💕x', '"x" != v:val'))
-  call assert_equal('xxxx', filter('あxax😊x💕💕b💕x', '"x" == v:val'))
-  let t = "%),:;>?]}’”†‡…‰,‱‼⁇⁈⁉℃℉,、。〉》」,』】〕〗〙〛,！），．：,；？,］｝"
-  let u = "%):;>?]}’”†‡…‰‱‼⁇⁈⁉℃℉、。〉》」』】〕〗〙〛！），．：；？］｝"
-  call assert_equal(u, filter(t, '"," != v:val'))
-  call assert_equal('', filter('abc', '0'))
-  call assert_equal('ac', filter('abc', { i, x -> "b" != x }))
-  call assert_equal('あいうえお', filter('あxいxうxえxお', { i, x -> "x" != x }))
-  call assert_equal('', filter('abc', { i, x -> v:false }))
+  let lines =<< trim END
+    VAR s = "abc"
+    call filter(s, '"b" != v:val')
+    call assert_equal(s, s)
+    call assert_equal('ac', filter('abc', '"b" != v:val'))
+    call assert_equal('あいうえお', filter('あxいxうxえxお', '"x" != v:val'))
+    call assert_equal('あa😊💕💕b💕', filter('あxax😊x💕💕b💕x', '"x" != v:val'))
+    call assert_equal('xxxx', filter('あxax😊x💕💕b💕x', '"x" == v:val'))
+    VAR t = "%),:;>?]}’”†‡…‰,‱‼⁇⁈⁉℃℉,、。〉》」,』】〕〗〙〛,！），．：,；？,］｝"
+    VAR u = "%):;>?]}’”†‡…‰‱‼⁇⁈⁉℃℉、。〉》」』】〕〗〙〛！），．：；？］｝"
+    call assert_equal(u, filter(t, '"," != v:val'))
+    call assert_equal('', filter('abc', '0'))
+    call assert_equal('ac', filter('abc', LSTART i, x LMIDDLE "b" != x LEND))
+    call assert_equal('あいうえお', filter('あxいxうxえxお', LSTART i, x LMIDDLE "x" != x LEND))
+    call assert_equal('', filter('abc', LSTART i, x LMIDDLE v:false LEND))
+    call assert_equal('', filter('', "v:val == 'a'"))
+    call assert_equal('', filter(test_null_string(), "v:val == 'a'"))
+  END
+  call CheckLegacyAndVim9Success(lines)
 
   " map()
-  call map(s, 'nr2char(char2nr(v:val) + 2)')
-  call assert_equal(s, s)
-  call assert_equal('cde', map('abc', 'nr2char(char2nr(v:val) + 2)'))
-  call assert_equal('[あ][i][う][え][お]', map('あiうえお', '"[" .. v:val .. "]"'))
-  call assert_equal('[あ][a][😊][,][‱][‼][⁇][⁈][⁉][💕][b][💕][c][💕]', map('あa😊,‱‼⁇⁈⁉💕b💕c💕', '"[" .. v:val .. "]"'))
-  call assert_equal('', map('abc', '""'))
-  call assert_equal('cde', map('abc', { i, x -> nr2char(char2nr(x) + 2) }))
-  call assert_equal('[あ][i][う][え][お]', map('あiうえお', { i, x -> '[' .. x .. ']' }))
-  call assert_equal('', map('abc', { i, x -> '' }))
+  let lines =<< trim END
+    VAR s = "abc"
+    call map(s, 'nr2char(char2nr(v:val) + 2)')
+    call assert_equal(s, s)
+    call assert_equal('cde', map('abc', 'nr2char(char2nr(v:val) + 2)'))
+    call assert_equal('[あ][i][う][え][お]', map('あiうえお', '"[" .. v:val .. "]"'))
+    call assert_equal('[あ][a][😊][,][‱][‼][⁇][⁈][⁉][💕][b][💕][c][💕]', map('あa😊,‱‼⁇⁈⁉💕b💕c💕', '"[" .. v:val .. "]"'))
+    call assert_equal('', map('abc', '""'))
+    call assert_equal('cde', map('abc', LSTART i, x LMIDDLE nr2char(char2nr(x) + 2) LEND))
+    call assert_equal('[あ][i][う][え][お]', map('あiうえお', LSTART i, x LMIDDLE '[' .. x .. ']' LEND))
+    call assert_equal('', map('abc', LSTART i, x LMIDDLE '' LEND))
+    call assert_equal('', map('', "v:val == 'a'"))
+    call assert_equal('', map(test_null_string(), "v:val == 'a'"))
+  END
+  call CheckLegacyAndVim9Success(lines)
 
   " mapnew()
-  call mapnew(s, 'nr2char(char2nr(v:val) + 2)')
-  call assert_equal(s, s)
-  call assert_equal('cde', mapnew('abc', 'nr2char(char2nr(v:val) + 2)'))
-  call assert_equal('[あ][i][う][え][お]', mapnew('あiうえお', '"[" .. v:val .. "]"'))
-  call assert_equal('[あ][a][😊][,][‱][‼][⁇][⁈][⁉][💕][b][💕][c][💕]', mapnew('あa😊,‱‼⁇⁈⁉💕b💕c💕', '"[" .. v:val .. "]"'))
-  call assert_equal('', mapnew('abc', '""'))
-  call assert_equal('cde', mapnew('abc', { i, x -> nr2char(char2nr(x) + 2) }))
-  call assert_equal('[あ][i][う][え][お]', mapnew('あiうえお', { i, x -> '[' .. x .. ']' }))
-  call assert_equal('', mapnew('abc', { i, x -> '' }))
+  let lines =<< trim END
+    VAR s = "abc"
+    call mapnew(s, 'nr2char(char2nr(v:val) + 2)')
+    call assert_equal(s, s)
+    call assert_equal('cde', mapnew('abc', 'nr2char(char2nr(v:val) + 2)'))
+    call assert_equal('[あ][i][う][え][お]', mapnew('あiうえお', '"[" .. v:val .. "]"'))
+    call assert_equal('[あ][a][😊][,][‱][‼][⁇][⁈][⁉][💕][b][💕][c][💕]', mapnew('あa😊,‱‼⁇⁈⁉💕b💕c💕', '"[" .. v:val .. "]"'))
+    call assert_equal('', mapnew('abc', '""'))
+    call assert_equal('cde', mapnew('abc', LSTART i, x LMIDDLE nr2char(char2nr(x) + 2) LEND))
+    call assert_equal('[あ][i][う][え][お]', mapnew('あiうえお', LSTART i, x LMIDDLE '[' .. x .. ']' LEND))
+    call assert_equal('', mapnew('abc', LSTART i, x LMIDDLE '' LEND))
+    call assert_equal('', mapnew('', "v:val == 'a'"))
+    call assert_equal('', mapnew(test_null_string(), "v:val == 'a'"))
+  END
+  call CheckLegacyAndVim9Success(lines)
 
-  " map() and filter()
-  call assert_equal('[あ][⁈][a][😊][⁉][💕][💕][b][💕]', map(filter('あx⁈ax😊x⁉💕💕b💕x', '"x" != v:val'), '"[" .. v:val .. "]"'))
+  let lines =<< trim END
+    #" map() and filter()
+    call assert_equal('[あ][⁈][a][😊][⁉][💕][💕][b][💕]', map(filter('あx⁈ax😊x⁉💕💕b💕x', '"x" != v:val'), '"[" .. v:val .. "]"'))
 
-  " patterns-composing(\Z)
-  call assert_equal('ॠॠ', filter('ऊॠॡ,ऊॠॡ', {i,x -> x =~ '\Z' .. nr2char(0x0960) }))
-  call assert_equal('àà', filter('càt,càt', {i,x -> x =~ '\Za' }))
-  call assert_equal('ÅÅ', filter('Åström,Åström', {i,x -> x =~ '\Z' .. nr2char(0xc5) }))
-  call assert_equal('öö', filter('Åström,Åström', {i,x -> x =~ '\Z' .. nr2char(0xf6) }))
-  call assert_equal('ऊ@ॡ', map('ऊॠॡ', {i,x -> x =~ '\Z' .. nr2char(0x0960) ? '@' : x }))
-  call assert_equal('c@t', map('càt', {i,x -> x =~ '\Za' ? '@' : x }))
-  call assert_equal('@ström', map('Åström', {i,x -> x =~ '\Z' .. nr2char(0xc5) ? '@' : x }))
-  call assert_equal('Åstr@m', map('Åström', {i,x -> x =~ '\Z' .. nr2char(0xf6) ? '@' : x }))
+    #" patterns-composing(\Z)
+    call assert_equal('ॠॠ', filter('ऊॠॡ,ऊॠॡ', LSTART i, x LMIDDLE x =~ '\Z' .. nr2char(0x0960) LEND))
+    call assert_equal('àà', filter('càt,càt', LSTART i, x LMIDDLE x =~ '\Za' LEND))
+    call assert_equal('ÅÅ', filter('Åström,Åström', LSTART i, x LMIDDLE x =~ '\Z' .. nr2char(0xc5) LEND))
+    call assert_equal('öö', filter('Åström,Åström', LSTART i, x LMIDDLE x =~ '\Z' .. nr2char(0xf6) LEND))
+    call assert_equal('ऊ@ॡ', map('ऊॠॡ', LSTART i, x LMIDDLE x =~ '\Z' .. nr2char(0x0960) ? '@' : x LEND))
+    call assert_equal('c@t', map('càt', LSTART i, x LMIDDLE x =~ '\Za' ? '@' : x LEND))
+    call assert_equal('@ström', map('Åström', LSTART i, x LMIDDLE x =~ '\Z' .. nr2char(0xc5) ? '@' : x LEND))
+    call assert_equal('Åstr@m', map('Åström', LSTART i, x LMIDDLE x =~ '\Z' .. nr2char(0xf6) ? '@' : x LEND))
 
-  " patterns-composing(\%C)
-  call assert_equal('ॠॠ', filter('ऊॠॡ,ऊॠॡ', {i,x -> x =~ nr2char(0x0960) .. '\%C' }))
-  call assert_equal('àà', filter('càt,càt', {i,x -> x =~ 'a' .. '\%C' }))
-  call assert_equal('ÅÅ', filter('Åström,Åström', {i,x -> x =~ nr2char(0xc5) .. '\%C' }))
-  call assert_equal('öö', filter('Åström,Åström', {i,x -> x =~ nr2char(0xf6) .. '\%C' }))
-  call assert_equal('ऊ@ॡ', map('ऊॠॡ', {i,x -> x =~ nr2char(0x0960) .. '\%C' ? '@' : x }))
-  call assert_equal('c@t', map('càt', {i,x -> x =~ 'a' .. '\%C' ? '@' : x }))
-  call assert_equal('@ström', map('Åström', {i,x -> x =~ nr2char(0xc5) .. '\%C' ? '@' : x }))
-  call assert_equal('Åstr@m', map('Åström', {i,x -> x =~ nr2char(0xf6) .. '\%C' ? '@' : x }))
+    #" patterns-composing(\%C)
+    call assert_equal('ॠॠ', filter('ऊॠॡ,ऊॠॡ', LSTART i, x LMIDDLE x =~ nr2char(0x0960) .. '\%C' LEND))
+    call assert_equal('àà', filter('càt,càt', LSTART i, x LMIDDLE x =~ 'a' .. '\%C' LEND))
+    call assert_equal('ÅÅ', filter('Åström,Åström', LSTART i, x LMIDDLE x =~ nr2char(0xc5) .. '\%C' LEND))
+    call assert_equal('öö', filter('Åström,Åström', LSTART i, x LMIDDLE x =~ nr2char(0xf6) .. '\%C' LEND))
+    call assert_equal('ऊ@ॡ', map('ऊॠॡ', LSTART i, x LMIDDLE x =~ nr2char(0x0960) .. '\%C' ? '@' : x LEND))
+    call assert_equal('c@t', map('càt', LSTART i, x LMIDDLE x =~ 'a' .. '\%C' ? '@' : x LEND))
+    call assert_equal('@ström', map('Åström', LSTART i, x LMIDDLE x =~ nr2char(0xc5) .. '\%C' ? '@' : x LEND))
+    call assert_equal('Åstr@m', map('Åström', LSTART i, x LMIDDLE x =~ nr2char(0xf6) .. '\%C' ? '@' : x LEND))
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -1232,7 +1232,7 @@ def Wrong_dict_key_type(items: list<number>): list<number>
 enddef
 
 def Test_filter()
-  CheckDefAndScriptFailure2(['filter(1.1, "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got float', 'E1228: List, Dictionary or Blob required for argument 1')
+  CheckDefAndScriptFailure2(['filter(1.1, "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got float', 'E1228: List, Dictionary, Blob or String required for argument 1')
   assert_equal([], filter([1, 2, 3], '0'))
   assert_equal([1, 2, 3], filter([1, 2, 3], '1'))
   assert_equal({b: 20}, filter({a: 10, b: 20}, 'v:val == 20'))
@@ -2027,8 +2027,8 @@ def Test_luaeval()
 enddef
 
 def Test_map()
-  CheckDefAndScriptFailure2(['map("x", "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got string', 'E1228: List, Dictionary or Blob required for argument 1')
-  CheckDefAndScriptFailure2(['map(1, "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got number', 'E1228: List, Dictionary or Blob required for argument 1')
+  CheckDefAndScriptFailure2(['map(test_null_channel(), "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got channel', 'E1228: List, Dictionary, Blob or String required for argument 1')
+  CheckDefAndScriptFailure2(['map(1, "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got number', 'E1228: List, Dictionary, Blob or String required for argument 1')
 enddef
 
 def Test_map_failure()
@@ -2144,8 +2144,8 @@ def Test_mapcheck()
 enddef
 
 def Test_mapnew()
-  CheckDefAndScriptFailure2(['mapnew("x", "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got string', 'E1228: List, Dictionary or Blob required for argument 1')
-  CheckDefAndScriptFailure2(['mapnew(1, "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got number', 'E1228: List, Dictionary or Blob required for argument 1')
+  CheckDefAndScriptFailure2(['mapnew(test_null_job(), "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got job', 'E1228: List, Dictionary, Blob or String required for argument 1')
+  CheckDefAndScriptFailure2(['mapnew(1, "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got number', 'E1228: List, Dictionary, Blob or String required for argument 1')
 enddef
 
 def Test_mapset()

--- a/src/typval.c
+++ b/src/typval.c
@@ -832,6 +832,28 @@ check_for_list_or_dict_or_blob_arg(typval_T *args, int idx)
 }
 
 /*
+ * Give an error and return FAIL unless "args[idx]" is a list or dict or a
+ * blob or a string.
+ */
+    int
+check_for_list_or_dict_or_blob_or_string_arg(typval_T *args, int idx)
+{
+    if (args[idx].v_type != VAR_LIST
+	    && args[idx].v_type != VAR_DICT
+	    && args[idx].v_type != VAR_BLOB
+	    && args[idx].v_type != VAR_STRING)
+    {
+	if (idx >= 0)
+	    semsg(_(e_list_dict_blob_or_string_required_for_argument_nr),
+								idx + 1);
+	else
+	    emsg(_(e_listreq));
+	return FAIL;
+    }
+    return OK;
+}
+
+/*
  * Give an error and return FAIL unless "args[idx]" is an optional buffer
  * number or a dict.
  */


### PR DESCRIPTION

Modify the type check to include string type for map()/filter()
Don't copy the first argument to rettv for string argument (as it is overwritten later).
Modify the tests to run in legacy and Vim9 script contexts.
