### PR TITLE
Always include FEAT_CMDWIN, alias 'tiny' build to 'small'

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,6 @@ environment:
   matrix:
     - FEATURE: HUGE
 # disabled
-#    - FEATURE: TINY
 #    - FEATURE: SMALL
 #    - FEATURE: NORMAL
 #    - FEATURE: BIG

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1124,7 +1124,6 @@ Also see |`=|.
 In the command-line window the command line can be edited just like editing
 text in any window.  It is a special kind of window, because you cannot leave
 it in a normal way.
-{not available when compiled without the |+cmdwin| feature}
 
 
 OPEN						*c_CTRL-F* *q:* *q/* *q?*

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -318,8 +318,7 @@ g8			Print the hex values of the bytes used in the
 			Here is an overview of the features.
 			The first column shows the smallest version in which
 			they are included:
-			   T	tiny (always)
-			   S	small
+			   S	small (always)
 			   N	normal
 			   B	big
 			   H	huge
@@ -334,7 +333,7 @@ g8			Print the hex values of the bytes used in the
    *+ARP*		Amiga only: ARP support included
 B  *+arabic*		|Arabic| language support
 B  *+autochdir*		support 'autochdir' option
-T  *+autocmd*		|:autocmd|, automatic commands.  Always enabled since
+S  *+autocmd*		|:autocmd|, automatic commands.  Always enabled since
 			8.0.1564
 H  *+autoservername*	Automatically enable |clientserver|
 m  *+balloon_eval*	|balloon-eval| support in the GUI. Included when
@@ -344,7 +343,7 @@ m  *+balloon_eval*	|balloon-eval| support in the GUI. Included when
 H  *+balloon_eval_term*	|balloon-eval| support in the terminal,
 			'balloonevalterm'
 N  *+browse*		|:browse| command
-T  *++builtin_terms*	maximal terminals builtin |builtin-terms| Always
+S  *++builtin_terms*	maximal terminals builtin |builtin-terms| Always
 			enabled since 9.0.0280
 N  *+byte_offset*	support for 'o' flag in 'statusline' option, "go"
 			and ":goto" commands.
@@ -353,15 +352,15 @@ m  *+channel*		inter process communication |channel|
 N  *+clientserver*	Unix and Win32: Remote invocation |clientserver|
    *+clipboard*		|clipboard| support compiled-in
    *+clipboard_working*	|clipboard| support compiled-in and working
-T  *+cmdline_compl*	command line completion |cmdline-completion|
-T  *+cmdline_hist*	command line history |cmdline-history|
+S  *+cmdline_compl*	command line completion |cmdline-completion|
+S  *+cmdline_hist*	command line history |cmdline-history|
 N  *+cmdline_info*	|'showcmd'| and |'ruler'|
-S  *+cmdwin*		|cmdline-window| support
-T  *+comments*		|'comments'| support
+S  *+cmdwin*		|cmdline-window| support  Always enabled since 9.0.0652
+S  *+comments*		|'comments'| support
 B  *+conceal*		"conceal" support, see |conceal| |:syn-conceal| etc.
 N  *+cryptv*		encryption support |encryption|
 B  *+cscope*		|cscope| support
-T  *+cursorbind*	|'cursorbind'| support
+S  *+cursorbind*	|'cursorbind'| support
 m  *+cursorshape*	|termcap-cursor-shape| support
 m  *+debug*		Compiled for debugging.
 N  *+dialog_gui*	Support for |:confirm| with GUI dialog.
@@ -373,17 +372,17 @@ N  *+digraphs*		|digraphs| *E196*
    *+dnd*		Support for DnD into the "~ register |quote_~|.
 B  *+emacs_tags*	|emacs-tags| files
 N  *+eval*		expression evaluation |eval.txt|
-T  *+ex_extra*		always on now, used to be for Vim's extra Ex commands
+S  *+ex_extra*		always on now, used to be for Vim's extra Ex commands
 N  *+extra_search*	|'hlsearch'| and |'incsearch'| options.
 -  *+farsi*		Removed: |farsi| language
-T  *+file_in_path*	|gf|, |CTRL-W_f| and |<cfile>|  Always enabled since
+S  *+file_in_path*	|gf|, |CTRL-W_f| and |<cfile>|  Always enabled since
 			9.0.265
 N  *+find_in_path*	include file searches: |[I|, |:isearch|,
 			|CTRL-W_CTRL-I|, |:checkpath|, etc.
 N  *+folding*		|folding|
    *+footer*		|gui-footer|
    *+fork*		Unix only: |fork| shell commands
-T  *+float*		Floating point support  Always enabled since 9.0.0491
+S  *+float*		Floating point support  Always enabled since 9.0.0491
 N  *+gettext*		message translations |multi-lang|
 -  *+GUI_Athena*	Unix only: Athena |GUI|
    *+GUI_neXtaw*	Unix only: neXtaw |GUI|
@@ -393,25 +392,25 @@ N  *+gettext*		message translations |multi-lang|
 m  *+hangul_input*	Hangul input support |hangul|
    *+iconv*		Compiled with the |iconv()| function
    *+iconv/dyn*		Likewise |iconv-dynamic| |/dyn|
-T  *+insert_expand*	|insert_expand| Insert mode completion
+S  *+insert_expand*	|insert_expand| Insert mode completion
 m  *+ipv6*		Support for IPv6 networking |channel|
 m  *+job*		starting and stopping jobs |job|
-T  *+jumplist*		|jumplist|; Always enabled since 8.2.3795
+S  *+jumplist*		|jumplist|; Always enabled since 8.2.3795
 B  *+keymap*		|'keymap'|
 N  *+lambda*		|lambda| and |closure|
 B  *+langmap*		|'langmap'|
 N  *+libcall*		|libcall()|
 N  *+linebreak*		|'linebreak'|, |'breakat'| and |'showbreak'|
 t  *+lispindent*	|'lisp'|
-T  *+listcmds*		Vim commands for the list of buffers |buffer-hidden|
+S  *+listcmds*		Vim commands for the list of buffers |buffer-hidden|
 			and argument list |:argdelete|
-T  *+localmap*		Support for mappings local to a buffer |:map-local|
+S  *+localmap*		Support for mappings local to a buffer |:map-local|
 m  *+lua*		|Lua| interface
 m  *+lua/dyn*		|Lua| interface |/dyn|
 N  *+menu*		|:menu|
 N  *+mksession*		|:mksession|
-T  *+modify_fname*	|filename-modifiers|
-T  *+mouse*		Mouse handling |mouse-using|
+S  *+modify_fname*	|filename-modifiers|
+S  *+mouse*		Mouse handling |mouse-using|
 N  *+mouseshape*	|'mouseshape'|
 B  *+mouse_dec*		Unix only: Dec terminal mouse handling |dec-mouse|
 N  *+mouse_gpm*		Unix only: Linux console mouse handling |gpm-mouse|
@@ -424,18 +423,18 @@ N  *+mouse_sysmouse*	Unix only: *BSD console mouse handling |sysmouse|
 B  *+mouse_sgr*		Unix only: sgr mouse handling |sgr-mouse|
 B  *+mouse_urxvt*	Unix only: urxvt mouse handling |urxvt-mouse|
 N  *+mouse_xterm*	Unix only: xterm mouse handling |xterm-mouse|
-T  *+multi_byte*	Unicode support, 16 and 32 bit characters |multibyte|
+S  *+multi_byte*	Unicode support, 16 and 32 bit characters |multibyte|
    *+multi_byte_ime*	Win32 input method for multibyte chars |multibyte-ime|
 N  *+multi_lang*	non-English language support |multi-lang|
 m  *+mzscheme*		Mzscheme interface |mzscheme|
 m  *+mzscheme/dyn*	Mzscheme interface |mzscheme-dynamic| |/dyn|
 m  *+netbeans_intg*	|netbeans|
-T  *+num64*		64-bit Number support |Number|
+S  *+num64*		64-bit Number support |Number|
 			Always enabled since 8.2.0271, use v:numbersize to
 			check the actual size of a Number.
 m  *+ole*		Win32 GUI only: |ole-interface|
 N  *+packages*		Loading |packages|
-T  *+path_extra*	Up/downwards search in 'path' and 'tags'  Always
+S  *+path_extra*	Up/downwards search in 'path' and 'tags'  Always
 			enabled since 9.0.0270
 m  *+perl*		Perl interface |perl|
 m  *+perl/dyn*		Perl interface |perl-dynamic| |/dyn|
@@ -454,7 +453,7 @@ N  *+reltime*		|reltime()| function, 'hlsearch'/'incsearch' timeout,
 B  *+rightleft*		Right to left typing |'rightleft'|
 m  *+ruby*		Ruby interface |ruby|
 m  *+ruby/dyn*		Ruby interface |ruby-dynamic| |/dyn|
-T  *+scrollbind*	|'scrollbind'|
+S  *+scrollbind*	|'scrollbind'|
 B  *+signs*		|:sign|
 t  *+smartindent*	|'smartindent'|
 B  *+sodium*		compiled with libsodium for better encryption support
@@ -466,7 +465,7 @@ N  *+statusline*	Options 'statusline', 'rulerformat' and special
 -  *+sun_workshop*	Removed: |workshop|
 N  *+syntax*		Syntax highlighting |syntax|
    *+system()*		Unix only: opposite of |+fork|
-T  *+tag_binary*	binary searching in tags file |tag-binary-search|
+S  *+tag_binary*	binary searching in tags file |tag-binary-search|
 -  *+tag_old_static*	Removed; method for static tags |tag-old-static|
 -  *+tag_any_white*	Removed; was to allow any white space in tags files
 m  *+tcl*		Tcl interface |tcl|
@@ -475,27 +474,27 @@ m  *+terminal*		Support for terminal window |terminal|
    *+terminfo*		uses |terminfo| instead of termcap
 N  *+termresponse*	support for |t_RV| and |v:termresponse|
 B  *+termguicolors*	24-bit color in xterm-compatible terminals support
-T  *+textobjects*	|text-objects| selection. Always enabled since 9.0.0222.
+S  *+textobjects*	|text-objects| selection. Always enabled since 9.0.0222.
 N  *+textprop*		|text-properties|
    *+tgetent*		non-Unix only: able to use external termcap
 N  *+timers*		the |timer_start()| function
-T  *+title*		Setting the window 'title' and 'icon'; Always enabled
+S  *+title*		Setting the window 'title' and 'icon'; Always enabled
 N  *+toolbar*		|gui-toolbar|
-T  *+user_commands*	User-defined commands. |user-commands|
+S  *+user_commands*	User-defined commands. |user-commands|
 			Always enabled since 8.1.1210.
 B  *+vartabs*		Variable-width tabstops. |'vartabstop'|
-T  *+vertsplit*		Vertically split windows |:vsplit|; Always enabled
+S  *+vertsplit*		Vertically split windows |:vsplit|; Always enabled
 			since 8.0.1118.
-T  *+vim9script*	|Vim9| script
+S  *+vim9script*	|Vim9| script
 N  *+viminfo*		|'viminfo'|
-T  *+virtualedit*	|'virtualedit'| Always enabled since 8.1.826.
-T  *+visual*		Visual mode |Visual-mode| Always enabled since 7.4.200.
-T  *+visualextra*	extra Visual mode commands |blockwise-operators|
-T  *+vreplace*		|gR| and |gr|
+S  *+virtualedit*	|'virtualedit'| Always enabled since 8.1.826.
+S  *+visual*		Visual mode |Visual-mode| Always enabled since 7.4.200.
+S  *+visualextra*	extra Visual mode commands |blockwise-operators|
+S  *+vreplace*		|gR| and |gr|
    *+vtp*		on MS-Windows console: support for 'termguicolors'
-T  *+wildignore*	|'wildignore'|  Always enabled since 9.0.0278
-T  *+wildmenu*		|'wildmenu'||  Always enabled since 9.0.0279
-T  *+windows*		more than one window; Always enabled since 8.0.1118.
+S  *+wildignore*	|'wildignore'|  Always enabled since 9.0.0278
+S  *+wildmenu*		|'wildmenu'||  Always enabled since 9.0.0279
+S  *+windows*		more than one window; Always enabled since 8.0.1118.
 m  *+writebackup*	|'writebackup'| is default on
 m  *+xim*		X input method |xim|
    *+xfontset*		X fontset support |xfontset|

--- a/src/INSTALLvms.txt
+++ b/src/INSTALLvms.txt
@@ -77,9 +77,7 @@ from CVS mirror ftp://ftp.polarhome.com/pub/cvs/SOURCE/
 
 	Parameter name	: MODEL
 	Description	: Build model selection
-	Options:	: TINY	  - Almost no features enabled, not even
-			  multiple windows
-			  SMALL   - Few features enabled, as basic as possible
+	Options:	: SMALL   - Few features enabled, as basic as possible
 			  NORMAL  - A default selection of features enabled
 			  BIG	  - Many features enabled, as rich as possible.
 			  (OpenVMS default)

--- a/src/Make_ami.mak
+++ b/src/Make_ami.mak
@@ -50,9 +50,9 @@ ifeq ($(BUILD),small)
 CFLAGS += -DFEAT_SMALL
 else
 
-# Vim 'tiny' build
+# Vim 'tiny' build, alias for 'small'
 ifeq ($(BUILD),tiny)
-CFLAGS += -DFEAT_TINY
+CFLAGS += -DFEAT_SMALL
 endif
 endif
 endif

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -28,8 +28,8 @@
 # Updated 2014 Oct 13.
 
 #>>>>> choose options:
-# FEATURES=[TINY | SMALL | NORMAL | BIG | HUGE]
-# Set to TINY to make minimal version (few features).
+# FEATURES=[SMALL | NORMAL | BIG | HUGE]
+# Set to SMALL to make minimal version (few features).
 FEATURES=HUGE
 
 # Set to yes for a debug build.

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -16,7 +16,7 @@
 #
 #	!!!!  After changing any features do "nmake clean" first  !!!!
 #
-#	Feature Set: FEATURES=[TINY, SMALL, NORMAL, BIG, HUGE] (default is HUGE)
+#	Feature Set: FEATURES=[SMALL, NORMAL, BIG, HUGE] (default is HUGE)
 #
 #   	Name to add to the version: MODIFIED_BY=[name of modifier]
 #
@@ -1124,7 +1124,7 @@ CFLAGS = $(CFLAGS) -DMSWINPS
 !endif # POSTSCRIPT
 
 #
-# FEATURES: TINY, SMALL, NORMAL, BIG or HUGE
+# FEATURES: SMALL, NORMAL, BIG or HUGE
 #
 CFLAGS = $(CFLAGS) -DFEAT_$(FEATURES)
 
@@ -1359,14 +1359,14 @@ testgvim testgui:
 	$(MAKE) /NOLOGO -f Make_mvc.mak VIMPROG=..\gvim
 	cd ..
 
-testtiny:
+testsmall:
 	cd testdir
-	$(MAKE) /NOLOGO -f Make_mvc.mak tiny
+	$(MAKE) /NOLOGO -f Make_mvc.mak small
 	cd ..
 
-testgvimtiny:
+testgvimsmall:
 	cd testdir
-	$(MAKE) /NOLOGO -f Make_mvc.mak tiny VIMPROG=..\gvim
+	$(MAKE) /NOLOGO -f Make_mvc.mak small VIMPROG=..\gvim
 	cd ..
 
 testclean:
@@ -1376,7 +1376,7 @@ testclean:
 
 # Run individual OLD style test.
 # These do not depend on the executable, compile it when needed.
-$(SCRIPTS_TINY):
+$(SCRIPTS_SMALL):
 	cd testdir
 	- if exist $@.out del $@.out
 	$(MAKE) /NOLOGO -f Make_mvc.mak VIMPROG=..\$(VIMTESTTARGET) nolog

--- a/src/Make_vms.mms
+++ b/src/Make_vms.mms
@@ -27,7 +27,6 @@
 DECC = YES
 
 # Build model selection
-# TINY   - Almost no features enabled, not even multiple windows
 # SMALL  - Few features enabled, as basic as possible
 # NORMAL - A default selection of features enabled
 # BIG    - Many features enabled, as rich as possible. (default)

--- a/src/Makefile
+++ b/src/Makefile
@@ -386,7 +386,7 @@ CClink = $(CC)
 # "liblua5.4-dev".
 # Use --with-luajit if you want to use LuaJIT instead of Lua.
 # Set PATH environment variable to find lua or luajit executable.
-# This requires at least "normal" features, "tiny" and "small" don't work.
+# This requires at least "normal" features, "small" don't work.
 #CONF_OPT_LUA = --enable-luainterp
 #CONF_OPT_LUA = --enable-luainterp=dynamic
 #CONF_OPT_LUA = --enable-luainterp --with-luajit
@@ -415,14 +415,14 @@ CClink = $(CC)
 # the next line.
 # When you get an error for a missing "perl.exp" file, try creating an empty
 # one: "touch perl.exp".
-# This requires at least "normal" features, "tiny" and "small" don't work.
+# This requires at least "normal" features, "small" don't work.
 #CONF_OPT_PERL = --enable-perlinterp
 #CONF_OPT_PERL = --enable-perlinterp=dynamic
 
 # PYTHON
 # Uncomment lines here when you want to include the Python interface.
 # Debian package is "libpython3-dev".
-# This requires at least "normal" features, "tiny" and "small" don't work.
+# This requires at least "normal" features, "small" don't work.
 # Python 3 is preferred, Python 2 (often referred to as "Python") has been
 # deprecated for a long time.
 # NOTE: This may cause threading to be enabled, which has side effects (such
@@ -444,7 +444,7 @@ CClink = $(CC)
 # Uncomment this when you want to include the Ruby interface.
 # First one for static linking, second one for loading when used.
 # Debian package is "ruby-dev".
-# This requires at least "normal" features, "tiny" and "small" don't work.
+# This requires at least "normal" features, "small" don't work.
 #CONF_OPT_RUBY = --enable-rubyinterp
 #CONF_OPT_RUBY = --enable-rubyinterp=dynamic
 #CONF_OPT_RUBY = --enable-rubyinterp --with-ruby-command=ruby1.9.1
@@ -529,7 +529,6 @@ CClink = $(CC)
 # FEATURES - For creating Vim with more or less features
 # Uncomment one of these lines when you want to include few to many features.
 # The default is "huge" for most systems.
-#CONF_OPT_FEAT = --with-features=tiny
 #CONF_OPT_FEAT = --with-features=small
 #CONF_OPT_FEAT = --with-features=normal
 #CONF_OPT_FEAT = --with-features=big
@@ -2184,8 +2183,8 @@ scripttests:
 testgui:
 	cd testdir; $(MAKE) -f Makefile $(GUI_TESTTARGET) VIMPROG=../$(VIMTARGET) GUI_FLAG=-g $(GUI_TESTARG) SCRIPTSOURCE=../$(SCRIPTSOURCE)
 
-testtiny:
-	cd testdir; $(MAKE) -f Makefile tiny VIMPROG=../$(VIMTARGET) SCRIPTSOURCE=../$(SCRIPTSOURCE)
+testsmall:
+	cd testdir; $(MAKE) -f Makefile small VIMPROG=../$(VIMTARGET) SCRIPTSOURCE=../$(SCRIPTSOURCE)
 
 # Run benchmarks.
 benchmark:
@@ -2227,7 +2226,7 @@ test_libvterm:
 
 # Run individual OLD style test.
 # These do not depend on the executable, compile it when needed.
-$(SCRIPTS_TINY):
+$(SCRIPTS_SMALL):
 	cd testdir; rm -f $@.out; $(MAKE) -f Makefile $@.out VIMPROG=../$(VIMTESTTARGET) $(GUI_TESTARG) SCRIPTSOURCE=../$(SCRIPTSOURCE)
 
 # Run individual NEW style test.

--- a/src/arglist.c
+++ b/src/arglist.c
@@ -1186,13 +1186,11 @@ do_arg_all(
     tabpage_T		*last_curtab;
     int			prev_arglist_locked = arglist_locked;
 
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
     {
 	emsg(_(e_invalid_in_cmdline_window));
 	return;
     }
-#endif
     if (ARGCOUNT <= 0)
     {
 	// Don't give an error message.  We don't want it when the ":all"

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -1523,7 +1523,7 @@ Optional Packages:
   --with-view-name=NAME   what to call the View executable
   --with-global-runtime=DIR    global runtime directory in 'runtimepath', comma-separated for multiple directories
   --with-modified-by=NAME       name of who modified a release version
-  --with-features=TYPE    tiny, small, normal, big or huge (default: huge)
+  --with-features=TYPE    small, normal, big or huge (default: huge)
   --with-compiledby=NAME  name to show in :version message
   --with-lua-prefix=PFX   Prefix where Lua is installed.
   --with-luajit           Link with LuaJIT instead of Lua.
@@ -5219,11 +5219,13 @@ $as_echo "Defaulting to huge" >&6; }
 fi
 
 
+case "$features" in
+  tiny) features="small" ;;
+esac
+
 dovimdiff=""
 dogvimdiff=""
 case "$features" in
-  tiny)		$as_echo "#define FEAT_TINY 1" >>confdefs.h
- ;;
   small)	$as_echo "#define FEAT_SMALL 1" >>confdefs.h
  ;;
   normal)	$as_echo "#define FEAT_NORMAL 1" >>confdefs.h
@@ -5242,7 +5244,7 @@ esac
 
 
 
-if test "x$features" = "xtiny" -o "x$features" = "xsmall"; then
+if "x$features" = "xsmall"; then
   has_eval=no
 else
   has_eval=yes
@@ -5300,7 +5302,7 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking diff feature" >&5
 $as_echo_n "checking diff feature... " >&6; }
-if test "x$features" = "xtiny" -o "x$features" = "xsmall"; then
+if "x$features" = "xsmall"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled in $features version" >&5
 $as_echo "disabled in $features version" >&6; }
 else
@@ -5326,7 +5328,7 @@ $as_echo "$enable_luainterp" >&6; }
 
 if test "$enable_luainterp" = "yes" -o "$enable_luainterp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    as_fn_error $? "cannot use Lua with tiny or small features" "$LINENO" 5
+    as_fn_error $? "cannot use Lua with small features" "$LINENO" 5
   fi
 
 
@@ -6096,7 +6098,7 @@ fi
 $as_echo "$enable_perlinterp" >&6; }
 if test "$enable_perlinterp" = "yes" -o "$enable_perlinterp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    as_fn_error $? "cannot use Perl with tiny or small features" "$LINENO" 5
+    as_fn_error $? "cannot use Perl with small features" "$LINENO" 5
   fi
 
   # Extract the first word of "perl", so it can be a program name with args.
@@ -6301,7 +6303,7 @@ fi
 $as_echo "$enable_pythoninterp" >&6; }
 if test "$enable_pythoninterp" = "yes" -o "$enable_pythoninterp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    as_fn_error $? "cannot use Python with tiny or small features" "$LINENO" 5
+    as_fn_error $? "cannot use Python with small features" "$LINENO" 5
   fi
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking --with-python-command argument" >&5
@@ -6652,7 +6654,7 @@ fi
 $as_echo "$enable_python3interp" >&6; }
 if test "$enable_python3interp" = "yes" -o "$enable_python3interp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    as_fn_error $? "cannot use Python with tiny or small features" "$LINENO" 5
+    as_fn_error $? "cannot use Python with small features" "$LINENO" 5
   fi
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking --with-python3-command argument" >&5
@@ -7580,7 +7582,7 @@ fi
 $as_echo "$enable_rubyinterp" >&6; }
 if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    as_fn_error $? "cannot use Ruby with tiny or small features" "$LINENO" 5
+    as_fn_error $? "cannot use Ruby with small features" "$LINENO" 5
   fi
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking --with-ruby-command argument" >&5
@@ -7758,8 +7760,8 @@ fi
 
 if test "$enable_netbeans" = "yes"; then
   if test "$has_eval" = "no"; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: cannot use NetBeans with tiny or small features" >&5
-$as_echo "cannot use NetBeans with tiny or small features" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: cannot use NetBeans with small features" >&5
+$as_echo "cannot use NetBeans with small features" >&6; }
     enable_netbeans="no"
   else
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
@@ -7781,8 +7783,8 @@ fi
 
 if test "$enable_channel" = "yes"; then
   if test "$has_eval" = "no"; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: cannot use channels with tiny or small features" >&5
-$as_echo "cannot use channels with tiny or small features" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: cannot use channels with small features" >&5
+$as_echo "cannot use channels with small features" >&6; }
     enable_channel="no"
   else
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
@@ -8085,8 +8087,8 @@ fi
 
 if test "$enable_terminal" = "yes" || test "$enable_terminal" = "auto" -a "x$features" = "xhuge" ; then
   if test "$has_eval" = "no"; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: cannot use terminal emulator with tiny or small features" >&5
-$as_echo "cannot use terminal emulator with tiny or small features" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: cannot use terminal emulator with small features" >&5
+$as_echo "cannot use terminal emulator with small features" >&6; }
     enable_terminal="no"
   else
     if test "$enable_terminal" = "auto"; then
@@ -12892,8 +12894,8 @@ $as_echo "Defaulting to no" >&6; }
   fi
 else
   if test "$enable_canberra" = "yes" -a "$has_eval" = "no"; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: cannot use sound with tiny or small features" >&5
-$as_echo "cannot use sound with tiny or small features" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: cannot use sound with small features" >&5
+$as_echo "cannot use sound with small features" >&6; }
     enable_canberra="no"
   else
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_canberra" >&5
@@ -14721,7 +14723,7 @@ rm -f core conftest.err conftest.$ac_objext \
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: msgfmt not found - disabled" >&5
 $as_echo "msgfmt not found - disabled" >&6; };
     fi
-    if test $have_gettext = "yes" -a "x$features" != "xtiny" -a "x$features" != "xsmall"; then
+    if test $have_gettext = "yes" -a "x$features" != "xsmall"; then
       $as_echo "#define HAVE_GETTEXT 1" >>confdefs.h
 
       MAKEMO=yes
@@ -15011,17 +15013,9 @@ if test "$MACOS_X" = "yes"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need macOS frameworks" >&5
 $as_echo_n "checking whether we need macOS frameworks... " >&6; }
   if test "$MACOS_X_DARWIN" = "yes"; then
-    if test "$features" = "tiny"; then
-            OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_macosx.m++'`
-      OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_macosx.o++'`
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, we need CoreServices" >&5
-$as_echo "yes, we need CoreServices" >&6; }
-      LIBS="$LIBS -framework CoreServices"
-    else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, we need AppKit" >&5
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, we need AppKit" >&5
 $as_echo "yes, we need AppKit" >&6; }
