### PR TITLE
update neomuttrc syntax

### DIFF
--- a/runtime/syntax/neomuttrc.vim
+++ b/runtime/syntax/neomuttrc.vim
@@ -2,10 +2,10 @@
 " Language:	NeoMutt setup files
 " Maintainer:	Richard Russon <rich@flatcap.org>
 " Previous Maintainer:	Guillaume Brogi <gui-gui@netcourrier.com>
-" Last Change:	2020-06-21
+" Last Change:	2022-04-08
 " Original version based on syntax/muttrc.vim
 
-" This file covers NeoMutt 2020-06-19
+" This file covers NeoMutt 2022-04-08
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -115,6 +115,8 @@ syntax region muttrcIndexFormatStr      contained skipwhite keepend start=+"+ sk
 syntax region muttrcIndexFormatStr      contained skipwhite keepend start=+'+ skip=+\\'+ end=+'+ contains=muttrcIndexFormatEscapes,muttrcIndexFormatConditionals,muttrcFormatErrors,muttrcTimeEscapes           nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 syntax region muttrcMixFormatStr        contained skipwhite keepend start=+"+ skip=+\\"+ end=+"+ contains=muttrcMixFormatEscapes,muttrcMixFormatConditionals,muttrcFormatErrors                                 nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 syntax region muttrcMixFormatStr        contained skipwhite keepend start=+'+ skip=+\\'+ end=+'+ contains=muttrcMixFormatEscapes,muttrcMixFormatConditionals,muttrcFormatErrors                                 nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
+syntax region muttrcPatternFormatStr    contained skipwhite keepend start=+"+ skip=+\\"+ end=+"+ contains=muttrcPatternFormatEscapes,muttrcPatternFormatConditionals,muttrcFormatErrors                                 nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
+syntax region muttrcPatternFormatStr    contained skipwhite keepend start=+'+ skip=+\\'+ end=+'+ contains=muttrcPatternFormatEscapes,muttrcPatternFormatConditionals,muttrcFormatErrors                                 nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 syntax region muttrcPGPCmdFormatStr     contained skipwhite keepend start=+"+ skip=+\\"+ end=+"+ contains=muttrcPGPCmdFormatEscapes,muttrcPGPCmdFormatConditionals,muttrcVariable,muttrcFormatErrors            nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 syntax region muttrcPGPCmdFormatStr     contained skipwhite keepend start=+'+ skip=+\\'+ end=+'+ contains=muttrcPGPCmdFormatEscapes,muttrcPGPCmdFormatConditionals,muttrcVariable,muttrcFormatErrors            nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 syntax region muttrcPGPFormatStr        contained skipwhite keepend start=+"+ skip=+\\"+ end=+"+ contains=muttrcPGPFormatEscapes,muttrcPGPFormatConditionals,muttrcFormatErrors,muttrcPGPTimeEscapes            nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
@@ -144,35 +146,37 @@ function! s:escapesConditionals(baseName, sequence, padding, conditional)
 	endif
 endfunction
 
-" CHECKED 2020-06-21
-" Ref: alias_format_str() in alias/dlgalias.c
+" CHECKED 2022-04-08
+" Ref: alias_format_str() in alias/dlg_alias.c
 call s:escapesConditionals('AliasFormat', '[acfnrt]', 1, 0)
-" Ref: attach_format_str() in recvattach.c
+" Ref: attach_format_str() in attach/dlg_attach.c
 call s:escapesConditionals('AttachFormat', '[CcDdeFfIMmnQsTtuX]', 1, 1)
-" Ref: compose_format_str() in compose.c
+" Ref: compose_format_str() in compose/cbar.c
 call s:escapesConditionals('ComposeFormat', '[ahlv]', 1, 1)
-" Ref: folder_format_str() in browser.c
+" Ref: folder_format_str() in browser/browser.c
 call s:escapesConditionals('FolderFormat', '[CDdFfgilmNnstu]', 1, 0)
-" Ref: group_index_format_str() in browser.c
+" Ref: group_index_format_str() in nntp/browse.c
 call s:escapesConditionals('GroupIndexFormat', '[CdfMNns]', 1, 1)
 " Ref: index_format_str() in hdrline.c
 call s:escapesConditionals('IndexFormat', '[AaBbCDdEefgHIiJKLlMmNnOPqRrSsTtuvWXxYyZ(<[{]\|@\i\+@\|G[a-zA-Z]\+\|Fp\=\|z[cst]\|cr\=', 1, 1)
 " Ref: mix_format_str() in remailer.c
 call s:escapesConditionals('MixFormat', '[acns]', 1, 0)
+" Ref: pattern_format_str() in pattern/dlg_pattern.c
+call s:escapesConditionals('PatternFormat', '[den]', 1, 0)
 " Ref: pgp_command_format_str() in ncrypt/pgpinvoke.c
 call s:escapesConditionals('PGPCmdFormat', '[afprs]', 0, 1)
-" Ref: crypt_format_str() in ncrypt/crypt_gpgme.c
-" Ref: pgp_entry_format_str() in ncrypt/pgpkey.c
+" Ref: crypt_format_str() in ncrypt/dlg_gpgme.c
+" Ref: pgp_entry_format_str() in ncrypt/dlg_pgp.c
 " Note: crypt_format_str() supports 'p', but pgp_entry_fmt() does not
 call s:escapesConditionals('PGPFormat', '[AaCcFfKkLlnptu[]', 0, 0)
-" Ref: query_format_str() in alias/dlgquery.c
+" Ref: query_format_str() in alias/dlg_query.c
 call s:escapesConditionals('QueryFormat', '[acent]', 1, 1)
-" Ref: sidebar_format_str() in sidebar.c
+" Ref: sidebar_format_str() in sidebar/window.c
 call s:escapesConditionals('SidebarFormat', '[!BDdFLNnorStZ]', 1, 1)
 " Ref: smime_command_format_str() in ncrypt/smime.c
 call s:escapesConditionals('SmimeFormat', '[aCcdfiks]', 0, 1)
 " Ref: status_format_str() in status.c
-call s:escapesConditionals('StatusFormat', '[bDdFfhLlMmnoPpRrSstuVv]', 1, 1)
+call s:escapesConditionals('StatusFormat', '[bDdFfhLlMmnoPpRrSsTtuVv]', 1, 1)
 
 syntax region muttrcPGPTimeEscapes contained start=+%\[+ end=+\]+ contains=muttrcStrftimeEscapes
 syntax region muttrcTimeEscapes    contained start=+%(+  end=+)+  contains=muttrcStrftimeEscapes
@@ -187,6 +191,7 @@ syntax match muttrcVarEqualsFolderFmt     contained skipwhite "=" nextgroup=mutt
 syntax match muttrcVarEqualsGrpIdxFmt     contained skipwhite "=" nextgroup=muttrcGroupIndexFormatStr
 syntax match muttrcVarEqualsIdxFmt        contained skipwhite "=" nextgroup=muttrcIndexFormatStr
 syntax match muttrcVarEqualsMixFmt        contained skipwhite "=" nextgroup=muttrcMixFormatStr
