### PR TITLE
runtime(typescript): Fix highlighting symbols after number literal

### DIFF
--- a/runtime/syntax/shared/typescriptcommon.vim
+++ b/runtime/syntax/shared/typescriptcommon.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     TypeScript and TypeScriptReact
 " Maintainer:   Herrington Darkholme
-" Last Change:	2023 Aug 13
+" Last Change:	2023 Aug 24
 " Based On:     Herrington Darkholme's yats.vim
 " Changes:      See https://github.com/HerringtonDarkholme/yats.vim
 " Credits:      See yats.vim on github
@@ -149,7 +149,7 @@ syntax match typescriptNumber /\<0[bB][01][01_]*\>/        nextgroup=@typescript
 syntax match typescriptNumber /\<0[oO][0-7][0-7_]*\>/       nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<0[xX][0-9a-fA-F][0-9a-fA-F_]*\>/ nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<\%(\d[0-9_]*\%(\.\d[0-9_]*\)\=\|\.\d[0-9_]*\)\%([eE][+-]\=\d[0-9_]*\)\=\>/
-  \ nextgroup=typescriptSymbols skipwhite skipempty
+  \ nextgroup=@typescriptSymbols skipwhite skipempty
 
 syntax region  typescriptObjectLiteral         matchgroup=typescriptBraces
   \ start=/{/ end=/}/


### PR DESCRIPTION
fix #12831

Test code 

```ts
enum Foo {
  A = 2 << 12, // A comment with "<" and ">"
}
```
The `<<` is not recognized as a symbol. The syntax relies heavily on the relative position of numbers and operators by specifying `aftergroup`.

The bug's root cause is that the `typescriptSymbols` is not used as a syntax group in the `aftergroup`.

This patch fixed the wrong usage.