### PR TITLE
Fix: Cannot catch an exception from `term_start`

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -1891,6 +1891,7 @@ apply_autocmds_group(
     int		did_save_redobuff = FALSE;
     save_redo_T	save_redo;
     int		save_KeyTyped = KeyTyped;
+    int		save_did_emsg;
     ESTACK_CHECK_DECLARATION
 
     /*
@@ -2171,8 +2172,12 @@ apply_autocmds_group(
 	    // make sure cursor and topline are valid
 	    check_lnums(TRUE);
 
+	save_did_emsg = did_emsg;
+
 	do_cmdline(NULL, getnextac, (void *)&patcmd,
 				     DOCMD_NOWAIT|DOCMD_VERBOSE|DOCMD_REPEAT);
+
+	did_emsg += save_did_emsg;
 
 	if (nesting == 1)
 	    // restore cursor and topline, unless they were changed

--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -901,5 +901,25 @@ func Test_terminal_getwinpos()
   only!
 endfunc
 
+func Test_terminal_term_start_error()
+  func s:term_start_error() abort
+    try
+      return term_start([[]])
+    catch
+      return v:exception
+    finally
+      "
+    endtry
+  endfunc
+  autocmd WinEnter * call type(0)
+
+  " Must not crash in s:term_start_error, nor the exception thrown.
+  let result = s:term_start_error()
+  call assert_match('^Vim(return):E730:', result)
+
+  autocmd! WinEnter
+  delfunc s:term_start_error
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
### Problem

Some kind of exceptions from `term_start` are not caught.

### Repro steps

test.vim
```vim
autocmd WinEnter * call type(0)
func F() abort
  try
    return term_start([[]])
  catch
    return -1
  finally
    "
  endtry
endfunc
echo F()
```

`vim -Nu NONE -S test.vim`

Excepted:
- `F()` ends normally and `-1` is echoed

Actual: 
- Exceptions `E730` is thrown from `F()`, or Vim crashes on some systems

### Cause

When passing the invalid argument `[[]]` to `term_start`, the exception is generated (set `did_emsg > 0`) but some autocmds (e.g. `WinEnter`) are invoked in `term_start`, and they call `do_cmdline` so `did_emsg` is cleared (in `do_cmdline`).
Therefore, in `ex_catch` the `cstack` information doesn't have "exception is thrown", but actually the exception object has been generated and `did_throw > 0`, so it is thrown to outside of function `F`.

In addition, because of above inconsistency, in `ex_finally` the "active" exception object (which should be kept until returning from `F`) is discarded, thus Vim can crash.

### Solution

Save and restore `did_emsg` before and after `do_cmdline` in `apply_autocmds_group`.
