### PR TITLE
make gotchars() ignore some bytes when typing a printable character in Select mode

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -1296,7 +1296,7 @@ wait_return(int redraw)
 	{
 	    // Put the character back in the typeahead buffer.  Don't use the
 	    // stuff buffer, because lmaps wouldn't work.
-	    ins_char_typebuf(vgetc_char, vgetc_mod_mask);
+	    ins_char_typebuf(vgetc_char, vgetc_mod_mask, FALSE);
 	    do_redraw = TRUE;	    // need a redraw even though there is
 				    // typeahead
 	}
@@ -3824,7 +3824,7 @@ do_dialog(
 		if (c == ':' && ex_cmd)
 		{
 		    retval = dfltbutton;
-		    ins_char_typebuf(':', 0);
+		    ins_char_typebuf(':', 0, FALSE);
 		    break;
 		}
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -597,7 +597,7 @@ normal_cmd(
 	// restart automatically.
 	// Insert the typed character in the typeahead buffer, so that it can
 	// be mapped in Insert mode.  Required for ":lmap" to work.
-	ins_char_typebuf(vgetc_char, vgetc_mod_mask);
+	ins_char_typebuf(vgetc_char, vgetc_mod_mask, TRUE);
 	if (restart_edit != 0)
 	    c = 'd';
 	else

--- a/src/proto/getchar.pro
+++ b/src/proto/getchar.pro
@@ -24,7 +24,7 @@ int start_redo_ins(void);
 void stop_redo_ins(void);
 int noremap_keys(void);
 int ins_typebuf(char_u *str, int noremap, int offset, int nottyped, int silent);
-void ins_char_typebuf(int c, int modifier);
+void ins_char_typebuf(int c, int modifier, int gotchars_ignore);
 int typebuf_changed(int tb_change_cnt);
 int typebuf_typed(void);
 int typebuf_maplen(void);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3562,7 +3562,7 @@ term_channel_closed(channel_T *ch)
 	redraw_statuslines();
 
 	// Need to break out of vgetc().
-	ins_char_typebuf(K_IGNORE, 0);
+	ins_char_typebuf(K_IGNORE, 0, FALSE);
 	typebuf_was_filled = TRUE;
 
 	term = curbuf->b_term;

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -197,6 +197,20 @@ func Test_recording_esc_sequence()
   endif
 endfunc
 
+" Replaying a macro that involves typing a printable character in Select mode
+" should not insert the character twice
+func Test_recording_select_mode_printable()
+  new
+  call feedkeys("qqi123456789\<Esc>gH987654321\<Esc>q", 'xt')
+  call assert_equal('987654321', getline(1))
+  call feedkeys('dd', 'xt')
+  call assert_equal('', getline(1))
+  call feedkeys('@q', 'xt')
+  " The first 9 used to be inserted twice when the register is replayed
+  call assert_equal('987654321', getline(1))
+  bwipe!
+endfunc
+
 " Test for executing the last used register (@)
 func Test_last_used_exec_reg()
   " Test for the @: command


### PR DESCRIPTION
This is an attempt to fix to #9462 

Maybe the `gotchars_ignore = TRUE` can also be used in some other places, but for now I only use it for printable character in Select mode.

I think there can also be a test involving typing multibyte characters in Select mode, but I don't know what's the best place to put it.