### PR TITLE
Make it possible to move to last non-blank char on a line

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -242,8 +242,8 @@ gM			Like "g0", but to halfway the text of the line.
 			Thus "10gM" is near the start of the text and "90gM"
 			is near the end of the text.
 
-							*g$* *g<End>*
-g$ or g<End>		When lines wrap ('wrap' on): To the last character of
+							*g$*
+g$			When lines wrap ('wrap' on): To the last character of
 			the screen line and [count - 1] screen lines downward
 			|inclusive|.  Differs from "$" when a line is wider
 			than the screen.
@@ -255,6 +255,9 @@ g$ or g<End>		When lines wrap ('wrap' on): To the last character of
 			instead of going to the end of the line.
 			When 'virtualedit' is enabled moves to the end of the
 			screen line.
+							*g<End>*
+g<End>			Like |g$| but to the last non-blank character
+			instead of the last character.
 
 							*bar*
 |			To screen column [count] in the current line.

--- a/src/normal.c
+++ b/src/normal.c
@@ -5812,6 +5812,10 @@ nv_g_dollar_cmd(cmdarg_T *cap)
     oparg_T	*oap = cap->oap;
     int		i;
     int		col_off = curwin_col_off();
+    int		flag = FALSE;
+
+    if (cap->nchar == K_END)
+	flag = TRUE;
 
     oap->motion_type = MCHAR;
     oap->inclusive = TRUE;
@@ -5876,6 +5880,13 @@ nv_g_dollar_cmd(cmdarg_T *cap)
 
 	// Make sure we stick in this column.
 	update_curswant_force();
+    }
+    if (flag)
+    {
+	do
+	    i = gchar_cursor();
+	while (VIM_ISWHITE(i) && oneleft() == OK);
+	curwin->w_valid &= ~VALID_WCOL;
     }
 }
 

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -3998,4 +3998,22 @@ func Test_normal_j_below_botline()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_normal33_g_cmd_nonblank()
+  " Test that g$ goes to the last non-blank char and g<end> to the last
+  " visible column
+  20vnew
+  setlocal nowrap nonumber signcolumn=no
+  call setline(1, ['fooo   fooo         fooo   fooo         fooo   fooo         fooo   fooo        '])
+  exe "normal 0g\<end>"
+  call assert_equal(11, col('.'))
+  normal 0g$
+  call assert_equal(20, col('.'))
+  setlocal wrap
+  exe "normal 0g\<end>"
+  call assert_equal(11, col('.'))
+  normal 0g$
+  call assert_equal(20, col('.'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
We can distinguish between g0 and g^ to move to the very first character and the first non-blank char.

And while we can move to the last screen char, we cannot go to the last non-blank screen char.

Since I think `g$` is the more widely used and known movement command (and `g<end>` is synonymous to it) change the behaviour of `g<end>` to move to last non-screen char instead and don't have this be the same command as the g$ command anymore.

If you want to keep the old behaviour, you can use:

```
nnoremap g<end> g$
```

Add a test to verify the behaviour.