### PR TITLE
refactor(lint): macro argument should be enclosed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ src/pixmaps
 
 # other possible files build by tools
 src/cscope.out
+.cache/

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -217,9 +217,9 @@ static AutoPat *last_autopat[NUM_EVENTS] =
     NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
 };
 
-#define AUGROUP_DEFAULT    -1	    // default autocmd group
-#define AUGROUP_ERROR	   -2	    // erroneous autocmd group
-#define AUGROUP_ALL	   -3	    // all autocmd groups
+#define AUGROUP_DEFAULT    (-1)	    // default autocmd group
+#define AUGROUP_ERROR	   (-2)	    // erroneous autocmd group
+#define AUGROUP_ALL	   (-3)	    // all autocmd groups
 
 /*
  * struct used to keep status while executing autocommands for an event.

--- a/src/charset.c
+++ b/src/charset.c
@@ -386,9 +386,9 @@ str_foldcase(
     int		len = orglen;
 
 #define GA_CHAR(i)  ((char_u *)ga.ga_data)[i]
-#define GA_PTR(i)   ((char_u *)ga.ga_data + i)
+#define GA_PTR(i)   ((char_u *)ga.ga_data + (i))
 #define STR_CHAR(i)  (buf == NULL ? GA_CHAR(i) : buf[i])
-#define STR_PTR(i)   (buf == NULL ? GA_PTR(i) : buf + i)
+#define STR_PTR(i)   (buf == NULL ? GA_PTR(i) : buf + (i))
 
     // Copy "str" into "buf" or allocated memory, unmodified.
     if (buf == NULL)
@@ -706,7 +706,7 @@ vim_strnsize(char_u *s, int len)
 
 #ifdef FEAT_VARTABS
 # define RET_WIN_BUF_CHARTABSIZE(wp, buf, p, col) \
-    if (*(p) == TAB && (!(wp)->w_p_list || wp->w_lcs_chars.tab1)) \
+    if (*(p) == TAB && (!(wp)->w_p_list || (wp)->w_lcs_chars.tab1)) \
     { \
 	return tabstop_padding(col, (buf)->b_p_ts, (buf)->b_p_vts_array); \
     } \

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -404,32 +404,32 @@ win_line(
     // draw_state: items that are drawn in sequence:
 #define WL_START	0		// nothing done yet
 #ifdef FEAT_CMDWIN
-# define WL_CMDLINE	WL_START + 1	// cmdline window column
+# define WL_CMDLINE	(WL_START + 1)	// cmdline window column
 #else
 # define WL_CMDLINE	WL_START
 #endif
 #ifdef FEAT_FOLDING
-# define WL_FOLD	WL_CMDLINE + 1	// 'foldcolumn'
+# define WL_FOLD	(WL_CMDLINE + 1)	// 'foldcolumn'
 #else
 # define WL_FOLD	WL_CMDLINE
 #endif
 #ifdef FEAT_SIGNS
-# define WL_SIGN	WL_FOLD + 1	// column for signs
+# define WL_SIGN	(WL_FOLD + 1)	// column for signs
 #else
 # define WL_SIGN	WL_FOLD		// column for signs
 #endif
-#define WL_NR		WL_SIGN + 1	// line number
+#define WL_NR		(WL_SIGN + 1)	// line number
 #ifdef FEAT_LINEBREAK
-# define WL_BRI		WL_NR + 1	// 'breakindent'
+# define WL_BRI		(WL_NR + 1)	// 'breakindent'
 #else
 # define WL_BRI		WL_NR
 #endif
 #if defined(FEAT_LINEBREAK) || defined(FEAT_DIFF)
-# define WL_SBR		WL_BRI + 1	// 'showbreak' or 'diff'
+# define WL_SBR		(WL_BRI + 1)	// 'showbreak' or 'diff'
 #else
 # define WL_SBR		WL_BRI
 #endif
-#define WL_LINE		WL_SBR + 1	// text in the line
+#define WL_LINE		(WL_SBR + 1)	// text in the line
     int		draw_state = WL_START;	// what to draw next
 #if defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
     int		feedback_col = 0;

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1112,10 +1112,10 @@ fold_line(
 # define RL_MEMSET(p, v, l) \
     do { \
 	if (wp->w_p_rl) \
-	    for (ri = 0; ri < l; ++ri) \
+	    for (ri = 0; ri < (l); ++ri) \
 	       ScreenAttrs[off + (wp->w_width - (p) - (l)) + ri] = v; \
 	 else \
-	    for (ri = 0; ri < l; ++ri) \
+	    for (ri = 0; ri < (l); ++ri) \
 	       ScreenAttrs[off + (p) + ri] = v; \
     } while (0)
 #else

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7878,21 +7878,21 @@ init_srand(UINT32_T *x)
 	*x = vim_time();
 }
 
-#define ROTL(x, k) ((x << k) | (x >> (32 - k)))
+#define ROTL(x, k) (((x) << (k)) | ((x) >> (32 - (k))))
 #define SPLITMIX32(x, z) ( \
-    z = (x += 0x9e3779b9), \
-    z = (z ^ (z >> 16)) * 0x85ebca6b, \
-    z = (z ^ (z >> 13)) * 0xc2b2ae35, \
-    z ^ (z >> 16) \
+    (z) = ((x) += 0x9e3779b9), \
+    (z) = ((z) ^ ((z) >> 16)) * 0x85ebca6b, \
+    (z) = ((z) ^ ((z) >> 13)) * 0xc2b2ae35, \
+    (z) ^ ((z) >> 16) \
     )
 #define SHUFFLE_XOSHIRO128STARSTAR(x, y, z, w) \
-    result = ROTL(y * 5, 7) * 9; \
-    t = y << 9; \
-    z ^= x; \
-    w ^= y; \
-    y ^= z, x ^= w; \
-    z ^= t; \
-    w = ROTL(w, 11);
+    result = ROTL((y) * 5, 7) * 9; \
+    t = (y) << 9; \
+    (z) ^= (x); \
+    (w) ^= (y); \
+    (y) ^= (z), (x) ^= (w); \
+    (z) ^= t; \
+    (w) = ROTL(w, 11);
 
 /*
  * "rand()" function

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4799,7 +4799,7 @@ readdir_core(
 # ifdef FEAT_EVAL
 #  define FREE_ITEM(item)   do { \
 	if (withattr) \
-	    dict_unref((dict_T*)item); \
+	    dict_unref((dict_T*)(item)); \
 	else \
 	    vim_free(item); \
     } while (0)

--- a/src/fold.c
+++ b/src/fold.c
@@ -3066,7 +3066,7 @@ truncate_fold(fold_T *fp, linenr_T end)
 
 #define fold_end(fp) ((fp)->fd_top + (fp)->fd_len - 1)
 #define valid_fold(fp, gap) ((gap)->ga_len > 0 && (fp) < ((fold_T *)(gap)->ga_data + (gap)->ga_len))
-#define fold_index(fp, gap) ((size_t)(fp - ((fold_T *)(gap)->ga_data)))
+#define fold_index(fp, gap) ((size_t)((fp) - ((fold_T *)(gap)->ga_data)))
 
     void
 foldMoveRange(garray_T *gap, linenr_T line1, linenr_T line2, linenr_T dest)

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -3603,7 +3603,7 @@ inchar(
 	 */
 	if (got_int)
 	{
-#define DUM_LEN MAXMAPLEN * 3 + 3
+#define DUM_LEN (MAXMAPLEN * 3 + 3)
 	    char_u	dum[DUM_LEN + 1];
 
 	    for (;;)

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -29,7 +29,7 @@ static char *(hl_name_table[]) =
       "italic", "reverse", "inverse", "nocombine", "strikethrough", "NONE"};
 static int hl_attr_table[] =
     {HL_BOLD, HL_STANDOUT, HL_UNDERLINE, HL_UNDERCURL, HL_ITALIC, HL_INVERSE, HL_INVERSE, HL_NOCOMBINE, HL_STRIKETHROUGH, 0};
