### PR TITLE
don't use compound assignment expression is used inside condition

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -2399,12 +2399,14 @@ ex_display(exarg_T *eap)
 			msg_puts_attr("^J", attr);
 			n -= 2;
 		    }
-		    for (p = yb->y_array[j]; *p && (n -= ptr2cells(p)) >= 0;
-									   ++p)
-		    {
+		    for (p = yb->y_array[j]; *p && n >= ptr2cells(p); p++) {
+			n -= ptr2cells(p);
 			clen = (*mb_ptr2len)(p);
 			msg_outtrans_len(p, clen);
 			p += clen - 1;
+		    }
+		    if (*p) {
+			n -= ptr2cells(p);
 		    }
 		}
 		if (n > 1 && yb->y_type == MLINE)
@@ -2490,8 +2492,9 @@ dis_msg(
     n = (int)Columns - 6;
     while (*p != NUL
 	    && !(*p == ESC && skip_esc && *(p + 1) == NUL)
-	    && (n -= ptr2cells(p)) >= 0)
+	    && n >= ptr2cells(p))
     {
+	n -= ptr2cells(p);
 	if (has_mbyte && (l = (*mb_ptr2len)(p)) > 1)
 	{
 	    msg_outtrans_len(p, l);


### PR DESCRIPTION
"Official" justification: https://pvs-studio.com/en/docs/warnings/v1019/

My justification: it's confusing lol. Also had an exceptionally hard
time (I'm trying not to use the word "impossible") finding information
on the priority of the calculation n-=a>=b and also what is actually
being compared with what. Like I could not for the life of me find any
rules on this. My conclusion is that it's because it's evil and must be
hidden from mankind.
