### PR TITLE
Runtime: add better sway support as extension of i3config.vim

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -169,6 +169,7 @@ runtime/ftplugin/scss.vim		@tpope
 runtime/ftplugin/sdoc.vim		@gpanders
 runtime/ftplugin/solution.vim		@dkearns
 runtime/ftplugin/spec.vim		@ignatenkobrain
+runtime/ftplugin/swayconfig.vim		@jamespeapen
 runtime/ftplugin/systemverilog.vim	@Kocha
 runtime/ftplugin/tap.vim		@petdance
 runtime/ftplugin/tcsh.vim		@dkearns
@@ -387,6 +388,7 @@ runtime/syntax/sshconfig.vim		@Jakuje
 runtime/syntax/sshdconfig.vim		@Jakuje
 runtime/syntax/sudoers.vim		@e-kwsm
 runtime/syntax/svn.vim			@hdima
+runtime/syntax/swayconfig.vim       @jamespeapen
 runtime/syntax/systemverilog.vim	@Kocha
 runtime/syntax/tags.vim			@cecamp
 runtime/syntax/tap.vim			@petdance

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -853,9 +853,13 @@ au BufNewFile,BufRead *.hb			setf hb
 " Httest
 au BufNewFile,BufRead *.htt,*.htb		setf httest
 
-" i3 (and sway)
-au BufNewFile,BufRead */i3/config,*/sway/config		setf i3config
-au BufNewFile,BufRead */.i3/config,*/.sway/config	setf i3config
+" i3
+au BufNewFile,BufRead */i3/config		setf i3config
+au BufNewFile,BufRead */.i3/config  	setf i3config
+
+" sway
+au BufNewFile,BufRead */sway/config		setf swayconfig
+au BufNewFile,BufRead */.sway/config	setf swayconfig
 
 " Icon
 au BufNewFile,BufRead *.icn			setf icon

--- a/runtime/ftplugin/swayconfig.vim
+++ b/runtime/ftplugin/swayconfig.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin file
+" Language: sway config file
+" Original Author: James Eapen <james.eapen@vai.org>
+" Maintainer: James Eapen <james.eapen@vai.org>
+" Version: 0.1
+" Last Change: 2022 June 07
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let b:did_ftplugin = 1
+
+let b:undo_ftplugin = "setlocal cms<"
+
+setlocal commentstring=#\ %s

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -17,6 +17,9 @@ endif
 
 scriptencoding utf-8
 
+" Error
+syn match i3ConfigError /.*/
+
 " Todo
 syn keyword i3ConfigTodo TODO FIXME XXX contained
 
