### PR TITLE
More termdebug fixes/improvements

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1,4 +1,4 @@
-*terminal.txt*	For Vim version 9.0.  Last change: 2023 Jun 28
+*terminal.txt*	For Vim version 9.0.  Last change: 2023 Aug 23
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -38,6 +38,7 @@ If the result is "1" you have it.
       Example session				|termdebug-example|
       Stepping through code			|termdebug-stepping|
       Inspecting variables			|termdebug-variables|
+      Navigating stack frames			|termdebug-frames|
       Other commands				|termdebug-commands|
       Events					|termdebug-events|
       Prompt mode				|termdebug-prompt|
@@ -1376,19 +1377,16 @@ This is similar to using "print" in the gdb window.
 You can usually shorten `:Evaluate` to `:Ev`.
 
 
-Navigation in the Stack ~
-					*termdebug-variables* *:Frame*
- `:Frame`	Select the given frame, using  either the frame's
-                stack number, address, or function name.
- `:Up`	        Select the frame that called the current one with an
-                optional argument to say how many frames to go up.
- `+`		same (see |termdebug_map_plus| to disable)
- `:Down`	        Select the frame called by the current one with
-                an optional argument to say how many frames to go down.
- `-`		same (see |termdebug_map_minus| to disable)
-
-This is similar to using "print" in the gdb window.
-You can usually shorten `:Evaluate` to `:Ev`.
+Navigating stack frames ~
+				*termdebug-frames* *:Frame* *:Up* *:Down*
+ `:Frame` [frame]	select frame [frame], which is a frame number,
+			address, or function name (default: current frame)
+ `:Up` [count]		go up [count] frames (default: 1; the frame that
+			called the current)
+ `+`			same (see |termdebug_map_plus| to disable)
+ `:Down` [count]	go down [count] frames (default: 1; the frame called
+			by the current)
+ `-`			same (see |termdebug_map_minus| to disable)
 
 
 Other commands ~
@@ -1464,17 +1462,17 @@ If there is no g:termdebug_config you can use: >
 	let g:termdebug_use_prompt = 1
 <
 						*termdebug_map_K*
-The K key is normally mapped to :Evaluate. If you do not want this use: >
+The K key is normally mapped to |:Evaluate|. If you do not want this use: >
 	let g:termdebug_config['map_K'] = 0
 If there is no g:termdebug_config you can use: >
 	let g:termdebug_map_K = 0
 <
 						*termdebug_map_minus*
-The - key is normally mapped to :Down. If you do not want this use: >
+The - key is normally mapped to |:Down|. If you do not want this use: >
 	let g:termdebug_config['map_minus'] = 0
 <
 						*termdebug_map_plus*
-The + key is normally mapped to :Up. If you do not want this use: >
+The + key is normally mapped to |:Up|. If you do not want this use: >
 	let g:termdebug_config['map_plus'] = 0
 <
 						*termdebug_disasm_window*

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2023 Jun 24
+" Last Change: 2023 Aug 23
 "
 " WORK IN PROGRESS - The basics works stable, more to come
 " Note: In general you need at least GDB 7.12 because this provides the
@@ -235,7 +235,7 @@ func s:CloseBuffers()
   if s:varbuf > 0 && bufexists(s:varbuf)
     exe 'bwipe! ' . s:varbuf
   endif
-  s:running = 0
+  let s:running = 0
   unlet! s:gdbwin
 endfunc
 
@@ -453,6 +453,8 @@ func s:StartDebug_prompt(dict)
     exe 'bwipe! ' . s:promptbuf
     return
   endif
+  exe $'au BufUnload <buffer={s:promptbuf}> ++once ' ..
+	\ 'call job_stop(s:gdbjob, ''kill'')'
   " Mark the buffer modified so that it's not easy to close.
   set modified
   let s:gdb_channel = job_getchannel(s:gdbjob)
@@ -782,12 +784,8 @@ func s:EndPromptDebug(job, status)
     doauto <nomodeline> User TermdebugStopPre
   endif
 
-  let curwinid = win_getid()
-  call win_gotoid(s:gdbwin)
-  set nomodified
-  close
-  if curwinid != s:gdbwin
-    call win_gotoid(curwinid)
+  if bufexists(s:promptbuf)
+    exe 'bwipe! ' . s:promptbuf
   endif
 
   call s:EndDebugCommon()
@@ -973,8 +971,8 @@ func s:InstallCommands()
   endif
 
   command -nargs=* Frame call s:Frame(<q-args>)
-  command -nargs=* Up call s:Up(<q-args>)
-  command -nargs=* Down call s:Down(<q-args>)
+  command -count=1 Up call s:Up(<count>)
+  command -count=1 Down call s:Down(<count>)
 
   command -range -nargs=* Evaluate call s:Evaluate(<range>, <q-args>)
   command Gdb call win_gotoid(s:gdbwin)
@@ -1001,7 +999,7 @@ func s:InstallCommands()
   endif
   if map
     let s:plus_map_saved = maparg('+', 'n', 0, 1)
-    nnoremap + :Up<CR>
+    nnoremap <expr> + $'<Cmd>{v:count1}Up<CR>'
   endif
 
   let map = 1
@@ -1010,7 +1008,7 @@ func s:InstallCommands()
   endif
   if map
     let s:minus_map_saved = maparg('-', 'n', 0, 1)
-    nnoremap - :Down<CR>
+    nnoremap <expr> - $'<Cmd>{v:count1}Down<CR>'
   endif
 
 
@@ -1240,26 +1238,16 @@ func s:Frame(arg)
   endif
 endfunc
 
-" :Up - go one frame in the stack "higher"
-func s:Up(arg)
-  if a:arg != ''
-    let s:cmd = '"up ' . a:arg . '"'
-  else
-    let s:cmd = '"up"'
-  endif
+" :Up - go a:count frames in the stack "higher"
+func s:Up(count)
   " the 'correct' one would be -stack-select-frame N, but we don't know N
-  call s:SendCommand('-interpreter-exec console ' . s:cmd)
+  call s:SendCommand($'-interpreter-exec console "up {a:count}"')
 endfunc
 
-" :Down - go one frame in the stack "below"
-func s:Down(arg)
-  if a:arg != ''
-    let s:cmd = '"down ' . a:arg . '"'
-  else
-    let s:cmd = '"down"'
-  endif
+" :Down - go a:count frames in the stack "below"
+func s:Down(count)
   " the 'correct' one would be -stack-select-frame N, but we don't know N
-  call s:SendCommand('-interpreter-exec console ' . s:cmd)
+  call s:SendCommand($'-interpreter-exec console "down {a:count}"')
 endfunc
 
 func s:SendEval(expr)


### PR DESCRIPTION
- Fix and attempt to simplify :Frame/:Up/:Down documentation.

- Accept a count instead for :Up/:Down/+/-.

- Fix a missing :let (caused an error if gdb fails to start).

- Wipe the prompt buffer when ending prompt mode (if it exists and wasn't wiped
  by the user first). Avoids issues with stale prompt buffers (such as E95 when
  starting a new prompt mode session).

- Kill the gdb job if the prompt buffer is unloaded (similar to what's done for
  a terminal buffer). Fixes not being able to start a new termdebug session if
  the buffer was wiped by the user, for example.