### PR TITLE
Remember when options where reset because of the paste/binary option

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -68,6 +68,21 @@ static void check_winopt(winopt_T *wop);
 static int wc_use_keyname(char_u *varp, long *wcp);
 static void compatible_set(void);
 
+#if defined(FEAT_EVAL) || defined(PROTO)
+static char *(p_bin_dep_opts[])    = {"textwidth", "wrapmargin", "modeline", "expandtab", NULL};
+static char *(p_paste_dep_opts[])  = {"autoindent", "expandtab", "ruler", "showmatch", "smarttab",
+    "softtabstop", "textwidth", "wrapmargin",
+#ifdef FEAT_RIGHTLEFT
+    "hkmap", "revins",
+#endif
+#ifdef FEAT_VARTABS
+    "varsofttabstop",
+#endif
+    NULL};
+static void didset_options_sctx(int opt_flags, char **buf);
+#endif
+
+
 /*
  * Initialize the 'shell' option to a default value.
  */
@@ -2763,6 +2778,10 @@ set_options_bin(
 	    p_et = p_et_nobin;
 	}
     }
+#if defined(FEAT_EVAL) || defined(PROTO)
+    // Remember where the dependent option were reset
+    didset_options_sctx(opt_flags, p_bin_dep_opts);
+#endif
 }
 
 /*
@@ -3846,6 +3865,7 @@ did_set_paste(optset_T *args UNUSED)
 	p_wm = 0;
 	p_sts = 0;
 	p_ai = 0;
+	p_et = 0;
 #ifdef FEAT_VARTABS
 	if (p_vsts)
 	    free_string_option(p_vsts);
@@ -3901,6 +3921,11 @@ did_set_paste(optset_T *args UNUSED)
     }
 
     old_p_paste = p_paste;
+
+#if defined(FEAT_EVAL) || defined(PROTO)
+    // Remember where the dependent options were reset
+    didset_options_sctx((OPT_LOCAL | OPT_GLOBAL), p_paste_dep_opts);
+#endif
 
     return NULL;
 }
@@ -8170,3 +8195,19 @@ option_set_callback_func(char_u *optval UNUSED, callback_T *optcb UNUSED)
     return FAIL;
 #endif
 }
+
+#if defined(FEAT_EVAL) || defined(PROTO)
+    static void
+didset_options_sctx(int opt_flags, char **buf)
+{
+	for (int i = 0; ; ++i)
+	{
+	    if (buf[i] == NULL)
+		break;
+
+	    int idx = findoption((char_u *)buf[i]);
+	    if (idx >= 0)
+		set_option_sctx_idx(idx, opt_flags, current_sctx);
+	}
+}
+#endif

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1774,4 +1774,85 @@ func Test_set_option_window_global_local_all()
   bw!
 endfunc
 
+func Test_paste_depending_options()
+  " setting the paste option, resets all dependent options
+  " and will be reported correctly using :verbose set <option>?
+  let lines =<< trim [CODE]
+    " set paste test
+    set autoindent
+    set expandtab
+    " disabled, because depends on compiled feature set
+    " set hkmap
+    " set revins
+    " set varsofttabstop=8,32,8
+    set ruler
+    set showmatch
+    set smarttab
+    set softtabstop=4
+    set textwidth=80
+    set wrapmargin=10
+
+    source Xvimrc_paste2
+
+    redir > Xoutput_paste
+    verbose set expandtab?
+    verbose setg expandtab?
+    verbose setl expandtab?
+    redir END
+
+    qall!
+  [CODE]
+
+  call writefile(lines, 'Xvimrc_paste', 'D')
+  call writefile(['set paste'], 'Xvimrc_paste2', 'D')
+  if !RunVim([], lines, '--clean')
+    return
+  endif
+
+  let result = readfile('Xoutput_paste')->filter('!empty(v:val)')
+  call assert_equal('noexpandtab', result[0])
+  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[1])
+  call assert_equal('noexpandtab', result[2])
+  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[3])
+  call assert_equal('noexpandtab', result[4])
+  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[5])
+
+  call delete('Xoutput_paste')
+endfunc
+
+func Test_binary_depending_options()
+  " setting the paste option, resets all dependent options
+  " and will be reported correctly using :verbose set <option>?
+  let lines =<< trim [CODE]
+    " set binary test
+    set expandtab
+
+    source Xvimrc_bin2
+
+    redir > Xoutput_bin
+    verbose set expandtab?
+    verbose setg expandtab?
+    verbose setl expandtab?
+    redir END
+
+    qall!
+  [CODE]
+
+  call writefile(lines, 'Xvimrc_bin', 'D')
+  call writefile(['set binary'], 'Xvimrc_bin2', 'D')
+  if !RunVim([], lines, '--clean')
+    return
+  endif
+
+  let result = readfile('Xoutput_bin')->filter('!empty(v:val)')
+  call assert_equal('noexpandtab', result[0])
+  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[1])
+  call assert_equal('noexpandtab', result[2])
+  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[3])
+  call assert_equal('noexpandtab', result[4])
+  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[5])
+
+  call delete('Xoutput_bin')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Mention if depending options for 'binary' or 'paste' have been reset indirectly. Add a test to verify it works.

Also noticed as small bug, that the global option value for expandtab was not reset when paste option is set, so fix that while at it.

Regarding the test: for some reason, setting paste does somehow affect how the internal terminal vim renders the output so we cannot directly use term_getline(), it will always return an empty vim line. Perhaps Vim does not correctly redraw when paste option is in affect (probably to make processing faster). Therefore, we will redir the output and post-process it a bit (removing path components, removing empty lines) so that it is easier to scrape the actual buffer line later.

fixes: vim/vim#12837