### PR TITLE
Add ISN_BUILDSTRING

### DIFF
--- a/src/proto/vim9instr.pro
+++ b/src/proto/vim9instr.pro
@@ -62,7 +62,7 @@ int generate_LEGACY_EVAL(cctx_T *cctx, char_u *line);
 int generate_EXECCONCAT(cctx_T *cctx, int count);
 int generate_RANGE(cctx_T *cctx, char_u *range);
 int generate_UNPACK(cctx_T *cctx, int var_count, int semicolon);
-int generate_NEWSTRING(cctx_T *cctx, int count);
+int generate_CONCAT(cctx_T *cctx, int count);
 int generate_cmdmods(cctx_T *cctx, cmdmod_T *cmod);
 int generate_undo_cmdmods(cctx_T *cctx);
 int generate_store_var(cctx_T *cctx, assign_dest_T dest, int opt_flags, int vimvaridx, int scriptvar_idx, int scriptvar_sid, type_T *type, char_u *name);

--- a/src/proto/vim9instr.pro
+++ b/src/proto/vim9instr.pro
@@ -62,6 +62,7 @@ int generate_LEGACY_EVAL(cctx_T *cctx, char_u *line);
 int generate_EXECCONCAT(cctx_T *cctx, int count);
 int generate_RANGE(cctx_T *cctx, char_u *range);
 int generate_UNPACK(cctx_T *cctx, int var_count, int semicolon);
+int generate_NEWSTRING(cctx_T *cctx, int count);
 int generate_cmdmods(cctx_T *cctx, cmdmod_T *cmod);
 int generate_undo_cmdmods(cctx_T *cctx);
 int generate_store_var(cctx_T *cctx, assign_dest_T dest, int opt_flags, int vimvaridx, int scriptvar_idx, int scriptvar_sid, type_T *type, char_u *name);

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -208,7 +208,7 @@ def Test_disassemble_redir_var()
         ' redir END\_s*' ..
         '\d LOAD $0\_s*' ..
         '\d REDIR END\_s*' ..
-        '\d CONCAT\_s*' ..
+        '\d CONCAT size 2\_s*' ..
         '\d STORE $0\_s*' ..
         '\d RETURN void',
         res)
@@ -883,7 +883,7 @@ def Test_disassemble_closure()
         'local ..= arg\_s*' ..
         '\d LOADOUTER level 1 $0\_s*' ..
         '\d LOAD arg\[-1\]\_s*' ..
-        '\d CONCAT\_s*' ..
+        '\d CONCAT size 2\_s*' ..
         '\d STOREOUTER level 1 $0\_s*' ..
         '\d RETURN void',
         res)
@@ -973,7 +973,7 @@ def Test_disassemble_call_default()
         '6 LOAD arg\[-2]\_s*' ..
         '\d LOAD arg\[-1]\_s*' ..
         '\d 2STRING stack\[-1]\_s*' ..
-        '\d\+ CONCAT\_s*' ..
+        '\d\+ CONCAT size 2\_s*' ..
         '\d\+ RETURN',
         res)
 enddef
@@ -1245,9 +1245,9 @@ def Test_disassemble_lambda()
         '\d PUSHS "X"\_s*' ..
         '\d LOAD arg\[-1\]\_s*' ..
         '\d 2STRING_ANY stack\[-1\]\_s*' ..
-        '\d CONCAT\_s*' ..
+        '\d CONCAT size 2\_s*' ..
         '\d PUSHS "X"\_s*' ..
-        '\d CONCAT\_s*' ..
+        '\d CONCAT size 2\_s*' ..
         '\d RETURN',
         instr)
 enddef
@@ -1432,7 +1432,7 @@ def Test_disassemble_for_loop_eval()
         '\d\+ LOAD $0\_s*' ..
         '\d\+ LOAD $2\_s*' ..
         '\d 2STRING_ANY stack\[-1\]\_s*' ..
-        '\d\+ CONCAT\_s*' ..
+        '\d\+ CONCAT size 2\_s*' ..
         '\d\+ STORE $0\_s*' ..
         'endfor\_s*' ..
         '\d\+ JUMP -> 5\_s*' ..
