### PR TITLE
better srand

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8156,13 +8156,18 @@ init_srand(UINT32_T *x)
 	}
     }
     if (dev_urandom_state != OK)
-	// Reading /dev/urandom doesn't work, fall back to reltime() or time().
+	// Reading /dev/urandom doesn't work, fall back to:
+	//   randombytes_random()
+	//   reltime()
+	//   time() ^ getpid()
 #endif
     {
-#ifdef FEAT_RELTIME
+#if defined(FEAT_SODIUM)
+	*x = randombytes_random();
+#elif defined(FEAT_RELTIME)
 	proftime_T res;
 	profile_start(&res);
-#  ifdef MSWIN
+#  if defined(MSWIN)
 	*x = (UINT32_T) res.LowPart;
 #  else
 	*x = (UINT32_T) res.tv_usec;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8158,7 +8158,7 @@ init_srand(UINT32_T *x)
     if (dev_urandom_state != OK)
 	// Reading /dev/urandom doesn't work, fall back to time().
 #endif
-	*x = vim_time();
+	*x = vim_time() ^ mch_get_pid();
 }
 
 #define ROTL(x, k) (((x) << (k)) | ((x) >> (32 - (k))))

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8156,9 +8156,21 @@ init_srand(UINT32_T *x)
 	}
     }
     if (dev_urandom_state != OK)
-	// Reading /dev/urandom doesn't work, fall back to time().
+	// Reading /dev/urandom doesn't work, fall back to reltime() or time().
 #endif
+    {
+#ifdef FEAT_RELTIME
+	proftime_T res;
+	profile_start(&res);
+#  ifdef MSWIN
+	*x = (UINT32_T) res.LowPart;
+#  else
+	*x = (UINT32_T) res.tv_usec;
+#  endif
+#else
 	*x = vim_time() ^ mch_get_pid();
+#endif
+    }
 }
 
 #define ROTL(x, k) (((x) << (k)) | ((x) >> (32 - (k))))

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -8163,8 +8163,14 @@ init_srand(UINT32_T *x)
 #endif
     {
 #if defined(FEAT_SODIUM)
-	*x = randombytes_random();
-#elif defined(FEAT_RELTIME)
+	if (sodium_init() >= 0)
+	{
+	    *x = randombytes_random();
+	    return;
+	}
+#endif
+
+#if defined(FEAT_RELTIME)
 	proftime_T res;
 	profile_start(&res);
 #  if defined(MSWIN)

--- a/src/testdir/test_random.vim
+++ b/src/testdir/test_random.vim
@@ -47,6 +47,9 @@ func Test_issue_5587()
 endfunc
 
 func Test_srand()
+  if has('gui_running')
+    return
+  endif
   let cmd = GetVimCommand() .. ' -V -es -c "echo rand()" -c qa!'
   let bad = 0
   for _ in range(10)

--- a/src/testdir/test_random.vim
+++ b/src/testdir/test_random.vim
@@ -56,7 +56,6 @@ func Test_srand()
     if result1 ==# result2
       let bad += 1
     endif
-    echo result1 result2
   endfor
   call assert_true(bad > 5)
 endfunc

--- a/src/testdir/test_random.vim
+++ b/src/testdir/test_random.vim
@@ -57,7 +57,7 @@ func Test_srand()
       let bad += 1
     endif
   endfor
-  call assert_true(bad > 5)
+  call assert_true(bad < 5)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_random.vim
+++ b/src/testdir/test_random.vim
@@ -1,5 +1,7 @@
 " Tests for srand() and rand()
 
+source shared.vim
+
 func Test_Rand()
   let r = srand(123456789)
   call assert_equal([1573771921, 319883699, 2742014374, 1324369493], r)
@@ -42,6 +44,21 @@ func Test_issue_5587()
   call rand()
   call garbagecollect()
   call rand()
+endfunc
+
+func Test_srand()
+  let cmd = GetVimCommand() .. ' -V -es -c "echo rand()" -c qa!'
+  let bad = 0
+  for _ in range(10)
+    echo cmd
+    let result1 = system(cmd)
+    let result2 = system(cmd)
+    if result1 ==# result2
+      let bad += 1
+    endif
+    echo result1 result2
+  endfor
+  call assert_true(bad > 5)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Currrent implementation of init_srand for Windows makes wrong seed value if vim run few times in same seconds.

```
vim -u NONE -V -es -c "echo rand(). ' '" -c quit && vim -u NONE -V -es -c "echo rand(). ' '" -c quit
```

![image](https://user-images.githubusercontent.com/10111/205499711-35584b4f-83a4-47e3-a8a9-dadbeabc213b.png)
