### PR TITLE
CI: Select windows-2019 or windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
           make ${TEST}
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     env:
       VCVARSALL: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat


### PR DESCRIPTION
https://github.com/actions/virtual-environments/issues/4856
`windows-latest` will become `windows-2022` soon, so we need decide to either specify and continue to use `windows-2019` or switch to `windows-2022`.

When use `windows-2022`, since EOL python 2 has been removed, we need remove if_python from build options.