### PR TITLE
Add new type keyword "any" and "comparable" for the go syntax

### DIFF
--- a/runtime/syntax/go.vim
+++ b/runtime/syntax/go.vim
@@ -117,7 +117,7 @@ hi def link     goLabel             Label
 hi def link     goRepeat            Repeat
 
 " Predefined types
-syn keyword     goType              chan map bool string error
+syn keyword     goType              chan map bool string error any comparable
 syn keyword     goSignedInts        int int8 int16 int32 int64 rune
 syn keyword     goUnsignedInts      byte uint uint8 uint16 uint32 uint64 uintptr
 syn keyword     goFloats            float32 float64


### PR DESCRIPTION
go from 1.18 has new type keyword "any" and "comparable".

from [Go 1.18 Release Notes](https://tip.golang.org/doc/go1.18):
> The new [predeclared identifier](https://tip.golang.org/ref/spec#Predeclared_identifiers) `any` is an alias for the empty interface. It may be used instead of `interface{}`.
> The new [predeclared identifier](https://tip.golang.org/ref/spec#Predeclared_identifiers) `comparable` is an interface that denotes the set of all types which can be compared using `==` or `!=`. It may only be used as (or embedded in) a type constraint.