### PR TITLE
win32: Fix mismatch of {Get,Free}EnvironmentStrings

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -5788,7 +5788,7 @@ win32_build_env(dict_T *env, garray_T *gap, int is_terminal)
 		*((WCHAR*)gap->ga_data + gap->ga_len++) = *p;
 	    p++;
 	}
-	FreeEnvironmentStrings(base);
+	FreeEnvironmentStringsW(base);
 	*((WCHAR*)gap->ga_data + gap->ga_len++) = L'\0';
     }
 


### PR DESCRIPTION
Closes #13094

After we call GetEnvironmentStringsW, we should call FreeEnvironmentStringsW instead of FreeEnvironmentStringsA.