### PR TITLE
TermDebug: Error message displayed when closing the gdb window

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -668,7 +668,9 @@ func s:EndDebugCommon()
       endif
     endif
   endfor
-  exe was_buf .. "buf"
+  if bufexists(was_buf)
+    exe was_buf .. "buf"
+  endif
 
   call s:DeleteCommands()
 


### PR DESCRIPTION

The following sequence of commands produce the "E86: Buffer 4 does not exist" error
when closing the GDB window opened by the TermDebug plugin:

:Termdebug
:wincmd b
:close
:wincmd t
(gdb) quit

When the last command is executed, the following error message is displayed:

Error detected while processing function <SNR>16_EndTermDebug[4]..<SNR>16_EndDebugCommon:
line   19:
E86: Buffer 4 does not exist
