### PR TITLE
MS-Windows: debug executable not found when running test from Make_mvc.mak

### DIFF
--- a/src/testdir/Make_mvc.mak
+++ b/src/testdir/Make_mvc.mak
@@ -3,7 +3,13 @@
 #
 # Requires a set of Unix tools: echo, diff, etc.
 
+# Testing may be done with a debug build 
+!IF EXIST(..\\vimd.exe) && !EXIST(..\\vim.exe)
+VIMPROG = ..\\vimd
+!ELSE
 VIMPROG = ..\\vim
+!ENDIF
+
 
 default: nongui
 


### PR DESCRIPTION
Problem: MS-Windows: debug executable not found when running test from msvc nmake
Solution: Also look for vimd.exe. in Make_mvc.mak

Similar to previous PR Patch 9.0.0856, that was for individual tests, whereas this PR resolves vimd.exe when running tests from nmake -f Make_mvc.mak