### PR TITLE
Avoid unnecessary redraw caused by screenpos()

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -2343,7 +2343,7 @@ win_update(win_T *wp)
 			    {
 				int n = plines_win_nofill(wp, l, FALSE)
 								+ wp->w_topfill;
-				n = adjust_plines_for_skipcol(wp, n);
+				n -= adjust_plines_for_skipcol(wp);
 				if (n > wp->w_height)
 				    n = wp->w_height;
 				new_rows += n;

--- a/src/proto/move.pro
+++ b/src/proto/move.pro
@@ -1,5 +1,5 @@
 /* move.c */
-int adjust_plines_for_skipcol(win_T *wp, int n);
+int adjust_plines_for_skipcol(win_T *wp);
 void redraw_for_cursorline(win_T *wp);
 int sms_marker_overlap(win_T *wp, int extra2);
 void update_topline_redraw(void);


### PR DESCRIPTION
Problem:    Calling screenpos() may cause unnecessary redraw.
Solution:   Don't unnecessarily reset VALID_WROW flag.

VALID_WROW flag is only used by two functions: validate_cursor() and
cursor_valid(), and cursor_valid() is only used once in ex_sleep().
When adjust_plines_for_skipcol() was first added in patch 9.0.0640, it
was called in two functions: comp_botline() and curs_rows().
- comp_botline() is called in two places:
  - onepage(), which resets VALID_WROW flag immediately afterwards.
  - validate_botline_win(), where resetting a VALID_ flag is strange.
- curs_rows() is called in two places:
  - curs_columns(), which sets VALID_WROW flag afterwards.
  - validate_cline_row(), which is only used by GUI mouse focus.

Therefore resetting VALID_WROW there doesn't seem to do anything useful.
Also, a w_skipcol check (which resets VALID_WROW flag) was added to
check_cursor_moved() in patch 9.0.0734, which seems to make more sense
than resetting that flag in the middle of a computation.

Also make adjust_plines_for_skipcol() and textpos2screenpos() a bit less
confusing:
- Make adjust_plines_for_skipcol() return "off" instead of "n - off".
- Use 0-based "row" in textpos2screenpos() until W_WINROW is added.
