### PR TITLE
syntax(swayconfig): improved highlighting

### DIFF
--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -4,7 +4,7 @@
 " Maintainer: James Eapen <james.eapen@vai.org>
 " Version: 0.2.2
 " Reference version (JosefLitos/i3config.vim): 1.8.1
-" Last Change: 2023-09-09
+" Last Change: 2023-09-12
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -19,91 +19,110 @@ endif
 
 runtime! syntax/i3config.vim
 
+" i3 extensions
 syn match i3ConfigSet /^\s*set \$\w\+ .*$/ contains=i3ConfigVariable,i3ConfigSetKeyword,i3ConfigColor,i3ConfigString,i3ConfigNoStartupId,i3ConfigNumber,swayConfigOutputCommand,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShParam,i3ConfigShOper
 
-syn keyword i3ConfigBindKeyword bindsym bindcode bindswitch bindgesture contained
-syn match i3ConfigBindArgument /--\(release\|border\|whole-window\|exclude-titlebar\|locked\|to-code\|no-repeat\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
-syn match i3ConfigBind /^\s*bind\(sym\|code\|switch\|gesture\)\s\+.*[^{]$/ contains=i3ConfigBindComboLine,swayConfigBindswitchLine,swayConfigBindgestureLine,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec
+syn keyword i3ConfigActionKeyword opacity contained
 
-syn region i3ConfigModeBlock start=/^mode\( --pango_markup\)\? \([^'" {]\+\|'[^']\+'\|".\+"\)\s\+{$/ end=/^\s*}$/ contains=i3ConfigModeKeyword,i3ConfigString,i3ConfigVariable,i3ConfigBind,swayConfigBindComboBlock,swayConfigBindswitchBlock,swayConfigBindgestureBlock,i3ConfigComment,i3ConfigNumber,i3ConfigParen fold keepend extend
+syn keyword swayConfigBindKeyword bindswitch bindgesture contained
+syn match i3ConfigBindArgument /--\(locked\|to-code\|no-repeat\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
+syn region i3ConfigBind start=/^\s*bind\(switch\|gesture\) / skip=/\\$/ end=/$/ contains=swayConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,swayConfigBindgesture,swayConfigBindgestureArgument,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean keepend
 
-syn keyword i3ConfigBarBlockKeyword bar id swaybar_command binding_mode_indicator font gaps height hidden_state mode output pango_markup position separator_symbol status_command status_edge_padding status_padding strip_workspace_name strip_workspace_numbers wrap_scroll workspace_buttons workspace_min_width tray_bindcode tray_bindsym tray_padding tray_output icon_theme contained
+syn match swayConfigBindBlockHeader /^\s*bind\(sym\|code\) .*{$/ contained contains=i3ConfigBindKeyword,i3ConfigBindArgument,i3ConfigParen
+syn match swayConfigBindBlockCombo /^\s\+\(--[a-z-]\+ \)*[$a-zA-Z0-9_+]\+ [a-z[]\@=/ contained contains=i3ConfigBindArgument,i3ConfigBindCombo
+syn region i3ConfigBind start=/^\s*bind\(sym\|code\) .*{$/ end=/^\s*}$/ contains=swayConfigBindBlockHeader,swayConfigBindBlockCombo,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean,i3ConfigComment,i3ConfigParen fold keepend extend
 
-" Sway options
-" sway bindswitch and bindgesture
-syn region swayConfigBindComboBlock start=/^\s*bind\(sym\|code\)\s\+.*{$/ end=/^\s*}$/ contains=i3ConfigBindKeyword,i3ConfigBindCombo,i3ConfigBindArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec,i3ConfigComment,i3ConfigParen fold keepend extend
-syn match swayConfigBindswitchArgument /--\(locked\|no-warn\|reload\)/ contained
-syn keyword swayConfigBindswitchType lid tablet contained
-syn keyword swayConfigBindswitchAction on off toggle contained
-syn match swayConfigBindswitch /\(lid\|tablet\):\(on\|off\|toggle\) / contained contains=swayConfigSwitchType,i3ConfigOperator,swayConfigBindswitchAction
-syn match swayConfigBindswitchLine /bindswitch\( --\(locked\|no-warn\|reload\)\)* \(lid\|tablet\):\(on\|off\|toggle\) / contained contains=i3ConfigBindKeyword,swayConfigBindswitchArgument,swayConfigBindswitchType,swayConfigBindswitchAction,i3ConfigOperator
-syn region swayConfigBindswitchBlock start=/^\s*bindswitch\s\+.*{$/ end=/^\s*}$/ contains=i3ConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec,i3ConfigComment,i3ConfigParen fold keepend extend
-
-syn keyword swayConfigBindgestureType hold swipe pinch contained
-syn keyword swayConfigBindgestureDir up down left right inward outward clockwise counterclockwise contained
-syn match swayConfigBindgestureArgument /--\(exact\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
-syn match swayConfigBindgesture /\(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigNumber,swayConfigBindgestureType,i3ConfigOperator,swayConfigBindgestureDir,i3ConfigBindModifier
-syn match swayConfigBindgestureLine /bindgesture\( --\(exact\|input-device=".*"\|no-warn\)\)* \(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigBindKeyword,swayConfigBindgestureArgument,i3ConfigNumber,swayConfigBindgestureType,i3ConfigOperator,swayConfigBindgestureDir,i3ConfigBindModifier
-syn region swayConfigBindgestureBlock start=/^\s*bindgesture\s\+.*{$/ end=/^\s*}$/ contains=i3ConfigBindKeyword,swayConfigBindgesture,swayConfigBindgestureArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec,i3ConfigComment,i3ConfigParen fold keepend extend
+syn keyword i3ConfigClientOpts focused_tab_title contained
 
 syn region swayConfigExecBlock start=/exec\(_always\)\? {/ end=/^}$/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigComment fold keepend extend
 
-syn keyword swayConfigBlockKeyword input output seat contained
+syn keyword swayConfigFloatingModifierOpts normal inverse contained
+syn match i3ConfigKeyword /^floating_modifier [$a-zA-Z0-9+]\+ \(normal\|inverse\)$/ contains=i3ConfigVariable,i3ConfigBindModkey,swayConfigFloatingModifierOpts
 
-" sway display outputs
-syn keyword swayConfigOutputOpts mode pos position adaptive_sync scale res resolution power max_render_time transform scale_filter subpixel bg background enable disable toggle contained
-syn keyword swayConfigOutputOptVals toggle normal flipped contained
-syn keyword swayConfigOutputBgOpts fill stretch fit center tile contained
-syn match swayConfigOutputBg / \(background\|bg\) .* \(fill\|fit\|center\|stretch\|tile\)/ contained contains=swayConfigOutputOpts,swayConfigOutputBgOpts,swayConfigBlockKeyword,i3ConfigString
+syn match i3ConfigEdge /^hide_edge_borders\( --i3\)\? \(none\|vertical\|horizontal\|both\|smart\|smart_no_gaps\)\s\?$/ contains=i3ConfigEdgeKeyword,i3ConfigShParam
+
+syn keyword i3ConfigBarBlockKeyword swaybar_command gaps height pango_markup status_edge_padding status_padding wrap_scroll tray_bindcode tray_bindsym icon_theme contained
+
+syn keyword i3ConfigExecActionKeyword swaymsg contained
+
+" Sway-only options
+" Xwayland
+syn keyword swayConfigXOpt enable disable force contained
+syn match i3ConfigKeyword /^xwayland .*$/ contains=swayConfigXOpt
+
+" Bindswitch
+syn match swayConfigBindswitchArgument /--\(locked\|no-warn\|reload\)/ contained
+syn keyword swayConfigBindswitchType lid tablet contained
+syn keyword swayConfigBindswitchState toggle contained
+syn match swayConfigBindswitch /\(lid\|tablet\):\(on\|off\|toggle\) / contained contains=swayConfigBindswitchType,i3ConfigColonOperator,swayConfigBindswitchState,i3ConfigBoolean
+syn region i3ConfigBind start=/^\s*bindswitch\s\+.*{$/ end=/^\s*}$/ contains=swayConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigSeparator,i3ConfigString,i3ConfigCriteria,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigComment,i3ConfigParen fold keepend extend
+
+" Bindgesture
+syn match swayConfigBindgestureArgument /--\(exact\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
+syn keyword swayConfigBindgestureType hold swipe pinch contained
+syn keyword swayConfigBindgestureDir up down left right inward outward clockwise counterclockwise contained
+syn match swayConfigBindgesture /\(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigNumber,swayConfigBindgestureType,i3ConfigColonOperator,swayConfigBindgestureDir,i3ConfigBindModifier
+syn region i3ConfigBind start=/^\s*bindgesture\s\+.*{$/ end=/^\s*}$/ contains=swayConfigBindKeyword,swayConfigBindgesture,swayConfigBindgestureArgument,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean,i3ConfigParen fold keepend extend
+
+" Titlebar commands
+syn match i3ConfigKeyword /^titlebar_border_thickness \(\d\+\|\$\S\+\)$/ contains=i3ConfigNumber,i3ConfigVariable
+syn match i3ConfigKeyword /^titlebar_padding \(\d\+\|\$\S\+\)\( \d\+\)\?$/ contains=i3ConfigNumber,i3ConfigVariable
+
+syn match swayConfigDeviceOps /[*,:;]/ contained
+
+" Output monitors
+syn keyword swayConfigOutputKeyword output contained
+syn keyword swayConfigOutputOpts mode resolution res modeline position pos scale scale_filter subpixel background bg transform disable enable power dpms max_render_time adaptive_sync render_bit_depth contained
+syn keyword swayConfigOutputOptVals linear nearest smart rgb bgr vrgb vbgr none normal flipped fill stretch fit center tile solid_color clockwise anticlockwise toggle contained
 syn match swayConfigOutputFPS /@[0-9.]\+Hz/ contained
 syn match swayConfigOutputMode / [0-9]\+x[0-9]\+\(@[0-9.]\+Hz\)\?/ contained contains=swayConfigOutputFPS,i3ConfigNumber
-syn match swayConfigOutputCommand /output .*/ contains=swayConfigBlockKeyword,swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,i3ConfigVariable,i3ConfigNumber,i3ConfigString,swayConfigOutputBg,i3ConfigBoolean
+syn region i3ConfigAction start=/output/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps keepend
+syn region swayConfigOutput start=/^output/ skip=/\\$/ end=/$/  contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps keepend
+syn region swayConfigOutput start=/^output .* {$/ end=/}$/  contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps,i3ConfigParen keepend extend
 
-" sway input devices
+" Input devices
+syn keyword swayConfigInputKeyword input contained
 syn keyword swayConfigInputOpts xkb_layout xkb_variant xkb_rules xkb_switch_layout xkb_numlock xkb_file xkb_capslock xkb_model repeat_delay repeat_rate map_to_output map_to_region map_from_region tool_mode accel_profile dwt dwtp drag_lock drag click_method middle_emulation tap events calibration_matrix natural_scroll left_handed pointer_accel scroll_button scroll_factor scroll_method tap_button_map contained
 syn keyword swayConfigInputOptVals absolute relative adaptive flat none button_areas clickfinger toggle two_finger edge on_button_down lrm lmr contained
-syn keyword swayConfigInputXkbOptsKeyword xkb_options contained
-syn match swayConfigInputXkbOptsVals /:[0-9a-z_-]\+/ contained contains=i3ConfigOperator
-syn match swayConfigInputXkbOptsOpts /[a-z]\+:[0-9a-z_-]\+/ contained contains=swayConfigInputXkbOptsVals
-syn match swayConfigInputXkbOpts /xkb_options \([a-z]\+:[0-9a-z_-]\+,\?\)\+/ contained contains=i3ConfigOperator,swayConfigInputXkbOptsKeyword,swayConfigInputXkbOptsOpts
-syn match swayConfigInputCommand /^input\s\+".*".*/ contains=swayConfigBlockKeyword,swayConfigInputXkbOptsOpts,i3ConfigNumber,i3ConfigString,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigBoolean,swayConfigInputXkbOpts,i3ConfigOperator,i3ConfigBoolean
+syn match swayConfigColonPairVal /:[0-9a-z_-]\+/ contained contains=i3ConfigColonOperator
+syn match swayConfigColonPair /[a-z]\+:[0-9a-z_-]\+/ contained contains=swayConfigColonPairVal
+syn match swayConfigInputXkbOpts /xkb_options \([a-z]\+:[0-9a-z_-]\+,\?\)\+/ contained contains=swayConfigColonPair,swayConfigDeviceOps
+syn region i3ConfigAction start=/input/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigInputKeyword,swayConfigColonPair,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigBoolean,swayConfigDeviceOps keepend
+syn region i3ConfigInput start=/^input/ skip=/\\$/ end=/$/ contains=swayConfigInputKeyword,swayConfigColonPair,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigBoolean,swayConfigDeviceOps keepend
+syn region i3ConfigInput start=/^input .* {/ end=/}$/ contains=swayConfigInputKeyword,swayConfigColonPair,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigBoolean,swayConfigDeviceOps,i3ConfigParen keepend extend
 
-" set display focus
-syn keyword swayConfigFocusKeyword focus contained
-syn match swayConfigFocus /^focus output .*$/ contains=swayConfigFocusKeyword,swayConfigBlockKeyword
-
-" enable/disable xwayland
-syn keyword swayConfigXOpt enable disable force contained
-syn match swayConfigXwayland /^xwayland \(enable\|disable\|force\)/ contains=swayConfigXOpt
-
-" sway seat
+" Seat
+syn keyword swayConfigSeatKeyword seat contained
 syn keyword swayConfigSeatOpts attach cursor fallback hide_cursor idle_inhibit idle_wake keyboard_grouping shortcuts_inhibitor pointer_constraint xcursor_theme contained
+syn match swayConfigSeatOptVals /when-typing/ contained
 syn keyword swayConfigSeatOptVals move set press release none smart activate deactivate toggle escape enable disable contained
-syn match swayConfigSeat /^seat .*/ contains=swayConfigBlockKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts
-
-syn region swayConfigBlock start=/^\(input\|output\|seat\).*\s{$/ end=/^}$/ contains=swayConfigInputXkbOptsOpts,swayConfigBlockKeyword,i3ConfigParen,i3ConfigVariable,i3ConfigString,i3ConfigNumber,swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,i3ConfigColor,swayConfigOutputBg,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigBoolean,swayConfigInputXkbOpts,i3ConfigOperator,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,i3ConfigComment fold keepend extend
+syn region i3ConfigAction start=/seat/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigSeatKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigDeviceOps keepend
+syn region swayConfigSeat start=/seat/ skip=/\\$/ end=/$/ contains=swayConfigSeatKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigDeviceOps keepend
+syn region swayConfigSeat start=/seat .* {$/ end=/}$/ contains=swayConfigSeatKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigDeviceOps,i3ConfigParen keepend extend
 
 " Define the highlighting.
-hi def link swayConfigFocusKeyword                  i3ConfigAction
-hi def link swayConfigOutputOpts                    i3ConfigOption
-hi def link swayConfigOutputBgOpts                  i3ConfigOption
-hi def link swayConfigOutputOptVals                 i3ConfigOption
-hi def link swayConfigOutputFPS                     Constant
-hi def link swayConfigInputOptVals                  i3ConfigOption
-hi def link swayConfigInputOpts                     i3ConfigKeyword
-hi def link swayConfigInputXkbOptsVals              i3ConfigString
-hi def link swayConfigInputXkbOptsOpts              i3ConfigOption
-hi def link swayConfigInputXkbOptsKeyword           i3ConfigKeyword
-hi def link swayConfigSeatOpts                      i3ConfigKeyword
-hi def link swayConfigSeatOptVals                   i3ConfigOption
-hi def link swayConfigBlockKeyword                  i3ConfigAction
+hi def link swayConfigFloatingModifierOpts          i3ConfigOption
+hi def link swayConfigBindKeyword                   i3ConfigBindKeyword
 hi def link swayConfigXOpt                          i3ConfigOption
-hi def link swayConfigXwayland                      i3ConfigKeyword
-hi def link swayConfigBindswitchType                Type
-hi def link swayConfigBindswitchAction              Keyword
 hi def link swayConfigBindswitchArgument            i3ConfigBindArgument
-hi def link swayConfigBindgestureType               Type
-hi def link swayConfigBindgestureDir                Keyword
+hi def link swayConfigBindswitchType                i3ConfigMoveType
+hi def link swayConfigBindswitchState               i3ConfigMoveDir
 hi def link swayConfigBindgestureArgument           i3ConfigBindArgument
+hi def link swayConfigBindgestureType               i3ConfigMoveType
+hi def link swayConfigBindgestureDir                i3ConfigMoveDir
+hi def link swayConfigDeviceOps                     i3ConfigOperator
+hi def link swayConfigOutputKeyword                 i3ConfigCommand
+hi def link swayConfigOutputOptVals                 i3ConfigOption
+hi def link swayConfigOutputOpts                    i3ConfigOption
+hi def link swayConfigOutputFPS                     Constant
+hi def link swayConfigInputKeyword                  i3ConfigCommand
+hi def link swayConfigInputOptVals                  i3ConfigShParam
+hi def link swayConfigInputOpts                     i3ConfigOption
+hi def link swayConfigInputXkbOpts                  i3ConfigOption
+hi def link swayConfigColonPairVal                  i3ConfigString
+hi def link swayConfigColonPair                     i3ConfigShParam
+hi def link swayConfigSeatKeyword                   i3ConfigCommand
+hi def link swayConfigSeatOptVals                   i3ConfigOption
+hi def link swayConfigSeatOpts                      i3ConfigOption
 
 let b:current_syntax = "swayconfig"

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language: sway window manager config
-" Original Author: James Eapen <james.eapen@vai.org>
+" Original Author: Josef Litos
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 0.2.1
-" Reference version (jamespeapen/swayconfig.vim): 0.12.1
-" Last Change: 2023 Mar 20
+" Version: 0.2.2
+" Reference version (JosefLitos/i3config.vim): 1.8.1
+" Last Change: 2023-09-09
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -19,98 +19,91 @@ endif
 
 runtime! syntax/i3config.vim
 
-scriptencoding utf-8
+syn match i3ConfigSet /^\s*set \$\w\+ .*$/ contains=i3ConfigVariable,i3ConfigSetKeyword,i3ConfigColor,i3ConfigString,i3ConfigNoStartupId,i3ConfigNumber,swayConfigOutputCommand,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShParam,i3ConfigShOper
 
-" Error
-"syn match swayConfigError /.*/
+syn keyword i3ConfigBindKeyword bindsym bindcode bindswitch bindgesture contained
+syn match i3ConfigBindArgument /--\(release\|border\|whole-window\|exclude-titlebar\|locked\|to-code\|no-repeat\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
+syn match i3ConfigBind /^\s*bind\(sym\|code\|switch\|gesture\)\s\+.*[^{]$/ contains=i3ConfigBindComboLine,swayConfigBindswitchLine,swayConfigBindgestureLine,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec
 
-" binding
-syn keyword swayConfigBindKeyword bindswitch bindgesture contained
-syn match swayConfigBind /^\s*\(bindswitch\)\s\+.*$/ contains=i3ConfigVariable,i3ConfigBindKeyword,swayConfigBindKeyword,i3ConfigVariableAndModifier,i3ConfigNumber,i3ConfigUnit,i3ConfigUnitOr,i3ConfigBindArgument,i3ConfigModifier,i3ConfigAction,i3ConfigString,i3ConfigGapStyleKeyword,i3ConfigBorderStyleKeyword
+syn region i3ConfigModeBlock start=/^mode\( --pango_markup\)\? \([^'" {]\+\|'[^']\+'\|".\+"\)\s\+{$/ end=/^\s*}$/ contains=i3ConfigModeKeyword,i3ConfigString,i3ConfigVariable,i3ConfigBind,swayConfigBindComboBlock,swayConfigBindswitchBlock,swayConfigBindgestureBlock,i3ConfigComment,i3ConfigNumber,i3ConfigParen fold keepend extend
 
-" bindgestures
-syn keyword swayConfigBindGestureCommand swipe pinch hold contained
-syn keyword swayConfigBindGestureDirection up down left right next prev contained
-syn keyword swayConfigBindGesturePinchDirection inward outward clockwise counterclockwise contained
-syn match swayConfigBindGestureHold /^\s*\(bindgesture\)\s\+hold\(:[1-5]\)\?\s\+.*$/ contains=swayConfigBindKeyword,swayConfigBindGestureCommand,swayConfigBindGestureDirection,i3ConfigWorkspaceKeyword,i3ConfigAction
-syn match swayConfigBindGestureSwipe /^\s*\(bindgesture\)\s\+swipe\(:[3-5]\)\?:\(up\|down\|left\|right\)\s\+.*$/ contains=swayConfigBindKeyword,swayConfigBindGestureCommand,swayConfigBindGestureDirection,i3ConfigWorkspaceKeyword,i3ConfigAction
-syn match swayConfigBindGesturePinch /^\s*\(bindgesture\)\s\+pinch\(:[2-5]\)\?:\(up\|down\|left\|right\|inward\|outward\|clockwise\|counterclockwise\)\(+\(up\|down\|left\|right\|inward\|outward\|clockwise\|counterclockwise\)\)\?.*$/ contains=swayConfigBindKeyword,swayConfigBindGestureCommand,swayConfigBindGestureDirection,swayConfigBindGesturePinchDirection,i3ConfigWorkspaceKeyword,i3ConfigAction
+syn keyword i3ConfigBarBlockKeyword bar id swaybar_command binding_mode_indicator font gaps height hidden_state mode output pango_markup position separator_symbol status_command status_edge_padding status_padding strip_workspace_name strip_workspace_numbers wrap_scroll workspace_buttons workspace_min_width tray_bindcode tray_bindsym tray_padding tray_output icon_theme contained
 
-" floating
-syn keyword swayConfigFloatingKeyword floating contained
-syn match swayConfigFloating /^\s*floating\s\+\(enable\|disable\|toggle\)\s*$/ contains=swayConfigFloatingKeyword
+" Sway options
+" sway bindswitch and bindgesture
+syn region swayConfigBindComboBlock start=/^\s*bind\(sym\|code\)\s\+.*{$/ end=/^\s*}$/ contains=i3ConfigBindKeyword,i3ConfigBindCombo,i3ConfigBindArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec,i3ConfigComment,i3ConfigParen fold keepend extend
+syn match swayConfigBindswitchArgument /--\(locked\|no-warn\|reload\)/ contained
+syn keyword swayConfigBindswitchType lid tablet contained
+syn keyword swayConfigBindswitchAction on off toggle contained
+syn match swayConfigBindswitch /\(lid\|tablet\):\(on\|off\|toggle\) / contained contains=swayConfigSwitchType,i3ConfigOperator,swayConfigBindswitchAction
+syn match swayConfigBindswitchLine /bindswitch\( --\(locked\|no-warn\|reload\)\)* \(lid\|tablet\):\(on\|off\|toggle\) / contained contains=i3ConfigBindKeyword,swayConfigBindswitchArgument,swayConfigBindswitchType,swayConfigBindswitchAction,i3ConfigOperator
+syn region swayConfigBindswitchBlock start=/^\s*bindswitch\s\+.*{$/ end=/^\s*}$/ contains=i3ConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec,i3ConfigComment,i3ConfigParen fold keepend extend
 
-syn clear i3ConfigFloatingModifier
-syn keyword swayConfigFloatingModifier floating_modifier contained
-syn match swayConfigFloatingMouseAction /^\s\?.*floating_modifier\s\S\+\s\?\(normal\|inverted\|none\)\?$/ contains=swayConfigFloatingModifier,i3ConfigVariable
+syn keyword swayConfigBindgestureType hold swipe pinch contained
+syn keyword swayConfigBindgestureDir up down left right inward outward clockwise counterclockwise contained
+syn match swayConfigBindgestureArgument /--\(exact\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
+syn match swayConfigBindgesture /\(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigNumber,swayConfigBindgestureType,i3ConfigOperator,swayConfigBindgestureDir,i3ConfigBindModifier
+syn match swayConfigBindgestureLine /bindgesture\( --\(exact\|input-device=".*"\|no-warn\)\)* \(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigBindKeyword,swayConfigBindgestureArgument,i3ConfigNumber,swayConfigBindgestureType,i3ConfigOperator,swayConfigBindgestureDir,i3ConfigBindModifier
+syn region swayConfigBindgestureBlock start=/^\s*bindgesture\s\+.*{$/ end=/^\s*}$/ contains=i3ConfigBindKeyword,swayConfigBindgesture,swayConfigBindgestureArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec,i3ConfigComment,i3ConfigParen fold keepend extend
 
-" Gaps
-syn clear i3ConfigSmartBorderKeyword
-syn clear i3ConfigSmartBorder
-syn keyword swayConfigSmartBorderKeyword on no_gaps off contained
-syn match swayConfigSmartBorder /^\s*smart_borders\s\+\(on\|no_gaps\|off\)\s\?$/ contains=swayConfigSmartBorderKeyword
+syn region swayConfigExecBlock start=/exec\(_always\)\? {/ end=/^}$/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigComment fold keepend extend
 
-" Changing colors
-syn keyword swayConfigClientColorKeyword focused_tab_title contained
-syn match swayConfigClientColor /^\s*client.\w\+\s\+.*$/ contains=i3ConfigClientColorKeyword,i3ConfigColor,i3ConfigVariable,i3ConfigClientColorKeyword,swayConfigClientColorKeyword
+syn keyword swayConfigBlockKeyword input output seat contained
 
-" Input config
-syn keyword swayConfigInputKeyword input contained
-syn match swayConfigInput /^\s*input\s\+.*$/ contains=swayConfigInputKeyword
+" sway display outputs
+syn keyword swayConfigOutputOpts mode pos position adaptive_sync scale res resolution power max_render_time transform scale_filter subpixel bg background enable disable toggle contained
+syn keyword swayConfigOutputOptVals toggle normal flipped contained
+syn keyword swayConfigOutputBgOpts fill stretch fit center tile contained
+syn match swayConfigOutputBg / \(background\|bg\) .* \(fill\|fit\|center\|stretch\|tile\)/ contained contains=swayConfigOutputOpts,swayConfigOutputBgOpts,swayConfigBlockKeyword,i3ConfigString
+syn match swayConfigOutputFPS /@[0-9.]\+Hz/ contained
+syn match swayConfigOutputMode / [0-9]\+x[0-9]\+\(@[0-9.]\+Hz\)\?/ contained contains=swayConfigOutputFPS,i3ConfigNumber
+syn match swayConfigOutputCommand /output .*/ contains=swayConfigBlockKeyword,swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,i3ConfigVariable,i3ConfigNumber,i3ConfigString,swayConfigOutputBg,i3ConfigBoolean
 
-" Seat config
-syn keyword swayConfigSeatKeyword seat contained
-syn match swayConfigSeat /^\s*seat\s\+.*$/ contains=swayConfigSeatKeyword
+" sway input devices
+syn keyword swayConfigInputOpts xkb_layout xkb_variant xkb_rules xkb_switch_layout xkb_numlock xkb_file xkb_capslock xkb_model repeat_delay repeat_rate map_to_output map_to_region map_from_region tool_mode accel_profile dwt dwtp drag_lock drag click_method middle_emulation tap events calibration_matrix natural_scroll left_handed pointer_accel scroll_button scroll_factor scroll_method tap_button_map contained
+syn keyword swayConfigInputOptVals absolute relative adaptive flat none button_areas clickfinger toggle two_finger edge on_button_down lrm lmr contained
+syn keyword swayConfigInputXkbOptsKeyword xkb_options contained
+syn match swayConfigInputXkbOptsVals /:[0-9a-z_-]\+/ contained contains=i3ConfigOperator
+syn match swayConfigInputXkbOptsOpts /[a-z]\+:[0-9a-z_-]\+/ contained contains=swayConfigInputXkbOptsVals
+syn match swayConfigInputXkbOpts /xkb_options \([a-z]\+:[0-9a-z_-]\+,\?\)\+/ contained contains=i3ConfigOperator,swayConfigInputXkbOptsKeyword,swayConfigInputXkbOptsOpts
+syn match swayConfigInputCommand /^input\s\+".*".*/ contains=swayConfigBlockKeyword,swayConfigInputXkbOptsOpts,i3ConfigNumber,i3ConfigString,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigBoolean,swayConfigInputXkbOpts,i3ConfigOperator,i3ConfigBoolean
 
-" set display outputs
-syn match swayConfigOutput /^\s*output\s\+.*$/ contains=i3ConfigOutput
-
-" set display focus 
+" set display focus
 syn keyword swayConfigFocusKeyword focus contained
-syn keyword swayConfigFocusType output contained
-syn match swayConfigFocus /^\s*focus\soutput\s.*$/ contains=swayConfigFocusKeyword,swayConfigFocusType
+syn match swayConfigFocus /^focus output .*$/ contains=swayConfigFocusKeyword,swayConfigBlockKeyword
 
-" mouse warping
-syn keyword swayConfigMouseWarpingType container contained
-syn match swayConfigMouseWarping /^\s*mouse_warping\s\+\(output\|container\|none\)\s\?$/ contains=i3ConfigMouseWarpingKeyword,i3ConfigMouseWarpingType,swayConfigMouseWarpingType
+" enable/disable xwayland
+syn keyword swayConfigXOpt enable disable force contained
+syn match swayConfigXwayland /^xwayland \(enable\|disable\|force\)/ contains=swayConfigXOpt
 
-" focus follows mouse
-syn clear i3ConfigFocusFollowsMouseType
-syn clear i3ConfigFocusFollowsMouse
+" sway seat
+syn keyword swayConfigSeatOpts attach cursor fallback hide_cursor idle_inhibit idle_wake keyboard_grouping shortcuts_inhibitor pointer_constraint xcursor_theme contained
+syn keyword swayConfigSeatOptVals move set press release none smart activate deactivate toggle escape enable disable contained
+syn match swayConfigSeat /^seat .*/ contains=swayConfigBlockKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts
 
-syn keyword swayConfigFocusFollowsMouseType yes no always contained
-syn match swayConfigFocusFollowsMouse /^\s*focus_follows_mouse\s\+\(yes\|no\|always\)\s\?$/ contains=i3ConfigFocusFollowsMouseKeyword,swayConfigFocusFollowsMouseType
+syn region swayConfigBlock start=/^\(input\|output\|seat\).*\s{$/ end=/^}$/ contains=swayConfigInputXkbOptsOpts,swayConfigBlockKeyword,i3ConfigParen,i3ConfigVariable,i3ConfigString,i3ConfigNumber,swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,i3ConfigColor,swayConfigOutputBg,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigBoolean,swayConfigInputXkbOpts,i3ConfigOperator,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,i3ConfigComment fold keepend extend
 
-
-" xwayland 
-syn keyword swayConfigXwaylandKeyword xwayland contained
-syn match swayConfigXwaylandModifier /^\s*xwayland\s\+\(enable\|disable\|force\)\s\?$/ contains=swayConfigXwaylandKeyword
-
-" Group mode/bar
-syn clear i3ConfigBlock
-syn region swayConfigBlock start=+.*s\?{$+ end=+^}$+ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigInitializeKeyword,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable,swayConfigInputKeyword,swayConfigSeatKeyword,i3ConfigOutput transparent keepend extend
-
-"hi def link swayConfigError                         Error
-hi def link i3ConfigFloating                        Error
-hi def link swayConfigFloating                      Type
-hi def link swayConfigFloatingMouseAction           Type
-hi def link swayConfigFocusKeyword                  Type
-hi def link swayConfigSmartBorderKeyword            Type
-hi def link swayConfigInputKeyword                  Type
-hi def link swayConfigSeatKeyword                   Type
-hi def link swayConfigMouseWarpingType              Type
-hi def link swayConfigFocusFollowsMouseType         Type
-hi def link swayConfigBindGestureCommand            Identifier
-hi def link swayConfigBindGestureDirection          Constant
-hi def link swayConfigBindGesturePinchDirection     Constant
-hi def link swayConfigBindKeyword                   Identifier
-hi def link swayConfigClientColorKeyword            Identifier
-hi def link swayConfigFloatingKeyword               Identifier
-hi def link swayConfigFloatingModifier              Identifier
-hi def link swayConfigFocusType                     Identifier
-hi def link swayConfigSmartBorder                   Identifier
-hi def link swayConfigXwaylandKeyword               Identifier
-hi def link swayConfigXwaylandModifier              Type
-hi def link swayConfigBindGesture                   PreProc
+" Define the highlighting.
+hi def link swayConfigFocusKeyword                  i3ConfigAction
+hi def link swayConfigOutputOpts                    i3ConfigOption
+hi def link swayConfigOutputBgOpts                  i3ConfigOption
+hi def link swayConfigOutputOptVals                 i3ConfigOption
+hi def link swayConfigOutputFPS                     Constant
+hi def link swayConfigInputOptVals                  i3ConfigOption
+hi def link swayConfigInputOpts                     i3ConfigKeyword
+hi def link swayConfigInputXkbOptsVals              i3ConfigString
+hi def link swayConfigInputXkbOptsOpts              i3ConfigOption
+hi def link swayConfigInputXkbOptsKeyword           i3ConfigKeyword
+hi def link swayConfigSeatOpts                      i3ConfigKeyword
+hi def link swayConfigSeatOptVals                   i3ConfigOption
+hi def link swayConfigBlockKeyword                  i3ConfigAction
+hi def link swayConfigXOpt                          i3ConfigOption
+hi def link swayConfigXwayland                      i3ConfigKeyword
+hi def link swayConfigBindswitchType                Type
+hi def link swayConfigBindswitchAction              Keyword
+hi def link swayConfigBindswitchArgument            i3ConfigBindArgument
+hi def link swayConfigBindgestureType               Type
+hi def link swayConfigBindgestureDir                Keyword
+hi def link swayConfigBindgestureArgument           i3ConfigBindArgument
 
 let b:current_syntax = "swayconfig"


### PR DESCRIPTION
This PR relies on matches set by #13054 (i3config highlighting improvement).

The purpose of this PR is to make highlighting of the config file thorough enough to inform the users about the correctness of their config files just by seeing if the text is correctly highlighted. It makes use of more groups to better distinguish different actions, their options and so on.

I would love to share this improvement with everyone using vim and sway, so I welcome any suggestions for changes and improvements.

@jamespeapen could you please take a look at this PR?