### PR TITLE
Fix textprop truncate issue

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -739,10 +739,35 @@ text_prop_position(
 
 		    if (has_mbyte)
 		    {
+			char_u	*cp = IObuff;
+
 			// change last character to '…'
+			STRCPY(IObuff, "…");
+			if (!enc_utf8)
+			{
+			    vimconv_T	vc;
+
+			    vc.vc_type = CONV_NONE;
+			    convert_setup(&vc, (char_u *)"utf-8", p_enc);
+			    if (vc.vc_type != CONV_NONE)
+			    {
+				cp = string_convert(&vc, IObuff, NULL);
+				if (cp == NULL)
+				{
+				    cp = IObuff;
+				    // When convert fails, use '>'
+				    STRCPY(IObuff, ">");
+				}
+				convert_setup(&vc, NULL, NULL);
+			    }
+			}
+
+			lp -= (*mb_ptr2cells)(cp) - 1;
 			lp -= (*mb_head_off)(l, lp);
-			STRCPY(lp, "…");
+			STRCPY(lp, cp);
 			n_used = lp - l + 3 - before - padding;
+			if (cp != IObuff)
+			    vim_free(cp);
 		    }
 		    else
 			// change last character to '>'

--- a/src/testdir/dumps/Test_prop_with_text_after_trunc_ambiw_d_1.dump
+++ b/src/testdir/dumps/Test_prop_with_text_after_trunc_ambiw_d_1.dump
@@ -1,0 +1,9 @@
+|o+0&#ffffff0|n|e| |t|w|o| |t|h|r|e@1| |f|o|u|r| |f|i|v|e| |s|i|x| |s|e|v|e|n| +0&#ffff4012|O|N|E| |a|n|d| |T|W|O| |a|n|d| |T|H|R|E@1| |a|n|…| 
+|o+0&#ffffff0|n|e| |t|w|o| |t|h|r|e@1| |f|o|u|r| |f|i|v|e| |s|i|x| |s|e|v|e|n| +0&#ffff4012|o|n|e| |A|N|D| |t|w|o| |A|N|D| |t|h|r|e@1| |A|N|…| 
+|o+0&#ffffff0|n|e| |t|w|o| |t|h|r|e@1| |f|o|u|r| |f|i|v|e| |s|i|x| |s|e|v|e|n| @26
+| +0&#ffff4012|o|n|e| |A|N|D| |t|w|o| |A|N|D| |t|h|r|e@1| |A|N|D| |f|o|u|r| |A|N|D| |f|i|v|e| |l|e|t|s| |w|r|a|p| |a|f|t|e|r| |s|…| 
+|c+0&#ffffff0|u|r|s|o|r| >h|e|r|e| @48
+|~+0#4040ff13&| @58
+|~| @58
+|~| @58
+| +0#0000000&@41|4|,|8| @10|A|l@1| 

--- a/src/testdir/dumps/Test_prop_with_text_after_trunc_enc_is_not_utf8.dump
+++ b/src/testdir/dumps/Test_prop_with_text_after_trunc_enc_is_not_utf8.dump
@@ -1,0 +1,9 @@
+|o+0&#ffffff0|n|e| |t|w|o| |t|h|r|e@1| |f|o|u|r| |f|i|v|e| |s|i|x| |s|e|v|e|n| +0&#ffff4012|O|N|E| |a|n|d| |T|W|O| |a|n|d| |T|H|R|E@1| |a|n|…| +0&#ffffff0
+|o|n|e| |t|w|o| |t|h|r|e@1| |f|o|u|r| |f|i|v|e| |s|i|x| |s|e|v|e|n| +0&#ffff4012|o|n|e| |A|N|D| |t|w|o| |A|N|D| |t|h|r|e@1| |A|N|…| +0&#ffffff0
+|o|n|e| |t|w|o| |t|h|r|e@1| |f|o|u|r| |f|i|v|e| |s|i|x| |s|e|v|e|n| @26
+| +0&#ffff4012|o|n|e| |A|N|D| |t|w|o| |A|N|D| |t|h|r|e@1| |A|N|D| |f|o|u|r| |A|N|D| |f|i|v|e| |l|e|t|s| |w|r|a|p| |a|f|t|e|r| |s|…| +0&#ffffff0
+|c|u|r|s|o|r| >h|e|r|e| @48
+|~+0#4040ff13&| @58
+|~| @58
+|~| @58
+| +0#0000000&@41|4|,|8| @10|A|l@1| 

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -2949,6 +2949,57 @@ func Test_props_with_text_after_truncated()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_props_with_text_after_truncated_and_ambiwidth_is_double()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      set ambiwidth=double
+      call setline(1, ['one two three four five six seven'])
+      call prop_type_add('afterprop', #{highlight: 'Search'})
+      call prop_add(1, 0, #{type: 'afterprop', text: ' ONE and TWO and THREE and FOUR and FIVE'})
+
+      call setline(2, ['one two three four five six seven'])
+      call prop_add(2, 0, #{type: 'afterprop', text: ' one AND two AND three AND four AND five', text_align: 'right'})
+
+      call setline(3, ['one two three four five six seven'])
+      call prop_add(3, 0, #{type: 'afterprop', text: ' one AND two AND three AND four AND five lets wrap after some more text', text_align: 'below'})
+
+      call setline(4, ['cursor here'])
+      normal 4Gfh
+  END
+  call writefile(lines, 'XscriptPropsWithTextAfterTrunc-and-ambiwidth-is-double', 'D')
+  let buf = RunVimInTerminal('-S XscriptPropsWithTextAfterTrunc-and-ambiwidth-is-double', #{rows: 9, cols: 60})
+  call VerifyScreenDump(buf, 'Test_prop_with_text_after_trunc_ambiw_d_1', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+
+func Test_props_with_text_after_truncated_and_enc_is_not_utf8()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      set enc=cp932 tenc=utf-8
+      call setline(1, ['one two three four five six seven'])
+      call prop_type_add('afterprop', #{highlight: 'Search'})
+      call prop_add(1, 0, #{type: 'afterprop', text: ' ONE and TWO and THREE and FOUR and FIVE'})
+
+      call setline(2, ['one two three four five six seven'])
+      call prop_add(2, 0, #{type: 'afterprop', text: ' one AND two AND three AND four AND five', text_align: 'right'})
+
+      call setline(3, ['one two three four five six seven'])
+      call prop_add(3, 0, #{type: 'afterprop', text: ' one AND two AND three AND four AND five lets wrap after some more text', text_align: 'below'})
+
+      call setline(4, ['cursor here'])
+      normal 4Gfh
+  END
+  call writefile(lines, 'XscriptPropsWithTextAfterTrunc-enc-is-not-utf8', 'D')
+  let buf = RunVimInTerminal('-S XscriptPropsWithTextAfterTrunc-enc-is-not-utf8', #{rows: 9, cols: 60})
+  call VerifyScreenDump(buf, 'Test_prop_with_text_after_trunc_enc_is_not_utf8', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_props_with_text_empty_line()
   CheckRunVimInTerminal
 


### PR DESCRIPTION
Hi Bram,

I have found two problems with the truncate character in text property.
1. Truncate character '...' (U+2026 HORIZONTAL ELLIPSIS) is hard-coded in drawline.c
https://github.com/vim/vim/blob/master/src/drawline.c#L744
so when 'enc' is not utf-8, this character is garbled.
2. Cell width of the above character is fixed at 1, so the drawing will be incorrect in case of 'set ambiwidth=double'.

Please refer to the added test for reproducibility.

--
Best regards,
Hirohito Higashi (h_east)