### PR TITLE
Allow comparing v:null and number

### DIFF
--- a/src/typval.c
+++ b/src/typval.c
@@ -1403,6 +1403,7 @@ typval_compare_null(typval_T *tv1, typval_T *tv2)
 	    case VAR_JOB: return tv->vval.v_job == NULL;
 #endif
 	    case VAR_LIST: return tv->vval.v_list == NULL;
+	    case VAR_NUMBER: return tv->vval.v_number == 0;
 	    case VAR_PARTIAL: return tv->vval.v_partial == NULL;
 	    case VAR_STRING: return tv->vval.v_string == NULL;
 	    default: break;


### PR DESCRIPTION
Fix the following error in 8.2.4487:

	From test_vimscript.vim:
	Found errors in Test_type():
	Caught exception in Test_type(): Vim(call):E1072: Cannot compare special with number @ command line..script D:/a/vim/vim/src/testdir/runtest.vim[456]..function RunTheTest[44]..Test_type, line 62