### PR TITLE
fnamemodify() with empty string argument doesn't return the current directory on MS-Windows

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -390,7 +390,7 @@ mch_isFullName(char_u *fname)
     // the same as the name or mch_FullName() fails.  However, this has quite a
     // bit of overhead, so let's not do that.
     if (*fname == NUL)
-	return TRUE;
+	return FALSE;
     return ((ASCII_ISALPHA(fname[0]) && fname[1] == ':'
 				      && (fname[2] == '/' || fname[2] == '\\'))
 	    || (fname[0] == fname[1] && (fname[0] == '/' || fname[0] == '\\')));

--- a/src/testdir/test_fnamemodify.vim
+++ b/src/testdir/test_fnamemodify.vim
@@ -32,6 +32,7 @@ func Test_fnamemodify()
   call assert_equal('fb2.tar.gz', fnamemodify('abc.fb2.tar.gz', ':e:e:e'))
   call assert_equal('fb2.tar.gz', fnamemodify('abc.fb2.tar.gz', ':e:e:e:e'))
   call assert_equal('tar', fnamemodify('abc.fb2.tar.gz', ':e:e:r'))
+  call assert_equal(getcwd(), fnamemodify('', ':p:h'))
 
   let cwd = getcwd()
   call chdir($HOME)


### PR DESCRIPTION

Address the regression introduced by 8.2.3824. Fixes #9427.