### PR TITLE
Properly fix build error on old macOS / Xcode with clockid_t

### DIFF
--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -272,7 +272,8 @@
 
 # include <dispatch/dispatch.h>
 
-# ifndef MAC_OS_X_VERSION_10_12
+# if !defined(MAC_OS_X_VERSION_10_12) || \
+	(MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12)
 typedef int clockid_t;
 # endif
 # ifndef CLOCK_REALTIME


### PR DESCRIPTION
PR #10549 attempted to fix a build break on older Xcode versions (Xcode 8 / macOS 10.11 SDK), but it did it in a way that's not very reliable. In particular, it did it just by checking whether
`MAC_OS_X_VERSION_10_12` exists, but that macro is just the version number for 10.12 SDK. In MacVim, we manually define it to allow us to do version checks. As a result, MacVim builds would fail on macOS 10.11 SDKs (or below).

Instead, the proper fix is to check `MAC_OS_X_VERSION_MAX_ALLOWED` against `MAC_OS_X_VERSION_10_12`. The "max allowed" value is the version of the SDK we are building with and it will be properly defined. The previous bug that the PR was trying to fix was that it was using `MAC_OS_X_VERSION_MIN_REQUIRED` instead, which is the "deployment target" of the build and wasn't the right value to use.

See https://github.com/macvim-dev/macvim/pull/1372