### PR TITLE
Add a NULL check of cl in object_clear()

### DIFF
--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1502,6 +1502,9 @@ object_clear(object_T *obj)
 
     class_T *cl = obj->obj_class;
 
+	if (!cl)
+		return;
+
     // the member values are just after the object structure
     typval_T *tv = (typval_T *)(obj + 1);
     for (int i = 0; i < cl->class_obj_member_count; ++i)


### PR DESCRIPTION
In the commit d13dd30240e3, `rettv->vval.v_object->obj_class` or `cl` can be NULL, and thus a NULL check is required. However, in the following call stack, `obj->obj_class` or `cl` is not checked:
`handle_subscript()` -> `eval_lambda()` -> `clear_tv()` -> `object_unref()` -> `object_clear()`
Thus, a NULL check of `cl` should be added in `object_clear()`.
