### PR TITLE
Remove redundant CHECK_CMDWIN

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -4324,7 +4324,6 @@ goto_tabpage(int n)
 	text_locked_msg();
 	return;
     }
-    CHECK_CMDWIN;
 
     // If there is only one it can't work.
     if (first_tabpage->tp_next == NULL)


### PR DESCRIPTION
It's already checked for and handled above by text_locked() and
text_locked_msg().