### PR TITLE
feature: add has('wsl')

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -10445,6 +10445,7 @@ xpm			Compiled with pixmap support.
 xpm_w32			Compiled with pixmap support for Win32. (Only for
 			backward compatibility. Use "xpm" instead.)
 xsmp			Compiled with X session management support.
+wsl			Vim is running on WSL (Windows Subsystem for Linux).
 xsmp_interact		Compiled with interactive X session management support.
 xterm_clipboard		Compiled with support for xterm clipboard.
 xterm_save		Compiled with support for saving and restoring the

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6558,8 +6558,8 @@ f_has(typval_T *argvars, typval_T *rettv)
 	    x = TRUE;
 #if defined(__linux__) && defined(HAVE_SYS_UTSNAME_H)
 	    mch_get_kernel_release(kernel_release, 256);
-	    vim_strlow(kernel_release);
-	    if (strstr((char *)kernel_release, "microsoft") != NULL)
+	    vim_strup(kernel_release);
+	    if (strstr((char *)kernel_release, "MICROSOFT") != NULL)
 	        n = TRUE;
 	    else
 	        n = FALSE;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5260,6 +5260,11 @@ f_has(typval_T *argvars, typval_T *rettv)
 	char *name;
 	short present;
     } has_item_T;
+#if (defined(UNIX) || defined(VMS)) \
+    && (!defined(MACOS_X) || defined(HAVE_CONFIG_H)) \
+    && defined(HAVE_SYS_UTSNAME_H)
+    char_u	kernel_release[256];
+#else
     static has_item_T has_list[] =
     {
 	{"amiga",
@@ -6548,6 +6553,25 @@ f_has(typval_T *argvars, typval_T *rettv)
 	    x = TRUE;
 #ifdef FEAT_CLIPBOARD
 	    n = clip_star.available;
+#endif
+	}
+	else if (STRICMP(name, "wsl") == 0)
+	{
+	    x = TRUE;
+#if (defined(UNIX) || defined(VMS)) \
+     && (!defined(MACOS_X) || defined(HAVE_CONFIG_H)) \
+     && defined(HAVE_SYS_UTSNAME_H)
+	    mch_get_kernel_release(kernel_release, 256);
+
+	    for (i = 0; i <= strlen((char *)kernel_release); i++)
+	        kernel_release[i] = TOLOWER_ASC(kernel_release[i]);
+
+	    if (strstr((char *)kernel_release, "microsoft") != NULL)
+	        n = TRUE;
+	    else
+	        n = FALSE;
+#else
+	    n = FALSE;
 #endif
 	}
     }

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5260,9 +5260,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 	char *name;
 	short present;
     } has_item_T;
-#if (defined(UNIX) || defined(VMS)) \
-    && (!defined(MACOS_X) || defined(HAVE_CONFIG_H)) \
-    && defined(HAVE_SYS_UTSNAME_H)
+#if defined(__linux__) && defined(HAVE_SYS_UTSNAME_H)
     char_u	kernel_release[256];
 #endif
     static has_item_T has_list[] =
@@ -6558,14 +6556,9 @@ f_has(typval_T *argvars, typval_T *rettv)
 	else if (STRICMP(name, "wsl") == 0)
 	{
 	    x = TRUE;
-#if (defined(UNIX) || defined(VMS)) \
-     && (!defined(MACOS_X) || defined(HAVE_CONFIG_H)) \
-     && defined(HAVE_SYS_UTSNAME_H)
+#if defined(__linux__) && defined(HAVE_SYS_UTSNAME_H)
 	    mch_get_kernel_release(kernel_release, 256);
-
-	    for (i = 0; i <= strlen((char *)kernel_release); i++)
-	        kernel_release[i] = TOLOWER_ASC(kernel_release[i]);
-
+	    vim_strlow(kernel_release);
 	    if (strstr((char *)kernel_release, "microsoft") != NULL)
 	        n = TRUE;
 	    else

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5264,7 +5264,7 @@ f_has(typval_T *argvars, typval_T *rettv)
     && (!defined(MACOS_X) || defined(HAVE_CONFIG_H)) \
     && defined(HAVE_SYS_UTSNAME_H)
     char_u	kernel_release[256];
-#else
+#endif
     static has_item_T has_list[] =
     {
 	{"amiga",

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2527,6 +2527,21 @@ mch_get_host_name(char_u *s, int len)
 #endif // HAVE_SYS_UTSNAME_H
 
 /*
+ * Insert kernel release is s[len] (like uname(1))
+ */
+#ifdef HAVE_SYS_UTSNAME_H
+    void
+mch_get_kernel_release(char_u *s, int len) {
+    struct utsname vutsname;
+
+    if (uname(&vutsname) < 0)
+        *s = NUL;
+    else
+        vim_strncpy(s, (char_u *)vutsname.release, len - 1);
+}
+#endif
+
+/*
  * return process ID
  */
     long

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -27,6 +27,7 @@ int vim_is_fastterm(char_u *name);
 int mch_get_user_name(char_u *s, int len);
 int mch_get_uname(uid_t uid, char_u *s, int len);
 void mch_get_host_name(char_u *s, int len);
+void mch_get_kernel_release(char_u *s, int len);
 long mch_get_pid(void);
 int mch_process_running(long pid);
 int mch_dirname(char_u *buf, int len);


### PR DESCRIPTION
I have added has('wsl') to Vim. This determines if Vim is running on a WSL system.
It is a reproduction of a feature in Neovim and uses the idea of determining if it is running on WSL(see: https://github.com/neovim/neovim/pull/16153), but I have not appropriated any of the source code.

There are a few things to note in the code, which are as follows
・The position of the kernel_release variable declaration is far from where it is actually used.
・The variable "i" is used in another logic.