### PR TITLE
Add USD filetype detection

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2743,6 +2743,9 @@ au BufNewFile,BufRead .login*,.cshrc*  call dist#ft#CSH()
 " tmux configuration with arbitrary extension
 au BufNewFile,BufRead {.,}tmux*.conf*		setf tmux
 
+" Universal Scene Description
+au BufNewFile,BufRead *.usda,*.usd		setf usd
+
 " VHDL
 au BufNewFile,BufRead *.vhdl_[0-9]*		call s:StarSetf('vhdl')
 

--- a/runtime/ftplugin/usd.vim
+++ b/runtime/ftplugin/usd.vim
@@ -1,0 +1,18 @@
+" Vim filetype plugin file
+" Language:     Pixar Animation's Universal Scene Description format
+" Maintainer:   Colin Kennedy <colinvfx@gmail.com>
+" Last Change:  2023 May 9
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let b:did_ftplugin = 1
+
+setlocal commentstring=#\ %s
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -638,6 +638,7 @@ let s:filename_checks = {
     \ 'upstreamdat': ['upstream.dat', 'UPSTREAM.DAT', 'upstream.file.dat', 'UPSTREAM.FILE.DAT', 'file.upstream.dat', 'FILE.UPSTREAM.DAT'],
     \ 'upstreaminstalllog': ['upstreaminstall.log', 'UPSTREAMINSTALL.LOG', 'upstreaminstall.file.log', 'UPSTREAMINSTALL.FILE.LOG', 'file.upstreaminstall.log', 'FILE.UPSTREAMINSTALL.LOG'],
     \ 'upstreamlog': ['fdrupstream.log', 'upstream.log', 'UPSTREAM.LOG', 'upstream.file.log', 'UPSTREAM.FILE.LOG', 'file.upstream.log', 'FILE.UPSTREAM.LOG', 'UPSTREAM-file.log', 'UPSTREAM-FILE.LOG'],
+    \ 'usd': ['file.usda', 'file.usd'],
     \ 'usserverlog': ['usserver.log', 'USSERVER.LOG', 'usserver.file.log', 'USSERVER.FILE.LOG', 'file.usserver.log', 'FILE.USSERVER.LOG'],
     \ 'usw2kagtlog': ['usw2kagt.log', 'USW2KAGT.LOG', 'usw2kagt.file.log', 'USW2KAGT.FILE.LOG', 'file.usw2kagt.log', 'FILE.USW2KAGT.LOG'],
     \ 'vala': ['file.vala'],


### PR DESCRIPTION
This PR adds filetype recognition for [USD](https://www.pixar.com/usd) files. USD was developed by Pixar Animation Studios but it's extremely pervasive in VFX, 3D animation, and more recently, games. I was hoping to keep this PR small for a first pass but if syntax highlighting and other features are desired please let me know and I can add them. If highlighting in particular is desired, there's an existing https://github.com/superfunc/usda-syntax repository that was released with an MIT license that we could use as a base.

About USD's file extensions, I'd like to mention something briefly.

USD has 4 standardized file extensions

- `.usd` - This could be text or binary
- `.usda` - This is always text
- `.usdc` - This is always binary
- `.usdz` - This is a gzipped archive and not text

In this PR I figured "explicit text files only is preferred" so I've included just `.usda` and `.usd` for the file type detection.

### About the .usd filetype
Because it can be text or binary, I have a some personal autocmd that will, if it detects that the .usd is binary, convert it to text and set the filetype accordingly and then, on BufWritePost, convert the changes back to binary. Inspired by Vim's documentation (`:help gzip-example`). And I also do that for .usdc files too. If you consider that a personal configuration then I'll leave it there but wanted to mention it in case there was a desire to upstream.