### PR TITLE
CI: Fix 8.2.4437 again

### DIFF
--- a/src/testdir/test_vartabs.vim
+++ b/src/testdir/test_vartabs.vim
@@ -446,11 +446,12 @@ func Test_vartabstop_latin1()
   let save_encoding = &encoding
   new
   set encoding=iso8859-1
-  silent exe "norm :se \<C-A>\<C-C>"
+  set compatible linebreak list revins smarttab
   set vartabstop=400
   exe "norm i00\t\<C-D>"
   bwipe!
   let &encoding = save_encoding
+  set nocompatible linebreak& list& revins& smarttab& vartabstop&
 endfunc
 
 


### PR DESCRIPTION
The changed test in 8.2.4437 didn't cause a crash on 8.2.4435 or earlier.
Make the test causes a crash on 8.2.4435 again.

It seems that the following steps are the minimal sample:
```vim
  set encoding=iso8859-1
  set compatible linebreak list revins smarttab
  set vartabstop=400
  exe "norm i00\t\<C-D>"
```

Actually, `set compatible` changes many other options. I haven't checked which options are related to the crash.