### PR TITLE
Regex and Breakindent fixes 

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -756,6 +756,9 @@ did_set_string_option(
     {
 	if (briopt_check(curwin) == FAIL)
 	    errmsg = e_invalid_argument;
+	// list setting requires a redraw
+	if (curwin->w_briopt_list)
+	    redraw_all_later(NOT_VALID);
     }
 #endif
 
@@ -2608,6 +2611,14 @@ ambw_end:
 #if defined(FEAT_LUA) || defined(PROTO)
     if (varp == &p_rtp)
 	update_package_paths_in_lua();
+#endif
+
+#if defined(FEAT_LINEBREAK)
+    // Changing Formatlistpattern when briopt includes the list setting:
+    // redraw
+    if ((varp == &p_flp || varp == &(curbuf->b_p_flp))
+	    && curwin->w_briopt_list)
+	redraw_all_later(NOT_VALID);
 #endif
 
     if (curwin->w_curswant != MAXCOL

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -4292,6 +4292,25 @@ sub_equal(regsub_T *sub1, regsub_T *sub2)
 
 #ifdef ENABLE_LOG
     static void
+open_debug_log(int result)
+{
+    log_fd = fopen(NFA_REGEXP_RUN_LOG, "a");
+    if (log_fd != NULL)
+    {
+	fprintf(log_fd, "****************************\n");
+	fprintf(log_fd, "FINISHED RUNNING nfa_regmatch() recursively\n");
+	fprintf(log_fd, "MATCH = %s\n", result == TRUE ? "OK" : result == MAYBE
+		? "MAYBE" : "FALSE");
+	fprintf(log_fd, "****************************\n");
+    }
+    else
+    {
+	emsg(_(e_log_open_failed));
+	log_fd = stderr;
+    }
+}
+
+    static void
 report_state(char *action,
 	     regsub_T *sub,
 	     nfa_state_T *state,
@@ -4307,6 +4326,9 @@ report_state(char *action,
     else
 	col = (int)(sub->list.line[0].start - rex.line);
     nfa_set_code(state->c);
+    if (!log_fd)
+	open_debug_log(MAYBE);
+
     fprintf(log_fd, "> %s state %d to list %d. char %d: %s (start col %d)%s\n",
 	    action, abs(state->id), lid, state->c, code, col,
 	    pim_info(pim));
@@ -5430,19 +5452,7 @@ recursive_regmatch(
     nfa_endp = save_nfa_endp;
 
 #ifdef ENABLE_LOG
-    log_fd = fopen(NFA_REGEXP_RUN_LOG, "a");
-    if (log_fd != NULL)
-    {
-	fprintf(log_fd, "****************************\n");
-	fprintf(log_fd, "FINISHED RUNNING nfa_regmatch() recursively\n");
-	fprintf(log_fd, "MATCH = %s\n", result == TRUE ? "OK" : "FALSE");
-	fprintf(log_fd, "****************************\n");
-    }
-    else
-    {
-	emsg(_(e_log_open_failed));
-	log_fd = stderr;
-    }
+    open_debug_log(result);
 #endif
 
     return result;

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -2885,7 +2885,7 @@ nfa_print_state2(FILE *debugf, nfa_state_T *state, garray_T *indent)
 	char_u	save[2];
 
 	STRNCPY(save, &p[last], 2);
-	STRNCPY(&p[last], "+-", 2);
+	memcpy(&p[last], "+-", 2);
 	fprintf(debugf, " %s", p);
 	STRNCPY(&p[last], save, 2);
     }

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -6929,7 +6929,7 @@ nfa_regmatch(
 
 #ifdef DEBUG
 		if (c < 0)
-		    siemsg("INTERNAL: Negative state char: %ld", c);
+		    siemsg("INTERNAL: Negative state char: %ld", (long)c);
 #endif
 		result = (c == curc);
 


### PR DESCRIPTION
This PR fixes a couple of minor problems:
- In DEBUG mode, fix some warnings in the NFA regexp code
- Fix a  crash when nfa_regmatch() is called recursively  and  `report_state()` is called but the `log_fd` is NULL.
- when setting the formatlistpat option and breakindent option is also set, issue a redraw, so that when you change your 'formatlistpat' option Vim will correctly redraw and update the indent for lines matching the formatlistpattern
- correctly cache the indent for the formatlistpattern, so that we do not have to match the formatlistpattern against the (potentially long lines) several times, which may cause slow down


Also the last point seems to help fixing #9309 even if not done completely. A proper fix may still be required for that.