### PR TITLE
Fix: `execute({list})` is not equivalent from to `redir` contrary to help description

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4136,7 +4136,7 @@ get_list_nextline(void *cookie)
  * "execute()" function
  */
     void
-execute_common(typval_T *argvars, typval_T *rettv, int arg_off)
+execute_common(typval_T *argvars, typval_T *rettv)
 {
     char_u	*cmd = NULL;
     list_T	*list = NULL;
@@ -4153,32 +4153,31 @@ execute_common(typval_T *argvars, typval_T *rettv, int arg_off)
     rettv->vval.v_string = NULL;
     rettv->v_type = VAR_STRING;
 
-    if (argvars[arg_off].v_type == VAR_LIST)
+    if (argvars[0].v_type == VAR_LIST)
     {
-	list = argvars[arg_off].vval.v_list;
+	list = argvars[0].vval.v_list;
 	if (list == NULL || list->lv_len == 0)
 	    // empty list, no commands, empty output
 	    return;
 	++list->lv_refcount;
     }
-    else if (argvars[arg_off].v_type == VAR_JOB
-	    || argvars[arg_off].v_type == VAR_CHANNEL)
+    else if (argvars[0].v_type == VAR_JOB || argvars[0].v_type == VAR_CHANNEL)
     {
 	semsg(_(e_using_invalid_value_as_string_str),
-				       vartype_name(argvars[arg_off].v_type));
+					      vartype_name(argvars[0].v_type));
 	return;
     }
     else
     {
-	cmd = tv_get_string_chk(&argvars[arg_off]);
+	cmd = tv_get_string_chk(&argvars[0]);
 	if (cmd == NULL)
 	    return;
     }
 
-    if (argvars[arg_off + 1].v_type != VAR_UNKNOWN)
+    if (argvars[1].v_type != VAR_UNKNOWN)
     {
 	char_u	buf[NUMBUFLEN];
-	char_u  *s = tv_get_string_buf_chk_strict(&argvars[arg_off + 1], buf,
+	char_u  *s = tv_get_string_buf_chk_strict(&argvars[1], buf,
 							      in_vim9script());
 
 	if (s == NULL)
@@ -4263,7 +4262,7 @@ f_execute(typval_T *argvars, typval_T *rettv)
 		|| check_for_opt_string_arg(argvars, 1) == FAIL))
 	return;
 
-    execute_common(argvars, rettv, 0);
+    execute_common(argvars, rettv);
 }
 
 /*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -4044,7 +4044,7 @@ get_list_line(
     item = item->li_next;
 
     // Only concatenate lines starting with a \ when 'cpoptions' doesn't
-    // contain the 'C' flag.
+    // contain the 'C' flag.  See getsourceline().
     if (line != NULL && item != NULL && options != GETLINE_NONE
 				      && vim_strchr(p_cpo, CPO_CONCAT) == NULL)
     {
@@ -4117,6 +4117,19 @@ get_list_line(
 
     *p = item;
     return line;
+}
+
+/*
+ * Return the readahead line. Note that the pointer may become invalid when
+ * getting the next line, if it's concatenated with the next one.
+ */
+    char_u *
+get_list_nextline(void *cookie)
+{
+    static char_u	buf[NUMBUFLEN];
+    listitem_T		*item = *(listitem_T **)cookie;
+
+    return item == NULL ? NULL : tv_get_string_buf_chk(&item->li_tv, buf);
 }
 
 /*

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -760,7 +760,7 @@ f_win_execute(typval_T *argvars, typval_T *rettv)
     if (switch_win_noblock(&switchwin, wp, tp, TRUE) == OK)
     {
 	check_cursor();
-	execute_common(argvars, rettv, 1);
+	execute_common(argvars + 1, rettv);
     }
     restore_win_noblock(&switchwin, TRUE);
 #ifdef FEAT_AUTOCHDIR

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1601,6 +1601,8 @@ getline_peek(
     }
     if (gp == getsourceline)
 	return source_nextline(cp);
+    else if (gp == get_list_line)
+	return get_list_nextline(cp);
     return NULL;
 }
 #endif

--- a/src/proto/evalfunc.pro
+++ b/src/proto/evalfunc.pro
@@ -19,6 +19,7 @@ win_T *get_optional_window(typval_T *argvars, int idx);
 void execute_redir_str(char_u *value, int value_len);
 void execute_cmds_from_string(char_u *str);
 char_u *get_list_line(int c, void *cookie, int indent, getline_opt_T options);
+char_u *get_list_nextline(void *cookie);
 void execute_common(typval_T *argvars, typval_T *rettv, int arg_off);
 void f_exists(typval_T *argvars, typval_T *rettv);
 void f_has(typval_T *argvars, typval_T *rettv);

--- a/src/proto/evalfunc.pro
+++ b/src/proto/evalfunc.pro
@@ -20,7 +20,7 @@ void execute_redir_str(char_u *value, int value_len);
 void execute_cmds_from_string(char_u *str);
 char_u *get_list_line(int c, void *cookie, int indent, getline_opt_T options);
 char_u *get_list_nextline(void *cookie);
-void execute_common(typval_T *argvars, typval_T *rettv, int arg_off);
+void execute_common(typval_T *argvars, typval_T *rettv);
 void f_exists(typval_T *argvars, typval_T *rettv);
 void f_has(typval_T *argvars, typval_T *rettv);
 int dynamic_feature(char_u *feature);

--- a/src/testdir/test_execute_func.vim
+++ b/src/testdir/test_execute_func.vim
@@ -45,10 +45,34 @@ endfunc
 
 func Test_execute_list()
   call assert_equal("\nsomething\nnice", execute(['echo "something"', 'echo "nice"']))
-  let l = ['for n in range(0, 3)',
-	\  'echo n',
-	\  'endfor']
+  let l =<< trim END
+    for n in range(0, 3)
+      echo n
+    endfor
+  END
   call assert_equal("\n0\n1\n2\n3", execute(l))
+
+  " line-continuation
+  let l =<< trim END
+    echo "123
+          \ abc"
+    echo "456
+          \ def"
+    " echo "789
+          \ ghi"
+  END
+  call assert_equal("\n123 abc\n456 def", execute(l))
+
+  " line-continuation-comment
+  let l =<< trim END
+    echo 1
+          "\ + 10
+          \ + 100
+  END
+  call assert_equal("\n101", execute(l))
+
+  " line-continuation in vim9script
+  call v9.CheckDefSuccess(['execute(["echo 1 +", "10 +", "100"])'])
 
   call assert_equal("", execute([]))
 endfunc


### PR DESCRIPTION
`redir` can handle line-continuation but `execute({list})` cannot.

`redir`: no error
```vim
redir => var
echo 1 +
    \ 2
redir END
```

`execute({list})`: `E15: Invalid expression: "1 +"`
```vim
echo execute(['echo 1 +',  '\ 2'])
```

This PR modifies `get_list_line()` to handle line-continuation as `getsourceline()` and in addtion define `get_list_nextline()` to handle vim9script's line-continuation.