### PR TITLE
After a object/class method call, remove the object/class from the stack

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -2747,4 +2747,51 @@ def Test_object_lockvar()
   v9.CheckScriptSuccess(lines)
 enddef
 
+" Test for using the return value of a class/object method as a function
+" argument.
+def Test_objmethod_funcarg()
+  var lines =<< trim END
+    vim9script
+
+    class C
+      def Foo(): string
+        return 'foo'
+      enddef
+    endclass
+
+    def Bar(a: number, s: string): string
+      return s
+    enddef
+
+    def Baz(c: C)
+      assert_equal('foo', Bar(10, c.Foo()))
+    enddef
+
+    var t = C.new()
+    Baz(t)
+  END
+  v9.CheckScriptSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+
+    class C
+      static def Foo(): string
+        return 'foo'
+      enddef
+    endclass
+
+    def Bar(a: number, s: string): string
+      return s
+    enddef
+
+    def Baz()
+      assert_equal('foo', Bar(10, C.Foo()))
+    enddef
+
+    Baz()
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -1902,6 +1902,10 @@ generate_CALL(
     // drop the argument types
     cctx->ctx_type_stack.ga_len -= argcount;
 
+    // For an object or class method call, drop the object/class type
+    if (ufunc->uf_class != NULL)
+	cctx->ctx_type_stack.ga_len--;
+
     // add return type
     return push_type_stack(cctx, ufunc->uf_ret_type);
 }


### PR DESCRIPTION
Fixes #12081.