### PR TITLE
Add Vim ftplugin file for Apache .conf files

### DIFF
--- a/runtime/ftplugin/apache.vim
+++ b/runtime/ftplugin/apache.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin
+" Language:	apache configuration file
+" Maintainer:	Per Juchtmans <dubgeiser+vimNOSPAM@gmail.com>
+" Last Change:	2022 Oct 22
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"
+
+" vim: nowrap sw=2 sts=2 ts=8 noet:


### PR DESCRIPTION
Since Apache configuration files only use `#` for comments, the default values for `comments` and `commentstring` are not completely correct.

Closes #11417