### PR TITLE
Port WinScrolled impl from NeoVim

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -402,7 +402,7 @@ Name			triggered by ~
 |User|			to be used in combination with ":doautocmd"
 |SigUSR1|		after the SIGUSR1 signal has been detected
 
-WinScrolled		after scrolling a window
+|WinScrolled|		after scrolling a window
 
 
 The alphabetical list of autocommand events:		*autocmd-events-abc*
@@ -1320,7 +1320,12 @@ WinNew				When a new window was created.  Not done for
 				Before a WinEnter event.
 
 							*WinScrolled*
-WinScrolled			After scrolling the content of a window.
+WinScrolled			After scrolling the content of a window.  Note
+				that this autocommand may also be executed after
+				resizing a window.  The pattern is matched
+				against the |window-ID|.  Both <amatch> and
+				<afile> are set to the |window-ID|.
+				Non-recursive (the event cannot trigger itself).
 
 ==============================================================================
 6. Patterns					*autocmd-patterns* *{aupat}*

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -402,6 +402,8 @@ Name			triggered by ~
 |User|			to be used in combination with ":doautocmd"
 |SigUSR1|		after the SIGUSR1 signal has been detected
 
+WinScrolled		after scrolling a window
+
 
 The alphabetical list of autocommand events:		*autocmd-events-abc*
 
@@ -1316,6 +1318,9 @@ WinLeave			Before leaving a window.  If the window to be
 WinNew				When a new window was created.  Not done for
 				the first window, when Vim has just started.
 				Before a WinEnter event.
+
+							*WinScrolled*
+WinScrolled			After scrolling the content of a window.
 
 ==============================================================================
 6. Patterns					*autocmd-patterns* *{aupat}*

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -190,6 +190,7 @@ static struct event_name
     {"WinClosed",	EVENT_WINCLOSED},
     {"WinEnter",	EVENT_WINENTER},
     {"WinLeave",	EVENT_WINLEAVE},
+    {"WinScrolled",	EVENT_WINSCROLLED},
     {"VimResized",	EVENT_VIMRESIZED},
     {"TextYankPost",	EVENT_TEXTYANKPOST},
     {"VimSuspend",	EVENT_VIMSUSPEND},
@@ -1780,6 +1781,15 @@ trigger_cursorhold(void)
 	    return TRUE;
     }
     return FALSE;
+}
+
+/*
+ * Return TRUE when there is a WinScrolled autocommand defined.
+ */
+    int
+has_winscrolled(void)
+{
+    return (first_autopat[(int)EVENT_WINSCROLLED] != NULL);
 }
 
 /*

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -1252,6 +1252,15 @@ do_autocmd_event(
 		    vim_free(rettv.vval.v_string);
 		}
 #endif
+		// Initialize the fields checked by the WinScrolled trigger to
+		// stop it from firing right after the first autocmd is defined.
+		if (event == EVENT_WINSCROLLED && !has_winscrolled())
+		{
+		    curwin->w_last_topline = curwin->w_topline;
+		    curwin->w_last_leftcol = curwin->w_leftcol;
+		    curwin->w_last_width = curwin->w_width;
+		    curwin->w_last_height = curwin->w_height;
+		}
 
 		if (is_buflocal)
 		{
@@ -2088,7 +2097,8 @@ apply_autocmds_group(
 		|| event == EVENT_DIRCHANGEDPRE
 		|| event == EVENT_MODECHANGED
 		|| event == EVENT_USER
-		|| event == EVENT_WINCLOSED)
+		|| event == EVENT_WINCLOSED
+		|| event == EVENT_WINSCROLLED)
 	{
 	    fname = vim_strsave(fname);
 	    autocmd_fname_full = TRUE; // don't expand it later

--- a/src/edit.c
+++ b/src/edit.c
@@ -1529,6 +1529,9 @@ ins_redraw(int ready)	    // not busy with something
 					(linenr_T)(curwin->w_cursor.lnum + 1));
     }
 
+    if (ready && has_winscrolled())
+	trigger_winscrolled(curwin);
+
     // Trigger SafeState if nothing is pending.
     may_trigger_safestate(ready
 	    && !ins_compl_active()

--- a/src/gui.c
+++ b/src/gui.c
@@ -5237,6 +5237,9 @@ gui_update_screen(void)
 	last_cursormoved = curwin->w_cursor;
     }
 
+    if (!finish_op && has_winscrolled())
+	trigger_winscrolled(curwin);
+
 # ifdef FEAT_CONCEAL
     if (conceal_update_lines
 	    && (conceal_old_cursor_line != conceal_new_cursor_line

--- a/src/main.c
+++ b/src/main.c
@@ -1336,9 +1336,10 @@ main_loop(
 		curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
 	    }
 
-	    // Ensure curwin->w_topline is up to date before triggering a
-	    // WinScrolled autocommand.
+	    // Ensure curwin->w_topline and curwin->w_leftcol are up to date
+	    // before triggering a WinScrolled autocommand.
 	    update_topline();
+	    validate_cursor();
 
 	    if (!finish_op && has_winscrolled())
 		trigger_winscrolled(curwin);

--- a/src/main.c
+++ b/src/main.c
@@ -1336,6 +1336,13 @@ main_loop(
 		curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
 	    }
 
+	    // Ensure curwin->w_topline is up to date before triggering a
+	    // WinScrolled autocommand.
+	    update_topline();
+
+	    if (!finish_op && has_winscrolled())
+		trigger_winscrolled(curwin);
+
 	    // If nothing is pending and we are going to wait for the user to
 	    // type a character, trigger SafeState.
 	    may_trigger_safestate(!op_pending() && restart_edit == 0);

--- a/src/proto/autocmd.pro
+++ b/src/proto/autocmd.pro
@@ -26,6 +26,7 @@ int has_cmdundefined(void);
 int has_textyankpost(void);
 int has_completechanged(void);
 int has_modechanged(void);
+int has_winscrolled(void);
 void block_autocmds(void);
 void unblock_autocmds(void);
 int is_autocmd_blocked(void);

--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -83,4 +83,5 @@ int win_hasvertsplit(void);
 int get_win_number(win_T *wp, win_T *first_win);
 int get_tab_number(tabpage_T *tp);
 char *check_colorcolumn(win_T *wp);
+void trigger_winscrolled(win_T *wp);
 /* vim: set ft=c : */

