### PR TITLE
if_ruby: Use `NORETURN()` macro

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -502,7 +502,11 @@ static int (*dll_rb_w32_snprintf)(char*, size_t, const char*, ...);
 #  endif
 # endif
 # if RUBY_VERSION >= 31
-static void (*dll_rb_unexpected_type) (VALUE, int) ATTRIBUTE_NORETURN;
+#  ifdef _MSC_VER
+static void (*dll_rb_unexpected_type) (VALUE, int);
+#  else
+NORETURN(static void (*dll_rb_unexpected_type) (VALUE, int));
+#  endif
 # endif
 # if RUBY_VERSION >= 18
 static char * (*dll_rb_string_value_ptr) (volatile VALUE*);

--- a/src/vim.h
+++ b/src/vim.h
@@ -2178,15 +2178,13 @@ typedef struct stat stat_T;
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
-# define likely(x)		__builtin_expect((x), 1)
-# define unlikely(x)		__builtin_expect((x), 0)
-# define ATTRIBUTE_COLD		__attribute__((cold))
-# define ATTRIBUTE_NORETURN	__attribute__((noreturn))
+# define likely(x)	__builtin_expect((x), 1)
+# define unlikely(x)	__builtin_expect((x), 0)
+# define ATTRIBUTE_COLD	__attribute__((cold))
 #else
 # define unlikely(x)	(x)
 # define likely(x)	(x)
 # define ATTRIBUTE_COLD
-# define ATTRIBUTE_NORETURN
 #endif
 
 typedef enum {


### PR DESCRIPTION
#9420 I added `ATTRIBUTE_NORETURN` but same feature `NORETURN()` already exists in ruby header (I had forgotten I used in the past).