### PR TITLE
Respect selected region in dict completion

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -3942,13 +3942,10 @@ spell_dump_compl(
 	}
     }
 
-    if (do_region && region_names != NULL)
+    if (do_region && region_names != NULL && pat == NULL)
     {
-	if (pat == NULL)
-	{
-	    vim_snprintf((char *)IObuff, IOSIZE, "/regions=%s", region_names);
-	    ml_append(lnum++, IObuff, (colnr_T)0, FALSE);
-	}
+	vim_snprintf((char *)IObuff, IOSIZE, "/regions=%s", region_names);
+	ml_append(lnum++, IObuff, (colnr_T)0, FALSE);
     }
     else
 	do_region = FALSE;

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -274,8 +274,7 @@ func Test_compl_with_CTRL_X_CTRL_K_using_spell()
   call assert_equal(['theater'], getline(1, '$'))
   set spelllang=en_gb
   call feedkeys("Stheat\<c-x>\<c-k>\<esc>", 'tnx')
-  " FIXME: commented out, expected theatre bug got theater. See issue #7025.
-  " call assert_equal(['theatre'], getline(1, '$'))
+  call assert_equal(['theatre'], getline(1, '$'))
 
   bwipe!
   set spell& spelllang& dictionary& ignorecase&


### PR DESCRIPTION
Set do_region to zero as we don't want a complete dump of the matching words, we want the code to filter them according to the user's selected region.

Closes #7025