### PR TITLE
CI: Enable `sodium` on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,8 @@ jobs:
       # winpty
       WINPTY_URL: https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip
       # libsodium
-      SODIUM_URL: https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip
+      SODIUM_MSVC_URL: https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip
+      SODIUM_MINGW_URL: https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-mingw.tar.gz
       SODIUM_DIR: D:\libsodium
       SODIUM_VER: v143
       # Escape sequences
@@ -403,14 +404,13 @@ jobs:
 
           git config --global core.autocrlf input
 
-          if [ "${{ matrix.arch }}" = "x64" ]; then
+          if ${{ matrix.arch == 'x64' }}; then
             cygreg=registry
             pyreg=
             echo "VCARCH=amd64" >> $GITHUB_ENV
             echo "WARCH=x64" >> $GITHUB_ENV
             echo "BITS=64" >> $GITHUB_ENV
             echo "MSYSTEM=MINGW64" >> $GITHUB_ENV
-            echo "SODIUM_LIB=${SODIUM_DIR}\\x64\\Release\\${SODIUM_VER}\\dynamic" >> $GITHUB_ENV
           else
             cygreg=registry32
             pyreg=-32
@@ -418,7 +418,6 @@ jobs:
             echo "WARCH=ia32" >> $GITHUB_ENV
             echo "BITS=32" >> $GITHUB_ENV
             echo "MSYSTEM=MINGW32" >> $GITHUB_ENV
-            echo "SODIUM_LIB=${SODIUM_DIR}\\Win32\\Release\\${SODIUM_VER}\\dynamic" >> $GITHUB_ENV
           fi
 
           echo "VCVARSALL=$(vswhere -products \* -latest -property installationPath)\\VC\\Auxiliary\\Build\\vcvarsall.bat" >> $GITHUB_ENV
@@ -431,6 +430,15 @@ jobs:
           fi
           python3_dir=$(cat "/proc/$cygreg/HKEY_LOCAL_MACHINE/SOFTWARE/Python/PythonCore/${PYTHON3_VER_DOT}$pyreg/InstallPath/@")
           echo "PYTHON3_DIR=$python3_dir" >> $GITHUB_ENV
+
+          if ${{ matrix.toolchain == 'msvc' }}; then
+            echo "SODIUM_LIB=${SODIUM_DIR}\\${{ matrix.arch == 'x64' && 'x64' || 'Win32' }}\\Release\\${SODIUM_VER}\\dynamic" >> $GITHUB_ENV
+            echo "SODIUM_URL=${SODIUM_MSVC_URL}" >> $GITHUB_ENV
+          else
+            echo "SODIUM_DIR=${SODIUM_DIR}-win${{ matrix.arch == 'x64' && '64' || '32' }}" >> $GITHUB_ENV
+            echo "SODIUM_LIB=${SODIUM_DIR}\\bin" >> $GITHUB_ENV
+            echo "SODIUM_URL=${SODIUM_MINGW_URL}" >> $GITHUB_ENV
+          fi
 
       - uses: msys2/setup-msys2@v2
         if: matrix.toolchain == 'mingw'
@@ -478,6 +486,9 @@ jobs:
           echo %COL_GREEN%Download libsodium%COL_RESET%
           call :downloadfile %SODIUM_URL% downloads\libsodium.zip
           7z x -y downloads\libsodium.zip -oD:\ > nul || exit 1
+          if "${{ matrix.toolchain }}"=="mingw" (
+            mklink %SODIUM_LIB%\libsodium.dll %SODIUM_LIB%\libsodium-23.dll
+          )
 
           goto :eof
 
@@ -534,6 +545,7 @@ jobs:
               DYNAMIC_LUA=yes LUA=${LUA_DIR_SLASH} \
               DYNAMIC_PYTHON=yes PYTHON=${PYTHON_DIR} \
               DYNAMIC_PYTHON3=yes PYTHON3=${PYTHON3_DIR} \
