### PR TITLE
Add additional checks when parsing a class definition

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4479,6 +4479,9 @@ E1380	vim9class.txt	/*E1380*
 E1381	vim9class.txt	/*E1381*
 E1382	vim9class.txt	/*E1382*
 E1383	vim9class.txt	/*E1383*
+E1387	vim9class.txt	/*E1387*
+E1388	vim9class.txt	/*E1388*
+E1389	vim9class.txt	/*E1389*
 E139	message.txt	/*E139*
 E140	message.txt	/*E140*
 E1400	builtin.txt	/*E1400*

--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -464,10 +464,10 @@ The interface name can be used as a type: >
 	   echo $'the surface is {shape.Surface()}'
 	endfor
 <
-						*E1378* *E1379* *E1380*
-An interface can have only instance variables (read-only and read-write
-access) and methods.  An interface cannot contain private variables, private
-methods, class variables and class methods.
+					*E1378* *E1379* *E1380* *E1387*
+An interface can contain only object methods and read-only object variables.
+An interface cannot contain read-write and private object variables, private
+object methods, class variables and class methods.
 
 An interface can extend another interface using "extends".  The sub-interface
 inherits all the instance variables and methods from the super interface.
@@ -563,7 +563,7 @@ will be added automatically.
 
 
 A class implementing an interface ~
-						*implements* *E1346* *E1347*
+					*implements* *E1346* *E1347* *E1389*
 A class can implement one or more interfaces.  The "implements" keyword can
 only appear once *E1350* .  Multiple interfaces can be specified, separated by
 commas.  Each interface name can appear only once. *E1351*
@@ -577,7 +577,7 @@ interface, which is often done in many languages, especially Java.
 
 
 Items in a class ~
-						*E1318* *E1325*
+						*E1318* *E1325* *E1388*
 Inside a class, in between `:class` and `:endclass`, these items can appear:
 - An object variable declaration: >
 	this._privateVariableName: memberType

--- a/src/errors.h
+++ b/src/errors.h
@@ -3523,6 +3523,12 @@ EXTERN char e_class_method_str_accessible_only_using_class_str[]
 	INIT(= N_("E1385: Class method \"%s\" accessible only using class \"%s\""));
 EXTERN char e_object_method_str_accessible_only_using_object_str[]
 	INIT(= N_("E1386: Object method \"%s\" accessible only using class \"%s\" object"));
+EXTERN char e_public_member_not_supported_in_interface[]
+	INIT(= N_("E1387: Public variable not supported in an interface"));
+EXTERN char e_public_keyword_not_supported_for_method[]
+	INIT(= N_("E1388: Public keyword not supported for a method"));
+EXTERN char e_missing_name_after_implements[]
+	INIT(= N_("E1389: Missing name after implements"));
 #endif
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1400: Cannot mix positional and non-positional arguments: %s"));
@@ -3538,4 +3544,4 @@ EXTERN char e_invalid_format_specifier_str[]
 	INIT(= N_("E1405: Invalid format specifier: %s"));
 EXTERN char e_aptypes_is_null_nr_str[]
 	INIT(= "E1408: Internal error: ap_types or ap_types[idx] is NULL: %d: %s");
-// E1387 - E1399 unused
+// E1390 - E1399 unused

--- a/src/eval.c
+++ b/src/eval.c
@@ -1220,8 +1220,7 @@ get_lval(
 	int r = OK;
 	if (v_type == VAR_LIST && lp->ll_tv->vval.v_list == NULL)
 	    r = rettv_list_alloc(lp->ll_tv);
-	else if (v_type == VAR_BLOB
-					     && lp->ll_tv->vval.v_blob == NULL)
+	else if (v_type == VAR_BLOB && lp->ll_tv->vval.v_blob == NULL)
 	    r = rettv_blob_alloc(lp->ll_tv);
 	if (r == FAIL)
 	    return NULL;

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -3052,15 +3052,15 @@ def Test_disassemble_interface_static_member()
   var lines =<< trim END
     vim9script
     interface I
-      public this.o_var: number
-      public this.o_var2: number
+      this.o_var: number
+      this.o_var2: number
     endinterface
 
     class C implements I
       public static s_var: number
-      public this.o_var: number
+      this.o_var: number
       public static s_var2: number
-      public this.o_var2: number
+      this.o_var2: number
     endclass
 
     def F1(i: I)


### PR DESCRIPTION
Also, support only read-only object variables in an interface.

Fixes #13183, #13184 and #13185.