### PR TITLE
Remove unnecessary variable retval in changedir_func()

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7358,7 +7358,6 @@ changedir_func(
 {
     char_u	*pdir = NULL;
     int		dir_differs;
-    int		retval = FALSE;
 
     if (new_dir == NULL || allbuf_locked())
 	return FALSE;
@@ -7415,6 +7414,7 @@ changedir_func(
     {
 	emsg(_(e_command_failed));
 	vim_free(pdir);
+	return FALSE;
     }
     else
     {
@@ -7443,10 +7443,8 @@ changedir_func(
 	    apply_autocmds(EVENT_DIRCHANGED, acmd_fname, new_dir, FALSE,
 								curbuf);
 	}
-	retval = TRUE;
+	return TRUE;
     }
-
-    return retval;
 }
 
 /*

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1903,7 +1903,6 @@ vim_chdirfile(char_u *fname, char *trigger_autocmd)
 {
     char_u	old_dir[MAXPATHL];
     char_u	new_dir[MAXPATHL];
-    int		res;
 
     if (mch_dirname(old_dir, MAXPATHL) != OK)
 	*old_dir = NUL;
@@ -1913,16 +1912,16 @@ vim_chdirfile(char_u *fname, char *trigger_autocmd)
 
     if (pathcmp((char *)old_dir, (char *)new_dir, -1) == 0)
 	// nothing to do
-	res = OK;
-    else
-    {
-	res = mch_chdir((char *)new_dir) == 0 ? OK : FAIL;
+	return OK;
 
-	if (res == OK && trigger_autocmd != NULL)
-	    apply_autocmds(EVENT_DIRCHANGED, (char_u *)trigger_autocmd,
-						       new_dir, FALSE, curbuf);
-    }
-    return res;
+    if (mch_chdir((char *)new_dir) != 0)
+	return FAIL;
+
+    if (trigger_autocmd != NULL)
+	apply_autocmds(EVENT_DIRCHANGED, (char_u *)trigger_autocmd, new_dir,
+								FALSE, curbuf);
+
+    return OK;
 }
 #endif
 


### PR DESCRIPTION
After patch 8.2.3933 the memory is now freed in the two if branches instead of at the end of the function, so it is safe to just return in the two if branches.