### PR TITLE
CI: use --enable-perlinterp=dynamic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,6 @@ jobs:
         run: |
           brew install lua
           echo "LUA_PREFIX=/usr/local" >> $GITHUB_ENV
-          brew uninstall perl
 
       - name: Set up environment
         run: |
@@ -289,7 +288,7 @@ jobs:
           normal)
             ;;
           huge)
-            echo "CONFOPT=--enable-perlinterp --enable-python3interp --enable-rubyinterp --enable-luainterp --enable-tclinterp"
+            echo "CONFOPT=--enable-perlinterp=dynamic --enable-python3interp --enable-rubyinterp --enable-luainterp --enable-tclinterp"
             ;;
           esac
           ) >> $GITHUB_ENV


### PR DESCRIPTION
to make sure we get no errors on stable Perl Versions. And can fix them if necessary.
refs:
https://github.com/vim/vim/issues/12543
https://github.com/Perl/perl5/issues/21164