### PR TITLE
Make object/class member variables public by default

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -114,31 +114,10 @@ naming convention makes the object members easy to spot.  Also, when a
 variable does not have the "this." prefix you know it is not an object member.
 
 
-Member write access ~
+Member accessibility ~
 
-Now try to change an object member directly: >
+By default object members are public and can be read and modified directly.
 
-	pos.lnum = 9
-<							*E1335*
-This will give you an error!  That is because by default object members can be
-read but not set.  That's why the TextPosition class provides a method for it: >
-
-	pos.SetLnum(9)
-
-Allowing to read but not set an object member is the most common and safest
-way.  Most often there is no problem using a value, while setting a value may
-have side effects that need to be taken care of.  In this case, the SetLnum()
-method could check if the line number is valid and either give an error or use
-the closest valid value.
-							*:public* *E1331*
-If you don't care about side effects and want to allow the object member to be
-changed at any time, you can make it public: >
-
-	public this.lnum: number
-	public this.col: number
-
-Now you don't need the SetLnum(), SetCol() and SetPosition() methods, setting
-"pos.lnum" directly above will no longer give an error.
 							*E1334*
 If you try to set an object member that doesn't exist you get an error: >
 	pos.other = 9
@@ -204,12 +183,12 @@ including "this.", as the argument to new() means the value provided in the
 new() call is assigned to that object member.  This mechanism comes from the
 Dart language.
 
-Putting together this way of using new() and making the members public results
-in a much shorter class definition than what we started with: >
+Putting together this way of using new() results in a much shorter class
+definition than what we started with: >
 
 	class TextPosition
-	   public this.lnum: number
-	   public this.col: number
+	   this.lnum: number
+	   this.col: number
 
 	   def new(this.lnum, this.col)
 	   enddef
@@ -255,14 +234,13 @@ prefix: >
 Since the name is used as-is, shadowing the name by a function argument name
 or local variable name is not allowed.
 
-Just like object members the access can be made private by using an underscore
-as the first character in the name, and it can be made public by prefixing
-"public": >
+Just like object members the class members are public by default and the
+access can be made private by using an underscore as the first character in
+the name: >
 
     class OtherThing
-	static total: number	      # anybody can read, only class can write
+	static total: number	      # anybody can read and write
 	static _sum: number	      # only class can read and write
-	public static result: number  # anybody can read and write
     endclass
 <
 							*class-function*
@@ -482,7 +460,6 @@ Inside a class, in between `:class` and `:endclass`, these items can appear:
 - An object member declaration: >
 	this._memberName: memberType
 	this.memberName: memberType
-	public this.memberName: memberType
 - A constructor method: >
 	def new(arguments)
 	def newName(arguments)
@@ -864,9 +841,8 @@ you will have to track down and change.  You may have to make it a "set"
 method call.  This reflects the real world problem that taking away access
 requires work to be done for all places where that access exists.
 
-An alternative would have been using the "private" keyword, just like "public"
-changes the access in the other direction.  Well, that's just to reduce the
-number of keywords.
+An alternative would have been using the "private" keyword.  Well, that's just
+to reduce the number of keywords.
 
 
 No protected object members ~

--- a/src/errors.h
+++ b/src/errors.h
@@ -3405,8 +3405,6 @@ EXTERN char e_cannot_get_object_member_type_from_initializer_str[]
 	INIT(= N_("E1329: Cannot get object member type from initializer: %s"));
 EXTERN char e_invalid_type_for_object_member_str[]
 	INIT(= N_("E1330: Invalid type for object member: %s"));
-EXTERN char e_public_must_be_followed_by_this_or_static[]
-	INIT(= N_("E1331: Public must be followed by \"this\" or \"static\""));
 EXTERN char e_public_member_name_cannot_start_with_underscore_str[]
 	INIT(= N_("E1332: Public member name cannot start with underscore: %s"));
 EXTERN char e_cannot_access_private_member_str[]

