### PR TITLE
Find debug vim when sourcing single test file

### DIFF
--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -236,7 +236,15 @@ endfunc
 func GetVimProg()
   if !filereadable('vimcmd')
     " Assume the script was sourced instead of running "make".
-    return '../vim'
+    if !has("win32")
+      return '../vim'
+    else
+      if !filereadable('..\vim.exe') && filereadable('..\vimd.exe')
+        return '..\vimd.exe'
+      else
+        return '..\vim.exe'
+      endif
+    endif
   endif
   return readfile('vimcmd')[0]
 endfunc
@@ -251,7 +259,11 @@ func GetVimCommand(...)
     if !has("win32")
       let lines = ['../vim']
     else
-      let lines = ['..\vim.exe']
+      if !filereadable('..\vim.exe') && filereadable('..\vimd.exe')
+        let lines = ['..\vimd.exe']
+      else
+        let lines = ['..\vim.exe']
+      endif
     endif
   else
     let lines = readfile('vimcmd')


### PR DESCRIPTION
Problem:  Sourcing single test scripts in DEBUG mode failed on MS-Win, because the scripts didn't find "..\vimd.exe"
Solution:   Fix test script fallback, was hardcoded to '..\vim.exe', now the fallback checks for '..\vimd.exe' if '..\vim.exe' not found.