### PR TITLE
configure: Python3: Use sysconfig for -I

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -6825,6 +6825,30 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $vi_cv_path_python3_epfx" >&5
 $as_echo "$vi_cv_path_python3_epfx" >&6; }
 
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking Python's include path" >&5
+$as_echo_n "checking Python's include path... " >&6; }
+if ${vi_cv_path_python3_include+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+   vi_cv_path_python3_include=`
+       ${vi_cv_path_python3} -c \
+       "import sysconfig; print(sysconfig.get_path(\"include\"))"`
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $vi_cv_path_python3_include" >&5
+$as_echo "$vi_cv_path_python3_include" >&6; }
+
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking Python's include path" >&5
+$as_echo_n "checking Python's include path... " >&6; }
+if ${vi_cv_path_python3_platinclude+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+   vi_cv_path_python3_platinclude=`
+       ${vi_cv_path_python3} -c \
+       "import sysconfig; print(sysconfig.get_path(\"platinclude\"))"`
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $vi_cv_path_python3_platinclude" >&5
+$as_echo "$vi_cv_path_python3_platinclude" >&6; }
+
 
       if ${vi_cv_path_python3path+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6923,10 +6947,10 @@ fi
 $as_echo "$vi_cv_dll_name_python3" >&6; }
 
         PYTHON3_LIBS="${vi_cv_path_python3_plibs}"
-        if test "${vi_cv_path_python3_pfx}" = "${vi_cv_path_python3_epfx}"; then
-          PYTHON3_CFLAGS="-I${vi_cv_path_python3_pfx}/include/python${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags}"
+        if test "${vi_cv_path_python3_include}" = "${vi_cv_path_python3_platinclude}"; then
+          PYTHON3_CFLAGS="-I${vi_cv_path_python3_include}"
         else
-          PYTHON3_CFLAGS="-I${vi_cv_path_python3_pfx}/include/python${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags} -I${vi_cv_path_python3_epfx}/include/python${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags}"
+          PYTHON3_CFLAGS="-I${vi_cv_path_python3_include} -I${vi_cv_path_python3_platinclude}"
         fi
         if test "X$have_python3_config_dir" = "X1" -a "$enable_python3interp" = "dynamic"; then
                     PYTHON3_CFLAGS="${PYTHON3_CFLAGS}  -DPYTHON3_HOME='L\"${vi_cv_path_python3_pfx}\"'"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1543,6 +1543,18 @@ if test "$enable_python3interp" = "yes" -o "$enable_python3interp" = "dynamic"; 
        ${vi_cv_path_python3} -c \
        "import sys; print(sys.exec_prefix)"` ])
 
+      dnl -- python3's include path
+      AC_CACHE_CHECK(Python's include path,vi_cv_path_python3_include,
+      [ vi_cv_path_python3_include=`
+       ${vi_cv_path_python3} -c \
+       "import sysconfig; print(sysconfig.get_path(\"include\"))"` ])
+
+      dnl -- python3's platform include path
+      AC_CACHE_CHECK(Python's include path,vi_cv_path_python3_platinclude,
+      [ vi_cv_path_python3_platinclude=`
+       ${vi_cv_path_python3} -c \
+       "import sysconfig; print(sysconfig.get_path(\"platinclude\"))"` ])
+
       dnl -- python3's internal library path
 
       AC_CACHE_VAL(vi_cv_path_python3path,
@@ -1621,10 +1633,10 @@ eof
 	])
 
         PYTHON3_LIBS="${vi_cv_path_python3_plibs}"
-        if test "${vi_cv_path_python3_pfx}" = "${vi_cv_path_python3_epfx}"; then
-          PYTHON3_CFLAGS="-I${vi_cv_path_python3_pfx}/include/python${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags}"
+        if test "${vi_cv_path_python3_include}" = "${vi_cv_path_python3_platinclude}"; then
+          PYTHON3_CFLAGS="-I${vi_cv_path_python3_include}"
         else
-          PYTHON3_CFLAGS="-I${vi_cv_path_python3_pfx}/include/python${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags} -I${vi_cv_path_python3_epfx}/include/python${vi_cv_var_python3_version}${vi_cv_var_python3_abiflags}"
+          PYTHON3_CFLAGS="-I${vi_cv_path_python3_include} -I${vi_cv_path_python3_platinclude}"
         fi
         if test "X$have_python3_config_dir" = "X1" -a "$enable_python3interp" = "dynamic"; then
           dnl Define PYTHON3_HOME if --with-python-config-dir was used


### PR DESCRIPTION
It seems better to use tools provided by Python for determining the include directories, rather than construct them "manually".

Current system is broken when using virtual environments for python 3.11.4.  It used to work before, but now it detects a incorrect value for `-I`.

It would probably make sense to switch to a similar logic for lib folders, that is for the `-l` switch.  There are also `sysconfig.get_config_h_filename()` and
`sysconfig.get_makefile_filename()`, that could replace more Python specific logic in the current `configure{.ac,}`.

sysconfig provides the necessary tools since Python 2.7.