### PR TITLE
runtime: Set b:undo_indent where missing

### DIFF
--- a/runtime/indent/ch.vim
+++ b/runtime/indent/ch.vim
@@ -3,6 +3,7 @@
 " Maintainer:	SoftIntegration, Inc. <info@softintegration.com>
 " URL:		http://www.softintegration.com/download/vim/indent/ch.vim
 " Last change:	2006 Apr 30
+" 		2023 Aug 28 by Vim Project (undo_indent)
 "		Created based on cpp.vim
 "
 " Ch is a C/C++ interpreter with many high level extensions
@@ -16,3 +17,5 @@ let b:did_indent = 1
 
 " Ch indenting is built-in, thus this is very simple
 setlocal cindent
+
+let b:undo_indent = "setlocal cindent<"

--- a/runtime/indent/dune.vim
+++ b/runtime/indent/dune.vim
@@ -3,6 +3,7 @@
 " Maintainers:  Markus Mottl         <markus.mottl@gmail.com>
 " URL:          https://github.com/ocaml/vim-ocaml
 " Last Change:  2021 Jan 01
+"               2023 Aug 28 by Vim Project (undo_indent)
 
 if exists("b:did_indent")
  finish
@@ -11,3 +12,5 @@ let b:did_indent = 1
 
 " dune format-dune-file uses 1 space to indent
 setlocal softtabstop=1 shiftwidth=1 expandtab
+
+let b:undo_indent = "setl et< sts< sw<"

--- a/runtime/indent/fish.vim
+++ b/runtime/indent/fish.vim
@@ -3,6 +3,7 @@
 " Maintainer:   Nicholas Boyle (github.com/nickeb96)
 " Repository:   https://github.com/nickeb96/fish.vim
 " Last Change:  February 4, 2023
+"               2023 Aug 28 by Vim Project (undo_indent)
 
 if exists("b:did_indent")
     finish
@@ -11,6 +12,8 @@ let b:did_indent = 1
 
 setlocal indentexpr=GetFishIndent(v:lnum)
 setlocal indentkeys+==end,=else,=case
+
+let b:undo_indent = "setlocal indentexpr< indentkeys<"
 
 function s:PrevCmdStart(linenum)
     let l:linenum = a:linenum

--- a/runtime/indent/go.vim
+++ b/runtime/indent/go.vim
@@ -2,6 +2,7 @@
 " Language:	Go
 " Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
 " Last Change:	2017 Jun 13
+"		2023 Aug 28 by Vim Project (undo_indent)
 "
 " TODO:
 " - function invocations split across lines
@@ -18,6 +19,8 @@ setlocal nolisp
 setlocal autoindent
 setlocal indentexpr=GoIndent(v:lnum)
 setlocal indentkeys+=<:>,0=},0=)
+
+let b:undo_indent = "setl ai< inde< indk< lisp<"
 
 if exists('*GoIndent')
   finish

--- a/runtime/indent/hare.vim
+++ b/runtime/indent/hare.vim
@@ -2,6 +2,7 @@
 " Language: Hare
 " Maintainer: Amelia Clarke <me@rsaihe.dev>
 " Last Change: 2022 Sep 22
+"              2023 Aug 28 by Vim Project (undo_indent)
 
 if exists("b:did_indent")
   finish
@@ -39,6 +40,8 @@ setlocal indentkeys=0{,0},0),0],!^F,o,O,e,0=case
 setlocal cinwords=if,else,for,switch,match
 
 setlocal indentexpr=GetHareIndent()
+
+let b:undo_indent = "setl cin< cino< cinw< inde< indk<"
 
 function! FloorCindent(lnum)
   return cindent(a:lnum) / shiftwidth() * shiftwidth()

--- a/runtime/indent/jsonc.vim
+++ b/runtime/indent/jsonc.vim
@@ -4,6 +4,7 @@
 " Acknowledgement:  Based off of vim-json maintained by Eli Parra <eli@elzr.com>
 "                   https://github.com/elzr/vim-json
 " Last Change:      2021-07-01
