### PR TITLE
Use the funcref instruction index instead of the instruction pointer

### DIFF
--- a/src/proto/vim9instr.pro
+++ b/src/proto/vim9instr.pro
@@ -45,7 +45,7 @@ int generate_OLDSCRIPT(cctx_T *cctx, isntype_T isn_type, char_u *name, int sid, 
 int generate_VIM9SCRIPT(cctx_T *cctx, isntype_T isn_type, int sid, int idx, type_T *type);
 int generate_NEWLIST(cctx_T *cctx, int count, int use_null);
 int generate_NEWDICT(cctx_T *cctx, int count, int use_null);
-int generate_FUNCREF(cctx_T *cctx, ufunc_T *ufunc, class_T *cl, int fi, isn_T **isnp);
+int generate_FUNCREF(cctx_T *cctx, ufunc_T *ufunc, class_T *cl, int fi, int *isn_idx);
 int generate_NEWFUNC(cctx_T *cctx, char_u *lambda_name, char_u *func_name);
 int generate_DEF(cctx_T *cctx, char_u *name, size_t len);
 int generate_JUMP(cctx_T *cctx, jumpwhen_T when, int where);

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -4636,6 +4636,56 @@ def Test_free_type_before_use()
   v9.CheckScriptSuccess(lines)
 enddef
 
+" The following complicated script used to cause an internal error (E340)
+" because the funcref instruction memory was referenced after the instruction
+" memory was reallocated (Github issue #13178)
+def Test_refer_funcref_instr_after_realloc()
+  var lines =<< trim END
+    vim9script
+    def A(d: bool)
+      var e = abs(0)
+      var f = &emoji
+      &emoji = true
+      if ['', '', '']->index('xxx') == 0
+        eval 0 + 0
+      endif
+      if &filetype == 'xxx'
+        var g = abs(0)
+        while g > 0
+          if getline(g) == ''
+            break
+          endif
+          --g
+        endwhile
+        if g == 0
+          return
+        endif
+        if d
+          feedkeys($'{g}G')
+          g = abs(0)
+        endif
+        var h = abs(0)
+        var i = abs(0)
+        var j = abs(0)
+        while j < 0
+          if abs(0) < h && getline(j) != ''
+          break
+          endif
+          ++j
+        endwhile
+        feedkeys($'{g}G{j}G')
+        return
+      endif
+      def B()
+      enddef
+      def C()
+      enddef
+    enddef
+    A(false)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " Keep this last, it messes up highlighting.
 def Test_substitute_cmd()
   new

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1029,7 +1029,7 @@ compile_nested_function(exarg_T *eap, cctx_T *cctx, garray_T *lines_to_free)
     ufunc_T	*ufunc;
     int		r = FAIL;
     compiletype_T   compile_type;
-    isn_T	*funcref_isn = NULL;
+    int		funcref_isn_idx = -1;
     lvar_T	*lvar = NULL;
 
     if (eap->forceit)
@@ -1148,7 +1148,7 @@ compile_nested_function(exarg_T *eap, cctx_T *cctx, garray_T *lines_to_free)
 					    ASSIGN_CONST, ufunc->uf_func_type);
 	if (lvar == NULL)
 	    goto theend;
-	if (generate_FUNCREF(cctx, ufunc, NULL, 0, &funcref_isn) == FAIL)
+	if (generate_FUNCREF(cctx, ufunc, NULL, 0, &funcref_isn_idx) == FAIL)
 	    goto theend;
 	r = generate_STORE(cctx, ISN_STORE, lvar->lv_idx, NULL);
     }
@@ -1178,8 +1178,12 @@ compile_nested_function(exarg_T *eap, cctx_T *cctx, garray_T *lines_to_free)
 #endif
 
     // If a FUNCREF instruction was generated, set the index after compiling.
-    if (funcref_isn != NULL && ufunc->uf_def_status == UF_COMPILED)
+    if (funcref_isn_idx != -1 && ufunc->uf_def_status == UF_COMPILED)
+    {
+	isn_T	*funcref_isn = ((isn_T *)cctx->ctx_instr.ga_data) +
+							funcref_isn_idx;
 	funcref_isn->isn_arg.funcref.fr_dfunc_idx = ufunc->uf_dfunc_idx;
+    }
 
 theend:
     vim_free(lambda_name);


### PR DESCRIPTION
A pointer to the funcref instruction is saved so that the function index can be updated later.  But before the function index can be updated, additional instructions are generated.  This may result in the instruction memory getting reallocated thereby invalidating the saved pointer.  To fix this problem, instead of using the instruction pointer, use the instruction index.

Fixes #13178