### PR TITLE
Avoid bogus error when export is not executed

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2586,8 +2586,8 @@ do_one_cmd(
 
 #ifdef FEAT_EVAL
     // A command will reset "is_export" when exporting an item.  If it is still
-    // set something went wrong.
-    if (is_export)
+    // set something went wrong or the command was never executed.
+    if (!ea.skip && is_export)
     {
 	if (errormsg == NULL)
 	    errormsg = _(e_export_with_invalid_argument);

--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -2919,5 +2919,15 @@ def Test_vim9_import_symlink()
   endif
 enddef
 
+def Test_export_in_conditional_block()
+  var lines =<< trim END
+      vim9script
+      if exists('this_will_fail')
+        export var MyVar = "hello"
+      endif
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
When the export command is not executed at all it doesn't make sense to print an error pointing to it.

Closes #12912