### PR TITLE
Ensure the cached env values do not get stale

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -9223,9 +9223,9 @@ f_setenv(typval_T *argvars, typval_T *rettv UNUSED)
     name = tv_get_string_buf(&argvars[0], namebuf);
     if (argvars[1].v_type == VAR_SPECIAL
 				      && argvars[1].vval.v_number == VVAL_NULL)
-	vim_unsetenv(name);
+	vim_unsetenv_ext(name);
     else
-	vim_setenv(name, tv_get_string_buf(&argvars[1], valbuf));
+	vim_setenv_ext(name, tv_get_string_buf(&argvars[1], valbuf));
 }
 
 /*

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -1795,7 +1795,7 @@ do_unlet_var(
 
 	// Environment variable, normal name or expanded name.
 	if (*lp->ll_name == '$')
-	    vim_unsetenv(lp->ll_name + 1);
+	    vim_unsetenv_ext(lp->ll_name + 1);
 	else if (do_unlet(lp->ll_name, forceit) == FAIL)
 	    ret = FAIL;
 	*name_end = cc;

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1910,6 +1910,20 @@ vim_unsetenv(char_u *var)
 #endif
 }
 
+/*
+ * Removes environment variable "name" and take care of side effects.
+ */
+    void
+vim_unsetenv_ext(char_u *var)
+{
+    vim_unsetenv(var);
+    if (STRICMP(var, "HOME") == 0)
+	VIM_CLEAR(homedir);
+    else if (STRICMP(var, "VIM") == 0)
+	didset_vim = FALSE;
+    else if (STRICMP(var, "VIMRUNTIME") == 0)
+	didset_vimruntime = FALSE;
+}
 
 /*
  * Set environment variable "name" and take care of side effects.

--- a/src/proto/misc1.pro
+++ b/src/proto/misc1.pro
@@ -32,6 +32,7 @@ void expand_env(char_u *src, char_u *dst, int dstlen);
 void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, int esc, int one, char_u *startstr);
 char_u *vim_getenv(char_u *name, int *mustfree);
 void vim_unsetenv(char_u *var);
+void vim_unsetenv_ext(char_u *var);
 void vim_setenv_ext(char_u *name, char_u *val);
 void vim_setenv(char_u *name, char_u *val);
 char_u *get_env_name(expand_T *xp, int idx);

--- a/src/testdir/test_environ.vim
+++ b/src/testdir/test_environ.vim
@@ -28,6 +28,24 @@ func Test_setenv()
   call assert_equal(v:null, getenv('TEST ENV'))
 endfunc
 
+func Test_special_env()
+  " The value for $HOME is cached internally by Vim, ensure the value is up to
+  " date.
+  let orig_ENV = $HOME
+
+  let $HOME = 'foo'
+  call assert_equal('foo', expand('~'))
+  unlet $HOME
+  call assert_equal('~', expand('~'))
+
+  call setenv('HOME', 'bar')
+  call assert_equal('bar', expand('~'))
+  call setenv('HOME', v:null)
+  call assert_equal('~', expand('~'))
+
+  let $HOME = orig_ENV
+endfunc
+
 func Test_external_env()
   call setenv('FOO', 'HelloWorld')
   if has('win32')

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -3490,7 +3490,7 @@ exec_instructions(ectx_T *ectx)
 		    goto on_error;
 		break;
 	    case ISN_UNLETENV:
-		vim_unsetenv(iptr->isn_arg.unlet.ul_name);
+		vim_unsetenv_ext(iptr->isn_arg.unlet.ul_name);
 		break;
 
 	    case ISN_LOCKUNLOCK:


### PR DESCRIPTION
Update the cached info after getenv()/setenv() (or let/unlet).