### PR TITLE
Fix sporadic test failures in test_search.vim and test_usercommands.vim

### DIFF
--- a/src/testdir/term_util.vim
+++ b/src/testdir/term_util.vim
@@ -141,6 +141,9 @@ func StopVimInTerminal(buf, kill = 1)
 
   call assert_equal("running", term_getstatus(a:buf))
 
+  " Wait for all the pending updates to terminal to complete
+  call TermWait(a:buf)
+
   " CTRL-O : works both in Normal mode and Insert mode to start a command line.
   " In Command-line it's inserted, the CTRL-U removes it again.
   call term_sendkeys(a:buf, "\<C-O>:\<C-U>qa!\<cr>")

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2393,7 +2393,6 @@ func Test_autocmd_user_clear_group()
   call term_sendkeys(buf, ":autocmd User\<CR>")
   call TermWait(buf, 50)
   call term_sendkeys(buf, "G")
-  call TermWait(buf, 50)
 
   call StopVimInTerminal(buf)
 endfunc

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -375,7 +375,7 @@ func Test_searchpair_timeout_with_skip()
   else
     let ms = 1
     let min_time = 0.001
-    let max_time = min_time * 10.0
+    let max_time = min_time * 15.0
     if RunningWithValgrind()
       let max_time += 0.04  " this can be slow with valgrind
     endif


### PR DESCRIPTION
- Fix sporadic failure in Test_comclear_while_listing
- Fix slight timing issue in Test_searchpair_timeout_with_skip
