### PR TITLE
CI: use ubuntu-20.04 on Coverity as well

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   scan:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     env:
       CC: gcc


### PR DESCRIPTION
I missed to update it on Coverity CI.