### PR TITLE
(object|class)_(member|method)_idx, use *_lookup.

### DIFF
--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -394,10 +394,10 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 
     if (type->tt_type == VAR_OBJECT)
     {
-	int m_idx = object_member_idx(cl, name, len);
+        int m_idx;
+        ocmember_T *m = object_member_lookup(cl, name, len, &m_idx);
 	if (m_idx >= 0)
 	{
-	    ocmember_T *m = &cl->class_obj_members[m_idx];
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
 		semsg(_(e_cannot_access_private_member_str), m->ocm_name);

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -1838,9 +1838,7 @@ generate_CALL(
 		{
 		    class_T *clp = mtype->tt_class;
 		    char_u  *aname = ((char_u **)ufunc->uf_args.ga_data)[i];
-		    int	    m_idx;
-		    ocmember_T *m = object_member_lookup(clp, aname, 0,
-									&m_idx);
+		    ocmember_T *m = object_member_lookup(clp, aname, 0, NULL);
 		    if (m != NULL)
 			expected = m->ocm_type;
 		}


### PR DESCRIPTION
Implement (object|class)_(member|method)_lookup as the base code.
Implement `*_idx` using `*_lookup`.
Take advantage of NULL idx ptr where possible.