### PR TITLE
fix: get_ctime() crashes according to Ubuntu-22.04 automatic crash reports

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -82,7 +82,7 @@ vim_time(void)
     char *
 get_ctime(time_t thetime, int add_newline)
 {
-    static char buf[50];
+    static char buf[100];
 #ifdef HAVE_STRFTIME
     struct tm	tmval;
     struct tm	*curtime;
@@ -90,22 +90,28 @@ get_ctime(time_t thetime, int add_newline)
     curtime = vim_localtime(&thetime, &tmval);
     // MSVC returns NULL for an invalid value of seconds.
     if (curtime == NULL)
-	vim_strncpy((char_u *)buf, (char_u *)_("(Invalid)"), sizeof(buf) - 1);
+	vim_strncpy((char_u *)buf, (char_u *)_("(Invalid)"), sizeof(buf) - 2);
     else
     {
 	// xgettext:no-c-format
-	(void)strftime(buf, sizeof(buf) - 1, _("%a %b %d %H:%M:%S %Y"),
-								    curtime);
+	if (strftime(buf, sizeof(buf) - 2, _("%a %b %d %H:%M:%S %Y"), curtime) == 0)
+	{
+	    // Quoting "man strftime":
+	    // > If the length of the result string (including the terminating
+	    // > null byte) would exceed max bytes, then strftime() returns 0,
+	    // > and the contents of the array are undefined.
+	    vim_strncpy((char_u *)buf, (char_u *)_("(Invalid)"), sizeof(buf) - 2);
+	}
 # ifdef MSWIN
 	if (enc_codepage >= 0 && (int)GetACP() != enc_codepage)
 	{
 	    char_u	*to_free = NULL;
 	    int		len;
 
-	    acp_to_enc((char_u *)buf, (int)strlen(buf), &to_free, &len);
+	    acp_to_enc((char_u *)buf, (int)(sizeof(buf) - 2), &to_free, &len);
 	    if (to_free != NULL)
 	    {
-		STRCPY(buf, to_free);
+		STRNCPY(buf, to_free, sizeof(buf) - 2);
 		vim_free(to_free);
 	    }
 	}
@@ -318,10 +324,8 @@ f_strftime(typval_T *argvars, typval_T *rettv)
 	convert_setup(&conv, p_enc, enc);
 	if (conv.vc_type != CONV_NONE)
 	    p = string_convert(&conv, p, NULL);
-	if (p != NULL)
-	    (void)strftime((char *)result_buf, sizeof(result_buf),
-							  (char *)p, curtime);
-	else
+	if (p == NULL || strftime((char *)result_buf, sizeof(result_buf),
+						  (char *)p, curtime) == 0)
 	    result_buf[0] = NUL;
 
 	if (conv.vc_type != CONV_NONE)
@@ -1117,16 +1121,19 @@ add_time(char_u *buf, size_t buflen, time_t tt)
 #ifdef HAVE_STRFTIME
     struct tm	tmval;
     struct tm	*curtime;
+    int		n;
 
     if (vim_time() - tt >= 100)
     {
 	curtime = vim_localtime(&tt, &tmval);
 	if (vim_time() - tt < (60L * 60L * 12L))
 	    // within 12 hours
-	    (void)strftime((char *)buf, buflen, "%H:%M:%S", curtime);
+	    n = strftime((char *)buf, buflen, "%H:%M:%S", curtime);
 	else
 	    // longer ago
-	    (void)strftime((char *)buf, buflen, "%Y/%m/%d %H:%M:%S", curtime);
+	    n = strftime((char *)buf, buflen, "%Y/%m/%d %H:%M:%S", curtime);
+	if (n == 0)
+	    buf[0] = NUL;
     }
     else
 #endif


### PR DESCRIPTION
1/ Looking at this query...
  https://errors.ubuntu.com/?release=Ubuntu%2022.04&package=vim&period=day

I see that the most frequent source of crashes in Vim in
Ubuntu-22.04 is a crash in get_ctime() where buffer buf[50]
overflows when doing STRCAT(buf, "\n") at the end of the function.
There are 10 occurrences of this crash being automatically reported.

Ubuntu-22.04 uses vim-8.2.3995 which is a bit old, but the function get_ctime()
has not been changed since 2020-02-14 according to git blame, so
the bug should still be present in the latest Vim.

I don't know how to reproduce it (it most certainly depends on the locale)
but inspecting the code, I can see several bugs which could cause this
crash:

- we should pass a max bytes of sizeof(buf) - 2 for strftime() call 
  instead of sizeof(buf) - 1 because we need to leave space for
  the "\n" appended at the end of the function get_ctime and for the
  NUL for end of string.

- according to the man page, if strftime() fails, it returns 0 and leaves
  the buffer with undefined content. So we should check the return
  value instead of ignoring it.

- for MSWIN (irrelevant for the Ubuntu crash of course), there are
  2 additional bugs:
  - we should pass sizeof(buf) - 2 for the max bytes in buf instead
    of strlen(buf).
  - we should use STRNCPY instead of STRCPY to prevent overflows.

That's a lot of bugs.

Since apparently there might be a local where the date exceeds 50 bytes,
maybe because of Unicode characters that use multiple bytes or because
abbreviated days %a or abbreviated month %b may take more than 3 characters
in some locale, I also increased buf size from 50 to 100 so truncation
is less likely to happen (most certainly should not happen anymore).

2/ There are other unrelated calls to strftime() which did
not check the return value of strftime(). Patch also fixes that.

3/ :help strftime() says:

> The maximum length of the result is 80 characters.

However, I see that the implementation in f_strftime() uses
a buffer of 256 bytes which is inconsistent with the doc.
I did not fix that.
