### PR TITLE
A typo in a variable name breaks conversion with :TOhtml

### DIFF
--- a/runtime/syntax/2html.vim
+++ b/runtime/syntax/2html.vim
@@ -1881,7 +1881,7 @@ if s:settings.use_css && !s:settings.no_doc
   endif
 endif
 
-if !s:settings.use_css && !s:settings_no_doc
+if !s:settings.use_css && !s:settings.no_doc
   " For Netscape 4, set <body> attributes too, though, strictly speaking, it's
   " incorrect.
   execute '%s:<body\([^>]*\):<body bgcolor="' . s:bgc . '" text="' . s:fgc . '"\1>\r<font face="'. s:htmlfont .'"'


### PR DESCRIPTION
This patch replaces `s:settings_no_doc` -> `s:settings.no_doc`