### PR TITLE
[WIP/RFC] Documentation for indexing into strings/buffers/windows/screen

### DIFF
--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -35,7 +35,6 @@ DOCS = \
 	ft_raku.txt \
 	ft_rust.txt \
 	ft_sql.txt \
-	geometry.txt \
 	gui.txt \
 	gui_w32.txt \
 	gui_x11.txt \
@@ -55,6 +54,7 @@ DOCS = \
 	if_tcl.txt \
 	indent.txt \
 	index.txt \
+	indexing.txt \
 	insert.txt \
 	intro.txt \
 	map.txt \

--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -35,6 +35,7 @@ DOCS = \
 	ft_raku.txt \
 	ft_rust.txt \
 	ft_sql.txt \
+	geometry.txt \
 	gui.txt \
 	gui_w32.txt \
 	gui_x11.txt \

--- a/runtime/doc/geometry.txt
+++ b/runtime/doc/geometry.txt
@@ -1,0 +1,132 @@
+*geometry.txt*  For Vim version 8.2.  Last change: 2022 May 05
+
+
+		  VIM REFERENCE MANUAL
+
+
+Indexing into strings/buffers/windows by line/row/byte/column.	*geometry*
+
+
+0. String/line indexing		|geometry-string-indexing|
+   By byte			|geometry-string-by-byte|
+   By character			|geometry-string-by-character|
+   By display cell		|geometry-string-by-display-cell|
+   Conversion functions		|geometry-string-indexing-conversion|
+
+
+==============================================================================
+0. String/line indexing				*geometry-string-indexing*
+
+Informally, a string is a finite sequence of characters, for example "foobar"
+or "여보세요". Vim represents a buffer as a list of strings, one per line, and
+provides functions which do things like return the `n`th line of a buffer as a
+string.
+
+This section discusses indexing into strings (and therefore buffer lines).
+Strings can be indexed by byte, by character (code point), or by display
+column (horizontal offset on the screen). Being careful about how you index is
+important if you are writing code where horizontal offsets are important, for
+example if you are making a plugin for auto-formatting tables.
+
+Strings are normally represented by sequences of bytes (8-bit integers), which
+are converted into display characters (like "f" or "여") using a character
+encoding, which is essentially a table that maps byte sequences to display
+characters. Once interpreted as a sequence of display characters, a string can
+be rendered in a terminal or GUI using the terminal or GUI's fonts, display
+settings, etc.
+
+In UTF-8 (the usual *'encoding'* used by Vim), the ASCII characters are all
+one byte long, but other UTF-8 characters use multiple bytes, and there are
+other common encodings such as UTF-16 where all characters use multiple bytes,
+so indexing by display character is encoding-dependent. In a terminal, some
+characters (all common Latin characters, for example) are one column wide, but
+some characters are more than one column wide, so indexing by screen column is
+both encoding- dependent and renderer-dependent.
+
+
+BY BYTE						*geometry-string-by-byte*
+
+Using square brackets to index into a string performs indexing by byte offset,
+and is zero-based. The builtin function *strlen* can be used to get the byte
+length of a string.
+
+Example:
+	:let s = "foobar" ~
+	:echo s[0] ~
+	(prints "f")
+	:echo s[3] ~
+	(prints "b")
+	:echo strlen(s) ~
+	(prints "6")
+	:echo "여보세요"[2] ~
+	(prints an encoding-dependent byte, `<ac>` in UTF-8)
+	:echo strlen("여보세요") ~
+	(prints "12" in UTF-8)
+
+See also: *strpart*
+
+
+BY CHARACTER					*geometry-string-by-character*
+
+The builtin function *strcharpart* can be used to get an arbitrary-length
+portion of a string, indexed by character, zero-based. Using this function
+with a length argument of 1 is the easiest way to get the `n`th character from
+a string.
+
+Example:
+	:echo strcharpart("foobar", 3, 2) ~
+	(prints "ba")
+	:echo strcharpart("foobar", 0, 1) ~
+	(prints "f")
+	:echo strcharpart("여보세요", 0, 2) ~
+	(prints "여보")
+
+The function *strchars* gives the number of characters in a string. The
+builtin function *strgetchar* can be used to get the numeric value (usually
+Unicode code point) of the `n`th character from a string.
+
+Example:
+	:echo strchars("여보세요") ~
+	(prints "4")
+	:echo strgetchar("여보세요", 2) ~
+	(prints 50668)
+
+See also: *slice()*
+
+
+BY DISPLAY CELL				*geometry-string-by-display-cell*
+
+Some text.
+
+
+CONVERSION FUNCTIONS			*geometry-string-indexing-conversion*
+
+- *charidx* : convert byte index to character index
+- *byteidx* : convert character index to byte index
+
+==============================================================================
+0. String indexing				*geometry-string-indexing*
+
+Some text.
+
+
+BY BYTE						*geometry-string-by-byte*
+
+Some text.
+
+
+BY CHARACTER					*geometry-string-by-character*
+
+Some text.
+
+
+BY DISPLAY CELL				*geometry-string-by-display-cell*
+
+Some text.
+
+
+CONVERSION FUNCTIONS			*geometry-string-indexing-conversion*
+
+Some text.
+
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -139,6 +139,7 @@ Advanced editing ~
 |builtin.txt|	builtin functions
 |channel.txt|	Jobs, Channels, inter-process communication
 |fold.txt|	hide (fold) ranges of lines
