### PR TITLE
Add support for processing language server protocol messages

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -53,6 +53,7 @@ RAW	nothing known, Vim cannot tell where a message ends
 NL	every message ends in a NL (newline) character
 JSON	JSON encoding |json_encode()|
 JS	JavaScript style JSON-like encoding |js_encode()|
+LSP	Language Server Protocol encoding |language-server-protocol|
 
 Common combination are:
 - Using a job connected through pipes in NL mode.  E.g., to run a style
@@ -130,6 +131,7 @@ When using an IPv6 address, enclose it within square brackets.  E.g.,
 	"js"   - Use JS (JavaScript) encoding, more efficient than JSON.
 	"nl"   - Use messages that end in a NL character
 	"raw"  - Use raw messages
+	"lsp"  - Use language server protocol encoding
 						*channel-callback* *E921*
 "callback"	A function that is called when a message is received that is
 		not handled otherwise (e.g. a JSON message with ID zero).  It
@@ -140,8 +142,8 @@ When using an IPv6 address, enclose it within square brackets.  E.g.,
 	endfunc
 	let channel = ch_open("localhost:8765", {"callback": "Handle"})
 <
-		When "mode" is "json" or "js" the "msg" argument is the body
-		of the received message, converted to Vim types.
+		When "mode" is "json" or "js" or "lsp" the "msg" argument is
+		the body of the received message, converted to Vim types.
 		When "mode" is "nl" the "msg" argument is one message,
 		excluding the NL.
 		When "mode" is "raw" the "msg" argument is the whole message
@@ -503,6 +505,7 @@ ch_evalexpr({handle}, {expr} [, {options}])			*ch_evalexpr()*
 		according to the type of channel.  The function cannot be used
 		with a raw channel.  See |channel-use|.
 		{handle} can be a Channel or a Job that has a Channel.
+		When using the "lsp" channel mode, {expr} must be a |Dict|.
 								*E917*
 		{options} must be a Dictionary.  It must not have a "callback"
 		entry.  It can have a "timeout" entry to specify the timeout
@@ -578,7 +581,7 @@ ch_info({handle})						*ch_info()*
 		   "err_io"	  "out", "null", "pipe", "file" or "buffer"
 		   "err_timeout"  timeout in msec
 		   "in_status"	  "open" or "closed"
-		   "in_mode"	  "NL", "RAW", "JSON" or "JS"
+		   "in_mode"	  "NL", "RAW", "JSON", "JS" or "LSP"
 		   "in_io"	  "null", "pipe", "file" or "buffer"
 		   "in_timeout"	  timeout in msec
 
@@ -674,6 +677,7 @@ ch_sendexpr({handle}, {expr} [, {options}])			*ch_sendexpr()*
 		with a raw channel.
 		See |channel-use|.				*E912*
 		{handle} can be a Channel or a Job that has a Channel.
+		When using the "lsp" channel mode, {expr} must be a |Dict|.
 
 		Can also be used as a |method|: >
 			GetChannel()->ch_sendexpr(expr)
@@ -1361,5 +1365,76 @@ The same in |Vim9| script: >
 	# start accepting shell commands
 	startinsert
 
