### PR TITLE
Timeout

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -13080,6 +13080,76 @@ $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for timer_create" >&5
+$as_echo_n "checking for timer_create... " >&6; }
+save_LIBS="$LIBS"
+LIBS="$LIBS -lrt"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include<signal.h>
+#include<time.h>
+void set_flag(union sigval _unused) {}
+
+int
+main ()
+{
+
+  struct timespec ts;
+  struct sigevent action = {0};
+  timer_t timer_id;
+
+  action.sigev_notify = SIGEV_THREAD;
+  action.sigev_notify_function = set_flag;
+  timer_create(CLOCK_REALTIME, &action, &timer_id);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes; with -lrt" >&5
+$as_echo "yes; with -lrt" >&6; }; $as_echo "#define HAVE_TIMER_CREATE 1" >>confdefs.h
+
+else
+  LIBS="$save_LIBS"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include<signal.h>
+#include<time.h>
+void set_flag(union sigval _unused) {}
+
+int
+main ()
+{
+
+    struct timespec ts;
+    struct sigevent action = {0};
+    timer_t timer_id;
+
+    action.sigev_notify = SIGEV_THREAD;
+    action.sigev_notify_function = set_flag;
+    timer_create(CLOCK_REALTIME, &action, &timer_id);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }; $as_echo "#define HAVE_TIMER_CREATE 1" >>confdefs.h
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether stat() ignores a trailing slash" >&5
 $as_echo_n "checking whether stat() ignores a trailing slash... " >&6; }
 if ${vim_cv_stat_ignores_slash+:} false; then :

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -231,6 +231,7 @@
 #undef HAVE_UTIME
 #undef HAVE_BIND_TEXTDOMAIN_CODESET
 #undef HAVE_MBLEN
+#undef HAVE_TIMER_CREATE
 
 /* Define, if needed, for accessing large files. */
 #undef _LARGE_FILES

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3812,6 +3812,41 @@ AC_TRY_COMPILE(
 	AC_MSG_RESULT(yes); AC_DEFINE(HAVE_ST_BLKSIZE),
 	AC_MSG_RESULT(no))
 
+dnl Check for timer_create. It probably requires the 'rt' library.
+AC_MSG_CHECKING([for timer_create])
+save_LIBS="$LIBS"
+LIBS="$LIBS -lrt"
+AC_TRY_LINK([
+#include<signal.h>
+#include<time.h>
+void set_flag(union sigval _unused) {}
+], [
+  struct timespec ts;
+  struct sigevent action = {0};
+  timer_t timer_id;
+
+  action.sigev_notify = SIGEV_THREAD;
+  action.sigev_notify_function = set_flag;
+  timer_create(CLOCK_REALTIME, &action, &timer_id);
+  ],
+  AC_MSG_RESULT(yes; with -lrt); AC_DEFINE(HAVE_TIMER_CREATE),
+  LIBS="$save_LIBS"
+  AC_TRY_LINK([
+#include<signal.h>
+#include<time.h>
+void set_flag(union sigval _unused) {}
+    ], [
+    struct timespec ts;
+    struct sigevent action = {0};
+    timer_t timer_id;
+
+    action.sigev_notify = SIGEV_THREAD;
+    action.sigev_notify_function = set_flag;
+    timer_create(CLOCK_REALTIME, &action, &timer_id);
+    ],
+    AC_MSG_RESULT(yes); AC_DEFINE(HAVE_TIMER_CREATE),
+    AC_MSG_RESULT(no)))
+
 AC_CACHE_CHECK([whether stat() ignores a trailing slash], [vim_cv_stat_ignores_slash],
   [
     AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1474,9 +1474,6 @@ win_update(win_T *wp)
 #if defined(FEAT_SYN_HL) || defined(FEAT_SEARCH_EXTRA)
     int		save_got_int;
 #endif
-#ifdef SYN_TIME_LIMIT
-    proftime_T	syntax_tm;
-#endif
 
 #if defined(FEAT_SEARCH_EXTRA) || defined(FEAT_CLIPBOARD)
     // This needs to be done only for the first window when update_screen() is

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -2182,8 +2182,7 @@ win_update(win_T *wp)
 #endif
 #ifdef SYN_TIME_LIMIT
     // Set the time limit to 'redrawtime'.
-    profile_setlimit(p_rdt, &syntax_tm);
-    syn_set_timeout(&syntax_tm);
+    init_regexp_timeout(p_rdt);
 #endif
 #ifdef FEAT_FOLDING
     win_foldinfo.fi_level = 0;
@@ -2695,7 +2694,7 @@ win_update(win_T *wp)
     }
 
 #ifdef SYN_TIME_LIMIT
-    syn_set_timeout(NULL);
+    disable_regexp_timeout();
 #endif
 
     // Reset the type of redrawing required, the window has been updated.

--- a/src/errors.h
+++ b/src/errors.h
@@ -3288,3 +3288,15 @@ EXTERN char e_bitshift_ops_must_be_postive[]
 EXTERN char e_argument_1_list_item_nr_dictionary_required[]
 	INIT(= N_("E1284: Argument 1, list item %d: Dictionary required"));
 #endif
+#ifdef FEAT_RELTIME
+EXTERN char e_could_not_clear_timeout[]
+	INIT(= N_("E1284: Could not disarm timeout: %s"));
+EXTERN char e_could_not_set_timeout[]
+	INIT(= N_("E1285: Could not set timeout: %s"));
+EXTERN char e_could_not_set_timeout_handler[]
+	INIT(= N_("E1286: Could not set handler for timeout: %s"));
+EXTERN char e_could_not_reset_timeout_handler[]
+	INIT(= N_("E1287: Could not reset handler for timeout: %s"));
+EXTERN char e_could_not_check_pending_sigal[]
+	INIT(= N_("E1288: Could not check for pending SIGALM: %s"));
+#endif

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8439,7 +8439,6 @@ search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
     int		retval = 0;	// default: FAIL
     long	lnum_stop = 0;
 #ifdef FEAT_RELTIME
-    proftime_T	tm;
     long	time_limit = 0;
 #endif
     int		options = SEARCH_KEEP;
@@ -8486,11 +8485,6 @@ search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
 	}
     }
 
