### PR TITLE
Fix 'linebreak' incorrectly drawn after 'breakindent'

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -1319,6 +1319,9 @@ win_lbr_chartabsize(
 	vcol -= wp->w_virtcol_first_char;
 #endif
 	colnr_T	wcol = vcol + col_off_prev;
+	colnr_T	max_head_vcol = cts->cts_max_head_vcol;
+	int	added = 0;
+
 	// cells taken by 'showbreak'/'breakindent' before current char
 	int	head_prev = 0;
 	if (wcol >= wp->w_width)
@@ -1332,23 +1335,18 @@ win_lbr_chartabsize(
 	    if (wp->w_p_bri)
 		head_prev += get_breakindent_win(wp, line);
 	    if (wcol < head_prev)
-		wcol = head_prev;
-	    wcol += col_off_prev;
-	}
-
-	if ((vcol > 0 && wcol == col_off_prev + head_prev)
-						  || wcol + size > wp->w_width)
-	{
-	    int added = 0;
-	    colnr_T max_head_vcol = cts->cts_max_head_vcol;
-
-	    if (vcol > 0 && wcol == col_off_prev + head_prev)
 	    {
+		head_prev -= wcol;
+		wcol += head_prev;
 		added += head_prev;
 		if (max_head_vcol <= 0 || vcol < max_head_vcol)
 		    head += head_prev;
 	    }
+	    wcol += col_off_prev;
+	}
 
+	if (wcol + size > wp->w_width)
+	{
 	    // cells taken by 'showbreak'/'breakindent' halfway current char
 	    int	head_mid = 0;
 	    if (*sbr != NUL)
@@ -1384,9 +1382,9 @@ win_lbr_chartabsize(
 		}
 #endif
 	    }
-
-	    size += added;
 	}
+
+	size += added;
     }
     if (headp != NULL)
 	*headp = head;

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -2887,14 +2887,6 @@ win_line(
 		    wlv.n_extra = win_lbr_chartabsize(&cts, NULL) - 1;
 		    clear_chartabsize_arg(&cts);
 
-		    // We have just drawn the showbreak value, no need to add
-		    // space for it again.
-		    if (wlv.vcol == wlv.vcol_sbr)
-		    {
-			wlv.n_extra -= MB_CHARLEN(get_showbreak_value(wp));
-			if (wlv.n_extra < 0)
-			    wlv.n_extra = 0;
-		    }
 		    if (on_last_col && c != TAB)
 			// Do not continue search/match highlighting over the
 			// line break, but for TABs the highlighting should

--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -410,12 +410,19 @@ func Test_display_linebreak_breakat()
   new
   vert resize 25
   let _breakat = &breakat
-  setl signcolumn=yes linebreak breakat=) showbreak=+\ 
+  setl signcolumn=yes linebreak breakat=) showbreak=++
   call setline(1, repeat('x', winwidth(0) - 2) .. ')abc')
   let lines = ScreenLines([1, 2], 25)
   let expected = [
           \ '  xxxxxxxxxxxxxxxxxxxxxxx',
-          \ '  + )abc                 '
+          \ '  ++)abc                 ',
+          \ ]
+  call assert_equal(expected, lines)
+  setl breakindent breakindentopt=shift:2
+  let lines = ScreenLines([1, 2], 25)
+  let expected = [
+          \ '  xxxxxxxxxxxxxxxxxxxxxxx',
+          \ '    ++)abc               ',
           \ ]
   call assert_equal(expected, lines)
   %bw!


### PR DESCRIPTION
Problem: 'linebreak' is incorrectly drawn after 'breakindent'.
Solution: Don't include 'breakindent' size when already after it.

Fix #12937