+"                   2023 Aug 28 by Vim Project (undo_indent)
 
 " 0. Initialization {{{1
 " =================
@@ -19,6 +20,8 @@ setlocal nosmartindent
 " Now, set up our indentation expression and keys that trigger it.
 setlocal indentexpr=GetJSONCIndent()
 setlocal indentkeys=0{,0},0),0[,0],!^F,o,O,e
+
+let b:undo_indent = "setlocal indentexpr< indentkeys< smartindent<"
 
 " Only define the function once.
 if exists("*GetJSONCIndent")

--- a/runtime/indent/julia.vim
+++ b/runtime/indent/julia.vim
@@ -3,7 +3,8 @@
 " Maintainer:	Carlo Baldassi <carlobaldassi@gmail.com>
 " Homepage:	https://github.com/JuliaEditorSupport/julia-vim
 " Last Change:	2022 Jun 14
-" Notes:        originally based on Bram Molenaar's indent file for vim
+"		2023 Aug 28 by Vim Project (undo_indent)
+" Notes:        originally based on Bram Moolenaar's indent file for vim
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -20,6 +21,8 @@ setlocal indentkeys-=:
 setlocal indentkeys-=0{
 setlocal indentkeys-=0}
 setlocal nosmartindent
+
+let b:undo_indent = "setl ai< inde< indk< si<"
 
 " Only define the function once.
 if exists("*GetJuliaIndent")

--- a/runtime/indent/logtalk.vim
+++ b/runtime/indent/logtalk.vim
@@ -1,5 +1,6 @@
 "  Maintainer:	Paulo Moura <pmoura@logtalk.org>
 "  Revised on:	2018.08.04
+"		2023 Aug 28 by Vim Project (undo_indent)
 "  Language:	Logtalk
 
 " This Logtalk indent file is a modified version of the Prolog
@@ -15,6 +16,8 @@ let b:did_indent = 1
 setlocal indentexpr=GetLogtalkIndent()
 setlocal indentkeys-=:,0#
 setlocal indentkeys+=0%,-,0;,>,0)
+
+let b:undo_indent = "setlocal indentexpr< indentkeys<"
 
 " Only define the function once.
 if exists("*GetLogtalkIndent")

--- a/runtime/indent/ocaml.vim
+++ b/runtime/indent/ocaml.vim
@@ -4,7 +4,8 @@
 "               Mike Leary           <leary@nwlink.com>
 "               Markus Mottl         <markus.mottl@gmail.com>
 " URL:          https://github.com/ocaml/vim-ocaml
-" Last Change:  2017 Jun 13
+" Last Change:  2023 Aug 28 - Add undo_indent (Vim Project)
+"               2017 Jun 13
 "               2005 Jun 25 - Fixed multiple bugs due to 'else\nreturn ind' working
 "               2005 May 09 - Added an option to not indent OCaml-indents specially (MM)
 "               2013 June   - commented textwidth (Marc Weber)
@@ -23,6 +24,8 @@ setlocal indentexpr=GetOCamlIndent()
 setlocal indentkeys+=0=and,0=class,0=constraint,0=done,0=else,0=end,0=exception,0=external,0=if,0=in,0=include,0=inherit,0=initializer,0=let,0=method,0=open,0=then,0=type,0=val,0=with,0;;,0>\],0\|\],0>},0\|,0},0\],0)
 setlocal nolisp
 setlocal nosmartindent
+
+let b:undo_indent = "setl et< inde< indk< lisp< si<"
 
 " At least Marc Weber and Markus Mottl do not like this:
 " setlocal textwidth=80

--- a/runtime/indent/php.vim
+++ b/runtime/indent/php.vim
@@ -4,6 +4,7 @@
 " URL:		https://www.2072productions.com/vim/indent/php.vim
 " Home:		https://github.com/2072/PHP-Indenting-for-VIm
 " Last Change:	2020 Mar 05
