### PR TITLE
LGTM.com will be shut down in December 2022

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,4 +1,0 @@
-# Format of this file: https://lgtm.com/help/lgtm/lgtm.yml-configuration-file
-path_classifiers:
-  documentation:
-    - runtime/tutor/tutor*

--- a/Filelist
+++ b/Filelist
@@ -15,7 +15,6 @@ SRC_ALL =	\
 		.github/dependabot.yml \
 		.gitignore \
 		.hgignore \
-		.lgtm.yml \
 		.appveyor.yml \
 		.codecov.yml \
 		ci/appveyor.bat \


### PR DESCRIPTION
LGTM.com recommends to use GitHub code scanning instead.

16th of December: LGTM.com will be shut down
From the 16th of December, LGTM.com will no longer be available. This includes but is not limited to:
    LGTM.com code quality badges
    The LGTM query console (including historical results)
    The LGTM documentation
    All LGTM.com APIs
https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/#16th-of-december-lgtm-com-will-be-shut-down
