### PR TITLE
fix: Crash on QNX when using :vimgrep via remote terminal

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -1613,10 +1613,15 @@ win_found:
 #endif
 	}
 #if defined(FEAT_GUI)
-	// Hide the scrollbars from the aucmd_win and update.
-	gui_mch_enable_scrollbar(&aucmd_win->w_scrollbars[SBAR_LEFT], FALSE);
-	gui_mch_enable_scrollbar(&aucmd_win->w_scrollbars[SBAR_RIGHT], FALSE);
-	gui_may_update_scrollbars();
+	if (gui.in_use)
+	{
+	    // Hide the scrollbars from the aucmd_win and update.
+	    gui_mch_enable_scrollbar(&aucmd_win->w_scrollbars[SBAR_LEFT],
+									FALSE);
+	    gui_mch_enable_scrollbar(&aucmd_win->w_scrollbars[SBAR_RIGHT],
+									FALSE);
+	    gui_may_update_scrollbars();
+	}
 #endif
     }
     else


### PR DESCRIPTION
Hi Bram,

OS info:
```
# uname -snmr
QNX QNX_650_sp1 6.5.0 x86pc
```
I did the following operations from remote PuTTY 0.76.
```
# env | grep TERM
TERM=qansi-m
```

How to install Vim:
```
# ./configure CFLAGS='-g3'
# make
# make install
```

Step to repro:
```
# vim -Nu NONE
:vimgrep a **/*.c

Vim: Caught deadly signal SEGV
Vim: Finished.
Memory fault (core dumped)
```

---

Gdb info 1:
```
Program received signal SIGSEGV, Segmentation fault.
0xb82ec0e7 in PtUnrealizeWidget ()
   from /usr/qnx650/target/qnx6/x86/usr/lib/libph.so.3
(gdb) bt
#0  0xb82ec0e7 in PtUnrealizeWidget ()
   from /usr/qnx650/target/qnx6/x86/usr/lib/libph.so.3
#1  0x0827ec6e in gui_mch_enable_scrollbar (sb=0x8349f78, flag=0)
    at gui_photon.c:1835
#2  0x080516bb in aucmd_restbuf (aco=0x8047108) at autocmd.c:1617
#3  0x081815d2 in load_dummy_buffer (fname=0x8323ce0 "alloc.c",
    dirname_start=0x832f3b0 "/root/temp/vim/src", resulting_dir=0x8335210 " ")
    at quickfix.c:6520
#4  0x0818070e in vgr_load_dummy_buf (fname=0x8323ce0 "alloc.c",
    dirname_start=0x832f3b0 "/root/temp/vim/src", dirname_now=0x8335210 " ")
    at quickfix.c:5876
#5  0x08180e0e in vgr_process_files (wp=0x0, qi=0x830d020,
    cmd_args=0x8047258, redraw_for_dummy=0x8047250,
    first_match_buf=0x804724c, target_dir=0x8047248) at quickfix.c:6208
#6  0x081811ff in ex_vimgrep (eap=0x80473d8) at quickfix.c:6354
#7  0x080bf38f in do_one_cmd (cmdlinep=0x80479bc, flags=0, cstack=0x8047528,
    fgetline=0x80d1770 <getexline>, cookie=0x0) at ex_docmd.c:2572
#8  0x080bcfc6 in do_cmdline (cmdline=0x0, fgetline=0x80d1770 <getexline>,
    cookie=0x0, flags=0) at ex_docmd.c:994
#9  0x08144b07 in nv_colon (cap=0x8047a7c) at normal.c:3457
#10 0x08141037 in normal_cmd (oap=0x8047b24, toplevel=1) at normal.c:1114
#11 0x082a9aa9 in main_loop (cmdwin=0, noexmode=0) at main.c:1500
#12 0x082a8f6e in vim_main2 () at main.c:879
#13 0x082a86bf in main (argc=3, argv=0x8047c2c) at main.c:426
```

Gdb info 2:
```
(gdb) frame 2
#2  0x080516bb in aucmd_restbuf (aco=0x8047108) at autocmd.c:1617
1617            gui_mch_enable_scrollbar(&aucmd_win->w_scrollbars[SBAR_LEFT], FALSE);
(gdb) list
1612                curwin->w_topfill = 0;
1613    #endif
1614            }
1615    #if defined(FEAT_GUI)
1616            // Hide the scrollbars from the aucmd_win and update.
1617            gui_mch_enable_scrollbar(&aucmd_win->w_scrollbars[SBAR_LEFT], FALSE);
1618            gui_mch_enable_scrollbar(&aucmd_win->w_scrollbars[SBAR_RIGHT], FALSE);
1619            gui_may_update_scrollbars();
1620    #endif
1621        }
(gdb)
```

---

It seems that QNX will SEGV when calling the Photon API in a non-GUI environment.
So I made a fix to call the GUI API after checking `gui.in_use`.

--
Best regards,
Hirohito Higashi (h_east)