### PR TITLE
Add Unison support

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2484,6 +2484,9 @@ au BufNewFile,BufRead *.fsproj,*.fsproj.user	setf xml
 " VBPROJ files are Visual Studio.NET's XML-based Visual Basic project config files
 au BufNewFile,BufRead *.vbproj,*.vbproj.user	setf xml
 
+" Unison Language
+au BufNewFile,BufRead *.u,*.uu				setf unison
+
 " Qt Linguist translation source and Qt User Interface Files are XML
 " However, for .ts TypeScript is more common.
 au BufNewFile,BufRead *.ui			setf xml

--- a/runtime/ftplugin/unison.vim
+++ b/runtime/ftplugin/unison.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin file
+" Language:             unison
+" Maintainer:           Anton Parkhomenko <anton@chuwy.me>
+" Latest Revision:      2023-08-07
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let b:undo_ftplugin = "setl cms< isk<"
+
+setlocal commentstring=--\ %s
+setlocal iskeyword+=!,'

--- a/runtime/syntax/unison.vim
+++ b/runtime/syntax/unison.vim
@@ -1,0 +1,103 @@
+" Vim syntax file
+"
+" Language:        unison
+" Maintainer:      Anton Parkhomenko <anton@chuwy.me>
+" Last Change:     Aug 7, 2023
+" Original Author: John Williams, Paul Chiusano and Rúnar Bjarnason
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syntax include @markdown $VIMRUNTIME/syntax/markdown.vim
+
+syn cluster markdownLikeDocs contains=markdownBold,markdownItalic,markdownLinkText,markdownListMarker,markdownOrderedListMarker,markdownH1,markdownH2,markdownH3,markdownH4,markdownH5,markdownH6
+
+syn match unisonOperator "[-!#$%&\*\+/<=>\?@\\^|~]"
+syn match unisonDelimiter "[\[\](){},.]"
+
+" Strings and constants
+syn match   unisonSpecialChar	contained "\\\([0-9]\+\|o[0-7]\+\|x[0-9a-fA-F]\+\|[\"\\'&\\abfnrtv]\|^[A-Z^_\[\\\]]\)"
+syn match   unisonSpecialChar	contained "\\\(NUL\|SOH\|STX\|ETX\|EOT\|ENQ\|ACK\|BEL\|BS\|HT\|LF\|VT\|FF\|CR\|SO\|SI\|DLE\|DC1\|DC2\|DC3\|DC4\|NAK\|SYN\|ETB\|CAN\|EM\|SUB\|ESC\|FS\|GS\|RS\|US\|SP\|DEL\)"
+syn match   unisonSpecialCharError	contained "\\&\|'''\+"
+syn region  unisonString		start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=unisonSpecialChar
+syn match   unisonCharacter		"[^a-zA-Z0-9_']'\([^\\]\|\\[^']\+\|\\'\)'"lc=1 contains=unisonSpecialChar,unisonSpecialCharError
+syn match   unisonCharacter		"^'\([^\\]\|\\[^']\+\|\\'\)'" contains=unisonSpecialChar,unisonSpecialCharError
+syn match   unisonNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>"
+syn match   unisonFloat		"\<[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\=\>"
+
+" Keyword definitions. These must be patterns instead of keywords
+" because otherwise they would match as keywords at the start of a
+" "literate" comment (see lu.vim).
+syn match unisonModule		"\<namespace\>"
+syn match unisonImport		"\<use\>"
+syn match unisonTypedef		"\<\(unique\|structural\|∀\|forall\)\>"
+syn match unisonStatement		"\<\(ability\|do\|type\|where\|match\|cases\|;\|let\|with\|handle\)\>"
+syn match unisonConditional		"\<\(if\|else\|then\)\>"
+
+syn match unisonBoolean "\<\(true\|false\)\>"
+
+syn match unisonType "\<\C[A-Z][0-9A-Za-z_'!]*\>"
+syn match unisonName "\<\C[a-z_][0-9A-Za-z_'!]*\>"
+
+" Comments
+syn match   unisonLineComment      "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
+syn region  unisonBlockComment     start="{-"  end="-}" contains=unisonBlockComment
+syn region  unisonBelowFold	   start="^---" skip="." end="." contains=unisonBelowFold
+
+" Docs
+syn region  unisonDocBlock         matchgroup=unisonDoc start="{{" end="}}" contains=unisonDocTypecheck,unisonDocQuasiquote,unisonDocDirective,unisonDocCode,unisonDocCodeInline,unisonDocCodeRaw,unisonDocMono,@markdownLikeDocs
+syn region  unisonDocQuasiquote    contained matchgroup=unisonDocQuote start="{{" end= "}}" contains=TOP
+syn region  unisonDocCode          contained matchgroup=unisonDocCode start="^\s*```\s*$" end="^\s*```\s*$" contains=TOP
+syn region  unisonDocTypecheck     contained matchgroup=unisonDocCode start="^\s*@typecheck\s*```\s*$" end="^\s*```\s*$" contains=TOP
+syn region  unisonDocCodeRaw       contained matchgroup=unisonDocCode start="^\s*```\s*raw\s*$" end="^\s*```\s*$" contains=NoSyntax
+syn region  unisonDocCodeInline    contained matchgroup=unisonDocCode start="`\@<!``" end="`\@<!``" contains=TOP
+syn match   unisonDocMono          "''[^']*''"
+syn region  unisonDocDirective     contained matchgroup=unisonDocDirective start="\(@\([a-zA-Z0-9_']*\)\)\?{{\@!" end="}" contains=TOP
+
+syn match unisonDebug "\<\(todo\|bug\|Debug.trace\|Debug.evalToText\)\>"
+
+" things like 
+"    > my_func 1 3
+"    test> Function.tap.tests.t1 = check let
+"      use Nat == +
+"      ( 99, 100 ) === (withInitialValue 0 do
+"          :      :      :
+syn match unisonWatch "^[A-Za-z]*>"
+
+hi def link       unisonWatch                           Debug
+hi def link       unisonDocMono                         Delimiter
+hi def link       unisonDocDirective                    Import
+hi def link       unisonDocQuote                        Delimiter
+hi def link       unisonDocCode                         Delimiter
+hi def link       unisonDoc                             String
+hi def link       unisonBelowFold                       Comment
+hi def link       unisonBlockComment                    Comment
+hi def link       unisonBoolean                         Boolean
+hi def link       unisonCharacter                       Character
+hi def link       unisonComment                         Comment
+hi def link       unisonConditional                     Conditional
+hi def link       unisonConditional                     Conditional
+hi def link       unisonDebug                           Debug
+hi def link       unisonDelimiter                       Delimiter
+hi def link       unisonDocBlock                        String
+hi def link       unisonDocDirective                    Import
+hi def link       unisonDocIncluded                     Import
+hi def link       unisonFloat                           Float
+hi def link       unisonImport                          Include
+hi def link       unisonLineComment                     Comment
+hi def link       unisonLink                            Type
+hi def link       unisonName                            Identifier
+hi def link       unisonNumber                          Number
+hi def link       unisonOperator                        Operator
+hi def link       unisonSpecialChar                     SpecialChar
+hi def link       unisonSpecialCharError                Error
+hi def link       unisonStatement                       Statement
+hi def link       unisonString                          String
+hi def link       unisonType                            Type
+hi def link       unisonTypedef                         Typedef
+
+
+let b:current_syntax = "unison"
+
+" Options for vi: ts=8 sw=2 sts=2 nowrap noexpandtab ft=vim

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -741,6 +741,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     udevperm: ['/etc/udev/permissions.d/file.permissions', 'any/etc/udev/permissions.d/file.permissions'],
     udevrules: ['/etc/udev/rules.d/file.rules', '/usr/lib/udev/rules.d/file.rules', '/lib/udev/rules.d/file.rules'],
     uil: ['file.uit', 'file.uil'],
+    unison: ['file.u', 'file.uu'],
     updatedb: ['/etc/updatedb.conf', 'any/etc/updatedb.conf'],
     upstart: ['/usr/share/upstart/file.conf', '/usr/share/upstart/file.override', '/etc/init/file.conf', '/etc/init/file.override', '/.init/file.conf', '/.init/file.override', '/.config/upstart/file.conf', '/.config/upstart/file.override', 'any/.config/upstart/file.conf', 'any/.config/upstart/file.override', 'any/.init/file.conf', 'any/.init/file.override', 'any/etc/init/file.conf', 'any/etc/init/file.override', 'any/usr/share/upstart/file.conf', 'any/usr/share/upstart/file.override'],
     upstreamdat: ['upstream.dat', 'UPSTREAM.DAT', 'upstream.file.dat', 'UPSTREAM.FILE.DAT', 'file.upstream.dat', 'FILE.UPSTREAM.DAT'],


### PR DESCRIPTION
Adds support for [Unison language](https://www.unison-lang.org/).

The code was originally in [Unison's official repo](https://github.com/unisonweb/unison/tree/trunk/editor-support). I asked for author's permission in https://github.com/unisonweb/unison/issues/4202 to copy it over here.