### PR TITLE
Fix getcompletion() "cmdline" not working for command after :autocmd

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -4017,9 +4017,10 @@ f_getcompletion(typval_T *argvars, typval_T *rettv)
     ExpandInit(&xpc);
     if (STRCMP(type, "cmdline") == 0)
     {
-	set_one_cmd_context(&xpc, pat);
+	int cmdline_len = (int)STRLEN(pat);
+	set_cmd_context(&xpc, pat, cmdline_len, cmdline_len, FALSE);
 	xpc.xp_pattern_len = (int)STRLEN(xpc.xp_pattern);
-	xpc.xp_col = (int)STRLEN(pat);
+	xpc.xp_col = cmdline_len;
     }
     else
     {

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -612,6 +612,8 @@ func Test_getcompletion()
   call assert_true(index(l, 'taglist(') >= 0)
   let l = getcompletion('call paint', 'cmdline')
   call assert_equal([], l)
+  let l = getcompletion('autocmd BufEnter * map <bu', 'cmdline')
+  call assert_equal(['<buffer>'], l)
 
   func T(a, c, p)
     let g:cmdline_compl_params = [a:a, a:c, a:p]
@@ -3498,14 +3500,15 @@ func Test_rulerformat_position()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_usercmd_completion()
-  let g:complete=[]
+func Test_getcompletion_usercmd()
   command! -nargs=* -complete=command TestCompletion echo <q-args>
-  let g:complete = getcompletion('TestCompletion ', 'cmdline')
-  let a = getcompletion('', 'cmdline')
 
-  call assert_equal(a, g:complete)
+  call assert_equal(getcompletion('', 'cmdline'),
+        \ getcompletion('TestCompletion ', 'cmdline'))
+  call assert_equal(['<buffer>'],
+        \ getcompletion('TestCompletion map <bu', 'cmdline'))
+
   delcom TestCompletion
-  unlet! g:complete
 endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -329,11 +329,7 @@ set_context_in_user_cmdarg(
 	return set_context_in_menu_cmd(xp, cmd, arg, forceit);
 #endif
     if (context == EXPAND_COMMANDS)
-    {
-	if (xp->xp_context == EXPAND_NOTHING)
-	    xp->xp_context = context;
 	return arg;
-    }
     if (context == EXPAND_MAPPINGS)
 	return set_context_in_map_cmd(xp, (char_u *)"map", arg, forceit, FALSE,
 							FALSE, CMD_map);


### PR DESCRIPTION
Problem:    getcompletion() "cmdline" fails for command after :autocmd.
Solution:   Use set_cmd_context() instead of set_one_cmd_context().
