### PR TITLE
Allow more characters in highlight group names

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -215,9 +215,9 @@ thing.  These are then linked to a highlight group that specifies the color.
 A syntax group name doesn't specify any color or attributes itself.
 
 The name for a highlight or syntax group must consist of ASCII letters,
-digits, underscores, dots, hyphens, or the @ character.  As a regexp:
-"[a-zA-Z0-9_.-]*".  However, Vim does not give an error when using other
-characters.  The maximum length of a group name is about 200 bytes.  *E1249*
+digits, underscores, dots, or hyphens.  As a regexp: "[a-zA-Z0-9_.-]*".
+However, Vim does not give an error when using other characters.  The maximum
+length of a group name is about 200 bytes.  *E1249*
 
 To be able to allow each user to pick their favorite set of colors, there must
 be preferred names for highlight groups that are common for many languages.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -214,10 +214,10 @@ A syntax group name is to be used for syntax items that match the same kind of
 thing.  These are then linked to a highlight group that specifies the color.
 A syntax group name doesn't specify any color or attributes itself.
 
-The name for a highlight or syntax group must consist of ASCII letters, digits
-and the underscore.  As a regexp: "[a-zA-Z0-9_]*".  However, Vim does not give
-an error when using other characters.  The maximum length of a group name is
-about 200 bytes.  *E1249*
+The name for a highlight or syntax group must consist of ASCII letters,
+digits, underscores, dots, hyphens, or the @ character.  As a regexp:
+"[a-zA-Z0-9_.@-]*".  However, Vim does not give an error when using other
+characters.  The maximum length of a group name is about 200 bytes.  *E1249*
 
 To be able to allow each user to pick their favorite set of colors, there must
 be preferred names for highlight groups that are common for many languages.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -216,11 +216,8 @@ A syntax group name doesn't specify any color or attributes itself.
 
 The name for a highlight or syntax group must consist of ASCII letters,
 digits, underscores, dots, hyphens, or the @ character.  As a regexp:
-"[a-zA-Z0-9_.@-]*".  However, Vim does not give an error when using other
+"[a-zA-Z0-9_.-]*".  However, Vim does not give an error when using other
 characters.  The maximum length of a group name is about 200 bytes.  *E1249*
-
-Note that using "@" as the first character of a highlight group name may
-behave unexpectedly in syntax definitions. Avoid doing this.
 
 To be able to allow each user to pick their favorite set of colors, there must
 be preferred names for highlight groups that are common for many languages.
@@ -4654,10 +4651,6 @@ this notation to implicitly declare a cluster before specifying its contents.
 Example: >
    :syntax match Thing "# [^#]\+ #" contains=@ThingMembers
    :syntax cluster ThingMembers contains=ThingMember1,ThingMember2
-
-Note that using "@" in a syntax definition will always refer to a cluster, not
-a highlight group. It is recommended to avoid using "@" as the first character
-of a highlight group name.
 
 As the previous example suggests, modifications to a cluster are effectively
 retroactive; the membership of the cluster is checked at the last minute, so

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -219,6 +219,9 @@ digits, underscores, dots, hyphens, or the @ character.  As a regexp:
 "[a-zA-Z0-9_.@-]*".  However, Vim does not give an error when using other
 characters.  The maximum length of a group name is about 200 bytes.  *E1249*
 
+Note that using "@" as the first character of a highlight group name may
+behave unexpectedly in syntax definitions. Avoid doing this.
+
 To be able to allow each user to pick their favorite set of colors, there must
 be preferred names for highlight groups that are common for many languages.
 These are the suggested group names (if syntax highlighting works properly
@@ -4651,6 +4654,10 @@ this notation to implicitly declare a cluster before specifying its contents.
 Example: >
    :syntax match Thing "# [^#]\+ #" contains=@ThingMembers
    :syntax cluster ThingMembers contains=ThingMember1,ThingMember2
+
+Note that using "@" in a syntax definition will always refer to a cluster, not
+a highlight group. It is recommended to avoid using "@" as the first character
+of a highlight group name.
 
 As the previous example suggests, modifications to a cluster are effectively
 retroactive; the membership of the cluster is checked at the last minute, so

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -3452,7 +3452,7 @@ syn_add_group(char_u *name)
     char_u	*p;
     char_u	*name_up;
 
-    // Check that the name is ASCII letters, digits and underscore.
+    // Check that the name is valid (ASCII letters, digits, underscores, @, dots, or hyphens).
     for (p = name; *p != NUL; ++p)
     {
 	if (!vim_isprintc(*p))
@@ -3461,7 +3461,7 @@ syn_add_group(char_u *name)
 	    vim_free(name);
 	    return 0;
 	}
-	else if (!ASCII_ISALNUM(*p) && *p != '_')
+	else if (!ASCII_ISALNUM(*p) && *p != '_' && *p != '.' && *p != '@' && *p != '-')
 	{
 	    // This is an error, but since there previously was no check only
 	    // give a warning.

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -3452,7 +3452,7 @@ syn_add_group(char_u *name)
     char_u	*p;
     char_u	*name_up;
 
-    // Check that the name is valid (ASCII letters, digits, underscores, @, dots, or hyphens).
+    // Check that the name is valid (ASCII letters, digits, underscores, dots, or hyphens).
     for (p = name; *p != NUL; ++p)
     {
 	if (!vim_isprintc(*p))
@@ -3461,7 +3461,7 @@ syn_add_group(char_u *name)
 	    vim_free(name);
 	    return 0;
 	}
-	else if (!ASCII_ISALNUM(*p) && *p != '_' && *p != '.' && *p != '@' && *p != '-')
+	else if (!ASCII_ISALNUM(*p) && *p != '_' && *p != '.' && *p != '-')
 	{
 	    // This is an error, but since there previously was no check only
 	    // give a warning.


### PR DESCRIPTION
Allow dots, hyphens, and @ character in group names. There does not seem to be any reason for these to be disallowed.

As a simple test, I tried the following in a C source file:

```vim
:hi link foo-bar Error
:syn keyword foo-bar static
```

This all works as expected.

---

For further context, we made this same change in Neovim (https://github.com/neovim/neovim/pull/24714 and https://github.com/neovim/neovim/pull/19830). If allowing these extra characters does no harm, then there's no reason for a divergence here between the two projects.
