### PR TITLE
Rename textwinlock back to textlock

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -671,7 +671,7 @@ Note: The keys that are valid in CTRL-X mode are not mapped.  This allows for
 ends CTRL-X mode (any key that is not a valid CTRL-X mode command) is mapped.
 Also, when doing completion with 'complete' mappings apply as usual.
 
-							*E578* *E565*
+								*E565*
 Note: While completion is active Insert mode can't be used recursively and
 buffer text cannot be changed.  Mappings that somehow invoke ":normal i.."
 will generate an E565 error.

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4749,7 +4749,6 @@ E574	starting.txt	/*E574*
 E575	starting.txt	/*E575*
 E576	starting.txt	/*E576*
 E577	starting.txt	/*E577*
-E578	insert.txt	/*E578*
 E579	eval.txt	/*E579*
 E580	eval.txt	/*E580*
 E581	eval.txt	/*E581*

--- a/src/beval.c
+++ b/src/beval.c
@@ -284,7 +284,7 @@ general_beval_cb(BalloonEval *beval, int state UNUSED)
 	    curbuf = save_curbuf;
 	    if (use_sandbox)
 		++sandbox;
-	    ++textwinlock;
+	    ++textlock;
 
 	    if (bexpr == p_bexpr)
 	    {
@@ -311,7 +311,7 @@ general_beval_cb(BalloonEval *beval, int state UNUSED)
 
 	    if (use_sandbox)
 		--sandbox;
-	    --textwinlock;
+	    --textlock;
 	    current_sctx = save_sctx;
 
 	    set_vim_var_string(VV_BEVAL_TEXT, NULL, -1);

--- a/src/change.c
+++ b/src/change.c
@@ -324,7 +324,7 @@ f_listener_remove(typval_T *argvars, typval_T *rettv)
 	    next = lnr->lr_next;
 	    if (lnr->lr_id == id)
 	    {
-		if (textwinlock > 0)
+		if (textlock > 0)
 		{
 		    // in invoke_listeners(), clear ID and delete later
 		    lnr->lr_id = 0;
@@ -401,7 +401,7 @@ invoke_listeners(buf_T *buf)
 
     argv[4].v_type = VAR_LIST;
     argv[4].vval.v_list = buf->b_recorded_changes;
-    ++textwinlock;
+    ++textlock;
 
     for (lnr = buf->b_listener; lnr != NULL; lnr = lnr->lr_next)
     {
@@ -421,7 +421,7 @@ invoke_listeners(buf_T *buf)
 	    prev = lnr;
     }
 
-    --textwinlock;
+    --textlock;
     list_unref(buf->b_recorded_changes);
     buf->b_recorded_changes = NULL;
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -168,8 +168,7 @@ edit(
     // Don't allow changes in the buffer while editing the cmdline.  The
     // caller of getcmdline() may get confused.
     // Don't allow recursive insert mode when busy with completion.
-    if (textwinlock != 0 || textlock != 0
-			  || ins_compl_active() || compl_busy || pum_visible())
+    if (textlock != 0 || ins_compl_active() || compl_busy || pum_visible())
     {
 	emsg(_(e_not_allowed_to_change_text_or_change_window));
 	return FALSE;
@@ -5342,7 +5341,7 @@ do_insert_char_pre(int c)
     }
 
     // Lock the text to avoid weird things from happening.
-    ++textwinlock;
+    ++textlock;
     set_vim_var_string(VV_CHAR, buf, -1);  // set v:char
 
     res = NULL;
@@ -5356,7 +5355,7 @@ do_insert_char_pre(int c)
     }
 
     set_vim_var_string(VV_CHAR, NULL, -1);  // clear v:char
-    --textwinlock;
+    --textlock;
 
     // Restore the State, it may have been changed.
     State = save_State;

--- a/src/errors.h
+++ b/src/errors.h
@@ -1458,8 +1458,7 @@ EXTERN char e_nonr_missing_gt[]
 EXTERN char e_illegal_register_name[]
 	INIT(= N_("Illegal register name"));
 #endif
-EXTERN char e_not_allowed_to_change_text_here[]
-	INIT(= N_("E578: Not allowed to change text here"));
+// E578 unused
 #ifdef FEAT_EVAL
 EXTERN char e_if_nesting_too_deep[]
 	INIT(= N_("E579: :if nesting too deep"));

--- a/src/eval.c
+++ b/src/eval.c
@@ -543,7 +543,7 @@ eval_to_string(
 
 /*
  * Call eval_to_string() without using current local variables and using
- * textwinlock.  When "use_sandbox" is TRUE use the sandbox.
+ * textlock.  When "use_sandbox" is TRUE use the sandbox.
  * Use legacy Vim script syntax.
  */
     char_u *
