### PR TITLE
XXD: color-support feature

### DIFF
--- a/runtime/doc/xxd.1
+++ b/runtime/doc/xxd.1
@@ -135,6 +135,12 @@ to read plain hexadecimal dumps without line number information and without a
 particular column layout. Additional Whitespace and line-breaks are allowed
 anywhere.
 .TP
+.IR \-R " "[WHEN]
+In output the hex-value and the value are both colored with the same color depending on the hex-value. Mostly helping to differentiate printable and non-printable characters.
+.I WHEN
+is
+.BR never ", " always ", or " auto .
+.TP
 .I \-seek offset
 When used after
 .IR \-r :

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -415,4 +415,132 @@ func Test_xxd_little_endian_with_cols()
   bwipe!
 endfunc
 
+func Test_xxd_color()
+  "Test: color=never
+  let s:test = 1
+
+  "Note Quotation mark escaped
+  "Note Aposhpere vaihdettu apostrophe replaced with 0x00
+  "Note Backslash replaced with 0x00
+  let data = [
+      \ "00000000: 0001 0203 0405 0607 0809 0a0b 0c0d 0e0f  ................",
+      \ "00000010: 1011 1213 1415 1617 1819 1a1b 1c1d 1e1f  ................",
+      \ "00000020: 2021 2223 2425 2600 2829 2a2b 2c2d 2e2f   !\"#$%&.()*+,-./",
+      \ "00000030: 3031 3233 3435 3637 3839 3a3b 3c3d 3e3f  0123456789:;<=>?",
+      \ "00000040: 4041 4243 4445 4647 4849 4a4b 4c4d 4e4f  @ABCDEFGHIJKLMNO",
+      \ "00000050: 5051 5253 5455 5657 5859 5a5b 005d 5e5f  PQRSTUVWXYZ[.]^_",
+      \ "00000060: 6061 6263 6465 6667 6869 6a6b 6c6d 6e6f  `abcdefghijklmno",
+      \ "00000070: 7071 7273 7475 7677 7879 7a7b 7c7d 7e7f  pqrstuvwxyz{|}~.",
+      \ "00000080: 8081 8283 8485 8687 8889 8a8b 8c8d 8e8f  ................",
+      \ "00000090: 9091 9293 9495 9697 9899 9a9b 9c9d 9e9f  ................",
+      \ "000000a0: a0a1 a2a3 a4a5 a6a7 a8a9 aaab acad aeaf  ................",
+      \ "000000b0: b0b1 b2b3 b4b5 b6b7 b8b9 babb bcbd bebf  ................",
+      \ "000000c0: c0c1 c2c3 c4c5 c6c7 c8c9 cacb cccd cecf  ................",
+      \ "000000d0: d0d1 d2d3 d4d5 d6d7 d8d9 dadb dcdd dedf  ................",
+      \ "000000e0: e0e1 e2e3 e4e5 e6e7 e8e9 eaeb eced eeef  ................",
+      \ "000000f0: f0f1 f2f3 f4f5 f6f7 f8f9 fafb fcfd feff  ................"]
+  call writefile(data,'Xinput')
+
+  silent exe '!' . s:xxd_cmd . ' -r < Xinput > XXDfile'
+
+  %d
+  exe '0r! ' . s:xxd_cmd . ' -R never ' . ' XXDfile'
+  $d
+  let expected = [
+      \ "00000000: 0001 0203 0405 0607 0809 0a0b 0c0d 0e0f  ................",
+      \ "00000010: 1011 1213 1415 1617 1819 1a1b 1c1d 1e1f  ................",
+      \ "00000020: 2021 2223 2425 2600 2829 2a2b 2c2d 2e2f   !\"#$%&.()*+,-./",
+      \ "00000030: 3031 3233 3435 3637 3839 3a3b 3c3d 3e3f  0123456789:;<=>?",
+      \ "00000040: 4041 4243 4445 4647 4849 4a4b 4c4d 4e4f  @ABCDEFGHIJKLMNO",
+      \ "00000050: 5051 5253 5455 5657 5859 5a5b 005d 5e5f  PQRSTUVWXYZ[.]^_",
+      \ "00000060: 6061 6263 6465 6667 6869 6a6b 6c6d 6e6f  `abcdefghijklmno",
+      \ "00000070: 7071 7273 7475 7677 7879 7a7b 7c7d 7e7f  pqrstuvwxyz{|}~.",
+      \ "00000080: 8081 8283 8485 8687 8889 8a8b 8c8d 8e8f  ................",
+      \ "00000090: 9091 9293 9495 9697 9899 9a9b 9c9d 9e9f  ................",
+      \ "000000a0: a0a1 a2a3 a4a5 a6a7 a8a9 aaab acad aeaf  ................",
+      \ "000000b0: b0b1 b2b3 b4b5 b6b7 b8b9 babb bcbd bebf  ................",
+      \ "000000c0: c0c1 c2c3 c4c5 c6c7 c8c9 cacb cccd cecf  ................",
+      \ "000000d0: d0d1 d2d3 d4d5 d6d7 d8d9 dadb dcdd dedf  ................",
+      \ "000000e0: e0e1 e2e3 e4e5 e6e7 e8e9 eaeb eced eeef  ................",
+      \ "000000f0: f0f1 f2f3 f4f5 f6f7 f8f9 fafb fcfd feff  ................"]
+
+  call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
+
+  "Test: color=always
+  let s:test += 1
+
+  %d
+  exe '0r! ' . s:xxd_cmd . ' -R always -c 4 ' . ' XXDfile'
+  $d
+  let expected = [
+      \ "00000000: \e[1;37m00\e[0m\e[1;31m01\e[0m \e[1;31m02\e[0m\e[1;31m03\e[0m  \e[1;37m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000004: \e[1;31m04\e[0m\e[1;31m05\e[0m \e[1;31m06\e[0m\e[1;31m07\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000008: \e[1;31m08\e[0m\e[1;33m09\e[0m \e[1;33m0a\e[0m\e[1;31m0b\e[0m  \e[1;31m.\e[0m\e[1;33m.\e[0m\e[1;33m.\e[0m\e[1;31m.\e[0m",
+      \ "0000000c: \e[1;31m0c\e[0m\e[1;33m0d\e[0m \e[1;31m0e\e[0m\e[1;31m0f\e[0m  \e[1;31m.\e[0m\e[1;33m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000010: \e[1;31m10\e[0m\e[1;31m11\e[0m \e[1;31m12\e[0m\e[1;31m13\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000014: \e[1;31m14\e[0m\e[1;31m15\e[0m \e[1;31m16\e[0m\e[1;31m17\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000018: \e[1;31m18\e[0m\e[1;31m19\e[0m \e[1;31m1a\e[0m\e[1;31m1b\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "0000001c: \e[1;31m1c\e[0m\e[1;31m1d\e[0m \e[1;31m1e\e[0m\e[1;31m1f\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000020: \e[1;32m20\e[0m\e[1;32m21\e[0m \e[1;32m22\e[0m\e[1;32m23\e[0m  \e[1;32m \e[0m\e[1;32m!\e[0m\e[1;32m\"\e[0m\e[1;32m#\e[0m",
+      \ "00000024: \e[1;32m24\e[0m\e[1;32m25\e[0m \e[1;32m26\e[0m\e[1;37m00\e[0m  \e[1;32m$\e[0m\e[1;32m%\e[0m\e[1;32m&\e[0m\e[1;37m.\e[0m",
+      \ "00000028: \e[1;32m28\e[0m\e[1;32m29\e[0m \e[1;32m2a\e[0m\e[1;32m2b\e[0m  \e[1;32m(\e[0m\e[1;32m)\e[0m\e[1;32m*\e[0m\e[1;32m+\e[0m",
+      \ "0000002c: \e[1;32m2c\e[0m\e[1;32m2d\e[0m \e[1;32m2e\e[0m\e[1;32m2f\e[0m  \e[1;32m,\e[0m\e[1;32m-\e[0m\e[1;32m.\e[0m\e[1;32m/\e[0m",
+      \ "00000030: \e[1;32m30\e[0m\e[1;32m31\e[0m \e[1;32m32\e[0m\e[1;32m33\e[0m  \e[1;32m0\e[0m\e[1;32m1\e[0m\e[1;32m2\e[0m\e[1;32m3\e[0m",
+      \ "00000034: \e[1;32m34\e[0m\e[1;32m35\e[0m \e[1;32m36\e[0m\e[1;32m37\e[0m  \e[1;32m4\e[0m\e[1;32m5\e[0m\e[1;32m6\e[0m\e[1;32m7\e[0m",
+      \ "00000038: \e[1;32m38\e[0m\e[1;32m39\e[0m \e[1;32m3a\e[0m\e[1;32m3b\e[0m  \e[1;32m8\e[0m\e[1;32m9\e[0m\e[1;32m:\e[0m\e[1;32m;\e[0m",
+      \ "0000003c: \e[1;32m3c\e[0m\e[1;32m3d\e[0m \e[1;32m3e\e[0m\e[1;32m3f\e[0m  \e[1;32m<\e[0m\e[1;32m=\e[0m\e[1;32m>\e[0m\e[1;32m?\e[0m",
+      \ "00000040: \e[1;32m40\e[0m\e[1;32m41\e[0m \e[1;32m42\e[0m\e[1;32m43\e[0m  \e[1;32m@\e[0m\e[1;32mA\e[0m\e[1;32mB\e[0m\e[1;32mC\e[0m",
+      \ "00000044: \e[1;32m44\e[0m\e[1;32m45\e[0m \e[1;32m46\e[0m\e[1;32m47\e[0m  \e[1;32mD\e[0m\e[1;32mE\e[0m\e[1;32mF\e[0m\e[1;32mG\e[0m",
+      \ "00000048: \e[1;32m48\e[0m\e[1;32m49\e[0m \e[1;32m4a\e[0m\e[1;32m4b\e[0m  \e[1;32mH\e[0m\e[1;32mI\e[0m\e[1;32mJ\e[0m\e[1;32mK\e[0m",
+      \ "0000004c: \e[1;32m4c\e[0m\e[1;32m4d\e[0m \e[1;32m4e\e[0m\e[1;32m4f\e[0m  \e[1;32mL\e[0m\e[1;32mM\e[0m\e[1;32mN\e[0m\e[1;32mO\e[0m",
+      \ "00000050: \e[1;32m50\e[0m\e[1;32m51\e[0m \e[1;32m52\e[0m\e[1;32m53\e[0m  \e[1;32mP\e[0m\e[1;32mQ\e[0m\e[1;32mR\e[0m\e[1;32mS\e[0m",
+      \ "00000054: \e[1;32m54\e[0m\e[1;32m55\e[0m \e[1;32m56\e[0m\e[1;32m57\e[0m  \e[1;32mT\e[0m\e[1;32mU\e[0m\e[1;32mV\e[0m\e[1;32mW\e[0m",
+      \ "00000058: \e[1;32m58\e[0m\e[1;32m59\e[0m \e[1;32m5a\e[0m\e[1;32m5b\e[0m  \e[1;32mX\e[0m\e[1;32mY\e[0m\e[1;32mZ\e[0m\e[1;32m[\e[0m",
+      \ "0000005c: \e[1;37m00\e[0m\e[1;32m5d\e[0m \e[1;32m5e\e[0m\e[1;32m5f\e[0m  \e[1;37m.\e[0m\e[1;32m]\e[0m\e[1;32m^\e[0m\e[1;32m_\e[0m",
+      \ "00000060: \e[1;32m60\e[0m\e[1;32m61\e[0m \e[1;32m62\e[0m\e[1;32m63\e[0m  \e[1;32m`\e[0m\e[1;32ma\e[0m\e[1;32mb\e[0m\e[1;32mc\e[0m",
+      \ "00000064: \e[1;32m64\e[0m\e[1;32m65\e[0m \e[1;32m66\e[0m\e[1;32m67\e[0m  \e[1;32md\e[0m\e[1;32me\e[0m\e[1;32mf\e[0m\e[1;32mg\e[0m",
+      \ "00000068: \e[1;32m68\e[0m\e[1;32m69\e[0m \e[1;32m6a\e[0m\e[1;32m6b\e[0m  \e[1;32mh\e[0m\e[1;32mi\e[0m\e[1;32mj\e[0m\e[1;32mk\e[0m",
+      \ "0000006c: \e[1;32m6c\e[0m\e[1;32m6d\e[0m \e[1;32m6e\e[0m\e[1;32m6f\e[0m  \e[1;32ml\e[0m\e[1;32mm\e[0m\e[1;32mn\e[0m\e[1;32mo\e[0m",
+      \ "00000070: \e[1;32m70\e[0m\e[1;32m71\e[0m \e[1;32m72\e[0m\e[1;32m73\e[0m  \e[1;32mp\e[0m\e[1;32mq\e[0m\e[1;32mr\e[0m\e[1;32ms\e[0m",
+      \ "00000074: \e[1;32m74\e[0m\e[1;32m75\e[0m \e[1;32m76\e[0m\e[1;32m77\e[0m  \e[1;32mt\e[0m\e[1;32mu\e[0m\e[1;32mv\e[0m\e[1;32mw\e[0m",
+      \ "00000078: \e[1;32m78\e[0m\e[1;32m79\e[0m \e[1;32m7a\e[0m\e[1;32m7b\e[0m  \e[1;32mx\e[0m\e[1;32my\e[0m\e[1;32mz\e[0m\e[1;32m{\e[0m",
+      \ "0000007c: \e[1;32m7c\e[0m\e[1;32m7d\e[0m \e[1;32m7e\e[0m\e[1;31m7f\e[0m  \e[1;32m|\e[0m\e[1;32m}\e[0m\e[1;32m~\e[0m\e[1;31m.\e[0m",
+      \ "00000080: \e[1;31m80\e[0m\e[1;31m81\e[0m \e[1;31m82\e[0m\e[1;31m83\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000084: \e[1;31m84\e[0m\e[1;31m85\e[0m \e[1;31m86\e[0m\e[1;31m87\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000088: \e[1;31m88\e[0m\e[1;31m89\e[0m \e[1;31m8a\e[0m\e[1;31m8b\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "0000008c: \e[1;31m8c\e[0m\e[1;31m8d\e[0m \e[1;31m8e\e[0m\e[1;31m8f\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000090: \e[1;31m90\e[0m\e[1;31m91\e[0m \e[1;31m92\e[0m\e[1;31m93\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000094: \e[1;31m94\e[0m\e[1;31m95\e[0m \e[1;31m96\e[0m\e[1;31m97\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "00000098: \e[1;31m98\e[0m\e[1;31m99\e[0m \e[1;31m9a\e[0m\e[1;31m9b\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "0000009c: \e[1;31m9c\e[0m\e[1;31m9d\e[0m \e[1;31m9e\e[0m\e[1;31m9f\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000a0: \e[1;31ma0\e[0m\e[1;31ma1\e[0m \e[1;31ma2\e[0m\e[1;31ma3\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000a4: \e[1;31ma4\e[0m\e[1;31ma5\e[0m \e[1;31ma6\e[0m\e[1;31ma7\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000a8: \e[1;31ma8\e[0m\e[1;31ma9\e[0m \e[1;31maa\e[0m\e[1;31mab\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000ac: \e[1;31mac\e[0m\e[1;31mad\e[0m \e[1;31mae\e[0m\e[1;31maf\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000b0: \e[1;31mb0\e[0m\e[1;31mb1\e[0m \e[1;31mb2\e[0m\e[1;31mb3\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000b4: \e[1;31mb4\e[0m\e[1;31mb5\e[0m \e[1;31mb6\e[0m\e[1;31mb7\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000b8: \e[1;31mb8\e[0m\e[1;31mb9\e[0m \e[1;31mba\e[0m\e[1;31mbb\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000bc: \e[1;31mbc\e[0m\e[1;31mbd\e[0m \e[1;31mbe\e[0m\e[1;31mbf\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000c0: \e[1;31mc0\e[0m\e[1;31mc1\e[0m \e[1;31mc2\e[0m\e[1;31mc3\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000c4: \e[1;31mc4\e[0m\e[1;31mc5\e[0m \e[1;31mc6\e[0m\e[1;31mc7\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000c8: \e[1;31mc8\e[0m\e[1;31mc9\e[0m \e[1;31mca\e[0m\e[1;31mcb\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000cc: \e[1;31mcc\e[0m\e[1;31mcd\e[0m \e[1;31mce\e[0m\e[1;31mcf\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000d0: \e[1;31md0\e[0m\e[1;31md1\e[0m \e[1;31md2\e[0m\e[1;31md3\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000d4: \e[1;31md4\e[0m\e[1;31md5\e[0m \e[1;31md6\e[0m\e[1;31md7\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000d8: \e[1;31md8\e[0m\e[1;31md9\e[0m \e[1;31mda\e[0m\e[1;31mdb\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000dc: \e[1;31mdc\e[0m\e[1;31mdd\e[0m \e[1;31mde\e[0m\e[1;31mdf\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000e0: \e[1;31me0\e[0m\e[1;31me1\e[0m \e[1;31me2\e[0m\e[1;31me3\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000e4: \e[1;31me4\e[0m\e[1;31me5\e[0m \e[1;31me6\e[0m\e[1;31me7\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000e8: \e[1;31me8\e[0m\e[1;31me9\e[0m \e[1;31mea\e[0m\e[1;31meb\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000ec: \e[1;31mec\e[0m\e[1;31med\e[0m \e[1;31mee\e[0m\e[1;31mef\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000f0: \e[1;31mf0\e[0m\e[1;31mf1\e[0m \e[1;31mf2\e[0m\e[1;31mf3\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000f4: \e[1;31mf4\e[0m\e[1;31mf5\e[0m \e[1;31mf6\e[0m\e[1;31mf7\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000f8: \e[1;31mf8\e[0m\e[1;31mf9\e[0m \e[1;31mfa\e[0m\e[1;31mfb\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m",
+      \ "000000fc: \e[1;31mfc\e[0m\e[1;31mfd\e[0m \e[1;31mfe\e[0m\e[1;34mff\e[0m  \e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;31m.\e[0m\e[1;34m.\e[0m"]
+  call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
+
+  call delete('Xinput')
+  call delete('XXDfile')
+
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -503,7 +503,7 @@ static unsigned char etoa64[] =
 
    static void
 begin_coloring_char (char *l,int *c,int e,int ebcdic) {
-  if (ebcdic)  /* EBCDIC */
+  if (ebcdic)
     {
       if ((e >= 75 && e <= 80) || (e >= 90 && e <= 97) ||
           (e >= 107 && e <= 111) || (e >= 121 && e <= 127) ||

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -501,8 +501,8 @@ static unsigned char etoa64[] =
     0070,0071,0372,0373,0374,0375,0376,0377
 };
 
-   static char
-begin_coloring_char(char *l,int *c,int e,int ebcdic) {
+   static void
+begin_coloring_char (char *l,int *c,int e,int ebcdic) {
   if (ebcdic)  /* EBCDIC */
     {
       if ((e >= 75 && e <= 80) || (e >= 90 && e <= 97) ||

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -517,10 +517,11 @@ main(int argc, char *argv[])
   char *pp;
   char *varname = NULL;
   int addrlen = 9;
-  int color= isatty (STDOUT_FILENO);
+  int color = 0;
 
-#ifdef  __MVS__
-  color=0;
+
+#ifdef UNIX
+  color = isatty (STDOUT_FILENO);
 #endif
 
 #ifdef AMIGA

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -517,10 +517,10 @@ main(int argc, char *argv[])
   char *pp;
   char *varname = NULL;
   int addrlen = 9;
-  int color= isatty (STDOUT_FILENO);
+  int color=0;
 
-#ifdef  __MVS__
-  color=0;
+#ifndef  __MVS__
+  color=isatty (STDOUT_FILENO);
 #endif
 
 #ifdef AMIGA

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -920,8 +920,6 @@ main(int argc, char *argv[])
 
   while ((length < 0 || n < length) && (e = getc_or_die(fp)) != EOF)
     {
-      int x;
-
       if (p == 0)
 	{
 	  addrlen = sprintf(l, decimal_offset ? "%08ld:" : "%08lx:",
@@ -951,7 +949,6 @@ main(int argc, char *argv[])
 	}
       else /* hextype == HEX_BITS */
 	{
-	  int i;
 	  for (i = 7; i >= 0; i--)
 	    l[c++] = (e & (1 << i)) ? '1' : '0';
 	}

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -207,17 +207,17 @@ char hexxa[] = "0123456789abcdef0123456789ABCDEF", *hexx = hexxa;
 #define CONDITIONAL_CAPITALIZE(c) (capitalize ? toupper((int)c) : c)
 
 #define COLOR_PROLOGUE \
-l[c++] ='\033'; \
-l[c++] ='['; \
-l[c++] ='1'; \
-l[c++] =';'; \
-l[c++] ='3';
+l[c++] = '\033'; \
+l[c++] = '['; \
+l[c++] = '1'; \
+l[c++] = ';'; \
+l[c++] = '3';
 
 #define COLOR_EPILOGUE \
-l[c++] ='\033'; \
-l[c++] ='['; \
-l[c++] ='0'; \
-l[c++] ='m';
+l[c++] = '\033'; \
+l[c++] = '['; \
+l[c++] = '0'; \
+l[c++] = 'm';
 #define COLOR_RED '1'
 #define COLOR_GREEN '2'
 #define COLOR_YELLOW '3'
@@ -622,15 +622,15 @@ main(int argc, char *argv[])
 	{
 	  relseek = 0;
 	  negseek = 0;
-	  if (pp[2] && STRNCMP("kip", pp+2, 3) && STRNCMP("eek", pp+2, 3))
+	  if (pp[2] && STRNCMP("kip", pp + 2, 3) && STRNCMP("eek", pp+2, 3))
 	    {
 #ifdef TRY_SEEK
 	      if (pp[2] == '+')
 		relseek++;
-	      if (pp[2+relseek] == '-')
+	      if (pp[2 + relseek] == '-')
 		negseek++;
 #endif
-	      seekoff = strtol(pp + 2+relseek+negseek, (char **)NULL, 0);
+	      seekoff = strtol(pp + 2 + relseek + negseek, (char **)NULL, 0);
 	    }
 	  else
 	    {
@@ -642,7 +642,7 @@ main(int argc, char *argv[])
 	      if (argv[2][relseek] == '-')
 		negseek++;
 #endif
-	      seekoff = strtol(argv[2] + relseek+negseek, (char **)NULL, 0);
+	      seekoff = strtol(argv[2] + relseek + negseek, (char **)NULL, 0);
 	      argv++;
 	      argc--;
 	    }
@@ -679,11 +679,11 @@ main(int argc, char *argv[])
           exit_with_usage();
         if (!STRNCMP(argv[2], "always", 2))
         {
-          color=1;
+          color = 1;
         }
         else if (!STRNCMP(argv[2], "never", 1))
         {
-          color=0;
+          color = 0;
         }
         argv++;
         argc--;
@@ -868,7 +868,7 @@ main(int argc, char *argv[])
     {
       grplen = octspergrp + octspergrp + 1;	/* chars per octet group */
       if (color)
-        grplen +=11*octspergrp;  /* color-code needs 11 extra characters */
+        grplen += 11 * octspergrp;  /* color-code needs 11 extra characters */
 
     }
   else	/* hextype == HEX_BITS */
@@ -885,7 +885,7 @@ main(int argc, char *argv[])
 	  for (c = addrlen; c < LLEN; l[c++] = ' ')
 	    ;
 	}
-      x = hextype == HEX_LITTLEENDIAN ? p ^ (octspergrp-1) : p;
+      x = hextype == HEX_LITTLEENDIAN ? p ^ (octspergrp - 1) : p;
       c = addrlen + 1 + (grplen * x) / octspergrp;
       if (hextype == HEX_NORMAL || hextype == HEX_LITTLEENDIAN)
 	{
@@ -900,8 +900,8 @@ main(int argc, char *argv[])
                     (e >= 129 && e <= 137) || (e >= 145 && e <= 154) ||
                     (e >= 162 && e <= 169) || (e >= 192 && e <= 201) ||
                     (e >= 208 && e <= 217) || (e >= 226 && e <= 233) ||
-                    (e >= 240 && e <= 249) || (e==189) || (e==64) ||
-                    (e==173) || (e==224) )
+                    (e >= 240 && e <= 249) || (e == 189) || (e == 64) ||
+                    (e == 173) || (e == 224) )
                   l[c++] = COLOR_GREEN;
 
                 else if (e==37 || e == 13 || e == 5)
@@ -933,7 +933,7 @@ main(int argc, char *argv[])
                   l[c++] = COLOR_RED;
               }
 
-            l[c++] ='m';
+            l[c++] = 'm';
             l[c++] = hexx[(e >> 4) & 0xf];
             l[c++] = hexx[e & 0xf];
 
@@ -968,7 +968,7 @@ main(int argc, char *argv[])
             c = addrlen + 3 + (grplen * cols - 1)/octspergrp + p*12;
 
           if (hextype == HEX_LITTLEENDIAN)
-            c+=1;
+            c += 1;
 
           COLOR_PROLOGUE
 
@@ -979,11 +979,11 @@ main(int argc, char *argv[])
                   (e >= 129 && e <= 137) || (e >= 145 && e <= 154) ||
                   (e >= 162 && e <= 169) || (e >= 192 && e <= 201) ||
                   (e >= 208 && e <= 217) || (e >= 226 && e <= 233) ||
-                  (e >= 240 && e <= 249) || (e==189) || (e==64) ||
-                  (e==173) || (e==224) )
+                  (e >= 240 && e <= 249) || (e == 189) || (e == 64) ||
+                  (e == 173) || (e == 224) )
                 l[c++] = COLOR_GREEN;
 
-              else if (e==37 || e == 13 || e == 5)
+              else if (e == 37 || e == 13 || e == 5)
                 l[c++] = COLOR_YELLOW;
               else if (e == 0)
                 l[c++] = COLOR_WHITE;
@@ -1005,16 +1005,16 @@ main(int argc, char *argv[])
                 else
                   l[c++] = COLOR_RED;
               }
-            l[c++] ='m';
+            l[c++] = 'm';
 
             #ifdef __MVS__
-            if (e >= 64) l[c++] =e;
-            else  l[c++] ='.';
+            if (e >= 64) l[c++] = e;
+            else  l[c++] = '.';
             #else
 
             if (ebcdic)
               e = (e < 64) ? '.' : etoa64[e-64];
-            l[c++] =(e > 31 && e < 127) ? e : '.';
+            l[c++] = (e > 31 && e < 127) ? e : '.';
             #endif
 
         COLOR_EPILOGUE
@@ -1061,22 +1061,22 @@ main(int argc, char *argv[])
         {
         c++;
 
-        int x=p;
+        int x = p;
         if (hextype == HEX_LITTLEENDIAN)
           {
-            int fill=octspergrp-(p%octspergrp);
-            if (fill==octspergrp) fill=0;
+            int fill = octspergrp - (p % octspergrp);
+            if (fill == octspergrp) fill = 0;
 
-            c = addrlen + 1 + (grplen * (x-(octspergrp-fill))) / octspergrp;
+            c = addrlen + 1 + (grplen * (x - (octspergrp-fill))) / octspergrp;
 
             int i;
-            for (i=0;i<fill;i++)
+            for (i = 0;i < fill;i++)
               {
                 COLOR_PROLOGUE
 
                 l[c++] = COLOR_RED;
-                l[c++] ='m';
-                l[c++] =' '; //empty space
+                l[c++] = 'm';
+                l[c++] = ' '; /* empty space */
 
                 COLOR_EPILOGUE
                 x++;
@@ -1087,18 +1087,18 @@ main(int argc, char *argv[])
         if (hextype != HEX_BITS)
           {
             c = addrlen + 1 + (grplen * x) / octspergrp;
-            c+=cols-p;
-            c+=(cols-p)/octspergrp;
+            c += cols - p;
+            c += (cols - p) / octspergrp;
 
             int i;
-            for (i=cols-p;i>0;i--)
+            for (i = cols - p;i > 0;i--)
               {
                 COLOR_PROLOGUE
 
-                l[c++] =COLOR_RED;
+                l[c++] = COLOR_RED;
 
-                l[c++] ='m';
-                l[c++] =' '; //empty space
+                l[c++] = 'm';
+                l[c++] = ' '; /* empty space */
                 COLOR_EPILOGUE
               }
           }

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -550,7 +550,7 @@ begin_coloring_char (char *l,int *c,int e,int ebcdic) {
 main(int argc, char *argv[])
 {
   FILE *fp, *fpo;
-  int c, e, p = 0, relseek = 1, negseek = 0, revert = 0;
+  int c, e, p = 0, relseek = 1, negseek = 0, revert = 0,i,x;
   int cols = 0, colsgiven = 0, nonzero = 0, autoskip = 0, hextype = HEX_NORMAL;
   int capitalize = 0, decimal_offset = 0;
   int ebcdic = 0;
@@ -1030,7 +1030,7 @@ main(int argc, char *argv[])
         {
         c++;
 
-        int x = p;
+        x = p;
         if (hextype == HEX_LITTLEENDIAN)
           {
             int fill = octspergrp - (p % octspergrp);
@@ -1038,7 +1038,6 @@ main(int argc, char *argv[])
 
             c = addrlen + 1 + (grplen * (x - (octspergrp-fill))) / octspergrp;
 
-            int i;
             for (i = 0; i < fill;i++)
               {
                 COLOR_PROLOGUE
@@ -1059,7 +1058,6 @@ main(int argc, char *argv[])
             c += cols - p;
             c += (cols - p) / octspergrp;
 
-            int i;
             for (i = cols - p; i > 0;i--)
               {
                 COLOR_PROLOGUE

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -564,7 +564,6 @@ main(int argc, char *argv[])
   int addrlen = 9;
   int color = 0;
 
-
 #ifdef UNIX
   color = isatty (STDOUT_FILENO);
 #endif
@@ -982,7 +981,6 @@ main(int argc, char *argv[])
             if (e >= 64) l[c++] = e;
             else  l[c++] = '.';
             #else
-
             if (ebcdic)
               e = (e < 64) ? '.' : etoa64[e-64];
             l[c++] = (e > 31 && e < 127) ? e : '.';
@@ -1041,7 +1039,7 @@ main(int argc, char *argv[])
             c = addrlen + 1 + (grplen * (x - (octspergrp-fill))) / octspergrp;
 
             int i;
-            for (i = 0;i < fill;i++)
+            for (i = 0; i < fill;i++)
               {
                 COLOR_PROLOGUE
 
@@ -1062,7 +1060,7 @@ main(int argc, char *argv[])
             c += (cols - p) / octspergrp;
 
             int i;
-            for (i = cols - p;i > 0;i--)
+            for (i = cols - p; i > 0;i--)
               {
                 COLOR_PROLOGUE
 

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -517,10 +517,10 @@ main(int argc, char *argv[])
   char *pp;
   char *varname = NULL;
   int addrlen = 9;
-  int color=0;
+  int color= isatty (STDOUT_FILENO);
 
-#ifndef  __MVS__
-  color=isatty (STDOUT_FILENO);
+#ifdef  __MVS__
+  color=0;
 #endif
 
 #ifdef AMIGA

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -974,29 +974,29 @@ main(int argc, char *argv[])
           if (hextype == HEX_LITTLEENDIAN)
             c += 1;
 
-            COLOR_PROLOGUE
-            begin_coloring_char(l,&c,e,ebcdic);
+          COLOR_PROLOGUE
+          begin_coloring_char(l,&c,e,ebcdic);
 
-            #ifdef __MVS__
-            if (e >= 64) l[c++] = e;
-            else  l[c++] = '.';
-            #else
-            if (ebcdic)
-              e = (e < 64) ? '.' : etoa64[e-64];
-            l[c++] = (e > 31 && e < 127) ? e : '.';
-            #endif
+          #ifdef __MVS__
+          if (e >= 64) l[c++] = e;
+          else  l[c++] = '.';
+          #else
+          if (ebcdic)
+            e = (e < 64) ? '.' : etoa64[e-64];
+          l[c++] = (e > 31 && e < 127) ? e : '.';
+          #endif
 
-            COLOR_EPILOGUE
+          COLOR_EPILOGUE
 
-        n++;
-        if (++p == cols)
-          {
-            l[c++] = '\n';
-            l[c++] = '\0';
-            xxdline(fpo, l, autoskip ? nonzero : 1);
-            nonzero = 0;
-            p = 0;
-          }
+          n++;
+          if (++p == cols)
+            {
+              l[c++] = '\n';
+              l[c++] = '\0';
+              xxdline(fpo, l, autoskip ? nonzero : 1);
+              nonzero = 0;
+              p = 0;
+            }
         }
       else /*no colors*/
         {

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -1068,7 +1068,8 @@ main(int argc, char *argv[])
 
             c = addrlen + 1 + (grplen * (x-(octspergrp-fill))) / octspergrp;
 
-            for (int i=0;i<fill;i++)
+            int i;
+            for (i=0;i<fill;i++)
               {
                 COLOR_PROLOGUE
 
@@ -1088,7 +1089,8 @@ main(int argc, char *argv[])
             c+=cols-p;
             c+=(cols-p)/octspergrp;
 
-            for (int i=cols-p;i>0;i--)
+            int i;
+            for (i=cols-p;i>0;i--)
               {
                 COLOR_PROLOGUE
 

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -501,6 +501,51 @@ static unsigned char etoa64[] =
     0070,0071,0372,0373,0374,0375,0376,0377
 };
 
+   static char
+begin_coloring_char(char *l,int *c,int e,int ebcdic) {
+  if (ebcdic)  /* EBCDIC */
+    {
+      if ((e >= 75 && e <= 80) || (e >= 90 && e <= 97) ||
+          (e >= 107 && e <= 111) || (e >= 121 && e <= 127) ||
+          (e >= 129 && e <= 137) || (e >= 145 && e <= 154) ||
+          (e >= 162 && e <= 169) || (e >= 192 && e <= 201) ||
+          (e >= 208 && e <= 217) || (e >= 226 && e <= 233) ||
+          (e >= 240 && e <= 249) || (e == 189) || (e == 64) ||
+          (e == 173) || (e == 224) )
+        l[(*c)++] = COLOR_GREEN;
+
+      else if (e==37 || e == 13 || e == 5)
+        l[(*c)++] = COLOR_YELLOW;
+      else if (e == 0)
+        l[(*c)++] = COLOR_WHITE;
+      else if (e == 255)
+        l[(*c)++] = COLOR_BLUE;
+      else
+        l[(*c)++] = COLOR_RED;
+    }
+  else  /* ASCII */
+    {
+      #ifdef __MVS__
+      if (e >= 64)
+        l[(*c)++] = COLOR_GREEN;
+      #else
+      if (e > 31 && e < 127)
+        l[(*c)++] = COLOR_GREEN;
+      #endif
+
+      else if (e == 9 || e == 10 || e == 13)
+        l[(*c)++] = COLOR_YELLOW;
+      else if (e == 0)
+        l[(*c)++] = COLOR_WHITE;
+      else if (e == 255)
+        l[(*c)++] = COLOR_BLUE;
+      else
+        l[(*c)++] = COLOR_RED;
+    }
+
+  l[(*c)++] = 'm';
+}
+
   int
 main(int argc, char *argv[])
 {
@@ -892,48 +937,8 @@ main(int argc, char *argv[])
           if (color)
             {
             COLOR_PROLOGUE
+            begin_coloring_char(l,&c,e,ebcdic);
 
-            if (ebcdic)  /* EBCDIC */
-              {
-                if ((e >= 75 && e <= 80) || (e >= 90 && e <= 97) ||
-                    (e >= 107 && e <= 111) || (e >= 121 && e <= 127) ||
-                    (e >= 129 && e <= 137) || (e >= 145 && e <= 154) ||
-                    (e >= 162 && e <= 169) || (e >= 192 && e <= 201) ||
-                    (e >= 208 && e <= 217) || (e >= 226 && e <= 233) ||
-                    (e >= 240 && e <= 249) || (e == 189) || (e == 64) ||
-                    (e == 173) || (e == 224) )
-                  l[c++] = COLOR_GREEN;
-
-                else if (e==37 || e == 13 || e == 5)
-                  l[c++] = COLOR_YELLOW;
-                else if (e == 0)
-                  l[c++] = COLOR_WHITE;
-                else if (e == 255)
-                  l[c++] = COLOR_BLUE;
-                else
-                  l[c++] = COLOR_RED;
-              }
-            else  /* ASCII */
-              {
-                #ifdef __MVS__
-                if (e >= 64)
-                  l[c++] = COLOR_GREEN;
-                #else
-                if (e > 31 && e < 127)
-                  l[c++] = COLOR_GREEN;
-                #endif
-
-                else if (e == 9 || e == 10 || e == 13)
-                  l[c++] = COLOR_YELLOW;
-                else if (e == 0)
-                  l[c++] = COLOR_WHITE;
-                else if (e == 255)
-                  l[c++] = COLOR_BLUE;
-                else
-                  l[c++] = COLOR_RED;
-              }
-
-            l[c++] = 'm';
             l[c++] = hexx[(e >> 4) & 0xf];
             l[c++] = hexx[e & 0xf];
 
@@ -970,42 +975,8 @@ main(int argc, char *argv[])
           if (hextype == HEX_LITTLEENDIAN)
             c += 1;
 
-          COLOR_PROLOGUE
-
-          if (ebcdic)  /* EBCDIC */
-            {
-              if ((e >= 75 && e <= 80) || (e >= 90 && e <= 97) ||
-                  (e >= 107 && e <= 111) || (e >= 121 && e <= 127) ||
-                  (e >= 129 && e <= 137) || (e >= 145 && e <= 154) ||
-                  (e >= 162 && e <= 169) || (e >= 192 && e <= 201) ||
-                  (e >= 208 && e <= 217) || (e >= 226 && e <= 233) ||
-                  (e >= 240 && e <= 249) || (e == 189) || (e == 64) ||
-                  (e == 173) || (e == 224) )
-                l[c++] = COLOR_GREEN;
-
-              else if (e == 37 || e == 13 || e == 5)
-                l[c++] = COLOR_YELLOW;
-              else if (e == 0)
-                l[c++] = COLOR_WHITE;
-              else if (e == 255)
-                l[c++] = COLOR_BLUE;
-              else
-                l[c++] = COLOR_RED;
-            }
-            else /* ascii */
-              {
-                if (e > 31 && e < 127)
-                  l[c++] = COLOR_GREEN;
-                else if (e == 9 || e == 10 || e == 13)
-                  l[c++] = COLOR_YELLOW;
-                else if (e == 0)
-                  l[c++] = COLOR_WHITE;
-                else if (e == 255)
-                  l[c++] = COLOR_BLUE;
-                else
-                  l[c++] = COLOR_RED;
-              }
-            l[c++] = 'm';
+            COLOR_PROLOGUE
+            begin_coloring_char(l,&c,e,ebcdic);
 
             #ifdef __MVS__
             if (e >= 64) l[c++] = e;
@@ -1017,7 +988,7 @@ main(int argc, char *argv[])
             l[c++] = (e > 31 && e < 127) ? e : '.';
             #endif
 
-        COLOR_EPILOGUE
+            COLOR_EPILOGUE
 
         n++;
         if (++p == cols)


### PR DESCRIPTION
Adds colors in xxd. Coloring the output might help some hexdumping tasks (visualizing).

![xxd](https://user-images.githubusercontent.com/132666/224427943-c58ae2ed-6be3-4919-b41b-5a7b3a855ef3.png)

The hex-value and value are both colored with the same color depending on the hex-value, e.g.:

- 0x00 = white
- 0xff = blue
- printable = green
- non-printable = red
- tabs and linebreaks = yellow
- (should be more?)

Each character needs 11 more bytes to contain color. (Same color in a row could contain only one overhead but the logic how xxd creates colums must be then changed.) Size of colored output is increased by factor of ~6. Also grepping the output will break when colors is used. 

Flag for color is "-R", because _less_ uses "-R".

Color uses parameters _auto,always,never_ same as _less_ and _grep_ (among others).

E.g. 
```
xxd -R always $FILE | less -R
```

Issues:
-  _ _ MVS _ _ not tested
-  not all col/group -combinations in little-endian (-e) works (check #12097)


### Basic
![R](https://user-images.githubusercontent.com/132666/224424070-3ae2ee0e-5e61-443c-909b-c6ce62fb9153.png)

### ebcdic
![E](https://user-images.githubusercontent.com/132666/224424809-52c03787-7b5a-4303-aed5-f809c22a040e.png)

### Binary (bits are not colored)
![b](https://user-images.githubusercontent.com/132666/224425193-077e2157-81c9-4fe8-90cd-530200510579.png)


### Little-endian (Decimal offsets, Uppercase)
![edu](https://user-images.githubusercontent.com/132666/224425361-5437fd52-9097-4b64-b1d6-c6db488ced8b.png)


### Test-script
Running 7632 combinations of flags run two times: without and with color (total of 15264 rounds).  Color is then dropped with _ansifilter_ (http://andre-simon.de/doku/ansifilter/en/ansifilter.php) and compared against known-good version of xxd.

When -c and -g are limited to the power-of-two then also all little-endian tests passed.

```bash
#!/bin/bash

for i in `printf '%.2x\n' {0..255}` ; do echo -ne "\x$i" ; done > asciiA.txt
#add one extra character because length of the data is not always 2^x
echo -n A >> asciiA.txt

DATA=asciiA.txt
XXD=./xxd_ff226d49fed2d8fc668084324c7b0f00117c5e74

function test_color_no() {
    echo -n ./xxd "$1" -R never "  "
    str1=$( $XXD $1 $DATA | md5sum)

    color_no=$(./xxd -R never $1 $DATA | md5sum)        
    if [ "$str1" == "$color_no" ]; then
        echo -n $(echo $str1 | cut -d" " -f1) " OK"
    else
        echo -n FAILED $str1 and $color_no
    fi
    echo
}

function test_color_yes() {
    echo -n ./xxd "$1" -R always " "
    str1=$( $XXD $1 $DATA | md5sum)

    color_yes=$(./xxd -R always $1 $DATA | ansifilter | md5sum)
    if [ "$str1" == "$color_yes" ]; then
        echo -n $(echo $str1 | cut -d" " -f1) " OK"
    else
        echo -n FAILED $str1 and $color_yes
    fi
    echo
}

function not_power_of_two () {
    declare -i n=$1
    (( n > 0 && (n & (n - 1)) != 0 ))
}

for a in "" "-a"
do
 for b in "" "-e" "-b" 
 do
  for d in "" "-d"
  do
   for E in "" "-E"
   do
    for u in "" "-u"
    do
     for c in {1..21}
     do
     for (( g=1; g<=c; g++ ))
      do
      if  [ "$b" == "-e" ] && not_power_of_two "$g" 
       then
        :
      elif [ "$b" == "-e" ] && not_power_of_two "$c" 
       then
        :
       else
        test_color_no  "$a $b $d $E $u -c $c -g $g"
        test_color_yes "$a $b $d $E $u -c $c -g $g"
       fi
      done
     done
    done
   done
  done
 done
done
exit 0
```