### PR TITLE
Fix heap-based buffer overflow in function utfc_ptr2len at mbyte.c

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5366,6 +5366,7 @@ ex_buffer_all(exarg_T *eap)
 
     setpcmark();
 
+    reset_VIsual_and_resel();	// stop Visual mode
 #ifdef FEAT_GUI
     need_mouse_correct = TRUE;
 #endif

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1523,4 +1523,24 @@ func Test_switch_buffer_ends_visual_mode()
   exe 'bwipe!' buf2
 endfunc
 
+" Check fix for the heap-based buffer overflow bug
+" found in the function utfc_ptr2len and reported at
+" https://huntr.dev/bounties/ae933869-a1ec-402a-bbea-d51764c6618e
+func Test_heap_buffer_overflow()
+  enew
+  set updatecount=0
+
+  norm R0
+  split other
+  norm R000
+  exe "norm \<C-V>l"
+  ball
+  call assert_equal(getpos("."), getpos("v"))
+  call assert_equal('n', mode())
+  norm zW
+
+  %bwipe!
+  set updatecount&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This issue was previously indicated in https://huntr.dev/bounties/ae933869-a1ec-402a-bbea-d51764c6618e. But a fix was proposed for only one of them. An additional check for the length of selected text should fix it.