### PR TITLE
Fix for modifier keys to work with mouse scroll mappings, in MS-Win.

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1745,10 +1745,8 @@ vgetc(void)
 
 	    // Get two extra bytes for special keys
 	    if (c == K_SPECIAL
-#if defined(FEAT_GUI) || defined(MSWIN)
-		    // GUI codes start with CSI; MS-Windows sends mouse scroll
-		    // events with CSI.
-		    || c == CSI
+#ifdef FEAT_GUI
+		    || (c == CSI)
 #endif
 	       )
 	    {
@@ -2520,32 +2518,12 @@ handle_mapping(
 	    && State != MODE_CONFIRM
 	    && !at_ins_compl_key())
     {
-#if defined(FEAT_GUI) || defined(MSWIN)
-	if (tb_c1 == CSI
-# if !defined(MSWIN)
-		&& gui.in_use
-# endif
-		&& typebuf.tb_len >= 2
-		&& (typebuf.tb_buf[typebuf.tb_off + 1] == KS_MODIFIER
-# if defined(MSWIN)
-		    || (typebuf.tb_len >= 3
-#  ifdef FEAT_GUI
-		      && !gui.in_use
-#  endif
-		      && typebuf.tb_buf[typebuf.tb_off + 1] == KS_EXTRA
-		      && (typebuf.tb_buf[typebuf.tb_off + 2] == KE_MOUSEUP
-			|| typebuf.tb_buf[typebuf.tb_off + 2] == KE_MOUSEDOWN
-			|| typebuf.tb_buf[typebuf.tb_off + 2] == KE_MOUSELEFT
-			|| typebuf.tb_buf[typebuf.tb_off + 2] == KE_MOUSERIGHT)
-		       )
-# endif
-		   )
-	   )
+#ifdef FEAT_GUI
+	if (gui.in_use && tb_c1 == CSI && typebuf.tb_len >= 2
+		&& typebuf.tb_buf[typebuf.tb_off + 1] == KS_MODIFIER)
 	{
 	    // The GUI code sends CSI KS_MODIFIER {flags}, but mappings expect
 	    // K_SPECIAL KS_MODIFIER {flags}.
-	    // MS-Windows sends mouse scroll events CSI KS_EXTRA {what}, but
-	    // non-GUI mappings expect K_SPECIAL KS_EXTRA {what}.
 	    tb_c1 = K_SPECIAL;
 	}
 #endif

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2047,7 +2047,7 @@ mch_inchar(
 	    {
 		if (modifiers > 0)
 		{
-		    typeahead[typeaheadlen++] = CSI;
+		    typeahead[typeaheadlen++] = K_SPECIAL;
 		    typeahead[typeaheadlen++] = KS_MODIFIER;
 		    typeahead[typeaheadlen++] = modifiers;
 		}

--- a/src/term.c
+++ b/src/term.c
@@ -5456,6 +5456,21 @@ check_termcode(
 	}
 	else
 #endif // FEAT_GUI
+#ifdef MSWIN
+	if (len >= 3 && tp[0] == CSI && tp[1] == KS_EXTRA
+	    && (tp[2] == KE_MOUSEUP || tp[2] == KE_MOUSEDOWN
+	    || tp[2] == KE_MOUSELEFT || tp[2] == KE_MOUSERIGHT))
+	{
+	    // MS-Windows console sends mouse scroll events 
+	    // - CSI 
+	    // - KS_EXTRA 
+	    // - {KE_MOUSE[UP|DOWN|LEFT|RIGHT]}
+	    slen = 3;
+	    key_name[0] = tp[1];
+	    key_name[1] = tp[2];
+	}
+	else
+#endif // MSWIN
 	{
 	    int  mouse_index_found = -1;
 


### PR DESCRIPTION
Problem:  in MS-windows terminal, modifier keys were not working in mappings with mouse scroll events.
Solution  Use K_SPECIAL instead of CSI for the modifier keys, and move code out of vgetc() and into check_termcode().