### PR TITLE
Skip Test_timer_peek_and_get_char() less often

### DIFF
--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -298,8 +298,9 @@ func Interrupt(timer)
 endfunc
 
 func Test_timer_peek_and_get_char()
-  CheckUnix
-  CheckGui
+  if !has('unix') && !has('gui_running')
+    throw 'Skipped: cannot feed low-level input'
+  endif
 
   call timer_start(0, 'FeedAndPeek')
   let intr = timer_start(100, 'Interrupt')
@@ -310,7 +311,7 @@ endfunc
 
 func Test_timer_getchar_zero()
   if has('win32') && !has('gui_running')
-    throw 'Skipped: cannot get low-level input'
+    throw 'Skipped: cannot feed low-level input'
   endif
   CheckFunction reltimefloat
 


### PR DESCRIPTION
Patch 8.1.1826 skips this test in more cases. This reverts that change.
