### PR TITLE
Add limit for matchfuzzy()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5602,6 +5602,9 @@ matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 		empty list is returned. If length of {str} is greater than
 		256, then returns an empty list.
 
+		When {limit} is given, matchfuzzy() will return the best match
+		within this limit.
+
 		Refer to |fuzzy-matching| for more information about fuzzy
 		matching strings.
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -351,7 +351,7 @@ matcharg({nr})			List	arguments of |:match|
 matchdelete({id} [, {win}])	Number	delete match identified by {id}
 matchend({expr}, {pat} [, {start} [, {count}]])
 				Number	position where {pat} ends in {expr}
-matchfuzzy({list}, {str} [, {dict}, {limit}])
+matchfuzzy({list}, {str} [, {dict}])
 				List	fuzzy match {str} in {list}
 matchfuzzypos({list}, {str} [, {dict}])
 				List	fuzzy match {str} in {list}
@@ -5567,7 +5567,7 @@ matchend({expr}, {pat} [, {start} [, {count}]])			*matchend()*
 			GetText()->matchend('word')
 
 
-matchfuzzy({list}, {str} [, {dict}, {limit}])		*matchfuzzy()*
+matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 		If {list} is a list of strings, then returns a |List| with all
 		the strings in {list} that fuzzy match {str}. The strings in
 		the returned list are sorted based on the matching score.
@@ -5589,6 +5589,7 @@ matchfuzzy({list}, {str} [, {dict}, {limit}])		*matchfuzzy()*
 				This should accept a dictionary item as the
 				argument and return the text for that item to
 				use for fuzzy matching.
+		    limit	the maximum number of list to be matched.
 
 		{str} is treated as a literal string and regular expression
 		matching is NOT supported.  The maximum supported {str} length
@@ -5600,9 +5601,6 @@ matchfuzzy({list}, {str} [, {dict}, {limit}])		*matchfuzzy()*
 		If there are no matching strings or there is an error, then an
 		empty list is returned. If length of {str} is greater than
 		256, then returns an empty list.
-
-		When {limit} is given this specifies the maximum number of
-		list to be matched.
 
 		Refer to |fuzzy-matching| for more information about fuzzy
 		matching strings.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -351,7 +351,7 @@ matcharg({nr})			List	arguments of |:match|
 matchdelete({id} [, {win}])	Number	delete match identified by {id}
 matchend({expr}, {pat} [, {start} [, {count}]])
 				Number	position where {pat} ends in {expr}
-matchfuzzy({list}, {str} [, {dict}])
+matchfuzzy({list}, {str} [, {dict}, {limit}])
 				List	fuzzy match {str} in {list}
 matchfuzzypos({list}, {str} [, {dict}])
 				List	fuzzy match {str} in {list}
@@ -5567,7 +5567,7 @@ matchend({expr}, {pat} [, {start} [, {count}]])			*matchend()*
 			GetText()->matchend('word')
 
 
-matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
+matchfuzzy({list}, {str} [, {dict}, {limit}])		*matchfuzzy()*
 		If {list} is a list of strings, then returns a |List| with all
 		the strings in {list} that fuzzy match {str}. The strings in
 		the returned list are sorted based on the matching score.
@@ -5600,6 +5600,9 @@ matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 		If there are no matching strings or there is an error, then an
 		empty list is returned. If length of {str} is greater than
 		256, then returns an empty list.
+
+		When {limit} is given this specifies the maximum number of
+		list to be matched.
 
 		Refer to |fuzzy-matching| for more information about fuzzy
 		matching strings.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5589,7 +5589,8 @@ matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 				This should accept a dictionary item as the
 				argument and return the text for that item to
 				use for fuzzy matching.
-		    limit	the maximum number of list to be matched.
+		    limit	maximum number of items in {list} to be
+				matched.
 
 		{str} is treated as a literal string and regular expression
 		matching is NOT supported.  The maximum supported {str} length

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2063,7 +2063,7 @@ static funcentry_T global_functions[] =
 			ret_number_bool,    f_matchdelete},
     {"matchend",	2, 4, FEARG_1,	    arg24_match_func,
 			ret_number,	    f_matchend},
-    {"matchfuzzy",	2, 3, FEARG_1,	    arg3_list_string_dict,
+    {"matchfuzzy",	2, 4, FEARG_1,	    arg3_list_string_dict,
 			ret_list_string,    f_matchfuzzy},
     {"matchfuzzypos",	2, 3, FEARG_1,	    arg3_list_string_dict,
 			ret_list_any,	    f_matchfuzzypos},

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2063,7 +2063,7 @@ static funcentry_T global_functions[] =
 			ret_number_bool,    f_matchdelete},
     {"matchend",	2, 4, FEARG_1,	    arg24_match_func,
 			ret_number,	    f_matchend},
-    {"matchfuzzy",	2, 4, FEARG_1,	    arg3_list_string_dict,
+    {"matchfuzzy",	2, 3, FEARG_1,	    arg3_list_string_dict,
 			ret_list_string,    f_matchfuzzy},
     {"matchfuzzypos",	2, 3, FEARG_1,	    arg3_list_string_dict,
 			ret_list_any,	    f_matchfuzzypos},

--- a/src/search.c
+++ b/src/search.c
@@ -4888,12 +4888,19 @@ do_fuzzymatch(typval_T *argvars, typval_T *rettv, int retmatchpos)
 		return;
 	    }
 	}
+	else if ((di = dict_find(d, (char_u *)"limit", -1)) != NULL)
+	{
+	    if (di->di_tv.v_type != VAR_NUMBER)
+	    {
+		semsg(_(e_invalid_argument), tv_get_string(&di->di_tv));
+		return;
+	    }
+	    num_limit = (long)tv_get_number_chk(&di->di_tv, NULL);
+	}
+
 	if (dict_has_key(d, "matchseq"))
 	    matchseq = TRUE;
     }
