### PR TITLE
Add Zig ftplugin and syntax support

### DIFF
--- a/runtime/autoload/zig/fmt.vim
+++ b/runtime/autoload/zig/fmt.vim
@@ -1,0 +1,100 @@
+" Adapted from fatih/vim-go: autoload/go/fmt.vim
+"
+" Copyright 2011 The Go Authors. All rights reserved.
+" Use of this source code is governed by a BSD-style
+" license that can be found in the LICENSE file.
+"
+" Upstream: https://github.com/ziglang/zig.vim
+
+function! zig#fmt#Format() abort
+  " Save cursor position and many other things.
+  let view = winsaveview()
+
+  if !executable('zig')
+    echohl Error | echomsg "no zig binary found in PATH" | echohl None
+    return
+  endif
+
+  let cmdline = 'zig fmt --stdin --ast-check'
+  let current_buf = bufnr('')
+
+  " The formatted code is output on stdout, the errors go on stderr.
+  if exists('*systemlist')
+    silent let out = systemlist(cmdline, current_buf)
+  else
+    silent let out = split(system(cmdline, current_buf))
+  endif
+  if len(out) == 1
+    if out[0] == "error: unrecognized parameter: '--ast-check'"
+      let cmdline = 'zig fmt --stdin'
+      if exists('*systemlist')
+        silent let out = systemlist(cmdline, current_buf)
+      else
+        silent let out = split(system(cmdline, current_buf))
+      endif
+    endif
+  endif
+  let err = v:shell_error
+
+
+  if err == 0
+    " remove undo point caused via BufWritePre.
+    try | silent undojoin | catch | endtry
+
+    " Replace the file content with the formatted version.
+    if exists('*deletebufline')
+      call deletebufline(current_buf, len(out), line('$'))
+    else
+      silent execute ':' . len(out) . ',' . line('$') . ' delete _'
+    endif
+    call setline(1, out)
+
+    " No errors detected, close the loclist.
+    call setloclist(0, [], 'r')
+    lclose
+  elseif get(g:, 'zig_fmt_parse_errors', 1)
+    let errors = s:parse_errors(expand('%'), out)
+
+    call setloclist(0, [], 'r', {
+        \ 'title': 'Errors',
+        \ 'items': errors,
+        \ })
+
+    let max_win_height = get(g:, 'zig_fmt_max_window_height', 5)
+    " Prevent the loclist from becoming too long.
+    let win_height = min([max_win_height, len(errors)])
+    " Open the loclist, but only if there's at least one error to show.
+    execute 'silent! lwindow ' . win_height
+  endif
+
+  call winrestview(view)
+
+  if err != 0
+    echohl Error | echomsg "zig fmt returned error" | echohl None
+    return
+  endif
+
+  " Run the syntax highlighter on the updated content and recompute the folds if
+  " needed.
+  syntax sync fromstart
+endfunction
+
+" parse_errors parses the given errors and returns a list of parsed errors
+function! s:parse_errors(filename, lines) abort
+  " list of errors to be put into location list
+  let errors = []
+  for line in a:lines
+    let tokens = matchlist(line, '^\(.\{-}\):\(\d\+\):\(\d\+\)\s*\(.*\)')
+    if !empty(tokens)
+      call add(errors,{
+            \"filename": a:filename,
+            \"lnum":     tokens[2],
+            \"col":      tokens[3],
+            \"text":     tokens[4],
+            \ })
+    endif
+  endfor
+
+  return errors
+endfunction
+" vim: sw=2 ts=2 et

