### PR TITLE
Remove optimization of mark updating to fix fold bug

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -772,14 +772,7 @@ appended_lines(linenr_T lnum, long count)
     void
 appended_lines_mark(linenr_T lnum, long count)
 {
-    // Skip mark_adjust when adding a line after the last one, there can't
-    // be marks there. But it's still needed in diff mode.
-    if (lnum + count < curbuf->b_ml.ml_line_count
-#ifdef FEAT_DIFF
-	    || curwin->w_p_diff
-#endif
-	)
-	mark_adjust(lnum + 1, (linenr_T)MAXLNUM, count, 0L);
+    mark_adjust(lnum + 1, (linenr_T)MAXLNUM, count, 0L);
     changed_lines(lnum + 1, 0, lnum + 1, count);
 }
 
@@ -2142,14 +2135,7 @@ open_line(
 	    goto theend;
 	// Postpone calling changed_lines(), because it would mess up folding
 	// with markers.
-	// Skip mark_adjust when adding a line after the last one, there can't
-	// be marks there. But still needed in diff mode.
-	if (curwin->w_cursor.lnum + 1 < curbuf->b_ml.ml_line_count
-#ifdef FEAT_DIFF
-		|| curwin->w_p_diff
-#endif
-	    )
-	    mark_adjust(curwin->w_cursor.lnum + 1, (linenr_T)MAXLNUM, 1L, 0L);
+	mark_adjust(curwin->w_cursor.lnum + 1, (linenr_T)MAXLNUM, 1L, 0L);
 	did_append = TRUE;
 #ifdef FEAT_PROP_POPUP
 	if ((State & MODE_INSERT) && (State & VREPLACE_FLAG) == 0)

--- a/src/register.c
+++ b/src/register.c
@@ -2208,15 +2208,7 @@ error:
 		if (dir == FORWARD)
 		    curbuf->b_op_start.lnum++;
 	    }
-	    // Skip mark_adjust when adding lines after the last one, there
-	    // can't be marks there. But still needed in diff mode.
-	    if (curbuf->b_op_start.lnum + (y_type == MCHAR) - 1 + nr_lines
-						 < curbuf->b_ml.ml_line_count
-#ifdef FEAT_DIFF
-						 || curwin->w_p_diff
-#endif
-						 )
-		mark_adjust(curbuf->b_op_start.lnum + (y_type == MCHAR),
+	    mark_adjust(curbuf->b_op_start.lnum + (y_type == MCHAR),
 					     (linenr_T)MAXLNUM, nr_lines, 0L);
 
 	    // note changed text for displaying and folding

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1683,4 +1683,16 @@ func Test_indent_with_L_command()
   bwipe!
 endfunc
 
+" Make sure that when you have a fold at the bottom of the buffer and you append
+" a newline character to the line, the fold gets expanded (instead of the new
+" line not being part of the fold)
+func Test_expand_fold_at_bottom_of_buffer()
+  new
+  " create a fold on the only line
+  fold
+  execute "normal A\<CR>"
+  call assert_equal([1, 1], range(1, 2)->map('foldlevel(v:val)'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This fixes #10698. The bug can be described more accurately like so: Doing "A<CR>" on [a line that is at the end of the buffer and that is within a fold] does not expand the fold as it would if the line was not at the end of the buffer.

The bug was a regression caused by patch [7.4.1896](https://github.com/vim/vim/commit/82faa259cc42379f2a17d598a2a39d14048685b0). I assume that this patch was for speed optimization, but there doesn't seem to be any reasoning provided, so it would take some work to determine how much of a difference the optimization made and in what cases.

This patch also caused another bug fixed by patch [8.0.0421](https://github.com/vim/vim/commit/f58a8475e17bd566760fc7e2a17d35ddf4edacf2). In that patch, the optimization logic was kept and made more complicated by adding another condition.

My solution is to simply revert the buggy optimization logic instead of adding yet another condition to it. In theory this can make the program slower in certain cases, and I haven't done any speed testing, so that should probably be considered.