### PR TITLE
Fix v_P clipboard behavior

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1180,11 +1180,11 @@ deleting the selection.)
 With 'p' the previously selected text is put in the unnamed register.  This is
 useful if you want to put that text somewhere else.  But you cannot repeat the
 same change.
-With 'P' the unnamed register is not changed, you can repeat the same change.
-But the deleted text cannot be used.  If you do need it you can use 'p' with
-another register.  E.g., yank the text to copy, Visually select the text to
-replace and use "0p .  You can repeat this as many times as you like, and the
-unnamed register will be changed each time.
+With 'P' the unnamed/clipboard registers are not changed, you can repeat the
+same change. But the deleted text cannot be used.  If you do need it you can
+use 'p' with another register.  E.g., yank the text to copy, Visually select
+the text to replace and use "0p .  You can repeat this as many times as you
+like, and the unnamed register will be changed each time.
 
 When you use a blockwise Visual mode command and yank only a single line into
 a register, a paste on a visual selected area will paste that single line on

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -939,7 +939,7 @@ tag		command	      note action in Visual mode	~
 |v_K|		K		   run 'keywordprg' on the highlighted area
 |v_O|		O		   move horizontally to other corner of area
 |v_P|		P		   replace highlighted area with register
-				   contents; unnamed register is unchanged
+				   contents; registers are unchanged
 		Q		   does not start Ex mode
 |v_R|		R		2  delete the highlighted lines and start
 				   insert

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -265,7 +265,7 @@ Additionally the following commands can be used:
 	X	delete (2)					|v_X|
 	Y	yank (2)					|v_Y|
 	p	put						|v_p|
-	P	put without unnamed register overwrite		|v_P|
+	P	put without registers overwrite			|v_P|
 	J	join (1)					|v_J|
 	U	make uppercase					|v_U|
 	u	make lowercase					|v_u|

--- a/src/normal.c
+++ b/src/normal.c
@@ -7237,7 +7237,6 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		dir;
     int		flags = 0;
     int		save_unnamed = FALSE;
-    yankreg_T	*old_y_current, *old_y_previous;
 
     if (cap->oap->op_type != OP_NOP)
     {
@@ -7302,25 +7301,14 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    }
 
 	    // Now delete the selected text. Avoid messages here.
-	    if (save_unnamed)
-	    {
-		old_y_current = get_y_current();
-		old_y_previous = get_y_previous();
-	    }
 	    cap->cmdchar = 'd';
 	    cap->nchar = NUL;
-	    cap->oap->regname = NUL;
+	    cap->oap->regname = save_unnamed ? '_' : NUL;
 	    ++msg_silent;
 	    nv_operator(cap);
 	    do_pending_operator(cap, 0, FALSE);
 	    empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
 	    --msg_silent;
-
-	    if (save_unnamed)
-	    {
-		set_y_current(old_y_current);
-		set_y_previous(old_y_previous);
-	    }
 
 	    // delete PUT_LINE_BACKWARD;
 	    cap->oap->regname = regname;

--- a/src/normal.c
+++ b/src/normal.c
@@ -7238,7 +7238,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		flags = 0;
     int		keep_registers = FALSE;
 #ifdef FEAT_CLIPBOARD
-    char_u	*save_cb = NULL;
+    void	*save_cb = NULL;
 #endif
 
     if (cap->oap->op_type != OP_NOP)
@@ -7307,8 +7307,10 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 #ifdef FEAT_CLIPBOARD
 	    if (keep_registers)
 	    {
-		save_cb = p_cb;
-		p_cb = (char_u *)"";
+		if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED)
+		    save_cb = get_register('*', TRUE);
+		else if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED_PLUS)
+		    save_cb = get_register('+', TRUE);
 	    }
 #endif
 	    cap->cmdchar = 'd';
@@ -7322,7 +7324,10 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 
 #ifdef FEAT_CLIPBOARD
 	    if (keep_registers)
-		p_cb = save_cb;
+		if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED)
+		    put_register('*', save_cb);
+		else if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED_PLUS)
+		    put_register('+', save_cb);
 #endif
 
 	    // delete PUT_LINE_BACKWARD;

--- a/src/normal.c
+++ b/src/normal.c
@@ -7302,11 +7302,13 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    }
 
 	    // Now delete the selected text. Avoid messages here.
+#ifdef FEAT_CLIPBOARD
 	    if (keep_registers)
 	    {
 		save_cb = p_cb;
 		p_cb = (char_u *)"";
 	    }
+#endif
 	    cap->cmdchar = 'd';
 	    cap->nchar = NUL;
 	    cap->oap->regname = keep_registers ? '_' : NUL;
@@ -7316,8 +7318,10 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
 	    --msg_silent;
 
+#ifdef FEAT_CLIPBOARD
 	    if (keep_registers)
 		p_cb = save_cb;
