### PR TITLE
Cleanup Tests

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -411,6 +411,24 @@ func RunTheTest(test)
   endif
 endfunc
 
+function Delete_Xtest_Files()
+  for file in glob('X*', v:false, v:true)
+    if file ==? 'XfakeHOME'
+      " Clean up files created by setup.vim
+      call delete('XfakeHOME', 'rf')
+      continue
+    endif
+    " call add(v:errors, file .. " exists when it shouldn't, trying to delete it!")
+    call delete(file)
+    if !empty(glob(file, v:false, v:true))
+      " call add(v:errors, file .. " still exists after trying to delete it!")
+      if has('unix')
+        call system('rm -rf  ' .. file)
+      endif
+    endif
+  endfor
+endfunc
+
 func AfterTheTest(func_name)
   if len(v:errors) > 0
     if match(s:may_fail_list, '^' .. a:func_name) >= 0
@@ -439,12 +457,10 @@ endfunc
 " This function can be called by a test if it wants to abort testing.
 func FinishTesting()
   call AfterTheTest('')
+  call Delete_Xtest_Files()
 
   " Don't write viminfo on exit.
   set viminfo=
-
-  " Clean up files created by setup.vim
-  call delete('XfakeHOME', 'rf')
 
   if s:fail == 0 && s:fail_expected == 0
     " Success, create the .res file so that make knows it's done.

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -973,6 +973,7 @@ func Test_mksession_foldopt()
   close
   %bwipe
   set sessionoptions&
+  call delete('Xtest_mks.out')
 endfunc
 
 " Test for mksession with "help" but not "options" in 'sessionoptions'
@@ -1105,6 +1106,7 @@ func Test_mksession_shortmess_with_A()
   set shortmess&
   set sessionoptions&
   call delete('Xtestsession')
+  call delete('Xtestfile')
 endfunc
 
 " Test for mksession with 'compatible' option

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -309,6 +309,7 @@ func Test_terminal_rename_buffer()
   call assert_equal('bar', bufname())
   call assert_match('bar.*finished', execute('ls'))
   exe 'bwipe! ' .. buf
+  call delete('Xtext')
 endfunc
 
 func s:Nasty_exit_cb(job, st)
@@ -1045,6 +1046,8 @@ func Test_terminal_redir_file()
     call WaitForAssert({-> assert_equal('dead', job_status(g:job))})
     bwipe
   endif
+
+  call delete('Xtext')
 endfunc
 
 func TerminalTmap(remap)

--- a/src/version.c
+++ b/src/version.c
@@ -696,6 +696,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    1679,
+/**/
     1678,
 /**/
     1677,


### PR DESCRIPTION
Clean up temporary left-over files after tests run.

There were a few failures in 'linux (huge, gcc, testgui, true, true)' e.g. here: https://github.com/vim/vim/actions/runs/5497376153/jobs/10018060156

,----
| Error detected while processing command line..script /home/runner/work/vim/vim/src/testdir/runtest.vim[585]..function RunTheTest[54]..Test_lvimgrep_crash[16]..TestTimeout[12]..VimLeavePre Autocommands for "*"..function EarlyExit[7]..FinishTesting:
| line   70:
| E445: Other window contains changes
| E937: Attempt to delete a buffer that is in use: Xtest_stable_xxd.txt
| E937: Attempt to delete a buffer that is in use: Xtest_stable_xxd.txt
| E937: Attempt to delete a buffer that is in use: Xtest_stable_xxd.txtmalloc(): unsorted double linked list corrupted
`----

Which is puzzling, because the Xtest_stable_xxd file should have been long gone after test_crypt.vim is run (and definitely no longer be staying around in test_quickfix.vim).

So try to clean up properly after a test script is run, just in case any X<file> is still around. During testing, a found a few leftover files, which I also fixed in the relevant test-file.

Unfortunately, the test workflow 'linux (huge, gcc, testgui, true, true)' now seems to fail with 'E1230: Encryption: sodium_mlock()' in test_crypt.vim. Hopefully this is only temporary hickup :/ 