### PR TITLE
'imstatusfunc' and 'imactivatefunc' breaks 'foldopen'

### DIFF
--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -89,17 +89,21 @@ set_imstatusfunc_option(void)
 call_imactivatefunc(int active)
 {
     typval_T argv[2];
+    int save_KeyTyped = KeyTyped;
 
     argv[0].v_type = VAR_NUMBER;
     argv[0].vval.v_number = active ? 1 : 0;
     argv[1].v_type = VAR_UNKNOWN;
     (void)call_callback_retnr(&imaf_cb, 1, argv);
+
+    KeyTyped = save_KeyTyped;
 }
 
     static int
 call_imstatusfunc(void)
 {
     int is_active;
+    int save_KeyTyped = KeyTyped;
 
     // FIXME: Don't execute user function in unsafe situation.
     if (exiting || is_autocmd_blocked())
@@ -109,6 +113,8 @@ call_imstatusfunc(void)
     ++msg_silent;
     is_active = call_callback_retnr(&imsf_cb, 0, NULL);
     --msg_silent;
+
+    KeyTyped = save_KeyTyped;
     return (is_active > 0);
 }
 #endif

--- a/src/testdir/test_iminsert.vim
+++ b/src/testdir/test_iminsert.vim
@@ -63,6 +63,35 @@ func Test_getimstatus()
   set imstatusfunc=
 endfunc
 
+func Test_imactivatefunc_imstatusfunc_callback_no_breaks_foldopen()
+  CheckScreendump
+
+  let lines =<< trim END
+    func IM_activatefunc(active)
+    endfunc
+    func IM_statusfunc()
+      return 0
+    endfunc
+    set imactivatefunc=IM_activatefunc
+    set imstatusfunc=IM_statusfunc
+    set foldmethod=marker
+    set foldopen=search
+    call setline(1, ['{{{', 'abc', '}}}'])
+    %foldclose
+  END
+  call writefile(lines, 'Xscript')
+  let buf = RunVimInTerminal('-S Xscript', {})
+  call term_wait(buf)
+  call assert_notequal('abc', term_getline(buf, 2))
+  call term_sendkeys(buf, "/abc\n")
+  call term_wait(buf)
+  call assert_equal('abc', term_getline(buf, 2))
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xscript')
+endfunc
+
 " Test for using an lmap in insert mode
 func Test_lmap_in_insert_mode()
   new


### PR DESCRIPTION
Fix vim-jp/issues#1384

## Problem

If `'imstatusfunc'` and `'imactivatefunc'` is specified,
Folding does not open when type `/pat<Enter>` in normal-mode.

## Reproduce

vimrc:
```vim
" {{{
set nocompatible
function! ActivateFunc()
endfunction
function! StatusFunc()
    return 0
endfunction
set imactivatefunc=ActivateFunc
set imstatusfunc=StatusFunc
set foldopen=search
set foldmethod=marker
```

1. Run `vim -u vimrc --noplugin vimrc`
2. Type `/set` and <kbd>Enter</kbd>

### Expected

Folding is opened.

### Actual (before fixed)

Folding is not opened.