### PR TITLE
'splitscroll' test takes too long

### DIFF
--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -919,7 +919,7 @@ Short explanation of each option:		*option-list*
 'spellsuggest'	  'sps'     method(s) used to suggest spelling corrections
 'splitbelow'	  'sb'	    new window from split is below the current one
 'splitright'	  'spr'     new window is put right of the current one
-'splitscroll'	  'spsc'    determines scroll behavior when splitting windows
+'splitscroll'	  'spsc'    determines scroll behavior for split windows
 'startofline'	  'sol'     commands move cursor to first non-blank in line
 'statusline'	  'stl'     custom format for the status line
 'suffixes'	  'su'	    suffixes that are ignored with multiple match

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -515,7 +515,7 @@ call <SID>AddOption("splitbelow", gettext("a new window is put below the current
 call <SID>BinOptionG("sb", &sb)
 call <SID>AddOption("splitright", gettext("a new window is put right of the current one"))
 call <SID>BinOptionG("spr", &spr)
-call <SID>AddOption("splitscroll", gettext("determines scroll behavior when spliting windows"))
+call <SID>AddOption("splitscroll", gettext("determines scroll behavior for split windows"))
 call <SID>BinOptionG("spsc", &spsc)
 call <SID>AddOption("scrollbind", gettext("this window scrolls together with other bound windows"))
 call append("$", "\t" .. s:local_to_window)

--- a/src/window.c
+++ b/src/window.c
@@ -6403,7 +6403,6 @@ win_fix_scroll(int resize)
     static void
 win_fix_cursor(int normal)
 {
-    int      top = FALSE;
     win_T    *wp = curwin;
     long     so = get_scrolloff_value();
     linenr_T nlnum = 0;
@@ -6418,7 +6417,7 @@ win_fix_cursor(int normal)
     so = MIN(wp->w_height / 2, so);
     // Check if cursor position is above topline or below botline.
     if (wp->w_cursor.lnum < (wp->w_topline + so) && wp->w_topline != 1)
-	top = nlnum = MIN(wp->w_topline + so, wp->w_buffer->b_ml.ml_line_count);
+	nlnum = MIN(wp->w_topline + so, wp->w_buffer->b_ml.ml_line_count);
     else if (wp->w_cursor.lnum > (wp->w_botline - so - 1)
 	    && (wp->w_botline - wp->w_buffer->b_ml.ml_line_count) != 1)
 	nlnum = MAX(wp->w_botline - so - 1, 1);
@@ -6436,7 +6435,11 @@ win_fix_cursor(int normal)
 	}
 	else
 	{   // Ensure cursor stays visible if we are not in normal mode.
-	    wp->w_fraction = top ? 0 : FRACTION_MULT;
+	    wp->w_fraction = 0.5 * FRACTION_MULT;
+	    // Make sure cursor is closer to topline than botline.
+	    if (so == wp->w_height / 2
+			  && nlnum - wp->w_topline > wp->w_botline - 1 - nlnum)
+		wp->w_fraction++;
 	    scroll_to_fraction(wp, wp->w_prev_height);
 	}
     }


### PR DESCRIPTION
Problem:    'splitscroll' test takes too long. Cursor position is not always maintained when not in normal mode.
Solution:   Get rid of nested for loops. Center cursor in window when not in normal mode.

I think this should test most of what we actually wanted to test with the nested loops. Tested option values generated by `call add(v:errors, "so=".run.", tab=".(run % 5).", winbar=".(run % 2).", ls=".(run % 3).", ea=".(run % 2).", sb=".(run % 3).", pos=".pos)`:

```vim
so=0, tab=0, winbar=0, ls=0, ea=0, sb=0, pos=H
so=1, tab=1, winbar=1, ls=1, ea=1, sb=1, pos=M
so=2, tab=1, winbar=0, ls=2, ea=0, sb=1, pos=L
so=3, tab=1, winbar=1, ls=0, ea=1, sb=0, pos=H
so=4, tab=1, winbar=0, ls=1, ea=0, sb=1, pos=L
so=5, tab=0, winbar=1, ls=2, ea=1, sb=1, pos=M
so=6, tab=1, winbar=0, ls=0, ea=0, sb=0, pos=H
so=7, tab=1, winbar=1, ls=1, ea=1, sb=1, pos=M
so=8, tab=1, winbar=0, ls=2, ea=0, sb=1, pos=L
so=9, tab=1, winbar=1, ls=0, ea=1, sb=0, pos=H
so=10, tab=0, winbar=0, ls=1, ea=0, sb=1, pos=L
```

EDIT: investigating failing test.