### PR TITLE
Add g:filetype_sys for consistency

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -797,7 +797,9 @@ export def FTperl(): number
 enddef
 
 export def FTsys()
-  if IsRapid()
+  if exists("g:filetype_sys")
+    exe "setf " .. g:filetype_sys
+  elseif IsRapid()
     setf rapid
   else
     setf bat

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -155,6 +155,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.pp		g:filetype_pp	|ft-pascal-syntax|
 	*.prg		g:filetype_prg
 	*.src		g:filetype_src
+	*.sys		g:filetype_sys
 	*.sh		g:bash_is_sh	|ft-sh-syntax|
 	*.tex		g:tex_flavor	|ft-tex-plugin|
 	*.w		g:filetype_w	|ft-cweb-syntax|

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1540,6 +1540,13 @@ func Test_sys_file()
   call assert_equal('bat', &filetype)
   bwipe!
 
+  " Users preference set by g:filetype_sys
+  let g:filetype_sys = 'sys'
+  split sysfile.sys
+  call assert_equal('sys', &filetype)
+  unlet g:filetype_sys
+  bwipe!
+
   " RAPID header start with a line containing only "%%%", 
   " but is not always present.
   call writefile(['%%%'], 'sysfile.sys')


### PR DESCRIPTION
If we want all RAPID files to have a filetype overrule variable, then
g:filetype_sys is still missing.

On the other hand, I think g:filetype_cfg and g:filetype_sys are not
necessary, the pattern for RAPID cfg files is pretty distinct. Same for
*.sys files. There will be no MSDOS Batch file which is false positively
caught by the RAPID pattern.