### PR TITLE
win32: Enable dark mode when guioptions contains 'd'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3912,6 +3912,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 	In its simplest form the value is just one font name.
 	See |gui-font| for the details.
 
+					*'guidarkmode'*
+'guidarkmode'		string	(default "automatic")
+			global
+			{only available when compiled with GUI enabled}
+	This option specifies whether Vim GUI elements should be drawn using a
+	dark color scheme if available.
+	The allowed values are:
+	  automatic	Follow the current system's preference.
+	  prefer_dark	Apply the dark mode to the GUI elements.
+	  prefer_light	Apply the light mode to the GUI elements.
+	  use_bg	Follow the value of Vim's |background| option.
+
 					*'guifontset'* *'gfs'*
 					*E250* *E252* *E234* *E597* *E598*
 'guifontset' 'gfs'	string	(default "")

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4011,7 +4011,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		choices.
 								*'go-d'*
 	  'd'	Use dark theme variant if available. Currently only works for
-		GTK+ GUI.
+		Win32 and GTK+ GUI.
 								*'go-e'*
 	  'e'	Add tab pages when indicated with 'showtabline'.
 		'guitablabel' can be used to change the text in the labels.

--- a/src/feature.h
+++ b/src/feature.h
@@ -513,7 +513,7 @@
 /*
  * GUI dark theme variant
  */
-#if defined(FEAT_GUI_GTK) && defined(USE_GTK3)
+#if (defined(FEAT_GUI_GTK) && defined(USE_GTK3)) || defined(FEAT_GUI_MSWIN)
 # define FEAT_GUI_DARKTHEME
 #endif
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -741,6 +741,7 @@ gui_init(void)
 	resettitle();
 
 	init_gui_options();
+
 #ifdef FEAT_ARABIC
 	// Our GUI can't do bidi.
 	p_tbidi = FALSE;
@@ -3463,7 +3464,6 @@ static int	prev_which_scrollbars[3];
 gui_init_which_components(char_u *oldval UNUSED)
 {
 #ifdef FEAT_GUI_DARKTHEME
-    static int	prev_dark_theme = -1;
     int		using_dark_theme = FALSE;
 #endif
 #ifdef FEAT_MENU
@@ -3567,10 +3567,10 @@ gui_init_which_components(char_u *oldval UNUSED)
     fix_size = FALSE;
 
 #ifdef FEAT_GUI_DARKTHEME
-    if (using_dark_theme != prev_dark_theme)
+    if (*p_guidarkmode == NUL)
     {
-	gui_mch_set_dark_theme(using_dark_theme);
-	prev_dark_theme = using_dark_theme;
+	gui.prefer_dark_theme = using_dark_theme ? DM_PREFER_DARK : DM_PREFER_LIGHT;
+	gui_mch_set_dark_theme();
     }
 #endif
 
@@ -4683,6 +4683,11 @@ init_gui_options(void)
 	set_option_value_give_err((char_u *)"bg", 0L, gui_bg_default(), 0);
 	highlight_changed();
     }
+
+#ifdef FEAT_GUI_DARKTHEME
+    // Apply the user preference now that the GUI window is open.
+    gui_mch_set_dark_theme();
+#endif
 }
 
 #if defined(FEAT_GUI_X11) || defined(PROTO)

--- a/src/gui.h
+++ b/src/gui.h
@@ -149,6 +149,15 @@
 				// is no console input possible
 #endif
 
