### PR TITLE
When using nested objects, check for the member variable access correctly

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1582,7 +1582,6 @@ get_lval(
 					lp->ll_tv->vval.v_object + 1)) + m_idx;
 			else
 			    lp->ll_tv = &cl->class_members_tv[m_idx];
-			break;
 		    }
 		}
 

--- a/src/proto/vim9compile.pro
+++ b/src/proto/vim9compile.pro
@@ -24,6 +24,7 @@ int compile_all_expr_in_str(char_u *str, int evalstr, cctx_T *cctx);
 int assignment_len(char_u *p, int *heredoc);
 void vim9_declare_error(char_u *name);
 int get_var_dest(char_u *name, assign_dest_T *dest, cmdidx_T cmdidx, int *option_scope, int *vimvaridx, type_T **type, cctx_T *cctx);
+int cctx_class_member_modifiable(class_T *cl, ocmember_T *m, int is_object, cctx_T *cctx);
 int compile_lhs(char_u *var_start, lhs_T *lhs, cmdidx_T cmdidx, int heredoc, int has_cmd, int oplen, cctx_T *cctx);
 int compile_assign_lhs(char_u *var_start, lhs_T *lhs, cmdidx_T cmdidx, int is_decl, int heredoc, int has_cmd, int oplen, cctx_T *cctx);
 int compile_load_lhs_with_index(lhs_T *lhs, char_u *var_start, cctx_T *cctx);

--- a/src/proto/vim9expr.pro
+++ b/src/proto/vim9expr.pro
@@ -14,5 +14,6 @@ int bool_on_stack(cctx_T *cctx);
 void error_white_both(char_u *op, int len);
 int compile_expr1(char_u **arg, cctx_T *cctx, ppconst_T *ppconst);
 int compile_expr0_ext(char_u **arg, cctx_T *cctx, int *is_const);
+int compile_expr0_lhs(char_u **arg, cctx_T *cctx);
 int compile_expr0(char_u **arg, cctx_T *cctx);
 /* vim: set ft=c : */

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -529,7 +529,7 @@ def Test_member_any_used_as_object()
       endclass
 
       class Outer
-        this.inner: any
+        public this.inner: any
       endclass
 
       def F(outer: Outer)
@@ -552,7 +552,7 @@ def Test_member_any_used_as_object()
     endclass
 
     class Outer
-      this.inner: any
+      public this.inner: any
     endclass
 
     def F(outer: Outer)
@@ -574,7 +574,7 @@ def Test_member_any_used_as_object()
     endclass
 
     class Outer
-      this.inner: any
+      public this.inner: any
     endclass
 
     def F(outer: Outer)
@@ -598,7 +598,7 @@ def Test_assignment_nested_type()
     endclass
 
     class Outer
-      this.inner: Inner
+      public this.inner: Inner
     endclass
 
     def F(outer: Outer)
@@ -5481,7 +5481,76 @@ def Test_nested_object_assignment()
     var d = D.new()
     T(d)
   END
-  v9.CheckSourceFailure(lines, 'E46: Cannot change read-only variable "value"')
+  v9.CheckSourceFailure(lines, 'E46: Cannot change read-only variable "c"')
+enddef
+
+" Test for modifying a object variable
+def Test_dict_in_object_assignment()
+  # Modifying a read-only dict object variable in def function context
+  var lines =<< trim END
+    vim9script
+
+    class A
+      this.d = {val: 10}
+    endclass
+
+    def T()
+      var a = A.new()
+      a.d.val = 20
+    enddef
+    T()
+  END
+  v9.CheckSourceFailure(lines, 'E46: Cannot change read-only variable "d"')
+
+  # Modifying a read-only dict object variable in script context
+  lines =<< trim END
+    vim9script
+
+    class A
+      this.d = {val: 10}
+    endclass
+
+    var a = A.new()
+    a.d.val = 20
+  END
+  v9.CheckSourceFailure(lines, 'E1335: Member is not writable: d')
+
+  # Modifying a read-write dict object variable in def function context
+  lines =<< trim END
+    vim9script
+
+    class A
+      public this.d = {val: 10}
+      def GetVal(): number
+        return this.d.val
+      enddef
+    endclass
+
+    def T()
+      var a = A.new()
+      a.d.val = 20
+      assert_equal(20, a.GetVal())
+    enddef
+    T()
+  END
+  v9.CheckSourceSuccess(lines)
+
+  # Modifying a read-write dict object variable in script context
+  lines =<< trim END
+    vim9script
+
+    class A
+      public this.d = {val: 10}
+      def GetVal(): number
+        return this.d.val
+      enddef
+    endclass
+
+    var a = A.new()
+    a.d.val = 20
+    assert_equal(20, a.GetVal())
+  END
+  v9.CheckSourceSuccess(lines)
 enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -856,6 +856,7 @@ struct cctx_S {
 
     lhs_T	ctx_redir_lhs;	    // LHS for ":redir => var", valid when
 				    // lhs_name is not NULL
+    int		ctx_lhs_expr;	    // compiling LHS expression
 };
 
 /*

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -2071,7 +2071,7 @@ get_member_tv(
     if (m == NULL)
 	return FAIL;
 
-    if (*name == '_')
+    if (m->ocm_access == VIM_ACCESS_PRIVATE)
     {
 	semsg(_(e_cannot_access_private_member_str), m->ocm_name);
 	return FAIL;
@@ -2230,7 +2230,7 @@ class_object_index(
 	    return FAIL;
 	}
 
-	if (*name == '_')
+	if (m->ocm_access == VIM_ACCESS_PRIVATE)
 	{
 	    semsg(_(e_cannot_access_private_member_str), m->ocm_name);
 	    return FAIL;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2170,7 +2170,7 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 	    ocmember_T *m = object_member_lookup(cl, member, 0, &m_idx);
 	    if (m != NULL)
 	    {
-		if (*member == '_')
+		if (m->ocm_access == VIM_ACCESS_PRIVATE)
 		{
 		    semsg(_(e_cannot_access_private_member_str), m->ocm_name);
 		    status = FAIL;


### PR DESCRIPTION
Fixes #13118 and #13123