### PR TITLE
Termdebug: allow disabling the window toolbar

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1537,6 +1537,13 @@ If you don't want this then disable it with: >
 or if there is no g:termdebug_config: >
 	let g:termdebug_popup = 0
 
+Window toolbar ~
+							*termdebug_winbar*
+
+By default the Termdebug plugin creates a window toolbar if mouse is enabled.
+If you don't want this then disable it with: >
+	let g:termdebug_config['winbar'] = 0
+
 
 Vim window width ~
 							*termdebug_wide*

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -891,7 +891,14 @@ func s:InstallCommands()
   endif
 
   if has('menu') && &mouse != ''
-    call s:InstallWinbar()
+    if exists('g:termdebug_config')
+      let winbar = get(g:termdebug_config, 'winbar', 1)
+    else
+      let winbar = 1
+    endif
+    if winbar
+      call s:InstallWinbar()
+    endif
 
     let popup = 1
     if exists('g:termdebug_config')


### PR DESCRIPTION
Problem:    The termdebug plugin assumes mouse being enabled means the user wants the window toolbar, which may not be correct.
Solution:   Add an option to explicitly disable the window toolbar (closes #11442)