### PR TITLE
Implement interpolated strings

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3255,19 +3255,16 @@ text...
 
 			If "eval" is not specified, then each line of text is
 			used as a |literal-string|.  If "eval" is specified,
-			then any Vim expression in the form ``={expr}`` is
-			evaluated and the result replaces the expression.
+			then each line is used as an |interp-string|.
 			Example where $HOME is expanded: >
 				let lines =<< trim eval END
 				  some text
-				  See the file `=$HOME`/.vimrc
+				  See the file {$HOME}/.vimrc
 				  more text
 				END
 <			There can be multiple Vim expressions in a single line
 			but an expression cannot span multiple lines.  If any
 			expression evaluation fails, then the assignment fails.
-			once the "`=" has been found {expr} and a backtick
-			must follow.  {expr} cannot be empty.
 
 			{endmarker} must not contain white space.
 			{endmarker} cannot start with a lower case character.
@@ -3320,10 +3317,10 @@ text...
 				DATA
 
 				let code =<< trim eval CODE
-				   let v = `=10 + 20`
-				   let h = "`=$HOME`"
-				   let s = "`=Str1()` abc `=Str2()`"
-				   let n = `=MyFunc(3, 4)`
+				   let v = {10 + 20}
+				   let h = "{$HOME}"
+				   let s = "{Str1()} abc {Str2()}"
+				   let n = {MyFunc(3, 4)}
 				CODE
 <
 								*E121*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1542,7 +1542,7 @@ To include an opening brace '{' in the string content double it.
 Examples: >
 	let your_name = input("What's your name? ")
 	echo $"Hello, {your_name}!"
-	echo $"{your_name} spelled backwards is {your_name->reverse()}!"
+	echo $"The square root of 9 is {sqrt(9)}"
 
 option						*expr-option* *E112* *E113*
 ------

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1523,6 +1523,27 @@ to be doubled.  These two commands are equivalent: >
 	if a =~ '\s*'
 
 
+interpolated-string					*interp-string* *E256*
+--------------------
+$"string"		interpolated string constant		*expr-$quote*
+$'string'		interpolated literal string constant	*expr-$'*
+
+Interpolated strings are an extension of the |string| and |literal-string|,
+allowing the inclusion of Vim script expressions (see |expr1|).
+
+String literals that are preceded by the '$' symbol are interpreted as
+interpolated strings.  Any valid expression returning a value can be enclosed
+between braces, '{' and '}' to distinguish it from the string content.  After
+the whole string is parsed and all the blocks successfully evaluated a new
+string composed by appending all the pieces is returned.
+
+To include an opening brace '{' in the string content double it.
+
+Examples: >
+	let your_name = input("What's your name? ")
+	echo $"Hello, {your_name}!"
+	echo $"{your_name} spelled backwards is {your_name->reverse()}!"
+
 option						*expr-option* *E112* *E113*
 ------
 &option			option value, local value if possible

--- a/src/errors.h
+++ b/src/errors.h
@@ -622,7 +622,8 @@ EXTERN char e_cannot_allocate_color_str[]
 EXTERN char e_couldnt_read_in_sign_data[]
 	INIT(= N_("E255: Couldn't read in sign data"));
 #endif
-// E256 unused
+EXTERN char e_missing_close_curly_str[]
+	INIT(= N_("E256: Missing }: %s"));
 #ifdef FEAT_CSCOPE
 EXTERN char e_cstag_tag_not_founc[]
 	INIT(= N_("E257: cstag: tag not found"));

--- a/src/errors.h
+++ b/src/errors.h
@@ -248,7 +248,8 @@ EXTERN char e_escape_not_allowed_in_digraph[]
 EXTERN char e_using_loadkeymap_not_in_sourced_file[]
 	INIT(= N_("E105: Using :loadkeymap not in a sourced file"));
 #endif
