### PR TITLE
Treat tmux like xterm so you get focused gained/lost events.

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2348,6 +2348,7 @@ vim_is_xterm(char_u *name)
 		|| STRNICMP(name, "mlterm", 6) == 0
 		|| STRNICMP(name, "rxvt", 4) == 0
 		|| STRNICMP(name, "screen.xterm", 12) == 0
+		|| STRNICMP(name, "tmux", 4) == 0
 		|| STRCMP(name, "builtin_xterm") == 0);
 }
 


### PR DESCRIPTION
This change allows vim to get Focused Gained/Lost events when running with TERM set to `tmux` or `tmux-256color`. These values must be used under tmux per their [FAQ](https://github.com/tmux/tmux/wiki/FAQ):

> PLEASE NOTE: most display problems are due to incorrect TERM! Before
> reporting problems make SURE that TERM settings are correct inside and
> outside tmux.
> 
>Inside tmux TERM must be "screen", "tmux" or similar (such as
>"tmux-256color").  Don't bother reporting problems where it isn't!
>
> Outside, it should match your terminal: particularly, use "rxvt" for rxvt
> and derivatives.

## Tested On

```
$ uname -a
Linux ip-172-16-0-117 5.10.0-10-cloud-amd64 #1 SMP Debian 5.10.84-1 (2021-12-08) x86_64 GNU/Linux
```