### PR TITLE
Improve json encoding of strings

### DIFF
--- a/src/testdir/test_json.vim
+++ b/src/testdir/test_json.vim
@@ -107,6 +107,9 @@ func Test_json_encode()
   call assert_equal('"café"', json_encode("caf\xe9"))
   let &encoding = save_encoding
 
+  " Invalid utf-8 sequences are replaced with U+FFFD (replacement character)
+  call assert_equal('"foo' . "\ufffd" . '"', json_encode("foo\xAB"))
+
   call assert_fails('echo json_encode(function("tr"))', 'E1161: Cannot json encode a func')
   call assert_fails('echo json_encode([function("tr")])', 'E1161: Cannot json encode a func')
 


### PR DESCRIPTION
This patch improves two aspects of the json encoder:
- Speeds up the encoding by avoiding a char-by-char copy if possible.
- Avoids creating invalid utf-8 sequences by validating the string and
  replacing the offending characters with the U+FFFD codepoint. An
  alternative error handling strategy would be to raise an error or, to
  get the best of both approaches, add an (optional) extra argument to
  `json_encode` to let the user decide.

You can measure the speed up by running this silly benchmark (that I cobbled together from @lacygoill's excellent scripts):
```vim
vim9script

#

var n: number = 64
var data: string = repeat('x', n)
def Func()
    var i: number = 0
    while i < 100000
	var enc = json_encode(data)
	i = i + 1
    endwhile
enddef
var time = reltime()
Func()
setline(3, '# ' .. reltime(time)->reltimestr()->matchstr('.*\..\{,3}') .. ' seconds to run Func()')
```

Fixes #585