### PR TITLE
termdebug: Parse filenames literally

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -588,14 +588,14 @@ func s:GdbOutCallback(channel, text)
     return
   endif
   if a:text =~ '^\^error,msg='
-    let text = s:DecodeMessage(a:text[11:])
+    let text = s:DecodeMessage(a:text[11:], v:false)
     if exists('s:evalexpr') && text =~ 'A syntax error in expression, near\|No symbol .* in current context'
       " Silently drop evaluation errors.
       unlet s:evalexpr
       return
     endif
   elseif a:text[0] == '~'
-    let text = s:DecodeMessage(a:text[1:])
+    let text = s:DecodeMessage(a:text[1:], v:false)
   else
     call s:CommOutput(a:channel, a:text)
     return
@@ -618,14 +618,13 @@ endfunc
 " - change \0xhh to \xhh (disabled for now)
 " - change \ooo to octal
 " - change \\ to \
-func s:DecodeMessage(quotedText)
+func s:DecodeMessage(quotedText, literal)
   if a:quotedText[0] != '"'
     echoerr 'DecodeMessage(): missing quote in ' . a:quotedText
     return
   endif
-  return a:quotedText
-        \ ->substitute('^"\|".*\|\\n', '', 'g')
-        \ ->substitute('\\t', "\t", 'g')
+  let msg=a:quotedText
+        \ ->substitute('^"\|".*', '', 'g')
         " multi-byte characters arrive in octal form
         " NULL-values must be kept encoded as those break the string otherwise
         \ ->substitute('\\000', s:NullRepl, 'g')
@@ -637,6 +636,13 @@ func s:DecodeMessage(quotedText)
         " \ ->substitute('\\0x00', s:NullRepl, 'g')
         \ ->substitute('\\\\', '\', 'g')
         \ ->substitute(s:NullRepl, '\\000', 'g')
+  if !a:literal
+          return msg
+        \ ->substitute('\\t', "\t", 'g')
+        \ ->substitute('\\n', '', 'g')
+  else
+          return msg
+  endif
 endfunc
 const s:NullRepl = 'XXXNULLXXX'
 
@@ -645,7 +651,7 @@ func s:GetFullname(msg)
   if a:msg !~ 'fullname'
     return ''
   endif
-  let name = s:DecodeMessage(substitute(a:msg, '.*fullname=', '', ''))
+  let name = s:DecodeMessage(substitute(a:msg, '.*fullname=', '', ''), v:true)
   if has('win32') && name =~ ':\\\\'
     " sometimes the name arrives double-escaped
     let name = substitute(name, '\\\\', '\\', 'g')
@@ -658,7 +664,7 @@ func s:GetAsmAddr(msg)
   if a:msg !~ 'addr='
     return ''
   endif
-  let addr = s:DecodeMessage(substitute(a:msg, '.*addr=', '', ''))
+  let addr = s:DecodeMessage(substitute(a:msg, '.*addr=', '', ''), v:false)
   return addr
 endfunc
 


### PR DESCRIPTION
On Windows with a default path-separator of \ a filename like test.c may occur, which would be parsed by the termdebug plugin as \t and therefore replaced by a literal tab.

The same may also happen on Unix, but there filenames with a backslash in its name are much more uncommon, while on Windows this may happen just because of the default directory separator.

So stop replacing \n and \t by their typical values when parsing filenames.

Fixes: #12560 and #12550