@@ -562,12 +562,12 @@ eval_to_string_safe(
     save_funccal(&funccal_entry);
     if (use_sandbox)
 	++sandbox;
-    ++textwinlock;
+    ++textlock;
     may_garbage_collect = FALSE;
     retval = eval_to_string(arg, FALSE);
     if (use_sandbox)
 	--sandbox;
-    --textwinlock;
+    --textlock;
     may_garbage_collect = save_garbage;
     restore_funccal();
     current_sctx.sc_version = save_sc_version;
@@ -807,7 +807,7 @@ eval_foldexpr(win_T *wp, int *cp)
     ++emsg_off;
     if (use_sandbox)
 	++sandbox;
-    ++textwinlock;
+    ++textlock;
     *cp = NUL;
     if (eval0(arg, &tv, NULL, &EVALARG_EVALUATE) == FAIL)
 	retval = 0;
@@ -832,7 +832,7 @@ eval_foldexpr(win_T *wp, int *cp)
     --emsg_off;
     if (use_sandbox)
 	--sandbox;
-    --textwinlock;
+    --textlock;
     clear_evalarg(&EVALARG_EVALUATE, NULL);
     current_sctx = saved_sctx;
 

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4414,14 +4414,14 @@ ex_substitute(exarg_T *eap)
 		subflags_save = subflags;
 
 		// Disallow changing text or switching window in an expression.
-		++textwinlock;
+		++textlock;
 #endif
 		// get length of substitution part
 		sublen = vim_regsub_multi(&regmatch,
 				    sub_firstlnum - regmatch.startpos[0].lnum,
 			       sub, sub_firstline, FALSE, magic_isset(), TRUE);
 #ifdef FEAT_EVAL
-		--textwinlock;
+		--textlock;
 
 		// If getting the substitute string caused an error, don't do
 		// the replacement.
@@ -4524,13 +4524,13 @@ ex_substitute(exarg_T *eap)
 		new_end += copy_len;
 
 #ifdef FEAT_EVAL
-		++textwinlock;
+		++textlock;
 #endif
 		(void)vim_regsub_multi(&regmatch,
 				    sub_firstlnum - regmatch.startpos[0].lnum,
 				      sub, new_end, TRUE, magic_isset(), TRUE);
 #ifdef FEAT_EVAL
-		--textwinlock;
+		--textlock;
 #endif
 		sub_nsubs++;
 		did_sub = TRUE;

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -850,12 +850,12 @@ cmdline_handle_backslash_key(int c, int *gotesc)
 	c = get_expr_register();
 	if (c == '=')
 	{
-	    // Need to save and restore ccline.  And set "textwinlock"
+	    // Need to save and restore ccline.  And set "textlock"
 	    // to avoid nasty things like going to another buffer when
 	    // evaluating an expression.
-	    ++textwinlock;
+	    ++textlock;
 	    p = get_expr_line();
-	    --textwinlock;
+	    --textlock;
 
 	    if (p != NULL)
 	    {
@@ -2710,13 +2710,13 @@ check_opt_wim(void)
  * 'balloonexpr', etc.
  */
     int
-text_and_win_locked(void)
+text_locked(void)
 {
 #ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
 	return TRUE;
 #endif
-    return textwinlock != 0;
+    return textlock != 0;
 }
 
 /*
@@ -2736,19 +2736,7 @@ get_text_locked_msg(void)
     if (cmdwin_type != 0)
 	return e_invalid_in_cmdline_window;
 #endif
-    if (textwinlock != 0)
-	return e_not_allowed_to_change_text_or_change_window;
-    return e_not_allowed_to_change_text_here;
-}
-
-/*
- * Return TRUE when the text must not be changed and/or we cannot switch to
- * another window.  TRUE while evaluating 'completefunc'.
- */
-    int
-text_locked(void)
-{
-    return text_and_win_locked() || textlock != 0;
+    return e_not_allowed_to_change_text_or_change_window;
 }
 
 /*
@@ -3730,11 +3718,11 @@ cmdline_paste(
     regname = may_get_selection(regname);
 #endif
 
-    // Need to  set "textwinlock" to avoid nasty things like going to another
+    // Need to set "textlock" to avoid nasty things like going to another
     // buffer when evaluating an expression.
-    ++textwinlock;
+    ++textlock;
     i = get_spec_reg(regname, &arg, &allocated, TRUE);
-    --textwinlock;
+    --textlock;
 
     if (i)
     {

--- a/src/globals.h
+++ b/src/globals.h
@@ -846,15 +846,10 @@ EXTERN int	secure INIT(= FALSE);
 				// allowed, e.g. when sourcing .exrc or .vimrc
 				// in current directory
 
-EXTERN int	textwinlock INIT(= 0);
+EXTERN int	textlock INIT(= 0);
 				// non-zero when changing text and jumping to
 				// another window or editing another buffer is
 				// not allowed
-
-EXTERN int	textlock INIT(= 0);
-				// non-zero when changing text is not allowed,
-				// jumping to another window is allowed,
-				// editing another buffer is not allowed.
 
 EXTERN int	curbuf_lock INIT(= 0);
 				// non-zero when the current buffer can't be

--- a/src/indent.c
+++ b/src/indent.c
@@ -1872,7 +1872,7 @@ get_expr_indent(void)
     set_vim_var_nr(VV_LNUM, curwin->w_cursor.lnum);
     if (use_sandbox)
 	++sandbox;
-    ++textwinlock;
+    ++textlock;
     current_sctx = curbuf->b_p_script_ctx[BV_INDE];
 
     // Need to make a copy, the 'indentexpr' option could be changed while
@@ -1886,7 +1886,7 @@ get_expr_indent(void)
 
     if (use_sandbox)
 	--sandbox;
-    --textwinlock;
+    --textlock;
     current_sctx = save_sctx;
 
     // Restore the cursor position so that 'indentexpr' doesn't need to.

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1144,9 +1144,9 @@ trigger_complete_changed_event(int cur)
     dict_set_items_ro(v_event);
 
     recursive = TRUE;
-    textwinlock++;
+    textlock++;
     apply_autocmds(EVENT_COMPLETECHANGED, NULL, NULL, FALSE, curbuf);
-    textwinlock--;
+    textlock--;
     recursive = FALSE;
 
     restore_v_event(v_event, &save_v_event);
@@ -2643,7 +2643,7 @@ expand_by_function(int type, char_u *base)
     // Lock the text to avoid weird things from happening.  Also disallow
     // switching to another window, it should not be needed and may end up in
     // Insert mode in another buffer.
-    ++textwinlock;
+    ++textlock;
 
     cb = get_insert_callback(type);
     retval = call_callback(cb, 0, &rettv, 2, args);
@@ -2669,7 +2669,7 @@ expand_by_function(int type, char_u *base)
 		break;
 	}
     }
-    --textwinlock;
+    --textlock;
 
     curwin->w_cursor = pos;	// restore the cursor position
     validate_cursor();
@@ -2867,7 +2867,6 @@ set_completion(colnr_T startcol, list_T *list)
 f_complete(typval_T *argvars, typval_T *rettv UNUSED)
 {
     int	    startcol;
-    int	    save_textlock = textlock;
 
     if (in_vim9script()
 	    && (check_for_number_arg(argvars, 0) == FAIL
@@ -2879,10 +2878,6 @@ f_complete(typval_T *argvars, typval_T *rettv UNUSED)
 	emsg(_(e_complete_can_only_be_used_in_insert_mode));
 	return;
     }
-
-    // "textlock" is set when evaluating 'completefunc' but we can change
-    // text here.
-    textlock = 0;
 
     // Check for undo allowed here, because if something was already inserted
     // the line was already saved for undo and this check isn't done.
@@ -2897,7 +2892,6 @@ f_complete(typval_T *argvars, typval_T *rettv UNUSED)
 	if (startcol > 0)
 	    set_completion(startcol - 1, argvars[1].vval.v_list);
     }
-    textlock = save_textlock;
 }
 
 /*
@@ -4508,10 +4502,10 @@ get_userdefined_compl_info(colnr_T curs_col UNUSED)
     args[1].vval.v_string = (char_u *)"";
     args[2].v_type = VAR_UNKNOWN;
     pos = curwin->w_cursor;
-    ++textwinlock;
+    ++textlock;
     cb = get_insert_callback(ctrl_x_mode);
     col = call_callback_retnr(cb, 2, args);
-    --textwinlock;
+    --textlock;
 
     State = save_State;
     curwin->w_cursor = pos;	// restore the cursor position

--- a/src/map.c
+++ b/src/map.c
@@ -1695,7 +1695,7 @@ eval_map_expr(
 
     // Forbid changing text or using ":normal" to avoid most of the bad side
     // effects.  Also restore the cursor position.
-    ++textwinlock;
+    ++textlock;
     ++ex_normal_lock;
     set_vim_var_char(c);  // set v:char to the typed character
     save_cursor = curwin->w_cursor;
@@ -1710,7 +1710,7 @@ eval_map_expr(
     // Note: the evaluation may make "mp" invalid.
     p = eval_to_string(expr, FALSE);
 
-    --textwinlock;
+    --textlock;
     --ex_normal_lock;
     curwin->w_cursor = save_cursor;
     msg_col = save_msg_col;

--- a/src/proto/ex_getln.pro
+++ b/src/proto/ex_getln.pro
@@ -3,7 +3,6 @@ void cmdline_init(void);
 char_u *getcmdline(int firstc, long count, int indent, getline_opt_T do_concat);
 char_u *getcmdline_prompt(int firstc, char_u *prompt, int attr, int xp_context, char_u *xp_arg);
 int check_opt_wim(void);
-int text_and_win_locked(void);
 void text_locked_msg(void);
 char *get_text_locked_msg(void);
 int text_locked(void);

--- a/src/register.c
+++ b/src/register.c
@@ -1055,9 +1055,9 @@ yank_do_autocmd(oparg_T *oap, yankreg_T *reg)
     dict_set_items_ro(v_event);
 
     recursive = TRUE;
-    textwinlock++;
+    textlock++;
     apply_autocmds(EVENT_TEXTYANKPOST, NULL, NULL, FALSE, curbuf);
-    textwinlock--;
+    textlock--;
     recursive = FALSE;
 
     // Empty the dictionary, v:event is still valid

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -1041,7 +1041,7 @@ func Test_edit_completefunc_delete()
   set completefunc=CompleteFunc
   call setline(1, ['', 'abcd', ''])
   2d
-  call assert_fails("normal 2G$a\<C-X>\<C-U>", 'E578:')
+  call assert_fails("normal 2G$a\<C-X>\<C-U>", 'E565:')
   bwipe!
 endfunc
 

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -698,7 +698,7 @@ func Test_completefunc_error()
   endfunc
   set completefunc=CompleteFunc
   call setline(1, ['', 'abcd', ''])
-  call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E578:')
+  call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E565:')
 
   " delete text when called for the second time
   func CompleteFunc2(findstart, base)
@@ -710,7 +710,7 @@ func Test_completefunc_error()
   endfunc
   set completefunc=CompleteFunc2
   call setline(1, ['', 'abcd', ''])
-  call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E578:')
+  call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E565:')
 
   " Jump to a different window from the complete function
   func CompleteFunc3(findstart, base)

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -655,7 +655,7 @@ func Test_complete_func_mess()
   set completefunc=MessComplete
   new
   call setline(1, 'Ju')
-  call assert_fails('call feedkeys("A\<c-x>\<c-u>/\<esc>", "tx")', 'E578:')
+  call assert_fails('call feedkeys("A\<c-x>\<c-u>/\<esc>", "tx")', 'E565:')
   call assert_equal('Jan/', getline(1))
   bwipe!
   set completefunc=

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -3474,7 +3474,7 @@ endfunc
 func Test_vimgrep_with_textlock()
   new
 
-  " Simple way to execute something with "textwinlock" set.
+  " Simple way to execute something with "textlock" set.
   " Check that vimgrep without jumping can be executed.
   au InsertCharPre * vimgrep /RunTheTest/j runtest.vim
   normal ax

--- a/src/undo.c
+++ b/src/undo.c
@@ -331,9 +331,9 @@ undo_allowed(void)
 
     // Don't allow changes in the buffer while editing the cmdline.  The
     // caller of getcmdline() may get confused.
-    if (textwinlock != 0 || textlock != 0)
+    if (textlock != 0)
     {
-	emsg(_(e_not_allowed_to_change_text_here));
+	emsg(_(e_not_allowed_to_change_text_or_change_window));
 	return FALSE;
     }
 

--- a/src/window.c
+++ b/src/window.c
@@ -4584,7 +4584,7 @@ win_goto(win_T *wp)
 	return;
     }
 #endif
-    if (text_and_win_locked())
+    if (text_locked())
     {
 	beep_flush();
 	text_locked_msg();


### PR DESCRIPTION
After patch 8.2.2426 the value of `textlock` is always zero, so rename `textwinlock` back to `textlock`, as `textlock` is used frequently in help files:
```
Textlock							*textlock*

In a few situations it is not allowed to change the text in the buffer, jump
to another window and some other things that might confuse or break what Vim
is currently doing.  This mostly applies to things that happen when Vim is
actually doing something else.  For example, evaluating the 'balloonexpr' may
happen any moment the mouse cursor is resting at some position.

This is not allowed when the textlock is active:
	- changing the buffer text
	- jumping to another buffer or window
	- editing another file
	- closing a window or quitting Vim
	- etc.
```