### PR TITLE
Fix win_equal()/last_status() order in win_close()

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1617,4 +1617,17 @@ func Test_window_alloc_failure()
   tabonly
 endfunc
 
+func Test_win_equal_last_status()
+  set lines=20
+  set splitbelow
+  set laststatus=0
+
+  split | split | quit
+  call assert_equal(winheight(1), winheight(2))
+
+  set lines&
+  set splitbelow&
+  set laststatus&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -2712,6 +2712,13 @@ win_close(win_T *win, int free_buf)
 	// using the window.
 	check_cursor();
     }
+
+    /*
+     * If last window has a status line now and we don't want one,
+     * remove the status line.
+     */
+    last_status(FALSE);
+
     if (p_ea && (*p_ead == 'b' || *p_ead == dir))
 	// If the frame of the closed window contains the new current window,
 	// only resize that frame.  Otherwise resize all windows.
@@ -2740,12 +2747,6 @@ win_close(win_T *win, int free_buf)
     if (!did_decrement)
 	--dont_parse_messages;
 #endif
-
-    /*
-     * If last window has a status line now and we don't want one,
-     * remove the status line.
-     */
-    last_status(FALSE);
 
     // After closing the help window, try restoring the window layout from
     // before it was opened.


### PR DESCRIPTION
Problem: win_equal being called before last_status can result in windows not having equal height with laststatus=0 and splitbelow set.
Solution: Move last_status() call before win_equal().

Came across this issue while testing 'nosplitscroll'. It is the root cause of a problem I encountered for 'nosplitscroll'. Moving the last_status() call before win_equal() fixes the non-equal height problem and simultaneously fixes the problem I was experiencing in the 'nosplitscroll' patch. Unsure if the win_equal()->last_status() order was intentional and if swapping them around will cause any problems but the test-suite was successful on my [fork](https://github.com/luukvbaal/vim/actions/runs/3004685340).