### PR TITLE
perf(runtime): fix strace regex

### DIFF
--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -338,7 +338,7 @@ def DetectFromText(line1: string)
     set ft=virata
 
     # Strace
-  elseif line1 =~ '[0-9:.]* *execve(' || line1 =~ '^__libc_start_main'
+  elseif line1 =~ 'execve(' || line1 =~ '^__libc_start_main'
     set ft=strace
 
     # VSE JCL

--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -338,7 +338,8 @@ def DetectFromText(line1: string)
     set ft=virata
 
     # Strace
-  elseif line1 =~ 'execve(' || line1 =~ '^__libc_start_main'
+  elseif (line1 =~ 'execve(' && line1 =~ '^[0-9:.]* *execve(')
+     || line1 =~ '^__libc_start_main'
     set ft=strace
 
     # VSE JCL

--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -338,6 +338,7 @@ def DetectFromText(line1: string)
     set ft=virata
 
     # Strace
+    # fast match first and complete regex if necessary
   elseif (line1 =~ 'execve(' && line1 =~ '^[0-9:.]* *execve(')
      || line1 =~ '^__libc_start_main'
     set ft=strace

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -733,8 +733,8 @@ func Test_filetype_detection()
   filetype off
 endfunc
 
-" Content lines that should not be detected as a filetype.
-let s:false_positive_check = {
+" Content lines that should not result in filetype detection
+let s:false_positive_checks = {
       \ '': [['test execve("/usr/bin/pstree", ["pstree"], 0x7ff0 /* 63 vars */) = 0']],
       \ }
 
@@ -829,7 +829,7 @@ func Run_script_detection(test_dict)
 endfunc
 
 func Test_script_detection()
-  call Run_script_detection(s:false_positive_check)
+  call Run_script_detection(s:false_positive_checks)
   call Run_script_detection(s:script_checks)
   call Run_script_detection(s:script_env_checks)
 endfunc

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -733,6 +733,11 @@ func Test_filetype_detection()
   filetype off
 endfunc
 
+" Content lines that should not be detected as a filetype.
+let s:false_positive_check = {
+      \ '': [['test execve("/usr/bin/pstree", ["pstree"], 0x7ff0 /* 63 vars */) = 0']],
+      \ }
+
 " Filetypes detected from the file contents by scripts.vim
 let s:script_checks = {
       \ 'virata': [['% Virata'],
@@ -824,6 +829,7 @@ func Run_script_detection(test_dict)
 endfunc
 
 func Test_script_detection()
+  call Run_script_detection(s:false_positive_check)
   call Run_script_detection(s:script_checks)
   call Run_script_detection(s:script_env_checks)
 endfunc


### PR DESCRIPTION
I think this regex can be simplified with no undesired effects. 

When opening text file with long lines of numbers (bitstrings in my case) the additional and optional `[0-9:.]* *` put unnecessary work on the regex engine. 

Honestly I don't see any reason why the regex should have the additional pattern. The two tests works fine with the simplified version