### PR TITLE
Fix comparing uninitialized memory when reading empty file in binary mode

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -1796,7 +1796,7 @@ read_file_or_blob(typval_T *argvars, typval_T *rettv, int always_blob)
 		p < buf + readlen || (readlen <= 0 && (prevlen > 0 || binary));
 		++p)
 	{
-	    if (*p == '\n' || readlen <= 0)
+	    if (readlen <= 0 || *p == '\n')
 	    {
 		listitem_T  *li;
 		char_u	    *s	= NULL;

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -93,6 +93,13 @@ func Test_readfile_binary()
   call delete('XReadfile_bin')
 endfunc
 
+func Test_readfile_binary_empty()
+  call writefile([], 'Xempty-file')
+  " This used to compare uninitialized memory in Vim <= 8.2.4065
+  call assert_equal([''], readfile('Xempty-file', 'b'))
+  call delete('Xempty-file')
+endfunc
+
 func Test_readfile_bom()
   call writefile(["\ufeffFOO", "FOO\ufeffBAR"], 'XReadfile_bom')
   call assert_equal(['FOO', 'FOOBAR'], readfile('XReadfile_bom'))


### PR DESCRIPTION
This PR fixes comparing uninitialized memory.
Bug was reproducible with the latest vim 8.2.4065:
```
$ touch empty-file
$ valgrind --num-callers=50 --track-origins=yes ./vim --clean -c 'echo readfile("empty-file", "b")' 2> valgrind.log
$ cat valgrind.log 
==27047== Memcheck, a memory error detector
==27047== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27047== Using Valgrind-3.17.0.GIT and LibVEX; rerun with -h for copyright info
==27047== Command: ./vim --clean -c echo\ readfile("empty-file",\ "b")
==27047== 
==27047== Conditional jump or move depends on uninitialised value(s)
==27047==    at 0x1F797F: read_file_or_blob (filepath.c:1799)
==27047==    by 0x1F81C2: f_readfile (filepath.c:1977)
==27047==    by 0x1A8DA2: call_internal_func (evalfunc.c:2693)
==27047==    by 0x39FB77: call_func (userfunc.c:3490)
==27047==    by 0x39BDFB: get_func_tv (userfunc.c:1775)
==27047==    by 0x19C7BB: eval_func (eval.c:2024)
==27047==    by 0x19FD6A: eval7 (eval.c:3651)
==27047==    by 0x19F432: eval7t (eval.c:3347)
==27047==    by 0x19EE74: eval6 (eval.c:3139)
==27047==    by 0x19E5BD: eval5 (eval.c:2902)
==27047==    by 0x19E0E6: eval4 (eval.c:2755)
==27047==    by 0x19DC06: eval3 (eval.c:2616)
==27047==    by 0x19D73F: eval2 (eval.c:2490)
==27047==    by 0x19D008: eval1 (eval.c:2336)
==27047==    by 0x1A4972: ex_echo (eval.c:6201)
==27047==    by 0x1D196A: do_one_cmd (ex_docmd.c:2573)
==27047==    by 0x1CE8E0: do_cmdline (ex_docmd.c:993)
==27047==    by 0x1CDD6F: do_cmdline_cmd (ex_docmd.c:587)
==27047==    by 0x41B8E5: exe_commands (main.c:3084)
==27047==    by 0x4183ED: vim_main2 (main.c:774)
==27047==    by 0x417D2C: main (main.c:426)
==27047==  Uninitialised value was created by a stack allocation
==27047==    at 0x1F7647: read_file_or_blob (filepath.c:1727)
==27047== 
==27047== 
==27047== HEAP SUMMARY:
==27047==     in use at exit: 65,449 bytes in 859 blocks
==27047==   total heap usage: 39,166 allocs, 38,307 frees, 32,908,128 bytes allocated
==27047== 
==27047== LEAK SUMMARY:
==27047==    definitely lost: 520 bytes in 1 blocks
==27047==    indirectly lost: 132 bytes in 6 blocks
==27047==      possibly lost: 0 bytes in 0 blocks
==27047==    still reachable: 64,797 bytes in 852 blocks
==27047==         suppressed: 0 bytes in 0 blocks
==27047== Rerun with --leak-check=full to see details of leaked memory
==27047== 
==27047== For lists of detected and suppressed errors, rerun with: -s
==27047== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```