### PR TITLE
Test_fileformats() errors

### DIFF
--- a/src/testdir/test_fileformat.vim
+++ b/src/testdir/test_fileformat.vim
@@ -94,6 +94,8 @@ func Test_fileformats()
   call assert_equal("mac\rmac\r\n", s:file2str('Xtest'))
   bwipe XXUnix XXDos XXMac
 
+  new
+
   " try with 'fileformat' set to 'dos'
   set fileformat=dos
   e! XXUnix
@@ -106,6 +108,8 @@ func Test_fileformats()
   w! Xtest
   call assert_equal("mac\rmac\r\r\n", s:file2str('Xtest'))
   bwipe XXUnix XXDos XXMac
+
+  new
 
   " try with 'fileformat' set to 'mac'
   set fileformat=mac
@@ -122,6 +126,8 @@ func Test_fileformats()
 
   " Test 2: try reading and writing with 'fileformats' set to one format
 
+  new
+
   " try with 'fileformats' set to 'unix'
   set fileformats=unix
   e! XXUxDsMc
@@ -130,6 +136,8 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
+  new
+
   " try with 'fileformats' set to 'dos'
   set fileformats=dos
   e! XXUxDsMc
@@ -137,6 +145,8 @@ func Test_fileformats()
   call assert_equal("unix\r\nunix\r\ndos\r\ndos\r\nmac\rmac\r\r\n",
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
+
+  new
 
   " try with 'fileformats' set to 'mac'
   set fileformats=mac
@@ -148,6 +158,8 @@ func Test_fileformats()
 
   " Test 3: try reading and writing with 'fileformats' set to two formats
 
+  new
+
   " try with 'fileformats' set to 'unix,dos'
   set fileformats=unix,dos
   e! XXUxDsMc
@@ -156,15 +168,21 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
+  new
+
   e! XXUxMac
   w! Xtest
   call assert_equal("unix\nunix\nmac\rmac\r\n", s:file2str('Xtest'))
   bwipe XXUxMac
 
+  new
+
   e! XXDosMac
   w! Xtest
   call assert_equal("dos\r\ndos\r\nmac\rmac\r\r\n", s:file2str('Xtest'))
   bwipe XXDosMac
+
+  new
 
   " try with 'fileformats' set to 'unix,mac'
   set fileformats=unix,mac
@@ -173,22 +191,30 @@ func Test_fileformats()
   call assert_equal("unix\nunix\ndos\r\ndos\r\n", s:file2str('Xtest'))
   bwipe XXUxDs
 
+  new
+
   e! XXUxDsMc
   w! Xtest
   call assert_equal("unix\nunix\ndos\r\ndos\r\nmac\rmac\r\n",
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
+  new
+
   e! XXDosMac
   w! Xtest
   call assert_equal("dos\r\ndos\r\nmac\rmac\r", s:file2str('Xtest'))
   bwipe XXDosMac
+
+  new
 
   e! XXEol
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
   w! Xtest
   call assert_equal("unix,mac:unix\nnoeol\n", s:file2str('Xtest'))
   bwipe! XXEol
+
+  new
 
   " try with 'fileformats' set to 'dos,mac'
   set fileformats=dos,mac
@@ -197,6 +223,8 @@ func Test_fileformats()
   call assert_equal("unix\r\nunix\r\ndos\r\ndos\r\n", s:file2str('Xtest'))
   bwipe XXUxDs
 
+  new
+
   e! XXUxMac
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
   w! Xtest
@@ -204,11 +232,15 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe! XXUxMac
 
+  new
+
   e! XXUxDsMc
   w! Xtest
   call assert_equal("unix\r\nunix\r\ndos\r\ndos\r\nmac\rmac\r\r\n",
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
+
+  new
 
   e! XXMacEol
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
@@ -217,6 +249,9 @@ func Test_fileformats()
   bwipe! XXMacEol
 
   " Test 4: try reading and writing with 'fileformats' set to three formats
+
+  new
+
   set fileformats=unix,dos,mac
   e! XXUxDsMc
   w! Xtest
@@ -224,11 +259,15 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
+  new
+
   e! XXEol
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
   w! Xtest
   call assert_equal("unix,dos,mac:unix\nnoeol\n", s:file2str('Xtest'))
   bwipe! XXEol
+
+  new
 
   set fileformats=mac,dos,unix
   e! XXUxDsMc
@@ -237,6 +276,8 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
+  new
+
   e! XXEol
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
   w! Xtest
@@ -244,6 +285,9 @@ func Test_fileformats()
   bwipe! XXEol
 
   " Test 5: try with 'binary' set
+
+  new
+
   set fileformats=mac,unix,dos
   set binary
   e! XXUxDsMc
@@ -252,6 +296,8 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
+  new
+
   set fileformats=mac
   e! XXUxDsMc
   w! Xtest
@@ -259,12 +305,16 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
+  new
+
   set fileformats=dos
   e! XXUxDsMc
   w! Xtest
   call assert_equal("unix\nunix\ndos\r\ndos\r\nmac\rmac\r",
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
+
+  new
 
   e! XXUnix
   w! Xtest

--- a/src/testdir/test_fileformat.vim
+++ b/src/testdir/test_fileformat.vim
@@ -63,6 +63,13 @@ endfun
 
 " Test for a lot of variations of the 'fileformats' option
 func Test_fileformats()
+  " in case we have some buffer open, when starting this test, and we will come
+  " back to those buffer with incompatible 'fileformat' option value, content of
+  " buffer will be re-interpreted and in case of some modeline expressions there
+  " will be an error. Wipe all away helps in this case.
+  only
+  %bwipe!
+
   " create three test files, one in each format
   call writefile(['unix', 'unix'], 'XXUnix', 'D')
   call writefile(["dos\r", "dos\r"], 'XXDos', 'D')
@@ -75,8 +82,6 @@ func Test_fileformats()
   call s:concat_files('XXDos', 'XXMac', 'XXDosMac')
   call s:concat_files('XXMac', 'XXEol', 'XXMacEol')
   call s:concat_files('XXUxDs', 'XXMac', 'XXUxDsMc')
-
-  new
 
   " Test 1: try reading and writing with 'fileformats' empty
   set fileformats=
@@ -94,8 +99,6 @@ func Test_fileformats()
   call assert_equal("mac\rmac\r\n", s:file2str('Xtest'))
   bwipe XXUnix XXDos XXMac
 
-  new
-
   " try with 'fileformat' set to 'dos'
   set fileformat=dos
   e! XXUnix
@@ -108,8 +111,6 @@ func Test_fileformats()
   w! Xtest
   call assert_equal("mac\rmac\r\r\n", s:file2str('Xtest'))
   bwipe XXUnix XXDos XXMac
-
-  new
 
   " try with 'fileformat' set to 'mac'
   set fileformat=mac
@@ -126,8 +127,6 @@ func Test_fileformats()
 
   " Test 2: try reading and writing with 'fileformats' set to one format
 
-  new
-
   " try with 'fileformats' set to 'unix'
   set fileformats=unix
   e! XXUxDsMc
@@ -136,8 +135,6 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
-  new
-
   " try with 'fileformats' set to 'dos'
   set fileformats=dos
   e! XXUxDsMc
@@ -145,8 +142,6 @@ func Test_fileformats()
   call assert_equal("unix\r\nunix\r\ndos\r\ndos\r\nmac\rmac\r\r\n",
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
-
-  new
 
   " try with 'fileformats' set to 'mac'
   set fileformats=mac
@@ -158,8 +153,6 @@ func Test_fileformats()
 
   " Test 3: try reading and writing with 'fileformats' set to two formats
 
-  new
-
   " try with 'fileformats' set to 'unix,dos'
   set fileformats=unix,dos
   e! XXUxDsMc
@@ -168,21 +161,15 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
-  new
-
   e! XXUxMac
   w! Xtest
   call assert_equal("unix\nunix\nmac\rmac\r\n", s:file2str('Xtest'))
   bwipe XXUxMac
 
-  new
-
   e! XXDosMac
   w! Xtest
   call assert_equal("dos\r\ndos\r\nmac\rmac\r\r\n", s:file2str('Xtest'))
   bwipe XXDosMac
-
-  new
 
   " try with 'fileformats' set to 'unix,mac'
   set fileformats=unix,mac
@@ -191,30 +178,22 @@ func Test_fileformats()
   call assert_equal("unix\nunix\ndos\r\ndos\r\n", s:file2str('Xtest'))
   bwipe XXUxDs
 
-  new
-
   e! XXUxDsMc
   w! Xtest
   call assert_equal("unix\nunix\ndos\r\ndos\r\nmac\rmac\r\n",
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
-  new
-
   e! XXDosMac
   w! Xtest
   call assert_equal("dos\r\ndos\r\nmac\rmac\r", s:file2str('Xtest'))
   bwipe XXDosMac
-
-  new
 
   e! XXEol
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
   w! Xtest
   call assert_equal("unix,mac:unix\nnoeol\n", s:file2str('Xtest'))
   bwipe! XXEol
-
-  new
 
   " try with 'fileformats' set to 'dos,mac'
   set fileformats=dos,mac
@@ -223,8 +202,6 @@ func Test_fileformats()
   call assert_equal("unix\r\nunix\r\ndos\r\ndos\r\n", s:file2str('Xtest'))
   bwipe XXUxDs
 
-  new
-
   e! XXUxMac
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
   w! Xtest
@@ -232,15 +209,11 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe! XXUxMac
 
-  new
-
   e! XXUxDsMc
   w! Xtest
   call assert_equal("unix\r\nunix\r\ndos\r\ndos\r\nmac\rmac\r\r\n",
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
-
-  new
 
   e! XXMacEol
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
@@ -249,9 +222,6 @@ func Test_fileformats()
   bwipe! XXMacEol
 
   " Test 4: try reading and writing with 'fileformats' set to three formats
-
-  new
-
   set fileformats=unix,dos,mac
   e! XXUxDsMc
   w! Xtest
@@ -259,15 +229,11 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
-  new
-
   e! XXEol
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
   w! Xtest
   call assert_equal("unix,dos,mac:unix\nnoeol\n", s:file2str('Xtest'))
   bwipe! XXEol
-
-  new
 
   set fileformats=mac,dos,unix
   e! XXUxDsMc
@@ -276,8 +242,6 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
-  new
-
   e! XXEol
   exe "normal ggO\<C-R>=&ffs\<CR>:\<C-R>=&ff\<CR>"
   w! Xtest
@@ -285,9 +249,6 @@ func Test_fileformats()
   bwipe! XXEol
 
   " Test 5: try with 'binary' set
-
-  new
-
   set fileformats=mac,unix,dos
   set binary
   e! XXUxDsMc
@@ -296,8 +257,6 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
-  new
-
   set fileformats=mac
   e! XXUxDsMc
   w! Xtest
@@ -305,16 +264,12 @@ func Test_fileformats()
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
 
-  new
-
   set fileformats=dos
   e! XXUxDsMc
   w! Xtest
   call assert_equal("unix\nunix\ndos\r\ndos\r\nmac\rmac\r",
 	      \ s:file2str('Xtest'))
   bwipe XXUxDsMc
-
-  new
 
   e! XXUnix
   w! Xtest


### PR DESCRIPTION
(those are probably not catched by CI because no assertion is failed, however they confuse one a lot if test is running interatively)

bwipe causes come back at some point to the buffer with source code of test itself; content of that buffer is reinterpreted with ff=mac, due to this file content looks like junk (one long string with lot of ^J) - leads to modeline confusion which blames about "expandtab trailing characters"