### PR TITLE
testdir/test_python3.vim: Use raw strings

### DIFF
--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -22,10 +22,10 @@ func Test_AAA_python3_setup()
     import sys
     import re
 
-    py33_type_error_pattern = re.compile('^__call__\(\) takes (\d+) positional argument but (\d+) were given$')
+    py33_type_error_pattern = re.compile(r'^__call__\(\) takes (\d+) positional argument but (\d+) were given$')
     py37_exception_repr = re.compile(r'([^\(\),])(\)+)$')
-    py39_type_error_pattern = re.compile('\w+\.([^(]+\(\) takes)')
-    py310_type_error_pattern = re.compile('takes (\d+) positional argument but (\d+) were given')
+    py39_type_error_pattern = re.compile(r'\w+\.([^(]+\(\) takes)')
+    py310_type_error_pattern = re.compile(r'takes (\d+) positional argument but (\d+) were given')
 
     def emsg(ei):
       return ei[0].__name__ + ':' + repr(ei[1].args)


### PR DESCRIPTION
Fixes Python3.12 warnings during running test suite, which makes it fail. This handling of strings is Python3 for some time, but it started to produce warnings since 3.12.

OS: Fedora 39+
Vim version: 9.0, patchlevel 1677

Reproducer:
$ ./configure --enable-python3interp=dynamic
$ make test

Output:
```
	From test_python3.vim:
	Found errors in Test_AAA_python3_setup():
	Caught exception in Test_AAA_python3_setup(): Vim(py3):<string>:8: SyntaxWarning: invalid escape sequence '\d' @ command line..script /var/tmp/tmt/run-030/plans/all/tree/Sanity/upstream-scripttests/vim/src/testdir/runtest.vim[601]..function RunTheTest[54]..Test_AAA_python3_setup, line 68
```