### PR TITLE
Accepts a string in reduce()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8959,9 +8959,9 @@ readfile({fname} [, {type} [, {max}]])
 
 reduce({object}, {func} [, {initial}])			*reduce()* *E998*
 		{func} is called for every item in {object}, which can be a
-		|List| or a |Blob|.  {func} is called with two arguments: the
-		result so far and current item.  After processing all items
-		the result is returned.
+		|String|, |List| or a |Blob|.  {func} is called with two arguments:
+		the result so far and current item.  After processing all
+		items the result is returned.
 
 		{initial} is the initial result.  When omitted, the first item
 		in {object} is used and {func} is first called for the second
@@ -8972,6 +8972,7 @@ reduce({object}, {func} [, {initial}])			*reduce()* *E998*
 			echo reduce([1, 3, 5], { acc, val -> acc + val })
 			echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
 			echo reduce(0z1122, { acc, val -> 2 * acc + val })
+			echo reduce('xyz', { acc, val -> acc .. ',' .. val })
 <
 		Can also be used as a |method|: >
 			echo mylist->reduce({ acc, val -> acc + val }, 0)

--- a/src/errors.h
+++ b/src/errors.h
@@ -826,3 +826,7 @@ EXTERN char e_argument_of_str_must_be_list_string_dictionary_or_blob[]
 	INIT(= N_("E1250: Argument of %s must be a List, String, Dictionary or Blob"));
 EXTERN char e_list_dict_blob_or_string_required_for_argument_nr[]
 	INIT(= N_("E1228: List, Dictionary, Blob or String required for argument %d"));
+EXTERN char e_string_list_or_blob_required_for_argument_nr[]
+	INIT(= N_("E???: String, List or Blob required for argument %d"));
+EXTERN char e_string_expected[]
+       INIT(= N_("E???: String expected"));

--- a/src/errors.h
+++ b/src/errors.h
@@ -827,6 +827,6 @@ EXTERN char e_argument_of_str_must_be_list_string_dictionary_or_blob[]
 EXTERN char e_list_dict_blob_or_string_required_for_argument_nr[]
 	INIT(= N_("E1228: List, Dictionary, Blob or String required for argument %d"));
 EXTERN char e_string_list_or_blob_required_for_argument_nr[]
-	INIT(= N_("E9998 String, List or Blob required for argument %d"));
+	INIT(= N_("E9998: String, List or Blob required for argument %d"));
 EXTERN char e_string_expected[]
 	INIT(= N_("E9999: String expected"));

--- a/src/errors.h
+++ b/src/errors.h
@@ -827,6 +827,6 @@ EXTERN char e_argument_of_str_must_be_list_string_dictionary_or_blob[]
 EXTERN char e_list_dict_blob_or_string_required_for_argument_nr[]
 	INIT(= N_("E1228: List, Dictionary, Blob or String required for argument %d"));
 EXTERN char e_string_list_or_blob_required_for_argument_nr[]
-	INIT(= N_("E???: String, List or Blob required for argument %d"));
+	INIT(= N_("E9998 String, List or Blob required for argument %d"));
 EXTERN char e_string_expected[]
-       INIT(= N_("E???: String expected"));
+	INIT(= N_("E9999: String expected"));

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -465,7 +465,7 @@ arg_list_or_dict_or_blob_or_string(type_T *type, argcontext_T *context)
 }
 
 /*
- * Check "type" is a list of 'any' or a string or a blob or a string.
+ * Check "type" is a list of 'any' or a blob or a string.
  */
     static int
 arg_string_list_or_blob(type_T *type, argcontext_T *context)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -465,6 +465,21 @@ arg_list_or_dict_or_blob_or_string(type_T *type, argcontext_T *context)
 }
 
 /*
+ * Check "type" is a list of 'any' or a string or a blob or a string.
+ */
+    static int
+arg_string_list_or_blob(type_T *type, argcontext_T *context)
+{
+    if (type->tt_type == VAR_ANY
+		     || type->tt_type == VAR_LIST
+		     || type->tt_type == VAR_BLOB
+		     || type->tt_type == VAR_STRING)
+	return OK;
+    arg_type_mismatch(&t_list_any, type, context->arg_idx + 1);
+    return FAIL;
+}
+
+/*
  * Check "type" is a job.
  */
     static int
