### PR TITLE
CI: Fix that test_gui may hang

### DIFF
--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1607,12 +1607,13 @@ func Test_gui_CTRL_SHIFT_V()
 endfunc
 
 func Test_gui_dialog_file()
+  call delete('Xdialfile')
   let lines =<< trim END
     file Xdialfile
     normal axxx
     confirm qa
   END
-  call writefile(lines, 'Xlines')
+  call writefile(lines, 'Xlines', 'D')
   let prefix = '!'
   if has('win32')
     let prefix = '!start '
@@ -1624,7 +1625,6 @@ func Test_gui_dialog_file()
 
   call delete('Xdialog')
   call delete('Xdialfile')
-  call delete('Xlines')
 endfunc
 
 " Test for sending low level key presses


### PR DESCRIPTION
test_gui often hangs on CI:
https://github.com/vim/vim/runs/8210640448?check_suite_focus=true
https://github.com/vim/vim/runs/8211225394?check_suite_focus=true

It seems that this hangs in Test_gui_dialog_file() when Xdialfile exists. If Xdialfile exists, the following two messages are shown:

```
Question: Save changes to "Xdialfile"?
Question: Overwrite existing file "Xdialfile"?
```

The default answer for the second message is "No", so gvim won't be closed and the test will stop.

Not sure why Xdialfile can be left behind on the CI, but deleting this seems to solve the issue.

Also use the 'D' flag for writefile().