### PR TITLE
use indexof() to optimize and simplify runtime files

### DIFF
--- a/runtime/autoload/dist/vimindent.vim
+++ b/runtime/autoload/dist/vimindent.vim
@@ -1046,13 +1046,8 @@ def Is_IN_KeywordForLoop(line_1: string, line_2: string): bool # {{{3
 enddef
 
 def InCommentOrString(): bool # {{{3
-    for synID: number in synstack('.', col('.'))
-        if synIDattr(synID, 'name') =~ '\ccomment\|string\|heredoc'
-            return true
-        endif
-    endfor
-
-    return false
+    return synstack('.', col('.'))
+        ->indexof((_, id: number): bool => synIDattr(id, 'name') =~ '\ccomment\|string\|heredoc') >= 0
 enddef
 
 def AlsoClosesBlock(line_B: dict<any>): bool # {{{3

--- a/runtime/autoload/python.vim
+++ b/runtime/autoload/python.vim
@@ -22,8 +22,7 @@ let s:maxoff = 50       " maximum number of lines to look backwards for ()
 function s:SearchBracket(fromlnum, flags)
   return searchpairpos('[[({]', '', '[])}]', a:flags,
           \ {-> synstack('.', col('.'))
-          \   ->map({_, id -> id->synIDattr('name')})
-          \   ->match('\%(Comment\|Todo\|String\)$') >= 0},
+          \ ->indexof({_, id -> synIDattr(id, 'name') =~ '\%(Comment\|Todo\|String\)$'}) >= 0},
           \ [0, a:fromlnum - s:maxoff]->max(), g:python_indent.searchpair_timeout)
 endfunction
 
@@ -157,15 +156,13 @@ function python#GetIndent(lnum, ...)
     " the start of the comment.  synID() is slow, a linear search would take
     " too long on a long line.
     if synstack(plnum, pline_len)
-    \ ->map({_, id -> id->synIDattr('name')})
-    \ ->match('\%(Comment\|Todo\)$') >= 0
+    \ ->indexof({_, id -> synIDattr(id, 'name') =~ '\%(Comment\|Todo\)$'}) >= 0
       let min = 1
       let max = pline_len
       while min < max
 	let col = (min + max) / 2
         if synstack(plnum, col)
-        \ ->map({_, id -> id->synIDattr('name')})
-        \ ->match('\%(Comment\|Todo\)$') >= 0
+        \ ->indexof({_, id -> synIDattr(id, 'name') =~ '\%(Comment\|Todo\)$'}) >= 0
 	  let max = col
 	else
 	  let min = col + 1

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -108,8 +108,9 @@ func s:Highlight_Matching_Pair()
     " searchpairpos()'s skip argument.
     " We match "escape" for special items, such as lispEscapeSpecial, and
     " match "symbol" for lispBarSymbol.
-    let s_skip = '!empty(filter(map(synstack(line("."), col(".")), ''synIDattr(v:val, "name")''), ' .
-	\ '''v:val =~? "string\\|character\\|singlequote\\|escape\\|symbol\\|comment"''))'
+    let s_skip = 'synstack(".", col("."))'
+        \ . '->indexof({_, id -> synIDattr(id, "name") =~? '
+        \ . '"string\\|character\\|singlequote\\|escape\\|symbol\\|comment"}) >= 0'
     " If executing the expression determines that the cursor is currently in
     " one of the syntax types, then we want searchpairpos() to find the pair
     " within those syntax types (i.e., not skip).  Otherwise, the cursor is


### PR DESCRIPTION
In the runtime files, we sometimes use hard to read and costly combinations of `synstack()` + `map()` + other function calls.  `indexof()` lets us simplify the code (by removing 1 or 2 function calls) and make it a bit faster.

I've run the indent tests, and they still pass.
