### PR TITLE
Don't display error messages when expandcmd() fails (same as expand())

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2299,7 +2299,9 @@ expandcmd({string})					*expandcmd()*
 		like with |expand()|, and environment variables, anywhere in
 		{string}.  "~user" and "~/path" are only expanded at the
 		start.
-		Returns the expanded string.  Example: >
+		Returns the expanded string.  If an error is encountered
+		during expansion, the unmodified {string} is returned.
+		Example: >
 			:echo expandcmd('make %<.o')
 
 <		Can also be used as a |method|: >

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4168,9 +4168,9 @@ f_expandcmd(typval_T *argvars, typval_T *rettv)
     eap.nextcmd = NULL;
     eap.cmdidx = CMD_USER;
 
+    ++emsg_off;
     expand_filename(&eap, &cmdstr, &errormsg);
-    if (errormsg != NULL && *errormsg != NUL)
-	emsg(errormsg);
+    --emsg_off;
 
     rettv->vval.v_string = cmdstr;
 }

--- a/src/testdir/test_expand.vim
+++ b/src/testdir/test_expand.vim
@@ -78,10 +78,11 @@ func Test_expandcmd()
   edit a1a2a3.rb
   call assert_equal('make b1b2b3.rb a1a2a3 Xfile.o', expandcmd('make %:gs?a?b? %< #<.o'))
 
-  call assert_fails('call expandcmd("make <afile>")', 'E495:')
-  call assert_fails('call expandcmd("make <afile>")', 'E495:')
+  call assert_equal('make <afile>', expandcmd("make <afile>"))
+  call assert_equal('make <amatch>', expandcmd("make <amatch>"))
+  call assert_equal('make <abuf>', expandcmd("make <abuf>"))
   enew
-  call assert_fails('call expandcmd("make %")', 'E499:')
+  call assert_equal('make %', expandcmd("make %"))
   let $FOO="blue\tsky"
   call setline(1, "$FOO")
   call assert_equal("grep pat blue\tsky", expandcmd('grep pat <cfile>'))
@@ -94,6 +95,11 @@ func Test_expandcmd()
   let $FOO= "foo bar baz"
   call assert_equal("e foo bar baz", expandcmd("e $FOO"))
 
+  if has('unix')
+    " test for using the shell to expand a command argument
+    call assert_equal('{1..4}', expandcmd('{1..4}'))
+  endif
+
   unlet $FOO
   close!
 endfunc
@@ -101,14 +107,14 @@ endfunc
 " Test for expanding <sfile>, <slnum> and <sflnum> outside of sourcing a script
 func Test_source_sfile()
   let lines =<< trim [SCRIPT]
-    :call assert_fails('echo expandcmd("<sfile>")', 'E498:')
-    :call assert_fails('echo expandcmd("<slnum>")', 'E842:')
-    :call assert_fails('echo expandcmd("<sflnum>")', 'E961:')
-    :call assert_fails('call expandcmd("edit <cfile>")', 'E446:')
-    :call assert_fails('call expandcmd("edit #")', 'E194:')
-    :call assert_fails('call expandcmd("edit #<2")', 'E684:')
-    :call assert_fails('call expandcmd("edit <cword>")', 'E348:')
-    :call assert_fails('call expandcmd("edit <cexpr>")', 'E348:')
+    :call assert_equal('<sfile>', expandcmd("<sfile>"))
+    :call assert_equal('<slnum>', expandcmd("<slnum>"))
+    :call assert_equal('<sflnum>', expandcmd("<sflnum>"))
+    :call assert_equal('edit <cfile>', expandcmd("edit <cfile>"))
+    :call assert_equal('edit #', expandcmd("edit #"))
+    :call assert_equal('edit #<2', expandcmd("edit #<2"))
+    :call assert_equal('edit <cword>', expandcmd("edit <cword>"))
+    :call assert_equal('edit <cexpr>', expandcmd("edit <cexpr>"))
     :call assert_fails('autocmd User MyCmd echo "<sfile>"', 'E498:')
     :call writefile(v:errors, 'Xresult')
     :qall!


### PR DESCRIPTION
When expanding a string using expand() if an error is encountered, then error messages are not displayed. Change the expandcmd() behavior to be similar to that of expand() for error handling.