### PR TITLE
getcompletion() doesn't work properly when 'wildoptions' contains 'fuzzy'

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3273,6 +3273,10 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		is applied to filter the results.  Otherwise all the matches
 		are returned. The 'wildignorecase' option always applies.
 
+		If the 'wildoptions' option contains 'fuzzy', then fuzzy
+		matching is used to get the completion matches. Otherwise
+		regular expression matching is used.
+
 		If {type} is "cmdline", then the |cmdline-completion| result is
 		returned.  For example, to complete the possible values after
 		a ":call" command: >

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -3707,7 +3707,12 @@ f_getcompletion(typval_T *argvars, typval_T *rettv)
 # endif
     }
 
-    pat = addstar(xpc.xp_pattern, xpc.xp_pattern_len, xpc.xp_context);
+    if (cmdline_fuzzy_completion_supported(&xpc))
+       // If fuzzy matching, don't modify the search string
+       pat = vim_strsave(xpc.xp_pattern);
+    else
+       pat = addstar(xpc.xp_pattern, xpc.xp_pattern_len, xpc.xp_context);
+
     if ((rettv_list_alloc(rettv) != FAIL) && (pat != NULL))
     {
 	int	i;

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -552,6 +552,22 @@ func Test_getcompletion()
   call assert_fails('call getcompletion("abc", [])', 'E475:')
 endfunc
 
+" Test for getcompletion() with "fuzzy" in 'wildoptions'
+func Test_getcompletion_wildoptions()
+  let save_wildoptions = &wildoptions
+  set wildoptions&
+  let l = getcompletion('space', 'option')
+  call assert_equal([], l)
+  let l = getcompletion('ier', 'command')
+  call assert_equal([], l)
+  set wildoptions=fuzzy
+  let l = getcompletion('space', 'option')
+  call assert_true(index(l, 'backspace') >= 0)
+  let l = getcompletion('ier', 'command')
+  call assert_true(index(l, 'compiler') >= 0)
+  let &wildoptions = save_wildoptions
+endfunc
+
 func Test_complete_autoload_error()
   let save_rtp = &rtp
   let lines =<< trim END


### PR DESCRIPTION

Fixes the problem reported in #9986.