### PR TITLE
html indentation: add configuration option for attribute level

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -778,6 +778,14 @@ You can set the indent for the first line after <script> and <style>
       "auto"	auto indent (same indent as the blocktag)
       "inc"	auto indent + one indent step
 
+You can set the indent for attributes after open <tag lines: >
+
+      :let g:html_indent_attribute = "auto"
+<
+      VALUE	MEANING ~
+      "auto"	auto indent (one indent step more than <tag)
+      "inc"	auto indent + one indent step (default)
+
 Many tags increase the indent for what follows per default (see "Add Indent
 Tags" in the script).  You can add further tags with: >
 

--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -1,7 +1,7 @@
 " Vim indent script for HTML
 " Maintainer:	Bram Moolenaar
 " Original Author: Andy Wokula <anwoku@yahoo.de>
-" Last Change:	2021 Jun 13
+" Last Change:	2021 Jan 28
 " Version:	1.0 "{{{
 " Description:	HTML indent script with cached state for faster indenting on a
 "		range of lines.
@@ -149,6 +149,21 @@ func HtmlIndent_CheckUserSettings()
       let b:html_indent_line_limit = 200
     endif
   endif
+
+  let attr_level_opt = {"auto": 1 ,"inc": 2}
+
+  let attr_level = ''
+  if exists('b:html_indent_attribute')
+    let attr_level = b:html_indent_attribute
+  elseif exists('g:html_indent_attribute')
+    let attr_level = g:html_indent_attribute
+  endif
+  if len(attr_level) > 0
+    let b:hi_attr_indent = get(attr_level_opt, attr_level, attr_level_opt.inc)
+  else
+    let b:hi_attr_indent = attr_level_opt.inc
+  endif
+
 endfunc "}}}
 
 " Init Script Vars
@@ -946,11 +961,11 @@ func s:InsideTag(foundHtmlString)
       let idx = match(text, '<' . s:tagname . '\s\+\zs\w')
     endif
     if idx == -1
-      " after just "<tag" indent two levels more
+      " after just "<tag" indent two levels more by default
       let idx = match(text, '<' . s:tagname . '$')
       if idx >= 0
 	call cursor(lnum, idx + 1)
-	return virtcol('.') - 1 + shiftwidth() * 2
+	return virtcol('.') - 1 + shiftwidth() * b:hi_attr_indent
       endif
     endif
     if idx > 0

--- a/runtime/indent/testdir/html.in
+++ b/runtime/indent/testdir/html.in
@@ -1,4 +1,4 @@
-" vim: set ft=html sw=4 :
+" vim: set ft=html sw=4 ts=8 :
 
 
 " START_INDENT
@@ -41,6 +41,11 @@ dd text
 dt text
 </dt>
 </dl>
+<div
+class="test"
+style="color: yellow">
+text
+</div>
 
     </body>
 </html>
@@ -50,6 +55,7 @@ dt text
 % START_INDENT
 % INDENT_EXE let g:html_indent_style1 = "inc"
 % INDENT_EXE let g:html_indent_script1 = "zero"
+% INDENT_EXE let g:html_indent_attribute = "auto"
 % INDENT_EXE call HtmlIndent_CheckUserSettings()
 <html>
     <body>
@@ -61,6 +67,11 @@ div#d2 { color: green; }
 	var v1 = "v1";
 var v2 = "v2";
     </script>
+<div
+class="test"
+style="color: yellow">
+text
+</div>
 </body>
 </html>
 % END_INDENT

--- a/runtime/indent/testdir/html.ok
+++ b/runtime/indent/testdir/html.ok
@@ -1,4 +1,4 @@
-" vim: set ft=html sw=4 :
+" vim: set ft=html sw=4 ts=8 :
 
 
 " START_INDENT
@@ -41,6 +41,11 @@ div#d2 { color: green; }
 		dt text
 	    </dt>
 	</dl>
+	<div
+		class="test"
+		style="color: yellow">
+	    text
+	</div>
 
     </body>
 </html>
@@ -50,6 +55,7 @@ div#d2 { color: green; }
 % START_INDENT
 % INDENT_EXE let g:html_indent_style1 = "inc"
 % INDENT_EXE let g:html_indent_script1 = "zero"
+% INDENT_EXE let g:html_indent_attribute = "auto"
 % INDENT_EXE call HtmlIndent_CheckUserSettings()
 <html>
     <body>
@@ -61,6 +67,11 @@ div#d2 { color: green; }
 var v1 = "v1";
 var v2 = "v2";
 	</script>
+	<div
+	    class="test"
+	    style="color: yellow">
+	    text
+	</div>
     </body>
 </html>
 % END_INDENT


### PR DESCRIPTION
In 942db23c9cb7532d68048530d749eb84ca94d0cd, the indentation for html attributes was changed from 1 level to two levels.
While this may be preferable to some, many coding standards/tools default to a single level of indentation.

This PR adds a configuration option to switch between one level and two, defaulting to two levels.
Exact naming of the option/its values is open to bikeshed.

The CONTRIBUTING.MD file said to contact the maintainer directly for runtime files, presumably per mail. However, the maintainer is Bram himself, and it seems that Github PRs for runtime files are common, so I decided on a PR out of convenience. I can also send the patch per mail if preferred.