### PR TITLE
Fix suspending with Ctrl+Z on OpenBSD

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -887,7 +887,7 @@ sig_tstp SIGDEFARG(sigarg)
     else
 	got_tstp = TRUE;
 
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(__OpenBSD__)
     // this is not required on all systems
     signal(SIGTSTP, (RETSIGTYPE (*)())sig_tstp);
 #endif


### PR DESCRIPTION
As mentioned in my comment on https://github.com/vim/vim/pull/9422 Ctrl-Z was broken on OpenBSD too. Seems widening the ifdef in the Android fix added in https://github.com/vim/vim/pull/9854 fixes it for me too.