### PR TITLE
remove maintainer from syntax/sml.vim

### DIFF
--- a/runtime/syntax/sml.vim
+++ b/runtime/syntax/sml.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:     SML
 " Filenames:    *.sml *.sig
-" Maintainers:  Markus Mottl            <markus.mottl@gmail.com>
-"               Fabrizio Zeno Cornelli  <zeno@filibusta.crema.unimi.it>
+" Maintainers:           Markus Mottl            <markus.mottl@gmail.com>
+" Previous maintainers:  Fabrizio Zeno Cornelli  <zeno@filibusta.crema.unimi.it>
 " Last Change:  2021 Oct 04
 "               2015 Aug 31 - Fixed opening of modules (Ramana Kumar)
 "               2006 Oct 23 - Fixed character highlighting bug (MM)


### PR DESCRIPTION
He mentions here that he doesn't maintain it anymore: https://github.com/vim/vim/issues/5173#issuecomment-551315275

I mailed the other person about [this](https://github.com/vim/vim/issues/5173) issue but I'll probably have a higher chance of winning the lottery than getting an answer back.
