### PR TITLE
Update Rust runtime files

### DIFF
--- a/runtime/autoload/cargo.vim
+++ b/runtime/autoload/cargo.vim
@@ -1,0 +1,149 @@
+" Last Modified: 2023-09-11
+
+function! cargo#Load()
+    " Utility call to get this script loaded, for debugging
+endfunction
+
+function! cargo#cmd(args) abort
+    " Trim trailing spaces. This is necessary since :terminal command parses
+    " trailing spaces as an empty argument.
+    let args = substitute(a:args, '\s\+$', '', '')
+    if exists('g:cargo_shell_command_runner')
+        let cmd = g:cargo_shell_command_runner
+    elseif has('terminal')
+        let cmd = 'terminal'
+    elseif has('nvim')
+        let cmd = 'noautocmd new | terminal'
+    else
+        let cmd = '!'
+    endif
+    execute cmd 'cargo' args
+endfunction
+
+function! s:nearest_cargo(...) abort
+    " If the second argument is not specified, the first argument determines
+    " whether we will start from the current directory or the directory of the
+    " current buffer, otherwise, we start with the provided path on the 
+    " second argument.
+
+    let l:is_getcwd = get(a:, 1, 0)
+    if l:is_getcwd 
+        let l:starting_path = get(a:, 2, getcwd())
+    else
+        let l:starting_path = get(a:, 2, expand('%:p:h'))
+    endif
+
+    return findfile('Cargo.toml', l:starting_path . ';')
+endfunction
+
+function! cargo#nearestCargo(is_getcwd) abort
+    return s:nearest_cargo(a:is_getcwd)
+endfunction
+
+function! cargo#nearestWorkspaceCargo(is_getcwd) abort
+    let l:nearest = s:nearest_cargo(a:is_getcwd)
+    while l:nearest !=# ''
+        for l:line in readfile(l:nearest, '', 0x100)
+            if l:line =~# '\V[workspace]'
+                return l:nearest
+            endif
+        endfor
+        let l:next = fnamemodify(l:nearest, ':p:h:h')
+        let l:nearest = s:nearest_cargo(0, l:next)
+    endwhile
+    return ''
+endfunction
+
+function! cargo#nearestRootCargo(is_getcwd) abort
+    " Try to find a workspace Cargo.toml, and if not found, take the nearest
+    " regular Cargo.toml
+    let l:workspace_cargo = cargo#nearestWorkspaceCargo(a:is_getcwd)
+    if l:workspace_cargo !=# ''
+        return l:workspace_cargo
+    endif
+    return s:nearest_cargo(a:is_getcwd)
+endfunction
+
+
+function! cargo#build(args)
+    call cargo#cmd("build " . a:args)
+endfunction
+
+function! cargo#check(args)
+    call cargo#cmd("check " . a:args)
+endfunction
+
+function! cargo#clean(args)
+    call cargo#cmd("clean " . a:args)
+endfunction
+
+function! cargo#doc(args)
+    call cargo#cmd("doc " . a:args)
+endfunction
+
+function! cargo#new(args)
+    call cargo#cmd("new " . a:args)
+    cd `=a:args`
+endfunction
+
+function! cargo#init(args)
+    call cargo#cmd("init " . a:args)
+endfunction
+
+function! cargo#run(args)
+    call cargo#cmd("run " . a:args)
+endfunction
+
+function! cargo#test(args)
+    call cargo#cmd("test " . a:args)
+endfunction
+
+function! cargo#bench(args)
+    call cargo#cmd("bench " . a:args)
+endfunction
+
+function! cargo#update(args)
+    call cargo#cmd("update " . a:args)
+endfunction
+
+function! cargo#search(args)
+    call cargo#cmd("search " . a:args)
+endfunction
+
+function! cargo#publish(args)
+    call cargo#cmd("publish " . a:args)
+endfunction
+
+function! cargo#install(args)
+    call cargo#cmd("install " . a:args)
+endfunction
+
+function! cargo#runtarget(args)
+    let l:filename = expand('%:p')
+    let l:read_manifest = system('cargo read-manifest')
+    let l:metadata = json_decode(l:read_manifest)
+    let l:targets = get(l:metadata, 'targets', [])
+    let l:did_run = 0
+    for l:target in l:targets
+        let l:src_path = get(l:target, 'src_path', '')
+        let l:kinds = get(l:target, 'kind', [])
+        let l:name = get(l:target, 'name', '')
+        if l:src_path == l:filename
+        if index(l:kinds, 'example') != -1
+            let l:did_run = 1
+            call cargo#run("--example " . shellescape(l:name) . " " . a:args)
+            return
+        elseif index(l:kinds, 'bin') != -1
+            let l:did_run = 1
+            call cargo#run("--bin " . shellescape(l:name) . " " . a:args)
+            return
+        endif
+        endif
+    endfor
+    if l:did_run != 1
+        call cargo#run(a:args)
+        return
+    endif
+endfunction
+
+" vim: set et sw=4 sts=4 ts=8:

