### PR TITLE
Fix failing Test_recover_empty_swap test

### DIFF
--- a/src/testdir/test_recover.vim
+++ b/src/testdir/test_recover.vim
@@ -161,6 +161,7 @@ endfunc
 func Test_recover_empty_swap_file()
   CheckUnix
   call writefile([], '.Xfile1.swp', 'D')
+  set dir=.
   let msg = execute('recover Xfile1')
   call assert_match('Unable to read block 0 from .Xfile1.swp', msg)
   call assert_equal('Xfile1', @%)
@@ -173,6 +174,7 @@ func Test_recover_empty_swap_file()
 
   " :recover from an empty buffer
   call assert_fails('recover', 'E305:')
+  set dir&vim
 endfunc
 
 " Test for :recover using a corrupted swap file


### PR DESCRIPTION
:recover by default not only looks in the current directory, but also in ~/tmp for files to recover. If it finds some files to recover, it will interactively prompt for a file to recover. However, prompting doesn't work when running the test suite (and even if it would, there is no one that can answer the prompt).

So it doesn't really make sense during testing, to inspect different directories for swap files and prompt and wait (which will lead to a timeout and therefore a failing test).

So set the 'directory' option temporarily to the current directory only and reset it back once the test finishes.

Now, I need to clean up my ~/temp directory of swap files laying around there :/