### PR TITLE
Modifiable v:completed_item

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2005,6 +2005,8 @@ v:completed_item
 		|Dictionary| containing the |complete-items| for the most
 		recently completed word after |CompleteDone|.  The
 		|Dictionary| is empty if the completion failed.
+		Note: Plugins can modify the value to emulate builtin
+		|CompleteDone| behavior.
 
 					*v:count* *count-variable*
 v:count		The count given for the last Normal mode command.  Can be used

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -111,7 +111,7 @@ static struct vimvar
     {VV_NAME("oldfiles",	 VAR_LIST), &t_list_string, 0},
     {VV_NAME("windowid",	 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("progpath",	 VAR_STRING), NULL, VV_RO},
-    {VV_NAME("completed_item",	 VAR_DICT), &t_dict_string, VV_RO},
+    {VV_NAME("completed_item",	 VAR_DICT), &t_dict_string, 0},
     {VV_NAME("option_new",	 VAR_STRING), NULL, VV_RO},
     {VV_NAME("option_old",	 VAR_STRING), NULL, VV_RO},
     {VV_NAME("option_oldlocal",	 VAR_STRING), NULL, VV_RO},

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -387,6 +387,19 @@ func Test_CompleteDone_undo()
   au! CompleteDone
 endfunc
 
+func Test_CompleteDone_modify()
+  let value = {
+        \ 'word': '',
+        \ 'abbr': '',
+        \ 'menu': '',
+        \ 'info': '',
+        \ 'kind': '',
+        \ 'user_data': '',
+        \ }
+  let v:completed_item = value
+  call assert_equal(v:completed_item, value)
+endfunc
+
 func CompleteTest(findstart, query)
   if a:findstart
     return col('.')
@@ -2128,6 +2141,5 @@ func Test_ins_complete_add()
 
   bwipe!
 endfunc
-
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
I think `v:completed_item` should be modifiable.

Some plugins(ddc.vim, nvim-cmp, coc.nvim etc) plugins emulates native popup completion system, but it cannot support `CompleteDone` autocmd behavior.
Because `v:completed_item` is read only.

Related issue: https://github.com/neoclide/coc.nvim/pull/3862