### PR TITLE
src/if_python3.c: Fix build with Clang on Windows

### DIFF
--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -628,9 +628,8 @@ static struct
     {"PyStdPrinter_Type", (PYTHON_PROC*)&py3_PyStdPrinter_Type},
     {"PySlice_Type", (PYTHON_PROC*)&py3_PySlice_Type},
     {"PyFloat_Type", (PYTHON_PROC*)&py3_PyFloat_Type},
+# if PY_VERSION_HEX < 0x030c00b0
     {"PyBool_Type", (PYTHON_PROC*)&py3_PyBool_Type},
-# if PY_VERSION_HEX >= 0x030c00b0
-    {"PyLong_Type", (PYTHON_PROC*)&py3_PyLong_Type},
 # endif
     {"PyNumber_Check", (PYTHON_PROC*)&py3_PyNumber_Check},
     {"PyNumber_Long", (PYTHON_PROC*)&py3_PyNumber_Long},


### PR DESCRIPTION
Clang on Win doesn't like non-static functions in static struct with Python 3.12 - removing the new obfuscated function and protecting the old PyBool function for older Pythons fixes the issue.