### PR TITLE
Problem:    :cd - returns to wrong directory after :cd fails

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7419,7 +7419,10 @@ changedir_func(
     dir_differs = new_dir == NULL || pdir == NULL
 	|| pathcmp((char *)pdir, (char *)new_dir, -1) != 0;
     if (new_dir == NULL || (dir_differs && vim_chdir(new_dir)))
+    {
 	emsg(_(e_failed));
+	vim_free(pdir);
+	}
     else
     {
 	char_u  *acmd_fname;

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7393,12 +7393,6 @@ changedir_func(
 	pdir = vim_strsave(NameBuff);
     else
 	pdir = NULL;
-    if (scope == CDSCOPE_WINDOW)
-	curwin->w_prevdir = pdir;
-    else if (scope == CDSCOPE_TABPAGE)
-	curtab->tp_prevdir = pdir;
-    else
-	prev_dir = pdir;
 
     // For UNIX ":cd" means: go to home directory.
     // On other systems too if 'cdhome' is set.
@@ -7430,6 +7424,13 @@ changedir_func(
     {
 	char_u  *acmd_fname;
 
+	if (scope == CDSCOPE_WINDOW)
+		curwin->w_prevdir = pdir;
+	else if (scope == CDSCOPE_TABPAGE)
+		curtab->tp_prevdir = pdir;
+	else
+		prev_dir = pdir;
+
 	post_chdir(scope);
 
 	if (dir_differs)
@@ -7444,8 +7445,8 @@ changedir_func(
 								curbuf);
 	}
 	retval = TRUE;
+	vim_free(tofree);
     }
-    vim_free(tofree);
 
     return retval;
 }

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -44,6 +44,13 @@ func Test_cd_minus()
   cd -
   call assert_equal(path, getcwd())
 
+  " Test for :cd - after a failed :cd
+  call assert_fails('cd /nonexistent', 'E344:')
+  call assert_equal(path, getcwd())
+  cd -
+  call assert_equal(path_dotdot, getcwd())
+  cd -
+
   " Test for :cd - without a previous directory
   let lines =<< trim [SCRIPT]
     call assert_fails('cd -', 'E186:')


### PR DESCRIPTION
Solution:   do not update "previous" directory until after chdir succeeds

This addresses issue 8983