### PR TITLE
CI: unset HOMEBREW_NO_AUTO_UPDATE: 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,8 +299,6 @@ jobs:
 
       - name: Install packages
         if: matrix.features == 'huge'
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           brew install lua
           echo "LUA_PREFIX=/usr/local" >> $GITHUB_ENV


### PR DESCRIPTION
https://brew.sh/2023/02/16/homebrew-4.0.0/
"If you had previously set HOMEBREW_NO_AUTO_UPDATE, HOMEBREW_NO_INSTALL_FROM_API or HOMEBREW_AUTO_UPDATE_SECS to work around bugs or annoyances: please consider unsetting these and tweaking the values based on the new behaviour."