### PR TITLE
Add WebGPU Shading Language (WGSL) filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2396,6 +2396,9 @@ au BufNewFile,BufRead .wgetrc,wgetrc		setf wget
 " Wget2 config
 au BufNewFile,BufRead .wget2rc,wget2rc		setf wget2
 
+" WebGPU Shading Language (WGSL)
+au BufNewFile,BufRead *.wgsl			setf wgsl
+
 " Website MetaLanguage
 au BufNewFile,BufRead *.wml			setf wml
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -774,6 +774,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     webmacro: ['file.wm'],
     wget: ['.wgetrc', 'wgetrc'],
     wget2: ['.wget2rc', 'wget2rc'],
+    wgsl: ['file.wgsl'],
     winbatch: ['file.wbt'],
     wit: ['file.wit'],
     wml: ['file.wml'],


### PR DESCRIPTION
The current W3C Working Draft for the WebGPU Shading Language (WGSL) specifies 'text/wgsl' media type for WGSL modules with the '.wgsl' file extension: https://www.w3.org/TR/WGSL/#text-wgsl-media-type

It has also been registered at the Internet Assigned Numbers Authority (IANA): https://www.iana.org/assignments/media-types/text/wgsl

Neovim's nvim-lspconfig already associates wgsl language servers with 'filetype wgsl':
https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#wgsl_analyzer

However currenly setting 'filetype wgsl' for *.wgsl files by defalut in Neovim is blocked by adding this filetype to the vim project first: https://github.com/neovim/neovim/pull/23331

This commit adds this missing wgsl filetype.