### PR TITLE
MS-Win Restore screen buffer on exit

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7955,7 +7955,7 @@ mch_setenv(char *var, char *value, int x UNUSED)
 /*
  * Not stable now.
  */
-#define CONPTY_STABLE_BUILD	    MAKE_VER(10, 0, 20348)  // T.B.D. ?32767?
+#define CONPTY_STABLE_BUILD	    MAKE_VER(10, 0, 32767)  // T.B.D.
 // Notes: 
 // Windows 10 22H2 Final is build 19045, its conpty seems stable.
 // However, 19045 is a lower build number than the 2020 insider preview which

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -72,7 +72,6 @@ void set_alist_count(void);
 void fix_arg_enc(void);
 int mch_setenv(char *var, char *value, int x);
 int vtp_printf(char *format, ...);
-int use_wt(void);
 void get_default_console_color(int *cterm_fg, int *cterm_bg, guicolor_T *gui_fg, guicolor_T *gui_bg);
 void control_console_color_rgb(void);
 int use_vtp(void);


### PR DESCRIPTION
Moved from PR #11516 after merge conflict.

Problem: Windows 10 introduced new terminal line wrapping on resize features into command prompt. This makes it behave similar to the new WT, but not quite the same.

Solution: Restore screen behavior checks for various WT and VTP combinations to act correctly.

Hopefully Closes #11507 