### PR TITLE
Remove dead code in open_cmdwin()

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4613,11 +4613,6 @@ open_cmdwin(void)
 		stuffcharReadbuff(CAR);
 	    }
 	}
-	else if (cmdwin_result == K_XF2)	// :qa typed
-	{
-	    ccline.cmdbuff = vim_strsave((char_u *)"qa");
-	    cmdwin_result = CAR;
-	}
 	else if (cmdwin_result == Ctrl_C)
 	{
 	    // :q or :close, don't execute any command


### PR DESCRIPTION
Problem: Dead code in open_cmdwin()
Solution: Remove it

The condition is already handled by the if statement above.