### PR TITLE
listchars: allows to specify leading multiple spaces

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5074,15 +5074,24 @@ A jump table for the options with a short description can be found at |Q_op|.
 			setting, except for single spaces.  When omitted, the
 			"space" setting is used.  For example,
 			`:set listchars=multispace:---+` shows ten consecutive
-			spaces as:
+			spaces as: >
 				---+---+--
-							*lcs-lead*
+<							*lcs-lead*
 	  lead:c	Character to show for leading spaces.  When omitted,
 			leading spaces are blank.  Overrides the "space" and
 			"multispace" settings for leading spaces.  You can
 			combine it with "tab:", for example: >
 				:set listchars+=tab:>-,lead:.
-<							*lcs-trail*
+<							*lcs-leadmultispace*
+	  leadmultispace:c...
+			Like multispace value, but only for leading whitespace
+			Overrides |lcs-lead| for leading multiple spaces.
+			`:set listchars=leadmultispace:---+` shows ten consecutive
+			leading spaces as: >
+				---+---+--XXX
+<			Where "XXX" denotes the first non-blank characters in
+			the line.
+							*lcs-trail*
 	  trail:c	Character to show for trailing spaces.  When omitted,
 			trailing spaces are blank.  Overrides the "space" and
 			"multispace" settings for trailing spaces.

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -2126,16 +2126,11 @@ win_line(
 			if (wp->w_lcs_chars.leadmultispace[multispace_pos] == NUL)
 			    multispace_pos = 0;
 		    }
-#if 0
-		    else
-			c = (ptr > line + trailcol) ? wp->w_lcs_chars.trail
-			     : (wp->w_lcs_chars.lead ? wp->w_lcs_chars.lead : ' ');
-#endif
 
 		    else if (ptr > line + trailcol && wp->w_lcs_chars.trail)
 			c = wp->w_lcs_chars.trail;
 
