### PR TITLE
test_xxd.vim: flaky on some distros

### DIFF
--- a/src/testdir/check.vim
+++ b/src/testdir/check.vim
@@ -103,11 +103,11 @@ func CheckLinux()
   endif
 endfunc
 
-" Command to check for not running on Linux
-command CheckNotLinux call CheckNotLinux()
-func CheckNotLinux()
-  if has('linux')
-    throw 'Skipped: does not work on Linux'
+" Command to check for dash is not executable
+command CheckDash call CheckDash()
+func CheckDash()
+  if !executable('dash')
+    throw 'Skipped: dash not executable!'
   endif
 endfunc
 

--- a/src/testdir/check.vim
+++ b/src/testdir/check.vim
@@ -103,6 +103,14 @@ func CheckLinux()
   endif
 endfunc
 
+" Command to check for not running on Linux
+command CheckNotLinux call CheckNotLinux()
+func CheckNotLinux()
+  if has('linux')
+    throw 'Skipped: does not work on Linux'
+  endif
+endfunc
+
 " Command to check for not running on a BSD system.
 command CheckNotBSD call CheckNotBSD()
 func CheckNotBSD()

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -552,6 +552,7 @@ func Test_xxd_color2()
   CheckUnix
   CheckNotMac
   CheckNotBSD
+  CheckNotLinux
 
   "Note Quotation mark escaped
   "Note Aposhpere vaihdettu apostrophe replaced with 0x00

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -552,7 +552,7 @@ func Test_xxd_color2()
   CheckUnix
   CheckNotMac
   CheckNotBSD
-  CheckNotLinux
+  CheckDash
 
   "Note Quotation mark escaped
   "Note Aposhpere vaihdettu apostrophe replaced with 0x00


### PR DESCRIPTION
Compiling VIM for ArchLinux and other see: https://github.com/vim/vim/pull/13040#issuecomment-1707772164
leads to flaky test on `Test_xxd_color2()`
see: https://gitlab.archlinux.org/archlinux/packaging/packages/vim/-/commit/30422a45a0d674e9883921b271cba0b367ca790d
Workaround with this Patch the Test will be skipped, but `make test` will pass then.