@@ -2142,7 +2142,7 @@ def Test_disassemble_execute()
         "execute 'help ' .. tag\\_s*" ..
         '\d\+ PUSHS "help "\_s*' ..
         '\d\+ LOAD $1\_s*' ..
-        '\d\+ CONCAT\_s*' ..
+        '\d\+ CONCAT size 2\_s*' ..
         '\d\+ EXECUTE 1\_s*' ..
         '\d\+ RETURN void',
         res)

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -97,7 +97,6 @@ typedef enum {
 			// -1 for null_list
     ISN_NEWDICT,	// push dict from stack items, size is isn_arg.number
 			// -1 for null_dict
-    ISN_NEWSTRING,	// push string from stack items, size is isn_arg.number
     ISN_NEWPARTIAL,	// push NULL partial
 
     ISN_AUTOLOAD,	// get item from autoload import, function or variable
@@ -153,7 +152,7 @@ typedef enum {
     ISN_COMPAREANY,
 
     // expression operations
-    ISN_CONCAT,
+    ISN_CONCAT,     // concatenate isn_arg.number strings
     ISN_STRINDEX,   // [expr] string index
     ISN_STRSLICE,   // [expr:expr] string slice
     ISN_LISTAPPEND, // append to a list, like add()

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -97,6 +97,7 @@ typedef enum {
 			// -1 for null_list
     ISN_NEWDICT,	// push dict from stack items, size is isn_arg.number
 			// -1 for null_dict
+    ISN_NEWSTRING,	// push string from stack items, size is isn_arg.number
     ISN_NEWPARTIAL,	// push NULL partial
 
     ISN_AUTOLOAD,	// get item from autoload import, function or variable

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -2125,7 +2125,7 @@ compile_redir(char_u *line, exarg_T *eap, cctx_T *cctx)
 	    generate_instr_type(cctx, ISN_REDIREND, &t_string);
 
 	    if (lhs->lhs_append)
-		generate_instr_drop(cctx, ISN_CONCAT, 1);
+		generate_CONCAT(cctx, 2);
 
 	    if (lhs->lhs_has_index)
 	    {

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1034,7 +1034,7 @@ compile_heredoc_string(char_u *str, int evalstr, cctx_T *cctx)
 	}
 
 	if (count != 1)
-	    generate_NEWSTRING(cctx, count);
+	    generate_CONCAT(cctx, count);
     }
     else
     {
@@ -2383,7 +2383,7 @@ compile_assignment(char_u *arg, exarg_T *eap, cmdidx_T cmdidx, cctx_T *cctx)
 
 	    if (*op == '.')
 	    {
-		if (generate_instr_drop(cctx, ISN_CONCAT, 1) == NULL)
+		if (generate_CONCAT(cctx, 2) == FAIL)
 		    goto theend;
 	    }
 	    else if (*op == '+')

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -988,14 +988,12 @@ compile_heredoc_string(char_u *str, int evalstr, cctx_T *cctx)
     if (evalstr && (p = (char_u *)strstr((char *)str, "`=")) != NULL)
     {
 	char_u	*start = str;
+	int	count = 0;
 
 	// Need to evaluate expressions of the form `=<expr>` in the string.
 	// Split the string into literal strings and Vim expressions and
 	// generate instructions to concatenate the literal strings and the
 	// result of evaluating the Vim expressions.
-	val = vim_strsave((char_u *)"");
-	generate_PUSHS(cctx, &val);
-
 	for (;;)
 	{
 	    if (p > start)
@@ -1003,7 +1001,7 @@ compile_heredoc_string(char_u *str, int evalstr, cctx_T *cctx)
 		// literal string before the expression
 		val = vim_strnsave(start, p - start);
 		generate_PUSHS(cctx, &val);
-		generate_instr_drop(cctx, ISN_CONCAT, 1);
+		count++;
 	    }
 	    p += 2;
 
@@ -1011,7 +1009,7 @@ compile_heredoc_string(char_u *str, int evalstr, cctx_T *cctx)
 	    if (compile_expr0(&p, cctx) == FAIL)
 		return FAIL;
 	    may_generate_2STRING(-1, TRUE, cctx);
-	    generate_instr_drop(cctx, ISN_CONCAT, 1);
+	    count++;
 
 	    p = skipwhite(p);
 	    if (*p != '`')
@@ -1029,11 +1027,14 @@ compile_heredoc_string(char_u *str, int evalstr, cctx_T *cctx)
 		{
 		    val = vim_strsave(start);
 		    generate_PUSHS(cctx, &val);
-		    generate_instr_drop(cctx, ISN_CONCAT, 1);
+		    count++;
 		}
 		break;
 	    }
 	}
+
+	if (count != 1)
+	    generate_NEWSTRING(cctx, count);
     }
     else
     {

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -2513,7 +2513,8 @@ compile_expr5(char_u **arg, cctx_T *cctx, ppconst_T *ppconst)
 		if (may_generate_2STRING(-2, FALSE, cctx) == FAIL
 			|| may_generate_2STRING(-1, FALSE, cctx) == FAIL)
 		    return FAIL;
-		generate_instr_drop(cctx, ISN_CONCAT, 1);
+		if (generate_CONCAT(cctx, 2) == FAIL)
+		    return FAIL;
 	    }
 	    else
 		generate_two_op(cctx, op);

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -470,6 +470,27 @@ generate_COMPARE(cctx_T *cctx, exprtype_T exprtype, int ic)
 
     return OK;
 }
