### PR TITLE
Fix obvious typos and inconsistencies in the Finnish translation

### DIFF
--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -17,14 +17,15 @@ msgstr ""
 "Project-Id-Version: Vim\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-01-17 00:43+0100\n"
-"PO-Revision-Date: 2022-01-19 16:54+0100\n"
-"Last-Translator: Flammie A Pirinen <flammie@iki.fi>\n"
+"PO-Revision-Date: 2023-05-07 16:29+0300\n"
+"Last-Translator: Juhani Krekelä <juhani@krekelä.fi>\n"
 "Language-Team: Finnish <laatu@lokalisointi.org>\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.2.2\n"
 
 msgid "ERROR: "
 msgstr "VIRHE: "
@@ -35,7 +36,7 @@ msgid ""
 "[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
 msgstr ""
 "\n"
-"[tavua] yht. alloc-free %lu-%lu, käytössä %lu, käyttöhuippu %lu\n"
+"[tavua] yht. alloc-freed %lu-%lu, käytössä %lu, käyttöhuippu %lu\n"
 
 #, c-format
 msgid ""
@@ -190,7 +191,7 @@ msgstr " MUUNNOSVIRHE"
 
 #, c-format
 msgid " in line %ld;"
-msgstr " rivillä %ld"
+msgstr " rivillä %ld;"
 
 msgid "[NOT converted]"
 msgstr "[EI muunnettu]"
@@ -280,7 +281,7 @@ msgstr "Siirrytään vianetsintätilaan, kirjoita cont jatkaaksesi."
 
 #, c-format
 msgid "Oldval = \"%s\""
-msgstr "vanha-arvo = %s"
+msgstr "Vanha-arvo = %s"
 
 #, c-format
 msgid "Newval = \"%s\""
@@ -403,7 +404,7 @@ msgstr "Bopomofo"
 
 msgid "Not enough memory to set references, garbage collection aborted!"
 msgstr ""
-"Ei tarpeeksi muistia viitteiden asettamista varten, roskiekeruu peruttiin."
+"Ei tarpeeksi muistia viitteiden asettamista varten, roskienkeruu peruttiin."
 
 msgid ""
 "\n"
@@ -459,7 +460,7 @@ msgstr "> %d, heksana %04x, oktaalina %o, digraafi %s"
 
 #, c-format
 msgid "> %d, Hex %08x, Oct %o, Digr %s"
-msgstr "> %d, hekdana %08x, oktaalina %o, digraafi %s"
+msgstr "> %d, heksana %08x, oktaalina %o, digraafi %s"
 
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
@@ -467,7 +468,7 @@ msgstr "> %d, heksana %04x, oktaalina %o"
 
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
-msgstr "> %d, hekdana %08x, oktaalina %o"
+msgstr "> %d, heksana %08x, oktaalina %o"
 
 #, c-format
 msgid "%ld line moved"
@@ -483,11 +484,11 @@ msgid "[No write since last change]\n"
 msgstr "[Viimeisintä muutosta ei ole kirjoitettu]\n"
 
 msgid "Write partial file?"
-msgstr "Kirjoita osittainen tiedosto"
+msgstr "Kirjoita osittainen tiedosto?"
 
 #, c-format
 msgid "Overwrite existing file \"%s\"?"
-msgstr "Ylikirjoitetaanko olemassaoleva tiedosto %s?"
+msgstr "Ylikirjoitetaanko olemassa oleva tiedosto %s?"
 
 #, c-format
 msgid "Swap file \"%s\" exists, overwrite anyway?"
@@ -519,7 +520,7 @@ msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "korvaa kohteella %s (y/n/a/q/l/^E/^Y)?"
 
 msgid "(Interrupted) "
-msgstr "(Keskeytetty)"
+msgstr "(Keskeytetty) "
 
 #, c-format
 msgid "%ld match on %ld line"
@@ -575,7 +576,7 @@ msgstr "Takaperoinen arvoalue annettu, OK kääntää"
 msgid ""
 "INTERNAL: Cannot use EX_DFLALL with ADDR_NONE, ADDR_UNSIGNED or ADDR_QUICKFIX"
 msgstr ""
-"Sisäinen: Ei voi käyttää EX_DFLALLia yhdessä ADDR_NONEn, ADDR_UNSIGNEDin tai"
+"Sisäinen: Ei voi käyttää EX_DFLALLia yhdessä ADDR_NONEn, ADDR_UNSIGNEDin tai "
 "ADDR_QUICKFIXin kanssa"
 
 #, c-format
@@ -594,14 +595,14 @@ msgid "Already only one tab page"
 msgstr "Vain yksi välilehti jäljellä enää"
 
 msgid "Edit File in new tab page"
-msgstr "Muokkaa uudessa tabissa"
+msgstr "Muokkaa uudessa välilehdessä"
 
 msgid "Edit File in new window"
 msgstr "Muokkaa uudessa ikkunassa"
 
 #, c-format
 msgid "Tab page %d"
-msgstr "Tabisivu %d"
+msgstr "Välilehtisivu %d"
 
 msgid "No swap file"
 msgstr "Ei swap-tiedostoa"
@@ -691,7 +692,7 @@ msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Luetaan vakiosyötteestä...\n"
 
 msgid "Reading from stdin..."
-msgstr "Luetaan vakiosyötteestä"
+msgstr "Luetaan vakiosyötteestä..."
 
 msgid "[fifo]"
 msgstr "[fifo]"
@@ -721,7 +722,7 @@ msgid "[READ ERRORS]"
 msgstr "[LUKUVIRHEITÄ]"
 
 msgid "Can't find temp file for conversion"
-msgstr "Ei voi löytää väliaikaistiedstoa muuntamiseksi"
+msgstr "Ei voi löytää väliaikaistiedostoa muuntamiseksi"
 
 msgid "Conversion with 'charconvert' failed"
 msgstr "Muunnos charconvert epäonnistui"
@@ -761,15 +762,14 @@ msgstr[1] "%lld tavua"
 
 # ei rivinvaihtoja
 msgid "[noeol]"
-msgstr "[eiriviv.]"
+msgstr "[eirivinv.]"
 
 msgid "[Incomplete last line]"
 msgstr "[Vajaa viimeinen rivi]"
 
 #, c-format
 msgid ""
-"W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
-"well"
+"W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as well"
 msgstr ""
 "W12: Varoitus: Tiedostoa %s on muutettu ja Vimin puskurissa on muutoksia "
 "tiedostoon"
@@ -812,7 +812,7 @@ msgid "<empty>"
 msgstr "<tyhjä>"
 
 msgid "writefile() first argument must be a List or a Blob"
-msgstr "writefile()-funktion ensimmäisen argumentin on oltava List tai Blob "
+msgstr "writefile()-funktion ensimmäisen argumentin on oltava List tai Blob"
 
 msgid "Select Directory dialog"
 msgstr "Hakemiston valintaikkuna"
@@ -829,8 +829,8 @@ msgstr "ei täsmäyksiä"
 #, c-format
 msgid "+--%3ld line folded "
 msgid_plural "+--%3ld lines folded "
-msgstr[0] "+--%3ld rivi taiteltu"
-msgstr[1] "+--%3ld riviä taiteltu"
+msgstr[0] "+--%3ld rivi taiteltu "
+msgstr[1] "+--%3ld riviä taiteltu "
 
 #, c-format
 msgid "+-%s%3ld line: "
@@ -854,7 +854,7 @@ msgid "Vim dialog"
 msgstr "Vim-ikkuna"
 
 msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-msgstr "Vierityspalkki: Pixmapin geometria ei selviä"
+msgstr "Vierityspalkki: Pixmapin geometria ei selviä."
 
 msgid "No match at cursor, finding next"
 msgstr "Ei täsmäystä kursorin alla, etsitään seuraava"
@@ -1074,7 +1074,7 @@ msgstr "Tulostustyö lähetetty."
 
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
-msgstr "ohjetiedostoa %s ei löydy"
+msgstr "Ohjetiedostoa %s ei löydy"
 
 msgid "W18: Invalid character in group name"
 msgstr "W18: Virheellinen merkki ryhmän nimessä"
@@ -1243,7 +1243,7 @@ msgid "invalid mark name"
 msgstr "virheellinen merkin nimi"
 
 msgid "mark not set"
-msgstr "merkko ei ole asetettu"
+msgstr "merkki ei ole asetettu"
 
 #, c-format
 msgid "row %d column %d"
@@ -1267,8 +1267,7 @@ msgstr "näppäimistökeskeytys"
 msgid "cannot create buffer/window command: object is being deleted"
 msgstr "ei voi luoda puskuri- tai ikkunakomentoa, olio on poistumassa"
 
-msgid ""
-"cannot register callback command: buffer/window is already being deleted"
+msgid "cannot register callback command: buffer/window is already being deleted"
 msgstr "callbackia ei voi rekisteröidä: puskuri tai ikkuna on poistettu"
 
 msgid "cannot register callback command: buffer/window reference not found"
@@ -1282,7 +1281,7 @@ msgstr "Komentopalvelimen nimen rekisteröinti ei onnistu"
 
 #, c-format
 msgid "%ld lines to indent... "
-msgstr "%ld riviä sisennettävänä..."
+msgstr "%ld riviä sisennettävänä... "
 
 #, c-format
 msgid "%ld line indented "
@@ -1447,13 +1446,13 @@ msgid "This Vim was not compiled with the diff feature."
 msgstr "Tähän Vimiin ei ole käännetty diff-toimintoja mukaan."
 
 msgid "Attempt to open script file again: \""
-msgstr "Yritettiin avata skriptitiedostoa uudestaan:"
+msgstr "Yritettiin avata skriptitiedostoa uudestaan: \""
 
 msgid "Cannot open for reading: \""
-msgstr "Ei voi avata luettavaksi: "
+msgstr "Ei voi avata luettavaksi: \""
 
 msgid "Cannot open for script output: \""
-msgstr "Ei voi avata skriptin tulostetta varten: "
+msgstr "Ei voi avata skriptin tulostetta varten: \""
 
 msgid "Vim: Error: Failure to start gvim from NetBeans\n"
 msgstr "Vim: Virhe: Gvimin käynnistys NetBeansistä ei onnistu\n"
@@ -1513,8 +1512,7 @@ msgid ""
 "Where case is ignored prepend / to make flag upper case"
 msgstr ""
 "\n"
-"Jos aakkoslaji on ohitettu, lisää alkuun / tehdäksesi asetuksesta "
-"suuraakkosia"
+"Jos aakkoslaji on ohitettu, lisää alkuun / tehdäksesi asetuksesta suuraakkosia"
 
 msgid ""
 "\n"
@@ -1526,13 +1524,13 @@ msgstr ""
 "Argumentit:\n"
 
 msgid "--\t\t\tOnly file names after this"
-msgstr "--\t\t\tvain tiedostonimiä tämän jälkeen"
+msgstr "--\t\t\tVain tiedostonimiä tämän jälkeen"
 
 msgid "--literal\t\tDon't expand wildcards"
-msgstr "--literal\t\tÄlä käsittele jokerimerkkejä "
+msgstr "--literal\t\tÄlä käsittele jokerimerkkejä"
 
 msgid "-register\t\tRegister this gvim for OLE"
-msgstr "-register\t\trekisteröi gvim OLEa varten"
+msgstr "-register\t\tRekisteröi gvim OLEa varten"
 
 msgid "-unregister\t\tUnregister gvim for OLE"
 msgstr "-unregister\t\tPoista gvim OLE-rekisteristä"
@@ -1547,7 +1545,7 @@ msgid "-v\t\t\tVi mode (like \"vi\")"
 msgstr "-v\t\t\tVi-tila (kuten villä)"
 
 msgid "-e\t\t\tEx mode (like \"ex\")"
-msgstr "-e\t\t\tEx-tila (kute exillä)"
+msgstr "-e\t\t\tEx-tila (kuten exillä)"
 
 msgid "-E\t\t\tImproved Ex mode"
 msgstr "-E\t\t\tParanneltu Ex-tila"
@@ -1586,8 +1584,7 @@ msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
 msgstr "-N\t\t\tEi Vi-yhteensopivuutta: nocompatible"
 
 msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
-msgstr ""
-"-V[N][tnimi]\t\tMonisanainen tuloste [Taso N] [kirjoita tuloste tnimeen] "
+msgstr "-V[N][tnimi]\t\tMonisanainen tuloste [Taso N] [kirjoita tuloste tnimeen]"
 
 msgid "-D\t\t\tDebugging mode"
 msgstr "-D\t\t\tVianetsintätila"
@@ -1602,7 +1599,7 @@ msgid "-r (with file name)\tRecover crashed session"
 msgstr "-r (tiedostonimi)\tPalauta kaatunut sessio"
 
 msgid "-L\t\t\tSame as -r"
-msgstr "-L\t\t\tkuten -r"
+msgstr "-L\t\t\tKuten -r"
 
 msgid "-f\t\t\tDon't use newcli to open window"
 msgstr "-f\t\t\tÄlä käytä newcli:tä ikkunan avaamiseen"
@@ -1611,10 +1608,10 @@ msgid "-dev <device>\t\tUse <device> for I/O"
 msgstr "-dev <laite>\t\tKäytä <laitetta> IO:hon"
 
 msgid "-A\t\t\tStart in Arabic mode"
-msgstr "-A\t\t\tkäynnistä arabia-tilassa"
+msgstr "-A\t\t\tKäynnistä arabia-tilassa"
 
 msgid "-H\t\t\tStart in Hebrew mode"
-msgstr "-H\t\t\tkäynnistä heprea-tilassa"
+msgstr "-H\t\t\tKäynnistä heprea-tilassa"
 
 msgid "-T <terminal>\tSet terminal type to <terminal>"
 msgstr "-T <terminaali>\tAseta terminaalin tyypiksi <terminaali>"
@@ -1684,25 +1681,22 @@ msgstr ""
 
 msgid "--remote-silent <files>  Same, don't complain if there is no server"
 msgstr ""
-"--remote-silent <tiedostoja>\tSama, mutta älä ilmoita puuttuvasta "
-"palvelimesta"
+"--remote-silent <tiedostoja>\tSama, mutta älä ilmoita puuttuvasta palvelimesta"
 
-msgid ""
-"--remote-wait <files>  As --remote but wait for files to have been edited"
+msgid "--remote-wait <files>  As --remote but wait for files to have been edited"
 msgstr ""
-"--remote-wait <tiedostoja>  kuten --remote, mutta odota tiedostojen "
+"--remote-wait <tiedostoja>  Kuten --remote, mutta odota tiedostojen "
 "muokkaamista"
 
-msgid ""
-"--remote-wait-silent <files>  Same, don't complain if there is no server"
+msgid "--remote-wait-silent <files>  Same, don't complain if there is no server"
 msgstr ""
-"--remote-wait-silent <tiedostoja>  sama, mutta älä ilmoita puuttuvasta "
+"--remote-wait-silent <tiedostoja>  Sama, mutta älä ilmoita puuttuvasta "
 "palvelimesta"
 
 msgid ""
 "--remote-tab[-wait][-silent] <files>  As --remote but use tab page per file"
 msgstr ""
-"--remote-tab[-wait][-silent] <tiedostoja>  kuten --remote, mutta avaa "
+"--remote-tab[-wait][-silent] <tiedostoja>  Kuten --remote, mutta avaa "
 "välilehti joka tiedostolle"
 
 msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
@@ -1726,8 +1720,7 @@ msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
 msgstr "-i <viminfo>\t\tKäytä <viminfo>-tiedostoa .viminfon sijaan"
 
 msgid "--clean\t\t'nocompatible', Vim defaults, no plugins, no viminfo"
-msgstr ""
-"--clean\t\t'nocompatible', Vimin oletukset,ei liitännäisiä tai viminfoa"
+msgstr "--clean\t\t'nocompatible', Vimin oletukset,ei liitännäisiä tai viminfoa"
 
 msgid "-h  or  --help\tPrint Help (this message) and exit"
 msgstr "-h tai --help\tTulosta ohje (tämä viesti) ja lopeta"
@@ -1778,21 +1771,19 @@ msgid "-italicfont <font>\tUse <font> for italic text"
 msgstr "-italicfont <fontti>\tKäytä <fonttia> kursivoidussa tekstissä"
 
 msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-msgstr ""
-"-geometry <geom>\tKäytä mittoja <geom> ikkunan asetteluun (myös: -geom)"
+msgstr "-geometry <geom>\tKäytä mittoja <geom> ikkunan asetteluun (myös: -geom)"
 
 msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-msgstr "-borderwidt <leveys>\tKäytä <leveyttä> reunuksissa (myös: -bw) "
+msgstr "-borderwidt <leveys>\tKäytä <leveyttä> reunuksissa (myös: -bw)"
 
 msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-msgstr ""
-"-scrollbarwidth <leveys>  Käytä <leveyttä> vierityspalkissa (myös: -sw)"
+msgstr "-scrollbarwidth <leveys>  Käytä <leveyttä> vierityspalkissa (myös: -sw)"
 
 msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
 msgstr "-menuheight <korkeus>\tKäytä <korkeutta> valikossa (myös: -mh)"
 
 msgid "-reverse\t\tUse reverse video (also: -rv)"
-msgstr "-reverse\t\tKäytä käänteisvärejä (myös: -rv) "
+msgstr "-reverse\t\tKäytä käänteisvärejä (myös: -rv)"
 
 msgid "+reverse\t\tDon't use reverse video (also: +rv)"
 msgstr "+reverse\t\tÄlä käytä käänteisvärejä (myös: +rv)"
@@ -1816,7 +1807,7 @@ msgid "--role <role>\tSet a unique role to identify the main window"
 msgstr "--role <rooli>\tAseta pääikkunalle ainutlaatuinen rooli tunnisteeksi"
 
 msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-msgstr "--socketid <xid>\tAvaa Vim annettuun GTK-olioon "
+msgstr "--socketid <xid>\tAvaa Vim annettuun GTK-olioon"
 
 msgid "--echo-wid\t\tMake gvim echo the Window ID on stdout"
 msgstr "--echo-wid\t\tTulosta gvimin Window ID vakiotulosteeseen"
@@ -1825,7 +1816,7 @@ msgid "-P <parent title>\tOpen Vim inside parent application"
 msgstr "-P <otsikko>\tAvaa Vim isäntäohjelman sisään"
 
 msgid "--windowid <HWND>\tOpen Vim inside another win32 widget"
-msgstr "--windowid <HWND>\tAvaa Vim annettuun win32-olioon "
+msgstr "--windowid <HWND>\tAvaa Vim annettuun win32-olioon"
 
 msgid "No abbreviation found"
 msgstr "Lyhennettä ei löydy"
@@ -1930,7 +1921,7 @@ msgid ""
 "to use the same key for text file and swap file"
 msgstr ""
 "\n"
-"käyttääksesi samaa avainta teksti- ja swäppitiedostoille"
+"käyttääksesi samaa avainta teksti- ja swap-tiedostoille"
 
 msgid "???MANY LINES MISSING"
 msgstr "???PALJON RIVEJÄ PUUTTUU"
