### PR TITLE
Make links use color scheme colors in TOhtml

### DIFF
--- a/runtime/syntax/2html.vim
+++ b/runtime/syntax/2html.vim
@@ -1769,6 +1769,10 @@ if s:settings.use_css
   " default font size for different elements
   call append('.', '* { font-size: 1em; }')
   +
+  " use color scheme styles for links
+  " browser-default blue/purple colors for links don't look like the existing theme and are unreadable on dark backgrounds
+  call append('.', 'a { color: inherit; }')
+  +
   " if we use any input elements for unselectable content, make sure they look
   " like normal text
   if !empty(s:settings.prevent_copy)


### PR DESCRIPTION
The browser-default dark blue/purple colors don't fit in with most color schemes and also are unreadable if the color scheme has a dark background.

Before:
![Screenshot from 2022-04-14 11-56-42](https://user-images.githubusercontent.com/401167/163458109-07d318be-b703-4ae5-9c6d-a6538f60de3c.png)

After:
![Screenshot from 2022-04-14 11-56-54](https://user-images.githubusercontent.com/401167/163458119-ed7fb341-6924-4be1-a1b0-4f3188aa38f8.png)

NB: I *think* I am adding this in the right place, but I have not rebuilt Vim to manually test this. Instead, I am adding the CSS manually to the output.