### PR TITLE
Fix mouseshape to be set correctly when using 'r' or 'gr'

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -418,6 +418,9 @@ normal_cmd_get_more_chars(
 #ifdef CURSOR_SHAPE
 	    ui_cursor_shape();	// show different cursor shape
 #endif
+#ifdef FEAT_MOUSESHAPE
+	    update_mouseshape(-1);
+#endif
 	}
 	if (lang && curbuf->b_p_iminsert == B_IMODE_LMAP)
 	{


### PR DESCRIPTION
Currently, when entering the "pretend" or single character replace modes using `r` or `gr` (in GUI), the mouse cursor doesn't immediately update until you have re-focused the window or moved the mouse. This is because it's not calling `update_mouseshape(-1)` immediately, so the cursor will only be updated when it's called by other functions like `gui_mouse_focus` (which happens just if you move the mouse or re-focus the application).

To fix this, just make sure we call this `update_mouseshape(-1)`. It's what we do when entering Insert or Replace modes for example.

I noticed this when trying to figure out why MacVim CI is failing in `Test_mouse_shape_after_cancelling_gr` (introduced in #12110), but I think that test is only passing in Vim GTK CI by accident, since this issue happens there too. I think the window captured focus after the mouse `gr` call which triggers a mouse shape change but it probably would have failed under other circumstances.