### PR TITLE
Add a way to know if <expr> mapping is triggered on timeout

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2544,6 +2544,10 @@ v:testing	Must be set before using `test_garbagecollect_now()`.
 		Also, when set certain error messages won't be shown for 2
 		seconds. (e.g. "'dictionary' option is empty")
 
+					*v:timedout* *timedout-variable*
+v:timedout	Set to |TRUE| when inside an <expr> mapping triggered on
+		timeout and |FALSE| otherwise.
+
 				*v:this_session* *this_session-variable*
 v:this_session	Full filename of the last loaded or saved session file.  See
 		|:mksession|.  It is allowed to set this variable.  When no

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -283,6 +283,9 @@ For abbreviations |v:char| is set to the character that was typed to trigger
 the abbreviation.  You can use this to decide how to expand the {lhs}.  You
 should not either insert or change the v:char.
 
+For mappings |v:timedout| is set to |TRUE| if the mapping the triggered on
+timeout and |FALSE| otherwise.
+
 In case you want the mapping to not do anything, you can have the expression
 evaluate to an empty string.  If something changed that requires Vim to
 go through the main loop (e.g. to update the display), return "\<Ignore>".

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -144,6 +144,7 @@ static struct vimvar
     {VV_NAME("termu7resp",	 VAR_STRING), NULL, VV_RO},
     {VV_NAME("termstyleresp",	 VAR_STRING), NULL, VV_RO},
     {VV_NAME("termblinkresp",	 VAR_STRING), NULL, VV_RO},
+    {VV_NAME("timedout",	 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("event",		 VAR_DICT), NULL, VV_RO},
     {VV_NAME("versionlong",	 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("echospace",	 VAR_NUMBER), NULL, VV_RO},

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2877,7 +2877,7 @@ handle_mapping(
 	    may_garbage_collect = FALSE;
 
 	    save_m_keys = vim_strsave(mp->m_keys);
-	    map_str = eval_map_expr(mp, NUL);
+	    map_str = eval_map_expr(mp, NUL, *timedout);
 
 	    // The mapping may do anything, but we expect it to take care of
 	    // redrawing.  Do put the cursor back where it was.

--- a/src/map.c
+++ b/src/map.c
@@ -1641,7 +1641,7 @@ check_abbr(
 	    expr = mp->m_expr;
 
 	    if (expr)
-		s = eval_map_expr(mp, c);
+		s = eval_map_expr(mp, c, FALSE);
 	    else
 #endif
 		s = mp->m_str;
@@ -1678,7 +1678,8 @@ check_abbr(
     char_u *
 eval_map_expr(
     mapblock_T	*mp,
-    int		c)	    // NUL or typed character for abbreviation
+    int		c,	    // NUL or typed character for abbreviation
+    int		timedout)   // whether mapping is triggered on timeout
 {
     char_u	*res;
     char_u	*p;
@@ -1701,6 +1702,7 @@ eval_map_expr(
     ++textlock;
     ++ex_normal_lock;
     set_vim_var_char(c);  // set v:char to the typed character
+    set_vim_var_nr(VV_TIMEDOUT, timedout);
     save_cursor = curwin->w_cursor;
     save_msg_col = msg_col;
     save_msg_row = msg_row;
@@ -1713,6 +1715,7 @@ eval_map_expr(
     // Note: the evaluation may make "mp" invalid.
     p = eval_to_string(expr, FALSE);
 
+    set_vim_var_nr(VV_TIMEDOUT, FALSE);
     --textlock;
     --ex_normal_lock;
     curwin->w_cursor = save_cursor;

--- a/src/proto/map.pro
+++ b/src/proto/map.pro
@@ -10,7 +10,7 @@ int map_to_exists_mode(char_u *rhs, int mode, int abbr);
 char_u *set_context_in_map_cmd(expand_T *xp, char_u *cmd, char_u *arg, int forceit, int isabbrev, int isunmap, cmdidx_T cmdidx);
 int ExpandMappings(char_u *pat, regmatch_T *regmatch, int *numMatches, char_u ***matches);
 int check_abbr(int c, char_u *ptr, int col, int mincol);
-char_u *eval_map_expr(mapblock_T *mp, int c);
+char_u *eval_map_expr(mapblock_T *mp, int c, int timedout);
 char_u *vim_strsave_escape_csi(char_u *p);
 void vim_unescape_csi(char_u *p);
 int makemap(FILE *fd, buf_T *buf);

--- a/src/vim.h
+++ b/src/vim.h
@@ -2078,18 +2078,19 @@ typedef int sock_T;
 #define VV_TERMU7RESP	90
 #define VV_TERMSTYLERESP 91
 #define VV_TERMBLINKRESP 92
-#define VV_EVENT	93
-#define VV_VERSIONLONG	94
-#define VV_ECHOSPACE	95
-#define VV_ARGV		96
-#define VV_COLLATE      97
-#define VV_EXITING	98
-#define VV_COLORNAMES   99
-#define VV_SIZEOFINT	100
-#define VV_SIZEOFLONG	101
-#define VV_SIZEOFPOINTER 102
-#define VV_MAXCOL	103
-#define VV_LEN		104	// number of v: vars
+#define VV_TIMEDOUT	93
+#define VV_EVENT	94
+#define VV_VERSIONLONG	95
+#define VV_ECHOSPACE	96
+#define VV_ARGV		97
+#define VV_COLLATE	98
+#define VV_EXITING	99
+#define VV_COLORNAMES	100
+#define VV_SIZEOFINT	101
+#define VV_SIZEOFLONG	102
+#define VV_SIZEOFPOINTER 103
+#define VV_MAXCOL	104
+#define VV_LEN		105	// number of v: vars
 
 // used for v_number in VAR_BOOL and VAR_SPECIAL
 #define VVAL_FALSE	0L	// VAR_BOOL


### PR DESCRIPTION
I've currently chosen `v:timedout` as the name, as this name may be reused for other timeout-related things in future.
