### PR TITLE
Bugfix: Correct typo in netrw BrowseX core dump handler

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -5345,8 +5345,8 @@ fun! netrw#BrowseX(fname,remote)
      " g:Netrw_corehandler is a List of function references (see :help Funcref)
 "     call Decho("g:Netrw_corehandler is a List",'~'.expand("<slnum>"))
      for Fncref in g:Netrw_corehandler
-      if type(FncRef) == 2
-       call FncRef(a:fname)
+      if type(Fncref) == 2
+       call Fncref(a:fname)
       endif
      endfor
     endif


### PR DESCRIPTION
This typo affects the netrw BrowseX core dump handler.

There was a similar `Fncref` typo fixed in [89a9c15](https://github.com/vim/vim/commit/89a9c15) for other netrw code.