### PR TITLE
'smoothscroll' marker handling is incomplete

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -568,8 +568,8 @@ changed_common(
 			    && wp->w_topline < lnume
 			    && win_linetabsize(wp, wp->w_topline,
 					ml_get(wp->w_topline), (colnr_T)MAXCOL)
-				    <= wp->w_skipcol + (wp->w_p_list
-					    && wp->w_lcs_chars.prec ? 1 : 3))))
+				    <= wp->w_skipcol + marker_overlap(wp,
+					win_col_off(wp) - win_col_off2(wp)))))
 		wp->w_skipcol = 0;
 
 	    // Check if a change in the buffer has invalidated the cached

--- a/src/proto/move.pro
+++ b/src/proto/move.pro
@@ -49,4 +49,5 @@ void cursor_correct(void);
 int onepage(int dir, long count);
 void halfpage(int flag, linenr_T Prenum);
 void do_check_cursorbind(void);
+int marker_overlap(win_T *wp, int extra2);
 /* vim: set ft=c : */

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -426,8 +426,7 @@ func Test_smoothscroll_cursor_position()
 
   " Test moving the cursor behind the <<< display with 'virtualedit'
   set virtualedit=all
-  exe "normal \<C-E>"
-  norm 3lgkh
+  exe "normal \<C-E>3lgkh"
   call s:check_col_calc(3, 2, 23)
   set virtualedit&
 
@@ -497,6 +496,16 @@ func Test_smoothscroll_cursor_position()
   call s:check_col_calc(1, 2, 37)
   exe "normal \<C-Y>"
   call s:check_col_calc(1, 3, 37)
+  normal gg
+
+  " Test list + listchars "precedes", where there is always 1 overlap
+  " regardless of number and cpo-=n.
+  setl number list listchars=precedes:< cpo-=n
+  call s:check_col_calc(5, 1, 1)
+  exe "normal 2|\<C-E>"
+  call s:check_col_calc(6, 1, 18)
+  norm h
+  call s:check_col_calc(5, 2, 17)
   normal gg
 
   bwipe!


### PR DESCRIPTION
Problem:    'smoothscroll' marker overlap calculation is not always used
            and does not account for 'list' and 'listchars' "precedes".
Solution:   Add 'list' and 'listchars' "precedes" to the 'smoothscroll'
            marker calculation and use it in more places.