### PR TITLE
Port numhl sign support from Neovim

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5601,8 +5601,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	number.
 	When a long, wrapped line doesn't start with the first character, '-'
 	characters are put before the number.
-	See |hl-LineNr|  and |hl-CursorLineNr| for the highlighting used for
-	the number.
+	For highlighting see |hl-LineNr|, and |hl-CursorLineNr|, and the
+	|:sign-define| "numhl" argument.
 						*number_relativenumber*
 	The 'relativenumber' option changes the displayed number to be
 	relative to the cursor.  Together with 'number' there are these

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -140,6 +140,11 @@ See |sign_define()| for the equivalent Vim script function.
 		Highlighting group used for the whole line the sign is placed
 		in.  Most useful is defining a background color.
 
+	numhl={group}
+		Highlighting group used for the line number on the line where
+		the sign is placed.  Overrides |hl-LineNr|, |hl-LineNrAbove|,
+		|hl-LineNrBelow|, and |hl-CursorLineNr|.
+
 	text={text}						*E239*
 		Define the text that is displayed when there is no icon or the
 		GUI is not being used.  Only printable characters are allowed
@@ -396,6 +401,8 @@ sign_define({list})
 		   icon		full path to the bitmap file for the sign.
 		   linehl	highlight group used for the whole line the
 				sign is placed in.
+		   numhl	highlight group used for the line number where
+				the sign is placed.
 		   text		text that is displayed when there is no icon
 				or the GUI is not being used.
 		   texthl	highlight group used for the text item
@@ -443,6 +450,8 @@ sign_getdefined([{name}])				*sign_getdefined()*
 		   linehl	highlight group used for the whole line the
 				sign is placed in; not present if not set
 		   name		name of the sign
+		   numhl	highlight group used for the line number where
+				the sign is placed; not present if not set
 		   text		text that is displayed when there is no icon
 				or the GUI is not being used.
 		   texthl	highlight group used for the text item; not

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -377,6 +377,7 @@ win_line(
 #ifdef FEAT_SIGNS
     int		sign_present = FALSE;
     sign_attrs_T sattr;
+    int		num_attr = 0;		// attribute for the number column
 #endif
 #ifdef FEAT_ARABIC
     int		prev_c = 0;		// previous Arabic character
@@ -699,6 +700,8 @@ win_line(
 
 #ifdef FEAT_SIGNS
     sign_present = buf_get_signattrs(wp, lnum, &sattr);
+    if (sign_present)
+	num_attr = sattr.sat_numhl;
 #endif
 
 #ifdef LINE_ATTR
@@ -1206,6 +1209,10 @@ win_line(
 			  char_attr = hl_combine_attr(wcr_attr,
 							     HL_ATTR(HLF_LNB));
 		    }
+#ifdef FEAT_SIGNS
+		    if (num_attr)
+			char_attr = num_attr;
+#endif
 		}
 	    }
 

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -632,7 +632,7 @@ popup_highlight_curline(win_T *wp)
 
 	    if (syn_name2id((char_u *)linehl) == 0)
 		linehl = "PmenuSel";
-	    sign_define_by_name(sign_name, NULL, (char_u *)linehl, NULL, NULL, NULL);
+	    sign_define_by_name(sign_name, NULL, (char_u *)linehl, NULL, NULL, NULL, NULL);
 	}
 
 	sign_place(&sign_id, (char_u *)"PopUpMenu", sign_name,

--- a/src/proto/sign.pro
+++ b/src/proto/sign.pro
@@ -8,7 +8,7 @@ int buf_findsigntype_id(buf_T *buf, linenr_T lnum, int typenr);
 int buf_signcount(buf_T *buf, linenr_T lnum);
 void buf_delete_signs(buf_T *buf, char_u *group);
 void sign_mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_after);
-int sign_define_by_name(char_u *name, char_u *icon, char_u *linehl, char_u *text, char_u *texthl, char_u *culhl);
+int sign_define_by_name(char_u *name, char_u *icon, char_u *linehl, char_u *text, char_u *texthl, char_u *culhl, char_u *numhl);
 int sign_exists_by_name(char_u *name);
 int sign_undefine_by_name(char_u *name, int give_error);
 int sign_place(int *sign_id, char_u *sign_group, char_u *sign_name, buf_T *buf, linenr_T lnum, int prio);

--- a/src/structs.h
+++ b/src/structs.h
@@ -854,6 +854,7 @@ typedef struct sign_attrs_S {
     int		sat_texthl;
     int		sat_linehl;
     int		sat_culhl;
+    int		sat_numhl;
     int		sat_priority;
 } sign_attrs_T;
 

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -15,13 +15,13 @@ func Test_sign()
   " the icon name when listing signs.
   sign define Sign1 text=x
 
-  call Sign_command_ignore_error('sign define Sign2 text=xy texthl=Title linehl=Error culhl=Search icon=../../pixmaps/stock_vim_find_help.png')
+  call Sign_command_ignore_error('sign define Sign2 text=xy texthl=Title linehl=Error culhl=Search numhl=Number icon=../../pixmaps/stock_vim_find_help.png')
 
   " Test listing signs.
   let a=execute('sign list')
   call assert_match('^\nsign Sign1 text=x \nsign Sign2 ' .
 	      \ 'icon=../../pixmaps/stock_vim_find_help.png .*text=xy ' .
-	      \ 'linehl=Error texthl=Title culhl=Search$', a)
+	      \ 'linehl=Error texthl=Title culhl=Search numhl=Number$', a)
 
   let a=execute('sign list Sign1')
   call assert_equal("\nsign Sign1 text=x ", a)
