### PR TITLE
GvimExt: Use UTF-8 for gettext

### DIFF
--- a/src/GvimExt/Make_ming.mak
+++ b/src/GvimExt/Make_ming.mak
@@ -43,9 +43,9 @@ else
 DEL = del
 endif
 endif
-# Set the default $(WINVER) to make it work with WinXP.
+# Set the default $(WINVER) to make it work with Windows 7.
 ifndef WINVER
-WINVER = 0x0501
+WINVER = 0x0601
 endif
 CXX := $(CROSS_COMPILE)g++
 WINDRES := $(CROSS_COMPILE)windres

--- a/src/GvimExt/Make_mvc.mak
+++ b/src/GvimExt/Make_mvc.mak
@@ -8,10 +8,11 @@
 TARGETOS = WINNT
 
 !ifndef APPVER
-APPVER = 5.01
+APPVER = 6.01
 !endif
+# Set the default $(WINVER) to make it work with Windows 7.
 !ifndef WINVER
-WINVER = 0x0501
+WINVER = 0x0601
 !endif
 
 !if "$(DEBUG)" != "yes"
@@ -40,9 +41,9 @@ CPU = i386
 !endif
 
 !ifdef SDK_INCLUDE_DIR
-!include $(SDK_INCLUDE_DIR)\Win32.mak
+! include $(SDK_INCLUDE_DIR)\Win32.mak
 !elseif "$(USE_WIN32MAK)"=="yes"
-!include <Win32.mak>
+! include <Win32.mak>
 !else
 cc = cl
 link = link

--- a/src/GvimExt/gvimext.h
+++ b/src/GvimExt/gvimext.h
@@ -81,21 +81,20 @@ DEFINE_GUID(CLSID_ShellExtension, 0x51eee242, 0xad87, 0x11d3, 0x9c, 0x1e, 0x0, 0
 class CShellExtClassFactory : public IClassFactory
 {
 protected:
-	ULONG	m_cRef;
+    ULONG	m_cRef;
 
 public:
-	CShellExtClassFactory();
-	~CShellExtClassFactory();
+    CShellExtClassFactory();
+    ~CShellExtClassFactory();
 
-	//IUnknown members
-	STDMETHODIMP			QueryInterface(REFIID, LPVOID FAR *);
-	STDMETHODIMP_(ULONG)	AddRef();
-	STDMETHODIMP_(ULONG)	Release();
+    //IUnknown members
+    STDMETHODIMP		QueryInterface(REFIID, LPVOID FAR *);
+    STDMETHODIMP_(ULONG)	AddRef();
+    STDMETHODIMP_(ULONG)	Release();
 
-	//IClassFactory members
-	STDMETHODIMP		CreateInstance(LPUNKNOWN, REFIID, LPVOID FAR *);
-	STDMETHODIMP		LockServer(BOOL);
-
+    //IClassFactory members
+    STDMETHODIMP		CreateInstance(LPUNKNOWN, REFIID, LPVOID FAR *);
+    STDMETHODIMP		LockServer(BOOL);
 };
 typedef CShellExtClassFactory *LPCSHELLEXTCLASSFACTORY;
 #define MAX_HWND 100


### PR DESCRIPTION
Closes #12431

* Use bind_textdomain_codeset() to use UTF-8.
   Set to UTF-8 before using _(), and restore to original encoding after using it.
* Use Wide functions to handle the menu strings. (ANSI functions are still used in other part.)
* Fix size checking in CShellExt::GetCommandString(). Stop using the hard-coded size.
* Adjust indentation.
* Change WINVER for Windows 7.