### PR TITLE
Extend guard for sound support on OS X

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -102,6 +102,11 @@
 # define ROOT_UID 0
 #endif
 
+/* Include MAC_OS_X_VERSION_* macros */
+#ifdef HAVE_AVAILABILITYMACROS_H
+# include <AvailabilityMacros.h>
+#endif
+
 /*
  * MACOS_X	    compiling for Mac OS X
  * MACOS_X_DARWIN   integrating the darwin feature into MACOS_X
@@ -167,7 +172,9 @@
 # if defined(FEAT_NORMAL) && !defined(FEAT_CLIPBOARD)
 #  define FEAT_CLIPBOARD
 # endif
-# if defined(FEAT_HUGE) && !defined(FEAT_SOUND)
+# if defined(FEAT_HUGE) && !defined(FEAT_SOUND) && \
+   defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
+    MAC_OS_X_VERSION_MIN_REQUIRED >= 101100
 #  define FEAT_SOUND
 # endif
 # if defined(FEAT_SOUND)


### PR DESCRIPTION
Fixes build on legacy versions where required coreaudio functionality may not be available.
[NSSoundDelegate apparently was introduced in Snow Leopard](https://developer.apple.com/documentation/appkit/nssounddelegate) yet the build breaks on it. Guarding off enabling sound support to El Capitan as that's the next version I had access to for testing (it may work on earlier versions, between 10.6 & 10.11).
Vim builds on OS X Tiger 10.4 and newer with this change.