+syntax match muttrcVarEqualsPatternFmt    contained skipwhite "=" nextgroup=muttrcPatternFormatStr
 syntax match muttrcVarEqualsPGPCmdFmt     contained skipwhite "=" nextgroup=muttrcPGPCmdFormatStr
 syntax match muttrcVarEqualsPGPFmt        contained skipwhite "=" nextgroup=muttrcPGPFormatStr
 syntax match muttrcVarEqualsQueryFmt      contained skipwhite "=" nextgroup=muttrcQueryFormatStr
@@ -197,9 +202,9 @@ syntax match muttrcVarEqualsStrftimeFmt   contained skipwhite "=" nextgroup=mutt
 
 syntax match muttrcVPrefix contained /[?&]/ nextgroup=muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
-" CHECKED 2020-06-21
-" List of the different screens in mutt (see Menus in keymap.c)
-syntax keyword muttrcMenu contained alias attach browser compose editor generic index key_select_pgp key_select_smime mix pager pgp postpone query smime
+" CHECKED 2022-04-08
+" List of the different screens in NeoMutt (see MenuNames in menu/type.c)
+syntax keyword muttrcMenu contained alias attach autocrypt browser compose editor generic index key_select_pgp key_select_smime mix pager pgp postpone query smime
 syntax match muttrcMenuList "\S\+" contained contains=muttrcMenu
 syntax match muttrcMenuCommas /,/ contained
 
@@ -234,12 +239,12 @@ syntax match muttrcEscapedVariable	contained "\\\$[a-zA-Z_-]\+"
 syntax match muttrcBadAction	contained "[^<>]\+" contains=muttrcEmail
 syntax match muttrcAction		contained "<[^>]\{-}>" contains=muttrcBadAction,muttrcFunction,muttrcKeyName
 
-" CHECKED 2020-06-21
-" First, functions that take regular expressions:
+" CHECKED 2022-04-08
+" First, hooks that take regular expressions:
 syntax match  muttrcRXHookNot	contained /!\s*/ skipwhite nextgroup=muttrcRXHookString,muttrcRXHookStringNL
 syntax match  muttrcRXHooks	/\<\%(account\|append\|close\|crypt\|folder\|mbox\|open\|pgp\)-hook\>/ skipwhite nextgroup=muttrcRXHookNot,muttrcRXHookString,muttrcRXHookStringNL
 
-" Now, functions that take patterns
+" Now, hooks that take patterns
 syntax match muttrcPatHookNot	contained /!\s*/ skipwhite nextgroup=muttrcPattern
 syntax match muttrcPatHooks	/\<\%(charset\|iconv\|index-format\)-hook\>/ skipwhite nextgroup=muttrcPatHookNot,muttrcPattern
 syntax match muttrcPatHooks	/\<\%(message\|reply\|send\|send2\|save\|fcc\|fcc-save\)-hook\>/ skipwhite nextgroup=muttrcPatHookNot,muttrcOptPattern
@@ -295,10 +300,10 @@ syntax match muttrcAliasNL		contained /\s*\\$/ skipwhite skipnl nextgroup=muttrc
 syntax match muttrcUnAliasKey	contained "\s*\w\+\s*" skipwhite nextgroup=muttrcUnAliasKey,muttrcUnAliasNL
 syntax match muttrcUnAliasNL	contained /\s*\\$/ skipwhite skipnl nextgroup=muttrcUnAliasKey,muttrcUnAliasNL
 
-" CHECKED 2020-06-21
-" List of letters in Flags in pattern.c
+" CHECKED 2022-04-08
+" List of letters in Flags in pattern/flags.c
 " Parameter: none
-syntax match muttrcSimplePat contained "!\?\^\?[~][ADEFGgklNOPpQRSTuUvV#$=]"
+syntax match muttrcSimplePat contained "!\?\^\?[~][ADEFGgklNOPpQRSTUuVv#$=]"
 " Parameter: range
 syntax match muttrcSimplePat contained "!\?\^\?[~][mnXz]\s*\%([<>-][0-9]\+[kM]\?\|[0-9]\+[kM]\?[-]\%([0-9]\+[kM]\?\)\?\)"
 " Parameter: date
@@ -306,7 +311,7 @@ syntax match muttrcSimplePat contained "!\?\^\?[~][dr]\s*\%(\%(-\?[0-9]\{1,2}\%(
 " Parameter: regex
 syntax match muttrcSimplePat contained "!\?\^\?[~][BbCcefHhIiLMstwxYy]\s*" nextgroup=muttrcSimplePatRXContainer
 " Parameter: pattern
-syntax match muttrcSimplePat contained "!\?\^\?[%][bBcCefhHiLstxy]\s*" nextgroup=muttrcSimplePatString
+syntax match muttrcSimplePat contained "!\?\^\?[%][BbCcefHhiLstxy]\s*" nextgroup=muttrcSimplePatString
 " Parameter: pattern
 syntax match muttrcSimplePat contained "!\?\^\?[=][bcCefhHiLstxy]\s*" nextgroup=muttrcSimplePatString
 syntax region muttrcSimplePat contained keepend start=+!\?\^\?[~](+ end=+)+ contains=muttrcSimplePat
@@ -369,8 +374,8 @@ syntax keyword muttrcMonoAttrib	contained bold none normal reverse standout unde
 syntax keyword muttrcMono	contained mono		skipwhite nextgroup=muttrcColorField,muttrcColorCompose
 syntax match   muttrcMonoLine	"^\s*mono\s\+\S\+"	skipwhite nextgroup=muttrcMonoAttrib contains=muttrcMono
 
-" CHECKED 2020-06-21
-" List of fields in Fields in color.c
+" CHECKED 2022-04-08
+" List of fields in ColorFields in color/commmand.c
 syntax keyword muttrcColorField skipwhite contained
 	\ attachment attach_headers body bold error hdrdefault header index index_author
 	\ index_collapsed index_date index_flags index_label index_number index_size index_subject
@@ -383,8 +388,8 @@ syntax match   muttrcColorField	contained "\<quoted\d\=\>"
 
 syntax match muttrcColorCompose skipwhite contained /\s*compose\s*/ nextgroup=muttrcColorComposeField
 
-" CHECKED 2020-06-21
-" List of fields in ComposeFields in color.c
+" CHECKED 2022-04-08
+" List of fields in ComposeColorFields in color/command.c
 syntax keyword muttrcColorComposeField skipwhite contained
 	\ header security_both security_encrypt security_none security_sign
 	\ nextgroup=muttrcColorFG,muttrcColorFGNL
