### PR TITLE
Allow assigning a Funcref to autoload variable

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -4012,10 +4012,12 @@ var_wrong_func_name(
 {
     // Allow for w: b: s: and t:.  In Vim9 script s: is not allowed, because
     // the name can be used without the s: prefix.
+    // Allow autoload variable.
     if (!((vim_strchr((char_u *)"wbt", name[0]) != NULL
 		    || (!in_vim9script() && name[0] == 's')) && name[1] == ':')
 	    && !ASCII_ISUPPER((name[0] != NUL && name[1] == ':')
-						     ? name[2] : name[0]))
+						     ? name[2] : name[0])
+	    && vim_strchr(name, '#') == NULL)
     {
 	semsg(_(e_funcref_variable_name_must_start_with_capital_str), name);
 	return TRUE;

--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -8,6 +8,10 @@ func Test_let()
   let Test104#numvar = function('tr')
   call assert_equal("function('tr')", string(Test104#numvar))
 
+  let foo#tr = function('tr')
+  call assert_equal("function('tr')", string(foo#tr))
+  unlet foo#tr
+
   let a = 1
   let b = 2
 


### PR DESCRIPTION
In Vim, defining a User function that starts with a lowercase letter is not allowed because it could overwrite a built-in function.
However, defining an autoload function that starts with a lowercase letter is permitted because it does not cause the above problem.

For the same reason, Vim does not allow Funcref to be assigned to a global variable whose name begins with a lowercase letter.
This also applies to the autoload variable; `let foo#tr = function('tr')` is not allowed and must be `let Foo#tr = function('tr')`.
I see no need for this restriction.  `let foo#tr = function('tr')` should be allowed.