### PR TITLE
Error in screen dump for Test_smoothscroll_one_long_line.

### DIFF
--- a/src/testdir/dumps/Test_smooth_one_long_2.dump
+++ b/src/testdir/dumps/Test_smooth_one_long_2.dump
@@ -1,6 +1,6 @@
-|<+0#4040ff13#ffffff0@2|t+0#0000000&|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t
->s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f
+|<+0#4040ff13#ffffff0@2>t+0#0000000&|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t
+|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f
 | |t|e|x|t| @34
+@40
 |~+0#4040ff13&| @38
-|~| @38
-| +0#0000000&@21|1|,|8|1| @9|A|l@1| 
+| +0#0000000&@21|1|,|4@1| @9|A|l@1| 


### PR DESCRIPTION
The corrected screen dump puts the cursor on the 1st screen line, the current dump erroneously has the cursor on the 2nd screen line. So the test seems to pass, but in fact it fails. This is related to https://groups.google.com/g/vim_dev/c/YkQbUsC-pek/m/WeyQk4lhAwAJ

BTW, if I do `call term_dumpload("Test_smooth_one_long_2.dump")` the cursor is shown in the wrong spot. I'm guessing this is an issue in `term_dumpload`, but this area is not well known (or even poorly known) to me. The first line on the screen is
```
<<<ts of text with lots of text with lot
```
The `term_dumpload` shows the cursor on column 0; but it should be on column 3, the first visible text character on that line.