### PR TITLE
Docs: Normalize capitalization in syntax docs

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -488,7 +488,7 @@ your own highlight colors for the progress bar. Example: >
 	hi TOhtmlProgress guifg=#c0ffee ctermbg=7
 <
 							 *g:html_number_lines*
-Default: current 'number' setting.
+Default: Current 'number' setting.
 When 0, buffer text is displayed in the generated HTML without line numbering.
 When 1, a column of line numbers is added to the generated HTML with the same
 highlighting as the line number column in Vim (|hl-LineNr|).
@@ -577,7 +577,7 @@ folded text will open the fold as if |g:html_hover_unfold| were set.
    :let g:html_no_foldcolumn = 1
 <
 				*TOhtml-uncopyable-text* *g:html_prevent_copy*
-Default: empty string.
+Default: Empty string.
 This option prevents certain regions of the generated HTML from being copied,
 when you select all text in document rendered in a browser and copy it. Useful
 for allowing users to copy-paste only the source text even if a fold column or
@@ -603,7 +603,7 @@ uncopyable regions. In some browsers, especially older browsers, after
 selecting an entire page and copying the selection, the <input> tags are not
 pasted with the page text. If |g:html_no_invalid| is 0, the <input> tags have
 invalid type; this works in more browsers, but the page will not validate.
-Note: this method does NOT work in recent versions of Chrome and equivalent
+Note: This method does NOT work in recent versions of Chrome and equivalent
 browsers; the <input> tags get pasted with the text.
 
 When "fallback" (default value), the same <input> elements are generated for
@@ -659,12 +659,12 @@ To append a string "_mystring" to the end of each ID: >
 
 	:let g:html_id_expr = '"_mystring"'
 <
-Note, when converting a diff view to HTML, the expression will only be
+Note: When converting a diff view to HTML, the expression will only be
 evaluated for the first window in the diff, and the result used for all the
 windows.
 
 					  *TOhtml-wrap-text* *g:html_pre_wrap*
-Default: current 'wrap' setting.
+Default: Current 'wrap' setting.
 When 0, if |g:html_no_pre| is 0 or unset, the text in the generated HTML does
 not wrap at the edge of the browser window.
 When 1, if |g:html_use_css| is 1, the CSS 2.0 "white-space:pre-wrap" value is
@@ -724,7 +724,7 @@ wide browser support. However, you can override this to support specific
 encodings that may not be automatically detected by default (see options
 below). See http://www.iana.org/assignments/character-sets for the IANA names.
 
-Note, by default all Unicode encodings are converted to UTF-8 with no BOM in
+Note: By default all Unicode encodings are converted to UTF-8 with no BOM in
 the generated HTML, as recommended by W3C:
 
 	http://www.w3.org/International/questions/qa-choosing-encodings
@@ -1328,8 +1328,8 @@ the global or buffer-local variable load_doxygen_syntax.  This is done by
 adding the following to your .vimrc. >
 	:let g:load_doxygen_syntax=1
 
-There are a couple of variables that have an effect on syntax highlighting, and
-are to do with non-standard highlighting options.
+There are a couple of variables that have an effect on syntax highlighting,
+and are to do with non-standard highlighting options.
 
 Variable			Default	Effect ~
 g:doxygen_enhanced_color
@@ -1471,8 +1471,8 @@ To enable highlighting some special atoms, put this in your vimrc: >
 
 ELIXIR						*elixir.vim* *ft-elixir-syntax*
 
-Elixir is a dynamic, functional language for building scalable and maintainable
-applications.
+Elixir is a dynamic, functional language for building scalable and
+maintainable applications.
 
 The following file extensions are auto-detected as Elixir file types:
 
@@ -1488,7 +1488,7 @@ Elixir.
 FLEXWIKI				*flexwiki.vim* *ft-flexwiki-syntax*
 
 FlexWiki is an ASP.NET-based wiki package available at http://www.flexwiki.com
-NOTE: this site currently doesn't work, on Wikipedia is mentioned that
+NOTE: This site currently doesn't work, on Wikipedia is mentioned that
 development stopped in 2009.
 
 Syntax highlighting is available for the most common elements of FlexWiki
