### PR TITLE
Trigger incsearch on cmdline paste

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2092,7 +2092,7 @@ getcmdline_int(
 		}
 		else if (res == GOTO_NORMAL_MODE)
 		    goto returncmd;
-		goto cmdline_changed;
+		goto cmdline_not_changed;
 
 	case Ctrl_D:
 		if (showmatches(&xpc, FALSE) == EXPAND_NOTHING)

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2083,15 +2083,12 @@ getcmdline_int(
 
 	case Ctrl_R:			// insert register
 		res = cmdline_insert_reg(&gotesc);
-		if (res == CMDLINE_NOT_CHANGED)
-		{
+		if (res == GOTO_NORMAL_MODE)
+		    goto returncmd;
 #ifdef FEAT_SEARCH_EXTRA
+		if (res == CMDLINE_NOT_CHANGED)
 		    is_state.incsearch_postponed = TRUE;
 #endif
-		    goto cmdline_not_changed;
-		}
-		else if (res == GOTO_NORMAL_MODE)
-		    goto returncmd;
 		goto cmdline_not_changed;
 
 	case Ctrl_D:

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2081,11 +2081,12 @@ getcmdline_int(
 
 	case Ctrl_R:			// insert register
 		res = cmdline_insert_reg(&gotesc);
-		if (res == CMDLINE_NOT_CHANGED)
-		    goto cmdline_not_changed;
-		else if (res == GOTO_NORMAL_MODE)
+		if (res == GOTO_NORMAL_MODE)
 		    goto returncmd;
-		goto cmdline_changed;
+#ifdef FEAT_SEARCH_EXTRA
+		is_state.incsearch_postponed = TRUE;
+#endif
+		goto cmdline_not_changed;
 
 	case Ctrl_D:
 		if (showmatches(&xpc, FALSE) == EXPAND_NOTHING)


### PR DESCRIPTION
Inserting register literally (e.g. `Ctrl-R +` or `Ctrl-R Ctrl-R "`) in commandline didn't trigger incsearch or hlsearch.

Steps to reproduce:

1. `vim --clean --cmd 'set incsearch hlsearch | let @"="text" | put'`
2. Type `/` to start searching then type `Ctrl-R Ctrl-R "`.
   Unexpectedly, `text` is not highlighted.

~~I also found that `cmdline_insert_reg()` returns only `CMDLINE_NOT_CHANGED` or `GOTO_NORMAL_MODE`. So, the checks of the returned value was redundant and the `goto cmdline_changed;` line was not executed.~~

This PR fixes them.
(I'm not sure how to add a test for this...)