### PR TITLE
Add window, tabpage and blob allocation failure tests

### DIFF
--- a/src/alloc.h
+++ b/src/alloc.h
@@ -40,6 +40,9 @@ typedef enum {
     aid_sign_getplaced_list,
     aid_insert_sign,
     aid_sign_getinfo,
-    aid_buflistnew_bvars,
+    aid_newbuf_bvars,
+    aid_newwin_wvars,
+    aid_newtabpage_tvars,
+    aid_blob_alloc,
     aid_last
 } alloc_id_T;

--- a/src/blob.c
+++ b/src/blob.c
@@ -22,7 +22,7 @@
     blob_T *
 blob_alloc(void)
 {
-    blob_T *blob = ALLOC_CLEAR_ONE(blob_T);
+    blob_T *blob = ALLOC_CLEAR_ONE_ID(blob_T, aid_blob_alloc);
 
     if (blob != NULL)
 	ga_init2(&blob->bv_ga, 1, 100);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2093,7 +2093,7 @@ buflist_new(
 	}
 #ifdef FEAT_EVAL
 	// init b: variables
-	buf->b_vars = dict_alloc_id(aid_buflistnew_bvars);
+	buf->b_vars = dict_alloc_id(aid_newbuf_bvars);
 	if (buf->b_vars == NULL)
 	{
 	    vim_free(ffname);

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -702,4 +702,43 @@ func Test_blob2string()
   call assert_equal(v, string(b))
 endfunc
 
+" Test for blob allocation failure
+func Test_blob_alloc_failure()
+  " blob variable
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let v = 0z10', 'E342:')
+
+  " blob slice
+  let v = 0z1020
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = v[0:0]', 'E342:')
+  call assert_equal(0z1020, x)
+
+  " blob remove()
+  let v = 0z10203040
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = remove(v, 1, 2)', 'E342:')
+  call assert_equal(0, x)
+
+  " list2blob()
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let a = list2blob([1, 2, 4])', 'E342:')
+  call assert_equal(0, a)
+
+  " mapnew()
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = mapnew(0z1234, {_, v -> 1})', 'E342:')
+  call assert_equal(0, x)
+
+  " copy()
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = copy(v)', 'E342:')
+  call assert_equal(0z, x)
+
+  " readblob()
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = readblob("test_blob.vim")', 'E342:')
+  call assert_equal(0, x)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -430,50 +430,50 @@ func Test_buffer_maxmem()
   set maxmem& maxmemtot&
 endfunc
 
-" Test for a allocation failure when adding a new buffer
+" Test for buffer allocation failure
 func Test_buflist_alloc_failure()
   %bw!
 
   edit Xfile1
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('edit Xfile2', 'E342:')
 
   " test for bufadd()
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('call bufadd("Xbuffer")', 'E342:')
 
   " test for setting the arglist
   edit Xfile2
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('next Xfile3', 'E342:')
 
   " test for setting the alternate buffer name when writing a file
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('write Xother', 'E342:')
   call delete('Xother')
 
   " test for creating a buffer using bufnr()
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails("call bufnr('Xnewbuf', v:true)", 'E342:')
 
   " test for renaming buffer using :file
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('file Xnewfile', 'E342:')
 
   " test for creating a buffer for a popup window
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('call popup_create("mypop", {})', 'E342:')
 
   if has('terminal')
     " test for creating a buffer for a terminal window
-    call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+    call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
     call assert_fails('call term_start(&shell)', 'E342:')
     %bw!
   endif
 
   " test for loading a new buffer after wiping out all the buffers
   edit Xfile4
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('%bw!', 'E342:')
 
   " test for :checktime loading the buffer
@@ -484,19 +484,19 @@ func Test_buflist_alloc_failure()
     sleep 200m
     call writefile(['two'], 'Xfile5')
     set autoread
-    call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+    call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
     call assert_fails('checktime', 'E342:')
     set autoread&
     bw!
   endif
 
   " test for :vimgrep loading a dummy buffer
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('vimgrep two Xfile5', 'E342:')
   call delete('Xfile5')
 
   " test for quickfix command loading a buffer
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('cexpr "Xfile6:10:Line10"', 'E342:')
 endfunc
 

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -852,4 +852,27 @@ func Test_lastused_tabpage()
   tabonly!
 endfunc
 
+" Test for tabpage allocation failure
+func Test_tabpage_alloc_failure()
+  call test_alloc_fail(GetAllocId('newtabpage_tvars'), 0, 0)
+  call assert_fails('tabnew', 'E342:')
+
+  call test_alloc_fail(GetAllocId('newtabpage_tvars'), 0, 0)
+  edit Xfile1
+  call assert_fails('tabedit Xfile2', 'E342:')
+  call assert_equal(1, winnr('$'))
+  call assert_equal(1, tabpagenr('$'))
+  call assert_equal('Xfile1', @%)
+
+  new
+  call test_alloc_fail(GetAllocId('newtabpage_tvars'), 0, 0)
+  call assert_fails('wincmd T', 'E342:')
+  bw!
+
+  call test_alloc_fail(GetAllocId('newtabpage_tvars'), 0, 0)
+  call assert_fails('tab split', 'E342:')
+  call assert_equal(2, winnr('$'))
+  call assert_equal(1, tabpagenr('$'))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1512,5 +1512,49 @@ func Test_win_move_statusline()
   %bwipe!
 endfunc
 
+" Test for window allocation failure
+func Test_window_alloc_failure()
+  %bw!
+
+  " test for creating a new window above current window
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('above new', 'E342:')
+  call assert_equal(1, winnr('$'))
+
+  " test for creating a new window below current window
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('below new', 'E342:')
+  call assert_equal(1, winnr('$'))
+
+  " test for popup window creation failure
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('call popup_create("Hello", {})', 'E342:')
+  call assert_equal([], popup_list())
+
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('split', 'E342:')
+  call assert_equal(1, winnr('$'))
+
+  edit Xfile1
+  edit Xfile2
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('sb Xfile1', 'E342:')
+  call assert_equal(1, winnr('$'))
+  call assert_equal('Xfile2', @%)
+  %bw!
+
+  " FIXME: The following test crashes Vim
+  " test for new tabpage creation failure
+  " call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  " call assert_fails('tabnew', 'E342:')
+  " call assert_equal(1, tabpagenr('$'))
+  " call assert_equal(1, winnr('$'))
+
+  " This test messes up the internal Vim window/frame information. So the
+  " Test_window_cmd_cmdwin_with_vsp() test fails after running this test.
+  " Open a new tab and close everything else to fix this issue.
+  tabnew
+  tabonly
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -3801,6 +3801,8 @@ win_init_popup_win(win_T *wp, buf_T *buf)
 win_alloc_firstwin(win_T *oldwin)
 {
     curwin = win_alloc(NULL, FALSE);
+    if (curwin == NULL)
+	return FAIL;
     if (oldwin == NULL)
     {
 	// Very first window, need to create an empty buffer for it and
@@ -3882,7 +3884,7 @@ alloc_tabpage(void)
 
 # ifdef FEAT_EVAL
     // init t: variables
-    tp->tp_vars = dict_alloc();
+    tp->tp_vars = dict_alloc_id(aid_newtabpage_tvars);
     if (tp->tp_vars == NULL)
     {
 	vim_free(tp);
@@ -5020,7 +5022,7 @@ win_alloc(win_T *after UNUSED, int hidden UNUSED)
 
 #ifdef FEAT_EVAL
     // init w: variables
-    new_wp->w_vars = dict_alloc();
+    new_wp->w_vars = dict_alloc_id(aid_newwin_wvars);
     if (new_wp->w_vars == NULL)
     {
 	win_free_lsize(new_wp);


### PR DESCRIPTION

When creating a new tab page, if the window creation fails, then Vim crashes.
I tried to address this issue. But it is much more involved. So I have commented
out that test for now.