### PR TITLE
Free PangoCoverage with g_object_unref for Pango >= 1.52

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4845,7 +4845,11 @@ is_cjk_font(PangoFontDescription *font_desc)
 	{
 	    uc = (cjk_langs[i][0] == 'k') ? 0xAC00 : 0x4E00;
 	    is_cjk = (pango_coverage_get(coverage, uc) == PANGO_COVERAGE_EXACT);
+#if PANGO_VERSION_CHECK(1, 52, 0)
+	    g_object_unref(coverage);
+#else
 	    pango_coverage_unref(coverage);
+#endif
 	}
     }
 


### PR DESCRIPTION
pango_coverage_unref was declared deprecated in Pango 1.52.0 in favor of g_object_unref.  Adjust the call when building against a new enough Pango to avoid the deprecation warning.

Signed-off-by: James McCoy <jamessan@jamessan.com>
