### PR TITLE
Add a test for another bug fixed by patch 8.2.4819

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -726,6 +726,8 @@ do_map(
 				    mpp = &(mp->m_next);
 				    continue;
 				}
+				// In keyround for simplified keys, don't unmap
+				// a mapping without m_simplified flag.
 				if (keyround1_simplified && !mp->m_simplified)
 				    break;
 				// We reset the indicated mode bits. If nothing

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -1627,7 +1627,7 @@ func Test_mouse_drag_insert_map()
   set mouse&
 endfunc
 
-func Test_unmap_simplfied()
+func Test_unmap_simplifiable()
   map <C-I> foo
   map <Tab> bar
   call assert_equal('foo', maparg('<C-I>'))
@@ -1636,6 +1636,11 @@ func Test_unmap_simplfied()
   call assert_equal('', maparg('<C-I>'))
   call assert_equal('bar', maparg('<Tab>'))
   unmap <Tab>
+
+  map <C-I> foo
+  unmap <Tab>
+  " This should not error
+  unmap <C-I>
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Before patch 8.2.4819 this caused an error:
```vim
map <C-I> foo
unmap <Tab>
unmap <C-I>
```

Patch 8.2.4819 made failure to unmap in the keyround for simplified keys no longer an error.

Also add comments.