### PR TITLE
remove else after return/break to reduce indentation

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -3149,21 +3149,20 @@ mb_replace_pop_ins(int cc)
 		replace_push(c);
 		break;
 	    }
+
+	    buf[0] = c;
+	    for (i = 1; i < n; ++i)
+		buf[i] = replace_pop();
+	    if (utf_iscomposing(utf_ptr2char(buf)))
+		ins_bytes_len(buf, n);
 	    else
 	    {
-		buf[0] = c;
-		for (i = 1; i < n; ++i)
-		    buf[i] = replace_pop();
-		if (utf_iscomposing(utf_ptr2char(buf)))
-		    ins_bytes_len(buf, n);
-		else
-		{
-		    // Not a composing char, put it back.
-		    for (i = n - 1; i >= 0; --i)
-			replace_push(buf[i]);
-		    break;
-		}
+		// Not a composing char, put it back.
+		for (i = n - 1; i >= 0; --i)
+		    replace_push(buf[i]);
+		break;
 	    }
+
 	}
 }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1245,30 +1245,29 @@ retry:
 				read_buf_col += n;
 				break;
 			    }
-			    else
+
+			    // Append whole line and new-line.  Change NL
+			    // to NUL to reverse the effect done below.
+			    for (ni = 0; ni < n; ++ni)
 			    {
-				// Append whole line and new-line.  Change NL
-				// to NUL to reverse the effect done below.
-				for (ni = 0; ni < n; ++ni)
-				{
-				    if (p[ni] == NL)
-					ptr[tlen++] = NUL;
-				    else
-					ptr[tlen++] = p[ni];
-				}
-				ptr[tlen++] = NL;
-				read_buf_col = 0;
-				if (++read_buf_lnum > from)
-				{
-				    // When the last line didn't have an
-				    // end-of-line don't add it now either.
-				    if (!curbuf->b_p_eol)
-					--tlen;
-				    size = tlen;
-				    eof = TRUE;
-				    break;
-				}
+				if (p[ni] == NL)
+				    ptr[tlen++] = NUL;
+				else
+				    ptr[tlen++] = p[ni];
 			    }
+			    ptr[tlen++] = NL;
+			    read_buf_col = 0;
+			    if (++read_buf_lnum > from)
+			    {
+				// When the last line didn't have an
+				// end-of-line don't add it now either.
+				if (!curbuf->b_p_eol)
+				    --tlen;
+				size = tlen;
+				eof = TRUE;
+				break;
+			    }
+
 			}
 		    }
 		}

--- a/src/memline.c
+++ b/src/memline.c
@@ -3165,94 +3165,93 @@ ml_append_int(
 		 */
 		break;
 	    }
