### PR TITLE
CI: Fix indenttest on FreeBSD

### DIFF
--- a/runtime/indent/testdir/runtest.vim
+++ b/runtime/indent/testdir/runtest.vim
@@ -12,6 +12,7 @@ set nowrapscan
 set report=9999
 set modeline
 set debug=throw
+set nomore
 
 au! SwapExists * call HandleSwapExists()
 func HandleSwapExists()


### PR DESCRIPTION
### Problem

Cirrus CI on FreeBSD fails at indenttest.

### Cause

At commit https://github.com/vim/vim/commit/b7398fe41c9e1e731d058105a34158871ee83e3f, by indent/dts added,the number of the tests in indenttest is 12 so the output of indenttest is 24 lines.
Thus, when the terminal line is 25 or less and depending on the terminal settings (termcap/terminfo), 'more' prompt is displayed just after the indent testing so then the test stops. 

e.g. on linux

Set the terminal to 25 lines and:
```
export TERM=ansi
make indenttest
```

`TERM` on FreeBSD is `xterm`, but FreeBSD's `xterm` setting (termcap) encounters this problem and the test is timedout.

## Solution

Add `set nomore` to indent/runtest.vim.

