### PR TITLE
Linker error with Python 3.11

### DIFF
--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -692,7 +692,12 @@ py3__PyObject_TypeCheck(PyObject *ob, PyTypeObject *type)
 {
     return Py_IS_TYPE(ob, type) || PyType_IsSubtype(Py_TYPE(ob), type);
 }
-#  define _PyObject_TypeCheck(o,t) py3__PyObject_TypeCheck(o,t)
+#  if PY_VERSION_HEX >= 0x030b00b3
+#   undef PyObject_TypeCheck
+#   define PyObject_TypeCheck(o,t) py3__PyObject_TypeCheck(o,t)
+#  else
+#   define _PyObject_TypeCheck(o,t) py3__PyObject_TypeCheck(o,t)
+#  endif
 # endif
 
 # ifdef MSWIN


### PR DESCRIPTION
Problem: Linker error with dynamic Python 3.11, because
_PyObject_TypeCheck is no longer available in Python3.11

Solution: Undefine PyObject_TypeCheck() from Python3.11 and define it
internally in Vim if Python is 3.11.0.b3 or higher.

OS: Fedora 37
Vim: 8.2.5167

How to reproduce:
1. ./configure --enable-python3interp=dynamic --enable-gui=no --with-features=Huge
2. make