@@ -1957,7 +1948,7 @@ msgid "???END"
 msgstr "???LOPPU"
 
 msgid "See \":help E312\" for more information."
-msgstr ":help E312 kertoo lisätietoja"
+msgstr ":help E312 kertoo lisätietoja."
 
 msgid "Recovery completed. You should check if everything is OK."
 msgstr "Palautus onnistui. Tarkista, että kaikki on kunnossa."
@@ -1990,7 +1981,7 @@ msgstr ""
 "Huom: prosessi on vielä käynnissä: "
 
 msgid "Using crypt key from swap file for the text file.\n"
-msgstr "Käytetään swäpin salausavainta tekstitiedostolle\n"
+msgstr "Käytetään swap-tiedoston salausavainta tekstitiedostolle\n"
 
 msgid "Swap files found:"
 msgstr "Swap-tiedostoja löytyi:"
@@ -2014,7 +2005,7 @@ msgid "   dated: "
 msgstr "  ajalta: "
 
 msgid "             dated: "
-msgstr "            ajalta:"
+msgstr "            ajalta: "
 
 msgid "         [from Vim version 3.0]"
 msgstr "         [Vimin 3.0-versiosta]"
@@ -2108,7 +2099,7 @@ msgstr ""
 "Swap-tiedosto löytyi: \""
 
 msgid "While opening file \""
-msgstr "Avattaessa tiedostoa "
+msgstr "Avattaessa tiedostoa \""
 
 msgid "      CANNOT BE FOUND"
 msgstr "      EI LÖYTYNYT"
@@ -2141,7 +2132,7 @@ msgstr ""
 "    palauttaaksesi muutokset (lisätietoja: \":help recovery\").\n"
 
 msgid "    If you did this already, delete the swap file \""
-msgstr "    Jos teit jo näin, poista swap-tiedosto "
+msgstr "    Jos teit jo näin, poista swap-tiedosto \""
 
 msgid ""
 "\"\n"
@@ -2154,16 +2145,16 @@ msgid "Found a swap file that is not useful, deleting it"
 msgstr "Swap-tiedosto löytyi mutta on käyttökelvoton joten se poistetaan"
 
 msgid "Swap file \""
-msgstr "Swap-tiedosto "
+msgstr "Swap-tiedosto \""
 
 msgid "\" already exists!"
-msgstr " on jo olemassa"
+msgstr "\" on jo olemassa!"
 
 msgid "VIM - ATTENTION"
 msgstr "VIM - HUOMAUTUS"
 
 msgid "Swap file already exists!"
-msgstr "Swap-tiedosto on jo olemassa"
+msgstr "Swap-tiedosto on jo olemassa."
 
 msgid ""
 "&Open Read-Only\n"
@@ -2222,7 +2213,7 @@ msgid "Interrupt: "
 msgstr "Keskeytys: "
 
 msgid "Press ENTER or type command to continue"
-msgstr "Paina enteriä tai kirjoita komento aloittaaksesi "
+msgstr "Paina enteriä tai kirjoita komento aloittaaksesi"
 
 msgid "Unknown"
 msgstr "Tuntematon"
@@ -2310,7 +2301,7 @@ msgstr[0] "%ld rivi %s %d kertaa"
 msgstr[1] "%ld riviä %s %d kertaa"
 
 msgid "cannot yank; delete anyway"
-msgstr "Ei voi kopioida; poista joka tapauksessa"
+msgstr "ei voi kopioida; poista joka tapauksessa"
 
 #, c-format
 msgid "%ld line changed"
@@ -2345,8 +2336,8 @@ msgstr "Sarake %s/%s, Rivi %ld/%ld, sana %lld/%lld, tavu %lld/%lld"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %lld of %lld; Char %lld of %lld; Byte "
-"%lld of %lld"
+"Col %s of %s; Line %ld of %ld; Word %lld of %lld; Char %lld of %lld; Byte %lld "
+"of %lld"
 msgstr ""
 "Sarake %s/%s, rivi %ld/%ld, sana %lld/%lld, merkki %lld/%lld, tavu %lld/%lld"
 
@@ -2356,7 +2347,7 @@ msgid "(+%lld for BOM)"
 msgstr "(+%lld BOMista)"
 
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
-msgstr "W17: Arabialle pitää olla UTF-8:aa, aseta :set encoding=utf-8"
+msgstr "W17: Arabia vaatii UTF-8:n, aseta :set encoding=utf-8"
 
 msgid ""
 "\n"
@@ -2488,7 +2479,7 @@ msgstr "Ei voitu asettaa turvallisuuskontekstia %s kohteelle %s"
 # mikä security context?
 #, c-format
 msgid "Could not get security context %s for %s. Removing it!"
-msgstr "Ei saatu turvallisuuskontekstia %s kohteelle %s ja se poistetaan"
+msgstr "Ei saatu turvallisuuskontekstia %s kohteelle %s ja se poistetaan."
 
 msgid ""
 "\n"
@@ -2578,7 +2569,7 @@ msgid ""
 msgstr ""
 "VIMRUN.EXEä ei löydy muuttujasta $PATH.\n"
 "Ulkoiset komennot eivät pysähdy suorituksen lopussa.\n"
-"Lisätietoja komennolla  :help win32-vimrun"
+"Lisätietoja komennolla  :help win32-vimrun."
 
 msgid "Vim Warning"
 msgstr "Vim-varoitus"
@@ -2596,7 +2587,7 @@ msgstr " (rivi poistettu)"
 
 #, c-format
 msgid "%serror list %d of %d; %d errors "
-msgstr "%svirhelista %d/%d, %d virhettä"
+msgstr "%svirhelista %d/%d, %d virhettä "
 
 msgid "No entries"
 msgstr "Ei kenttiä"
@@ -2879,16 +2870,14 @@ msgstr "FLAG kohteessa %s lippujen jälkeen rivillä %d: %s"
 
 #, c-format
 msgid ""
-"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
-"%d"
+"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line %d"
 msgstr ""
 "COMPOUNDFORBIDFLAG PFX:n jälkeen voi antaa vääriä tuloksia kohteessa %s "
 "rivillä %d"
 
 #, c-format
 msgid ""
-"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
-"%d"
+"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line %d"
 msgstr ""
 "COMPOUNDPERMITFLAG PFX:n jälkeen voi antaa vääriä tuloksia kohteessa %s "
 "rivillä %d"
@@ -2992,7 +2981,7 @@ msgstr "%s-arvo eroaa toisessa .aff-tiedostossa olevasta"
 
 #, c-format
 msgid "Reading dictionary file %s..."
-msgstr "Luetaan sanakirjatiedostoa %s"
+msgstr "Luetaan sanakirjatiedostoa %s..."
 
 #, c-format
 msgid "line %6d, word %6ld - %s"
@@ -3102,11 +3091,11 @@ msgid "Word '%.*s' added to %s"
 msgstr "Sana %.*s lisätty kohteeseen %s"
 
 msgid "Sorry, no suggestions"
-msgstr "ei ehdotuksia"
+msgstr "Ei ehdotuksia"
 
 #, c-format
 msgid "Sorry, only %ld suggestions"
-msgstr "vain %ld ehdotusta"
+msgstr "Vain %ld ehdotusta"
 
 #, c-format
 msgid "Change \"%.*s\" to:"
@@ -3129,7 +3118,7 @@ msgid "syntax conceal off"
 msgstr "syntaksin piilotus pois"
 
 msgid "syntax case ignore"
-msgstr "syntaksin merkkitason ohitus "
+msgstr "syntaksin merkkitason ohitus"
 
 msgid "syntax case match"
 msgstr "syntaksin merkkitason täsmäys"
@@ -3198,7 +3187,7 @@ msgid "minimal "
 msgstr "vähintään "
 
 msgid "maximal "
-msgstr "enitntään "
+msgstr "enintään "
 
 msgid "; match "
 msgstr "; täsmää "
@@ -3223,7 +3212,7 @@ msgid " or more"
 msgstr " tai useammasta"
 
 msgid "  Using tag with different case!"
-msgstr "  Tägissä eri kirjaintaso"
+msgstr "  Tägissä eri kirjaintaso."
 
 msgid "  # pri kind tag"
 msgstr "  # arvo tyyppi tägi"
@@ -3236,7 +3225,7 @@ msgid ""
 "  # TO tag         FROM line  in file/text"
 msgstr ""
 "\n"
-"  # TILL tagg          FRÅN LINJE  i fil/text"
+"  # TILL tagg          FRÅN linje  i fil/text"
 
 #, c-format
 msgid "Searching tags file %s"
@@ -3254,10 +3243,10 @@ msgid "Duplicate field name: %s"
 msgstr "Kaksoiskappale kentän nimestä: %s"
 
 msgid "' not known. Available builtin terminals are:"
-msgstr " ei tunnettu. Tuetut terminaalit:"
+msgstr "' ei tunnettu. Tuetut terminaalit:"
 
 msgid "defaulting to '"
-msgstr "oletusarvona "
+msgstr "oletusarvona '"
 
 msgid ""
 "\n"
@@ -3268,7 +3257,7 @@ msgstr ""
 
 #, c-format
 msgid "Kill job in \"%s\"?"
-msgstr "Tapetaanko komento kohteessa %s"
+msgstr "Tapetaanko komento kohteessa %s?"
 
 msgid "Terminal"
 msgstr "Terminaali"
@@ -3314,7 +3303,7 @@ msgstr "Ei voitu lukea kumoustiedostoa mistään undodir-muuttujan hakemistosta"
 
 #, c-format
 msgid "Will not overwrite with undo file, cannot read: %s"
-msgstr "Ei ylikirjoitetat kumoustiedostolla, koska ei voida lukea: %s"
+msgstr "Ei ylikirjoiteta kumoustiedostolla, koska ei voida lukea: %s"
 
 #, c-format
 msgid "Will not overwrite, this is not an undo file: %s"
@@ -3336,12 +3325,11 @@ msgid "Reading undo file: %s"
 msgstr "Luetaan kumoustiedostoa: %s"
 
 msgid "File contents changed, cannot use undo info"
-msgstr ""
-"Tiedoston sisältö on muuttunut, joen kumoustiedot ovat käyttökelvottomia"
+msgstr "Tiedoston sisältö on muuttunut, joen kumoustiedot ovat käyttökelvottomia"
 
 #, c-format
 msgid "Finished reading undo file %s"
-msgstr "Ladattu kumoustiedoto %s"
+msgstr "Ladattu kumoustiedosto %s"
 
 msgid "Already at oldest change"
 msgstr "Vanhimmassa muutoksessa"
@@ -3475,7 +3463,7 @@ msgid ""
 "macOS version w/o darwin feat."
 msgstr ""
 "\n"
-"macOS-versio ilman darwinia"
+"macOS-versio ilman darwinia."
 
 msgid ""
 "\n"
@@ -3625,7 +3613,7 @@ msgid "Compilation: "
 msgstr "Käännös: "
 
 msgid "Compiler: "
-msgstr "Käännin: "
+msgstr "Kääntäjä: "
 
 msgid "Linking: "
 msgstr "Linkitys: "
@@ -3646,7 +3634,7 @@ msgid "Vim is open source and freely distributable"
 msgstr "Vim on avointa lähdekoodia ja vapaasti jaossa"
 
 msgid "Help poor children in Uganda!"
-msgstr "Auta Ugandan köyhiä lapsia"
+msgstr "Auta Ugandan köyhiä lapsia."
 
 msgid "type  :help iccf<Enter>       for information "
 msgstr "kirjoita :help iccf<Enter>    lisätietoa varten            "
@@ -3655,16 +3643,16 @@ msgid "type  :q<Enter>               to exit         "
 msgstr "kirjoita :q<Enter>            lopettaaksesi                "
 
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
-msgstr "kirjoita :help<Enter> tai <F1> ohjetta varten              "
+msgstr "kirjoita :help<Enter> tai <F1> ohjetta varten"
 
 msgid "type  :help version9<Enter>   for version info"
-msgstr "kirjoita :help version9<Enter> versiotietoja varten        "
+msgstr "kirjoita :help version9<Enter> versiotietoja varten"
 
 msgid "Running in Vi compatible mode"
 msgstr "Suoritetaan Vi-yhteensopivuustilaa"
 
 msgid "type  :set nocp<Enter>        for Vim defaults"
-msgstr "kirjoita :set nocp<Enter>      Vimin oletuksiin            "
+msgstr "kirjoita :set nocp<Enter>      Vimin oletuksiin"
 
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "kirjoita :help cp-default<Enter> ohjetta oletuksista varten"
@@ -3676,7 +3664,7 @@ msgid "Running modeless, typed text is inserted"
 msgstr "Suoritetaan tilattomana, kirjoitettu teksti syötetään"
 
 msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-msgstr "valikko Muokkaa->Yleiset asetukset->Vaihda syötetilaa"
+msgstr "valikko Muokkaa->Yleiset asetukset->Vaihda syötetilaa  "
 
 msgid "                              for two modes      "
 msgstr "                              kahta tilaa varten "
@@ -3685,22 +3673,22 @@ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
 msgstr "valikko Muokkaa->Yleiset asetukset->Vaihda Vi-yhteensopivuutta"
 
 msgid "                              for Vim defaults   "
-msgstr "                              Vim-oletuksia varten"
+msgstr "                              Vim-oletuksia varten   "
 
 msgid "Sponsor Vim development!"
-msgstr "Tue Vimin kehitystä"
+msgstr "Tue Vimin kehitystä."
 
 msgid "Become a registered Vim user!"
 msgstr "Rekisteröidy Vim-käyttäjäksi."
 
 msgid "type  :help sponsor<Enter>    for information "
-msgstr "kirjoita :help sponsor<Enter>  lisätietoja varten"
+msgstr "kirjoita :help sponsor<Enter>  lisätietoja varten "
 
 msgid "type  :help register<Enter>   for information "
-msgstr "kirjoita :help register<Enter> lisätietoja varten"
+msgstr "kirjoita :help register<Enter> lisätietoja varten "
 
 msgid "menu  Help->Sponsor/Register  for information    "
-msgstr "valikko Ohje->Sponsoroi/Rekisteröi lisätietoja varten"
+msgstr "valikko Ohje->Sponsoroi/Rekisteröi lisätietoja varten    "
 
 msgid "global"
 msgstr "globaali"
@@ -3857,7 +3845,7 @@ msgid "E370: Could not load library %s"
 msgstr "E370: Kirjaston %s lataaminen ei onnistu"
 
 msgid "Sorry, this command is disabled: the Perl library could not be loaded."
-msgstr "komento ei toimi, Perl kirjastoa ei voinut ladata."
+msgstr "Komento ei toimi, Perl kirjastoa ei voinut ladata."
 
 msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
 msgstr "E299: Perl-suoritus kielletty hiekkalaatikossa ilman Safe-moduulia"
@@ -3875,16 +3863,16 @@ msgid "Edit with &Vim"
 msgstr "Muokkaa &Vimillä"
 
 msgid "Edit with existing Vim"
-msgstr "Muokkaa olemassaolevalla Vimillä"
+msgstr "Muokkaa olemassa olevalla Vimillä"
 
 msgid "Edit with existing Vim - "
-msgstr "Muokkaa olemassaolevalla Vimillä - "
+msgstr "Muokkaa olemassa olevalla Vimillä - "
 
 msgid "Edits the selected file(s) with Vim"
 msgstr "Muokkaa valittuja tiedostoja Vimillä"
 
 msgid "Error creating process: Check if gvim is in your path!"
-msgstr "Virhe prosessin käynnistämisessä, varmista että gvim on polulla"
+msgstr "Virhe prosessin käynnistämisessä: Varmista että gvim on polulla."
 
 msgid "gvimext.dll error"
 msgstr "gvimext.dll-virhe"
@@ -3900,8 +3888,7 @@ msgstr "E11: Virheellinen komentorivi-ikkuna, <CR> suorittaa, Ctrl C lopettaa"
 
 msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
 msgstr ""
-"E12: Komentoa ei tueta exrc:ssä tai vimrc:ssä tässä hakemistossa tai "
-"tägihaussa"
+"E12: Komentoa ei tueta exrc:ssä tai vimrc:ssä tässä hakemistossa tai tägihaussa"
 
 msgid "E13: File exists (add ! to override)"
 msgstr "E13: Tiedosto on jo olemassa (lisää ! ohittaaksesi)"
@@ -3936,7 +3923,7 @@ msgid "E22: Scripts nested too deep"
 msgstr "E22: Liian monta tasoa skripteissä"
 
 msgid "E23: No alternate file"
-msgstr "E23: Eo vaihtoehtoista tiedostoa"
+msgstr "E23: Ei vaihtoehtoista tiedostoa"
 
 msgid "E24: No such abbreviation"
 msgstr "E24: Lyhennettä ei ole"
@@ -3996,7 +3983,7 @@ msgid "E40: Can't open errorfile %s"
 msgstr "E40: virhetiedostoa %s ei voi avata"
 
 msgid "E41: Out of memory!"
-msgstr "E41: Muisti loppui"
+msgstr "E41: Muisti loppui."
 
 # ;-)
 msgid "E42: No Errors"
@@ -4050,9 +4037,8 @@ msgid "E55: Unmatched %s)"
 msgstr "E55: Pariton %s)"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E59: Invalid character after %s@"
-msgstr "E59: virheellinen merkki kohdan %s@ jälkeen"
+msgstr "E59: Virheellinen merkki kohdan %s@ jälkeen"
 
 #, c-format
 msgid "E60: Too many complex %s{...}s"
@@ -4066,9 +4052,8 @@ msgstr "E61: Sisäkkäistetty %s*"
 msgid "E62: Nested %s%c"
 msgstr "E62: Sisäkkäistetty %s%c"
 
-# TODO: Capitalise first word of message?
 msgid "E63: Invalid use of \\_"
-msgstr "E63: väärinkäytetty \\_"
+msgstr "E63: Väärinkäytetty \\_"
 
 #, c-format
 msgid "E64: %s%c follows nothing"
@@ -4101,9 +4086,8 @@ msgstr "E71: Virheellinen merkki merkinnän %s%% jäljessä"
 msgid "E72: Close error on swap file"
 msgstr "E72: Swap-tiedoston sulkemisvirhe"
 
-# TODO: Capitalise first word of message?
 msgid "E73: Tag stack empty"
-msgstr "E73: tägipino tyhjä"
+msgstr "E73: Tägipino tyhjä"
 
 msgid "E74: Command too complex"
 msgstr "E74: Liian monimutkainen komento"
@@ -4154,8 +4138,7 @@ msgstr "E88: Ensimmäisen puskurin ohi ei voi edetä"
 #, c-format
 msgid "E89: No write since last change for buffer %d (add ! to override)"
 msgstr ""
-"E89: Puskurin %d muutoksia ei ole tallennettu (lisää komentoon ! "
-"ohittaaksesi)"
+"E89: Puskurin %d muutoksia ei ole tallennettu (lisää komentoon ! ohittaaksesi)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Ei voi vapauttaa viimeistä puskuria"
@@ -4327,7 +4310,7 @@ msgstr "E137: Viminfo-tiedostoon ei voitu kirjoittaa: %s"
 
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
-msgstr "E138: Viminfo-tiedoston kirjoittaminen ei onnistu %s"
+msgstr "E138: Viminfo-tiedoston kirjoittaminen ei onnistu %s."
 
 msgid "E139: File is loaded in another buffer"
 msgstr "E139: Tiedosto on ladattu toiseen puskuriin"
