### PR TITLE
Alias 'big' version to 'normal'

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -332,8 +332,8 @@ g8			Print the hex values of the bytes used in the
 							*+feature-list*
    *+acl*		|ACL| support included
    *+ARP*		Amiga only: ARP support included
-B  *+arabic*		|Arabic| language support
-B  *+autochdir*		support 'autochdir' option
+N  *+arabic*		|Arabic| language support
+N  *+autochdir*		support 'autochdir' option
 T  *+autocmd*		|:autocmd|, automatic commands.  Always enabled since
 			8.0.1564
 H  *+autoservername*	Automatically enable |clientserver|
@@ -358,9 +358,9 @@ T  *+cmdline_hist*	command line history |cmdline-history|
 N  *+cmdline_info*	|'showcmd'| and |'ruler'|
 T  *+cmdwin*		|cmdline-window| support; Always enabled since 9.0.0657
 T  *+comments*		|'comments'| support
-B  *+conceal*		"conceal" support, see |conceal| |:syn-conceal| etc.
+N  *+conceal*		"conceal" support, see |conceal| |:syn-conceal| etc.
 N  *+cryptv*		encryption support |encryption|
-B  *+cscope*		|cscope| support
+N  *+cscope*		|cscope| support
 T  *+cursorbind*	|'cursorbind'| support
 m  *+cursorshape*	|termcap-cursor-shape| support
 m  *+debug*		Compiled for debugging.
@@ -371,7 +371,7 @@ N  *+diff*		|vimdiff| and 'diff'
 N  *+digraphs*		|digraphs| *E196*
    *+directx*		Win32 GUI only: DirectX and |'renderoptions'|
    *+dnd*		Support for DnD into the "~ register |quote_~|.
-B  *+emacs_tags*	|emacs-tags| files
+N  *+emacs_tags*	|emacs-tags| files
 N  *+eval*		expression evaluation |eval.txt|
 T  *+ex_extra*		always on now, used to be for Vim's extra Ex commands
 N  *+extra_search*	|'hlsearch'| and |'incsearch'| options.
@@ -397,9 +397,9 @@ T  *+insert_expand*	|insert_expand| Insert mode completion
 m  *+ipv6*		Support for IPv6 networking |channel|
 m  *+job*		starting and stopping jobs |job|
 T  *+jumplist*		|jumplist|; Always enabled since 8.2.3795
-B  *+keymap*		|'keymap'|
+N  *+keymap*		|'keymap'|
 N  *+lambda*		|lambda| and |closure|
-B  *+langmap*		|'langmap'|
+N  *+langmap*		|'langmap'|
 N  *+libcall*		|libcall()|
 N  *+linebreak*		|'linebreak'|, |'breakat'| and |'showbreak'|
 t  *+lispindent*	|'lisp'|
@@ -413,16 +413,16 @@ N  *+mksession*		|:mksession|
 T  *+modify_fname*	|filename-modifiers|
 T  *+mouse*		Mouse handling |mouse-using|
 N  *+mouseshape*	|'mouseshape'|
-B  *+mouse_dec*		Unix only: Dec terminal mouse handling |dec-mouse|
+N  *+mouse_dec*		Unix only: Dec terminal mouse handling |dec-mouse|
 N  *+mouse_gpm*		Unix only: Linux console mouse handling |gpm-mouse|
 m  *+mouse_gpm/dyn*	Same as |+mouse_gpm| with optional library dependency
 			|/dyn|
 N  *+mouse_jsbterm*	JSB mouse handling |jsbterm-mouse|
-B  *+mouse_netterm*	Unix only: netterm mouse handling |netterm-mouse|
+N  *+mouse_netterm*	Unix only: netterm mouse handling |netterm-mouse|
 N  *+mouse_pterm*	QNX only: pterm mouse handling |qnx-terminal|
 N  *+mouse_sysmouse*	Unix only: *BSD console mouse handling |sysmouse|
