### PR TITLE
ifdef out code which is not used

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -151,6 +151,7 @@ alloc(size_t size)
     return lalloc(size, TRUE);
 }
 
+#if defined(FEAT_QUICKFIX) || defined(PROTO)
 /*
  * alloc() with an ID for alloc_fail().
  */
@@ -163,6 +164,7 @@ alloc_id(size_t size, alloc_id_T id UNUSED)
 #endif
     return lalloc(size, TRUE);
 }
+#endif
 
 /*
  * Allocate memory and set all bytes to zero.
@@ -178,6 +180,7 @@ alloc_clear(size_t size)
     return p;
 }
 
+#if defined(FEAT_SIGNS) || defined(PROTO)
 /*
  * Same as alloc_clear() but with allocation id for testing
  */
@@ -190,6 +193,7 @@ alloc_clear_id(size_t size, alloc_id_T id UNUSED)
 #endif
     return alloc_clear(size);
 }
+#endif
 
 /*
  * Allocate memory like lalloc() and set all bytes to zero.
@@ -648,6 +652,7 @@ ga_clear_strings(garray_T *gap)
     ga_clear(gap);
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Copy a growing array that contains a list of strings.
  */
@@ -682,6 +687,7 @@ ga_copy_strings(garray_T *from, garray_T *to)
     to->ga_len = from->ga_len;
     return OK;
 }
+#endif
 
 /*
  * Initialize a growing array.	Don't forget to set ga_itemsize and

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -138,6 +138,7 @@ read_buffer(
     return retval;
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Ensure buffer "buf" is loaded.  Does not trigger the swap-exists action.
  */
@@ -154,6 +155,7 @@ buffer_ensure_loaded(buf_T *buf)
 	aucmd_restbuf(&aco);
     }
 }
+#endif
 
 /*
  * Open current buffer, that is: open the memfile and read the file into
@@ -5609,6 +5611,7 @@ bt_prompt(buf_T *buf)
     return buf != NULL && buf->b_p_bt[0] == 'p' && buf->b_p_bt[1] == 'r';
 }
 
+#if defined(FEAT_PROP_POPUP) || defined(PROTO)
 /*
  * Return TRUE if "buf" is a buffer for a popup window.
  */
@@ -5618,6 +5621,7 @@ bt_popup(buf_T *buf)
     return buf != NULL && buf->b_p_bt != NULL
 	&& buf->b_p_bt[0] == 'p' && buf->b_p_bt[1] == 'o';
 }
+#endif
 
 /*
  * Return TRUE if "buf" is a "nofile", "acwrite", "terminal" or "prompt"
@@ -5632,6 +5636,7 @@ bt_nofilename(buf_T *buf)
 	    || buf->b_p_bt[0] == 'p');
 }
 
+#if defined(FEAT_QUICKFIX) || defined(PROTO)
 /*
  * Return TRUE if "buf" has 'buftype' set to "nofile".
  */
@@ -5640,6 +5645,7 @@ bt_nofile(buf_T *buf)
 {
     return buf != NULL && buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f';
 }
+#endif
 
 /*
  * Return TRUE if "buf" is a "nowrite", "nofile", "terminal" or "prompt"

--- a/src/charset.c
+++ b/src/charset.c
@@ -1476,6 +1476,7 @@ skipwhite(char_u *q)
     return p;
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * skip over ' ', '\t' and '\n'.
  */
@@ -1488,6 +1489,7 @@ skipwhite_and_nl(char_u *q)
 	++p;
     return p;
 }
+#endif
 
 /*
  * getwhitecols: return the number of whitespace

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -1540,6 +1540,7 @@ clip_x11_notify_cb(Widget w UNUSED, Atom *sel_atom UNUSED, Atom *target UNUSED)
 /*
  * Property callback to get a timestamp for XtOwnSelection.
  */
