### PR TITLE
install: add missing DEST_BIN dependency on tutor bianries

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2484,11 +2484,11 @@ installpack: $(DEST_VIM) $(DEST_RT) $(DEST_PACK)
 	chmod $(FILEMOD) `find $(DEST_PACK) -type f -print`
 
 # install the tutor files
-installtutorbin: $(DEST_VIM)
+installtutorbin: $(DEST_BIN)
 	$(INSTALL_DATA) vimtutor $(DEST_BIN)/$(VIMNAME)tutor
 	chmod $(SCRIPTMOD) $(DEST_BIN)/$(VIMNAME)tutor
 
-installgtutorbin: $(DEST_VIM)
+installgtutorbin: $(DEST_BIN)
 	$(INSTALL_DATA) gvimtutor $(DEST_BIN)/$(GVIMNAME)tutor
 	chmod $(SCRIPTMOD) $(DEST_BIN)/$(GVIMNAME)tutor
 


### PR DESCRIPTION
Without the change parallel install sometimes fails as:

    vim> cp vimtutor /nix/store/vim-8.2.4350/bin/vimtutor
    vim> cp: cannot create regular file '/nix/store/vim-8.2.4350/bin/vimtutor': No such file or directory
    vim> make[1]: *** [Makefile:2546: installtutorbin] Error 1 --shuffle=1647765748
    vim> make[1]: Leaving directory '/build/source/src'

The change makes sure that bin directory is created before
install copies a file.