### PR TITLE
Incsearch not triggered by clipboard registers

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1221,7 +1221,12 @@ cmdline_insert_reg(int *gotesc UNUSED)
 #endif
     if (c != ESC)	    // use ESC to cancel inserting register
     {
-	literally = i == Ctrl_R;
+	literally = (i == Ctrl_R)
+#ifdef FEAT_CLIPBOARD
+	    || (clip_star.available && c == '*')
+	    || (clip_plus.available && c == '+')
+#endif
+	    ;
 	cmdline_paste(c, literally, FALSE);
 
 #ifdef FEAT_EVAL

--- a/src/testdir/test_hlsearch.vim
+++ b/src/testdir/test_hlsearch.vim
@@ -91,4 +91,23 @@ func Test_hlsearch_Ctrl_R()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_hlsearch_clipboard()
+  CheckRunVimInTerminal
+  CheckFeature clipboard_working
+
+  let lines =<< trim END
+      set incsearch hlsearch
+      let @* = "text"
+      put *
+  END
+  call writefile(lines, 'XhlsearchClipboard', 'D')
+  let buf = RunVimInTerminal('-S XhlsearchClipboard', #{rows: 6, cols: 60})
+
+  call term_sendkeys(buf, "/\<C-R>*")
+  call VerifyScreenDump(buf, 'Test_hlsearch_ctrlr_1', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This is an additional fix to v9.0.1298 (#11960) and v9.0.1299.
`Ctrl-R *` and `Ctrl-R +` were not fixed by the above patches.
Handle `*` and `+` separately.

Note:
Now `*` and `+` are checked in `cmdline_insert_reg()`.
However, they are checked in `get_yank_register()` again.
This might be redundant...

`cmdline_insert_reg()`
-> `cmdline_paste()`
-> `cmdline_paste_reg()`
-> `get_yank_register()`