+# if (defined(FEAT_X11) && defined(FEAT_XCLIPBOARD)) || defined(PROTO)
     static void
 clip_x11_timestamp_cb(
     Widget	w,
@@ -1592,6 +1593,7 @@ x11_setup_selection(Widget w)
     XtAddEventHandler(w, PropertyChangeMask, False,
 	    /*(XtEventHandler)*/clip_x11_timestamp_cb, (XtPointer)NULL);
 }
+# endif
 
     static void
 clip_x11_request_selection_cb(

--- a/src/cmdhist.c
+++ b/src/cmdhist.c
@@ -37,11 +37,13 @@ get_histentry(int hist_type)
     return history[hist_type];
 }
 
+#if defined(FEAT_VIMINFO) || defined(PROTO)
     void
 set_histentry(int hist_type, histentry_T *entry)
 {
     history[hist_type] = entry;
 }
+#endif
 
     int *
 get_hisidx(int hist_type)
@@ -49,11 +51,13 @@ get_hisidx(int hist_type)
     return &hisidx[hist_type];
 }
 
+#if defined(FEAT_VIMINFO) || defined(PROTO)
     int *
 get_hisnum(int hist_type)
 {
     return &hisnum[hist_type];
 }
+#endif
 
 /*
  * Translate a history character to the associated type number.

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -247,6 +247,7 @@ crypt_get_header_len(int method_nr)
 }
 
 
+#if defined(FEAT_SODIUM) || defined(PROTO)
 /*
  * Get maximum crypt method specific length of the file header in bytes.
  */
@@ -265,6 +266,7 @@ crypt_get_max_header_len()
     }
     return max;
 }
+#endif
 
 /*
  * Set the crypt method for buffer "buf" to "method_nr" using the int value as

--- a/src/edit.c
+++ b/src/edit.c
@@ -1715,6 +1715,7 @@ edit_putchar(int c, int highlight)
     }
 }
 
+#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
 /*
  * Set the insert start position for when using a prompt buffer.
  */
@@ -1728,6 +1729,7 @@ set_insstart(linenr_T lnum, int col)
     Insstart_blank_vcol = MAXCOL;
     arrow_used = FALSE;
 }
+#endif
 
 /*
  * Undo the previous edit_putchar().

--- a/src/eval.c
+++ b/src/eval.c
@@ -653,6 +653,7 @@ call_vim_function(
     return ret;
 }
 
+#if 0
 /*
  * Call Vim script function "func" and return the result as a number.
  * Returns -1 when calling the function fails.
@@ -693,6 +694,7 @@ call_func_noret(
     clear_tv(&rettv);
     return OK;
 }
+#endif
 
 /*
  * Call Vim script function "func" and return the result as a string.
@@ -4783,6 +4785,8 @@ set_ref_in_ht(hashtab_T *ht, int copyID, list_stack_T **list_stack)
     return abort;
 }
 
+#if defined(FEAT_LUA) || defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) \
+							|| defined(PROTO)
 /*
  * Mark a dict and its items with "copyID".
  * Returns TRUE if setting references failed somehow.
@@ -4797,6 +4801,7 @@ set_ref_in_dict(dict_T *d, int copyID)
     }
     return FALSE;
 }
+#endif
 
 /*
  * Mark a list and its items with "copyID".

--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -864,9 +864,7 @@ f_setline(typval_T *argvars, typval_T *rettv)
 }
 #endif  // FEAT_EVAL
 
-#if defined(FEAT_JOB_CHANNEL) \
-	|| defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) \
-	|| defined(PROTO)
+#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) || defined(PROTO)
 /*
  * Make "buf" the current buffer.  restore_buffer() MUST be called to undo.
  * No autocommands will be executed.  Use aucmd_prepbuf() if there are any.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3529,6 +3529,7 @@ execute_redir_str(char_u *value, int value_len)
     }
 }
 
+#if defined(FEAT_LUA) || defined(PROTO)
 /*
  * Get next line from a string containing NL separated lines.
  * Called by do_cmdline() to get the next line.
@@ -3570,6 +3571,7 @@ execute_cmds_from_string(char_u *str)
     do_cmdline(NULL, get_str_line, (void *)&str,
 	    DOCMD_NOWAIT|DOCMD_VERBOSE|DOCMD_REPEAT|DOCMD_KEYTYPED);
 }
+#endif
 
 /*
  * Get next line from a list.

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3082,6 +3082,7 @@ parse_command_modifiers(
     return OK;
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Return TRUE if "cmod" has anything set.
  */
