### PR TITLE
update URL for termguicolors-related extra details

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -569,7 +569,7 @@ anymore.
 Vim supports using true colors in the terminal (taken from |highlight-guifg|
 and |highlight-guibg|), given that the terminal supports this. To make this
 work the 'termguicolors' option needs to be set.
-See https://gist.github.com/XVilka/8346728 for a list of terminals that
+See https://github.com/termstandard/colors for a list of terminals that
 support true colors.
 
 Sometimes setting 'termguicolors' is not enough and one has to set the |t_8f|


### PR DESCRIPTION
It seems this information has been moved.

I'm not sure if it's appropriate to link just to a Github repository like this (maybe this should link to a specific file and/or a specific commit?), so please adjust as necessary or let me know if you want me to make changes.