### PR TITLE
feat: added tape extension

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2181,6 +2181,9 @@ au BufNewFile,BufRead *.va,*.vams		setf verilogams
 " SystemVerilog
 au BufNewFile,BufRead *.sv,*.svh		setf systemverilog
 
+" VHS tape
+au BufNewFile,BufRead *.tape		    setf vhs
+
 " VHDL
 au BufNewFile,BufRead *.hdl,*.vhd,*.vhdl,*.vbe,*.vst,*.vho  setf vhdl
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2182,6 +2182,8 @@ au BufNewFile,BufRead *.va,*.vams		setf verilogams
 au BufNewFile,BufRead *.sv,*.svh		setf systemverilog
 
 " VHS tape
+" .tape is also used by TapeCalc, which we do not support.
+" If we want to support it we'll need to match the contents of the file.
 au BufNewFile,BufRead *.tape		    setf vhs
 
 " VHDL

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -611,6 +611,7 @@ let s:filename_checks = {
     \ 'verilogams': ['file.va', 'file.vams'],
     \ 'vgrindefs': ['vgrindefs'],
     \ 'vhdl': ['file.hdl', 'file.vhd', 'file.vhdl', 'file.vbe', 'file.vst', 'file.vhdl_123', 'file.vho', 'some.vhdl_1', 'some.vhdl_1-file'],
+    \ 'vhs': ['file.tape'],
     \ 'vim': ['file.vim', 'file.vba', '.exrc', '_exrc', 'some-vimrc', 'some-vimrc-file', 'vimrc', 'vimrc-file'],
     \ 'viminfo': ['.viminfo', '_viminfo'],
     \ 'vmasm': ['file.mar'],


### PR DESCRIPTION
[VHS](https://github.com/charmbracelet/vhs) is a tool that generates terminal gifs from code, like asciicinema, but with actual gifs as result, and instead of recoding it, you generate them from code.

`.tape` is the extension of those files.

I already PR the treesitter stuff, check https://github.com/nvim-treesitter/nvim-treesitter/pull/3726

This registers `.tape` files to the `vhs` filetype.

refs https://github.com/neovim/neovim/pull/20831