### PR TITLE
implement cmdline completion of "syn list @cluster"

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -6341,7 +6341,8 @@ static enum
     EXP_SUBCMD,	    // expand ":syn" sub-commands
     EXP_CASE,	    // expand ":syn case" arguments
     EXP_SPELL,	    // expand ":syn spell" arguments
-    EXP_SYNC	    // expand ":syn sync" arguments
+    EXP_SYNC,	    // expand ":syn sync" arguments
+    EXP_CLUSTER	    // expand ":syn list @cluster" arguments
 } expand_what;
 
 /*
@@ -6396,10 +6397,15 @@ set_context_in_syntax_cmd(expand_T *xp, char_u *arg)
 		expand_what = EXP_SPELL;
 	    else if (STRNICMP(arg, "sync", p - arg) == 0)
 		expand_what = EXP_SYNC;
-	    else if (  STRNICMP(arg, "keyword", p - arg) == 0
+	    else if (STRNICMP(arg, "list", p - arg) == 0) {
+		p = skipwhite(p);
+		if (*p == '@')
+		    expand_what = EXP_CLUSTER;
+		else
+		    xp->xp_context = EXPAND_HIGHLIGHT;
+	    } else if (  STRNICMP(arg, "keyword", p - arg) == 0
 		    || STRNICMP(arg, "region", p - arg) == 0
-		    || STRNICMP(arg, "match", p - arg) == 0
-		    || STRNICMP(arg, "list", p - arg) == 0)
+		    || STRNICMP(arg, "match", p - arg) == 0)
 		xp->xp_context = EXPAND_HIGHLIGHT;
 	    else
 		xp->xp_context = EXPAND_NOTHING;
@@ -6414,6 +6420,8 @@ set_context_in_syntax_cmd(expand_T *xp, char_u *arg)
     char_u *
 get_syntax_name(expand_T *xp UNUSED, int idx)
 {
+#define CBUFFER_LEN 256
+    static char_u	cbuffer[CBUFFER_LEN]; //hack
     switch (expand_what)
     {
 	case EXP_SUBCMD:
@@ -6436,6 +6444,16 @@ get_syntax_name(expand_T *xp UNUSED, int idx)
 		 "linebreaks=", "linecont", "lines=", "match",
 		 "maxlines=", "minlines=", "region", NULL};
 	    return (char_u *)sync_args[idx];
+	}
+	case EXP_CLUSTER:
+	{
+	    if (idx < curwin->w_s->b_syn_clusters.ga_len) {
+		cbuffer[0] = '@';
+		vim_strncpy(cbuffer+1, SYN_CLSTR(curwin->w_s)[idx].scl_name, CBUFFER_LEN - 2);
+		return cbuffer;
+	    } else {
+		return NULL;
+	    }
 	}
     }
     return NULL;

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -201,6 +201,10 @@ func Test_syntax_completion()
 
   call feedkeys(":syn match \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('^"syn match Boolean Character ', @:)
+
+  syn cluster Aax contains=Aap
+  call feedkeys(":syn list @A\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_match('^"syn list @Aax', @:)
 endfunc
 
 func Test_echohl_completion()


### PR DESCRIPTION
`syn list @myCluster` can be used to list the contents of a syntax cluster. However wildmenu completion of `syn list @my<tab>` does not work, unlike `syn list syntaxGroup`. This implements it.