### PR TITLE
Accept 0x80-0xFF for setcellwidths()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7958,7 +7958,7 @@ setcellwidths({list})					*setcellwidths()*
 		{low} and {high} can be the same, in which case this refers to
 		one character.  Otherwise it is the range of characters from
 		{low} to {high} (inclusive).		*E1111* *E1114*
-		Only characters with value 0x100 and higher can be used.
+		Only characters with value 0x80 and higher can be used.
 
 		{width} must be either 1 or 2, indicating the character width
 		in screen cells.			*E1112*

--- a/src/errors.h
+++ b/src/errors.h
@@ -2841,8 +2841,8 @@ EXTERN char e_list_item_nr_cell_width_invalid[]
 	INIT(= N_("E1112: List item %d cell width invalid"));
 EXTERN char e_overlapping_ranges_for_nr[]
 	INIT(= N_("E1113: Overlapping ranges for 0x%lx"));
-EXTERN char e_only_values_of_0x100_and_higher_supported[]
-	INIT(= N_("E1114: Only values of 0x100 and higher supported"));
+EXTERN char e_only_values_of_0x80_and_higher_supported[]
+	INIT(= N_("E1114: Only values of 0x80 and higher supported"));
 EXTERN char e_assert_fails_fourth_argument[]
 	INIT(= N_("E1115: \"assert_fails()\" fourth argument must be a number"));
 EXTERN char e_assert_fails_fifth_argument[]

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -1590,7 +1590,13 @@ utf_char2cells(int c)
     };
 
 #ifdef FEAT_EVAL
-    if (c >= 0x80)
+    if (c >= 0x80 &&
+# ifdef USE_WCHAR_FUNCTIONS
+	    wcwidth(c) >= 1
+# else
+	    vim_isprintc(c)
+# endif
+	    )
     {
 	int n = cw_value(c);
 	if (n != 0)

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -1589,19 +1589,20 @@ utf_char2cells(int c)
 #endif
     };
 
