### PR TITLE
win32: Drop support for XP and Vista

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ All commands are given with normal keyboard characters, so those who can type
 with ten fingers can work very fast.  Additionally, function keys can be
 mapped to commands by the user, and the mouse can be used.
 
-Vim runs under MS-Windows (XP, Vista, 7, 8, 10), macOS, Haiku, VMS and almost
-all flavours of UNIX.  Porting to other systems should not be very difficult.
-Older versions of Vim run on MS-DOS, MS-Windows 95/98/Me/NT/2000, Amiga DOS,
-Atari MiNT, BeOS, RISC OS and OS/2.  These are no longer maintained.
+Vim runs under MS-Windows (7, 8, 10, 11), macOS, Haiku, VMS and almost all
+flavours of UNIX.  Porting to other systems should not be very difficult.
+Older versions of Vim run on MS-DOS, MS-Windows 95/98/Me/NT/2000/XP/Vista,
+Amiga DOS, Atari MiNT, BeOS, RISC OS and OS/2.  These are no longer maintained.
 
 For Vim9 script see [README_VIM9](README_VIM9.md).
 

--- a/README.txt
+++ b/README.txt
@@ -16,10 +16,10 @@ All commands are given with normal keyboard characters, so those who can type
 with ten fingers can work very fast.  Additionally, function keys can be
 mapped to commands by the user, and the mouse can be used.
 
-Vim runs under MS-Windows (XP, Vista, 7, 8, 10), macOS, VMS and almost all
+Vim runs under MS-Windows (7, 8, 10, 11), macOS, Haiku, VMS and almost all
 flavours of UNIX.  Porting to other systems should not be very difficult.
-Older versions of Vim run on MS-DOS, MS-Windows 95/98/Me/NT/2000, Amiga DOS,
-Atari MiNT, BeOS, RISC OS and OS/2.  These are no longer maintained.
+Older versions of Vim run on MS-DOS, MS-Windows 95/98/Me/NT/2000/XP/Vista,
+Amiga DOS, Atari MiNT, BeOS, RISC OS and OS/2.  These are no longer maintained.
 
 
 DISTRIBUTION

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -106,8 +106,7 @@ when you have got a new version):
 You can also install Vim in the "Send To" menu:
 1. Start a Windows Explorer
 2. Navigate to your sendto directory:
-   Windows XP: C:\Documents and Settings\%user%\SendTo
-   Windows Vista: C:\Users\%user%\AppData\Roaming\Microsoft\Windows\SendTo .
+   C:\Users\%user%\AppData\Roaming\Microsoft\Windows\SendTo .
 3. Right-click in the file pane and select New->Shortcut
 4. Follow the shortcut wizard, using the full path to VIM/GVIM.
 

--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -7,8 +7,8 @@
 						*win32* *Win32* *MS-Windows*
 This file documents the idiosyncrasies of the Win32 version of Vim.
 
-The Win32 version of Vim works on Windows XP, Vista, 7, 8, 10 and 11.  There are
-both console and GUI versions.
+The Win32 version of Vim works on Windows 7, 8, 10 and 11.  There are both
+console and GUI versions.
 
 The 32 bit version also runs on 64 bit MS-Windows systems.
 

--- a/src/INSTALLpc.txt
+++ b/src/INSTALLpc.txt
@@ -12,7 +12,7 @@ this, then you will get the default behavior as is documented, which should
 be fine for most people.
 
 This document assumes that you are building Vim for Win32 or later (Windows
-XP/2003/Vista/7/8/10).  There are also instructions for pre-XP systems, but
+7/8/10/11).  There are also instructions for pre-Vista and pre-XP systems, but
 they might no longer work.
 
 The recommended way is to build a 32 bit Vim, also on 64 bit systems.  You can
@@ -42,9 +42,9 @@ Contents:
 
 
 The currently recommended way (that means it has been verified to work) is
