### PR TITLE
Fix crash with buffer-local user command in cmdwin

### DIFF
--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -856,6 +856,15 @@ func Test_buflocal_ambiguous_usercmd()
   bw!
 endfunc
 
+" Test for using buffer-local user command from cmdwin.
+func Test_buflocal_usercmd_cmdwin()
+  new
+  command -buffer TestCmd edit Test
+  " This used to crash Vim
+  call assert_fails("norm q::TestCmd\<CR>", 'E11:')
+  bw!
+endfunc
+
 " Test for using a multibyte character in a user command
 func Test_multibyte_in_usercmd()
   command SubJapanesePeriodToDot exe "%s/\u3002/./g"

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -1838,7 +1838,7 @@ do_ucmd(exarg_T *eap)
     if (eap->cmdidx == CMD_USER)
 	cmd = USER_CMD(eap->useridx);
     else
-	cmd = USER_CMD_GA(&curbuf->b_ucmds, eap->useridx);
+	cmd = USER_CMD_GA(&prevwin_curwin()->w_buffer->b_ucmds, eap->useridx);
 
     /*
      * Replace <> in the command by the arguments.


### PR DESCRIPTION
Fix #12029

It's still possible to create autocommands local to cmdwin buffer, but those are neither listed nor executed. Changing the existing behavior isn't useful either, so may the other `curbuf->b_ucmds` usages can just be left as-is?
