### PR TITLE
Fix various Termdebug issues

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -229,10 +229,10 @@ endfunc
 func s:CloseBuffers()
   exe 'bwipe! ' . s:ptybuf
   exe 'bwipe! ' . s:commbuf
-  if s:asmbuf > 0
+  if s:asmbuf > 0 && bufexists(s:asmbuf)
     exe 'bwipe! ' . s:asmbuf
   endif
-  if s:varbuf > 0
+  if s:varbuf > 0 && bufexists(s:varbuf)
     exe 'bwipe! ' . s:varbuf
   endif
   s:running = 0
@@ -709,15 +709,7 @@ func s:EndTermDebug(job, status)
   endif
 
   exe 'bwipe! ' . s:commbuf
-  if s:asmbuf > 0
-    exe 'bwipe! ' . s:asmbuf
-  endif
-  if s:varbuf > 0
-    exe 'bwipe! ' . s:varbuf
-  endif
-  let s:running = 0
   unlet s:gdbwin
-
   call s:EndDebugCommon()
 endfunc
 
@@ -727,6 +719,13 @@ func s:EndDebugCommon()
   if exists('s:ptybuf') && s:ptybuf
     exe 'bwipe! ' . s:ptybuf
   endif
+  if s:asmbuf > 0 && bufexists(s:asmbuf)
+    exe 'bwipe! ' . s:asmbuf
+  endif
+  if s:varbuf > 0 && bufexists(s:varbuf)
+    exe 'bwipe! ' . s:varbuf
+  endif
+  let s:running = 0
 
   " Restore 'signcolumn' in all buffers for which it was set.
   call win_gotoid(s:sourcewin)
@@ -1358,7 +1357,7 @@ func s:GotoAsmwinOrCreateIt()
     setlocal signcolumn=no
     setlocal modifiable
 
-    if s:asmbuf > 0
+    if s:asmbuf > 0 && bufexists(s:asmbuf)
       exe 'buffer' . s:asmbuf
     else
       silent file Termdebug-asm-listing
@@ -1420,7 +1419,7 @@ func s:GotoVariableswinOrCreateIt()
     setlocal signcolumn=no
     setlocal modifiable
 
-    if s:varbuf > 0
+    if s:varbuf > 0 && bufexists(s:varbuf)
       exe 'buffer' . s:varbuf
     else
       silent file Termdebug-variables-listing


### PR DESCRIPTION
Problem: Cleanup for :Var and :Asm buffers did not apply to prompt mode, and
E86 was possible if they were hidden.
Solution: Move cleanup to s:EndDebugCommon. Check that the buffers exist before
switching.

E86 could be triggered by simply `:quit`ting the :Asm or :Var windows due to the `bufhidden=wipe` changes.

---

Problem: :Asm does not work in prompt mode.
Solution: Make it work by handling disassembly-related messages properly.

The previous implementation depended on the typed or sent (via s:SendCommand())
"disassemble ..." message being visible to s:CommOutput(), but this was only
true for the terminal-based job.

A more robust solution would be to use GDB MI's -data-disassemble command. I may
implement this in a future PR.

---

Problem: Termdebug does not escape gdb messages properly.
Solution: Improve the logic. Do not mangle messages if they have inner escaped
quotes. Use line continuation comments properly.

Interestingly, due to the missing line continuation comments (`"\`), most of
these substitutions were ignored.

Presumably, this logic still isn't exact. For example, if a message ends in
`\\"`, the quote may be preserved, even though it's the `\` being escaped
(similar issues may exist for the other escapes). This may not be a problem in
practice, though.