### PR TITLE
debsources files using deb822 format are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -538,8 +538,8 @@ au BufNewFile,BufRead copyright
 	\| endif
 
 " Debian Sources.list
-au BufNewFile,BufRead */etc/apt/sources.list		setf debsources
-au BufNewFile,BufRead */etc/apt/sources.list.d/*.list	setf debsources
+au BufNewFile,BufRead */etc/apt/sources.list			setf debsources
+au BufNewFile,BufRead */etc/apt/sources.list.d/*.{list,sources}	setf debsources
 
 " Deny hosts
 au BufNewFile,BufRead denyhosts.conf		setf denyhosts


### PR DESCRIPTION
If we open `/etc/apt/sources.list.d/debian.sources`, the filetype is not set.  It should be set to `debsources`.  The format `deb822` allows APT sources to be specified in a more structured way.  But this format can only be used in a `.sources` file;  not in a `.list` file.  See:

   > Files in this format have the extension .sources.

Source: https://manpages.debian.org/stretch/apt/sources.list.5.en.html#DEB822-STYLE_FORMAT
