### PR TITLE
Fix test_environ for mac

### DIFF
--- a/src/testdir/test_environ.vim
+++ b/src/testdir/test_environ.vim
@@ -81,7 +81,7 @@ func Test_mac_locale()
   " 1. The locale is the form of <locale>.UTF-8.
   " 2. Check that fourth item (LC_NUMERIC) is properly set to "C".
   " Example match: "en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8"
-  call assert_match('"\([a-zA-Z_]\+\.UTF-8/\)\{3}C\(/[a-zA-Z_]\+\.UTF-8\)\{2}"',
+  call assert_match('"\(\([a-zA-Z_]\+\.\)\?UTF-8/\)\{3}C\(/\([a-zA-Z_]\+\.\)\?UTF-8\)\{2}"',
         \ lang_results,
         \ "Default locale should have UTF-8 encoding set, and LC_NUMERIC set to 'C'")
 endfunc


### PR DESCRIPTION
The environ test failed on my mac, because the regex couldn't match my :lang string `"en_US.UTF-8/UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8"`.

The second value is only `UTF-8` which fails the regex since it currently checks for `[a-zA-Z_]+\.UTF-8`

I wrapped the checks in optional groups like this: `([a-zA-Z_]+\.)?UTF-8`

<hr>

There is a different fix that seemed to work for me too:
I simply added `unset LC_CTYPE` in line 76:
https://github.com/vim/vim/blob/0caaf1e46511f7a92e036f05e6aa9d5992540117/src/testdir/test_environ.vim#L76

If that is preferred, I prepared a patch file:
[test_environ_unset.patch](https://github.com/vim/vim/files/10698199/test_environ_unset.patch)
