### PR TITLE
Avoid simplifying "\<*C-@>" into NUL

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1637,7 +1637,11 @@ merge_modifyOtherKeys(int c_arg, int *modifiers)
     if (*modifiers & MOD_MASK_CTRL)
     {
 	if ((c >= '`' && c <= 0x7f) || (c >= '@' && c <= '_'))
+	{
 	    c &= 0x1f;
+	    if (c == NUL)
+		c = K_ZERO;
+	}
 	else if (c == '6')
 	    // CTRL-6 is equivalent to CTRL-^
 	    c = 0x1e;
@@ -3661,7 +3665,7 @@ inchar(
 	    for (;;)
 	    {
 		len = ui_inchar(dum, DUM_LEN, 0L, 0);
-		if (len == 0 || (len == 1 && dum[0] == 3))
+		if (len == 0 || (len == 1 && dum[0] == Ctrl_C))
 		    break;
 	    }
 	    return retesc;

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1561,7 +1561,7 @@ extract_modifiers(int key, int *modp, int simplify, int *did_simplify)
 	key = Ctrl_chr(key);
 	modifiers &= ~MOD_MASK_CTRL;
 	// <C-@> is <Nul>
-	if (key == 0)
+	if (key == NUL)
 	    key = K_ZERO;
 	if (did_simplify != NULL)
 	    *did_simplify = TRUE;

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2437,5 +2437,11 @@ func Test_terminal_builtin_without_gui()
   call assert_notequal(-1, index(output, 'builtin_dumb'))
 endfunc
 
+func Test_simplify_ctrl_at()
+  " feeding unsimplified CTRL-@ should still trigger i_CTRL-@
+  call feedkeys("ifoo\<Esc>A\<*C-@>", 'xt')
+  call assert_equal('foofoo', getline(1))
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Also compare with `NUL` instead of `0` as it is a character.