### PR TITLE
Clarify docs on g:python_indent

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -982,9 +982,11 @@ indentation: >
 
 PYTHON							*ft-python-indent*
 
-The amount of indent can be set for the following situations.  The examples
-given are the defaults.  Note that the dictionary values are set to an
-expression, so that you can change the value of 'shiftwidth' later.
+The amount of indent can be set with the `g:python_indent` |Dictionary|, which
+needs to be defined first: >
+	let g:python_indent = {}
+The examples given are the defaults.  Note that the dictionary values are set
+to an expression, so that you can change the value of 'shiftwidth' later.
 
 Indent after an open paren: >
 	let g:python_indent.open_paren = 'shiftwidth() * 2'


### PR DESCRIPTION
It's not clear that you need to define the dictionary first; just copy/pasting the examples will be an error.

Led to some confusion: https://vi.stackexchange.com/q/38823/51