### PR TITLE
Add filetype detection for Livebook files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1162,6 +1162,9 @@ au BufNewFile,BufRead *.lite,*.lt		setf lite
 " LiteStep RC files
 au BufNewFile,BufRead */LiteStep/*/*.rc		setf litestep
 
+" Livebook
+au BufNewFile,BufRead *.livemd			setf markdown
+
 " Login access
 au BufNewFile,BufRead */etc/login.access	setf loginaccess
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -359,7 +359,7 @@ let s:filename_checks = {
     \ 'manconf': ['/etc/man.conf', 'man.config', 'any/etc/man.conf'],
     \ 'map': ['file.map'],
     \ 'maple': ['file.mv', 'file.mpl', 'file.mws'],
-    \ 'markdown': ['file.markdown', 'file.mdown', 'file.mkd', 'file.mkdn', 'file.mdwn', 'file.md'],
+    \ 'markdown': ['file.markdown', 'file.mdown', 'file.mkd', 'file.mkdn', 'file.mdwn', 'file.md', 'file.livemd'],
     \ 'mason': ['file.mason', 'file.mhtml', 'file.comp'],
     \ 'master': ['file.mas', 'file.master'],
     \ 'matlab': ['file.m'],


### PR DESCRIPTION
There is not yet any filetype detection in Vim for [Livebook](https://livebook.dev/) files, so I thought it would be worthwhile adding.

Please, let me know if anything is missing.