### PR TITLE
Delete empty lines at the bottom of translation files

### DIFF
--- a/src/po/cleanup.vim
+++ b/src/po/cleanup.vim
@@ -19,6 +19,7 @@ silent g/^msgid"/s//msgid "/
 silent g/^msgstr ""\(\n"\)\@!/?^msgid?,.s/^/#\~ /
 
 silent g/^\n\n\n/.d
+silent! %s/\n\+\%$//
 
 if s:was_diff
   setl diff


### PR DESCRIPTION
The translation cleanup script didn't delete one or two empty lines at
the bottom of the files. `git diff` shows them as an error.

(I'm thinking whether the `silent g/^\n\n\n/.d` line can be removed.)