-#define ATTR_COMBINE(attr_a, attr_b) ((((attr_b) & HL_NOCOMBINE) ? attr_b : (attr_a)) | (attr_b))
+#define ATTR_COMBINE(attr_a, attr_b) ((((attr_b) & HL_NOCOMBINE) ? (attr_b) : (attr_a)) | (attr_b))
 
 /*
  * Structure that stores information about a highlight group.
@@ -2260,7 +2260,7 @@ color_name2handle(char_u *name)
 #  undef RGB
 # endif
 # ifndef RGB
-#  define RGB(r, g, b)	((r<<16) | (g<<8) | (b))
+#  define RGB(r, g, b)	(((r)<<16) | ((g)<<8) | (b))
 # endif
 
 # ifdef VIMDLL

--- a/src/memline.c
+++ b/src/memline.c
@@ -227,7 +227,7 @@ static linenr_T	lowest_marked = 0;
 #define ML_INSERT	0x12	    // insert line
 #define ML_FIND		0x13	    // just find the line
 #define ML_FLUSH	0x02	    // flush locked block
-#define ML_SIMPLE(x)	(x & 0x10)  // DEL, INS or FIND
+#define ML_SIMPLE(x)	((x) & 0x10)  // DEL, INS or FIND
 
 // argument for ml_upd_block0()
 typedef enum {

--- a/src/normal.c
+++ b/src/normal.c
@@ -1563,7 +1563,7 @@ may_clear_cmdline(void)
  * Routines for displaying a partly typed command
  */
 
