### PR TITLE
Rework interfaces

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -400,7 +400,7 @@ a number.  This example extends the one above: >
 	      return this.base * this.height / 2
 	   enddef
 	endclass
-< 							*E1349*
+<							*E1349*
 If a class declares to implement an interface, all the methods specified in
 the interface must appear in the class, with the same signatures.
 
@@ -596,7 +596,7 @@ return type, but without the body and without `:enddef`.  Example: >
 	interface HasSurface
 	   def Surface(): number
 	endinterface
-< 							*E1343*
+<							*E1343*
 An interface name must start with an uppercase letter.
 The "Has" prefix can be used to make it easier to guess this is an interface
 name, with a hint about what it provides.

--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -47,9 +47,10 @@ An object can only be created by a class.  A class provides:
 - State shared by all objects of the class: class variables (class members).
 - A hierarchy of classes, with super-classes and sub-classes, inheritance.
 
-An interface is used to specify properties of an object:
+An interface is used to specify methods of an object:
 - An object can declare several interfaces that it implements.
-- Different objects implementing the same interface can be used the same way.
+- Objects belonging to different classes, implementing the same interface, can
+  be used in the same way.
 
 The class hierarchy allows for single inheritance.  Otherwise interfaces are
 to be used where needed.
@@ -399,10 +400,56 @@ a number.  This example extends the one above: >
 	      return this.base * this.height / 2
 	   enddef
 	endclass
+< 							*E1349*
+If a class declares to implement an interface, all the methods specified in
+the interface must appear in the class, with the same signatures.
 
-If a class declares to implement an interface, all the items specified in the
-interface must appear in the class, with the same types. *E1348* *E1349*
+An interface shouldn't be considered akin to a class: it's a collection of
+methods definitions that must be defined by all classes implementing that
+interface. It's a way of saying: if a class implements `SomeInterface`, it's
+guaranteed that class has `SomeMethod` and you can call it.
 
