### PR TITLE
win32,python3: Avoid python3 being aborted when initialization failed

### DIFF
--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -834,6 +834,19 @@ To work around such problems there are these options:
 Raising SystemExit exception in python isn't endorsed way to quit vim, use: >
 	:py vim.command("qall!")
 <
+							*Exxxx*
+This error can occur when python 3 cannot load the required modules.  This
+means that your python 3 is not correctly installed or there are some mistakes
+in your settings.  Please check the following items:
+1. Make sure that python 3 is correctly installed.  Also check the version of
+   python.
+2. Check the 'pythonthreedll' option.
+3. Check the 'pythonthreehome' option.
+4. Check the PATH environment variable if you don't set 'pythonthreedll'.
+   On MS-Windows, you can use where.exe to check which dll will be loaded.
+   E.g. >
+	where.exe python310.dll
+5. Check the PYTHONPATH and PYTHONHOME environment variables.
 
 							*has-python*
 You can test what Python version is available with: >

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -3,6 +3,7 @@ HINSTANCE vimLoadLib(char *name);
 int mch_is_gui_executable(void);
 HINSTANCE find_imported_module_by_funcname(HINSTANCE hInst, const char *funcname);
 void *get_dll_import_func(HINSTANCE hInst, const char *funcname);
+void *hook_dll_import_func(HINSTANCE hInst, const char *funcname, const void *hook);
 int dyn_libintl_init(void);
 void dyn_libintl_end(void);
 void PlatformId(void);


### PR DESCRIPTION
When the initialization of python3 failed e.g. because of miss settings,
python3 will abort together with vim itself.

To reproduce this:
```
vim -u DEFAULTS -c "set pythonthreehome=." -c "py3 print()"
```

This is really user-unfriendly. I've seen many question about this. E.g.
vim/vim-win32-installer#71

This PR hooks python3 dll's exit(), and when it is called, recover from
exit and show a useful error message.

(This issue can also happen on Linux, but I don't know how to hook exit()
on Linux.)

Could you assign an error number and move the message to errors.h before
merging?  Could you also refine the wording of the error message and the
document if necessary?