### PR TITLE
Make sure word list is cleared after each spell test

### DIFF
--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -14,6 +14,8 @@ func TearDown()
   call delete('Xtest.latin1.add.spl')
   call delete('Xtest.latin1.spl')
   call delete('Xtest.latin1.sug')
+  " set 'encoding' to clear the word list
+  set encoding=utf-8
 endfunc
 
 func Test_wrap_search()
@@ -781,6 +783,10 @@ func Test_zz_sal_and_addition()
   set spl=Xtest_ca.latin1.spl
   call assert_equal("elequint", FirstSpellWord())
   call assert_equal("elekwint", SecondSpellWord())
+
+  bwipe!
+  set spellfile=
+  set spl&
 endfunc
 
 func Test_spellfile_value()
@@ -864,9 +870,6 @@ func Test_spell_good_word_invalid()
   sil! norm z=
 
   bwipe!
-  " clear the internal word list
-  set enc=latin1
-  set enc=utf-8
 endfunc
 
 func LoadAffAndDic(aff_contents, dic_contents)

--- a/src/testdir/test_spell_utf8.vim
+++ b/src/testdir/test_spell_utf8.vim
@@ -13,6 +13,8 @@ func TearDown()
   call delete('Xtest.utf-8.add.spl')
   call delete('Xtest.utf-8.spl')
   call delete('Xtest.utf-8.sug')
+  " set 'encoding' to clear the word list
+  set encoding=utf-8
 endfunc
 
 let g:test_data_aff1 = [
@@ -484,7 +486,6 @@ let g:test_data_aff_sal = [
       \ ]
 
 func LoadAffAndDic(aff_contents, dic_contents)
-  set enc=utf-8
   set spellfile=
   call writefile(a:aff_contents, "Xtest.aff")
   call writefile(a:dic_contents, "Xtest.dic")
@@ -759,6 +760,7 @@ func Test_spell_sal_and_addition()
   call assert_equal("elequint", FirstSpellWord())
   call assert_equal("elekwint", SecondSpellWord())
 
+  bwipe!
   set spellfile=
   set spl&
 endfunc
@@ -802,8 +804,6 @@ func Test_word_index()
   sil norm z=
 
   bwipe!
-  " clear the word list
-  set enc=utf-8
   call delete('Xtmpfile')
 endfunc
 
@@ -816,7 +816,6 @@ func Test_check_empty_line()
   sil! norm P]svc
   norm P]s
 
-  " TODO: should we clear the word list?
   bwipe!
 endfunc
 


### PR DESCRIPTION
It is easy to forget to clear the word list at the end of a spell test,
for example in Test_spelldump(), which can interfere with future tests.
