### PR TITLE
fix cindent: fix for `export namespace` in C++20

### DIFF
--- a/src/cindent.c
+++ b/src/cindent.c
@@ -769,7 +769,7 @@ cin_is_cpp_namespace(char_u *s)
 
     s = cin_skipcomment(s);
 
-    if (STRNCMP(s, "inline", 6) == 0 && (s[6] == NUL || !vim_iswordc(s[6])))
+    while ((STRNCMP(s, "inline", 6) == 0 || STRNCMP(s, "export", 6) == 0) && (s[6] == NUL || !vim_iswordc(s[6])))
 	s = cin_skipcomment(skipwhite(s + 6));
 
     if (STRNCMP(s, "namespace", 9) == 0 && (s[9] == NUL || !vim_iswordc(s[9])))

--- a/src/testdir/test_cindent.vim
+++ b/src/testdir/test_cindent.vim
@@ -4406,6 +4406,18 @@ def Test_cindent_47()
   inline/* test */namespace {
     111111111111111111;
   }
+  export namespace {
+    111111111111111111;
+  }
+  export inline namespace {
+    111111111111111111;
+  }
+  export/* test */inline namespace {
+    111111111111111111;
+  }
+  inline export namespace {
+    111111111111111111;
+  }
 
   /* invalid namespaces use block indent */
   namespace test test2 {
@@ -4507,6 +4519,18 @@ def Test_cindent_47()
   111111111111111111;
   }
   inline/* test */namespace {
+  111111111111111111;
+  }
+  export namespace {
+  111111111111111111;
+  }
+  export inline namespace {
+  111111111111111111;
+  }
+  export/* test */inline namespace {
+  111111111111111111;
+  }
+  inline export namespace {
   111111111111111111;
   }
 


### PR DESCRIPTION
This PR closes #12133.

Currently, such namespaces can't be recognized as a namespace by cindent:

```cpp
export namespace Test
{
}
```

Since both `export inline namespace` and `inline export namespace` are legal, adding a loop to extract the modifiers can fix this.
