### PR TITLE
Fix perl compilation errors

### DIFF
--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -40,7 +40,7 @@
 /* Work around for perl-5.18.
  * Don't include "perl\lib\CORE\inline.h" for now,
  * include it after Perl_sv_free2 is defined. */
-#if (PERL_REVISION == 5) && (PERL_VERSION >= 18)
+#ifdef DYNAMIC_PERL
 # define PERL_NO_INLINE_FUNCTIONS
 #endif
 
@@ -707,6 +707,10 @@ S_POPMARK(pTHX)
 /* perl-5.32 needs Perl_POPMARK */
 # if (PERL_REVISION == 5) && (PERL_VERSION >= 32)
 #  define Perl_POPMARK S_POPMARK
+# endif
+
+# if (PERL_REVISION == 5) && (PERL_VERSION >= 37)
+#  define GIMME GIMME_V
 # endif
 
 /* perl-5.34 needs Perl_SvTRUE_common; used in SvTRUE_nomg_NN */
@@ -1649,7 +1653,7 @@ Buffers(...)
     PPCODE:
     if (items == 0)
     {
-	if (GIMME_V == G_SCALAR)
+	if (GIMME == G_SCALAR)
 	{
 	    i = 0;
 	    FOR_ALL_BUFFERS(vimbuf)
@@ -1700,7 +1704,7 @@ Windows(...)
     PPCODE:
     if (items == 0)
     {
-	if (GIMME_V == G_SCALAR)
+	if (GIMME == G_SCALAR)
 	    XPUSHs(sv_2mortal(newSViv(win_count())));
 	else
 	{


### PR DESCRIPTION
Commit 1d7caa58e3c87f75a4becbceabbd1af181ace11e slightly changed how to integrate with Perl 5.37. Unfortunately, it seems it unexpectedly broke integration with older Perls.

So parly revert part of the patch:

1) GIMME was changed to GIMME_V for Perl5.37. Let's instead keep the GIMME
   macro and define it to GIMME_V for Perl.37 instead.

2) Change the line
   #if (PERL_REVISION == 5) && (PERL_VERSION >= 18)
back to
  #ifdef DYNAMIC_PERL

I did verify that this comiles using Perl 5.32 and Perl 5.37 in dynamic mode, but for some reason loading the perl.a library fails, so not hundert percent sure this is correct.

related #12758