### PR TITLE
Source `.exrc`/`.vimrc` in current work dir with -u flag

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3288,7 +3288,7 @@ source_startup_scripts(mparm_T *parmp)
      * Only do this if VIMRC_FILE is not the same as USR_VIMRC_FILE or
      * SYS_VIMRC_FILE.
      */
-    if (p_exrc && use_exrc)
+    if (!silent_mode && p_exrc && use_exrc)
     {
 #if defined(UNIX) || defined(VMS)
 	// If ".vimrc" file is not owned by user, set 'secure' mode.

--- a/src/main.c
+++ b/src/main.c
@@ -3172,8 +3172,7 @@ exe_commands(mparm_T *parmp)
     static void
 source_startup_scripts(mparm_T *parmp)
 {
-    int		i;
-    bool use_exrc;
+    int		i, use_exrc;
 
     /*
      * For "evim" source evim.vim first of all, so that the user can overrule
@@ -3208,7 +3207,7 @@ source_startup_scripts(mparm_T *parmp)
 	{
 	    if (do_source(parmp->use_vimrc, FALSE, DOSO_NONE, NULL) != OK)
 		semsg(_(e_cannot_read_from_str_2), parmp->use_vimrc);
-	    use_exrc = true;
+	    use_exrc = 1;
 	}
     }
     else if (!silent_mode)

--- a/src/main.c
+++ b/src/main.c
@@ -3186,8 +3186,7 @@ source_startup_scripts(mparm_T *parmp)
     }
 
     /*
-     * If -u argument given, use only the initializations from that file and
-     * nothing else.
+     * If -u argument given, use the initializations from that file.
      */
     if (parmp->use_vimrc != NULL)
     {
@@ -3281,7 +3280,8 @@ source_startup_scripts(mparm_T *parmp)
     }
     /*
      * Read initialization commands from ".vimrc" or ".exrc" in current
-     * directory.  This is only done if the 'exrc' option is set.
+     * directory.  This is only done if the 'exrc' option is set and
+     * the "-u" flag, if present, is not "DEFAULTS", "NONE" or "NORC".
      * Because of security reasons we disallow shell and write commands
      * now, except for Unix if the file is owned by the user or 'secure'
      * option has been reset in environment of global ".exrc" or ".vimrc".

--- a/src/main.c
+++ b/src/main.c
@@ -3172,7 +3172,8 @@ exe_commands(mparm_T *parmp)
     static void
 source_startup_scripts(mparm_T *parmp)
 {
-    int		i, use_exrc;
+    int		i;
+    int use_exrc = 1;
 
     /*
      * For "evim" source evim.vim first of all, so that the user can overrule
@@ -3194,6 +3195,7 @@ source_startup_scripts(mparm_T *parmp)
 	    if (do_source((char_u *)VIM_DEFAULTS_FILE, FALSE, DOSO_NONE, NULL)
 									 != OK)
 		emsg(e_failed_to_source_defaults);
+	    use_exrc = 0;
 	}
 	else if (STRCMP(parmp->use_vimrc, "NONE") == 0
 				     || STRCMP(parmp->use_vimrc, "NORC") == 0)
@@ -3202,12 +3204,12 @@ source_startup_scripts(mparm_T *parmp)
 	    if (use_gvimrc == NULL)	    // don't load gvimrc either
 		use_gvimrc = parmp->use_vimrc;
 #endif
+	    use_exrc = 0;
 	}
 	else
 	{
 	    if (do_source(parmp->use_vimrc, FALSE, DOSO_NONE, NULL) != OK)
 		semsg(_(e_cannot_read_from_str_2), parmp->use_vimrc);
-	    use_exrc = 1;
 	}
     }
     else if (!silent_mode)

--- a/src/main.c
+++ b/src/main.c
@@ -3208,8 +3208,7 @@ source_startup_scripts(mparm_T *parmp)
 	{
 	    if (do_source(parmp->use_vimrc, FALSE, DOSO_NONE, NULL) != OK)
 		semsg(_(e_cannot_read_from_str_2), parmp->use_vimrc);
-	    else
-		use_exrc = true;
+	    use_exrc = true;
 	}
     }
     else if (!silent_mode)

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -1320,6 +1320,19 @@ func Test_write_in_vimrc()
   endif
 endfunc
 
+func Test_sources_local_exrc_and_vimrc_with_custom_vimrc()
+  call writefile(['set exrc'], 'Xflagvimrc', 'D')
+  for rc_file in ['exrc', 'vimrc']
+    let rc_file = has('win32') ? '_'.rc_file : '.'.rc_file
+    call writefile(['call writefile(["'.rc_file.'"], "Xtestout")'], rc_file, 'D')
+
+    if RunVim([], ['quit'], '-u Xflagvimrc')
+      call assert_equal([rc_file], readfile('Xtestout'))
+      call delete('Xtestout')
+    endif
+  endfor
+endfunc
+
 func Test_echo_true_in_cmd()
   CheckNotGui
 


### PR DESCRIPTION
Vim does not respect the `set exrc` option when included in a custom vimrc that is provided with the `-u` flag.

The proposed change is to load the files from the current directory if the value of the `-u` flag is a custom vimrc with `set exrc` inside and not "DEFAULTS", "NONE" or "NORC".