### PR TITLE
FEAT_TITLE still remains

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6159,7 +6159,7 @@ gui_mch_haskey(char_u *name)
     return FAIL;
 }
 
-#if defined(FEAT_TITLE) || defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(PROTO)
 /*
  * Return the text window-id and display.  Only required for X-based GUI's
  */


### PR DESCRIPTION
FEAT_TITLE was removed at [patch 8.2.3699](https://github.com/vim/vim/commit/651fca85c71a4c5807f8f828f9ded30fbd754325#diff-be2f5db462c144bac48d3c5a47db61e80c233d57ff04a2e1ee29dc0b02d8cfb1).