### PR TITLE
Fix 'nosplitscroll' poblems

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -375,7 +375,6 @@ main
      * Set the default values for the options that use Rows and Columns.
      */
     ui_get_shellsize();		// inits Rows and Columns
-    win_init_size();
 #ifdef FEAT_DIFF
     // Set the 'diff' option now, so that it can be checked for in a .vimrc
     // file.  There is no buffer yet though.
@@ -542,6 +541,7 @@ vim_main2(void)
 	    mch_exit(1);
     }
 #endif
+    win_init_size();
 
 #ifdef FEAT_VIMINFO
     /*

--- a/src/menu.c
+++ b/src/menu.c
@@ -436,6 +436,7 @@ ex_menu(
 		--curwin->w_height;
 	    curwin->w_winbar_height = h;
 	}
+	curwin->w_prev_height = curwin->w_height;
     }
 
 theend:

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1646,6 +1646,7 @@ func Test_splitscroll_with_splits()
           for so in [0, 5]
             for ls in range(0, 2)
               for pos in ["H", "M", "L"]
+              tabnew | tabonly!
               let tabline = (gui ? 0 : (tab ? 1 : 0))
               let winbar_sb = (sb ? winbar : 0)
               execute 'set scrolloff=' . so
@@ -1655,17 +1656,15 @@ func Test_splitscroll_with_splits()
               execute tab ? 'tabnew' : ''
               execute winbar ? 'nnoremenu 1.10 WinBar.Test :echo' : ''
               call setline(1, range(1, 256))
-              execute 'norm gg' . pos
-              " No scroll for vertical split and quit
-              vsplit | quit
-              call assert_equal(1, line("w0"))
-
-              " No scroll for horizontal split
+              execute 'norm gg' . pos | redraw!
+              " No scroll for firstwin horizontal split
               split | redraw! | wincmd k
               call assert_equal(1, line("w0"))
+              wincmd j
+              call assert_equal(win_screenpos(0)[0] - tabline - winbar_sb, line("w0"))
 
               " No scroll when resizing windows
-              resize +2
+              wincmd k | resize +2
               call assert_equal(1, line("w0"))
               wincmd j
               call assert_equal(win_screenpos(0)[0] - tabline - winbar_sb, line("w0"))
@@ -1715,7 +1714,7 @@ func Test_splitscroll_with_splits()
               call assert_equal(1, line("w0"))
 
               " No scroll in windows split and quit multiple times
-              quit | split | split | quit
+              quit | redraw! | split | split | quit
               call assert_equal(win_screenpos(0)[0] - tabline - winbar_sb, line("w0"))
 
               " No scroll for new buffer
@@ -1740,11 +1739,9 @@ func Test_splitscroll_with_splits()
               call assert_equal(6, line("w0"))
               wincmd j
               call assert_equal(5 + win_screenpos(0)[0] - tabline - winbar_sb, line("w0"))
-              only
               endfor
             endfor
           endfor
-          tabonly!
         endfor
       endfor
     endfor

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1646,7 +1646,7 @@ func Test_splitscroll_with_splits()
           for so in [0, 5]
             for ls in range(0, 2)
               for pos in ["H", "M", "L"]
-              tabnew | tabonly!
+              tabnew | tabonly! | redraw
               let tabline = (gui ? 0 : (tab ? 1 : 0))
               let winbar_sb = (sb ? winbar : 0)
               execute 'set scrolloff=' . so
@@ -1656,9 +1656,17 @@ func Test_splitscroll_with_splits()
               execute tab ? 'tabnew' : ''
               execute winbar ? 'nnoremenu 1.10 WinBar.Test :echo' : ''
               call setline(1, range(1, 256))
-              execute 'norm gg' . pos | redraw!
+              " No scroll for restore_snapshot
+              norm G
+              try
+                copen | close | colder
+              catch /E380/
+              endtry
+              call assert_equal(257 - winheight(0), line("w0"))
+
               " No scroll for firstwin horizontal split
-              split | redraw! | wincmd k
+              execute 'norm gg' . pos
+              split | redraw | wincmd k
               call assert_equal(1, line("w0"))
               wincmd j
               call assert_equal(win_screenpos(0)[0] - tabline - winbar_sb, line("w0"))
@@ -1714,7 +1722,7 @@ func Test_splitscroll_with_splits()
               call assert_equal(1, line("w0"))
 
               " No scroll in windows split and quit multiple times
-              quit | redraw! | split | split | quit
+              quit | redraw | split | redraw | split | redraw | quit | redraw
               call assert_equal(win_screenpos(0)[0] - tabline - winbar_sb, line("w0"))
 
               " No scroll for new buffer

--- a/src/window.c
+++ b/src/window.c
@@ -3923,6 +3923,7 @@ new_frame(win_T *wp)
 win_init_size(void)
 {
     firstwin->w_height = ROWS_AVAIL;
+    firstwin->w_prev_height = ROWS_AVAIL;
     topframe->fr_height = ROWS_AVAIL;
     firstwin->w_width = Columns;
     topframe->fr_width = Columns;
@@ -4069,6 +4070,7 @@ win_new_tabpage(int after)
 
 	win_init_size();
 	firstwin->w_winrow = tabline_height();
+	firstwin->w_prev_winrow = firstwin->w_winrow;
 	win_comp_scroll(curwin);
 
 	newtp->tp_topframe = topframe;
@@ -6372,10 +6374,8 @@ win_fix_scroll(int resize)
 	    {
 		lnum = wp->w_cursor.lnum;
 		wp->w_cursor.lnum = MIN(wp->w_buffer->b_ml.ml_line_count,
-			wp->w_botline - 1 + (wp->w_prev_height
-			    ? (wp->w_winrow - wp->w_prev_winrow)
-					   + (wp->w_height - wp->w_prev_height)
-			    : -WINBAR_HEIGHT(wp)));
+			wp->w_botline - 1 + (wp->w_winrow - wp->w_prev_winrow)
+					  + (wp->w_height - wp->w_prev_height));
 		// Bring the new cursor position to the bottom of the screen.
 		wp->w_fraction = FRACTION_MULT;
 		scroll_to_fraction(wp, wp->w_prev_height);
@@ -6802,6 +6802,9 @@ last_status_rec(frame_T *fr, int statusline)
 	    comp_col();
 	    redraw_all_later(UPD_SOME_VALID);
 	}
+	// Set prev_height when difference is due to 'laststatus'.
+	if (abs(wp->w_height - wp->w_prev_height) == 1)
+	    wp->w_prev_height = wp->w_height;
     }
     else if (fr->fr_layout == FR_ROW)
     {

--- a/src/window.c
+++ b/src/window.c
@@ -7094,6 +7094,8 @@ restore_snapshot(
 	win_comp_pos();
 	if (wp != NULL && close_curwin)
 	    win_goto(wp);
+	if (!p_spsc)
+	    win_fix_scroll(FALSE);
 	redraw_all_later(UPD_NOT_VALID);
     }
     clear_snapshot(curtab, idx);


### PR DESCRIPTION
Problem:    w_prev_height may be wrong when adding laststatus or winbar.
Solution:   Initialize w_prev_height and update it when setting laststatus or winbar. Also delay initializing firstwin size until after gui has started.

Instead of having a separate case in win_fix_scroll() for when w_prev_height was uninitialized, we now initialize it in win_init_size(). This prevents scrolling for the first split when 'nosplitbelow' is set. Slipped through the cracks as this only happens for the first window in a new tab when the first split is horizontal. Might be considered hair splitting again but I feel this is more correct and not too involved.

~I don't think this addresses https://github.com/vim/vim/issues/11115 yet. Feel free to keep this open and I'll add the fix to that if I find it.~
Added a commit that should fix #11115.