-#ifdef FEAT_RELTIME
-    // Set the time limit, if there is one.
-    profile_setlimit(time_limit, &tm);
-#endif
-
     /*
      * This function does not accept SP_REPEAT and SP_RETCOUNT flags.
      * Check to make sure only those flags are set.
@@ -8509,7 +8503,7 @@ search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
     CLEAR_FIELD(sia);
     sia.sa_stop_lnum = (linenr_T)lnum_stop;
 #ifdef FEAT_RELTIME
-    sia.sa_tm = &tm;
+    sia.sa_tm = time_limit;
 #endif
 
     // Repeat until {skip} returns FALSE.
@@ -8955,18 +8949,10 @@ do_searchpair(
     int		use_skip = FALSE;
     int		err;
     int		options = SEARCH_KEEP;
-#ifdef FEAT_RELTIME
-    proftime_T	tm;
-#endif
 
     // Make 'cpoptions' empty, the 'l' flag should not be used here.
     save_cpo = p_cpo;
     p_cpo = empty_option;
-
-#ifdef FEAT_RELTIME
-    // Set the time limit, if there is one.
-    profile_setlimit(time_limit, &tm);
-#endif
 
     // Make two search patterns: start/end (pat2, for in nested pairs) and
     // start/middle/end (pat3, for the top pair).
@@ -8998,7 +8984,7 @@ do_searchpair(
 	CLEAR_FIELD(sia);
 	sia.sa_stop_lnum = lnum_stop;
 #ifdef FEAT_RELTIME
-	sia.sa_tm = &tm;
+	sia.sa_tm = time_limit;
 #endif
 	n = searchit(curwin, curbuf, &pos, NULL, dir, pat, 1L,
 						     options, RE_SEARCH, &sia);

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4006,7 +4006,7 @@ ex_substitute(exarg_T *eap)
 		); ++lnum)
     {
 	nmatch = vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
-						       (colnr_T)0, NULL, NULL);
+						       (colnr_T)0, NULL);
 	if (nmatch)
 	{
 	    colnr_T	copycol;
@@ -4663,7 +4663,7 @@ skip:
 			|| nmatch_tl > 0
 			|| (nmatch = vim_regexec_multi(&regmatch, curwin,
 							curbuf, sub_firstlnum,
-						    matchcol, NULL, NULL)) == 0
+						    matchcol, NULL)) == 0
 			|| regmatch.startpos[0].lnum > 0)
 		{
 		    if (new_start != NULL)
@@ -4728,7 +4728,7 @@ skip:
 		    }
 		    if (nmatch == -1 && !lastone)
 			nmatch = vim_regexec_multi(&regmatch, curwin, curbuf,
-					  sub_firstlnum, matchcol, NULL, NULL);
+					  sub_firstlnum, matchcol, NULL);
 
 		    /*
 		     * 5. break if there isn't another match in this line
@@ -4992,7 +4992,7 @@ ex_global(exarg_T *eap)
     {
 	lnum = curwin->w_cursor.lnum;
 	match = vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
-						       (colnr_T)0, NULL, NULL);
+						       (colnr_T)0, NULL);
 	if ((type == 'g' && match) || (type == 'v' && !match))
 	    global_exe_one(cmd, lnum);
     }
@@ -5005,7 +5005,7 @@ ex_global(exarg_T *eap)
 	{
 	    // a match on this line?
 	    match = vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
-						       (colnr_T)0, NULL, NULL);
+						       (colnr_T)0, NULL);
 	    if (regmatch.regprog == NULL)
 		break;  // re-compiling regprog failed
 	    if ((type == 'g' && match) || (type == 'v' && !match))

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -417,7 +417,6 @@ may_do_incsearch_highlighting(
     int		found;  // do_search() result
     pos_T	end_pos;
 #ifdef FEAT_RELTIME
-    proftime_T	tm;
     searchit_arg_T sia;
 #endif
     int		next_char;
@@ -484,10 +483,6 @@ may_do_incsearch_highlighting(
 	cursor_off();	// so the user knows we're busy
 	out_flush();
 	++emsg_off;	// so it doesn't beep if bad expr
-#ifdef FEAT_RELTIME
-	// Set the time limit to half a second.
-	profile_setlimit(500L, &tm);
-#endif
 	if (!p_hls)
 	    search_flags += SEARCH_KEEP;
 	if (search_first_line != 0)
@@ -495,7 +490,8 @@ may_do_incsearch_highlighting(
 	ccline.cmdbuff[skiplen + patlen] = NUL;
 #ifdef FEAT_RELTIME
 	CLEAR_FIELD(sia);
-	sia.sa_tm = &tm;
+	// Set the time limit to half a second.
+	sia.sa_tm = 500;
 #endif
 	found = do_search(NULL, firstc == ':' ? '/' : firstc, search_delim,
 				 ccline.cmdbuff + skiplen, count, search_flags,

--- a/src/match.c
+++ b/src/match.c
@@ -493,13 +493,7 @@ next_search_hl(
 				&& cur->match.regprog == cur->hl.rm.regprog);
 
 	    nmatched = vim_regexec_multi(&shl->rm, win, shl->buf, lnum,
-		    matchcol,
-#ifdef FEAT_RELTIME
-		    &timed_out
-#else
-		    NULL, NULL
-#endif
-		    );
+		    matchcol, &timed_out);
 	    // Copy the regprog, in case it got freed and recompiled.
 	    if (regprog_is_copy)
 		cur->match.regprog = cur->hl.rm.regprog;

--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -6,6 +6,9 @@
  * Do ":help credits" in Vim to see a list of people who contributed.
  */
 
