### PR TITLE
feat: enable matchit for html tags in vue files

### DIFF
--- a/runtime/ftplugin/vue.vim
+++ b/runtime/ftplugin/vue.vim
@@ -1,0 +1,15 @@
+" Vim filetype plugin file
+" Language:	vue
+
+if exists("b:did_ftplugin") | finish | endif
+let b:did_ftplugin = 1
+
+" Copied from ftplugin/html.vim
+" Original thanks to Johannes Zellner and Benji Fisher.
+if exists("loaded_matchit")
+    let b:match_ignorecase = 1
+    let b:match_words = '<:>,' .
+    \ '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' .
+    \ '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' .
+    \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+endif


### PR DESCRIPTION
Problem:
In vue files `%` key (mapped to matchit) is not working for html tags
because of missing `b:match_words` value

Solution:
- Create `runtime/ftplugin/vue.vim` file.
- Copy `b:match_words` value from `runtime/ftplugin/html.vim`