### PR TITLE
termdebug: fix winbar config

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -877,7 +877,7 @@ func s:InstallCommands()
   command Program call s:GotoProgram()
   command Source call s:GotoSourcewinOrCreateIt()
   command Asm call s:GotoAsmwinOrCreateIt()
-  command Winbar call s:InstallWinbar()
+  command Winbar call s:InstallWinbar(1)
 
   let map = 1
   if exists('g:termdebug_config')
@@ -891,14 +891,7 @@ func s:InstallCommands()
   endif
 
   if has('menu') && &mouse != ''
-    " install the window toolbar by default, can be disabled in the config
-    let winbar = 1
-    if exists('g:termdebug_config')
-      let winbar = get(g:termdebug_config, 'winbar', 1)
-    endif
-    if winbar
-      call s:InstallWinbar()
-    endif
+    call s:InstallWinbar(0)
 
     let popup = 1
     if exists('g:termdebug_config')
@@ -923,8 +916,14 @@ endfunc
 let s:winbar_winids = []
 
 " Install the window toolbar in the current window.
-func s:InstallWinbar()
-  if has('menu') && &mouse != ''
+func s:InstallWinbar(force)
+  " install the window toolbar by default, can be disabled in the config
+  let winbar = 1
+  if exists('g:termdebug_config')
+    let winbar = get(g:termdebug_config, 'winbar', 1)
+  endif
+
+  if has('menu') && &mouse != '' && (winbar || a:force)
     nnoremenu WinBar.Step   :Step<CR>
     nnoremenu WinBar.Next   :Over<CR>
     nnoremenu WinBar.Finish :Finish<CR>
@@ -1222,7 +1221,7 @@ func s:GotoSourcewinOrCreateIt()
   if !win_gotoid(s:sourcewin)
     new
     let s:sourcewin = win_getid(winnr())
-    call s:InstallWinbar()
+    call s:InstallWinbar(0)
   endif
 endfunc
 
@@ -1345,7 +1344,7 @@ echomsg 'different fname: "' .. expand('%:p') .. '" vs "' .. fnamemodify(fname, 
           " TODO: find existing window
           exe 'split ' . fnameescape(fname)
           let s:sourcewin = win_getid(winnr())
-          call s:InstallWinbar()
+          call s:InstallWinbar(0)
         else
           exe 'edit ' . fnameescape(fname)
         endif


### PR DESCRIPTION
Problem:  Despite having `winbar` disabled in `g:termdebug_config`, the
          termdebug plugin will still end up creating the winbar in certain
          situations. Such as when called from GotoSourcewinOrCreateIt().
Solution: Check for winbar inside InstallWinbar(), additionally use a
          `force` parameter to ensure explicit :Winbar commands are respected.