### PR TITLE
Emit the searched-for pattern for `:g//`

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4011,7 +4011,7 @@ ex_substitute(exarg_T *eap)
 	return;
     }
 
-    if (search_regcomp(pat, RE_SUBST, which_pat, SEARCH_HIS, &regmatch) == FAIL)
+    if (search_regcomp(pat, NULL, RE_SUBST, which_pat, SEARCH_HIS, &regmatch) == FAIL)
     {
 	if (subflags.do_error)
 	    emsg(_(e_invalid_command));
@@ -5039,6 +5039,7 @@ ex_global(exarg_T *eap)
 
     char_u	delim;		// delimiter, normally '/'
     char_u	*pat;
+    char_u	*used_pat;
     regmmatch_T	regmatch;
     int		match;
     int		which_pat;
@@ -5104,7 +5105,7 @@ ex_global(exarg_T *eap)
 	    *cmd++ = NUL;		    // replace it with a NUL
     }
 
-    if (search_regcomp(pat, RE_BOTH, which_pat, SEARCH_HIS, &regmatch) == FAIL)
+    if (search_regcomp(pat, &used_pat, RE_BOTH, which_pat, SEARCH_HIS, &regmatch) == FAIL)
     {
 	emsg(_(e_invalid_command));
 	return;
@@ -5148,16 +5149,16 @@ ex_global(exarg_T *eap)
 	    if (type == 'v')
 	    {
 		if (in_vim9script())
-		    semsg(_(e_pattern_found_in_every_line_str), pat);
+		    semsg(_(e_pattern_found_in_every_line_str), used_pat);
 		else
-		    smsg(_("Pattern found in every line: %s"), pat);
+		    smsg(_("Pattern found in every line: %s"), used_pat);
 	    }
 	    else
 	    {
 		if (in_vim9script())
-		    semsg(_(e_pattern_not_found_str), pat);
+		    semsg(_(e_pattern_not_found_str), used_pat);
 		else
-		    smsg(_("Pattern not found: %s"), pat);
+		    smsg(_("Pattern not found: %s"), used_pat);
 	    }
 	}
 	else

--- a/src/proto/search.pro
+++ b/src/proto/search.pro
@@ -1,5 +1,5 @@
 /* search.c */
-int search_regcomp(char_u *pat, int pat_save, int pat_use, int options, regmmatch_T *regmatch);
+int search_regcomp(char_u *pat, char_u **used_pat, int pat_save, int pat_use, int options, regmmatch_T *regmatch);
 char_u *get_search_pat(void);
 char_u *reverse_text(char_u *s);
 void save_re_pat(int idx, char_u *pat, int magic);

--- a/src/search.c
+++ b/src/search.c
@@ -123,6 +123,7 @@ typedef struct SearchedFile
     int
 search_regcomp(
     char_u	*pat,
+    char_u	**used_pat,
     int		pat_save,
     int		pat_use,
     int		options,
@@ -158,6 +159,9 @@ search_regcomp(
     }
     else if (options & SEARCH_HIS)	// put new pattern in history
 	add_to_history(HIST_SEARCH, pat, TRUE, NUL);
+
+    if (used_pat)
+            *used_pat = pat;
 
     vim_free(mr_pattern);
 #ifdef FEAT_RIGHTLEFT
@@ -597,7 +601,7 @@ last_pat_prog(regmmatch_T *regmatch)
 	return;
     }
     ++emsg_off;		// So it doesn't beep if bad expr
-    (void)search_regcomp((char_u *)"", 0, last_idx, SEARCH_KEEP, regmatch);
+    (void)search_regcomp((char_u *)"", NULL, 0, last_idx, SEARCH_KEEP, regmatch);
     --emsg_off;
 }
 #endif
@@ -661,7 +665,7 @@ searchit(
     int		unused_timeout_flag = FALSE;
     int		*timed_out = &unused_timeout_flag;  // set when timed out.
 
-    if (search_regcomp(pat, RE_SEARCH, pat_use,
+    if (search_regcomp(pat, NULL, RE_SEARCH, pat_use,
 		   (options & (SEARCH_HIS + SEARCH_KEEP)), &regmatch) == FAIL)
     {
 	if ((options & SEARCH_MSG) && !rc_did_emsg)
@@ -2864,7 +2868,7 @@ is_zero_width(char_u *pattern, int move, pos_T *cur, int direction)
     if (pattern == NULL)
 	pattern = spats[last_idx].pat;
 
-    if (search_regcomp(pattern, RE_SEARCH, RE_SEARCH,
+    if (search_regcomp(pattern, NULL, RE_SEARCH, RE_SEARCH,
 					      SEARCH_KEEP, &regmatch) == FAIL)
 	return -1;
 

--- a/src/testdir/test_global.vim
+++ b/src/testdir/test_global.vim
@@ -92,6 +92,18 @@ func Test_global_print()
   close!
 endfunc
 
+func Test_global_empty_pattern()
+  " populate history
+  silent g/hello/
+
+  redir @a
+  g//
+  redir END
+
+  call assert_match('Pattern not found: hello', @a)
+  "                                     ^~~~~ this was previously empty
+endfunc
+
 " Test for global command with newline character
 func Test_global_newline()
   new


### PR DESCRIPTION
Currently if we use the prior pattern (when the user gives us an empty pattern), if we emit a message about it, the pattern is referenced as "". We now retrieve the actual pattern used, to show the user.