### PR TITLE
Set filetypes for `*.vsh` and `*.vv` files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2314,6 +2314,9 @@ au BufNewFile,BufRead */.config/upstart/*.override	       setf upstart
 " URL shortcut
 au BufNewFile,BufRead *.url			setf urlshortcut
 
+" V
+au BufNewFile,BufRead *.vsh,*.vv			setf v
+
 " Vala
 au BufNewFile,BufRead *.vala			setf vala
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -750,6 +750,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     usd: ['file.usda', 'file.usd'],
     usserverlog: ['usserver.log', 'USSERVER.LOG', 'usserver.file.log', 'USSERVER.FILE.LOG', 'file.usserver.log', 'FILE.USSERVER.LOG'],
     usw2kagtlog: ['usw2kagt.log', 'USW2KAGT.LOG', 'usw2kagt.file.log', 'USW2KAGT.FILE.LOG', 'file.usw2kagt.log', 'FILE.USW2KAGT.LOG'],
+    v: ['file.vsh', 'file.vv'],
     vala: ['file.vala'],
     vb: ['file.sba', 'file.vb', 'file.vbs', 'file.dsm', 'file.ctl'],
     vdf: ['file.vdf'],


### PR DESCRIPTION
This PR covers the additional V filetypes:

https://github.com/v-analyzer/v-analyzer/blob/e14fdf6e661b10edccc744102e4ccf0b187aa8ad/editors/code/syntaxes/v.tmLanguage.json#L4