### PR TITLE
Suppress warnings and fix a mistake

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -705,7 +705,7 @@ ga_init(garray_T *gap)
 ga_init2(garray_T *gap, size_t itemsize, int growsize)
 {
     ga_init(gap);
-    gap->ga_itemsize = itemsize;
+    gap->ga_itemsize = (int)itemsize;
     gap->ga_growsize = growsize;
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -4089,7 +4089,7 @@ eval_method(
 	    else
 	    {
 		name = deref;
-		len = STRLEN(name);
+		len = (long)STRLEN(name);
 	    }
 	    *paren = '(';
 	}

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -587,7 +587,7 @@ handle_import(
     {
 	imported_T  *imported;
 
-	imported = find_imported(as_name, FALSE, STRLEN(as_name), cctx);
+	imported = find_imported(as_name, STRLEN(as_name), FALSE, cctx);
 	if (imported != NULL && imported->imp_sid != sid)
 	{
 	    semsg(_(e_name_already_defined_str), as_name);


### PR DESCRIPTION
> alloc.c(708) : warning C4267: '=' : conversion from 'size_t' to 'int', possible loss of data
> eval.c(4092) : warning C4267: '=' : conversion from 'size_t' to 'long', possible loss of data
> vim9script.c(590) : warning C4267: 'function' : conversion from 'size_t' to 'int', possible loss of data