### PR TITLE
Use a terminal test for assert_fails() in a timer

### DIFF
--- a/src/testdir/test_assert.vim
+++ b/src/testdir/test_assert.vim
@@ -1,5 +1,8 @@
 " Test that the methods used for testing work.
 
+source check.vim
+source term_util.vim
+
 func Test_assert_false()
   call assert_equal(0, assert_false(0))
   call assert_equal(0, assert_false(v:false))
@@ -338,10 +341,19 @@ func Test_assert_fails_in_try_block()
   endtry
 endfunc
 
+" Test that assert_fails() in a timer should not cause a hit-enter prompt.
 func Test_assert_fails_in_timer()
-  " should not cause a hit-enter prompt, which isn't actually checked here
-  call timer_start(0, {-> assert_fails('call', 'E471:')})
-  sleep 10m
+  CheckRunVimInTerminal
+  let buf = RunVimInTerminal('', {'rows': 6})
+  let cmd = ":call timer_start(0, {-> assert_fails('call', 'E471:')})"
+  call term_sendkeys(buf, cmd)
+  call WaitForAssert({-> assert_equal(cmd, term_getline(buf, 6))})
+  call term_sendkeys(buf, "\n")
+  call TermWait(buf)
+  call assert_notmatch('^Press', term_getline(buf, 6))
+
+  " clean up
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_assert_beeps()


### PR DESCRIPTION
The test are run on startup, where no_wait_return is always set, so a
terminal test is needed.
