### PR TITLE
instanceof() fails in a def function

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -282,7 +282,11 @@ arg_number(type_T *type, type_T *decl_type UNUSED, argcontext_T *context)
     static int
 arg_object(type_T *type, type_T *decl_type UNUSED, argcontext_T *context)
 {
-    return check_arg_type(&t_object, type, context);
+    if (type->tt_type == VAR_OBJECT
+	    || type_any_or_unknown(type))
+	return OK;
+    arg_type_mismatch(&t_object, type, context->arg_idx + 1);
+    return FAIL;
 }
 
 /*

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -2317,6 +2317,28 @@ def Test_instanceof()
     instanceof(Foo.new(), 123)
   END
   v9.CheckScriptFailure(lines, 'E693: List or Class required for argument 2')
+
+  lines =<< trim END
+    vim9script
+    class Foo
+    endclass
+    def Bar()
+      instanceof('hello', Foo)
+    enddef
+    Bar()
+  END
+  v9.CheckScriptFailure(lines, 'E1013: Argument 1: type mismatch, expected object<Unknown> but got string')
+
+  lines =<< trim END
+    vim9script
+    class Foo
+    endclass
+    def Bar()
+      instanceof(Foo.new(), 123)
+    enddef
+    Bar()
+  END
+  v9.CheckScriptFailure(lines, 'E1013: Argument 2: type mismatch, expected class<Unknown> but got number')
 enddef
 
 def Test_invert()

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -2396,6 +2396,20 @@ def Test_instanceof()
     assert_true(instanceof(b3, Mix1))
     assert_false(instanceof(b3, []))
     assert_true(instanceof(b3, [Base1, Base2, Intf1]))
+
+    def Foo()
+      var a1 = Base1.new()
+      var a2 = Base2.new()
+      var a3 = Base3.new()
+
+      assert_true(instanceof(a1, Base1))
+      assert_true(instanceof(a2, Base1))
+      assert_false(instanceof(a1, Base2))
+      assert_true(instanceof(a3, Mix1))
+      assert_false(instanceof(a3, []))
+      assert_true(instanceof(a3, [Base1, Base2, Intf1]))
+    enddef
+    Foo()
   END
   v9.CheckScriptSuccess(lines)
 enddef


### PR DESCRIPTION

Modify the compile time check for an object to ignore the specific object type and support object<Unknown>.