### PR TITLE
Fix typos in comments

### DIFF
--- a/src/typval.c
+++ b/src/typval.c
@@ -1179,7 +1179,7 @@ typval_compare(
 
     if (type_is && tv1->v_type != tv2->v_type)
     {
-	// For "is" a different type always means FALSE, for "notis"
+	// For "is" a different type always means FALSE, for "isnot"
 	// it means TRUE.
 	n1 = (type == EXPR_ISNOT);
     }

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -8,7 +8,7 @@
  */
 
 /*
- * vim9cmds.c: Dealing with compiled function expressions
+ * vim9expr.c: Dealing with compiled function expressions
  */
 
 #define USING_FLOAT_STUFF


### PR DESCRIPTION
Fixed a file name mismatch in the file description comment at the head of vim9expr.c.
(Note that the file description comment is same to the vim9cmds.c's, so maybe it should also be changed?)