### PR TITLE
Fix insert mode cursor position for 'splitkeep'

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1754,10 +1754,7 @@ func Test_splitkeep_options()
     " Scroll when cursor becomes invalid in insert mode.
     norm Lic
     call assert_equal(curpos[0], getcurpos()[0], 'run ' .. run)
-
-    " The line number might be one less because of round-off.
-    call assert_inrange(curpos[1] - 1, curpos[1], getcurpos()[1], 'run ' .. run)
-
+    call assert_equal(curpos[1], getcurpos()[1], 'run ' .. run)
     call assert_equal(curpos[2], getcurpos()[2], 'run ' .. run)
     call assert_equal(curpos[3], getcurpos()[3], 'run ' .. run)
     call assert_equal(curpos[4], getcurpos()[4], 'run ' .. run)

--- a/src/window.c
+++ b/src/window.c
@@ -5328,7 +5328,8 @@ win_enter_ext(win_T *wp, int flags)
     if (*p_spk == 'c')		// assume cursor position needs updating
 	changed_line_abv_curs();
     else
-	win_fix_cursor(TRUE);
+	win_fix_cursor(get_real_state()
+				    & (MODE_NORMAL|MODE_CMDLINE|MODE_TERMINAL));
 
     // Now it is OK to parse messages again, which may be needed in
     // autocommands.


### PR DESCRIPTION
Problem:    Incorrect assumption that when `win_fix_cursor()` is called
            from `win_enter_ext()` we are in normal mode.
Solution:   Determine whether we are in normal mode.