### PR TITLE
Fix memory leak found by ASan

### DIFF
--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -459,6 +459,7 @@ cmdsrv_main(
 			break;
 # endif
 		    j = atoi((char *)p);
+		    vim_free(p);
 		    if (j >= 0 && j < numFiles)
 		    {
 # ifdef FEAT_GUI_MSWIN


### PR DESCRIPTION
https://github.com/vim/vim/runs/8237024588?check_suite_focus=true
```
Direct leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x55db6c1e9abe in __interceptor_malloc ??:?
    #1 0x55db6c224077 in lalloc /home/runner/work/vim/vim/src/alloc.c:246:11
    #2 0x55db6cb41a77 in vim_strsave /home/runner/work/vim/vim/src/strings.c:27:9
    #3 0x55db6c6446a6 in serverReadReply /home/runner/work/vim/vim/src/if_xcmdsrv.c:797:9
    #4 0x55db6c2d7e14 in cmdsrv_main /home/runner/work/vim/vim/src/clientserver.c:458:11
    #5 0x55db6c2d7e14 in exec_on_server /home/runner/work/vim/vim/src/clientserver.c:204:6
    #6 0x55db6d04be1e in main /home/runner/work/vim/vim/src/main.c:199:5
    #1 0x7fd13881b082 in __libc_start_main ??:?
```