--- a/src/structs.h
+++ b/src/structs.h
@@ -3509,6 +3509,11 @@ struct window_S
 				    // window
 #endif
 
+    linenr_T	w_last_topline;	    // last known value for w_topline
+    colnr_T	w_last_leftcol;	    // last known value for w_leftcol
+    int		w_last_width;	    // last known value for w_width
+    int		w_last_height;	    // last known value for w_height
+
     /*
      * Layout of the window in the screen.
      * May need to add "msg_scrolled" to "w_winrow" in rare situations.

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -3,6 +3,7 @@
 source shared.vim
 source check.vim
 source term_util.vim
+source screendump.vim
 import './vim9.vim' as v9
 
 func s:cleanup_buffers() abort
@@ -307,6 +308,60 @@ func Test_win_tab_autocmd()
     au!
   augroup END
   unlet g:record
+endfunc
+
+func Test_WinScrolled()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+	set nowrap scrolloff=0
+        for ii in range(1, 18)
+          call setline(ii, repeat(nr2char(96 + ii), ii * 2))
+        endfor
+        let win_id = win_getid()
+        let g:matched = v:false
+        execute 'au WinScrolled' win_id 'let g:matched = v:true'
+        let g:scrolled = 0
+        au WinScrolled * let g:scrolled += 1
+        au WinScrolled * let g:amatch = str2nr(expand('<amatch>'))
+        au WinScrolled * let g:afile = str2nr(expand('<afile>'))
+  END
+  call writefile(lines, 'Xtest_winscrolled')
+  let buf = RunVimInTerminal('-S Xtest_winscrolled', {'rows': 6})
+
+  call term_sendkeys(buf, ":echo g:scrolled\<CR>")
+  call WaitForAssert({-> assert_match('^0 ', term_getline(buf, 6))}, 1000)
+
+  " Scroll left/right in Normal mode.
+  call term_sendkeys(buf, "zlzh:echo g:scrolled\<CR>")
+  call WaitForAssert({-> assert_match('^2 ', term_getline(buf, 6))}, 1000)
+
+  " Scroll up/down in Normal mode.
+  call term_sendkeys(buf, "\<c-e>\<c-y>:echo g:scrolled\<CR>")
+  call WaitForAssert({-> assert_match('^4 ', term_getline(buf, 6))}, 1000)
+
+  " Scroll up/down in Insert mode.
+  call term_sendkeys(buf, "Mi\<c-x>\<c-e>\<Esc>i\<c-x>\<c-y>\<Esc>")
+  call term_sendkeys(buf, ":echo g:scrolled\<CR>")
+  call WaitForAssert({-> assert_match('^6 ', term_getline(buf, 6))}, 1000)
+
+  " Scroll the window horizontally to focus the last letter of the third line
+  " containing only six characters. Moving to the previous and shorter lines
+  " should trigger another autocommand as Vim has to make them visible.
+  call term_sendkeys(buf, "5zl2k")
+  call term_sendkeys(buf, ":echo g:scrolled\<CR>")
+  call WaitForAssert({-> assert_match('^8 ', term_getline(buf, 6))}, 1000)
+
+  " Ensure the command was triggered for the specified window ID.
+  call term_sendkeys(buf, ":echo g:matched\<CR>")
+  call WaitForAssert({-> assert_match('^v:true ', term_getline(buf, 6))}, 1000)
+
+  " Ensure the expansion of <amatch> and <afile> matches the window ID.
+  call term_sendkeys(buf, ":echo g:amatch == win_id && g:afile == win_id\<CR>")
+  call WaitForAssert({-> assert_match('^v:true ', term_getline(buf, 6))}, 1000)
+
+  call StopVimInTerminal(buf)
+  call delete('Xtest_winscrolled')
 endfunc
 
 func Test_WinClosed()

--- a/src/vim.h
+++ b/src/vim.h
@@ -1386,6 +1386,7 @@ enum auto_event
     EVENT_WINCLOSED,		// after closing a window
     EVENT_VIMSUSPEND,		// before Vim is suspended
     EVENT_VIMRESUME,		// after Vim is resumed
+    EVENT_WINSCROLLED,		// after Vim window was scrolled
 
     NUM_EVENTS			// MUST be the last one
 };

--- a/src/window.c
+++ b/src/window.c
@@ -2784,6 +2784,30 @@ trigger_winclosed(win_T *win)
     recursive = FALSE;
 }
 
+    void
+trigger_winscrolled(win_T *wp)
+{
+    static int	    recursive = FALSE;
+
+    if (recursive)
+	return;
+
+    if (wp->w_last_topline != wp->w_topline ||
+	    wp->w_last_leftcol != wp->w_leftcol ||
+	    wp->w_last_width != wp->w_width ||
+	    wp->w_last_height != wp->w_height)
+    {
+	recursive = TRUE;
+	apply_autocmds(EVENT_WINSCROLLED, NULL, NULL, FALSE, wp->w_buffer);
+	recursive = FALSE;
+
+	wp->w_last_topline = wp->w_topline;
+	wp->w_last_leftcol = wp->w_leftcol;
+	wp->w_last_width = wp->w_width;
+	wp->w_last_height = wp->w_height;
+    }
+}
+
 /*
  * Close window "win" in tab page "tp", which is not the current tab page.
  * This may be the last window in that tab page and result in closing the tab,

--- a/src/window.c
+++ b/src/window.c
@@ -2788,6 +2788,7 @@ trigger_winclosed(win_T *win)
 trigger_winscrolled(win_T *wp)
 {
     static int	    recursive = FALSE;
+    char_u	    winid[NUMBUFLEN];
 
     if (recursive)
 	return;
@@ -2797,8 +2798,10 @@ trigger_winscrolled(win_T *wp)
 	    wp->w_last_width != wp->w_width ||
 	    wp->w_last_height != wp->w_height)
     {
+	vim_snprintf((char *)winid, sizeof(winid), "%i", wp->w_id);
+
 	recursive = TRUE;
-	apply_autocmds(EVENT_WINSCROLLED, NULL, NULL, FALSE, wp->w_buffer);
+	apply_autocmds(EVENT_WINSCROLLED, winid, winid, FALSE, wp->w_buffer);
 	recursive = FALSE;
 
 	wp->w_last_topline = wp->w_topline;


### PR DESCRIPTION
Emit a WinScrolled autocommand whenever the window content is shifted up or down.

Writing a test for this turned out to be not so trivial, the testing harness doesn't let `main_loop` execute (this may also explain the `TODO` entry in `Test_Changed_ChangedI`) and thus no `WinScrolled` autocommand is triggered until the UI is drawn.
Suggestions and/or test cases are welcome.