### PR TITLE
Remove 'r' and 'o' from formatoptions.

### DIFF
--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -17,9 +17,8 @@ set cpo-=C
 
 let b:undo_ftplugin = "setl fo< com< ofu< cms< def< inc< | if has('vms') | setl isk< | endif"
 
-" Set 'formatoptions' to break comment lines but not other lines,
-" and insert the comment leader when hitting <CR> or using "o".
-setlocal fo-=t fo+=croql
+" Set 'formatoptions' to break comment lines but not other lines.
+setlocal fo-=t fo+=cql
 
 " These options have the right value as default, but the user may have
 " overruled that.

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -37,9 +37,8 @@ endif
 
 let b:undo_ftplugin = "call VimFtpluginUndo()"
 
-" Set 'formatoptions' to break comment lines but not other lines,
-" and insert the comment leader when hitting <CR> or using "o".
-setlocal fo-=t fo+=croql
+" Set 'formatoptions' to break comment lines but not other lines.
+setlocal fo-=t fo+=cql
 
 " To allow tag lookup via CTRL-] for autoload functions, '#' must be a
 " keyword character.  E.g., for netrw#Nread().


### PR DESCRIPTION
I don't think these particular options should be set from a ftplugin as
I don't believe them to be relevant to the C or Vim languages. I know
it's possible to override this with the "after" directory, but I feel
like this is a more "correct" behavior by not setting these in the first
place.