-#define SHOWCMD_BUFLEN SHOWCMD_COLS + 1 + 30
+#define SHOWCMD_BUFLEN (SHOWCMD_COLS + 1 + 30)
 static char_u	showcmd_buf[SHOWCMD_BUFLEN];
 static char_u	old_showcmd_buf[SHOWCMD_BUFLEN];  // For push_showcmd()
 static int	showcmd_is_clear = TRUE;

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -189,28 +189,28 @@ static void	unload_dummy_buffer(buf_T *buf, char_u *dirname_start);
 static qf_info_T *ll_get_or_alloc_list(win_T *);
 
 // Quickfix window check helper macro
-#define IS_QF_WINDOW(wp) (bt_quickfix(wp->w_buffer) && wp->w_llist_ref == NULL)
+#define IS_QF_WINDOW(wp) (bt_quickfix((wp)->w_buffer) && (wp)->w_llist_ref == NULL)
 // Location list window check helper macro
-#define IS_LL_WINDOW(wp) (bt_quickfix(wp->w_buffer) && wp->w_llist_ref != NULL)
+#define IS_LL_WINDOW(wp) (bt_quickfix((wp)->w_buffer) && (wp)->w_llist_ref != NULL)
 
 // Quickfix and location list stack check helper macros
-#define IS_QF_STACK(qi)		(qi->qfl_type == QFLT_QUICKFIX)
-#define IS_LL_STACK(qi)		(qi->qfl_type == QFLT_LOCATION)
-#define IS_QF_LIST(qfl)		(qfl->qfl_type == QFLT_QUICKFIX)
-#define IS_LL_LIST(qfl)		(qfl->qfl_type == QFLT_LOCATION)
+#define IS_QF_STACK(qi)		((qi)->qfl_type == QFLT_QUICKFIX)
+#define IS_LL_STACK(qi)		((qi)->qfl_type == QFLT_LOCATION)
+#define IS_QF_LIST(qfl)		((qfl)->qfl_type == QFLT_QUICKFIX)
+#define IS_LL_LIST(qfl)		((qfl)->qfl_type == QFLT_LOCATION)
 
 /*
  * Return location list for window 'wp'
  * For location list window, return the referenced location list
  */
