### PR TITLE
curwin->w_nrwidth_line_count is reset unnecessarily

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -316,9 +316,6 @@ ml_open(buf_T *buf)
 #endif
     buf->b_ml.ml_flags = ML_EMPTY;
     buf->b_ml.ml_line_count = 1;
-#ifdef FEAT_LINEBREAK
-    curwin->w_nrwidth_line_count = 0;
-#endif
 
 /*
  * fill block0 struct and write page 0


### PR DESCRIPTION
Problem:   `ml_open()` resets `curwin->w_nrwidth_line_count`, causing
           unnecessary recalculation of `curwin->w_nrwidth_width`.
           `number_width()` will catch the changed buffer length if necessary.
Solution:  Remove the `curwin->w_nrwidth_line_count` assignment.


Ref: https://github.com/neovim/neovim/pull/21493