### PR TITLE
CI: use more recent gcc 12 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,10 @@ jobs:
       - name: Install gcc-${{ env.GCC_VER }}
         if:  matrix.compiler == 'gcc'
         run: |
-          sudo apt-get install -y gcc-${{ env.GCC_VER }}
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VER }} 100
-          sudo update-alternatives --set gcc /usr/bin/gcc-${{ env.GCC_VER }}
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew install gcc@${{ env.GCC_VER }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /home/linuxbrew/.linuxbrew/bin/gcc-${{ env.GCC_VER }} 100
+          sudo update-alternatives --set gcc /home/linuxbrew/.linuxbrew/bin/gcc-${{ env.GCC_VER }}
 
       - name: Install clang-${{ env.CLANG_VER }}
         if: matrix.compiler == 'clang'


### PR DESCRIPTION
- gcc 12.3.0 (current latest 12 Version) is been installed via brew
- linked to gcc