### PR TITLE
ChainPack Object Notation (CPON) files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -310,6 +310,9 @@ au BufNewFile,BufRead *.cdl			setf cdl
 " Conary Recipe
 au BufNewFile,BufRead *.recipe			setf conaryrecipe
 
+" ChainPack Object Notation (CPON)
+au BufNewFile,BufRead *.cpon			setf cpon
+
 " Controllable Regex Mutilator
 au BufNewFile,BufRead *.crm			setf crm
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -124,6 +124,7 @@ let s:filename_checks = {
     \ 'confini': ['/etc/pacman.conf', 'any/etc/pacman.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'file.nmconnection'],
     \ 'context': ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],
     \ 'cook': ['file.cook'],
+    \ 'cpon': ['file.cpon'],
     \ 'cpp': ['file.cxx', 'file.c++', 'file.hh', 'file.hxx', 'file.hpp', 'file.ipp', 'file.moc', 'file.tcc', 'file.inl', 'file.tlh'],
     \ 'cqlang': ['file.cql'],
     \ 'crm': ['file.crm'],


### PR DESCRIPTION
https://github.com/silicon-heaven/libshv/wiki/ChainPack-RPC#cpon-chainpack-object-notation

Problem: ChainPack Object Notation (CPON) files are not recognized
Solution: Add patterns for CPON files. (Amaan Qureshi)