### PR TITLE
Change the LSP HTTP header Content-Type field

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -105,7 +105,7 @@ json_encode_lsp_msg(typval_T *val)
     ga_init2(&lspga, 1, 4000);
     vim_snprintf((char *)IObuff, IOSIZE,
 	    "Content-Length: %u\r\n"
-	    "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n\r\n",
+	    "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n",
 	    ga.ga_len - 1);
     ga_concat(&lspga, IObuff);
     ga_concat_len(&lspga, ga.ga_data, ga.ga_len);

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -2670,7 +2670,7 @@ func LspTests(port)
   " " Test for sending a raw message
   " let g:lspNotif = []
   " let s = "Content-Length: 62\r\n"
-  " let s ..= "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+  " let s ..= "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
   " let s ..= "\r\n"
   " let s ..= '{"method":"echo","jsonrpc":"2.0","params":{"m":"raw-message"}}'
   " call ch_sendraw(ch, s)

--- a/src/testdir/test_channel_lsp.py
+++ b/src/testdir/test_channel_lsp.py
@@ -35,7 +35,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
             v['id'] = msgid
         s = json.dumps(v)
         resp = "Content-Length: " + str(len(s)) + "\r\n"
-        resp += "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp += "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
         resp += "\r\n"
         resp += s
         if self.debug:
@@ -46,7 +46,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
         v = 'wrong-payload'
         s = json.dumps(v)
         resp = "Content-Length: " + str(len(s)) + "\r\n"
-        resp += "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp += "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
         resp += "\r\n"
         resp += s
         self.request.sendall(resp.encode('utf-8'))
@@ -60,7 +60,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
 
     def send_empty_payload(self):
         resp = "Content-Length: 0\r\n"
-        resp += "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp += "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
         resp += "\r\n"
         self.request.sendall(resp.encode('utf-8'))
 
@@ -71,7 +71,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
         resp = "Host: abc.vim.org\r\n"
         resp += "User-Agent: Python\r\n"
         resp += "Accept-Language: en-US,en\r\n"
-        resp += "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp += "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
         resp += "Content-Length: " + str(len(s)) + "\r\n"
         resp += "\r\n"
         resp += s
@@ -93,7 +93,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
         # test for sending the http header without length
         v = {'jsonrpc': '2.0', 'id': msgid, 'result': resp_dict}
         s = json.dumps(v)
-        resp = "Content-Type: application/vim-jsonrpc; charset=utf-8\r\n"
+        resp = "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
         resp += "\r\n"
         resp += s
         self.request.sendall(resp.encode('utf-8'))


### PR DESCRIPTION
Based on the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#headerPart), change the HTTP header Content-Type field from vim-jsonrpc to vscode-jsonrpc.

Some LSP servers (e.g. https://github.com/hashicorp/terraform-ls), compare the value of the Content-Type field against
vscode-jsonrpc and reject the LSP message if it is set to some other value.
