### PR TITLE
Fix indention in nginx plugin

### DIFF
--- a/runtime/indent/nginx.vim
+++ b/runtime/indent/nginx.vim
@@ -1,19 +1,78 @@
 " Vim indent file
 " Language: nginx.conf
 " Maintainer: Chris Aumann <me@chr4.org>
-" Last Change:  2022 Apr 06
+" Last Change:  2022 Dec 01
 
-if exists("b:did_indent")
-    finish
+" Only load this indent file when no other was loaded.
+if exists('b:did_indent')
+  finish
 endif
 let b:did_indent = 1
 
-setlocal indentexpr=
+setlocal indentexpr=GetNginxIndent()
 
-" cindent actually works for nginx' simple file structure
-setlocal cindent
+setlocal indentkeys=0{,0},0#,!^F,o,O
 
-" Just make sure that the comments are not reset as defs would be.
-setlocal cinkeys-=0#
+let b:undo_indent = 'setl inde< indk<'
 
-let b:undo_indent = "setl inde< cin< cink<"
+" Only define the function once.
+if exists('*GetNginxIndent')
+  finish
+endif
+
+function! GetNginxIndent() abort
+  let plnum = s:PrevNotAsBlank(v:lnum - 1)
+
+  " Hit the start of the file, use zero indent.
+  if plnum == 0
+    return 0
+  endif
+
+  let ind = indent(plnum)
+
+  " Add a 'shiftwidth' after '{'
+  if s:AsEndWith(getline(plnum), '{')
+    let ind = ind + shiftwidth()
+  end
+
+  " Subtract a 'shiftwidth' on '}'
+  " This is the part that requires 'indentkeys'.
+  if getline(v:lnum) =~ '^\s*}'
+    let ind = ind - shiftwidth()
+  endif
+
+  let pplnum = s:PrevNotAsBlank(plnum - 1)
+
+  if s:IsLineContinuation(plnum)
+    if !s:IsLineContinuation(pplnum)
+      let ind = ind + shiftwidth()
+    end
+  else
+    if s:IsLineContinuation(pplnum)
+      let ind = ind - shiftwidth()
+    end
+  endif
+
+  return ind
+endfunction
+
+" Find the first line at or above {lnum} that is non-blank and not a comment.
+function! s:PrevNotAsBlank(lnum) abort
+  let lnum = prevnonblank(a:lnum)
+  while lnum > 0
+    if getline(lnum) !~ '^\s*#'
+      break
+    endif
+    let lnum = prevnonblank(lnum - 1)
+  endwhile
+  return lnum
+endfunction
+
+" Check whether {line} ends with {pat}, ignoring trailing comments.
+function! s:AsEndWith(line, pat) abort
+  return a:line =~ a:pat . '\m\s*\%(#.*\)\?$'
+endfunction
+
+function! s:IsLineContinuation(lnum) abort
+  return a:lnum > 0 && !s:AsEndWith(getline(a:lnum), '[;{}]')
+endfunction

--- a/runtime/indent/nginx.vim
+++ b/runtime/indent/nginx.vim
@@ -20,7 +20,7 @@ if exists('*GetNginxIndent')
   finish
 endif
 
-function! GetNginxIndent() abort
+function GetNginxIndent() abort
   let plnum = s:PrevNotAsBlank(v:lnum - 1)
 
   " Hit the start of the file, use zero indent.
@@ -57,7 +57,7 @@ function! GetNginxIndent() abort
 endfunction
 
 " Find the first line at or above {lnum} that is non-blank and not a comment.
-function! s:PrevNotAsBlank(lnum) abort
+function s:PrevNotAsBlank(lnum) abort
   let lnum = prevnonblank(a:lnum)
   while lnum > 0
     if getline(lnum) !~ '^\s*#'
@@ -69,10 +69,10 @@ function! s:PrevNotAsBlank(lnum) abort
 endfunction
 
 " Check whether {line} ends with {pat}, ignoring trailing comments.
-function! s:AsEndWith(line, pat) abort
+function s:AsEndWith(line, pat) abort
   return a:line =~ a:pat . '\m\s*\%(#.*\)\?$'
 endfunction
 
-function! s:IsLineContinuation(lnum) abort
+function s:IsLineContinuation(lnum) abort
   return a:lnum > 0 && !s:AsEndWith(getline(a:lnum), '[;{}]')
 endfunction


### PR DESCRIPTION
Currently the indenting for nginx files breaks in certain cases, see chr4/nginx.vim#3. This PR fixes it.

This was handed in earlier, I know found the time to finally review and merge this upstream:
- https://github.com/vim/vim/pull/9003
- https://github.com/chr4/nginx.vim/pull/20