### PR TITLE
Update scdoc runtime files

### DIFF
--- a/runtime/compiler/scdoc.vim
+++ b/runtime/compiler/scdoc.vim
@@ -1,7 +1,8 @@
 " scdoc compiler for Vim
 " Compiler: scdoc
-" Maintainer: Greg Anders <greg@gpanders.com>
+" Maintainer: Gregory Anders <contact@gpanders.com>
 " Last Updated: 2019-10-24
+" Upstream: https://github.com/gpanders/vim-scdoc
 
 if exists('current_compiler')
     finish

--- a/runtime/ftplugin/scdoc.vim
+++ b/runtime/ftplugin/scdoc.vim
@@ -1,6 +1,7 @@
 " scdoc filetype plugin
-" Maintainer: Gregory Anders <greg@gpanders.com>
-" Last Updated: 2021-08-04
+" Maintainer: Gregory Anders <contact@gpanders.com>
+" Last Updated: 2022-05-09
+" Upstream: https://github.com/gpanders/vim-scdoc
 
 " Only do this when not done yet for this buffer
 if exists('b:did_ftplugin')
@@ -19,8 +20,3 @@ setlocal softtabstop=0
 setlocal textwidth=80
 
 let b:undo_ftplugin = 'setl com< cms< fo< et< sw< sts< tw<'
-
-if has('conceal')
-    setlocal conceallevel=2
-    let b:undo_ftplugin .= ' cole<'
-endif

--- a/runtime/syntax/scdoc.vim
+++ b/runtime/syntax/scdoc.vim
@@ -1,6 +1,7 @@
 " Syntax file for scdoc files
-" Maintainer: Gregory Anders <greg@gpanders.com>
-" Last Updated: 2021-08-04
+" Maintainer: Gregory Anders <contact@gpanders.com>
+" Last Updated: 2022-05-09
+" Upstream: https://github.com/gpanders/vim-scdoc
 
 if exists('b:current_syntax')
     finish
@@ -20,33 +21,43 @@ syntax match scdocIndentError "^[ ]\+"
 
 syntax match scdocLineBreak "++$"
 
-syntax match scdocOrderedListMarker "^\s*\.\%(\s\+\S\)\@="
-syntax match scdocListMarker "^\s*-\%(\s\+\S\)\@="
+syntax region scdocOrderedListItem matchgroup=scdocOrderedListMarker start="^\z(\s*\)\." skip="^\z1  .*$" end="^" contains=scdocBold,scdocUnderline
+syntax region scdocListItem matchgroup=scdocListMarker start="^\z(\s*\)-" skip="^\z1  .*$" end="^" contains=scdocBold,scdocUnderline
 
-syntax match scdocTableStartMarker "^[\[|\]][\[\-\]]"
-syntax match scdocTableMarker "^[|:][\[\-\] ]"
+" Tables cannot start with a column
+syntax match scdocTableError "^:"
+
+syntax region scdocTable matchgroup=scdocTableEntry start="^[\[|\]][\[\-\]<=>]" end="^$" contains=scdocTableEntry,scdocTableError,scdocTableContinuation,scdocBold,scdocUnderline,scdocPre
+syntax match scdocTableError "^.*$" contained
+syntax match scdocTableContinuation "^   \+\S\+" contained
+syntax match scdocTableEntry "^[|:][\[\-\]<=> ]" contained
+syntax match scdocTableError "^[|:][\[\-\]<=> ]\S.*$" contained
 
 syntax region scdocBold concealends matchgroup=scdocBoldDelimiter start="\\\@<!\*" end="\\\@<!\*"
 syntax region scdocUnderline concealends matchgroup=scdocUnderlineDelimiter start="\<\\\@<!_" end="\\\@<!_\>"
 syntax region scdocPre matchgroup=scdocPreDelimiter start="^\t*```" end="^\t*```"
 
-hi link scdocFirstLineValid     Comment
-hi link scdocComment            Comment
-hi link scdocHeader             Title
-hi link scdocOrderedListMarker  Statement
-hi link scdocListMarker         scdocOrderedListMarker
-hi link scdocLineBreak          Special
-hi link scdocTableMarker        Statement
-hi link scdocTableStartMarker   scdocTableMarker
+syntax sync minlines=50
 
-hi link scdocFirstLineError     Error
-hi link scdocCommentError       Error
-hi link scdocHeaderError        Error
-hi link scdocIndentError        Error
+hi default link scdocFirstLineValid     Comment
+hi default link scdocComment            Comment
+hi default link scdocHeader             Title
+hi default link scdocOrderedListMarker  Statement
+hi default link scdocListMarker         scdocOrderedListMarker
+hi default link scdocLineBreak          Special
+hi default link scdocTableSpecifier     Statement
+hi default link scdocTableEntry         Statement
 
-hi link scdocPreDelimiter       Delimiter
+hi default link scdocFirstLineError        Error
+hi default link scdocCommentError          Error
+hi default link scdocHeaderError           Error
+hi default link scdocIndentError           Error
+hi default link scdocTableError            Error
+hi default link scdocTableError Error
 
-hi scdocBold term=bold cterm=bold gui=bold
-hi scdocUnderline term=underline cterm=underline gui=underline
-hi link scdocBoldDelimiter scdocBold
-hi link scdocUnderlineDelimiter scdocUnderline
+hi default link scdocPreDelimiter       Delimiter
+
+hi default scdocBold term=bold cterm=bold gui=bold
+hi default scdocUnderline term=underline cterm=underline gui=underline
+hi default link scdocBoldDelimiter scdocBold
+hi default link scdocUnderlineDelimiter scdocUnderline


### PR DESCRIPTION
- Disable conceal by default
- Don't highlight indent for list continuation as an error
- Add upstream link to file headers
- Highlight errors in malformed tables
