### PR TITLE
Graduate +cmdline_info, +byteoff, +linebreak

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6476,8 +6476,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 					 *'ruler'* *'ru'* *'noruler'* *'noru'*
 'ruler' 'ru'		boolean	(default off, set in |defaults.vim|)
 			global
-			{not available when compiled without the
-			|+cmdline_info| feature}
 	Show the line and column number of the cursor position, separated by a
 	comma.  When there is room, the relative position of the displayed
 	text in the file is shown on the far right:
@@ -7137,8 +7135,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 'showcmd' 'sc'		boolean	(Vim default: on, off for Unix,
 				       Vi default: off, set in |defaults.vim|)
 			global
-			{not available when compiled without the
-			|+cmdline_info| feature}
 	Show (partial) command in the last line of the screen.  Set this
 	option off if your terminal is slow.
 	In Visual mode the size of the selected area is shown:

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -355,7 +355,7 @@ N  *+clientserver*	Unix and Win32: Remote invocation |clientserver|
    *+clipboard_working*	|clipboard| support compiled-in and working
 T  *+cmdline_compl*	command line completion |cmdline-completion|
 T  *+cmdline_hist*	command line history |cmdline-history|
-N  *+cmdline_info*	|'showcmd'| and |'ruler'|
+T  *+cmdline_info*	|'showcmd'| and |'ruler'|
 T  *+cmdwin*		|cmdline-window| support; Always enabled since 9.0.0657
 T  *+comments*		|'comments'| support
 N  *+conceal*		"conceal" support, see |conceal| |:syn-conceal| etc.

--- a/src/arglist.c
+++ b/src/arglist.c
@@ -295,7 +295,7 @@ get_arglist(garray_T *gap, char_u *str, int escaped)
     return OK;
 }
 
