### PR TITLE
Add mode_bits to mapping-dict

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5331,6 +5331,10 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 		  "nowait"   Do not wait for other, longer mappings.
 			     (|:map-<nowait>|).
 		  "abbr"     True if this is an |abbreviation|.
+		  "mode_bits" Vim's internal binary representation of "mode".
+			     |mapset()| ignores this; only "mode" is used.
+			     See |maplist()| for usage examples. The values
+			     are from vim.h and may change in the future.
 
 		The dictionary can be used to restore a mapping with
 		|mapset()|.
@@ -5391,6 +5395,28 @@ maplist([{abbr}])					*maplist()*
 			vim9script
 			echo maplist()->filter(
 				(_, m) => match(m.rhs, 'MultiMatch') >= 0)
+<		It can be tricky to find mappings for particular |:map-modes|.
+		|mapping-dict|'s "mode_bits" can simplify this. For example,
+		the mode_bits for Normal, Insert or Command-line modes are
+		0x19. To find all the mappings available in those modes you
+		can do: >
+			vim9script
+			var saved_maps = []
+			for m in maplist()
+			    if and(m.mode_bits, 0x19) != 0
+				saved_maps->add(m)
+			    endif
+			endfor
+			echo saved_maps->mapnew((_, m) => m.lhs)
+<		The values of the mode_bits are defined in Vim's vim.h file
+		and they can be discovered at runtime using |:map-commands|
+		and "maplist()". Example >
+			vim9script
+			omap xyzzy <Nop>
+			var op_bit = maplist()->filter(
+			    (_, m) => m.lhs == 'xyzzy')[0].mode_bits
+			ounmap xyzzy
+			echo printf("Operator-pending mode bit: 0x%x", op_bit)
 
 
 mapnew({expr1}, {expr2})					*mapnew()*

--- a/src/map.c
+++ b/src/map.c
@@ -2303,6 +2303,7 @@ mapblock2dict(
     dict_add_number(dict, "nowait", mp->m_nowait ? 1L : 0L);
     dict_add_string(dict, "mode", mapmode);
     dict_add_number(dict, "abbr", abbr ? 1L : 0L);
+    dict_add_number(dict, "mode_bits", mp->m_mode);
 
     vim_free(mapmode);
 }

--- a/src/testdir/test_map_functions.vim
+++ b/src/testdir/test_map_functions.vim
@@ -19,13 +19,13 @@ func Test_maparg()
         \ 'lhsraw': "foo\x80\xfc\x04V", 'lhsrawalt': "foo\x16",
         \ 'mode': ' ', 'nowait': 0, 'expr': 0, 'sid': sid, 'scriptversion': 1,
         \ 'lnum': lnum + 1, 
-	\ 'rhs': 'is<F4>foo', 'buffer': 0, 'abbr': 0},
+	\ 'rhs': 'is<F4>foo', 'buffer': 0, 'abbr': 0, 'mode_bits': 0x47},
 	\ maparg('foo<C-V>', '', 0, 1))
   call assert_equal({'silent': 1, 'noremap': 1, 'script': 1, 'lhs': 'bar',
         \ 'lhsraw': 'bar', 'mode': 'v',
         \ 'nowait': 0, 'expr': 1, 'sid': sid, 'scriptversion': 1,
         \ 'lnum': lnum + 2,
-	\ 'rhs': 'isbar', 'buffer': 1, 'abbr': 0},
+	\ 'rhs': 'isbar', 'buffer': 1, 'abbr': 0, 'mode_bits': 0x42},
         \ 'bar'->maparg('', 0, 1))
   let lnum = expand('<sflnum>')
   map <buffer> <nowait> foo bar
@@ -33,7 +33,7 @@ func Test_maparg()
         \ 'lhsraw': 'foo', 'mode': ' ',
         \ 'nowait': 1, 'expr': 0, 'sid': sid, 'scriptversion': 1,
         \ 'lnum': lnum + 1, 'rhs': 'bar',
-	\ 'buffer': 1, 'abbr': 0},
+	\ 'buffer': 1, 'abbr': 0, 'mode_bits': 0x47},
         \ maparg('foo', '', 0, 1))
   let lnum = expand('<sflnum>')
   tmap baz foo
@@ -41,7 +41,7 @@ func Test_maparg()
         \ 'lhsraw': 'baz', 'mode': 't',
         \ 'nowait': 0, 'expr': 0, 'sid': sid, 'scriptversion': 1,
         \ 'lnum': lnum + 1, 'rhs': 'foo',
-	\ 'buffer': 0, 'abbr': 0},
+        \ 'buffer': 0, 'abbr': 0, 'mode_bits': 0x80},
         \ maparg('baz', 't', 0, 1))
   let lnum = expand('<sflnum>')
   iab A B
@@ -49,7 +49,7 @@ func Test_maparg()
         \ 'lhsraw': 'A', 'mode': 'i',
         \ 'nowait': 0, 'expr': 0, 'sid': sid, 'scriptversion': 1,
         \ 'lnum': lnum + 1, 'rhs': 'B',
-	\ 'buffer': 0, 'abbr': 1},
+	\ 'buffer': 0, 'abbr': 1, 'mode_bits': 0x0010},
         \ maparg('A', 'i', 1, 1))
   iuna A
 

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -2464,7 +2464,8 @@ def Test_maparg()
         scriptversion: 999999,
         rhs: 'bar',
         buffer: 0,
-        abbr: 0})
+        abbr: 0,
+        mode_bits: 0x47})
   unmap foo
   v9.CheckDefAndScriptFailure(['maparg(1)'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1174: String required for argument 1'])
   v9.CheckDefAndScriptFailure(['maparg("a", 2)'], ['E1013: Argument 2: type mismatch, expected string but got number', 'E1174: String required for argument 2'])


### PR DESCRIPTION
Working on some functions that return functions that can be used with `maplist()->filter()`. This PR gets the last bit of performance.

Here's some excerpts from MapModeFilter. The entire file can be seen at
https://github.com/errael/splice.vim/blob/master/autoload/splice9/splicelib/util/MapModeFilter.vim
It started in a discussion/suggestions with @lacygoill.
```
# examples: 
# MapModeFilter(modes, pattern, exact = true, field = lhs)
# MapModeFilterFunc(modes, filter_func)
# ...
#   Any mapping of 'K' used in '!' or ' ' modes
#   (this is all modes except 'l' and 't')
#       saved_maps = maplist()->filter(MapModeFilter('! ', 'K'))
#   Any mapping of 'K' used in 's' or 'c' modes
#       saved_maps = maplist()->filter(MapModeFilter('sc', 'K'))
```
Currently it returns a function like:
```
    if exact
        return (_, m) => {
            if m[field] != pattern | return false | endif
            var map_modes = 0
            for mm in m.mode
                #map_modes = or(map_modes, mode_bits_table[mm])
                map_modes += mode_bits_table[mm]
            endfor

            return and(map_modes, target_modes) != 0
            }
```
With this patch, it would return
```
        return (_, m) => {
            if m[field] != pattern | return false | endif
            return and(m.mode_bits, target_modes) != 0
            }
```

MapModeFilter is reusable, not sure the best way to make it available. Evan so, it may well be that I've gone overboard squeezing out the cycles. In particular

- The performance may not be that important
- It uses vim's internal bits.

I doubt the bits have moved in these 30 years so I don't see that as a real issue. It's possible to add a builtin that returns a dict with the mode2bits (like the mode_bits_table dict that exists in the file) but seems overboard.
