### PR TITLE
Recover test fails without FEAT_CRYPT; redundant call to rename()

### DIFF
--- a/src/testdir/test_recover.vim
+++ b/src/testdir/test_recover.vim
@@ -121,7 +121,6 @@ func Test_nocatch_process_still_running()
   call test_override("uptime", 0)
   sleep 1
 
-  call rename('Xswap', swname)
   call feedkeys('e', 'tL')
   redir => editOutput
   edit Xswaptest
@@ -322,6 +321,7 @@ endfunc
 
 " Test for :recover using an encrypted swap file
 func Test_recover_encrypted_swap_file()
+  CheckFeature cryptv
   CheckUnix
 
   " Recover an encrypted file from the swap file without the original file


### PR DESCRIPTION
The Xswap file is already renamed above, so renaming it again does nothing.
