### PR TITLE
fix lua indentation of non-lowercase "keywords"

### DIFF
--- a/runtime/indent/lua.vim
+++ b/runtime/indent/lua.vim
@@ -27,6 +27,16 @@ if exists("*GetLuaIndent")
 endif
 
 function! GetLuaIndent()
+    let ignorecase_save = &ignorecase
+  try
+    let &ignorecase = 0
+    return GetLuaIndentIntern()
+  finally
+    let &ignorecase = ignorecase_save
+  endtry
+endfunction
+
+function! GetLuaIndentIntern()
   " Find a non-blank line above the current line.
   let prevlnum = prevnonblank(v:lnum - 1)
 


### PR DESCRIPTION
The current lua indentation interprets some occurrences of "keywords" containing upper-case characters as actual keywords. (e.g. "iF").

To reproduce the issue, create a file called x.lua containing the following lines:
```lua
local t = {
iF = 1,
a = 1,
}
```

Now, if you open vim with `vim --clean --cmd 'set ignorecase' x.lua`, indenting the file (via "=G") results in the following:
```lua
local t = {
        iF = 1,
                a = 1
        }
```

After this commit, the result is the following:
```lua
local t = {
        iF = 1,
        a = 1
}
```

Note that I tried to reach out to the maintainer listed in the file, but the email bounced back.

Thanks

