### PR TITLE
Remove two redundant checks in f_getreg() and f_getregtype()

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4717,7 +4717,7 @@ f_getreg(typval_T *argvars, typval_T *rettv)
     if (error)
 	return;
 
-    regname = (strregname == NULL ? '"' : *strregname);
+    regname = *strregname;
     if (regname == 0)
 	regname = '"';
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4772,7 +4772,7 @@ f_getregtype(typval_T *argvars, typval_T *rettv)
 	// Default to v:register
 	strregname = get_vim_var_str(VV_REG);
 
-    regname = (strregname == NULL ? '"' : *strregname);
+    regname = *strregname;
     if (regname == 0)
 	regname = '"';
 


### PR DESCRIPTION
In the first branch above, error is set to TRUE if strregname is NULL,
so the function cannot reach this line.
In the second branch, get_vim_var_str() never returns NULL.