### PR TITLE
Add support for the GDB 'until' command to the termdebug plugin

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1285,6 +1285,8 @@ Put focus on the gdb window to type commands there.  Some common ones are:
 - next		execute the current line and stop at the next line
 - step		execute the current line and stop at the next statement,
 		entering functions
+- until		execute until past the current cursor line or past a specified
+		position or the current stack frame returns
 - finish	execute until leaving the current function
 - where		show the stack
 - frame N	go to the Nth stack frame
@@ -1303,6 +1305,7 @@ gdb:
 
  *:Step*	execute the gdb "step" command
  *:Over*	execute the gdb "next" command (`:Next` is a Vim command)
+ *:Until*	execute the gdb "until" command
  *:Finish*	execute the gdb "finish" command
  *:Continue*	execute the gdb "continue" command
  *:Stop*	interrupt the program

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -151,7 +151,6 @@ Terminal debugger:
 - Add option to not open the program window.  It's not used when attaching to
   an already running program. (M. Kelly)
 - When only gdb window exists, on "quit" edit another buffer.
-- Use a sign group
 - Termdebug does not work when Vim was built with mzscheme: gdb hangs just
   after "run".  Everything else works, including communication channel.  Not
   initializing mzscheme avoid the problem, thus it's not some #ifdef.


### PR DESCRIPTION
Add support for the GDB ":until" command. Use a separate group for the TermDebug signs.
Use the sign_xxx() functions instead of the `:sign` command to manage the TermDebug signs.