### PR TITLE
Fix crash when adding package with its after/ already in &rtp

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -718,18 +718,6 @@ add_pack_dir_to_rtp(char_u *fname)
 	char_u *cur_entry = entry;
 
 	copy_option_part(&entry, buf, MAXPATHL, ",");
-	if (insp == NULL)
-	{
-	    add_pathsep(buf);
-	    rtp_ffname = fix_fname(buf);
-	    if (rtp_ffname == NULL)
-		goto theend;
-	    match = vim_fnamencmp(rtp_ffname, ffname, fname_len) == 0;
-	    vim_free(rtp_ffname);
-	    if (match)
-		// Insert "ffname" after this entry (and comma).
-		insp = entry;
-	}
 
 	if ((p = (char_u *)strstr((char *)buf, "after")) != NULL
 		&& p > buf
@@ -742,6 +730,19 @@ add_pack_dir_to_rtp(char_u *fname)
 		insp = cur_entry;
 	    after_insp = cur_entry;
 	    break;
+	}
+
+	if (insp == NULL)
+	{
+	    add_pathsep(buf);
+	    rtp_ffname = fix_fname(buf);
+	    if (rtp_ffname == NULL)
+		goto theend;
+	    match = vim_fnamencmp(rtp_ffname, ffname, fname_len) == 0;
+	    vim_free(rtp_ffname);
+	    if (match)
+		// Insert "ffname" after this entry (and comma).
+		insp = entry;
 	}
     }
 

--- a/src/testdir/test_packadd.vim
+++ b/src/testdir/test_packadd.vim
@@ -21,6 +21,13 @@ func Test_packadd()
   call mkdir(s:plugdir . '/plugin/also', 'p')
   call mkdir(s:plugdir . '/ftdetect', 'p')
   call mkdir(s:plugdir . '/after', 'p')
+
+  " This used to crash Vim
+  let &rtp = 'nosuchdir,' . s:plugdir . '/after'
+  packadd mytest
+  " plugdir should be inserted before plugdir/after
+  call assert_match('^nosuchdir,' . s:plugdir . ',', &rtp)
+
   set rtp&
   let rtp = &rtp
   filetype on


### PR DESCRIPTION
Problem:
Crash when adding package with its after/ already in &rtp.

Solution:
Check for after/ before matching directory name.
