### PR TITLE
Add sound support for macOS

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -8630,6 +8630,9 @@ sound_playevent({name} [, {callback}])
 <		On MS-Windows, {name} can be SystemAsterisk, SystemDefault,
 		SystemExclamation, SystemExit, SystemHand, SystemQuestion,
 		SystemStart, SystemWelcome, etc.
+		On macOS, {name} refers to files located in
+		/System/Library/Sounds (e.g. "Tink").  It will also work for
+		custom installed sounds in folders like ~/Library/Sounds.
 
 		When {callback} is specified it is invoked when the sound is
 		finished.  The first argument is the sound ID, the second

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -450,8 +450,6 @@ find them. (Max Kukartsev, #6218)
 
 Enable 'termbidi' if $VTE_VERSION >= 5703 ?
 
-Sound: support on Mac?  Or does libcanberra work there?
-
 Python 3.8 doesn't work. (Antonios Hadjigeorgalis, #5509)
 
 "--cleanFOO" does not result in an error. (#5537)

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4553,7 +4553,7 @@ if test "$MACOS_X" = "yes"; then
   AC_MSG_CHECKING([whether we need macOS frameworks])
   if test "$MACOS_X_DARWIN" = "yes"; then
     if test "$features" = "tiny"; then
-      dnl Since no FEAT_CLIPBOARD, no longer need for os_macosx.m.
+      dnl Since no FEAT_CLIPBOARD or FEAT_SOUND, no longer need for os_macosx.m.
       OS_EXTRA_SRC=`echo "$OS_EXTRA_SRC" | sed -e 's+os_macosx.m++'`
       OS_EXTRA_OBJ=`echo "$OS_EXTRA_OBJ" | sed -e 's+objects/os_macosx.o++'`
       AC_MSG_RESULT([yes, we need CoreServices])

--- a/src/feature.h
+++ b/src/feature.h
@@ -484,7 +484,7 @@
 #endif
 
 /*
- * sound - currently only with libcanberra
+ * sound
  */
 #if !defined(FEAT_SOUND) && defined(HAVE_CANBERRA)
 # define FEAT_SOUND

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2326,6 +2326,10 @@ parse_queued_messages(void)
 # ifdef FEAT_TERMINAL
 	free_unused_terminals();
 # endif
+
+# ifdef FEAT_SOUND_MACOSX
+	process_cfrunloop();
+# endif
 # ifdef FEAT_SOUND_CANBERRA
 	if (has_sound_callback_in_queue())
 	    invoke_sound_callback();

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -6125,6 +6125,10 @@ WaitForCharOrMouse(long msec, int *interrupted, int ignore_input)
 		rest -= msec;
 	}
 # endif
+# ifdef FEAT_SOUND_MACOSX
+	// Invoke any pending sound callbacks.
+	process_cfrunloop();
+# endif
 # ifdef FEAT_SOUND_CANBERRA
 	// Invoke any pending sound callbacks.
 	if (has_sound_callback_in_queue())

--- a/src/proto.h
+++ b/src/proto.h
@@ -327,6 +327,9 @@ extern char_u *vimpty_getenv(const char_u *string);	// in misc2.c
 # ifdef MACOS_CONVERT
 #  include "os_mac_conv.pro"
 # endif
+# ifdef MACOS_X
+#  include "os_macosx.pro"
+# endif
 # if defined(MACOS_X_DARWIN) && defined(FEAT_CLIPBOARD) && !defined(FEAT_GUI)
 // functions in os_macosx.m
 void clip_mch_lose_selection(Clipboard_T *cbd);

--- a/src/proto/os_macosx.pro
+++ b/src/proto/os_macosx.pro
@@ -1,0 +1,7 @@
+/* os_macosx.m */
+void process_cfrunloop();
+bool sound_mch_play(const char_u* event, long sound_id, soundcb_T *callback, bool playfile);
+void sound_mch_stop(long sound_id);
+void sound_mch_clear();
+void sound_mch_free();
+/* vim: set ft=c : */

--- a/src/proto/sound.pro
+++ b/src/proto/sound.pro
@@ -1,6 +1,10 @@
 /* sound.c */
+typedef struct soundcb_S soundcb_T;
+
 int has_any_sound_callback(void);
 int has_sound_callback_in_queue(void);
+void call_sound_callback(soundcb_T *soundcb, long sound_id, int result);
+void delete_sound_callback(soundcb_T *soundcb);
 void invoke_sound_callback(void);
 void f_sound_playevent(typval_T *argvars, typval_T *rettv);
 void f_sound_playfile(typval_T *argvars, typval_T *rettv);

--- a/src/sound.c
+++ b/src/sound.c
@@ -65,9 +65,28 @@ get_sound_callback(typval_T *arg)
 }
 
 /*
+ * Call "soundcb" with proper parameters.
+ */
+    void
+call_sound_callback(soundcb_T *soundcb, long snd_id, int result)
+{
+    typval_T	argv[3];
+    typval_T	rettv;
+
+    argv[0].v_type = VAR_NUMBER;
+    argv[0].vval.v_number = snd_id;
+    argv[1].v_type = VAR_NUMBER;
+    argv[1].vval.v_number = result;
+    argv[2].v_type = VAR_UNKNOWN;
+
+    call_callback(&soundcb->snd_callback, -1, &rettv, 2, argv);
+    clear_tv(&rettv);
+}
+
+/*
  * Delete "soundcb" from the list of pending callbacks.
  */
