### PR TITLE
WIP: Update menu translations for Italian / Italiano

### DIFF
--- a/runtime/lang/menu_it_it.latin1.vim
+++ b/runtime/lang/menu_it_it.latin1.vim
@@ -1,409 +1,1266 @@
-" Menu Translations:	Italian / Italiano
-" Maintainer:		Antonio Colombo <azc100@gmail.com>
-"			Vlad Sandrini <vlad.gently@gmail.com>
-"			Luciano Montanaro <mikelima@cirulla.net>
-" Last Change:	2022 Jun 17
+" Menu Translations:	  Italian / Italiano
+" Maintainer:           Ada (Haowen) Yu <me@yuhaowen.com>
+" Previous Maintainer:  Antonio Colombo <azc100@gmail.com>, Vlad Sandrini <vlad.gently@gmail.com>, Luciano Montanaro <mikelima@cirulla.net>
+" Last Change:          2022 July 10
 " Original translations
+"
+" Generated with the scripts from:
+"
+"       https://github.com/adaext/vim-menutrans-helper
 
 " Quit when menu translations have already been done.
+
 if exists("did_menu_trans")
   finish
 endif
 let did_menu_trans = 1
-let s:keepcpo= &cpo
+let s:keepcpo = &cpo
 set cpo&vim
 
-scriptencoding iso-8859-1
+scriptencoding latin1
 
-" Help / Aiuto
-menut &Help			&Aiuto
+" Help menu
+menutrans &Help &Aiuto
+" Help menuitems and dialog {{{1
+menutrans &Overview<Tab><F1> &Panoramica<Tab><F1>
+menutrans &User\ Manual Manuale\ &Utente
+menutrans &How-to\ Links Co&Me\.\.\.
+menutrans &Find\.\.\. &Cerca\.\.\.
+menutrans &Credits Cr&Editi
+menutrans Co&pying C&Opie
+menutrans &Sponsor/Register &Sponsor/Registrazione
+menutrans O&rphans O&Rfani
+menutrans &Version &Versione
+menutrans &About &Intro
 
-menut &Overview<Tab><F1>	&Panoramica<Tab><F1>
-menut &User\ Manual		Manuale\ &Utente
-menut &How-to\ links	Co&Me\.\.\.
-menut &Find\.\.\.	&Cerca\.\.\.
-menut &Credits		Cr&Editi
-menut Co&pying		C&Opie
-menut &Sponsor/Register &Sponsor/Registrazione
-menut O&rphans		O&Rfani
-menut &Version		&Versione
-menut &About		&Intro
+" fun! s:Helpfind()
+if !exists("g:menutrans_help_dialog")
+  let g:menutrans_help_dialog = "Batti un comando o una parola per cercare aiuto:\n\nPremetti i_ per comandi in modo Input (p.es.: i_CTRL-X)\nPremetti c_ per comandi che editano la linea-comandi (p.es.: c_<Del>)\nPremetti ' per un nome di opzione (p.es.: 'shiftwidth')"
+endif
+" }}}
 
-let g:menutrans_help_dialog = "Batti un comando o una parola per cercare aiuto:\n\nPremetti i_ per comandi in modo Input (p.es.: i_CTRL-X)\nPremetti c_ per comandi che editano la linea-comandi (p.es.: c_<Del>)\nPremetti ' per un nome di opzione (p.es.: 'shiftwidth')"
+" File menu
+menutrans &File &File
+" File menuitems {{{1
+menutrans &Open\.\.\.<Tab>:e &Apri\.\.\.<Tab>:e
+menutrans Sp&lit-Open\.\.\.<Tab>:sp A&Pri\ nuova\ finestra\.\.\.<Tab>:sp
+menutrans Open\ Tab\.\.\.<Tab>:tabnew Apri\ nuova\ &Linguetta\.\.\.<Tab>:tabnew
+menutrans &New<Tab>:enew &Nuovo<Tab>:enew
+menutrans &Close<Tab>:close &Chiudi<Tab>:close
+menutrans &Save<Tab>:w &Salva<Tab>:w
+menutrans Save\ &As\.\.\.<Tab>:sav Salva\ &Con\ nome\.\.\.<Tab>:sav
+menutrans Split\ &Diff\ With\.\.\. &Differenza\ con\.\.\.
+menutrans Split\ Patched\ &By\.\.\. Patc&H\ da\.\.\.
+menutrans &Print S&tampa
+menutrans Sa&ve-Exit<Tab>:wqa Sa&Lva\ ed\ esci<Tab>:wqa
+menutrans E&xit<Tab>:qa &Esci<Tab>:qa
+" }}}
 
-" File / File
-menut &File				&File
+" Edit menu
+menutrans &Edit &Modifica
+" Edit menuitems {{{1
+menutrans &Undo<Tab>u &Annulla<Tab>u
+menutrans &Redo<Tab>^R &Ripristina<Tab>^R
+menutrans Rep&eat<Tab>\. Ri&Peti<Tab>\.
+menutrans Cu&t<Tab>"+x &Taglia<Tab>"+x
+menutrans &Copy<Tab>"+y &Copia<Tab>"+y
+menutrans &Paste<Tab>"+gP &Incolla<Tab>"+gP
+menutrans Put\ &Before<Tab>[p &Metti\ davanti<Tab>[p
+menutrans Put\ &After<Tab>]p M&Etti\ dietro<Tab>]p
+menutrans &Delete<Tab>x Cance&Lla<Tab>x
+menutrans &Select\ All<Tab>ggVG Seleziona\ &Tutto<Tab>ggVG
+menutrans &Find\.\.\. &Cerca\.\.\.
+menutrans Find\ and\ Rep&lace\.\.\. &Sostituisci\.\.\.
+" menutrans &Find<Tab>/ TRANSLATION\ MISSING
+" menutrans Find\ and\ Rep&lace<Tab>:%s TRANSLATION\ MISSING
+" menutrans Find\ and\ Rep&lace<Tab>:s TRANSLATION\ MISSING
+menutrans Settings\ &Window &Finestra\ Impostazioni
+menutrans Startup\ &Settings Impostazioni\ di\ &Avvio
 
-menut &Open\.\.\.<Tab>:e		&Apri\.\.\.<Tab>:e
-menut Sp&lit-Open\.\.\.<Tab>:sp		A&Pri\ nuova\ finestra\.\.\.<Tab>:sp
-menut Open\ Tab\.\.\.<Tab>:tabnew	Apri\ nuova\ &Linguetta\.\.\.<Tab>:tabnew
-menut &New<Tab>:enew			&Nuovo<Tab>:enew
-menut &Close<Tab>:close			&Chiudi<Tab>:close
-menut &Save<Tab>:w			&Salva<Tab>:w
-menut Save\ &As\.\.\.<Tab>:sav		Salva\ &Con\ nome\.\.\.<Tab>:sav
-menut Split\ &Diff\ with\.\.\.		&Differenza\ con\.\.\.
-menut Split\ Patched\ &By\.\.\.		Patc&H\ da\.\.\.
-menut &Print				S&tampa
-menut Sa&ve-Exit<Tab>:wqa		Sa&Lva\ ed\ esci<Tab>:wqa
-menut E&xit<Tab>:qa			&Esci<Tab>:qa
+" Edit/Global Settings
+menutrans &Global\ Settings Impostazioni\ &Globali
+" Edit.Global Settings menuitems and dialogs {{{2
+menutrans Toggle\ Pattern\ &Highlight<Tab>:set\ hls! &Evidenzia\ ricerche\ Sì/No<Tab>:set\ hls!
+menutrans Toggle\ &Ignoring\ Case<Tab>:set\ ic! &Ignora\ maiusc\.-minusc\.\ Sì/No<Tab>:set\ ic!
+menutrans Toggle\ &Showing\ Matched\ Pairs<Tab>:set\ sm! Indica\ &Corrispondenze\ Sì/No<Tab>:set\ sm!
+menutrans &Context\ Lines &Linee\ di\ contesto
+menutrans &Virtual\ Edit &Edit\ virtuale
+" Edit.Global Settings.Virtual Edit menuitems {{{3
+menutrans Never Mai
+menutrans Block\ Selection Selezione\ Blocco
+menutrans Insert\ Mode Modo\ Insert
+menutrans Block\ and\ Insert Selezione\ Blocco\ e\ Inserimento
+menutrans Always Sempre
+" }}}
+menutrans Toggle\ Insert\ &Mode<Tab>:set\ im! &Modo\ Insert\ Sì/No<Tab>:set\ im!
+menutrans Toggle\ Vi\ C&ompatibility<Tab>:set\ cp! C&Ompatibilità\ VI\ Sì/No<Tab>:set\ cp!
+menutrans Search\ &Path\.\.\. &Percorso\ di\ ricerca\.\.\.
+menutrans Ta&g\ Files\.\.\. File\ ta&G\.\.\.
 
-" Edit / Modifica
-menut &Edit				&Modifica
+" GUI options
+menutrans Toggle\ &Toolbar Barra\ s&Trumenti\ Sì/No
+menutrans Toggle\ &Bottom\ Scrollbar Barra\ scorrimento\ in\ &Fondo\ Sì/No
+menutrans Toggle\ &Left\ Scrollbar Barra\ scorrimento\ a\ &Sinistra\ Sì/No
+menutrans Toggle\ &Right\ Scrollbar Barra\ scorrimento\ a\ &Destra\ Sì/No
 
-menut &Undo<Tab>u			&Annulla<Tab>u
-menut &Redo<Tab>^R			&Ripristina<Tab>^R
-menut Rep&eat<Tab>\.			Ri&Peti<Tab>\.
-menut Cu&t<Tab>"+x			&Taglia<Tab>"+x
-menut &Copy<Tab>"+y			&Copia<Tab>"+y
-menut &Paste<Tab>"+gP			&Incolla<Tab>"+gP
-menut Put\ &Before<Tab>[p		&Metti\ davanti<Tab>[p
-menut Put\ &After<Tab>]p		M&Etti\ dietro<Tab>]p
-menut &Delete<Tab>x			Cance&Lla<Tab>x
-menut &Select\ all<Tab>ggVG		Seleziona\ &Tutto<Tab>ggVG
-menut &Find\.\.\.			&Cerca\.\.\.
-menut &Find\.\.\.<Tab>/			&Cerca\.\.\.<Tab>/
-menut Find\ and\ Rep&lace\.\.\.		&Sostituisci\.\.\.
-menut Find\ and\ Rep&lace\.\.\.<Tab>:%s	&Sostituisci\.\.\.<Tab>:%s
-menut Find\ and\ Rep&lace\.\.\.<Tab>:s	&Sostituisci\.\.\.<Tab>:s
-menut Settings\ &Window			&Finestra\ Impostazioni
-menut Startup\ &Settings		Impostazioni\ di\ &Avvio
-menut &Global\ Settings			Impostazioni\ &Globali
-menut Question				Domanda
-
-" Edit / Modifica / Impostazioni Globali
-
-menut Toggle\ Pattern\ &Highlight<Tab>:set\ hls!	&Evidenzia\ ricerche\ Sì/No<Tab>:set\ hls!
-menut Toggle\ &Ignoring\ Case<Tab>:set\ ic!		&Ignora\ maiusc\.-minusc\.\ Sì/No<Tab>:set\ ic!
-menut Toggle\ &Showing\ Matched\ Pairs<Tab>:set\ sm!			Indica\ &Corrispondenze\ Sì/No<Tab>:set\ sm!
-
-menut &Context\ lines		&Linee\ di\ contesto
-
-menut &Virtual\ Edit		&Edit\ virtuale
-menut Never			Mai
-menut Block\ Selection		Selezione\ Blocco
-menut Insert\ mode		Modo\ Insert
-menut Block\ and\ Insert	Selezione\ Blocco\ e\ Inserimento
-menut Always			Sempre
-
-menut Toggle\ Insert\ &Mode<Tab>:set\ im!	&Modo\ Insert\ Sì/No<Tab>:set\ im!
-menut Toggle\ Vi\ C&ompatibility<Tab>:set\ cp!	C&Ompatibilità\ VI\ Sì/No<Tab>:set\ cp!
-menut Search\ &Path\.\.\.	&Percorso\ di\ ricerca\.\.\.
-menut Ta&g\ Files\.\.\.		File\ ta&G\.\.\.
-menut Toggle\ &Toolbar			Barra\ s&Trumenti\ Sì/No
-menut Toggle\ &Bottom\ Scrollbar	Barra\ scorrimento\ in\ &Fondo\ Sì/No
-menut Toggle\ &Left\ Scrollbar		Barra\ scorrimento\ a\ &Sinistra\ Sì/No
-menut Toggle\ &Right\ Scrollbar		Barra\ scorrimento\ a\ &Destra\ Sì/No
-
-if has("toolbar")
-   if exists("*Do_toolbar_tmenu")
-      delfun Do_toolbar_tmenu
-   endif
-   fun Do_toolbar_tmenu()
-      tmenu ToolBar.Open		Apri file
-      tmenu ToolBar.Save		Salva file
-      tmenu ToolBar.SaveAll		Salva tutti i file
-      if has("printer") || has("unix")
-         tmenu ToolBar.Print		Stampa
-      endif
-      tmenu ToolBar.Undo		Annulla
-      tmenu ToolBar.Redo		Rifai
-      tmenu ToolBar.Cut			Taglia
-      tmenu ToolBar.Copy		Copia
-      tmenu ToolBar.Paste		Incolla
-      tmenu ToolBar.Find		Trova...
-      tmenu ToolBar.FindNext		Trova seguente
-      tmenu ToolBar.FindPrev		Trova precedente
-      tmenu ToolBar.Replace		Sostituisci
-      if 0	" disabled; These are in the Windows menu
-         tmenu ToolBar.New		Nuovo
-         tmenu ToolBar.WinSplit		Dividi
-         tmenu ToolBar.WinMax		Massimizza
-         tmenu ToolBar.WinMin		Minimizza
-         tmenu ToolBar.WinClose		Chiudi
-      endif
-      tmenu ToolBar.LoadSesn		Carica sessione
-      tmenu ToolBar.SaveSesn		Salva sessione
-      tmenu ToolBar.RunScript		Esegui script
-      tmenu ToolBar.Make		Esegui make
-      tmenu ToolBar.Shell		Esegui shell
-      tmenu ToolBar.RunCtags		Esegui ctags
-      tmenu ToolBar.TagJump		Salta alla tag
-      tmenu ToolBar.Help		Aiuto
-      tmenu ToolBar.FindHelp		Trova aiuto...
-   endfun
+" fun! s:SearchP()
+if !exists("g:menutrans_path_dialog")
+  let g:menutrans_path_dialog = "Batti percorso di ricerca per i file.\nSepara fra loro i nomi di directory con una virgola."
 endif
 