+typedef enum
+{
+    DM_DEFAULT,			// Use the default value for the system.
+    DM_AUTOMATIC,
+    DM_PREFER_LIGHT,
+    DM_PREFER_DARK,
+    DM_USE_BACKGROUND,
+} dm_pref_T;
+
 typedef struct GuiScrollbar
 {
     long	ident;		// Unique identifier for each scrollbar
@@ -262,6 +271,10 @@ typedef struct Gui
     int		scrollbar_height;   // Height of horizontal scrollbar
     int		left_sbar_x;	    // Calculated x coord for left scrollbar
     int		right_sbar_x;	    // Calculated x coord for right scrollbar
+#ifdef FEAT_GUI_DARKTHEME
+    dm_pref_T	prefer_dark_theme;   // Whether to follow or not the global system dark
+				    // mode preference.
+#endif
 
 #ifdef FEAT_MENU
 # ifndef FEAT_GUI_GTK

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3135,13 +3135,50 @@ update_window_manager_hints(int force_width, int force_height)
 
 #if defined(FEAT_GUI_DARKTHEME) || defined(PROTO)
     void
-gui_mch_set_dark_theme(int dark)
+gui_mch_set_dark_theme(void)
 {
 # if GTK_CHECK_VERSION(3,0,0)
     GtkSettings *gtk_settings;
+    gboolean dark;
+# if !GTK_CHECK_VERSION(3,20,0)
+    static gboolean sys_prefer_dark_theme;
+    static int sys_prefer_dark_theme_set = FALSE;
+# endif
 
     gtk_settings = gtk_settings_get_for_screen(gdk_screen_get_default());
-    g_object_set(gtk_settings, "gtk-application-prefer-dark-theme", (gboolean)dark, NULL);
+
+# if !GTK_CHECK_VERSION(3,20,0)
+    if (sys_prefer_dark_theme_set == FALSE)
+    {
+	g_object_get(gtk_settings, "gtk-application-prefer-dark-theme",
+		&sys_prefer_dark_theme, NULL);
+	sys_prefer_dark_theme_set = TRUE;
+    }
+# endif
+
+    switch (gui.sys_prefer_dark_theme)
+    {
+	case DM_PREFER_LIGHT:
+	case DM_PREFER_DARK:
+	    dark = (gui.sys_prefer_dark_theme == DM_PREFER_DARK);
+	    break;
+	case DM_DEFAULT:
+	case DM_AUTOMATIC:
+	    // Reset the value if possible, otherwise use the cached value.
+# if GTK_CHECK_VERSION(3,20,0)
+	    gtk_settings_reset_property(gtk_settings,
+		    "gtk-application-prefer-dark-theme");
+	    return;
+# else
+	    dark = sys_prefer_dark_theme;
+# endif
+	    break;
+	case DM_USE_BACKGROUND:
+	    dark = (*p_bg == 'd');
+	    break;
+    }
+
+    g_object_set(gtk_settings, "gtk-application-prefer-dark-theme", dark, NULL);
 # endif
 }
 #endif // FEAT_GUI_DARKTHEME

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -405,6 +405,8 @@ typedef enum PreferredAppMode
 } PreferredAppMode;
 
 static DWORD (WINAPI *pSetPreferredAppMode)(DWORD) = NULL;
+static BOOL (WINAPI *pShouldAppsUseDarkMode)(void) = NULL;
+static BOOL (WINAPI *pShouldSystemUseDarkMode)(void) = NULL;
 static void (WINAPI *pFlushMenuThemes)(void) = NULL;
 #endif
 
@@ -2810,7 +2812,101 @@ gui_mch_set_curtab(int nr)
 #endif
 
 #if defined(FEAT_GUI_DARKTHEME) || defined(PROTO)
