### PR TITLE
Fix a gcc warning about uninitialized variable

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -2023,7 +2023,7 @@ do_unlet(char_u *name, int forceit)
 {
     hashtab_T	*ht;
     hashitem_T	*hi;
-    char_u	*varname;
+    char_u	*varname = NULL;
     dict_T	*d;
     dictitem_T	*di;
 


### PR DESCRIPTION
GCC warns:
```
evalvars.c: In function 'do_unlet':
evalvars.c:2064:14: warning: 'varname' may be used uninitialized [-Wmaybe-uninitialized]
 2064 |         hi = hash_find(ht, varname);
      |              ^~~~~~~~~~~~~~~~~~~~~~
evalvars.c:2026:18: note: 'varname' was declared here
 2026 |     char_u      *varname;
      |                  ^~~~~~~
```

Version: Vim8.2.5014