-B  *+mouse_sgr*		Unix only: sgr mouse handling |sgr-mouse|
-B  *+mouse_urxvt*	Unix only: urxvt mouse handling |urxvt-mouse|
+N  *+mouse_sgr*		Unix only: sgr mouse handling |sgr-mouse|
+N  *+mouse_urxvt*	Unix only: urxvt mouse handling |urxvt-mouse|
 N  *+mouse_xterm*	Unix only: xterm mouse handling |xterm-mouse|
 T  *+multi_byte*	Unicode support, 16 and 32 bit characters |multibyte|
    *+multi_byte_ime*	Win32 input method for multibyte chars |multibyte-ime|
@@ -451,14 +451,14 @@ m  *+python3/dyn*	Python 3 interface |python-dynamic| |/dyn|
 N  *+quickfix*		|:make| and |quickfix| commands
 N  *+reltime*		|reltime()| function, 'hlsearch'/'incsearch' timeout,
 			'redrawtime' option
-B  *+rightleft*		Right to left typing |'rightleft'|
+N  *+rightleft*		Right to left typing |'rightleft'|
 m  *+ruby*		Ruby interface |ruby|
 m  *+ruby/dyn*		Ruby interface |ruby-dynamic| |/dyn|
 T  *+scrollbind*	|'scrollbind'|
-B  *+signs*		|:sign|
-t  *+smartindent*	|'smartindent'|
-B  *+sodium*		compiled with libsodium for better encryption support
-B  *+sound*		|sound_playevent()|, |sound_playfile()| functions, etc.
+N  *+signs*		|:sign|
+T  *+smartindent*	|'smartindent'|
+N  *+sodium*		compiled with libsodium for better encryption support
+N  *+sound*		|sound_playevent()|, |sound_playfile()| functions, etc.
 N  *+spell*		spell checking support, see |spell|
 N  *+startuptime*	|--startuptime| argument
 N  *+statusline*	Options 'statusline', 'rulerformat' and special
@@ -474,7 +474,7 @@ m  *+tcl/dyn*		Tcl interface |tcl-dynamic| |/dyn|
 m  *+terminal*		Support for terminal window |terminal|
    *+terminfo*		uses |terminfo| instead of termcap
 N  *+termresponse*	support for |t_RV| and |v:termresponse|
-B  *+termguicolors*	24-bit color in xterm-compatible terminals support
+N  *+termguicolors*	24-bit color in xterm-compatible terminals support
 T  *+textobjects*	|text-objects| selection. Always enabled since 9.0.0222.
 N  *+textprop*		|text-properties|
    *+tgetent*		non-Unix only: able to use external termcap
@@ -483,7 +483,7 @@ T  *+title*		Setting the window 'title' and 'icon'; Always enabled
 N  *+toolbar*		|gui-toolbar|
 T  *+user_commands*	User-defined commands. |user-commands|
 			Always enabled since 8.1.1210.
-B  *+vartabs*		Variable-width tabstops. |'vartabstop'|
+N  *+vartabs*		Variable-width tabstops. |'vartabstop'|
 T  *+vertsplit*		Vertically split windows |:vsplit|; Always enabled
 			since 8.0.1118.
 T  *+vim9script*	|Vim9| script

--- a/src/INSTALL
+++ b/src/INSTALL
@@ -182,9 +182,7 @@ Unix: COMPILING WITH MULTI-BYTE
 
 When you want to compile with the multi-byte features enabled, make sure you
 compile on a machine where the locale settings actually work, otherwise the
-configure tests may fail.  You need to compile with "big" features:
-
-    ./configure --with-features=big
+configure tests may fail.
 
 Unix: COMPILING ON LINUX
 

--- a/src/INSTALLvms.txt
+++ b/src/INSTALLvms.txt
@@ -79,11 +79,9 @@ from CVS mirror ftp://ftp.polarhome.com/pub/cvs/SOURCE/
 	Description	: Build model selection
 	Options:	: TINY	  - No optional features enabled
 			  NORMAL  - A default selection of features enabled
-			  BIG	  - Many features enabled, as rich as possible.
-			  (OpenVMS default)
 			  HUGE	  - All possible features enabled.
