### PR TITLE
Eliminate control characters from shellmenu.vim

### DIFF
--- a/runtime/pack/dist/opt/shellmenu/plugin/shellmenu.vim
+++ b/runtime/pack/dist/opt/shellmenu/plugin/shellmenu.vim
@@ -9,49 +9,49 @@
 "
 " Written by: Lennart Schultz <les@dmi.min.dk>
 
-imenu Stmts.for	for  in dodoneki	kk0elli
-imenu Stmts.case	case  in) ;;esacbki	k0elli
-imenu Stmts.if	if   thenfiki	kk0elli
-imenu Stmts.if-else	if   thenelsefiki	kki	kk0elli
-imenu Stmts.elif	elif   thenki	kk0elli
-imenu Stmts.while	while   dodoneki	kk0elli
+imenu Stmts.for	for  in <c-m>do<c-m><c-m>done<esc>ki	<esc>kk0elli
+imenu Stmts.case	case  in<c-m>) ;;<c-m>esac<esc>bki	<esc>k0elli
+imenu Stmts.if	if   <c-m>then<c-m><c-m>fi<esc>ki	<esc>kk0elli
+imenu Stmts.if-else	if   <c-m>then<c-m><c-m>else<c-m><c-m>fi<esc>ki	<esc>kki	<esc>kk0elli
+imenu Stmts.elif	elif   <c-m>then<c-m><c-m><esc>ki	<esc>kk0elli
+imenu Stmts.while	while   do<c-m><c-m>done<esc>ki	<esc>kk0elli
 imenu Stmts.break	break 
 imenu Stmts.continue	continue 
-imenu Stmts.function	() {}ki	k0i
+imenu Stmts.function	() {<c-m><c-m>}<esc>ki	<esc>k0i
 imenu Stmts.return	return 
 imenu Stmts.return-true	return 0
 imenu Stmts.return-false	return 1
 imenu Stmts.exit	exit 
 imenu Stmts.shift	shift 
 imenu Stmts.trap	trap 
