### PR TITLE
Cap'n Proto files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -277,6 +277,9 @@ au BufNewFile,BufRead *.lpc,*.ulpc		setf lpc
 " Calendar
 au BufNewFile,BufRead calendar			setf calendar
 
+" Cap'n Proto
+au BufNewFile,BufRead *.capnp			setf capnp
+
 " C#
 au BufNewFile,BufRead *.cs,*.csx		setf cs
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -96,6 +96,7 @@ let s:filename_checks = {
     \ 'cabalconfig': ['cabal.config'],
     \ 'cabalproject': ['cabal.project', 'cabal.project.local'],
     \ 'calendar': ['calendar', '/.calendar/file', '/share/calendar/any/calendar.file', '/share/calendar/calendar.file', 'any/share/calendar/any/calendar.file', 'any/share/calendar/calendar.file'],
+    \ 'capnp': ['file.capnp'],
     \ 'catalog': ['catalog', 'sgml.catalogfile', 'sgml.catalog', 'sgml.catalog-file'],
     \ 'cdl': ['file.cdl'],
     \ 'cdrdaoconf': ['/etc/cdrdao.conf', '/etc/defaults/cdrdao', '/etc/default/cdrdao', '.cdrdao', 'any/etc/cdrdao.conf', 'any/etc/default/cdrdao', 'any/etc/defaults/cdrdao'],


### PR DESCRIPTION
https://capnproto.org/

Problem: Cap'n Proto files are not recognized.
Solution: Add the name of Cap'n Proto files. (Amaan Qureshi)