### PR TITLE
Fix termguicolors not to break ctermbg=NONE on vim.exe & Windows Terminal.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8073,6 +8073,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	This requires Vim to be built with the |+vtp| feature.
 
 	Note that the "cterm" attributes are still used, not the "gui" ones.
+
+	When using vim with Windows Terminal, the background image of Windows
+	Terminal is filled with the vim background colors.
+	Setting termguicolors and the guibg of the Normal highlight group to
+	NONE will make transparent to the background: >
+		:hi Normal guibg=NONE
+<
 	NOTE: This option is reset when 'compatible' is set.
 
 						*'termwinkey'* *'twk'*

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -8139,7 +8139,7 @@ get_default_console_color(
 	if (id > 0)
 	    syn_id2cterm_bg(id, &ctermfg, &ctermbg);
 	if (ctermbg != -1)
-	    cterm_normal_bg_gui_color = ctermtoxterm(ctermbg);
+	    cterm_normal_bg_gui_color = guibg = ctermtoxterm(ctermbg);
 	else
 	{
 	    guibg = INVALCOLOR;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -8142,7 +8142,10 @@ get_default_console_color(
 	    syn_id2cterm_bg(id, &ctermfg, &ctermbg);
 	guibg = ctermbg != -1 ? ctermtoxterm(ctermbg)
 						    : default_console_color_bg;
-	cterm_normal_bg_gui_color = guibg;
+	if (ctermbg != -1)
+	    cterm_normal_bg_gui_color = guibg;
+	else
+	    guibg = INVALCOLOR;
 	ctermbg = ctermbg < 0 ? 0 : ctermbg;
     }
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -8138,13 +8138,11 @@ get_default_console_color(
 	ctermbg = -1;
 	if (id > 0)
 	    syn_id2cterm_bg(id, &ctermfg, &ctermbg);
-	if (ctermbg != -1)
-	    cterm_normal_bg_gui_color = guibg = ctermtoxterm(ctermbg);
-	else
-	{
-	    guibg = INVALCOLOR;
+	cterm_normal_bg_gui_color = guibg =
+	    ctermbg != -1 ? ctermtoxterm(ctermbg) : INVALCOLOR;
+
+	if (ctermbg < 0)
 	    ctermbg = 0;
-	}
     }
 
     *cterm_fg = ctermfg;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -211,7 +211,6 @@ static int g_color_index_bg = 0;
 static int g_color_index_fg = 7;
 
 # ifdef FEAT_TERMGUICOLORS
-static int default_console_color_bg = 0x000000; // black
 static int default_console_color_fg = 0xc0c0c0; // white
 # endif
 
@@ -7859,7 +7858,6 @@ vtp_init(void)
     fg = (COLORREF)csbi.ColorTable[g_color_index_fg];
     bg = (GetRValue(bg) << 16) | (GetGValue(bg) << 8) | GetBValue(bg);
     fg = (GetRValue(fg) << 16) | (GetGValue(fg) << 8) | GetBValue(fg);
-    default_console_color_bg = bg;
     default_console_color_fg = fg;
 # endif
 
@@ -8140,13 +8138,13 @@ get_default_console_color(
 	ctermbg = -1;
 	if (id > 0)
 	    syn_id2cterm_bg(id, &ctermfg, &ctermbg);
-	guibg = ctermbg != -1 ? ctermtoxterm(ctermbg)
-						    : default_console_color_bg;
 	if (ctermbg != -1)
-	    cterm_normal_bg_gui_color = guibg;
+	    cterm_normal_bg_gui_color = ctermtoxterm(ctermbg);
 	else
+	{
 	    guibg = INVALCOLOR;
-	ctermbg = ctermbg < 0 ? 0 : ctermbg;
+	    ctermbg = 0;
+	}
     }
 
     *cterm_fg = ctermfg;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7827,7 +7827,7 @@ vtp_init(void)
     HMODULE hKerneldll;
     DYN_CONSOLE_SCREEN_BUFFER_INFOEX csbi;
 # ifdef FEAT_TERMGUICOLORS
-    COLORREF fg, bg;
+    COLORREF fg;
 # endif
 
     // Use functions supported from Vista
@@ -7854,9 +7854,7 @@ vtp_init(void)
     store_console_fg_rgb = save_console_fg_rgb;
 
 # ifdef FEAT_TERMGUICOLORS
-    bg = (COLORREF)csbi.ColorTable[g_color_index_bg];
     fg = (COLORREF)csbi.ColorTable[g_color_index_fg];
-    bg = (GetRValue(bg) << 16) | (GetGValue(bg) << 8) | GetBValue(bg);
     fg = (GetRValue(fg) << 16) | (GetGValue(fg) << 8) | GetBValue(fg);
     default_console_color_fg = fg;
 # endif

--- a/src/term.c
+++ b/src/term.c
@@ -3083,7 +3083,8 @@ term_fg_rgb_color(guicolor_T rgb)
     void
 term_bg_rgb_color(guicolor_T rgb)
 {
-    term_rgb_color(T_8B, rgb);
+    if (rgb != INVALCOLOR)
+	term_rgb_color(T_8B, rgb);
 }
 
     void


### PR DESCRIPTION
Current implementation of vim.exe, ctermbg=NONE does not make transparent on Windows Terminal.

Repro steps

1. Start Windows Terminal
2. Set background image of cmd.exe to something.
3. Start vim.exe on the cmd.exe
4. `set termguicolor`

![image](https://user-images.githubusercontent.com/10111/165780775-a5ca4ea4-871f-4dc8-98e9-210e20cca33f.png)

![image](https://user-images.githubusercontent.com/10111/165781678-db529a12-33d7-47c6-9ba8-cf754ae1c737.png)

![image](https://user-images.githubusercontent.com/10111/165781764-6cd12c9d-5678-4adc-838c-462cf5139dd9.png)

![image](https://user-images.githubusercontent.com/10111/165785019-ccdeb643-ef37-432e-9840-b4b085543ed9.png)

This change fixes background color not to set invalid color.

![image](https://user-images.githubusercontent.com/10111/165785120-1613eb7c-586d-4883-8046-96f916a98798.png)

![image](https://user-images.githubusercontent.com/10111/165785328-4971a442-ad5e-4f8e-a233-5e9cc46ab7aa.png)

If the ctermbg is set to NONE of Normal highlight group, this works like below.

![image](https://user-images.githubusercontent.com/10111/165785978-991e234f-138b-493c-ae9b-d8afbc3fe566.png)