-
-    if (argvars[3].v_type != VAR_UNKNOWN)
-	num_limit = (long)tv_get_number_chk(&argvars[3], NULL);
 
     // get the fuzzy matches
     ret = rettv_list_alloc(rettv);

--- a/src/search.c
+++ b/src/search.c
@@ -4649,7 +4649,7 @@ fuzzy_match_in_list(
 	callback_T	*item_cb,
 	int		retmatchpos,
 	list_T		*fmatchlist,
-	long		num_limit)
+	long		max_matches)
 {
     long	len;
     fuzzyItem_T	*ptrs;
@@ -4677,7 +4677,7 @@ fuzzy_match_in_list(
 	ptrs[i].item = li;
 	ptrs[i].score = SCORE_NONE;
 
-	if (num_limit > 0 && found_match >= num_limit)
+	if (max_matches > 0 && found_match >= max_matches)
 	{
 	    i++;
 	    continue;
@@ -4830,7 +4830,7 @@ do_fuzzymatch(typval_T *argvars, typval_T *rettv, int retmatchpos)
     char_u	*key = NULL;
     int		ret;
     int		matchseq = FALSE;
-    long	num_limit = 0;
+    long	max_matches = 0;
 
     if (in_vim9script()
 	    && (check_for_list_arg(argvars, 0) == FAIL
@@ -4895,7 +4895,7 @@ do_fuzzymatch(typval_T *argvars, typval_T *rettv, int retmatchpos)
 		semsg(_(e_invalid_argument), tv_get_string(&di->di_tv));
 		return;
 	    }
-	    num_limit = (long)tv_get_number_chk(&di->di_tv, NULL);
+	    max_matches = (long)tv_get_number_chk(&di->di_tv, NULL);
 	}
 
 	if (dict_has_key(d, "matchseq"))
@@ -4932,7 +4932,7 @@ do_fuzzymatch(typval_T *argvars, typval_T *rettv, int retmatchpos)
     }
 
     fuzzy_match_in_list(argvars[0].vval.v_list, tv_get_string(&argvars[1]),
-	    matchseq, key, &cb, retmatchpos, rettv->vval.v_list, num_limit);
+	    matchseq, key, &cb, retmatchpos, rettv->vval.v_list, max_matches);
 
 done:
     free_callback(&cb);

--- a/src/search.c
+++ b/src/search.c
@@ -4892,7 +4892,7 @@ do_fuzzymatch(typval_T *argvars, typval_T *rettv, int retmatchpos)
 	{
 	    if (di->di_tv.v_type != VAR_NUMBER)
 	    {
-		semsg(_(e_invalid_argument), tv_get_string(&di->di_tv));
+		semsg(_(e_invalid_argument_str), tv_get_string(&di->di_tv));
 		return;
 	    }
 	    max_matches = (long)tv_get_number_chk(&di->di_tv, NULL);

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -230,4 +230,13 @@ func Test_matchfuzzypos_mbyte()
   call assert_equal([['xффйд'], [[2, 3, 4]], [168]], matchfuzzypos(['xффйд'], 'фйд'))
 endfunc
 
+" Test for matchfuzz() with limit
+func Test_matchfuzzy_limit()
+  let x = ['1', '2', '3', '2']
+  call assert_equal(['2', '2'], x->matchfuzzy('2', {}, 0))
+  call assert_equal(['2'], x->matchfuzzy('2', {}, 1))
+  call assert_equal(['2', '2'], x->matchfuzzy('2', {}, 2))
+  call assert_equal(['2', '2'], x->matchfuzzy('2', {}, 3))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -239,6 +239,7 @@ func Test_matchfuzzy_limit()
   call assert_equal(['2'], x->matchfuzzy('2', #{limit: 1}))
   call assert_equal(['2', '2'], x->matchfuzzy('2', #{limit: 2}))
   call assert_equal(['2', '2'], x->matchfuzzy('2', #{limit: 3}))
+  call assert_fails("call matchfuzzy(x, '2', #{limit: '2'})", 'E475:')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -230,7 +230,7 @@ func Test_matchfuzzypos_mbyte()
   call assert_equal([['xффйд'], [[2, 3, 4]], [168]], matchfuzzypos(['xффйд'], 'фйд'))
 endfunc
 
-" Test for matchfuzz() with limit
+" Test for matchfuzzy() with limit
 func Test_matchfuzzy_limit()
   let x = ['1', '2', '3', '2']
   call assert_equal(['2', '2'], x->matchfuzzy('2'))

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -233,10 +233,12 @@ endfunc
 " Test for matchfuzz() with limit
 func Test_matchfuzzy_limit()
   let x = ['1', '2', '3', '2']
-  call assert_equal(['2', '2'], x->matchfuzzy('2', {}, 0))
-  call assert_equal(['2'], x->matchfuzzy('2', {}, 1))
-  call assert_equal(['2', '2'], x->matchfuzzy('2', {}, 2))
-  call assert_equal(['2', '2'], x->matchfuzzy('2', {}, 3))
+  call assert_equal(['2', '2'], x->matchfuzzy('2'))
+  call assert_equal(['2', '2'], x->matchfuzzy('2', #{}))
+  call assert_equal(['2', '2'], x->matchfuzzy('2', #{limit: 0}))
+  call assert_equal(['2'], x->matchfuzzy('2', #{limit: 1}))
+  call assert_equal(['2', '2'], x->matchfuzzy('2', #{limit: 2}))
+  call assert_equal(['2', '2'], x->matchfuzzy('2', #{limit: 3}))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
matchfuzzy() is useful. But when huge list are given, it takes heavily times. This pull-request add limit for matchfuzzy().