### PR TITLE
Correctly highlight SpellCaps error with trailing ws

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1980,7 +1980,10 @@ win_line(
 		if (has_spell && v >= word_end && v > cur_checked_col)
 		{
 		    spell_attr = 0;
-		    if (c != 0 && (
+		    // do not calculate cap_col at the end of the line
+		    // or when only trailing white space is following
+		    if (c != 0 && (*skipwhite(prev_ptr) != NUL) &&
+			    (
 # ifdef FEAT_SYN_HL
 				!has_syntax ||
 # endif

--- a/src/testdir/dumps/Test_spell_2.dump
+++ b/src/testdir/dumps/Test_spell_2.dump
@@ -1,0 +1,8 @@
+> +0&#ffffff0@2|T|h|i|s| |l|i|n|e| |h|a|s| |a| |s+0&#ffd7d7255|e|p|l@1| +0&#ffffff0|e|r@1|o|r|.| |a+0&#5fd7ff255|n|d| +0&#ffffff0|m|i|s@1|i|n|g| |c|a|p|s| |a|n|d| |t|r|a|i|l|i|n|g| |s|p|a|c|e|s|.| @5
+|a+0&#5fd7ff255|n|o|t|h|e|r| +0&#ffffff0|m|i|s@1|i|n|g| |c|a|p| |h|e|r|e|.| @49
+@75
+|a+0&#5fd7ff255|n|d| +0&#ffffff0|h|e|r|e|.| @65
+@75
+|a+0&#5fd7ff255|n|d| +0&#ffffff0|h|e|r|e|.| @65
+|~+0#4040ff13&| @73
+| +0#0000000&@56|1|,|1| @10|A|l@1| 

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -965,6 +965,29 @@ func Test_spell_screendump()
   call delete('XtestSpell')
 endfunc
 
+func Test_spell_screendump_spellcap()
+  CheckScreendump
+
+  let lines =<< trim END
+       call setline(1, [
+             \ "   This line has a sepll error. and missing caps and trailing spaces.   ",
+             \ "another missing cap here.",
+             \ "",
+             \ "and here.",
+             \ "    ",
+             \ "and here."
+             \ ])
+       set spell spelllang=en
+  END
+  call writefile(lines, 'XtestSpellCap')
+  let buf = RunVimInTerminal('-S XtestSpellCap', {'rows': 8})
+  call VerifyScreenDump(buf, 'Test_spell_2', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('XtestSpellCap')
+endfunc
+
 let g:test_data_aff1 = [
       \"SET ISO8859-1",
       \"TRY esianrtolcdugmphbyfvkwjkqxz-\xEB\xE9\xE8\xEA\xEF\xEE\xE4\xE0\xE2\xF6\xFC\xFB'ESIANRTOLCDUGMPHBYFVKWJKQXZ",


### PR DESCRIPTION
as noticed in #10838 SpellCap highlighting is not applied, if the previous line ends with trailing white space.

So skip calculating cap_col, in `win_line()` when the rest of the line only contains whitespaces.