### PR TITLE
Fix off-by-one error in column calculation for popup_setpos in mouse (and bugs in visual line and also one-char selection)

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -596,7 +596,19 @@ do_mouse(
 			jump_flags = MOUSE_MAY_STOP_VIS;
 		    else
 		    {
-			if ((LT_POS(curwin->w_cursor, VIsual)
+			if (VIsual_mode == 'V')
+			{
+			    if ((curwin->w_cursor.lnum <= VIsual.lnum
+				    && (m_pos.lnum < curwin->w_cursor.lnum
+					|| VIsual.lnum < m_pos.lnum))
+				|| (VIsual.lnum < curwin->w_cursor.lnum
+				    && (m_pos.lnum < VIsual.lnum
+					|| curwin->w_cursor.lnum < m_pos.lnum)))
+			    {
+				jump_flags = MOUSE_MAY_STOP_VIS;
+			    }
+			}
+			else if ((LTOREQ_POS(curwin->w_cursor, VIsual)
 				    && (LT_POS(m_pos, curwin->w_cursor)
 					|| LT_POS(VIsual, m_pos)))
 				|| (LT_POS(VIsual, curwin->w_cursor)

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -172,8 +172,6 @@ get_fpos_of_mouse(pos_T *mpos)
 
     mpos->col = vcol2col(wp, mpos->lnum, col);
 
-    if (mpos->col > 0)
-	--mpos->col;
     mpos->coladd = 0;
     return IN_BUFFER;
 }

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -1298,20 +1298,20 @@ func Test_term_mouse_popup_menu_setpos()
     call assert_equal([1, 10], [line('.'), col('.')], msg)
     call assert_equal('ran away', @", msg)
 
-    " Test for right click in visual mode before the selection
+    " Test for right click in visual mode right before the selection
     let @" = ''
     call cursor(1, 10)
-    call feedkeys('vee' .. MouseRightClickCode(1, 2)
-		\ .. MouseRightReleaseCode(1, 2) .. "\<Down>\<CR>", "x")
-    call assert_equal([1, 2], [line('.'), col('.')], msg)
+    call feedkeys('vee' .. MouseRightClickCode(1, 9)
+		\ .. MouseRightReleaseCode(1, 9) .. "\<Down>\<CR>", "x")
+    call assert_equal([1, 9], [line('.'), col('.')], msg)
     call assert_equal('', @", msg)
 
-    " Test for right click in visual mode after the selection
+    " Test for right click in visual mode right after the selection
     let @" = ''
     call cursor(1, 10)
-    call feedkeys('vee' .. MouseRightClickCode(1, 20)
-		\ .. MouseRightReleaseCode(1, 20) .. "\<Down>\<CR>", "x")
-    call assert_equal([1, 20], [line('.'), col('.')], msg)
+    call feedkeys('vee' .. MouseRightClickCode(1, 18)
+		\ .. MouseRightReleaseCode(1, 18) .. "\<Down>\<CR>", "x")
+    call assert_equal([1, 18], [line('.'), col('.')], msg)
     call assert_equal('', @", msg)
 
     " Test for right click in block-wise visual mode inside the selection
@@ -1330,6 +1330,32 @@ func Test_term_mouse_popup_menu_setpos()
     call assert_equal([2, 2], [line('.'), col('.')], msg)
     call assert_equal('v', getregtype('"'), msg)
     call assert_equal('', @", msg)
+
+    " Test for right click in line-wise visual mode inside the selection
+    let @" = ''
+    call cursor(1, 16)
+    call feedkeys("V" .. MouseRightClickCode(1, 10)
+		\ .. MouseRightReleaseCode(1, 10) .. "\<Down>\<CR>", "x")
+    call assert_equal([1, 1], [line('.'), col('.')], msg) " After yanking, the cursor goes to 1,1
+    call assert_equal("V", getregtype('"'), msg)
+    call assert_equal(len(getreg('"', 1, v:true)), 1, msg)
+
+    " Test for right click in multi-line line-wise visual mode inside the selection
+    let @" = ''
+    call cursor(1, 16)
+    call feedkeys("Vj" .. MouseRightClickCode(2, 20)
+		\ .. MouseRightReleaseCode(2, 20) .. "\<Down>\<CR>", "x")
+    call assert_equal([1, 1], [line('.'), col('.')], msg) " After yanking, the cursor goes to 1,1
+    call assert_equal("V", getregtype('"'), msg)
+    call assert_equal(len(getreg('"', 1, v:true)), 2, msg)
+
+    " Test for right click in line-wise visual mode outside the selection
+    let @" = ''
+    call cursor(1, 16)
+    call feedkeys("V" .. MouseRightClickCode(2, 10)
+		\ .. MouseRightReleaseCode(2, 10) .. "\<Down>\<CR>", "x")
+    call assert_equal([2, 10], [line('.'), col('.')], msg)
+    call assert_equal("", @", msg)
 
     " Try clicking on the status line
     let @" = ''


### PR DESCRIPTION
This fixes an off-by-one error arbitrarily introduced in the popup_setpos calculation (in `get_fpos_of_mouse()`) code in mouse.c. I'm not really sure why it's there as we intentionally decrement the column by 1, but from looking at the code I cannot see why it's there at all, considering the column is already 0-indexed.

Testing this in GTK and MacVim confirms that it fixes the issue, and the function isn't used outside of popup_setpos.