### PR TITLE
Prevent PVS warning.

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -253,7 +253,7 @@ spell_check(
 							     MAXWLEN + 1);
     mi.mi_fwordlen = (int)STRLEN(mi.mi_fword);
 
-    if (camel_case)
+    if (camel_case && mi.mi_fwordlen >= 1)
 	// Introduce a fake word end space into the folded word.
 	mi.mi_fword[mi.mi_fwordlen - 1] = ' ';
 


### PR DESCRIPTION
PVS gives the following warning: "Array underrun is possible. The value
of 'mi.mi_fwordlen - 1' index could reach -1." Possible it's not a
scenario that is possible, if so please feel free to ignore it.
