### PR TITLE
Changes for :terminal color handling

### DIFF
--- a/src/job.c
+++ b/src/job.c
@@ -548,13 +548,13 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 		    break;
 
 		if (item == NULL || item->v_type != VAR_LIST
-			|| item->vval.v_list == NULL)
+			|| item->vval.v_list == NULL
+			|| item->vval.v_list->lv_first == &range_list_item)
 		{
 		    semsg(_(e_invalid_value_for_argument_str), "ansi_colors");
 		    return FAIL;
 		}
 
-		CHECK_LIST_MATERIALIZE(item->vval.v_list);
 		li = item->vval.v_list->lv_first;
 		for (; li != NULL && n < 16; li = li->li_next, n++)
 		{

--- a/src/option.c
+++ b/src/option.c
@@ -3255,6 +3255,7 @@ set_bool_option(
 # endif
 # ifdef FEAT_TERMINAL
 	term_update_colors_all();
+	term_update_palette_all();
 	term_update_wincolor_all();
 # endif
     }

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -86,4 +86,5 @@ void update_tcap(int attr);
 void swap_tcap(void);
 void cterm_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx);
 void term_replace_bs_del_keycode(char_u *ta_buf, int ta_len, int len);
+void ansi_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx);
 /* vim: set ft=c : */

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -67,4 +67,5 @@ void term_send_eof(channel_T *ch);
 job_T *term_getjob(term_T *term);
 int use_conpty(void);
 int terminal_enabled(void);
+void term_update_palette_all();
 /* vim: set ft=c : */

--- a/src/term.c
+++ b/src/term.c
@@ -6730,7 +6730,7 @@ static int grey_ramp[] = {
     0x80, 0x8A, 0x94, 0x9E, 0xA8, 0xB2, 0xBC, 0xC6, 0xD0, 0xDA, 0xE4, 0xEE
 };
 
-static char_u ansi_table[16][3] = {
+static const char_u ansi_table[16][3] = {
 //   R    G    B
   {  0,   0,   0}, // black
   {224,   0,   0}, // dark red
@@ -6759,6 +6759,25 @@ static const char_u cterm_ansi_idx[] = {
 #endif
 
 #define ANSI_INDEX_NONE 0
+
+    void
+ansi_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx)
+{
+    if (nr < 16)
+    {
+	*r = ansi_table[nr][0];
+	*g = ansi_table[nr][1];
+	*b = ansi_table[nr][2];
+	*ansi_idx = nr;
+    }
+    else
+    {
+	*r = 0;
+	*g = 0;
+	*b = 0;
+	*ansi_idx = ANSI_INDEX_NONE;
+    }
+}
 
     void
 cterm_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2829,13 +2829,23 @@ color2index(VTermColor *color, int fg, int *boldp)
     int blue = color->blue;
     int green = color->green;
 
+    *boldp = FALSE;
+
     if (VTERM_COLOR_IS_INVALID(color))
 	return 0;
+
     if (VTERM_COLOR_IS_INDEXED(color))
     {
 	// Use the color as-is if possible, give up otherwise.
 	if (color->index < t_colors)
 	    return color->index + 1;
+	// 8-color terminals can actually display twice as many colors by
+	// setting the high-intensity/bold bit.
+	else if (t_colors == 8 && fg && color->index < 16)
+	{
+	    *boldp = TRUE;
+	    return (color->index & 7) + 1;
+	}
 	return 0;
     }
 

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2685,8 +2685,8 @@ func Test_range()
     set tgc
     call assert_fails('call term_start("' .. cmd .. '", #{term_finish: "close"})',
         \ 'E475:')
-    set tgc&
     unlet g:terminal_ansi_colors
+    set tgc&
   endif
 
   " type()

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2681,12 +2681,6 @@ func Test_range()
     endif
     call assert_fails('call term_start("' .. cmd .. '", #{term_finish: "close"'
         \ .. ', ansi_colors: range(16)})', 'E475:')
-    " tgc must be enabled for term_start() to pick the color palette.
-    set tgc
-    call assert_fails('call term_start("' .. cmd .. '", #{term_finish: "close"})',
-        \ 'E475:')
-    unlet g:terminal_ansi_colors
-    set tgc&
   endif
 
   " type()

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2679,7 +2679,13 @@ func Test_range()
     else
       let cmd = "ls"
     endif
-    call assert_fails('call term_start("' .. cmd .. '", #{term_finish: "close"})', 'E475:')
+    call assert_fails('call term_start("' .. cmd .. '", #{term_finish: "close"'
+        \ .. ', ansi_colors: range(16)})', 'E475:')
+    " tgc must be enabled for term_start() to pick the color palette.
+    set tgc
+    call assert_fails('call term_start("' .. cmd .. '", #{term_finish: "close"})',
+        \ 'E475:')
+    set tgc&
     unlet g:terminal_ansi_colors
   endif
 

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -2012,6 +2012,10 @@ func Test_terminal_ansicolors_global()
   CheckFeature termguicolors
   CheckFunction term_getansicolors
 
+  if has('vtp') && !has('vcon') && !has('gui_running')
+    throw 'Skipped: does not support termguicolors'
+  endif
+
   set tgc
   let g:terminal_ansi_colors = reverse(copy(s:test_colors))
   let buf = Run_shell_in_terminal({})
@@ -2026,6 +2030,10 @@ endfunc
 func Test_terminal_ansicolors_func()
   CheckFeature termguicolors
   CheckFunction term_getansicolors
+
+  if has('vtp') && !has('vcon') && !has('gui_running')
+    throw 'Skipped: does not support termguicolors'
+  endif
 
   set tgc
   let g:terminal_ansi_colors = reverse(copy(s:test_colors))

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -2012,10 +2012,12 @@ func Test_terminal_ansicolors_global()
   CheckFeature termguicolors
   CheckFunction term_getansicolors
 
+  set tgc
   let g:terminal_ansi_colors = reverse(copy(s:test_colors))
   let buf = Run_shell_in_terminal({})
   call assert_equal(g:terminal_ansi_colors, term_getansicolors(buf))
   call StopShellInTerminal(buf)
+  set tgc&
 
   exe buf . 'bwipe'
   unlet g:terminal_ansi_colors
@@ -2025,6 +2027,7 @@ func Test_terminal_ansicolors_func()
   CheckFeature termguicolors
   CheckFunction term_getansicolors
 
+  set tgc
   let g:terminal_ansi_colors = reverse(copy(s:test_colors))
   let buf = Run_shell_in_terminal({'ansi_colors': s:test_colors})
   call assert_equal(s:test_colors, term_getansicolors(buf))
@@ -2047,6 +2050,7 @@ func Test_terminal_ansicolors_func()
   let colors[4] = 'Invalid'
   call assert_fails('call term_setansicolors(buf, colors)', 'E254:')
   call assert_fails('call term_setansicolors(buf, {})', 'E714:')
+  set tgc&
 
   call StopShellInTerminal(buf)
   call assert_equal(0, term_setansicolors(buf, []))


### PR DESCRIPTION
Implement the logic described in the help text, whenever tgc is off or
a GUI is not running the color numbers < 16 are left as-is. Otherwise
apply g:terminal_ansi_colors or the user-specified palette from
"ansi_colors".

Please give this patch a try CC @craigmac @lacygoill

Closes #7227
Closes #10347