### PR TITLE
doc: Add {{{ and }}} to the 'fold-marker' help tag

### DIFF
--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -182,7 +182,7 @@ When 'scrollbind' is also set, Vim will attempt to keep the same folds open in
 other diff windows, so that the same text is visible.
 
 
-MARKER						*fold-marker*
+MARKER						*fold-marker* *{{{* *}}}*
 
 Markers in the text tell where folds start and end.  This allows you to
 precisely specify the folds.  This will allow deleting and putting a fold,


### PR DESCRIPTION
Seeing `{{{` in code without exactly knowing what it does makes one curious. Help find information about the fold markers without knowing how they are called by adding the default 'foldmarker' value to the help tag.