### PR TITLE
Cosme: Modify the definitions of some macros

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -2020,7 +2020,7 @@ apply_autocmds_group(
     save_redo_T	save_redo;
     int		save_KeyTyped = KeyTyped;
     int		save_did_emsg;
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 
     /*
      * Quickly return if there are no autocommands for this event or
@@ -2226,7 +2226,7 @@ apply_autocmds_group(
 
     // name and lnum are filled in later
     estack_push(ETYPE_AUCMD, NULL, 0);
-    ESTACK_CHECK_SETUP
+    ESTACK_CHECK_SETUP;
 
     save_current_sctx = current_sctx;
 
@@ -2339,7 +2339,7 @@ apply_autocmds_group(
     filechangeshell_busy = FALSE;
     autocmd_nested = save_autocmd_nested;
     vim_free(SOURCING_NAME);
-    ESTACK_CHECK_NOW
+    ESTACK_CHECK_NOW;
     estack_pop();
     vim_free(autocmd_fname);
     autocmd_fname = save_autocmd_fname;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5641,8 +5641,7 @@ chk_modeline(
     int		end;
     int		retval = OK;
     sctx_T	save_current_sctx;
-
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 
     prev = -1;
     for (s = ml_get(lnum); *s != NUL; ++s)
@@ -5686,7 +5685,7 @@ chk_modeline(
 
 	// prepare for emsg()
 	estack_push(ETYPE_MODELINE, (char_u *)"modelines", lnum);
-	ESTACK_CHECK_SETUP
+	ESTACK_CHECK_SETUP;
 
 	end = FALSE;
 	while (end == FALSE)
@@ -5747,7 +5746,7 @@ chk_modeline(
 	    s = e + 1;			// advance to next part
 	}
 
-	ESTACK_CHECK_NOW
+	ESTACK_CHECK_NOW;
 	estack_pop();
 	vim_free(linecopy);
     }

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1390,7 +1390,7 @@ handle_did_throw(void)
 {
     char	*p = NULL;
     msglist_T	*messages = NULL;
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 
     /*
      * If the uncaught exception is a user exception, report it as an
@@ -1416,7 +1416,7 @@ handle_did_throw(void)
 
     estack_push(ETYPE_EXCEPT, current_exception->throw_name,
 					current_exception->throw_lnum);
-    ESTACK_CHECK_SETUP
+    ESTACK_CHECK_SETUP;
     current_exception->throw_name = NULL;
 
     discard_current_exception();	// uses IObuff if 'verbose'
@@ -1446,7 +1446,7 @@ handle_did_throw(void)
 	vim_free(p);
     }
     vim_free(SOURCING_NAME);
-    ESTACK_CHECK_NOW
+    ESTACK_CHECK_NOW;
     estack_pop();
 }
 

--- a/src/macros.h
+++ b/src/macros.h
@@ -366,21 +366,31 @@
 
 
 #ifdef ABORT_ON_INTERNAL_ERROR
-# define ESTACK_CHECK_DECLARATION int estack_len_before;
-# define ESTACK_CHECK_SETUP estack_len_before = exestack.ga_len;
-# define ESTACK_CHECK_NOW if (estack_len_before != exestack.ga_len) \
-	siemsg("Exestack length expected: %d, actual: %d", estack_len_before, exestack.ga_len);
-# define CHECK_CURBUF if (curwin != NULL && curwin->w_buffer != curbuf) \
-		iemsg("curbuf != curwin->w_buffer")
+# define ESTACK_CHECK_DECLARATION int estack_len_before
+# define ESTACK_CHECK_SETUP do { estack_len_before = exestack.ga_len; } while (0)
+# define ESTACK_CHECK_NOW \
+    do { \
+	if (estack_len_before != exestack.ga_len) \
+	    siemsg("Exestack length expected: %d, actual: %d", estack_len_before, exestack.ga_len); \
+    } while (0)
+# define CHECK_CURBUF \
+    do { \
+	if (curwin != NULL && curwin->w_buffer != curbuf) \
+	    iemsg("curbuf != curwin->w_buffer"); \
+    } while (0)
 #else
-# define ESTACK_CHECK_DECLARATION
-# define ESTACK_CHECK_SETUP
-# define ESTACK_CHECK_NOW
-# define CHECK_CURBUF
+# define ESTACK_CHECK_DECLARATION do { /**/ } while (0)
+# define ESTACK_CHECK_SETUP do { /**/ } while (0)
+# define ESTACK_CHECK_NOW do { /**/ } while (0)
+# define CHECK_CURBUF do { /**/ } while (0)
 #endif
 
 // Inline the condition for performance.
