### PR TITLE
Make Test_exit_error_reading_input() actually fail without patch 8.2.4438

### DIFF
--- a/src/testdir/test_exit.vim
+++ b/src/testdir/test_exit.vim
@@ -112,13 +112,13 @@ endfunc
 
 func Test_exit_error_reading_input()
   CheckNotGui
-  CheckNotMSWindows
   " The early exit causes memory not to be freed somehow
   CheckNotAsan
 
   call writefile([":au VimLeave * call writefile(['l = ' .. v:exiting], 'Xtestout')", ":tabnew", "q:"], 'Xscript', 'b')
 
   if RunVim([], [], '<Xscript')
+    call assert_equal(1, v:shell_error)
     call assert_equal(['l = 1'], readfile('Xtestout'))
   endif
   call delete('Xscript')

--- a/src/testdir/test_exit.vim
+++ b/src/testdir/test_exit.vim
@@ -112,6 +112,7 @@ endfunc
 
 func Test_exit_error_reading_input()
   CheckNotGui
+  CheckNotMSWindows
   " The early exit causes memory not to be freed somehow
   CheckNotAsan
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -1065,9 +1065,6 @@ read_error_exit(void)
     if (silent_mode)	// Normal way to exit for "ex -s"
 	getout(0);
     STRCPY(IObuff, _("Vim: Error reading input, exiting...\n"));
-#ifdef FEAT_CMDWIN
-    cmdwin_type = 0;
-#endif
     preserve_exit();
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -2856,6 +2856,10 @@ win_free_all(void)
 {
     int		dummy;
 
+#ifdef FEAT_CMDWIN
+    cmdwin_type = 0;
+#endif
+
     while (first_tabpage->tp_next != NULL)
 	tabpage_close(TRUE);
 


### PR DESCRIPTION
`VimLeave` is executed before `free_all_mem()`, so a segfault in `free_all_mem()` doesn't affect it. The correct way seems to be checking `v:shell_error` instead.

Maybe the `cmdwin_type = 0` can be moved to `free_all_mem()`?