### PR TITLE
win32: Support PerMonitorV2

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1433,10 +1433,6 @@ gui_position_components(int total_width UNUSED)
     if (gui.menu_is_active)
 	text_area_y += gui.menu_height;
 #endif
-#if defined(FEAT_TOOLBAR) && defined(FEAT_GUI_MSWIN)
-    if (vim_strchr(p_go, GO_TOOLBAR) != NULL)
-	text_area_y = TOOLBAR_BUTTON_HEIGHT + TOOLBAR_BORDER_HEIGHT;
-#endif
 
 # if defined(FEAT_GUI_TABLINE) && (defined(FEAT_GUI_MSWIN) \
 	|| defined(FEAT_GUI_MOTIF))
@@ -1445,7 +1441,7 @@ gui_position_components(int total_width UNUSED)
 #endif
 
 #if defined(FEAT_TOOLBAR) && (defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_ATHENA) \
-	|| defined(FEAT_GUI_HAIKU))
+	|| defined(FEAT_GUI_HAIKU) || defined(FEAT_GUI_MSWIN))
     if (vim_strchr(p_go, GO_TOOLBAR) != NULL)
     {
 # if defined(FEAT_GUI_ATHENA) || defined(FEAT_GUI_HAIKU)
@@ -1529,11 +1525,7 @@ gui_get_base_height(void)
 # endif
 # ifdef FEAT_TOOLBAR
     if (vim_strchr(p_go, GO_TOOLBAR) != NULL)
-#  if defined(FEAT_GUI_MSWIN) && defined(FEAT_TOOLBAR)
-	base_height += (TOOLBAR_BUTTON_HEIGHT + TOOLBAR_BORDER_HEIGHT);
-#  else
 	base_height += gui.toolbar_height;
-#  endif
 # endif
 # if defined(FEAT_GUI_TABLINE) && (defined(FEAT_GUI_MSWIN) \
 	|| defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_HAIKU))
@@ -4342,13 +4334,7 @@ gui_update_scrollbars(
 #if defined(FEAT_TOOLBAR) && (defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_ATHENA) \
 	|| defined(FEAT_GUI_HAIKU))
 	    if (vim_strchr(p_go, GO_TOOLBAR) != NULL)
-# if defined(FEAT_GUI_ATHENA) || defined(FEAT_GUI_HAIKU)
 		y += gui.toolbar_height;
-# else
-#  ifdef FEAT_GUI_MSWIN
-		y += TOOLBAR_BUTTON_HEIGHT + TOOLBAR_BORDER_HEIGHT;
-#  endif
-# endif
 #endif
 
 #if defined(FEAT_GUI_TABLINE) && defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_HAIKU)

--- a/src/gui.h
+++ b/src/gui.h
@@ -424,7 +424,7 @@ typedef struct Gui
 #endif
 
 #if defined(FEAT_TOOLBAR) \
-	&& (defined(FEAT_GUI_ATHENA) || defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_HAIKU))
+	&& (defined(FEAT_GUI_ATHENA) || defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_HAIKU) || defined(FEAT_GUI_MSWIN))
     int		toolbar_height;	    // height of the toolbar
 #endif
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -3329,7 +3329,7 @@ update_im_font(void)
 
     lf = norm_logfont;
     if (s_process_dpi_aware == DPI_AWARENESS_UNAWARE)
-	lf.lfHeight = lf.lfHeight * 96 / s_dpi;
+	lf.lfHeight = lf.lfHeight * DEFAULT_DPI / s_dpi;
     im_set_font(&lf);
 }
 #endif
