### PR TITLE
Redundant calls to update_topline() before curs_columns()

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -7032,11 +7032,8 @@ scroll_to_fraction(win_T *wp, int prev_height)
     }
 
     if (wp == curwin)
-    {
-	if (get_scrolloff_value())
-	    update_topline();
 	curs_columns(FALSE);	// validate w_wrow
-    }
+
     if (prev_height > 0)
 	wp->w_prev_fraction_row = wp->w_wrow;
 
@@ -7055,13 +7052,10 @@ win_new_width(win_T *wp, int width)
     wp->w_lines_valid = 0;
     changed_line_abv_curs_win(wp);
     invalidate_botline_win(wp);
-    if (wp == curwin)
-    {
-	skip_update_topline = (*p_spk != 'c');
-	update_topline();
+
+    if (wp == curwin && *p_spk == 'c')
 	curs_columns(TRUE);	// validate w_wrow
-	skip_update_topline = FALSE;
-    }
+
     redraw_win_later(wp, UPD_NOT_VALID);
     wp->w_redr_status = TRUE;
 }


### PR DESCRIPTION
update_topline() is always called in curs_columns(), so these callers don't have to.