### PR TITLE
Fix 'eof' option

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -578,6 +578,30 @@ single <NL> characters are unexpectedly replaced with <CR><NL>.
 You can encrypt files that are written by setting the 'key' option.  This
 provides some security against others reading your files. |encryption|
 
+END OF LINE AND END OF FILE				*eol-and-eof*
+
+Vim has several options to control the file formats:
+	'fileformat'	the <EOL> style
+	'endoofline'	whether every line ends with a <EOL>
+	'endooffile'	whether the file ends with a CTRL-Z
+	'fixendofline'	whether to fix eol and eof
+
+Here are some examples how to use them.
+
+If you want files in Unix format (every line NL terminated): >
+	setl ff=unix fixeol
+
+If you want to use an old MS-DOS file in a modern environment, fixing line
+endings and dropping CTRL-Z, keeping the <CR><NL> style <EOL>: >
+	setl ff=dos fixeol
+
+If you want to drop final <EOL> and add final CTRL-Z (e.g. for old systems
+like CP/M): >
+	setl ff=dos nofixeol noeol eof
+
+If you want to preserve the fileformat exactly as-is, including final <EOL>
+and final CTRL-Z: >
+	setl nofixeol
 
 ==============================================================================
 3. The argument list				*argument-list* *arglist*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3056,6 +3056,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When writing a file and this option is off and the 'binary' option
 	is on, or 'fixeol' option is off, no CTRL-Z will be written at the
 	end of the file.
+	See |eol-and-eof| for example settings.
 
 			*'endofline'* *'eol'* *'noendofline'* *'noeol'*
 'endofline' 'eol'	boolean	(default on)
@@ -3071,6 +3072,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	to remember the presence of a <EOL> for the last line in the file, so
 	that when you write the file the situation from the original file can
 	be kept.  But you can change it if you want to.
+	See |eol-and-eof| for example settings.
 
 			     *'equalalways'* *'ea'* *'noequalalways'* *'noea'*
 'equalalways' 'ea'	boolean	(default on)
@@ -3466,6 +3468,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When the 'binary' option is set the value of this option doesn't
 	matter.
 	See the 'endofline' option.
+	See |eol-and-eof| for example settings.
 
 					*'fkmap'* *'fk'* *'nofkmap'* *'nofk'*
 'fkmap' 'fk'		boolean (default off)

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -2050,10 +2050,6 @@ restore_backup:
 		len = 0;
 		write_info.bw_start_lnum = lnum;
 	    }
-	    if (!buf->b_p_fixeol && buf->b_p_eof)
-		// write trailing CTRL-Z
-		(void)write_eintr(write_info.bw_fd, "\x1a", 1);
-
 	    // write failed or last line has no EOL: stop here
 	    if (end == 0
 		    || (lnum == end
@@ -2156,6 +2152,13 @@ restore_backup:
 	    if (buf_write_bytes(&write_info) == FAIL)
 		end = 0;		    // write error
 	    nchars += len;
+	}
+
+	if (!buf->b_p_fixeol && buf->b_p_eof)
+	{
+	    // write trailing CTRL-Z
+	    (void)write_eintr(write_info.bw_fd, "\x1a", 1);
+	    nchars++;
 	}
 
 	// Stop when writing done or an error was encountered.

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -2272,26 +2272,29 @@ failed:
 	error = FALSE;
 
     /*
+     * In Dos format ignore a trailing CTRL-Z, unless 'binary' set.
+     */
+    if (linerest != 0
+	    && !curbuf->b_p_bin
+	    && fileformat == EOL_DOS
+	    && ptr[-1] == Ctrl_Z)
+    {
+	ptr--;
+	linerest--;
+	if (set_options)
+	    curbuf->b_p_eof = TRUE;
+    }
+    /*
      * If we get EOF in the middle of a line, note the fact and
      * complete the line ourselves.
-     * In Dos format ignore a trailing CTRL-Z, unless 'binary' set.
      */
     if (!error
 	    && !got_int
-	    && linerest != 0
-	    // TODO: should we handle CTRL-Z differently here for 'endoffile'?
-	    && !(!curbuf->b_p_bin
-		&& fileformat == EOL_DOS
-		&& *line_start == Ctrl_Z
-		&& ptr == line_start + 1))
+	    && linerest != 0)
     {
 	// remember for when writing
 	if (set_options)
-	{
 	    curbuf->b_p_eol = FALSE;
-	    if (*line_start == Ctrl_Z && ptr == line_start + 1)
-		curbuf->b_p_eof = TRUE;
-	}
 	*ptr = NUL;
 	len = (colnr_T)(ptr - line_start + 1);
 	if (ml_append(lnum, line_start, len, newfile) == FAIL)

--- a/src/testdir/test_fixeol.vim
+++ b/src/testdir/test_fixeol.vim
@@ -48,4 +48,71 @@ func Test_fixeol()
   enew!
 endfunc
 
+func Test_eof()
+  let data = 0z68656c6c6f.0d0a.776f726c64   " "hello\r\nworld"
+
+  " 1. Eol, Eof
+  " read
+  call writefile(data + 0z0d0a.1a, 'XXEolEof')
+  e! XXEolEof
+  call assert_equal(['hello', 'world'], getline(1, 2))
+  call assert_equal([1, 1], [&eol, &eof])
+  " write
+  set fixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXEolEof'))
+  set nofixeol
+  w!
+  call assert_equal(data + 0z0d0a.1a, readblob('XXEolEof'))
+
+  " 2. NoEol, Eof
+  " read
+  call writefile(data + 0z1a, 'XXNoEolEof')
+  e! XXNoEolEof
+  call assert_equal(['hello', 'world'], getline(1, 2))
+  call assert_equal([0, 1], [&eol, &eof])
+  " write
+  set fixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXNoEolEof'))
+  set nofixeol
+  w!
+  call assert_equal(data + 0z1a, readblob('XXNoEolEof'))
+
+  " 3. Eol, NoEof
+  " read
+  call writefile(data + 0z0d0a, 'XXEolNoEof')
+  e! XXEolNoEof
+  call assert_equal(['hello', 'world'], getline(1, 2))
+  call assert_equal([1, 0], [&eol, &eof])
+  " write
+  set fixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXEolNoEof'))
+  set nofixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXEolNoEof'))
+
+  " 4. NoEol, NoEof
+  " read
+  call writefile(data, 'XXNoEolNoEof')
+  e! XXNoEolNoEof
+  call assert_equal(['hello', 'world'], getline(1, 2))
+  call assert_equal([0, 0], [&eol, &eof])
+  " write
+  set fixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXNoEolNoEof'))
+  set nofixeol
+  w!
+  call assert_equal(data, readblob('XXNoEolNoEof'))
+
+  call delete('XXEolEof')
+  call delete('XXNoEolEof')
+  call delete('XXEolNoEof')
+  call delete('XXNoEolNoEof')
+  set ff& fixeol& eof& eol&
+  enew!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix the bugs that Ctrl-Z is inserted on top of the file and 'eof' is not correctly detected.

Add tests for 4 combinations of 'eol' and 'eof'.