### PR TITLE
Fix 'shellslash' behaves differently when sourcing a script twice

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1534,10 +1534,6 @@ do_source_ext(
     cookie.level = ex_nesting_level;
 #endif
 
-    // Keep the sourcing name/lnum, for recursive calls.
-    estack_push(ETYPE_SCRIPT, fname_exp, 0);
-    ESTACK_CHECK_SETUP
-
 #ifdef STARTUPTIME
     if (time_fd != NULL)
 	time_push(&tv_rel, &tv_start);
@@ -1629,6 +1625,10 @@ do_source_ext(
 	// Remember the "is_vimrc" flag for when the file is sourced again.
 	si->sn_is_vimrc = is_vimrc;
     }
+
+    // Keep the sourcing name/lnum, for recursive calls.
+    estack_push(ETYPE_SCRIPT, si->sn_name, 0);
+    ESTACK_CHECK_SETUP
 
 # ifdef FEAT_PROFILE
     if (do_profiling == PROF_YES)


### PR DESCRIPTION
Problem:    Changing 'shellslash' doesn't affect the result of expand()
            when sourcing a script multiple times.
Solution:   Always store si->sn_name on the execution stack.