-#if defined(FEAT_QUICKFIX) || defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_QUICKFIX) || defined(FEAT_SYN_HL) || defined(FEAT_SPELL) || defined(PROTO)
 /*
  * Parse a list of arguments (file names), expand them and return in
  * "fnames[fcountp]".  When "wig" is TRUE, removes files matching 'wildignore'.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2543,7 +2543,7 @@ buflist_getfpos(void)
     }
 }
 
-#if defined(FEAT_QUICKFIX) || defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_QUICKFIX) || defined(FEAT_EVAL) || defined(FEAT_SPELL) || defined(PROTO)
 /*
  * Find file in buffer list by name (it has to be for the current window).
  * Returns NULL if not found.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -3846,14 +3846,12 @@ fileinfo(
 					    (long)curbuf->b_ml.ml_line_count);
     if (curbuf->b_ml.ml_flags & ML_EMPTY)
 	vim_snprintf_add(buffer, IOSIZE, "%s", _(no_lines_msg));
-#ifdef FEAT_CMDL_INFO
     else if (p_ru)
 	// Current line and column are already on the screen -- webb
 	vim_snprintf_add(buffer, IOSIZE,
 		NGETTEXT("%ld line --%d%%--", "%ld lines --%d%%--",
 						   curbuf->b_ml.ml_line_count),
 		(long)curbuf->b_ml.ml_line_count, n);
-#endif
     else
     {
 	vim_snprintf_add(buffer, IOSIZE,
@@ -5177,8 +5175,6 @@ build_stl_str_hl(
 }
 #endif // FEAT_STL_OPT
 
-#if defined(FEAT_STL_OPT) || defined(FEAT_CMDL_INFO) \
-	    || defined(FEAT_GUI_TABLINE) || defined(PROTO)
 /*
  * Get relative cursor position in window into "buf[buflen]", in the form 99%,
  * using "Top", "Bot" or "All" when appropriate.
@@ -5213,7 +5209,6 @@ get_rel_pos(
 				    ? (int)(above / ((above + below) / 100L))
 				    : (int)(above * 100L / (above + below)));
 }
-#endif
 
 /*
  * Append (file 2 of 8) to "buf[buflen]", if editing more than one file.

--- a/src/charset.c
+++ b/src/charset.c
@@ -1085,7 +1085,7 @@ win_lbr_chartabsize(
 	int		*headp UNUSED)
 {
     win_T	*wp = cts->cts_win;
-#ifdef FEAT_PROP_POPUP
+#if defined(FEAT_PROP_POPUP) || defined(FEAT_LINEBREAK)
     char_u	*line = cts->cts_line; // start of the line
 #endif
     char_u	*s = cts->cts_ptr;

--- a/src/digraph.c
+++ b/src/digraph.c
@@ -1546,10 +1546,8 @@ get_digraph(
 		    )
 		putcmdline(c, TRUE);
 	}
-#ifdef FEAT_CMDL_INFO
 	else
 	    add_to_showcmd(c);
-#endif
 	++no_mapping;
 	++allow_keys;
 	cc = plain_vgetc();

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1087,7 +1087,7 @@ win_line(
     int		feedback_old_attr = -1;
 #endif
 
-#if defined(FEAT_CONCEAL) || defined(FEAT_SEARCH_EXTRA)
+#if defined(FEAT_CONCEAL) || defined(FEAT_SEARCH_EXTRA) || defined(FEAT_LINEBREAK)
     int		match_conc	= 0;	// cchar for match functions
     int		on_last_col     = FALSE;
 #endif

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1089,6 +1089,8 @@ win_line(
 
 #if defined(FEAT_CONCEAL) || defined(FEAT_SEARCH_EXTRA)
     int		match_conc	= 0;	// cchar for match functions
+#endif
+#if defined(FEAT_CONCEAL) || defined(FEAT_SEARCH_EXTRA) || defined(FEAT_LINEBREAK)
     int		on_last_col     = FALSE;
 #endif
 #ifdef FEAT_CONCEAL

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1075,7 +1075,7 @@ win_line(
     int		get_term_attr = FALSE;
 #endif
 
-#ifdef FEAT_SYN_HL
+#if defined(FEAT_SYN_HL) || defined(FEAT_DIFF)
     // margin columns for the screen line, needed for when 'cursorlineopt'
     // contains "screenline"
     int		left_curline_col = 0;

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1087,7 +1087,7 @@ win_line(
     int		feedback_old_attr = -1;
 #endif
 
-#if defined(FEAT_CONCEAL) || defined(FEAT_SEARCH_EXTRA) || defined(FEAT_LINEBREAK)
+#if defined(FEAT_CONCEAL) || defined(FEAT_SEARCH_EXTRA)
     int		match_conc	= 0;	// cchar for match functions
     int		on_last_col     = FALSE;
 #endif

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -547,9 +547,7 @@ win_redr_status(win_T *wp, int ignore_pum UNUSED)
 	    screen_puts(NameBuff, row, (int)(this_ru_col - STRLEN(NameBuff)
 						   - 1 + wp->w_wincol), attr);
 
-#ifdef FEAT_CMDL_INFO
 	win_redr_ruler(wp, TRUE, ignore_pum);
-#endif
     }
 
     /*
@@ -619,9 +617,7 @@ showruler(int always)
 	redraw_custom_statusline(curwin);
     else
 #endif
-#ifdef FEAT_CMDL_INFO
 	win_redr_ruler(curwin, always, FALSE);
-#endif
 
     if (need_maketitle
 #ifdef FEAT_STL_OPT
@@ -636,7 +632,6 @@ showruler(int always)
 	draw_tabline();
 }
 
-#if defined(FEAT_CMDL_INFO) || defined(PROTO)
     void
 win_redr_ruler(win_T *wp, int always, int ignore_pum)
 {
@@ -816,7 +811,6 @@ win_redr_ruler(win_T *wp, int always, int ignore_pum)
 #endif
     }
 }
-#endif
 
 /*
  * To be called when "updating_screen" was set before and now the postponed
@@ -2924,10 +2918,7 @@ updateWindow(win_T *wp)
     if (redraw_tabline)
 	draw_tabline();
 
-    if (wp->w_redr_status
-# ifdef FEAT_CMDL_INFO
-	    || p_ru
-# endif
+    if (wp->w_redr_status || p_ru
 # ifdef FEAT_STL_OPT
 	    || *p_stl != NUL || *wp->w_p_stl != NUL
 # endif

--- a/src/edit.c
+++ b/src/edit.c
@@ -310,9 +310,7 @@ edit(
 #endif
 
     setmouse();
-#ifdef FEAT_CMDL_INFO
     clear_showcmd();
-#endif
 #ifdef FEAT_RIGHTLEFT
     // there is no reverse replace mode
     revins_on = (State == MODE_INSERT && p_ri);
@@ -1561,9 +1559,7 @@ ins_ctrl_v(void)
     }
     AppendToRedobuff((char_u *)CTRL_V_STR);	// CTRL-V
 
-#ifdef FEAT_CMDL_INFO
     add_to_showcmd_c(Ctrl_V);
-#endif
 
     // Do not change any modifyOtherKeys ESC sequence to a normal key for
     // CTRL-SHIFT-V.
@@ -1572,9 +1568,7 @@ ins_ctrl_v(void)
 	// when the line fits in 'columns' the '^' is at the start of the next
 	// line and will not removed by the redraw
 	edit_unputchar();
-#ifdef FEAT_CMDL_INFO
     clear_showcmd();
-#endif
 
     insert_special(c, FALSE, TRUE);
 #ifdef FEAT_RIGHTLEFT
@@ -1907,10 +1901,8 @@ get_literal(int noReduceKeys)
 	    // character for i_CTRL-V_digit.
 	    break;
 
-#ifdef FEAT_CMDL_INFO
 	if ((State & MODE_CMDLINE) == 0 && MB_BYTE2LEN_CHECK(nc) == 1)
 	    add_to_showcmd(nc);
-#endif
 	if (nc == 'x' || nc == 'X')
 	    hex = TRUE;
 	else if (nc == 'o' || nc == 'O')
@@ -3372,9 +3364,7 @@ ins_reg(void)
 	ins_redraw(FALSE);
 
 	edit_putchar('"', TRUE);
-#ifdef FEAT_CMDL_INFO
 	add_to_showcmd_c(Ctrl_R);
-#endif
     }
 
 #ifdef USE_ON_FLY_SCROLL
@@ -3393,9 +3383,7 @@ ins_reg(void)
     {
 	// Get a third key for literal register insertion
 	literally = regname;
-#ifdef FEAT_CMDL_INFO
 	add_to_showcmd_c(literally);
-#endif
 	regname = plain_vgetc();
 	LANGMAP_ADJUST(regname, TRUE);
     }
@@ -3463,9 +3451,7 @@ ins_reg(void)
 	ins_need_undo = TRUE;
     u_sync_once = 0;
 #endif
-#ifdef FEAT_CMDL_INFO
     clear_showcmd();
-#endif
 
     // If the inserted register is empty, we need to remove the '"'
     if (need_redraw || stuff_empty())
@@ -5176,9 +5162,7 @@ ins_digraph(void)
 
 	edit_putchar('?', TRUE);
 	did_putchar = TRUE;
-#ifdef FEAT_CMDL_INFO
 	add_to_showcmd_c(Ctrl_K);
-#endif
     }
 
 #ifdef USE_ON_FLY_SCROLL
@@ -5199,9 +5183,7 @@ ins_digraph(void)
 
     if (IS_SPECIAL(c) || mod_mask)	    // special key
     {
-#ifdef FEAT_CMDL_INFO
 	clear_showcmd();
-#endif
 	insert_special(c, TRUE, FALSE);
 	return NUL;
     }
@@ -5219,9 +5201,7 @@ ins_digraph(void)
 		edit_putchar(c, TRUE);
 		did_putchar = TRUE;
 	    }
-#ifdef FEAT_CMDL_INFO
 	    add_to_showcmd_c(c);
-#endif
 	}
 	++no_mapping;
 	++allow_keys;
@@ -5236,15 +5216,11 @@ ins_digraph(void)
 	{
 	    AppendToRedobuff((char_u *)CTRL_V_STR);
 	    c = digraph_get(c, cc, TRUE);
-#ifdef FEAT_CMDL_INFO
 	    clear_showcmd();
-#endif
 	    return c;
 	}
     }
-#ifdef FEAT_CMDL_INFO
     clear_showcmd();
-#endif
     return NUL;
 }
 #endif

--- a/src/errors.h
+++ b/src/errors.h
@@ -3082,7 +3082,7 @@ EXTERN char e_bool_required_for_argument_nr[]
 EXTERN char e_redefining_imported_item_str[]
 	INIT(= N_("E1213: Redefining imported item \"%s\""));
 #endif
-#if defined(FEAT_DIGRAPHS) && defined(FEAT_EVAL)
+#if defined(FEAT_DIGRAPHS)
 EXTERN char e_digraph_must_be_just_two_characters_str[]
 	INIT(= N_("E1214: Digraph must be just two characters: %s"));
 EXTERN char e_digraph_argument_must_be_one_character_str[]

--- a/src/errors.h
+++ b/src/errors.h
@@ -1907,7 +1907,7 @@ EXTERN char e_character_in_fol_low_or_upp_is_out_of_range[]
 EXTERN char e_word_characters_differ_between_spell_files[]
 	INIT(= N_("E763: Word characters differ between spell files"));
 #endif
-#if defined(FEAT_SYN_HL) || defined(FEAT_COMPL_FUNC)
+#if defined(FEAT_SYN_HL) || defined(FEAT_COMPL_FUNC) || defined(FEAT_SPELL)
 EXTERN char e_option_str_is_not_set[]
 	INIT(= N_("E764: Option '%s' is not set"));
 #endif

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6091,20 +6091,8 @@ f_has(typval_T *argvars, typval_T *rettv)
 #endif
 		},
 	{"scrollbind", 1},
-	{"showcmd",
-#ifdef FEAT_CMDL_INFO
-		1
-#else
-		0
-#endif
-		},
-	{"cmdline_info",
-#ifdef FEAT_CMDL_INFO
-		1
-#else
-		0
-#endif
-		},
+	{"showcmd", 1},
+	{"cmdline_info", 1},
 	{"signs",
 #ifdef FEAT_SIGNS
 		1

--- a/src/feature.h
+++ b/src/feature.h
@@ -186,6 +186,7 @@
 #ifdef FEAT_NORMAL
 # define FEAT_LINEBREAK
 #endif
+# define FEAT_LINEBREAK
 
 /*
  * +extra_search	'hlsearch' and 'incsearch' options.

--- a/src/feature.h
+++ b/src/feature.h
@@ -126,6 +126,7 @@
  * +builtin_terms	all builtin termcap entries included
  * +float		Floating point variables.
  * +cmdwin		Command line window.
+ * +cmdline_info	'showcmd' and 'ruler' options.
  *
  * Obsolete:
  * +tag_old_static	Old style static tags: "file:tag  file  ..".
@@ -176,13 +177,6 @@
 
 #ifdef FEAT_NORMAL
 # define VIM_BACKTICK		// internal backtick expansion
-#endif
-
-/*
- * +cmdline_info	'showcmd' and 'ruler' options.
- */
-#ifdef FEAT_NORMAL
-# define FEAT_CMDL_INFO
 #endif
 
 /*
@@ -324,9 +318,6 @@
  */
 #ifdef FEAT_NORMAL
 # define FEAT_STL_OPT
