### PR TITLE
Fix netrw plugin issue using powershell

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -12066,7 +12066,7 @@ endfun
 " s:NetrwExe: executes a string using "!" {{{2
 fun! s:NetrwExe(cmd)
 "  call Dfunc("s:NetrwExe(a:cmd<".a:cmd.">)")
-  if has("win32") && &shell !~? 'cmd' && !g:netrw_cygwin
+  if has("win32") && &shell !~? 'cmd\|pwsh\|powershell' && !g:netrw_cygwin
 "    call Decho("using win32:",expand("<slnum>"))
     let savedShell=[&shell,&shellcmdflag,&shellxquote,&shellxescape,&shellquote,&shellpipe,&shellredir,&shellslash]
     set shell& shellcmdflag& shellxquote& shellxescape&


### PR DESCRIPTION
`Vim\vim82\autoload\netrw.vim plugin` has issues with powershell because the function `s:NetrwExe` falls back to `cmd` on windows. This is used for example to call `curl`.

`netrw.vim` uses vim's `shellescape()` to decorate urls and is witty enough to use single quotes to escape if powershell is detected (`'http://whatever'` for example). Uses it through `s:ShellEscape()`.

`curl` doesn't admit single quoted arguments from `cmd` and breaks. But it works on powershell because it will remove them for the call.