@@ -4347,7 +4330,6 @@ msgstr ""
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Autocommand poisti uuden puskurin odotuksen vastaisesti %s"
 
-# TODO: Capitalise first word of message?
 msgid "E144: Non-numeric argument to :z"
 msgstr "E144: :z:n argumentti ei ole numero"
 
@@ -4475,7 +4457,6 @@ msgid "E178: Invalid default value for count"
 msgstr "E178: Lukumäärän oletusarvo on väärä"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E179: Argument required for %s"
 msgstr "E179: %s vaatii argumentin"
 
@@ -4549,8 +4530,7 @@ msgid "E199: Active window or buffer deleted"
 msgstr "E199: Aktiivinen ikkuna tai puskuri poistettu"
 
 msgid "E200: *ReadPre autocommands made the file unreadable"
-msgstr ""
-"E200: *ReadPre-autocommand-komennot tekivät tiedostosta lukukelvottoman"
+msgstr "E200: *ReadPre-autocommand-komennot tekivät tiedostosta lukukelvottoman"
 
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: *ReadPre-autocommand-komennot eivät saa muuttaa puskuria"
@@ -4569,9 +4549,8 @@ msgstr "E204: Autocommand-komento muutti rivien määrä odottamatta"
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Patch-tilassa ei voi tallentaa alkuperäistiedostoa"
 
-# TODO: Capitalise first word of message?
 msgid "E206: Patchmode: can't touch empty original file"
-msgstr "E206: patch-tilassa ei voi muuttaa tyhjää alkuperäistiedostoa"
+msgstr "E206: Patch-tilassa ei voi muuttaa tyhjää alkuperäistiedostoa"
 
 msgid "E207: Can't delete backup file"
 msgstr "E207: Ei voi poistaa varmuuskopiota"
@@ -4596,8 +4575,7 @@ msgid "E212: Can't open file for writing"
 msgstr "E212: Tiedoston avaus kirjoittamista varten ei onnistu"
 
 msgid "E213: Cannot convert (add ! to write without conversion)"
-msgstr ""
-"E213: Muunnos ei onnistu (lisää komentoon ! kirjoittaaksesi muuntamatta)"
+msgstr "E213: Muunnos ei onnistu (lisää komentoon ! kirjoittaaksesi muuntamatta)"
 
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Ei voi löytää väliaikaistiedostoa kirjoitettavaksi"
@@ -4617,9 +4595,8 @@ msgstr "E216: Ryhmää tai eventtiä ei ole: %s"
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Ei voi suorittaa autocommandsia kaikille eventeille"
 
-# TODO: Capitalise first word of message?
 msgid "E218: Autocommand nesting too deep"
-msgstr "E218: liian monta tasoa autocommandissa"
+msgstr "E218: Liian monta tasoa autocommandissa"
 
 msgid "E219: Missing {."
 msgstr "E219: { puuttuu."
@@ -4633,29 +4610,24 @@ msgstr "E221: Merkintä ei voi alkaa pienaakkosella"
 msgid "E222: Add to internal buffer that was already read from"
 msgstr "E222: Lisäys sisäiseen puskuriin josta on jo luettu"
 
-# TODO: Capitalise first word of message?
 msgid "E223: Recursive mapping"
-msgstr "E223: rekursiivinen kuvaus"
+msgstr "E223: Rekursiivinen kuvaus"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E224: Global abbreviation already exists for %s"
-msgstr "E224: globaali lyhenne merkinnälle %s on jo olemassa"
+msgstr "E224: Globaali lyhenne merkinnälle %s on jo olemassa"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E225: Global mapping already exists for %s"
-msgstr "E225: globaali kuvaus merkinnälle %s on jo olemassa"
+msgstr "E225: Globaali kuvaus merkinnälle %s on jo olemassa"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E226: Abbreviation already exists for %s"
-msgstr "E226: lyhenne on jo olemassa %s"
+msgstr "E226: Lyhenne on jo olemassa %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E227: Mapping already exists for %s"
-msgstr "E227: kuvaus on jo olemassa %s"
+msgstr "E227: Kuvaus on jo olemassa %s"
 
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Virheellinen tila"
@@ -4673,9 +4645,8 @@ msgstr "E231: guifontwide virheellinen"
 msgid "E232: Cannot create BalloonEval with both message and callback"
 msgstr "E232: Ei voi luoda BalloonEvalia viestille ja callbackille"
 
-# TODO: Capitalise first word of message?
 msgid "E233: Cannot open display"
-msgstr "E233: näyttöä ei voi avata"
+msgstr "E233: Näyttöä ei voi avata"
 
 #, c-format
 msgid "E234: Unknown fontset: %s"
@@ -4713,7 +4684,7 @@ msgstr "E242: Ei voida halkaista ikkunaa kun toista suljetaan"
 # OLE on object linking and embedding på windowska
 #, c-format
 msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: Argumenttia ei tueta: -%s, käytä OLE-versiota"
+msgstr "E243: Argumenttia ei tueta: -%s, käytä OLE-versiota."
 
 #, c-format
 msgid "E244: Illegal %s name \"%s\" in font name \"%s\""
@@ -4727,23 +4698,21 @@ msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: FileChangedShell-autocommand poisti puskurin"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E247: No registered server named \"%s\""
-msgstr "E247: palvelinta %s ei ole rekisteröitynä"
+msgstr "E247: Palvelinta %s ei ole rekisteröitynä"
 
 msgid "E248: Failed to send command to the destination program"
 msgstr "E248: Komennon lähetys kohdeohjelmalle ei onnistu"
 
-# TODO: Capitalise first word of message?
 msgid "E249: Window layout changed unexpectedly"
-msgstr "E249: ikkunan asettelu vaihtui odottamatta"
+msgstr "E249: Ikkunan asettelu vaihtui odottamatta"
 
 #, c-format
 msgid "E250: Fonts for the following charsets are missing in fontset %s:"
 msgstr "E250: Seuraavien merkistöjoukkojen fontit puuttuvat fontsetistä %s:"
 
 msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-msgstr "E251: VIMin instanssin rekisteriarvo on virheellinen, poistettiin."
+msgstr "E251: VIMin instanssin rekisteriarvo on virheellinen.  Poistettiin."
 
 #, c-format
 msgid "E252: Fontset name: %s - Font '%s' is not fixed-width"
@@ -4760,74 +4729,62 @@ msgstr "E254: Väriä %s ei voi määritellä"
 msgid "E255: Couldn't read in sign data"
 msgstr "E255: Merkkidatan luku ei onnistu"
 
-# TODO: Capitalise first word of message?
 msgid "E257: cstag: Tag not found"
-msgstr "E257: cstag: tägia ei löydy"
+msgstr "E257: cstag: Tägia ei löydy"
 
 msgid "E258: Unable to send to client"
 msgstr "E258: Asiakkaalle lähetys ei onnistunut"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E259: No matches found for cscope query %s of %s"
-msgstr "E259: ei täsmäyksiä cscope-hakuun %s/%s"
+msgstr "E259: Ei täsmäyksiä cscope-hakuun %s/%s"
 
 msgid "E260: Missing name after ->"
 msgstr "E260: Nimi puuttuu perästä ->"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E261: Cscope connection %s not found"
-msgstr "E261: cscope-yhteys %s puuttuu"
+msgstr "E261: Cscope-yhteys %s puuttuu"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E262: Error reading cscope connection %d"
-msgstr "E262: virhe luettaessa cscope-yhteyttä %d"
+msgstr "E262: Virhe luettaessa cscope-yhteyttä %d"
 
 msgid ""
-"E263: Sorry, this command is disabled, the Python library could not be "
-"loaded."
-msgstr "E263: komento ei toimi, Python-kirjaston lataaminen ei onnistunut."
+"E263: Sorry, this command is disabled, the Python library could not be loaded."
+msgstr "E263: Komento ei toimi, Python-kirjaston lataaminen ei onnistunut."
 
 msgid "E264: Python: Error initialising I/O objects"
 msgstr "E264: Python: Virhe IO-olioiden alustuksessa"
 
 msgid "E265: $_ must be an instance of String"
-msgstr "E265: muuttujan $_ pitää olla Stringin instanssi"
+msgstr "E265: Muuttujan $_ pitää olla Stringin instanssi"
 
 msgid ""
 "E266: Sorry, this command is disabled, the Ruby library could not be loaded."
-msgstr "E266: komento ei toimi, Ruby-kirjastoa ei voitu ladata."
+msgstr "E266: Komento ei toimi, Ruby-kirjastoa ei voitu ladata."
 
-# TODO: Capitalise first word of message?
 msgid "E267: Unexpected return"
-msgstr "E267: odotuksenvastainen return"
+msgstr "E267: Odotuksenvastainen return"
 
-# TODO: Capitalise first word of message?
 msgid "E268: Unexpected next"
 msgstr "E268: Odotuksenvastainen next"
 
-# TODO: Capitalise first word of message?
 msgid "E269: Unexpected break"
 msgstr "E269: Odotuksenvastainen break"
 
-# TODO: Capitalise first word of message?
 msgid "E270: Unexpected redo"
-msgstr "E270: odotuksenvastainen redo"
+msgstr "E270: Odotuksenvastainen redo"
 
-# TODO: Capitalise first word of message?
 msgid "E271: Retry outside of rescue clause"
-msgstr "E271: retry rescuen ulkopuolella"
+msgstr "E271: Retry rescuen ulkopuolella"
 
-# TODO: Capitalise first word of message?
 msgid "E272: Unhandled exception"
-msgstr "E272: käsittelemätön poikkeus"
+msgstr "E272: Käsittelemätön poikkeus"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E273: Unknown longjmp status %d"
-msgstr "E273: tuntematon longjmp-tila %d"
+msgstr "E273: Tuntematon longjmp-tila %d"
 
 msgid "E274: No white space allowed before parenthesis"
 msgstr "E274: Tyhjeet ei sallittu sulkeissa"
@@ -4846,11 +4803,10 @@ msgid "E279: Sorry, ++shell is not supported on this system"
 msgstr "E279: ++shell ei toimi tällä järjestelmällä"
 
 msgid ""
-"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
-"org"
+"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim.org"
 msgstr ""
-"E280: kriittinen TCL-virhe: reflist hajalla? Ilmoita asiasta "
-"postituslistalle vim-dev@vim.org"
+"E280: Kriittinen TCL-virhe: reflist hajalla? Ilmoita asiasta postituslistalle "
+"vim-dev@vim.org"
 
 #, c-format
 msgid "E282: Cannot read from \"%s\""
@@ -4870,16 +4826,13 @@ msgid "E286: Failed to open input method"
 msgstr "E286: Syötemetodin avaus ei onnistu"
 
 msgid "E287: Warning: Could not set destroy callback to IM"
-msgstr ""
-"E287: Varoitus: Ei voitu asettaa destroy-kutsua syötemetodipalvelimelle"
+msgstr "E287: Varoitus: Ei voitu asettaa destroy-kutsua syötemetodipalvelimelle"
 
-# TODO: Capitalise first word of message?
 msgid "E288: Input method doesn't support any style"
-msgstr "E288: syötemetodi ei tue tyylejä"
+msgstr "E288: Syötemetodi ei tue tyylejä"
 
-# TODO: Capitalise first word of message?
 msgid "E289: Input method doesn't support my preedit type"
-msgstr "E289: syötemetodi ei tue tätä preedit-tyyppiä"
+msgstr "E289: Syötemetodi ei tue tätä preedit-tyyppiä"
 
 msgid "E290: List or number required"
 msgstr "E290: Lista tai luku tarvitaan"
@@ -4888,9 +4841,8 @@ msgstr "E290: Lista tai luku tarvitaan"
 msgid "E292: Invalid count for del_bytes(): %ld"
 msgstr "E292: Virheellinen lukumäärä funktiolle del_bytes(): %ld"
 
-# TODO: Capitalise first word of message?
 msgid "E293: Block was not locked"
-msgstr "E293: lohkoa ei ole lukittu"
+msgstr "E293: Lohkoa ei ole lukittu"
 
 msgid "E294: Seek error in swap file read"
 msgstr "E294: Hakuvirhe swap-tiedostoa luettaessa"
@@ -4920,7 +4872,7 @@ msgid "E301: Oops, lost the swap file!!!"
 msgstr "E301: Hups, swap-tiedosto hävisi!"
 
 msgid "E302: Could not rename swap file"
-msgstr "E302: Swap-tiedoston uudellennimeys ei onnistu"
+msgstr "E302: Swap-tiedoston uudellennimeäminen ei onnistu"
 
 #, c-format
 msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
@@ -4955,8 +4907,7 @@ msgstr "E310: Lohon 1 tunniste väärä (%s ei ole .swp-tiedosto?)"
 msgid "E311: Recovery Interrupted"
 msgstr "E311: Palautus keskeytetty"
 
-msgid ""
-"E312: Errors detected while recovering; look for lines starting with ???"
+msgid "E312: Errors detected while recovering; look for lines starting with ???"
 msgstr "E312: Palautuksessa oli virheitä, etsi rivejä, jotka alkavat ???"
 
 msgid "E313: Cannot preserve, there is no swap file"
@@ -4966,33 +4917,27 @@ msgid "E314: Preserve failed"
 msgstr "E314: Säilyttäminen epäonnistui"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E315: ml_get: Invalid lnum: %ld"
-msgstr "E315: ml_get: virheellinen lnum: %ld"
+msgstr "E315: ml_get: Virheellinen lnum: %ld"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E316: ml_get: Cannot find line %ld in buffer %d %s"
-msgstr "E316: ml_get: riviä %ld ei löydy puskurist %d %s"
+msgstr "E316: ml_get: Riviä %ld ei löydy puskurista %d %s"
 
-# TODO: Capitalise first word of message?
 msgid "E317: Pointer block id wrong"
-msgstr "E317: osoitinlohkon tunnus väärä"
+msgstr "E317: Osoitinlohkon tunnus väärä"
 
-# TODO: Capitalise first word of message?
 msgid "E317: Pointer block id wrong 2"
-msgstr "E317: osoitinlohon tunnus väärä 2"
+msgstr "E317: Osoitinlohon tunnus väärä 2"
 
-# TODO: Capitalise first word of message?
 msgid "E317: Pointer block id wrong 3"
-msgstr "E317: osoitinlohkon tunnus väärä 3"
+msgstr "E317: Osoitinlohkon tunnus väärä 3"
 
-# TODO: Capitalise first word of message?
 msgid "E317: Pointer block id wrong 4"
-msgstr "E317: osoitinlohkon tunnus väärä 4"
+msgstr "E317: Osoitinlohkon tunnus väärä 4"
 
 msgid "E318: Updated too many blocks?"
-msgstr "E318: Päivitetty liikaa lohkoja"
+msgstr "E318: Päivitetty liikaa lohkoja?"
 
 msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Komento ei ole käytettävissä tässä versiossa"
@@ -5003,17 +4948,15 @@ msgstr "E320: Riviä %ld ei löydy"
 
 #, c-format
 msgid "E321: Could not reload \"%s\""
-msgstr "E321: Ei voitu uudelleenavata %s"
+msgstr "E321: Ei voitu avata uudelleen %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E322: Line number out of range: %ld past the end"
-msgstr "E322: rivinumero arvoalueen ulkopuoleta: %ld on loppua suurempi"
+msgstr "E322: Rivinumero arvoalueen ulkopuolelta: %ld on loppua suurempi"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E323: Line count wrong in block %ld"
-msgstr "E323: rivimäärä väärin lohkossa %ld"
+msgstr "E323: Rivimäärä väärin lohkossa %ld"
 
 msgid "E324: Can't open PostScript output file"
 msgstr "E324: PostScript-tulostetiedoston avaus ei onnistu"
@@ -5061,7 +5004,7 @@ msgid "E337: Menu not found - check menu names"
 msgstr "E337: Valikkoa ei löytynyt - tarkista valikkojen nimet"
 
 msgid "E338: Sorry, no file browser in console mode"
-msgstr "E338: tiedostonselain puuttuu konsolitilasta"
+msgstr "E338: Tiedostonselain puuttuu konsolitilasta"
 
 msgid "E339: Pattern too long"
 msgstr "E339: Liian pitkä kuvio"
@@ -5071,12 +5014,12 @@ msgstr "E341: Sisäinen virhe: lalloc(0, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Muisti loppui! (varattaessa %lu tavua)"
+msgstr "E342: Muisti loppui. (varattaessa %lu tavua)"
 
 #, c-format
 msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
+"E343: Invalid path: '**[number]' must be at the end of the path or be followed "
+"by '%s'."
 msgstr ""
 "E343: Virheellinen polku: '**[numero]' kuuluu polun loppuun tai ennen kohtaa "
 "%s."
@@ -5133,7 +5076,7 @@ msgstr "E357: langmap: Merkkiin %s täsmäävä merkki puuttuu"
 
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
-msgstr "E358: langmap: ylimääräisiä merkkejä puolipisteen jälkeen: %s"
+msgstr "E358: langmap: Ylimääräisiä merkkejä puolipisteen jälkeen: %s"
 
 msgid "E359: Screen mode setting not supported"
 msgstr "E359: Näyttötila-asetus ei tuettu"
@@ -5144,13 +5087,12 @@ msgstr "E360: Kuorta ei voi avata asetuksella -f"
 msgid "E362: Using a boolean value as a Float"
 msgstr "E362: Käytettiin totuusarvoa Floattina"
 
-# TODO: Capitalise first word of message?
 msgid "E363: Pattern uses more memory than 'maxmempattern'"
-msgstr "E363: kuvio käyttää enemmän muistia kuin maxmempattern on"
+msgstr "E363: Kuvio käyttää enemmän muistia kuin maxmempattern on"
 
 #, c-format
 msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Kirjastukutsu %s() epäonnistui"
+msgstr "E364: Kirjastokutsu %s() epäonnistui"
 
 msgid "E365: Failed to print PostScript file"
 msgstr "E365: PostScript-tiedoston tulostus epäonnistui"
@@ -5163,14 +5105,12 @@ msgid "E367: No such group: \"%s\""
 msgstr "E367: Ryhmää ei ole: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E368: Got SIG%s in libcall()"
-msgstr "E368: saatiin SIG%s kutsusta libcall()"
+msgstr "E368: Saatiin SIG%s kutsusta libcall()"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E369: Invalid item in %s%%[]"
-msgstr "E369: virheellinen olio kohdassa %s%%[]"
+msgstr "E369: Virheellinen olio kohdassa %s%%[]"
 
 #, c-format
 msgid "E370: Could not load library %s: %s"
@@ -5188,7 +5128,7 @@ msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Odottamaton %%%c muotoilumerkkijonossa"
 
 msgid "E374: Missing ] in format string"
