### PR TITLE
test_terminal.vim: Raise wait time for test_terminal_noblock

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -715,7 +715,7 @@ endfunction
 func Test_terminal_noblock()
   let g:test_is_flaky = 1
   let buf = term_start(&shell)
-  let wait_time = 5000
+  let wait_time = 7500
   let letters = 'abcdefghijklmnopqrstuvwxyz'
   if has('bsd') || has('mac') || has('sun')
     " The shell or something else has a problem dealing with more than 1000


### PR DESCRIPTION
The test fails at internal CI machines (Fedora 36 and 37) - raising wait time solves the
issue.