### PR TITLE
Problem:    Amiga: Compiler warnings due to unused variables.

### DIFF
--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -154,7 +154,7 @@ mch_inchar(
     char_u  *buf,
     int	    maxlen,
     long    time,		// milliseconds
-    int	    tb_change_cnt)
+    int	    tb_change_cnt UNUSED)
 {
     int	    len;
     long    utime;
@@ -571,7 +571,7 @@ mch_input_isatty(void)
     void
 fname_case(
     char_u	*name,
-    int		len)		// buffer size, ignored here
+    int		len UNUSED)		// buffer size, ignored here
 {
     struct FileInfoBlock    *fib;
     size_t		    flen;
@@ -837,7 +837,7 @@ mch_setperm(char_u *name, long perm)
  * Set hidden flag for "name".
  */
     void
-mch_hide(char_u *name)
+mch_hide(char_u *name UNUSED)
 {
     // can't hide a file
 }
@@ -889,7 +889,7 @@ mch_mkdir(char_u *name)
  * Return -1 if unknown.
  */
     int
-mch_can_exe(char_u *name, char_u **path, int use_path)
+mch_can_exe(char_u *name, char_u **path UNUSED, int use_path)
 {
     int exe = -1;
 #ifdef __amigaos4__
@@ -942,7 +942,7 @@ mch_can_exe(char_u *name, char_u **path, int use_path)
  * NODE_OTHER: non-writable things
  */
     int
-mch_nodetype(char_u *name)
+mch_nodetype(char_u *name UNUSED)
 {
     // TODO
     return NODE_NORMAL;
@@ -1490,7 +1490,7 @@ mch_call_shell(
  * trouble with lattice-c programs.
  */
     void
-mch_breakcheck(int force)
+mch_breakcheck(int force UNUSED)
 {
    if (SetSignal(0L, (long)(SIGBREAKF_CTRL_C|SIGBREAKF_CTRL_D|SIGBREAKF_CTRL_E|SIGBREAKF_CTRL_F)) & SIGBREAKF_CTRL_C)
 	got_int = TRUE;
@@ -1755,7 +1755,7 @@ mch_getenv(char_u *var)
  */
 // ARGSUSED
     int
-mch_setenv(char *var, char *value, int x)
+mch_setenv(char *var, char *value, int x UNUSED)
 {
 #ifdef FEAT_ARP
     if (!dos2)


### PR DESCRIPTION
Solution:   Use UNUSED attribute for unused variables.