### PR TITLE
Parameter of gui_gtk:gui_mch_browse incorrectly marked as UNUSED

### DIFF
--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -1239,10 +1239,10 @@ browse_destroy_cb(GtkWidget *widget UNUSED)
  * dflt				default name
  * ext				not used (extension added)
  * initdir			initial directory, NULL for current dir
- * filter			not used (file name filter)
+ * filter			file name filter
  */
     char_u *
-gui_mch_browse(int saving UNUSED,
+gui_mch_browse(int saving,
 	       char_u *title,
 	       char_u *dflt,
 	       char_u *ext UNUSED,


### PR DESCRIPTION
Problem:    Parameter of gui_gtk:gui_mch_browse incorrectly marked as
            UNUSED.
Solution:   Remove UNUSED.