+|geometry.txt|	indexing into buffers/windows by line/row/byte/column
 
 Special issues ~
 |testing.txt|	testing Vim and Vim scripts

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -139,7 +139,7 @@ Advanced editing ~
 |builtin.txt|	builtin functions
 |channel.txt|	Jobs, Channels, inter-process communication
 |fold.txt|	hide (fold) ranges of lines
-|geometry.txt|	indexing into buffers/windows by line/row/byte/column
+|indexing.txt|	indexing into strings/buffers/windows
 
 Special issues ~
 |testing.txt|	testing Vim and Vim scripts

--- a/runtime/doc/indexing.txt
+++ b/runtime/doc/indexing.txt
@@ -1,4 +1,4 @@
-*geometry.txt*  For Vim version 8.2.  Last change: 2022 May 05
+*indexing.txt*  For Vim version 8.2.  Last change: 2022 May 05
 
 
 		  VIM REFERENCE MANUAL
@@ -26,13 +26,14 @@ This section discusses indexing into strings (and therefore buffer lines).
 Strings can be indexed by byte, by character (code point), or by display
 column (horizontal offset on the screen). Being careful about how you index is
 important if you are writing code where horizontal offsets are important, for
-example if you are making a plugin for auto-formatting tables.
+example if you are making a plugin for auto-formatting tables, or a plugin
+with an in-buffer UI.
 
 Strings are normally represented by sequences of bytes (8-bit integers), which
 are converted into display characters (like "f" or "여") using a character
 encoding, which is essentially a table that maps byte sequences to display
 characters. Once interpreted as a sequence of display characters, a string can
-be rendered in a terminal or GUI using the terminal or GUI's fonts, display
+be rendered in a terminal or GUI using the terminal's or GUI's fonts, display
 settings, etc.
 
 In UTF-8 (the usual *'encoding'* used by Vim), the ASCII characters are all
@@ -47,7 +48,7 @@ both encoding- dependent and renderer-dependent.
 BY BYTE						*geometry-string-by-byte*
 
 Using square brackets to index into a string performs indexing by byte offset,
-and is zero-based. The builtin function *strlen* can be used to get the byte
+and is zero-based. The builtin function *strlen()* can be used to get the byte
 length of a string.
 
 Example:
@@ -63,17 +64,23 @@ Example:
 	:echo strlen("여보세요") ~
 	(prints "12" in UTF-8)
 
-See also: *strpart*
+See also: *strpart()*
 
 
 BY CHARACTER					*geometry-string-by-character*
 
-The builtin function *strcharpart* can be used to get an arbitrary-length
-portion of a string, indexed by character, zero-based. Using this function
-with a length argument of 1 is the easiest way to get the `n`th character from
-a string.
+The builtin function *strgetchar()* can be used to get the `n`th character
+from a string, and the function *strcharpart()* can be used to get an
+arbitrary-length portion of a string. Both of these functions accept character
+indices and are zero-based.
 
 Example:
+	:echo strgetchar("foobar", 0) ~
+	(prints "f")
+	:echo strgetchar("foobar", 1) ~
+	(prints "o")
+	:echo strcharpart("여보세요", 2) ~
+	(prints "세")
 	:echo strcharpart("foobar", 3, 2) ~
 	(prints "ba")
 	:echo strcharpart("foobar", 0, 1) ~
@@ -81,8 +88,8 @@ Example:
 	:echo strcharpart("여보세요", 0, 2) ~
 	(prints "여보")
 
