### PR TITLE
Support `CSI {key} u` keys without modifiers

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -4862,6 +4862,32 @@ handle_key_with_modifier(
 }
 
 /*
+ * Handle a sequence with key without a modifier:
+ *	{lead}{key}u
+ * Returns the difference in length.
+ */
+    static int
+handle_key_without_modifier(
+	int	*arg,
+	int	csi_len,
+	int	offset,
+	char_u	*buf,
+	int	bufsize,
+	int	*buflen)
+{
+    int	    key = arg[0];
+    int	    new_slen = 0;
+    char_u  string[MAX_KEY_CODE_LEN + 1];
+
+    string[new_slen++] = key;
+
+    if (put_string_in_typebuf(offset, csi_len, string, new_slen,
+						 buf, bufsize, buflen) == FAIL)
+	return -1;
+    return new_slen - csi_len + offset;
+}
+
+/*
  * Handle a CSI escape sequence.
  * - Xterm version string.
  *
@@ -5013,6 +5039,14 @@ handle_csi(
 	    || (argc == 2 && trail == 'u'))
     {
 	return len + handle_key_with_modifier(arg, trail,
+			    csi_len, offset, buf, bufsize, buflen);
+    }
+
+    // Key without modifier:
+    //	{lead}{key}u
+    else if (argc == 1 && trail == 'u')
+    {
+	return len + handle_key_without_modifier(arg,
 			    csi_len, offset, buf, bufsize, buflen);
     }
 

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -1992,6 +1992,11 @@ func GetEscCodeCSIu(key, modifier)
   return "\<Esc>[" .. key .. ';' .. mod .. 'u'
 endfunc
 
+func GetEscCodeCSIuWithoutModifier(key)
+  let key = printf("%d", char2nr(a:key))
+  return "\<Esc>[" .. key .. 'u'
+endfunc
+
 " This checks the CSI sequences when in modifyOtherKeys mode.
 " The mode doesn't need to be enabled, the codes are always detected.
 func RunTest_modifyOtherKeys(func)
@@ -2078,6 +2083,19 @@ func Test_modifyOtherKeys_no_mapping()
   bwipe!
 
   set timeoutlen&
+endfunc
+
+func Test_CSIu_keys_without_modifiers()
+  " Escape sent as `CSI 27 u` should act as normal escape and not undo
+  call setline(1, 'a')
+  call feedkeys('a' .. GetEscCodeCSIuWithoutModifier("\e"), 'Lx!')
+  call assert_equal('n', mode())
+  call assert_equal('a', getline(1))
+
+  " Tab sent as `CSI 9 u` should work
+  call setline(1, '')
+  call feedkeys('a' .. GetEscCodeCSIuWithoutModifier("\t") .. "\<Esc>", 'Lx!')
+  call assert_equal("\t", getline(1))
 endfunc
 
 " Check that when DEC mouse codes are recognized a special key is handled.


### PR DESCRIPTION
The kitty terminal emulator, as well as some others, suppors sending keys as `CSI {key} u`, like the keys with modifiers that's already supported, but for keys without any modifiers. The most notable example is escape being sent as `CSI 27 u`, to be able to distinguish the key press from the start of an escape sequence. It's also used to support some "special" keys, like media keys and print screen.

The main reason for adding support for this is a problem with kitty and the existing key handling in vim. By default kitty has support for keys that are not traditionally supported in terminals, like super+<key>, and sends those as keys with modifiers. E.g. super+q is `CSI 113 ; 9 u`. If I press such a key, vim sets `seenModifyOtherKeys` to true and stops processing normal control keys, so the bindings i have for those stops working because kitty sends them as normal control keys by default.

I can set kitty to send control keys as keys with modifiers by enabling disambiguate escape codes by sending `CSI > 1 u`. This makes the control keys work again. However, this also changes the escape key to be sent as `CSI 27 u`, so that stops working. By adding support for this, all keys work as far as I know.

The problem exists by default when I'm not enabling disambiguate escape codes though, so it would be nice if vim could enable this automatically. I think it should be safe to send it to any terminal emulator, but alternatively vim could query for support of the protocol by sending `CSI ? u` and check if it gets a reply like `CSI ? flags u`.

Note that none of the escape sequences I wrote actually contains spaces, they were just added for readability.

You can read more about the keyboard handling in kitty here: https://sw.kovidgoyal.net/kitty/keyboard-protocol/

There's also an issue in kitty's repo with some discussion here: https://github.com/kovidgoyal/kitty/issues/4075