### PR TITLE
Make converted locale files build in macOS, and fix zh_TW.po

### DIFF
--- a/runtime/lang/Makefile
+++ b/runtime/lang/Makefile
@@ -25,24 +25,25 @@ all: \
 		menu_hu_hu.iso_8859-2.vim \
 		menu_sk_sk.iso_8859-2.vim \
 
+SED = LANG=C sed
 
 # Convert menu_zh_cn.utf-8.vim to create menu_chinese_gb.936.vim.
 menu_chinese_gb.936.vim: menu_zh_cn.utf-8.vim
 	rm -f menu_chinese_gb.936.vim
 	iconv -f utf-8 -t cp936 menu_zh_cn.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding cp936/' -e 's/" Original translations/" Generated from menu_zh_cn.utf-8.vim, DO NOT EDIT/' > menu_chinese_gb.936.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding cp936/' -e 's/" Original translations/" Generated from menu_zh_cn.utf-8.vim, DO NOT EDIT/' > menu_chinese_gb.936.vim
 
 # Convert menu_zh_tw.utf-8.vim to create menu_chinese_taiwan.950.vim.
 menu_chinese_taiwan.950.vim: menu_zh_tw.utf-8.vim
 	rm -f menu_chinese_taiwan.950.vim
 	iconv -f utf-8 -t cp950 menu_zh_tw.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding cp950/' -e 's/" Original translations/" Generated from menu_zh_tw.utf-8.vim, DO NOT EDIT/' > menu_chinese_taiwan.950.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding cp950/' -e 's/" Original translations/" Generated from menu_zh_tw.utf-8.vim, DO NOT EDIT/' > menu_chinese_taiwan.950.vim
 
 # Convert menu_cs_cz.utf-8.vim to create menu_cs_cz.iso_8859-2.vim.
 menu_cs_cz.iso_8859-2.vim: menu_cs_cz.utf-8.vim
 	rm -f menu_cs_cz.iso_8859-2.vim
 	iconv -f utf-8 -t iso8859-2 menu_cs_cz.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding iso-8859-2/' \
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding iso-8859-2/' \
 			-e 's/" Original translations/" Generated from menu_cs_cz.utf-8.vim, DO NOT EDIT/' \
 			-e 's/\(" Menu Translations:.*\)(.*)/\1(ISO8859-2)/'  \
 			> menu_cs_cz.iso_8859-2.vim
@@ -51,7 +52,7 @@ menu_cs_cz.iso_8859-2.vim: menu_cs_cz.utf-8.vim
 menu_czech_czech_republic.1250.vim: menu_cs_cz.utf-8.vim
 	rm -f menu_czech_czech_republic.1250.vim
 	iconv -f utf-8 -t cp1250 menu_cs_cz.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding cp1250/'  \
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding cp1250/'  \
 		-e 's/" Original translations/" Generated from menu_cs_cz.utf-8.vim, DO NOT EDIT/'  \
 		-e 's/\(" Menu Translations:.*\)(.*)/\1(CP1250)/'  \
 		> menu_czech_czech_republic.1250.vim
@@ -59,7 +60,7 @@ menu_czech_czech_republic.1250.vim: menu_cs_cz.utf-8.vim
 # Convert menu_cs_cz.utf-8.vim to create menu_czech_czech_republic.ascii.vim.
 menu_czech_czech_republic.ascii.vim: menu_cs_cz.utf-8.vim
 	rm -f menu_czech_czech_republic.ascii.vim
-	sed -e 's/Á/A/g' -e 's/á/a/g' -e 's/Č/C/g' -e 's/č/c/g' -e 's/Ď/D/g' \
+	$(SED) -e 's/Á/A/g' -e 's/á/a/g' -e 's/Č/C/g' -e 's/č/c/g' -e 's/Ď/D/g' \
 		-e 's/ď/d/g' -e 's/É/E/g' -e 's/é/e/g' -e 's/Ě/E/g' -e 's/ě/e/g' \
 		-e 's/Í/I/g' -e 's/í/i/g' -e 's/Ň/N/g' -e 's/ň/n/g' -e 's/Ó/O/g' \
 		-e 's/ó/o/g' -e 's/Ř/R/g' -e 's/ř/r/g' -e 's/Š/S/g' -e 's/š/s/g' \
