### PR TITLE
Redraw the stl when terminal title changes

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3133,7 +3133,10 @@ handle_settermprop(
 	    }
 	    VIM_CLEAR(term->tl_status_text);
 	    if (term == curbuf->b_term)
+	    {
 		maketitle();
+		curwin->w_redr_status = TRUE;
+	    }
 	    break;
 
 	case VTERM_PROP_CURSORVISIBLE:


### PR DESCRIPTION
Writing a test that fails without this is left as an exercise for the reader, here's what I've got so far:

```vim
func Test_statusline_change_term_title()
  if !has('title') || empty(&t_ts)
    throw "Skipped: can't get/set title"
  endif

  let g:term = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'],
      \ #{hidden: 1})
  set ls=2 stl=%{'xX'..term_gettitle(g:term)..'Xx'}

  call term_sendkeys(g:term, ":set title titlestring=foo\n")
  call WaitForAssert({-> assert_equal('foo', term_gettitle(g:term)) })
  call assert_match('^xXfooXx\s*$', s:get_statusline())

  set ls& stl&
  exe g:term . 'bwipe!'
  unlet g:term
endfunc
```

Closes #3418