### PR TITLE
Don't loop over all scripts when getting info about an SID

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -2096,7 +2096,6 @@ get_script_local_funcs(scid_T sid)
     void
 f_getscriptinfo(typval_T *argvars, typval_T *rettv)
 {
-    int		i;
     list_T	*l;
     char_u	*pat = NULL;
     regmatch_T	regmatch;
@@ -2116,8 +2115,17 @@ f_getscriptinfo(typval_T *argvars, typval_T *rettv)
 
     if (argvars[0].v_type == VAR_DICT)
     {
-	sid = dict_get_number_def(argvars[0].vval.v_dict, "sid", -1);
-	if (sid == -1)
+	dictitem_T *sid_di = dict_find(argvars[0].vval.v_dict, (char_u *)"sid",
+									    3);
+	if (sid_di != NULL)
+	{
+	    int error = FALSE;
+	    sid = tv_get_number_chk(&sid_di->di_tv, &error);
+	    if (!error && sid <= 0)
+		semsg(e_invalid_value_for_argument_str_str, "sid",
+						tv_get_string(&sid_di->di_tv));
+	}
+	else
 	{
 	    pat = dict_get_string(argvars[0].vval.v_dict, "name", TRUE);
 	    if (pat != NULL)
@@ -2127,7 +2135,8 @@ f_getscriptinfo(typval_T *argvars, typval_T *rettv)
 	}
     }
 
-    for (i = 1; i <= script_items.ga_len; ++i)
+    for (varnumber_T i = sid > 0 ? sid : 1;
+		       (i == sid || sid <= 0) && i <= script_items.ga_len; ++i)
     {
 	scriptitem_T	*si = SCRIPT_ITEM(i);
 	dict_T		*d;
@@ -2136,9 +2145,6 @@ f_getscriptinfo(typval_T *argvars, typval_T *rettv)
 	    continue;
 
 	if (filterpat && !vim_regexec(&regmatch, si->sn_name, (colnr_T)0))
-	    continue;
-
-	if (sid != -1 && sid != i)
 	    continue;
 
 	if ((d = dict_alloc()) == NULL
@@ -2151,10 +2157,9 @@ f_getscriptinfo(typval_T *argvars, typval_T *rettv)
 				si->sn_state == SN_STATE_NOT_LOADED) == FAIL)
 	    return;
 
-	// When a filter pattern is specified to return information about only
-	// specific script(s), also add the script-local variables and
-	// functions.
-	if (sid != -1)
+	// When a script ID is specified, return information about only the
+	// specified script, and add the script-local variables and functions.
+	if (sid > 0)
 	{
 	    dict_T	*var_dict;
 

--- a/src/testdir/test_scriptnames.vim
+++ b/src/testdir/test_scriptnames.vim
@@ -91,6 +91,11 @@ func Test_getscriptinfo()
   call assert_fails("echo getscriptinfo('foobar')", 'E1206:')
 
   call assert_fails("echo getscriptinfo({'sid': []})", 'E745:')
+  call assert_fails("echo getscriptinfo({'sid': 0})", 'E475:')
+  call assert_fails("echo getscriptinfo({'sid': -1})", 'E475:')
+
+  let max_sid = max(map(getscriptinfo(), { k, v -> v.sid }))
+  call assert_equal([], getscriptinfo({'sid': max_sid + 1}))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Also give an error when SID is not a positive integer.
