### PR TITLE
Fix "Open &Tab..." CJK translations to have shortcut key

### DIFF
--- a/runtime/lang/menu_chinese_gb.936.vim
+++ b/runtime/lang/menu_chinese_gb.936.vim
@@ -44,7 +44,7 @@ menutrans &File 文件(&F)
 " File menuitems {{{1
 menutrans &Open\.\.\.<Tab>:e 打开(&O)\.\.\.<Tab>:e
 menutrans Sp&lit-Open\.\.\.<Tab>:sp 在拆分窗口打开(&L)\.\.\.<Tab>:sp
-menutrans Open\ &Tab\.\.\.<Tab>:tabnew 在标签页打开\.\.\.<Tab>:tabnew
+menutrans Open\ &Tab\.\.\.<Tab>:tabnew 在标签页打开(&T)\.\.\.<Tab>:tabnew
 menutrans &New<Tab>:enew 新建(&N)<Tab>:enew
 menutrans &Close<Tab>:close 关闭(&C)<Tab>:close
 menutrans &Save<Tab>:w 保存(&S)<Tab>:w

--- a/runtime/lang/menu_ja_jp.euc-jp.vim
+++ b/runtime/lang/menu_ja_jp.euc-jp.vim
@@ -39,7 +39,7 @@ let g:menutrans_help_dialog = "¥Ø¥ë¥×¤ò¸¡º÷¤·¤¿¤¤¥³¥Þ¥ó¥É¤â¤·¤¯¤ÏÃ±¸ì¤òÆþÎÏ¤·¤Æ¤
 menutrans &File				¥Õ¥¡¥¤¥ë(&F)
 menutrans &Open\.\.\.<Tab>:e		³«¤¯(&O)\.\.\.<Tab>:e
 menutrans Sp&lit-Open\.\.\.<Tab>:sp	Ê¬³ä¤·¤Æ³«¤¯(&L)\.\.\.<Tab>:sp
-menutrans Open\ &Tab\.\.\.<Tab>:tabnew	¥¿¥Ö¥Ú¡¼¥¸¤Ç³«¤¯<Tab>:tabnew
+menutrans Open\ &Tab\.\.\.<Tab>:tabnew	¥¿¥Ö¥Ú¡¼¥¸¤Ç³«¤¯(&T)<Tab>:tabnew
 menutrans &New<Tab>:enew		¿·µ¬ºîÀ®(&N)<Tab>:enew
 menutrans &Close<Tab>:close		ÊÄ¤¸¤ë(&C)<Tab>:close
 menutrans &Save<Tab>:w			ÊÝÂ¸(&S)<Tab>:w

--- a/runtime/lang/menu_ja_jp.utf-8.vim
+++ b/runtime/lang/menu_ja_jp.utf-8.vim
@@ -39,7 +39,7 @@ let g:menutrans_help_dialog = "ヘルプを検索したいコマンドもしく�
 menutrans &File				ファイル(&F)
 menutrans &Open\.\.\.<Tab>:e		開く(&O)\.\.\.<Tab>:e
 menutrans Sp&lit-Open\.\.\.<Tab>:sp	分割して開く(&L)\.\.\.<Tab>:sp
-menutrans Open\ &Tab\.\.\.<Tab>:tabnew	タブページで開く<Tab>:tabnew
+menutrans Open\ &Tab\.\.\.<Tab>:tabnew	タブページで開く(&T)<Tab>:tabnew
 menutrans &New<Tab>:enew		新規作成(&N)<Tab>:enew
 menutrans &Close<Tab>:close		閉じる(&C)<Tab>:close
 menutrans &Save<Tab>:w			保存(&S)<Tab>:w

--- a/runtime/lang/menu_japanese_japan.932.vim
+++ b/runtime/lang/menu_japanese_japan.932.vim
@@ -39,7 +39,7 @@ let g:menutrans_help_dialog = "ƒwƒ‹ƒv‚ğŒŸõ‚µ‚½‚¢ƒRƒ}ƒ“ƒh‚à‚µ‚­‚Í’PŒê‚ğ“ü—Í‚µ‚Ä‚
 menutrans &File				ƒtƒ@ƒCƒ‹(&F)
 menutrans &Open\.\.\.<Tab>:e		ŠJ‚­(&O)\.\.\.<Tab>:e
 menutrans Sp&lit-Open\.\.\.<Tab>:sp	•ªŠ„‚µ‚ÄŠJ‚­(&L)\.\.\.<Tab>:sp