-# ifndef FEAT_CMDL_INFO
-#  define FEAT_CMDL_INFO	// 'ruler' is required for 'statusline'
-# endif
 #endif
 
 /*

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -3077,9 +3077,7 @@ vgetorpeek(int advance)
 					// 'ttimeoutlen' for complete key code
     int		mapdepth = 0;		// check for recursive mapping
     int		mode_deleted = FALSE;   // set when mode has been deleted
-#ifdef FEAT_CMDL_INFO
     int		new_wcol, new_wrow;
-#endif
 #ifdef FEAT_GUI
     int		shape_changed = FALSE;  // adjusted cursor shape
 #endif
@@ -3149,9 +3147,7 @@ vgetorpeek(int advance)
 	    {
 		long	wait_time;
 		int	keylen = 0;
-#ifdef FEAT_CMDL_INFO
 		int	showcmd_idx;
-#endif
 		check_end_reg_executing(advance);
 		/*
 		 * ui_breakcheck() is slow, don't use it too often when
@@ -3249,10 +3245,8 @@ vgetorpeek(int advance)
 		 * place does not matter.
 		 */
 		c = 0;
-#ifdef FEAT_CMDL_INFO
 		new_wcol = curwin->w_wcol;
 		new_wrow = curwin->w_wrow;
