### PR TITLE
'splitkeep' handles undrawn cursor position

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -2589,6 +2589,7 @@ win_update(win_T *wp)
     wp->w_last_cursorline = wp->w_p_cul ? wp->w_cursor.lnum : 0;
 #endif
     wp->w_last_cursor_lnum_rnu = wp->w_p_rnu ? wp->w_cursor.lnum : 0;
+    wp->w_last_cursor_lnum_drawn = wp->w_cursor.lnum;
 
 #ifdef FEAT_VTP
     // Rewrite the character at the end of the screen line.

--- a/src/structs.h
+++ b/src/structs.h
@@ -3709,6 +3709,8 @@ struct window_S
 
     linenr_T    w_last_cursor_lnum_rnu;  // cursor lnum when 'rnu' was last
 					 // redrawn
+    linenr_T    w_last_cursor_lnum_drawn;// cursor lnum when window was last
+					 // redrawn
 
     lcs_chars_T	w_lcs_chars;	    // 'listchars' characters
     fill_chars_T w_fill_chars;	    // 'fillchars' characters

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1703,7 +1703,7 @@ func Test_splitkeep_options()
     " No scroll when resizing windows
     wincmd k | resize +2 | redraw
     call assert_equal(1, line("w0"))
-    wincmd j
+    wincmd j | redraw!
     call assert_equal(&spk == 'topline' ? 1 : win_screenpos(0)[0] - tl - wsb, line("w0"))
 
     " No scroll when dragging statusline
@@ -1715,7 +1715,7 @@ func Test_splitkeep_options()
     " No scroll when changing shellsize
     set lines+=2
     call assert_equal(1, line("w0"))
-    wincmd j
+    wincmd j | redraw
     call assert_equal(&spk == 'topline' ? 1 : win_screenpos(0)[0] - tl - wsb, line("w0"))
     set lines-=2
     call assert_equal(&spk == 'topline' ? 1 : win_screenpos(0)[0] - tl - wsb, line("w0"))
@@ -1824,10 +1824,12 @@ func Test_splitkeep_misc()
   " Cursor is adjusted to start and end of buffer
   norm M
   wincmd s
+  redraw
   resize 1
   call assert_equal(1, line('.'))
   wincmd j
   norm GM
+  redraw
   resize 1
   call assert_equal(&lines, line('.'))
   only!
@@ -1858,6 +1860,30 @@ func Test_splitkeep_misc()
 
   %bwipeout!
   set splitbelow&
+  set splitkeep&
+endfunc
+
+func Test_splitkeep_cursor_resize()
+  set splitkeep=screen
+
+  func CursorResize()
+    call cursor(100, 1)
+    wincmd -
+  endfunc
+  func CursorEqualize()
+    call cursor(100, 1)
+    wincmd =
+  endfunc
+
+  call setline(1, range(1, 200))
+  call CursorResize()
+  call assert_equal(100, line('.'))
+
+  norm gg
+  call CursorEqualize()
+  call assert_equal(100, line('.'))
+
+  bwipeout!
   set splitkeep&
 endfunc
 

--- a/src/window.c
+++ b/src/window.c
@@ -6821,7 +6821,11 @@ win_fix_scroll(int resize)
 	wp->w_prev_winrow = wp->w_winrow;
     }
     skip_update_topline = FALSE;
-    // Ensure cursor is valid when not in normal mode or when resized.
+    // If the cursor position hasn't changed since it was last drawn, ensure
+    // cursor is valid when not in normal mode or when resized.  If it has
+    // changed, let update_topline() move the cursor onto the screen.
+    if (curwin->w_cursor.lnum != curwin->w_last_cursor_lnum_drawn)
+	return;
     if (!(get_real_state() & (MODE_NORMAL|MODE_CMDLINE|MODE_TERMINAL)))
 	win_fix_cursor(FALSE);
     else if (resize)
@@ -6874,7 +6878,7 @@ win_fix_cursor(int normal)
 	{
 	    wp->w_fraction = (nlnum == bot) ? FRACTION_MULT : 0;
 	    scroll_to_fraction(wp, wp->w_prev_height);
-	    validate_botline_win(curwin);
+	    validate_botline();
 	}
     }
 }


### PR DESCRIPTION
Problem:    Cursor is adjusted to keep "topline" or "screen" for
            a cursor position that was not drawn in the first place.
Solution:   Avoid adjusting cursor position when the current cursor
            position was never drawn.