-let g:menutrans_path_dialog = "Batti percorso di ricerca per i file.\nSepara fra loro i nomi di directory con una virgola."
-let g:menutrans_tags_dialog = "Batti nome dei file di tag.\nSepara fra loro i nomi di directory con una virgola."
+" fun! s:TagFiles()
+if !exists("g:menutrans_tags_dialog")
+  let g:menutrans_tags_dialog = "Batti nome dei file di tag.\nSepara fra loro i nomi di directory con una virgola."
+endif
+" }}}
 
-" Edit / Impostazioni File
-menut F&ile\ Settings	&Impostazioni\ file
-
+" Edit/File Settings
+menutrans F&ile\ Settings &Impostazioni\ file
+" Edit.File Settings menuitems and dialogs {{{2
 " Boolean options
-menut Toggle\ Line\ &Numbering<Tab>:set\ nu!		&Numerazione\ Sì/No<Tab>:set\ nu!
-menut Toggle\ Relati&ve\ Line\ Numbering<Tab>:set\ rnu!	Numerazione\ relati&Va\ Sì/No<Tab>:set\ rnu!
-menut Toggle\ &List\ Mode<Tab>:set\ list!		Modo\ &List\ Sì/No<Tab>:set\ list!
-menut Toggle\ Line\ &Wrapping<Tab>:set\ wrap!		Linee\ &Continuate\ Sì/No<Tab>:set\ wrap!
-menut Toggle\ W&rapping\ at\ word<Tab>:set\ lbr!	A\ capo\ alla\ &Parola\ Sì/No<Tab>:set\ lbr!
-menut Toggle\ Tab\ &expanding<Tab>:set\ et!		&Espandi\ Tabulazione\ Sì/No<Tab>:set\ et!
-menut Toggle\ &Auto\ Indenting<Tab>:set\ ai!		Indentazione\ &Automatica\ Sì/No<Tab>:set\ ai!
-menut Toggle\ &C-Style\ Indenting<Tab>:set\ cin!	Indentazione\ stile\ &C\ Sì/No<Tab>:set\ cin!
-menut &Shiftwidth					&Spazi\ rientranza
-"menut &Shiftwidth.2<Tab>:set\ sw=2\ sw?<CR>		&Spazi\ rientranza.2<Tab>:set\ sw=2\ sw?<CR>
-"menut &Shiftwidth.3<Tab>:set\ sw=3\ sw?<CR>		&Spazi\ rientranza.3<Tab>:set\ sw=3\ sw?<CR>
-"menut &Shiftwidth.4<Tab>:set\ sw=4\ sw?<CR>		&Spazi\ rientranza.4<Tab>:set\ sw=4\ sw?<CR>
-"menut &Shiftwidth.5<Tab>:set\ sw=5\ sw?<CR>		&Spazi\ rientranza.5<Tab>:set\ sw=5\ sw?<CR>
-"menut &Shiftwidth.6<Tab>:set\ sw=6\ sw?<CR>		&Spazi\ rientranza.6<Tab>:set\ sw=6\ sw?<CR>
-"menut &Shiftwidth.8<Tab>:set\ sw=8\ sw?<CR>		&Spazi\ rientranza.8<Tab>:set\ sw=8\ sw?<CR>
-menut Soft\ &Tabstop					&Tabulazione\ software
-"menut Soft\ &Tabstop.2<Tab>:set\ sts=2\ sts?		&Tabulazione\ software.2<Tab>:set\ sts=2\ sts?
-"menut Soft\ &Tabstop.3<Tab>:set\ sts=3\ sts?		&Tabulazione\ software.3<Tab>:set\ sts=3\ sts?
-"menut Soft\ &Tabstop.4<Tab>:set\ sts=4\ sts?		&Tabulazione\ software.4<Tab>:set\ sts=4\ sts?
-"menut Soft\ &Tabstop.5<Tab>:set\ sts=5\ sts?		&Tabulazione\ software.5<Tab>:set\ sts=5\ sts?
-"menut Soft\ &Tabstop.6<Tab>:set\ sts=6\ sts?		&Tabulazione\ software.6<Tab>:set\ sts=6\ sts?
-"menut Soft\ &Tabstop.8<Tab>:set\ sts=8\ sts?		&Tabulazione\ software.8<Tab>:set\ sts=8\ sts?
-menut Te&xt\ Width\.\.\.				Lunghe&Zza\ riga\.\.\.
-menut &File\ Format\.\.\.				Formato\ &File\.\.\.
+menutrans Toggle\ Line\ &Numbering<Tab>:set\ nu! &Numerazione\ Sì/No<Tab>:set\ nu!
+menutrans Toggle\ Relati&ve\ Line\ Numbering<Tab>:set\ rnu! Numerazione\ relati&Va\ Sì/No<Tab>:set\ rnu!
+menutrans Toggle\ &List\ Mode<Tab>:set\ list! Modo\ &List\ Sì/No<Tab>:set\ list!
+menutrans Toggle\ Line\ &Wrapping<Tab>:set\ wrap! Linee\ &Continuate\ Sì/No<Tab>:set\ wrap!
+menutrans Toggle\ W&rapping\ at\ Word<Tab>:set\ lbr! A\ capo\ alla\ &Parola\ Sì/No<Tab>:set\ lbr!
+menutrans Toggle\ Tab\ &Expanding<Tab>:set\ et! &Espandi\ Tabulazione\ Sì/No<Tab>:set\ et!
+menutrans Toggle\ &Auto\ Indenting<Tab>:set\ ai! Indentazione\ &Automatica\ Sì/No<Tab>:set\ ai!
+menutrans Toggle\ &C-Style\ Indenting<Tab>:set\ cin! Indentazione\ stile\ &C\ Sì/No<Tab>:set\ cin!
 
-let g:menutrans_textwidth_dialog = "Batti nuova lunghezza linea (0 per inibire la formattazione): "
-let g:menutrans_fileformat_dialog = "Scegli formato con cui scrivere il file"
-let g:menutrans_fileformat_choices = " &Unix \n &Dos \n &Mac \n &Annullare "
+" other options
+menutrans &Shiftwidth &Spazi\ rientranza
+menutrans Soft\ &Tabstop &Tabulazione\ software
+menutrans Te&xt\ Width\.\.\. Lunghe&Zza\ riga\.\.\.
+menutrans &File\ Format\.\.\. Formato\ &File\.\.\.
 
-menut Show\ C&olor\ Schemes\ in\ Menu	Mostra\ Schemi\ C&olore\ in\ Menù
-menut C&olor\ Scheme		Schema\ c&Olori
+" fun! s:TextWidth()
+if !exists("g:menutrans_textwidth_dialog")
+  let g:menutrans_textwidth_dialog = "Batti nuova lunghezza linea (0 per inibire la formattazione): "
+endif
 
-menut blue		blù
-menut darkblue		blù\ scuro
-menut desert		deserto
-menut elflord		signore\ degli\ elfi
-menut evening		sera
-menut industry		industria
-menut morning		mattino
-menut peachpuff		pesca
-menut shine		brillante
-menut slate		ardesia
-menut BLUE		BLÙ
-menut DARKBLUE		BLÙ\ SCURO
-menut DESERT		DESERTO
-menut ELFLORD		SIGNORE\ DEGLI\ ELFI
-menut EVENING		SERA
-menut INDUSTRY		INDUSTRIA
-menut MORNING		MATTINO
-menut PEACHPUFF		PESCA
-menut SHINE		BRILLANTE
-menut SLATE		ARDESIA
+" fun! s:FileFormat()
+if !exists("g:menutrans_fileformat_dialog")
+  let g:menutrans_fileformat_dialog = "Scegli formato con cui scrivere il file"
+endif
+if !exists("g:menutrans_fileformat_choices")
+  let g:menutrans_fileformat_choices = " &Unix \n &Dos \n &Mac \n &Annullare "
+endif
+" }}}
+menutrans Show\ C&olor\ Schemes\ in\ Menu Mostra\ Schemi\ C&olore\ in\ Menù
+menutrans C&olor\ Scheme Schema\ c&Olori
+menutrans None nessuna
+menutrans Show\ &Keymaps\ in\ Menu Mostra\ Ma&ppe\ tastiera\ in\ Menù
+menutrans &Keymap Ma&ppa\ tastiera
+menutrans Select\ Fo&nt\.\.\. Scegli\ &Font\.\.\.
+" }}}
 
-menut Show\ &Keymaps\ in\ Menu	Mostra\ Ma&ppe\ tastiera\ in\ Menù
-menut &Keymap			Ma&ppa\ tastiera
+" Programming menu
+menutrans &Tools &Strumenti
+" Tools menuitems {{{1
+menutrans &Jump\ to\ This\ Tag<Tab>g^] &Vai\ a\ questa\ tag<Tab>g^]
+menutrans Jump\ &Back<Tab>^T Torna\ &Indietro<Tab>^T
+menutrans Build\ &Tags\ File Costruisci\ file\ &Tags\
 
