### PR TITLE
More 'nosplitscroll' problems

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1742,3 +1742,5 @@ EXTERN optmagic_T magic_overruled INIT(= OPTION_MAGIC_NOT_SET);
 // Skip win_fix_cursor() call for 'nosplitscroll' when cmdwin is closed.
 EXTERN int skip_win_fix_cursor INIT(= FALSE);
 #endif
+// Skip update_topline() call while executing win_fix_scroll().
+EXTERN int skip_update_topline INIT(= FALSE);

--- a/src/globals.h
+++ b/src/globals.h
@@ -1742,5 +1742,7 @@ EXTERN optmagic_T magic_overruled INIT(= OPTION_MAGIC_NOT_SET);
 // Skip win_fix_cursor() call for 'nosplitscroll' when cmdwin is closed.
 EXTERN int skip_win_fix_cursor INIT(= FALSE);
 #endif
+// Skip win_fix_scroll() call for 'nosplitscroll' when closing tab page.
+EXTERN int skip_win_fix_scroll INIT(= FALSE);
 // Skip update_topline() call while executing win_fix_scroll().
 EXTERN int skip_update_topline INIT(= FALSE);

--- a/src/move.c
+++ b/src/move.c
@@ -991,7 +991,7 @@ curs_columns(
     /*
      * First make sure that w_topline is valid (after moving the cursor).
      */
-    if (p_spsc)
+    if (!skip_update_topline)
 	update_topline();
 
     /*

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1631,10 +1631,11 @@ func Test_win_equal_last_status()
   set laststatus&
 endfunc
 
-" Ensure no scrolling happens with 'nosplitscroll' with and without a
-" winbar, tabline, for each possible value of 'laststatus', 'scrolloff',
+" Ensure no scrolling happens with 'nosplitscroll' for a sequence of
+" split operations for various options: with and without a winbar,
+" tabline, for each possible value of 'laststatus', 'scrolloff',
 " 'equalalways', and regardless of the cursor position.
-func Test_splitscroll_with_splits()
+func Test_nosplitscroll_options()
   set nowrap
   set nosplitscroll
 
@@ -1648,7 +1649,7 @@ func Test_splitscroll_with_splits()
     tabnew | tabonly! | redraw    
     let tabline = (gui ? 0 : ((run % 5) ? 1 : 0))
     let winbar_sb = (run % 2) && (run % 3)
-    execute 'set scrolloff=' . !(run % 3) ? 0 : run
+    execute 'set scrolloff=' . (!(run % 4) ? 0 : run)
     execute 'set laststatus=' . (run % 3)
     execute 'set ' . ((run % 2) ? 'equalalways' : 'noequalalways')
     execute 'set ' . ((run % 3) ? 'splitbelow' : 'nosplitbelow')
@@ -1790,31 +1791,28 @@ function Test_nosplitscroll_cmdwin_cursor_position()
   set splitscroll&
 endfunction
 
-" No scroll when aucmd_win is opened.
-function Test_nosplitscroll_aucmdwin()
+function Test_nosplitscroll_misc()
   set nosplitscroll
+  set splitbelow
 
   call setline(1, range(1, &lines))
   norm Gzz
   let top = line('w0')
+  " No scroll when aucmd_win is opened
   call setbufvar(bufnr("test", 1) , '&buftype', 'nofile')
   call assert_equal(top, line('w0'))
-
-  %bwipeout!
-  set splitscroll&
-endfunc
-
-" No scroll when help is closed and buffer line count < window height.
-function Test_nosplitscroll_helpwin()
-  set nosplitscroll
-  set splitbelow
-
-  call setline(1, range(&lines - 10))
+  " No scroll when tab is changed/closed
+  tab help | close
+  call assert_equal(top, line('w0'))
+  " No scroll when help is closed and buffer line count < window height
+  norm ggdG
+  call setline(1, range(1, &lines - 10))
   norm G
   let top = line('w0')
   help | quit
   call assert_equal(top, line('w0'))
 
+  %bwipeout!
   set splitbelow&
   set splitscroll&
 endfunc

--- a/src/window.c
+++ b/src/window.c
@@ -6392,7 +6392,7 @@ win_fix_scroll(int resize)
     }
     skip_update_topline = FALSE;
     // Ensure cursor is valid when not in normal mode or when resized.
-    if (!(get_real_state() & (MODE_NORMAL|MODE_CMDLINE)))
+    if (!(get_real_state() & (MODE_NORMAL|MODE_CMDLINE|MODE_TERMINAL)))
 	win_fix_cursor(FALSE);
     else if (resize)
 	win_fix_cursor(TRUE);

--- a/src/window.c
+++ b/src/window.c
@@ -6362,6 +6362,7 @@ win_fix_scroll(int resize)
     win_T    *wp;
     linenr_T lnum;
 
+    skip_update_topline = TRUE;  // avoid flicker in curs_rows()
     FOR_ALL_WINDOWS(wp)
     {
 	// Skip when window height has not changed or when
@@ -6387,6 +6388,7 @@ win_fix_scroll(int resize)
 	wp->w_prev_height = wp->w_height;
 	wp->w_prev_winrow = wp->w_winrow;
     }
+    skip_update_topline = FALSE;
     // Ensure cursor is valid when not in normal mode or when resized.
     if (!(get_real_state() & (MODE_NORMAL|MODE_CMDLINE)))
 	win_fix_cursor(FALSE);

--- a/src/window.c
+++ b/src/window.c
@@ -6438,11 +6438,8 @@ win_fix_cursor(int normal)
 	else
 	{   // Ensure cursor stays visible if we are not in normal mode.
 	    wp->w_fraction = 0.5 * FRACTION_MULT;
-	    // Make sure cursor is closer to topline than botline.
-	    if (so == wp->w_height / 2
-			  && nlnum - wp->w_topline > wp->w_botline - 1 - nlnum)
-		wp->w_fraction--;
 	    scroll_to_fraction(wp, wp->w_prev_height);
+	    validate_botline_win(curwin);
 	}
     }
 }

--- a/src/window.c
+++ b/src/window.c
@@ -6364,11 +6364,10 @@ win_fix_scroll(int resize)
     win_T    *wp;
     linenr_T lnum;
 
-    skip_update_topline = TRUE;  // avoid flicker in curs_rows()
+    skip_update_topline = TRUE;  // avoid scrolling in curs_rows()
     FOR_ALL_WINDOWS(wp)
     {
-	// Skip when window height has not changed or when
-	// buffer has less lines than the window height.
+	// Skip when window height has not changed.
 	if (wp->w_height != wp->w_prev_height)
 	{
 	    // Determine botline needed to avoid scrolling and set cursor.
@@ -6442,7 +6441,7 @@ win_fix_cursor(int normal)
 	    // Make sure cursor is closer to topline than botline.
 	    if (so == wp->w_height / 2
 			  && nlnum - wp->w_topline > wp->w_botline - 1 - nlnum)
-		wp->w_fraction++;
+		wp->w_fraction--;
 	    scroll_to_fraction(wp, wp->w_prev_height);
 	}
     }

--- a/src/window.c
+++ b/src/window.c
@@ -4478,6 +4478,7 @@ goto_tabpage_tp(
     // Don't repeat a message in another tab page.
     set_keep_msg(NULL, 0);
 
+    skip_win_fix_scroll = TRUE;
     if (tp != curtab && leave_tabpage(tp->tp_curwin->w_buffer,
 					trigger_leave_autocmds) == OK)
     {
@@ -4488,6 +4489,7 @@ goto_tabpage_tp(
 	    enter_tabpage(curtab, curbuf, trigger_enter_autocmds,
 		    trigger_leave_autocmds);
     }
+    skip_win_fix_scroll = FALSE;
 }
 
 /*
@@ -5481,7 +5483,7 @@ shell_new_rows(void)
     compute_cmdrow();
     curtab->tp_ch_used = p_ch;
 
-    if (!p_spsc)
+    if (!p_spsc && !skip_win_fix_scroll)
 	win_fix_scroll(TRUE);
 
 #if 0


### PR DESCRIPTION
* Fix https://github.com/vim/vim/issues/11159, added test.
* Fix https://github.com/vim/vim/issues/11158. Was just a redraw issue I think, it's not that WinScrolled was called twice or something. Topline was updated at a later point because we skipped it in curs_columns, resulting in flickering. Not sure if it is possible to add a test for this issue.
* Fix https://github.com/vim/vim/issues/11160, not sure how to add a test for this issue. I tried
```vim
  " No scroll when splitting window in terminal callback
  norm ggL
  let top = line('w0')
  func s:ExitCb(a, b)
    close | help
  endfunc
  let buf = term_start(&shell, { 'hidden': 1, 'exit_cb': 's:ExitCb' })
  call popup_create(buf, {})
  call term_sendkeys(buf, "exit\<CR>")
  sleep 200m
  redraw!
  wincmd k
  call assert_equal(top, line('w0'))
```
but this only passes **with** the redraw, at which point it also passes before the fix. 

Moreover, if we move the `wincmd k` to the callback function, the current fix is not enough to catch that and scrolling will still happen. Trying to fix it with a watchpoint on `firstwin->w_topline` and backtracing led me to trying to add workarounds in `redraw_after_callback()` or `ex_docmd.c` but it got quite complicated. Not sure if it's worth to catch this issue.