### PR TITLE
PyPA manifest files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1676,6 +1676,9 @@ au BufNewFile,BufRead *.pk			setf poke
 " Protocols
 au BufNewFile,BufRead */etc/protocols		setf protocols
 
+" PyPA manifest files
+au BufNewFile,BufRead MANIFEST.in		setf pymanifest
+
 " Pyret
 au BufNewFile,BufRead *.arr			setf pyret
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -543,6 +543,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     psl: ['file.psl'],
     pug: ['file.pug'],
     puppet: ['file.pp'],
+    pymanifest: ['MANIFEST.in'],
     pyret: ['file.arr'],
     pyrex: ['file.pyx', 'file.pxd'],
     python: ['file.py', 'file.pyw', '.pythonstartup', '.pythonrc', 'file.ptl', 'file.pyi', 'SConstruct'],


### PR DESCRIPTION
The filetype is subject to change since there's no official name for it.

I will also add a basic syntax file later.

Docs: https://packaging.python.org/en/latest/guides/using-manifest-in/

