### PR TITLE
CI: Workaround for test_diff_screen() on Cirrus CI (macOS 13)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,7 @@ macos_task:
   timeout_in: 20m
   install_script:
     - brew update
-    - brew install gettext libtool
+    - brew install gettext libtool diffutils
   build_script:
     - NPROC=$(getconf _NPROCESSORS_ONLN)
     - ./configure --with-features=${FEATURES}


### PR DESCRIPTION
Since macOS 13 changed diff command from GNU diff to Apple diff, but this seems to have a bug so causes `test_diff_screen()` fails on Cirrus CI (which uses macOS 13).
As a workaround, install GNU diffutils before testing.

```
$ seq 10 > file0
$ seq 0 9 > file1
$ diff -U0 file0 file1
```

GNU diff:
```
--- file0
+++ file1
@@ -0,0 +1 @@
+0
@@ -10 +10,0 @@
-10
```

Apple diff (macOS 13.2):
```
--- file0
+++ file1
@@ -1,0 +1 @@
+0
@@ -10 +10,0 @@
-10
```