### PR TITLE
More 'splitscroll' problems

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -375,6 +375,7 @@ main
      * Set the default values for the options that use Rows and Columns.
      */
     ui_get_shellsize();		// inits Rows and Columns
+    win_init_size();
 #ifdef FEAT_DIFF
     // Set the 'diff' option now, so that it can be checked for in a .vimrc
     // file.  There is no buffer yet though.
@@ -539,9 +540,9 @@ vim_main2(void)
 	// don't have them.
 	if (!gui.in_use && params.evim_mode)
 	    mch_exit(1);
+	firstwin->w_prev_height = firstwin->w_height; // may have changed
     }
 #endif
-    win_init_size();
 
 #ifdef FEAT_VIMINFO
     /*

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1668,6 +1668,7 @@ func Test_splitscroll_with_splits()
               execute 'norm gg' . pos
               split | redraw | wincmd k
               call assert_equal(1, line("w0"))
+              call assert_equal(&scroll, winheight(0) / 2)
               wincmd j
               call assert_equal(win_screenpos(0)[0] - tabline - winbar_sb, line("w0"))
 

--- a/src/window.c
+++ b/src/window.c
@@ -6384,6 +6384,7 @@ win_fix_scroll(int resize)
 	    invalidate_botline_win(wp);
 	    validate_botline_win(wp);
 	}
+	win_comp_scroll(wp);
 	wp->w_prev_height = wp->w_height;
 	wp->w_prev_winrow = wp->w_winrow;
     }


### PR DESCRIPTION
Problem:    'scroll' is not updated when resizing windows, alloc error due to unitialized window size in terminal communication?
Solution:   Update 'scroll' in win_fix_scroll(), revert win_init_size() relocation in main.c and update prev_height for gui instead. (closes https://github.com/vim/vim/issues/11123, https://github.com/vim/vim/issues/11119, https://github.com/vim/vim/issues/11125)

This was being skipped for cases where scroll_to_fraction was not used in win_fix_scroll/cursor. Might be able to refactor this such that is only called when we do not scroll_to_fraction in either win_fix_scroll or win_fix cursor but it seems an inexpensive function so I'm not sure we care enough to? Does this need a test? Seems trivial.