### PR TITLE
Make the "Diff_with_Vim" use vertical splits

### DIFF
--- a/src/GvimExt/gvimext.cpp
+++ b/src/GvimExt/gvimext.cpp
@@ -907,7 +907,7 @@ STDMETHODIMP CShellExt::InvokeSingleGvim(HWND hParent,
     getGvimInvocationW(cmdStrW);
 
     if (gvimExtraOptions == EDIT_WITH_VIM_IN_DIFF_MODE)
-	wcscat(cmdStrW, L" -d");
+	wcscat(cmdStrW, L" -d -O");
     else if (gvimExtraOptions == EDIT_WITH_VIM_USE_TABPAGES)
 	wcscat(cmdStrW, L" -p");
     for (i = 0; i < cbFiles; i++)


### PR DESCRIPTION
I find it more naturally to view diffs in vertical splits, so please consider this change.