### PR TITLE
Fix warnings on macOS

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -40,7 +40,7 @@ typedef struct {
     int	    whole_undofile; // whole undo file is encrypted
 
     // Optional function pointer for a self-test.
-    int (* self_test_fn)();
+    int (* self_test_fn)(void);
 
     // Function pointer for initializing encryption/decryption.
     int (* init_fn)(cryptstate_T *state, char_u *key,

--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -430,7 +430,7 @@ static NSMutableDictionary<NSNumber*, NSSound*> *sounds_list = nil;
 @end
 
     void
-process_cfrunloop()
+process_cfrunloop(void)
 {
     if (sounds_list != nil && [sounds_list count] > 0)
     {
@@ -493,7 +493,7 @@ sound_mch_stop(long sound_id)
 }
 
     void
-sound_mch_clear()
+sound_mch_clear(void)
 {
     if (sounds_list != nil)
     {
@@ -510,7 +510,7 @@ sound_mch_clear()
 }
 
     void
-sound_mch_free()
+sound_mch_free(void)
 {
     sound_mch_clear();
 }

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -198,7 +198,7 @@ static void deathtrap SIGPROTOARG;
 
 static void catch_int_signal(void);
 static void set_signals(void);
-static void catch_signals(void (*func_deadly)(), void (*func_other)());
+static void catch_signals(void (*func_deadly)(int), void (*func_other)(int));
 #ifdef HAVE_SIGPROCMASK
 # define SIGSET_DECL(set)	sigset_t set;
 # define BLOCK_SIGNALS(set)	block_signals(set)
@@ -670,7 +670,7 @@ mch_delay(long msec, int flags)
 	}
 #  endif // HAVE_SELECT
 # endif // HAVE_NANOSLEEP
-#endif // HAVE_USLEEP
+#endif // HAVE_NANOSLEEP
 #ifdef FEAT_MZSCHEME
 	}
 	while (total > 0);
@@ -812,7 +812,7 @@ static struct sigstack sigstk;		// for sigstack()
  * Get a size of signal stack.
  * Preference (if available): sysconf > SIGSTKSZ > guessed size
  */
-static long int get_signal_stack_size()
+static long int get_signal_stack_size(void)
 {
 # ifdef HAVE_SYSCONF_SIGSTKSZ
     long int size = -1;
@@ -869,7 +869,7 @@ init_signal_stack(void)
 sig_winch SIGDEFARG(sigarg)
 {
     // this is not required on all systems, but it doesn't hurt anybody
-    signal(SIGWINCH, (void (*)())sig_winch);
+    signal(SIGWINCH, (void (*)(int))sig_winch);
     do_resize = TRUE;
 }
 #endif
@@ -890,7 +890,7 @@ sig_tstp SIGDEFARG(sigarg)
 #if !defined(__ANDROID__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
     // This is not required on all systems.  On some systems (at least Android,
     // OpenBSD, and DragonFlyBSD) this breaks suspending with CTRL-Z.
-    signal(SIGTSTP, (void (*)())sig_tstp);
+    signal(SIGTSTP, (void (*)(int))sig_tstp);
 #endif
 }
 #endif
@@ -900,7 +900,7 @@ sig_tstp SIGDEFARG(sigarg)
 catch_sigint SIGDEFARG(sigarg)
 {
     // this is not required on all systems, but it doesn't hurt anybody
-    signal(SIGINT, (void (*)())catch_sigint);
+    signal(SIGINT, (void (*)(int))catch_sigint);
     got_int = TRUE;
 }
 #endif
@@ -910,7 +910,7 @@ catch_sigint SIGDEFARG(sigarg)
 catch_sigusr1 SIGDEFARG(sigarg)
 {
     // this is not required on all systems, but it doesn't hurt anybody
-    signal(SIGUSR1, (void (*)())catch_sigusr1);
+    signal(SIGUSR1, (void (*)(int))catch_sigusr1);
     got_sigusr1 = TRUE;
 }
 #endif
@@ -1383,7 +1383,7 @@ set_signals(void)
     /*
      * WINDOW CHANGE signal is handled with sig_winch().
      */
-    signal(SIGWINCH, (void (*)())sig_winch);
+    signal(SIGWINCH, (void (*)(int))sig_winch);
 #endif
 
 #ifdef SIGTSTP
@@ -1395,7 +1395,7 @@ set_signals(void)
 # ifdef FEAT_GUI
 				: gui.in_use || gui.starting ? SIG_DFL
 # endif
-				    : (void (*)())sig_tstp);
+				    : (void (*)(int))sig_tstp);
 #endif
 #if defined(SIGCONT)
     signal(SIGCONT, sigcont_handler);
@@ -1415,7 +1415,7 @@ set_signals(void)
     /*
      * Call user's handler on SIGUSR1
      */
-    signal(SIGUSR1, (void (*)())catch_sigusr1);
+    signal(SIGUSR1, (void (*)(int))catch_sigusr1);
 #endif
 
     /*
@@ -1454,7 +1454,7 @@ set_signals(void)
     static void
 catch_int_signal(void)
 {
-    signal(SIGINT, (void (*)())catch_sigint);
+    signal(SIGINT, (void (*)(int))catch_sigint);
 }
 #endif
 
@@ -1470,8 +1470,8 @@ reset_signals(void)
 
     static void
 catch_signals(
-    void (*func_deadly)(),
-    void (*func_other)())
+    void (*func_deadly)(int),
+    void (*func_other)(int))
 {
     int	    i;
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -670,7 +670,7 @@ mch_delay(long msec, int flags)
 	}
 #  endif // HAVE_SELECT
 # endif // HAVE_NANOSLEEP
-#endif // HAVE_NANOSLEEP
+#endif // HAVE_USLEEP
 #ifdef FEAT_MZSCHEME
 	}
 	while (total > 0);

--- a/src/proto/os_macosx.pro
+++ b/src/proto/os_macosx.pro
@@ -1,7 +1,7 @@
 /* os_macosx.m */
-void process_cfrunloop();
+void process_cfrunloop(void);
 bool sound_mch_play(const char_u* event, long sound_id, soundcb_T *callback, bool playfile);
 void sound_mch_stop(long sound_id);
-void sound_mch_clear();
-void sound_mch_free();
+void sound_mch_clear(void);
+void sound_mch_free(void);
 /* vim: set ft=c : */


### PR DESCRIPTION
Clang 14.0.3 is complaining that a function declaration without a prototype is deprecated in all versions of C. 

These just clean up the warnings. 

Example:

```
crypt.c:43:25: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    int (* self_test_fn)();
                        ^
                         void
```

Also, in one place (`src/os_unix.c:673`) I fixed where a comment didn't match the opening comment. 
