### PR TITLE
Fixed a few compiler errors in MSVC. (size_t typecast related)

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -1092,7 +1092,7 @@ win_lbr_chartabsize(
 		char_u *p = ((char_u **)wp->w_buffer->b_textprop_text.ga_data)[
 							       -tp->tp_id - 1];
 		// TODO: count screen cells
-		cts->cts_cur_text_width = STRLEN(p);
+		cts->cts_cur_text_width = (int)STRLEN(p);
 		size += cts->cts_cur_text_width;
 		break;
 	    }

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1524,7 +1524,7 @@ win_line(
 			if (p != NULL)
 			{
 			    p_extra = p;
-			    n_extra = STRLEN(p);
+			    n_extra = (int)STRLEN(p);
 			    extra_attr = used_attr;
 			    n_attr = n_extra;
 			    text_prop_attr = 0;


### PR DESCRIPTION
I added a typecast from size_t to int in file charset.c at line 1095 and file drawline.c at line 1527.
This fixes a few C4627 errors when compiling with Microsoft Visual C++.