### PR TITLE
Modify class_member_type() to provide more information

### DIFF
--- a/src/proto/vim9class.pro
+++ b/src/proto/vim9class.pro
@@ -1,7 +1,7 @@
 /* vim9class.c */
 int object_index_from_itf_index(class_T *itf, int is_method, int idx, class_T *cl);
 void ex_class(exarg_T *eap);
-type_T *class_member_type(class_T *cl, char_u *name, char_u *name_end, int *member_idx, omacc_T *access);
+type_T *class_member_type(class_T *cl, char_u *name, char_u *name_end, int *member_idx, ocmember_T **m);
 void ex_enum(exarg_T *eap);
 void ex_type(exarg_T *eap);
 int class_object_index(char_u **arg, typval_T *rettv, evalarg_T *evalarg, int verbose);

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1554,6 +1554,7 @@ cleanup:
  * Find member "name" in class "cl", set "member_idx" to the member index and
  * return its type.
  * When not found "member_idx" is set to -1 and t_any is returned.
+ * Set *p_m ocmmember_T if not NULL
  */
     type_T *
 class_member_type(
@@ -1561,7 +1562,7 @@ class_member_type(
     char_u	*name,
     char_u	*name_end,
     int		*member_idx,
-    omacc_T	*access)
+    ocmember_T	**p_m)
 {
     *member_idx = -1;  // not found (yet)
     size_t len = name_end - name;
@@ -1572,7 +1573,8 @@ class_member_type(
 	if (STRNCMP(m->ocm_name, name, len) == 0 && m->ocm_name[len] == NUL)
 	{
 	    *member_idx = i;
-	    *access = m->ocm_access;
+	    if (p_m != NULL)
+		*p_m = m;
 	    return m->ocm_type;
 	}
     }

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1866,27 +1866,21 @@ compile_lhs(
 	{
 	    // for an object or class member get the type of the member
 	    class_T	*cl = lhs->lhs_type->tt_class;
-	    omacc_T	access;
+	    ocmember_T	*m;
 
 	    lhs->lhs_member_type = class_member_type(cl, after + 1,
-					lhs->lhs_end, &lhs->lhs_member_idx,
-					&access);
+				    lhs->lhs_end, &lhs->lhs_member_idx, &m);
 	    if (lhs->lhs_member_idx < 0)
 		return FAIL;
 
 	    // If it is private member variable, then accessing it outside the
 	    // class is not allowed.
-	    if ((access != VIM_ACCESS_ALL) && !inside_class(cctx, cl))
+	    if ((m->ocm_access != VIM_ACCESS_ALL) && !inside_class(cctx, cl))
 	    {
-		char_u	*m_name;
-		char	*msg;
-
-		m_name = vim_strnsave(after + 1, lhs->lhs_end - after - 1);
-		msg = (access == VIM_ACCESS_PRIVATE)
+		char *msg = (m->ocm_access == VIM_ACCESS_PRIVATE)
 				? e_cannot_access_private_member_str
 				: e_cannot_change_readonly_variable_str;
-		semsg(_(msg), m_name);
-		vim_free(m_name);
+		semsg(_(msg), m->ocm_name);
 		return FAIL;
 	    }
 	}
@@ -2097,10 +2091,9 @@ compile_load_lhs_with_index(lhs_T *lhs, char_u *var_start, cctx_T *cctx)
 	   return FAIL;
 
 	class_T	*cl = lhs->lhs_type->tt_class;
-	omacc_T	access;
 	type_T	*type = class_member_type(cl, dot + 1,
 					   lhs->lhs_end, &lhs->lhs_member_idx,
-					   &access);
+					   NULL);
 	if (lhs->lhs_member_idx < 0)
 	    return FAIL;
 


### PR DESCRIPTION
This is a follow on to #12978. In that PR a pointer argument was added to `class_member_type()` through which a value was returned. This PR modifies `class_member_type()` to instead indirectly and optionally return a pointer to an existing structure which contains the desired value plus a bit more. This allows the  getting rid of an alloc/free; may be useful in the future.