### PR TITLE
Recognize javascript module files (*.jsm)

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -940,7 +940,7 @@ au BufNewFile,BufRead *.java,*.jav		setf java
 au BufNewFile,BufRead *.jj,*.jjt		setf javacc
 
 " JavaScript, ECMAScript, ES module script, CommonJS script
-au BufNewFile,BufRead *.js,*.javascript,*.es,*.mjs,*.cjs   setf javascript
+au BufNewFile,BufRead *.js,*.jsm,*.javascript,*.es,*.mjs,*.cjs   setf javascript
 
 " JavaScript with React
 au BufNewFile,BufRead *.jsx			setf javascriptreact

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -275,7 +275,7 @@ let s:filename_checks = {
     \ 'jam': ['file.jpl', 'file.jpr', 'JAM-file.file', 'JAM.file', 'Prl-file.file', 'Prl.file'],
     \ 'java': ['file.java', 'file.jav'],
     \ 'javacc': ['file.jj', 'file.jjt'],
-    \ 'javascript': ['file.js', 'file.javascript', 'file.es', 'file.mjs', 'file.cjs'],
+    \ 'javascript': ['file.js', 'file.jsm', 'file.javascript', 'file.es', 'file.mjs', 'file.cjs'],
     \ 'javascript.glimmer': ['file.gjs'],
     \ 'javascriptreact': ['file.jsx'],
     \ 'jess': ['file.clp'],


### PR DESCRIPTION
Mozilla projects (and some others) use *.jsm to denote javascript modules. This is currently not detected in vim as javascript.

Related: A popular vim plugin for javascript [added something similar in 2011](https://github.com/pangloss/vim-javascript/pull/37).