### PR TITLE
Fix make clean/make distclean/make testclean from top level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,8 @@ all install uninstall tools config configure reconfig proto depend lint tags typ
 	fi
 	@# When the target is "clean" also clean for the indent and syntax tests.
 	@if test "$@" = "clean" -o "$@" = "distclean" -o "$@" = "testclean"; then \
-		cd runtime/indent && \
-			$(MAKE) clean; \
-		cd runtime/syntax && \
-			$(MAKE) clean; \
+		(cd runtime/indent && $(MAKE) clean); \
+		(cd runtime/syntax && $(MAKE) clean); \
 	fi
 
 # Executable used for running the indent tests.


### PR DESCRIPTION
Problem: make distclean, clean, testclean fail from top level
Solution: restore the cwd after cleaning inside runtime directories.


Previously, the embedded script would:

* cd to runtime/indent
* run make clean
* attempt to cd to runtime/syntax, failing (as runtime/indent/runtime/syntax doesn't exit)

Solution is to run the cd & make in a sub shell.

Also considered this:

```
	@if test "$@" = "clean" -o "$@" = "distclean" -o "$@" = "testclean"; then \
		$(MAKE) -C runtime/indent clean; \
		$(MAKE) -C runtime/syntax clean; \
	fi
```

But wasn't sure if `make -C` is universally supported, and avoided it given Vim's makefiles don't appear to rely on it in other places.