### PR TITLE
Fix: SEGV using null_object for method call

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -256,6 +256,24 @@ def Test_object_not_set()
   lines =<< trim END
       vim9script
 
+      class Class
+          this.id: string
+          def Method1()
+              echo 'Method1' .. this.id
+          enddef
+      endclass
+
+      var obj = null_object
+      def Func()
+          obj.Method1()
+      enddef
+      Func()
+  END
+  v9.CheckScriptFailure(lines, 'E685:')
+
+  lines =<< trim END
+      vim9script
+
       class Background
         this.background = 'dark'
       endclass

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -264,6 +264,15 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
     }
 
     class_T *cl = type->tt_class;
+    if (cl == NULL)
+    {
+	    // TODO: Possibly related to #12089? Might handle as part of
+	    //	     dynamic method resolution for class hierarchy?
+	    //	     Otherwise: emsg(_(e_using_null_object));
+	    semsg(_(e_internal_error_str),
+				"compile untyped object method reference");
+	    return FAIL;
+    }
     int is_super = type->tt_flags & TTFLAG_SUPER;
     if (type == &t_super)
     {


### PR DESCRIPTION
Solves the SEGV. Gives "internal error"; placeholder depending of actual fix.
May be related to #12089.