-	    else			// pointer block full
+	    // pointer block full
+	    /*
+	     * split the pointer block
+	     * allocate a new pointer block
+	     * move some of the pointer into the new block
+	     * prepare for updating the parent block
+	     */
+	    for (;;)	// do this twice when splitting block 1
 	    {
-		/*
-		 * split the pointer block
-		 * allocate a new pointer block
-		 * move some of the pointer into the new block
-		 * prepare for updating the parent block
-		 */
-		for (;;)	// do this twice when splitting block 1
-		{
-		    hp_new = ml_new_ptr(mfp);
-		    if (hp_new == NULL)	    // TODO: try to fix tree
-			goto theend;
-		    pp_new = (PTR_BL *)(hp_new->bh_data);
+		hp_new = ml_new_ptr(mfp);
+		if (hp_new == NULL)	    // TODO: try to fix tree
+		    goto theend;
+		pp_new = (PTR_BL *)(hp_new->bh_data);
 
-		    if (hp->bh_bnum != 1)
-			break;
-
-		    /*
-		     * if block 1 becomes full the tree is given an extra level
-		     * The pointers from block 1 are moved into the new block.
-		     * block 1 is updated to point to the new block
-		     * then continue to split the new block
-		     */
-		    mch_memmove(pp_new, pp, (size_t)page_size);
-		    pp->pb_count = 1;
-		    pp->pb_pointer[0].pe_bnum = hp_new->bh_bnum;
-		    pp->pb_pointer[0].pe_line_count = buf->b_ml.ml_line_count;
-		    pp->pb_pointer[0].pe_old_lnum = 1;
-		    pp->pb_pointer[0].pe_page_count = 1;
-		    mf_put(mfp, hp, TRUE, FALSE);   // release block 1
-		    hp = hp_new;		// new block is to be split
-		    pp = pp_new;
-		    CHECK(stack_idx != 0, _("stack_idx should be 0"));
-		    ip->ip_index = 0;
-		    ++stack_idx;	// do block 1 again later
-		}
-		/*
-		 * move the pointers after the current one to the new block
-		 * If there are none, the new entry will be in the new block.
-		 */
-		total_moved = pp->pb_count - pb_idx - 1;
-		if (total_moved)
-		{
-		    mch_memmove(&pp_new->pb_pointer[0],
-				&pp->pb_pointer[pb_idx + 1],
-				(size_t)(total_moved) * sizeof(PTR_EN));
-		    pp_new->pb_count = total_moved;
-		    pp->pb_count -= total_moved - 1;
-		    pp->pb_pointer[pb_idx + 1].pe_bnum = bnum_right;
-		    pp->pb_pointer[pb_idx + 1].pe_line_count = line_count_right;
-		    pp->pb_pointer[pb_idx + 1].pe_page_count = page_count_right;
-		    if (lnum_right)
-			pp->pb_pointer[pb_idx + 1].pe_old_lnum = lnum_right;
-		}
-		else
-		{
-		    pp_new->pb_count = 1;
-		    pp_new->pb_pointer[0].pe_bnum = bnum_right;
-		    pp_new->pb_pointer[0].pe_line_count = line_count_right;
-		    pp_new->pb_pointer[0].pe_page_count = page_count_right;
-		    pp_new->pb_pointer[0].pe_old_lnum = lnum_right;
-		}
-		pp->pb_pointer[pb_idx].pe_bnum = bnum_left;
-		pp->pb_pointer[pb_idx].pe_line_count = line_count_left;
-		pp->pb_pointer[pb_idx].pe_page_count = page_count_left;
-		if (lnum_left)
-		    pp->pb_pointer[pb_idx].pe_old_lnum = lnum_left;
-		lnum_left = 0;
-		lnum_right = 0;
+		if (hp->bh_bnum != 1)
+		    break;
 
 		/*
-		 * recompute line counts
+		 * if block 1 becomes full the tree is given an extra level
+		 * The pointers from block 1 are moved into the new block.
+		 * block 1 is updated to point to the new block
+		 * then continue to split the new block
 		 */
-		line_count_right = 0;
-		for (i = 0; i < (int)pp_new->pb_count; ++i)
-		    line_count_right += pp_new->pb_pointer[i].pe_line_count;
-		line_count_left = 0;
-		for (i = 0; i < (int)pp->pb_count; ++i)
-		    line_count_left += pp->pb_pointer[i].pe_line_count;
-
-		bnum_left = hp->bh_bnum;
-		bnum_right = hp_new->bh_bnum;
-		page_count_left = 1;
-		page_count_right = 1;
-		mf_put(mfp, hp, TRUE, FALSE);
-		mf_put(mfp, hp_new, TRUE, FALSE);
+		mch_memmove(pp_new, pp, (size_t)page_size);
+		pp->pb_count = 1;
+		pp->pb_pointer[0].pe_bnum = hp_new->bh_bnum;
+		pp->pb_pointer[0].pe_line_count = buf->b_ml.ml_line_count;
+		pp->pb_pointer[0].pe_old_lnum = 1;
+		pp->pb_pointer[0].pe_page_count = 1;
+		mf_put(mfp, hp, TRUE, FALSE);   // release block 1
+		hp = hp_new;		// new block is to be split
+		pp = pp_new;
+		CHECK(stack_idx != 0, _("stack_idx should be 0"));
+		ip->ip_index = 0;
+		++stack_idx;	// do block 1 again later
 	    }
