### PR TITLE
Add a test for what patch 8.1.0052 fixes

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -3458,8 +3458,8 @@ vgetorpeek(int advance)
  * get a character: 3. from the user - get it
  */
 		if (typebuf.tb_len == 0)
-		    // timedout may have been set while waiting for a mapping
-		    // that has a <Nop> RHS.
+		    // timedout may have been set if a mapping with empty RHS
+		    // fully matched while longer mappings timed out.
 		    timedout = FALSE;
 
 		if (advance)

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -1685,4 +1685,34 @@ func Test_expr_map_escape_special()
   nunmap …
 endfunc
 
+" Testing for mapping after an <Nop> mapping is triggered on timeout.
+" Test for what patch 8.1.0052 fixes.
+func Test_map_after_timed_out_nop()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set timeout timeoutlen=400
+    inoremap ab TEST
+    inoremap a <Nop>
+  END
+  call writefile(lines, 'Xtest_map_after_timed_out_nop')
+  let buf = RunVimInTerminal('-S Xtest_map_after_timed_out_nop', #{rows: 6})
+
+  " Enter Insert mode
+  call term_sendkeys(buf, 'i')
+  " Wait for the "a" mapping to timeout
+  call term_sendkeys(buf, 'a')
+  call term_wait(buf, 500)
+  " Send "a" and wait for a period shorter than 'timeoutlen'
+  call term_sendkeys(buf, 'a')
+  call term_wait(buf, 100)
+  " Send "b", should trigger the "ab" mapping
+  call term_sendkeys(buf, 'b')
+  call WaitForAssert({-> assert_equal("TEST", term_getline(buf, 1))})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_map_after_timed_out_nop')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
While it is not easy to write a test for the original bug, it is still
possible to write a test that fails without that patch.

Also make the the comment clearer about what is happening.