### PR TITLE
Problem: Amiga: Hostname not used.

### DIFF
--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -691,7 +691,7 @@ mch_get_user_name(char_u *s, int len)
     void
 mch_get_host_name(char_u *s, int len)
 {
-#if defined(__amigaos4__) && defined(__CLIB2__)
+#if !defined(__AROS__)
     gethostname(s, len);
 #else
     vim_strncpy(s, "Amiga", len - 1);


### PR DESCRIPTION
Solution: Use gethostname() on all Amiga-like systems except AROS.