### PR TITLE
Screenrow motion doesn't bring cursor to start of closed fold

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -2344,20 +2344,11 @@ nv_screengo(oparg_T *oap, int dir, long dist)
 	    else
 	    {
 		// to previous line
-#ifdef FEAT_FOLDING
-		// Move to the start of a closed fold.  Don't do that when
-		// 'foldopen' contains "all": it will open in a moment.
-		if (!(fdo_flags & FDO_ALL))
-		    (void)hasFolding(curwin->w_cursor.lnum,
-						&curwin->w_cursor.lnum, NULL);
-#endif
-		if (curwin->w_cursor.lnum == 1)
+		if (!cursor_up_inner(curwin, 1))
 		{
 		    retval = FAIL;
 		    break;
 		}
-		--curwin->w_cursor.lnum;
-
 		linelen = linetabsize_str(ml_get_curline());
 		if (linelen > width1)
 		    curwin->w_curswant += (((linelen - width1 - 1) / width2)
@@ -2380,17 +2371,11 @@ nv_screengo(oparg_T *oap, int dir, long dist)
 	    else
 	    {
 		// to next line
-#ifdef FEAT_FOLDING
-		// Move to the end of a closed fold.
-		(void)hasFolding(curwin->w_cursor.lnum, NULL,
-						      &curwin->w_cursor.lnum);
-#endif
-		if (curwin->w_cursor.lnum == curbuf->b_ml.ml_line_count)
+		if (!cursor_down_inner(curwin, 1))
 		{
 		    retval = FAIL;
 		    break;
 		}
-		curwin->w_cursor.lnum++;
 		curwin->w_curswant %= width2;
 		// Check if the cursor has moved below the number display
 		// when width1 < width2 (with cpoptions+=n). Subtract width2

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1748,4 +1748,11 @@ func Test_expand_fold_at_bottom_of_buffer()
   bwipe!
 endfunc
 
+func Test_fold_screenrow_motion()
+  call setline(1, repeat(['aaaa'], 5))
+  1,4fold
+  norm Ggkzo
+  call assert_equal(1, line('.'))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Screenrow motion implements it's own code for moving up a
	    non-wrapped line, which also exhibits a problem with closed
	    folds.
Solution:   Re-use inner cursor up and down functions, fixing the
	    problem.