### PR TITLE
Recompute `swb_flags` in `didset_string_options`

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -125,6 +125,7 @@ didset_string_options(void)
 #if defined(FEAT_TOOLBAR) && defined(FEAT_GUI_GTK)
     (void)opt_strings_flags(p_tbis, p_tbis_values, &tbis_flags, FALSE);
 #endif
+    (void)opt_strings_flags(p_swb, p_swb_values, &swb_flags, TRUE);
 }
 
 #if defined(FEAT_EVAL)

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1299,4 +1299,15 @@ func Test_set_completion_2()
   set wildoptions=
 endfunc
 
+func Test_switchbuf_reset()
+  set switchbuf=useopen
+  sblast
+  call assert_equal(1, winnr('$'))
+  set all&
+  call assert_equal('', &switchbuf)
+  sblast
+  call assert_equal(2, winnr('$'))
+  only!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
'switchbuf's flags are not recomputed when the option value changes in some
cases (e.g: `:set all&`: the option's value will be reset, but will act like the
previous value is still set).