### PR TITLE
Add Free Form ILE RPG filetype files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,7 @@ runtime/autoload/netrw.vim		@cecamp
 runtime/autoload/netrwFileHandlers.vim	@cecamp
 runtime/autoload/netrwSettings.vim	@cecamp
 runtime/autoload/php.vim		@david-szabo97
+runtime/autoload/rpgle.vim		@andlrc
 runtime/autoload/rubycomplete.vim	@segfault @dkearns
 runtime/autoload/tar.vim		@cecamp
 runtime/autoload/vimball.vim		@cecamp
@@ -104,6 +105,7 @@ runtime/doc/pi_tar.txt			@cecamp
 runtime/doc/pi_vimball.txt		@cecamp
 runtime/doc/pi_zip.txt			@cecamp
 runtime/doc/ps1.txt			@heaths
+runtime/doc/ft_rpgle.txt		@andlrc
 runtime/ftplugin/abaqus.vim		@costerwi
 runtime/ftplugin/apache.vim		@dubgeiser 
 runtime/ftplugin/awk.vim		@dkearns
@@ -187,6 +189,7 @@ runtime/ftplugin/rhelp.vim		@jalvesaq
 runtime/ftplugin/rmd.vim		@jalvesaq
 runtime/ftplugin/rnoweb.vim		@jalvesaq
 runtime/ftplugin/routeros.vim		@zainin
+runtime/ftplugin/rpgle.vim		@andlrc
 runtime/ftplugin/rrst.vim		@jalvesaq
 runtime/ftplugin/rst.vim		@marshallward
 runtime/ftplugin/ruby.vim		@tpope @dkearns
@@ -271,6 +274,7 @@ runtime/indent/readline.vim		@dkearns
 runtime/indent/rhelp.vim		@jalvesaq
 runtime/indent/rmd.vim			@jalvesaq
 runtime/indent/rnoweb.vim		@jalvesaq
+runtime/indent/rpgle.vim		@andlrc
 runtime/indent/rrst.vim			@jalvesaq
 runtime/indent/ruby.vim			@AndrewRadev @dkearns
 runtime/indent/sass.vim			@tpope
@@ -431,6 +435,7 @@ runtime/syntax/rmd.vim			@jalvesaq
 runtime/syntax/rng.vim			@jhradilek
 runtime/syntax/routeros.vim		@zainin
 runtime/syntax/rpcgen.vim		@cecamp
+runtime/syntax/rpgle.vim		@andlrc
 runtime/syntax/rrst.vim			@jalvesaq
 runtime/syntax/rst.vim			@marshallward
 runtime/syntax/ruby.vim			@dkearns

