### PR TITLE
consolidate python indent config

### DIFF
--- a/runtime/autoload/python.vim
+++ b/runtime/autoload/python.vim
@@ -3,13 +3,19 @@
 let s:keepcpo= &cpo
 set cpo&vim
 
-" searchpair() can be slow, limit the time to 150 msec or what is put in
-" g:pyindent_searchpair_timeout
-let s:searchpair_timeout = get(g:, 'pyindent_searchpair_timeout', 150)
-
-" Identing inside parentheses can be very slow, regardless of the searchpair()
-" timeout, so let the user disable this feature if he doesn't need it
-let s:disable_parentheses_indenting = get(g:, 'pyindent_disable_parentheses_indenting', v:false)
+" need to inspect some old g:pyindent_* variables to be backward compatible
+let g:pyindent = extend(get(g:, 'pyindent', {}), #{
+  \ closed_paren_align_last_line: v:true,
+  \ open_paren: get(g:, 'pyindent_open_paren', 'shiftwidth() * 2')->eval(),
+  \ nested_paren: get(g:, 'pyindent_nested_paren', 'shiftwidth()')->eval(),
+  \ continue: get(g:, 'pyindent_continue', 'shiftwidth() * 2')->eval(),
+  "\ searchpair() can be slow, limit the time to 150 msec or what is put in
+  "\ g:pyindent.searchpair_timeout
+  \ searchpair_timeout: get(g:, 'pyindent_searchpair_timeout', 150),
+  "\ Identing inside parentheses can be very slow, regardless of the searchpair()
+  "\ timeout, so let the user disable this feature if he doesn't need it
+  \ disable_parentheses_indenting: get(g:, 'pyindent_disable_parentheses_indenting', v:false),
+  \ }, 'keep')
 
 let s:maxoff = 50       " maximum number of lines to look backwards for ()
 
@@ -17,7 +23,7 @@ function s:SearchBracket(fromlnum, flags)
   return searchpairpos('[[({]', '', '[])}]', a:flags,
           \ {-> synID('.', col('.'), v:true)->synIDattr('name')
           \ =~ '\%(Comment\|Todo\|String\)$'},
-          \ [0, a:fromlnum - s:maxoff]->max(), s:searchpair_timeout)
+          \ [0, a:fromlnum - s:maxoff]->max(), g:pyindent.searchpair_timeout)
 endfunction
 
 " See if the specified line is already user-dedented from the expected value.
@@ -37,7 +43,7 @@ function python#GetIndent(lnum, ...)
     if a:lnum > 1 && getline(a:lnum - 2) =~ '\\$'
       return indent(a:lnum - 1)
     endif
-    return indent(a:lnum - 1) + (exists("g:pyindent_continue") ? eval(g:pyindent_continue) : (shiftwidth() * 2))
+    return indent(a:lnum - 1) + g:pyindent.continue
   endif
 
   " If the start of the line is in a string don't change the indent.
@@ -54,7 +60,7 @@ function python#GetIndent(lnum, ...)
     return 0
   endif
 
-  if s:disable_parentheses_indenting == 1
+  if g:pyindent.disable_parentheses_indenting == 1
     let plindent = indent(plnum)
     let plnumstart = plnum
   else
@@ -69,8 +75,12 @@ function python#GetIndent(lnum, ...)
     "         100, 200, 300, 400)
     call cursor(a:lnum, 1)
     let [parlnum, parcol] = s:SearchBracket(a:lnum, 'nbW')
-    if parlnum > 0 && parcol != col([parlnum, '$']) - 1
-      return parcol
+    if parlnum > 0
+      if parcol != col([parlnum, '$']) - 1
+        return parcol
+      elseif getline(a:lnum) =~ '^\s*[])}]' && !g:pyindent.closed_paren_align_last_line
+        return indent(parlnum)
+      endif
     endif
 
     call cursor(plnum, 1)
@@ -122,9 +132,9 @@ function python#GetIndent(lnum, ...)
           " When the start is inside parenthesis, only indent one 'shiftwidth'.
           let [pp, _] = s:SearchBracket(a:lnum, 'bW')
           if pp > 0
-            return indent(plnum) + (exists("g:pyindent_nested_paren") ? eval(g:pyindent_nested_paren) : shiftwidth())
+            return indent(plnum) + g:pyindent.nest_paren
           endif
-          return indent(plnum) + (exists("g:pyindent_open_paren") ? eval(g:pyindent_open_paren) : (shiftwidth() * 2))
+          return indent(plnum) + g:pyindent.open_paren
         endif
         if plnumstart == p
           return indent(plnum)

