### PR TITLE
win32: Support Ruby 3.1.0

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -466,6 +466,8 @@ RUBY_PLATFORM = i586-mswin32
 RUBY_PLATFORM = i386-mingw32
   else ifneq ($(wildcard $(RUBY)/lib/ruby/$(RUBY_API_VER_LONG)/x64-mingw32),)
 RUBY_PLATFORM = x64-mingw32
+  else ifneq ($(wildcard $(RUBY)/lib/ruby/$(RUBY_API_VER_LONG)/x64-mingw-ucrt),)
+RUBY_PLATFORM = x64-mingw-ucrt
   else
 RUBY_PLATFORM = i386-mswin32
   endif
@@ -479,7 +481,9 @@ RUBY_INSTALL_NAME = mswin32-ruby$(RUBY_API_VER)
 # Base name of msvcrXX.dll which is used by ruby's dll.
 RUBY_MSVCRT_NAME = msvcrt
    endif
-   ifeq ($(ARCH),x86-64)
+   ifeq ($(RUBY_PLATFORM),x64-mingw-ucrt)
+RUBY_INSTALL_NAME = x64-ucrt-ruby$(RUBY_API_VER)
+   else ifeq ($(ARCH),x86-64)
 RUBY_INSTALL_NAME = x64-$(RUBY_MSVCRT_NAME)-ruby$(RUBY_API_VER)
    else
 RUBY_INSTALL_NAME = $(RUBY_MSVCRT_NAME)-ruby$(RUBY_API_VER)

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1186,7 +1186,11 @@ RUBY_MSVCRT_NAME = $(MSVCRT_NAME)
 !   if "$(CPU)" == "i386"
 RUBY_INSTALL_NAME = $(RUBY_MSVCRT_NAME)-ruby$(RUBY_API_VER)
 !   else # CPU
+!    if EXIST($(RUBY)/lib/ruby/$(RUBY_API_VER_LONG)/x64-mingw-ucrt)
+RUBY_INSTALL_NAME = x64-ucrt-ruby$(RUBY_API_VER)
+!    else
 RUBY_INSTALL_NAME = x64-$(RUBY_MSVCRT_NAME)-ruby$(RUBY_API_VER)
+!    endif
 !   endif # CPU
 !  endif # RUBY_INSTALL_NAME
 


### PR DESCRIPTION
RubyInstaller 3.1.0 x64 is now built with ucrt64 instead of mingw64.
Adjust DLL name and include directory.