### PR TITLE
correcting makefiles for patch 9.0.1537

### DIFF
--- a/src/po/Make_cyg.mak
+++ b/src/po/Make_cyg.mak
@@ -64,10 +64,12 @@ PO_INPUTLIST = \
 	vim.desktop.in
 
 PO_VIM_INPUTLIST = \
-	../../runtime/optwin.vim
+	../../runtime/optwin.vim \
+	../../runtime/defaults.vim
 
 PO_VIM_JSLIST = \
-	optwin.js
+	optwin.js \
+	defaults.js
 
 first_time: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
 	$(VIM) -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)

--- a/src/po/Make_ming.mak
+++ b/src/po/Make_ming.mak
@@ -77,10 +77,12 @@ PO_INPUTLIST = \
 	vim.desktop.in
 
 PO_VIM_INPUTLIST = \
-	../../runtime/optwin.vim
+	../../runtime/optwin.vim \
+	../../runtime/defaults.vim
 
 PO_VIM_JSLIST = \
-	optwin.js
+	optwin.js \
+	defaults.js
 
 first_time: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
 	$(VIM) -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)

--- a/src/po/Make_mvc.mak
+++ b/src/po/Make_mvc.mak
@@ -54,20 +54,21 @@ PO_INPUTLIST = \
 	vim.desktop.in
 
 PO_VIM_INPUTLIST = \
-	..\..\runtime\optwin.vim
+	..\..\runtime\optwin.vim \
+	..\..\runtime\defaults.vim
 
 PO_VIM_JSLIST = \
-	optwin.js
+	optwin.js \
+	defaults.js
 
-files: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
+files: $(PO_INPUTLIST)
 	$(LS) $(LSFLAGS) $(PO_INPUTLIST) > .\files
-	echo $(PO_VIM_JSLIST)>> .\files
 
 first_time: files
 	$(VIM) -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
 	set OLD_PO_FILE_INPUT=yes
 	set OLD_PO_FILE_OUTPUT=yes
-	$(XGETTEXT) --default-domain=$(LANGUAGE) --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2 --files-from=.\files
+	$(XGETTEXT) --default-domain=$(LANGUAGE) --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2 --files-from=.\files $(PO_VIM_JSLIST)
 	$(VIM) -u NONE --not-a-term -S fixfilenames.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
 	$(RM) *.js
 
@@ -75,7 +76,7 @@ $(PACKAGE).pot: files
 	$(VIM) -u NONE --not-a-term -S tojavascript.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
 	set OLD_PO_FILE_INPUT=yes
 	set OLD_PO_FILE_OUTPUT=yes
-	$(XGETTEXT) --default-domain=$(PACKAGE) --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2 --files-from=.\files
+	$(XGETTEXT) --default-domain=$(PACKAGE) --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2 --files-from=.\files $(PO_VIM_JSLIST)
 	$(MV) $(PACKAGE).po $(PACKAGE).pot
 	$(VIM) -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
 	$(RM) *.js


### PR DESCRIPTION
Changed makefiles according to patch 9.0.1537
The path to the defaults.vim file has been added to the PO_VIM_INPUTLIST variable.
Name defaults.js was added to the PO_VIM_JLIST variable.
The "files" rule has been changed in the Make_mc.mak file. And the $(PO_VIM_JSLIST) variable has been added for xgettext.