### PR TITLE
Fix maparg() and &pastetoggle sometimes do not return a string that can be reused

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -4017,6 +4017,8 @@ get_option_value(
 	    if ((char_u **)varp == &curbuf->b_p_key
 						&& **(char_u **)(varp) != NUL)
 		*stringval = vim_strsave((char_u *)"*****");
+	    else if ((char_u **)varp == &p_pt)	// 'pastetoggle'
+		*stringval = str2special_save(*(char_u **)(varp), FALSE);
 	    else
 #endif
 		*stringval = vim_strsave(*(char_u **)(varp));

--- a/src/testdir/test_map_functions.vim
+++ b/src/testdir/test_map_functions.vim
@@ -58,6 +58,20 @@ func Test_maparg()
   map abc y<S-char-114>y
   call assert_equal("yRy", maparg('abc'))
 
+  " character with K_SPECIAL byte
+  nmap abc …
+  call assert_equal('…', maparg('abc'))
+
+  " modified character with K_SPECIAL byte
+  nmap abc <M-…>
+  call assert_equal('<M-…>', maparg('abc'))
+
+  " illegal bytes
+  let str = ":\x7f:\x80:\x90:\xd0:"
+  exe 'nmap abc ' .. str
+  call assert_equal(str, maparg('abc'))
+  unlet str
+
   omap { w
   let d = maparg('{', 'o', 0, 1)
   call assert_equal(['{', 'w', 'o'], [d.lhs, d.rhs, d.mode])

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -502,6 +502,13 @@ func Test_list_mappings()
   call assert_equal(['n  <M-…>         foo'],
         \ execute('nmap <M-…>')->trim()->split("\n"))
 
+  " illegal bytes
+  let str = ":\x7f:\x80:\x90:\xd0:"
+  exe 'nmap foo ' .. str
+  call assert_equal(['n  foo           ' .. strtrans(str)],
+        \ execute('nmap foo')->trim()->split("\n"))
+  unlet str
+
   " map to CTRL-V
   exe "nmap ,k \<C-V>"
   call assert_equal(['n  ,k            <Nop>'],

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -48,6 +48,26 @@ func Test_isfname()
   set isfname&
 endfunc
 
+" Test for getting the value of 'pastetoggle'
+func Test_pastetoggle()
+  " character with K_SPECIAL byte
+  let &pastetoggle = '…'
+  call assert_equal('…', &pastetoggle)
+  call assert_equal("\n  pastetoggle=…", execute('set pastetoggle?'))
+
+  " modified character with K_SPECIAL byte
+  let &pastetoggle = '<M-…>'
+  call assert_equal('<M-…>', &pastetoggle)
+  call assert_equal("\n  pastetoggle=<M-…>", execute('set pastetoggle?'))
+
+  " illegal bytes
+  let str = ":\x7f:\x80:\x90:\xd0:"
+  let &pastetoggle = str
+  call assert_equal(str, &pastetoggle)
+  call assert_equal("\n  pastetoggle=" .. strtrans(str), execute('set pastetoggle?'))
+  unlet str
+endfunc
+
 func Test_wildchar()
   " Empty 'wildchar' used to access invalid memory.
   call assert_fails('set wildchar=', 'E521:')


### PR DESCRIPTION
Show invalid UTF-8 in `msg_outtrans_special()` instead of `str2special()`.
Call `str2special()` when getting `&pastetoggle`.