### PR TITLE
Fix wrong screenpos() row with topfill

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -344,7 +344,8 @@ update_topline(void)
 		check_topline = TRUE;
 	    else if (check_top_offset())
 		check_topline = TRUE;
-	    else if (curwin->w_cursor.lnum == curwin->w_topline)
+	    else if (curwin->w_skipcol > 0
+				 && curwin->w_cursor.lnum == curwin->w_topline)
 	    {
 		colnr_T vcol;
 
@@ -1459,7 +1460,8 @@ textpos2screenpos(
 
 #ifdef FEAT_DIFF
 	// Add filler lines above this buffer line.
-	row += diff_check_fill(wp, lnum);
+	row += lnum == wp->w_topline ? wp->w_topfill :
+						     diff_check_fill(wp, lnum);
 #endif
 
 	colnr_T	off = win_col_off(wp);
@@ -1479,7 +1481,7 @@ textpos2screenpos(
 	    col += off;
 	    width = wp->w_width - off + win_col_off2(wp);
 
-	    if (pos->lnum == wp->w_topline)
+	    if (lnum == wp->w_topline)
 		col -= wp->w_skipcol;
 
 	    // long line wrapping, adjust row

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -132,13 +132,14 @@ func Test_screenpos()
   1split
   normal G$
   redraw
+  " w_skipcol should be subtracted
   call assert_equal({'row': winrow + 0,
 	\ 'col': wincol + 20 - 1,
 	\ 'curscol': wincol + 20 - 1,
 	\ 'endcol': wincol + 20 - 1},
 	\ screenpos(win_getid(), line('.'), col('.')))
 
-  " w_skipcol should be subtracted
+  " w_leftcol should be subtracted
   setlocal nowrap
   normal 050zl$
   call assert_equal({'row': winrow + 0,
@@ -203,6 +204,19 @@ func Test_screenpos_diff()
   windo diffthis
   wincmd w
   call assert_equal(#{col: 3, row: 7, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 8, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
+  exe "normal! 3\<C-E>"
+  call assert_equal(#{col: 3, row: 4, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 5, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
+  exe "normal! \<C-E>"
+  call assert_equal(#{col: 3, row: 3, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 4, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
+  exe "normal! \<C-E>"
+  call assert_equal(#{col: 3, row: 2, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 3, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
+  exe "normal! \<C-E>"
+  call assert_equal(#{col: 3, row: 1, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 2, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
 
   windo diffoff
   bwipe!


### PR DESCRIPTION
Fix #12484

Also fix adding 'smoothscroll' marker overlap even if skipcol is 0.
