### PR TITLE
Add missing Ex commands to help index, and add test to catch them in future

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1150,7 +1150,7 @@ tag		command		action ~
 |:!!|		:!!		repeat last ":!" command
 |:#|		:#		same as ":number"
 |:&|		:&		repeat last ":substitute"
-|:star|		:*		execute contents of a register
+|:star|		:*		use the last selected area in Visual mode
 |:<|		:<		shift lines one 'shiftwidth' left
 |:=|		:=		print the last line number
 |:>|		:>		shift lines one 'shiftwidth' right
@@ -1277,6 +1277,7 @@ tag		command		action ~
 |:debuggreedy|	:debugg[reedy]	read debug mode commands from normal input
 |:def|		:def		define a Vim9 user function
 |:defcompile|	:defc[ompile]	compile Vim9 user functions in current script
+|:defer|	:defer		call function when current function is done
 |:delcommand|	:delc[ommand]	delete user-defined command
 |:delfunction|	:delf[unction]	delete a user function
 |:delmarks|	:delm[arks]	delete marks
@@ -1308,6 +1309,7 @@ tag		command		action ~
 |:echohl|	:echoh[l]	set highlighting for echo commands
 |:echomsg|	:echom[sg]	same as :echo, put message in history
 |:echon|	:echon		same as :echo, but without <EOL>
+|:echowindow|	:echow[indow]	same as :echomsg, but use a popup window
 |:else|		:el[se]		part of an :if command
 |:elseif|	:elsei[f]	part of an :if command
 |:emenu|	:em[enu]	execute a menu by name
@@ -1356,6 +1358,7 @@ tag		command		action ~
 |:highlight|	:hi[ghlight]	specify highlighting methods
 |:hide|		:hid[e]		hide current buffer for a command
 |:history|	:his[tory]	print a history list
+|:horizontal|	:hor[izontal]	make windcmd = only apply horizontally
 |:insert|	:i[nsert]	insert text
 |:iabbrev|	:ia[bbrev]	like ":abbrev" but for Insert mode
 |:iabclear|	:iabc[lear]	like ":abclear" but for Insert mode

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -91,6 +91,7 @@ NEW_TESTS = \
 	test_cjk_linebreak \
 	test_clientserver \
 	test_close_count \
+	test_cmd_lists \
 	test_cmdline \
 	test_cmdmods \
 	test_cmdwin \
@@ -351,6 +352,7 @@ NEW_TESTS_RES = \
 	test_cjk_linebreak.res \
 	test_clientserver.res \
 	test_close_count.res \
+	test_cmd_lists.res \
 	test_cmdline.res \
 	test_cmdmods.res \
 	test_cmdwin.res \

--- a/src/testdir/test_cmd_lists.vim
+++ b/src/testdir/test_cmd_lists.vim
@@ -1,0 +1,68 @@
+" Test to verify that the cmd list in runtime/doc/index.txt contains all of
+" the commands in src/ex_cmds.h. It doesn't map the other way round because
+" index.txt contains some shorthands like :!! which are useful to list, but
+" they don't exist as an independent entry in src/ex_cmds.h.
+"
+" Currently this just checks for existence, and we aren't checking for whether
+" they are sorted in the index, or whether the substring needed (e.g.
+" 'defc[ompile]') is correct or not.
+
+func Test_cmd_lists()
+
+  " Create a list of the commands in ex_cmds.h:CMD_index.
+  enew!
+  read ../ex_cmds.h
+  1,/^enum CMD_index$/d
+  call search('^};$')
+  .,$d
+  v/^EXCMD/d
+  %s/^.*"\(\S\+\)".*$/\1/
+  " Special case ':*' because it's represented as ':star'
+  %s/^\*$/star/
+  sort u
+  let l:command_list = getline(1, '$')
+
+  " Verify that the ':help ex-cmd-index' list contains all known commands.
+  enew!
+  if filereadable('../../doc/index.txt')
+    " unpacked MS-Windows zip archive
+    read ../../doc/index.txt
+  else
+    read ../../runtime/doc/index.txt
+  endif
+  call search('\*ex-cmd-index\*')
+  1,.d
+  v/^|:/d
+  %s/^|:\(\S*\)|.*/\1/
+  sort u
+  norm gg
+  let l:missing_cmds = []
+  for cmd in l:command_list
+    " Reserved Vim 9 commands or other script-only syntax aren't useful to
+    " document as Ex commands.
+    let l:vim9cmds = [
+          \ 'abstract',
+          \ 'class',
+          \ 'endclass',
+          \ 'endenum',
+          \ 'endinterface',
+          \ 'enum',
+          \ 'interface',
+          \ 'static',
+          \ 'type',
+          \ '++',
+          \ '--',
+          \ '{',
+          \ '}']
+    if index(l:vim9cmds, cmd) != -1
+      continue
+    endif
+
+    if search('^\V' .. cmd .. '\v$', 'cW') == 0
+      call add(l:missing_cmds, ':' .. cmd)
+    endif
+  endfor
+  call assert_equal(0, len(l:missing_cmds), "Missing commands from `:help ex-cmd-index`: " .. string(l:missing_cmds))
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This is similar to test_function_lists.vim, which makes sure we won't forget to add this again in the future.

I omitted the Vim9script specific stuff as those seems more like they are only useful for scripting and not really for Ex cmds.