### PR TITLE
EdgeDB Schema Definition Language (ESDL) files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -650,6 +650,9 @@ au BufNewFile,BufRead filter-rules		setf elmfilt
 " Elsa - https://github.com/ucsd-progsys/elsa
 au BufNewFile,BufRead *.lc			setf elsa
 
+" EdgeDB Schema Definition Language
+au BufNewFile,BufRead *.esdl			setf esdl
+
 " ESMTP rc file
 au BufNewFile,BufRead *esmtprc			setf esmtprc
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -189,6 +189,7 @@ let s:filename_checks = {
     \ 'epuppet': ['file.epp'],
     \ 'erlang': ['file.erl', 'file.hrl', 'file.yaws'],
     \ 'eruby': ['file.erb', 'file.rhtml'],
+    \ 'esdl': ['file.esdl'],
     \ 'esmtprc': ['anyesmtprc', 'esmtprc', 'some-esmtprc'],
     \ 'esqlc': ['file.ec', 'file.EC'],
     \ 'esterel': ['file.strl'],


### PR DESCRIPTION
https://www.edgedb.com/docs/reference/sdl/index

Problem: EdgeDB Schema Definition Language (ESDL)  files are not recognized.
Solution: Add a pattern for ESDL files. (Amaan Qureshi)