### PR TITLE
Reverse arguments for e_aptypes_is_null_nr_str.

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3511,8 +3511,8 @@ EXTERN char e_member_str_type_mismatch_expected_str_but_got_str[]
 	INIT(= N_("E1406: Member \"%s\": type mismatch, expected %s but got %s"));
 EXTERN char e_method_str_type_mismatch_expected_str_but_got_str[]
 	INIT(= N_("E1407: Member \"%s\": type mismatch, expected %s but got %s"));
-EXTERN char e_aptypes_is_null_str_nr[]
-	INIT(= "E1408: Internal error: ap_types or ap_types[idx] is NULL: %s: %d");
+EXTERN char e_aptypes_is_null_nr_str[]
+	INIT(= "E1408: Internal error: ap_types or ap_types[idx] is NULL: %d: %s");
 EXTERN char e_interface_static_direct_access_str[]
 	INIT(= N_("E1409: Cannot directly access interface \"%s\" static member \"%s\""));
 // E1371 - E1399 unused

--- a/src/strings.c
+++ b/src/strings.c
@@ -2801,7 +2801,7 @@ skip_to_arg(
 
 	if (ap_types == NULL || ap_types[*arg_cur] == NULL)
 	{
-	    siemsg(e_aptypes_is_null_str_nr, fmt, *arg_cur);
+	    siemsg(e_aptypes_is_null_nr_str, *arg_cur, fmt);
 	    return;
 	}
 


### PR DESCRIPTION
Recently, code has been added to check that the positional formatting code does not run into a NULL dereference error by checking its arguments. Because the format string can be very involved, it is easier to add the index where the code errors by putting it in front of the format string.