### PR TITLE
(Proposal) Fix is/isnot expr of vim9script

### DIFF
--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -886,11 +886,11 @@ def Test_expr4_compare_null()
       assert_false(null != null_string)
 
       assert_true(null_string is test_null_string())
-      assert_false(null_string is '')
-      assert_false('' is null_string)
+      assert_true(null_string is '')
+      assert_true('' is null_string)
       assert_false(null_string isnot test_null_string())
-      assert_true(null_string isnot '')
-      assert_true('' isnot null_string)
+      assert_false(null_string isnot '')
+      assert_false('' isnot null_string)
 
       var ns = null_string
       assert_true(ns == null_string)
@@ -1271,6 +1271,19 @@ def Test_expr4_is()
                             is 0z1234)
       var otherblob = myblob
       assert_true(myblob is otherblob)
+
+      var va = 'foo'
+      var vb = 'foo'
+      var vc = 'bar'
+      var vd = 123
+
+      assert_true(va is va)
+      assert_true(va is vb)
+      assert_false(va is vc)
+
+      assert_false(va isnot va)
+      assert_false(va isnot vb)
+      assert_true(va isnot vc)
   END
   v9.CheckDefAndScriptSuccess(lines)
 enddef

--- a/src/typval.c
+++ b/src/typval.c
@@ -1607,24 +1607,12 @@ typval_compare_string(
 	i = ic ? MB_STRICMP(s1, s2) : STRCMP(s1, s2);
     switch (type)
     {
-	case EXPR_IS:	    if (in_vim9script())
-			    {
-				// Really check it is the same string, not just
-				// the same value.
-				val = tv1->vval.v_string == tv2->vval.v_string;
-				break;
-			    }
-			    // FALLTHROUGH
-	case EXPR_EQUAL:    val = (i == 0); break;
-	case EXPR_ISNOT:    if (in_vim9script())
-			    {
-				// Really check it is not the same string, not
-				// just a different value.
-				val = tv1->vval.v_string != tv2->vval.v_string;
-				break;
-			    }
-			    // FALLTHROUGH
-	case EXPR_NEQUAL:   val = (i != 0); break;
+	case EXPR_EQUAL:
+	case EXPR_IS:       val = (i == 0); break;
+
+	case EXPR_NEQUAL:
+	case EXPR_ISNOT:    val = (i != 0); break;
+
 	case EXPR_GREATER:  val = (i > 0); break;
 	case EXPR_GEQUAL:   val = (i >= 0); break;
 	case EXPR_SMALLER:  val = (i < 0); break;


### PR DESCRIPTION
This issue is Reported by @thinca 
@kat0h made this patch

## issue
is/isnot expr of Vim9 script are looks broken. 

This is reproduction code.
```vim
vim9script
echo 'foo' is 'foo'    # => false
echo 'foo' is 'bar'    # => false
echo 'foo' isnot 'foo' # => true
echo 'foo' isnot 'bar' # => true

var a = 'foo'
echo a is a            # => false
echo a isnot a         # => true
```

## cause
Vim script uses `typval_compare_string()` function in `src/typval.c` to compare strings.
in Vim9 script context, [it checks if the pointers of the two values passed as arguments equal](https://github.com/vim/vim/blob/master/src/typval.c#L1608-L1625).
But, LOAD command of assembly pushes value to stack after copy it. so values are placed different address.

I think, It seems that string value is not an object. So, I think vim can't compare that the string instances are identical.
```vim
vim9script
var a = 'foo'
var b = a
a = 'bar'
echo b #=> 'foo'
```

## solution
I deleted code which checks that string instances are same.
This patch includes breaking change. Now, `null_string is ''` returns true, and `null_string isnot ''` returns false.

regards.