### PR TITLE
Fix wrong cursor position when clicking on a TAB or unprintable char

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1829,10 +1829,10 @@ win_line(
 
     win_line_start(wp, &wlv, FALSE);
 
+    char_u	*prev_ptr = ptr;
     // Repeat for the whole displayed line.
     for (;;)
     {
-	char_u	*prev_ptr = ptr;
 #if defined(FEAT_CONCEAL) || defined(FEAT_SEARCH_EXTRA)
 	int	has_match_conc = 0;	// match wants to conceal
 #endif
@@ -2261,9 +2261,9 @@ win_line(
 	    }
 #endif
 
-#ifdef FEAT_SEARCH_EXTRA
 	    if (wlv.n_extra == 0)
 	    {
+#ifdef FEAT_SEARCH_EXTRA
 		// Check for start/end of 'hlsearch' and other matches.
 		// After end, check for start/end of next match.
 		// When another match, have to check for start again.
@@ -2273,14 +2273,15 @@ win_line(
 				      &match_conc, did_line_attr, lcs_eol_one,
 				      &on_last_col);
 		ptr = line + v;  // "line" may have been changed
-		prev_ptr = ptr;
 
 		// Do not allow a conceal over EOL otherwise EOL will be missed
 		// and bad things happen.
 		if (*ptr == NUL)
 		    has_match_conc = 0;
-	    }
 #endif
+
+		prev_ptr = ptr;
+	    }
 
 #ifdef FEAT_DIFF
 	    if (wlv.diff_hlf != (hlf_T)0)

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4036,4 +4036,47 @@ func Test_normal_r_ctrl_v_cmd()
   bw!
 endfunc
 
+" Test clicking on a TAB or an unprintable character in Normal mode
+func Test_normal_click_on_ctrl_char()
+  let save_mouse = &mouse
+  set mouse=a
+  new
+
+  call setline(1, "a\<Tab>b\<C-K>c")
+  redraw
+  call test_setmouse(1, 1)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 1, 0, 1], getcurpos())
+  call test_setmouse(1, 2)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 2, 0, 8], getcurpos())
+  call test_setmouse(1, 3)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 2, 0, 8], getcurpos())
+  call test_setmouse(1, 7)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 2, 0, 8], getcurpos())
+  call test_setmouse(1, 8)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 2, 0, 8], getcurpos())
+  call test_setmouse(1, 9)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 3, 0, 9], getcurpos())
+  call test_setmouse(1, 10)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 4, 0, 10], getcurpos())
+  call test_setmouse(1, 11)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 4, 0, 10], getcurpos())
+  call test_setmouse(1, 12)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 5, 0, 12], getcurpos())
+  call test_setmouse(1, 13)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 5, 0, v:maxcol], getcurpos())
+
+  bwipe!
+  let &mouse = save_mouse
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Wrong cursor position when clicking on an unprintable char.
Solution:   Don't update prev_ptr when wlv.n_extra is not zero.