### PR TITLE
Add SF Symbols 4 Unicode values to double-width table (macOS)

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -1565,10 +1565,10 @@ utf_char2cells(int c)
 	{0x1f6f3, 0x1f6f3}
 
 #ifdef MACOS_X
-	// Include SF Symbols characters, which should be rendered as
+	// Include SF Symbols 4 characters, which should be rendered as
 	// double-width. All of them are in the Supplementary Private Use
-	// Area-B range. The exact range was determined by downloading the "SF
-	// Symbols" app from Apple, and then selecting all symbols, copying
+	// Area-B range. The exact range was determined by downloading the 'SF
+	// Symbols 4' app from Apple, and then selecting all symbols, copying
 	// them out, and inspecting the unicode values of them.
 	, {0x100000, 0x1018c7}
 #endif

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -1566,10 +1566,26 @@ utf_char2cells(int c)
 
 #ifdef MACOS_X
 	// Include SF Symbols 4 characters, which should be rendered as
-	// double-width. All of them are in the Supplementary Private Use
-	// Area-B range. The exact range was determined by downloading the 'SF
-	// Symbols 4' app from Apple, and then selecting all symbols, copying
-	// them out, and inspecting the unicode values of them.
+	// double-width.  SF Symbols is an Apple-specific set of symbols and
+	// icons for use in Apple operating systems.  They are included as
+	// glyphs as part of the default San Francisco fonts shipped with
+	// macOS.  The symbols are released in a versioned manner, and the
+	// latest version is SF Symbols 4.
+	//
+	// These Apple-specific glyphs are not part of standard Unicode, and
+	// all of them are in the Supplementary Private Use Area-B range. The
+	// exact range was determined by downloading the 'SF Symbols 4' app
+	// from Apple (https://developer.apple.com/sf-symbols/), and then
+	// selecting all symbols, copying them out, and inspecting the unicode
+	// values of them.
+	//
+	// Note that these symbols are of varying widths, as they are symbols
+	// representing differents things ranging from a simple gear icon to an
+	// airplane. Some of them are in fact wider than double-width, but Vim
+	// doesn't support non-fixed-width font, and tagging them as
+	// double-width is the easiest way to handle them now.
+	//
+	// Also see https://en.wikipedia.org/wiki/San_Francisco_(sans-serif_typeface)#SF_Symbols
 	, {0x100000, 0x1018c7}
 #endif
     };

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -1570,7 +1570,7 @@ utf_char2cells(int c)
 	// Area-B range. The exact range was determined by downloading the "SF
 	// Symbols" app from Apple, and then selecting all symbols, copying
 	// them out, and inspecting the unicode values of them.
-	, {0x100000, 0x100d7f}
+	, {0x100000, 0x1018c7}
 #endif
     };
 


### PR DESCRIPTION
With the release of macOS 13 Ventura, Apple has also released SF Symbols 4 which contains new symbols to be used by apps. Just as before, these symbols also have corresponding Unicode values by using the Supplmentary Private Use Area-B range. Add the new symbols' Unicode values to the double-width ranges so Vim will show them properly. (In reality some of the symbols like the ones for cars like 'suv.side' / U+00101800 are quite long and go longer than double-width, but this is a decent enough compromise since Vim doesn't have triple-width characters, and I don't think any of them are narrow enough to use single-width)