### PR TITLE
Add documentation for autoload (and :color) auto-load packages

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -628,6 +628,11 @@ When Vim starts up, after processing your .vimrc, it scans all directories in
 directories are added to 'runtimepath'.  Then all the plugins are loaded.
 See |packload-two-steps| for how these two steps can be useful.
 
+To allow for calling into package functionality while parsing your .vimrc,
+|:colorscheme| and |autoload| will both automatically search under 'packpath'
+as well in addition to 'runtimepath'.  See the documentation for each for
+details.
+
 In the example Vim will find "pack/foo/start/foobar/plugin/foo.vim" and adds
 "~/.vim/pack/foo/start/foobar" to 'runtimepath'.
 

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -482,6 +482,10 @@ then define the function like this: >
 	   echo "Done!"
 	endfunction
 
+If the file doesn't exist, Vim will also search in 'packpath' (under "start")
+to allow calling packages' functions from your .vimrc when the packages have
+not been added to 'runtimepath' yet (see |packages|).
+
 The file name and the name used before the # in the function must match
 exactly, and the defined function must have the name exactly as it will be
 called.  In Vim9 script the "g:" prefix must be used: >

--- a/runtime/doc/usr_52.txt
+++ b/runtime/doc/usr_52.txt
@@ -159,6 +159,7 @@ relative path: >
 
 This will search for the script "monthlib.vim" in the autoload directories of
 'runtimepath'.  With Unix one of the directories often is "~/.vim/autoload".
+It will also search under 'packpath', under "start".
 
 The main advantage of this is that this script can be easily shared with other
 scripts.  You do need to make sure that the script name is unique, since Vim


### PR DESCRIPTION
Autoload functionality now automatically searches 'packpath' to support calling package functions from a vimrc file (#7193). However, the documentation were not updated in that commit, so it's still a little confusing to the user exactly how this works. Document that both in the packages docs and autoload docs.

Also add some mentioning of :colorscheme's behavior in the ~~autoload~~ (Edit: package) docs as well as it also does something similar.