### PR TITLE
Add "in_cmdwin()" function and "%@" for cmdline, expand(), bufname(), and so on

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1080,7 +1080,9 @@ bufname([{buf}])					*bufname()*
 		set and 'cpoptions' is empty.  When there is more than one
 		match an empty string is returned.
 		"" or "%" can be used for the current buffer, "#" for the
-		alternate buffer.
+		alternate buffer, "%@" for the buffer where commands will be
+		executed in (i.e. "%@" for the current buffer unless in
+		|cmdwin|, the alternative buffer in |cmdwin|).
 		A full match is preferred, otherwise a match at the start, end
 		or middle of the buffer name is accepted.  If you only want a
 		full match then put "^" at the start and "$" at the end of the
@@ -9025,6 +9027,22 @@ tabpagewinnr({tabarg} [, {arg}])			*tabpagewinnr()*
 		  the window which will be used when going to this tab page.
 		- When "$" the number of windows is returned.
 		- When "#" the previous window nr is returned.
+		- When "%@"
+		    - {tabarg} is the current tab page and the current window
+		      is not |cmdwin|, the current window number is returned.
+		    - {tabarg} is the current tab page and the current window
+		      is |cmdwin|, the previous window number is returned.
+		    - {tabarg} is not the current tab page, the current number
+		      is returned.
+		`tabapgewinnr(tabarg, "%@")` is equivalent to: >
+		    function MyTabpageWinnr(tabarg)
+		      if a:tabarg == tabpagenr()
+			return winnr("%@")
+		      else
+			return tabpagewinnr(tabarg)
+		      endif
+		    endfunction
+<
 		Useful examples: >
 		    tabpagewinnr(1)	    " current window of tab page 1
 		    tabpagewinnr(4, '$')    " number of windows in tab page 4
@@ -9770,6 +9788,10 @@ winnr([{arg}])	The result is a Number, which is the number of the current
 				|CTRL-W_p| goes to).  If there is no previous
 				window or it is in another tab page 0 is
 				returned.
+			%@	the number of the window where commands will
+				be executed. (i.e. the current window unless
+				in |cmdwin|, the last accessed window in
+				|cmdwin|.)
 			{N}j	the number of the Nth window below the
 				current window (where |CTRL-W_j| goes to).
 			{N}k	the number of the Nth window above the current

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1082,7 +1082,7 @@ bufname([{buf}])					*bufname()*
 		"" or "%" can be used for the current buffer, "#" for the
 		alternate buffer, "%@" for the buffer where commands will be
 		executed in (i.e. "%@" for the current buffer unless in
-		|cmdwin|, the alternative buffer in |cmdwin|).
+		|cmdwin|, the alternate buffer in |cmdwin|).
 		A full match is preferred, otherwise a match at the start, end
 		or middle of the buffer name is accepted.  If you only want a
 		full match then put "^" at the start and "$" at the end of the
@@ -9034,7 +9034,7 @@ tabpagewinnr({tabarg} [, {arg}])			*tabpagewinnr()*
 		      is |cmdwin|, the previous window number is returned.
 		    - {tabarg} is not the current tab page, the current number
 		      is returned.
-		`tabapgewinnr(tabarg, "%@")` is equivalent to: >
+		`tabpagewinnr(tabarg, "%@")` is equivalent to: >
 		    function MyTabpageWinnr(tabarg)
 		      if a:tabarg == tabpagenr()
 			return winnr("%@")

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4463,6 +4463,7 @@ in_cmdwin()						*in_cmdwin()*
 		Returns TRUE if the current window is |cmdwin|, not editing
 		command-line.
 		Example: >
+			" getcmdlne(), but also works in cmdwin.
 			function GetCmdline()
 			  if in_cmdwin()
 			    return getline(".")
@@ -4471,6 +4472,7 @@ in_cmdwin()						*in_cmdwin()*
 			  endif
 			endfunction
 
+			" getcmdpos(), but also works in cmdwin.
 			function GetCmdpos()
 			  if in_cmdwin()
 			    return col(".")

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -280,6 +280,8 @@ hlget([{name} [, {resolve}]])	List	get highlight group attributes
 hlset({list})			Number	set highlight group attributes
 hostname()			String	name of the machine Vim is running on
 iconv({expr}, {from}, {to})	String	convert encoding of {expr}
