### PR TITLE
KDL files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1029,6 +1029,9 @@ au BufNewFile,BufRead *.jsonnet,*.libsonnet	setf jsonnet
 " Julia
 au BufNewFile,BufRead *.jl			setf julia
 
+" KDL
+au BufNewFile,BufRead *.kdl			setf kdl
+
 " Kixtart
 au BufNewFile,BufRead *.kix			setf kix
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -299,6 +299,7 @@ let s:filename_checks = {
     \ 'jsp': ['file.jsp'],
     \ 'julia': ['file.jl'],
     \ 'kconfig': ['Kconfig', 'Kconfig.debug', 'Kconfig.file'],
+    \ 'kdl': ['file.kdl'],
     \ 'kivy': ['file.kv'],
     \ 'kix': ['file.kix'],
     \ 'kotlin': ['file.kt', 'file.ktm', 'file.kts'],


### PR DESCRIPTION
https://kdl.dev/
Problem: KDL files are not recognized.
Solution: Add the name of KDL files. (Amaan Qureshi)