### PR TITLE
getmappings() handle bool option "abbr"

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -235,7 +235,7 @@ getline({lnum})			String	line {lnum} of current buffer
 getline({lnum}, {end})		List	lines {lnum} to {end} of current buffer
 getloclist({nr})		List	list of location list items
 getloclist({nr}, {what})	Dict	get specific location list properties
-getmappings()			List	list of all mappings, a dict for each
+getmappings([{abbr}])		List	list of all mappings, a dict for each
 getmarklist([{buf}])		List	list of global/local marks
 getmatches([{win}])		List	list of current matches
 getmousepos()			Dict	last known mouse position
@@ -3571,10 +3571,11 @@ getloclist({nr} [, {what}])				*getloclist()*
 			:echo getloclist(5, {'filewinid': 0})
 
 
-getmappings()						*getmappings()*
+getmappings([{abbr}])					*getmappings()*
 		Returns a |List| of all mappings.  Each List item is a |Dict|,
 		the same as what is returned by |maparg()|, see
-		|mapping-dict|.
+		|mapping-dict|.  When {abbr} is there and it is |TRUE| use
+		abbreviations instead of mappings.
 
 		Example to show all mappings with 'MultiMatch' in rhs: >
 			vim9script

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1871,7 +1871,7 @@ static funcentry_T global_functions[] =
 			ret_getline,	    f_getline},
     {"getloclist",	1, 2, 0,	    arg2_number_dict_any,
 			ret_list_or_dict_1, f_getloclist},
-    {"getmappings",		0, 0, 0,	    NULL,
+    {"getmappings",	0, 1, 0,	    arg1_bool,
 			ret_list_dict_any,  f_getmappings},
     {"getmarklist",	0, 1, FEARG_1,	    arg1_buffer,
 			ret_list_dict_any,  f_getmarklist},

--- a/src/map.c
+++ b/src/map.c
@@ -2403,6 +2403,12 @@ f_getmappings(typval_T *argvars UNUSED, typval_T *rettv)
     int		hash;
     char_u	*lhs;
     const int	flags = REPTERM_FROM_PART | REPTERM_DO_LT;
+    int		abbr = FALSE;
+
+    if (in_vim9script() && check_for_opt_bool_arg(argvars, 0) == FAIL)
+	return;
+    if (argvars[0].v_type != VAR_UNKNOWN)
+	abbr = tv_get_bool(&argvars[0]);
 
     if (rettv_list_alloc(rettv) != OK)
 	return;
@@ -2414,7 +2420,16 @@ f_getmappings(typval_T *argvars UNUSED, typval_T *rettv)
     {
 	for (hash = 0; hash < 256; ++hash)
 	{
-	    if (buffer_local)
+	    if (abbr)
+	    {
+		if (hash > 0)		// there is only one abbr list
+		    break;
+		if (buffer_local)
+		    mp = curbuf->b_first_abbr;
+		else
+		    mp = first_abbr;
+	    }
+	    else if (buffer_local)
 		mp = curbuf->b_maphash[hash];
 	    else
 		mp = maphash[hash];

--- a/src/testdir/test_maparg.vim
+++ b/src/testdir/test_maparg.vim
@@ -299,13 +299,14 @@ endfunc
 
 def Test_getmappings()
   new
-  def ClearMaps()
+  def ClearMappingsAbbreviations()
     mapclear | nmapclear | vmapclear | xmapclear | smapclear | omapclear
     mapclear!  | imapclear | lmapclear | cmapclear | tmapclear
     mapclear <buffer> | nmapclear <buffer> | vmapclear <buffer>
     xmapclear <buffer> | smapclear <buffer> | omapclear <buffer>
     mapclear! <buffer> | imapclear <buffer> | lmapclear <buffer>
     cmapclear <buffer> | tmapclear <buffer>
+    abclear | abclear <buffer>
   enddef
 
   def AddMaps(new: list<string>, accum: list<string>)
@@ -314,8 +315,9 @@ def Test_getmappings()
     endif
   enddef
 
-  ClearMaps()
+  ClearMappingsAbbreviations()
   assert_equal(0, len(getmappings()))
+  assert_equal(0, len(getmappings(true)))
 
   # Set up some mappings.
   map dup bar
@@ -331,10 +333,16 @@ def Test_getmappings()
   map abc <Nop>
   nmap <M-j> x
   nmap <M-Space> y
+  # And abbreviations
+  abbreviate xy he
+  abbreviate xx she
+  abbreviate <buffer> x they
 
   # Get a list of the mappings with the ':map' commands.
   # Check getmappings() return a list of the same size.
   assert_equal(13, len(getmappings()))
+  assert_equal(3, len(getmappings(true)))
+  assert_equal(13, len(getmappings(false)))
 
   # collect all the current maps using :map commands
   var maps_command: list<string>
@@ -364,8 +372,16 @@ def Test_getmappings()
     assert_equal(d_maparg, d)
   endfor
 
-  ClearMaps()
+  # Check abbr matches maparg
+  for d in getmappings(true)
+    # Note, d.mode is '!', but can't use that with maparg
+    var d_maparg = maparg(d.lhs, 'i', true, true)
+    assert_equal(d_maparg, d)
+  endfor
+
+  ClearMappingsAbbreviations()
   assert_equal(0, len(getmappings()))
+  assert_equal(0, len(getmappings(true)))
 enddef
 
 


### PR DESCRIPTION
And there's considerations of

`mapget()`, `mapgetall()`

`maplist()` or `map_getlist()`. There is some precedence for this with existing functions: digraph_getlist(), prop_type_list(), popup_list(), term_list() and tabpagebuflist(). On the other hand, we also have the following function names: getchangelist(), getjumplist(), getloclist(), getmarklist() and getqflist().

`getmaplist()`