--- a/runtime/compiler/zig.vim
+++ b/runtime/compiler/zig.vim
@@ -1,0 +1,28 @@
+" Vim compiler file
+" Compiler: Zig Compiler
+" Upstream: https://github.com/ziglang/zig.vim
+
+if exists("current_compiler")
+    finish
+endif
+let current_compiler = "zig"
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+if exists(":CompilerSet") != 2
+    command -nargs=* CompilerSet setlocal <args>
+endif
+
+" a subcommand must be provided for the this compiler (test, build-exe, etc)
+if has('patch-7.4.191')
+    CompilerSet makeprg=zig\ \$*\ \%:S
+else
+    CompilerSet makeprg=zig\ \$*\ \"%\"
+endif
+
+" TODO: improve errorformat as needed.
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/runtime/compiler/zig_build.vim
+++ b/runtime/compiler/zig_build.vim
@@ -1,0 +1,29 @@
+" Vim compiler file
+" Compiler: Zig Compiler (zig build)
+" Upstream: https://github.com/ziglang/zig.vim
+
+if exists('current_compiler')
+  finish
+endif
+runtime compiler/zig.vim
+let current_compiler = 'zig_build'
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+
+if exists(':CompilerSet') != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+if exists('g:zig_build_makeprg_params')
+	execute 'CompilerSet makeprg=zig\ build\ '.escape(g:zig_build_makeprg_params, ' \|"').'\ $*'
+else
+	CompilerSet makeprg=zig\ build\ $*
+endif
+
+" TODO: anything to add to errorformat for zig build specifically?
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/runtime/compiler/zig_build_exe.vim
+++ b/runtime/compiler/zig_build_exe.vim
@@ -1,0 +1,27 @@
+" Vim compiler file
+" Compiler: Zig Compiler (zig build-exe)
+" Upstream: https://github.com/ziglang/zig.vim
+
+if exists('current_compiler')
+  finish
+endif
+runtime compiler/zig.vim
+let current_compiler = 'zig_build_exe'
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+
+if exists(':CompilerSet') != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+if has('patch-7.4.191')
+  CompilerSet makeprg=zig\ build-exe\ \%:S\ \$* 
+else
+  CompilerSet makeprg=zig\ build-exe\ \"%\"\ \$* 
+endif
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/runtime/compiler/zig_test.vim
+++ b/runtime/compiler/zig_test.vim
@@ -1,0 +1,27 @@
+" Vim compiler file
+" Compiler: Zig Compiler (zig test)
+" Upstream: https://github.com/ziglang/zig.vim
+
+if exists('current_compiler')
+  finish
+endif
+runtime compiler/zig.vim
+let current_compiler = 'zig_test'
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+
+if exists(':CompilerSet') != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+if has('patch-7.4.191')
+  CompilerSet makeprg=zig\ test\ \%:S\ \$* 
+else
+  CompilerSet makeprg=zig\ test\ \"%\"\ \$* 
+endif
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1857,6 +1857,7 @@ au BufNewFile,BufRead .login,.cshrc,csh.cshrc,csh.login,csh.logout,*.csh,.alias 
 
 " Zig
 au BufNewFile,BufRead *.zig			setf zig
+au BufNewFile,BufRead *.zir			setf zir
 
 " Z-Shell script (patterns ending in a star further below)
 au BufNewFile,BufRead .zprofile,*/etc/zprofile,.zfbfmarks  setf zsh

