### PR TITLE
fix: make test_compiler failed on xubuntu 22.04.3

### DIFF
--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -7,10 +7,8 @@ func Test_compiler()
   CheckExecutable perl
   CheckFeature quickfix
 
-  " $LANG changes the output of Perl.
-  if $LANG != ''
-    unlet $LANG
-  endif
+  let save_LC_ALL = $LC_ALL
+  let $LC_ALL= "C"
 
   " %:S does not work properly with 'shellslash' set
   let save_shellslash = &shellslash
@@ -40,6 +38,7 @@ func Test_compiler()
   let &shellslash = save_shellslash
   call delete('Xfoo.pl')
   bw!
+  let $LC_ALL = save_LC_ALL
 endfunc
 
 func GetCompilerNames()


### PR DESCRIPTION
Problem: `make test_compiler` failed on Linux xubuntu 22.04.3 but succeeded on e.g. macOS. To reproduce:
```
$ ./configure --with-features=huge --enable-gui=no --enable-perlinterp=yes
$ make -j12
$ cd vim/src/testdir
$ make test_compiler
...snip...
Found errors in Test_compiler():
command line..script /home/dope/sb/vim/src/testdir/runtest.vim[601]..function RunTheTest[54]..Test_compiler line 24: command did not fail: clist
command line..script /home/dope/sb/vim/src/testdir/runtest.vim[601]..function RunTheTest[54]..Test_compiler line 30: Pattern '\\n \\d\\+ Xfoo.pl:3: Global symbol "$foo" requires explicit package name' does not match '\n19 Xfoo.pl:3: Global symbol "$foo" requires explicit package name (did you forget to declare "my $foo"?)'
make: *** [Makefile:70: test_compiler] Error 1
```
Solution: set `LC_ALL` to "C" in `Test_compiler()`