### PR TITLE
Detect *.src/*.dat preferably from content

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim functions for file type detection
 #
 # Maintainer:	Bram Moolenaar <Bram@vim.org>
-# Last Change:	2022 Mar 05
+# Last Change:	07. Apr 2022
 
 # These functions are moved here from runtime/filetype.vim to make startup
 # faster.
@@ -898,19 +898,19 @@ enddef
 
 # Determine if a *.src file is Kuka Robot Language
 export def FTsrc()
-  if exists("g:filetype_src")
-    exe "setf " .. g:filetype_src
-  elseif getline(nextnonblank(1)) =~? '^\s*\%(&\w\+\|\%(global\s\+\)\?def\>\)'
+  if getline(nextnonblank(1)) =~? '^\s*\%(&\w\+\|\%(global\s\+\)\?def\>\)'
     setf krl
+  elseif exists("g:filetype_src")
+    exe "setf " .. g:filetype_src
   endif
 enddef
 
 # Determine if a *.dat file is Kuka Robot Language
 export def FTdat()
-  if exists("g:filetype_dat")
-    exe "setf " .. g:filetype_dat
-  elseif getline(nextnonblank(1)) =~? '^\s*\%(&\w\+\|defdat\>\)'
+  if getline(nextnonblank(1)) =~? '^\s*\%(&\w\+\|defdat\>\)'
     setf krl
+  elseif exists("g:filetype_dat")
+    exe "setf " .. g:filetype_dat
   endif
 enddef
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -870,26 +870,44 @@ func Test_d_file()
   call delete('Xfile.d')
 endfunc
 
+" Test dist#ft#FTdat()
 func Test_dat_file()
   filetype on
 
+  " Users preference set by g:filetype_dat
+  call writefile(['anything'], 'datfile.dat')
+  let g:filetype_dat = 'dat'
+  split datfile.dat
+  call assert_equal('dat', &filetype)
+  bwipe!
+
+  " KRL header start with "&WORD",
+  " but is not always present.
   call writefile(['&ACCESS'], 'datfile.dat')
   split datfile.dat
   call assert_equal('krl', &filetype)
   bwipe!
   call delete('datfile.dat')
 
+  " KRL defdat with leading spaces,
+  " the .src extension is not case sensitive.
   call writefile(['  DEFDAT datfile'], 'datfile.Dat')
   split datfile.Dat
   call assert_equal('krl', &filetype)
   bwipe!
   call delete('datfile.Dat')
 
+  " KRL defdat with embedded spaces,
+  " file starts with empty line(s).
   call writefile(['', 'defdat  datfile'], 'datfile.DAT')
   split datfile.DAT
   call assert_equal('krl', &filetype)
   bwipe!
   call delete('datfile.DAT')
+
+  " Recognize KRL even though g:filetype_dat is set.
+  " Clean up now
+  unlet g:filetype_dat
 
   filetype off
 endfunc
@@ -1336,26 +1354,44 @@ func Test_pp_file()
   filetype off
 endfunc
 
+" Test dist#ft#FTsrc()
 func Test_src_file()
   filetype on
 
+  " Users preference set by g:filetype_src
+  call writefile(['anything'], 'srcfile.src')
+  let g:filetype_src = 'src'
+  split srcfile.src
+  call assert_equal('src', &filetype)
+  bwipe!
+
+  " KRL header start with "&WORD",
+  " but is not always present.
   call writefile(['&ACCESS'], 'srcfile.src')
   split srcfile.src
   call assert_equal('krl', &filetype)
   bwipe!
   call delete('srcfile.src')
 
+  " KRL def with leading spaces,
+  " the .src extension is not case sensitive.
   call writefile(['  DEF srcfile()'], 'srcfile.Src')
   split srcfile.Src
   call assert_equal('krl', &filetype)
   bwipe!
   call delete('srcfile.Src')
 
+  " KRL def with embedded spaces and global attribute,
+  " file starts with empty line(s).
   call writefile(['', 'global  def  srcfile()'], 'srcfile.SRC')
   split srcfile.SRC
   call assert_equal('krl', &filetype)
   bwipe!
   call delete('srcfile.SRC')
+
+  " Recognize KRL even though g:filetype_src is set.
+  " Clean up now
+  unlet g:filetype_src
 
   filetype off
 endfunc


### PR DESCRIPTION
KRL files are easiely recognized. Even if the user does set
g:filetype_src or g:filetype_dat one may very well profit from file
content inspection. New files will always default to g:filetype_* if
present.