@@ -74,7 +75,7 @@ menu_czech_czech_republic.ascii.vim: menu_cs_cz.utf-8.vim
 menu_ja_jp.euc-jp.vim: menu_ja_jp.utf-8.vim
 	rm -f menu_ja_jp.euc-jp.vim
 	iconv -f utf-8 -t euc-jp menu_ja_jp.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding euc-jp/'  \
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding euc-jp/'  \
 		-e 's/" Original translations/" Generated from menu_ja_jp.utf-8.vim, DO NOT EDIT/'  \
 		-e 's/\(" Menu Translations:.*\)(.*)/\1(EUC-JP)/'  \
 		> menu_ja_jp.euc-jp.vim
@@ -83,7 +84,7 @@ menu_ja_jp.euc-jp.vim: menu_ja_jp.utf-8.vim
 menu_japanese_japan.932.vim: menu_ja_jp.utf-8.vim
 	rm -f menu_japanese_japan.932.vim
 	iconv -f utf-8 -t cp932 menu_ja_jp.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding cp932/'  \
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding cp932/'  \
 		-e 's/" Original translations/" Generated from menu_ja_jp.utf-8.vim, DO NOT EDIT/' \
 		-e 's/\(" Menu Translations:.*\)(.*)/\1(CP932)/'  \
 		> menu_japanese_japan.932.vim
