### PR TITLE
Add proper test for escaping of "<" in mapping completion

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -325,19 +325,21 @@ func Test_map_completion()
   call assert_equal('"map ,g', getreg(':'))
   call feedkeys(":map <L\<Tab>\<Home>\"\<CR>", 'xt')
   call assert_equal('"map <Left>', getreg(':'))
-  call feedkeys(":map <A-Left>\<Tab>\<Home>\"\<CR>", 'xt')
-  call assert_equal("\"map <A-Left>\<Tab>", getreg(':'))
+  call feedkeys(":map <M-Left>\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal("\"map <M-Left>x", getreg(':'))
   unmap ,f
   unmap ,g
   unmap <Left>
   unmap <A-Left>x
 
-  set cpo-=< cpo-=B cpo-=k
+  set cpo-=< cpo-=k
   map <Left> left
   call feedkeys(":map <L\<Tab>\<Home>\"\<CR>", 'xt')
   call assert_equal('"map <Left>', getreg(':'))
   call feedkeys(":map <M\<Tab>\<Home>\"\<CR>", 'xt')
   call assert_equal("\"map <M\<Tab>", getreg(':'))
+  call feedkeys(":map \<C-V>\<C-V><M\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal("\"map \<C-V><Middle>x", getreg(':'))
   unmap <Left>
 
   set cpo+=<

--- a/src/testdir/test_cpoptions.vim
+++ b/src/testdir/test_cpoptions.vim
@@ -67,15 +67,20 @@ endfunc
 func Test_cpo_B()
   let save_cpo = &cpo
   new
+  imap <buffer> x<Bslash>k Test
   set cpo-=B
   iabbr <buffer> abc ab\<BS>d
   exe "normal iabc "
   call assert_equal('ab<BS>d ', getline(1))
+  call feedkeys(":imap <buffer> x\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"imap <buffer> x\\k', @:)
   %d
   set cpo+=B
   iabbr <buffer> abc ab\<BS>d
   exe "normal iabc "
   call assert_equal('abd ', getline(1))
+  call feedkeys(":imap <buffer> x\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"imap <buffer> x\k', @:)
   close!
   let &cpo = save_cpo
 endfunc


### PR DESCRIPTION
I've also noticed that the current behavior of mapping completion is
strange when the pattern contains characters like asterisk or backslash,
because addstar() modifies these characters. Does this need change?
