### PR TITLE
Add GYP file type & syntax

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -802,6 +802,9 @@ au BufNewFile,BufRead */etc/group,*/etc/group-,*/etc/group.edit,*/etc/gshadow,*/
 " GTK RC
 au BufNewFile,BufRead .gtkrc,gtkrc		setf gtkrc
 
+" GYP
+au BufNewFile,BufRead *.gyp,*.gypi		setf gyp
+
 " Hack
 au BufRead,BufNewFile *.hack,*.hackpartial			setf hack
 

--- a/runtime/ftplugin/gyp.vim
+++ b/runtime/ftplugin/gyp.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:	GYP
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Last Change:	2022 Sep 27
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal formatoptions-=t
+setlocal commentstring=#\ %s comments=b:#,fb:-
+
+let b:undo_ftplugin = 'setlocal fo< cms< com<'

--- a/runtime/indent/gyp.vim
+++ b/runtime/indent/gyp.vim
@@ -1,0 +1,7 @@
+" Vim indent file
+" Language:	GYP
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Last Change:	2022 Sep 27
+
+" JSON indent works well
+runtime! indent/json.vim

--- a/runtime/syntax/gyp.vim
+++ b/runtime/syntax/gyp.vim
@@ -1,0 +1,49 @@
+" Vim syntax file
+" Language:	GYP
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Filenames:	*.gyp,*.gypi
+" Last Change:	2022 Sep 27
+
+if !exists('g:main_syntax')
+  if exists('b:current_syntax') && b:current_syntax ==# 'gyp'
+    finish
+  endif
+  let g:main_syntax = 'gyp'
+endif
+
+" Based on JSON syntax
+runtime! syntax/json.vim
+
+" Single quotes are allowed
+syn clear jsonStringSQError
+
+syn match jsonKeywordMatch /'\([^']\|\\\'\)\+'[[:blank:]\r\n]*\:/ contains=jsonKeyword
+if has('conceal') && (!exists('g:vim_json_conceal') || g:vim_json_conceal==1)
+   syn region  jsonKeyword matchgroup=jsonQuote start=/'/  end=/'\ze[[:blank:]\r\n]*\:/ concealends contained
+else
+   syn region  jsonKeyword matchgroup=jsonQuote start=/'/  end=/'\ze[[:blank:]\r\n]*\:/ contained
+endif
+
+syn match  jsonStringMatch /'\([^']\|\\\'\)\+'\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
+if has('conceal') && (!exists('g:vim_json_conceal') || g:vim_json_conceal==1)
+    syn region  jsonString oneline matchgroup=jsonQuote start=/'/  skip=/\\\\\|\\'/  end=/'/ concealends contains=jsonEscape contained
+else
+    syn region  jsonString oneline matchgroup=jsonQuote start=/'/  skip=/\\\\\|\\'/  end=/'/ contains=jsonEscape contained
+endif
+
+" Trailing commas are allowed
+if !exists('g:vim_json_warnings') || g:vim_json_warnings==1
+    syn clear jsonTrailingCommaError
+endif
+
+" Python-style comments are allowed
+syn match   jsonComment  /#.*$/ contains=jsonTodo,@Spell
+syn keyword jsonTodo     FIXME NOTE TODO XXX TBD contained
+
+hi def link jsonComment Comment
+hi def link jsonTodo    Todo
+
+let b:current_syntax = 'gyp'
+if g:main_syntax ==# 'gyp'
+  unlet g:main_syntax
+endif

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -240,6 +240,7 @@ let s:filename_checks = {
     \ 'grub': ['/boot/grub/menu.lst', '/boot/grub/grub.conf', '/etc/grub.conf', 'any/boot/grub/grub.conf', 'any/boot/grub/menu.lst', 'any/etc/grub.conf'],
     \ 'gsp': ['file.gsp'],
     \ 'gtkrc': ['.gtkrc', 'gtkrc', '.gtkrc-file', 'gtkrc-file'],
+    \ 'gyp': ['file.gyp', 'file.gypi'],
     \ 'hack': ['file.hack', 'file.hackpartial'],
     \ 'haml': ['file.haml'],
     \ 'hamster': ['file.hsm'],


### PR DESCRIPTION
GYP files are basically JSON files with the following deviations:

* Single-quoted strings are allowed.
* Trailing commas are allowed.
* `#` comments are supported.

Strings can contain operators and expansions which may be added to the syntax file at a later point.

----

**Source:**

* https://gyp.gsrc.io/docs/UserDocumentation.md#skeleton-of-a-typical-chromium-gyp-file
* https://gyp.gsrc.io/docs/LanguageSpecification.md#overview
* https://gyp.gsrc.io/docs/InputFormatReference.md