-			  Uncommented - will default to BIG
-	Default		: MODEL = BIG
+			  Uncommented - will default to NORMAL
+	Default		: MODEL = NORMAL
 
 	Parameter name	: GUI
 	Description	: GUI or terminal mode executable

--- a/src/Make_ami.mak
+++ b/src/Make_ami.mak
@@ -29,14 +29,6 @@ CFLAGS += \
 	-DFEAT_HUGE
 else
 
-# Vim 'big' build
-ifeq ($(BUILD),big)
-CFLAGS += \
-	-DFEAT_BROWSE \
-	-DFEAT_MOUSE \
-	-DFEAT_BIG
-else
-
 # Vim 'normal' build
 ifeq ($(BUILD),normal)
 CFLAGS +=\

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -28,7 +28,7 @@
 # Updated 2014 Oct 13.
 
 #>>>>> choose options:
-# FEATURES=[TINY | NORMAL | BIG | HUGE]
+# FEATURES=[TINY | NORMAL | HUGE]
 # Set to TINY to make a minimal version (no optional features).
 FEATURES=HUGE
 
@@ -113,7 +113,7 @@ TERMINAL=no
 endif
 
 # Set to yes to enable sound support.
-ifneq ($(findstring $(FEATURES),BIG HUGE),)
+ifneq ($(findstring $(FEATURES),NORMAL HUGE),)
 SOUND=yes
 else
 SOUND=no

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -16,7 +16,7 @@
 #
 #	!!!!  After changing any features do "nmake clean" first  !!!!
 #
-#	Feature Set: FEATURES=[TINY, NORMAL, BIG, HUGE] (default is HUGE)
+#	Feature Set: FEATURES=[TINY, NORMAL, HUGE] (default is HUGE)
 #
 #   	Name to add to the version: MODIFIED_BY=[name of modifier]
 #
@@ -354,7 +354,7 @@ TERM_DEPS = \
 !endif
 
 !ifndef SOUND
-! if "$(FEATURES)"=="HUGE" || "$(FEATURES)"=="BIG"
+! if "$(FEATURES)"=="HUGE" || "$(FEATURES)"=="NORMAL"
 SOUND = yes
 ! else
 SOUND = no
@@ -1124,7 +1124,7 @@ CFLAGS = $(CFLAGS) -DMSWINPS
 !endif # POSTSCRIPT
 
 #
-# FEATURES: TINY, NORMAL, BIG or HUGE
+# FEATURES: TINY, NORMAL, or HUGE
 #
 CFLAGS = $(CFLAGS) -DFEAT_$(FEATURES)
 

--- a/src/Make_vms.mms
+++ b/src/Make_vms.mms
@@ -29,7 +29,6 @@ DECC = YES
 # Build model selection
 # TINY   - No optional features enabled
 # NORMAL - A default selection of features enabled
-# BIG    - Many features enabled, as rich as possible. (default)
 # HUGE   - All possible features enabled.
 # Please select one of these alternatives above.
 MODEL = HUGE

--- a/src/Makefile
+++ b/src/Makefile
@@ -482,7 +482,7 @@ CClink = $(CC)
 # MULTIBYTE - To edit multi-byte characters.
 # This is now always enabled.
 
-# When building with at least "big" features, right-left and Arabic
+# When building with at least "normal" features, right-left and Arabic
 # features are enabled.  Use this to disable them.
 #CONF_OPT_MULTIBYTE = --disable-rightleft --disable-arabic
 
@@ -518,7 +518,7 @@ CClink = $(CC)
 # though you have /dev/sysmouse and includes.
 #CONF_OPT_SYSMOUSE = --disable-sysmouse
 
-# libcanberra - For sound support.  Default is on for big features.
+# libcanberra - For sound support.  Default is on for normal features.
 # Uncomment one of the two to chose otherwise.
 # CONF_OPT_CANBERRA = --enable-canberra
 # CONF_OPT_CANBERRA = --disable-canberra
@@ -532,7 +532,6 @@ CClink = $(CC)
 # The default is "huge" for most systems.
 #CONF_OPT_FEAT = --with-features=tiny
 #CONF_OPT_FEAT = --with-features=normal