-#endif
 		if (	   advance
 			&& typebuf.tb_len == 1
 			&& typebuf.tb_buf[typebuf.tb_off] == ESC
@@ -3351,10 +3345,8 @@ vgetorpeek(int advance)
 		    }
 		    setcursor();
 		    out_flush();
-#ifdef FEAT_CMDL_INFO
 		    new_wcol = curwin->w_wcol;
 		    new_wrow = curwin->w_wrow;
-#endif
 		    curwin->w_wcol = old_wcol;
 		    curwin->w_wrow = old_wrow;
 		}
@@ -3442,9 +3434,7 @@ vgetorpeek(int advance)
 		 * input from the user), show the partially matched characters
 		 * to the user with showcmd.
 		 */
-#ifdef FEAT_CMDL_INFO
 		showcmd_idx = 0;
-#endif
 		c1 = 0;
 		if (typebuf.tb_len > 0 && advance && !exmode_active)
 		{
@@ -3462,7 +3452,6 @@ vgetorpeek(int advance)
 			    setcursor(); // put cursor back where it belongs
 			    c1 = 1;
 			}
-#ifdef FEAT_CMDL_INFO
 			// need to use the col and row from above here
 			old_wcol = curwin->w_wcol;
 			old_wrow = curwin->w_wrow;
@@ -3476,7 +3465,6 @@ vgetorpeek(int advance)
 			       typebuf.tb_buf[typebuf.tb_off + showcmd_idx++]);
 			curwin->w_wcol = old_wcol;
 			curwin->w_wrow = old_wrow;
-#endif
 		    }
 
 		    // this looks nice when typing a dead character map
@@ -3521,10 +3509,8 @@ vgetorpeek(int advance)
 			typebuf.tb_buflen - typebuf.tb_off - typebuf.tb_len - 1,
 			wait_time);
 
-#ifdef FEAT_CMDL_INFO
 		if (showcmd_idx != 0)
 		    pop_showcmd();
