### PR TITLE
Crystal scripts not recognised

### DIFF
--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -209,6 +209,10 @@ export def Exe2filetype(name: string, line1: string): string
   elseif name =~ 'nix-shell'
     return 'nix'
 
+    # Crystal
+  elseif name =~ '^crystal\>'
+    return 'crystal'
+
   endif
 
   return ''

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -943,6 +943,7 @@ def s:GetScriptChecks(): dict<list<list<string>>>
     fish:   [['#!/path/fish']],
     forth:  [['#!/path/gforth']],
     icon:   [['#!/path/icon']],
+    crystal: [['#!/path/crystal']],
   }
 enddef
 


### PR DESCRIPTION
Problem:  Crystal scripts not recognised
Solution: Filetype detect Crystal scripts by shebang line
