### PR TITLE
cshtml files can be considered html

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -813,7 +813,7 @@ au BufRead,BufNewFile *.hws			setf hollywood
 au BufNewFile,BufRead *.t.html			setf tilde
 
 " HTML (.shtml and .stm for server side)
-au BufNewFile,BufRead *.html,*.htm,*.shtml,*.stm  call dist#ft#FThtml()
+au BufNewFile,BufRead *.html,*.htm,*.shtml,*.stm,*.cshtml  call dist#ft#FThtml()
 
 " HTML with Ruby - eRuby
 au BufNewFile,BufRead *.erb,*.rhtml		setf eruby

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -258,6 +258,7 @@ let s:filename_checks = {
     \ 'rnoweb': ['file.rnw', 'file.snw'],
     \ 'rrst': ['file.rrst', 'file.srst'],
     \ 'template': ['file.tmpl'],
+    \ 'html': ['file.html', 'file.cshtml'],
     \ 'htmlm4': ['file.html.m4'],
     \ 'httest': ['file.htt', 'file.htb'],
     \ 'ibasic': ['file.iba', 'file.ibi'],


### PR DESCRIPTION
cshtml files are used by the popular Razor Markup engine:
https://docs.fileformat.com/web/cshtml/