### PR TITLE
Motif: Fix scrollbar width after splitting

### DIFF
--- a/src/gui_motif.c
+++ b/src/gui_motif.c
@@ -1801,12 +1801,14 @@ gui_mch_create_scrollbar(
 	    XtSetArg(args[n], XmNtopAttachment, XmATTACH_FORM); n++;
 	    XtSetArg(args[n], XmNbottomAttachment, XmATTACH_OPPOSITE_FORM); n++;
 	    XtSetArg(args[n], XmNleftAttachment, XmATTACH_FORM); n++;
+	    XtSetArg(args[n], XmNwidth, gui.scrollbar_width); n++;
 	    break;
 
 	case SBAR_RIGHT:
 	    XtSetArg(args[n], XmNtopAttachment, XmATTACH_FORM); n++;
 	    XtSetArg(args[n], XmNbottomAttachment, XmATTACH_OPPOSITE_FORM); n++;
 	    XtSetArg(args[n], XmNrightAttachment, XmATTACH_FORM); n++;
+	    XtSetArg(args[n], XmNwidth, gui.scrollbar_width); n++;
 	    break;
 
 	case SBAR_BOTTOM:

--- a/src/gui_motif.c
+++ b/src/gui_motif.c
@@ -1815,6 +1815,7 @@ gui_mch_create_scrollbar(
 	    XtSetArg(args[n], XmNleftAttachment, XmATTACH_FORM); n++;
 	    XtSetArg(args[n], XmNrightAttachment, XmATTACH_FORM); n++;
 	    XtSetArg(args[n], XmNbottomAttachment, XmATTACH_FORM); n++;
+	    XtSetArg(args[n], XmNheight, gui.scrollbar_width); n++;
 	    break;
     }
 


### PR DESCRIPTION
The bug is observable if splitright is on and a non-default -scrollbarwidth is passed:

    ./vim --clean -g -sw 5 +'se splitright' +vs

Without the fix, the right window scrollbar is much more than 5px wide, although it would change into the correct 5px width once you interact with the window.

An immediate q: will make the left scrollbar too big as well.