### PR TITLE
Nvim Lua scripts not recognized from shebang line

### DIFF
--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -877,6 +877,8 @@ enddef
 " Filetypes detected from the file contents by scripts.vim
 def s:GetScriptChecks(): dict<list<list<string>>>
   return {
+    conf:   [['#!'],
+            ['#!UNKNOWN-INTERPRETER']],
     virata: [['% Virata'],
             ['', '% Virata'],
             ['', '', '% Virata'],
@@ -908,7 +910,10 @@ def s:GetScriptChecks(): dict<list<list<string>>>
     pike:   [['#!/path/pike'],
             ['#!/path/pike0'],
             ['#!/path/pike9']],
-    lua:    [['#!/path/lua']],
+    lua:    [['#!/path/lua'],
+            ['#!/path/nvim -l'],
+            ['#!/path/nvim -ll'],
+            ['#!/path/pandoc --lua-filter']],
     raku:   [['#!/path/raku']],
     perl:   [['#!/path/perl']],
     php:    [['#!/path/php']],


### PR DESCRIPTION
Nvim specifies Lua scripts with the -l and -ll options so match nvim
shebang lines with these options as as file type Lua.

E.g., #!/usr/bin/env -S nvim -l

Fixes #12722
