### PR TITLE
W32 GUI: set active keyboard layout for gvim

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -8658,3 +8658,86 @@ test_gui_w32_sendevent(dict_T *args)
     return TRUE;
 }
 #endif
+
+#if defined(FEAT_EVAL) || defined(PROTO)
+    int
+test_gui_w32_setkblayout(dict_T *args)
+{
+    char_u	*kblayout;
+    const char	*kblayout_internal_name = 0;
+
+    HKL hkl, prev_hkl;
+
+    kblayout = dict_get_string(args, "kblayout", TRUE);
+    if (kblayout == NULL)
+	return FALSE;
+
+    /*
+	EN: GetKeyboardLayoutName: 00000409
+	CS: GetKeyboardLayoutName: A0000405
+	FR: GetKeyboardLayoutName: 0000080C
+	DE: GetKeyboardLayoutName: 00000407
+	RU: GetKeyboardLayoutName: 00000419
+	*/
+
+
+    if (STRICMP(kblayout, "EN") == 0)
+	kblayout_internal_name = "00000409";
+    else if (STRICMP(kblayout, "CS") == 0)
+	kblayout_internal_name = "A0000405"; // just my special
+					     // case?
+    else if (STRICMP(kblayout, "FR") == 0)
+	kblayout_internal_name = "0000080C";
+    else if (STRICMP(kblayout, "DE") == 0)
+	kblayout_internal_name = "00000407";
+    else if (STRICMP(kblayout, "RU") == 0)
+	kblayout_internal_name = "00000419";
+    else
+    {
+	semsg(_(e_invalid_argument_str), kblayout);
+	goto ENDKB;
+    }
+
+    hkl = LoadKeyboardLayout(kblayout_internal_name, KLF_ACTIVATE|KLF_SUBSTITUTE_OK);
+    if (hkl == NULL)
+    {
+	semsg(_(e_invalid_argument_str), "cannot load kb layout");
+	goto ENDKB;
+    }
+
+    prev_hkl = ActivateKeyboardLayout(
+	  hkl,
+	  KLF_SETFORPROCESS
+	);
+    if (prev_hkl == NULL)
+    {
+	semsg(_(e_invalid_argument_str), "cannot activate kb layout");
+	goto ENDKB;
+    }
+
+    //{
+    //    WORD	    vkCode;
+
+    //    vkCode = dict_get_number_def(args, "keycode", 0);
+    //    if (vkCode <= 0 || vkCode >= 0xFF)
+    //    {
+    //        semsg(_(e_invalid_argument_nr), (long)vkCode);
+    //        return FALSE;
+    //    }
+
+    //    inputs[0].type = INPUT_KEYBOARD;
+    //    inputs[0].ki.wVk = vkCode;
+    //    if (STRICMP(event, "keyup") == 0)
+    //        inputs[0].ki.dwFlags = KEYEVENTF_KEYUP;
+    //    SendInput(ARRAYSIZE(inputs), inputs, sizeof(INPUT));
+    //}
+    //else
+    //    semsg(_(e_invalid_argument_str), event);
+
+ENDKB:
+
+    vim_free(kblayout);
+
+    return TRUE;
+}
+#endif

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -97,4 +97,5 @@ BalloonEval *gui_mch_create_beval_area(void *target, char_u *mesg, void (*mesgCB
 void gui_mch_destroy_beval_area(BalloonEval *beval);
 void netbeans_draw_multisign_indicator(int row);
 int test_gui_w32_sendevent(dict_T *args);
+int test_gui_w32_setkblayout(dict_T *args);
 /* vim: set ft=c : */

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1729,9 +1729,9 @@ func GetSendMyKeysSrc()
 
 endfunc
 
-" test if ctrl+dead circumflex on AZERTY/FR (and on QWERTZ/DE) generates ESC
+" test if ctrl+dead circumflex on QWERTZ/DE generates ESC
 " (This has failed before 9.0.0087 (#10687, #10454)
-func Test_gui_lowlevel_ctrl_dead_clfex_eq_esc()
+func Test_gui_lowlvl_DE_ctrl_dead_cflex_eq_esc()
   CheckMSWindows
   new
 
@@ -1745,7 +1745,7 @@ func Test_gui_lowlevel_ctrl_dead_clfex_eq_esc()
     " <dead>
     call SendMyKeys(["68","du","69","du","65","du","68","du"])
 
-    " { this should generate "ESC" via new feature "dead circumflex in DE"
+    " this should generate "ESC" via new feature "dead circumflex in DE"
     " 17 = ctrl; 220 = dead^ on german keyboard
     call SendMyKeys([17,"d",220,"du",17,"u"])
 
@@ -1765,6 +1765,68 @@ func Test_gui_lowlevel_ctrl_dead_clfex_eq_esc()
 
     " <shift v m i (56 )57 shift up ENTER>
     call SendMyKeys([16,"d", 86, "du", 77, "du", 73, "du", 56, "du", 57, "du", 16, "u", 13, "du"])
+
+    func VMI()
+      write
+      quit
+    endfunction
+  END
+
+  call writefile(sendmykeys_src + lines, 'Xlines')
+  "call writefile(lines, 'Xlines')
+
+  let prefix = '!'
+  if has('win32')
+    let prefix = '!start '
+  endif
+  execute prefix .. GetVimCommand() .. ' -g -u NONE Xresult -S Xlines'
+
+  call WaitForAssert({-> assert_true(filereadable('Xresult'))})
+  edit Xresult
+
+  call assert_equal("dead"      , getline(1)) 
+  call assert_equal("circumflex", getline(2)) 
+
+  bw!
+  call delete('Xresult')
+  call delete('Xlines')
+endfunc
+
+" test if ctrl+dead circumflex on AZERTY/FR generates ESC
+" (This has failed before 9.0.0087 (#10687, #10454)
+func Test_gui_lowlvl_FR_ctrl_dead_cflex_eq_esc()
+  CheckMSWindows
+  new
+
+  let sendmykeys_src = GetSendMyKeysSrc()
+
+  let lines =<< trim END
+    call test_gui_event("setkblayout", #{kblayout: "FR", keycode: -99})
+
+    " <i>
+    call SendMyKeys([73,"du"])
+    " <dead>
+    call SendMyKeys(["68","du","69","du","65","du","68","du"])
+
+    " this should generate "ESC" via new feature "ctrl+dead circumflex in
+    " FR=ESC"
+    " 17 = ctrl; 221 = dead^ on AZERTY keyboard
+    call SendMyKeys([17,"d",221,"du",17,"u"])
+
+    " <o>
+    call SendMyKeys([79,"du"])
+
+    " <cicrumflex>
+    call SendMyKeys(["67","du","73","du","82","du","67","du","85","du",77,"du","70","du","76","du",69,"du",88,"du"])
+
+    " <ESC>
+    call SendMyKeys([27,"du"])
+
+    " <':'(azerty) 'c' 'a' 'l' 'l' space>
+    call SendMyKeys([191,"du",67,"du",65,"du",76,"du",76,"du",32,"du"])
+
+    " <shift v m i (56 )57 shift up ENTER>
+    call SendMyKeys([16,"d", 86, "du", 77, "du", 73, "du", 16, "u", 53, "du", 219, "du", 13, "du"])
 
     func VMI()
       write

--- a/src/testing.c
+++ b/src/testing.c
@@ -1529,6 +1529,8 @@ f_test_gui_event(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 #  ifdef FEAT_GUI_MSWIN
     else if (STRCMP(event, "sendevent") == 0)
 	rettv->vval.v_number = test_gui_w32_sendevent(argvars[1].vval.v_dict);
+    else if (STRCMP(event, "setkblayout") == 0)
+	rettv->vval.v_number = test_gui_w32_setkblayout(argvars[1].vval.v_dict);
 #  endif
     else
     {


### PR DESCRIPTION
New function "setkblayout" usable from tests is introduced, to control keyboard
layout of running gvim. Usage example (expected to insert string "d€@ö" into
current buffer, it requires my last PR #10814 - uses Alt+Ctrl as AltGr thus
need to activate German keyboard layout as first):

call test_gui_event("setkblayout", #{kblayout: "DE", keycode: -99})

func SendMyKeys(keylist)
  let l:k = ""
  let l:t = ""
  for key in a:keylist
    "echomsg "k[i]=".key
    if l:k == ""
      let l:k = key
      "echomsg "l:k=".l:k
    else
      let l:t = key
      "echomsg "l:t=".l:k
    endif
    if l:t != ""
      if l:t == "du"
        "echomsg "k=".l:k.", t=".l:t
        call test_gui_event("sendevent", #{event: "keydown", keycode: l:k})
        call test_gui_event("sendevent", #{event: "keyup", keycode: l:k})
      endif
      if l:t == "d"
        call test_gui_event("sendevent", #{event: "keydown", keycode: l:k})
      endif
      if l:t == "u"
        call test_gui_event("sendevent", #{event: "keyup", keycode: l:k})
      endif
      let l:t=""
      let l:k=""
    endif
  endfor
endfunc

" <i>
call SendMyKeys([73,"du"])
" <d ctrl, Lalt, e->€ q->@ ö ctrl_up, lalt_up>
call SendMyKeys([68,"du",  17,"d",18,"d",  69,"du",81,"du",192,"du", 17,"u",18,"u"])