### PR TITLE
make quote text objects more intuitive

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -658,26 +658,24 @@ iB			"inner Block", select [count] Blocks, from "[count] [{"
 a"							*v_aquote* *aquote*
 a'							*v_a'* *a'*
 a`							*v_a`* *a`*
-			"a quoted string".  Selects the text from the previous
-			quote until the next quote.  The 'quoteescape' option
-			is used to skip escaped quotes.
+			"a quoted string".  Selects [count]th quoted string
+			The 'quoteescape' option is used to skip escaped quotes.
 			Only works within one line.
-			When the cursor starts on a quote, Vim will figure out
-			which quote pairs form a string by searching from the
-			start of the line.
+			Vim will figure out which quote pairs form a string by
+			searching from the start of the line.
 			Any trailing white space is included, unless there is
 			none, then leading white space is included.
 			When used in Visual mode it is made characterwise.
 			Repeating this object in Visual mode another string is
-			included.  A count is currently not used.
+			included.
 
 i"							*v_iquote* *iquote*
 i'							*v_i'* *i'*
 i`							*v_i`* *i`*
-			Like a", a' and a`, but exclude the quotes and
-			repeating won't extend the Visual selection.
-			Special case: With a count of 2 the quotes are
-			included, but no extra white space as with a"/a'/a`.
+			Like a", a' and a`, but exclude the quotes.
+			If repeated the quotes are included, but no extra
+			white space as with a"/a'/a`, repeating it again will
+			select the next string.
 
 When used after an operator:
 For non-block objects:


### PR DESCRIPTION
# Problem

If you have the following text with `|` indicating the cursor

    'string' |stuff 'string'

now in normal mode if you press `vi'` the region demarcated with `*` is selected

    'string'* stuff *'string'

But we can agree that `stuff` is not part of any string, but the help says that it will always select a "quoted string"

Visual mode gets some more nice (special cased) behaviours as well, taking the same example as above, if we do `vli'` or
`vhi'` we properly select the left or right string. but `di'` or `ci'` don't get just niceties.
There also exists no way to select the nth string by doing `vni'` (somewhat akin to `vnib`).

I propose the following behaviour for the `i{quote}` and `a{quote}` textobjects.

- Select the nearest "balanced" quote object (always selecting forwards but backwards if there is nothing forwards)
- Choose to select the string forwards or backwards (using `vhi'` or `vli'` for example).
- The repeat behaviour is not very obvious, I am open to suggestions but I thought the following made sense:
    - `vi'i'` includes the quotes
    - after doing `vi'i'` the next `i'` selects the next string obeying the rules of `i'`
    - `v2i'` selects the 2nd string (so selecting the nth quote object using `vni'`)
    - repeating `a'` always selects the next string

One caveat is that some languages leverage unbalanced quotes in their grammar (vimscript quotes, rust lifetimes).
Its tricky to handle those cases. My proposal is:

- An even number of quotes are always balanced.
- In case of an odd number of quotes if the user is already inside a _percieved_ balanced string, then select it.
  more precisely if the cursor is after the end of a balanced quote and there is a partial quote present after it, then
  region between the end of the balanced quote and partial quote is selected.
  (`*` marks selection `|` is cursor)
```
              v balanced quote end
    " comment "*string|*"
    ^ start           ^ start but no end
```

This also somewhat simplifies the code by not having too many special cases.

This is certainly not perfect, ideally we would want syntax based text objects, but as a default I think this is much better and an improvement over the current behaviour.