### PR TITLE
Fix wrong curswant when clicking with 'virtualedit' and 'nowrap'

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -3852,7 +3852,14 @@ win_line(
 	    else
 		ScreenAttrs[wlv.off] = wlv.char_attr;
 
-	    ScreenCols[wlv.off] = wlv.vcol;
+	    if (wlv.draw_state > WL_NR
+#ifdef FEAT_DIFF
+		    && wlv.filler_todo <= 0
+#endif
+		    )
+		ScreenCols[wlv.off] = wlv.vcol;
+	    else
+		ScreenCols[wlv.off] = -1;
 
 	    if (has_mbyte && (*mb_char2cells)(mb_c) > 1)
 	    {
@@ -3865,18 +3872,20 @@ win_line(
 		else
 		    // DBCS: Put second byte in the second screen char.
 		    ScreenLines[wlv.off] = mb_c & 0xff;
+
 		if (wlv.draw_state > WL_NR
 #ifdef FEAT_DIFF
 			&& wlv.filler_todo <= 0
 #endif
 			)
-		    ++wlv.vcol;
+		    ScreenCols[wlv.off] = ++wlv.vcol;
+		else
+		    ScreenCols[wlv.off] = -1;
+
 		// When "wlv.tocol" is halfway a character, set it to the end
 		// of the character, otherwise highlighting won't stop.
 		if (wlv.tocol == wlv.vcol)
 		    ++wlv.tocol;
-
-		ScreenCols[wlv.off] = wlv.vcol;
 
 #ifdef FEAT_RIGHTLEFT
 		if (wp->w_p_rl)

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -2115,11 +2115,16 @@ retnomove:
 		else
 		    off_r = off_m - 1;
 	    }
-	    col = ScreenCols[off_r] + (off_click - off_r);
+	    colnr_T eol_vcol = ScreenCols[off_r];
+	    if (eol_vcol < 0)
+		// Empty line or whole line before w_leftcol,
+		// with columns before buffer text
+		eol_vcol = curwin->w_leftcol - 1;
+	    col = eol_vcol + (off_click - off_r);
 	}
 	else
-	    // Clicking on an empty line
-	    col = prev_col - curwin->w_wincol;
+	    // Empty line or whole line before w_leftcol
+	    col = prev_col - curwin->w_wincol + curwin->w_leftcol;
     }
     else if (col_from_screen >= 0)
     {

--- a/src/screen.c
+++ b/src/screen.c
@@ -18,8 +18,8 @@
  *		     displayed (excluding text written by external commands).
  * ScreenAttrs[off]  Contains the associated attributes.
  * ScreenCols[off]   Contains the virtual columns in the line. -1 means not
- *		     available (below last line), MAXCOL means after the end
- *		     of the line.
+ *		     available or before buffer text, MAXCOL means after the
+ *		     end of the line.
  *
  * LineOffset[row]   Contains the offset into ScreenLines*[], ScreenAttrs[]
  *		     and ScreenCols[] for each line.

--- a/src/testdir/test_virtualedit.vim
+++ b/src/testdir/test_virtualedit.vim
@@ -599,6 +599,61 @@ func Test_virtualedit_mouse()
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 10, 2, 15], getcurpos())
 
+  setlocal nowrap
+  call setline(2, repeat('a', 19))
+  normal! j14zl
+  redraw
+  call test_setmouse(row, 21 + 1)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 10, 2, 15], getcurpos())
+  call test_setmouse(row, 21 + 11)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 10, 12, 25], getcurpos())
+  call test_setmouse(row + 1, 21 + 1)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 2, 15, 0, 15], getcurpos())
+  call test_setmouse(row + 1, 21 + 11)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 2, 20, 5, 25], getcurpos())
+
+  setlocal number numberwidth=2
+  redraw
+  call test_setmouse(row, 21 + 3)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 10, 2, 15], getcurpos())
+  call test_setmouse(row, 21 + 13)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 10, 12, 25], getcurpos())
+  call test_setmouse(row + 1, 21 + 3)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 2, 15, 0, 15], getcurpos())
+  call test_setmouse(row + 1, 21 + 13)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 2, 20, 5, 25], getcurpos())
+  setlocal nonumber
+
+  if has('signs')
+    sign define Sign1 text=口
+    sign place 1 name=Sign1 line=1
+    sign place 2 name=Sign1 line=2
+    redraw
+    call test_setmouse(row, 21 + 3)
+    call feedkeys("\<LeftMouse>", "xt")
+    call assert_equal([0, 1, 10, 2, 15], getcurpos())
+    call test_setmouse(row, 21 + 13)
+    call feedkeys("\<LeftMouse>", "xt")
+    call assert_equal([0, 1, 10, 12, 25], getcurpos())
+    call test_setmouse(row + 1, 21 + 3)
+    call feedkeys("\<LeftMouse>", "xt")
+    call assert_equal([0, 2, 15, 0, 15], getcurpos())
+    call test_setmouse(row + 1, 21 + 13)
+    call feedkeys("\<LeftMouse>", "xt")
+    call assert_equal([0, 2, 20, 5, 25], getcurpos())
+    sign unplace 1
+    sign unplace 2
+    sign undefine Sign1
+  endif
+
   bwipe!
   let &mouse = save_mouse
   set virtualedit&


### PR DESCRIPTION
Problem:  Wrong curswant when clicking with 'virtualedit' and 'nowrap'.
Solution: Add w_leftcol to mouse click column.