### PR TITLE
Problem: ACCESS_* enum naming conflicts on some systems.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1576,11 +1576,11 @@ get_lval(
 			{
 			    switch (om->ocm_access)
 			    {
-				case ACCESS_PRIVATE:
+				case VIM_ACCESS_PRIVATE:
 					semsg(_(e_cannot_access_private_member_str),
 								 om->ocm_name);
 					return NULL;
-				case ACCESS_READ:
+				case VIM_ACCESS_READ:
 					if ((flags & GLV_READ_ONLY) == 0)
 					{
 					    semsg(_(e_member_is_not_writable_str),
@@ -1588,7 +1588,7 @@ get_lval(
 					    return NULL;
 					}
 					break;
-				case ACCESS_ALL:
+				case VIM_ACCESS_ALL:
 					break;
 			    }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3830,7 +3830,7 @@ vim_rename(char_u *from, char_u *to)
      * original file will be somewhere else so the backup isn't really
      * important. If autoscripting is off the rename may fail.
      */
-    flock = Lock((UBYTE *)from, (long)ACCESS_READ);
+    flock = Lock((UBYTE *)from, (long)VIM_ACCESS_READ);
 #endif
     mch_remove(to);
 #ifdef AMIGA

--- a/src/structs.h
+++ b/src/structs.h
@@ -1469,9 +1469,9 @@ typedef struct {
 #define TTFLAG_SUPER	    0x40    // object from "super".
 
 typedef enum {
-    ACCESS_PRIVATE,	// read/write only inside th class
-    ACCESS_READ,	// read everywhere, write only inside th class
-    ACCESS_ALL		// read/write everywhere
+    VIM_ACCESS_PRIVATE,	// read/write only inside th class
+    VIM_ACCESS_READ,	// read everywhere, write only inside th class
+    VIM_ACCESS_ALL	// read/write everywhere
 } omacc_T;
 
 /*

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -148,8 +148,8 @@ add_member(
 	return FAIL;
     ocmember_T *m = ((ocmember_T *)gap->ga_data) + gap->ga_len;
     m->ocm_name = vim_strnsave(varname, varname_end - varname);
-    m->ocm_access = has_public ? ACCESS_ALL
-			      : *varname == '_' ? ACCESS_PRIVATE : ACCESS_READ;
+    m->ocm_access = has_public ? VIM_ACCESS_ALL
+			      : *varname == '_' ? VIM_ACCESS_PRIVATE : VIM_ACCESS_READ;
     m->ocm_type = type;
     if (init_expr != NULL)
 	m->ocm_init = init_expr;


### PR DESCRIPTION
Solution: Add VIM_ prefix to avoid conflicts.