### PR TITLE
Do not check overwrite if writing an acwrite buffer to its b_ffname

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2094,12 +2094,17 @@ check_overwrite(
     /*
      * Write to another file or b_flags set or not writing the whole file:
      * overwriting only allowed with '!'.
+     * If "other" is FALSE and bt_nofilename(buf) is TRUE, this must be
+     * writing an "acwrite" buffer to the same file as its b_ffname, and
+     * buf_write() will only allow writing with BufWriteCmd autocommands,
+     * so there is no need for an overwrite check.
      */
     if (       (other
-		|| (buf->b_flags & BF_NOTEDITED)
-		|| ((buf->b_flags & BF_NEW)
-		    && vim_strchr(p_cpo, CPO_OVERNEW) == NULL)
-		|| (buf->b_flags & BF_READERR))
+		|| (!bt_nofilename(buf)
+		    && ((buf->b_flags & BF_NOTEDITED)
+			|| ((buf->b_flags & BF_NEW)
+			    && vim_strchr(p_cpo, CPO_OVERNEW) == NULL)
+			|| (buf->b_flags & BF_READERR))))
 	    && !p_wa
 	    && vim_fexists(ffname))
     {

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -1922,6 +1922,21 @@ func Test_BufReadCmd()
   au! BufWriteCmd
 endfunc
 
+func Test_BufWriteCmd()
+  autocmd BufWriteCmd Xbufwritecmd let g:written = 1
+  new
+  file Xbufwritecmd
+  set buftype=acwrite
+  call mkdir('Xbufwritecmd')
+  write
+  " BufWriteCmd should be triggered even if a directory has the same name
+  call assert_equal(1, g:written)
+  call delete('Xbufwritecmd', 'd')
+  unlet g:written
+  au! BufWriteCmd
+  bwipe!
+endfunc
+
 func SetChangeMarks(start, end)
   exe a:start .. 'mark ['
   exe a:end .. 'mark ]'


### PR DESCRIPTION
Patch 8.2.0474 only made :write with BufWriteCmd work if BufReadCmd is
used to read the buffer. If BufReadCmd is not used then :write still
doesn't work. In this case, buf_write() will only allow writing using
BufWriteCmd, so there is no need for an overwrite check.