@@ -183,6 +186,7 @@ syn region i3ConfigBlock start=+^\s*[^#]*s\?{$+ end=+^\s*[^#]*}$+ contains=i3Con
 syn region i3ConfigLineCont start=/^.*\\$/ end=/^.*$/ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable transparent keepend extend
 
 " Define the highlighting.
+hi def link i3ConfigError                           Error
 hi def link i3ConfigTodo                            Todo
 hi def link i3ConfigComment                         Comment
 hi def link i3ConfigFontContent                     Type

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -54,8 +54,8 @@ syn match i3ConfigInclude /^\s*include\s\+.*$/ contains=i3ConfigIncludeKeyword,i
 " Gaps
 syn keyword i3ConfigGapStyleKeyword inner outer horizontal vertical top right bottom left current all set plus minus toggle up down contained
 syn match i3ConfigGapStyle /^\s*\(gaps\)\s\+\(inner\|outer\|horizontal\|vertical\|left\|top\|right\|bottom\)\(\s\+\(current\|all\)\)\?\(\s\+\(set\|plus\|minus\|toggle\)\)\?\(\s\+\(-\?\d\+\|\$.*\)\)$/ contains=i3ConfigGapStyleKeyword,i3ConfigNumber,i3ConfigVariable
-syn keyword i3ConfigSmartGapKeyword on inverse_outer contained
-syn match i3ConfigSmartGap /^\s*smart_gaps\s\+\(on\|inverse_outer\)\s\?$/ contains=i3ConfigSmartGapKeyword
+syn keyword i3ConfigSmartGapKeyword on inverse_outer off contained
+syn match i3ConfigSmartGap /^\s*smart_gaps\s\+\(on\|inverse_outer\|off\)\s\?$/ contains=i3ConfigSmartGapKeyword
 syn keyword i3ConfigSmartBorderKeyword on no_gaps contained
 syn match i3ConfigSmartBorder /^\s*smart_borders\s\+\(on\|no_gaps\)\s\?$/ contains=i3ConfigSmartBorderKeyword
 

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -213,6 +213,7 @@ hi def link i3ConfigTimeUnit                        Constant
 hi def link i3ConfigModifier                        Constant
 hi def link i3ConfigString                          Constant
 hi def link i3ConfigNegativeSize                    Constant
+hi def link i3ConfigInclude                         Constant
 hi def link i3ConfigFontSeparator                   Special
 hi def link i3ConfigVariableModifier                Special
 hi def link i3ConfigSizeSpecial                     Special

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -74,7 +74,7 @@ syn match i3ConfigBind /^\s*\(bindsym\|bindcode\)\s\+.*$/ contains=i3ConfigVaria
 syn keyword i3ConfigSizeSpecial x contained
 syn match i3ConfigNegativeSize /-/ contained
 syn match i3ConfigSize /-\?\d\+\s\?x\s\?-\?\d\+/ contained contains=i3ConfigSizeSpecial,i3ConfigNumber,i3ConfigNegativeSize
-syn match i3ConfigFloating /^\s*floating_modifier\s\+\$\w\+\d\?/ contains=i3ConfigVariable
+syn match i3ConfigFloatingModifier /^\s*floating_modifier\s\+\$\w\+\d\?/ contains=i3ConfigVariable
 syn match i3ConfigFloating /^\s*floating_\(maximum\|minimum\)_size\s\+-\?\d\+\s\?x\s\?-\?\d\+/ contains=i3ConfigSize
 
 " Orientation
@@ -233,6 +233,7 @@ hi def link i3ConfigLayout                          Identifier
 hi def link i3ConfigBorderStyle                     Identifier
 hi def link i3ConfigEdge                            Identifier
 hi def link i3ConfigFloating                        Identifier
+hi def link i3ConfigFloatingModifier                Identifier
 hi def link i3ConfigCommandKeyword                  Identifier
 hi def link i3ConfigNoFocusKeyword                  Identifier
 hi def link i3ConfigInitializeKeyword               Identifier

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -1,0 +1,92 @@
+" Vim syntax file
+" Language: sway window manager config
+" Original Author: James Eapen <james.eapen@vai.org>
+" Maintainer: James Eapen <james.eapen@vai.org>
+" Version: 0.11.0
+" Last Change: 2022 Jun 07
+
+" References:
+" http://i3wm.org/docs/userguide.html#configuring
+" https://github.com/swaywm/sway/blob/b69d637f7a34e239e48a4267ae94a5e7087b5834/sway/sway.5.scd
+" http://vimdoc.sourceforge.net/htmldoc/syntax.html
+"
+"
+" Quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+runtime! syntax/i3config.vim
+
+scriptencoding utf-8
+
+" Error
+"syn match swayConfigError /.*/
+
+" Group mode/bar
+syn keyword swayConfigBlockKeyword set input contained
+syn region swayConfigBlock start=+.*s\?{$+ end=+^}$+ contains=i3ConfigBlockKeyword,swayConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable transparent keepend extend
+
+" binding
+syn keyword swayConfigBindKeyword bindswitch bindgesture contained
+syn match swayConfigBind /^\s*\(bindswitch\)\s\+.*$/ contains=i3ConfigVariable,i3ConfigBindKeyword,swayConfigBindKeyword,i3ConfigVariableAndModifier,i3ConfigNumber,i3ConfigUnit,i3ConfigUnitOr,i3ConfigBindArgument,i3ConfigModifier,i3ConfigAction,i3ConfigString,i3ConfigGapStyleKeyword,i3ConfigBorderStyleKeyword
+
+" bindgestures
+syn keyword swayConfigBindGestureCommand swipe pinch hold contained
+syn keyword swayConfigBindGestureDirection up down left right next prev contained
+syn keyword swayConfigBindGesturePinchDirection inward outward clockwise counterclockwise contained
+syn match swayConfigBindGestureHold /^\s*\(bindgesture\)\s\+hold\(:[1-5]\)\?\s\+.*$/ contains=swayConfigBindKeyword,swayConfigBindGestureCommand,swayConfigBindGestureDirection,i3ConfigWorkspaceKeyword,i3ConfigAction
+syn match swayConfigBindGestureSwipe /^\s*\(bindgesture\)\s\+swipe\(:[1-5]\)\?:\(up\|down\|left\|right\)\s\+.*$/ contains=swayConfigBindKeyword,swayConfigBindGestureCommand,swayConfigBindGestureDirection,i3ConfigWorkspaceKeyword,i3ConfigAction
+syn match swayConfigBindGesturePinch /^\s*\(bindgesture\)\s\+\(pinch\):.*$/ contains=swayConfigBindKeyword,swayConfigBindGestureCommand,swayConfigBindGestureDirection,swayConfigBindGesturePinchDirection,i3ConfigWorkspaceKeyword,i3ConfigAction
+
+" floating
+syn keyword swayConfigFloatingKeyword floating contained
+syn match swayConfigFloating /^\s*floating\s\+\(enable\|disable\|toggle\)\s*$/ contains=swayConfigFloatingKeyword
+
+syn clear i3ConfigFloatingModifier
+syn keyword swayConfigFloatingModifier floating_modifier contained
+syn match swayConfigFloatingMouseAction /^\s\?.*floating_modifier\s.*\(normal\|inverted\)$/ contains=swayConfigFloatingModifier,i3ConfigVariable
+
+" Gaps
+syn clear i3ConfigSmartBorderKeyword
+syn clear i3ConfigSmartBorder
+syn keyword swayConfigSmartBorderKeyword on no_gaps off contained
+syn match swayConfigSmartBorder /^\s*smart_borders\s\+\(on\|no_gaps\|off\)\s\?$/ contains=swayConfigSmartBorderKeyword
+
+" Changing colors
+syn keyword swayConfigClientColorKeyword focused_tab_title contained
+syn match swayConfigClientColor /^\s*client.\w\+\s\+.*$/ contains=i3ConfigClientColorKeyword,i3ConfigColor,i3ConfigVariable,i3ConfigClientColorKeyword,swayConfigClientColorKeyword
+
+" set display outputs
+syn match swayConfigOutput /^\s*output\s\+.*$/ contains=i3ConfigOutput
+
+" set display focus 
+syn keyword swayConfigFocusKeyword focus contained
+syn keyword swayConfigFocusType output contained
+syn match swayConfigFocus /^\s*focus\soutput\s.*$/ contains=swayConfigFocusKeyword,swayConfigFocusType
+
+" xwayland 
+syn keyword swayConfigXwaylandKeyword xwayland contained
+syn match swayConfigXwaylandModifier /^\s*xwayland\s\+\(enable\|disable\|force\)\s\?$/ contains=swayConfigXwaylandKeyword
+
+"hi def link swayConfigError                         Error
+hi def link i3ConfigFloating                        Error
+hi def link swayConfigFloating                      Type
+hi def link swayConfigFloatingMouseAction           Type
+hi def link swayConfigFocusKeyword                  Type
+hi def link swayConfigSmartBorderKeyword            Type
+hi def link swayConfigBindGestureCommand            Identifier
+hi def link swayConfigBindGestureDirection          Constant
+hi def link swayConfigBindGesturePinchDirection     Constant
+hi def link swayConfigBindKeyword                   Identifier
+hi def link swayConfigBlockKeyword                  Identifier
+hi def link swayConfigClientColorKeyword            Identifier
+hi def link swayConfigFloatingKeyword               Identifier
+hi def link swayConfigFloatingModifier              Identifier
+hi def link swayConfigFocusType                     Identifier
+hi def link swayConfigSmartBorder                   Identifier
+hi def link swayConfigXwaylandKeyword               Identifier
+hi def link swayConfigXwaylandModifier              Type
+hi def link swayConfigBindGesture                   PreProc
+
+let b:current_syntax = "swayconfig"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -531,7 +531,7 @@ let s:filename_checks = {
     \ 'svelte': ['file.svelte'],
     \ 'svg': ['file.svg'],
     \ 'svn': ['svn-commitfile.tmp', 'svn-commit-file.tmp', 'svn-commit.tmp'],
-    \ 'sway': ['/home/user/.sway/config', '/home/user/.config/sway/config', '/etc/sway/config', '/etc/xdg/sway/config'],
+    \ 'swayconfig': ['/home/user/.sway/config', '/home/user/.config/sway/config', '/etc/sway/config', '/etc/xdg/sway/config'],
     \ 'swift': ['file.swift'],
     \ 'swiftgyb': ['file.swift.gyb'],
     \ 'sysctl': ['/etc/sysctl.conf', '/etc/sysctl.d/file.conf', 'any/etc/sysctl.conf', 'any/etc/sysctl.d/file.conf'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -531,6 +531,7 @@ let s:filename_checks = {
     \ 'svelte': ['file.svelte'],
     \ 'svg': ['file.svg'],
     \ 'svn': ['svn-commitfile.tmp', 'svn-commit-file.tmp', 'svn-commit.tmp'],
+    \ 'sway': ['/home/user/.sway/config', '/home/user/.config/sway/config', '/etc/sway/config', '/etc/xdg/sway/config'],
     \ 'swift': ['file.swift'],
     \ 'swiftgyb': ['file.swift.gyb'],
     \ 'sysctl': ['/etc/sysctl.conf', '/etc/sysctl.d/file.conf', 'any/etc/sysctl.conf', 'any/etc/sysctl.d/file.conf'],


### PR DESCRIPTION
This based on my fork of the current i3config [parent repo](https://github.com/mboughaba/i3config.vim) that was added here through #7969. I have added support for sway specific keywords and extended options based on conversations in https://github.com/vim/vim/issues/10231#issuecomment-1105485718. I am actively maintaining my fork and can maintain the sway syntax file here.

In this PR, I've updated the i3config syntax, both with i3 options (`smart_gaps off`), and for getting it to support the sway syntax.