### PR TITLE
Use a more accurate clock source when possible

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -762,6 +762,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -897,6 +898,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1149,6 +1151,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1286,7 +1297,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1439,6 +1450,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -12725,7 +12737,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -12771,7 +12783,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -12795,7 +12807,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -12840,7 +12852,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -12864,7 +12876,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -13137,6 +13149,34 @@ rm -f core conftest.err conftest.$ac_objext \
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for clock_gettime" >&5
+$as_echo_n "checking for clock_gettime... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include<time.h>
+#include<sys/time.h>
+int
+main ()
+{
+
+ struct timespec ts;
+ (void)clock_gettime(0, &ts);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }; $as_echo "#define HAVE_CLOCK_GETTIME 1" >>confdefs.h
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether stat() ignores a trailing slash" >&5
 $as_echo_n "checking whether stat() ignores a trailing slash... " >&6; }

--- a/src/channel.c
+++ b/src/channel.c
@@ -827,7 +827,7 @@ channel_connect(
 	    tv.tv_sec = waitnow / 1000;
 	    tv.tv_usec = (waitnow % 1000) * 1000;
 #ifndef MSWIN
-	    gettimeofday(&start_tv, NULL);
+	    time_now(&start_tv);
 #endif
 	    ch_log(channel,
 		      "Waiting for connection (waiting %d msec)...", waitnow);
@@ -893,7 +893,7 @@ channel_connect(
 		// Did not detect an error, connection is established.
 		break;
 
-	    gettimeofday(&end_tv, NULL);
+	    time_now(&end_tv);
 	    elapsed_msec = (end_tv.tv_sec - start_tv.tv_sec) * 1000
 				 + (end_tv.tv_usec - start_tv.tv_usec) / 1000;
 #endif
@@ -2395,7 +2395,7 @@ channel_parse_json(channel_T *channel, ch_part_T part)
 #ifdef MSWIN
 	    chanpart->ch_deadline = GetTickCount() + 100L;
 #else
-	    gettimeofday(&chanpart->ch_deadline, NULL);
+	    time_now(&chanpart->ch_deadline);
 	    chanpart->ch_deadline.tv_usec += 100 * 1000;
 	    if (chanpart->ch_deadline.tv_usec > 1000 * 1000)
 	    {
@@ -2413,7 +2413,7 @@ channel_parse_json(channel_T *channel, ch_part_T part)
 	    {
 		struct timeval now_tv;
 
-		gettimeofday(&now_tv, NULL);
+		time_now(&now_tv);
 		timeout = now_tv.tv_sec > chanpart->ch_deadline.tv_sec
 		      || (now_tv.tv_sec == chanpart->ch_deadline.tv_sec
 			   && now_tv.tv_usec > chanpart->ch_deadline.tv_usec);
@@ -4066,7 +4066,7 @@ channel_read_json_block(
 		{
 		    struct timeval now_tv;
 
-		    gettimeofday(&now_tv, NULL);
+		    time_now(&now_tv);
 		    timeout = (chanpart->ch_deadline.tv_sec
 						       - now_tv.tv_sec) * 1000
 			+ (chanpart->ch_deadline.tv_usec

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -232,6 +232,7 @@
 #undef HAVE_BIND_TEXTDOMAIN_CODESET
 #undef HAVE_MBLEN
 #undef HAVE_TIMER_CREATE
+#undef HAVE_CLOCK_GETTIME
 
 /* Define, if needed, for accessing large files. */
 #undef _LARGE_FILES

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3848,6 +3848,18 @@ static void set_flag(union sigval) {}
     AC_MSG_RESULT(yes); AC_DEFINE(HAVE_TIMER_CREATE),
     AC_MSG_RESULT(no)))
 
+dnl Check for clock_gettime.
+AC_MSG_CHECKING([for clock_gettime])
+AC_TRY_COMPILE([
+#include<time.h>
+#include<sys/time.h>],
+[
+ struct timespec ts;
+ (void)clock_gettime(0, &ts);
+],
+AC_MSG_RESULT(yes); AC_DEFINE(HAVE_CLOCK_GETTIME),
+AC_MSG_RESULT(no))
+
 AC_CACHE_CHECK([whether stat() ignores a trailing slash], [vim_cv_stat_ignores_slash],
   [
     AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/src/feature.h
+++ b/src/feature.h
@@ -279,8 +279,7 @@
  */
 #if defined(FEAT_HUGE) \
 	&& defined(FEAT_EVAL) \
-	&& ((defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H)) \
-		|| defined(MSWIN))
+	&& (defined(HAVE_SYS_TIME_H) || defined(MSWIN))
 # define FEAT_PROFILE
 #endif
 
@@ -289,8 +288,7 @@
  */
 #if defined(FEAT_NORMAL) \
 	&& defined(FEAT_EVAL) \
-	&& ((defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H)) \
-		|| defined(MSWIN))
+	&& (defined(HAVE_SYS_TIME_H) || defined(MSWIN))
 # define FEAT_RELTIME
 #endif
 
@@ -703,8 +701,7 @@
  *			timestamps.
  */
 #if defined(FEAT_NORMAL) \
-	&& ((defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H)) \
-		|| defined(MSWIN))
+	&& (defined(HAVE_SYS_TIME_H) || defined(MSWIN))
 # define STARTUPTIME 1
 #endif
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2814,7 +2814,7 @@ elapsed(struct timeval *start_tv)
 {
     struct timeval  now_tv;
 
-    gettimeofday(&now_tv, NULL);
+    time_now(&now_tv);
     return (now_tv.tv_sec - start_tv->tv_sec) * 1000L
 	 + (now_tv.tv_usec - start_tv->tv_usec) / 1000L;
 }

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -2779,7 +2779,7 @@ check_termcode_mouse(
 		    /*
 		     * Compute the time elapsed since the previous mouse click.
 		     */
-		    gettimeofday(&mouse_time, NULL);
+		    time_now(&mouse_time);
 		    if (orig_mouse_time.tv_sec == 0)
 		    {
 			/*

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -24,7 +24,7 @@ profile_start(proftime_T *tm)
 # ifdef MSWIN
     QueryPerformanceCounter(tm);
 # else
-    gettimeofday(tm, NULL);
+    time_now(tm);
 # endif
 }
 
@@ -40,7 +40,7 @@ profile_end(proftime_T *tm)
     QueryPerformanceCounter(&now);
     tm->QuadPart = now.QuadPart - tm->QuadPart;
 # else
-    gettimeofday(&now, NULL);
+    time_now(&now);
     tm->tv_usec = now.tv_usec - tm->tv_usec;
     tm->tv_sec = now.tv_sec - tm->tv_sec;
     if (tm->tv_usec < 0)
@@ -127,7 +127,7 @@ profile_setlimit(long msec, proftime_T *tm)
 # else
 	long	    usec;
 
-	gettimeofday(tm, NULL);
+	time_now(tm);
 	usec = (long)tm->tv_usec + (long)msec * 1000;
 	tm->tv_usec = usec % 1000000L;
 	tm->tv_sec += usec / 1000000L;
@@ -151,7 +151,7 @@ profile_passed_limit(proftime_T *tm)
 # else
     if (tm->tv_sec == 0)    // timer was not set
 	return FALSE;
-    gettimeofday(&now, NULL);
+    time_now(&now);
     return (now.tv_sec > tm->tv_sec
 	    || (now.tv_sec == tm->tv_sec && now.tv_usec > tm->tv_usec));
 # endif

--- a/src/proto/time.pro
+++ b/src/proto/time.pro
@@ -25,4 +25,5 @@ time_T get8ctime(FILE *fd);
 int put_time(FILE *fd, time_T the_time);
 void time_to_bytes(time_T the_time, char_u *buf);
 void add_time(char_u *buf, size_t buflen, time_t tt);
+int time_now(struct timeval *tv);
 /* vim: set ft=c : */

--- a/src/vim.h
+++ b/src/vim.h
@@ -2734,9 +2734,9 @@ typedef enum {
 # endif
 #endif
 
-#if defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H)
+#if defined(HAVE_SYS_TIME_H)
 # define ELAPSED_TIMEVAL
-# define ELAPSED_INIT(v) gettimeofday(&(v), NULL)
+# define ELAPSED_INIT(v) time_now(&(v))
 # define ELAPSED_FUNC(v) elapsed(&(v))
 typedef struct timeval elapsed_T;
 long elapsed(struct timeval *start_tv);


### PR DESCRIPTION
Kill every single (mis)use of gettimeofday() and replace them with a
faster non-wall-clock timer.

cc @paul-ollis 