### PR TITLE
Don't error when pressing ESC after "g'" or "g`"

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -899,7 +899,7 @@ normal_cmd(
 
     State = MODE_NORMAL;
 
-    if (ca.nchar == ESC)
+    if (ca.nchar == ESC || ca.extra_char == ESC)
     {
 	clearop(oap);
 	if (restart_edit == 0 && goto_im())
@@ -984,7 +984,8 @@ normal_end:
 #ifdef CURSOR_SHAPE
     // Redraw the cursor with another shape, if we were in Operator-pending
     // mode or did a replace command.
-    if (prev_finish_op || ca.cmdchar == 'r')
+    if (prev_finish_op || ca.cmdchar == 'r'
+				     || (ca.cmdchar == 'g' && ca.nchar == 'r'))
     {
 	ui_cursor_shape();		// may show different cursor shape
 # ifdef FEAT_MOUSESHAPE
@@ -5025,7 +5026,7 @@ nv_vreplace(cmdarg_T *cap)
 	return;
     }
 
-    if (checkclearopq(cap->oap) || cap->extra_char == ESC)
+    if (checkclearopq(cap->oap))
 	return;
 
     if (!curbuf->b_p_ma)
@@ -5903,7 +5904,7 @@ nv_g_cmd(cmdarg_T *cap)
 	else
 #endif
     // "g^A/g^X": sequentially increment visually selected region
-	     if (VIsual_active)
+	if (VIsual_active)
 	{
 	    cap->arg = TRUE;
 	    cap->cmdchar = cap->nchar;

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -2526,6 +2526,8 @@ func Test_normal33_g_cmd2()
   norm! g'a
   call assert_equal('>', a[-1:])
   call assert_equal(1, line('.'))
+  call assert_nobeep("normal! g`\<Esc>")
+  call assert_nobeep("normal! g'\<Esc>")
 
   " Test for g; and g,
   norm! g;
@@ -3305,7 +3307,8 @@ func Test_gr_command()
   set modifiable&
 
   call assert_nobeep("normal! gr\<Esc>")
-  call assert_beeps("normal! cgr\<Esc>")
+  call assert_nobeep("normal! cgr\<Esc>")
+  call assert_beeps("normal! cgrx")
 
   call assert_equal('zxxxx line    l', getline(1))
   exe "normal! 2|gr\<C-V>\<Esc>"
@@ -3917,6 +3920,38 @@ func Test_mouse_shape_after_failed_change()
   call RunVim([], [], "-g -S Xmouseshape.vim")
   sleep 300m
   call assert_equal(['busy', 'arrow'], readfile('Xmouseshapes'))
+
+  call delete('Xmouseshapes')
+endfunc
+
+" Test that mouse shape is restored to Normal mode after cancelling "gr".
+func Test_mouse_shape_after_cancelling_gr()
+  CheckFeature mouseshape
+  CheckCanRunGui
+
+  let lines =<< trim END
+    vim9script
+    var mouse_shapes = []
+
+    feedkeys('gr')
+    timer_start(50, (_) => {
+      mouse_shapes += [getmouseshape()]
+      timer_start(50, (_) => {
+        feedkeys("\<Esc>")
+        timer_start(50, (_) => {
+          mouse_shapes += [getmouseshape()]
+          timer_start(50, (_) => {
+            writefile(mouse_shapes, 'Xmouseshapes')
+            quit
+          })
+        })
+      })
+    })
+  END
+  call writefile(lines, 'Xmouseshape.vim', 'D')
+  call RunVim([], [], "-g -S Xmouseshape.vim")
+  sleep 300m
+  call assert_equal(['beam', 'arrow'], readfile('Xmouseshapes'))
 
   call delete('Xmouseshapes')
 endfunc


### PR DESCRIPTION
This is more consist with "'" and "`".
Also fix a problem that cursor shape remains in replace mode after
cancelling "gr" with ESC.