@@ -5814,7 +5814,7 @@ _OnImeNotify(HWND hWnd, DWORD dwCommand, DWORD dwData UNUSED)
 	    {
 		LOGFONTW lf = norm_logfont;
 		if (s_process_dpi_aware == DPI_AWARENESS_UNAWARE)
-		    lf.lfHeight = lf.lfHeight * 96 / s_dpi;
+		    lf.lfHeight = lf.lfHeight * DEFAULT_DPI / s_dpi;
 		pImmSetCompositionFontW(hImc, &lf);
 		im_set_position(gui.row, gui.col);
 
@@ -5985,8 +5985,8 @@ im_set_position(int row, int col)
 	MapWindowPoints(s_textArea, s_hwnd, &cfs.ptCurrentPos, 1);
 	if (s_process_dpi_aware == DPI_AWARENESS_UNAWARE)
 	{
-	    cfs.ptCurrentPos.x = cfs.ptCurrentPos.x * 96 / s_dpi;
-	    cfs.ptCurrentPos.y = cfs.ptCurrentPos.y * 96 / s_dpi;
+	    cfs.ptCurrentPos.x = cfs.ptCurrentPos.x * DEFAULT_DPI / s_dpi;
+	    cfs.ptCurrentPos.y = cfs.ptCurrentPos.y * DEFAULT_DPI / s_dpi;
 	}
 	pImmSetCompositionWindow(hImc, &cfs);
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -3316,7 +3316,7 @@ logfont2name(LOGFONTW lf)
     static void
 update_im_font(void)
 {
-    LOGFONTW	lf_wide, lf;
+    LOGFONTW	lf_wide;
 
     if (p_guifontwide != NULL && *p_guifontwide != NUL
 	    && gui.wide_font != NOFONT
@@ -3324,9 +3324,7 @@ update_im_font(void)
 	norm_logfont = lf_wide;
     else
 	norm_logfont = sub_logfont;
-    lf = norm_logfont;
-    lf.lfHeight = lf.lfHeight * (int)pGetDpiForSystem() / s_dpi;
-    im_set_font(&lf);
+    im_set_font(&norm_logfont);
 }
 #endif
 
@@ -5802,10 +5800,7 @@ _OnImeNotify(HWND hWnd, DWORD dwCommand, DWORD dwData UNUSED)
 	case IMN_SETOPENSTATUS:
 	    if (pImmGetOpenStatus(hImc))
 	    {
-		LOGFONTW lf = norm_logfont;
-
-		lf.lfHeight = lf.lfHeight * (int)pGetDpiForSystem() / s_dpi;
-		pImmSetCompositionFontW(hImc, &lf);
+		pImmSetCompositionFontW(hImc, &norm_logfont);
 		im_set_position(gui.row, gui.col);
 
 		// Disable langmap
@@ -5973,8 +5968,6 @@ im_set_position(int row, int col)
 	cfs.ptCurrentPos.x = FILL_X(col);
 	cfs.ptCurrentPos.y = FILL_Y(row);
 	MapWindowPoints(s_textArea, s_hwnd, &cfs.ptCurrentPos, 1);
-	cfs.ptCurrentPos.x = cfs.ptCurrentPos.x * (int)pGetDpiForSystem() / s_dpi;
-	cfs.ptCurrentPos.y = cfs.ptCurrentPos.y * (int)pGetDpiForSystem() / s_dpi;
 	pImmSetCompositionWindow(hImc, &cfs);
 
 	pImmReleaseContext(s_hwnd, hImc);

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -3329,6 +3329,7 @@ update_im_font(void)
 
     lf = norm_logfont;
     if (s_process_dpi_aware == DPI_AWARENESS_UNAWARE)
+	// Work around when PerMonitorV2 is not enabled in the process level.
 	lf.lfHeight = lf.lfHeight * DEFAULT_DPI / s_dpi;
     im_set_font(&lf);
 }
@@ -5338,6 +5339,12 @@ load_dpi_func(void)
 	{
 	    TRACE("DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 enabled");
 	    s_process_dpi_aware = pGetAwarenessFromDpiAwarenessContext(oldctx);
+#ifdef DEBUG
+	    if (s_process_dpi_aware == DPI_AWARENESS_UNAWARE)
+	    {
+		TRACE("WARNING: PerMonitorV2 is not enabled in the process level for some reasons. IME window may not shown correctly.");
+	    }
+#endif
 	    return;
 	}
     }
@@ -5814,6 +5821,7 @@ _OnImeNotify(HWND hWnd, DWORD dwCommand, DWORD dwData UNUSED)
 	    {
 		LOGFONTW lf = norm_logfont;
 		if (s_process_dpi_aware == DPI_AWARENESS_UNAWARE)
+		    // Work around when PerMonitorV2 is not enabled in the process level.
 		    lf.lfHeight = lf.lfHeight * DEFAULT_DPI / s_dpi;
 		pImmSetCompositionFontW(hImc, &lf);
 		im_set_position(gui.row, gui.col);
@@ -5985,6 +5993,7 @@ im_set_position(int row, int col)
 	MapWindowPoints(s_textArea, s_hwnd, &cfs.ptCurrentPos, 1);
 	if (s_process_dpi_aware == DPI_AWARENESS_UNAWARE)
 	{
+	    // Work around when PerMonitorV2 is not enabled in the process level.
 	    cfs.ptCurrentPos.x = cfs.ptCurrentPos.x * DEFAULT_DPI / s_dpi;
 	    cfs.ptCurrentPos.y = cfs.ptCurrentPos.y * DEFAULT_DPI / s_dpi;
 	}

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -40,6 +40,8 @@ static void directx_binddc(void);
 
 #ifdef FEAT_MENU
 static int gui_mswin_get_menu_height(int fix_window);
+#else
+# define gui_mswin_get_menu_height(fix_window)	0
 #endif
 
 #if defined(FEAT_RENDER_OPTIONS) || defined(PROTO)
@@ -2931,10 +2933,8 @@ _OnSize(
     {
 	gui_resize_shell(cx, cy);
 
-#ifdef FEAT_MENU
 	// Menu bar may wrap differently now
 	gui_mswin_get_menu_height(TRUE);
-#endif
     }
 }
 
@@ -3024,10 +3024,7 @@ gui_mswin_get_valid_dimensions(
 	+ (pGetSystemMetricsForDpi(SM_CYFRAME, s_dpi) +
 	   pGetSystemMetricsForDpi(SM_CXPADDEDBORDER, s_dpi)) * 2
 	+ pGetSystemMetricsForDpi(SM_CYCAPTION, s_dpi)
-#ifdef FEAT_MENU
-	+ gui_mswin_get_menu_height(FALSE)
-#endif
-	;
+	+ gui_mswin_get_menu_height(FALSE);
     *cols = (w - base_width) / gui.char_width;
     *rows = (h - base_height) / gui.char_height;
     *valid_w = base_width + *cols * gui.char_width;
@@ -3505,20 +3502,13 @@ gui_mch_newfont(void)
 	    - (pGetSystemMetricsForDpi(SM_CYFRAME, s_dpi) +
 	       pGetSystemMetricsForDpi(SM_CXPADDEDBORDER, s_dpi)) * 2
 	    - pGetSystemMetricsForDpi(SM_CYCAPTION, s_dpi)
-#ifdef FEAT_MENU
-	    - gui_mswin_get_menu_height(FALSE)
-#endif
-	);
+	    - gui_mswin_get_menu_height(FALSE));
     }
     else
     {
 	// Inside another window, don't use the frame and border.
 	gui_resize_shell(rect.right - rect.left,
-	    rect.bottom - rect.top
-#ifdef FEAT_MENU
-			- gui_mswin_get_menu_height(FALSE)
-#endif
-	);
+	    rect.bottom - rect.top - gui_mswin_get_menu_height(FALSE));
     }
 }
 
