### PR TITLE
xxd: Improve colored output

### DIFF
--- a/runtime/doc/xxd.1
+++ b/runtime/doc/xxd.1
@@ -135,9 +135,9 @@ to read plain hexadecimal dumps without line number information and without a
 particular column layout. Additional whitespace and line breaks are allowed
 anywhere.
 .TP
-.IR \-R " "[WHEN]
+.IR \-R " " when
 In output the hex-value and the value are both colored with the same color depending on the hex-value. Mostly helping to differentiate printable and non-printable characters.
-.I WHEN
+.I \fIwhen\fP
 is
 .BR never ", " always ", or " auto .
 .TP

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -88,10 +88,9 @@
 #if defined(WIN32) || defined(CYGWIN)
 # include <io.h>	/* for setmode() */
 # include <windows.h>
-#else
-# ifdef UNIX
-#  include <unistd.h>
-# endif
+#endif
+#ifdef UNIX
+# include <unistd.h>
 #endif
 #include <stdlib.h>
 #include <string.h>	/* for strncmp() */

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -743,21 +743,26 @@ main(int argc, char *argv[])
         }
       else if (!STRNCMP(pp, "-R", 2))
         {
-	  if (!argv[2])
+	  char *pw = pp + 2;
+	  if (!pw[0])
+	    {
+	      pw = argv[2];
+	      argv++;
+	      argc--;
+	    }
+	  if (!pw)
 	    exit_with_usage();
-	  if (!STRNCMP(argv[2], "always", 6))
+	  if (!STRNCMP(pw, "always", 6))
 	    {
 	      (void)enable_color();
 	      color = 1;
 	    }
-	  else if (!STRNCMP(argv[2], "never", 5))
+	  else if (!STRNCMP(pw, "never", 5))
 	    color = 0;
-	  else if (!STRNCMP(argv[2], "auto", 4))
+	  else if (!STRNCMP(pw, "auto", 4))
 	    ;	/* Do nothing. */
 	  else
 	    exit_with_usage();
-	  argv++;
-	  argc--;
         }
       else if (!strcmp(pp, "--"))	/* end of options */
 	{


### PR DESCRIPTION
* Support colored output on Windows.
  SetConsoleMode() is required to enable ANSI color sequences.
* Support "NO_COLOR" environment variable.
  If "NO_COLOR" is defined and not empty, colored output should be disabled.
  See https://no-color.org/
* "-R" should only accept "always", "never" or "auto" as the parameter.
* Allow omitting space after "-R".
* Adjust help and documentation.
  "-R" cannot omit the parameter. Remove surrounding brackets.

Related #12131