### PR TITLE
win32: Set cursor style on Windows Terminal

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -1527,13 +1527,27 @@ decode_mouse_event(
     static void
 mch_set_cursor_shape(int thickness)
 {
-    CONSOLE_CURSOR_INFO ConsoleCursorInfo;
-    ConsoleCursorInfo.dwSize = thickness;
-    ConsoleCursorInfo.bVisible = s_cursor_visible;
+    if (USE_VTP || USE_WT)
+    {
+	if (*T_CSI == NUL)
+	{
+	    // If 't_SI' is not set, use the default cursor styles.
+	    if (thickness < 50)
+		vtp_printf("\033[3 q");	// underline
+	    else
+		vtp_printf("\033[0 q");	// default
+	}
+    }
+    else
+    {
+	CONSOLE_CURSOR_INFO ConsoleCursorInfo;
+	ConsoleCursorInfo.dwSize = thickness;
+	ConsoleCursorInfo.bVisible = s_cursor_visible;
 
-    SetConsoleCursorInfo(g_hConOut, &ConsoleCursorInfo);
-    if (s_cursor_visible)
-	SetConsoleCursorPosition(g_hConOut, g_coord);
+	SetConsoleCursorInfo(g_hConOut, &ConsoleCursorInfo);
+	if (s_cursor_visible)
+	    SetConsoleCursorPosition(g_hConOut, g_coord);
+    }
 }
 
     void
@@ -6769,6 +6783,21 @@ notsgr:
 	    }
 # endif
 	}
+	else if (s[0] == ESC && len >= 3-1 && s[1] == '[')
+	{
+	    int l = 2;
+
+	    if (isdigit(s[l]))
+		l++;
+	    if (s[l] == ' ' && s[l + 1] == 'q')
+	    {
+		// DECSCUSR (cursor style) sequences
+		if (USE_VTP || USE_WT)
+		    vtp_printf("%.*s", l + 2, s);   // Pass through
+		s += l + 2;
+		len -= l + 1;
+	    }
+	}
 	else
 	{
 	    // Write a single character
@@ -7945,7 +7974,7 @@ vtp_sgr_bulks(
     if (argc == 0)
     {
 	sgrfgr = sgrbgr = -1;
-	vtp_printf("033[m");
+	vtp_printf("\033[m");
 	return;
     }
 


### PR DESCRIPTION
Close #6576

Win32 version of Vim supports changing cursor shape by
`mch_set_cursor_shape()`. However, this didn't work on Windows Terminal.

This patch supports changing cursor shape on Windows Terminal.
By default, the default shape (that is set by the terminal) will be used
on normal mode, and underline will be used on insert mode.

This also allows to customize the cursor shape by setting 't_SI', 't_EI'
and so on.

Sample setting:
```vim
" Change cursor shape
" Note: This should be set after `set termguicolors` or `set t_Co=256`.
if &term =~ 'xterm' || &term == 'win32'
  " Use DECSCUSR escape sequences
  let &t_SI = "\e[5 q"    " blink bar
  let &t_SR = "\e[3 q"    " blink underline
  let &t_EI = "\e[1 q"    " blink block
  let &t_ti .= "\e[1 q"   " blink block
  let &t_te .= "\e[0 q"   " default (depends on terminal, normally blink block)
endif
```

Win32 version of Vim uses its own terminal codes. However, this passes
through DECSCUSR escape sequences to the terminal. This allows to use
the same settings on Windows and Unix (as shown above).

Note: Win32 version of Vim will reset 't_SI', 't_EI' and other terminal
codes when `set termguicolors` or `set t_Co=256` is used. So, the above
setting should be written after them.