### PR TITLE
Specify global/local 'undolevels' to avoid unintentional changes.

### DIFF
--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -111,9 +111,19 @@ use CTRL-G u.  This is useful if you want an insert command to be undoable in
 parts.  E.g., for each sentence.  |i_CTRL-G_u|
 
 Setting the value of 'undolevels' also closes the undo block.  Even when the
-new value is equal to the old value.  In |Vim9| script: >
-	&undolevels = &undolevels
+new value is equal to the old value.  Use `g:undolevels` to explicitly read
+and write only the global value of 'undolevels'. In |Vim9| script: >
+	&g:undolevels = &g:undolevels
 In legacy script: >
+	let &g:undolevels = &g:undolevels
+
+Note that the similar-looking assignment `let &undolevels=&undolevels` does not
+preserve the global option value of 'undolevels' in the event that the local
+option has been set to a different value.  For example: >
+	" Start with different global and local values for 'undolevels'.
+	let &g:undolevels = 1000
+	let &l:undolevels = 2000
+	" This assignment changes the global option to 2000:
 	let &undolevels = &undolevels
 
 ==============================================================================
@@ -366,11 +376,19 @@ undo is possible.  Use this if you are running out of memory.
 When you set 'undolevels' to -1 the undo information is not immediately
 cleared, this happens at the next change.  To force clearing the undo
 information you can use these commands: >
-	:let old_undolevels = &undolevels
-	:set undolevels=-1
+	:let old_undolevels = &l:undolevels
+	:setlocal undolevels=-1
 	:exe "normal a \<BS>\<Esc>"
-	:let &undolevels = old_undolevels
+	:let &l:undolevels = old_undolevels
 	:unlet old_undolevels
+
+Note use of `&l:undolevels` to explicitly read the local value of 'undolevels'
+and the use of `:setlocal` to change only the local option (which takes
+precedence over the corresponding global option value).  Saving the option value
+via the use of `&undolevels` is unpredictable; it reads either the local value
+(if one has been set) or the global value (otherwise).  Also, if a local value
+has been set, changing the option via `:set undolevels` will change both the
+global and local values, requiring extra work to save and restore both values.
 
 Marks for the buffer ('a to 'z) are also saved and restored, together with the
 text.

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -1341,13 +1341,13 @@ func Test_map_cmdkey_op_pending_mode()
   call assert_equal(['lines', 'of test text'], getline(1, '$'))
   call assert_equal(['some short '], getreg('"', 1, 1))
   " create a new undo point
-  let &undolevels = &undolevels
+  let &g:undolevels = &g:undolevels
 
   call feedkeys(".", 'xt')
   call assert_equal(['test text'], getline(1, '$'))
   call assert_equal(['lines', 'of '], getreg('"', 1, 1))
   " create a new undo point
-  let &undolevels = &undolevels
+  let &g:undolevels = &g:undolevels
 
   call feedkeys("uu", 'xt')
   call assert_equal(['some short lines', 'of test text'], getline(1, '$'))

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -1658,7 +1658,7 @@ func Test_sign_lnum_adjust()
 
   " Break the undo. Otherwise the undo operation below will undo all the
   " changes made by this function.
-  let &undolevels=&undolevels
+  let &g:undolevels=&g:undolevels
 
   " Delete the line with the sign
   call deletebufline('', 4)
@@ -1671,7 +1671,7 @@ func Test_sign_lnum_adjust()
   call assert_equal(5, l[0].signs[0].lnum)
 
   " Break the undo
-  let &undolevels=&undolevels
+  let &g:undolevels=&g:undolevels
 
   " Delete few lines at the end of the buffer including the line with the sign
   " Sign line number should not change (as it is placed outside of the buffer)


### PR DESCRIPTION
When saving and restoring 'undolevels', the constructs `&undolevels` and `:set undolevels` are problematic.

The construct `&undolevels` reads an unpredictable value; it will be the local option value (if one has been set), or the global option value (otherwise), making it unsuitable for saving a value for later restoration.

Similarly, if a local option value has been set for 'undolevels', temporarily modifying the option via `:set undolevels` changes the local value as well as the global value, requiring extra work to restore both values.

Saving and restoring the option value in one step via the construct `:let &undolevels = &undolevels` appears to make no changes to the 'undolevels' option, but if a local option has been set to a different value than the global option, it has the unintended effect of changing the global 'undolevels' value to the local value.

Update the documentation to explain these issues and recommend explicit use of global and local option values when saving and restoring.  Update some unit tests to use `g:undolevels`.