### PR TITLE
'splitkeep' uses old botline when buffer line count changed

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1807,6 +1807,13 @@ function Test_splitkeep_misc()
   let top = line('w0')
   help | quit
   call assert_equal(top, line('w0'))
+  " No error when resizing window in autocmd and buffer length changed
+  autocmd FileType qf exe "resize" line('$')
+  cexpr getline(1, '$')
+  copen
+  wincmd p
+  norm dd
+  cexpr getline(1, '$')
 
   %bwipeout!
   set splitbelow&

--- a/src/window.c
+++ b/src/window.c
@@ -6356,7 +6356,8 @@ win_fix_scroll(int resize)
 	if (wp->w_height != wp->w_prev_height)
 	{
 	    // If window has moved update botline to keep the same screenlines.
-	    if (*p_spk == 's' && wp->w_winrow != wp->w_prev_winrow)
+	    if (*p_spk == 's' && wp->w_winrow != wp->w_prev_winrow
+		    && wp->w_buffer->b_ml.ml_line_count >= wp->w_botline - 1)
 	    {
 		lnum = wp->w_cursor.lnum;
 		diff = (wp->w_winrow - wp->w_prev_winrow)


### PR DESCRIPTION
Problem:	'splitkeep' uses old botline when buffer line count changed.
Solution:	Check that buffer line count is larger than botline (Fixes https://github.com/vim/vim/issues/11292).