### PR TITLE
Python 3.11 depreciations seen as well on gcc compiler

### DIFF
--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -82,8 +82,9 @@
 #endif
 
 // Suppress Python 3.11 depreciations to see useful warnings
-#if defined(__clang__) && defined(__clang_major__) && __clang_major__ > 11
-# pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 // Python 3 does not support CObjects, always use Capsules


### PR DESCRIPTION
`__GNUC__` avoid this warnings on both compilers.