### PR TITLE
Fix a potential error of buf_write()

### DIFF
--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1212,10 +1212,17 @@ buf_write(
 		{
 		    sprintf((char *)gettail(IObuff), "%d", i);
 		    if (mch_lstat((char *)IObuff, &st) < 0)
-			break;
-		}
-		fd = mch_open((char *)IObuff,
+		    {
+			fd = mch_open((char *)IObuff,
 				    O_CREAT|O_WRONLY|O_EXCL|O_NOFOLLOW, perm);
+			if (fd < 0 && errno == EEXIST)
+			    // If the same file name is created by another
+			    // process between lstat() and open(), go to the
+			    // next loop.
+			    continue;
+			break;
+		    }
+		}
 		if (fd < 0)	// can't write in directory
 		    backup_copy = TRUE;
 		else


### PR DESCRIPTION
buf_write() uses a loop to find a file name that doesn't exist yet.
However, it uses lstat() then open().  If another process created a file
with the same name between lstat() and open(), open() will fail with
EEXIST.