### PR TITLE
xxd: Add -n[ame] option to set the variable name used with -i

### DIFF
--- a/runtime/doc/xxd.1
+++ b/runtime/doc/xxd.1
@@ -113,6 +113,10 @@ Stop after writing
 .RI  < len >
 octets.
 .TP
+.I "\-n name " | " \-name name"
+Override the variable name output when \-i is used. The array is named
+\fIname\fP and the length is named \fIname\fP_len.
+.TP
 .I \-o offset
 Add
 .RI < offset >

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -219,6 +219,40 @@ func Test_xxd()
     call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
   endfor
 
+  " Test 17: Print C include with custom variable name
+  let s:test += 1
+  for arg in ['-nvarName', '-n varName', '-name varName']
+    call writefile(['TESTabcd09'], 'XXDfile')
+    %d
+    exe '0r! ' . s:xxd_cmd . ' -i ' . arg . ' XXDfile'
+    $d
+    let expected =<< trim [CODE]
+      unsigned char varName[] = {
+        0x54, 0x45, 0x53, 0x54, 0x61, 0x62, 0x63, 0x64, 0x30, 0x39, 0x0a
+      };
+      unsigned int varName_len = 11;
+    [CODE]
+  
+    call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
+  endfor
+
+  " Test 18: Print C include: custom variable names can be capitalized
+  let s:test += 1
+  for arg in ['-C', '-capitalize']
+    call writefile(['TESTabcd09'], 'XXDfile')
+    %d
+    exe '0r! ' . s:xxd_cmd . ' -i ' . arg . ' -n varName XXDfile'
+    $d
+    let expected =<< trim [CODE]
+      unsigned char VARNAME[] = {
+        0x54, 0x45, 0x53, 0x54, 0x61, 0x62, 0x63, 0x64, 0x30, 0x39, 0x0a
+      };
+      unsigned int VARNAME_LEN = 11;
+    [CODE]
+    call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
+  endfor
+
+
   %d
   bwipe!
   call delete('XXDfile')

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -55,6 +55,7 @@
  * 11.01.2019  Add full 64/32 bit range to -o and output by Christer Jensen.
  * 04.02.2020  Add -d for decimal offsets by Aapo Rantalainen
  * 14.01.2022  Disable extra newlines with -c0 -p by Erik Auerswald.
+ * 20.06.2022  Permit setting the variable names used by -i by David Gow
  *
  * (c) 1990-1998 by Juergen Weigert (jnweiger@gmail.com)
  *
@@ -226,6 +227,7 @@ exit_with_usage(void)
   fprintf(stderr, "    -h          print this summary.\n");
   fprintf(stderr, "    -i          output in C include file style.\n");
   fprintf(stderr, "    -l len      stop after <len> octets.\n");
+  fprintf(stderr, "    -n name     set the variable name used in C include output (-i).\n");
   fprintf(stderr, "    -o off      add <off> to the displayed file position.\n");
   fprintf(stderr, "    -ps         output in postscript plain hexdump style.\n");
   fprintf(stderr, "    -r          reverse operation: convert (or patch) hexdump into binary.\n");
@@ -497,6 +499,7 @@ main(int argc, char *argv[])
   unsigned long displayoff = 0;
   static char l[LLEN+1];  /* static because it may be too big for stack */
   char *pp;
+  char *varname = NULL;
   int addrlen = 9;
 
 #ifdef AMIGA
@@ -635,6 +638,19 @@ main(int argc, char *argv[])
 	      argc--;
 	    }
 	}
+      else if (!STRNCMP(pp, "-n", 2))
+        {
+          if (pp[2] && STRNCMP("ame", pp + 2, 3))
+            varname = pp + 2;
+          else
+            {
+              if (!argv[2])
+                exit_with_usage();
+              varname = argv[2];
+              argv++;
+              argc--;
+            }
+        }
       else if (!strcmp(pp, "--"))	/* end of options */
 	{
 	  argv++;
@@ -753,10 +769,16 @@ main(int argc, char *argv[])
 
   if (hextype == HEX_CINCLUDE)
     {
-      if (fp != stdin)
+      /* A user-set variable name overrides fp == stdin */
+      int have_varname = (varname || fp != stdin);
+
+      if (!varname)
+        varname = argv[1];
+
+      if (have_varname)
 	{
 	  FPRINTF_OR_DIE((fpo, "unsigned char %s", isdigit((int)argv[1][0]) ? "__" : ""));
-	  for (e = 0; (c = argv[1][e]) != 0; e++)
+	  for (e = 0; (c = varname[e]) != 0; e++)
 	    putc_or_die(isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
 	  fputs_or_die("[] = {\n", fpo);
 	}
@@ -776,8 +798,8 @@ main(int argc, char *argv[])
       if (fp != stdin)
 	{
 	  fputs_or_die("};\n", fpo);
-	  FPRINTF_OR_DIE((fpo, "unsigned int %s", isdigit((int)argv[1][0]) ? "__" : ""));
-	  for (e = 0; (c = argv[1][e]) != 0; e++)
+	  FPRINTF_OR_DIE((fpo, "unsigned int %s", isdigit((int)varname[0]) ? "__" : ""));
+	  for (e = 0; (c = varname[e]) != 0; e++)
 	    putc_or_die(isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
 	  FPRINTF_OR_DIE((fpo, "_%s = %d;\n", capitalize ? "LEN" : "len", p));
 	}


### PR DESCRIPTION
At present, ``xxd -i`` will always create an output file either with no variables (if stdin is used as input), or with variables with names
based on the input filename/path. In particular:
- An array of bytes with the name of the input file (with special characters removed), and
- An integer length of the output.

It'd be very convenient to allow overriding these names (or providing them at all in the case of stdin), particularly since they're based on the exact argument passed to xxd, which may be an absolute path. (No one would want to have to access variables based on the absolute path name in their code!)

This patch adds a ``-n`` option, which accepts a new variable name as an argument. This variable name is used for the data, and ``_len`` is appended to it for the length variable. Both still have special characters stripped and replaced with '_', and are capitalised if ``-C`` is used.

For example:
```
xxd -i -n myvar ~/data.dat
```
produces the following variables:
- ``unsigned char myvar[]``
- ``unsigned int myvar_len``
instead of something like:
- ``unsigned char _home_david_data_dat``
- ``unsigned int _home_david_data_dat_len``