### PR TITLE
undo is synced after character find

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -570,7 +570,9 @@ normal_cmd_get_more_chars(
 	    // but when replaying a recording the next key is already in the
 	    // typeahead buffer, so record a <Nop> before that to prevent the
 	    // vpeekc() above from applying wrong mappings when replaying.
+	    ++no_u_sync;
 	    gotchars_nop();
+	    --no_u_sync;
 	}
     }
     --no_mapping;

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -862,5 +862,15 @@ func Test_undo_after_write()
   call delete('Xtestfile.txt')
 endfunc
 
+func Test_undo_range_normal()
+  new
+  call setline(1, ['asa', 'bsb'])
+  let &l:undolevels = &l:undolevels
+  %normal dfs
+  call assert_equal(['a', 'b'], getline(1, '$'))
+  undo
+  call assert_equal(['asa', 'bsb'], getline(1, '$'))
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Undo is synced after character find.
Solution: Set `no_u_sync` when calling `gotchars_nop()`.

Fix #13022
