### PR TITLE
fix: crash when accessing a NULL object

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -1180,6 +1180,36 @@ def Test_class_member()
   END
   v9.CheckScriptFailure(lines, 'E1010:')
 
+  # Test for setting a member on a null object
+  lines =<< trim END
+    vim9script
+    class A
+        this.val: string
+    endclass
+
+    def F()
+        var obj: A
+        obj.val = ""
+    enddef
+    F()
+  END
+  v9.CheckScriptFailure(lines, 'E1360: Using a null object')
+
+  # Test for accessing a member on a null object
+  lines =<< trim END
+    vim9script
+    class A
+        this.val: string
+    endclass
+
+    def F()
+        var obj: A
+        echo obj.val
+    enddef
+    F()
+  END
+  v9.CheckScriptFailure(lines, 'E1360: Using a null object')
+
   # Test for no space before or after the '=' when initializing a member
   # variable
   lines =<< trim END

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -1210,6 +1210,32 @@ def Test_class_member()
   END
   v9.CheckScriptFailure(lines, 'E1360: Using a null object')
 
+  # Test for setting a member on a null object, at script level
+  lines =<< trim END
+    vim9script
+    class A
+        this.val: string
+    endclass
+
+    var obj: A
+    obj.val = ""
+  END
+  # FIXME(in source): this should give E1360 as well!
+  v9.CheckScriptFailure(lines, 'E1012: Type mismatch; expected object<A> but got string')
+
+  # Test for accessing a member on a null object, at script level
+  lines =<< trim END
+    vim9script
+    class A
+        this.val: string
+    endclass
+
+    var obj: A
+    echo obj.val
+    F()
+  END
+  v9.CheckScriptFailure(lines, 'E1360: Using a null object')
+
   # Test for no space before or after the '=' when initializing a member
   # variable
   lines =<< trim END

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -1232,7 +1232,6 @@ def Test_class_member()
 
     var obj: A
     echo obj.val
-    F()
   END
   v9.CheckScriptFailure(lines, 'E1360: Using a null object')
 

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2147,7 +2147,14 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
     // -1 dict, list, blob or object
     tv = STACK_TV_BOT(-3);
     SOURCING_LNUM = iptr->isn_lnum;
-    if (dest_type == VAR_ANY)
+
+    // Make sure an object has been initialized
+    if (dest_type == VAR_OBJECT && tv_dest->vval.v_object == NULL)
+    {
+	emsg(_(e_using_null_object));
+	status = FAIL;
+    }
+    else if (dest_type == VAR_ANY)
     {
 	dest_type = tv_dest->v_type;
 	if (dest_type == VAR_DICT)


### PR DESCRIPTION
An object is NULL when the variable is declared, but the constructor isn't called. Accessing/setting a member on the object crashes Vim.

Note: this happens inside def functions, at script level things work differently. Accessing a NULL object member results in E1360 (correctly), while setting a value on it results in E1012 (type mismatch) so there's still something to fix.