### PR TITLE
fix: Lua indentation

### DIFF
--- a/runtime/indent/lua.vim
+++ b/runtime/indent/lua.vim
@@ -4,6 +4,8 @@
 " First Author:	Max Ischenko <mfi 'at' ukr.net>
 " Last Change:	2017 Jun 13
 "		2022 Sep 07: b:undo_indent added by Doug Kearns
+"		2023 Feb 26: fix: commented bracket not ignored if inside
+"		nested syntax (added by github user lacygoill)
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -42,7 +44,8 @@ function! GetLuaIndent()
   let midx = match(prevline, '^\s*\%(if\>\|for\>\|while\>\|repeat\>\|else\>\|elseif\>\|do\>\|then\>\)')
   if midx == -1
     let midx = match(prevline, '{\s*$')
-    if midx == -1
+
+    if midx == -1 || s:IsCommented(prevlnum, midx + 1)
       let midx = match(prevline, '\<function\>\s*\%(\k\|[.:]\)\{-}\s*(')
     endif
   endif
@@ -63,4 +66,9 @@ function! GetLuaIndent()
   endif
 
   return ind
+endfunction
+
+function s:IsCommented(lnum, col) abort
+  return synstack(a:lnum, a:col)
+      \ ->indexof({_, id -> id->synIDattr('name') == 'luaComment'}) >= 0
 endfunction

--- a/runtime/indent/lua.vim
+++ b/runtime/indent/lua.vim
@@ -44,7 +44,6 @@ function! GetLuaIndent()
   let midx = match(prevline, '^\s*\%(if\>\|for\>\|while\>\|repeat\>\|else\>\|elseif\>\|do\>\|then\>\)')
   if midx == -1
     let midx = match(prevline, '{\s*$')
-
     if midx == -1 || s:IsCommented(prevlnum, midx + 1)
       let midx = match(prevline, '\<function\>\s*\%(\k\|[.:]\)\{-}\s*(')
     endif

--- a/runtime/indent/lua.vim
+++ b/runtime/indent/lua.vim
@@ -69,5 +69,5 @@ endfunction
 
 function s:IsCommented(lnum, col) abort
   return synstack(a:lnum, a:col)
-      \ ->indexof({_, id -> id->synIDattr('name') == 'luaComment'}) >= 0
+      \ ->indexof({_, id -> synIDattr(id, 'name') == 'luaComment'}) >= 0
 endfunction

--- a/runtime/indent/testdir/lua.in
+++ b/runtime/indent/testdir/lua.in
@@ -1,0 +1,7 @@
+-- vim: set ft=lua sw=2 et:
+
+-- START_INDENT
+-- INDENT_EXE syntax match luaFoldMarkers /{{{\d*/ contained containedin=luaComment
+-- some comment with a fold marker {{{
+-- some other comment
+-- END_INDENT

--- a/runtime/indent/testdir/lua.ok
+++ b/runtime/indent/testdir/lua.ok
@@ -1,0 +1,7 @@
+-- vim: set ft=lua sw=2 et:
+
+-- START_INDENT
+-- INDENT_EXE syntax match luaFoldMarkers /{{{\d*/ contained containedin=luaComment
+-- some comment with a fold marker {{{
+-- some other comment
+-- END_INDENT


### PR DESCRIPTION
The Lua indent plugin does not ignore a commented bracket if it's inside a nested syntax. It should.

MRE:

    vim -Nu NONE -S <(tee <<'EOF'
        vim9script
        filetype plugin indent on
        syntax on
        &filetype = 'lua'
        syntax match luaFoldMarkers /{{{\d*/ contained containedin=luaComment
        var lines =<< trim END
        -- some comment with a fold marker {{{
        -- some other comment
        END
        lines->setline(1)
        normal! gg=G
    EOF
    )

Expected:

    -- some comment with a fold marker {{{
    -- some other comment

Actual:

    -- some comment with a fold marker {{{
            -- some other comment

The proposed patch fixes the issue and includes a test.
A similar patch was merged in [this PR](https://github.com/vim/vim/pull/10921).
