### PR TITLE
force restricted-mode for nologin shell

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -256,6 +256,8 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 		Interfaces, such as Python, Ruby and Lua, are also disabled,
 		since they could be used to execute shell commands.  Perl uses
 		the Safe module.
+		For Unix restricted mode is always on when $SHELL is set to
+		"nologin" or "false".
 		Note that the user may still find a loophole to execute a
 		shell command, it has only been made difficult.
 

--- a/src/option.c
+++ b/src/option.c
@@ -307,6 +307,13 @@ set_init_1(int clean_arg)
      */
     set_options_default(0);
 
+#ifdef UNIX
+    // Force restricted-mode on for "nologin" or "false" $SHELL
+    p = get_isolated_shell_name();
+    if (fnamecmp(p, "nologin") == 0 || fnamecmp(p, "false") == 0)
+	restricted = TRUE;
+#endif
+
 #ifdef CLEAN_RUNTIMEPATH
     if (clean_arg)
     {

--- a/src/option.c
+++ b/src/option.c
@@ -312,6 +312,7 @@ set_init_1(int clean_arg)
     p = get_isolated_shell_name();
     if (fnamecmp(p, "nologin") == 0 || fnamecmp(p, "false") == 0)
 	restricted = TRUE;
+    vim_free(p);
 #endif
 
 #ifdef CLEAN_RUNTIMEPATH

--- a/src/option.c
+++ b/src/option.c
@@ -310,9 +310,12 @@ set_init_1(int clean_arg)
 #ifdef UNIX
     // Force restricted-mode on for "nologin" or "false" $SHELL
     p = get_isolated_shell_name();
-    if (fnamecmp(p, "nologin") == 0 || fnamecmp(p, "false") == 0)
-	restricted = TRUE;
-    vim_free(p);
+    if (p != NULL)
+    {
+	if (fnamecmp(p, "nologin") == 0 || fnamecmp(p, "false") == 0)
+	    restricted = TRUE;
+	vim_free(p);
+    }
 #endif
 
 #ifdef CLEAN_RUNTIMEPATH

--- a/src/testdir/test_restricted.vim
+++ b/src/testdir/test_restricted.vim
@@ -105,6 +105,12 @@ func Test_restricted_mode()
   if RunVim([], [], '-Z --clean -S Xrestricted')
     call assert_equal([], readfile('Xresult'))
   endif
+  if has('unix')
+    let $SHELL = '/sbin/nologin'
+    if RunVim([], [], '--clean -S Xrestricted')
+      call assert_equal([], readfile('Xresult'))
+    endif
+  endif
 
   call delete('Xrestricted')
   call delete('Xresult')

--- a/src/testdir/test_restricted.vim
+++ b/src/testdir/test_restricted.vim
@@ -105,11 +105,8 @@ func Test_restricted_mode()
   if RunVim([], [], '-Z --clean -S Xrestricted')
     call assert_equal([], readfile('Xresult'))
   endif
-  if has('unix')
-    let $SHELL = '/sbin/nologin'
-    if RunVim([], [], '--clean -S Xrestricted')
-      call assert_equal([], readfile('Xresult'))
-    endif
+  if has('unix') && RunVimPiped([], [], '--clean -S Xrestricted', 'SHELL=/bin/false ')
+    call assert_equal([], readfile('Xresult'))
   endif
 
   call delete('Xrestricted')


### PR DESCRIPTION
Problem: Vim only enters restricted-mode if -Z switch supplied on command line
Solution: For Unix force restricted-mode also when $SHELL is set to "nologin" or "false" (closes #8126).

This partially closes a well-known hole when "nologin" user runs Vim in order to get access to normal shell.

Also, it helps for better error handling by plugins when run by "nologin" user. I.e. always `catch /E145:/` for all shell commands instead of different and unexpected `/E484:/` or such. Notably this applies to perl standard plugin.