--- a/src/eval.c
+++ b/src/eval.c
@@ -1573,19 +1573,19 @@ get_lval(
 			    switch (om->ocm_access)
 			    {
 				case VIM_ACCESS_PRIVATE:
-					semsg(_(e_cannot_access_private_member_str),
+				    semsg(_(e_cannot_access_private_member_str),
 								 om->ocm_name);
-					return NULL;
+				    return NULL;
 				case VIM_ACCESS_READ:
-					if ((flags & GLV_READ_ONLY) == 0)
-					{
-					    semsg(_(e_member_is_not_writable_str),
-								 om->ocm_name);
-					    return NULL;
-					}
-					break;
+				    if ((flags & GLV_READ_ONLY) == 0)
+				    {
+					semsg(_(e_member_is_not_writable_str),
+						om->ocm_name);
+					return NULL;
+				    }
+				    break;
 				case VIM_ACCESS_ALL:
-					break;
+				    break;
 			    }
 
 			    lp->ll_valtype = om->ocm_type;

--- a/src/structs.h
+++ b/src/structs.h
@@ -1489,8 +1489,8 @@ typedef struct {
 #define TTFLAG_SUPER	    0x40    // object from "super".
 
 typedef enum {
-    VIM_ACCESS_PRIVATE,	// read/write only inside th class
-    VIM_ACCESS_READ,	// read everywhere, write only inside th class
+    VIM_ACCESS_PRIVATE,	// read/write only inside the class
+    VIM_ACCESS_READ,	// read everywhere, write only inside the class
     VIM_ACCESS_ALL	// read/write everywhere
 } omacc_T;
 

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -719,7 +719,6 @@ def Test_class_object_member_access()
       class Triple
          this._one = 1
          this.two = 2
-         public this.three = 3
 
          def GetOne(): number
            return this._one
@@ -729,26 +728,15 @@ def Test_class_object_member_access()
       var trip = Triple.new()
       assert_equal(1, trip.GetOne())
       assert_equal(2, trip.two)
-      assert_equal(3, trip.three)
       assert_fails('echo trip._one', 'E1333')
 
       assert_fails('trip._one = 11', 'E1333')
-      assert_fails('trip.two = 22', 'E1335')
-      trip.three = 33
-      assert_equal(33, trip.three)
+      trip.two = 22
+      assert_equal(22, trip.two)
 
       assert_fails('trip.four = 4', 'E1334')
   END
   v9.CheckScriptSuccess(lines)
-
-  # Test for a public member variable name beginning with an underscore
-  lines =<< trim END
-    vim9script
-    class A
-      public this._val = 10
-    endclass
-  END
-  v9.CheckScriptFailure(lines, 'E1332:')
 
   lines =<< trim END
       vim9script
@@ -828,23 +816,14 @@ def Test_class_object_member_access()
   END
   v9.CheckScriptSuccess(lines)
 
-  # Test for "public" cannot be abbreviated
+  # Test for using the "public" keyword
   lines =<< trim END
     vim9script
     class Something
-      pub this.val = 1
+      public this.val = 1
     endclass
   END
-  v9.CheckScriptFailure(lines, 'E1065:')
-
-  # Test for "public" keyword must be followed by "this" or "static".
-  lines =<< trim END
-    vim9script
-    class Something
-      public val = 1
-    endclass
-  END
-  v9.CheckScriptFailure(lines, 'E1331:')
+  v9.CheckScriptFailure(lines, 'E1318:')
 
   # Test for "static" cannot be abbreviated
   lines =<< trim END
@@ -983,7 +962,7 @@ def Test_class_member()
          this.col = 1
          static counter = 0
          static _secret = 7
-         public static  anybody = 42
+         static anybody = 42
 
          static def AddToCounter(nr: number)
            counter += nr
@@ -1001,8 +980,8 @@ def Test_class_member()
       assert_equal(3, GetCounter())
 
       assert_fails('TextPos.noSuchMember = 2', 'E1337:')
-      assert_fails('TextPos.counter = 5', 'E1335:')
-      assert_fails('TextPos.counter += 5', 'E1335:')
+      TextPos.counter = 5
+      assert_equal(5, TextPos.counter)
 
       assert_fails('echo TextPos._secret', 'E1333:')
       assert_fails('TextPos._secret = 8', 'E1333:')
@@ -1522,14 +1501,14 @@ def Test_class_implements_interface()
       vim9script
 
       interface Result
-        public this.label: string
+        this.label: string
         this.errpos: number
       endinterface
 
       # order of members is opposite of interface
       class Failure implements Result
         this.errpos: number = 42
-        public this.label: string = 'label'
+        this.label: string = 'label'
       endclass
 
       def Test()


### PR DESCRIPTION

To be consistent and simple, make the default access for class/object member variables public.
If a member variable name starts with an underscore, then it is private.
