### PR TITLE
Add /// to 'comments' in C ftplugin

### DIFF
--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -31,7 +31,7 @@ if exists('&ofu')
 endif
 
 " Set 'comments' to format dashed lists in comments.
-setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://
 
 " In VMS C keywords contain '$' characters.
 if has("vms")


### PR DESCRIPTION
The /// comment string is commonly used for Doxygen "doc comments". With
the status quo, entering a newline in a doc comment results in only two
// characters on the newline, which is a minor annoyance. Adding this to
the default 'comments' option makes writing doc comments easier without
affecting existing //-style comment blocks.