### PR TITLE
Bring Bram's last patch (9.0.1678) to GitHub

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -254,6 +254,9 @@ au BufNewFile,BufRead named*.conf,rndc*.conf,rndc*.key	setf named
 au BufNewFile,BufRead named.root		setf bindzone
 au BufNewFile,BufRead *.db			call dist#ft#BindzoneCheck('')
 
+" Blade
+au BufNewFile,BufRead *.blade.php		setf blade
+
 " Blank
 au BufNewFile,BufRead *.bl			setf blank
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -122,6 +122,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     bicep: ['file.bicep'],
     bindzone: ['named.root', '/bind/db.file', '/named/db.file', 'any/bind/db.file', 'any/named/db.file'],
     bitbake: ['file.bb', 'file.bbappend', 'file.bbclass', 'build/conf/local.conf', 'meta/conf/layer.conf', 'build/conf/bbappend.conf', 'meta-layer/conf/distro/foo.conf'],
+    blade: ['file.blade.php'],
     blank: ['file.bl'],
     blueprint: ['file.blp'],
     bsdl: ['file.bsd', 'file.bsdl'],

--- a/src/version.c
+++ b/src/version.c
@@ -696,6 +696,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    1678,
+/**/
     1677,
 /**/
     1676,


### PR DESCRIPTION
Bram's last patch was 9.0.1678: http://ftp.vim.org/pub/vim/patches/9.0/9.0.1678

Unfortunately, it was not committed to this repository.
Bring his last commit to here.

```
patch 9.0.1678: blade files are not recognized

Problem:    Blade files are not recognized.
Solution:   Add a pattern for Blade files. (closes #12650)
```