### PR TITLE
Ralt combo

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -856,7 +856,9 @@ get_active_modifiers(void)
     // because if AltGr is press, Windows claims that Ctrl is
     // hold as well. That way we can recognize RightALT alone and
     // be sure that not AltGr is hold.
-    if (!(GetKeyState(VK_CONTROL) & 0x8000) && (GetKeyState(VK_RMENU) & 0x8000))
+    if (!(GetKeyState(VK_CONTROL) & 0x8000)
+	    &&  (GetKeyState(VK_RMENU) & 0x8000)
+	    && !(GetKeyState(VK_LMENU) & 0x8000)) // seems AltGr has both set
 	modifiers |= MOD_MASK_ALT;
 
     return modifiers;

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -852,6 +852,12 @@ get_active_modifiers(void)
 	modifiers |= MOD_MASK_ALT;
     if ((modifiers & MOD_MASK_CTRL) && (GetKeyState(VK_RMENU) & 0x8000))
 	modifiers &= ~MOD_MASK_CTRL;
+    // Add RightALT only if it is hold alone (without Ctrl),
+    // because if AltGr is press, Windows claims that Ctrl is
+    // hold as well. That way we can recognize RightALT alone and
+    // be sure that not AltGr is hold.
+    if (!(GetKeyState(VK_CONTROL) & 0x8000) && (GetKeyState(VK_RMENU) & 0x8000))
+	modifiers |= MOD_MASK_ALT;
 
     return modifiers;
 }


### PR DESCRIPTION
ralt_combo v2 (issue #10826) solved, tested

Note, gvim9 seems to generally have a problem (even before this patch)
with AltGr handling, if operated via windows on-screen keyboard. Old
versions (very old gvim8) seems to be fine yet, perhaps it is a
consequence of us not calling TranslateMessage() windows API any more.

This drove me a bit crazy during my first test attempts (my RightAlt key
is remapped as Ctrl in the registry, so to test this fix i was trying to
take shortcut and used on-screen keyboard firstly and my tests failed;
with RightAlt enabled back in registry and using direct keyboard for
testing all is fine)