### PR TITLE
fix(matchparen): do not highlight inactive windows

### DIFF
--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -20,7 +20,7 @@ endif
 
 augroup matchparen
   " Replace all matchparen autocommands
-  autocmd! CursorMoved,CursorMovedI,WinEnter,BufWinEnter,WinScrolled * call s:Highlight_Matching_Pair()
+  autocmd! CursorMoved,CursorMovedI,WinEnter,WinScrolled * call s:Highlight_Matching_Pair()
   autocmd! WinLeave,BufLeave * call s:Remove_Matches()
   if exists('##TextChanged')
     autocmd! TextChanged,TextChangedI * call s:Highlight_Matching_Pair()


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/25099

The issue here is that when `BufWinEnter` is fired, the cursor's position won't correctly indicate whether the cursor is inside the window or not. Instead the plugin should try to match parentheses once the cursor has entered the window with `WinEnter`.