### PR TITLE
termdebug: fix sign text is longer than 2 characters (E239)

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1547,12 +1547,12 @@ Termdebug uses the last two characters of the breakpoint ID in the
 signcolumn to represent breakpoints. For example, breakpoint ID 133
 will be displayed as `33`.
 
-If you want to customise the breakpoint signcolumn label: >
-	let g:termdebug_config['label'] = 'BB'
+If you want to customise the breakpoint signs: >
+	let g:termdebug_config['sign'] = '>>'
 If there is no g:terminal_config you can use: >
-	let g:termdebug_label = 'BB'
+	let g:termdebug_sign = '>>'
 
-After this, breakpoints will be displayed as `BB` in the signcolumn.
+After this, breakpoints will be displayed as `>>` in the signcolumn.
 
 
 Window toolbar ~

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1543,8 +1543,8 @@ If there is no g:termdebug_config you can use: >
 
 Change default signs ~
 							*termdebug_signs*
-Termdebug uses the last two characters of the breakpoint ID in the 
-signcolumn to represent breakpoints. For example, breakpoint ID 133 
+Termdebug uses the last two characters of the breakpoint ID in the
+signcolumn to represent breakpoints. For example, breakpoint ID 133
 will be displayed as `33`.
 
 If you want to customise the breakpoint signcolumn label: >

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1541,6 +1541,20 @@ If there is no g:termdebug_config you can use: >
 	let g:termdebug_popup = 0
 
 
+Change default signs ~
+							*termdebug_signs*
+Termdebug uses the last two characters of the breakpoint ID in the 
+signcolumn to represent breakpoints. For example, breakpoint ID 133 
+will be displayed as `33`.
+
+If you want to customise the breakpoint signcolumn label: >
+	let g:termdebug_config['label'] = 'BB'
+If there is no g:terminal_config you can use: >
+	let g:termdebug_label = 'BB'
+
+After this, breakpoints will be displayed as `BB` in the signcolumn.
+
+
 Window toolbar ~
 							*termdebug_winbar*
 By default the Termdebug plugin creates a window toolbar if the mouse is

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1401,9 +1401,21 @@ func s:CreateBreakpoint(id, subid, enabled)
     else
       let hiName = "debugBreakpoint"
     endif
+    let label = ''
+    if exists('g:termdebug_config')
+        let label = get(g:termdebug_config, 'label', '')
+    elseif exists('g:termdebug_label')
+        let label = g:termdebug_label
+    endif
+    if label == ''
+        let label = substitute(nr, '\..*', '', '')
+        if strlen(label) > 2
+            let label = strpart(label, strlen(label) - 2)
+        endif
+    endif
     call sign_define('debugBreakpoint' .. nr,
-			    \ #{text: substitute(nr, '\..*', '', ''),
-			    \ texthl: hiName})
+				\ #{text: strpart(label, 0, 2), 
+				\ texthl: hiName})
   endif
 endfunc
 

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1403,9 +1403,9 @@ func s:CreateBreakpoint(id, subid, enabled)
     endif
     let label = ''
     if exists('g:termdebug_config')
-        let label = get(g:termdebug_config, 'label', '')
-    elseif exists('g:termdebug_label')
-        let label = g:termdebug_label
+        let label = get(g:termdebug_config, 'sign', '')
+    elseif exists('g:termdebug_sign')
+        let label = g:termdebug_sign
     endif
     if label == ''
         let label = substitute(nr, '\..*', '', '')


### PR DESCRIPTION
In termdebug, when breakpoint id is greater than 99 the `CreateBreakpoint` function will fail because
the `text` element in `sign_defined()` function only accept strings no more than 2 characters.

solution:

1) always display the last two characters of the breakpoint id, in other words, 133 will display as `33`.
2) if `g:termdebug_config['sign']` is defined by user, display it in the signcolumn instead of the the breakpoint id.

closes https://github.com/vim/vim/issues/12588