### PR TITLE
Ignore some Make output in errorformat

### DIFF
--- a/src/option.h
+++ b/src/option.h
@@ -89,7 +89,7 @@ typedef enum {
 #   ifdef VMS
 #    define DFLT_EFM	"%A%p^,%C%%CC-%t-%m,%Cat line number %l in file %f,%f|%l| %m"
 #   else // Unix, probably
-#define DFLT_EFM	"%*[^\"]\"%f\"%*\\D%l: %m,\"%f\"%*\\D%l: %m,%-G%f:%l: (Each undeclared identifier is reported only once,%-G%f:%l: for each function it appears in.),%-GIn file included from %f:%l:%c:,%-GIn file included from %f:%l:%c\\,,%-GIn file included from %f:%l:%c,%-GIn file included from %f:%l,%-G%*[ ]from %f:%l:%c,%-G%*[ ]from %f:%l:,%-G%*[ ]from %f:%l\\,,%-G%*[ ]from %f:%l,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,\"%f\"\\, line %l%*\\D%c%*[^ ] %m,%D%*\\a[%*\\d]: Entering directory %*[`']%f',%X%*\\a[%*\\d]: Leaving directory %*[`']%f',%D%*\\a: Entering directory %*[`']%f',%X%*\\a: Leaving directory %*[`']%f',%DMaking %*\\a in %f,%f|%l| %m"
+#define DFLT_EFM	"%*[^\"]\"%f\"%*\\D%l: %m,\"%f\"%*\\D%l: %m,%-Gg%\\?make[%*\\d]: *** [%f:%l:%m,%-Gg%\\?make: *** [%f:%l:%m,%-G%f:%l: (Each undeclared identifier is reported only once,%-G%f:%l: for each function it appears in.),%-GIn file included from %f:%l:%c:,%-GIn file included from %f:%l:%c\\,,%-GIn file included from %f:%l:%c,%-GIn file included from %f:%l,%-G%*[ ]from %f:%l:%c,%-G%*[ ]from %f:%l:,%-G%*[ ]from %f:%l\\,,%-G%*[ ]from %f:%l,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,\"%f\"\\, line %l%*\\D%c%*[^ ] %m,%D%*\\a[%*\\d]: Entering directory %*[`']%f',%X%*\\a[%*\\d]: Leaving directory %*[`']%f',%D%*\\a: Entering directory %*[`']%f',%X%*\\a: Leaving directory %*[`']%f',%DMaking %*\\a in %f,%f|%l| %m"
 #   endif
 #  endif
 # endif

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -1200,7 +1200,7 @@ func Test_efm1()
     ﻿"Xtestfile", line 6 col 19; this is an error
     gcc -c -DHAVE_CONFIsing-prototypes -I/usr/X11R6/include  version.c
     Xtestfile:9: parse error before `asd'
-    make: *** [vim] Error 1
+    make: *** [src/vim/testdir/Makefile:100: test_quickfix] Error 1
     in file "Xtestfile" linenr 10: there is an error
 
     2 returned


### PR DESCRIPTION
Problem: GNU Make issues messages such as

    make[1]: *** [foo/bar/baz/Makefile:210: src/foo.o] Error 1

The default 'errorformat' value matches these messages because of the
%f:%l:%m pattern, and creates quickfix list entries that appear valid
but create a new buffer named `make[1]: *** [foo/bar/baz/Makefile`,
which is obviously incorrect.

Solution: Add entries to 'errorformat' to ignore these messages.

The entries added are:

1. `%-Gg%\?make[%*\d]: *** [%f:%l:%m`
2. `%-Gg%\?make: *** [%f:%l:%m`

This covers all of the following cases:

    make[1]: *** [foo/bar/baz/Makefile:200: src/foo.o] Error 1
    gmake[1]: *** [foo/bar/baz/Makefile:200: src/foo.o] Error 1
    make: *** [Makefile:114: all] Error 2
    gmake: *** [Makefile:114: all] Error 2