+#endif
 
 	    // delete PUT_LINE_BACKWARD;
 	    cap->oap->regname = regname;

--- a/src/normal.c
+++ b/src/normal.c
@@ -7324,10 +7324,12 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 
 #ifdef FEAT_CLIPBOARD
 	    if (keep_registers)
+	    {
 		if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED)
 		    put_register('*', save_cb);
 		else if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED_PLUS)
 		    put_register('+', save_cb);
+	    }
 #endif
 
 	    // delete PUT_LINE_BACKWARD;

--- a/src/normal.c
+++ b/src/normal.c
@@ -7237,7 +7237,9 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		dir;
     int		flags = 0;
     int		keep_registers = FALSE;
+#ifdef FEAT_CLIPBOARD
     char_u	*save_cb = NULL;
+#endif
 
     if (cap->oap->op_type != OP_NOP)
     {

--- a/src/normal.c
+++ b/src/normal.c
@@ -7317,7 +7317,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    --msg_silent;
 
 	    if (keep_registers)
-		p_cb = p_cb;
+		p_cb = save_cb;
 
 	    // delete PUT_LINE_BACKWARD;
 	    cap->oap->regname = regname;

--- a/src/normal.c
+++ b/src/normal.c
@@ -7237,7 +7237,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		dir;
     int		flags = 0;
     int		keep_registers = FALSE;
-    char	*save_cb = NULL;
+    char_u	*save_cb = NULL;
 
     if (cap->oap->op_type != OP_NOP)
     {
@@ -7305,7 +7305,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    if (keep_registers)
 	    {
 		save_cb = p_cb;
-		p_cb = "";
+		p_cb = (char_u *)"";
 	    }
 	    cap->cmdchar = 'd';
 	    cap->nchar = NUL;

--- a/src/normal.c
+++ b/src/normal.c
@@ -7237,6 +7237,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		dir;
     int		flags = 0;
     int		keep_registers = FALSE;
+    char	*save_cb = NULL;
 
     if (cap->oap->op_type != OP_NOP)
     {
@@ -7301,6 +7302,11 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    }
 
 	    // Now delete the selected text. Avoid messages here.
+	    if (keep_registers)
+	    {
+		save_cb = p_cb;
+		p_cb = "";
+	    }
 	    cap->cmdchar = 'd';
 	    cap->nchar = NUL;
 	    cap->oap->regname = keep_registers ? '_' : NUL;
@@ -7309,6 +7315,9 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    do_pending_operator(cap, 0, FALSE);
 	    empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
 	    --msg_silent;
+
+	    if (keep_registers)
+		p_cb = p_cb;
 
 	    // delete PUT_LINE_BACKWARD;
 	    cap->oap->regname = regname;

--- a/src/normal.c
+++ b/src/normal.c
@@ -7322,16 +7322,6 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
 	    --msg_silent;
 
-#ifdef FEAT_CLIPBOARD
-	    if (keep_registers)
-	    {
-		if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED)
-		    put_register('*', save_cb);
-		else if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED_PLUS)
-		    put_register('+', save_cb);
-	    }
-#endif
-
 	    // delete PUT_LINE_BACKWARD;
 	    cap->oap->regname = regname;
 
@@ -7368,6 +7358,16 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	// If a register was saved, put it back now.
 	if (reg2 != NULL)
 	    put_register(regname, reg2);
+
+#ifdef FEAT_CLIPBOARD
+	if (keep_registers && save_cb != NULL)
+	{
+	    if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED)
+		put_register('*', save_cb);
+	    else if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED_PLUS)
+		put_register('+', save_cb);
+	}
+#endif
 
 	// What to reselect with "gv"?  Selecting the just put text seems to
 	// be the most useful, since the original text was removed.

--- a/src/normal.c
+++ b/src/normal.c
@@ -7237,9 +7237,6 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		dir;
     int		flags = 0;
     int		keep_registers = FALSE;
-#ifdef FEAT_CLIPBOARD
-    void	*save_cb = NULL;
-#endif
 
     if (cap->oap->op_type != OP_NOP)
     {
@@ -7304,15 +7301,6 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    }
 
 	    // Now delete the selected text. Avoid messages here.
-#ifdef FEAT_CLIPBOARD
-	    if (keep_registers)
-	    {
-		if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED)
-		    save_cb = get_register('*', TRUE);
-		else if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED_PLUS)
-		    save_cb = get_register('+', TRUE);
-	    }
-#endif
 	    cap->cmdchar = 'd';
 	    cap->nchar = NUL;
 	    cap->oap->regname = keep_registers ? '_' : NUL;
@@ -7358,16 +7346,6 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	// If a register was saved, put it back now.
 	if (reg2 != NULL)
 	    put_register(regname, reg2);
