### PR TITLE
Add filetype detection for eyaml files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2529,7 +2529,7 @@ au BufNewFile,BufRead *.yy,*.yxx,*.y++		setf yacc
 au BufNewFile,BufRead *.y			call dist#ft#FTy()
 
 " Yaml
-au BufNewFile,BufRead *.yaml,*.yml		setf yaml
+au BufNewFile,BufRead *.yaml,*.yml,*.eyaml		setf yaml
 
 " Raml
 au BufNewFile,BufRead *.raml			setf raml

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -794,7 +794,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     xsd: ['file.xsd'],
     xslt: ['file.xsl', 'file.xslt'],
     yacc: ['file.yy', 'file.yxx', 'file.y++'],
-    yaml: ['file.yaml', 'file.yml', '.clangd', '.clang-format', '.clang-tidy'],
+    yaml: ['file.yaml', 'file.yml', 'file.eyaml', '.clangd', '.clang-format', '.clang-tidy'],
     yang: ['file.yang'],
     yuck: ['file.yuck'],
     z8a: ['file.z8a'],


### PR DESCRIPTION
https://github.com/voxpupuli/hiera-eyaml/ uses and produces the eyaml
format, which is simply yaml with some encrypted values.

It's convenient to edit the file without decrypting when not touching
encrypted values (or when you don't have access to the decryption key),
which is why vim should treat those files as yaml files.
