### PR TITLE
Fix wrong 'listchars' "multispace"/"leadmultispace" with w_leftcol

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1684,6 +1684,27 @@ win_line(
 	    cts.cts_vcol += charsize;
 	    prev_ptr = cts.cts_ptr;
 	    MB_PTR_ADV(cts.cts_ptr);
+	    if (wp->w_p_list)
+	    {
+		in_multispace = *prev_ptr == ' ' && (*cts.cts_ptr == ' '
+				  || (prev_ptr > line && prev_ptr[-1] == ' '));
+		if (!in_multispace)
+		    multispace_pos = 0;
+		else if (cts.cts_ptr >= line + leadcol
+					 && wp->w_lcs_chars.multispace != NULL)
+		{
+		    ++multispace_pos;
+		    if (wp->w_lcs_chars.multispace[multispace_pos] == NUL)
+			multispace_pos = 0;
+		}
+		else if (cts.cts_ptr < line + leadcol
+				     && wp->w_lcs_chars.leadmultispace != NULL)
+		{
+		    ++multispace_pos;
+		    if (wp->w_lcs_chars.leadmultispace[multispace_pos] == NUL)
+			multispace_pos = 0;
+		}
+	    }
 	}
 	wlv.vcol = cts.cts_vcol;
 	ptr = cts.cts_ptr;
@@ -2589,9 +2610,7 @@ win_line(
 #ifdef FEAT_LINEBREAK
 	    int		c0;
 #endif
-#ifdef FEAT_SPELL
 	    char_u	*prev_ptr = ptr;
-#endif
 
 	    // Get a character from the line itself.
 	    c = *ptr;
@@ -2941,10 +2960,13 @@ win_line(
 		    }
 		}
 #endif
-		in_multispace = c == ' '
-		    && ((ptr > line + 1 && ptr[-2] == ' ') || *ptr == ' ');
-		if (!in_multispace)
-		    multispace_pos = 0;
+		if (wp->w_p_list)
+		{
+		    in_multispace = c == ' ' && (*ptr == ' '
+				  || (prev_ptr > line && prev_ptr[-1] == ' '));
+		    if (!in_multispace)
+			multispace_pos = 0;
+		}
 
 		// 'list': Change char 160 to 'nbsp' and space to 'space'
 		// setting in 'listchars'.  But not when the character is

--- a/src/message.c
+++ b/src/message.c
@@ -2005,10 +2005,13 @@ msg_prt_line(char_u *s, int list)
 	{
 	    attr = 0;
 	    c = *s++;
-	    in_multispace = c == ' '
-		&& ((col > 0 && s[-2] == ' ') || *s == ' ');
-	    if (!in_multispace)
-		multispace_pos = 0;
+	    if (list)
+	    {
+		in_multispace = c == ' ' && (*s == ' '
+						 || (col > 0 && s[-2] == ' '));
+		if (!in_multispace)
+		    multispace_pos = 0;
+	    }
 	    if (c == TAB && (!list || curwin->w_lcs_chars.tab1))
 	    {
 		// tab amount depends on current column
@@ -2062,7 +2065,7 @@ msg_prt_line(char_u *s, int list)
 	    }
 	    else if (c == ' ')
 	    {
-		if (list && lead != NULL && s <= lead && in_multispace
+		if (lead != NULL && s <= lead && in_multispace
 			&& curwin->w_lcs_chars.leadmultispace != NULL)
 		{
 		    c = curwin->w_lcs_chars.leadmultispace[multispace_pos++];
@@ -2082,7 +2085,7 @@ msg_prt_line(char_u *s, int list)
 		    c = curwin->w_lcs_chars.trail;
 		    attr = HL_ATTR(HLF_8);
 		}
-		else if (list && in_multispace
+		else if (in_multispace
 			&& curwin->w_lcs_chars.multispace != NULL)
 		{
 		    c = curwin->w_lcs_chars.multispace[multispace_pos++];


### PR DESCRIPTION
Problem:  Wrong 'listchars' "multispace"/"leadmultispace" when screen
          has scrolled horizontally.
Solution: Update position in "multispace" or "leadmultispace" also in
          skipped chars. Reorder conditions to be more consistent.

Fix #13145