### PR TITLE
E1281 was not tested with the old regexp engine

### DIFF
--- a/src/testdir/test_regexp_latin.vim
+++ b/src/testdir/test_regexp_latin.vim
@@ -1101,13 +1101,17 @@ func Test_using_two_engines_pattern()
   call setline(1, ['foobar=0', 'foobar=1', 'foobar=2'])
   " \%#= at the end of the pattern
   for i in range(0, 2)
-    call cursor( (i+1), 7) 
-    call assert_fails("%s/foobar\\%#=" .. i, 'E1281:')
+    for j in range(0, 2)
+      exe "set re=" .. i
+      call cursor( (j+1), 7)
+      call assert_fails("%s/foobar\\%#=" .. j, 'E1281:')
+    endfor
   endfor
+  set re=0
 
   " \%#= at the start of the pattern
   for i in range(0, 2)
-    call cursor( (i+1), 7) 
+    call cursor( (i+1), 7)
     exe ":%s/\\%#=" .. i .. "foobar=" .. i .. "/xx"
   endfor
   call assert_equal(['xx', 'xx', 'xx'], getline(1, '$'))


### PR DESCRIPTION
E1281 was not tested with the old regexp engine.

See line 1510 at:
https://app.codecov.io/gh/vim/vim/blob/b90818867c089d4987f1a48ee3666674826d6f4b/src/regexp_bt.c