### PR TITLE
win32: clientserver: Check timeout when sending a message 

### DIFF
--- a/runtime/pack/dist/opt/editexisting/plugin/editexisting.vim
+++ b/runtime/pack/dist/opt/editexisting/plugin/editexisting.vim
@@ -35,32 +35,36 @@ func s:EditElsewhere(filename)
     endif
 
     " Check if this server is editing our file.
-    if remote_expr(servername, "bufloaded('" . fname_esc . "')")
-      " Yes, bring it to the foreground.
-      if has("win32")
-	call remote_foreground(servername)
-      endif
-      call remote_expr(servername, "foreground()")
-
-      if remote_expr(servername, "exists('*EditExisting')")
-	" Make sure the file is visible in a window (not hidden).
-	" If v:swapcommand exists and is set, send it to the server.
-	if exists("v:swapcommand")
-	  let c = substitute(v:swapcommand, "'", "''", "g")
-	  call remote_expr(servername, "EditExisting('" . fname_esc . "', '" . c . "')")
-	else
-	  call remote_expr(servername, "EditExisting('" . fname_esc . "', '')")
+    try
+      if remote_expr(servername, "bufloaded('" . fname_esc . "')")
+	" Yes, bring it to the foreground.
+	if has("win32")
+	  call remote_foreground(servername)
 	endif
-      endif
+	call remote_expr(servername, "foreground()")
 
-      if !(has('vim_starting') && has('gui_running') && has('gui_win32'))
-	" Tell the user what is happening.  Not when the GUI is starting
-	" though, it would result in a message box.
-	echomsg "File is being edited by " . servername
-	sleep 2
+	if remote_expr(servername, "exists('*EditExisting')")
+	  " Make sure the file is visible in a window (not hidden).
+	  " If v:swapcommand exists and is set, send it to the server.
+	  if exists("v:swapcommand")
+	    let c = substitute(v:swapcommand, "'", "''", "g")
+	    call remote_expr(servername, "EditExisting('" . fname_esc . "', '" . c . "')")
+	  else
+	    call remote_expr(servername, "EditExisting('" . fname_esc . "', '')")
+	  endif
+	endif
+
+	if !(has('vim_starting') && has('gui_running') && has('gui_win32'))
+	  " Tell the user what is happening.  Not when the GUI is starting
+	  " though, it would result in a message box.
+	  echomsg "File is being edited by " . servername
+	  sleep 2
+	endif
+	return 'q'
       endif
-      return 'q'
-    endif
+    catch /^Vim\%((\a\+)\)\=:E241:/
+      " Unable to send to this server. Ignore it.
+    endtry
   endwhile
   return ''
 endfunc


### PR DESCRIPTION
In the following situation, vim hangs:

1. Debug vim on a debugger, or vim hangs because of any bugs.
2. Try to open a file with another vim with the editexisting plugin installed.
    E.g.: `gvim --cmd "packadd! editexisting" foo.txt`
3. editexisting tries to send a message via `remote_expr()` to the first vim, but the function doesn't return because no timeouts.

The first commit uses `SendMessageTimeout()` instead of `SendMessage()` and set the timeout to 5 sec.
After this commit, the hangup doesn't happen (vim stops only 5 sec), but the following message is shown.
![image](https://user-images.githubusercontent.com/840186/174285288-55cf468c-d180-4fb9-9801-e0293a38fa94.png)

I think this can be ignored. So, the second commit fixed this.

I'm still thinking whether the 5 sec timeout is enough.
Additionally, `:help remote_expr()` says that the default timeout is 600 sec, but I found that the default is infinite on Windows.