-#define CHECK_LIST_MATERIALIZE(l) if ((l)->lv_first == &range_list_item) range_list_materialize(l)
+#define CHECK_LIST_MATERIALIZE(l) \
+    do { \
+	if ((l)->lv_first == &range_list_item) \
+	    range_list_materialize(l); \
+    } while (0)
 
 // Inlined version of ga_grow() with optimized condition that it fails.
 #define GA_GROW_FAILS(gap, n) unlikely((((gap)->ga_maxlen - (gap)->ga_len < (n)) ? ga_grow_inner((gap), (n)) : OK) == FAIL)

--- a/src/main.c
+++ b/src/main.c
@@ -3101,21 +3101,21 @@ exe_pre_commands(mparm_T *parmp)
     char_u	**cmds = parmp->pre_commands;
     int		cnt = parmp->n_pre_commands;
     int		i;
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 
     if (cnt <= 0)
 	return;
 
     curwin->w_cursor.lnum = 0; // just in case..
     estack_push(ETYPE_ARGS, (char_u *)_("pre-vimrc command line"), 0);
-    ESTACK_CHECK_SETUP
+    ESTACK_CHECK_SETUP;
 # ifdef FEAT_EVAL
-	current_sctx.sc_sid = SID_CMDARG;
+    current_sctx.sc_sid = SID_CMDARG;
 # endif
-	for (i = 0; i < cnt; ++i)
-	    do_cmdline_cmd(cmds[i]);
-    ESTACK_CHECK_NOW
-	estack_pop();
+    for (i = 0; i < cnt; ++i)
+	do_cmdline_cmd(cmds[i]);
+    ESTACK_CHECK_NOW;
+    estack_pop();
 # ifdef FEAT_EVAL
     current_sctx.sc_sid = 0;
 # endif
