### PR TITLE
improve Device Tree file type support

### DIFF
--- a/runtime/indent/dts.vim
+++ b/runtime/indent/dts.vim
@@ -1,0 +1,63 @@
+" Vim indent file
+" Language:		Device Tree
+" Maintainer:		Roland Hieber, Pengutronix <rhi@pengutronix.de>
+"
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+
+setlocal autoindent
+setlocal nosmartindent
+setlocal indentkeys=o,O,0},0<>>,!<Ctrl-F>
+setlocal indentexpr=GetDTSIndent()
+setlocal nolisp
+
+let b:undo_indent = 'setl autoindent< smartindent< indentkeys< indentexpr< lisp<'
+
+function GetDTSIndent()
+    let sw        = shiftwidth()
+    let lnum      = v:lnum
+    let line      = getline(lnum)
+    let prevline  = getline(prevnonblank(lnum-1))
+    let prevind   = indent(prevnonblank(lnum-1))
+
+    if prevnonblank(lnum-1) < 1
+        return 0
+    endif
+
+    " Don't indent header and preprocessor directives
+    if line =~ '^\s*\(/dts-\|#\(include\|define\|undef\|warn\(ing\)\?\|error\|if\(n\?def\)\?\|else\|elif\|endif\)\)'
+        return 0
+
+    " Don't indent /node and &label blocks
+    elseif line =~ '^\s*[/&].\+{\s*$'
+        return 0
+
+    " Indent to matching bracket or remove one shiftwidth if line begins with } or >
+    elseif line =~ '^\s*[}>]'
+        " set cursor to closing bracket on current line
+        let col = matchend(line, '^\s*[>}]')
+        call cursor(lnum, col)
+        
+        " determine bracket type, {} or <>
+        let pair = strpart('{}<>', stridx('}>', line[col-1]) * 2, 2)
+
+        " find matching bracket pair
+        let pairline = searchpair(pair[0], '', pair[1], 'bW')
+
+        if pairline > 0 
+            return indent(pairline)
+        else
+            return prevind - sw
+        endif
+
+    " else, add one level of indent if line ends in { or < or = or ,
+    elseif prevline =~ '[{<=,]$'
+        return prevind + sw
+
+    else
+        return prevind
+    endif
+
+endfunction

--- a/runtime/indent/testdir/dts.in
+++ b/runtime/indent/testdir/dts.in
@@ -1,0 +1,46 @@
+/* vim: set ft=dts noet sw=8 : */
+
+/* START_INDENT */
+/dts-v1/;
+#include <dt-bindings/pinctrl/pinctrl-imx6q.h>
+	#include "imx6qdl.dtsi"
+#include "imx6qdl-someboard.dtsi"
+
+	/delete-node/ &{/memory@10000000};
+
+	/ {
+compatible = "some,board";
+/delete-node/ memory;
+
+	chosen {
+environment = &{usdhc4/partitions/partition@0};
+};
+}
+
+	&iomuxc {
+pinctrl-names = "default";
+pinctrl-0 = <&pinctrl_hog>;
+
+pinctrl_gpiohog: gpiohoggrp {
+fsl,pins = <
+MX6QDL_PAD_GPIO_9__GPIO1_IO09           0x130b0
+MX6QDL_PAD_GPIO_17__GPIO7_IO12          0x130b0
+>;
+};
+}
+
+&usdhc4 {
+partitions {
+compatible = "fixed-partitions";
+
+partition@0 {
+label = "environment";
+reg = <0x0 0xe0000>;
+};
+};
+};
+
+&{/aliases} {
+usb0 = &usb;
+};
+/* END_INDENT */

--- a/runtime/indent/testdir/dts.ok
+++ b/runtime/indent/testdir/dts.ok
@@ -1,0 +1,46 @@
+/* vim: set ft=dts noet sw=8 : */
+
+/* START_INDENT */
+/dts-v1/;
+#include <dt-bindings/pinctrl/pinctrl-imx6q.h>
+#include "imx6qdl.dtsi"
+#include "imx6qdl-someboard.dtsi"
+
+/delete-node/ &{/memory@10000000};
+
+/ {
+	compatible = "some,board";
+	/delete-node/ memory;
+
+	chosen {
+		environment = &{usdhc4/partitions/partition@0};
+	};
+}
+
+&iomuxc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_hog>;
+
+	pinctrl_gpiohog: gpiohoggrp {
+		fsl,pins = <
+			MX6QDL_PAD_GPIO_9__GPIO1_IO09           0x130b0
+			MX6QDL_PAD_GPIO_17__GPIO7_IO12          0x130b0
+		>;
+	};
+}
+
+&usdhc4 {
+	partitions {
+		compatible = "fixed-partitions";
+
+		partition@0 {
+			label = "environment";
+			reg = <0x0 0xe0000>;
+		};
+	};
+};
+
+&{/aliases} {
+	usb0 = &usb;
+};
+/* END_INDENT */

--- a/runtime/syntax/dts.vim
+++ b/runtime/syntax/dts.vim
@@ -10,9 +10,10 @@ let b:current_syntax = 'dts'
 
 syntax region dtsComment        start="/\*"  end="\*/"
 syntax match  dtsReference      "&[[:alpha:][:digit:]_]\+"
+syntax match  dtsReference      "&{[[:alpha:][:digit:]@_/-]\+}"
 syntax region dtsBinaryProperty start="\[" end="\]"
 syntax match  dtsStringProperty "\".*\""
-syntax match  dtsKeyword        "/.\{-1,\}/"
+syntax match  dtsKeyword        "/[[:alpha:][:digit:]-]\+/\([[:space:]]\|;\)"he=e-1
 syntax match  dtsLabel          "^[[:space:]]*[[:alpha:][:digit:]_]\+:"
 syntax match  dtsNode           /[[:alpha:][:digit:]-_]\+\(@[0-9a-fA-F]\+\|\)[[:space:]]*{/he=e-1
 syntax region dtsCellProperty   start="<" end=">" contains=dtsReference,dtsBinaryProperty,dtsStringProperty,dtsComment


### PR DESCRIPTION
* Add indent definitions for .dts and .dtsi files, because the default autoindent behaviour wrongly unindents properties starting with `#`, e.g. `#address-cells` and `#size-cells`, or labels ending in `:`.
* cc @zonque: Improve syntax highlighting for .dts and .dtsi files to include support for label-relative path references, which were [introduced in dtc 1.7](https://git.kernel.org/pub/scm/utils/dtc/dtc.git/commit/?id=ec7986e682cf9a5078bdbad341feb807a56b21e0). Currently this syntax is matched by the `dtsKeyword` element, so make that more specific to only match directives like `/dtc-v1/`, `/delete-node/` and the like. Screenshots below show before and after states, with an additional `hi link dtsReference Identifier` to distinguish them from other similarly-colored syntax elements.

Before:
![667e2cc6-b795-42e2-8e5b-3d82f94d12e1](https://user-images.githubusercontent.com/192014/234306463-a35561ab-ab4b-4e87-8f8a-cc8b0df880e3.png)

After:
![9e7eff49-df0d-4414-a6e3-8c3d89134ab0](https://user-images.githubusercontent.com/192014/234306445-4cb7c27a-50b8-45eb-acce-a735afb67a2a.png)