-msgstr "E374: ] puuttuu muotoilemerkkijonosta"
+msgstr "E374: ] puuttuu muotoilumerkkijonosta"
 
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
@@ -5222,12 +5162,10 @@ msgid "E383: Invalid search string: %s"
 msgstr "E383: Viallinen hakujono: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E384: Search hit TOP without match for: %s"
 msgstr "E384: Haku pääsi alkuun löytämättä jonoa: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E385: Search hit BOTTOM without match for: %s"
 msgstr "E385: Haku pääsi loppuun löytämättä jonoa: %s"
 
@@ -5241,7 +5179,7 @@ msgid "E388: Couldn't find definition"
 msgstr "E388: Määritelmä ei löydy"
 
 msgid "E389: Couldn't find pattern"
-msgstr "E389: kuvio ei löydy"
+msgstr "E389: Kuvio ei löydy"
 
 #, c-format
 msgid "E390: Illegal argument: %s"
@@ -5253,7 +5191,7 @@ msgstr "E391: Syntaksiklusteri puuttuu: %s"
 
 #, c-format
 msgid "E392: No such syntax cluster: %s"
-msgstr "E392: syntaksiklusteria ei ole: %s"
+msgstr "E392: Syntaksiklusteria ei ole: %s"
 
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: group[t]here ei sovi tähän"
@@ -5262,9 +5200,8 @@ msgstr "E393: group[t]here ei sovi tähän"
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Aluetta nimelle %s ei löydy"
 
-# TODO: Capitalise first word of message?
 msgid "E395: Contains argument not accepted here"
-msgstr "E395: contains ei sovi tähän"
+msgstr "E395: Contains ei sovi tähän"
 
 msgid "E397: Filename required"
 msgstr "E397: Tiedostonimi puuttuu"
@@ -5278,19 +5215,18 @@ msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Argumentteja puuttuu: syntaksialue %s"
 
 msgid "E400: No cluster specified"
-msgstr "E400: klusteri määrittelemättä"
+msgstr "E400: Klusteri määrittelemättä"
 
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
-msgstr "E401: Kuvoin erotin puuttuu: %s"
+msgstr "E401: Kuvion erotin puuttuu: %s"
 
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Roskia kuvion jäljessä: %s"
 
-# TODO: Capitalise first word of message?
 msgid "E403: syntax sync: Line continuations pattern specified twice"
-msgstr "E403: syntax sync: rivinjatkamiskuvio määritelty kahdesti"
+msgstr "E403: syntax sync: Rivinjatkamiskuvio määritelty kahdesti"
 
 #, c-format
 msgid "E404: Illegal arguments: %s"
@@ -5318,12 +5254,11 @@ msgstr "E409: Tuntematon ryhmän nimi: %s"
 
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
-msgstr "E410: Virheelluinen :syntax-osakomento: %s"
+msgstr "E410: Virheellinen :syntax-osakomento: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E411: Highlight group not found: %s"
-msgstr "E411: korostusryhmää ei löytynyt: %s"
+msgstr "E411: Korostusryhmää ei löytynyt: %s"
 
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
@@ -5333,24 +5268,20 @@ msgstr "E412: Argumentteja puuttuu: :highlight link %s"
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Liikaa argumentteja: :highlight link %s"
 
-# TODO: Capitalise first word of message?
 msgid "E414: Group has settings, highlight link ignored"
-msgstr "E414: ryhmällä on asetuksia, highlight link -komento ohitetaan"
+msgstr "E414: Ryhmällä on asetuksia, highlight link -komento ohitetaan"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E415: Unexpected equal sign: %s"
-msgstr "E415: odotuksenvastainen =-merkki: %s"
+msgstr "E415: Odotuksenvastainen =-merkki: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E416: Missing equal sign: %s"
-msgstr "E416: puuttuva =-merkki: %s"
+msgstr "E416: Puuttuva =-merkki: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E417: Missing argument: %s"
-msgstr "E417: puuttuva argumentti: %s"
+msgstr "E417: Puuttuva argumentti: %s"
 
 #, c-format
 msgid "E418: Illegal value: %s"
@@ -5367,9 +5298,8 @@ msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Värin nimi tai numero tuntematon: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E422: Terminal code too long: %s"
-msgstr "E422: terminaalikoodi liian pitkä: %s"
+msgstr "E422: Terminaalikoodi liian pitkä: %s"
 
 #, c-format
 msgid "E423: Illegal argument: %s"
@@ -5382,9 +5312,8 @@ msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Ei voida mennä ensimmäistä täsmäävää tägiä alummaksi"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E426: Tag not found: %s"
-msgstr "E426: tägi puuttuu: %s"
+msgstr "E426: Tägi puuttuu: %s"
 
 msgid "E427: There is only one matching tag"
 msgstr "E427: Vain yksi tägi täsmää"
@@ -5402,7 +5331,7 @@ msgstr "E430: Tägitiedoston polku katkaistu kohdassa %s\n"
 
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
-msgstr "E431: Muotovirh tägitiedostossa %s"
+msgstr "E431: Muotovirhe tägitiedostossa %s"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5421,27 +5350,23 @@ msgstr "E435: Tägiä ei löydy, arvataan."
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: %s ei löytynyt termcapista"
 
-# TODO: Capitalise first word of message?
 msgid "E437: Terminal capability \"cm\" required"
-msgstr "E437: terminaalilla pitää olla cm kyvyissään"
+msgstr "E437: Terminaalilla pitää olla cm kyvyissään"
 
-# TODO: Capitalise first word of message?
 msgid "E438: u_undo: Line numbers wrong"
-msgstr "E438: u_undo: väärät rivinumerot"
+msgstr "E438: u_undo: Väärät rivinumerot"
 
-# TODO: Capitalise first word of message?
 msgid "E439: Undo list corrupt"
-msgstr "E439: kumouslista rikki"
+msgstr "E439: Kumouslista rikki"
 
-# TODO: Capitalise first word of message?
 msgid "E440: Undo line missing"
-msgstr "E440: kumousrivi puuttuu"
+msgstr "E440: Kumousrivi puuttuu"
 
 msgid "E441: There is no preview window"
 msgstr "E441: Ei esikatseluikkunaa"
 
 msgid "E442: Can't split topleft and botright at the same time"
-msgstr "E442: Ei voi jakaa vasenta ylänurkkaa ja oikeaa alanurkkaa yhtäaikaa"
+msgstr "E442: Ei voi jakaa vasenta ylänurkkaa ja oikeaa alanurkkaa yhtä aikaa"
 
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Ei voi kiertää kun toinen ikkuna on jaettu"
@@ -5461,28 +5386,26 @@ msgstr "E447: Tiedosto %s ei löydy polulta"
 
 #, c-format
 msgid "E448: Could not load library function %s"
-msgstr "E448: Ei voitu ladta kirjastofunktiota %s"
+msgstr "E448: Ei voitu ladata kirjastofunktiota %s"
 
 msgid "E449: Invalid expression received"
 msgstr "E449: Virheellinen ilmaus saatu"
 
-# TODO: Capitalise first word of message?
 msgid "E450: Buffer number, text or a list required"
-msgstr "E450: puskurinumero, teksti tai lista vaaditaan"
+msgstr "E450: Puskurinumero, teksti tai lista vaaditaan"
 
 #, c-format
 msgid "E451: Expected }: %s"
-msgstr "E451: )-merkki puuttuu: %s"
+msgstr "E451: }-merkki puuttuu: %s"
 
 msgid "E452: Double ; in list of variables"
-msgstr "E452: Kaksi ;:ttä muuttujalistassa"
+msgstr "E452: Kaksi ;:ä muuttujalistassa"
 
 msgid "E453: UL color unknown"
 msgstr "E453: UL-väri tuntematon"
 
-# TODO: Capitalise first word of message?
 msgid "E454: Function list was modified"
-msgstr "E454: funktioluettelo on muuttunut"
+msgstr "E454: Funktioluettelo on muuttunut"
 
 msgid "E455: Error writing to PostScript output file"
 msgstr "E455: Virhe kirjoitettaessa PostScriptiä tiedostoon"
@@ -5493,7 +5416,7 @@ msgstr "E456: Tiedoston %s avaus ei onnistu"
 
 #, c-format
 msgid "E456: Can't find PostScript resource file \"%s.ps\""
-msgstr "E456: Postscript-resurssitiedosta %s.ps ei löydy"
+msgstr "E456: PostScript-resurssitiedosta %s.ps ei löydy"
 
 #, c-format
 msgid "E457: Can't read PostScript resource file \"%s\""
@@ -5505,7 +5428,6 @@ msgstr "E458: Ei voi varata värikartan alkiota, värit voivat mennä väärin"
 msgid "E459: Cannot go back to previous directory"
 msgstr "E459: Ei voi siirtyä edelliseen hakemistoon"
 
-# TODO: Capitalise first word of message?
 msgid "E460: Entries missing in mapset() dict argument"
 msgstr "E460: mapset()-kutsun dict-argumentista puuttuu kenttiä"
 
@@ -5536,9 +5458,8 @@ msgid "E468: Completion argument only allowed for custom completion"
 msgstr "E468: Täydennysargumentti sopii vain itse määriteltyyn täydennykseen"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E469: Invalid cscopequickfix flag %c for %c"
-msgstr "E469: virheellinen cscopequickfix-asetus %c kohteelle %c"
+msgstr "E469: Virheellinen cscopequickfix-asetus %c kohteelle %c"
 
 msgid "E470: Command aborted"
 msgstr "E470: Komento peruttu"
@@ -5585,7 +5506,7 @@ msgstr "E479: Ei täsmää"
 
 #, c-format
 msgid "E480: No match: %s"
-msgstr "E480: Ei tsämää: %s"
+msgstr "E480: Ei täsmää: %s"
 
 msgid "E481: No range allowed"
 msgstr "E481: Arvoalue ei sallittu"
@@ -5595,7 +5516,7 @@ msgid "E482: Can't create file %s"
 msgstr "E482: Tiedostoa %s ei voi luoda"
 
 msgid "E483: Can't get temp file name"
-msgstr "E483: väliaikaistiedoston nimeä ei saada selville"
+msgstr "E483: Väliaikaistiedoston nimeä ei saada selville"
 
 #, c-format
 msgid "E484: Can't open file %s"
@@ -5622,17 +5543,15 @@ msgstr "E488: Ylimääräisiä merkkejä perässä"
 msgid "E488: Trailing characters: %s"
 msgstr "E488: Ylimääräisiä merkkejä perässä: %s"
 
-# TODO: Capitalise first word of message?
 msgid "E489: No call stack to substitute for \"<stack>\""
-msgstr "E489: ei kutsupinokorvausta kohteessa <stack>"
+msgstr "E489: Ei kutsupinokorvausta kohteessa <stack>"
 
 msgid "E490: No fold found"
-msgstr "E490: taitos puuttuu"
+msgstr "E490: Taitos puuttuu"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E491: JSON decode error at '%s'"
-msgstr "E491: json-dekoodaus-virhe kohteessa %s"
+msgstr "E491: JSON-dekoodaus-virhe kohteessa %s"
 
 msgid "E492: Not an editor command"
 msgstr "E492: Ei ole editorikomento"
@@ -5641,23 +5560,19 @@ msgid "E493: Backwards range given"
 msgstr "E493: Takaperoinen arvoalue annettu"
 
 msgid "E494: Use w or w>>"
-msgstr "E494: Käytä w:tä tai w>>:aa"
+msgstr "E494: Käytä w:tä tai w>>:ä"
 
-# TODO: Capitalise first word of message?
 msgid "E495: No autocommand file name to substitute for \"<afile>\""
-msgstr "E495: ei autocommand-tiedostoa kohteelle <afile>"
+msgstr "E495: Ei autocommand-tiedostoa kohteelle <afile>"
 
-# TODO: Capitalise first word of message?
 msgid "E496: No autocommand buffer number to substitute for \"<abuf>\""
-msgstr "E496: ei autocommand-puskurinumeroa kohteelle <abuf>"
+msgstr "E496: Ei autocommand-puskurinumeroa kohteelle <abuf>"
 
-# TODO: Capitalise first word of message?
 msgid "E497: No autocommand match name to substitute for \"<amatch>\""
-msgstr "E497: ei autocommand-täsmäysnimeä kohteella <amatch>"
+msgstr "E497: Ei autocommand-täsmäysnimeä kohteella <amatch>"
 
-# TODO: Capitalise first word of message?
 msgid "E498: No :source file name to substitute for \"<sfile>\""
-msgstr "E498: ei :source-tiedostonimeä kohteelle <sfile>"
+msgstr "E498: Ei :source-tiedostonimeä kohteelle <sfile>"
 
 #, no-c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
@@ -5688,8 +5603,7 @@ msgstr "E505: %s on kirjoitussuojattu (lisää komentoon ! ohittaaksesi)"
 
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr ""
-"E506: Ei voi kirjoittaa varmuuskopiotiedostoon (lisää komentoon ! "
-"ohittaaksesi)"
+"E506: Ei voi kirjoittaa varmuuskopiotiedostoon (lisää komentoon ! ohittaaksesi)"
 
 msgid "E507: Close error for backup file (add ! to write anyway)"
 msgstr ""
@@ -5708,28 +5622,24 @@ msgid "E510: Can't make backup file (add ! to write anyway)"
 msgstr ""
 "E510: Ei voi tehdä varmuuskopiotiedostoa (lisää komentoon ! ohittaaksesi)"
 
-# TODO: Capitalise first word of message?
 msgid "E511: NetBeans already connected"
-msgstr "E511: netbeans on yhdistetty jo"
+msgstr "E511: NetBeans on jo yhdistetty"
 
 msgid "E512: Close failed"
 msgstr "E512: Sulkeminen ei onnistunut"
 
-# TODO: Capitalise first word of message?
 msgid "E513: Write error, conversion failed (make 'fenc' empty to override)"
-msgstr "E513: kirjoitusvirhe, muunnos epäonnistui (tyhjää fenc ohittaaksesi)"
+msgstr "E513: Kirjoitusvirhe, muunnos epäonnistui (tyhjää fenc ohittaaksesi)"
 
 #, c-format
 msgid ""
 "E513: write error, conversion failed in line %ld (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: kirjoitusvirhe, muunnos epäonnistui rivillä %ld(tyhjää fenc "
-"ohittaaksesi)"
+"E513: Kirjoitusvirhe, muunnos epäonnistui rivillä %ld(tyhjää fenc ohittaaksesi)"
 
-# TODO: Capitalise first word of message?
 msgid "E514: Write error (file system full?)"
-msgstr "E514: kirjoitusvirhe (tiedostojärjestelmä täysi)"
+msgstr "E514: Kirjoitusvirhe (tiedostojärjestelmä täysi?)"
 
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Puskureita ei vapautettu"
@@ -5747,7 +5657,7 @@ msgid "E519: Option not supported"
 msgstr "E519: Asetusta ei tueta"
 
 msgid "E520: Not allowed in a modeline"
-msgstr "E520: Ei sallitu modeline-rivillä"
+msgstr "E520: Ei sallittu modeline-rivillä"
 
 msgid "E521: Number required after ="
 msgstr "E521: =:n jälkeen tarvitaan luku"
@@ -5787,11 +5697,9 @@ msgstr "E530: Ei voi vaihtaa termiä GUIssa"
 msgid "E531: Use \":gui\" to start the GUI"
 msgstr "E531: Käytä komentoa :gui GUIn käynnistämiseen"
 
-# TODO: Capitalise first word of message?
 msgid "E532: Highlighting color name too long in defineAnnoType"
-msgstr "E532: korostusvärin nimi on liian pitkä defineAnnoTypessä"
+msgstr "E532: Korostusvärin nimi on liian pitkä defineAnnoTypessä"
 
-# TODO: Capitalise first word of message?
 msgid "E533: Can't select wide font"
 msgstr "E533: Leveän fontin valinta ei onnistu"
 
@@ -5802,9 +5710,8 @@ msgstr "E534: Viallinen leveä fontti"
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Virheellinen merkki merkin <%c> jälkeen"
 
-# TODO: Capitalise first word of message?
 msgid "E536: Comma required"
-msgstr "E536: pilkku puuttuu"
+msgstr "E536: Pilkku puuttuu"
 
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
@@ -5817,9 +5724,8 @@ msgstr "E539: Virheellinen merkki <%s>"
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Sulkematon lausekesarja"
 
-# TODO: Capitalise first word of message?
 msgid "E542: Unbalanced groups"
-msgstr "E542: epätasapainoisia ryhmiä"
+msgstr "E542: Epätasapainoisia ryhmiä"
 
 msgid "E543: Not a valid codepage"
 msgstr "E543: Koodisivu ei ole käypä"
@@ -5836,22 +5742,20 @@ msgstr "E546: Virheellinen tila"
 msgid "E547: Illegal mouseshape"
 msgstr "E547: Virheellinen hiiren muoto"
 
-# TODO: Capitalise first word of message?
 msgid "E548: Digit expected"
-msgstr "E548: pitää olla numero"
+msgstr "E548: Pitää olla numero"
 
 msgid "E549: Illegal percentage"
 msgstr "E549: Virheellinen prosenttiluku"
 
 msgid "E550: Missing colon"
-msgstr "E550: kaksoispiste puuttuu"
+msgstr "E550: Kaksoispiste puuttuu"
 
 msgid "E551: Illegal component"
 msgstr "E551: Virheellinen komponentti"
 
-# TODO: Capitalise first word of message?
 msgid "E552: Digit expected"
-msgstr "E552: pitäisi olla numero"
+msgstr "E552: Pitää olla numero"
 
 msgid "E553: No more items"
 msgstr "E553: Ei enää kohteita"
@@ -5860,13 +5764,11 @@ msgstr "E553: Ei enää kohteita"
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Syntaksivirhe ilmauksessa %s{...}"
 
-# TODO: Capitalise first word of message?
 msgid "E555: At bottom of tag stack"
-msgstr "E555: tägipinon pohja"
+msgstr "E555: Tägipinon pohja"
 
-# TODO: Capitalise first word of message?
 msgid "E556: At top of tag stack"
-msgstr "E556: tägipinon huippu"
+msgstr "E556: Tägipinon huippu"
 
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Ei voi avata termcap-tiedostoa"
@@ -5881,9 +5783,8 @@ msgstr "E559: Terminaalia ei löytynyt termcapista"
 msgid "E560: Usage: cs[cope] %s"
 msgstr "E560: Käyttö: cs[cope] %s"
 
-# TODO: Capitalise first word of message?
 msgid "E561: Unknown cscope search type"
-msgstr "E561: tuntematon cscope-hakutyyppi"
+msgstr "E561: Tuntematon cscope-hakutyyppi"
 
 msgid "E562: Usage: cstag <ident>"
 msgstr "E562: Käyttö: cstag <ident>"
@@ -5897,31 +5798,27 @@ msgid "E564: %s is not a directory or a valid cscope database"
 msgstr "E564: %s ei ole hakemisto eikä cscope-tietokanta"
 
 msgid "E565: Not allowed to change text or change window"
-msgstr "E565: ei voi vaihtaa tekstiä tai ikkunaa"
+msgstr "E565: Ei voi vaihtaa tekstiä tai ikkunaa"
 
 msgid "E566: Could not create cscope pipes"
 msgstr "E566: Ei voitu luoda cscope-putkia"
 
