### PR TITLE
Make the mouse scroll steps configurable

### DIFF
--- a/runtime/doc/scroll.txt
+++ b/runtime/doc/scroll.txt
@@ -237,30 +237,29 @@ it works depends on your system.  It might also work in an xterm
 |xterm-mouse-wheel|.  By default only vertical scroll wheels are supported,
 but some GUIs also support horizontal scroll wheels.
 
-For the Win32 GUI the scroll action is hard coded.  It works just like
-dragging the scrollbar of the current window.  How many lines are scrolled
-depends on your mouse driver.  If the scroll action causes input focus
-problems, see |intellimouse-wheel-problems|.
-
-For the X11 GUIs (Motif and GTK) scrolling the wheel generates key
+For Win32 and the X11 GUIs (Motif and GTK) scrolling the wheel generates key
 presses <ScrollWheelUp>, <ScrollWheelDown>, <ScrollWheelLeft> and
 <ScrollWheelRight>.  For example, if you push the scroll wheel upwards a
 <ScrollWheelUp> key press is generated causing the window to scroll upwards
 (while the text is actually moving downwards).  The default action for these
 keys are:
-    <ScrollWheelUp>	    scroll three lines up	*<ScrollWheelUp>*
+    <ScrollWheelUp>	    scroll N lines up	        *<ScrollWheelUp>*
     <S-ScrollWheelUp>	    scroll one page up		*<S-ScrollWheelUp>*
     <C-ScrollWheelUp>	    scroll one page up		*<C-ScrollWheelUp>*
-    <ScrollWheelDown>	    scroll three lines down	*<ScrollWheelDown>*
+    <ScrollWheelDown>	    scroll N lines down	        *<ScrollWheelDown>*
     <S-ScrollWheelDown>	    scroll one page down	*<S-ScrollWheelDown>*
     <C-ScrollWheelDown>	    scroll one page down	*<C-ScrollWheelDown>*
-    <ScrollWheelLeft>	    scroll six columns left	*<ScrollWheelLeft>*
+    <ScrollWheelLeft>	    scroll N columns left	*<ScrollWheelLeft>*
     <S-ScrollWheelLeft>	    scroll one page left	*<S-ScrollWheelLeft>*
     <C-ScrollWheelLeft>	    scroll one page left	*<C-ScrollWheelLeft>*
-    <ScrollWheelRight>	    scroll six columns right	*<ScrollWheelRight>*
+    <ScrollWheelRight>	    scroll N columns right	*<ScrollWheelRight>*
     <S-ScrollWheelRight>    scroll one page right	*<S-ScrollWheelRight>*
     <C-ScrollWheelRight>    scroll one page right	*<C-ScrollWheelRight>*
 This should work in all modes, except when editing the command line.
+
+By default Vim scrolls three lines when moving vertically, and six columns when
+moving horizontally.  On MS-Windows the amount of lines and columns for each
+scroll action is taken from the system-wide settings.
 
 Note that horizontal scrolling only works if 'nowrap' is set.  Also, unless
 the "h" flag in 'guioptions' is set, the cursor moves to the longest visible

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -230,6 +230,10 @@ gui_mch_set_rendering_options(char_u *s)
 # define SPI_GETWHEELSCROLLCHARS	0x006C
 #endif
 
+#ifndef SPI_SETWHEELSCROLLCHARS
+# define SPI_SETWHEELSCROLLCHARS	0x006D
+#endif
+
 #ifdef PROTO
 /*
  * Define a few things for generating prototypes.  This is just to avoid
@@ -4117,18 +4121,32 @@ gui_mswin_get_menu_height(
 /*
  * Setup for the Intellimouse
  */
+    static long
+mouse_vertical_scroll_step(void)
+{
+    UINT val;
+    if (SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &val, 0))
+	return (val != WHEEL_PAGESCROLL) ? (long)val : -1;
+    return 3; // Safe default;
+}
+
+    static long
+mouse_horizontal_scroll_step(void)
+{
+    UINT val;
+    if (SystemParametersInfo(SPI_GETWHEELSCROLLCHARS, 0, &val, 0))
+	return (long)val;
+    return 3; // Safe default;
+}
+
     static void
 init_mouse_wheel(void)
 {
-    // Reasonable default values.
-    mouse_scroll_lines = 3;
-    mouse_scroll_chars = 3;
-
-    // if NT 4.0+ (or Win98) get scroll lines directly from system
-    SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &mouse_scroll_lines, 0);
-    SystemParametersInfo(SPI_GETWHEELSCROLLCHARS, 0, &mouse_scroll_chars, 0);
+    // Get the default values for the horizontal and vertical scroll steps from
+    // the system.
+    mouse_set_scroll_step(mouse_vertical_scroll_step(), FALSE);
+    mouse_set_scroll_step(mouse_horizontal_scroll_step(), TRUE);
 }
