### PR TITLE
{msg} argument of assert_inrange() behaves differently from others

### DIFF
--- a/src/testdir/test_assert.vim
+++ b/src/testdir/test_assert.vim
@@ -9,11 +9,11 @@ func Test_assert_false()
   call assert_equal(0, v:false->assert_false())
 
   call assert_equal(1, assert_false(123))
-  call assert_match("Expected 'False' but got 123", v:errors[0])
+  call assert_match("Expected False but got 123", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, 123->assert_false())
-  call assert_match("Expected 'False' but got 123", v:errors[0])
+  call assert_match("Expected False but got 123", v:errors[0])
   call remove(v:errors, 0)
 endfunc
 
@@ -24,11 +24,11 @@ func Test_assert_true()
   call assert_equal(0, v:true->assert_true())
 
   call assert_equal(1, assert_true(0))
-  call assert_match("Expected 'True' but got 0", v:errors[0])
+  call assert_match("Expected True but got 0", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, 0->assert_true())
-  call assert_match("Expected 'True' but got 0", v:errors[0])
+  call assert_match("Expected True but got 0", v:errors[0])
   call remove(v:errors, 0)
 endfunc
 
@@ -416,8 +416,11 @@ func Test_assert_inrange()
   call remove(v:errors, 0)
 
   " Use a custom message
+  call assert_equal(1, assert_inrange(5, 7, 8, "Higher"))
+  call assert_match("Higher: Expected range 5 - 7, but got 8", v:errors[0])
+  call remove(v:errors, 0)
   call assert_equal(1, assert_inrange(5, 7, 8.0, "Higher"))
-  call assert_match("Higher", v:errors[0])
+  call assert_match("Higher: Expected range 5.0 - 7.0, but got 8.0", v:errors[0])
   call remove(v:errors, 0)
 
   " Invalid arguments

--- a/src/testing.c
+++ b/src/testing.c
@@ -223,9 +223,11 @@ fill_assert_error(
     }
     else
     {
-	ga_concat(gap, (char_u *)"'");
+	if (atype == ASSERT_FAILS)
+	    ga_concat(gap, (char_u *)"'");
 	ga_concat_shorten_esc(gap, exp_str);
-	ga_concat(gap, (char_u *)"'");
+	if (atype == ASSERT_FAILS)
+	    ga_concat(gap, (char_u *)"'");
     }
     if (atype != ASSERT_NOTEQUAL)
     {
@@ -743,7 +745,7 @@ f_assert_fails(typval_T *argvars, typval_T *rettv)
 		actual_tv.vval.v_string = actual;
 	    }
 	    fill_assert_error(&ga, &argvars[2], expected_str,
-			&argvars[error_found_index], &actual_tv, ASSERT_OTHER);
+			&argvars[error_found_index], &actual_tv, ASSERT_FAILS);
 	    ga_concat(&ga, (char_u *)": ");
 	    assert_append_cmd_or_arg(&ga, argvars, cmd);
 	    assert_error(&ga);
@@ -785,9 +787,7 @@ assert_inrange(typval_T *argvars)
 {
     garray_T	ga;
     int		error = FALSE;
-    char_u	*tofree;
-    char	msg[200];
-    char_u	numbuf[NUMBUFLEN];
+    char_u	expected_str[200];
 
     if (argvars[0].v_type == VAR_FLOAT
 	    || argvars[1].v_type == VAR_FLOAT
@@ -800,17 +800,10 @@ assert_inrange(typval_T *argvars)
 	if (factual < flower || factual > fupper)
 	{
 	    prepare_assert_error(&ga);
-	    if (argvars[3].v_type != VAR_UNKNOWN)
-	    {
-		ga_concat(&ga, tv2string(&argvars[3], &tofree, numbuf, 0));
-		vim_free(tofree);
-	    }
-	    else
-	    {
-		vim_snprintf(msg, 200, "Expected range %g - %g, but got %g",
-						      flower, fupper, factual);
-		ga_concat(&ga, (char_u *)msg);
-	    }
+	    vim_snprintf((char *)expected_str, 200, "range %g - %g,",
+							       flower, fupper);
+	    fill_assert_error(&ga, &argvars[3], expected_str, NULL,
+						    &argvars[2], ASSERT_OTHER);
 	    assert_error(&ga);
 	    ga_clear(&ga);
 	    return 1;
@@ -827,17 +820,10 @@ assert_inrange(typval_T *argvars)
 	if (actual < lower || actual > upper)
 	{
 	    prepare_assert_error(&ga);
-	    if (argvars[3].v_type != VAR_UNKNOWN)
-	    {
-		ga_concat(&ga, tv2string(&argvars[3], &tofree, numbuf, 0));
-		vim_free(tofree);
-	    }
-	    else
-	    {
-		vim_snprintf(msg, 200, "Expected range %ld - %ld, but got %ld",
-				       (long)lower, (long)upper, (long)actual);
-		ga_concat(&ga, (char_u *)msg);
-	    }
+	    vim_snprintf((char *)expected_str, 200, "range %ld - %ld,",
+						     (long)lower, (long)upper);
+	    fill_assert_error(&ga, &argvars[3], expected_str, NULL,
+						    &argvars[2], ASSERT_OTHER);
 	    assert_error(&ga);
 	    ga_clear(&ga);
 	    return 1;

--- a/src/vim.h
+++ b/src/vim.h
@@ -2254,6 +2254,7 @@ typedef enum {
     ASSERT_NOTEQUAL,
     ASSERT_MATCH,
     ASSERT_NOTMATCH,
+    ASSERT_FAILS,
     ASSERT_OTHER
 } assert_type_T;
 


### PR DESCRIPTION
In assert_inrange(), the {msg} argument replaces the default message,
whereas in other assert functions {msg} is prepended to the default
message.

This PR changes the behavior of assert_inrange() to also prepend {msg}
to the default message by using fill_assert_error().

However, the help for all assert function seems to suggest that {msg}
replaces the default message. Maybe this needs change?

This PR is a superset of #12341.
