### PR TITLE
Give an error when changing 'ambiwidth' makes global 'listchars' or local 'fillchars' invalid

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5645,12 +5645,12 @@ f_setcellwidths(typval_T *argvars, typval_T *rettv UNUSED)
     cw_table = table;
     cw_table_size = l->lv_len;
 
-    // Check that the new value does not conflict with 'fillchars' or
-    // 'listchars'.
-    if (set_chars_option(curwin, &p_fcs, FALSE) != NULL)
-	error = e_conflicts_with_value_of_fillchars;
-    else if (set_chars_option(curwin, &p_lcs, FALSE) != NULL)
+    // Check that the new value does not conflict with 'listchars' or
+    // 'fillchars'.
+    if (set_chars_option(curwin, &p_lcs, FALSE) != NULL)
 	error = e_conflicts_with_value_of_listchars;
+    else if (set_chars_option(curwin, &p_fcs, FALSE) != NULL)
+	error = e_conflicts_with_value_of_fillchars;
     else
     {
 	tabpage_T   *tp;

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5647,29 +5647,7 @@ f_setcellwidths(typval_T *argvars, typval_T *rettv UNUSED)
 
     // Check that the new value does not conflict with 'listchars' or
     // 'fillchars'.
-    if (set_chars_option(curwin, &p_lcs, FALSE) != NULL)
-	error = e_conflicts_with_value_of_listchars;
-    else if (set_chars_option(curwin, &p_fcs, FALSE) != NULL)
-	error = e_conflicts_with_value_of_fillchars;
-    else
-    {
-	tabpage_T   *tp;
-	win_T	    *wp;
-
-	FOR_ALL_TAB_WINDOWS(tp, wp)
-	{
-	    if (set_chars_option(wp, &wp->w_p_lcs, FALSE) != NULL)
-	    {
-		error = e_conflicts_with_value_of_listchars;
-		break;
-	    }
-	    if (set_chars_option(wp, &wp->w_p_fcs, FALSE) != NULL)
-	    {
-		error = e_conflicts_with_value_of_fillchars;
-		break;
-	    }
-	}
-    }
+    error = check_chars_options();
     if (error != NULL)
     {
 	emsg(_(error));

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -866,6 +866,8 @@ did_set_string_option(
     {
 	if (check_opt_strings(p_ambw, p_ambw_values, FALSE) != OK)
 	    errmsg = e_invalid_argument;
+	else if (set_chars_option(curwin, &p_lcs, FALSE) != NULL)
+	    errmsg = e_conflicts_with_value_of_listchars;
 	else if (set_chars_option(curwin, &p_fcs, FALSE) != NULL)
 	    errmsg = e_conflicts_with_value_of_fillchars;
 	else
@@ -878,6 +880,11 @@ did_set_string_option(
 		if (set_chars_option(wp, &wp->w_p_lcs, FALSE) != NULL)
 		{
 		    errmsg = e_conflicts_with_value_of_listchars;
+		    goto ambw_end;
+		}
+		if (set_chars_option(wp, &wp->w_p_fcs, FALSE) != NULL)
+		{
+		    errmsg = e_conflicts_with_value_of_fillchars;
 		    goto ambw_end;
 		}
 	    }

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -866,31 +866,8 @@ did_set_string_option(
     {
 	if (check_opt_strings(p_ambw, p_ambw_values, FALSE) != OK)
 	    errmsg = e_invalid_argument;
-	else if (set_chars_option(curwin, &p_lcs, FALSE) != NULL)
-	    errmsg = e_conflicts_with_value_of_listchars;
-	else if (set_chars_option(curwin, &p_fcs, FALSE) != NULL)
-	    errmsg = e_conflicts_with_value_of_fillchars;
 	else
-	{
-	    tabpage_T	*tp;
-	    win_T	*wp;
-
-	    FOR_ALL_TAB_WINDOWS(tp, wp)
-	    {
-		if (set_chars_option(wp, &wp->w_p_lcs, FALSE) != NULL)
-		{
-		    errmsg = e_conflicts_with_value_of_listchars;
-		    goto ambw_end;
-		}
-		if (set_chars_option(wp, &wp->w_p_fcs, FALSE) != NULL)
-		{
-		    errmsg = e_conflicts_with_value_of_fillchars;
-		    goto ambw_end;
-		}
-	    }
-	}
-ambw_end:
-	{}
+	    errmsg = check_chars_options();
     }
 
     // 'background'

--- a/src/proto/screen.pro
+++ b/src/proto/screen.pro
@@ -56,4 +56,5 @@ int number_width(win_T *wp);
 int screen_screencol(void);
 int screen_screenrow(void);
 char *set_chars_option(win_T *wp, char_u **varp, int apply);
+char *check_chars_options(void);
 /* vim: set ft=c : */

--- a/src/screen.c
+++ b/src/screen.c
@@ -5155,3 +5155,30 @@ set_chars_option(win_T *wp, char_u **varp, int apply)
 
     return NULL;	// no error
 }
+
+/*
+ * Check all global and local values of 'listchars' and 'fillchars'.
+ * Return an error messages if any of them is invalid, NULL otherwise.
+ */
+    char *
+check_chars_options(void)
+{
+    if (set_chars_option(curwin, &p_lcs, FALSE) != NULL)
+	return e_conflicts_with_value_of_listchars;
+    else if (set_chars_option(curwin, &p_fcs, FALSE) != NULL)
+	return e_conflicts_with_value_of_fillchars;
+    else
+    {
+	tabpage_T   *tp;
+	win_T	    *wp;
+
+	FOR_ALL_TAB_WINDOWS(tp, wp)
+	{
+	    if (set_chars_option(wp, &wp->w_p_lcs, FALSE) != NULL)
+		return e_conflicts_with_value_of_listchars;
+	    if (set_chars_option(wp, &wp->w_p_fcs, FALSE) != NULL)
+		return e_conflicts_with_value_of_fillchars;
+	}
+    }
+    return NULL;
+}

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -466,9 +466,17 @@ func Test_set_errors()
   call assert_fails('set sessionoptions=curdir,sesdir', 'E474:')
   call assert_fails('set foldmarker={{{,', 'E474:')
   call assert_fails('set sessionoptions=sesdir,curdir', 'E474:')
-  call assert_fails('set listchars=trail:· ambiwidth=double', 'E834:')
+  setlocal listchars=trail:·
+  call assert_fails('set ambiwidth=double', 'E834:')
+  setlocal listchars=trail:-
+  setglobal listchars=trail:·
+  call assert_fails('set ambiwidth=double', 'E834:')
   set listchars&
-  call assert_fails('set fillchars=stl:· ambiwidth=double', 'E835:')
+  setlocal fillchars=stl:·
+  call assert_fails('set ambiwidth=double', 'E835:')
+  setlocal fillchars=stl:-
+  setglobal fillchars=stl:·
+  call assert_fails('set ambiwidth=double', 'E835:')
   set fillchars&
   call assert_fails('set fileencoding=latin1,utf-8', 'E474:')
   set nomodifiable


### PR DESCRIPTION
Order code consistently: since E834 comes before E835, check for
'listchars' before 'fillchars' in code.
