### PR TITLE
Removing one listener in the callback results in a memory leak

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -362,6 +362,7 @@ invoke_listeners(buf_T *buf)
     int		save_updating_screen = updating_screen;
     static int	recursive = FALSE;
     listener_T	*next;
+    listener_T	*prev;
 
     if (buf->b_recorded_changes == NULL  // nothing changed
 	    || buf->b_listener == NULL   // no listeners
@@ -406,10 +407,9 @@ invoke_listeners(buf_T *buf)
     }
 
     // If f_listener_remove() was called may have to remove a listener now.
+    prev = NULL;
     for (lnr = buf->b_listener; lnr != NULL; lnr = next)
     {
-	listener_T	*prev = NULL;
-
 	next = lnr->lr_next;
 	if (lnr->lr_id == 0)
 	    remove_listener(buf, lnr, prev);

--- a/src/testdir/test_listener.vim
+++ b/src/testdir/test_listener.vim
@@ -387,6 +387,37 @@ func Test_remove_listener_in_callback()
   unlet g:listener_called
 endfunc
 
+" When multiple listeners are registered, remove one listener and verify the
+" other listener is still called
+func Test_remove_one_listener_in_callback()
+  new
+  let g:listener1_called = 0
+  let g:listener2_called = 0
+  let s:ID1 = listener_add('Listener1')
+  let s:ID2 = listener_add('Listener2')
+  func Listener1(...)
+    call listener_remove(s:ID1)
+    let g:listener1_called += 1
+  endfunc
+  func Listener2(...)
+    let g:listener2_called += 1
+  endfunc
+  call setline(1, ['foo'])
+  call feedkeys("~", 'xt')
+  call listener_flush()
+  call feedkeys("~", 'xt')
+  call listener_flush()
+  call assert_equal(1, g:listener1_called)
+  call assert_equal(2, g:listener2_called)
+
+  call listener_remove(s:ID2)
+  bwipe!
+  delfunc Listener1
+  delfunc Listener2
+  unlet g:listener1_called
+  unlet g:listener2_called
+endfunc
+
 func Test_no_change_for_empty_undo()
   new
   let text = ['some word here', 'second line']


### PR DESCRIPTION
Removing one listener in the callback results in a memory leak and removes the subsequent listeners.
This is a regression introduced by patch 8.2.3426 (4b4b1b84eee70b74fa3bb57624533c65bafd8428).

This issue is found by the clang static analyzer (https://clang-analyzer.llvm.org/).