### PR TITLE
Fix expansion of <script> in autocmd contexts

### DIFF
--- a/src/proto/autocmd.pro
+++ b/src/proto/autocmd.pro
@@ -1,6 +1,7 @@
 /* autocmd.c */
 void aubuflocal_remove(buf_T *buf);
 int au_has_group(char_u *name);
+sctx_T *acp_script_ctx(AutoPatCmd *acp);
 void do_augroup(char_u *arg, int del_group);
 void free_all_autocmds(void);
 int check_ei(void);

--- a/src/testdir/test_expand.vim
+++ b/src/testdir/test_expand.vim
@@ -169,43 +169,52 @@ endfunc
 
 func Test_expand_script_source()
   let lines0 =<< trim [SCRIPT]
-    let g:script_level[0] = expand('<script>:t')
+    call extend(g:script_level, [expand('<script>:t')])
     so Xscript1
     func F0()
-      let g:func_level[0] = expand('<script>:t')
+      call extend(g:func_level, [expand('<script>:t')])
     endfunc
+
+    au User * call extend(g:au_level, [expand('<script>:t')])
   [SCRIPT]
 
   let lines1 =<< trim [SCRIPT]
-    let g:script_level[1] = expand('<script>:t')
+    call extend(g:script_level, [expand('<script>:t')])
     so Xscript2
     func F1()
-      let g:func_level[1] = expand('<script>:t')
+      call extend(g:func_level, [expand('<script>:t')])
     endfunc
+
+    au User * call extend(g:au_level, [expand('<script>:t')])
   [SCRIPT]
 
   let lines2 =<< trim [SCRIPT]
-    let g:script_level[2] = expand('<script>:t')
+    call extend(g:script_level, [expand('<script>:t')])
     func F2()
-      let g:func_level[2] = expand('<script>:t')
+      call extend(g:func_level, [expand('<script>:t')])
     endfunc
+
+    au User * call extend(g:au_level, [expand('<script>:t')])
   [SCRIPT]
 
   call writefile(lines0, 'Xscript0')
   call writefile(lines1, 'Xscript1')
   call writefile(lines2, 'Xscript2')
 
-  " Check the expansion of <script> at script and function level.
-  let g:script_level = ['', '', '']
-  let g:func_level = ['', '', '']
+  " Check the expansion of <script> at different levels.
+  let g:script_level = []
+  let g:func_level = []
+  let g:au_level = []
 
   so Xscript0
   call F0()
   call F1()
   call F2()
+  doautocmd User
 
   call assert_equal(['Xscript0', 'Xscript1', 'Xscript2'], g:script_level)
   call assert_equal(['Xscript0', 'Xscript1', 'Xscript2'], g:func_level)
+  call assert_equal(['Xscript2', 'Xscript1', 'Xscript0'], g:au_level)
 
   unlet g:script_level g:func_level
   delfunc F0


### PR DESCRIPTION
- Populate es_info for ETYPE_AUCMD callstack entries.
- Keep track of the script context where the autocmd is defined.
- Let `estack_sfile` expand `<script>` everywhere instead of relying on
  early replacement hooks such as `expand_sfile`.

cc @lacygoill, this patch fixes the problem you noticed in a earlier PR.