### PR TITLE
Remove "new_value_alloced"

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -1716,8 +1716,6 @@ do_set(
 #endif
 			unsigned  newlen;
 			int	  comma;
-			int	  new_value_alloced;	// new string option
-							// was allocated
 
 			// When using ":set opt=val" for a global option
 			// with a local value the local value will be
@@ -1785,13 +1783,11 @@ do_set(
 				    s = newval;
 				newval = vim_strsave(s);
 			    }
-			    new_value_alloced = TRUE;
 			}
 			else if (nextchar == '<')	// set to global val
 			{
 			    newval = vim_strsave(*(char_u **)get_varp_scope(
 					     &(options[opt_idx]), OPT_GLOBAL));
-			    new_value_alloced = TRUE;
 			}
 			else
 			{
@@ -2060,7 +2056,6 @@ do_set(
 
 			    if (save_arg != NULL)   // number for 'whichwrap'
 				arg = save_arg;
-			    new_value_alloced = TRUE;
 			}
 
 			/*
@@ -2109,8 +2104,7 @@ do_set(
 			    // 'syntax' or 'filetype' autocommands may be
 			    // triggered that can cause havoc.
 			    errmsg = did_set_string_option(
-				    opt_idx, (char_u **)varp,
-				    new_value_alloced, oldval, errbuf,
+				    opt_idx, (char_u **)varp, oldval, errbuf,
 				    opt_flags, &value_checked);
 
 			    secure = secure_saved;

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -9,6 +9,6 @@ void set_string_option_direct(char_u *name, int opt_idx, char_u *val, int opt_fl
 void set_string_option_direct_in_win(win_T *wp, char_u *name, int opt_idx, char_u *val, int opt_flags, int set_sid);
 void set_string_option_direct_in_buf(buf_T *buf, char_u *name, int opt_idx, char_u *val, int opt_flags, int set_sid);
 char *set_string_option(int opt_idx, char_u *value, int opt_flags);
-char *did_set_string_option(int opt_idx, char_u **varp, int new_value_alloced, char_u *oldval, char *errbuf, int opt_flags, int *value_checked);
+char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *errbuf, int opt_flags, int *value_checked);
 int check_ff_value(char_u *p);
 /* vim: set ft=c : */


### PR DESCRIPTION
Starting from patch 6.1.272, "new_value_alloced" is always TRUE.
