### PR TITLE
Make r_CTRL-C behave consistent in visual mode

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -4799,7 +4799,7 @@ nv_replace(cmdarg_T *cap)
     if (VIsual_active)
     {
 	if (got_int)
-	    reset_VIsual();
+	    got_int = FALSE;
 	if (had_ctrl_v)
 	{
 	    // Use a special (negative) number to make a difference between a

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1573,4 +1573,18 @@ func Test_visual_hl_with_showbreak()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_Visual_r_CTRL_C()
+  new
+  " visual r_cmd
+  call setline(1, ['   '])
+  call feedkeys("\<c-v>$r\<c-c>", 'tx')
+  call assert_equal([''], getline(1, 1))
+
+  " visual gr_cmd
+  call setline(1, ['   '])
+  call feedkeys("\<c-v>$gr\<c-c>", 'tx')
+  call assert_equal([''], getline(1, 1))
+  bw!
+endfu
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
closes: #13091

in visual mode, r CTRL-C behaves strange in Unix like environments. It seems to end visual mode, but still is waiting for few more chars, however it never seems to replace it by any characters and eventually just returns back into normal mode.

In contrast in Windows GUI mode, r_CTRL-C replaces in the selected area all characters by a literal CTRL-C.

Not sure why it behaves like this. It seems in the Windows GUI, got_int is not set and therefore behaves as if any other normal character has been pressed.

So remove the special casing of what happens when got_int is set and make it always behave like in Windows GUI mode. Add a test to verify it always behaves like replacing in the selected area each selected character by a literal CTRL-C.