### PR TITLE
syntax/rust: add "dyn" keyword

### DIFF
--- a/runtime/syntax/rust.vim
+++ b/runtime/syntax/rust.vim
@@ -37,7 +37,7 @@ syn keyword   rustKeyword     unsafe where
 syn keyword   rustKeyword     use nextgroup=rustModPath skipwhite skipempty
 " FIXME: Scoped impl's name is also fallen in this category
 syn keyword   rustKeyword     mod trait nextgroup=rustIdentifier skipwhite skipempty
-syn keyword   rustStorage     move mut ref static const
+syn keyword   rustStorage     move mut ref static const dyn
 syn match rustDefault /\<default\ze\_s\+\(impl\|fn\|type\|const\)\>/
 
 syn keyword   rustInvalidBareKeyword crate


### PR DESCRIPTION
I noticed `dyn` doesn't get highlighted, it was kinda surprising, considering vim has syntax highlighting even for non-official keywords (like `box`).

It is placed in the same group as `mut` so both words in `&mut dyn` are identically highlighted.