### PR TITLE
`vim9cmd execute(cmd)` and `legacy call execute(cmd)` execute cmd in wrong context

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3929,6 +3929,7 @@ execute_common(typval_T *argvars, typval_T *rettv, int arg_off)
     int		save_redir_off = redir_off;
     garray_T	save_ga;
     int		save_msg_col = msg_col;
+    int		save_sticky_cmdmod_flags = sticky_cmdmod_flags;
     int		echo_output = FALSE;
 
     rettv->vval.v_string = NULL;
@@ -3985,6 +3986,8 @@ execute_common(typval_T *argvars, typval_T *rettv, int arg_off)
     if (!echo_output)
 	msg_col = 0;  // prevent leading spaces
 
+    // "legacy call execute('cmd')" and "vim9cmd execute('cmd')" applies to "cmd".
+    sticky_cmdmod_flags = cmdmod.cmod_flags & (CMOD_LEGACY | CMOD_VIM9CMD);
     if (cmd != NULL)
 	do_cmdline_cmd(cmd);
     else
@@ -3997,6 +4000,7 @@ execute_common(typval_T *argvars, typval_T *rettv, int arg_off)
 		      DOCMD_NOWAIT|DOCMD_VERBOSE|DOCMD_REPEAT|DOCMD_KEYTYPED);
 	--list->lv_refcount;
     }
+    sticky_cmdmod_flags = save_sticky_cmdmod_flags;
 
     // Need to append a NUL to the result.
     if (ga_grow(&redir_execute_ga, 1) == OK)

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -142,6 +142,42 @@ def Test_cmdmod_execute()
   END
   v9.CheckScriptSuccess(lines)
   delfunc g:TheFunc
+
+  # vim9cmd execute(cmd) executes code in vim9 script context
+  lines =<< trim END
+    vim9cmd execute("g:vim9executetest = 'bar'")
+    call assert_equal('bar', g:vim9executetest)
+  END
+  v9.CheckScriptSuccess(lines)
+  unlet g:vim9executetest
+
+  lines =<< trim END
+    vim9cmd execute(["g:vim9executetest1 = 'baz'", "g:vim9executetest2 = 'foo'"])
+    call assert_equal('baz', g:vim9executetest1)
+    call assert_equal('foo', g:vim9executetest2)
+  END
+  v9.CheckScriptSuccess(lines)
+  unlet g:vim9executetest1
+  unlet g:vim9executetest2
+
+  # legacy call execute(cmd) executes code in vim script context
+  lines =<< trim END
+    vim9script
+    legacy call execute("let g:vim9executetest = 'bar'")
+    assert_equal('bar', g:vim9executetest)
+  END
+  v9.CheckScriptSuccess(lines)
+  unlet g:vim9executetest
+
+  lines =<< trim END
+    vim9script
+    legacy call execute(["let g:vim9executetest1 = 'baz'", "let g:vim9executetest2 = 'foo'"])
+    assert_equal('baz', g:vim9executetest1)
+    assert_equal('foo', g:vim9executetest2)
+  END
+  v9.CheckScriptSuccess(lines)
+  unlet g:vim9executetest1
+  unlet g:vim9executetest2
 enddef
 
 def Test_edit_wildcards()


### PR DESCRIPTION
## issue
Contents of execute function executed by `:legacy call execute("let g:hoge = 'hugo'")` or :vim9cmd in Vim9 script are processed by unintended context.

## cause
execute_common() does not refer to the CMOD_LEGACY and CMOD_VIM9CMD flag, so the return value of in_vim9script() is referenced and the command is executed as wrong context

## solution
CMOD_LEGACY and CMOD_VIM9CMD are now checked.
same as :execute (https://github.com/vim/vim/blob/master/src/eval.c#L6793)

## test code
These scripts are expected to run but return an error
```vim
vim9script
legacy call execute('let g:str = rand()')
legacy call execute(['let g:list1 = rand()', 'let g:list2 = rand()'])

echo g:str
echo g:list1
echo g:list2
```

```vim
let g:str = 0
let g:list1 = 0
let g:list2 = 0

vim9cmd execute('g:str = rand()')
vim9cmd execute(['g:list1 = rand()', 'g:list2 = rand()'])

echo g:str
echo g:list1
echo g:list2
```