### PR TITLE
Modify pos instead of *pp when getting mark character position

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -5661,9 +5661,10 @@ var2fpos(
 	pp = getmark_buf_fnum(curbuf, name[1], FALSE, fnum);
 	if (pp == NULL || pp == (pos_T *)-1 || pp->lnum <= 0)
 	    return NULL;
+	pos = *pp;
 	if (charcol)
-	    pp->col = buf_byteidx_to_charidx(curbuf, pp->lnum, pp->col);
-	return pp;
+	    pos.col = buf_byteidx_to_charidx(curbuf, pos.lnum, pos.col);
+	return &pos;
     }
 
     pos.coladd = 0;

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -204,6 +204,8 @@ func Test_getcharpos()
   " Test for a mark
   normal 2G7lmmgg
   call assert_equal([0, 2, 8, 0], getcharpos("'m"))
+  " Getting the mark again should return the same value
+  call assert_equal([0, 2, 8, 0], getcharpos("'m"))
   delmarks m
   call assert_equal([0, 0, 0, 0], getcharpos("'m"))
 


### PR DESCRIPTION
Fix #10148
