### PR TITLE
Add 'syntax' completion

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -7349,6 +7349,14 @@ set_context_in_set_cmd(
 
     xp->xp_pattern = p + 1;
 
+#ifdef FEAT_SYN_HL
+    if (options[opt_idx].var == (char_u *)&p_syn)
+    {
+	xp->xp_context = EXPAND_OWNSYNTAX;
+	return;
+    }
+#endif
+
     if (flags & P_EXPAND)
     {
 	p = options[opt_idx].var;

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -374,6 +374,12 @@ func Test_set_completion()
   call assert_equal('"set filetype=sshdconfig', @:)
   call feedkeys(":set filetype=a\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set filetype=' .. getcompletion('a*', 'filetype')->join(), @:)
+
+  " Expand values for 'syntax'
+  call feedkeys(":set syntax=sshdconfi\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"set syntax=sshdconfig', @:)
+  call feedkeys(":set syntax=a\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"set syntax=' .. getcompletion('a*', 'syntax')->join(), @:)
 endfunc
 
 func Test_set_option_errors()


### PR DESCRIPTION
Problem:  The 'syntax' option has no completion.
Solution: Add syntax option completion.
