### PR TITLE
Silence FutureWarning in python3complete

### DIFF
--- a/runtime/autoload/python3complete.vim
+++ b/runtime/autoload/python3complete.vim
@@ -91,6 +91,9 @@ endfunction
 
 function! s:DefPython()
 py3 << PYTHONEOF
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
 import sys, tokenize, io, types
 from token import NAME, DEDENT, NEWLINE, STRING
 


### PR DESCRIPTION
Silence FutureWarning when the autocomplete script runs/loads code;
they'll be emitted when the user actually runs the code, so we're not
actually hiding anything important.