@@ -3110,6 +3111,7 @@ cmdmod_error(int ignore_silent)
     }
     return FALSE;
 }
+#endif
 
 /*
  * Apply the command modifiers.  Saves current state in "cmdmod", call
@@ -3393,6 +3395,7 @@ append_command(char_u *cmd)
     *d = NUL;
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * If "start" points "&opt", "&l:opt", "&g:opt" or "$ENV" return a pointer to
  * the name.  Otherwise just return "start".
@@ -3413,6 +3416,7 @@ skip_option_env_lead(char_u *start)
 	name += 1;
     return name;
 }
+#endif
 
 /*
  * Find an Ex command by its name, either built-in or user.

--- a/src/globals.h
+++ b/src/globals.h
@@ -440,7 +440,9 @@ EXTERN type_T t_dict_string INIT6(VAR_DICT, 0, 0, TTFLAG_STATIC, &t_string, NULL
 
 #endif
 
+#ifdef FEAT_EVAL
 EXTERN int	did_source_packages INIT(= FALSE);
+#endif
 
 // Magic number used for hashitem "hi_key" value indicating a deleted item.
 // Only the address is used.
@@ -1153,7 +1155,9 @@ EXTERN int	ctrl_c_interrupts INIT(= TRUE);	// CTRL-C sets got_int
 
 EXTERN cmdmod_T	cmdmod;			// Ex command modifiers
 
+#ifdef FEAT_EVAL
 EXTERN int	is_export INIT(= FALSE);    // :export {cmd}
+#endif
 
 EXTERN int	msg_silent INIT(= 0);	// don't print messages
 EXTERN int	emsg_silent INIT(= 0);	// don't print error messages
@@ -1190,7 +1194,9 @@ EXTERN typebuf_T typebuf		// typeahead buffer
 #endif
 		    ;
 EXTERN int	ex_normal_busy INIT(= 0);   // recursiveness of ex_normal()
+#ifdef FEAT_EVAL
 EXTERN int	in_feedkeys INIT(= 0);	    // ex_normal_busy set in feedkeys()
+#endif
 EXTERN int	ex_normal_lock INIT(= 0);   // forbid use of ex_normal()
 
 #ifdef FEAT_EVAL
@@ -1394,8 +1400,10 @@ EXTERN char_u no_lines_msg[]	INIT(= N_("--No lines in buffer--"));
 EXTERN long	sub_nsubs;	// total number of substitutions
 EXTERN linenr_T	sub_nlines;	// total number of lines changed
 
+#ifdef FEAT_EVAL
 // Used when a compiled :substitute has an expression.
 EXTERN struct subs_expr_S	*substitute_instr INIT(= NULL);
+#endif
 
 // table to store parsed 'wildmode'
 EXTERN char_u	wim_flags[4];
@@ -1588,7 +1596,9 @@ EXTERN int netbeansSuppressNoLines INIT(= 0); // skip "No lines in buffer"
 EXTERN char top_bot_msg[]   INIT(= N_("search hit TOP, continuing at BOTTOM"));
 EXTERN char bot_top_msg[]   INIT(= N_("search hit BOTTOM, continuing at TOP"));
 
+#ifdef FEAT_EVAL
 EXTERN char line_msg[]	    INIT(= N_(" line "));
+#endif
 
 #ifdef FEAT_CRYPT
 EXTERN char need_key_msg[]  INIT(= N_("Need encryption key for \"%s\""));

--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -125,6 +125,7 @@ free_xim_stuff(void)
 }
 #endif
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Mark the global 'imactivatefunc' and 'imstatusfunc' callbacks with 'copyID'
  * so that they are not garbage collected.
@@ -134,14 +135,14 @@ set_ref_in_im_funcs(int copyID UNUSED)
 {
     int abort = FALSE;
 
-#if defined(FEAT_EVAL) && \
-    (defined(FEAT_XIM) || defined(IME_WITHOUT_XIM) || defined(VIMDLL))
+# if defined(FEAT_XIM) || defined(IME_WITHOUT_XIM) || defined(VIMDLL)
     abort = set_ref_in_callback(&imaf_cb, copyID);
     abort = abort || set_ref_in_callback(&imsf_cb, copyID);
-#endif
+# endif
 
     return abort;
 }
+#endif
 
 
 #if defined(FEAT_XIM) || defined(PROTO)

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -288,6 +288,7 @@ hash_lock(hashtab_T *ht)
     ++ht->ht_locked;
 }
 
+#if defined(FEAT_PROP_POPUP) || defined(PROTO)
 /*
  * Lock a hashtable at the specified number of entries.
  * Caller must make sure no more than "size" entries will be added.
@@ -299,6 +300,7 @@ hash_lock_size(hashtab_T *ht, int size)
     (void)hash_may_resize(ht, size);
     ++ht->ht_locked;
 }
+#endif
 
 /*
  * Unlock a hashtable: allow ht_array changes again.

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -343,6 +343,7 @@ static char *(highlight_init_dark[]) = {
     NULL
 };
 
+#if defined(FEAT_SYN_HL) || defined(PROTO)
 /*
  * Returns the number of highlight groups.
  */
