### PR TITLE
win32: Parse APPEXECLINK junctions in executable_file()

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -1789,11 +1789,6 @@ resolve_reparse_point(char_u *fname)
     char_u	    *rfname = NULL;
     WCHAR	    *buff = NULL;
     static BOOL	    loaded = FALSE;
-    // The buffer size is arbitrarily chosen to be "big enough" (TM), the
-    // ceiling should be around 16k.
-    char_u	    buf[4096];
-    DWORD	    buf_len = sizeof(buf);
-    REPARSE_DATA_BUFFER *rb = (REPARSE_DATA_BUFFER *)buf;
 
     if (pGetFinalPathNameByHandleW == NULL)
     {

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -72,46 +72,6 @@
 # endif
 #endif
 
-# ifndef IO_REPARSE_TAG_APPEXECLINK
-#  define IO_REPARSE_TAG_APPEXECLINK 0x8000001B
-# endif
-
-/*
- * Definition of the reparse point buffer.
- * This is usually defined in the DDK, copy the definition here to avoid
- * adding it as a dependence only for a single structure.
- */
-typedef struct _REPARSE_DATA_BUFFER {
-    ULONG  ReparseTag;
-    USHORT ReparseDataLength;
-    USHORT Reserved;
-    union {
-	struct {
-	    USHORT SubstituteNameOffset;
-	    USHORT SubstituteNameLength;
-	    USHORT PrintNameOffset;
-	    USHORT PrintNameLength;
-	    ULONG  Flags;
-	    WCHAR  PathBuffer[1];
-	} SymbolicLinkReparseBuffer;
-	struct {
-	    USHORT SubstituteNameOffset;
-	    USHORT SubstituteNameLength;
-	    USHORT PrintNameOffset;
-	    USHORT PrintNameLength;
-	    WCHAR  PathBuffer[1];
-	} MountPointReparseBuffer;
-	struct {
-	    UCHAR DataBuffer[1];
-	} GenericReparseBuffer;
-	struct
-	{
-	    ULONG StringCount;
-	    WCHAR StringList[1];
-	} AppExecLinkReparseBuffer;
-    } DUMMYUNIONNAME;
-} REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
-
 /*
  * When generating prototypes for Win32 on Unix, these lines make the syntax
  * errors disappear.  They do not need to be correct.

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -126,9 +126,9 @@
 #ifndef IO_REPARSE_TAG_SYMLINK
 # define IO_REPARSE_TAG_SYMLINK		0xA000000C
 #endif
-# ifndef IO_REPARSE_TAG_APPEXECLINK
-#  define IO_REPARSE_TAG_APPEXECLINK	0x8000001B
-# endif
+#ifndef IO_REPARSE_TAG_APPEXECLINK
+# define IO_REPARSE_TAG_APPEXECLINK	0x8000001B
+#endif
 
 /*
  * Definition of the reparse point buffer.

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -126,6 +126,45 @@
 #ifndef IO_REPARSE_TAG_SYMLINK
 # define IO_REPARSE_TAG_SYMLINK		0xA000000C
 #endif
+# ifndef IO_REPARSE_TAG_APPEXECLINK
+#  define IO_REPARSE_TAG_APPEXECLINK	0x8000001B
+# endif
+
+/*
+ * Definition of the reparse point buffer.
+ * This is usually defined in the DDK, copy the definition here to avoid
+ * adding it as a dependence only for a single structure.
+ */
+typedef struct _REPARSE_DATA_BUFFER {
+    ULONG  ReparseTag;
+    USHORT ReparseDataLength;
+    USHORT Reserved;
+    union {
+	struct {
+	    USHORT SubstituteNameOffset;
+	    USHORT SubstituteNameLength;
+	    USHORT PrintNameOffset;
+	    USHORT PrintNameLength;
+	    ULONG  Flags;
+	    WCHAR  PathBuffer[1];
+	} SymbolicLinkReparseBuffer;
+	struct {
+	    USHORT SubstituteNameOffset;
+	    USHORT SubstituteNameLength;
+	    USHORT PrintNameOffset;
+	    USHORT PrintNameLength;
+	    WCHAR  PathBuffer[1];
+	} MountPointReparseBuffer;
+	struct {
+	    UCHAR DataBuffer[1];
+	} GenericReparseBuffer;
+	struct
+	{
+	    ULONG StringCount;
+	    WCHAR StringList[1];
+	} AppExecLinkReparseBuffer;
+    } DUMMYUNIONNAME;
+} REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
 
 #ifdef _MSC_VER
     // Support for __try / __except.  All versions of MSVC are

--- a/src/proto/os_mswin.pro
+++ b/src/proto/os_mswin.pro
@@ -50,4 +50,5 @@ char *charset_id2name(int id);
 char *quality_id2name(DWORD id);
 int get_logfont(LOGFONTW *lf, char_u *name, HDC printer_dc, int verbose);
 void channel_init_winsock(void);
+char_u *resolve_appexeclink(char_u *fname);
 /* vim: set ft=c : */

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1398,6 +1398,28 @@ func Test_Executable()
   endif
 endfunc
 
+func Test_executable_windows_store_apps()
+  CheckMSWindows
+
+  " Windows Store apps install some 'decoy' .exe that require some careful
+  " handling as they behave similarly to symlinks.
+  let app_dir = expand("$LOCALAPPDATA\\Microsoft\\WindowsApps")
+  if !isdirectory(app_dir)
+    return
+  endif
+
+  let save_path = $PATH
+  let $PATH = app_dir
+  " Ensure executable() finds all the app .exes
+  for entry in readdir(app_dir)
+    if entry =~ '\.exe$'
+      call assert_true(executable(entry))
+    endif
+  endfor
+
+  let $PATH = save_path
+endfunc
+
 func Test_executable_longname()
   CheckMSWindows
 


### PR DESCRIPTION
On newer Windows versions (>= 10) the Windows Store installs some decoy
.exe files in %LOCALAPPDATA%\Microsoft\WindowsApps that can _only_ be
executed, doing any other I/O operation on them results in a
file-not-found error to be raised.

This PR solves a (big?) problem if eg. you've installed python from the
store, in that case calling executable('python') or exepath('python')
would fail miserably even though python.exe _is_ found in $PATH.

cc @k-takata 