-# TODO: Capitalise first word of message?
 msgid "E567: No cscope connections"
-msgstr "E567: ei cscope-yhteyksiä"
+msgstr "E567: Ei cscope-yhteyksiä"
 
-# TODO: Capitalise first word of message?
 msgid "E568: Duplicate cscope database not added"
-msgstr "E568: kaksoiskappaletta cscope-tietokannasta ei lisätty"
+msgstr "E568: Kaksoiskappaletta cscope-tietokannasta ei lisätty"
 
-# TODO: Capitalise first word of message?
 msgid "E570: Fatal error in cs_manage_matches"
-msgstr "E570: kriittinen virhe cs_manage_matches-funktiossa"
+msgstr "E570: Kriittinen virhe cs_manage_matches-funktiossa"
 
 msgid ""
 "E571: Sorry, this command is disabled: the Tcl library could not be loaded."
-msgstr "E571: komento ei toimi, Tcl-kirjastoa ei voitu ladata."
+msgstr "E571: Komento ei toimi, Tcl-kirjastoa ei voitu ladata."
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E572: Exit code %d"
-msgstr "E572: palautusarvo %d"
+msgstr "E572: Palautusarvo %d"
 
 #, c-format
 msgid "E573: Invalid server id used: %s"
@@ -5943,13 +5840,11 @@ msgstr "Virheellinen rekisterin nimi"
 msgid "E578: Not allowed to change text here"
 msgstr "E578: Ei voi vaihtaa tekstiä täällä"
 
-# TODO: Capitalise first word of message?
 msgid "E579: :if nesting too deep"
-msgstr "E579: liian monta kerrosta :if-komennossa"
+msgstr "E579: Liian monta kerrosta :if-komennossa"
 
-# TODO: Capitalise first word of message?
 msgid "E579: Block nesting too deep"
-msgstr "E579: liian monta kerrosta"
+msgstr "E579: Liian monta kerrosta"
 
 msgid "E580: :endif without :if"
 msgstr "E580: :endif ilman komentoa :if"
@@ -5960,7 +5855,6 @@ msgstr "E581: :else ilman komentoa :if"
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif ilman komentoa :if"
 
-# TODO: Capitalise first word of message?
 msgid "E583: Multiple :else"
 msgstr "E583: :else monta kertaa"
 
@@ -5968,7 +5862,7 @@ msgid "E584: :elseif after :else"
 msgstr "E584: :elseif komennon :else jälkeen"
 
 msgid "E585: :while/:for nesting too deep"
-msgstr "E585: liian monta tasoa :while- tai :for-komennoissa"
+msgstr "E585: Liian monta tasoa :while- tai :for-komennoissa"
 
 msgid "E586: :continue without :while or :for"
 msgstr "E586: :continue ilman komentoa :while tai :for"
@@ -6008,7 +5902,6 @@ msgstr "E595: showbreak sisältää tulostumattomia tai leveitä merkkejä"
 msgid "E596: Invalid font(s)"
 msgstr "E596: Viallisia fontteja"
 
-# TODO: Capitalise first word of message?
 msgid "E597: Can't select fontset"
 msgstr "E597: Fontsetin valinta ei onnistu"
 
@@ -6040,7 +5933,6 @@ msgstr "E605: Kiinniottamaton poikkeus: %s"
 msgid "E606: :finally without :try"
 msgstr "E606: :finally ilman komentoa :try"
 
-# TODO: Capitalise first word of message?
 msgid "E607: Multiple :finally"
 msgstr "E607: :finally monta kertaa"
 
@@ -6052,7 +5944,7 @@ msgid "E609: Cscope error: %s"
 msgstr "E609: Cscope-virhe: %s"
 
 msgid "E610: No argument to delete"
-msgstr "E610: ei poistettavia argumenttejä"
+msgstr "E610: Ei poistettavia argumenttejä"
 
 msgid "E611: Using a Special as a Number"
 msgstr "E611: Special ei käy Numberista"
@@ -6078,14 +5970,12 @@ msgid "E617: Cannot be changed in the GTK GUI"
 msgstr "E617: Ei voi muuttaa GTK-GUIssa"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E618: File \"%s\" is not a PostScript resource file"
-msgstr "E618: tiedosto %s ei ole PostScript-resurssitiedosto"
+msgstr "E618: Tiedosto %s ei ole PostScript-resurssitiedosto"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E619: File \"%s\" is not a supported PostScript resource file"
-msgstr "E619: tiedosto %s ei ole tuettu PostScript-resurssitiedosto"
+msgstr "E619: Tiedosto %s ei ole tuettu PostScript-resurssitiedosto"
 
 #, c-format
 msgid "E620: Unable to convert to print encoding \"%s\""
@@ -6106,28 +5996,23 @@ msgid "E624: Can't open file \"%s\""
 msgstr "E624: Ei voi avata tiedostoa %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E625: Cannot open cscope database: %s"
-msgstr "E625: ei voi avata cscope-tietokantaa: %s"
+msgstr "E625: Ei voi avata cscope-tietokantaa: %s"
 
-# TODO: Capitalise first word of message?
 msgid "E626: Cannot get cscope database information"
-msgstr "E626: ei voi hakea cscope-tietokannan tietoja"
+msgstr "E626: Ei voi hakea cscope-tietokannan tietoja"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E630: %s(): Write while not connected"
-msgstr "E630: %s(): ei voi kirjoittaa ilman yhteyttä"
+msgstr "E630: %s(): Ei voi kirjoittaa ilman yhteyttä"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E631: %s(): Write failed"
-msgstr "E631: %s(): kirjoitus epäonnistui"
+msgstr "E631: %s(): Kirjoitus epäonnistui"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E654: Missing delimiter after search pattern: %s"
-msgstr "E654: erotin puuttuu hakuilmauksen perästä: %s"
+msgstr "E654: Erotin puuttuu hakuilmauksen perästä: %s"
 
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Liikaa symbolisia linkkejä (mahdollinen sykli)"
@@ -6147,7 +6032,7 @@ msgstr "E659: Pythonia ei voi kutsua rekursiivisesti"
 
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
-msgstr "E661: ei löydy %s-ohjetta kohteelle %s"
+msgstr "E661: Ei löydy %s-ohjetta kohteelle %s"
 
 msgid "E662: At start of changelist"
 msgstr "E662: Muutoslistan alussa"
@@ -6155,17 +6040,15 @@ msgstr "E662: Muutoslistan alussa"
 msgid "E663: At end of changelist"
 msgstr "E663: Muutoslistan lopussa"
 
-# TODO: Capitalise first word of message?
 msgid "E664: Changelist is empty"
-msgstr "E664: muutoslista on tyhjä"
+msgstr "E664: Muutoslista on tyhjä"
 
 msgid "E665: Cannot start GUI, no valid font found"
 msgstr "E665: Ei voi avata GUIta, sopivaa fonttia ei löydy"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E666: Compiler not supported: %s"
-msgstr "E666: kääntäjää ei tueta: %s"
+msgstr "E666: Kääntäjää ei tueta: %s"
 
 msgid "E667: Fsync failed"
 msgstr "E667: Fsync ei onnistunut"
@@ -6190,13 +6073,13 @@ msgid "E672: Unable to open window inside MDI application"
 msgstr "E672: Ikkunaa ei voitu avata MDI-sovellukseen"
 
 msgid "E673: Incompatible multi-byte encoding and character set"
-msgstr "E673: Tukematon monitvauinen merkistökoodaus ja merkistö"
+msgstr "E673: Tukematon monitavuinen merkistökoodaus ja merkistö"
 
 msgid "E674: printmbcharset cannot be empty with multi-byte encoding."
 msgstr "E674: printmbcharset ei voi olla tyhjä monitavuiselle koodaukselle."
 
 msgid "E675: No default font specified for multi-byte printing."
-msgstr "E675: Ei oletusfonttia monitavuiseen tulostukseen"
+msgstr "E675: Ei oletusfonttia monitavuiseen tulostukseen."
 
 msgid "E676: No matching autocommands for acwrite buffer"
 msgstr "E676: Ei autocommand-komentoa acwrite-puskurille"
@@ -6208,9 +6091,8 @@ msgstr "E677: Väliaikaistiedostoon kirjoittaminen ei onnistunut"
 msgid "E678: Invalid character after %s%%[dxouU]"
 msgstr "E678: Virheellinen merkki merkinnän %s%%[dxouU] jäljessä"
 
-# TODO: Capitalise first word of message?
 msgid "E679: Recursive loop loading syncolor.vim"
-msgstr "E679: rekursiivinen silmukka syncolor.vimissä"
+msgstr "E679: Rekursiivinen silmukka syncolor.vimissä"
 
 #, c-format
 msgid "E680: <buffer=%d>: invalid buffer number"
@@ -6226,7 +6108,6 @@ msgid "E683: File name missing or invalid pattern"
 msgstr "E683: Tiedostonimi puuttuu tai kuvio on viallinen"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E684: List index out of range: %ld"
 msgstr "E684: Indeksi %ld luettelon rajojen ulkopuolella"
 
@@ -6270,9 +6151,8 @@ msgstr "E696: Listasta puuttuu pilkku: %s"
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: Listan lopusta puuttuu ]: %s"
 
-# TODO: Capitalise first word of message?
 msgid "E698: Variable nested too deep for making a copy"
-msgstr "E698: muuttuja on upotettu liian syvälle kopioitavaksi"
+msgstr "E698: Muuttuja on upotettu liian syvälle kopioitavaksi"
 
 msgid "E699: Too many arguments"
 msgstr "E699: Liikaa argumentteja"
@@ -6357,9 +6237,8 @@ msgstr "E722: Sanakirjasta puuttuu pilkku: %s"
 msgid "E723: Missing end of Dictionary '}': %s"
 msgstr "E723: Sanakirjan lopusta puuttuu }: %s"
 
-# TODO: Capitalise first word of message?
 msgid "E724: Variable nested too deep for displaying"
-msgstr "E724: muuttuja on upotettu liian syvälle näytettäväksi"
+msgstr "E724: Muuttuja on upotettu liian syvälle näytettäväksi"
 
 #, c-format
 msgid "E725: Calling dict function without Dictionary: %s"
@@ -6409,7 +6288,7 @@ msgstr "E738: Kohteen %s muuttujia ei voi listata"
 
 #, c-format
 msgid "E739: Cannot create directory: %s"
-msgstr "E739: hakemistoa ei voi luoda: %s"
+msgstr "E739: Hakemistoa ei voi luoda: %s"
 
 #, c-format
 msgid "E740: Too many arguments for function %s"
@@ -6429,9 +6308,8 @@ msgstr "E742: Ei voi muuttaa"
 msgid "E742: Cannot change value of %s"
 msgstr "E742: Ei voi muuttaa muuttujan %s arvoa"
 
-# TODO: Capitalise first word of message?
 msgid "E743: Variable nested too deep for (un)lock"
-msgstr "E743: muuttujassa liian monta tasoa lukituksen käsittelyyn"
+msgstr "E743: Muuttujassa liian monta tasoa lukituksen käsittelyyn"
 
 msgid "E744: NetBeans does not allow changes in read-only files"
 msgstr "E744: NetBeans ei tue muutoksia kirjoitussuojattuihin tiedostoihin"
@@ -6451,9 +6329,8 @@ msgstr ""
 msgid "E748: No previously used register"
 msgstr "E748: Ei aiemmin käytettyjä rekisterejä"
 
-# TODO: Capitalise first word of message?
 msgid "E749: Empty buffer"
-msgstr "E749: tyhjä puskuri"
+msgstr "E749: Tyhjä puskuri"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Aloita käskyllä :profile start {fname}"
@@ -6493,7 +6370,7 @@ msgid "E760: No word count in %s"
 msgstr "E760: Ei sanalaskuria kohteessa %s"
 
 msgid "E761: Format error in affix file FOL, LOW or UPP"
-msgstr "E761: Affiksitiedoston FOL-, LOW- tai UPP-muotovirhe "
+msgstr "E761: Affiksitiedoston FOL-, LOW- tai UPP-muotovirhe"
 
 msgid "E762: Character in FOL, LOW or UPP is out of range"
 msgstr "E762: Merkki FOL:ssä, LOW:ssä tai UPP:ssä ei kuulu arvoalueeseen"
@@ -6565,13 +6442,11 @@ msgid "E781: .sug file doesn't match .spl file: %s"
 msgstr "E781: .sug-tiedosto ei täsmää .spl-tiedostoon: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E782: Error while reading .sug file: %s"
-msgstr "E782: virhe luettaessa .sug-tiedostoa: %s"
+msgstr "E782: Virhe luettaessa .sug-tiedostoa: %s"
 
-# TODO: Capitalise first word of message?
 msgid "E783: Duplicate char in MAP entry"
-msgstr "E783: kaksoiskappale merkistä MAP-kohdassa"
+msgstr "E783: Kaksoiskappale merkistä MAP-kohdassa"
 
 msgid "E784: Cannot close last tab page"
 msgstr "E784: Viimeistä välilehteä ei voi sulkea"
@@ -6599,7 +6474,7 @@ msgid "E791: Empty keymap entry"
 msgstr "E791: Tyhjä keymap-kenttä"
 
 msgid "E792: Empty menu name"
-msgstr "E792: tyhjä valikkonimi"
+msgstr "E792: Tyhjä valikkonimi"
 
 msgid "E793: No other buffer in diff mode is modifiable"
 msgstr "E793: Yksikään muu diff-tilan puskurit ei ole muokattavissa"
@@ -6641,7 +6516,7 @@ msgstr "E801: ID jo käytössä: %d"
 
 #, c-format
 msgid "E802: Invalid ID: %d (must be greater than or equal to 1)"
-msgstr "E802: Käyttöklvoton ID: %d (pitää olla vähintään 1)"
+msgstr "E802: Käyttökelvoton ID: %d (pitää olla vähintään 1)"
 
 #, c-format
 msgid "E803: ID not found: %d"
@@ -6654,7 +6529,6 @@ msgstr "E804: Ei voi käyttää '%':a Floatin kanssa"
 msgid "E805: Using a Float as a Number"
 msgstr "E805: Float ei käy Numberista"
 
-# TODO: Capitalise first word of message?
 msgid "E806: Using a Float as a String"
 msgstr "E806: Float ei käy merkkijonosta"
 
@@ -6677,7 +6551,7 @@ msgid "E812: Autocommands changed buffer or buffer name"
 msgstr "E812: Autocommands muutti puskurin tai sen nimen"
 
 msgid "E813: Cannot close autocmd or popup window"
-msgstr "E813: Ei voi sulkea autocmd- tai ponnahsdusikkunaa"
+msgstr "E813: Ei voi sulkea autocmd- tai ponnahdusikkunaa"
 
 msgid "E814: Cannot close window, only autocmd window would remain"
 msgstr "E814: Ei voi sulkea viimeistä ikkunaa, joka ei ole autocmd-ikkuna"
@@ -6694,7 +6568,7 @@ msgid "E817: Blowfish big/little endian use wrong"
 msgstr "E817: Blowfishin tavujärjestys väärä"
 
 msgid "E818: sha256 test failed"
-msgstr "E818: sha256-testi epäonnistui failed"
+msgstr "E818: sha256-testi epäonnistui"
 
 msgid "E819: Blowfish test failed"
 msgstr "E819: Blowfish-testi epäonnistui"
@@ -6719,7 +6593,7 @@ msgstr "E824: Epäyhteensopiva kumoustiedosto: %s"
 
 #, c-format
 msgid "E825: Corrupted undo file (%s): %s"
-msgstr "E825: Pilaanntunut kumoustiedosto (%s): %s"
+msgstr "E825: Pilaantunut kumoustiedosto (%s): %s"
 
 #, c-format
 msgid "E826: Undo file decryption failed: %s"
@@ -6734,7 +6608,6 @@ msgid "E828: Cannot open undo file for writing: %s"
 msgstr "E828: Kumoustiedoston avaus kirjoittamista varten ei onnistu: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E829: Write error in undo file: %s"
 msgstr "E829: Kirjoitusvirhe kumoustiedostossa: %s"
 
@@ -6750,8 +6623,7 @@ msgid "E832: Non-encrypted file has encrypted undo file: %s"
 msgstr "E832: Salaamattomalla tiedostolla on salattu kumoustiedosto: %s"
 
 #, c-format
-msgid ""
-"E833: %s is encrypted and this version of Vim does not support encryption"
+msgid "E833: %s is encrypted and this version of Vim does not support encryption"
 msgstr "E833: %s on salattu eikä tämä Vim tue salausta"
 
 msgid "E834: Conflicts with value of 'listchars'"
@@ -6766,9 +6638,8 @@ msgstr "E836: Python: Ei voi käyttää komentoja :py ja :py3 samassa istunnossa
 msgid "E837: This Vim cannot execute :py3 after using :python"
 msgstr "E837: Python: Ei voi käyttää komentoja :py ja :py3 samassa istunnossa"
 
-# TODO: Capitalise first word of message?
 msgid "E838: NetBeans is not supported with this GUI"
-msgstr "E838: netbeans ei toimi tässä käyttöliittymässä"
+msgstr "E838: NetBeans ei toimi tässä käyttöliittymässä"
 
 msgid "E840: Completion function deleted text"
 msgstr "E840: Täydennys poisti tekstiä"
@@ -6776,14 +6647,12 @@ msgstr "E840: Täydennys poisti tekstiä"
 msgid "E841: Reserved name, cannot be used for user defined command"
 msgstr "E841: Varattua nimeä ei voi käyttää käyttäjän määrittelemänä komentona"
 
-# TODO: Capitalise first word of message?
 msgid "E842: No line number to use for \"<slnum>\""
-msgstr "E842: ei rivinumeroa kohteelle <slnum>"
+msgstr "E842: Ei rivinumeroa kohteelle <slnum>"
 
 msgid "E843: Error while updating swap file crypt"
 msgstr "E843: Virhe päivitettäessä swapin kryptausta"
 
-# TODO: Capitalise first word of message?
 msgid "E844: Invalid cchar value"
 msgstr "E844: Virheellinen cchar-arvo"
 
@@ -6815,9 +6684,8 @@ msgstr "E852: Lapsiprosesi ei voinut käynnistää käyttöliittymää"
 msgid "E853: Duplicate argument name: %s"
 msgstr "E853: Kaksoiskappale argumentin nimestä: %s"
 
-# TODO: Capitalise first word of message?
 msgid "E854: Path too long for completion"
-msgstr "E854: polku on liian pitkä täydennykseen"
+msgstr "E854: Polku on liian pitkä täydennykseen"
 
 msgid "E855: Autocommands caused command to abort"
 msgstr "E855: Autocommands lopetti komennon"
@@ -6837,10 +6705,10 @@ msgid "E858: Eval did not return a valid python object"
 msgstr "E858: Eval ei palauttanut python-oliota"
 
 msgid "E859: Failed to convert returned python object to a Vim value"
-msgstr "E859: Ei voitu konvertoida python-oliota vim-arvoksi"
+msgstr "E859: Ei voitu muuntaa python-oliota vim-arvoksi"
 
 msgid "E860: Need 'id' and 'type' with 'both'"
