### PR TITLE
Fix Home/End keys not recognized at hit-Enter prompt

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -871,13 +871,13 @@ static struct builtin_term builtin_termcaps[] =
     {K_HELP,		"\033[28;*~"},
     {K_UNDO,		"\033[26;*~"},
     {K_INS,		"\033[2;*~"},
-    {K_HOME,		"\033[1;*H"},
+    {K_HOME,		"\033[@;*H"},
     // {K_S_HOME,		"\033O2H"},
     // {K_C_HOME,		"\033O5H"},
     {K_KHOME,		"\033[1;*~"},
     {K_XHOME,		"\033O*H"},	// other Home
     {K_ZHOME,		"\033[7;*~"},	// other Home
-    {K_END,		"\033[1;*F"},
+    {K_END,		"\033[@;*F"},
     // {K_S_END,		"\033O2F"},
     // {K_C_END,		"\033O5F"},
     {K_KEND,		"\033[4;*~"},


### PR DESCRIPTION
As mentioned in issue #7562 and patch 8.2.2246, cursor keys are not recognized at the hit-Enter prompt after executing an external command. While arrow keys were fixed by that, the Home and End keys are also considered cursor keys by xterm and also change control sequences between normal and application mode, so they were still not working.

To be honest, the reason I discovered this is that after enabling the kitty keyboard protocol as discussed in PR #11364 the Home and End keys stopped working. While debugging this, I noticed this inconsistency between the handling of the arrow keys and Home/End keys since the arrow keys still worked. The reason for this is that in this mode, kitty sends the arrow and Home/End keys the same way as in normal terminal mode, and vim supports that for arrow keys, but not for Home/End keys.

I would hesitate to change the builtin termcap for xterm to just fix behavior in kitty, but since this is an inconsistency between the handling of the arrow keys and the Home/End keys that I don't think should be there, and since it actually fixes the #7562 issue for Home/End keys in xterm I think it makes sense to do this change. And it happens to also fix the problem I have with Home/End keys in the kitty keyboard protocol (at least as long as TERM is some xterm name).