### PR TITLE
Fix Test_autocmd_shortmess() depending on messages

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -4247,6 +4247,7 @@ endfunc
 func Test_autocmd_shortmess()
   CheckNotMSWindows
 
+  messages clear
   call SetupVimTest_shm()
   let output = execute(':mess')->split('\n')
 


### PR DESCRIPTION
The following command
```sh
make test_autocmd TEST_FILTER='_autocmd'
```
will fail with
```
Test_autocmd_shortmess line 18: Expected 3 but got 4
```
Clear messages in `Test_autocmd_shortmess()` to fix that.