@@ -369,6 +370,7 @@ highlight_link_id(int id)
 {
     return HL_TABLE()[id].sg_link;
 }
+#endif
 
     void
 init_highlight(

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -263,7 +263,9 @@ ins_ctrl_x(void)
 /*
  * Functions to check the current CTRL-X mode.
  */
+#ifdef FEAT_CINDENT
 int ctrl_x_mode_none(void) { return ctrl_x_mode == 0; }
+#endif
 int ctrl_x_mode_normal(void) { return ctrl_x_mode == CTRL_X_NORMAL; }
 int ctrl_x_mode_scroll(void) { return ctrl_x_mode == CTRL_X_SCROLL; }
 int ctrl_x_mode_whole_line(void) { return ctrl_x_mode == CTRL_X_WHOLE_LINE; }

--- a/src/main.c
+++ b/src/main.c
@@ -1091,12 +1091,15 @@ state_no_longer_safe(char *reason UNUSED)
     was_safe = FALSE;
 }
 
+#if defined(FEAT_EVAL) || defined(MESSAGE_QUEUE) || defined(PROTO)
     int
 get_was_safe_state(void)
 {
     return was_safe;
 }
+#endif
 
+#if defined(MESSAGE_QUEUE) || defined(PROTO)
 /*
  * Invoked when leaving code that invokes callbacks.  Then trigger
  * SafeStateAgain, if it was safe when starting to wait for a character.
@@ -1137,6 +1140,7 @@ may_trigger_safestateagain(void)
 		  "SafeState: back to waiting, not triggering SafeStateAgain");
 #endif
 }
+#endif
 
 
 /*

--- a/src/mark.c
+++ b/src/mark.c
@@ -1368,6 +1368,7 @@ free_all_marks(void)
 }
 #endif
 
+#if defined(FEAT_VIMINFO) || defined(PROTO)
 /*
  * Return a pointer to the named file marks.
  */
@@ -1376,6 +1377,7 @@ get_namedfm(void)
 {
     return namedfm;
 }
+#endif
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 /*

--- a/src/message.c
+++ b/src/message.c
@@ -876,6 +876,7 @@ internal_error(char *where)
     siemsg(_(e_internal_error_str), where);
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Like internal_error() but do not call abort(), to avoid tests using
  * test_unknown() and test_void() causing Vim to exit.
@@ -885,6 +886,7 @@ internal_error_no_abort(char *where)
 {
      semsg(_(e_internal_error_str), where);
 }
+#endif
 
 // emsg3() and emsgn() are in misc2.c to avoid warnings for the prototypes.
 
@@ -894,6 +896,7 @@ emsg_invreg(int name)
     semsg(_(e_invalid_register_name_str), transchar(name));
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Give an error message which contains %s for "name[len]".
  */
