### PR TITLE
replaced site link

### DIFF
--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -540,7 +540,7 @@ JTags			For Java, in Java.  It can be found at
 ptags.py		For Python, in Python.  Found in your Python source
 			directory at Tools/scripts/ptags.py.
 ptags			For Perl, in Perl.  It can be found at
-			http://www.eleves.ens.fr:8080/home/nthiery/Tags/.
+			https://nicolas.thiery.name/Tags/
 gnatxref		For Ada.  See http://www.gnuada.org/.  gnatxref is
 			part of the gnat package.
 


### PR DESCRIPTION
http://www.eleves.ens.fr:8080/home/nthiery/Tags/ is now defunct.