### PR TITLE
Fix that setvbuf causes assertion error

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -580,6 +580,7 @@ free_all_mem(void)
 # ifdef FEAT_EVAL
     free_resub_eval_result();
 # endif
+    free_vbuf();
 }
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -76,10 +76,11 @@ static char *(main_errors[]) =
 // Various parameters passed between main() and other functions.
 static mparm_T	params;
 
+static void *s_vbuf = NULL;		// buffer for setvbuf()
+
 #ifndef NO_VIM_MAIN	// skip this for unittests
 
 static char_u *start_dir = NULL;	// current working dir on startup
-static void *s_vbuf = NULL;		// buffer for setvbuf()
 
 static int has_dash_c_arg = FALSE;
 

--- a/src/main.c
+++ b/src/main.c
@@ -356,7 +356,10 @@ main
     // Ensure output works usefully without a tty: buffer lines instead of
     // fully buffered.
     if (silent_mode)
-	setvbuf(stdout, NULL, _IOLBF, 0);
+    {
+	void *buf = malloc(BUFSIZ);
+	setvbuf(stdout, buf, _IOLBF, BUFSIZ);
+    }
 #endif
 
     // This message comes before term inits, but after setting "silent_mode"

--- a/src/main.c
+++ b/src/main.c
@@ -79,6 +79,7 @@ static mparm_T	params;
 #ifndef NO_VIM_MAIN	// skip this for unittests
 
 static char_u *start_dir = NULL;	// current working dir on startup
+static void *s_vbuf = NULL;		// buffer for setvbuf()
 
 static int has_dash_c_arg = FALSE;
 
@@ -357,8 +358,9 @@ main
     // fully buffered.
     if (silent_mode)
     {
-	void *buf = malloc(BUFSIZ);
-	setvbuf(stdout, buf, _IOLBF, BUFSIZ);
+	s_vbuf = malloc(BUFSIZ);
+	if (s_vbuf != NULL)
+	    setvbuf(stdout, s_vbuf, _IOLBF, BUFSIZ);
     }
 #endif
 
@@ -438,6 +440,19 @@ main
 }
 #endif // NO_VIM_MAIN
 #endif // PROTO
+
+#if defined(EXITFREE) || defined(PROTO)
+    void
+free_vbuf(void)
+{
+    if (s_vbuf != NULL)
+    {
+	setvbuf(stdout, NULL, _IONBF, 0);
+	free(s_vbuf);
+	s_vbuf = NULL;
+    }
+}
+#endif
 
 /*
  * vim_main2() is needed for FEAT_MZSCHEME, but we define it always to keep

--- a/src/proto/main.pro
+++ b/src/proto/main.pro
@@ -1,4 +1,5 @@
 /* main.c */
+void free_vbuf(void);
 int vim_main2(void);
 void common_init(mparm_T *paramp);
 int is_not_a_term(void);


### PR DESCRIPTION
When Vim is compiled with debug mode on MSVC, the following command causes an assertion error:

```
> vimd -e -s -c q
```

```
Debug Assertion Failed!

Program: C:\work\vim-msvc\src\vim32d.dll
File: minkernel\crts\ucrt\src\appcrt\stdio\setvbuf.cpp
Line: 55

Expression: 2 <= buffer_size_in_bytes && buffer_size_in_bytes <= INT_MAX
```

This is because MSVC's setvbuf() doesn't accept 0 as the 4th parameter. https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setvbuf?view=msvc-170

Additionally, it seems that passing NULL to the 2nd parameter is no-op in some C libraries.