+in_cmdwin()
+				bool		|TRUE| if the current window is |cmdwin|
 indent({lnum})			Number	indent of line {lnum}
 index({object}, {expr} [, {start} [, {ic}]])
 				Number	index in {object} where {expr} appears
@@ -4455,6 +4457,27 @@ iconv({string}, {from}, {to})				*iconv()*
 		Can also be used as a |method|: >
 			GetText()->iconv('latin1', 'utf-8')
 <
+in_cmdwin()						*in_cmdwin()*
+		Returns TRUE if the current window is |cmdwin|, not editing
+		command-line.
+		Example: >
+			function GetCmdline()
+			  if in_cmdwin()
+			    return getline(".")
+			  else
+			    return getcmdline()
+			  endif
+			endfunction
+
+			function GetCmdpos()
+			  if in_cmdwin()
+			    return col(".")
+			  else
+			    return getcmdpos()
+			  endif
+			endfunction
+<
+
 							*indent()*
 indent({lnum})	The result is a Number, which is indent of line {lnum} in the
 		current buffer.  The indent is counted in spaces, the value

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -869,7 +869,7 @@ function |expand()|.
 		number.							*E809*
 	%@  Is replaced with the file name where commands will *:_%@* *:c_%@*
 	 	be executed. (i.e. the current file name unless in |cmdwin|, the
-		alternative file name in |cmdwin|.)
+		alternate file name in |cmdwin|.)
 		{only when compiled with the |+eval| and |+viminfo| features}
 In |Vim9-script| # is used to start a comment, use %% for the alternate file
 name:

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -867,6 +867,9 @@ function |expand()|.
 	#<n	(where n is a number > 0) is replaced with old	  *:_#<* *c_#<*
 		file name n.  See |:oldfiles| or |v:oldfiles| to get the
 		number.							*E809*
+	%@  Is replaced with the file name where commands will *:_%@* *:c_%@*
+	 	be executed. (i.e. the current file name unless in |cmdwin|, the
+		alternative file name in |cmdwin|.)
 		{only when compiled with the |+eval| and |+viminfo| features}
 In |Vim9-script| # is used to start a comment, use %% for the alternate file
 name:
@@ -893,7 +896,8 @@ that contain a quote and wildcards): >
 	:!ls "%"
 	:r !spell "%"
 
-To avoid the special meaning of '%' and '#' insert a backslash before it.
+To avoid the special meaning of '%', '#', and '%@' insert a backslash before
+it.
 Detail: The special meaning is always escaped when there is a backslash before
 it, no matter how many backslashes.
 	you type:		result	~
@@ -967,8 +971,9 @@ Note: these are typed literally, they are not special keys!
 							 *filename-modifiers*
 *:_%:* *::8* *::p* *::.* *::~* *::h* *::t* *::r* *::e* *::s* *::gs* *::S*
      *%:8* *%:p* *%:.* *%:~* *%:h* *%:t* *%:r* *%:e* *%:s* *%:gs* *%:S*
-The file name modifiers can be used after "%", "#", "#n", "<cfile>", "<sfile>",
-"<afile>" or "<abuf>".  They are also used with the |fnamemodify()| function.
+The file name modifiers can be used after "%", "#", "#n", "%@", "<cfile>",
+"<sfile>", "<afile>" or "<abuf>".  They are also used with the |fnamemodify()|
+function.
 
 These modifiers can be given, in this order:
 	:p	Make file name a full path.  Must be the first modifier.  Also
@@ -1066,6 +1071,8 @@ name).  This is included for backwards compatibility with version 3.0, the
 	#<		idem, without extension
 	#31		alternate file number 31
 	#31<		idem, without extension
+	%@		file name where commands will be executed
+	%@<		idem, without extension
 	<cword>		word under the cursor
 	<cWORD>		WORD under the cursor (see |WORD|)
 	<cfile>		path name under the cursor

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -980,6 +980,7 @@ Command line:					*command-line-functions*
 	setcmdpos()		set position of the cursor in the command line
 	getcmdtype()		return the current command-line type
 	getcmdwintype()		return the current command-line window type
