### PR TITLE
Session is unable to restore help buffers properly

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -4821,6 +4821,69 @@ makefoldset(FILE *fd)
 }
 #endif
 
+/*
+ *  Generate default set commands for "help" buffer.  Used when
+ *  'sessionoptions' or 'viewoptions' does not contain "options".
+ */
+    int
+makehelpset(FILE *fd, int foldset)
+{
+    long	eight = 8;
+    char_u	*help = (char_u *)"help";
+#ifdef FEAT_FOLDING
+    char_u	*manual = (char_u *)"manual";
+#endif
+#ifdef EBCDIC
+    char_u	*isk = (char_u *)"65-255,^*,^|,^\"";
+#else
+    char_u	*isk = (char_u *)"!-~,^*,^|,^\",192-255";
+#endif
+
+    if (put_setstring(fd, "setlocal", "bt", &help, 0) == FAIL
+	    || put_setstring(fd, "setlocal", "isk", &isk, P_COMMA) == FAIL
+	    || put_setnum(fd, "setlocal", "ts", &eight) == FAIL
+	    || put_setbool(fd, "setlocal", "bin", FALSE) == FAIL
+	    || put_setbool(fd, "setlocal", "bl", FALSE) == FAIL
+	    || put_setbool(fd, "setlocal", "list", FALSE) == FAIL
+	    || put_setbool(fd, "setlocal", "ma", FALSE) == FAIL
+	    || put_setbool(fd, "setlocal", "nu", FALSE) == FAIL
+	    || put_setbool(fd, "setlocal", "rnu", FALSE) == FAIL
+	    || put_setbool(fd, "setlocal", "ro", TRUE) == FAIL
+	    || put_setbool(fd, "setlocal", "crb", FALSE) == FAIL
+	    || put_setbool(fd, "setlocal", "scb", FALSE) == FAIL
+#ifdef FEAT_ARABIC
+	    || put_setbool(fd, "setlocal", "arab", FALSE) == FAIL
+#endif
+#ifdef FEAT_DIFF
+	    || put_setbool(fd, "setlocal", "diff", FALSE) == FAIL
+#endif
+#ifdef FEAT_RIGHTLEFT
+	    || put_setbool(fd, "setlocal", "rl", FALSE) == FAIL
+#endif
+#ifdef FEAT_SPELL
+	    || put_setbool(fd, "setlocal", "spell", FALSE) == FAIL
+#endif
+	    )
+	return FAIL;
+
+#ifdef FEAT_FOLDING
+    if (foldset)
+    {
+	if (makefoldset(fd) == FAIL)
+	    return FAIL;
+    }
+    else
+    {
+	if (put_setstring(fd, "setlocal", "fdm", &manual, 0) == FAIL
+	    || put_setbool(fd, "setlocal", "fen", FALSE) == FAIL
+	    )
+	    return FAIL;
+    }
+#endif
+
+    return OK;
+}
+
     static int
 put_setstring(
     FILE	*fd,

--- a/src/option.c
+++ b/src/option.c
@@ -4875,11 +4875,18 @@ makehelpset(FILE *fd, int foldset)
     else
     {
 	if (put_setstring(fd, "setlocal", "fdm", &manual, 0) == FAIL
-	    || put_setbool(fd, "setlocal", "fen", FALSE) == FAIL
-	    )
+		|| put_setbool(fd, "setlocal", "fen", FALSE) == FAIL
+		)
 	    return FAIL;
     }
 #endif
+
+    // Setting &filetype last as it triggers an event.
+    if (put_line(fd, "if empty(&ft)") == FAIL
+	    || put_setstring(fd, "  setlocal", "ft", &help, 0) == FAIL
+	    || put_line(fd, "endif") == FAIL
+	    )
+	return FAIL;
 
     return OK;
 }

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -42,6 +42,7 @@ char_u *get_highlight_default(void);
 char_u *get_encoding_default(void);
 int makeset(FILE *fd, int opt_flags, int local_only);
 int makefoldset(FILE *fd);
+int makehelpset(FILE *fd, int foldset);
 void clear_termoptions(void);
 void free_termoptions(void);
 void free_one_termoption(char_u *var);

--- a/src/session.c
+++ b/src/session.c
@@ -422,12 +422,16 @@ put_view(
     // used and 'sessionoptions' doesn't include "options".
     // Some folding options are always stored when "folds" is included,
     // otherwise the folds would not be restored correctly.
+    // For "help" buffers a set of default options is also stored unless
+    // 'sessionoptions' already includes "options".
     save_curwin = curwin;
     curwin = wp;
     curbuf = curwin->w_buffer;
     if (*flagp & (SSOP_OPTIONS | SSOP_LOCALOPTIONS))
 	f = makeset(fd, OPT_LOCAL,
 			     flagp == &vop_flags || !(*flagp & SSOP_OPTIONS));
+    else if (bt_help(curbuf))
+	f = makehelpset(fd, !!(*flagp & SSOP_FOLDS));
 #ifdef FEAT_FOLDING
     else if (*flagp & SSOP_FOLDS)
 	f = makefoldset(fd);

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -909,6 +909,24 @@ func Test_mksession_foldopt()
   set sessionoptions&
 endfunc
 
+" Test for mksession with help but no options
+func Test_mksession_help_noopt()
+  set sessionoptions-=options
+  set sessionoptions+=help
+  help
+  mksession! Xtest_mks.out
+  bwipe
+
+  source Xtest_mks.out
+  call assert_equal('help', &buftype)
+  call assert_false(&modifiable)
+  call assert_true(&readonly)
+
+  helpclose
+  call delete('Xtest_mks.out')
+  set sessionoptions&
+endfunc
+
 " Test for mksession with window position
 func Test_mksession_winpos()
   " Only applicable in GUI Vim

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -919,6 +919,7 @@ func Test_mksession_help_noopt()
 
   source Xtest_mks.out
   call assert_equal('help', &buftype)
+  call assert_equal('help', &filetype)
   call assert_false(&modifiable)
   call assert_true(&readonly)
 


### PR DESCRIPTION
Problem: Session is unable to restore "help" buffers properly unless "sessionoptions" includes "options".
Solution: Session provides default options for all "help" buffers.

Closes #9458