### PR TITLE
Reset postponed_split for failed <C-W>] commands

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1911,4 +1911,16 @@ function Test_splitkeep_status()
   call VerifyScreenDump(buf, 'Test_splitkeep_status_1', {})
 endfunction
 
+function Test_new_help_window_on_error()
+  help change.txt
+  execute "normal! /CTRL-@\<CR>"
+  silent! execute "normal! \<C-W>]"
+
+  let wincount = winnr('$')
+  help 'mod'
+
+  call assert_equal(wincount, winnr('$'))
+  call assert_equal(expand("<cword>"), "'mod'")
+endfunction
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -559,6 +559,7 @@ newwindow:
 		// Execute the command right here, required when "wincmd ]"
 		// was used in a function.
 		do_nv_ident(Ctrl_RSB, NUL);
+		postponed_split = 0;
 		break;
 
 // edit file name under cursor in a new window
@@ -674,6 +675,7 @@ wingotofile:
 			// Execute the command right here, required when
 			// "wincmd g}" was used in a function.
 			do_nv_ident('g', xchar);
+			postponed_split = 0;
 			break;
 
 		    case 'f':	    // CTRL-W gf: "gf" in a new tab page


### PR DESCRIPTION
This prevents `postponed_split` affecting later, unrelated commands.

To reproduce, prior to this commit:

In a help file, `Ctrl-W_Ctrl-]` on a tag that doesn't exist. e.g. `:h change.txt | /CTRL-@`
(Find the "CTRL-@" and `Ctrl-W_Ctrl-]` with your cursor over it)

The tag jump will fail (this is ok/expected, since it tries to look for `CTRL-@)`)

Then, run a help command, such as `:h 'mod'`.
The help will open in a new window, not the current one