@@ -817,7 +832,7 @@ static argcheck_T arg2_mapfilter[] = {arg_list_or_dict_or_blob_or_string, NULL};
 static argcheck_T arg25_matchadd[] = {arg_string, arg_string, arg_number, arg_number, arg_dict_any};
 static argcheck_T arg25_matchaddpos[] = {arg_string, arg_list_any, arg_number, arg_number, arg_dict_any};
 static argcheck_T arg119_printf[] = {arg_string_or_nr, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
-static argcheck_T arg23_reduce[] = {arg_list_or_blob, NULL, NULL};
+static argcheck_T arg23_reduce[] = {arg_string_list_or_blob, NULL, NULL};
 static argcheck_T arg24_remote_expr[] = {arg_string, arg_string, arg_string, arg_number};
 static argcheck_T arg23_remove[] = {arg_list_or_dict_or_blob, arg_remove2, arg_number};
 static argcheck_T arg2_repeat[] = {arg_repeat1, arg_number};

--- a/src/list.c
+++ b/src/list.c
@@ -3338,7 +3338,7 @@ f_reduce(typval_T *argvars, typval_T *rettv)
 	    STRNCPY(buf, p, len);
 	    buf[len] = NUL;
 	    initial.v_type = VAR_STRING;
-	    initial.vval.v_string = vim_strsave(buf);
+	    initial.vval.v_string = buf;
 	    p += len;
 	}
 	else if (argvars[2].v_type != VAR_STRING)
@@ -3356,9 +3356,8 @@ f_reduce(typval_T *argvars, typval_T *rettv)
 	    STRNCPY(buf, p, len);
 	    buf[len] = NUL;
 	    argv[1].v_type = VAR_STRING;
-	    argv[1].vval.v_string = vim_strsave(buf);
+	    argv[1].vval.v_string = buf;
 	    r = call_func(func_name, -1, rettv, 2, argv, &funcexe);
-	    clear_tv(&argv[1]);
 	    if (r == FAIL || called_emsg != called_emsg_start)
 		break;
 	}

--- a/src/list.c
+++ b/src/list.c
@@ -3251,8 +3251,15 @@ f_reduce(typval_T *argvars, typval_T *rettv)
     int		r;
     int		called_emsg_start = called_emsg;
 
-    if (check_for_string_or_list_or_blob_arg(argvars, in_vim9script() ? 0 : -1) == FAIL)
+    if (in_vim9script() && check_for_string_or_list_or_blob_arg(argvars, 0) == FAIL)
 	return;
+
+    if (argvars[0].v_type != VAR_STRING
+	    && argvars[0].v_type != VAR_LIST
+	    && argvars[0].v_type != VAR_BLOB)
+    {
+	semsg(_(e_string_list_or_blob_required), "reduce()");
+    }
 
     if (argvars[1].v_type == VAR_FUNC)
 	func_name = argvars[1].vval.v_string;

--- a/src/list.c
+++ b/src/list.c
@@ -3257,9 +3257,7 @@ f_reduce(typval_T *argvars, typval_T *rettv)
     if (argvars[0].v_type != VAR_STRING
 	    && argvars[0].v_type != VAR_LIST
 	    && argvars[0].v_type != VAR_BLOB)
-    {
 	semsg(_(e_string_list_or_blob_required), "reduce()");
-    }
 
     if (argvars[1].v_type == VAR_FUNC)
 	func_name = argvars[1].vval.v_string;

