### PR TITLE
Prevent use of :: for dosbatch comments by default

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1307,18 +1307,32 @@ When not set 4 is used.
 
 DOSBATCH				*dosbatch.vim* *ft-dosbatch-syntax*
 
-There is one option with highlighting DOS batch files.	This covers new
-extensions to the Command Interpreter introduced with Windows 2000 and
-is controlled by the variable dosbatch_cmdextversion.  For Windows NT
-this should have the value 1, and for Windows 2000 it should be 2.
+Select the set of Windows Command interpreter extensions that should be
+supported with the variable dosbatch_cmdextversion.  For versions of Windows
+NT (before Windows 2000) this should have the value of 1.  For Windows 2000
+and later it should be 2.
 Select the version you want with the following line: >
 
    :let dosbatch_cmdextversion = 1
 
 If this variable is not defined it defaults to a value of 2 to support
-Windows 2000.
+Windows 2000 and later.
 
-A second option covers whether *.btm files should be detected as type
+The original MS-DOS supports an idiom of using a double colon (::) as an
+alternative way to enter a comment line.  This idiom can be used with the
+current Windows Command Interpreter, but it can lead to problems when used
+inside ( ... ) command blocks.  You can find a discussion about this on
+Stack Overflow -
+
+https://stackoverflow.com/questions/12407800/which-comment-style-should-i-use-in-batch-files
+
+To allow the use of the :: idiom for comments in the Windows Command
+Interpreter or working with MS-DOS bat files, set the
+dosbatch_colons_comment variable to anything: >
+
+   :let dosbatch_colons_comment = 1
+
+There is an option that covers whether *.btm files should be detected as type
 "dosbatch" (MS-DOS batch files) or type "btm" (4DOS batch files).  The latter
 is used by default.  You may select the former with the following line: >
 

--- a/runtime/ftplugin/dosbatch.vim
+++ b/runtime/ftplugin/dosbatch.vim
@@ -1,7 +1,10 @@
 " Vim filetype plugin file
-" Language:    MS-DOS .bat files
-" Maintainer:  Mike Williams <mrw@eandem.co.uk>
-" Last Change: 7th May 2020
+" Language:    MS-DOS/Windows .bat files
+" Maintainer:  Mike Williams <mrmrdubya@gmail.com>
+" Last Change: 12th February 2023
+"
+" Options Flags:
+" dosbatch_colons_comment       - any value to treat :: as comment line
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -15,8 +18,13 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 " BAT comment formatting
-setlocal comments=b:rem,b:@rem,b:REM,b:@REM,:::
-setlocal commentstring=::\ %s
+setlocal comments=b:rem,b:@rem,b:REM,b:@REM
+if exists("dosbatch_colons_comment")
+  setlocal comments+=:::
+  setlocal commentstring=::\ %s
+else
+  setlocal commentstring=REM\ %s
+endif
 setlocal formatoptions-=t formatoptions+=rol
 
 " Lookup DOS keywords using Windows command help.

--- a/runtime/syntax/dosbatch.vim
+++ b/runtime/syntax/dosbatch.vim
@@ -1,12 +1,12 @@
 " Vim syntax file
-" Language:	MS-DOS batch file (with NT command extensions)
-" Maintainer:	Mike Williams <mrw@eandem.co.uk>
+" Language:	MS-DOS/Windows batch file (with NT command extensions)
+" Maintainer:	Mike Williams <mrmrdubya@gmail.com>
 " Filenames:    *.bat
-" Last Change:	6th September 2009
-" Web Page:     http://www.eandem.co.uk/mrw/vim
+" Last Change:	12th February 2023
 "
 " Options Flags:
 " dosbatch_cmdextversion	- 1 = Windows NT, 2 = Windows 2000 [default]
+" dosbatch_colons_comment       - any value to treat :: as comment line
 "
 
 " quit when a syntax file was already loaded
@@ -92,7 +92,11 @@ syn match dosbatchComment	"^rem\($\|\s.*$\)"lc=3 contains=dosbatchTodo,dosbatchS
 syn match dosbatchComment	"^@rem\($\|\s.*$\)"lc=4 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
 syn match dosbatchComment	"\srem\($\|\s.*$\)"lc=4 contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
 syn match dosbatchComment	"\s@rem\($\|\s.*$\)"lc=5 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
-syn match dosbatchComment	"\s*:\s*:.*$" contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
+if exists("dosbatch_colons_comment")
+  syn match dosbatchComment	"\s*:\s*:.*$" contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
+else
+  syn match dosbatchError       "\s*:\s*:.*$"
+endif
 
 " Comments in ()'s - still to handle spaces before rem
 syn match dosbatchComment	"(rem\([^)]\|\^\@<=)\)*"lc=4 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
@@ -110,34 +114,35 @@ syn keyword dosbatchImplicit    vol xcopy
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
-hi def link dosbatchTodo		Todo
+hi def link dosbatchTodo	Todo
+hi def link dosbatchError	Error
 
 hi def link dosbatchStatement	Statement
 hi def link dosbatchCommands	dosbatchStatement
-hi def link dosbatchLabel		Label
+hi def link dosbatchLabel	Label
 hi def link dosbatchConditional	Conditional
-hi def link dosbatchRepeat		Repeat
+hi def link dosbatchRepeat	Repeat
 
-hi def link dosbatchOperator       Operator
-hi def link dosbatchEchoOperator   dosbatchOperator
-hi def link dosbatchIfOperator     dosbatchOperator
+hi def link dosbatchOperator	Operator
+hi def link dosbatchEchoOperator dosbatchOperator
+hi def link dosbatchIfOperator	dosbatchOperator
 
 hi def link dosbatchArgument	Identifier
-hi def link dosbatchIdentifier     Identifier
+hi def link dosbatchIdentifier	Identifier
 hi def link dosbatchVariable	dosbatchIdentifier
 
 hi def link dosbatchSpecialChar	SpecialChar
-hi def link dosbatchString		String
-hi def link dosbatchNumber		Number
+hi def link dosbatchString	String
+hi def link dosbatchNumber	Number
 hi def link dosbatchInteger	dosbatchNumber
 hi def link dosbatchHex		dosbatchNumber
-hi def link dosbatchBinary		dosbatchNumber
-hi def link dosbatchOctal		dosbatchNumber
+hi def link dosbatchBinary	dosbatchNumber
+hi def link dosbatchOctal	dosbatchNumber
 
 hi def link dosbatchComment	Comment
 hi def link dosbatchImplicit	Function
 
-hi def link dosbatchSwitch		Special
+hi def link dosbatchSwitch	Special
 
 hi def link dosbatchCmd		PreProc
 


### PR DESCRIPTION
This patch is to disable (in fact highlight as an error) comments using the :: idiom in batch files as it can use problems on modern Windows systems. For anyone still working with good old MS-DOS (or equivalents) where the idiom still works fine you can set a variable in the vimrc file to support them as before.

Rolled in some miscellaneous fix-ups to the doc and syntax file.