### PR TITLE
Process VK_CAPITAL as key modifier

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -2049,6 +2049,8 @@ process_message(void)
 	    memset(keyboard_state, 0, 256);
 	    if (GetKeyState(VK_SHIFT) & 0x8000)
 		keyboard_state[VK_SHIFT] = 0x80;
+	    if (GetKeyState(VK_CAPITAL) & 0x0001)
+		keyboard_state[VK_CAPITAL] = 0x01;
 	    if (GetKeyState(VK_RMENU) & 0x8000)
 	    {
 		keyboard_state[VK_MENU] = 0x80;


### PR DESCRIPTION
This change is needed to process Caps-Lock when translating the key
code.

Closes #10258

@xvim64, can you confirm this patch fixes your problem?