### PR TITLE
Only include dispatch.h when needed

### DIFF
--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -28,7 +28,9 @@
 #include <sys/errno.h>
 #include <stdlib.h>
 
+#ifdef FEAT_RELTIME
 #include <dispatch/dispatch.h>
+#endif
 
 #include "vim.h"
 #import <AppKit/AppKit.h>


### PR DESCRIPTION
This change allows "small" vim to be built on pre-dispatch Mac systems (10.5 and earlier).