### PR TITLE
win32: Fix dynamic sodium

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5997,7 +5997,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 #endif
 		},
 	{"sodium",
-#ifdef FEAT_SODIUM
+#if defined(FEAT_SODIUM) && !defined(DYNAMIC_SODIUM)
 		1
 #else
 		0
@@ -6317,6 +6317,10 @@ f_has(typval_T *argvars, typval_T *rettv)
 #ifdef DYNAMIC_TCL
 	else if (STRICMP(name, "tcl") == 0)
 	    n = tcl_enabled(FALSE);
+#endif
+#ifdef DYNAMIC_SODIUM
+	else if (STRICMP(name, "sodium") == 0)
+	    n = sodium_enabled(FALSE);
 #endif
 #if defined(FEAT_TERMINAL) && defined(MSWIN)
 	else if (STRICMP(name, "terminal") == 0)

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -59,7 +59,7 @@
 #endif
 
 #ifdef DYNAMIC_DIRECTX
-extern "C" HINSTANCE vimLoadLib(char *name);
+extern "C" HINSTANCE vimLoadLib(const char *name);
 
 typedef int (WINAPI *PGETUSERDEFAULTLOCALENAME)(LPWSTR, int);
 typedef HRESULT (WINAPI *PD2D1CREATEFACTORY)(D2D1_FACTORY_TYPE,
@@ -1212,8 +1212,8 @@ DWrite_Init(void)
 {
 #ifdef DYNAMIC_DIRECTX
     // Load libraries.
-    hD2D1DLL = vimLoadLib(const_cast<char*>("d2d1.dll"));
-    hDWriteDLL = vimLoadLib(const_cast<char*>("dwrite.dll"));
+    hD2D1DLL = vimLoadLib("d2d1.dll");
+    hDWriteDLL = vimLoadLib("dwrite.dll");
     if (hD2D1DLL == NULL || hDWriteDLL == NULL)
     {
 	DWrite_Final();

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1371,10 +1371,7 @@ cs_insert_filelist(
 		char *winmsg = GetWin32Error();
 
 		if (winmsg != NULL)
-		{
 		    (void)semsg(cant_msg, winmsg);
-		    LocalFree(winmsg);
-		}
 		else
 		    // subst filename if can't get error text
 		    (void)semsg(cant_msg, fname);

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -520,7 +520,7 @@ unescape_shellxquote(char_u *p, char_u *escaped)
  * Load library "name".
  */
     HINSTANCE
-vimLoadLib(char *name)
+vimLoadLib(const char *name)
 {
     HINSTANCE	dll = NULL;
 
@@ -8279,15 +8279,20 @@ resize_console_buf(void)
     char *
 GetWin32Error(void)
 {
+    static char *oldmsg = NULL;
     char *msg = NULL;
+
     FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER|FORMAT_MESSAGE_FROM_SYSTEM,
 	    NULL, GetLastError(), 0, (LPSTR)&msg, 0, NULL);
+    if (oldmsg != NULL)
+	LocalFree(oldmsg);
     if (msg != NULL)
     {
 	// remove trailing \r\n
 	char *pcrlf = strstr(msg, "\r\n");
 	if (pcrlf != NULL)
 	    *pcrlf = '\0';
+	oldmsg = msg;
     }
     return msg;
 }

--- a/src/proto/crypt.pro
+++ b/src/proto/crypt.pro
@@ -1,4 +1,5 @@
 /* crypt.c */
+int sodium_enabled(int verbose);
 int crypt_method_nr_from_name(char_u *name);
 int crypt_method_nr_from_magic(char *ptr, int len);
 int crypt_works_inplace(cryptstate_T *state);

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -1,5 +1,5 @@
 /* os_win32.c */
-HINSTANCE vimLoadLib(char *name);
+HINSTANCE vimLoadLib(const char *name);
 int mch_is_gui_executable(void);
 HINSTANCE find_imported_module_by_funcname(HINSTANCE hInst, const char *funcname);
 void *get_dll_import_func(HINSTANCE hInst, const char *funcname);

--- a/src/version.c
+++ b/src/version.c
@@ -548,7 +548,11 @@ static char *(features[]) =
 	"-smartindent",
 #endif
 #ifdef FEAT_SODIUM
+# ifdef DYNAMIC_SODIUM
+	"+sodium/dyn",
+# else
 	"+sodium",
+# endif
 #else
 	"-sodium",
 #endif


### PR DESCRIPTION
This is an additional fix to 8.2.4144.

* Fix that `has('sodium')` returns 1 even if libsodium.dll cannot be
  loaded.
* Fix `:version`. Show as `+sodium/dyn` when it is dynamically loaded.
* Some preparation for dynamic loading on non-Windows environments.
* Show error messages when failed to load the dll.
* Mitigate memory leaks when calling `GetWin32Error()`.
  Free the previous allocation when the function is called multiple
  times.
* Change the type of the 1st parameter of `vimLoadLib()` from `char *`
  to `const char *` so that const string can be directly passed to the
  function.