### PR TITLE
Do not simplify Ctrl if Shift is present

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1634,7 +1634,7 @@ merge_modifyOtherKeys(int c_arg, int *modifiers)
 {
     int c = c_arg;
 
-    if (*modifiers & MOD_MASK_CTRL)
+    if ((*modifiers & MOD_MASK_CTRL) && !(*modifiers & MOD_MASK_SHIFT))
     {
 	if ((c >= '`' && c <= 0x7f) || (c >= '@' && c <= '_'))
 	{

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1560,4 +1560,10 @@ func Test_gui_findrepl()
   bw!
 endfunc
 
+func Test_gui_CTRL_V()
+  call feedkeys(":let g:str = '\<C-V>\<*C-S-I>\<C-V>\<*C-S-@>'\<CR>", 'tx')
+  call assert_equal('<C-S-I><C-S-@>', g:str)
+  unlet g:str
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This fixes `<C-S-I>` becoming `<S-Tab>` and `<C-S-@>` becoming `<S-NL>` after `c_CTRL-V` in GUI.