### PR TITLE
getchar(): return early when there are no chars available

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2103,6 +2103,10 @@ getchar_common(typval_T *argvars, typval_T *rettv)
     set_vim_var_nr(VV_MOUSE_COL, 0);
 
     rettv->vval.v_number = n;
+
+    if (n == 0)
+	return;
+
     if (IS_SPECIAL(n) || mod_mask != 0)
     {
 	char_u		temp[10];   // modifier: 3, mbyte-char: 6, NUL: 1

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1818,6 +1818,10 @@ func Test_getchar()
   call assert_equal('', getcharstr(0))
   call assert_equal('', getcharstr(1))
 
+  call feedkeys("\<M-F2>", '')
+  call assert_equal("\<M-F2>", getchar(0))
+  call assert_equal(0, getchar(0))
+
   call setline(1, 'xxxx')
   call test_setmouse(1, 3)
   let v:mouse_win = 9


### PR DESCRIPTION
This prevents `getchar()` from returning a `NUL` with modifiers of the previous char when there are no chars available and the previous char has modifiers.