-    static void load_dwm_func(void)
+    static int
+is_w10_newer_than(unsigned short build_no)
+{
+    static DWORD win_ver = 0;
+
+    if (win_ver == 0)
+	win_ver = get_win_version();
+
+    return win_ver >= MAKE_VER(10U, 0U, build_no);
+}
+
+    static int
+is_high_contrast_theme(int *high_contrast)
+{
+	HIGHCONTRASTW hc;
+
+	hc.cbSize = sizeof(HIGHCONTRASTW);
+	if (!SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRASTW), &hc,
+		    FALSE))
+	    return FAIL;
+
+	*high_contrast = (hc.dwFlags & HCF_HIGHCONTRASTON) != 0;
+	return OK;
+}
+
+    static int
+system_prefers_dark_theme(void)
+{
+    int high_contrast;
+
+    if (pShouldSystemUseDarkMode != NULL)
+    {
+	return pShouldSystemUseDarkMode() &&
+		is_high_contrast_theme(&high_contrast) == OK &&
+		!high_contrast;
+    }
+
+    return FALSE;
+}
+
+    static void
+set_dark_theme(HWND hwnd, int dark)
+{
+    BOOL	value = dark != 0;
+    DWORD	ver = get_win_version();
+
+    if (pDwmSetWindowAttribute != NULL)
+    {
+	if (is_w10_newer_than(18985))
+	    pDwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value,
+		    sizeof(value));
+	else
+	    pDwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1,
+		    &value, sizeof(value));
+    }
+}
+
+    static void
+set_dark_theme_impl(const int dark)
+{
+    if (is_w10_newer_than(18362))
+    {
+	if (pSetPreferredAppMode != NULL && pFlushMenuThemes != NULL)
+	{
+	    pSetPreferredAppMode(dark ? ForceDark : ForceLight);
+	    pFlushMenuThemes();
+	}
+    }
+
+    if (is_w10_newer_than(17763))
+	set_dark_theme(s_hwnd, dark);
+}
+
+    void
+gui_mch_set_dark_theme(void)
+{
+    switch (gui.prefer_dark_theme)
+    {
+	case DM_DEFAULT:
+	    // Defaults to light mode.
+	case DM_PREFER_LIGHT:
+	case DM_PREFER_DARK:
+	    set_dark_theme_impl(gui.prefer_dark_theme == DM_PREFER_DARK);
+	    break;
+	case DM_AUTOMATIC:
+	    set_dark_theme_impl(system_prefers_dark_theme());
+	    break;
+	case DM_USE_BACKGROUND:
+	    set_dark_theme_impl(*p_bg == 'd');
+	    break;
+    }
+}
+
+    static void
+load_dwm_func(void)
 {
     static HMODULE hDwmLib = NULL;
 
@@ -2825,7 +2921,8 @@ gui_mch_set_curtab(int nr)
 	    GetProcAddress(hDwmLib, "DwmSetWindowAttribute");
 }
 
-    static void load_uxtheme_func(void)
+    static void
+load_uxtheme_func(void)
 {
     static HMODULE hUxThemeLib = NULL;
 
@@ -2836,43 +2933,16 @@ gui_mch_set_curtab(int nr)
     if (hUxThemeLib == NULL)
 	return;
 
+    pShouldAppsUseDarkMode = (BOOL (WINAPI *)(void))
+	    GetProcAddress(hUxThemeLib, MAKEINTRESOURCE(132));
     pSetPreferredAppMode = (DWORD (WINAPI *)(DWORD))
 	    GetProcAddress(hUxThemeLib, MAKEINTRESOURCE(135));
     pFlushMenuThemes = (void (WINAPI *)(void))
 	    GetProcAddress(hUxThemeLib, MAKEINTRESOURCE(136));
+    pShouldSystemUseDarkMode = (BOOL (WINAPI *)(void))
+	    GetProcAddress(hUxThemeLib, MAKEINTRESOURCE(138));
 }
-    void
-gui_mch_set_dark_theme(int dark)
-{
-    BOOL	value = dark != 0;
-    DWORD	ver = get_win_version();
 
-    if (ver >= MAKE_VER(10, 0, 18362))
-    {
-	load_uxtheme_func();
-
-	if (pSetPreferredAppMode != NULL && pFlushMenuThemes != NULL)
-	{
-	    pSetPreferredAppMode(dark ? ForceDark : ForceLight);
-	    pFlushMenuThemes();
-	}
-    }
-
-    if (ver >= MAKE_VER(10, 0, 17763))
-    {
-	load_dwm_func();
-
-	if (pDwmSetWindowAttribute != NULL)
-	{
-	    if (ver >= MAKE_VER(10, 0, 18985))
-		pDwmSetWindowAttribute(s_hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value,
-			sizeof(value));
-	    else
-		pDwmSetWindowAttribute(s_hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1,
-			&value, sizeof(value));
-	}
-    }
-}
 #endif // FEAT_GUI_DARKTHEME
 
 /*
@@ -4469,12 +4539,16 @@ set_tabline_font(void)
 # define set_tabline_font()
 #endif
 
+
+
 /*
  * Invoked when a setting was changed.
  */
     static LRESULT CALLBACK
