### PR TITLE
Fix wrong syntax of ldSections in ld.vim

### DIFF
--- a/runtime/syntax/ld.vim
+++ b/runtime/syntax/ld.vim
@@ -43,7 +43,7 @@ syn match   ldSpecial       '/DISCARD/'
 syn keyword ldIdentifier    ORIGIN LENGTH
 
 syn match   ldSpecSections  '\.'
-syn match   ldSections      '\.\S\+'
+syn match   ldSections      '\.[^ \t)]\+'
 syn match   ldSpecSections  '\.\%(text\|data\|bss\|symver\)\>'
 
 syn match   ldNumber        display '\<0[xX]\x\+\>'


### PR DESCRIPTION
This is an example:

```ld
SECTIONS
{
  .text: {*(.text)}
}
```

The `)` after `.text` shouldn't be recognized as `ldSections`.

Same as <https://github.com/neovim/neovim/blob/master/runtime/syntax/ld.vim> and <https://github.com/sheerun/vim-polyglot/blob/master/syntax/ld.vim>.