### PR TITLE
Update bindzone.vim to support dns-record-type APL

### DIFF
--- a/runtime/syntax/bindzone.vim
+++ b/runtime/syntax/bindzone.vim
@@ -33,7 +33,7 @@ syn match       zoneDomain      contained  /[^[:space:]!"#$%&'()*+,\/:;<=>?@[\]\
 syn match       zoneSpecial     contained /^[@*.]\s/
 syn match       zoneTTL         contained /\s\@<=\d[0-9WwDdHhMmSs]*\(\s\|$\)\@=/ nextgroup=zoneClass,zoneRRType skipwhite
 syn keyword     zoneClass       contained IN CHAOS CH HS HESIOD nextgroup=zoneRRType,zoneTTL skipwhite
-syn keyword     zoneRRType      contained A AAAA CERT CNAME DNAME DNSKEY DS HINFO LOC MX NAPTR NS NSEC NSEC3 NSEC3PARAM PTR RP RRSIG SSHFP SOA SPF SRV TLSA TXT nextgroup=zoneRData skipwhite
+syn keyword     zoneRRType      contained A AAAA APL CERT CNAME DNAME DNSKEY DS HINFO LOC MX NAPTR NS NSEC NSEC3 NSEC3PARAM PTR RP RRSIG SSHFP SOA SPF SRV TLSA TXT nextgroup=zoneRData skipwhite
 syn match       zoneRData       contained /[^;]*/ contains=zoneDomain,zoneIPAddr,zoneIP6Addr,zoneText,zoneNumber,zoneParen,zoneUnknown
 
 syn match       zoneIPAddr      contained /\<[0-9]\{1,3}\(\.[0-9]\{1,3}\)\{,3}\>/


### PR DESCRIPTION
Add support for APL type in runtime/syntax/bindzone.vim

Bind9 supports catalogzones:
https://bind9.readthedocs.io/en/latest/advanced.html#catalog-zones
which in turn supports APL:
https://datatracker.ietf.org/doc/html/rfc3123.html

In a catalogzone you can use type APL (Address Prefix Lists) to define a list of IP's for allow-transfer and similar, for example the following which would define allow-transfer for "myzone" to be this list of ip's:
```
allow-transfer.myzone.zones IN APL (
        1:192.0.2.0/24 2:2001:db8::/32
        )
```

This PR just adds "APL" to the list of known zoneRRTypes.