### PR TITLE
win32: Suppress warnings

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -5780,7 +5780,7 @@ latin9_to_ucs(char_u *text, int len, WCHAR *unicodebuf)
  * noticeably so.
  */
     static void
-RevOut( HDC s_hdc,
+RevOut( HDC hdc,
 	int col,
 	int row,
 	UINT foptions,
@@ -5792,7 +5792,7 @@ RevOut( HDC s_hdc,
     int		ix;
 
     for (ix = 0; ix < (int)len; ++ix)
-	ExtTextOut(s_hdc, col + TEXT_X(ix), row, foptions,
+	ExtTextOut(hdc, col + TEXT_X(ix), row, foptions,
 					pcliprect, text + ix, 1, padding);
 }
 #endif
@@ -5868,7 +5868,6 @@ gui_mch_draw_string(
 {
     static int	*padding = NULL;
     static int	pad_size = 0;
-    int		i;
     const RECT	*pcliprect = NULL;
     UINT	foptions = 0;
     static WCHAR *unicodebuf = NULL;
@@ -5959,6 +5958,8 @@ gui_mch_draw_string(
 
     if (pad_size != Columns || padding == NULL || padding[0] != gui.char_width)
     {
+	int	i;
+
 	vim_free(padding);
 	pad_size = Columns;
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -427,7 +427,7 @@ peek_console_input(
     DWORD	    nLength UNUSED,
     LPDWORD	    lpEvents)
 {
-    return read_console_input(hInput, lpBuffer, -1, lpEvents);
+    return read_console_input(hInput, lpBuffer, (DWORD)-1, lpEvents);
 }
 
 # ifdef FEAT_CLIENTSERVER
@@ -439,7 +439,7 @@ msg_wait_for_multiple_objects(
     DWORD    dwMilliseconds,
     DWORD    dwWakeMask)
 {
-    if (read_console_input(NULL, NULL, -2, NULL))
+    if (read_console_input(NULL, NULL, (DWORD)-2, NULL))
 	return WAIT_OBJECT_0;
     return MsgWaitForMultipleObjects(nCount, pHandles, fWaitAll,
 				     dwMilliseconds, dwWakeMask);
@@ -5537,7 +5537,7 @@ mch_signal_job(job_T *job, char_u *how)
 	{
 	    if (job->jv_channel != NULL && job->jv_channel->ch_anonymous_pipe)
 		job->jv_channel->ch_killing = TRUE;
-	    return TerminateJobObject(job->jv_job_object, -1) ? OK : FAIL;
+	    return TerminateJobObject(job->jv_job_object, (UINT)-1) ? OK : FAIL;
 	}
 	return terminate_all(job->jv_proc_info.hProcess, -1) ? OK : FAIL;
     }
@@ -6270,7 +6270,7 @@ write_chars(
 	    cchwritten = 1;
     }
 
-    if (cchwritten == length)
+    if (cchwritten == (DWORD)length)
     {
 	written = cbToWrite;
 	g_coord.X += (SHORT)cells;


### PR DESCRIPTION
Suppress some warnings when compiled with the /W4 option.