### PR TITLE
termdebug: install a colorscheme autocommand

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -90,9 +90,18 @@ func s:Highlight(init, old, new)
   endif
 endfunc
 
-call s:Highlight(1, '', &background)
-hi default debugBreakpoint term=reverse ctermbg=red guibg=red
-hi default debugBreakpointDisabled term=reverse ctermbg=gray guibg=gray
+func s:InitHighlight()
+  call s:Highlight(1, '', &background)
+  hi default debugBreakpoint term=reverse ctermbg=red guibg=red
+  hi default debugBreakpointDisabled term=reverse ctermbg=gray guibg=gray
+endfunc
+
+func s:InitAutocmd()
+  augroup TermDebug
+    autocmd!
+    autocmd colorscheme * call s:InitHighlight()
+  augroup END
+endfunc
 
 " Get the command to execute the debugger as a list, defaults to ["gdb"].
 func s:GetCommand()
@@ -1521,6 +1530,9 @@ func s:BufUnloaded()
     endfor
   endfor
 endfunc
+
+call s:InitHighlight()
+call s:InitAutocmd()
 
 let &cpo = s:keepcpo
 unlet s:keepcpo


### PR DESCRIPTION
When changing the colorscheme, the default highlighting groups used by the termplugin debugPC, debugBreakpoint and debugBreakpointDisabled may become cleared.

So install a colorscheme autocommand, to reset those highlighting groups to their default values.

Fixes: #12555