-
-#ifdef FEAT_CLIPBOARD
-	if (keep_registers && save_cb != NULL)
-	{
-	    if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED)
-		put_register('*', save_cb);
-	    else if ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED_PLUS)
-		put_register('+', save_cb);
-	}
-#endif
 
 	// What to reselect with "gv"?  Selecting the just put text seems to
 	// be the most useful, since the original text was removed.

--- a/src/normal.c
+++ b/src/normal.c
@@ -7236,7 +7236,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		was_visual = FALSE;
     int		dir;
     int		flags = 0;
-    int		save_unnamed = FALSE;
+    int		keep_registers = FALSE;
 
     if (cap->oap->op_type != OP_NOP)
     {
@@ -7283,7 +7283,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    // overwrites if the old contents is being put.
 	    was_visual = TRUE;
 	    regname = cap->oap->regname;
-	    save_unnamed = cap->cmdchar == 'P';
+	    keep_registers = cap->cmdchar == 'P';
 #ifdef FEAT_CLIPBOARD
 	    adjust_clip_reg(&regname);
 #endif
@@ -7303,7 +7303,7 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    // Now delete the selected text. Avoid messages here.
 	    cap->cmdchar = 'd';
 	    cap->nchar = NUL;
-	    cap->oap->regname = save_unnamed ? '_' : NUL;
+	    cap->oap->regname = keep_registers ? '_' : NUL;
 	    ++msg_silent;
 	    nv_operator(cap);
 	    do_pending_operator(cap, 0, FALSE);

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1390,62 +1390,66 @@ func Test_visual_paste()
   call assert_equal('x', @-)
   call assert_equal('bazooxxf', getline(1))
 
-  if has('clipboard')
-    " v_P does not overwrite unnamed register.
-    call setline(1, ['xxxx'])
-    call setreg('"', 'foo')
-    call setreg('-', 'bar')
-    normal gg0vP
-    call assert_equal('foo', @")
-    call assert_equal('bar', @-)
-    call assert_equal('fooxxx', getline(1))
-    normal $vP
-    call assert_equal('foo', @")
-    call assert_equal('bar', @-)
-    call assert_equal('fooxxfoo', getline(1))
-    " Test with a different register as unnamed register.
-    call setline(2, ['baz'])
-    normal 2gg0"rD
-    call assert_equal('baz', @")
-    normal gg0vP
-    call assert_equal('baz', @")
-    call assert_equal('bar', @-)
-    call assert_equal('bazooxxfoo', getline(1))
-    normal $vP
-    call assert_equal('baz', @")
-    call assert_equal('bar', @-)
-    call assert_equal('bazooxxfobaz', getline(1))
-
-    " Test for unnamed clipboard
-    set clipboard=unnamed
-    call setline(1, ['xxxx'])
-    call setreg('"', 'foo')
-    call setreg('-', 'bar')
-    call setreg('*', 'baz')
-    normal gg0vP
-    call assert_equal('foo', @")
-    call assert_equal('bar', @-)
-    call assert_equal('baz', @*)
-    call assert_equal('bazxxx', getline(1))
-
-    " Test for unnamedplus clipboard
-    if has('unnamedplus')
-      set clipboard=unnamedplus
-      call setline(1, ['xxxx'])
-      call setreg('"', 'foo')
-      call setreg('-', 'bar')
-      call setreg('+', 'baz')
-      normal gg0vP
-      call assert_equal('foo', @")
-      call assert_equal('bar', @-)
-      call assert_equal('baz', @+)
-      call assert_equal('bazxxx', getline(1))
-    endif
-
-    set clipboard&
-  endif
-
   bwipe!
 endfunc
+
+func Test_visual_paste_clipboard()
+  CheckFeature clipboard_working
+
+  " v_P does not overwrite unnamed register.
+  call setline(1, ['xxxx'])
+  call setreg('"', 'foo')
+  call setreg('-', 'bar')
+  normal gg0vP
+  call assert_equal('foo', @")
+  call assert_equal('bar', @-)
+  call assert_equal('fooxxx', getline(1))
+  normal $vP
+  call assert_equal('foo', @")
+  call assert_equal('bar', @-)
+  call assert_equal('fooxxfoo', getline(1))
+  " Test with a different register as unnamed register.
+  call setline(2, ['baz'])
+  normal 2gg0"rD
+  call assert_equal('baz', @")
+  normal gg0vP
+  call assert_equal('baz', @")
+  call assert_equal('bar', @-)
+  call assert_equal('bazooxxfoo', getline(1))
+  normal $vP
+  call assert_equal('baz', @")
+  call assert_equal('bar', @-)
+  call assert_equal('bazooxxfobaz', getline(1))
+
+  " Test for unnamed clipboard
+  set clipboard=unnamed
+  call setline(1, ['xxxx'])
+  call setreg('"', 'foo')
+  call setreg('-', 'bar')
+  call setreg('*', 'baz')
+  normal gg0vP
+  call assert_equal('foo', @")
+  call assert_equal('bar', @-)
+  call assert_equal('baz', @*)
+  call assert_equal('bazxxx', getline(1))
+
+  " Test for unnamedplus clipboard
+  if has('unnamedplus')
+    set clipboard=unnamedplus
+    call setline(1, ['xxxx'])
+    call setreg('"', 'foo')
+    call setreg('-', 'bar')
+    call setreg('+', 'baz')
+    normal gg0vP
+    call assert_equal('foo', @")
+    call assert_equal('bar', @-)
+    call assert_equal('baz', @+)
+    call assert_equal('bazxxx', getline(1))
+  endif
+
+  set clipboard&
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1397,11 +1397,11 @@ func Test_visual_paste()
     call setreg('-', 'bar')
     normal gg0vP
     call assert_equal('foo', @")
-    call assert_equal('x', @-)
+    call assert_equal('bar', @-)
     call assert_equal('fooxxx', getline(1))
     normal $vP
     call assert_equal('foo', @")
-    call assert_equal('x', @-)
+    call assert_equal('bar', @-)
     call assert_equal('fooxxfoo', getline(1))
     " Test with a different register as unnamed register.
     call setline(2, ['baz'])
@@ -1409,12 +1409,36 @@ func Test_visual_paste()
     call assert_equal('baz', @")
     normal gg0vP
     call assert_equal('baz', @")
-    call assert_equal('f', @-)
+    call assert_equal('bar', @-)
     call assert_equal('bazooxxfoo', getline(1))
     normal $vP
     call assert_equal('baz', @")
-    call assert_equal('o', @-)
+    call assert_equal('bar', @-)
     call assert_equal('bazooxxfobaz', getline(1))
+
+    " Test for unnamed clipboard
+    set clipboard=unnamed
+    call setline(1, ['xxxx'])
+    call setreg('"', 'foo')
+    call setreg('-', 'bar')
+    call setreg('*', 'baz')
+    normal gg0vP
+    call assert_equal('foo', @")
+    call assert_equal('bar', @-)
+    call assert_equal('baz', @*)
+    call assert_equal('bazxxx', getline(1))
+
+    " Test for unnamedplus clipboard
+    set clipboard=unnamedplus
+    call setline(1, ['xxxx'])
+    call setreg('"', 'foo')
+    call setreg('-', 'bar')
+    call setreg('+', 'baz')
+    normal gg0vP
+    call assert_equal('foo', @")
+    call assert_equal('bar', @-)
+    call assert_equal('baz', @+)
+    call assert_equal('bazxxx', getline(1))
   endif
 
   bwipe!

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1439,6 +1439,7 @@ func Test_visual_paste()
     call assert_equal('bar', @-)
     call assert_equal('baz', @+)
     call assert_equal('bazxxx', getline(1))
+    set clipboard&
   endif
 
   bwipe!

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1429,16 +1429,19 @@ func Test_visual_paste()
     call assert_equal('bazxxx', getline(1))
 
     " Test for unnamedplus clipboard
-    set clipboard=unnamedplus
-    call setline(1, ['xxxx'])
-    call setreg('"', 'foo')
-    call setreg('-', 'bar')
-    call setreg('+', 'baz')
-    normal gg0vP
-    call assert_equal('foo', @")
-    call assert_equal('bar', @-)
-    call assert_equal('baz', @+)
-    call assert_equal('bazxxx', getline(1))
+    if has('unnamedplus')
+      set clipboard=unnamedplus
+      call setline(1, ['xxxx'])
+      call setreg('"', 'foo')
+      call setreg('-', 'bar')
+      call setreg('+', 'baz')
+      normal gg0vP
+      call assert_equal('foo', @")
+      call assert_equal('bar', @-)
+      call assert_equal('baz', @+)
+      call assert_equal('bazxxx', getline(1))
+    endif
+
     set clipboard&
   endif
 

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1396,6 +1396,11 @@ endfunc
 func Test_visual_paste_clipboard()
   CheckFeature clipboard_working
 
+  if has('gui')
+    " auto select feature breaks tests
+    set guioptions-=a
+  endif
+
   " v_P does not overwrite unnamed register.
   call setline(1, ['xxxx'])
   call setreg('"', 'foo')
@@ -1448,6 +1453,9 @@ func Test_visual_paste_clipboard()
   endif
 
   set clipboard&
+  if has('gui')
+    set guioptions&
+  endif
   bwipe!
 endfunc
 


### PR DESCRIPTION
I have fixed `v_P` behavior with clipboard option.

Please see https://github.com/neovim/neovim/issues/18408.

To implementation simpler, I use blackhole register instead.
I think the implementation is better.