### PR TITLE
cache linux-modules-extra to reduce failed downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,23 +180,20 @@ jobs:
           sudo usermod -a -G audio "${USER}"
           sudo bash ci/setup-xvfb.sh
 
-      - name: Check if linux-modules-extra is available
-        id: check-snd-dummy
-        if: (!(contains(matrix.extra, 'unittests') || contains(matrix.extra, 'vimtags')))
-        continue-on-error: true
-        run: |
-          sudo apt-get install -d -y linux-modules-extra-${{ env.LINUX_VERSION }}
-
       - name: Set up snd-dummy
-        if: steps.check-snd-dummy.outcome == 'success' && (!(contains(matrix.extra, 'unittests') || contains(matrix.extra, 'vimtags')))
+        if: (!(contains(matrix.extra, 'unittests') || contains(matrix.extra, 'vimtags')))
         env:
           DEST_DIR: ${{ env.TMPDIR }}/linux-modules-extra-${{ env.LINUX_VERSION }}
+        uses: tecolicom/actions-use-apt-tools@main
+        with:
+          tools: linux-modules-extra-${{ env.LINUX_VERSION }}
+          path: "${DEST_DIR}"
+
+      - name: modprobe snd-dummy
+        if: (!(contains(matrix.extra, 'unittests') || contains(matrix.extra, 'vimtags')))
         run: |
-          cd /lib/modules/${{ env.LINUX_VERSION }}
-          sudo dpkg -x /var/cache/apt/archives/linux-modules-extra-${{ env.LINUX_VERSION }}*.deb "${DEST_DIR}"
-          tar -cvC "${DEST_DIR}"/lib/modules/${{ env.LINUX_VERSION }} kernel/sound | sudo tar -x
           sudo depmod --verbose
-          sudo modprobe --verbose snd-dummy 
+          sudo modprobe --verbose snd-dummy
 
       - name: Check autoconf
         if: contains(matrix.extra, 'unittests')


### PR DESCRIPTION
This GitHub action install Linux APT packages and cache them for later use. When executed next time with same package list, and any other environment are not changed, installed files are extracted from the cached archive.

When valid cached archive is not found, all packages are installed by apt-get command. If you want partial install/cache behavior, use this action multiple times.
ref: https://github.com/marketplace/actions/install-and-cache-apt-tools#actions-use-apt-tools