@@ -411,20 +416,21 @@ function! s:boolQuadGen(type, vars, deprecated)
 
 endfunction
 
-" CHECKED 2020-06-21
+" CHECKED 2022-04-08
 " List of DT_BOOL in MuttVars in mutt_config.c
 call s:boolQuadGen('Bool', [
-	\ 'abort_backspace', 'allow_8bit', 'allow_ansi', 'arrow_cursor', 'ascii_chars', 'askbcc',
-	\ 'askcc', 'ask_follow_up', 'ask_x_comment_to', 'attach_save_without_prompting',
-	\ 'attach_split', 'autocrypt', 'autocrypt_reply', 'autoedit', 'auto_subscribe', 'auto_tag',
+	\ 'abort_backspace', 'allow_8bit', 'allow_ansi', 'arrow_cursor', 'ascii_chars', 'ask_bcc',
+	\ 'ask_cc', 'ask_follow_up', 'ask_x_comment_to', 'attach_save_without_prompting',
+	\ 'attach_split', 'autocrypt', 'autocrypt_reply', 'auto_edit', 'auto_subscribe', 'auto_tag',
 	\ 'beep', 'beep_new', 'bounce_delivered', 'braille_friendly',
 	\ 'browser_abbreviate_mailboxes', 'change_folder_next', 'check_mbox_size', 'check_new',
-	\ 'collapse_all', 'collapse_flagged', 'collapse_unread', 'confirmappend', 'confirmcreate',
-	\ 'crypt_autoencrypt', 'crypt_autopgp', 'crypt_autosign', 'crypt_autosmime',
-	\ 'crypt_confirmhook', 'crypt_opportunistic_encrypt',
+	\ 'collapse_all', 'collapse_flagged', 'collapse_unread', 'compose_show_user_headers',
+	\ 'confirm_append', 'confirm_create', 'copy_decode_weed', 'count_alternatives',
+	\ 'crypt_auto_encrypt', 'crypt_auto_pgp', 'crypt_auto_sign', 'crypt_auto_smime',
+	\ 'crypt_confirm_hook', 'crypt_opportunistic_encrypt',
 	\ 'crypt_opportunistic_encrypt_strong_keys', 'crypt_protected_headers_read',
-	\ 'crypt_protected_headers_save', 'crypt_protected_headers_write', 'crypt_replyencrypt',
-	\ 'crypt_replysign', 'crypt_replysignencrypted', 'crypt_timestamp', 'crypt_use_gpgme',
+	\ 'crypt_protected_headers_save', 'crypt_protected_headers_write', 'crypt_reply_encrypt',
+	\ 'crypt_reply_sign', 'crypt_reply_sign_encrypted', 'crypt_timestamp', 'crypt_use_gpgme',
 	\ 'crypt_use_pka', 'delete_untag', 'digest_collapse', 'duplicate_threads', 'edit_headers',
 	\ 'encode_from', 'fast_reply', 'fcc_before_send', 'fcc_clear', 'flag_safe', 'followup_to',
 	\ 'force_name', 'forward_decode', 'forward_decrypt', 'forward_quote', 'forward_references',
@@ -433,45 +439,52 @@ call s:boolQuadGen('Bool', [
 	\ 'history_remove_dups', 'honor_disposition', 'idn_decode', 'idn_encode',
 	\ 'ignore_list_reply_to', 'imap_check_subscribed', 'imap_condstore', 'imap_deflate',
 	\ 'imap_idle', 'imap_list_subscribed', 'imap_passive', 'imap_peek', 'imap_qresync',
-	\ 'imap_rfc5161', 'imap_servernoise', 'implicit_autoview', 'include_encrypted',
-	\ 'include_onlyfirst', 'keep_flagged', 'mailcap_sanitize', 'maildir_check_cur',
-	\ 'maildir_header_cache_verify', 'maildir_trash', 'mail_check_recent', 'mail_check_stats',
-	\ 'markers', 'mark_old', 'menu_move_off', 'menu_scroll', 'message_cache_clean', 'meta_key',
-	\ 'metoo', 'mh_purge', 'mime_forward_decode', 'mime_subject', 'mime_type_query_first',
-	\ 'narrow_tree', 'nm_record', 'nntp_listgroup', 'nntp_load_description', 'pager_stop',
-	\ 'pgp_autoinline', 'pgp_auto_decode', 'pgp_check_exit', 'pgp_check_gpg_decrypt_status_fd',
-	\ 'pgp_ignore_subkeys', 'pgp_long_ids', 'pgp_replyinline', 'pgp_retainable_sigs',
+	\ 'imap_rfc5161', 'imap_server_noise', 'implicit_autoview', 'include_encrypted',
+	\ 'include_only_first', 'keep_flagged', 'local_date_header', 'mailcap_sanitize',
+	\ 'maildir_check_cur', 'maildir_header_cache_verify', 'maildir_trash', 'mail_check_recent',
+	\ 'mail_check_stats', 'markers', 'mark_old', 'menu_move_off', 'menu_scroll',
+	\ 'message_cache_clean', 'meta_key', 'me_too', 'mh_purge', 'mime_forward_decode',
+	\ 'mime_type_query_first', 'narrow_tree', 'nm_query_window_enable', 'nm_record',
+	\ 'nntp_listgroup', 'nntp_load_description', 'pager_stop', 'pgp_auto_decode',
+	\ 'pgp_auto_inline', 'pgp_check_exit', 'pgp_check_gpg_decrypt_status_fd',
+	\ 'pgp_ignore_subkeys', 'pgp_long_ids', 'pgp_reply_inline', 'pgp_retainable_sigs',
 	\ 'pgp_self_encrypt', 'pgp_show_unusable', 'pgp_strict_enc', 'pgp_use_gpg_agent',
-	\ 'pipe_decode', 'pipe_split', 'pop_auth_try_all', 'pop_last', 'postpone_encrypt',
-	\ 'print_decode', 'print_split', 'prompt_after', 'read_only', 'reflow_space_quotes',
-	\ 'reflow_text', 'reply_self', 'reply_with_xorig', 'resolve', 'resume_draft_files',
-	\ 'resume_edited_draft_files', 'reverse_alias', 'reverse_name', 'reverse_realname',
-	\ 'rfc2047_parameters', 'save_address', 'save_empty', 'save_name', 'save_unsubscribed',
-	\ 'score', 'show_new_news', 'show_only_unread', 'sidebar_folder_indent',
-	\ 'sidebar_new_mail_only', 'sidebar_next_new_wrap', 'sidebar_non_empty_mailbox_only',
-	\ 'sidebar_on_right', 'sidebar_short_path', 'sidebar_visible', 'sig_dashes', 'sig_on_top',
-	\ 'size_show_bytes', 'size_show_fractions', 'size_show_mb', 'size_units_on_left',
-	\ 'smart_wrap', 'smime_ask_cert_label', 'smime_decrypt_use_default_key', 'smime_is_default',
-	\ 'smime_self_encrypt', 'sort_re', 'ssl_force_tls', 'ssl_usesystemcerts', 'ssl_use_sslv2',
-	\ 'ssl_use_sslv3', 'ssl_use_tlsv1', 'ssl_use_tlsv1_1', 'ssl_use_tlsv1_2', 'ssl_use_tlsv1_3',
+	\ 'pipe_decode', 'pipe_decode_weed', 'pipe_split', 'pop_auth_try_all', 'pop_last',
+	\ 'postpone_encrypt', 'print_decode', 'print_decode_weed', 'print_split', 'prompt_after',
+	\ 'read_only', 'reflow_space_quotes', 'reflow_text', 'reply_self', 'reply_with_xorig',
+	\ 'resolve', 'resume_draft_files', 'resume_edited_draft_files', 'reverse_alias',
+	\ 'reverse_name', 'reverse_real_name', 'rfc2047_parameters', 'save_address', 'save_empty',
+	\ 'save_name', 'save_unsubscribed', 'score', 'show_new_news', 'show_only_unread',
+	\ 'sidebar_folder_indent', 'sidebar_new_mail_only', 'sidebar_next_new_wrap',
+	\ 'sidebar_non_empty_mailbox_only', 'sidebar_on_right', 'sidebar_short_path',
+	\ 'sidebar_visible', 'sig_dashes', 'sig_on_top', 'size_show_bytes', 'size_show_fractions',
+	\ 'size_show_mb', 'size_units_on_left', 'smart_wrap', 'smime_ask_cert_label',
+	\ 'smime_decrypt_use_default_key', 'smime_is_default', 'smime_self_encrypt', 'sort_re',
+	\ 'ssl_force_tls', 'ssl_use_sslv2', 'ssl_use_sslv3', 'ssl_use_system_certs',
+	\ 'ssl_use_tlsv1', 'ssl_use_tlsv1_1', 'ssl_use_tlsv1_2', 'ssl_use_tlsv1_3',
 	\ 'ssl_verify_dates', 'ssl_verify_host', 'ssl_verify_partial_chains', 'status_on_top',
 	\ 'strict_threads', 'suspend', 'text_flowed', 'thorough_search', 'thread_received', 'tilde',
-	\ 'ts_enabled', 'uncollapse_jump', 'uncollapse_new', 'user_agent', 'use_8bitmime',
-	\ 'use_domain', 'use_envelope_from', 'use_from', 'use_ipv6', 'virtual_spoolfile',
-	\ 'wait_key', 'weed', 'wrap_search', 'write_bcc', 'x_comment_to'
+	\ 'ts_enabled', 'tunnel_is_secure', 'uncollapse_jump', 'uncollapse_new', 'user_agent',
+	\ 'use_8bit_mime', 'use_domain', 'use_envelope_from', 'use_from', 'use_ipv6',
+	\ 'virtual_spool_file', 'wait_key', 'weed', 'wrap_search', 'write_bcc', 'x_comment_to'
 	\ ], 0)
 
-" CHECKED 2020-06-21
+" CHECKED 2022-04-08
 " Deprecated Bools
 " List of DT_SYNONYM or DT_DEPRECATED Bools in MuttVars in mutt_config.c
 call s:boolQuadGen('Bool', [
-	\ 'edit_hdrs', 'envelope_from', 'forw_decode', 'forw_decrypt', 'forw_quote',
-	\ 'header_cache_compress', 'ignore_linear_white_space', 'pgp_autoencrypt', 'pgp_autosign',
-	\ 'pgp_auto_traditional', 'pgp_create_traditional', 'pgp_replyencrypt', 'pgp_replysign',
-	\ 'pgp_replysignencrypted', 'xterm_set_titles'
+	\ 'askbcc', 'askcc', 'autoedit', 'confirmappend', 'confirmcreate', 'crypt_autoencrypt',
+	\ 'crypt_autopgp', 'crypt_autosign', 'crypt_autosmime', 'crypt_confirmhook',
+	\ 'crypt_replyencrypt', 'crypt_replysign', 'crypt_replysignencrypted', 'edit_hdrs',
+	\ 'envelope_from', 'forw_decode', 'forw_decrypt', 'forw_quote', 'header_cache_compress',
+	\ 'ignore_linear_white_space', 'imap_servernoise', 'include_onlyfirst', 'metoo',
+	\ 'mime_subject', 'pgp_autoencrypt', 'pgp_autoinline', 'pgp_autosign',
+	\ 'pgp_auto_traditional', 'pgp_create_traditional', 'pgp_replyencrypt', 'pgp_replyinline',
+	\ 'pgp_replysign', 'pgp_replysignencrypted', 'reverse_realname', 'ssl_usesystemcerts',
+	\ 'use_8bitmime', 'virtual_spoolfile', 'xterm_set_titles'
 	\ ], 1)
 
-" CHECKED 2020-06-21
+" CHECKED 2022-04-08
 " List of DT_QUAD in MuttVars in mutt_config.c
 call s:boolQuadGen('Quad', [
 	\ 'abort_noattach', 'abort_nosubject', 'abort_unmodified', 'bounce', 'catchup_newsgroup',
@@ -481,31 +494,32 @@ call s:boolQuadGen('Quad', [
 	\ 'post_moderated', 'print', 'quit', 'recall', 'reply_to', 'ssl_starttls', 
 	\ ], 0)
 
-" CHECKED 2020-06-21
+" CHECKED 2022-04-08
 " Deprecated Quads
 " List of DT_SYNONYM or DT_DEPRECATED Quads in MuttVars in mutt_config.c
 call s:boolQuadGen('Quad', [
 	\ 'mime_fwd', 'pgp_encrypt_self', 'pgp_verify_sig', 'smime_encrypt_self'
 	\ ], 1)
 
-" CHECKED 2020-06-21
+" CHECKED 2022-04-08
 " List of DT_NUMBER or DT_LONG in MuttVars in mutt_config.c
 syntax keyword muttrcVarNum	skipwhite contained
-	\ connect_timeout debug_level header_cache_compress_level history
-	\ imap_fetch_chunk_size imap_keepalive imap_pipeline_depth imap_poll_timeout mail_check
-	\ mail_check_stats_interval menu_context net_inc nm_db_limit nm_open_timeout
-	\ nm_query_window_current_position nm_query_window_duration nntp_context nntp_poll
-	\ pager_context pager_index_lines pgp_timeout pop_checkinterval read_inc reflow_wrap
-	\ save_history score_threshold_delete score_threshold_flag score_threshold_read
-	\ search_context sendmail_wait sidebar_component_depth sidebar_width skip_quoted_offset
-	\ sleep_time smime_timeout ssl_min_dh_prime_bits timeout time_inc toggle_quoted_show_levels
-	\ wrap wrap_headers write_inc
+	\ connect_timeout debug_level header_cache_compress_level history imap_fetch_chunk_size
+	\ imap_keepalive imap_pipeline_depth imap_poll_timeout mail_check mail_check_stats_interval
+	\ menu_context net_inc nm_db_limit nm_open_timeout nm_query_window_current_position
+	\ nm_query_window_duration nntp_context nntp_poll pager_context pager_index_lines
+	\ pager_read_delay pager_skip_quoted_context pgp_timeout pop_check_interval read_inc
+	\ reflow_wrap save_history score_threshold_delete score_threshold_flag score_threshold_read
+	\ search_context sendmail_wait sidebar_component_depth sidebar_width sleep_time
+	\ smime_timeout ssl_min_dh_prime_bits timeout time_inc toggle_quoted_show_levels wrap
+	\ wrap_headers write_inc
 	\ nextgroup=muttrcSetNumAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
+" CHECKED 2022-04-08
+" Deprecated Numbers
 syntax keyword muttrcVarDeprecatedNum	contained skipwhite
-	\ header_cache_pagesize wrapmargin
-	\ nextgroup=muttrcSetNumAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
+	\ header_cache_pagesize pop_checkinterval skip_quoted_offset
 
-" CHECKED 2020-06-21
+" CHECKED 2022-04-08
 " List of DT_STRING in MuttVars in mutt_config.c
 " Special cases first, and all the rest at the end
 " Formats themselves must be updated in their respective groups
@@ -517,19 +531,19 @@ syntax keyword muttrcVarStr	contained skipwhite compose_format nextgroup=muttrcV
 syntax keyword muttrcVarStr	contained skipwhite folder_format vfolder_format nextgroup=muttrcVarEqualsFolderFmt
 syntax keyword muttrcVarStr	contained skipwhite attribution forward_format index_format message_format pager_format nextgroup=muttrcVarEqualsIdxFmt
 syntax keyword muttrcVarStr	contained skipwhite mix_entry_format nextgroup=muttrcVarEqualsMixFmt
+syntax keyword muttrcVarStr	contained skipwhite pattern_format nextgroup=muttrcVarEqualsPatternFmt
 syntax keyword muttrcVarStr	contained skipwhite
-	\ pgp_clearsign_command pgp_decode_command pgp_decrypt_command
-	\ pgp_encrypt_only_command pgp_encrypt_sign_command pgp_export_command pgp_getkeys_command
-	\ pgp_import_command pgp_list_pubring_command pgp_list_secring_command
-	\ pgp_sign_command pgp_verify_command pgp_verify_key_command
+	\ pgp_clear_sign_command pgp_decode_command pgp_decrypt_command pgp_encrypt_only_command
+	\ pgp_encrypt_sign_command pgp_export_command pgp_get_keys_command pgp_import_command
+	\ pgp_list_pubring_command pgp_list_secring_command pgp_sign_command pgp_verify_command
+	\ pgp_verify_key_command
 	\ nextgroup=muttrcVarEqualsPGPCmdFmt
 syntax keyword muttrcVarStr	contained skipwhite pgp_entry_format nextgroup=muttrcVarEqualsPGPFmt
 syntax keyword muttrcVarStr	contained skipwhite query_format nextgroup=muttrcVarEqualsQueryFmt
 syntax keyword muttrcVarStr	contained skipwhite
 	\ smime_decrypt_command smime_encrypt_command smime_get_cert_command
-	\ smime_get_cert_email_command smime_get_signer_cert_command
-	\ smime_import_cert_command smime_pk7out_command smime_sign_command
-	\ smime_verify_command smime_verify_opaque_command
+	\ smime_get_cert_email_command smime_get_signer_cert_command smime_import_cert_command
+	\ smime_pk7out_command smime_sign_command smime_verify_command smime_verify_opaque_command
 	\ nextgroup=muttrcVarEqualsSmimeFmt
 syntax keyword muttrcVarStr	contained skipwhite status_format ts_icon_format ts_status_format nextgroup=muttrcVarEqualsStatusFmt
 syntax keyword muttrcVarStr	contained skipwhite date_format nextgroup=muttrcVarEqualsStrftimeFmt
@@ -538,64 +552,66 @@ syntax keyword muttrcVarStr	contained skipwhite sidebar_format nextgroup=muttrcV
 syntax keyword muttrcVarStr	contained skipwhite
 	\ abort_key arrow_string assumed_charset attach_charset attach_sep attribution_locale
 	\ autocrypt_acct_format charset config_charset content_type crypt_protected_headers_subject
-	\ default_hook dsn_notify dsn_return empty_subject escape forward_attribution_intro
-	\ forward_attribution_trailer header_cache_backend header_cache_compress_method hidden_tags
-	\ hostname imap_authenticators imap_delim_chars imap_headers imap_login imap_pass imap_user
-	\ indent_string mailcap_path mark_macro_prefix mh_seq_flagged mh_seq_replied mh_seq_unseen
-	\ newsgroups_charset news_server nm_default_url nm_exclude_tags nm_flagged_tag nm_query_type
-	\ nm_query_window_current_search nm_query_window_timebase nm_record_tags nm_replied_tag
-	\ nm_unread_tag nntp_authenticators nntp_pass nntp_user pgp_default_key pgp_sign_as pipe_sep
-	\ pop_authenticators pop_host pop_pass pop_user postpone_encrypt_as post_indent_string
-	\ preconnect preferred_languages realname send_charset show_multipart_alternative
-	\ sidebar_delim_chars sidebar_divider_char sidebar_indent_string simple_search
-	\ smime_default_key smime_encrypt_with smime_sign_as smime_sign_digest_alg
-	\ smtp_authenticators smtp_pass smtp_url smtp_user spam_separator ssl_ciphers
+	\ default_hook dsn_notify dsn_return empty_subject forward_attribution_intro
+	\ forward_attribution_trailer greeting header_cache_backend header_cache_compress_method
+	\ hidden_tags hostname imap_authenticators imap_delim_chars imap_headers imap_login
+	\ imap_pass imap_user indent_string mailcap_path mark_macro_prefix mh_seq_flagged
+	\ mh_seq_replied mh_seq_unseen newsgroups_charset news_server nm_default_url nm_exclude_tags
+	\ nm_flagged_tag nm_query_type nm_query_window_current_search nm_query_window_or_terms
+	\ nm_query_window_timebase nm_record_tags nm_replied_tag nm_unread_tag nntp_authenticators
+	\ nntp_pass nntp_user pgp_default_key pgp_sign_as pipe_sep pop_authenticators pop_host
+	\ pop_pass pop_user postpone_encrypt_as post_indent_string preconnect preferred_languages
+	\ real_name send_charset show_multipart_alternative sidebar_delim_chars sidebar_divider_char
+	\ sidebar_indent_string simple_search smime_default_key smime_encrypt_with smime_sign_as
+	\ smime_sign_digest_alg smtp_authenticators smtp_pass smtp_url smtp_user spam_separator
+	\ ssl_ciphers
 	\ nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
 " Deprecated strings
 syntax keyword muttrcVarDeprecatedStr
-	\ abort_noattach_regexp attach_keyword forw_format hdr_format indent_str msg_format
-	\ nm_default_uri pgp_self_encrypt_as post_indent_str print_cmd quote_regexp reply_regexp
-	\ smime_self_encrypt_as xterm_icon xterm_title
+	\ abort_noattach_regexp attach_keyword escape forw_format hdr_format indent_str msg_format
+	\ nm_default_uri pgp_clearsign_command pgp_getkeys_command pgp_self_encrypt_as
+	\ post_indent_str print_cmd quote_regexp realname reply_regexp smime_self_encrypt_as
+	\ spoolfile visual xterm_icon xterm_title
 
-" CHECKED 2020-06-21
+" CHECKED 2022-04-08
 " List of DT_ADDRESS
 syntax keyword muttrcVarStr	contained skipwhite envelope_from_address from nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 " List of DT_ENUM
-syntax keyword muttrcVarStr	contained skipwhite mbox_type nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
+syntax keyword muttrcVarStr	contained skipwhite mbox_type use_threads nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 " List of DT_MBTABLE
 syntax keyword muttrcVarStr	contained skipwhite crypt_chars flag_chars from_chars status_chars to_chars nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
-" CHECKED 2020-06-21
-" List of DT_PATH
+" CHECKED 2022-04-08
+" List of DT_PATH or DT_MAILBOX
 syntax keyword muttrcVarStr	contained skipwhite
 	\ alias_file attach_save_dir autocrypt_dir certificate_file debug_file
 	\ entropy_file folder header_cache history_file mbox message_cachedir newsrc
 	\ news_cache_dir postponed record signature smime_ca_location
-	\ smime_certificates smime_keys spoolfile ssl_ca_certificates_file
-	\ ssl_client_cert tmpdir trash
+	\ smime_certificates smime_keys spool_file ssl_ca_certificates_file ssl_client_cert
+	\ tmpdir trash
 	\ nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 " List of DT_COMMAND (excluding pgp_*_command and smime_*_command)
 syntax keyword muttrcVarStr	contained skipwhite
 	\ display_filter editor inews ispell mixmaster new_mail_command pager
-	\ print_command query_command sendmail shell visual external_search_command
+	\ print_command query_command sendmail shell external_search_command
 	\ imap_oauth_refresh_command pop_oauth_refresh_command
 	\ mime_type_query_command smtp_oauth_refresh_command tunnel
 	\ nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
-" CHECKED 2020-06-21
+" CHECKED 2022-04-08
 " List of DT_REGEX
 syntax keyword muttrcVarStr	contained skipwhite
-	\ abort_noattach_regex gecos_mask mask pgp_decryption_okay pgp_good_sign
-	\ quote_regex reply_regex smileys
+	\ abort_noattach_regex gecos_mask mask pgp_decryption_okay pgp_good_sign quote_regex 
+	\ reply_regex smileys
 	\ nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 " List of DT_SORT
 syntax keyword muttrcVarStr	contained skipwhite
 	\ pgp_sort_keys sidebar_sort_method sort sort_alias sort_aux sort_browser
 	\ nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
-" CHECKED 2020-06-21
-" List of commands in Commands in mutt_config.c
+" CHECKED 2022-04-08
+" List of commands in mutt_commands in mutt_commands.c
 " Remember to remove hooks, they have already been dealt with
 syntax keyword muttrcCommand	skipwhite alias nextgroup=muttrcAliasGroupDef,muttrcAliasKey,muttrcAliasNL
 syntax keyword muttrcCommand	skipwhite bind nextgroup=muttrcBindMenuList,muttrcBindMenuListNL
@@ -607,14 +623,12 @@ syntax keyword muttrcCommand	skipwhite spam nextgroup=muttrcSpamPattern
 syntax keyword muttrcCommand	skipwhite unalias nextgroup=muttrcUnAliasKey,muttrcUnAliasNL
 syntax keyword muttrcCommand	skipwhite unhook nextgroup=muttrcHooks
 syntax keyword muttrcCommand	skipwhite
-	\ alternative_order attachments auto_view finish hdr_order ifdef ifndef
-	\ ignore lua lua-source mailboxes mailto_allow mime_lookup my_hdr push score
-	\ setenv sidebar_whitelist source subjectrx subscribe-to tag-formats
-	\ tag-transforms unalternative_order unattachments unauto_view uncolor
-	\ unhdr_order unignore unmailboxes unmailto_allow unmime_lookup unmono
-	\ unmy_hdr unscore unsetenv unsidebar_whitelist unsubjectrx unsubscribe-from
-	\ unvirtual-mailboxes virtual-mailboxes named-mailboxes
-	\ echo unbind unmacro
+	\ alternative_order attachments auto_view cd echo finish hdr_order ifdef ifndef ignore lua
+	\ lua-source mailboxes mailto_allow mime_lookup my_hdr named-mailboxes push score setenv
+	\ sidebar_whitelist source subjectrx subscribe-to tag-formats tag-transforms
+	\ unalternative_order unattachments unauto_view unbind uncolor unhdr_order unignore unmacro
+	\ unmailboxes unmailto_allow unmime_lookup unmono unmy_hdr unscore unsetenv
+	\ unsidebar_whitelist unsubjectrx unsubscribe-from unvirtual-mailboxes virtual-mailboxes
 
 function! s:genFunctions(functions)
 	for f in a:functions
@@ -622,66 +636,68 @@ function! s:genFunctions(functions)
 	endfor
 endfunction
 
-" CHECKED 2020-06-21
+" CHECKED 2022-04-08
 " List of functions in functions.c
 " Note: 'noop' is included but is elsewhere in the source
 call s:genFunctions(['noop',
-	\ 'accept', 'append', 'attach-file', 'attach-key', 'attach-message', 'attach-news-message',
-	\ 'autocrypt-acct-menu', 'autocrypt-menu', 'backspace', 'backward-char', 'backward-word',
-	\ 'bol', 'bottom-page', 'bottom', 'bounce-message', 'break-thread', 'buffy-cycle',
-	\ 'buffy-list', 'capitalize-word', 'catchup', 'chain-next', 'chain-prev', 'change-dir',
-	\ 'change-folder-readonly', 'change-folder', 'change-newsgroup-readonly',
-	\ 'change-newsgroup', 'change-vfolder', 'check-new', 'check-stats',
+	\ 'accept', 'alias-dialog', 'append', 'attach-file', 'attach-key', 'attach-message',
+	\ 'attach-news-message', 'autocrypt-acct-menu', 'autocrypt-menu', 'backspace',
+	\ 'backward-char', 'backward-word', 'bol', 'bottom', 'bottom-page', 'bounce-message',
+	\ 'break-thread', 'buffy-cycle', 'buffy-list', 'capitalize-word', 'catchup', 'chain-next',
+	\ 'chain-prev', 'change-dir', 'change-folder', 'change-folder-readonly', 'change-newsgroup',
+	\ 'change-newsgroup-readonly', 'change-vfolder', 'check-new', 'check-stats',
 	\ 'check-traditional-pgp', 'clear-flag', 'collapse-all', 'collapse-parts',
-	\ 'collapse-thread', 'complete-query', 'complete', 'compose-to-sender', 'copy-file',
+	\ 'collapse-thread', 'complete', 'complete-query', 'compose-to-sender', 'copy-file',
 	\ 'copy-message', 'create-account', 'create-alias', 'create-mailbox', 'current-bottom',
 	\ 'current-middle', 'current-top', 'decode-copy', 'decode-save', 'decrypt-copy',
-	\ 'decrypt-save', 'delete-account', 'delete-char', 'delete-entry', 'delete-mailbox',
-	\ 'delete-message', 'delete-pattern', 'delete-subthread', 'delete-thread', 'delete',
+	\ 'decrypt-save', 'delete', 'delete-account', 'delete-char', 'delete-entry',
+	\ 'delete-mailbox', 'delete-message', 'delete-pattern', 'delete-subthread', 'delete-thread',
 	\ 'descend-directory', 'detach-file', 'display-address', 'display-filename',
-	\ 'display-message', 'display-toggle-weed', 'downcase-word', 'edit-bcc', 'edit-cc',
-	\ 'edit-description', 'edit-encoding', 'edit-fcc', 'edit-file', 'edit-followup-to',
-	\ 'edit-from', 'edit-headers', 'edit-label', 'edit-language', 'edit-message', 'edit-mime',
-	\ 'edit-newsgroups', 'edit-or-view-raw-message', 'edit-raw-message', 'edit-reply-to',
-	\ 'edit-subject', 'edit-to', 'edit-type', 'edit-x-comment-to', 'edit', 'end-cond',
-	\ 'enter-command', 'enter-mask', 'entire-thread', 'eol', 'exit', 'extract-keys',
-	\ 'fetch-mail', 'filter-entry', 'first-entry', 'flag-message', 'followup-message',
-	\ 'forget-passphrase', 'forward-char', 'forward-message', 'forward-to-group',
-	\ 'forward-word', 'get-attachment', 'get-children', 'get-message', 'get-parent',
-	\ 'goto-folder', 'goto-parent', 'group-alternatives', 'group-chat-reply',
-	\ 'group-multilingual', 'group-reply', 'half-down', 'half-up', 'help', 'history-down',
-	\ 'history-search', 'history-up', 'imap-fetch-mail', 'imap-logout-all', 'insert', 'ispell',
-	\ 'jump', 'kill-eol', 'kill-eow', 'kill-line', 'kill-word', 'last-entry',
-	\ 'limit-current-thread', 'limit', 'link-threads', 'list-reply', 'mail-key',
-	\ 'mailbox-cycle', 'mailbox-list', 'mail', 'mark-as-new', 'mark-message', 'middle-page',
-	\ 'mix', 'modify-labels-then-hide', 'modify-labels', 'modify-tags-then-hide',
-	\ 'modify-tags', 'move-down', 'move-up', 'new-mime', 'next-entry', 'next-line',
-	\ 'next-new-then-unread', 'next-new', 'next-page', 'next-subthread', 'next-thread',
-	\ 'next-undeleted', 'next-unread-mailbox', 'next-unread', 'parent-message', 'pgp-menu',
-	\ 'pipe-entry', 'pipe-message', 'post-message', 'postpone-message', 'previous-entry',
-	\ 'previous-line', 'previous-new-then-unread', 'previous-new', 'previous-page',
-	\ 'previous-subthread', 'previous-thread', 'previous-undeleted', 'previous-unread',
-	\ 'print-entry', 'print-message', 'purge-message', 'purge-thread', 'quasi-delete',
-	\ 'query-append', 'query', 'quit', 'quote-char', 'read-subthread', 'read-thread',
-	\ 'recall-message', 'reconstruct-thread', 'redraw-screen', 'refresh', 'reload-active',
-	\ 'rename-attachment', 'rename-file', 'rename-mailbox', 'reply', 'resend-message',
-	\ 'root-message', 'save-entry', 'save-message', 'search-next', 'search-opposite',
-	\ 'search-reverse', 'search-toggle', 'search', 'select-entry', 'select-new',
+	\ 'display-message', 'display-toggle-weed', 'downcase-word', 'edit', 'edit-bcc', 'edit-cc',
+	\ 'edit-content-id', 'edit-description', 'edit-encoding', 'edit-fcc', 'edit-file',
+	\ 'edit-followup-to', 'edit-from', 'edit-headers', 'edit-label', 'edit-language',
+	\ 'edit-message', 'edit-mime', 'edit-newsgroups', 'edit-or-view-raw-message',
+	\ 'edit-raw-message', 'edit-reply-to', 'edit-subject', 'edit-to', 'edit-type',
+	\ 'edit-x-comment-to', 'end-cond', 'enter-command', 'enter-mask', 'entire-thread', 'eol',
+	\ 'error-history', 'exit', 'extract-keys', 'fetch-mail', 'filter-entry', 'first-entry',
+	\ 'flag-message', 'followup-message', 'forget-passphrase', 'forward-char',
+	\ 'forward-message', 'forward-to-group', 'forward-word', 'get-attachment', 'get-children',
+	\ 'get-message', 'get-parent', 'goto-folder', 'goto-parent', 'group-alternatives',
+	\ 'group-chat-reply', 'group-multilingual', 'group-related', 'group-reply', 'half-down',
+	\ 'half-up', 'help', 'history-down', 'history-search', 'history-up', 'imap-fetch-mail',
+	\ 'imap-logout-all', 'insert', 'ispell', 'jump', 'kill-eol', 'kill-eow', 'kill-line',
+	\ 'kill-word', 'last-entry', 'limit', 'limit-current-thread', 'link-threads', 'list-reply',
+	\ 'list-subscribe', 'list-unsubscribe', 'mail', 'mail-key', 'mailbox-cycle', 'mailbox-list',
+	\ 'mark-as-new', 'mark-message', 'middle-page', 'mix', 'modify-labels',
+	\ 'modify-labels-then-hide', 'modify-tags', 'modify-tags-then-hide', 'move-down', 'move-up',
+	\ 'new-mime', 'next-entry', 'next-line', 'next-new', 'next-new-then-unread', 'next-page',
+	\ 'next-subthread', 'next-thread', 'next-undeleted', 'next-unread', 'next-unread-mailbox',
+	\ 'parent-message', 'pgp-menu', 'pipe-entry', 'pipe-message', 'post-message',
+	\ 'postpone-message', 'previous-entry', 'previous-line', 'previous-new',
+	\ 'previous-new-then-unread', 'previous-page', 'previous-subthread', 'previous-thread',
+	\ 'previous-undeleted', 'previous-unread', 'print-entry', 'print-message', 'purge-message',
+	\ 'purge-thread', 'quasi-delete', 'query', 'query-append', 'quit', 'quote-char',
+	\ 'read-subthread', 'read-thread', 'recall-message', 'reconstruct-thread', 'redraw-screen',
+	\ 'refresh', 'reload-active', 'rename-attachment', 'rename-file', 'rename-mailbox', 'reply',
+	\ 'resend-message', 'root-message', 'save-entry', 'save-message', 'search', 'search-next',
+	\ 'search-opposite', 'search-reverse', 'search-toggle', 'select-entry', 'select-new',
 	\ 'send-message', 'set-flag', 'shell-escape', 'show-limit', 'show-log-messages',
-	\ 'show-version', 'sidebar-next-new', 'sidebar-first', 'sidebar-last', 'sidebar-next',
-	\ 'sidebar-open', 'sidebar-page-down', 'sidebar-page-up', 'sidebar-prev-new',
-	\ 'sidebar-prev', 'sidebar-toggle-virtual', 'sidebar-toggle-visible', 'skip-quoted',
-	\ 'smime-menu', 'sort-mailbox', 'sort-reverse', 'sort', 'subscribe-pattern',
-	\ 'sync-mailbox', 'tag-entry', 'tag-message', 'tag-pattern', 'tag-prefix-cond',
-	\ 'tag-prefix', 'tag-subthread', 'tag-thread', 'toggle-active', 'toggle-disposition',
-	\ 'toggle-mailboxes', 'toggle-new', 'toggle-prefer-encrypt', 'toggle-quoted',
-	\ 'toggle-read', 'toggle-recode', 'toggle-subscribed', 'toggle-unlink', 'toggle-write',
-	\ 'top-page', 'top', 'transpose-chars', 'uncatchup', 'undelete-entry', 'undelete-message',
-	\ 'undelete-pattern', 'undelete-subthread', 'undelete-thread', 'unsubscribe-pattern',
-	\ 'untag-pattern', 'upcase-word', 'update-encoding', 'verify-key',
-	\ 'vfolder-from-query-readonly', 'vfolder-from-query', 'vfolder-window-backward',
-	\ 'vfolder-window-forward', 'view-attachments', 'view-attach', 'view-file', 'view-mailcap',
-	\ 'view-name', 'view-raw-message', 'view-text', 'what-key', 'write-fcc'
+	\ 'show-version', 'sidebar-first', 'sidebar-last', 'sidebar-next', 'sidebar-next-new',
+	\ 'sidebar-open', 'sidebar-page-down', 'sidebar-page-up', 'sidebar-prev',
+	\ 'sidebar-prev-new', 'sidebar-toggle-virtual', 'sidebar-toggle-visible', 'skip-headers',
+	\ 'skip-quoted', 'smime-menu', 'sort', 'sort-alias', 'sort-alias-reverse', 'sort-mailbox',
+	\ 'sort-reverse', 'subscribe', 'subscribe-pattern', 'sync-mailbox', 'tag-entry',
+	\ 'tag-message', 'tag-pattern', 'tag-prefix', 'tag-prefix-cond', 'tag-subthread',
+	\ 'tag-thread', 'toggle-active', 'toggle-disposition', 'toggle-mailboxes', 'toggle-new',
+	\ 'toggle-prefer-encrypt', 'toggle-quoted', 'toggle-read', 'toggle-recode',
+	\ 'toggle-subscribed', 'toggle-unlink', 'toggle-write', 'top', 'top-page',
+	\ 'transpose-chars', 'uncatchup', 'undelete-entry', 'undelete-message', 'undelete-pattern',
+	\ 'undelete-subthread', 'undelete-thread', 'ungroup-attachment', 'unsubscribe',
+	\ 'unsubscribe-pattern', 'untag-pattern', 'upcase-word', 'update-encoding', 'verify-key',
+	\ 'vfolder-from-query', 'vfolder-from-query-readonly', 'vfolder-window-backward',
+	\ 'vfolder-window-forward', 'vfolder-window-reset', 'view-attach', 'view-attachments',
+	\ 'view-file', 'view-mailcap', 'view-name', 'view-pager', 'view-raw-message', 'view-text',
+	\ 'what-key', 'write-fcc'
 	\ ])
 
 " Define the default highlighting.
@@ -758,6 +774,7 @@ highlight def link muttrcFolderFormatEscapes		muttrcEscape
 highlight def link muttrcGroupIndexFormatEscapes	muttrcEscape
 highlight def link muttrcIndexFormatEscapes		muttrcEscape
 highlight def link muttrcMixFormatEscapes		muttrcEscape
+highlight def link muttrcPatternFormatEscapes		muttrcEscape
 highlight def link muttrcPGPCmdFormatEscapes		muttrcEscape
 highlight def link muttrcPGPFormatEscapes		muttrcEscape
 highlight def link muttrcPGPTimeEscapes			muttrcEscape
@@ -774,6 +791,7 @@ highlight def link muttrcComposeFormatConditionals	muttrcFormatConditionals2
 highlight def link muttrcFolderFormatConditionals	muttrcFormatConditionals2
 highlight def link muttrcIndexFormatConditionals	muttrcFormatConditionals2
 highlight def link muttrcMixFormatConditionals		muttrcFormatConditionals2
+highlight def link muttrcPatternFormatConditionals	muttrcFormatConditionals2
 highlight def link muttrcPGPCmdFormatConditionals	muttrcFormatConditionals2
 highlight def link muttrcPGPFormatConditionals		muttrcFormatConditionals2
 highlight def link muttrcSmimeFormatConditionals	muttrcFormatConditionals2
@@ -789,6 +807,7 @@ highlight def link muttrcFolderFormatStr		muttrcString
 highlight def link muttrcGroupIndexFormatStr            muttrcString
 highlight def link muttrcIndexFormatStr			muttrcString
 highlight def link muttrcMixFormatStr			muttrcString
+highlight def link muttrcPatternFormatStr		muttrcString
 highlight def link muttrcPGPCmdFormatStr		muttrcString
 highlight def link muttrcPGPFormatStr			muttrcString
 highlight def link muttrcQueryFormatStr			muttrcString


### PR DESCRIPTION
Update the config file syntax for the [NeoMutt email client](https://github.com/neomutt/neomutt).
This updates the syntax for [release 2022-04-08](https://github.com/neomutt/neomutt/releases/tag/20220408).

Low urgency :-)

Thanks