-      LIBS="$LIBS -framework AppKit"
-    fi
+	LIBS="$LIBS -framework AppKit"
   else
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -316,9 +316,6 @@
 /* Define if strings.h cannot be included when strings.h already is */
 #undef NO_STRINGS_WITH_STRING_H
 
-/* Define if you want tiny features. */
-#undef FEAT_TINY
-
 /* Define if you want small features. */
 #undef FEAT_SMALL
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -522,14 +522,18 @@ fi
 dnl Check user requested features.
 
 AC_MSG_CHECKING(--with-features argument)
-AC_ARG_WITH(features, [  --with-features=TYPE    tiny, small, normal, big or huge (default: huge)],
+AC_ARG_WITH(features, [  --with-features=TYPE    small, normal, big or huge (default: huge)],
 	features="$withval"; AC_MSG_RESULT($features),
 	features="huge"; AC_MSG_RESULT(Defaulting to huge))
+
+dnl Alias 'tiny' to 'small'.
+case "$features" in
+  tiny) features="small" ;;
+esac
 
 dovimdiff=""
 dogvimdiff=""
 case "$features" in
-  tiny)		AC_DEFINE(FEAT_TINY) ;;
   small)	AC_DEFINE(FEAT_SMALL) ;;
   normal)	AC_DEFINE(FEAT_NORMAL) dovimdiff="installvimdiff";
 			dogvimdiff="installgvimdiff" ;;
