### PR TITLE
Document compilers/dotnet.vim variables

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@ runtime/compiler/dartanalyser.vim	@dkearns
 runtime/compiler/dartdevc.vim		@dkearns
 runtime/compiler/dartdoc.vim		@dkearns
 runtime/compiler/dartfmt.vim		@dkearns
+runtime/compiler/dotnet.vim		@nickspoons
 runtime/compiler/eruby.vim		@dkearns
 runtime/compiler/fbc.vim		@dkearns
 runtime/compiler/gawk.vim		@dkearns

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1273,6 +1273,21 @@ not "b:current_compiler".  What the command actually does is the following:
 For writing a compiler plugin, see |write-compiler-plugin|.
 
 
+DOTNET							*compiler-dotnet*
+
+The .NET CLI compiler outputs both errors and warnings by default. The output
+may be limited to include only errors, by setting the g:dotnet_errors_only
+variable to |v:true|.
+
+The associated project name is included in each error and warning. To supress
+the project name, set the g:dotnet_show_project_file variable to |v:false|.
+
+Example: limit output to only display errors, and suppress the project name: >
+	let dotnet_errors_only = v:true
+	let dotnet_show_project_file = v:false
+	compiler dotnet
+<
+
 GCC					*quickfix-gcc*	*compiler-gcc*
 
 There's one variable you can set for the GCC compiler:


### PR DESCRIPTION
A new `compiler/dotnet.vim` compiler has been added in the latest runtime files. The compiler has some configuration variables, which are documented in this PR.

I have also updated `CODEOWNERS` to include the new files.