### PR TITLE
Remove incorrect use of W_WINROW

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -525,8 +525,8 @@ edit(
 #else
 		(int)curwin->w_wcol < mincol - curbuf->b_p_ts
 #endif
-		    && curwin->w_wrow == W_WINROW(curwin)
-				 + curwin->w_height - 1 - get_scrolloff_value()
+		    && curwin->w_wrow ==
+				   curwin->w_height - 1 - get_scrolloff_value()
 		    && (curwin->w_cursor.lnum != curwin->w_topline
 #ifdef FEAT_DIFF
 			|| curwin->w_topfill > 0


### PR DESCRIPTION
In structs.h it is mentioned that w_wrow is relative to w_winrow, so
using W_WINROW doesn't make sense when comparing with window height.
