### PR TITLE
CI: Optimize on macOS  with tiny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install packages
+        if: matrix.features == 'huge'
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: |

--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -779,6 +779,8 @@ endfunc
 func Test_terminal_sync_shell_dir()
   CheckUnix
   " The test always use sh (see src/testdir/unix.vim).
+  " However, BSD's sh doesn't seem to play well with OSC 7 escape sequence.
+  CheckNotBSD
 
   set asd
   " , is


### PR DESCRIPTION
On macOS with features=tiny (and normal) doesn't need "Install Package" step so can skip it.

And; though v8.2.4078 enabled Test_terminal_sync_shell_dir on BSD but still quite flaky so should disable it again for now.