### PR TITLE
LSP messages are not parsed properly if the http header and json payload are received separately

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -1433,10 +1433,16 @@ To open a channel using the 'lsp' mode with a job, set the 'in_mode' and
     let opts = {}
     let opts.in_mode = 'lsp'
     let opts.out_mode = 'lsp'
+    let opts.err_mode = 'nl'
     let opts.out_cb = function('LspOutCallback')
     let opts.err_cb = function('LspErrCallback')
     let opts.exit_cb = function('LspExitCallback')
     let job = job_start(cmd, opts)
+
+Note that if a job outputs LSP messages on stdout and non-LSP messages on
+stderr, then the channel-callback function should handle both the message
+formats appropriately or you should use a separate callback function for
+"out_cb" and "err_cb" to handle them as shown above.
 
 To synchronously send a JSON-RPC request to the server, use the
 |ch_evalexpr()| function. This function will wait and return the decoded

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -2580,6 +2580,11 @@ func LspTests(port)
   call assert_equal({'id': 14, 'jsonrpc': '2.0', 'result': 'extra-hdr-fields'},
         \ resp)
 
+  " Test for processing delayed payload
+  let resp = ch_evalexpr(ch, #{method: 'delayed-payload', params: {}})
+  call assert_equal({'id': 15, 'jsonrpc': '2.0', 'result': 'delayed-payload'},
+        \ resp)
+
   " Test for processing a HTTP header without the Content-Length field
   let resp = ch_evalexpr(ch, #{method: 'hdr-without-len', params: {}},
         \ #{timeout: 200})
@@ -2629,13 +2634,6 @@ func LspTests(port)
   call assert_equal([], g:lspNotif)
   " Restore the callback function
   call ch_setoptions(ch, #{callback: 'LspCb'})
-  let g:lspNotif = []
-  call ch_sendexpr(ch, #{method: 'echo', params: #{s: 'no-callback'}})
-  " Send a ping to wait for all the notification messages to arrive
-  call assert_equal('alive', ch_evalexpr(ch, #{method: 'ping'}).result)
-  call assert_equal([#{jsonrpc: '2.0', result:
-        \ #{method: 'echo', jsonrpc: '2.0', params: #{s: 'no-callback'}}}],
-        \ g:lspNotif)
 
   " " Test for sending a raw message
   " let g:lspNotif = []


### PR DESCRIPTION

Collapse all the received data before parsing the LSP messages.