### PR TITLE
Bugfix - :mksession hard-codes the value of the shortmess option

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -686,6 +686,12 @@ makeopens(
     if (put_line(fd, "endif") == FAIL)
 	goto fail;
 
+    // Save 'shortmess'
+    if (!(ssop_flags & SSOP_OPTIONS)) {
+        if (put_line(fd, "let s:shortmess_save = &shortmess") == FAIL)
+            goto fail;
+    }
+
     // Now save the current files, current buffer first.
     if (put_line(fd, "set shortmess=aoO") == FAIL)
 	goto fail;
@@ -956,10 +962,22 @@ makeopens(
     if (put_line(fd, "unlet! s:wipebuf") == FAIL)
 	goto fail;
 
-    // Re-apply 'winheight', 'winwidth' and 'shortmess'.
-    if (fprintf(fd, "set winheight=%ld winwidth=%ld shortmess=%s",
-			       p_wh, p_wiw, p_shm) < 0 || put_eol(fd) == FAIL)
+    // Re-apply 'winheight' and 'winwidth'
+    if (fprintf(fd, "set winheight=%ld winwidth=%ld",
+			       p_wh, p_wiw) < 0 || put_eol(fd) == FAIL)
 	goto fail;
+
+    // Restore 'shortmess'
+    if ((ssop_flags & SSOP_OPTIONS)) {
+        if (fprintf(fd, "set shortmess=%s", p_shm) < 0 || put_eol(fd) == FAIL)
+            goto fail;
+    }
+    else
+    {
+        if (put_line(fd, "let &shortmess = s:shortmess_save") == FAIL)
+            goto fail;
+    }
+
     if (tab_firstwin->w_next != NULL)
     {
 	// Restore 'winminheight' and 'winminwidth'.

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -1007,6 +1007,49 @@ func Test_mksession_winminheight()
   set sessionoptions&
 endfunc
 
+" Test for mksession with and without options restores shortmess
+func Test_mksession_shortmess()
+  " Without options
+  set sessionoptions-=options
+  split
+  mksession! Xtest_mks.out
+  let found_save = 0
+  let found_restore = 0
+  let lines = readfile('Xtest_mks.out')
+  for line in lines
+    let line = trim(line)
+
+    if line ==# 'let s:shortmess_save = &shortmess'
+      let found_save += 1
+    endif
+
+    if found_save !=# 0 && line ==# 'let &shortmess = s:shortmess_save'
+      let found_restore += 1
+    endif
+  endfor
+  call assert_equal(1, found_save)
+  call assert_equal(1, found_restore)
+  call delete('Xtest_mks.out')
+  close
+  set sessionoptions&
+
+  " With options
+  set sessionoptions+=options
+  split
+  mksession! Xtest_mks.out
+  let found_restore = 0
+  let lines = readfile('Xtest_mks.out')
+  for line in lines
+    if line =~# 's:shortmess_save'
+      let found_restore += 1
+    endif
+  endfor
+  call assert_equal(0, found_restore)
+  call delete('Xtest_mks.out')
+  close
+  set sessionoptions&
+endfunc
+
 " Test for mksession with 'compatible' option
 func Test_mksession_compatible()
   mksession! Xtest_mks1.out


### PR DESCRIPTION
`:mksession` hard-codes the value of the `shortmess` option:
```viml
"...
set shortmess=aoO
"...
set winheight=5 winwidth=10 shortmess=filnxtToOS
"...
```

This pull request makes `:mksession` save and restore the value of the `shortmess` option:
```viml
"...
let s:shortmess_save = &shortmess
set shortmess=aoO
"...
set winheight=5 winwidth=10
let &shortmess = s:shortmess_save
"...
```

> --
> James Cherti
