### PR TITLE
Remove the help text introduced in patch 8.2.3219

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1771,12 +1771,6 @@ There are three different types of searching:
 	/u/user_x/work/include
 	/u/user_x/include
 
-<   Note: If your 'path' setting includes a non-existing directory, Vim will
-   skip the non-existing directory, but continues searching in the parent of
-   the non-existing directory if upwards searching is used.  E.g. when
-   searching "../include" and that doesn't exist, and upward searching is
-   used, also searches in "..".
-
 3) Combined up/downward search:
    If Vim's current path is /u/user_x/work/release and you do >
 	set path=**;/u/user_x


### PR DESCRIPTION
This help text describes the behavior before that patch, not the behavior after that patch.