### PR TITLE
Fixed bugs where small fold is closable after deletions (issue #10436)

### DIFF
--- a/src/fold.c
+++ b/src/fold.c
@@ -817,6 +817,8 @@ clearFolding(win_T *win)
     void
 foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 {
+    linenr_T	maybe_small_start;
+    linenr_T	maybe_small_end;
     fold_T	*fp;
 
     if (disable_fold_update > 0)
@@ -829,10 +831,20 @@ foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 
     if (wp->w_folds.ga_len > 0)
     {
-	// Mark all folds from top to bot as maybe-small.
-	(void)foldFind(&wp->w_folds, top, &fp);
+	// Mark all folds from top to bot (or bot to top) as maybe-small.
+	if (top <= bot)
+	{
+	    maybe_small_start = top;
+	    maybe_small_end = bot;
+	}
+	else
+	{
+	    maybe_small_start = bot;
+	    maybe_small_end = top;
+	}
+	(void)foldFind(&wp->w_folds, maybe_small_start, &fp);
 	while (fp < (fold_T *)wp->w_folds.ga_data + wp->w_folds.ga_len
-		&& fp->fd_top < bot)
+		&& fp->fd_top <= maybe_small_end)
 	{
 	    fp->fd_small = MAYBE;
 	    ++fp;
@@ -2165,7 +2177,7 @@ foldUpdateIEMS(win_T *wp, linenr_T top, linenr_T bot)
 	bot = wp->w_buffer->b_ml.ml_line_count;
 	wp->w_foldinvalid = FALSE;
 
-	// Mark all folds a maybe-small.
+	// Mark all folds as maybe-small.
 	setSmallMaybe(&wp->w_folds);
     }
 

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1479,4 +1479,33 @@ func Test_indent_append_under_blank_line()
   bw!
 endfunc
 
+" Make sure that when you delete 1 line of a fold whose length is 2 lines, the
+" fold can't be closed since its length (1) is now less than foldminlines.
+func Test_indent_one_line_fold_close()
+  let lines =<< trim END
+    line 1
+      line 2
+      line 3
+  END
+
+  new
+  setlocal sw=2 foldmethod=indent
+  call setline(1, lines)
+  " open all folds, delete line, then close all folds
+  normal zR
+  3delete
+  normal zM
+  call assert_equal(-1, foldclosed(2)) " the fold should not be closed
+
+  " Now do the same, but delete line 2 this time; this covers different code.
+  " (Combining this code with the above code doesn't expose both bugs.)
+  1,$delete
+  call setline(1, lines)
+  normal zR
+  2delete
+  normal zM
+  call assert_equal(-1, foldclosed(2))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This fixes 2 bugs related to foldminlines not being respected when using foldmethod=indent after deleting lines. After fixing, I searched if anybody had reported this problem and saw that someone had in issue #10436.

Notes:
Changing "<" to "<=" in the loop conditional is not a typo (see commit message).
The test looks like it can be refactored to be smaller, but doing so doesn't expose both bugs, so this is as small as I could make it.