### PR TITLE
Check for a null object only when calling an object method

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -5654,4 +5654,34 @@ def Test_dict_object_member()
   v9.CheckSourceSuccess(lines)
 enddef
 
+" The following test was failing after 9.0.1914.  This was caused by using a
+" freed object from a previous method call.
+def Test_freed_object_from_previous_method_call()
+  var lines =<< trim END
+    vim9script
+
+    class Context
+    endclass
+
+    class Result
+    endclass
+
+    def Failure(): Result
+      return Result.new()
+    enddef
+
+    def GetResult(ctx: Context): Result
+      return Failure()
+    enddef
+
+    def Test_GetResult()
+      var ctx = Context.new()
+      var result = GetResult(ctx)
+    enddef
+
+    Test_GetResult()
+  END
+  v9.CheckSourceSuccess(lines)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -535,15 +535,6 @@ call_dfunc(
     // If this is an object method, the object is just before the arguments.
     typval_T	*obj = STACK_TV_BOT(0) - argcount - vararg_count - 1;
 
-    if (obj->v_type == VAR_OBJECT && obj->vval.v_object == NULL
-					&& !IS_CONSTRUCTOR_METHOD(ufunc))
-    {
-	// If this is not the constructor method, then a valid object is
-	// needed.
-	emsg(_(e_using_null_object));
-	return FAIL;
-    }
-
     // Check the argument types.
     if (check_ufunc_arg_types(ufunc, argcount, vararg_count, ectx) == FAIL)
 	return FAIL;
@@ -610,6 +601,15 @@ call_dfunc(
     // the first local variable.
     if (IS_OBJECT_METHOD(ufunc))
     {
+	if (obj->v_type == VAR_OBJECT && obj->vval.v_object == NULL
+					    && !IS_CONSTRUCTOR_METHOD(ufunc))
+	{
+	    // If this is not a constructor method, then a valid object is
+	    // needed.
+	    emsg(_(e_using_null_object));
+	    return FAIL;
+	}
+
 	*STACK_TV_VAR(0) = *obj;
 	obj->v_type = VAR_UNKNOWN;
     }


### PR DESCRIPTION

Fixes the issue reported in #13154.