+==============================================================================
+14. Language Server Protocol			*language-server-protocol*
+
+The language server protocol specification is available at:
+
+    https://microsoft.github.io/language-server-protocol/specification
+
+Each LSP protocol message starts with a simple HTTP header followed by the
+payload encoded in JSON-RPC format.  This is described in:
+
+    https://www.jsonrpc.org/specification
+
+For messages received on a channel with mode set to "lsp", Vim will process
+the HTTP header and decode the payload into a Vim |Dict| type and call the
+channel callback or the specified callback function.  When sending messages on
+a channel using |ch_evalexpr()| or |ch_sendexpr()|, Vim will add the HTTP
+header and encode the Vim expression into JSON-RPC.
+
+To open a channel using the 'lsp' mode, set the 'mode' item in the |ch_open()|
+{options} argument to 'lsp'.  Example: >
+
+    let ch = ch_open(..., #{mode: 'lsp'})
+
+To open a channel using the 'lsp' mode with a job, set the 'in_mode' and
+'out_mode' items in the |job_start()| {options} argument to 'lsp'. Example: >
+
+    let job = job_start(...., #{in_mode: 'lsp', out_mode: 'lsp'})
+
+To synchronously send a JSON-RPC request to the server, use the |ch_evalexpr()|
+function. This function will return the response from the server. You can use
+the 'timeout' field in the {options} argument to control the response wait
+time. Example: >
+
+    let req = {}
+    let req.method = 'textDocument/definition'
+    let req.params = {}
+    let req.params.textDocument = #{uri: 'a.c'}
+    let req.params.position = #{line: 10, character: 3}
+    let resp = ch_evalexpr(ch, req, #{timeout: 100})
+
+Note that in the request message the 'id' field should not be specified. If it
+is specified, then Vim will overwrite the value with an internally generated
+identifier.  Vim currently supports only a number type for the 'id' field.
+
+To send a JSON-RPC request to the server and asynchronously process the
+response, use the |ch_sendexpr()| function and supply a callback function.
+Example: >
+
+    let req = {}
+    let req.method = 'textDocument/hover'
+    let req.params = {}
+    let req.params.textDocument = #{uri: 'a.c'}
+    let req.params.position = #{line: 10, character: 3}
+    let resp = ch_sendexpr(ch, req, #{callback: 'MyFn'})
+
+To send a JSON-RPC notification message to the server, use the |ch_sendexpr()|
+function. Example: >
+
+    call ch_sendexpr(ch, #{method: 'initialized'})
+
+To respond to a JSON-RPC request message from the server, use the
+|ch_sendexpr()| function.  In the response message, copy the 'id' field value
+from the server request message. Example: >
+
+    let resp = {}
+    let resp.id = req.id
+    let resp.result = 1
+    call ch_sendexpr(ch, resp)
+
+The JSON-RPC notification messages from the server are delivered through the
+|channel-callback| function.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/job.c
+++ b/src/job.c
@@ -31,6 +31,8 @@ handle_mode(typval_T *item, jobopt_T *opt, ch_mode_T *modep, int jo)
 	*modep = MODE_JS;
     else if (STRCMP(val, "json") == 0)
 	*modep = MODE_JSON;
+    else if (STRCMP(val, "lsp") == 0)
+	*modep = MODE_LSP;
     else
     {
 	semsg(_(e_invalid_argument_str), val);

--- a/src/json.c
+++ b/src/json.c
@@ -86,6 +86,32 @@ json_encode_nr_expr(int nr, typval_T *val, int options)
     ga_append(&ga, NUL);
     return ga.ga_data;
 }
+
+/*
+ * Encode "val" into a JSON format string prefixed by the LSP HTTP header.
+ * Returns NULL when out of memory.
+ */
+    char_u *
+json_encode_lsp_msg(typval_T *val)
+{
+    garray_T	ga;
+    garray_T	lspga;
+
+    ga_init2(&ga, 1, 4000);
+    if (json_encode_gap(&ga, val, 0) == FAIL)
+	return NULL;
+    ga_append(&ga, NUL);
+
+    ga_init2(&lspga, 1, 4000);
+    vim_snprintf((char *)IObuff, IOSIZE,
+	    "Content-Length: %u\r\n"
+	    "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n\r\n",
+	    ga.ga_len - 1);
+    ga_concat(&lspga, IObuff);
+    ga_concat_len(&lspga, ga.ga_data, ga.ga_len);
+    ga_clear(&ga);
+    return lspga.ga_data;
+}
 #endif
 
     static void

--- a/src/proto/json.pro
+++ b/src/proto/json.pro
@@ -1,6 +1,7 @@
 /* json.c */
 char_u *json_encode(typval_T *val, int options);
 char_u *json_encode_nr_expr(int nr, typval_T *val, int options);
+char_u *json_encode_lsp_msg(typval_T *val);
 int json_decode(js_read_T *reader, typval_T *res, int options);
 int json_find_end(js_read_T *reader, int options);
 void f_js_decode(typval_T *argvars, typval_T *rettv);

--- a/src/structs.h
+++ b/src/structs.h
@@ -2193,6 +2193,7 @@ typedef enum
     MODE_RAW,
     MODE_JSON,
     MODE_JS,
+    MODE_LSP			// Language Server Protocol (http + json)
 } ch_mode_T;
 
 typedef enum {

--- a/src/testdir/test_channel_lsp.py
+++ b/src/testdir/test_channel_lsp.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+#
+# Server that will accept connections from a Vim channel.
+# Used by test_channel.vim to test LSP functionality.
+#
+# This requires Python 2.6 or later.
+
+from __future__ import print_function
+import json
+import socket
+import sys
+import time
+import threading
+
+try:
+    # Python 3
+    import socketserver
+except ImportError:
+    # Python 2
+    import SocketServer as socketserver
+
+class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
+
+    def setup(self):
+        self.request.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+    def send_lsp_msg(self, msgid, resp_dict):
+        v = {'jsonrpc': '2.0', 'result': resp_dict}
+        if msgid != -1:
+            v['id'] = msgid
+        s = json.dumps(v)
+        resp = "Content-Length: " + str(len(s)) + "\r\n"
+        resp += "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp += "\r\n"
+        resp += s
+        if self.debug:
+            with open("Xlspdebug.log", "a") as myfile:
+                myfile.write("\n=> send\n" + resp)
+        self.request.sendall(resp.encode('utf-8'))
+
+    def send_wrong_payload(self):
+        v = 'wrong-payload'
+        s = json.dumps(v)
+        resp = "Content-Length: " + str(len(s)) + "\r\n"
+        resp += "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp += "\r\n"
+        resp += s
+        self.request.sendall(resp.encode('utf-8'))
+
+    def send_empty_header(self, msgid, resp_dict):
+        v = {'jsonrpc': '2.0', 'id': msgid, 'result': resp_dict}
+        s = json.dumps(v)
+        resp = "\r\n"
+        resp += s
+        self.request.sendall(resp.encode('utf-8'))
+
+    def send_empty_payload(self):
+        resp = "Content-Length: 0\r\n"
+        resp += "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp += "\r\n"
+        self.request.sendall(resp.encode('utf-8'))
+
+    def send_extra_hdr_fields(self, msgid, resp_dict):
+        # test for sending extra fields in the http header
+        v = {'jsonrpc': '2.0', 'id': msgid, 'result': resp_dict}
+        s = json.dumps(v)
+        resp = "Host: abc.vim.org\r\n"
+        resp += "User-Agent: Python\r\n"
+        resp += "Accept-Language: en-US,en\r\n"
+        resp += "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp += "Content-Length: " + str(len(s)) + "\r\n"
+        resp += "\r\n"
+        resp += s
+        self.request.sendall(resp.encode('utf-8'))
+
+    def send_hdr_without_len(self, msgid, resp_dict):
+        # test for sending the http header without length
+        v = {'jsonrpc': '2.0', 'id': msgid, 'result': resp_dict}
+        s = json.dumps(v)
+        resp = "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp += "\r\n"
+        resp += s
+        self.request.sendall(resp.encode('utf-8'))
+
+    def send_hdr_with_wrong_len(self, msgid, resp_dict):
+        # test for sending the http header with wrong length
+        v = {'jsonrpc': '2.0', 'id': msgid, 'result': resp_dict}
+        s = json.dumps(v)
+        resp = "Content-Length: 1000\r\n"
+        resp += "\r\n"
+        resp += s
+        self.request.sendall(resp.encode('utf-8'))
+
+    def send_hdr_with_negative_len(self, msgid, resp_dict):
+        # test for sending the http header with negative length
+        v = {'jsonrpc': '2.0', 'id': msgid, 'result': resp_dict}
+        s = json.dumps(v)
+        resp = "Content-Length: -1\r\n"
+        resp += "\r\n"
+        resp += s
+        self.request.sendall(resp.encode('utf-8'))
+
+    def do_ping(self, payload):
+        time.sleep(0.2)
+        self.send_lsp_msg(payload['id'], 'alive')
+
+    def do_echo(self, payload):
+        self.send_lsp_msg(-1, payload)
+
+    def do_simple_rpc(self, payload):
+        # test for a simple RPC request
+        self.send_lsp_msg(payload['id'], 'simple-rpc')
+
+    def do_rpc_with_notif(self, payload):
+        # test for sending a notification before replying to a request message
+        self.send_lsp_msg(-1, 'rpc-with-notif-notif')
+        # sleep for some time to make sure the notification is delivered
+        time.sleep(0.2)
+        self.send_lsp_msg(payload['id'], 'rpc-with-notif-resp')
+
+    def do_wrong_payload(self, payload):
+        # test for sending a non dict payload
+        self.send_wrong_payload()
+        time.sleep(0.2)
+        self.send_lsp_msg(-1, 'wrong-payload')
+
+    def do_rpc_resp_incorrect_id(self, payload):
+        self.send_lsp_msg(-1, 'rpc-resp-incorrect-id-1')
+        self.send_lsp_msg(-1, 'rpc-resp-incorrect-id-2')
+        self.send_lsp_msg(1, 'rpc-resp-incorrect-id-3')
+        time.sleep(0.2)
+        self.send_lsp_msg(payload['id'], 'rpc-resp-incorrect-id-4')
+
+    def do_simple_notif(self, payload):
+        # notification message test
+        self.send_lsp_msg(-1, 'simple-notif')
+
+    def do_multi_notif(self, payload):
+        # send multiple notifications
+        self.send_lsp_msg(-1, 'multi-notif1')
+        self.send_lsp_msg(-1, 'multi-notif2')
+
+    def do_msg_with_id(self, payload):
+        self.send_lsp_msg(payload['id'], 'msg-with-id')
+
+    def do_msg_specific_cb(self, payload):
+        self.send_lsp_msg(payload['id'], 'msg-specifc-cb')
+
+    def do_server_req(self, payload):
+        self.send_lsp_msg(201, {'method': 'checkhealth', 'params': {'a': 20}})
+
+    def do_extra_hdr_fields(self, payload):
+        self.send_extra_hdr_fields(payload['id'], 'extra-hdr-fields')
+
+    def do_hdr_without_len(self, payload):
+        self.send_hdr_without_len(payload['id'], 'hdr-without-len')
+
+    def do_hdr_with_wrong_len(self, payload):
+        self.send_hdr_with_wrong_len(payload['id'], 'hdr-with-wrong-len')
+
+    def do_hdr_with_negative_len(self, payload):
+        self.send_hdr_with_negative_len(payload['id'], 'hdr-with-negative-len')
+
+    def do_empty_header(self, payload):
+        self.send_empty_header(payload['id'], 'empty-header')
+
+    def do_empty_payload(self, payload):
+        self.send_empty_payload()
+
+    def process_msg(self, msg):
+        try:
+            decoded = json.loads(msg)
+            print("Decoded:")
+            print(str(decoded))
+            if 'method' in decoded:
+                test_map = {
+                        'ping': self.do_ping,
+                        'echo': self.do_echo,
+                        'simple-rpc': self.do_simple_rpc,
+                        'rpc-with-notif': self.do_rpc_with_notif,
+                        'wrong-payload': self.do_wrong_payload,
+                        'rpc-resp-incorrect-id': self.do_rpc_resp_incorrect_id,
+                        'simple-notif': self.do_simple_notif,
+                        'multi-notif': self.do_multi_notif,
+                        'msg-with-id': self.do_msg_with_id,
+                        'msg-specifc-cb': self.do_msg_specific_cb,
+                        'server-req': self.do_server_req,
+                        'extra-hdr-fields': self.do_extra_hdr_fields,
+                        'hdr-without-len': self.do_hdr_without_len,
+                        'hdr-with-wrong-len': self.do_hdr_with_wrong_len,
+                        'hdr-with-negative-len': self.do_hdr_with_negative_len,
+                        'empty-header': self.do_empty_header,
+                        'empty-payload': self.do_empty_payload
+                        }
+                if decoded['method'] in test_map:
+                    test_map[decoded['method']](decoded)
+                else:
+                    print("Error: Unsupported method: " + decoded['method'])
+            else:
+                print("Error: 'method' field is not found")
+
+        except ValueError:
+            print("json decoding failed")
+
+    def process_msgs(self, msgbuf):
+        while True:
+            sidx = msgbuf.find('Content-Length: ')
+            if sidx == -1:
+                return msgbuf
+            sidx += 16
+            eidx = msgbuf.find('\r\n')
+            if eidx == -1:
+                return msgbuf
+            msglen = int(msgbuf[sidx:eidx])
+
+            hdrend = msgbuf.find('\r\n\r\n')
+            if hdrend == -1:
+                return msgbuf
+
+            # Remove the header
+            msgbuf = msgbuf[hdrend + 4:]
+            payload = msgbuf[:msglen]
+
+            self.process_msg(payload)
+
+            # Remove the processed message
+            msgbuf = msgbuf[msglen:]
+
+    def handle(self):
+        print("=== socket opened ===")
+        self.debug = False
+        msgbuf = ''
+        while True:
+            try:
+                received = self.request.recv(4096).decode('utf-8')
+            except socket.error:
+                print("=== socket error ===")
+                break
+            except IOError:
+                print("=== socket closed ===")
+                break
+            if received == '':
+                print("=== socket closed ===")
+                break
+            print("\nReceived:\n{0}".format(received))
+
+            # Write the received lines into the file for debugging
+            if self.debug:
+                with open("Xlspdebug.log", "a") as myfile:
+                    myfile.write("\n<= recv\n" + received)
+
+            # Can receive more than one line in a response or a partial line.
+            # Accumulate all the received characters and process one line at
+            # a time.
+            msgbuf += received
+            msgbuf = self.process_msgs(msgbuf)
+
+class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    pass
+
+def writePortInFile(port):
+    # Write the port number in Xportnr, so that the test knows it.
+    f = open("Xportnr", "w")
+    f.write("{0}".format(port))
+    f.close()
+
+def main(host, port, server_class=ThreadedTCPServer):
+    # Wait half a second before opening the port to test waittime in ch_open().
+    # We do want to get the port number, get that first.  We cannot open the
+    # socket, guess a port is free.
+    if len(sys.argv) >= 2 and sys.argv[1] == 'delay':
+        port = 13684
+        writePortInFile(port)
+
+        print("Wait for it...")
+        time.sleep(0.5)
+
+    server = server_class((host, port), ThreadedTCPRequestHandler)
+    ip, port = server.server_address[0:2]
+
+    # Start a thread with the server.  That thread will then start a new thread
+    # for each connection.
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.start()
+
+    writePortInFile(port)
+
+    print("Listening on port {0}".format(port))
+
+    # Main thread terminates, but the server continues running
+    # until server.shutdown() is called.
+    try:
+        while server_thread.is_alive():
+            server_thread.join(1)
+    except (KeyboardInterrupt, SystemExit):
+        server.shutdown()
+
+if __name__ == "__main__":
+    main("localhost", 0)


### PR DESCRIPTION
Add support for processing language server protocol encoded messages. The protocol is
described in: https://microsoft.github.io/language-server-protocol/specification.

The existing support in Vim for processing JSON encoded messages doesn't work
for language server protocol. The LSP messages start with a HTTP header followed
by a JSON encoded dictionary. This format is currently not supported by the Vim
channel "json" mode.

This PR adds a new "lsp" channel mode to process the LSP header. A LSP client
can use the ch_sendexpr() and ch_evalexpr() functions to send a Vim expression to
the LSP server and receive the decoded responses.

I have tested this with the Vim9 LSP client and it works.

This PR adds the features requested in #9390.
