### PR TITLE
feat: detect dash as shell

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -712,7 +712,7 @@ export def SetFileTypeSH(name: string)
     if exists("b:is_sh")
       unlet b:is_sh
     endif
-  elseif name =~ '\<sh\>'
+  elseif name =~ '\<sh\>' || name =~ '\<dash\>'
     b:is_sh = 1
     if exists("b:is_kornshell")
       unlet b:is_kornshell

--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -53,8 +53,8 @@ def DetectFromHashBang(firstline: string)
     name = 'wish'
   endif
 
-  # Bourne-like shell scripts: bash bash2 ksh ksh93 sh
-  if name =~ '^\(bash\d*\|\|ksh\d*\|sh\)\>'
+  # Bourne-like shell scripts: bash bash2 dash ksh ksh93 sh
+  if name =~ '^\(bash\d*\|dash\|ksh\d*\|sh\)\>'
     call dist#ft#SetFileTypeSH(line1)
 
     # csh scripts


### PR DESCRIPTION
dash is a POSIX compliant shell, and `/bin/sh` symlinks to `dash` on Debian/Ubuntu.