@@ -92,67 +93,67 @@ menu_japanese_japan.932.vim: menu_ja_jp.utf-8.vim
 menu_ko_kr.euckr.vim: menu_ko_kr.utf-8.vim
 	rm -f menu_ko_kr.euckr.vim
 	iconv -f utf-8 -t euc-kr menu_ko_kr.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding euc-kr/' -e 's/" Original translations/" Generated from menu_ko_kr.utf-8.vim, DO NOT EDIT/' > menu_ko_kr.euckr.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding euc-kr/' -e 's/" Original translations/" Generated from menu_ko_kr.utf-8.vim, DO NOT EDIT/' > menu_ko_kr.euckr.vim
 
 # Convert menu_pl_pl.utf-8.vim to create menu_pl_pl.iso_8859-2.vim.
 menu_pl_pl.iso_8859-2.vim: menu_pl_pl.utf-8.vim
 	rm -f menu_pl_pl.iso_8859-2.vim
 	iconv -f utf-8 -t iso8859-2 menu_pl_pl.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding iso-8859-2/' -e 's/" Original translations/" Generated from menu_pl_pl.utf-8.vim, DO NOT EDIT/' > menu_pl_pl.iso_8859-2.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding iso-8859-2/' -e 's/" Original translations/" Generated from menu_pl_pl.utf-8.vim, DO NOT EDIT/' > menu_pl_pl.iso_8859-2.vim
 
 # Convert menu_pl_pl.utf-8.vim to create menu_polish_poland.1250.vim.
 menu_polish_poland.1250.vim: menu_pl_pl.utf-8.vim
 	rm -f menu_polish_poland.1250.vim
 	iconv -f utf-8 -t cp1250 menu_pl_pl.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding cp1250/' -e 's/" Original translations/" Generated from menu_pl_pl.utf-8.vim, DO NOT EDIT/' > menu_polish_poland.1250.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding cp1250/' -e 's/" Original translations/" Generated from menu_pl_pl.utf-8.vim, DO NOT EDIT/' > menu_polish_poland.1250.vim
 
 # Convert menu_ru_ru.utf-8.vim to create menu_ru_ru.koi8-r.vim.
 menu_ru_ru.koi8-r.vim: menu_ru_ru.utf-8.vim
 	rm -f menu_ru_ru.koi8-r.vim
 	iconv -f utf-8 -t koi8-r menu_ru_ru.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding koi8-r/' -e 's/" Original translations/" Generated from menu_ru_ru.utf-8.vim, DO NOT EDIT/' > menu_ru_ru.koi8-r.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding koi8-r/' -e 's/" Original translations/" Generated from menu_ru_ru.utf-8.vim, DO NOT EDIT/' > menu_ru_ru.koi8-r.vim
 
 # Convert menu_sl_si.utf-8.vim to create menu_sl_si.cp1250.vim.
 menu_sl_si.cp1250.vim: menu_sl_si.utf-8.vim
 	rm -f menu_sl_si.cp1250.vim
 	iconv -f utf-8 -t cp1250 menu_sl_si.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding cp1250/'  \
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding cp1250/'  \
 		-e 's/" Original translations/" Generated from menu_sl_si.utf-8.vim, DO NOT EDIT/' > menu_sl_si.cp1250.vim
 
 # Convert menu_uk_ua.utf-8.vim to create menu_sl_si.latin2.vim.
 menu_sl_si.latin2.vim: menu_sl_si.utf-8.vim
 	rm -f menu_sl_si.latin2.vim
 	iconv -f utf-8 -t latin2 menu_sl_si.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding latin2/' -e 's/" Original translations/" Generated from menu_sl_si.utf-8.vim, DO NOT EDIT/' > menu_sl_si.latin2.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding latin2/' -e 's/" Original translations/" Generated from menu_sl_si.utf-8.vim, DO NOT EDIT/' > menu_sl_si.latin2.vim
 
 # Convert menu_uk_ua.utf-8.vim to create menu_slovak_slovak_republic.1250.vim.
 menu_slovak_slovak_republic.1250.vim: menu_sl_si.utf-8.vim
 	rm -f menu_slovak_slovak_republic.1250.vim
 	iconv -f utf-8 -t cp1250 menu_sl_si.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding cp1250/' -e 's/" Original translations/" Generated from menu_sl_si.utf-8.vim, DO NOT EDIT/' > menu_slovak_slovak_republic.1250.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding cp1250/' -e 's/" Original translations/" Generated from menu_sl_si.utf-8.vim, DO NOT EDIT/' > menu_slovak_slovak_republic.1250.vim
 
 # Convert menu_tr_tr.utf-8.vim to create menu_tr_tr.cp1254.vim.
 menu_tr_tr.cp1254.vim: menu_tr_tr.utf-8.vim
 	rm -f menu_tr_tr.cp1254.vim
 	iconv -f utf-8 -t cp1254 menu_tr_tr.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding cp1254/' -e 's/" Original translations/" Generated from menu_tr_tr.utf-8.vim, DO NOT EDIT/' > menu_tr_tr.cp1254.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding cp1254/' -e 's/" Original translations/" Generated from menu_tr_tr.utf-8.vim, DO NOT EDIT/' > menu_tr_tr.cp1254.vim
 
 # Convert menu_tr_tr.utf-8.vim to create menu_tr_tr.iso_8859-9.vim.
 menu_tr_tr.iso_8859-9.vim: menu_tr_tr.utf-8.vim
 	rm -f menu_tr_tr.iso_8859-9.vim
 	iconv -f utf-8 -t iso8859-9 menu_tr_tr.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding iso8859-9/' -e 's/" Original translations/" Generated from menu_tr_tr.utf-8.vim, DO NOT EDIT/' > menu_tr_tr.iso_8859-9.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding iso8859-9/' -e 's/" Original translations/" Generated from menu_tr_tr.utf-8.vim, DO NOT EDIT/' > menu_tr_tr.iso_8859-9.vim
 
 # Convert menu_sr_rs.utf-8.vim to create menu_sr_rs.iso_8859-5.vim.
 menu_sr_rs.iso_8859-5.vim: menu_sr_rs.utf-8.vim
 	rm -f menu_sr_rs.iso_8859-5.vim
 	iconv -f utf-8 -t iso8859-5 menu_sr_rs.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding iso8859-5/' -e 's/" Original translations/" Generated from menu_sr_rs.utf-8.vim, DO NOT EDIT/' > menu_sr_rs.iso_8859-5.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding iso8859-5/' -e 's/" Original translations/" Generated from menu_sr_rs.utf-8.vim, DO NOT EDIT/' > menu_sr_rs.iso_8859-5.vim
 
 # Convert menu_sr_rs.utf-8.vim to create menu_sr_rs.iso_8859-2.vim.
 menu_sr_rs.iso_8859-2.vim: menu_sr_rs.utf-8.vim
 	rm -f menu_sr_rs.iso_8859-2.vim
