### PR TITLE
Allow the \%#= atom only at the start of the pattern

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -379,7 +379,7 @@ Vim includes two regexp engines:
 1. An old, backtracking engine that supports everything.
 2. A new, NFA engine that works much faster on some patterns, possibly slower
    on some patterns.
-
+								 *E1281*
 Vim will automatically select the right engine for you.  However, if you run
 into a problem or want to specifically select one engine or the other, you can
 prepend one of the following to the pattern:

--- a/src/errors.h
+++ b/src/errors.h
@@ -3277,3 +3277,5 @@ EXTERN char e_missing_close_curly_str[]
 EXTERN char e_illegal_character_in_word[]
 	INIT(= N_("E1280: Illegal character in word"));
 #endif
+EXTERN char e_regexp_engine_not_at_start_of_pattern[]
+	INIT(= N_("E1281: Atom '\\%%#=%c' must be at the start of the pattern"));

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -1503,8 +1503,18 @@ regatom(int *flagp)
 		    break;
 
 		case '#':
-		    ret = regnode(CURSOR);
-		    break;
+			{
+			    if (regparse[0] != NUL && regparse[0] == '=' &&
+				regparse[1] != NUL && regparse[1] >= 48 &&
+				regparse[1] <= 50)
+			    {
+				semsg(_(e_regexp_engine_not_at_start_of_pattern), regparse[1]);
+				return FAIL;
+			    }
+			    else
+				ret = regnode(CURSOR);
+			    break;
+			}
 
 		case 'V':
 		    ret = regnode(RE_VISUAL);

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1592,8 +1592,18 @@ nfa_regatom(void)
 		    break;
 
 		case '#':
-		    EMIT(NFA_CURSOR);
-		    break;
+		    {
+			if (regparse[0] != NUL && regparse[0] == '=' &&
+			    regparse[1] != NUL && regparse[1] >= 48 &&
+			    regparse[1] <= 50)
+			{
+			    semsg(_(e_regexp_engine_not_at_start_of_pattern), regparse[1]);
+			    return FAIL;
+			}
+			else
+			    EMIT(NFA_CURSOR);
+			break;
+		    }
 
 		case 'V':
 		    EMIT(NFA_VISUAL);

--- a/src/testdir/test_regexp_latin.vim
+++ b/src/testdir/test_regexp_latin.vim
@@ -1096,4 +1096,21 @@ func Test_using_invalid_visual_position()
   bwipe!
 endfunc
 
+func! Test_using_two_engines_pattern()
+  new
+  call setline(1, ['foobar=0', 'foobar=1', 'foobar=2'])
+  " \%#= at the end of the pattern
+  for i in range(0, 2)
+    call cursor( (i+1), 7) 
+    call assert_fails("%s/foobar\\%#=" .. i, 'E1281:')
+  endfor
+
+  " \%#= at the start of the pattern
+  for i in range(0, 2)
+    call cursor( (i+1), 7) 
+    exe ":%s/\\%#=" .. i .. "foobar=" .. i
+  endfor
+  call assert_equal(['', '', ''], getline(1, '$'))
+  bwipe!
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Currently, the pattern \%#= is allowed everywhere, but only if it is at the start of the pattern, it will actually select the correct regexp engine. 

However, Vim will happily accept a pattern like 'foo\%#=2bar' but will interpret `\%#` as the current cursor position. So make the regexp a bit more strict and output an error, if the special atom `\%#=` is found anywhere but at the start of the pattern.