### PR TITLE
Still apply window-local directory when 'acd' fails

### DIFF
--- a/src/testdir/test_autochdir.vim
+++ b/src/testdir/test_autochdir.vim
@@ -86,22 +86,27 @@ func Test_verbose_pwd()
   set acd
   wincmd w
   call assert_match('\[autochdir\].*testdir$', execute('verbose pwd'))
-  execute 'lcd' cwd
-  call assert_match('\[window\].*testdir$', execute('verbose pwd'))
   execute 'tcd' cwd
   call assert_match('\[tabpage\].*testdir$', execute('verbose pwd'))
   execute 'cd' cwd
   call assert_match('\[global\].*testdir$', execute('verbose pwd'))
+  execute 'lcd' cwd
+  call assert_match('\[window\].*testdir$', execute('verbose pwd'))
   edit
   call assert_match('\[autochdir\].*testdir$', execute('verbose pwd'))
+  enew
+  wincmd w
+  call assert_match('\[autochdir\].*testdir[/\\]Xautodir', execute('verbose pwd'))
+  wincmd w
+  call assert_match('\[window\].*testdir$', execute('verbose pwd'))
   wincmd w
   call assert_match('\[autochdir\].*testdir[/\\]Xautodir', execute('verbose pwd'))
   set noacd
   call assert_match('\[autochdir\].*testdir[/\\]Xautodir', execute('verbose pwd'))
   wincmd w
-  call assert_match('\[autochdir\].*testdir[/\\]Xautodir', execute('verbose pwd'))
+  call assert_match('\[window\].*testdir$', execute('verbose pwd'))
   execute 'cd' cwd
-  call assert_match('\[global\].*testdir', execute('verbose pwd'))
+  call assert_match('\[global\].*testdir$', execute('verbose pwd'))
   wincmd w
   call assert_match('\[window\].*testdir[/\\]Xautodir', execute('verbose pwd'))
 

--- a/src/window.c
+++ b/src/window.c
@@ -4772,11 +4772,6 @@ win_enter(win_T *wp, int undo_sync)
     static void
 fix_current_dir(void)
 {
-#ifdef FEAT_AUTOCHDIR
-    if (p_acd)
-	do_autochdir();
-    else
-#endif
     if (curwin->w_localdir != NULL || curtab->tp_localdir != NULL)
     {
 	char_u	*dirname;


### PR DESCRIPTION
This fixes a regression introduced in patch 8.2.3739: window-local
directory is not applied if 'acd' fails.

It is no longer necessary to call do_autochdir() from fix_current_dir()
after patch 8.2.3920, as fix_current_dir() is now only called when
entering a window, while do_autochdir() will be called later when
entering the buffer.