### PR TITLE
Problem: docs elide import semantics when used in vim9script vs legacy script

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -378,7 +378,14 @@ in a plugin using an autoload script: >
 	vim9script
 	import autoload 'implementation.vim' as impl
 	nnoremap <F4> <ScriptCmd>impl.DoTheWork()<CR>
-
+<
+It is also particularly helpful when referencing an imported vim9 function
+from a mapping in a legacy script: >
+	" without <ScriptCmd> using s: would result in
+	" E121: Undefined variable: s:impl
+	import 'implementation.vim' as impl
+	nnoremap <F4> <ScriptCmd>:call s:impl.DoTheWork()
+<
 No matter where <F4> is typed, the "impl" import will be found in the script
 context of where the mapping was defined.  And since it's an autoload import,
 the "implementation.vim" script will only be loaded once <F4> is typed, not

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1687,12 +1687,25 @@ be exported. {not implemented yet: class, interface}
 Import ~
 					*:import* *:imp* *E1094* *E1047* *E1262*
 					*E1048* *E1049* *E1053* *E1071* *E1236*
-The exported items can be imported in another Vim9 script: >
+The exported items can be imported in another script. The import syntax has
+two forms. The simple form: >
+	import {filename}
+<
+Where {filename} is an expression that must evaluate to a string.  In this
+form the filename must end in ".vim" and the portion before ".vim" will become
+the script local name of the namespace. For example: >
 	import "myscript.vim"
-
+<
 This makes each item available as "myscript.item".
 						*:import-as* *E1257* *E1261*
-In case the name is long or ambiguous, another name can be specified: >
+In case the name is long or ambiguous, another form can be used to specify
+another name: >
+	import {filename} as {name}
+<
+In this form you get to provide {name} as a specific script local name for the
+imported namespace.  Therefore {name} must consist of letters, digits and '_',
+like |internal-variables|.  The {filename} expression still must evaluate to a
+string but it can have any filename extension. For example: >
 	import "thatscript.vim" as that
 <						*E1060* *E1258* *E1259* *E1260*
 Then you can use "that.EXPORTED_CONST", "that.someValue", etc.  You are free
@@ -1713,15 +1726,6 @@ This also works for constants: >
 This does not work for variables, since the value would be copied once and
 when changing the variable the copy will change, not the original variable.
 You will need to use the full name, with the dot.
-
-The full syntax of the command is:
-	import {filename} [as {name}]
-Where {filename} is an expression that must evaluate to a string.  Without the
-"as {name}" part it must end in ".vim".  {name} must consist of letters,
-digits and '_', like |internal-variables|.
-
-`:import` can also be used in legacy Vim script.  The imported items still
-become script-local, even when the "s:" prefix is not given.
 
 `:import` can not be used in a function.  Imported items are intended to exist
 at the script level and only imported once.
@@ -1752,14 +1756,39 @@ line, there can be no line break: >
 	echo that
 		.name  # Error!
 
-To refer to a function in an imported script in a mapping, |<SID>| can be
-used: >
+When you've imported a function from one script into a vim9 script you can
+refer to the imported function in a mapping by prefixing it with |<SID>|: >
 	noremap <silent> ,a :call <SID>name.Function()<CR>
 
 When the mapping is defined "<SID>name." will be replaced with <SNR> and the
 script ID of the imported script.
 An even simpler solution is using |<ScriptCmd>|: >
 	noremap ,a <ScriptCmd>name.Function()<CR>
+<
+					    *import-legacy* *legacy-import*
+`:import` can also be used in legacy Vim script.  The imported namespace still
+becomes script-local, even when the "s:" prefix is not given. For example: >
+	" using default namespace naming rules, facilitated by conventional
+	" filename extension
+        import "myfile.vim"
+	call s:myfile.MyFunc()
+
+	" using explicit namespace name, required due to unconventional
+	" filename extension
+	import "otherfile.vim9script" as that
+	call s:that.OtherFunc()
+
+However the namespace cannot be resolved on it's own: >
+	" will result in E1060: Expected dot after name: s:that
+	import "that.vim"
+	echo s:that
+<
+This also affects the use of |<SID>| in the legacy mapping context.  Since |<SID>| is
+only a valid prefix for a function and NOT for a namespace, you cannot use it
+to scope a function in a script local namespace. Instead of prefixing the
+function with |<SID>| you should prefix the command with |<ScriptCmd>|. For
+example, in a legacy script: >
+	noremap ,a <ScriptCmd>:call s:that.OtherFunc()<CR>
 <
 							*:import-cycle*
 The `import` commands are executed when encountered.  If script A imports


### PR DESCRIPTION
Problem: docs elide import semantics when used in vim9script vs legacy script.
Solution: Provide clarifying examples.

This updates the documentation based on my experience as reported in https://github.com/vim/vim/issues/10656. I've condensed the import syntax explanation so the generic syntax and specific examples are closer together. I then moved the legacy import points to their own section with tags identifying the section. I've moved this below the exceptions to the main vim9script behavior in order to more clearly delineate what is specific to legacy imports.