### PR TITLE
Fixed compiler warning on MSVC on Windows with size_t to int typecast.

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -2281,7 +2281,7 @@ put_msg_win(win_T *wp, int where, char_u *t_s, char_u *end, linenr_T lnum)
     redraw_win_later(wp, UPD_NOT_VALID);
 
     // set msg_col so that a newline is written if needed
-    msg_col = STRLEN(t_s);
+    msg_col = (int)STRLEN(t_s);
 }
 #endif
 


### PR DESCRIPTION
I've fixed another Win32 MSVC compiler warning with a typecast from size_t to int, this time in `messages.c` at line 2284.