### PR TITLE
Fix FORM and Visual Basic form file detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -67,7 +67,10 @@ func dist#ft#FTasmsyntax()
   endif
 endfunc
 
-func dist#ft#FTbas(alt = '')
+let s:ft_visual_basic_content = '\cVB_Name\|Begin VB\.\(Form\|MDIForm\|UserControl\)'
+
+" See FTfrm() for Visual Basic form file detection
+func dist#ft#FTbas()
   if exists("g:filetype_bas")
     exe "setf " . g:filetype_bas
     return
@@ -86,10 +89,8 @@ func dist#ft#FTbas(alt = '')
     setf freebasic
   elseif match(lines, qb64_preproc) > -1
     setf qb64
-  elseif match(lines, '\cVB_Name\|Begin VB\.\(Form\|MDIForm\|UserControl\)') > -1
+  elseif match(lines, s:ft_visual_basic_content) > -1
     setf vb
-  elseif a:alt != ''
-    exe 'setf ' .. a:alt
   else
     setf basic
   endif
@@ -234,6 +235,21 @@ func dist#ft#FTe()
       let n = n + 1
     endwhile
     setf eiffel
+  endif
+endfunc
+
+func dist#ft#FTfrm()
+  if exists("g:filetype_frm")
+    exe "setf " . g:filetype_frm
+    return
+  endif
+
+  let lines = getline(1, min([line("$"), 5]))
+
+  if match(lines, s:ft_visual_basic_content) > -1
+    setf vb
+  else
+    setf form
   endif
 endfunc
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -142,7 +142,8 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.asm		g:asmsyntax	|ft-asm-syntax|
 	*.asp		g:filetype_asp	|ft-aspvbs-syntax| |ft-aspperl-syntax|
 	*.bas		g:filetype_bas	|ft-basic-syntax|
-	*.fs		g:filetype_fs   |ft-forth-syntax|
+	*.frm		g:filetype_frm	|ft-form-syntax|
+	*.fs		g:filetype_fs	|ft-forth-syntax|
 	*.i		g:filetype_i	|ft-progress-syntax|
 	*.inc		g:filetype_inc
 	*.m		g:filetype_m	|ft-mathematica-syntax|

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1536,6 +1536,14 @@ The enhanced mode also takes advantage of additional color features for a dark
 gvim display.  Here, statements are colored LightYellow instead of Yellow, and
 conditionals are LightBlue for better distinction.
 
+Both Visual Basic and FORM use the extension ".frm".  To detect which one
+should be used, Vim checks for the string "VB_Name" in the first five lines of
+the file.  If it is found, filetype will be "vb", otherwise "form".
+
+If the automatic detection doesn't work for you or you only edit, for
+example, FORM files, use this in your startup vimrc: >
+   :let filetype_frm = "form"
+
 
 FORTH						*forth.vim* *ft-forth-syntax*
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2051,7 +2051,7 @@ au BufRead,BufNewFile *.hw,*.module,*.pkg
 	\ endif
 
 " Visual Basic (also uses *.bas) or FORM
-au BufNewFile,BufRead *.frm			call dist#ft#FTbas('form')
+au BufNewFile,BufRead *.frm			call dist#ft#FTfrm()
 
 " SaxBasic is close to Visual Basic
 au BufNewFile,BufRead *.sba			setf vb

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -183,6 +183,7 @@ let s:filename_checks = {
     \ 'fgl': ['file.4gl', 'file.4gh', 'file.m4gl'],
     \ 'fish': ['file.fish'],
     \ 'focexec': ['file.fex', 'file.focexec'],
+    \ 'form': ['file.frm'],
     \ 'forth': ['file.ft', 'file.fth'],
     \ 'fortran': ['file.f', 'file.for', 'file.fortran', 'file.fpp', 'file.ftn', 'file.f77', 'file.f90', 'file.f95', 'file.f03', 'file.f08'],
     \ 'fpcmake': ['file.fpc'],
@@ -1275,6 +1276,33 @@ func Test_bas_file()
   bwipe!
 
   call delete('Xfile.bas')
+  filetype off
+endfunc
+
+func Test_frm_file()
+  filetype on
+
+  call writefile(['looks like FORM'], 'Xfile.frm')
+  split Xfile.frm
+  call assert_equal('form', &filetype)
+  bwipe!
+
+  " Test dist#ft#FTfrm()
+
+  let g:filetype_frm = 'form'
+  split Xfile.frm
+  call assert_equal('form', &filetype)
+  bwipe!
+  unlet g:filetype_frm
+
+  " Visual Basic
+
+  call writefile(['Begin VB.Form Form1'], 'Xfile.frm')
+  split Xfile.frm
+  call assert_equal('vb', &filetype)
+  bwipe!
+
+  call delete('Xfile.frm')
   filetype off
 endfunc
 


### PR DESCRIPTION
Thanks for the fix @lacygoill.

It seems to me that it's a little bit simpler and more consistent with the general strategies used in ft.vim to just have a separate function to disambiguate the uses of `*.frm` rather than mix it in with the BASIC detection.  I've also added a `g:filetype_frm` override for completeness but it may be impossible to confuse the two so I can remove that if it's considered overkill.


Sorry for missing that the first time around.
