### PR TITLE
fix: avoid conflict with supercollider and scala files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -816,7 +816,7 @@ enddef
 #       rely on checks that can't be confused.
 export def FTsc()
   for lnum in range(1, min([line("$"), 25]))
-    if getline(lnum) =~# 'var\s<\|classvar\s<\|\^this.*\||\w*|\|+\s\w*\s{\|\*ar\s'
+    if getline(lnum) =~# 'var\s<\|classvar\s<\|\^this.*\||\w\+|\|+\s\w*\s{\|\*ar\s'
       setf supercollider
       return
     endif

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -810,10 +810,13 @@ export def SQL()
 enddef
 
 # This function checks the first 25 lines of file extension "sc" to resolve
-# detection between scala and SuperCollider
+# detection between scala and SuperCollider.
+# NOTE: that we don't do a check for 'Class : Method' as this can easily be
+#       confused with valid Scala like `val x : Int = 3`. So we instead only
+#       rely on checks that can't be confused.
 export def FTsc()
   for lnum in range(1, min([line("$"), 25]))
-    if getline(lnum) =~# '[A-Za-z0-9]*\s:\s[A-Za-z0-9]\|var\s<\|classvar\s<\|\^this.*\||\w*|\|+\s\w*\s{\|\*ar\s'
+    if getline(lnum) =~# 'var\s<\|classvar\s<\|\^this.*\||\w*|\|+\s\w*\s{\|\*ar\s'
       setf supercollider
       return
     endif

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1533,13 +1533,6 @@ endfunc
 func Test_sc_file()
   filetype on
 
-  " SC file methods are defined 'Class : Method'
-  call writefile(['SCNvimDocRenderer : SCDocHTMLRenderer {'], 'srcfile.sc')
-  split srcfile.sc
-  call assert_equal('supercollider', &filetype)
-  bwipe!
-  call delete('srcfile.sc')
-
   " SC classes are defined with '+ Class {}'
   call writefile(['+ SCNvim {', '*methodArgs {|method|'], 'srcfile.sc')
   split srcfile.sc


### PR DESCRIPTION
Since the changes introduced in
https://github.com/vim/vim/pull/10142/commits/919ebcb8cbb5710eeccbf9750633e56572ccd471
I've seen an increasing amount of Scala users report that their Scala
scripts are being treated as supercollider files. There is one line in
the check there is problematic since it treats the following (valid
Scala) as supercollider code:

```scala
val example : String = "hello"
```

It's the ` : ` that is problematic here since looking at the notes this
can also be used for `Class : Method` is supercollider, but is also
totally valid Scala. The rest of the checks can't be confused like this
and are safe, but this one is problematic. I think it should be fine to
remove this and instead rely on the other checks to find supercollider
usage where there can't be confusion. This is anecdotal since I'm not a
supercollider user, but searching around on GitHub I'm not really even
finding this patter for supercollider files, which again, I might be
misunderstanding their usage.
