### PR TITLE
QMLdir files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1649,6 +1649,9 @@ au BufNewFile,BufRead *.ptl,*.pyi,SConstruct		   setf python
 " QL
 au BufRead,BufNewFile *.ql,*.qll		setf ql
 
+" QMLdir
+au BufRead,BufNewFile qmldir			setf qmldir
+
 " Quarto
 au BufRead,BufNewFile *.qmd			setf quarto
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -471,6 +471,7 @@ let s:filename_checks = {
     \ 'pyrex': ['file.pyx', 'file.pxd'],
     \ 'python': ['file.py', 'file.pyw', '.pythonstartup', '.pythonrc', 'file.ptl', 'file.pyi', 'SConstruct'],
     \ 'ql': ['file.ql', 'file.qll'],
+    \ 'qmldir': ['qmldir'],
     \ 'quake': ['anybaseq2/file.cfg', 'anyid1/file.cfg', 'quake3/file.cfg', 'baseq2/file.cfg', 'id1/file.cfg', 'quake1/file.cfg', 'some-baseq2/file.cfg', 'some-id1/file.cfg', 'some-quake1/file.cfg'],
     \ 'quarto': ['file.qmd'],
     \ 'r': ['file.r', '.Rprofile', 'Rprofile', 'Rprofile.site'],


### PR DESCRIPTION
https://doc.qt.io/qt-6/qtqml-modules-qmldir.html

Problem: QMLdir files are not recognized.
Solution: Add a pattern for QMLdir files. (Amaan Qureshi)