### PR TITLE
Fix ffs_filerray_cur type to not overflow in directories with more than 255 entries

### DIFF
--- a/src/findfile.c
+++ b/src/findfile.c
@@ -75,7 +75,7 @@ typedef struct ff_stack
     // of wc_part
     char_u		**ffs_filearray;
     int			ffs_filearray_size;
-    char_u		ffs_filearray_cur;   // needed for partly handled dirs
+    int			ffs_filearray_cur;   // needed for partly handled dirs
 
     // to store status of partly handled directories
     // 0: we work on this directory for the first time
@@ -1046,6 +1046,7 @@ vim_findfile(void *search_ctx_arg)
 #endif
 
 				// push dir to examine rest of subdirs later
+				assert(i < INT_MAX);
 				stackp->ffs_filearray_cur = i + 1;
 				ff_push(search_ctx, stackp);
 

--- a/src/testdir/test_gf.vim
+++ b/src/testdir/test_gf.vim
@@ -250,4 +250,26 @@ func Test_includeexpr_scriptlocal_func()
   bw!
 endfunc
 
+func Test_gf_subdirs_wildcard()
+  let cwd = getcwd()
+  let dir = 'Xtestgf_dir'
+  call mkdir(dir)
+  call chdir(dir)
+  for i in range(300)
+    call mkdir(i)
+    call writefile([], i .. '/' .. i, 'S')
+  endfor
+  set path=./**
+
+  new | only
+  call setline(1, '99')
+  w! Xtest1
+  normal gf
+  call assert_equal('99', fnamemodify(bufname(''), ":t"))
+
+  call chdir(cwd)
+  call delete(dir, 'rf')
+  set path&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
`ffs_filearray_cur` is used as an index up to `ffs_filearray_size` but the types don't match. Specifically, `ffs_filearray_cur` is currently a `char_u` (while `ffs_filearray_size` and index variable `i` are ints), so it overflows when searching a directory that contains more than 255 entries. This is technically undefined behavior, and likely causes the find loop at around line 971 to do more work than necessary.

Add this assert:
```diff
diff --git a/src/findfile.c b/src/findfile.c
index 881eef156..9e59346e9 100644
--- a/src/findfile.c
+++ b/src/findfile.c
@@ -1046,6 +1046,7 @@ vim_findfile(void *search_ctx_arg)
 #endif

                                // push dir to examine rest of subdirs later
+                               assert(i < UCHAR_MAX);
                                stackp->ffs_filearray_cur = i + 1;
                                ff_push(search_ctx, stackp);
```

Test case:
```sh
$ mkdir test; cd test
$ for i in {1..300}; do mkdir -p $i; touch $i/$i.h; done
$ cat << EOF > test.h
#include "99.h"
EOF
$ cat << EOF > test.in
:set path=\$PWD/**
Wgf
EOF
$ vim -u NONE test.h -s test.in
```

The fix is simply change `ffs_filearray_cur` to an int to match the loop index `i` and `ffs_filearray_size`.

Related: https://github.com/neovim/neovim/issues/13284