-The function *strchars* gives the number of characters in a string. The
-builtin function *strgetchar* can be used to get the numeric value (usually
+The function *strchars()* gives the number of characters in a string. The
+builtin function *strgetchar()* can be used to get the numeric value (usually
 Unicode code point) of the `n`th character from a string.
 
 Example:
@@ -91,18 +98,27 @@ Example:
 	:echo strgetchar("여보세요", 2) ~
 	(prints 50668)
 
-See also: *slice()*
+See also: *slice()* *strcharlen()*
 
 
 BY DISPLAY CELL				*geometry-string-by-display-cell*
 
-Some text.
+The builtin function *strwidth()* gives the width of a string in display
+cells.
+
+Example:
+	:echo strwidth("여") ~
+	(renderer-dependent, but in many terminals prints "2")
+
+See also: *strdisplaywidth()* *setcellwidths()*
 
 
 CONVERSION FUNCTIONS			*geometry-string-indexing-conversion*
 
-- *charidx* : convert byte index to character index
-- *byteidx* : convert character index to byte index
+- *charidx()* : convert byte index to character index
+- *byteidx()* : convert character index to byte index
+- *byteidxcomp()* : like *byteidx()* but count composing characters
+- *iconv()* : convert text from one encoding to another
 
 ==============================================================================
 0. String indexing				*geometry-string-indexing*

--- a/runtime/doc/indexing.txt
+++ b/runtime/doc/indexing.txt
@@ -4,18 +4,19 @@
 		  VIM REFERENCE MANUAL
 
 
-Indexing into strings/buffers/windows by line/row/byte/column.	*geometry*
+								*indexing*
+Indexing into strings/buffers/windows by line/row/byte/column/character.
 
 
-0. String/line indexing		|geometry-string-indexing|
-   By byte			|geometry-string-by-byte|
-   By character			|geometry-string-by-character|
-   By display cell		|geometry-string-by-display-cell|
-   Conversion functions		|geometry-string-indexing-conversion|
+0. String/line indexing		|indexing-strings|
+   By byte			|indexing-strings-by-byte|
+   By character			|indexing-strings-by-character|
+   By display cell		|indexing-strings-by-display-cell|
+   Conversion functions		|indexing-strings-conversion|
 
 
 ==============================================================================
-0. String/line indexing				*geometry-string-indexing*
+0. String/line indexing				*indexing-strings*
 
 Informally, a string is a finite sequence of characters, for example "foobar"
 or "여보세요". Vim represents a buffer as a list of strings, one per line, and
@@ -45,7 +46,7 @@ some characters are more than one column wide, so indexing by screen column is
 both encoding- dependent and renderer-dependent.
 
 
-BY BYTE						*geometry-string-by-byte*
+BY BYTE						*indexing-strings-by-byte*
 
 Using square brackets to index into a string performs indexing by byte offset,
 and is zero-based. The builtin function *strlen()* can be used to get the byte
@@ -67,7 +68,7 @@ Example:
 See also: *strpart()*
 
 
-BY CHARACTER					*geometry-string-by-character*
+BY CHARACTER					*indexing-strings-by-character*
 
 The builtin function *strgetchar()* can be used to get the `n`th character
 from a string, and the function *strcharpart()* can be used to get an
@@ -101,7 +102,7 @@ Example:
 See also: *slice()* *strcharlen()*
 
 
-BY DISPLAY CELL				*geometry-string-by-display-cell*
+BY DISPLAY CELL				*indexing-strings-by-display-cell*
 
 The builtin function *strwidth()* gives the width of a string in display
 cells.
@@ -113,7 +114,7 @@ Example:
 See also: *strdisplaywidth()* *setcellwidths()*
 
 
-CONVERSION FUNCTIONS			*geometry-string-indexing-conversion*
+CONVERSION FUNCTIONS			*indexing-strings-conversion*
 
 - *charidx()* : convert byte index to character index
 - *byteidx()* : convert character index to byte index
@@ -121,27 +122,27 @@ CONVERSION FUNCTIONS			*geometry-string-indexing-conversion*
 - *iconv()* : convert text from one encoding to another
 
 ==============================================================================
-0. String indexing				*geometry-string-indexing*
+0. String indexing				*indexing-strings*
 
 Some text.
 
 
-BY BYTE						*geometry-string-by-byte*
+BY BYTE						*indexing-strings-by-byte*
 
 Some text.
 
 
-BY CHARACTER					*geometry-string-by-character*
+BY CHARACTER					*indexing-strings-by-character*
 
 Some text.
 
 
-BY DISPLAY CELL				*geometry-string-by-display-cell*
+BY DISPLAY CELL				*indexing-strings-by-display-cell*
 
 Some text.
 
 
-CONVERSION FUNCTIONS			*geometry-string-indexing-conversion*
+CONVERSION FUNCTIONS			*indexing-strings-conversion*
 
 Some text.
 

--- a/runtime/doc/indexing.txt
+++ b/runtime/doc/indexing.txt
@@ -8,15 +8,24 @@
 Indexing into strings/buffers/windows by line/row/byte/column/character.
 
 
-0. String/line indexing		|indexing-strings|
+1. String/line indexing		|indexing-strings|
    By byte			|indexing-strings-by-byte|
    By character			|indexing-strings-by-character|
    By display cell		|indexing-strings-by-display-cell|
    Conversion functions		|indexing-strings-conversion|
+2. Buffer indexing		|indexing-buffers|
+   Getting and setting text	|indexing-buffer-text|
+   Cursor/mark/mouse position	|indexing-buffer-cusror-pos|
+3. Window indexing		|indexing-windows|
+   Cursor/mark/mouse position	|indexing-windows-cusror-pos|
+4. Screen indexing		|indexing-screen|
+   Getting text			|indexing-screen-text|
+   Cursor/mark/mouse position	|indexing-screen-cusror-pos|
+   Window position		|indexing-screen-window-pos|
 
 
 ==============================================================================
-0. String/line indexing				*indexing-strings*
+1. String/line indexing				*indexing-strings*
 
 Informally, a string is a finite sequence of characters, for example "foobar"
 or "여보세요". Vim represents a buffer as a list of strings, one per line, and
@@ -65,7 +74,7 @@ Example:
 	:echo strlen("여보세요") ~
 	(prints "12" in UTF-8)
 
-See also: *strpart()*
+See also / TODO: *strpart()* *len()* *stridx()* *strridx()*
 
 
 BY CHARACTER					*indexing-strings-by-character*
@@ -99,7 +108,7 @@ Example:
 	:echo strgetchar("여보세요", 2) ~
 	(prints 50668)
 
-See also: *slice()* *strcharlen()*
+See also / TODO: *slice()* *strcharlen()* *strpart()*
 
 
 BY DISPLAY CELL				*indexing-strings-by-display-cell*
@@ -111,10 +120,15 @@ Example:
 	:echo strwidth("여") ~
 	(renderer-dependent, but in many terminals prints "2")
 
-See also: *strdisplaywidth()* *setcellwidths()*
+TODO: Add some content or a link about how to get the character at the `n`th
+display column from a buffer line.
+
+See also / TODO: *strdisplaywidth()* *setcellwidths()*
 
 
 CONVERSION FUNCTIONS			*indexing-strings-conversion*
+
+TODO: Flesh this out.
 
 - *charidx()* : convert byte index to character index
 - *byteidx()* : convert character index to byte index
@@ -122,28 +136,131 @@ CONVERSION FUNCTIONS			*indexing-strings-conversion*
 - *iconv()* : convert text from one encoding to another
 
 ==============================================================================
-0. String indexing				*indexing-strings*
+1. Buffer indexing				*indexing-buffers*
 
-Some text.
+This section covers how to index into different parts of a buffer to get or
+set text, to get or set the cursor position within a buffer, etc.
 
+Most Vim functions referring to buffer locations use `[line, column]` indices,
+where `line` is usually a line number in the buffer (ignoring wrapping), and
+`column` is usually a byte index/offset within a line. Both of these are
+usually one-based (the first character on the first line has `[line, column]`
+equal to `[1, 1]`); however, this varies, and you should check the
+documentation when using a function indexing into a buffer.
 
-BY BYTE						*indexing-strings-by-byte*
-
-Some text.
-
-
-BY CHARACTER					*indexing-strings-by-character*
-
-Some text.
-
-
-BY DISPLAY CELL				*indexing-strings-by-display-cell*
-
-Some text.
+TODO: Flesh this out more.
 
 
-CONVERSION FUNCTIONS			*indexing-strings-conversion*
+GETTING AND SETTING TEXT				*indexing-buffer-text*
 
-Some text.
+This section covers how to get and set text based on its location in a buffer.
+
+TODO: Flesh this out.
+
+The built-in function `getline` lets you get the `n`th line in the current
+buffer as a string.
+
+Example:
+	:echo getline(3) ~
+	(prints the third line of the current buffer)
+
+TODO: *setline()* *append()* *appendbufline()* *deletebufline()*
+*getbufline()* *getline()* *nextnonblank()* *setbufline()* *setline()*
+
+TODO: Subsection on conversion between line number and byte offset within the
+buffer? *byte2line()* *line2byte()*
+
+==============================================================================
+3. Window indexing					*indexing-windows*
+
+This section covers how to access parts of the screen indexed by line/column
+offsets within a window. These offsets count screen lines and screen columns
+starting at the upper-left-most cell of a window. The upper-left-most cell
+usually has `[line, column]` equal to `[1, 1]` . TODO: Proofread/verify/revise.
+
+TODO: Make it explicit and clear that a "window" is not the OS window that
+contains the editor, but a Vim "window".
+
+TODO: Flesh this out more.
+
+TODO: Where does *virtcol()* go?
+
+
+CURSOR MARK MOUSE POSITION			*indexing-windows-cursor-pos*
+
+This section primarily covers how to get and set the cursor position using
+line and column indices within a window. Many (most? all? TODO) of the
+functions in this section also work to get and set positions of marks within a
+buffer.
+
+TODO: Flesh this out.
+
+TODO:
+*getmousepos()*
+*wincol()*
+*winline()*
+
+==============================================================================
+4. Screen indexing					*indexing-screen*
+
+This section covers how to access parts of the screen indexed by screen row
+and column. These offsets count screen lines and screen columns starting at
+the upper-left-most cell of Vim. The upper-left-most cell usually has
+`[row, column]` equal to `[1, 1]` . TODO: Proofread/verify/revise.
+
+A note on terminology: Vim usually uses the term "line" to refer to buffer
+lines and screen lines within a window, and the term "row" to refer to screen
+lines within the editor.
+
+TODO: Flesh this out more.
+
+TODO: Talk about *'rows'* and *'columns'* .
+
+TODO: Probably in another section:
+*getcmdpos()* *getcmdscreenpos()* *setcmdpos()*
+
+
+GETTING TEXT						*indexing-screen-text*
+
+This section covers how to get text based on its location on the screen.
+
+TODO: Flesh this out.
+
+TODO:
+*screenchar()*
+*screenattr()*
+*screenchars()*
+*screenstring()*
+*screenpos()*
+
+
+CURSOR MARK MOUSE POSITION			*indexing-screen-cursor-pos*
+
+This section primarily covers how to get and set the cursor position using
+screen row and column indices. Many (most? all? TODO) of the functions in this
+section also work to get and set positions of marks within a buffer.
+
+TODO: Flesh this out.
+
+TODO:
+*screenrow()*
+*screencol()*
+*getmousepos()*
+
+
+WINDOW POSITION					*indexing-screen-window-pos*
+
+This section covers how to get and set the position of windows within the
+screen.
+
+TODO: Flesh this out.
+
+TODO: Discuss popups?
+
+TODO:
+*win_screenpos()*
+*winheight()*
+*winlayout()*
+*winwidth()*
 
  vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
I think it could be useful to have a help page covering indexing into strings/buffers/windows/the screen. Specifically I think this would be useful for plugin authors writing text manipulation code where alignment is important, for example when writing an in-buffer GUI or writing a plugin dealing with text alignment.

My hope is that this page can cover the main coordinate systems in Vim (buffer, window, virtual, screen), functions that let you get/set text and cursor position in each of these coordinate systems, and conversion between the coordinate systems. It is also a good place to talk about the different "coordinate systems" for indexing into a string (byte/character/display column).

Doing this will take a lot of work, so before I go further I would like to get feedback:

- Is this addition welcome? I am willing to put a lot of time into making this well-organized, well-written, consistent with the rest of the docs, etc., but the change will still probably require some feedback from Bram or another core maintainer.
- How should this help page be named? Ideas: `indexing.txt`, `geometry.txt`, `coords.txt`, `coordinates.txt`, ...
  - I think `indexing.txt` is a good name, but it's very close to `index.txt`, which might be annoying.
- If this help page gets created, should it just consist of prose/examples with links to the reference docs in `builtin.txt`, or should the reference documentation for all of these functions get moved to this help page?

The PR below has a proposed outline and a writing sample. Let me know what you think and whether I should continue.

Thanks!

---

Edit: this page could be the canonical answer to a question of the form "How do I [get|set] the [text|cursor-position|mark|...] at [location] in [string|buffer|window|screen]?"