-msgstr "E860: tarvitaan id ja type parametrillä both"
+msgstr "E860: Tarvitaan id ja type parametrilla both"
 
 msgid "E861: Cannot open a second popup with a terminal"
 msgstr "E861: Ei voi avata toista ponnahdusta terminaaliin"
@@ -6856,8 +6724,8 @@ msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
 "used"
 msgstr ""
-"E864: \\%#=-merkkien perään voi tulla vain 0, 1 tai 2. Käytetään "
-"automaattista masiinaa"
+"E864: \\%#=-merkkien perään voi tulla vain 0, 1 tai 2. Käytetään automaattista "
+"masiinaa"
 
 msgid "E865: (NFA) Regexp end encountered prematurely"
 msgstr "E865: (NFA) Säännöllisen ilmauksen ennenaikainen loppu"
@@ -6875,7 +6743,7 @@ msgid "E867: (NFA regexp) Unknown operator '\\%%%c'"
 msgstr "E867: (NFA-regexp) Tuntematon operaattori '\\%%%c'"
 
 msgid "E868: Error building NFA with equivalence class!"
-msgstr "E868: Virhe NFA:n ekvivalenssiluokkia tekemisessä"
+msgstr "E868: Virhe NFA:n ekvivalenssiluokkia tekemisessä."
 
 #, c-format
 msgid "E869: (NFA regexp) Unknown operator '\\@%c'"
@@ -6891,17 +6759,17 @@ msgid "E872: (NFA regexp) Too many '('"
 msgstr "E872: (NFA regexp) Liian monta suljetta '('"
 
 msgid "E873: (NFA regexp) proper termination error"
-msgstr "E873: (NFA regexp) oikea lopetusvirhe"
+msgstr "E873: (NFA regexp) Oikea lopetusvirhe"
 
 msgid "E874: (NFA regexp) Could not pop the stack!"
-msgstr "E874: (NFA-regexp) Ei voida poistaa pinosta"
+msgstr "E874: (NFA-regexp) Ei voida poistaa pinosta."
 
 msgid ""
 "E875: (NFA regexp) (While converting from postfix to NFA), too many states "
 "left on stack"
 msgstr ""
-"E875: (NFA regexp) (Muunnettaessa postfixistä NFA:ksi), liikaa tiloja "
-"jäljellä pinossa"
+"E875: (NFA regexp) (Muunnettaessa postfixistä NFA:ksi), liikaa tiloja jäljellä "
+"pinossa"
 
 msgid "E876: (NFA regexp) Not enough space to store the whole NFA"
 msgstr "E876: (NFA regexp) Tila ei riitä NFA:n tallentamiseen"
@@ -6911,7 +6779,7 @@ msgid "E877: (NFA regexp) Invalid character class: %d"
 msgstr "E877: (NFA regexp) Virheellinen merkkiluokka: %d"
 
 msgid "E878: (NFA regexp) Could not allocate memory for branch traversal!"
-msgstr "E878: (NFA-regexp) Ei voitu allokoida muistia polkujen läpikäyntiin"
+msgstr "E878: (NFA-regexp) Ei voitu allokoida muistia polkujen läpikäyntiin."
 
 msgid "E879: (NFA regexp) Too many \\z("
 msgstr "E879: (NFA regexp) Liikaa merkkejä \\z("
@@ -6926,11 +6794,9 @@ msgid "E882: Uniq compare function failed"
 msgstr "E882: Uniqin vertausfunktio ei onnistunut"
 
 msgid ""
-"E883: search pattern and expression register may not contain two or more "
-"lines"
+"E883: search pattern and expression register may not contain two or more lines"
 msgstr ""
-"E883: hakulauseke- ja -ilmausrekisteri ei voi sisältää kahta tai useampaa "
-"riviä"
+"E883: hakulauseke- ja -ilmausrekisteri ei voi sisältää kahta tai useampaa riviä"
 
 #, c-format
 msgid "E884: Function name cannot contain a colon: %s"
@@ -6942,7 +6808,7 @@ msgstr "E885: Ei voida muuttaa merkkiä %s"
 
 #, c-format
 msgid "E886: Can't rename viminfo file to %s!"
-msgstr "E886: Viminfo-tiedostoa ei voit uudelleennimetä nimelle %s"
+msgstr "E886: Viminfo-tiedostoa ei voi nimetä uudelleen nimelle %s."
 
 msgid ""
 "E887: Sorry, this command is disabled, the Python's site module could not be "
@@ -6958,7 +6824,6 @@ msgid "E889: Number required"
 msgstr "E889: Number vaaditaan"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E890: Trailing char after ']': %s]%s"
 msgstr "E890: Ylimääräisiä merkkejä merkin ] perässä: %s]%s"
 
@@ -6975,8 +6840,8 @@ msgid "E894: Using a Dictionary as a Float"
 msgstr "E894: Sanakirja ei käy Floatista"
 
 msgid ""
-"E895: Sorry, this command is disabled, the MzScheme's racket/base module "
-"could not be loaded."
+"E895: Sorry, this command is disabled, the MzScheme's racket/base module could "
+"not be loaded."
 msgstr "E895: Komento ei toimi, MzScheme-moduulia racket/base ei voitu ladata."
 
 # datarakenteita
@@ -7007,37 +6872,31 @@ msgstr "E901: gethostbyname() funktiossa channel_open()"
 msgid "E902: Cannot connect to port"
 msgstr "E902: Ei voi yhdistää porttiin"
 
-# TODO: Capitalise first word of message?
 msgid "E903: Received command with non-string argument"
-msgstr "E903: komennolla ei-merkkijonoargumentti"
+msgstr "E903: Komennolla ei-merkkijonoargumentti"
 
-# TODO: Capitalise first word of message?
 msgid "E904: Last argument for expr/call must be a number"
-msgstr "E904: viimeisen expr/call-argumentin pitää olla numero"
+msgstr "E904: Viimeisen expr/call-argumentin pitää olla numero"
 
-# TODO: Capitalise first word of message?
 msgid "E904: Third argument for call must be a list"
-msgstr "E904: kolmannen argumentin pitää olla lista"
+msgstr "E904: Kolmannen argumentin pitää olla lista"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E905: Received unknown command: %s"
-msgstr "E905: tuntematon komento: %s"
+msgstr "E905: Tuntematon komento: %s"
 
-# TODO: Capitalise first word of message?
 msgid "E906: Not an open channel"
-msgstr "E906: ei ole avoin kanava"
+msgstr "E906: Ei ole avoin kanava"
 
 msgid "E907: Using a special value as a Float"
 msgstr "E907: Käytettiin erikoisarvoa Floattina"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E908: Using an invalid value as a String: %s"
-msgstr "E908: huono arvo merkkijonolle: %s"
+msgstr "E908: Huono arvo merkkijonolle: %s"
 
 msgid "E909: Cannot index a special variable"
-msgstr "E909: erikoismuuttujaa ei voi indeksoida"
+msgstr "E909: Erikoismuuttujaa ei voi indeksoida"
 
 msgid "E910: Using a Job as a Number"
 msgstr "E910: Job ei käy Numberista"
@@ -7045,10 +6904,9 @@ msgstr "E910: Job ei käy Numberista"
 msgid "E911: Using a Job as a Float"
 msgstr "E911: Job ei käy Floatista"
 
-# TODO: Capitalise first word of message?
 msgid "E912: Cannot use ch_evalexpr()/ch_sendexpr() with a raw or nl channel"
 msgstr ""
-"E912: ei voida käyttää funktioita ch_evalexpr(), ch_sendexpr() raa'an tai nl-"
+"E912: Ei voida käyttää funktioita ch_evalexpr(), ch_sendexpr() raa'an tai nl-"
 "kanavan kanssa"
 
 msgid "E913: Using a Channel as a Number"
@@ -7060,18 +6918,16 @@ msgstr "E914: Käytettiin Channelia Floattina"
 msgid "E915: in_io buffer requires in_buf or in_name to be set"
 msgstr "E915: in_io-puskurilla pitää olla in_buf tai in_name asetettu"
 
-# TODO: Capitalise first word of message?
 msgid "E916: Not a valid job"
-msgstr "E916: ei ole job"
+msgstr "E916: Ei ole job"
 
 #, c-format
 msgid "E917: Cannot use a callback with %s()"
 msgstr "E917: Ei voitu käyttää callbackia %s()"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E918: Buffer must be loaded: %s"
-msgstr "E918: puskuria ei voi ladata: %s"
+msgstr "E918: Puskuria ei voi ladata: %s"
 
 #, c-format
 msgid "E919: Directory not found in '%s': \"%s\""
@@ -7083,13 +6939,12 @@ msgstr "E920: _io-tiedostolla pitää olla _name asetettu"
 msgid "E921: Invalid callback argument"
 msgstr "E921: Virheellinen callback-argumentti"
 
-# TODO: Capitalise first word of message?
 msgid "E922: Expected a dict"
-msgstr "E922: odotettiin dictiä"
+msgstr "E922: Odotettiin dictiä"
 
 # datarakenteita
 msgid "E923: Second argument of function() must be a list or a dict"
-msgstr "E923: toisen function()-argumentin pitää olla lista tai sanakirja"
+msgstr "E923: Toisen function()-argumentin pitää olla lista tai sanakirja"
 
 msgid "E924: Current window was closed"
 msgstr "E924: Nykyinen ikkuna on suljettu"
@@ -7109,7 +6964,7 @@ msgstr "E928: Merkkijono puuttuu"
 
 #, c-format
 msgid "E929: Too many viminfo temp files, like %s!"
-msgstr "E929: liikaa viminfo-väliaikaistiedostoja, kuten %s."
+msgstr "E929: Liikaa viminfo-väliaikaistiedostoja, kuten %s."
 
 msgid "E930: Cannot use :redir inside execute()"
 msgstr "E930: Komentoa :redir ei voi käyttää funktion execute() sisällä"
@@ -7129,7 +6984,6 @@ msgid "E934: Cannot jump to a buffer that does not have a name"
 msgstr "E934: Ei voida hypätä puskuriin jolla ei ole nimeä"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E935: Invalid submatch number: %d"
 msgstr "E935: Virheellinen alitäsmäyksen numero: %d"
 
@@ -7151,9 +7005,8 @@ msgstr "E939: Positiivinen luku tarvitaan"
 msgid "E940: Cannot lock or unlock variable %s"
 msgstr "E940: Muuttujaa %s ei voi lukita tai avata"
 
-# TODO: Capitalise first word of message?
 msgid "E941: Already started a server"
-msgstr "E941: palvelin on jo käynnissä"
+msgstr "E941: Palvelin on jo käynnissä"
 
 msgid "E942: +clientserver feature not available"
 msgstr "E942: +clientserver-toiminto ei ole saatavilla"
@@ -7162,14 +7015,13 @@ msgid "E943: Command table needs to be updated, run 'make cmdidxs'"
 msgstr "E943: Komentotaulukko pitää päivittää komennolla 'make cmdidxs'"
 
 msgid "E944: Reverse range in character class"
-msgstr "E944: Merkiluokan arvoalua on takaperin"
+msgstr "E944: Merkkiluokan arvoalue on takaperin"
 
 msgid "E945: Range too large in character class"
 msgstr "E945: Liian laaja valikoima merkkiluokassa"
 
 msgid "E946: Cannot make a terminal with running job modifiable"
-msgstr ""
-"E946: Terminaalia jossa suoritetaan komentoa ei voi tehdä muokattavaksi"
+msgstr "E946: Terminaalia jossa suoritetaan komentoa ei voi tehdä muokattavaksi"
 
 #, c-format
 msgid "E947: Job still running in buffer \"%s\""
@@ -7203,7 +7055,7 @@ msgid "E954: 24-bit colors are not supported on this environment"
 msgstr "E954: 24-bittiset värit eivät toimi tässä järjestelmässä"
 
 msgid "E955: Not a terminal buffer"
-msgstr "E955: ei ole terminaalipuskuri"
+msgstr "E955: Ei ole terminaalipuskuri"
 
 msgid "E956: Cannot use pattern recursively"
 msgstr "E956: Ilmaus ei toimi rekursiivisesti"
@@ -7220,34 +7072,30 @@ msgstr "E959: Viallinen diff-formaatti."
 msgid "E960: Problem creating the internal diff"
 msgstr "E960: Ongelma sisäisen diffin teossa"
 
-# TODO: Capitalise first word of message?
 msgid "E961: No line number to use for \"<sflnum>\""
-msgstr "E961: ei rivinumeroa kohteelle <sflnum>"
+msgstr "E961: Ei rivinumeroa kohteelle <sflnum>"
 
 #, c-format
 msgid "E962: Invalid action: '%s'"
 msgstr "E962: Viallinen toiminto: %s"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E963: Setting %s to value with wrong type"
-msgstr "E963: väärä tyyppi asetuksen %s arvoksi"
+msgstr "E963: Väärä tyyppi asetuksen %s arvoksi"
 
 #, c-format
 msgid "E964: Invalid column number: %ld"
 msgstr "E964: Virheellinen sarakenumero: %ld"
 
-# TODO: Capitalise first word of message?
 msgid "E965: Missing property type name"
 msgstr "E965: Puuttuva ominaisuustyyppinimi"
 
 #, c-format
 msgid "E966: Invalid line number: %ld"
-msgstr "E966: virheellinen rivinumero: %ld"
+msgstr "E966: Virheellinen rivinumero: %ld"
 
-# TODO: Capitalise first word of message?
 msgid "E967: Text property info corrupted"
-msgstr "E967: tekstiarvo info korruptoitunut"
+msgstr "E967: Tekstiarvo info korruptoitunut"
 
 msgid "E968: Need at least one of 'id' or 'type'"
 msgstr "E968: Tarvitaan ainakin id tai type"
@@ -7289,12 +7137,11 @@ msgstr "E978: Virheellinen toiminto Blobille"
 msgid "E979: Blob index out of range: %ld"
 msgstr "E979: Blobin indeksi %ld rajojen ulkopuolella"
 
-# TODO: Capitalise first word of message?
 msgid "E980: Lowlevel input not supported"
-msgstr "E980: matalan tason syötettä ei tueta"
+msgstr "E980: Matalan tason syötettä ei tueta"
 
 msgid "E981: Command not allowed in rvim"
-msgstr "E981: komennot eivät toimi rvimissä"
+msgstr "E981: Komennot eivät toimi rvimissä"
 
 msgid "E982: ConPTY is not available"
 msgstr "E982: ConPTY ei ole saatavilla"
@@ -7309,13 +7156,11 @@ msgstr "E984: :scriptversion ladatun tiedoston ulkopuolella"
 msgid "E985: .= is not supported with script version >= 2"
 msgstr "E985: .= ei tuettu skriptiversiössa >=2"
 
-# TODO: Capitalise first word of message?
 msgid "E986: Cannot modify the tag stack within tagfunc"
-msgstr "E986: tagipinoa ei voi muokata tagfuncissa"
+msgstr "E986: Tägipinoa ei voi muokata tagfuncissa"
 
-# TODO: Capitalise first word of message?
 msgid "E987: Invalid return value from tagfunc"
-msgstr "E987: väärä palautusarvo tagfuncissa"
+msgstr "E987: Väärä palautusarvo tagfuncissa"
 
 msgid "E988: GUI cannot be used. Cannot execute gvim.exe."
 msgstr "E988: GUIta ei voi käyttää eli gvim.exe ei toimi."
@@ -7327,7 +7172,6 @@ msgstr "E989: Oletusarvoton argumentti oletusarvollisen jälkeen"
 msgid "E990: Missing end marker '%s'"
 msgstr "E990: Lopetusmerkki %s puuttuu"
 
-# TODO: Capitalise first word of message?
 msgid "E991: Cannot use =<< here"
 msgstr "E991: =<< ei toimi täällä"
 
@@ -7335,15 +7179,14 @@ msgid "E992: Not allowed in a modeline when 'modelineexpr' is off"
 msgstr "E992: Ei sallitu modeline-rivillä kun modelineexpr on pois päältä"
 
 #, c-format
-# TODO: Capitalise first word of message?
 msgid "E993: Window %d is not a popup window"
-msgstr "E993: ikkuna %d ei ole popup"
+msgstr "E993: Ikkuna %d ei ole popup"
 
 msgid "E994: Not allowed in a popup window"
 msgstr "E994: Ei sallittu ponnahdusikkunassa"
 
 msgid "E995: Cannot modify existing variable"
-msgstr "E995: Olemassaolevaa muuttujaa ei voi muuttaa"
+msgstr "E995: Olemassa olevaa muuttujaa ei voi muuttaa"
 
 msgid "E996: Cannot lock a range"
 msgstr "E996: Arvoaluetta ei voi lukita"
@@ -7370,7 +7213,7 @@ msgstr "E998: Vähennys tyhjästä %s ilman aloitusarvoa"
 
 #, c-format
 msgid "E999: scriptversion not supported: %d"
-msgstr "E999: skriptiversiota ei tueta: %d"
+msgstr "E999: Skriptiversiota ei tueta: %d"
 
 #, c-format
 msgid "E1001: Variable not found: %s"
@@ -7385,8 +7228,8 @@ msgstr "E1003: Palautusarvo puuttuu"
 
 #, c-format
 msgid "E1004: White space required before and after '%s' at \"%s\""
-msgstr "E1004: Välilyöntejä pitää olle ennen ja jälkeen kohteen "
-"’%s’ kohteessa ”%s”"
+msgstr ""
+"E1004: Välilyöntejä pitää olla ennen ja jälkeen kohteen ’%s’ kohteessa ”%s”"
 
 msgid "E1005: Too many argument types"
 msgstr "E1005: Liikaa argumenttityyppejä"
@@ -7414,7 +7257,7 @@ msgstr "E1011: Liian pitkä nimi: %s"
 
 #, c-format
 msgid "E1012: Type mismatch; expected %s but got %s"
-msgstr "E1012: Tyyppivirhe; odotettiin tyyppiä %s saatiin %s"
+msgstr "E1012: Tyyppivirhe: odotettiin tyyppiä %s saatiin %s"
 
 #, c-format
 msgid "E1012: Type mismatch; expected %s but got %s in %s"
@@ -7426,8 +7269,9 @@ msgstr "E1013: Argumentti %d: tyyppivirhe, odotettiin tyyppiä %s saatiin %s"
 
 #, c-format
 msgid "E1013: Argument %d: type mismatch, expected %s but got %s in %s"
-msgstr "E1013: argumentti %d: tyyppivirhe, odotettiin tyyppiä %s saatiin %s "
-"kohteessa %s"
+msgstr ""
+"E1013: Argumentti %d: tyyppivirhe, odotettiin tyyppiä %s saatiin %s kohteessa "
+"%s"
 
 #, c-format
 msgid "E1014: Invalid key: %s"
@@ -7529,7 +7373,7 @@ msgstr "E1040: :scriptversion ei toimi :vim9scriptin jälkeen"
 
 #, c-format
 msgid "E1041: Redefining script item %s"
