### PR TITLE
Fix Perl 5.30 build issues, and remove GIMME_V usage

### DIFF
--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -297,5 +297,11 @@ instead of DYNAMIC_PERL_DLL file what was specified at compile time.  The
 version of the shared library must match the Perl version Vim was compiled
 with.
 
+Note: If you are building Perl locally, you have to use a version compiled
+with threading support for it for Vim to successfully link against it. You can
+use the `-Dusethreads` flags when configuring Perl, and check that a Perl
+binary has it enabled by running `perl -V` and verify that `USE_ITHREADS` is
+under "Compile-time options".
+
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -6291,6 +6291,7 @@ $as_echo ">>> too old; need Perl version 5.003_01 or later <<<" >&6; }
       $as_echo "#define DYNAMIC_PERL 1" >>confdefs.h
 
       PERL_CFLAGS="-DDYNAMIC_PERL_DLL=\\\"$libperl\\\" $PERL_CFLAGS"
+      PERL_LIBS=""
     fi
   fi
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1218,6 +1218,7 @@ if test "$enable_perlinterp" = "yes" -o "$enable_perlinterp" = "dynamic"; then
     if test "$perl_ok" = "yes" -a "X$libperl" != "X"; then
       AC_DEFINE(DYNAMIC_PERL)
       PERL_CFLAGS="-DDYNAMIC_PERL_DLL=\\\"$libperl\\\" $PERL_CFLAGS"
+      PERL_LIBS=""
     fi
   fi
 

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -651,6 +651,13 @@ static struct {
     {"", NULL},
 };
 
+# if (PERL_REVISION == 5) && (PERL_VERSION <= 30)
+// In 5.30, GIMME_V requires linking to Perl_block_gimme() instead of being
+// completely inline. Just use the deprecated GIMME for simplicity.
+#  undef GIMME_V
+#  define GIMME_V GIMME
+# endif
+
 /*
  * Make all runtime-links of perl.
  *
@@ -1593,7 +1600,7 @@ Buffers(...)
     PPCODE:
     if (items == 0)
     {
-	if (GIMME == G_SCALAR)
+	if (GIMME_V == G_SCALAR)
 	{
 	    i = 0;
 	    FOR_ALL_BUFFERS(vimbuf)
@@ -1644,7 +1651,7 @@ Windows(...)
     PPCODE:
     if (items == 0)
     {
-	if (GIMME == G_SCALAR)
+	if (GIMME_V == G_SCALAR)
 	    XPUSHs(sv_2mortal(newSViv(win_count())));
 	else
 	{

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -190,7 +190,9 @@ typedef int perl_key;
 # define perl_run dll_perl_run
 # define perl_destruct dll_perl_destruct
 # define perl_free dll_perl_free
-# define Perl_get_context dll_Perl_get_context
+# if defined(WIN32) || ((PERL_REVISION == 5) && (PERL_VERSION < 38))
+#  define Perl_get_context dll_Perl_get_context
+# endif
 # define Perl_croak dll_Perl_croak
 # ifdef PERL5101_OR_LATER
 #  define Perl_croak_xs_usage dll_Perl_croak_xs_usage
@@ -339,7 +341,9 @@ static void (*perl_destruct)(PerlInterpreter*);
 static void (*perl_free)(PerlInterpreter*);
 static int (*perl_run)(PerlInterpreter*);
 static int (*perl_parse)(PerlInterpreter*, XSINIT_t, int, char**, char**);
+# if defined(WIN32) || ((PERL_REVISION == 5) && (PERL_VERSION < 38))
 static void* (*Perl_get_context)(void);
+# endif
 static void (*Perl_croak)(pTHX_ const char*, ...) __attribute__noreturn__;
 # ifdef PERL5101_OR_LATER
 /* Perl-5.18 has a different Perl_croak_xs_usage signature. */
@@ -509,7 +513,9 @@ static struct {
     {"perl_free", (PERL_PROC*)&perl_free},
     {"perl_run", (PERL_PROC*)&perl_run},
     {"perl_parse", (PERL_PROC*)&perl_parse},
+# if defined(WIN32) || ((PERL_REVISION == 5) && (PERL_VERSION < 38))
     {"Perl_get_context", (PERL_PROC*)&Perl_get_context},
+# endif
     {"Perl_croak", (PERL_PROC*)&Perl_croak},
 # ifdef PERL5101_OR_LATER
     {"Perl_croak_xs_usage", (PERL_PROC*)&Perl_croak_xs_usage},
@@ -1493,6 +1499,20 @@ bool Perl_sv_2bool_flags(pTHX_ SV* sv, I32 flags)
 int Perl_mg_get(pTHX_ SV* sv)
 {
     return (*dll_Perl_mg_get)(aTHX_ sv);
+}
+# endif
+
+# undef Perl_sv_2nv_flags
+NV Perl_sv_2nv_flags(pTHX_ SV *const sv, const I32 flags)
+{
+    return (*dll_Perl_sv_2nv_flags)(aTHX_ sv, flags);
+}
+
+# ifdef PERL589_OR_LATER
+#  undef Perl_sv_2iv_flags
+IV Perl_sv_2iv_flags(pTHX_ SV* sv, I32 flags)
+{
+    return (*dll_Perl_sv_2iv_flags)(aTHX_ sv, flags);
 }
 # endif
 

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -1516,6 +1516,10 @@ IV Perl_sv_2iv_flags(pTHX_ SV* sv, I32 flags)
 }
 # endif
 
+# ifdef PERL_USE_THREAD_LOCAL
+PERL_THREAD_LOCAL void *PL_current_context;
+# endif
+
 #endif // DYNAMIC_PERL
 
 XS(boot_VIM);


### PR DESCRIPTION
This makes Perl 5.30 dynamic builds work again, by reverting GIMME_V back to GIMME. In Perl headers, GIMME_V requires usage of functions from inline.h which requires manual copy-paste into if_perl.xs which is fragile. Just use GIMME for now (which was the case before) as its implementation in Perl headers does not require using inline functions.

Also, fix the configure script so that if we are using dynamic linkage, we don't pass `-lperl` to the build flags, to avoid accidental external linkage. This is similar to how Python integration works.

Also fix misleading comments in if_perl.xs saying that we include perl\lib\CORE\inline.h manually. That was the case in the past but changed to manually copying inline functions over to fix 5.22 build issues with PERL_NO_INLINE_FUNCTIONS.
