### PR TITLE
fix segmentation fault in tabline format parser

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4170,8 +4170,11 @@ build_stl_str_hl(
     {
 	stl_items = ALLOC_MULT(stl_item_T, stl_items_len);
 	stl_groupitem = ALLOC_MULT(int, stl_items_len);
-	stl_hltab  = ALLOC_MULT(stl_hlrec_T, stl_items_len);
-	stl_tabtab = ALLOC_MULT(stl_hlrec_T, stl_items_len);
+
+	// The last element (stl_hltab[stl_items_len], stl_tabtab[stl_items_len])
+	// is used to indicate the end of the list.
+	stl_hltab  = ALLOC_MULT(stl_hlrec_T, stl_items_len + 1);
+	stl_tabtab = ALLOC_MULT(stl_hlrec_T, stl_items_len + 1);
     }
 
 #ifdef FEAT_EVAL
@@ -4251,11 +4254,11 @@ build_stl_str_hl(
 	    if (new_groupitem == NULL)
 		break;
 	    stl_groupitem = new_groupitem;
-	    new_hlrec = vim_realloc(stl_hltab, sizeof(stl_hlrec_T) * new_len);
+	    new_hlrec = vim_realloc(stl_hltab, sizeof(stl_hlrec_T) * (new_len + 1));
 	    if (new_hlrec == NULL)
 		break;
 	    stl_hltab = new_hlrec;
-	    new_hlrec = vim_realloc(stl_tabtab, sizeof(stl_hlrec_T) * new_len);
+	    new_hlrec = vim_realloc(stl_tabtab, sizeof(stl_hlrec_T) * (new_len + 1));
 	    if (new_hlrec == NULL)
 		break;
 	    stl_tabtab = new_hlrec;

--- a/src/testdir/test_tabline.vim
+++ b/src/testdir/test_tabline.vim
@@ -134,6 +134,17 @@ func Test_tabline_empty_group()
   set tabline=
 endfunc
 
+" When there are exactly 20 tabline format items (the exact size of the
+" initial tabline items array), test that we don't write beyond the size
+" of the array.
+func Test_tabline_20_format_items_no_overrun()
+  set showtabline=2
 
+  let tabline = repeat('%#StatColorHi2#', 20)
+  let &tabline = tabline
+  redrawtabline
+
+  set showtabline& tabline&
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When parsing the statusline/tabline format string, highlight information
is stored in an array which has size 20 by default. The last item in
this array is used to indicate the end of the array, with struct members
being set to NULL/0.

When there are exactly 20 highlight items in the format string, the
array is not resized to account for the last item used to indicate the
end of the array. When copying the items to an array to be passed back
to the caller, the routine attempts to write beyond the size of the
array, often resulting in a segmentation fault.

To address this, update parser to allocate one more entry in the array
to account for the array end indicator. A test was introduced that
validates the fix when tests are run with valgrind memcheck.