### PR TITLE
For profiling, use CLOCK_MONOTONIC if available.

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7150,7 +7150,8 @@ reltimestr({time})				*reltimestr()*
 			call MyFunction()
 			echo reltimestr(reltime(start))
 <		Note that overhead for the commands will be added to the time.
-		The accuracy depends on the system.
+		The accuracy depends on the system. Use reltimefloat() for the
+		greatest accuracy which is nanoseconds on some systems.
 		Leading spaces are used to make the string align nicely.  You
 		can use split() to remove it. >
 			echo split(reltimestr(reltime(start)))[0]
@@ -10753,6 +10754,7 @@ persistent_undo		Compiled with support for persistent undo history.
 postscript		Compiled with PostScript file printing.
 printer			Compiled with |:hardcopy| support.
 profile			Compiled with |:profile| support.
+prof_nsec		Profile results are in nano seconds.
 python			Python 2.x interface available. |has-python|
 python_compiled		Compiled with Python 2.x interface. |has-python|
 python_dynamic		Python 2.x interface is dynamically loaded. |has-python|

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -1148,9 +1148,10 @@ long you take to respond to the input() prompt is irrelevant.
 Profiling should give a good indication of where time is spent, but keep in
 mind there are various things that may clobber the results:
 
-- The accuracy of the time measured depends on the gettimeofday() system
-  function.  It may only be as accurate as 1/100 second, even though the times
-  are displayed in micro seconds.
+- The accuracy of the time measured depends on the gettimeofday(), or
+  clock_gettime if available, system function. The accuracy ranges from 1/100
+  second to nano seconds. With clock_gettime the times are displayed in nano
+  seconds, otherwise micro seconds.
 
 - Real elapsed time is measured, if other processes are busy they may cause
   delays at unpredictable moments.  You may want to run the profiling several

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6145,6 +6145,13 @@ f_has(typval_T *argvars, typval_T *rettv)
 		0
 #endif
 		},
+	{"prof_nsec",
+#ifdef HAVE_TIMER_CREATE
+		1
+#else
+		0
+#endif
+		},
 	{"reltime",
 #ifdef FEAT_RELTIME
 		1
@@ -8226,7 +8233,7 @@ init_srand(UINT32_T *x)
 #  if defined(MSWIN)
 	    *x = (UINT32_T)res.LowPart;
 #  else
-	    *x = (UINT32_T)res.tv_usec;
+	    *x = (UINT32_T)res.tv_fsec;
 #  endif
 #else
 	    *x = vim_time();

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -24,7 +24,7 @@ profile_start(proftime_T *tm)
 # ifdef MSWIN
     QueryPerformanceCounter(tm);
 # else
-    gettimeofday(tm, NULL);
+    PROF_GET_TIME(tm);
 # endif
 }
 
@@ -40,12 +40,12 @@ profile_end(proftime_T *tm)
     QueryPerformanceCounter(&now);
     tm->QuadPart = now.QuadPart - tm->QuadPart;
 # else
-    gettimeofday(&now, NULL);
-    tm->tv_usec = now.tv_usec - tm->tv_usec;
+    PROF_GET_TIME(&now);
+    tm->tv_fsec = now.tv_fsec - tm->tv_fsec;
     tm->tv_sec = now.tv_sec - tm->tv_sec;
-    if (tm->tv_usec < 0)
+    if (tm->tv_fsec < 0)
     {
-	tm->tv_usec += 1000000;
+	tm->tv_fsec += TV_FSEC;
 	--tm->tv_sec;
     }
 # endif
@@ -60,11 +60,11 @@ profile_sub(proftime_T *tm, proftime_T *tm2)
 # ifdef MSWIN
     tm->QuadPart -= tm2->QuadPart;
 # else
-    tm->tv_usec -= tm2->tv_usec;
+    tm->tv_fsec -= tm2->tv_fsec;
     tm->tv_sec -= tm2->tv_sec;
-    if (tm->tv_usec < 0)
+    if (tm->tv_fsec < 0)
     {
-	tm->tv_usec += 1000000;
+	tm->tv_fsec += TV_FSEC;
 	--tm->tv_sec;
     }
 # endif
