### PR TITLE
Text is not always scrolled when cursor is moved off-screen.

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -2734,6 +2734,7 @@ oneleft(void)
 	}
 
 	curwin->w_set_curswant = TRUE;
+	adjust_skipcol();
 	return OK;
     }
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -5762,6 +5762,7 @@ nv_g_home_m_cmd(cmdarg_T *cap)
 	curwin->w_valid &= ~VALID_WCOL;
     }
     curwin->w_set_curswant = TRUE;
+    adjust_skipcol();
 }
 
 /*

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -419,6 +419,18 @@ func Test_smoothscroll_cursor_position()
   exe "normal \<C-Y>"
   call s:check_col_calc(1, 3, 41)
 
+  " Test "g0/g<Home>"
+  exe "normal gg\<C-E>"
+  norm $gkg0
+  call s:check_col_calc(1, 2, 21)
+
+  " Test moving the cursor behind the <<< display with 'virtualedit'
+  set virtualedit=all
+  exe "normal \<C-E>"
+  norm 3lgkh
+  call s:check_col_calc(3, 2, 23)
+  set virtualedit&
+
   normal gg3l
   exe "normal \<C-E>"
 


### PR DESCRIPTION
Problem:    The scroll position is not adjusted when pressing "g0" on a
            smooth-scrolled line and when pressing "h" when 'virtualedit'
            is enabled.
Solution:   Adjust "w_skipcol" when the cursor position becomes invalid.
            (issue #12386)