### PR TITLE
doc: Write about --cmd in startup part

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -795,6 +795,7 @@ accordingly.  Vim proceeds in this order:
 	inspected.  Buffers are created for all files (but not loaded yet).
 	The |-V| argument can be used to display or log what happens next,
 	useful for debugging the initializations.
+	The |--cmd| arguments are also executed here.
 
 3. Execute Ex commands, from environment variables and/or files
 	An environment variable is read as one Ex command line, where multiple


### PR DESCRIPTION
`:h startup` doesn't describe where the --cmd arguments are executed. Write about it.

Note:
The command line is parsed in command_line_scan() in main.c, then mch_init(), set_init_2() and some initializations are executed, then exe_pre_commands() executes the --cmd arguments.