### PR TITLE
Add blueprint filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2579,6 +2579,8 @@ au BufNewFile,BufRead *.txt
 	\|   setf text
 	\| endif
 
+" Blueprint markup files
+au BufNewFile,BufRead *.blp		setf blueprint
 
 " Use the filetype detect plugins.  They may overrule any of the previously
 " detected filetypes.

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -88,6 +88,7 @@ let s:filename_checks = {
     \ 'bindzone': ['named.root', '/bind/db.file', '/named/db.file', 'any/bind/db.file', 'any/named/db.file'],
     \ 'bitbake': ['file.bb', 'file.bbappend', 'file.bbclass', 'build/conf/local.conf', 'meta/conf/layer.conf', 'build/conf/bbappend.conf', 'meta-layer/conf/distro/foo.conf'],
     \ 'blank': ['file.bl'],
+    \ 'blueprint': ['file.blp'],
     \ 'bsdl': ['file.bsd', 'file.bsdl'],
     \ 'bst': ['file.bst'],
     \ 'bzl': ['file.bazel', 'file.bzl', 'WORKSPACE'],


### PR DESCRIPTION
[Blueprint](https://gitlab.gnome.org/jwestman/blueprint-compiler/) is a markup language for GTK user interfaces