### PR TITLE
VIMDLL: Fix gvim --version

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2004,7 +2004,7 @@ command_line_scan(mparm_T *parmp)
 		{
 		    Columns = 80;	// need to init Columns
 		    info_message = TRUE; // use mch_msg(), not mch_errmsg()
-#if defined(FEAT_GUI) && !defined(ALWAYS_USE_GUI)
+#if defined(FEAT_GUI) && !defined(ALWAYS_USE_GUI) && !defined(VIMDLL)
 		    gui.starting = FALSE; // not starting GUI, will exit
 #endif
 		    list_version();


### PR DESCRIPTION
Fix that `gvim --version` didn't work since 8.2.2499 when built with VIMDLL.