### PR TITLE
virtcol2col() should return the column number of the first byte in a multibyte character

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -10347,6 +10347,9 @@ virtcol2col({winid}, {lnum}, {col})			*virtcol2col()*
 		{lnum}, then the byte index of the character at the last
 		virtual column is returned.
 
+		For a multi-byte character, the column number of the first
+		byte in the character is returned.
+
 		The {winid} argument can be the window number or the
 		|window-ID|. If this is zero, then the current window is used.
 

--- a/src/move.c
+++ b/src/move.c
@@ -1557,6 +1557,25 @@ f_screenpos(typval_T *argvars UNUSED, typval_T *rettv)
 }
 
 /*
+ * Convert a virtual (screen) column to a character column.  The first column
+ * is one.  For a multibyte character, the column number of the first byte is
+ * returned.
+ */
+    static int
+virtcol2col(win_T *wp, linenr_T lnum, int vcol)
+{
+    int		offset = vcol2col(wp, lnum, vcol);
+    char_u	*line = ml_get_buf(wp->w_buffer, lnum, FALSE);
+    char_u	*p = line + offset;
+
+    // For a multibyte character, need to return the column number of the first
+    // byte.
+    MB_PTR_BACK(line, p);
+
+    return (int)(p - line + 1);
+}
+
+/*
  * "virtcol2col({winid}, {lnum}, {col})" function
  */
     void
@@ -1586,7 +1605,7 @@ f_virtcol2col(typval_T *argvars UNUSED, typval_T *rettv)
     if (error || screencol < 0)
 	return;
 
-    rettv->vval.v_number = vcol2col(wp, lnum, screencol);
+    rettv->vval.v_number = virtcol2col(wp, lnum, screencol);
 }
 #endif
 

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -531,6 +531,15 @@ func Test_virtcol2col()
   call assert_equal(-1, virtcol2col(0, -1, 1))
   call assert_equal(-1, virtcol2col(0, 1, -1))
   call assert_equal(5, virtcol2col(0, 1, 20))
+
+  " Multibyte character
+  call setline(1, ['a✅✅✅'])
+  call assert_equal(1, virtcol2col(0, 1, 1))
+  call assert_equal(2, virtcol2col(0, 1, 3))
+  call assert_equal(5, virtcol2col(0, 1, 5))
+  call assert_equal(8, virtcol2col(0, 1, 7))
+  call assert_equal(8, virtcol2col(0, 1, 8))
+
   call assert_fails('echo virtcol2col("0", 1, 20)', 'E1210:')
   call assert_fails('echo virtcol2col(0, "1", 20)', 'E1210:')
   call assert_fails('echo virtcol2col(0, 1, "1")', 'E1210:')


### PR DESCRIPTION
Fixes #12786