### PR TITLE
win32: Fix test_gui_w32_sendevent()

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -8649,6 +8649,7 @@ test_gui_w32_sendevent(dict_T *args)
 	inputs[0].ki.wVk = vkCode;
 	if (STRICMP(event, "keyup") == 0)
 	    inputs[0].ki.dwFlags = KEYEVENTF_KEYUP;
+	(void)SetForegroundWindow(s_hwnd);
 	SendInput(ARRAYSIZE(inputs), inputs, sizeof(INPUT));
     }
     else


### PR DESCRIPTION
`test_gui_event("sendevent", ...)` didn't work as expected when gvim didn't have the focus. Make sure that events will be sent to gvim's window.

It seems that 9.0.0400 was not enough to fix the hang-up issue of test_gui.