### PR TITLE
Correctly check if the linux-modules-extra package exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,8 @@ jobs:
           DEST_DIR: ${{ env.TMPDIR }}/linux-modules-extra-${{ env.LINUX_VERSION }}
         run: |
           cd /lib/modules/${{ env.LINUX_VERSION }}
-          if [ sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }} 2>&1 | $(grep "Unable to locate package ") ]; then
-          echo "Download of " linux-modules-extra-${{ env.LINUX_VERSION }} "failed continue anyway" exit 0
+          if apt-cache show linux-modules-extra-${{ env.LINUX_VERSION }} >/dev/null 2>&1 ; then
+          echo "Module " linux-modules-extra-${{ env.LINUX_VERSION }} "doesn't seem to exist, continue anyway"; exit 0
           else
           sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }}
           sudo dpkg -x /var/cache/apt/archives/linux-modules-extra-${{ env.LINUX_VERSION }}*.deb "${DEST_DIR}"


### PR DESCRIPTION
commit e741f039cf46ccfbdaaa274618810787129d152b re-enabled the sound-dummy modules in the CI.

Unfortunately, the commit does not correctly check whether the linux-modules-extra- package exist, and so the CI throws an error
```
/home/runner/work/_temp/8c235aad-f1bd-4bdc-adcc-308dd3c8d320.sh: line 2: ]: command not found
```
e.g. here: https://github.com/vim/vim/actions/runs/4961614845/jobs/8878622463#step:8:30

So instead, properly check, whether apt-cache shows is able to show the package description. We do not need the shell test builtin

  if [ ... ]; then ... fi

because `if` can directly check the return value of the given command, which makes the test slightly easier to understand.