### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you want to report a security issue, please use [huntr.dev](https://huntr.dev/bounties/disclose?target=https%3A%2F%2Fgithub.com%2Fvim%2Fvim),
+they have rewards in the form of money, swag and CVEs.
+
+**Please don't publicly disclose the issue until it has been addressed by us.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-If you want to report a security issue, please use [huntr.dev](https://huntr.dev/bounties/disclose?target=https%3A%2F%2Fgithub.com%2Fvim%2Fvim),
-they have rewards in the form of money, swag and CVEs.
+If you want to report a security issue, please use [huntr.dev](https://huntr.dev/bounties/disclose?target=https%3A%2F%2Fgithub.com%2Fvim%2Fvim) to privately disclose the issue to us.
+They also have rewards in the form of money, swag and CVEs.
 
 **Please don't publicly disclose the issue until it has been addressed by us.**


### PR DESCRIPTION
Currently, it is hard to find where to report security issues, the only mention of it is in the issue template.

https://github.com/vim/vim/blob/4c0089d696b8d1d5dc40568f25ea5738fa5bbffb/.github/ISSUE_TEMPLATE/bug_report.yml?plain=1#L12-L15

Adding a SECURITY.md file will make it easier to find, it will be displayed in https://github.com/vim/vim/security.

BTW, I just reported one in huntr.dev :)