### PR TITLE
add \mathscr and \mathds syntax for tex

### DIFF
--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	TeX
 " Maintainer:	Charles E. Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
-" Last Change:	Jun 29, 2020
+" Last Change:	Mar 23, 2022
 " Version:	119
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TEX
 "
@@ -337,10 +337,12 @@ syn match texTypeStyle		"\\textrm\>"
 syn match texTypeStyle		"\\mathbb\>"
 syn match texTypeStyle		"\\mathbf\>"
 syn match texTypeStyle		"\\mathcal\>"
+syn match texTypeStyle		"\\mathds\>"
 syn match texTypeStyle		"\\mathfrak\>"
 syn match texTypeStyle		"\\mathit\>"
 syn match texTypeStyle		"\\mathnormal\>"
 syn match texTypeStyle		"\\mathrm\>"
+syn match texTypeStyle		"\\mathscr\>"
 syn match texTypeStyle		"\\mathsf\>"
 syn match texTypeStyle		"\\mathtt\>"
 


### PR DESCRIPTION
`\mathscr` is used for script typestyle for uppercase letters, which is
defined in [`amsfonts`](https://ctan.org/pkg/amsfonts) just like `\mathcal` and similar fonts.

I am quite hesitant to add `\mathds`, as it is not used as often as the previous one (when searching on arXiv, this appears 95% less than `\mathscr`). However, the [doublestroke package](https://www.ctan.org/pkg/doublestroke) dates back 20 years since its last update and is still well-used as no other package generate nice symbols such as blackboard "1".

I suppose I should ping Charles @cecamp in order to get this approved.