### PR TITLE
Problem:   Amiga: Compiler warning due to invalid tputs() type.

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -37,7 +37,7 @@
  * A few linux systems define outfuntype in termcap.h to be used as the third
  * argument for tputs().
  */
-# ifdef VMS
+# if defined(VMS) || defined(AMIGA)
 #  define TPUTSFUNCAST (void (*)(unsigned int))
 # else
 #  ifdef HAVE_OUTFUNTYPE


### PR DESCRIPTION
Solution:  Use the same type cast define as VMS on Amiga.