### PR TITLE
Add :confirm support for terminal buffers

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -129,6 +129,12 @@ an <silent> 10.330 &File.&Close<Tab>:close
 	\ else <Bar>
 	\   confirm close <Bar>
 	\ endif<CR>
+tln <silent> 10.330 &File.&Close<Tab>:close
+	\ <C-W>:if winheight(2) < 0 && tabpagewinnr(2) == 0 <Bar>
+	\   confirm enew <Bar>
+	\ else <Bar>
+	\   confirm close <Bar>
+	\ endif<CR>
 an 10.335 &File.-SEP1-				<Nop>
 an <silent> 10.340 &File.&Save<Tab>:w		:if expand("%") == ""<Bar>browse confirm w<Bar>else<Bar>confirm w<Bar>endif<CR>
 an 10.350 &File.Save\ &As\.\.\.<Tab>:sav	:browse confirm saveas<CR>

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -86,6 +86,13 @@ check_changed(buf_T *buf, int flags)
 #if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG)
 	if ((p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)) && p_write)
 	{
+# ifdef FEAT_TERMINAL
+	    if (term_job_running(buf->b_term))
+	    {
+		return term_confirm_stop(buf) == FAIL;
+	    }
+# endif
+
 	    buf_T	*buf2;
 	    int		count = 0;
 
@@ -198,6 +205,7 @@ dialog_changed(
 			|| (cmdmod.cmod_flags & CMOD_BROWSE)
 #endif
 			)
+		    && !bt_dontwrite(buf2)
 		    && !buf2->b_p_ro)
 	    {
 		bufref_T bufref;

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -10,6 +10,7 @@ void write_to_term(buf_T *buffer, char_u *msg, channel_T *channel);
 int term_job_running(term_T *term);
 int term_job_running_not_none(term_T *term);
 int term_none_open(term_T *term);
+int term_confirm_stop(buf_T *buf);
 int term_try_stop_job(buf_T *buf);
 int term_check_timers(int next_due_arg, proftime_T *now);
 int term_in_normal_mode(void);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1651,6 +1651,25 @@ term_none_open(term_T *term)
 	&& term->tl_job->jv_channel->ch_keep_open;
 }
 
