### PR TITLE
:test_override instead of :call test_override

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1222,7 +1222,7 @@ func Test_terminal_qall_prompt()
   let buf = RunVimInTerminal('', {})
 
   " the shell may set the window title, we don't want that here
-  call term_sendkeys(buf, ":test_override('vterm_title', 1)\<CR>")
+  call term_sendkeys(buf, ":call test_override('vterm_title', 1)\<CR>")
 
   " Open a terminal window and wait for the prompt to appear
   call term_sendkeys(buf, ":term\<CR>")


### PR DESCRIPTION
found here: https://github.com/vim/vim/issues/10530
Fix error in 99f4b6e -- it does :test_override instead of :call test_override.