### PR TITLE
Fix a segfault in `handle_viminfo_register`

### DIFF
--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -614,6 +614,26 @@ func Test_viminfo_bad_syntax2()
   rviminfo Xviminfo
 endfunc
 
+" This used to crash Vim (GitHub issue #12652)
+func Test_viminfo_bad_syntax3()
+  let lines =<< trim END
+    call writefile([], 'Xvbs3.result')
+    qall!
+  END
+  call writefile(lines, 'Xvbs3script', 'D')
+
+  let lines = []
+  call add(lines, '|1,4')
+  " bad viminfo syntax for register barline
+  call add(lines, '|3,1,1,1,1,0,71489,,125') " empty line1
+  call writefile(lines, 'Xviminfo', 'D')
+
+  call RunVim([], [], '--clean -i Xviminfo -S Xvbs3script')
+  call assert_true(filereadable('Xvbs3.result'))
+
+  call delete('Xvbs3.result')
+endfunc
+
 func Test_viminfo_file_marks()
   silent! bwipe test_viminfo.vim
   silent! bwipe Xviminfo

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1804,6 +1804,11 @@ handle_viminfo_register(garray_T *values, int force)
 	    y_ptr->y_array[i] = vp[i + 6].bv_string;
 	    vp[i + 6].bv_string = NULL;
 	}
+        else if (vp[i + 6].bv_type != BVAL_STRING)
+        {
+            free(y_ptr->y_array);
+            y_ptr->y_array = NULL;
+        }
 	else
 	    y_ptr->y_array[i] = vim_strsave(vp[i + 6].bv_string);
     }


### PR DESCRIPTION
This commit addresses #12652 by expanding upon @chrisbra’s proposed patch.

I replaced the test to prevent the segfault from happening for integer elements as well. I also added a `free` call to prevent memory leaks.

I tested the resulting build with no segfault. Valgrind found no definitely-lost memory block.