### PR TITLE
Check CWD length for Test_Debugger_breakadd_expr

### DIFF
--- a/src/testdir/test_debugger.vim
+++ b/src/testdir/test_debugger.vim
@@ -364,6 +364,7 @@ endfunc
 
 " Test for expression breakpoint set using ":breakadd expr <expr>"
 func Test_Debugger_breakadd_expr()
+  CheckCWD
   let lines =<< trim END
     let g:Xtest_var += 1
   END


### PR DESCRIPTION
This test seems to be susceptible to issues with long working directory
names, as shown below, so use CheckCWD to skip it.

	Found errors in Test_Debugger_breakadd_expr():
	Run 1:
	command line..script /builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/runtest.vim[468]..function RunTheTest[44]..Test_Debugger_breakadd_expr[17]..RunDbgCmd[9]..CheckDbgOutput[8]..WaitForAssert[2]..<SNR>5_WaitForCommon[11]..<lambda>121 line 1: Expected 'Oldval = "10"' but got 'Newval = "11"'
	command line..script /builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/runtest.vim[468]..function RunTheTest[44]..Test_Debugger_breakadd_expr[17]..RunDbgCmd[9]..CheckDbgOutput[8]..WaitForAssert[2]..<SNR>5_WaitForCommon[11]..<lambda>122 line 1: Expected 'Newval = "11"' but got '/builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/Xtest.vi'
	command line..script /builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/runtest.vim[468]..function RunTheTest[44]..Test_Debugger_breakadd_expr[17]..RunDbgCmd[9]..CheckDbgOutput[8]..WaitForAssert[2]..<SNR>5_WaitForCommon[11]..<lambda>123 line 1: Expected '/builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/Xtest.vim' but got 'm'
	command line..script /builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/runtest.vim[468]..function RunTheTest[44]..Test_Debugger_breakadd_expr[25]..RunDbgCmd[9]..CheckDbgOutput[8]..WaitForAssert[2]..<SNR>5_WaitForCommon[11]..<lambda>125 line 1: Expected 'Oldval = "11"' but got 'Newval = "12"'
	command line..script /builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/runtest.vim[468]..function RunTheTest[44]..Test_Debugger_breakadd_expr[25]..RunDbgCmd[9]..CheckDbgOutput[8]..WaitForAssert[2]..<SNR>5_WaitForCommon[11]..<lambda>126 line 1: Expected 'Newval = "12"' but got '/builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/Xtest.vi'
	command line..script /builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/runtest.vim[468]..function RunTheTest[44]..Test_Debugger_breakadd_expr[25]..RunDbgCmd[9]..CheckDbgOutput[8]..WaitForAssert[2]..<SNR>5_WaitForCommon[11]..<lambda>127 line 1: Expected '/builds/vim-team/vim/debian/output/source_dir/src/vim-gtk3/testdir/Xtest.vim' but got 'm'