@@ -905,6 +908,7 @@ emsg_namelen(char *msg, char_u *name, int len)
     semsg(msg, copy == NULL ? "NULL" : (char *)copy);
     vim_free(copy);
 }
+#endif
 
 /*
  * Like msg(), but truncate to a single line if p_shm contains 't', or when

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1896,7 +1896,6 @@ vim_unsetenv(char_u *var)
     vim_setenv(var, (char_u *)"");
 #endif
 }
-#endif
 
 
 /*
@@ -1914,6 +1913,7 @@ vim_setenv_ext(char_u *name, char_u *val)
 	    && STRICMP(name, "VIMRUNTIME") == 0)
 	didset_vimruntime = FALSE;
 }
+#endif
 
 /*
  * Our portable version of setenv.
@@ -2230,6 +2230,7 @@ fast_breakcheck(void)
     }
 }
 
+# if defined(FEAT_SPELL) || defined(PROTO)
 /*
  * Like line_breakcheck() but check 100 times less often.
  */
@@ -2242,6 +2243,7 @@ veryfast_breakcheck(void)
 	ui_breakcheck();
     }
 }
+#endif
 
 #if defined(VIM_BACKTICK) || defined(FEAT_EVAL) \
 	|| (defined(HAVE_LOCALE_H) || defined(X_LOCALE)) \

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2424,6 +2424,7 @@ get_user_name(char_u *buf, int len)
     return OK;
 }
 
+#if defined(EXITFREE) || defined(PROTOS)
 /*
  * Free the memory allocated by get_user_name()
  */
@@ -2432,6 +2433,7 @@ free_username(void)
 {
     vim_free(username);
 }
+#endif
 
 #ifndef HAVE_QSORT
 /*

--- a/src/ops.c
+++ b/src/ops.c
@@ -3350,6 +3350,7 @@ free_operatorfunc_option(void)
 }
 #endif
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Mark the global 'operatorfunc' callback with 'copyID' so that it is not
  * garbage collected.
@@ -3359,12 +3360,11 @@ set_ref_in_opfunc(int copyID UNUSED)
 {
     int abort = FALSE;
 
-#ifdef FEAT_EVAL
     abort = set_ref_in_callback(&opfunc_cb, copyID);
-#endif
 
     return abort;
 }
+#endif
 
 /*
  * Handle the "g@" operator: call 'operatorfunc'.

--- a/src/option.c
+++ b/src/option.c
@@ -753,6 +753,7 @@ set_number_default(char *name, long val)
 	options[opt_idx].def_val[VI_DEFAULT] = (char_u *)(long_i)val;
 }
 
+#if defined(FEAT_PROP_POPUP) || defined(PROTO)
 /*
  * Set all window-local and buffer-local options to the Vim default.
  * local-global options will use the global value.
@@ -784,6 +785,7 @@ set_local_options_default(win_T *wp, int do_buffer)
     curwin = save_curwin;
     curbuf = curwin->w_buffer;
 }
+#endif
 
 #if defined(EXITFREE) || defined(PROTO)
 /*
@@ -5535,6 +5537,7 @@ get_option_var(int opt_idx)
     return options[opt_idx].var;
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Return the full name of the option at 'opt_idx'
  */
@@ -5543,6 +5546,7 @@ get_option_fullname(int opt_idx)
 {
     return (char_u *)options[opt_idx].fullname;
 }
