### PR TITLE
fix for bug 11596 - gm and g^ do not remember column for vertical motion in folds

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -5719,8 +5719,6 @@ nv_g_home_m_cmd(cmdarg_T *cap)
     int		i;
     int		flag = FALSE;
 
-    if (curwin->w_cline_folded) return; // in case of folded lines, exit
-
     if (cap->nchar == '^')
 	flag = TRUE;
 
@@ -5759,7 +5757,12 @@ nv_g_home_m_cmd(cmdarg_T *cap)
 	while (VIM_ISWHITE(i) && oneright() == OK);
 	curwin->w_valid &= ~VALID_WCOL;
     }
-    curwin->w_set_curswant = TRUE;
+    if (curwin->w_cline_folded)
+    {
+	update_curswant_force();
+    } else {
+	curwin->w_set_curswant = TRUE;
+    }
 }
 
 /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -5719,6 +5719,8 @@ nv_g_home_m_cmd(cmdarg_T *cap)
     int		i;
     int		flag = FALSE;
 
+    if (curwin->w_cline_folded) return; // in case of folded lines, exit
+
     if (cap->nchar == '^')
 	flag = TRUE;
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -5757,12 +5757,10 @@ nv_g_home_m_cmd(cmdarg_T *cap)
 	while (VIM_ISWHITE(i) && oneright() == OK);
 	curwin->w_valid &= ~VALID_WCOL;
     }
-    if (curwin->w_cline_folded)
-    {
+    if (curwin->w_cline_folded)    
 	update_curswant_force();
-    } else {
+    else
 	curwin->w_set_curswant = TRUE;
-    }
 }
 
 /*


### PR DESCRIPTION
I changed nv_g_home_m_cmd for doing nothing in case of gm executed on a folded line
Do you think that this could be a good solution ?