### PR TITLE
fix failing test `Test_expr4_fails` without job feature

### DIFF
--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -1463,10 +1463,12 @@ func Test_expr4_fails()
   call v9.CheckDefAndScriptFailure(["var x = [13] =~ [88]"], 'Cannot compare list with list', 1)
   call v9.CheckDefAndScriptFailure(["var x = [13] !~ [88]"], 'Cannot compare list with list', 1)
 
-  call v9.CheckDefAndScriptFailure(['var j: job', 'var chan: channel', 'var r = j == chan'], 'Cannot compare job with channel', 3)
-  call v9.CheckDefAndScriptFailure(['var j: job', 'var x: list<any>', 'var r = j == x'], 'Cannot compare job with list', 3)
-  call v9.CheckDefAndScriptFailure(['var j: job', 'var Xx: func', 'var r = j == Xx'], 'Cannot compare job with func', 3)
-  call v9.CheckDefAndScriptFailure(['var j: job', 'var Xx: func', 'var r = j == Xx'], 'Cannot compare job with func', 3)
+  if has('job')
+    call v9.CheckDefAndScriptFailure(['var j: job', 'var chan: channel', 'var r = j == chan'], 'Cannot compare job with channel', 3)
+    call v9.CheckDefAndScriptFailure(['var j: job', 'var x: list<any>', 'var r = j == x'], 'Cannot compare job with list', 3)
+    call v9.CheckDefAndScriptFailure(['var j: job', 'var Xx: func', 'var r = j == Xx'], 'Cannot compare job with func', 3)
+    call v9.CheckDefAndScriptFailure(['var j: job', 'var Xx: func', 'var r = j == Xx'], 'Cannot compare job with func', 3)
+  endif
 endfunc
 
 " test addition, subtraction, concatenation


### PR DESCRIPTION
Test `Test_expr4_fails` was failing when vim is built without job feature:
```
$ ./configure --with-features=huge --enable-gui=none --disable-channel
$ cd testdir
$ make test_vim9_expr
...
Executed 85 tests                        in   4.561160 seconds
1 FAILED:
Found errors in Test_expr4_fails():
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[459]..function RunTheTest[44]..Test_expr4_fails[63]..<SNR>9_CheckDefAndScriptFailure[13]..<SNR>9_CheckDefFailure line 6: ['var j: job', 'var chan: channel', 'var r = j == chan']: Expected 'Cannot compare job with channel' but got 'E1277: Channel and job feature is not available': ['var j: job', 'var chan: channel', 'var r = j == chan']
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[459]..function RunTheTest[44]..Test_expr4_fails[64]..<SNR>9_CheckDefAndScriptFailure[13]..<SNR>9_CheckDefFailure line 6: ['var j: job', 'var x: list<any>', 'var r = j == x']: Expected 'Cannot compare job with list' but got 'E1277: Channel and job feature is not available': ['var j: job', 'var x: list<any>', 'var r = j == x']
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[459]..function RunTheTest[44]..Test_expr4_fails[65]..<SNR>9_CheckDefAndScriptFailure[13]..<SNR>9_CheckDefFailure line 6: ['var j: job', 'var Xx: func', 'var r = j == Xx']: Expected 'Cannot compare job with func' but got 'E1277: Channel and job feature is not available': ['var j: job', 'var Xx: func', 'var r = j == Xx']
command line..script /home/pel/sb/vim/src/testdir/runtest.vim[459]..function RunTheTest[44]..Test_expr4_fails[66]..<SNR>9_CheckDefAndScriptFailure[13]..<SNR>9_CheckDefFailure line 6: ['var j: job', 'var Xx: func', 'var r = j == Xx']: Expected 'Cannot compare job with func' but got 'E1277: Channel and job feature is not available': ['var j: job', 'var Xx: func', 'var r = j == Xx']
SKIPPED Test_expr5_fails_channel(): channel feature missing
SKIPPED Test_expr5_vim9script_channel(): channel feature missing
Makefile:63: recipe for target 'test_vim9_expr' failed
make: *** [test_vim9_expr] Error 1
```