-// E106 unused
+EXTERN char e_stray_closing_curly_str[]
+	INIT(= N_("E106: Stray '}' without a matching '{': %s"));
 #ifdef FEAT_EVAL
 EXTERN char e_missing_parenthesis_str[]
 	INIT(= N_("E107: Missing parentheses: %s"));

--- a/src/eval.c
+++ b/src/eval.c
@@ -3763,8 +3763,12 @@ eval7(
 
     /*
      * Environment variable: $VAR.
+     * Interpolated string: $"string" or $'string'.
      */
-    case '$':	ret = eval_env_var(arg, rettv, evaluate);
+    case '$':	if ((*arg)[1] == '"' || (*arg)[1] == '\'')
+		    ret = eval_interp_string(arg, rettv, evaluate);
+		else
+		    ret = eval_env_var(arg, rettv, evaluate);
 		break;
 
     /*

--- a/src/proto/evalvars.pro
+++ b/src/proto/evalvars.pro
@@ -105,4 +105,6 @@ void set_callback(callback_T *dest, callback_T *src);
 void copy_callback(callback_T *dest, callback_T *src);
 void expand_autload_callback(callback_T *cb);
 void free_callback(callback_T *callback);
+char_u *eval_all_expr_in_str(char_u *str);
+
 /* vim: set ft=c : */

--- a/src/proto/typval.pro
+++ b/src/proto/typval.pro
@@ -71,6 +71,7 @@ int eval_string(char_u **arg, typval_T *rettv, int evaluate);
 int eval_lit_string(char_u **arg, typval_T *rettv, int evaluate);
 char_u *tv2string(typval_T *tv, char_u **tofree, char_u *numbuf, int copyID);
 int eval_env_var(char_u **arg, typval_T *rettv, int evaluate);
+int eval_interp_string(char_u **arg, typval_T *rettv, int evaluate);
 linenr_T tv_get_lnum(typval_T *argvars);
 linenr_T tv_get_lnum_buf(typval_T *argvars, buf_T *buf);
 buf_T *tv_get_buf(typval_T *tv, int curtab_only);

--- a/src/proto/vim9compile.pro
+++ b/src/proto/vim9compile.pro
@@ -16,7 +16,7 @@ int may_get_next_line(char_u *whitep, char_u **arg, cctx_T *cctx);
 int may_get_next_line_error(char_u *whitep, char_u **arg, cctx_T *cctx);
 void fill_exarg_from_cctx(exarg_T *eap, cctx_T *cctx);
 int func_needs_compiling(ufunc_T *ufunc, compiletype_T compile_type);
-int compile_heredoc_string(char_u *str, int evalstr, cctx_T *cctx);
+int compile_all_expr_in_str(char_u *str, int evalstr, cctx_T *cctx);
 int assignment_len(char_u *p, int *heredoc);
 void vim9_declare_error(char_u *name);
 int get_var_dest(char_u *name, assign_dest_T *dest, cmdidx_T cmdidx, int *option_scope, int *vimvaridx, type_T **type, cctx_T *cctx);

--- a/src/testdir/test_debugger.vim
+++ b/src/testdir/test_debugger.vim
@@ -377,7 +377,7 @@ func Test_Debugger_breakadd_expr()
   let expected =<< eval trim END
     Oldval = "10"
     Newval = "11"
-    `=fnamemodify('Xtest.vim', ':p')`
+    {fnamemodify('Xtest.vim', ':p')}
     line 1: let g:Xtest_var += 1
   END
   call RunDbgCmd(buf, ':source %', expected)
@@ -385,7 +385,7 @@ func Test_Debugger_breakadd_expr()
   let expected =<< eval trim END
     Oldval = "11"
     Newval = "12"
-    `=fnamemodify('Xtest.vim', ':p')`
+    {fnamemodify('Xtest.vim', ':p')}
     line 1: let g:Xtest_var += 1
   END
   call RunDbgCmd(buf, ':source %', expected)

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -895,9 +895,11 @@ func Test_string_interp()
     call assert_equal('', $"")
     call assert_equal('foobar', $"foobar")
     #" Escaping rules.
-    call assert_equal('"foo"{bar}', $"\"foo\"{{bar}")
-    call assert_equal('"foo"{bar}', $'"foo"{{bar}')
+    call assert_equal('"foo"{bar}', $"\"foo\"{{bar}}")
+    call assert_equal('"foo"{bar}', $'"foo"{{bar}}')
     call assert_equal('foobar', $"{\"foo\"}" .. $'{''bar''}')
+    #" Whitespace before/after the expression.
+    call assert_equal('3', $"{ 1 + 2 }")
     #" String conversion.
     call assert_equal('hello from ' .. v:version, $"hello from {v:version}")
     call assert_equal('hello from ' .. v:version, $'hello from {v:version}')
@@ -906,7 +908,7 @@ func Test_string_interp()
     call assert_equal('(1+1=2)', $"(1+1={1 + 1})")
     #" Hex-escaped opening brace: char2nr('{') == 0x7b
     call assert_equal('esc123ape', $"esc\x7b123}ape")
-    call assert_equal('me{}me', $"me\x7b\x7b}me")
+    call assert_equal('me{}me', $"me{\x7b}\x7dme")
     VAR var1 = "sun"
     VAR var2 = "shine"
     call assert_equal('sunshine', $"{var1}{var2}")
@@ -922,6 +924,8 @@ func Test_string_interp()
     endif
     call assert_equal(0, tmp)
 
+    #" Stray closing brace.
+    call assert_fails('echo $"moo}"', 'E106:')
     #" Undefined variable in expansion.
     call assert_fails('echo $"{moo}"', 'E121:')
     #" Empty blocks are rejected.

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -890,4 +890,56 @@ func Test_float_compare()
   call v9.CheckLegacyAndVim9Success(lines)
 endfunc
 
+func Test_string_interp()
+  let lines =<< trim END
+    call assert_equal('', $"")
+    call assert_equal('foobar', $"foobar")
+    #" Escaping rules.
+    call assert_equal('"foo"{bar}', $"\"foo\"{{bar}")
+    call assert_equal('"foo"{bar}', $'"foo"{{bar}')
+    call assert_equal('foobar', $"{\"foo\"}" .. $'{''bar''}')
+    #" String conversion.
+    call assert_equal('hello from ' .. v:version, $"hello from {v:version}")
+    call assert_equal('hello from ' .. v:version, $'hello from {v:version}')
+    #" Paper over a small difference between VimScript behaviour.
+    call assert_equal(string(v:true), $"{v:true}")
+    call assert_equal('(1+1=2)', $"(1+1={1 + 1})")
+    #" Hex-escaped opening brace: char2nr('{') == 0x7b
+    call assert_equal('esc123ape', $"esc\x7b123}ape")
+    call assert_equal('me{}me', $"me\x7b\x7b}me")
+    VAR var1 = "sun"
+    VAR var2 = "shine"
+    call assert_equal('sunshine', $"{var1}{var2}")
+    call assert_equal('sunsunsun', $"{var1->repeat(3)}")
+    #" Multibyte strings.
+    call assert_equal('say ハロー・ワールド', $"say {'ハロー・ワールド'}")
+    #" Nested.
+    call assert_equal('foobarbaz', $"foo{$\"{'bar'}\"}baz")
+    #" Do not evaluate blocks when the expr is skipped.
+    VAR tmp = 0
+    if v:false
+      echo "${ LET tmp += 1 }"
+    endif
+    call assert_equal(0, tmp)
+
+    #" Undefined variable in expansion.
+    call assert_fails('echo $"{moo}"', 'E121:')
+    #" Empty blocks are rejected.
+    call assert_fails('echo $"{}"', 'E15:')
+    call assert_fails('echo $"{   }"', 'E15:')
+  END
+  call v9.CheckLegacyAndVim9Success(lines)
+
+  let lines =<< trim END
+    call assert_equal('5', $"{({x -> x + 1})(4)}")
+  END
+  call v9.CheckLegacySuccess(lines)
+
+  let lines =<< trim END
+    call assert_equal('5', $"{((x) => x + 1)(4)}")
+    call assert_fails('echo $"{ # foo }"', 'E256:')
+  END
+  call v9.CheckDefAndScriptSuccess(lines)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -498,72 +498,72 @@ END
   call assert_equal(['     x', '     \y', '     z'], [a, b, c])
 endfunc
 
-" Test for evaluating Vim expressions in a heredoc using `=expr`
+" Test for evaluating Vim expressions in a heredoc using {expr}
 " Keep near the end, this messes up highlighting.
 func Test_let_heredoc_eval()
   let str = ''
   let code =<< trim eval END
-    let a = `=5 + 10`
-    let b = `=min([10, 6])` + `=max([4, 6])`
-    `=str`
-    let c = "abc`=str`d"
+    let a = {5 + 10}
+    let b = {min([10, 6])} + {max([4, 6])}
+    {str}
+    let c = "abc{str}d"
   END
   call assert_equal(['let a = 15', 'let b = 6 + 6', '', 'let c = "abcd"'], code)
 
   let $TESTVAR = "Hello"
   let code =<< eval trim END
-    let s = "`=$TESTVAR`"
+    let s = "{$TESTVAR}"
   END
   call assert_equal(['let s = "Hello"'], code)
 
   let code =<< eval END
-    let s = "`=$TESTVAR`"
+    let s = "{$TESTVAR}"
 END
   call assert_equal(['    let s = "Hello"'], code)
 
   let a = 10
   let data =<< eval END
-`=a`
+{a}
 END
   call assert_equal(['10'], data)
 
   let x = 'X'
   let code =<< eval trim END
-    let a = `abc`
-    let b = `=x`
-    let c = `
+    let a = {{abc}}
+    let b = {x}
+    let c = {{
   END
-  call assert_equal(['let a = `abc`', 'let b = X', 'let c = `'], code)
+  call assert_equal(['let a = {abc}', 'let b = X', 'let c = {'], code)
 
   let code = 'xxx'
   let code =<< eval trim END
-    let n = `=5 +
-    6`
+    let n = {5 +
+    6}
   END
   call assert_equal('xxx', code)
 
   let code =<< eval trim END
-     let n = `=min([1, 2]` + `=max([3, 4])`
+     let n = {min([1, 2]} + {max([3, 4])}
   END
   call assert_equal('xxx', code)
 
   let lines =<< trim LINES
       let text =<< eval trim END
-        let b = `=
+        let b = {
       END
   LINES
-  call v9.CheckScriptFailure(lines, 'E1083:')
+  call v9.CheckScriptFailure(lines, 'E256:')
 
   let lines =<< trim LINES
       let text =<< eval trim END
-        let b = `=abc
+        let b = {abc
       END
   LINES
-  call v9.CheckScriptFailure(lines, 'E1083:')
+  call v9.CheckScriptFailure(lines, 'E256:')
 
   let lines =<< trim LINES
       let text =<< eval trim END
-        let b = `=`
+        let b = {}
       END
   LINES
   call v9.CheckScriptFailure(lines, 'E15:')
@@ -571,7 +571,7 @@ END
   " skipped heredoc
   if 0
     let msg =<< trim eval END
-        n is: `=n`
+        n is: {n}
     END
   endif
 
@@ -583,7 +583,7 @@ END
   let lines =<< trim END
     let Xvar =<< eval CODE
     let a = 1
-    let b = `=5+`
+    let b = {5+}
     let c = 2
     CODE
     let g:Count += 1
@@ -592,10 +592,10 @@ END
   let g:Count = 0
   call assert_fails('source', 'E15:')
   call assert_equal(1, g:Count)
-  call setline(3, 'let b = `=abc`')
+  call setline(3, 'let b = {abc}')
   call assert_fails('source', 'E121:')
   call assert_equal(2, g:Count)
-  call setline(3, 'let b = `=abc` + `=min([9, 4])` + 2')
+  call setline(3, 'let b = {abc} + {min([9, 4])} + 2')
   call assert_fails('source', 'E121:')
   call assert_equal(3, g:Count)
   call assert_equal('test', g:Xvar)

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -2670,10 +2670,10 @@ def Test_heredoc_expr()
     var a3 = "3"
     var a4 = ""
     var code =<< trim eval END
-      var a = `=5 + 10`
-      var b = `=min([10, 6])` + `=max([4, 6])`
-      var c = "`=s`"
-      var d = x`=a1`x`=a2`x`=a3`x`=a4`
+      var a = {5 + 10}
+      var b = {min([10, 6])} + {max([4, 6])}
+      var c = "{s}"
+      var d = x{a1}x{a2}x{a3}x{a4}
     END
     assert_equal(['var a = 15', 'var b = 6 + 6', 'var c = "local"', 'var d = x1x2x3x'], code)
   CODE
@@ -2681,7 +2681,7 @@ def Test_heredoc_expr()
 
   lines =<< trim CODE
     var code =<< eval trim END
-      var s = "`=$SOME_ENV_VAR`"
+      var s = "{$SOME_ENV_VAR}"
     END
     assert_equal(['var s = "somemore"'], code)
   CODE
@@ -2689,7 +2689,7 @@ def Test_heredoc_expr()
 
   lines =<< trim CODE
     var code =<< eval END
-      var s = "`=$SOME_ENV_VAR`"
+      var s = "{$SOME_ENV_VAR}"
     END
     assert_equal(['  var s = "somemore"'], code)
   CODE
@@ -2697,34 +2697,34 @@ def Test_heredoc_expr()
 
   lines =<< trim CODE
     var code =<< eval trim END
-      let a = `abc`
-      let b = `=g:someVar`
-      let c = `
+      let a = {{abc}}
+      let b = {g:someVar}
+      let c = {{
     END
-    assert_equal(['let a = `abc`', 'let b = X', 'let c = `'], code)
+    assert_equal(['let a = {abc}', 'let b = X', 'let c = {'], code)
   CODE
   v9.CheckDefAndScriptSuccess(lines)
 
   lines =<< trim LINES
       var text =<< eval trim END
-        let b = `=
+        let b = {
       END
   LINES
-  v9.CheckDefAndScriptFailure(lines, ['E1143: Empty expression: ""', 'E1083: Missing backtick'])
+  v9.CheckDefAndScriptFailure(lines, 'E256: Missing }')
 
   lines =<< trim LINES
       var text =<< eval trim END
-        let b = `=abc
+        let b = {abc
       END
   LINES
-  v9.CheckDefAndScriptFailure(lines, ['E1001: Variable not found: abc', 'E1083: Missing backtick'])
+  v9.CheckDefAndScriptFailure(lines, 'E256: Missing }')
 
   lines =<< trim LINES
       var text =<< eval trim END
-        let b = `=`
+        let b = {}
       END
   LINES
-  v9.CheckDefAndScriptFailure(lines, ['E1015: Name expected: `', 'E15: Invalid expression: "`"'])
+  v9.CheckDefAndScriptFailure(lines, 'E15: Invalid expression: "}"')
 enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -268,7 +268,7 @@ def Test_folddo_backtick_expansion()
   var lines =<< trim END
       g:val = 'value'
       def Test()
-        folddoopen echo `=g:val`
+        folddoopen echo {g:val}
       enddef
       call Test()
   END

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -268,7 +268,7 @@ def Test_folddo_backtick_expansion()
   var lines =<< trim END
       g:val = 'value'
       def Test()
-        folddoopen echo {g:val}
+        folddoopen echo `=g:val`
       enddef
       call Test()
   END

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -2820,6 +2820,25 @@ def Test_disassemble_after_reload()
     delfunc g:ThatFunc
 enddef
 
+def s:MakeString(x: number): string
+  return $"x={x} x^2={x * x}"
+enddef
 
+def Test_disassemble_string_interp()
+  var instr = execute('disassemble s:MakeString')
+  assert_match('MakeString\_s*' ..
+        'return $"x={x} x^2={x \* x}"\_s*' ..
+        '0 PUSHS "x="\_s*' ..
+        '1 LOAD arg\[-1\]\_s*' ..
+        '2 2STRING stack\[-1\]\_s*' ..
+        '3 PUSHS " x^2="\_s*' ..
+        '4 LOAD arg\[-1\]\_s*' ..
+        '5 LOAD arg\[-1\]\_s*' ..
+        '6 OPNR \*\_s*' ..
+        '7 2STRING stack\[-1\]\_s*' ..
+        '8 CONCAT size 4\_s*' ..
+        '9 RETURN\_s*',
+        instr)
+enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -1380,52 +1380,55 @@ compile_interp_string(char_u **arg, cctx_T *cctx)
 
     while (*str != NUL)
     {
-	char_u	*block_start = vim_strchr(str, '{');
+	char_u	*lit_start;
+	char_u	*block_start;
 	char_u	*block_end;
 	int	escaped_brace = FALSE;
 
-	// Escaped opening brace, unescape and continue.
-	if (block_start != NULL && block_start[1] == '{')
+	// Look for a block start.
+	lit_start = str;
+	while (*str != '{' && *str != '}' && *str != NUL)
+	    ++str;
+
+	if (*str != NUL && *str == str[1])
 	{
+	    // Escaped brace, unescape and continue.
 	    // Include the brace in the literal string.
-	    block_start += 1;
+	    ++str;
 	    escaped_brace = TRUE;
 	}
-
-	if (block_start == NULL)
+	else if (*str == '}')
 	{
-	    dup = vim_strsave(str);
-	    ret = generate_PUSHS(cctx, &dup);
-	    len += 1;
-	    // Break anyways, the string is over.
+	    semsg(_(e_stray_closing_curly_str), *arg);
+	    ret = FAIL;
 	    break;
 	}
-	else
+
+	// Append the literal part.
+	if (str != lit_start)
 	{
-	    // From `str` to `block_start` we have a chunk of literal text.
-	    dup = vim_strnsave(str, (size_t)(block_start - str));
-	    ret = generate_PUSHS(cctx, &dup);
-	    len += 1;
+	    dup = vim_strnsave(lit_start, (size_t)(str - lit_start));
+	    if ((ret = generate_PUSHS(cctx, &dup)) == FAIL)
+		break;
+	    ++len;
 	}
 
-	if (ret != OK)
+	if (*str == NUL)
 	    break;
 
 	if (escaped_brace)
 	{
 	    // Skip the second brace.
-	    str = block_start + 1;
+	    ++str;
 	    continue;
 	}
 
 	// Skip the opening {.
-	block_start += 1;
+	block_start = skipwhite(str + 1);
 	block_end = block_start;
-	if (skip_expr(&block_end, NULL) == FAIL)
-	{
-	    ret = FAIL;
+	if ((ret = skip_expr(&block_end, NULL)) == FAIL)
 	    break;
-	}
+	block_end = skipwhite(block_end);
 	// The block must be closed by a }.
 	if (*block_end != '}')
 	{
@@ -1437,7 +1440,7 @@ compile_interp_string(char_u **arg, cctx_T *cctx)
 	if ((ret = compile_expr0(&block_start, cctx)) == FAIL)
 	    break;
 	may_generate_2STRING(-1, TRUE, cctx);
-	len += 1;
+	++len;
 
 	str = block_end + 1;
     }


### PR DESCRIPTION
The syntax for interpolated strings in Vim (both Vim9 and pre-Vim9) is
heavily inspired by C# and previous discussions on vim_dev ML.

The interpolated strings are prefixed with the dollar `$` sign and the
inner expression are surrounded with braces `{` `}`.