### PR TITLE
Fix exepath not to return executable file in current directory if NoDefaultCurrentDirectoryInExePath is set

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2237,7 +2237,11 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
 		retval = FALSE;
 		goto theend;
 	    }
-	    STRCPY(pathbuf, ".;");
+
+	    if (getenv("NoDefaultCurrentDirectoryInExePath") == NULL)
+		STRCPY(pathbuf, ".;");
+	    else
+		*pathbuf = NUL;
 	    STRCAT(pathbuf, p);
 	}
     }

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2238,7 +2238,7 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
 		goto theend;
 	    }
 
-	    if (getenv("NoDefaultCurrentDirectoryInExePath") == NULL)
+	    if (mch_getenv("NoDefaultCurrentDirectoryInExePath") == NULL)
 		STRCPY(pathbuf, ".;");
 	    else
 		*pathbuf = NUL;

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2906,4 +2906,22 @@ func Test_isabsolutepath()
   endif
 endfunc
 
+" Test for exepath()
+func Test_exepath()
+  if has('win32')
+    call assert_notequal(exepath('cmd'), '')
+
+    let oldNoDefaultCurrentDirectoryInExePath = $NoDefaultCurrentDirectoryInExePath
+    call writefile(['@echo off', 'echo Evil'], 'vim-test-evil.bat')
+    let $NoDefaultCurrentDirectoryInExePath = ''
+    call assert_notequal(exepath("vim-test-evil.bat"), '')
+    let $NoDefaultCurrentDirectoryInExePath = '1'
+    call assert_equal(exepath("vim-test-evil.bat"), '')
+    let $NoDefaultCurrentDirectoryInExePath = oldNoDefaultCurrentDirectoryInExePath
+    call delete('vim-test-evil.bat')
+  else
+    call assert_notequal(exepath('sh'), '')
+  endif
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Windows always execute executable on current directory without path prefix. This behavior is dangerous. I want to add check environment variable `NoDefaultCurrentDirectoryInExePath` is set or not. For example, if you have vim.exe in current directory, `exepath("git")` return executable path on current directory.

This change return original path to git.exe if NoDefaultCurrentDirectoryInExePath is set.

https://docs.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-needcurrentdirectoryforexepatha