--- a/runtime/autoload/cargo/quickfix.vim
+++ b/runtime/autoload/cargo/quickfix.vim
@@ -1,0 +1,29 @@
+" Last Modified: 2023-09-11
+
+function! cargo#quickfix#CmdPre() abort
+    if &filetype ==# 'rust' && get(b:, 'current_compiler', '') ==# 'cargo' &&
+         \ &makeprg =~ '\V\^cargo\ \.\*'
+        " Preserve the current directory, and 'lcd' to the nearest Cargo file.
+        let b:rust_compiler_cargo_qf_has_lcd = haslocaldir()
+        let b:rust_compiler_cargo_qf_prev_cd = getcwd()
+        let b:rust_compiler_cargo_qf_prev_cd_saved = 1
+        let l:nearest = fnamemodify(cargo#nearestRootCargo(0), ':h')
+        execute 'lchdir! '.l:nearest
+    else
+        let b:rust_compiler_cargo_qf_prev_cd_saved = 0
+    endif
+endfunction
+
+function! cargo#quickfix#CmdPost() abort
+    if exists("b:rust_compiler_cargo_qf_prev_cd_saved") && b:rust_compiler_cargo_qf_prev_cd_saved
+        " Restore the current directory.
+        if b:rust_compiler_cargo_qf_has_lcd
+            execute 'lchdir! '.b:rust_compiler_cargo_qf_prev_cd
+        else
+            execute 'chdir! '.b:rust_compiler_cargo_qf_prev_cd
+        endif
+        let b:rust_compiler_cargo_qf_prev_cd_saved = 0
+    endif
+endfunction
+
+" vim: set et sw=4 sts=4 ts=8:

--- a/runtime/autoload/rust.vim
+++ b/runtime/autoload/rust.vim
@@ -1,207 +1,258 @@
-" Author: Lily Ballard
 " Description: Helper functions for Rust commands/mappings
-" Last Modified: May 27, 2014
+" Last Modified: 2023-09-11
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
+
+function! rust#Load()
+    " Utility call to get this script loaded, for debugging
+endfunction
+
+function! rust#GetConfigVar(name, default)
+    " Local buffer variable with same name takes predeence over global
+    if has_key(b:, a:name)
+        return get(b:, a:name)
+    endif
+    if has_key(g:, a:name)
+        return get(g:, a:name)
+    endif
+    return a:default
+endfunction
+
+" Include expression {{{1
+
+function! rust#IncludeExpr(fname) abort
+    " Remove leading 'crate::' to deal with 2018 edition style 'use'
+    " statements
+    let l:fname = substitute(a:fname, '^crate::', '', '')
+
+    " Remove trailing colons arising from lines like
+    "
+    "     use foo::{Bar, Baz};
+    let l:fname = substitute(l:fname, ':\+$', '', '')
+
+    " Replace '::' with '/'
+    let l:fname = substitute(l:fname, '::', '/', 'g')
+
+    " When we have
+    "
+    "    use foo::bar::baz;
+    "
+    " we can't tell whether baz is a module or a function; and we can't tell
+    " which modules correspond to files.
+    "
+    " So we work our way up, trying
+    "
+    "     foo/bar/baz.rs
+    "     foo/bar.rs
+    "     foo.rs
+    while l:fname !=# '.'
+        let l:path = findfile(l:fname)
+        if !empty(l:path)
+            return l:fname
+        endif
+        let l:fname = fnamemodify(l:fname, ':h')
+    endwhile
+    return l:fname
+endfunction
 
 " Jump {{{1
 
 function! rust#Jump(mode, function) range
-	let cnt = v:count1
-	normal! m'
-	if a:mode ==# 'v'
-		norm! gv
-	endif
-	let foldenable = &foldenable
-	set nofoldenable
-	while cnt > 0
-		execute "call <SID>Jump_" . a:function . "()"
-		let cnt = cnt - 1
-	endwhile
-	let &foldenable = foldenable
+    let cnt = v:count1
+    normal! m'
+    if a:mode ==# 'v'
+        norm! gv
+    endif
+    let foldenable = &foldenable
+    set nofoldenable
+    while cnt > 0
+        execute "call <SID>Jump_" . a:function . "()"
+        let cnt = cnt - 1
+    endwhile
+    let &foldenable = foldenable
 endfunction
 
 function! s:Jump_Back()
-	call search('{', 'b')
-	keepjumps normal! w99[{
+    call search('{', 'b')
+    keepjumps normal! w99[{
 endfunction
 
 function! s:Jump_Forward()
-	normal! j0
-	call search('{', 'b')
-	keepjumps normal! w99[{%
-	call search('{')
+    normal! j0
+    call search('{', 'b')
+    keepjumps normal! w99[{%
+    call search('{')
 endfunction
 
 " Run {{{1
 
 function! rust#Run(bang, args)
-	let args = s:ShellTokenize(a:args)
-	if a:bang
-		let idx = index(l:args, '--')
-		if idx != -1
-			let rustc_args = idx == 0 ? [] : l:args[:idx-1]
-			let args = l:args[idx+1:]
-		else
-			let rustc_args = l:args
-			let args = []
-		endif
-	else
-		let rustc_args = []
-	endif
+    let args = s:ShellTokenize(a:args)
+    if a:bang
+        let idx = index(l:args, '--')
+        if idx != -1
+            let rustc_args = idx == 0 ? [] : l:args[:idx-1]
+            let args = l:args[idx+1:]
+        else
+            let rustc_args = l:args
+            let args = []
+        endif
+    else
+        let rustc_args = []
+    endif
 
-	let b:rust_last_rustc_args = l:rustc_args
-	let b:rust_last_args = l:args
+    let b:rust_last_rustc_args = l:rustc_args
+    let b:rust_last_args = l:args
 
-	call s:WithPath(function("s:Run"), rustc_args, args)
+    call s:WithPath(function("s:Run"), rustc_args, args)
 endfunction
 
 function! s:Run(dict, rustc_args, args)
-	let exepath = a:dict.tmpdir.'/'.fnamemodify(a:dict.path, ':t:r')
-	if has('win32')
-		let exepath .= '.exe'
-	endif
+    let exepath = a:dict.tmpdir.'/'.fnamemodify(a:dict.path, ':t:r')
+    if has('win32')
+        let exepath .= '.exe'
+    endif
 
-	let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
-	let rustc_args = [relpath, '-o', exepath] + a:rustc_args
+    let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
+    let rustc_args = [relpath, '-o', exepath] + a:rustc_args
 
-	let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
+    let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
-	let pwd = a:dict.istemp ? a:dict.tmpdir : ''
-	let output = s:system(pwd, shellescape(rustc) . " " . join(map(rustc_args, 'shellescape(v:val)')))
-	if output != ''
-		echohl WarningMsg
-		echo output
-		echohl None
-	endif
-	if !v:shell_error
-		exe '!' . shellescape(exepath) . " " . join(map(a:args, 'shellescape(v:val)'))
-	endif
+    let pwd = a:dict.istemp ? a:dict.tmpdir : ''
+    let output = s:system(pwd, shellescape(rustc) . " " . join(map(rustc_args, 'shellescape(v:val)')))
+    if output !=# ''
+        echohl WarningMsg
+        echo output
+        echohl None
+    endif
+    if !v:shell_error
+        exe '!' . shellescape(exepath) . " " . join(map(a:args, 'shellescape(v:val)'))
+    endif
 endfunction
 
 " Expand {{{1
 
 function! rust#Expand(bang, args)
-	let args = s:ShellTokenize(a:args)
-	if a:bang && !empty(l:args)
-		let pretty = remove(l:args, 0)
-	else
-		let pretty = "expanded"
-	endif
-	call s:WithPath(function("s:Expand"), pretty, args)
+    let args = s:ShellTokenize(a:args)
+    if a:bang && !empty(l:args)
+        let pretty = remove(l:args, 0)
+    else
+        let pretty = "expanded"
+    endif
+    call s:WithPath(function("s:Expand"), pretty, args)
 endfunction
 
 function! s:Expand(dict, pretty, args)
-	try
-		let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
+    try
+        let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
-		if a:pretty =~? '^\%(everybody_loops$\|flowgraph=\)'
-			let flag = '--xpretty'
-		else
-			let flag = '--pretty'
-		endif
-		let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
-		let args = [relpath, '-Z', 'unstable-options', l:flag, a:pretty] + a:args
-		let pwd = a:dict.istemp ? a:dict.tmpdir : ''
-		let output = s:system(pwd, shellescape(rustc) . " " . join(map(args, 'shellescape(v:val)')))
-		if v:shell_error
-			echohl WarningMsg
-			echo output
-			echohl None
-		else
-			new
-			silent put =output
-			1
-			d
-			setl filetype=rust
-			setl buftype=nofile
-			setl bufhidden=hide
-			setl noswapfile
-			" give the buffer a nice name
-			let suffix = 1
-			let basename = fnamemodify(a:dict.path, ':t:r')
-			while 1
-				let bufname = basename
-				if suffix > 1 | let bufname .= ' ('.suffix.')' | endif
-				let bufname .= '.pretty.rs'
-				if bufexists(bufname)
-					let suffix += 1
-					continue
-				endif
-				exe 'silent noautocmd keepalt file' fnameescape(bufname)
-				break
-			endwhile
-		endif
-	endtry
+        if a:pretty =~? '^\%(everybody_loops$\|flowgraph=\)'
+            let flag = '--xpretty'
+        else
+            let flag = '--pretty'
+        endif
+        let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
+        let args = [relpath, '-Z', 'unstable-options', l:flag, a:pretty] + a:args
+        let pwd = a:dict.istemp ? a:dict.tmpdir : ''
+        let output = s:system(pwd, shellescape(rustc) . " " . join(map(args, 'shellescape(v:val)')))
+        if v:shell_error
+            echohl WarningMsg
+            echo output
+            echohl None
+        else
+            new
+            silent put =output
+            1
+            d
+            setl filetype=rust
+            setl buftype=nofile
+            setl bufhidden=hide
+            setl noswapfile
+            " give the buffer a nice name
+            let suffix = 1
+            let basename = fnamemodify(a:dict.path, ':t:r')
+            while 1
+                let bufname = basename
+                if suffix > 1 | let bufname .= ' ('.suffix.')' | endif
+                let bufname .= '.pretty.rs'
+                if bufexists(bufname)
+                    let suffix += 1
+                    continue
+                endif
+                exe 'silent noautocmd keepalt file' fnameescape(bufname)
+                break
+            endwhile
+        endif
+    endtry
 endfunction
 
 function! rust#CompleteExpand(lead, line, pos)
-	if a:line[: a:pos-1] =~ '^RustExpand!\s*\S*$'
-		" first argument and it has a !
-		let list = ["normal", "expanded", "typed", "expanded,identified", "flowgraph=", "everybody_loops"]
-		if !empty(a:lead)
-			call filter(list, "v:val[:len(a:lead)-1] == a:lead")
-		endif
-		return list
-	endif
+    if a:line[: a:pos-1] =~# '^RustExpand!\s*\S*$'
+        " first argument and it has a !
+        let list = ["normal", "expanded", "typed", "expanded,identified", "flowgraph=", "everybody_loops"]
+        if !empty(a:lead)
+            call filter(list, "v:val[:len(a:lead)-1] == a:lead")
+        endif
+        return list
+    endif
 
-	return glob(escape(a:lead, "*?[") . '*', 0, 1)
+    return glob(escape(a:lead, "*?[") . '*', 0, 1)
 endfunction
 
 " Emit {{{1
 
 function! rust#Emit(type, args)
-	let args = s:ShellTokenize(a:args)
-	call s:WithPath(function("s:Emit"), a:type, args)
+    let args = s:ShellTokenize(a:args)
+    call s:WithPath(function("s:Emit"), a:type, args)
 endfunction
 
 function! s:Emit(dict, type, args)
-	try
-		let output_path = a:dict.tmpdir.'/output'
+    try
+        let output_path = a:dict.tmpdir.'/output'
 
-		let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
+        let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
-		let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
-		let args = [relpath, '--emit', a:type, '-o', output_path] + a:args
-		let pwd = a:dict.istemp ? a:dict.tmpdir : ''
-		let output = s:system(pwd, shellescape(rustc) . " " . join(map(args, 'shellescape(v:val)')))
-		if output != ''
-			echohl WarningMsg
-			echo output
-			echohl None
-		endif
-		if !v:shell_error
-			new
-			exe 'silent keepalt read' fnameescape(output_path)
-			1
-			d
-			if a:type == "llvm-ir"
-				setl filetype=llvm
-				let extension = 'll'
-			elseif a:type == "asm"
-				setl filetype=asm
-				let extension = 's'
-			endif
-			setl buftype=nofile
-			setl bufhidden=hide
-			setl noswapfile
-			if exists('l:extension')
-				" give the buffer a nice name
-				let suffix = 1
-				let basename = fnamemodify(a:dict.path, ':t:r')
-				while 1
-					let bufname = basename
-					if suffix > 1 | let bufname .= ' ('.suffix.')' | endif
-					let bufname .= '.'.extension
-					if bufexists(bufname)
-						let suffix += 1
-						continue
-					endif
-					exe 'silent noautocmd keepalt file' fnameescape(bufname)
-					break
-				endwhile
-			endif
-		endif
-	endtry
+        let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
+        let args = [relpath, '--emit', a:type, '-o', output_path] + a:args
+        let pwd = a:dict.istemp ? a:dict.tmpdir : ''
+        let output = s:system(pwd, shellescape(rustc) . " " . join(map(args, 'shellescape(v:val)')))
+        if output !=# ''
+            echohl WarningMsg
+            echo output
+            echohl None
+        endif
+        if !v:shell_error
+            new
+            exe 'silent keepalt read' fnameescape(output_path)
+            1
+            d
+            if a:type ==# "llvm-ir"
+                setl filetype=llvm
+                let extension = 'll'
+            elseif a:type ==# "asm"
+                setl filetype=asm
+                let extension = 's'
+            endif
+            setl buftype=nofile
+            setl bufhidden=hide
+            setl noswapfile
+            if exists('l:extension')
+                " give the buffer a nice name
+                let suffix = 1
+                let basename = fnamemodify(a:dict.path, ':t:r')
+                while 1
+                    let bufname = basename
+                    if suffix > 1 | let bufname .= ' ('.suffix.')' | endif
+                    let bufname .= '.'.extension
+                    if bufexists(bufname)
+                        let suffix += 1
+                        continue
+                    endif
+                    exe 'silent noautocmd keepalt file' fnameescape(bufname)
+                    break
+                endwhile
+            endif
+        endif
+    endtry
 endfunction
 
 " Utility functions {{{1
@@ -219,145 +270,154 @@ endfunction
 " existing path of the current buffer. If the path is inside of {dict.tmpdir}
 " then it is guaranteed to have a '.rs' extension.
 function! s:WithPath(func, ...)
-	let buf = bufnr('')
-	let saved = {}
-	let dict = {}
-	try
-		let saved.write = &write
-		set write
-		let dict.path = expand('%')
-		let pathisempty = empty(dict.path)
+    let buf = bufnr('')
+    let saved = {}
+    let dict = {}
+    try
+        let saved.write = &write
+        set write
+        let dict.path = expand('%')
+        let pathisempty = empty(dict.path)
 
-		" Always create a tmpdir in case the wrapped command wants it
-		let dict.tmpdir = tempname()
-		call mkdir(dict.tmpdir)
+        " Always create a tmpdir in case the wrapped command wants it
+        let dict.tmpdir = tempname()
+        call mkdir(dict.tmpdir)
 
-		if pathisempty || !saved.write
-			let dict.istemp = 1
-			" if we're doing this because of nowrite, preserve the filename
-			if !pathisempty
-				let filename = expand('%:t:r').".rs"
-			else
-				let filename = 'unnamed.rs'
-			endif
-			let dict.tmpdir_relpath = filename
-			let dict.path = dict.tmpdir.'/'.filename
+        if pathisempty || !saved.write
+            let dict.istemp = 1
+            " if we're doing this because of nowrite, preserve the filename
+            if !pathisempty
+                let filename = expand('%:t:r').".rs"
+            else
+                let filename = 'unnamed.rs'
+            endif
+            let dict.tmpdir_relpath = filename
+            let dict.path = dict.tmpdir.'/'.filename
 
-			let saved.mod = &mod
-			set nomod
+            let saved.mod = &modified
+            set nomodified
 
-			silent exe 'keepalt write! ' . fnameescape(dict.path)
-			if pathisempty
-				silent keepalt 0file
-			endif
-		else
-			let dict.istemp = 0
-			update
-		endif
+            silent exe 'keepalt write! ' . fnameescape(dict.path)
+            if pathisempty
+                silent keepalt 0file
+            endif
+        else
+            let dict.istemp = 0
+            update
+        endif
 
-		call call(a:func, [dict] + a:000)
-	finally
-		if bufexists(buf)
-			for [opt, value] in items(saved)
-				silent call setbufvar(buf, '&'.opt, value)
-				unlet value " avoid variable type mismatches
-			endfor
-		endif
-		if has_key(dict, 'tmpdir') | silent call s:RmDir(dict.tmpdir) | endif
-	endtry
+        call call(a:func, [dict] + a:000)
+    finally
+        if bufexists(buf)
+            for [opt, value] in items(saved)
+                silent call setbufvar(buf, '&'.opt, value)
+                unlet value " avoid variable type mismatches
+            endfor
+        endif
+        if has_key(dict, 'tmpdir') | silent call s:RmDir(dict.tmpdir) | endif
+    endtry
 endfunction
 
 function! rust#AppendCmdLine(text)
-	call setcmdpos(getcmdpos())
-	let cmd = getcmdline() . a:text
-	return cmd
+    call setcmdpos(getcmdpos())
+    let cmd = getcmdline() . a:text
+    return cmd
 endfunction
 
 " Tokenize the string according to sh parsing rules
 function! s:ShellTokenize(text)
-	" states:
-	" 0: start of word
-	" 1: unquoted
-	" 2: unquoted backslash
-	" 3: double-quote
-	" 4: double-quoted backslash
-	" 5: single-quote
-	let l:state = 0
-	let l:current = ''
-	let l:args = []
-	for c in split(a:text, '\zs')
-		if l:state == 0 || l:state == 1 " unquoted
-			if l:c ==# ' '
-				if l:state == 0 | continue | endif
-				call add(l:args, l:current)
-				let l:current = ''
-				let l:state = 0
-			elseif l:c ==# '\'
-				let l:state = 2
-			elseif l:c ==# '"'
-				let l:state = 3
-			elseif l:c ==# "'"
-				let l:state = 5
-			else
-				let l:current .= l:c
-				let l:state = 1
-			endif
-		elseif l:state == 2 " unquoted backslash
-			if l:c !=# "\n" " can it even be \n?
-				let l:current .= l:c
-			endif
-			let l:state = 1
-		elseif l:state == 3 " double-quote
-			if l:c ==# '\'
-				let l:state = 4
-			elseif l:c ==# '"'
-				let l:state = 1
-			else
-				let l:current .= l:c
-			endif
-		elseif l:state == 4 " double-quoted backslash
-			if stridx('$`"\', l:c) >= 0
-				let l:current .= l:c
-			elseif l:c ==# "\n" " is this even possible?
-				" skip it
-			else
-				let l:current .= '\'.l:c
-			endif
-			let l:state = 3
-		elseif l:state == 5 " single-quoted
-			if l:c == "'"
-				let l:state = 1
-			else
-				let l:current .= l:c
-			endif
-		endif
-	endfor
-	if l:state != 0
-		call add(l:args, l:current)
-	endif
-	return l:args
+    " states:
+    " 0: start of word
+    " 1: unquoted
+    " 2: unquoted backslash
+    " 3: double-quote
+    " 4: double-quoted backslash
+    " 5: single-quote
+    let l:state = 0
+    let l:current = ''
+    let l:args = []
+    for c in split(a:text, '\zs')
+        if l:state == 0 || l:state == 1 " unquoted
+            if l:c ==# ' '
+                if l:state == 0 | continue | endif
+                call add(l:args, l:current)
+                let l:current = ''
+                let l:state = 0
+            elseif l:c ==# '\'
+                let l:state = 2
+            elseif l:c ==# '"'
+                let l:state = 3
+            elseif l:c ==# "'"
+                let l:state = 5
+            else
+                let l:current .= l:c
+                let l:state = 1
+            endif
+        elseif l:state == 2 " unquoted backslash
+            if l:c !=# "\n" " can it even be \n?
+                let l:current .= l:c
+            endif
+            let l:state = 1
+        elseif l:state == 3 " double-quote
+            if l:c ==# '\'
+                let l:state = 4
+            elseif l:c ==# '"'
+                let l:state = 1
+            else
+                let l:current .= l:c
+            endif
+        elseif l:state == 4 " double-quoted backslash
+            if stridx('$`"\', l:c) >= 0
+                let l:current .= l:c
+            elseif l:c ==# "\n" " is this even possible?
+                " skip it
+            else
+                let l:current .= '\'.l:c
+            endif
+            let l:state = 3
+        elseif l:state == 5 " single-quoted
+            if l:c ==# "'"
+                let l:state = 1
+            else
+                let l:current .= l:c
+            endif
+        endif
+    endfor
+    if l:state != 0
+        call add(l:args, l:current)
+    endif
+    return l:args
 endfunction
 
 function! s:RmDir(path)
-	" sanity check; make sure it's not empty, /, or $HOME
-	if empty(a:path)
-		echoerr 'Attempted to delete empty path'
-		return 0
-	elseif a:path == '/' || a:path == $HOME
-		echoerr 'Attempted to delete protected path: ' . a:path
-		return 0
-	endif
-	return system("rm -rf " . shellescape(a:path))
+    " sanity check; make sure it's not empty, /, or $HOME
+    if empty(a:path)
+        echoerr 'Attempted to delete empty path'
+        return 0
+    elseif a:path ==# '/' || a:path ==# $HOME
+        let l:path = expand(a:path)
+        if l:path ==# '/' || l:path ==# $HOME
+            echoerr 'Attempted to delete protected path: ' . a:path
+            return 0
+        endif
+    endif
+
+    if !isdirectory(a:path)
+        return 0
+    endif
+
+    " delete() returns 0 when removing file successfully
+    return delete(a:path, 'rf') == 0
 endfunction
 
 " Executes {cmd} with the cwd set to {pwd}, without changing Vim's cwd.
 " If {pwd} is the empty string then it doesn't change the cwd.
 function! s:system(pwd, cmd)
-	let cmd = a:cmd
-	if !empty(a:pwd)
-		let cmd = 'cd ' . shellescape(a:pwd) . ' && ' . cmd
-	endif
-	return system(cmd)
+    let cmd = a:cmd
+    if !empty(a:pwd)
+        let cmd = 'cd ' . shellescape(a:pwd) . ' && ' . cmd
+    endif
+    return system(cmd)
 endfunction
 
 " Playpen Support {{{1
@@ -366,10 +426,10 @@ endfunction
 " http://github.com/mattn/gist-vim
 function! s:has_webapi()
     if !exists("*webapi#http#post")
-	try
-	    call webapi#http#post()
-	catch
-	endtry
+        try
+            call webapi#http#post()
+        catch
+        endtry
     endif
     return exists("*webapi#http#post")
 endfunction
@@ -381,35 +441,130 @@ function! rust#Play(count, line1, line2, ...) abort
     let l:rust_shortener_url = get(g:, 'rust_shortener_url', 'https://is.gd/')
 
     if !s:has_webapi()
-	echohl ErrorMsg | echomsg ':RustPlay depends on webapi.vim (https://github.com/mattn/webapi-vim)' | echohl None
-	return
+        echohl ErrorMsg | echomsg ':RustPlay depends on webapi.vim (https://github.com/mattn/webapi-vim)' | echohl None
+        return
     endif
 
     let bufname = bufname('%')
     if a:count < 1
-	let content = join(getline(a:line1, a:line2), "\n")
+        let content = join(getline(a:line1, a:line2), "\n")
     else
-	let save_regcont = @"
-	let save_regtype = getregtype('"')
-	silent! normal! gvy
-	let content = @"
-	call setreg('"', save_regcont, save_regtype)
+        let save_regcont = @"
+        let save_regtype = getregtype('"')
+        silent! normal! gvy
+        let content = @"
+        call setreg('"', save_regcont, save_regtype)
     endif
 
-    let body = l:rust_playpen_url."?code=".webapi#http#encodeURI(content)
+    let url = l:rust_playpen_url."?code=".webapi#http#encodeURI(content)
 
-    if strlen(body) > 5000
-	echohl ErrorMsg | echomsg 'Buffer too large, max 5000 encoded characters ('.strlen(body).')' | echohl None
-	return
+    if strlen(url) > 5000
+        echohl ErrorMsg | echomsg 'Buffer too large, max 5000 encoded characters ('.strlen(url).')' | echohl None
+        return
     endif
 
-    let payload = "format=simple&url=".webapi#http#encodeURI(body)
+    let payload = "format=simple&url=".webapi#http#encodeURI(url)
     let res = webapi#http#post(l:rust_shortener_url.'create.php', payload, {})
-    let url = res.content
+    if res.status[0] ==# '2'
+        let url = res.content
+    endif
 
-    redraw | echomsg 'Done: '.url
+    let footer = ''
+    if exists('g:rust_clip_command')
+        call system(g:rust_clip_command, url)
+        if !v:shell_error
+            let footer = ' (copied to clipboard)'
+        endif
+    endif
+    redraw | echomsg 'Done: '.url.footer
+endfunction
+
+" Run a test under the cursor or all tests {{{1
+
+" Finds a test function name under the cursor. Returns empty string when a
+" test function is not found.
+function! s:SearchTestFunctionNameUnderCursor() abort
+    let cursor_line = line('.')
+
+    " Find #[test] attribute
+    if search('\m\C#\[test\]', 'bcW') is 0
+        return ''
+    endif
+
+    " Move to an opening brace of the test function
+    let test_func_line = search('\m\C^\s*fn\s\+\h\w*\s*(.\+{$', 'eW')
+    if test_func_line is 0
+        return ''
+    endif
+
+    " Search the end of test function (closing brace) to ensure that the
+    " cursor position is within function definition
+    if maparg('<Plug>(MatchitNormalForward)') ==# ''
+        keepjumps normal! %
+    else
+        " Prefer matchit.vim official plugin to native % since the plugin
+        " provides better behavior than original % (#391)
+        " To load the plugin, run:
+        "   :packadd matchit
+        execute 'keepjumps' 'normal' "\<Plug>(MatchitNormalForward)"
+    endif
+    if line('.') < cursor_line
+        return ''
+    endif
+
+    return matchstr(getline(test_func_line), '\m\C^\s*fn\s\+\zs\h\w*')
+endfunction
+
+function! rust#Test(mods, winsize, all, options) abort
+    let manifest = findfile('Cargo.toml', expand('%:p:h') . ';')
+    if manifest ==# ''
+        return rust#Run(1, '--test ' . a:options)
+    endif
+
+    " <count> defaults to 0, but we prefer an empty string
+    let winsize = a:winsize ? a:winsize : ''
+
+    if has('terminal')
+        if has('patch-8.0.910')
+            let cmd = printf('%s noautocmd %snew | terminal ++curwin ', a:mods, winsize)
+        else
+            let cmd = printf('%s terminal ', a:mods)
+        endif
+    elseif has('nvim')
+        let cmd = printf('%s noautocmd %snew | terminal ', a:mods, winsize)
+    else
+        let cmd = '!'
+        let manifest = shellescape(manifest)
+    endif
+
+    if a:all
+        if a:options ==# ''
+            execute cmd . 'cargo test --manifest-path' manifest
+        else
+            execute cmd . 'cargo test --manifest-path' manifest a:options
+        endif
+        return
+    endif
+
+    let saved = getpos('.')
+    try
+        let func_name = s:SearchTestFunctionNameUnderCursor()
+    finally
+        call setpos('.', saved)
+    endtry
+    if func_name ==# ''
+        echohl ErrorMsg
+        echomsg 'No test function was found under the cursor. Please add ! to command if you want to run all tests'
+        echohl None
+        return
+    endif
+    if a:options ==# ''
+        execute cmd . 'cargo test --manifest-path' manifest func_name
+    else
+        execute cmd . 'cargo test --manifest-path' manifest func_name a:options
+    endif
 endfunction
 
 " }}}1
 
-" vim: set noet sw=8 ts=8:
+" vim: set et sw=4 sts=4 ts=8:

--- a/runtime/autoload/rust/debugging.vim
+++ b/runtime/autoload/rust/debugging.vim
@@ -1,0 +1,105 @@
+" Last Modified: 2023-09-11
+
+" For debugging, inspired by https://github.com/w0rp/rust/blob/master/autoload/rust/debugging.vim
+
+let s:global_variable_list = [
+            \ '_rustfmt_autosave_because_of_config',
+            \ 'ftplugin_rust_source_path',
+            \ 'loaded_syntastic_rust_cargo_checker',
+            \ 'loaded_syntastic_rust_filetype',
+            \ 'loaded_syntastic_rust_rustc_checker',
+            \ 'rust_bang_comment_leader',
+            \ 'rust_cargo_avoid_whole_workspace',
+            \ 'rust_clip_command',
+            \ 'rust_conceal',
+            \ 'rust_conceal_mod_path',
+            \ 'rust_conceal_pub',
+            \ 'rust_fold',
+            \ 'rust_last_args',
+            \ 'rust_last_rustc_args',
+            \ 'rust_original_delimitMate_excluded_regions',
+            \ 'rust_playpen_url',
+            \ 'rust_prev_delimitMate_quotes',
+            \ 'rust_recent_nearest_cargo_tol',
+            \ 'rust_recent_root_cargo_toml',
+            \ 'rust_recommended_style',
+            \ 'rust_set_conceallevel',
+            \ 'rust_set_conceallevel=1',
+            \ 'rust_set_foldmethod',
+            \ 'rust_set_foldmethod=1',
+            \ 'rust_shortener_url',
+            \ 'rustc_makeprg_no_percent',
+            \ 'rustc_path',
+            \ 'rustfmt_autosave',
+            \ 'rustfmt_autosave_if_config_present',
+            \ 'rustfmt_command',
+            \ 'rustfmt_emit_files',
+            \ 'rustfmt_fail_silently',
+            \ 'rustfmt_options',
+            \ 'syntastic_extra_filetypes',
+            \ 'syntastic_rust_cargo_fname',
+            \]
+
+function! s:Echo(message) abort
+    execute 'echo a:message'
+endfunction
+
+function! s:EchoGlobalVariables() abort
+    for l:key in s:global_variable_list
+        if l:key !~# '^_'
+            call s:Echo('let g:' . l:key . ' = ' . string(get(g:, l:key, v:null)))
+        endif
+
+        if has_key(b:, l:key)
+            call s:Echo('let b:' . l:key . ' = ' . string(b:[l:key]))
+        endif
+    endfor
+endfunction
+
+function! rust#debugging#Info() abort
+    call cargo#Load()
+    call rust#Load()
+    call rustfmt#Load()
+    call s:Echo('rust.vim Global Variables:')
+    call s:Echo('')
+    call s:EchoGlobalVariables()
+
+    silent let l:output = system(g:rustfmt_command . ' --version')
+    echo l:output
+
+    let l:rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
+    silent let l:output = system(l:rustc . ' --version')
+    echo l:output
+
+    silent let l:output = system('cargo --version')
+    echo l:output
+
+    version
+
+    if exists(":SyntasticInfo")
+        echo "----"
+        echo "Info from Syntastic:"
+        execute "SyntasticInfo"
+    endif
+endfunction
+
+function! rust#debugging#InfoToClipboard() abort
+    redir @"
+    silent call rust#debugging#Info()
+    redir END
+
+    call s:Echo('RustInfo copied to your clipboard')
+endfunction
+
+function! rust#debugging#InfoToFile(filename) abort
+    let l:expanded_filename = expand(a:filename)
+
+    redir => l:output
+    silent call rust#debugging#Info()
+    redir END
+
+    call writefile(split(l:output, "\n"), l:expanded_filename)
+    call s:Echo('RustInfo written to ' . l:expanded_filename)
+endfunction
+
+" vim: set et sw=4 sts=4 ts=8:

--- a/runtime/autoload/rustfmt.vim
+++ b/runtime/autoload/rustfmt.vim
@@ -1,107 +1,261 @@
 " Author: Stephen Sugden <stephen@stephensugden.com>
+" Last Modified: 2023-09-11
 "
 " Adapted from https://github.com/fatih/vim-go
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if !exists("g:rustfmt_autosave")
-	let g:rustfmt_autosave = 0
+    let g:rustfmt_autosave = 0
 endif
 
 if !exists("g:rustfmt_command")
-	let g:rustfmt_command = "rustfmt"
+    let g:rustfmt_command = "rustfmt"
 endif
 
 if !exists("g:rustfmt_options")
-	let g:rustfmt_options = ""
+    let g:rustfmt_options = ""
 endif
 
 if !exists("g:rustfmt_fail_silently")
-	let g:rustfmt_fail_silently = 0
+    let g:rustfmt_fail_silently = 0
+endif
+
+function! rustfmt#DetectVersion()
+    " Save rustfmt '--help' for feature inspection
+    silent let s:rustfmt_help = system(g:rustfmt_command . " --help")
+    let s:rustfmt_unstable_features = s:rustfmt_help =~# "--unstable-features"
+
+    " Build a comparable rustfmt version varible out of its `--version` output:
+    silent let l:rustfmt_version_full = system(g:rustfmt_command . " --version")
+    let l:rustfmt_version_list = matchlist(l:rustfmt_version_full,
+        \    '\vrustfmt ([0-9]+[.][0-9]+[.][0-9]+)')
+    if len(l:rustfmt_version_list) < 3
+        let s:rustfmt_version = "0"
+    else
+        let s:rustfmt_version = l:rustfmt_version_list[1]
+    endif
+    return s:rustfmt_version
+endfunction
+
+call rustfmt#DetectVersion()
+
+if !exists("g:rustfmt_emit_files")
+    let g:rustfmt_emit_files = s:rustfmt_version >= "0.8.2"
+endif
+
+if !exists("g:rustfmt_file_lines")
+    let g:rustfmt_file_lines = s:rustfmt_help =~# "--file-lines JSON"
 endif
 
 let s:got_fmt_error = 0
 
+function! rustfmt#Load()
+    " Utility call to get this script loaded, for debugging
+endfunction
+
+function! s:RustfmtWriteMode()
+    if g:rustfmt_emit_files
+        return "--emit=files"
+    else
+        return "--write-mode=overwrite"
+    endif
+endfunction
+
+function! s:RustfmtConfigOptions()
+    let l:rustfmt_toml = findfile('rustfmt.toml', expand('%:p:h') . ';')
+    if l:rustfmt_toml !=# ''
+        return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
+    endif
+
+    let l:_rustfmt_toml = findfile('.rustfmt.toml', expand('%:p:h') . ';')
+    if l:_rustfmt_toml !=# ''
+        return '--config-path '.shellescape(fnamemodify(l:_rustfmt_toml, ":p"))
+    endif
+
+    " Default to edition 2018 in case no rustfmt.toml was found.
+    return '--edition 2018'
+endfunction
+
 function! s:RustfmtCommandRange(filename, line1, line2)
-	let l:arg = {"file": shellescape(a:filename), "range": [a:line1, a:line2]}
-	return printf("%s %s --write-mode=overwrite --file-lines '[%s]'", g:rustfmt_command, g:rustfmt_options, json_encode(l:arg))
+    if g:rustfmt_file_lines == 0
+        echo "--file-lines is not supported in the installed `rustfmt` executable"
+        return
+    endif
+
+    let l:arg = {"file": shellescape(a:filename), "range": [a:line1, a:line2]}
+    let l:write_mode = s:RustfmtWriteMode()
+    let l:rustfmt_config = s:RustfmtConfigOptions()
+
+    " FIXME: When --file-lines gets to be stable, add version range checking
+    " accordingly.
+    let l:unstable_features = s:rustfmt_unstable_features ? '--unstable-features' : ''
+
+    let l:cmd = printf("%s %s %s %s %s --file-lines '[%s]' %s", g:rustfmt_command,
+                \ l:write_mode, g:rustfmt_options,
+                \ l:unstable_features, l:rustfmt_config,
+                \ json_encode(l:arg), shellescape(a:filename))
+    return l:cmd
 endfunction
 
-function! s:RustfmtCommand(filename)
-	return g:rustfmt_command . " --write-mode=overwrite " . g:rustfmt_options . " " . shellescape(a:filename)
+function! s:RustfmtCommand()
+    let write_mode = g:rustfmt_emit_files ? '--emit=stdout' : '--write-mode=display'
+    let config = s:RustfmtConfigOptions()
+    return join([g:rustfmt_command, write_mode, config, g:rustfmt_options])
 endfunction
 
-function! s:RunRustfmt(command, curw, tmpname)
-	if exists("*systemlist")
-		let out = systemlist(a:command)
-	else
-		let out = split(system(a:command), '\r\?\n')
-	endif
+function! s:DeleteLines(start, end) abort
+    silent! execute a:start . ',' . a:end . 'delete _'
+endfunction
 
-	if v:shell_error == 0 || v:shell_error == 3
-		" remove undo point caused via BufWritePre
-		try | silent undojoin | catch | endtry
+function! s:RunRustfmt(command, tmpname, from_writepre)
+    let l:view = winsaveview()
 
-		" Replace current file with temp file, then reload buffer
-		call rename(a:tmpname, expand('%'))
-		silent edit!
-		let &syntax = &syntax
+    let l:stderr_tmpname = tempname()
+    call writefile([], l:stderr_tmpname)
 
-		" only clear location list if it was previously filled to prevent
-		" clobbering other additions
-		if s:got_fmt_error
-			let s:got_fmt_error = 0
-			call setloclist(0, [])
-			lwindow
-		endif
-	elseif g:rustfmt_fail_silently == 0
-		" otherwise get the errors and put them in the location list
-		let errors = []
+    let l:command = a:command . ' 2> ' . l:stderr_tmpname
 
-		for line in out
-			" src/lib.rs:13:5: 13:10 error: expected `,`, or `}`, found `value`
-			let tokens = matchlist(line, '^\(.\{-}\):\(\d\+\):\(\d\+\):\s*\(\d\+:\d\+\s*\)\?\s*error: \(.*\)')
-			if !empty(tokens)
-				call add(errors, {"filename": @%,
-						 \"lnum":     tokens[2],
-						 \"col":      tokens[3],
-						 \"text":     tokens[5]})
-			endif
-		endfor
+    if a:tmpname ==# ''
+        " Rustfmt in stdin/stdout mode
 
-		if empty(errors)
-			% | " Couldn't detect rustfmt error format, output errors
-		endif
+        " chdir to the directory of the file
+        let l:has_lcd = haslocaldir()
+        let l:prev_cd = getcwd()
+        execute 'lchdir! '.expand('%:h')
 
-		if !empty(errors)
-			call setloclist(0, errors, 'r')
-			echohl Error | echomsg "rustfmt returned error" | echohl None
-		endif
+        let l:buffer = getline(1, '$')
+        if exists("*systemlist")
+            silent let out = systemlist(l:command, l:buffer)
+        else
+            silent let out = split(system(l:command,
+                        \ join(l:buffer, "\n")), '\r\?\n')
+        endif
+    else
+        if exists("*systemlist")
+            silent let out = systemlist(l:command)
+        else
+            silent let out = split(system(l:command), '\r\?\n')
+        endif
+    endif
 
-		let s:got_fmt_error = 1
-		lwindow
-		" We didn't use the temp file, so clean up
-		call delete(a:tmpname)
-	endif
+    let l:stderr = readfile(l:stderr_tmpname)
 
-	call winrestview(a:curw)
+    call delete(l:stderr_tmpname)
+
+    let l:open_lwindow = 0
+    if v:shell_error == 0
+        if a:from_writepre
+            " remove undo point caused via BufWritePre
+            try | silent undojoin | catch | endtry
+        endif
+
+        if a:tmpname ==# ''
+            let l:content = l:out
+        else
+            " take the tmpfile's content, this is better than rename
+            " because it preserves file modes.
+            let l:content = readfile(a:tmpname)
+        endif
+
+        call s:DeleteLines(len(l:content), line('$'))
+        call setline(1, l:content)
+
+        " only clear location list if it was previously filled to prevent
+        " clobbering other additions
+        if s:got_fmt_error
+            let s:got_fmt_error = 0
+            call setloclist(0, [])
+            let l:open_lwindow = 1
+        endif
+    elseif g:rustfmt_fail_silently == 0 && !a:from_writepre
+        " otherwise get the errors and put them in the location list
+        let l:errors = []
+
+        let l:prev_line = ""
+        for l:line in l:stderr
+            " error: expected one of `;` or `as`, found `extern`
+            "  --> src/main.rs:2:1
+            let tokens = matchlist(l:line, '^\s\+-->\s\(.\{-}\):\(\d\+\):\(\d\+\)$')
+            if !empty(tokens)
+                call add(l:errors, {"filename": @%,
+                            \"lnum":	tokens[2],
+                            \"col":	tokens[3],
+                            \"text":	l:prev_line})
+            endif
+            let l:prev_line = l:line
+        endfor
+
+        if !empty(l:errors)
+            call setloclist(0, l:errors, 'r')
+            echohl Error | echomsg "rustfmt returned error" | echohl None
+        else
+            echo "rust.vim: was not able to parse rustfmt messages. Here is the raw output:"
+            echo "\n"
+            for l:line in l:stderr
+                echo l:line
+            endfor
+        endif
+
+        let s:got_fmt_error = 1
+        let l:open_lwindow = 1
+    endif
+
+    " Restore the current directory if needed
+    if a:tmpname ==# ''
+        if l:has_lcd
+            execute 'lchdir! '.l:prev_cd
+        else
+            execute 'chdir! '.l:prev_cd
+        endif
+    endif
+
+    " Open lwindow after we have changed back to the previous directory
+    if l:open_lwindow == 1
+        lwindow
+    endif
+
+    call winrestview(l:view)
 endfunction
 
 function! rustfmt#FormatRange(line1, line2)
-	let l:curw = winsaveview()
-	let l:tmpname = expand("%:p:h") . "/." . expand("%:p:t") . ".rustfmt"
-	call writefile(getline(1, '$'), l:tmpname)
-
-	let command = s:RustfmtCommandRange(l:tmpname, a:line1, a:line2)
-
-	call s:RunRustfmt(command, l:curw, l:tmpname)
+    let l:tmpname = tempname()
+    call writefile(getline(1, '$'), l:tmpname)
+    let command = s:RustfmtCommandRange(l:tmpname, a:line1, a:line2)
+    call s:RunRustfmt(command, l:tmpname, v:false)
+    call delete(l:tmpname)
 endfunction
 
 function! rustfmt#Format()
-	let l:curw = winsaveview()
-	let l:tmpname = expand("%:p:h") . "/." . expand("%:p:t") . ".rustfmt"
-	call writefile(getline(1, '$'), l:tmpname)
-
-	let command = s:RustfmtCommand(l:tmpname)
-
-	call s:RunRustfmt(command, l:curw, l:tmpname)
+    call s:RunRustfmt(s:RustfmtCommand(), '', v:false)
 endfunction
+
+function! rustfmt#Cmd()
+    " Mainly for debugging
+    return s:RustfmtCommand()
+endfunction
+
+function! rustfmt#PreWrite()
+    if !filereadable(expand("%@"))
+        return
+    endif
+    if rust#GetConfigVar('rustfmt_autosave_if_config_present', 0)
+        if findfile('rustfmt.toml', '.;') !=# '' || findfile('.rustfmt.toml', '.;') !=# ''
+            let b:rustfmt_autosave = 1
+            let b:_rustfmt_autosave_because_of_config = 1
+        endif
+    else
+        if has_key(b:, '_rustfmt_autosave_because_of_config')
+            unlet b:_rustfmt_autosave_because_of_config
+            unlet b:rustfmt_autosave
+        endif
+    endif
+
+    if !rust#GetConfigVar("rustfmt_autosave", 0)
+        return
+    endif
+
+    call s:RunRustfmt(s:RustfmtCommand(), '', v:true)
+endfunction
+
+
+" vim: set et sw=4 sts=4 ts=8:

--- a/runtime/compiler/cargo.vim
+++ b/runtime/compiler/cargo.vim
@@ -1,35 +1,51 @@
 " Vim compiler file
 " Compiler:         Cargo Compiler
 " Maintainer:       Damien Radtke <damienradtke@gmail.com>
-" Latest Revision:  2014 Sep 24
+" Latest Revision:  2023-09-11
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists('current_compiler')
-	finish
+    finish
 endif
 runtime compiler/rustc.vim
 let current_compiler = "cargo"
 
+" vint: -ProhibitAbbreviationOption
 let s:save_cpo = &cpo
 set cpo&vim
+" vint: +ProhibitAbbreviationOption
 
 if exists(':CompilerSet') != 2
-	command -nargs=* CompilerSet setlocal <args>
+    command -nargs=* CompilerSet setlocal <args>
 endif
 
 if exists('g:cargo_makeprg_params')
-	execute 'CompilerSet makeprg=cargo\ '.escape(g:cargo_makeprg_params, ' \|"').'\ $*'
+    execute 'CompilerSet makeprg=cargo\ '.escape(g:cargo_makeprg_params, ' \|"').'\ $*'
 else
-	CompilerSet makeprg=cargo\ $*
+    CompilerSet makeprg=cargo\ $*
 endif
+
+augroup RustCargoQuickFixHooks
+    autocmd!
+    autocmd QuickFixCmdPre make call cargo#quickfix#CmdPre()
+    autocmd QuickFixCmdPost make call cargo#quickfix#CmdPost()
+augroup END
 
 " Ignore general cargo progress messages
 CompilerSet errorformat+=
-			\%-G%\\s%#Downloading%.%#,
-			\%-G%\\s%#Compiling%.%#,
-			\%-G%\\s%#Finished%.%#,
-			\%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
-			\%-G%\\s%#To\ learn\ more\\,%.%#
+            \%-G%\\s%#Downloading%.%#,
+            \%-G%\\s%#Checking%.%#,
+            \%-G%\\s%#Compiling%.%#,
+            \%-G%\\s%#Finished%.%#,
+            \%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
+            \%-G%\\s%#To\ learn\ more\\,%.%#,
+            \%-G%\\s%#For\ more\ information\ about\ this\ error\\,%.%#,
+            \%-Gnote:\ Run\ with\ \`RUST_BACKTRACE=%.%#,
+            \%.%#panicked\ at\ \\'%m\\'\\,\ %f:%l:%c
 
+" vint: -ProhibitAbbreviationOption
 let &cpo = s:save_cpo
 unlet s:save_cpo
+" vint: +ProhibitAbbreviationOption
+
+" vim: set et sw=4 sts=4 ts=8:

--- a/runtime/compiler/rustc.vim
+++ b/runtime/compiler/rustc.vim
@@ -1,46 +1,57 @@
 " Vim compiler file
 " Compiler:         Rust Compiler
 " Maintainer:       Chris Morgan <me@chrismorgan.info>
-" Latest Revision:  2013 Jul 12
+" Latest Revision:  2023-09-11
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("current_compiler")
-	finish
+    finish
 endif
 let current_compiler = "rustc"
 
-let s:cpo_save = &cpo
+" vint: -ProhibitAbbreviationOption
+let s:save_cpo = &cpo
 set cpo&vim
+" vint: +ProhibitAbbreviationOption
 
 if exists(":CompilerSet") != 2
-	command -nargs=* CompilerSet setlocal <args>
+    command -nargs=* CompilerSet setlocal <args>
 endif
 
-if exists("g:rustc_makeprg_no_percent") && g:rustc_makeprg_no_percent != 0
-	CompilerSet makeprg=rustc
+if get(g:, 'rustc_makeprg_no_percent', 0)
+    CompilerSet makeprg=rustc
 else
-	CompilerSet makeprg=rustc\ \%:S
+    if has('patch-7.4.191')
+      CompilerSet makeprg=rustc\ \%:S
+    else
+      CompilerSet makeprg=rustc\ \"%\"
+    endif
 endif
-
-" Old errorformat (before nightly 2016/08/10)
-CompilerSet errorformat=
-			\%f:%l:%c:\ %t%*[^:]:\ %m,
-			\%f:%l:%c:\ %*\\d:%*\\d\ %t%*[^:]:\ %m,
-			\%-G%f:%l\ %s,
-			\%-G%*[\ ]^,
-			\%-G%*[\ ]^%*[~],
-			\%-G%*[\ ]...
 
 " New errorformat (after nightly 2016/08/10)
-CompilerSet errorformat+=
-			\%-G,
-			\%-Gerror:\ aborting\ %.%#,
-			\%-Gerror:\ Could\ not\ compile\ %.%#,
-			\%Eerror:\ %m,
-			\%Eerror[E%n]:\ %m,
-			\%Wwarning:\ %m,
-			\%Inote:\ %m,
-			\%C\ %#-->\ %f:%l:%c
+CompilerSet errorformat=
+            \%-G,
+            \%-Gerror:\ aborting\ %.%#,
+            \%-Gerror:\ Could\ not\ compile\ %.%#,
+            \%Eerror:\ %m,
+            \%Eerror[E%n]:\ %m,
+            \%Wwarning:\ %m,
+            \%Inote:\ %m,
+            \%C\ %#-->\ %f:%l:%c,
+            \%E\ \ left:%m,%C\ right:%m\ %f:%l:%c,%Z
 
-let &cpo = s:cpo_save
-unlet s:cpo_save
+" Old errorformat (before nightly 2016/08/10)
+CompilerSet errorformat+=
+            \%f:%l:%c:\ %t%*[^:]:\ %m,
+            \%f:%l:%c:\ %*\\d:%*\\d\ %t%*[^:]:\ %m,
+            \%-G%f:%l\ %s,
+            \%-G%*[\ ]^,
+            \%-G%*[\ ]^%*[~],
+            \%-G%*[\ ]...
+
+" vint: -ProhibitAbbreviationOption
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vint: +ProhibitAbbreviationOption
+
+" vim: set et sw=4 sts=4 ts=8:

--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -1,70 +1,72 @@
-*ft_rust.txt*	For Vim version 9.0.  Last change: 2022 Oct 17
-
-This is documentation for the Rust filetype plugin.
+*ft_rust.txt*      Filetype plugin for Rust
 
 ==============================================================================
-CONTENTS						      *rust*
+CONTENTS                                                      *rust*
 
-1. Introduction							  |rust-intro|
-2. Settings						       |rust-settings|
-3. Commands						       |rust-commands|
-4. Mappings						       |rust-mappings|
+1. Introduction                                                   |rust-intro|
+2. Settings                                                    |rust-settings|
+3. Commands                                                    |rust-commands|
+4. Mappings                                                    |rust-mappings|
 
 ==============================================================================
-INTRODUCTION							  *rust-intro*
+INTRODUCTION                                                      *rust-intro*
 
 This plugin provides syntax and supporting functionality for the Rust
-filetype.
+filetype. It requires Vim 8 or higher for full functionality. Some commands
+will not work on earlier versions.
 
 ==============================================================================
-SETTINGS						       *rust-settings*
+SETTINGS                                                       *rust-settings*
 
 This plugin has a few variables you can define in your vimrc that change the
 behavior of the plugin.
 
-								*g:rustc_path*
+Some variables can be set buffer local (`:b` prefix), and the buffer local
+will take precedence over the global `g:` counterpart.
+
+                                                                *g:rustc_path*
 g:rustc_path~
 	Set this option to the path to rustc for use in the |:RustRun| and
 	|:RustExpand| commands. If unset, "rustc" will be located in $PATH: >
-	    let g:rustc_path = $HOME .. "/bin/rustc"
+	    let g:rustc_path = $HOME."/bin/rustc"
 <
 
-						  *g:rustc_makeprg_no_percent*
+                                                  *g:rustc_makeprg_no_percent*
 g:rustc_makeprg_no_percent~
 	Set this option to 1 to have 'makeprg' default to "rustc" instead of
 	"rustc %": >
 	    let g:rustc_makeprg_no_percent = 1
 <
 
-							      *g:rust_conceal*
+                                                              *g:rust_conceal*
 g:rust_conceal~
 	Set this option to turn on the basic |conceal| support: >
 	    let g:rust_conceal = 1
 <
 
-						     *g:rust_conceal_mod_path*
+                                                     *g:rust_conceal_mod_path*
 g:rust_conceal_mod_path~
 	Set this option to turn on |conceal| for the path connecting token
 	"::": >
 	    let g:rust_conceal_mod_path = 1
 <
 
-							  *g:rust_conceal_pub*
+                                                          *g:rust_conceal_pub*
 g:rust_conceal_pub~
 	Set this option to turn on |conceal| for the "pub" token: >
 	    let g:rust_conceal_pub = 1
 <
 
-						     *g:rust_recommended_style*
+                                                     *g:rust_recommended_style*
 g:rust_recommended_style~
-	Set this option to enable vim indentation and textwidth settings to
-	conform to style conventions of the rust standard library (i.e. use 4
-	spaces for indents and sets 'textwidth' to 99). This option is enabled
+        Set this option to enable vim indentation and textwidth settings to
+        conform to style conventions of the rust standard library (i.e. use 4
+        spaces for indents and sets 'textwidth' to 99). This option is enabled
 	by default. To disable it: >
 	    let g:rust_recommended_style = 0
 <
 
-								 *g:rust_fold*
+                                                                 *g:rust_fold*
 g:rust_fold~
 	Set this option to turn on |folding|: >
 	    let g:rust_fold = 1
@@ -76,63 +78,303 @@ g:rust_fold~
 	2		Braced blocks are folded. 'foldlevel' is left at the
 			global value (all folds are closed by default).
 
-						  *g:rust_bang_comment_leader*
+                                                  *g:rust_bang_comment_leader*
 g:rust_bang_comment_leader~
 	Set this option to 1 to preserve the leader on multi-line doc comments
 	using the /*! syntax: >
 	    let g:rust_bang_comment_leader = 1
 <
 
-						 *g:ftplugin_rust_source_path*
+                                                *g:rust_use_custom_ctags_defs*
+g:rust_use_custom_ctags_defs~
+	Set this option to 1 if you have customized ctags definitions for Rust
+	and do not wish for those included with rust.vim to be used: >
+	    let g:rust_use_custom_ctags_defs = 1
+<
+
+	NOTE: rust.vim's built-in definitions are only used for the Tagbar Vim
+	plugin, if you have it installed, AND if Universal Ctags is not
+	detected. This is because Universal Ctags already has built-in
+	support for Rust when used with Tagbar.
+
+	Also, note that when using ctags other than Universal Ctags, it is not
+	automatically used when generating |tags| files that Vim can use to
+	navigate to definitions across different source files. Feel free to
+	copy `rust.vim/ctags/rust.ctags` into your own `~/.ctags` if you wish
+	to generate |tags| files.
+
+
+                                                 *g:ftplugin_rust_source_path*
 g:ftplugin_rust_source_path~
 	Set this option to a path that should be prepended to 'path' for Rust
 	source files: >
-	    let g:ftplugin_rust_source_path = $HOME .. '/dev/rust'
+	    let g:ftplugin_rust_source_path = $HOME.'/dev/rust'
 <
 
-						       *g:rustfmt_command*
+                                                       *g:rustfmt_command*
 g:rustfmt_command~
 	Set this option to the name of the 'rustfmt' executable in your $PATH. If
 	not specified it defaults to 'rustfmt' : >
 	    let g:rustfmt_command = 'rustfmt'
 <
-						       *g:rustfmt_autosave*
+                                                       *g:rustfmt_autosave*
 g:rustfmt_autosave~
 	Set this option to 1 to run |:RustFmt| automatically when saving a
 	buffer. If not specified it defaults to 0 : >
 	    let g:rustfmt_autosave = 0
 <
-						       *g:rustfmt_fail_silently*
+	There is also a buffer-local b:rustfmt_autosave that can be set for
+	the same purpose, and can override the global setting.
+
+                                        *g:rustfmt_autosave_if_config_present*
+g:rustfmt_autosave_if_config_present~
+	Set this option to 1 to have *b:rustfmt_autosave* be set automatically
+	if a `rustfmt.toml` file is present in any parent directly leading to
+	the file being edited. If not set, default to 0: >
+	    let g:rustfmt_autosave_if_config_present = 0
+<
+	This is useful to have `rustfmt` only execute on save, on projects
+	that have `rustfmt.toml` configuration.
+
+	There is also a buffer-local b:rustfmt_autosave_if_config_present
+	that can be set for the same purpose, which can overrides the global
+	setting.
+                                                       *g:rustfmt_fail_silently*
 g:rustfmt_fail_silently~
 	Set this option to 1 to prevent 'rustfmt' from populating the
 	|location-list| with errors. If not specified it defaults to 0: >
 	    let g:rustfmt_fail_silently = 0
 <
-						       *g:rustfmt_options*
+                                                       *g:rustfmt_options*
 g:rustfmt_options~
 	Set this option to a string of options to pass to 'rustfmt'. The
 	write-mode is already set to 'overwrite'. If not specified it
 	defaults to '' : >
 	    let g:rustfmt_options = ''
 <
+                                                       *g:rustfmt_emit_files*
+g:rustfmt_emit_files~
+	If not specified rust.vim tries to detect the right parameter to
+	pass to rustfmt based on its reported version. Otherwise, it
+	determines whether to run rustfmt with '--emit=files' (when 1 is
+	provided) instead of '--write-mode=overwrite'. >
+	    let g:rustfmt_emit_files = 0
 
-							  *g:rust_playpen_url*
+
+                                                          *g:rust_playpen_url*
 g:rust_playpen_url~
-	Set this option to override the URL for the playpen to use: >
+	Set this option to override the url for the playpen to use: >
 	    let g:rust_playpen_url = 'https://play.rust-lang.org/'
 <
 
-							*g:rust_shortener_url*
+                                                        *g:rust_shortener_url*
 g:rust_shortener_url~
-	Set this option to override the URL for the URL shortener: >
+	Set this option to override the url for the url shortener: >
 	    let g:rust_shortener_url = 'https://is.gd/'
 <
 
+                                                        *g:rust_clip_command*
+g:rust_clip_command~
+	Set this option to the command used in your OS to copy the Rust Play
+	url to the clipboard: >
+	    let g:rust_clip_command = 'xclip -selection clipboard'
+<
+
+                                                       *g:cargo_makeprg_params*
+g:cargo_makeprg_params~
+	Set this option to the string of parameters to pass to cargo. If not
+	specified it defaults to '$*' : >
+	    let g:cargo_makeprg_params = 'build'
+<
+
+                                                  *g:cargo_shell_command_runner*
+g:cargo_shell_command_runner~
+	Set this option to change how to run shell commands for cargo commands
+	|:Cargo|, |:Cbuild|, |:Crun|, ...
+	By default, |:terminal| is used to run shell command in terminal window
+	asynchronously. But if you prefer |:!| for running the commands, it can
+	be specified: >
+	    let g:cargo_shell_command_runner = '!'
+<
+
+
+Integration with Syntastic                                    *rust-syntastic*
+--------------------------
+
+This plugin automatically integrates with the Syntastic checker. There are two
+checkers provided: 'rustc', and 'cargo'. The latter invokes 'Cargo' in order to
+build code, and the former delivers a single edited '.rs' file as a compilation
+target directly to the Rust compiler, `rustc`.
+
+Because Cargo is almost exclusively being used for building Rust code these
+days, 'cargo' is the default checker. >
+
+    let g:syntastic_rust_checkers = ['cargo']
+<
+If you would like to change it, you can set `g:syntastic_rust_checkers` to a
+different value.
+                                          *g:rust_cargo_avoid_whole_workspace*
+                                          *b:rust_cargo_avoid_whole_workspace*
+g:rust_cargo_avoid_whole_workspace~
+	When editing a crate that is part of a Cargo workspace, and this
+	option is set to 1 (the default), then 'cargo' will be executed
+	directly in that crate directory instead of in the workspace
+	directory. Setting 0 prevents this behavior - however be aware that if
+	you are working in large workspace, Cargo commands may take more time,
+	plus the Syntastic error list may include all the crates in the
+	workspace. >
+            let g:rust_cargo_avoid_whole_workspace = 0
+<
+                                              *g:rust_cargo_check_all_targets*
+                                              *b:rust_cargo_check_all_targets*
+g:rust_cargo_check_all_targets~
+	When set to 1, the `--all-targets` option will be passed to cargo when
+	Syntastic executes it, allowing the linting of all targets under the
+	package.
+	The default is 0.
+
+                                              *g:rust_cargo_check_all_features*
+                                              *b:rust_cargo_check_all_features*
+g:rust_cargo_check_all_features~
+	When set to 1, the `--all-features` option will be passed to cargo when
+	Syntastic executes it, allowing the linting of all features of the
+	package.
+	The default is 0.
+
+                                                 *g:rust_cargo_check_examples*
+                                                 *b:rust_cargo_check_examples*
+g:rust_cargo_check_examples~
+	When set to 1, the `--examples` option will be passed to cargo when
+	Syntastic executes it, to prevent the exclusion of examples from
+	linting. The examples are normally under the `examples/` directory of
+	the crate.
+	The default is 0.
+
+                                                    *g:rust_cargo_check_tests*
+                                                    *b:rust_cargo_check_tests*
+g:rust_cargo_check_tests~
+	When set to 1, the `--tests` option will be passed to cargo when
+	Syntastic executes it, to prevent the exclusion of tests from linting.
+	The tests are normally under the `tests/` directory of the crate.
+	The default is 0.
+
+                                                  *g:rust_cargo_check_benches*
+                                                  *b:rust_cargo_check_benches*
+g:rust_cargo_check_benches~
+	When set to 1, the `--benches` option will be passed to cargo when
+	Syntastic executes it.  The benches are normally under the `benches/`
+	directory of the crate.
+	The default is 0.
+
+Integration with auto-pairs                                    *rust-auto-pairs*
+---------------------------
+
+This plugin automatically configures the auto-pairs plugin not to duplicate
+single quotes, which are used more often for lifetime annotations than for
+single character literals.
+
+                                                  *g:rust_keep_autopairs_default*
+g:rust_keep_autopairs_default~
+
+	Don't override auto-pairs default for the Rust filetype. The default
+	is 0.
 
 ==============================================================================
-COMMANDS						       *rust-commands*
+COMMANDS                                                       *rust-commands*
 
-:RustRun  [args]						    *:RustRun*
+Invoking Cargo
+--------------
+
+This plug defines very simple shortcuts for invoking Cargo from with Vim.
+
+:Cargo <args>                                                       *:Cargo*
+                Runs 'cargo' with the provided arguments.
+
+:Cbuild <args>                                                     *:Cbuild*
+                Shortcut for 'cargo build`.
+
+:Cclean <args>                                                     *:Cclean*
+                Shortcut for 'cargo clean`.
+
+:Cdoc <args>                                                         *:Cdoc*
+                Shortcut for 'cargo doc`.
+
+:Cinit <args>                                                       *:Cinit*
+                Shortcut for 'cargo init`.
+
+:Crun <args>                                                         *:Crun*
+                Shortcut for 'cargo run`.
+
+:Ctest <args>                                                       *:Ctest*
+                Shortcut for 'cargo test`.
+
+:Cupdate <args>                                                   *:Cupdate*
+                Shortcut for 'cargo update`.
+
+:Cbench <args>                                                     *:Cbench*
+                Shortcut for 'cargo bench`.
+
+:Csearch <args>                                                   *:Csearch*
+                Shortcut for 'cargo search`.
+
+:Cpublish <args>                                                 *:Cpublish*
+                Shortcut for 'cargo publish`.
+
+:Cinstall <args>                                                 *:Cinstall*
+                Shortcut for 'cargo install`.
+
+:Cruntarget <args>                                                 *:Cruntarget*
+                Shortcut for 'cargo run --bin' or 'cargo run --example',
+                depending on the currently open buffer.
+
+Formatting
+----------
+
+:RustFmt                                                       *:RustFmt*
+		Runs |g:rustfmt_command| on the current buffer. If
+		|g:rustfmt_options| is set then those will be passed to the
+		executable.
+
+		If |g:rustfmt_fail_silently| is 0 (the default) then it
+		will populate the |location-list| with the errors from
+		|g:rustfmt_command|. If |g:rustfmt_fail_silently| is set to 1
+		then it will not populate the |location-list|.
+
+:RustFmtRange                                                  *:RustFmtRange*
+		Runs |g:rustfmt_command| with selected range. See
+		|:RustFmt| for any other information.
+
+
+Playpen integration
+-------------------
+
+:RustPlay                                                          *:RustPlay*
+		This command will only work if you have web-api.vim installed
+		(available at https://github.com/mattn/webapi-vim).  It sends the
+		current selection, or if nothing is selected, the entirety of the
+		current buffer to the Rust playpen, and emits a message with the
+		shortened URL to the playpen.
+
+		|g:rust_playpen_url| is the base URL to the playpen, by default
+		"https://play.rust-lang.org/".
+
+		|g:rust_shortener_url| is the base url for the shorterner, by
+		default "https://is.gd/"
+
+		|g:rust_clip_command| is the command to run to copy the
+		playpen url to the clipboard of your system.
+
+
+Evaluation of a single Rust file
+--------------------------------
+
+NOTE: These commands are useful only when working with standalone Rust files,
+which is usually not the case for common Rust development. If you wish to
+building Rust crates from with Vim can should use Vim's make, Syntastic, or
+functionality from other plugins.
+
+
+:RustRun  [args]                                                    *:RustRun*
 :RustRun! [rustc-args] [--] [args]
 		Compiles and runs the current file. If it has unsaved changes,
 		it will be saved first using |:update|. If the current file is
@@ -150,7 +392,7 @@ COMMANDS						       *rust-commands*
 		If |g:rustc_path| is defined, it is used as the path to rustc.
 		Otherwise it is assumed rustc can be found in $PATH.
 
-:RustExpand  [args]						 *:RustExpand*
+:RustExpand  [args]                                              *:RustExpand*
 :RustExpand! [TYPE] [args]
 		Expands the current file using --pretty and displays the
 		results in a new split. If the current file has unsaved
@@ -169,7 +411,7 @@ COMMANDS						       *rust-commands*
 		If |g:rustc_path| is defined, it is used as the path to rustc.
 		Otherwise it is assumed rustc can be found in $PATH.
 
-:RustEmitIr [args]						 *:RustEmitIr*
+:RustEmitIr [args]                                               *:RustEmitIr*
 		Compiles the current file to LLVM IR and displays the results
 		in a new split. If the current file has unsaved changes, it
 		will be saved first using |:update|. If the current file is an
@@ -180,7 +422,7 @@ COMMANDS						       *rust-commands*
 		If |g:rustc_path| is defined, it is used as the path to rustc.
 		Otherwise it is assumed rustc can be found in $PATH.
 
-:RustEmitAsm [args]						*:RustEmitAsm*
+:RustEmitAsm [args]                                             *:RustEmitAsm*
 		Compiles the current file to assembly and displays the results
 		in a new split. If the current file has unsaved changes, it
 		will be saved first using |:update|. If the current file is an
@@ -191,49 +433,54 @@ COMMANDS						       *rust-commands*
 		If |g:rustc_path| is defined, it is used as the path to rustc.
 		Otherwise it is assumed rustc can be found in $PATH.
 
-:RustPlay							   *:RustPlay*
-		This command will only work if you have web-api.vim installed
-		(available at https://github.com/mattn/webapi-vim).  It sends the
-		current selection, or if nothing is selected, the entirety of the
-		current buffer to the Rust playpen, and emits a message with the
-		shortened URL to the playpen.
 
-		|g:rust_playpen_url| is the base URL to the playpen, by default
-		"https://play.rust-lang.org/".
+Running test(s)
+---------------
 
-		|g:rust_shortener_url| is the base URL for the shortener, by
-		default "https://is.gd/"
+:[N]RustTest[!] [options]                                       *:RustTest*
+		Runs a test under the cursor when the current buffer is in a
+		cargo project with "cargo test" command. If the command did
+		not find any test function under the cursor, it stops with an
+		error message.
 
-:RustFmt						       *:RustFmt*
-		Runs |g:rustfmt_command| on the current buffer. If
-		|g:rustfmt_options| is set then those will be passed to the
-		executable.
+		When N is given, adjust the size of the new window to N lines
+		or columns.
 
-		If |g:rustfmt_fail_silently| is 0 (the default) then it
-		will populate the |location-list| with the errors from
-		|g:rustfmt_command|. If |g:rustfmt_fail_silently| is set to 1
-		then it will not populate the |location-list|.
+		When ! is given, runs all tests regardless of current cursor
+		position.
 
-:RustFmtRange						       *:RustFmtRange*
-		Runs |g:rustfmt_command| with selected range. See
-		|:RustFmt| for any other information.
+		When [options] is given, it is passed to "cargo" command
+		arguments.
+
+		When the current buffer is outside cargo project, the command
+		runs "rustc --test" command instead of "cargo test" as
+		fallback. All tests are run regardless of adding ! since there
+		is no way to run specific test function with rustc. [options]
+		is passed to "rustc" command arguments in the case.
+
+		Takes optional modifiers (see |<mods>|):  >
+		    :tab RustTest
+		    :belowright 16RustTest
+		    :leftabove vert 80RustTest
+<
+rust.vim Debugging
+------------------
+
+:RustInfo                                                          *:RustInfo*
+		Emits debugging info of the Vim Rust plugin.
+
+:RustInfoToClipboard                                      *:RustInfoClipboard*
+		Saves debugging info of the Vim Rust plugin to the default
+		register.
+
+:RustInfoToFile [filename]                                   *:RustInfoToFile*
+		Saves debugging info of the Vim Rust plugin to the the given
+		file, overwritting it.
 
 ==============================================================================
-MAPPINGS						       *rust-mappings*
+MAPPINGS                                                       *rust-mappings*
 
 This plugin defines mappings for |[[| and |]]| to support hanging indents.
 
-It also has a few other mappings:
-
-							*rust_<D-r>*
-<D-r>			Executes |:RustRun| with no arguments.
-			Note: This binding is only available in MacVim.
-
-							*rust_<D-R>*
-<D-R>			Populates the command line with |:RustRun|! using the
-			arguments given to the last invocation, but does not
-			execute it.
-			Note: This binding is only available in MacVim.
-
 ==============================================================================
- vim:tw=78:sw=4:ts=8:noet:ft=help:norl:
+ vim:tw=78:sw=4:noet:ts=8:ft=help:norl:

--- a/runtime/ftplugin/rust.vim
+++ b/runtime/ftplugin/rust.vim
@@ -1,20 +1,26 @@
 " Language:     Rust
 " Description:  Vim ftplugin for Rust
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
-" Maintainer:   Lily Ballard <lily@ballards.net>
-" Last Change:  June 08, 2016
-" For bugs, patches and license go to https://github.com/rust-lang/rust.vim 
+" Last Change:  2023-09-11
+" For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("b:did_ftplugin")
-	finish
+    finish
 endif
 let b:did_ftplugin = 1
 
+" vint: -ProhibitAbbreviationOption
 let s:save_cpo = &cpo
 set cpo&vim
+" vint: +ProhibitAbbreviationOption
 
-augroup rust.vim
-autocmd!
+if get(b:, 'current_compiler', '') ==# ''
+    if strlen(findfile('Cargo.toml', '.;')) > 0
+        compiler cargo
+    else
+        compiler rustc
+    endif
+endif
 
 " Variables {{{1
 
@@ -22,13 +28,13 @@ autocmd!
 " comments, so we'll use that as our default, but make it easy to switch.
 " This does not affect indentation at all (I tested it with and without
 " leader), merely whether a leader is inserted by default or not.
-if exists("g:rust_bang_comment_leader") && g:rust_bang_comment_leader != 0
-	" Why is the `,s0:/*,mb:\ ,ex:*/` there, you ask? I don't understand why,
-	" but without it, */ gets indented one space even if there were no
-	" leaders. I'm fairly sure that's a Vim bug.
-	setlocal comments=s1:/*,mb:*,ex:*/,s0:/*,mb:\ ,ex:*/,:///,://!,://
+if get(g:, 'rust_bang_comment_leader', 0)
+    " Why is the `,s0:/*,mb:\ ,ex:*/` there, you ask? I don't understand why,
+    " but without it, */ gets indented one space even if there were no
+    " leaders. I'm fairly sure that's a Vim bug.
+    setlocal comments=s1:/*,mb:*,ex:*/,s0:/*,mb:\ ,ex:*/,:///,://!,://
 else
-	setlocal comments=s0:/*!,m:\ ,ex:*/,s1:/*,mb:*,ex:*/,:///,://!,://
+    setlocal comments=s0:/*!,ex:*/,s1:/*,mb:*,ex:*/,:///,://!,://
 endif
 setlocal commentstring=//%s
 setlocal formatoptions-=t formatoptions+=croqnl
@@ -39,13 +45,14 @@ silent! setlocal formatoptions+=j
 " otherwise it's better than nothing.
 setlocal smartindent nocindent
 
-if !exists("g:rust_recommended_style") || g:rust_recommended_style != 0
-	setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtab
-	setlocal textwidth=99
+if get(g:, 'rust_recommended_style', 1)
+    let b:rust_set_style = 1
+    setlocal shiftwidth=4 softtabstop=4 expandtab
+    setlocal textwidth=99
 endif
 
-" This includeexpr isn't perfect, but it's a good start
-setlocal includeexpr=substitute(v:fname,'::','/','g')
+setlocal include=\\v^\\s*(pub\\s+)?use\\s+\\zs(\\f\|:)+
+setlocal includeexpr=rust#IncludeExpr(v:fname)
 
 setlocal suffixesadd=.rs
 
@@ -54,51 +61,36 @@ if exists("g:ftplugin_rust_source_path")
 endif
 
 if exists("g:loaded_delimitMate")
-	if exists("b:delimitMate_excluded_regions")
-		let b:rust_original_delimitMate_excluded_regions = b:delimitMate_excluded_regions
-	endif
+    if exists("b:delimitMate_excluded_regions")
+        let b:rust_original_delimitMate_excluded_regions = b:delimitMate_excluded_regions
+    endif
 
-	let s:delimitMate_extra_excluded_regions = ',rustLifetimeCandidate,rustGenericLifetimeCandidate'
+    augroup rust.vim.DelimitMate
+        autocmd!
 
-	" For this buffer, when delimitMate issues the `User delimitMate_map`
-	" event in the autocommand system, add the above-defined extra excluded
-	" regions to delimitMate's state, if they have not already been added.
-	autocmd User <buffer>
-		\ if expand('<afile>') ==# 'delimitMate_map' && match(
-		\     delimitMate#Get("excluded_regions"),
-		\     s:delimitMate_extra_excluded_regions) == -1
-		\|  let b:delimitMate_excluded_regions =
-		\       delimitMate#Get("excluded_regions")
-		\       . s:delimitMate_extra_excluded_regions
-		\|endif
-
-	" For this buffer, when delimitMate issues the `User delimitMate_unmap`
-	" event in the autocommand system, delete the above-defined extra excluded
-	" regions from delimitMate's state (the deletion being idempotent and
-	" having no effect if the extra excluded regions are not present in the
-	" targeted part of delimitMate's state).
-	autocmd User <buffer>
-		\ if expand('<afile>') ==# 'delimitMate_unmap'
-		\|  let b:delimitMate_excluded_regions = substitute(
-		\       delimitMate#Get("excluded_regions"),
-		\       '\C\V' . s:delimitMate_extra_excluded_regions,
-		\       '', 'g')
-		\|endif
+        autocmd User delimitMate_map   :call rust#delimitmate#onMap()
+        autocmd User delimitMate_unmap :call rust#delimitmate#onUnmap()
+    augroup END
 endif
 
-if has("folding") && exists('g:rust_fold') && g:rust_fold != 0
-	let b:rust_set_foldmethod=1
-	setlocal foldmethod=syntax
-	if g:rust_fold == 2
-		setlocal foldlevel<
-	else
-		setlocal foldlevel=99
-	endif
+" Integration with auto-pairs (https://github.com/jiangmiao/auto-pairs)
+if exists("g:AutoPairsLoaded") && !get(g:, 'rust_keep_autopairs_default', 0)
+    let b:AutoPairs = {'(':')', '[':']', '{':'}','"':'"', '`':'`'}
 endif
 
-if has('conceal') && exists('g:rust_conceal') && g:rust_conceal != 0
-	let b:rust_set_conceallevel=1
-	setlocal conceallevel=2
+if has("folding") && get(g:, 'rust_fold', 0)
+    let b:rust_set_foldmethod=1
+    setlocal foldmethod=syntax
+    if g:rust_fold == 2
+        setlocal foldlevel<
+    else
+        setlocal foldlevel=99
+    endif
+endif
+
+if has('conceal') && get(g:, 'rust_conceal', 0)
+    let b:rust_set_conceallevel=1
+    setlocal conceallevel=2
 endif
 
 " Motion Commands {{{1
@@ -126,72 +118,122 @@ command! -nargs=* -buffer RustEmitIr call rust#Emit("llvm-ir", <q-args>)
 command! -nargs=* -buffer RustEmitAsm call rust#Emit("asm", <q-args>)
 
 " See |:RustPlay| for docs
-command! -range=% RustPlay :call rust#Play(<count>, <line1>, <line2>, <f-args>)
+command! -range=% -buffer RustPlay :call rust#Play(<count>, <line1>, <line2>, <f-args>)
 
 " See |:RustFmt| for docs
-command! -buffer RustFmt call rustfmt#Format()
+command! -bar -buffer RustFmt call rustfmt#Format()
 
 " See |:RustFmtRange| for docs
 command! -range -buffer RustFmtRange call rustfmt#FormatRange(<line1>, <line2>)
 
-" Mappings {{{1
+" See |:RustInfo| for docs
+command! -bar -buffer RustInfo call rust#debugging#Info()
 
-" Bind ⌘R in MacVim to :RustRun
-nnoremap <silent> <buffer> <D-r> :RustRun<CR>
-" Bind ⌘⇧R in MacVim to :RustRun! pre-filled with the last args
-nnoremap <buffer> <D-R> :RustRun! <C-r>=join(b:rust_last_rustc_args)<CR><C-\>erust#AppendCmdLine(' -- ' . join(b:rust_last_args))<CR>
+" See |:RustInfoToClipboard| for docs
+command! -bar -buffer RustInfoToClipboard call rust#debugging#InfoToClipboard()
+
+" See |:RustInfoToFile| for docs
+command! -bar -nargs=1 -buffer RustInfoToFile call rust#debugging#InfoToFile(<f-args>)
+
+" See |:RustTest| for docs
+command! -buffer -nargs=* -count -bang RustTest call rust#Test(<q-mods>, <count>, <bang>0, <q-args>)
 
 if !exists("b:rust_last_rustc_args") || !exists("b:rust_last_args")
-	let b:rust_last_rustc_args = []
-	let b:rust_last_args = []
+    let b:rust_last_rustc_args = []
+    let b:rust_last_args = []
 endif
 
 " Cleanup {{{1
 
 let b:undo_ftplugin = "
-		\ setlocal formatoptions< comments< commentstring< includeexpr< suffixesadd<
-		\|setlocal tabstop< shiftwidth< softtabstop< expandtab< textwidth<
-		\|if exists('b:rust_original_delimitMate_excluded_regions')
-		  \|let b:delimitMate_excluded_regions = b:rust_original_delimitMate_excluded_regions
-		  \|unlet b:rust_original_delimitMate_excluded_regions
-		\|else
-		  \|unlet! b:delimitMate_excluded_regions
-		\|endif
-		\|if exists('b:rust_set_foldmethod')
-		  \|setlocal foldmethod< foldlevel<
-		  \|unlet b:rust_set_foldmethod
-		\|endif
-		\|if exists('b:rust_set_conceallevel')
-		  \|setlocal conceallevel<
-		  \|unlet b:rust_set_conceallevel
-		\|endif
-		\|unlet! b:rust_last_rustc_args b:rust_last_args
-		\|delcommand RustRun
-		\|delcommand RustExpand
-		\|delcommand RustEmitIr
-		\|delcommand RustEmitAsm
-		\|delcommand RustPlay
-		\|nunmap <buffer> <D-r>
-		\|nunmap <buffer> <D-R>
-		\|nunmap <buffer> [[
-		\|nunmap <buffer> ]]
-		\|xunmap <buffer> [[
-		\|xunmap <buffer> ]]
-		\|ounmap <buffer> [[
-		\|ounmap <buffer> ]]
-		\|set matchpairs-=<:>
-		\"
+            \ setlocal formatoptions< comments< commentstring< include< includeexpr< suffixesadd<
+            \|if exists('b:rust_set_style')
+                \|setlocal tabstop< shiftwidth< softtabstop< expandtab< textwidth<
+                \|endif
+                \|if exists('b:rust_original_delimitMate_excluded_regions')
+                    \|let b:delimitMate_excluded_regions = b:rust_original_delimitMate_excluded_regions
+                    \|unlet b:rust_original_delimitMate_excluded_regions
+                    \|else
+                        \|unlet! b:delimitMate_excluded_regions
+                        \|endif
+                        \|if exists('b:rust_set_foldmethod')
+                            \|setlocal foldmethod< foldlevel<
+                            \|unlet b:rust_set_foldmethod
+                            \|endif
+                            \|if exists('b:rust_set_conceallevel')
+                                \|setlocal conceallevel<
+                                \|unlet b:rust_set_conceallevel
+                                \|endif
+                                \|unlet! b:rust_last_rustc_args b:rust_last_args
+                                \|delcommand -buffer RustRun
+                                \|delcommand -buffer RustExpand
+                                \|delcommand -buffer RustEmitIr
+                                \|delcommand -buffer RustEmitAsm
+                                \|delcommand -buffer RustPlay
+                                \|delcommand -buffer RustFmt
+                                \|delcommand -buffer RustFmtRange
+                                \|delcommand -buffer RustInfo
+                                \|delcommand -buffer RustInfoToClipboard
+                                \|delcommand -buffer RustInfoToFile
+                                \|delcommand -buffer RustTest
+                                \|nunmap <buffer> [[
+                                \|nunmap <buffer> ]]
+                                \|xunmap <buffer> [[
+                                \|xunmap <buffer> ]]
+                                \|ounmap <buffer> [[
+                                \|ounmap <buffer> ]]
+                                \|setlocal matchpairs-=<:>
+                                \|unlet b:match_skip
+                                \"
 
 " }}}1
 
 " Code formatting on save
-if get(g:, "rustfmt_autosave", 0)
-	autocmd BufWritePre *.rs silent! call rustfmt#Format()
-endif
-
+augroup rust.vim.PreWrite
+    autocmd!
+    autocmd BufWritePre *.rs silent! call rustfmt#PreWrite()
 augroup END
 
+setlocal matchpairs+=<:>
+" For matchit.vim (rustArrow stops `Fn() -> X` messing things up)
+let b:match_skip = 's:comment\|string\|rustCharacter\|rustArrow'
+
+command! -buffer -nargs=+ Cargo call cargo#cmd(<q-args>)
+command! -buffer -nargs=* Cbuild call cargo#build(<q-args>)
+command! -buffer -nargs=* Ccheck call cargo#check(<q-args>)
+command! -buffer -nargs=* Cclean call cargo#clean(<q-args>)
+command! -buffer -nargs=* Cdoc call cargo#doc(<q-args>)
+command! -buffer -nargs=+ Cnew call cargo#new(<q-args>)
+command! -buffer -nargs=* Cinit call cargo#init(<q-args>)
+command! -buffer -nargs=* Crun call cargo#run(<q-args>)
+command! -buffer -nargs=* Ctest call cargo#test(<q-args>)
+command! -buffer -nargs=* Cbench call cargo#bench(<q-args>)
+command! -buffer -nargs=* Cupdate call cargo#update(<q-args>)
+command! -buffer -nargs=* Csearch  call cargo#search(<q-args>)
+command! -buffer -nargs=* Cpublish call cargo#publish(<q-args>)
+command! -buffer -nargs=* Cinstall call cargo#install(<q-args>)
+command! -buffer -nargs=* Cruntarget call cargo#runtarget(<q-args>)
+
+let b:undo_ftplugin .= '
+            \|delcommand -buffer Cargo
+            \|delcommand -buffer Cbuild
+            \|delcommand -buffer Ccheck
+            \|delcommand -buffer Cclean
+            \|delcommand -buffer Cdoc
+            \|delcommand -buffer Cnew
+            \|delcommand -buffer Cinit
+            \|delcommand -buffer Crun
+            \|delcommand -buffer Ctest
+            \|delcommand -buffer Cbench
+            \|delcommand -buffer Cupdate
+            \|delcommand -buffer Csearch
+            \|delcommand -buffer Cpublish
+            \|delcommand -buffer Cinstall
+            \|delcommand -buffer Cruntarget'
+
+" vint: -ProhibitAbbreviationOption
 let &cpo = s:save_cpo
 unlet s:save_cpo
+" vint: +ProhibitAbbreviationOption
 
-" vim: set noet sw=8 ts=8:
+" vim: set et sw=4 sts=4 ts=8:

--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -1,27 +1,26 @@
 " Vim indent file
 " Language:         Rust
 " Author:           Chris Morgan <me@chrismorgan.info>
-" Last Change:      2017 Jun 13
-"                   2023 Aug 28 by Vim Project (undo_indent)
+" Last Change:      2023-09-11
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
-	finish
+    finish
 endif
 let b:did_indent = 1
 
 setlocal cindent
-setlocal cinoptions=L0,(0,Ws,J1,j1
-setlocal cinkeys=0{,0},!^F,o,O,0[,0]
+setlocal cinoptions=L0,(s,Ws,J1,j1,m1
+setlocal cinkeys=0{,0},!^F,o,O,0[,0],0(,0)
 " Don't think cinwords will actually do anything at all... never mind
-setlocal cinwords=for,if,else,while,loop,impl,mod,unsafe,trait,struct,enum,fn,extern
+setlocal cinwords=for,if,else,while,loop,impl,mod,unsafe,trait,struct,enum,fn,extern,macro
 
 " Some preliminary settings
 setlocal nolisp		" Make sure lisp indenting doesn't supersede us
 setlocal autoindent	" indentexpr isn't much help otherwise
 " Also do indentkeys, otherwise # gets shoved to column 0 :-/
-setlocal indentkeys=0{,0},!^F,o,O,0[,0]
+setlocal indentkeys=0{,0},!^F,o,O,0[,0],0(,0)
 
 setlocal indentexpr=GetRustIndent(v:lnum)
 
@@ -29,204 +28,259 @@ let b:undo_indent = "setlocal cindent< cinoptions< cinkeys< cinwords< lisp< auto
 
 " Only define the function once.
 if exists("*GetRustIndent")
-	finish
+    finish
 endif
 
+" vint: -ProhibitAbbreviationOption
 let s:save_cpo = &cpo
 set cpo&vim
+" vint: +ProhibitAbbreviationOption
 
 " Come here when loading the script the first time.
 
 function! s:get_line_trimmed(lnum)
-	" Get the line and remove a trailing comment.
-	" Use syntax highlighting attributes when possible.
-	" NOTE: this is not accurate; /* */ or a line continuation could trick it
-	let line = getline(a:lnum)
-	let line_len = strlen(line)
-	if has('syntax_items')
-		" If the last character in the line is a comment, do a binary search for
-		" the start of the comment.  synID() is slow, a linear search would take
-		" too long on a long line.
-		if synIDattr(synID(a:lnum, line_len, 1), "name") =~ 'Comment\|Todo'
-			let min = 1
-			let max = line_len
-			while min < max
-				let col = (min + max) / 2
-				if synIDattr(synID(a:lnum, col, 1), "name") =~ 'Comment\|Todo'
-					let max = col
-				else
-					let min = col + 1
-				endif
-			endwhile
-			let line = strpart(line, 0, min - 1)
-		endif
-		return substitute(line, "\s*$", "", "")
-	else
-		" Sorry, this is not complete, nor fully correct (e.g. string "//").
-		" Such is life.
-		return substitute(line, "\s*//.*$", "", "")
-	endif
+    " Get the line and remove a trailing comment.
+    " Use syntax highlighting attributes when possible.
+    " NOTE: this is not accurate; /* */ or a line continuation could trick it
+    let line = getline(a:lnum)
+    let line_len = strlen(line)
+    if has('syntax_items')
+        " If the last character in the line is a comment, do a binary search for
+        " the start of the comment.  synID() is slow, a linear search would take
+        " too long on a long line.
+        if synIDattr(synID(a:lnum, line_len, 1), "name") =~? 'Comment\|Todo'
+            let min = 1
+            let max = line_len
+            while min < max
+                let col = (min + max) / 2
+                if synIDattr(synID(a:lnum, col, 1), "name") =~? 'Comment\|Todo'
+                    let max = col
+                else
+                    let min = col + 1
+                endif
+            endwhile
+            let line = strpart(line, 0, min - 1)
+        endif
+        return substitute(line, "\s*$", "", "")
+    else
+        " Sorry, this is not complete, nor fully correct (e.g. string "//").
+        " Such is life.
+        return substitute(line, "\s*//.*$", "", "")
+    endif
 endfunction
 
 function! s:is_string_comment(lnum, col)
-	if has('syntax_items')
-		for id in synstack(a:lnum, a:col)
-			let synname = synIDattr(id, "name")
-			if synname == "rustString" || synname =~ "^rustComment"
-				return 1
-			endif
-		endfor
-	else
-		" without syntax, let's not even try
-		return 0
-	endif
+    if has('syntax_items')
+        for id in synstack(a:lnum, a:col)
+            let synname = synIDattr(id, "name")
+            if synname ==# "rustString" || synname =~# "^rustComment"
+                return 1
+            endif
+        endfor
+    else
+        " without syntax, let's not even try
+        return 0
+    endif
 endfunction
+
+if exists('*shiftwidth')
+    function! s:shiftwidth()
+        return shiftwidth()
+    endfunc
+else
+    function! s:shiftwidth()
+        return &shiftwidth
+    endfunc
+endif
 
 function GetRustIndent(lnum)
+    " Starting assumption: cindent (called at the end) will do it right
+    " normally. We just want to fix up a few cases.
 
-	" Starting assumption: cindent (called at the end) will do it right
-	" normally. We just want to fix up a few cases.
+    let line = getline(a:lnum)
 
-	let line = getline(a:lnum)
+    if has('syntax_items')
+        let synname = synIDattr(synID(a:lnum, 1, 1), "name")
+        if synname ==# "rustString"
+            " If the start of the line is in a string, don't change the indent
+            return -1
+        elseif synname =~? '\(Comment\|Todo\)'
+                    \ && line !~# '^\s*/\*'  " not /* opening line
+            if synname =~? "CommentML" " multi-line
+                if line !~# '^\s*\*' && getline(a:lnum - 1) =~# '^\s*/\*'
+                    " This is (hopefully) the line after a /*, and it has no
+                    " leader, so the correct indentation is that of the
+                    " previous line.
+                    return GetRustIndent(a:lnum - 1)
+                endif
+            endif
+            " If it's in a comment, let cindent take care of it now. This is
+            " for cases like "/*" where the next line should start " * ", not
+            " "* " as the code below would otherwise cause for module scope
+            " Fun fact: "  /*\n*\n*/" takes two calls to get right!
+            return cindent(a:lnum)
+        endif
+    endif
 
-	if has('syntax_items')
-		let synname = synIDattr(synID(a:lnum, 1, 1), "name")
-		if synname == "rustString"
-			" If the start of the line is in a string, don't change the indent
-			return -1
-		elseif synname =~ '\(Comment\|Todo\)'
-					\ && line !~ '^\s*/\*'  " not /* opening line
-			if synname =~ "CommentML" " multi-line
-				if line !~ '^\s*\*' && getline(a:lnum - 1) =~ '^\s*/\*'
-					" This is (hopefully) the line after a /*, and it has no
-					" leader, so the correct indentation is that of the
-					" previous line.
-					return GetRustIndent(a:lnum - 1)
-				endif
-			endif
-			" If it's in a comment, let cindent take care of it now. This is
-			" for cases like "/*" where the next line should start " * ", not
-			" "* " as the code below would otherwise cause for module scope
-			" Fun fact: "  /*\n*\n*/" takes two calls to get right!
-			return cindent(a:lnum)
-		endif
-	endif
+    " cindent gets second and subsequent match patterns/struct members wrong,
+    " as it treats the comma as indicating an unfinished statement::
+    "
+    " match a {
+    "     b => c,
+    "         d => e,
+    "         f => g,
+    " };
 
-	" cindent gets second and subsequent match patterns/struct members wrong,
-	" as it treats the comma as indicating an unfinished statement::
-	"
-	" match a {
-	"     b => c,
-	"         d => e,
-	"         f => g,
-	" };
+    " Search backwards for the previous non-empty line.
+    let prevlinenum = prevnonblank(a:lnum - 1)
+    let prevline = s:get_line_trimmed(prevlinenum)
+    while prevlinenum > 1 && prevline !~# '[^[:blank:]]'
+        let prevlinenum = prevnonblank(prevlinenum - 1)
+        let prevline = s:get_line_trimmed(prevlinenum)
+    endwhile
 
-	" Search backwards for the previous non-empty line.
-	let prevlinenum = prevnonblank(a:lnum - 1)
-	let prevline = s:get_line_trimmed(prevlinenum)
-	while prevlinenum > 1 && prevline !~ '[^[:blank:]]'
-		let prevlinenum = prevnonblank(prevlinenum - 1)
-		let prevline = s:get_line_trimmed(prevlinenum)
-	endwhile
+    " A standalone '{', '}', or 'where'
+    let l:standalone_open = line =~# '\V\^\s\*{\s\*\$'
+    let l:standalone_close = line =~# '\V\^\s\*}\s\*\$'
+    let l:standalone_where = line =~# '\V\^\s\*where\s\*\$'
+    if l:standalone_open || l:standalone_close || l:standalone_where
+        " ToDo: we can search for more items than 'fn' and 'if'.
+        let [l:found_line, l:col, l:submatch] =
+                    \ searchpos('\<\(fn\)\|\(if\)\>', 'bnWp')
+        if l:found_line !=# 0
+            " Now we count the number of '{' and '}' in between the match
+            " locations and the current line (there is probably a better
+            " way to compute this).
+            let l:i = l:found_line
+            let l:search_line = strpart(getline(l:i), l:col - 1)
+            let l:opens = 0
+            let l:closes = 0
+            while l:i < a:lnum
+                let l:search_line2 = substitute(l:search_line, '\V{', '', 'g')
+                let l:opens += strlen(l:search_line) - strlen(l:search_line2)
+                let l:search_line3 = substitute(l:search_line2, '\V}', '', 'g')
+                let l:closes += strlen(l:search_line2) - strlen(l:search_line3)
+                let l:i += 1
+                let l:search_line = getline(l:i)
+            endwhile
+            if l:standalone_open || l:standalone_where
+                if l:opens ==# l:closes
+                    return indent(l:found_line)
+                endif
+            else
+                " Expect to find just one more close than an open
+                if l:opens ==# l:closes + 1
+                    return indent(l:found_line)
+                endif
+            endif
+        endif
+    endif
 
-	" Handle where clauses nicely: subsequent values should line up nicely.
-	if prevline[len(prevline) - 1] == ","
-				\ && prevline =~# '^\s*where\s'
-		return indent(prevlinenum) + 6
-	endif
+    " A standalone 'where' adds a shift.
+    let l:standalone_prevline_where = prevline =~# '\V\^\s\*where\s\*\$'
+    if l:standalone_prevline_where
+        return indent(prevlinenum) + 4
+    endif
 
-	"match newline after struct with generic bound like
-	"struct SomeThing<T>
-	"| <-- newline indent should same as prevline
-	if prevline[len(prevline) - 1] == ">"
-				\ && prevline =~# "\s*struct.*>$"
-		return indent(prevlinenum)
-	endif
+    " Handle where clauses nicely: subsequent values should line up nicely.
+    if prevline[len(prevline) - 1] ==# ","
+                \ && prevline =~# '^\s*where\s'
+        return indent(prevlinenum) + 6
+    endif
 
-	"match newline after where like:
-	"struct SomeThing<T>
-	"where
-	"     T: Display,
-	if prevline =~# '^\s*where$'
-		return indent(prevlinenum) + 4
-	endif
+    let l:last_prevline_character = prevline[len(prevline) - 1]
 
-	if prevline[len(prevline) - 1] == ","
-				\ && s:get_line_trimmed(a:lnum) !~ '^\s*[\[\]{}]'
-				\ && prevline !~ '^\s*fn\s'
-				\ && prevline !~ '([^()]\+,$'
-				\ && s:get_line_trimmed(a:lnum) !~ '^\s*\S\+\s*=>'
-		" Oh ho! The previous line ended in a comma! I bet cindent will try to
-		" take this too far... For now, let's normally use the previous line's
-		" indent.
+    " A line that ends with '.<expr>;' is probably an end of a long list
+    " of method operations.
+    if prevline =~# '\V\^\s\*.' && l:last_prevline_character ==# ';'
+        call cursor(a:lnum - 1, 1)
+        let l:scope_start = searchpair('{\|(', '', '}\|)', 'nbW',
+                    \ 's:is_string_comment(line("."), col("."))')
+        if l:scope_start != 0 && l:scope_start < a:lnum
+            return indent(l:scope_start) + 4
+        endif
+    endif
 
-		" One case where this doesn't work out is where *this* line contains
-		" square or curly brackets; then we normally *do* want to be indenting
-		" further.
-		"
-		" Another case where we don't want to is one like a function
-		" definition with arguments spread over multiple lines:
-		"
-		" fn foo(baz: Baz,
-		"        baz: Baz) // <-- cindent gets this right by itself
-		"
-		" Another case is similar to the previous, except calling a function
-		" instead of defining it, or any conditional expression that leaves
-		" an open paren:
-		"
-		" foo(baz,
-		"     baz);
-		"
-		" if baz && (foo ||
-		"            bar) {
-		"
-		" Another case is when the current line is a new match arm.
-		"
-		" There are probably other cases where we don't want to do this as
-		" well. Add them as needed.
-		return indent(prevlinenum)
-	endif
+    if l:last_prevline_character ==# ","
+                \ && s:get_line_trimmed(a:lnum) !~# '^\s*[\[\]{})]'
+                \ && prevline !~# '^\s*fn\s'
+                \ && prevline !~# '([^()]\+,$'
+                \ && s:get_line_trimmed(a:lnum) !~# '^\s*\S\+\s*=>'
+        " Oh ho! The previous line ended in a comma! I bet cindent will try to
+        " take this too far... For now, let's normally use the previous line's
+        " indent.
 
-	if !has("patch-7.4.355")
-		" cindent before 7.4.355 doesn't do the module scope well at all; e.g.::
-		"
-		" static FOO : &'static [bool] = [
-		" true,
-		"	 false,
-		"	 false,
-		"	 true,
-		"	 ];
-		"
-		"	 uh oh, next statement is indented further!
+        " One case where this doesn't work out is where *this* line contains
+        " square or curly brackets; then we normally *do* want to be indenting
+        " further.
+        "
+        " Another case where we don't want to is one like a function
+        " definition with arguments spread over multiple lines:
+        "
+        " fn foo(baz: Baz,
+        "        baz: Baz) // <-- cindent gets this right by itself
+        "
+        " Another case is similar to the previous, except calling a function
+        " instead of defining it, or any conditional expression that leaves
+        " an open paren:
+        "
+        " foo(baz,
+        "     baz);
+        "
+        " if baz && (foo ||
+        "            bar) {
+        "
+        " Another case is when the current line is a new match arm.
+        "
+        " There are probably other cases where we don't want to do this as
+        " well. Add them as needed.
+        return indent(prevlinenum)
+    endif
 
-		" Note that this does *not* apply the line continuation pattern properly;
-		" that's too hard to do correctly for my liking at present, so I'll just
-		" start with these two main cases (square brackets and not returning to
-		" column zero)
+    if !has("patch-7.4.355")
+        " cindent before 7.4.355 doesn't do the module scope well at all; e.g.::
+        "
+        " static FOO : &'static [bool] = [
+        " true,
+        "	 false,
+        "	 false,
+        "	 true,
+        "	 ];
+        "
+        "	 uh oh, next statement is indented further!
 
-		call cursor(a:lnum, 1)
-		if searchpair('{\|(', '', '}\|)', 'nbW',
-					\ 's:is_string_comment(line("."), col("."))') == 0
-			if searchpair('\[', '', '\]', 'nbW',
-						\ 's:is_string_comment(line("."), col("."))') == 0
-				" Global scope, should be zero
-				return 0
-			else
-				" At the module scope, inside square brackets only
-				"if getline(a:lnum)[0] == ']' || search('\[', '', '\]', 'nW') == a:lnum
-				if line =~ "^\\s*]"
-					" It's the closing line, dedent it
-					return 0
-				else
-					return shiftwidth()
-				endif
-			endif
-		endif
-	endif
+        " Note that this does *not* apply the line continuation pattern properly;
+        " that's too hard to do correctly for my liking at present, so I'll just
+        " start with these two main cases (square brackets and not returning to
+        " column zero)
 
-	" Fall back on cindent, which does it mostly right
-	return cindent(a:lnum)
+        call cursor(a:lnum, 1)
+        if searchpair('{\|(', '', '}\|)', 'nbW',
+                    \ 's:is_string_comment(line("."), col("."))') == 0
+            if searchpair('\[', '', '\]', 'nbW',
+                        \ 's:is_string_comment(line("."), col("."))') == 0
+                " Global scope, should be zero
+                return 0
+            else
+                " At the module scope, inside square brackets only
+                "if getline(a:lnum)[0] == ']' || search('\[', '', '\]', 'nW') == a:lnum
+                if line =~# "^\\s*]"
+                    " It's the closing line, dedent it
+                    return 0
+                else
+                    return &shiftwidth
+                endif
+            endif
+        endif
+    endif
+
+    " Fall back on cindent, which does it mostly right
+    return cindent(a:lnum)
 endfunction
 
+" vint: -ProhibitAbbreviationOption
 let &cpo = s:save_cpo
 unlet s:save_cpo
+" vint: +ProhibitAbbreviationOption
+
+" vim: set et sw=4 sts=4 ts=8:


### PR DESCRIPTION
Update Rust runtime files from https://github.com/rust-lang/rust.vim/commit/889b9a7515db477f4cb6808bef1769e53493c578.

The Rust runtime files are notably out of date. The provided `:RustFmt` command (and the associated auto formatting features) do not work because the ftplugin uses a command line argument that is no longer supported by `rustfmt`.

I updated all of the Last Modified headers to the date of this commit. The only modifications I made from upstream was moving the `:Cargo` family of commands from a `plugin/` to `ftplugin/rust.vim` and making them buffer-local (and cleaning them up in `b:undo_ftplugin`).