+#endif
 
 /*
  * Get the value of 'equalprg', either the buffer-local one or the global one.

--- a/src/option.h
+++ b/src/option.h
@@ -486,7 +486,9 @@ EXTERN int	p_deco;		// 'delcombine'
 EXTERN char_u	*p_ccv;		// 'charconvert'
 #endif
 EXTERN int	p_cdh;		// 'cdhome'
+#ifdef FEAT_CINDENT
 EXTERN char_u	*p_cino;	// 'cinoptions'
+#endif
 #ifdef FEAT_CMDWIN
 EXTERN char_u	*p_cedit;	// 'cedit'
 EXTERN long	p_cwh;		// 'cmdwinheight'
@@ -730,13 +732,6 @@ EXTERN char_u	*p_mef;		// 'makeef'
 EXTERN char_u	*p_mp;		// 'makeprg'
 #endif
 EXTERN char_u	*p_mps;		// 'matchpairs'
-#ifdef FEAT_SIGNS
-EXTERN char_u  *p_scl;		// signcolumn
-#endif
-#ifdef FEAT_SYN_HL
-EXTERN char_u   *p_cc;		// 'colorcolumn'
-EXTERN int      p_cc_cols[256]; // array for 'colorcolumn' columns
-#endif
 EXTERN long	p_mat;		// 'matchtime'
 EXTERN long	p_mco;		// 'maxcombine'
 #ifdef FEAT_EVAL
@@ -840,7 +835,9 @@ EXTERN int	p_ru;		// 'ruler'
 EXTERN char_u	*p_ruf;		// 'rulerformat'
 #endif
 EXTERN char_u	*p_pp;		// 'packpath'
+#ifdef FEAT_QUICKFIX
 EXTERN char_u	*p_qftf;	// 'quickfixtextfunc'
+#endif
 EXTERN char_u	*p_rtp;		// 'runtimepath'
 EXTERN long	p_sj;		// 'scrolljump'
 #if defined(MSWIN) && defined(FEAT_GUI)
@@ -949,7 +946,9 @@ EXTERN unsigned	swb_flags;
 #define SWB_NEWTAB		0x008
 #define SWB_VSPLIT		0x010
 #define SWB_USELAST		0x020
+#ifdef FEAT_SYN_HL
 EXTERN char_u	*p_syn;		// 'syntax'
+#endif
 EXTERN long	p_ts;		// 'tabstop'
 EXTERN int	p_tbs;		// 'tagbsearch'
 EXTERN char_u	*p_tc;		// 'tagcase'
@@ -1026,8 +1025,8 @@ EXTERN unsigned ttym_flags;
 # define TTYM_URXVT		0x40
 # define TTYM_SGR		0x80
 #endif
-EXTERN char_u	*p_udir;	// 'undodir'
 #ifdef FEAT_PERSISTENT_UNDO
+EXTERN char_u	*p_udir;	// 'undodir'
 EXTERN int	p_udf;		// 'undofile'
 #endif
 EXTERN long	p_ul;		// 'undolevels'

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -454,6 +454,7 @@ set_string_option_direct_in_win(
     unblock_autocmds();
 }
 
+#if defined(FEAT_PROP_POPUP) || defined(PROTO)
 /*
  * Like set_string_option_direct(), but for a buffer-local option in "buf".
  * Blocks autocommands to avoid the old curbuf becoming invalid.
@@ -477,6 +478,7 @@ set_string_option_direct_in_buf(
     curwin->w_buffer = curbuf;
     unblock_autocmds();
 }
+#endif
 
 /*
  * Set a string option to a new value, and handle the effects.

--- a/src/register.c
+++ b/src/register.c
@@ -38,41 +38,53 @@ static void	copy_yank_reg(yankreg_T *reg);
 #endif
 static void	dis_msg(char_u *p, int skip_esc);
 
+#if defined(FEAT_VIMINFO) || defined(PROTO)
     yankreg_T *
 get_y_regs(void)
 {
     return y_regs;
 }
+#endif
 
+#if defined(FEAT_CLIPBOARD) || defined(PROTO)
     yankreg_T *
 get_y_register(int reg)
 {
     return &y_regs[reg];
 }
+#endif
 
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_VIMINFO) || defined(FEAT_EVAL) || defined(PROTO)
     yankreg_T *
 get_y_current(void)
 {
     return y_current;
 }
+#endif
 
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_VIMINFO) || defined(PROTO)
     yankreg_T *
 get_y_previous(void)
 {
     return y_previous;
 }
+#endif
 
+#if defined(FEAT_CLIPBOARD) || defined(PROTO)
     void
 set_y_current(yankreg_T *yreg)
 {
     y_current = yreg;
 }
+#endif
 
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_VIMINFO) || defined(PROTO)
     void
 set_y_previous(yankreg_T *yreg)
 {
     y_previous = yreg;
 }
+#endif
 
     void
 reset_y_append(void)
@@ -474,6 +486,7 @@ stuff_yank(int regname, char_u *p)
  */
 static int execreg_lastc = NUL;
 
