### PR TITLE
fix(ftdetect): detect go.mod files with precedence

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -484,14 +484,14 @@ enddef
 export def FTmod()
   if exists("g:filetype_mod")
     exe "setf " .. g:filetype_mod
+  elseif expand("<afile>") =~ '\<go.mod$'
+    setf gomod
   elseif IsLProlog()
     setf lprolog
   elseif getline(nextnonblank(1)) =~ '\%(\<MODULE\s\+\w\+\s*;\|^\s*(\*\)'
     setf modula2
   elseif IsRapid()
     setf rapid
-  elseif expand("<afile>") =~ '\<go.mod$'
-    setf gomod
   else
     # Nothing recognized, assume modsim3
     setf modsim3

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1451,6 +1451,12 @@ func Test_mod_file()
   bwipe!
   call delete('go.mod')
 
+  call writefile(['module M'], 'go.mod')
+  split go.mod
+  call assert_equal('gomod', &filetype)
+  bwipe!
+  call delete('go.mod')
+
   filetype off
 endfunc
 


### PR DESCRIPTION
The previous implementation was causing valid go.mod files with module names not containing any forward slashes to be treated as rapid files.