+"		2023 Aug 28 by Vim Project (undo_indent)
 " Version:	1.70
 "
 "
@@ -128,7 +129,7 @@ setlocal nolisp
 setlocal indentexpr=GetPhpIndent()
 setlocal indentkeys=0{,0},0),0],:,!^F,o,O,e,*<Return>,=?>,=<?,=*/
 
-
+let b:undo_indent = "setl ai< cin< inde< indk< lisp< si<"
 
 let s:searchpairflags = 'bWr'
 

--- a/runtime/indent/raku.vim
+++ b/runtime/indent/raku.vim
@@ -4,6 +4,7 @@
 " Homepage:      https://github.com/vim-perl/vim-perl
 " Bugs/requests: https://github.com/vim-perl/vim-perl/issues
 " Last Change:   2020 Apr 15
+"                2023 Aug 28 by Vim Project (undo_indent)
 " Contributors:  Andy Lester <andy@petdance.com>
 "                Hinrik Örn Sigurðsson <hinrik.sig@gmail.com>
 "
@@ -46,6 +47,8 @@ setlocal indentkeys+=0=,0),0],0>,0»,0=or,0=and
 if !b:indent_use_syntax
     setlocal indentkeys+=0=EO
 endif
+
+let b:undo_indent = "setlocal indentexpr< indentkeys<"
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/indent/rst.vim
+++ b/runtime/indent/rst.vim
@@ -4,6 +4,7 @@
 " Maintainer: Marshall Ward <marshall.ward@gmail.com>
 " Previous Maintainer: Nikolai Weibull <now@bitwi.se>
 " Latest Revision: 2020-03-31
+"                  2023 Aug 28 by Vim Project (undo_indent)
 
 if exists("b:did_indent")
   finish
@@ -13,6 +14,8 @@ let b:did_indent = 1
 setlocal indentexpr=GetRSTIndent()
 setlocal indentkeys=!^F,o,O
 setlocal nosmartindent
+
+let b:undo_indent = "setlocal indentexpr< indentkeys< smartindent<"
 
 if exists("*GetRSTIndent")
   finish

--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -2,6 +2,7 @@
 " Language:         Rust
 " Author:           Chris Morgan <me@chrismorgan.info>
 " Last Change:      2017 Jun 13
+"                   2023 Aug 28 by Vim Project (undo_indent)
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 " Only load this indent file when no other was loaded.
@@ -23,6 +24,8 @@ setlocal autoindent	" indentexpr isn't much help otherwise
 setlocal indentkeys=0{,0},!^F,o,O,0[,0]
 
 setlocal indentexpr=GetRustIndent(v:lnum)
+
+let b:undo_indent = "setlocal cindent< cinoptions< cinkeys< cinwords< lisp< autoindent< indentkeys< indentexpr<"
 
 " Only define the function once.
 if exists("*GetRustIndent")

--- a/runtime/indent/scala.vim
+++ b/runtime/indent/scala.vim
@@ -4,6 +4,7 @@
 " Modifications By:     Derek Wyatt
 " URL:                  https://github.com/derekwyatt/vim-scala
 " Last Change:          2016 Aug 26
+"                       2023 Aug 28 by Vim Project (undo_indent)
 
 if exists("b:did_indent")
   finish
@@ -13,6 +14,8 @@ let b:did_indent = 1
 setlocal autoindent
 setlocal indentexpr=GetScalaIndent()
 setlocal indentkeys=0{,0},0),!^F,<>>,o,O,e,=case,<CR>
+
+let b:undo_indent = "setl ai< inde< indk<"
 
 if exists("*GetScalaIndent")
   finish

--- a/runtime/indent/tex.vim
+++ b/runtime/indent/tex.vim
@@ -67,7 +67,8 @@
 "               2020/04/26 by Yichao Zhou <broken.zhou AT gmail.com>
 "               (*) Fix a bug related to \[ & \].  Thanks Manuel Boni for
 "               reporting.