@@ -543,7 +547,7 @@ esac
 AC_SUBST(dovimdiff)
 AC_SUBST(dogvimdiff)
 
-if test "x$features" = "xtiny" -o "x$features" = "xsmall"; then
+if "x$features" = "xsmall"; then
   has_eval=no
 else
   has_eval=yes
@@ -577,7 +581,7 @@ else
 fi
 
 AC_MSG_CHECKING([diff feature])
-if test "x$features" = "xtiny" -o "x$features" = "xsmall"; then
+if "x$features" = "xsmall"; then
   AC_MSG_RESULT([disabled in $features version])
 else
   AC_MSG_RESULT(enabled)
@@ -595,7 +599,7 @@ AC_MSG_RESULT($enable_luainterp)
 
 if test "$enable_luainterp" = "yes" -o "$enable_luainterp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    AC_MSG_ERROR([cannot use Lua with tiny or small features])
+    AC_MSG_ERROR([cannot use Lua with small features])
   fi
 
   dnl -- find the lua executable
@@ -1082,7 +1086,7 @@ AC_ARG_ENABLE(perlinterp,
 AC_MSG_RESULT($enable_perlinterp)
 if test "$enable_perlinterp" = "yes" -o "$enable_perlinterp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    AC_MSG_ERROR([cannot use Perl with tiny or small features])
+    AC_MSG_ERROR([cannot use Perl with small features])
   fi
   AC_SUBST(vi_cv_path_perl)
   AC_PATH_PROG(vi_cv_path_perl, perl)
@@ -1231,7 +1235,7 @@ AC_ARG_ENABLE(pythoninterp,
 AC_MSG_RESULT($enable_pythoninterp)
 if test "$enable_pythoninterp" = "yes" -o "$enable_pythoninterp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    AC_MSG_ERROR([cannot use Python with tiny or small features])
+    AC_MSG_ERROR([cannot use Python with small features])
   fi
 
   dnl -- find the python executable
@@ -1466,7 +1470,7 @@ AC_ARG_ENABLE(python3interp,
 AC_MSG_RESULT($enable_python3interp)
 if test "$enable_python3interp" = "yes" -o "$enable_python3interp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    AC_MSG_ERROR([cannot use Python with tiny or small features])
+    AC_MSG_ERROR([cannot use Python with small features])
   fi
 
   dnl -- find the python3 executable
@@ -1979,7 +1983,7 @@ AC_ARG_ENABLE(rubyinterp,
 AC_MSG_RESULT($enable_rubyinterp)
 if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
   if test "$has_eval" = "no"; then
-    AC_MSG_ERROR([cannot use Ruby with tiny or small features])
+    AC_MSG_ERROR([cannot use Ruby with small features])
   fi
 
   AC_MSG_CHECKING(--with-ruby-command argument)
@@ -2092,7 +2096,7 @@ AC_ARG_ENABLE(netbeans,
 	, [enable_netbeans="yes"])
 if test "$enable_netbeans" = "yes"; then
   if test "$has_eval" = "no"; then
-    AC_MSG_RESULT([cannot use NetBeans with tiny or small features])
+    AC_MSG_RESULT([cannot use NetBeans with small features])
     enable_netbeans="no"
   else
     AC_MSG_RESULT(no)
@@ -2107,7 +2111,7 @@ AC_ARG_ENABLE(channel,
 	, [enable_channel="yes"])
 if test "$enable_channel" = "yes"; then
   if test "$has_eval" = "no"; then
-    AC_MSG_RESULT([cannot use channels with tiny or small features])
+    AC_MSG_RESULT([cannot use channels with small features])
     enable_channel="no"
   else
     AC_MSG_RESULT(no)
@@ -2215,7 +2219,7 @@ AC_ARG_ENABLE(terminal,
 	, [enable_terminal="auto"])
 if test "$enable_terminal" = "yes" || test "$enable_terminal" = "auto" -a "x$features" = "xhuge" ; then
   if test "$has_eval" = "no"; then
-    AC_MSG_RESULT([cannot use terminal emulator with tiny or small features])
+    AC_MSG_RESULT([cannot use terminal emulator with small features])
     enable_terminal="no"
   else
     if test "$enable_terminal" = "auto"; then
@@ -3722,7 +3726,7 @@ if test "$enable_canberra" = "maybe"; then
   fi
 else
   if test "$enable_canberra" = "yes" -a "$has_eval" = "no"; then
-    AC_MSG_RESULT([cannot use sound with tiny or small features])
+    AC_MSG_RESULT([cannot use sound with small features])
     enable_canberra="no"
   else
     AC_MSG_RESULT($enable_canberra)
@@ -4432,7 +4436,7 @@ if test "$enable_nls" = "yes"; then
     else
       AC_MSG_RESULT([msgfmt not found - disabled]);
     fi
-    if test $have_gettext = "yes" -a "x$features" != "xtiny" -a "x$features" != "xsmall"; then
+    if test $have_gettext = "yes" -a "x$features" != "xsmall"; then
       AC_DEFINE(HAVE_GETTEXT)
       MAKEMO=yes
       AC_SUBST(MAKEMO)
@@ -4548,16 +4552,8 @@ fi
 if test "$MACOS_X" = "yes"; then
   AC_MSG_CHECKING([whether we need macOS frameworks])
   if test "$MACOS_X_DARWIN" = "yes"; then
-    if test "$features" = "tiny"; then
-      dnl Since no FEAT_CLIPBOARD, no longer need for os_macosx.m.
-      OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_macosx.m++'`
-      OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_macosx.o++'`
-      AC_MSG_RESULT([yes, we need CoreServices])
-      LIBS="$LIBS -framework CoreServices"
-    else
-      AC_MSG_RESULT([yes, we need AppKit])
-      LIBS="$LIBS -framework AppKit"
-    fi
+	AC_MSG_RESULT([yes, we need AppKit])
+	LIBS="$LIBS -framework AppKit"
   else
     AC_MSG_RESULT([no])
   fi

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -156,11 +156,7 @@ typedef struct {
 
 // draw_state values for items that are drawn in sequence:
 #define WL_START	0		// nothing done yet, must be zero
-#ifdef FEAT_CMDWIN
-# define WL_CMDLINE	(WL_START + 1)	// cmdline window column
-#else
-# define WL_CMDLINE	WL_START
-#endif
+#define WL_CMDLINE	(WL_START + 1)	// cmdline window column
 #ifdef FEAT_FOLDING
 # define WL_FOLD	(WL_CMDLINE + 1)	// 'foldcolumn'
 #else
@@ -1677,7 +1673,6 @@ win_line(
 		line_attr = line_attr_save;
 	    }
 #endif
-#ifdef FEAT_CMDWIN
 	    if (wlv.draw_state == WL_CMDLINE - 1 && wlv.n_extra == 0)
 	    {
 		wlv.draw_state = WL_CMDLINE;
@@ -1691,7 +1686,6 @@ win_line(
 				hl_combine_attr(wlv.wcr_attr, HL_ATTR(HLF_AT));
 		}
 	    }
-#endif
 #ifdef FEAT_FOLDING
 	    if (wlv.draw_state == WL_FOLD - 1 && wlv.n_extra == 0)
 	    {

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1102,7 +1102,6 @@ fold_line(
 
     // 1. Add the cmdwin_type for the command-line window
     // Ignores 'rightleft', this window is never right-left.
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0 && wp == curwin)
     {
 	ScreenLines[off] = cmdwin_type;
@@ -1111,7 +1110,6 @@ fold_line(
 	    ScreenLinesUC[off] = 0;
 	++col;
     }
-#endif
 
 #ifdef FEAT_RIGHTLEFT
 # define RL_MEMSET(p, v, l) \

--- a/src/edit.c
+++ b/src/edit.c
@@ -785,7 +785,6 @@ edit(
 	    // FALLTHROUGH
 
 	case Ctrl_C:	// End input mode
-#ifdef FEAT_CMDWIN
 	    if (c == Ctrl_C && cmdwin_type != 0)
 	    {
 		// Close the cmdline window.
@@ -794,7 +793,6 @@ edit(
 		nomove = TRUE;
 		goto doESCkey;
 	    }
-#endif
 #ifdef FEAT_JOB_CHANNEL
 	    if (c == Ctrl_C && bt_prompt(curbuf))
 	    {
@@ -1196,14 +1194,12 @@ doESCkey:
 		break;
 	    }
 #endif
-#ifdef FEAT_CMDWIN
 	    if (cmdwin_type != 0)
 	    {
 		// Execute the command in the cmdline window.
 		cmdwin_result = CAR;
 		goto doESCkey;
 	    }
-#endif
 #ifdef FEAT_JOB_CHANNEL
 	    if (bt_prompt(curbuf))
 	    {

--- a/src/errors.h
+++ b/src/errors.h
@@ -15,10 +15,8 @@ EXTERN char e_interrupted[]
 
 EXTERN char e_backslash_should_be_followed_by[]
 	INIT(= N_("E10: \\ should be followed by /, ? or &"));
-#ifdef FEAT_CMDWIN
 EXTERN char e_invalid_in_cmdline_window[]
 	INIT(= N_("E11: Invalid in command-line window; :q<CR> closes the window"));
-#endif
 EXTERN char e_command_not_allowed_from_vimrc_in_current_dir_or_tag_search[]
 	INIT(= N_("E12: Command not allowed from exrc/vimrc in current dir or tag search"));
 EXTERN char e_file_exists[]
@@ -461,10 +459,8 @@ EXTERN char e_no_digraphs_version[]
 EXTERN char e_cannot_set_language_to_str[]
 	INIT(= N_("E197: Cannot set language to \"%s\""));
 // E198 unused
-#ifdef FEAT_CMDWIN
 EXTERN char e_active_window_or_buffer_deleted[]
 	INIT(= N_("E199: Active window or buffer deleted"));
-#endif
 EXTERN char e_readpre_autocommands_made_file_unreadable[]
 	INIT(= N_("E200: *ReadPre autocommands made the file unreadable"));
 EXTERN char e_readpre_autocommands_must_not_change_current_buffer[]
@@ -3012,7 +3008,7 @@ EXTERN char e_expression_does_not_result_in_value_str[]
 #endif
 EXTERN char e_failed_to_source_defaults[]
 	INIT(= N_("E1187: Failed to source defaults.vim"));
-#if defined(FEAT_TERMINAL) && defined(FEAT_CMDWIN)
+#if defined(FEAT_TERMINAL)
 EXTERN char e_cannot_open_terminal_from_command_line_window[]
 	INIT(= N_("E1188: Cannot open a terminal from the command line window"));
 #endif
@@ -3291,10 +3287,8 @@ EXTERN char e_substitute_nesting_too_deep[]
 EXTERN char e_invalid_argument_nr[]
 	INIT(= N_("E1291: Invalid argument: %ld"));
 #endif
-#ifdef FEAT_CMDWIN
 EXTERN char e_cmdline_window_already_open[]
 	INIT(= N_("E1292: Command-line window is already open"));
-#endif
 #ifdef FEAT_PROP_POPUP
 EXTERN char e_cannot_use_negative_id_after_adding_textprop_with_text[]
 	INIT(= N_("E1293: Cannot use a negative id after adding a textprop with text"));

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5582,13 +5582,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 		},
 	{"cmdline_compl", 1},
 	{"cmdline_hist", 1},
-	{"cmdwin",
-#ifdef FEAT_CMDWIN
-		1
-#else
-		0
-#endif
-		},
+	{"cmdwin", 1},
 	{"comments", 1},
 	{"conceal",
 #ifdef FEAT_CONCEAL

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -821,13 +821,11 @@ f_win_gotoid(typval_T *argvars, typval_T *rettv)
 	return;
 
     id = tv_get_number(&argvars[0]);
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
     {
 	emsg(_(e_invalid_in_cmdline_window));
 	return;
     }
-#endif
 #if defined(FEAT_PROP_POPUP) && defined(FEAT_TERMINAL)
     if (popup_is_popup(curwin) && curbuf->b_term != NULL)
     {
@@ -1065,10 +1063,8 @@ f_win_gettype(typval_T *argvars, typval_T *rettv)
     else if (WIN_IS_POPUP(wp))
 	rettv->vval.v_string = vim_strsave((char_u *)"popup");
 #endif
-#ifdef FEAT_CMDWIN
     else if (wp == curwin && cmdwin_type != 0)
 	rettv->vval.v_string = vim_strsave((char_u *)"command");
-#endif
 #ifdef FEAT_QUICKFIX
     else if (bt_quickfix(wp->w_buffer))
 	rettv->vval.v_string = vim_strsave((char_u *)
@@ -1085,14 +1081,12 @@ f_getcmdwintype(typval_T *argvars UNUSED, typval_T *rettv)
 {
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = NULL;
-#ifdef FEAT_CMDWIN
     rettv->vval.v_string = alloc(2);
     if (rettv->vval.v_string != NULL)
     {
 	rettv->vval.v_string[0] = cmdwin_type;
 	rettv->vval.v_string[1] = NUL;
     }
-#endif
 }
 
 /*

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2739,12 +2739,11 @@ do_ecmd(
 	if (buf != curbuf)
 	{
 	    bufref_T	save_au_new_curbuf;
-#ifdef FEAT_CMDWIN
 	    int		save_cmdwin_type = cmdwin_type;
 
 	    // BufLeave applies to the old buffer.
 	    cmdwin_type = 0;
-#endif
+
 	    /*
 	     * Be careful: The autocommands may delete any buffer and change
 	     * the current buffer.
@@ -2760,9 +2759,7 @@ do_ecmd(
 	    save_au_new_curbuf = au_new_curbuf;
 	    set_bufref(&au_new_curbuf, buf);
 	    apply_autocmds(EVENT_BUFLEAVE, NULL, NULL, FALSE, curbuf);
-#ifdef FEAT_CMDWIN
 	    cmdwin_type = save_cmdwin_type;
-#endif
 	    if (!bufref_valid(&au_new_curbuf))
 	    {
 		// new buffer has been deleted

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2083,14 +2083,12 @@ do_one_cmd(
 
 	if (!IS_USER_CMDIDX(ea.cmdidx))
 	{
-#ifdef FEAT_CMDWIN
 	    if (cmdwin_type != 0 && !(ea.argt & EX_CMDWIN))
 	    {
 		// Command not allowed in the command line window
 		errormsg = _(e_invalid_in_cmdline_window);
 		goto doend;
 	    }
-#endif
 	    if (text_locked() && !(ea.argt & EX_LOCK_OK))
 	    {
 		// Command not allowed when text is locked
@@ -5849,13 +5847,11 @@ ex_quit(exarg_T *eap)
 {
     win_T	*wp;
 
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
     {
 	cmdwin_result = Ctrl_C;
 	return;
     }
-#endif
     // Don't quit while editing the command line.
     if (text_locked())
     {
@@ -5934,7 +5930,6 @@ ex_cquit(exarg_T *eap UNUSED)
     static void
 ex_quit_all(exarg_T *eap)
 {
-# ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
     {
 	if (eap->forceit)
@@ -5943,7 +5938,6 @@ ex_quit_all(exarg_T *eap)
 	    cmdwin_result = K_XF2;
 	return;
     }
-# endif
 
     // Don't quit while editing the command line.
     if (text_locked())
@@ -5969,11 +5963,9 @@ ex_close(exarg_T *eap)
 {
     win_T	*win;
     int		winnr = 0;
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
 	cmdwin_result = Ctrl_C;
     else
-#endif
 	if (!text_locked() && !curbuf_locked())
 	{
 	    if (eap->addr_count == 0)
@@ -6189,11 +6181,9 @@ ex_tabclose(exarg_T *eap)
     tabpage_T	*tp;
     int		tab_number;
 
-# ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
 	cmdwin_result = K_IGNORE;
     else
-# endif
 	if (first_tabpage->tp_next == NULL)
 	    emsg(_(e_cannot_close_last_tab_page));
 	else
@@ -6228,11 +6218,9 @@ ex_tabonly(exarg_T *eap)
     int		done;
     int		tab_number;
 
-# ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
 	cmdwin_result = K_IGNORE;
     else
-# endif
 	if (first_tabpage->tp_next == NULL)
 	    msg(_("Already only one tab page"));
 	else
@@ -6403,13 +6391,11 @@ ex_exit(exarg_T *eap)
     if (not_in_vim9(eap) == FAIL)
 	return;
 #endif
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
     {
 	cmdwin_result = Ctrl_C;
 	return;
     }
-#endif
     // Don't quit while editing the command line.
     if (text_locked())
     {

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -52,16 +52,12 @@ static void	restore_cmdline(cmdline_info_T *ccp);
 static int	cmdline_paste(int regname, int literally, int remcr);
 static void	redrawcmdprompt(void);
 static int	ccheck_abbr(int);
+static int	open_cmdwin(void);
 #ifdef FEAT_SEARCH_EXTRA
 static int	empty_pattern_magic(char_u *pat, size_t len, magic_T magic_val);
 #endif
 
-#ifdef FEAT_CMDWIN
-static int	open_cmdwin(void);
-
 static int	cedit_key = -1;	// key value of 'cedit' option
-#endif
-
 
     static void
 trigger_cmd_autocmd(int typechar, int evt)
@@ -1922,7 +1918,6 @@ getcmdline_int(
 					// cmdline_handle_backslash_key()
 	}
 
-#ifdef FEAT_CMDWIN
 	if (c == cedit_key || c == K_CMDWIN)
 	{
 	    // TODO: why is ex_normal_busy checked here?
@@ -1935,11 +1930,8 @@ getcmdline_int(
 		some_key_typed = TRUE;
 	    }
 	}
-# ifdef FEAT_DIGRAPHS
-	else
-# endif
-#endif
 #ifdef FEAT_DIGRAPHS
+	else
 	    c = do_digraph(c);
 #endif
 
@@ -2687,10 +2679,8 @@ check_opt_wim(void)
     int
 text_locked(void)
 {
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
 	return TRUE;
-#endif
     return textlock != 0;
 }
 
@@ -2707,10 +2697,8 @@ text_locked_msg(void)
     char *
 get_text_locked_msg(void)
 {
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
 	return e_invalid_in_cmdline_window;
-#endif
     return e_not_allowed_to_change_text_or_change_window;
 }
 
@@ -4080,7 +4068,6 @@ get_cmdline_info(void)
     return &ccline;
 }
 
-#if defined(FEAT_EVAL) || defined(FEAT_CMDWIN) || defined(PROTO)
 /*
  * Get pointer to the command line info to use. save_cmdline() may clear
  * ccline and put the previous value in prev_ccline.
@@ -4096,9 +4083,7 @@ get_ccline_ptr(void)
 	return &prev_ccline;
     return NULL;
 }
-#endif
 
-#if defined(FEAT_EVAL) || defined(FEAT_CMDWIN)
 /*
  * Get the current command-line type.
  * Returns ':' or '/' or '?' or '@' or '>' or '-'
@@ -4120,7 +4105,6 @@ get_cmdline_type(void)
 	    '-';
     return p->cmdfirstc;
 }
-#endif
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 /*
@@ -4365,7 +4349,6 @@ get_list_range(char_u **str, int *num1, int *num2)
     return OK;
 }
 
-#if defined(FEAT_CMDWIN) || defined(PROTO)
 /*
  * Check value of 'cedit' and set cedit_key.
  * Returns NULL if value is OK, error message otherwise.
@@ -4694,7 +4677,6 @@ is_in_cmdwin(void)
 {
     return cmdwin_type != 0 && get_cmdline_type() == NUL;
 }
-#endif // FEAT_CMDWIN
 
 /*
  * Used for commands that either take a simple command string argument, or:

--- a/src/feature.h
+++ b/src/feature.h
@@ -31,22 +31,21 @@
  * Basic choices:
  * ==============
  *
- * +tiny		almost no features enabled, not even multiple windows
- * +small		as tiny plus cmdline window
+ * +tiny		Identical to +small
+ * +small		Many features removed, including VimScript
  * +normal		A default selection of features enabled
  * +big			many features enabled, as rich as possible.
  * +huge		all possible features enabled.
  *
- * When +small is used, +tiny is also included.  +normal implies +small, etc.
+ * When +normal is used, +small is also included.  +huge implies +normal, etc.
  */
 
 /*
  * Uncomment one of these to override the default.  For unix use a configure
  * argument, see Makefile.
  */
-#if !defined(FEAT_TINY) && !defined(FEAT_SMALL) && !defined(FEAT_NORMAL) \
+#if !defined(FEAT_SMALL) && !defined(FEAT_NORMAL) \
 	&& !defined(FEAT_BIG) && !defined(FEAT_HUGE)
-// #define FEAT_TINY
 // #define FEAT_SMALL
 // #define FEAT_NORMAL
 // #define FEAT_BIG
@@ -59,7 +58,7 @@
  * Use +big for older systems: VMS and Amiga.
  * Otherwise use +normal
  */
-#if !defined(FEAT_TINY) && !defined(FEAT_SMALL) && !defined(FEAT_NORMAL) \
+#if !defined(FEAT_SMALL) && !defined(FEAT_NORMAL) \
 	&& !defined(FEAT_BIG) && !defined(FEAT_HUGE)
 # if defined(UNIX) || defined(MSWIN) || defined(MACOS_X)
 #  define FEAT_HUGE
@@ -83,9 +82,6 @@
 #endif
 #ifdef FEAT_NORMAL
 # define FEAT_SMALL
-#endif
-#ifdef FEAT_SMALL
-# define FEAT_TINY
 #endif
 
 /*
@@ -122,6 +118,7 @@
  * +wildmenu		'wildmenu' option
  * +builtin_terms	all builtin termcap entries included
  * +float		Floating point variables.
+ * +cmdwin		cmdline-window support.
  *
  * Obsolete:
  * +tag_old_static	Old style static tags: "file:tag  file  ..".
@@ -136,10 +133,6 @@
  * Message history is fixed at 200 messages.
  */
 #define MAX_MSG_HIST_LEN 200
-
-#if defined(FEAT_SMALL)
-# define FEAT_CMDWIN
-#endif
 
 /*
  * +folding		Fold lines.

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -3372,9 +3372,7 @@ vgetorpeek(int advance)
 
 		if (ex_normal_busy > 0)
 		{
-#ifdef FEAT_CMDWIN
 		    static int tc = 0;
-#endif
 
 		    // No typeahead left and inside ":normal".  Must return
 		    // something to avoid getting stuck.  When an incomplete
@@ -3397,17 +3395,11 @@ vgetorpeek(int advance)
 		    else if (terminal_is_active())
 			c = K_CANCEL;
 #endif
-		    else if ((State & MODE_CMDLINE)
-#ifdef FEAT_CMDWIN
-			    || (cmdwin_type > 0 && tc == ESC)
-#endif
-			    )
+		    else if ((State & MODE_CMDLINE) || (cmdwin_type > 0 && tc == ESC))
 			c = Ctrl_C;
 		    else
 			c = ESC;
-#ifdef FEAT_CMDWIN
 		    tc = c;
-#endif
 		    // set a flag to indicate this wasn't a normal char
 		    if (advance)
 			typebuf_was_empty = TRUE;

--- a/src/globals.h
+++ b/src/globals.h
@@ -1637,10 +1637,8 @@ EXTERN int	disable_fold_update INIT(= 0);
 EXTERN int	km_stopsel INIT(= FALSE);
 EXTERN int	km_startsel INIT(= FALSE);
 
-#ifdef FEAT_CMDWIN
 EXTERN int	cmdwin_type INIT(= 0);	// type of cmdline window or 0
 EXTERN int	cmdwin_result INIT(= 0); // result of cmdline window or 0
-#endif
 
 EXTERN char_u no_lines_msg[]	INIT(= N_("--No lines in buffer--"));
 
@@ -1974,10 +1972,8 @@ EXTERN int channel_need_redraw INIT(= FALSE);
 // overrules p_magic.  Otherwise set to OPTION_MAGIC_NOT_SET.
 EXTERN optmagic_T magic_overruled INIT(= OPTION_MAGIC_NOT_SET);
 
-#ifdef FEAT_CMDWIN
 // Skip win_fix_cursor() call for 'splitkeep' when cmdwin is closed.
 EXTERN int skip_win_fix_cursor INIT(= FALSE);
-#endif
 // Skip win_fix_scroll() call for 'splitkeep' when closing tab page.
 EXTERN int skip_win_fix_scroll INIT(= FALSE);
 // Skip update_topline() call while executing win_fix_scroll().

--- a/src/gui.c
+++ b/src/gui.c
@@ -3844,11 +3844,7 @@ send_tabline_event(int nr)
 	return FALSE;
 
     // Don't put events in the input queue now.
-    if (hold_gui_events
-# ifdef FEAT_CMDWIN
-	    || cmdwin_type != 0
-# endif
-	    )
+    if (hold_gui_events || cmdwin_type != 0)
     {
 	// Set it back to the current tab page.
 	gui_mch_set_curtab(tabpage_index(curtab));
@@ -3993,10 +3989,8 @@ gui_drag_scrollbar(scrollbar_T *sb, long value, int still_dragging)
     if (hold_gui_events)
 	return;
 
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0 && sb->wp != curwin)
 	return;
-#endif
 
     if (still_dragging)
     {

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3311,11 +3311,7 @@ on_tabline_menu(GtkWidget *widget, GdkEvent *event)
 
 	// When ignoring events return TRUE so that the selected page doesn't
 	// change.
-	if (hold_gui_events
-# ifdef FEAT_CMDWIN
-		|| cmdwin_type != 0
-# endif
-	   )
+	if (hold_gui_events || cmdwin_type != 0)
 	    return TRUE;
 
 	tabwin = gui_gtk_window_at_position(gui.mainwin, &x, &y);

--- a/src/gui_motif.c
+++ b/src/gui_motif.c
@@ -232,11 +232,7 @@ tabline_menu_cb(
 	return;
 
     // When ignoring events don't show the menu.
-    if (hold_gui_events
-# ifdef FEAT_CMDWIN
-	    || cmdwin_type != 0
-# endif
-       )
+    if (hold_gui_events || cmdwin_type != 0)
 	return;
 
     if (event->subwindow != None)

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -2609,11 +2609,7 @@ show_tabline_popup_menu(void)
     POINT	    pt;
 
     // When ignoring events don't show the menu.
-    if (hold_gui_events
-# ifdef FEAT_CMDWIN
-	    || cmdwin_type != 0
-# endif
-       )
+    if (hold_gui_events || cmdwin_type != 0)
 	return;
 
     tab_pmenu = CreatePopupMenu();

--- a/src/if_mzsch.c
+++ b/src/if_mzsch.c
@@ -17,7 +17,7 @@
  * 1. Memory, allocated with scheme_malloc*, need not to be freed explicitly,
  *    garbage collector will do it self
  * 2. Requires at least NORMAL features. I can't imagine why one may want
- *    to build with SMALL or TINY features but with MzScheme interface.
+ *    to build with SMALL features but with MzScheme interface.
  * 3. I don't use K&R-style functions. Anyways, MzScheme headers are ANSI.
  */
 

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2293,12 +2293,10 @@ ins_compl_stop(int c, int prev_mode, int retval)
 	showmode();
     }
 
-#ifdef FEAT_CMDWIN
     if (c == Ctrl_C && cmdwin_type != 0)
 	// Avoid the popup menu remains displayed when leaving the
 	// command line window.
 	update_screen(0);
-#endif
     // Indent now if a key was typed that is in 'cinkeys'.
     if (want_cindent && in_cinkeys(KEY_COMPLETE, ' ', inindent(0)))
 	do_c_expr_indent();

--- a/src/main.c
+++ b/src/main.c
@@ -1216,11 +1216,7 @@ main_loop(
 #endif
 
     clear_oparg(&oa);
-    while (!cmdwin
-#ifdef FEAT_CMDWIN
-	    || cmdwin_result == 0
-#endif
-	    )
+    while (!cmdwin || cmdwin_result == 0)
     {
 	if (stuff_empty())
 	{

--- a/src/map.c
+++ b/src/map.c
@@ -2811,8 +2811,6 @@ init_mappings(void)
 #endif
 }
 
-#if defined(MSWIN) || defined(FEAT_CMDWIN) || defined(MACOS_X) \
-							     || defined(PROTO)
 /*
  * Add a mapping "map" for mode "mode".
  * When "nore" is TRUE use MAPTYPE_NOREMAP.
@@ -2833,7 +2831,6 @@ add_map(char_u *map, int mode, int nore)
     }
     p_cpo = cpo_save;
 }
-#endif
 
 #if defined(FEAT_LANGMAP) || defined(PROTO)
 /*

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -488,12 +488,7 @@ do_mouse(
 	    }
 
 	    // click in a tab selects that tab page
-	    if (is_click
-# ifdef FEAT_CMDWIN
-		    && cmdwin_type == 0
-# endif
-		    && mouse_col < Columns)
-	    {
+	    if (is_click && cmdwin_type == 0 && mouse_col < Columns) {
 		in_tab_line = TRUE;
 		c1 = TabPageIdxs[mouse_col];
 		if (c1 >= 0)
@@ -745,7 +740,7 @@ do_mouse(
     }
 #endif
 
-#if defined(FEAT_CLIPBOARD) && defined(FEAT_CMDWIN)
+#if defined(FEAT_CLIPBOARD)
     if ((jump_flags & IN_OTHER_WIN) && !VIsual_active && clip_star.available)
     {
 	clip_modeless(which_button, is_click, is_drag);
@@ -1602,7 +1597,7 @@ retnomove:
 	    end_visual_mode_keep_button();
 	    redraw_curbuf_later(UPD_INVERTED);	// delete the inversion
 	}
-#if defined(FEAT_CMDWIN) && defined(FEAT_CLIPBOARD)
+#if defined(FEAT_CLIPBOARD)
 	// Continue a modeless selection in another window.
 	if (cmdwin_type != 0 && row < curwin->w_winrow)
 	    return IN_OTHER_WIN;
@@ -1732,10 +1727,7 @@ retnomove:
 # ifdef FEAT_RIGHTLEFT
 			    wp->w_p_rl ? col < wp->w_width - wp->w_p_fdc :
 # endif
-			    col >= wp->w_p_fdc
-# ifdef FEAT_CMDWIN
-				  + (cmdwin_type == 0 && wp == curwin ? 0 : 1)
-# endif
+			    col >= wp->w_p_fdc + (cmdwin_type == 0 && wp == curwin ? 0 : 1)
 			    )
 #endif
 			&& (flags & MOUSE_MAY_STOP_VIS))))
@@ -1743,7 +1735,6 @@ retnomove:
 	    end_visual_mode_keep_button();
 	    redraw_curbuf_later(UPD_INVERTED);	// delete the inversion
 	}
-#ifdef FEAT_CMDWIN
 	if (cmdwin_type != 0 && wp != curwin)
 	{
 	    // A click outside the command-line window: Use modeless
@@ -1759,7 +1750,6 @@ retnomove:
 	    wp = curwin;
 # endif
 	}
-#endif
 #if defined(FEAT_PROP_POPUP) && defined(FEAT_TERMINAL)
 	if (popup_is_popup(curwin) && curbuf->b_term != NULL)
 	    // terminal in popup window: don't jump to another window
@@ -1848,7 +1838,7 @@ retnomove:
 	    redraw_curbuf_later(UPD_INVERTED);	// delete the inversion
 	}
 
-#if defined(FEAT_CMDWIN) && defined(FEAT_CLIPBOARD)
+#if defined(FEAT_CLIPBOARD)
 	// Continue a modeless selection in another window.
 	if (cmdwin_type != 0 && row < curwin->w_winrow)
 	    return IN_OTHER_WIN;
@@ -1986,10 +1976,7 @@ retnomove:
 # ifdef FEAT_RIGHTLEFT
 	    curwin->w_p_rl ? col < curwin->w_width - curwin->w_p_fdc :
 # endif
-	    col >= curwin->w_p_fdc
-#  ifdef FEAT_CMDWIN
-				+ (cmdwin_type == 0 ? 0 : 1)
-#  endif
+	    col >= curwin->w_p_fdc + (cmdwin_type == 0 ? 0 : 1)
        )
 	mouse_char = ' ';
 #endif

--- a/src/move.c
+++ b/src/move.c
@@ -968,9 +968,7 @@ validate_cursor_col(void)
 win_col_off(win_T *wp)
 {
     return (((wp->w_p_nu || wp->w_p_rnu) ? number_width(wp) + 1 : 0)
-#ifdef FEAT_CMDWIN
 	    + (cmdwin_type == 0 || wp != curwin ? 0 : 1)
-#endif
 #ifdef FEAT_FOLDING
 	    + wp->w_p_fdc
 #endif

--- a/src/normal.c
+++ b/src/normal.c
@@ -4028,12 +4028,10 @@ nv_down(cmdarg_T *cap)
 #endif
     else
     {
-#ifdef FEAT_CMDWIN
 	// In the cmdline window a <CR> executes the command.
 	if (cmdwin_type != 0 && cap->cmdchar == CAR)
 	    cmdwin_result = CAR;
 	else
-#endif
 #ifdef FEAT_JOB_CHANNEL
 	// In a prompt buffer a <CR> in the last line invokes the callback.
 	if (bt_prompt(curbuf) && cap->cmdchar == CAR
@@ -6754,10 +6752,8 @@ nv_normal(cmdarg_T *cap)
 	if (restart_edit != 0 && mode_displayed)
 	    clear_cmdline = TRUE;		// unshow mode later
 	restart_edit = 0;
-#ifdef FEAT_CMDWIN
 	if (cmdwin_type != 0)
 	    cmdwin_result = Ctrl_C;
-#endif
 	if (VIsual_active)
 	{
 	    end_visual_mode();		// stop Visual
@@ -6788,12 +6784,7 @@ nv_esc(cmdarg_T *cap)
 
     if (cap->arg)		// TRUE for CTRL-C
     {
-	if (restart_edit == 0
-#ifdef FEAT_CMDWIN
-		&& cmdwin_type == 0
-#endif
-		&& !VIsual_active
-		&& no_reason)
+	if (restart_edit == 0 && cmdwin_type == 0 && !VIsual_active && no_reason)
 	{
 	    int	out_redir = !stdout_isatty && !is_not_a_term_or_gui();
 
@@ -6828,16 +6819,13 @@ nv_esc(cmdarg_T *cap)
 	// set again below when halfway a mapping.
 	if (!p_im)
 	    restart_edit = 0;
-#ifdef FEAT_CMDWIN
 	if (cmdwin_type != 0)
 	{
 	    cmdwin_result = K_IGNORE;
 	    got_int = FALSE;	// don't stop executing autocommands et al.
 	    return;
 	}
-#endif
     }
-#ifdef FEAT_CMDWIN
     else if (cmdwin_type != 0 && ex_normal_busy && typebuf_was_empty)
     {
 	// When :normal runs out of characters while in the command line window
@@ -6846,7 +6834,6 @@ nv_esc(cmdarg_T *cap)
 	cmdwin_result = K_IGNORE;
 	return;
     }
-#endif
 
     if (VIsual_active)
     {
@@ -7178,7 +7165,6 @@ nv_record(cmdarg_T *cap)
     }
     else if (!checkclearop(cap->oap))
     {
-#ifdef FEAT_CMDWIN
 	if (cap->nchar == ':' || cap->nchar == '/' || cap->nchar == '?')
 	{
 	    if (cmdwin_type != 0)
@@ -7190,7 +7176,6 @@ nv_record(cmdarg_T *cap)
 	    stuffcharReadbuff(K_CMDWIN);
 	}
 	else
-#endif
 	    // (stop) recording into a named register, unless executing a
 	    // register
 	    if (reg_executing == 0 && do_record(cap->nchar) == FAIL)

--- a/src/option.c
+++ b/src/option.c
@@ -2404,10 +2404,8 @@ didset_options(void)
     (void)compile_cap_prog(curwin->w_s);
     (void)did_set_spell_option(TRUE);
 #endif
-#ifdef FEAT_CMDWIN
     // set cedit_key
     (void)check_cedit();
-#endif
 #ifdef FEAT_LINEBREAK
     // initialize the table for 'breakat'.
     fill_breakat_flags();
@@ -3804,13 +3802,11 @@ set_num_option(
 	errmsg = e_argument_must_be_positive;
 	p_siso = 0;
     }
-#ifdef FEAT_CMDWIN
     if (p_cwh < 1)
     {
 	errmsg = e_argument_must_be_positive;
 	p_cwh = 1;
     }
-#endif
     if (p_ut < 0)
     {
 	errmsg = e_argument_must_be_positive;

--- a/src/option.h
+++ b/src/option.h
@@ -486,10 +486,8 @@ EXTERN char_u	*p_ccv;		// 'charconvert'
 #endif
 EXTERN int	p_cdh;		// 'cdhome'
 EXTERN char_u	*p_cino;	// 'cinoptions'
-#ifdef FEAT_CMDWIN
 EXTERN char_u	*p_cedit;	// 'cedit'
 EXTERN long	p_cwh;		// 'cmdwinheight'
-#endif
 #ifdef FEAT_CLIPBOARD
 EXTERN char_u	*p_cb;		// 'clipboard'
 #endif

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -544,13 +544,8 @@ static struct vimoption options[] =
 			    {(char_u *)",,", (char_u *)0L}
 			    SCTX_INIT},
     {"cedit",	    NULL,   P_STRING,
-#ifdef FEAT_CMDWIN
 			    (char_u *)&p_cedit, PV_NONE,
 			    {(char_u *)"", (char_u *)CTRL_F_STR}
-#else
-			    (char_u *)NULL, PV_NONE,
-			    {(char_u *)0L, (char_u *)0L}
-#endif
 			    SCTX_INIT},
     {"charconvert",  "ccv", P_STRING|P_VI_DEF|P_SECURE,
 #if defined(FEAT_EVAL)
@@ -597,11 +592,7 @@ static struct vimoption options[] =
 			    (char_u *)&p_ch, PV_NONE,
 			    {(char_u *)1L, (char_u *)0L} SCTX_INIT},
     {"cmdwinheight", "cwh", P_NUM|P_VI_DEF,
-#ifdef FEAT_CMDWIN
 			    (char_u *)&p_cwh, PV_NONE,
-#else
-			    (char_u *)NULL, PV_NONE,
-#endif
 			    {(char_u *)7L, (char_u *)0L} SCTX_INIT},
     {"colorcolumn", "cc",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP|P_RWIN,
 #ifdef FEAT_SYN_HL

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1326,13 +1326,11 @@ did_set_string_option(
 	errmsg = set_chars_option(curwin, varp, TRUE);
     }
 
-#ifdef FEAT_CMDWIN
     // 'cedit'
     else if (varp == &p_cedit)
     {
 	errmsg = check_cedit();
     }
-#endif
 
     // 'verbosefile'
     else if (varp == &p_vfile)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -445,13 +445,11 @@ term_start(
 
     if (check_restricted() || check_secure())
 	return NULL;
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
     {
 	emsg(_(e_cannot_open_terminal_from_command_line_window));
 	return NULL;
     }
-#endif
 
     if ((opt->jo_set & (JO_IN_IO + JO_OUT_IO + JO_ERR_IO))
 					 == (JO_IN_IO + JO_OUT_IO + JO_ERR_IO)

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -10,8 +10,8 @@ NO_INITS = -U NONE $(NO_PLUGINS)
 # File to delete when testing starts
 CLEANUP_FILES = test.log messages starttime
 
-# Tests for tiny and small builds.
-SCRIPTS_TINY = \
+# Tests for small builds.
+SCRIPTS_SMALL = \
 	test10 \
 	test20 \
 	test21 \
@@ -22,7 +22,7 @@ SCRIPTS_TINY = \
 	test26 \
 	test27
 
-SCRIPTS_TINY_OUT = \
+SCRIPTS_SMALL_OUT = \
 	test10.out \
 	test20.out \
 	test21.out \

--- a/src/testdir/Make_amiga.mak
+++ b/src/testdir/Make_amiga.mak
@@ -9,7 +9,7 @@ default: nongui
 
 include Make_all.mak
 
-SCRIPTS = $(SCRIPTS_TINY_OUT)
+SCRIPTS = $(SCRIPTS_SMALL_OUT)
 
 .SUFFIXES: .in .out .res .vim
 

--- a/src/testdir/Make_ming.mak
+++ b/src/testdir/Make_ming.mak
@@ -24,7 +24,7 @@ include Make_all.mak
 # Explicit dependencies.
 test_options.res test_alot.res: opt_test.vim
 
-TEST_OUTFILES = $(SCRIPTS_TINY_OUT)
+TEST_OUTFILES = $(SCRIPTS_SMALL_OUT)
 DOSTMP = dostmp
 # Keep $(DOSTMP)/*.in
 .PRECIOUS: $(patsubst %.out, $(DOSTMP)/%.in, $(TEST_OUTFILES))
@@ -34,11 +34,11 @@ DOSTMP = dostmp
 # Add --gui-dialog-file to avoid getting stuck in a dialog.
 COMMON_ARGS = $(NO_INITS) --gui-dialog-file guidialog
 
-nongui:	nolog tinytests newtests report
+nongui:	nolog smalltests newtests report
 
-gui:	nolog tinytests newtests report
+gui:	nolog smalltests newtests report
 
-tiny:	nolog tinytests report
+small:	nolog smalltests report
 
 benchmark: $(SCRIPTS_BENCH)
 
@@ -98,8 +98,8 @@ nolog:
 	-@if exist starttime $(DEL) starttime
 
 
-# Tiny tests.  Works even without the +eval feature.
-tinytests: $(SCRIPTS_TINY_OUT)
+# Small tests.  Works even without the +eval feature.
+smalltests: $(SCRIPTS_SMALL_OUT)
 
 # Copy the input files to dostmp, changing the fileformat to dos.
 $(DOSTMP)/%.in : %.in

--- a/src/testdir/Make_mvc.mak
+++ b/src/testdir/Make_mvc.mak
@@ -12,7 +12,7 @@ default: nongui
 # Explicit dependencies.
 test_options.res test_alot.res: opt_test.vim
 
-TEST_OUTFILES = $(SCRIPTS_TINY_OUT)
+TEST_OUTFILES = $(SCRIPTS_SMALL_OUT)
 DOSTMP = dostmp
 DOSTMP_OUTFILES = $(TEST_OUTFILES:test=dostmp\test)
 DOSTMP_INFILES = $(DOSTMP_OUTFILES:.out=.in)
@@ -22,11 +22,11 @@ DOSTMP_INFILES = $(DOSTMP_OUTFILES:.out=.in)
 # Add --gui-dialog-file to avoid getting stuck in a dialog.
 COMMON_ARGS = $(NO_INITS) --gui-dialog-file guidialog
 
-nongui:	nolog tinytests newtests report
+nongui:	nolog smalltests newtests report
 
-gui:	nolog tinytests newtests report
+gui:	nolog smalltests newtests report
 
-tiny:	nolog tinytests report
+small:	nolog smalltests report
 
 benchmark: $(SCRIPTS_BENCH)
 
@@ -86,8 +86,8 @@ nolog:
 	-if exist starttime del starttime
 
 
-# Tiny tests.  Works even without the +eval feature.
-tinytests: $(SCRIPTS_TINY_OUT)
+# Small tests.  Works even without the +eval feature.
+smalltests: $(SCRIPTS_SMALL_OUT)
 
 # Copy the input files to dostmp, changing the fileformat to dos.
 $(DOSTMP_INFILES): $(*B).in

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -26,7 +26,7 @@ REDIR_TEST_TO_NULL = --cmd 'au SwapExists * let v:swapchoice = "e"' | LC_ALL=C L
 default: nongui
 
 # The list of tests is common to all systems.
-# This defines SCRIPTS_TINY_OUT, NEW_TESTS and NEW_TESTS_RES.
+# This defines SCRIPTS_SMALL_OUT, NEW_TESTS and NEW_TESTS_RES.
 include Make_all.mak
 
 # Explicit dependencies.
@@ -34,11 +34,11 @@ test_options.res test_alot.res: opt_test.vim
 
 .SUFFIXES: .in .out .res .vim
 
-nongui:	nolog tinytests newtests report
+nongui:	nolog smalltests newtests report
 
-gui:	nolog tinytests newtests report
+gui:	nolog smalltests newtests report
 
-tiny:	nolog tinytests report
+small:	nolog smalltests report
 
 benchmark: $(SCRIPTS_BENCH)
 
@@ -58,7 +58,7 @@ report:
 		else echo ALL DONE; \
 		fi"
 
-$(SCRIPTS_TINY_OUT) $(NEW_TESTS_RES): $(VIMPROG)
+$(SCRIPTS_SMALL_OUT) $(NEW_TESTS_RES): $(VIMPROG)
 
 
 # Execute an individual new style test, e.g.:
@@ -104,8 +104,8 @@ nolog:
 	-rm -f test_result.log $(CLEANUP_FILES)
 
 
-# Tiny tests.  Works even without the +eval feature.
-tinytests: $(SCRIPTS_TINY_OUT)
+# Small tests.  Works even without the +eval feature.
+smalltests: $(SCRIPTS_SMALL_OUT)
 
 .in.out:
 	-rm -rf $*.failed test.ok $(RM_ON_RUN)

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -794,10 +794,8 @@ comp_textwidth(
 	// The width is the window width minus 'wrapmargin' minus all the
 	// things that add to the margin.
 	textwidth = curwin->w_width - curbuf->b_p_wm;
-#ifdef FEAT_CMDWIN
 	if (cmdwin_type != 0)
 	    textwidth -= 1;
-#endif
 #ifdef FEAT_FOLDING
 	textwidth -= curwin->w_p_fdc;
 #endif

--- a/src/version.c
+++ b/src/version.c
@@ -2327,10 +2327,8 @@ list_version(void)
     msg_puts(_("\nBig version "));
 #elif defined(FEAT_NORMAL)
     msg_puts(_("\nNormal version "));
-#elif defined(FEAT_SMALL)
-    msg_puts(_("\nSmall version "));
 #else
-    msg_puts(_("\nTiny version "));
+    msg_puts(_("\nSmall version "));
 #endif
 #if !defined(FEAT_GUI)
     msg_puts(_("without GUI."));

--- a/src/vim.h
+++ b/src/vim.h
@@ -159,7 +159,7 @@
 
 /*
  * #defines for optionals and features
- * Also defines FEAT_TINY, FEAT_SMALL, etc. when FEAT_HUGE is defined.
+ * Also defines FEAT_SMALL, etc. when FEAT_HUGE is defined.
  */
 #include "feature.h"
 

--- a/src/window.c
+++ b/src/window.c
@@ -119,12 +119,8 @@ log_frame_layout(frame_T *frame)
     win_T *
 prevwin_curwin(void)
 {
-    return
-#ifdef FEAT_CMDWIN
-	// In cmdwin, the alternative buffer should be used.
-	is_in_cmdwin() && prevwin != NULL ? prevwin :
-#endif
-	curwin;
+    // In cmdwin, the alternative buffer should be used.
+    return is_in_cmdwin() && prevwin != NULL ? prevwin : curwin;
 }
 
 /*
@@ -149,8 +145,7 @@ do_window(
     if (ERROR_IF_ANY_POPUP_WINDOW)
 	return;
 
-#ifdef FEAT_CMDWIN
-# define CHECK_CMDWIN \
+#define CHECK_CMDWIN \
     do { \
 	if (cmdwin_type != 0) \
 	{ \
@@ -158,9 +153,6 @@ do_window(
 	    return; \
 	} \
     } while (0)
-#else
-# define CHECK_CMDWIN do { /**/ } while (0)
-#endif
 
     Prenum1 = Prenum == 0 ? 1 : Prenum;
 
@@ -2963,10 +2955,9 @@ win_free_all(void)
 {
     int		dummy;
 
-#ifdef FEAT_CMDWIN
     // avoid an error for switching tabpage with the cmdline window open
     cmdwin_type = 0;
-#endif
+
     while (first_tabpage->tp_next != NULL)
 	tabpage_close(TRUE);
 
@@ -4019,13 +4010,11 @@ win_new_tabpage(int after)
     tabpage_T	*newtp;
     int		n;
 
-#ifdef FEAT_CMDWIN
     if (cmdwin_type != 0)
     {
 	emsg(_(e_invalid_in_cmdline_window));
 	return FAIL;
     }
-#endif
 
     newtp = alloc_tabpage();
     if (newtp == NULL)
@@ -5513,7 +5502,6 @@ shell_new_columns(void)
 #endif
 }
 
-#if defined(FEAT_CMDWIN) || defined(PROTO)
 /*
  * Save the size of all windows in "gap".
  */
@@ -5567,7 +5555,6 @@ win_size_restore(garray_T *gap)
 	(void)win_comp_pos();
     }
 }
-#endif // FEAT_CMDWIN
 
 /*
  * Update the position for all windows, using the width and height of the
@@ -6419,10 +6406,9 @@ win_fix_cursor(int normal)
 
     if (wp->w_buffer->b_ml.ml_line_count < wp->w_height)
 	return;
-#ifdef FEAT_CMDWIN
     if (skip_win_fix_cursor)
 	return;
-#endif
+
     // Determine valid cursor range.
     so = MIN(wp->w_height / 2, so);
     wp->w_cursor.lnum = wp->w_topline;


### PR DESCRIPTION
FEAT_CMDWIN is the only difference between the "tiny" and "small" versions, and the difference in generated code is very small (4 to 8K, depending on compile flags):j

	      | -O2                         | -Os
	tiny  | 1633984 (1.6M)              | 1190576 (1.2M)
	small | 1638240 (1.6M), +4256 bytes | 1198928 (1.2M), +8352 bytes

Even on very small and constrained systems this increase is negligible, and there are quite a few #ifdefs that can be removed.

Since the 'tiny' and 'small' builds are now identical this removes the 'tiny' build altogether, but make --with-features=tiny behave like 'small' was given for compatibility so no one's build should break.