### PR TITLE
fuuzy: correctly expand option names

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2787,7 +2787,7 @@ ExpandFromContext(
 
     if (xp->xp_context == EXPAND_SETTINGS
 	    || xp->xp_context == EXPAND_BOOL_SETTINGS)
-	ret = ExpandSettings(xp, &regmatch, pat, numMatches, matches);
+	ret = ExpandSettings(xp, &regmatch, pat, numMatches, matches, fuzzy);
     else if (xp->xp_context == EXPAND_MAPPINGS)
 	ret = ExpandMappings(pat, &regmatch, numMatches, matches);
 # if defined(FEAT_EVAL)

--- a/src/option.c
+++ b/src/option.c
@@ -6511,7 +6511,8 @@ ExpandSettings(
     regmatch_T	*regmatch,
     char_u	*fuzzystr,
     int		*numMatches,
-    char_u	***matches)
+    char_u	***matches,
+    int         can_fuzzy)
 {
     int		num_normal = 0;	    // Nr of matching non-term-code settings
     int		num_term = 0;	    // Nr of matching terminal code settings
@@ -6527,7 +6528,7 @@ ExpandSettings(
     int		fuzzy;
     fuzmatch_str_T  *fuzmatch = NULL;
 
-    fuzzy = cmdline_fuzzy_complete(fuzzystr);
+    fuzzy = cmdline_fuzzy_complete(fuzzystr) && can_fuzzy;
 
     // do this loop twice:
     // loop == 0: count the number of matching options

--- a/src/option.c
+++ b/src/option.c
@@ -6528,7 +6528,7 @@ ExpandSettings(
     int		fuzzy;
     fuzmatch_str_T  *fuzmatch = NULL;
 
-    fuzzy = cmdline_fuzzy_complete(fuzzystr) && can_fuzzy;
+    fuzzy = can_fuzzy && cmdline_fuzzy_complete(fuzzystr);
 
     // do this loop twice:
     // loop == 0: count the number of matching options

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -64,7 +64,7 @@ void reset_modifiable(void);
 void set_iminsert_global(void);
 void set_imsearch_global(void);
 void set_context_in_set_cmd(expand_T *xp, char_u *arg, int opt_flags);
-int ExpandSettings(expand_T *xp, regmatch_T *regmatch, char_u *fuzzystr, int *numMatches, char_u ***matches);
+int ExpandSettings(expand_T *xp, regmatch_T *regmatch, char_u *fuzzystr, int *numMatches, char_u ***matches, int do_fuzzy);
 int ExpandOldSetting(int *num_file, char_u ***file);
 int shortmess(int x);
 void vimrc_found(char_u *fname, char_u *envname);

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1258,6 +1258,7 @@ func Test_opt_cdhome()
 endfunc
 
 func Test_set_completion_2()
+  CheckOption termguicolors
 
   " Test default option completion
   set wildoptions=

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1257,4 +1257,25 @@ func Test_opt_cdhome()
   set cdhome&
 endfunc
 
+func Test_set_completion_2()
+
+  " Test default option completion
+  set wildoptions=
+  call feedkeys(":set termg\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set termguicolors', @:)
+
+  call feedkeys(":set notermg\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set notermguicolors', @:)
+
+  " Test fuzzy option completion
+  set wildoptions=fuzzy
+  call feedkeys(":set termg\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set termguicolors termencoding', @:)
+
+  call feedkeys(":set notermg\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set notermguicolors', @:)
+
+  set wildoptions=
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Pass the value of fuzzy from ExpandFromContext down to ExpandSettings.
In particular, in ExpandSettings fuzzy might be set to zero (because the
expansion type is not supported by fuzzy matching), but later on in
ExpandSettings Vim would still try to expand using the fuzzy matching.

closes #10318