### PR TITLE
Improve profiling results.

### DIFF
--- a/src/profiler.c
+++ b/src/profiler.c
@@ -664,7 +664,8 @@ script_prof_save(
     void
 profile_may_start_func(profinfo_T *info, ufunc_T *fp, ufunc_T *caller)
 {
-    if (!fp->uf_profiling && has_profiling(FALSE, fp->uf_name, NULL))
+    if (!fp->uf_profiling && has_profiling(FALSE, fp->uf_name, NULL,
+								&fp->uf_hash))
     {
 	info->pi_started_profiling = TRUE;
 	func_do_profile(fp);

--- a/src/proto/debugger.pro
+++ b/src/proto/debugger.pro
@@ -10,6 +10,6 @@ int debug_has_expr_breakpoint(void);
 void ex_breakdel(exarg_T *eap);
 void ex_breaklist(exarg_T *eap);
 linenr_T dbg_find_breakpoint(int file, char_u *fname, linenr_T after);
-int has_profiling(int file, char_u *fname, int *fp);
+int has_profiling(int file, char_u *fname, int *fp, hash_T *hash);
 void dbg_breakpoint(char_u *name, linenr_T lnum);
 /* vim: set ft=c : */

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1721,7 +1721,7 @@ do_source_ext(
 	int	forceit;
 
 	// Check if we do profiling for this script.
-	if (!si->sn_prof_on && has_profiling(TRUE, si->sn_name, &forceit))
+	if (!si->sn_prof_on && has_profiling(TRUE, si->sn_name, &forceit, NULL))
 	{
 	    script_do_profile(si);
 	    si->sn_pr_force = forceit;

--- a/src/structs.h
+++ b/src/structs.h
@@ -1823,6 +1823,7 @@ struct ufunc_S
 # ifdef FEAT_PROFILE
     int		uf_profiling;	// TRUE when func is being profiled
     int		uf_prof_initialized;
+    hash_T	uf_hash;	// hash for uf_name when profiling
     // profiling the function as a whole
     int		uf_tm_count;	// nr of calls
     proftime_T	uf_tm_total;	// time spent in function + children

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1475,6 +1475,7 @@ early_ret:
 
 	// Add the class to the script-local variables.
 	// TODO: handle other context, e.g. in a function
+	// TODO: does uf_hash need to be cleared?
 	typval_T tv;
 	tv.v_type = VAR_CLASS;
 	tv.vval.v_class = cl;

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2983,7 +2983,8 @@ get_compile_type(ufunc_T *ufunc)
 #ifdef FEAT_PROFILE
     if (do_profiling == PROF_YES)
     {
-	if (!ufunc->uf_profiling && has_profiling(FALSE, ufunc->uf_name, NULL))
+	if (!ufunc->uf_profiling && has_profiling(FALSE, ufunc->uf_name, NULL,
+							    &ufunc->uf_hash))
 	    func_do_profile(ufunc);
 	if (ufunc->uf_profiling)
 	    return CT_PROFILE;


### PR DESCRIPTION
Reduce overhead of checking if a function should be profiled, by caching results of checking (which are done with regexp). Cache cleared when regexps are changed.
Break at first match for has_profiling lookup.