### PR TITLE
CI: Reduce packages installing on linux job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,25 +63,30 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install packages
-        if: matrix.features == 'huge'
         run: |
-          sudo apt update && sudo apt install -y \
-            autoconf \
-            lcov \
+          PKGS=( \
             gettext \
-            libcanberra-dev \
-            libperl-dev \
-            python-dev \
-            python3-dev \
-            liblua5.3-dev \
-            lua5.3 \
-            ruby-dev \
-            tcl-dev \
-            cscope \
             libgtk2.0-dev \
             desktop-file-utils \
             libtool-bin \
-            libsodium-dev
+          )
+          if ${{ matrix.features == 'huge' }}; then
+            PKGS+=( \
+              autoconf \
+              lcov \
+              libcanberra-dev \
+              libperl-dev \
+              python-dev \
+              python3-dev \
+              liblua5.3-dev \
+              lua5.3 \
+              ruby-dev \
+              tcl-dev \
+              cscope \
+              libsodium-dev \
+            )
+          fi
+          sudo apt update && sudo apt install -y "${PKGS[@]}"
 
       - name: Install clang-13
         if: matrix.compiler == 'clang'
@@ -284,6 +289,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install packages
+        if: matrix.features == 'huge'
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: |


### PR DESCRIPTION
Ref: https://github.com/vim/vim/commit/ece07639f4989a300276d66b13553c21a7435030#r63914673

On linux job, most of the packages are needed only when features=huge.
