### PR TITLE
Some error messages are not translated

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -1269,7 +1269,7 @@ del_bytes(
     // If "count" is negative the caller must be doing something wrong.
     if (count < 1)
     {
-	siemsg(e_invalid_count_for_del_bytes_nr, count);
+	siemsg(_(e_invalid_count_for_del_bytes_nr), count);
 	return FAIL;
     }
 

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -3313,7 +3313,7 @@ save_clear_shm_value(void)
 {
     if (STRLEN(p_shm) >= SHM_LEN)
     {
-	iemsg(e_internal_error_shortmess_too_long);
+	iemsg(_(e_internal_error_shortmess_too_long));
 	return;
     }
 

--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -1526,7 +1526,7 @@ pum_show_popupmenu(vimmenu_T *menu)
     // pum_size being zero.
     if (pum_size <= 0)
     {
-	emsg(e_menu_only_exists_in_another_mode);
+	emsg(_(e_menu_only_exists_in_another_mode));
 	return;
     }
 

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -2126,7 +2126,7 @@ f_getscriptinfo(typval_T *argvars, typval_T *rettv)
 		return;
 	    if (sid <= 0)
 	    {
-		semsg(e_invalid_value_for_argument_str_str, "sid",
+		semsg(_(e_invalid_value_for_argument_str_str), "sid",
 						tv_get_string(&sid_di->di_tv));
 		return;
 	    }

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2156,7 +2156,7 @@ compile_assign_unlet(
 	dest_type = lhs->lhs_type->tt_type;
 	if (dest_type == VAR_DICT && range)
 	{
-	    emsg(e_cannot_use_range_with_dictionary);
+	    emsg(_(e_cannot_use_range_with_dictionary));
 	    return FAIL;
 	}
 	if (dest_type == VAR_DICT


### PR DESCRIPTION
Not sure about the two changes for internal error messages, as there are
other internal error messages without an error number that are not
translated.