-#define GET_LOC_LIST(wp) (IS_LL_WINDOW(wp) ? wp->w_llist_ref : wp->w_llist)
+#define GET_LOC_LIST(wp) (IS_LL_WINDOW(wp) ? (wp)->w_llist_ref : (wp)->w_llist)
 
 // Macro to loop through all the items in a quickfix list
 // Quickfix item index starts from 1, so i below starts at 1
 #define FOR_ALL_QFL_ITEMS(qfl, qfp, i) \
-		    for (i = 1, qfp = qfl->qf_start; \
-			    !got_int && i <= qfl->qf_count && qfp != NULL; \
-			    ++i, qfp = qfp->qf_next)
+		    for ((i) = 1, (qfp) = (qfl)->qf_start; \
+			    !got_int && (i) <= (qfl)->qf_count && (qfp) != NULL; \
+			    ++(i), (qfp) = (qfp)->qf_next)
 
 /*
  * Looking up a buffer can be slow if there are many.  Remember the last one

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -247,15 +247,15 @@ init_class_tab(void)
     done = TRUE;
 }
 
-#define ri_digit(c)	(c < 0x100 && (class_tab[c] & RI_DIGIT))
-#define ri_hex(c)	(c < 0x100 && (class_tab[c] & RI_HEX))
-#define ri_octal(c)	(c < 0x100 && (class_tab[c] & RI_OCTAL))
-#define ri_word(c)	(c < 0x100 && (class_tab[c] & RI_WORD))
-#define ri_head(c)	(c < 0x100 && (class_tab[c] & RI_HEAD))
-#define ri_alpha(c)	(c < 0x100 && (class_tab[c] & RI_ALPHA))
-#define ri_lower(c)	(c < 0x100 && (class_tab[c] & RI_LOWER))
-#define ri_upper(c)	(c < 0x100 && (class_tab[c] & RI_UPPER))
-#define ri_white(c)	(c < 0x100 && (class_tab[c] & RI_WHITE))
+#define ri_digit(c)	((c) < 0x100 && (class_tab[c] & RI_DIGIT))
+#define ri_hex(c)	((c) < 0x100 && (class_tab[c] & RI_HEX))
+#define ri_octal(c)	((c) < 0x100 && (class_tab[c] & RI_OCTAL))
+#define ri_word(c)	((c) < 0x100 && (class_tab[c] & RI_WORD))
+#define ri_head(c)	((c) < 0x100 && (class_tab[c] & RI_HEAD))
+#define ri_alpha(c)	((c) < 0x100 && (class_tab[c] & RI_ALPHA))
+#define ri_lower(c)	((c) < 0x100 && (class_tab[c] & RI_LOWER))
+#define ri_upper(c)	((c) < 0x100 && (class_tab[c] & RI_UPPER))
+#define ri_white(c)	((c) < 0x100 && (class_tab[c] & RI_WHITE))
 
 // flags for regflags
 #define RF_ICASE    1	// ignore case

--- a/src/search.c
+++ b/src/search.c
@@ -4300,15 +4300,15 @@ typedef struct
 // bonus if the first letter is matched
 #define FIRST_LETTER_BONUS 15
 // penalty applied for every letter in str before the first match
-#define LEADING_LETTER_PENALTY -5
+#define LEADING_LETTER_PENALTY (-5)
 // maximum penalty for leading letters
-#define MAX_LEADING_LETTER_PENALTY -15
+#define MAX_LEADING_LETTER_PENALTY (-15)
 // penalty for every letter that doesn't match
-#define UNMATCHED_LETTER_PENALTY -1
+#define UNMATCHED_LETTER_PENALTY (-1)
 // penalty for gap in matching positions (-2 * k)
-#define GAP_PENALTY	-2
+#define GAP_PENALTY	(-2)
 // Score for a string that doesn't fuzzy match the pattern
-#define SCORE_NONE	-9999
+#define SCORE_NONE	(-9999)
 
 #define FUZZY_MATCH_RECURSION_LIMIT	10
 

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -79,8 +79,8 @@ sha256_process(context_sha256_T *ctx, char_u data[64])
     GET_UINT32(W[14], data, 56);
     GET_UINT32(W[15], data, 60);
 
-#define  SHR(x, n) ((x & 0xFFFFFFFF) >> n)
-#define ROTR(x, n) (SHR(x, n) | (x << (32 - n)))
+#define  SHR(x, n) (((x) & 0xFFFFFFFF) >> (n))
+#define ROTR(x, n) (SHR(x, n) | ((x) << (32 - (n))))
 
 #define S0(x) (ROTR(x, 7) ^ ROTR(x, 18) ^  SHR(x, 3))
 #define S1(x) (ROTR(x, 17) ^ ROTR(x, 19) ^  SHR(x, 10))
@@ -88,20 +88,20 @@ sha256_process(context_sha256_T *ctx, char_u data[64])
 #define S2(x) (ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22))
 #define S3(x) (ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25))
 
-#define F0(x, y, z) ((x & y) | (z & (x | y)))
-#define F1(x, y, z) (z ^ (x & (y ^ z)))
+#define F0(x, y, z) (((x) & (y)) | ((z) & ((x) | (y))))
+#define F1(x, y, z) ((z) ^ ((x) & ((y) ^ (z))))
 
 #define R(t)				\
 (					\
-    W[t] = S1(W[t -  2]) + W[t -  7] +	\
-	   S0(W[t - 15]) + W[t - 16]	\
+    W[t] = S1(W[(t) -  2]) + W[(t) -  7] +	\
+	   S0(W[(t) - 15]) + W[(t) - 16]	\
 )
 
 #define P(a,b,c,d,e,f,g,h,x,K)		     \
 {					     \
-    temp1 = h + S3(e) + F1(e, f, g) + K + x; \
+    temp1 = (h) + S3(e) + F1(e, f, g) + (K) + (x); \
     temp2 = S2(a) + F0(a, b, c);	     \
-    d += temp1; h = temp1 + temp2;	     \
+    (d) += temp1; (h) = temp1 + temp2;	     \
 }
 
     A = ctx->state[0];

--- a/src/spell.c
+++ b/src/spell.c
@@ -67,7 +67,7 @@
 #define REGION_ALL 0xff		// word valid in all regions
 
 // Result values.  Lower number is accepted over higher one.
-#define SP_BANNED	-1
+#define SP_BANNED	(-1)
 #define SP_OK		0
 #define SP_RARE		1
 #define SP_LOCAL	2

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -2018,7 +2018,7 @@ static void init_spellfile(void);
 // In the postponed prefixes tree wn_flags is used to store the WFP_ flags,
 // but it must be negative to indicate the prefix tree to tree_add_word().
 // Use a negative number with the lower 8 bits zero.
-#define PFX_FLAGS	-256
+#define PFX_FLAGS	(-256)
 
 // flags for "condit" argument of store_aff_word()
 #define CONDIT_COMB	1	// affix must combine

--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -23,13 +23,13 @@
  * vs "ht") and goes down in the list.
  * Used when 'spellsuggest' is set to "best".
  */
