### PR TITLE
CI: linux 6.2 does not modeprobe snd-dummy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     env:
       CC: ${{ matrix.compiler }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
             libxt-dev:${{ matrix.architecture }} \
           )
           if ${{ matrix.features == 'huge' }}; then
-            LUA_VER=${{ matrix.lua_ver || '5.4' }}
+            LUA_VER=${{ matrix.lua_ver || '5.3' }}
             PKGS+=( \
               autoconf \
               gdb \


### PR DESCRIPTION
- downgrade to ubuntu 20.04
- toolchain can be used anyway