### PR TITLE
No need to use `errbuf` for option argument

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -1323,13 +1323,11 @@ do_set_string(
 	/*
 	 * Set 'keywordprg' to ":help" if an empty
 	 * value was passed to :set by the user.
-	 * Misuse errbuf[] for the resulting string.
 	 */
 	if (varp == (char_u *)&p_kp && (*arg == NUL || *arg == ' '))
 	{
-	    STRCPY(errbuf, ":help");
 	    save_arg = arg;
-	    arg = (char_u *)errbuf;
+	    arg = (char_u *)":help";
 	}
 	/*
 	 * Convert 'backspace' number to string, for
@@ -1417,7 +1415,7 @@ do_set_string(
 	 * but do remove it for "\\\\machine\\path".
 	 * The reverse is found in ExpandOldSetting().
 	 */
-	while (*arg && !VIM_ISWHITE(*arg))
+	while (*arg != NUL && !VIM_ISWHITE(*arg))
 	{
 	    int i;
 
@@ -1565,7 +1563,8 @@ do_set_string(
 	    }
 	}
 
-	if (save_arg != NULL)   // number for 'whichwrap'
+	if (save_arg != NULL)
+	    // empty string for 'keywordprg' or number for 'whichwrap'
 	    arg = save_arg;
     }
 

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1342,4 +1342,17 @@ func Test_switchbuf_reset()
   only!
 endfunc
 
+" :set empty string for global 'keywordprg' falls back to :help
+func Test_keywordprg_empty()
+  let k = &keywordprg
+  set keywordprg=man
+  call assert_equal('man', &keywordprg)
+  set keywordprg=
+  call assert_equal(':help', &keywordprg)
+  set keywordprg=man
+  call assert_equal('man', &keywordprg)
+  call assert_equal("\n  keywordprg=:help", execute('set kp= kp?'))
+  let &keywordprg = k
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When out-of-memory causes an early return in do_set_string(), `*arg` may
be set to a local pointer to `whichwrap`, which becomes invalid after
returning. Although `arg` will no longer be used in do_set() if
do_set_string() returns `FAIL`, it is still better to avoid an invalid
pointer.

It should also be unnecessary to use `errbuf` for the argument.

Add a test for :set global 'keywordprg' to empty.