-"
+"               2023/08/28 by Vim Project
+"               (*) Set b:undo_indent.
 " }}}
 
 " Document: {{{
@@ -167,6 +168,7 @@ setlocal indentexpr=GetTeXIndent()
 setlocal indentkeys&
 exec 'setlocal indentkeys+=[,(,{,),},],\&' . substitute(g:tex_items, '^\|\(\\|\)', ',=', 'g')
 let g:tex_items = '^\s*' . substitute(g:tex_items, '^\(\^\\s\*\)*', '', '')
+let b:undo_indent = "setlocal autoindent< indentexpr< indentkeys< smartindent<"
 " }}}
 
 function! GetTeXIndent() " {{{

--- a/runtime/indent/typescript.vim
+++ b/runtime/indent/typescript.vim
@@ -2,6 +2,7 @@
 " Language: TypeScript
 " Maintainer: See https://github.com/HerringtonDarkholme/yats.vim
 " Last Change: 2019 Oct 18
+"              2023 Aug 28 by Vim Project (undo_indent)
 " Acknowledgement: Based off of vim-ruby maintained by Nikolai Weibull http://vim-ruby.rubyforge.org
 
 " 0. Initialization {{{1
@@ -19,6 +20,8 @@ setlocal nosmartindent
 setlocal indentexpr=GetTypescriptIndent()
 setlocal formatexpr=Fixedgq(v:lnum,v:count)
 setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e
+
+let b:undo_indent = "setlocal formatexpr< indentexpr< indentkeys< smartindent<"
 
 " Only define the function once.
 if exists("*GetTypescriptIndent")

--- a/runtime/indent/verilog.vim
+++ b/runtime/indent/verilog.vim
@@ -1,6 +1,7 @@
 " Language:     Verilog HDL
 " Maintainer:	Chih-Tsun Huang <cthuang@cs.nthu.edu.tw>
 " Last Change:	2017 Aug 25 by Chih-Tsun Huang
+" 		2023 Aug 28 by Vim Project (undo_indent)
 " URL:		    http://www.cs.nthu.edu.tw/~cthuang/vim/indent/verilog.vim
 "
 " Credits:
@@ -27,6 +28,8 @@ setlocal indentkeys=!^F,o,O,0),=begin,=end,=join,=endcase
 setlocal indentkeys+==endmodule,=endfunction,=endtask,=endspecify
 setlocal indentkeys+==endconfig,=endgenerate,=endprimitive,=endtable
 setlocal indentkeys+==`else,=`elsif,=`endif
+
+let b:undo_indent = "setlocal indentexpr< indentkeys<"
 
 " Only define the function once.
 if exists("*GetVerilogIndent")

--- a/runtime/indent/vhdl.vim
+++ b/runtime/indent/vhdl.vim
@@ -3,6 +3,7 @@
 " Maintainer:  Gerald Lai <laigera+vim?gmail.com>
 " Version:     1.62
 " Last Change: 2017 Oct 17
+"              2023 Aug 28 by Vim Project (undo_indent)
 " URL:         http://www.vim.org/scripts/script.php?script_id=1450
 
 " only load this indent file when no other was loaded
@@ -18,6 +19,8 @@ setlocal indentkeys+==~begin,=~end\ ,=~end\	,=~is,=~select,=~when
 setlocal indentkeys+==~if,=~then,=~elsif,=~else
 setlocal indentkeys+==~case,=~loop,=~for,=~generate,=~record,=~units,=~process,=~block,=~function,=~component,=~procedure
 setlocal indentkeys+==~architecture,=~configuration,=~entity,=~package
+
+let b:undo_indent = "setlocal indentexpr< indentkeys<"
 
 " constants
 " not a comment


### PR DESCRIPTION
These changes have been sent out to maintainers in the past.  Many have been accepted but never made their way back into the distributed versions.
