### PR TITLE
Fix rare channel hang when processing json data

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -3997,6 +3997,11 @@ channel_read_json_block(
 	    if (channel_parse_messages())
 		continue;
 
+	    // The call to `channel_parse_messages` may fill the queue with new
+	    // data to process.
+	    if (channel_has_readahead(channel, part))
+		continue;
+
 	    // Wait for up to the timeout.  If there was an incomplete message
 	    // use the deadline for that.
 	    timeout = timeout_arg;


### PR DESCRIPTION
In some rare cases Vim may receive some buffered data from a channel
closed by `channel_parse_messages`, in that case process the received
data instead of entering the waiting loop.

Closes #7781
Closes #6364