### PR TITLE
Fix possible uninitialized var in memline.c

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -3626,7 +3626,7 @@ adjust_text_props_for_delete(
     int		idx;
     int		line_start;
     long	line_size;
-    int		this_props_len;
+    int		this_props_len = 0;
     char_u	*text;
     size_t	textlen;
     int		found;


### PR DESCRIPTION
With gcc on msys64:
,----
| $ gcc --version
| gcc.exe (Rev6, Built by MSYS2 project) 13.1.0
| Copyright (C) 2023 Free Software Foundation, Inc. | This is free software; see the source for copying conditions.  There is NO | warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. `----

I see the following warning in memline.c:

,----
| memline.c: In function 'adjust_text_props_for_delete': | memline.c:3670:43: warning: 'this_props_len' may be used uninitialized [-Wmaybe-uninitialized]
|  3670 |             for (done_this = 0; done_this < this_props_len;
|       |                                 ~~~~~~~~~~^~~~~~~~~~~~~~~~
| memline.c:3629:17: note: 'this_props_len' was declared here
|  3629 |     int         this_props_len;
|       |                 ^~~~~~~~~~~~~~
| In file included from memline.c:45:
| memline.c:3677:56: warning: 'text' may be used uninitialized [-Wmaybe-uninitialized]
|  3677 |                 mch_memmove(&prop_this, text + textlen + done_this,
| vim.h:1803:66: note: in definition of macro 'mch_memmove'
|  1803 | # define mch_memmove(to, from, len) memmove((char*)(to), (char*)(from), (size_t)(len))
|       |                                                                  ^~~~
| memline.c:3630:18: note: 'text' was declared here
|  3630 |     char_u      *text;
|       |                  ^~~~
| memline.c:3677:56: warning: 'textlen' may be used uninitialized [-Wmaybe-uninitialized]
|  3677 |                 mch_memmove(&prop_this, text + textlen + done_this,
|       |                                                        ^
| vim.h:1803:66: note: in definition of macro 'mch_memmove'
|  1803 | # define mch_memmove(to, from, len) memmove((char*)(to), (char*)(from), (size_t)(len))
|       |                                                                  ^~~~
| memline.c:3631:17: note: 'textlen' was declared here
|  3631 |     size_t      textlen;
|       |                 ^~~~~~~
`----

Interestingly the other warnings go away, after fixing the first one and initializing this_prop_len.

But I think this may be worth it anyhow to fix this warning.