-	sed -e 's/а/a/g' -e 's/б/b/g' -e 's/в/v/g' -e 's/г/g/g' -e 's/д/d/g' \
+	$(SED) -e 's/а/a/g' -e 's/б/b/g' -e 's/в/v/g' -e 's/г/g/g' -e 's/д/d/g' \
 		-e 's/ђ/đ/g' -e 's/е/e/g' -e 's/ж/ž/g' -e 's/з/z/g' -e 's/и/i/g' \
 		-e 's/ј/j/g' -e 's/к/k/g' -e 's/л/l/g' -e 's/љ/lj/g' -e 's/м/m/g' \
 		-e 's/н/n/g' -e 's/њ/nj/g' -e 's/о/o/g' -e 's/п/p/g' -e 's/р/r/g' \
@@ -171,7 +172,7 @@ menu_sr_rs.iso_8859-2.vim: menu_sr_rs.utf-8.vim
 # Convert menu_sr_rs.utf-8.vim to create menu_sr_rs.ascii.vim.
 menu_sr_rs.ascii.vim: menu_sr_rs.utf-8.vim
 	rm -f menu_sr_rs.ascii.vim
-	sed -e 's/а/a/g' -e 's/б/b/g' -e 's/в/v/g' -e 's/г/g/g' -e 's/д/d/g' \
+	$(SED) -e 's/а/a/g' -e 's/б/b/g' -e 's/в/v/g' -e 's/г/g/g' -e 's/д/d/g' \
 		-e 's/ђ/dj/g' -e 's/е/e/g' -e 's/ж/z/g' -e 's/з/z/g' -e 's/и/i/g' \
 		-e 's/ј/j/g' -e 's/к/k/g' -e 's/л/l/g' -e 's/љ/lj/g' -e 's/м/m/g' \
 		-e 's/н/n/g' -e 's/њ/nj/g' -e 's/о/o/g' -e 's/п/p/g' -e 's/р/r/g' \
@@ -190,22 +191,22 @@ menu_sr_rs.ascii.vim: menu_sr_rs.utf-8.vim
 menu_uk_ua.cp1251.vim: menu_uk_ua.utf-8.vim
 	rm -f menu_uk_ua.cp1251.vim
 	iconv -f utf-8 -t cp1251 menu_uk_ua.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding cp1251/' -e 's/" Original translations/" Generated from menu_uk_ua.utf-8.vim, DO NOT EDIT/' > menu_uk_ua.cp1251.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding cp1251/' -e 's/" Original translations/" Generated from menu_uk_ua.utf-8.vim, DO NOT EDIT/' > menu_uk_ua.cp1251.vim
 
 # Convert menu_uk_ua.utf-8.vim to create menu_uk_ua.koi8-u.vim.
 menu_uk_ua.koi8-u.vim: menu_uk_ua.utf-8.vim
 	rm -f menu_uk_ua.koi8-u.vim
 	iconv -f utf-8 -t koi8-u menu_uk_ua.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding koi8-u/' -e 's/" Original translations/" Generated from menu_uk_ua.utf-8.vim, DO NOT EDIT/' > menu_uk_ua.koi8-u.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding koi8-u/' -e 's/" Original translations/" Generated from menu_uk_ua.utf-8.vim, DO NOT EDIT/' > menu_uk_ua.koi8-u.vim
 
 # Convert menu_hu_hu.utf-8.vim to create menu_hu_hu.iso_8859-2.vim.
 menu_hu_hu.iso_8859-2.vim: menu_hu_hu.utf-8.vim
 	rm -f menu_hu_hu.iso_8859-2.vim
 	iconv -f utf-8 -t iso8859-2 menu_hu_hu.utf-8.vim | \
-		sed -e 's/scriptencoding utf-8/scriptencoding iso-8859-2/' -e 's/" Original translations/" Generated from menu_hu_hu.utf-8.vim, DO NOT EDIT/' > menu_hu_hu.iso_8859-2.vim
+		$(SED) -e 's/scriptencoding utf-8/scriptencoding iso-8859-2/' -e 's/" Original translations/" Generated from menu_hu_hu.utf-8.vim, DO NOT EDIT/' > menu_hu_hu.iso_8859-2.vim
 
 # Convert menu_slovak_slovak_republic.1250.vim to create menu_sk_sk.iso_8859-2.vim.
 menu_sk_sk.iso_8859-2.vim: menu_slovak_slovak_republic.1250.vim
 	rm -f menu_sk_sk.iso_8859-2.vim
 	iconv -f cp1250 -t iso8859-2 menu_slovak_slovak_republic.1250.vim | \
