### PR TITLE
IObuff does not end with '\0'

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -541,7 +541,7 @@ ins_compl_infercase_gettext(
     int		was_letter = FALSE;
     garray_T	gap;
 
-    IObuff[0] = NUL;
+    vim_memset(IObuff, NUL, IOSIZE * sizeof(char_u));
 
     // Allocate wide character array for the completion and fill it.
     wca = ALLOC_MULT(int, char_len);

--- a/src/version.c
+++ b/src/version.c
@@ -736,6 +736,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    58,
+/**/
     57,
 /**/
     56,


### PR DESCRIPTION
Problem:    IObuff does not end with '\0'.
Solution:   Initialize IObuff to NUL.