### PR TITLE
fix python indentation when comment contains nested syntax items

### DIFF
--- a/runtime/indent/testdir/python.in
+++ b/runtime/indent/testdir/python.in
@@ -1,6 +1,14 @@
-" vim: set ft=python sw=4 et:
+# vim: set ft=python sw=4 et:
 
-" START_INDENT
+# START_INDENT
+# INDENT_EXE syntax match pythonFoldMarkers /{{{\d*/ contained containedin=pythonComment
+# xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {{{1
+
+if True:
+pass
+# END_INDENT
+
+# START_INDENT
 open_paren_not_at_EOL(100,
 (200,
 300),
@@ -65,4 +73,4 @@ open_paren_not_at_EOL(100,
 open_paren_at_EOL(
 100, 200, 300, 400)
 
-" END_INDENT
+# END_INDENT

--- a/runtime/indent/testdir/python.ok
+++ b/runtime/indent/testdir/python.ok
@@ -1,6 +1,14 @@
-" vim: set ft=python sw=4 et:
+# vim: set ft=python sw=4 et:
 
-" START_INDENT
+# START_INDENT
+# INDENT_EXE syntax match pythonFoldMarkers /{{{\d*/ contained containedin=pythonComment
+# xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {{{1
+
+if True:
+    pass
+# END_INDENT
+
+# START_INDENT
 open_paren_not_at_EOL(100,
                       (200,
                        300),
@@ -65,4 +73,4 @@ open_paren_not_at_EOL(100,
 open_paren_at_EOL(
         100, 200, 300, 400)
 
-" END_INDENT
+# END_INDENT


### PR DESCRIPTION
This is an attempt at fixing the issue discussed [here](https://github.com/vim/vim/issues/10865#issuecomment-1214464023).

MRE:

    vim -Nu NONE -S <(tee <<'EOF'
        vim9script
        filetype plugin indent on
        syntax on
        &filetype = 'python'
        &formatoptions = 'o'
        syntax match pythonFoldMarkers /{{{\d*/ contained containedin=pythonComment
        var lines =<< trim END
        # xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {{{1

        if True:
        pass
        END
        lines->setline(1)
        normal! gg=G
    EOF
    )

Expected:

    # xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {{{1

    if True:
        pass

Actual:

    # xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {{{1

                                                  if True:
                                                  pass

---

The PR includes a test which passes only with the patch.
If someone could confirm or infirm that the patch works and doesn't break anything, that would help.
