### PR TITLE
Fix flaky Test_no_unknown_error_after_error

### DIFF
--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -4087,7 +4087,7 @@ def Test_no_unknown_error_after_error()
       endfor
   END
   writefile(lines, 'Xdef', 'D')
-  assert_fails('so Xdef', ['E684:', 'E1012:'])
+  assert_fails('so Xdef', ['E684:\|E1012:', 'E1012:\|E684:'])
 enddef
 
 def InvokeNormal()


### PR DESCRIPTION
In MacVim's CI, `Test_no_unknown_error_after_error` in `test_vim9_script.vim` would occasionally fail, with an error message saying the following:

    Expected 'E1012:' but got 'E684: List index out of range: 0':

The reason for that is that this test uses a job which triggers both an exit and an out callback, and relies on the out_cb being called first before the exit_cb. From the docs for exit_cb, sometimes we can have buffered data, which means the exit_cb could have finished before out_cb instead. Fix the test to not rely on either finishing before the other, as it's trying to make sure we don't get an E1099 (unknown error) anyway.