@@ -85,7 +85,7 @@ profile_msg(proftime_T *tm)
     QueryPerformanceFrequency(&fr);
     sprintf(buf, "%10.6lf", (double)tm->QuadPart / (double)fr.QuadPart);
 # else
-    sprintf(buf, "%3ld.%06ld", (long)tm->tv_sec, (long)tm->tv_usec);
+    sprintf(buf, PROF_TIME_FORMAT, (long)tm->tv_sec, (long)tm->tv_fsec);
 # endif
     return buf;
 }
@@ -102,7 +102,7 @@ profile_float(proftime_T *tm)
     QueryPerformanceFrequency(&fr);
     return (float_T)tm->QuadPart / (float_T)fr.QuadPart;
 # else
-    return (float_T)tm->tv_sec + (float_T)tm->tv_usec / 1000000.0;
+    return (float_T)tm->tv_sec + (float_T)tm->tv_fsec / (float_T)TV_FSEC;
 # endif
 }
 
@@ -123,12 +123,12 @@ profile_setlimit(long msec, proftime_T *tm)
 	QueryPerformanceFrequency(&fr);
 	tm->QuadPart += (LONGLONG)((double)msec / 1000.0 * (double)fr.QuadPart);
 # else
-	long	    usec;
+	long	    fsec;
 
-	gettimeofday(tm, NULL);
-	usec = (long)tm->tv_usec + (long)msec * 1000;
-	tm->tv_usec = usec % 1000000L;
-	tm->tv_sec += usec / 1000000L;
+	PROF_GET_TIME(tm);
+	fsec = (long)tm->tv_fsec + (long)msec * (TV_FSEC / 1000);
+	tm->tv_fsec = fsec % (long)TV_FSEC;
+	tm->tv_sec += fsec / (long)TV_FSEC;
 # endif
     }
 }
@@ -149,9 +149,9 @@ profile_passed_limit(proftime_T *tm)
 # else
     if (tm->tv_sec == 0)    // timer was not set
 	return FALSE;
-    gettimeofday(&now, NULL);
+    PROF_GET_TIME(&now);
     return (now.tv_sec > tm->tv_sec
-	    || (now.tv_sec == tm->tv_sec && now.tv_usec > tm->tv_usec));
+	    || (now.tv_sec == tm->tv_sec && now.tv_fsec > tm->tv_fsec));
 # endif
 }
 
@@ -164,7 +164,7 @@ profile_zero(proftime_T *tm)
 # ifdef MSWIN
     tm->QuadPart = 0;
 # else
-    tm->tv_usec = 0;
+    tm->tv_fsec = 0;
     tm->tv_sec = 0;
 # endif
 }
@@ -189,10 +189,10 @@ profile_divide(proftime_T *tm, int count, proftime_T *tm2)
 # ifdef MSWIN
 	tm2->QuadPart = tm->QuadPart / count;
 # else
-	double usec = (tm->tv_sec * 1000000.0 + tm->tv_usec) / count;
+	double fsec = (tm->tv_sec * (float_T)TV_FSEC + tm->tv_fsec) / count;
 
-	tm2->tv_sec = floor(usec / 1000000.0);
-	tm2->tv_usec = vim_round(usec - (tm2->tv_sec * 1000000.0));
+	tm2->tv_sec = floor(fsec / (float_T)TV_FSEC);
+	tm2->tv_fsec = vim_round(fsec - (tm2->tv_sec * (float_T)TV_FSEC));
 # endif
     }
 }
@@ -213,11 +213,11 @@ profile_add(proftime_T *tm, proftime_T *tm2)
 # ifdef MSWIN
     tm->QuadPart += tm2->QuadPart;
 # else
-    tm->tv_usec += tm2->tv_usec;
+    tm->tv_fsec += tm2->tv_fsec;
     tm->tv_sec += tm2->tv_sec;
-    if (tm->tv_usec >= 1000000)
+    if (tm->tv_fsec >= TV_FSEC)
     {
-	tm->tv_usec -= 1000000;
+	tm->tv_fsec -= TV_FSEC;
 	++tm->tv_sec;
     }
 # endif
