### PR TITLE
Fix argdedupe not cleaning different paths to same files

### DIFF
--- a/src/arglist.c
+++ b/src/arglist.c
@@ -782,10 +782,22 @@ ex_argdedupe(exarg_T *eap UNUSED)
 {
     int i;
     int j;
+    char_u* firstFullname;
+    char_u* secondFullname;
+    int areNamesDuplicate;
 
     for (i = 0; i < ARGCOUNT; ++i)
 	for (j = i + 1; j < ARGCOUNT; ++j)
-	    if (fnamecmp(ARGLIST[i].ae_fname, ARGLIST[j].ae_fname) == 0)
+	{
+	    firstFullname = FullName_save(ARGLIST[i].ae_fname, FALSE);
+	    secondFullname = FullName_save(ARGLIST[j].ae_fname, FALSE);
+
+	    areNamesDuplicate = fnamecmp(firstFullname, secondFullname) == 0;
+
+	    vim_free(firstFullname);
+	    vim_free(secondFullname);
+
+	    if (areNamesDuplicate)
 	    {
 		vim_free(ARGLIST[j].ae_fname);
 		mch_memmove(ARGLIST + j, ARGLIST + j + 1,
@@ -799,6 +811,7 @@ ex_argdedupe(exarg_T *eap UNUSED)
 
 		--j;
 	    }
+	}
 }
 
 /*

--- a/src/arglist.c
+++ b/src/arglist.c
@@ -782,19 +782,22 @@ ex_argdedupe(exarg_T *eap UNUSED)
 {
     int i;
     int j;
-    char_u* firstFullname;
-    char_u* secondFullname;
-    int areNamesDuplicate;
 
     for (i = 0; i < ARGCOUNT; ++i)
+    {
+	char_u* firstFullname;
+
+	firstFullname = FullName_save(ARGLIST[i].ae_fname, FALSE);
+
 	for (j = i + 1; j < ARGCOUNT; ++j)
 	{
-	    firstFullname = FullName_save(ARGLIST[i].ae_fname, FALSE);
+	    char_u* secondFullname;
+	    int areNamesDuplicate;
+
 	    secondFullname = FullName_save(ARGLIST[j].ae_fname, FALSE);
 
 	    areNamesDuplicate = fnamecmp(firstFullname, secondFullname) == 0;
 
-	    vim_free(firstFullname);
 	    vim_free(secondFullname);
 
 	    if (areNamesDuplicate)
@@ -812,6 +815,9 @@ ex_argdedupe(exarg_T *eap UNUSED)
 		--j;
 	    }
 	}
+
+	vim_free(firstFullname);
+    }
 }
 
 /*

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -441,6 +441,9 @@ func Test_argdedupe()
   argdedupe
   next
   call assert_equal('c', expand('%:t'))
+  args a ./a
+  argdedupe
+  call assert_equal(['a'], argv())
   %argd
 endfunc
 


### PR DESCRIPTION
Solution: While checking for duplicate paths, first expand to absolute paths before comparing

closes #9402 