### PR TITLE
Add  (enable) support for MouseMove events

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -261,6 +261,7 @@ Other options that are relevant:
 'mousefocus'	window focus follows mouse pointer |gui-mouse-focus|
 'mousemodel'	what mouse button does which action
 'mousehide'	hide mouse pointer while typing text
+'mousemoveevent' enable mouse move events for mapping
 'selectmode'	whether to start Select mode or Visual mode
 
 A quick way to set these is with the ":behave" command.
@@ -404,7 +405,8 @@ The mouse events, complete with modifiers, may be mapped.  Eg: >
    :map <4-S-LeftRelease> <4-RightRelease>
 These mappings make selection work the way it probably should in a Motif
 application, with shift-left mouse allowing for extending the visual area
-rather than the right mouse button.
+rather than the right mouse button. <MouseMove> may be mapped, but
+'mousemoveevent' must be enabled to use the mapping.
 
 Mouse mapping with modifiers does not work for modeless selection.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5517,6 +5517,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	The 'mousemodel' option is set by the |:behave| command.
 
+						*'mousemoveevent'* *'mousemev'*
+'mousemoveevent' 'mousemev'  boolean	(default off)
+			global
+			{only works in the GUI}
+	When on, mouse move events are delivered to the input queue and are
+	available for mapping. The default, off, avoids the mouse movement
+	overhead except when needed. See |gui-mouse-mapping|.
+
 					*'mouseshape'* *'mouses'* *E547*
 'mouseshape' 'mouses'	string	(default "i-r:beam,s:updown,sd:udsizing,
 					vs:leftright,vd:lrsizing,m:no,

--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -131,8 +131,8 @@ test_gui_event({event}, {args})
 		    forward:	set to 1 for forward search.
 
 		"mouse":
-		  Inject a mouse button click event.  The supported items in
-		  {args} are:
+		  Inject either a mouse button click, or a mouse move, event.
+		  The supported items in {args} are:
 		    button:	mouse button.  The supported values are:
 				    0	right mouse button
 				    1	middle mouse button
@@ -151,6 +151,9 @@ test_gui_event({event}, {args})
 				    4	shift is pressed
 				    8	alt is pressed
 				   16	ctrl is pressed
+		    move:	This is optional; it defaults to false.
+				Only {args} row: and col: are used and
+				required; they are interpreted as pixels.
 
 		"scrollbar":
 		  Set or drag the left, right or horizontal scrollbar.  Only

--- a/src/option.h
+++ b/src/option.h
@@ -760,6 +760,9 @@ EXTERN int	p_mousef;	// 'mousefocus'
 EXTERN int	p_mh;		// 'mousehide'
 #endif
 EXTERN char_u	*p_mousem;	// 'mousemodel'
+#ifdef FEAT_GUI
+EXTERN int	p_mousemev;	// 'mousemoveevent'
+#endif
 EXTERN long	p_mouset;	// 'mousetime'
 EXTERN int	p_more;		// 'more'
 #ifdef FEAT_MZSCHEME

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1746,6 +1746,13 @@ static struct vimoption options[] =
 # endif
 #endif
 				(char_u *)0L} SCTX_INIT},
