### PR TITLE
xxd: Fix color when -R is specified multiple times

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -759,7 +759,7 @@ main(int argc, char *argv[])
 	  else if (!STRNCMP(pw, "never", 5))
 	    color = 0;
 	  else if (!STRNCMP(pw, "auto", 4))
-	    ;	/* Do nothing. */
+	    color = enable_color();
 	  else
 	    exit_with_usage();
         }


### PR DESCRIPTION
See: https://github.com/vim/vim/pull/12986#issuecomment-1704375892