### PR TITLE
xxd - Build warning with -std=c2x

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -72,6 +72,11 @@
 # define CYGWIN
 #endif
 
+#if (defined(__linux__) && !defined(__ANDROID__)) || defined(__CYGWIN__)
+// Needed for fdopen().
+#define _XOPEN_SOURCE 700
+#endif
+
 #include <stdio.h>
 #ifdef VAXC
 # include <file.h>


### PR DESCRIPTION
When building xxd with "-std=c2x", the following warning messages are emitted:

xxd.c: In function ‘main’:
xxd.c:706:18: warning: implicit declaration of function ‘fdopen’; did you mean ‘fopen’? [-Wimplicit-function-declaration]
  706 |           (fpo = fdopen(fd, BIN_WRITE(revert))) == NULL)
      |                  ^~~~~~
      |                  fopen
xxd.c:706:16: warning: assignment to ‘FILE *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  706 |           (fpo = fdopen(fd, BIN_WRITE(revert))) == NULL)

Define _XOPEN_SOURCE to address these warning messages.