### PR TITLE
Disable class member variable access using an object

### DIFF
--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1966,8 +1966,7 @@ class_object_index(
     {
 	// Search in the object member variable table and the class member
 	// variable table.
-	if (get_member_tv(cl, TRUE, name, len, rettv) == OK
-		|| get_member_tv(cl, FALSE, name, len, rettv) == OK)
+	if (get_member_tv(cl, TRUE, name, len, rettv) == OK)
 	{
 	    *arg = name_end;
 	    return OK;

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -413,24 +413,6 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    }
 	}
 
-	for (int i = 0; i < cl->class_class_member_count; ++i)
-	{
-	    ocmember_T *m = &cl->class_class_members[i];
-	    if (STRNCMP(name, m->ocm_name, len) == 0 && m->ocm_name[len] == NUL)
-	    {
-		if (*name == '_' && !inside_class(cctx, cl))
-		{
-		    semsg(_(e_cannot_access_private_member_str), m->ocm_name);
-		    return FAIL;
-		}
-		*arg = name_end;
-		if (cl->class_flags & (CLASS_INTERFACE | CLASS_EXTENDED))
-		    return generate_GET_ITF_MEMBER(cctx, cl, i, m->ocm_type,
-									TRUE);
-		return generate_GET_OBJ_MEMBER(cctx, i, m->ocm_type, TRUE);
-	    }
-	}
-
 	// Could be a function reference: "obj.Func".
 	for (int i = 0; i < cl->class_obj_method_count; ++i)
 	{


### PR DESCRIPTION

Class methods can be accessed only using the class name and cannot be accessed using an object.
To be consistent with this, do the same for class member variables also.  They can be accessed only
using the class name and not using an object.