### PR TITLE
append non-existing path when expanding shortpath on Windows

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -186,7 +186,7 @@ shortpath_for_invalid_fname(
 	    // unless get_short_pathname() did its work in-place.
 	    *fname = *bufp = save_fname;
 	    if (short_fname != save_fname)
-		vim_strncpy(save_fname, short_fname, len);
+		STRNCPY(save_fname, short_fname, len);
 	    save_fname = NULL;
 	}
 

--- a/src/testdir/test_shortpathname.vim
+++ b/src/testdir/test_shortpathname.vim
@@ -88,4 +88,9 @@ func Test_ColonEight_MultiByte()
   call delete(dir, 'd')
 endfunc
 
+func Test_ColonEight_notexists()
+  let non_exists='C:\windows\newfile.txt'
+  call assert_equal(non_exists, fnamemodify(non_exists, ':p:8'))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
vim_strncpy(to, from, len) is basically the same as strncpy(to, from, len) but it will in addition set `to[len] = NUL`. 

So this will set `save_fname[len]=0`. Unfortunately, we remembered save_fname[len] a couple of lines above in `*endp`, which will now again be `NUL` so the whole concatenation won't work. 

So instead of using `vim_strncpy`, simply use `strncpy`, which should leave `*endp` untouched. 

fixes vim/vim#8600