### PR TITLE
Add v:maxcol

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2480,7 +2480,7 @@ filter({expr1}, {expr2})				*filter()*
 			:let l = filter(copy(mylist), 'v:val =~ "KEEP"')
 
 <		Returns {expr1}, the |List| or |Dictionary| that was filtered,
-		or a new |Blob| or |String|. 
+		or a new |Blob| or |String|.
 		When an error is encountered while evaluating {expr2} no
 		further items in {expr1} are processed.
 		When {expr2} is a Funcref errors inside a function are ignored,
@@ -3128,8 +3128,8 @@ getcharpos({expr})
 		Get the position for String {expr}. Same as |getpos()| but the
 		column number in the returned List is a character index
 		instead of a byte index.
-		If |getpos()| returns a very large column number, such as
-		2147483647, then getcharpos() will return the character index
+		If |getpos()| returns a very large column number equal to
+		|v:maxcol|, then getcharpos() will return the character index
 		of the last character.
 
 		Example:
@@ -3279,7 +3279,8 @@ getcurpos([{winid}])
 		includes an extra "curswant" item in the list:
 		    [0, lnum, col, off, curswant] ~
 		The "curswant" number is the preferred column when moving the
-		cursor vertically.  Also see |getcursorcharpos()| and
+		cursor vertically.  After |$| command it will be a very large
+		number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
 		|getpos()|.
 		The first "bufnum" item is always zero. The byte position of
 		the cursor is returned in 'col'. To get the character
@@ -3624,12 +3625,12 @@ getpos({expr})	Get the position for String {expr}.  For possible values of
 		character.
 		Note that for '< and '> Visual mode matters: when it is "V"
 		(visual line mode) the column of '< is zero and the column of
-		'> is a large number.
+		'> is a large number equal to |v:maxcol|.
 		The column number in the returned List is the byte position
 		within the line. To get the character position in the line,
 		use |getcharpos()|.
-		The column number can be very large, e.g. 2147483647, in which
-		case it means "after the end of the line".
+		A very large column number equal to |v:maxcol| can be returned,
+		in which case it means "after the end of the line".
 		This can be used to save and restore the position of a mark: >
 			let save_a_mark = getpos("'a")
 			...
@@ -9748,10 +9749,14 @@ winsaveview()	Returns a |Dictionary| that contains information to restore
 		The return value includes:
 			lnum		cursor line number
 			col		cursor column (Note: the first column
-					zero, as opposed to what getpos()
+					zero, as opposed to what |getcurpos()|
 					returns)
 			coladd		cursor column offset for 'virtualedit'
-			curswant	column for vertical movement
+			curswant	column for vertical movement (Note:
+					the first column is zero, as opposed
+					to what |getcurpos()| returns).  After
+					|$| command it will be a very large
+					number equal to |v:maxcol|.
 			topline		first line in the window
 			topfill		filler lines, only in diff mode
 			leftcol		first column displayed; only used when

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2161,6 +2161,9 @@ v:lnum		Line number for the 'foldexpr' |fold-expr|, 'formatexpr' and
 		expressions is being evaluated.  Read-only when in the
 		|sandbox|.
 
