### PR TITLE
Allows MS Windows console mouse pointer coordinates greater than 223 columns

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -2308,10 +2308,14 @@ check_termcode_mouse(
 	 */
 	for (;;)
 	{
-# ifdef FEAT_GUI
-	    if (gui.in_use)
+# if defined(FEAT_GUI) || defined(MSWIN)
+	    if (TRUE
+#  if defined(FEAT_GUI) && !defined(MSWIN)
+		&& gui.in_use
+#  endif
+		)
 	    {
-		// GUI uses more bits for columns > 223
+		// GUI and MS-Windows consoles use 2 bytes for columns > 223
 		num_bytes = get_bytes_from_buf(tp + *slen, bytes, 5);
 		if (num_bytes == -1)	// not enough coordinates
 		    return -1;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2055,7 +2055,6 @@ mch_inchar(
 		typeahead[typeaheadlen++] = CSI;
 		typeahead[typeaheadlen++] = KS_EXTRA;
 		typeahead[typeaheadlen++] = scroll_dir;
-		g_nMouseClick = -1;
 	    }
 	    else
 	    {

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2063,8 +2063,8 @@ mch_inchar(
 		typeahead[typeaheadlen++] = 'M';
 		typeahead[typeaheadlen++] = g_nMouseClick;
 	    }
-	    // Pass the pointer coordinates of the scroll event so that we know
-	    // which window to scroll. Use 2 bytes for > 223 columns.
+	    // Pass the pointer coordinates of the mouse event. 
+	    // Use 2 bytes for > 223 columns.
 	    typeahead[typeaheadlen++] = (char_u)(g_xMouse / 128 + ' ' + 1);
 	    typeahead[typeaheadlen++] = (char_u)(g_xMouse % 128 + ' ' + 1);
 	    typeahead[typeaheadlen++] = (char_u)(g_yMouse / 128 + ' ' + 1);

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2062,10 +2062,14 @@ mch_inchar(
 		typeahead[typeaheadlen++] = ESC + 128;
 		typeahead[typeaheadlen++] = 'M';
 		typeahead[typeaheadlen++] = g_nMouseClick;
-		typeahead[typeaheadlen++] = g_xMouse + '!';
-		typeahead[typeaheadlen++] = g_yMouse + '!';
-		g_nMouseClick = -1;
 	    }
+	    // Pass the pointer coordinates of the scroll event so that we know
+	    // which window to scroll. Use 2 bytes for > 223 columns.
+	    typeahead[typeaheadlen++] = (char_u)(g_xMouse / 128 + ' ' + 1);
+	    typeahead[typeaheadlen++] = (char_u)(g_xMouse % 128 + ' ' + 1);
+	    typeahead[typeaheadlen++] = (char_u)(g_yMouse / 128 + ' ' + 1);
+	    typeahead[typeaheadlen++] = (char_u)(g_yMouse % 128 + ' ' + 1);
+	    g_nMouseClick = -1;
 	}
 	else
 	{

--- a/src/term.c
+++ b/src/term.c
@@ -5723,13 +5723,16 @@ check_termcode(
 
 	// We only get here when we have a complete termcode match
 
-#ifdef FEAT_GUI
+#if defined(FEAT_GUI) || defined(MSWIN)
 	/*
-	 * Only in the GUI: Fetch the pointer coordinates of the scroll event
-	 * so that we know which window to scroll later.
+	 * For scroll events from the GUI or MS-Windows consoles, fetch the
+	 * pointer coordinates so that we know which window to scroll later.
 	 */
-	if (gui.in_use
-		&& key_name[0] == (int)KS_EXTRA
+	if (
+# if defined(FEAT_GUI) && !defined(MSWIN)
+		gui.in_use &&
+# endif
+		key_name[0] == (int)KS_EXTRA
 		&& (key_name[1] == (int)KE_X1MOUSE
 		    || key_name[1] == (int)KE_X2MOUSE
 		    || key_name[1] == (int)KE_MOUSEMOVE_XY


### PR DESCRIPTION
Problem: MS WIndows console mouse event coordinates were restricted by being passed in single byte values. Effectively max 223 columns.
Solution: Pass the mouse coordinates in 2 byte values.  ie. Same as SGR and GUI uses.  Effectively max 49729 columns.