### PR TITLE
Add Lua string and comment delimiter syntax groups

### DIFF
--- a/runtime/syntax/lua.vim
+++ b/runtime/syntax/lua.vim
@@ -1,11 +1,11 @@
 " Vim syntax file
-" Language:	Lua 4.0, Lua 5.0, Lua 5.1 and Lua 5.2
-" Maintainer:	Marcus Aurelius Farias <masserahguard-lua 'at' yahoo com>
-" First Author:	Carlos Augusto Teixeira Mendes <cmendes 'at' inf puc-rio br>
-" Last Change:	2022 Mar 31
-" Options:	lua_version = 4 or 5
-"		lua_subversion = 0 (4.0, 5.0) or 1 (5.1) or 2 (5.2)
-"		default 5.2
+" Language:     Lua 4.0, Lua 5.0, Lua 5.1 and Lua 5.2
+" Maintainer:   Marcus Aurelius Farias <masserahguard-lua 'at' yahoo com>
+" First Author: Carlos Augusto Teixeira Mendes <cmendes 'at' inf puc-rio br>
+" Last Change:  2022 Mar 31
+" Options:      lua_version = 4 or 5
+"               lua_subversion = 0 (4.0, 5.0) or 1 (5.1) or 2 (5.2)
+"               default 5.2
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -333,29 +333,29 @@ endif
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
-hi def link luaStatement		Statement
-hi def link luaRepeat		Repeat
-hi def link luaFor			Repeat
-hi def link luaString		String
-hi def link luaString2		String
-hi def link luaStringDelimiter	luaString
-hi def link luaNumber		Number
-hi def link luaOperator		Operator
-hi def link luaIn			Operator
-hi def link luaConstant		Constant
-hi def link luaCond		Conditional
-hi def link luaElse		Conditional
-hi def link luaFunction		Function
-hi def link luaComment		Comment
-hi def link luaCommentDelimiter	luaComment
-hi def link luaTodo		Todo
-hi def link luaTable		Structure
-hi def link luaError		Error
-hi def link luaParenError		Error
-hi def link luaBraceError		Error
-hi def link luaSpecial		SpecialChar
-hi def link luaFunc		Identifier
-hi def link luaLabel		Label
+hi def link luaStatement        Statement
+hi def link luaRepeat           Repeat
+hi def link luaFor              Repeat
+hi def link luaString           String
+hi def link luaString2          String
+hi def link luaStringDelimiter  luaString
+hi def link luaNumber           Number
+hi def link luaOperator         Operator
+hi def link luaIn               Operator
+hi def link luaConstant         Constant
+hi def link luaCond             Conditional
+hi def link luaElse             Conditional
+hi def link luaFunction         Function
+hi def link luaComment          Comment
+hi def link luaCommentDelimiter luaComment
+hi def link luaTodo             Todo
+hi def link luaTable            Structure
+hi def link luaError            Error
+hi def link luaParenError       Error
+hi def link luaBraceError       Error
+hi def link luaSpecial          SpecialChar
+hi def link luaFunc             Identifier
+hi def link luaLabel            Label
 
 
 let b:current_syntax = "lua"

--- a/runtime/syntax/lua.vim
+++ b/runtime/syntax/lua.vim
@@ -33,11 +33,11 @@ syn sync minlines=100
 syn keyword luaTodo            contained TODO FIXME XXX
 syn match   luaComment         "--.*$" contains=luaTodo,@Spell
 if lua_version == 5 && lua_subversion == 0
-  syn region luaComment        matchgroup=luaComment start="--\[\[" end="\]\]" contains=luaTodo,luaInnerComment,@Spell
+  syn region luaComment        matchgroup=luaCommentDelimiter start="--\[\[" end="\]\]" contains=luaTodo,luaInnerComment,@Spell
   syn region luaInnerComment   contained transparent start="\[\[" end="\]\]"
 elseif lua_version > 5 || (lua_version == 5 && lua_subversion >= 1)
   " Comments in Lua 5.1: --[[ ... ]], [=[ ... ]=], [===[ ... ]===], etc.
-  syn region luaComment        matchgroup=luaComment start="--\[\z(=*\)\[" end="\]\z1\]" contains=luaTodo,@Spell
+  syn region luaComment        matchgroup=luaCommentDelimiter start="--\[\z(=*\)\[" end="\]\z1\]" contains=luaTodo,@Spell
 endif
 
 " First line may start with #!
@@ -99,18 +99,18 @@ if lua_version < 5
 elseif lua_version == 5
   if lua_subversion == 0
     syn match  luaSpecial contained #\\[\\abfnrtv'"[\]]\|\\[[:digit:]]\{,3}#
-    syn region luaString2 matchgroup=luaString start=+\[\[+ end=+\]\]+ contains=luaString2,@Spell
+    syn region luaString2 matchgroup=luaStringDelimiter start=+\[\[+ end=+\]\]+ contains=luaString2,@Spell
   else
     if lua_subversion == 1
       syn match  luaSpecial contained #\\[\\abfnrtv'"]\|\\[[:digit:]]\{,3}#
     else " Lua 5.2
       syn match  luaSpecial contained #\\[\\abfnrtvz'"]\|\\x[[:xdigit:]]\{2}\|\\[[:digit:]]\{,3}#
     endif
-    syn region luaString2 matchgroup=luaString start="\[\z(=*\)\[" end="\]\z1\]" contains=@Spell
+    syn region luaString2 matchgroup=luaStringDelimiter start="\[\z(=*\)\[" end="\]\z1\]" contains=@Spell
   endif
 endif
-syn region luaString  start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=luaSpecial,@Spell
-syn region luaString  start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=luaSpecial,@Spell
+syn region luaString matchgroup=luaStringDelimiter start=+'+ end=+'+ skip=+\\\\\|\\'+ contains=luaSpecial,@Spell
+syn region luaString matchgroup=luaStringDelimiter start=+"+ end=+"+ skip=+\\\\\|\\"+ contains=luaSpecial,@Spell
 
 " integer number
 syn match luaNumber "\<\d\+\>"
@@ -338,6 +338,7 @@ hi def link luaRepeat		Repeat
 hi def link luaFor			Repeat
 hi def link luaString		String
 hi def link luaString2		String
+hi def link luaStringDelimiter	luaString
 hi def link luaNumber		Number
 hi def link luaOperator		Operator
 hi def link luaIn			Operator
@@ -346,6 +347,7 @@ hi def link luaCond		Conditional
 hi def link luaElse		Conditional
 hi def link luaFunction		Function
 hi def link luaComment		Comment
+hi def link luaCommentDelimiter	luaComment
 hi def link luaTodo		Todo
 hi def link luaTable		Structure
 hi def link luaError		Error


### PR DESCRIPTION
It's not currently possible to distinguish between comment and string delimiters and the respective content of these syntax groups.

While some users like to highlight these delimiters differently my current motivation for this change is to more accurately match these delimiters in the Lua ftplugin when defining `match_words` and `]/` comment mappings.

Any objections to this being included @marcuscf?
