### PR TITLE
v_P does not overwrite unnamed registers

### DIFF
--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -265,7 +265,7 @@ Additionally the following commands can be used:
 	X	delete (2)					|v_X|
 	Y	yank (2)					|v_Y|
 	p	put						|v_p|
-	P	put without register overwrite			|v_P|
+	P	put without unnamed register overwrite		|v_P|
 	J	join (1)					|v_J|
 	U	make uppercase					|v_U|
 	u	make lowercase					|v_u|

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -265,6 +265,7 @@ Additionally the following commands can be used:
 	X	delete (2)					|v_X|
 	Y	yank (2)					|v_Y|
 	p	put						|v_p|
+	P	put without register overwrite			|v_P|
 	J	join (1)					|v_J|
 	U	make uppercase					|v_U|
 	u	make lowercase					|v_u|

--- a/src/normal.c
+++ b/src/normal.c
@@ -7566,9 +7566,9 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    }
 
 	    // Now delete the selected text. Avoid messages here.
+	    cap->oap->regname = cap->cmdchar == 'P' ? '_' : NUL;
 	    cap->cmdchar = 'd';
 	    cap->nchar = NUL;
-	    cap->oap->regname = NUL;
 	    ++msg_silent;
 	    nv_operator(cap);
 	    do_pending_operator(cap, 0, FALSE);

--- a/src/normal.c
+++ b/src/normal.c
@@ -7552,9 +7552,9 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    // Need to save and restore the registers that the delete
 	    // overwrites if the old contents is being put.
 	    was_visual = TRUE;
-	    save_unnamed = cap->cmdchar == 'P';
 	    regname = cap->oap->regname;
 #ifdef FEAT_CLIPBOARD
+	    save_unnamed = cap->cmdchar == 'P';
 	    adjust_clip_reg(&regname);
 #endif
 	   if (regname == 0 || regname == '"'

--- a/src/normal.c
+++ b/src/normal.c
@@ -7576,6 +7576,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    }
 	    cap->cmdchar = 'd';
 	    cap->nchar = NUL;
+	    cap->oap->regname = NUL;
 	    ++msg_silent;
 	    nv_operator(cap);
 	    do_pending_operator(cap, 0, FALSE);

--- a/src/normal.c
+++ b/src/normal.c
@@ -7504,7 +7504,9 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		dir;
     int		flags = 0;
     int		save_unnamed = FALSE;
+#if defined(FEAT_CLIPBOARD) || defined(PROTO)
     yankreg_T	*old_y_current, *old_y_previous;
+#endif
 
     if (cap->oap->op_type != OP_NOP)
     {

--- a/src/normal.c
+++ b/src/normal.c
@@ -7568,12 +7568,14 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 		reg1 = get_register(regname, TRUE);
 	    }
 
+#if defined(FEAT_CLIPBOARD) || defined(PROTO)
 	    // Now delete the selected text. Avoid messages here.
 	    if (save_unnamed)
 	    {
 		old_y_current = get_y_current();
 		old_y_previous = get_y_previous();
 	    }
+#endif
 	    cap->cmdchar = 'd';
 	    cap->nchar = NUL;
 	    cap->oap->regname = NUL;
@@ -7582,11 +7584,14 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    do_pending_operator(cap, 0, FALSE);
 	    empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
 	    --msg_silent;
+
+#if defined(FEAT_CLIPBOARD) || defined(PROTO)
 	    if (save_unnamed)
 	    {
 		set_y_current(old_y_current);
 		set_y_previous(old_y_previous);
 	    }
+#endif
 
 	    // delete PUT_LINE_BACKWARD;
 	    cap->oap->regname = regname;

--- a/src/normal.c
+++ b/src/normal.c
@@ -7503,8 +7503,8 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		was_visual = FALSE;
     int		dir;
     int		flags = 0;
+#ifdef FEAT_CLIPBOARD
     int		save_unnamed = FALSE;
-#if defined(FEAT_CLIPBOARD) || defined(PROTO)
     yankreg_T	*old_y_current, *old_y_previous;
 #endif
 
@@ -7570,7 +7570,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 		reg1 = get_register(regname, TRUE);
 	    }
 
-#if defined(FEAT_CLIPBOARD) || defined(PROTO)
+#ifdef FEAT_CLIPBOARD
 	    // Now delete the selected text. Avoid messages here.
 	    if (save_unnamed)
 	    {
@@ -7587,7 +7587,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
 	    --msg_silent;
 
-#if defined(FEAT_CLIPBOARD) || defined(PROTO)
+#ifdef FEAT_CLIPBOARD
 	    if (save_unnamed)
 	    {
 		set_y_current(old_y_current);

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1368,14 +1368,18 @@ func Test_visual_paste()
   " v_p overwrites unnamed register.
   call setline(1, ['xxxx'])
   call setreg('"', 'foo')
+  call setreg('-', 'bar')
   normal 1Gvp
   call assert_equal(@", 'x')
+  call assert_equal(@-, 'x')
 
   " v_P does not overwrite unnamed register.
   call setline(1, ['xxxx'])
   call setreg('"', 'foo')
+  call setreg('-', 'bar')
   normal 1GvP
   call assert_equal(@", 'foo')
+  call assert_equal(@-, 'x')
 
   bwipe!
 endfunc

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1373,13 +1373,15 @@ func Test_visual_paste()
   call assert_equal(@", 'x')
   call assert_equal(@-, 'x')
 
-  " v_P does not overwrite unnamed register.
-  call setline(1, ['xxxx'])
-  call setreg('"', 'foo')
-  call setreg('-', 'bar')
-  normal 1GvP
-  call assert_equal(@", 'foo')
-  call assert_equal(@-, 'x')
+  if has('clipboard')
+    " v_P does not overwrite unnamed register.
+    call setline(1, ['xxxx'])
+    call setreg('"', 'foo')
+    call setreg('-', 'bar')
+    normal 1GvP
+    call assert_equal(@", 'foo')
+    call assert_equal(@-, 'x')
+  endif
 
   bwipe!
 endfunc

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1335,6 +1335,7 @@ func Test_visual_exchange_windows()
   bwipe!
 endfunc
 
+<<<<<<< HEAD
 " this was leaving the end of the Visual area beyond the end of a line
 func Test_visual_ex_copy_line()
   new
@@ -1358,8 +1359,26 @@ func Test_visual_undo_deletes_last_line()
   exe "normal ggvjfxO"
   undo
   normal gNU
+
   bwipe!
 endfunc
 
+func Test_visual_paste()
+  new
+
+  " v_p overwrites unnamed register.
+  call setline(1, ['xxxx'])
+  call setreg('"', 'foo')
+  normal 1Gvp
+  call assert_equal(@", 'x')
+
+  " v_P does not overwrite unnamed register.
+  call setline(1, ['xxxx'])
+  call setreg('"', 'foo')
+  normal 1GvP
+  call assert_equal(@", 'foo')
+
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1335,7 +1335,6 @@ func Test_visual_exchange_windows()
   bwipe!
 endfunc
 
-<<<<<<< HEAD
 " this was leaving the end of the Visual area beyond the end of a line
 func Test_visual_ex_copy_line()
   new


### PR DESCRIPTION
I have changed `v_P` behavior.
Current both `v_p` and `v_P` behavior overwrites unnamed register.
But it is very annoying if I want to replace more words.

`vim-operator-replace` is available for it.
https://github.com/kana/vim-operator-replace
But I think it should be builtin key mapping.