+#if defined(FEAT_VIMINFO) || defined(PROTO)
     int
 get_execreg_lastc(void)
 {
@@ -485,6 +498,7 @@ set_execreg_lastc(int lastc)
 {
     execreg_lastc = lastc;
 }
+#endif
 
 /*
  * When executing a register as a series of ex-commands, if the
@@ -2308,6 +2322,7 @@ get_register_name(int num)
     }
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Return the index of the register "" points to.
  */
@@ -2316,6 +2331,7 @@ get_unname_register()
 {
     return y_previous == NULL ? -1 : y_previous - &y_regs[0];
 }
+#endif
 
 /*
  * ":dis" and ":registers": Display the contents of the yank registers.

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1635,8 +1635,6 @@ free_autoload_scriptnames(void)
 }
 # endif
 
-#endif
-
     linenr_T
 get_sourced_lnum(
 	char_u *(*fgetline)(int, void *, int, getline_opt_T),
@@ -1646,6 +1644,7 @@ get_sourced_lnum(
 			? ((source_cookie_T *)cookie)->sourcing_lnum
 			: SOURCING_LNUM;
 }
+#endif
 
     static char_u *
 get_one_sourceline(source_cookie_T *sp)

--- a/src/tag.c
+++ b/src/tag.c
@@ -102,6 +102,7 @@ static callback_T tfu_cb;	    // 'tagfunc' callback function
 // Used instead of NUL to separate tag fields in the growarrays.
 #define TAG_SEP 0x02
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Reads the 'tagfunc' option value and convert that to a callback value.
  * Invoked when the 'tagfunc' option is set. The option value can be a name of
@@ -125,8 +126,9 @@ set_tagfunc_option(void)
 
     return OK;
 }
+#endif
 
-#if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE) || defined(PROTO)
     void
 free_tagfunc_option(void)
 {
@@ -134,8 +136,9 @@ free_tagfunc_option(void)
     free_callback(&tfu_cb);
 # endif
 }
-#endif
+# endif
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Mark the global 'tagfunc' callback with 'copyID' so that it is not garbage
  * collected.
@@ -145,9 +148,7 @@ set_ref_in_tagfunc(int copyID UNUSED)
 {
     int	abort = FALSE;
 
-#ifdef FEAT_EVAL
     abort = set_ref_in_callback(&tfu_cb, copyID);
-#endif
 
     return abort;
 }
@@ -159,12 +160,11 @@ set_ref_in_tagfunc(int copyID UNUSED)
     void
 set_buflocal_tfu_callback(buf_T *buf UNUSED)
 {
-#ifdef FEAT_EVAL
     free_callback(&buf->b_tfu_cb);
     if (tfu_cb.cb_name != NULL && *tfu_cb.cb_name != NUL)
 	copy_callback(&buf->b_tfu_cb, &tfu_cb);
-#endif
 }
+#endif
 
 /*
  * Jump to tag; handling of tag commands and tag stack

--- a/src/term.c
+++ b/src/term.c
@@ -3991,6 +3991,7 @@ cursor_off(void)
     }
 }
 
+#ifdef FEAT_GUI
 /*
  * Check whether the cursor is invisible due to an ongoing cursor-less sleep
  */
@@ -3999,6 +4000,7 @@ cursor_is_sleeping(void)
 {
     return cursor_is_asleep;
 }
+#endif
 
 /*
  * Disable the cursor and mark it disabled by cursor-less sleep

--- a/src/typval.c
+++ b/src/typval.c
@@ -528,6 +528,7 @@ check_for_opt_dict_arg(typval_T *args, int idx)
 	    || check_for_dict_arg(args, idx) != FAIL);
 }
 
+#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
 /*
  * Give an error and return FAIL unless "args[idx]" is a channel or a job.
  */
@@ -576,6 +577,7 @@ check_for_opt_job_arg(typval_T *args, int idx)
     return (args[idx].v_type == VAR_UNKNOWN
 	    || check_for_job_arg(args, idx) != FAIL);
 }
