### PR TITLE
CI: remove coveralls.yml

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: github-actions


### PR DESCRIPTION
Coveralls is no longer used, we ditched using it in patch v9.0.1547, commit 12eb0f4ec5a9d9899d09691f944e4fbfdf4318fd issue #12389

So let's remove the .coveralls.yml file, it does not seem useful anymore.