### PR TITLE
Fix statusline %{% item check

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1807,8 +1807,8 @@ ambw_end:
     }
 
 #ifdef FEAT_STL_OPT
-    // 'statusline' or 'rulerformat'
-    else if (gvarp == &p_stl || varp == &p_ruf)
+    // 'statusline', 'tabline' or 'rulerformat'
+    else if (gvarp == &p_stl || varp == &p_tal || varp == &p_ruf)
     {
 	int wid;
 
@@ -1826,7 +1826,7 @@ ambw_end:
 	    else
 		errmsg = check_stl_option(p_ruf);
 	}
-	// check 'statusline' only if it doesn't start with "%!"
+	// check 'statusline' or 'tabline' only if it doesn't start with "%!"
 	else if (varp == &p_ruf || s[0] != '%' || s[1] != '!')
 	    errmsg = check_stl_option(s);
 	if (varp == &p_ruf && errmsg == NULL)

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -625,9 +625,11 @@ check_stl_option(char_u *s)
 	}
 	if (*s == '{')
 	{
-	    int reevaluate = (*s == '%');
+	    int reevaluate = (*++s == '%');
 
-	    s++;
+	    if (reevaluate && *++s == '}')
+		// "}" is not allowed immediately after "%{%"
+		return illegal_char(errbuf, '}');
 	    while ((*s != '}' || (reevaluate && s[-1] != '%')) && *s)
 		s++;
 	    if (*s != '}')

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -396,6 +396,12 @@ func Test_set_errors()
   call assert_fails('set statusline=%{%}', 'E539:')
   call assert_fails('set statusline=%(', 'E542:')
   call assert_fails('set statusline=%)', 'E542:')
+  call assert_fails('set tabline=%$', 'E539:')
+  call assert_fails('set tabline=%{', 'E540:')
+  call assert_fails('set tabline=%{%', 'E540:')
+  call assert_fails('set tabline=%{%}', 'E539:')
+  call assert_fails('set tabline=%(', 'E542:')
+  call assert_fails('set tabline=%)', 'E542:')
 
   if has('cursorshape')
     " This invalid value for 'guicursor' used to cause Vim to crash.

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -392,6 +392,8 @@ func Test_set_errors()
   call assert_fails('set rulerformat=%15(%%', 'E542:')
   call assert_fails('set statusline=%$', 'E539:')
   call assert_fails('set statusline=%{', 'E540:')
+  call assert_fails('set statusline=%{%', 'E540:')
+  call assert_fails('set statusline=%{%}', 'E539:')
   call assert_fails('set statusline=%(', 'E542:')
   call assert_fails('set statusline=%)', 'E542:')
 


### PR DESCRIPTION
This can cause a stack buffer overflow:
```vim
set laststatus=2
set statusline=%{%}
redrawstatus
```
Since a valid expression cannot start with `}`, just do not allow `}` immediately after `%{%`.

Also check for invalid `'tabline'`.