### PR TITLE
win term: do not take highlight attributes from NORMAL

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -3283,27 +3283,6 @@ set_hl_attr(
 	at_en.ae_u.cterm.bg_color = sgp->sg_cterm_bg;
 	at_en.ae_u.cterm.ul_color = sgp->sg_cterm_ul;
 # ifdef FEAT_TERMGUICOLORS
-#  ifdef MSWIN
-#   ifdef VIMDLL
-	// Only when not using the GUI.
-	if (!gui.in_use && !gui.starting)
-#   endif
-	{
-	    int id;
-	    guicolor_T fg, bg;
-
-	    id = syn_name2id((char_u *)"Normal");
-	    if (id > 0)
-	    {
-		syn_id2colors(id, &fg, &bg);
-		if (sgp->sg_gui_fg == INVALCOLOR)
-		    sgp->sg_gui_fg = fg;
-		if (sgp->sg_gui_bg == INVALCOLOR)
-		    sgp->sg_gui_bg = bg;
-	    }
-
-	}
-#  endif
 	at_en.ae_u.cterm.fg_rgb = GUI_MCH_GET_RGB2(sgp->sg_gui_fg);
 	at_en.ae_u.cterm.bg_rgb = GUI_MCH_GET_RGB2(sgp->sg_gui_bg);
 	// Only use the underline/undercurl color when used, it may clear the


### PR DESCRIPTION
It doesn't seem to make sense, that when defining a highlighting group
to copy over foreground and background color definitions from the NORMAL
highlighting group. Because:

1) you lose the ability to combine those groups properly with each other
   (e.g. CursorLine highlight cannot show Syntax highlighting, even when defining 
    CursorLine explicitly without a foreground color)
2) it's inconsistent to what happens on other systems (windows gui
   behaves different, as does linux)
3) why to do it only when 'termguicolor' is set?
4) when querying the highlighting attributes using `synIDattr()` you
    get other results from what was the intention when it was defined
5) those NORMAL attributes are copied over at the time the highlighting group
    is defined. But when it is used, it may have changed already (and when a
    colorscheme first defines ColorLine highlighting and Normal group afterwards, 
    that would be different again)

So let's just remove that part of the code that was there since whenever
24bit color for the windows console have been introduced in
cafafb381a04e33f3ce9cd15d

ping @k-takata, @mattn, @ntakcat

closes #10241, #9617