### PR TITLE
gtk GUI: Fix Ctrl+[ (Belgian,German keyb. layout)

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -1160,6 +1160,7 @@ key_press_event(GtkWidget *widget UNUSED,
     int		key;
     guint	state;
     char_u	*s, *d;
+    int         ctrl_prefix_added = 0;
 
     gui.event_time = event->time;
     key_sym = event->keyval;
@@ -1245,6 +1246,20 @@ key_press_event(GtkWidget *widget UNUSED,
 	}
     }
 
+    // Belgian Ctrl+[ workaround
+    if (len == 0 && key_sym == GDK_KEY_dead_circumflex)
+    {
+	string[0] = CSI;
+	string[1] = KS_MODIFIER;
+	string[2] = MOD_MASK_CTRL;
+	string[3] = '[';
+	len = 4;
+	add_to_input_buf(string, len);
+	// workaround has to return here, otherwise our fake string[] entries
+	// are confusing code downstream
+	return TRUE;
+    }
+
     if (len == 0)   // Unrecognized key
 	return TRUE;
 
@@ -1288,6 +1303,8 @@ key_press_event(GtkWidget *widget UNUSED,
 	string2[1] = KS_MODIFIER;
 	string2[2] = modifiers;
 	add_to_input_buf(string2, 3);
+	if (modifiers == 0x4)
+	    ctrl_prefix_added = 1;
     }
 
     // Check if the key interrupts.
@@ -1302,6 +1319,15 @@ key_press_event(GtkWidget *widget UNUSED,
 	}
     }
 
+    // workaround for German keyboard, where instead of '[' char we have code
+    // sequence of bytes 195, 188 (UTF-8 for "u-umlaut")
+    if (ctrl_prefix_added && len == 2
+		    && ((int)string[0]) == 195
+		    && ((int)string[1]) == 188)
+    {
+	    string[0] = 91; // ASCII('[')
+	    len = 1;
+    }
     add_to_input_buf(string, len);
 
     // blank out the pointer if necessary


### PR DESCRIPTION
Problem: issue #10454 reported troubles with leaving insert mode on Belgian keyboard in GTK GUI. Handling of Ctrl+ü on German keyboard is lost over the time as well in GTK GUI.


This PR partly fixes issue #10454 (only GTK part of it, not Win32). Additionally it provides back missing Ctrl+ü handling on German keyboard (ü is on same place in german layout where [ is on english keyboard). Fix is probably not very nice and cannot be yet considered a final solution (?) but it seems to work. It was made possible due to the fact that Motif GUI still handles both Belgian and German CTRL+[ nicely. Tracing/comparing of the key codes feed to background Vim engine by Motif GUI and by GTK GUI via add_to_input_buf() was the key.