### PR TITLE
highlight more C keywords, including some from C23

### DIFF
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -276,6 +276,9 @@ if !exists("c_no_c99") " ISO C99
   syn keyword	cType		intptr_t uintptr_t
   syn keyword	cType		intmax_t uintmax_t
 endif
+if exists("c_c23") " ISO C23
+  syn keyword	cType           _Decimal32 _Decimal64 _Decimal128
+endif
 
 syn keyword	cTypedef	typedef
 syn keyword	cStructure	struct union enum
@@ -373,10 +376,21 @@ if !exists("c_no_ansi") || exists("c_ansi_constants") || exists("c_gnu")
 endif
 if !exists("c_no_c99") " ISO C99
   syn keyword cConstant true false
+  syn keyword cConstant INFINITY NAN
+  " math.h
+  syn keyword cConstant HUGE_VAL HUGE_VALF HUGE_VALL
+  syn keyword cConstant FP_FAST_FMAF FP_FAST_FMA FP_FAST_FMAL
+  syn keyword cConstant FP_ILOGB0 FP_ILOGBNAN
+  syn keyword cConstant math_errhandling MATH_ERRNO MATH_ERREXCEPT
+  syn keyword cConstant FP_NORMAL FP_SUBNORMAL FP_ZERO FP_INFINITE FP_NAN
 endif
 
 " Accept %: for # (C99)
-syn region	cPreCondit	start="^\s*\zs\(%:\|#\)\s*\(if\|ifdef\|ifndef\|elif\)\>" skip="\\$" end="$" keepend contains=cComment,cCommentL,cCppString,cCharacter,cCppParen,cParenError,cNumbers,cCommentError,cSpaceError
+if exists("c_c23") " FIXME: `if !exists(c_no_c23)` when C23 is widely accepted
+  syn region	cPreCondit	start="^\s*\zs\(%:\|#\)\s*\%(el\)\=\(if\|ifdef\|ifndef\)\>" skip="\\$" end="$" keepend contains=cComment,cCommentL,cCppString,cCharacter,cCppParen,cParenError,cNumbers,cCommentError,cSpaceError
+else
+  syn region	cPreCondit	start="^\s*\zs\(%:\|#\)\s*\(if\|ifdef\|ifndef\|elif\)\>" skip="\\$" end="$" keepend contains=cComment,cCommentL,cCppString,cCharacter,cCppParen,cParenError,cNumbers,cCommentError,cSpaceError
+endif
 syn match	cPreConditMatch	display "^\s*\zs\(%:\|#\)\s*\(else\|endif\)\>"
 if !exists("c_no_if0")
   syn cluster	cCppOutInGroup	contains=cCppInIf,cCppInElse,cCppInElse2,cCppOutIf,cCppOutIf2,cCppOutElse,cCppInSkip,cCppOutSkip


### PR DESCRIPTION
Added some keywords, some that are from C99 and some from C23.

As C23 is not completed yet, I chose to enforce users to define `c_c23` if they want such features.

It is very okay if this PR sits for a year until C23 has been set in stone.