+	in_cmdwin()			check if the current window is |cmdwin|
 	getcompletion()		list of command-line completion matches
 	fullcommand()		get full command name
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2601,13 +2601,21 @@ buflist_findpat(
     char_u	*p;
     int		toggledollar;
 
-    // "%" is current file, "%%" or "#" is alternate file
+    // "%" is current file, "%%" or "#" is alternate file, "%@" is current file
+    // unless in the cmdline window and is alternate file in the cmdline window
     if ((pattern_end == pattern + 1 && (*pattern == '%' || *pattern == '#'))
-	    || (in_vim9script() && pattern_end == pattern + 2
-				    && pattern[0] == '%' && pattern[1] == '%'))
+	    || (pattern_end == pattern + 2 && pattern[0] == '%' &&
+		((in_vim9script() && pattern[1] == '%') || pattern[1] == '@')))
     {
-	if (*pattern == '#' || pattern_end == pattern + 2)
+	if (*pattern == '#')
 	    match = curwin->w_alt_fnum;
+	else if (pattern_end == pattern + 2 && *pattern == '%')
+	{
+	    if (pattern[1] == '%')
+		match = curwin->w_alt_fnum;
+	    else  // pattern[1] == '@'
+		match = prevwin_curwin()->w_buffer->b_fnum;
+	}
 	else
 	    match = curbuf->b_fnum;
 #ifdef FEAT_DIFF

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1948,6 +1948,8 @@ static funcentry_T global_functions[] =
 			ret_string,	    f_hostname},
     {"iconv",		3, 3, FEARG_1,	    arg3_string,
 			ret_string,	    f_iconv},
