### PR TITLE
Fix a SEGFAULT

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -759,8 +759,9 @@ readfile(
 		// Also write a message in the GUI window, if there is one.
 		if (gui.in_use && !gui.dying && !gui.starting)
 		{
-		    p = (char_u *)_("Reading from stdin...");
+		    p = vim_strsave((char_u *)_("Reading from stdin..."));
 		    gui_write(p, (int)STRLEN(p));
+		    vim_free(p);
 		}
 #endif
 	    }


### PR DESCRIPTION
Fixes #9719

Problem: gVim segfaults in `gui_gtk2_draw_string` when reading from stdin with `guiligatures` enabled. Caused by `gui_gtk2_draw_string` trying to modify "Reading from stdin..." string which is located in `.rodata`  section.

Solution: Make a copy of the string before calling `gui_write()` in `readfile()`.