### PR TITLE
 don't show function in completion candidates, if f_func was set to NULL,

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2872,7 +2872,7 @@ get_function_name(expand_T *xp, int idx)
     }
     if (++intidx < (int)ARRAY_LENGTH(global_functions))
     {
-	// skip if function does'nt have implementation
+	// Skip if function doesn't have implementation.
 	if (global_functions[intidx].f_func == NULL)
 	    return (char_u *)"";
 	STRCPY(IObuff, global_functions[intidx].f_name);

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2872,6 +2872,9 @@ get_function_name(expand_T *xp, int idx)
     }
     if (++intidx < (int)ARRAY_LENGTH(global_functions))
     {
+	// skip if function does'nt have implementation
+	if (global_functions[intidx].f_func == NULL)
+	    return (char_u *)"";
 	STRCPY(IObuff, global_functions[intidx].f_name);
 	STRCAT(IObuff, "(");
 	if (global_functions[intidx].f_max_argc == 0)

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -488,6 +488,11 @@ func Test_getcompletion()
   call assert_true(index(l, 'taglist(') >= 0)
   let l = getcompletion('paint', 'function')
   call assert_equal([], l)
+  if !has('ruby')
+    " global_functions has entry but it doesn't have implement
+    let l = getcompletion('ruby', 'function')
+    call assert_equal([], l)
+  endif
 
   let Flambda = {-> 'hello'}
   let l = getcompletion('', 'function')


### PR DESCRIPTION
Modified to not display functions that may not exist depending on the function, such as `if_ruby`'s `rubyeval()` function, in the completion candidates.

Example
```vim
:echo getcompletion("rubye", "function") " ['rubyeval(']
:call rubyeval() " E117: Unknown function
```