### PR TITLE
Change BV_VE to WV_VE

### DIFF
--- a/src/option.h
+++ b/src/option.h
@@ -1235,7 +1235,6 @@ enum
     , BV_VSTS
     , BV_VTS
 #endif
-    , BV_VE
     , BV_COUNT	    // must be the last one
 };
 
@@ -1287,6 +1286,7 @@ enum
 #endif
     , WV_NU
     , WV_RNU
+    , WV_VE
 #ifdef FEAT_LINEBREAK
     , WV_NUW
 #endif

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -156,7 +156,6 @@
 # define PV_VSTS		OPT_BUF(BV_VSTS)
 # define PV_VTS		OPT_BUF(BV_VTS)
 #endif
-#define PV_VE		OPT_BOTH(OPT_BUF(BV_VE))
 
 // Definition of the PV_ values for window-local options.
 // The WV_ values are defined in option.h.
@@ -192,6 +191,7 @@
 #define PV_LCS		OPT_BOTH(OPT_WIN(WV_LCS))
 #define PV_NU		OPT_WIN(WV_NU)
 #define PV_RNU		OPT_WIN(WV_RNU)
+#define PV_VE		OPT_BOTH(OPT_WIN(WV_VE))
 #ifdef FEAT_LINEBREAK
 # define PV_NUW		OPT_WIN(WV_NUW)
 #endif


### PR DESCRIPTION
`'virtualedit'` was changed to window-local in patch 8.2.3280, so `BV_VE` should be changed to `WV_VE`.