### PR TITLE
Starlark files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2025,6 +2025,9 @@ au BufNewFile,BufRead */etc/ssh/ssh_config.d/*.conf		setf sshconfig
 au BufNewFile,BufRead sshd_config			setf sshdconfig
 au BufNewFile,BufRead */etc/ssh/sshd_config.d/*.conf	setf sshdconfig
 
+" Starlark
+au BufNewFile,BufRead *.ipd,*.star,*.starlark	setf starlark
+
 " OpenVPN configuration
 au BufNewFile,BufRead *.ovpn			setf openvpn
 au BufNewFile,BufRead */openvpn/*/*.conf	setf openvpn

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -559,6 +559,7 @@ let s:filename_checks = {
     \ 'sshconfig': ['ssh_config', '/.ssh/config', '/etc/ssh/ssh_config.d/file.conf', 'any/etc/ssh/ssh_config.d/file.conf', 'any/.ssh/config', 'any/.ssh/file.conf'],
     \ 'sshdconfig': ['sshd_config', '/etc/ssh/sshd_config.d/file.conf', 'any/etc/ssh/sshd_config.d/file.conf'],
     \ 'st': ['file.st'],
+    \ 'starlark': ['file.ipd', 'file.star', 'file.starlark'],
     \ 'stata': ['file.ado', 'file.do', 'file.imata', 'file.mata'],
     \ 'stp': ['file.stp'],
     \ 'sudoers': ['any/etc/sudoers', 'sudoers.tmp', '/etc/sudoers', 'any/etc/sudoers.d/file'],


### PR DESCRIPTION
https://github.com/bazelbuild/starlark
https://github.com/google/starlark-go

Problem: Starlark files are not recognized
Solution: Add a filetype pattern for Starlark files. (Amaan Qureshi)

Also, *.bzl (Bazel) files are also considered Starlark files, not sure if that should be added or not...