### PR TITLE
Fix textprop breaking at line boundaries

### DIFF
--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -1958,4 +1958,37 @@ func Test_prop_shift_block()
   bwipe!
 endfunc
 
+func Test_prop_insert_multiline()
+  new
+  call AddPropTypes()
+
+  call setline(1, ['foobar', 'barbaz'])
+  call prop_add(1, 4, #{end_lnum: 2, end_col: 4, type: 'one'})
+
+  call feedkeys("1Goquxqux\<Esc>", 'nxt')
+  call feedkeys("2GOquxqux\<Esc>", 'nxt')
+
+  let lines =<< trim END
+  foobar
+  quxqux
+  quxqux
+  barbaz
+  END
+  call assert_equal(lines, getline(1, '$'))
+  let expected = [
+      \ {'lnum': 1, 'id': 0, 'col': 4, 'type_bufnr': 0, 'end': 0, 'type': 'one',
+      \ 'length': 4 ,'start': 1},
+      \ {'lnum': 2, 'id': 0, 'col': 1, 'type_bufnr': 0, 'end': 0, 'type': 'one',
+      \ 'length': 7, 'start': 0},
+      \ {'lnum': 3, 'id': 0, 'col': 1, 'type_bufnr': 0, 'end': 0, 'type': 'one',
+      \ 'length': 7, 'start': 0},
+      \ {'lnum': 4, 'id': 0, 'col': 1, 'type_bufnr': 0, 'end': 1, 'type': 'one',
+      \ 'length': 3, 'start': 0}
+      \ ]
+  call assert_equal(expected, prop_list(1, #{end_lnum: 10}))
+
+  call DeletePropTypes()
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -1649,12 +1649,13 @@ adjust_prop(
 {
     proptype_T	*pt = text_prop_type_by_id(curbuf, prop->tp_type);
     int		start_incl = (pt != NULL
-				    && (pt->pt_flags & PT_FLAG_INS_START_INCL))
-						   || (flags & APC_SUBSTITUTE);
+	    && (pt->pt_flags & PT_FLAG_INS_START_INCL))
+	    || (flags & APC_SUBSTITUTE)
+	    || (prop->tp_flags & TP_FLAG_CONT_PREV);
     int		end_incl = (pt != NULL
-				     && (pt->pt_flags & PT_FLAG_INS_END_INCL));
-		// Do not drop zero-width props if they later can increase in
-		// size.
+	    && (pt->pt_flags & PT_FLAG_INS_END_INCL))
+	    || (prop->tp_flags & TP_FLAG_CONT_NEXT);
+    // Do not drop zero-width props if they later can increase in size.
     int		droppable = !(start_incl || end_incl);
     adjustres_T res = {TRUE, FALSE};
 


### PR DESCRIPTION
If the text property spans more than one line let's make sure that we
don't break it into smaller pieces when adding to the line start or
end.

Closes #8261 I guess