### PR TITLE
Add ftdetect for org-mode filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1277,6 +1277,10 @@ au BufNewFile,BufRead *.[Oo][Pp][Ll]		setf opl
 " Oracle config file
 au BufNewFile,BufRead *.ora			setf ora
 
+" Org
+au BufNewFile,BufRead *.org		           	setf org
+au BufNewFile,BufRead *.org_archive		setf org
+
 " Packet filter conf
 au BufNewFile,BufRead pf.conf			setf pf
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -382,6 +382,7 @@ let s:filename_checks = {
     \ 'opam': ['opam', 'file.opam', 'file.opam.template'],
     \ 'openroad': ['file.or'],
     \ 'ora': ['file.ora'],
+    \ 'org': ['file.org', 'file.org_archive'],
     \ 'pamconf': ['/etc/pam.conf', '/etc/pam.d/file', 'any/etc/pam.conf', 'any/etc/pam.d/file'],
     \ 'pamenv': ['/etc/security/pam_env.conf', '/home/user/.pam_environment', '.pam_environment', 'pam_env.conf'],
     \ 'papp': ['file.papp', 'file.pxml', 'file.pxsl'],


### PR DESCRIPTION
Just a small PR that adds ftdetect for Emacs' orgmode filetype. 
There are already various plugins for vim and neovim to get ormode working. Having the filetype natively recognized might help