### PR TITLE
fix segfault in crypt code

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -907,6 +907,16 @@ crypt_append_msg(
     }
 }
 
+    void
+crypt_sodium_lock_key(
+       char_u  *key)
+{
+    if (sodium_init() < 0)
+       return;
+    sodium_mlock(key, STRLEN(key));
+    return;
+}
+
     static int
 crypt_sodium_init_(
     cryptstate_T	*state UNUSED,

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -907,6 +907,7 @@ crypt_append_msg(
     }
 }
 
+# ifdef FEAT_SODIUM
     void
 crypt_sodium_lock_key(
        char_u  *key)
@@ -916,6 +917,7 @@ crypt_sodium_lock_key(
     sodium_mlock(key, STRLEN(key));
     return;
 }
+# endif
 
     static int
 crypt_sodium_init_(

--- a/src/memline.c
+++ b/src/memline.c
@@ -2504,8 +2504,6 @@ ml_sync_all(int check_file, int check_char)
 	    // close the swapfile
 	    mf_close_file(buf, TRUE);
 	    buf->b_p_swf = FALSE;
-	    vim_free(buf->b_p_key);
-	    buf->b_p_key = empty_option;
 	    continue;
 	}
 #endif
@@ -2567,6 +2565,17 @@ ml_preserve(buf_T *buf, int message)
 	    emsg(_(e_cannot_preserve_there_is_no_swap_file));
 	return;
     }
+#ifdef FEAT_CRYPT
+       // Safety Check
+       if (crypt_method_is_sodium(crypt_get_method_nr(buf))
+                                       && *buf->b_p_key != NUL)
+       {
+           // close the swapfile
+           mf_close_file(buf, TRUE);
+           buf->b_p_swf = FALSE;
+           return;
+       }
+#endif
 
     // We only want to stop when interrupted here, not when interrupted
     // before.

--- a/src/memline.c
+++ b/src/memline.c
@@ -501,6 +501,7 @@ ml_set_crypt_key(
 	return;  // no memfile yet, nothing to do
     old_method = crypt_method_nr_from_name(old_cm);
 
+#ifdef FEAT_CRYPT
     // Swapfile encryption is not supported by XChaCha20, therefore disable the
     // swapfile to avoid plain text being written to disk.
     if (crypt_method_is_sodium(crypt_get_method_nr(buf))
@@ -511,6 +512,7 @@ ml_set_crypt_key(
 	buf->b_p_swf = FALSE;
 	return;
     }
+#endif
 
     // First make sure the swapfile is in a consistent state, using the old
     // key and method.
@@ -2494,6 +2496,7 @@ ml_sync_all(int check_file, int check_char)
 		|| buf->b_ml.ml_mfp->mf_fd < 0)
 	    continue;			    // no file
 
+#ifdef FEAT_CRYPT
 	// Safety Check
 	if (crypt_method_is_sodium(crypt_get_method_nr(buf))
 					&& *buf->b_p_key != NUL)
@@ -2505,6 +2508,7 @@ ml_sync_all(int check_file, int check_char)
 	    buf->b_p_key = empty_option;
 	    continue;
 	}
+#endif
 
 	ml_flush_line(buf);		    // flush buffered line
 					    // flush locked block

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1174,6 +1174,10 @@ did_set_cryptkey(optset_T *args)
 		*curbuf->b_p_cm == NUL ? p_cm : curbuf->b_p_cm);
 	changed_internal();
     }
+#ifdef FEAT_SODIUM
+    if (crypt_method_is_sodium(crypt_get_method_nr(curbuf)))
+       crypt_sodium_lock_key(args->os_newval.string);
+#endif
 
     return NULL;
 }

--- a/src/proto/crypt.pro
+++ b/src/proto/crypt.pro
@@ -30,4 +30,6 @@ int crypt_sodium_munlock(void *const addr, const size_t len);
 void crypt_sodium_randombytes_buf(void *const buf, const size_t size);
 int crypt_sodium_init(void);
 uint32_t crypt_sodium_randombytes_random(void);
+void crypt_sodium_lock_key(char_u *key);
+
 /* vim: set ft=c : */

--- a/src/testdir/test_crypt.vim
+++ b/src/testdir/test_crypt.vim
@@ -392,4 +392,24 @@ func Test_crypt_set_key_changes_buffer()
   call delete('Xtest1.txt')
 endfunc
 
+func Test_crypt_set_key_segfault()
+  CheckFeature sodium
+
+  defer delete('Xtest2.txt')
+  new Xtest2.txt
+  call setline(1, 'nothing')
+  set cryptmethod=xchacha20
+  set key=foobar
+  w
+  new Xtest3
+  put ='other content'
+  setl modified
+  sil! preserve
+  bw!
+
+  set cryptmethod&
+  set key=
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_crypt.vim
+++ b/src/testdir/test_crypt.vim
@@ -394,8 +394,6 @@ endfunc
 
 func Test_crypt_set_key_segfault()
   CheckFeature sodium
-  " This test fails on Windows, why?
-  CheckNotMSWindows
 
   defer delete('Xtest2.txt')
   new Xtest2.txt

--- a/src/testdir/test_crypt.vim
+++ b/src/testdir/test_crypt.vim
@@ -394,6 +394,8 @@ endfunc
 
 func Test_crypt_set_key_segfault()
   CheckFeature sodium
+  " This test fails on Windows, why?
+  CheckNotMSWindows
 
   defer delete('Xtest2.txt')
   new Xtest2.txt


### PR DESCRIPTION
This fixes #12585 by adding some checks for the sodium encryption into the swapfile creation code.

Not sure this is the best way.