### PR TITLE
MANPAGER: make buffer nomodifiable and hide line numbers

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -642,15 +642,15 @@ manpages and follows linked manpages on hitting CTRL-]).
 
 For bash,zsh,ksh or dash, add to the config file (.bashrc,.zshrc, ...)
 
-	export MANPAGER="vim -M +MANPAGER -"
+	export MANPAGER="vim +MANPAGER --not-a-term -"
 
 For (t)csh, add to the config file
 
-	setenv MANPAGER "vim -M +MANPAGER -"
+	setenv MANPAGER "vim +MANPAGER --not-a-term -"
 
 For fish, add to the config file
 
-	set -x MANPAGER "vim -M +MANPAGER -"
+	set -x MANPAGER "vim +MANPAGER --not-a-term -"
 
 
 MARKDOWN                                                *ft-markdown-plugin*

--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -1,8 +1,9 @@
 " Vim plugin for using Vim as manpager.
 " Maintainer: Enno Nagel <ennonagel+vim@gmail.com>
-" Last Change: 2022 Jun 05
+" Last Change: 2022 Jun 07
 
-command! -nargs=0 MANPAGER call s:ManPager() | delcommand MANPAGER
+" Set up the current buffer (likely read from stdin) as a manpage
+command MANPAGER call s:ManPager()
 
 function s:ManPager()
   " global options, keep these to a minimum to avoid side effects
@@ -12,11 +13,16 @@ function s:ManPager()
   if exists('+viminfofile')
     set viminfofile=NONE
   endif
-  set noswapfile 
+  syntax on
 
-  setlocal ft=man
-  runtime ftplugin/man.vim
-  setlocal buftype=nofile bufhidden=hide iskeyword+=: modifiable
+  " Make this an unlisted, readonly scratch buffer
+  setlocal buftype=nofile noswapfile bufhidden=hide nobuflisted readonly
+
+  " Ensure text width matches window width
+  setlocal foldcolumn& nofoldenable nonumber norelativenumber
+
+  " In case Vim was invoked with -M
+  setlocal modifiable
 
   " Emulate 'col -b'
   silent! keepj keepp %s/\v(.)\b\ze\1?//ge
@@ -30,7 +36,11 @@ function s:ManPager()
   if n > 1
     exe "1," . n-1 . "d"
   endif
-  setlocal nomodifiable nomodified readonly nowrite
 
-  syntax on
+  " Finished preprocessing the buffer, prevent any further modifications
+  setlocal nomodified nomodifiable
+
+  " Set filetype to man even if ftplugin is disabled
+  setlocal iskeyword+=: filetype=man
+  runtime ftplugin/man.vim
 endfunction


### PR DESCRIPTION
The current version has a bug where it doesn't matter whether you invoke `vim -M` because it does `setl modifiable`. This fixes that, and makes a bunch of other options the same as what you get if you do `:Man`; most notably, disabling line numbering so that the preformatted text from `man` doesn't wrap at every line.

Also some general cleanup for clarity and updating docs to suggest `--not-a-term` so that the "Reading from stdin..." message is hidden, which is more in line with plain `man`.