### PR TITLE
Have glob() always respect wildignorecase

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3945,13 +3945,13 @@ gen_expand_wildcards(
 	    }
 
 	    /*
-	     * If there are wildcards: Expand file names and add each match to
-	     * the list.  If there is no match, and EW_NOTFOUND is given, add
-	     * the pattern.
-	     * If there are no wildcards: Add the file name if it exists or
-	     * when EW_NOTFOUND is given.
+	     * If there are wildcards or case-insensitive expansion is required:
+	     * Expand file names and add each match to the list.  If there is no
+	     * match, and EW_NOTFOUND is given, add the pattern.
+	     * Otherwise: Add the file name if it exists or when EW_NOTFOUND is
+	     * given.
 	     */
-	    if (mch_has_exp_wildcard(p))
+	    if (mch_has_exp_wildcard(p) || (flags & EW_ICASE))
 	    {
 #if defined(FEAT_SEARCHPATH)
 		if ((flags & EW_PATH)

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2821,6 +2821,8 @@ func Test_glob()
   " Sort output of glob() otherwise we end up with different
   " ordering depending on whether file system is case-sensitive.
   call assert_equal(['XGLOB2', 'Xglob1'], sort(glob('Xglob[12]', 0, 1)))
+  " wildignorecase shall be applied even when the pattern contains no wildcards.
+  call assert_equal('XGLOB2', glob('xglob2'))
   set wildignorecase&
 
   call delete('Xglob1')


### PR DESCRIPTION
The code took a shortcut if the pattern contained no wildcard producing
incomplete results if the expansion is case-insensitive.

Fixes #8350