### PR TITLE
fix warning about possibly uninitialized eof var in fileio.

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -218,7 +218,7 @@ readfile(
     int		using_b_ffname;
     int		using_b_fname;
     static char *msg_is_a_directory = N_("is a directory");
-    int		eof;
+    int		eof = FALSE;
 #ifdef FEAT_SODIUM
     int		may_need_lseek = FALSE;
 #endif
@@ -1229,7 +1229,6 @@ retry:
 		     * Read bytes from curbuf.  Used for converting text read
 		     * from stdin.
 		     */
-		    eof = FALSE;
 		    if (read_buf_lnum > from)
 			size = 0;
 		    else


### PR DESCRIPTION
So my gcc 12.2 started complaining about possibly using an uninitialized variable eof:
,----
| fileio.c: In function ‘readfile’:
| fileio.c:221:17: warning: ‘eof’ may be used uninitialized [-Wmaybe-uninitialized]
|   221 |     int         eof;
|       |                 ^~~
`----

It is currently only initialized in the `if (read_buffer)` case but not in the else clause. There is the following code:

    if (read_buffer)
      eof = FALSE;
    else                  [1]
    {
      if (filesize == 0)
       [...]
      else if (filesize > 0 ...  [4]
      {
          [...]
	  if (curbuf->b_cryptstate->method_nr == CRYPT_M_SOD
					&& !eof && may_need_lseek)   [3]
	  {
          [...]

	  }
      }
      eof = size;        [2]

In the `else` condition [1], eof will only be initialized at [2], while it looks like it may be used at [3].

So technically, the `eof` variable could be accessed uninitialized in the else if case [4]. This can not happen, because filesize is initialized to zero, so Vim cannot run into this case in practice and after the first loop, eof will be initialized.

However, I think it's worth it, to move the initialization of the `eof` variable to the beginning of the function and don't init it in both branches of the if/else condition and also also do not depend on the implicit initialization of the filesize variable.