@@ -1568,8 +1568,8 @@ syntax highlighting will not be correct if the form is incorrectly set.
 When you create a new fortran file, the syntax script assumes fixed source
 form.  If you always use free source form, then >
     :let fortran_free_source=1
-in your .vimrc prior to the :syntax on command.  If you always use fixed source
-form, then >
+in your .vimrc prior to the :syntax on command.  If you always use fixed
+source form, then >
     :let fortran_fixed_source=1
 in your .vimrc prior to the :syntax on command.
 
@@ -1840,8 +1840,8 @@ ends with -->) you can define >
 
 JavaScript and Visual Basic embedded inside HTML documents are highlighted as
 'Special' with statements, comments, strings and so on colored as in standard
-programming languages.  Note that only JavaScript and Visual Basic are currently
-supported, no other scripting language has been added yet.
+programming languages.  Note that only JavaScript and Visual Basic are
+currently supported, no other scripting language has been added yet.
 
 Embedded and inlined cascading style sheets (CSS) are highlighted too.
 
@@ -1945,8 +1945,8 @@ The java.vim syntax highlighting file offers several options:
 
 In Java 1.0.2 it was never possible to have braces inside parens, so this was
 flagged as an error.  Since Java 1.1 this is possible (with anonymous
-classes), and therefore is no longer marked as an error.  If you prefer the old
-way, put the following line into your vim startup file: >
+classes), and therefore is no longer marked as an error.  If you prefer the
+old way, put the following line into your vim startup file: >
 	:let java_mark_braces_in_parens_as_errors=1
 
 All identifiers in java.lang.* are always visible in all classes.  To
@@ -2064,10 +2064,10 @@ LISP						*lisp.vim* *ft-lisp-syntax*
 
 The lisp syntax highlighting provides two options: >
 
-	g:lisp_instring : if it exists, then "(...)" strings are highlighted
+	g:lisp_instring : If it exists, then "(...)" strings are highlighted
 			  as if the contents of the string were lisp.
 			  Useful for AutoLisp.
-	g:lisp_rainbow  : if it exists and is nonzero, then differing levels
+	g:lisp_rainbow  : If it exists and is nonzero, then differing levels
 			  of parenthesization will receive different
 			  highlighting.
 <
@@ -2474,8 +2474,8 @@ If you do not want complex things like '@{${"foo"}}' to be parsed: >
 
 (In Vim 6.x it was the other way around: "perl_extended_vars" enabled it.)
 
-The coloring strings can be changed.  By default strings and qq friends will be
-highlighted like the first line.  If you set the variable
+The coloring strings can be changed.  By default strings and qq friends will
+be highlighted like the first line.  If you set the variable
 perl_string_as_statement, it will be highlighted as in the second line.
 
    "hello world!"; qq|hello world|;
@@ -2487,8 +2487,8 @@ perl_string_as_statement, it will be highlighted as in the second line.
 The syncing has 3 options.  The first two switch off some triggering of
 synchronization and should only be needed in case it fails to work properly.
 If while scrolling all of a sudden the whole screen changes color completely
-then you should try and switch off one of those.  Let me know if you can figure
-out the line that causes the mistake.
+then you should try and switch off one of those.  Let me know if you can
+figure out the line that causes the mistake.
 
 One triggers on "^\s*sub\s*" and the other on "^[$@%]" more or less. >
 
@@ -2525,7 +2525,7 @@ behavior, set 'perl_nofold_packages': >
 
 PHP3 and PHP4		*php.vim* *php3.vim* *ft-php-syntax* *ft-php3-syntax*
 