-using the "Visual Studio Community 2015" installation.  This includes the SDK
-needed to target Windows XP.  But not older Windows versions (95, 98), see
-"OLDER VERSIONS" below for that.
+using the "Visual Studio Community 2015" installation.  This doesn't include
+the SDK for older Windows versions (95, 98), see "OLDER VERSIONS" below for
+that.
 
 
 1. Microsoft Visual C++
@@ -57,16 +57,17 @@ execute the installer from it.
 
 When installing "Visual Studio Community 2015 with Update 3" or "Visual C++
 Build Tools for Visual Studio 2015 with Update 3" make sure to
-select "custom" and check "Windows XP Support for C++" and all checkboxes
-under "Universal Windows App Development Tools".  Or whatever they are called
-now.
+select "custom" and check all checkboxes under "Universal Windows App
+Development Tools".  Or whatever they are called now.
+(If you still want to target Windows XP, check also "Windows XP Support for
+C++".  Note that this is no longer supported.)
 
 
 Visual Studio
 -------------
 
-Building with Visual Studio (VS2010, VS2012, VS2013, VS2015, VS2017 and VS2019)
-is straightforward.
+Building with Visual Studio (VS2010, VS2012, VS2013, VS2015, VS2017, VS2019
+and VS2022) is straightforward.
 
 To build Vim from the command line with MSVC, use Make_mvc.mak.
 Visual Studio installed a batch file called vcvars32.bat, which you must
@@ -103,6 +104,9 @@ Vim with Make_mvc.mak.
 
 Targeting Windows XP with MSVC 2012 and later      *new-msvc-windows-xp*
 ---------------------------------------------
+
+(The support for pre-Vista was removed in patch 9.0.0xxx.  If you want to
+target Windows XP, use the source code before that.)
 
 Beginning with Visual C++ 2012, Microsoft changed the behavior of LINK.EXE
 so that it targets Windows 6.0 (Vista) by default.  In order to override
@@ -141,9 +145,6 @@ compiler by using the "x64" option:
 The following Visual C++ team blog can serve as a reference page:
     http://blogs.msdn.com/b/vcblog/archive/2012/10/08/windows-xp-targeting-with-c-in-visual-studio-2012.aspx
 
-VC 2019 dropped support for targeting Windows XP.  If you want a binary that
-targeting Windows XP, use VC 2017 or earlier.
-
 
 Cross compile support for Windows on ARM64
 ------------------------------------------
@@ -156,7 +157,7 @@ The ARM64 support was provided by Leendert van Doorn.
 
 OLDER VERSIONS
 
-The minimal supported version is Windows XP. Building with older compilers
+The minimal supported version is Windows 7. Building with older compilers
 might still work, but these instructions might be outdated.
 
 If you need the executable to run on Windows 98 or ME, use the 2005 one
@@ -774,12 +775,12 @@ config.h and Ruby's DLL name. Here are the steps for working around them:
       nmake -f Make_mvc.mak
           RUBY=C:\Ruby24 DYNAMIC_RUBY=yes RUBY_VER=24 RUBY_API_VER_LONG=2.4.0
           RUBY_MSVCRT_NAME=msvcrt
-          WINVER=0x501
+          WINVER=0x601
 
     For 64-bit version, replace RUBY=C:\Ruby24 with RUBY=C:\Ruby24-x64.
 
     If you set WINVER explicitly, it must be set to >=0x500, when building
-    with Ruby 2.1 or later.  (Default is 0x501.)
+    with Ruby 2.1 or later.  (Default is 0x601.)
     When using this trick, you also need to set RUBY_MSVCRT_NAME to msvcrt
     which is used for the Ruby's DLL name.
 
@@ -790,11 +791,11 @@ After you install RubyInstaller, just type this (as one line):
 
     mingw32-make -f Make_ming.mak
         RUBY=C:/Ruby24 DYNAMIC_RUBY=yes RUBY_VER=24 RUBY_API_VER_LONG=2.4.0
-        WINVER=0x600
+        WINVER=0x601
 
 For 64-bit version, replace RUBY=C:/Ruby24 with RUBY=C:/Ruby24-x64.
 If you set WINVER explicitly, it must be set to >=0x500, when building with
-Ruby 2.1 or later.  (Default is 0x600.)
+Ruby 2.1 or later.  (Default is 0x601.)
 
 
 

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -87,10 +87,9 @@ POSTSCRIPT=no
 # Set to yes to enable OLE support.
 OLE=no
 
-# Set the default $(WINVER).  Use 0x0501 to make it work with WinXP.
+# Set the default $(WINVER).  Use 0x0601 to make it work with Windows 7.
 ifndef WINVER
-# WINVER = 0x0501
-WINVER = 0x0600
+WINVER = 0x0601
 endif
 
 # Set to yes to enable Cscope support.

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1320,7 +1320,7 @@ ifeq (16, $(RUBY))
 endif
 
 $(OUTDIR)/iscygpty.o:	iscygpty.c $(CUI_INCL)
-	$(CC) -c $(CFLAGS) iscygpty.c -o $(OUTDIR)/iscygpty.o -U_WIN32_WINNT -D_WIN32_WINNT=0x0600 -DUSE_DYNFILEID -DENABLE_STUB_IMPL
+	$(CC) -c $(CFLAGS) iscygpty.c -o $@
 
 $(OUTDIR)/main.o:	main.c $(INCL) $(CUI_INCL)
 	$(CC) -c $(CFLAGS) main.c -o $@

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1684,7 +1684,7 @@ $(OUTDIR)/if_tcl.obj: $(OUTDIR) if_tcl.c  $(INCL)
 	$(CC) $(CFLAGS_OUTDIR) $(TCL_INC) if_tcl.c
 
 $(OUTDIR)/iscygpty.obj:	$(OUTDIR) iscygpty.c $(CUI_INCL)
-	$(CC) $(CFLAGS_OUTDIR) iscygpty.c -D_WIN32_WINNT=0x0600 -DUSE_DYNFILEID -DENABLE_STUB_IMPL
+	$(CC) $(CFLAGS_OUTDIR) iscygpty.c
 
 $(OUTDIR)/job.obj:	$(OUTDIR) job.c $(INCL)
 

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1,7 +1,7 @@
-# Makefile for Vim on Win32 (Windows XP/2003/Vista/7/8/10) and Win64,
-# using the Microsoft Visual C++ compilers. Known to work with VC10 (VS2010),
-# VC11 (VS2012), VC12 (VS2013), VC14 (VS2015), VC14.1 (VS2017) and
-# VC14.2 (VS2019).
+# Makefile for Vim on Win32 (Windows 7/8/10/11) and Win64, using the Microsoft
+# Visual C++ compilers. Known to work with VC10 (VS2010), VC11 (VS2012), VC12
+# (VS2013), VC14 (VS2015), VC14.1 (VS2017), VC14.2 (VS2019) and VC14.3
+# (VS2022).
 #
 # To build using other Windows compilers, see INSTALLpc.txt
 #
@@ -128,13 +128,13 @@
 #
 #	Optimization: OPTIMIZE=[SPACE, SPEED, MAXSPEED] (default is MAXSPEED)
 #
-#	Processor Version: CPUNR=[any, i586, i686, sse, sse2, avx, avx2] (default is
-#	any)
+#	Processor Version: CPUNR=[any, i686, sse, sse2, avx, avx2] (default is
+#	sse2)
 #	  avx is available on Visual C++ 2010 and after.
 #	  avx2 is available on Visual C++ 2013 Update 2 and after.
 #
-#	Version Support: WINVER=[0x0501, 0x0502, 0x0600, 0x0601, 0x0602,
-#	0x0603, 0x0A00] (default is 0x0501)
+#	Version Support: WINVER=[0x0601, 0x0602, 0x0603, 0x0A00] (default is
+#	0x0601)
 #	Supported versions depends on your target SDK, check SDKDDKVer.h
 #	See https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt
 #
@@ -303,9 +303,9 @@ MSVCRT_NAME = msvcr$(MSVCRT_VER)
 MSVCRT_NAME = vcruntime$(MSVCRT_VER)
 !endif
 
-### Set the default $(WINVER) to make it work with VC++7.0 (VS.NET)
+### Set the default $(WINVER) to make it work with Windows 7
 !ifndef WINVER
-WINVER = 0x0501
+WINVER = 0x0601
 !endif
 
 # Use multiprocess build
@@ -523,27 +523,27 @@ OUTDIR=$(OBJDIR)
 
 ### Validate CPUNR
 !ifndef CPUNR
-# default to untargeted code
-CPUNR = any
-!elseif "$(CPUNR)" == "i386" || "$(CPUNR)" == "i486"
-# alias i386 and i486 to i586
+# default to SSE2
+CPUNR = sse2
+!elseif "$(CPUNR)" == "i386" || "$(CPUNR)" == "i486" || "$(CPUNR)" == "i586"
+# alias i386, i486 and i586 to i686
 ! message *** WARNING CPUNR=$(CPUNR) is not a valid target architecture.
-! message Windows XP is the minimum target OS, with a minimum target
-! message architecture of i586.
-! message Retargeting to i586
-CPUNR = i586
+! message Windows 7 is the minimum target OS, with a minimum target
+! message architecture of i686.
+! message Retargeting to i686
+CPUNR = i686
 !elseif "$(CPUNR)" == "pentium4"
 # alias pentium4 to sse2
 ! message *** WARNING CPUNR=pentium4 is deprecated in favour of sse2.
 ! message Retargeting to sse2.
 CPUNR = sse2
-!elseif "$(CPUNR)" != "any" && "$(CPUNR)" != "i586" && "$(CPUNR)" != "i686" && "$(CPUNR)" != "sse" && "$(CPUNR)" != "sse2" && "$(CPUNR)" != "avx" && "$(CPUNR)" != "avx2"
+!elseif "$(CPUNR)" != "any" && "$(CPUNR)" != "i686" && "$(CPUNR)" != "sse" && "$(CPUNR)" != "sse2" && "$(CPUNR)" != "avx" && "$(CPUNR)" != "avx2"
 ! error *** ERROR Unknown target architecture "$(CPUNR)". Make aborted.
 !endif
 
 # Convert processor ID to MVC-compatible number
 # IA32/SSE/SSE2 are only supported on x86
-!if "$(ASSEMBLY_ARCHITECTURE)" == "i386" && ("$(CPUNR)" == "i586" || "$(CPUNR)" == "i686" || "$(CPUNR)" == "any")
+!if "$(ASSEMBLY_ARCHITECTURE)" == "i386" && ("$(CPUNR)" == "i686" || "$(CPUNR)" == "any")
 # VC<11 generates fp87 code by default
 ! if $(MSVC_MAJOR) < 11
 CPUARG =

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -1744,13 +1744,6 @@ mch_print_set_fg(long_u fgcol)
 #  include <shlobj.h>
 # endif
 
-typedef BOOL (WINAPI *pfnGetFinalPathNameByHandleW)(
-	HANDLE	hFile,
-	LPWSTR	lpszFilePath,
-	DWORD	cchFilePath,
-	DWORD	dwFlags);
-static pfnGetFinalPathNameByHandleW pGetFinalPathNameByHandleW = NULL;
-
 # define is_path_sep(c)	    ((c) == L'\\' || (c) == L'/')
 
     static int
@@ -1792,20 +1785,6 @@ resolve_reparse_point(char_u *fname)
     WCHAR	    *p, *wp;
     char_u	    *rfname = NULL;
     WCHAR	    *buff = NULL;
-    static BOOL	    loaded = FALSE;
-
-    if (pGetFinalPathNameByHandleW == NULL)
-    {
-	HMODULE hmod = GetModuleHandle("kernel32.dll");
-
-	if (loaded == TRUE)
-	    return NULL;
-	pGetFinalPathNameByHandleW = (pfnGetFinalPathNameByHandleW)
-		GetProcAddress(hmod, "GetFinalPathNameByHandleW");
-	loaded = TRUE;
-	if (pGetFinalPathNameByHandleW == NULL)
-	    return NULL;
-    }
 
     p = enc_to_utf16(fname, NULL);
     if (p == NULL)
@@ -1824,13 +1803,13 @@ resolve_reparse_point(char_u *fname)
     if (h == INVALID_HANDLE_VALUE)
 	goto fail;
 
-    size = pGetFinalPathNameByHandleW(h, NULL, 0, 0);
+    size = GetFinalPathNameByHandleW(h, NULL, 0, 0);
     if (size == 0)
 	goto fail;
     buff = ALLOC_MULT(WCHAR, size);
     if (buff == NULL)
 	goto fail;
-    if (pGetFinalPathNameByHandleW(h, buff, size, 0) == 0)
+    if (GetFinalPathNameByHandleW(h, buff, size, 0) == 0)
 	goto fail;
 
     if (wcsncmp(buff, L"\\\\?\\UNC\\", 8) == 0)

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -243,27 +243,6 @@ static char_u *exe_path = NULL;
 
 static BOOL win8_or_later = FALSE;
 
-#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
-// Dynamic loading for portability
-typedef struct _DYN_CONSOLE_SCREEN_BUFFER_INFOEX
-{
-    ULONG cbSize;
-    COORD dwSize;
-    COORD dwCursorPosition;
-    WORD wAttributes;
-    SMALL_RECT srWindow;
-    COORD dwMaximumWindowSize;
-    WORD wPopupAttributes;
-    BOOL bFullscreenSupported;
-    COLORREF ColorTable[16];
-} DYN_CONSOLE_SCREEN_BUFFER_INFOEX, *PDYN_CONSOLE_SCREEN_BUFFER_INFOEX;
-typedef BOOL (WINAPI *PfnGetConsoleScreenBufferInfoEx)(HANDLE, PDYN_CONSOLE_SCREEN_BUFFER_INFOEX);
-static PfnGetConsoleScreenBufferInfoEx pGetConsoleScreenBufferInfoEx;
-typedef BOOL (WINAPI *PfnSetConsoleScreenBufferInfoEx)(HANDLE, PDYN_CONSOLE_SCREEN_BUFFER_INFOEX);
-static PfnSetConsoleScreenBufferInfoEx pSetConsoleScreenBufferInfoEx;
-static BOOL has_csbiex = FALSE;
-#endif
-
 /*
  * Get version number including build number
  */
@@ -7878,30 +7857,13 @@ vtp_flag_init(void)
     static void
 vtp_init(void)
 {
-    HMODULE hKerneldll;
-    DYN_CONSOLE_SCREEN_BUFFER_INFOEX csbi;
+    CONSOLE_SCREEN_BUFFER_INFOEX csbi;
 # ifdef FEAT_TERMGUICOLORS
     COLORREF fg;
 # endif
 
-    // Use functions supported from Vista
-    hKerneldll = GetModuleHandle("kernel32.dll");
-    if (hKerneldll != NULL)
-    {
-	pGetConsoleScreenBufferInfoEx =
-		(PfnGetConsoleScreenBufferInfoEx)GetProcAddress(
-		hKerneldll, "GetConsoleScreenBufferInfoEx");
-	pSetConsoleScreenBufferInfoEx =
-		(PfnSetConsoleScreenBufferInfoEx)GetProcAddress(
-		hKerneldll, "SetConsoleScreenBufferInfoEx");
-	if (pGetConsoleScreenBufferInfoEx != NULL
-		&& pSetConsoleScreenBufferInfoEx != NULL)
-	    has_csbiex = TRUE;
-    }
-
     csbi.cbSize = sizeof(csbi);
-    if (has_csbiex)
-	pGetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
+    GetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
     save_console_bg_rgb = (guicolor_T)csbi.ColorTable[g_color_index_bg];
     save_console_fg_rgb = (guicolor_T)csbi.ColorTable[g_color_index_fg];
     store_console_bg_rgb = save_console_bg_rgb;
@@ -8130,7 +8092,7 @@ ctermtoxterm(
 set_console_color_rgb(void)
 {
 # ifdef FEAT_TERMGUICOLORS
-    DYN_CONSOLE_SCREEN_BUFFER_INFOEX csbi;
+    CONSOLE_SCREEN_BUFFER_INFOEX csbi;
     guicolor_T	fg, bg;
     int		ctermfg, ctermbg;
 
@@ -8150,8 +8112,7 @@ set_console_color_rgb(void)
     bg = (GetRValue(bg) << 16) | (GetGValue(bg) << 8) | GetBValue(bg);
 
     csbi.cbSize = sizeof(csbi);
-    if (has_csbiex)
-	pGetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
+    GetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
 
     csbi.cbSize = sizeof(csbi);
     csbi.srWindow.Right += 1;
@@ -8160,8 +8121,7 @@ set_console_color_rgb(void)
     store_console_fg_rgb = csbi.ColorTable[g_color_index_fg];
     csbi.ColorTable[g_color_index_bg] = (COLORREF)bg;
     csbi.ColorTable[g_color_index_fg] = (COLORREF)fg;
-    if (has_csbiex)
-	pSetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
+    SetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
 # endif
 }
 
@@ -8227,22 +8187,20 @@ get_default_console_color(
 reset_console_color_rgb(void)
 {
 # ifdef FEAT_TERMGUICOLORS
-    DYN_CONSOLE_SCREEN_BUFFER_INFOEX csbi;
+    CONSOLE_SCREEN_BUFFER_INFOEX csbi;
 
     if (USE_WT)
 	return;
 
     csbi.cbSize = sizeof(csbi);
-    if (has_csbiex)
-	pGetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
+    GetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
 
     csbi.cbSize = sizeof(csbi);
     csbi.srWindow.Right += 1;
     csbi.srWindow.Bottom += 1;
     csbi.ColorTable[g_color_index_bg] = (COLORREF)store_console_bg_rgb;
     csbi.ColorTable[g_color_index_fg] = (COLORREF)store_console_fg_rgb;
-    if (has_csbiex)
-	pSetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
+    SetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
 # endif
 }
 
@@ -8253,19 +8211,17 @@ reset_console_color_rgb(void)
 restore_console_color_rgb(void)
 {
 # ifdef FEAT_TERMGUICOLORS
-    DYN_CONSOLE_SCREEN_BUFFER_INFOEX csbi;
+    CONSOLE_SCREEN_BUFFER_INFOEX csbi;
 
     csbi.cbSize = sizeof(csbi);
-    if (has_csbiex)
-	pGetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
+    GetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
 
     csbi.cbSize = sizeof(csbi);
     csbi.srWindow.Right += 1;
     csbi.srWindow.Bottom += 1;
     csbi.ColorTable[g_color_index_bg] = (COLORREF)save_console_bg_rgb;
     csbi.ColorTable[g_color_index_fg] = (COLORREF)save_console_fg_rgb;
-    if (has_csbiex)
-	pSetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
+    SetConsoleScreenBufferInfoEx(g_hConOut, &csbi);
 # endif
 }
 


### PR DESCRIPTION
I tried this in #6091, but it was rejected.
Two years past and Vim 9 has been released. It should be a good timing to drop support for 20-year old OS.