### PR TITLE
lockvar on object or class

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3517,6 +3517,10 @@ EXTERN char e_member_str_type_mismatch_expected_str_but_got_str[]
 	INIT(= N_("E1382: Member \"%s\": type mismatch, expected %s but got %s"));
 EXTERN char e_method_str_type_mismatch_expected_str_but_got_str[]
 	INIT(= N_("E1383: Method \"%s\": type mismatch, expected %s but got %s"));
+EXTERN char e_cannot_lock_object[]
+	INIT(= N_("E1384: Cannot lock or unlock an object"));
+EXTERN char e_cannot_lock_class[]
+	INIT(= N_("E1384: Cannot lock or unlock a class"));
 #endif
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1400: Cannot mix positional and non-positional arguments: %s"));

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -2185,6 +2185,18 @@ do_lock_var(
 								  lp->ll_name);
 			    ret = FAIL;
 			}
+			// TODO: && deep != 0 ???
+			// not worth the special case, use final in vim9script
+			if (sv != NULL && sv->sv_type->tt_type == VAR_OBJECT)
+			{
+			    emsg(_(e_cannot_lock_object));
+			    ret = FAIL;
+			}
+			if (sv != NULL && sv->sv_type->tt_type == VAR_CLASS)
+			{
+			    emsg(_(e_cannot_lock_class));
+			    ret = FAIL;
+			}
 		    }
 
 		    if (ret == OK)


### PR DESCRIPTION
There are no defined semantics for using `lockvar` on an object or class.
Make it illegal for now, then it can possibly be allowed in the future.
(vim9 TODO item: how about lock/unlock?)

Currently it is OK to `lockvar` an `object` or `class`;  that doesn't prevent modification of an `object`'s variables.
 
```
final o = C.new()   # OK
const o = C.new()   # "cannot lock object"

final c = C         # OK
const c = C         # "cannot lock class"
```

Don't allow lockvar, even in situations where it might be OK, if `class`/`object` involved.

Doing `lockvar` on a variable holding a class is OK, but give an error since
can't easily distinguish between the following two `lockvar` statements.

```
var c = C
lockvar 0 c     # technically OK, but give error. Use final c = C
lockvar 0 C     # can't lock a class, error at any depth
```

To be consistent and simpler, don't allow lockvar with any object situation.

```
var o = C.new()
lockvar 0 o     # technically OK, but give error. Use final o = C.new()
lockvar! 0 o    # not defined to lock an object.
```
