### PR TITLE
[vim9script] fully implement lockvar; avoid `SEGV`; accurate error messages.

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3534,8 +3534,12 @@ EXTERN char e_missing_name_after_implements[]
 	INIT(= N_("E1389: Missing name after implements"));
 EXTERN char e_cannot_use_an_object_variable_except_with_the_new_method_str[]
 	INIT(= N_("E1390: Cannot use an object variable \"this.%s\" except with the \"new\" method"));
+EXTERN char e_cannot_lock_object_variable_str[]
+	INIT(= N_("E1391: Cannot (un)lock variable \"%s\" in class \"%s\""));
+EXTERN char e_cannot_lock_class_variable_str[]
+	INIT(= N_("E1392: Cannot (un)lock class variable \"%s\" in class \"%s\""));
 #endif
-// E1391 - E1499 unused (reserved for Vim9 class support)
+// E1393 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/globals.h
+++ b/src/globals.h
@@ -1954,6 +1954,7 @@ EXTERN int  timer_busy INIT(= 0);   // when timer is inside vgetc() then > 0
 EXTERN int  input_busy INIT(= 0);   // when inside get_user_input() then > 0
 
 EXTERN typval_T	*lval_root INIT(= NULL);
+EXTERN int	lval_root_is_arg INIT(= 0);
 #endif
 
 #ifdef FEAT_BEVAL_TERM

--- a/src/proto/vim9instr.pro
+++ b/src/proto/vim9instr.pro
@@ -69,6 +69,7 @@ int generate_MULT_EXPR(cctx_T *cctx, isntype_T isn_type, int count);
 int generate_ECHOWINDOW(cctx_T *cctx, int count, long time);
 int generate_SOURCE(cctx_T *cctx, int sid);
 int generate_PUT(cctx_T *cctx, int regname, linenr_T lnum);
+int generate_LOCKUNLOCK(cctx_T *cctx, char_u *line, int is_arg);
 int generate_EXEC_copy(cctx_T *cctx, isntype_T isntype, char_u *line);
 int generate_EXEC(cctx_T *cctx, isntype_T isntype, char_u *str);
 int generate_LEGACY_EVAL(cctx_T *cctx, char_u *line);

--- a/src/structs.h
+++ b/src/structs.h
@@ -4535,6 +4535,11 @@ typedef struct
  *	"tv"	    points to the (first) list item value
  *	"li"	    points to the (first) list item
  *	"range", "n1", "n2" and "empty2" indicate what items are used.
+ * For a member in a class/object: TODO: verify fields
+ *	"name"	    points to the (expanded) variable name.
+ *	"exp_name"  NULL or non-NULL, to be freed later.
+ *	"tv"	    points to the (first) list item value
+ *	"oi"	    index into member array, see _type to determine which array
  * For an existing Dict item:
  *	"name"	    points to the (expanded) variable name.
  *	"exp_name"  NULL or non-NULL, to be freed later.
@@ -4571,6 +4576,11 @@ typedef struct lval_S
     type_T	*ll_valtype;	// type expected for the value or NULL
     blob_T	*ll_blob;	// The Blob or NULL
     ufunc_T	*ll_ufunc;	// The function or NULL
+    object_T	*ll_object;	// The object or NULL, class is not NULL
+    class_T	*ll_class;	// The class or NULL, object may be NULL
+    int		ll_oi;		// The object/class member index
+    int		ll_is_root;	// Special case. ll_tv is lval_root,
+				// ignore the rest.
 } lval_T;
 
 // Structure used to save the current state.  Used when executing Normal mode

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -500,11 +500,18 @@ typedef struct {
     int		cm_idx;
     int		cm_static;
 } classmember_T;
+
 // arguments to ISN_STOREINDEX
 typedef struct {
     vartype_T	si_vartype;
     class_T	*si_class;
 } storeindex_T;