-#define RESCORE(word_score, sound_score) ((3 * word_score + sound_score) / 4)
+#define RESCORE(word_score, sound_score) ((3 * (word_score) + (sound_score)) / 4)
 
 /*
  * Do the opposite: based on a maximum end score and a known sound score,
  * compute the maximum word score that can be used.
  */
-#define MAXSCORE(word_score, sound_score) ((4 * word_score - sound_score) / 3)
+#define MAXSCORE(word_score, sound_score) ((4 * (word_score) - (sound_score)) / 3)
 
 // only used for su_badflags
 #define WF_MIXCAP   0x20	// mix of upper and lower case: macaRONI
@@ -70,7 +70,7 @@ typedef struct suggest_S
 #define SUG(ga, i) (((suggest_T *)(ga).ga_data)[i])
 
 // TRUE if a word appears in the list of banned words.
-#define WAS_BANNED(su, word) (!HASHITEM_EMPTY(hash_find(&su->su_banned, word)))
+#define WAS_BANNED(su, word) (!HASHITEM_EMPTY(hash_find(&(su)->su_banned, word)))
 
 // Number of suggestions kept when cleaning up.  We need to keep more than
 // what is displayed, because when rescore_suggestions() is called the score
@@ -118,7 +118,7 @@ typedef struct suggest_S
 #define SCORE_SFMAX2	300	// maximum score for second try
 #define SCORE_SFMAX3	400	// maximum score for third try
 
