### PR TITLE
Add comment support to netrc file syntax

### DIFF
--- a/runtime/ftplugin/netrc.vim
+++ b/runtime/ftplugin/netrc.vim
@@ -13,7 +13,7 @@ set cpo&vim
 
 let b:undo_ftplugin = "setl com< cms< fo<"
 
-setlocal comments= commentstring= formatoptions-=tcroq formatoptions+=l
+setlocal comments=b:# commentstring=#\ %s formatoptions-=tcroq formatoptions+=l
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/syntax/netrc.vim
+++ b/runtime/syntax/netrc.vim
@@ -35,6 +35,8 @@ syn keyword netrcSpecial    contained anonymous
 syn match   netrcInit       contained '\<init$'
                           \ nextgroup=netrcMacro skipwhite skipnl
 
+syn match   netrcComment    '#.*$'
+
 syn sync fromstart
 
 hi def link netrcKeyword    Keyword
@@ -45,6 +47,7 @@ hi def link netrcPassword   String
 hi def link netrcMacroName  String
 hi def link netrcSpecial    Special
 hi def link netrcInit       Special
+hi def link netrcComment    Comment
 
 let b:current_syntax = "netrc"
 


### PR DESCRIPTION
The netrc format definition doesn't seem to officially support comments, but both curl and python's netrc parser implementations respect a leading octothorp as a comment character. This adds support for highlighting those as such.