### PR TITLE
win32: Fix 'window' when gvim started maximized

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -3380,7 +3380,8 @@ win_new_shellsize(void)
     {
 	// If 'window' uses the whole screen, keep it using that.
 	// Don't change it when set with "-w size" on the command line.
-	if (p_window == old_Rows - 1 || (old_Rows == 0 && p_window == 0))
+	if (p_window == old_Rows - 1
+		    || (old_Rows == 0 && !option_was_set((char_u *)"window")))
 	    p_window = Rows - 1;
 	old_Rows = Rows;
 	shell_new_rows();	// update window sizes


### PR DESCRIPTION
See: https://groups.google.com/g/vim_dev/c/f9uMei8FFto

The 'window' option was not properly set when gvim was started maximized.

The calling sequence is as follows:
```
set_init_2(): setting p_window to 24
set_termname(): builtin_gui
_OnSize(): 148,0, p_window=24, Rows=25
  -> gui_resize_shell(): return because !gui.shell_created
_OnSize(): 661,511, p_window=24, Rows=25
  -> gui_resize_shell()
    -> shell_resized()
      -> set_shellsize()
_OnSize(): 1920,976, p_window=24, Rows=25
  -> gui_resize_shell()
    -> shell_resized()
      -> set_shellsize()
        -> ui_get_shellsize(): Rows is set to 49
gui_init()
  -> win_new_shellsize(), p_window=24, old_Rows=0, Rows=49
       p_window is not updated unexpectedly. (48 is expected.)
```