@@ -4641,9 +4631,11 @@ _OnDpiChanged(HWND hwnd, UINT xdpi, UINT ydpi, RECT *rc)
     update_scrollbar_size();
     update_toolbar_size();
     set_tabline_font();
+
     gui_init_font(*p_guifont == NUL ? hl_get_font_name() : p_guifont, FALSE);
     gui_mswin_get_menu_height(FALSE);
     InvalidateRect(hwnd, NULL, TRUE);
+
     s_in_dpichanged = FALSE;
     return 0L;
 }
@@ -5369,7 +5361,7 @@ gui_mch_init(void)
 
     load_dpi_func();
 
-    s_dpi = pGetDpiForSystem(s_hwnd);
+    s_dpi = pGetDpiForSystem();
     update_scrollbar_size();
 
 #ifdef FEAT_MENU
@@ -5676,10 +5668,7 @@ gui_mch_set_shellsize(
     win_height = height + (pGetSystemMetricsForDpi(SM_CYFRAME, s_dpi) +
 		       pGetSystemMetricsForDpi(SM_CXPADDEDBORDER, s_dpi)) * 2
 			+ pGetSystemMetricsForDpi(SM_CYCAPTION, s_dpi)
-#ifdef FEAT_MENU
-			+ gui_mswin_get_menu_height(FALSE)
-#endif
-			;
+			+ gui_mswin_get_menu_height(FALSE);
 
     // The following should take care of keeping Vim on the same monitor, no
     // matter if the secondary monitor is left or right of the primary
@@ -5706,10 +5695,8 @@ gui_mch_set_shellsize(
     SetActiveWindow(s_hwnd);
     SetFocus(s_hwnd);
 
-#ifdef FEAT_MENU
     // Menu may wrap differently now
     gui_mswin_get_menu_height(!gui.starting);
-#endif
 }
 
 
@@ -6586,10 +6573,7 @@ gui_mch_get_screen_dimensions(int *screen_w, int *screen_h)
 		- (pGetSystemMetricsForDpi(SM_CYFRAME, s_dpi) +
 		   pGetSystemMetricsForDpi(SM_CXPADDEDBORDER, s_dpi)) * 2
 		- pGetSystemMetricsForDpi(SM_CYCAPTION, s_dpi)
-#ifdef FEAT_MENU
-		- gui_mswin_get_menu_height(FALSE)
-#endif
-		;
+		- gui_mswin_get_menu_height(FALSE);
 }
 
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -4252,6 +4252,8 @@ static void initialise_toolbar(void);
 static void update_toolbar_size(void);
 static LRESULT CALLBACK toolbar_wndproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 static int get_toolbar_bitmap(vimmenu_T *menu);
