### PR TITLE
Session is unable to restore help buffers properly #2

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -348,16 +348,32 @@ put_view(
     // Edit the file.  Skip this when ":next" already did it.
     if (add_edit && (!did_next || wp->w_arg_idx_invalid))
     {
+	if (bt_help(wp->w_buffer))
+	{
+	    char_u *curtag = NULL;
+
+	    if (0 < wp->w_tagstackidx
+		    && wp->w_tagstackidx <= wp->w_tagstacklen)
+		curtag = wp->w_tagstack[wp->w_tagstackidx - 1].tagname;
+
+	    // First, create a new empty buffer with buftype=help.
+	    // Then help will re-use both the buffer and the window.
+	    if (put_line(fd, "enew | setl bt=help") == FAIL
+		    || fprintf(fd, "help %s", curtag != NULL ? curtag
+						// Will Arthur ever find it?
+						: (char_u *)"holy-grail") < 0
+		    || put_eol(fd) == FAIL)
+		return FAIL;
+	}
 # ifdef FEAT_TERMINAL
-	if (bt_terminal(wp->w_buffer))
+	else if (bt_terminal(wp->w_buffer))
 	{
 	    if (term_write_session(fd, wp, terminal_bufs) == FAIL)
 		return FAIL;
 	}
-	else
 # endif
 	// Load the file.
-	if (wp->w_buffer->b_ffname != NULL
+	else if (wp->w_buffer->b_ffname != NULL
 # ifdef FEAT_QUICKFIX
 		&& !bt_nofilename(wp->w_buffer)
 # endif

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -909,6 +909,25 @@ func Test_mksession_foldopt()
   set sessionoptions&
 endfunc
 
+" Test for mksession with help but no options
+func Test_mksession_help_noopt()
+  set sessionoptions-=options
+  set sessionoptions+=help
+  help
+  mksession! Xtest_mks.out
+  bwipe
+
+  source Xtest_mks.out
+  call assert_equal('help', &buftype)
+  call assert_equal('help', &filetype)
+  call assert_false(&modifiable)
+  call assert_true(&readonly)
+
+  helpclose
+  call delete('Xtest_mks.out')
+  set sessionoptions&
+endfunc
+
 " Test for mksession with window position
 func Test_mksession_winpos()
   " Only applicable in GUI Vim


### PR DESCRIPTION
Problem: Session is unable to restore "help" buffers properly unless "sessionoptions" includes "options".
Solution: Use :help to restore "help" buffers.

Closes #9458.
Invalidates #9472.