### PR TITLE
Exepath allow curdir if in path

### DIFF
--- a/runtime/autoload/gzip.vim
+++ b/runtime/autoload/gzip.vim
@@ -11,7 +11,10 @@ fun s:check(cmd)
   let name = substitute(a:cmd, '\(\S*\).*', '\1', '')
   if !exists("s:have_" . name)
     " safety check, don't execute anything from the current directory
-    let f = fnamemodify(exepath(name), ":p:h") !=# getcwd()
+    let s:tmp_cwd = getcwd()
+    let f = (fnamemodify(exepath(name), ":p:h") !=# s:tmp_cwd
+          \ || (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) != -1 && s:tmp_cwd != '.'))
+    unlet s:tmp_cwd
     if !f
       echoerr "Warning: NOT executing " .. name .. " from current directory!"
     endif

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -57,10 +57,15 @@ if !exists("g:zip_extractcmd")
  let g:zip_extractcmd= g:zip_unzipcmd
 endif
 
-if fnamemodify(exepath(g:zip_unzipcmd), ":p:h") ==# getcwd()
+let s:tmp_cwd = getcwd()
+if (fnamemodify(exepath(g:zip_unzipcmd), ":p:h") ==# getcwd()
+          \ && (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) == -1 || s:tmp_cwd == '.'))
+ unlet s:tmp_cwd
  echoerr "Warning: NOT executing " .. g:zip_unzipcmd .. " from current directory!"
  finish
 endif
+unlet s:tmp_cwd
+
 " ----------------
 "  Functions: {{{1
 " ----------------

--- a/runtime/ftplugin/perl.vim
+++ b/runtime/ftplugin/perl.vim
@@ -55,7 +55,9 @@ endif
 " Set this once, globally.
 if !exists("perlpath")
     " safety check: don't execute perl from current directory
-    if executable("perl") && fnamemodify(exepath("perl"), ":p:h") != getcwd()
+    let s:tmp_cwd = getcwd()
+    if executable("perl") && (fnamemodify(exepath("perl"), ":p:h") != s:tmp_cwd
+          \ || (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) != -1 && s:tmp_cwd != '.'))
       try
 	if &shellxquote != '"'
 	    let perlpath = system('perl -e "print join(q/,/,@INC)"')
@@ -71,6 +73,7 @@ if !exists("perlpath")
 	" current directory and the directory of the current file.
 	let perlpath = ".,,"
     endif
+    unlet s:tmp_cwd
 endif
 
 " Append perlpath to the existing path value, if it is set.  Since we don't

--- a/runtime/ftplugin/ruby.vim
+++ b/runtime/ftplugin/ruby.vim
@@ -77,11 +77,14 @@ function! s:query_path(root) abort
   let cwd = fnameescape(getcwd())
   try
     exe cd fnameescape(a:root)
-    if fnamemodify(exepath('ruby'), ':p:h') ==# getcwd()
+    let s:tmp_cwd = getcwd()
+    if (fnamemodify(exepath('ruby'), ':p:h') ==# cwd
+          \ && (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) == -1 || s:tmp_cwd == '.'))
       let path = []
     else
       let path = split(system(path_check),',')
     endif
+    unlet s:tmp_cwd
     exe cd cwd
     return path
   finally

--- a/runtime/ftplugin/zig.vim
+++ b/runtime/ftplugin/zig.vim
@@ -40,14 +40,17 @@ endif
 let &l:define='\v(<fn>|<const>|<var>|^\s*\#\s*define)'
 
 " Safety check: don't execute zip from current directory
+let s:tmp_cwd = getcwd()
 if !exists('g:zig_std_dir') && exists('*json_decode') &&
-    \  executable('zig') && fnamemodify(exepath("zig"), ":p:h") != getcwd()
+    \  executable('zig') && (fnamemodify(exepath("zig"), ":p:h") != s:tmp_cwd
+          \ || (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) != -1 && s:tmp_cwd != '.'))
     silent let s:env = system('zig env')
     if v:shell_error == 0
         let g:zig_std_dir = json_decode(s:env)['std_dir']
     endif
     unlet! s:env
 endif
+unlet s:tmp_cwd
 
 if exists('g:zig_std_dir')
     let &l:path = &l:path . ',' . g:zig_std_dir


### PR DESCRIPTION
perl,zip,ruby,... - exec from curdir sometimes ok

perl,gzip,zip,ruby,zig - exec from curdir is sometimes ok

In case the current directory is present as valid $PATH entry, it is OK
to call the program from it, even if vim curdir is in that same
directory.

(Without that patch, for instance, you will not be able to open .zip
files while your current directory is /bin)

(While on that, small bug in ruby.vim was found and submitted as separate
PR #13026)