+    {"mousemoveevent",   "mousemev",   P_BOOL|P_VI_DEF,
+#ifdef FEAT_GUI
+			    (char_u *)&p_mousemev, PV_NONE,
+#else
+			    (char_u *)NULL, PV_NONE,
+#endif
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"mouseshape",  "mouses",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_MOUSESHAPE
 			    (char_u *)&p_mouseshape, PV_NONE,

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1194,6 +1194,78 @@ func Test_gui_mouse_event()
   set mousemodel&
 endfunc
 
+func Test_gui_mouse_move_event()
+  let args = #{move: 1, button: 0, multiclick: 0, modifiers: 0}
+
+  " default, do not generate mouse move events
+  set mousemev&
+  call assert_false(&mousemev)
+
+  let n_event = 0
+  nnoremap <special> <MouseMove> :let n_event += 1<CR>
+
+  " start at mouse pos (1,1), clear counter
+  call extend(args, #{row: 1, col:1})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+  let n_event = 0
+
+  call extend(args, #{row: 30, col:300})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+
+  call extend(args, #{row: 100, col:300})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+
+  " no events since mousemev off
+  call assert_equal(0, n_event)
+
+  " turn on mouse events and try the same thing
+  set mousemev
+  call extend(args, #{row: 1, col:1})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+  let n_event = 0
+
+  call extend(args, #{row: 30, col:300})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+
+  call extend(args, #{row: 100, col:300})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+
+  call assert_equal(2, n_event)
+
+  " wiggle the mouse around, shouldn't get events
+  call extend(args, #{row: 1, col:1})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+  let n_event = 0
+
+  call extend(args, #{row: 1, col:2})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+
+  call extend(args, #{row: 2, col:2})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+
+  call extend(args, #{row: 2, col:1})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+
+  call extend(args, #{row: 1, col:1})
+  call test_gui_event('mouse', args)
+  call feedkeys('', 'Lx!')
+
+  call assert_equal(0, n_event)
+
+  unmap <MouseMove>
+  set mousemev&
+endfunc
+
 " Test for 'guitablabel' and 'guitabtooltip' options
 func TestGuiTabLabel()
   call add(g:TabLabels, v:lnum + 100)

--- a/src/testing.c
+++ b/src/testing.c
@@ -1368,22 +1368,34 @@ test_gui_mouse_event(dict_T *args)
     int		col;
     int		repeated_click;
     int_u	mods;
+    int		move;
 
-    if (dict_find(args, (char_u *)"button", -1) == NULL
-	    || dict_find(args, (char_u *)"row", -1) == NULL
-	    || dict_find(args, (char_u *)"col", -1) == NULL
-	    || dict_find(args, (char_u *)"multiclick", -1) == NULL
-	    || dict_find(args, (char_u *)"modifiers", -1) == NULL)
+    if (dict_find(args, (char_u *)"row", -1) == NULL
+	    || dict_find(args, (char_u *)"col", -1) == NULL)
 	return FALSE;
 
-    button = (int)dict_get_number(args, (char_u *)"button");
+    // Note: "move" is optional, requires fewer arguments
+    move = (int)dict_get_bool(args, (char_u *)"move", FALSE);
+
+    if (!move && (dict_find(args, (char_u *)"button", -1) == NULL
+	    || dict_find(args, (char_u *)"multiclick", -1) == NULL
+	    || dict_find(args, (char_u *)"modifiers", -1) == NULL))
+	return FALSE;
+
     row = (int)dict_get_number(args, (char_u *)"row");
     col = (int)dict_get_number(args, (char_u *)"col");
-    repeated_click = (int)dict_get_number(args, (char_u *)"multiclick");
-    mods = (int)dict_get_number(args, (char_u *)"modifiers");
 
-    gui_send_mouse_event(button, TEXT_X(col - 1), TEXT_Y(row - 1),
+    if (move)
+	gui_mouse_moved(col, row);
+    else {
+	button = (int)dict_get_number(args, (char_u *)"button");
+	repeated_click = (int)dict_get_number(args, (char_u *)"multiclick");
+	mods = (int)dict_get_number(args, (char_u *)"modifiers");
+
+	gui_send_mouse_event(button, TEXT_X(col - 1), TEXT_Y(row - 1),
 							repeated_click, mods);
+    }
+
     return TRUE;
 }
 


### PR DESCRIPTION
**Goal**
First phase: update Splice (merge conflict resolution), a vim-python plugin that's been idle about 10 years, to vim9 and move some python code over to vim and fix a variety of issues (include settings validation) and increase configurability (shortcuts, highlights...) and provide additional ways to interact with app.

The tool has a 3 line window at top with status and a list of commands. I've made the commands clickable and highlight them when mouse rollover (using text properties). The rollover should be particularly useful for existing users who don't read the documentation to alert them of something new.

To get the rollover effect, a patch is needed that deliver `MOUSE_MOVE` events, which are then access by mapping <MouseMove>.

**Overhead**
When the mouse is not moving, there is no additional overhead.  When the mouse is moving, the additional overhead per mouse interrupt is tiny: entry to `gui_send_mouse_event()` and `switch (button)` and `gui_xy2colrow()` and a few comparisons. An event is queued, `add_to_input_buf()`, only when the cursor moves to a different character. Little overhead.

The changes to gui.c could be restricted to gui_mouse_moved. In this case, gui_mouse_moved would maintain it's own prev_row/prev_col. As well as isolating the change, it would be a further small reduction in overhead for this change.

Overhead could be eliminated when `<MouseMove>` events are not mapped, for example introducing a global `mapping_uses_mouse_move`. Is this worth exploring?

**Testing**

I looked around a little in testdir. In general, motion is difficult to test; and `test_gui_event('mouse', ...)` doesn't have any motion related stuff. Any testing by injecting into input buf covers existing code paths that are not being modified. Is this patch simple enough as is?

**Todo**

I propose adding, after MOUSE_MOVE in vim.h,
```
#define MOUSE_MOVE_POPUP 0x800 // report mouse moved for popup consumption
```
and use that when `popup_uses_mouse_move` is true. Use the existing `MOUSE_MOVE` for the regular per character move events.  Note: with some of the possibilities discussed above, no new define is required.

Are there other parts of vim that might be sensitive to this change?
