### PR TITLE
Make it clearer what `:mapclear` does in `:help`

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -120,7 +120,8 @@ modes.
 			command applies.
 			Use the <buffer> argument to remove buffer-local
 			mappings |:map-<buffer>|
-			Warning: This also removes the default mappings.
+			Warning: This also removes the |mac-standard-mappings|
+			and the |dos-standard-mappings|.
 
 :map				|mapmode-nvo|
 :nm[ap]				|mapmode-n|


### PR DESCRIPTION
It's easy for a newish user to take "default mappings" to refer to the
built-in commands (dd, etc.). Then :mapclear seems not to work since it
doesn't disable the built-ins, it just unmaps the mac-standard-mappings
and the dos-standard-mappings. This link should help with
discoverability.