### PR TITLE
ftplugin ruby: wrong cwd checked

### DIFF
--- a/runtime/ftplugin/ruby.vim
+++ b/runtime/ftplugin/ruby.vim
@@ -77,7 +77,7 @@ function! s:query_path(root) abort
   let cwd = fnameescape(getcwd())
   try
     exe cd fnameescape(a:root)
-    if fnamemodify(exepath('ruby'), ':p:h') ==# getcwd()
+    if fnamemodify(exepath('ruby'), ':p:h') ==# cwd
       let path = []
     else
       let path = split(system(path_check),',')


### PR DESCRIPTION
after ```exe cd .. a:root ..``` we don't need to compare with ```getcwd()```, which is ```a:root``` obviously. Compare with ```cwd``` instead.

Test: 

OK (cwd outside of /bin  folder):

```
cd /tmp; vim tmp.rb +'echo g:ruby_default_path' +q

['/usr/lib64/ruby/site_ruby/3.1.0', '/usr/lib64/ruby/site_ruby/3.1.0/x86_64-linux-gnu', '/usr/lib64/ruby/site_ruby', '/usr/lib64/ruby/vendor_ruby/3.1.0', '/usr/lib64/ruby/ven
dor_ruby/3.1.0/x86_64-linux-gnu', '/usr/lib64/ruby/vendor_ruby', '/usr/lib64/ruby/3.1.0', '/usr/lib64/ruby/3.1.0/x86_64-linux-gnu']
```

NOK (cwd inside /bin folder, should be empty dictionary):

```
cd /bin; vim tmp.rb +'echo g:ruby_default_path' +q

['/usr/lib64/ruby/site_ruby/3.1.0', '/usr/lib64/ruby/site_ruby/3.1.0/x86_64-linux-gnu', '/usr/lib64/ruby/site_ruby', '/usr/lib64/ruby/vendor_ruby/3.1.0', '/usr/lib64/ruby/ven
dor_ruby/3.1.0/x86_64-linux-gnu', '/usr/lib64/ruby/vendor_ruby', '/usr/lib64/ruby/3.1.0', '/usr/lib64/ruby/3.1.0/x86_64-linux-gnu']
```