### PR TITLE
Fix if_python undefined behavior for function pointer casts

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -5962,14 +5962,15 @@ static struct PyMethodDef CurrentMethods[] = {
 };
 
     static void
-init_range_cmd(exarg_T *eap)
+init_range_cmd(void *arg)
 {
+    exarg_T *eap = (exarg_T*)arg;
     RangeStart = eap->line1;
     RangeEnd = eap->line2;
 }
 
     static void
-init_range_eval(typval_T *rettv UNUSED)
+init_range_eval(void *rettv UNUSED)
 {
     RangeStart = (PyInt) curwin->w_cursor.lnum;
     RangeEnd = RangeStart;

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -1103,7 +1103,7 @@ ex_python(exarg_T *eap)
 	    p_pyx = 2;
 
 	DoPyCommand(script == NULL ? (char *) eap->arg : (char *) script,
-		(rangeinitializer) init_range_cmd,
+		init_range_cmd,
 		(runner) run_cmd,
 		(void *) eap);
     }
@@ -1154,7 +1154,7 @@ ex_pyfile(exarg_T *eap)
 
     // Execute the file
     DoPyCommand(buffer,
-	    (rangeinitializer) init_range_cmd,
+	    init_range_cmd,
 	    (runner) run_cmd,
 	    (void *) eap);
 }
@@ -1166,7 +1166,7 @@ ex_pydo(exarg_T *eap)
 	p_pyx = 2;
 
     DoPyCommand((char *)eap->arg,
-	    (rangeinitializer) init_range_cmd,
+	    init_range_cmd,
 	    (runner)run_do,
 	    (void *)eap);
 }
@@ -1524,7 +1524,7 @@ FunctionGetattr(PyObject *self, char *name)
 do_pyeval(char_u *str, typval_T *rettv)
 {
     DoPyCommand((char *) str,
-	    (rangeinitializer) init_range_eval,
+	    init_range_eval,
 	    (runner) run_eval,
 	    (void *) rettv);
     if (rettv->v_type == VAR_UNKNOWN)

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -1425,7 +1425,7 @@ ex_py3(exarg_T *eap)
 	    p_pyx = 3;
 
 	DoPyCommand(script == NULL ? (char *) eap->arg : (char *) script,
-		(rangeinitializer) init_range_cmd,
+		init_range_cmd,
 		(runner) run_cmd,
 		(void *) eap);
     }
@@ -1491,7 +1491,7 @@ ex_py3file(exarg_T *eap)
 
     // Execute the file
     DoPyCommand(buffer,
-	    (rangeinitializer) init_range_cmd,
+	    init_range_cmd,
 	    (runner) run_cmd,
 	    (void *) eap);
 }
@@ -1503,7 +1503,7 @@ ex_py3do(exarg_T *eap)
 	p_pyx = 3;
 
     DoPyCommand((char *)eap->arg,
-	    (rangeinitializer)init_range_cmd,
+	    init_range_cmd,
 	    (runner)run_do,
 	    (void *)eap);
 }
@@ -2053,7 +2053,7 @@ LineToString(const char *str)
 do_py3eval(char_u *str, typval_T *rettv)
 {
     DoPyCommand((char *) str,
-	    (rangeinitializer) init_range_eval,
+	    init_range_eval,
 	    (runner) run_eval,
 	    (void *) rettv);
     if (rettv->v_type == VAR_UNKNOWN)


### PR DESCRIPTION
Identified by clang 17 UBSAN (see #12745). Make sure to cast function pointers with the same signature only.