### PR TITLE
forced restricted mode based on $SHELL astonishes

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -256,8 +256,6 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 		Interfaces, such as Python, Ruby and Lua, are also disabled,
 		since they could be used to execute shell commands.  Perl uses
 		the Safe module.
-		For Unix restricted mode is used when the last part of $SHELL
-		is "nologin" or "false".
 		Note that the user may still find a loophole to execute a
 		shell command, it has only been made difficult.
 

--- a/src/option.c
+++ b/src/option.c
@@ -307,24 +307,6 @@ set_init_default_printexpr(void)
 }
 #endif
 
-#ifdef UNIX
-/*
- * Force restricted-mode on for "nologin" or "false" $SHELL
- */
-    static void
-set_init_restricted_mode(void)
-{
-    char_u	*p;
-
-    p = get_isolated_shell_name();
-    if (p == NULL)
-	return;
-    if (fnamecmp(p, "nologin") == 0 || fnamecmp(p, "false") == 0)
-	restricted = TRUE;
-    vim_free(p);
-}
-#endif
-
 #ifdef CLEAN_RUNTIMEPATH
 /*
  * When Vim is started with the "--clean" argument, set the default value
@@ -570,10 +552,6 @@ set_init_1(int clean_arg)
      * value.  Also set the global value for local options.
      */
     set_options_default(0);
-
-#ifdef UNIX
-    set_init_restricted_mode();
-#endif
 
 #ifdef CLEAN_RUNTIMEPATH
     if (clean_arg)

--- a/src/testdir/test_restricted.vim
+++ b/src/testdir/test_restricted.vim
@@ -105,14 +105,6 @@ func Test_restricted_mode()
   if RunVim([], [], '-Z --clean -S Xrestricted')
     call assert_equal([], readfile('Xresult'))
   endif
-  call delete('Xresult')
-  if has('unix') && RunVimPiped([], [], '--clean -S Xrestricted', 'SHELL=/bin/false ')
-    call assert_equal([], readfile('Xresult'))
-  endif
-  call delete('Xresult')
-  if has('unix') && RunVimPiped([], [], '--clean -S Xrestricted', 'SHELL=/sbin/nologin')
-    call assert_equal([], readfile('Xresult'))
-  endif
 
   call delete('Xresult')
 endfunc


### PR DESCRIPTION
Problem:    Overloading semantics of $SHELL interferes with legit job control
Solution:   Avoid triggering restricted mode based on $SHELL value (closes #12656)

This PR basically reverses the changes from #9681, which were incorporated into [patch 8.2.4282](https://github.com/vim/vim/commit/adbb1bf21dad5697cd82d46d9dd9e8e8d0f647e6).

More detailed rationale for this PR is in issue #12656.