### PR TITLE
fix: `make test_filetype` leaves temp file `Xfile.m`

### DIFF
--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1233,7 +1233,7 @@ endfunc
 func Test_m_file()
   filetype on
 
-  call writefile(['looks like Matlab'], 'Xfile.m')
+  call writefile(['looks like Matlab'], 'Xfile.m', 'D')
   split Xfile.m
   call assert_equal('matlab', &filetype)
   bwipe!


### PR DESCRIPTION
`make test_filetype` leaves temp file `Xfile.m`.