### PR TITLE
Add support for clearing script-local variables and functions before sourcing a Vim9 script

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -198,16 +198,35 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			start with a ":".
 			Triggers the |SourcePre| autocommand.
 
-:[range]so[urce] 	Read Ex commands from the [range] of lines in the
-			current buffer.  When sourcing commands from the
-			current buffer, the same script-ID |<SID>| is used
-			even if the buffer is sourced multiple times. If a
-			buffer is sourced more than once, then the functions
-			in the buffer are redefined again.
-			Sourcing a buffer with a Vim9 script more than once
-			works like |vim9-reload|.
-			To source a script in the Vim9 context, the |:vim9cmd|
-			modifier can be used.
+:[range]so[urce] [++clear]
+			Read Ex commands from the [range] of lines in the
+			current buffer.
+
+			When sourcing commands from the current buffer, the
+			same script-ID |<SID>| is used even if the buffer is
+			sourced multiple times. If a buffer is sourced more
+			than once, then the functions in the buffer are
+			defined again.
+
+			To source a range of lines that doesn't start with the
+			|:vim9script| command in Vim9 script context, the
+			|:vim9cmd| modifier can be used.
+
+			When a range of lines in a buffer is sourced in the
+			Vim9 script context, the previously defined
+			script-local variables and functions are not cleared.
+			This works like the range started with the
+			":vim9script noclear" command.  The "++clear" argument
+			can be used to clear the script-local variables and
+			functions before sourcing the script. This works like
+			the range started with the |:vimscript| command
+			without the "noclear" argument. See |vim9-reload| for
+			more information.
+			Examples: >
+
+				:4,5source
+				:vim9cmd :'<,'>source
+				:10,18source ++clear
 
 							*:source!*
 :so[urce]! {file}	Read Vim commands from {file}.  These are commands

--- a/src/proto/vim9script.pro
+++ b/src/proto/vim9script.pro
@@ -2,6 +2,7 @@
 int in_vim9script(void);
 int in_old_script(int max_version);
 int current_script_is_vim9(void);
+void clear_vim9_scriptlocal_vars(int sid);
 void ex_vim9script(exarg_T *eap);
 int not_in_vim9(exarg_T *eap);
 int vim9_bad_comment(char_u *p);

--- a/src/testdir/test_source.vim
+++ b/src/testdir/test_source.vim
@@ -608,6 +608,34 @@ func Test_source_buffer_vim9()
   source
   call assert_equal('red', g:Color)
 
+  " test for ++clear argument to clear all the functions/variables
+  %d _
+  let lines =<< trim END
+     g:ScriptVarFound = exists("color")
+     g:MyFuncFound = exists('*Myfunc')
+     if g:MyFuncFound
+       finish
+     endif
+     var color = 'blue'
+     def Myfunc()
+     enddef
+  END
+  call setline(1, lines)
+  vim9cmd source
+  call assert_false(g:MyFuncFound)
+  call assert_false(g:ScriptVarFound)
+  vim9cmd source
+  call assert_true(g:MyFuncFound)
+  call assert_true(g:ScriptVarFound)
+  vim9cmd source ++clear
+  call assert_false(g:MyFuncFound)
+  call assert_false(g:ScriptVarFound)
+  vim9cmd source ++clear
+  call assert_false(g:MyFuncFound)
+  call assert_false(g:ScriptVarFound)
+  call assert_fails('vim9cmd source ++clearx', 'E475:')
+  call assert_fails('vim9cmd source ++abcde', 'E484:')
+
   %bw!
 endfunc
 


### PR DESCRIPTION

Add the "++clear" argument to the ":source" command.