### PR TITLE
win32,vimdll: Fix that garbage characters are output

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -2899,6 +2899,8 @@ _OnKillFocus(
     HWND hwnd,
     HWND hwndNewFocus)
 {
+    if (destroying)
+	return;
     gui_focus_change(FALSE);
     s_getting_focus = FALSE;
     (void)DefWindowProcW(hwnd, WM_KILLFOCUS, (WPARAM)hwndNewFocus, 0);


### PR DESCRIPTION
When gvim.exe is compiled with VIMDLL and the stdout is redirected,
garbage characters may be output.

```
gvim -u NONE -U NONE -cq > log.txt
```

We can see it also on the CI:
https://github.com/vim/vim/runs/5310962850?check_suite_focus=true#step:13:106

> ^[|24;11M[New]^L16L,^L1014B^Lwritten

When gvim is going to quit, `mch_write()` is called with the following
sequence:

```
_OnKillFocus()
-> gui_focus_change()
-> out_flush_cursor()
-> out_flush()
-> ui_write()
-> mch_write()
```

At this moment, `gui.in_use` has been changed to 0, so garbage
characters are written to the stdout.

Skip calling `gui_focus_change()` in `_OnKillFocus()` when gvim is going
to quit.