### PR TITLE
fix: It's '...to substitute 'old' for 'new'. ...'

### DIFF
--- a/runtime/tutor/tutor
+++ b/runtime/tutor/tutor
@@ -555,7 +555,7 @@ NOTE: This is very useful in debugging a program with unmatched parentheses!
 		      Lesson 4.4: THE SUBSTITUTE COMMAND
 
 
-	** Type  :s/old/new/g  to substitute 'new' for 'old'. **
+	** Type  :s/old/new/g  to substitute 'old' for 'new'. **
 
   1. Move the cursor to the line below marked --->.
 

--- a/runtime/tutor/tutor.utf-8
+++ b/runtime/tutor/tutor.utf-8
@@ -555,7 +555,7 @@ NOTE: This is very useful in debugging a program with unmatched parentheses!
 		      Lesson 4.4: THE SUBSTITUTE COMMAND
 
 
-	** Type  :s/old/new/g  to substitute 'new' for 'old'. **
+	** Type  :s/old/new/g  to substitute 'old' for 'new'. **
 
   1. Move the cursor to the line below marked --->.
 


### PR DESCRIPTION
I have noticed in Lesson 4.4 (vimtutor) that the command :s/old/new/g actually changes 'old' to 'new', not 'new' to 'old'.