-		sed -e 's/scriptencoding cp1250/scriptencoding iso-8859-2/' -e 's/" Original translations/" Generated from menu_slovak_slovak_republic.1250.vim, DO NOT EDIT/' > menu_sk_sk.iso_8859-2.vim
+		$(SED) -e 's/scriptencoding cp1250/scriptencoding iso-8859-2/' -e 's/" Original translations/" Generated from menu_slovak_slovak_republic.1250.vim, DO NOT EDIT/' > menu_sk_sk.iso_8859-2.vim

--- a/src/po/Make_all.mak
+++ b/src/po/Make_all.mak
@@ -105,7 +105,6 @@ MOFILES = \
 		it.mo \
 		ja.mo \
 		ko.UTF-8.mo \
-		ko.mo \
 		lv.mo \
 		nb.mo \
 		nl.mo \
@@ -121,13 +120,13 @@ MOFILES = \
 		vi.mo \
 		zh_CN.UTF-8.mo \
 		zh_TW.UTF-8.mo \
-		zh_TW.mo \
 
 
 MOCONVERTED = \
 		cs.cp1250.mo \
 		ja.euc-jp.mo \
 		ja.sjis.mo \
+		ko.mo \
 		pl.UTF-8.mo \
 		pl.cp1250.mo \
 		ru.cp1251.mo \
@@ -135,6 +134,7 @@ MOCONVERTED = \
 		uk.cp1251.mo \
 		zh_CN.mo \
 		zh_CN.cp936.mo \
+		zh_TW.mo \
 
 
 CHECKFILES = \

--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -13,6 +13,8 @@ PACKAGE = vim
 SHELL = /bin/sh
 VIM = ../vim
 
+SED = LANG=C sed
+
 # The OLD_PO_FILE_INPUT and OLD_PO_FILE_OUTPUT are for the new GNU gettext
 # tools 0.10.37, which use a slightly different .po file format that is not
 # compatible with Solaris (and old gettext implementations) unless these are
@@ -58,7 +60,7 @@ uninstall:
 	@$(MAKE) prefixcheck
 	for cat in $(MOFILES) $(MOCONVERTED); do \
 	  cat=`basename $$cat`; \
-	  lang=`echo $$cat | sed 's/\$(CATOBJEXT)$$//'`; \
+	  lang=`echo $$cat | $(SED) 's/\$(CATOBJEXT)$$//'`; \
 	  rm -f $(LOCALEDIR)/$$lang/LC_MESSAGES/$(PACKAGE).mo; \
 	done
 
@@ -106,37 +108,37 @@ sjiscorr: sjiscorr.c
 
 ja.euc-jp.po: ja.po
 	iconv -f utf-8 -t euc-jp ja.po | \
-		sed -e 's/charset=[uU][tT][fF]-8/charset=euc-jp/' -e 's/# Original translations/# Generated from ja.po, DO NOT EDIT/' > ja.euc-jp.po
+		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=euc-jp/' -e 's/# Original translations/# Generated from ja.po, DO NOT EDIT/' > ja.euc-jp.po
 
 # Convert cs.po to create cs.cp1250.po.
 cs.cp1250.po: cs.po
 	rm -f cs.cp1250.po
 	iconv -f iso-8859-2 -t cp1250 cs.po | \
-		sed -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from cs.po, DO NOT EDIT/' > cs.cp1250.po
+		$(SED) -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from cs.po, DO NOT EDIT/' > cs.cp1250.po
 
 # Convert pl.po to create pl.cp1250.po.
 pl.cp1250.po: pl.po
 	rm -f pl.cp1250.po
 	iconv -f iso-8859-2 -t cp1250 pl.po | \
-		sed -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' > pl.cp1250.po
+		$(SED) -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' > pl.cp1250.po
 
 # Convert pl.po to create pl.UTF-8.po.
 pl.UTF-8.po: pl.po
 	rm -f pl.UTF-8.po
 	iconv -f iso-8859-2 -t utf-8 pl.po | \
-		sed -e 's/charset=ISO-8859-2/charset=UTF-8/' -e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' > pl.UTF-8.po
+		$(SED) -e 's/charset=ISO-8859-2/charset=UTF-8/' -e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' > pl.UTF-8.po
 
 # Convert sk.po to create sk.cp1250.po.
 sk.cp1250.po: sk.po
 	rm -f sk.cp1250.po
 	iconv -f iso-8859-2 -t cp1250 sk.po | \