-[note: previously this was called "php3", but since it now also supports php4
+[Note: Previously this was called "php3", but since it now also supports php4
 it has been renamed to "php"]
 
 There are the following options for the php syntax highlighting.
@@ -2595,15 +2595,15 @@ PPWizard is a preprocessor for HTML and OS/2 INF files
 
 This syntax file has the options:
 
-- ppwiz_highlight_defs : determines highlighting mode for PPWizard's
+- ppwiz_highlight_defs : Determines highlighting mode for PPWizard's
   definitions.  Possible values are
 
   ppwiz_highlight_defs = 1 : PPWizard #define statements retain the
-    colors of their contents (e.g. PPWizard macros and variables)
+    colors of their contents (e.g. PPWizard macros and variables).
 
-  ppwiz_highlight_defs = 2 : preprocessor #define and #evaluate
+  ppwiz_highlight_defs = 2 : Preprocessor #define and #evaluate
     statements are shown in a single color with the exception of line
-    continuation symbols
+    continuation symbols.
 
   The default setting for ppwiz_highlight_defs is 1.
 
@@ -2642,7 +2642,7 @@ highlighted by defining the postscr_level variable as follows: >
 If this variable is not defined it defaults to 2 (level 2) since this is
 the most prevalent version currently.
 
-Note, not all PS interpreters will support all language features for a
+Note: Not all PS interpreters will support all language features for a
 particular language level.  In particular the %!PS-Adobe-3.0 at the start of
 PS files does NOT mean the PostScript present is level 3 PostScript!
 
@@ -2744,7 +2744,7 @@ If you want all possible Python highlighting (the same as setting the
 preceding last option and unsetting all other ones): >
 	:let python_highlight_all = 1
 
-Note: only existence of these options matter, not their value. You can replace
+Note: Only existence of these options matter, not their value. You can replace
       1 above with anything.
 
 QUAKE						*quake.vim* *ft-quake-syntax*
@@ -3184,16 +3184,16 @@ The Speedup syntax file has some options:
   the DECLARE section; if you defined own types, you have to include
   them in the syntax file.
 
-- oneline_comments : this value ranges from 1 to 3 and determines the
+- oneline_comments : This value ranges from 1 to 3 and determines the
   highlighting of # style comments.
 
-  oneline_comments = 1 : allow normal Speedup code after an even
+  oneline_comments = 1 : Allow normal Speedup code after an even
   number of #s.
 
-  oneline_comments = 2 : show code starting with the second # as
+  oneline_comments = 2 : Show code starting with the second # as
   error.  This is the default setting.
 
-  oneline_comments = 3 : show the whole line as error if it contains
+  oneline_comments = 3 : Show the whole line as error if it contains
   more than one #.
 
 Since especially OPERATION sections tend to become very large due to
@@ -3232,8 +3232,8 @@ This covers the shell named "tcsh".  It is a superset of csh.  See |csh.vim|
 for how the filetype is detected.
 
 Tcsh does not allow \" in strings unless the "backslash_quote" shell variable
-is set.  If you want VIM to assume that no backslash quote constructs exist add
-this line to your .vimrc: >
+is set.  If you want VIM to assume that no backslash quote constructs exist
+add this line to your .vimrc: >
 
 	:let tcsh_backslash_quote = 0
 
@@ -3599,7 +3599,7 @@ start and end tags.  This can be turned on by >
 	:let g:xml_syntax_folding = 1
 	:set foldmethod=syntax
 
-Note: syntax folding might slow down syntax highlighting significantly,
+Note: Syntax folding might slow down syntax highlighting significantly,
 especially for large files.
 
 
@@ -5098,8 +5098,8 @@ ctermul={color-nr}				*highlight-ctermul*
 
 	The case of the color names is ignored.
 	Note that for 16 color ansi style terminals (including xterms), the
-	numbers in the NR-8 column is used.  Here '*' means 'add 8' so that Blue
-	is 12, DarkGray is 8 etc.
+	numbers in the NR-8 column is used.  Here '*' means 'add 8' so that
+	Blue is 12, DarkGray is 8 etc.
 
 	Note that for some color terminals these names may result in the wrong
 	colors!
@@ -5242,48 +5242,46 @@ When possible the name is highlighted in the used colors.  If this makes it
 unreadable use Visual selection.
 
 							*hl-ColorColumn*
-ColorColumn	used for the columns set with 'colorcolumn'
+ColorColumn	Used for the columns set with 'colorcolumn'.
 							*hl-Conceal*
-Conceal		placeholder characters substituted for concealed
-		text (see 'conceallevel')
+Conceal		Placeholder characters substituted for concealed
+		text (see 'conceallevel').
 							*hl-Cursor*
-Cursor		the character under the cursor
-lCursor		the character under the cursor when |language-mapping|
-		is used (see 'guicursor')
+Cursor		Character under the cursor.
+lCursor		Character under the cursor when |language-mapping|
+		is used (see 'guicursor').
 							*hl-CursorIM*
-CursorIM	like Cursor, but used when in IME mode |CursorIM|
+CursorIM	Like Cursor, but used when in IME mode. |CursorIM|
 							*hl-CursorColumn*
-CursorColumn	the screen column that the cursor is in when 'cursorcolumn' is
-		set
+CursorColumn	Screen column that the cursor is in when 'cursorcolumn' is set.
 							*hl-CursorLine*
-CursorLine	the screen line that the cursor is in when 'cursorline' is
-		set
+CursorLine	Screen line that the cursor is in when 'cursorline' is set.
 							*hl-Directory*
-Directory	directory names (and other special names in listings)
+Directory	Directory names (and other special names in listings).
 							*hl-DiffAdd*
-DiffAdd		diff mode: Added line |diff.txt|
+DiffAdd		Diff mode: Added line. |diff.txt|
 							*hl-DiffChange*
-DiffChange	diff mode: Changed line |diff.txt|
+DiffChange	Diff mode: Changed line. |diff.txt|
 							*hl-DiffDelete*
-DiffDelete	diff mode: Deleted line |diff.txt|
+DiffDelete	Diff mode: Deleted line. |diff.txt|
 							*hl-DiffText*
-DiffText	diff mode: Changed text within a changed line |diff.txt|
+DiffText	Diff mode: Changed text within a changed line. |diff.txt|
 							*hl-EndOfBuffer*
-EndOfBuffer	filler lines (~) after the last line in the buffer.
+EndOfBuffer	Filler lines (~) after the last line in the buffer.
 		By default, this is highlighted like |hl-NonText|.
 							*hl-ErrorMsg*
-ErrorMsg	error messages on the command line
+ErrorMsg	Error messages on the command line.
 							*hl-VertSplit*
-VertSplit	the column separating vertically split windows
+VertSplit	Column separating vertically split windows.
 							*hl-Folded*
-Folded		line used for closed folds
+Folded		Line used for closed folds.
 							*hl-FoldColumn*
 FoldColumn	'foldcolumn'
 							*hl-SignColumn*
-SignColumn	column where |signs| are displayed
+SignColumn	Column where |signs| are displayed.
 							*hl-IncSearch*
 IncSearch	'incsearch' highlighting; also used for the text replaced with
-		":s///c"
+		":s///c".
 							*hl-LineNr*
 LineNr		Line number for ":number" and ":#" commands, and when 'number'
 		or 'relativenumber' option is set.
@@ -5301,11 +5299,11 @@ CursorLineSign	Like SignColumn when 'cursorline' is set for the cursor line.
 							*hl-CursorLineFold*
 CursorLineFold	Like FoldColumn when 'cursorline' is set for the cursor line.
 							*hl-MatchParen*
-MatchParen	The character under the cursor or just before it, if it
+MatchParen	Character under the cursor or just before it, if it
 		is a paired bracket, and its match. |pi_paren.txt|
 
 							*hl-ModeMsg*
-ModeMsg		'showmode' message (e.g., "-- INSERT --")
+ModeMsg		'showmode' message (e.g., "-- INSERT --").
 							*hl-MoreMsg*
 MoreMsg		|more-prompt|
 							*hl-NonText*
@@ -5314,17 +5312,17 @@ NonText		'@' at the end of the window, characters from 'showbreak'
 		(e.g., ">" displayed when a double-wide character doesn't
 		fit at the end of the line).
 							*hl-Normal*
-Normal		normal text
+Normal		Normal text.
 							*hl-Pmenu*
-Pmenu		Popup menu: normal item.
+Pmenu		Popup menu: Normal item.
 							*hl-PmenuSel*
-PmenuSel	Popup menu: selected item.
+PmenuSel	Popup menu: Selected item.
 							*hl-PmenuSbar*
-PmenuSbar	Popup menu: scrollbar.
+PmenuSbar	Popup menu: Scrollbar.
 							*hl-PmenuThumb*
 PmenuThumb	Popup menu: Thumb of the scrollbar.
 							*hl-Question*
-Question	|hit-enter| prompt and yes/no questions
+Question	|hit-enter| prompt and yes/no questions.
 							*hl-QuickFixLine*
 QuickFixLine	Current |quickfix| item in the quickfix window.
 							*hl-Search*
@@ -5332,12 +5330,12 @@ Search		Last search pattern highlighting (see 'hlsearch').
 		Also used for similar items that need to stand out.
 							*hl-CurSearch*
 CurSearch	Current match for the last search pattern (see 'hlsearch').
-		Note: this is correct after a search, but may get outdated if
-		changes are made or the screen is redrawn. 
+		Note: This is correct after a search, but may get outdated if
+		changes are made or the screen is redrawn.
 							*hl-SpecialKey*
 SpecialKey	Meta and special keys listed with ":map", also for text used
 		to show unprintable characters in the text, 'listchars'.
-		Generally: text that is displayed differently from what it
+		Generally: Text that is displayed differently from what it
 		really is.
 							*hl-SpellBad*
 SpellBad	Word that is not recognized by the spellchecker. |spell|
@@ -5354,35 +5352,35 @@ SpellRare	Word that is recognized by the spellchecker as one that is
 		hardly ever used. |spell|
 		This will be combined with the highlighting used otherwise.
 							*hl-StatusLine*
-StatusLine	status line of current window
+StatusLine	Status line of current window.
 							*hl-StatusLineNC*
 StatusLineNC	status lines of not-current windows
-		Note: if this is equal to "StatusLine" Vim will use "^^^" in
+		Note: If this is equal to "StatusLine", Vim will use "^^^" in
 		the status line of the current window.
 							*hl-StatusLineTerm*
-StatusLineTerm	status line of current window, if it is a |terminal| window.
+StatusLineTerm	Status line of current window, if it is a |terminal| window.
 							*hl-StatusLineTermNC*
-StatusLineTermNC   status lines of not-current windows that is a |terminal|
+StatusLineTermNC   Status lines of not-current windows that is a |terminal|
 		window.
 							*hl-TabLine*
-TabLine		tab pages line, not active tab page label
+TabLine		Tab pages line, not active tab page label.
 							*hl-TabLineFill*
-TabLineFill	tab pages line, where there are no labels
+TabLineFill	Tab pages line, where there are no labels.
 							*hl-TabLineSel*
-TabLineSel	tab pages line, active tab page label
+TabLineSel	Tab pages line, active tab page label.
 							*hl-Terminal*
-Terminal	|terminal| window (see |terminal-size-color|)
+Terminal	|terminal| window (see |terminal-size-color|).
 							*hl-Title*
-Title		titles for output from ":set all", ":autocmd" etc.
+Title		Titles for output from ":set all", ":autocmd" etc.
 							*hl-Visual*
-Visual		Visual mode selection
+Visual		Visual mode selection.
 							*hl-VisualNOS*
 VisualNOS	Visual mode selection when vim is "Not Owning the Selection".
 		Only X11 Gui's |gui-x11| and |xterm-clipboard| supports this.
 							*hl-WarningMsg*
-WarningMsg	warning messages
+WarningMsg	Warning messages.
 							*hl-WildMenu*
-WildMenu	current match in 'wildmenu' completion
+WildMenu	Current match in 'wildmenu' completion.
 
 					*hl-User1* *hl-User1..9* *hl-User9*
 The 'statusline' syntax allows the use of 9 different highlights in the
@@ -5772,7 +5770,7 @@ If your syntax causes redrawing to be slow, here are a few hints on making it
 faster.  To see slowness switch on some features that usually interfere, such
 as 'relativenumber' and |folding|.
 
-Note: this is only available when compiled with the |+profile| feature.
+Note: This is only available when compiled with the |+profile| feature.
 You many need to build Vim with "huge" features.
 
 To find out what patterns are consuming most time, get an overview with this


### PR DESCRIPTION
I've removed the `|CursorIM|` link, as that appears to lead nowhere.