+#else
+# define update_toolbar_size()
 #endif
 
 #ifdef FEAT_GUI_TABLINE
@@ -4514,6 +4516,8 @@ set_tabline_font(void)
      */
     gui.tabline_height = tm.tmHeight + tm.tmInternalLeading + 7;
 }
+#else
+# define set_tabline_font()
 #endif
 
 /*
@@ -4525,10 +4529,8 @@ _OnSettingChange(UINT n)
     if (n == SPI_SETWHEELSCROLLLINES)
 	SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0,
 		&mouse_scroll_lines, 0);
-#if defined(FEAT_GUI_TABLINE) && defined(USE_SYSMENU_FONT)
     if (n == SPI_SETNONCLIENTMETRICS)
 	set_tabline_font();
-#endif
     return 0;
 }
 
@@ -4637,12 +4639,8 @@ _OnDpiChanged(HWND hwnd, UINT xdpi, UINT ydpi, RECT *rc)
     //TRACE("DPI: %d", ydpi);
 
     update_scrollbar_size();
-#ifdef FEAT_TOOLBAR
     update_toolbar_size();
-#endif
-#if defined(FEAT_GUI_TABLINE) && defined(USE_SYSMENU_FONT)
     set_tabline_font();
-#endif
     gui_init_font(*p_guifont == NUL ? hl_get_font_name() : p_guifont, FALSE);
     gui_mswin_get_menu_height(FALSE);
     InvalidateRect(hwnd, NULL, TRUE);
@@ -8251,9 +8249,7 @@ initialise_tabline(void)
 
     gui.tabline_height = TABLINE_HEIGHT;
 
-# ifdef USE_SYSMENU_FONT
     set_tabline_font();
-# endif
 }
 
 /*

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -1526,6 +1526,13 @@ gui_mswin_find_scrollbar(HWND hwnd)
     return NULL;
 }
 
+    static void
+update_scrollbar_size(void)
+{
+    gui.scrollbar_width = pGetSystemMetricsForDpi(SM_CXVSCROLL, s_dpi);
+    gui.scrollbar_height = pGetSystemMetricsForDpi(SM_CYHSCROLL, s_dpi);
+}
+
 /*
  * Get the character size of a font.
  */
@@ -4629,9 +4636,7 @@ _OnDpiChanged(HWND hwnd, UINT xdpi, UINT ydpi, RECT *rc)
     s_in_dpichanged = TRUE;
     //TRACE("DPI: %d", ydpi);
 
-    gui.scrollbar_width = pGetSystemMetricsForDpi(SM_CXVSCROLL, s_dpi);
-    gui.scrollbar_height = pGetSystemMetricsForDpi(SM_CYHSCROLL, s_dpi);
-
+    update_scrollbar_size();
 #ifdef FEAT_TOOLBAR
     update_toolbar_size();
 #endif
