### PR TITLE
Fix the tag file linear search performance regression introduced by patch 8.2.3776

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -2092,10 +2092,7 @@ findtags_get_next_line(findtags_state_T *st, tagsearch_info_T *sinfo_p)
 		eof = cs_fgets(st->lbuf, st->lbuf_size);
 	    else
 #endif
-	    {
-		sinfo_p->curr_offset = vim_ftell(st->fp);
 		eof = vim_fgets(st->lbuf, st->lbuf_size, st->fp);
-	    }
 	} while (!eof && vim_isblankline(st->lbuf));
 
 	if (eof)
@@ -2850,7 +2847,7 @@ line_read_in:
 		return;
 	    }
 
-	    if (st->state == TS_STEP_FORWARD)
+	    if (st->state == TS_STEP_FORWARD || st->state == TS_LINEAR)
 		// Seek to the same position to read the same line again
 		vim_ignored = vim_fseek(st->fp, search_info.curr_offset,
 								     SEEK_SET);

--- a/src/testdir/test_taglist.vim
+++ b/src/testdir/test_taglist.vim
@@ -259,8 +259,15 @@ func Test_tag_complete_with_overlong_line()
   call writefile(tagslines, 'Xtags')
   set tags=Xtags
 
+  " try with binary search
+  set tagbsearch
   call feedkeys(":tag inbou\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"tag inboundGSV inboundGovernor inboundGovernorCounters', @:)
+  " try with linear search
+  set notagbsearch
+  call feedkeys(":tag inbou\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"tag inboundGSV inboundGovernor inboundGovernorCounters', @:)
+  set tagbsearch&
 
   call delete('Xtags')
   set tags&


### PR DESCRIPTION
When measuring the performance of linear searching a tag file, I found that the performance
has degraded after "patch 8.2.3776: when a tags file line is long a tag may not be found"
(https://github.com/vim/vim/commit/f8e9eb8e173bf0ff9560192ae888941ef8302269).

I used the below Vim9 script to measure the performance. With this script, before
patch 8.2.3776, it takes around 7.2 seconds to run the script. After this patch, it takes
around 18 seconds.

This PR addresses this issue.

Also, I noticed that the original issue reported was still observed when using
linear search instead of binary search. This patch fixes that also.

I noticed a slight decrease in linear searching performance with the recent refactoring
of the tags feature. I will create a separate PR to address this.

```
vim9script

def CreateTagsFile()
  var l: list<string>
  for i in range(1, 1000000)
    add(l, 'abc' .. i .. "\tXfile\t" .. i .. ";")
  endfor
  sort(l)
  var hdr: list<string> =<< trim END
    !_TAG_FILE_FORMAT   2       /extended format; --format=1 will not append ;" to lines/
    !_TAG_FILE_SORTED   1       /0=unsorted, 1=sorted, 2=foldcase/
  END
  call writefile(hdr, 'Xtags')
  call writefile(l, 'Xtags', 'a')
enddef

def ProfileCmdCompletion()
  var start: list<any> = reltime()
  var l: list<any>
  for i in range(100)
    l = getcompletion('abc500x', 'tag')
  endfor
  var seconds: string = reltimefloat(reltime(start))->string()
  echomsg "Took " .. seconds .. " seconds"
enddef

set notagbsearch
set tags=Xtags
CreateTagsFile()
ProfileCmdCompletion()
set tags&
```