### PR TITLE
Illegal memory access when displaying a blob

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -240,6 +240,7 @@ blob2string(blob_T *blob, char_u **tofree, char_u *numbuf)
 	vim_snprintf((char *)numbuf, NUMBUFLEN, "%02X", (int)blob_get(blob, i));
 	ga_concat(&ga, numbuf);
     }
+    ga_append(&ga, NUL);		// append a NUL at the end
     *tofree = ga.ga_data;
     return *tofree;
 }

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -2917,20 +2917,20 @@ nfa_print_state2(FILE *debugf, nfa_state_T *state, garray_T *indent)
 	ga_concat(indent, (char_u *)"| ");
     else
 	ga_concat(indent, (char_u *)"  ");
-    ga_append(indent, '\0');
+    ga_append(indent, NUL);
 
     nfa_print_state2(debugf, state->out, indent);
 
     // replace last part of indent for state->out1
     indent->ga_len -= 3;
     ga_concat(indent, (char_u *)"  ");
-    ga_append(indent, '\0');
+    ga_append(indent, NUL);
 
     nfa_print_state2(debugf, state->out1, indent);
 
     // shrink indent
     indent->ga_len -= 3;
-    ga_append(indent, '\0');
+    ga_append(indent, NUL);
 }
 
 /*

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -680,5 +680,12 @@ func Test_list2blob()
   call assert_equal(0z00010203, list2blob(range(4)))
 endfunc
 
+" The following used to cause a out-of-bounds memory access
+func Test_blob2string()
+  let v = '0z' .. repeat('01010101.', 444)
+  let v ..= '01'
+  exe 'let b = ' .. v
+  call assert_equal(v, string(b))
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -341,7 +341,7 @@ endfunc
 func Test_echo_string_partial()
   function CountSpaces()
   endfunction
-  echomsg function('CountSpaces', [#{aaaaaaaaaaa: v:false, bbbbbbbbbbbb: '', ccccccccccc: ['ab', 'cd']}])
+  call assert_equal("function('CountSpaces', [{'ccccccccccc': ['ab', 'cd'], 'aaaaaaaaaaa': v:false, 'bbbbbbbbbbbb': ''}])", string(function('CountSpaces', [#{aaaaaaaaaaa: v:false, bbbbbbbbbbbb: '', ccccccccccc: ['ab', 'cd']}])))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION

Based on 8.2.3850, fix a similar problem when displaying a blob.