### PR TITLE
Fix :bwipe not working after switching window from aucmd_win

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -1635,7 +1635,6 @@ aucmd_restbuf(
     {
 	win_T *awp = aucmd_win[aco->use_aucmd_win_idx].auc_win;
 
-	--curbuf->b_nwindows;
 	// Find "awp", it can't be closed, but it may be in another tab
 	// page. Do not trigger autocommands here.
 	block_autocmds();
@@ -1656,8 +1655,8 @@ aucmd_restbuf(
 	    }
 	}
 win_found:
+	--curbuf->b_nwindows;
 #ifdef FEAT_JOB_CHANNEL
-	;
 	int save_stop_insert_mode = stop_insert_mode;
 	// May need to stop Insert mode if we were in a prompt buffer.
 	leaving_window(curwin);

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -3630,9 +3630,20 @@ func Test_closing_autocmd_window()
   END
   call v9.CheckScriptFailure(lines, 'E814:')
   au! BufEnter
-  only!
   bwipe Xa.txt
   bwipe Xb.txt
+endfunc
+
+func Test_switch_window_in_autocmd_window()
+  edit Xa.txt
+  tabnew Xb.txt
+  autocmd BufEnter Xa.txt wincmd w
+  doautoall BufEnter
+  au! BufEnter
+  bwipe Xa.txt
+  call assert_false(bufexists('Xa.txt'))
+  bwipe Xb.txt
+  call assert_false(bufexists('Xb.txt'))
 endfunc
 
 func Test_bufwipeout_changes_window()


### PR DESCRIPTION
Problem:  :bwipe doesn't work after switching window from aucmd_win.
Solution: Decrement b_nwindows after switching back to aucmd_win.
