### PR TITLE
fixed netrw copying files in the same directory (trailing slash issue)

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -7124,7 +7124,7 @@ fun! s:NetrwMarkFileCopy(islocal,...)
    endif
 
    " copy marked files while within the same directory (ie. allow renaming)
-   if simplify(s:netrwmftgt) == simplify(b:netrw_curdir)
+   if netrw#StripTrailingSlash( simplify(s:netrwmftgt) ) == netrw#StripTrailingSlash( simplify(b:netrw_curdir) )
     if len(s:netrwmarkfilelist_{bufnr('%')}) == 1
      " only one marked file
 "     call Decho("case: only one marked file",'~'.expand("<slnum>"))
@@ -7201,7 +7201,7 @@ fun! s:NetrwMarkFileCopy(islocal,...)
 "   call Decho("system(".copycmd." '".args."' '".tgt."')",'~'.expand("<slnum>"))
    call system(copycmd.g:netrw_localcopycmdopt." '".args."' '".tgt."'")
    if v:shell_error != 0
-    if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && !g:netrw_keepdir
+    if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && g:netrw_keepdir
      call netrw#ErrorMsg(s:ERROR,"copy failed; perhaps due to vim's current directory<".getcwd()."> not matching netrw's (".b:netrw_curdir.") (see :help netrw-cd)",101)
     else
      call netrw#ErrorMsg(s:ERROR,"tried using g:netrw_localcopycmd<".g:netrw_localcopycmd.">; it doesn't work!",80)
@@ -11564,6 +11564,17 @@ fun! netrw#WinPath(path)
 "  call Dret("netrw#WinPath <".path.">")
   return path
 endfun
+
+" ---------------------------------------------------------------------
+" netrw#StripTrailingSlash: removes trailing slashes from a path
+fun! netrw#StripTrailingSlash(path)
+"  call Dfunc("netrw#StripTrailingSlash(path<".a:path.">)")
+   " remove trailing slash
+   let path = substitute(a:path, '\(\\\|/\)$', '', 'g')
+"  call Dret("netrw#StripTrailingSlash <".path.">")
+  return path
+endfun
+
 
 " ---------------------------------------------------------------------
 " s:NetrwBadd: adds marked files to buffer list or vice versa {{{2


### PR DESCRIPTION
Addressing these issues:

- https://groups.google.com/g/vim_use/c/6yqU3RX2CWA
- https://vi.stackexchange.com/questions/17450/copy-a-file-in-netrw

TLDR when you press `mt`, `mf`, then `mc` it tries to allow you to copy to a newly named file in the same dir it but it actually doesn't work.

The problem is `s:netrwmftgt` has no trailing slash, and `b:netrw_curdir` does,  for example `/home/me/dir` and `/home/me/dir/` so when it compares the two it thinks they are different directories. So no new filename prompt. Additionally the error message doesn't show.  `g:netrw_keepdir` defaults to `1`, meaning it should check if it IS indeed `1`, the original code checked if it was not `1`. 