-		sed -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from sk.po, DO NOT EDIT/' > sk.cp1250.po
+		$(SED) -e 's/charset=ISO-8859-2/charset=cp1250/' -e 's/# Original translations/# Generated from sk.po, DO NOT EDIT/' > sk.cp1250.po
 
 # Convert zh_CN.UTF-8.po to create zh_CN.po.
 zh_CN.po: zh_CN.UTF-8.po
 	rm -f zh_CN.po
 	iconv -f UTF-8 -t gb2312 zh_CN.UTF-8.po | \
-		sed -e 's/charset=[uU][tT][fF]-8/charset=gb2312/' -e 's/# Original translations/# Generated from zh_CN.UTF-8.po, DO NOT EDIT/' > zh_CN.po
+		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=gb2312/' -e 's/# Original translations/# Generated from zh_CN.UTF-8.po, DO NOT EDIT/' > zh_CN.po
 
 # Convert zh_CN.UTF-8.po to create zh_CN.cp936.po.
 # Set 'charset' to gbk to avoid that msfmt generates a warning.
@@ -144,13 +146,19 @@ zh_CN.po: zh_CN.UTF-8.po
 zh_CN.cp936.po: zh_CN.UTF-8.po
 	rm -f zh_CN.cp936.po
 	iconv -f UTF-8 -t cp936 zh_CN.UTF-8.po | \
-		sed -e 's/charset=[uU][tT][fF]-8/charset=gbk/' -e 's/# Original translations/# Generated from zh_CN.UTF-8.po, DO NOT EDIT/' > zh_CN.cp936.po
+		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=gbk/' -e 's/# Original translations/# Generated from zh_CN.UTF-8.po, DO NOT EDIT/' > zh_CN.cp936.po
+
+# Convert zh_TW.UTF-8.po to create zh_TW.po
+zh_TW.po: zh_TW.UTF-8.po
+	rm -f zh_TW.po
+	iconv -f UTF-8 -t big5 zh_TW.UTF-8.po | \
+		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=big5/' -e 's/# Original translations/# Generated from zh_TW.UTF-8.po, DO NOT EDIT/' > zh_TW.po
 
 # Convert ko.UTF-8.po to create ko.po.
 ko.po: ko.UTF-8.po
 	rm -f ko.po
 	iconv -f UTF-8 -t euc-kr ko.UTF-8.po | \
-		sed -e 's/charset=UTF-8/charset=euc-kr/' \
+		$(SED) -e 's/charset=UTF-8/charset=euc-kr/' \
 		    -e 's/# Korean translation for Vim/# Generated from ko.UTF-8.po, DO NOT EDIT/' \
 		    > ko.po
 
@@ -158,13 +166,13 @@ ko.po: ko.UTF-8.po
 ru.cp1251.po: ru.po
 	rm -f ru.cp1251.po
 	iconv -f utf-8 -t cp1251 ru.po | \
-		sed -e 's/charset=[uU][tT][fF]-8/charset=cp1251/' -e 's/# Original translations/# Generated from ru.po, DO NOT EDIT/' > ru.cp1251.po
+		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=cp1251/' -e 's/# Original translations/# Generated from ru.po, DO NOT EDIT/' > ru.cp1251.po
 
 # Convert uk.po to create uk.cp1251.po.
 uk.cp1251.po: uk.po
 	rm -f uk.cp1251.po
 	iconv -f utf-8 -t cp1251 uk.po | \
-		sed -e 's/charset=[uU][tT][fF]-8/charset=cp1251/' -e 's/# Original translations/# Generated from uk.po, DO NOT EDIT/' > uk.cp1251.po
+		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=cp1251/' -e 's/# Original translations/# Generated from uk.po, DO NOT EDIT/' > uk.cp1251.po
 
 prefixcheck:
 	@if test "x" = "x$(prefix)"; then \
@@ -214,7 +222,7 @@ $(PACKAGE).pot: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
 	rm *.js
 
 vim.desktop: vim.desktop.in $(POFILES)
