### PR TITLE
Fix sporadic failure in Test_autocmd_user_clear_group

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2393,6 +2393,7 @@ func Test_autocmd_user_clear_group()
   call term_sendkeys(buf, ":autocmd User\<CR>")
   call TermWait(buf, 50)
   call term_sendkeys(buf, "G")
+  call TermWait(buf, 50)
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
This test would sometimes fail in the StopVimInTerminal() because the terminal state was "running", rather than "finished".  Adding a debug dump of the terminal lines to the "finished" assert showed that the child vim was `recording @a`.

This implies that part of the `\<C-o>:\<C-u>qa!\<CR>` was being eaten while the child Vim was handling scrolling the autocmd list.  Adding the TermWait() call after feeding the G eliminated the occurrences of the test failures.