+
+// arguments to ISN_LOCKUNLOCK
+typedef struct {
+    char_u	*string;	// for exec_command
+    int		is_arg;		// is lval_root a function arg
+} lockunlock_T;
 
 /*
  * Instruction
@@ -562,6 +569,7 @@ struct isn_S {
 	construct_T	    construct;
 	classmember_T	    classmember;
 	storeindex_T	    storeindex;
+	lockunlock_T	    lockunlock;
     } isn_arg;
 };
 

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -189,10 +189,15 @@ compile_lock_unlock(
     int		cc = *name_end;
     char_u	*p = lvp->ll_name;
     int		ret = OK;
-    size_t	len;
     char_u	*buf;
     isntype_T	isn = ISN_EXEC;
     char	*cmd = eap->cmdidx == CMD_lockvar ? "lockvar" : "unlockvar";
+    int		is_arg = FALSE;
+
+#ifdef LOG_LOCKVAR
+    ch_log(NULL, "LKVAR: compile_lock_unlock(): cookie %p, name %s",
+								coookie, p);
+#endif
 
     if (cctx->ctx_skip == SKIP_YES)
 	return OK;
@@ -207,20 +212,68 @@ compile_lock_unlock(
     if (p[1] != ':')
     {
 	char_u *end = find_name_end(p, NULL, NULL, FNE_CHECK_START);
+	// If name is is locally accessible, except for local var,
+	// then put it on the stack to use with ISN_LOCKUNLOCK.
+	// This could be v.memb, v[idx_key]; bare class variable,
+	// function arg. The local variable on the stack, will be passed
+	// to ex_lockvar() indirectly.
 
-	if (lookup_local(p, end - p, NULL, cctx) == OK)
+	char_u	*name = NULL;
+	int	len = end - p;
+
+	if (lookup_local(p, len, NULL, cctx) == OK)
 	{
-	    char_u *s = p;
-
-	    if (*end != '.' && *end != '[')
+	    // Handle "this", "this.val", "anyvar[idx]"
+	    if (*end != '.' && *end != '['
+				&& (len != 4 || STRNCMP("this", p, len) != 0))
 	    {
 		emsg(_(e_cannot_lock_unlock_local_variable));
 		return FAIL;
 	    }
-
-	    // For "d.member" put the local variable on the stack, it will be
-	    // passed to ex_lockvar() indirectly.
-	    if (compile_load(&s, end, cctx, FALSE, FALSE) == FAIL)
+	    // Push the local on the stack, could be "this".
+	    name = p;
+#ifdef LOG_LOCKVAR
+	    ch_log(NULL, "LKVAR: compile... lookup_local: name %s", name);
+#endif
+	}
+	if (name == NULL)
+	{
+	    class_T *cl;
+	    if (cctx_class_member_idx(cctx, p, len, &cl) >= 0)
+	    {
+		if (*end != '.' && *end != '[')
+		{
+		    // Push the class of the bare class variable name
+		    name = cl->class_name;
+		    len = STRLEN(name);
+#ifdef LOG_LOCKVAR
+		    ch_log(NULL, "LKVAR: compile... cctx_class_member: name %s",
+			   name);
+#endif
+		}
+	    }
+	}
+	if (name == NULL)
+	{
+	    int	    idx;
+	    type_T  *type;
+	    // Can lockvar any function arg.
+	    // TODO: test arg[idx]/arg.member
+	    if (arg_exists(p, len, &idx, &type, NULL, cctx) == OK)
+	    {
+		name = p;
+		is_arg = TRUE;
+#ifdef LOG_LOCKVAR
+		ch_log(NULL, "LKVAR: compile... arg_exists: name %s", name);
+#endif
+	    }
+	}
+	if (name != NULL)
+	{
+#ifdef LOG_LOCKVAR
+	    ch_log(NULL, "LKVAR: compile... INS_LOCKUNLOCK %s", name);
+#endif
+	    if (compile_load(&name, name + len, cctx, FALSE, FALSE) == FAIL)
 		return FAIL;
 	    isn = ISN_LOCKUNLOCK;
 	}
@@ -228,7 +281,7 @@ compile_lock_unlock(
 
     // Checking is done at runtime.
     *name_end = NUL;
-    len = name_end - p + 20;
+    size_t len = name_end - p + 20;
     buf = alloc(len);
     if (buf == NULL)
 	ret = FAIL;
@@ -238,7 +291,13 @@ compile_lock_unlock(
 	    vim_snprintf((char *)buf, len, "%s! %s", cmd, p);
 	else
 	    vim_snprintf((char *)buf, len, "%s %d %s", cmd, deep, p);
-	ret = generate_EXEC_copy(cctx, isn, buf);
+#ifdef LOG_LOCKVAR
+	ch_log(NULL, "LKVAR: compile... buf %s", buf);
+#endif
+	if (isn == ISN_LOCKUNLOCK)
+	    ret = generate_LOCKUNLOCK(cctx, buf, is_arg);
+	else
+	    ret = generate_EXEC_copy(cctx, isn, buf);
 
 	vim_free(buf);
 	*name_end = cc;

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -2177,6 +2177,23 @@ generate_PUT(cctx_T *cctx, int regname, linenr_T lnum)
  * A copy is made of "line".
  */
     int
+generate_LOCKUNLOCK(cctx_T *cctx, char_u *line, int is_arg)
+{
+    isn_T	*isn;
+
+    RETURN_OK_IF_SKIP(cctx);
+    if ((isn = generate_instr(cctx, ISN_LOCKUNLOCK)) == NULL)
+	return FAIL;
+    isn->isn_arg.lockunlock.string = vim_strsave(line);
+    isn->isn_arg.lockunlock.is_arg = is_arg;
+    return OK;
+}
+
+/*
+ * Generate an EXEC instruction that takes a string argument.
+ * A copy is made of "line".
+ */
+    int
 generate_EXEC_copy(cctx_T *cctx, isntype_T isntype, char_u *line)
 {
     isn_T	*isn;


### PR DESCRIPTION
- `get_lval()` detects/returns object/class/lval_root in `lval_T`
- `compile_lock_unlock()` generate code for bare_static or obj_arg access
- `do_lock_var()` check lval for `ll_object`/`ll_class` and fail if so.

Details:
- Add `ll_object`/`ll_class`/`ll_oi` to `lval_T`.
- Add `lockunlock_T` to `isn_T` for `is_arg` to specify handling of `lval_root` in `get_lval()`.
- In `get_lval()`, fill in `ll_object`/`ll_class`/`ll_oi` as needed; when no `[idx] or .key`, check lval_root on the way out.
- In `do_lock_var()` check for `ll_object`/`ll_class`; also bullet proof ll_dict case and give `Dictionay required` if problem. (not needed to avoid lockvar crash anymore)
- In `compile_lock_unlock()` compile for the class variable and func arg cases.


This PR gives these vim9class semantics for `lockvar` in vim9.1
- `lockvar` of a `class` or `object` does nothing and no error.
  A possible future extension would allow a class to hook into `lockvar`, ass suggested for `len()`, `empty()` in todo
- handle lockvar of :def argument and other expected scenarios.
- `lockvar` of a class/object variable is an error.