-msgstr "E1041: Uudelleenmärittely skriptin kohteelle %s"
+msgstr "E1041: Skriptin kohde %s määritelty uudelleen"
 
 msgid "E1042: Export can only be used in vim9script"
 msgstr "E1042: Export toimii vain vim9scriptissä"
@@ -7645,14 +7489,14 @@ msgstr "E1076: Tähän Vimiin ei ole käännetty liukulukutoimintoja mukaan"
 
 #, c-format
 msgid "E1077: Missing argument type for %s"
-msgstr "E1077: puuttuva argumenttityyppi: %s"
+msgstr "E1077: Puuttuva argumenttityyppi: %s"
 
 #, c-format
 msgid "E1081: Cannot unlet %s"
 msgstr "E1081: Ei voi suorittaa komentoa unlet %s"
 
 msgid "E1083: Missing backtick"
-msgstr "E1083: takapilkku puuttuu"
+msgstr "E1083: Takapilkku puuttuu"
 
 #, c-format
 msgid "E1084: Cannot delete Vim9 script function %s"
@@ -7660,13 +7504,13 @@ msgstr "E1084: Vim9-skriptiunktiota %s ei voi poistaa"
 
 #, c-format
 msgid "E1085: Not a callable type: %s"
-msgstr "E1085: ei ole kutsutyyppiä: %s"
+msgstr "E1085: Ei ole kutsutyyppiä: %s"
 
 msgid "E1086: Function reference invalid"
 msgstr "E1086: Funktioviite on viallinen"
 
 msgid "E1087: Cannot use an index when declaring a variable"
-msgstr "E1087: Ei voi käyttää indeksia muuttujan julistuksessa"
+msgstr "E1087: Ei voi käyttää indeksiä muuttujan julistuksessa"
 
 #, c-format
 msgid "E1089: Unknown variable: %s"
@@ -7705,7 +7549,7 @@ msgstr "E1099: Tuntematon virhe suoritettaessa koodia %s"
 
 #, c-format
 msgid "E1100: Command not supported in Vim9 script (missing :var?): %s"
-msgstr "E1100: Komentoa ei tueta Vim0-skriptissä (puuttuuko :var?): %s"
+msgstr "E1100: Komentoa ei tueta Vim9-skriptissä (puuttuuko :var?): %s"
 
 #, c-format
 msgid "E1101: Cannot declare a script variable in a function: %s"
@@ -7723,7 +7567,7 @@ msgstr "E1104: > puuttuu"
 
 #, c-format
 msgid "E1105: Cannot convert %s to string"
-msgstr "E1105: Ei voida konvertoida juttua %s merkkijonoksi"
+msgstr "E1105: Ei voida muuntaa juttua %s merkkijonoksi"
 
 msgid "E1106: One argument too many"
 msgstr "E1106: Yksi argumentti on liikaa"
@@ -7766,8 +7610,8 @@ msgid "E1115: \"assert_fails()\" fourth argument must be a number"
 msgstr "E1115: assert_fails()-funktion neljännen argumentin tulee olla numero"
 
 msgid "E1116: \"assert_fails()\" fifth argument must be a string"
-msgstr "E1116: ”assert_fails()”-funktion viidennen argumentin on oltava "
-"merkkijono"
+msgstr ""
+"E1116: ”assert_fails()”-funktion viidennen argumentin on oltava merkkijono"
 
 msgid "E1117: Cannot use ! with nested :def"
 msgstr "E1117: ! ei toimi sisäkkäistetyissä :def-määrittelyissä"
@@ -7874,8 +7718,9 @@ msgstr "E1148: Kohdetta %s ei voi indeksoida"
 
 #, c-format
 msgid "E1149: Script variable is invalid after reload in function %s"
-msgstr "E1149: Skriptimuuttuja on käyttökelvoton uudelleenlatauksen jälkeen "
-"funktiossa %s"
+msgstr ""
+"E1149: Skriptimuuttuja on käyttökelvoton uudelleenlatauksen jälkeen funktiossa "
+"%s"
 
 msgid "E1150: Script variable type changed"
 msgstr "E1150: Skriptimuuttujan tyyppi muuttui"
@@ -7921,12 +7766,13 @@ msgstr "E1162: Rekisterin nimen on oltava yksimerkkinen: %s"
 
 #, c-format
 msgid "E1163: Variable %d: type mismatch, expected %s but got %s"
-msgstr "E1163: Muuttuja %d: tyyppivirhe, odottettiin tyyppiä %s saatiin %s"
+msgstr "E1163: Muuttuja %d: tyyppivirhe, odotettiin tyyppiä %s saatiin %s"
 
 #, c-format
 msgid "E1163: Variable %d: type mismatch, expected %s but got %s in %s"
-msgstr "E1163: Muuttuja %d: tyyppivirhe, odotettiin tyyppiä %s mutta saatiin %s"
-" kohteessa %s"
+msgstr ""
+"E1163: Muuttuja %d: tyyppivirhe, odotettiin tyyppiä %s mutta saatiin %s "
+"kohteessa %s"
 
 msgid "E1164: vim9cmd must be followed by a command"
 msgstr "E1164: vim9cmd:tä pitää seurata komento"
@@ -7940,14 +7786,14 @@ msgstr "E1166: Arvoaluetta ei voi käyttää sanakirjassa"
 
 #, c-format
 msgid "E1167: Argument name shadows existing variable: %s"
-msgstr "E1167: Argumentin nimi varjostaa olemassaolevaa muuttujaa: %s"
+msgstr "E1167: Argumentin nimi varjostaa olemassa olevaa muuttujaa: %s"
 
 #, c-format
 msgid "E1168: Argument already declared in the script: %s"
 msgstr "E1168: Argumentti on jo määritelty tässä skriptissä: %s"
 
 msgid "E1169: 'import * as {name}' not supported here"
-msgstr "E1169: import * as {name] ei toimi täällä"
+msgstr "E1169: import * as {name} ei toimi täällä"
 
 msgid "E1170: Cannot use #{ to start a comment"
 msgstr "E1170: #( ei ole sallittu kommentin alussa"
@@ -7982,8 +7828,8 @@ msgstr "E1178: Ei voi lukita tai avata paikallista muuttujaa"
 
 #, c-format
 msgid ""
-"E1179: Failed to extract PWD from %s, check your shell's config related to "
-"OSC 7"
+"E1179: Failed to extract PWD from %s, check your shell's config related to OSC "
+"7"
 msgstr ""
 "E1179: Ei saatu PWD:tä kohteesta %s, koeta tarkistaa komentoriviasetukset "
 "liittyen OSC 7:ään"
@@ -8043,7 +7889,7 @@ msgid "E1193: cryptmethod xchacha20 not built into this Vim"
 msgstr "E1193: cryptmethod-asetus xchacha20 ei ole mukana tässä Vimissä"
 
 msgid "E1194: Cannot encrypt header, not enough space"
-msgstr "E1194: Ei voida salata otsakkete koska tila ei riitä"
+msgstr "E1194: Ei voida salata otsaketta koska tila ei riitä"
 
 msgid "E1195: Cannot encrypt buffer, not enough space"
 msgstr "E1195: Ei voida salata puskuria, koska tila ei riitä"
@@ -8061,14 +7907,14 @@ msgid "E1199: Cannot decrypt buffer, not enough space"
 msgstr "E1199: Ei voitu purkaa puskuria, koska tila loppui kesken"
 
 msgid "E1200: Decryption failed!"
-msgstr "E1200: Purku epäonnistui"
+msgstr "E1200: Purku epäonnistui."
 
 msgid "E1201: Decryption failed: pre-mature end of file!"
 msgstr "E1201: Purku epäonnistui: tiedosto loppui kesken."
 
 #, c-format
 msgid "E1202: No white space allowed after '%s': %s"
-msgstr "E1202: Välilyöntjeä ei saa olla kohteen %s jälkeen: %s"
+msgstr "E1202: Välilyöntejä ei saa olla kohteen %s jälkeen: %s"
 
 #, c-format
 msgid "E1203: Dot can only be used on a dictionary: %s"
@@ -8090,7 +7936,7 @@ msgid "E1207: Expression without an effect: %s"
 msgstr "E1207: Ilmauksella ei ole vaikutusta: %s"
 
 msgid "E1208: -complete used without allowing arguments"
-msgstr "E1208: -complete ilman argumenttejä"
+msgstr "E1208: -complete ilman argumentteja"
 
 #, c-format
 msgid "E1209: Invalid value for a line number: \"%s\""
@@ -8120,8 +7966,7 @@ msgstr "E1214: Digraafin on oltava tasan kaksi merkkiä: %s"
 msgid "E1215: Digraph must be one character: %s"
 msgstr "E1215: Digraafin pitää olla yksi merkki: %s"
 
-msgid ""
-"E1216: digraph_setlist() argument must be a list of lists with two items"
+msgid "E1216: digraph_setlist() argument must be a list of lists with two items"
 msgstr ""
 "E1216: digraph_setlist()-funktion argumentin pitää olla lista kaksikohtaisia "
 "listoja"
@@ -8144,7 +7989,7 @@ msgstr "E1220: Merkkijono tai numero tarvitaan argumentiksi %d"
 
 #, c-format
 msgid "E1221: String or Blob required for argument %d"
-msgstr "E1221: Merkkijono tai Blob vaaditaan arugmentiksi %d"
+msgstr "E1221: Merkkijono tai Blob vaaditaan argumentiksi %d"
 
 #, c-format
 msgid "E1222: String or List required for argument %d"
@@ -8152,7 +7997,7 @@ msgstr "E1222: Merkkijono tai lista vaaditaan argumentiksi %d"
 
 #, c-format
 msgid "E1223: String or Dictionary required for argument %d"
-msgstr "E1223: Merkkijono tai dict vaaditaan argumentiksi %d"
+msgstr "E1223: Merkkijono tai sanakirja vaaditaan argumentiksi %d"
 
 #, c-format
 msgid "E1224: String, Number or List required for argument %d"
@@ -8160,7 +8005,7 @@ msgstr "E1224: Merkkijono, numero tai lista vaaditaan argumentiksi %d"
 
 #, c-format
 msgid "E1225: String, List or Dictionary required for argument %d"
-msgstr "E1225: Merkkijono, lista tai dict vaaditaan argumentiksi %d"
+msgstr "E1225: Merkkijono, lista tai sanakirja vaaditaan argumentiksi %d"
 
 #, c-format
 msgid "E1226: List or Blob required for argument %d"
@@ -8172,11 +8017,11 @@ msgstr "E1227: Lista tai sanakirja vaaditaan argumentiksi %d"
 
 #, c-format
 msgid "E1228: List, Dictionary or Blob required for argument %d"
-msgstr "E1228: Lista, dict tai blob vaaditaan argumentiksi %d"
+msgstr "E1228: Lista, sanakirja tai blob vaaditaan argumentiksi %d"
 
 #, c-format
 msgid "E1229: Expected dictionary for using key \"%s\", but got %s"
-msgstr "E1229: Odotettu dict jossa on avain %s mutta tässä on %s"
+msgstr "E1229: Odotettu sanakirja jossa on avain %s mutta tässä on %s"
 
 msgid "E1230: Encryption: sodium_mlock() failed"
 msgstr "E1230: Salaus: sodium_mlock() ei toiminut"
@@ -8204,7 +8049,7 @@ msgstr "E1236: Kohdetta %s ei voi käyttää itseensä, joten se importoidaan"
 
 #, c-format
 msgid "E1237: No such user-defined command in current buffer: %s"
-msgstr "E1237: Käyttähän määrittelemää komentoa ei löydy tästä puskurista: %s"
+msgstr "E1237: Käyttäjän määrittelemää komentoa ei löydy tästä puskurista: %s"
 
 #, c-format
 msgid "E1238: Blob required for argument %d"
@@ -8255,7 +8100,7 @@ msgstr "E1250: Argumentin %s on oltava lista, merkkijono sanakirja tai blob"
 
 #, c-format
 msgid "E1251: List, Dictionary, Blob or String required for argument %d"
-msgstr "E1251: Lista, dict, blob tai merkkijono vaaditaan argumentiksi %d"
+msgstr "E1251: Lista, sanakirja, blob tai merkkijono vaaditaan argumentiksi %d"
 
 #, c-format
 msgid "E1252: String, List or Blob required for argument %d"
@@ -8277,8 +8122,9 @@ msgstr "E1256: Merkkijono tai funktio tarvitaan argumentiksi %d"
 
 #, c-format
 msgid "E1257: Imported script must use \"as\" or end in .vim: %s"
-msgstr "E1257: Tuodun skriptin pitää käyttää komentoa as tai loppua "
-"merkkijonoon .vim: %s"
+msgstr ""
+"E1257: Tuodun skriptin pitää käyttää komentoa as tai loppua merkkijonoon .vim: "
+"%s"
 
 #, c-format
 msgid "E1258: No '.' after imported name: %s"
@@ -8299,14 +8145,13 @@ msgstr "E1261: Ei voida tuoda .vim-tiedostoa ilman komentoa as"
 msgid "E1262: Cannot import the same script twice: %s"
 msgstr "E1262: Ei voida tuoda samaa skriptiä kahdesti: %s"
 
-# TODO: Capitalise first word of message?
 msgid "E1263: Using autoload in a script not under an autoload directory"
 msgstr "E1263: Käytetään autoloadia skriptissä joka ei ole autoload-hakemistossa"
 
 #, c-format
 msgid "E1264: Autoload import cannot use absolute or relative path: %s"
-msgstr "E1264: Autoload-tuonti ei voi käyttää absoluuttista tai "
-"suhteellista polkua: %s"
+msgstr ""
+"E1264: Autoload-tuonti ei voi käyttää absoluuttista tai suhteellista polkua: %s"
 
 msgid "E1265: Cannot use a partial here"
 msgstr "E1265: Partial ei toimi tässä"
@@ -8325,13 +8170,13 @@ msgstr " rivi "
 
 #, c-format
 msgid "Need encryption key for \"%s\""
-msgstr "Tarvitaan salausavain kohteelle %s "
+msgstr "Tarvitaan salausavain kohteelle \"%s\""
 
 msgid "empty keys are not allowed"
 msgstr "tyhjiä avaimia ei voi käyttää"
 
 msgid "dictionary is locked"
-msgstr "dictionary on lukittu"
+msgstr "sanakirja on lukittu"
 
 msgid "list is locked"
 msgstr "luettelo on lukittu"
@@ -8346,7 +8191,7 @@ msgstr "indeksin pitää olla int tai slice, ei %s"
 
 #, c-format
 msgid "expected str() or unicode() instance, but got %s"
-msgstr "odottettiin insanssia tyypeistä str() tai unicode(), ei %s"
+msgstr "odotettiin instanssia tyypeistä str() tai unicode(), ei %s"
 
 #, c-format
 msgid "expected bytes() or str() instance, but got %s"
@@ -8356,8 +8201,8 @@ msgstr "odotettiin instanssia tyypeistä bytes() tai str(), ei %s"
 msgid ""
 "expected int(), long() or something supporting coercing to long(), but got %s"
 msgstr ""
-"odotettiin instanssia tyypeistä int(), long() tai mitä tahansa joka "
-"muuntuisi tyyppiin long(), ei %s"
+"odotettiin instanssia tyypeistä int(), long() tai mitä tahansa joka muuntuisi "
+"tyyppiin long(), ei %s"
 
 #, c-format
 msgid "expected int() or something supporting coercing to int(), but got %s"
@@ -8392,7 +8237,7 @@ msgstr "odotettiin 3-tuplea tuloksena imp.find_module()-kutsulle, ei %s"
 #, c-format
 msgid "expected 3-tuple as imp.find_module() result, but got tuple of size %d"
 msgstr ""
-"odotettiin 3-tuple tuloksnea imp.find_module()-kutsulle, mutta tuplen koko "
+"odotettiin 3-tuple tuloksena imp.find_module()-kutsulle, mutta tuplen koko "
 "onkin %d"
 
 msgid "internal error: imp.find_module returned tuple with NULL"
@@ -8444,8 +8289,7 @@ msgstr "sisäinen virhe: ei voitu lisätä kohtaa listaan"
 
 #, c-format
 msgid "attempt to assign sequence of size %d to extended slice of size %d"
-msgstr ""
-"yritettiin asettaa sekvenssiä jonka koko on %d sliceen jonka koko on %d"
+msgstr "yritettiin asettaa sekvenssiä jonka koko on %d sliceen jonka koko on %d"
 
 msgid "failed to add item to list"
 msgstr "ei voitu lisätä kohtaa listaan"
@@ -8454,7 +8298,7 @@ msgid "cannot delete vim.List attributes"
 msgstr "ei voi poistaa vim.List-attribuutteja"
 
 msgid "cannot modify fixed list"
-msgstr "ei voida muokata kiinitettyä listaa"
+msgstr "ei voida muokata kiinnitettyä listaa"
 
 #, c-format
 msgid "unnamed function %s does not exist"
@@ -8507,7 +8351,7 @@ msgid "attempt to refer to deleted buffer"
 msgstr "yritettiin viitata poistettuun puskuriin"
 
 msgid "failed to rename buffer"
-msgstr "ei voity uudelleennimetä puskuria"
+msgstr "ei voitu nimetä puskuria uudelleen"
 
 msgid "mark name must be a single character"
 msgstr "merkin nimen pitää olla yksi merkki"
@@ -8542,15 +8386,15 @@ msgstr "ei voitu suorittaa koodia"
 
 #, c-format
 msgid "unable to convert %s to a Vim dictionary"
-msgstr "ei voitu konvertoida oliota %s vim-sanakirjaksi"
+msgstr "ei voitu muuntaa oliota %s vim-sanakirjaksi"
 
 #, c-format
 msgid "unable to convert %s to a Vim list"
-msgstr "ei voitu konvertoida tyypistä %s vim-listaksi"
+msgstr "ei voitu muuntaa tyypistä %s vim-listaksi"
 
 #, c-format
 msgid "unable to convert %s to a Vim structure"
-msgstr "ei voi konvertoida oliota %s vim-tietorakenteeksi"
+msgstr "ei voitu muuntaa oliota %s vim-tietorakenteeksi"
 
 msgid "internal error: NULL reference passed"
 msgstr "sisäinen virhe: NULL-viite annettu"
@@ -8644,26 +8488,23 @@ msgstr "(paikallinen puskurille)"
 msgid "(global or local to buffer)"
 msgstr "(globaali tai paikallinen puskuri"
 
-msgid ""
-"\" Each \"set\" line shows the current value of an option (on the left)."
-msgstr ""
-"\" jokainen \"set\"-rivi näyttää asetuksen arvon (vasemmalla)."
+msgid "\" Each \"set\" line shows the current value of an option (on the left)."
+msgstr "\" jokainen \"set\"-rivi näyttää asetuksen arvon (vasemmalla)."
 
 msgid "\" Hit <Enter> on a \"set\" line to execute it."
-msgstr "\" Paina <Enter> \"set\"-rivillä niin se suoritettaan"
+msgstr "\" Paina <Enter> \"set\"-rivillä niin se suoritettaan."
 
 msgid "\"            A boolean option will be toggled."
 msgstr "\"            totuusarvoa muutetaan."
 
 msgid ""
