### PR TITLE
if_lua: Prevent SEGV/ABRT for Lua functions invoked via Vim callbacks

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -71,14 +71,16 @@ static int in_ccallback = 0;
 // get/setudata manage references to vim userdata in cache table through
 // object pointers (light userdata)
 #define luaV_getudata(L, v) \
-    if (in_ccallback) { \
+    if (in_ccallback) \
 	lua_pushnil(L); \
-    } else { \
+    else \
+    { \
 	lua_pushlightuserdata((L), (void *) (v)); \
 	lua_rawget((L), lua_upvalueindex(1)); \
     }
 #define luaV_setudata(L, v) \
-    if (!in_ccallback) { \
+    if (!in_ccallback) \
+    { \
 	lua_pushlightuserdata((L), (void *) (v)); \
 	lua_pushvalue((L), -2); \
 	lua_rawset((L), lua_upvalueindex(1)); \


### PR DESCRIPTION
`if_lua` employs a cache system using upvalues that fails when a Lua function is invoked as a Vim callback *with* parameters.   

A MRE that causes a SEGV with PUC Lua 5.1 and an ABRT with Luajit:

`vim --clean -S if_lua-segv-mre.vim.txt`

[`if_lua-segv-mre.vim.txt`](https://github.com/vim/vim/files/12330205/if_lua-segv-mre.vim.txt)

```vim
let s:Lua_funcref = luaeval('function(d) print("in Lua callback") end')

function! Exit_CB(job, status)
    call s:Lua_funcref({'a' : 'b'})
endfunction

let s:job = job_start("echo Hi",
      \ { 'exit_cb' : 'Exit_CB' })
```

This patch gates use of the cache system with a static variable, so that it is not employed when upvalues are unavailable.

