### PR TITLE
Fix texprop shift in replace mode w/ multibyte replacements

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -1118,7 +1118,12 @@ ins_char_bytes(char_u *buf, int charlen)
     ml_replace(lnum, newp, FALSE);
 
     // mark the buffer as changed and prepare for displaying
-    inserted_bytes(lnum, col, newlen - oldlen);
+    changed_bytes(lnum, col);
+#ifdef FEAT_PROP_POPUP
+    if (curbuf->b_has_textprop && newlen != oldlen)
+	adjust_prop_columns(lnum, col, newlen - oldlen, State & REPLACE_FLAG
+		? APC_SUBSTITUTE : 0);
+#endif
 
     // If we're in Insert or Replace mode and 'showmatch' is set, then briefly
     // show the match for right parens and braces.

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -573,6 +573,13 @@ func Test_prop_replace()
   call assert_equal('yyyex xyyoxx', getline(1))
   call assert_equal(expected, prop_list(1))
 
+  " Replace three 1-byte chars with three 2-byte ones.
+  exe "normal 0l3rø"
+  call assert_equal('yøøøx xyyoxx', getline(1))
+  let expected[0].length += 3
+  let expected[1].col += 3
+  call assert_equal(expected, prop_list(1))
+
   call DeletePropTypes()
   bwipe!
   set bs&


### PR DESCRIPTION
Pass the APC_SUBSTITUTE flag if we are in replace mode.

Perhaps we need a `replaced_bytes` to complement `inserted_bytes`?