### PR TITLE
Support fuzzy completion using lower case letters and numbers for user commands

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -2776,6 +2776,18 @@ func Test_wildoptions_fuzzy()
   delcommand T123FendingOff
   %bw
 
+  " Test for fuzzy completion of a command with lower case letters and a
+  " number
+  command Foo2Bar :
+  set wildoptions=fuzzy
+  call feedkeys(":foo2\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"Foo2Bar', @:)
+  call feedkeys(":foo\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"Foo2Bar', @:)
+  call feedkeys(":bar\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"Foo2Bar', @:)
+  delcommand Foo2Bar
+
   set wildoptions&
   %bw!
 endfunc


### PR DESCRIPTION

Also, do regex initialization only for non-fuzzy completion.