@@ -237,7 +237,7 @@ profile_self(proftime_T *self, proftime_T *total, proftime_T *children)
 #else
     if (total->tv_sec < children->tv_sec
 	    || (total->tv_sec == children->tv_sec
-		&& total->tv_usec <= children->tv_usec))
+		&& total->tv_fsec <= children->tv_fsec))
 	return;
 #endif
     profile_add(self, total);
@@ -274,7 +274,7 @@ profile_equal(proftime_T *tm1, proftime_T *tm2)
 # ifdef MSWIN
     return (tm1->QuadPart == tm2->QuadPart);
 # else
-    return (tm1->tv_usec == tm2->tv_usec && tm1->tv_sec == tm2->tv_sec);
+    return (tm1->tv_fsec == tm2->tv_fsec && tm1->tv_sec == tm2->tv_sec);
 # endif
 }
 
@@ -288,7 +288,7 @@ profile_cmp(const proftime_T *tm1, const proftime_T *tm2)
     return (int)(tm2->QuadPart - tm1->QuadPart);
 # else
     if (tm1->tv_sec == tm2->tv_sec)
-	return tm2->tv_usec - tm1->tv_usec;
+	return tm2->tv_fsec - tm1->tv_fsec;
     return tm2->tv_sec - tm1->tv_sec;
 # endif
 }
@@ -551,16 +551,16 @@ prof_func_line(
     {
 	fprintf(fd, "%5d ", count);
 	if (prefer_self && profile_equal(total, self))
-	    fprintf(fd, "           ");
+	    fprintf(fd, PROF_TIME_BLANK);
 	else
 	    fprintf(fd, "%s ", profile_msg(total));
 	if (!prefer_self && profile_equal(total, self))
-	    fprintf(fd, "           ");
+	    fprintf(fd, PROF_TIME_BLANK);
 	else
 	    fprintf(fd, "%s ", profile_msg(self));
     }
     else
-	fprintf(fd, "                            ");
+	fprintf(fd, "      %s%s", PROF_TIME_BLANK, PROF_TIME_BLANK);
 }
 
     static void
