### PR TITLE
Adjust `__CYGWIN32__` #ifdefs

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2571,7 +2571,7 @@ scripterror:
 		}
 	    }
 #endif
-#ifdef __CYGWIN32__
+#ifdef __CYGWIN__
 	    /*
 	     * If vim is invoked by non-Cygwin tools, convert away any
 	     * DOS paths, so things like .swp files are created correctly.

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -6341,7 +6341,7 @@ select_eintr:
 	FD_ZERO(&wfds);
 	FD_ZERO(&efds);
 	FD_SET(fd, &rfds);
-# if !defined(__QNX__) && !defined(__CYGWIN32__)
+# ifndef __QNX__
 	// For QNX select() always returns 1 if this is set.  Why?
 	FD_SET(fd, &efds);
 # endif

--- a/src/pty.c
+++ b/src/pty.c
@@ -46,10 +46,6 @@
 
 #include <signal.h>
 
-#ifdef __CYGWIN32__
-# include <sys/termios.h>
-#endif
-
 #ifdef HAVE_SYS_IOCTL_H
 # include <sys/ioctl.h>
 #endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -1576,10 +1576,10 @@ typedef UINT32_TYPEDEF UINT32_T;
 #endif
 
 /*
- * EMX doesn't have a global way of making open() use binary I/O.
+ * Cygwin doesn't have a global way of making open() use binary I/O.
  * Use O_BINARY for all open() calls.
  */
-#if defined(__CYGWIN32__)
+#ifdef __CYGWIN__
 # define O_EXTRA    O_BINARY
 #else
 # define O_EXTRA    0


### PR DESCRIPTION
`__CYGWIN32__` is defined only on 32-bit Cygwin and not defined on
64-bit Cygwin (unlike `_WIN32`).  Remove some outdated #ifdefs and
enable some other #ifdefs also on 64-bit Cygwin.

This PR is an additional fix to #9693.