+						*v:maxcol* *maxcol-variable*
+v:maxcol	Maximum line length.
+
 					*v:mouse_win* *mouse_win-variable*
 v:mouse_win	Window number for a mouse click obtained with |getchar()|.
 		First window has number 1, like with |winnr()|.  The value is

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -154,6 +154,7 @@ static struct vimvar
     {VV_NAME("sizeofint",	 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("sizeoflong",	 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("sizeofpointer",	 VAR_NUMBER), NULL, VV_RO},
+    {VV_NAME("maxcol",		 VAR_NUMBER), NULL, VV_RO},
 };
 
 // shorthand
@@ -241,6 +242,7 @@ evalvars_init(void)
     set_vim_var_nr(VV_SIZEOFINT, sizeof(int));
     set_vim_var_nr(VV_SIZEOFLONG, sizeof(long));
     set_vim_var_nr(VV_SIZEOFPOINTER, sizeof(char *));
+    set_vim_var_nr(VV_MAXCOL, MAXCOL);
 
     set_vim_var_nr(VV_TYPE_NUMBER,  VAR_TYPE_NUMBER);
     set_vim_var_nr(VV_TYPE_STRING,  VAR_TYPE_STRING);

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -38,6 +38,18 @@ func Test_move_cursor()
   quit!
 endfunc
 
+func Test_curswant_maxcol()
+  new
+  call setline(1, 'foo')
+
+  " Test that after "$" command curswant is set to the same value as v:maxcol.
+  normal! 1G$
+  call assert_equal(v:maxcol, getcurpos()[4])
+  call assert_equal(v:maxcol, winsaveview().curswant)
+
+  quit!
+endfunc
+
 " Very short version of what matchparen does.
 function s:Highlight_Matching_Pair()
   let save_cursor = getcurpos()

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -858,7 +858,7 @@ func Test_normal14_page()
   set nostartofline
   exe "norm! $\<c-b>"
   call assert_equal('92', getline('.'))
-  call assert_equal([0, 92, 2, 0, 2147483647], getcurpos())
+  call assert_equal([0, 92, 2, 0, v:maxcol], getcurpos())
   " cleanup
   set startofline
   bw!
@@ -902,7 +902,7 @@ func Test_normal15_z_scroll_vert()
   norm! >>$ztzb
   call assert_equal('	30', getline('.'))
   call assert_equal(30, winsaveview()['topline']+winheight(0)-1)
-  call assert_equal([0, 30, 3, 0, 2147483647], getcurpos())
+  call assert_equal([0, 30, 3, 0, v:maxcol], getcurpos())
 
   " Test for z-
   1
@@ -2798,7 +2798,7 @@ func Test_normal36_g_cmd5()
   call assert_equal([0, 14, 1, 0, 1], getcurpos())
   " count > buffer content
   norm! 120go
-  call assert_equal([0, 14, 1, 0, 2147483647], getcurpos())
+  call assert_equal([0, 14, 1, 0, v:maxcol], getcurpos())
   " clean up
   bw!
 endfunc
@@ -2980,7 +2980,7 @@ func Test_normal42_halfpage()
   set nostartofline
   exe "norm! $\<c-u>"
   call assert_equal('95', getline('.'))
-  call assert_equal([0, 95, 2, 0, 2147483647], getcurpos())
+  call assert_equal([0, 95, 2, 0, v:maxcol], getcurpos())
   " cleanup
   set startofline
   bw!

--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -205,7 +205,7 @@ func Test_multibyte_op_end_mark()
   call assert_equal([0, 1, 7, 0], getpos("']"))
 
   normal Vyp
-  call assert_equal([0, 1, 2147483647, 0], getpos("'>"))
+  call assert_equal([0, 1, v:maxcol, 0], getpos("'>"))
   call assert_equal([0, 2, 7, 0], getpos("']"))
   bwipe!
 endfunc

--- a/src/vim.h
+++ b/src/vim.h
@@ -2067,7 +2067,8 @@ typedef int sock_T;
 #define VV_SIZEOFINT	100
 #define VV_SIZEOFLONG	101
 #define VV_SIZEOFPOINTER 102
-#define VV_LEN		103	// number of v: vars
+#define VV_MAXCOL	103
+#define VV_LEN		104	// number of v: vars
 
 // used for v_number in VAR_BOOL and VAR_SPECIAL
 #define VVAL_FALSE	0L	// VAR_BOOL


### PR DESCRIPTION
This is one fruit of the discussion in  https://github.com/vim/vim/issues/9308.

Vim uses a large number to indicate "at/after the end of a line". It can be seen in the return value of `getpos()`, `getcurpos()`, etc. The large number is typically 2147483647, but it can be different on some systems. This patch introduces `v:maxcol` variable that stores this large number.

One use case is: comparing the curswant with `v:maxcol` to know if the current blockwise visual selection is extended by `$` command or not. This is necessary to support dot-repeat of a custom operator (`g@`) on an extended blockwise visual selection.