### PR TITLE
Add ftplugin for Elixir

### DIFF
--- a/runtime/ftplugin/elixir.vim
+++ b/runtime/ftplugin/elixir.vim
@@ -1,0 +1,17 @@
+" Elixir filetype plugin
+" Language: Elixir
+" Maintainer:	Mitchell Hanberg <vimNOSPAM@mitchellhanberg.com>
+" Last Change: 2022 Apr 20
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal commentstring=#\ %s
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
This primarily sets the commentstring for Elixir files. Now that elixir is detected by Vim, it makes sense to add this functionality and reduces the need for external plugins.

Thank you for considering this patch 🙇.