### PR TITLE
Add filetype support for bicepparam files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -245,7 +245,7 @@ au BufNewFile,BufRead *.bib			setf bib
 au BufNewFile,BufRead *.bst			setf bst
 
 " Bicep
-au BufNewFile,BufRead *.bicep			setf bicep
+au BufNewFile,BufRead *.bicep,*.bicepparam			setf bicep
 
 " BIND configuration
 " sudoedit uses namedXXXX.conf

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -119,7 +119,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     bdf: ['file.bdf'],
     beancount: ['file.beancount'],
     bib: ['file.bib'],
-    bicep: ['file.bicep'],
+    bicep: ['file.bicep', 'file.bicepparam'],
     bindzone: ['named.root', '/bind/db.file', '/named/db.file', 'any/bind/db.file', 'any/named/db.file'],
     bitbake: ['file.bb', 'file.bbappend', 'file.bbclass', 'build/conf/local.conf', 'meta/conf/layer.conf', 'build/conf/bbappend.conf', 'meta-layer/conf/distro/foo.conf'],
     blade: ['file.blade.php'],


### PR DESCRIPTION
The [Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep) filetype should include support for both *.bicep and *.bicepparam files.

In fact, bicepparam is now preferred over json parameter files. Documentation [here](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameter-files?tabs=Bicep).