### PR TITLE
Require quickfix filename to always be valid

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -972,13 +972,7 @@ qf_parse_fmt_f(regmatch_T *rmp, int midx, qffields_T *fields, int prefix)
     expand_env(rmp->startp[midx], fields->namebuf, CMDBUFFSIZE);
     *rmp->endp[midx] = c;
 
-    // For separate filename patterns (%O, %P and %Q), the specified file
-    // should exist.
-    if (vim_strchr((char_u *)"OPQ", prefix) != NULL
-	    && mch_getperm(fields->namebuf) == -1)
-	return QF_FAIL;
-
-    return QF_OK;
+    return mch_getperm(fields->namebuf) == -1 ? QF_FAIL : QF_OK;
 }
 
 /*

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -959,7 +959,7 @@ typedef struct {
  * Return the matched value in "fields->namebuf".
  */
     static int
-qf_parse_fmt_f(regmatch_T *rmp, int midx, qffields_T *fields, int prefix)
+qf_parse_fmt_f(regmatch_T *rmp, int midx, qffields_T *fields)
 {
     int c;
 
@@ -972,6 +972,7 @@ qf_parse_fmt_f(regmatch_T *rmp, int midx, qffields_T *fields, int prefix)
     expand_env(rmp->startp[midx], fields->namebuf, CMDBUFFSIZE);
     *rmp->endp[midx] = c;
 
+    // The specified file should exist.
     return mch_getperm(fields->namebuf) == -1 ? QF_FAIL : QF_OK;
 }
 
@@ -1255,7 +1256,7 @@ qf_parse_match(
 	status = QF_OK;
 	midx = (int)fmt_ptr->addr[i];
 	if (i == 0 && midx > 0)				// %f
-	    status = qf_parse_fmt_f(regmatch, midx, fields, idx);
+	    status = qf_parse_fmt_f(regmatch, midx, fields);
 	else if (i == FMT_PATTERN_M)
 	{
 	    if (fmt_ptr->flags == '+' && !qf_multiscan)	// %+


### PR DESCRIPTION
The cases where the file name is not valid are usually misparses of compiler output - e.g., thinking that "make: *** [Makefile" is a filename. Vim also already requires the file to exist with %O, %P, and %Q; this patch simply makes the check apply in all cases.

The behavior of opening a garbage buffer with a nonsensical name is annoying. Vim presumes the user will look for and fix errors in that file, but Vim already knows the buffer will be empty.