### PR TITLE
Vim9: Fix E1096 error when vim9 comment follows after :return

### DIFF
--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -467,6 +467,17 @@ def Test_return_bool()
   v9.CheckScriptSuccess(lines)
 enddef
 
+def Test_return_void_comment_follows()
+  var lines =<< trim END
+    vim9script
+    def ReturnCommentFollows(): void
+      return # Some comment
+    enddef
+    defcompile
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 let s:nothing = 0
 def ReturnNothing()
   s:nothing = 1

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -2531,7 +2531,7 @@ compile_return(char_u *arg, int check_return_type, int legacy, cctx_T *cctx)
     char_u	*p = arg;
     type_T	*stack_type;
 
-    if (*p != NUL && *p != '|' && *p != '\n')
+    if (*p != NUL && *p != '|' && *p != '\n' && !(!legacy && vim9_comment_start(p)))
     {
 	// For a lambda, "return expr" is always used, also when "expr" results
 	// in a void.


### PR DESCRIPTION
### Problem

E1096 error is raised when using vim9 comment after `:return` statement in a function without a return type.  This PR fixes it.

### Reproduce steps
1. Open Vim with: `vim -u NONE`
2. Run this script with `:%source`:

```vim
vim9script
def F(): void
  return # some comment
enddef
defcompile
```

Then you'll get this message on the command line:
```
Error detected while compiling :source buffer=1[6]..function <SNR>1_F:
line    1:
E1096: Returning a value in a function without a return type
```

### Expected behavior

No error is raised.

### Environment

Vim 9.0.990
macOS Monterey