### PR TITLE
Adjust alignment of help message

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3588,7 +3588,7 @@ usage(void)
     main_msg(_("--startuptime <file>\tWrite startup timing messages to <file>"));
 #endif
 #ifdef FEAT_JOB_CHANNEL
-    main_msg(_("--log <file>\tStart logging to <file> early"));
+    main_msg(_("--log <file>\t\tStart logging to <file> early"));
 #endif
 #ifdef FEAT_VIMINFO
     main_msg(_("-i <viminfo>\t\tUse <viminfo> instead of .viminfo"));

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -1730,7 +1730,7 @@ msgstr "--servername <Name>\tBenutze den Vim-Server <Name>"
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <Datei>\tSchreibe Start Zeitmessung in <Datei>"
 
-msgid "--log <file>\tStart logging to <file> early"
+msgid "--log <file>\t\tStart logging to <file> early"
 msgstr "--log <Datei>\tLogge frühzeitig in <Datei>"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -1765,7 +1765,7 @@ msgstr ""
 "-- startuptime <archivo>\tGuardar los mensajes de tiempo de inicio en "
 "<archivo>"
 
-msgid "--log <file>\tStart logging to <file> early"
+msgid "--log <file>\t\tStart logging to <file> early"
 msgstr "--log <archivo>\tIniciar registro en <archivo> pronto"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -1616,8 +1616,8 @@ msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr ""
 "--startuptime <file>\tScrivi tutti i messaggi iniziali di timing in <file>"
 
-msgid "--log <file>\tStart logging to <file> early"
-msgstr "--log <file>\tInizia registrazione a <file> appena possibile"
+msgid "--log <file>\t\tStart logging to <file> early"
+msgstr "--log <file>\t\tInizia registrazione a <file> appena possibile"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tUsa <viminfo> invece di .viminfo"

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -1741,7 +1741,7 @@ msgstr ""
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <файл>\tЗаписать временные метки запуска в <файл>"
 
-msgid "--log <file>\tStart logging to <file> early"
+msgid "--log <file>\t\tStart logging to <file> early"
 msgstr ""
 "--log <файл>\t\tНачать запись журнала в <файл> на раннем этапе\n"
 "\t\t\t\tинициализации"

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -1741,7 +1741,7 @@ msgstr ""
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <файл>\tЗаписать временные метки запуска в <файл>"
 
-msgid "--log <file>\tStart logging to <file> early"
+msgid "--log <file>\t\tStart logging to <file> early"
 msgstr ""
 "--log <файл>\t\tНачать запись журнала в <файл> на раннем этапе\n"
 "\t\t\t\tинициализации"

--- a/src/po/sr.po
+++ b/src/po/sr.po
@@ -1628,7 +1628,7 @@ msgstr "--servername <име>\tПошаљи/постани Vim сервер <и�
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <фајл>\tУпиши поруке о дужини покретања у <фајл>"
 
-msgid "--log <file>\tStart logging to <file> early"
+msgid "--log <file>\t\tStart logging to <file> early"
 msgstr "--log <фајл>\t\tЗапочиње рано логовање у <фајл>"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"

--- a/src/po/tr.po
+++ b/src/po/tr.po
@@ -1691,7 +1691,7 @@ msgstr "--servername <ad>\t<ad> Vim sunucusuna gönder veya sunucu ol"
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <dsy>\tBaşlangıç zamanlama iletilerini <dsy>'ya yaz"
 
-msgid "--log <file>\tStart logging to <file> early"
+msgid "--log <file>\t\tStart logging to <file> early"
 msgstr "--log <dosya>\t<dosya>'ya günlüklemeyi erkenden başlat"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -1745,8 +1745,8 @@ msgstr ""
 "--startuptime <файл>\tЗаписати запускні повідомлення з часовими відмітками "
 "до <файлу>"
 
-msgid "--log <file>\tStart logging to <file> early"
-msgstr "--log <файл>\tПочати запис у <файл> журналу якнайраніше"
+msgid "--log <file>\t\tStart logging to <file> early"
+msgstr "--log <файл>\t\tПочати запис у <файл> журналу якнайраніше"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tВикористати <viminfo> замість .viminfo"

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -1745,8 +1745,8 @@ msgstr ""
 "--startuptime <файл>\tЗаписати запускні повідомлення з часовими відмітками "
 "до <файлу>"
 
-msgid "--log <file>\tStart logging to <file> early"
-msgstr "--log <файл>\tПочати запис у <файл> журналу якнайраніше"
+msgid "--log <file>\t\tStart logging to <file> early"
+msgstr "--log <файл>\t\tПочати запис у <файл> журналу якнайраніше"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tВикористати <viminfo> замість .viminfo"

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -1676,8 +1676,8 @@ msgstr "--servername <名称>\t发送到或成为 Vim 服务器 <名称>"
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <文件>\t将启动计时信息写入 <文件>"
 
-msgid "--log <file>\tStart logging to <file> early"
-msgstr "--log <文件>\t尽早开始记录日志到 <文件>"
+msgid "--log <file>\t\tStart logging to <file> early"
+msgstr "--log <文件>\t\t尽早开始记录日志到 <文件>"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t使用 <viminfo> 取代 .viminfo"

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -1676,8 +1676,8 @@ msgstr "--servername <名称>\t发送到或成为 Vim 服务器 <名称>"
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <文件>\t将启动计时信息写入 <文件>"
 
-msgid "--log <file>\tStart logging to <file> early"
-msgstr "--log <文件>\t尽早开始记录日志到 <文件>"
+msgid "--log <file>\t\tStart logging to <file> early"
+msgstr "--log <文件>\t\t尽早开始记录日志到 <文件>"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t使用 <viminfo> 取代 .viminfo"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -1676,8 +1676,8 @@ msgstr "--servername <名称>\t发送到或成为 Vim 服务器 <名称>"
 msgid "--startuptime <file>\tWrite startup timing messages to <file>"
 msgstr "--startuptime <文件>\t将启动计时信息写入 <文件>"
 
-msgid "--log <file>\tStart logging to <file> early"
-msgstr "--log <文件>\t尽早开始记录日志到 <文件>"
+msgid "--log <file>\t\tStart logging to <file> early"
+msgstr "--log <文件>\t\t尽早开始记录日志到 <文件>"
 
 msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\t使用 <viminfo> 取代 .viminfo"


### PR DESCRIPTION
The `--log` line of the help message was not well aligned. Adjust it.