### PR TITLE
confusing error when using .= in compiled functions

### DIFF
--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -79,6 +79,25 @@ def Test_vim9cmd()
       legacy echo version
   END
   v9.CheckScriptSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+    def Func()
+        var d: dict<string>
+        d.k .= ''
+    enddef
+    defcompile
+  END
+  v9.CheckScriptFailure(lines, 'E985:')
+  lines =<< trim END
+    vim9script
+    def Func()
+        var d: dict<string>
+        d.k ,= ''
+    enddef
+    defcompile
+  END
+  v9.CheckScriptFailure(lines, 'E1017:')
 enddef
 
 def Test_defcompile_fails()

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1669,7 +1669,14 @@ compile_lhs(
 	    {
 		if (is_decl)
 		{
-		    semsg(_(e_variable_already_declared_str), lhs->lhs_name);
+		    // if we come here with what looks like an assignment like .=
+		    // but which has been reject by assignment_len() from may_compile_assignment
+		    // give a better error message
+		    char_u *p = skipwhite(lhs->lhs_end);
+		    if (p[0] == '.' && p[1] == '=')
+			emsg(_(e_dot_equal_not_supported_with_script_version_two));
+		    else
+			semsg(_(e_variable_already_declared_str), lhs->lhs_name);
 		    return FAIL;
 		}
 	    }


### PR DESCRIPTION
closes: #12972