### PR TITLE
vim9: Compile substitute {sub} parameter

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -9951,7 +9951,8 @@ f_substitute(typval_T *argvars, typval_T *rettv)
     pat = tv_get_string_buf_chk(&argvars[1], patbuf);
     flg = tv_get_string_buf_chk(&argvars[3], flagsbuf);
 
-    if (argvars[2].v_type == VAR_FUNC || argvars[2].v_type == VAR_PARTIAL)
+    if (argvars[2].v_type == VAR_FUNC || argvars[2].v_type == VAR_PARTIAL ||
+	    argvars[2].v_type == VAR_INSTR)
 	expr = &argvars[2];
     else
 	sub = tv_get_string_buf_chk(&argvars[2], subbuf);

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -2004,6 +2004,10 @@ vim_regsub_both(
 		    funcexe.fe_partial = partial;
 		    call_func(s, -1, &rettv, 1, argv, &funcexe);
 		}
+		else if (expr->v_type == VAR_INSTR)
+		{
+		    exe_typval_instr(expr, &rettv);
+		}
 		if (matchList.sl_list.lv_len > 0)
 		    // fill_submatch_list() was called
 		    clear_submatch_list(&matchList);

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -4077,6 +4077,11 @@ def Test_substitute()
   v9.CheckDefAndScriptFailure(['substitute("a", 2, "1", "d")'], ['E1013: Argument 2: type mismatch, expected string but got number', 'E1174: String required for argument 2'])
   v9.CheckDefAndScriptFailure(['substitute("a", "b", "1", 4)'], ['E1013: Argument 4: type mismatch, expected string but got number', 'E1174: String required for argument 4'])
   substitute('', '', '', '')->assert_equal('')
+
+  var lines =<< trim END
+    assert_equal("4", substitute("3", '\d', '\=str2nr(submatch(0)) + 1', 'g'))
+  END
+  v9.CheckDefAndScriptSuccess(lines)
 enddef
 
 def Test_swapinfo()

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -187,6 +187,26 @@ def Test_disassemble_seachpair()
 enddef
 
 
+def s:SubstituteExpr()
+    substitute('', '', '\=123', 'g')
+enddef
+
+def Test_disassemble_substitute_expr()
+  var res = execute('disass s:SubstituteExpr')
+  assert_match('<SNR>\d*_SubstituteExpr.*' ..
+        'substitute('''', '''', ''\\=123'', ''g'')\_s*' ..
+        '\d PUSHS ""\_s*' ..
+        '\d PUSHS ""\_s*' ..
+        '\d INSTR\_s*' ..
+        '  0 PUSHNR 123\_s*' ..
+        ' -------------\_s*' ..
+        '\d PUSHS "g"\_s*' ..
+        '\d BCALL substitute(argc 4)\_s*' ..
+        '\d DROP\_s*' ..
+        '\d RETURN void',
+        res)
+enddef
+
 def s:RedirVar()
   var result: string
   redir =>> result

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -5010,6 +5010,10 @@ exe_typval_instr(typval_T *tv, typval_T *rettv)
     int		save_iidx = ectx->ec_iidx;
     int		res;
 
+    // Initialize rettv so that it is safe for caller to invoke clear_tv(rettv)
+    // even when the compilation fails.
+    rettv->v_type = VAR_UNKNOWN;
+
     ectx->ec_instr = tv->vval.v_instr->instr_instr;
     res = exec_instructions(ectx);
     if (res == OK)


### PR DESCRIPTION
When the \= prefix is present we compile the string into a set of
instructions.

Useful for people porting code that makes heavy use of strings, they get
a massive speed-up and ahead-of-time type and syntax checking.