### PR TITLE
Fix clang's FORTIFY_SOURCE crashing vim9script

### DIFF
--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -969,7 +969,7 @@ update_vim9_script_var(
 		sv->sv_flags |= SVFLAG_ASSIGNED;
 	    newsav->sav_var_vals_idx = si->sn_var_vals.ga_len;
 	    ++si->sn_var_vals.ga_len;
-	    STRCPY(&newsav->sav_key, name);
+	    STRCPY(&newsav->sav_key[0], name);
 	    sv->sv_name = newsav->sav_key;
 	    newsav->sav_di = di;
 	    newsav->sav_block_id = si->sn_current_block_id;


### PR DESCRIPTION
This changes the usage of strcpy to a flexible array member. Instead of taking its address directly, take the first element instead to make the compiler's source fortification happy.

Context:

While debugging Vim, I ran into an issue where Vim kept crashing when opening a file. After some bisecting it turned out to be a2baa73d1d330 which was the trigger as it introduced some vim9script. The actual crash was in vim9script.c and *only* happens when I build in debug mode.

After some investigation, turned out that when you build in debug modes, gcc/clang's FORTIFY_SOURCE feature would kick in and it injects "helpful" markers to help detect buffer overflow issues. In particular, I think that's because this line of code was using strcpy, which is a known vulnerability magnet. I looked through the code and it seemed fine, but the compiler would inject a trap EXC_BREAKPOINT during the strcpy to essentially crash the program. If you change the code to do `&newsav->sav_key[0]` instead, it would not trigger this issue even though they do the same thing, presumably because it's clearer what you are trying to do here (using a flexible array at the end of struct).

Alternatively I could have compiled with -D_FORTIFY_SOURCE=0 which would have removed the issue, but this seems like a small change that makes semantics of the code clearer anyway.

(I was debating using vim_strncpy instead since strcpy makes me nervous, but just decided to make the change smaller)

---

Just for reference, here is how to reproduce the issue (I'm using clang just for consistency in reproduction):

```
cd $VIM_DIR
CC=clang ./configure
make "CFLAGS=-O0 -g" VIMRUNTIMEDIR=$VIM_DIR/runtime
src/vim --clean src/vim.h
```

What I see (on my Mac at least) is the following:

```
Vim: Caught deadly signal TRAP
Vim: Finished.
zsh: trace trap  src/vim src/vim.h
```

In a debugger I would see that a EXC_BREAKPOINT was fired.