### PR TITLE
Reduce branches related to cmod_verbose

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3089,12 +3089,10 @@ parse_command_modifiers(
 			    break;
 			if (vim_isdigit(*eap->cmd))
 			{
-			    cmod->cmod_verbose = atoi((char *)eap->cmd);
-			    if (cmod->cmod_verbose == 0)
-				cmod->cmod_verbose = -1;
+			    cmod->cmod_verbose = atoi((char *)eap->cmd) + 1;
 			}
 			else
-			    cmod->cmod_verbose = 1;
+			    cmod->cmod_verbose = 2;  // 1 + 1
 			eap->cmd = p;
 			continue;
 	}
@@ -3182,11 +3180,11 @@ apply_cmdmod(cmdmod_T *cmod)
 	cmod->cmod_did_sandbox = TRUE;
     }
 #endif
-    if (cmod->cmod_verbose != 0)
+    if (cmod->cmod_verbose > 0)
     {
 	if (cmod->cmod_verbose_save == 0)
 	    cmod->cmod_verbose_save = p_verbose + 1;
-	p_verbose = cmod->cmod_verbose < 0 ? 0 : cmod->cmod_verbose;
+	p_verbose = cmod->cmod_verbose - 1;
     }
 
     if ((cmod->cmod_flags & (CMOD_SILENT | CMOD_UNSILENT))

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -256,7 +256,6 @@ do_incsearch_highlighting(
     ea.cmd = ccline.cmdbuff;
     ea.addr_type = ADDR_LINES;
 
-    CLEAR_FIELD(dummy_cmdmod);
     parse_command_modifiers(&ea, &dummy, &dummy_cmdmod, TRUE);
 
     cmd = skip_range(ea.cmd, TRUE, NULL);

--- a/src/globals.h
+++ b/src/globals.h
@@ -1291,7 +1291,7 @@ EXTERN pos_T	last_cursormoved	      // for CursorMoved event
 
 EXTERN int	postponed_split INIT(= 0);  // for CTRL-W CTRL-] command
 EXTERN int	postponed_split_flags INIT(= 0);  // args for win_split()
-EXTERN int	postponed_split_tab INIT(= 0);  // cmdmod.tab
+EXTERN int	postponed_split_tab INIT(= 0);  // cmdmod.cmod_tab
 #ifdef FEAT_QUICKFIX
 EXTERN int	g_do_tagpreview INIT(= 0);  // for tag preview commands:
 					    // height of preview window

--- a/src/structs.h
+++ b/src/structs.h
@@ -662,8 +662,8 @@ typedef struct
     regmatch_T	cmod_filter_regmatch;	// set by :filter /pat/
     int		cmod_filter_force;	// set for :filter!
 
-    int		cmod_verbose;		// non-zero to set 'verbose', -1 is
-					// used for zero override
+    int		cmod_verbose;		// > 0 to set 'verbose' to
+					// value of cmod_verbose - 1
 
     // values for undo_cmdmod()
     char_u	*cmod_save_ei;		// saved value of 'eventignore'


### PR DESCRIPTION
Use it more similarly to cmod_verbose_save: add 1 to the value.

parse_command_modifiers already calls CLEAR_POINTER, so the CLEAR_FIELD
in ex_getln.c isn't necessary.