### PR TITLE
Cast result of STRLEN to prevent build warning.

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -643,7 +643,7 @@ ins_compl_infercase_gettext(
 	    if (ga_grow(&gap, IOSIZE) == FAIL)
 		return (char_u *)"[failed]";
 	    STRCPY(gap.ga_data, IObuff);
-	    gap.ga_len = STRLEN(IObuff);
+	    gap.ga_len = (int)STRLEN(IObuff);
 	}
 	else if (has_mbyte)
 	    p += (*mb_char2bytes)(wca[i++], p);


### PR DESCRIPTION
It's been so long I thought I had seen the last of these. Oh well. Usual lie to the compiler solution.