-		    else if (ptr < line + trailcol && wp->w_lcs_chars.lead)
+		    else if (ptr < line + leadcol && wp->w_lcs_chars.lead)
 			c = wp->w_lcs_chars.lead;
 
 		    else if (leadcol != 0 && c == ' ' && wp->w_lcs_chars.space)

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -767,6 +767,7 @@ win_line(
     {
 	if (wp->w_lcs_chars.space
 		|| wp->w_lcs_chars.multispace != NULL
+		|| wp->w_lcs_chars.leadmultispace != NULL
 		|| wp->w_lcs_chars.trail
 		|| wp->w_lcs_chars.lead
 		|| wp->w_lcs_chars.nbsp)
@@ -781,7 +782,7 @@ win_line(
 	    trailcol += (colnr_T) (ptr - line);
 	}
 	// find end of leading whitespace
-	if (wp->w_lcs_chars.lead)
+	if (wp->w_lcs_chars.lead || wp->w_lcs_chars.leadmultispace != NULL)
 	{
 	    leadcol = 0;
 	    while (VIM_ISWHITE(ptr[leadcol]))
@@ -2118,8 +2119,29 @@ win_line(
 		if ((trailcol != MAXCOL && ptr > line + trailcol && c == ' ')
 			|| (leadcol != 0 && ptr < line + leadcol && c == ' '))
 		{
-		    c = (ptr > line + trailcol) ? wp->w_lcs_chars.trail
-							: wp->w_lcs_chars.lead;
+		    if (leadcol != 0 && in_multispace && ptr < line + leadcol
+			    && wp->w_lcs_chars.leadmultispace != NULL)
+		    {
+			c = wp->w_lcs_chars.leadmultispace[multispace_pos++];
+			if (wp->w_lcs_chars.leadmultispace[multispace_pos] == NUL)
+			    multispace_pos = 0;
+		    }
+#if 0
+		    else
+			c = (ptr > line + trailcol) ? wp->w_lcs_chars.trail
+			     : (wp->w_lcs_chars.lead ? wp->w_lcs_chars.lead : ' ');
+#endif
+
+		    else if (ptr > line + trailcol && wp->w_lcs_chars.trail)
+			c = wp->w_lcs_chars.trail;
+
+		    else if (ptr < line + trailcol && wp->w_lcs_chars.lead)
+			c = wp->w_lcs_chars.lead;
+
+		    else if (leadcol != 0 && c == ' ' && wp->w_lcs_chars.space)
+			c = wp->w_lcs_chars.space;
+
+
 		    if (!attr_pri)
 		    {
 			n_attr = 1;

--- a/src/message.c
+++ b/src/message.c
@@ -1881,7 +1881,7 @@ msg_prt_line(char_u *s, int list)
 		--trail;
 	}
 	// find end of leading whitespace
-	if (curwin->w_lcs_chars.lead)
+	if (curwin->w_lcs_chars.lead || curwin->w_lcs_chars.leadmultispace != NULL)
 	{
 	    lead = s;
 	    while (VIM_ISWHITE(lead[0]))
@@ -1993,7 +1993,15 @@ msg_prt_line(char_u *s, int list)
 	    }
 	    else if (c == ' ')
 	    {
-		if (lead != NULL && s <= lead)
+		if (list && lead != NULL && s <= lead && in_multispace
+			&& curwin->w_lcs_chars.leadmultispace != NULL)
+		{
+		    c = curwin->w_lcs_chars.leadmultispace[multispace_pos++];
+		    if (curwin->w_lcs_chars.leadmultispace[multispace_pos] == NUL)
+			multispace_pos = 0;
+		    attr = HL_ATTR(HLF_8);
+		}
+		else if (lead != NULL && s <= lead && curwin->w_lcs_chars.lead)
 		{
 		    c = curwin->w_lcs_chars.lead;
 		    attr = HL_ATTR(HLF_8);
@@ -2001,6 +2009,14 @@ msg_prt_line(char_u *s, int list)
 		else if (trail != NULL && s > trail)
 		{
 		    c = curwin->w_lcs_chars.trail;
+		    attr = HL_ATTR(HLF_8);
+		}
+		else if (list && lead != NULL && s <= lead && in_multispace
+			&& curwin->w_lcs_chars.leadmultispace != NULL)
+		{
+		    c = curwin->w_lcs_chars.leadmultispace[multispace_pos++];
+		    if (curwin->w_lcs_chars.leadmultispace[multispace_pos] == NUL)
+			multispace_pos = 0;
 		    attr = HL_ATTR(HLF_8);
 		}
 		else if (list && in_multispace

--- a/src/screen.c
+++ b/src/screen.c
@@ -4839,9 +4839,9 @@ set_chars_option(win_T *wp, char_u **varp)
     char_u	*p, *s;
     int		c1 = 0, c2 = 0, c3 = 0;
     char_u	*last_multispace = NULL; // Last occurrence of "multispace:"
-    char_u	*last_lmultispace = NULL; // Last occurrence of "lead-multispace:"
+    char_u	*last_lmultispace = NULL; // Last occurrence of "leadmultispace:"
     int		multispace_len = 0;	 // Length of lcs-multispace string
-    int		lead_multispace_len = 0; // Length of lcs-lead-multispace string
+    int		lead_multispace_len = 0; // Length of lcs-leadmultispace string
     struct charstab
     {
 	int	*cp;
@@ -5032,7 +5032,7 @@ set_chars_option(win_T *wp, char_u **varp)
 		    s = p + len2 + 1;
 		    if (round == 0)
 		    {
-			// Get length of lcs-multispace string in first round
+			// Get length of lcsmultispace string in first round
 			last_lmultispace = p;
 			lead_multispace_len = 0;
 			while (*s != NUL && *s != ',')
@@ -5043,7 +5043,7 @@ set_chars_option(win_T *wp, char_u **varp)
 			    ++lead_multispace_len;
 			}
 			if (lead_multispace_len == 0)
-			    // lcs-multispace cannot be an empty string
+			    // lcsmultispace cannot be an empty string
 			    return e_invalid_argument;
 			p = s;
 		    }

--- a/src/structs.h
+++ b/src/structs.h
@@ -3414,6 +3414,7 @@ typedef struct
     int		trail;
     int		lead;
     int		*multispace;
+    int		*leadmultispace;
 #ifdef FEAT_CONCEAL
     int		conceal;
 #endif

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -132,7 +132,7 @@ func Test_listchars()
 	      \ 'h<<<<<<<<<<<$',
 	      \ '<<<<<<<<<<<<$',
 	      \ '>>>>0xx0<<<<$',
-              \ '$'
+        \ '$'
 	      \ ]
   redraw!
   for i in range(1, 5)
@@ -162,7 +162,7 @@ func Test_listchars()
 	      \ ' hyYzZyYzZyY$',
 	      \ 'yYzZyYzZyYj $',
 	      \ 'yYzZ0yY0yYzZ$',
-              \ '$'
+        \ '$'
 	      \ ]
   redraw!
   for i in range(1, 5)
@@ -172,7 +172,132 @@ func Test_listchars()
 
   call assert_equal(expected, split(execute("%list"), "\n"))
 
+  " Test leadmultispace + multispace
+  normal ggdG
+  set listchars=eol:$,multispace:yYzZ
+  set listchars+=leadmultispace:ABCD
+  set list
+
+  call append(0, [
+	      \ '    ffff    ',
+	      \ '  i i     gg',
+	      \ ' h          ',
+	      \ '          j ',
+	      \ '    0  0    ',
+	      \ ])
+
+  let expected = [
+	      \ 'ABCDffffyYzZ$',
+	      \ 'ABi iyYzZygg$',
+	      \ ' hyYzZyYzZyY$',
+	      \ 'ABCDABCDABj $',
+	      \ 'ABCD0yY0yYzZ$',
+        \ '$'
+	      \ ]
+  redraw!
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+
+  call assert_equal(expected, split(execute("%list"), "\n"))
+
+  " Test leadmultispace without multispace
+  normal ggdG
+  set listchars-=multispace:yYzZ
+  set listchars+=space:+,trail:>,eol:$
+  set list
+
+  call append(0, [
+	      \ '    ffff    ',
+	      \ '  i i     gg',
+	      \ ' h          ',
+	      \ '          j ',
+	      \ '    0  0    ',
+	      \ ])
+
+  let expected = [
+	      \ 'ABCDffff>>>>$',
+	      \ 'ABi+i+++++gg$',
+	      \ '+h>>>>>>>>>>$',
+	      \ 'ABCDABCDABj>$',
+	      \ 'ABCD0++0>>>>$',
+        \ '$',
+	      \ ]
+
+  redraw!
+  call assert_equal('eol:$,leadmultispace:ABCD,space:+,trail:>,eol:$', &listchars)
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+
+  call assert_equal(expected, split(execute("%list"), "\n"))
+
+  " Test leadmultispace only
+  normal ggdG
+  set listchars&
+  set listchars=leadmultispace:ABCD
+  set list
+
+  call append(0, [
+	      \ '    ffff    ',
+	      \ '  i i     gg',
+	      \ ' h          ',
+	      \ '          j ',
+	      \ '    0  0    ',
+	      \ ])
+
+  let expected = [
+	      \ 'ABCDffff    ',
+	      \ 'ABi i     gg',
+	      \ ' h          ',
+	      \ 'ABCDABCDABj ',
+	      \ 'ABCD0  0    ',
+        \ ' ',
+	      \ ]
+  redraw!
+  call assert_equal('leadmultispace:ABCD', &listchars)
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, 12))
+  endfor
+  call assert_equal(expected, split(execute("%list"), "\n"))
+
+  " Test leadmultispace and lead and space
+  normal ggdG
+  set listchars&
+  set listchars+=lead:<,space:-
+  set listchars+=leadmultispace:ABCD
+  set list
+
+  call append(0, [
+	      \ '    ffff    ',
+	      \ '  i i     gg',
+	      \ ' h          ',
+	      \ '          j ',
+	      \ '    0  0    ',
+	      \ ])
+
+  let expected = [
+	      \ 'ABCDffff----$',
+	      \ 'ABi-i-----gg$',
+	      \ '<h----------$',
+	      \ 'ABCDABCDABj-$',
+	      \ 'ABCD0--0----$',
+        \ '$',
+	      \ ]
+  redraw!
+  call assert_equal('eol:$,lead:<,space:-,leadmultispace:ABCD', &listchars)
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+  call assert_equal(expected, split(execute("%list"), "\n"))
+
   " the last occurrence of 'multispace:' is used
+  set listchars&
+  set listchars+=multispace:yYzZ
   set listchars+=space:x,multispace:XyY
 
   let expected = [
@@ -181,9 +306,10 @@ func Test_listchars()
 	      \ 'xhXyYXyYXyYX$',
 	      \ 'XyYXyYXyYXjx$',
 	      \ 'XyYX0Xy0XyYX$',
-              \ '$'
+        \ '$'
 	      \ ]
   redraw!
+  call assert_equal('eol:$,multispace:yYzZ,space:x,multispace:XyY', &listchars)
   for i in range(1, 5)
     call cursor(i, 1)
     call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
@@ -199,7 +325,7 @@ func Test_listchars()
 	      \ '>h<<<<<<<<<<$',
 	      \ '>>>>>>>>>>j<$',
 	      \ '>>>>0Xy0<<<<$',
-              \ '$'
+        \ '$'
 	      \ ]
   redraw!
   for i in range(1, 5)
@@ -219,7 +345,7 @@ func Test_listchars()
 	      \ '>h<<<<<<<<<<$',
 	      \ '>>>>>>>>>>j<$',
 	      \ '>>>>0xx0<<<<$',
-              \ '$'
+        \ '$'
 	      \ ]
   redraw!
   for i in range(1, 5)
@@ -315,11 +441,13 @@ func Test_listchars_invalid()
   call assert_fails('set listchars=x', 'E474:')
   call assert_fails('set listchars=x', 'E474:')
   call assert_fails('set listchars=multispace', 'E474:')
+  call assert_fails('set listchars=leadmultispace', 'E474:')
 
   " Too short
   call assert_fails('set listchars=space:', 'E474:')
   call assert_fails('set listchars=tab:x', 'E474:')
   call assert_fails('set listchars=multispace:', 'E474:')
+  call assert_fails('set listchars=leadmultispace:', 'E474:')
 
   " One occurrence too short
   call assert_fails('set listchars=space:,space:x', 'E474:')
@@ -328,6 +456,8 @@ func Test_listchars_invalid()
   call assert_fails('set listchars=tab:xx,tab:x', 'E474:')
   call assert_fails('set listchars=multispace:,multispace:x', 'E474:')
   call assert_fails('set listchars=multispace:x,multispace:', 'E474:')
+  call assert_fails('set listchars=leadmultispace:,leadmultispace:x', 'E474:')
+  call assert_fails('set listchars=leadmultispace:x,leadmultispace:', 'E474:')
 
   " Too long
   call assert_fails('set listchars=space:xx', 'E474:')
@@ -340,6 +470,8 @@ func Test_listchars_invalid()
   call assert_fails('set listchars=tab:xx·', 'E474:')
   call assert_fails('set listchars=multispace:·', 'E474:')
   call assert_fails('set listchars=multispace:xxx·', 'E474:')
+  call assert_fails('set listchars=leadmultispace:·', 'E474:')
+  call assert_fails('set listchars=leadmultispace:xxx·', 'E474:')
 
   " Has control character
   call assert_fails("set listchars=space:\x01", 'E474:')
@@ -354,6 +486,10 @@ func Test_listchars_invalid()
   call assert_fails('set listchars=tab:xx\\x01', 'E474:')
   call assert_fails('set listchars=multispace:\\x01', 'E474:')
   call assert_fails('set listchars=multispace:xxx\\x01', 'E474:')
+  call assert_fails("set listchars=leadmultispace:\x01", 'E474:')
+  call assert_fails('set listchars=leadmultispace:\\x01', 'E474:')
+  call assert_fails("set listchars=leadmultispace:xxx\x01", 'E474:')
+  call assert_fails('set listchars=leadmultispace:xxx\\x01', 'E474:')
 
   enew!
   set ambiwidth& listchars& ff&

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -174,13 +174,13 @@ func Test_listchars()
 
   " Test leadmultispace + multispace
   normal ggdG
-  set listchars=eol:$,multispace:yYzZ
+  set listchars=eol:$,multispace:yYzZ,nbsp:S
   set listchars+=leadmultispace:ABCD
   set list
 
   call append(0, [
 	      \ '    ffff    ',
-	      \ '  i i     gg',
+	      \ '  i i     gg',
 	      \ ' h          ',
 	      \ '          j ',
 	      \ '    0  0    ',
@@ -188,13 +188,14 @@ func Test_listchars()
 
   let expected = [
 	      \ 'ABCDffffyYzZ$',
-	      \ 'ABi iyYzZygg$',
+	      \ 'ABi iSyYzZgg$',
 	      \ ' hyYzZyYzZyY$',
 	      \ 'ABCDABCDABj $',
 	      \ 'ABCD0yY0yYzZ$',
         \ '$'
 	      \ ]
   redraw!
+  call assert_equal('eol:$,multispace:yYzZ,nbsp:S,leadmultispace:ABCD', &listchars)
   for i in range(1, 5)
     call cursor(i, 1)
     call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
@@ -226,7 +227,7 @@ func Test_listchars()
 	      \ ]
 
   redraw!
-  call assert_equal('eol:$,leadmultispace:ABCD,space:+,trail:>,eol:$', &listchars)
+  call assert_equal('eol:$,nbsp:S,leadmultispace:ABCD,space:+,trail:>,eol:$', &listchars)
   for i in range(1, 5)
     call cursor(i, 1)
     call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -175,7 +175,7 @@ func Test_listchars()
   " Test leadmultispace + multispace
   normal ggdG
   set listchars=eol:$,multispace:yYzZ,nbsp:S
-  set listchars+=leadmultispace:ABCD
+  set listchars+=leadmultispace:.-+*
   set list
 
   call append(0, [
@@ -187,15 +187,15 @@ func Test_listchars()
 	      \ ])
 
   let expected = [
-	      \ 'ABCDffffyYzZ$',
-	      \ 'ABi iSyYzZgg$',
+	      \ '.-+*ffffyYzZ$',
+	      \ '.-i iSyYzZgg$',
 	      \ ' hyYzZyYzZyY$',
-	      \ 'ABCDABCDABj $',
-	      \ 'ABCD0yY0yYzZ$',
+	      \ '.-+*.-+*.-j $',
+	      \ '.-+*0yY0yYzZ$',
         \ '$'
 	      \ ]
   redraw!
-  call assert_equal('eol:$,multispace:yYzZ,nbsp:S,leadmultispace:ABCD', &listchars)
+  call assert_equal('eol:$,multispace:yYzZ,nbsp:S,leadmultispace:.-+*', &listchars)
   for i in range(1, 5)
     call cursor(i, 1)
     call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
@@ -218,16 +218,16 @@ func Test_listchars()
 	      \ ])
 
   let expected = [
-	      \ 'ABCDffff>>>>$',
-	      \ 'ABi+i+++++gg$',
+	      \ '.-+*ffff>>>>$',
+	      \ '.-i+i+++++gg$',
 	      \ '+h>>>>>>>>>>$',
-	      \ 'ABCDABCDABj>$',
-	      \ 'ABCD0++0>>>>$',
+	      \ '.-+*.-+*.-j>$',
+	      \ '.-+*0++0>>>>$',
         \ '$',
 	      \ ]
 
   redraw!
-  call assert_equal('eol:$,nbsp:S,leadmultispace:ABCD,space:+,trail:>,eol:$', &listchars)
+  call assert_equal('eol:$,nbsp:S,leadmultispace:.-+*,space:+,trail:>,eol:$', &listchars)
   for i in range(1, 5)
     call cursor(i, 1)
     call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
@@ -238,7 +238,7 @@ func Test_listchars()
   " Test leadmultispace only
   normal ggdG
   set listchars&
-  set listchars=leadmultispace:ABCD
+  set listchars=leadmultispace:.-+*
   set list
 
   call append(0, [
@@ -250,15 +250,15 @@ func Test_listchars()
 	      \ ])
 
   let expected = [
-	      \ 'ABCDffff    ',
-	      \ 'ABi i     gg',
+	      \ '.-+*ffff    ',
+	      \ '.-i i     gg',
 	      \ ' h          ',
-	      \ 'ABCDABCDABj ',
-	      \ 'ABCD0  0    ',
+	      \ '.-+*.-+*.-j ',
+	      \ '.-+*0  0    ',
         \ ' ',
 	      \ ]
   redraw!
-  call assert_equal('leadmultispace:ABCD', &listchars)
+  call assert_equal('leadmultispace:.-+*', &listchars)
   for i in range(1, 5)
     call cursor(i, 1)
     call assert_equal([expected[i - 1]], ScreenLines(i, 12))
@@ -269,7 +269,7 @@ func Test_listchars()
   normal ggdG
   set listchars&
   set listchars+=lead:<,space:-
-  set listchars+=leadmultispace:ABCD
+  set listchars+=leadmultispace:.-+*
   set list
 
   call append(0, [
@@ -281,15 +281,15 @@ func Test_listchars()
 	      \ ])
 
   let expected = [
-	      \ 'ABCDffff----$',
-	      \ 'ABi-i-----gg$',
+	      \ '.-+*ffff----$',
+	      \ '.-i-i-----gg$',
 	      \ '<h----------$',
-	      \ 'ABCDABCDABj-$',
-	      \ 'ABCD0--0----$',
+	      \ '.-+*.-+*.-j-$',
+	      \ '.-+*0--0----$',
         \ '$',
 	      \ ]
   redraw!
-  call assert_equal('eol:$,lead:<,space:-,leadmultispace:ABCD', &listchars)
+  call assert_equal('eol:$,lead:<,space:-,leadmultispace:.-+*', &listchars)
   for i in range(1, 5)
     call cursor(i, 1)
     call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))

--- a/src/window.c
+++ b/src/window.c
@@ -5191,6 +5191,7 @@ win_free(
     clear_winopt(&wp->w_allbuf_opt);
 
     vim_free(wp->w_lcs_chars.multispace);
+    vim_free(wp->w_lcs_chars.leadmultispace);
 
 #ifdef FEAT_EVAL
     vars_clear(&wp->w_vars->dv_hashtab);	// free all w: variables


### PR DESCRIPTION
As requested in vim/vim#10411 add a new suboption for the 'listchars'
setting, that allows to specify multiple leading spaces. This basically
works like 'multispace' suboption, but only for leading whitespace, e.g.
before any non-whitespace characters.