### PR TITLE
Fix Scala highlighting string literal as type param

### DIFF
--- a/runtime/syntax/scala.vim
+++ b/runtime/syntax/scala.vim
@@ -180,7 +180,7 @@ hi def link scalaNumber Number
 
 syn region scalaRoundBrackets start="(" end=")" skipwhite contained contains=scalaTypeDeclaration,scalaSquareBrackets,scalaRoundBrackets
 
-syn region scalaSquareBrackets matchgroup=scalaSquareBracketsBrackets start="\[" end="\]" skipwhite nextgroup=scalaTypeExtension contains=scalaTypeDeclaration,scalaSquareBrackets,scalaTypeOperator,scalaTypeAnnotationParameter
+syn region scalaSquareBrackets matchgroup=scalaSquareBracketsBrackets start="\[" end="\]" skipwhite nextgroup=scalaTypeExtension contains=scalaTypeDeclaration,scalaSquareBrackets,scalaTypeOperator,scalaTypeAnnotationParameter,scalaString
 syn match scalaTypeOperator /[-+=:<>]\+/ contained
 syn match scalaTypeAnnotationParameter /@\<[`_A-Za-z0-9$]\+\>/ contained
 hi def link scalaSquareBracketsBrackets Type


### PR DESCRIPTION
Since https://docs.scala-lang.org/sips/42.type.html which is implemented in Scala 2.13 and in Scala 3 it possible to use string literals as singleton types. So code like
```
someFunc["abc"]
```
is valid. Currently this code is not hightlighted correctly and worse if there is an unclosed `(` in the string it breaks the formating in the rest of the file.

I also submitted this patch to the mentioned project for this runtime file: https://github.com/derekwyatt/vim-scala/pull/173 But there are no commits there over the last 2 years and no response in the week since I created it. Also the last change to the Scala syntax file: https://github.com/vim/vim/pull/9594 is yet to be backported to that repo. Therefore I am opening this PR as well to get some feedback on how to proceed to get this fixed.