### PR TITLE
redraw after setcellwidth

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5742,6 +5742,8 @@ f_setcellwidths(typval_T *argvars, typval_T *rettv UNUSED)
     }
 
     vim_free(cw_table_save);
+
+    redraw_all_later(UPD_CLEAR);
 }
 
     void


### PR DESCRIPTION
```vim
autocmd BufReadCmd hoge.txt call setline(1, "\ue5ffDesktop")
function! s:main() abort
        call setcellwidths([[0xe5ff, 0xe5ff, 2]])
        new hoge.txt
endfunction

call s:main()
```

![image](https://user-images.githubusercontent.com/10111/211579268-1e202e91-6e4d-4b76-b418-656e9493eefa.png)

with this patch.
![image](https://user-images.githubusercontent.com/10111/211579389-ffeb5190-ca6f-476d-8d54-875abdc6465b.png)
