### PR TITLE
Eclipse preference files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -981,6 +981,7 @@ au BufNewFile,BufRead *.jsp			setf jsp
 
 " Java Properties resource file (note: doesn't catch font.properties.pl)
 au BufNewFile,BufRead *.properties,*.properties_??,*.properties_??_??	setf jproperties
+au BufNewFile,BufRead org.eclipse.*.prefs				setf jproperties
 
 " Jess
 au BufNewFile,BufRead *.clp			setf jess

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -286,7 +286,7 @@ let s:filename_checks = {
     \ 'jess': ['file.clp'],
     \ 'jgraph': ['file.jgr'],
     \ 'jovial': ['file.jov', 'file.j73', 'file.jovial'],
-    \ 'jproperties': ['file.properties', 'file.properties_xx', 'file.properties_xx_xx', 'some.properties_xx_xx_file'],
+    \ 'jproperties': ['file.properties', 'file.properties_xx', 'file.properties_xx_xx', 'some.properties_xx_xx_file', 'org.eclipse.xyz.prefs'],
     \ 'json': ['file.json', 'file.jsonp', 'file.json-patch', 'file.webmanifest', 'Pipfile.lock', 'file.ipynb', '.babelrc', '.eslintrc', '.prettierrc', '.firebaserc', 'file.slnf'],
     \ 'json5': ['file.json5'],
     \ 'jsonc': ['file.jsonc'],


### PR DESCRIPTION
Problem:    Eclipse preference files are not recognized.
Solution:   Recognize Eclipse preference files as "jproperties".