### PR TITLE
Add support for Unix-domain sockets

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -582,10 +582,15 @@ ch_info({handle})						*ch_info()*
 		When opened with ch_open():
 		   "hostname"	  the hostname of the address
 		   "port"	  the port of the address
+		   "path"	  the path of the Unix-domain socket
 		   "sock_status"  "open" or "closed"
 		   "sock_mode"	  "NL", "RAW", "JSON" or "JS"
 		   "sock_io"	  "socket"
 		   "sock_timeout" timeout in msec
+
+		Note that "pair" is only present for Unix-domain sockets, for
+		regular ones "hostname" and "port" are present instead.
+
 		When opened with job_start():
 		   "out_status"	  "open", "buffered" or "closed"
 		   "out_mode"	  "NL", "RAW", "JSON" or "JS"

--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -119,10 +119,13 @@ To open a channel: >
 
 Use |ch_status()| to see if the channel could be opened.
 
-{address} has the form "hostname:port".  E.g., "localhost:8765".
-
-When using an IPv6 address, enclose it within square brackets.  E.g.,
-"[2001:db8::1]:8765".
+					*channel-address*
+{address} can be a domain name or an IP address, followed by a port number, or
+a Unix-domain socket path prefixed by "unix:".  E.g. >
+    www.example.com:80   " domain + port
+    127.0.0.1:1234       " IPv4 + port
+    [2001:db8::1]:8765   " IPv6 + port
+    unix:/tmp/my-socket  " Unix-domain socket path
 
 {options} is a dictionary with optional entries:	*channel-open-options*
 
@@ -641,11 +644,8 @@ ch_open({address} [, {options}])				*ch_open()*
 		Open a channel to {address}.  See |channel|.
 		Returns a Channel.  Use |ch_status()| to check for failure.
 
-		{address} is a String and has the form "hostname:port", e.g.,
-		"localhost:8765".
-
-		When using an IPv6 address, enclose it within square brackets.
-		E.g., "[2001:db8::1]:8765".
+		{address} is a String, see |channel-address| for the possible
+		accepted forms.
 
 		If {options} is given it must be a |Dictionary|.
 		See |channel-open-options|.

--- a/src/channel.c
+++ b/src/channel.c
@@ -3356,9 +3356,14 @@ channel_info(channel_T *channel, dict_T *dict)
 
     if (channel->ch_hostname != NULL)
     {
-	dict_add_string(dict, "hostname", (char_u *)channel->ch_hostname);
 	if (channel->ch_port)
+	{
+	    dict_add_string(dict, "hostname", (char_u *)channel->ch_hostname);
 	    dict_add_number(dict, "port", channel->ch_port);
+	}
+	else
+	    // Unix-domain socket.
+	    dict_add_string(dict, "path", (char_u *)channel->ch_hostname);
 	channel_part_info(channel, dict, "sock", PART_SOCK);
     }
     else

--- a/src/testdir/check.vim
+++ b/src/testdir/check.vim
@@ -95,7 +95,7 @@ func CheckUnix()
   endif
 endfunc
 
-" Command to check for running on Linix
+" Command to check for running on Linux
 command CheckLinux call CheckLinux()
 func CheckLinux()
   if !has('linux')
@@ -174,6 +174,14 @@ func CheckEnglish()
   if v:lang != "C" && v:lang !~ '^[Ee]n'
       throw 'Skipped: only works in English language environment'
   endif
+endfunc
+
+" Command to check if the OS supports Unix-domain sockets
+command CheckUnixSockets call CheckUnixSockets()
+func CheckUnixSockets()
+  if has('win32') && system('sc query afunix') !~? '\<RUNNING\>'
+    throw 'Skipped: cannot use Unix sockets'
+  end
 endfunc
 
 " Command to check that loopback device has IPv6 address

--- a/src/testdir/check.vim
+++ b/src/testdir/check.vim
@@ -176,14 +176,6 @@ func CheckEnglish()
   endif
 endfunc
 
-" Command to check if the OS supports Unix-domain sockets
-command CheckUnixSockets call CheckUnixSockets()
-func CheckUnixSockets()
-  if has('win32') && system('sc query afunix') !~? '\<RUNNING\>'
-    throw 'Skipped: cannot use Unix sockets'
-  end
-endfunc
-
 " Command to check that loopback device has IPv6 address
 command CheckIPv6 call CheckIPv6()
 func CheckIPv6()

