### PR TITLE
fix: reset BF_NOTEDITED flag when reloading file

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2899,6 +2899,10 @@ do_ecmd(
     // highlighting to work in the other file.
     did_filetype = FALSE;
 
+    // If file name was changed, reset the flag when reloading the file.
+    if (!other_file)
+	curbuf->b_flags &= ~BF_NOTEDITED;
+
 /*
  * other_file	oldbuf
  *  FALSE	FALSE	    re-edit same file, buffer is re-used

--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -725,5 +725,19 @@ func Test_using_zero_in_range()
   bwipe!
 endfunc
 
+" Test :write after changing name with :file and loading it with :edit
+func Test_write_after_rename()
+  call writefile(['text'], 'Xfile')
+
+  enew
+  file Xfile
+  call assert_fails('write', 'E13: File exists (add ! to override)')
+
+  edit
+  write
+
+  call delete('Xfile')
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
If a file name was changed to an already existing file with `:file existing_file.txt`, reset the `BF_NOTEDITED` flag when reloading the file with `:edit`.

Use case:
1. Parse line/column information from a file name (`file.txt:10:33`)
2. Change the name with `:f file.txt` (to avoid creating a new buffer)
3. Read the actual file with `:e`
4. Problem: `:w` raises `E13: File exists`