### PR TITLE
runtime(menu): define shortcut for File->Open Tab

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -122,7 +122,7 @@ enddef
 " File menu
 an 10.310 &File.&Open\.\.\.<Tab>:e		:browse confirm e<CR>
 an 10.320 &File.Sp&lit-Open\.\.\.<Tab>:sp	:browse sp<CR>
-an 10.320 &File.Open\ Tab\.\.\.<Tab>:tabnew	:browse tabnew<CR>
+an 10.320 &File.Open\ &Tab\.\.\.<Tab>:tabnew	:browse tabnew<CR>
 an 10.325 &File.&New<Tab>:enew			:confirm enew<CR>
 an <silent> 10.330 &File.&Close<Tab>:close
 	\ :if winheight(2) < 0 && tabpagewinnr(2) == 0 <Bar>


### PR DESCRIPTION
Seems missing as noted by Antonio Giovanni Colombo. So add it and use the 'T' as shortcut, which does not seem to be used in the File dialog.

Verified on Windows.