### PR TITLE
add shortmess option for "scanning" messages while ins-completion

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7079,6 +7079,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  c	don't give |ins-completion-menu| messages.  For example,
 		"-- XXX completion (YYY)", "match 1 of 2", "The only match",
 		"Pattern not found", "Back at original", etc.
+	  C	don't give messages while scanning for ins-completion items.
+		For instance "scanning tags."
 	  q	use "recording" instead of "recording @a"
 	  F	don't give the file info when editing a file, like `:silent`
 		was used for the command; note that this also affects messages

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1573,7 +1573,7 @@ ins_compl_files(
     for (i = 0; i < count && !got_int && !compl_interrupted; i++)
     {
 	fp = mch_fopen((char *)files[i], "r");  // open dictionary file
-	if (flags != DICT_EXACT)
+	if (flags != DICT_EXACT && !shortmess(SHM_COMPLETIONSCAN))
 	{
 	    msg_hist_off = TRUE;	// reset in msg_trunc_attr()
 	    vim_snprintf((char *)IObuff, IOSIZE,
@@ -3281,14 +3281,16 @@ process_next_cpt_value(
 	    st->dict = st->ins_buf->b_fname;
 	    st->dict_f = DICT_EXACT;
 	}
-	msg_hist_off = TRUE;	// reset in msg_trunc_attr()
-	vim_snprintf((char *)IObuff, IOSIZE, _("Scanning: %s"),
-		st->ins_buf->b_fname == NULL
-		    ? buf_spname(st->ins_buf)
-		    : st->ins_buf->b_sfname == NULL
-			? st->ins_buf->b_fname
-			: st->ins_buf->b_sfname);
-	(void)msg_trunc_attr((char *)IObuff, TRUE, HL_ATTR(HLF_R));
+	if (!shortmess(SHM_COMPLETIONSCAN)) {
+	    msg_hist_off = TRUE;	// reset in msg_trunc_attr()
+	    vim_snprintf((char *)IObuff, IOSIZE, _("Scanning: %s"),
+		    st->ins_buf->b_fname == NULL
+			? buf_spname(st->ins_buf)
+			: st->ins_buf->b_sfname == NULL
+			    ? st->ins_buf->b_fname
+			    : st->ins_buf->b_sfname);
+	    (void)msg_trunc_attr((char *)IObuff, TRUE, HL_ATTR(HLF_R));
+	}
     }
     else if (*st->e_cpt == NUL)
 	status = INS_COMPL_CPT_END;
@@ -3316,10 +3318,12 @@ process_next_cpt_value(
 #endif
 	else if (*st->e_cpt == ']' || *st->e_cpt == 't')
 	{
-	    msg_hist_off = TRUE;	// reset in msg_trunc_attr()
 	    compl_type = CTRL_X_TAGS;
-	    vim_snprintf((char *)IObuff, IOSIZE, _("Scanning tags."));
-	    (void)msg_trunc_attr((char *)IObuff, TRUE, HL_ATTR(HLF_R));
+	    if (!shortmess(SHM_COMPLETIONSCAN)) {
+		msg_hist_off = TRUE;	// reset in msg_trunc_attr()
+		vim_snprintf((char *)IObuff, IOSIZE, _("Scanning tags."));
+		(void)msg_trunc_attr((char *)IObuff, TRUE, HL_ATTR(HLF_R));
+	    }
 	}
 	else
 	    compl_type = -1;

--- a/src/option.h
+++ b/src/option.h
@@ -265,11 +265,12 @@ typedef enum {
 #define SHM_ATTENTION	'A'		// no ATTENTION messages
 #define SHM_INTRO	'I'		// intro messages
 #define SHM_COMPLETIONMENU  'c'		// completion menu messages
+#define SHM_COMPLETIONSCAN  'C'		// completion scanning messages
 #define SHM_RECORDING	'q'		// short recording message
 #define SHM_FILEINFO	'F'		// no file info messages
 #define SHM_SEARCHCOUNT  'S'		// search stats: '[1/10]'
 #define SHM_POSIX       "AS"		// POSIX value
-#define SHM_ALL		"rmfixlnwaWtToOsAIcqFS" // all possible flags for 'shm'
+#define SHM_ALL		"rmfixlnwaWtToOsAIcCqFS" // all possible flags for 'shm'
 
 // characters for p_go:
 #define GO_TERMINAL	'!'		// use terminal for system commands


### PR DESCRIPTION
Problem: shortmess+=c does not hide all insert mode completion messages.
Solution: add shortmess+=C which disables the messages while scanning for items