### PR TITLE
vim indent plugin: support new class/interface/enum syntaxes

### DIFF
--- a/runtime/autoload/dist/vimindent.vim
+++ b/runtime/autoload/dist/vimindent.vim
@@ -7,7 +7,7 @@ vim9script
 # NOTE: Whenever you change the code, make sure the tests are still passing:
 #
 #     $ cd runtime/indent/
-#     $ make clean; make test || vimdiff testdir/vim.{fail,ok}
+#     $ make clean; make test || vimdiff testdir/vim.{ok,fail}
 
 # Config {{{1
 
@@ -173,9 +173,13 @@ const MODIFIERS: dict<string> = {
     class: ['export', 'abstract', 'export abstract'],
     interface: ['export'],
 }
+#     ...
 #     class: ['export', 'abstract', 'export abstract'],
+#     ...
 #     →
+#     ...
 #     class: '\%(export\|abstract\|export\s\+abstract\)\s\+',
+#     ...
 ->map((_, mods: list<string>): string =>
     '\%(' .. mods
     ->join('\|')
@@ -352,6 +356,10 @@ const TRICKY_COMMANDS: string = patterns->join('\|')
 
 const OPENING_BRACKET_AT_EOL: string = OPENING_BRACKET .. END_OF_VIM9_LINE
 
+# CLOSING_BRACKET_AT_EOL {{{3
+
+const CLOSING_BRACKET_AT_EOL: string = CLOSING_BRACKET .. END_OF_VIM9_LINE
+
 # COMMA_AT_EOL {{{3
 
 const COMMA_AT_EOL: string = $',{END_OF_VIM9_LINE}'
@@ -478,6 +486,7 @@ export def Expr(lnum = v:lnum): number # {{{2
     if line_A.text->ContinuesBelowBracketBlock(line_B, past_bracket_block)
             && line_A.text !~ CLOSING_BRACKET_AT_SOL
         return past_bracket_block.startindent
+            + (past_bracket_block.startline =~ STARTS_NAMED_BLOCK ? 2 * shiftwidth() : 0)
     endif
 
     # Problem: If we press `==` on the line right below the start of a multiline
@@ -1147,6 +1156,10 @@ enddef
 
 def EndsWithOpeningBracket(line: dict<any>): bool # {{{3
     return NonCommentedMatch(line, OPENING_BRACKET_AT_EOL)
+enddef
+
+def EndsWithClosingBracket(line: dict<any>): bool # {{{3
+    return NonCommentedMatch(line, CLOSING_BRACKET_AT_EOL)
 enddef
 
 def NonCommentedMatch(line: dict<any>, pat: string): bool # {{{3

--- a/runtime/indent/testdir/vim.in
+++ b/runtime/indent/testdir/vim.in
@@ -887,3 +887,40 @@ if true
 elseif
 endif
 " END_INDENT
+
+" START_INDENT
+abstract class Shape
+this.color = Color.Black
+this.thickness = 10
+endclass
+" END_INDENT
+
+" START_INDENT
+class OtherThing
+this.size: number
+static totalSize: number
+
+static def ClearTotalSize(): number
+var prev = totalSize
+totalSize = 0
+return prev
+enddef
+endclass
+" END_INDENT
+
+" START_INDENT
+interface HasSurface
+this.size: number
+def Surface(): number
+endinterface
+" END_INDENT
+
+" START_INDENT
+enum Color
+White
+Red
+Green
+Blue
+Black
+endenum
+" END_INDENT

--- a/runtime/indent/testdir/vim.in
+++ b/runtime/indent/testdir/vim.in
@@ -889,6 +889,14 @@ endif
 " END_INDENT
 
 " START_INDENT
+if (
+true)
+&& true
+echo
+endif
+" END_INDENT
+
+" START_INDENT
 abstract class Shape
 this.color = Color.Black
 this.thickness = 10

--- a/runtime/indent/testdir/vim.in
+++ b/runtime/indent/testdir/vim.in
@@ -924,6 +924,13 @@ endinterface
 " END_INDENT
 
 " START_INDENT
+interface EnterExit
+def Enter(): void
+def Exit(): void
+endinterface
+" END_INDENT
+
+" START_INDENT
 enum Color
 White
 Red

--- a/runtime/indent/testdir/vim.ok
+++ b/runtime/indent/testdir/vim.ok
@@ -887,3 +887,40 @@ if true
 elseif
 endif
 " END_INDENT
+
+" START_INDENT
+abstract class Shape
+    this.color = Color.Black
+    this.thickness = 10
+endclass
+" END_INDENT
+
+" START_INDENT
+class OtherThing
+    this.size: number
+    static totalSize: number
+
+    static def ClearTotalSize(): number
+	var prev = totalSize
+	totalSize = 0
+	return prev
+    enddef
+endclass
+" END_INDENT
+
+" START_INDENT
+interface HasSurface
+    this.size: number
+    def Surface(): number
+endinterface
+" END_INDENT
+
+" START_INDENT
+enum Color
+    White
+    Red
+    Green
+    Blue
+    Black
+endenum
+" END_INDENT

--- a/runtime/indent/testdir/vim.ok
+++ b/runtime/indent/testdir/vim.ok
@@ -889,6 +889,14 @@ endif
 " END_INDENT
 
 " START_INDENT
+if (
+	true)
+	&& true
+    echo
+endif
+" END_INDENT
+
+" START_INDENT
 abstract class Shape
     this.color = Color.Black
     this.thickness = 10

--- a/runtime/indent/testdir/vim.ok
+++ b/runtime/indent/testdir/vim.ok
@@ -924,6 +924,13 @@ endinterface
 " END_INDENT
 
 " START_INDENT
+interface EnterExit
+    def Enter(): void
+    def Exit(): void
+endinterface
+" END_INDENT
+
+" START_INDENT
 enum Color
     White
     Red


### PR DESCRIPTION
Should also make it easier to support/update new syntaxes, by editing only 2 variables, `BLOCKS`:
```vim
const BLOCKS: list<list<string>> = [
    ['if', 'el\%[se]', 'elseif\=', 'en\%[dif]'],
    ['for', 'endfor\='],
    ['wh\%[ile]', 'endw\%[hile]'],
    ['try', 'cat\%[ch]', 'fina\|finally\=', 'endt\%[ry]'],
    ['def', 'enddef'],
    ['fu\%[nction](\@!', 'endf\%[unction]'],
    ['class', 'endclass'],
    ['interface', 'endinterface'],
    ['enum', 'endenum'],
    ['aug\%[roup]\%(\s\+[eE][nN][dD]\)\@!\s\+\S\+', 'aug\%[roup]\s\+[eE][nN][dD]'],
]
```
And `MODIFIERS`:
```vim
const MODIFIERS: dict<string> = {
    def: ['export', 'static'],
    class: ['export', 'abstract', 'export abstract'],
    interface: ['export'],
}
```
---

Also fixes a bug.

Expected:

```vim
vim9script
if (
        true)
        && true
    echo
endif
```

Actual:
```vim
vim9script
if (
        true)
&& true
    echo
endif
```