+	    /*
+	     * move the pointers after the current one to the new block
+	     * If there are none, the new entry will be in the new block.
+	     */
+	    total_moved = pp->pb_count - pb_idx - 1;
+	    if (total_moved)
+	    {
+		mch_memmove(&pp_new->pb_pointer[0],
+			&pp->pb_pointer[pb_idx + 1],
+			(size_t)(total_moved) * sizeof(PTR_EN));
+		pp_new->pb_count = total_moved;
+		pp->pb_count -= total_moved - 1;
+		pp->pb_pointer[pb_idx + 1].pe_bnum = bnum_right;
+		pp->pb_pointer[pb_idx + 1].pe_line_count = line_count_right;
+		pp->pb_pointer[pb_idx + 1].pe_page_count = page_count_right;
+		if (lnum_right)
+		    pp->pb_pointer[pb_idx + 1].pe_old_lnum = lnum_right;
+	    }
+	    else
+	    {
+		pp_new->pb_count = 1;
+		pp_new->pb_pointer[0].pe_bnum = bnum_right;
+		pp_new->pb_pointer[0].pe_line_count = line_count_right;
+		pp_new->pb_pointer[0].pe_page_count = page_count_right;
+		pp_new->pb_pointer[0].pe_old_lnum = lnum_right;
+	    }
+	    pp->pb_pointer[pb_idx].pe_bnum = bnum_left;
+	    pp->pb_pointer[pb_idx].pe_line_count = line_count_left;
+	    pp->pb_pointer[pb_idx].pe_page_count = page_count_left;
+	    if (lnum_left)
+		pp->pb_pointer[pb_idx].pe_old_lnum = lnum_left;
+	    lnum_left = 0;
+	    lnum_right = 0;
+
+	    /*
+	     * recompute line counts
+	     */
+	    line_count_right = 0;
+	    for (i = 0; i < (int)pp_new->pb_count; ++i)
+		line_count_right += pp_new->pb_pointer[i].pe_line_count;
+	    line_count_left = 0;
+	    for (i = 0; i < (int)pp->pb_count; ++i)
+		line_count_left += pp->pb_pointer[i].pe_line_count;
+
+	    bnum_left = hp->bh_bnum;
+	    bnum_right = hp_new->bh_bnum;
+	    page_count_left = 1;
+	    page_count_right = 1;
+	    mf_put(mfp, hp, TRUE, FALSE);
+	    mf_put(mfp, hp_new, TRUE, FALSE);
+
 	}
 
 	/*

--- a/src/option.c
+++ b/src/option.c
@@ -4384,38 +4384,37 @@ set_option_value(
 #endif
 	if (flags & P_STRING)
 	    return set_string_option(opt_idx, string, opt_flags);
-	else
+
+	varp = get_varp_scope(&(options[opt_idx]), opt_flags);
+	if (varp != NULL)	// hidden option is not changed
 	{
-	    varp = get_varp_scope(&(options[opt_idx]), opt_flags);
-	    if (varp != NULL)	// hidden option is not changed
+	    if (number == 0 && string != NULL)
 	    {
-		if (number == 0 && string != NULL)
+		int idx;
+
+		// Either we are given a string or we are setting option
+		// to zero.
+		for (idx = 0; string[idx] == '0'; ++idx)
+		    ;
+		if (string[idx] != NUL || idx == 0)
 		{
-		    int idx;
+		    // There's another character after zeros or the string
+		    // is empty.  In both cases, we are trying to set a
+		    // num option using a string.
+		    semsg(_(e_number_required_after_str_equal_str),
+			    name, string);
+		    return NULL;     // do nothing as we hit an error
 
-		    // Either we are given a string or we are setting option
-		    // to zero.
-		    for (idx = 0; string[idx] == '0'; ++idx)
-			;
-		    if (string[idx] != NUL || idx == 0)
-		    {
-			// There's another character after zeros or the string
-			// is empty.  In both cases, we are trying to set a
-			// num option using a string.
-			semsg(_(e_number_required_after_str_equal_str),
-								name, string);
-			return NULL;     // do nothing as we hit an error
-
-		    }
 		}
-		if (flags & P_NUM)
-		    return set_num_option(opt_idx, varp, number,
-							  NULL, 0, opt_flags);
-		else
-		    return set_bool_option(opt_idx, varp, (int)number,
-								   opt_flags);
 	    }
+	    if (flags & P_NUM)
+		return set_num_option(opt_idx, varp, number,
+			NULL, 0, opt_flags);
+	    else
+		return set_bool_option(opt_idx, varp, (int)number,
+			opt_flags);
 	}
+
     }
     return NULL;
 }

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -2504,55 +2504,53 @@ check_state_ends(void)
 		next_match_col = MAXCOL;
 		break;
 	    }
-	    else
+
+	    // handle next_list, unless at end of line and no "skipnl" or
+	    // "skipempty"
+	    current_next_list = cur_si->si_next_list;
+	    current_next_flags = cur_si->si_flags;
+	    if (!(current_next_flags & (HL_SKIPNL | HL_SKIPEMPTY))
+		    && syn_getcurline()[current_col] == NUL)
+		current_next_list = NULL;
+
+	    // When the ended item has "extend", another item with
+	    // "keepend" now needs to check for its end.
+	    had_extend = (cur_si->si_flags & HL_EXTEND);
+
+	    pop_current_state();
+
+	    if (current_state.ga_len == 0)
+		break;
+
+	    if (had_extend && keepend_level >= 0)
 	    {
-		// handle next_list, unless at end of line and no "skipnl" or
-		// "skipempty"
-		current_next_list = cur_si->si_next_list;
-		current_next_flags = cur_si->si_flags;
-		if (!(current_next_flags & (HL_SKIPNL | HL_SKIPEMPTY))
-			&& syn_getcurline()[current_col] == NUL)
-		    current_next_list = NULL;
-
-		// When the ended item has "extend", another item with
-		// "keepend" now needs to check for its end.
-		 had_extend = (cur_si->si_flags & HL_EXTEND);
-
-		pop_current_state();
-
+		syn_update_ends(FALSE);
 		if (current_state.ga_len == 0)
 		    break;
+	    }
 
-		if (had_extend && keepend_level >= 0)
-		{
-		    syn_update_ends(FALSE);
-		    if (current_state.ga_len == 0)
-			break;
-		}
+	    cur_si = &CUR_STATE(current_state.ga_len - 1);
 
-		cur_si = &CUR_STATE(current_state.ga_len - 1);
-
-		/*
-		 * Only for a region the search for the end continues after
-		 * the end of the contained item.  If the contained match
-		 * included the end-of-line, break here, the region continues.
-		 * Don't do this when:
-		 * - "keepend" is used for the contained item
-		 * - not at the end of the line (could be end="x$"me=e-1).
-		 * - "excludenl" is used (HL_HAS_EOL won't be set)
-		 */
-		if (cur_si->si_idx >= 0
-			&& SYN_ITEMS(syn_block)[cur_si->si_idx].sp_type
-							       == SPTYPE_START
-			&& !(cur_si->si_flags & (HL_MATCH | HL_KEEPEND)))
-		{
-		    update_si_end(cur_si, (int)current_col, TRUE);
-		    check_keepend();
-		    if ((current_next_flags & HL_HAS_EOL)
-			    && keepend_level < 0
-			    && syn_getcurline()[current_col] == NUL)
-			break;
-		}
+	    /*
+	     * Only for a region the search for the end continues after
+	     * the end of the contained item.  If the contained match
+	     * included the end-of-line, break here, the region continues.
+	     * Don't do this when:
+	     * - "keepend" is used for the contained item
+	     * - not at the end of the line (could be end="x$"me=e-1).
+	     * - "excludenl" is used (HL_HAS_EOL won't be set)
+	     */
+	    if (cur_si->si_idx >= 0
+		    && SYN_ITEMS(syn_block)[cur_si->si_idx].sp_type
+		    == SPTYPE_START
+		    && !(cur_si->si_flags & (HL_MATCH | HL_KEEPEND)))
+	    {
+		update_si_end(cur_si, (int)current_col, TRUE);
+		check_keepend();
+		if ((current_next_flags & HL_HAS_EOL)
+			&& keepend_level < 0
+			&& syn_getcurline()[current_col] == NUL)
+		    break;
 	    }
 	}
 	else


### PR DESCRIPTION
This is just something I personally find more readable and thought maybe
you would too. I understand how subjective these things are so feel free
to close it if you think this makes it harder to follow.
