### PR TITLE
Fix heap-use-after-free when using synstack() and synID() in WinEnter

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6487,7 +6487,8 @@ syn_get_id(
 {
     // When the position is not after the current position and in the same
     // line of the same buffer, need to restart parsing.
-    if (wp->w_buffer != syn_buf
+    if (wp != syn_win
+	    || wp->w_buffer != syn_buf
 	    || lnum != current_lnum
 	    || col < current_col)
 	syntax_start(wp, lnum);

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -956,5 +956,18 @@ func Test_syn_include_contains_TOP()
   bw!
 endfunc
 
+" This was using freed memory
+func Test_WinEnter_synstack_synID()
+  autocmd WinEnter * call synstack(line("."), col("."))
+  autocmd WinEnter * call synID(line('.'), col('.') - 1, 1)
+  call setline(1, 'aaaaa')
+  normal! $
+  new
+  close
+
+  au! WinEnter
+  bw!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This causes heap-use-after-free:
```vim
autocmd WinEnter * call synstack(line("."), col("."))
autocmd WinEnter * call synID(line('.'), col('.') - 1, 1)
call setline(1, 'aaaaa')
normal! $
new
close
```

Adding a `wp != syn_win` seems to fix this.