### PR TITLE
Fix missing help tags for 'keywordprg'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4943,8 +4943,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	empty.  Then set the 'term' option to have it take effect: >
 		set keyprotocol=
 		let &term = &term
-
-
+<
 					*'keywordprg'* *'kp'*
 'keywordprg' 'kp'	string	(default "man" or "man -s",  DOS: ":help",
 								  VMS: "help")


### PR DESCRIPTION
Help tags for 'keywordprg' are recognized as help example contents because of a missing close pattern of help example. So Vim can't find these tags.