### PR TITLE
Fix SEGV when modifying collection being filtered.

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1365,7 +1365,7 @@ dict_filter_map(
     // Create one funccal_T for all eval_expr_typval() calls.
     fc = eval_expr_get_funccal(expr, &newtv);
 
-    if (filtermap != FILTERMAP_FILTER && d->dv_lock == 0)
+    if (d->dv_lock == 0)
 	d->dv_lock = VAR_LOCKED;
     ht = &d->dv_hashtab;
     hash_lock(ht);

--- a/src/list.c
+++ b/src/list.c
@@ -2398,7 +2398,7 @@ list_filter_map(
     // set_vim_var_nr() doesn't set the type
     set_vim_var_type(VV_KEY, VAR_NUMBER);
 
-    if (filtermap != FILTERMAP_FILTER && l->lv_lock == 0)
+    if (l->lv_lock == 0)
 	l->lv_lock = VAR_LOCKED;
 
     // Create one funccal_T for all eval_expr_typval() calls.
@@ -2578,7 +2578,8 @@ filter_map(typval_T *argvars, typval_T *rettv, filtermap_T filtermap)
 	dict_filter_map(argvars[0].vval.v_dict, filtermap, type, func_name,
 		arg_errmsg, expr, rettv);
     else if (argvars[0].v_type == VAR_BLOB)
-	blob_filter_map(argvars[0].vval.v_blob, filtermap, expr, rettv);
+	blob_filter_map(argvars[0].vval.v_blob, filtermap, expr,
+			arg_errmsg, rettv);
     else if (argvars[0].v_type == VAR_STRING)
 	string_filter_map(tv_get_string(&argvars[0]), filtermap, expr,
 		rettv);

--- a/src/proto/blob.pro
+++ b/src/proto/blob.pro
@@ -20,7 +20,7 @@ int check_blob_range(long bloblen, varnumber_T n1, varnumber_T n2, int quiet);
 int blob_set_range(blob_T *dest, long n1, long n2, typval_T *src);
 void blob_add(typval_T *argvars, typval_T *rettv);
 void blob_remove(typval_T *argvars, typval_T *rettv, char_u *arg_errmsg);
-void blob_filter_map(blob_T *blob_arg, filtermap_T filtermap, typval_T *expr, typval_T *rettv);
+void blob_filter_map(blob_T *blob_arg, filtermap_T filtermap, typval_T *expr, char_u *arg_errmsg, typval_T *rettv);
 void blob_insert_func(typval_T *argvars, typval_T *rettv);
 void blob_reduce(typval_T *argvars, typval_T *expr, typval_T *rettv);
 void blob_reverse(blob_T *b, typval_T *rettv);

--- a/src/testdir/test_filter_map.vim
+++ b/src/testdir/test_filter_map.vim
@@ -116,6 +116,21 @@ func Test_map_and_modify()
   let d = #{a: 1, b: 2, c: 3}
   call assert_fails('call map(d, "remove(d, v:key)[0]")', 'E741:')
   call assert_fails('echo map(d, {k,v -> remove(d, k)})', 'E741:')
+
+  let b = 0z1234
+  call assert_fails('call filter(b, "remove(b, 0)")', 'E741:')
+endfunc
+
+func Test_filter_and_modify()
+  let l = [0]
+  " cannot change the list halfway a map()
+  call assert_fails('call filter(l, "remove(l, 0)")', 'E741:')
+
+  let d = #{a: 0, b: 0, c: 0}
+  call assert_fails('call filter(d, "remove(d, v:key)")', 'E741:')
+
+  let b = 0z1234
+  call assert_fails('call filter(b, "remove(b, 0)")', 'E741:')
 endfunc
 
 func Test_mapnew_dict()


### PR DESCRIPTION
Lock the collection during `filter()`.
Also lock blob when `map()`; seems to have been missing.
Add some tests.

---

Same fix for list/dict/blob; they all got SEGV.
Needed some additional work for blob since it didn't protect
for modifications during map().

The fix changes
```
    if (filtermap != FILTERMAP_FILTER && l->lv_lock == 0)
	l->lv_lock = VAR_LOCKED;
```
to
```
    if (l->lv_lock == 0)
	l->lv_lock = VAR_LOCKED;
```
during the start of `list_filter_map()`. Similarly for `dict`/`blob`.

The fix doesn't run into problems because with
```
    else if (filtermap == FILTERMAP_FILTER && rem)
        listitem_remove(l, li);
```
since `listitem_remove()` doesn't check locks.

I tried a variety of things, and things seem to behave
with this PR.
Not certain why FILTERMAP_FILTER was excluding from
locking the collection.
There may be other cases I didn't consider that could
run into problems, but I couldn't find them.

The following got a SEGV for me. Similar scripts for `dict`/`blob`.
```
vim9script
def FilterRemoveTest2()
    var l = [1]
    l->add(777)

    def FilterRemove(_, _): bool
        while l->len() > 0
            l->remove(0)
        endwhile
        return false
    enddef
    l->filter(FilterRemove)
enddef
FilterRemoveTest2()
```

With this PR, a lock error is reported:

```
Error detected while processing command line
    ..script /home/err/play/xxx.vim[14]
    ..function <SNR>34_FilterRemoveTest2[10]..<lambda>1:
line    2:
E741: Value is locked: remove() argument
```
---

With the fix, using range() as in
```
vim9script
def FilterRemoveTest2()
    var l = range(4)
    ...
```

doesn't get the lock error or the SEGV. I guess this is an
implementation detail; doesn't seem right.
