### PR TITLE
win32: Remove old settings for Windows XP

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1,7 +1,6 @@
 # Makefile for Vim on Win32 (Windows 7/8/10/11) and Win64, using the Microsoft
-# Visual C++ compilers. Known to work with VC10 (VS2010), VC11 (VS2012), VC12
-# (VS2013), VC14 (VS2015), VC14.1 (VS2017), VC14.2 (VS2019) and VC14.3
-# (VS2022).
+# Visual C++ compilers. Known to work with VC14 (VS2015), VC14.1 (VS2017),
+# VC14.2 (VS2019) and VC14.3 (VS2022).
 #
 # To build using other Windows compilers, see INSTALLpc.txt
 #

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -688,10 +688,6 @@ LIBC = $(LIBC) libcmtd.lib
 
 !endif # DEBUG
 
-!if "$(CL)" == "/D_USING_V110_SDK71_"
-RCFLAGS = $(RCFLAGS) /D_USING_V110_SDK71_
-!endif
-
 # Visual Studio 2005 has 'deprecated' many of the standard CRT functions
 CFLAGS_DEPR = /D_CRT_SECURE_NO_DEPRECATE /D_CRT_NONSTDC_NO_DEPRECATE
 CFLAGS = $(CFLAGS) $(CFLAGS_DEPR)

--- a/src/msvc2015.bat
+++ b/src/msvc2015.bat
@@ -11,27 +11,5 @@ rem   This works on any editions including Express edition.
 rem   If you use Community (or Professional) edition, you can also use "x64"
 rem   option:
 rem     msvc2015 x64
-@echo on
 
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %*
-
-rem Use Windows SDK 7.1A for targeting Windows XP.
-if "%ProgramFiles(x86)%"=="" (
-	set "WinSdk71=%ProgramFiles%\Microsoft SDKs\Windows\v7.1A"
-) else (
-	set "WinSdk71=%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.1A"
-)
-if not exist "%WinSdk71%" (
-	echo Windows SDK 7.1A is not found.  Targeting Windows Vista and later.
-	goto :eof
-)
-
-set INCLUDE=%WinSdk71%\Include;%INCLUDE%
-if /i "%Platform%"=="x64" (
-	set "LIB=%WinSdk71%\Lib\x64;%LIB%"
-	set SUBSYSTEM_VER=5.02
-) else (
-	set "LIB=%WinSdk71%\Lib;%LIB%"
-	set SUBSYSTEM_VER=5.01
-)
-set CL=/D_USING_V110_SDK71_


### PR DESCRIPTION
Settings for Windows XP were still remaining. Remove them.