### PR TITLE
Don't make cursor moves when closing cmdwin with nosplitscroll

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4405,6 +4405,7 @@ open_cmdwin(void)
     int			save_restart_edit = restart_edit;
     int			save_State = State;
     int			save_exmode = exmode_active;
+    int			save_p_spsc;
 #ifdef FEAT_RIGHTLEFT
     int			save_cmdmsg_rl = cmdmsg_rl;
 #endif
@@ -4643,7 +4644,11 @@ open_cmdwin(void)
 	// First go back to the original window.
 	wp = curwin;
 	set_bufref(&bufref, curbuf);
+
+	save_p_spsc = p_spsc;
+	p_spsc = 1;
 	win_goto(old_curwin);
+	p_spsc = save_p_spsc;
 
 	// win_goto() may trigger an autocommand that already closes the
 	// cmdline window.

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1734,9 +1734,13 @@ func Test_splitscroll_with_splits()
               above copen | wincmd j
               call assert_equal(win_screenpos(0)[0] - tabline, line("w0"))
 
-              " No scroll when opening cmdwin
-              only | norm ggLq:
+              " No scroll when opening cmdwin, and no cursor move when closing
+              " cmdwin.
+              only | norm ggL
+              let curpos = getcurpos()
+              norm q:
               call assert_equal(1, line("w0"))
+              call assert_equal(curpos, getcurpos())
 
               " Scroll when cursor becomes invalid in insert mode
               norm Lic


### PR DESCRIPTION
When `set nosplitscroll`, sometimes the cursor position of the current window is changed after closing cmdwin.
It shouldn't happen since no cursor moves on the current window happens when leaving command-line.

**Steps to reproduce**
- Open vim with `vim -u NONE --cmd "set nosplitscroll | call setline(1, range(1, &lines)) | normal L"`.
- Type `q:<C-w>q` and check the cursor position.

**Images**
- before
![nosplitscroll-before](https://user-images.githubusercontent.com/24771416/190110326-522fa0c6-516e-42b7-978a-b81e0f4eb214.gif)

- after
![nosplitscroll-after](https://user-images.githubusercontent.com/24771416/190110398-5a705a76-d76b-4818-ab2a-61d7d59b3462.gif)
