### PR TITLE
Fix crash when passing NULL string to setcmdline()

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4294,7 +4294,7 @@ f_setcmdline(typval_T *argvars, typval_T *rettv)
 	}
     }
 
-    rettv->vval.v_number = set_cmdline_str(argvars[0].vval.v_string, pos);
+    rettv->vval.v_number = set_cmdline_str(tv_get_string(&argvars[0]), pos);
 }
 
 /*

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3393,6 +3393,10 @@ endfunc
 
 func Test_setcmdline()
   func SetText(text, pos)
+    call assert_equal(0, setcmdline(test_null_string()))
+    call assert_equal('', getcmdline())
+    call assert_equal(1, getcmdpos())
+
     autocmd CmdlineChanged * let g:cmdtype = expand('<afile>')
     call assert_equal(0, setcmdline(a:text))
     call assert_equal(a:text, getcmdline())


### PR DESCRIPTION
Fix #12227