+#ifndef OS_MAC__H
+#define OS_MAC__H
+
 // Before Including the MacOS specific files,
 // let's set the OPAQUE_TOOLBOX_STRUCTS to 0 so we
 // can access the internal structures.
@@ -266,3 +269,52 @@
 
 // A Mac constant causing big problem to syntax highlighting
 #define UNKNOWN_CREATOR '\?\?\?\?'
+
+#ifdef FEAT_RELTIME
+
+# include <dispatch/dispatch.h>
+
+# if !defined(MAC_OS_X_VERSION_10_12) || \
+	(MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12)
+typedef int clockid_t;
+# endif
+# ifndef CLOCK_REALTIME
+#   define CLOCK_REALTIME 0
+# endif
+# ifndef CLOCK_MONOTONIC
+#   define CLOCK_MONOTONIC 1
+# endif
+
+struct itimerspec
+{
+    struct timespec it_interval;  /* timer period */
+    struct timespec it_value;	  /* initial expiration */
+};
+
+struct sigevent;
+
+struct macos_timer
+{
+    dispatch_queue_t tim_queue;
+    dispatch_source_t tim_timer;
+    void (*tim_func)(union sigval);
+    void *tim_arg;
+};
+
+typedef struct macos_timer *timer_t;
+
+extern int timer_create(
+    clockid_t clockid,
+    struct sigevent *sevp,
+    timer_t *timerid);
+
+extern int timer_delete(timer_t timerid);
+
+extern int timer_settime(
+    timer_t timerid, int flags,
+    const struct itimerspec *new_value,
+    struct itimerspec *unused);
+
+#endif /* FEAT_RELTIME */
+
+#endif /* OS_MAC__H */

--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -23,6 +23,13 @@
  * X11 header files. */
 #define NO_X11_INCLUDES
 
+#include <stdbool.h>
+#include <mach/boolean.h>
+#include <sys/errno.h>
+#include <stdlib.h>
+
+#include <dispatch/dispatch.h>
+
 #include "vim.h"
 #import <AppKit/AppKit.h>
 
@@ -207,6 +214,173 @@ releasepool:
 }
 
 #endif /* FEAT_CLIPBOARD */
