### PR TITLE
Add Authzed filetype.

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -184,6 +184,9 @@ au BufNewFile,BufRead *.atl,*.as		setf atlas
 " Atom is based on XML
 au BufNewFile,BufRead *.atom			setf xml
 
+" Authzed
+au BufNewFile,BufRead *.zed			setf authzed
+
 " Autoit v3
 au BufNewFile,BufRead *.au3			setf autoit
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -107,6 +107,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     asterisk: ['asterisk/file.conf', 'asterisk/file.conf-file', 'some-asterisk/file.conf', 'some-asterisk/file.conf-file'],
     astro: ['file.astro'],
     atlas: ['file.atl', 'file.as'],
+    authzed: ['schema.zed'],
     autohotkey: ['file.ahk'],
     autoit: ['file.au3'],
     automake: ['GNUmakefile.am', 'makefile.am', 'Makefile.am'],


### PR DESCRIPTION
The Authzed filetype defines schemas for the SpiceDB permissions database.

https://authzed.com/docs/reference/schema-lang