### PR TITLE
Fix high cpu usage in --remote-wait

### DIFF
--- a/src/if_xcmdsrv.c
+++ b/src/if_xcmdsrv.c
@@ -563,10 +563,7 @@ ServerWait(
     fds.events = POLLIN;
 #else
     fd_set	    fds;
-    struct timeval  tv;
 
-    tv.tv_sec = 0;
-    tv.tv_usec =  SEND_MSEC_POLL * 1000;
     FD_ZERO(&fds);
     FD_SET(ConnectionNumber(dpy), &fds);
 #endif
@@ -597,6 +594,10 @@ ServerWait(
 	    if (poll(&fds, 1, SEND_MSEC_POLL) < 0)
 		break;
 #else
+	    struct timeval  tv;
+
+	    tv.tv_sec = 0;
+	    tv.tv_usec =  SEND_MSEC_POLL * 1000;
 	    if (select(FD_SETSIZE, &fds, NULL, NULL, &tv) < 0)
 		break;
 #endif


### PR DESCRIPTION
the issue seems to start from 773c1ef81b2d29e40592cd2743a7d7a6e554e06f

from select doc: 'select() may update the timeout argument to indicate
how much time was left'

fix #2975