### PR TITLE
Remove unused `shl->lines`

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -624,10 +624,10 @@ prepare_search_hl(win_T *wp, match_T *search_hl, linenr_T lnum)
     static void
 check_cur_search_hl(win_T *wp, match_T *shl)
 {
-    long linecount = shl->rm.endpos[0].lnum - shl->rm.startpos[0].lnum;
+    linenr_T linecount = shl->rm.endpos[0].lnum - shl->rm.startpos[0].lnum;
 
     if (wp->w_cursor.lnum >= shl->lnum
-	    && wp->w_cursor.lnum <= shl->lnum + shl->rm.endpos[0].lnum
+	    && wp->w_cursor.lnum <= shl->lnum + linecount
 	    && (wp->w_cursor.lnum > shl->lnum
 				|| wp->w_cursor.col >= shl->rm.startpos[0].col)
 	    && (wp->w_cursor.lnum < shl->lnum + linecount
@@ -673,7 +673,6 @@ prepare_search_hl_line(
 	    shl = &cur->hl;
 	shl->startcol = MAXCOL;
 	shl->endcol = MAXCOL;
-	shl->lines = 0;
 	shl->attr_cur = 0;
 	shl->is_addpos = FALSE;
 	shl->has_cursor = FALSE;
@@ -697,9 +696,6 @@ prepare_search_hl_line(
 		shl->endcol = shl->rm.endpos[0].col;
 	    else
 		shl->endcol = MAXCOL;
-	    shl->lines = shl->rm.endpos[0].lnum - shl->rm.startpos[0].lnum;
-	    if (shl->lines == 0)
-		shl->lines = 1;
 
 	    // check if the cursor is in the match before changing the columns
 	    if (shl == search_hl)

--- a/src/structs.h
+++ b/src/structs.h
@@ -3331,7 +3331,6 @@ typedef struct
 			    // found match (may continue in next line)
     buf_T	*buf;	    // the buffer to search for a match
     linenr_T	lnum;	    // the line to search for a match
-    linenr_T	lines;	    // number of lines starting from lnum
     int		attr;	    // attributes to be used for a match
     int		attr_cur;   // attributes currently active in win_line()
     linenr_T	first_lnum; // first lnum to search for multi-line pat


### PR DESCRIPTION
Also make `check_cur_search_hl()` code a bit less confusing, as `linecount` is actually equal to `endpos[0].lnum`, and `startpos[0].lnum` is always 0