### PR TITLE
Simply fix:  syntax/help - helpHeadline highlight element chararcter

### DIFF
--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -11,7 +11,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-syn match helpHeadline		"^[A-Z.][-A-Z0-9 .,()_]*?\=\ze\(\s\+\*\|$\)"
+syn match helpHeadline		"^[A-Z.][-A-Z0-9 .,()_']*?\=\ze\(\s\+\*\|$\)"
 syn match helpSectionDelim	"^===.*===$"
 syn match helpSectionDelim	"^---.*--$"
 if has("conceal")


### PR DESCRIPTION
Simply fix for help syntax:

- Add `'` to helpHeadline 

For usr_10.txt - `WHEN IT DOESN'T WORK` small caption.

https://github.com/vim/vim/blob/28c56d501352bd98472d23667bade683877cadcc/runtime/doc/usr_10.txt#L740

It does not highlighted.