### PR TITLE
getchar(2) waits for character without moving the cursor

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3272,6 +3272,8 @@ getchar([expr])						*getchar()*
 			Return zero otherwise.
 		If [expr] is 1, only check if a character is available, it is
 			not consumed.  Return zero if no character available.
+		If [expr] is 2, wait until a character is available without
+			moving the cursor.
 		If you prefer always getting a string use |getcharstr()|.
 
 		Without [expr] and when [expr] is 0 a whole character or
@@ -3408,6 +3410,8 @@ getcharstr([expr])					*getcharstr()*
 		If [expr] is 1 or true, only check if a character is
 			available, it is not consumed.  Return an empty string
 			if no character is available.
+		If [expr] is 2, wait until a character is available without
+			moving the cursor.
 		Otherwise this works like |getchar()|, except that a number
 		result is converted to a string.
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -3300,3 +3300,7 @@ EXTERN char e_could_not_reset_handler_for_timeout_str[]
 EXTERN char e_could_not_check_for_pending_sigalrm_str[]
 	INIT(= N_("E1289: Could not check for pending SIGALRM: %s"));
 #endif
+#ifdef FEAT_EVAL
+EXTERN char e_bool_or_number_required_for_argument_nr[]
+	INIT(= N_("E1290: Bool or Number required for argument %d"));
+#endif

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2057,7 +2057,7 @@ getchar_common(typval_T *argvars, typval_T *rettv)
     varnumber_T		n;
     varnumber_T		arg = -1;
 
-    if (in_vim9script() && check_for_opt_bool_arg(argvars, 0) == FAIL)
+    if (in_vim9script() && check_for_opt_bool_or_number_arg(argvars, 0) == FAIL)
 	return;
 
 #ifdef MESSAGE_QUEUE

--- a/src/proto/typval.pro
+++ b/src/proto/typval.pro
@@ -18,6 +18,8 @@ int check_for_opt_number_arg(typval_T *args, int idx);
 int check_for_float_or_nr_arg(typval_T *args, int idx);
 int check_for_bool_arg(typval_T *args, int idx);
 int check_for_opt_bool_arg(typval_T *args, int idx);
+int check_for_bool_or_number_arg(typval_T *args, int idx);
+int check_for_opt_bool_or_number_arg(typval_T *args, int idx);
 int check_for_blob_arg(typval_T *args, int idx);
 int check_for_list_arg(typval_T *args, int idx);
 int check_for_opt_list_arg(typval_T *args, int idx);

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -1683,8 +1683,7 @@ def Test_getchar()
   endwhile
   getchar(true)->assert_equal(0)
   getchar(1)->assert_equal(0)
-  v9.CheckDefAndScriptFailure(['getchar(2)'], ['E1013: Argument 1: type mismatch, expected bool but got number', 'E1212: Bool required for argument 1'])
-  v9.CheckDefAndScriptFailure(['getchar("1")'], ['E1013: Argument 1: type mismatch, expected bool but got string', 'E1212: Bool required for argument 1'])
+  v9.CheckDefAndScriptFailure(['getchar("1")'], ['E1013: Argument 1: type mismatch, expected bool but got string', 'E1290: Bool or Number required for argument 1'])
 enddef
 
 def Test_getcharpos()

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -1695,8 +1695,7 @@ def Test_getcharpos()
 enddef
 
 def Test_getcharstr()
-  v9.CheckDefAndScriptFailure(['getcharstr(2)'], ['E1013: Argument 1: type mismatch, expected bool but got number', 'E1212: Bool required for argument 1'])
-  v9.CheckDefAndScriptFailure(['getcharstr("1")'], ['E1013: Argument 1: type mismatch, expected bool but got string', 'E1212: Bool required for argument 1'])
+  v9.CheckDefAndScriptFailure(['getcharstr("1")'], ['E1013: Argument 1: type mismatch, expected bool but got string', 'E1290: Bool or Number required for argument 1'])
 enddef
 
 def Test_getcompletion()

--- a/src/typval.c
+++ b/src/typval.c
@@ -481,6 +481,32 @@ check_for_opt_bool_arg(typval_T *args, int idx)
 }
 
 /*
+ * Give an error and return FAIL unless "args[idx]" is a bool or
+ * a number.
+ */
+    int
+check_for_bool_or_number_arg(typval_T *args, int idx)
+{
+    if (args[idx].v_type != VAR_BOOL && args[idx].v_type != VAR_NUMBER)
+    {
+	semsg(_(e_bool_or_number_required_for_argument_nr), idx + 1);
+	return FAIL;
+    }
+    return OK;
+}
+
+/*
+ * Check for an optional bool or number argument at 'idx'.
+ */
+    int
+check_for_opt_bool_or_number_arg(typval_T *args, int idx)
+{
+    return (args[idx].v_type == VAR_UNKNOWN
+	    || check_for_bool_or_number_arg(args, idx) != FAIL);
+}
+
+
+/*
  * Give an error and return FAIL unless "args[idx]" is a blob.
  */
     int


### PR DESCRIPTION
`getchar()` is useful for mapping dynamic key sequences, but the downside is that it moves the cursor to the command line when waiting for input. If the action depends on where the cursor is, you can lose the visual feedback on where you're about to make an edit. `getchar(2)` behaves just like `getchar()`, but bypasses the move of the cursor.