### PR TITLE
Implement a cross-platform way to get the OS cache dir

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -557,6 +557,7 @@ split({expr} [, {pat} [, {keepempty}]])
 sqrt({expr})			Float	square root of {expr}
 srand([{expr}])			List	get seed for |rand()|
 state([{what}])			String	current state of Vim
+stdpath({what})			String	standard path for {what}
 str2float({expr} [, {quoted}])	Float	convert String to Float
 str2list({expr} [, {utf8}])	List	convert each character of {expr} to
 					ASCII/UTF-8 value
@@ -8367,6 +8368,16 @@ state([{what}])						*state()*
 		    c	callback invoked, including timer (repeats for
 			recursiveness up to "ccc")
 		    s	screen has scrolled for messages
+
+stdpath({what})						*stdpath()* *E1275*
+		Returns a String containing the standard system path to store
+		user-specific data.
+
+		If the requested standard path cannot be determined an E1275 is
+		given.
+
+		{what} can be one of these strings:
+			"cache"	root directory to store cached data in
 
 str2float({string} [, {quoted}])				*str2float()*
 		Convert String {string} to a Float.  This mostly works the

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -913,6 +913,7 @@ System functions and manipulation of files:
 	chdir()			change current working directory
 	delete()		delete a file
 	rename()		rename a file
+	stdpath()		get the root path for a certain kind of files
 	system()		get the result of a shell command as a string
 	systemlist()		get the result of a shell command as a list
 	environ()		get all environment variables

--- a/src/errors.h
+++ b/src/errors.h
@@ -3259,3 +3259,5 @@ EXTERN char e_nfa_regexp_missing_value_in_chr[]
 	INIT(= N_("E1273: (NFA regexp) missing value in '\\%%%c'"));
 EXTERN char e_no_script_file_name_to_substitute_for_script[]
 	INIT(= N_("E1274: No script file name to substitute for \"<script>\""));
+EXTERN char e_could_not_determine_stdpath_for_str[]
+	INIT(= N_("E1275: Could not determine standard path: %s"));

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -165,6 +165,7 @@ static void f_spellbadword(typval_T *argvars, typval_T *rettv);
 static void f_spellsuggest(typval_T *argvars, typval_T *rettv);
 static void f_split(typval_T *argvars, typval_T *rettv);
 static void f_srand(typval_T *argvars, typval_T *rettv);
+static void f_stdpath(typval_T *argvars, typval_T *rettv);
 static void f_submatch(typval_T *argvars, typval_T *rettv);
 static void f_substitute(typval_T *argvars, typval_T *rettv);
 static void f_swapinfo(typval_T *argvars, typval_T *rettv);
@@ -2405,6 +2406,8 @@ static funcentry_T global_functions[] =
 			ret_list_number,    f_srand},
     {"state",		0, 1, FEARG_1,	    arg1_string,
 			ret_string,	    f_state},
+    {"stdpath",		1, 1, FEARG_1,	    arg1_string,
+			ret_string,	    f_stdpath},
     {"str2float",	1, 2, FEARG_1,	    arg2_string_bool,
 			ret_float,	    FLOAT_FUNC(f_str2float)},
     {"str2list",	1, 2, FEARG_1,	    arg2_string_bool,
@@ -8086,6 +8089,40 @@ f_srand(typval_T *argvars, typval_T *rettv)
 #undef ROTL
 #undef SPLITMIX32
 #undef SHUFFLE_XOSHIRO128STARSTAR
+
+/*
+ * "stdpath()" function
+ */
+    void
+f_stdpath(typval_T *argvars, typval_T *rettv)
+{
+    char_u	*kind;
+    char_u	*val;
+
+    rettv->v_type = VAR_STRING;
+    rettv->vval.v_string = NULL;
+
+    if (in_vim9script()
+	    && check_for_string_or_number_arg(argvars, 0) == FAIL)
+	return;
+
+    kind = tv_get_string(&argvars[0]);
+
+    if (STRCMP(kind, "cache") == 0)
+    {
+	val = mch_special_dir(DIR_CACHE);
+    }
+    else
+    {
+	semsg(_(e_invalid_argument_str), kind);
+	return;
+    }
+
+    if (val == NULL)
+	semsg(_(e_could_not_determine_stdpath_for_str), kind);
+
+    rettv->vval.v_string = val;
+}
 
 /*
  * "range()" function

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4755,6 +4755,17 @@ mch_call_shell_terminal(
 }
 #endif
 
+    char_u *
+mch_special_dir(int kind UNUSED)
+{
+    char_u *env;
+
+    if ((env = (char_u *)getenv("LOCALAPPDATA")))
+	return vim_strsave(env);
+
+    return NULL;
+}
+
 /*
  * Either execute a command by calling the shell or start a new shell
  */

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -59,6 +59,7 @@ int mch_report_winsize(int fd, int rows, int cols);
 void mch_set_shellsize(void);
 void mch_new_shellsize(void);
 int unix_build_argv(char_u *cmd, char ***argvp, char_u **sh_tofree, char_u **shcf_tofree);
+char_u *mch_special_dir(int kind);
 int mch_call_shell(char_u *cmd, int options);
 void mch_job_start(char **argv, job_T *job, jobopt_T *options, int is_terminal);
 char *mch_job_status(job_T *job);

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -45,6 +45,7 @@ int mch_get_shellsize(void);
 void mch_set_shellsize(void);
 void mch_new_shellsize(void);
 void mch_set_winsize_now(void);
+char_u *mch_special_dir(int kind);
 int mch_call_shell(char_u *cmd, int options);
 void win32_build_env(dict_T *env, garray_T *gap, int is_terminal);
 void mch_job_start(char *cmd, job_T *job, jobopt_T *options);

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2887,5 +2887,24 @@ func Test_funcref_to_string()
   call assert_equal("function('g:Test_funcref_to_string')", string(Fn))
 endfunc
 
+" Test for stdpath()
+func Test_stdpath()
+  call assert_fails('call stdpath()', 'E119:')
+  call assert_fails('call stdpath("foo")', 'E475:')
+
+  if has('win32')
+    let old_LOCALAPPDATA = $LOCALAPPDATA
+    let $LOCALAPPDATA = 'C:\\foo\\bar'
+    call assert_equal($LOCALAPPDATA, stdpath("cache"))
+    let $LOCALAPPDATA = old_LOCALAPPDATA
+  elseif has('osx')
+    call assert_equal($HOME.'/Library/Caches', stdpath("cache"))
+  else
+    let old_XDG_CACHE_HOME = $XDG_CACHE_HOME
+    let $XDG_CACHE_HOME = '~/foo/bar'
+    call assert_equal($XDG_CACHE_HOME, stdpath("cache"))
+    let $XDG_CACHE_HOME = old_XDG_CACHE_HOME
+  endif
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim.h
+++ b/src/vim.h
@@ -980,6 +980,9 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define SHELL_READ	32	// read lines and insert into buffer
 #define SHELL_WRITE	64	// write lines from buffer
 
+// Values for mch_special_dir() argument
+#define DIR_CACHE	0
+
 // Values returned by mch_nodetype()
 #define NODE_NORMAL	0	// file or directory, check with mch_isdir()
 #define NODE_WRITABLE	1	// something we can write to (character


### PR DESCRIPTION
Borrow the name from NeoVim's stdpath() but handle only a single case,
"cache". If needed this function can be easily expanded to handle more
cases and, if the XDG specification is ever adopted, to return some
sensible values for other kind of data beside cached files.