### PR TITLE
Use Lua 5.1 compatible numeric escapes in Lua tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         features: [tiny, normal, huge]
         compiler: [clang, gcc]
         extra: [none]
+        luaver: [lua5.4]
         include:
           - features: tiny
             compiler: clang
@@ -54,13 +55,18 @@ jobs:
             coverage: true
             extra: testgui
             uchar: true
+            luaver: lua5.4
           - features: huge
             compiler: clang
             extra: asan
+            # Lua5.1 is the most widely used version (since it's what LuaJIT is
+            # compatible with), so ensure it works
+            luaver: lua5.1
           - features: huge
             compiler: gcc
             coverage: true
             extra: unittests
+            luaver: lua5.4
           - features: normal
             compiler: gcc
             extra: vimtags
@@ -85,8 +91,8 @@ jobs:
               libperl-dev \
               python2-dev \
               python3-dev \
-              liblua5.4-dev \
-              lua5.4 \
+              lib${{ matrix.luaver }}-dev \
+              ${{ matrix.luaver }} \
               ruby-dev \
               tcl-dev \
               cscope \

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -616,10 +616,10 @@ endfunc
 func Test_lua_blob()
   call assert_equal(0z, luaeval('vim.blob("")'))
   call assert_equal(0z31326162, luaeval('vim.blob("12ab")'))
-  call assert_equal(0z00010203, luaeval('vim.blob("\x00\x01\x02\x03")'))
-  call assert_equal(0z8081FEFF, luaeval('vim.blob("\x80\x81\xfe\xff")'))
+  call assert_equal(0z00010203, luaeval('vim.blob("\000\001\002\003")'))
+  call assert_equal(0z8081FEFF, luaeval('vim.blob("\128\129\254\255")'))
 
-  lua b = vim.blob("\x00\x00\x00\x00")
+  lua b = vim.blob("\000\000\000\000")
   call assert_equal(0z00000000, luaeval('b'))
   call assert_equal(4, luaeval('#b'))
   lua b[0], b[1], b[2], b[3] = 1, 32, 256, 0xff


### PR DESCRIPTION
Only Lua 5.2+ and LuaJIT understand hexadecimal escapes in strings.  Lua
5.1 uses decimal escapes:

> A character in a string can also be specified by its numerical value
> using the escape sequence \ddd, where ddd is a sequence of up to three
> decimal digits. (Note that if a numerical escape is to be followed by a
> digit, it must be expressed using exactly three digits.) Strings in Lua
> can contain any 8-bit value, including embedded zeros, which can be
> specified as '\0'.