### PR TITLE
cursor moves when cmdwin is closed when 'splitscroll' is off

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4405,7 +4405,6 @@ open_cmdwin(void)
     int			save_restart_edit = restart_edit;
     int			save_State = State;
     int			save_exmode = exmode_active;
-    int			save_p_spsc;
 #ifdef FEAT_RIGHTLEFT
     int			save_cmdmsg_rl = cmdmsg_rl;
 #endif
@@ -4645,10 +4644,8 @@ open_cmdwin(void)
 	wp = curwin;
 	set_bufref(&bufref, curbuf);
 
-	save_p_spsc = p_spsc;
-	p_spsc = TRUE;
+	skip_win_fix_cursor = TRUE;
 	win_goto(old_curwin);
-	p_spsc = save_p_spsc;
 
 	// win_goto() may trigger an autocommand that already closes the
 	// cmdline window.
@@ -4662,6 +4659,7 @@ open_cmdwin(void)
 
 	// Restore window sizes.
 	win_size_restore(&winsizes);
+	skip_win_fix_cursor = FALSE;
     }
 
     ga_clear(&winsizes);

--- a/src/globals.h
+++ b/src/globals.h
@@ -1737,3 +1737,6 @@ EXTERN int channel_need_redraw INIT(= FALSE);
 // While executing a regexp and set to OPTION_MAGIC_ON or OPTION_MAGIC_OFF this
 // overrules p_magic.  Otherwise set to OPTION_MAGIC_NOT_SET.
 EXTERN optmagic_T magic_overruled INIT(= OPTION_MAGIC_NOT_SET);
+
+// Skip win_fix_cursor() call for 'nosplitscroll' when cmdwin is closed.
+EXTERN int skip_win_fix_cursor INIT(= 0);

--- a/src/window.c
+++ b/src/window.c
@@ -6408,7 +6408,8 @@ win_fix_cursor(int normal)
     long     so = get_scrolloff_value();
     linenr_T nlnum = 0;
 
-    if (wp->w_buffer->b_ml.ml_line_count < wp->w_height)
+    if (wp->w_buffer->b_ml.ml_line_count < wp->w_height
+	    || skip_win_fix_cursor)
 	return;
 
     so = MIN(wp->w_height / 2, so);


### PR DESCRIPTION
Problem:    Cursor moves when cmdwin is closed when 'splitscroll' is off.
Solution:   Skip win_fix_cursor if called when cmdwin is open or closing.

Reverts change to ex_getln.c from https://github.com/vim/vim/commit/e697d488901b6321ddaad68b553f0a434c97d849, keep the test. Can you confirm this works @mityu.