### PR TITLE
fix(filetype): correct Jsonnet file extensions

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1004,7 +1004,7 @@ au BufNewFile,BufRead .babelrc,.eslintrc,.prettierrc,.firebaserc  setf json
 au BufNewFile,BufRead *.jsonc			setf jsonc
 
 " Jsonnet
-au BufNewFile,BufRead *.jsonnet,*.libjsonnet	setf jsonnet
+au BufNewFile,BufRead *.jsonnet,*.libsonnet	setf jsonnet
 
 " Julia
 au BufNewFile,BufRead *.jl			setf julia

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -289,7 +289,7 @@ let s:filename_checks = {
     \ 'json': ['file.json', 'file.jsonp', 'file.json-patch', 'file.webmanifest', 'Pipfile.lock', 'file.ipynb', '.babelrc', '.eslintrc', '.prettierrc', '.firebaserc', 'file.slnf'],
     \ 'json5': ['file.json5'],
     \ 'jsonc': ['file.jsonc'],
-    \ 'jsonnet': ['file.jsonnet', 'file.libjsonnet'],
+    \ 'jsonnet': ['file.jsonnet', 'file.libsonnet'],
     \ 'jsp': ['file.jsp'],
     \ 'julia': ['file.jl'],
     \ 'kconfig': ['Kconfig', 'Kconfig.debug', 'Kconfig.file'],


### PR DESCRIPTION
> In this style, the configuration is a set of `.jsonnet` and `.libsonnet` files. Every output file corresponds to a `.jsonnet` file and all shared setup is in `.libsonnet` files.

https://jsonnet.org/ref/language.html#consider-self-contained-programs

Follow up to #11081