### PR TITLE
Missing safety check in PBYTE macro

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -14,11 +14,6 @@
  */
 
 /*
- * PBYTE(lp, c) - put byte 'c' at position 'lp'
- */
-#define PBYTE(lp, c) (*(ml_get_buf(curbuf, (lp).lnum, TRUE) + (lp).col) = (c))
-
-/*
  * Position comparisons
  */
 #define LT_POS(a, b) (((a).lnum != (b).lnum) \

--- a/src/ops.c
+++ b/src/ops.c
@@ -17,6 +17,9 @@
 static void shift_block(oparg_T *oap, int amount);
 static void	mb_adjust_opend(oparg_T *oap);
 static int	do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1);
+static void	pbyte(pos_T lp, int c);
+#define PBYTE(lp, c) pbyte(lp, c)
+
 
 // Flags for third item in "opchars".
 #define OPF_LINES  1	// operator always works on lines
@@ -4348,4 +4351,19 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 #ifdef FEAT_LINEBREAK
     restore_lbr(lbr_saved);
 #endif
+}
+
+// put byte 'c' at position 'lp', but
+// verify, that the position to place
+// is actually safe
+    static void
+pbyte(pos_T lp, int c)
+{
+    char_u *p = ml_get_buf(curbuf, lp.lnum, TRUE);
+    int	len = curbuf->b_ml.ml_line_len;
+
+    // safety check
+    if (lp.col >= len)
+	lp.col = (len > 1 ? len - 2 : 0);
+    *(p + lp.col) = c;
 }


### PR DESCRIPTION
the PBYTE macro is used to put byte c at a position lp of the returned memline. However, in case of unexpected errors ml_get_buf() may return either "???" or an empty line in which case it is quite likely that we are causing a buffer overrun.

Therefore, switch the macro PBYTE (which is only used in ops.c anyhow) to a function, that verifies that we will only try to access within the given length of the buffer.