### PR TITLE
Fix cygwin GUI-Motif build

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -84,6 +84,11 @@
 #  define WIN32_LEAN_AND_MEAN
 # endif
 # if defined(FEAT_GUI) || defined(FEAT_XCLIPBOARD)
+#  ifdef __CYGWIN__
+    // ControlMask from <X11/X.h> (included in "vim.h") is conflicting with
+    // <w32api/windows.h> (included in <X11/Xwindows.h>).
+#   undef ControlMask
+#  endif
 #  include <X11/Xwindows.h>
 #  define WINBYTE wBYTE
 # else


### PR DESCRIPTION
`ControlMask` from `<X11/X.h>` (included in `"vim.h"`) is conflicting with `<w32api/processthreadsapi.h>` (through `<X11/Xwindows.h>`, then `<w32api/windows.h>`).
As `ControlMask` is not used in `mbyte.c`, simply undef `ControlMask` before including `<X11/Xwindows.h>` so that `<w32api/processthreadsapi.h>` can be compiled.