### PR TITLE
Fix Haiku build

### DIFF
--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -75,8 +75,6 @@ extern "C" {
 #include <syslog.h>
 
 #include "vim.h"
-#include "globals.h"
-#include "proto.h"
 #include "version.h"
 
 }   // extern "C"


### PR DESCRIPTION
gui_haiku.cc includes globals.h and proto.h directly, but they are also in vim.h thus many symbol-redefined errors occur.