### PR TITLE
Cython files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -448,6 +448,9 @@ au BufNewFile,BufRead *.cu,*.cuh		setf cuda
 " Cue
 au BufNewFile,BufRead *.cue			setf cue
 
+" Cython
+au BufNewFile,BufRead *.pyx,*.pxd,*.pxi		setf cython
+
 " Dockerfile; Podman uses the same syntax with name Containerfile
 " Also see Dockerfile.* below.
 au BufNewFile,BufRead Containerfile,Dockerfile,dockerfile,*.[dD]ockerfile	setf dockerfile

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -146,6 +146,7 @@ let s:filename_checks = {
     \ 'cvs': ['cvs123'],
     \ 'cvsrc': ['.cvsrc'],
     \ 'cynpp': ['file.cyn'],
+    \ 'cython': ['file.pyx', 'file.pxd', 'file.pxi'],
     \ 'd': ['file.d'],
     \ 'dart': ['file.dart', 'file.drt'],
     \ 'datascript': ['file.ds'],


### PR DESCRIPTION
https://cython.org/

Problem: Cython files are not recognized.
Solution: Add a pattern for Cython files. (Amaan Qureshi)