### PR TITLE
DOS/Windows installer - Crash when "-create-directories" is final arg

### DIFF
--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -2495,7 +2495,7 @@ command_line_setup_choices(int argc, char **argv)
 	    int vimfiles_dir_choice = (int)vimfiles_dir_none;
 
 	    init_directories_choice();
-	    if (argv[i + 1][0] != '-')
+	    if (argc > (i + 1) && argv[i + 1][0] != '-')
 	    {
 		i++;
 		if (strcmp(argv[i], "vim") == 0)


### PR DESCRIPTION
When running install.exe with `-create-directories` as the final argument, an access violation was happening due to a missing bounds check.