### PR TITLE
Do not allow control character for 'lcs' and 'fcs'

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4914,19 +4914,19 @@ set_chars_option(win_T *wp, char_u **varp)
 		    c2 = c3 = 0;
 		    s = p + len + 1;
 		    c1 = get_encoded_char_adv(&s);
-		    if (mb_char2cells(c1) > 1)
+		    if (char2cells(c1) > 1)
 			return e_invarg;
 		    if (tab[i].cp == &lcs_chars.tab2)
 		    {
 			if (*s == NUL)
 			    return e_invarg;
 			c2 = get_encoded_char_adv(&s);
-			if (mb_char2cells(c2) > 1)
+			if (char2cells(c2) > 1)
 			    return e_invarg;
 			if (!(*s == ',' || *s == NUL))
 			{
 			    c3 = get_encoded_char_adv(&s);
-			    if (mb_char2cells(c3) > 1)
+			    if (char2cells(c3) > 1)
 				return e_invarg;
 			}
 		    }
@@ -4968,7 +4968,7 @@ set_chars_option(win_T *wp, char_u **varp)
 			while (*s != NUL && *s != ',')
 			{
 			    c1 = get_encoded_char_adv(&s);
-			    if (mb_char2cells(c1) > 1)
+			    if (char2cells(c1) > 1)
 				return e_invarg;
 			    ++multispace_len;
 			}

--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -266,6 +266,8 @@ func Test_eob_fillchars()
   call assert_fails(':set fillchars=eob:xy', 'E474:')
   call assert_fails(':set fillchars=eob:\255', 'E474:')
   call assert_fails(':set fillchars=eob:<ff>', 'E474:')
+  call assert_fails(":set fillchars=eob:\x01", 'E474:')
+  call assert_fails(':set fillchars=eob:\\x01', 'E474:')
   " default is ~
   new
   redraw

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -333,13 +333,27 @@ func Test_listchars_invalid()
   call assert_fails('set listchars=space:xx', 'E474:')
   call assert_fails('set listchars=tab:xxxx', 'E474:')
 
-  " Has non-single width character
+  " Has double-width character
   call assert_fails('set listchars=space:·', 'E474:')
   call assert_fails('set listchars=tab:·x', 'E474:')
   call assert_fails('set listchars=tab:x·', 'E474:')
   call assert_fails('set listchars=tab:xx·', 'E474:')
   call assert_fails('set listchars=multispace:·', 'E474:')
   call assert_fails('set listchars=multispace:xxx·', 'E474:')
+
+  " Has control character
+  call assert_fails("set listchars=space:\x01", 'E474:')
+  call assert_fails("set listchars=tab:\x01x", 'E474:')
+  call assert_fails("set listchars=tab:x\x01", 'E474:')
+  call assert_fails("set listchars=tab:xx\x01", 'E474:')
+  call assert_fails("set listchars=multispace:\x01", 'E474:')
+  call assert_fails("set listchars=multispace:xxx\x01", 'E474:')
+  call assert_fails('set listchars=space:\\x01', 'E474:')
+  call assert_fails('set listchars=tab:\\x01x', 'E474:')
+  call assert_fails('set listchars=tab:x\\x01', 'E474:')
+  call assert_fails('set listchars=tab:xx\\x01', 'E474:')
+  call assert_fails('set listchars=multispace:\\x01', 'E474:')
+  call assert_fails('set listchars=multispace:xxx\\x01', 'E474:')
 
   enew!
   set ambiwidth& listchars& ff&


### PR DESCRIPTION
Control characters are not single-width. Just use `char2cells` instead of `utf_char2cells`.