### PR TITLE
CI: Replace codecov bash-uploader by action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
           sudo update-alternatives --set clang /usr/bin/clang-13
           sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-13 100
+          sudo update-alternatives --install /usr/bin/asan_symbolize asan_symbolize /usr/bin/asan_symbolize-13 100
 
       - name: Set up environment
         run: |
@@ -119,7 +120,6 @@ jobs:
             ;;
           esac
 
-          CFLAGS=""
           if ${{ matrix.coverage == true }}; then
             CFLAGS="$CFLAGS --coverage -DUSE_GCOV_FLUSH"
             echo "LDFLAGS=--coverage"
@@ -241,7 +241,7 @@ jobs:
         if: contains(matrix.extra, 'asan') && !cancelled()
         run: |
           for f in $(grep -lR '#[[:digit:]]* *0x[[:digit:]a-fA-F]*' "${LOG_DIR}"); do
-            asan_symbolize-13 -l "$f"
+            asan_symbolize -l "$f"
             false # in order to fail a job
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,24 +218,30 @@ jobs:
           do_test() { sg audio "sg $(id -gn) '$*'"; }
           do_test make ${SHADOWOPT} ${TEST}
 
-      #      - name: Coveralls
-      #        if: matrix.coverage && success() && github.event_name != 'pull_request'
-      #        env:
-      #          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      #          COVERALLS_PARALLEL: true
-      #          TRAVIS_JOB_ID: ${{ github.run_id }}
-      #        run: |
-      #          sudo apt-get install -y python3-setuptools python3-wheel
-      #          sudo -H pip3 install pip -U
-      #          # needed for https support for coveralls building cffi only works with gcc, not with clang
-      #          CC=gcc pip3 install --user cpp-coveralls pyopenssl ndg-httpsclient pyasn1
-      #          ~/.local/bin/coveralls -b "${SRCDIR}" -x .xs -e "${SRCDIR}"/if_perl.c -e "${SRCDIR}"/xxd -e "${SRCDIR}"/libvterm --encodings utf-8
+      # - name: Coveralls
+      #   if: matrix.coverage && success() && github.event_name != 'pull_request'
+      #   env:
+      #     COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      #     COVERALLS_PARALLEL: true
+      #     TRAVIS_JOB_ID: ${{ github.run_id }}
+      #   run: |
+      #     sudo apt-get install -y python3-setuptools python3-wheel
+      #     sudo -H pip3 install pip -U
+      #     # needed for https support for coveralls building cffi only works with gcc, not with clang
+      #     CC=gcc pip3 install --user cpp-coveralls pyopenssl ndg-httpsclient pyasn1
+      #     ~/.local/bin/coveralls -b "${SRCDIR}" -x .xs -e "${SRCDIR}"/if_perl.c -e "${SRCDIR}"/xxd -e "${SRCDIR}"/libvterm --encodings utf-8
 
-      - name: Codecov
+      - name: Generate gcov files
         if: matrix.coverage && success()
         run: |
           cd "${SRCDIR}"
-          bash <(curl -s https://codecov.io/bash) -F "${{ matrix.features }}-${{ matrix.compiler }}-${{ matrix.extra }}"
+          find . -type f -name '*.gcno' -exec gcov -pb {} + || true
+
+      - name: Codecov
+        if: matrix.coverage && success()
+        uses: codecov/codecov-action@v2
+        with:
+          flags: ${{ matrix.features }}-${{ matrix.compiler }}-${{ matrix.extra }}
 
       - name: ASan logs
         if: contains(matrix.extra, 'asan') && !cancelled()
@@ -245,18 +251,18 @@ jobs:
             false # in order to fail a job
           done
 
-  #  coveralls:
-  #    runs-on: ubuntu-18.04
+  # coveralls:
+  #   runs-on: ubuntu-18.04
   #
-  #    needs: linux
-  #    if: always() && github.event_name != 'pull_request'
+  #   needs: linux
+  #   if: always() && github.event_name != 'pull_request'
   #
-  #    steps:
-  #      - name: Parallel finished
-  #        env:
-  #          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-  #        run: |
-  #          curl -k "https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN}" -d "payload[build_num]=${GITHUB_RUN_ID}&payload[status]=done"
+  #   steps:
+  #     - name: Parallel finished
+  #       env:
+  #         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+  #       run: |
+  #         curl -k "https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN}" -d "payload[build_num]=${GITHUB_RUN_ID}&payload[status]=done"
 
   macos:
     runs-on: macos-latest


### PR DESCRIPTION
Codecov bash-uploader will be deprecated soon so should replace it by codecov-action.
https://docs.codecov.com/docs/about-the-codecov-bash-uploader

Unfortunately, when applying this patch, coverage score will get worse about 7% since codecov comes to interpret partial-line coverage exactly(?).

e.g.

total lines-partials:
v8.2.4058: 0
https://codecov.io/gh/vim/vim/tree/762838218feb223f53ab87d80928dadd991a1746/src
patched: 12072
https://codecov.io/gh/ichizok/vim/tree/fed005df197cecbe657c329fee6a2f3454e52d92/src

lines-partials in alloc.c:
v8.2.4058: 0
https://app.codecov.io/gh/vim/vim/blob/762838218feb223f53ab87d80928dadd991a1746/src/alloc.c
patched: 28
https://app.codecov.io/gh/ichizok/vim/blob/fed005df197cecbe657c329fee6a2f3454e52d92/src/alloc.c