### PR TITLE
Fix 'linebreak' with 'list' and 'number' issue

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -3095,7 +3095,8 @@ win_line(
 							? wp->w_lcs_chars.tab3
 							: wp->w_lcs_chars.tab1;
 #ifdef FEAT_LINEBREAK
-			if (wp->w_p_lbr && wlv.p_extra != NULL)
+			if (wp->w_p_lbr && wlv.p_extra != NULL
+							&& *wlv.p_extra != NUL)
 			    wlv.c_extra = NUL; // using p_extra from above
 			else
 #endif

--- a/src/testdir/test_listlbr.vim
+++ b/src/testdir/test_listlbr.vim
@@ -73,6 +73,30 @@ func Test_linebreak_with_nolist()
   call s:close_windows()
 endfunc
 
+func Test_linebreak_with_list_and_number()
+  call s:test_windows('setl list listchars+=tab:>-')
+  call setline(1, ["abcdefg\thijklmnopqrstu", "v"])
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect_nonumber = [
+\ "abcdefg>------------",
+\ "hijklmnopqrstu$     ",
+\ "v$                  ",
+\ "~                   ",
+\ ]
+  call s:compare_lines(expect_nonumber, lines)
+
+  setl number
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect_number = [
+\ "  1 abcdefg>--------",
+\ "    hijklmnopqrstu$ ",
+\ "  2 v$              ",
+\ "~                   ",
+\ ]
+  call s:compare_lines(expect_number, lines)
+  call s:close_windows()
+endfunc
+
 func Test_should_break()
   call s:test_windows('setl sbr=+ nolist')
   call setline(1, "1\t" . repeat('a', winwidth(0)-2))


### PR DESCRIPTION
### Step to repro.
Start Vim with the following arguments on terminal **80x24**
```bash
$ vim -Nu NONE +'set linebreak list listchars+=tab:>- wrap number' +'call setline(1, ["Saa aaaaaaa aaaaaaaaaaE\tBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", "i"])'
```

### Actual behavior:
Tab 2nd characters and following text does not appear.
![image](https://user-images.githubusercontent.com/518808/221397846-c6710c39-1a69-494f-ac79-6fe6996f018a.png)

### Expected behavior
Tab 2nd characters and following text does appear.
![image](https://user-images.githubusercontent.com/518808/221398215-948e8556-ff76-41e6-8e85-58f52354ae60.png)

I wrote patch with test.
Check it out.

--
Best regards,
Hirohito Higashi (h_east)