### PR TITLE
Add filetype detection for robot framework

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1592,6 +1592,9 @@ au BufNewFile,BufRead *.rng			setf rng
 " RPL/2
 au BufNewFile,BufRead *.rpl			setf rpl
 
+" Robot Framework
+au BufNewFile,BufRead *.robot,*.resource	setf robot
+
 " Robots.txt
 au BufNewFile,BufRead robots.txt		setf robots
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -457,6 +457,7 @@ let s:filename_checks = {
     \ 'rib': ['file.rib'],
     \ 'rnc': ['file.rnc'],
     \ 'rng': ['file.rng'],
+    \ 'robot': ['file.robot', 'file.resource'],
     \ 'robots': ['robots.txt'],
     \ 'routeros': ['file.rsc'],
     \ 'rpcgen': ['file.x'],


### PR DESCRIPTION
This PR adds a filetype for [robot framework](https://robotframework.org/) files.