### PR TITLE
Filelist: Add missing directory `crash`

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -217,6 +217,7 @@ SRC_ALL =	\
 		src/testdir/color_ramp.vim \
 		src/testdir/silent.wav \
 		src/testdir/popupbounce.vim \
+		src/testdir/crash/* \
 		src/proto.h \
 		src/protodef.h \
 		src/proto/alloc.pro \


### PR DESCRIPTION
Test_crash_1 test fails in Fedora, because the directory ```crash``` is not in Filelist (we use ```make unixall``` to generate source tarball).