--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -15,10 +15,16 @@ func PythonProg()
   if has('unix')
     " We also need the job feature or the pkill command to make sure the server
     " can be stopped.
-    if !(executable('python') && (has('job') || executable('pkill')))
+    if !(has('job') || executable('pkill'))
       return ''
     endif
-    let s:python = 'python'
+    if executable('python')
+      let s:python = 'python'
+    elseif executable('python3')
+      let s:python = 'python3'
+    else
+      return ''
+    end
   elseif has('win32')
     " Use Python Launcher for Windows (py.exe) if available.
     " NOTE: if you get a "Python was not found" error, disable the Python

--- a/src/testdir/test_channel.py
+++ b/src/testdir/test_channel.py
@@ -22,7 +22,8 @@ except ImportError:
 class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
     def setup(self):
-        self.request.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        if self.server.address_family != socket.AF_UNIX:
+            self.request.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
     def handle(self):
         print("=== socket opened ===")

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -271,6 +271,7 @@ func Test_communicate_ipv6()
 endfunc
 
 func Test_communicate_unix()
+  CheckUnixSockets
   call Test_communicate()
 endfunc
 
@@ -312,7 +313,7 @@ func Test_two_channels_ipv6()
 endfunc
 
 func Test_two_channels_unix()
-  CheckUnix
+  CheckUnixSockets
   call Test_two_channels()
 endfunc
 
@@ -339,7 +340,7 @@ func Test_server_crash_ipv6()
 endfunc
 
 func Test_server_crash_unix()
-  CheckUnix
+  CheckUnixSockets
   call Test_server_crash()
 endfunc
 
@@ -382,7 +383,7 @@ func Test_channel_handler_ipv6()
 endfunc
 
 func Test_channel_handler_unix()
-  CheckUnix
+  CheckUnixSockets
   call Test_channel_handler()
 endfunc
 
@@ -450,7 +451,7 @@ func Test_zero_reply_ipv6()
 endfunc
 
 func Test_zero_reply_unix()
-  CheckUnix
+  CheckUnixSockets
   call Test_zero_reply()
 endfunc
 
@@ -503,7 +504,7 @@ func Test_raw_one_time_callback_ipv6()
 endfunc
 
 func Test_raw_one_time_callback_unix()
-  CheckUnix
+  CheckUnixSockets
   call Test_raw_one_time_callback()
 endfunc
 
@@ -1575,7 +1576,7 @@ func Test_call_ipv6()
 endfunc
 
 func Test_call_unix()
-  CheckUnix
+  CheckUnixSockets
   call Test_call()
 endfunc
 
@@ -1676,7 +1677,7 @@ func Test_close_callback_ipv6()
 endfunc
 
 func Test_close_callback_unix()
-  CheckUnix
+  CheckUnixSockets
   call Test_close_callback()
 endfunc
 
@@ -1707,7 +1708,7 @@ func Test_close_partial_ipv6()
 endfunc
 
 func Test_close_partial_unix()
-  CheckUnix
+  CheckUnixSockets
   call Test_close_partial()
 endfunc
 
@@ -2003,7 +2004,7 @@ func Test_close_lambda_ipv6()
 endfunc
 
 func Test_close_lambda_unix()
-  CheckUnix
+  CheckUnixSockets
   call Test_close_lambda()
 endfunc
 
@@ -2302,7 +2303,7 @@ func Test_issue_5485()
 endfunc
 
 func Test_job_trailing_space_unix()
