### PR TITLE
`term_start()` segfaults when passing `{term_cols: -1}`

### DIFF
--- a/src/job.c
+++ b/src/job.c
@@ -444,10 +444,19 @@ get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2)
 	    }
 	    else if (STRCMP(hi->hi_key, "term_cols") == 0)
 	    {
+		int error = FALSE;
+
 		if (!(supported2 & JO2_TERM_COLS))
 		    break;
 		opt->jo_set2 |= JO2_TERM_COLS;
-		opt->jo_term_cols = tv_get_number(item);
+		opt->jo_term_cols = tv_get_number_chk(item, &error);
+		if (error)
+		    return FAIL;
+		if (opt->jo_term_cols < 0 || opt->jo_term_cols > 1000)
+		{
+		    semsg(_(e_invalid_value_for_argument_str), "term_cols");
+		    return FAIL;
+		}
 	    }
 	    else if (STRCMP(hi->hi_key, "vertical") == 0)
 	    {


### PR DESCRIPTION
Vim segfaults when calling `term_start()` with a negative value `term_cols`. This PR adds a value-range check for `term_cols` as the same as `term_rows`.

**Steps to reproduce**
```vim
:call term_start(&shell, #{term_cols: -1})
```


    Thread 1 "vim" received signal SIGSEGV, Segmentation fault.
    0x0000559951fb5eef in vterm_allocator_free (vt=0x559c0a83acdf, ptr=0x5599531f4bc0) at libvterm/src/vterm.c:124
    124         (*vt->allocator->free)(ptr, vt->allocdata);
    (gdb) bt
    #0  0x0000559951fb5eef in vterm_allocator_free (vt=0x559c0a83acdf, ptr=0x5599531f4bc0) at libvterm/src/vterm.c:124
    #1  0x0000559951fadd38 in vterm_state_free (state=0x5599531cfc60) at libvterm/src/state.c:109
    #2  0x0000559951fb5e5a in vterm_free (vt=0x5599531670c0) at libvterm/src/vterm.c:105
    #3  0x0000559951f1ec9b in term_free_vterm (term=0x55995313a590) at terminal.c:7690
    #4  0x0000559951f127a0 in free_unused_terminals () at terminal.c:1118
    #5  0x0000559951dac87e in parse_queued_messages () at getchar.c:2368
    #6  0x0000559951f34ab7 in inchar_loop (buf=0x559952098a10 <typebuf_init+80> "", maxlen=61, wtime=-1, tb_change_cnt=25, wait_func=0x559951e43840 <WaitForChar>, resize_func=0x559951e3e26a <resize_func>) at ui.c:298
    #7  0x0000559951e3e2d3 in mch_inchar (buf=0x559952098a10 <typebuf_init+80> "", maxlen=61, wtime=-1, tb_change_cnt=25) at os_unix.c:407
    #8  0x0000559951f349f9 in ui_inchar (buf=0x559952098a10 <typebuf_init+80> "", maxlen=61, wtime=-1, tb_change_cnt=25) at ui.c:232
    #9  0x0000559951daed27 in inchar (buf=0x559952098a10 <typebuf_init+80> "", maxlen=184, wait_time=-1) at getchar.c:3804
    #10 0x0000559951dae8c2 in vgetorpeek (advance=1) at getchar.c:3584
    #11 0x0000559951daba45 in vgetc () at getchar.c:1774
    #12 0x0000559951dac139 in safe_vgetc () at getchar.c:2025
    #13 0x0000559951e13602 in normal_cmd (oap=0x7ffc9d6596f0, toplevel=1) at normal.c:751
    #14 0x0000559951fdb8c4 in main_loop (cmdwin=0, noexmode=0) at main.c:1539
    #15 0x0000559951fdacde in vim_main2 () at main.c:887
    #16 0x0000559951fda4b6 in main (argc=1, argv=0x7ffc9d659918) at main.c:433
    (gdb)

**Expected behaviour**

Vim shall not segfault and should report an error for an invalid argument.

**Version of Vim**

    VIM - Vi IMproved 9.0 (2022 Jun 28, compiled May  9 2023 01:02:50)
    Included patches: 1-1524

**Environment**

OS: Linux
Terminal: Alacritty
value of $TERM: alacrity
shell: zsh