### PR TITLE
filetype: support new init files added in gdb 11

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -668,7 +668,7 @@ au BufNewFile,BufRead *.fs			call dist#ft#FTfs()
 au BufNewFile,BufRead *.fsi,*.fsx		setf fsharp
 
 " GDB command files
-au BufNewFile,BufRead .gdbinit,gdbinit		setf gdb
+au BufNewFile,BufRead .gdbinit,gdbinit,.gdbearlyinit,gdbearlyinit,*.gdb		setf gdb
 
 " GDMO
 au BufNewFile,BufRead *.mo,*.gdmo		setf gdmo

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -196,7 +196,7 @@ let s:filename_checks = {
     \ 'fstab': ['fstab', 'mtab'],
     \ 'fusion': ['file.fusion'],
     \ 'fvwm': ['/.fvwm/file', 'any/.fvwm/file'],
-    \ 'gdb': ['.gdbinit', 'gdbinit'],
+    \ 'gdb': ['.gdbinit', 'gdbinit', 'file.gdb', '.config/gdbearlyinit', '.gdbearlyinit'],
     \ 'gdresource': ['file.tscn', 'file.tres'],
     \ 'gdscript': ['file.gd'],
     \ 'gdmo': ['file.mo', 'file.gdmo'],


### PR DESCRIPTION
See
https://sourceware.org/gdb/onlinedocs/gdb/Initialization-Files.html#Initialization-Files

In particular, it adds (noting the ones relevant to filetype):
- ~/.config/gdb/gdbinit (covered already)
- ~/.config/gdb/gdbearlyinit
- ~/.gdbearlyinit
- (system gdbinit directory)/*.gdb