### PR TITLE
Clear got_int before getting a character in Cmdline mode

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1786,6 +1786,8 @@ getcmdline_int(
 				// that occurs while typing a command should
 				// cause the command not to be executed.
 
+	got_int = FALSE;	// Avoid infinite Ctrl-C loop in Ex mode
+
 	// Trigger SafeState if nothing is pending.
 	may_trigger_safestate(xpc.xp_numfiles <= 0);
 

--- a/src/testdir/test_ex_mode.vim
+++ b/src/testdir/test_ex_mode.vim
@@ -145,6 +145,29 @@ func Test_Ex_global()
   bwipe!
 endfunc
 
+" Test for pressing Ctrl-C in :append inside a loop in Ex mode
+" This used to hang Vim
+func Test_Ex_append_in_loop()
+  CheckRunVimInTerminal
+  let buf = RunVimInTerminal('', {'rows': 6})
+
+  call term_sendkeys(buf, "gQ")
+  call term_sendkeys(buf, "for i in range(1)\<CR>")
+  call term_sendkeys(buf, "append\<CR>")
+  call WaitForAssert({-> assert_match(':  append', term_getline(buf, 5))}, 1000)
+  call term_sendkeys(buf, "\<C-C>")
+  call term_wait(buf)
+  call term_sendkeys(buf, "foo\<CR>")
+  call WaitForAssert({-> assert_match('foo', term_getline(buf, 5))}, 1000)
+  call term_sendkeys(buf, ".\<CR>")
+  call WaitForAssert({-> assert_match('.', term_getline(buf, 5))}, 1000)
+  call term_sendkeys(buf, "endfor\<CR>")
+  call term_sendkeys(buf, "vi\<CR>")
+  call WaitForAssert({-> assert_match('foo', term_getline(buf, 1))}, 1000)
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " In Ex-mode, a backslash escapes a newline
 func Test_Ex_escape_enter()
   call feedkeys("gQlet l = \"a\\\<kEnter>b\"\<cr>vi\<cr>", 'xt')


### PR DESCRIPTION
Fix #10728
