### PR TITLE
update gp.vim syntax file for the GP language (version 2.15)

### DIFF
--- a/runtime/syntax/gp.vim
+++ b/runtime/syntax/gp.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
-" Language:	gp (version 2.5)
+" Language:	gp (version 2.15)
 " Maintainer:	Karim Belabas <Karim.Belabas@math.u-bordeaux.fr>
-" Last change:	2012 Jan 08
+" Last change:	2023 Aug 22
 " URL:		http://pari.math.u-bordeaux.fr
 
 " quit when a syntax file was already loaded
@@ -14,23 +14,29 @@ set cpo&vim
 
 " control statements
 syntax keyword gpStatement	break return next
-syntax keyword gpConditional	if
-syntax keyword gpRepeat		until while for fordiv forell forprime 
-syntax keyword gpRepeat		forsubgroup forstep forvec
+syntax keyword gpConditional	if iferr
+syntax keyword gpRepeat		until while for forcomposite fordiv
+syntax keyword gpRepeat		fordivfactored foreach forell forfactored
+syntax keyword gpRepeat		forpart forperm forprime forprimestep forqfvec
+syntax keyword gpRepeat		forsquarefree forstep forsubgroup forsubset
+syntax keyword gpRepeat		forvec
+syntax keyword gpRepeat		parfor parforeach parforprime parforprimestep
+syntax keyword gpRepeat		parforvec
 " storage class
-syntax keyword gpScope		my local global
+syntax keyword gpScope		my local global export exportall
 " defaults
 syntax keyword gpInterfaceKey	breakloop colors compatible
-syntax keyword gpInterfaceKey	datadir debug debugfiles debugmem 
-syntax keyword gpInterfaceKey	echo factor_add_primes factor_proven format 
+syntax keyword gpInterfaceKey	datadir debug debugfiles debugmem
+syntax keyword gpInterfaceKey	echo factor_add_primes factor_proven format
 syntax keyword gpInterfaceKey	graphcolormap graphcolors
-syntax keyword gpInterfaceKey	help histfile histsize 
-syntax keyword gpInterfaceKey	lines linewrap log logfile new_galois_format
-syntax keyword gpInterfaceKey	output parisize path prettyprinter primelimit
-syntax keyword gpInterfaceKey	prompt prompt_cont psfile 
-syntax keyword gpInterfaceKey	readline realprecision recover 
-syntax keyword gpInterfaceKey	secure seriesprecision simplify strictmatch
-syntax keyword gpInterfaceKey	TeXstyle timer
+syntax keyword gpInterfaceKey	help histfile histsize
+syntax keyword gpInterfaceKey	lines linewrap log logfile nbthreads
+syntax keyword gpInterfaceKey	new_galois_format output parisize parisizemax
+syntax keyword gpInterfaceKey	path plothsizes prettyprinter primelimit prompt
+syntax keyword gpInterfaceKey	prompt_cont psfile readline realbitprecision
+syntax keyword gpInterfaceKey	realprecision recover secure seriesprecision
+syntax keyword gpInterfaceKey	simplify sopath strictmatch TeXstyle
+syntax keyword gpInterfaceKey	threadsize threadsizemax timer
 
 syntax match gpInterface	"^\s*\\[a-z].*"
 syntax keyword gpInterface	default
@@ -58,24 +64,23 @@ syntax region gpParen		transparent start='(' end=')' contains=ALLBUT,gpParenErro
 syntax match gpParenError	")"
 syntax match gpInParen contained "[{}]"
 
-
-hi def link gpConditional		Conditional
+hi def link gpConditional	Conditional
 hi def link gpRepeat		Repeat
 hi def link gpError		Error
-hi def link gpParenError		gpError
+hi def link gpParenError	gpError
 hi def link gpInParen		gpError
 hi def link gpStatement		Statement
 hi def link gpString		String
 hi def link gpComment		Comment
 hi def link gpInterface		Type
 hi def link gpInput		Type
-hi def link gpInterfaceKey		Statement
+hi def link gpInterfaceKey	Statement
 hi def link gpFunction		Function
 hi def link gpScope		Type
 " contained ones
 hi def link gpSpecial		Special
-hi def link gpTodo			Todo
-hi def link gpArgs			Type
+hi def link gpTodo		Todo
+hi def link gpArgs		Type
 
 let b:current_syntax = "gp"
 let &cpo = s:cpo_save


### PR DESCRIPTION
- add missing defaults
- add missing control structures (incl. parallelism)
- add missing scope declarations
- whitespace edits (remove extra tabs)