### PR TITLE
fix: clang compilation warnings with -Wstrict-prototypes

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1000,7 +1000,7 @@ has_profiling(
 }
 
     static void
-prof_clear_cache()
+prof_clear_cache(void)
 {
     if (!prof_cache_initialized)
     {

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -2070,7 +2070,7 @@ set_ref_in_python3(int copyID)
 }
 
     int
-python3_version()
+python3_version(void)
 {
 #ifdef USE_LIMITED_API
     return Py_LIMITED_API;

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1858,7 +1858,7 @@ ex_xrestore(exarg_T *eap)
     static int
 test_x11_window(Display *dpy)
 {
-    int			(*old_handler)();
+    int			(*old_handler)(Display*, XErrorEvent*);
     XTextProperty	text_prop;
 
     old_handler = XSetErrorHandler(x_error_check);
@@ -7781,9 +7781,9 @@ setup_term_clip(void)
     open_app_context();
     if (app_context != NULL && xterm_Shell == (Widget)0)
     {
-	int (*oldhandler)();
+	int (*oldhandler)(Display*, XErrorEvent*);
 # if defined(USING_SETJMP)
-	int (*oldIOhandler)();
+	int (*oldIOhandler)(Display*);
 # endif
 # ifdef ELAPSED_FUNC
 	elapsed_T start_tv;

--- a/src/proto/if_python3.pro
+++ b/src/proto/if_python3.pro
@@ -10,5 +10,5 @@ void python3_window_free(win_T *win);
 void python3_tabpage_free(tabpage_T *tab);
 void do_py3eval(char_u *str, typval_T *rettv);
 int set_ref_in_python3(int copyID);
-int python3_version();
+int python3_version(void);
 /* vim: set ft=c : */


### PR DESCRIPTION
Change fixes this kind of compilation warnings with clang-17:
```
proto/if_python3.pro:13:20: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
   13 | int python3_version();
      |                    ^
      |                     void
```