### PR TITLE
Improve the teapot

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -156,7 +156,7 @@ digraph_setlist({digraphlist})	Boolean	register multiple |digraph|s
 echoraw({expr})			none	output {expr} as-is
 empty({expr})			Number	|TRUE| if {expr} is empty
 environ()			Dict	return environment variables
-err_teapot()			Number	produce error 418
+err_teapot([{expr}])		none	give E418 or E503 if {expr} is |TRUE|
 escape({string}, {chars})	String	escape {chars} in {string} with '\'
 eval({string})			any	evaluate {string} into its value
 eventhandler()			Number	|TRUE| if inside an event handler

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -156,7 +156,7 @@ digraph_setlist({digraphlist})	Boolean	register multiple |digraph|s
 echoraw({expr})			none	output {expr} as-is
 empty({expr})			Number	|TRUE| if {expr} is empty
 environ()			Dict	return environment variables
-err_teapot([{expr}])		none	give E418 or E503 if {expr} is |TRUE|
+err_teapot([{expr}])		none	give E418, or E503 if {expr} is |TRUE|
 escape({string}, {chars})	String	escape {chars} in {string} with '\'
 eval({string})			any	evaluate {string} into its value
 eventhandler()			Number	|TRUE| if inside an event handler

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3936,7 +3936,7 @@ f_err_teapot(typval_T *argvars, typval_T *rettv UNUSED)
 	if (argvars[0].v_type == VAR_STRING)
 	{
 	    char_u *s = tv_get_string_strict(&argvars[0]);
-	    if (s == NULL || *skipwhite(s) == NUL)
+	    if (*skipwhite(s) == NUL)
 		return;
 	}
 


### PR DESCRIPTION
Update the builtin-function-list entry. (Implicitly returns 0, but such functions usually use "none")

~~Correct the RFC number.~~ Actually it's OK.

tv_get_string_strict() can not return NULL.