### PR TITLE
Adjust message `e_member_is_not_writable_str` to include more info.

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3411,7 +3411,7 @@ EXTERN char e_cannot_access_private_member_str[]
 	INIT(= N_("E1333: Cannot access private member: %s"));
 // E1334 unused
 EXTERN char e_member_is_not_writable_str[]
-	INIT(= N_("E1335: Member is not writable: %s"));
+	INIT(= N_("E1335: Variable \"%s\" in class \"%s\" is not writable"));
 #endif
 EXTERN char e_internal_error_shortmess_too_long[]
 	INIT(= "E1336: Internal error: shortmess too long");

--- a/src/eval.c
+++ b/src/eval.c
@@ -1570,7 +1570,7 @@ get_lval(
 				if ((flags & GLV_READ_ONLY) == 0)
 				{
 				    semsg(_(e_member_is_not_writable_str),
-					    om->ocm_name);
+					    om->ocm_name, cl->class_name);
 				    return NULL;
 				}
 				break;

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -646,7 +646,7 @@ def Test_assignment_nested_type()
 
     Test_assign_to_nested_typed_member()
   END
-  v9.CheckSourceFailure(lines, 'E46: Cannot change read-only variable "value"')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "value" in class "Inner" is not writable')
 
   # Assignment where target item is read only script level
   lines =<< trim END
@@ -669,7 +669,7 @@ def Test_assignment_nested_type()
     script_outer.inner.value = 1
     assert_equal(1, script_inner.value)
   END
-  v9.CheckSourceFailure(lines, 'E1335: Member is not writable: value')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "value" in class "Inner" is not writable')
 enddef
 
 def Test_assignment_with_operator()
@@ -1243,7 +1243,7 @@ def Test_class_variable_access()
       var b = B.new()
       b.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E46: Cannot change read-only variable "ro_class_var"')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "ro_class_var" in class "A" is not writable')
 
   # A private class variable cannot be accessed from a child class
   lines =<< trim END
@@ -4269,7 +4269,7 @@ def Test_readonly_member_change_in_def_func()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E46: Cannot change read-only variable "val"')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "val" in class "A" is not writable')
 enddef
 
 " Test for reading and writing a class member from a def function
@@ -5541,7 +5541,7 @@ def Test_nested_object_assignment()
     var d = D.new()
     T(d)
   END
-  v9.CheckSourceFailure(lines, 'E46: Cannot change read-only variable "value"')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "value" in class "A" is not writable')
 enddef
 
 " Test for calling methods using a null object

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1611,8 +1611,8 @@ lhs_class_member_modifiable(lhs_T *lhs, char_u	*var_start, cctx_T *cctx)
     {
 	char *msg = (m->ocm_access == VIM_ACCESS_PRIVATE)
 				? e_cannot_access_private_member_str
-				: e_cannot_change_readonly_variable_str;
-	semsg(_(msg), m->ocm_name);
+				: e_member_is_not_writable_str;
+	semsg(_(msg), m->ocm_name, cl->class_name);
 	return FALSE;
     }
 


### PR DESCRIPTION
Change `member` to `variable`; include class in msg; quote program names. Message based on comments from #13068 and #13135.

Update `E1335` to
```
E1335: Variable "value" in "class C" is not writable
```
from
```
E1335: Member is not writable: value
```
Change one use of `E46` to `E1335`
```
E46: Cannot change read-only variable "value"
```
