### PR TITLE
CI uninstall brew perl and use built-in perl (mac OS huge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,7 @@ jobs:
         run: |
           brew install lua
           echo "LUA_PREFIX=/usr/local" >> $GITHUB_ENV
+          brew uninstall perl
 
       - name: Set up environment
         run: |
@@ -317,8 +318,7 @@ jobs:
           normal)
             ;;
           huge)
-            # Use "dynamic" for Perl otherwise it fails.
-            echo "CONFOPT=--enable-perlinterp=dynamic --enable-python3interp --enable-rubyinterp --enable-luainterp --enable-tclinterp"
+            echo "CONFOPT=--enable-perlinterp --enable-python3interp --enable-rubyinterp --enable-luainterp --enable-tclinterp"
             ;;
           esac
           ) >> $GITHUB_ENV


### PR DESCRIPTION
better workaround which re-enable `--enable-perlinterp`