### PR TITLE
go.work.sum file isn't recognized as gosum

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -862,7 +862,7 @@ au BufNewFile,BufRead *.htpp			setf hastepreproc
 au BufRead,BufNewFile *.hcl			setf hcl
 
 " Go checksum file (must be before *.sum Hercules)
-au BufNewFile,BufRead go.sum			setf gosum
+au BufNewFile,BufRead go.sum,go.work.sum		setf gosum
 
 " Hercules
 au BufNewFile,BufRead *.vc,*.ev,*.sum,*.errsum	setf hercules

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -233,7 +233,7 @@ let s:filename_checks = {
     \ 'gnuplot': ['file.gpi', '.gnuplot'],
     \ 'go': ['file.go'],
     \ 'gomod': ['go.mod'],
-    \ 'gosum': ['go.sum'],
+    \ 'gosum': ['go.sum', 'go.work.sum'],
     \ 'gowork': ['go.work'],
     \ 'gp': ['file.gp', '.gprc'],
     \ 'gpg': ['/.gnupg/options', '/.gnupg/gpg.conf', '/usr/any/gnupg/options.skel', 'any/.gnupg/gpg.conf', 'any/.gnupg/options', 'any/usr/any/gnupg/options.skel'],


### PR DESCRIPTION
Problem: go.work.sum file isn't recognized as gosum
Solution: Add go.work.sum to gosum filetype detection