### PR TITLE
Fix :Man plugin not working if gdefault is set

### DIFF
--- a/runtime/autoload/dist/man.vim
+++ b/runtime/autoload/dist/man.vim
@@ -196,11 +196,7 @@ func dist#man#GetPage(cmdmods, ...)
 
   " Emulate piping the buffer through the "col -b" command.
   " Ref: https://github.com/vim/vim/issues/12301
-  if &gdefault
-    silent! keepjumps keeppatterns %s/\v(.)\b\ze\1?//e
-  else
-    silent! keepjumps keeppatterns %s/\v(.)\b\ze\1?//ge
-  endif
+  exe 'silent! keepjumps keeppatterns %s/\v(.)\b\ze\1?//e' .. (&gdefault ? '' : 'g')
 
   if unsetwidth
     let $MANWIDTH = ''

--- a/runtime/autoload/dist/man.vim
+++ b/runtime/autoload/dist/man.vim
@@ -196,7 +196,11 @@ func dist#man#GetPage(cmdmods, ...)
 
   " Emulate piping the buffer through the "col -b" command.
   " Ref: https://github.com/vim/vim/issues/12301
-  silent! keepjumps keeppatterns %s/\v(.)\b\ze\1?//ge
+  if &gdefault
+    silent! keepjumps keeppatterns %s/\v(.)\b\ze\1?//e
+  else
+    silent! keepjumps keeppatterns %s/\v(.)\b\ze\1?//ge
+  endif
 
   if unsetwidth
     let $MANWIDTH = ''


### PR DESCRIPTION
Fix the issue introduced by #12557. `:substitue` commands in plugins need to take into account whether `gdefault` is set or not because that depends on the user.