### PR TITLE
CI: Fix that test_autocmd is still flaky

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -763,7 +763,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost()
 
   call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --not-a-term --noplugins -S Session.vim -c cq')
-  sleep 50m
+  sleep 100m
   let errors = join(readfile('Xerrors'))
   call assert_match('E814:', errors)
 
@@ -787,6 +787,7 @@ func Test_autocmd_blast_badd()
 
   call writefile(content, 'XblastBall', 'D')
   call system(GetVimCommand() .. ' --clean -S XblastBall')
+  sleep 100m
   call assert_match('OK', readfile('Xerrors')->join())
 
   call delete('Xerrors')
@@ -823,6 +824,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost2()
 
   call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --not-a-term --noplugins -S Session.vim -c cq')
+  sleep 100m
   let errors = join(readfile('Xerrors'))
   " This probably only ever matches on unix.
   call assert_notmatch('Caught deadly signal SEGV', errors)


### PR DESCRIPTION
It seems that test_autocmd is still flaky on Windows.
Add some more sleeps.