### PR TITLE
runtime: Recognise ".cppm", etc. files as C++ 20 Modules

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -338,6 +338,10 @@ if has("fname_case")
   au BufNewFile,BufRead *.C,*.H setf cpp
 endif
 
+" C++ 20 modules (clang)
+" https://clang.llvm.org/docs/StandardCPlusPlusModules.html#file-name-requirement
+au BufNewFile,BufRead *.cppm,*.ccm,*.cxxm,*.c++m setf cpp
+
 " .h files can be C, Ch C++, ObjC or ObjC++.
 " Set c_syntax_for_h if you want C, ch_syntax_for_h if you want Ch. ObjC is
 " detected automatically.

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -127,7 +127,7 @@ let s:filename_checks = {
     \ 'context': ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],
     \ 'cook': ['file.cook'],
     \ 'cpon': ['file.cpon'],
-    \ 'cpp': ['file.cxx', 'file.c++', 'file.hh', 'file.hxx', 'file.hpp', 'file.ipp', 'file.moc', 'file.tcc', 'file.inl', 'file.tlh'],
+    \ 'cpp': ['file.cxx', 'file.c++', 'file.hh', 'file.hxx', 'file.hpp', 'file.ipp', 'file.moc', 'file.tcc', 'file.inl', 'file.tlh', 'file.cppm', 'file.ccm', 'file.cxxm', 'file.c++m'],
     \ 'cqlang': ['file.cql'],
     \ 'crm': ['file.crm'],
     \ 'crontab': ['crontab', 'crontab.file', '/etc/cron.d/file', 'any/etc/cron.d/file'],


### PR DESCRIPTION
clang's c++ 20 modules uses the "cppm" and similiar extensions: https://clang.llvm.org/docs/StandardCPlusPlusModules.html#file-name-requirement

Recognise .cppm, .ccm, .cxxm and .c++m as a C++ file (C++ 20 Module)