### PR TITLE
Use `setl lisp` in runtime/ftplugin/dune.vim

### DIFF
--- a/runtime/ftplugin/dune.vim
+++ b/runtime/ftplugin/dune.vim
@@ -11,7 +11,7 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin=1
 
-set lisp
+setl lisp
 
 " Comment string
 setl commentstring=;\ %s


### PR DESCRIPTION
Use `setl lisp` instead of `set lisp` in runtime/ftplugin/dune.vim so other buffers aren't affected.