### PR TITLE
Remove unneeded call to check_colorcolumn()

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -5604,7 +5604,7 @@ win_copy_options(win_T *wp_from, win_T *wp_to)
  * After copying window options: update variables depending on options.
  */
     void
-after_copy_winopt(win_T *wp UNUSED)
+after_copy_winopt(win_T *wp)
 {
 #ifdef FEAT_LINEBREAK
     briopt_check(wp);

--- a/src/window.c
+++ b/src/window.c
@@ -1415,9 +1415,6 @@ win_init(win_T *newp, win_T *oldp, int flags UNUSED)
 
     win_init_some(newp, oldp);
 
-#ifdef FEAT_SYN_HL
-    check_colorcolumn(newp);
-#endif
 #ifdef FEAT_TERMINAL
     term_update_wincolor(newp);
 #endif


### PR DESCRIPTION
It is already called in after_copy_winopt:
(win_init -> win_init_some -> win_copy_options -> after_copy_winopt -> check_colorcolumn).

Also remove UNUSED attribute from wp in after_copy_winopt; wp is always used for
set_chars_option.