### PR TITLE
Fixed build error when configuring with --disable-channel

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2902,7 +2902,6 @@ mch_parse_cmd(char_u *cmd, int use_shcf, char ***argv, int *argc)
     return OK;
 }
 
-# if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
 /*
  * Build "argv[argc]" from the string "cmd".
  * "argv[argc]" is set to NULL;
@@ -2929,6 +2928,7 @@ build_argv_from_string(char_u *cmd, char ***argv, int *argc)
     return OK;
 }
 
+# if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
 /*
  * Build "argv[argc]" from the list "l".
  * "argv[argc]" is set to NULL;


### PR DESCRIPTION
This PR fixes a link error when configuring and building vim with:
```
$ ./configure --with-features=huge --enable-gui=none --disable-channel
$ make
...snip...
/usr/local/bin/ld: objects/if_cscope.o: in function `cs_create_connection':
/home/pel/sb/vim/src/if_cscope.c:990: undefined reference to `build_argv_from_string'
collect2: error: ld returned 1 exit status
```
The error was introduced by this recent change:
```
patch 8.2.4081: CodeQL reports problem in if_cscope causing it to fail

Problem:    CodeQL reports problem in if_cscope causing it to fail.
Solution:   Use execvp() instead of execl().  Merge the header file into the 
            source file. (Ozaki Kiichi, closes #9519)
```