### PR TITLE
Do not apply 'langmap' if merging modifiers results in another char

### DIFF
--- a/src/testdir/test_langmap.vim
+++ b/src/testdir/test_langmap.vim
@@ -49,6 +49,39 @@ func Test_langmap()
   call feedkeys(';', 'tx')
   call assert_equal(5, col('.'))
 
+  set langmap=RL
+  let g:counter = 0
+  nnoremap L;L <Cmd>let g:counter += 1<CR>
+  nnoremap <C-L> <Cmd>throw 'This mapping shoud not be triggered'<CR>
+
+  " 'langmap' is applied to keys without modifiers when matching a mapping
+  call feedkeys('R;R', 'tx')
+  call assert_equal(1, g:counter)
+  nunmap L;L
+  unlet g:counter
+
+  delete
+  call assert_equal('', getline(1))
+  undo
+  call assert_equal('Hello World', getline(1))
+  " 'langmap' does not change Ctrl-R to Ctrl-L for consistency
+  call feedkeys("\<*C-R>", 'tx')
+  call assert_equal('', getline(1))
+
+  set langmap=6L
+  undo
+  setlocal bufhidden=hide
+  let oldbuf = bufnr()
+  enew
+  call assert_notequal(oldbuf, bufnr())
+  " 'langmap' does not change Ctrl-6 to Ctrl-L for consistency
+  " Ctrl-6 becomes Ctrl-^ after merging the Ctrl modifier
+  call feedkeys("\<*C-6>", 'tx')
+  call assert_equal(oldbuf, bufnr())
+  setlocal bufhidden&
+
+  nunmap <C-L>
+
   set langmap&
   quit!
 endfunc


### PR DESCRIPTION
This is an approach to fix #11395 that makes 'langmap' behavior
consistent only for keys for which 'langmap' previously behaves
inconsistently. However, one may argue that this is now inconsistent
between different keys or when compiled with different flags. A more
consistent solution is to just avoid 'langmap' for any key that has a
modifier, but this is a bigger change in behavior.
