### PR TITLE
Unlet sh syntax script vars before completing

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -793,8 +793,11 @@ endif
 " Delete shell folding commands {{{1
 " =============================
 delc ShFoldFunctions
+unlet s:sh_fold_functions
 delc ShFoldHereDoc
+unlet s:sh_fold_heredoc
 delc ShFoldIfDoFor
+unlet s:sh_fold_ifdofor
 
 " Set Current Syntax: {{{1
 " ===================


### PR DESCRIPTION
Fixes #11536.

Unletting the script variables ensures the folding function commands will be re-defined respecting the present value of g:sh_fold_enabled whenever syntax highlighting is re-enabled, new buffers are opened, et cetera.