### PR TITLE
Add liquidsoap to filetype.vim

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1181,6 +1181,9 @@ endif
 " SBCL implementation of Common Lisp
 au BufNewFile,BufRead sbclrc,.sbclrc		setf lisp
 
+" Liquidsoap
+au BufNewFile,BufRead *.liq			setf liquidsoap
+
 " Liquid
 au BufNewFile,BufRead *.liquid			setf liquid
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -372,6 +372,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     lilo: ['lilo.conf', 'lilo.conf-file'],
     lilypond: ['file.ly', 'file.ily'],
     limits: ['/etc/limits', '/etc/anylimits.conf', '/etc/anylimits.d/file.conf', '/etc/limits.conf', '/etc/limits.d/file.conf', '/etc/some-limits.conf', '/etc/some-limits.d/file.conf', 'any/etc/limits', 'any/etc/limits.conf', 'any/etc/limits.d/file.conf', 'any/etc/some-limits.conf', 'any/etc/some-limits.d/file.conf'],
+    liquidsoap: ['file.liq'],
     liquid: ['file.liquid'],
     lisp: ['file.lsp', 'file.lisp', 'file.asd', 'file.el', 'file.cl', '.emacs', '.sawfishrc', 'sbclrc', '.sbclrc'],
     lite: ['file.lite', 'file.lt'],


### PR DESCRIPTION
This PR adds proper filetype detection for liquidsoap script files.

Liquidsoap is scripting language for creating media streams and more. It's got about [1.5k](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.liq) script files on github.

Thanks for your consideration!