-menut None			nessuna
-menut accents			accenti
-menut arabic			arabo
-menut armenian-eastern		armeno-orientale
-menut armenian-western		armeno-occidentale
-menut belarusian-jcuken		bielorusso-jcuken
-menut czech			ceco
-menut greek			greco
-menut hebrew			ebraico
-menut hebrewp			ebraicop
-menut magyar			ungherese
-menut persian			persiano
-menut serbian			serbo
-menut serbian-latin		serbo-latino
-menut slovak			slovacco
-menut ACCENTS			ACCENTI
-menut ARABIC			ARABO
-menut ARMENIAN-EASTERN		ARMENO-ORIENTALE
-menut ARMENIAN-WESTERN		ARMENO-OCCIDENTALE
-menut BELARUSIAN-JCUKEN		BIELORUSSO-JCUKEN
-menut CZECH			CECO
-menut GREEK			GRECO
-menut HEBREW			EBRAICO
-menut HEBREWP			EBRAICOP
-menut MAGYAR			UNGHERESE
-menut PERSIAN			PERSIANO
-menut SERBIAN			SERBO
-menut SERBIAN-LATIN		SERBO-LATINO
-menut SLOVAK			SLOVACCO
+" Tools.Spelling Menu
+menutrans &Spelling &Ortografia
+" Tools.Spelling menuitems and dialog {{{2
+menutrans &Spell\ Check\ On Attiva\ &Controllo\ ortografico
+menutrans Spell\ Check\ &Off &Disattiva\ controllo\ ortografico
+menutrans To\ &Next\ Error<Tab>]s Errore\ &Seguente<tab>]s
+menutrans To\ &Previous\ Error<Tab>[s Errore\ &Precedente<tab>[s
+menutrans Suggest\ &Corrections<Tab>z= &Suggerimenti<Tab>z=
+menutrans &Repeat\ Correction<Tab>:spellrepall &Ripeti\ correzione<Tab>:spellrepall
+menutrans Set\ Language\ to\ "en" Imposta\ lingua\ a\ "en"
+menutrans Set\ Language\ to\ "en_au" Imposta\ lingua\ a\ "en_au"
+menutrans Set\ Language\ to\ "en_ca" Imposta\ lingua\ a\ "en_ca"
+menutrans Set\ Language\ to\ "en_gb" Imposta\ lingua\ a\ "en_gb"
+menutrans Set\ Language\ to\ "en_nz" Imposta\ lingua\ a\ "en_nz"
+menutrans Set\ Language\ to\ "en_us" Imposta\ lingua\ a\ "en_us"
+menutrans &Find\ More\ Languages &Trova\ altre\ lingue
 
-menut Select\ Fo&nt\.\.\.		Scegli\ &Font\.\.\.
+" func! s:SpellLang()
+if !exists("g:menutrans_set_lang_to")
+  let g:menutrans_set_lang_to = "Cambia linguaggio a"
+endif
+" }}}
 
-" Menù strumenti programmazione
-menut &Tools				&Strumenti
+" Tools.Fold Menu
+menutrans &Folding &Piegature
+" Tools.Fold menuitems {{{2
+" open close folds
+menutrans &Enable/Disable\ Folds<Tab>zi Pi&egature\ Sì/No<Tab>zi
+menutrans &View\ Cursor\ Line<Tab>zv &Vedi\ linea\ col\ Cursore<Tab>zv
+menutrans Vie&w\ Cursor\ Line\ Only<Tab>zMzx Vedi\ &Solo\ linea\ col\ Cursore<Tab>zMzx
+menutrans C&lose\ More\ Folds<Tab>zm C&Hiudi\ più\ piegature<Tab>zm
+menutrans &Close\ All\ Folds<Tab>zM &Chiudi\ tutte\ le\ piegature<Tab>zM
+menutrans O&pen\ More\ Folds<Tab>zr A&Pri\ più\ piegature<Tab>zr
+menutrans &Open\ All\ Folds<Tab>zR &Apri\ tutte\ le\ piegature<Tab>zR
+" fold method
+menutrans Fold\ Met&hod Meto&Do\ piegatura
+" Tools.Fold.Fold Method menuitems {{{3
+menutrans M&anual &Manuale
+menutrans I&ndent &Nidificazione
+menutrans E&xpression &Espressione\ Reg\.
+menutrans S&yntax &Sintassi
+menutrans &Diff &Differenza
+menutrans Ma&rker Mar&Catura
+" }}}
+" create and delete folds
+menutrans Create\ &Fold<Tab>zf Crea\ &Piegatura<Tab>zf
+menutrans &Delete\ Fold<Tab>zd &Leva\ piegatura<Tab>zd
+menutrans Delete\ &All\ Folds<Tab>zD Leva\ &Tutte\ le\ piegature<Tab>zD
+" moving around in folds
+menutrans Fold\ Col&umn\ Width Larghezza\ piegat&Ure\ in\ colonne
+" }}}
 
-menut &Jump\ to\ this\ tag<Tab>g^]	&Vai\ a\ questa\ tag<Tab>g^]
-menut Jump\ &back<Tab>^T		Torna\ &Indietro<Tab>^T
-menut Build\ &Tags\ File		Costruisci\ file\ &Tags\
-" Menù ortografia / Spelling
-menut &Spelling			&Ortografia
+" Tools.Diff Menu
+menutrans &Diff &Differenza
+" Tools.Diff menuitems {{{2
+menutrans &Update &Aggiorna
+menutrans &Get\ Block &Importa\ differenze
+menutrans &Put\ Block &Esporta\ differenze
+" }}}
 
