### PR TITLE
Fix yaml indent in key value case

### DIFF
--- a/runtime/indent/testdir/yaml.in
+++ b/runtime/indent/testdir/yaml.in
@@ -15,5 +15,5 @@ map: val
 
 # START_INDENT
 map: multiline
-value
+  value
 # END_INDENT

--- a/runtime/indent/testdir/yaml.in
+++ b/runtime/indent/testdir/yaml.in
@@ -17,11 +17,4 @@ map: val
 map: |
 line1
 line2
-map: val
-# END_INDENT
-
-# START_INDENT
-map: val
-  map:
-    sub: val
 # END_INDENT

--- a/runtime/indent/testdir/yaml.in
+++ b/runtime/indent/testdir/yaml.in
@@ -14,6 +14,14 @@ map: val
 # END_INDENT
 
 # START_INDENT
-map: multiline
-  value
+map: |
+line1
+line2
+map: val
+# END_INDENT
+
+# START_INDENT
+map: val
+  map:
+    sub: val
 # END_INDENT

--- a/runtime/indent/testdir/yaml.ok
+++ b/runtime/indent/testdir/yaml.ok
@@ -17,11 +17,4 @@ map: val
 map: |
   line1
   line2
-map: val
-# END_INDENT
-
-# START_INDENT
-map: val
-map:
-  sub: val
 # END_INDENT

--- a/runtime/indent/testdir/yaml.ok
+++ b/runtime/indent/testdir/yaml.ok
@@ -15,5 +15,5 @@ map: val
 
 # START_INDENT
 map: multiline
-  value
+value
 # END_INDENT

--- a/runtime/indent/testdir/yaml.ok
+++ b/runtime/indent/testdir/yaml.ok
@@ -14,6 +14,14 @@ map: val
 # END_INDENT
 
 # START_INDENT
-map: multiline
-value
+map: |
+  line1
+  line2
+map: val
+# END_INDENT
+
+# START_INDENT
+map: val
+map:
+  sub: val
 # END_INDENT

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -54,7 +54,7 @@ let s:c_ns_anchor_name = s:c_ns_anchor_char.'+'
 let s:c_ns_anchor_property =  '\v\&'.s:c_ns_anchor_name
 
 let s:ns_word_char = '\v[[:alnum:]_\-]'
-let s:ns_tag_char  = '\v%('.s:ns_word_char.'|[#/;?:@&=+$.~*''()])'
+let s:ns_tag_char  = '\v%(%\x\x|'.s:ns_word_char.'|[#/;?:@&=+$.~*''()])'
 let s:c_named_tag_handle     = '\v\!'.s:ns_word_char.'+\!'
 let s:c_secondary_tag_handle = '\v\!\!'
 let s:c_primary_tag_handle   = '\v\!'

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -63,7 +63,7 @@ let s:c_tag_handle = '\v%('.s:c_named_tag_handle.
             \            '|'.s:c_primary_tag_handle.')'
 let s:c_ns_shorthand_tag = '\v'.s:c_tag_handle . s:ns_tag_char.'+'
 let s:c_non_specific_tag = '\v\!'
-let s:ns_uri_char  = '\v%('.s:ns_word_char.'\v|[#/;?:@&=+$,.!~*''()[\]])'
+let s:ns_uri_char  = '\v%(%\x\x|'.s:ns_word_char.'\v|[#/;?:@&=+$,.!~*''()[\]])'
 let s:c_verbatim_tag = '\v\!\<'.s:ns_uri_char.'+\>'
 let s:c_ns_tag_property = '\v'.s:c_verbatim_tag.
             \               '\v|'.s:c_ns_shorthand_tag.


### PR DESCRIPTION
Closes #8740 

This PR resolves unexpected indent in a new line.
I rollback cause fix in https://github.com/vim/vim/commit/acc224064033e5cea21ef7f1eefb356ca06ff11d

However, I don't understand the purpose of this fix.
Please check that this rollback has no problem.

Current behavior (`|` is cursor) 
```
a: b
  |
```

Updated behavior
```
a: b
|
```


> This problem doesn't occur in Vim 8.1. (8.1.3741)
> I confirmed diff between codes in 8.1 and 8.2.
> 
> The following fixes affect this problem.
> https://github.com/vim/vim/commit/acc224064033e5cea21ef7f1eefb356ca06ff11d#diff-723cc09b2d0f8f9383c670a8846979363fbc67a741aad1aae657242b8c2667a3L56
acc2240#diff-723cc09b2d0f8f9383c670a8846979363fbc67a741aad1aae657242b8c2667a3L65
> 
> In 8.1, process doesn't enter any if/elseif prevline block in GetYAMLIndent function.
> In 8.2, process enters the last elseif prevline block in GetYAMLIndent function. (https://github.com/vim/vim/blob/master/runtime/indent/yaml.vim#L145)