### PR TITLE
Fixed bug in athena gui found by a gcc-11 warning

### DIFF
--- a/src/gui_athena.c
+++ b/src/gui_athena.c
@@ -1159,7 +1159,9 @@ gui_mch_add_menu_item(vimmenu_T *menu, int idx UNUSED)
 	    XtSetArg(args[n], XtNinternalWidth, 1); n++;
 	    XtSetArg(args[n], XtNborderWidth, 1); n++;
 	    if (menu->image != 0)
+	    {
 		XtSetArg(args[n], XtNbitmap, menu->image); n++;
+	    }
 	}
 	XtSetArg(args[n], XtNhighlightThickness, 0); n++;
 	type = commandWidgetClass;


### PR DESCRIPTION
Compiling with gcc-11, I see this compilation warning which points to an ugly bug:
```
gui_athena.c:1161:13: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
 1161 |             if (menu->image != 0)
      |             ^~
gui_athena.c:1162:60: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
 1162 |                 XtSetArg(args[n], XtNbitmap, menu->image); n++;
      |                                                            ^
```
The code int `gui_athena.c:1161` looks like this:
```
  1161             if (menu->image != 0)
  1162                 XtSetArg(args[n], XtNbitmap, menu->image); n++;
```
The curly braces are needed as the `n++` statement should be inside the `if`,
but it's not.