-#CONF_OPT_FEAT = --with-features=big
 #CONF_OPT_FEAT = --with-features=huge
 
 # COMPILED BY - For including a specific e-mail address for ":version".

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -1523,7 +1523,7 @@ Optional Packages:
   --with-view-name=NAME   what to call the View executable
   --with-global-runtime=DIR    global runtime directory in 'runtimepath', comma-separated for multiple directories
   --with-modified-by=NAME       name of who modified a release version
-  --with-features=TYPE    tiny, normal, big or huge (default: huge)
+  --with-features=TYPE    tiny, normal, or huge (default: huge)
   --with-compiledby=NAME  name to show in :version message
   --with-lua-prefix=PFX   Prefix where Lua is installed.
   --with-luajit           Link with LuaJIT instead of Lua.
@@ -5220,7 +5220,8 @@ fi
 
 
 case "$features" in
-  small) features="tiny" ;;
+  small) features="tiny"   ;;
+  big)   features="normal" ;;
 esac
 
 dovimdiff=""
@@ -5229,9 +5230,6 @@ case "$features" in
   tiny)		$as_echo "#define FEAT_TINY 1" >>confdefs.h
  ;;
   normal)	$as_echo "#define FEAT_NORMAL 1" >>confdefs.h
- dovimdiff="installvimdiff";
-			dogvimdiff="installgvimdiff" ;;
-  big)		$as_echo "#define FEAT_BIG 1" >>confdefs.h
  dovimdiff="installvimdiff";
 			dogvimdiff="installgvimdiff" ;;
   huge)		$as_echo "#define FEAT_HUGE 1" >>confdefs.h
@@ -12883,7 +12881,7 @@ fi
 
 
 if test "$enable_canberra" = "maybe"; then
-  if test "$features" = "big" -o "$features" = "huge"; then
+  if test "$features" = "normal" -o "$features" = "huge"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: Defaulting to yes" >&5
 $as_echo "Defaulting to yes" >&6; }
     enable_canberra="yes"
@@ -12957,7 +12955,7 @@ fi
 
 
 if test "$enable_libsodium" = "maybe"; then
-  if test "$features" = "big" -o "$features" = "huge"; then
+  if test "$features" = "normal" -o "$features" = "huge"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: Defaulting to yes" >&5
 $as_echo "Defaulting to yes" >&6; }
     enable_libsodium="yes"

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -322,9 +322,6 @@
 /* Define if you want normal features. */
 #undef FEAT_NORMAL
 
-/* Define if you want big features. */
-#undef FEAT_BIG
-
 /* Define if you want huge features. */
 #undef FEAT_HUGE
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -522,13 +522,15 @@ fi
 dnl Check user requested features.
 
 AC_MSG_CHECKING(--with-features argument)
-AC_ARG_WITH(features, [  --with-features=TYPE    tiny, normal, big or huge (default: huge)],
+AC_ARG_WITH(features, [  --with-features=TYPE    tiny, normal, or huge (default: huge)],
 	features="$withval"; AC_MSG_RESULT($features),
 	features="huge"; AC_MSG_RESULT(Defaulting to huge))
 
-dnl "small" is supported for backwards compatibility, now an alias for "tiny"
+dnl "small" and "big" are supported for backwards compatibility, now an alias
+dnl for "tiny" and "normal".
 case "$features" in
-  small) features="tiny" ;;
+  small) features="tiny"   ;;
+  big)   features="normal" ;;
 esac
 
 dovimdiff=""
@@ -536,8 +538,6 @@ dogvimdiff=""
 case "$features" in
   tiny)		AC_DEFINE(FEAT_TINY) ;;
   normal)	AC_DEFINE(FEAT_NORMAL) dovimdiff="installvimdiff";
-			dogvimdiff="installgvimdiff" ;;
-  big)		AC_DEFINE(FEAT_BIG) dovimdiff="installvimdiff";
 			dogvimdiff="installgvimdiff" ;;
   huge)		AC_DEFINE(FEAT_HUGE) dovimdiff="installvimdiff";
 			dogvimdiff="installgvimdiff" ;;