-_OnSettingChange(UINT param)
+_OnSettingChange(UINT param, LPCWSTR param_name)
 {
+    // ch_log(NULL, "OnSettingChange(param=%08lx, name=%s)", param, param_name);
+
     switch (param)
     {
 	case SPI_SETWHEELSCROLLLINES:
@@ -4485,6 +4559,14 @@ _OnSettingChange(UINT param)
 	    break;
 	case SPI_SETNONCLIENTMETRICS:
 	    set_tabline_font();
+	    break;
+	case 0:
+#ifdef FEAT_GUI_DARKTHEME
+	    if (param_name != NULL &&
+		    !wcscmp(param_name, L"ImmersiveColorSet") &&
+		    gui.prefer_dark_theme == DM_AUTOMATIC)
+		set_dark_theme_impl(system_prefers_dark_theme());
+#endif
 	    break;
 	default:
 	    break;
@@ -4957,7 +5039,7 @@ _WndProc(
 
 	// Notification for change in SystemParametersInfo()
     case WM_SETTINGCHANGE:
-	return _OnSettingChange((UINT)wParam);
+	return _OnSettingChange((UINT)wParam, (LPCWSTR)lParam);
 
 #if defined(FEAT_TOOLBAR) || defined(FEAT_GUI_TABLINE)
     case WM_NOTIFY:
@@ -5350,6 +5432,10 @@ gui_mch_init(void)
 #endif
 
     load_dpi_func();
+#ifdef FEAT_GUI_DARKTHEME
+    load_uxtheme_func();
+    load_dwm_func();
+#endif
 
     s_dpi = pGetDpiForSystem();
     update_scrollbar_size();

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -392,7 +392,7 @@ static DPI_AWARENESS_CONTEXT (WINAPI *pSetThreadDpiAwarenessContext)(DPI_AWARENE
 static DPI_AWARENESS (WINAPI *pGetAwarenessFromDpiAwarenessContext)(DPI_AWARENESS_CONTEXT) = NULL;
 
 #if defined(FEAT_GUI_DARKTHEME)
-static HRESULT (*pDwmSetWindowAttribute)(HWND, DWORD, LPCVOID, DWORD) = NULL;
+static HRESULT (WINAPI *pDwmSetWindowAttribute)(HWND, DWORD, LPCVOID, DWORD) = NULL;
 #endif
 
     static UINT WINAPI

--- a/src/option.h
+++ b/src/option.h
@@ -621,6 +621,7 @@ EXTERN char_u	*p_header;	// 'printheader'
 #endif
 EXTERN int	p_prompt;	// 'prompt'
 #ifdef FEAT_GUI
+EXTERN char_u	*p_guidarkmode; // 'guidarkmode'
 EXTERN char_u	*p_guifont;	// 'guifont'
 # ifdef FEAT_XFONTSET
 EXTERN char_u	*p_guifontset;	// 'guifontset'

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1159,6 +1159,15 @@ static struct vimoption options[] =
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCTX_INIT},
+    {"guidarkmode",  NULL,  P_STRING|P_VI_DEF|P_RCLR,
+#ifdef FEAT_GUI
+			    (char_u *)&p_guidarkmode, PV_NONE, did_set_guidarkmode,
+			    {(char_u *)"", (char_u *)0L}
+#else
+			    (char_u *)NULL, PV_NONE, NULL,
+			    {(char_u *)NULL, (char_u *)0L}
+#endif
+			    SCTX_INIT},
     {"guifont",	    "gfn",  P_STRING|P_VI_DEF|P_RCLR|P_ONECOMMA|P_NODUP,
 #ifdef FEAT_GUI
 			    (char_u *)&p_guifont, PV_NONE, did_set_guifont,

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1160,7 +1160,7 @@ static struct vimoption options[] =
 #endif
 			    SCTX_INIT},
     {"guidarkmode",  NULL,  P_STRING|P_VI_DEF|P_RCLR,
-#ifdef FEAT_GUI
+#if defined(FEAT_GUI_DARKTHEME)
 			    (char_u *)&p_guidarkmode, PV_NONE, did_set_guidarkmode,
 			    {(char_u *)"", (char_u *)0L}
 #else

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1656,13 +1656,13 @@ did_set_guifont(optset_T *args UNUSED)
     return errmsg;
 }
 
+#if defined(FEAT_GUI_DARKTHEME) || defined(PROTO)
 /*
  * The 'guidarkmode' option is changed.
  */
     char *
 did_set_guidarkmode(optset_T *args UNUSED)
 {
-#if defined(FEAT_GUI_DARKTHEME)
     if (*p_guidarkmode == NUL)
     {
 	gui.prefer_dark_theme = DM_DEFAULT;
@@ -1687,10 +1687,10 @@ did_set_guidarkmode(optset_T *args UNUSED)
 
     if (gui.in_use)
 	gui_mch_set_dark_theme();
-#endif
 
     return NULL;
 }
+#endif
 
 # if defined(FEAT_XFONTSET) || defined(PROTO)
 /*

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -266,11 +266,9 @@ static BOOL use_alternate_screen_buffer = FALSE;
  * Get version number including build number
  */
 typedef BOOL (WINAPI *PfnRtlGetVersion)(LPOSVERSIONINFOW);
-#define MAKE_VER(major, minor, build) \
-    (((major) << 24) | ((minor) << 16) | (build))
 
-    static DWORD
-get_build_number(void)
+    DWORD
+get_win_version(void)
 {
     OSVERSIONINFOW	osver;
     HMODULE		hNtdll;
@@ -8420,7 +8418,7 @@ mch_setenv(char *var, char *value, int x UNUSED)
     static void
 vtp_flag_init(void)
 {
-    DWORD   ver = get_build_number();
+    DWORD   ver = get_win_version();
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
     DWORD   mode;
     HANDLE  out;

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -223,3 +223,6 @@ Trace(char *pszFormat, ...);
 #endif
 #define mch_getenv(x) (char_u *)getenv((char *)(x))
 #define vim_mkdir(x, y) mch_mkdir(x)
+
+#define MAKE_VER(major, minor, build) \
+    (((major) << 24) | ((minor) << 16) | (build))

--- a/src/proto/gui_gtk_x11.pro
+++ b/src/proto/gui_gtk_x11.pro
@@ -8,7 +8,7 @@ void gui_mch_stop_blink(int may_call_gui_update_cursor);
 void gui_mch_start_blink(void);
 int gui_mch_early_init_check(int give_message);
 int gui_mch_init_check(void);
-void gui_mch_set_dark_theme(int dark);
+void gui_mch_set_dark_theme(void);
 void gui_mch_show_tabline(int showit);
 int gui_mch_showing_tabline(void);
 void gui_mch_update_tabline(void);

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -42,6 +42,7 @@ void gui_mch_show_tabline(int showit);
 int gui_mch_showing_tabline(void);
 void gui_mch_update_tabline(void);
 void gui_mch_set_curtab(int nr);
+void gui_mch_set_dark_theme(int dark);
 void ex_simalt(exarg_T *eap);
 void gui_mch_find_dialog(exarg_T *eap);
 void gui_mch_replace_dialog(exarg_T *eap);

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -42,7 +42,7 @@ void gui_mch_show_tabline(int showit);
 int gui_mch_showing_tabline(void);
 void gui_mch_update_tabline(void);
 void gui_mch_set_curtab(int nr);
-void gui_mch_set_dark_theme(int dark);
+void gui_mch_set_dark_theme(void);
 void ex_simalt(exarg_T *eap);
 void gui_mch_find_dialog(exarg_T *eap);
 void gui_mch_replace_dialog(exarg_T *eap);

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -52,6 +52,7 @@ char *did_set_foldmethod(optset_T *args);
 char *did_set_foldopen(optset_T *args);
 char *did_set_formatoptions(optset_T *args);
 char *did_set_guicursor(optset_T *args);
+char *did_set_guidarkmode(optset_T *args);
 char *did_set_guifont(optset_T *args);
 char *did_set_guifontset(optset_T *args);
 char *did_set_guifontwide(optset_T *args);

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -1,4 +1,5 @@
 /* os_win32.c */
+DWORD get_win_version(void);
 void mch_get_exe_name(void);
 HINSTANCE vimLoadLib(const char *name);
 int mch_is_gui_executable(void);

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -101,6 +101,7 @@ let test_values = {
       \ 'foldmarker': [['((,))'], ['', 'xxx']],
       \ 'formatoptions': [['', 'vt', 'v,t'], ['xxx']],
       \ 'guicursor': [['', 'n:block-Cursor'], ['xxx']],
+      \ 'guidarkmode': [['', 'automatic', 'prefer_light'], ['xxx', '1', 'automatic,prefer_light']],
       \ 'guifont': [['', fontname], []],
       \ 'guifontwide': [['', fontname], []],
       \ 'guifontset': [['', fontname], []],


### PR DESCRIPTION
Enabling the dark mode makes the windows title bar dark, the option is already being honored by the GTK UI so let's follow the lead and enable it on Win32 too.

Closes #3922