-	echo $(LANGUAGES) | tr " " "\n" |sed -e '/\./d' | sort > LINGUAS
+	echo $(LANGUAGES) | tr " " "\n" |$(SED) -e '/\./d' | sort > LINGUAS
 	$(MSGFMT) --desktop -d . --template vim.desktop.in -o tmp_vim.desktop
 	rm -f LINGUAS
 	if command -v desktop-file-validate; then desktop-file-validate tmp_vim.desktop; fi
@@ -223,7 +231,7 @@ vim.desktop: vim.desktop.in $(POFILES)
 # The dependency on vim.desktop is only to avoid the two targets are build at
 # the same time, which causes a race for the LINGUAS file.
 gvim.desktop: gvim.desktop.in $(POFILES) vim.desktop
-	echo $(LANGUAGES) | tr " " "\n" |sed -e '/\./d' | sort > LINGUAS
+	echo $(LANGUAGES) | tr " " "\n" |$(SED) -e '/\./d' | sort > LINGUAS
 	$(MSGFMT) --desktop -d . --template gvim.desktop.in -o tmp_gvim.desktop
 	rm -f LINGUAS
 	if command -v desktop-file-validate; then desktop-file-validate tmp_gvim.desktop; fi

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -7,6 +7,8 @@
 # FIRST RELEASE Thu Jun 14 14:24:17 CST 2001
 # MAINTAINER: Debian VIM Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
 #
+# Original translations.
+#
 # Last update: $LastChangedDate: 2006-04-16 22:06:40 -0400 (dom, 16 apr 2006) $
 #
 # XXX This file is in need of a new maintainer, Debian VIM Maintainers maintain

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -5,8 +5,17 @@
 #
 # FIRST AUTHOR  Francis S.Lin <piaip@csie.ntu.edu.tw>, 2000
 # FIRST RELEASE Thu Jun 14 14:24:17 CST 2001
+# MAINTAINER: Debian VIM Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
 #
-# Last update: 2005/01/27 07:03 (6.3)
+# Generated from zh_TW.UTF-8.po, DO NOT EDIT.
+#
+# Last update: $LastChangedDate: 2006-04-16 22:06:40 -0400 (dom, 16 apr 2006) $
+#
+# XXX This file is in need of a new maintainer, Debian VIM Maintainers maintain
+#     it only because patches have been submitted for it by Debian users and the
+#     former maintainer was MIA (Missing In Action), taking over its
+#     maintenance was thus the only way to include those patches.
+#     If you care about this file, and have time to maintain it please do so!
 #
 # To update, search pattern:		/fuzzy\|^msgstr ""\(\n"\)\@!
 #
@@ -2620,7 +2629,7 @@ msgstr ""
 "gvim 認得的參數 (GTK+ 版):\n"
 
 msgid "-display <display>\tRun Vim on <display> (also: --display)"
-msgstr "-display <display>\t在 <display> 執行 Vim (也可用 --display)"
+msgstr "-display <display>\t在 <display> 執行 vim (也可用 --display)"
 
 msgid "--role <role>\tSet a unique role to identify the main window"
 msgstr "--role <role>\t設定獨特的角色(role)以區分主視窗"
@@ -3281,11 +3290,11 @@ msgstr "少於一行 "
 
 #, c-format
 msgid "%ld more lines"
-msgstr "還有 %ld 行 "
+msgstr "多了 %ld 行 "
 
 #, c-format
 msgid "%ld fewer lines"
-msgstr "只剩 %ld 行 "
+msgstr "少了 %ld 行 "
 
 msgid " (Interrupted)"
 msgstr " (已中斷)"


### PR DESCRIPTION
Vim's build system currently uses iconv to pre-convert .po files to different encodings to accommodate Vim versions that don't have iconv. It uses sed to add a generated file / do-not-edit marker to the converted file (to make sure contributors don't erroneously try to edit the generated version), but that step fails in macOS because macOS's version of sed is locale aware and gets confused (see https://stackoverflow.com/questions/19242275/re-error-illegal-byte-sequence-on-mac-os-x). To fix this, make sure we prepend `LANG=C` before calling sed which fixes the issue.

Also fix a couple issues with locale files:

- zh_TW.po is currently generated from zh_TW.UTF-8.po but it's not configured as such in the Makefile. In fact, it doesn't contain a couple updates from the UTF-8 version. Just add it to the Makefile and re-generate it as well.
- Minor: ko.po is generated from ko.UTF-8.po, so it should be under `$(MOCONVERTED)` instead of `$(MOFILES)`.