### PR TITLE
remove misleading :3mat from the documentation

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2316,7 +2316,6 @@ exists({expr})	The result is a Number, which is |TRUE| if {expr} is defined,
 					To check for a supported command
 					always check the return value to be 2.
 			:2match		The |:2match| command.
-			:3match		The |:3match| command.
 			#event		autocommand defined for this event
 			#event#pattern	autocommand defined for this event and
 					pattern (the pattern is taken
@@ -5771,9 +5770,10 @@ matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		The optional {id} argument allows the request for a specific
 		match ID.  If a specified ID is already taken, an error
 		message will appear and the match will not be added.  An ID
-		is specified as a positive integer (zero excluded).  IDs 1, 2
-		and 3 are reserved for |:match|, |:2match| and |:3match|,
-		respectively.  If the {id} argument is not specified or -1,
+		is specified as a positive integer (zero excluded).  IDs 1 and 2
+		are reserved for |:match|, |:2match| respectively. NOTE: ID 3 is
+		reserved for internal usage (by |matchparen| plugin).
+		If the {id} argument is not specified or -1,
 		|matchadd()| automatically chooses a free ID.
 
 		The optional {dict} argument allows for further custom
@@ -5846,15 +5846,15 @@ matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])
 
 matcharg({nr})							*matcharg()*
 		Selects the {nr} match item, as set with a |:match|,
-		|:2match| or |:3match| command.
+		|:2match| command.
 		Return a |List| with two elements:
 			The name of the highlight group used
 			The pattern used.
-		When {nr} is not 1, 2 or 3 returns an empty |List|.
+		When {nr} is not 1 or 2 returns an empty |List|.
 		When there is no match item set returns ['', ''].
 		This is useful to save and restore a |:match|.
 		Highlighting matches using the |:match| commands are limited
-		to three matches. |matchadd()| does not have this limitation.
+		to two matches. |matchadd()| does not have this limitation.
 
 		Can also be used as a |method|: >
 			GetMatch()->matcharg()

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1425,8 +1425,8 @@ Finally, these constructs are unique to Perl:
 		command.  The latter returns a list with highlight groups and
 		patterns defined by both |matchadd()| and |:match|.
 
-		Highlighting matches using |:match| are limited to three
-		matches (aside from |:match|, |:2match| and |:3match| are
+		Highlighting matches using |:match| are limited to two
+		matches (aside from |:match| |:2match| is
 		available). |matchadd()| does not have this limitation and in
 		addition makes it possible to prioritize matches.
 
@@ -1448,16 +1448,13 @@ Finally, these constructs are unique to Perl:
 :2mat[ch] {group} /{pattern}/					*:2match*
 :2mat[ch]
 :2mat[ch] none
-:3mat[ch] {group} /{pattern}/					*:3match*
-:3mat[ch]
-:3mat[ch] none
 		Just like |:match| above, but set a separate match.  Thus
 		there can be three matches active at the same time.  The match
 		with the lowest number has priority if several match at the
 		same position.
-		The ":3match" command is used by the |matchparen| plugin.  You
-		are suggested to use ":match" for manual matching and
-		":2match" for another plugin.
+		":match" and ":2match" commands should be reserved for
+		interactive usage. Plugin autors are encouraged to directly
+		use matchadd() call instead.
 
 ==============================================================================
 11. Fuzzy matching					*fuzzy-matching*


### PR DESCRIPTION
When skimming over documentation it is easy to erroneously believe one can use ":3mat" command - see my recent bug report #10690 instantly closed by @chrisbra   ))))

Thinking about it a bit, may be this is good idea to officially remove ":3mat" from the documentation. For normal use cases it is anyway not (really) available, it can be only used (as far as I understood) only in some exotic circumstances - for example that standard matchit plugin is deactivated?

Another "improvement"  - documentation encourages plugin authors to use ":2mat". Is it not better to leave ":mat" and ":2mat" for interactive usage entirely and ask plugin authors to use matchadd() call directly?