### PR TITLE
Add fsh filetype detection and test

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -701,6 +701,9 @@ au BufRead,BufNewFile *.fusion			setf fusion
 " F# or Forth
 au BufNewFile,BufRead *.fs			call dist#ft#FTfs()
 
+" FHIR Shorthand (FSH)
+au BufNewFile,BufRead *.fsh			setf fsh
+
 " F#
 au BufNewFile,BufRead *.fsi,*.fsx		setf fsharp
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -202,6 +202,7 @@ let s:filename_checks = {
     \ 'fpcmake': ['file.fpc'],
     \ 'framescript': ['file.fsl'],
     \ 'freebasic': ['file.fb'],
+    \ 'fsh': ['file.fsh'],
     \ 'fsharp': ['file.fs', 'file.fsi', 'file.fsx'],
     \ 'fstab': ['fstab', 'mtab'],
     \ 'fusion': ['file.fusion'],


### PR DESCRIPTION
FHIR Shorthand (FSH) is a domain-specific language in healthcare IT for authoring artifacts related to the FHIR standard. Read more here: https://build.fhir.org/ig/HL7/fhir-shorthand/overview.html

I briefly scanned for any conflicting file types. I found [this](https://fileinfo.com/extension/fsh) (Fragment Shader File) which I have never really heard of nor does it exist in filetype detection. However, let me know if I need to name the filetype something more specific than just "fsh"