+
+#ifdef FEAT_RELTIME
+/*
+ * The following timer code is based on a Gist by Jorgen Lundman:
+ *
+ *     https://gist.github.com/lundman
+ */
+
+typedef struct macos_timer macos_timer_T;
+
+    static void
+_timer_cancel(void *arg)
+{
+    // This is not currently used, but it might be useful in the future and
+    // it is non-trivial enough to provide as usable implementation.
+#   if 0
+    macos_timer_T *timerid = (macos_timer_T *)arg;
+
+    dispatch_release(timerid->tim_timer);
+    dispatch_release(timerid->tim_queue);
+    timerid->tim_timer = NULL;
+    timerid->tim_queue = NULL;
+    free(timerid);
+#   endif
+}
+
+    static void
+_timer_handler(void *arg)
+{
+    macos_timer_T *timerid = (macos_timer_T *)arg;
+    union sigval sv;
+
+    sv.sival_ptr = timerid->tim_arg;
+
+    if (timerid->tim_func != NULL)
+	timerid->tim_func(sv);
+}
+
+    static uint64_t
+itime_to_ns(const struct timespec *it)
+{
+    time_t   sec  = it->tv_sec;
+    long     nsec = it->tv_nsec;
+    uint64_t ns   = NSEC_PER_SEC * sec + nsec;
+
+    return ns == 0 ? DISPATCH_TIME_FOREVER : ns;
+}
+
+/*
+ * A partial emulation of the POSIX timer_create function.
+ *
+ * The limitations and differences include:
+ *
+ * - Only CLOCK_REALTIME and CLOCK_MONOTONIC are supported as clockid
+ *   values.
+ * - Even if CLOCK_REALTIME is specified, internally the mach_absolute_time
+ *   source is used internally.
+ * - The only notification method supported is SIGEV_THREAD.
+ */
+    inline int
+timer_create(clockid_t clockid, struct sigevent *sevp, timer_t *timerid)
+{
+    macos_timer_T *timer = NULL;
+
+    // We only support real time and monotonic clocks; and SIGEV_THREAD
+    // notification. In practice, there is no difference between the two
+    // types of clocks on MacOS - we always use the mach_machine_time
+    // source.
+    if (   (clockid != CLOCK_REALTIME && clockid != CLOCK_MONOTONIC)
+        || sevp->sigev_notify != SIGEV_THREAD)
+    {
+	semsg("clockid: %d %d", clockid, CLOCK_REALTIME);
+	semsg("notify:  %d %d", sevp->sigev_notify, SIGEV_THREAD);
+	errno = ENOTSUP;
+	return -1;
+    }
+
+    timer = (macos_timer_T *)malloc(sizeof(macos_timer_T));
+    if (timer == NULL)
+    {
+	errno = ENOMEM;
+	return -1;
+    }
+    *timerid = timer;
+
+    timer->tim_queue = dispatch_queue_create(
+	    "org.vim.timerqueue", NULL);
+    if (timer->tim_queue == NULL)
+    {
+	errno = ENOMEM;
+	return -1;
+    }
+
+    timer->tim_timer = dispatch_source_create(
+	    DISPATCH_SOURCE_TYPE_TIMER, 0, 0, timer->tim_queue);
+    if (timer->tim_timer == NULL)
+    {
+	errno = ENOMEM;
+	return -1;
+    }
+
+    timer->tim_func = sevp->sigev_notify_function;
+    timer->tim_arg = sevp->sigev_value.sival_ptr;
+
+    dispatch_set_context(timer->tim_timer, timer);
+    dispatch_source_set_event_handler_f(timer->tim_timer, _timer_handler);
+    dispatch_source_set_cancel_handler_f(timer->tim_timer, _timer_cancel);
+
+    dispatch_resume(timer->tim_timer);
+
+    return 0;
+}
+
+/*
+ * A partial emulation of the POSIX timer_settime function.
+ *
+ * The limitations and differences include:
+ *
+ * - The flags argument is ignored. The supplied new_value is therfore
+ *   always treated as a relative time.
+ * - The old_value argument is ignored.
+ */
+    int
+timer_settime(
+    timer_t timerid, int unused_flags, 
+    const struct itimerspec *new_value, struct itimerspec *old_value)
+{
+    uint64_t first_shot = itime_to_ns(&new_value->it_value);
+
+    if (timerid == NULL)
+	return 0;
+
+    if (first_shot == DISPATCH_TIME_FOREVER)
+    {
+	dispatch_source_set_timer(
+	    timerid->tim_timer, first_shot, first_shot, 0);
+    }
+    else
+    {
+	uint64_t interval = itime_to_ns(&new_value->it_interval);
+
+	dispatch_time_t start = dispatch_time(DISPATCH_TIME_NOW, first_shot);
+	dispatch_source_set_timer(timerid->tim_timer, start, interval, 0);
+    }
+
+    return 0;
+}
+
+/*
+ * An emulation of the POSIX timer_delete function.
+ *
+ * Disabled because it is not currently used, but an implemented provided
+ * for completeness and possible future use.
+ */
+#if 0
+    int
+timer_delete(timer_t timerid)
+{
+    /* Calls _timer_cancel() */
+    if (timerid != NULL)
+	dispatch_source_cancel(timerid->tim_timer);
+
+    return 0;
+}
+#endif
+
+#endif /* FEAT_RELTIME */
 
 /* Lift the compiler warning suppression. */
 #if defined(__clang__) && defined(__STRICT_ANSI__)

