### PR TITLE
win32: Always enable multiline balloon

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5104,8 +5104,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 #endif
 		},
 	{"balloon_multiline",
-#if defined(FEAT_BEVAL_GUI) && !defined(FEAT_GUI_MSWIN)
-			// MS-Windows requires runtime check, see below
+#ifdef FEAT_BEVAL_GUI
 		1
 #else
 		0
@@ -6079,10 +6078,6 @@ f_has(typval_T *argvars, typval_T *rettv)
 	{
 	    // intentionally empty
 	}
-#if defined(FEAT_BEVAL) && defined(FEAT_GUI_MSWIN)
-	else if (STRICMP(name, "balloon_multiline") == 0)
-	    n = multiline_balloon_available();
-#endif
 #ifdef VIMDLL
 	else if (STRICMP(name, "filterpipe") == 0)
 	    n = gui.in_use || gui.starting;
@@ -6261,9 +6256,6 @@ f_has(typval_T *argvars, typval_T *rettv)
 dynamic_feature(char_u *feature)
 {
     return (feature == NULL
-#if defined(FEAT_BEVAL) && defined(FEAT_GUI_MSWIN)
-	    || STRICMP(feature, "balloon_multiline") == 0
-#endif
 #if defined(FEAT_GUI) && defined(FEAT_BROWSE)
 	    || (STRICMP(feature, "browse") == 0 && !gui.in_use)
 #endif

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -90,7 +90,6 @@ void gui_mch_set_foreground(void);
 void gui_mch_drawsign(int row, int col, int typenr);
 void *gui_mch_register_sign(char_u *signfile);
 void gui_mch_destroy_sign(void *sign);
-int multiline_balloon_available(void);
 void gui_mch_disable_beval_area(BalloonEval *beval);
 void gui_mch_enable_beval_area(BalloonEval *beval);
 void gui_mch_post_balloon(BalloonEval *beval, char_u *mesg);


### PR DESCRIPTION
Multiline balloon is always available on Windows XP or later.
We don't need to check it dynamically anymore.