--- a/runtime/autoload/rpgle.vim
+++ b/runtime/autoload/rpgle.vim
@@ -1,0 +1,92 @@
+" Vim rpgle autoload file
+" Language:             Free-Form ILE RPG
+" Maintainer:           Andreas Louv <andreas@louv.dk>
+" Last Change:          Mar 14, 2023
+" Version:              1
+
+function rpgle#NextSection(motion, flags, mode) range abort
+  let cnt = v:count1
+  let old_pos = line('.')
+
+  if a:mode ==# 'x'
+    normal! gv
+  endif
+
+  normal! m`0
+
+  while cnt > 0
+    call search(a:motion, a:flags . 'W')
+    if old_pos == line('.')
+      execute 'norm!' a:flags =~# 'b' ? 'gg' : 'G'
+    endif
+    let old_pos = line('.')
+    let cnt = cnt - 1
+  endwhile
+
+  normal! ^
+endfunction
+
+function rpgle#NextNest(flags) abort
+  let flags = a:flags
+  let fn = a:flags ==# 'b' ? 'max' : 'min'
+
+  " We can get the list from "b:match_words" and just use first and last of each group
+  let poss = split(b:match_words, ',')
+           \ ->map({ key, val -> s:nextNestSearch(split(val, ':'), flags) })
+           \ ->filter({ key, val -> val > 0 })
+
+  let new_pos = call(fn, [poss])
+
+  if new_pos > 0
+    execute 'normal! ' . new_pos . 'G^'
+  endif
+endfunction
+
+function s:nextNestSearch(kw, flags) abort
+  if a:kw[0] =~? 'if'
+    let middle = '\<\(else\|elseif\)\>'
+  elseif a:kw[0] =~? 'select'
+    let middle = '\<\(when\|other\)\>'
+  else
+    let middle = ''
+  endif
+
+  return s:findpair(a:kw[0], middle, a:kw[-1], a:flags)
+endfunction
+
+function s:findpair(start, middle, end, flags) abort
+  " Find a pair which isn't inside a string nor comment
+  return searchpair(a:start, a:middle, a:end, a:flags . 'nW',
+                  \ 'synIDattr(synID(line("."), col("."), 1), "name") =~? "string\\|comment"')
+endfunction
+
+function rpgle#Operator(ai) abort
+  let pairs = split(b:match_words, ',')
+            \ ->map({ key, val -> [split(val, ':')[0], split(val, ':')[-1]] })
+
+  " Find a pair which isn't inside a string nor comment
+  let poss = pairs
+           \ ->map({ key, val -> {"pair": val, "pos": s:findpair(val[0], '', val[1], 'b')} })
+           \ ->filter({ key, val -> val.pos > 0 })
+
+  let closest = { "index": 0, "pos": -1 }
+  let index = 0
+  for pos in poss
+    if pos.pos > closest.pos
+      let closest.pos = pos.pos
+      let closest.index = index
+      let closest.pair = pos.pair
+    endif
+    let index = index + 1
+  endfor
+
+  let match_words = b:match_words
+  let b:match_words = join(closest.pair, ':')
+  execute 'normal! ' . closest.pos . 'G^V'
+  normal %
+  let b:match_words = match_words
+
+  if a:ai == 'i'
+    normal! koj
+  endif
+endfunction

--- a/runtime/doc/ft_rpgle.txt
+++ b/runtime/doc/ft_rpgle.txt
@@ -1,0 +1,104 @@
+*ft_rpgle.txt*	For Vim version 9.0.  Last change: 2023 Mar 14`
+
+by Andreas Louv <andreas@louv.dk>
+
+INTRODUCTION					*ft-rpgle*
+
+This is a filetype plugin to work with Free-Form ILE RPG programs.
+
+VARIABLES					*ft-rpgle-variables*
+
+						*g:rpgle_indentStart*
+`g:rpgle_indentStart`	Set the number of leading spaces that should be used
+			when no previous line is to be accounted for.
+
+						*g:no_rpgle_maps*
+`g:no_rpgle_maps`	Set to |v:true| to disable mappings defined in
+			|ft-rpgle-movements| and |ft-rpgle-operator-pending|.
+
+						*g:rpgle_spellString*
+`g:rpgle_spellString`	Set to |v:false| to disable spell checking in string
+			constants.
+
+FILETYPE DETECT					*ft-rpgle-detect*
+
+File ending with ".rpgle" and ".rpgleinc" are detected as ILE RPG files.
+
+INDENT						*ft-rpgle-indent*
+
+Enable by adding the following to your |vimrc| >
+	:filetype indent on
+<
+SYNTAX						*ft-rpgle-syntax*
+
+Enable by adding the following to your |vimrc| >
+	:syntax enable
+<
+SYNTAX FOLDS					*ft-rpgle-fold*
+
+Settings |foldmethod| to 'syntax' to enable the following folds: >
+	if		-> endif
+	dow		-> enddo
+	dou		-> enddo
+	for		-> endfor
+	select		-> endsl
+	dcl-proc	-> end-proc
+	begsr		-> endsr
+<
+MATCH WORDS					*ft-rpgle-match-words*
+
+Enable by adding the following to your |vimrc| >
+	:packadd! matchit
+<
+The following match words is supported: >
+	select		-> when		-> other	-> endsl
+	if		-> elseif	-> else		-> endif
+	dow		-> iter		-> leave	-> enddo
+	dou		-> iter		-> leave	-> enddo
+	for		-> iter		-> leave	-> endfor
+	begsr		-> endsr
+	dcl-proc	-> return	-> end-proc
+	dcl-pi		-> end-pi
+	dcl-pr		-> end-pr
+	monitor		-> on-error	-> endmon
+<
+MOVEMENTS					*ft-rpgle-movements*
+
+Enable by adding the following to your |vimrc| >
+	:filetype on
+<
+						*ft-rpgle-[[*
+[[			Jump to previous dcl-proc keyword
+						*ft-rpgle-]]*
+]]			Jump to next dcl-proc keyword
+						*ft-rpgle-[]*
+[]			Jump to previous end-proc keyword
+						*ft-rpgle-][*
+][			Jump to next end-proc keyword
+						*ft-rpgle-gd*
+gd			Goto local Declaration. When the cursor is on a local
+			variable, this command will jump to its declaration.
+			Use |gD| to goto global declaration.
+						*ft-rpgle-[{*
+[{			Jump back to the block opener at the start of the
+			current code block, i.e. pressing |[{| inside an
+			if-statement will jump to the if keyword.
+						*ft-rpgle-]}*
+]}			Jump forward to the block closer at the end of the
+			current code block, i.e. pressing |]}| inside an
+			if-statement will jump to the endif keyword.
+
+OPERATOR PENDING				*ft-rpgle-operator-pending*
+
+Enable by adding the following to your |vimrc| >
+	:filetype on
+<
+a}						*ft-rpgle-a}* *ft-rpgle-a{*
+a{						*ft-rpgle-aB*
+aB			See |aB|
+
+i}						*ft-rpgle-i}* *ft-rpgle-i{*
+i{						*ft-rpgle-iB*
+iB			See |iB|
+
+vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/ftplugin/rpgle.vim
+++ b/runtime/ftplugin/rpgle.vim
@@ -1,0 +1,132 @@
+" Vim ftplugin file
+" Language:             Free-Form ILE RPG
+" Maintainer:           Andreas Louv <andreas@louv.dk>
+" Last Change:          Mar 14, 2023
+" Version:              1
+
+if exists('b:did_ftplugin')
+  finish
+endif
+
+let b:did_ftplugin = 1
+
+setlocal iskeyword+=-,%
+
+setlocal suffixesadd=.rpgle,.rpgleinc
+setlocal include=^\\s*/\\%(include\\\|copy\\)
+
+setlocal comments=s1:/*,mb:*,ex:*/,://,:*
+
+" ILE RPG is in case-sensitive
+setlocal tagcase=ignore nosmartcase ignorecase
+
+let b:match_words = '\<select\>:\<when\>:\<other\>:\<endsl\>'
+                \ . ',\<if\>:\<elseif\>:\<else\>:\<endif\>'
+                \ . ',\<do[uw]\>:\<iter\>:\<leave\>:\<enddo\>'
+                \ . ',\<for\>:\<iter\>:\<leave\>:\<endfor\>'
+                \ . ',\<begsr\>:\<endsr\>'
+                \ . ',\<dcl-proc\>:\<return\>:\<end-proc\>'
+                \ . ',\<dcl-pi\>:\<end-pi\>'
+                \ . ',\<dcl-pr\>:\<end-pr\>'
+                \ . ',\<monitor\>:\<on-error\>:\<endmon\>'
+                \ . ',\<dcl-ds\>:\<\%(likeds\|extname\|end-ds\)\>'
+
+function s:GoToDecl(curword) abort
+  keepj call rpgle#NextSection('^\s*dcl-proc', 'b', '')
+  call setreg('/', '\<' .. a:curword .. '\>', 'c')
+  keepj norm! n
+endfunction
+
+" section jumping
+nnoremap <script> <buffer> <silent> <Plug>RpgleGoToDeclaration
+       \ :<C-U>call <Sid>GoToDecl(expand('<cword>'))<Cr>
+nnoremap <script> <buffer> <silent> <Plug>RpgleNextProcStart
+       \ :<C-U>call rpgle#NextSection('^\s*dcl-proc', '', '')<CR>
+nnoremap <script> <buffer> <silent> <Plug>RpgleNextProcEnd
+       \ :<C-U>call rpgle#NextSection('^\s*end-proc', '', '')<CR>
+nnoremap <script> <buffer> <silent> <Plug>RpglePrevProcStart
+       \ :<C-U>call rpgle#NextSection('^\s*dcl-proc', 'b', '')<CR>
+nnoremap <script> <buffer> <silent> <Plug>RpglePrevProcEnd
+       \ :<C-U>call rpgle#NextSection('^\s*end-proc', 'b', '')<CR>
+xnoremap <script> <buffer> <silent> <Plug>XRpgleNextProcStart
+       \ :<C-U>call rpgle#NextSection('^\s*dcl-proc', '', 'x')<CR>
+xnoremap <script> <buffer> <silent> <Plug>XRpgleNextProcEnd
+       \ :<C-U>call rpgle#NextSection('^\s*end-proc', '', 'x')<CR>
+xnoremap <script> <buffer> <silent> <Plug>XRpglePrevProcStart
+       \ :<C-U>call rpgle#NextSection('^\s*dcl-proc', 'b', 'x')<CR>
+xnoremap <script> <buffer> <silent> <Plug>XRpglePrevProcEnd
+       \ :<C-U>call rpgle#NextSection('^\s*end-proc', 'b', 'x')<CR>
+
+" Nest jumping
+nnoremap <script> <buffer> <silent> <Plug>RpglePrevBlock
+       \ :call rpgle#NextNest('b')<CR>
+nnoremap <script> <buffer> <silent> <Plug>RpgleNextBlock
+       \ :call rpgle#NextNest('')<CR>
+
+" Operator Pending brackets
+noremap <script> <buffer> <silent> <Plug>RpgleAroundBlock
+       \ :<C-U>call rpgle#Operator('a')<CR>
+noremap <script> <buffer> <silent> <Plug>RpgleInnerBlock
+       \ :<C-U>call rpgle#Operator('i')<CR>
+
+if !exists("g:no_plugin_maps") && !exists("g:no_rpgle_maps")
+  nmap <buffer> <silent> gd <Plug>RpgleGoToDeclaration
+  nmap <buffer> <silent> ]] <Plug>RpgleNextProcStart
+  nmap <buffer> <silent> ][ <Plug>RpgleNextProcEnd
+  nmap <buffer> <silent> [[ <Plug>RpglePrevProcStart
+  nmap <buffer> <silent> [] <Plug>RpglePrevProcEnd
+
+  xmap <buffer> <silent> ]] <Plug>XRpgleNextProcStart
+  xmap <buffer> <silent> ][ <Plug>XRpgleNextProcEnd
+  xmap <buffer> <silent> [[ <Plug>XRpglePrevProcStart
+  xmap <buffer> <silent> [] <Plug>XRpglePrevProcEnd
+
+  nmap <buffer> [{ <Plug>RpglePrevBlock
+  nmap <buffer> ]} <Plug>RpgleNextBlock
+
+  omap <buffer> a} <Plug>RpgleAroundBlock
+  omap <buffer> a{ <Plug>RpgleAroundBlock
+  omap <buffer> aB <Plug>RpgleAroundBlock
+  omap <buffer> i} <Plug>RpgleInnerBlock
+  omap <buffer> i{ <Plug>RpgleInnerBlock
+  omap <buffer> iB <Plug>RpgleInnerBlock
+
+  xmap <buffer> a} <Plug>RpgleAroundBlock
+  xmap <buffer> a{ <Plug>RpgleAroundBlock
+  xmap <buffer> aB <Plug>RpgleAroundBlock
+  xmap <buffer> i} <Plug>RpgleInnerBlock
+  xmap <buffer> i{ <Plug>RpgleInnerBlock
+  xmap <buffer> iB <Plug>RpgleInnerBlock
+endif
+
+let b:undo_ftplugin = 'setlocal iskeyword<'
+  \ . '|setlocal suffixesadd<'
+  \ . '|setlocal include<'
+  \ . '|setlocal comments<'
+  \ . '|setlocal tagcase<'
+  \ . '|setlocal nosmartcase<'
+  \ . '|setlocal ignorecase<'
+  \ . '|silent! nunmap <buffer> gd'
+  \ . '|silent! nunmap <buffer> ]]'
+  \ . '|silent! nunmap <buffer> ]['
+  \ . '|silent! nunmap <buffer> [['
+  \ . '|silent! nunmap <buffer> []'
+  \ . '|silent! xunmap <buffer> ]]'
+  \ . '|silent! xunmap <buffer> ]['
+  \ . '|silent! xunmap <buffer> [['
+  \ . '|silent! xunmap <buffer> []'
+  \ . '|silent! nunmap <buffer> [{'
+  \ . '|silent! nunmap <buffer> ]}'
+  \ . '|silent! ounmap <buffer> a}'
+  \ . '|silent! ounmap <buffer> a{'
+  \ . '|silent! ounmap <buffer> aB'
+  \ . '|silent! ounmap <buffer> i}'
+  \ . '|silent! ounmap <buffer> i{'
+  \ . '|silent! ounmap <buffer> iB'
+  \ . '|silent! xunmap <buffer> a}'
+  \ . '|silent! xunmap <buffer> a{'
+  \ . '|silent! xunmap <buffer> aB'
+  \ . '|silent! xunmap <buffer> i}'
+  \ . '|silent! xunmap <buffer> i{'
+  \ . '|silent! xunmap <buffer> iB'
+  \ . '|unlet! b:match_words'

--- a/runtime/indent/rpgle.vim
+++ b/runtime/indent/rpgle.vim
@@ -1,0 +1,111 @@
+" Vim indent file
+" Language:             Free-Form ILE RPG
+" Maintainer:           Andreas Louv <andreas@louv.dk>
+" Last Change:          Mar 14, 2023
+" Version:              1
+
+if exists('b:did_indent')
+  finish
+endif
+
+let b:did_indent = 1
+
+setlocal indentexpr=GetRpgleIndent()
+setlocal indentkeys=o,O
+setlocal indentkeys+=0*
+setlocal indentkeys+=0=~if,0=~elseif,0=~else,0=~endif
+setlocal indentkeys+=0=~dou,0=~dow,0=~enddo
+setlocal indentkeys+=0=~for,0=~endfor
+setlocal indentkeys+=0=~monitor,0=~on-error,0=~endmon
+setlocal indentkeys+=0=~select,0=~when,0=~other,0=~endsl
+setlocal indentkeys+=0=~dcl-proc,0=~end-proc
+setlocal indentkeys+=0=~begsr,0=~endsr
+setlocal indentkeys+=0=~dcl-pi,0=~end-pi
+setlocal indentkeys+=0=~dcl-pr,0=~end-pr
+setlocal indentkeys+=0=~dcl-ds,0=~end-ds
+setlocal nosmartindent
+
+let b:undo_indent = 'setlocal indentexpr< indentkeys< smartindent<'
+
+if exists('*GetRpgleIndent')
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! GetRpgleIndent()
+  let cnum = v:lnum
+  let pnum = prevnonblank(cnum - 1)
+
+  " There is no lines to determinate indent, so use what is set in
+  " "g:rpgle_indentStart", check if "**FREE" is present or default to "7".
+  if pnum == 0
+    if exists('g:rpgle_indentStart')
+      return g:rpgle_indentStart
+    elseif getline(1) =~? '^\*\*FREE$'
+      return 0
+    else
+      return 7
+    endif
+  endif
+
+  let pind = indent(pnum)
+
+  let pline = getline(pnum)
+  let cline = getline(cnum)
+
+  " Continues comments should indent the "*" one space
+  if cline =~# '^\s*\*' && pline =~# '^\s*/\*' && pline !~# '\*/'
+    return pind + 1
+  endif
+
+  " Continues comments should de indent one space when ended
+  if pline =~# '^\s*\*.*\*/' || cline =~# '^\s*\\\*.*\*/'
+    return pind - 1
+  endif
+
+  " A "when" which follows a "select" should be indented:
+  " All other "when" should be dedented
+  if cline =~? '^\s*\<when\>'
+    return pline =~? '^\s*\<select\>;' ?
+      \ pind + shiftwidth() : pind - shiftwidth()
+  endif
+
+  " "dcl-pi", "dcl-pr", and "dcl-ds" with no parameters should not
+  " indent the "end-xx":
+  if pline =~? '^\s*\<dcl-pi\>' && cline =~? '^\s*\<end-pi\>'
+  \ || pline =~? '^\s*\<dcl-pr\>' && cline =~? '^\s*\<end-pr\>'
+  \ || pline =~? '^\s*\<dcl-ds\>' && cline =~? '^\s*\<end-ds\>'
+    return pind
+  endif
+
+  " "dcl-ds" with "likeds" or "likerec" on the same line doesn't take a
+  " definition and should not do any indent:
+  if pline =~? '^\s*\<dcl-ds\>' && pline =~? '\<likeds\>\|\<likerec\>'
+    return pind
+  endif
+
+  " Add indent for opening keywords:
+  if pline =~ '^\s*\%(if\|else\|elseif\|dou\|dow\|for\|monitor\|on-error\|' .
+      \ 'on-error\|when\|other\|dcl-proc\|begsr\|dcl-pi\|dcl-pr\|dcl-ds\)\>'
+    return pind + shiftwidth()
+  endif
+
+  " Remove indent for closing keywords:
+  if cline =~ '^\s*\<\%(endif\|enddo\|endfor\|endmon\|other\|else\|' .
+    \ 'elseif\|on-error\|end-pi\|end-proc\|endsr\|end-pr\|end-ds\)\>'
+    return pind - shiftwidth()
+  endif
+
+  " "endsl" have to dedent two levels, to handle the extra indent from "when"
+  if cline =~? '^\s*\<endsl\>'
+    return pind - shiftwidth() * 2
+  endif
+
+  " If no match return the same indent as before:
+  return pind
+endfunction
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/syntax/rpgle.vim
+++ b/runtime/syntax/rpgle.vim
@@ -1,0 +1,411 @@
+" Vim syntax file
+" Language:             Free-Form ILE RPG
+" Maintainer:           Andreas Louv <andreas@louv.dk>
+" Last Change:          Mar 14, 2023
+" Version:              1
+
+if exists('b:current_syntax')
+  finish
+endif
+
+let b:current_syntax = 'rpgle'
+
+syntax case ignore
+syntax iskeyword @,48-57,192-255,-,%,*,/,_
+
+" Comments
+
+syntax match   rpgleLineComment      '//.*'
+                                   \ contains=@rpgleCommentProps
+syntax region  rpgleBracketedComment start='/\*'
+                                   \ end='\*/'
+                                   \ contains=@rpgleCommentProps
+syntax cluster rpgleComment          contains=rpgleLineComment,rpgleBracketedComment
+
+syntax cluster rpgleCommentProps contains=rpgleTodo,@Spell
+syntax keyword rpgleTodo         contained TODO FIXME
+
+" Compiler directive
+syntax keyword rpglePreProc **FREE
+
+syntax keyword rpglePreProc /COPY /DEFINE /EJECT /ELSE /ELSEIF /END-FREE
+                          \ /ENDIF /EOF /FREE /IF /INCLUDE /RESTORE /SET
+                          \ /SPACE /TITLE /UNDEFINE /SET
+                          \ nextgroup=rpglePreProcValue
+
+syntax match rpglePreProcValue /.*/ contained display
+
+" Header Specs
+" CTL-OPT ... ;
+syntax region rpgleCtlSpec   matchgroup=rpgleKeywords
+                           \ start=/\<CTL-OPT\>/
+                           \ end=/;/
+                           \ contains=@rpgleCtlProps
+syntax cluster rpgleCtlProps contains=rpgleCtlKeywords,rpgleNumber,
+                                     \@rpgleString,rpgleConstant,rpgleError,
+                                     \rpgleCtlParanBalance
+
+syntax region rpgleCtlParanBalance matchgroup=rpgleParen
+                                 \ start=/(/
+                                 \ end=/)/
+                                 \ contains=@rpgleCtlProps
+
+" Header Keywords
+syntax keyword rpgleCtlKeywords contained
+                              \ ALLOC ACTGRP ALTSEQ ALWNULL AUT BNDDIR CCSID
+                              \ CCSIDCVT COPYNEST COPYRIGHT CURSYM CVTOPT
+                              \ DATEDIT DATFMT DCLOPT DEBUG DECEDIT DECPREC
+                              \ DFTACTGRP DFTNAME ENBPFRCOL EXPROPTS
+                              \ EXTBININT  FIXNBR FLYDIV FORMSALIGN FTRANS
+                              \ GENLVL INDENT  INTPREC LANGID MAIN NOMAIN
+                              \ OPENOPT OPTIMIZE  OPTION PGMINFO PRFDTA
+                              \ SRTSEQ STGMDL TEXT THREAD  TIMFMT TRUNCNBR
+                              \ USERPRF VALIDATE
+
+" Declaration Specs
+
+" Numbers and Strings
+syntax match   rpgleNumber display
+                         \ /\<\%(\d\+\.\d\+\|\.\d\+\|\d\+\.\|\d\+\)\>/
+
+syntax match   rpgleString /'\([+-]\n\|''\|[^']\)*'/ contains=@rpgleStringProps
+syntax cluster rpgleString contains=rpgleString
+
+if get(g:, 'rpgle_spellString', 1)
+  syntax cluster rpgleStringProps contains=@Spell
+endif
+
+" Constants
+syntax keyword rpgleConstant *ALL *BLANK *BLANKS *ENTRY *HIVAL *LOVAL *NULL
+                           \ *OFF *ON *ZERO *ZEROS
+
+" *IN01 .. *IN99, *INH1 .. *INH9, *INL1 .. *INL9, *INLR, *INRT
+syntax match   rpgleSpecialKey display /\%(\*IN0[1-9]\|\*IN[1-9][0-9]\)/
+syntax match   rpgleSpecialKey display /\*INH[1-9]/
+syntax match   rpgleSpecialKey display /\*INL[1-9]/
+syntax match   rpgleSpecialKey display /\*INU[1-8]/
+syntax keyword rpgleSpecialKey *INLR *INRT
+
+" Operators
+syntax match   rpgleOperator display /<>/
+syntax match   rpgleOperator display />=/
+syntax match   rpgleOperator display /<=/
+syntax match   rpgleOperator display /[*=><+-]/
+
+" Standalone, Constant
+syntax region  rpgleDclSpec display matchgroup=rpgleDclKeywords
+                          \ start=/\<DCL-[SC]\>/
+                          \ end=/$/
+                          \ contains=rpgleDclProp
+
+" Procedure Interface
+syntax keyword rpgleError END-PI
+syntax region  rpgleDclSpec   matchgroup=rpgleDclKeywords
+                            \ start=/\<DCL-PI\>/
+                            \ end=/\<END-PI\>/
+                            \ contains=rpgleDclProp,rpgleDclPiName
+                            \ fold
+
+" Special PI Name
+syntax keyword rpgleDclPiName *N
+
+" Prototype
+syntax keyword rpgleError END-PR
+syntax region  rpgleDclSpec matchgroup=rpgleDclKeywords
+                          \ start=/\<DCL-PR\>/
+                          \ end=/\<END-PR\>/
+                          \ contains=rpgleDclProp
+
+" Data Structure
+syntax keyword rpgleError LIKEDS LIKEREC END-DS
+
+syntax region  rpgleDclSpec matchgroup=rpgleDclKeywords
+                          \ start=/\<DCL-DS\>/
+                          \ end=/\<END-DS\>/
+                          \ contains=rpgleDclProp
+
+" These this syntax regions cannot be "display", even though it is on one line,
+" as the rule above could be matched wrongly then.
+syntax region  rpgleDclSpec matchgroup=rpgleDclKeywords
+                          \ start=/\<DCL-DS\>\ze.*LIKEDS/
+                          \ start=/\<DCL-DS\>\ze.*LIKEREC/
+                          \ end=/$/
+                          \ contains=rpgleDclProp
+
+" Declaration Types
+syntax keyword rpgleDclTypes contained
+                           \ BINDEC CHAR DATE DATE FLOAT GRAPH IND INT OBJECT
+                           \ PACKED POINTER TIME TIMESTAMP UCS2 UCS2 UNS
+                           \ VARCHAR VARGRAPH VARUCS2 ZONED
+
+" Declaration Keywords
+syntax keyword rpgleDclKeywords contained
+                              \ ALIAS ALIGN ALT ALTSEQ ASCEND BASED CCSID
+                              \ CLASS CONST CTDATA DATFMT DESCEND DIM DTAARA
+                              \ EXPORT EXT EXTFLD EXTFMT EXTNAME EXTPGM
+                              \ EXTPROC FROMFILE IMPORT INZ LEN LIKE LIKEDS
+                              \ LIKEFILE LIKEREC NOOPT NULLIND OCCURS OPDESC
+                              \ OPTIONS OVERLAY PACKEVEN PERRCD POS PREFIX
+                              \ PSDS QUALIFIED RTNPARM STATIC TEMPLATE TIMFMT
+                              \ TOFILE VALUE
+
+" Declaration Constants
+syntax keyword rpgleDclSpecialKeys contained
+                               \ *NOPASS *OMIT *VARSIZE *STRING *RIGHTADJ
+
+syntax region rpgleDclParenBalance matchgroup=rpgleParan
+                                 \ start=/(/
+                                 \ end=/)/
+                                 \ contains=@rpgleComment,rpgleDclSpecialKeys,
+                                           \rpgleNumber,@rpgleString,
+                                           \rpgleConstant,rpgleError,
+                                           \rpgleDclParenBalance,rpgleBIF
+
+
+syntax match rpgleDclProp     /\s*/  contained nextgroup=rpgleDclPropName
+syntax match rpgleDclPropName /\k\+/ contained nextgroup=rpgleDclPropTail
+syntax match rpgleDclPropTail /.\+/  contained
+                                   \ contains=@rpgleComment,rpgleDclTypes,
+                                             \rpgleDclKeywords,rpgleError,
+                                             \rpgleDclParenBalance
+
+" Calculation Specs
+
+" IF ... ENDIF
+syntax keyword rpgleError ENDIF
+syntax region  rpgleIf   matchgroup=rpgleConditional
+                       \ start=/\<IF\>/
+                       \ end=/\<ENDIF\>/
+                       \ contains=@rpgleNest,rpgleElse
+                       \ fold
+
+" ELSE ELSEIF
+syntax keyword rpgleError ELSE ELSEIF
+syntax keyword rpgleElse contained ELSE ELSEIF
+
+" NOT, AND, OR
+syntax keyword rpgleConditional NOT AND OR
+
+" DOW .. ENDDO, DOU .. ENDDO
+syntax keyword rpgleError ENDDO
+syntax region  rpgleDo matchgroup=rpgleRepeat
+                     \ start=/\<DO[WU]\>/
+                     \ end=/\<ENDDO\>/
+                     \ contains=@rpgleNest
+                     \ fold
+
+" FOR ... ENDFOR
+syntax region  rpgleFor matchgroup=rpgleRepeat
+                      \ start=/\<FOR\>/
+                      \ end=/\<ENDFOR\>/
+                      \ contains=@rpgleNest
+                      \ fold
+syntax keyword rpgleError ENDFOR
+
+" ITER, LEAVE
+syntax keyword rpgleRepeat contained ITER LEAVE
+
+" MONITOR ... ENDMON
+syntax keyword rpgleError ENDMON
+syntax region  rpgleMonitor matchgroup=rpgleConditional
+                          \ start=/\<MONITOR\>/
+                          \ end=/\<ENDMON\>/
+                          \ contains=@rpgleNest,rpgleOnError
+                          \ fold
+
+" ON-ERROR
+syntax keyword rpgleError ON-ERROR
+syntax keyword rpgleOnError contained ON-ERROR
+
+" SELECT ... ENDSL
+syntax keyword rpgleError ENDSL
+syntax region  rpgleSelect    matchgroup=rpgleKeywords
+                            \ start=/\<SELECT\>/
+                            \ end=/\<ENDSL\>/
+                            \ contains=@rpgleNest,rpgleWhenOther
+                            \ fold
+
+" WHEN, OTHER
+syntax keyword rpgleError WHEN OTHER
+syntax keyword rpgleWhenOther contained WHEN OTHER
+
+" Exec SQL
+syntax region rpgleSql matchgroup=rpgleKeywords
+                     \ start=/\<EXEC\_s\+SQL\>/
+                     \ end=/;/
+
+" Build In Functions
+syntax match rpgleError /%\w\+/
+
+syntax keyword rpgleBIF %ABS
+                      \ %ADDR
+                      \ %ALLOC
+                      \ %BITAND
+                      \ %BITNOT
+                      \ %BITOR
+                      \ %BITXOR
+                      \ %CHAR
+                      \ %CHECK
+                      \ %CHECKR
+                      \ %DATA
+                      \ %DATE
+                      \ %DAYS
+                      \ %DEC
+                      \ %DECH
+                      \ %DECPOS
+                      \ %DIFF
+                      \ %DIV
+                      \ %EDITC
+                      \ %EDITFLT
+                      \ %EDITW
+                      \ %ELEM
+                      \ %EOF
+                      \ %EQUAL
+                      \ %ERROR
+                      \ %FIELDS
+                      \ %FLOAT
+                      \ %FOUND
+                      \ %GRAPH
+                      \ %HANDLER
+                      \ %HOURS
+                      \ %INT
+                      \ %INTH
+                      \ %KDS
+                      \ %LEN
+                      \ %LOOKUPxx
+                      \ %MAX
+                      \ %MIN
+                      \ %MINUTES
+                      \ %MONTHS
+                      \ %MSECONDS
+                      \ %NULLIND
+                      \ %OCCUR
+                      \ %OPEN
+                      \ %PADDR
+                      \ %PARMS
+                      \ %PARMNUM
+                      \ %PARSER
+                      \ %PROC
+                      \ %REALLOC
+                      \ %REM
+                      \ %REPLACE
+                      \ %SCAN
+                      \ %SCANR
+                      \ %SCANRPL
+                      \ %SECONDS
+                      \ %SHTDN
+                      \ %SIZE
+                      \ %SQRT
+                      \ %STATUS
+                      \ %STR
+                      \ %SUBARR
+                      \ %SUBDT
+                      \ %SUBST
+                      \ %THIS
+                      \ %TIME
+                      \ %TIMESTAMP
+                      \ %TLOOKUPxx
+                      \ %TRIM
+                      \ %TRIML
+                      \ %TRIMR
+                      \ %UCS2
+                      \ %UNS
+                      \ %UNSH
+                      \ %XFOOT
+                      \ %XLATE
+                      \ %XML
+                      \ %YEARS
+
+" Procedures
+syntax match rpgleError /)/
+syntax region  rpgleProcCall matchgroup=rpgleParan
+                           \ start=/%\@1<!\<\w\+(/
+                           \ end=/)/
+                           \ contains=@rpgleProcArgs
+
+syntax cluster rpgleProcArgs contains=rpgleBIF,@rpgleComment,rpgleConstant,
+                                     \rpgleNumber,rpglePreProc,rpgleProcCall,
+                                     \rpgleProcOmit,rpgleSpecialKey,
+                                     \@rpgleString,rpgleError,rpgleParenBalance
+syntax keyword rpgleProcOmit contained *OMIT
+syntax keyword rpgleKeywords RETURN
+
+" BEGSR .. ENDSR
+syntax keyword rpgleError ENDSR
+syntax region rpgleSub matchgroup=rpgleKeywords
+                     \ start=/\<BEGSR\>/
+                     \ end=/\<ENDSR\>/
+                     \ contains=@rpgleNest
+                     \ fold
+
+" EXSR
+syntax keyword rpgleKeywords EXSR
+
+" Procedure Specs
+
+syntax region  rpgleDclProcBody   matchgroup=rpgleDclProc
+                                \ start=/\<DCL-PROC\>/
+                                \ end=/\<END-PROC\>/
+                                \ contains=@rpgleDclProcNest
+                                \ fold
+syntax cluster rpgleDclProcNest   contains=@rpgleNest,rpgleSub,rpgleDclSpec,
+                                         \rpgleDclProcName,rpgleError
+syntax keyword rpgleError END-PROC
+
+" Procedure Name
+syntax match   rpgleDclProcName   display contained skipwhite
+                                \ /\%(DCL-PROC\s\+\)\@10<=\w\+/
+                                \ nextgroup=rpgleDclProcExport
+
+syntax keyword rpgleError END-PROC
+
+" Export
+syntax keyword rpgleDclProcExport contained EXPORT
+
+syntax region rpgleParenBalance matchgroup=rpgleParan
+                              \ start=/(/
+                              \ end=/)/
+                              \ contains=@rpgleNest
+
+" All nestable groups, i.e. mostly Calculation Spec keywords:
+syntax cluster rpgleNest contains=rpgleBIF,@rpgleComment,rpgleConditional,
+                                 \rpgleConstant,rpgleDo,rpgleFor,rpgleIf,
+                                 \rpgleKeywords,rpgleMonitor,rpgleNumber,
+                                 \rpgleOperator,rpglePreProc,rpgleProcCall,
+                                 \rpgleRepeat,rpgleSelect,rpgleSpecialKey,
+                                 \rpgleSql,@rpgleString,rpgleError,
+                                 \rpgleParenBalance
+
+syntax sync ccomment rpgleBracketedComment
+
+hi def link rpgleError            Error
+hi def link rpglePreProc          PreProc
+hi def link rpgleProc             Function
+hi def link rpgleSpecialKey       SpecialKey
+hi def link rpgleNumber           Number
+hi def link rpgleString           String
+hi def link rpgleOperator         Operator
+hi def link rpgleComment          Comment
+hi def link rpgleTodo             Todo
+hi def link rpgleConstant         Constant
+hi def link rpgleConditional      Conditional
+hi def link rpgleRepeat           Repeat
+hi def link rpgleKeywords         Keyword
+hi def link rpgleSpecial          Special
+hi def link rpgleTypes            Type
+
+hi def link rpgleLineComment      rpgleComment
+hi def link rpgleBracketedComment rpgleComment
+
+hi def link rpgleProcOmit         rpgleSpecialKey
+hi def link rpgleCtlKeywords      rpgleKeywords
+hi def link rpgleDclTypes         rpgleTypes
+hi def link rpgleDclKeywords      rpgleKeywords
+hi def link rpgleDclProc          rpgleKeywords
+hi def link rpgleDclProcExport    rpgleKeywords
+hi def link rpgleDclPiName        rpgleSpecial
+hi def link rpgleDclSpecialKeys   rpgleSpecialKey
+hi def link rpgleElse             rpgleConditional
+hi def link rpgleOnError          rpgleKeywords
+hi def link rpgleWhenOther        rpgleKeywords
+hi def link rpgleBIF              rpgleSpecial


### PR DESCRIPTION
It seems like vim doesn't ship with syntax / filetype files for the ILE RPG programming language:

https://en.wikipedia.org/wiki/IBM_RPG and  
https://www.ibm.com/docs/en/i/7.5?topic=rpg-ile-reference

This PR contains ftdetect, syntax, indent and ftplugin files for Free Form ILE RPG files.

The files `*.rpgle` and `*.rpgleinc` will be detected as being the `filetype=rpgle`.

This PR contains adopted code from https://github.com/andlrc/rpgle.vim
