### PR TITLE
Ensure w_botline is valid in getwininfo()

### DIFF
--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -395,6 +395,9 @@ get_win_info(win_T *wp, short tpnr, short winnr)
     if (dict == NULL)
 	return NULL;
 
+    // make sure w_botline is valid
+    validate_botline_win(wp);
+
     dict_add_number(dict, "tabnr", tpnr);
     dict_add_number(dict, "winnr", winnr);
     dict_add_number(dict, "winid", wp->w_id);

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -867,6 +867,28 @@ func Test_split_noscroll()
   let &so = so_save
 endfunc
 
+func Test_getwininfo_au()
+  enew
+  call setline(1, range(1, 16))
+
+  let g:info = #{}
+  augroup T1
+    au!
+    au WinEnter * let g:info = getwininfo(win_getid())[0]
+  augroup END
+
+  4split
+  " Check that calling getwininfo() from WinEnter returns fresh values for
+  " topline and botline.
+  call assert_equal(1, g:info.topline)
+  call assert_equal(4, g:info.botline)
+  close
+
+  unlet g:info
+  augroup! T1
+  bwipe!
+endfunc
+
 " Tests for the winnr() function
 func Test_winnr()
   only | tabonly


### PR DESCRIPTION
This is needed to make sure we're not returning stale information to the
user.