### PR TITLE
feat: add CQL filetype to runtime

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -420,7 +420,9 @@ au BufNewFile,BufRead configure.in,configure.ac setf config
 au BufNewFile,BufRead *.cook			setf cook
 
 " Clinical Quality Language (CQL)
-au BufNewFile,BufRead *.cql	  		setf cql
+" .cql is also mentioned in 'XDCC Catcher queue list' as a file extension
+" If support for XDCC Catcher is needed in the future, the contents of the file needs to be inspected.
+au BufNewFile,BufRead *.cql	  		setf cqlang
 
 " CSV Files
 au BufNewFile,BufRead *.csv			setf csv

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -419,6 +419,9 @@ au BufNewFile,BufRead configure.in,configure.ac setf config
 " Cooklang
 au BufNewFile,BufRead *.cook			setf cook
 
+" Clinical Quality Language (CQL)
+au BufNewFile,BufRead *.cql	  		setf cql
+
 " CSV Files
 au BufNewFile,BufRead *.csv			setf csv
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -124,6 +124,7 @@ let s:filename_checks = {
     \ 'context': ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],
     \ 'cook': ['file.cook'],
     \ 'cpp': ['file.cxx', 'file.c++', 'file.hh', 'file.hxx', 'file.hpp', 'file.ipp', 'file.moc', 'file.tcc', 'file.inl', 'file.tlh'],
+    \ 'cql': ['file.cql'],
     \ 'crm': ['file.crm'],
     \ 'crontab': ['crontab', 'crontab.file', '/etc/cron.d/file', 'any/etc/cron.d/file'],
     \ 'cs': ['file.cs', 'file.csx'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -124,7 +124,7 @@ let s:filename_checks = {
     \ 'context': ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],
     \ 'cook': ['file.cook'],
     \ 'cpp': ['file.cxx', 'file.c++', 'file.hh', 'file.hxx', 'file.hpp', 'file.ipp', 'file.moc', 'file.tcc', 'file.inl', 'file.tlh'],
-    \ 'cql': ['file.cql'],
+    \ 'cqlang': ['file.cql'],
     \ 'crm': ['file.crm'],
     \ 'crontab': ['crontab', 'crontab.file', '/etc/cron.d/file', 'any/etc/cron.d/file'],
     \ 'cs': ['file.cs', 'file.csx'],


### PR DESCRIPTION
Clinical Quality Language (CQL) is a language used in a variety of Healtchare IT/clinical use cases. See https://cql.hl7.org/ and https://github.com/cqframework/clinical_quality_language for more description on CQL, and [here](https://github.com/cqframework/clinical_quality_language/blob/master/Examples/ChlamydiaScreeningCDS.cql) for an example `.cql` file.

This PR simply adds detection of `*.cql` files and sets the filetype accordingly.

I have not yet provided any syntax for the CQL grammar itself within Vim, but let me know if this is necessary in order for this contribution to be accepted. Thank you!