### PR TITLE
Minor documentation fix: 'gdb program' -> 'debugged program'

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1178,7 +1178,7 @@ gdb window	A terminal window in which "gdb vim" is executed.  Here you
 program window	A terminal window for the executed program.  When "run" is
 		used in gdb the program I/O will happen in this window, so
 		that it does not interfere with controlling gdb.  The buffer
-		name is "gdb program".
+		name is "debugged program".
 
 The current window is used to show the source code.  When gdb pauses the
 source file location will be displayed, if possible.  A sign is used to


### PR DESCRIPTION
The source code is updated, but not the documentation.

Link to related parts

https://github.com/vim/vim/blob/2f0936cb9a2eb026acac03e6a8fd0b2a5d97508b/runtime/doc/terminal.txt#L1181

the commit:

https://github.com/vim/vim/commit/b3307b5e7e7bd3962b0d5c61a94e638564c146b0#diff-f17e0dd888d6e8cd63e14b598ed3a141e59870e04a35701b66c93ddb175f2a57L79