### PR TITLE
Vim9 Class: member_count field is used instead of method_count field

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -1874,5 +1874,43 @@ def Test_defer_with_object()
   unlet g:result
 enddef
 
+" The following test used to crash Vim (Github issue #12676)
+def Test_extends_method_crashes_vim()
+  var lines =<< trim END
+    vim9script
+
+    class Observer
+    endclass
+
+    class Property
+      this.value: any
+
+      def Set(v: any)
+        if v != this.value
+          this.value = v
+        endif
+      enddef
+
+      def Register(observer: Observer)
+      enddef
+    endclass
+
+    class Bool extends Property
+      this.value: bool
+    endclass
+
+    def Observe(obj: Property, who: Observer)
+      obj.Register(who)
+    enddef
+
+    var p = Bool.new(false)
+    var myObserver = Observer.new()
+
+    Observe(p, myObserver)
+
+    p.Set(true)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -897,7 +897,7 @@ early_ret:
 		    if (!done && extends_cl != NULL)
 		    {
 			for (int cl_i = 0;
-			     cl_i < extends_cl->class_obj_member_count; ++cl_i)
+			     cl_i < extends_cl->class_obj_method_count; ++cl_i)
 			{
 			    if (STRCMP(ifcl->class_obj_methods[if_i]->uf_name,
 				   extends_cl->class_obj_methods[cl_i]->uf_name)


### PR DESCRIPTION
Fixes #12676