### PR TITLE
Fix modifiers not simplifed when timed out or using feedkeys() with "n" flag

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2699,17 +2699,19 @@ handle_mapping(
 	 * - and not an ESC sequence, not in insert mode or p_ek is on,
 	 * - and when not timed out,
 	 */
-	if ((no_mapping == 0 || allow_keys != 0)
-		&& (typebuf.tb_maplen == 0
+	if (no_mapping == 0 || allow_keys != 0)
+	{
+	    if ((typebuf.tb_maplen == 0
 		    || (p_remap && typebuf.tb_noremap[
 						    typebuf.tb_off] == RM_YES))
 		&& !*timedout)
-	{
-	    keylen = check_termcode(max_mlen + 1, NULL, 0, NULL);
+		keylen = check_termcode(max_mlen + 1, NULL, 0, NULL);
+	    else
+		keylen = 0;
 
 	    // If no termcode matched but 'pastetoggle' matched partially
 	    // it's like an incomplete key sequence.
-	    if (keylen == 0 && save_keylen == KEYLEN_PART_KEY)
+	    if (keylen == 0 && save_keylen == KEYLEN_PART_KEY && !*timedout)
 		keylen = KEYLEN_PART_KEY;
 
 	    // If no termcode matched, try to include the modifier into the

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2444,5 +2444,21 @@ func Test_simplify_ctrl_at()
   bw!
 endfunc
 
+func Test_simplify_noremap()
+  call feedkeys("i\<*C-M>", 'nx')
+  call assert_equal('', getline(1))
+  call assert_equal([0, 2, 1, 0, 1], getcurpos())
+  bw!
+endfunc
+
+func Test_simplify_timedout()
+  inoremap <C-M>a b
+  call feedkeys("i\<*C-M>", 'xt')
+  call assert_equal('', getline(1))
+  call assert_equal([0, 2, 1, 0, 1], getcurpos())
+  iunmap <C-M>a
+  bw!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This fixes two regressions from patch 8.2.0919.