### PR TITLE
Fix Test_debug_option() fail with certain terminal size and path length

### DIFF
--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -2526,8 +2526,11 @@ func Test_normal33_g_cmd2()
   norm! g'a
   call assert_equal('>', a[-1:])
   call assert_equal(1, line('.'))
+  let v:errmsg = ''
   call assert_nobeep("normal! g`\<Esc>")
+  call assert_equal('', v:errmsg)
   call assert_nobeep("normal! g'\<Esc>")
+  call assert_equal('', v:errmsg)
 
   " Test for g; and g,
   norm! g;

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1058,8 +1058,8 @@ func Test_debug_option()
   exe "normal \<C-c>"
   call assert_equal('Beep!', Screenline(&lines))
   call assert_equal('line    4:', Screenline(&lines - 1))
-  " only match the final colon in the line that shows the source
-  call assert_match(':$', Screenline(&lines - 2))
+  call assert_match('Test_debug_option:$',
+        \ Screenline(&lines - 3) .. Screenline(&lines - 2))
   set debug&
 endfunc
 


### PR DESCRIPTION
If the length of the line with the source is exactly the same as
terminal width, it still wraps and the next line is empty. Also check
the line above it.
