### PR TITLE
regex: \%G ignores diacrectic chars

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1319,6 +1319,13 @@ characters may be different and the number of composing characters may differ.
 Only relevant when 'encoding' is "utf-8".
 Exception: If the pattern starts with one or more composing characters, these
 must match.
+							*/\%G* *E1515*
+When "\%G" appears at the beginning of the pattern (but must be after
+|two-engines|), all diacretic characters are ignored.  Thus searching for
+"\%Gbaum" will match "baum", "bäume" and "bäume" (the difference between the
+last two is the use of combining characters).
+This works similar to the |/[[=| atom, but for the complete pattern.
+Only relevant when 'encoding' is "utf-8".
 							*/\%C*
 Use "\%C" to skip any composing characters.  For example, the pattern "a" does
 not match in "càt" (where the a has the composing character 0x0300), but

--- a/src/Makefile
+++ b/src/Makefile
@@ -602,7 +602,7 @@ CClink = $(CC)
 #CFLAGS = -g -O2 -fno-strength-reduce -Wall -Wmissing-prototypes
 #CFLAGS = -g -Wall -Wmissing-prototypes
 #CFLAGS = -O6 -fno-strength-reduce -Wall -Wshadow -Wmissing-prototypes
-#CFLAGS = -g -DDEBUG -Wall -Wshadow -Wmissing-prototypes
+CFLAGS = -g -DDEBUG -Wall -Wshadow -Wmissing-prototypes
 #CFLAGS = -g -O2 '-DSTARTUPTIME="vimstartup"' -fno-strength-reduce -Wall -Wmissing-prototypes
 
 # Use this with GCC to check for mistakes, unused arguments, etc.

--- a/src/errors.h
+++ b/src/errors.h
@@ -3654,3 +3654,5 @@ EXTERN char e_winfixbuf_cannot_go_to_buffer[]
 	INIT(= N_("E1513: Cannot switch buffer. 'winfixbuf' is enabled"));
 EXTERN char e_invalid_return_type_from_findfunc[]
 	INIT(= N_("E1514: 'findfunc' did not return a List type"));
+EXTERN char e_atom_diacritics_must_be_at_start_of_pattern[]
+	INIT(= N_("E1515: Atom '\\%%G' must be at the start of the pattern"));

--- a/src/libvterm/src/vterm_internal.h
+++ b/src/libvterm/src/vterm_internal.h
@@ -18,6 +18,10 @@
 #endif
 
 #ifdef DEBUG
+#undef DEBUG
+#endif
+
+#ifdef DEBUG
 # define DEBUG_LOG(s) fprintf(stderr, s)
 # define DEBUG_LOG1(s, a) fprintf(stderr, s, a)
 # define DEBUG_LOG2(s, a, b) fprintf(stderr, s, a, b)

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -349,6 +349,7 @@ init_class_tab(void)
 #define RF_HASNL    4	// can match a NL
 #define RF_ICOMBINE 8	// ignore combining characters
 #define RF_LOOKBH   16	// uses "\@<=" or "\@<!"
+#define RF_IDIAC    32	// ignore diacritic characters
 
 /*
  * Global work variables for vim_regcomp().
@@ -1183,6 +1184,10 @@ typedef struct {
     // Similar to "reg_ic", but only for 'combining' characters.  Set with \Z
     // flag in the regexp.  Defaults to false, always.
     int			reg_icombine;
+
+    // Similar to "reg_iccombine", but for the complete pattern.  Set with \%G
+    // flag at the beginning of the pattern.  Defaults to false.
+    int			reg_idiac;
 
     // Copy of "rmm_maxcol": maximum column to search for a match.  Zero when
     // there is no maximum.
@@ -2866,6 +2871,7 @@ init_regexec_multi(
     rex.reg_line_lbr = FALSE;
     rex.reg_ic = rmp->rmm_ic;
     rex.reg_icombine = FALSE;
+    rex.reg_idiac = FALSE;
     rex.reg_maxcol = rmp->rmm_maxcol;
 }
 
@@ -2950,6 +2956,11 @@ vim_regcomp(char_u *expr_arg, int re_flags)
 #endif
     // reg_iswordc() uses rex.reg_buf
     rex.reg_buf = curbuf;
+    if (STRNCMP(expr, "\\%G", 3 ) == 0)
+    {
+	rex.reg_idiac = TRUE;
+	expr += 3;
+    }
 
     /*
      * First try the NFA engine, unless backtracking was requested.

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1603,6 +1603,11 @@ nfa_regatom(void)
 		    EMIT(NFA_CURSOR);
 		    break;
 
+		case 'G':
+		    // misplaced \%G
+		    semsg(_(e_atom_diacritics_must_be_at_start_of_pattern));
+		    return FAIL;
+
 		case 'V':
 		    EMIT(NFA_VISUAL);
 		    break;
@@ -2111,7 +2116,8 @@ collection:
 
 nfa_do_multibyte:
 		// plen is length of current char with composing chars
-		if (enc_utf8 && ((*mb_char2len)(c)
+		if (enc_utf8 && !rex.reg_idiac
+			&& ((*mb_char2len)(c)
 			    != (plen = utfc_ptr2len(old_regparse))
 						       || utf_iscomposing(c)))
 		{
@@ -2136,6 +2142,15 @@ nfa_do_multibyte:
 		    }
 		    EMIT(NFA_COMPOSING);
 		    regparse = old_regparse + plen;
+		}
+		else if (enc_utf8 && rex.reg_idiac)
+		{
+		    // Use Collation Equivalence Class for the character entered
+		    EMIT(NFA_START_COLL);
+		    result = nfa_emit_equi_class(c);
+		    if (result == FAIL)
+			EMSG_RET_FAIL(_(e_error_building_nfa_with_equivalence_class));
+		    EMIT(NFA_END_COLL);
 		}
 		else
 		{
@@ -7469,6 +7484,10 @@ nfa_regexec_both(
     if (prog->regflags & RF_ICOMBINE)
 	rex.reg_icombine = TRUE;
 
+    // Using \%G to not match diacritic chars
+    if (prog->regflags & RF_IDIAC)
+	rex.reg_idiac = TRUE;
+
     rex.line = line;
     rex.lnum = 0;    // relative to line
 
@@ -7716,6 +7735,7 @@ nfa_regexec_nl(
     rex.reg_win = NULL;
     rex.reg_ic = rmp->rm_ic;
     rex.reg_icombine = FALSE;
+    rex.reg_idiac = FALSE;
     rex.reg_maxcol = 0;
     return nfa_regexec_both(line, col, NULL);
 }

--- a/src/testdir/samples/diacritics.txt
+++ b/src/testdir/samples/diacritics.txt
@@ -1,0 +1,8 @@
+a
+Bäume
+baum
+Baum
+bäume
+bäume
+kočička
+kocicka

--- a/src/testdir/test_regexp_utf8.vim
+++ b/src/testdir/test_regexp_utf8.vim
@@ -619,4 +619,27 @@ func Test_search_multibyte_match_ascii()
   bw!
 endfunc
 
+func Test_match_diacritics()
+  sp ./samples/diacritics.txt
+  for i in range(0, 2)
+    exe 'set regexpengine=' .. i
+    %s/\%Gbau.*\>//g
+    call assert_equal([&re] + ['a', 'Bäume', '', 'Baum', '', '', 'kočička', 'kocicka'], [&re] + getline(1, '$'))
+    e!
+    %s/\%Gbau.*\>\%C//g
+    call assert_equal([&re] + ['a', 'Bäume', '', 'Baum', '', '', 'kočička', 'kocicka'], [&re] + getline(1, '$'))
+
+    e!
+    %s/\%Gkocicka.*\n//g
+    call assert_equal([&re] + ['a', 'Bäume', 'baum', 'Baum', 'bäume', 'bäume', ''], [&re] + getline(1, '$'))
+    e!
+    %s/\%Ga//g
+    call assert_equal([&re] + ['', 'Bume', 'bum', 'Bum', 'bume', 'bume', 'kočičk', 'kocick'], [&re] + getline(1, '$'))
+    e!
+    call assert_fails('%s/a\%G//', 'E1515')
+    e!
+  endfor
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
In #8026, a way to ignore diacretic characters was requested.

Here, let's make use of the `\%G` atom, to ignore diacrectics when a
simple character is found.  Internally, this works by making use of
equivalence classes for each character (similar to as if you would add
`[[=<char>=]]` around each character.

The implementation is a bit messy, since I do not know the regexp code
very well. Also using `\%G` changes quite a bit how the pattern matching
works and how to count the size of the regexp beforehand, so this needs to
be added at the very beginning of the pattern (only after the engine
selection), it can't be done in the middle of the pattern once found,
since it changes significantly how to add atoms and how to match ordinary
items.

This is currently work in progress, so no tests are here. I just like to
get some feedback, if the approach used here seems okay or not.

Tests will be added later.