### PR TITLE
Fix getmousepos() "column" value when past last buffer line

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -3099,8 +3099,8 @@ f_getmousepos(typval_T *argvars UNUSED, typval_T *rettv)
 	    col -= left_off;
 	    if (row >= 0 && row < wp->w_height && col >= 0 && col < wp->w_width)
 	    {
-		if (!mouse_comp_pos(wp, &row, &col, &lnum, NULL))
-		    col = vcol2col(wp, lnum, col);
+		mouse_comp_pos(wp, &row, &col, &lnum, NULL);
+		col = vcol2col(wp, lnum, col);
 		column = col + 1;
 	    }
 	}

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2783,6 +2783,29 @@ func Test_getmousepos()
         \ line: 1,
         \ column: 8,
         \ }, getmousepos())
+
+  " If the mouse is positioned past the last buffer line, "line" and "column"
+  " should act like it's positioned on the last buffer line.
+  call test_setmouse(2, 25)
+  call assert_equal(#{
+        \ screenrow: 2,
+        \ screencol: 25,
+        \ winid: win_getid(),
+        \ winrow: 2,
+        \ wincol: 25,
+        \ line: 1,
+        \ column: 4,
+        \ }, getmousepos())
+  call test_setmouse(2, 50)
+  call assert_equal(#{
+        \ screenrow: 2,
+        \ screencol: 50,
+        \ winid: win_getid(),
+        \ winrow: 2,
+        \ wincol: 50,
+        \ line: 1,
+        \ column: 8,
+        \ }, getmousepos())
   bwipe!
 endfunc
 


### PR DESCRIPTION
After v8.2.4559, the value of "column" from getmousepos() is the same as
"wincol" if the mouse is positioned below the last line in the buffer.

Instead, similar to before, return the text column as if we moved on the last
buffer line.