### PR TITLE
Behavior of assert_false('False') is confusing

### DIFF
--- a/src/testdir/test_assert.vim
+++ b/src/testdir/test_assert.vim
@@ -9,11 +9,11 @@ func Test_assert_false()
   call assert_equal(0, v:false->assert_false())
 
   call assert_equal(1, assert_false(123))
-  call assert_match("Expected 'False' but got 123", v:errors[0])
+  call assert_match("Expected False but got 123", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, 123->assert_false())
-  call assert_match("Expected 'False' but got 123", v:errors[0])
+  call assert_match("Expected False but got 123", v:errors[0])
   call remove(v:errors, 0)
 endfunc
 
@@ -24,11 +24,11 @@ func Test_assert_true()
   call assert_equal(0, v:true->assert_true())
 
   call assert_equal(1, assert_true(0))
-  call assert_match("Expected 'True' but got 0", v:errors[0])
+  call assert_match("Expected True but got 0", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, 0->assert_true())
-  call assert_match("Expected 'True' but got 0", v:errors[0])
+  call assert_match("Expected True but got 0", v:errors[0])
   call remove(v:errors, 0)
 endfunc
 

--- a/src/testing.c
+++ b/src/testing.c
@@ -223,9 +223,11 @@ fill_assert_error(
     }
     else
     {
-	ga_concat(gap, (char_u *)"'");
+	if (atype == ASSERT_FAILS)
+	    ga_concat(gap, (char_u *)"'");
 	ga_concat_shorten_esc(gap, exp_str);
-	ga_concat(gap, (char_u *)"'");
+	if (atype == ASSERT_FAILS)
+	    ga_concat(gap, (char_u *)"'");
     }
     if (atype != ASSERT_NOTEQUAL)
     {
@@ -743,7 +745,7 @@ f_assert_fails(typval_T *argvars, typval_T *rettv)
 		actual_tv.vval.v_string = actual;
 	    }
 	    fill_assert_error(&ga, &argvars[2], expected_str,
-			&argvars[error_found_index], &actual_tv, ASSERT_OTHER);
+			&argvars[error_found_index], &actual_tv, ASSERT_FAILS);
 	    ga_concat(&ga, (char_u *)": ");
 	    assert_append_cmd_or_arg(&ga, argvars, cmd);
 	    assert_error(&ga);

--- a/src/vim.h
+++ b/src/vim.h
@@ -2254,6 +2254,7 @@ typedef enum {
     ASSERT_NOTEQUAL,
     ASSERT_MATCH,
     ASSERT_NOTMATCH,
+    ASSERT_FAILS,
     ASSERT_OTHER
 } assert_type_T;
 


### PR DESCRIPTION
Using `assert_false('False')` leaving the following in `v:errors`:

	Expected 'False' but got 'False'

which looks a bit confusing.

Solution:   Only add quotes to expected value when using assert_fails().
