### PR TITLE
Fix shellcheck compiler for shell scripts

### DIFF
--- a/runtime/compiler/shellcheck.vim
+++ b/runtime/compiler/shellcheck.vim
@@ -15,7 +15,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-CompilerSet makeprg=shellcheck\ -f\ gcc
+CompilerSet makeprg=shellcheck\ -f\ gcc\ %
 CompilerSet errorformat=%f:%l:%c:\ %trror:\ %m\ [SC%n],
 		       \%f:%l:%c:\ %tarning:\ %m\ [SC%n],
 		       \%f:%l:%c:\ %tote:\ %m\ [SC%n],


### PR DESCRIPTION
Problem: :compiler shellcheck does not work
Solution: Add ' %' to makeprg to pass current file to shellcheck