--- a/src/proto/typval.pro
+++ b/src/proto/typval.pro
@@ -34,6 +34,7 @@ int check_for_opt_lnum_arg(typval_T *args, int idx);
 int check_for_opt_string_or_number_arg(typval_T *args, int idx);
 int check_for_string_or_blob_arg(typval_T *args, int idx);
 int check_for_string_or_list_arg(typval_T *args, int idx);
+int check_for_string_or_list_or_blob_arg(typval_T *args, int idx);
 int check_for_opt_string_or_list_arg(typval_T *args, int idx);
 int check_for_string_or_dict_arg(typval_T *args, int idx);
 int check_for_string_or_number_or_list_arg(typval_T *args, int idx);

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -944,17 +944,19 @@ func Test_reduce()
       call assert_equal(0xff, reduce(0zff, LSTART acc, val LMIDDLE acc + val LEND))
       call assert_equal(2 * (2 * 0xaf + 0xbf) + 0xcf, reduce(0zAFBFCF, LSTART acc, val LMIDDLE 2 * acc + val LEND))
 
+      VAR d = {}
       func F(acc, val)
         return a:acc .. ',' .. a:val
       endfunc
-      call assert_equal('x,y,z', 'xyz'->reduce(function('F')))
-      call assert_equal('', ''->reduce(function('F'), ''))
-      call assert_equal('あ,い,う,え,お,😊,💕', 'あいうえお😊💕'->reduce(function('F')))
-      call assert_equal('😊,あ,い,う,え,お,💕', 'あいうえお💕'->reduce(function('F'), '😊'))
-      call assert_equal('ऊ,ॠ,ॡ', reduce('ऊॠॡ', function('F')))
-      call assert_equal('c,à,t', reduce('càt', function('F')))
-      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', function('F')))
-      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', function('F')))
+      LET d.func = function('F')
+      call assert_equal('x,y,z', 'xyz'->reduce(get(d, 'func')))
+      call assert_equal('', ''->reduce(get(d, 'func'), ''))
+      call assert_equal('あ,い,う,え,お,😊,💕', 'あいうえお😊💕'->reduce(get(d, 'func')))
+      call assert_equal('😊,あ,い,う,え,お,💕', 'あいうえお💕'->reduce(get(d, 'func'), '😊'))
+      call assert_equal('ऊ,ॠ,ॡ', reduce('ऊॠॡ', get(d, 'func')))
+      call assert_equal('c,à,t', reduce('càt', get(d, 'func')))
+      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', get(d, 'func')))
+      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', get(d, 'func')))
   END
   call CheckLegacyAndVim9Success(lines)
 

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -952,6 +952,7 @@ func Test_reduce()
       call assert_equal('c,à,t', reduce('càt', LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
       call assert_equal('Å,s,t,r,ö,m', reduce('Åström', LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
       call assert_equal('Å,s,t,r,ö,m', reduce('Åström', LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
+      call assert_equal(',a,b,c', reduce('abc', LSTART acc, val LMIDDLE acc .. ',' .. val LEND, test_null_string()))
   END
   call CheckLegacyAndVim9Success(lines)
 
@@ -961,6 +962,7 @@ func Test_reduce()
   call assert_fails("call reduce([], { acc, val -> acc + val })", 'E998: Reduce of an empty List with no initial value')
   call assert_fails("call reduce(0z, { acc, val -> acc + val })", 'E998: Reduce of an empty Blob with no initial value')
   call assert_fails("call reduce('', { acc, val -> acc + val })", 'E998: Reduce of an empty String with no initial value')
+  call assert_fails("call reduce(test_null_string(), { acc, val -> acc + val })", 'E998: Reduce of an empty String with no initial value')
 
   call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E1098:')
   call assert_fails("call reduce(0, { acc, val -> acc + val }, 1)", 'E1098:')

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -944,19 +944,14 @@ func Test_reduce()
       call assert_equal(0xff, reduce(0zff, LSTART acc, val LMIDDLE acc + val LEND))
       call assert_equal(2 * (2 * 0xaf + 0xbf) + 0xcf, reduce(0zAFBFCF, LSTART acc, val LMIDDLE 2 * acc + val LEND))
 
-      VAR d = {}
-      func F(acc, val)
-        return a:acc .. ',' .. a:val
-      endfunc
-      LET d.func = function('F')
-      call assert_equal('x,y,z', 'xyz'->reduce(get(d, 'func')))
-      call assert_equal('', ''->reduce(get(d, 'func'), ''))
-      call assert_equal('あ,い,う,え,お,😊,💕', 'あいうえお😊💕'->reduce(get(d, 'func')))
-      call assert_equal('😊,あ,い,う,え,お,💕', 'あいうえお💕'->reduce(get(d, 'func'), '😊'))
-      call assert_equal('ऊ,ॠ,ॡ', reduce('ऊॠॡ', get(d, 'func')))
-      call assert_equal('c,à,t', reduce('càt', get(d, 'func')))
-      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', get(d, 'func')))
-      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', get(d, 'func')))
+      call assert_equal('x,y,z', 'xyz'->reduce(LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
+      call assert_equal('', ''->reduce(LSTART acc, val LMIDDLE acc .. ',' .. val LEND, ''))
+      call assert_equal('あ,い,う,え,お,😊,💕', 'あいうえお😊💕'->reduce(LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
+      call assert_equal('😊,あ,い,う,え,お,💕', 'あいうえお💕'->reduce(LSTART acc, val LMIDDLE acc .. ',' .. val LEND, '😊'))
+      call assert_equal('ऊ,ॠ,ॡ', reduce('ऊॠॡ', LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
+      call assert_equal('c,à,t', reduce('càt', LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
+      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
+      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
   END
   call CheckLegacyAndVim9Success(lines)
 

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -944,14 +944,17 @@ func Test_reduce()
       call assert_equal(0xff, reduce(0zff, LSTART acc, val LMIDDLE acc + val LEND))
       call assert_equal(2 * (2 * 0xaf + 0xbf) + 0xcf, reduce(0zAFBFCF, LSTART acc, val LMIDDLE 2 * acc + val LEND))
 
-      call assert_equal('x,y,z', 'xyz'->reduce({ acc, val -> acc .. ',' .. val}))
-      call assert_equal('', ''->reduce({ acc, val -> acc .. ',' .. val}, ''))
-      call assert_equal('あ,い,う,え,お,😊,💕', 'あいうえお😊💕'->reduce({ acc, val -> acc .. ',' .. val}))
-      call assert_equal('😊,あ,い,う,え,お,💕', 'あいうえお💕'->reduce({ acc, val -> acc .. ',' .. val}, '😊'))
-      call assert_equal('ऊ,ॠ,ॡ', reduce('ऊॠॡ', { acc, val -> acc .. ',' .. val}))
-      call assert_equal('c,à,t', reduce('càt', { acc, val -> acc .. ',' .. val}))
-      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', { acc, val -> acc .. ',' .. val}))
-      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', { acc, val -> acc .. ',' .. val}))
+      func F(acc, val)
+        return a:acc .. ',' .. a:val
+      endfunc
+      call assert_equal('x,y,z', 'xyz'->reduce(function('F')))
+      call assert_equal('', ''->reduce(function('F'), ''))
+      call assert_equal('あ,い,う,え,お,😊,💕', 'あいうえお😊💕'->reduce(function('F')))
+      call assert_equal('😊,あ,い,う,え,お,💕', 'あいうえお💕'->reduce(function('F'), '😊'))
+      call assert_equal('ऊ,ॠ,ॡ', reduce('ऊॠॡ', function('F')))
+      call assert_equal('c,à,t', reduce('càt', function('F')))
+      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', function('F')))
+      call assert_equal('Å,s,t,r,ö,m', reduce('Åström', function('F')))
   END
   call CheckLegacyAndVim9Success(lines)
 

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -2678,7 +2678,7 @@ def Test_readfile()
 enddef
 
 def Test_reduce()
-  CheckDefAndScriptFailure2(['reduce({a: 10}, "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got dict<number>', 'E897: List or Blob required')
+  CheckDefAndScriptFailure2(['reduce({a: 10}, "1")'], 'E1013: Argument 1: type mismatch, expected list<any> but got dict<number>', 'E9998: String, List or Blob required for argument 1')
   assert_equal(6, [1, 2, 3]->reduce((r, c) => r + c, 0))
   assert_equal(11, 0z0506->reduce((r, c) => r + c, 0))
 enddef

--- a/src/typval.c
+++ b/src/typval.c
@@ -672,10 +672,7 @@ check_for_string_or_list_or_blob_arg(typval_T *args, int idx)
 	    && args[idx].v_type != VAR_LIST
 	    && args[idx].v_type != VAR_BLOB)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_list_or_blob_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_string_list_or_blob_required));
+	semsg(_(e_string_list_or_blob_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
     return OK;

--- a/src/typval.c
+++ b/src/typval.c
@@ -713,10 +713,7 @@ check_for_string_or_number_or_list_arg(typval_T *args, int idx)
 	    && args[idx].v_type != VAR_NUMBER
 	    && args[idx].v_type != VAR_LIST)
     {
-	if (idx >= 0)
-	    semsg(_(e_string_number_or_list_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_stringreq));
+	semsg(_(e_string_number_or_list_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
     return OK;
@@ -758,10 +755,7 @@ check_for_list_or_blob_arg(typval_T *args, int idx)
 {
     if (args[idx].v_type != VAR_LIST && args[idx].v_type != VAR_BLOB)
     {
-	if (idx >= 0)
-	    semsg(_(e_list_or_blob_required_for_argument_nr), idx + 1);
-	else
-	    emsg(_(e_listreq));
+	semsg(_(e_list_or_blob_required_for_argument_nr), idx + 1);
 	return FAIL;
     }
     return OK;

--- a/src/typval.c
+++ b/src/typval.c
@@ -699,6 +699,25 @@ check_for_string_or_list_arg(typval_T *args, int idx)
 }
 
 /*
+ * Give an error and return FAIL unless "args[idx]" is a string or a list or a blob.
+ */
+    int
+check_for_string_or_list_or_blob_arg(typval_T *args, int idx)
+{
+    if (args[idx].v_type != VAR_STRING
+	    && args[idx].v_type != VAR_LIST
+	    && args[idx].v_type != VAR_BLOB)
+    {
+	if (idx >= 0)
+	    semsg(_(e_string_list_or_blob_required_for_argument_nr), idx + 1);
+	else
+	    emsg(_(e_string_list_or_blob_required));
+	return FAIL;
+    }
+    return OK;
+}
+
+/*
  * Check for an optional string or list argument at 'idx'
  */
     int


### PR DESCRIPTION
This is reduce() of https://github.com/vim/vim/pull/9327. 
Please E9998 and E9999 replace latest error numbers.

|               | Blob | String    | List    | Dict   |
|-----------|------|--------|------|------|
|for-in {expr}       | yes  | yes    | yes  |  -   |
| map({expr}, )     | yes  |  yes   | yes  | yes  |
|mapnew({expr}, )  | yes  |  yes     | yes  | yes  |
| filter({expr}, )  | yes  |  yes  | yes  | yes  |
|redulce({expr}, ) | yes  |  -  → **yes**  | yes  |  -   |

And I'm sorry, there was still useless test for negative index in check functions([patch 8.2.3840](https://github.com/vim/vim/commit/ddc80aff575dd60c04c79621a0358cf0abaac53a)).