### PR TITLE
test_options: Check for toolbariconsize support explicitly

### DIFF
--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1642,6 +1642,8 @@ func Test_string_option_revert_on_failure()
   endif
   if exists('+toolbar')
     call add(optlist, ['toolbar', 'text', 'a123'])
+  endif
+  if exists('+toolbariconsize')
     call add(optlist, ['toolbariconsize', 'medium', 'a123'])
   endif
   if exists('+ttymouse') && !has('gui')


### PR DESCRIPTION
Not all GUIs (e.g., motif) which support toolbar also support toolbariconsize.