+              DYNAMIC_SODIUM=yes SODIUM=${SODIUM_DIR} \
               STATIC_STDCPLUS=yes COVERAGE=${{ matrix.coverage }}
           else
             mingw32-make -f Make_ming.mak -j2 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,10 @@ jobs:
       # Other dependencies
       # winpty
       WINPTY_URL: https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip
+      # libsodium
+      SODIUM_URL: https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip
+      SODIUM_DIR: D:\libsodium
+      SODIUM_VER: v143
       # Escape sequences
       COL_RED: "\x1b[31m"
       COL_GREEN: "\x1b[32m"
@@ -406,6 +410,7 @@ jobs:
             echo "WARCH=x64" >> $GITHUB_ENV
             echo "BITS=64" >> $GITHUB_ENV
             echo "MSYSTEM=MINGW64" >> $GITHUB_ENV
+            echo "SODIUM_LIB=${SODIUM_DIR}\\x64\\Release\\${SODIUM_VER}\\dynamic" >> $GITHUB_ENV
           else
             cygreg=registry32
             pyreg=-32
@@ -413,6 +418,7 @@ jobs:
             echo "WARCH=ia32" >> $GITHUB_ENV
             echo "BITS=32" >> $GITHUB_ENV
             echo "MSYSTEM=MINGW32" >> $GITHUB_ENV
+            echo "SODIUM_LIB=${SODIUM_DIR}\\Win32\\Release\\${SODIUM_VER}\\dynamic" >> $GITHUB_ENV
           fi
 
           echo "VCVARSALL=$(vswhere -products \* -latest -property installationPath)\\VC\\Auxiliary\\Build\\vcvarsall.bat" >> $GITHUB_ENV
@@ -445,6 +451,7 @@ jobs:
           type NUL > urls.txt
           echo %LUA_RELEASE%>> urls.txt
           echo %WINPTY_URL%>> urls.txt
+          echo %SODIUM_URL%>> urls.txt
 
       - name: Cache downloaded files
         uses: actions/cache@v3
@@ -467,6 +474,10 @@ jobs:
           7z x -y downloads\winpty.zip -oD:\winpty > nul || exit 1
           copy /Y D:\winpty\%WARCH%\bin\winpty.dll        src\winpty%BITS%.dll
           copy /Y D:\winpty\%WARCH%\bin\winpty-agent.exe  src\
+
+          echo %COL_GREEN%Download libsodium%COL_RESET%
+          call :downloadfile %SODIUM_URL% downloads\libsodium.zip
+          7z x -y downloads\libsodium.zip -oD:\ > nul || exit 1
 
           goto :eof
 
@@ -498,7 +509,8 @@ jobs:
               GUI=%GUI% IME=yes ICONV=yes VIMDLL=${{ matrix.VIMDLL }} ^
               DYNAMIC_LUA=yes LUA=%LUA_DIR% ^
               DYNAMIC_PYTHON=yes PYTHON=%PYTHON_DIR% ^
