### PR TITLE
Remove redundant comparison in f_fullcommand()

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3897,7 +3897,7 @@ f_fullcommand(typval_T *argvars, typval_T *rettv)
     if (name == NULL)
 	return;
 
-    while (*name != NUL && *name == ':')
+    while (*name == ':')
 	name++;
     name = skip_range(name, TRUE, NULL);
 


### PR DESCRIPTION
`*name == ':'` already implies `*name != NUL` so the `*name != NUL` comparison is redundant