### PR TITLE
python3: Remove some ifdefs

### DIFF
--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -1167,14 +1167,10 @@ Python3_Init(void)
 	// Catch exit() called in Py_Initialize().
 	hook_py_exit();
 	if (setjmp(exit_hook_jump_buf) == 0)
-#endif
 	{
 	    Py_Initialize();
-#ifdef HOOK_EXIT
 	    restore_py_exit();
-#endif
 	}
-#ifdef HOOK_EXIT
 	else
 	{
 	    // exit() was called in Py_Initialize().
@@ -1182,6 +1178,8 @@ Python3_Init(void)
 	    emsg(_(e_critical_error_in_python3_initialization_check_your_installation));
 	    goto fail;
 	}
+#else
+	Py_Initialize();
 #endif
 
 #if PY_VERSION_HEX < 0x03090000


### PR DESCRIPTION
The code introduced by 8.2.4317 has too many #ifdefs, and it is hard to read.
Remove some #ifdefs.