### PR TITLE
netrw: Fix handling of very long filename on longlist style

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -4,6 +4,7 @@
 " Version:	173a
 " Last Change:
 " 	2023 Nov 21 by Vim Project: ignore wildignore when expanding $COMSPEC	(v173a)
+" 	2023 Nov 22 by Vim Project: fix handling of very long filename on longlist style	(v173a)
 " Maintainer:	Charles E Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 2016 Charles E. Campbell {{{1
@@ -11187,16 +11188,16 @@ fun! s:LocalListing()
 "   call Decho("pfile   <".pfile.">",'~'.expand("<slnum>"))
 
    if w:netrw_liststyle == s:LONGLIST
+    let longfile= printf("%-".g:netrw_maxfilenamelen."S",pfile)
     let sz   = getfsize(filename)
 	let szlen = 15 - (strdisplaywidth(longfile) - g:netrw_maxfilenamelen)
     let szlen = (szlen > 0) ? szlen : 0
-    let fsz  = printf("%".szlen."S",sz)
 
     if g:netrw_sizestyle =~# "[hH]"
      let sz= s:NetrwHumanReadable(sz)
     endif
-	let longfile= printf("%-".g:netrw_maxfilenamelen."S",pfile)
-    let pfile   = longfile."  ".sz." ".strftime(g:netrw_timefmt,getftime(filename))
+    let fsz  = printf("%".szlen."S",sz)
+    let pfile   = longfile."  ".fsz." ".strftime(g:netrw_timefmt,getftime(filename))
 "    call Decho("longlist support: sz=".sz." fsz=".fsz,'~'.expand("<slnum>"))
    endif
 
@@ -11206,7 +11207,7 @@ fun! s:LocalListing()
 "    call Decho("implementing g:netrw_sort_by=".g:netrw_sort_by." (time)")
 "    call Decho("getftime(".filename.")=".getftime(filename),'~'.expand("<slnum>"))
     let t  = getftime(filename)
-    let ft = strpart("000000000000000000",1,18-strlen(t)).t
+    let ft = printf("%018d",t)
 "    call Decho("exe NetrwKeepj put ='".ft.'/'.pfile."'",'~'.expand("<slnum>"))
     let ftpfile= ft.'/'.pfile
     sil! NetrwKeepj put=ftpfile
@@ -11216,10 +11217,7 @@ fun! s:LocalListing()
 "    call Decho("implementing g:netrw_sort_by=".g:netrw_sort_by." (size)")
 "    call Decho("getfsize(".filename.")=".getfsize(filename),'~'.expand("<slnum>"))
     let sz   = getfsize(filename)
-    if g:netrw_sizestyle =~# "[hH]"
-     let sz= s:NetrwHumanReadable(sz)
-    endif
-    let fsz  = strpart("000000000000000000",1,18-strlen(sz)).sz
+    let fsz  = printf("%018d",sz)
 "    call Decho("exe NetrwKeepj put ='".fsz.'/'.filename."'",'~'.expand("<slnum>"))
     let fszpfile= fsz.'/'.pfile
     sil! NetrwKeepj put =fszpfile


### PR DESCRIPTION
If there is a file with a very long filename (longer than g:netrw_maxfilenamelen), and if g:netrw_liststyle is set to 1, no space is inserted between the filename and the filesize and the file cannot be opened because of this.

E.g.:
```
$ echo hello > 12345678901234567890123456789012	  # 32 bytes: OK
$ echo hello > 123456789012345678901234567890123  # 33 bytes: not OK
$ echo hello > 1234567890123456789012345678901234 # 34 bytes: not OK
$ echo hello > こんにちは                         # multibyte filename
$ LC_ALL=C.UTF-8 vim . --clean --cmd "set loadplugins" --cmd "let g:netrw_liststyle=1"
```

Then, it will be shown like this:
```
" ============================================================================
" Netrw Directory Listing                                        (netrw v171)
"   /cygdrive/c/work/netrw-test
"   Sorted by      name
"   Sort sequence: [\/]$,\<core\%(\.\d\+\)\=\>,\.h$,\.c$,\.cpp$,\~\=\*$,*,\.o$,\
"   Quick Help: <F1>:help  -:go up dir  D:delete  R:rename  s:sort-by  x:special
" ==============================================================================
../                              0 Mon Mar 13 19:25:16 2023
./                               0 Mon Mar 13 19:44:58 2023
12345678901234567890123456789012 6 Mon Mar 13 19:29:43 2023
12345678901234567890123456789012346 Mon Mar 13 19:32:40 2023
1234567890123456789012345678901236 Mon Mar 13 19:29:49 2023
こんにちは                  6 Mon Mar 13 19:30:41 2023
```

If the length of the filename is 32 bytes, there is a space between the filename and the filesize. However, when it is longer than 32 bytes, no space is shown.

Also, you may find that the filesize of the multibyte named file is not aligned.

After this patch is applied, it will be shown like this:
```
" ============================================================================
" Netrw Directory Listing                                        (netrw v171)
"   /cygdrive/c/work/netrw-test
"   Sorted by      name
"   Sort sequence: [\/]$,\<core\%(\.\d\+\)\=\>,\.h$,\.c$,\.cpp$,\~\=\*$,*,\.o$,\
"   Quick Help: <F1>:help  -:go up dir  D:delete  R:rename  s:sort-by  x:special
" ==============================================================================
../                               0 Mon Mar 13 19:25:16 2023
./                                0 Mon Mar 13 19:50:36 2023
12345678901234567890123456789012  6 Mon Mar 13 19:29:43 2023
123456789012345678901234567890123  6 Mon Mar 13 19:29:49 2023
1234567890123456789012345678901234  6 Mon Mar 13 19:32:40 2023
こんにちは                        6 Mon Mar 13 19:30:41 2023
```

Now, two space characters are always inserted between the name and the size, and the last line that has multibyte filename is also aligned.