### PR TITLE
Fix: crash on QNX via remote terminal

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -835,7 +835,7 @@ vim_main2(void)
 #if defined(FEAT_GUI)
     // When tab pages were created, may need to update the tab pages line and
     // scrollbars.  This is skipped while creating them.
-    if (first_tabpage->tp_next != NULL)
+    if (gui.in_use && first_tabpage->tp_next != NULL)
     {
 	out_flush();
 	gui_init_which_components(NULL);


### PR DESCRIPTION
OS info:
```
# uname -snmr
QNX QNX_650_sp1 6.5.0 x86pc
```

How to build and reproduce:
```
# cd /pathToYour/vim/
# ./configure
# make
# cd src
# ./vim -p ex_cmds.*
Vim: Caught deadly signal SEGV

Vim: Finished.
Memory fault (core dumped)
```

Gdb info:
```
Program received signal SIGSEGV, Segmentation fault.
0xb82efc1f in PtHold () from /usr/qnx650/target/qnx6/x86/usr/lib/libph.so.3

(gdb) bt
#0  0xb82efc1f in PtHold ()
from /usr/qnx650/target/qnx6/x86/usr/lib/libph.so.3
#1  0xb82e609a in PtSetResources ()
from /usr/qnx650/target/qnx6/x86/usr/lib/libph.so.3
#2  0xb82e6136 in _PtSetResource ()
from /usr/qnx650/target/qnx6/x86/usr/lib/libph.so.3
#3  0x0827f634 in gui_mch_set_scrollbar_pos (sb=0x832aee4, x=0, y=0, w=0, h=0)
at gui_photon.c:1763
#4  0x0827bea6 in gui_update_scrollbars (force=1) at gui.c:4374
#5  0x082a99bc in vim_main2 () at main.c:842
#6  0x082a91cb in main (argc=4, argv=0x8047bbc) at main.c:426
```

The cause is the same as the following Pull request and patch.
- #9363 
- [patch 8.2.3837: QNX: crash when compiled with GUI but using terminal](https://github.com/vim/vim/commit/d2ff705af32862b4da49d213613233f93343874c)
