### PR TITLE
.cirrus.yml: skip pkg update

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,6 @@ freebsd_task:
         image_family: freebsd-12-4
   timeout_in: 20m
   install_script:
-    - pkg update -f
     - pkg install -y gettext
   build_script:
     - NPROC=$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
PKG Install does not continue on 13.1

```
pkg update -f
Updating FreeBSD repository catalogue...
Fetching meta.conf: . done
Fetching packagesite.pkg: .......... done
Processing entries: 
Newer FreeBSD version for package zziplib:
To ignore this error set IGNORE_OSVERSION=yes
- package: 1302001
- running kernel: 1301000
Ignore the mismatch and continue? [y/N]: pkg: repository FreeBSD contains packages for wrong OS version: FreeBSD:13:amd64
Processing entries... done
Unable to update repository FreeBSD
Error updating repositories!
```