### PR TITLE
Add support for number literals including '_' in Python

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -165,16 +165,16 @@ syn match   pythonEscape	"\\$"
 " https://docs.python.org/reference/lexical_analysis.html#numeric-literals
 if !exists("python_no_number_highlight")
   " numbers (including longs and complex)
-  syn match   pythonNumber	"\<0[oO]\=\o\+[Ll]\=\>"
-  syn match   pythonNumber	"\<0[xX]\x\+[Ll]\=\>"
-  syn match   pythonNumber	"\<0[bB][01]\+[Ll]\=\>"
-  syn match   pythonNumber	"\<\%([1-9]\d*\|0\)[Ll]\=\>"
-  syn match   pythonNumber	"\<\d\+[jJ]\>"
-  syn match   pythonNumber	"\<\d\+[eE][+-]\=\d\+[jJ]\=\>"
+  syn match   pythonNumber	"\<0[oO]\=\%(\o\|_\)\+_\@<![Ll]\=\>"
+  syn match   pythonNumber	"\<0[xX]\%(\x\|_\)\+_\@<![Ll]\=\>"
+  syn match   pythonNumber	"\<0[bB][01_]\+_\@<![Ll]\=\>"
+  syn match   pythonNumber	"\<\%([1-9]\%(\d\|_\)*\|0\)_\@<!\>"
+  syn match   pythonNumber	"\<\d\%(\d\|_\)*_\@<![jJ]\>"
+  syn match   pythonNumber	"\<\d\%(\d\|_\)*_\@<![eE][+-]\=\d\%(\d\|_\)*_\@<![jJ]\=\>"
   syn match   pythonNumber
-	\ "\<\d\+\.\%([eE][+-]\=\d\+\)\=[jJ]\=\%(\W\|$\)\@="
+	\ "\<\d\%(\d\|_\)*_\@<!\.\%([eE][+-]\=\d\%(\d\|_\)*_\@<!\)\=[jJ]\=\%(\W\|$\)\@="
   syn match   pythonNumber
-	\ "\%(^\|\W\)\zs\d*\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>"
+	\ "\%(^\|\W\)\zs\d*\.\d\%(\d\|_\)*_\@<!\%([eE][+-]\=\d\%(\d\|_\)*_\@<!\)\=[jJ]\=\>"
 endif
 
 " Group the built-ins in the order in the 'Python Library Reference' for


### PR DESCRIPTION
This pull request intend to solve the problem reported as  #11978

It adds syntax highlighting to Python number literal of the kind 1_024.
