### PR TITLE
Cursor not adjusted at buffer boundaries when 'splitkeep' is not "cursor"

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -2359,11 +2359,12 @@ nv_screengo(oparg_T *oap, int dir, long dist)
 	    else
 	    {
 		// to previous line
-		if (!cursor_up_inner(curwin, 1))
+		if (curwin->w_cursor.lnum <= 1)
 		{
 		    retval = FAIL;
 		    break;
 		}
+		cursor_up_inner(curwin, 1);
 		linelen = linetabsize_str(ml_get_curline());
 		if (linelen > width1)
 		    curwin->w_curswant += (((linelen - width1 - 1) / width2)
@@ -2386,11 +2387,13 @@ nv_screengo(oparg_T *oap, int dir, long dist)
 	    else
 	    {
 		// to next line
-		if (!cursor_down_inner(curwin, 1))
+		if (curwin->w_cursor.lnum
+					>= curwin->w_buffer->b_ml.ml_line_count)
 		{
 		    retval = FAIL;
 		    break;
 		}
+		cursor_down_inner(curwin, 1);
 		curwin->w_curswant %= width2;
 		// Check if the cursor has moved below the number display
 		// when width1 < width2 (with cpoptions+=n). Subtract width2

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1819,9 +1819,19 @@ endfunc
 
 func Test_splitkeep_misc()
   set splitkeep=screen
-  set splitbelow
 
   call setline(1, range(1, &lines))
+  " Cursor is adjusted to start and end of buffer
+  norm M
+  wincmd s
+  resize 1
+  call assert_equal(1, line('.'))
+  wincmd j
+  norm GM
+  resize 1
+  call assert_equal(&lines, line('.'))
+  only
+  set splitbelow
   norm Gzz
   let top = line('w0')
   " No scroll when aucmd_win is opened


### PR DESCRIPTION
Problem:    Cursor not adjusted at buffer boundaries when 'splitkeep' is
            not "cursor"
Solution:   Move error handling to outer cursor move functions, inner
            functions should only return valid cursor positions.

I could just as well have accounted for this in `win_fix_cursor()` but I think it is unexpected that `cursor_up/down_inner()` could return 0. Thus, I moved the error handling to the outer functions so that the inner functions always return a valid cursor position.
Let me know if you would rather keep the error handling in the inner functions. Then I could check the return value in `win_fix_cursor()` instead.

Regarding the updated TODO comment for `win_fix_scroll()`, this relates back to the discussion in https://github.com/vim/vim/issues/12411#issuecomment-1552965532. If you don't think this should be allowed, perhaps remove the TODO note instead.