### PR TITLE
Fix Test_terminal_basic on win32

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1642,6 +1642,7 @@ EXTERN int  nfa_fail_for_testing INIT(= FALSE);
 EXTERN int  no_query_mouse_for_testing INIT(= FALSE);
 EXTERN int  ui_delay_for_testing INIT(= 0);
 EXTERN int  reset_term_props_on_termresponse INIT(= FALSE);
+EXTERN int  disable_vterm_title_for_testing INIT(= FALSE);
 EXTERN long override_sysinfo_uptime INIT(= -1);
 EXTERN int  override_autoload INIT(= FALSE);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3088,6 +3088,8 @@ handle_settermprop(
     switch (prop)
     {
 	case VTERM_PROP_TITLE:
+	    if (disable_vterm_title_for_testing)
+		break;
 	    strval = vim_strnsave((char_u *)value->string.str,
 							    value->string.len);
 	    if (strval == NULL)

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -14,6 +14,7 @@ let s:python = PythonProg()
 let $PROMPT_COMMAND=''
 
 func Test_terminal_basic()
+  call test_override('vterm_title', 1)
   au TerminalOpen * let b:done = 'yes'
   let buf = Run_shell_in_terminal({})
 
@@ -37,6 +38,7 @@ func Test_terminal_basic()
   call assert_equal("", bufname(buf))
 
   au! TerminalOpen
+  call test_override('ALL', 0)
   unlet g:job
 endfunc
 

--- a/src/testing.c
+++ b/src/testing.c
@@ -1053,6 +1053,8 @@ f_test_override(typval_T *argvars, typval_T *rettv UNUSED)
 	    ui_delay_for_testing = val;
 	else if (STRCMP(name, (char_u *)"term_props") == 0)
 	    reset_term_props_on_termresponse = val;
+	else if (STRCMP(name, (char_u *)"vterm_title") == 0)
+	    disable_vterm_title_for_testing = val;
 	else if (STRCMP(name, (char_u *)"uptime") == 0)
 	    override_sysinfo_uptime = val;
 	else if (STRCMP(name, (char_u *)"autoload") == 0)


### PR DESCRIPTION
Why Test_terminal_basic is flaky on win32 is that:
When user is Administrator, just after vterm starts, vterm receives `OSC 0; Administrator:  ` from pty (winpty) and the terminal title will change to `Administrator:  `.
Therefore, in this case, the status text doesn't include `[running]`.