-"\"            For other options you can edit the value before hitting "
-"<Enter>."
+"\"            For other options you can edit the value before hitting <Enter>."
 msgstr ""
 "\"            Muita asetuksia voi muokata ennen <Enter>-napin painamista."
 
 msgid "\" Hit <Enter> on a help line to open a help window on this option."
-msgstr "\" Painamalla <Enter>-näppäintä ohjerivillä avataan ohjeikkuna "
-"asetukselle."
+msgstr ""
+"\" Painamalla <Enter>-näppäintä ohjerivillä avataan ohjeikkuna asetukselle."
 
 msgid "\" Hit <Enter> on an index line to jump there."
 msgstr "\" Painamalla <Enter>-näppäintä siirrytään kohteeseen."
@@ -8684,13 +8525,13 @@ msgid "use Insert mode as the default mode"
 msgstr "käytä syöttötilaa oletuksena"
 
 msgid "paste mode, insert typed text literally"
-msgstr "liittämistila, lisää kirjoitetunt tekstin sellaisenaan"
+msgstr "liittämistila, lisää kirjoitetun tekstin sellaisenaan"
 
 msgid "key sequence to toggle paste mode"
 msgstr "näppäinyhdistelmä jolla siirrytään liittämistilaan ja pois"
 
 msgid "list of directories used for runtime files and plugins"
-msgstr "hakemistot joita käytetään ajonaikaisiin tiesotoihin ja liitännäisiin"
+msgstr "hakemistot joita käytetään ajonaikaisiin tieostoihin ja liitännäisiin"
 
 msgid "list of directories used for plugin packages"
 msgstr "hakemistot joita käytetään liitännäispaketeille"
@@ -8781,14 +8622,14 @@ msgid ""
 "how to handle case when searching in tags files:\n"
 "\"followic\" to follow 'ignorecase', \"ignore\" or \"match\""
 msgstr ""
-"miten merkkitasot käsitellän tägitiedostoissa:\n"
+"miten merkkitasot käsitellään tägitiedostoissa:\n"
 "followic (toimii kuin ignorecase), ignore tai match"
 
 msgid "file names in a tags file are relative to the tags file"
 msgstr "tiedostonimet tägitiedostossa ovat suhteellisia tiedostoon"
 
 msgid "a :tag command will use the tagstack"
-msgstr ":tag-koento käyttää tägipinoa"
+msgstr ":tag-komento käyttää tägipinoa"
 
 msgid "when completing tags in Insert mode show more info"
 msgstr "kun tägejä täydennetään lisäystilassa näytä lisää tietoja"
@@ -8803,7 +8644,7 @@ msgid "use cscope for tag commands"
 msgstr "käytä cscope-tägikomentoja"
 
 msgid "0 or 1; the order in which \":cstag\" performs a search"
-msgstr "0 tai 1, missä järjestyksess :cstag tekee haun"
+msgstr "0 tai 1, missä järjestyksessä :cstag tekee haun"
 
 msgid "give messages when adding a cscope database"
 msgstr "anna viestejä kun lisätään cscope-tietokantaan"
@@ -8812,7 +8653,7 @@ msgid "how many components of the path to show"
 msgstr "montako komponenttia polusta näytetään"
 
 msgid "when to open a quickfix window for cscope"
-msgstr "milloin avatan quickfix-ikkuna cscopelle"
+msgstr "milloin avataan quickfix-ikkuna cscopelle"
 
 msgid "file names in a cscope file are relative to that file"
 msgstr "tiedostonimet cscope-tiedostossa ovat suhteellisia"
@@ -8876,8 +8717,8 @@ msgid "don't redraw while executing macros"
 msgstr "ei uudelleenpiirtoa makroja suoritettaessa"
 
 msgid "timeout for 'hlsearch' and :match highlighting in msec"
-msgstr "aikakatkaisu komennoille hlsearch ja :match korostettaessa "
-"millisekunneissa"
+msgstr ""
+"aikakatkaisu komennoille hlsearch ja :match korostettaessa millisekunneissa"
 
 msgid ""
 "delay in msec for each char written to the display\n"
@@ -9018,8 +8859,7 @@ msgstr "älä poista puskuria muistista vaikka se ei näy enää ikkunassa"
 msgid ""
 "\"useopen\" and/or \"split\"; which window to use when jumping\n"
 "to a buffer"
-msgstr ""
-"useopen ja tai split, mihin ikkunaan siirrytään puskurin siirrossa"
+msgstr "useopen ja tai split, mihin ikkunaan siirrytään puskurin siirrossa"
 
 msgid "a new window is put below the current one"
 msgstr "uusi ikkuna pannaan nykyisen alle"
@@ -9034,8 +8874,8 @@ msgid "\"ver\", \"hor\" and/or \"jump\"; list of options for 'scrollbind'"
 msgstr "ver, hor ja tai jump, arvot asetukselle scrollbind"
 
 msgid "this window's cursor moves together with other bound windows"
-msgstr "tämän ikkunan kursori liikkuu yhdessä muiden liitettyjen ikkunoiden "
-"kanssa"
+msgstr ""
+"tämän ikkunan kursori liikkuu yhdessä muiden liitettyjen ikkunoiden kanssa"
 
 msgid "size of a terminal window"
 msgstr "terminaali-ikkunan koko"
@@ -9059,16 +8899,16 @@ msgid "0, 1 or 2; when to use a tab pages line"
 msgstr "0, 1 tai 2, milloin tabit näytetään rivillä"
 
 msgid "maximum number of tab pages to open for -p and \"tab all\""
-msgstr "enimmäimäärä tabisivuja avattaessa -p ja tab all"
+msgstr "enimmäismäärä tabisivuja avattaessa -p ja tab all"
 
 msgid "custom tab pages line"
 msgstr "mukautettu välilehtirivi"
 
 msgid "custom tab page label for the GUI"
-msgstr "mukautetta tabisivun nimi GUIlle"
+msgstr "mukautettu tabisivun nimi GUIlle"
 
 msgid "custom tab page tooltip for the GUI"
-msgstr "mukautette tabisivun ponnahdusohje GUIlle"
+msgstr "mukautettu tabisivun ponnahdusohje GUIlle"
 
 msgid "terminal"
 msgstr "terminaali"
@@ -9089,7 +8929,7 @@ msgid "request terminal key codes when an xterm is detected"
 msgstr "kutsu terminaalikoodit kun xterm on havaittu"
 
 msgid "terminal that requires extra redrawing"
-msgstr "terminaali joka tarviaa enemmän uudelleenpiirtämistä"
+msgstr "terminaali joka tarvitsee enemmän uudelleenpiirtämistä"
 
 msgid "recognize keys that start with <Esc> in Insert mode"
 msgstr "tunnista näppäimet jotka alkavat merkillä <Esc> syöttötilassa"
@@ -9162,7 +9002,7 @@ msgid "list of font names to be used in the GUI"
 msgstr "fonttinimet joita käytetään GUIssa"
 
 msgid "pair of fonts to be used, for multibyte editing"
-msgstr "Fonttipari monitavuiselle muokkaukselle"
+msgstr "fonttipari monitavuiselle muokkaukselle"
 
 msgid "list of font names to be used for double-wide characters"
 msgstr "fonttinimet joita käytetään kaksoisleveille merkeille"
@@ -9192,10 +9032,8 @@ msgid "use a pseudo-tty for I/O to external commands"
 msgstr "käytä pseudo-tty:tä ulkoisten komentojen syötteeseen ja tulosteeseen"
 
 msgid ""
-"\"last\", \"buffer\" or \"current\": which directory used for the file "
-"browser"
-msgstr ""
-"last, buffer tai current, mitä hakemistoa käytetään tiedostoselaimessa"
+"\"last\", \"buffer\" or \"current\": which directory used for the file browser"
+msgstr "last, buffer tai current, mitä hakemistoa käytetään tiedostoselaimessa"
 
 msgid "language to be used for the menus"
 msgstr "valikkojen kieli"
@@ -9225,7 +9063,7 @@ msgid "printing"
 msgstr "tulostus"
 
 msgid "list of items that control the format of :hardcopy output"
-msgstr "asetukset jotka määrittävät :hardcopu-tulostusta"
+msgstr "asetukset jotka määrittävät :hardcopy-tulostusta"
 
 msgid "name of the printer to be used for :hardcopy"
 msgstr "tulostin jota asetetaan :hardcopy-komennolle"
@@ -9240,10 +9078,10 @@ msgid "format of the header used for :hardcopy"
 msgstr "otsakkeen muoto :hardcopy-komennolle"
 
 msgid "encoding used to print the PostScript file for :hardcopy"
-msgstr "koodaus jota käytetään kommenon :hardcopy postscript-tiedostossa"
+msgstr "koodaus jota käytetään komimenon :hardcopy postscript-tiedostossa"
 
 msgid "the CJK character set to be used for CJK output from :hardcopy"
-msgstr "CJK-merkisttö CJK-tulosteelle :hardcopy-komennossa"
+msgstr "CJK-merkistö CJK-tulosteelle :hardcopy-komennossa"
 
 msgid "list of font names to be used for CJK output from :hardcopy"
 msgstr "fontit joita käytetään CJK-tulosteelle :hardcopy-komennossa"
@@ -9267,7 +9105,7 @@ msgid "show cursor position below each window"
 msgstr "näytä kursori jokaisen ikkunan alla"
 
 msgid "alternate format to be used for the ruler"
-msgstr "vaihtele viivottimeen muotoa"
+msgstr "vaihtoehtoinen viivoittimen muotoa"
 
 msgid "threshold for reporting number of changed lines"
 msgstr "kynnys muuttuneiden rivien ilmoittamiselle"
@@ -9300,7 +9138,7 @@ msgid "selecting text"
 msgstr "tekstin valinta"
 
 msgid "\"old\", \"inclusive\" or \"exclusive\"; how selecting text behaves"
-msgstr "old inclusive tai exclusive, miten tekstin valinta toimii"
+msgstr "old, inclusive tai exclusive, miten tekstin valinta toimii"
 
 msgid ""
 "\"mouse\", \"key\" and/or \"cmd\"; when to start Select mode\n"
@@ -9326,13 +9164,14 @@ msgid "maximum number of changes that can be undone"
 msgstr "enimmäismäärä muutoksia jotka voidaan perua"
 
 msgid "automatically save and restore undo history"
-msgstr "automaattisest tallenna ja palauta perumishistoria"
+msgstr "tallenna ja palauta perumishistoria automaattisesti"
 
 msgid "list of directories for undo files"
 msgstr "hakemistot perumistiedostoille"
 
 msgid "maximum number lines to save for undo on a buffer reload"
-msgstr "enimmäismäärä rivejä jotka tallenetaan perumista varten puskurin "
+msgstr ""
+"enimmäismäärä rivejä jotka tallennetaan perumista varten puskurin "
 "uudelleenavaukselle"
 
 msgid "changes have been made and not written to a file"
@@ -9354,20 +9193,20 @@ msgid "specifies what <BS>, CTRL-W, etc. can do in Insert mode"
 msgstr "määrittää mitä <BS>, CTRL-W jne. voi tehdä syöttötilassa"
 
 msgid "definition of what comment lines look like"
-msgstr "määrittää miltä kommentirivit näyttävät"
+msgstr "määrittää miltä kommenttirivit näyttävät"
 
 msgid "list of flags that tell how automatic formatting works"
-msgstr "asetukset joiden mukaan automaattinen formatointi toimii"
+msgstr "asetukset joiden mukaan automaattinen muotoilu toimii"
 
 msgid "pattern to recognize a numbered list"
 msgstr "kuvio jolla numeroidut rivit tunnistetaan"
 
 msgid "expression used for \"gq\" to format lines"
-msgstr "ilmaus jolla gq formatoi rivejä"
+msgstr "ilmaus jolla gq muotoilee rivejä"
 
 msgid "specifies how Insert mode completion works for CTRL-N and CTRL-P"
-msgstr "määrittää miten syöttötilantäydennys toimii näppäiyille "
-"CTRL-N ja CTRL-P"
+msgstr ""
+"määrittää miten syöttötilantäydennys toimii näppäilyille CTRL-N ja CTRL-P"
 
 msgid "whether to use a popup menu for Insert mode completion"
 msgstr "käytetäänkö ponnahdusvalikkoa syöttötilantäydennyksessä"
@@ -9400,10 +9239,10 @@ msgid "adjust case of a keyword completion match"
 msgstr "vaihda merkkitasoa avainsanatäydennystäsmäykselle"
 
 msgid "enable entering digraphs with c1 <BS> c2"
-msgstr "mahdollista digraafit  näppäilemällä c1 <BS> c2"
+msgstr "mahdollista digraafit näppäilemällä c1 <BS> c2"
 
 msgid "the \"~\" command behaves like an operator"
-msgstr "komento ~ toimii kuin operaattor"
+msgstr "komento ~ toimii kuin operaattori"
 
 msgid "function called for the \"g@\" operator"
 msgstr "funktio jota g@-operaattori kutsuu"
@@ -9467,7 +9306,7 @@ msgid "options for C-indenting"
 msgstr "C-sisennysasetukset"
 
 msgid "keys that trigger C-indenting in Insert mode"
-msgstr "näppäimet joiden mukaan C-sisenns toimii syöttötilassa"
+msgstr "näppäimet joiden mukaan C-sisennys toimii syöttötilassa"
 
 msgid "list of words that cause more C-indent"
 msgstr "sanat jotka aiheuttavat C-sisennyksen"
@@ -9476,8 +9315,8 @@ msgid "expression used to obtain the indent of a line"
 msgstr "ilmaus jolla selvitetään rivin sisennys"
 
 msgid "keys that trigger indenting with 'indentexpr' in Insert mode"
-msgstr "näppäimet jotka käynnistävät siennyksen indentexpr-asetuksen "
-"syöttötilassa"
+msgstr ""
+"näppäimet jotka käynnistävät sisennyksen indentexpr-asetuksen syöttötilassa"
 
 msgid "copy whitespace for indenting from previous line"
 msgstr "kopioi tyhjeet sisennystä varten edelliseltä riviltä"
@@ -9628,7 +9467,7 @@ msgid "whether to make the backup as a copy or rename the existing file"
 msgstr "tehdäänkö varmuuskopio kopioimalla tai uudelleennimeämällä"
 
 msgid "list of directories to put backup files in"
-msgstr "hakemistot joiin varmuuskopiot lisätään"
+msgstr "hakemistot joihin varmuuskopiot lisätään"
 
 msgid "file name extension for the backup file"
 msgstr "tiedostonimenlopuke varmuuskopiolle"
@@ -9664,7 +9503,7 @@ msgid "list of directories for the swap file"
 msgstr "hakemistot swap-tiedostolle"
 
 msgid "use a swap file for this buffer"
-msgstr "kätä swap-tiedostoa tälle puskurille"
+msgstr "käytä swap-tiedostoa tälle puskurille"
 
 msgid "\"sync\", \"fsync\" or empty; how to flush a swap file to disk"
 msgstr "sync, fsync tai tyhjä, miten heittovaihtotiedosto siirretään levylle"
@@ -9700,7 +9539,7 @@ msgid "empty or \"tagfile\" to list file name of matching tags"
 msgstr "tyhjä tai tagfile, tiedostonimi tägejä varten"
 
 msgid "list of file name extensions that have a lower priority"
-msgstr "tiedostnimipäätteet joilla on matalampi prioriteetti"
+msgstr "tiedostonimipäätteet joilla on matalampi prioriteetti"
 
 msgid "list of file name extensions added when searching for a file"
 msgstr "tiedostonimipäätteet joista etsitään tiedostoja"
@@ -9739,7 +9578,7 @@ msgid "like 'shellquote' but include the redirection"
 msgstr "kuten shellquote mutta uudelleenohjaus sisältyy"
 
 msgid "characters to escape when 'shellxquote' is ("
-msgstr "merkit jotka lainaataan kun shellxquote on ("
+msgstr "merkit jotka lainataan kun shellxquote on ("
 
 msgid "argument for 'shell' to execute a command"
 msgstr "argumentti komennolle shell komennon suorittamiseen"
@@ -9754,7 +9593,7 @@ msgid "program used for \"=\" command"
 msgstr "komento komennolle ="
 
 msgid "program used to format lines with \"gq\" command"
-msgstr "ohjelma jolla formatoidaan gq-rivit"
+msgstr "ohjelma jolla muotoillaan gq-rivit"
 
 msgid "program used for the \"K\" command"
 msgstr "ohjelma komennolle K"
@@ -9796,10 +9635,10 @@ msgid "system specific"
 msgstr "järjestelmäspesifit"
 
 msgid "use forward slashes in file names; for Unix-like shells"
-msgstr "käytä vinoviivoja teidostonimissä, unix-tyyppisille komentoriveille"
+msgstr "käytä vinoviivoja tiedostonimissä, unix-tyyppisille komentoriveille"
 
 msgid "specifies slash/backslash used for completion"
-msgstr "määrit vinoviiva/takakenoviiv täydennykselle"
+msgstr "määritä vinoviiva/takakenoviiva täydennykselle"
 
 msgid "language specific"
 msgstr "kielispesifi"
@@ -9814,7 +9653,7 @@ msgid "specifies the characters in a keyword"
 msgstr "määritä avainsanan merkit"
 
 msgid "specifies printable characters"
-msgstr "määrittää tulostettavat merkti"
+msgstr "määrittää tulostettavat merkit"
 
 msgid "specifies escape characters in a string"
 msgstr "määritä lainausmerkit merkkijonossa"
@@ -9856,7 +9695,7 @@ msgid "list of characters that are translated in Normal mode"
 msgstr "merkit jotka käännetään normaalitilassa"
 
 msgid "apply 'langmap' to mapped characters"
-msgstr "suorita langmap kuvatuile merkeille"
+msgstr "suorita langmap kuvatuille merkeille"
 
 msgid "when set never use IM; overrules following IM options"
 msgstr "kun IM on pois käytöstä, ohittaa IM-asetukset"
@@ -9933,7 +9772,7 @@ msgid "load plugin scripts when starting up"
 msgstr "lataa liitännäisskriptit alussa"
 
 msgid "enable reading .vimrc/.exrc/.gvimrc in the current directory"
-msgstr "lue .vimrc/.exrc/.gvimrc nykyisestä hakemistostsa"
+msgstr "lue .vimrc/.exrc/.gvimrc nykyisestä hakemistosta"
 
 msgid "safer working with script files in the current directory"
 msgstr "turvallisempi tila skripteille nykyisessä hakemistossa"
@@ -10002,7 +9841,7 @@ msgid "name of the Python 3 dynamic library"
 msgstr "Python 3:n dynaamisen kirjaston nimi"
 
 msgid "name of the Python 3 home directory"
-msgstr "Python 3:n kotihakemist"
+msgstr "Python 3:n kotihakemisto"
 
 msgid "name of the Ruby dynamic library"
 msgstr "Rubyn dynaamisen kirjaston nimi"


### PR DESCRIPTION
This is not an in-depth translation cleanup; I just fixed all the typos and inconsistencies that I could immediately see when scrolling through the file in poedit or which I have encountered in my daily use.