### PR TITLE
configure.ac: Fix create_timer solaris test for cross compiling

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3807,7 +3807,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
 dnl Check for timer_create. It probably requires the 'rt' library.
 dnl Run the program to find out if timer_create(CLOCK_MONOTONIC) actually
 dnl works, on Solaris timer_create() exists but fails at runtime.
-AC_MSG_CHECKING([for timer_create])
+AC_CACHE_CHECK([for timer_create], [vim_cv_timer_create],
 save_LIBS="$LIBS"
 LIBS="$LIBS -lrt"
 AC_RUN_IFELSE([AC_LANG_PROGRAM([
@@ -3824,7 +3824,7 @@ static void set_flag(union sigval sv) {}
   if (timer_create(CLOCK_MONOTONIC, &action, &timer_id) < 0)
     exit(1);  // cannot create a monotonic timer
   ])],
-  AC_MSG_RESULT(yes; with -lrt); AC_DEFINE(HAVE_TIMER_CREATE),
+  AC_MSG_NOTICE(timer_create with -lrt); vim_cv_timer_create=yes,
   LIBS="$save_LIBS"
   AC_RUN_IFELSE([AC_LANG_PROGRAM([
 #include<signal.h>
@@ -3840,8 +3840,16 @@ static void set_flag(union sigval sv) {}
     if (timer_create(CLOCK_MONOTONIC, &action, &timer_id) < 0)
       exit(1);  // cannot create a monotonic timer
     ])],
-    AC_MSG_RESULT(yes); AC_DEFINE(HAVE_TIMER_CREATE),
-    AC_MSG_RESULT(no)))
+    vim_cv_timer_create=yes,
+    vim_cv_timer_create=no),
+    AC_MSG_ERROR(cross-compiling: please set 'vim_cv_timer_create')
+    )
+)
+
+if test "x$vim_cv_timer_create" = "xyes" ; then
+  AC_DEFINE(HAVE_TIMER_CREATE)
+fi
+
 
 AC_CACHE_CHECK([whether stat() ignores a trailing slash], [vim_cv_stat_ignores_slash],
   [


### PR DESCRIPTION
A runtime test was added for create_timer however this meant cross compiling
would no longer work. Allow a cache value to be specified to allow cross
compiling again.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>