-              DYNAMIC_PYTHON3=yes PYTHON3=%PYTHON3_DIR%
+              DYNAMIC_PYTHON3=yes PYTHON3=%PYTHON3_DIR% ^
+              DYNAMIC_SODIUM=yes SODIUM=%SODIUM_DIR%
           ) else (
             nmake -nologo -f Make_mvc.mak ^
               FEATURES=${{ matrix.features }} ^
@@ -566,7 +578,7 @@ jobs:
         shell: cmd
         timeout-minutes: 15
         run: |
-          PATH %LUA_DIR%;C:\msys64\%MSYSTEM%\bin;%PATH%;%PYTHON3_DIR%
+          PATH %LUA_DIR%;C:\msys64\%MSYSTEM%\bin;%PATH%;%PYTHON3_DIR%;%SODIUM_LIB%
           call "%VCVARSALL%" %VCARCH%
 
           echo %COL_GREEN%Test gVim:%COL_RESET%
@@ -583,7 +595,7 @@ jobs:
         shell: cmd
         timeout-minutes: 15
         run: |
-          PATH %LUA_DIR%;C:\msys64\%MSYSTEM%\bin;%PATH%;%PYTHON3_DIR%
+          PATH %LUA_DIR%;C:\msys64\%MSYSTEM%\bin;%PATH%;%PYTHON3_DIR%;%SODIUM_LIB%
           call "%VCVARSALL%" %VCARCH%
 
           echo %COL_GREEN%Test Vim:%COL_RESET%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,10 +371,11 @@ jobs:
       # winpty
       WINPTY_URL: https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip
       # libsodium
-      SODIUM_MSVC_URL: https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip
-      SODIUM_MINGW_URL: https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-mingw.tar.gz
-      SODIUM_DIR: D:\libsodium
-      SODIUM_VER: v143
+      SODIUM_VER: 1.0.18
+      SODIUM_MSVC_URL: https://download.libsodium.org/libsodium/releases/libsodium-%SODIUM_VER%-stable-msvc.zip
+      SODIUM_MSVC_VER: v143
+      SODIUM_MINGW_URL: https://download.libsodium.org/libsodium/releases/libsodium-%SODIUM_VER%-stable-mingw.tar.gz
+      SODIUM_MINGW_VER: 23
       # Escape sequences
       COL_RED: "\x1b[31m"
       COL_GREEN: "\x1b[32m"
@@ -421,8 +422,8 @@ jobs:
           fi
 
           echo "VCVARSALL=$(vswhere -products \* -latest -property installationPath)\\VC\\Auxiliary\\Build\\vcvarsall.bat" >> $GITHUB_ENV
-          if [ "${{ matrix.features }}" != "TINY" ]; then
-            if [ "${{ matrix.arch }}" = "x86" ]; then
+          if ${{ matrix.features != 'TINY' }}; then
+            if ${{ matrix.arch == 'x86' }}; then
               choco install python2 --no-progress --forcex86
             else
               choco install python2 --no-progress
@@ -432,13 +433,17 @@ jobs:
           echo "PYTHON3_DIR=$python3_dir" >> $GITHUB_ENV
 
           if ${{ matrix.toolchain == 'msvc' }}; then
-            echo "SODIUM_LIB=${SODIUM_DIR}\\${{ matrix.arch == 'x64' && 'x64' || 'Win32' }}\\Release\\${SODIUM_VER}\\dynamic" >> $GITHUB_ENV
+            SODIUM_DIR="D:\\libsodium"
+            echo "SODIUM_LIB=${SODIUM_DIR}\\${{ matrix.arch == 'x64' && 'x64' || 'Win32' }}\\Release\\${SODIUM_MSVC_VER}\\dynamic" >> $GITHUB_ENV
             echo "SODIUM_URL=${SODIUM_MSVC_URL}" >> $GITHUB_ENV
+            echo "SODIUM_FILE=libsodium.zip" >> $GITHUB_ENV
           else
-            echo "SODIUM_DIR=${SODIUM_DIR}-win${{ matrix.arch == 'x64' && '64' || '32' }}" >> $GITHUB_ENV
+            SODIUM_DIR=D:\\libsodium-win${{ matrix.arch == 'x64' && '64' || '32' }}
             echo "SODIUM_LIB=${SODIUM_DIR}\\bin" >> $GITHUB_ENV
             echo "SODIUM_URL=${SODIUM_MINGW_URL}" >> $GITHUB_ENV
+            echo "SODIUM_FILE=libsodium.tar.gz" >> $GITHUB_ENV
           fi
+          echo "SODIUM_DIR=${SODIUM_DIR}" >> $GITHUB_ENV
 
       - uses: msys2/setup-msys2@v2
         if: matrix.toolchain == 'mingw'
@@ -484,10 +489,10 @@ jobs:
           copy /Y D:\winpty\%WARCH%\bin\winpty-agent.exe  src\
 
           echo %COL_GREEN%Download libsodium%COL_RESET%
-          call :downloadfile %SODIUM_URL% downloads\libsodium.zip
-          7z x -y downloads\libsodium.zip -oD:\ > nul || exit 1
+          call :downloadfile %SODIUM_URL% downloads\%SODIUM_FILE%
+          7z x -y downloads\%SODIUM_FILE% -oD:\ > nul || exit 1
           if "${{ matrix.toolchain }}"=="mingw" (
-            mklink %SODIUM_LIB%\libsodium.dll %SODIUM_LIB%\libsodium-23.dll
+            mklink %SODIUM_LIB%\libsodium.dll %SODIUM_LIB%\libsodium-%SODIUM_MINGW_VER%.dll
           )
 
           goto :eof

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
       # winpty
       WINPTY_URL: https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip
       # libsodium
-      SODIUM_VER: 1.0.18
+      SODIUM_VER: '1.0.18'
       SODIUM_MSVC_URL: https://download.libsodium.org/libsodium/releases/libsodium-%SODIUM_VER%-stable-msvc.zip
       SODIUM_MSVC_VER: v143
       SODIUM_MINGW_URL: https://download.libsodium.org/libsodium/releases/libsodium-%SODIUM_VER%-stable-mingw.tar.gz
@@ -433,15 +433,11 @@ jobs:
           echo "PYTHON3_DIR=$python3_dir" >> $GITHUB_ENV
 
           if ${{ matrix.toolchain == 'msvc' }}; then
-            SODIUM_DIR="D:\\libsodium"
+            SODIUM_DIR=D:\\libsodium
             echo "SODIUM_LIB=${SODIUM_DIR}\\${{ matrix.arch == 'x64' && 'x64' || 'Win32' }}\\Release\\${SODIUM_MSVC_VER}\\dynamic" >> $GITHUB_ENV
-            echo "SODIUM_URL=${SODIUM_MSVC_URL}" >> $GITHUB_ENV
-            echo "SODIUM_FILE=libsodium.zip" >> $GITHUB_ENV
           else
             SODIUM_DIR=D:\\libsodium-win${{ matrix.arch == 'x64' && '64' || '32' }}
             echo "SODIUM_LIB=${SODIUM_DIR}\\bin" >> $GITHUB_ENV
-            echo "SODIUM_URL=${SODIUM_MINGW_URL}" >> $GITHUB_ENV
-            echo "SODIUM_FILE=libsodium.tar.gz" >> $GITHUB_ENV
           fi
           echo "SODIUM_DIR=${SODIUM_DIR}" >> $GITHUB_ENV
 
@@ -464,7 +460,7 @@ jobs:
           type NUL > urls.txt
           echo %LUA_RELEASE%>> urls.txt
           echo %WINPTY_URL%>> urls.txt
-          echo %SODIUM_URL%>> urls.txt
+          echo %SODIUM_VER%>> urls.txt
 
       - name: Cache downloaded files
         uses: actions/cache@v3
@@ -489,9 +485,12 @@ jobs:
           copy /Y D:\winpty\%WARCH%\bin\winpty-agent.exe  src\
 
           echo %COL_GREEN%Download libsodium%COL_RESET%
-          call :downloadfile %SODIUM_URL% downloads\%SODIUM_FILE%
-          7z x -y downloads\%SODIUM_FILE% -oD:\ > nul || exit 1
-          if "${{ matrix.toolchain }}"=="mingw" (
+          if "${{ matrix.toolchain }}"=="msvc" (
+            call :downloadfile %SODIUM_MSVC_URL% downloads\libsodium.zip
+            7z x -y downloads\libsodium.zip -oD:\ > nul || exit 1
+          ) else (
+            call :downloadfile %SODIUM_MINGW_URL% downloads\libsodium.tar.gz
+            7z x -y downloads\libsodium.tar.gz -so | 7z x -si -ttar -oD:\ > nul || exit 1
             mklink %SODIUM_LIB%\libsodium.dll %SODIUM_LIB%\libsodium-%SODIUM_MINGW_VER%.dll
           )
 


### PR DESCRIPTION
Ref: #12296

Install libsodium to enable `sodium` feature and do related tests in test_crypt.

9.0.1486, `Test_uncrypt_xchacha20v2()` and `Test_uncrypt_xchacha20v2_custom()` in test_crypt fails on x86 environment.