### PR TITLE
Store and return the text_padding_left value for text properties

### DIFF
--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -338,6 +338,8 @@ prop_list({lnum} [, {props}])				*prop_list()*
 		   text		text to be displayed before {col}.  Only
 				present for |virtual-text| properties.
 		   text_align	alignment property of |virtual-text|.
+		   text_padding_left
+				left padding used for virtual text.
 		   text_wrap	specifies whether |virtual-text| is wrapped.
 		   type		name of the property type, omitted if
 				the type was deleted

--- a/src/structs.h
+++ b/src/structs.h
@@ -827,6 +827,8 @@ typedef struct textprop_S
     int		tp_id;		// identifier
     int		tp_type;	// property type
     int		tp_flags;	// TP_FLAG_ values
+    int		tp_padleft;	// left padding between text line and virtual
+				// text
 } textprop_T;
 
 #define TP_FLAG_CONT_NEXT	0x1	// property continues in next line

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -4063,8 +4063,8 @@ func Test_virtual_text_get()
 
   let p = prop_list(1, #{end_lnum: -1})
   call assert_equal(
-        \ #{lnum: 1, id: -1, col: 2, type_bufnr: 0, end: 1,
-        \   type: 'test', length: 1, start: 1,
+        \ #{lnum: 1, col: 2, type_bufnr: 0, end: 1,
+        \   type: 'test', start: 1,
         \   text: ' virtual text1 '}, p[0])
   call assert_equal(
         \ #{lnum: 1, id: 0, col: 3, type_bufnr: 0, end: 1,
@@ -4073,8 +4073,8 @@ func Test_virtual_text_get()
         \ #{lnum: 1, id: 0, col: 5, type_bufnr: 0, end: 1,
         \   type: 'test', length: 0, start: 1}, p[2])
   call assert_equal(
-        \ #{lnum: 1, id: -3, col: 6, type_bufnr: 0, end: 1, type: 'test',
-        \   text_wrap: 'wrap', length: 1, start: 1, text: ' virtual text3 '},
+        \ #{lnum: 1, col: 6, type_bufnr: 0, end: 1, type: 'test',
+        \   text_wrap: 'wrap', start: 1, text: ' virtual text3 '},
         \  p[3])
   call assert_equal('right', p[4].text_align)
 

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -308,6 +308,7 @@ prop_add_one(
 			    | (lnum < end_lnum ? TP_FLAG_CONT_NEXT : 0)
 			    | ((type->pt_flags & PT_FLAG_INS_START_INCL)
 						     ? TP_FLAG_START_INCL : 0);
+	tmp_prop.tp_padleft = text_padding_left;
 	mch_memmove(newprops + i * sizeof(textprop_T), &tmp_prop,
 							   sizeof(textprop_T));
 
@@ -969,10 +970,14 @@ prop_fill_dict(dict_T *dict, textprop_T *prop, buf_T *buf)
 {
     proptype_T *pt;
     int buflocal = TRUE;
+    int virtualtext_prop = prop->tp_id < 0;
 
-    dict_add_number(dict, "col", prop->tp_col);
-    dict_add_number(dict, "length", prop->tp_len);
-    dict_add_number(dict, "id", prop->tp_id);
+    dict_add_number(dict, "col", (prop->tp_col == MAXCOL) ? 0 : prop->tp_col);
+    if (!virtualtext_prop)
+    {
+	dict_add_number(dict, "length", prop->tp_len);
+	dict_add_number(dict, "id", prop->tp_id);
+    }
     dict_add_number(dict, "start", !(prop->tp_flags & TP_FLAG_CONT_PREV));
     dict_add_number(dict, "end", !(prop->tp_flags & TP_FLAG_CONT_NEXT));
 
@@ -990,7 +995,7 @@ prop_fill_dict(dict_T *dict, textprop_T *prop, buf_T *buf)
 	dict_add_number(dict, "type_bufnr", buf->b_fnum);
     else
 	dict_add_number(dict, "type_bufnr", 0);
-    if (prop->tp_id < 0)
+    if (virtualtext_prop)
     {
 	// virtual text property
 	garray_T    *gap = &buf->b_textprop_text;
@@ -1014,6 +1019,8 @@ prop_fill_dict(dict_T *dict, textprop_T *prop, buf_T *buf)
 	// text_wrap
 	if (prop->tp_flags & TP_FLAG_WRAP)
 	    dict_add_string(dict, "text_wrap", (char_u *)"wrap");
+	if (prop->tp_padleft != 0)
+	    dict_add_number(dict, "text_padding_left", prop->tp_padleft);
     }
 }
 


### PR DESCRIPTION
When adding text properties using the prop_add() function, the "text_padding_left" item can be specified to control
the virtual text padding.  The prop_list() function doesn't return the "text_padding_left" value for a virtual text
property.  Store and return this value.