### PR TITLE
Reduce redraws for 'cursorline' when moving cursor multiple lines

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -945,8 +945,7 @@ win_line(
     if (wp->w_p_cul && lnum == wp->w_cursor.lnum)
     {
 	// Do not show the cursor line in the text when Visual mode is active,
-	// because it's not clear what is selected then.  Do update
-	// w_last_cursorline.
+	// because it's not clear what is selected then.
 	if (!(wp == curwin && VIsual_active)
 					 && wp->w_p_culopt_flags != CULOPT_NBR)
 	{
@@ -971,18 +970,14 @@ win_line(
 		else
 # endif
 		    line_attr = cul_attr;
-		wp->w_last_cursorline = wp->w_cursor.lnum;
 	    }
 	    else
 	    {
 		line_attr_save = line_attr;
-		wp->w_last_cursorline = 0;
 		margin_columns_win(wp, &left_curline_col, &right_curline_col);
 	    }
 	    area_highlighting = TRUE;
 	}
-	else
-	    wp->w_last_cursorline = wp->w_cursor.lnum;
     }
 #endif
 

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1468,9 +1468,6 @@ win_update(win_T *wp)
 # define DID_FOLD 3	// updated a folded line
     int		did_update = DID_NONE;
     linenr_T	syntax_last_parsed = 0;		// last parsed text line
-    // remember the current w_last_cursorline, it changes when drawing the new
-    // cursor line
-    linenr_T	last_cursorline = wp->w_last_cursorline;
 #endif
     linenr_T	mod_top = 0;
     linenr_T	mod_bot = 0;
@@ -2246,8 +2243,8 @@ win_update(win_T *wp)
 #endif
 				))))
 #ifdef FEAT_SYN_HL
-		|| (wp->w_p_cul && (lnum == wp->w_cursor.lnum
-						   || lnum == last_cursorline))
+		|| (wp->w_p_cul && lnum == wp->w_cursor.lnum)
+		|| lnum == wp->w_last_cursorline
 #endif
 				)
 	{
@@ -2551,6 +2548,10 @@ win_update(win_T *wp)
     }
 
     // End of loop over all window lines.
+
+#ifdef FEAT_SYN_HL
+    wp->w_last_cursorline = wp->w_p_cul ? wp->w_cursor.lnum : 0;
+#endif
 
 #ifdef FEAT_VTP
     // Rewrite the character at the end of the screen line.

--- a/src/move.c
+++ b/src/move.c
@@ -115,14 +115,6 @@ comp_botline(win_T *wp)
     set_empty_rows(wp, done);
 }
 
-#ifdef FEAT_SYN_HL
-    void
-reset_cursorline(void)
-{
-    curwin->w_last_cursorline = 0;
-}
-#endif
-
 /*
  * Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is
  * set.
@@ -138,24 +130,8 @@ redraw_for_cursorline(win_T *wp)
 	    && (wp->w_valid & VALID_CROW) == 0
 	    && !pum_visible())
     {
-	if (wp->w_p_rnu)
-	    // win_line() will redraw the number column only.
-	    redraw_win_later(wp, VALID);
-#ifdef FEAT_SYN_HL
-	if (wp->w_p_cul)
-	{
-	    if (wp->w_redr_type <= VALID && wp->w_last_cursorline != 0)
-	    {
-		// "w_last_cursorline" may be outdated, worst case we redraw
-		// too much.  This is optimized for moving the cursor around in
-		// the current window.
-		redrawWinline(wp, wp->w_last_cursorline);
-		redrawWinline(wp, wp->w_cursor.lnum);
-	    }
-	    else
-		redraw_win_later(wp, SOME_VALID);
-	}
-#endif
+	// win_line() will redraw the number column and cursorline only.
+	redraw_win_later(wp, VALID);
     }
 }
 

--- a/src/option.c
+++ b/src/option.c
@@ -2782,11 +2782,6 @@ set_bool_option(
 	p_lrm = !p_lnr;
 #endif
 
-#ifdef FEAT_SYN_HL
-    else if ((int *)varp == &curwin->w_p_cul && !value && old_value)
-	reset_cursorline();
-#endif
-
 #ifdef FEAT_PERSISTENT_UNDO
     // 'undofile'
     else if ((int *)varp == &curbuf->b_p_udf || (int *)varp == &p_udf)

--- a/src/proto/move.pro
+++ b/src/proto/move.pro
@@ -1,5 +1,4 @@
 /* move.c */
-void reset_cursorline(void);
 void redraw_for_cursorline(win_T *wp);
 void update_topline_redraw(void);
 void update_topline(void);


### PR DESCRIPTION
After patches 8.1.2214 and 8.2.4591, `win_update()` always updates 'cursorline', so it is no longer necessary to call `redrawWinline()` twice, which redraw every line between these two lines. It is also no longer necessary to change `wp->w_last_cursorline` in `win_line()`.