@@ -3129,7 +3129,7 @@ exe_pre_commands(mparm_T *parmp)
 exe_commands(mparm_T *parmp)
 {
     int		i;
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 
     /*
      * We start commands on line 0, make "vim +/pat file" match a
@@ -3140,7 +3140,7 @@ exe_commands(mparm_T *parmp)
     if (parmp->tagname == NULL && curwin->w_cursor.lnum <= 1)
 	curwin->w_cursor.lnum = 0;
     estack_push(ETYPE_ARGS, (char_u *)"command line", 0);
-    ESTACK_CHECK_SETUP
+    ESTACK_CHECK_SETUP;
 #ifdef FEAT_EVAL
     current_sctx.sc_sid = SID_CARG;
     current_sctx.sc_seq = 0;
@@ -3151,7 +3151,7 @@ exe_commands(mparm_T *parmp)
 	if (parmp->cmds_tofree[i])
 	    vim_free(parmp->commands[i]);
     }
-    ESTACK_CHECK_NOW
+    ESTACK_CHECK_NOW;
     estack_pop();
 #ifdef FEAT_EVAL
     current_sctx.sc_sid = 0;
@@ -3370,8 +3370,7 @@ process_env(
 {
     char_u	*initstr;
     sctx_T	save_current_sctx;
-
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 
     if ((initstr = mch_getenv(env)) == NULL || *initstr == NUL)
 	return FAIL;
@@ -3379,8 +3378,8 @@ process_env(
     if (is_viminit)
 	vimrc_found(NULL, NULL);
     estack_push(ETYPE_ENV, env, 0);
-    ESTACK_CHECK_SETUP
-	save_current_sctx = current_sctx;
+    ESTACK_CHECK_SETUP;
+    save_current_sctx = current_sctx;
     current_sctx.sc_version = 1;
 #ifdef FEAT_EVAL
     current_sctx.sc_sid = SID_ENV;
@@ -3390,8 +3389,8 @@ process_env(
 
     do_cmdline_cmd(initstr);
 
-    ESTACK_CHECK_NOW
-	estack_pop();
+    ESTACK_CHECK_NOW;
+    estack_pop();
     current_sctx = save_current_sctx;
     return OK;
 }

--- a/src/map.c
+++ b/src/map.c
@@ -2231,12 +2231,12 @@ check_map_keycodes(void)
     int		abbr;
     int		hash;
     buf_T	*bp;
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 
     validate_maphash();
     // avoids giving error messages
     estack_push(ETYPE_INTERNAL, (char_u *)"mappings", 0);
-    ESTACK_CHECK_SETUP
+    ESTACK_CHECK_SETUP;
 
     // Do this once for each buffer, and then once for global
     // mappings/abbreviations with bp == NULL
@@ -2293,7 +2293,7 @@ check_map_keycodes(void)
 	if (bp == NULL)
 	    break;
     }
-    ESTACK_CHECK_NOW
+    ESTACK_CHECK_NOW;
     estack_pop();
 }
 

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1456,7 +1456,7 @@ do_source_ext(
     int			    sid = -1;
     scriptitem_T	    *si = NULL;
     int			    save_estack_compiling = estack_compiling;
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 #endif
 #ifdef STARTUPTIME
     struct timeval	    tv_rel;
@@ -1711,7 +1711,7 @@ do_source_ext(
 
     // Keep the sourcing name/lnum, for recursive calls.
     estack_push(ETYPE_SCRIPT, si->sn_name, 0);
-    ESTACK_CHECK_SETUP
+    ESTACK_CHECK_SETUP;
 
 # ifdef FEAT_PROFILE
     if (do_profiling == PROF_YES)
@@ -1780,7 +1780,7 @@ do_source_ext(
     if (got_int)
 	emsg(_(e_interrupted));
 #ifdef FEAT_EVAL
-    ESTACK_CHECK_NOW
+    ESTACK_CHECK_NOW;
 #endif
     estack_pop();
     if (p_verbose > 1)

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1450,14 +1450,6 @@ do_source_ext(
     char_u		    *firstline = NULL;
     int			    retval = FAIL;
     sctx_T		    save_current_sctx;
-#ifdef FEAT_EVAL
-    funccal_entry_T	    funccalp_entry;
-    int			    save_debug_break_level = debug_break_level;
-    int			    sid = -1;
-    scriptitem_T	    *si = NULL;
-    int			    save_estack_compiling = estack_compiling;
-    ESTACK_CHECK_DECLARATION;
-#endif
 #ifdef STARTUPTIME
     struct timeval	    tv_rel;
     struct timeval	    tv_start;
@@ -1467,6 +1459,14 @@ do_source_ext(
 #endif
     int			    save_sticky_cmdmod_flags = sticky_cmdmod_flags;
     int			    trigger_source_post = FALSE;
+#ifdef FEAT_EVAL
+    funccal_entry_T	    funccalp_entry;
+    int			    save_debug_break_level = debug_break_level;
+    int			    sid = -1;
+    scriptitem_T	    *si = NULL;
+    int			    save_estack_compiling = estack_compiling;
+    ESTACK_CHECK_DECLARATION;
+#endif
 
     CLEAR_FIELD(cookie);
     if (fname == NULL)

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -356,7 +356,7 @@ spell_load_file(
     int		c = 0;
     int		res;
     int		did_estack_push = FALSE;
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 
     fd = mch_fopen((char *)fname, "r");
     if (fd == NULL)
@@ -397,7 +397,7 @@ spell_load_file(
 
     // Set sourcing_name, so that error messages mention the file name.
     estack_push(ETYPE_SPELL, fname, 0);
-    ESTACK_CHECK_SETUP
+    ESTACK_CHECK_SETUP;
     did_estack_push = TRUE;
 
     /*
@@ -588,7 +588,7 @@ endOK:
 	fclose(fd);
     if (did_estack_push)
     {
-	ESTACK_CHECK_NOW
+	ESTACK_CHECK_NOW;
 	estack_pop();
     }
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2748,7 +2748,7 @@ call_user_func(
 #ifdef FEAT_PROFILE
     profinfo_T	profile_info;
 #endif
-    ESTACK_CHECK_DECLARATION
+    ESTACK_CHECK_DECLARATION;
 
 #ifdef FEAT_PROFILE
     CLEAR_FIELD(profile_info);
@@ -2963,7 +2963,7 @@ call_user_func(
     }
 
     estack_push_ufunc(fp, 1);
-    ESTACK_CHECK_SETUP
+    ESTACK_CHECK_SETUP;
     if (p_verbose >= 12)
     {
 	++no_wait_return;
@@ -3117,7 +3117,7 @@ call_user_func(
 	--no_wait_return;
     }
 
-    ESTACK_CHECK_NOW
+    ESTACK_CHECK_NOW;
     estack_pop();
     current_sctx = save_current_sctx;
     restore_current_ectx(save_current_ectx);


### PR DESCRIPTION
* Surround by `do { ... } while (0)` in order to able to append semicolon and indent properly