### PR TITLE
FIRRTL files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -671,6 +671,9 @@ autocmd BufRead,BufNewFile *.fnl		setf fennel
 " Fetchmail RC file
 au BufNewFile,BufRead .fetchmailrc		setf fetchmail
 
+" FIRRTL
+au BufNewFile,BufRead *.fir			setf firrtl
+
 " Fish shell
 au BufNewFile,BufRead *.fish			setf fish
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -197,6 +197,7 @@ let s:filename_checks = {
     \ 'fennel': ['file.fnl'],
     \ 'fetchmail': ['.fetchmailrc'],
     \ 'fgl': ['file.4gl', 'file.4gh', 'file.m4gl'],
+    \ 'firrtl': ['file.fir'],
     \ 'fish': ['file.fish'],
     \ 'focexec': ['file.fex', 'file.focexec'],
     \ 'form': ['file.frm'],


### PR DESCRIPTION
https://www.chisel-lang.org/firrtl/
Problem:  FIRRTL files are not recognized.
Solution:   Add a pattern for FIRRTL files. (Amaan Qureshi)