+#endif
 
 /*
  * Give an error and return FAIL unless "args[idx]" is a string or
@@ -642,6 +644,7 @@ check_for_opt_lnum_arg(typval_T *args, int idx)
 	    || check_for_lnum_arg(args, idx));
 }
 
+#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
 /*
  * Give an error and return FAIL unless "args[idx]" is a string or a blob.
  */
@@ -655,6 +658,7 @@ check_for_string_or_blob_arg(typval_T *args, int idx)
     }
     return OK;
 }
+#endif
 
 /*
  * Give an error and return FAIL unless "args[idx]" is a string or a list.

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -319,6 +319,7 @@ get_user_commands(expand_T *xp UNUSED, int idx)
     return NULL;
 }
 
+#ifdef FEAT_EVAL
 /*
  * Get the name of user command "idx".  "cmdidx" can be CMD_USER or
  * CMD_USER_BUF.
@@ -343,6 +344,7 @@ get_user_command_name(int idx, int cmdidx)
     }
     return NULL;
 }
+#endif
 
 /*
  * Function given to ExpandGeneric() to obtain the list of user address type
@@ -394,6 +396,7 @@ get_user_cmd_complete(expand_T *xp UNUSED, int idx)
     return (char_u *)command_complete[idx].name;
 }
 
+#ifdef FEAT_EVAL
     int
 cmdcomplete_str_to_type(char_u *complete_str)
 {
@@ -405,6 +408,7 @@ cmdcomplete_str_to_type(char_u *complete_str)
 
     return EXPAND_NOTHING;
 }
+#endif
 
 /*
  * List user commands starting with "name[name_len]".

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -39,6 +39,7 @@ func_init()
     hash_init(&func_hashtab);
 }
 
+#if defined(FEAT_PROFILE) || defined(PROTO)
 /*
  * Return the function hash table
  */
@@ -47,6 +48,7 @@ func_tbl_get(void)
 {
     return &func_hashtab;
 }
+#endif
 
 /*
  * Get one function argument.

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -115,6 +115,7 @@ ex_vim9script(exarg_T *eap UNUSED)
 #endif
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * When in Vim9 script give an error and return FAIL.
  */
@@ -159,6 +160,7 @@ vim9_bad_comment(char_u *p)
     }
     return FALSE;
 }
+#endif
 
 /*
  * Return TRUE if "p" points at a "#" not followed by one '{'.

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -531,11 +531,13 @@ check_typval_type(type_T *expected, typval_T *actual_tv, where_T where)
     return res;
 }
 
+#if 0
     void
 type_mismatch(type_T *expected, type_T *actual)
 {
     arg_type_mismatch(expected, actual, 0);
 }
+#endif
 
     void
 arg_type_mismatch(type_T *expected, type_T *actual, int arg_idx)


### PR DESCRIPTION
`ifdef` out code which is not used.

Unused function were found by compiling and linking with gcc options ` -fdata-sections -ffunction-sections  -Wl,--gc-sections,--print-gc-sections`.  gcc then reports unused functions at link time. I built vim with tiny/small/normal/big/huge features, with various guis and disabled unused code.

Not done:

* many symbols could be ifdef out in `errors.h`.  I can do it as a separate PR if deemed useful enough
* many symbols are also unused in `xdiff/*.c` as when `FEAT_DIFF` is not enabled.
* for a few symbols, the expression to disable symbols could be too complex so I did not disable them.