-menut &Spell\ Check\ On			Attiva\ &Controllo\ ortografico
-menut Spell\ Check\ &Off		&Disattiva\ controllo\ ortografico
-menut To\ &Next\ error<Tab>]s		Errore\ &Seguente<tab>]s
-menut To\ &Previous\ error<Tab>[s	Errore\ &Precedente<tab>[s
-menut Suggest\ &Corrections<Tab>z=	&Suggerimenti<Tab>z=
-menut &Repeat\ correction<Tab>:spellrepall	&Ripeti\ correzione<Tab>:spellrepall
-menut Set\ language\ to\ "en"		Imposta\ lingua\ a\ "en"
-menut Set\ language\ to\ "en_au"	Imposta\ lingua\ a\ "en_au"
-menut Set\ language\ to\ "en_ca"	Imposta\ lingua\ a\ "en_ca"
-menut Set\ language\ to\ "en_gb"	Imposta\ lingua\ a\ "en_gb"
-menut Set\ language\ to\ "en_nz"	Imposta\ lingua\ a\ "en_nz"
-menut Set\ language\ to\ "en_us"	Imposta\ lingua\ a\ "en_us"
-menut &Find\ More\ Languages		&Trova\ altre\ lingue
+menutrans &Make<Tab>:make Esegui\ &Make<Tab>:make
+menutrans &List\ Errors<Tab>:cl Lista\ &Errori<Tab>:cl
+menutrans L&ist\ Messages<Tab>:cl! Lista\ &Messaggi<Tab>:cl!
+menutrans &Next\ Error<Tab>:cn Errore\ s&Uccessivo<Tab>:cn
+menutrans &Previous\ Error<Tab>:cp Errore\ &Precedente<Tab>:cp
+menutrans &Older\ List<Tab>:cold Lista\ men&O\ recente<Tab>:cold
+menutrans N&ewer\ List<Tab>:cnew Lista\ più\ rece&Nte<Tab>:cnew
+menutrans Error\ &Window &Finestra\ errori
+" Tools.Error Window menuitems {{{2
+menutrans &Update<Tab>:cwin A&Ggiorna<Tab>:cwin
+menutrans &Open<Tab>:copen &Apri<Tab>:copen
+menutrans &Close<Tab>:cclose &Chiudi<Tab>:cclose
+" }}}
+" menutrans Show\ Compiler\ Se&ttings\ in\ Menu TRANSLATION\ MISSING
+menutrans Se&t\ Compiler Impo&Sta\ Compilatore
+menutrans &Convert\ to\ HEX<Tab>:%!xxd &Converti\ a\ esadecimale<Tab>:%!xxd
+menutrans Conve&rt\ Back<Tab>:%!xxd\ -r Conve&rti\ da\ esadecimale<Tab>:%!xxd\ -r
+" }}}
 
-" Menù piegature / Fold
-menut &Folding					&Piegature
-" apri e chiudi piegature
-menut &Enable/Disable\ folds<Tab>zi		Pi&egature\ Sì/No<Tab>zi
-menut &View\ Cursor\ Line<Tab>zv			&Vedi\ linea\ col\ Cursore<Tab>zv
-menut Vie&w\ Cursor\ Line\ only<Tab>zMzx		Vedi\ &Solo\ linea\ col\ Cursore<Tab>zMzx
-menut C&lose\ more\ folds<Tab>zm			C&Hiudi\ più\ piegature<Tab>zm
-menut &Close\ all\ folds<Tab>zM			&Chiudi\ tutte\ le\ piegature<Tab>zM
-menut O&pen\ more\ folds<Tab>zr			A&Pri\ più\ piegature<Tab>zr
-menut &Open\ all\ folds<Tab>zR			&Apri\ tutte\ le\ piegature<Tab>zR
-" metodo piegatura
-menut Fold\ Met&hod				Meto&Do\ piegatura
-menut M&anual					&Manuale
-menut I&ndent					&Nidificazione
-menut E&xpression					&Espressione\ Reg\.
-menut S&yntax					&Sintassi
-menut &Diff					&Differenza
-menut Ma&rker					Mar&Catura
+" Buffer menu
+menutrans &Buffers &Buffer
+" menutrans Dummy TRANSLATION\ MISSING
+" Buffer menuitems and dialog {{{1
+menutrans &Refresh\ Menu A&ggiorna\ menù
+menutrans &Delete &Elimina
+menutrans &Alternate &Alternato
+menutrans &Next &Successivo
+menutrans &Previous &Precedente
 
-" crea e cancella piegature
-menut Create\ &Fold<Tab>zf			Crea\ &Piegatura<Tab>zf
-menut &Delete\ Fold<Tab>zd			&Leva\ piegatura<Tab>zd
-menut Delete\ &All\ Folds<Tab>zD			Leva\ &Tutte\ le\ piegature<Tab>zD
-" movimenti all'interno delle piegature
-menut Fold\ col&umn\ width			Larghezza\ piegat&Ure\ in\ colonne
+" func! s:BMMunge(fname, bnum)
+if !exists("g:menutrans_no_file")
+  let g:menutrans_no_file = "[Senza nome]"
+endif
+" }}}
 
-menut &Diff					&Differenza
-"
-menut &Update					&Aggiorna
-menut &Get\ Block				&Importa\ differenze
-menut &Put\ Block				&Esporta\ differenze
+" Window menu
+menutrans &Window &Finestra
+" Window menuitems {{{1
+menutrans &New<Tab>^Wn &Nuova<Tab>^Wn
+menutrans S&plit<Tab>^Ws &Dividi\ lo\ schermo<Tab>^Ws
+menutrans Sp&lit\ To\ #<Tab>^W^^ D&Ividi\ verso\ #<Tab>^W^^
+menutrans Split\ &Vertically<Tab>^Wv Di&Vidi\ verticalmente<Tab>^Wv
+menutrans Split\ File\ E&xplorer Aggiungi\ finestra\ e&Xplorer
+menutrans &Close<Tab>^Wc &Chiudi<Tab>^Wc
+menutrans Close\ &Other(s)<Tab>^Wo C&Hiudi\ altra(e)<Tab>^Wo
+menutrans Move\ &To &Muovi\ verso
+menutrans &Top<Tab>^WK &Cima<Tab>^WK
+menutrans &Bottom<Tab>^WJ &Fondo<Tab>^WJ
+menutrans &Left\ Side<Tab>^WH Lato\ &Sinistro<Tab>^WH
+menutrans &Right\ Side<Tab>^WL Lato\ &Destro<Tab>^WL
+menutrans Rotate\ &Up<Tab>^WR Ruota\ verso\ l'&Alto<Tab>^WR
+menutrans Rotate\ &Down<Tab>^Wr Ruota\ verso\ il\ &Basso<Tab>^Wr
+menutrans &Equal\ Size<Tab>^W= &Uguale\ ampiezza<Tab>^W=
+menutrans &Max\ Height<Tab>^W_ &Altezza\ massima<Tab>^W_
+menutrans M&in\ Height<Tab>^W1_ A&Ltezza\ minima<Tab>^W1_
+menutrans Max\ &Width<Tab>^W\| Larghezza\ massima<Tab>^W\|
+menutrans Min\ Widt&h<Tab>^W1\| Larghezza\ minima<Tab>^W1\|
+" }}}
 
-menut &Make<Tab>:make		Esegui\ &Make<Tab>:make
+" The popup menu {{{1
+menutrans &Undo &Annulla
+menutrans Cu&t &Taglia
+menutrans &Copy &Copia
+menutrans &Paste &Incolla
+menutrans &Delete &Elimina
+menutrans Select\ Blockwise Seleziona\ in\ blocco
+menutrans Select\ &Word Seleziona\ &Parola
+" menutrans Select\ &Sentence TRANSLATION\ MISSING
+" menutrans Select\ Pa&ragraph TRANSLATION\ MISSING
+menutrans Select\ &Line Seleziona\ &Linea
+menutrans Select\ &Block Seleziona\ &Blocco
+menutrans Select\ &All Seleziona\ t&Utto
 
-menut &List\ Errors<Tab>:cl		Lista\ &Errori<Tab>:cl
-menut L&ist\ Messages<Tab>:cl!	Lista\ &Messaggi<Tab>:cl!
-menut &Next\ Error<Tab>:cn		Errore\ s&Uccessivo<Tab>:cn
-menut &Previous\ Error<Tab>:cp	Errore\ &Precedente<Tab>:cp
-menut &Older\ List<Tab>:cold	Lista\ men&O\ recente<Tab>:cold
-menut N&ewer\ List<Tab>:cnew	Lista\ più\ rece&Nte<Tab>:cnew
+" func! <SID>SpellPopup()
+if !exists("g:menutrans_spell_change_ARG_to")
+  " let g:menutrans_spell_change_ARG_to = "TRANSLATION MISSING"
+endif
+if !exists("g:menutrans_spell_add_ARG_to_word_list")
+  let g:menutrans_spell_add_ARG_to_word_list = 'Aggiungi\ "%s"\ alla\ Word\ List'
+endif
+if !exists("g:menutrans_spell_ignore_ARG")
+  let g:menutrans_spell_ignore_ARG = 'Ignora\ "%s"'
+endif
+" }}}
 
-menut Error\ &Window		&Finestra\ errori
+" The GUI toolbar {{{1
+if has("toolbar")
+  if exists("*Do_toolbar_tmenu")
+    delfun Do_toolbar_tmenu
+  endif
+  fun Do_toolbar_tmenu()
+    let did_toolbar_tmenu = 1
+    tmenu ToolBar.Open Apri file
+    tmenu ToolBar.Save Salva file
+    tmenu ToolBar.SaveAll Salva tutti i file
+    tmenu ToolBar.Print Stampa
+    tmenu ToolBar.Undo Annulla
+    tmenu ToolBar.Redo Rifai
+    tmenu ToolBar.Cut Taglia
+    tmenu ToolBar.Copy Copia
+    tmenu ToolBar.Paste Incolla
+    if !has("gui_athena")
+      tmenu ToolBar.Replace Sostituisci
+      tmenu ToolBar.FindNext Trova seguente
+      tmenu ToolBar.FindPrev Trova precedente
+    endif
+    tmenu ToolBar.LoadSesn Carica sessione
+    tmenu ToolBar.SaveSesn Salva sessione
+    tmenu ToolBar.RunScript Esegui script
+    tmenu ToolBar.Make Esegui make
+    tmenu ToolBar.RunCtags Esegui ctags
+    tmenu ToolBar.TagJump Salta alla tag
+    tmenu ToolBar.Help Aiuto
+    tmenu ToolBar.FindHelp Trova aiuto...
+  endfun
+endif
+" }}}
 
-menut &Update<Tab>:cwin		A&Ggiorna<Tab>:cwin
-menut &Open<Tab>:copen		&Apri<Tab>:copen
-menut &Close<Tab>:cclose	&Chiudi<Tab>:cclose
+" Syntax menu
+menutrans &Syntax &Sintassi
+" Syntax menuitems {{{1
+menutrans &Show\ File\ Types\ in\ Menu Mo&Stra\ tipi\ di\ file\ nel\ menù
+menutrans &Off &Disattiva
+menutrans &Manual &Manuale
+menutrans A&utomatic A&Utomatico
+menutrans On/Off\ for\ &This\ File Attiva\ Sì/No\ su\ ques&To\ file
+menutrans Co&lor\ Test Test\ &Colori
+menutrans &Highlight\ Test Test\ &Evidenziamento
+menutrans &Convert\ to\ HTML Converti\ ad\ &HTML
 
-menut &Convert\ to\ HEX<Tab>:%!xxd	&Converti\ a\ esadecimale<Tab>:%!xxd
-menut Conve&rt\ back<Tab>:%!xxd\ -r	Conve&rti\ da\ esadecimale<Tab>:%!xxd\ -r
+" From synmenu.vim
+menutrans Set\ '&syntax'\ Only &S\ Attiva\ solo\ \ 'syntax'
+menutrans Set\ '&filetype'\ Too &F\ Attiva\ anche\ 'filetype'
+" menutrans AB TRANSLATION\ MISSING
+" menutrans A2ps\ config TRANSLATION\ MISSING
+" menutrans Aap TRANSLATION\ MISSING
+" menutrans ABAP/4 TRANSLATION\ MISSING
+" menutrans Abaqus TRANSLATION\ MISSING
+" menutrans ABC\ music\ notation TRANSLATION\ MISSING
+" menutrans ABEL TRANSLATION\ MISSING
+" menutrans AceDB\ model TRANSLATION\ MISSING
+" menutrans Ada TRANSLATION\ MISSING
+" menutrans AfLex TRANSLATION\ MISSING
+" menutrans ALSA\ config TRANSLATION\ MISSING
+" menutrans Altera\ AHDL TRANSLATION\ MISSING
+" menutrans Amiga\ DOS TRANSLATION\ MISSING
+" menutrans AMPL TRANSLATION\ MISSING
+" menutrans Ant\ build\ file TRANSLATION\ MISSING
+" menutrans ANTLR TRANSLATION\ MISSING
+" menutrans Apache\ config TRANSLATION\ MISSING
+" menutrans Apache-style\ config TRANSLATION\ MISSING
+" menutrans Applix\ ELF TRANSLATION\ MISSING
+" menutrans APT\ config TRANSLATION\ MISSING
+" menutrans Arc\ Macro\ Language TRANSLATION\ MISSING
+" menutrans Arch\ inventory TRANSLATION\ MISSING
+" menutrans Arduino TRANSLATION\ MISSING
+" menutrans ART TRANSLATION\ MISSING
+" menutrans Ascii\ Doc TRANSLATION\ MISSING
+" menutrans ASP\ with\ VBScript TRANSLATION\ MISSING
+" menutrans ASP\ with\ Perl TRANSLATION\ MISSING
+" menutrans Assembly TRANSLATION\ MISSING
+" menutrans 680x0 TRANSLATION\ MISSING
+" menutrans AVR TRANSLATION\ MISSING
+" menutrans Flat TRANSLATION\ MISSING
+" menutrans GNU TRANSLATION\ MISSING
+" menutrans GNU\ H-8300 TRANSLATION\ MISSING
+" menutrans Intel\ IA-64 TRANSLATION\ MISSING
+" menutrans Microsoft TRANSLATION\ MISSING
+" menutrans Netwide TRANSLATION\ MISSING
+" menutrans PIC TRANSLATION\ MISSING
+" menutrans Turbo TRANSLATION\ MISSING
+" menutrans VAX\ Macro\ Assembly TRANSLATION\ MISSING
+" menutrans Z-80 TRANSLATION\ MISSING
+" menutrans xa\ 6502\ cross\ assember TRANSLATION\ MISSING
+" menutrans ASN\.1 TRANSLATION\ MISSING
+" menutrans Asterisk\ config TRANSLATION\ MISSING
+" menutrans Asterisk\ voicemail\ config TRANSLATION\ MISSING
+" menutrans Atlas TRANSLATION\ MISSING
+" menutrans Autodoc TRANSLATION\ MISSING
+" menutrans AutoHotKey TRANSLATION\ MISSING
+" menutrans AutoIt TRANSLATION\ MISSING
+" menutrans Automake TRANSLATION\ MISSING
+" menutrans Avenue TRANSLATION\ MISSING
+" menutrans Awk TRANSLATION\ MISSING
+" menutrans AYacc TRANSLATION\ MISSING
+" menutrans B TRANSLATION\ MISSING
+" menutrans Baan TRANSLATION\ MISSING
+" menutrans Bash TRANSLATION\ MISSING
+" menutrans Basic TRANSLATION\ MISSING
+" menutrans FreeBasic TRANSLATION\ MISSING
+" menutrans IBasic TRANSLATION\ MISSING
+" menutrans QBasic TRANSLATION\ MISSING
+" menutrans Visual\ Basic TRANSLATION\ MISSING
+" menutrans Bazaar\ commit\ file TRANSLATION\ MISSING
+" menutrans Bazel TRANSLATION\ MISSING
+" menutrans BC\ calculator TRANSLATION\ MISSING
+" menutrans BDF\ font TRANSLATION\ MISSING
+" menutrans BibTeX TRANSLATION\ MISSING
+" menutrans Bibliography\ database TRANSLATION\ MISSING
+" menutrans Bibliography\ Style TRANSLATION\ MISSING
+" menutrans BIND TRANSLATION\ MISSING
+" menutrans BIND\ config TRANSLATION\ MISSING
+" menutrans BIND\ zone TRANSLATION\ MISSING
+" menutrans Blank TRANSLATION\ MISSING
+" menutrans C TRANSLATION\ MISSING
+" menutrans C++ TRANSLATION\ MISSING
+" menutrans C# TRANSLATION\ MISSING
+" menutrans Cabal\ Haskell\ build\ file TRANSLATION\ MISSING
+" menutrans Calendar TRANSLATION\ MISSING
+" menutrans Cascading\ Style\ Sheets TRANSLATION\ MISSING
+" menutrans CDL TRANSLATION\ MISSING
+" menutrans Cdrdao\ TOC TRANSLATION\ MISSING
+" menutrans Cdrdao\ config TRANSLATION\ MISSING
+" menutrans Century\ Term TRANSLATION\ MISSING
+" menutrans CH\ script TRANSLATION\ MISSING
+" menutrans ChaiScript TRANSLATION\ MISSING
+" menutrans Changelog TRANSLATION\ MISSING
+" menutrans CHILL TRANSLATION\ MISSING
+" menutrans Cheetah\ template TRANSLATION\ MISSING
+" menutrans Chicken TRANSLATION\ MISSING
+" menutrans ChordPro TRANSLATION\ MISSING
+" menutrans Clean TRANSLATION\ MISSING
+" menutrans Clever TRANSLATION\ MISSING
+" menutrans Clipper TRANSLATION\ MISSING
+" menutrans Clojure TRANSLATION\ MISSING
+" menutrans Cmake TRANSLATION\ MISSING
+" menutrans Cmod TRANSLATION\ MISSING
+" menutrans Cmusrc TRANSLATION\ MISSING
+" menutrans Cobol TRANSLATION\ MISSING
+" menutrans Coco/R TRANSLATION\ MISSING
+" menutrans Cold\ Fusion TRANSLATION\ MISSING
+" menutrans Conary\ Recipe TRANSLATION\ MISSING
+" menutrans Config TRANSLATION\ MISSING
+" menutrans Cfg\ Config\ file TRANSLATION\ MISSING
+" menutrans Configure\.in TRANSLATION\ MISSING
+" menutrans Generic\ Config\ file TRANSLATION\ MISSING
+" menutrans CRM114 TRANSLATION\ MISSING
+" menutrans Crontab TRANSLATION\ MISSING
+" menutrans CSDL TRANSLATION\ MISSING
+" menutrans CSP TRANSLATION\ MISSING
+" menutrans Ctrl-H TRANSLATION\ MISSING
+" menutrans Cucumber TRANSLATION\ MISSING
+" menutrans CUDA TRANSLATION\ MISSING
+" menutrans CUPL TRANSLATION\ MISSING
+" menutrans Simulation TRANSLATION\ MISSING
+" menutrans CVS TRANSLATION\ MISSING
+" menutrans commit\ file TRANSLATION\ MISSING
+" menutrans cvsrc TRANSLATION\ MISSING
+" menutrans Cyn++ TRANSLATION\ MISSING
+" menutrans Cynlib TRANSLATION\ MISSING
+" menutrans DE TRANSLATION\ MISSING
+" menutrans D TRANSLATION\ MISSING
+" menutrans Dart TRANSLATION\ MISSING
+" menutrans Datascript TRANSLATION\ MISSING
+" menutrans Debian TRANSLATION\ MISSING
+" menutrans Debian\ ChangeLog TRANSLATION\ MISSING
+" menutrans Debian\ Control TRANSLATION\ MISSING
+" menutrans Debian\ Copyright TRANSLATION\ MISSING
+" menutrans Debian\ Sources\.list TRANSLATION\ MISSING
+" menutrans Denyhosts TRANSLATION\ MISSING
+" menutrans Desktop TRANSLATION\ MISSING
+" menutrans Dict\ config TRANSLATION\ MISSING
+" menutrans Dictd\ config TRANSLATION\ MISSING
+" menutrans Diff TRANSLATION\ MISSING
+" menutrans Digital\ Command\ Lang TRANSLATION\ MISSING
+" menutrans Dircolors TRANSLATION\ MISSING
+" menutrans Dirpager TRANSLATION\ MISSING
+" menutrans Django\ template TRANSLATION\ MISSING
+" menutrans DNS/BIND\ zone TRANSLATION\ MISSING
+" menutrans Dnsmasq\ config TRANSLATION\ MISSING
+" menutrans DocBook TRANSLATION\ MISSING
+" menutrans auto-detect TRANSLATION\ MISSING
+" menutrans SGML TRANSLATION\ MISSING
+" menutrans XML TRANSLATION\ MISSING
+" menutrans Dockerfile TRANSLATION\ MISSING
+" menutrans Dot TRANSLATION\ MISSING
+" menutrans Doxygen TRANSLATION\ MISSING
+" menutrans C\ with\ doxygen TRANSLATION\ MISSING
+" menutrans C++\ with\ doxygen TRANSLATION\ MISSING
+" menutrans IDL\ with\ doxygen TRANSLATION\ MISSING
+" menutrans Java\ with\ doxygen TRANSLATION\ MISSING
+" menutrans DataScript\ with\ doxygen TRANSLATION\ MISSING
+" menutrans Dracula TRANSLATION\ MISSING
+" menutrans DSSSL TRANSLATION\ MISSING
+" menutrans DTD TRANSLATION\ MISSING
+" menutrans DTML\ (Zope) TRANSLATION\ MISSING
+" menutrans DTrace TRANSLATION\ MISSING
+" menutrans Dts/dtsi TRANSLATION\ MISSING
+" menutrans Dune TRANSLATION\ MISSING
+" menutrans Dylan TRANSLATION\ MISSING
+" menutrans Dylan\ interface TRANSLATION\ MISSING
+" menutrans Dylan\ lid TRANSLATION\ MISSING
+" menutrans EDIF TRANSLATION\ MISSING
+" menutrans Eiffel TRANSLATION\ MISSING
+" menutrans Eight TRANSLATION\ MISSING
+" menutrans Elinks\ config TRANSLATION\ MISSING
+" menutrans Elm\ filter\ rules TRANSLATION\ MISSING
+" menutrans Embedix\ Component\ Description TRANSLATION\ MISSING
+" menutrans ERicsson\ LANGuage TRANSLATION\ MISSING
+" menutrans ESMTP\ rc TRANSLATION\ MISSING
+" menutrans ESQL-C TRANSLATION\ MISSING
+" menutrans Essbase\ script TRANSLATION\ MISSING
+" menutrans Esterel TRANSLATION\ MISSING
+" menutrans Eterm\ config TRANSLATION\ MISSING
+" menutrans Euphoria\ 3 TRANSLATION\ MISSING
+" menutrans Euphoria\ 4 TRANSLATION\ MISSING
+" menutrans Eviews TRANSLATION\ MISSING
+" menutrans Exim\ conf TRANSLATION\ MISSING
+" menutrans Expect TRANSLATION\ MISSING
+" menutrans Exports TRANSLATION\ MISSING
+" menutrans FG TRANSLATION\ MISSING
+" menutrans Falcon TRANSLATION\ MISSING
+" menutrans Fantom TRANSLATION\ MISSING
+" menutrans Fetchmail TRANSLATION\ MISSING
+" menutrans FlexWiki TRANSLATION\ MISSING
+" menutrans Focus\ Executable TRANSLATION\ MISSING
+" menutrans Focus\ Master TRANSLATION\ MISSING
+" menutrans FORM TRANSLATION\ MISSING
+" menutrans Forth TRANSLATION\ MISSING
+" menutrans Fortran TRANSLATION\ MISSING
+" menutrans FoxPro TRANSLATION\ MISSING
+" menutrans FrameScript TRANSLATION\ MISSING
+" menutrans Fstab TRANSLATION\ MISSING
+" menutrans Fvwm TRANSLATION\ MISSING
+" menutrans Fvwm\ configuration TRANSLATION\ MISSING
+" menutrans Fvwm2\ configuration TRANSLATION\ MISSING
+" menutrans Fvwm2\ configuration\ with\ M4 TRANSLATION\ MISSING
+" menutrans GDB\ command\ file TRANSLATION\ MISSING
+" menutrans GDMO TRANSLATION\ MISSING
+" menutrans Gedcom TRANSLATION\ MISSING
+" menutrans Git TRANSLATION\ MISSING
+" menutrans Output TRANSLATION\ MISSING
+" menutrans Commit TRANSLATION\ MISSING
+" menutrans Rebase TRANSLATION\ MISSING
+" menutrans Send\ Email TRANSLATION\ MISSING
+" menutrans Gitolite TRANSLATION\ MISSING
+" menutrans Gkrellmrc TRANSLATION\ MISSING
+" menutrans Gnash TRANSLATION\ MISSING
+" menutrans Go TRANSLATION\ MISSING
+" menutrans Godoc TRANSLATION\ MISSING
+" menutrans GP TRANSLATION\ MISSING
+" menutrans GPG TRANSLATION\ MISSING
+" menutrans Grof TRANSLATION\ MISSING
+" menutrans Group\ file TRANSLATION\ MISSING
+" menutrans Grub TRANSLATION\ MISSING
+" menutrans GNU\ Server\ Pages TRANSLATION\ MISSING
+" menutrans GNUplot TRANSLATION\ MISSING
+" menutrans GrADS\ scripts TRANSLATION\ MISSING
+" menutrans Gretl TRANSLATION\ MISSING
+" menutrans Groff TRANSLATION\ MISSING
+" menutrans Groovy TRANSLATION\ MISSING
+" menutrans GTKrc TRANSLATION\ MISSING
+" menutrans HIJK TRANSLATION\ MISSING
+" menutrans Haml TRANSLATION\ MISSING
+" menutrans Hamster TRANSLATION\ MISSING
+" menutrans Haskell TRANSLATION\ MISSING
+" menutrans Haskell-c2hs TRANSLATION\ MISSING
+" menutrans Haskell-literate TRANSLATION\ MISSING
+" menutrans HASTE TRANSLATION\ MISSING
+" menutrans HASTE\ preproc TRANSLATION\ MISSING
+" menutrans Hercules TRANSLATION\ MISSING
+" menutrans Hex\ dump TRANSLATION\ MISSING
+" menutrans XXD TRANSLATION\ MISSING
+" menutrans Intel\ MCS51 TRANSLATION\ MISSING
+" menutrans Hg\ commit TRANSLATION\ MISSING
+" menutrans Hollywood TRANSLATION\ MISSING
+" menutrans HTML TRANSLATION\ MISSING
+" menutrans HTML\ with\ M4 TRANSLATION\ MISSING
+" menutrans HTML\ with\ Ruby\ (eRuby) TRANSLATION\ MISSING
+" menutrans Cheetah\ HTML\ template TRANSLATION\ MISSING
+" menutrans Django\ HTML\ template TRANSLATION\ MISSING
+" menutrans Vue TRANSLATION\ MISSING
+" menutrans js\ HTML\ template TRANSLATION\ MISSING
+" menutrans HTML/OS TRANSLATION\ MISSING
+" menutrans XHTML TRANSLATION\ MISSING
+" menutrans Host\.conf TRANSLATION\ MISSING
+" menutrans Hosts\ access TRANSLATION\ MISSING
+" menutrans Hyper\ Builder TRANSLATION\ MISSING
+" menutrans Icewm\ menu TRANSLATION\ MISSING
+" menutrans Icon TRANSLATION\ MISSING
+" menutrans IDL\Generic\ IDL TRANSLATION\ MISSING
+" menutrans IDL\Microsoft\ IDL TRANSLATION\ MISSING
+" menutrans Indent\ profile TRANSLATION\ MISSING
+" menutrans Inform TRANSLATION\ MISSING
+" menutrans Informix\ 4GL TRANSLATION\ MISSING
+" menutrans Initng TRANSLATION\ MISSING
+" menutrans Inittab TRANSLATION\ MISSING
+" menutrans Inno\ setup TRANSLATION\ MISSING
+" menutrans Innovation\ Data\ Processing TRANSLATION\ MISSING
+" menutrans Upstream\ dat TRANSLATION\ MISSING
+" menutrans Upstream\ log TRANSLATION\ MISSING
+" menutrans Upstream\ rpt TRANSLATION\ MISSING
+" menutrans Upstream\ Install\ log TRANSLATION\ MISSING
+" menutrans Usserver\ log TRANSLATION\ MISSING
+" menutrans USW2KAgt\ log TRANSLATION\ MISSING
+" menutrans InstallShield\ script TRANSLATION\ MISSING
+" menutrans Interactive\ Data\ Lang TRANSLATION\ MISSING
+" menutrans IPfilter TRANSLATION\ MISSING
+" menutrans J TRANSLATION\ MISSING
+" menutrans JAL TRANSLATION\ MISSING
+" menutrans JAM TRANSLATION\ MISSING
+" menutrans Jargon TRANSLATION\ MISSING
+" menutrans Java TRANSLATION\ MISSING
+" menutrans JavaCC TRANSLATION\ MISSING
+" menutrans Java\ Server\ Pages TRANSLATION\ MISSING
+" menutrans Java\ Properties TRANSLATION\ MISSING
+" menutrans JavaScript TRANSLATION\ MISSING
+" menutrans JavaScriptReact TRANSLATION\ MISSING
+" menutrans Jess TRANSLATION\ MISSING
+" menutrans Jgraph TRANSLATION\ MISSING
+" menutrans Jovial TRANSLATION\ MISSING
+" menutrans JSON TRANSLATION\ MISSING
+" menutrans Kconfig TRANSLATION\ MISSING
+" menutrans KDE\ script TRANSLATION\ MISSING
+" menutrans Kimwitu++ TRANSLATION\ MISSING
+" menutrans Kivy TRANSLATION\ MISSING
+" menutrans KixTart TRANSLATION\ MISSING
+" menutrans L TRANSLATION\ MISSING
+" menutrans Lace TRANSLATION\ MISSING
+" menutrans LamdaProlog TRANSLATION\ MISSING
+" menutrans Latte TRANSLATION\ MISSING
+" menutrans Ld\ script TRANSLATION\ MISSING
+" menutrans LDAP TRANSLATION\ MISSING
+" menutrans LDIF TRANSLATION\ MISSING
+" menutrans Configuration TRANSLATION\ MISSING
+" menutrans Less TRANSLATION\ MISSING
+" menutrans Lex TRANSLATION\ MISSING
+" menutrans LFTP\ config TRANSLATION\ MISSING
+" menutrans Libao TRANSLATION\ MISSING
+" menutrans LifeLines\ script TRANSLATION\ MISSING
+" menutrans Lilo TRANSLATION\ MISSING
+" menutrans Limits\ config TRANSLATION\ MISSING
+" menutrans Linden\ scripting TRANSLATION\ MISSING
+" menutrans Liquid TRANSLATION\ MISSING
+" menutrans Lisp TRANSLATION\ MISSING
+" menutrans Lite TRANSLATION\ MISSING
+" menutrans LiteStep\ RC TRANSLATION\ MISSING
+" menutrans Locale\ Input TRANSLATION\ MISSING
+" menutrans Login\.access TRANSLATION\ MISSING
+" menutrans Login\.defs TRANSLATION\ MISSING
+" menutrans Logtalk TRANSLATION\ MISSING
+" menutrans LOTOS TRANSLATION\ MISSING
+" menutrans LotusScript TRANSLATION\ MISSING
+" menutrans Lout TRANSLATION\ MISSING
+" menutrans LPC TRANSLATION\ MISSING
+" menutrans Lua TRANSLATION\ MISSING
+" menutrans Lynx\ Style TRANSLATION\ MISSING
+" menutrans Lynx\ config TRANSLATION\ MISSING
+" menutrans M TRANSLATION\ MISSING
+" menutrans M4 TRANSLATION\ MISSING
+" menutrans MaGic\ Point TRANSLATION\ MISSING
+" menutrans Mail\ aliases TRANSLATION\ MISSING
+" menutrans Mailcap TRANSLATION\ MISSING
+" menutrans Mallard TRANSLATION\ MISSING
+" menutrans Makefile TRANSLATION\ MISSING
+" menutrans MakeIndex TRANSLATION\ MISSING
+" menutrans Man\ page TRANSLATION\ MISSING
+" menutrans Man\.conf TRANSLATION\ MISSING
+" menutrans Maple\ V TRANSLATION\ MISSING
+" menutrans Markdown TRANSLATION\ MISSING
+" menutrans Markdown\ with\ R\ statements TRANSLATION\ MISSING
+" menutrans Mason TRANSLATION\ MISSING
+" menutrans Mathematica TRANSLATION\ MISSING
+" menutrans Matlab TRANSLATION\ MISSING
+" menutrans Maxima TRANSLATION\ MISSING
+" menutrans MEL\ (for\ Maya) TRANSLATION\ MISSING
+" menutrans Meson TRANSLATION\ MISSING
+" menutrans Messages\ (/var/log) TRANSLATION\ MISSING
+" menutrans Metafont TRANSLATION\ MISSING
+" menutrans MetaPost TRANSLATION\ MISSING
+" menutrans MGL TRANSLATION\ MISSING
+" menutrans MIX TRANSLATION\ MISSING
+" menutrans MMIX TRANSLATION\ MISSING
+" menutrans Modconf TRANSLATION\ MISSING
+" menutrans Model TRANSLATION\ MISSING
+" menutrans Modsim\ III TRANSLATION\ MISSING
+" menutrans Modula\ 2 TRANSLATION\ MISSING
+" menutrans Modula\ 3 TRANSLATION\ MISSING
+" menutrans Monk TRANSLATION\ MISSING
+" menutrans Motorola\ S-Record TRANSLATION\ MISSING
+" menutrans Mplayer\ config TRANSLATION\ MISSING
+" menutrans MOO TRANSLATION\ MISSING
+" menutrans Mrxvtrc TRANSLATION\ MISSING
+" menutrans MS-DOS/Windows TRANSLATION\ MISSING
+" menutrans 4DOS\ \.bat\ file TRANSLATION\ MISSING
+" menutrans \.bat\/\.cmd\ file TRANSLATION\ MISSING
+" menutrans \.ini\ file TRANSLATION\ MISSING
+" menutrans Message\ text TRANSLATION\ MISSING
+" menutrans Module\ Definition TRANSLATION\ MISSING
+" menutrans Registry TRANSLATION\ MISSING
+" menutrans Resource\ file TRANSLATION\ MISSING
+" menutrans Msql TRANSLATION\ MISSING
+" menutrans MuPAD TRANSLATION\ MISSING
+" menutrans Murphi TRANSLATION\ MISSING
+" menutrans MUSHcode TRANSLATION\ MISSING
+" menutrans Muttrc TRANSLATION\ MISSING
+" menutrans NO TRANSLATION\ MISSING
+" menutrans N1QL TRANSLATION\ MISSING
+" menutrans Nanorc TRANSLATION\ MISSING
+" menutrans Nastran\ input/DMAP TRANSLATION\ MISSING
+" menutrans Natural TRANSLATION\ MISSING
+" menutrans NeoMutt\ setup\ files TRANSLATION\ MISSING
+" menutrans Netrc TRANSLATION\ MISSING
+" menutrans Ninja TRANSLATION\ MISSING
+" menutrans Novell\ NCF\ batch TRANSLATION\ MISSING
+" menutrans Not\ Quite\ C\ (LEGO) TRANSLATION\ MISSING
+" menutrans Nroff TRANSLATION\ MISSING
+" menutrans NSIS\ script TRANSLATION\ MISSING
+" menutrans Obj\ 3D\ wavefront TRANSLATION\ MISSING
+" menutrans Objective\ C TRANSLATION\ MISSING
+" menutrans Objective\ C++ TRANSLATION\ MISSING
+" menutrans OCAML TRANSLATION\ MISSING
+" menutrans Occam TRANSLATION\ MISSING
+" menutrans Omnimark TRANSLATION\ MISSING
+" menutrans OpenROAD TRANSLATION\ MISSING
+" menutrans Open\ Psion\ Lang TRANSLATION\ MISSING
+" menutrans Oracle\ config TRANSLATION\ MISSING
+" menutrans PQ TRANSLATION\ MISSING
+" menutrans Packet\ filter\ conf TRANSLATION\ MISSING
+" menutrans Palm\ resource\ compiler TRANSLATION\ MISSING
+" menutrans Pam\ config TRANSLATION\ MISSING
+" menutrans PApp TRANSLATION\ MISSING
+" menutrans Pascal TRANSLATION\ MISSING
+" menutrans Password\ file TRANSLATION\ MISSING
+" menutrans PCCTS TRANSLATION\ MISSING
+" menutrans PDF TRANSLATION\ MISSING
+" menutrans Perl TRANSLATION\ MISSING
+" menutrans Perl\ 6 TRANSLATION\ MISSING
+" menutrans Perl\ POD TRANSLATION\ MISSING
+" menutrans Perl\ XS TRANSLATION\ MISSING
+" menutrans Template\ toolkit TRANSLATION\ MISSING
+" menutrans Template\ toolkit\ Html TRANSLATION\ MISSING
+" menutrans Template\ toolkit\ JS TRANSLATION\ MISSING
+" menutrans PHP TRANSLATION\ MISSING
+" menutrans PHP\ 3-4 TRANSLATION\ MISSING
+" menutrans Phtml\ (PHP\ 2) TRANSLATION\ MISSING
+" menutrans Pike TRANSLATION\ MISSING
+" menutrans Pine\ RC TRANSLATION\ MISSING
+" menutrans Pinfo\ RC TRANSLATION\ MISSING
+" menutrans PL/M TRANSLATION\ MISSING
+" menutrans PL/SQL TRANSLATION\ MISSING
+" menutrans Pli TRANSLATION\ MISSING
+" menutrans PLP TRANSLATION\ MISSING
+" menutrans PO\ (GNU\ gettext) TRANSLATION\ MISSING
+" menutrans Postfix\ main\ config TRANSLATION\ MISSING
+" menutrans PostScript TRANSLATION\ MISSING
+" menutrans PostScript\ Printer\ Description TRANSLATION\ MISSING
+" menutrans Povray TRANSLATION\ MISSING
+" menutrans Povray\ scene\ descr TRANSLATION\ MISSING
+" menutrans Povray\ configuration TRANSLATION\ MISSING
+" menutrans PPWizard TRANSLATION\ MISSING
+" menutrans Prescribe\ (Kyocera) TRANSLATION\ MISSING
+" menutrans Printcap TRANSLATION\ MISSING
+" menutrans Privoxy TRANSLATION\ MISSING
+" menutrans Procmail TRANSLATION\ MISSING
+" menutrans Product\ Spec\ File TRANSLATION\ MISSING
+" menutrans Progress TRANSLATION\ MISSING
+" menutrans Prolog TRANSLATION\ MISSING
+" menutrans ProMeLa TRANSLATION\ MISSING
+" menutrans Proto TRANSLATION\ MISSING
+" menutrans Protocols TRANSLATION\ MISSING
+" menutrans Purify\ log TRANSLATION\ MISSING
+" menutrans Pyrex TRANSLATION\ MISSING
+" menutrans Python TRANSLATION\ MISSING
+" menutrans Quake TRANSLATION\ MISSING
+" menutrans Quickfix\ window TRANSLATION\ MISSING
+" menutrans R TRANSLATION\ MISSING
+" menutrans R\ help TRANSLATION\ MISSING
+" menutrans R\ noweb TRANSLATION\ MISSING
+" menutrans Racc\ input TRANSLATION\ MISSING
+" menutrans Radiance TRANSLATION\ MISSING
+" menutrans Raml TRANSLATION\ MISSING
+" menutrans Ratpoison TRANSLATION\ MISSING
+" menutrans RCS TRANSLATION\ MISSING
+" menutrans RCS\ log\ output TRANSLATION\ MISSING
+" menutrans RCS\ file TRANSLATION\ MISSING
+" menutrans Readline\ config TRANSLATION\ MISSING
+" menutrans Rebol TRANSLATION\ MISSING
+" menutrans ReDIF TRANSLATION\ MISSING
+" menutrans Rego TRANSLATION\ MISSING
+" menutrans Relax\ NG TRANSLATION\ MISSING
+" menutrans Remind TRANSLATION\ MISSING
+" menutrans Relax\ NG\ compact TRANSLATION\ MISSING
+" menutrans Renderman TRANSLATION\ MISSING
+" menutrans Renderman\ Shader\ Lang TRANSLATION\ MISSING
+" menutrans Renderman\ Interface\ Bytestream TRANSLATION\ MISSING
+" menutrans Resolv\.conf TRANSLATION\ MISSING
+" menutrans Reva\ Forth TRANSLATION\ MISSING
+" menutrans Rexx TRANSLATION\ MISSING
+" menutrans Robots\.txt TRANSLATION\ MISSING
+" menutrans RockLinux\ package\ desc\. TRANSLATION\ MISSING
+" menutrans Rpcgen TRANSLATION\ MISSING
+" menutrans RPL/2 TRANSLATION\ MISSING
+" menutrans ReStructuredText TRANSLATION\ MISSING
+" menutrans ReStructuredText\ with\ R\ statements TRANSLATION\ MISSING
+" menutrans RTF TRANSLATION\ MISSING
+" menutrans Ruby TRANSLATION\ MISSING
+" menutrans Rust TRANSLATION\ MISSING
+" menutrans S-Sm TRANSLATION\ MISSING
+" menutrans S-Lang TRANSLATION\ MISSING
+" menutrans Samba\ config TRANSLATION\ MISSING
+" menutrans SAS TRANSLATION\ MISSING
+" menutrans Sass TRANSLATION\ MISSING
+" menutrans Sather TRANSLATION\ MISSING
+" menutrans Sbt TRANSLATION\ MISSING
+" menutrans Scala TRANSLATION\ MISSING
+" menutrans Scheme TRANSLATION\ MISSING
+" menutrans Scilab TRANSLATION\ MISSING
+" menutrans Screen\ RC TRANSLATION\ MISSING
+" menutrans SCSS TRANSLATION\ MISSING
+" menutrans SDC\ Synopsys\ Design\ Constraints TRANSLATION\ MISSING
+" menutrans SDL TRANSLATION\ MISSING
+" menutrans Sed TRANSLATION\ MISSING
+" menutrans Sendmail\.cf TRANSLATION\ MISSING
+" menutrans Send-pr TRANSLATION\ MISSING
+" menutrans Sensors\.conf TRANSLATION\ MISSING
+" menutrans Service\ Location\ config TRANSLATION\ MISSING
+" menutrans Service\ Location\ registration TRANSLATION\ MISSING
+" menutrans Service\ Location\ SPI TRANSLATION\ MISSING
+" menutrans Services TRANSLATION\ MISSING
+" menutrans Setserial\ config TRANSLATION\ MISSING
+" menutrans SGML\ catalog TRANSLATION\ MISSING
+" menutrans SGML\ DTD TRANSLATION\ MISSING
+" menutrans SGML\ Declaration TRANSLATION\ MISSING
+" menutrans SGML-linuxdoc TRANSLATION\ MISSING
+" menutrans Shell\ script TRANSLATION\ MISSING
+" menutrans sh\ and\ ksh TRANSLATION\ MISSING
+" menutrans csh TRANSLATION\ MISSING
+" menutrans tcsh TRANSLATION\ MISSING
+" menutrans zsh TRANSLATION\ MISSING
+" menutrans SiCAD TRANSLATION\ MISSING
+" menutrans Sieve TRANSLATION\ MISSING
+" menutrans Simula TRANSLATION\ MISSING
+" menutrans Sinda TRANSLATION\ MISSING
+" menutrans Sinda\ compare TRANSLATION\ MISSING
+" menutrans Sinda\ input TRANSLATION\ MISSING
+" menutrans Sinda\ output TRANSLATION\ MISSING
+" menutrans SiSU TRANSLATION\ MISSING
+" menutrans SKILL TRANSLATION\ MISSING
+" menutrans SKILL\ for\ Diva TRANSLATION\ MISSING
+" menutrans Slice TRANSLATION\ MISSING
+" menutrans SLRN TRANSLATION\ MISSING
+" menutrans Slrn\ rc TRANSLATION\ MISSING
+" menutrans Slrn\ score TRANSLATION\ MISSING
+" menutrans SmallTalk TRANSLATION\ MISSING
+" menutrans Smarty\ Templates TRANSLATION\ MISSING
+" menutrans SMIL TRANSLATION\ MISSING
+" menutrans SMITH TRANSLATION\ MISSING
+" menutrans Sn-Sy TRANSLATION\ MISSING
+" menutrans SNMP\ MIB TRANSLATION\ MISSING
+" menutrans SNNS TRANSLATION\ MISSING
+" menutrans SNNS\ network TRANSLATION\ MISSING
+" menutrans SNNS\ pattern TRANSLATION\ MISSING
+" menutrans SNNS\ result TRANSLATION\ MISSING
+" menutrans Snobol4 TRANSLATION\ MISSING
+" menutrans Snort\ Configuration TRANSLATION\ MISSING
+" menutrans SPEC\ (Linux\ RPM) TRANSLATION\ MISSING
+" menutrans Specman TRANSLATION\ MISSING
+" menutrans Spice TRANSLATION\ MISSING
+" menutrans Spyce TRANSLATION\ MISSING
+" menutrans Speedup TRANSLATION\ MISSING
+" menutrans Splint TRANSLATION\ MISSING
+" menutrans Squid\ config TRANSLATION\ MISSING
+" menutrans SQL TRANSLATION\ MISSING
+" menutrans SAP\ HANA TRANSLATION\ MISSING
+" menutrans MySQL TRANSLATION\ MISSING
+" menutrans SQL\ Anywhere TRANSLATION\ MISSING
+" menutrans SQL\ (automatic) TRANSLATION\ MISSING
+" menutrans SQL\ (Oracle) TRANSLATION\ MISSING
+" menutrans SQL\ Forms TRANSLATION\ MISSING
+" menutrans SQLJ TRANSLATION\ MISSING
+" menutrans SQL-Informix TRANSLATION\ MISSING
+" menutrans SQR TRANSLATION\ MISSING
+" menutrans Ssh TRANSLATION\ MISSING
+" menutrans ssh_config TRANSLATION\ MISSING
+" menutrans sshd_config TRANSLATION\ MISSING
+" menutrans Standard\ ML TRANSLATION\ MISSING
+" menutrans Stata TRANSLATION\ MISSING
+" menutrans SMCL TRANSLATION\ MISSING
+" menutrans Stored\ Procedures TRANSLATION\ MISSING
+" menutrans Strace TRANSLATION\ MISSING
+" menutrans Streaming\ descriptor\ file TRANSLATION\ MISSING
+" menutrans Subversion\ commit TRANSLATION\ MISSING
+" menutrans Sudoers TRANSLATION\ MISSING
+" menutrans SVG TRANSLATION\ MISSING
+" menutrans Symbian\ meta-makefile TRANSLATION\ MISSING
+" menutrans Sysctl\.conf TRANSLATION\ MISSING
+" menutrans Systemd TRANSLATION\ MISSING
+" menutrans SystemVerilog TRANSLATION\ MISSING
+" menutrans T TRANSLATION\ MISSING
+" menutrans TADS TRANSLATION\ MISSING
+" menutrans Tags TRANSLATION\ MISSING
+" menutrans TAK TRANSLATION\ MISSING
+" menutrans TAK\ compare TRANSLATION\ MISSING
+" menutrans TAK\ input TRANSLATION\ MISSING
+" menutrans TAK\ output TRANSLATION\ MISSING
+" menutrans Tar\ listing TRANSLATION\ MISSING
+" menutrans Task\ data TRANSLATION\ MISSING
+" menutrans Task\ 42\ edit TRANSLATION\ MISSING
+" menutrans Tcl/Tk TRANSLATION\ MISSING
+" menutrans TealInfo TRANSLATION\ MISSING
+" menutrans Telix\ Salt TRANSLATION\ MISSING
+" menutrans Termcap/Printcap TRANSLATION\ MISSING
+" menutrans Terminfo TRANSLATION\ MISSING
+" menutrans Tera\ Term TRANSLATION\ MISSING
+" menutrans TeX TRANSLATION\ MISSING
+" menutrans TeX/LaTeX TRANSLATION\ MISSING
+" menutrans plain\ TeX TRANSLATION\ MISSING
+" menutrans Initex TRANSLATION\ MISSING
+" menutrans ConTeXt TRANSLATION\ MISSING
+" menutrans TeX\ configuration TRANSLATION\ MISSING
+" menutrans Texinfo TRANSLATION\ MISSING
+" menutrans TF\ mud\ client TRANSLATION\ MISSING
+" menutrans Tidy\ configuration TRANSLATION\ MISSING
+" menutrans Tilde TRANSLATION\ MISSING
+" menutrans Tmux\ configuration TRANSLATION\ MISSING
+" menutrans TPP TRANSLATION\ MISSING
+" menutrans Trasys\ input TRANSLATION\ MISSING
+" menutrans Treetop TRANSLATION\ MISSING
+" menutrans Trustees TRANSLATION\ MISSING
+" menutrans TSS TRANSLATION\ MISSING
+" menutrans Command\ Line TRANSLATION\ MISSING
+" menutrans Geometry TRANSLATION\ MISSING
+" menutrans Optics TRANSLATION\ MISSING
+" menutrans Typescript TRANSLATION\ MISSING
+" menutrans TypescriptReact TRANSLATION\ MISSING
+" menutrans UV TRANSLATION\ MISSING
+" menutrans Udev\ config TRANSLATION\ MISSING
+" menutrans Udev\ permissions TRANSLATION\ MISSING
+" menutrans Udev\ rules TRANSLATION\ MISSING
+" menutrans UIT/UIL TRANSLATION\ MISSING
+" menutrans UnrealScript TRANSLATION\ MISSING
+" menutrans Updatedb\.conf TRANSLATION\ MISSING
+" menutrans Upstart TRANSLATION\ MISSING
+" menutrans Valgrind TRANSLATION\ MISSING
+" menutrans Vera TRANSLATION\ MISSING
+" menutrans Verbose\ TAP\ Output TRANSLATION\ MISSING
+" menutrans Verilog-AMS\ HDL TRANSLATION\ MISSING
+" menutrans Verilog\ HDL TRANSLATION\ MISSING
+" menutrans Vgrindefs TRANSLATION\ MISSING
+" menutrans VHDL TRANSLATION\ MISSING
+" menutrans Vim TRANSLATION\ MISSING
+" menutrans Vim\ help\ file TRANSLATION\ MISSING
+" menutrans Vim\ script TRANSLATION\ MISSING
+" menutrans Viminfo\ file TRANSLATION\ MISSING
+" menutrans Virata\ config TRANSLATION\ MISSING
+" menutrans VOS\ CM\ macro TRANSLATION\ MISSING
+" menutrans VRML TRANSLATION\ MISSING
+" menutrans Vroom TRANSLATION\ MISSING
+" menutrans VSE\ JCL TRANSLATION\ MISSING
+" menutrans WXYZ TRANSLATION\ MISSING
+" menutrans WEB TRANSLATION\ MISSING
+" menutrans CWEB TRANSLATION\ MISSING
+" menutrans WEB\ Changes TRANSLATION\ MISSING
+" menutrans WebAssembly TRANSLATION\ MISSING
+" menutrans Webmacro TRANSLATION\ MISSING
+" menutrans Website\ MetaLanguage TRANSLATION\ MISSING
+" menutrans wDiff TRANSLATION\ MISSING
+" menutrans Wget\ config TRANSLATION\ MISSING
+" menutrans Whitespace\ (add) TRANSLATION\ MISSING
+" menutrans WildPackets\ EtherPeek\ Decoder TRANSLATION\ MISSING
+" menutrans WinBatch/Webbatch TRANSLATION\ MISSING
+" menutrans Windows\ Scripting\ Host TRANSLATION\ MISSING
+" menutrans WSML TRANSLATION\ MISSING
+" menutrans WvDial TRANSLATION\ MISSING
+" menutrans X\ Keyboard\ Extension TRANSLATION\ MISSING
+" menutrans X\ Pixmap TRANSLATION\ MISSING
+" menutrans X\ Pixmap\ (2) TRANSLATION\ MISSING
+" menutrans X\ resources TRANSLATION\ MISSING
+" menutrans XBL TRANSLATION\ MISSING
+" menutrans Xinetd\.conf TRANSLATION\ MISSING
+" menutrans Xmodmap TRANSLATION\ MISSING
+" menutrans Xmath TRANSLATION\ MISSING
+" menutrans XML\ Schema\ (XSD) TRANSLATION\ MISSING
+" menutrans XQuery TRANSLATION\ MISSING
+" menutrans Xslt TRANSLATION\ MISSING
+" menutrans XFree86\ Config TRANSLATION\ MISSING
+" menutrans YAML TRANSLATION\ MISSING
+" menutrans Yacc TRANSLATION\ MISSING
+" menutrans Zimbu TRANSLATION\ MISSING
+" }}}
 
-menut Se&T\ Compiler		Impo&Sta\ Compilatore
+" Netrw menu {{{1
+" Plugin loading may be after menu translation
+" So giveup testing if Netrw Plugin is loaded
+" if exists("g:loaded_netrwPlugin")
+  " menutrans Help<tab><F1> TRANSLATION\ MISSING
+  " menutrans Bookmarks TRANSLATION\ MISSING
+  " menutrans History TRANSLATION\ MISSING
+  " menutrans Go\ Up\ Directory<tab>- TRANSLATION\ MISSING
+  " menutrans Apply\ Special\ Viewer<tab>x TRANSLATION\ MISSING
+  " menutrans Bookmarks\ and\ History TRANSLATION\ MISSING
+  " Netrw.Bookmarks and History menuitems {{{2
+  " menutrans Bookmark\ Current\ Directory<tab>mb TRANSLATION\ MISSING
+  " menutrans Bookmark\ Delete TRANSLATION\ MISSING
+  " menutrans Goto\ Prev\ Dir\ (History)<tab>u TRANSLATION\ MISSING
+  " menutrans Goto\ Next\ Dir\ (History)<tab>U TRANSLATION\ MISSING
+  " menutrans List<tab>qb TRANSLATION\ MISSING
+  " }}}
+  " menutrans Browsing\ Control TRANSLATION\ MISSING
+  " Netrw.Browsing Control menuitems {{{2
+  " menutrans Horizontal\ Split<tab>o TRANSLATION\ MISSING
+  " menutrans Vertical\ Split<tab>v TRANSLATION\ MISSING
+  " menutrans New\ Tab<tab>t TRANSLATION\ MISSING
+  " menutrans Preview<tab>p TRANSLATION\ MISSING
+  " menutrans Edit\ File\ Hiding\ List<tab><ctrl-h> TRANSLATION\ MISSING
+  " menutrans Edit\ Sorting\ Sequence<tab>S TRANSLATION\ MISSING
+  " menutrans Quick\ Hide/Unhide\ Dot\ Files<tab>gh TRANSLATION\ MISSING
+  " menutrans Refresh\ Listing<tab><ctrl-l> TRANSLATION\ MISSING
+  " menutrans Settings/Options<tab>:NetrwSettings TRANSLATION\ MISSING
+  " }}}
+  " menutrans Delete\ File/Directory<tab>D TRANSLATION\ MISSING
+  " menutrans Edit\ File/Dir TRANSLATION\ MISSING
+  " Netrw.Edit File menuitems {{{2
+  " menutrans Create\ New\ File<tab>% TRANSLATION\ MISSING
+  " menutrans In\ Current\ Window<tab><cr> TRANSLATION\ MISSING
+  " menutrans Preview\ File/Directory<tab>p TRANSLATION\ MISSING
+  " menutrans In\ Previous\ Window<tab>P TRANSLATION\ MISSING
+  " menutrans In\ New\ Window<tab>o TRANSLATION\ MISSING
+  " menutrans In\ New\ Tab<tab>t TRANSLATION\ MISSING
+  " menutrans In\ New\ Vertical\ Window<tab>v TRANSLATION\ MISSING
+  " }}}
+  " menutrans Explore TRANSLATION\ MISSING
+  " Netrw.Explore menuitems {{{2
+  " menutrans Directory\ Name TRANSLATION\ MISSING
+  " menutrans Filenames\ Matching\ Pattern\ (curdir\ only)<tab>:Explore\ */ TRANSLATION\ MISSING
+  " menutrans Filenames\ Matching\ Pattern\ (+subdirs)<tab>:Explore\ **/ TRANSLATION\ MISSING
+  " menutrans Files\ Containing\ String\ Pattern\ (curdir\ only)<tab>:Explore\ *// TRANSLATION\ MISSING
+  " menutrans Files\ Containing\ String\ Pattern\ (+subdirs)<tab>:Explore\ **// TRANSLATION\ MISSING
+  " menutrans Next\ Match<tab>:Nexplore TRANSLATION\ MISSING
+  " menutrans Prev\ Match<tab>:Pexplore TRANSLATION\ MISSING
+  " }}}
+  " menutrans Make\ Subdirectory<tab>d TRANSLATION\ MISSING
+  " menutrans Marked\ Files TRANSLATION\ MISSING
+  " Netrw.Marked Files menuitems {{{2
+  " menutrans Mark\ File<tab>mf TRANSLATION\ MISSING
+  " menutrans Mark\ Files\ by\ Regexp<tab>mr TRANSLATION\ MISSING
+  " menutrans Hide-Show-List\ Control<tab>a TRANSLATION\ MISSING
+  " menutrans Copy\ To\ Target<tab>mc TRANSLATION\ MISSING
+  " menutrans Delete<tab>D TRANSLATION\ MISSING
+  " menutrans Diff<tab>md TRANSLATION\ MISSING
+  " menutrans Edit<tab>me TRANSLATION\ MISSING
+  " menutrans Exe\ Cmd<tab>mx TRANSLATION\ MISSING
+  " menutrans Move\ To\ Target<tab>mm TRANSLATION\ MISSING
+  " menutrans Obtain<tab>O TRANSLATION\ MISSING
+  " menutrans Print<tab>mp TRANSLATION\ MISSING
+  " menutrans Replace<tab>R TRANSLATION\ MISSING
+  " menutrans Set\ Target<tab>mt TRANSLATION\ MISSING
+  " menutrans Tag<tab>mT TRANSLATION\ MISSING
+  " menutrans Zip/Unzip/Compress/Uncompress<tab>mz TRANSLATION\ MISSING
+  " }}}
+  " menutrans Obtain\ File<tab>O TRANSLATION\ MISSING
+  " menutrans Style TRANSLATION\ MISSING
+  " Netrw.Style menuitems {{{2
+  " menutrans Listing TRANSLATION\ MISSING
+  " Netrw.Style.Listing menuitems {{{3
+  " menutrans thin<tab>i TRANSLATION\ MISSING
+  " menutrans long<tab>i TRANSLATION\ MISSING
+  " menutrans wide<tab>i TRANSLATION\ MISSING
+  " menutrans tree<tab>i TRANSLATION\ MISSING
+  " }}}
+  " menutrans Normal-Hide-Show TRANSLATION\ MISSING
+  " Netrw.Style.Normal-Hide_show menuitems {{{3
+  " menutrans Show\ All<tab>a TRANSLATION\ MISSING
+  " menutrans Normal<tab>a TRANSLATION\ MISSING
+  " menutrans Hidden\ Only<tab>a TRANSLATION\ MISSING
+  " }}}
+  " menutrans Reverse\ Sorting\ Order<tab>r TRANSLATION\ MISSING
+  " menutrans Sorting\ Method TRANSLATION\ MISSING
+  " Netrw.Style.Sorting Method menuitems {{{3
+  " menutrans Name<tab>s TRANSLATION\ MISSING
+  " menutrans Time<tab>s TRANSLATION\ MISSING
+  " menutrans Size<tab>s TRANSLATION\ MISSING
+  " menutrans Exten<tab>s TRANSLATION\ MISSING
+  " }}}
+  " }}}
+  " menutrans Rename\ File/Directory<tab>R TRANSLATION\ MISSING
+  " menutrans Set\ Current\ Directory<tab>c TRANSLATION\ MISSING
+  " menutrans Targets TRANSLATION\ MISSING
+" endif
+" }}}
 
-" Buffers / Buffer
-menut &Buffers			&Buffer
+" Shellmenu menu
+" Shellmenu menuitems {{{1
+" From shellmenu.vim
+" menutrans ShellMenu TRANSLATION\ MISSING
+" menutrans MAIL TRANSLATION\ MISSING
+" menutrans eval TRANSLATION\ MISSING
+" menutrans Statements TRANSLATION\ MISSING
+" menutrans for TRANSLATION\ MISSING
+" menutrans case TRANSLATION\ MISSING
+" menutrans if TRANSLATION\ MISSING
+" menutrans if-else TRANSLATION\ MISSING
+" menutrans elif TRANSLATION\ MISSING
+" menutrans while TRANSLATION\ MISSING
+" menutrans break TRANSLATION\ MISSING
+" menutrans continue TRANSLATION\ MISSING
+" menutrans function TRANSLATION\ MISSING
+" menutrans return TRANSLATION\ MISSING
+" menutrans return-true TRANSLATION\ MISSING
+" menutrans return-false TRANSLATION\ MISSING
+" menutrans exit TRANSLATION\ MISSING
+" menutrans shift TRANSLATION\ MISSING
+" menutrans trap TRANSLATION\ MISSING
+" menutrans Test TRANSLATION\ MISSING
+" menutrans Existence TRANSLATION\ MISSING
+" menutrans Existence\ -\ file TRANSLATION\ MISSING
+" menutrans Existence\ -\ file\ (not\ empty) TRANSLATION\ MISSING
+" menutrans Existence\ -\ directory TRANSLATION\ MISSING
+" menutrans Existence\ -\ executable TRANSLATION\ MISSING
+" menutrans Existence\ -\ readable TRANSLATION\ MISSING
+" menutrans Existence\ -\ writable TRANSLATION\ MISSING
+" menutrans String\ is\ empty TRANSLATION\ MISSING
+" menutrans String\ is\ not\ empty TRANSLATION\ MISSING
+" menutrans Strings\ are\ equal TRANSLATION\ MISSING
+" menutrans Strings\ are\ not\ equal TRANSLATION\ MISSING
+" menutrans Value\ is\ greater\ than TRANSLATION\ MISSING
+" menutrans Value\ is\ greater\ equal TRANSLATION\ MISSING
+" menutrans Values\ are\ equal TRANSLATION\ MISSING
+" menutrans Values\ are\ not\ equal TRANSLATION\ MISSING
+" menutrans Value\ is\ less\ than TRANSLATION\ MISSING
+" menutrans Value\ is\ less\ equal TRANSLATION\ MISSING
+" menutrans ParmSub TRANSLATION\ MISSING
+" menutrans Substitute\ word\ if\ parm\ not\ set TRANSLATION\ MISSING
+" menutrans Set\ parm\ to\ word\ if\ not\ set TRANSLATION\ MISSING
+" menutrans Substitute\ word\ if\ parm\ set\ else\ nothing TRANSLATION\ MISSING
+" menutrans If\ parm\ not\ set\ print\ word\ and\ exit TRANSLATION\ MISSING
+" menutrans SpShVars TRANSLATION\ MISSING
+" menutrans Number\ of\ positional\ parameters TRANSLATION\ MISSING
+" menutrans All\ positional\ parameters\ (quoted\ spaces) TRANSLATION\ MISSING
+" menutrans All\ positional\ parameters\ (unquoted\ spaces) TRANSLATION\ MISSING
+" menutrans Flags\ set TRANSLATION\ MISSING
+" menutrans Return\ code\ of\ last\ command TRANSLATION\ MISSING
+" menutrans Process\ number\ of\ this\ shell TRANSLATION\ MISSING
+" menutrans Process\ number\ of\ last\ background\ command TRANSLATION\ MISSING
+" menutrans Environ TRANSLATION\ MISSING
+" menutrans HOME TRANSLATION\ MISSING
+" menutrans PATH TRANSLATION\ MISSING
+" menutrans CDPATH TRANSLATION\ MISSING
+" menutrans MAILCHECK TRANSLATION\ MISSING
+" menutrans PS1 TRANSLATION\ MISSING
+" menutrans PS2 TRANSLATION\ MISSING
+" menutrans IFS TRANSLATION\ MISSING
+" menutrans SHACCT TRANSLATION\ MISSING
+menutrans SHELL Shell
+" menutrans LC_CTYPE TRANSLATION\ MISSING
+" menutrans LC_MESSAGES TRANSLATION\ MISSING
+" menutrans Builtins TRANSLATION\ MISSING
+" menutrans cd TRANSLATION\ MISSING
+" menutrans echo TRANSLATION\ MISSING
+" menutrans exec TRANSLATION\ MISSING
+" menutrans export TRANSLATION\ MISSING
+" menutrans getopts TRANSLATION\ MISSING
+" menutrans hash TRANSLATION\ MISSING
+" menutrans newgrp TRANSLATION\ MISSING
+" menutrans pwd TRANSLATION\ MISSING
+" menutrans read TRANSLATION\ MISSING
+" menutrans readonly TRANSLATION\ MISSING
+" menutrans times TRANSLATION\ MISSING
+" menutrans type TRANSLATION\ MISSING
+" menutrans umask TRANSLATION\ MISSING
+" menutrans wait TRANSLATION\ MISSING
+" menutrans Set TRANSLATION\ MISSING
+" menutrans unset TRANSLATION\ MISSING
+" menutrans Mark\ created\ or\ modified\ variables\ for\ export TRANSLATION\ MISSING
+" menutrans Exit\ when\ command\ returns\ non-zero\ status TRANSLATION\ MISSING
+" menutrans Disable\ file\ name\ expansion TRANSLATION\ MISSING
+" menutrans Locate\ and\ remember\ commands\ when\ being\ looked\ up TRANSLATION\ MISSING
+" menutrans All\ assignment\ statements\ are\ placed\ in\ the\ environment\ for\ a\ command TRANSLATION\ MISSING
+" menutrans Read\ commands\ but\ do\ not\ execute\ them TRANSLATION\ MISSING
+" menutrans Exit\ after\ reading\ and\ executing\ one\ command TRANSLATION\ MISSING
+" menutrans Treat\ unset\ variables\ as\ an\ error\ when\ substituting TRANSLATION\ MISSING
+" menutrans Print\ shell\ input\ lines\ as\ they\ are\ read TRANSLATION\ MISSING
+" menutrans Print\ commands\ and\ their\ arguments\ as\ they\ are\ executed TRANSLATION\ MISSING
+" }}}
 
-menut &Refresh\ menu		A&ggiorna\ menù
-menut &Delete			&Elimina
-menut &Alternate		&Alternato
-menut &Next			&Successivo
-menut &Previous			&Precedente
-menut [No\ File]		[Nessun\ File]
+" termdebug menu
+" termdebug menuitems {{{1
+" From termdebug.vim
+" menutrans Set\ breakpoint TRANSLATION\ MISSING
+" menutrans Clear\ breakpoint TRANSLATION\ MISSING
+" menutrans Run\ until TRANSLATION\ MISSING
+" menutrans Evaluate TRANSLATION\ MISSING
+" menutrans WinBar TRANSLATION\ MISSING
+" menutrans Step TRANSLATION\ MISSING
+" menutrans Next TRANSLATION\ MISSING
+" menutrans Finish TRANSLATION\ MISSING
+" menutrans Cont TRANSLATION\ MISSING
+" menutrans Stop TRANSLATION\ MISSING
+" }}}
 
-" Syntax / Sintassi
-menut &Syntax				&Sintassi
+" debchangelog menu
+" debchangelog menuitems {{{1
+" From debchangelog.vim
+" menutrans &Changelog TRANSLATION\ MISSING
+" menutrans &New\ Version TRANSLATION\ MISSING
+" menutrans &Add\ Entry TRANSLATION\ MISSING
+" menutrans &Close\ Bug TRANSLATION\ MISSING
+" menutrans Set\ &Distribution TRANSLATION\ MISSING
+" menutrans &unstable TRANSLATION\ MISSING
+" menutrans &frozen TRANSLATION\ MISSING
+" menutrans &stable TRANSLATION\ MISSING
+" menutrans frozen\ unstable TRANSLATION\ MISSING
+" menutrans stable\ unstable TRANSLATION\ MISSING
+" menutrans stable\ frozen TRANSLATION\ MISSING
+" menutrans stable\ frozen\ unstable TRANSLATION\ MISSING
+" menutrans Set\ &Urgency TRANSLATION\ MISSING
+" menutrans &low TRANSLATION\ MISSING
+" menutrans &medium TRANSLATION\ MISSING
+" menutrans &high TRANSLATION\ MISSING
+" menutrans U&nfinalise TRANSLATION\ MISSING
+" menutrans &Finalise TRANSLATION\ MISSING
+" }}}
 
-menut &Show\ File\ Types\ in\ menu	Mo&Stra\ tipi\ di\ file\ nel\ menù
-menut Set\ '&syntax'\ only		&S\ Attiva\ solo\ \ 'syntax'
-menut Set\ '&filetype'\ too		&F\ Attiva\ anche\ 'filetype'
-menut &Off				&Disattiva
-menut &Manual				&Manuale
-menut A&utomatic			A&Utomatico
-menut on/off\ for\ &This\ file		Attiva\ Sì/No\ su\ ques&To\ file
-menut Co&lor\ test			Test\ &Colori
-menut &Highlight\ test			Test\ &Evidenziamento
-menut &Convert\ to\ HTML		Converti\ ad\ &HTML
+" ada menu
+" ada menuitems {{{1
+" From ada.vim
+" menutrans Tag TRANSLATION\ MISSING
+" menutrans List TRANSLATION\ MISSING
+" menutrans Jump TRANSLATION\ MISSING
+" menutrans Create\ File TRANSLATION\ MISSING
+" menutrans Create\ Dir TRANSLATION\ MISSING
+" menutrans Highlight TRANSLATION\ MISSING
+" menutrans Toggle\ Space\ Errors TRANSLATION\ MISSING
+" menutrans Toggle\ Lines\ Errors TRANSLATION\ MISSING
+" menutrans Toggle\ Rainbow\ Color TRANSLATION\ MISSING
+" menutrans Toggle\ Standard\ Types TRANSLATION\ MISSING
+" }}}
 
-let g:menutrans_set_lang_to = "Cambia linguaggio a"
-let g:menutrans_no_file = "[Senza nome]"
-let g:menutrans_spell_change_ARG = 'Cambia\ da\ "%s"\ a'
-let g:menutrans_spell_add_ARG_to_word_list = 'Aggiungi\ "%s"\ alla\ Word\ List'
-let g:menutrans_spell_ignore_ARG = 'Ignora\ "%s"'
-
-" Window / Finestra
-menut &Window				&Finestra
-
-menut &New<Tab>^Wn			&Nuova<Tab>^Wn
-menut S&plit<Tab>^Ws			&Dividi\ lo\ schermo<Tab>^Ws
-menut Sp&lit\ To\ #<Tab>^W^^		D&Ividi\ verso\ #<Tab>^W^^
-menut Split\ &Vertically<Tab>^Wv	Di&Vidi\ verticalmente<Tab>^Wv
-menut Split\ File\ E&xplorer		Aggiungi\ finestra\ e&Xplorer
-menut &Close<Tab>^Wc			&Chiudi<Tab>^Wc
-menut Close\ &Other(s)<Tab>^Wo		C&Hiudi\ altra(e)<Tab>^Wo
-menut Move\ &To				&Muovi\ verso
-
-menut &Top<Tab>^WK			&Cima<Tab>^WK
-menut &Bottom<Tab>^WJ			&Fondo<Tab>^WJ
-menut &Left\ side<Tab>^WH		Lato\ &Sinistro<Tab>^WH
-menut &Right\ side<Tab>^WL		Lato\ &Destro<Tab>^WL
-menut Rotate\ &Up<Tab>^WR		Ruota\ verso\ l'&Alto<Tab>^WR
-menut Rotate\ &Down<Tab>^Wr		Ruota\ verso\ il\ &Basso<Tab>^Wr
-menut &Equal\ Size<Tab>^W=		&Uguale\ ampiezza<Tab>^W=
-menut &Max\ Height<Tab>^W_		&Altezza\ massima<Tab>^W_
-menut M&in\ Height<Tab>^W1_		A&Ltezza\ minima<Tab>^W1_
-menut Max\ &Width<Tab>^W\|		Larghezza\ massima<Tab>^W\|
-menut Min\ Widt&h<Tab>^W1\|		Larghezza\ minima<Tab>^W1\|
-
-" The popup menu
-menut &Undo		&Annulla
-menut Cu&t		&Taglia
-menut &Copy		&Copia
-menut &Paste		&Incolla
-menut &Delete		&Elimina
-menut Select\ Blockwise 	Seleziona\ in\ blocco
-menut Select\ &Word		Seleziona\ &Parola
-menut Select\ &Line		Seleziona\ &Linea
-menut Select\ &Block 		Seleziona\ &Blocco
-menut Select\ &All		Seleziona\ t&Utto
-
-" The GUI Toolbar / Barra Strumenti
-menut Open		Apri
-menut Save		Salva
-menut SaveAll		Salva\ Tutto
-menut Print		Stampa
-menut Undo		Annulla
-menut Redo		Ripristina
-menut Cut		Taglia
-menut Copy		Copia
-menut Paste		Incolla
-" -sep3-
-menut Find	Cerca
-menut FindNext	Cerca\ Successivo
-menut FindPrev	Cerca\ Precedente
-menut Replace	Sostituisci
-" -sep4-
-menut New		Nuova\ finestra
-menut WinSplit		Dividi\ finestra
-menut WinMax		Massima\ ampiezza
-menut WinMin		Minima\ ampiezza
-menut WinVSplit		Dividi\ verticalmente
-menut WinMaxWidth	Massima\ larghezza
-menut WinMinWidth	Minima\ larghezza
-menut WinClose		Chiudi\ finestra
-menut LoadSesn		Carica\ Sessione
-menut SaveSesn		Salva\ Sessione
-menut RunScript		Esegui\ Script
-menut Make		Make
-menut Shell		Shell
-menut RunCtags		Esegui\ Ctags
-menut TagJump		Vai\ a\ Tag
-menut Help		Aiuto
-menut FindHelp		Cerca\ in\ Aiuto
+" gnat menu
+" gnat menuitems {{{1
+" From gnat.vim
+" menutrans GNAT TRANSLATION\ MISSING
+" menutrans Build TRANSLATION\ MISSING
+" menutrans Pretty\ Print TRANSLATION\ MISSING
+menutrans Find Cerca
+" menutrans Set\ Projectfile\.\.\. TRANSLATION\ MISSING
+" }}}
 
 let &cpo = s:keepcpo
 unlet s:keepcpo
 
-" vim: set sw=2 :
+" vim: set ts=4 sw=4 noet fdm=marker fdc=4 :


### PR DESCRIPTION
Developers who know the language are now needed to help complete this PR.  The menu translation items template is generated by https://github.com/adaext/vim-menutrans-helper. I've scanned all the menu items and created a fairly completed template. It haven't been updated for years, many new items would be added except items in`menu.vim`.