### PR TITLE
Problem:    Task address used as process ID on AmigaOS4.

### DIFF
--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -704,7 +704,9 @@ mch_get_host_name(char_u *s, int len)
     long
 mch_get_pid(void)
 {
-#if defined(__amigaos4__) || defined(__AROS__) || defined(__MORPHOS__)
+#if defined(__amigaos4__)
+    return (long) getpid();
+#elif defined(__AROS__) || defined(__MORPHOS__)
     // This is as close to a pid as we can come. We could use CLI numbers also,
     // but then we would have two different types of process identifiers.
     return((long)FindTask(0));


### PR DESCRIPTION
Solution:   Use proper process ID.