### PR TITLE
Implement isabsolutepath()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -295,6 +295,7 @@ inputsecret({prompt} [, {text}]) String	like input() but hiding the text
 insert({object}, {item} [, {idx}]) List	insert {item} in {object} [before {idx}]
 interrupt()			none	interrupt script execution
 invert({expr})			Number	bitwise invert
+isabsolutepath({path})		Number	|TRUE| if {path} is an absolute path
 isdirectory({directory})	Number	|TRUE| if {directory} is a directory
 isinf({expr})			Number	determine if {expr} is infinity value
 					(positive or negative)
@@ -4671,6 +4672,24 @@ invert({expr})						*invert()*
 			:let bits = invert(bits)
 <		Can also be used as a |method|: >
 			:let bits = bits->invert()
+
+isabsolutepath({directory})				*isabsolutepath()*
+		The result is a Number, which is |TRUE| when {path} is an
+		absolute path.
+<		On Unix, a path is considered absolute when it starts with '/'.
+		On MS-Windows, it is considered absolute when it starts with an
+		optional drive prefix and is followed by a '\' or '/'. UNC paths
+		are always absolute.
+		Example: >
+			echo isabsolutepath('/usr/share/')	" 1
+			echo isabsolutepath('./foobar')		" 0
+			echo isabsolutepath('C:\Windows')	" 1
+			echo isabsolutepath('foobar')		" 0
+			echo isabsolutepath('\\remote\file')	" 1
+
+		Can also be used as a |method|: >
+			GetName()->isabsolutepath()
+
 
 isdirectory({directory})				*isdirectory()*
 		The result is a Number, which is |TRUE| when a directory

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -904,6 +904,7 @@ System functions and manipulation of files:
 	getfperm()		get the permissions of a file
 	setfperm()		set the permissions of a file
 	getftype()		get the kind of a file
+	isabsolutepath()	check if a path is absolute
 	isdirectory()		check if a directory exists
 	getfsize()		get the size of a file
 	getcwd()		get the current working directory

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1969,6 +1969,8 @@ static funcentry_T global_functions[] =
 			ret_void,	    f_interrupt},
     {"invert",		1, 1, FEARG_1,	    arg1_number,
 			ret_number,	    f_invert},
+    {"isabsolutepath",	1, 1, FEARG_1,	    arg1_string,
+			ret_number_bool,    f_isabsolutepath},
     {"isdirectory",	1, 1, FEARG_1,	    arg1_string,
 			ret_number_bool,    f_isdirectory},
     {"isinf",		1, 1, FEARG_1,	    arg1_float_or_nr,

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -1417,6 +1417,18 @@ f_isdirectory(typval_T *argvars, typval_T *rettv)
 }
 
 /*
+ * "isabsolutepath()" function
+ */
+    void
+f_isabsolutepath(typval_T *argvars, typval_T *rettv)
+{
+    if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
+	return;
+
+    rettv->vval.v_number = mch_isFullName(tv_get_string_strict(&argvars[0]));
+}
+
+/*
  * Create the directory in which "dir" is located, and higher levels when
  * needed.
  * Return OK or FAIL.

--- a/src/proto/filepath.pro
+++ b/src/proto/filepath.pro
@@ -22,6 +22,7 @@ void f_glob(typval_T *argvars, typval_T *rettv);
 void f_glob2regpat(typval_T *argvars, typval_T *rettv);
 void f_globpath(typval_T *argvars, typval_T *rettv);
 void f_isdirectory(typval_T *argvars, typval_T *rettv);
+void f_isabsolutepath(typval_T *argvars, typval_T *rettv);
 void f_mkdir(typval_T *argvars, typval_T *rettv);
 void f_pathshorten(typval_T *argvars, typval_T *rettv);
 void f_readdir(typval_T *argvars, typval_T *rettv);

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2887,5 +2887,23 @@ func Test_funcref_to_string()
   call assert_equal("function('g:Test_funcref_to_string')", string(Fn))
 endfunc
 
+" Test for isabsolutepath()
+func Test_isabsolutepath()
+  call assert_false(isabsolutepath(''))
+  call assert_false(isabsolutepath('.'))
+  call assert_false(isabsolutepath('../Foo'))
+  call assert_false(isabsolutepath('Foo/'))
+  if has('win32')
+    call assert_true(isabsolutepath('A:\'))
+    call assert_true(isabsolutepath('A:\Foo'))
+    call assert_true(isabsolutepath('A:/Foo'))
+    call assert_false(isabsolutepath('A:Foo'))
+    call assert_false(isabsolutepath('\Windows'))
+    call assert_true(isabsolutepath('\\Server2\Share\Test\Foo.txt'))
+  else
+    call assert_true(isabsolutepath('/'))
+    call assert_true(isabsolutepath('/usr/share/'))
+  endif
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This is statistically one of the most reimplemented function by plugin
writers with different degrees of accuracy: some of them use regexps
while others only check the presence of the root path separator).