### PR TITLE
win32: Recognize VSCMD_ARG_TGT_ARCH environment variable

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -222,8 +222,12 @@ CPU = i386
 !  endif
 ! else  # !CPU
 CPU = i386
-!  if !defined(PLATFORM) && defined(TARGET_CPU)
+!  ifndef PLATFORM
+!   ifdef TARGET_CPU
 PLATFORM = $(TARGET_CPU)
+!   elseif defined(VSCMD_ARG_TGT_ARCH)
+PLATFORM = $(VSCMD_ARG_TGT_ARCH)
+!   endif
 !  endif
 !  ifdef PLATFORM
 !   if ("$(PLATFORM)" == "x64") || ("$(PLATFORM)" == "X64")


### PR DESCRIPTION
When "Developer Command Prompt for VS 2017" is selected on Windows Terminal, the `VSCMD_ARG_TGT_ARCH` environment variable is set, but the `Platform` environment variable is not set.

Recognize `VSCMD_ARG_TGT_ARCH`.