### PR TITLE
Fix: Redefining `HAVE_DUP` at Python 3.11

### DIFF
--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -45,6 +45,9 @@
 # undef F_BLANK
 #endif
 
+#ifdef HAVE_DUP
+# undef HAVE_DUP
+#endif
 #ifdef HAVE_STRFTIME
 # undef HAVE_STRFTIME
 #endif


### PR DESCRIPTION
Python 3.11 defines `HAVE_DUP` at pyconfig.h, so should set `undef HAVE_DUP` at if_python3.c to avoid redefining.

```
gcc -c -I. -I/usr/local/share/asdf/installs/python/3.11.0/include/python3.11 -pthread -DDYNAMIC_PYTHON3_DLL=\"libpython3.11.so.1.0\" -Iproto -DHAVE_CONFIG_H   -DWE_ARE_PROFILING
 -Wall -Wextra -Wshadow -Wno-unknown-pragmas -g -ggdb3 -O0  -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -Wall -Wextra -Wshadow -Werror -Wno-error=maybe-uninitialized
   -o objects/if_python3.o if_python3.c
In file included from /usr/local/share/asdf/installs/python/3.11.0/include/python3.11/Python.h:12,
                 from if_python3.c:69:
/usr/local/share/asdf/installs/python/3.11.0/include/python3.11/pyconfig.h:292: error: "HAVE_DUP" redefined [-Werror]
  292 | #define HAVE_DUP 1
      |
In file included from vim.h:244,
                 from if_python3.c:32:
os_unix.h:481: note: this is the location of the previous definition
  481 | # define HAVE_DUP               // have dup()
      |
```