### PR TITLE
Don't clear previous command on :!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ src/testdir/messages
 src/testdir/viminfo
 src/testdir/opt_test.vim
 src/testdir/failed
+src/testdir/starttime
 runtime/indent/testdir/*.out
 runtime/indent/testdir/*.fail
 src/memfile_test

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -249,7 +249,8 @@ g8			Print the hex values of the bytes used in the
 
 							*:!cmd* *:!*
 :!{cmd}			Execute {cmd} with the shell.  See also the 'shell'
-			and 'shelltype' option.
+			and 'shelltype' option. :! without a {cmd} is a no-op
+			that does nothing.
 							*E34*
 			Any '!' in {cmd} is replaced with the previous
 			external command (see also 'cpoptions').  But not when

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -957,6 +957,11 @@ do_bang(
 	}
     } while (trailarg != NULL);
 
+    // Don't do anything if there is no command as there isn't really anything
+    // useful to do except run "sh -c ''".
+    if (STRLEN(newcmd) == 0)
+	return;
+
     vim_free(prevcmd);
     prevcmd = newcmd;
 

--- a/src/testdir/test_shell.vim
+++ b/src/testdir/test_shell.vim
@@ -251,4 +251,33 @@ func Test_set_shell()
   call delete('Xtestout')
 endfunc
 
+func Test_shell_repeat()
+  let save_shell = &shell
+
+  call writefile(['#!/bin/sh', 'echo "Cmd: [$*]" > Xlog'], 'Xtestshell', 'D')
+  call setfperm('Xtestshell', "r-x------")
+  set shell=./Xtestshell
+  defer delete('Xlog')
+
+  call feedkeys(":!echo coconut\<CR>", 'xt')   " Run command
+  call assert_equal(['Cmd: [-c echo coconut]'], readfile('Xlog'))
+
+  call feedkeys(":!!\<CR>", 'xt')              " Re-run previous
+  call assert_equal(['Cmd: [-c echo coconut]'], readfile('Xlog'))
+
+  call writefile(['empty'], 'Xlog')
+  call feedkeys(":!\<CR>", 'xt')               " :! is a no-op
+  call assert_equal(['empty'], readfile('Xlog'))
+
+  call feedkeys(":!!\<CR>", 'xt')              " :! doesn't clear previous command
+  call assert_equal(['Cmd: [-c echo coconut]'], readfile('Xlog'))
+
+  call feedkeys(":!echo banana\<CR>", 'xt')    " Make sure setting previous command keeps working after a :! no-op
+  call assert_equal(['Cmd: [-c echo banana]'], readfile('Xlog'))
+  call feedkeys(":!!\<CR>", 'xt')
+  call assert_equal(['Cmd: [-c echo banana]'], readfile('Xlog'))
+
+  let &shell = save_shell
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_shell.vim
+++ b/src/testdir/test_shell.vim
@@ -252,6 +252,8 @@ func Test_set_shell()
 endfunc
 
 func Test_shell_repeat()
+  CheckUnix
+
   let save_shell = &shell
 
   call writefile(['#!/bin/sh', 'echo "Cmd: [$*]" > Xlog'], 'Xtestshell', 'D')


### PR DESCRIPTION
If I run a command with :!

        :!echo asd
        asd

        Press ENTER or type command to continue

I can repeat it quickly with :!!

        :!!
        :!echo asd
        asd

        Press ENTER or type command to continue

Now I accidentally use :! instead of :!!

        :!

        Press ENTER or type command to continue

And the previous command is gone:

        :!!

        Press ENTER or type command to continue

Need to hit ENTER to clear the prompt, press :!, up, Enter to get it back.

Been bugging me for years.

---

Also: I'm not sure if there's a good reason for :! to do anything at all instead of being a no-op? It just runs sh -c '', but I don't know if there is some reason for it to behave as it does?