### PR TITLE
checking for 'stl' error is done all over the place

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -573,7 +573,6 @@ win_redr_status(win_T *wp, int ignore_pum UNUSED)
 redraw_custom_statusline(win_T *wp)
 {
     static int	    entered = FALSE;
-    int		    saved_did_emsg = did_emsg;
 
     // When called recursively return.  This can happen when the statusline
     // contains an expression that triggers a redraw.
@@ -581,18 +580,7 @@ redraw_custom_statusline(win_T *wp)
 	return;
     entered = TRUE;
 
-    did_emsg = FALSE;
     win_redr_custom(wp, FALSE);
-    if (did_emsg)
-    {
-	// When there is an error disable the statusline, otherwise the
-	// display is messed up with errors and a redraw triggers the problem
-	// again and again.
-	set_string_option_direct((char_u *)"statusline", -1,
-		(char_u *)"", OPT_FREE | (*wp->w_p_stl != NUL
-					? OPT_LOCAL : OPT_GLOBAL), SID_ERROR);
-    }
-    did_emsg |= saved_did_emsg;
     entered = FALSE;
 }
 #endif
@@ -673,12 +661,7 @@ win_redr_ruler(win_T *wp, int always, int ignore_pum)
 #ifdef FEAT_STL_OPT
     if (*p_ruf)
     {
-	int	called_emsg_before = called_emsg;
-
 	win_redr_custom(wp, TRUE);
-	if (called_emsg > called_emsg_before)
-	    set_string_option_direct((char_u *)"rulerformat", -1,
-					   (char_u *)"", OPT_FREE, SID_ERROR);
 	return;
     }
 #endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -3760,8 +3760,6 @@ get_tabline_label(
     opt = (tooltip ? &p_gtt : &p_gtl);
     if (**opt != NUL)
     {
-	int	use_sandbox = FALSE;
-	int	called_emsg_before = called_emsg;
 	char_u	res[MAXPATHL];
 	tabpage_T *save_curtab;
 	char_u	*opt_name = (char_u *)(tooltip ? "guitabtooltip"
@@ -3770,7 +3768,6 @@ get_tabline_label(
 	printer_page_num = tabpage_index(tp);
 # ifdef FEAT_EVAL
 	set_vim_var_nr(VV_LNUM, printer_page_num);
-	use_sandbox = was_set_insecurely(opt_name, 0);
 # endif
 	// It's almost as going to the tabpage, but without autocommands.
 	curtab->tp_firstwin = firstwin;
@@ -3785,7 +3782,7 @@ get_tabline_label(
 	curbuf = curwin->w_buffer;
 
 	// Can't use NameBuff directly, build_stl_str_hl() uses it.
-	build_stl_str_hl(curwin, res, MAXPATHL, *opt, use_sandbox,
+	build_stl_str_hl(curwin, res, MAXPATHL, *opt, opt_name, 0,
 						 0, (int)Columns, NULL, NULL);
 	STRCPY(NameBuff, res);
 
@@ -3796,10 +3793,6 @@ get_tabline_label(
 	lastwin = curtab->tp_lastwin;
 	curwin = curtab->tp_curwin;
 	curbuf = curwin->w_buffer;
-
-	if (called_emsg > called_emsg_before)
-	    set_string_option_direct(opt_name, -1,
-					   (char_u *)"", OPT_FREE, SID_ERROR);
     }
 
     // If 'guitablabel'/'guitabtooltip' is not set or the result is empty then

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -471,7 +471,6 @@ prt_header(
     if (*p_header != NUL)
     {
 	linenr_T	tmp_lnum, tmp_topline, tmp_botline;
-	int		use_sandbox = FALSE;
 
 	/*
 	 * Need to (temporarily) set current line number and first/last line
@@ -487,12 +486,8 @@ prt_header(
 	curwin->w_botline = lnum + 63;
 	printer_page_num = pagenum;
 
-# ifdef FEAT_EVAL
-	use_sandbox = was_set_insecurely((char_u *)"printheader", 0);
-# endif
-	build_stl_str_hl(curwin, tbuf, (size_t)(width + IOSIZE),
-						  p_header, use_sandbox,
-						  ' ', width, NULL, NULL);
+	build_stl_str_hl(curwin, tbuf, (size_t)(width + IOSIZE), p_header,
+			    (char_u *)"printheader", 0, ' ', width, NULL, NULL);
 
 	// Reset line numbers
 	curwin->w_cursor.lnum = tmp_lnum;

--- a/src/proto/buffer.pro
+++ b/src/proto/buffer.pro
@@ -48,7 +48,7 @@ void col_print(char_u *buf, size_t buflen, int col, int vcol);
 void maketitle(void);
 void resettitle(void);
 void free_titles(void);
-int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use_sandbox, int fillchar, int maxwidth, stl_hlrec_T **hltab, stl_hlrec_T **tabtab);
+int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, char_u *opt_name, int scope, int fillchar, int maxwidth, stl_hlrec_T **hltab, stl_hlrec_T **tabtab);
 void get_rel_pos(win_T *wp, char_u *buf, int buflen);
 char_u *fix_fname(char_u *fname);
 void fname_expand(buf_T *buf, char_u **ffname, char_u **sfname);


### PR DESCRIPTION
Problem:	Error checking for 'statusline'-format options is done all over the place.
Solution:	Do this locally in build_stl_str_hl() instead by passing in the option name.

This irked me while working on the 'numberformat' feature. Not sure if this is a welcome change but I thought I'd propose it. Similar refactor is done for the `use_sandbox()` calls in `win_redr_custom()`.

Currently, for some options `did_emsg` is checked while for others `called_emsg` is checked. The proposed change checks for `did_emsg` in all cases, which seemed like a harmless change to me. It doesn't seem to cause any regressions in the test suite at least.