### PR TITLE
Using negative number as a array index before checking

### DIFF
--- a/src/typval.c
+++ b/src/typval.c
@@ -18,11 +18,15 @@
 /*
  * Check whether idx as a array index is valid.
  */
-    static void
+    static int
 check_idx(int idx, char *where)
 {
     if (idx < 0)
+    {
 	internal_error(where);
+	return FAIL;
+    }
+    return OK;
 }
 
 /*
@@ -367,7 +371,8 @@ tv_get_float(typval_T *varp)
     int
 check_for_string_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_string_arg()");
+    if (check_idx(idx, "check_for_string_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_STRING)
     {
@@ -410,7 +415,8 @@ check_for_opt_string_arg(typval_T *args, int idx)
     int
 check_for_number_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_number_arg()");
+    if (check_idx(idx, "check_for_number_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_NUMBER)
     {
@@ -437,7 +443,8 @@ check_for_opt_number_arg(typval_T *args, int idx)
     int
 check_for_float_or_nr_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_float_or_nr_arg()");
+    if (check_idx(idx, "check_for_float_or_nr_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_FLOAT && args[idx].v_type != VAR_NUMBER)
     {
@@ -454,7 +461,8 @@ check_for_float_or_nr_arg(typval_T *args, int idx)
     int
 check_for_bool_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_bool_arg()");
+    if (check_idx(idx, "check_for_bool_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_BOOL
 	    && !(args[idx].v_type == VAR_NUMBER
@@ -486,7 +494,8 @@ check_for_opt_bool_arg(typval_T *args, int idx)
     int
 check_for_blob_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_blob_arg()");
+    if (check_idx(idx, "check_for_blob_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_BLOB)
     {
@@ -503,7 +512,8 @@ check_for_blob_arg(typval_T *args, int idx)
     int
 check_for_list_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_list_arg()");
+    if (check_idx(idx, "check_for_list_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_LIST)
     {
@@ -530,7 +540,8 @@ check_for_opt_list_arg(typval_T *args, int idx)
     int
 check_for_dict_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_dict_arg()");
+    if (check_idx(idx, "check_for_dict_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_DICT)
     {
@@ -557,7 +568,8 @@ check_for_opt_dict_arg(typval_T *args, int idx)
     int
 check_for_chan_or_job_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_chan_or_job_arg()");
+    if (check_idx(idx, "check_for_chan_or_job_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_CHANNEL && args[idx].v_type != VAR_JOB)
     {
@@ -585,7 +597,8 @@ check_for_opt_chan_or_job_arg(typval_T *args, int idx)
     int
 check_for_job_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_job_arg()");
+    if (check_idx(idx, "check_for_job_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_JOB)
     {
@@ -613,7 +626,8 @@ check_for_opt_job_arg(typval_T *args, int idx)
     int
 check_for_string_or_number_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_string_or_number_arg()");
+    if (check_idx(idx, "check_for_string_or_number_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_STRING && args[idx].v_type != VAR_NUMBER)
     {
@@ -680,7 +694,8 @@ check_for_opt_lnum_arg(typval_T *args, int idx)
     int
 check_for_string_or_blob_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_string_or_blob_arg()");
+    if (check_idx(idx, "check_for_string_or_blob_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_STRING && args[idx].v_type != VAR_BLOB)
     {
@@ -697,7 +712,8 @@ check_for_string_or_blob_arg(typval_T *args, int idx)
     int
 check_for_string_or_list_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_string_or_list_arg()");
+    if (check_idx(idx, "check_for_string_or_list_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_STRING && args[idx].v_type != VAR_LIST)
     {
@@ -724,7 +740,8 @@ check_for_opt_string_or_list_arg(typval_T *args, int idx)
     int
 check_for_string_or_dict_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_string_or_dict_arg()");
+    if (check_idx(idx, "check_for_string_or_dict_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_STRING && args[idx].v_type != VAR_DICT)
     {
@@ -742,7 +759,8 @@ check_for_string_or_dict_arg(typval_T *args, int idx)
     int
 check_for_string_or_number_or_list_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_string_or_number_or_list_arg()");
+    if (check_idx(idx, "check_for_string_or_number_or_list_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_STRING
 	    && args[idx].v_type != VAR_NUMBER
@@ -773,7 +791,8 @@ check_for_opt_string_or_number_or_list_arg(typval_T *args, int idx)
     int
 check_for_string_or_list_or_dict_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_string_or_list_or_dict_arg()");
+    if (check_idx(idx, "check_for_string_or_list_or_dict_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_STRING
 	    && args[idx].v_type != VAR_LIST
@@ -792,7 +811,8 @@ check_for_string_or_list_or_dict_arg(typval_T *args, int idx)
     int
 check_for_list_or_blob_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_list_or_blob_arg()");
+    if (check_idx(idx, "check_for_list_or_blob_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_LIST && args[idx].v_type != VAR_BLOB)
     {
@@ -809,7 +829,8 @@ check_for_list_or_blob_arg(typval_T *args, int idx)
     int
 check_for_list_or_dict_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_list_or_dict_arg()");
+    if (check_idx(idx, "check_for_list_or_dict_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_LIST
 	    && args[idx].v_type != VAR_DICT)
@@ -828,7 +849,8 @@ check_for_list_or_dict_arg(typval_T *args, int idx)
     int
 check_for_list_or_dict_or_blob_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_list_or_dict_or_blob_arg()");
+    if (check_idx(idx, "check_for_list_or_dict_or_blob_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_LIST
 	    && args[idx].v_type != VAR_DICT
@@ -848,7 +870,8 @@ check_for_list_or_dict_or_blob_arg(typval_T *args, int idx)
     int
 check_for_list_or_dict_or_blob_or_string_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_list_or_dict_or_blob_or_string_arg()");
+    if (check_idx(idx, "check_for_list_or_dict_or_blob_or_string_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_LIST
 	    && args[idx].v_type != VAR_DICT
@@ -870,7 +893,8 @@ check_for_list_or_dict_or_blob_or_string_arg(typval_T *args, int idx)
     int
 check_for_opt_buffer_or_dict_arg(typval_T *args, int idx)
 {
-    check_idx(idx, "check_for_opt_buffer_or_dict_arg()");
+    if (check_idx(idx, "check_for_opt_buffer_or_dict_arg()") == FAIL)
+	return FAIL;
 
     if (args[idx].v_type != VAR_UNKNOWN
 	    && args[idx].v_type != VAR_STRING

--- a/src/typval.c
+++ b/src/typval.c
@@ -16,6 +16,16 @@
 #if defined(FEAT_EVAL) || defined(PROTO)
 
 /*
+ * Check whether idx as a array index is valid.
+ */
+    static void
+check_idx(int idx, char *where)
+{
+    if (idx < 0)
+	internal_error(where);
+}
+
+/*
  * Allocate memory for a variable type-value, and make it empty (0 or NULL
  * value).
  */
