### PR TITLE
feat: Sort :vimgrep fuzzy-match by score with 's' flag

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1034,7 +1034,7 @@ commands can be combined to create a NewGrep command: >
 5.1 using Vim's internal grep
 
 					*:vim* *:vimgrep* *E682* *E683*
-:vim[grep][!] /{pattern}/[g][j][f] {file} ...
+:vim[grep][!] /{pattern}/[g][j][f][s] {file} ...
 			Search for {pattern} in the files {file} ... and set
 			the error list to the matches.  Files matching
 			'wildignore' are ignored; files in 'suffixes' are
@@ -1065,6 +1065,12 @@ commands can be combined to create a NewGrep command: >
 			     instead of a regular expression.  See
 			     |fuzzy-matching| for more information about fuzzy
 			     matching strings.
+
+			's'  When the 's' flag is specified, the values
+			     matched from the 'f' flag are sorted based on
+			     their score. Without the 'f' flag, this does
+			     nothing. See |fuzzy-matching| for more
+			     information about fuzzy matching scores.
 
 			|QuickFixCmdPre| and |QuickFixCmdPost| are triggered.
 			A file that is opened for matching may use a buffer

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5504,7 +5504,7 @@ skip_vimgrep_pat_ext(char_u *p, char_u **s, int *flags, char_u **nulp, int *cp)
 	++p;
 
 	// Find the flags
-	while (*p == 'g' || *p == 'j' || *p == 'f')
+	while (*p == 'g' || *p == 'j' || *p == 'f' || *p == 's')
 	{
 	    if (flags != NULL)
 	    {
@@ -5512,6 +5512,8 @@ skip_vimgrep_pat_ext(char_u *p, char_u **s, int *flags, char_u **nulp, int *cp)
 		    *flags |= VGR_GLOBAL;
 		else if (*p == 'j')
 		    *flags |= VGR_NOJUMP;
+		else if (*p == 's')
+		    *flags |= VGR_FUZZYSORT;
 		else
 		    *flags |= VGR_FUZZY;
 	    }

--- a/src/vim.h
+++ b/src/vim.h
@@ -2562,6 +2562,7 @@ typedef enum {
 #define VGR_GLOBAL	1
 #define VGR_NOJUMP	2
 #define VGR_FUZZY	4
+#define VGR_FUZZYSORT	8
 
 // behavior for bad character, "++bad=" argument
 #define BAD_REPLACE	'?'	// replace it with '?' (default)


### PR DESCRIPTION
This simple extension is the implementation of this discussion: https://groups.google.com/g/vim_dev/c/9NZ5M0933Bg

Adds an `s` flag to `:vimgrep`. When used with the `f` flag, the results of the `:vimgrep` will be sorted based on their fuzzy-match score. When the `f` flag is not present, the `s` flag does nothing.

Current method of sorting is to store all matches, sort based on score, then go through and add the sorted matches to the qflist.

Please let me know if anything needs to be changed. Thanks!