-#define SCORE_BIG	SCORE_INS * 3	// big difference
+#define SCORE_BIG	(SCORE_INS * 3)	// big difference
 #define SCORE_MAXMAX	999999		// accept any score
 #define SCORE_LIMITMAX	350		// for spell_edit_score_limit()
 
@@ -1214,7 +1214,7 @@ suggest_try_change(suginfo_T *su)
 
 // Check the maximum score, if we go over it we won't try this change.
 #define TRY_DEEPER(su, stack, depth, add) \
-       (depth < MAXWLEN - 1 && stack[depth].ts_score + (add) < su->su_maxscore)
+       ((depth) < MAXWLEN - 1 && (stack)[depth].ts_score + (add) < (su)->su_maxscore)
 
 /*
  * Try finding suggestions by adding/removing/swapping letters.
@@ -3077,7 +3077,7 @@ typedef struct
 } sftword_T;
 
 static sftword_T dumsft;
-#define HIKEY2SFT(p)  ((sftword_T *)(p - (dumsft.sft_word - (char_u *)&dumsft)))
+#define HIKEY2SFT(p)  ((sftword_T *)((p) - (dumsft.sft_word - (char_u *)&dumsft)))
 #define HI2SFT(hi)     HIKEY2SFT((hi)->hi_key)
 
 /*

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -81,7 +81,7 @@ typedef struct syn_pattern
 
 #define SYN_ITEMS(buf)	((synpat_T *)((buf)->b_syn_patterns.ga_data))
 
-#define NONE_IDX	-2	// value of sp_sync_idx for "NONE"
+#define NONE_IDX	(-2)	// value of sp_sync_idx for "NONE"
 
 /*
  * Flags for b_syn_sync_flags:
@@ -207,8 +207,8 @@ typedef struct state_item
 					// pattern
 } stateitem_T;
 
-#define KEYWORD_IDX	-1	    // value of si_idx for keywords
-#define ID_LIST_ALL	(short *)-1 // valid of si_cont_list for containing all
+#define KEYWORD_IDX	(-1)	    // value of si_idx for keywords
+#define ID_LIST_ALL	((short *)-1) // valid of si_cont_list for containing all
 				    // but contained groups
 
 #ifdef FEAT_CONCEAL

--- a/src/window.c
+++ b/src/window.c
@@ -64,7 +64,7 @@ static int frame_check_width(frame_T *topfrp, int width);
 
 static win_T *win_alloc(win_T *after, int hidden);
 
-#define NOWIN		(win_T *)-1	// non-existing window
+#define NOWIN		((win_T *)-1)	// non-existing window
 
 #define ROWS_AVAIL (Rows - p_ch - tabline_height())
 


### PR DESCRIPTION
Macros are expanded by the preprocessor as-is. As a result, there can be unexpected behavior.

This in accordance to "PRE02-C: Macro replacement lists should be parenthesized"

Refs
- <https://wiki.sei.cmu.edu/confluence/display/c/PRE02-C.+Macro+replacement+lists+should+be+parenthesized>
- <https://clang.llvm.org/extra/clang-tidy/checks/bugprone-macro-parentheses.html>
