### PR TITLE
Fix 'scrollbind' not working when scrolling inactive window

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -1171,6 +1171,9 @@ do_mousescroll(cmdarg_T *cap)
 	    leftcol = 0;
 	do_mousescroll_horiz((long_u)leftcol);
     }
+
+    if (curwin->w_p_scb)
+	do_check_scrollbind(TRUE);
     may_trigger_win_scrolled_resized();
 }
 

--- a/src/move.c
+++ b/src/move.c
@@ -3587,7 +3587,7 @@ do_check_cursorbind(void)
     FOR_ALL_WINDOWS(curwin)
     {
 	curbuf = curwin->w_buffer;
-	// skip original window  and windows with 'noscrollbind'
+	// skip original window and windows with 'nocursorbind'
 	if (curwin != old_curwin && curwin->w_p_crb)
 	{
 # ifdef FEAT_DIFF

--- a/src/testdir/test_scrollbind.vim
+++ b/src/testdir/test_scrollbind.vim
@@ -30,6 +30,9 @@ func Test_scrollbind()
   wincmd p
   setl noscrollbind
   call assert_equal(0, topLineLeft - topLineRight)
+
+  bwipe!
+  bwipe!
 endfunc
 
 " Test for 'scrollbind'
@@ -266,10 +269,44 @@ end of window 2
 	      \ '. line 15 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ 15',
 	      \ '. line 12 ZYXWVUTSRQPONMLKJIHGREDCBA9876543210 12',
 	      \ ],  getline(1, '$'))
-  enew!
 
-  new | only!
+  bwipe!
+  bwipe!
+  bwipe!
   set scrollbind& scrollopt& scrolloff& wrap& equalalways& splitbelow&
+endfunc
+
+func Test_scrollbind_mouse()
+  new | only
+  let w1 = win_getid()
+  setlocal nowrap scrollbind
+  call setline(1, range(1, 8))
+  rightbelow vnew
+  let w2 = win_getid()
+  setlocal nowrap scrollbind
+  call setline(1, range(1, 8))
+
+  for w in [w1, w2]
+    call win_gotoid(w)
+    call test_setmouse(1, 1)
+    call assert_equal(1, line('w0', w1))
+    call assert_equal(1, line('w0', w2))
+    call feedkeys("\<ScrollWheelDown>", 'xt')
+    call assert_equal(4, line('w0', w1))
+    call assert_equal(4, line('w0', w2))
+    call feedkeys("\<ScrollWheelDown>", 'xt')
+    call assert_equal(7, line('w0', w1))
+    call assert_equal(7, line('w0', w2))
+    call feedkeys("\<ScrollWheelUp>", 'xt')
+    call assert_equal(4, line('w0', w1))
+    call assert_equal(4, line('w0', w2))
+    call feedkeys("\<ScrollWheelUp>", 'xt')
+    call assert_equal(1, line('w0', w1))
+    call assert_equal(1, line('w0', w2))
+  endfor
+
+  bwipe!
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  'scrollbind' doesn't work when scrolling inactive window.
Solution: Call do_check_scrollbind() after scrolling inactive window.
