### PR TITLE
LSP server request message is misinterpreted as a response message

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -2927,9 +2927,16 @@ may_invoke_callback(channel_T *channel, ch_part_T part)
 	    seq_nr = 0;
 	    if (d != NULL)
 	    {
-		di = dict_find(d, (char_u *)"id", -1);
-		if (di != NULL && di->di_tv.v_type == VAR_NUMBER)
-		    seq_nr = di->di_tv.vval.v_number;
+		// When looking for a response message from the LSP server,
+		// ignore new LSP request and notification messages.  LSP
+		// request and notification messages have the "method" field in
+		// the header and the response messages do not have this field.
+		if (!dict_has_key(d, "method"))
+		{
+		    di = dict_find(d, (char_u *)"id", -1);
+		    if (di != NULL && di->di_tv.v_type == VAR_NUMBER)
+			seq_nr = di->di_tv.vval.v_number;
+		}
 	    }
 
 	    argv[1] = *listtv;


### PR DESCRIPTION
When waiting for a response message from the LSP server, if a new request message is received from the server with the same sequence number, then the request message is incorrectly interpreted as a response message.

This is reported in https://github.com/yegappan/lsp/issues/395

The LSP request and notifications messages will have the "method" field in the header.  The LSP response messages will not
have this field.  When looking for a response message with a matching sequence number, use this field to ignore request
and notification messages.