### PR TITLE
if_lua: Prevent SEGV/ABRT for Lua functions invoked via Vim callbacks (fixed issues with PR #12782)

### DIFF
--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -1232,4 +1232,11 @@ func Test_lua_debug()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for a crash when a Lua funcref is invoked with parameters from Vim
+func Test_lua_funcref_with_params()
+  let Lua_funcref = luaeval('function(d) local s = "in Lua callback" end')
+  call Lua_funcref({'a' : 'b'})
+  call assert_true(v:true)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
`if_lua` employs a cache system using upvalues that fails when a Lua function is invoked as a Vim callback with certain types of parameters (lists, dicts, blobs, buffers, windows).

A MRE that causes a SEGV with PUC Lua 5.1 and an ABRT with Luajit:

```vim
let Lua_funcref = luaeval('function(d) local s = "in Lua callback" end')
call Lua_funcref({'a' : 'b'})
```

This patch uses the Lua registry rather than upvalues for the userdata cache.
