### PR TITLE
CI: Work around flaky tests

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -763,6 +763,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost()
 
   call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --not-a-term --noplugins -S Session.vim -c cq')
+  sleep 50m
   let errors = join(readfile('Xerrors'))
   call assert_match('E814:', errors)
 

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -375,6 +375,7 @@ endfunc
 func Test_buffer_scheme()
   CheckMSWindows
 
+  set noswapfile
   set noshellslash
   %bwipe!
   let bufnames = [
@@ -397,6 +398,7 @@ func Test_buffer_scheme()
   endfor
 
   set shellslash&
+  set swapfile&
 endfunc
 
 " this was using a NULL pointer after failing to use the pattern

--- a/src/testdir/test_bufline.vim
+++ b/src/testdir/test_bufline.vim
@@ -83,6 +83,7 @@ func Test_setline_startup()
   endif
   call writefile(['call setline(1, "Hello")', 'silent w Xtest', 'q!'], 'Xscript', 'D')
   call system(cmd)
+  sleep 50m
   call assert_equal(['Hello'], readfile('Xtest'))
 
   call delete('Xtest')

--- a/src/testdir/test_profile.vim
+++ b/src/testdir/test_profile.vim
@@ -53,6 +53,7 @@ func RunProfileFunc(command, declare, assign)
     \ . ' -c "qall!"')
   call assert_equal(0, v:shell_error)
 
+  sleep 50m
   let lines = readfile('Xprofile_func.log')
 
   " - Foo1() is called 3 times but should be reported as called twice

--- a/src/testdir/test_shell.vim
+++ b/src/testdir/test_shell.vim
@@ -5,6 +5,11 @@ source check.vim
 source shared.vim
 
 func Test_shell_options()
+  if has('win32')
+    " FIXME: This test is flaky on MS-Windows.
+    let g:test_is_flaky = 1
+  endif
+
   " The expected value of 'shellcmdflag', 'shellpipe', 'shellquote',
   " 'shellredir', 'shellxescape', 'shellxquote' for the supported shells.
   let shells = []

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -335,6 +335,11 @@ func Test_insert_expr()
 endfunc
 
 func Test_undofile_earlier()
+  if has('win32')
+    " FIXME: This test is flaky on MS-Windows.
+    let g:test_is_flaky = 1
+  endif
+
   " Issue #1254
   " create undofile with timestamps older than Vim startup time.
   let t0 = localtime() - 43200

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -722,6 +722,7 @@ func Test_viminfo_file_mark_unloaded_buf()
 endfunc
 
 func Test_viminfo_oldfiles()
+  set noswapfile
   let v:oldfiles = []
   let lines = [
 	\ '# comment line',
@@ -765,6 +766,7 @@ func Test_viminfo_oldfiles()
   call assert_equal("/tmp/another.txt", expand("%"))
   bwipe
   delmark E
+  set swapfile&
 endfunc
 
 " Test for storing and restoring buffer list in 'viminfo'


### PR DESCRIPTION
Some tests are flaky on MS-Windows. Work around them.

* `Test_autocmd_bufwipe_in_SessLoadPost()`, `Test_setline_startup()`, `Test_profile_func()`
  Sometimes E484 occurs. Add a short sleep before reading the files.

* `Test_shell_options()`, `Test_undofile_earlier()`
  Not sure why they are flaky. Need to be analyzed.
  Set g:test_is_flaky to 1 for now.

* `Test_viminfo_oldfiles()`, `Test_buffer_scheme()`
  Sometimes fail because of unexpected swapfile. (Not sure why.)
  These test don't rely on swapfile. So, disabled.