### PR TITLE
feat(heex): borrow matchit support from html

### DIFF
--- a/runtime/ftplugin/heex.vim
+++ b/runtime/ftplugin/heex.vim
@@ -13,4 +13,16 @@ setlocal shiftwidth=2 softtabstop=2 expandtab
 setlocal comments=:<%!--
 setlocal commentstring=<%!--\ %s\ --%>
 
+" HTML: thanks to Johannes Zellner and Benji Fisher.
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_ignorecase = 1
+  let b:match_words = '<!--:-->,' ..
+	\	      '<:>,' ..
+	\	      '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' ..
+	\	      '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' ..
+	\	      '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+  let b:html_set_match_words = 1
+  let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:html_set_match_words"
+endif
+
 let b:undo_ftplugin = 'set sw< sts< et< com< cms<'

--- a/runtime/ftplugin/heex.vim
+++ b/runtime/ftplugin/heex.vim
@@ -23,5 +23,5 @@ if exists("loaded_matchit") && !exists("b:match_words")
 	\	      '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' ..
 	\	      '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' ..
 	\	      '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
-  let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:html_set_match_words"
+  let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words"
 endif

--- a/runtime/ftplugin/heex.vim
+++ b/runtime/ftplugin/heex.vim
@@ -13,6 +13,8 @@ setlocal shiftwidth=2 softtabstop=2 expandtab
 setlocal comments=:<%!--
 setlocal commentstring=<%!--\ %s\ --%>
 
+let b:undo_ftplugin = 'set sw< sts< et< com< cms<'
+
 " HTML: thanks to Johannes Zellner and Benji Fisher.
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 1
@@ -21,8 +23,5 @@ if exists("loaded_matchit") && !exists("b:match_words")
 	\	      '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' ..
 	\	      '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' ..
 	\	      '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
-  let b:html_set_match_words = 1
   let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:html_set_match_words"
 endif
-
-let b:undo_ftplugin = 'set sw< sts< et< com< cms<'


### PR DESCRIPTION
Makes `%` behave the same in heex as in html. For example, quickly moving the cursor between opening and closing tags.