### PR TITLE
CI: set IGNORE_OSVERSION=yes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,7 @@ freebsd_task:
         image_family: freebsd-12-4
   timeout_in: 20m
   install_script:
+    - IGNORE_OSVERSION=yes
     - pkg install -y gettext
   build_script:
     - NPROC=$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
Newer FreeBSD version for package zxing-cpp:
To ignore this error set IGNORE_OSVERSION=yes
Follow up: https://github.com/vim/vim/pull/12767