### PR TITLE
Ungrammar files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2205,6 +2205,9 @@ au BufNewFile,BufRead */etc/udev/permissions.d/*.permissions setf udevperm
 " Udev symlinks config
 au BufNewFile,BufRead */etc/udev/cdsymlinks.conf	setf sh
 
+" Ungrammar
+au BufNewFile,BufRead *.ungram		setf ungrammar
+
 " UnrealScript
 au BufNewFile,BufRead *.uc			setf uc
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -607,6 +607,7 @@ let s:filename_checks = {
     \ 'typescript': ['file.mts', 'file.cts'],
     \ 'typescript.glimmer': ['file.gts'],
     \ 'typescriptreact': ['file.tsx'],
+    \ 'ungrammar': ['file.ungram'],
     \ 'uc': ['file.uc'],
     \ 'udevconf': ['/etc/udev/udev.conf', 'any/etc/udev/udev.conf'],
     \ 'udevperm': ['/etc/udev/permissions.d/file.permissions', 'any/etc/udev/permissions.d/file.permissions'],


### PR DESCRIPTION
https://github.com/rust-analyzer/ungrammar

Problem: Ungrammar files are not recognized
Solution: Add a filetype pattern for Ungrammar files. (Amaan Qureshi)