### PR TITLE
W32 GUI: Ctrl+[ via Ctrl+dead^ (AZERTY, QWERTZ)

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -29,6 +29,11 @@
 # include "gui_dwrite.h"
 #endif
 
+#define DEAD_KEY_OFF                  (0)
+#define DEAD_KEY_SET_DEFAULT          (1)
+#define DEAD_KEY_TRANSIENT_IN_ON_CHAR (2)
+#define DEAD_KEY_SKIP_ON_CHAR         (3)
+
 #if defined(FEAT_DIRECTX)
 static DWriteContext *s_dwc = NULL;
 static int s_directx_enabled = 0;
@@ -533,7 +538,7 @@ static int	s_y_pending;
 static UINT	s_kFlags_pending;
 static UINT_PTR	s_wait_timer = 0;	  // Timer for get char from user
 static int	s_timed_out = FALSE;
-static int	dead_key = 0;		  // 0: no dead key, 1: dead key pressed
+static int	dead_key = DEAD_KEY_OFF;  // DEAD_KEY_OFF: no dead key, DEAD_KEY_SET_DEFAULT: dead key pressed, ...
 static UINT	surrogate_pending_ch = 0; // 0: no surrogate pending,
 					  // else a high surrogate
 
@@ -866,7 +871,15 @@ _OnChar(
     int		modifiers;
     int		ch = cch;   // special keys are negative
 
-    dead_key = 0;
+    if (dead_key == DEAD_KEY_SKIP_ON_CHAR)
+	return;
+
+    /*
+     *  keep DEAD_KEY_TRANSIENT_IN_ON_CHAR value for later handling in
+     *  process_message()
+     */
+    if (dead_key != DEAD_KEY_TRANSIENT_IN_ON_CHAR)
+	dead_key = DEAD_KEY_OFF;
 
     modifiers = get_active_modifiers();
 
@@ -912,7 +925,7 @@ _OnSysChar(
     int		modifiers;
     int		ch = cch;   // special keys are negative
 
-    dead_key = 0;
+    dead_key = DEAD_KEY_OFF;
 
     // OK, we have a character key (given by ch) which was entered with the
     // ALT key pressed. Eg, if the user presses Alt-A, then ch == 'A'. Note
@@ -1844,14 +1857,14 @@ gui_mch_draw_part_cursor(
  * dead key's nominal character and re-post the original message.
  */
     static void
-outputDeadKey_rePost(MSG originalMsg)
+outputDeadKey_rePost_Ex(MSG originalMsg, int dead_key2set)
 {
     static MSG deadCharExpel;
 
-    if (!dead_key)
+    if (dead_key == DEAD_KEY_OFF)
 	return;
 
-    dead_key = 0;
+    dead_key = dead_key2set;
 
     // Make Windows generate the dead key's character
     deadCharExpel.message = originalMsg.message;
@@ -1863,6 +1876,15 @@ outputDeadKey_rePost(MSG originalMsg)
     // re-generate the current character free of the dead char influence
     PostMessage(originalMsg.hwnd, originalMsg.message, originalMsg.wParam,
 							  originalMsg.lParam);
+}
+
+/*
+ * Wrapper for outputDeadKey_rePost_Ex which always reset dead_key value.
+ */
+    static void
+outputDeadKey_rePost(MSG originalMsg)
+{
+    outputDeadKey_rePost_Ex(originalMsg, DEAD_KEY_OFF);
 }
 
 /*
@@ -1936,8 +1958,46 @@ process_message(void)
 	 *   for some reason TranslateMessage() do not trigger a call
 	 *   immediately to _OnChar() (or _OnSysChar()).
 	 */
-	if (dead_key)
+
+	/*
+	 * We are at the moment after WM_CHAR with DEAD_KEY_SKIP_ON_CHAR event
+	 * was handled by _WndProc, this keypress we want to process normally
+	 */
+	if (dead_key == DEAD_KEY_SKIP_ON_CHAR)
+	    dead_key = DEAD_KEY_OFF;
+
+	if (dead_key != DEAD_KEY_OFF)
 	{
+	    /*
+	     * Expell the dead key pressed with Ctrl in a special way.
+	     *
+	     * After dead key was pressed with Ctrl in some cases, ESC was
+	     * artificially injected and handled by _OnChar(), now we are
+	     * dealing with completely new key press from the user. If we don't
+	     * do anything, ToUnicode() call will interpret this vk+scan_code
+	     * under influence of "dead-modifier". To prevent this we translate
+	     * this message replacing current char from user with VK_SPACE,
+	     * which will cause WM_CHAR with dead_key's character itself. Using
+	     * DEAD_KEY_SKIP_ON_CHAR value of dead_char we force _OnChar() to
+	     * ignore this one WM_CHAR event completely. Afterwards (due to
+	     * usage of PostMessage), this procedure is scheduled to be called
+	     * again with user char and on next entry we will clean
+	     * DEAD_KEY_SKIP_ON_CHAR. We cannot use original
+	     * outputDeadKey_rePost() since we do not wish to reset dead_key
+	     * value.
+	     */
+	    if (dead_key == DEAD_KEY_TRANSIENT_IN_ON_CHAR)
+	    {
+		outputDeadKey_rePost_Ex(msg, /*dead_key2set=*/DEAD_KEY_SKIP_ON_CHAR);
+		return;
+	    }
+
+	    if (dead_key != DEAD_KEY_SET_DEFAULT)
+	    {
+		// should never happen - is there a way to make ASSERT here?
+		return;
+	    }
+
 	    /*
 	     * If a dead key was pressed and the user presses VK_SPACE,
 	     * VK_BACK, or VK_ESCAPE it means that he actually wants to deal
@@ -1952,7 +2012,7 @@ process_message(void)
 	     */
 	    if ((vk == VK_SPACE || vk == VK_BACK || vk == VK_ESCAPE))
 	    {
-		dead_key = 0;
+		dead_key = DEAD_KEY_OFF;
 		TranslateMessage(&msg);
 		return;
 	    }
@@ -1995,7 +2055,7 @@ process_message(void)
 		 * character output (such as a NUMPAD printable character or
 		 * the TAB key, etc...).
 		 */
-		if (dead_key && (special_keys[i].vim_code0 == 'K'
+		if (dead_key == DEAD_KEY_SET_DEFAULT && (special_keys[i].vim_code0 == 'K'
 						|| vk == VK_TAB || vk == CAR))
 		{
 		    outputDeadKey_rePost(msg);
@@ -2081,10 +2141,29 @@ process_message(void)
 	    // If this is a dead key ToUnicode returns a negative value.
 	    len = ToUnicode(vk, scan_code, keyboard_state, ch, ARRAY_LENGTH(ch),
 		    0);
-	    dead_key = len < 0;
+	    if (len < 0)
+		dead_key = DEAD_KEY_SET_DEFAULT;
 
 	    if (len <= 0)
+	    {
+		if (   dead_key == DEAD_KEY_SET_DEFAULT
+                    && (GetKeyState(VK_CONTROL) & 0x8000)
+		    && (
+			  (vk == 221 && scan_code == 26) // AZERTY CTRL+dead_circumflex
+			||(vk == 220 && scan_code == 41) // QWERTZ CTRL+dead_circumflex
+		       )
+		   )
+		{
+		    // post WM_CHAR='[' - which will be interpreted with CTRL
+		    // stil hold as ESC
+		    PostMessageW(msg.hwnd, WM_CHAR, '[', msg.lParam);
+		    // ask _OnChar() to not touch this state, wait for next key
+		    // press and maintain knowledge that we are "poisoned" with
+		    // "dead state"
+		    dead_key = DEAD_KEY_TRANSIENT_IN_ON_CHAR;
+		}
 		return;
+	    }
 
 	    // Post the message as TranslateMessage would do.
 	    if (msg.message == WM_KEYDOWN)


### PR DESCRIPTION
Provide Ctrl+[ via Ctrl+dead_circumflex on AZERTY, QWERTZ

This PR fixes second part (Win32 gvim) of #10454.

This is pretty "brute force" fix for UX regression introduced by
patch "8.2.4807: processing key events in Win32 GUI is not
ideal" (77fc0b02e53bdc49213900e0055cb6d678ce180d). Starting by
this revision it was not possible any more to generate ESC using
Ctrl+dead_circumflex on AZERTY keyboard layout in Win32 gvim.

Solution is found using trial-and-error approach. After AZERTY
solution was found, to check how generic it is QWERTZ (German)
Ctrl+dead_circumflex solution was found as well (made not big
sense as such but turned out to be good for generalization,
because windows handles Ctrl+dead_circumflex differently for
AZERTY and QWERTZ layouts, first solution for AZERTY was not
working for QWERTZ but QWERTZ was good enough for AZERTY. Hopes
are that other national layouts will be straight forward to add
if handling of CTRL+dead_key will ever be needed for them).

When we detect that Ctrl+dead_key is pressed, we check raw
vk+scan_code to be sure we are talking about specific key on the
keyboard. Condition that it is dead key is computed separately
already. So we restrict triggering of this fix to specific key on
the keyboard _and_ to the fact that it is a dead key _and_ that
now Ctrl is in hold state.

Firstly we inject WM_CHAR='[' into the message queue using
PostMessageW(). This will result in a call of ```_WndProc()```
after this call of process_message() will return (state of
Ctrl is separately dermined by _OnChar(), therefore '[' will be
Ctrl+[). This WM_CHAR will be processed as very next event.

After that gvim will go into waiting state to wait for some
subsequent key presses from the user.

In that moment gvim application is situated into "dead key" state -
next vk+scan_code of the key pressed will be translated by ToUnicode() call
differently from "normal state": preceding "dead key" will produce
"cicrumflex"-variant of the char (a->â,u->û etc), so we need to
"expel" this state. Don't want 'â' if user pressed 'a'.

There is already that boolean^H^H^H^H^H^H^Hint flag "dead_key" in
gui_w32.c to track the "dead key" state. Simple boolean usage of
that flag seems not enough for our needs any more, therefore
"dead_key" meaninig is extended from plain boolean to a
enumeration of several possible values, see below. 

Remember there was this preceeding _WndProc()->_OnChar()
call where we feed Ctrl+[ into vim internal event queue
(add_to_input_buf()).

Normally _OnChar() would reset vim variable "dead_key" value to
0. We want however to maintain our special state even after that
_OnChar() call - to be in-sync with windows point of view. To
achieve that, we introduce new value of the global "dead_key"
variable: DEAD_KEY_TRANSIENT_IN_ON_CHAR.

So, back to waiting for further user input.  Remember, that
application is marked by windows as "after dead key was press"
and when we obtain this future key press from user we still will
have this knowledge via DEAD_KEY_TRANSIENT_IN_ON_CHAR value of
"dead_key" variable, which was not removed by first _OnChar()
call.

Now we need to expel the dead key status in a special way, which
seems only(?) be possible to accomplish by handling of that
"poisoned" keypress in our _WndProc. We call TranslateMessage()
where we replace the key press of user with ' '(VK_SPACE) - it
will translate to just one WM_CHAR='^' event posted into our
queue. We self-post as well original char as WM_KEYDOWN to be
processed with PostMessage and return from this process_message()
call. (Even if we would skip call of TranslateMessage, Windows
still will force us to confront with that dead char by put in our
queue WM_CHAR = '^' event, seems to default to that even without
us calling TranslateMessage() with VK_SPACE).

That's where second special value of "dead_key" variable is
introduced: DEAD_KEY_SKIP_ON_CHAR. We set it and let "poisoned"
char to go through our _WndProc() ignoring it in _OnChar().

After that we are dealing with self-scheduled WM_KEYDOWN event in
subsequent call of process_message(), which reproduces the
original user key press.

PS/Sidenote: Detected by the way, perhaps already reported. It
seems that CTRL+6 handling is changed as well since 8.2.4807 for
AZERTY layout. Before that patch both CTRL+6 and CTRL+SHIFT+6 has
generated CTRL+^, since 8.2.4807 CTRL+6 generates CTRL+§ (and
CTRL+SHIFT+6 still generates CTRL+^). One can consider this
change to be kind of improvement, and if somebody really need old
behaviour it can easily be achieved by the user per configuration
with mapping CTRL+§.