### PR TITLE
Fix executable() ignoring symlinks on windows

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -1775,7 +1775,11 @@ is_reparse_point_included(LPCWSTR fname)
     return FALSE;
 }
 
-    static char_u *
+/*
+ * Return the resolved file path, NULL if "fname" is an AppExecLink reparse
+ * point, already fully resolved, or it doesn't exists.
+ */
+    char_u *
 resolve_reparse_point(char_u *fname)
 {
     HANDLE	    h = INVALID_HANDLE_VALUE;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2721,6 +2721,8 @@ executable_file(char *name, char_u **path)
     {
 	char_u	*res = resolve_appexeclink((char_u *)name);
 	if (res == NULL)
+	    res = resolve_reparse_point((char_u *)name);
+	if (res == NULL)
 	    return FALSE;
 	// The path is already absolute.
 	if (path != NULL)

--- a/src/proto/os_mswin.pro
+++ b/src/proto/os_mswin.pro
@@ -37,6 +37,7 @@ int mch_print_text_out(char_u *p, int len);
 void mch_print_set_font(int iBold, int iItalic, int iUnderline);
 void mch_print_set_bg(long_u bgcol);
 void mch_print_set_fg(long_u fgcol);
+char_u *resolve_reparse_point(char_u *fname);
 char_u *mch_resolve_path(char_u *fname, int reparse_point);
 void win32_set_foreground(void);
 void serverInitMessaging(void);

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -1803,6 +1803,10 @@ func Test_Executable()
     let [pathext, $PATHEXT] = [$PATHEXT, '.com;.exe;.bat;.cmd']
     call assert_equal(notepadbat, exepath('notepad'))
     let $PATHEXT = pathext
+    " check for symbolic link
+    execute 'silent !mklink np.bat "' .. notepadbat .. '"'
+    call assert_equal(1, executable('./np.bat'))
+    call assert_equal(1, executable('./np'))
     bwipe
     eval 'Xnotedir'->delete('rf')
   elseif has('unix')


### PR DESCRIPTION
`executable(fname)` returns 0 on windows when `fname` is a symlink pointing to an executable
e.g.
```vim
:!mklink mynotepad.exe C:\Windows\System32\notepad.exe
:echo executable('mynotepad.exe')
0
:echo executable('mynotepad')
0
:!mynotepad
*open notepad successfully*
```
Note that even with this patch a valid symlink but without a proper file extension like .exe is still rejected by executable().