### PR TITLE
CI: handle download of linux-module better

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,9 +185,9 @@ jobs:
           else
           sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }}
           sudo dpkg -x /var/cache/apt/archives/linux-modules-extra-${{ env.LINUX_VERSION }}*.deb "${DEST_DIR}"
-          tar -cC "${DEST_DIR}"/lib/modules/${{ env.LINUX_VERSION }} kernel/sound | sudo tar -x
-          sudo depmod
-          sudo modprobe snd-dummy
+          tar -cvC "${DEST_DIR}"/lib/modules/${{ env.LINUX_VERSION }} kernel/sound | sudo tar -x
+          sudo depmod --verbose
+          sudo modprobe --verbose snd-dummy
           fi
 
       - name: Check autoconf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           DEST_DIR: ${{ env.TMPDIR }}/linux-modules-extra-${{ env.LINUX_VERSION }}
         run: |
           cd /lib/modules/${{ env.LINUX_VERSION }}
-          if [ sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }} 2>&1 | grep "Unable to locate package " ]; then
+          if [ sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }} 2>&1 | $(grep "Unable to locate package ") ]; then
           echo "Download of " linux-modules-extra-${{ env.LINUX_VERSION }} "failed continue anyway" exit 0
           else
           sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,18 +174,21 @@ jobs:
           sudo usermod -a -G audio "${USER}"
           sudo bash ci/setup-xvfb.sh
 
-      # FIXME: Temporarily disabled because of build errors
-      # - name: Set up snd-dummy
-      #   if: (!(contains(matrix.extra, 'unittests') || contains(matrix.extra, 'vimtags')))
-      #   env:
-      #     DEST_DIR: ${{ env.TMPDIR }}/linux-modules-extra-${{ env.LINUX_VERSION }}
-      #   run: |
-      #     cd /lib/modules/${{ env.LINUX_VERSION }}
-      #     sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }}
-      #     sudo dpkg -x /var/cache/apt/archives/linux-modules-extra-${{ env.LINUX_VERSION }}*.deb "${DEST_DIR}"
-      #     tar -cC "${DEST_DIR}"/lib/modules/${{ env.LINUX_VERSION }} kernel/sound | sudo tar -x
-      #     sudo depmod
-      #     sudo modprobe snd-dummy
+      - name: Set up snd-dummy
+        if: (!(contains(matrix.extra, 'unittests') || contains(matrix.extra, 'vimtags')))
+        env:
+          DEST_DIR: ${{ env.TMPDIR }}/linux-modules-extra-${{ env.LINUX_VERSION }}
+        run: |
+          cd /lib/modules/${{ env.LINUX_VERSION }}
+          if [ sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }} 2>&1 | grep "Unable to locate package " ]; then
+          echo "Download of " linux-modules-extra-${{ env.LINUX_VERSION }} "failed continue anyway" exit 0
+          else
+          sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }}
+          sudo dpkg -x /var/cache/apt/archives/linux-modules-extra-${{ env.LINUX_VERSION }}*.deb "${DEST_DIR}"
+          tar -cC "${DEST_DIR}"/lib/modules/${{ env.LINUX_VERSION }} kernel/sound | sudo tar -x
+          sudo depmod
+          sudo modprobe snd-dummy
+          fi
 
       - name: Check autoconf
         if: contains(matrix.extra, 'unittests')


### PR DESCRIPTION
In some case they will be no sound test if the `linux-module` pkg is not available, the CI will continue anyway.