### PR TITLE
Files for haskell persistent library are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -891,6 +891,7 @@ if exists('$XDG_CONFIG_HOME')
 endif
 au BufNewFile,BufRead $HOME/.config/cabal/config setf cabalconfig
 au BufNewFile,BufRead cabal.config		setf cabalconfig
+au BufNewFile,BufRead *.persistentmodels	setf haskell.persistent
 
 " Haste
 au BufNewFile,BufRead *.ht			setf haste

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -891,7 +891,7 @@ if exists('$XDG_CONFIG_HOME')
 endif
 au BufNewFile,BufRead $HOME/.config/cabal/config setf cabalconfig
 au BufNewFile,BufRead cabal.config		setf cabalconfig
-au BufNewFile,BufRead *.persistentmodels	setf haskell.persistent
+au BufNewFile,BufRead *.persistentmodels	setf haskellpersistent
 
 " Haste
 au BufNewFile,BufRead *.ht			setf haste

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -286,6 +286,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     handlebars: ['file.hbs'],
     hare: ['file.ha'],
     haskell: ['file.hs', 'file.hsc', 'file.hs-boot', 'file.hsig'],
+    'haskell.persistent': ['file.persistentmodels'],
     haste: ['file.ht'],
     hastepreproc: ['file.htpp'],
     hb: ['file.hb'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -286,7 +286,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     handlebars: ['file.hbs'],
     hare: ['file.ha'],
     haskell: ['file.hs', 'file.hsc', 'file.hs-boot', 'file.hsig'],
-    'haskell.persistent': ['file.persistentmodels'],
+    haskellpersistent: ['file.persistentmodels'],
     haste: ['file.ht'],
     hastepreproc: ['file.htpp'],
     hb: ['file.hb'],


### PR DESCRIPTION
Add filetype for the [persistent library](https://hackage.haskell.org/package/persistent). The extension `.persistentmodels` is recommended [here](https://hackage.haskell.org/package/persistent-2.14.5.0/docs/Database-Persist-TH.html#v:persistFileWith).