@@ -5366,8 +5371,9 @@ gui_mch_init(void)
 
     load_dpi_func();
 
-    gui.scrollbar_width = pGetSystemMetricsForDpi(SM_CXVSCROLL, s_dpi);
-    gui.scrollbar_height = pGetSystemMetricsForDpi(SM_CYHSCROLL, s_dpi);
+    s_dpi = pGetDpiForSystem(s_hwnd);
+    update_scrollbar_size();
+
 #ifdef FEAT_MENU
     gui.menu_height = 0;	// Windows takes care of this
 #endif
@@ -5466,8 +5472,7 @@ gui_mch_init(void)
     if (pGetDpiForWindow != NULL)
     {
 	s_dpi = pGetDpiForWindow(s_hwnd);
-	gui.scrollbar_width = pGetSystemMetricsForDpi(SM_CXVSCROLL, s_dpi);
-	gui.scrollbar_height = pGetSystemMetricsForDpi(SM_CYHSCROLL, s_dpi);
+	update_scrollbar_size();
 	//TRACE("System DPI: %d, DPI: %d", pGetDpiForSystem(), s_dpi);
     }
 
@@ -7155,15 +7160,15 @@ gui_mch_dialog(
 	// Use our own window for the size, unless it's very small.
 	GetWindowRect(s_hwnd, &rect);
 	maxDialogWidth = rect.right - rect.left
-		   - (pGetSystemMetricsForDpi(SM_CXFRAME, dpi) +
-		      pGetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi)) * 2;
+		       - (pGetSystemMetricsForDpi(SM_CXFRAME, dpi) +
+			  pGetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi)) * 2;
 	if (maxDialogWidth < adjust_by_system_dpi(DLG_MIN_MAX_WIDTH))
 	    maxDialogWidth = adjust_by_system_dpi(DLG_MIN_MAX_WIDTH);
 
 	maxDialogHeight = rect.bottom - rect.top
-		   - (pGetSystemMetricsForDpi(SM_CYFRAME, dpi) +
-		      pGetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi)) * 4
-		   - pGetSystemMetricsForDpi(SM_CYCAPTION, dpi);
+		       - (pGetSystemMetricsForDpi(SM_CYFRAME, dpi) +
+			  pGetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi)) * 4
+		       - pGetSystemMetricsForDpi(SM_CYCAPTION, dpi);
 	if (maxDialogHeight < adjust_by_system_dpi(DLG_MIN_MAX_HEIGHT))
 	    maxDialogHeight = adjust_by_system_dpi(DLG_MIN_MAX_HEIGHT);
     }

--- a/src/vim.manifest
+++ b/src/vim.manifest
@@ -5,7 +5,7 @@
   Do ":help uganda"  in Vim to read copying and usage conditions.
   Do ":help credits" in Vim to see a list of people who contributed.
 -->
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity
     processorArchitecture="*"
     version="8.2.0.0"
@@ -51,7 +51,7 @@
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       <!--The ID below indicates application support for Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-      <!--The ID below indicates application support for Windows 10 -->
+      <!--The ID below indicates application support for Windows 10 and 11 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>

--- a/src/vim.manifest
+++ b/src/vim.manifest
@@ -37,8 +37,9 @@
   </trustInfo>
   <!-- Vista High DPI aware -->
   <asmv3:application>
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">


### PR DESCRIPTION
Improve High DPI support by using PerMonitorV2.

Close #3102

Implementation notes:
* PerMoniterV2 should be able to enable by using manifest. However, on some environments, it didn't work.
  Use `SetThreadDpiAwarenessContext()` to enable it explicitly.
* Currently gVim uses system DPI. Add support for per-monitor DPI only where it is needed. Font size is still managed with system DPI in most places.
* Dialog box is created by using system DPI. Let Windows scale it automatically.
* Don't consider PerMonitorV1.
  V2 is available since Windows 10 1703. It is already 5 years ago.
* Size of toolbar button is adjusted based on per-monitor DPI.
  However, toolbar bitmap is shown dot-by-dot, and it is not scaled.