### PR TITLE
Use gtk_window_get_size(), not gdk_*, to avoid missing function.

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -396,6 +396,9 @@ static int using_gnome = 0;
 # define using_gnome 0
 #endif
 
+// Comment out following to remove code for resize history tracking
+#define TRACK_RESIZE_HISTORY
+#ifdef TRACK_RESIZE_HISTORY
 /*
  * Keep a short term resize history so that stale gtk responses can be
  * discarded.
@@ -518,6 +521,7 @@ free_all_resize_hist()
     clear_resize_hists();
     vim_free(latest_resize_hist);
 }
+#endif
 #endif
 
 /*
@@ -717,7 +721,9 @@ gui_mch_free_all(void)
 #if defined(USE_GNOME_SESSION)
     vim_free(abs_restart_command);
 #endif
+#ifdef TRACK_RESIZE_HISTORY
     free_all_resize_hist();
+#endif
 }
 #endif
 
@@ -4131,26 +4137,26 @@ form_configure_event(GtkWidget *widget UNUSED,
 		     GdkEventConfigure *event,
 		     gpointer data UNUSED)
 {
-    int		usable_height = event->height;
-    // Resize requests are made for gui.mainwin,
-    // get it's dimensions for searching if this event
+    int	    usable_height = event->height;
+#ifdef TRACK_RESIZE_HISTORY
+    // Resize requests are made for gui.mainwin;
+    // get its dimensions for searching if this event
     // is a response to a vim request.
-    GdkWindow	*win = gtk_widget_get_window(gui.mainwin);
-    int		w = gdk_window_get_width(win);
-    int		h = gdk_window_get_height(win);
+    int	    w, h;
+    gtk_window_get_size(GTK_WINDOW(gui.mainwin), &w, &h);
 
 #ifdef ENABLE_RESIZE_HISTORY_LOG
     ch_log(NULL, "gui_gtk: form_configure_event: (%d, %d) [%d, %d]",
 	   w, h, (int)Columns, (int)Rows);
 #endif
 
-    // Look through history of recent vim resize reqeusts.
+    // Look through history of recent vim resize requests.
     // If this event matches:
     //	    - "latest resize hist" We're caught up;
     //		clear the history and process this event.
     //		If history is, old to new, 100, 99, 100, 99. If this event is
     //		99 for the stale, it is matched against the current. History
-    //		is cleared, we my bounce, but no worse than before.
+    //		is cleared, we may bounce, but no worse than before.
     //	    - "older/stale hist" If match an unused event in history,
     //		then discard this event, and mark the matching event as used.
     //	    - "no match" Figure it's a user resize event, clear history.
@@ -4161,6 +4167,7 @@ form_configure_event(GtkWidget *widget UNUSED,
 	// discard stale event
 	return TRUE;
     clear_resize_hists();
+#endif
 
 #if GTK_CHECK_VERSION(3,22,2) && !GTK_CHECK_VERSION(3,22,4)
     // As of 3.22.2, GdkWindows have started distributing configure events to
@@ -4483,7 +4490,9 @@ gui_mch_open(void)
      * manager upon us and should not interfere with what VIM is requesting
      * upon startup.
      */
+#ifdef TRACK_RESIZE_HISTORY
     latest_resize_hist = ALLOC_CLEAR_ONE(resize_hist_T);
+#endif
     g_signal_connect(G_OBJECT(gui.formwin), "configure-event",
 				       G_CALLBACK(form_configure_event), NULL);
 
@@ -4671,7 +4680,9 @@ gui_mch_set_shellsize(int width, int height,
     width  += get_menu_tool_width();
     height += get_menu_tool_height();
 
+#ifdef TRACK_RESIZE_HISTORY
     alloc_resize_hist(width, height); // track the resize request
+#endif
     if (gtk_socket_id == 0)
 	gtk_window_resize(GTK_WINDOW(gui.mainwin), width, height);
     else


### PR DESCRIPTION
Add define to include/exclude resize history tracking code.

Suspecting that gtk_window_get_size() is in all gtk-2 version, use that instead of the gdk_window variants to avoid compilation problems on gtk-2 before GDK 2.24. **Note:** don't know how to explicitly test that.

While running some tests on gtk-2, I ran into some unexpected behavior as seen in the logs below; with gtk-2, resize history fixes some, but not all, unexpected Column changes.

With gtk-2 Here's one log excerpt
```
  0.428288 : gui_gtk: New resize seq 1 (820, 946) [100, 55]
  0.502682 : gui_gtk: New resize seq 2 (980, 946) [120, 55]
  0.544860 : gui_gtk: form_configure_event: (820, 946) [120, 55]
  0.544882 : gui_gtk: discard seq 1, cur seq 2
  0.546639 : gui_gtk: form_configure_event: (820, 882) [120, 55] <<<<<<< ?
  0.546649 : gui_gtk: free 2 hists
```
Notice the dimensions of the last form_configure_event is wrong.  When this run completes the size of the width of the window is 820 pixels (100 cols); but the last request was 980 (120 cols).  BTW, note that the height value, 882, is out of nowhere.  Maybe gtk-2 has an issue with multiple outstanding resize requests.

_Bug in gtk-2?_

But the fix still has some use in gtk-2, here's a trace where the fix prevents a bounce in Columns due to the discard.
```
  0.431976 : gui_gtk: New resize seq 1 (820, 946) [100, 55]
  0.507312 : gui_gtk: New resize seq 2 (980, 946) [120, 55]
  0.544770 : gui_gtk: form_configure_event: (820, 946) [120, 55]
  0.544789 : gui_gtk: discard seq 1, cur seq 2
  0.549604 : gui_gtk: form_configure_event: (980, 946) [120, 55]
  0.549622 : gui_gtk: free 2 hists
```