-    static void
+    void
 delete_sound_callback(soundcb_T *soundcb)
 {
     soundcb_T	*p;
@@ -89,7 +108,7 @@ delete_sound_callback(soundcb_T *soundcb)
 #if defined(HAVE_CANBERRA) || defined(PROTO)
 
 /*
- * Sound implementation for Linux/Unix/Mac using libcanberra.
+ * Sound implementation for Linux/Unix using libcanberra.
  */
 # include <canberra.h>
 
@@ -152,23 +171,13 @@ has_sound_callback_in_queue(void)
 invoke_sound_callback(void)
 {
     soundcb_queue_T *scb;
-    typval_T	    argv[3];
-    typval_T	    rettv;
-
 
     while (callback_queue != NULL)
     {
 	scb = callback_queue;
 	callback_queue = scb->scb_next;
 
-	argv[0].v_type = VAR_NUMBER;
-	argv[0].vval.v_number = scb->scb_id;
-	argv[1].v_type = VAR_NUMBER;
-	argv[1].vval.v_number = scb->scb_result;
-	argv[2].v_type = VAR_UNKNOWN;
-
-	call_callback(&scb->scb_callback->snd_callback, -1, &rettv, 2, argv);
-	clear_tv(&rettv);
+	call_sound_callback(scb->scb_callback, scb->scb_id, scb->scb_result);
 
 	delete_sound_callback(scb->scb_callback);
 	vim_free(scb);
@@ -307,24 +316,15 @@ sound_wndproc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 	    for (p = first_callback; p != NULL; p = p->snd_next)
 		if (p->snd_device_id == (MCIDEVICEID) lParam)
 		{
-		    typval_T	argv[3];
-		    typval_T	rettv;
 		    char	buf[32];
 
 		    vim_snprintf(buf, sizeof(buf), "close sound%06ld",
 								p->snd_id);
 		    mciSendString(buf, NULL, 0, 0);
 
-		    argv[0].v_type = VAR_NUMBER;
-		    argv[0].vval.v_number = p->snd_id;
-		    argv[1].v_type = VAR_NUMBER;
-		    argv[1].vval.v_number =
-					wParam == MCI_NOTIFY_SUCCESSFUL ? 0
-				      : wParam == MCI_NOTIFY_ABORTED ? 1 : 2;
-		    argv[2].v_type = VAR_UNKNOWN;
-
-		    call_callback(&p->snd_callback, -1, &rettv, 2, argv);
-		    clear_tv(&rettv);
+		    long result =   wParam == MCI_NOTIFY_SUCCESSFUL ? 0
+				  : wParam == MCI_NOTIFY_ABORTED ? 1 : 2;
+		    call_sound_callback(p, p->snd_id, result);
 
 		    delete_sound_callback(p);
 		    redraw_after_callback(TRUE, FALSE);
@@ -459,6 +459,64 @@ sound_free(void)
 }
 # endif
 
-#endif // MSWIN
+#elif defined(MACOS_X_DARWIN)
+
+// Sound implementation for macOS.
+    static void
+sound_play_common(typval_T *argvars, typval_T *rettv, bool playfile)
+{
+    if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
+	return;
+
+    char_u *sound_name = tv_get_string(&argvars[0]);
+    soundcb_T *soundcb = get_sound_callback(&argvars[1]);
+
+    ++sound_id;
+
+    bool play_success = sound_mch_play(sound_name, sound_id, soundcb, playfile);
+    if (!play_success && soundcb)
+    {
+	delete_sound_callback(soundcb);
+    }
+    rettv->vval.v_number = play_success ? sound_id : 0;
+}
+
+    void
+f_sound_playevent(typval_T *argvars, typval_T *rettv)
+{
+    sound_play_common(argvars, rettv, false);
+}
+
+    void
+f_sound_playfile(typval_T *argvars, typval_T *rettv)
+{
+    sound_play_common(argvars, rettv, true);
+}
+
+    void
+f_sound_stop(typval_T *argvars, typval_T *rettv UNUSED)
+{
+    if (in_vim9script() && check_for_number_arg(argvars, 0) == FAIL)
+	return;
+    sound_mch_stop(tv_get_number(&argvars[0]));
+}
+
+    void
+f_sound_clear(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
+{
+    sound_mch_clear();
+}
+
+#if defined(EXITFREE) || defined(PROTO)
+    void
+sound_free(void)
+{
+    sound_mch_free();
+    while (first_callback != NULL)
+	delete_sound_callback(first_callback);
+}
+#endif
+
+#endif // MACOS_X_DARWIN
 
 #endif  // FEAT_SOUND

--- a/src/testdir/test_sound.vim
+++ b/src/testdir/test_sound.vim
@@ -17,7 +17,11 @@ func Test_play_event()
   endif
   let g:playcallback_count = 0
   let g:id = 0
-  let id = 'bell'->sound_playevent('PlayCallback')
+  let event_name = 'bell'
+  if has('osx')
+      let event_name = 'Tink'
+  endif
+  let id = event_name->sound_playevent('PlayCallback')
   if id == 0
     throw 'Skipped: bell event not available'
   endif

--- a/src/ui.c
+++ b/src/ui.c
@@ -460,7 +460,7 @@ ui_wait_for_chars_or_timer(
 	}
 	if (due_time <= 0 || (wtime > 0 && due_time > remaining))
 	    due_time = remaining;
-# if defined(FEAT_JOB_CHANNEL) || defined(FEAT_SOUND_CANBERRA)
+# if defined(FEAT_JOB_CHANNEL) || defined(FEAT_SOUND_CANBERRA) || defined(FEAT_SOUND_MACOSX)
 	if ((due_time < 0 || due_time > 10L) && (
 #  if defined(FEAT_JOB_CHANNEL)
 		(
@@ -468,11 +468,11 @@ ui_wait_for_chars_or_timer(
 		!gui.in_use &&
 #   endif
 		(has_pending_job() || channel_any_readahead()))
-#   ifdef FEAT_SOUND_CANBERRA
+#   if defined(FEAT_SOUND_CANBERRA) || defined(FEAT_SOUND_MACOSX)
 		||
 #   endif
 #  endif
-#  ifdef FEAT_SOUND_CANBERRA
+#  if defined(FEAT_SOUND_CANBERRA) ||  defined(FEAT_SOUND_MACOSX)
 		    has_any_sound_callback()
 #  endif
 		    ))

--- a/src/vim.h
+++ b/src/vim.h
@@ -163,9 +163,16 @@
  */
 #include "feature.h"
 
-#if defined(MACOS_X_DARWIN) && defined(FEAT_NORMAL) \
-	&& !defined(FEAT_CLIPBOARD)
-# define FEAT_CLIPBOARD
+#if defined(MACOS_X_DARWIN)
+# if defined(FEAT_NORMAL) && !defined(FEAT_CLIPBOARD)
+#  define FEAT_CLIPBOARD
+# endif
+# if defined(FEAT_BIG) && !defined(FEAT_SOUND)
+#  define FEAT_SOUND
+# endif
+# if defined(FEAT_SOUND)
+#  define FEAT_SOUND_MACOSX
+# endif
 #endif
 
 // +x11 is only enabled when it's both available and wanted.


### PR DESCRIPTION
This finally adds +sound support for Vim on macOS. In macOS, there are *quite* a few audio libraries to choose from. In the end, I decided to go with AppKit which is the user-level library which we already use for interfacing with the system clipboard. That's because the NSSound class from it is the easiest to use and essentially plug-and-play (with the caveat of needing a run loop as described below). Other libraries like CoreAudio are much too powerful and overkill for Vim's use case of just needing to play a file and be done with it, and they also involve a bit more code to set up and use.

One caveat of using NSSound is that it's an Objective C class so I had to do the implementation in os_macosx.m, and call that to/from sound.c. In order for the sound callback to work, I also had to set up a run loop that's ticked periodically in order to make sure the delegate will get invoked whenever the sound finishes playing. The run loop is ticked the same time as when we would have called `invoke_sound_callback()` in the Linux / Canberra implementation.

For sound event names, I'm using the builtin NSSound's `soundNamed` function which can locate the set of default installed sound files (e.g. "Tink", "Sosumi", "Submarine", "Bottle", etc). I was looking up how to get the more specific sounds (e.g. the "empty trash can" sound), and I think NSSound doesn't know how to load them (I think Core Audio has functions to load them but I don't think that's worth the trouble of using Core Audio). Looking up from
https://macreports.com/how-to-change-system-sounds-empty-trash-screenshot-sent-message-etc-on-mac/, it seems like those files can be located under
`/System/Library/Components/CoreAudio.component/Contents/SharedSupport/SystemSounds/`, but I didn't feel like adding special code to map those files to event names. Interested plugin authors or users can simply hard-code those path names on macOS.