### PR TITLE
fix: recognize *.tfvars as terraform-vars, not terraform

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1982,8 +1982,8 @@ au BufRead,BufNewFile *.ttl
 " Terminfo
 au BufNewFile,BufRead *.ti			setf terminfo
 
-" Terraform
-au BufRead,BufNewFile *.tfvars			setf terraform
+" Terraform variables
+au BufRead,BufNewFile *.tfvars			setf terraform-vars
 
 " TeX
 au BufNewFile,BufRead *.latex,*.sty,*.dtx,*.ltx,*.bbl	setf tex

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -547,7 +547,7 @@ let s:filename_checks = {
     \ 'template': ['file.tmpl'],
     \ 'teraterm': ['file.ttl'],
     \ 'terminfo': ['file.ti'],
-    \ 'terraform': ['file.tfvars'],
+    \ 'terraform-vars': ['file.tfvars'],
     \ 'tex': ['file.latex', 'file.sty', 'file.dtx', 'file.ltx', 'file.bbl'],
     \ 'texinfo': ['file.texinfo', 'file.texi', 'file.txi'],
     \ 'texmf': ['texmf.cnf'],


### PR DESCRIPTION
`*.tfvars` entry was initially introduced as part of https://github.com/vim/vim/pull/9607

In the context of Terraform, it's acceptable to _highlight_ both `*.tf` and `*.tfvars` the same, if the highlighting engine treats them as HCL (i.e. doesn't imply any particular keywords). It is however impossible to provide relevant autocompletion or any other IntelliSense via the language server.

See https://github.com/hashicorp/terraform-ls/blob/main/docs/language-clients.md#language-ids