-  CheckUnix
+  CheckUnixSockets
   CheckExecutable cat
 
   let job = job_start("cat ", #{in_io: 'null'})

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -271,7 +271,7 @@ func Test_communicate_ipv6()
 endfunc
 
 func Test_communicate_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_communicate()
   call delete('Xtestsocket')
 endfunc
@@ -314,7 +314,7 @@ func Test_two_channels_ipv6()
 endfunc
 
 func Test_two_channels_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_two_channels()
   call delete('Xtestsocket')
 endfunc
@@ -342,7 +342,7 @@ func Test_server_crash_ipv6()
 endfunc
 
 func Test_server_crash_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_server_crash()
   call delete('Xtestsocket')
 endfunc
@@ -386,7 +386,7 @@ func Test_channel_handler_ipv6()
 endfunc
 
 func Test_channel_handler_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_channel_handler()
   call delete('Xtestsocket')
 endfunc
@@ -455,7 +455,7 @@ func Test_zero_reply_ipv6()
 endfunc
 
 func Test_zero_reply_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_zero_reply()
   call delete('Xtestsocket')
 endfunc
@@ -509,7 +509,7 @@ func Test_raw_one_time_callback_ipv6()
 endfunc
 
 func Test_raw_one_time_callback_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_raw_one_time_callback()
   call delete('Xtestsocket')
 endfunc
@@ -1582,7 +1582,7 @@ func Test_call_ipv6()
 endfunc
 
 func Test_call_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_call()
   call delete('Xtestsocket')
 endfunc
@@ -1684,7 +1684,7 @@ func Test_close_callback_ipv6()
 endfunc
 
 func Test_close_callback_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_close_callback()
   call delete('Xtestsocket')
 endfunc
@@ -1716,7 +1716,7 @@ func Test_close_partial_ipv6()
 endfunc
 
 func Test_close_partial_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_close_partial()
   call delete('Xtestsocket')
 endfunc
@@ -2013,7 +2013,7 @@ func Test_close_lambda_ipv6()
 endfunc
 
 func Test_close_lambda_unix()
-  CheckUnixSockets
+  CheckUnix
   call Test_close_lambda()
   call delete('Xtestsocket')
 endfunc
@@ -2313,7 +2313,7 @@ func Test_issue_5485()
 endfunc
 
 func Test_job_trailing_space_unix()
-  CheckUnixSockets
+  CheckUnix
   CheckExecutable cat
 
   let job = job_start("cat ", #{in_io: 'null'})

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -273,6 +273,7 @@ endfunc
 func Test_communicate_unix()
   CheckUnixSockets
   call Test_communicate()
+  call delete('Xtestsocket')
 endfunc
 
 
@@ -315,6 +316,7 @@ endfunc
 func Test_two_channels_unix()
   CheckUnixSockets
   call Test_two_channels()
+  call delete('Xtestsocket')
 endfunc
 
 " Test that a server crash is handled gracefully.
@@ -342,6 +344,7 @@ endfunc
 func Test_server_crash_unix()
   CheckUnixSockets
   call Test_server_crash()
+  call delete('Xtestsocket')
 endfunc
 
 """""""""
@@ -385,6 +388,7 @@ endfunc
 func Test_channel_handler_unix()
   CheckUnixSockets
   call Test_channel_handler()
+  call delete('Xtestsocket')
 endfunc
 
 """""""""
@@ -453,6 +457,7 @@ endfunc
 func Test_zero_reply_unix()
   CheckUnixSockets
   call Test_zero_reply()
+  call delete('Xtestsocket')
 endfunc
 
 
@@ -506,6 +511,7 @@ endfunc
 func Test_raw_one_time_callback_unix()
   CheckUnixSockets
   call Test_raw_one_time_callback()
+  call delete('Xtestsocket')
 endfunc
 
 """""""""
@@ -1578,6 +1584,7 @@ endfunc
 func Test_call_unix()
   CheckUnixSockets
   call Test_call()
+  call delete('Xtestsocket')
 endfunc
 
 """""""""
@@ -1679,6 +1686,7 @@ endfunc
 func Test_close_callback_unix()
   CheckUnixSockets
   call Test_close_callback()
+  call delete('Xtestsocket')
 endfunc
 
 function Ch_test_close_partial(port)
@@ -1710,6 +1718,7 @@ endfunc
 func Test_close_partial_unix()
   CheckUnixSockets
   call Test_close_partial()
+  call delete('Xtestsocket')
 endfunc
 
 func Test_job_start_fails()
@@ -2006,6 +2015,7 @@ endfunc
 func Test_close_lambda_unix()
   CheckUnixSockets
   call Test_close_lambda()
+  call delete('Xtestsocket')
 endfunc
 
 func s:test_list_args(cmd, out, remove_lf)
@@ -2309,6 +2319,8 @@ func Test_job_trailing_space_unix()
   let job = job_start("cat ", #{in_io: 'null'})
   call WaitForAssert({-> assert_equal("dead", job_status(job))})
   call assert_equal(0, job_info(job).exitval)
+
+  call delete('Xtestsocket')
 endfunc
 
 func Test_ch_getbufnr()

--- a/src/testdir/test_channel_unix.py
+++ b/src/testdir/test_channel_unix.py
@@ -5,17 +5,24 @@
 #
 # This requires Python 2.6 or later.
 
+from __future__ import print_function
 from test_channel import ThreadedTCPServer, ThreadedTCPRequestHandler, \
     writePortInFile
 import socket
 import threading
 import os
 
+try:
+    FileNotFoundError
+except NameError:
+    # Python 2
+    FileNotFoundError = (IOError, OSError)
+
 class ThreadedUnixServer(ThreadedTCPServer):
     address_family = socket.AF_UNIX
 
 def main(path):
-    server = ThreadedUnixServer((path), ThreadedTCPRequestHandler)
+    server = ThreadedUnixServer(path, ThreadedTCPRequestHandler)
 
     # Start a thread with the server.  That thread will then start a new thread
     # for each connection.

--- a/src/testdir/test_channel_unix.py
+++ b/src/testdir/test_channel_unix.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#
+# Server that will accept connections from a Vim channel.
+# Used by test_channel.vim.
+#
+# This requires Python 2.6 or later.
+
+from test_channel import ThreadedTCPServer, ThreadedTCPRequestHandler, \
+    writePortInFile
+import socket
+import threading
+import os
+
+class ThreadedUnixServer(ThreadedTCPServer):
+    address_family = socket.AF_UNIX
+
+def cleanup(path):
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+
+def main(path):
+    server = ThreadedUnixServer((path), ThreadedTCPRequestHandler)
+
+    # Start a thread with the server.  That thread will then start a new thread
+    # for each connection.
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.start()
+
+    # Signal the test harness we're ready, the port value has no meaning.
+    writePortInFile(1234)
+
+    print("Listening on {0}".format(server.server_address))
+
+    # Main thread terminates, but the server continues running
+    # until server.shutdown() is called.
+    try:
+        while server_thread.is_alive():
+            server_thread.join(1)
+    except (KeyboardInterrupt, SystemExit):
+        server.shutdown()
+
+if __name__ == "__main__":
+    cleanup("Xtestsocket")
+    main("Xtestsocket")
+    cleanup("Xtestsocket")

--- a/src/testdir/test_channel_unix.py
+++ b/src/testdir/test_channel_unix.py
@@ -14,12 +14,6 @@ import os
 class ThreadedUnixServer(ThreadedTCPServer):
     address_family = socket.AF_UNIX
 
-def cleanup(path):
-    try:
-        os.remove(path)
-    except FileNotFoundError:
-        pass
-
 def main(path):
     server = ThreadedUnixServer((path), ThreadedTCPRequestHandler)
 
@@ -42,6 +36,8 @@ def main(path):
         server.shutdown()
 
 if __name__ == "__main__":
-    cleanup("Xtestsocket")
+    try:
+        os.remove("Xtestsocket")
+    except FileNotFoundError:
+        pass
     main("Xtestsocket")
-    cleanup("Xtestsocket")

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -620,8 +620,8 @@ func Test_fullcommand()
         \ ':5s':        'substitute',
         \ "'<,'>s":     'substitute',
         \ ":'<,'>s":    'substitute',
-        \ 'CheckUni':   'CheckUnix',
-        \ 'CheckUnix':  'CheckUnix',
+        \ 'CheckLin':   'CheckLinux',
+        \ 'CheckLinux': 'CheckLinux',
   \ }
 
   for [in, want] in items(tests)


### PR DESCRIPTION
As written on the tin this PR allows Vim channels to connect to Unix-domain sockets, much nicer than TCP for local tasks and possibly faster (?).

Open questions:
- The documentation could be better (suggestions welcome)
- The `port` argument is omitted in `ch_info`, is that better than returning a meaningless value (empty string or zero)?
- Should `ch_info` return any info about the kind of socket it's connected to (`ipv4`, `ipv6`, `unix`)?
- The whole thing should work on recent Windows 10 versions, testing is needed though.