### PR TITLE
Flush scrollbars to window edges (Athena and Motif)

### DIFF
--- a/src/gui_athena.c
+++ b/src/gui_athena.c
@@ -1894,17 +1894,27 @@ gui_mch_set_scrollbar_pos(
     int
 gui_mch_get_scrollbar_xpadding(void)
 {
-    // TODO: Calculate the padding for adjust scrollbar position when the
-    // Window is maximized.
-    return 0;
+    int xpad;
+    Dimension tw, ww;
+    Position  tx;
+
+    XtVaGetValues(textArea, XtNwidth, &tw, XtNx, &tx, NULL);
+    XtVaGetValues(vimShell, XtNwidth, &ww, NULL);
+    xpad = ww - tw - tx - gui.scrollbar_width;
+    return (xpad < 0) ? 0 : xpad;
 }
 
     int
 gui_mch_get_scrollbar_ypadding(void)
 {
-    // TODO: Calculate the padding for adjust scrollbar position when the
-    // Window is maximized.
-    return 0;
+    int ypad;
+    Dimension th, wh;
+    Position  ty;
+
+    XtVaGetValues(textArea, XtNheight, &th, XtNy, &ty, NULL);
+    XtVaGetValues(vimShell, XtNheight, &wh, NULL);
+    ypad = wh - th - ty - gui.scrollbar_height;
+    return (ypad < 0) ? 0 : ypad;
 }
 
     void

--- a/src/gui_motif.c
+++ b/src/gui_motif.c
@@ -1745,17 +1745,27 @@ gui_mch_set_scrollbar_pos(
     int
 gui_mch_get_scrollbar_xpadding(void)
 {
-    // TODO: Calculate the padding for adjust scrollbar position when the
-    // Window is maximized.
-    return 0;
+    int xpad;
+    Dimension tw, ww;
+    Position  tx;
+
+    XtVaGetValues(textArea, XtNwidth, &tw, XtNx, &tx, NULL);
+    XtVaGetValues(vimShell, XtNwidth, &ww, NULL);
+    xpad = ww - tw - tx - gui.scrollbar_width;
+    return (xpad < 0) ? 0 : xpad;
 }
 
     int
 gui_mch_get_scrollbar_ypadding(void)
 {
-    // TODO: Calculate the padding for adjust scrollbar position when the
-    // Window is maximized.
-    return 0;
+    int ypad;
+    Dimension th, wh;
+    Position  ty;
+
+    XtVaGetValues(textArea, XtNheight, &th, XtNy, &ty, NULL);
+    XtVaGetValues(vimShell, XtNheight, &wh, NULL);
+    ypad = wh - th - ty - gui.scrollbar_height;
+    return (ypad < 0) ? 0 : ypad;
 }
 
     void


### PR DESCRIPTION
 This expands fix #6466, created to address #5602, to Athena and Motif GUIs.