### PR TITLE
Bugfix - Netrw Tree Style Listing moves the cursor to a different position

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -4048,7 +4048,9 @@ fun! s:NetrwBrowse(islocal,dirname)
   " Otherwise            : set rexposn
   if exists("s:rexposn_".bufnr("%"))
 "   call Decho("restoring posn to s:rexposn_".bufnr('%')."<".string(s:rexposn_{bufnr('%')}).">",'~'.expand("<slnum>"))
-   NetrwKeepj call winrestview(s:rexposn_{bufnr('%')})
+   if ! (exists("w:netrw_liststyle") && w:netrw_liststyle ==# s:TREELIST)
+      NetrwKeepj call winrestview(s:rexposn_{bufnr('%')})
+   endif
    if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt
     NetrwKeepj exe w:netrw_bannercnt
    endif


### PR DESCRIPTION
This pull request fixes a bug in Netrw. 

Netrw Tree Style Listing moves the cursor to a different position when the user presses the Enter key to perform a directory listing; in a Netrw buffer that the user has reloaded with ':edit' or ':buffer'.

The "Perform Directory Listing" part of the function 's:NetrwBrowse()' should only call 'winrestview()' when the listing style of Netrw is not Tree Style Listing.

## Steps to reproduce the bug
1. Create the directory hierarchy:
```
$ mkdir -p ~/vim_bug/{dir1,dir2,dir3}
$ touch ~/vim_bug/{dir1,dir2,dir3}/{file1,file2,file3}
$ cd ~/vim_bug
```
2. Execute Vim:
```
$ vim -u NONE -c 'set nocompatible' -c 'let g:netrw_liststyle = 3' -c "source /usr/share/vim/vim82/plugin/netrwPlugin.vim"
```
3. Edit the current directory with Netrw:
```:edit .```
4. Move the cursor to "dir1" and press the Enter key. 
5. Move the cursor to "file1" and press the Enter key. 
6. Reopen netrw:
```:edit .```
7. Move the cursor to "dir3" and press the Enter key.

Netrw will move the cursor to a different position ("file1" under "dir1").