### PR TITLE
Fixup bitbake filetype detection for .inc files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -519,7 +519,7 @@ export def FTinc()
     # headers so assume POV-Ray
     elseif lines =~ '^\s*\%({\|(\*\)' || lines =~? ft_pascal_keywords
       setf pascal
-    elseif lines =~# '\<\%(require\|inherit\)\>' || lines =~# '\w\+ = '
+    elseif lines =~# '\<\%(require\|inherit\)\>' || lines =~# '[A-Z][A-Za-z0-9_:${}]*\s\+\%(??\|[?:+]\)\?= '
       setf bitbake
     else
       FTasmsyntax()

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1861,6 +1861,31 @@ func Test_inc_file()
   call assert_equal('bitbake', &filetype)
   bwipe!
 
+  call writefile(['S = "${WORKDIR}"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['DEPENDS:append = " somedep"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['MACHINE ??= "qemu"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['PROVIDES := "test"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['RDEPENDS_${PN} += "bar"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
   " asm
   call writefile(['asmsyntax=foo'], 'Xfile.inc')
   split Xfile.inc


### PR DESCRIPTION
Quick fixup for #10697. The original pattern (`\w\+`) was not sufficient, as it
did not detect lines such as

    DEPENDS:append = " foo"
    RDEPENDS_${PN} += "bar"
    MACHINE ??= "qemu"

which are common in bitbake files. This amends the pattern to

1. Require the first character be a capital letter
2. Include the characters `:`, `$`, `{`, and `}` in the character group3. 
3. Allow `??`, `?`, `+`, or `:` to prepend the `=` character

I also expanded the `Test_inc_file()` test to account for these cases.
