### PR TITLE
Fix buffer overflow in file name expansion in macOS due to UTF-8 names

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3709,7 +3709,7 @@ unix_expandpath(
     }
 
     // make room for file name
-    buflen = STRLEN(path) + BASENAMELEN + 5;
+    buflen = STRLEN(path) + MAXPATHL;
     buf = alloc(buflen);
     if (buf == NULL)
 	return 0;
@@ -3828,7 +3828,8 @@ unix_expandpath(
 		   || ((flags & EW_NOTWILD)
 		     && fnamencmp(path + (s - buf), dp->d_name, e - s) == 0)))
 	    {
-		STRCPY(s, dp->d_name);
+		STRNCPY(s, dp->d_name, buflen - (s - buf));
+		buf[buflen - 1] = '\0';
 		len = STRLEN(buf);
 
 		if (starstar && stardepth < 100)


### PR DESCRIPTION
Simple repro steps (macOS):

1. Make a file with name consisting of 255 '中' (or any 2-byte-long characters):

       touch `printf '中%.0s' {1..255}`

2. Open Vim.
3. Type `:echo expand('中*')`

Observe that Vim crashes. To best reproduce this, it's best to have `-fsanitize=address` in the compiler/linker flags, as otherwise Vim may just have a memory corruption and crash later.

---

This happens because when expanding a path (e.g. tab-completion in cmd-line or `expand('*')`), Vim calls `unix_exandpath()` to do so. The code isn't properly handling long Unicode file names in macOS.

This is due to two issues. Fix both in this commit:

1. The function is not properly guarding the strcpy call and relying on the file name being smaller than a provided constant (basically 255 on macOS / most Unix systems). However, on macOS, you can actually get a file name with more than 255 bytes (see below point), and for safety, we should really use strncpy calls instead to prevent buffer flow due to unexpected input.

2. Apparently, on macOS, the legal file name for their APFS file system is 255 *UTF-8* characters, not bytes. One can easily verify that by trying to make a file with non-ASCII names. Note that both `NAME_MAX` and `MAXNAMLEN` are 255 in the system headers, but `readdir()` would return a struct that's allocated to the max path length (1024) instead (sneaky).

   For the fix here, just allocate the buffer by the path max length instead of a somewhat hacky `BASENAMELEN + 5`. I said "hacky" because the `BASENAMELEN` constant is for providing a safe upperbound for file name length when generating new names (e.g. swap files) and cannot be made too large. For providing a safe size for memory allocation though (our situation here) it's better to use a safe large size that we know will fit instead.

More about the file name limit: I couldn't quite find concrete documentation, but I'm pretty sure PATH_MAX (1024) is enough to cover all file names in Apple's macOS. Reading up on [glibc documentation](https://www.gnu.org/software/libc/manual/html_node/Limits-for-Files.html) though (which macOS does not use just to be clear), they actually claim that these constants aren't always enforced, so it's preferable to dynamically allocate memory instead of pre-allocate based on compile-time max. Probably does not matter for the common OSes though as most targets (Windows/Linux/macOS) do have a max file name length limit, usually.