### PR TITLE
CI: Fix 8.2.4436 on Windows

### DIFF
--- a/src/testdir/test_vartabs.vim
+++ b/src/testdir/test_vartabs.vim
@@ -445,7 +445,7 @@ endfunc
 func Test_vartabstop_latin1()
   let save_encoding = &encoding
   new
-  set encoding=iso8859
+  set encoding=latin1
   silent norm :se 
   set vartabstop=400
   norm i00	

--- a/src/testdir/test_vartabs.vim
+++ b/src/testdir/test_vartabs.vim
@@ -445,7 +445,7 @@ endfunc
 func Test_vartabstop_latin1()
   let save_encoding = &encoding
   new
-  set encoding=latin1
+  set encoding=iso8859-1
   silent exe "norm :se \<C-A>\<C-C>"
   set vartabstop=400
   exe "norm i00\t\<C-D>"

--- a/src/testdir/test_vartabs.vim
+++ b/src/testdir/test_vartabs.vim
@@ -446,9 +446,9 @@ func Test_vartabstop_latin1()
   let save_encoding = &encoding
   new
   set encoding=latin1
-  silent norm :se 
+  silent exe "norm :se \<C-A>\<C-C>"
   set vartabstop=400
-  norm i00	
+  exe "norm i00\t\<C-D>"
   bwipe!
   let &encoding = save_encoding
 endfunc

--- a/src/testdir/test_vartabs.vim
+++ b/src/testdir/test_vartabs.vim
@@ -446,7 +446,7 @@ func Test_vartabstop_latin1()
   let save_encoding = &encoding
   new
   set encoding=latin1
-  silent norm :se 
+  silent norm :se 
   set vartabstop=400
   norm i00	
   bwipe!


### PR DESCRIPTION
> Caught exception in Test_vartabstop_latin1(): Vim(set):E950: Cannot convert between cp1252 and iso-8859- @ command line..script D:/a/vim/vim/src/testdir/runtest.vim[456]..function RunTheTest[44]..Test_vartabstop_latin1, line 3