### PR TITLE
termdebug: frame related commands

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1376,6 +1376,21 @@ This is similar to using "print" in the gdb window.
 You can usually shorten `:Evaluate` to `:Ev`.
 
 
+Navigation in the Stack ~
+					*termdebug-variables* *:Frame*
+ `:Frame`	Select the given frame, using  either the frame's
+                stack number, address, or function name.
+ `:Up`	        Select the frame that called the current one with an
+                optional argument to say how many frames to go up.
+ `+`		same (see |termdebug_map_plus| to disable)
+ `:Down`	        Select the frame called by the current one with
+                an optional argument to say how many frames to go down.
+ `-`		same (see |termdebug_map_minus| to disable)
+
+This is similar to using "print" in the gdb window.
+You can usually shorten `:Evaluate` to `:Ev`.
+
+
 Other commands ~
 							*termdebug-commands*
  *:Gdb*	     jump to the gdb window
@@ -1453,6 +1468,14 @@ The K key is normally mapped to :Evaluate. If you do not want this use: >
 	let g:termdebug_config['map_K'] = 0
 If there is no g:termdebug_config you can use: >
 	let g:termdebug_map_K = 0
+<
+						*termdebug_map_minus*
+The - key is normally mapped to :Down. If you do not want this use: >
+	let g:termdebug_config['map_minus'] = 0
+<
+						*termdebug_map_plus*
+The + key is normally mapped to :Up. If you do not want this use: >
+	let g:termdebug_config['map_plus'] = 0
 <
 						*termdebug_disasm_window*
 If you want the Asm window shown by default, set the "disasm_window" flag to

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -965,6 +965,10 @@ func s:InstallCommands()
     command Continue call term_sendkeys(s:gdbbuf, "continue\r")
   endif
 
+  command -nargs=* Frame call s:Frame(<q-args>)
+  command -nargs=* Up call s:Up(<q-args>)
+  command -nargs=* Down call s:Down(<q-args>)
+
   command -range -nargs=* Evaluate call s:Evaluate(<range>, <q-args>)
   command Gdb call win_gotoid(s:gdbwin)
   command Program call s:GotoProgram()
@@ -983,6 +987,25 @@ func s:InstallCommands()
     let s:k_map_saved = maparg('K', 'n', 0, 1)
     nnoremap K :Evaluate<CR>
   endif
+
+  let map = 1
+  if exists('g:termdebug_config')
+    let map = get(g:termdebug_config, 'map_plus', 1)
+  endif
+  if map
+    let s:plus_map_saved = maparg('+', 'n', 0, 1)
+    nnoremap + :Up<CR>
+  endif
+
+  let map = 1
+  if exists('g:termdebug_config')
+    let map = get(g:termdebug_config, 'map_minus', 1)
+  endif
+  if map
+    let s:minus_map_saved = maparg('-', 'n', 0, 1)
+    nnoremap - :Down<CR>
+  endif
+
 
   if has('menu') && &mouse != ''
     call s:InstallWinbar(0)
@@ -1040,6 +1063,9 @@ func s:DeleteCommands()
   delcommand Arguments
   delcommand Stop
   delcommand Continue
+  delcommand Frame
+  delcommand Up
+  delcommand Down
   delcommand Evaluate
   delcommand Gdb
   delcommand Program
@@ -1055,6 +1081,22 @@ func s:DeleteCommands()
       call mapset(s:k_map_saved)
     endif
     unlet s:k_map_saved
+  endif
+  if exists('s:plus_map_saved')
+    if empty(s:plus_map_saved)
+      nunmap +
+    else
+      call mapset(s:plus_map_saved)
+    endif
+    unlet s:plus_map_saved
+  endif
+  if exists('s:minus_map_saved')
+    if empty(s:minus_map_saved)
+      nunmap -
+    else
+      call mapset(s:minus_map_saved)
+    endif
+    unlet s:minus_map_saved
   endif
 
   if has('menu')
@@ -1170,6 +1212,47 @@ func s:Run(args)
     call s:SendResumingCommand('-exec-arguments ' . a:args)
   endif
   call s:SendResumingCommand('-exec-run')
+endfunc
+
+" :Frame - go to a specfic frame in the stack
+func s:Frame(arg)
+  " Note: we explicit do not use mi's command
+  " call s:SendCommand('-stack-select-frame "' . a:arg .'"')
+  " as we only get a "done" mi response and would have to open the file
+  " 'manually' - using cli command "frame" provides us with the mi response
+  " already parsed and allows for more formats
+  if a:arg =~ '^\d\+$' || a:arg == ''
+    " specify frame by number
+    call s:SendCommand('-interpreter-exec mi "frame ' . a:arg .'"')
+  elseif a:arg =~ '^0x[0-9a-fA-F]\+$'
+    " specify frame by stack address
+    call s:SendCommand('-interpreter-exec mi "frame address ' . a:arg .'"')
+  else
+    " specify frame by function name
+    call s:SendCommand('-interpreter-exec mi "frame function ' . a:arg .'"')
+  endif
+endfunc
+
+" :Up - go one frame in the stack "higher"
+func s:Up(arg)
+  if a:arg != ''
+    let s:cmd = '"up ' . a:arg . '"'
+  else
+    let s:cmd = '"up"'
+  endif
+  " the 'correct' one would be -stack-select-frame N, but we don't know N
+  call s:SendCommand('-interpreter-exec console ' . s:cmd)
+endfunc
+
+" :Down - go one frame in the stack "below"
+func s:Down(arg)
+  if a:arg != ''
+    let s:cmd = '"down ' . a:arg . '"'
+  else
+    let s:cmd = '"down"'
+  endif
+  " the 'correct' one would be -stack-select-frame N, but we don't know N
+  call s:SendCommand('-interpreter-exec console ' . s:cmd)
 endfunc
 
 func s:SendEval(expr)


### PR DESCRIPTION
partially fixing #10393

... its been a while that this was setting around. I do hope someone may take this as an option to get the commands already into termdebug before I try to add a window - as that is complicated and we have no finished design for that.

I do know that this PR is missing something: the help text - if possible please add it (as the PRs are not merged "directly" I think that's fine). Also I did not have another look at the FIXME note in the Frames command.

One thing I'd do suggest is to add a default mapping for Down as "D" and Up as "d". But as - again - only K is default mapped I was not sure if that's "too intrusive".

Thanks for considering this contribution!