### PR TITLE
Adjust Cygwin preprocessor directives

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5196,7 +5196,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 #endif
 		},
 	{"win32unix",
-#if defined(UNIX) && defined(__CYGWIN__)
+#ifdef WIN32UNIX
 		1
 #else
 		0

--- a/src/main.c
+++ b/src/main.c
@@ -11,11 +11,9 @@
 #include "vim.h"
 
 #ifdef __CYGWIN__
-# ifndef MSWIN
-#  include <cygwin/version.h>
-#  include <sys/cygwin.h>	// for cygwin_conv_to_posix_path() and/or
+# include <cygwin/version.h>
+# include <sys/cygwin.h>	// for cygwin_conv_to_posix_path() and/or
 				// cygwin_conv_path()
-# endif
 # include <limits.h>
 #endif
 
@@ -2570,7 +2568,7 @@ scripterror:
 		}
 	    }
 #endif
-#if defined(__CYGWIN32__) && !defined(MSWIN)
+#ifdef __CYGWIN32__
 	    /*
 	     * If vim is invoked by non-Cygwin tools, convert away any
 	     * DOS paths, so things like .swp files are created correctly.

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -44,15 +44,13 @@ static int selinux_enabled = -1;
 #endif
 
 #ifdef __CYGWIN__
-# ifndef MSWIN
-#  include <cygwin/version.h>
-#  include <sys/cygwin.h>	// for cygwin_conv_to_posix_path() and/or
+# include <cygwin/version.h>
+# include <sys/cygwin.h>	// for cygwin_conv_to_posix_path() and/or
 				// for cygwin_conv_path()
-#  ifdef FEAT_CYGWIN_WIN32_CLIPBOARD
-#   define WIN32_LEAN_AND_MEAN
-#   include <windows.h>
-#   include "winclip.pro"
-#  endif
+# ifdef FEAT_CYGWIN_WIN32_CLIPBOARD
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+#  include "winclip.pro"
 # endif
 #endif
 

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -11,11 +11,9 @@
  */
 
 #include "os_dos.h"		// common MS-DOS and Win32 stuff
-#ifndef __CYGWIN__
 // cproto fails on missing include files
-# ifndef PROTO
-#  include <direct.h>		// for _mkdir()
-# endif
+#ifndef PROTO
+# include <direct.h>		// for _mkdir()
 #endif
 
 #define BINARY_FILE_IO


### PR DESCRIPTION
`__CYGWIN__` and `_WIN32` won't be defined at the same time since Cygwin
GCC 4.x. (That could happen only when Cygwin GCC 3.x was used with the
`-mno-cygwin` option.)

Actually, when `windows.h` is included, `WIN32` and `_WIN64` might be
defined, but that doesn't matter here.

Simplify the conditions.