-#endif
 		if (c1 == 1)
 		{
 		    if (State & MODE_INSERT)

--- a/src/message.c
+++ b/src/message.c
@@ -1774,7 +1774,7 @@ msg_outtrans_special(
     return retval;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_SPELL) || defined(PROTO)
 /*
  * Return the lhs or rhs of a mapping, with the key codes turned into printable
  * strings, in an allocated string.

--- a/src/normal.c
+++ b/src/normal.c
@@ -20,9 +20,7 @@ static int	VIsual_mode_orig = NUL;		// saved Visual mode
 static void	set_vcount_ca(cmdarg_T *cap, int *set_prevcount);
 #endif
 static void	unshift_special(cmdarg_T *cap);
-#ifdef FEAT_CMDL_INFO
 static void	del_from_showcmd(int);
-#endif
 
 /*
  * nv_*(): functions called to handle Normal and Visual mode commands.
@@ -222,9 +220,7 @@ getcount:
 	    if (c == K_DEL || c == K_KDEL)
 	    {
 		cap->count0 /= 10;
-#ifdef FEAT_CMDL_INFO
 		del_from_showcmd(4);	// delete the digit and ~@%
-#endif
 	    }
 	    else if (cap->count0 > 99999999L)
 	    {
@@ -255,9 +251,7 @@ getcount:
 		--no_mapping;
 		--allow_keys;
 	    }
-#ifdef FEAT_CMDL_INFO
 	    *need_flushbuf |= add_to_showcmd(c);
-#endif
 	}
 
 	// If we got CTRL-W there may be a/another count
@@ -272,9 +266,7 @@ getcount:
 	    LANGMAP_ADJUST(c, TRUE);
 	    --no_mapping;
 	    --allow_keys;
-#ifdef FEAT_CMDL_INFO
 	    *need_flushbuf |= add_to_showcmd(c);
-#endif
 	    goto getcount;		// jump back
 	}
     }
@@ -375,9 +367,7 @@ normal_cmd_get_more_chars(
 	 */
 	cap->nchar = plain_vgetc();
 	LANGMAP_ADJUST(cap->nchar, TRUE);
-#ifdef FEAT_CMDL_INFO
 	*need_flushbuf |= add_to_showcmd(cap->nchar);
-#endif
 	if (cap->nchar == 'r' || cap->nchar == '\'' || cap->nchar == '`'
 		|| cap->nchar == Ctrl_BSL)
 	{
@@ -465,9 +455,7 @@ normal_cmd_get_more_chars(
 	p_smd = save_smd;
 #endif
 	State = MODE_NORMAL_BUSY;
-#ifdef FEAT_CMDL_INFO
 	*need_flushbuf |= add_to_showcmd(*cp);
-#endif
 
 	if (!lit)
 	{
@@ -482,11 +470,9 @@ normal_cmd_get_more_chars(
 		if (c > 0)
 		{
 		    *cp = c;
-# ifdef FEAT_CMDL_INFO
 		    // Guessing how to update showcmd here...
 		    del_from_showcmd(3);
 		    *need_flushbuf |= add_to_showcmd(*cp);
-# endif
 		}
 	    }
 #endif
@@ -789,9 +775,7 @@ normal_cmd(
     if (KeyTyped && !KeyStuffed)
 	win_ensure_size();
 
-#ifdef FEAT_CMDL_INFO
     need_flushbuf = add_to_showcmd(c);
-#endif
 
     // Get the command count
     c = normal_cmd_get_count(&ca, c, toplevel, set_prevcount, &ctrl_w,
@@ -879,14 +863,13 @@ normal_cmd(
     if (normal_cmd_needs_more_chars(&ca, nv_cmds[idx].cmd_flags))
 	idx = normal_cmd_get_more_chars(idx, &ca, &need_flushbuf);
 
-#ifdef FEAT_CMDL_INFO
     // Flush the showcmd characters onto the screen so we can see them while
     // the command is being executed.  Only do this when the shown command was
     // actually displayed, otherwise this will slow down a lot when executing
     // mappings.
     if (need_flushbuf)
 	out_flush();
-#endif
+
     if (ca.cmdchar != K_IGNORE)
     {
 	if (ex_normal_busy)
@@ -991,11 +974,9 @@ normal_end:
     }
 #endif
 
-#ifdef FEAT_CMDL_INFO
     if (oap->op_type == OP_NOP && oap->regname == 0
 	    && ca.cmdchar != K_CURSORHOLD)
 	clear_showcmd();
-#endif
 
     checkpcmark();		// check if we moved since setting pcmark
     vim_free(ca.searchbuf);
@@ -1566,13 +1547,10 @@ may_clear_cmdline(void)
 {
     if (mode_displayed)
 	clear_cmdline = TRUE;   // unshow visual mode later
-#ifdef FEAT_CMDL_INFO
     else
 	clear_showcmd();
-#endif
 }
 
-#if defined(FEAT_CMDL_INFO) || defined(PROTO)
 /*
  * Routines for displaying a partly typed command
  */
@@ -1820,7 +1798,6 @@ display_showcmd(void)
 
     setcursor();	    // put cursor back where it belongs
 }
-#endif
 
 /*
  * When "check" is FALSE, prepare for commands that scroll the window.
@@ -2550,9 +2527,8 @@ nv_z_get_count(cmdarg_T *cap, int *nchar_arg)
 	LANGMAP_ADJUST(nchar, TRUE);
 	--no_mapping;
 	--allow_keys;
-#ifdef FEAT_CMDL_INFO
 	(void)add_to_showcmd(nchar);
-#endif
+
 	if (nchar == K_DEL || nchar == K_KDEL)
 	    n /= 10;
 	else if (VIM_ISDIGIT(nchar))
@@ -2607,9 +2583,8 @@ nv_zg_zw(cmdarg_T *cap, int nchar)
 	LANGMAP_ADJUST(nchar, TRUE);
 	--no_mapping;
 	--allow_keys;
-#ifdef FEAT_CMDL_INFO
 	(void)add_to_showcmd(nchar);
-#endif
+
 	if (vim_strchr((char_u *)"gGwW", nchar) == NULL)
 	{
 	    clearopbeep(cap->oap);

--- a/src/option.c
+++ b/src/option.c
@@ -3931,7 +3931,7 @@ findoption(char_u *arg)
     return opt_idx;
 }
 
-#if defined(FEAT_EVAL) || defined(FEAT_TCL) || defined(FEAT_MZSCHEME)
+#if defined(FEAT_EVAL) || defined(FEAT_TCL) || defined(FEAT_MZSCHEME) || defined(FEAT_SPELL)
 /*
  * Get the value for an option.
  *

--- a/src/option.c
+++ b/src/option.c
@@ -6851,9 +6851,7 @@ paste_option_changed(void)
     static int	old_p_paste = FALSE;
     static int	save_sm = 0;
     static int	save_sta = 0;
-#ifdef FEAT_CMDL_INFO
     static int	save_ru = 0;
-#endif
 #ifdef FEAT_RIGHTLEFT
     static int	save_ri = 0;
     static int	save_hkmap = 0;
@@ -6887,9 +6885,7 @@ paste_option_changed(void)
 	    // save global options
 	    save_sm = p_sm;
 	    save_sta = p_sta;
-#ifdef FEAT_CMDL_INFO
 	    save_ru = p_ru;
-#endif
 #ifdef FEAT_RIGHTLEFT
 	    save_ri = p_ri;
 	    save_hkmap = p_hkmap;
@@ -6930,11 +6926,9 @@ paste_option_changed(void)
 	// set global options
 	p_sm = 0;		    // no showmatch
 	p_sta = 0;		    // no smarttab
-#ifdef FEAT_CMDL_INFO
 	if (p_ru)
 	    status_redraw_all();    // redraw to remove the ruler
 	p_ru = 0;		    // no ruler
-#endif
 #ifdef FEAT_RIGHTLEFT
 	p_ri = 0;		    // no reverse insert
 	p_hkmap = 0;		    // no Hebrew keyboard
@@ -6980,11 +6974,9 @@ paste_option_changed(void)
 	// restore global options
 	p_sm = save_sm;
 	p_sta = save_sta;
-#ifdef FEAT_CMDL_INFO
 	if (p_ru != save_ru)
 	    status_redraw_all();    // redraw to draw the ruler
 	p_ru = save_ru;
-#endif
 #ifdef FEAT_RIGHTLEFT
 	p_ri = save_ri;
 	p_hkmap = save_hkmap;

--- a/src/option.h
+++ b/src/option.h
@@ -821,9 +821,7 @@ EXTERN int	p_ri;		// 'revins'
 #if defined(DYNAMIC_RUBY)
 EXTERN char_u	*p_rubydll;	// 'rubydll'
 #endif
-#ifdef FEAT_CMDL_INFO
 EXTERN int	p_ru;		// 'ruler'
-#endif
 #ifdef FEAT_STL_OPT
 EXTERN char_u	*p_ruf;		// 'rulerformat'
 #endif
@@ -890,9 +888,7 @@ EXTERN int	p_sn;		// 'shortname'
 #ifdef FEAT_LINEBREAK
 EXTERN char_u	*p_sbr;		// 'showbreak'
 #endif
-#ifdef FEAT_CMDL_INFO
 EXTERN int	p_sc;		// 'showcmd'
-#endif
 EXTERN int	p_sft;		// 'showfulltag'
 EXTERN int	p_sm;		// 'showmatch'
 EXTERN int	p_smd;		// 'showmode'

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -2060,11 +2060,7 @@ static struct vimoption options[] =
 #endif
 			    SCTX_INIT},
     {"ruler",	    "ru",   P_BOOL|P_VI_DEF|P_VIM|P_RSTAT,
-#ifdef FEAT_CMDL_INFO
 			    (char_u *)&p_ru, PV_NONE,
-#else
-			    (char_u *)NULL, PV_NONE,
-#endif
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"rulerformat", "ruf",  P_STRING|P_VI_DEF|P_ALLOCED|P_RSTAT|P_MLE,
 #ifdef FEAT_STL_OPT
@@ -2224,11 +2220,7 @@ static struct vimoption options[] =
 #endif
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"showcmd",	    "sc",   P_BOOL|P_VIM,
-#ifdef FEAT_CMDL_INFO
 			    (char_u *)&p_sc, PV_NONE,
-#else
-			    (char_u *)NULL, PV_NONE,
-#endif
 			    {(char_u *)FALSE,
 #ifdef UNIX
 				(char_u *)FALSE

--- a/src/screen.c
+++ b/src/screen.c
@@ -4420,7 +4420,6 @@ showmode(void)
 	msg_clr_eos();
     }
 
-#ifdef FEAT_CMDL_INFO
     // In Visual mode the size of the selected area must be redrawn.
     if (VIsual_active)
 	clear_showcmd();
@@ -4429,7 +4428,7 @@ showmode(void)
     // message and must be redrawn
     if (redrawing() && lastwin->w_status_height == 0)
 	win_redr_ruler(lastwin, TRUE, FALSE);
-#endif
+
     redraw_cmdline = FALSE;
     redraw_mode = FALSE;
     clear_cmdline = FALSE;
@@ -4790,18 +4789,17 @@ messaging(void)
     void
 comp_col(void)
 {
-#if defined(FEAT_CMDL_INFO)
     int last_has_status = (p_ls == 2 || (p_ls == 1 && !ONE_WINDOW));
 
     sc_col = 0;
     ru_col = 0;
     if (p_ru)
     {
-# ifdef FEAT_STL_OPT
+#ifdef FEAT_STL_OPT
 	ru_col = (ru_wid ? ru_wid : COL_RULER) + 1;
-# else
+#else
 	ru_col = COL_RULER + 1;
-# endif
+#endif
 	// no last status line, adjust sc_col
 	if (!last_has_status)
 	    sc_col = ru_col;
@@ -4818,10 +4816,6 @@ comp_col(void)
 	sc_col = 1;
     if (ru_col <= 0)
 	ru_col = 1;
-#else
-    sc_col = Columns;
-    ru_col = Columns;
-#endif
 #ifdef FEAT_EVAL
     set_vim_var_nr(VV_ECHOSPACE, sc_col - 1);
 #endif

--- a/src/spell.c
+++ b/src/spell.c
@@ -2932,9 +2932,11 @@ ex_spellrepall(exarg_T *eap UNUSED)
 	    STRCAT(p, line + curwin->w_cursor.col + STRLEN(repl_from));
 	    ml_replace(curwin->w_cursor.lnum, p, FALSE);
 	    changed_bytes(curwin->w_cursor.lnum, curwin->w_cursor.col);
+#if defined(FEAT_PROP_POPUP)
 	    if (curbuf->b_has_textprop && addlen != 0)
 		adjust_prop_columns(curwin->w_cursor.lnum,
 				 curwin->w_cursor.col, addlen, APC_SUBSTITUTE);
+#endif
 
 	    if (curwin->w_cursor.lnum != prev_lnum)
 	    {

--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -702,9 +702,11 @@ spell_suggest(int count)
 	    curwin->w_cursor.col = c;
 
 	    changed_bytes(curwin->w_cursor.lnum, c);
+#if defined(FEAT_PROP_POPUP)
 	    if (curbuf->b_has_textprop && len_diff != 0)
 		adjust_prop_columns(curwin->w_cursor.lnum, c, len_diff,
 							       APC_SUBSTITUTE);
+#endif
 	}
     }
     else

--- a/src/structs.h
+++ b/src/structs.h
@@ -268,7 +268,7 @@ typedef struct
     int		wo_spell;
 # define w_p_spell w_onebuf_opt.wo_spell // 'spell'
 #endif
-#if defined(FEAT_SYN_HL) || defined(FEAT_FOLDING)
+#if defined(FEAT_SYN_HL) || defined(FEAT_FOLDING) || defined(FEAT_DIFF)
     int		wo_cuc;
 # define w_p_cuc w_onebuf_opt.wo_cuc	// 'cursorcolumn'
     int		wo_cul;
@@ -3831,7 +3831,7 @@ struct window_S
     long_u	w_p_fde_flags;	    // flags for 'foldexpr'
     long_u	w_p_fdt_flags;	    // flags for 'foldtext'
 #endif
-#if defined(FEAT_SIGNS) || defined(FEAT_FOLDING)
+#if defined(FEAT_SIGNS) || defined(FEAT_FOLDING) || defined(FEAT_DIFF)
     int		*w_p_cc_cols;	    // array of columns to highlight or NULL
     char_u	w_p_culopt_flags;   // flags for cursorline highlighting
 #endif

--- a/src/structs.h
+++ b/src/structs.h
@@ -3785,17 +3785,15 @@ struct window_S
     linenr_T	w_redraw_bot;	    // when != 0: last line needing redraw
     int		w_redr_status;	    // if TRUE status line must be redrawn
 
-#ifdef FEAT_CMDL_INFO
     // remember what is shown in the ruler for this window (if 'ruler' set)
     pos_T	w_ru_cursor;	    // cursor position shown in ruler
     colnr_T	w_ru_virtcol;	    // virtcol shown in ruler
     linenr_T	w_ru_topline;	    // topline shown in ruler
     linenr_T	w_ru_line_count;    // line count used for ruler
-# ifdef FEAT_DIFF
+#ifdef FEAT_DIFF
     int		w_ru_topfill;	    // topfill shown in ruler
-# endif
-    char	w_ru_empty;	    // TRUE if ruler shows 0-1 (empty line)
 #endif
+    char	w_ru_empty;	    // TRUE if ruler shows 0-1 (empty line)
 
     int		w_alt_fnum;	    // alternate file (for # and CTRL-^)
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -268,7 +268,7 @@ typedef struct
     int		wo_spell;
 # define w_p_spell w_onebuf_opt.wo_spell // 'spell'
 #endif
-#ifdef FEAT_SYN_HL
+#if defined(FEAT_SYN_HL) || defined(FEAT_FOLDING)
     int		wo_cuc;
 # define w_p_cuc w_onebuf_opt.wo_cuc	// 'cursorcolumn'
     int		wo_cul;
@@ -3831,7 +3831,7 @@ struct window_S
     long_u	w_p_fde_flags;	    // flags for 'foldexpr'
     long_u	w_p_fdt_flags;	    // flags for 'foldtext'
 #endif
-#ifdef FEAT_SYN_HL
+#if defined(FEAT_SIGNS) || defined(FEAT_FOLDING)
     int		*w_p_cc_cols;	    // array of columns to highlight or NULL
     char_u	w_p_culopt_flags;   // flags for cursorline highlighting
 #endif

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2315,15 +2315,13 @@ term_paste_register(int prev_c UNUSED)
     long	reglen = 0;
     int		type;
 
-#ifdef FEAT_CMDL_INFO
     if (add_to_showcmd(prev_c))
     if (add_to_showcmd('"'))
 	out_flush();
-#endif
+
     c = term_vgetc();
-#ifdef FEAT_CMDL_INFO
     clear_showcmd();
-#endif
+
     if (!term_use_loop())
 	// job finished while waiting for a character
 	return;
@@ -2702,16 +2700,14 @@ terminal_loop(int blocking)
 	    int	    prev_raw_c = raw_c;
 	    int	    prev_mod_mask = mod_mask;
 
-#ifdef FEAT_CMDL_INFO
 	    if (add_to_showcmd(c))
 		out_flush();
-#endif
+
 	    raw_c = term_vgetc();
 	    c = raw_c_to_ctrl(raw_c);
 
-#ifdef FEAT_CMDL_INFO
 	    clear_showcmd();
-#endif
+
 	    if (!term_use_loop_check(TRUE)
 					 || in_terminal_loop != curbuf->b_term)
 		// job finished while waiting for a character

--- a/src/version.c
+++ b/src/version.c
@@ -158,11 +158,7 @@ static char *(features[]) =
 #endif
 	"+cmdline_compl",
 	"+cmdline_hist",
-#ifdef FEAT_CMDL_INFO
 	"+cmdline_info",
-#else
-	"-cmdline_info",
-#endif
 	"+comments",
 #ifdef FEAT_CONCEAL
 	"+conceal",

--- a/src/window.c
+++ b/src/window.c
@@ -604,9 +604,8 @@ wingotofile:
 		LANGMAP_ADJUST(xchar, TRUE);
 		--no_mapping;
 		--allow_keys;
-#ifdef FEAT_CMDL_INFO
 		(void)add_to_showcmd(xchar);
-#endif
+
 		switch (xchar)
 		{
 #if defined(FEAT_QUICKFIX)


### PR DESCRIPTION
All combined these adds very little to the resulting filesize, between 12K and 20K depending on the compile flags:

|            | -O0          | -O2          | -Os          |
| ---------- | ------------ | ------------ | ------------ |
| master     | 1795496 1.8M | 1638240 1.6M | 1199456 1.2M |
| this patch | 1816152 +20K | 1654688 +16K | 1211808 +12K |


Looking at the code, there's a bit of extra runtime overhead in terms of memory and CPU, but that seems tiny as well.
