### PR TITLE
W32 GUI: try (again) to translate SPACE+Alt as well

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -2047,7 +2047,7 @@ process_message(void)
 	{
 	    // ignore VK_SPACE when ALT key pressed: system menu
 	    if (special_keys[i].key_sym == vk
-		    && (vk != VK_SPACE || !(GetKeyState(VK_LMENU) & 0x8000)))
+		    && (vk != VK_SPACE || !(GetKeyState(VK_MENU) & 0x8000)))
 	    {
 		/*
 		 * Behave as expected if we have a dead key and the special key


### PR DESCRIPTION
fixes: #10753 (Vim 9.0 : cannot use AltGr+Space in gvim.exe)

Due to the fact that modifiers AltGr vs Ctrl+Alt handling was made less
sensitive in the past (see patch 8.2.4843: treating CTRL + ALT as AltGr
is not backwards compatible), special chars loop has stopped to skip
space key if it was press with AltGr. Now started to skip it again thus
translating with ToUnicode() - and bepo made happy with their '_'.