### PR TITLE
'nosplitscroll' problems

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1789,4 +1789,34 @@ function Test_nosplitscroll_cmdwin_cursor_position()
   %bwipeout!
   set splitscroll&
 endfunction
+
+" No scroll when aucmd_win is opened.
+function Test_nosplitscroll_aucmdwin()
+  set nosplitscroll
+
+  call setline(1, range(1, &lines))
+  norm Gzz
+  let top = line('w0')
+  call setbufvar(bufnr("test", 1) , '&buftype', 'nofile')
+  call assert_equal(top, line('w0'))
+
+  %bwipeout!
+  set splitscroll&
+endfunc
+
+" No scroll when help is closed and buffer line count < window height.
+function Test_nosplitscroll_helpwin()
+  set nosplitscroll
+  set splitbelow
+
+  call setline(1, range(&lines - 10))
+  norm G
+  let top = line('w0')
+  help | quit
+  call assert_equal(top, line('w0'))
+
+  set splitbelow&
+  set splitscroll&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -1325,7 +1325,7 @@ win_split_ins(
 	win_equal(wp, TRUE,
 		(flags & WSP_VERT) ? (dir == 'v' ? 'b' : 'h')
 		: dir == 'h' ? 'b' : 'v');
-    else if (!p_spsc)
+    else if (!p_spsc && wp != aucmd_win)
 	win_fix_scroll(FALSE);
 
     // Don't change the window height/width to 'winheight' / 'winwidth' if a
@@ -1925,7 +1925,7 @@ win_equal(
     win_equal_rec(next_curwin == NULL ? curwin : next_curwin, current,
 		      topframe, dir, 0, tabline_height(),
 					   (int)Columns, topframe->fr_height);
-    if (!p_spsc)
+    if (!p_spsc && next_curwin != aucmd_win)
 	win_fix_scroll(TRUE);
 }
 
@@ -6366,8 +6366,7 @@ win_fix_scroll(int resize)
     {
 	// Skip when window height has not changed or when
 	// buffer has less lines than the window height.
-	if (wp->w_height != wp->w_prev_height
-		&& wp->w_height < wp->w_buffer->b_ml.ml_line_count)
+	if (wp->w_height != wp->w_prev_height)
 	{
 	    // Determine botline needed to avoid scrolling and set cursor.
 	    if (wp->w_winrow != wp->w_prev_winrow)
@@ -7102,8 +7101,6 @@ restore_snapshot(
 	win_comp_pos();
 	if (wp != NULL && close_curwin)
 	    win_goto(wp);
-	if (!p_spsc)
-	    win_fix_scroll(FALSE);
 	redraw_all_later(UPD_NOT_VALID);
     }
     clear_snapshot(curtab, idx);


### PR DESCRIPTION
Problem:	Text is scrolled when aucmd_win is opened and when help win is closed when buffer has less lines than window height. 
Solution:	Skip win_fix_scroll when next_curwin is aucmd_win and do not skip when buffer has less lines than window height.

The aucmd_win skip also prevents https://github.com/vim/vim/issues/11115, so we remove the earlier fix. The  w_buffer->b_ml.ml_line_count < w_height skip was just there as a performance consideration. Apparently we cannot always skip in this case to prevent scrolling though, so remove it. Closes https://github.com/vim/vim/issues/11147, closes https://github.com/vim/vim/issues/11145. 