### PR TITLE
Remove extra '\' from substitute() pattern in ftplugin/lua.vim

### DIFF
--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -21,7 +21,7 @@ setlocal formatoptions-=t formatoptions+=croql
 let &l:define = '\<function\|\<local\%(\s\+function\)\='
 
 " TODO: handle init.lua
-setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+setlocal includeexpr=substitute(v:fname,'\.','/','g')
 setlocal suffixesadd=.lua
 
 let b:undo_ftplugin = "setlocal cms< com< def< fo< inex< sua<"


### PR DESCRIPTION
Extra backslash causes the `substitute()` pattern to not transform as intended. Try it with:

```
echo substitute('foo.bar.baz','\\.','/','g')
```

versus the correct:

```
echo substitute('foo.bar.baz','\.','/','g')
```