### PR TITLE
WebAssembly Interface Type (WIT) files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2330,6 +2330,9 @@ au BufNewFile,BufRead *.vue			setf vue
 " WebAssembly
 au BufNewFile,BufRead *.wast,*.wat		setf wast
 
+" WebAssembly Interface Type (WIT)
+au BufNewFile,BufRead *.wit			setf wit
+
 " Webmacro
 au BufNewFile,BufRead *.wm			setf webmacro
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -658,6 +658,7 @@ let s:filename_checks = {
     \ 'wget': ['.wgetrc', 'wgetrc'],
     \ 'wget2': ['.wget2rc', 'wget2rc'],
     \ 'winbatch': ['file.wbt'],
+    \ 'wit': ['file.wit'],
     \ 'wml': ['file.wml'],
     \ 'wsh': ['file.wsf', 'file.wsc'],
     \ 'wsml': ['file.wsml'],


### PR DESCRIPTION
https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md

Problem: WebAssembly Interface Type (WIT) files are not recognized.
Solution: Add a pattern for WIT files. (Amaan Qureshi)