### PR TITLE
feat: ignore directory gnenrated by test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ src/testdir/dostmp/*
 src/testdir/messages
 src/testdir/viminfo
 src/testdir/opt_test.vim
+src/testdir/failed/
 runtime/indent/testdir/*.out
 runtime/indent/testdir/*.fail
 src/memfile_test


### PR DESCRIPTION
The `src/testdir/failed/` directory is generated when `make test` failed.

It's not necessary to track this directory.