### PR TITLE
src/hashtab.c: hash_may_resize was far too convoluted, refactor

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -1299,14 +1299,14 @@ typedef struct
  */
 typedef struct hashitem_S
 {
-    long_u	hi_hash;	// cached hash number of hi_key
     char_u	*hi_key;
+    long_u	hi_hash;	// cached hash number of hi_key
 } hashitem_T;
 
 // The address of "hash_removed" is used as a magic number for hi_key to
 // indicate a removed item.
 #define HI_KEY_REMOVED &hash_removed
-#define HASHITEM_EMPTY(hi) ((hi)->hi_key == NULL || (hi)->hi_key == &hash_removed)
+#define HASHITEM_EMPTY(hi) (NULL == (hi)->hi_key || HI_KEY_REMOVED == (hi)->hi_key)
 
 // Initial size for a hashtable.  Our items are relatively small and growing
 // is expensive, thus use 16 as a start.  Must be a power of 2.
@@ -1318,6 +1318,7 @@ typedef struct hashitem_S
 				// items before growing works.
 #define HTFLAGS_FROZEN	0x02	// Trying to add or remove an item will result
 				// in an error message.
+#define HTFLAGS_LOCKED  0x04    // Set when hashtable is locked
 
 typedef struct hashtable_S
 {
@@ -1326,7 +1327,6 @@ typedef struct hashtable_S
     long_u	ht_used;	// number of items used
     long_u	ht_filled;	// number of items used + removed
     int		ht_changed;	// incremented when adding or removing an item
-    int		ht_locked;	// counter for hash_lock()
     int		ht_flags;	// HTFLAGS_ values
     hashitem_T	*ht_array;	// points to the array, allocated when it's
 				// not "ht_smallarray"


### PR DESCRIPTION
This is in effect a partial rewrite of the hashtable code, with these changes:

- The code of hash_may_resize was far too convoluted (and as a result, contained code which defeated the automatic size adaptation as an optimisation, causing the size to flip-flop and rehashing the table, with the result of much wasted CPU). I have also removed the calls to hash_may_resize at the start of hash_add_item, since it's kind of dangerous. Depending on who changes hash_may_resize, it may invalidate iterators, which is a bug waiting to happen. The new code keeps the load factor below 2/3, shrinking the table when the load factor drops below 1/5. It also rehashes when more than 1/5 elements in the table that have been removed.
- The refactoring uses tail calls where possible to save on code size.
- be bit more consistent with unsigned quantities, and their sizes (int/long/long_u)
- hash_(un)lock* can be represented by a flag (recursive locking does not happen with the current code, and if it did, the code does not do what you want anyway because it will call hash_may_resize for every call to hash_unlock); this reduces the amount of memory needed for a hash table by a tiny bit
- change order of members of hashitem_T to reflect access pattern
- computed update of ht_filled in hash_add_item
- do minimum number of comparisons in hash_do_lookup

I have tried hard to remain true to the original spirit of the code, and refactored the code to be much simpler. Much of the code has been written with reuse in mind. With this patch (and my vim config), vim starts up around 4% faster, and the hash table code becomes around 13% smaller. More specifically, according to valgrind's cachegrind tool, I get these speedups/slowdowns in the hash table code (clang 15, -O2 -ftree-vectorize -march=native, on a Intel i7-2640M CPU):

- hash_find: 1.2% slower per call (or around 2 CPU cycles), consistent with the additional tail call to hash_do_lookup
- hash_add: 89% faster per call (because of better hash_may_resize)
- hash_remove: 2.7% faster (because of better hash_may_resize)

The rest of the hash table routines stay more or less the same in terms of speed. I realise that these numbers will be different of different machines, but, overall, this translates to a big net improvement.