### PR TITLE
Fix debug=beep does not show stacktrace for beep during :normal

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -531,6 +531,7 @@ msg_source(int attr)
 	return;
     recursive = TRUE;
 
+    msg_scroll = TRUE;
     ++no_wait_return;
     p = get_emsg_source();
     if (p != NULL)

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -934,11 +934,16 @@ func Test_rightleftcmd()
   set rightleft&
 endfunc
 
-" Test for the "debug" option
+" Test for the 'debug' option
 func Test_debug_option()
+  " redraw to avoid matching previous messages
+  redraw
   set debug=beep
   exe "normal \<C-c>"
   call assert_equal('Beep!', Screenline(&lines))
+  call assert_equal('line    4:', Screenline(&lines - 1))
+  " only match the final colon in the line that shows the source
+  call assert_match(':$', Screenline(&lines - 2))
   set debug&
 endfunc
 


### PR DESCRIPTION
In most other case where msg_source() is called, msg_scroll is already
TRUE, but when beeping during :normal msg_scroll is FALSE.

I think when a stacktrace needs to be shown, it is never intended to be
overwritten, so setting msg_scroll = TRUE in msg_source() can be a
general solution.
