### PR TITLE
Not able to get virtual text with the prop_list() function

### DIFF
--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -335,6 +335,10 @@ prop_list({lnum} [, {props}])				*prop_list()*
 		   length	length in bytes, one more if line break is
 				included
 		   id		property ID
+		   text		text to be displayed before {col}.  Only
+				present for |virtual-text| properties.
+		   text_align	alignment property of |virtual-text|.
+		   text_wrap	specifies whether |virtual-text| is wrapped.
 		   type		name of the property type, omitted if
 				the type was deleted
 		   type_bufnr	buffer number for which this type was defined;

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -4025,4 +4025,39 @@ func Test_text_prop_list_hl_and_sign_highlight()
 
   call StopVimInTerminal(buf)
 endfunc
+
+" Test for getting the virtual text properties
+func Test_virtual_text_get()
+  new foobar
+  call setline(1, '12345678')
+  call prop_type_add('test', #{highlight: 'Search'})
+  call prop_add(1, 2, #{type: 'test', text: ' virtual text1 '})
+  call prop_add(1, 3, #{type: 'test'})
+  call prop_add(1, 0, #{type: 'test', text: ' virtual text2 ',
+        \               text_align: 'right'})
+  call prop_add(1, 5, #{type: 'test'})
+  call prop_add(1, 6, #{type: 'test', text: ' virtual text3 ',
+        \               text_wrap: 'wrap'})
+
+  let p = prop_list(1, #{end_lnum: -1})
+  call assert_equal(
+        \ #{lnum: 1, id: -1, col: 2, type_bufnr: 0, end: 1,
+        \   type: 'test', length: 1, start: 1,
+        \   text: ' virtual text1 '}, p[0])
+  call assert_equal(
+        \ #{lnum: 1, id: 0, col: 3, type_bufnr: 0, end: 1,
+        \   type: 'test', length: 0, start: 1}, p[1])
+  call assert_equal(
+        \ #{lnum: 1, id: 0, col: 5, type_bufnr: 0, end: 1,
+        \   type: 'test', length: 0, start: 1}, p[2])
+  call assert_equal(
+        \ #{lnum: 1, id: -3, col: 6, type_bufnr: 0, end: 1, type: 'test',
+        \   text_wrap: 'wrap', length: 1, start: 1, text: ' virtual text3 '},
+        \  p[3])
+  call assert_equal('right', p[4].text_align)
+
+  call prop_type_delete('test')
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -990,6 +990,31 @@ prop_fill_dict(dict_T *dict, textprop_T *prop, buf_T *buf)
 	dict_add_number(dict, "type_bufnr", buf->b_fnum);
     else
 	dict_add_number(dict, "type_bufnr", 0);
+    if (prop->tp_id < 0)
+    {
+	// virtual text property
+	garray_T    *gap = &buf->b_textprop_text;
+	char_u	    *text;
+
+	// negate the property id to get the string index
+	text = ((char_u **)gap->ga_data)[-prop->tp_id - 1];
+	dict_add_string(dict, "text", text);
+
+	// text_align
+	char_u	    *text_align = NULL;
+	if (prop->tp_flags & TP_FLAG_ALIGN_RIGHT)
+	    text_align = (char_u *)"right";
+	else if (prop->tp_flags & TP_FLAG_ALIGN_ABOVE)
+	    text_align = (char_u *)"above";
+	else if (prop->tp_flags & TP_FLAG_ALIGN_BELOW)
+	    text_align = (char_u *)"below";
+	if (text_align != NULL)
+	    dict_add_string(dict, "text_align", text_align);
+
+	// text_wrap
+	if (prop->tp_flags & TP_FLAG_WRAP)
+	    dict_add_string(dict, "text_wrap", (char_u *)"wrap");
+    }
 }
 
 /*


### PR DESCRIPTION

Currently it is not possible to get the virtual text placed by the prop_add() function using the prop_list() function.
Return the text related properties for virtual text.  As this is the new feature introduced after Vim 9.0, it will be good
to get this included for the upcoming Vim 9.1 release.