### PR TITLE
Proposal: Support end_lnum (`%e`) and end_col (`%k`) with errorformat

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1385,12 +1385,17 @@ Basic items
 	%f		file name (finds a string)
 	%o		module name (finds a string)
 	%l		line number (finds a number)
+	%e		end of line number (finds a number)
 	%c		column number (finds a number representing character
 			column of the error, byte index, a <tab> is 1
 			character column)
 	%v		virtual column number (finds a number representing
 			screen column of the error (1 <tab> == 8 screen
 			columns))
+	%k		end of column number (finds a number representing
+			character column of the error, byte index, or a number
+			representing screen column of the error if it's used
+			with %v)
 	%t		error type (finds a single character):
 			    e - error message
 			    w - warning message

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1468,6 +1468,29 @@ func Test_efm_error_type()
   let &efm = save_efm
 endfunc
 
+" Test for end_lnum ('%e') and end_col ('%k') fields in 'efm'
+func Test_efm_end_lnum_col()
+  let save_efm = &efm
+
+  " single line
+  set efm=%f:%l-%e:%c-%k:%t:%m
+  cexpr ["Xfile1:10-20:1-2:E:msg1", "Xfile1:20-30:2-3:W:msg2",]
+  let output = split(execute('clist'), "\n")
+  call assert_equal([
+        \ ' 1 Xfile1:10-20 col 1-2 error: msg1',
+        \ ' 2 Xfile1:20-30 col 2-3 warning: msg2'], output)
+
+  " multiple lines
+  set efm=%A%n)%m,%Z%f:%l-%e:%c-%k
+  cexpr ["1)msg1", "Xfile1:14-24:1-2",
+        \ "2)msg2", "Xfile1:24-34:3-4"]
+  let output = split(execute('clist'), "\n")
+  call assert_equal([
+        \ ' 1 Xfile1:14-24 col 1-2 error   1: msg1',
+        \ ' 2 Xfile1:24-34 col 3-4 error   2: msg2'], output)
+  let &efm = save_efm
+endfunc
+
 func XquickfixChangedByAutocmd(cchar)
   call s:setup_commands(a:cchar)
   if a:cchar == 'c'


### PR DESCRIPTION
As described in #8393, modern tools may be able to specify range when outputting the location of the source code.

While #8393 added end_lnum and end_col support to quickfix entry, errorformat did not support parsing end lnum/col. This PR added end_lnum (`%e`) and end_col (`%k`) errorformat support.

Example: gopls (Go Language Server) CLI interface support outputting locations with the following format.
```
<file-name>:<lnum>[-<end_lnum>]:<col>[-<end_col>]: <message>
```

Actual message example:
```
/path/to/reviewdog/reviewdog/reviewdog.go:39:9-26: Sprintf format %s reads arg #1, but call has 0 args
```

What do you think?