### PR TITLE
feat: add godot game engine syntax/ftplugin/indent files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -698,6 +698,9 @@ au BufNewFile,BufRead *.gd			setf gdscript
 " Godot resource
 au BufRead,BufNewFile *.tscn,*.tres			setf gdresource
 
+" Godot shader
+au BufRead,BufNewFile *.gdshader,*.shader	setf gdshader
+
 " Gedcom
 au BufNewFile,BufRead *.ged,lltxxxxx.txt	setf gedcom
 

--- a/runtime/ftplugin/gdscript.vim
+++ b/runtime/ftplugin/gdscript.vim
@@ -1,0 +1,54 @@
+vim9script
+
+# Vim filetype plugin file
+# Language: gdscript (Godot game engine scripting language)
+# Maintainer: Maxim Kim <habamax@gmail.com>
+
+if exists("b:did_ftplugin") | finish | endif
+
+b:did_ftplugin = 1
+b:undo_ftplugin = 'setlocal cinkeys<'
+      \ .. '| setlocal indentkeys<'
+      \ .. '| setlocal commentstring<'
+      \ .. '| setlocal suffixesadd<'
+      \ .. '| setlocal foldexpr<'
+      \ .. '| setlocal foldignore<'
+      \ .. '| setlocal noexpandtab<'
+
+setlocal cinkeys-=0#
+setlocal indentkeys-=0#
+setlocal suffixesadd=.gd
+setlocal commentstring=#\ %s
+setlocal foldignore=
+setlocal foldexpr=GDScriptFoldLevel()
+
+
+def GDScriptFoldLevel(): string
+    var line = getline(v:lnum)
+    if line =~? '^\s*$'
+        return "-1"
+    endif
+
+    var sw = shiftwidth()
+    var indent = indent(v:lnum) / sw
+    var indent_next = indent(nextnonblank(v:lnum + 1)) / sw
+
+    if indent_next > indent && line =~ ':\s*$'
+        return $">{indent_next}"
+    else
+        return $"{indent}"
+    endif
+enddef
+
+
+# Next/Previous section
+def NextSection(back: bool, cnt: number)
+    for n in range(cnt)
+        search('^\s*func\s', back ? 'bW' : 'W')
+    endfor
+enddef
+
+nnoremap <silent><buffer>   ]] <scriptcmd>NextSection(false, v:count1)<CR>
+nnoremap <silent><buffer>   [[ <scriptcmd>NextSection(true, v:count1)<CR>
+xmap <silent><buffer><expr> ]] "\<esc>" .. v:count1 .. ']]m>gv'
+xmap <silent><buffer><expr> [[ "\<esc>" .. v:count1 .. '[[m>gv'

--- a/runtime/ftplugin/gdscript.vim
+++ b/runtime/ftplugin/gdscript.vim
@@ -13,7 +13,6 @@ b:undo_ftplugin = 'setlocal cinkeys<'
       \ .. '| setlocal suffixesadd<'
       \ .. '| setlocal foldexpr<'
       \ .. '| setlocal foldignore<'
-      \ .. '| setlocal noexpandtab<'
 
 setlocal cinkeys-=0#
 setlocal indentkeys-=0#

--- a/runtime/ftplugin/gdshader.vim
+++ b/runtime/ftplugin/gdshader.vim
@@ -1,0 +1,12 @@
+vim9script
+
+# Vim filetype plugin file
+# Language: Godot shading language
+# Maintainer: Maxim Kim <habamax@gmail.com>
+
+if exists("b:did_ftplugin") | finish | endif
+b:did_ftplugin = 1
+
+b:undo_ftplugin = 'setlocal suffixesadd<'
+
+setlocal suffixesadd=.gdshader

--- a/runtime/indent/gdscript.vim
+++ b/runtime/indent/gdscript.vim
@@ -1,0 +1,148 @@
+vim9script
+
+# Vim indent file
+# Language: gdscript (Godot game engine)
+# Maintainer: Maxim Kim <habamax@gmail.com>
+# Based on python indent file.
+
+if exists("b:did_indent")
+    finish
+endif
+b:did_indent = 1
+
+var undo_opts = "setl indentexpr< indentkeys< lisp< autoindent<"
+
+if exists('b:undo_indent')
+    b:undo_indent ..= "|" .. undo_opts
+else
+    b:undo_indent = undo_opts
+endif
+
+setlocal nolisp
+setlocal autoindent
+setlocal indentexpr=GDScriptIndent()
+setlocal indentkeys+=<:>,=elif,=except
+
+
+def GDScriptIndent(): number
+    # If this line is explicitly joined: If the previous line was also joined,
+    # line it up with that one, otherwise add two 'shiftwidth'
+    if getline(v:lnum - 1) =~ '\\$'
+        if v:lnum > 1 && getline(v:lnum - 2) =~ '\\$'
+            return indent(v:lnum - 1)
+        endif
+        return indent(v:lnum - 1) + (shiftwidth() * 2)
+    endif
+
+    # If the start of the line is in a string don't change the indent.
+    if has('syntax_items') && synIDattr(synID(v:lnum, 1, 1), "name") =~ "String$"
+        return -1
+    endif
+
+    # Search backwards for the previous non-empty line.
+    var plnum = prevnonblank(v:lnum - 1)
+
+    if plnum == 0
+        # This is the first non-empty line, use zero indent.
+        return 0
+    endif
+
+    var plindent = indent(plnum)
+    var plnumstart = plnum
+
+    # Get the line and remove a trailing comment.
+    # Use syntax highlighting attributes when possible.
+    var pline = getline(plnum)
+    var pline_len = strlen(pline)
+    if has('syntax_items')
+        # If the last character in the line is a comment, do a binary search for
+        # the start of the comment.  synID() is slow, a linear search would take
+        # too long on a long line.
+        if synIDattr(synID(plnum, pline_len, 1), "name") =~ "\\(Comment\\|Todo\\)$"
+            var min = 1
+            var max = pline_len
+            while min < max
+                var col = (min + max) / 2
+                if synIDattr(synID(plnum, col, 1), "name") =~ "\\(Comment\\|Todo\\)$"
+                    max = col
+                else
+                    min = col + 1
+                endif
+            endwhile
+            pline = strpart(pline, 0, min - 1)
+        endif
+    else
+        var col = 0
+        while col < pline_len
+            if pline[col] == '#'
+                pline = strpart(pline, 0, col)
+                break
+            endif
+            col = col + 1
+        endwhile
+    endif
+
+
+    # When "inside" parenthesis: If at the first line below the parenthesis add
+    # one 'shiftwidth' ("inside" is simplified and not really checked)
+    # my_var = (
+    #     a
+    #     + b
+    #     + c
+    # )
+    if pline =~ '[({\[]\s*$'
+        return indent(plnum) + shiftwidth()
+    endif
+
+
+    # If the previous line ended with a colon, indent this line
+    if pline =~ ':\s*$'
+        return plindent + shiftwidth()
+    endif
+
+    # If the previous line was a stop-execution statement...
+    if getline(plnum) =~ '^\s*\(break\|continue\|raise\|return\|pass\)\>'
+        # See if the user has already dedented
+        if indent(v:lnum) > indent(plnum) - shiftwidth()
+            # If not, recommend one dedent
+            return indent(plnum) - shiftwidth()
+        endif
+        # Otherwise, trust the user
+        return -1
+    endif
+
+    # If the current line begins with a keyword that lines up with "try"
+    if getline(v:lnum) =~ '^\s*\(except\|finally\)\>'
+        var lnum = v:lnum - 1
+        while lnum >= 1
+            if getline(lnum) =~ '^\s*\(try\|except\)\>'
+                var ind = indent(lnum)
+                if ind >= indent(v:lnum)
+                    return -1   # indent is already less than this
+                endif
+                return ind      # line up with previous try or except
+            endif
+            lnum = lnum - 1
+        endwhile
+        return -1               # no matching "try"!
+    endif
+
+
+    # If the current line begins with a header keyword, dedent
+    if getline(v:lnum) =~ '^\s*\(elif\|else\)\>'
+
+        # Unless the previous line was a one-liner
+        if getline(plnumstart) =~ '^\s*\(for\|if\|try\)\>'
+            return plindent
+        endif
+
+        # Or the user has already dedented
+        if indent(v:lnum) <= plindent - shiftwidth()
+            return -1
+        endif
+
+        return plindent - shiftwidth()
+    endif
+
+    return -1
+enddef

--- a/runtime/syntax/gdresource.vim
+++ b/runtime/syntax/gdresource.vim
@@ -1,0 +1,58 @@
+" Vim syntax file for Godot resource (scenes)
+" Language:     gdresource
+" Maintainer:   Maxim Kim <habamax@gmail.com>
+" Filenames:    *.tscn, *.tres
+
+if exists("b:current_syntax")
+    finish
+endif
+
+syn match gdResourceNumber "\<0x\%(_\=\x\)\+\>"
+syn match gdResourceNumber "\<0b\%(_\=[01]\)\+\>"
+syn match gdResourceNumber "\<\d\%(_\=\d\)*\>"
+syn match gdResourceNumber "\<\d\%(_\=\d\)*\%(e[+-]\=\d\%(_\=\d\)*\)\=\>"
+syn match gdResourceNumber "\<\d\%(_\=\d\)*\.\%(e[+-]\=\d\%(_\=\d\)*\)\=\%(\W\|$\)\@="
+syn match gdResourceNumber "\%(^\|\W\)\@1<=\%(\d\%(_\=\d\)*\)\=\.\d\%(_\=\d\)*\%(e[+-]\=\d\%(_\=\d\)*\)\=\>"
+
+syn keyword gdResourceKeyword true false
+
+syn region gdResourceString
+      \ start=+[uU]\="+ end='"' skip='\\\\\|\\"'
+      \ contains=@Spell keepend
+
+" Section
+syn region gdResourceSection matchgroup=gdResourceSectionDelimiter
+      \ start='^\[' end=']\s*$'
+      \ oneline keepend
+      \ contains=gdResourceSectionName,gdResourceSectionAttribute
+
+syn match gdResourceSectionName '\[\@<=\S\+' contained skipwhite
+syn match gdResourceSectionAttribute '\S\+\s*=\s*\S\+'
+      \ skipwhite keepend contained
+      \ contains=gdResourceSectionAttributeName,gdResourceSectionAttributeValue
+syn match gdResourceSectionAttributeName '\S\+\ze\(\s*=\)' skipwhite contained
+syn match gdResourceSectionAttributeValue '\(=\s*\)\zs\S\+\ze' skipwhite
+      \ contained
+      \ contains=gdResourceString,gdResourceNumber,gdResourceKeyword
+
+
+" Section body
+syn match gdResourceAttribute '^\s*\S\+\s*=.*$'
+      \ skipwhite keepend
+      \ contains=gdResourceAttributeName,gdResourceAttributeValue
+
+syn match gdResourceAttributeName '\S\+\ze\(\s*=\)' skipwhite contained
+syn match gdResourceAttributeValue '\(=\s*\)\zs.*$' skipwhite
+      \ contained
+      \ contains=gdResourceString,gdResourceNumber,gdResourceKeyword
+
+
+hi def link gdResourceNumber Constant
+hi def link gdResourceKeyword Constant
+hi def link gdResourceSectionName Statement
+hi def link gdResourceSectionDelimiter Delimiter
+hi def link gdResourceSectionAttributeName Type
+hi def link gdResourceAttributeName Identifier
+hi def link gdResourceString String
+
+let b:current_syntax = "gdresource"

--- a/runtime/syntax/gdscript.vim
+++ b/runtime/syntax/gdscript.vim
@@ -1,0 +1,98 @@
+" Vim syntax file for Godot gdscript
+" Language:     gdscript
+" Maintainer:   Maxim Kim <habamax@gmail.com>
+" Filenames:    *.gd
+
+if exists("b:current_syntax")
+    finish
+endif
+
+syntax sync maxlines=100
+
+syn keyword gdscriptConditional if else elif match
+syn keyword gdscriptRepeat for while break continue
+
+syn keyword gdscriptOperator is as not and or in
+
+syn match gdscriptClass "\v<\u\w+>"
+syn match gdscriptConstant "\<[_A-Z]\+[0-9_A-Z]*\>"
+syn match gdscriptBlockStart ":\s*$"
+
+syn keyword gdscriptKeyword null self owner parent tool
+syn keyword gdscriptBoolean false true
+
+syn keyword gdscriptStatement remote master puppet remotesync mastersync puppetsync sync
+syn keyword gdscriptStatement return pass
+syn keyword gdscriptStatement static const enum
+syn keyword gdscriptStatement breakpoint assert
+syn keyword gdscriptStatement onready
+syn keyword gdscriptStatement class_name extends
+
+syn keyword gdscriptType void bool int float String contained
+
+syn keyword gdscriptStatement var nextgroup=gdscriptTypeDecl skipwhite
+syn keyword gdscriptStatement const nextgroup=gdscriptTypeDecl skipwhite
+syn match gdscriptTypeDecl "\h\w*\s*:\s*\h\w*" contains=gdscriptOperator,gdscriptType,gdscriptClass contained skipwhite
+syn match gdscriptTypeDecl "->\s*\h\w*" contains=gdscriptOperator,gdscriptType,gdscriptClass skipwhite
+
+syn keyword gdscriptStatement export nextgroup=gdscriptExportTypeDecl skipwhite
+syn match gdscriptExportTypeDecl "(.\{-}[,)]" contains=gdscriptOperator,gdscriptType,gdscriptClass contained skipwhite
+
+syn keyword gdscriptStatement setget nextgroup=gdscriptSetGet,gdscriptSetGetSeparator skipwhite
+syn match gdscriptSetGet "\h\w*" nextgroup=gdscriptSetGetSeparator display contained skipwhite
+syn match gdscriptSetGetSeparator "," nextgroup=gdscriptSetGet display contained skipwhite
+
+syn keyword gdscriptStatement class func signal nextgroup=gdscriptFunctionName skipwhite
+syn match gdscriptFunctionName "\h\w*" nextgroup=gdscriptFunctionParams display contained skipwhite
+syn match gdscriptFunctionParams "(.*)" contains=gdscriptTypeDecl display contained skipwhite
+
+syn match gdscriptNode "\$\h\w*\%(/\h\w*\)*"
+
+syn match gdscriptComment "#.*$" contains=@Spell,gdscriptTodo
+
+syn region gdscriptString matchgroup=gdscriptQuotes
+      \ start=+[uU]\=\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
+      \ contains=gdscriptEscape,@Spell
+
+syn region gdscriptString matchgroup=gdscriptTripleQuotes
+      \ start=+[uU]\=\z('''\|"""\)+ end="\z1" keepend
+      \ contains=gdscriptEscape,@Spell
+
+syn match gdscriptEscape +\\[abfnrtv'"\\]+ contained
+syn match gdscriptEscape "\\$"
+
+" Numbers
+syn match gdscriptNumber "\<0x\%(_\=\x\)\+\>"
+syn match gdscriptNumber "\<0b\%(_\=[01]\)\+\>"
+syn match gdscriptNumber "\<\d\%(_\=\d\)*\>"
+syn match gdscriptNumber "\<\d\%(_\=\d\)*\%(e[+-]\=\d\%(_\=\d\)*\)\=\>"
+syn match gdscriptNumber "\<\d\%(_\=\d\)*\.\%(e[+-]\=\d\%(_\=\d\)*\)\=\%(\W\|$\)\@="
+syn match gdscriptNumber "\%(^\|\W\)\@1<=\%(\d\%(_\=\d\)*\)\=\.\d\%(_\=\d\)*\%(e[+-]\=\d\%(_\=\d\)*\)\=\>"
+
+" XXX, TODO, etc
+syn keyword gdscriptTodo TODO XXX FIXME HACK NOTE BUG contained
+
+hi def link gdscriptStatement Statement
+hi def link gdscriptKeyword Keyword
+hi def link gdscriptConditional Conditional
+hi def link gdscriptBoolean Boolean
+hi def link gdscriptOperator Operator
+hi def link gdscriptRepeat Repeat
+hi def link gdscriptSetGet Function
+hi def link gdscriptFunctionName Function
+hi def link gdscriptClass Type
+hi def link gdscriptConstant Constant
+hi def link gdscriptBuiltinStruct Typedef
+hi def link gdscriptComment Comment
+hi def link gdscriptString String
+hi def link gdscriptQuotes String
+hi def link gdscriptTripleQuotes String
+hi def link gdscriptEscape Special
+hi def link gdscriptNode PreProc
+hi def link gdscriptType Type
+hi def link gdscriptNumber Number
+hi def link gdscriptBlockStart Special
+hi def link gdscriptTodo Todo
+
+
+let b:current_syntax = "gdscript"

--- a/runtime/syntax/gdshader.vim
+++ b/runtime/syntax/gdshader.vim
@@ -1,0 +1,57 @@
+" Vim syntax file for Godot shading language
+" Language:     gdshader
+" Maintainer:   Maxim Kim <habamax@gmail.com>
+" Filenames:    *.gdshader
+
+if exists("b:current_syntax")
+    finish
+endif
+
+syn keyword gdshaderConditional if else switch case default
+syn keyword gdshaderRepeat for while do
+syn keyword gdshaderStatement return discard
+syn keyword gdshaderBoolean true false
+
+syn keyword gdshaderKeyword shader_type render_mode
+syn keyword gdshaderKeyword in out inout
+syn keyword gdshaderKeyword lowp mediump highp
+syn keyword gdshaderKeyword uniform varying const
+syn keyword gdshaderKeyword flat smooth
+
+syn keyword gdshaderType float vec2 vec3 vec4
+syn keyword gdshaderType uint uvec2 uvec3 uvec4
+syn keyword gdshaderType int ivec2 ivec3 ivec4
+syn keyword gdshaderType void bool
+syn keyword gdshaderType bvec2 bvec3 bvec4
+syn keyword gdshaderType mat2 mat3 mat4
+syn keyword gdshaderType sampler2D isampler2D usampler2D samplerCube
+
+syn match gdshaderMember "\v<(\.)@<=[a-z_]+\w*>"
+syn match gdshaderBuiltin "\v<[A-Z_]+[A-Z0-9_]*>"
+syn match gdshaderFunction "\v<\w*>(\()@="
+
+syn match gdshaderNumber "\v<\d+(\.)@!>"
+syn match gdshaderFloat "\v<\d*\.\d+(\.)@!>"
+syn match gdshaderFloat "\v<\d*\.=\d+(e-=\d+)@="
+syn match gdshaderExponent "\v(\d*\.=\d+)@<=e-=\d+>"
+
+syn match gdshaderComment "\v//.*$" contains=@Spell
+syn region gdshaderComment start="/\*" end="\*/" contains=@Spell
+syn keyword gdshaderTodo TODO FIXME XXX NOTE BUG HACK OPTIMIZE containedin=gdshaderComment
+
+hi def link gdshaderConditional Conditional
+hi def link gdshaderRepeat Repeat
+hi def link gdshaderStatement Statement
+hi def link gdshaderBoolean Boolean
+hi def link gdshaderKeyword Keyword
+hi def link gdshaderMember Identifier
+hi def link gdshaderBuiltin Identifier
+hi def link gdshaderFunction Function
+hi def link gdshaderType Type
+hi def link gdshaderNumber Number
+hi def link gdshaderFloat Float
+hi def link gdshaderExponent Special
+hi def link gdshaderComment Comment
+hi def link gdshaderTodo Todo
+
+let b:current_syntax = "gdshader"


### PR DESCRIPTION
Currently vim has detection of gdscript and gdresource files but actual
syntax/indent/ftplugin files are missing.

Additionally, gdshader detection is added to filetype.vim

Files are extracted and simplified from the plugin I maintain: https://github.com/habamax/vim-godot