### PR TITLE
IPv6 test fixes

### DIFF
--- a/src/testdir/test_channel.py
+++ b/src/testdir/test_channel.py
@@ -259,7 +259,12 @@ def main(host, port, server_class=ThreadedTCPServer):
         print("Wait for it...")
         time.sleep(0.5)
 
-    server = server_class((host, port), ThreadedTCPRequestHandler)
+    addrs = socket.getaddrinfo(host, port, 0, 0, socket.IPPROTO_TCP)
+    # Each addr is a (family, type, proto, canonname, sockaddr) tuple
+    sockaddr = addrs[0][4]
+    server_class.address_family = addrs[0][0]
+
+    server = server_class(sockaddr[0:2], ThreadedTCPRequestHandler)
     ip, port = server.server_address[0:2]
 
     # Start a thread with the server.  That thread will then start a new thread

--- a/src/testdir/test_channel_lsp.py
+++ b/src/testdir/test_channel_lsp.py
@@ -306,7 +306,12 @@ def main(host, port, server_class=ThreadedTCPServer):
         writePortInFile(port)
         time.sleep(0.5)
 
-    server = server_class((host, port), ThreadedTCPRequestHandler)
+    addrs = socket.getaddrinfo(host, port, 0, 0, socket.IPPROTO_TCP)
+    # Each addr is a (family, type, proto, canonname, sockaddr) tuple
+    sockaddr = addrs[0][4]
+    server_class.address_family = addrs[0][0]
+
+    server = server_class(sockaddr[0:2], ThreadedTCPRequestHandler)
     ip, port = server.server_address[0:2]
 
     # Start a thread with the server.  That thread will then start a new thread

--- a/src/testdir/test_netbeans.py
+++ b/src/testdir/test_netbeans.py
@@ -184,8 +184,13 @@ def writePortInFile(port):
 if __name__ == "__main__":
     HOST, PORT = "localhost", 0
 
-    server = ThreadedTCPServer((HOST, PORT), ThreadedTCPRequestHandler)
-    ip, port = server.server_address
+    addrs = socket.getaddrinfo(HOST, PORT, 0, 0, socket.IPPROTO_TCP)
+    # Each addr is a (family, type, proto, canonname, sockaddr) tuple
+    sockaddr = addrs[0][4]
+    ThreadedTCPServer.address_family = addrs[0][0]
+
+    server = ThreadedTCPServer(sockaddr[0:2], ThreadedTCPRequestHandler)
+    ip, port = server.server_address[0:2]
 
     # Start a thread with the server.  That thread will then start a new thread
     # for each connection.
@@ -199,7 +204,7 @@ if __name__ == "__main__":
     # Main thread terminates, but the server continues running
     # until server.shutdown() is called.
     try:
-        while server_thread.isAlive(): 
+        while server_thread.is_alive():
             server_thread.join(1)
     except (KeyboardInterrupt, SystemExit):
         server.shutdown()

--- a/src/testdir/test_netbeans.vim
+++ b/src/testdir/test_netbeans.vim
@@ -887,28 +887,32 @@ func Nb_quit_with_conn(port)
       return filter(l, 'v:val !~ "^0:geometry="')
     endfunc
 
-    " Establish the connection with the netbeans server
-    exe 'nbstart :localhost:' .. g:port .. ':star'
-    call assert_true(has("netbeans_enabled"))
-    call WaitFor('len(ReadXnetbeans()) >= 3')
-    let l = ReadXnetbeans()
-    call assert_equal(['AUTH star',
-      \ '0:version=0 "2.5"',
-      \ '0:startupDone=0'], l[-3:])
+    try
+      " Establish the connection with the netbeans server
+      exe 'nbstart :localhost:' .. g:port .. ':star'
+      call assert_true(has("netbeans_enabled"))
+      call WaitFor('len(ReadXnetbeans()) >= 3')
+      let l = ReadXnetbeans()
+      call assert_equal(['AUTH star',
+        \ '0:version=0 "2.5"',
+        \ '0:startupDone=0'], l[-3:])
 
-    " Open the command buffer to communicate with the server
-    split Xcmdbuf
-    call WaitFor('len(ReadXnetbeans()) >= 6')
-    let l = ReadXnetbeans()
-    call assert_equal('0:fileOpened=0 "Xcmdbuf" T F',
-          \ substitute(l[-3], '".*/', '"', ''))
-    call assert_equal('send: 1:putBufferNumber!15 "Xcmdbuf"',
-          \ substitute(l[-2], '".*/', '"', ''))
-    call assert_equal('1:startDocumentListen!16', l[-1])
-    sleep 1m
+      " Open the command buffer to communicate with the server
+      split Xcmdbuf
+      call WaitFor('len(ReadXnetbeans()) >= 6')
+      let l = ReadXnetbeans()
+      call assert_equal('0:fileOpened=0 "Xcmdbuf" T F',
+            \ substitute(l[-3], '".*/', '"', ''))
+      call assert_equal('send: 1:putBufferNumber!15 "Xcmdbuf"',
+            \ substitute(l[-2], '".*/', '"', ''))
+      call assert_equal('1:startDocumentListen!16', l[-1])
+      sleep 1m
 
-    quit!
-    quit!
+      quit!
+      quit!
+    finally
+      qall!
+    endtry
   END
   if RunVim(['let g:port = ' .. a:port], after, '')
     call WaitFor('len(ReadXnetbeans()) >= 9')


### PR DESCRIPTION
- Use getaddrinfo() to find localhost address/family for tests
- Use try/finally in Test_nb_quit_with_conn to avoid hit-enter prompt on a failure
