### PR TITLE
Fix mapset() test failure when using GUI

### DIFF
--- a/src/testdir/test_map_functions.vim
+++ b/src/testdir/test_map_functions.vim
@@ -511,7 +511,7 @@ func Test_map_restore_sid()
   new
   source Xmapscript
   inoremap <buffer> <C-B> <Cmd>call RestoreMap()<CR>
-  call feedkeys("i\<CR>\<C-B>\<CR>", 'xt')
+  call feedkeys("i\<CR>\<*C-B>\<CR>", 'xt')
   call assert_equal(['', '42', '42'], getline(1, '$'))
 
   bwipe!


### PR DESCRIPTION
Problem:    Test for mapset() fails when using GUI.
Solution:   Feed an unsimplified Ctrl-B.