--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -225,7 +225,7 @@ releasepool:
 typedef struct macos_timer macos_timer_T;
 
     static void
-_timer_cancel(void *arg)
+_timer_cancel(void *arg UNUSED)
 {
     // This is not currently used, but it might be useful in the future and
     // it is non-trivial enough to provide as usable implementation.
@@ -338,8 +338,10 @@ timer_create(clockid_t clockid, struct sigevent *sevp, timer_t *timerid)
  */
     int
 timer_settime(
-    timer_t timerid, int unused_flags, 
-    const struct itimerspec *new_value, struct itimerspec *old_value)
+    timer_t timerid,
+    int unused_flags UNUSED,
+    const struct itimerspec *new_value,
+    struct itimerspec *old_value UNUSED)
 {
     uint64_t first_shot = itime_to_ns(&new_value->it_value);
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -8276,7 +8276,7 @@ static int timer_created = FALSE;
  * Callback for when the timer expires.
  */
     static void
-set_flag(union sigval _unused)
+set_flag(union sigval _unused UNUSED)
 {
     timeout_flag = TRUE;
 }

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -8330,12 +8330,14 @@ static int      timer_active        = FALSE;
  */
 static int      timeout_flags[2];
 static int      flag_idx = 0;
+static int      *timeout_flag = &timeout_flags[0];
 
-    static void
+
+    static void CALLBACK
 set_flag(void *param, BOOLEAN unused2)
 {
     int *timeout_flag = (int *)param;
-    *timeout_flag = 1;
+    *timeout_flag = TRUE;
 }
 
 /*
@@ -8353,6 +8355,7 @@ stop_timeout(void)
 	    semsg(_(e_could_not_clear_timeout), GetWin32Error());
 	}
     }
+    *timeout_flag = FALSE;
 }
 
 /*
@@ -8373,7 +8376,7 @@ start_timeout(long msec)
 {
     UINT interval = (UINT)msec;
     BOOL ret;
-    int *timeout_flag = &timeout_flags[flag_idx];
+    timeout_flag = &timeout_flags[flag_idx];
 
     stop_timeout();
     ret = CreateTimerQueueTimer(
@@ -8387,7 +8390,7 @@ start_timeout(long msec)
     {
 	flag_idx = (flag_idx + 1) % 2;
 	timer_active = TRUE;
-	*timeout_flag = 0;
+	*timeout_flag = FALSE;
     }
     return timeout_flag;
 }

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -86,4 +86,6 @@ int xsmp_handle_requests(void);
 void xsmp_init(void);
 void xsmp_close(void);
 int gpm_available(void);
+void stop_timeout(void);
+const int *start_timeout(long msec);
 /* vim: set ft=c : */

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -84,4 +84,6 @@ int is_conpty_stable(void);
 int get_conpty_fix_type(void);
 void resize_console_buf(void);
 char * GetWin32Error(void);
+void stop_timeout(void);
+const int *start_timeout(long msec);
 /* vim: set ft=c : */

--- a/src/proto/regexp.pro
+++ b/src/proto/regexp.pro
@@ -1,4 +1,6 @@
 /* regexp.c */
+void init_regexp_timeout(long msec);
+void disable_regexp_timeout(void);
 int re_multiline(regprog_T *prog);
 char_u *skip_regexp(char_u *startp, int delim, int magic);
 char_u *skip_regexp_err(char_u *startp, int delim, int magic);
@@ -18,5 +20,5 @@ int regprog_in_use(regprog_T *prog);
 int vim_regexec_prog(regprog_T **prog, int ignore_case, char_u *line, colnr_T col);
 int vim_regexec(regmatch_T *rmp, char_u *line, colnr_T col);
 int vim_regexec_nl(regmatch_T *rmp, char_u *line, colnr_T col);
-long vim_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, colnr_T col, proftime_T *tm, int *timed_out);
+long vim_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, colnr_T col, int *timed_out);
 /* vim: set ft=c : */

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5990,7 +5990,7 @@ vgr_match_buflines(
 	{
 	    // Regular expression match
 	    while (vim_regexec_multi(regmatch, curwin, buf, lnum,
-			col, NULL, NULL) > 0)
+			col, NULL) > 0)
 	    {
 		// Pass the buffer number so that it gets used even for a
 		// dummy buffer, unless duplicate_name is set, then the

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -20,6 +20,11 @@
 # define BT_REGEXP_DEBUG_LOG_NAME	"bt_regexp_debug.log"
 #endif
 
+#ifdef FEAT_RELTIME
+static int dummy_timeout_flag = 0;
+static const int *timeout_flag = &dummy_timeout_flag;
+#endif
+
 /*
  * Magic characters have a special meaning, they don't match literally.
  * Magic characters are negative.  This separates them from literal characters
@@ -44,6 +49,20 @@ toggle_Magic(int x)
 	return un_Magic(x);
     return Magic(x);
 }
+
+#ifdef FEAT_RELTIME
+    void
+init_regexp_timeout(long msec)
+{
+    timeout_flag = start_timeout(msec);
+}
+
+    void
+disable_regexp_timeout(void)
+{
+    stop_timeout();
+}
+#endif
 
 /*
  * The first byte of the BT regexp internal "program" is actually this magic
@@ -2905,7 +2924,6 @@ vim_regexec_multi(
     buf_T       *buf,		// buffer in which to search
     linenr_T	lnum,		// nr of line to start looking for match
     colnr_T	col,		// column to start looking for match
-    proftime_T	*tm,		// timeout limit or NULL
     int		*timed_out)	// flag is set when timeout limit reached
 {
     int		result;
@@ -2926,7 +2944,7 @@ vim_regexec_multi(
     rex_in_use = TRUE;
 
     result = rmp->regprog->engine->regexec_multi(
-				      rmp, win, buf, lnum, col, tm, timed_out);
+				      rmp, win, buf, lnum, col, timed_out);
     rmp->regprog->re_in_use = FALSE;
 
     // NFA engine aborted because it's very slow.
@@ -2966,7 +2984,7 @@ vim_regexec_multi(
 
 		rmp->regprog->re_in_use = TRUE;
 		result = rmp->regprog->engine->regexec_multi(
-				      rmp, win, buf, lnum, col, tm, timed_out);
+				      rmp, win, buf, lnum, col, timed_out);
 		rmp->regprog->re_in_use = FALSE;
 	    }
 	    vim_free(pat);

--- a/src/regexp.h
+++ b/src/regexp.h
@@ -173,7 +173,7 @@ struct regengine
     // bt_regexec_nl or nfa_regexec_nl
     int		(*regexec_nl)(regmatch_T *, char_u *, colnr_T, int);
     // bt_regexec_mult or nfa_regexec_mult
-    long	(*regexec_multi)(regmmatch_T *, win_T *, buf_T *, linenr_T, colnr_T, proftime_T *, int *);
+    long	(*regexec_multi)(regmmatch_T *, win_T *, buf_T *, linenr_T, colnr_T, int *);
     //char_u	*expr;
 };
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -1760,10 +1760,6 @@ start_search_hl(void)
 	end_search_hl();  // just in case it wasn't called before
 	last_pat_prog(&screen_search_hl.rm);
 	screen_search_hl.attr = HL_ATTR(HLF_L);
-# ifdef FEAT_RELTIME
-	// Set the time limit to 'redrawtime'.
-	profile_setlimit(p_rdt, &screen_search_hl.tm);
-# endif
     }
 }
 
@@ -5029,4 +5025,3 @@ set_chars_option(win_T *wp, char_u **varp)
 
     return NULL;	// no error
 }
-

--- a/src/search.c
+++ b/src/search.c
@@ -658,14 +658,8 @@ searchit(
     int		break_loop = FALSE;
 #endif
     linenr_T	stop_lnum = 0;	// stop after this line number when != 0
-
-#   ifdef FEAT_RELTIME
-    static int       unused_timeout_flag = FALSE;
-    int	             *timed_out = &unused_timeout_flag;  // set when timed out.
-#   else
-    static const int unused_timeout_flag = FALSE;
-    const int	     *timed_out = &unused_timeout_flag;
-#   endif
+    static int  unused_timeout_flag = FALSE;
+    int	        *timed_out = &unused_timeout_flag;  // set when timed out.
 
     if (search_regcomp(pat, RE_SEARCH, pat_use,
 		   (options & (SEARCH_HIS + SEARCH_KEEP)), &regmatch) == FAIL)

--- a/src/search.c
+++ b/src/search.c
@@ -767,7 +767,8 @@ searchit(
 		 */
 		col = at_first_line && (options & SEARCH_COL) ? pos->col
 								 : (colnr_T)0;
-		nmatched = vim_regexec_multi(&regmatch, win, buf, lnum, col, timed_out);
+		nmatched = vim_regexec_multi(&regmatch, win, buf,
+					     lnum, col, timed_out);
 		// vim_regexec_multi() may clear "regprog"
 		if (regmatch.regprog == NULL)
 		    break;
@@ -1075,7 +1076,7 @@ searchit(
 	     * twice.
 	     */
 	    if (!p_ws || stop_lnum != 0 || got_int
-					    || called_emsg > called_emsg_before || *timed_out
+			        || called_emsg > called_emsg_before || *timed_out
 #ifdef FEAT_SEARCH_EXTRA
 				|| break_loop
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -658,8 +658,8 @@ searchit(
     int		break_loop = FALSE;
 #endif
     linenr_T	stop_lnum = 0;	// stop after this line number when != 0
-    static int  unused_timeout_flag = FALSE;
-    int	        *timed_out = &unused_timeout_flag;  // set when timed out.
+    int		unused_timeout_flag = FALSE;
+    int		*timed_out = &unused_timeout_flag;  // set when timed out.
 
     if (search_regcomp(pat, RE_SEARCH, pat_use,
 		   (options & (SEARCH_HIS + SEARCH_KEEP)), &regmatch) == FAIL)
@@ -674,8 +674,10 @@ searchit(
 	stop_lnum = extra_arg->sa_stop_lnum;
 #ifdef FEAT_RELTIME
 	if (extra_arg->sa_tm > 0)
+	{
 	    init_regexp_timeout(extra_arg->sa_tm);
-	timed_out = &extra_arg->sa_timed_out;
+	    timed_out = &extra_arg->sa_timed_out;
+	}
 #endif
     }
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -3329,9 +3329,6 @@ typedef struct
 			    // matchaddpos(). TRUE/FALSE
     char	has_cursor; // TRUE if the cursor is inside the match, used for
 			    // CurSearch
-#ifdef FEAT_RELTIME
-    proftime_T	tm;	    // for a time limit
-#endif
 } match_T;
 
 // number of positions supported by matchaddpos()
@@ -4419,7 +4416,7 @@ typedef struct
 {
     linenr_T	sa_stop_lnum;	// stop after this line number when != 0
 #ifdef FEAT_RELTIME
-    proftime_T	*sa_tm;		// timeout limit or NULL
+    long	sa_tm;		// timeout limit or zero
     int		sa_timed_out;	// set when timed out
 #endif
     int		sa_wrapped;	// search wrapped around

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -266,9 +266,6 @@ static reg_extmatch_T *next_match_extmatch = NULL;
 static win_T	*syn_win;		// current window for highlighting
 static buf_T	*syn_buf;		// current buffer for highlighting
 static synblock_T *syn_block;		// current buffer for highlighting
-#ifdef FEAT_RELTIME
-static proftime_T *syn_tm;		// timeout limit
-#endif
 static linenr_T current_lnum = 0;	// lnum of current state
 static colnr_T	current_col = 0;	// column of current state
 static int	current_state_stored = 0; // TRUE if stored current state
@@ -349,18 +346,6 @@ static void init_syn_patterns(void);
 static char_u *get_syn_pattern(char_u *arg, synpat_T *ci);
 static int get_id_list(char_u **arg, int keylen, short **list, int skip);
 static void syn_combine_list(short **clstr1, short **clstr2, int list_op);
-
-#if defined(FEAT_RELTIME) || defined(PROTO)
-/*
- * Set the timeout used for syntax highlighting.
- * Use NULL to reset, no timeout.
- */
-    void
-syn_set_timeout(proftime_T *tm)
-{
-    syn_tm = tm;
-}
-#endif
 
 /*
  * Start the syntax recognition for a line.  This function is normally called
@@ -3185,9 +3170,9 @@ syn_regexec(
     rmp->rmm_maxcol = syn_buf->b_p_smc;
     r = vim_regexec_multi(rmp, syn_win, syn_buf, lnum, col,
 #ifdef FEAT_RELTIME
-	    syn_tm, &timed_out
+	    &timed_out
 #else
-	    NULL, NULL
+	    NULL
 #endif
 	    );
 

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -3151,9 +3151,7 @@ syn_regexec(
     syn_time_T  *st UNUSED)
 {
     int r;
-#ifdef FEAT_RELTIME
     int timed_out = FALSE;
-#endif
 #ifdef FEAT_PROFILE
     proftime_T	pt;
 
@@ -3168,13 +3166,7 @@ syn_regexec(
 	return FALSE;
 
     rmp->rmm_maxcol = syn_buf->b_p_smc;
-    r = vim_regexec_multi(rmp, syn_win, syn_buf, lnum, col,
-#ifdef FEAT_RELTIME
-	    &timed_out
-#else
-	    NULL
-#endif
-	    );
+    r = vim_regexec_multi(rmp, syn_win, syn_buf, lnum, col, &timed_out);
 
 #ifdef FEAT_PROFILE
     if (syn_time_on)

--- a/src/testdir/test_hlsearch.vim
+++ b/src/testdir/test_hlsearch.vim
@@ -37,6 +37,15 @@ endfunc
 func Test_hlsearch_hangs()
   CheckFunction reltimefloat
 
+  " So, it turns out the Windows 7 implements TimerQueue timers differently
+  " and they can expire *before* the requested time has elapsed. So allow for
+  " the timeout occurring after 80 ms (5 * 16 (the typical clock tick)).
+  if has("win32")
+    let min_timeout = 0.08
+  else
+    let min_timeout = 0.1
+  endif
+
   " This pattern takes a long time to match, it should timeout.
   new
   call setline(1, ['aaa', repeat('abc ', 1000), 'ccc'])
@@ -45,7 +54,7 @@ func Test_hlsearch_hangs()
   let @/ = '\%#=1a*.*X\@<=b*'
   redraw
   let elapsed = reltimefloat(reltime(start))
-  call assert_true(elapsed > 0.1)
+  call assert_true(elapsed > min_timeout)
   call assert_true(elapsed < 1.0)
   set nohlsearch redrawtime&
   bwipe!

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -1554,7 +1554,7 @@ func Test_search_timeout()
   new
   let pattern = '\%#=1a*.*X\@<=b*'
   let search_timeout = 0.02
-  let slow_target_timeout = search_timeout * 10.0
+  let slow_target_timeout = search_timeout * 15.0
 
   for n in range(40, 400, 30)
       call setline(1, ['aaa', repeat('abc ', n), 'ccc'])

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -1550,6 +1550,28 @@ func Test_search_errors()
   bwipe!
 endfunc
 
+func Test_search_timeout()
+  new
+  let pattern = '\%#=1a*.*X\@<=b*'
+
+  for n in range(40, 400, 30)
+      call setline(1, ['aaa', repeat('abc ', n), 'ccc'])
+      let start = reltime()
+      call search(pattern, '', 0)
+      let elapsed = reltimefloat(reltime(start))
+      if elapsed > 0.1
+          break
+      endif
+  endfor
+  call assert_true(elapsed > 0.1)
+
+  let start = reltime()
+  call search(pattern, '', 0, 10)
+  let elapsed = reltimefloat(reltime(start))
+  call assert_true(elapsed < 0.05)
+  bwipe!
+endfunc
+
 func Test_search_display_pattern()
   new
   call setline(1, ['foo', 'bar', 'foobar'])

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -1553,22 +1553,26 @@ endfunc
 func Test_search_timeout()
   new
   let pattern = '\%#=1a*.*X\@<=b*'
+  let search_timeout = 0.02
+  let slow_target_timeout = search_timeout * 10.0
 
   for n in range(40, 400, 30)
       call setline(1, ['aaa', repeat('abc ', n), 'ccc'])
       let start = reltime()
       call search(pattern, '', 0)
       let elapsed = reltimefloat(reltime(start))
-      if elapsed > 0.1
+      if elapsed > slow_target_timeout
           break
       endif
   endfor
-  call assert_true(elapsed > 0.1)
+  call assert_true(elapsed > slow_target_timeout)
 
+  let max_time = elapsed / 2.0
   let start = reltime()
-  call search(pattern, '', 0, 10)
+  call search(pattern, '', 0, float2nr(search_timeout * 1000))
   let elapsed = reltimefloat(reltime(start))
-  call assert_true(elapsed < 0.05)
+  call assert_true(elapsed < max_time)
+
   bwipe!
 endfunc
 

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -527,6 +527,15 @@ func Test_syntax_hangs()
   CheckFunction reltimefloat
   CheckFeature syntax
 
+  " So, it turns out the Windows 7 implements TimerQueue timers differently
+  " and they can expire *before* the requested time has elapsed. So allow for
+  " the timeout occurring after 80 ms (5 * 16 (the typical clock tick)).
+  if has("win32")
+    let min_timeout = 0.08
+  else
+    let min_timeout = 0.1
+  endif
+
   " This pattern takes a long time to match, it should timeout.
   new
   call setline(1, ['aaa', repeat('abc ', 1000), 'ccc'])
@@ -535,7 +544,7 @@ func Test_syntax_hangs()
   syn match Error /\%#=1a*.*X\@<=b*/
   redraw
   let elapsed = reltimefloat(reltime(start))
-  call assert_true(elapsed > 0.1)
+  call assert_true(elapsed > min_timeout)
   call assert_true(elapsed < 1.0)
 
   " second time syntax HL is disabled
@@ -549,7 +558,7 @@ func Test_syntax_hangs()
   exe "normal \<C-L>"
   redraw
   let elapsed = reltimefloat(reltime(start))
-  call assert_true(elapsed > 0.1)
+  call assert_true(elapsed > min_timeout)
   call assert_true(elapsed < 1.0)
 
   set redrawtime&
@@ -642,7 +651,7 @@ func Test_syntax_c()
 	\ "\tNote: asdf",
 	\ '}',
 	\ ], 'Xtest.c')
- 
+
   " This makes the default for 'background' use "dark", check that the
   " response to t_RB corrects it to "light".
   let $COLORFGBG = '15;0'


### PR DESCRIPTION
FYI: Use of OS timers to timeout syntax highlighting and searching.

Removes the need to regularly read any system timers while executing the RE engine.