### PR TITLE
Fix remote_startserver() issue

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7314,6 +7314,7 @@ remote_send({server}, {string} [, {idvar}])
 remote_startserver({name})
 		Become the server {name}.  This fails if already running as a
 		server, when |v:servername| is not empty.
+		When {name} is empty string, an error is given.
 
 		Can also be used as a |method|: >
 			ServerName()->remote_startserver()

--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -968,18 +968,15 @@ f_remote_send(typval_T *argvars UNUSED, typval_T *rettv)
 f_remote_startserver(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 {
 #ifdef FEAT_CLIENTSERVER
-    char_u	*server;
-
-    if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
+    if (check_for_nonempty_string_arg(argvars, 0) == FAIL)
 	return;
 
-    server = tv_get_string_chk(&argvars[0]);
-    if (server == NULL)
-	return;		// type error; errmsg already given
     if (serverName != NULL)
 	emsg(_(e_already_started_server));
     else
     {
+	char_u *server = tv_get_string_chk(&argvars[0]);
+
 # ifdef FEAT_X11
 	if (check_connection() == OK)
 	    serverRegisterName(X_DISPLAY, server);

--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -182,7 +182,8 @@ func Test_client_server()
     endif
   endtry
 
-  call assert_fails('call remote_startserver([])', 'E730:')
+  call assert_fails('call remote_startserver("")', 'E1175:')
+  call assert_fails('call remote_startserver([])', 'E1174:')
   call assert_fails("let x = remote_peek([])", 'E730:')
   call assert_fails("let x = remote_read('vim10')",
         \ has('unix') ? ['E573:.*vim10'] : 'E277:')


### PR DESCRIPTION
`remote_startserver()` accepts "".  But `--servername` doesn't accept "".
So I modified remote_startserver() to not accept "".

--
Best regards,
Hirohito Higashi (h_east)