### PR TITLE
Fix +sound on macOS builds

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -167,7 +167,7 @@
 # if defined(FEAT_NORMAL) && !defined(FEAT_CLIPBOARD)
 #  define FEAT_CLIPBOARD
 # endif
-# if defined(FEAT_BIG) && !defined(FEAT_SOUND)
+# if defined(FEAT_HUGE) && !defined(FEAT_SOUND)
 #  define FEAT_SOUND
 # endif
 # if defined(FEAT_SOUND)


### PR DESCRIPTION
v9.0.700 (#11283) accidentally turned off the +sound feature on macOS because it removed the FEAT_BIG ifdef but didn't scrub the existing usages. Fix sound feature to depend on HUGE instead of BIG.