### PR TITLE
all output in a single line for xxd -ps -c0

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -904,9 +904,6 @@ With 'foldmethod' "indent" and appending an empty line, what follows isn't
 included in the existing fold.  Deleting the empty line and undo fixes it.
 (Oleg Koshovetc, 2018 Jul 15, #3214)
 
-Patch to support "xxd -ps". (Erik Auerswald, 2018 May 1)
-Lacks a test.
-
 Column number is wrong when using 'linebreak' and 'wrap'. (Keith Smiley, 2018
 Jan 15, #2555)
 

--- a/runtime/doc/xxd.1
+++ b/runtime/doc/xxd.1
@@ -70,6 +70,7 @@ followed by an ascii (or ebcdic) representation. The command line switches
 Format
 .RI < cols >
 octets per line. Default 16 (\-i: 12, \-ps: 30, \-b: 6). Max 256.
+No maxmimum for \-ps. With \-ps, 0 results in one line of output.
 .TP
 .IR \-C " | " \-capitalize
 Capitalize variable names in C include file style, when using \-i.

--- a/runtime/doc/xxd.man
+++ b/runtime/doc/xxd.man
@@ -42,7 +42,8 @@ OPTIONS
 
        -c cols | -cols cols
               Format  <cols> octets per line. Default 16 (-i: 12, -ps: 30, -b:
-              6). Max 256.
+              6). Max 256.  No maxmimum for -ps. With -ps, 0  results  in  one
+              line of output.
 
        -C | -capitalize
               Capitalize variable names in C include file  style,  when  using

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -54,6 +54,7 @@
  * 08.06.2013  Little-endian hexdump (-e) and offset (-o) by Vadim Vygonets.
  * 11.01.2019  Add full 64/32 bit range to -o and output by Christer Jensen.
  * 04.02.2020  Add -d for decimal offsets by Aapo Rantalainen
+ * 14.01.2022  Disable extra newlines with -c0 -p by Erik Auerswald.
  *
  * (c) 1990-1998 by Juergen Weigert (jnweiger@gmail.com)
  *
@@ -135,7 +136,7 @@ extern void perror __P((char *));
 extern long int strtol();
 extern long int ftell();
 
-char version[] = "xxd 2021-10-22 by Juergen Weigert et al.";
+char version[] = "xxd 2022-01-14 by Juergen Weigert et al.";
 #ifdef WIN32
 char osver[] = " (Win32)";
 #else
@@ -487,7 +488,7 @@ main(int argc, char *argv[])
 {
   FILE *fp, *fpo;
   int c, e, p = 0, relseek = 1, negseek = 0, revert = 0;
-  int cols = 0, nonzero = 0, autoskip = 0, hextype = HEX_NORMAL;
+  int cols = 0, colsgiven = 0, nonzero = 0, autoskip = 0, hextype = HEX_NORMAL;
   int capitalize = 0, decimal_offset = 0;
   int ebcdic = 0;
   int octspergrp = -1;	/* number of octets grouped in output */
@@ -540,11 +541,15 @@ main(int argc, char *argv[])
 	  if (pp[2] && !STRNCMP("apitalize", pp + 2, 9))
 	    capitalize = 1;
 	  else if (pp[2] && STRNCMP("ols", pp + 2, 3))
-	    cols = (int)strtol(pp + 2, NULL, 0);
+	    {
+	      colsgiven = 1;
+	      cols = (int)strtol(pp + 2, NULL, 0);
+	    }
 	  else
 	    {
 	      if (!argv[2])
 		exit_with_usage();
+	      colsgiven = 1;
 	      cols = (int)strtol(argv[2], NULL, 0);
 	      argv++;
 	      argc--;
@@ -645,7 +650,7 @@ main(int argc, char *argv[])
       argc--;
     }
 
-  if (!cols)
+  if (!colsgiven || (!cols && hextype != HEX_POSTSCRIPT))
     switch (hextype)
       {
       case HEX_POSTSCRIPT:	cols = 30; break;
@@ -667,7 +672,9 @@ main(int argc, char *argv[])
       default:			octspergrp = 0; break;
       }
 
-  if (cols < 1 || ((hextype == HEX_NORMAL || hextype == HEX_BITS || hextype == HEX_LITTLEENDIAN)
+  if ((hextype == HEX_POSTSCRIPT && cols < 0) ||
+      (hextype != HEX_POSTSCRIPT && cols < 1) ||
+      ((hextype == HEX_NORMAL || hextype == HEX_BITS || hextype == HEX_LITTLEENDIAN)
 							    && (cols > COLS)))
     {
       fprintf(stderr, "%s: invalid number of columns (max. %d).\n", pname, COLS);
@@ -787,13 +794,13 @@ main(int argc, char *argv[])
 	  putc_or_die(hexx[(e >> 4) & 0xf], fpo);
 	  putc_or_die(hexx[e & 0xf], fpo);
 	  n++;
-	  if (!--p)
+	  if (cols && !--p)
 	    {
 	      putc_or_die('\n', fpo);
 	      p = cols;
 	    }
 	}
-      if (p < cols)
+      if (!cols || p < cols)
 	putc_or_die('\n', fpo);
       fclose_or_die(fp, fpo);
       return 0;


### PR DESCRIPTION
It can be useful to have `xxd` output in plain hexdump style result
in a single line (i.e., POSIX text) without additional newlines.
Support this use case by specifying a column width of 0 (`-cols 0`).

For input data of less than or equal to `LONG_MAX` bytes, giving
`-cols $LONG_MAX` can be used.  Using `-cols 0` removes this size
limit.

On POSIX compatible systems, alternatively the output of `xxd -ps`
could be piped through `tr -d '\n'`, which removes *all* newlines
(this is no longer POSIX text), and then a newline could be appended,
e.g.:

```
$ { xxd -ps INPUT | tr -d '\n'; echo; } | wc -l
1
```

But this seems to be cumbersome to me, and xxd supports non-POSIX
platforms, too, where this does not work.

I sent a slightly different patch without any tests in May 2018[1],
but was asked to provide a test before this could be considered.
That initial patch changed more than intended, i.e., the behavior
of `-cols 0` for the other hexdump styles, while only that for
plain hexdump style should have been changed.

[1] https://groups.google.com/g/vim_dev/c/SfaksjJiDV4/m/mVAMNFpNBgAJ