### PR TITLE
Small cleanup in ModeChanged trigger

### DIFF
--- a/src/proto/misc1.pro
+++ b/src/proto/misc1.pro
@@ -14,6 +14,7 @@ void pchar_cursor(int c);
 char_u *skip_to_option_part(char_u *p);
 void check_status(buf_T *buf);
 int ask_yesno(char_u *str, int direct);
+char_u *get_mode(char_u *buf);
 void f_mode(typval_T *argvars, typval_T *rettv);
 void f_state(typval_T *argvars, typval_T *rettv);
 int get_keystroke(void);


### PR DESCRIPTION
Avoid many small allocations every time a `ModeChanged` event is emitted.
No functional changes are expected.

Side note, perhaps `trigger_modechanged` should be renamed into `may_trigger_modechanged`.