### PR TITLE
fix: do not set AI_V4MAPPED in ai_flags on Android

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -926,7 +926,9 @@ channel_open(
     CLEAR_FIELD(hints);
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
-# if defined(AI_ADDRCONFIG) && defined(AI_V4MAPPED)
+# if defined(__ANDROID__)
+    hints.ai_flags = AI_ADDRCONFIG;
+# elif defined(AI_ADDRCONFIG) && defined(AI_V4MAPPED)
     hints.ai_flags = AI_ADDRCONFIG | AI_V4MAPPED;
 # endif
     // Set port number manually in order to prevent name resolution services


### PR DESCRIPTION
Android's getaddrinfo returns EAI_BADFLAGS if ai_flags contains AI_V4MAPPED.