### PR TITLE
Revert resize behavior if height is greater than the available space

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -5693,11 +5693,7 @@ frame_setheight(frame_T *curfrp, int height)
     {
 	// topframe: can only change the command line height
 	if (height > ROWS_AVAIL)
-	    // If height is greater than the available space, try to create
-	    // space for the frame by reducing 'cmdheight' if possible, while
-	    // making sure `cmdheight` doesn't go below 1.
-	    height = MIN((p_ch > 0 ? ROWS_AVAIL + (p_ch - 1)
-							: ROWS_AVAIL), height);
+            height = ROWS_AVAIL;
 	if (height > 0)
 	    frame_new_height(curfrp, height, FALSE, FALSE);
     }


### PR DESCRIPTION
I have reverted partial changes when I have created `cmdheight=0` PR.
It is from neovim's code, but it changes older resize behavior.

Please see https://github.com/neovim/neovim/pull/17335#discussion_r945295765.