### PR TITLE
Do not scroll for a warning if there is no stacktrace

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -535,11 +535,11 @@ msg_source(int attr)
 	return;
     recursive = TRUE;
 
-    msg_scroll = TRUE;  // this will take more than one line
     ++no_wait_return;
     p = get_emsg_source();
     if (p != NULL)
     {
+	msg_scroll = TRUE;  // this will take more than one line
 	msg_attr((char *)p, attr);
 	vim_free(p);
     }
@@ -767,8 +767,8 @@ emsg_core(char_u *s)
 #endif
     /*
      * Display name and line number for the source of the error.
-     * Sets "msg_scroll".
      */
+    msg_scroll = TRUE;
     msg_source(attr);
 
     /*

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -166,6 +166,38 @@ func Test_echospace()
   set ruler& showcmd&
 endfunc
 
+func Test_warning_scroll()
+  CheckRunVimInTerminal
+  let lines =<< trim END
+      call test_override('ui_delay', 50)
+      set noruler
+      set readonly
+      undo
+  END
+  call writefile(lines, 'XTestWarningScroll', 'D')
+  let buf = RunVimInTerminal('', #{rows: 8})
+
+  " When the warning comes from a script, messages are scrolled so that the
+  " stacktrace is visible.
+  call term_sendkeys(buf, ":source XTestWarningScroll\n")
+  " only match the final colon in the line that shows the source
+  call WaitForAssert({-> assert_match(':$', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('line    4:W10: Warning: Changing a readonly file', term_getline(buf, 6))})
+  call WaitForAssert({-> assert_equal('Already at oldest change', term_getline(buf, 7))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 8))})
+  call term_sendkeys(buf, "\n")
+
+  " When the warning does not come from a script, messages are not scrolled.
+  call term_sendkeys(buf, ":enew\n")
+  call term_sendkeys(buf, ":set readonly\n")
+  call term_sendkeys(buf, 'u')
+  call WaitForAssert({-> assert_equal('W10: Warning: Changing a readonly file', term_getline(buf, 8))})
+  call WaitForAssert({-> assert_equal('Already at oldest change', term_getline(buf, 8))})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 " Test more-prompt (see :help more-prompt).
 func Test_message_more()
   CheckRunVimInTerminal


### PR DESCRIPTION
- Don't scroll when no stacktrace is available
- Do not scroll for a warning if there is no stacktrace
