### PR TITLE
Add Cadence `.cdc` filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1911,6 +1911,9 @@ au BufNewFile,BufRead *.sst.meta,*.-sst.meta,*._sst.meta setf sisu
 " SKILL
 au BufNewFile,BufRead *.il,*.ils,*.cdf		setf skill
 
+" Cadence
+au BufNewFile,BufRead *.cdc			setf cdc
+
 " SLRN
 au BufNewFile,BufRead .slrnrc			setf slrnrc
 au BufNewFile,BufRead *.score			setf slrnsc

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -521,6 +521,7 @@ let s:filename_checks = {
     \ 'sinda': ['file.sin', 'file.s85'],
     \ 'sisu': ['file.sst', 'file.ssm', 'file.ssi', 'file.-sst', 'file._sst', 'file.sst.meta', 'file.-sst.meta', 'file._sst.meta'],
     \ 'skill': ['file.il', 'file.ils', 'file.cdf'],
+    \ 'cdc': ['file.cdc'],
     \ 'slang': ['file.sl'],
     \ 'slice': ['file.ice'],
     \ 'slpconf': ['/etc/slp.conf', 'any/etc/slp.conf'],


### PR DESCRIPTION
This adds file type detection for `.cdc` files.

- [Cadence Home](https://developers.flow.com/cadence/language/index)
- [Cadence Git](https://github.com/onflow/cadence)
- Mention of `.cdc` extension:
    - from the [cadence linter](https://github.com/onflow/cadence-tools/blob/master/lint/README.md?plain=1#L61)
    - from the vscode [cadence extension](https://github.com/onflow/vscode-cadence/blob/master/package.json#L135)

