### PR TITLE
Added Python runtime syntax soft keywords

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -95,8 +95,8 @@ syn keyword pythonAsync		async await
 " See https://peps.python.org/pep-0634/#the-match-statement for more on this.
 " In Python 3.10's IDLE for example, 'match' and 'case' are only highlighted
 " when in the right context
-syn match   pythonConditional   "\v^\s*case(.*:$)@="
-syn match   pythonConditional   "\v^\s*match(.*:$)@="
+syn match   pythonConditional   "\v^\s*case(.*:\s*$)@="
+syn match   pythonConditional   "\v^\s*match(.*:\s*$)@="
 
 " Decorators
 " A dot must be allowed because of @MyClass.myfunc decorators.

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2021 Dec 10
+" Last Change:	2022 Jun 25
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "
@@ -84,12 +84,19 @@ syn keyword pythonStatement	as assert break continue del global
 syn keyword pythonStatement	lambda nonlocal pass return with yield
 syn keyword pythonStatement	class def nextgroup=pythonFunction skipwhite
 syn keyword pythonConditional	elif else if
-syn keyword pythonConditional	case match
 syn keyword pythonRepeat	for while
 syn keyword pythonOperator	and in is not or
 syn keyword pythonException	except finally raise try
 syn keyword pythonInclude	from import
 syn keyword pythonAsync		async await
+
+" Soft keywords
+" These keywords do not mean anything unless used in the right context
+" See https://peps.python.org/pep-0634/#the-match-statement for more on this.
+" In Python 3.10's IDLE for example, 'match' and 'case' are only highlighted
+" when in the right context
+syn match   pythonConditional   "\v^\s*case(.*:$)@="
+syn match   pythonConditional   "\v^\s*match(.*:$)@="
 
 " Decorators
 " A dot must be allowed because of @MyClass.myfunc decorators.

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -94,8 +94,8 @@ syn keyword pythonAsync		async await
 " These keywords do not mean anything unless used in the right context
 " See https://docs.python.org/3/reference/lexical_analysis.html#soft-keywords 
 " for more on this.
-syn match   pythonConditional   "^\s*\zscase\%(\s.*:.*$\)\@="
-syn match   pythonConditional   "^\s*\zsmatch\%(\s.*:\s*\%(#.*\)\?$\)\@="
+syn match   pythonConditional   "^\s*\zscase\%(\s\+.*:.*$\)\@="
+syn match   pythonConditional   "^\s*\zsmatch\%(\s\+.*:\s*\%(#.*\)\=$\)\@="
 
 " Decorators
 " A dot must be allowed because of @MyClass.myfunc decorators.

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -92,11 +92,10 @@ syn keyword pythonAsync		async await
 
 " Soft keywords
 " These keywords do not mean anything unless used in the right context
-" See https://peps.python.org/pep-0634/#the-match-statement for more on this.
-" In Python 3.10's IDLE for example, 'match' and 'case' are only highlighted
-" when in the right context
-syn match   pythonConditional   "\v^\s*case(.*:\s*$)@="
-syn match   pythonConditional   "\v^\s*match(.*:\s*$)@="
+" See https://docs.python.org/3/reference/lexical_analysis.html#soft-keywords 
+" for more on this.
+syn match   pythonConditional   "^\s*\zscase\%(\s.*:.*$\)\@="
+syn match   pythonConditional   "^\s*\zsmatch\%(\s.*:\s*\%(#.*\)\?$\)\@="
 
 " Decorators
 " A dot must be allowed because of @MyClass.myfunc decorators.


### PR DESCRIPTION
## Problem
In Python's current syntax highlighting, the words `match` and `case` are always highlighted, which could give the wrong idea about their usage. `match` and `case` are only given special meaning when used in a specific context, so it would be misleading to highlight them under the same conditions of `if` and `else`.

## Fix
Added `match` and `case` as soft keywords, as described [here](https://peps.python.org/pep-0634/#the-match-statement). Modeled after Python 3.10's own IDLE behavior when dealing with soft keywords.

I contacted the maintainer of the file about this pull request.