### PR TITLE
Correct filetype detection for bsdl

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -259,7 +259,7 @@ au BufNewFile,BufRead *.bb,*.bbappend,*.bbclass,*/build/conf/*.conf,*/meta{-*,}/
 au BufNewFile,BufRead */etc/blkid.tab,*/etc/blkid.tab.old   setf xml
 
 " BSDL
-au BufNewFile,BufRead *bsd,*.bsdl		setf bsdl
+au BufNewFile,BufRead *.bsd,*.bsdl		setf bsdl
 
 " Bazel (http://bazel.io)
 autocmd BufRead,BufNewFile *.bzl,*.bazel,WORKSPACE	setf bzl

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -85,7 +85,7 @@ let s:filename_checks = {
     \ 'bindzone': ['named.root', '/bind/db.file', '/named/db.file', 'any/bind/db.file', 'any/named/db.file'],
     \ 'bitbake': ['file.bb', 'file.bbappend', 'file.bbclass', 'build/conf/local.conf', 'meta/conf/layer.conf', 'build/conf/bbappend.conf', 'meta-layer/conf/distro/foo.conf'],
     \ 'blank': ['file.bl'],
-    \ 'bsdl': ['file.bsd', 'file.bsdl', 'bsd', 'some-bsd'],
+    \ 'bsdl': ['file.bsd', 'file.bsdl'],
     \ 'bst': ['file.bst'],
     \ 'bzl': ['file.bazel', 'file.bzl', 'WORKSPACE'],
     \ 'bzr': ['bzr_log.any', 'bzr_log.file'],


### PR DESCRIPTION
In PR #5945 it's added as "*.bsd", but in commit 0fc1288ae it got added
as "*bsd", without a dot.

I guess that's probably an error? So correct that, as it highlights
files named "freebsd", "openbsd", etc. wrong.