### PR TITLE
Save tab-local working directory when 'tabpages' is not specified

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -623,13 +623,14 @@ makeopens(
     win_T	*wp;
     char_u	*sname;
     win_T	*edited_win = NULL;
-    int		tabnr;
+    int		tabnr = 0;
     int		restore_stal = FALSE;
     win_T	*tab_firstwin;
     frame_T	*tab_topframe;
     int		cur_arg_idx = 0;
     int		next_arg_idx = 0;
     int		ret = FAIL;
+    tabpage_T	*tp;
 #ifdef FEAT_TERMINAL
     hashtab_T	terminal_bufs;
 
@@ -763,8 +764,6 @@ makeopens(
     tab_topframe = topframe;
     if ((ssop_flags & SSOP_TABPAGES))
     {
-	tabpage_T *tp;
-
 	// Similar to ses_win_rec() below, populate the tab pages first so
 	// later local options won't be copied to the new tabs.
 	FOR_ALL_TABPAGES(tp)
@@ -777,18 +776,15 @@ makeopens(
 	if (first_tabpage->tp_next != NULL && put_line(fd, "tabrewind") == FAIL)
 	    goto fail;
     }
-    for (tabnr = 1; ; ++tabnr)
+    FOR_ALL_TABPAGES(tp)
     {
-	tabpage_T *tp = NULL;
 	int	need_tabnext = FALSE;
 	int	cnr = 1;
 
+	++tabnr;
+
 	if ((ssop_flags & SSOP_TABPAGES))
 	{
-	    tp = find_tabpage(tabnr);
-
-	    if (tp == NULL)
-		break;		// done all tab pages
 	    if (tp == curtab)
 	    {
 		tab_firstwin = firstwin;

--- a/src/session.c
+++ b/src/session.c
@@ -888,6 +888,8 @@ makeopens(
 	// override the tab-local directory.
 	if (ssop_flags & SSOP_CURDIR)
 	{
+	    // When we're asked to save only the current tab page use curtab
+	    // instead of tp, the loop will terminate after this page is saved.
 	    tabpage_T	*t = (ssop_flags & SSOP_TABPAGES) ? tp : curtab;
 	    if (t->tp_localdir != NULL)
 	    {

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -873,17 +873,24 @@ func Test_mksession_tcd_single_tabs()
   let save_cwd = getcwd()
   set sessionoptions-=tabpages
   set sessionoptions+=curdir
-  call mkdir('Xtopdir')
+  call mkdir('Xtopdir1')
+  call mkdir('Xtopdir2')
 
-  tcd Xtopdir
+  " There are two tab pages, the current one has local cwd set to 'Xtopdir2'.
+  exec 'tcd ' .. save_cwd .. '/Xtopdir1'
+  tabnew
+  exec 'tcd ' .. save_cwd .. '/Xtopdir2'
   mksession! Xtest_tcd_single
 
   source Xtest_tcd_single
   call assert_equal(2, haslocaldir())
+  call assert_equal('Xtopdir2', fnamemodify(getcwd(-1, 0), ':t'))
+  %bwipe
 
   set sessionoptions&
   call chdir(save_cwd)
-  call delete('Xtopdir', 'rf')
+  call delete('Xtopdir1', 'rf')
+  call delete('Xtopdir2', 'rf')
 endfunc
 
 " Test for storing the 'lines' and 'columns' settings

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -865,6 +865,27 @@ func Test_mksession_sesdir()
   call delete('Xproj', 'rf')
 endfunc
 
+" Test for saving and restoring the tab-local working directory when there is
+" only a single tab and 'tabpages' is not in 'sessionoptions'.
+func Test_mksession_tcd_single_tabs()
+  only | tabonly
+
+  let save_cwd = getcwd()
+  set sessionoptions-=tabpages
+  set sessionoptions+=curdir
+  call mkdir('Xtopdir')
+
+  tcd Xtopdir
+  mksession! Xtest_tcd_single
+
+  source Xtest_tcd_single
+  call assert_equal(2, haslocaldir())
+
+  set sessionoptions&
+  call chdir(save_cwd)
+  call delete('Xtopdir', 'rf')
+endfunc
+
 " Test for storing the 'lines' and 'columns' settings
 func Test_mksession_resize()
   mksession! Xtest_mks1.out


### PR DESCRIPTION
According to the documentation 'tabpages' is only meant to restore the
tab layout. Saving the working directory, no matter whether local or
global, should only depend on 'curdir'.

This problem affects some plugins like
https://github.com/dhruvasagar/vim-zoom/issues/21