### PR TITLE
Fix valid "may be used uninitialized" warning.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1025,7 +1025,7 @@ get_lval(
     int		len;
     hashtab_T	*ht = NULL;
     int		quiet = flags & GLV_QUIET;
-    int		writing;
+    int		writing = 0;
     int		vim9script = in_vim9script();
 
     // Clear everything in "lp".


### PR DESCRIPTION
Obscure almost impossible to cause a problem until much 
greater usage of vim9class interface static from script level.