### PR TITLE
Clear mod_mask for i_CTRL-V_digit; Break get_literal() loop if the key has non-Shift modifiers 

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -1986,7 +1986,11 @@ get_literal(int noReduceKeys)
 	--allow_keys;
 #endif
     if (nc)
+    {
 	vungetc(nc);
+	// A character typed with i_CTRL-V_digit cannot have a mod_mask.
+	mod_mask = 0;
+    }
     got_int = FALSE;	    // CTRL-C typed after CTRL-V is not an interrupt
     return cc;
 }

--- a/src/edit.c
+++ b/src/edit.c
@@ -1908,6 +1908,10 @@ get_literal(int noReduceKeys)
 	nc = plain_vgetc();
 	if ((nc == ESC || nc == CSI) && !noReduceKeys)
 	    nc = decodeModifyOtherKeys(nc);
+	if ((mod_mask & ~MOD_MASK_SHIFT) != 0)
+	    // A character with non-Shift modifiers should not be
+	    // a valid character for i_CTRL-V_digit.
+	    break;
 
 #ifdef FEAT_CMDL_INFO
 	if (!(State & CMDLINE) && MB_BYTE2LEN_CHECK(nc) == 1)

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -1073,14 +1073,10 @@ func Test_edit_DROP()
 endfunc
 
 func Test_edit_CTRL_V()
-  CheckFeature ebcdic
+  CheckNotFeature ebcdic
   new
   call setline(1, ['abc'])
   call cursor(2, 1)
-  " force some redraws
-  set showmode showcmd
-  "call test_override_char_avail(1)
-  call test_override('ALL', 1)
   call feedkeys("A\<c-v>\<c-n>\<c-v>\<c-l>\<c-v>\<c-b>\<esc>", 'tnix')
   call assert_equal(["abc\x0e\x0c\x02"], getline(1, '$'))
 
@@ -1093,8 +1089,16 @@ func Test_edit_CTRL_V()
     set norl
   endif
 
-  call test_override('ALL', 0)
-  set noshowmode showcmd
+  " No modifiers should be applied to the char typed using i_CTRL-V_digit.
+  call feedkeys(":append\<CR>\<C-V>76c\<C-V>76\<C-F2>\<C-V>u3c0j\<C-V>u3c0\<M-F3>\<CR>.\<CR>", 'tnix')
+  call assert_equal('LcL<C-F2>πjπ<M-F3>', getline(2))
+
+  if has('osx')
+    " A char with a modifier should not be a valid char for i_CTRL-V_digit.
+    call feedkeys("o\<C-V>\<D-j>\<C-V>\<D-1>\<C-V>\<D-o>\<C-V>\<D-x>\<C-V>\<D-u>", 'tnix')
+    call assert_equal('<D-j><D-1><D-o><D-x><D-u>', getline(3))
+  endif
+
   bw!
 endfunc
 

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -15,6 +15,11 @@ endfunc
 func Test_edit_ctrl_v()
   call feedkeys("i\<C-V>76c\<C-V>76\<C-F2>\<C-V>u3c0j\<C-V>u3c0\<M-F3>", 'tx')
   call assert_equal('LcL<C-F2>πjπ<M-F3>', getline(1))
+
+  if has('osx')
+    call feedkeys("o\<C-V>\<D-j>\<C-V>\<D-1>\<C-V>\<D-o>\<C-V>\<D-x>\<C-V>\<D-u>", 'tx')
+    call assert_equal('<D-j><D-1><D-o><D-x><D-u>', getline(2))
+  endif
 endfunc
 
 " Test for built-in functions strchars() and strcharlen()

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -12,6 +12,11 @@ func Test_visual_block_insert()
   bwipeout!
 endfunc
 
+func Test_edit_ctrl_v()
+  call feedkeys("i\<C-V>76c\<C-V>76\<C-F2>\<C-V>u3c0j\<C-V>u3c0\<M-F3>", 'tx')
+  call assert_equal('LcL<C-F2>πjπ<M-F3>', getline(1))
+endfunc
+
 " Test for built-in functions strchars() and strcharlen()
 func Test_strchars()
   let inp = ["a", "あいa", "A\u20dd", "A\u20dd\u20dd", "\u20dd"]

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -12,16 +12,6 @@ func Test_visual_block_insert()
   bwipeout!
 endfunc
 
-func Test_edit_ctrl_v()
-  call feedkeys("i\<C-V>76c\<C-V>76\<C-F2>\<C-V>u3c0j\<C-V>u3c0\<M-F3>", 'tx')
-  call assert_equal('LcL<C-F2>πjπ<M-F3>', getline(1))
-
-  if has('osx')
-    call feedkeys("o\<C-V>\<D-j>\<C-V>\<D-1>\<C-V>\<D-o>\<C-V>\<D-x>\<C-V>\<D-u>", 'tx')
-    call assert_equal('<D-j><D-1><D-o><D-x><D-u>', getline(2))
-  endif
-endfunc
-
 " Test for built-in functions strchars() and strcharlen()
 func Test_strchars()
   let inp = ["a", "あいa", "A\u20dd", "A\u20dd\u20dd", "\u20dd"]


### PR DESCRIPTION
If one types something like `<C-V>u3c0<M-F3>` in ~~Insert~~ Cmdline mode, the `<M-` modifier is also applied to the `π` typed using `i_CTRL-V_digit`, which doesn't seem right. The solution is to just clear `mod_mask`, as a character typed using `i_CTRL-V_digit` cannot have a `mod_mask`.