### PR TITLE
Save and Restore shortmess option when loading initial error on listdo

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3389,3 +3389,5 @@ EXTERN char e_object_member_not_found_str[]
 EXTERN char e_object_member_is_not_writable_str[]
 	INIT(= N_("E1335: Object member is not writable: %s"));
 #endif
+EXTERN char e_internal_shm_length[]
+	INIT(= N_("EXXXX: Internal error: shortmess too long"));

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -460,7 +460,6 @@ ex_listdo(exarg_T *eap)
 #if defined(FEAT_SYN_HL)
     char_u	*save_ei = NULL;
 #endif
-    char_u	*p_shm_save;
 #ifdef FEAT_QUICKFIX
     int		qf_size = 0;
     int		qf_idx;
@@ -541,7 +540,9 @@ ex_listdo(exarg_T *eap)
 		buf = NULL;
 	    else
 	    {
+		save_shm_value();
 		ex_cc(eap);
+		restore_shm_value();
 
 		buf = curbuf;
 		i = eap->line1 - 1;
@@ -566,15 +567,9 @@ ex_listdo(exarg_T *eap)
 		// reloading the file.
 		if (curwin->w_arg_idx != i || !editing_arg_idx(curwin))
 		{
-		    // Clear 'shm' to avoid that the file message overwrites
-		    // any output from the command.
-		    p_shm_save = vim_strsave(p_shm);
-		    set_option_value_give_err((char_u *)"shm",
-							  0L, (char_u *)"", 0);
+		    save_shm_value();
 		    do_argfile(eap, i);
-		    set_option_value_give_err((char_u *)"shm",
-							    0L, p_shm_save, 0);
-		    vim_free(p_shm_save);
+		    restore_shm_value();
 		}
 		if (curwin->w_arg_idx != i)
 		    break;
@@ -628,13 +623,9 @@ ex_listdo(exarg_T *eap)
 		if (buf == NULL)
 		    break;
 
-		// Go to the next buffer.  Clear 'shm' to avoid that the file
-		// message overwrites any output from the command.
-		p_shm_save = vim_strsave(p_shm);
-		set_option_value_give_err((char_u *)"shm", 0L, (char_u *)"", 0);
+		save_shm_value();
 		goto_buffer(eap, DOBUF_FIRST, FORWARD, next_fnum);
-		set_option_value_give_err((char_u *)"shm", 0L, p_shm_save, 0);
-		vim_free(p_shm_save);
+		restore_shm_value();
 
 		// If autocommands took us elsewhere, quit here.
 		if (curbuf->b_fnum != next_fnum)
@@ -650,13 +641,9 @@ ex_listdo(exarg_T *eap)
 
 		qf_idx = qf_get_cur_idx(eap);
 
-		// Clear 'shm' to avoid that the file message overwrites
-		// any output from the command.
-		p_shm_save = vim_strsave(p_shm);
-		set_option_value_give_err((char_u *)"shm", 0L, (char_u *)"", 0);
+		save_shm_value();
 		ex_cnext(eap);
-		set_option_value_give_err((char_u *)"shm", 0L, p_shm_save, 0);
-		vim_free(p_shm_save);
+		restore_shm_value();
 
 		// If jumping to the next quickfix entry fails, quit here
 		if (qf_get_cur_idx(eap) == qf_idx)

--- a/src/option.h
+++ b/src/option.h
@@ -271,6 +271,7 @@ typedef enum {
 #define SHM_SEARCHCOUNT  'S'		// search stats: '[1/10]'
 #define SHM_POSIX       "AS"		// POSIX value
 #define SHM_ALL		"rmfixlnwaWtToOsAIcCqFS" // all possible flags for 'shm'
+#define SHM_LEN		30		// max length of all flags together
 
 // characters for p_go:
 #define GO_TERMINAL	'!'		// use terminal for system commands

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -13,6 +13,8 @@
 
 #include "vim.h"
 
+static char_u shm_buf[SHM_LEN];
+
 static char *(p_ambw_values[]) = {"single", "double", NULL};
 static char *(p_bg_values[]) = {"light", "dark", NULL};
 static char *(p_bkc_values[]) = {"yes", "auto", "no", "breaksymlink", "breakhardlink", NULL};
@@ -2689,4 +2691,29 @@ opt_strings_flags(
 check_ff_value(char_u *p)
 {
     return check_opt_strings(p, p_ff_values, FALSE);
+}
+
+/* 
+ * Save the acutal shortmess Flags and clear them 
+ * temporarily to avoid that file messages
+ * overwrites any output from the following commands.
+ *
+ * Caller must make sure to first call the save_shm_value()
+ * and then the restore_shm_value()!
+ */
+    void
+save_shm_value()
+{
+    mch_memmove(shm_buf, p_shm, STRLEN(p_shm));
+    set_option_value_give_err((char_u *)"shm", 0L, (char_u *)"", 0);
+}
+
+/* 
+ * Restore the shortmess Flags set from the save_shm_value() function
+ */
+    void
+restore_shm_value()
+{
+    set_option_value_give_err((char_u *)"shm", 0L, shm_buf, 0);
+    vim_memset(shm_buf, 0, SHM_LEN);
 }

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -11,4 +11,6 @@ void set_string_option_direct_in_buf(buf_T *buf, char_u *name, int opt_idx, char
 char *set_string_option(int opt_idx, char_u *value, int opt_flags);
 char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *errbuf, int opt_flags, int *value_checked);
 int check_ff_value(char_u *p);
+void save_shm_value(void);
+void restore_shm_value(void);
 /* vim: set ft=c : */


### PR DESCRIPTION
This fixes vim/vim#11471 by making sure, that the shortmess option is also restored not only when going through the quickfix/location list, but also initially when opening the first match in the list.

while at it, also refactor the way to save and restore the shortmess option into two separate function first fix version and instead of allocating and clearing the shortmess option time several times, make use of a static buffer to temporarily store the buffer