--- a/runtime/ftplugin/zig.vim
+++ b/runtime/ftplugin/zig.vim
@@ -1,0 +1,66 @@
+" Vim filetype plugin file
+" Language: Zig
+" Upstream: https://github.com/ziglang/zig.vim
+
+" Only do this when not done yet for this buffer
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let b:did_ftplugin = 1
+
+let s:cpo_orig = &cpo
+set cpo&vim
+
+compiler zig_build
+
+" Match Zig builtin fns
+setlocal iskeyword+=@-@
+
+" Recomended code style, no tabs and 4-space indentation
+setlocal expandtab
+setlocal tabstop=8
+setlocal softtabstop=4
+setlocal shiftwidth=4
+
+setlocal formatoptions-=t formatoptions+=croql
+
+setlocal suffixesadd=.zig,.zir
+
+if has('comments')
+    setlocal comments=:///,://!,://,:\\\\
+    setlocal commentstring=//\ %s
+endif
+
+if has('find_in_path')
+    let &l:includeexpr='substitute(v:fname, "^([^.])$", "\1.zig", "")'
+    let &l:include='\v(\@import>|\@cInclude>|^\s*\#\s*include)'
+endif
+
+let &l:define='\v(<fn>|<const>|<var>|^\s*\#\s*define)'
+
+if !exists('g:zig_std_dir') && exists('*json_decode') && executable('zig')
+    silent let s:env = system('zig env')
+    if v:shell_error == 0
+        let g:zig_std_dir = json_decode(s:env)['std_dir']
+    endif
+    unlet! s:env
+endif
+
+if exists('g:zig_std_dir')
+    let &l:path = &l:path . ',' . g:zig_std_dir
+endif
+
+let b:undo_ftplugin =
+    \ 'setl isk< et< ts< sts< sw< fo< sua< mp< com< cms< inex< inc< pa<'
+
+augroup vim-zig
+    autocmd! * <buffer>
+    autocmd BufWritePre <buffer> if get(g:, 'zig_fmt_autosave', 1) | call zig#fmt#Format() | endif
+augroup END
+
+let b:undo_ftplugin .= '|au! vim-zig * <buffer>'
+
+let &cpo = s:cpo_orig
+unlet s:cpo_orig
+" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/runtime/indent/zig.vim
+++ b/runtime/indent/zig.vim
@@ -1,0 +1,80 @@
+" Vim filetype indent file
+" Language: Zig
+" Upstream: https://github.com/ziglang/zig.vim
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+
+if (!has("cindent") || !has("eval"))
+    finish
+endif
+
+setlocal cindent
+
+" L0 -> 0 indent for jump labels (i.e. case statement in c).
+" j1 -> indenting for "javascript object declarations"
+" J1 -> see j1
+" w1 -> starting a new line with `(` at the same indent as `(`
+" m1 -> if `)` starts a line, match its indent with the first char of its
+"       matching `(` line
+" (s -> use one indent, when starting a new line after a trailing `(`
+setlocal cinoptions=L0,m1,(s,j1,J1,l1
+
+" cinkeys: controls what keys trigger indent formatting
+" 0{ -> {
+" 0} -> }
+" 0) -> )
+" 0] -> ]
+" !^F -> make CTRL-F (^F) reindent the current line when typed
+" o -> when <CR> or `o` is used
+" O -> when the `O` command is used
+setlocal cinkeys=0{,0},0),0],!^F,o,O
+
+setlocal indentexpr=GetZigIndent(v:lnum)
+
+let b:undo_indent = "setlocal cindent< cinkeys< cinoptions< indentexpr<"
+
+function! GetZigIndent(lnum)
+    let curretLineNum = a:lnum
+    let currentLine = getline(a:lnum)
+
+    " cindent doesn't handle multi-line strings properly, so force no indent
+    if currentLine =~ '^\s*\\\\.*'
+        return -1
+    endif
+
+    let prevLineNum = prevnonblank(a:lnum-1)
+    let prevLine = getline(prevLineNum)
+
+    " for lines that look like
+    "   },
+    "   };
+    " try treating them the same as a }
+    if prevLine =~ '\v^\s*},$'
+        if currentLine =~ '\v^\s*};$' || currentLine =~ '\v^\s*}$'
+            return indent(prevLineNum) - 4
+        endif
+        return indent(prevLineNum-1) - 4
+    endif
+    if currentLine =~ '\v^\s*},$'
+        return indent(prevLineNum) - 4
+    endif
+    if currentLine =~ '\v^\s*};$'
+        return indent(prevLineNum) - 4
+    endif
+
+
+    " cindent doesn't handle this case correctly:
+    " switch (1): {
+    "   1 => true,
+    "       ~
+    "       ^---- indents to here
+    if prevLine =~ '.*=>.*,$' && currentLine !~ '.*}$'
+       return indent(prevLineNum)
+    endif
+
+    return cindent(a:lnum)
+endfunction

