### PR TITLE
Remove hjson filetype detection

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -861,9 +861,6 @@ au BufRead,BufNewFile *.heex			setf heex
 " HEX (Intel)
 au BufNewFile,BufRead *.hex,*.h32		setf hex
 
-" Hjson
-au BufNewFile,BufRead *.hjson			setf hjson
-
 " HLS Playlist (or another form of playlist)
 au BufNewFile,BufRead *.m3u,*.m3u8		setf hlsplaylist
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -257,7 +257,6 @@ let s:filename_checks = {
     \ 'hercules': ['file.vc', 'file.ev', 'file.sum', 'file.errsum'],
     \ 'hex': ['file.hex', 'file.h32'],
     \ 'hgcommit': ['hg-editor-file.txt'],
-    \ 'hjson': ['file.hjson'],
     \ 'hlsplaylist': ['file.m3u', 'file.m3u8'],
     \ 'hog': ['file.hog', 'snort.conf', 'vision.conf'],
     \ 'hollywood': ['file.hws'],


### PR DESCRIPTION
This isn't worth having in the base install for a couple of reasons:

1. This filetype doesn't have an associated syntax file; the only way to get syntax rules is via external plugin.
2. The official plugin, https://github.com/hjson/vim-hjson, comes with [its own `ftdetect/hjson.vim`](https://github.com/hjson/vim-hjson/blob/master/ftdetect/hjson.vim), so having this in vanilla Vim isn't even necessary to support the plugin.