### PR TITLE
Add win_col_off when using screenpos() on a folded line

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -1437,6 +1437,7 @@ textpos2screenpos(
 	{
 	    row += W_WINROW(wp);
 	    coloff = wp->w_wincol + 1;
+	    coloff += win_col_off(wp);
 	}
 	else
 #endif

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -150,8 +150,12 @@ func Test_screenpos_fold()
   redraw
   call assert_equal(2, screenpos(1, 2, 1).row)
   call assert_equal(#{col: 1, row: 3, endcol: 1, curscol: 1}, screenpos(1, 3, 1))
-  call assert_equal(3, screenpos(1, 4, 1).row)
-  call assert_equal(3, screenpos(1, 5, 1).row)
+  call assert_equal(#{col: 1, row: 3, endcol: 1, curscol: 1}, screenpos(1, 4, 1))
+  call assert_equal(#{col: 1, row: 3, endcol: 1, curscol: 1}, screenpos(1, 5, 1))
+  setlocal number
+  call assert_equal(#{col: 5, row: 3, endcol: 5, curscol: 5}, screenpos(1, 3, 1))
+  call assert_equal(#{col: 5, row: 3, endcol: 5, curscol: 5}, screenpos(1, 4, 1))
+  call assert_equal(#{col: 5, row: 3, endcol: 5, curscol: 5}, screenpos(1, 5, 1))
   call assert_equal(4, screenpos(1, 6, 1).row)
   bwipe!
 endfunc


### PR DESCRIPTION
This is more consistent with the behavior on non-folded lines, and more
compatible with the behavior before patch 8.2.4389 for the first folded
line.
