### PR TITLE
fix(xdiff) add explicit cast to suppress compiler warning

### DIFF
--- a/src/xdiff/xutils.c
+++ b/src/xdiff/xutils.c
@@ -442,7 +442,7 @@ void* xdl_alloc_grow_helper(void *p, long nr, long *alloc, size_t size)
 	if (SIZE_MAX / size >= n)
 		tmp = xdl_realloc(p, n * size);
 	if (tmp) {
-		*alloc = n;
+		*alloc = (long)n;
 	} else {
 		xdl_free(p);
 		*alloc = 0;


### PR DESCRIPTION
Add explicit cast from size_t to long to resolve MS compiler warning.