### PR TITLE
sh.vim: Fix broken highlighting for shell scopes

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -335,7 +335,8 @@ syn match   shEscape	contained	'\%(^\)\@!\%(\\\\\)*\\.'	nextgroup=shComment
 " systems too, however, so the following syntax will flag $(..) as
 " an Error under /bin/sh.  By consensus of vimdev'ers!
 if exists("b:is_kornshell") || exists("b:is_bash") || exists("b:is_posix")
- syn region shCommandSub matchgroup=shCmdSubRegion start="\$(\ze[^(]\|$"  skip='\\\\\|\\.' end=")"  contains=@shCommandSubList
+" syn region shCommandSub matchgroup=shCmdSubRegion start="\$(\ze[^(]\|$"  skip='\\\\\|\\.' end=")"  contains=@shCommandSubList
+ syn region shCommandSub matchgroup=shCmdSubRegion start="\$(\ze[^(]"  skip='\\\\\|\\.' end=")"  contains=@shCommandSubList
  syn region shArithmetic matchgroup=shArithRegion  start="\$((" skip='\\\\\|\\.' end="))" contains=@shArithList
  syn region shArithmetic matchgroup=shArithRegion  start="\$\[" skip='\\\\\|\\.' end="\]" contains=@shArithList
  syn match  shSkipInitWS contained	"^\s\+"


### PR DESCRIPTION
The latest update of runtime files broke syntax highlighting of scopes in shell files.

This PR reverts the specific change in sh.vim which caused the behavior.

See especially colors in IF scopes:
[Broken highlighting](https://bugzilla-attachments.redhat.com/attachment.cgi?id=1944012)
[Working highlighting](https://bugzilla-attachments.redhat.com/attachment.cgi?id=1944014)

I'll write an email to the file maintainer as well.