### PR TITLE
Hide the messages popup when entering the command line

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -3187,6 +3187,13 @@ nv_colon(cmdarg_T *cap)
 	    }
 	}
 
+#ifdef HAS_MESSAGE_WINDOW
+	// hide any popup notification messages when entering the command line,
+	// otherwise it may be obscured
+	if (KeyTyped && use_message_window() && popup_message_win_visible())
+	    popup_hide_message_win();
+#endif
+
 	// When typing, don't type below an old message
 	if (KeyTyped)
 	    compute_cmdrow();

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -400,6 +400,10 @@ func Test_x_cmdheight_zero()
   if using_popupwin
     redraw
     call assert_equal('test echo', Screenline(&lines))
+    " check popup cleared when entering command line
+    call feedkeys( ':', 'xt' )
+    redraw
+    call assert_equal('~', Screenline(&lines))
   else
     call assert_equal(116, screenchar(&lines, 1))
   endif


### PR DESCRIPTION
Problem: Command line is obscured by notification popup when cmdheight=0
Solution: Hide the popup when entering command line


I'm not sure this patch is perfect, but steps to reproduce are below:

1. `vim --clean --cmd 'set cmdheight=0' `
2. `:echo 'this is a test'`
3. (within 3 seconds) type `:something`

Expect: `:something` is shown (i.e. the command line is visible)
Actual: the `this is a test` popup is drawn over the command line.