### PR TITLE
feat: add detection for Smithy files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1928,6 +1928,9 @@ au BufNewFile,BufRead *.smi
 " SMITH
 au BufNewFile,BufRead *.smt,*.smith		setf smith
 
+" Smithy
+au BufNewFile,BufRead *.smithy setf smithy
+
 " Snobol4 and spitbol
 au BufNewFile,BufRead *.sno,*.spt		setf snobol4
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -528,6 +528,7 @@ let s:filename_checks = {
     \ 'smarty': ['file.tpl'],
     \ 'smcl': ['file.hlp', 'file.ihlp', 'file.smcl'],
     \ 'smith': ['file.smt', 'file.smith'],
+    \ 'smithy': ['file.smithy'],
     \ 'sml': ['file.sml'],
     \ 'snobol4': ['file.sno', 'file.spt'],
     \ 'solidity': ['file.sol'],


### PR DESCRIPTION
Smithy is an idl language used pretty heavily in certain companies like
AWS and beyond. You can read more about it in
https://smithy.io/2.0/index.html. This small change just adds detection
for them.
