### PR TITLE
Fix typed command overlap with printed text in scrollback

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -2595,6 +2595,7 @@ sb_text_start_cmdline(void)
 sb_text_end_cmdline(void)
 {
     do_clear_sb_text = SB_CLEAR_CMDLINE_DONE;
+    msg_sb_eol();
 }
 
 /*
@@ -2614,7 +2615,7 @@ clear_sb_text(int all)
     {
 	if (last_msgchunk == NULL)
 	    return;
-	lastp = &last_msgchunk->sb_prev;
+	lastp = &msg_sb_start(last_msgchunk)->sb_prev;
     }
 
     while (*lastp != NULL)

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -233,7 +233,8 @@ func Test_message_more()
 
   " Up all the way with 'g'.
   call term_sendkeys(buf, 'g')
-  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('  4 4', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal(':%p#', term_getline(buf, 1))})
   call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
 
   " All the way down. Pressing f should do nothing but pressing


### PR DESCRIPTION
Fix #10764
