### PR TITLE
Use int64_t for nanosecond calculation

### DIFF
--- a/src/profiler.c
+++ b/src/profiler.c
@@ -123,10 +123,10 @@ profile_setlimit(long msec, proftime_T *tm)
 	QueryPerformanceFrequency(&fr);
 	tm->QuadPart += (LONGLONG)((double)msec / 1000.0 * (double)fr.QuadPart);
 # else
-	int64_t	    fsec;
+	varnumber_T	    fsec;
 
 	PROF_GET_TIME(tm);
-	fsec = (int64_t)tm->tv_fsec + (int64_t)msec * (int64_t)(TV_FSEC_SEC / 1000);
+	fsec = (varnumber_T)tm->tv_fsec + (varnumber_T)msec * (varnumber_T)(TV_FSEC_SEC / 1000);
 	tm->tv_fsec = fsec % (long)TV_FSEC_SEC;
 	tm->tv_sec += fsec / (long)TV_FSEC_SEC;
 # endif

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -123,10 +123,10 @@ profile_setlimit(long msec, proftime_T *tm)
 	QueryPerformanceFrequency(&fr);
 	tm->QuadPart += (LONGLONG)((double)msec / 1000.0 * (double)fr.QuadPart);
 # else
-	long	    fsec;
+	int64_t	    fsec;
 
 	PROF_GET_TIME(tm);
-	fsec = (long)tm->tv_fsec + (long)msec * (TV_FSEC_SEC / 1000);
+	fsec = (int64_t)tm->tv_fsec + (int64_t)msec * (int64_t)(TV_FSEC_SEC / 1000);
 	tm->tv_fsec = fsec % (long)TV_FSEC_SEC;
 	tm->tv_sec += fsec / (long)TV_FSEC_SEC;
 # endif


### PR DESCRIPTION
In src/profiler.c, profie_setlimit() assign multiplied nanosecond to (long)fsec.
For 32-bit cpu (ac_cv_sizeof_long=4), this cause many testdir/test_FEATNAME.vim fails:
 runtest.vim -> RunTheTest() -> timer_start(30000,'TestTimeout') -> profile_setlimit(30000,tm)
 -> (long)fsec = 30*10^9  ( > 2^35). Overflowed fsec is negative, assume time has passed.
Same as MSWIN (LONGLONG, double), use int64_t for nanosecond.

