### PR TITLE
Display patchlevel on first line in :version

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -69,7 +69,7 @@ init_longVersion(void)
 	size_t len = strlen(msg)
 		    + strlen(VIM_VERSION_LONG_ONLY)
 		    + strlen(VIM_VERSION_DATE_ONLY)
-		    + hp
+		    + 8 // For hp; should be more than enough.
 		    + strlen(date_time);
 
 	longVersion = alloc(len);

--- a/src/version.c
+++ b/src/version.c
@@ -64,10 +64,12 @@ init_longVersion(void)
 #else
 	char *date_time = __DATE__ " " __TIME__;
 #endif
-	char *msg = _("%s (%s, compiled %s)");
+	int hp = highest_patch();
+	char *msg = _("%s.%d (%s, compiled %s)");
 	size_t len = strlen(msg)
 		    + strlen(VIM_VERSION_LONG_ONLY)
 		    + strlen(VIM_VERSION_DATE_ONLY)
+		    + hp
 		    + strlen(date_time);
 
 	longVersion = alloc(len);
@@ -75,7 +77,7 @@ init_longVersion(void)
 	    longVersion = VIM_VERSION_LONG;
 	else
 	    vim_snprintf(longVersion, len, msg,
-		      VIM_VERSION_LONG_ONLY, VIM_VERSION_DATE_ONLY, date_time);
+		      VIM_VERSION_LONG_ONLY, hp, VIM_VERSION_DATE_ONLY, date_time);
     }
 }
 # endif


### PR DESCRIPTION
Currently the intro screen displays the version with the patch number:

                 VIM - Vi IMproved

                  version 9.0.648
             by Bram Moolenaar et al.
    Vim is open source and freely distributable

But the :version command and "vim --version" displays it a bit different:

	:version
	VIM - Vi IMproved 9.0 (2022 Jun 28, compiled Oct  3 2022 15:19:47)
	Included patches: 1-648
	Compiled by martin@x270.arp242.net

Many times I've seen people report only the first line from :version, which isn't all that useful; almost everyone is using *some* patchlevel, and "Vim 8.2" was 2.5 years of development, 8.1 a year and a half, etc.