### PR TITLE
Fix goto file(gf) for PHP files with no extension

### DIFF
--- a/runtime/ftplugin/php.vim
+++ b/runtime/ftplugin/php.vim
@@ -71,10 +71,11 @@ exe 'nno <buffer> <silent> ]] /' . escape(s:section, '|') . '/<CR>:nohls<CR>'
 exe 'ono <buffer> <silent> [[ ?' . escape(s:section, '|') . '?<CR>:nohls<CR>'
 exe 'ono <buffer> <silent> ]] /' . escape(s:section, '|') . '/<CR>:nohls<CR>'
 
+setlocal suffixesadd=.php
 setlocal commentstring=/*%s*/
 
 " Undo the stuff we changed.
-let b:undo_ftplugin = "setlocal commentstring< include< omnifunc<" .
+let b:undo_ftplugin = "setlocal suffixesadd< commentstring< include< omnifunc<" .
 	    \	      " | unlet! b:browsefilter b:match_words | " .
 	    \	      s:undo_ftplugin
 


### PR DESCRIPTION
This PR fixes an issue mentioned on [/r/vim](https://www.reddit.com/r/vim/comments/t8o0bw/gf_goto_file_doesnt_work_in_php_file/) where goto file or the `gf` mapping doesn't work on php files with no extension. I figured it would be an easy one as a first time contributor and I followed other ftplugin files as an example.


