### PR TITLE
PEM files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1532,6 +1532,9 @@ au BufNewFile,BufRead *.pm
 " Perl POD
 au BufNewFile,BufRead *.pod			setf pod
 
+" PEM
+au BufNewFile,BufRead *.pem,*.cer,*.crt,*.csr	setf pem
+
 " Php, php3, php4, etc.
 " Also Phtml (was used for PHP 2 in the past).
 " Also .ctp for Cake template file.

--- a/runtime/syntax/pem.vim
+++ b/runtime/syntax/pem.vim
@@ -1,0 +1,33 @@
+
+" Vim syntax file
+" Language:	PEM
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Filenames:	*.pem,*.cer,*.crt,*.csr
+" Last Change:	2023 Jun 24
+
+if exists('b:current_syntax')
+    finish
+endif
+
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
+syn region pemHeader matchgroup=pemDashes
+            \ start=/^-----\zeBEGIN/ end=/-----$/ contains=pemBegin
+syn region pemFooter matchgroup=pemDashes
+            \ start=/^-----\zeEND/ end=/-----$/ contains=pemEnd
+
+syn keyword pemBegin contained BEGIN nextgroup=pemLabel skipwhite
+syn keyword pemEnd contained END nextgroup=pemLabel skipwhite
+
+syn match pemLabel contained /[^-]\+/
+
+hi def link pemBegin Keyword
+hi def link pemEnd Keyword
+hi def link pemLabel Label
+hi def link pemDashes Delimiter
+
+let b:current_syntax = 'pem'
+
+let &cpoptions = s:cpo_save
+unlet s:cpo_save

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -507,6 +507,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     pcmk: ['file.pcmk'],
     pdf: ['file.pdf'],
     perl: ['file.plx', 'file.al', 'file.psgi', 'gitolite.rc', '.gitolite.rc', 'example.gitolite.rc', '.latexmkrc', 'latexmkrc'],
+    pem: ['file.pem', 'file.cer', 'file.crt', 'file.csr'],
     pf: ['pf.conf'],
     pfmain: ['main.cf', 'main.cf.proto'],
     php: ['file.php', 'file.php9', 'file.phtml', 'file.ctp', 'file.phpt', 'file.theme'],


### PR DESCRIPTION
The format is defined in [RFC7468](https://www.rfc-editor.org/rfc/rfc7468).

Things to consider:
- Should the filetype be "pem" or something else?
- Should we support more extensions (e.g. `.key`)?