### PR TITLE
ms-win flush termguicolors color for visual bell

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -6778,15 +6778,25 @@ visual_bell(void)
     DWORD   dwDummy;
     LPWORD  oldattrs = ALLOC_MULT(WORD, Rows * Columns);
 
-    if (oldattrs == NULL)
-	return;
-    ReadConsoleOutputAttribute(g_hConOut, oldattrs, Rows * Columns,
+# ifdef FEAT_TERMGUICOLORS
+    if (!(p_tgc || (!p_tgc && t_colors >= 256)))
+# endif
+    {
+	if (oldattrs == NULL)
+	    return;
+
+	ReadConsoleOutputAttribute(g_hConOut, oldattrs, Rows * Columns,
 			       coordOrigin, &dwDummy);
+    }
+
     FillConsoleOutputAttribute(g_hConOut, attrFlash, Rows * Columns,
 			       coordOrigin, &dwDummy);
 
     Sleep(15);	    // wait for 15 msec
-    if (!vtp_working)
+
+# ifdef FEAT_TERMGUICOLORS
+    if (!(p_tgc || (!p_tgc && t_colors >= 256)))
+# endif
 	WriteConsoleOutputAttribute(g_hConOut, oldattrs, Rows * Columns,
 				coordOrigin, &dwDummy);
     vim_free(oldattrs);

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -6779,7 +6779,7 @@ visual_bell(void)
     LPWORD  oldattrs = ALLOC_MULT(WORD, Rows * Columns);
 
 # ifdef FEAT_TERMGUICOLORS
-    if (!(p_tgc || (!p_tgc && t_colors >= 256)))
+    if (!(p_tgc || t_colors >= 256))
 # endif
     {
 	if (oldattrs == NULL)
@@ -6795,7 +6795,7 @@ visual_bell(void)
     Sleep(15);	    // wait for 15 msec
 
 # ifdef FEAT_TERMGUICOLORS
-    if (!(p_tgc || (!p_tgc && t_colors >= 256)))
+    if (!(p_tgc || t_colors >= 256))
 # endif
 	WriteConsoleOutputAttribute(g_hConOut, oldattrs, Rows * Columns,
 				coordOrigin, &dwDummy);

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -73,7 +73,6 @@ void set_alist_count(void);
 void fix_arg_enc(void);
 int mch_setenv(char *var, char *value, int x);
 int vtp_printf(char *format, ...);
-int use_wt(void);
 void get_default_console_color(int *cterm_fg, int *cterm_bg, guicolor_T *gui_fg, guicolor_T *gui_bg);
 void control_console_color_rgb(void);
 int use_vtp(void);

--- a/src/term.c
+++ b/src/term.c
@@ -3222,7 +3222,7 @@ term_rgb_color(char_u *s, guicolor_T rgb)
     vim_snprintf(buf, MAX_COLOR_STR_LEN,
 				  (char *)s, RED(rgb), GREEN(rgb), BLUE(rgb));
 #ifdef FEAT_VTP
-    if (use_wt())
+    if (use_vtp() && (p_tgc || t_colors >= 256))
     {
 	out_flush();
 	buf[1] = '[';


### PR DESCRIPTION
prb:  ms-win console not flushing termguicolors
sln: flush termguicolors

This fixes the flushing of the termguicolors in the new versions of the windows console host - that are capable of using 24 bit colors.  (ie. the flushing is not just for windows terminal.)

Flushing the termguicolors was also needed for the visual_bell feature to work properly.   So, this PR also merges in all of @ntak PR:  Revert visualbell in vim.exe 16 color mode #11830


