### PR TITLE
Fix keytrans() not working well for a recording typed in a GUI

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -1842,7 +1842,11 @@ str2special(
     }
 
     c = *str;
-    if (c == K_SPECIAL && str[1] != NUL && str[2] != NUL)
+    if ((c == K_SPECIAL
+#ifdef FEAT_GUI
+		|| c == CSI
+#endif
+	) && str[1] != NUL && str[2] != NUL)
     {
 	if (str[1] == KS_MODIFIER)
 	{
@@ -1850,7 +1854,11 @@ str2special(
 	    str += 3;
 	    c = *str;
 	}
-	if (c == K_SPECIAL && str[1] != NUL && str[2] != NUL)
+	if ((c == K_SPECIAL
+#ifdef FEAT_GUI
+		    || c == CSI
+#endif
+	    ) && str[1] != NUL && str[2] != NUL)
 	{
 	    c = TO_SPECIAL(str[1], str[2]);
 	    str += 2;

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1687,4 +1687,9 @@ func Test_gui_macro_csi()
   iunmap <C-D>t
 endfunc
 
+func Test_gui_csi_keytrans()
+  call assert_equal('<C-L>', keytrans("\x9b\xfc\x04L"))
+  call assert_equal('<C-D>', keytrans("\x9b\xfc\x04D"))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: The keytrans() function doesn't translate a recording typed in
a GUI well.
Solution: Handle CSI like K_SPECIAL, like in mb_unescape().

Fix #12964
