### PR TITLE
Prevent following make syntax error:

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3578,7 +3578,7 @@ objects/xpatience.o: xdiff/xpatience.c $(XDIFF_INCL)
 
 
 Makefile:
-	@echo The name of the makefile MUST be "Makefile" (with capital M)!!!!
+	@echo 'The name of the makefile MUST be "Makefile" (with capital M)!!!!'
 
 
 ###############################################################################


### PR DESCRIPTION
/bin/sh: 1: Syntax error: "(" unexpected
make[1]: *** [Makefile:3581: Makefile] Error 2
