### PR TITLE
Fix: vim9class constructor argument type checking bug

### DIFF
--- a/src/proto/vim9instr.pro
+++ b/src/proto/vim9instr.pro
@@ -57,7 +57,7 @@ int check_internal_func_args(cctx_T *cctx, int func_idx, int argcount, int metho
 int generate_BCALL(cctx_T *cctx, int func_idx, int argcount, int method_call);
 int generate_LISTAPPEND(cctx_T *cctx);
 int generate_BLOBAPPEND(cctx_T *cctx);
-int generate_CALL(cctx_T *cctx, type_T *type, ufunc_T *ufunc, class_T *cl, int mi, int pushed_argcount);
+int generate_CALL(cctx_T *cctx, ufunc_T *ufunc, class_T *cl, int mi, type_T *mtype, int pushed_argcount);
 int generate_UCALL(cctx_T *cctx, char_u *name, int argcount);
 int check_func_args_from_type(cctx_T *cctx, type_T *type, int argcount, int at_top, char_u *name);
 int generate_PCALL(cctx_T *cctx, int argcount, char_u *name, type_T *type, int at_top);

--- a/src/proto/vim9instr.pro
+++ b/src/proto/vim9instr.pro
@@ -57,7 +57,7 @@ int check_internal_func_args(cctx_T *cctx, int func_idx, int argcount, int metho
 int generate_BCALL(cctx_T *cctx, int func_idx, int argcount, int method_call);
 int generate_LISTAPPEND(cctx_T *cctx);
 int generate_BLOBAPPEND(cctx_T *cctx);
-int generate_CALL(cctx_T *cctx, ufunc_T *ufunc, class_T *cl, int mi, int pushed_argcount);
+int generate_CALL(cctx_T *cctx, type_T *type, ufunc_T *ufunc, class_T *cl, int mi, int pushed_argcount);
 int generate_UCALL(cctx_T *cctx, char_u *name, int argcount);
 int check_func_args_from_type(cctx_T *cctx, type_T *type, int argcount, int at_top, char_u *name);
 int generate_PCALL(cctx_T *cctx, int argcount, char_u *name, type_T *type, int at_top);

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -528,6 +528,8 @@ def Test_class_new_with_object_member()
         this.num: number
         def new(this.str, this.num)
         enddef
+        def newVals(this.str, this.num)
+        enddef
       endclass
 
       def Check()
@@ -535,32 +537,12 @@ def Test_class_new_with_object_member()
           var c = C.new('cats', 2)
           assert_equal('cats', c.str)
           assert_equal(2, c.num)
-        catch
-          echo $'Exception was caught: {v:exception}'
-        endtry
-      enddef
 
-      Check()
-  END
-  v9.CheckScriptSuccess(lines)
-
-  lines =<< trim END
-      vim9script
-
-      class C
-        this.str: string
-        this.num: number
-        def newVals(this.str, this.num)
-        enddef
-      endclass
-
-      def Check()
-        try
-          var c = C.newVals('dogs', 4)
+          c = C.newVals('dogs', 4)
           assert_equal('dogs', c.str)
           assert_equal(4, c.num)
         catch
-          echo $'Exception was caught: {v:exception}'
+          assert_report($'Unexpected exception was caught: {v:exception}')
         endtry
       enddef
 
@@ -582,7 +564,7 @@ def Test_class_new_with_object_member()
         try
           var c = C.new(1, 2)
         catch
-          echo $'Exception was caught: {v:exception}'
+          assert_report($'Unexpected exception was caught: {v:exception}')
         endtry
       enddef
 
@@ -604,7 +586,7 @@ def Test_class_new_with_object_member()
         try
           var c = C.newVals('dogs', 'apes')
         catch
-          echo $'Exception was caught: {v:exception}'
+          assert_report($'Unexpected exception was caught: {v:exception}')
         endtry
       enddef
 

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -518,6 +518,101 @@ def Test_class_default_new()
   v9.CheckScriptFailure(lines, 'E119:')
 enddef
 
+
+def Test_class_new_with_object_member()
+  var lines =<< trim END
+      vim9script
+
+      class C
+        this.str: string
+        this.num: number
+        def new(this.str, this.num)
+        enddef
+      endclass
+
+      def Check()
+        try
+          var c = C.new('cats', 2)
+          assert_equal('cats', c.str)
+          assert_equal(2, c.num)
+        catch
+          echo $'Exception was caught: {v:exception}'
+        endtry
+      enddef
+
+      Check()
+  END
+  v9.CheckScriptSuccess(lines)
+
+  lines =<< trim END
+      vim9script
+
+      class C
+        this.str: string
+        this.num: number
+        def newVals(this.str, this.num)
+        enddef
+      endclass
+
+      def Check()
+        try
+          var c = C.newVals('dogs', 4)
+          assert_equal('dogs', c.str)
+          assert_equal(4, c.num)
+        catch
+          echo $'Exception was caught: {v:exception}'
+        endtry
+      enddef
+
+      Check()
+  END
+  v9.CheckScriptSuccess(lines)
+
+  lines =<< trim END
+      vim9script
+
+      class C
+        this.str: string
+        this.num: number
+        def new(this.str, this.num)
+        enddef
+      endclass
+
+      def Check()
+        try
+          var c = C.new(1, 2)
+        catch
+          echo $'Exception was caught: {v:exception}'
+        endtry
+      enddef
+
+      Check()
+  END
+  v9.CheckScriptFailure(lines, 'E1013:')
+
+  lines =<< trim END
+      vim9script
+
+      class C
+        this.str: string
+        this.num: number
+        def newVals(this.str, this.num)
+        enddef
+      endclass
+
+      def Check()
+        try
+          var c = C.newVals('dogs', 'apes')
+        catch
+          echo $'Exception was caught: {v:exception}'
+        endtry
+      enddef
+
+      Check()
+  END
+  v9.CheckScriptFailure(lines, 'E1013:')
+enddef
+
 def Test_class_object_member_inits()
   var lines =<< trim END
       vim9script

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -358,8 +358,8 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 
 	if (type->tt_type == VAR_OBJECT
 		     && (cl->class_flags & (CLASS_INTERFACE | CLASS_EXTENDED)))
-	    return generate_CALL(cctx, ufunc, cl, fi, argcount);
-	return generate_CALL(cctx, ufunc, NULL, 0, argcount);
+	    return generate_CALL(cctx, type, ufunc, cl, fi, argcount);
+	return generate_CALL(cctx, type, ufunc, NULL, 0, argcount);
     }
 
     if (type->tt_type == VAR_OBJECT)
@@ -932,6 +932,7 @@ compile_call(
     int		has_g_namespace;
     ca_special_T special_fn;
     imported_T	*import;
+    type_T	*type;
 
     if (varlen >= sizeof(namebuf))
     {
@@ -1015,6 +1016,7 @@ compile_call(
     if (compile_arguments(arg, cctx, &argcount, special_fn) == FAIL)
 	goto theend;
 
+    type = get_decl_type_on_stack(cctx, 1);
     is_autoload = vim_strchr(name, AUTOLOAD_CHAR) != NULL;
     if (ASCII_ISLOWER(*name) && name[1] != ':' && !is_autoload)
     {
@@ -1032,8 +1034,6 @@ compile_call(
 
 	    if (STRCMP(name, "add") == 0 && argcount == 2)
 	    {
-		type_T	    *type = get_decl_type_on_stack(cctx, 1);
-
 		// add() can be compiled to instructions if we know the type
 		if (type->tt_type == VAR_LIST)
 		{
@@ -1080,7 +1080,7 @@ compile_call(
 	{
 	    if (!func_is_global(ufunc))
 	    {
-		res = generate_CALL(cctx, ufunc, NULL, 0, argcount);
+		res = generate_CALL(cctx, type, ufunc, NULL, 0, argcount);
 		goto theend;
 	    }
 	    if (!has_g_namespace
@@ -1109,7 +1109,7 @@ compile_call(
     // If we can find a global function by name generate the right call.
     if (ufunc != NULL)
     {
-	res = generate_CALL(cctx, ufunc, NULL, 0, argcount);
+	res = generate_CALL(cctx, type, ufunc, NULL, 0, argcount);
 	goto theend;
     }
 

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -358,8 +358,8 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 
 	if (type->tt_type == VAR_OBJECT
 		     && (cl->class_flags & (CLASS_INTERFACE | CLASS_EXTENDED)))
-	    return generate_CALL(cctx, type, ufunc, cl, fi, argcount);
-	return generate_CALL(cctx, type, ufunc, NULL, 0, argcount);
+	    return generate_CALL(cctx, ufunc, cl, fi, type, argcount);
+	return generate_CALL(cctx, ufunc, NULL, 0, type, argcount);
     }
 
     if (type->tt_type == VAR_OBJECT)
@@ -1080,7 +1080,7 @@ compile_call(
 	{
 	    if (!func_is_global(ufunc))
 	    {
-		res = generate_CALL(cctx, type, ufunc, NULL, 0, argcount);
+		res = generate_CALL(cctx, ufunc, NULL, 0, type, argcount);
 		goto theend;
 	    }
 	    if (!has_g_namespace
@@ -1109,7 +1109,7 @@ compile_call(
     // If we can find a global function by name generate the right call.
     if (ufunc != NULL)
     {
-	res = generate_CALL(cctx, type, ufunc, NULL, 0, argcount);
+	res = generate_CALL(cctx, ufunc, NULL, 0, type, argcount);
 	goto theend;
     }
 

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -1777,10 +1777,10 @@ generate_BLOBAPPEND(cctx_T *cctx)
     int
 generate_CALL(
 	cctx_T	    *cctx,
-	type_T	    *mtype,	// method type
 	ufunc_T	    *ufunc,
 	class_T	    *cl,
 	int	    mi,
+	type_T	    *mtype,	// method type
 	int	    pushed_argcount)
 {
     isn_T	*isn;
@@ -1827,7 +1827,9 @@ generate_CALL(
 		    continue;
 		expected = ufunc->uf_arg_types[i];
 
-		// class constructor with object member
+		// When the method is a class constructor and the formal
+		// argument is an object member, the type check is performed on
+		// the object member type.
 		if (class_constructor && expected->tt_type == VAR_ANY)
 		{
 		    class_T *clp = mtype->tt_class;


### PR DESCRIPTION
Type checking is not performed when the formal argument of a vim9class constructor is an object member.

Related: #12701 ([my comment](https://github.com/vim/vim/issues/12701#issuecomment-1680387283))
