### PR TITLE
Avoid restoring incorrect heights in `win_size_restore()`

### DIFF
--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -81,6 +81,7 @@ void win_comp_scroll(win_T *wp);
 void command_height(void);
 void last_status(int morewin);
 int tabline_height(void);
+int last_stl_height(int morewin);
 int min_rows(void);
 int only_one_window(void);
 void check_lnums(int do_curwin);

--- a/src/screen.c
+++ b/src/screen.c
@@ -4527,7 +4527,7 @@ messaging(void)
     void
 comp_col(void)
 {
-    int last_has_status = (p_ls == 2 || (p_ls == 1 && !ONE_WINDOW));
+    int last_has_status = last_stl_height(FALSE) > 0;
 
     sc_col = 0;
     ru_col = 0;

--- a/src/testdir/test_cmdwin.vim
+++ b/src/testdir/test_cmdwin.vim
@@ -440,5 +440,34 @@ func Test_cmdwin_split_often()
   let &columns = columns
 endfunc
 
+func Test_cmdwin_restore_heights()
+  set showtabline=0 cmdheight=2 laststatus=0
+  call feedkeys("q::set cmdheight=1\<CR>:q\<CR>", 'ntx')
+  call assert_equal(&lines - 1, winheight(0))
+
+  set showtabline=2 cmdheight=3
+  call feedkeys("q::set showtabline=0\<CR>:q\<CR>", 'ntx')
+  call assert_equal(&lines - 3, winheight(0))
+
+  set cmdheight=1 laststatus=2
+  call feedkeys("q::set laststatus=0\<CR>:q\<CR>", 'ntx')
+  call assert_equal(&lines - 1, winheight(0))
+
+  set laststatus=2
+  call feedkeys("q::set laststatus=1\<CR>:q\<CR>", 'ntx')
+  call assert_equal(&lines - 1, winheight(0))
+
+  set laststatus=2
+  belowright vsplit
+  wincmd _
+  let restcmds = winrestcmd()
+  call feedkeys("q::set laststatus=1\<CR>:q\<CR>", 'ntx')
+  " As we have 2 windows, &ls = 1 should still have a statusline on the last
+  " window. As such, the number of available rows hasn't changed and the window
+  " sizes should be restored.
+  call assert_equal(restcmds, winrestcmd())
+
+  set cmdheight& showtabline& laststatus&
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -5943,7 +5943,6 @@ shell_new_columns(void)
  */
     void
 win_size_save(garray_T *gap)
-
 {
     win_T	*wp;
 
@@ -5951,8 +5950,8 @@ win_size_save(garray_T *gap)
     if (ga_grow(gap, win_count() * 2 + 1) == FAIL)
 	return;
 
-    // first entry is value of 'lines'
-    ((int *)gap->ga_data)[gap->ga_len++] = Rows;
+    // first entry is the total lines available for windows
+    ((int *)gap->ga_data)[gap->ga_len++] = ROWS_AVAIL - last_stl_height(FALSE);
 
     FOR_ALL_WINDOWS(wp)
     {
@@ -5964,7 +5963,7 @@ win_size_save(garray_T *gap)
 
 /*
  * Restore window sizes, but only if the number of windows is still the same
- * and 'lines' didn't change.
+ * and total lines available for windows didn't change.
  * Does not free the growarray.
  */
     void
@@ -5974,7 +5973,7 @@ win_size_restore(garray_T *gap)
     int		i, j;
 
     if (win_count() * 2 + 1 == gap->ga_len
-	    && ((int *)gap->ga_data)[0] == Rows)
+	    && ((int *)gap->ga_data)[0] == ROWS_AVAIL - last_stl_height(FALSE))
     {
 	// The order matters, because frames contain other frames, but it's
 	// difficult to get right. The easy way out is to do it twice.
@@ -7192,8 +7191,7 @@ last_status(
     int		morewin)	// pretend there are two or more windows
 {
     // Don't make a difference between horizontal or vertical split.
-    last_status_rec(topframe, (p_ls == 2
-			  || (p_ls == 1 && (morewin || !ONE_WINDOW))));
+    last_status_rec(topframe, last_stl_height(morewin) > 0);
 }
 
     static void
@@ -7278,6 +7276,17 @@ tabline_height(void)
 	case 1: return (first_tabpage->tp_next == NULL) ? 0 : 1;
     }
     return 1;
+}
+
+/*
+ * Return the height of the last window's statusline.
+ */
+    int
+last_stl_height(
+    int		morewin)	// pretend there are two or more windows
+{
+    return (p_ls == 2 || (p_ls == 1 && (morewin || !ONE_WINDOW)))
+		? STATUS_HEIGHT : 0;
 }
 
 /*


### PR DESCRIPTION
Problem: changing `'showtabline'` or `'cmdheight'` in the cmdwin restores incorrect window heights after closing the cmdwin.

This may produce a gap between the cmdline and the window above.

Solution: restore window sizes only if the number of lines available for windows changed; subtract the rows of the tabline, cmdline and last window's statusline from `'lines'` (other statuslines don't matter).