### PR TITLE
Fix syntaxtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ VIM_FOR_SYNTAXTEST = ../../src/vim
 syntaxtest:
 	cd runtime/syntax && \
 		$(MAKE) clean && \
-		$(MAKE) test VIM="$(VIM_FOR_SYNTAXTEST)"
+		$(MAKE) test VIMPROG="$(VIM_FOR_SYNTAXTEST)"
 
 
 #########################################################################


### PR DESCRIPTION
Especially on FreeBSD.

It failed like this: https://github.com/vim/vim/pull/12534/checks?check_run_id=14218242478

```
�[?25hcd runtime/syntax &&  make clean &&  make test VIM="../../src/vim"
rm -f testdir/failed/* testdir/done/* testdir/vimcmd
VIMRUNTIME=../.. vim --clean --not-a-term -u testdir/runtest.vim
/bin/sh: vim: not found
*** Error code 127
```