### PR TITLE
refactor(syntax/tmux.vim): add more options and commands/aliases

### DIFF
--- a/runtime/syntax/tmux.vim
+++ b/runtime/syntax/tmux.vim
@@ -76,48 +76,48 @@ syn keyword tmuxOptions
 \ message-command-style message-limit message-style aggressive-resize
 \ allow-rename alternate-screen automatic-rename automatic-rename-format
 \ clock-mode-colour clock-mode-style copy-mode-current-match-style
-\ copy-mode-mark-style copy-mode-match-style main-pane-height
-\ main-pane-width mode-keys mode-style monitor-activity monitor-bell
-\ monitor-silence mouse other-pane-height other-pane-width
-\ pane-active-border-style pane-base-index pane-border-format
-\ pane-border-lines pane-border-status pane-border-style pane-colours prefix
-\ prefix2 prompt-history-limit remain-on-exit renumber-windows repeat-time
-\ set-clipboard set-titles set-titles-string silence-action status status-bg
-\ status-fg status-format status-interval status-justify status-keys
-\ status-left status-left-length status-left-style status-position
-\ status-right status-right-length status-right-style status-style
-\ synchronize-panes terminal-features terminal-overrides update-environment
-\ user-keys visual-activity visual-bell visual-silence window-active-style
-\ window-size window-status-activity-style window-status-bell-style
-\ window-status-current-format window-status-current-style
-\ window-status-format window-status-last-style window-status-separator
-\ window-status-style window-style word-separators wrap-search
+\ copy-mode-mark-style copy-mode-match-style main-pane-height main-pane-width
+\ mode-keys mode-style monitor-activity monitor-bell monitor-silence mouse
+\ other-pane-height other-pane-width pane-active-border-style pane-base-index
+\ pane-border-format pane-border-lines pane-border-status pane-border-style
+\ pane-colours popup-border-lines popup-border-style prefix prefix2
+\ prompt-history-limit remain-on-exit renumber-windows repeat-time set-clipboard
+\ set-titles set-titles-string silence-action status status-bg status-fg
+\ status-format status-interval status-justify status-keys status-left
+\ status-left-length status-left-style status-position status-right
+\ status-right-length status-right-style status-style synchronize-panes
+\ terminal-features terminal-overrides update-environment user-keys
+\ visual-activity visual-bell visual-silence window-active-style window-size
+\ window-status-activity-style window-status-bell-style
+\ window-status-current-format window-status-current-style window-status-format
+\ window-status-last-style window-status-separator window-status-style
+\ window-style word-separators wrap-search
 
 syn keyword tmuxCommands
-\ attach attach-session bind bind-key break-pane breakp capture-pane
-\ capturep choose-buffer choose-client choose-tree clear-history clearhist
-\ clock-mode command-prompt confirm confirm-before copy-mode customize-mode
-\ detach detach-client display display-menu display-message display-panes
-\ display-popup displayp find-window findw if if-shell join-pane joinp
-\ kill-pane kill-server kill-session kill-window killp has has-session killw
-\ link-window linkw list-buffers list-clients list-commands list-keys
-\ list-panes list-sessions list-windows load-buffer loadb lock lock-client
-\ lock-server lock-session lockc last-pane lastp locks ls last last-window
-\ lsb delete-buffer deleteb lsc lscm lsk lsp lsw menu move-pane move-window
-\ clear-prompt-history clearphist movep movew new new-session new-window
-\ neww next next-layout next-window nextl paste-buffer pasteb pipe-pane
-\ pipep popup prev previous-layout previous-window prevl refresh
-\ refresh-client rename rename-session rename-window renamew resize-pane
-\ resize-window resizep resizew respawn-pane respawn-window respawnp
-\ respawnw rotate-window rotatew run run-shell save-buffer saveb
+\ attach attach-session bind bind-key break-pane breakp capture-pane capturep
+\ choose-buffer choose-client choose-session choose-tree choose-window
+\ clear-history clearhist clock-mode command-prompt confirm confirm-before
+\ copy-mode customize-mode detach detach-client display display-menu
+\ display-message display-panes display-popup displayp find-window findw if
+\ if-shell join-pane joinp kill-pane kill-server kill-session kill-window killp
+\ has has-session info killw link-window linkw list-buffers list-clients
+\ list-commands list-keys list-panes list-sessions list-windows load-buffer
+\ loadb lock lock-client lock-server lock-session lockc last-pane lastp locks
+\ ls last last-window lsb delete-buffer deleteb lsc lscm lsk lsp lsw menu
+\ move-pane move-window clear-prompt-history clearphist movep movew new
+\ new-session new-window neww next next-layout next-window nextl paste-buffer
+\ pasteb pipe-pane pipep popup prev previous-layout previous-window prevl
+\ refresh refresh-client rename rename-session rename-window renamew
+\ resize-pane resize-window resizep resizew respawn-pane respawn-window
+\ respawnp respawnw rotate-window rotatew run run-shell save-buffer saveb
 \ select-layout select-pane select-window selectl selectp selectw send
-\ send-keys send-prefix set set-buffer set-environment set-hook set-option
-\ set-window-option setb setenv setw show show-buffer show-environment
-\ show-hooks show-messages show-options show-prompt-history
+\ send-keys send-prefix server-info set set-buffer set-environment set-hook
+\ set-option set-window-option setb setenv setw show show-buffer
+\ show-environment show-hooks show-messages show-options show-prompt-history
 \ show-window-options showb showenv showmsgs showphist showw source
-\ source-file split-window splitw start start-server suspend-client suspendc
-\ swap-pane swap-window swapp swapw switch-client switchc unbind unbind-key
-\ unlink-window unlinkw wait wait-for
+\ source-file split-pane splitp split-window splitw start start-server
+\ suspend-client suspendc swap-pane swap-window swapp swapw switch-client
+\ switchc unbind unbind-key unlink-window unlinkw wait wait-for
 
 let &cpo = s:original_cpo
 unlet! s:original_cpo s:bg s:i


### PR DESCRIPTION
The added options:
- popup-border-lines
- popup-border-style

The added commands/aliases:

- split-pane (an alias for split-window)
- splitp (an alias for split-window)
- server-info (an alias for show-messages -JT)
- info (an alias for show-messages -JT)
- choose-window (an alias for choose-tree -w)
- choose-session (an alias for choose-tree -s)

A recent build of tmux (based on tmux.git:ee3f1d25d568) was used as
reference.

Note: As of tmux.git commit 126d364abe2e8c063efa5a888de69, server-info
is defined as one of the recently introduced command-alias options,
which means (for now, at least) there are two separate sources of truth
for enumerating commands and their aliases.

Existing aliases are still found in the output of list-commands
immediately following the fully qualified name, like so:

$ tmux list-commands display-popup | awk '{print $1, $2}'
display-popup (popup)

However, command-alias items are instead stored as entries in a server
option:

$ tmux show-options -s command-alias
command-alias[0] split-pane=split-window
command-alias[1] splitp=split-window
command-alias[2] "server-info=show-messages -JT"
command-alias[3] "info=show-messages -JT"
command-alias[4] "choose-window=choose-tree -w"
command-alias[5] "choose-session=choose-tree -s"