### PR TITLE
xxd: Fix -R argument parsing

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -719,14 +719,38 @@ main(int argc, char *argv[])
         }
       else if (!STRNCMP(pp, "-R", 2))
         {
-	  if (!argv[2])
-	    exit_with_usage();
-	  if (!STRNCMP(argv[2], "always", 2))
-	    color = 1;
-	  else if (!STRNCMP(argv[2], "never", 1))
-	    color = 0;
-	  argv++;
-	  argc--;
+          if (argv[2] &&
+                  (!STRNCMP(argv[2], "always", 6) ||
+                   !STRNCMP(argv[2], "never", 5) ||
+                   !STRNCMP(argv[2], "auto", 4) ) )
+            {
+              if (argv[2][1] == 'l')
+                /* "a[l]ways" */
+                color = 1;
+              else if (argv[2][0] == 'n')
+                /* "[n]ever" */
+                color = 0;
+              else
+                {
+                  /* "auto" */
+#ifdef UNIX
+                  color = isatty(STDOUT_FILENO);
+#else
+                  color = 0;
+#endif
+                }
+              argv++;
+              argc--;
+            }
+          else
+            {
+              /* "auto" is default */
+#ifdef UNIX
+              color = isatty(STDOUT_FILENO);
+#else
+              color = 0;
+#endif
+            }
         }
       else if (!strcmp(pp, "--"))	/* end of options */
 	{


### PR DESCRIPTION
`-R` argument is specified as optional, yet, as written, it always consumes an argument.
Or was it intended to be a required value and the documentation need to be changed from `[WHEN]` to `WHEN`?

"auto" value has no effect, meaning if `-R` is repeated and the second case uses "auto" it does not overwrite the previous setting.

---

I wonder if `-R` is the best name for this argument.

If we use `less` as a reference, in `less` `-R` is for `--RAW-CONTROL-CHARS`.
`less` has a separate color argument called `-D` or `--color`.
`ls` uses `--color[=WHEN]` with no short form.

Existing arguments in `xxd` have long names, even though they are not documented.
It is probably a bit annoying to write `--color` all the time in the command line.
But the argument default is actually "auto".
`-c` is already used.
Next unused would be either `-D` or `-j`.