+    int
+generate_NEWSTRING(cctx_T *cctx, int count)
+{
+    isn_T	*isn;
+    garray_T	*stack = &cctx->ctx_type_stack;
+
+    RETURN_OK_IF_SKIP(cctx);
+    if ((isn = generate_instr(cctx, ISN_NEWSTRING)) == NULL)
+	return FAIL;
+    isn->isn_arg.number = count;
+
+    if (count > 0)
+    {
+	stack->ga_len -= count - 1;
+	set_type_on_stack(cctx, &t_bool, 0);
+    }
+    else
+	return push_type_stack(cctx, &t_string);
+
+    return OK;
+}
 
 /*
  * Generate an ISN_2BOOL instruction.
@@ -2251,6 +2272,7 @@ delete_instr(isn_T *isn)
 	case ISN_NEGATENR:
 	case ISN_NEWDICT:
 	case ISN_NEWLIST:
+	case ISN_NEWSTRING:
 	case ISN_NEWPARTIAL:
 	case ISN_OPANY:
 	case ISN_OPFLOAT:

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -470,24 +470,30 @@ generate_COMPARE(cctx_T *cctx, exprtype_T exprtype, int ic)
 
     return OK;
 }
+
+/*
+ * Generate an ISN_CONCAT instruction.
+ * "count" is the number of stack elements to join together and it must be
+ * greater or equal to one.
+ * The caller ensures all the "count" elements on the stack have the right type.
+ */
     int
-generate_NEWSTRING(cctx_T *cctx, int count)
+generate_CONCAT(cctx_T *cctx, int count)
 {
     isn_T	*isn;
     garray_T	*stack = &cctx->ctx_type_stack;
 
     RETURN_OK_IF_SKIP(cctx);
-    if ((isn = generate_instr(cctx, ISN_NEWSTRING)) == NULL)
+
+    if (count < 1)
+	return FAIL;
+
+    if ((isn = generate_instr(cctx, ISN_CONCAT)) == NULL)
 	return FAIL;
     isn->isn_arg.number = count;
 
-    if (count > 0)
-    {
-	stack->ga_len -= count - 1;
-	set_type_on_stack(cctx, &t_bool, 0);
-    }
-    else
-	return push_type_stack(cctx, &t_string);
+    // drop the argument types
+    stack->ga_len -= count - 1;
 
     return OK;
 }
@@ -2272,7 +2278,6 @@ delete_instr(isn_T *isn)
 	case ISN_NEGATENR:
 	case ISN_NEWDICT:
 	case ISN_NEWLIST:
-	case ISN_NEWSTRING:
 	case ISN_NEWPARTIAL:
 	case ISN_OPANY:
 	case ISN_OPFLOAT:


### PR DESCRIPTION
Add a new opcode to build a string using N string elements on the stack,
much faster than using N-1 CONCAT opcodes.

Use this when compiling heredocs, this may also be useful when
implementing templated strings or in some optimization pass.