+Not being a class, an interface cannot be extended, nor it can implement other
+interfaces, nor a class can extend an interface: it can only be implemented by
+classes. On the other hand, while a class can only extend another class (single
+inheritance), it can implement multiple interfaces: >
+
+	interface HasSurface
+	    def Surface(): float
+	endinterface
+	
+	interface HasCorners
+	    def Corners(): list<number>
+	endinterface
+	
+	class Triangle implements HasSurface, HasCorners
+	    this.base: number
+	    this.height: number
+	    this.corners: list<number>
+	
+	    def new(this.base, this.height, this.corners)
+	    enddef
+	
+	    def Surface(): float
+	        return this.base * this.height / 2
+	    enddef
+	
+	    def Corners(): list<number>
+	        return this.corners
+	    enddef
+	endclass
+	
+	class Circle implements HasSurface
+	    this.radius: number
+	
+	    def new(this.radius)
+	    enddef
+	
+	    def Surface(): float
+	        return this.radius * this.radius * 3.14159265
+	    enddef
+	endclass
+<
 The interface name can be used as a type: >
 
 	var shapes: list<HasSurface> = [
@@ -412,6 +459,8 @@ The interface name can be used as a type: >
 	for shape in shapes
 	   echo $'the surface is {shape.Surface()}'
 	endfor
+
+For additional details, read |:interface|
 
 
 ==============================================================================
@@ -505,13 +554,6 @@ only appear once *E1350* .  Multiple interfaces can be specified, separated by
 commas.  Each interface name can appear only once. *E1351*
 
 
-A class defining an interface ~
-							*specifies*
-A class can declare its interface, the object members and methods, with a
-named interface.  This avoids the need for separately specifying the
-interface, which is often done in many languages, especially Java.
-
-
 Items in a class ~
 						*E1318* *E1325* *E1326*
 Inside a class, in between `:class` and `:endclass`, these items can appear:
@@ -547,21 +589,33 @@ prefixed with `:export`: >
 
 	export interface InterfaceName
 	endinterface
-<							*E1344*
-An interface can declare object members, just like in a class but without any
-initializer.
-							*E1345*
+<							*E1345*
 An interface can declare methods with `:def`, including the arguments and
 return type, but without the body and without `:enddef`.  Example: >
 
 	interface HasSurface
-	   this.size: number
 	   def Surface(): number
 	endinterface
-
-An interface name must start with an uppercase letter. *E1343*
+< 							*E1343*
+An interface name must start with an uppercase letter.
 The "Has" prefix can be used to make it easier to guess this is an interface
 name, with a hint about what it provides.
+							*E1372*
+Interfaces aren't classes: they cannot define `new()` constructors since they
+cannot be instantiated as objects.
+							*E1374* *E1344* *E1375*
+Interfaces can only be implemented by classes with the |implements| keyword.
+
+- they cannot extend a class with |extends|
+- they cannot be extended with |extends|, neither by interfaces or classes
+- they cannot implement other interfaces with |implements|
+
+							*E1373*
+Interfaces can only define methods, not members.
+							*E1348*
+Interface methods cannot start with an underscore, they are always public.
+{not implemented}
+
 An interface can only be defined in a |Vim9| script file.  *E1342*
 
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -3437,16 +3437,16 @@ EXTERN char e_interface_can_only_be_defined_in_vim9_script[]
 	INIT(= N_("E1342: Interface can only be defined in Vim9 script"));
 EXTERN char e_interface_name_must_start_with_uppercase_letter_str[]
 	INIT(= N_("E1343: Interface name must start with an uppercase letter: %s"));
-EXTERN char e_cannot_initialize_member_in_interface[]
-	INIT(= N_("E1344: Cannot initialize a member in an interface"));
+EXTERN char e_cannot_extend_interfaces[]
+	INIT(= N_("E1344: Cannot extend an interface"));
 EXTERN char e_not_valid_command_in_interface_str[]
 	INIT(= N_("E1345: Not a valid command in an interface: %s"));
 EXTERN char e_interface_name_not_found_str[]
 	INIT(= N_("E1346: Interface name not found: %s"));
 EXTERN char e_not_valid_interface_str[]
 	INIT(= N_("E1347: Not a valid interface: %s"));
-EXTERN char e_member_str_of_interface_str_not_implemented[]
-	INIT(= N_("E1348: Member \"%s\" of interface \"%s\" not implemented"));
+EXTERN char e_interfaces_methods_cannot_be_private[]
+	INIT(= N_("E1348: Functions of interfaces cannot be private"));
 EXTERN char e_function_str_of_interface_str_not_implemented[]
 	INIT(= N_("E1349: Function \"%s\" of interface \"%s\" not implemented"));
 EXTERN char e_duplicate_implements[]
@@ -3495,6 +3495,16 @@ EXTERN char e_duplicate_member_str[]
 	INIT(= N_("E1369: Duplicate member: %s"));
 EXTERN char e_cannot_define_new_function_as_static[]
 	INIT(= N_("E1370: Cannot define a \"new\" function as static"));
+EXTERN char e_interfaces_cannot_have_access_modifiers[]
+	INIT(= N_("E1371: Cannot use access modifiers in interfaces"));
+EXTERN char e_cannot_define_new_function_in_interfaces[]
+	INIT(= N_("E1372: Cannot declare a \"new\" function in an interface"));
+EXTERN char e_interfaces_cannot_have_members[]
+	INIT(= N_("E1373: Cannot declare class or object members in an interface"));
+EXTERN char e_interfaces_cannot_extend_classes[]
+	INIT(= N_("E1374: Cannot extend a class with an interface"));
+EXTERN char e_interfaces_cannot_implement_interfaces[]
+	INIT(= N_("E1375: Interfaces cannot implement other interfaces"));
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1400: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -1452,6 +1452,24 @@ def Test_interface_basics()
   lines =<< trim END
       vim9script
 
+      interface A
+          public def Method(): float
+      endinterface
+  END
+  v9.CheckScriptFailure(lines, 'E1371: Cannot use access modifiers in interfaces')
+
+  lines =<< trim END
+      vim9script
+
+      interface A
+          def new()
+      endinterface
+  END
+  v9.CheckScriptFailure(lines, 'E1372: Cannot declare a "new" function in an interface')
+
+  lines =<< trim END
+      vim9script
+
       interface Some
         static count: number
         def Method(count: number)

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -373,20 +373,17 @@ validate_interface_methods(
 }
 
 /*
- * Validate all the "implements" classes when creating a new class.  The
- * classes are returned in "intf_classes".  The class functions, class members,
- * object methods and object members in the new class are in
- * "classfunctions_gap", "classmembers_gap", "objmethods_gap", and
- * "objmembers_gap" respectively.
+ * Validate all the "implements" interfaces when creating a new class.
+ * The classes are returned in "intf_classes". The class functions and
+ * object methods in the new class are in "classfunctions_gap" and
+ * "objmethods_gap" respectively.
  */
     static int
 validate_implements_classes(
     garray_T	*impl_gap,
     class_T	**intf_classes,
     garray_T	*classfunctions_gap,
-    garray_T	*classmembers_gap,
-    garray_T	*objmethods_gap,
-    garray_T	*objmembers_gap)
+    garray_T	*objmethods_gap)
 {
     int		success = TRUE;
 
@@ -1339,8 +1336,7 @@ early_ret:
 	intf_classes = ALLOC_CLEAR_MULT(class_T *, ga_impl.ga_len);
 
 	success = validate_implements_classes(&ga_impl, intf_classes,
-					&classfunctions, &classmembers,
-					&objmethods, &objmembers);
+					&classfunctions, &objmethods);
     }
 
     // Check no function argument name is used as a class member.


### PR DESCRIPTION
The PR works as is, marked as draft because it needs discussion.

It's a rework of the `interface` implementation. Actually only rather
superficial changes were needed, but the way interfaces are used is very
different.

Consider that the current implementation of `interface`:
- is only slightly different from an abstract class
- notwithstanding that, you can implement many interfaces, all with their
  members
- I think you can even extend an interface with a class, since they are classes

In short, they aren't interfaces, they are another sort of abstract classes, but
while you're limited to one parent class, you can have a class implement any
number of interfaces... That are full classes.

This PR aims at making them behave as interfaces, as they work in other OOP
languages.

Main changes are:

Interfaces aren't classes: they cannot define `new()` constructors since they
cannot be instantiated as objects.

Interfaces can only define methods, not members (not even static).

Interfaces can only be implemented by classes with the implements keyword:

- they cannot extend a class with `extends`
- they cannot be extended with `extends`, neither by interfaces or classes
- they cannot implement other interfaces with `implements`

As for methods, currently all types are supported, including private methods
(with underscore), something that maybe could be disallowed.

A possibility would be to allow interfaces to extend other interfaces,
currently not possible.