### PR TITLE
Fix mouse shape remains in op-pending mode after failed change operation

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -1734,6 +1734,7 @@ op_change(oparg_T *oap)
     long		pre_textlen = 0;
     long		pre_indent = 0;
     char_u		*firstline;
+    int			save_finish_op = finish_op;
     char_u		*ins_text, *newp, *oldp;
     struct block_def	bd;
 
@@ -1775,7 +1776,12 @@ op_change(oparg_T *oap)
     if (oap->motion_type == MLINE)
 	fix_indent();
 
+    // Reset finish_op now, don't want it set inside edit().
+    finish_op = FALSE;
+
     retval = edit(NUL, FALSE, (linenr_T)1);
+
+    finish_op = save_finish_op;
 
     /*
      * In Visual block mode, handle copying the new text to all lines of the
@@ -4113,8 +4119,6 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 		// before.
 		restore_lbr(lbr_saved);
 #endif
-		// Reset finish_op now, don't want it set inside edit().
-		finish_op = FALSE;
 		if (op_change(oap))	// will call edit()
 		    cap->retval |= CA_COMMAND_BUSY;
 		if (restart_edit == 0)

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -3807,4 +3807,37 @@ func Test_normal_count_out_of_range()
   bwipe!
 endfunc
 
+" Test that mouse shape is restored to Normal mode after failed "c" operation.
+func Test_mouse_shape_after_failed_change()
+  CheckFeature mouseshape
+  CheckCanRunGui
+
+  let lines =<< trim END
+    set mouseshape+=o:busy
+    setlocal nomodifiable
+    let g:mouse_shapes = []
+
+    func SaveMouseShape(timer)
+      let g:mouse_shapes += [getmouseshape()]
+    endfunc
+
+    func SaveAndQuit(timer)
+      call writefile(g:mouse_shapes, 'Xmouseshapes')
+      quit
+    endfunc
+
+    call timer_start(50, {_ -> feedkeys('c')})
+    call timer_start(100, 'SaveMouseShape')
+    call timer_start(150, {_ -> feedkeys('c')})
+    call timer_start(200, 'SaveMouseShape')
+    call timer_start(250, 'SaveAndQuit')
+  END
+  call writefile(lines, 'Xmouseshape.vim', 'D')
+  call RunVim([], [], "-g -S Xmouseshape.vim")
+  sleep 300m
+  call assert_equal(['busy', 'arrow'], readfile('Xmouseshapes'))
+
+  call delete('Xmouseshapes')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
If finish_op is reset but not restored, ui_cursor_shape() is not called
after do_pending_operator() returns, so mouse shape remains in operator
pending mode. I can somehow not reproduce this with cursor shape in GUI,
only with mouse shape. Steps to reproduce:
1. `:set mouseshape+=o:up-arrow`
2. `:set nomodifiable`
3. press "c" followed by a motion
4. mouse shape remains up-arrow.

Restoring finish_op seems to fix the problem. No idea how to test this.
