### PR TITLE
sed.vim: allow end-of-line comments

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3024,12 +3024,21 @@ To make tabs stand out from regular blanks (accomplished by using Todo
 highlighting on the tabs), define "highlight_sedtabs" by putting >
 
 	:let highlight_sedtabs = 1
-
+<
 in the vimrc file.  (This special highlighting only applies for tabs
 inside search patterns, replacement texts, addresses or text included
 by an Append/Change/Insert command.)  If you enable this option, it is
 also a good idea to set the tab width to one character; by doing that,
 you can easily count the number of tabs in a string.
+
+GNU sed allows comments to follow other text on the same line.
+BSD sed only allows comments when "#" is the first character of the line.
+To enforce BSD-style comments, i.e. mark end-of-line comments as errors, use: >
+
+	:let sed_dialect = "bsd"
+<
+Note that there are other differences between GNU sed and BSD sed which are
+not (yet) affected by this setting.
 
 Bugs:
 

--- a/runtime/syntax/sed.vim
+++ b/runtime/syntax/sed.vim
@@ -2,7 +2,7 @@
 " Language:	sed
 " Maintainer:	Haakon Riiser <hakonrk@fys.uio.no>
 " URL:		http://folk.uio.no/hakonrk/vim/syntax/sed.vim
-" Last Change:	2010 May 29
+" Last Change:	2022 Oct 13
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -17,8 +17,13 @@ syn match sedAddress	"[[:digit:]$]"
 syn match sedAddress	"\d\+\~\d\+"
 syn region sedAddress   matchgroup=Special start="[{,;]\s*/\(\\/\)\="lc=1 skip="[^\\]\(\\\\\)*\\/" end="/I\=" contains=sedTab,sedRegexpMeta
 syn region sedAddress   matchgroup=Special start="^\s*/\(\\/\)\=" skip="[^\\]\(\\\\\)*\\/" end="/I\=" contains=sedTab,sedRegexpMeta
-syn match sedComment	"^\s*#.*$"
 syn match sedFunction	"[dDgGhHlnNpPqQx=]\s*\($\|;\)" contains=sedSemicolon,sedWhitespace
+if exists("g:sed_dialect") && g:sed_dialect ==? "bsd"
+    syn match sedComment	"^\s*#.*$"
+else
+    syn match sedFunction	"[dDgGhHlnNpPqQx=]\s*\ze#" contains=sedSemicolon,sedWhitespace
+    syn match sedComment	"#.*$"
+endif
 syn match sedLabel	":[^;]*"
 syn match sedLineCont	"^\(\\\\\)*\\$" contained
 syn match sedLineCont	"[^\\]\(\\\\\)*\\$"ms=e contained


### PR DESCRIPTION
Closes #5876.

Allows (does not highlight as Error) end-of-line comments. Makes this default, but allows old behavior with `sed_syntax_style="bsd"`.

I have tested on Windows gVim 9.0.626 & linuxbrew Vim 9.0.700. I don't have an easy way to test on BSD or other platforms, but nothing should break; the worst case should be highlighting inconsistent with the platform's sed syntax.

Note [from the issue](https://github.com/vim/vim/issues/5876#issuecomment-608265394) that the file is apparently abandoned by the listed maintainer.