@@ -575,7 +575,7 @@ prof_sort_list(
     ufunc_T	*fp;
 
     fprintf(fd, "FUNCTIONS SORTED ON %s TIME\n", title);
-    fprintf(fd, "count  total (s)   self (s)  function\n");
+    fprintf(fd, "%s  function\n", PROF_TOTALS_HEADER);
     for (i = 0; i < 20 && i < st_len; ++i)
     {
 	fp = sorttab[i];
@@ -858,7 +858,7 @@ func_dump_profile(FILE *fd)
 		fprintf(fd, "Total time: %s\n", profile_msg(&fp->uf_tm_total));
 		fprintf(fd, " Self time: %s\n", profile_msg(&fp->uf_tm_self));
 		fprintf(fd, "\n");
-		fprintf(fd, "count  total (s)   self (s)\n");
+		fprintf(fd, "%s\n", PROF_TOTALS_HEADER);
 
 		for (i = 0; i < fp->uf_lines.ga_len; ++i)
 		{
@@ -948,7 +948,7 @@ script_dump_profile(FILE *fd)
 	    fprintf(fd, "Total time: %s\n", profile_msg(&si->sn_pr_total));
 	    fprintf(fd, " Self time: %s\n", profile_msg(&si->sn_pr_self));
 	    fprintf(fd, "\n");
-	    fprintf(fd, "count  total (s)   self (s)\n");
+	    fprintf(fd, "%s\n", PROF_TOTALS_HEADER);
 
 	    sfd = mch_fopen((char *)si->sn_name, "r");
 	    if (sfd == NULL)

--- a/src/testdir/test_profile.vim
+++ b/src/testdir/test_profile.vim
@@ -6,8 +6,13 @@ CheckFeature profile
 source shared.vim
 source screendump.vim
 
-let s:header = 'count  total (s)   self (s)'
-let s:header_func = 'count  total (s)   self (s)  function'
+if has('prof_nsec')
+  let s:header = 'count     total (s)      self (s)'
+  let s:header_func = 'count     total (s)      self (s)  function'
+else
+  let s:header = 'count  total (s)   self (s)'
+  let s:header_func = 'count  total (s)   self (s)  function'
+endif
 
 func Test_profile_func()
   call RunProfileFunc('func', 'let', 'let')

--- a/src/testdir/test_sleep.vim
+++ b/src/testdir/test_sleep.vim
@@ -1,11 +1,7 @@
 " Test for sleep and sleep! commands
 
 func! s:get_time_ms()
-  let timestr = reltimestr(reltime())
-  let dotidx = stridx(timestr, '.')
-  let sec = str2nr(timestr[:dotidx])
-  let msec = str2nr(timestr[dotidx + 1:])
-  return (sec * 1000) + (msec / 1000)
+  return float2nr(reltimefloat(reltime()) * 1000)
 endfunc
 
 func! s:assert_takes_longer(cmd, time_ms)

--- a/src/time.c
+++ b/src/time.c
@@ -163,7 +163,7 @@ list2proftime(typval_T *arg, proftime_T *tm)
     tm->LowPart = n2;
 #  else
     tm->tv_sec = n1;
-    tm->tv_usec = n2;
+    tm->tv_fsec = n2;
 #  endif
     return error ? FAIL : OK;
 }
@@ -222,7 +222,7 @@ f_reltime(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     n2 = res.LowPart;
 #  else
     n1 = res.tv_sec;
-    n2 = res.tv_usec;
+    n2 = res.tv_fsec;
 #  endif
     list_append_number(rettv->vval.v_list, (varnumber_T)n1);
     list_append_number(rettv->vval.v_list, (varnumber_T)n2);
@@ -258,6 +258,7 @@ f_reltimefloat(typval_T *argvars UNUSED, typval_T *rettv)
     void
 f_reltimestr(typval_T *argvars UNUSED, typval_T *rettv)
 {
+    static char buf[50];
 # ifdef FEAT_RELTIME
     proftime_T	tm;
 # endif
@@ -269,7 +270,15 @@ f_reltimestr(typval_T *argvars UNUSED, typval_T *rettv)
 	return;
 
     if (list2proftime(&argvars[0], &tm) == OK)
+    {
+# ifdef MSWIN
 	rettv->vval.v_string = vim_strsave((char_u *)profile_msg(&tm));
+# else
+	long usec = tm.tv_fsec / (TV_FSEC / 1000000);
+	sprintf(buf, "%3ld.%06ld", (long)tm.tv_sec, usec);
+	rettv->vval.v_string = vim_strsave((char_u *)buf);
+# endif
+    }
     else if (in_vim9script())
 	emsg(_(e_invalid_argument));
 # endif
@@ -392,7 +401,7 @@ static timer_T	*first_timer = NULL;
 static long	last_timer_id = 0;
 
 /*
- * Return time left until "due".  Negative if past "due".
+ * Return time left, in "msec", until "due".  Negative if past "due".
  */
     long
 proftime_time_left(proftime_T *due, proftime_T *now)
@@ -409,7 +418,7 @@ proftime_time_left(proftime_T *due, proftime_T *now)
     if (now->tv_sec > due->tv_sec)
 	return 0;
     return (due->tv_sec - now->tv_sec) * 1000
-	+ (due->tv_usec - now->tv_usec) / 1000;
+	+ (due->tv_fsec - now->tv_fsec) / (TV_FSEC / 1000);
 #  endif
 }
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -1869,8 +1869,27 @@ typedef void	    *vim_acl_T;		// dummy to pass an ACL to a function
 #if (defined(FEAT_PROFILE) || defined(FEAT_RELTIME)) && !defined(PROTO)
 # ifdef MSWIN
 typedef LARGE_INTEGER proftime_T;
+#  define PROF_TIME_BLANK "           "
+#  define PROF_TOTALS_HEADER "count  total (s)   self (s)"
 # else
+   // Use tv_fsec for fraction of second (micro or nano) of proftime_T
+#  if defined(HAVE_TIMER_CREATE)
+typedef struct timespec proftime_T;
+#   define PROF_GET_TIME(tm) clock_gettime(CLOCK_MONOTONIC, tm)
+#   define tv_fsec tv_nsec
+#   define TV_FSEC 1000000000L
+#   define PROF_TIME_FORMAT "%3ld.%09ld"
+#   define PROF_TIME_BLANK "              "
+#   define PROF_TOTALS_HEADER "count     total (s)      self (s)"
+#  else
 typedef struct timeval proftime_T;
+#   define PROF_GET_TIME(tm) gettimeofday(tm, NULL)
+#   define tv_fsec tv_usec
+#   define TV_FSEC 1000000
+#   define PROF_TIME_FORMAT "%3ld.%06ld"
+#   define PROF_TIME_BLANK "           "
+#   define PROF_TOTALS_HEADER "count  total (s)   self (s)"
+#  endif
 # endif
 #else
 typedef int proftime_T;	    // dummy for function prototypes


### PR DESCRIPTION
NOTE: profiling with `CLOCK_MONOTONIC` is enabled based on
`HAVE_TIMER_CREATE`; that is probably sufficient but a more specific test
could be added to `configure.ac`.

This PR modifies profiling to use `CLOCK_MONOTONIC`, nsec resolution, when
available. Current profiling uses `clockgettime()`, usec resolution, which
isn't suitable for micro benchmarking, where many lines of vimscript are
around a micro-second or less. The initial results show high accuracy as
indicated by the low standard deviation. The results suggest that, when
using CLOCK_MONOTONIC, meaningful data could be obtained from vim9script VM
instruction level profiling (something to consider in the future).

Below are two sets of profiling results for the given vim9 function. The
first uses `CLOCK_MONOTONIC`, the second `gettimeofday()`. A column reports
the function execution `nKeys * 10` times; and there are seven runs. Each
script line has three rows of output

- the usec per/script line, the fastest run as recommended
- average value
- standard deviation

There were occasional outliers and the tabulator was modified to throw out
the slowest result before computing the standard deviation. This got rid of
almost all high SD values in the NEW results, but the OLD results are still
messy. I'm curious about what the occasional interrupt/pause/whatever might
be.

```
def A_play2(_d: dict<list<number>>, _k: string, _v: list<number>): number
    var entry = 1               ###-0
    NullFunction(4)             ###-1
    var k = _k                  ###-2
    var d = _d                  ###-3
    d = {x: []}                 ###-4
    var e = {x: []}             ###-5
    var vdict = {[_k]: _v}      ###-6
    d->extend(vdict, 'keep')    ###-8
    var ret = 2                 ###-9
    return 1
enddef
```

=== NEW - CLOCK_MONOTONIC - toss out largest value for standard deviation

```
$ ./summarize | ./keys_algo_table 
     10     30     65    100    200    300 : nKeys (micro-sec/algorithm)
  0.023  0.024  0.023  0.023  0.023  0.023 : var entry = 1   ###-0
  0.024  0.024  0.023  0.023  0.023  0.025 :     average
  2.94%  0.30%  1.66%  0.92%  1.51%  9.40% :     std dev as % of avg
  0.420  1.675  3.172  4.158  5.556  6.989 : NullFunction(4)   ###-1
  1.002  2.145  3.530  4.758  5.965  7.415 :     average
 41.68% 16.66% 11.22%  7.31%  5.90%  5.27% :     std dev as % of avg
  0.063  0.064  0.103  0.107  0.107  0.098 : var k = _k   ###-2
  0.064  0.083  0.107  0.110  0.110  0.110 :     average
  2.06% 25.02%  3.10%  4.94%  1.60%  5.81% :     std dev as % of avg
  0.104  0.163  0.298  0.370  0.908  1.173 : var d = _d   ###-3
  0.106  0.163  0.323  0.388  0.922  1.213 :     average
  1.32%  0.23%  7.57%  3.45%  1.70%  1.94% :     std dev as % of avg
  0.166  0.166  0.158  0.161  0.179  0.231 : d = {x: []}   ###-4
  0.169  0.167  0.166  0.167  0.186  0.244 :     average
  1.78%  0.49%  5.84%  4.94%  2.53%  3.22% :     std dev as % of avg
  0.128  0.128  0.127  0.126  0.131  0.139 : var e = {x: []}   ###-5
  0.133  0.131  0.129  0.136  0.136  0.145 :     average
  2.18%  1.22%  1.76%  7.95%  3.17%  2.29% :     std dev as % of avg
  0.162  0.166  0.155  0.163  0.169  0.172 : var vdict = {[_k]: _v}   ###-6
  0.164  0.170  0.172  0.169  0.172  0.177 :     average
  1.50%  2.08% 13.54%  3.84%  1.54%  2.45% :     std dev as % of avg
  0.289  0.290  0.280  0.280  0.279  0.283 : d->extend(vdict, 'keep')   ###-8
  0.293  0.294  0.294  0.290  0.283  0.294 :     average
  0.94%  1.02%  4.08%  2.89%  0.82%  2.20% :     std dev as % of avg
  0.033  0.033  0.032  0.032  0.035  0.035 : var ret = 2   ###-9
  0.033  0.033  0.032  0.032  0.035  0.037 :     average
  0.58%  0.10%  3.33%  1.59%  0.87%  8.16% :     std dev as % of avg
```


=== OLD - gettimeofday - toss out largest value for standard deviation

```
$ ./summarize | ./keys_algo_table 
     10     30     65    100    200    300 : nKeys (micro-sec/algorithm)
  0.000  0.010  0.014  0.025  0.018  0.011 : var entry = 1   ###-0
  0.022  0.023  0.026  0.028  0.023  0.024 :     average
 67.94% 45.18% 56.29%  8.32% 21.57% 28.72% :     std dev as % of avg
  0.450  1.757  3.303  4.449  5.601  7.018 : NullFunction(4)   ###-1
  0.943  2.263  3.667  4.898  6.091  7.445 :     average
 37.47% 16.53%  8.44%  6.67%  6.07%  4.97% :     std dev as % of avg
  0.020  0.040  0.072  0.080  0.052  0.025 : var k = _k   ###-2
  0.053  0.085  0.088  0.095  0.092  0.094 :     average
 45.41% 39.66% 12.60% 15.94% 28.79% 36.34% :     std dev as % of avg
  0.060  0.130  0.278  0.290  0.832  1.049 : var d = _d   ###-3
  0.092  0.150  0.305  0.353  0.855  1.064 :     average
 25.27%  8.20%  9.66% 10.12%  1.56%  1.00% :     std dev as % of avg
  0.080  0.150  0.148  0.146  0.090  0.165 : d = {x: []}   ###-4
  0.142  0.162  0.167  0.155  0.149  0.177 :     average
 28.73%  8.22% 17.35%  4.50% 23.36%  7.73% :     std dev as % of avg
  0.080  0.107  0.120  0.104  0.115  0.128 : var e = {x: []}   ###-5
  0.110  0.119  0.129  0.145  0.162  0.141 :     average
 19.07%  9.33%  6.26% 17.33% 18.00%  9.35% :     std dev as % of avg
  0.140  0.120  0.149  0.135  0.129  0.157 : var vdict: dict<list<number>> = {[_k]: _v}   ###-6
  0.162  0.141  0.172  0.151  0.156  0.169 :     average
 10.65% 13.86%  9.32% 11.10% 13.20%  4.31% :     std dev as % of avg
  0.200  0.267  0.255  0.226  0.196  0.189 : d->extend(vdict, 'keep')   ###-8
  0.295  0.301  0.292  0.278  0.271  0.281 :     average
 19.27%  7.27% 11.09%  9.76% 13.53% 16.07% :     std dev as % of avg
  0.010  0.017  0.025  0.030  0.026  0.008 : var ret = 2   ###-9
  0.032  0.037  0.036  0.035  0.035  0.034 :     average
 67.48% 36.36% 26.67%  9.85% 14.54% 38.46% :     std dev as % of avg
```