@@ -357,14 +367,14 @@ tv_get_float(typval_T *varp)
     int
 check_for_string_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_string_arg()");
+
     if (args[idx].v_type != VAR_STRING)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_stringreq));
+	semsg(_(e_string_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -400,14 +410,14 @@ check_for_opt_string_arg(typval_T *args, int idx)
     int
 check_for_number_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_number_arg()");
+
     if (args[idx].v_type != VAR_NUMBER)
     {
-	if (idx >= 0)
-	    semsg(_(e_number_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_numberreq));
+	semsg(_(e_number_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -427,14 +437,14 @@ check_for_opt_number_arg(typval_T *args, int idx)
     int
 check_for_float_or_nr_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_float_or_nr_arg()");
+
     if (args[idx].v_type != VAR_FLOAT && args[idx].v_type != VAR_NUMBER)
     {
-	if (idx >= 0)
-	    semsg(_(e_float_or_number_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_numberreq));
+	semsg(_(e_float_or_number_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -444,17 +454,17 @@ check_for_float_or_nr_arg(typval_T *args, int idx)
     int
 check_for_bool_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_bool_arg()");
+
     if (args[idx].v_type != VAR_BOOL
 	    && !(args[idx].v_type == VAR_NUMBER
 		&& (args[idx].vval.v_number == 0
 		    || args[idx].vval.v_number == 1)))
     {
-	if (idx >= 0)
-	    semsg(_(e_bool_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_boolreq));
+	semsg(_(e_bool_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -476,14 +486,14 @@ check_for_opt_bool_arg(typval_T *args, int idx)
     int
 check_for_blob_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_blob_arg()");
+
     if (args[idx].v_type != VAR_BLOB)
     {
-	if (idx >= 0)
-	    semsg(_(e_blob_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_blob_required));
+	semsg(_(e_blob_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -493,14 +503,14 @@ check_for_blob_arg(typval_T *args, int idx)
     int
 check_for_list_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_list_arg()");
+
     if (args[idx].v_type != VAR_LIST)
     {
-	if (idx >= 0)
-	    semsg(_(e_list_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_listreq));
+	semsg(_(e_list_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -520,14 +530,14 @@ check_for_opt_list_arg(typval_T *args, int idx)
     int
 check_for_dict_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_dict_arg()");
+
     if (args[idx].v_type != VAR_DICT)
     {
-	if (idx >= 0)
-	    semsg(_(e_dict_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_dictreq));
+	semsg(_(e_dict_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -547,14 +557,14 @@ check_for_opt_dict_arg(typval_T *args, int idx)
     int
 check_for_chan_or_job_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_chan_or_job_arg()");
+
     if (args[idx].v_type != VAR_CHANNEL && args[idx].v_type != VAR_JOB)
     {
-	if (idx >= 0)
-	    semsg(_(e_chan_or_job_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_chan_or_job_req));
+	semsg(_(e_chan_or_job_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -575,14 +585,14 @@ check_for_opt_chan_or_job_arg(typval_T *args, int idx)
     int
 check_for_job_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_job_arg()");
+
     if (args[idx].v_type != VAR_JOB)
     {
-	if (idx >= 0)
-	    semsg(_(e_job_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_jobreq));
+	semsg(_(e_job_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -603,14 +613,14 @@ check_for_opt_job_arg(typval_T *args, int idx)
     int
 check_for_string_or_number_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_string_or_number_arg()");
+
     if (args[idx].v_type != VAR_STRING && args[idx].v_type != VAR_NUMBER)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_or_number_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_stringreq));
+	semsg(_(e_string_or_number_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -670,14 +680,14 @@ check_for_opt_lnum_arg(typval_T *args, int idx)
     int
 check_for_string_or_blob_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_string_or_blob_arg()");
+
     if (args[idx].v_type != VAR_STRING && args[idx].v_type != VAR_BLOB)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_or_blob_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_stringreq));
+	semsg(_(e_string_or_blob_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -687,14 +697,14 @@ check_for_string_or_blob_arg(typval_T *args, int idx)
     int
 check_for_string_or_list_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_string_or_list_arg()");
+
     if (args[idx].v_type != VAR_STRING && args[idx].v_type != VAR_LIST)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_or_list_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_stringreq));
+	semsg(_(e_string_or_list_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -714,14 +724,14 @@ check_for_opt_string_or_list_arg(typval_T *args, int idx)
     int
 check_for_string_or_dict_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_string_or_dict_arg()");
+
     if (args[idx].v_type != VAR_STRING && args[idx].v_type != VAR_DICT)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_or_dict_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_stringreq));
+	semsg(_(e_string_or_dict_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -732,16 +742,16 @@ check_for_string_or_dict_arg(typval_T *args, int idx)
     int
 check_for_string_or_number_or_list_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_string_or_number_or_list_arg()");
+
     if (args[idx].v_type != VAR_STRING
 	    && args[idx].v_type != VAR_NUMBER
 	    && args[idx].v_type != VAR_LIST)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_number_or_list_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_stringreq));
+	semsg(_(e_string_number_or_list_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -763,16 +773,16 @@ check_for_opt_string_or_number_or_list_arg(typval_T *args, int idx)
     int
 check_for_string_or_list_or_dict_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_string_or_list_or_dict_arg()");
+
     if (args[idx].v_type != VAR_STRING
 	    && args[idx].v_type != VAR_LIST
 	    && args[idx].v_type != VAR_DICT)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_list_or_dict_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_stringreq));
+	semsg(_(e_string_list_or_dict_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -782,14 +792,14 @@ check_for_string_or_list_or_dict_arg(typval_T *args, int idx)
     int
 check_for_list_or_blob_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_list_or_blob_arg()");
+
     if (args[idx].v_type != VAR_LIST && args[idx].v_type != VAR_BLOB)
     {
-	if (idx >= 0)
-	    semsg(_(e_list_or_blob_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_listreq));
+	semsg(_(e_list_or_blob_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -799,15 +809,15 @@ check_for_list_or_blob_arg(typval_T *args, int idx)
     int
 check_for_list_or_dict_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_list_or_dict_arg()");
+
     if (args[idx].v_type != VAR_LIST
 	    && args[idx].v_type != VAR_DICT)
     {
-	if (idx >= 0)
-	    semsg(_(e_list_or_dict_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_listreq));
+	semsg(_(e_list_or_dict_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -818,16 +828,16 @@ check_for_list_or_dict_arg(typval_T *args, int idx)
     int
 check_for_list_or_dict_or_blob_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_list_or_dict_or_blob_arg()");
+
     if (args[idx].v_type != VAR_LIST
 	    && args[idx].v_type != VAR_DICT
 	    && args[idx].v_type != VAR_BLOB)
     {
-	if (idx >= 0)
-	    semsg(_(e_list_dict_or_blob_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_listreq));
+	semsg(_(e_list_dict_or_blob_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -838,18 +848,18 @@ check_for_list_or_dict_or_blob_arg(typval_T *args, int idx)
     int
 check_for_list_or_dict_or_blob_or_string_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_list_or_dict_or_blob_or_string_arg()");
+
     if (args[idx].v_type != VAR_LIST
 	    && args[idx].v_type != VAR_DICT
 	    && args[idx].v_type != VAR_BLOB
 	    && args[idx].v_type != VAR_STRING)
     {
-	if (idx >= 0)
-	    semsg(_(e_list_dict_blob_or_string_required_for_argument_nr),
-								idx + 1);
-	else
-	    emsg(_(e_listreq));
+	semsg(_(e_list_dict_blob_or_string_required_for_argument_nr),
+							    idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 
@@ -860,17 +870,17 @@ check_for_list_or_dict_or_blob_or_string_arg(typval_T *args, int idx)
     int
 check_for_opt_buffer_or_dict_arg(typval_T *args, int idx)
 {
+    check_idx(idx, "check_for_opt_buffer_or_dict_arg()");
+
     if (args[idx].v_type != VAR_UNKNOWN
 	    && args[idx].v_type != VAR_STRING
 	    && args[idx].v_type != VAR_NUMBER
 	    && args[idx].v_type != VAR_DICT)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_stringreq));
+	semsg(_(e_string_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
+
     return OK;
 }
 


### PR DESCRIPTION
Currently using negative number as a array index before checking:
```
    if (args[idx].v_type != VAR_STRING)
    {
	if (idx >= 0)
```

I checked where functions in typval.c are used, Nowhere is using negative number as a array index for functions in typval.c.
This PR will be an internal error is occurred if using negative number as a array index for functions in typval.c.