### PR TITLE
Preserve buffer order when loading session

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -690,6 +690,28 @@ makeopens(
     if (put_line(fd, "set shortmess=aoO") == FAIL)
 	goto fail;
 
+    // Put all buffers into the buffer list.
+    // Do it very early to preserve buffer order after loading session (which
+    // can be disrupted by prior `edit` or `tabedit` calls).
+    FOR_ALL_BUFFERS(buf)
+    {
+	if (!(only_save_windows && buf->b_nwindows == 0)
+		&& !(buf->b_help && !(ssop_flags & SSOP_HELP))
+#ifdef FEAT_TERMINAL
+		// Skip terminal buffers: finished ones are not useful, others
+		// will be resurrected and result in a new buffer.
+		&& !bt_terminal(buf)
+#endif
+		&& buf->b_fname != NULL
+		&& buf->b_p_bl)
+	{
+	    if (fprintf(fd, "badd +%ld ", buf->b_wininfo == NULL ? 1L
+					   : buf->b_wininfo->wi_fpos.lnum) < 0
+		    || ses_fname(fd, buf, &ssop_flags, TRUE) == FAIL)
+		goto fail;
+	}
+    }
+
     // the global argument list
     if (ses_arglist(fd, "argglobal", &global_alist.al_ga,
 			    !(ssop_flags & SSOP_CURDIR), &ssop_flags) == FAIL)
@@ -741,7 +763,10 @@ makeopens(
 	// Similar to ses_win_rec() below, populate the tab pages first so
 	// later local options won't be copied to the new tabs.
 	FOR_ALL_TABPAGES(tp)
-	    if (tp->tp_next != NULL && put_line(fd, "tabnew") == FAIL)
+	    // Use `bufhidden=wipe` to remove empty "placeholder" buffers once
+	    // they are not needed. This prevents creating extra buffers (see
+	    // cause of patch 8.1.0829)
+	    if (tp->tp_next != NULL && put_line(fd, "tabnew +setlocal\\ bufhidden=wipe") == FAIL)
 		goto fail;
 	if (first_tabpage->tp_next != NULL && put_line(fd, "tabrewind") == FAIL)
 	    goto fail;
@@ -918,29 +943,6 @@ makeopens(
     }
     if (restore_stal && put_line(fd, "set stal=1") == FAIL)
 	goto fail;
-
-    // Now put the remaining buffers into the buffer list.
-    // This is near the end, so that when 'hidden' is set we don't create extra
-    // buffers.  If the buffer was already created with another command the
-    // ":badd" will have no effect.
-    FOR_ALL_BUFFERS(buf)
-    {
-	if (!(only_save_windows && buf->b_nwindows == 0)
-		&& !(buf->b_help && !(ssop_flags & SSOP_HELP))
-#ifdef FEAT_TERMINAL
-		// Skip terminal buffers: finished ones are not useful, others
-		// will be resurrected and result in a new buffer.
-		&& !bt_terminal(buf)
-#endif
-		&& buf->b_fname != NULL
-		&& buf->b_p_bl)
-	{
-	    if (fprintf(fd, "badd +%ld ", buf->b_wininfo == NULL ? 1L
-					   : buf->b_wininfo->wi_fpos.lnum) < 0
-		    || ses_fname(fd, buf, &ssop_flags, TRUE) == FAIL)
-		goto fail;
-	}
-    }
 
     // Wipe out an empty unnamed buffer we started in.
     if (put_line(fd, "if exists('s:wipebuf') && len(win_findbuf(s:wipebuf)) == 0")

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -362,6 +362,31 @@ func Test_mksession_buffer_count()
   set hidden&
 endfunc
 
+func Test_mksession_buffer_order()
+  %bwipe!
+  e Xfoo | e Xbar | e Xbaz | e Xqux
+  bufdo write
+  mksession! Xtest_mks.out
+
+  " Verify that loading the session preserves order of buffers
+  %bwipe!
+  source Xtest_mks.out
+
+  let s:buf_info = getbufinfo()
+  call assert_true(s:buf_info[0]['name'] =~# 'Xfoo$')
+  call assert_true(s:buf_info[1]['name'] =~# 'Xbar$')
+  call assert_true(s:buf_info[2]['name'] =~# 'Xbaz$')
+  call assert_true(s:buf_info[3]['name'] =~# 'Xqux$')
+
+  " Clean up.
+  call delete('Xfoo')
+  call delete('Xbar')
+  call delete('Xbaz')
+  call delete('Xqux')
+  call delete('Xtest_mks.out')
+  %bwipe!
+endfunc
+
 if has('extra_search')
 
 func Test_mksession_hlsearch()


### PR DESCRIPTION
This is a PR to fix #4352. It basically reverts 8.1.0829 and fixes its problem differently.

Current behavior is that all visible buffers along with alternative file are loaded first and then the rest ones. This happens because `badd` commands in session file are sourced near the end, after `edit` and `balt` commands. Placing `badd` commands near the end was a fix for extra empty buffers created when `hidden` was on and there were several tab pages to be restored.

After some investigation, the main reason for empty buffers seems to be plain `tabnew` calls in the beginning of session file to restore tabs (which in itself is a fix introduced in #3152, patch 8.1.0149). As a result of `tabnew`, each tab is created with new empty buffer. After later calls of `tabnext` and `edit <file>` these buffers disappear **unless** `<file>` is already loaded in another buffer.

My proposed fix is to open placeholder tab with empty buffer intentionally set to be wiped out after it is no longer needed. This change doesn't break any existing tests. The only situation I can think of where this local setting might matter is when user intentionally created session for tab with empty buffer. In that case its local `bufhidden` will be restored in later options restoration (if "options" is present in `sessionoptions`, meaning user cares about those options at all).

## What I also tried

- Temporarily setting `nohidden` and restoring. Resulted into placeholder empty buffers becoming unlisted but not completely absent.
- Removing `tabnew` calls in favor of `tabedit` calls later instead of `edit`, but it basically reverted #3152 and broke `Test_mksession_lcd_multiple_tabs()` test.

## Additional justification

In original issue it is stated that there is no clearly documented guarantee of preserving buffer order, which is true. Also it might seem like a minor thing and cosmetic change. However, besides use case from [this comment](https://github.com/vim/vim/issues/4352#issuecomment-498736235) (relying on manual buffer order in workflow), it becomes more visible when using tabline to show buffers instead of tabs, which seems to be quite common practise. In that case ever changing order is pretty inconvenient.