### PR TITLE
Fix smoothscroll cursor calculations bugs when 'number' is set

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -1114,13 +1114,15 @@ curs_columns(
 		&& curwin->w_skipcol > 0
 		&& curwin->w_wcol >= curwin->w_skipcol)
 	{
-	    // w_skipcol excludes win_col_off().  Include it here, since w_wcol
-	    // counts actual screen columns.
+	    // Deduct by multiples of width2.  This allows the long line
+	    // wrapping formula below to correctly calculate the w_wcol value
+	    // when we are wrapped.
 	    if (curwin->w_skipcol <= width1)
-		curwin->w_wcol -= curwin->w_width;
+		curwin->w_wcol -= width2;
 	    else
-		curwin->w_wcol -= curwin->w_width
+		curwin->w_wcol -= width2
 			       * (((curwin->w_skipcol - width1) / width2) + 1);
+
 	    did_sub_skipcol = TRUE;
 	}
 

--- a/src/testdir/dumps/Test_smooth_number_7.dump
+++ b/src/testdir/dumps/Test_smooth_number_7.dump
@@ -1,5 +1,5 @@
-|2+0#af5f00255#ffffff0|<+0#4040ff13&@2|o+0#0000000&|n|g| |t|e|x|t| |v|e|r|y| |l|o|n|g| |t|e|x|t| |v|e|r|y| |l|o|n>g| |t|e
-| +0#af5f00255&@3|x+0#0000000&|t| |v|e|r|y| |l|o|n|g| |t|e|x|t| |v|e|r|y| |l|o|n|g| |t|e|x|t| |v|e|r
+|2+0#af5f00255#ffffff0|<+0#4040ff13&@2|o+0#0000000&|n|g| |t|e|x|t| |v|e|r|y| |l|o|n|g| |t|e|x|t| |v|e|r|y| |l|o|n|g| |t|e
+| +0#af5f00255&@3>x+0#0000000&|t| |v|e|r|y| |l|o|n|g| |t|e|x|t| |v|e|r|y| |l|o|n|g| |t|e|x|t| |v|e|r
 | +0#af5f00255&@3|y+0#0000000&| |l|o|n|g| |t|e|x|t| |v|e|r|y| |l|o|n|g| |t|e|x|t| |v|e|r|y| |l|o|n|g
 | +0#af5f00255&@3| +0#0000000&|t|e|x|t| |v|e|r|y| |l|o|n|g| |t|e|x|t| |v|e|r|y| |l|o|n|g| |t|e|x|t| 
 | +0#af5f00255&@1|1| |t+0#0000000&|h|r|e@1| @30

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -308,5 +308,67 @@ func Test_smoothscroll_one_long_line()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that if the current cursor is on a smooth scrolled line, we correctly
+" reposition it. Also check that we don't miscalculate the values by checking
+" the consistency between wincol() and col('.') as they are calculated
+" separately in code.
+func Test_smoothscroll_cursor_position()
+  call NewWindow(10, 20)
+  setl smoothscroll wrap
+  call setline(1, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+  func s:check_col_calc(win_col, win_line, buf_col)
+    call assert_equal(a:win_col, wincol())
+    call assert_equal(a:win_line, winline())
+    call assert_equal(a:buf_col, col('.'))
+  endfunc
+
+  call s:check_col_calc(1, 1, 1)
+  exe "normal \<C-E>"
+  call s:check_col_calc(1, 2, 41) " We move down another line to avoid blocking the <<< display
+  exe "normal \<C-Y>"
+  call s:check_col_calc(1, 3, 41)
+  normal ggg$
+  exe "normal \<C-E>"
+  call s:check_col_calc(20, 1, 40) " We move down only 1 line when we are out of the range of the <<< display
+  exe "normal \<C-Y>"
+  call s:check_col_calc(20, 2, 40)
+  normal gg
+
+  " Test number, where we have indented lines
+  setl number
+  call s:check_col_calc(5, 1, 1)
+  exe "normal \<C-E>"
+  call s:check_col_calc(5, 2, 33)
+  exe "normal \<C-Y>"
+  call s:check_col_calc(5, 3, 33)
+  normal ggg$
+  exe "normal \<C-E>"
+  call s:check_col_calc(20, 1, 32)
+  exe "normal \<C-Y>"
+  call s:check_col_calc(20, 2, 32)
+  normal gg
+
+  " Test number + showbreak, so test that the additional indentation works
+  setl number showbreak=+++
+  call s:check_col_calc(5, 1, 1)
+  exe "normal \<C-E>"
+  call s:check_col_calc(8, 2, 30)
+  exe "normal \<C-Y>"
+  call s:check_col_calc(8, 3, 30)
+  normal gg
+
+  " Test number + cpo+=n mode, where wrapped lines aren't indented
+  setl number cpo+=n showbreak=
+  call s:check_col_calc(5, 1, 1)
+  exe "normal \<C-E>"
+  call s:check_col_calc(1, 2, 37)
+  exe "normal \<C-Y>"
+  call s:check_col_calc(1, 3, 37)
+  normal gg
+
+  bwipeout!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
The 'smoothscroll' feature currently doesn't work well when 'number' (or signs) is set. If you scroll using `<C-E>` when the cursor is on the first line, the cursor would end up at a wrong position, and there's also a disconnect between the window column calculation (`wincol()`) and the actual buffer position (`col('.')`). Commands like `g0` and `g$` would also start to behave incorrectly.

This was a regression caused by v9.0.0746 (856c5d2bc7). That commit actually fixed this issue for Vi compatibility mode `set cpo+=n`, but broke the normal nocompatible case. Fixed the logic to work in both case by correctly subtracting from `width2` instead of the entire window's width. This makes the calculation consistent with how the "long line wrapping" code below calculates the overflow wcol calculation.

For tests, fixed up an existing screen dump test (the old dump was actually demonstrating the incorrect behavior, but it is quite hard to tell IMO, because `term_dumpload` does *not* show the cursor position in a visual way and therefore it's hard to visually inspect). Also, add new tests to confirm that the cursor position is calculated correctly and we don't have a desync between `col('.')` and `wincol()`. Don't use screen dump tests for these because they are testing specific logic instead of an end-to-end tests like screen dumps, and asserts are clearer and easier to specify this way.