### PR TITLE
Detect TypeScript new file extensions

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2088,6 +2088,10 @@ au BufNewFile,BufReadPost *.ts
 	\   setf typescript |
 	\ endif
 
+" TypeScript new file extensions
+" https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions
+au BufNewFile,BufRead *.mts,*.cts		setf typescript
+
 " TypeScript with React
 au BufNewFile,BufRead *.tsx			setf typescriptreact
 


### PR DESCRIPTION
TypeScript compiler now supports two new file extensions `.mts` and `.cts`. This PR allows detecting the extensions as TypeScript sources.

Official document: https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions