### PR TITLE
Fix for #10430.

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -3569,7 +3569,7 @@ adjust_text_props_for_delete(
 							   : TP_FLAG_CONT_PREV;
 		textprop_T  prop_this;
 
-		mch_memmove(&prop_this, text + textlen + done_del,
+		mch_memmove(&prop_this, text + textlen + done_this,
 							   sizeof(textprop_T));
 		if ((prop_this.tp_flags & flag)
 			&& prop_del.tp_id == prop_this.tp_id
@@ -3577,7 +3577,7 @@ adjust_text_props_for_delete(
 		{
 		    found = TRUE;
 		    prop_this.tp_flags &= ~flag;
-		    mch_memmove(text + textlen + done_del, &prop_this,
+		    mch_memmove(text + textlen + done_this, &prop_this,
 							   sizeof(textprop_T));
 		    break;
 		}

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -1693,7 +1693,7 @@ def Test_delete_line_within_multiline_prop()
 
   prop_type_delete('Identifier')
   prop_type_delete('String')
-  bwip
+  bwip!
 enddef
 
 func Test_prop_in_linebreak()


### PR DESCRIPTION
Problem:    Line deletion can fail to correctly adjust text props.
Solution:   Correct updating for props of surrounding lines.
Files:      src/memline.c, src/testdir/test_textprop.vim