+//
+// Used to confirm whether we would like to kill a terminal.
+// Return OK when the user confirms to kill it.
+// Return FAIL if the user selects otherwise.
+//
+    int
+term_confirm_stop(buf_T *buf)
+{
+    char_u	buff[DIALOG_MSG_SIZE];
+    int	ret;
+
+    dialog_msg(buff, _("Kill job in \"%s\"?"), buf_get_fname(buf));
+    ret = vim_dialog_yesno(VIM_QUESTION, NULL, buff, 1);
+    if (ret == VIM_YES)
+	return OK;
+    else
+	return FAIL;
+}
+
 /*
  * Used when exiting: kill the job in "buf" if so desired.
  * Return OK when the job finished.
@@ -1666,14 +1685,9 @@ term_try_stop_job(buf_T *buf)
     if ((how == NULL || *how == NUL)
 			  && (p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)))
     {
-	char_u	buff[DIALOG_MSG_SIZE];
-	int	ret;
-
-	dialog_msg(buff, _("Kill job in \"%s\"?"), buf_get_fname(buf));
-	ret = vim_dialog_yesnocancel(VIM_QUESTION, NULL, buff, 1);
-	if (ret == VIM_YES)
+	if (term_confirm_stop(buf) == OK)
 	    how = "kill";
-	else if (ret == VIM_CANCEL)
+	else
 	    return FAIL;
     }
 #endif

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -98,13 +98,133 @@ endfunc
 
 func Test_terminal_wipe_buffer()
   let buf = Run_shell_in_terminal({})
-  call assert_fails(buf . 'bwipe', 'E89:')
+  call assert_fails(buf . 'bwipe', 'E948:')
   exe buf . 'bwipe!'
   call WaitForAssert({-> assert_equal('dead', job_status(g:job))})
   call assert_equal("", bufname(buf))
 
   unlet g:job
 endfunc
+
+" Test that using ':confirm bwipe' on terminal works
+func Test_terminal_confirm_wipe_buffer()
+  CheckUnix
+  CheckNotGui
+  CheckFeature dialog_con
+  let buf = Run_shell_in_terminal({})
+  call assert_fails(buf . 'bwipe', 'E948:')
+  call feedkeys('n', 'L')
+  call assert_fails('confirm ' .. buf .. 'bwipe', 'E517:')
+  call assert_equal(buf, bufnr())
+  call assert_equal(1, &modified)
+  call feedkeys('y', 'L')
+  exe 'confirm ' .. buf .. 'bwipe'
+  call assert_notequal(buf, bufnr())
+  call WaitForAssert({-> assert_equal('dead', job_status(g:job))})
+  call assert_equal("", bufname(buf))
+
+  unlet g:job
+endfunc
+
+" Test that using :b! will hide the terminal
+func Test_terminal_goto_buffer()
+  let buf_mod = bufnr()
+  let buf_term = Run_shell_in_terminal({})
+  call assert_equal(buf_term, bufnr())
+  call assert_fails(buf_mod . 'b', 'E948:')
+  exe buf_mod . 'b!'
+  call assert_equal(buf_mod, bufnr())
+  call assert_equal('run', job_status(g:job))
+  call assert_notequal('', bufname(buf_term))
+  exec buf_mod .. 'bwipe!'
+  exec buf_term .. 'bwipe!'
+
+  unlet g:job
+endfunc
+
+" Test that using ':confirm :b' will kill terminal
+func Test_terminal_confirm_goto_buffer()
+  CheckUnix
+  CheckNotGui
+  CheckFeature dialog_con
+  let buf_mod = bufnr()
+  let buf_term = Run_shell_in_terminal({})
+  call feedkeys('n', 'L')
+  exe 'confirm ' .. buf_mod .. 'b'
+  call assert_equal(buf_term, bufnr())
+  call feedkeys('y', 'L')
+  exec 'confirm ' .. buf_mod .. 'b'
+  call assert_equal(buf_mod, bufnr())
+  call WaitForAssert({-> assert_equal('dead', job_status(g:job))})
+  call assert_equal("", bufname(buf_term))
+  exec buf_mod .. 'bwipe!'
+
+  unlet g:job
+endfunc
+
+" Test that using :close! will hide the terminal
+func Test_terminal_close_win()
+  let buf = Run_shell_in_terminal({})
+  call assert_equal(buf, bufnr())
+  call assert_fails('close', 'E948:')
+  close!
+  call assert_notequal(buf, bufnr())
+  call assert_equal('run', job_status(g:job))
+  call assert_notequal('', bufname(buf))
+  exec buf .. 'bwipe!'
+
+  unlet g:job
+endfunc
+
+" Test that using ':confirm close' will kill terminal
+func Test_terminal_confirm_close_win()
+  CheckUnix
+  CheckNotGui
+  CheckFeature dialog_con
+  let buf = Run_shell_in_terminal({})
+  call feedkeys('n', 'L')
+  confirm close
+  call assert_equal(buf, bufnr())
+  call feedkeys('y', 'L')
+  confirm close
+  call assert_notequal(buf, bufnr())
+  call WaitForAssert({-> assert_equal('dead', job_status(g:job))})
+  call assert_equal("", bufname(buf))
+
+  unlet g:job
+endfunc
+
+" Test that using :quit! will kill the terminal
+func Test_terminal_quit()
+  let buf = Run_shell_in_terminal({})
+  call assert_equal(buf, bufnr())
+  call assert_fails('quit', 'E948:')
+  quit!
+  call assert_notequal(buf, bufnr())
+  call WaitForAssert({-> assert_equal('dead', job_status(g:job))})
+  exec buf .. 'bwipe!'
+
+  unlet g:job
+endfunc
+
+" Test that using ':confirm quit' will kill terminal
+func Test_terminal_confirm_quit()
+  CheckUnix
+  CheckNotGui
+  CheckFeature dialog_con
+  let buf = Run_shell_in_terminal({})
+  call feedkeys('n', 'L')
+  confirm quit
+  call assert_equal(buf, bufnr())
+  call feedkeys('y', 'L')
+  confirm quit
+  call assert_notequal(buf, bufnr())
+  call WaitForAssert({-> assert_equal('dead', job_status(g:job))})
+
+  unlet g:job
+endfunc
+
+" Test :q or :next
 
 func Test_terminal_split_quit()
   let buf = Run_shell_in_terminal({})
@@ -707,7 +827,7 @@ endfunc
 
 func Test_terminal_list_args()
   let buf = term_start([&shell, &shellcmdflag, 'echo "123"'])
-  call assert_fails(buf . 'bwipe', 'E89:')
+  call assert_fails(buf . 'bwipe', 'E948:')
   exe buf . 'bwipe!'
   call assert_equal("", bufname(buf))
 endfunction
@@ -1235,7 +1355,7 @@ func Test_terminal_qall_prompt()
 
   " make Vim exit, it will prompt to kill the shell
   call term_sendkeys(buf, "\<C-W>:confirm qall\<CR>")
-  call WaitForAssert({-> assert_match('ancel:', term_getline(buf, 20))})
+  call WaitForAssert({-> assert_match('\[Y\]es, (N)o:', term_getline(buf, 20))})
   call term_sendkeys(buf, "y")
   call WaitForAssert({-> assert_equal('finished', term_getstatus(buf))})
 


### PR DESCRIPTION
Previously terminal windows never really worked well with `:confirm` commands as most places still treated it like a buffer with modification (and the subsequent "Yes" confirmation would subsequently fail as Vim doesn't know how to "save" a terminal). The only place that really worked was `:confirm qa`.

Fix up the code so most places (at least the ones that I could find) that take `:confirm` also handles terminal buffers properly.

The list of commands modified:

- `check_changed()`, used for :q/:only/:enew/:next etc.
- `:bdelete` / `bwipe`
- `:close`
- `:buffer N`

(For `:buffer` and `:close` I had to manually call `free_terminal()`. For `:buffer` it's because the fallthrough logic is to just hide the buffer while the :confirm behavior is to kill the terminal, and for `:close` that's because I find that otherwise it leaves a straggling buffer that doesn't do anything, see below design question (3)).

Also, updated File.Close menu to be able to handle terminals as well.

Also added tests for both the :confirm and [!] behaviors for the above commands.

Design questions / notes:

1. [x] Terminal conf dialog boxes used to say yes/no/cancel, but I changed it to yes/no, because "no" and "cancel" used to do the same thing if you reason through the code. That said, I'm debating whether a yes/cancel makes more sense as usually the decision is to either "kill the terminal", or "cancel whatever operation you are doing". I think yes/cancel makes more sense personally, so if we want to do this I can update it (I just need to update all the localization po files as well).

2. [x] When writing tests, I noticed that `:q!` on a terminal has a quirk where it would leave a straggler buffer that is empty, but not deleted. This seems different from the other ways a terminal gets killed. If you just exit the terminal normally (e.g. type "exit" in the shell), it will remove itself from the buffer list. I think this is a bug. For `:confirm close` I found a similar issue, but I worked around it by calling `free_terminal()`.
    - (Edit: This and other related quirks will be fixed in https://github.com/vim/vim/pull/11323)
4. [x] `term_start` allows you to set a `term_kill` option on a terminal. Right now, if you set it, and then do `:qa`, Vim will just quit without warning you about the terminal. However, just doing regular `:q` *will* warn you about the terminal. I'm not really sure which is the correct behavior so I kept it as it is, but it seems slightly inconsistent. It's not directly related to adding `:confirm` support anyway.
    - (Edit: Filed #11325 for tracking)