### PR TITLE
Remove two redundant checks in changedir_func

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7411,9 +7411,9 @@ changedir_func(
 # endif
 	new_dir = NameBuff;
     }
-    dir_differs = new_dir == NULL || pdir == NULL
+    dir_differs = pdir == NULL
 	|| pathcmp((char *)pdir, (char *)new_dir, -1) != 0;
-    if (new_dir == NULL || (dir_differs && vim_chdir(new_dir)))
+    if (dir_differs && vim_chdir(new_dir))
     {
 	emsg(_(e_failed));
 	vim_free(pdir);


### PR DESCRIPTION
When `new_dir == NULL`, the function already returns at the beginning, so the control flow cannot reach here.