### PR TITLE
doc: fix bad example markers

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1275,7 +1275,7 @@ User				Never executed automatically.  To be used for
 				    if exists('#User#MyEvent')
 					doautocmd User MyEvent
 				    endif
-
+<
 							*SigUSR1*
 SigUSR1				After the SIGUSR1 signal has been detected.
 				Could be used if other ways of notifying Vim

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1149,7 +1149,7 @@ blob2list({blob})					*blob2list()*
 
 		Can also be used as a |method|: >
 			GetBlob()->blob2list()
-
+<
 							*browse()*
 browse({save}, {title}, {initdir}, {default})
 		Put up a file requester.  This only works when "has("browse")"

--- a/runtime/doc/ft_sql.txt
+++ b/runtime/doc/ft_sql.txt
@@ -506,7 +506,7 @@ documentation.
 Assuming you have followed the dbext-tutorial you can press <C-C>t to
 display a list of tables.  There is a delay while dbext is creating the table
 list.  After the list is displayed press <C-W>.  This will remove both the
-popup window and the table name already chosen when the list became active. >
+popup window and the table name already chosen when the list became active.
 
  4.3.1 Table Completion:			*sql-completion-tables*
 
@@ -514,7 +514,7 @@ Press <C-C>t to display a list of tables from within the database you
 have connected via the dbext plugin.
 NOTE: All of the SQL completion popups support typing a prefix before pressing
 the key map.  This will limit the contents of the popup window to just items
-beginning with those characters.  >
+beginning with those characters.
 
  4.3.2 Column Completion:			*sql-completion-columns*
 
@@ -587,13 +587,13 @@ popup a list of columns for the customer table.  It does this by looking back
 to the beginning of the select statement and finding a list of the tables
 specified in the FROM clause.  In this case it notes that in the string
 "customer c", "c" is an alias for the customer table.  The optional "AS"
-keyword is also supported, "customer AS c". >
+keyword is also supported, "customer AS c".
 
 
  4.3.3 Procedure Completion:			*sql-completion-procedures*
 
 Similar to the table list, <C-C>p, will display a list of stored
-procedures stored within the database. >
+procedures stored within the database.
 
  4.3.4 View Completion:				*sql-completion-views*
 

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -231,7 +231,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			Examples: >
 				:4,5source
 				:10,18source ++clear
-
+<
 							*:source!*
 :so[urce]! {file}	Read Vim commands from {file}.  These are commands
 			that are executed from Normal mode, like you type


### PR DESCRIPTION
Fix some missing or bad example markers (`>`, `<`) that were interfering with correct syntax highlighting for subsequent `*`-enclosed tag anchors.