### PR TITLE
Redundant LSP Content-Type header

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -105,8 +105,7 @@ json_encode_lsp_msg(typval_T *val)
     ga_init2(&lspga, 1, 4000);
     // Header according to LSP specification.
     vim_snprintf((char *)IObuff, IOSIZE,
-	    "Content-Length: %u\r\n"
-	    "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n",
+	    "Content-Length: %u\r\n\r\n",
 	    ga.ga_len - 1);
     ga_concat(&lspga, IObuff);
     ga_concat_len(&lspga, ga.ga_data, ga.ga_len);

--- a/src/testdir/test_channel_lsp.py
+++ b/src/testdir/test_channel_lsp.py
@@ -172,7 +172,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
     def do_extra_hdr_fields(self, payload):
         self.send_extra_hdr_fields(payload['id'], 'extra-hdr-fields')
 
-    def do_delayad_payload(self, payload):
+    def do_delayed_payload(self, payload):
         self.send_delayed_payload(payload['id'], 'delayed-payload')
 
     def do_hdr_without_len(self, payload):
@@ -208,7 +208,7 @@ class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                         'msg-specific-cb': self.do_msg_specific_cb,
                         'server-req': self.do_server_req,
                         'extra-hdr-fields': self.do_extra_hdr_fields,
-                        'delayed-payload': self.do_delayad_payload,
+                        'delayed-payload': self.do_delayed_payload,
                         'hdr-without-len': self.do_hdr_without_len,
                         'hdr-with-wrong-len': self.do_hdr_with_wrong_len,
                         'hdr-with-negative-len': self.do_hdr_with_negative_len,

--- a/src/version.c
+++ b/src/version.c
@@ -700,6 +700,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    1790,
+/**/
     1789,
 /**/
     1788,


### PR DESCRIPTION
Problem:  The Content-Type header is an optional header that some LSP
          servers struggle with and may crash when encountering it.
Solution: Drop the Content-Type header from all messages, because we use
          the default value anyway.

Because pretty much all popular LSP clients (e.g. coc.nvim, VSCode) do
not send the Content-Type header, the LSP server ecosystem has developed
such that some LSP servers may even crash when encountering it.
To improve compatibility with these misbehaving LSP servers, we drop
this header.

This is as discussed in #12295.
