### PR TITLE
Update ex_cmds.c

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4480,8 +4480,18 @@ ex_substitute(exarg_T *eap)
 		    nmatch_tl += nmatch - 1;
 		}
 		copy_len = regmatch.startpos[0].col - copycol;
-		needed_len = copy_len + ((unsigned)STRLEN(p1)
+
+		/*
+		 * Make sure needed_len always greater than copy_len
+		 */
+		if((unsigned)STRLEN(p1) == 0)	{
+			needed_len = copy_len + sublen + 1;
+		}		
+		else {
+			needed_len = copy_len + ((unsigned)STRLEN(p1)
 				       - regmatch.endpos[0].col) + sublen + 1;
+		}
+
 		if (new_start == NULL)
 		{
 		    /*

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4484,7 +4484,7 @@ ex_substitute(exarg_T *eap)
 		/*
 		 * Make sure needed_len always greater than copy_len
 		 */
-		if((unsigned)STRLEN(p1) == 0)	{
+		if(*p1 == 0)	{
 			needed_len = copy_len + sublen + 1;
 		}		
 		else {


### PR DESCRIPTION
Update length check before doing `mch_memmove()` in `ex_substitute()` function at ex_cmds.c to prevent heap-based buffer overflow.