### PR TITLE
Highlight editorconfig properties with dashes

### DIFF
--- a/runtime/syntax/editorconfig.vim
+++ b/runtime/syntax/editorconfig.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     EditorConfig
 " Maintainer:   Gregory Anders <greg@gpanders.com>
-" Last Change:  2023-01-03
+" Last Change:  2023-07-20
 
 if exists('b:current_syntax')
   finish
@@ -10,7 +10,7 @@ endif
 runtime! syntax/dosini.vim
 unlet! b:current_syntax
 
-syntax match editorconfigUnknownProperty "^\s*\zs\w\+\ze\s*="
+syntax match editorconfigUnknownProperty "^\s*\zs[a-zA-Z0-9_-]\+\ze\s*="
 
 syntax keyword editorconfigProperty root charset end_of_line indent_style
 syntax keyword editorconfigProperty indent_size tab_width max_line_length


### PR DESCRIPTION
Problem: editorconfig properties with dashes are not highlighted
Solution: update the property pattern to include dashes