### PR TITLE
po/Makefile: Avoid race over LINGUAS file

### DIFF
--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -213,17 +213,16 @@ $(PACKAGE).pot: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
 	# Delete the temporary files
 	rm *.js
 
-vim.desktop: vim.desktop.in $(POFILES)
+LINGUAS:
 	echo $(LANGUAGES) | tr " " "\n" |sed -e '/\./d' | sort > LINGUAS
+
+vim.desktop: vim.desktop.in $(POFILES) LINGUAS
 	$(MSGFMT) --desktop -d . --template vim.desktop.in -o tmp_vim.desktop
-	rm -f LINGUAS
 	if command -v desktop-file-validate; then desktop-file-validate tmp_vim.desktop; fi
 	mv tmp_vim.desktop vim.desktop
 
-gvim.desktop: gvim.desktop.in $(POFILES)
-	echo $(LANGUAGES) | tr " " "\n" |sed -e '/\./d' | sort > LINGUAS
+gvim.desktop: gvim.desktop.in $(POFILES) LINGUAS
 	$(MSGFMT) --desktop -d . --template gvim.desktop.in -o tmp_gvim.desktop
-	rm -f LINGUAS
 	if command -v desktop-file-validate; then desktop-file-validate tmp_gvim.desktop; fi
 	mv tmp_gvim.desktop gvim.desktop
 


### PR DESCRIPTION
The creation of the LINGUAS file is duplicated for each desktop file
which can lead the commands to race against each other. One target might
remove it before another has been able to use it. Rework the makefile to
avoid this as the expense of leaving the file on disk.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>