### PR TITLE
Fix nixInherit matcher in nix.vim

### DIFF
--- a/runtime/syntax/nix.vim
+++ b/runtime/syntax/nix.vim
@@ -5,7 +5,7 @@
 " Acknowledgement: Based on vim-nix maintained by Daiderd Jordan <daiderd@gmail.com>
 "                  https://github.com/LnL7/vim-nix
 " License:         MIT
-" Last Change:     2022 Dec 06
+" Last Change:     2023 Jul 28
 
 if exists("b:current_syntax")
   finish
@@ -68,7 +68,8 @@ syn match nixAttribute "[a-zA-Z_][a-zA-Z0-9_'-]*\ze\%([^a-zA-Z0-9_'.-]\|$\)" con
 syn region nixAttributeAssignment start="=" end="\ze;" contained contains=@nixExpr
 syn region nixAttributeDefinition start=/\ze[a-zA-Z_"$]/ end=";" contained contains=nixComment,nixAttribute,nixInterpolation,nixSimpleString,nixAttributeDot,nixAttributeAssignment
 
-syn region nixInheritAttributeScope start="(" end="\ze)" contained contains=@nixExpr
+syn region nixInheritAttributeSubExpr start="("ms=e+1 end="\ze)" contained contains=nixAttributeDot,@nixExpr
+syn region nixInheritAttributeScope start="\ze(" end=")" contained contains=nixInheritAttributeSubExpr
 syn region nixAttributeDefinition matchgroup=nixInherit start="\<inherit\>" end=";" contained contains=nixComment,nixInheritAttributeScope,nixAttribute
 
 syn region nixAttributeSet start="{" end="}" contains=nixComment,nixAttributeDefinition

--- a/runtime/syntax/nix.vim
+++ b/runtime/syntax/nix.vim
@@ -1,11 +1,12 @@
 " Vim syntax file
 " Language:        Nix
-" Maintainer:	   James Fleming <james@electronic-quill.net>
+" Maintainer:      James Fleming <james@electronic-quill.net>
+"                  (Github username: equill)
 " Original Author: Daiderd Jordan <daiderd@gmail.com>
 " Acknowledgement: Based on vim-nix maintained by Daiderd Jordan <daiderd@gmail.com>
 "                  https://github.com/LnL7/vim-nix
 " License:         MIT
-" Last Change:     2023 Jul 28
+" Last Change:     2023 Aug 19
 
 if exists("b:current_syntax")
   finish


### PR DESCRIPTION
Perform the lookahead in `nixInheritAttributeScope`, then hand over to a new region called `nixInheritAttributeSubExpr`, which sets the match start to one char after the opening bracket to avoid a double-match.

Finally, only do a lookahead to `)` in `nixInheritAttributeSubExpr` (and thus make sure the region is closed to not get a match of `nixParen` here) and let `nixInheritAttributeScope` close the bracket.