-    if (c >= 0x100)
-    {
-#if defined(FEAT_EVAL) || defined(USE_WCHAR_FUNCTIONS)
-	int	n;
-#endif
-
 #ifdef FEAT_EVAL
-	n = cw_value(c);
+    if (c >= 0x80)
+    {
+	int n = cw_value(c);
 	if (n != 0)
 	    return n;
+    }
 #endif
 
+    if (c >= 0x100)
+    {
 #ifdef USE_WCHAR_FUNCTIONS
+	int	n;
+
 	/*
 	 * Assume the library function wcwidth() works better than our own
 	 * stuff.  It should return 1 for ambiguous width chars!
@@ -5661,9 +5662,9 @@ f_setcellwidths(typval_T *argvars, typval_T *rettv UNUSED)
 	    if (i == 0)
 	    {
 		n1 = lili->li_tv.vval.v_number;
-		if (n1 < 0x100)
+		if (n1 < 0x80)
 		{
-		    emsg(_(e_only_values_of_0x100_and_higher_supported));
+		    emsg(_(e_only_values_of_0x80_and_higher_supported));
 		    vim_free(ptrs);
 		    return;
 		}

--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -7729,8 +7729,8 @@ msgstr "E1112: L'element de la llista %d no té una amplada vàlida"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Intervals solapats per a 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Només es suporten valors de 0x100 o superiors"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Només es suporten valors de 0x80 o superiors"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: el quart argument a \"assert_fails()\" ha de ser un número"

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -7836,8 +7836,8 @@ msgstr "E1112: Listenwert %d Zellbreite ungültig"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Überlappender Bereich für 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Nur Werte oberhalb 0x100 unterstützt"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Nur Werte oberhalb 0x80 unterstützt"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: \"assert_fails()\" viertes Argument muss eine Zahl sein"

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -7346,8 +7346,8 @@ msgstr "E1110: Listero %d ne enhavas 3 nombojn"
 msgid "E1111: List item %d range invalid"
 msgstr "E1111: Listero %d havas nevalidan amplekson"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Nur valoroj 0x100 kaj pli altaj estas subtenataj"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Nur valoroj 0x80 kaj pli altaj estas subtenataj"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: la 4-a argumento de \"assert_fails()\" devas esti nombro"

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -7809,8 +7809,8 @@ msgstr "E1112: Elemento %d de lista, ancho de celda no válido"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Rangos superpuestos para 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Solo se admiten valores de 0x100 y superiores"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Solo se admiten valores de 0x80 y superiores"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: El cuarto argumento \"assert_fails()\" debe ser un número"

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -7759,8 +7759,8 @@ msgstr "E1112: Listan kohdan %d soluleveys on viallinen"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Päällekkäiset arvoalueet osoitteessa 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Vain arvot 0x100:sta eteenpäin kelpaavat"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Vain arvot 0x80:sta eteenpäin kelpaavat"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: assert_fails()-funktion neljännen argumentin tulee olla numero"

--- a/src/po/ga.po
+++ b/src/po/ga.po
@@ -7768,8 +7768,8 @@ msgstr "E1112: Leithead cille neamhbhailí i mír %d sa liosta"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Raonta forluiteacha ar 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Ní thacaítear ach le luachanna 0x100 agus níos airde"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Ní thacaítear ach le luachanna 0x80 agus níos airde"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: Ní mór don cheathrú hargóint ar \"assert_fails()\" a bheith ina huimhir"

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -6995,8 +6995,8 @@ msgstr "E1112: Elemento di Lista %d con larghezza di cella non valida"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Intervalli sovrapposti per 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Solo valori 0x100 o più elevati sono supportati"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Solo valori 0x80 o più elevati sono supportati"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: Il quarto argomento di \"assert_fails()\" dev'essere un Numero"

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -7702,8 +7702,8 @@ msgstr "E1112: リストの要素 %d のセル幅が不正です"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: 0x%lx の範囲が重複しています"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: 0x100 以上の値しかサポートされていません"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: 0x80 以上の値しかサポートされていません"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: \"assert_fails()\" の第4引数は数字でなければなりません"

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -7702,8 +7702,8 @@ msgstr "E1112: リストの要素 %d のセル幅が不正です"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: 0x%lx の範囲が重複しています"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: 0x100 以上の値しかサポートされていません"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: 0x80 以上の値しかサポートされていません"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: \"assert_fails()\" の第4引数は数字でなければなりません"

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -7702,8 +7702,8 @@ msgstr "E1112: リストの要素 %d のセル幅が不正です"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: 0x%lx の範囲が重複しています"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: 0x100 以上の値しかサポートされていません"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: 0x80 以上の値しかサポートされていません"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: \"assert_fails()\" の第4引数は数字でなければなりません"

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -7696,8 +7696,8 @@ msgstr "E1112: Элемент %d в списке задаёт неправильную ширину ячейки"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Перекрывающиеся диапазоны для 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Поддерживаются только значения от 0x100 и выше"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Поддерживаются только значения от 0x80 и выше"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr ""

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -7696,8 +7696,8 @@ msgstr "E1112: Элемент %d в списке задаёт неправиль
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Перекрывающиеся диапазоны для 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Поддерживаются только значения от 0x100 и выше"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Поддерживаются только значения от 0x80 и выше"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr ""

--- a/src/po/sr.po
+++ b/src/po/sr.po
@@ -7635,8 +7635,8 @@ msgstr "E1112: Ширина ћелије ставке листе %d је нев�
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Опсези за 0x%lx се преклапају"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Подржавају се само вредности од 0x100 и веће"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Подржавају се само вредности од 0x80 и веће"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: „assert_fails()” четврти аргумент мора бити број"

--- a/src/po/tr.po
+++ b/src/po/tr.po
@@ -7562,8 +7562,8 @@ msgstr "E1112: Liste ögesi %d hücre genişliği geçersiz"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: 0x%lx için üst üste binen erimler"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Yalnızca 0x100 ve daha yüksek değerler destekleniyor"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Yalnızca 0x80 ve daha yüksek değerler destekleniyor"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: \"assert_fails()\" dördüncü argüman bir sayı olmalıdır"

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -7869,8 +7869,8 @@ msgstr "E1112: Ширина комірки елементу %d списку некоректна"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Перекриття діапазонів у 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Підтримуються тільки значення 0x100 і вищі"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Підтримуються тільки значення 0x80 і вищі"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: Четвертий аргумент «assert_fails()» має бути числом"

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -7869,8 +7869,8 @@ msgstr "E1112: Ширина комірки елементу %d списку не
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: Перекриття діапазонів у 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: Підтримуються тільки значення 0x100 і вищі"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: Підтримуються тільки значення 0x80 і вищі"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: Четвертий аргумент «assert_fails()» має бути числом"

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -7511,8 +7511,8 @@ msgstr "E1112: 列表项 %d 单元格宽度无效"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: 重叠范围为 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: 只支持 0x100 或更高的值"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: 只支持 0x80 或更高的值"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: \"assert_fails()\" 第四个参数必须是一个整数"

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -7511,8 +7511,8 @@ msgstr "E1112: 列表项 %d 单元格宽度无效"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: 重叠范围为 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: 只支持 0x100 或更高的值"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: 只支持 0x80 或更高的值"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: \"assert_fails()\" 第四个参数必须是一个整数"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -7511,8 +7511,8 @@ msgstr "E1112: 列表项 %d 单元格宽度无效"
 msgid "E1113: Overlapping ranges for 0x%lx"
 msgstr "E1113: 重叠范围为 0x%lx"
 
-msgid "E1114: Only values of 0x100 and higher supported"
-msgstr "E1114: 只支持 0x100 或更高的值"
+msgid "E1114: Only values of 0x80 and higher supported"
+msgstr "E1114: 只支持 0x80 或更高的值"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: \"assert_fails()\" 第四个参数必须是一个整数"

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -172,6 +172,7 @@ func Test_setcellwidths()
     " Handle \u0080 to \u009F as control chars even on MS-Windows.
     set isprint=@,161-255
 
+    call setcellwidths([])
     " Control chars
     call assert_equal(4, strwidth("\u0081"))
     call assert_equal(6, strwidth("\uFEFF"))
@@ -179,7 +180,8 @@ func Test_setcellwidths()
     call assert_equal((aw == 'single') ? 1 : 2, strwidth("\u00A1"))
     call assert_equal((aw == 'single') ? 1 : 2, strwidth("\u2010"))
 
-    call setcellwidths([[0xA1, 0xA1, 1], [0x2010, 0x2010, 1]])
+    call setcellwidths([[0x81, 0x81, 1], [0xA1, 0xA1, 1],
+                      \ [0x2010, 0x2010, 1], [0xFEFF, 0xFEFF, 1]])
     " Control chars
     call assert_equal(4, strwidth("\u0081"))
     call assert_equal(6, strwidth("\uFEFF"))
@@ -187,7 +189,8 @@ func Test_setcellwidths()
     call assert_equal(1, strwidth("\u00A1"))
     call assert_equal(1, strwidth("\u2010"))
 
-    call setcellwidths([[0xA1, 0xA1, 2], [0x2010, 0x2010, 2]])
+    call setcellwidths([[0x81, 0x81, 2], [0xA1, 0xA1, 2],
+                      \ [0x2010, 0x2010, 2], [0xFEFF, 0xFEFF, 2]])
     " Control chars
     call assert_equal(4, strwidth("\u0081"))
     call assert_equal(6, strwidth("\uFEFF"))

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -156,6 +156,7 @@ endfunc
 
 func Test_setcellwidths()
   call setcellwidths([
+        \ [0xA1, 0xA1, 2],
         \ [0x1330, 0x1330, 2],
         \ [9999, 10000, 1],
         \ [0x1337, 0x1339, 2],

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -156,7 +156,6 @@ endfunc
 
 func Test_setcellwidths()
   call setcellwidths([
-        \ [0xA1, 0xA1, 2],
         \ [0x1330, 0x1330, 2],
         \ [9999, 10000, 1],
         \ [0x1337, 0x1339, 2],
@@ -167,6 +166,36 @@ func Test_setcellwidths()
   call assert_equal(2, strwidth("\u1337"))
   call assert_equal(2, strwidth("\u1339"))
   call assert_equal(1, strwidth("\u133a"))
+
+  for aw in ['single', 'double']
+    exe 'set ambiwidth=' . aw
+    " Handle \u0080 to \u009F as control chars even on MS-Windows.
+    set isprint=@,161-255
+
+    " Control chars
+    call assert_equal(4, strwidth("\u0081"))
+    call assert_equal(6, strwidth("\uFEFF"))
+    " Ambiguous width chars
+    call assert_equal((aw == 'single') ? 1 : 2, strwidth("\u00A1"))
+    call assert_equal((aw == 'single') ? 1 : 2, strwidth("\u2010"))
+
+    call setcellwidths([[0xA1, 0xA1, 1], [0x2010, 0x2010, 1]])
+    " Control chars
+    call assert_equal(4, strwidth("\u0081"))
+    call assert_equal(6, strwidth("\uFEFF"))
+    " Ambiguous width chars
+    call assert_equal(1, strwidth("\u00A1"))
+    call assert_equal(1, strwidth("\u2010"))
+
+    call setcellwidths([[0xA1, 0xA1, 2], [0x2010, 0x2010, 2]])
+    " Control chars
+    call assert_equal(4, strwidth("\u0081"))
+    call assert_equal(6, strwidth("\uFEFF"))
+    " Ambiguous width chars
+    call assert_equal(2, strwidth("\u00A1"))
+    call assert_equal(2, strwidth("\u2010"))
+  endfor
+  set ambiwidth& isprint&
 
   call setcellwidths([])
 


### PR DESCRIPTION
Currently, setcellwidths() accepts only characters with value 0x100 or higher. However, there are many ambiguous width characters between 0xA1 to 0xFE.

See: https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt

This makes setcellwidths() to accept characters between 0x80 to 0xFF.