### PR TITLE
runtime: Some Rexx files are not recognised

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -147,13 +147,19 @@ export def FTcls()
   endif
 
   var line1 = getline(1)
-
-  if line1 =~ '^\v%(\%|\\)'
-    setf tex
-  elseif line1[0] == '#' && line1 =~ 'rexx'
+  if line1 =~ '^#!.*\<\%(rexx\|regina\)\>'
     setf rexx
+    return
   elseif line1 == 'VERSION 1.0 CLASS'
     setf vb
+    return
+  endif
+
+  var nonblank1 = getline(nextnonblank(1))
+  if nonblank1 =~ '^\v%(\%|\\)'
+    setf tex
+  elseif nonblank1 =~ '^\s*\%(/\*\|::\w\)'
+    setf rexx
   else
     setf st
   endif

--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -213,6 +213,10 @@ export def Exe2filetype(name: string, line1: string): string
   elseif name =~ '^crystal\>'
     return 'crystal'
 
+    # Rexx
+  elseif name =~ '^\%(rexx\|regina\)\>'
+    return 'rexx'
+
   endif
 
   return ''

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -945,6 +945,8 @@ def s:GetScriptChecks(): dict<list<list<string>>>
     forth:  [['#!/path/gforth']],
     icon:   [['#!/path/icon']],
     crystal: [['#!/path/crystal']],
+    rexx:   [['#!/path/rexx'],
+            ['#!/path/regina']],
   }
 enddef
 
@@ -2045,7 +2047,22 @@ func Test_cls_file()
 
   " Rexx
 
-  call writefile(['# rexx'], 'Xfile.cls')
+  call writefile(['#!/usr/bin/rexx'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('rexx', &filetype)
+  bwipe!
+
+  call writefile(['#!/usr/bin/regina'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('rexx', &filetype)
+  bwipe!
+
+  call writefile(['/* Comment */'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('rexx', &filetype)
+  bwipe!
+
+  call writefile(['::class Foo subclass Bar public'], 'Xfile.cls')
   split Xfile.cls
   call assert_equal('rexx', &filetype)
   bwipe!


### PR DESCRIPTION
Problem:  Some Rexx files are not recognised
Solution: Add shebang detection and improve disambiguation of *.cls
	  files
