### PR TITLE
Generate zh_CN.po from zh_CN.UTF-8.po

### DIFF
--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -132,6 +132,12 @@ sk.cp1250.po: sk.po
 	iconv -f iso-8859-2 -t cp1250 sk.po | \
 		sed -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from sk.po, DO NOT EDIT/' > sk.cp1250.po
 
+# Convert zh_CN.UTF-8.po to create zh_CN.po.
+zh_CN.po: zh_CN.UTF-8.po
+	rm -f zh_CN.po
+	iconv -f UTF-8 -t gb2312 zh_CN.UTF-8.po | \
+		sed -e 's/charset=[uU][tT][fF]-8/charset=gb2312/' -e 's/# Original translations/# Generated from zh_CN.UTF-8.po, DO NOT EDIT/' > zh_CN.po
+
 # Convert zh_CN.UTF-8.po to create zh_CN.cp936.po.
 # Set 'charset' to gbk to avoid that msfmt generates a warning.
 # This used to convert from zh_CN.po, but that results in a conversion error.

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -9,7 +9,7 @@
 #   Edyfox <edyfox@gmail.com>
 #   Yuheng Xie <elephant@linux.net.cn>
 #
-# Original translations.
+# Generated from zh_CN.UTF-8.po, DO NOT EDIT.
 #
 msgid ""
 msgstr ""
@@ -17,8 +17,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2006-04-21 15:16+0800\n"
 "PO-Revision-Date: 2006-04-21 14:00+0800\n"
-"Last-Translator: Yuheng Xie <elephant@linux.net.cn>\n"
-"Language-Team: Simplified Chinese <i18n-translation@lists.linux.net.cn>\n"
+"Last-Translator: Yuheng Xie\n"
+"Language-Team: Simplified Chinese\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=gb2312\n"
 "Content-Transfer-Encoding: 8-bit\n"
@@ -241,9 +241,8 @@ msgstr " 文件名补全 (^F^N^P)"
 msgid " Tag completion (^]^N^P)"
 msgstr " Tag 补全 (^]^N^P)"
 
-#, fuzzy
-#~ msgid " Path pattern completion (^N^P)"
-#~ msgstr " 路径模式补全 (^N^P)"
+msgid " Path pattern completion (^N^P)"
+msgstr " 头文件模式补全 (^N^P)"
 
 msgid " Definition completion (^D^N^P)"
 msgstr " 定义补全 (^D^N^P)"
@@ -2862,7 +2861,8 @@ msgstr "-X\t\t\t不连接到 X Server"
 msgid "--remote <files>\tEdit <files> in a Vim server if possible"
 msgstr "--remote <files>\t如有可能，在 Vim 服务器上编辑文件 <files>"
 
-msgid "--remote-silent <files>  Same, don't complain if there is no server"
+msgid ""
+"--remote-silent <files>  Same, don't complain if there is no server"
 msgstr "--remote-silent <files>  同上，找不到服务器时不抱怨"
 
 msgid ""
@@ -5243,7 +5243,7 @@ msgstr "Vim: 读错误，退出中...\n"
 
 #. must display the prompt
 msgid "No undo possible; continue anyway"
-msgstr "无法撤销；请继续"
+msgstr "无法撤销；仍然继续"
 
 msgid "Already at oldest change"
 msgstr "已位于最旧的改变"
@@ -5560,13 +5560,13 @@ msgid "type  :help cp-default<Enter> for info on this"
 msgstr "输入  :help cp-default<Enter> 查看相关说明    "
 
 msgid "menu  Help->Orphans           for information    "
-msgstr "菜单  Help->Orphans           查看说明           "
+msgstr "菜单  帮助->孤儿           查看说明           "
 
 msgid "Running modeless, typed text is inserted"
 msgstr "无模式运行，输入文字即插入"
 
 msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "菜单  Edit->Global Settings->Toggle Insert Mode  "
+msgstr "菜单  编辑->全局设定->开/关插入模式  "
 
 #, fuzzy
 #~ msgid "                              for two modes      "


### PR DESCRIPTION
"zh_CN.UTF-8.po" and "zh_CN.po" are only encoded differently but need to be translated separately. I've synchronized them in this PR. After this synchronization, Simplified Chinese translators won't be confused which file to translate, because zh_CN.po could be generated from zh_CN.UTF-8.po automatically.