### PR TITLE
Use long name "trace32" for TRACE32 files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2235,7 +2235,7 @@ au BufNewFile,BufRead *.toml			setf toml
 au BufNewFile,BufRead *.tpp			setf tpp
 
 " TRACE32 Script Language
-au BufNewFile,BufRead *.cmm,*.t32		setf t32
+au BufNewFile,BufRead *.cmm,*.t32		setf trace32
 
 " Treetop
 au BufRead,BufNewFile *.treetop			setf treetop

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -662,7 +662,7 @@ def s:GetFilenameChecks(): dict<list<string>>
               'any/etc/systemd/system/file.d/.#-file',
               'any/etc/systemd/system/file.d/file.conf'],
     systemverilog: ['file.sv', 'file.svh'],
-    t32: ['file.cmm', 'file.t32'],
+    trace32: ['file.cmm', 'file.t32'],
     tags: ['tags'],
     tak: ['file.tak'],
     tal: ['file.tal'],


### PR DESCRIPTION
Replaces file type "t32", because the longer version is more clear. (#12505)