-
 
 /*
  * Intellimouse wheel handler.
@@ -4137,15 +4155,9 @@ init_mouse_wheel(void)
     static void
 _OnMouseWheel(HWND hwnd, short zDelta, LPARAM param, int horizontal)
 {
-    int		i;
-    int		amount;
     int		button;
     win_T	*wp;
     int		modifiers, kbd_modifiers;
-
-    // Initializes mouse_scroll_chars too.
-    if (mouse_scroll_lines == 0)
-	init_mouse_wheel();
 
     wp = gui_mouse_window(FIND_POPUP);
 
@@ -4185,23 +4197,9 @@ _OnMouseWheel(HWND hwnd, short zDelta, LPARAM param, int horizontal)
     // Translate the scroll event into an event that Vim can process so that
     // the user has a chance to map the scrollwheel buttons.
     if (horizontal)
-    {
 	button = zDelta >= 0 ? MOUSE_6 : MOUSE_7;
-	if (mouse_scroll_chars > 0
-			       && mouse_scroll_chars < MAX(wp->w_width - 2, 1))
-	    amount = mouse_scroll_chars;
-	else
-	    amount = MAX(wp->w_width - 2, 1);
-    }
     else
-    {
 	button = zDelta >= 0 ? MOUSE_4 : MOUSE_5;
-	if (mouse_scroll_lines > 0
-			      && mouse_scroll_lines < MAX(wp->w_height - 2, 1))
-	    amount = mouse_scroll_lines;
-	else
-	    amount = MAX(wp->w_height - 2, 1);
-    }
 
     kbd_modifiers = get_active_modifiers();
 
@@ -4213,8 +4211,7 @@ _OnMouseWheel(HWND hwnd, short zDelta, LPARAM param, int horizontal)
 	modifiers |= MOUSE_ALT;
 
     mch_disable_flush();
-    for (i = amount; i > 0; --i)
-	gui_send_mouse_event(button, GET_X_LPARAM(param), GET_Y_LPARAM(param),
+    gui_send_mouse_event(button, GET_X_LPARAM(param), GET_Y_LPARAM(param),
 		FALSE, kbd_modifiers);
     mch_enable_flush();
     gui_may_flush();
@@ -4296,12 +4293,10 @@ _OnSettingChange(UINT param)
     switch (param)
     {
 	case SPI_SETWHEELSCROLLLINES:
-	    SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0,
-		    &mouse_scroll_lines, 0);
+	    mouse_set_scroll_step(mouse_vertical_scroll_step(), FALSE);
 	    break;
-	case SPI_GETWHEELSCROLLCHARS:
-	    SystemParametersInfo(SPI_GETWHEELSCROLLCHARS, 0,
-		    &mouse_scroll_chars, 0);
+	case SPI_SETWHEELSCROLLCHARS:
+	    mouse_set_scroll_step(mouse_horizontal_scroll_step(), TRUE);
 	    break;
 	case SPI_SETNONCLIENTMETRICS:
 	    set_tabline_font();

--- a/src/proto/mouse.pro
+++ b/src/proto/mouse.pro
@@ -1,4 +1,5 @@
 /* mouse.c */
+void mouse_set_scroll_step(long step, int horizontal);
 int do_mouse(oparg_T *oap, int c, int dir, long count, int fixindent);
 void ins_mouse(int c);
 void ins_mousescroll(int dir);

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -997,6 +997,7 @@ func Test_gui_mouse_event()
   call assert_equal(['one two abc three', 'four five posix'], getline(1, '$'))
 
   %d _
+  set scrolloff=0
   call setline(1, range(1, 100))
   " scroll up
   let args = #{button: 0x200, row: 2, col: 1, multiclick: 0, modifiers: 0}
@@ -1012,6 +1013,7 @@ func Test_gui_mouse_event()
   call test_gui_event('mouse', args)
   call feedkeys("H", 'Lx!')
   call assert_equal(4, line('.'))
+  set scrolloff&
 
   %d _
   set nowrap

--- a/src/testing.c
+++ b/src/testing.c
@@ -1393,6 +1393,11 @@ test_gui_mouse_event(dict_T *args)
 	repeated_click = (int)dict_get_number(args, (char_u *)"multiclick");
 	mods = (int)dict_get_number(args, (char_u *)"modifiers");
 
+	// Reset the scroll values to known values.
+	// XXX: Remove this when/if the scroll step is made configurable.
+	mouse_set_scroll_step(6, TRUE);
+	mouse_set_scroll_step(3, FALSE);
+
 	gui_send_mouse_event(button, TEXT_X(col - 1), TEXT_Y(row - 1),
 							repeated_click, mods);
     }


### PR DESCRIPTION
- At the moment we use the system defaults on Windows, on every other platform the previous values are kept.
- Fix a typo in a constant name.
- Make the scrolling respect the user settings on Windows, Vim kept multiplying the user-specified amount of scroll by 3 or 6, depending on the direction.