### PR TITLE
Add filetype t32

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2234,6 +2234,9 @@ au BufNewFile,BufRead *.toml			setf toml
 " TPP - Text Presentation Program
 au BufNewFile,BufRead *.tpp			setf tpp
 
+" TRACE32 Script Language
+au BufNewFile,BufRead *.cmm,*.t32		setf t32
+
 " Treetop
 au BufRead,BufNewFile *.treetop			setf treetop
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -662,6 +662,7 @@ def s:GetFilenameChecks(): dict<list<string>>
               'any/etc/systemd/system/file.d/.#-file',
               'any/etc/systemd/system/file.d/file.conf'],
     systemverilog: ['file.sv', 'file.svh'],
+    t32: ['file.cmm', 'file.t32'],
     tags: ['tags'],
     tak: ['file.tak'],
     tal: ['file.tal'],


### PR DESCRIPTION
TRACE32 is a debug tool for embedded systems. It includes a [scripting language](https://repo.lauterbach.com/pdf/practice_user.pdf) for automation purposes. Typically, scripts have the file extension _CMM_. The suffix _T32_ is used for auto-generated files with configuration settings.