### PR TITLE
Fix failing sign test

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -3343,7 +3343,9 @@ win_line(
 			wlv.char_attr = wlv.line_attr;
 #ifdef FEAT_SIGNS
 		    // At end of line: if Sign is present with line highlight, reset char_attr
-		    if (sign_present && wlv.sattr.sat_linehl > 0 && wlv.draw_state == WL_LINE)
+		    // but not when cursorline is active
+		    if (sign_present && wlv.sattr.sat_linehl > 0 && wlv.draw_state == WL_LINE
+			 && !(wp->w_p_cul && lnum == wp->w_cursor.lnum))
 			wlv.char_attr = wlv.sattr.sat_linehl;
 #endif
 # ifdef FEAT_DIFF


### PR DESCRIPTION
Unfortunately, commit dbeadf05b6a152e7d9c5cc23d9202057f8e99884 causes a failure with the sign test Test_sign_cursor_position()

The root cause is, that resetting the character attribute will also reset the existing cursor line highlighting and this breaks the test, that expects the cursor line highlighting to overrule the sign line highlighting.

So change the condition to reset the character attribute by making sure that this only happens, if the 'cursorline' option is not active and the cursor is not at the same line as the line to be drawn

closes: #12854