### PR TITLE
Make readblob() possible to read from character device

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6859,7 +6859,11 @@ readblob({fname} [, {offset} [, {size}]])			*readblob()*
 			readblob('file.bin', 0, 100)
 <		If {size} is -1 or omitted, the whole data starting from
 		{offset} will be read.
-		When the file can't be opened an error message is given and
+		This can be also used to read the data from a character device
+		on Unix when {size} is explicitly set.  {offset} should be
+		normally zero.  E.g. to read 10 bytes from "/dev/random": >
+			readblob('/dev/random', 0, 10)
+<		When the file can't be opened an error message is given and
 		the result is an empty |Blob|.
 		When trying to read bytes beyond the end of the file the
 		result is an empty blob.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6860,8 +6860,9 @@ readblob({fname} [, {offset} [, {size}]])			*readblob()*
 <		If {size} is -1 or omitted, the whole data starting from
 		{offset} will be read.
 		This can be also used to read the data from a character device
-		on Unix when {size} is explicitly set.  {offset} should be
-		normally zero.  E.g. to read 10 bytes from a serial console: >
+		on Unix when {size} is explicitly set.  Only if the device
+		supports seeking {offset} can be used.  Otherwise it should be
+		zero.  E.g. to read 10 bytes from a serial console: >
 			readblob('/dev/ttyS0', 0, 10)
 <		When the file can't be opened an error message is given and
 		the result is an empty |Blob|.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6861,8 +6861,8 @@ readblob({fname} [, {offset} [, {size}]])			*readblob()*
 		{offset} will be read.
 		This can be also used to read the data from a character device
 		on Unix when {size} is explicitly set.  {offset} should be
-		normally zero.  E.g. to read 10 bytes from "/dev/random": >
-			readblob('/dev/random', 0, 10)
+		normally zero.  E.g. to read 10 bytes from a serial console: >
+			readblob('/dev/ttyS0', 0, 10)
 <		When the file can't be opened an error message is given and
 		the result is an empty |Blob|.
 		When trying to read bytes beyond the end of the file the

--- a/src/blob.c
+++ b/src/blob.c
@@ -212,9 +212,13 @@ read_blob(FILE *fd, typval_T *rettv, off_T offset, off_T size_arg)
     }
     // Trying to read bytes that aren't there results in an empty blob, not an
     // error.
-    if (size < 0 || size > st.st_size)
+    if (size <= 0 || (
+#ifdef S_ISCHR
+		!S_ISCHR(st.st_mode) &&
+#endif
+		size > st.st_size))
 	return OK;
-    if (vim_fseek(fd, offset, whence) != 0)
+    if (offset != 0 && vim_fseek(fd, offset, whence) != 0)
 	return OK;
 
     if (ga_grow(&blob->bv_ga, (int)size) == FAIL)

--- a/src/proto/blob.pro
+++ b/src/proto/blob.pro
@@ -10,7 +10,7 @@ int blob_get(blob_T *b, int idx);
 void blob_set(blob_T *blob, int idx, int byte);
 void blob_set_append(blob_T *blob, int idx, int byte);
 int blob_equal(blob_T *b1, blob_T *b2);
-int read_blob(FILE *fd, typval_T *rettv, off_T offset, off_T size);
+int read_blob(FILE *fd, typval_T *rettv, off_T offset, off_T size_arg);
 int write_blob(FILE *fd, blob_T *blob);
 char_u *blob2string(blob_T *blob, char_u **tofree, char_u *numbuf);
 blob_T *string2blob(char_u *str);


### PR DESCRIPTION
With this patch, readblob() can read from a character device if "offset" is zero and "size" is specified (on Unix):

```vim
let b = readblob('/dev/random', 0, 10)
```

(Not sure if this is useful, though.)