### PR TITLE
Help tag generation: skip over examples

### DIFF
--- a/runtime/doc/doctags.c
+++ b/runtime/doc/doctags.c
@@ -21,6 +21,8 @@ main(int argc, char **argv)
 	char	*p1, *p2;
 	char	*p;
 	FILE	*fd;
+	int		len;
+	int		in_example;
 
 	if (argc <= 1)
 	{
@@ -37,8 +39,16 @@ main(int argc, char **argv)
 			fprintf(stderr, "Unable to open %s for reading\n", argv[0]);
 			continue;
 		}
+		in_example = 0;
 		while (fgets(line, LINELEN, fd) != NULL)
 		{
+			if (in_example)  /* skip over examples */
+			{
+				if (strchr(" \t\n\r", line[0]))
+					continue;
+				else
+					in_example = 0;
+			}
 			p1 = strchr(line, '*');				/* find first '*' */
 			while (p1 != NULL)
 			{
@@ -74,6 +84,12 @@ main(int argc, char **argv)
 					}
 				}
 				p1 = p2;
+			}
+			len = strlen(line);
+			if ((len == 2 && strcmp(&line[len - 2], ">\n") == 0) ||
+				(len >= 3 && strcmp(&line[len - 3], " >\n") == 0))
+			{
+				in_example = 1;
 			}
 		}
 		fclose(fd);

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -2103,7 +2103,6 @@ $quote	eval.txt	/*$quote*
 :XMLent	insert.txt	/*:XMLent*
 :XMLns	insert.txt	/*:XMLns*
 :[range]	motion.txt	/*:[range]*
-:[vV\x16]	autocmd.txt	/*:[vV\\x16]*
 :\bar	cmdline.txt	/*:\\bar*
 :_!	cmdline.txt	/*:_!*
 :_#	cmdline.txt	/*:_#*
@@ -10226,15 +10225,12 @@ try-finally	eval.txt	/*try-finally*
 try-nested	eval.txt	/*try-nested*
 try-nesting	eval.txt	/*try-nesting*
 tutor	usr_01.txt	/*tutor*
-twice	if_cscop.txt	/*twice*
 two-engines	pattern.txt	/*two-engines*
 type()	builtin.txt	/*type()*
 type-casting	vim9.txt	/*type-casting*
 type-checking	vim9.txt	/*type-checking*
 type-inference	vim9.txt	/*type-inference*
 type-mistakes	tips.txt	/*type-mistakes*
-typecorrect-settings	usr_51.txt	/*typecorrect-settings*
-typecorrect.txt	usr_51.txt	/*typecorrect.txt*
 typename()	builtin.txt	/*typename()*
 u	undo.txt	/*u*
 uganda	uganda.txt	/*uganda*

--- a/src/help.c
+++ b/src/help.c
@@ -960,6 +960,8 @@ helptags_one(
     int		utf8 = MAYBE;
     int		this_utf8;
     int		firstline;
+    int		in_example;
+    int		len;
     int		mix = FALSE;	// detected mixed encodings
 
     // Find all *.txt files.
@@ -1025,6 +1027,7 @@ helptags_one(
 	}
 	fname = files[fi] + dirlen + 1;
 
+	in_example = FALSE;
 	firstline = TRUE;
 	while (!vim_fgets(IObuff, IOSIZE, fd) && !got_int)
 	{
@@ -1058,6 +1061,13 @@ helptags_one(
 		    got_int = TRUE;
 		}
 		firstline = FALSE;
+	    }
+	    if (in_example)
+	    {
+		if (vim_strchr((char_u *)" \t\n\r", IObuff[0]))
+		    continue;
+		else
+		    in_example = FALSE;
 	    }
 	    p1 = vim_strchr(IObuff, '*');	// find first '*'
 	    while (p1 != NULL)
@@ -1102,6 +1112,12 @@ helptags_one(
 		    }
 		}
 		p1 = p2;
+	    }
+	    len = (int)STRLEN(IObuff);
+	    if ((len == 2 && STRCMP(&IObuff[len - 2], ">\n") == 0) ||
+		(len >= 3 && STRCMP(&IObuff[len - 3], " >\n") == 0))
+	    {
+		in_example = TRUE;
 	    }
 	    line_breakcheck();
 	}

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -141,6 +141,13 @@ func Test_helptag_cmd()
   call assert_equal(["help-tags\ttags\t1"], readfile('Xdir/tags'))
   call delete('Xdir/tags')
 
+  " Test parsing tags
+  call writefile(['*tag1*', 'Example: >', '  *notag*', 'Example end: *tag2*'],
+    \ 'Xdir/a/doc/sample.txt')
+  helptags Xdir
+  call assert_equal(["tag1\ta/doc/sample.txt\t/*tag1*",
+                  \  "tag2\ta/doc/sample.txt\t/*tag2*"], readfile('Xdir/tags'))
+
   " Duplicate tags in the help file
   call writefile(['*tag1*', '*tag1*', '*tag2*'], 'Xdir/a/doc/sample.txt')
   call assert_fails('helptags Xdir', 'E154:')


### PR DESCRIPTION
When generating the help tags file, don't parse tags inside examples.

This applies both to the implementation of the `:helptags` command, and to the `runtime/doc/doctags.c` program.

As can be seen from the changes to the help tags file also included in this commit, this removes a few bad entries from it that are not real help tags, and which therefore cannot be jumped to.