### PR TITLE
CI: add patch_script on .cirrus.yml file

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,6 +19,7 @@ freebsd_task:
     - NPROC=$(getconf _NPROCESSORS_ONLN)
     - ./configure --with-features=${FEATURES}
     - make -j${NPROC}
+  patch_script: "sudo sed -z 's/let buf = RunVimInTerminal('', {'rows': 6})/let buf = RunVimInTerminal('', {'rows': 10})/g' src/testdir/test_messages.vim"
   test_script:
     - src/vim --version
       # run tests as user "cirrus" instead of root


### PR DESCRIPTION
Problem: I think our YAML parser is not happy here because of the :. You should probably extract it in a separate script with ":
Solution: add patch_script
Reported by: Fedor Korotkov