### PR TITLE
Add getcellwidths() function

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3265,9 +3265,9 @@ getbufvar({buf}, {varname} [, {def}])				*getbufvar()*
 			GetBufnr()->getbufvar(varname)
 <
 getcellwidths()						*getcellwidths()*
-		Returns list for cell widths of character ranges which
-		overrides by |setcellwidths()|. If cell widths of character
-		ranges doesn't exist, an empty list is returned.
+		Returns a |List| of cell widths of character ranges overridden
+		by |setcellwidths()|.  If no character ranges have their cell
+		widths overridden, an empty List is returned.
 
 getchangelist([{buf}])					*getchangelist()*
 		Returns the |changelist| for the buffer {buf}. For the use

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -211,6 +211,8 @@ getbufline({buf}, {lnum} [, {end}])
 getbufoneline({buf}, {lnum})	String	line {lnum} of buffer {buf}
 getbufvar({buf}, {varname} [, {def}])
 				any	variable {varname} in buffer {buf}
+getcellwidths()			List	list of character cell width overrides
+					list items
 getchangelist([{buf}])		List	list of change list items
 getchar([expr])			Number or String
 					get one character from the user
@@ -3262,6 +3264,11 @@ getbufvar({buf}, {varname} [, {def}])				*getbufvar()*
 <		Can also be used as a |method|: >
 			GetBufnr()->getbufvar(varname)
 <
+getcellwidths()						*getcellwidths()*
+		Returns list for cell widths of character ranges which
+		overrides by |setcellwidths()|. If cell widths of character
+		ranges doesn't exist, an empty list is returned.
+
 getchangelist([{buf}])					*getchangelist()*
 		Returns the |changelist| for the buffer {buf}. For the use
 		of {buf}, see |bufname()| above. If buffer {buf} doesn't

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -775,6 +775,7 @@ String manipulation:					*string-functions*
 	execute()		execute an Ex command and get the output
 	win_execute()		like execute() but in a specified window
 	trim()			trim characters from a string
+	getcellwidths()		get character cell width overrides
 	gettext()		lookup message translation
 
 List manipulation:					*list-functions*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1928,6 +1928,8 @@ static funcentry_T global_functions[] =
 			ret_string,	    f_getbufoneline},
     {"getbufvar",	2, 3, FEARG_1,	    arg3_buffer_string_any,
 			ret_any,	    f_getbufvar},
+    {"getcellwidths",	0, 0, 0,	    NULL,
+			ret_list_any,	    f_getcellwidths},
     {"getchangelist",	0, 1, FEARG_1,	    arg1_buffer,
 			ret_list_any,	    f_getchangelist},
     {"getchar",		0, 1, 0,	    arg1_bool,

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5746,6 +5746,25 @@ f_setcellwidths(typval_T *argvars, typval_T *rettv UNUSED)
 }
 
     void
+f_getcellwidths(typval_T *argvars UNUSED, typval_T *rettv)
+{
+    size_t i;
+    list_T *entry;
+
+    if (rettv_list_alloc(rettv) == FAIL)
+	return;
+
+    for (i = 0; i < cw_table_size; i++) {
+	entry = list_alloc();
+	list_append_number(entry, (varnumber_T)cw_table[i].first);
+	list_append_number(entry, (varnumber_T)cw_table[i].last);
+	list_append_number(entry, (varnumber_T)cw_table[i].width);
+
+	list_append_list(rettv->vval.v_list, entry);
+    }
+}
+
+    void
 f_charclass(typval_T *argvars, typval_T *rettv UNUSED)
 {
     if (check_for_string_arg(argvars, 0) == FAIL

--- a/src/proto/mbyte.pro
+++ b/src/proto/mbyte.pro
@@ -86,5 +86,6 @@ int convert_input_safe(char_u *ptr, int len, int maxlen, char_u **restp, int *re
 char_u *string_convert(vimconv_T *vcp, char_u *ptr, int *lenp);
 char_u *string_convert_ext(vimconv_T *vcp, char_u *ptr, int *lenp, int *unconvlenp);
 void f_setcellwidths(typval_T *argvars, typval_T *rettv);
+void f_getcellwidths(typval_T *argvars, typval_T *rettv);
 void f_charclass(typval_T *argvars, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -199,6 +199,26 @@ func Test_setcellwidths()
   call setcellwidths([])
 endfunc
 
+func Test_getcellwidths()
+  call setcellwidths([])
+  call assert_equal([], getcellwidths())
+
+  let widthlist = [
+        \ [0x1330, 0x1330, 2],
+        \ [9999, 10000, 1],
+        \ [0x1337, 0x1339, 2],
+        \]
+  let widthlistsorted = [
+        \ [0x1330, 0x1330, 2],
+        \ [0x1337, 0x1339, 2],
+        \ [9999, 10000, 1],
+        \]
+  call setcellwidths(widthlist)
+  call assert_equal(widthlistsorted, getcellwidths())
+
+  call setcellwidths([])
+endfunc
+
 func Test_setcellwidths_dump()
   CheckRunVimInTerminal
 


### PR DESCRIPTION
# [Proposal] Add `getcellwidths()`

Add getcellwidths() function.
This allows the user to retrieve the cell widths of character ranges set by setcellwidths().
The function sort and return the values.

## Reason

### Symmetry of the function
Previously, it was not possible to retrieve the value set by `setcellwidths()`. The current situation is a bit unnatural since other functions have functions to retrieve settings.

### Add values to the table
Since `setcellwidths()` initializes the value of `cw_table`, it is not possible to set cell widths in multiple places.
`getcellwidths()` allows you to add entries in the following way...

```vim
call setcellwidths([[0x2729, 0x272f, 2], [0x2730, 0x273f, 2], [0x2740, 0x274d, 2]])
echo getcellwidths() " [[10025, 10031, 2], [10032, 10047, 2], [10048, 10061, 2]]

call setcellwidths(getcellwidths() + [[0x274f, 0x274f, 2]])
echo getcellwidths() " [[10025, 10031, 2], [10032, 10047, 2], [10048, 10061, 2], [10063, 10063, 2]]
```

### Easier debugging
Because `setcellwidths()` initializes the value of `cw_table`, if the function is called in multiple places by mistake, only the last setting will be reflected. Knowing the current settings is helpful for debugging.

## Supplement
- The help file may need to be rewritten (I'm not familiar with writing help file)
- It will need to be added the function name to `runtime/syntax/vim.vim`

Thank you.