### PR TITLE
Fixed foldmethod=indent fold splitting bug

### DIFF
--- a/src/fold.c
+++ b/src/fold.c
@@ -2911,7 +2911,8 @@ foldSplit(
     // any between top and bot, they have been removed by the caller.
     gap1 = &fp->fd_nested;
     gap2 = &fp[1].fd_nested;
-    if (foldFind(gap1, bot + 1 - fp->fd_top, &fp2))
+    (void)foldFind(gap1, bot + 1 - fp->fd_top, &fp2);
+    if (fp2 != NULL)
     {
 	len = (int)((fold_T *)gap1->ga_data + gap1->ga_len - fp2);
 	if (len > 0 && ga_grow(gap2, len) == OK)

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1439,4 +1439,24 @@ func Test_foldtext_scriptlocal_func()
   delfunc s:FoldText
 endfunc
 
+" Make sure a fold containing a nested fold is split correctly when using
+" foldmethod=indent
+func Test_fold_split()
+  new
+  let lines =<< trim END
+    line 1
+      line 2
+      line 3
+        line 4
+        line 5
+  END
+  call setline(1, lines)
+  setlocal sw=2
+  setlocal foldmethod=indent foldenable
+  call assert_equal([0, 1, 1, 2, 2], range(1, 5)->map('foldlevel(v:val)'))
+  call append(2, 'line 2.5')
+  call assert_equal([0, 1, 0, 1, 2, 2], range(1, 6)->map('foldlevel(v:val)'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When using "foldmethod=indent", Pasting text into a fold that has nested folds can ruin the folds in the window.
(See commit message for how to reproduce the bug.)

The bug was introduced in patch 8.2.1560
9c2b06637b32742cac11bfd66b1a4e84583c6c2e

"foldFind()" is used here for its side effect of setting the given fold pointer,
not for its return value. Relevant here is that the function returns null in its
final case (when the binary search fails), yet still sets the pointer. We need
that functionality to not have this bug.

In keeping with what I understand the purpose of the original patch to be, I've
kept the conditional so that the pointer arithmetic doesn't happen on a null
pointer.