@@ -127,26 +127,34 @@ func Test_sign()
   call assert_fails("sign define Sign4 text=\\ ab  linehl=Comment", 'E239:')
 
   " an empty highlight argument for an existing sign clears it
-  sign define SignY texthl=TextHl culhl=CulHl linehl=LineHl
+  sign define SignY texthl=TextHl culhl=CulHl linehl=LineHl numhl=NumHl
   let sl = sign_getdefined('SignY')[0]
   call assert_equal('TextHl', sl.texthl)
   call assert_equal('CulHl', sl.culhl)
   call assert_equal('LineHl', sl.linehl)
+  call assert_equal('NumHl', sl.numhl)
 
-  sign define SignY texthl= culhl=CulHl linehl=LineHl
+  sign define SignY texthl= culhl=CulHl linehl=LineHl numhl=NumHl
   let sl = sign_getdefined('SignY')[0]
   call assert_false(has_key(sl, 'texthl'))
   call assert_equal('CulHl', sl.culhl)
   call assert_equal('LineHl', sl.linehl)
+  call assert_equal('NumHl', sl.numhl)
 
   sign define SignY linehl=
   let sl = sign_getdefined('SignY')[0]
   call assert_false(has_key(sl, 'linehl'))
   call assert_equal('CulHl', sl.culhl)
+  call assert_equal('NumHl', sl.numhl)
 
   sign define SignY culhl=
   let sl = sign_getdefined('SignY')[0]
   call assert_false(has_key(sl, 'culhl'))
+  call assert_equal('NumHl', sl.numhl)
+
+  sign define SignY numhl=
+  let sl = sign_getdefined('SignY')[0]
+  call assert_false(has_key(sl, 'numhl'))
 
   sign undefine SignY
 
@@ -218,15 +226,13 @@ func Test_sign_completion()
   call assert_equal('"sign define jump list place undefine unplace', @:)
 
   call feedkeys(":sign define Sign \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"sign define Sign icon= linehl= text= texthl=', @:)
+  call assert_equal('"sign define Sign culhl= icon= linehl= numhl= text= texthl=', @:)
 
-  call feedkeys(":sign define Sign linehl=Spell\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"sign define Sign linehl=SpellBad SpellCap ' .
-	      \ 'SpellLocal SpellRare', @:)
-
-  call feedkeys(":sign define Sign texthl=Spell\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"sign define Sign texthl=SpellBad SpellCap ' .
-	      \ 'SpellLocal SpellRare', @:)
+  for hl in ['culhl', 'linehl', 'numhl', 'texthl']
+    call feedkeys(":sign define Sign "..hl.."=Spell\<C-A>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"sign define Sign '..hl..'=SpellBad SpellCap ' .
+                \ 'SpellLocal SpellRare', @:)
+  endfor
 
   call writefile(repeat(["Sun is shining"], 30), "XsignOne")
   call writefile(repeat(["Sky is blue"], 30), "XsignTwo")
@@ -417,20 +423,21 @@ func Test_sign_funcs()
 
   " Tests for sign_define()
   let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error',
-              \ 'culhl': 'Visual'}
+              \ 'culhl': 'Visual', 'numhl': 'Number'}
   call assert_equal(0, "sign1"->sign_define(attr))
-  call assert_equal([{'name' : 'sign1', 'texthl' : 'Error',
-	      \ 'linehl' : 'Search', 'culhl' : 'Visual', 'text' : '=>'}],
+  call assert_equal([{'name' : 'sign1', 'texthl' : 'Error', 'linehl' : 'Search',
+              \ 'culhl' : 'Visual', 'numhl': 'Number', 'text' : '=>'}],
               \ sign_getdefined())
 
   " Define a new sign without attributes and then update it
   call sign_define("sign2")
   let attr = {'text' : '!!', 'linehl' : 'DiffAdd', 'texthl' : 'DiffChange',
-	      \ 'culhl': 'DiffDelete', 'icon' : 'sign2.ico'}
+	      \ 'culhl': 'DiffDelete', 'numhl': 'Number', 'icon' : 'sign2.ico'}
   call Sign_define_ignore_error("sign2", attr)
   call assert_equal([{'name' : 'sign2', 'texthl' : 'DiffChange',
 	      \ 'linehl' : 'DiffAdd', 'culhl' : 'DiffDelete', 'text' : '!!',
-              \ 'icon' : 'sign2.ico'}], "sign2"->sign_getdefined())
+              \ 'numhl': 'Number', 'icon' : 'sign2.ico'}],
+              \ "sign2"->sign_getdefined())
 
   " Test for a sign name with digits
   call assert_equal(0, sign_define(0002, {'linehl' : 'StatusLine'}))


### PR DESCRIPTION
This allows highlighting the number column for a sign.

Command-line completion for ":sign define" is also updated to handle "culhl" and "numhl".

Original PR - https://github.com/neovim/neovim/pull/9113