### PR TITLE
Internal error messages are not for translation

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -76,9 +76,9 @@ See `:messages` above.
 
 
 LIST OF MESSAGES
-			*E222* *E228* *E232* *E293* *E298* *E304* *E317*
-			*E318* *E356* *E438* *E439* *E440* *E316* *E320* *E322*
-			*E323* *E341* *E473* *E570* *E292*
+			*E222* *E228* *E232* *E292* *E293* *E298* *E304* *E316*
+			*E317* *E318* *E320* *E322* *E323* *E341* *E356* *E438*
+			*E439* *E440* *E473* *E570*
   Add to read buffer ~
   makemap: Illegal mode ~
   Cannot create BalloonEval with both message and callback ~

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -226,7 +226,7 @@ lalloc(size_t size, int message)
     {
 	// Don't hide this message
 	emsg_silent = 0;
-	iemsg(_(e_internal_error_lalloc_zero));
+	iemsg(e_internal_error_lalloc_zero);
 	return NULL;
     }
 

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -416,7 +416,7 @@ bf_key_init(
     keylen = (int)STRLEN(key) / 2;
     if (keylen == 0)
     {
-	iemsg(_(e_bf_key_init_called_with_empty_password));
+	iemsg(e_bf_key_init_called_with_empty_password);
 	return;
     }
     for (i = 0; i < keylen; i++)

--- a/src/errors.h
+++ b/src/errors.h
@@ -98,7 +98,7 @@ EXTERN char e_no_write_since_last_change[]
 EXTERN char e_no_write_since_last_change_add_bang_to_override[]
 	INIT(= N_("E37: No write since last change (add ! to override)"));
 EXTERN char e_null_argument[]
-	INIT(= N_("E38: Null argument"));
+	INIT(= "E38: Null argument");
 #if defined(FEAT_DIGRAPHS) || defined(FEAT_TIMERS) || defined(FEAT_EVAL)
 EXTERN char e_number_expected[]
 	INIT(= N_("E39: Number expected"));
@@ -114,9 +114,9 @@ EXTERN char e_no_errors[]
 	INIT(= N_("E42: No Errors"));
 #endif
 EXTERN char e_damaged_match_string[]
-	INIT(= N_("E43: Damaged match string"));
+	INIT(= "E43: Damaged match string");
 EXTERN char e_corrupted_regexp_program[]
-	INIT(= N_("E44: Corrupted regexp program"));
+	INIT(= "E44: Corrupted regexp program");
 EXTERN char e_readonly_option_is_set_add_bang_to_override[]
 	INIT(= N_("E45: 'readonly' option is set (add ! to override)"));
 #ifdef FEAT_EVAL
@@ -526,7 +526,7 @@ EXTERN char e_marker_cannot_start_with_lower_case_letter[]
 	INIT(= N_("E221: Marker cannot start with lower case letter"));
 #endif
 EXTERN char e_add_to_internal_buffer_that_was_already_read_from[]
-	INIT(= N_("E222: Add to internal buffer that was already read from"));
+	INIT(= "E222: Add to internal buffer that was already read from");
 EXTERN char e_recursive_mapping[]
 	INIT(= N_("E223: Recursive mapping"));
 EXTERN char e_global_abbreviation_already_exists_for_str[]
@@ -538,7 +538,7 @@ EXTERN char e_abbreviation_already_exists_for_str[]
 EXTERN char e_mapping_already_exists_for_str[]
 	INIT(= N_("E227: Mapping already exists for %s"));
 EXTERN char e_makemap_illegal_mode[]
-	INIT(= N_("E228: makemap: Illegal mode"));
+	INIT(= "E228: makemap: Illegal mode");
 #ifdef FEAT_GUI
 EXTERN char e_cannot_start_the_GUI[]
 	INIT(= N_("E229: Cannot start the GUI"));
@@ -548,7 +548,7 @@ EXTERN char e_guifontwide_invalid[]
 	INIT(= N_("E231: 'guifontwide' invalid"));
 #ifdef FEAT_BEVAL_GUI
 EXTERN char e_cannot_create_ballooneval_with_both_message_and_callback[]
-	INIT(= N_("E232: Cannot create BalloonEval with both message and callback"));
+	INIT(= "E232: Cannot create BalloonEval with both message and callback");
 #endif
 # if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_X11)
 EXTERN char e_cannot_open_display[]
@@ -708,7 +708,7 @@ EXTERN char e_sorry_plusplusshell_not_supported_on_this_system[]
 #endif
 #ifdef FEAT_TCL
 EXTERN char e_tcl_fatal_error_reflist_corrupt_please_report_this[]
-	INIT(= N_("E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim.org"));
+	INIT(= "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim.org");
 #endif
 // E281 unused
 EXTERN char e_cannot_read_from_str_2[]
@@ -739,9 +739,9 @@ EXTERN char e_list_or_number_required[]
 #endif
 // E291 unused
 EXTERN char e_invalid_count_for_del_bytes_nr[]
-	INIT(= N_("E292: Invalid count for del_bytes(): %ld"));
+	INIT(= "E292: Invalid count for del_bytes(): %ld");
 EXTERN char e_block_was_not_locked[]
-	INIT(= N_("E293: Block was not locked"));
+	INIT(= "E293: Block was not locked");
 EXTERN char e_seek_error_in_swap_file_read[]
 	INIT(= N_("E294: Seek error in swap file read"));
 EXTERN char e_read_error_in_swap_file[]
@@ -751,11 +751,11 @@ EXTERN char e_seek_error_in_swap_file_write[]
 EXTERN char e_write_error_in_swap_file[]
 	INIT(= N_("E297: Write error in swap file"));
 EXTERN char e_didnt_get_block_nr_zero[]
-	INIT(= N_("E298: Didn't get block nr 0?"));
+	INIT(= "E298: Didn't get block nr 0?");
 EXTERN char e_didnt_get_block_nr_one[]
-	INIT(= N_("E298: Didn't get block nr 1?"));
+	INIT(= "E298: Didn't get block nr 1?");
 EXTERN char e_didnt_get_block_nr_two[]
-	INIT(= N_("E298: Didn't get block nr 2?"));
+	INIT(= "E298: Didn't get block nr 2?");
 #ifdef FEAT_PERL
 EXTERN char e_perl_evaluation_forbidden_in_sandbox_without_safe_module[]
 	INIT(= N_("E299: Perl evaluation forbidden in sandbox without the Safe module"));
@@ -769,7 +769,7 @@ EXTERN char e_could_not_rename_swap_file[]
 EXTERN char e_unable_to_open_swap_file_for_str_recovery_impossible[]
 	INIT(= N_("E303: Unable to open swap file for \"%s\", recovery impossible"));
 EXTERN char e_ml_upd_block0_didnt_get_block_zero[]
-	INIT(= N_("E304: ml_upd_block0(): Didn't get block 0??"));
+	INIT(= "E304: ml_upd_block0(): Didn't get block 0??");
 EXTERN char e_no_swap_file_found_for_str[]
 	INIT(= N_("E305: No swap file found for %s"));
 EXTERN char e_cannot_open_str[]
@@ -791,29 +791,29 @@ EXTERN char e_cannot_preserve_there_is_no_swap_file[]
 EXTERN char e_preserve_failed[]
 	INIT(= N_("E314: Preserve failed"));
 EXTERN char e_ml_get_invalid_lnum_nr[]
-	INIT(= N_("E315: ml_get: Invalid lnum: %ld"));
+	INIT(= "E315: ml_get: Invalid lnum: %ld");
 EXTERN char e_ml_get_cannot_find_line_nr_in_buffer_nr_str[]
-	INIT(= N_("E316: ml_get: Cannot find line %ld in buffer %d %s"));
+	INIT(= "E316: ml_get: Cannot find line %ld in buffer %d %s");
 EXTERN char e_pointer_block_id_wrong[]
-	INIT(= N_("E317: Pointer block id wrong"));
+	INIT(= "E317: Pointer block id wrong");
 EXTERN char e_pointer_block_id_wrong_two[]
-	INIT(= N_("E317: Pointer block id wrong 2"));
+	INIT(= "E317: Pointer block id wrong 2");
 EXTERN char e_pointer_block_id_wrong_three[]
-	INIT(= N_("E317: Pointer block id wrong 3"));
+	INIT(= "E317: Pointer block id wrong 3");
 EXTERN char e_pointer_block_id_wrong_four[]
-	INIT(= N_("E317: Pointer block id wrong 4"));
+	INIT(= "E317: Pointer block id wrong 4");
 EXTERN char e_updated_too_many_blocks[]
-	INIT(= N_("E318: Updated too many blocks?"));
+	INIT(= "E318: Updated too many blocks?");
 EXTERN char e_sorry_command_is_not_available_in_this_version[]
 	INIT(= N_("E319: Sorry, the command is not available in this version"));
 EXTERN char e_cannot_find_line_nr[]
-	INIT(= N_("E320: Cannot find line %ld"));
+	INIT(= "E320: Cannot find line %ld");
 EXTERN char e_could_not_reload_str[]
 	INIT(= N_("E321: Could not reload \"%s\""));
 EXTERN char e_line_number_out_of_range_nr_past_the_end[]
-	INIT(= N_("E322: Line number out of range: %ld past the end"));
+	INIT(= "E322: Line number out of range: %ld past the end");
 EXTERN char e_line_count_wrong_in_block_nr[]
-	INIT(= N_("E323: Line count wrong in block %ld"));
+	INIT(= "E323: Line count wrong in block %ld");
 #ifdef FEAT_POSTSCRIPT
 EXTERN char e_cant_open_postscript_output_file[]
 	INIT(= N_("E324: Can't open PostScript output file"));
@@ -855,7 +855,7 @@ EXTERN char e_pattern_too_long[]
 EXTERN char e_internal_error_please_report_a_bug[]
 	INIT(= N_("E340: Internal error; if you can reproduce please report a bug"));
 EXTERN char e_internal_error_lalloc_zero[]
-	INIT(= N_("E341: Internal error: lalloc(0, )"));
+	INIT(= "E341: Internal error: lalloc(0, )");
 EXTERN char e_out_of_memory_allocating_nr_bytes[]
 	INIT(= N_("E342: Out of memory!  (allocating %lu bytes)"));
 EXTERN char e_invalid_path_number_must_be_at_end_of_path_or_be_followed_by_str[]
@@ -887,7 +887,7 @@ EXTERN char e_invalid_register_name_str[]
 EXTERN char e_unknown_option_str_2[]
 	INIT(= N_("E355: Unknown option: %s"));
 EXTERN char e_get_varp_error[]
-	INIT(= N_("E356: get_varp ERROR"));
+	INIT(= "E356: get_varp ERROR");
 #ifdef FEAT_LANGMAP
 EXTERN char e_langmap_matching_character_missing_for_str[]
 	INIT(= N_("E357: 'langmap': Matching character missing for %s"));
@@ -1078,11 +1078,11 @@ EXTERN char e_no_str_entry_in_termcap[]
 EXTERN char e_terminal_capability_cm_required[]
 	INIT(= N_("E437: Terminal capability \"cm\" required"));
 EXTERN char e_u_undo_line_numbers_wrong[]
-	INIT(= N_("E438: u_undo: Line numbers wrong"));
+	INIT(= "E438: u_undo: Line numbers wrong");
 EXTERN char e_undo_list_corrupt[]
-	INIT(= N_("E439: Undo list corrupt"));
+	INIT(= "E439: Undo list corrupt");
 EXTERN char e_undo_line_missing[]
-	INIT(= N_("E440: Undo line missing"));
+	INIT(= "E440: Undo line missing");
 #ifdef FEAT_QUICKFIX
 EXTERN char e_there_is_no_preview_window[]
 	INIT(= N_("E441: There is no preview window"));
@@ -1180,7 +1180,7 @@ EXTERN char e_argument_required[]
 EXTERN char e_command_failed[]
 	INIT(= N_("E472: Command failed"));
 EXTERN char e_internal_error_in_regexp[]
-	INIT(= N_("E473: Internal error in regexp"));
+	INIT(= "E473: Internal error in regexp");
 EXTERN char e_invalid_argument[]
 	INIT(= N_("E474: Invalid argument"));
 EXTERN char e_invalid_argument_str[]
@@ -1442,7 +1442,7 @@ EXTERN char e_duplicate_cscope_database_not_added[]
 	INIT(= N_("E568: Duplicate cscope database not added"));
 // E569 unused
 EXTERN char e_fatal_error_in_cs_manage_matches[]
-	INIT(= N_("E570: Fatal error in cs_manage_matches"));
+	INIT(= "E570: Fatal error in cs_manage_matches");
 #endif
 #ifdef DYNAMIC_TCL
 EXTERN char e_sorry_this_command_is_disabled_tcl_library_could_not_be_loaded[]
@@ -2128,7 +2128,7 @@ EXTERN char e_undo_number_nr_not_found[]
 	INIT(= N_("E830: Undo number %ld not found"));
 #ifdef FEAT_CRYPT
 EXTERN char e_bf_key_init_called_with_empty_password[]
-	INIT(= N_("E831: bf_key_init() called with empty password"));
+	INIT(= "E831: bf_key_init() called with empty password");
 # ifdef FEAT_PERSISTENT_UNDO
 EXTERN char e_non_encrypted_file_has_encrypted_undo_file_str[]
 	INIT(= N_("E832: Non-encrypted file has encrypted undo file: %s"));
@@ -2258,7 +2258,7 @@ EXTERN char e_nfa_regexp_while_converting_from_postfix_to_nfa_too_many_stats_lef
 EXTERN char e_nfa_regexp_not_enough_space_to_store_whole_nfa[]
 	INIT(= N_("E876: (NFA regexp) Not enough space to store the whole NFA"));
 EXTERN char e_nfa_regexp_invalid_character_class_nr[]
-	INIT(= N_("E877: (NFA regexp) Invalid character class: %d"));
+	INIT(= "E877: (NFA regexp) Invalid character class: %d");
 EXTERN char e_nfa_regexp_could_not_allocate_memory_for_branch_traversal[]
 	INIT(= N_("E878: (NFA regexp) Could not allocate memory for branch traversal!"));
 #ifdef FEAT_SYN_HL
@@ -2453,7 +2453,7 @@ EXTERN char e_clientserver_feature_not_available[]
 # endif
 #endif
 EXTERN char e_command_table_needs_to_be_updated_run_make_cmdidxs[]
-	INIT(= N_("E943: Command table needs to be updated, run 'make cmdidxs'"));
+	INIT(= "E943: Command table needs to be updated, run 'make cmdidxs'");
 EXTERN char e_reverse_range_in_character_class[]
 	INIT(= N_("E944: Reverse range in character class"));
 EXTERN char e_range_too_large_in_character_class[]
@@ -2527,7 +2527,7 @@ EXTERN char_u e_invalid_line_number_nr[]
 #endif
 #ifdef FEAT_PROP_POPUP
 EXTERN char e_text_property_info_corrupted[]
-	INIT(= N_("E967: Text property info corrupted"));
+	INIT(= "E967: Text property info corrupted");
 EXTERN char e_need_at_least_one_of_id_or_type[]
 	INIT(= N_("E968: Need at least one of 'id' or 'type'"));
 EXTERN char e_property_type_str_already_defined[]
@@ -3408,7 +3408,7 @@ EXTERN char e_member_is_not_writable_str[]
 	INIT(= N_("E1335: Member is not writable: %s"));
 #endif
 EXTERN char e_internal_error_shortmess_too_long[]
-	INIT(= N_("E1336: Internal error: shortmess too long"));
+	INIT(= "E1336: Internal error: shortmess too long");
 #ifdef FEAT_EVAL
 EXTERN char e_class_member_not_found_str[]
 	INIT(= N_("E1337: Class member not found: %s"));

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3887,7 +3887,7 @@ find_ex_command(
 
 	    if (command_count != (int)CMD_SIZE)
 	    {
-		iemsg(_(e_command_table_needs_to_be_updated_run_make_cmdidxs));
+		iemsg(e_command_table_needs_to_be_updated_run_make_cmdidxs);
 		getout(1);
 	    }
 

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -214,7 +214,7 @@ add_buff(
     }
     else if (buf->bh_curr == NULL)	// buffer has already been read
     {
-	iemsg(_(e_add_to_internal_buffer_that_was_already_read_from));
+	iemsg(e_add_to_internal_buffer_that_was_already_read_from);
 	return;
     }
     else if (buf->bh_index != 0)

--- a/src/gui_beval.c
+++ b/src/gui_beval.c
@@ -93,7 +93,7 @@ gui_mch_create_beval_area(
 
     if (mesg != NULL && mesgCB != NULL)
     {
-	iemsg(_(e_cannot_create_ballooneval_with_both_message_and_callback));
+	iemsg(e_cannot_create_ballooneval_with_both_message_and_callback);
 	return NULL;
     }
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -8535,7 +8535,7 @@ gui_mch_create_beval_area(
 
     if (mesg != NULL && mesgCB != NULL)
     {
-	iemsg(_(e_cannot_create_ballooneval_with_both_message_and_callback));
+	iemsg(e_cannot_create_ballooneval_with_both_message_and_callback);
 	return NULL;
     }
 

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1723,7 +1723,7 @@ cs_manage_matches(
 	cs_print_tags_priv(mp, cp, cnt);
 	break;
     default:	// should not reach here
-	iemsg(_(e_fatal_error_in_cs_manage_matches));
+	iemsg(e_fatal_error_in_cs_manage_matches);
 	return NULL;
     }
 

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -1552,7 +1552,7 @@ tclsetdelcmd(
 	reflist = reflist->next;
     }
     // This should never happen.  Famous last word?
-    iemsg(_(e_tcl_fatal_error_reflist_corrupt_please_report_this));
+    iemsg(e_tcl_fatal_error_reflist_corrupt_please_report_this);
     Tcl_SetResult(interp, _("cannot register callback command: buffer/window reference not found"), TCL_STATIC);
     return TCL_ERROR;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2743,7 +2743,7 @@ check_tty(mparm_T *parmp)
 	 */
 	if (netbeans_active() && (!stdout_isatty || !input_isatty))
 	{
-	    mch_errmsg(_("Vim: Error: Failure to start gvim from NetBeans\n"));
+	    mch_errmsg("Vim: Error: Failure to start gvim from NetBeans\n");
 	    exit(1);
 	}
 #endif

--- a/src/map.c
+++ b/src/map.c
@@ -2043,7 +2043,7 @@ makemap(
 			c1 = 't';
 			break;
 		    default:
-			iemsg(_(e_makemap_illegal_mode));
+			iemsg(e_makemap_illegal_mode);
 			return FAIL;
 		}
 		do	// do this twice if c2 is set, 3 times with c3

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -478,7 +478,7 @@ mf_put(
     flags = hp->bh_flags;
 
     if ((flags & BH_LOCKED) == 0)
-	iemsg(_(e_block_was_not_locked));
+	iemsg(e_block_was_not_locked);
     flags &= ~BH_LOCKED;
     if (dirty)
     {

--- a/src/memline.c
+++ b/src/memline.c
@@ -332,7 +332,7 @@ ml_open(buf_T *buf)
 	goto error;
     if (hp->bh_bnum != 0)
     {
-	iemsg(_(e_didnt_get_block_nr_zero));
+	iemsg(e_didnt_get_block_nr_zero);
 	goto error;
     }
     b0p = (ZERO_BL *)(hp->bh_data);
@@ -382,7 +382,7 @@ ml_open(buf_T *buf)
 	goto error;
     if (hp->bh_bnum != 1)
     {
-	iemsg(_(e_didnt_get_block_nr_one));
+	iemsg(e_didnt_get_block_nr_one);
 	goto error;
     }
     pp = (PTR_BL *)(hp->bh_data);
@@ -400,7 +400,7 @@ ml_open(buf_T *buf)
 	goto error;
     if (hp->bh_bnum != 2)
     {
-	iemsg(_(e_didnt_get_block_nr_two));
+	iemsg(e_didnt_get_block_nr_two);
 	goto error;
     }
 
@@ -974,7 +974,7 @@ ml_upd_block0(buf_T *buf, upd_block0_T what)
 
     b0p = (ZERO_BL *)(hp->bh_data);
     if (ml_check_b0_id(b0p) == FAIL)
-	iemsg(_(e_ml_upd_block0_didnt_get_block_zero));
+	iemsg(e_ml_upd_block0_didnt_get_block_zero);
     else
     {
 	if (what == UB_FNAME)
@@ -2678,7 +2678,7 @@ ml_get_buf(
 	    // Avoid giving this message for a recursive call, may happen when
 	    // the GUI redraws part of the text.
 	    ++recursive;
-	    siemsg(_(e_ml_get_invalid_lnum_nr), lnum);
+	    siemsg(e_ml_get_invalid_lnum_nr, lnum);
 	    --recursive;
 	}
 	ml_flush_line(buf);
@@ -2725,7 +2725,7 @@ errorret:
 		++recursive;
 		get_trans_bufname(buf);
 		shorten_dir(NameBuff);
-		siemsg(_(e_ml_get_cannot_find_line_nr_in_buffer_nr_str),
+		siemsg(e_ml_get_cannot_find_line_nr_in_buffer_nr_str,
 						  lnum, buf->b_fnum, NameBuff);
 		--recursive;
 	    }
@@ -3219,7 +3219,7 @@ ml_append_int(
 	    pp = (PTR_BL *)(hp->bh_data);   // must be pointer block
 	    if (pp->pb_id != PTR_ID)
 	    {
-		iemsg(_(e_pointer_block_id_wrong_three));
+		iemsg(e_pointer_block_id_wrong_three);
 		mf_put(mfp, hp, FALSE, FALSE);
 		goto theend;
 	    }
@@ -3360,7 +3360,7 @@ ml_append_int(
 	 */
 	if (stack_idx < 0)
 	{
-	    iemsg(_(e_updated_too_many_blocks));
+	    iemsg(e_updated_too_many_blocks);
 	    buf->b_ml.ml_stack_top = 0;	// invalidate stack
 	}
     }
@@ -3820,7 +3820,7 @@ ml_delete_int(buf_T *buf, linenr_T lnum, int flags)
 	    pp = (PTR_BL *)(hp->bh_data);   // must be pointer block
 	    if (pp->pb_id != PTR_ID)
 	    {
-		iemsg(_(e_pointer_block_id_wrong_four));
+		iemsg(e_pointer_block_id_wrong_four);
 		mf_put(mfp, hp, FALSE, FALSE);
 		goto theend;
 	    }
@@ -4085,7 +4085,7 @@ ml_flush_line(buf_T *buf)
 
 	hp = ml_find_line(buf, lnum, ML_FIND);
 	if (hp == NULL)
-	    siemsg(_(e_cannot_find_line_nr), lnum);
+	    siemsg(e_cannot_find_line_nr, lnum);
 	else
 	{
 	    dp = (DATA_BL *)(hp->bh_data);
@@ -4345,7 +4345,7 @@ ml_find_line(buf_T *buf, linenr_T lnum, int action)
 	pp = (PTR_BL *)(dp);		// must be pointer block
 	if (pp->pb_id != PTR_ID)
 	{
-	    iemsg(_(e_pointer_block_id_wrong));
+	    iemsg(e_pointer_block_id_wrong);
 	    goto error_block;
 	}
 
@@ -4390,11 +4390,11 @@ ml_find_line(buf_T *buf, linenr_T lnum, int action)
 	if (idx >= (int)pp->pb_count)	    // past the end: something wrong!
 	{
 	    if (lnum > buf->b_ml.ml_line_count)
-		siemsg(_(e_line_number_out_of_range_nr_past_the_end),
+		siemsg(e_line_number_out_of_range_nr_past_the_end,
 					      lnum - buf->b_ml.ml_line_count);
 
 	    else
-		siemsg(_(e_line_count_wrong_in_block_nr), bnum);
+		siemsg(e_line_count_wrong_in_block_nr, bnum);
 	    goto error_block;
 	}
 	if (action == ML_DELETE)
@@ -4487,7 +4487,7 @@ ml_lineadd(buf_T *buf, int count)
 	if (pp->pb_id != PTR_ID)
 	{
 	    mf_put(mfp, hp, FALSE, FALSE);
-	    iemsg(_(e_pointer_block_id_wrong_two));
+	    iemsg(e_pointer_block_id_wrong_two);
 	    break;
 	}
 	pp->pb_pointer[ip->ip_index].pe_line_count += count;

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -518,7 +518,7 @@ nb_parse_cmd(char_u *cmd)
 	 * so I'm disabling it except for debugging.
 	 */
 	nbdebug(("nb_parse_cmd: Command error for \"%s\"\n", cmd));
-	emsg(_(e_bad_return_from_nb_do_cmd));
+	emsg(e_bad_return_from_nb_do_cmd);
 #endif
     }
 }

--- a/src/option.c
+++ b/src/option.c
@@ -6532,7 +6532,7 @@ get_varp(struct vimoption *p)
 	case PV_VSTS:	return (char_u *)&(curbuf->b_p_vsts);
 	case PV_VTS:	return (char_u *)&(curbuf->b_p_vts);
 #endif
-	default:	iemsg(_(e_get_varp_error));
+	default:	iemsg(e_get_varp_error);
     }
     // always return a valid pointer to avoid a crash!
     return (char_u *)&(curbuf->b_p_wm);

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -379,7 +379,7 @@ set_string_option_direct(
 	if (idx < 0)	// not found (should not happen)
 	{
 	    semsg(_(e_internal_error_str), "set_string_option_direct()");
-	    siemsg(_("For option %s"), name);
+	    siemsg("For option %s", name);
 	    return;
 	}
     }

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -2389,7 +2389,7 @@ vim_regsub_both(
 		    else if (*s == NUL) // we hit NUL.
 		    {
 			if (copy)
-			    iemsg(_(e_damaged_match_string));
+			    iemsg(e_damaged_match_string);
 			goto exit;
 		    }
 		    else

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -1376,7 +1376,7 @@ regatom(int *flagp)
 	if (one_exactly)
 	    EMSG_ONE_RET_NULL;
 	// Supposed to be caught earlier.
-	IEMSG_RET_NULL(_(e_internal_error_in_regexp));
+	IEMSG_RET_NULL(e_internal_error_in_regexp);
 	// NOTREACHED
 
       case Magic('='):
@@ -2477,7 +2477,7 @@ bt_regcomp(char_u *expr, int re_flags)
     int		flags;
 
     if (expr == NULL)
-	IEMSG_RET_NULL(_(e_null_argument));
+	IEMSG_RET_NULL(e_null_argument);
 
     init_class_tab();
 
@@ -3103,7 +3103,7 @@ do_class:
 	break;
 
       default:			// Oh dear.  Called inappropriately.
-	iemsg(_(e_corrupted_regexp_program));
+	iemsg(e_corrupted_regexp_program);
 #ifdef DEBUG
 	printf("Called regrepeat with op code %d\n", OP(p));
 #endif
@@ -4327,7 +4327,7 @@ regmatch(
 	    break;
 
 	  default:
-	    iemsg(_(e_corrupted_regexp_program));
+	    iemsg(e_corrupted_regexp_program);
 #ifdef DEBUG
 	    printf("Illegal op code %d\n", op);
 #endif
@@ -4740,7 +4740,7 @@ regmatch(
 	{
 	    // We get here only if there's trouble -- normally "case END" is
 	    // the terminating point.
-	    iemsg(_(e_corrupted_regexp_program));
+	    iemsg(e_corrupted_regexp_program);
 #ifdef DEBUG
 	    printf("Premature EOL\n");
 #endif
@@ -4889,7 +4889,7 @@ bt_regexec_both(
     // Be paranoid...
     if (prog == NULL || line == NULL)
     {
-	iemsg(_(e_null_argument));
+	iemsg(e_null_argument);
 	goto theend;
     }
 

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -5119,7 +5119,7 @@ check_char_class(int class, int c)
 
 	default:
 	    // should not be here :P
-	    siemsg(_(e_nfa_regexp_invalid_character_class_nr), class);
+	    siemsg(e_nfa_regexp_invalid_character_class_nr, class);
 	    return FAIL;
     }
     return FAIL;
@@ -7341,7 +7341,7 @@ nfa_regexec_both(
     // Be paranoid...
     if (prog == NULL || line == NULL)
     {
-	iemsg(_(e_null_argument));
+	iemsg(e_null_argument);
 	goto theend;
     }
 

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -642,7 +642,7 @@ get_text_props(buf_T *buf, linenr_T lnum, char_u **props, int will_change)
 	return 0;
     if (proplen % sizeof(textprop_T) != 0)
     {
-	iemsg(_(e_text_property_info_corrupted));
+	iemsg(e_text_property_info_corrupted);
 	return 0;
     }
     *props = text + textlen;

--- a/src/undo.c
+++ b/src/undo.c
@@ -2717,7 +2717,7 @@ u_undoredo(int undo)
 				      || bot > curbuf->b_ml.ml_line_count + 1)
 	{
 	    unblock_autocmds();
-	    iemsg(_(e_u_undo_line_numbers_wrong));
+	    iemsg(e_u_undo_line_numbers_wrong);
 	    changed();		// don't want UNCHANGED now
 	    return;
 	}
@@ -3307,7 +3307,7 @@ u_get_headentry(void)
 {
     if (curbuf->b_u_newhead == NULL || curbuf->b_u_newhead->uh_entry == NULL)
     {
-	iemsg(_(e_undo_list_corrupt));
+	iemsg(e_undo_list_corrupt);
 	return NULL;
     }
     return curbuf->b_u_newhead->uh_entry;
@@ -3339,7 +3339,7 @@ u_getbot(void)
 	uep->ue_bot = uep->ue_top + uep->ue_size + 1 + extra;
 	if (uep->ue_bot < 1 || uep->ue_bot > curbuf->b_ml.ml_line_count)
 	{
-	    iemsg(_(e_undo_line_missing));
+	    iemsg(e_undo_line_missing);
 	    uep->ue_bot = uep->ue_top + 1;  // assume all lines deleted, will
 					    // get all the old lines back
 					    // without deleting the current


### PR DESCRIPTION
Removed  \_() calls in the iemsg() and siemsg() functions.
Removed N_() in errors.h for internal error messages and debug messages.
Removed \_() calls in messages in \*DEBUG* definitions
The messages E864, E868, E874, E875, E876, E878 remained in question. They are output to the user via emsg() and are not marked as debugging in the code, but the documentation says that "This is only useful when debugging Vim".
As well as messages displayed via the PERROR() macro. Some of these messages have translations in errors.h, and some do not. And many of these messages are clearly debugging in kind.