### PR TITLE
Add vprintf builtin

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -682,6 +682,7 @@ uniq({list} [, {func} [, {dict}]])
 values({dict})			List	values in {dict}
 virtcol({expr})			Number	screen column of cursor or mark
 visualmode([expr])		String	last visual mode used
+vprintf({fmt}, {list})		String	format text
 wildmenumode()			Number	whether 'wildmenu' mode is active
 win_execute({id}, {command} [, {silent}])
 				String	execute {command} in window {id}
@@ -9517,6 +9518,15 @@ visualmode([{expr}])						*visualmode()*
 		If {expr} is supplied and it evaluates to a non-zero Number or
 		a non-empty String, then the Visual mode will be cleared and
 		the old value is returned.  See |non-zero-arg|.
+
+vprintf({fmt}, {list})					*vprintf()*
+		Identical to |printf()| except that the arguments are taken
+		from the list.
+
+		When used as a |method| the base is passed as the second
+		argument.  Example: >
+			echo [3, 7]->printf("v1: %d, v2: %d")
+<			v1: 3, v2: 7
 
 wildmenumode()					*wildmenumode()*
 		Returns |TRUE| when the wildmenu is active and |FALSE|

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -634,6 +634,30 @@ func Test_printf_spec_b()
   call v9.CheckLegacyAndVim9Success(lines)
 endfunc
 
+func Test_vprintf()
+  call v9.CheckLegacyAndVim9Failure(['echo vprintf()'],            'E119')
+  call v9.CheckLegacyAndVim9Failure(['echo vprintf("%d")'],        'E119')
+  call v9.CheckLegacyAndVim9Failure(['echo vprintf("%d", 3)'],     [ 'E474', 'E1013:', 'E1211'])
+  call v9.CheckLegacyAndVim9Failure(['echo vprintf(3, [])'],       [ 'E474', 'E1013:', 'E1174'])
+  call v9.CheckLegacyAndVim9Failure(['echo vprintf("%d", [], 3)'], 'E118')
+
+  call v9.CheckLegacyAndVim9Failure([ 'echo vprintf("", [0])' ], 'E767')
+  call v9.CheckLegacyAndVim9Failure([ 'echo vprintf("%d", [])' ], 'E766')
+
+  let lines =<< trim END
+      call assert_equal("3 7", vprintf("%d %d", [3, 7]))
+      call assert_equal("0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7", vprintf("%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7 ]))
+  END
+  call v9.CheckLegacyAndVim9Success(lines)
+
+  call v9.CheckLegacyAndVim9Failure(['echo vprintf(
+        \ "%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s",
+        \ [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8] )'], 'E118:')
+  call v9.CheckLegacyAndVim9Failure(['echo vprintf(
+        \ "%s",
+        \ [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8] )'], 'E118:')
+endfunc
+
 func Test_max_min_errors()
   call v9.CheckLegacyAndVim9Failure(['call max(v:true)'], ['E712:', 'E1013:', 'E1227:'])
   call v9.CheckLegacyAndVim9Failure(['call max(v:true)'], ['max()', 'E1013:', 'E1227:'])


### PR DESCRIPTION
In the vim-python plugin I'm working on, sending variable number of args from python to vim to log/popup errors, came up with the following (there may be better solutions). But seems very fragile, particularly the quoting. So I'd like to get rid of it.
```
export def VPrintf(fmt: string, _args: list<any> = []): string
    var t = @a
    var args = _args->map((_, v) => string(v))
    var printf_args = !!args ? ", " .. args->join(", ") : ''
    execute('@a = printf("' .. fmt .. '"' .. printf_args .. ')')
    var result = @a
    @a = t
    return result
enddef
```