### PR TITLE
Win32 fix for size_t build warning

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3641,7 +3641,7 @@ qf_list_entry(qfline_T *qfp, int qf_idx, int cursel)
 	// with ^^^^.
 	qf_fmt_text((fname != NULL || qfp->qf_lnum != 0)
 				    ? skipwhite(qfp->qf_text) : qfp->qf_text,
-				    tbuf, tbuflen);
+				    tbuf, (int)tbuflen);
 	msg_prt_line(tbuf, FALSE);
 
 	if (tbuf != IObuff)


### PR DESCRIPTION
Fix for another Win32 build warning for int<->size_t conversion.