### PR TITLE
Elaborate what "Vi compatible backspacing" is

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -987,7 +987,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	nostop	like start, except CTRL-W and CTRL-U do not stop at the start of
 		insert.
 
-	When the value is empty, Vi compatible backspacing is used.
+	When the value is empty, then only <Del> can be used to delete text in
+	insert mode. This is compatible with Vi.
 
 	For backwards compatibility with version 5.4 and earlier:
 	value	effect	~


### PR DESCRIPTION
Tested delete in insert mode on vi and nvi. Pressing delete for the first time inverted the case of the previous character (wat) and then it worked like normal delete. I guess this makes vim backspace not 100% compatible/identical, which is a good thing lol (assuming this isn't a weird bug on the vi/nvi versions I used).