### PR TITLE
Add a guard to manpager.vim

### DIFF
--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -2,6 +2,11 @@
 " Maintainer: Enno Nagel <ennonagel+vim@gmail.com>
 " Last Change: 2022 Sep 30
 
+if exists('g:loaded_manpager_plugin')
+  finish
+endif
+let g:loaded_manpager_plugin = 1
+
 " Set up the current buffer (likely read from stdin) as a manpage
 command MANPAGER call s:ManPager()
 


### PR DESCRIPTION
Closes #11388

Add a guard to manpager.vim to avoid double loading.