### PR TITLE
Make bracketed paste more consistent in linewise Visual mode

### DIFF
--- a/src/testdir/test_paste.vim
+++ b/src/testdir/test_paste.vim
@@ -109,23 +109,69 @@ func Test_paste_visual_mode()
   call feedkeys("0fsve\<Esc>[200~more\<Esc>[201~", 'xt')
   call assert_equal('here are more words', getline(1))
   call assert_equal('some', getreg('-'))
+  normal! u
+  call assert_equal('here are some words', getline(1))
+  normal! 
+  call assert_equal('here are more words', getline(1))
 
   " include last char in the line
   call feedkeys("0fwve\<Esc>[200~noises\<Esc>[201~", 'xt')
   call assert_equal('here are more noises', getline(1))
   call assert_equal('words', getreg('-'))
+  normal! u
+  call assert_equal('here are more words', getline(1))
+  normal! 
+  call assert_equal('here are more noises', getline(1))
 
   " exclude last char in the line
   call setline(1, 'some words!')
   call feedkeys("0fwve\<Esc>[200~noises\<Esc>[201~", 'xt')
   call assert_equal('some noises!', getline(1))
   call assert_equal('words', getreg('-'))
+  normal! u
+  call assert_equal('some words!', getline(1))
+  normal! 
+  call assert_equal('some noises!', getline(1))
 
   " multi-line selection
   call setline(1, ['some words', 'and more'])
   call feedkeys("0fwvj0fd\<Esc>[200~letters\<Esc>[201~", 'xt')
   call assert_equal('some letters more', getline(1))
   call assert_equal("words\nand", getreg('1'))
+  normal! u
+  call assert_equal(['some words', 'and more'], getline(1, 2))
+  normal! 
+  call assert_equal('some letters more', getline(1))
+
+  " linewise non-last line, cursor at start of line
+  call setline(1, ['some words', 'and more'])
+  call feedkeys("0V\<Esc>[200~letters\<Esc>[201~", 'xt')
+  call assert_equal('lettersand more', getline(1))
+  call assert_equal("some words\n", getreg('1'))
+  normal! u
+  call assert_equal(['some words', 'and more'], getline(1, 2))
+  normal! 
+  call assert_equal('lettersand more', getline(1))
+
+  " linewise non-last line, cursor in the middle of line
+  call setline(1, ['some words', 'and more'])
+  call feedkeys("0fwV\<Esc>[200~letters\<Esc>[201~", 'xt')
+  call assert_equal('lettersand more', getline(1))
+  call assert_equal("some words\n", getreg('1'))
+  normal! u
+  call assert_equal(['some words', 'and more'], getline(1, 2))
+  normal! 
+  call assert_equal('lettersand more', getline(1))
+
+  " linewise last line
+  call setline(1, ['some words', 'and more'])
+  call feedkeys("j0V\<Esc>[200~letters\<Esc>[201~", 'xt')
+  call assert_equal(['some words', 'letters'], getline(1, 2))
+  call assert_equal("and more\n", getreg('1'))
+  normal! u
+  call assert_equal(['some words', 'and more'], getline(1, 2))
+  normal! 
+  call assert_equal(['some words', 'letters'], getline(1, 2))
 
   bwipe!
 endfunc


### PR DESCRIPTION
This makes bracketed paste always insert before the beginning of next line if linewise Visual mode, regardless of the cursor position, by checking only `lnum`, not `col`. If the last line in the buffer was deleted then create a new line.

Also AFAIK cursor `lnum` cannot be above Visual area in after deleting text in non-linewise Visual mode, so only checking `col` should be enough in non-linewise Visual mode.