### PR TITLE
A typo in Ex commands index regarding :=

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1152,7 +1152,7 @@ tag		command		action ~
 |:&|		:&		repeat last ":substitute"
 |:star|		:*		execute contents of a register
 |:<|		:<		shift lines one 'shiftwidth' left
-|:=|		:=		print the cursor line number
+|:=|		:=		print the last line number
 |:>|		:>		shift lines one 'shiftwidth' right
 |:@|		:@		execute contents of a register
 |:@@|		:@@		repeat the previous ":@"


### PR DESCRIPTION
:=  prints the ~cursor~ last line number