### PR TITLE
Correct event order and values for reusing the NoName buffer

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2069,6 +2069,8 @@ buflist_new(
 	// It's like this buffer is deleted.  Watch out for autocommands that
 	// change curbuf!  If that happens, allocate a new buffer anyway.
 	buf_freeall(buf, BFA_WIPE | BFA_DEL);
+	if (buf != curbuf)   // autocommands deleted the buffer!
+		return NULL;
 #ifdef FEAT_EVAL
 	if (aborting())		// autocmds may abort script processing
 	{

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2068,10 +2068,7 @@ buflist_new(
 	buf = curbuf;
 	// It's like this buffer is deleted.  Watch out for autocommands that
 	// change curbuf!  If that happens, allocate a new buffer anyway.
-	if (curbuf->b_p_bl)
-	    apply_autocmds(EVENT_BUFDELETE, NULL, NULL, FALSE, curbuf);
-	if (buf == curbuf)
-	    apply_autocmds(EVENT_BUFWIPEOUT, NULL, NULL, FALSE, curbuf);
+	buf_freeall(buf, BFA_WIPE | BFA_DEL);
 #ifdef FEAT_EVAL
 	if (aborting())		// autocmds may abort script processing
 	{
@@ -2079,12 +2076,6 @@ buflist_new(
 	    return NULL;
 	}
 #endif
-	if (buf == curbuf)
-	{
-	    // Make sure 'bufhidden' and 'buftype' are empty
-	    clear_string_option(&buf->b_p_bh);
-	    clear_string_option(&buf->b_p_bt);
-	}
     }
     if (buf != curbuf || curbuf == NULL)
     {
@@ -2132,14 +2123,6 @@ buflist_new(
 
     if (buf == curbuf)
     {
-	// free all things allocated for this buffer
-	buf_freeall(buf, 0);
-	if (buf != curbuf)	 // autocommands deleted the buffer!
-	    return NULL;
-#if defined(FEAT_EVAL)
-	if (aborting())		// autocmds may abort script processing
-	    return NULL;
-#endif
 	free_buffer_stuff(buf, FALSE);	// delete local variables et al.
 
 	// Init the options.

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -3160,4 +3160,22 @@ func Test_v_event_readonly()
 endfunc
 
 
+func Test_noname_autocmd()
+  augroup test_noname_autocmd_group
+    autocmd!
+    autocmd BufEnter * call add(s:li, ["BufEnter", expand("<afile>")])
+    autocmd BufDelete * call add(s:li, ["BufDelete", expand("<afile>")])
+    autocmd BufLeave * call add(s:li, ["BufLeave", expand("<afile>")])
+    autocmd BufUnload * call add(s:li, ["BufUnload", expand("<afile>")])
+    autocmd BufWipeout * call add(s:li, ["BufWipeout", expand("<afile>")])
+  augroup END
+
+  let s:li = []
+  edit foo
+  call assert_equal([['BufUnload', ''], ['BufDelete', ''], ['BufWipeout', ''], ['BufEnter', 'foo']], s:li)
+
+  au! test_noname_autocmd_group
+  augroup! test_noname_autocmd_group
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -3038,8 +3038,8 @@ endfunc
 
 func Test_autocmd_vimgrep()
   augroup aucmd_vimgrep
-    au QuickfixCmdPre,BufNew,BufDelete,BufReadCmd * sb
-    au QuickfixCmdPre,BufNew,BufDelete,BufReadCmd * q9 
+    au QuickfixCmdPre,BufNew,BufReadCmd * sb
+    au QuickfixCmdPre,BufNew,BufReadCmd * q9 
   augroup END
   %bwipe!
   call assert_fails('lv ?a? foo', 'E926:')


### PR DESCRIPTION
Editing a real file after opening vim without a file to edit reuses the
"NoName" buffer that vim uses as a placeholder. Previously the buffer
creation code would emit BufDelete and BufWipeout events manually for
the NoName buffer and then call buf_freeall a bit later with that
buffer. buf_freeall emits BufUnload and optionally emits BufDelete and
BufWipeout via flags that indicate to emit them. The buf_freeall call
for the NoName buffer wasn't given those flags, so it only emitted
BufUnload.

All of this means that when reusing the NoName buffer, we'd emit
BufDelete, BufWipeout, and then BufUnload. The docs state that BufUnload
is before BufDelete, so that's one bug. A second bug was that the buffer
filename was set to the newly edited file's name in the meantime, so the
BufUnload event had the new file in when it's called, not the empty
string.

This pulls the call to buf_freeall up to where the delete and wipeout
events were manually emitted. It uses buf_freeall to emit those events,
so removes that duplication. That gets the events to go in the correct
unload, delete, and wipeout order and corrects the filename for the
unload event.