### PR TITLE
Fixed make uninstall - to remove all installed files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2871,6 +2871,7 @@ uninstall_runtime:
 	-rm -f $(SYS_FTPLUGOF_FILE) $(SYS_FTPLUGIN_FILE)
 	-rm -f $(SYS_OPTWIN_FILE)
 	-rm -f $(DEST_COL)/*.vim $(DEST_COL)/README.txt
+	-rm -rf $(DEST_COL)/lists
 	-rm -rf $(DEST_COL)/tools
 	-rm -f $(DEST_SYN)/*.vim $(DEST_SYN)/README.txt
 	-rm -f $(DEST_IND)/*.vim $(DEST_IND)/README.txt


### PR DESCRIPTION
When running "make uninstall" files are left at {--prefix}/share/vim/vim{version}/colors/lists

The below will remove these files.
