### PR TITLE
GUI: no escape for sub-replace specials in promptrepl

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -5361,7 +5361,9 @@ gui_do_findrepl(
     {
 	ga_concat(&ga, (char_u *)"/");
 	// escape slash and backslash
-	p = vim_strsave_escaped(repl_text, (char_u *)"/\\");
+	// also escape tilde and ampersand if p_magic is set
+	p = vim_strsave_escaped(repl_text,
+				p_magic ? (char_u *)"/\\~&" : (char_u *)"/\\");
 	if (p != NULL)
 	    ga_concat(&ga, p);
 	vim_free(p);

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1580,6 +1580,12 @@ func Test_gui_findrepl()
   call test_gui_event('findrepl', args)
   call assert_equal(['ONE two ONE', 'Twoo ONE two ONEo'], getline(1, '$'))
 
+  " Replace all instances with sub-replace specials
+  call cursor(1, 1)
+  let args = #{find_text: 'ONE', repl_text: '&~&', flags: 0x4, forward: 1}
+  call test_gui_event('findrepl', args)
+  call assert_equal(['&~& two &~&', 'Twoo &~& two &~&o'], getline(1, '$'))
+
   " Invalid arguments
   call assert_false(test_gui_event('findrepl', {}))
   let args = #{repl_text: 'a', flags: 1, forward: 1}


### PR DESCRIPTION
Closes #11064.