@@ -2266,7 +2266,7 @@ if test "$enable_multibyte" != "yes"; then
 		a problem with this, discuss on the Vim mailing list.])
 fi
 
-dnl Right-to-Left language support for Vim will be included with big features,
+dnl Right-to-Left language support for Vim will be included with normal features,
 dnl unless ENABLE_RIGHTLEFT is undefined.
 AC_MSG_CHECKING(--disable-rightleft argument)
 AC_ARG_ENABLE(rightleft,
@@ -2279,7 +2279,7 @@ else
 	AC_DEFINE(DISABLE_RIGHTLEFT)
 fi
 
-dnl Arabic language support for Vim will be included with big features,
+dnl Arabic language support for Vim will be included with normal features,
 dnl unless ENABLE_ARABIC is undefined.
 AC_MSG_CHECKING(--disable-arabic argument)
 AC_ARG_ENABLE(arabic,
@@ -3717,7 +3717,7 @@ AC_ARG_ENABLE(canberra,
 	, [enable_canberra="maybe"])
 
 if test "$enable_canberra" = "maybe"; then
-  if test "$features" = "big" -o "$features" = "huge"; then
+  if test "$features" = "normal" -o "$features" = "huge"; then
     AC_MSG_RESULT(Defaulting to yes)
     enable_canberra="yes"
   else
@@ -3763,7 +3763,7 @@ AC_ARG_ENABLE(libsodium,
 	, [enable_libsodium="maybe"])
 
 if test "$enable_libsodium" = "maybe"; then
-  if test "$features" = "big" -o "$features" = "huge"; then
+  if test "$features" = "normal" -o "$features" = "huge"; then
     AC_MSG_RESULT(Defaulting to yes)
     enable_libsodium="yes"
   else

--- a/src/feature.h
+++ b/src/feature.h
@@ -33,10 +33,9 @@
  *
  * +tiny		no optional features enabled, not even +eval
  * +normal		a default selection of features enabled
- * +big			many features enabled, except "expensive" ones
  * +huge		all possible features enabled.
  *
- * When +normal is used, +tiny is also included.  +big implies +normal, etc.
+ * When +normal is used, +tiny is also included.  +huge implies +normal, etc.
  */
 
 /*
@@ -50,33 +49,35 @@
 #endif
 
 /*
+ * +big is now an alias for +normal
+ */
+#if defined(FEAT_BIG)
+# undef FEAT_BIG
+# if !defined(FEAT_NORMAL)
+#  define FEAT_NORMAL
+# endif
+#endif
+
+/*
  * Uncomment one of these to override the default.  For unix use a configure
  * argument, see Makefile.
  */
-#if !defined(FEAT_TINY) && !defined(FEAT_NORMAL) \
-	&& !defined(FEAT_BIG) && !defined(FEAT_HUGE)
+#if !defined(FEAT_TINY) && !defined(FEAT_NORMAL) && !defined(FEAT_HUGE)
 // #define FEAT_TINY
 // #define FEAT_NORMAL
-// #define FEAT_BIG
 // #define FEAT_HUGE
 #endif
 
 /*
  * For Unix, Mac and Win32 use +huge by default.  These days CPUs are fast and
  * Memory is cheap.
- * Use +big for older systems: VMS and Amiga.
  * Otherwise use +normal
  */
-#if !defined(FEAT_TINY) && !defined(FEAT_NORMAL) \
-	&& !defined(FEAT_BIG) && !defined(FEAT_HUGE)
+#if !defined(FEAT_TINY) && !defined(FEAT_NORMAL) && !defined(FEAT_HUGE)
 # if defined(UNIX) || defined(MSWIN) || defined(MACOS_X)
 #  define FEAT_HUGE
 # else
-#  if defined(VMS) || defined(AMIGA)
-#   define FEAT_BIG
-#  else
-#   define FEAT_NORMAL
-#  endif
+#  define FEAT_NORMAL
 # endif
 #endif
 
@@ -84,9 +85,6 @@
  * Each feature implies including the "smaller" ones.
  */
 #ifdef FEAT_HUGE
-# define FEAT_BIG
-#endif
-#ifdef FEAT_BIG
 # define FEAT_NORMAL
 #endif
 #ifdef FEAT_NORMAL
@@ -164,7 +162,7 @@
  *			keyboard in a special language mode, e.g. for typing
  *			greek.
  */
-#ifdef FEAT_BIG
+#ifdef FEAT_NORMAL
 # define FEAT_LANGMAP
 #endif
 
@@ -172,7 +170,7 @@
  * +keymap		'keymap' option.  Allows you to map typed keys in
  *			Insert mode for a special language.
  */
-#ifdef FEAT_BIG
+#ifdef FEAT_NORMAL
 # define FEAT_KEYMAP
 #endif
 
@@ -219,7 +217,7 @@
 /*
  * +rightleft		Right-to-left editing/typing support.
  */
-#if defined(FEAT_BIG) && !defined(DISABLE_RIGHTLEFT)
+#if !defined(DISABLE_RIGHTLEFT)
 # define FEAT_RIGHTLEFT
 #endif
 
@@ -227,7 +225,7 @@
  * +arabic		Arabic keymap and shaping support.
  *			Requires FEAT_RIGHTLEFT
  */
-#if defined(FEAT_BIG) && !defined(DISABLE_ARABIC)
+#if !defined(DISABLE_ARABIC)
 # define FEAT_ARABIC
 #endif
 #ifdef FEAT_ARABIC
@@ -240,14 +238,14 @@
  * +emacs_tags		When FEAT_EMACS_TAGS defined: Include support for
  *			emacs style TAGS file.
  */
-#ifdef FEAT_BIG
+#ifdef FEAT_NORMAL
 # define FEAT_EMACS_TAGS
 #endif
 
 /*
  * +cscope		Unix only: Cscope support.
  */
-#if defined(UNIX) && defined(FEAT_BIG) && !defined(FEAT_CSCOPE) && !defined(MACOS_X)
+#if defined(UNIX) && defined(FEAT_NORMAL) && !defined(FEAT_CSCOPE) && !defined(MACOS_X)
 # define FEAT_CSCOPE
 #endif
 
@@ -362,7 +360,7 @@
  * +conceal		'conceal' option.  Depends on syntax highlighting
  *			as this is how the concealed text is defined.
  */
-#if defined(FEAT_BIG) && defined(FEAT_SYN_HL)
+#if defined(FEAT_NORMAL) && defined(FEAT_SYN_HL)
 # define FEAT_CONCEAL
 #endif
 
@@ -383,7 +381,7 @@
 /*
  * libsodium - add cryptography support
  */
-#if defined(HAVE_SODIUM) && defined(FEAT_BIG)
+#if defined(HAVE_SODIUM) && defined(FEAT_NORMAL)
 # define FEAT_SODIUM
 #endif
 
@@ -416,7 +414,7 @@
 // #define FEAT_MBYTE_IME
 #endif
 
-#if defined(FEAT_BIG) && defined(FEAT_GUI_HAIKU) && !defined(FEAT_MBYTE_IME)
+#if defined(FEAT_NORMAL) && defined(FEAT_GUI_HAIKU) && !defined(FEAT_MBYTE_IME)
 # define FEAT_MBYTE_IME
 #endif
 
@@ -594,14 +592,14 @@
 /*
  * +termguicolors	'termguicolors' option.
  */
-#if (defined(FEAT_BIG) && defined(FEAT_SYN_HL)) && !defined(ALWAYS_USE_GUI)
+#if (defined(FEAT_NORMAL) && defined(FEAT_SYN_HL)) && !defined(ALWAYS_USE_GUI)
 # define FEAT_TERMGUICOLORS
 #endif
 
 /*
  * +vartabs		'vartabstop' and 'varsofttabstop' options.
  */
-#ifdef FEAT_BIG
+#ifdef FEAT_NORMAL
 # define FEAT_VARTABS
 #endif
 
@@ -842,13 +840,13 @@
 // Amiga console has no mouse support
 #if defined(UNIX) || defined(VMS)
 # define FEAT_MOUSE_XTERM
-# ifdef FEAT_BIG
+# ifdef FEAT_NORMAL
 #  define FEAT_MOUSE_NET
 # endif
-# ifdef FEAT_BIG
+# ifdef FEAT_NORMAL
 #  define FEAT_MOUSE_DEC
 # endif
-# ifdef FEAT_BIG
+# ifdef FEAT_NORMAL
 #  define FEAT_MOUSE_URXVT
 # endif
 #endif
@@ -1079,7 +1077,7 @@
  * +signs		Allow signs to be displayed to the left of text lines.
  *			Adds the ":sign" command.
  */
-#if defined(FEAT_BIG) || defined(FEAT_NETBEANS_INTG) || defined(FEAT_PROP_POPUP)
+#if defined(FEAT_NORMAL) || defined(FEAT_NETBEANS_INTG) || defined(FEAT_PROP_POPUP)
 # define FEAT_SIGNS
 # if (defined(FEAT_GUI_MOTIF) && defined(HAVE_X11_XPM_H)) \
 	|| defined(FEAT_GUI_GTK) \
@@ -1137,7 +1135,7 @@
 /*
  * +autochdir		'autochdir' option.
  */
-#if defined(FEAT_NETBEANS_INTG) || defined(FEAT_BIG)
+#if defined(FEAT_NETBEANS_INTG) || defined(FEAT_NORMAL)
 # define FEAT_AUTOCHDIR
 #endif
 

--- a/src/testdir/test_regexp_utf8.vim
+++ b/src/testdir/test_regexp_utf8.vim
@@ -229,7 +229,7 @@ func Test_multibyte_chars()
   let tl = []
 
   " Multi-byte character tests. These will fail unless vim is compiled
-  " with Multibyte (FEAT_MBYTE) or BIG/HUGE features.
+  " with Multibyte (FEAT_MBYTE) or NORMAL/HUGE features.
   call add(tl, [2, '[[:alpha:][=a=]]\+', '879 aiaãâaiuvna ', 'aiaãâaiuvna'])
   call add(tl, [2, '[[=a=]]\+', 'ddaãâbcd', 'aãâ'])								" equivalence classes
   call add(tl, [2, '[^ม ]\+', 'มม oijasoifjos ifjoisj f osij j มมมมม abcd', 'oijasoifjos'])

--- a/src/version.c
+++ b/src/version.c
@@ -2337,8 +2337,6 @@ list_version(void)
 
 #if defined(FEAT_HUGE)
     msg_puts(_("\nHuge version "));
-#elif defined(FEAT_BIG)
-    msg_puts(_("\nBig version "));
 #elif defined(FEAT_NORMAL)
     msg_puts(_("\nNormal version "));
 #else


### PR DESCRIPTION
The difference between the 'normal' and 'big' builds is not very large:

	normal    | 3195080 (3.1M)        | 2514680 (2.4M)
	big       | 3261704 (3.2M), +65K  | 2560856 (2.5M), +45K

And I'm not sure many people are using the 'big' featureset.

This removes the 'big' featureset, and aliases that to 'normal', leaving us with three builds:

	          | -O2            | -Os
	tiny      | 1633984 (1.6M) | 1190576 (1.2M)
	normal    | 3195080 (3.1M) | 2514680 (2.4M)
	huge      | 3410232 (3.3M) | 3070104 (3.0M)

Which are all fairly distinct.

Features now included in 'normal':

	FEAT_LANGMAP
	FEAT_KEYMAP
	FEAT_EMACS_TAGS
	FEAT_CSCOPE
	FEAT_CONCEAL
	FEAT_TERMGUICOLORS
	FEAT_VARTABS
	FEAT_MOUSE_NET, FEAT_MOUSE_DEC, FEAT_MOUSE_URXVT
	FEAT_SIGNS
	FEAT_AUTOCHDIR
	FEAT_RIGHTLEFT  (unless --disable-rightleft)
	FEAT_ARABIC     (unless --disable-arabic)
	FEAT_SODIUM     (unless --disable-sodium, or libsodium isn't found)
	FEAT_SOUND      (unless --disable-canberra, or libcanberra not found)
	FEAT_MBYTE_IME  (Haiku)