-menutrans Open\ &Tab\.\.\.<Tab>:tabnew	ƒ^ƒuƒy[ƒW‚ÅŠJ‚­<Tab>:tabnew
+menutrans Open\ &Tab\.\.\.<Tab>:tabnew	ƒ^ƒuƒy[ƒW‚ÅŠJ‚­(&T)<Tab>:tabnew
 menutrans &New<Tab>:enew		V‹Kì¬(&N)<Tab>:enew
 menutrans &Close<Tab>:close		•Â‚¶‚é(&C)<Tab>:close
 menutrans &Save<Tab>:w			•Û‘¶(&S)<Tab>:w

--- a/runtime/lang/menu_ko_kr.euckr.vim
+++ b/runtime/lang/menu_ko_kr.euckr.vim
@@ -31,7 +31,7 @@ menutrans &About		이\ 프로그램은(&A)
 menutrans &File				파일(&F)
 menutrans &Open\.\.\.<Tab>:e		열기(&O)\.\.\.<Tab>:e
 menutrans Sp&lit-Open\.\.\.<Tab>:sp	나눠서\ 열기(&l)\.\.\.<Tab>:sp
-menutrans Open\ &Tab\.\.\.<Tab>:tabnew	탭\ 열기\.\.\.<Tab>:tabnew
+menutrans Open\ &Tab\.\.\.<Tab>:tabnew	탭\ 열기(&T)\.\.\.<Tab>:tabnew
 menutrans &New<Tab>:enew		새로운(&N)<Tab>:enew
 menutrans &Close<Tab>:close		닫기(&C)<Tab>:close
 menutrans &Save<Tab>:w			저장(&S)<Tab>:w

--- a/runtime/lang/menu_ko_kr.utf-8.vim
+++ b/runtime/lang/menu_ko_kr.utf-8.vim
@@ -31,7 +31,7 @@ menutrans &About		이\ 프로그램은(&A)
 menutrans &File				파일(&F)
 menutrans &Open\.\.\.<Tab>:e		열기(&O)\.\.\.<Tab>:e
 menutrans Sp&lit-Open\.\.\.<Tab>:sp	나눠서\ 열기(&l)\.\.\.<Tab>:sp
-menutrans Open\ &Tab\.\.\.<Tab>:tabnew	탭\ 열기\.\.\.<Tab>:tabnew
+menutrans Open\ &Tab\.\.\.<Tab>:tabnew	탭\ 열기(&T)\.\.\.<Tab>:tabnew
 menutrans &New<Tab>:enew		새로운(&N)<Tab>:enew
 menutrans &Close<Tab>:close		닫기(&C)<Tab>:close
 menutrans &Save<Tab>:w			저장(&S)<Tab>:w

--- a/runtime/lang/menu_zh_cn.utf-8.vim
+++ b/runtime/lang/menu_zh_cn.utf-8.vim
@@ -44,7 +44,7 @@ menutrans &File 文件(&F)
 " File menuitems {{{1
 menutrans &Open\.\.\.<Tab>:e 打开(&O)\.\.\.<Tab>:e
 menutrans Sp&lit-Open\.\.\.<Tab>:sp 在拆分窗口打开(&L)\.\.\.<Tab>:sp
-menutrans Open\ &Tab\.\.\.<Tab>:tabnew 在标签页打开\.\.\.<Tab>:tabnew
+menutrans Open\ &Tab\.\.\.<Tab>:tabnew 在标签页打开(&T)\.\.\.<Tab>:tabnew
 menutrans &New<Tab>:enew 新建(&N)<Tab>:enew
 menutrans &Close<Tab>:close 关闭(&C)<Tab>:close
 menutrans &Save<Tab>:w 保存(&S)<Tab>:w


### PR DESCRIPTION
Previous PR (#12993) fixed localization files to point to "Open &Tab..." but they didn't add the shortcut key to the translated names. This adds the shortcut keys to the CJK translations in the form of "(&T)".

Note that this doesn't add the shortcut to latin script languages like Czech. These types of translated names tend to also localize the shortcut keys for them to make sense to the user and it's up to each translator to decide how to do so. CJK translations tend to just take the English key directly since it doesn't make sense to have a localized shortcut key in general.