### PR TITLE
Find Python 3 dynamic library in macOS in configure script

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -6860,6 +6860,7 @@ __:
 	@echo "python3_SYSLIBS='$(SYSLIBS)'"
 	@echo "python3_DLLLIBRARY='$(DLLLIBRARY)'"
 	@echo "python3_INSTSONAME='$(INSTSONAME)'"
+	@echo "python3_PYTHONFRAMEWORKPREFIX='$(PYTHONFRAMEWORKPREFIX)'"
 eof
 	    	    eval "`cd ${PYTHON3_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
 	    rm -f -- "${tmp_mkf}"
@@ -6878,6 +6879,8 @@ else
 
 	  if test "X$python3_DLLLIBRARY" != "X"; then
 	    vi_cv_dll_name_python3="$python3_DLLLIBRARY"
+	  elif test "X$python3_PYTHONFRAMEWORKPREFIX" != "X"; then
+	    vi_cv_dll_name_python3="${python3_PYTHONFRAMEWORKPREFIX}/${python3_INSTSONAME}"
 	  else
 	    vi_cv_dll_name_python3="$python3_INSTSONAME"
 	  fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1578,6 +1578,7 @@ __:
 	@echo "python3_SYSLIBS='$(SYSLIBS)'"
 	@echo "python3_DLLLIBRARY='$(DLLLIBRARY)'"
 	@echo "python3_INSTSONAME='$(INSTSONAME)'"
+	@echo "python3_PYTHONFRAMEWORKPREFIX='$(PYTHONFRAMEWORKPREFIX)'"
 eof
 	    dnl -- delete the lines from make about Entering/Leaving directory
 	    eval "`cd ${PYTHON3_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
@@ -1592,6 +1593,8 @@ eof
 	[
 	  if test "X$python3_DLLLIBRARY" != "X"; then
 	    vi_cv_dll_name_python3="$python3_DLLLIBRARY"
+	  elif test "X$python3_PYTHONFRAMEWORKPREFIX" != "X"; then
+	    vi_cv_dll_name_python3="${python3_PYTHONFRAMEWORKPREFIX}/${python3_INSTSONAME}"
 	  else
 	    vi_cv_dll_name_python3="$python3_INSTSONAME"
 	  fi


### PR DESCRIPTION
Currently, using `./configure --enable-python3interp=dynamic` does not really work properly on macOS for most Python 3 installations because most Python installations use a "framework" mode of installations that's unique to macOS. This is enabled when configuring CPython with `--enable-framework` flag (see
https://docs.python.org/3/using/configure.html).

When using framework mode, the dynamic library's path works a little differently. The full path for Homebrew installation is `/opt/homebrew/opt/python@3.11/Frameworks/Python.framework/Versions/3.11/Python` and Xcode version is
`/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/Python3`. When Vim's configure script tries to use just `INSTSONAME` for setting the DLL path (will be used as the default for `pythonthreedll`), it will just grab the part that says `Python.framework/Versions/3.11/Python`. The rest of the path is encoded in a Makefile var called `PYTHONFRAMEWORKPREFIX` which contains the
`/opt/homebrew/opt/python@3.11/Frameworks` part.

The CPython logic for configuring these is in
https://github.com/python/cpython/blob/3.11/configure.ac, where we can see how the paths are constructed:

```
LDLIBRARY='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
```

This change makes sure to use `PYTHONFRAMEWORKPREFIX` to help construct a full path for the lib. With this change, I can now just configure as normal, and it seems to be able to find Python 3's dynamic library correctly.

I don't think this affects any non-macOS builds because `--enable-framework` should be a macOS-only configure option. Note that installations like miniconda on macOS do not use the framework mode, but they also won't be affected because `PYTHONFRAMEWORKPREFIX` will be empty just like other platforms.