### PR TITLE
Corn configuration files are not recognised

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -319,6 +319,9 @@ au BufNewFile,BufRead *.cdl			setf cdl
 " Conary Recipe
 au BufNewFile,BufRead *.recipe			setf conaryrecipe
 
+" Corn config file
+au BufNewFile,BufRead *.corn			setf corn
+
 " ChainPack Object Notation (CPON)
 au BufNewFile,BufRead *.cpon			setf cpon
 

--- a/runtime/ftplugin/corn.vim
+++ b/runtime/ftplugin/corn.vim
@@ -1,0 +1,19 @@
+" Vim filetype plugin
+" Language:         Corn
+" Original Author:  Jake Stanger (mail@jstanger.dev) 
+" License:          MIT
+" Last Change:      2023 May 26
+
+if exists('b:did_ftplugin')
+  finish
+else
+  let b:did_ftplugin = 1
+endif
+
+setlocal formatoptions-=t
+
+" Set comment (formatting) related options. {{{1
+setlocal commentstring=// %s comments=:// 
+
+" Let Vim know how to disable the plug-in.
+let b:undo_ftplugin = 'setlocal commentstring< comments< formatoptions<'


### PR DESCRIPTION
Problem: Corn configuration files are not recognised. 
Solution: Add a pattern to detect '*.corn' files. Add basic ftplugin support.

---

Corn: <https://github.com/jakestanger/corn>