### PR TITLE
Fix edge case for popup_create with negative firstline

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -1414,7 +1414,7 @@ popup_adjust_position(win_T *wp)
     }
 
     if (wp->w_firstline < 0)
-	wp->w_topline = lnum > 0 ? lnum + 1 : lnum;
+	wp->w_topline = lnum + 1;
 
     wp->w_has_scrollbar = wp->w_want_scrollbar
 	   && (wp->w_topline > 1 || lnum <= wp->w_buffer->b_ml.ml_line_count);

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -514,6 +514,19 @@ func Test_popup_firstline()
   call assert_equal(5, popup_getpos(winid).firstline)
 
   call popup_close(winid)
+
+  " Popup with less elements than the maximum height and negative firstline,
+  " check that the popup height is correctly computed
+  let winid = popup_create(['xxx']->repeat(4), #{
+        \ firstline: -1,
+        \ maxheight: 6,
+	\ })
+
+  let pos = popup_getpos(winid)
+  call assert_equal(3, pos.width)
+  call assert_equal(4, pos.height)
+
+  call popup_close(winid)
 endfunc
 
 func Test_popup_firstline_cursorline()


### PR DESCRIPTION
When `lnum` is zero we should still add one to compensate for the loop decrement.