--- a/runtime/autoload/python.vim
+++ b/runtime/autoload/python.vim
@@ -6,9 +6,9 @@ set cpo&vim
 " need to inspect some old g:pyindent_* variables to be backward compatible
 let g:pyindent = extend(get(g:, 'pyindent', {}), #{
   \ closed_paren_align_last_line: v:true,
-  \ open_paren: get(g:, 'pyindent_open_paren', 'shiftwidth() * 2')->eval(),
-  \ nested_paren: get(g:, 'pyindent_nested_paren', 'shiftwidth()')->eval(),
-  \ continue: get(g:, 'pyindent_continue', 'shiftwidth() * 2')->eval(),
+  \ open_paren: get(g:, 'pyindent_open_paren', 'shiftwidth() * 2'),
+  \ nested_paren: get(g:, 'pyindent_nested_paren', 'shiftwidth()'),
+  \ continue: get(g:, 'pyindent_continue', 'shiftwidth() * 2'),
   "\ searchpair() can be slow, limit the time to 150 msec or what is put in
   "\ g:pyindent.searchpair_timeout
   \ searchpair_timeout: get(g:, 'pyindent_searchpair_timeout', 150),
@@ -43,7 +43,7 @@ function python#GetIndent(lnum, ...)
     if a:lnum > 1 && getline(a:lnum - 2) =~ '\\$'
       return indent(a:lnum - 1)
     endif
-    return indent(a:lnum - 1) + g:pyindent.continue
+    return indent(a:lnum - 1) + g:pyindent.continue->eval()
   endif
 
   " If the start of the line is in a string don't change the indent.
@@ -132,9 +132,9 @@ function python#GetIndent(lnum, ...)
           " When the start is inside parenthesis, only indent one 'shiftwidth'.
           let [pp, _] = s:SearchBracket(a:lnum, 'bW')
           if pp > 0
-            return indent(plnum) + g:pyindent.nest_paren
+            return indent(plnum) + g:pyindent.nested_paren->eval()
           endif
-          return indent(plnum) + g:pyindent.open_paren
+          return indent(plnum) + g:pyindent.open_paren->eval()
         endif
         if plnumstart == p
           return indent(plnum)

--- a/runtime/autoload/python.vim
+++ b/runtime/autoload/python.vim
@@ -4,13 +4,13 @@ let s:keepcpo= &cpo
 set cpo&vim
 
 " need to inspect some old g:pyindent_* variables to be backward compatible
-let g:pyindent = extend(get(g:, 'pyindent', {}), #{
+let g:python_indent = extend(get(g:, 'python_indent', {}), #{
   \ closed_paren_align_last_line: v:true,
   \ open_paren: get(g:, 'pyindent_open_paren', 'shiftwidth() * 2'),
   \ nested_paren: get(g:, 'pyindent_nested_paren', 'shiftwidth()'),
   \ continue: get(g:, 'pyindent_continue', 'shiftwidth() * 2'),
   "\ searchpair() can be slow, limit the time to 150 msec or what is put in
-  "\ g:pyindent.searchpair_timeout
+  "\ g:python_indent.searchpair_timeout
   \ searchpair_timeout: get(g:, 'pyindent_searchpair_timeout', 150),
   "\ Identing inside parentheses can be very slow, regardless of the searchpair()
   "\ timeout, so let the user disable this feature if he doesn't need it
@@ -23,7 +23,7 @@ function s:SearchBracket(fromlnum, flags)
   return searchpairpos('[[({]', '', '[])}]', a:flags,
           \ {-> synID('.', col('.'), v:true)->synIDattr('name')
           \ =~ '\%(Comment\|Todo\|String\)$'},
-          \ [0, a:fromlnum - s:maxoff]->max(), g:pyindent.searchpair_timeout)
+          \ [0, a:fromlnum - s:maxoff]->max(), g:python_indent.searchpair_timeout)
 endfunction
 
 " See if the specified line is already user-dedented from the expected value.
@@ -43,7 +43,7 @@ function python#GetIndent(lnum, ...)
     if a:lnum > 1 && getline(a:lnum - 2) =~ '\\$'
       return indent(a:lnum - 1)
     endif
-    return indent(a:lnum - 1) + g:pyindent.continue->eval()
+    return indent(a:lnum - 1) + g:python_indent.continue->eval()
   endif
 
   " If the start of the line is in a string don't change the indent.
@@ -60,7 +60,7 @@ function python#GetIndent(lnum, ...)
     return 0
   endif
 
-  if g:pyindent.disable_parentheses_indenting == 1
+  if g:python_indent.disable_parentheses_indenting == 1
     let plindent = indent(plnum)
     let plnumstart = plnum
   else
@@ -78,7 +78,7 @@ function python#GetIndent(lnum, ...)
     if parlnum > 0
       if parcol != col([parlnum, '$']) - 1
         return parcol
-      elseif getline(a:lnum) =~ '^\s*[])}]' && !g:pyindent.closed_paren_align_last_line
+      elseif getline(a:lnum) =~ '^\s*[])}]' && !g:python_indent.closed_paren_align_last_line
         return indent(parlnum)
       endif
     endif
@@ -132,9 +132,9 @@ function python#GetIndent(lnum, ...)
           " When the start is inside parenthesis, only indent one 'shiftwidth'.
           let [pp, _] = s:SearchBracket(a:lnum, 'bW')
           if pp > 0
-            return indent(plnum) + g:pyindent.nested_paren->eval()
+            return indent(plnum) + g:python_indent.nested_paren->eval()
           endif
-          return indent(plnum) + g:pyindent.open_paren->eval()
+          return indent(plnum) + g:python_indent.open_paren->eval()
         endif
         if plnumstart == p
           return indent(plnum)

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -983,25 +983,38 @@ indentation: >
 PYTHON							*ft-python-indent*
 
 The amount of indent can be set for the following situations.  The examples
-given are the defaults.  Note that the variables are set to an expression, so
-that you can change the value of 'shiftwidth' later.
+given are the defaults.  Note that the dictionary values is are set to an
+expression, so that you can change the value of 'shiftwidth' later.
 
 Indent after an open paren: >
-	let g:pyindent_open_paren = 'shiftwidth() * 2'
+	let g:pyindent.open_paren = 'shiftwidth() * 2'
 Indent after a nested paren: >
-	let g:pyindent_nested_paren = 'shiftwidth()'
+	let g:pyindent.nested_paren = 'shiftwidth()'
 Indent for a continuation line: >
-	let g:pyindent_continue = 'shiftwidth() * 2'
+	let g:pyindent.continue = 'shiftwidth() * 2'
+
+By default, the closing paren on a multiline construct lines up under the first
+non-whitespace character of the previous line.
+If you prefer that it's lined up under the first character of the line that
+starts the multiline construct, reset this key: >
+	let g:pyindent.closed_paren_align_last_line = v:false
 
 The method uses |searchpair()| to look back for unclosed parentheses.  This
 can sometimes be slow, thus it timeouts after 150 msec.  If you notice the
 indenting isn't correct, you can set a larger timeout in msec: >
-	let g:pyindent_searchpair_timeout = 500
+	let g:pyindent.searchpair_timeout = 500
 
 If looking back for unclosed parenthesis is still too slow, especially during
 a copy-paste operation, or if you don't need indenting inside multi-line
 parentheses, you can completely disable this feature: >
-	let g:pyindent_disable_parentheses_indenting = 1
+	let g:pyindent.disable_parentheses_indenting = 1
+
+For backward compatibility, these variables are also supported: >
+	g:pyindent.open_paren
+	g:pyindent.nested_paren
+	g:pyindent.continue
+	g:pyindent.searchpair_timeout
+	g:pyindent.disable_parentheses_indenting
 
 
 R								*ft-r-indent*

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -1010,11 +1010,11 @@ parentheses, you can completely disable this feature: >
 	let g:python_indent.disable_parentheses_indenting = 1
 
 For backward compatibility, these variables are also supported: >
-	g:python_indent.open_paren
-	g:python_indent.nested_paren
-	g:python_indent.continue
-	g:python_indent.searchpair_timeout
-	g:python_indent.disable_parentheses_indenting
+	g:pyindent_open_paren
+	g:pyindent_nested_paren
+	g:pyindent_continue
+	g:pyindent_searchpair_timeout
+	g:pyindent_disable_parentheses_indenting
 
 
 R								*ft-r-indent*

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -983,7 +983,7 @@ indentation: >
 PYTHON							*ft-python-indent*
 
 The amount of indent can be set for the following situations.  The examples
-given are the defaults.  Note that the dictionary values is are set to an
+given are the defaults.  Note that the dictionary values are set to an
 expression, so that you can change the value of 'shiftwidth' later.
 
 Indent after an open paren: >

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -987,34 +987,34 @@ given are the defaults.  Note that the dictionary values is are set to an
 expression, so that you can change the value of 'shiftwidth' later.
 
 Indent after an open paren: >
-	let g:pyindent.open_paren = 'shiftwidth() * 2'
+	let g:python_indent.open_paren = 'shiftwidth() * 2'
 Indent after a nested paren: >
-	let g:pyindent.nested_paren = 'shiftwidth()'
+	let g:python_indent.nested_paren = 'shiftwidth()'
 Indent for a continuation line: >
-	let g:pyindent.continue = 'shiftwidth() * 2'
+	let g:python_indent.continue = 'shiftwidth() * 2'
 
 By default, the closing paren on a multiline construct lines up under the first
 non-whitespace character of the previous line.
 If you prefer that it's lined up under the first character of the line that
 starts the multiline construct, reset this key: >
-	let g:pyindent.closed_paren_align_last_line = v:false
+	let g:python_indent.closed_paren_align_last_line = v:false
 
 The method uses |searchpair()| to look back for unclosed parentheses.  This
 can sometimes be slow, thus it timeouts after 150 msec.  If you notice the
 indenting isn't correct, you can set a larger timeout in msec: >
-	let g:pyindent.searchpair_timeout = 500
+	let g:python_indent.searchpair_timeout = 500
 
 If looking back for unclosed parenthesis is still too slow, especially during
 a copy-paste operation, or if you don't need indenting inside multi-line
 parentheses, you can completely disable this feature: >
-	let g:pyindent.disable_parentheses_indenting = 1
+	let g:python_indent.disable_parentheses_indenting = 1
 
 For backward compatibility, these variables are also supported: >
-	g:pyindent.open_paren
-	g:pyindent.nested_paren
-	g:pyindent.continue
-	g:pyindent.searchpair_timeout
-	g:pyindent.disable_parentheses_indenting
+	g:python_indent.open_paren
+	g:python_indent.nested_paren
+	g:python_indent.continue
+	g:python_indent.searchpair_timeout
+	g:python_indent.disable_parentheses_indenting
 
 
 R								*ft-r-indent*

--- a/runtime/indent/testdir/python.in
+++ b/runtime/indent/testdir/python.in
@@ -1,6 +1,13 @@
-" vim: set ft=python sw=4 et:
+# vim: set ft=python sw=4 et:
 
-" START_INDENT
+# START_INDENT
+# INDENT_EXE let [g:pyindent.open_paren, g:pyindent.closed_paren_align_last_line] = [4, v:false]
+dict = {
+'a': 1,
+}
+# END_INDENT
+
+# START_INDENT
 open_paren_not_at_EOL(100,
 (200,
 300),
@@ -65,4 +72,4 @@ open_paren_not_at_EOL(100,
 open_paren_at_EOL(
 100, 200, 300, 400)
 
-" END_INDENT
+# END_INDENT

--- a/runtime/indent/testdir/python.in
+++ b/runtime/indent/testdir/python.in
@@ -1,7 +1,7 @@
 # vim: set ft=python sw=4 et:
 
 # START_INDENT
-# INDENT_EXE let [g:pyindent.open_paren, g:pyindent.closed_paren_align_last_line] = ['shiftwidth()', v:false]
+# INDENT_EXE let [g:python_indent.open_paren, g:python_indent.closed_paren_align_last_line] = ['shiftwidth()', v:false]
 dict = {
 'a': 1,
 'b': 2,

--- a/runtime/indent/testdir/python.in
+++ b/runtime/indent/testdir/python.in
@@ -1,9 +1,11 @@
 # vim: set ft=python sw=4 et:
 
 # START_INDENT
-# INDENT_EXE let [g:pyindent.open_paren, g:pyindent.closed_paren_align_last_line] = [4, v:false]
+# INDENT_EXE let [g:pyindent.open_paren, g:pyindent.closed_paren_align_last_line] = ['shiftwidth()', v:false]
 dict = {
 'a': 1,
+'b': 2,
+'c': 3,
 }
 # END_INDENT
 

--- a/runtime/indent/testdir/python.ok
+++ b/runtime/indent/testdir/python.ok
@@ -1,29 +1,20 @@
-" vim: set ft=python sw=4 et:
+# vim: set ft=python sw=4 et:
 
-" START_INDENT
+# START_INDENT
+# INDENT_EXE let [g:pyindent.open_paren, g:pyindent.closed_paren_align_last_line] = [4, v:false]
+dict = {
+    'a': 1,
+}
+# END_INDENT
+
+# START_INDENT
 open_paren_not_at_EOL(100,
                       (200,
                        300),
                       400)
 
 open_paren_at_EOL(
-        100, 200, 300, 400)
-
-open_paren_not_at_EOL(100,
-                      (200,
-                       300),
-                      400)
-
-open_paren_at_EOL(
-        100, 200, 300, 400)
-
-open_paren_not_at_EOL(100,
-                      (200,
-                       300),
-                      400)
-
-open_paren_at_EOL(
-        100, 200, 300, 400)
+    100, 200, 300, 400)
 
 open_paren_not_at_EOL(100,
                       (200,
@@ -31,7 +22,7 @@ open_paren_not_at_EOL(100,
                       400)
 
 open_paren_at_EOL(
-        100, 200, 300, 400)
+    100, 200, 300, 400)
 
 open_paren_not_at_EOL(100,
                       (200,
@@ -39,7 +30,7 @@ open_paren_not_at_EOL(100,
                       400)
 
 open_paren_at_EOL(
-        100, 200, 300, 400)
+    100, 200, 300, 400)
 
 open_paren_not_at_EOL(100,
                       (200,
@@ -47,7 +38,7 @@ open_paren_not_at_EOL(100,
                       400)
 
 open_paren_at_EOL(
-        100, 200, 300, 400)
+    100, 200, 300, 400)
 
 open_paren_not_at_EOL(100,
                       (200,
@@ -55,7 +46,7 @@ open_paren_not_at_EOL(100,
                       400)
 
 open_paren_at_EOL(
-        100, 200, 300, 400)
+    100, 200, 300, 400)
 
 open_paren_not_at_EOL(100,
                       (200,
@@ -63,6 +54,22 @@ open_paren_not_at_EOL(100,
                       400)
 
 open_paren_at_EOL(
-        100, 200, 300, 400)
+    100, 200, 300, 400)
 
-" END_INDENT
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+    100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+    100, 200, 300, 400)
+
+# END_INDENT

--- a/runtime/indent/testdir/python.ok
+++ b/runtime/indent/testdir/python.ok
@@ -1,7 +1,7 @@
 # vim: set ft=python sw=4 et:
 
 # START_INDENT
-# INDENT_EXE let [g:pyindent.open_paren, g:pyindent.closed_paren_align_last_line] = ['shiftwidth()', v:false]
+# INDENT_EXE let [g:python_indent.open_paren, g:python_indent.closed_paren_align_last_line] = ['shiftwidth()', v:false]
 dict = {
     'a': 1,
     'b': 2,

--- a/runtime/indent/testdir/python.ok
+++ b/runtime/indent/testdir/python.ok
@@ -1,9 +1,11 @@
 # vim: set ft=python sw=4 et:
 
 # START_INDENT
-# INDENT_EXE let [g:pyindent.open_paren, g:pyindent.closed_paren_align_last_line] = [4, v:false]
+# INDENT_EXE let [g:pyindent.open_paren, g:pyindent.closed_paren_align_last_line] = ['shiftwidth()', v:false]
 dict = {
     'a': 1,
+    'b': 2,
+    'c': 3,
 }
 # END_INDENT
 


### PR DESCRIPTION
The current python indent plugin relies on 5 global variables for its config:

    g:pyindent_continue
    g:pyindent_disable_parentheses_indenting
    g:pyindent_nested_paren
    g:pyindent_open_paren
    g:pyindent_searchpair_timeout

This PR consolidates all of them inside a single `g:pyindent` dictionary variable.

---

Also, the current plugin indents a multiline dictionary such as:
```python
dict = {
'a': 1,
}
```
Like this:
```python
dict = {
    'a': 1,
    }
```
Some people might prefer this:
```python
dict = {
    'a': 1,
}
```
This is given as an alternative in [PEP8](https://peps.python.org/pep-0008/#indentation).
It seems to be the only way in the [Google python style guide](https://google.github.io/styleguide/pyguide.html#34-indentation).
And it seems to be the default way for [the black Python formatter](https://black.vercel.app/?version=stable&state=_Td6WFoAAATm1rRGAgAhARYAAAB0L-Wj4AB5AFFdAD2IimZxl1N_WlbxpEc-goJ3yoqDCyUvIkDzHxUugEDCFO2QG0ChSEPsYHg3d9cEUoPBd04lAPiNtEFOnV2lBHav2Ag8en_3mPLXjTxq9Wd9AAAAAACLBcCUeogDgwABbXrjOAVAH7bzfQEAAAAABFla).

This PR adds a new key inside `g:pyindent`: `closed_paren_align_last_line`.  By default it's `true` to preserve the old way of aligning closing parens.  But when reset to `false`, the user can get the other type of alignment.

The help is updated, and a test is included.

I'm not sure how reliable it is yet.

