### PR TITLE
[Fix] TUTOR DOCS: typo in tutor.nl

### DIFF
--- a/runtime/tutor/tutor.nl
+++ b/runtime/tutor/tutor.nl
@@ -366,7 +366,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                    Les 3.1: HET COMMANDO PLAK
 
-  ** Tik  p  ('put') en plak daarmee zojuist gewiste tekst na te cursor. **
+  ** Tik  p  ('put') en plak daarmee zojuist gewiste tekst na de cursor. **
 
   1. Ga met de cursor naar de eerste regel met ---> hierna.
 

--- a/runtime/tutor/tutor.nl.utf-8
+++ b/runtime/tutor/tutor.nl.utf-8
@@ -366,7 +366,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                    Les 3.1: HET COMMANDO PLAK
 
-  ** Tik  p  ('put') en plak daarmee zojuist gewiste tekst na te cursor. **
+  ** Tik  p  ('put') en plak daarmee zojuist gewiste tekst na de cursor. **
 
   1. Ga met de cursor naar de eerste regel met ---> hierna.
 


### PR DESCRIPTION
This PR includes a fix for a typo in the Dutch vimtutor `tutor.nl` file.