### PR TITLE
Allow `prop_remove` to operate on a list of property types

### DIFF
--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -340,7 +340,7 @@ prop_list({lnum} [, {props}])				*prop_list()*
 		Can also be used as a |method|: >
 			GetLnum()->prop_list()
 <
-						*prop_remove()* *E968* *E860*
+					*prop_remove()* *E968* *E860* *E1295*
 prop_remove({props} [, {lnum} [, {lnum-end}]])
 		Remove a matching text property from line {lnum}.  When
 		{lnum-end} is given, remove matching text properties from line
@@ -352,11 +352,15 @@ prop_remove({props} [, {lnum} [, {lnum-end}]])
 		{props} is a dictionary with these fields:
 		   id		remove text properties with this ID
 		   type		remove text properties with this type name
-		   both		"id" and "type" must both match
+		   types	a list of property types to remove
+		   both		"id" and "type"/"types" must both match
 		   bufnr	use this buffer instead of the current one
 		   all		when TRUE remove all matching text properties,
 				not just the first one
-		A property matches when either "id" or "type" matches.
+		Only one of "type" and "types" may be supplied. 
+
+		A property matches when either "id" or one of the supplied
+		types matches.
 		If buffer "bufnr" does not exist you get an error message.
 		If buffer "bufnr" is not loaded then nothing happens.
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -2209,7 +2209,7 @@ EXTERN char e_failed_to_convert_returned_python_object_to_vim_value[]
 #endif
 #ifdef FEAT_PROP_POPUP
 EXTERN char e_need_id_and_type_with_both[]
-	INIT(= N_("E860: Need 'id' and 'type' with 'both'"));
+	INIT(= N_("E860: Need 'id' and 'type' or 'types' with 'both'"));
 # ifdef FEAT_TERMINAL
 EXTERN char e_cannot_open_second_popup_with_terminal[]
 	INIT(= N_("E861: Cannot open a second popup with a terminal"));
@@ -3315,4 +3315,8 @@ EXTERN char e_cannot_use_negative_id_after_adding_textprop_with_text[]
 	INIT(= N_("E1293: Cannot use a negative id after adding a textprop with text"));
 EXTERN char e_can_only_use_text_align_when_column_is_zero[]
 	INIT(= N_("E1294: Can only use text_align when column is zero"));
+#endif
+#ifdef FEAT_PROP_POPUP
+EXTERN char e_cannot_have_both_type_and_types[]
+	INIT(= N_("E1295: Cannot specify both 'type' and 'types'"));
 #endif

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -426,6 +426,37 @@ func Test_prop_remove()
 
   call DeletePropTypes()
   bwipe!
+
+  new
+  call AddPropTypes()
+  call SetupPropsInFirstLine()
+  let props = Get_expected_props() " [whole, one, two, three]
+  call assert_equal(props, prop_list(1))
+
+  " remove one by types
+  call assert_equal(1, prop_remove({'types': ['one','two','three']}, 1))
+  unlet props[1] " [whole, two, three]
+  call assert_equal(props, prop_list(1))
+
+  " remove 'all' by types
+  call assert_equal(2, prop_remove({'types': ['three', 'whole'], 'all': 1}, 1))
+  unlet props[0] " [two, three]
+  unlet props[1] " [three]
+  call assert_equal(props, prop_list(1))
+
+  " remove none by types
+  call assert_equal(0, prop_remove({'types': ['three', 'whole'], 'all': 1}, 1))
+  call assert_equal(props, prop_list(1))
+
+  " no types
+  call assert_fails("call prop_remove({'types': []}, 1)", 'E968:')
+  call assert_fails("call prop_remove({'types': ['not_a_real_type']}, 1)", 'E971:')
+
+  " only one of types and type can be supplied
+  call assert_fails("call prop_remove({'type': 'one', 'types': ['three'], 'all': 1}, 1)", 'E1295:')
+
+  call DeletePropTypes()
+  bwipe!
 endfunc
 
 def Test_prop_add_vim9()


### PR DESCRIPTION
Removing text properties can be slow as it requires scanning the buffer lines internally. The best way is to use a line range when calling `prop_remove`. However, due to the way text properties move around when text is modified, placing a text prop with `prop_add` on line 10 does not mean that it's on line 10 when you might want to remove it. When working with virtual text and semantic tokens, there can be a lot of text properties that need to be refreshed periodically. The simplest way is to remove existing properties matching some ID (or type) and re-add the new ones.

With "classic" text properties, it was possible to assign the same Id to each property and thus remove the props in one scan of the affected range (e.g. whole buffer). With virtual text properties, it's not possible as the ID is generated and returned, so we're left with deleting "all by type" over the range, or recording the IDs of each property type and querying if it's still present (as deleting or undoing can remove it).

We have `prop_find` that can take a list of types to find, so to avoid having to do multiple scans of the lines and to avoid having to remember and query every ID, provide `prop_remove` with the ability to remove all properties with one of a list of property types.

```
Problem: can't remove text properties for multiple types at once
Solution: Allow types to be a list
```

concrete example:

* create text property types for `Param`, `Type` and `Enum` inlay hints, including a type for "padding"
* (periodically) clear all `Param`, `Type`,  `Enum` and padding properties and re-create them based on the result of some query to the semantic engine.

currently requires at least 4 calls to `prop_remove`; can now be done with `prop_remove( { 'types': [ 'Param', 'Type', 'Enum', 'padding' ], 'all': 1 } )` 