### PR TITLE
Fix for issue #7972.

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -4676,9 +4676,11 @@ SetBufferLineList(
 	// Only adjust marks if we managed to switch to a window that holds
 	// the buffer, otherwise line numbers will be invalid.
 	if (save_curbuf.br_buf == NULL)
+	{
 	    mark_adjust((linenr_T)lo, (linenr_T)(hi - 1),
 						  (long)MAXLNUM, (long)extra);
-	changed_lines((linenr_T)lo, 0, (linenr_T)hi, (long)extra);
+	    changed_lines((linenr_T)lo, 0, (linenr_T)hi, (long)extra);
+	}
 
 	if (buf == curbuf && (switchwin.sw_curwin != NULL
 					   || save_curbuf.br_buf == NULL))

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -4086,8 +4086,8 @@ func Test_python3_hidden_buf_mod_does_not_mess_display()
   call TermWait(bufnr, 100)
   call assert_equal('run', job_status(term_getjob(bufnr)))
   let g:test_is_flaky = 0
-  call assert_match('^  3 aaa$', term_getline(bufnr, 1))
-  call assert_match('^ 11 bbbbbb$', term_getline(bufnr, rows - 1))
+  call WaitForAssert({-> assert_match('^  3 aaa$', term_getline(bufnr, 1))})
+  call WaitForAssert({-> assert_match('^ 11 bbbbbb$', term_getline(bufnr, rows - 1))})
 
   call term_sendkeys(bufnr, ":qall!\<CR>")
   call WaitForAssert({-> assert_equal('dead', job_status(term_getjob(bufnr)))})

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -4061,4 +4061,38 @@ func Test_python3_fold_hidden_buffer()
   bwipe! Xa.txt
 endfunc
 
+" Test to catch regression fix #10437.
+func Test_python3_hidden_buf_mod_does_not_mess_display()
+  let testfile = 'Xtest.vim'
+  let lines =<< trim END
+        set hidden number
+        new
+        hide
+        sil call setline(1, repeat(['aaa'], &lines) + ['bbbbbb'])
+        fu Func()
+        python3 << EOF
+        import vim
+        b = vim.buffers[2]
+        b[:] = ['', '']
+        EOF
+        endfu
+        norm! Gzb
+        call feedkeys(":call Func()\r", 'n')
+  END
+  call writefile(lines, testfile)
+
+  let rows = 10
+  let bufnr = term_start([GetVimProg(), '--clean', '-S', testfile], {'term_rows': rows})
+  call TermWait(bufnr, 100)
+  call assert_equal('run', job_status(term_getjob(bufnr)))
+  let g:test_is_flaky = 0
+  call assert_match('^  3 aaa$', term_getline(bufnr, 1))
+  call assert_match('^ 11 bbbbbb$', term_getline(bufnr, rows - 1))
+
+  call term_sendkeys(bufnr, ":qall!\<CR>")
+  call WaitForAssert({-> assert_equal('dead', job_status(term_getjob(bufnr)))})
+  exe bufnr . 'bwipe!'
+  call delete(testfile)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -4063,6 +4063,7 @@ endfunc
 
 " Test to catch regression fix #10437.
 func Test_python3_hidden_buf_mod_does_not_mess_display()
+  CheckRunVimInTerminal
   let testfile = 'Xtest.vim'
   let lines =<< trim END
         set hidden number


### PR DESCRIPTION
Problem:    Updating a hidden buffer using Python can cause display
            corruption of the visible buffer.
Solution:   Do not mark changed lines when Python code has temporarily
            switched the hidden buffer to be the `curbuf`.