### PR TITLE
Properly check for :normal running out of characters

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4236,7 +4236,8 @@ ex_substitute(exarg_T *eap)
 				// When ":normal" runs out of characters we get
 				// an empty line.  Use "q" to get out of the
 				// loop.
-				if (ex_normal_busy && typed == NUL)
+				if (ex_normal_busy > 0 && typebuf.tb_len == 0
+								&& typed == NUL)
 				    typed = 'q';
 			    }
 			}

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -2641,15 +2641,6 @@ func Test_normal33_g_cmd2()
   bw!
 endfunc
 
-func Test_normal_ex_substitute()
-  " This was hanging on the substitute prompt.
-  new
-  call setline(1, 'a')
-  exe "normal! gggQs/a/b/c\<CR>"
-  call assert_equal('a', getline(1))
-  bwipe!
-endfunc
-
 " Test for g CTRL-G
 func Test_g_ctrl_g()
   new

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -725,6 +725,18 @@ func Test_nocatch_sub_failure_handling()
   bwipe!
 endfunc
 
+func Test_normal_ex_substitute()
+  " This was hanging on the substitute prompt.
+  new
+  call setline(1, 'aaa')
+  exe "normal! gggQs/a/b/c\<CR>"
+  call assert_equal('aaa', getline(1))
+  " <NL> should not quit the prompt in the middle of :normal
+  exe "normal! gggQs/a/b/c\<CR>\<NL>y"
+  call assert_equal('baa', getline(1))
+  bwipe!
+endfunc
+
 " Test ":s/pat/sub/" with different ~s in sub.
 func Test_replace_with_tilde()
   new


### PR DESCRIPTION
`<NL>` should not quit the substitute prompt in the middle of `:normal`