-imenu Test.existence	[ -e  ]hi
-imenu Test.existence - file		[ -f  ]hi
-imenu Test.existence - file (not empty)	[ -s  ]hi
-imenu Test.existence - directory	[ -d  ]hi
-imenu Test.existence - executable	[ -x  ]hi
-imenu Test.existence - readable	[ -r  ]hi
-imenu Test.existence - writable	[ -w  ]hi
-imenu Test.String is empty [ x = "x$" ]hhi
-imenu Test.String is not empty [ x != "x$" ]hhi
-imenu Test.Strings is equal [ "" = "" ]hhhhhhhi
-imenu Test.Strings is not equal [ "" != "" ]hhhhhhhhi
-imenu Test.Values is greater than [  -gt  ]hhhhhhi
-imenu Test.Values is greater equal [  -ge  ]hhhhhhi
-imenu Test.Values is equal [  -eq  ]hhhhhhi
-imenu Test.Values is not equal [  -ne  ]hhhhhhi
-imenu Test.Values is less than [  -lt  ]hhhhhhi
-imenu Test.Values is less equal [  -le  ]hhhhhhi
-imenu ParmSub.Substitute word if parm not set ${:-}hhi
-imenu ParmSub.Set parm to word if not set ${:=}hhi
-imenu ParmSub.Substitute word if parm set else nothing ${:+}hhi
-imenu ParmSub.If parm not set print word and exit ${:?}hhi
-imenu SpShVars.Number of positional parameters ${#}
-imenu SpShVars.All positional parameters (quoted spaces) ${*}
-imenu SpShVars.All positional parameters (unquoted spaces) ${@}
-imenu SpShVars.Flags set ${-}
-imenu SpShVars.Return code of last command ${?}
-imenu SpShVars.Process number of this shell ${$}
-imenu SpShVars.Process number of last background command ${!}
+imenu Test.existence	[ -e  ]<esc>hi
+imenu Test.existence\ -\ file		[ -f  ]<esc>hi
+imenu Test.existence\ -\ file\ (not\ empty)	[ -s  ]<esc>hi
+imenu Test.existence\ -\ directory	[ -d  ]<esc>hi
+imenu Test.existence\ -\ executable	[ -x  ]<esc>hi
+imenu Test.existence\ -\ readable	[ -r  ]<esc>hi
+imenu Test.existence\ -\ writable	[ -w  ]<esc>hi
+imenu Test.String\ is\ empty [ x = "x$" ]<esc>hhi
+imenu Test.String\ is\ not\ empty [ x != "x$" ]<esc>hhi
+imenu Test.Strings\ is\ equal [ "" = "" ]<esc>hhhhhhhi
+imenu Test.Strings\ is\ not\ equal [ "" != "" ]<esc>hhhhhhhhi
+imenu Test.Values\ is\ greater\ than [  -gt  ]<esc>hhhhhhi
+imenu Test.Values\ is\ greater\ equal [  -ge  ]<esc>hhhhhhi
+imenu Test.Values\ is\ equal [  -eq  ]<esc>hhhhhhi
+imenu Test.Values\ is\ not\ equal [  -ne  ]<esc>hhhhhhi
+imenu Test.Values\ is\ less\ than [  -lt  ]<esc>hhhhhhi
+imenu Test.Values\ is\ less\ equal [  -le  ]<esc>hhhhhhi
+imenu ParmSub.Substitute\ word\ if\ parm\ not\ set ${:-}<esc>hhi
+imenu ParmSub.Set\ parm\ to\ word\ if\ not\ set ${:=}<esc>hhi
+imenu ParmSub.Substitute\ word\ if\ parm\ set\ else\ nothing ${:+}<esc>hhi
+imenu ParmSub.If\ parm\ not\ set\ print\ word\ and\ exit ${:?}<esc>hhi
+imenu SpShVars.Number\ of\ positional\ parameters ${#}
+imenu SpShVars.All\ positional\ parameters\ (quoted\ spaces) ${*}
+imenu SpShVars.All\ positional\ parameters\ (unquoted\ spaces) ${@}
+imenu SpShVars.Flags\ set ${-}
+imenu SpShVars.Return\ code\ of\ last\ command ${?}
+imenu SpShVars.Process\ number\ of\ this\ shell ${$}
+imenu SpShVars.Process\ number\ of\ last\ background\ command ${!}
 imenu Environ.HOME ${HOME}
 imenu Environ.PATH ${PATH}
 imenu Environ.CDPATH ${CDPATH}
@@ -82,13 +82,13 @@ imenu Builtins.umask umask
 imenu Builtins.wait wait
 imenu Set.set set
 imenu Set.unset unset
-imenu Set.mark modified or modified variables set -a
-imenu Set.exit when command returns non-zero exit code set -e
-imenu Set.Disable file name generation set -f
-imenu Set.remember function commands set -h
-imenu Set.All keyword arguments are placed in the environment set -k
-imenu Set.Read commands but do not execute them set -n
-imenu Set.Exit after reading and executing one command set -t
-imenu Set.Treat unset variables as an error when substituting set -u
-imenu Set.Print shell input lines as they are read set -v
-imenu Set.Print commands and their arguments as they are executed set -x
+imenu Set.mark\ modified\ or\ modified\ variables set -a
+imenu Set.exit\ when\ command\ returns\ non-zero\ exit\ code set -e
+imenu Set.Disable\ file\ name\ generation set -f
+imenu Set.remember\ function\ commands set -h
+imenu Set.All\ keyword\ arguments\ are\ placed\ in\ the\ environment set -k
+imenu Set.Read\ commands\ but\ do\ not\ execute\ them set -n
+imenu Set.Exit\ after\ reading\ and\ executing\ one\ command set -t
+imenu Set.Treat\ unset\ variables\ as\ an\ error\ when\ substituting set -u
+imenu Set.Print\ shell\ input\ lines\ as\ they\ are\ read set -v
+imenu Set.Print\ commands\ and\ their\ arguments\ as\ they\ are\ executed set -x

--- a/runtime/pack/dist/opt/shellmenu/plugin/shellmenu.vim
+++ b/runtime/pack/dist/opt/shellmenu/plugin/shellmenu.vim
@@ -7,7 +7,8 @@
 " Attached is a Vim script file for turning gvim into a shell script editor.
 " It may also be used as an example how to use menus in Vim.
 "
-" Written by: Lennart Schultz <les@dmi.min.dk>
+" Maintainer: Ada(Haowen) Yu <me@yuhaowen.com>
+" Original author: Lennart Schultz <les@dmi.min.dk> (mail unreachable)
 
 imenu Stmts.for	for  in <c-m>do<c-m><c-m>done<esc>ki	<esc>kk0elli
 imenu Stmts.case	case  in<c-m>) ;;<c-m>esac<esc>bki	<esc>k0elli

--- a/runtime/pack/dist/opt/shellmenu/plugin/shellmenu.vim
+++ b/runtime/pack/dist/opt/shellmenu/plugin/shellmenu.vim
@@ -7,18 +7,23 @@
 " Attached is a Vim script file for turning gvim into a shell script editor.
 " It may also be used as an example how to use menus in Vim.
 "
-" Maintainer: Ada(Haowen) Yu <me@yuhaowen.com>
+" Maintainer: Ada (Haowen) Yu <me@yuhaowen.com>
 " Original author: Lennart Schultz <les@dmi.min.dk> (mail unreachable)
 
-imenu Stmts.for	for  in <c-m>do<c-m><c-m>done<esc>ki	<esc>kk0elli
-imenu Stmts.case	case  in<c-m>) ;;<c-m>esac<esc>bki	<esc>k0elli
-imenu Stmts.if	if   <c-m>then<c-m><c-m>fi<esc>ki	<esc>kk0elli
-imenu Stmts.if-else	if   <c-m>then<c-m><c-m>else<c-m><c-m>fi<esc>ki	<esc>kki	<esc>kk0elli
-imenu Stmts.elif	elif   <c-m>then<c-m><c-m><esc>ki	<esc>kk0elli
-imenu Stmts.while	while   do<c-m><c-m>done<esc>ki	<esc>kk0elli
+" Make sure the '<' and 'C' flags are not included in 'cpoptions', otherwise
+" <CR> would not be recognized.  See ":help 'cpoptions'".
+let s:cpo_save = &cpo
+set cpo&vim
+
+imenu Stmts.for	for  in <CR>do<CR><CR>done<esc>ki	<esc>kk0elli
+imenu Stmts.case	case  in<CR>) ;;<CR>esac<esc>bki	<esc>k0elli
+imenu Stmts.if	if   <CR>then<CR><CR>fi<esc>ki	<esc>kk0elli
+imenu Stmts.if-else	if   <CR>then<CR><CR>else<CR><CR>fi<esc>ki	<esc>kki	<esc>kk0elli
+imenu Stmts.elif	elif   <CR>then<CR><CR><esc>ki	<esc>kk0elli
+imenu Stmts.while	while   do<CR><CR>done<esc>ki	<esc>kk0elli
 imenu Stmts.break	break 
 imenu Stmts.continue	continue 
-imenu Stmts.function	() {<c-m><c-m>}<esc>ki	<esc>k0i
+imenu Stmts.function	() {<CR><CR>}<esc>ki	<esc>k0i
 imenu Stmts.return	return 
 imenu Stmts.return-true	return 0
 imenu Stmts.return-false	return 1
@@ -93,3 +98,7 @@ imenu Set.Exit\ after\ reading\ and\ executing\ one\ command set -t
 imenu Set.Treat\ unset\ variables\ as\ an\ error\ when\ substituting set -u
 imenu Set.Print\ shell\ input\ lines\ as\ they\ are\ read set -v
 imenu Set.Print\ commands\ and\ their\ arguments\ as\ they\ are\ executed set -x
+
+" Restore the previous value of 'cpoptions'.
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
Firstly, shellmenu.vim relies on the feature that Carriage Return in the Unix-like operating system is not regarded as line break, and directly uses literal Carriage Return in the script. Using this operating system dependent feature makes the program brittle and can lead to compatibility issues.

Secondly, a lot of control characters appear this script, which is not easy to read or edit. While vim supports key notation, which means control characters could be expressed by printable characters. This makes it easy to read and edit.

Thirdly, this file uses ^V as the escape character, which is undocumented and should be avoid.