### PR TITLE
Vim9 script functions defined in Vim script cannot take references to script local functions whose names start with a lower case letter

### DIFF
--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -1957,6 +1957,45 @@ def Test_call_funcref()
     g:listarg->assert_equal([1, 2, 3])
   END
   v9.CheckScriptSuccess(lines)
+
+  lines =<< trim END
+    function s:func(num)
+      return a:num * 2
+    endfunction
+
+    def s:CallFuncref()
+      var Funcref = function('s:func')
+      Funcref(3)->assert_equal(6)
+    enddef
+    call s:CallFuncref()
+  END
+  v9.CheckScriptSuccess(lines)
+
+  lines =<< trim END
+    function s:func(num)
+      return a:num * 2
+    endfunction
+
+    def s:CallFuncref()
+      var Funcref = function(s:func)
+      Funcref(3)->assert_equal(6)
+    enddef
+    call s:CallFuncref()
+  END
+  v9.CheckScriptSuccess(lines)
+
+  lines =<< trim END
+    function s:func(num)
+      return a:num * 2
+    endfunction
+
+    def s:CallFuncref()
+      var Funcref = s:func
+      Funcref(3)->assert_equal(6)
+    enddef
+    call s:CallFuncref()
+  END
+  v9.CheckScriptSuccess(lines)
 enddef
 
 let SomeFunc = function('len')

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -3791,6 +3791,7 @@ trans_function_name(
     int		prefix_g = FALSE;
     lval_T	lv;
     int		vim9script = in_vim9script();
+    int		script_is_vim9 = current_script_is_vim9();
     int		vim9_local;
 
     if (fdp != NULL)
@@ -3995,7 +3996,8 @@ trans_function_name(
     {
 	if (!vim9_local)
 	{
-	    if (vim9script && lead == 2 && !ASCII_ISUPPER(*lv.ll_name))
+	    if (vim9script && lead == 2 && !ASCII_ISUPPER(*lv.ll_name)
+		    && script_is_vim9)
 	    {
 		semsg(_(e_function_name_must_start_with_capital_str), start);
 		goto theend;

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -451,8 +451,7 @@ compile_load(
 			      vim_free(name);
 			      return FAIL;
 			  }
-			  if (is_expr && ASCII_ISUPPER(*name)
-					     && find_func(name, FALSE) != NULL)
+			  if (is_expr && find_func(name, FALSE) != NULL)
 			      res = generate_funcref(cctx, name, FALSE);
 			  else
 			      res = compile_load_scriptvar(cctx, name,


### PR DESCRIPTION
Issue:
Only in Vim9 script functions defined in Vim script files, defining functions with s:foo style names (beginning with a lower case letter) are allowed, but it is not possible to get references to them by using the function() or by assigning variables.
The current behavior is inconvenient in terms of compatibility with Vim script, and I can't find the specifications in document.
```vim
# in def block
var Ref = s:foo
var Ref2 = function('s:foo')
```

Proposal:
Allow Vim9 script functions defined in Vim script to reference functions in s:foo format.

Advantage:
- It will be convenient to replace some of the plugin processes written in Vim script with Vim9 script without changing the function names.
- Improved compatibility with conventional Vim script.
- The current specification is unnatural because it can be processed normally in other cases

Reproducible code:
This code is added to the test.
```
function! s:func()
  echo "s:func() was called"
endfunction

def! s:C1()
  s:func()
enddef

def! s:C2()
  var Ref2 = function('s:func')
  Ref2()
enddef

def! s:C3()
  var Ref3 = function(s:func)
  Ref3()
enddef

def! s:C4()
  var Ref1 = s:func
  Ref1()
enddef


call s:C1()
" Error ↓
call s:C2()
call s:C3()
call s:C4()
```