### PR TITLE
When foldopen contains "search", expand folds the cursor is in

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1220,6 +1220,9 @@ do_search(
     searchit_arg_T  *sia)	// optional arguments or NULL
 {
     pos_T	    pos;	// position of the last match
+#ifdef FEAT_FOLDING
+    linenr_T	    start, end;
+#endif
     char_u	    *searchstr;
     soffset_T	    old_off;
     int		    retval;	// Return value
@@ -1278,15 +1281,16 @@ do_search(
 #ifdef FEAT_FOLDING
     // If the cursor is in a closed fold, don't find another match in the same
     // fold.
-    if (dirc == '/')
-    {
-	if (hasFolding(pos.lnum, NULL, &pos.lnum))
-	    pos.col = MAXCOL - 2;	// avoid overflow when adding 1
-    }
-    else
-    {
-	if (hasFolding(pos.lnum, &pos.lnum, NULL))
+    if (hasFolding(pos.lnum, &start, &end)) {
+	// anchor to the start/end of the fold (to cause a search within the fold)
+	// depending on whether 'fdo' contains "search"
+	if ((dirc == '/') != (fdo_flags & FDO_SEARCH)) {
+	    pos.lnum = start;
 	    pos.col = 0;
+	} else {
+	    pos.lnum = end;
+	    pos.col = MAXCOL - 2;	// avoid overflow when adding 1
+	}
     }
 #endif
 


### PR DESCRIPTION
For example:

```python
if cond:
    f()    #
    g()    # these three lines are folded
    h()    #
```

Displaying something like:

```python
  if cond:
+--  3 lines: f()    #
```

If the cursor is within the fold and the user types `/g`, vim reports no match (the same for subsequent `n` / `N` presses).

With this change, the fold is expanded and the line containing `g()` is visible. This is only done if `'foldopen'` contains `"search"`

---

I'm interested in opinions on this - normally if the cursor is on the only match in a file, `n`/`N` will report no matches, but the user can see that there's a match under the cursor. The same behaviour with folds is a little less useful, as the user can't see that they're on a match within the fold - a few times I've thought a search didn't exist in a file when in fact it was within a fold I was in.

(If the feature sounds good, I'll sort out testing)