### PR TITLE
Only call ungetchars() if the first char in Select mode is typed

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -1054,9 +1054,12 @@ normal_cmd(
 	// be mapped in Insert mode.  Required for ":lmap" to work.
 	len = ins_char_typebuf(vgetc_char, vgetc_mod_mask);
 
-	// When recording the character will be recorded again, remove the
-	// previously recording.
-	ungetchars(len);
+	if (KeyTyped)
+	{
+	    // When recording the character will be recorded again, remove the
+	    // previous recording.
+	    ungetchars(len);
+	}
 
 	if (restart_edit != 0)
 	    c = 'd';

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -745,6 +745,17 @@ func Test_record_in_select_mode()
   sil norm q00
   sil norm q
   call assert_equal('0ext', getline(1))
+
+  %delete
+  let @r = ''
+  call setline(1, ['abc', 'abc', 'abc'])
+  smap <F2> <Right><Right>,
+  call feedkeys("qrgh\<F2>Dk\<Esc>q", 'xt')
+  call assert_equal("gh\<F2>Dk\<Esc>", @r)
+  norm j0@rj0@@
+  call assert_equal([',Dk', ',Dk', ',Dk'], getline(1, 3))
+  sunmap <F2>
+
   bwipe!
 endfunc
 


### PR DESCRIPTION
If the char comes from a mapping, it will not be recorded again, and the previously recorded char is not the same one, so calling `ungetchars()` removes the wrong bytes from the recorded register, especially when that previously recorded char is a special char.