### PR TITLE
When set noshowcmd, the cursor is drawn at 1 column on screen.

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -779,6 +779,9 @@ normal_cmd(
 
 #ifdef FEAT_CMDL_INFO
     need_flushbuf = add_to_showcmd(c);
+    // When set noshowcmd, the cursor hides because of drawing at 1 column on screen.
+    if (!need_flushbuf)
+	cursor_off();
 #endif
 
     // Get the command count


### PR DESCRIPTION



### Steps to reproduce
1. vim -u NONE -N alloc.c
2. execute `:set noshowcmd`
3. execute `:vsplit`
4. move to the another window(`CTRL-W w`)
5.  repeat `j`

![](https://user-images.githubusercontent.com/1595779/159156626-e106da96-e2db-4fd7-8b5f-4faad9fac853.gif)

### Expected behaviour
The cursor is NOT drawn at 1 column on screen.

![after](https://user-images.githubusercontent.com/1595779/159156703-d22ac7f1-42bc-4744-bdaf-2c80e94b2997.gif)


### Version of Vim / Environment
```
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Mar 20 2022 18:42:02)
MS-Windows 32-bit console version
Included patches: 1-4594
Compiled by naru1@DESKTOP-M1SM7LO
Huge version without GUI.  Features included (+) or not (-):
+acl                +diff               +libcall            -python             +textprop
+arabic             +digraphs           +linebreak          -python3            -tgetent
+autocmd            -dnd                +lispindent         +quickfix           +timers
+autochdir          -ebcdic             +listcmds           +reltime            +title
+autoservername     +emacs_tags         +localmap           +rightleft          -toolbar
-balloon_eval       +eval               -lua                -ruby               +user_commands
+balloon_eval_term  +ex_extra           +menu               +scrollbind         +vartabs
-browse             +extra_search       +mksession          +signs              +vertsplit
++builtin_terms     -farsi              +modify_fname       +smartindent        +vim9script
+byte_offset        +file_in_path       +mouse              -sodium             +viminfo
+channel            +find_in_path       -mouseshape         +sound              +virtualedit
+cindent            +float              +multi_byte_ime/dyn +spell              +visual
+clientserver       +folding            +multi_lang         +startuptime        +visualextra
+clipboard          -footer             -mzscheme           +statusline         +vreplace
+cmdline_compl      +gettext/dyn        -netbeans_intg      -sun_workshop       +vtp
+cmdline_hist       -hangul_input       +num64              +syntax             +wildignore
+cmdline_info       +iconv/dyn          +packages           +tag_binary         +wildmenu
+comments           +insert_expand      +path_extra         -tag_old_static     +windows
+conceal            +ipv6               -perl               -tag_any_white      +writebackup
+cryptv             +job                +persistent_undo    -tcl                -xfontset
+cscope             +jumplist           +popupwin           +termguicolors      -xim
+cursorbind         +keymap             -postscript         +terminal           -xpm_w32
+cursorshape        +lambda             +printer            -termresponse       -xterm_save
+dialog_con         +langmap            +profile            +textobjects        
   system vimrc file: "$VIM\vimrc"
     user vimrc file: "$HOME\_vimrc"
 2nd user vimrc file: "$HOME\vimfiles\vimrc"
 3rd user vimrc file: "$VIM\_vimrc"
      user exrc file: "$HOME\_exrc"
  2nd user exrc file: "$VIM\_exrc"
       defaults file: "$VIMRUNTIME\defaults.vim"
Compilation: cl -c /W3 /GF /nologo -I. -Iproto -DHAVE_PATHDEF -DWIN32  -DFEAT_CSCOPE -DFEAT_TERMINAL -DFEAT_SOUND  -DFEAT_JOB_CHANNEL -DFEAT_IPV6        -DWINVER=0x0501 -D_WIN32_WINNT=0x0501 /source-charset:utf-8 /MP -DHAVE_STDINT_H /Ox /GL -DNDEBUG /arch:IA32 /Zl /MT /D_CRT_SECURE_NO_DEPRECATE /D_CRT_NONSTDC_NO_DEPRECATE -DFEAT_MBYTE_IME -DDYNAMIC_IME -DDYNAMIC_ICONV -DDYNAMIC_GETTEXT -DFEAT_HUGE /Fd.\ObjCi386/ /Zi
Linking: link /nologo /opt:ref /LTCG:STATUS oldnames.lib kernel32.lib advapi32.lib shell32.lib gdi32.lib  comdlg32.lib ole32.lib netapi32.lib uuid.lib user32.lib  /machine:i386   libcmt.lib           winmm.lib WSock32.lib Ws2_32.lib   /PDB:vim.pdb -debug
```
