### PR TITLE
Fix crash with win_move_separator() in another tabpage

### DIFF
--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -889,6 +889,11 @@ f_win_move_separator(typval_T *argvars, typval_T *rettv)
     wp = find_win_by_nr_or_id(&argvars[0]);
     if (wp == NULL || win_valid_popup(wp))
 	return;
+    if (!win_valid(wp))
+    {
+	emsg(_(e_cannot_resize_window_in_another_tab_page));
+	return;
+    }
 
     offset = (int)tv_get_number(&argvars[1]);
     win_drag_vsep_line(wp, offset);

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -1652,18 +1652,24 @@ func Test_mouse_drag_statusline()
   set laststatus=2
   set mouse=a
   func ClickExpr()
-      call test_setmouse(&lines - 1, 1)
-        return "\<LeftMouse>"
+    call test_setmouse(&lines - 1, 1)
+    return "\<LeftMouse>"
   endfunc
   func DragExpr()
-      call test_setmouse(&lines - 2, 1)
-        return "\<LeftDrag>"
+    call test_setmouse(&lines - 2, 1)
+    return "\<LeftDrag>"
   endfunc
   nnoremap <expr> <F2> ClickExpr()
   nnoremap <expr> <F3> DragExpr()
 
   " this was causing a crash in win_drag_status_line()
   call feedkeys("\<F2>:tabnew\<CR>\<F3>", 'tx')
+
+  nunmap <F2>
+  nunmap <F3>
+  delfunc ClickExpr
+  delfunc DragExpr
+  set laststatus& mouse&
 endfunc
 
 " Test for mapping <LeftDrag> in Insert mode

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1483,23 +1483,33 @@ func Test_win_move_separator()
   call assert_equal(w0, winwidth(0))
   call assert_true(win_move_separator(0, -1))
   call assert_equal(w0, winwidth(0))
+
   " check that win_move_separator doesn't error with offsets beyond moving
   " possibility
   call assert_true(win_move_separator(id, 5000))
   call assert_true(winwidth(id) > w)
   call assert_true(win_move_separator(id, -5000))
   call assert_true(winwidth(id) < w)
+
   " check that win_move_separator returns false for an invalid window
   wincmd =
   let w = winwidth(0)
   call assert_false(win_move_separator(-1, 1))
   call assert_equal(w, winwidth(0))
+
   " check that win_move_separator returns false for a popup window
   let id = popup_create(['hello', 'world'], {})
   let w = winwidth(id)
   call assert_false(win_move_separator(id, 1))
   call assert_equal(w, winwidth(id))
   call popup_close(id)
+
+  " check that using another tabpage fails without crash
+  let id = win_getid()
+  tabnew
+  call assert_fails('call win_move_separator(id, -1)', 'E1308:')
+  tabclose
+
   %bwipe!
 endfunc
 


### PR DESCRIPTION
The first two crashes in #11427 have been fixed, so this closes #11427.
