### PR TITLE
docs(fold/`za`): use keywords for easy search

### DIFF
--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -361,6 +361,7 @@ za		When on a closed fold: open it.  When folds are nested, you
 		the fold.  When a count is given that many folds will be
 		closed (that's not the same as repeating "za" that many
 		times).
+		In short: toggles fold under cursor.
 
 							*zA*
 zA		When on a closed fold: open it recursively.


### PR DESCRIPTION
I constantly forget this map and start searching for "toggle" in `:help fold.txt`, but no matches, so I have to open google. This will solve it.
(From https://github.com/neovim/neovim/pull/22642)