### PR TITLE
fix: :help local-addition behavior

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -818,27 +818,26 @@ fix_help_buffer(void)
 			// the same directory.
 			for (i1 = 0; i1 < fcount; ++i1)
 			{
-			    for (i2 = 0; i2 < fcount; ++i2)
+			    f1 = fnames[i1];
+			    t1 = gettail(f1);
+			    e1 = vim_strrchr(t1, '.');
+			    if (fnamecmp(e1, ".txt") != 0
+				&& fnamecmp(e1, fname + 4) != 0)
 			    {
-				if (i1 == i2)
-				    continue;
-				if (fnames[i1] == NULL || fnames[i2] == NULL)
-				    continue;
-				f1 = fnames[i1];
+				// Not .txt and not .abx, remove it.
+				VIM_CLEAR(fnames[i1]);
+				continue;
+			    }
+
+			    for (i2 = i1+1; i2 < fcount; ++i2)
+			    {
 				f2 = fnames[i2];
-				t1 = gettail(f1);
+				if (f2 == NULL)
+				    continue;
 				t2 = gettail(f2);
-				e1 = vim_strrchr(t1, '.');
 				e2 = vim_strrchr(t2, '.');
 				if (e1 == NULL || e2 == NULL)
 				    continue;
-				if (fnamecmp(e1, ".txt") != 0
-				    && fnamecmp(e1, fname + 4) != 0)
-				{
-				    // Not .txt and not .abx, remove it.
-				    VIM_CLEAR(fnames[i1]);
-				    continue;
-				}
 				if (e1 - f1 != e2 - f2
 					    || fnamencmp(f1, f2, e1 - f1) != 0)
 				    continue;

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -57,16 +57,42 @@ func Test_help_local_additions()
   call writefile(['*mydoc-ext.txt* my extended awesome doc'], 'Xruntime/doc/mydoc-ext.txt')
   let rtp_save = &rtp
   set rtp+=./Xruntime
-  help
-  1
-  call search('mydoc.txt')
-  call assert_equal('|mydoc.txt| my awesome doc', getline('.'))
-  1
-  call search('mydoc-ext.txt')
-  call assert_equal('|mydoc-ext.txt| my extended awesome doc', getline('.'))
+  help local-additions
+  let lines = getline(line(".") + 1, search("^$") - 1)
+  call assert_equal([
+  \ '|mydoc-ext.txt| my extended awesome doc',
+  \ '|mydoc.txt| my awesome doc'
+  \ ], lines)
+  call delete('Xruntime/doc/mydoc-ext.txt')
+  close
+
+  call mkdir('Xruntime-ja/doc', 'p')
+  call writefile(["local-additions\thelp.jax\t/*local-additions*"], 'Xruntime-ja/doc/tags-ja')
+  call writefile(['*help.txt* This is jax file', '',
+  \ 'LOCAL ADDITIONS: *local-additions*', ''], 'Xruntime-ja/doc/help.jax')
+  call writefile(['*work.txt* This is jax file'], 'Xruntime-ja/doc/work.jax')
+  call writefile(['*work2.txt* This is jax file'], 'Xruntime-ja/doc/work2.jax')
+  set rtp+=./Xruntime-ja
+
+  help local-additions@en
+  let lines = getline(line(".") + 1, search("^$") - 1)
+  call assert_equal([
+  \ '|mydoc.txt| my awesome doc'
+  \ ], lines)
+  close
+
+  help local-additions@ja
+  let lines = getline(line(".") + 1, search("^$") - 1)
+  call assert_equal([
+  \ '|mydoc.txt| my awesome doc',
+  \ '|help.txt| This is jax file',
+  \ '|work.txt| This is jax file',
+  \ '|work2.txt| This is jax file',
+  \ ], lines)
   close
 
   call delete('Xruntime', 'rf')
+  call delete('Xruntime-ja', 'rf')
   let &rtp = rtp_save
 endfunc
 


### PR DESCRIPTION
Hi Bram-san,
Happy New Year:tada:

When 'rtp' contains docs other than .txt (e.g. .jax), an incorrect line will be inserted at the end of `:help local-additions`.
See `Test_help_local_additions()` in [test_help.vim](https://github.com/vim/vim/compare/master...h-east:fix_help_local-addition?expand=1#diff-b87aec38ea1ea6423a717af08410088ee44336db086225fca901f2ea33e12c14) for how to reproduce this.

The following test will result in an error without patch.
```vim
  help local-additions@en
  let lines = getline(line(".") + 1, search("^$") - 1)
  call assert_equal([
  \ '|mydoc.txt| my awesome doc'
  \ ], lines)
  close
```

result
```
1 FAILED:
Found errors in Test_help_local_additions():
command line..script /........./vim/src/testdir/runtest.vim[456]..function 
RunTheTest[44]..Test_help_local_additions line 25: Expected ['|mydoc.txt| my 
awesome doc'] but got ['|mydoc.txt| my awesome doc', '|work2.txt| This is jax file']
```

--
Best regards,
Hirohito Higashi (h_east)