### PR TITLE
Fix mouse shape test timer issue in CI

### DIFF
--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -3818,24 +3818,33 @@ func Test_mouse_shape_after_failed_change()
   CheckCanRunGui
 
   let lines =<< trim END
+    vim9script
     set mouseshape+=o:busy
     setlocal nomodifiable
-    let g:mouse_shapes = []
+    var mouse_shapes = []
 
-    func SaveMouseShape(timer)
-      let g:mouse_shapes += [getmouseshape()]
-    endfunc
+    def SaveMouseShape()
+      mouse_shapes += [getmouseshape()]
+    enddef
 
-    func SaveAndQuit(timer)
-      call writefile(g:mouse_shapes, 'Xmouseshapes')
+    def SaveAndQuit()
+      writefile(mouse_shapes, 'Xmouseshapes')
       quit
-    endfunc
+    enddef
 
-    call timer_start(50, {_ -> feedkeys('c')})
-    call timer_start(100, 'SaveMouseShape')
-    call timer_start(150, {_ -> feedkeys('c')})
-    call timer_start(200, 'SaveMouseShape')
-    call timer_start(250, 'SaveAndQuit')
+    feedkeys('c')
+    timer_start(50, (_) => {
+      SaveMouseShape()
+      timer_start(50, (_) => {
+        feedkeys('c')
+        timer_start(50, (_) => {
+          SaveMouseShape()
+          timer_start(50, (_) => {
+            SaveAndQuit()
+          })
+        })
+      })
+    })
   END
   call writefile(lines, 'Xmouseshape.vim', 'D')
   call RunVim([], [], "-g -S Xmouseshape.vim")

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -3823,24 +3823,16 @@ func Test_mouse_shape_after_failed_change()
     setlocal nomodifiable
     var mouse_shapes = []
 
-    def SaveMouseShape()
-      mouse_shapes += [getmouseshape()]
-    enddef
-
-    def SaveAndQuit()
-      writefile(mouse_shapes, 'Xmouseshapes')
-      quit
-    enddef
-
     feedkeys('c')
     timer_start(50, (_) => {
-      SaveMouseShape()
+      mouse_shapes += [getmouseshape()]
       timer_start(50, (_) => {
         feedkeys('c')
         timer_start(50, (_) => {
-          SaveMouseShape()
+          mouse_shapes += [getmouseshape()]
           timer_start(50, (_) => {
-            SaveAndQuit()
+            writefile(mouse_shapes, 'Xmouseshapes')
+            quit
           })
         })
       })


### PR DESCRIPTION
In MacVim CI, the `Test_mouse_shape_after_failed_change` tests would fail due to test logic relying on precise timer sequencing. If any timer gets delayed, it will cause the logic to not work. Fix this by only starting a new timer when a previous step has completed (relying on callbacks), instead of scheduling all timer events right off the bat. This makes sure that we have the minimum of elapsed time between events. Also switched to vim9script because it's easier to do a callback style like this in it.