### PR TITLE
Stop setting 'b:did_indent = 1' in indent/vue.vim

### DIFF
--- a/runtime/indent/vue.vim
+++ b/runtime/indent/vue.vim
@@ -6,7 +6,6 @@
 if exists("b:did_indent")
    finish
 endif
-let b:did_indent = 1
 
 " Html comes closest
 runtime! indent/html.vim


### PR DESCRIPTION
This guard variable was being set before indent/html.vim was loaded, preventing it from doing any actual work.

Instead, don't set `b:did_indent = 1` at all with the expectation that indent/html.vim will do so, just like we do for similar file types (such as in indent/xhtml.vim).