### PR TITLE
Fixed html syntax for javaScript region start pattern

### DIFF
--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -221,7 +221,7 @@ if main_syntax != 'java' || exists("java_javascript")
   " JAVA SCRIPT
   syn include @htmlJavaScript syntax/javascript.vim
   unlet b:current_syntax
-  syn region  javaScript start=+<script\_[^>]*>+ keepend end=+</script\_[^>]*>+me=s-1 contains=@htmlJavaScript,htmlCssStyleComment,htmlScriptTag,@htmlPreproc
+  syn region  javaScript start=+<script \_[^>]*>+ keepend end=+</script\_[^>]*>+me=s-1 contains=@htmlJavaScript,htmlCssStyleComment,htmlScriptTag,@htmlPreproc
   syn region  htmlScriptTag	contained start=+<script+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent
   hi def link htmlScriptTag htmlTag
 


### PR DESCRIPTION
This fixes some weird syntax highlighting effects for markdown files.