### PR TITLE
CI: Workaround flaky tests on macOS huge

### DIFF
--- a/src/testdir/test_prompt_buffer.vim
+++ b/src/testdir/test_prompt_buffer.vim
@@ -253,6 +253,11 @@ func Test_prompt_while_writing_to_hidden_buffer()
 endfunc
 
 func Test_prompt_appending_while_hidden()
+  if has('macOS')
+    " FIXME: This test is flaky on macOS huge.
+    let g:test_is_flaky = 1
+  endif
+
   call CanTestPromptBuffer()
 
   let script =<< trim END


### PR DESCRIPTION
```
Failures: 
	From test_prompt_buffer.vim:
	Found errors in Test_prompt_appending_while_hidden():
	Run 1, 10:02:29 - 10:02:30:
	command line..script /Users/runner/work/vim/vim/src/testdir/runtest.vim[569]..function RunTheTest[52]..Test_prompt_appending_while_hidden line 31: Pattern '-- INSERT --' does match '-- INSERT --\[  occurs 45 times]0,1           All'
	Run 2, 10:02:32 - 10:02:33:
	command line..script /Users/runner/work/vim/vim/src/testdir/runtest.vim[604]..function RunTheTest[52]..Test_prompt_appending_while_hidden line 31: Pattern '-- INSERT --' does match '-- INSERT --'
	Run 3, 10:02:35 - 10:02:36:
	command line..script /Users/runner/work/vim/vim/src/testdir/runtest.vim[604]..function RunTheTest[52]..Test_prompt_appending_while_hidden line 31: Pattern '-- INSERT --' does match '-- INSERT --'
	Flaky test failed too often, giving up
```