### PR TITLE
Invalid line pointer used after patch 9.0.1585

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -2197,12 +2197,10 @@ win_update(win_T *wp)
 #ifdef FEAT_SPELL
     // Initialize spell related variables for the first drawn line.
     CLEAR_FIELD(spv);
-    spv.spv_has_spell = spell_check_window(wp);
-    if (spv.spv_has_spell)
+    if (spell_check_window(wp))
     {
+	spv.spv_has_spell = TRUE;
 	spv.spv_unchanged = mod_top == 0;
-	spv.spv_capcol_lnum = mod_top ? mod_top : lnum;
-	spv.spv_cap_col = check_need_cap(wp, spv.spv_capcol_lnum, 0) ? 0 : - 1;
     }
 #endif
 
@@ -2464,19 +2462,13 @@ win_update(win_T *wp)
 		fold_line(wp, fold_count, &win_foldinfo, lnum, row);
 		++row;
 		--fold_count;
-		linenr_T lnume = lnum + fold_count;
 		wp->w_lines[idx].wl_folded = TRUE;
-		wp->w_lines[idx].wl_lastlnum = lnume;
+		wp->w_lines[idx].wl_lastlnum = lnum + fold_count;
 # ifdef FEAT_SYN_HL
 		did_update = DID_FOLD;
 # endif
 # ifdef FEAT_SPELL
-		// Check if the line after this fold requires a capital.
-		if (spv.spv_has_spell && check_need_cap(wp, lnume + 1, 0))
-		{
-		    spv.spv_cap_col = 0;
-		    spv.spv_capcol_lnum = lnume + 1;
-		}
+		spv.spv_capcol_lnum = 0;
 # endif
 	    }
 	    else
@@ -2571,6 +2563,9 @@ win_update(win_T *wp)
 #endif
 #ifdef FEAT_SYN_HL
 	    did_update = DID_NONE;
+#endif
+#ifdef FEAT_SPELL
+	    spv.spv_capcol_lnum = 0;
 #endif
 	}
 

--- a/src/testdir/dumps/Test_spell_10.dump
+++ b/src/testdir/dumps/Test_spell_10.dump
@@ -1,0 +1,8 @@
+| +0&#ffffff0@2|T|h|i|s| |l|i|n|e| |h|a|s| |a| |s+0&#ffd7d7255|e|p|l@1| +0&#ffffff0|e|r@1|o|r|.| |a+0&#5fd7ff255|n|d| +0&#ffffff0|m|i|s@1|i|n|g| |c|a|p|s| |a|n|d| |t|r|a|i|l|i|n|g| |s|p|a|c|e|s|.| @5
+|a+0&#5fd7ff255|n|o|t|h|e|r| +0&#ffffff0|m|i|s@1|i|n|g| |c|a|p| |h|e|r|e| @50
+|++0#0000e05#a8a8a8255|-@1| @1|2| |l|i|n|e|s|:| |N|o|t|-@57
+> +0#0000000#ffffff0@74
+@75
+|a+0&#5fd7ff255|n|d| +0&#ffffff0|h|e|r|e|.| @65
+|~+0#4040ff13&| @73
+| +0#0000000&@56|5|,|0|-|1| @8|A|l@1| 

--- a/src/testdir/dumps/Test_spell_9.dump
+++ b/src/testdir/dumps/Test_spell_9.dump
@@ -1,0 +1,8 @@
+| +0&#ffffff0@2|T|h|i|s| |l|i|n|e| |h|a|s| |a| |s+0&#ffd7d7255|e|p|l@1| +0&#ffffff0|e|r@1|o|r|.| |a+0&#5fd7ff255|n|d| +0&#ffffff0|m|i|s@1|i|n|g| |c|a|p|s| |a|n|d| |t|r|a|i|l|i|n|g| |s|p|a|c|e|s|.| @5
+|a+0&#5fd7ff255|n|o|t|h|e|r| +0&#ffffff0|m|i|s@1|i|n|g| |c|a|p| |h|e|r|e| @50
+|++0#0000e05#a8a8a8255|-@1| @1|2| |l|i|n|e|s|:| |N|o|t|-@57
+> +0#0000000#ffffff0@74
+|a+0&#5fd7ff255|n|d| +0&#ffffff0|h|e|r|e|.| @65
+|~+0#4040ff13&| @73
+|~| @73
+| +0#0000000&@56|5|,|0|-|1| @8|A|l@1| 

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -1021,6 +1021,14 @@ func Test_spell_screendump_spellcap()
   call term_sendkeys(buf, "\<C-E>\<C-L>")
   call VerifyScreenDump(buf, 'Test_spell_8', {})
 
+  " Adding an empty line does not remove Cap in "mod_bot" area
+  call term_sendkeys(buf, "zbO\<Esc>")
+  call VerifyScreenDump(buf, 'Test_spell_9', {})
+
+  " Multiple empty lines does not remove Cap in the line after
+  call term_sendkeys(buf, "O\<Esc>\<C-L>")
+  call VerifyScreenDump(buf, 'Test_spell_10', {})
+
   " clean up
   call StopVimInTerminal(buf)
 endfunc

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -958,6 +958,7 @@ func Test_spell_screendump()
   CheckScreendump
 
   let lines =<< trim END
+       call test_override('alloc_lines', 1)
        call setline(1, [
              \ "This is some text without any spell errors.  Everything",
              \ "should just be black, nothing wrong here.",
@@ -980,6 +981,7 @@ func Test_spell_screendump_spellcap()
   CheckScreendump
 
   let lines =<< trim END
+       call test_override('alloc_lines', 1)
        call setline(1, [
              \ "   This line has a sepll error. and missing caps and trailing spaces.   ",
              \ "another missing cap here.",
@@ -1027,6 +1029,7 @@ func Test_spell_compatible()
   CheckScreendump
 
   let lines =<< trim END
+       call test_override('alloc_lines', 1)
        call setline(1, [
              \ "test "->repeat(20),
              \ "",


### PR DESCRIPTION
Grouping the spell checking blocks in the previous patch resulted in the "line" pointer in win_line() possibly being cleared by getting the pointer to the next line, apologies for that.

I guess this is why the block for getting the start of the next line was earlier in win_line() in the first place. This patch also works and keeps the spell checking code grouped.