### PR TITLE
Add filetype detection for Gleam.

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -719,6 +719,9 @@ au BufNewFile,BufRead *.git/*
 " Gkrellmrc
 au BufNewFile,BufRead gkrellmrc,gkrellmrc_?	setf gkrellmrc
 
+" Gleam
+au BufNewFile,BufRead *.gleam			setf gleam
+
 " GLSL
 au BufNewFile,BufRead *.glsl			setf glsl
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -211,6 +211,7 @@ let s:filename_checks = {
     \ 'gitrebase': ['git-rebase-todo'],
     \ 'gitsendemail': ['.gitsendemail.msg.xxxxxx'],
     \ 'gkrellmrc': ['gkrellmrc', 'gkrellmrc_x'],
+    \ 'gleam': ['file.gleam'],
     \ 'glsl': ['file.glsl'],
     \ 'gnash': ['gnashrc', '.gnashrc', 'gnashpluginrc', '.gnashpluginrc'],
     \ 'gnuplot': ['file.gpi', '.gnuplot'],


### PR DESCRIPTION
Since there is currently no filetype detection for [Gleam](https://gleam.run), I thought it would be worth adding.

It was a bit unclear to me how to properly test this, but I've been using https://github.com/vim/vim/pull/10120 as a reference. Please, let me know if anything is missing.