+    {"in_cmdwin",	0, 0, 0,	    NULL,
+			ret_bool,	    f_in_cmdwin},
     {"indent",		1, 1, FEARG_1,	    arg1_lnum,
 			ret_number,	    f_indent},
     {"index",		2, 4, FEARG_1,	    arg24_index,

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -333,6 +333,8 @@ get_winnr(tabpage_T *tp, typval_T *argvar)
 	{
 	    twin = (tp == curtab) ? prevwin : tp->tp_prevwin;
 	}
+        else if (STRCMP(arg, "%@") == 0)
+            twin = (tp == curtab) ? prevwin_curwin() : tp->tp_lastwin;
 	else
 	{
 	    long	count;

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4553,6 +4553,15 @@ is_in_cmdwin(void)
 {
     return cmdwin_type != 0 && get_cmdline_type() == NUL;
 }
+
+/*
+ * "in_cmdwin()" function
+ */
+    void
+f_in_cmdwin(typval_T *argvars UNUSED, typval_T *rettv) {
+    rettv->v_type = VAR_BOOL;
+    rettv->vval.v_number = is_in_cmdwin() ? VVAL_TRUE : VVAL_FALSE;
+}
 #endif // FEAT_CMDWIN
 
 /*

--- a/src/proto/ex_getln.pro
+++ b/src/proto/ex_getln.pro
@@ -38,6 +38,7 @@ int get_cmdline_firstc(void);
 int get_list_range(char_u **str, int *num1, int *num2);
 char *check_cedit(void);
 int is_in_cmdwin(void);
+void f_in_cmdwin(typval_T *argvars, typval_T *rettv);
 char_u *script_get(exarg_T *eap, char_u *cmd);
 void get_user_input(typval_T *argvars, typval_T *rettv, int inputdialog, int secret);
 /* vim: set ft=c : */

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1358,6 +1358,17 @@ function Test_prevwin_curwin_in_cmdwin()
   delfunction CmdlineTest
 endfunction
 
+function Test_in_cmdwin_function()
+  let cmd = ''
+  let cmd ..= "\<Cmd>call assert_false(in_cmdwin())\<CR>"
+  let cmd ..= 'q:'
+  let cmd ..= "\<Cmd>call assert_true(in_cmdwin())\<CR>"
+  let cmd ..= ':'
+  let cmd ..= "\<Cmd>call assert_false(in_cmdwin())\<CR>"
+  let cmd ..= "q\<CR>"
+  call feedkeys(cmd, 'x')
+endfunction
+
 func Test_verbosefile()
   set verbosefile=Xlog
   echomsg 'foo'


### PR DESCRIPTION
This PR adds:
 - `in_cmdwin()` function
 - a special identifier, `%@`, for cmdline, `expand()`, `bufname()`, and so on.

The `in_cmdwin()` function returns TRUE in cmdwin, not editing window.
The `%@` is used to refer to the buffer or window where commands will be executed.
In other words, `%@` refers to
 - the current buffer/window unless in cmdwin.
 - the alternate buffer/window in cmdwin, not editing command-line.

Example:

Suppose if buffers and windows are like this and you're on window 2.

```
+------------------+------------------+
|                  |                  |
|    foo.txt       |    bar.txt       |
|    bufnr: 1      |    bufnr: 2      |
|    winnr: 1      |    winnr: 2      |
|                  |                  |
+------------------+------------------+
```

In this situation, functions return these values:

|function|returned|
|:-|:-|
|`in_cmdwin()`|`FALSE`|
|`bufnr("%")`|`2`|
|`bufname("%@")`|`bar.txt`|
|`bufnr("%@")`|`2`|
|`winnr("%@")`|`2`|


Next, if you enter command-line, functions return these values:

```
+------------------+------------------+
|                  |                  |
|    foo.txt       |    bar.txt       |
|    bufnr: 1      |    bufnr: 2      |
|    winnr: 1      |    winnr: 2      |
|                  |                  |
+------------------+------------------+
|:                      (Command line)|
+-------------------------------------+
```

|function|returned|
|:-|:-|
|`in_cmdwin()`|`FALSE`|
|`bufnr("%")`|`2`|
|`bufname("%@")`|`bar.txt`|
|`bufnr("%@")`|`2`|
|`winnr("%@")`|`2`|


Then, if you enter cmdwin, functions return these values:

```
+------------------+------------------+
|                  |                  |
|    foo.txt       |    bar.txt       |
|    bufnr: 1      |    bufnr: 2      |
|    winnr: 1      |    winnr: 2      |
|                  |                  |
+------------------+------------------+
|   Command-line window               |
|   bufnr: 3                          |
|   winnr: 3                          |
+-------------------------------------+
```

|function|returned|
|:-|:-|
|`in_cmdwin()`|`TRUE`|
|`bufnr("%")`|`3`|
|`bufname("%@")`|`bar.txt`|
|`bufnr("%@")`|`2`|
|`winnr("%@")`|`2`|

In the last, if you enter command-line again, functions return these values:

```
+------------------+------------------+
|                  |                  |
|    foo.txt       |    bar.txt       |
|    bufnr: 1      |    bufnr: 2      |
|    winnr: 1      |    winnr: 2      |
|                  |                  |
+------------------+------------------+
|   Command-line window               |
|   bufnr: 3                          |
|   winnr: 3                          |
+-------------------------------------+
|:                      (Command line)|
+-------------------------------------+
```

|function|returned|
|:-|:-|
|`in_cmdwin()`|`FALSE`|
|`bufnr("%")`|`3`|
|`bufname("%@")`|`[Command Line]`|
|`bufnr("%@")`|`3`|
|`winnr("%@")`|`3`|

### Motivation

Actually, you can implement `in_cmdwin()`, `bufnr("%@")`, ... alternates with current Vim script like this:

```vim
function InCmdwin()
  return getcmdwintype() !=# '' && getcmdtype() ==# ''
endfunction

function MyBufnr()
  if InCmdwin()
    return bufnr("#")
  else
    return bufnr("%")
  endif
endfunction

" And so on...
```

However, many scripts (for example, a user command completion that refers to buffer local information) need these utility functions, so you may be required to write these functions many times.
It is tiresome work to write these functions whenever you make such scripts.
I believe it is worth to make these built-in feature.



### Additional context

 - Why `%@`
 	- `%#` looked good, but using `#` is not preferred in Vim9 script.
	- `%%` and `%%%` are already used.
	- `%%%%` is not used, but it seems too long.
	- It seems that there's no good single character to use in this purpose. Let's use `%{char}`.

When considered these, I felt `%@` is better.
However, to be honest with you, I'm not sure `%@` is the best. If you have any good idea, please tell me!

 - About backward compatibility

Strictly speaking, this change breaks backward compatibility, but a buffer named `%@` hardly appears, so I think this is acceptable.