--- a/runtime/syntax/zig.vim
+++ b/runtime/syntax/zig.vim
@@ -1,0 +1,292 @@
+" Vim syntax file
+" Language: Zig
+" Upstream: https://github.com/ziglang/zig.vim
+
+if exists("b:current_syntax")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let s:zig_syntax_keywords = {
+    \   'zigBoolean': ["true"
+    \ ,                "false"]
+    \ , 'zigNull': ["null"]
+    \ , 'zigType': ["bool"
+    \ ,             "f16"
+    \ ,             "f32"
+    \ ,             "f64"
+    \ ,             "f80"
+    \ ,             "f128"
+    \ ,             "void"
+    \ ,             "type"
+    \ ,             "anytype"
+    \ ,             "anyerror"
+    \ ,             "anyframe"
+    \ ,             "volatile"
+    \ ,             "linksection"
+    \ ,             "noreturn"
+    \ ,             "allowzero"
+    \ ,             "i0"
+    \ ,             "u0"
+    \ ,             "isize"
+    \ ,             "usize"
+    \ ,             "comptime_int"
+    \ ,             "comptime_float"
+    \ ,             "c_short"
+    \ ,             "c_ushort"
+    \ ,             "c_int"
+    \ ,             "c_uint"
+    \ ,             "c_long"
+    \ ,             "c_ulong"
+    \ ,             "c_longlong"
+    \ ,             "c_ulonglong"
+    \ ,             "c_longdouble"
+    \ ,             "anyopaque"]
+    \ , 'zigConstant': ["undefined"
+    \ ,                 "unreachable"]
+    \ , 'zigConditional': ["if"
+    \ ,                    "else"
+    \ ,                    "switch"]
+    \ , 'zigRepeat': ["while"
+    \ ,               "for"]
+    \ , 'zigComparatorWord': ["and"
+    \ ,                       "or"
+    \ ,                       "orelse"]
+    \ , 'zigStructure': ["struct"
+    \ ,                  "enum"
+    \ ,                  "union"
+    \ ,                  "error"
+    \ ,                  "packed"
+    \ ,                  "opaque"]
+    \ , 'zigException': ["error"]
+    \ , 'zigVarDecl': ["var"
+    \ ,                "const"
+    \ ,                "comptime"
+    \ ,                "threadlocal"]
+    \ , 'zigDummyVariable': ["_"]
+    \ , 'zigKeyword': ["fn"
+    \ ,                "try"
+    \ ,                "test"
+    \ ,                "pub"
+    \ ,                "usingnamespace"]
+    \ , 'zigExecution': ["return"
+    \ ,                  "break"
+    \ ,                  "continue"]
+    \ , 'zigMacro': ["defer"
+    \ ,              "errdefer"
+    \ ,              "async"
+    \ ,              "nosuspend"
+    \ ,              "await"
+    \ ,              "suspend"
+    \ ,              "resume"
+    \ ,              "export"
+    \ ,              "extern"]
+    \ , 'zigPreProc': ["catch"
+    \ ,                "inline"
+    \ ,                "noinline"
+    \ ,                "asm"
+    \ ,                "callconv"
+    \ ,                "noalias"]
+    \ , 'zigBuiltinFn': ["align"
+    \ ,                  "@addWithOverflow"
+    \ ,                  "@as"
+    \ ,                  "@atomicLoad"
+    \ ,                  "@atomicStore"
+    \ ,                  "@bitCast"
+    \ ,                  "@breakpoint"
+    \ ,                  "@alignCast"
+    \ ,                  "@alignOf"
+    \ ,                  "@cDefine"
+    \ ,                  "@cImport"
+    \ ,                  "@cInclude"
+    \ ,                  "@cUndef"
+    \ ,                  "@clz"
+    \ ,                  "@cmpxchgWeak"
+    \ ,                  "@cmpxchgStrong"
+    \ ,                  "@compileError"
+    \ ,                  "@compileLog"
+    \ ,                  "@ctz"
+    \ ,                  "@popCount"
+    \ ,                  "@divExact"
+    \ ,                  "@divFloor"
+    \ ,                  "@divTrunc"
+    \ ,                  "@embedFile"
+    \ ,                  "@export"
+    \ ,                  "@extern"
+    \ ,                  "@tagName"
+    \ ,                  "@TagType"
+    \ ,                  "@errorName"
+    \ ,                  "@call"
+    \ ,                  "@errorReturnTrace"
+    \ ,                  "@fence"
+    \ ,                  "@fieldParentPtr"
+    \ ,                  "@field"
+    \ ,                  "@unionInit"
+    \ ,                  "@frameAddress"
+    \ ,                  "@import"
+    \ ,                  "@newStackCall"
+    \ ,                  "@asyncCall"
+    \ ,                  "@intToPtr"
+    \ ,                  "@max"
+    \ ,                  "@min"
+    \ ,                  "@memcpy"
+    \ ,                  "@memset"
+    \ ,                  "@mod"
+    \ ,                  "@mulAdd"
+    \ ,                  "@mulWithOverflow"
+    \ ,                  "@splat"
+    \ ,                  "@src"
+    \ ,                  "@bitOffsetOf"
+    \ ,                  "@byteOffsetOf"
+    \ ,                  "@offsetOf"
+    \ ,                  "@OpaqueType"
+    \ ,                  "@panic"
+    \ ,                  "@prefetch"
+    \ ,                  "@ptrCast"
+    \ ,                  "@ptrToInt"
+    \ ,                  "@rem"
+    \ ,                  "@returnAddress"
+    \ ,                  "@setCold"
+    \ ,                  "@Type"
+    \ ,                  "@shuffle"
+    \ ,                  "@reduce"
+    \ ,                  "@select"
+    \ ,                  "@setRuntimeSafety"
+    \ ,                  "@setEvalBranchQuota"
+    \ ,                  "@setFloatMode"
+    \ ,                  "@shlExact"
+    \ ,                  "@This"
+    \ ,                  "@hasDecl"
+    \ ,                  "@hasField"
+    \ ,                  "@shlWithOverflow"
+    \ ,                  "@shrExact"
+    \ ,                  "@sizeOf"
+    \ ,                  "@bitSizeOf"
+    \ ,                  "@sqrt"
+    \ ,                  "@byteSwap"
+    \ ,                  "@subWithOverflow"
+    \ ,                  "@intCast"
+    \ ,                  "@floatCast"
+    \ ,                  "@intToFloat"
+    \ ,                  "@floatToInt"
+    \ ,                  "@boolToInt"
+    \ ,                  "@errSetCast"
+    \ ,                  "@truncate"
+    \ ,                  "@typeInfo"
+    \ ,                  "@typeName"
+    \ ,                  "@TypeOf"
+    \ ,                  "@atomicRmw"
+    \ ,                  "@intToError"
+    \ ,                  "@errorToInt"
+    \ ,                  "@intToEnum"
+    \ ,                  "@enumToInt"
+    \ ,                  "@setAlignStack"
+    \ ,                  "@frame"
+    \ ,                  "@Frame"
+    \ ,                  "@frameSize"
+    \ ,                  "@bitReverse"
+    \ ,                  "@Vector"
+    \ ,                  "@sin"
+    \ ,                  "@cos"
+    \ ,                  "@tan"
+    \ ,                  "@exp"
+    \ ,                  "@exp2"
+    \ ,                  "@log"
+    \ ,                  "@log2"
+    \ ,                  "@log10"
+    \ ,                  "@fabs"
+    \ ,                  "@floor"
+    \ ,                  "@ceil"
+    \ ,                  "@trunc"
+    \ ,                  "@wasmMemorySize"
+    \ ,                  "@wasmMemoryGrow"
+    \ ,                  "@round"]
+    \ }
+
+function! s:syntax_keyword(dict)
+  for key in keys(a:dict)
+    execute 'syntax keyword' key join(a:dict[key], ' ')
+  endfor
+endfunction
+
+call s:syntax_keyword(s:zig_syntax_keywords)
+
+syntax match zigType "\v<[iu][1-9]\d*>"
+syntax match zigOperator display "\V\[-+/*=^&?|!><%~]"
+syntax match zigArrowCharacter display "\V->"
+
+"                                     12_34  (. but not ..)? (12_34)?     (exponent  12_34)?
+syntax match zigDecNumber display   "\v<\d%(_?\d)*%(\.\.@!)?%(\d%(_?\d)*)?%([eE][+-]?\d%(_?\d)*)?"
+syntax match zigHexNumber display "\v<0x\x%(_?\x)*%(\.\.@!)?%(\x%(_?\x)*)?%([pP][+-]?\d%(_?\d)*)?"
+syntax match zigOctNumber display "\v<0o\o%(_?\o)*"
+syntax match zigBinNumber display "\v<0b[01]%(_?[01])*"
+
+syntax match zigCharacterInvalid display contained /b\?'\zs[\n\r\t']\ze'/
+syntax match zigCharacterInvalidUnicode display contained /b'\zs[^[:cntrl:][:graph:][:alnum:][:space:]]\ze'/
+syntax match zigCharacter /b'\([^\\]\|\\\(.\|x\x\{2}\)\)'/ contains=zigEscape,zigEscapeError,zigCharacterInvalid,zigCharacterInvalidUnicode
+syntax match zigCharacter /'\([^\\]\|\\\(.\|x\x\{2}\|u\x\{4}\|U\x\{6}\)\)'/ contains=zigEscape,zigEscapeUnicode,zigEscapeError,zigCharacterInvalid
+
+syntax region zigBlock start="{" end="}" transparent fold
+
+syntax region zigCommentLine start="//" end="$" contains=zigTodo,@Spell
+syntax region zigCommentLineDoc start="//[/!]/\@!" end="$" contains=zigTodo,@Spell
+
+syntax match zigMultilineStringPrefix /c\?\\\\/ contained containedin=zigMultilineString
+syntax region zigMultilineString matchgroup=zigMultilineStringDelimiter start="c\?\\\\" end="$" contains=zigMultilineStringPrefix display
+
+syntax keyword zigTodo contained TODO
+
+syntax region zigString matchgroup=zigStringDelimiter start=+c\?"+ skip=+\\\\\|\\"+ end=+"+ oneline contains=zigEscape,zigEscapeUnicode,zigEscapeError,@Spell
+syntax match zigEscapeError   display contained /\\./
+syntax match zigEscape        display contained /\\\([nrt\\'"]\|x\x\{2}\)/
+syntax match zigEscapeUnicode display contained /\\\(u\x\{4}\|U\x\{6}\)/
+
+highlight default link zigDecNumber zigNumber
+highlight default link zigHexNumber zigNumber
+highlight default link zigOctNumber zigNumber
+highlight default link zigBinNumber zigNumber
+
+highlight default link zigBuiltinFn Statement
+highlight default link zigKeyword Keyword
+highlight default link zigType Type
+highlight default link zigCommentLine Comment
+highlight default link zigCommentLineDoc Comment
+highlight default link zigDummyVariable Comment
+highlight default link zigTodo Todo
+highlight default link zigString String
+highlight default link zigStringDelimiter String
+highlight default link zigMultilineString String
+highlight default link zigMultilineStringContent String
+highlight default link zigMultilineStringPrefix String
+highlight default link zigMultilineStringDelimiter Delimiter
+highlight default link zigCharacterInvalid Error
+highlight default link zigCharacterInvalidUnicode zigCharacterInvalid
+highlight default link zigCharacter Character
+highlight default link zigEscape Special
+highlight default link zigEscapeUnicode zigEscape
+highlight default link zigEscapeError Error
+highlight default link zigBoolean Boolean
+highlight default link zigNull Boolean
+highlight default link zigConstant Constant
+highlight default link zigNumber Number
+highlight default link zigArrowCharacter zigOperator
+highlight default link zigOperator Operator
+highlight default link zigStructure Structure
+highlight default link zigExecution Special
+highlight default link zigMacro Macro
+highlight default link zigConditional Conditional
+highlight default link zigComparatorWord Keyword
+highlight default link zigRepeat Repeat
+highlight default link zigSpecial Special
+highlight default link zigVarDecl Function
+highlight default link zigPreProc PreProc
+highlight default link zigException Exception
+
+delfunction s:syntax_keyword
+
+let b:current_syntax = "zig"
+
+let &cpo = s:cpo_save
+unlet! s:cpo_save

--- a/runtime/syntax/zir.vim
+++ b/runtime/syntax/zir.vim
@@ -1,0 +1,49 @@
+" Vim syntax file
+" Language: Zir
+" Upstream: https://github.com/ziglang/zig.vim
+
+if exists("b:current_syntax")
+  finish
+endif
+let b:current_syntax = "zir"
+
+syn region zirCommentLine start=";" end="$" contains=zirTodo,@Spell
+
+syn region zirBlock start="{" end="}" transparent fold
+
+syn keyword zirKeyword primitive fntype int str as ptrtoint fieldptr deref asm unreachable export ref fn
+
+syn keyword zirTodo contained TODO
+
+syn region zirString start=+c\?"+ skip=+\\\\\|\\"+ end=+"+ oneline contains=zirEscape,zirEscapeUnicode,zirEscapeError,@Spell
+
+syn match zirEscapeError   display contained /\\./
+syn match zirEscape        display contained /\\\([nrt\\'"]\|x\x\{2}\)/
+syn match zirEscapeUnicode display contained /\\\(u\x\{4}\|U\x\{6}\)/
+
+syn match zirDecNumber display "\<[0-9]\+\%(.[0-9]\+\)\=\%([eE][+-]\?[0-9]\+\)\="
+syn match zirHexNumber display "\<0x[a-fA-F0-9]\+\%([a-fA-F0-9]\+\%([pP][+-]\?[0-9]\+\)\?\)\="
+syn match zirOctNumber display "\<0o[0-7]\+"
+syn match zirBinNumber display "\<0b[01]\+\%(.[01]\+\%([eE][+-]\?[0-9]\+\)\?\)\="
+
+syn match zirGlobal display "[^a-zA-Z0-9_]\?\zs@[a-zA-Z0-9_]\+"
+syn match zirLocal  display "[^a-zA-Z0-9_]\?\zs%[a-zA-Z0-9_]\+"
+
+hi def link zirCommentLine Comment
+hi def link zirTodo Todo
+
+hi def link zirKeyword Keyword
+
+hi def link zirString Constant
+
+hi def link zirEscape Special
+hi def link zirEscapeUnicode zirEscape
+hi def link zirEscapeError Error
+
+hi def link zirDecNumber Constant
+hi def link zirHexNumber Constant
+hi def link zirOctNumber Constant
+hi def link zirBinNumber Constant
+
+hi def link zirGlobal Identifier
+hi def link zirLocal  Identifier


### PR DESCRIPTION
Add ftplugin, syntax, indent, and compiler support for Zig source and Zig
Intermediate Representation (ZIR) files.

These files come from the upstream community plugin [1]. The author supplied
consent for these files to be upstreamed on Discord:
https://discord.com/channels/605571803288698900/855801133061636136/1049075626893656066.

[1]: https://github.com/ziglang/zig.vim
