### PR TITLE
Add extended attribute support (Linux)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
               tcl-dev \
               cscope \
               libsodium-dev \
+              attr \
+              libattr1-dev
             )
           fi
           sudo apt-get update && sudo apt-get install -y "${PKGS[@]}"

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.0.  Last change: 2023 Aug 09
+*builtin.txt*	For Vim version 9.0.  Last change: 2023 Sep 27
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -11082,6 +11082,8 @@ winaltkeys		Compiled with 'winaltkeys' option.
 windows			Compiled with support for more than one window.
 			(always true)
 writebackup		Compiled with 'writebackup' default on.
+xattr			Compiled with extended attributes support |xattr|
+			(currently only supported on Linux).
 xfontset		Compiled with X fontset support |xfontset|.
 xim			Compiled with X input method support |xim|.
 xpm			Compiled with pixmap support.

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1,4 +1,4 @@
-*editing.txt*   For Vim version 9.0.  Last change: 2023 Sep 22
+*editing.txt*   For Vim version 9.0.  Last change: 2023 Sep 27
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1096,6 +1096,13 @@ when the filesystem supports it.
 will get the ACL info of the original file.
    The ACL info is also used to check if a file is read-only (when opening the
 file).
+
+				*xattr* *E1506* *E1507* *E1508* *E1509*
+xattr stands for Extended Attributes  It is an advanced way to save metadata
+alongside the file in the filesystem.  It depends on the actual filesystem
+being used and Vim supports it only on a Linux system.
+   Vim attempts to preserve the extended attribute info when writing a file.
+The backup file will get the extended attribute of the original file.
 
 						*read-only-share*
 When MS-Windows shares a drive on the network it can be marked as read-only.

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -1483,6 +1483,7 @@ $quote	eval.txt	/*$quote*
 +wildmenu	various.txt	/*+wildmenu*
 +windows	various.txt	/*+windows*
 +writebackup	various.txt	/*+writebackup*
++xattr	various.txt	/*+xattr*
 +xfontset	various.txt	/*+xfontset*
 +xim	various.txt	/*+xim*
 +xpm	various.txt	/*+xpm*
@@ -4506,6 +4507,10 @@ E1502	builtin.txt	/*E1502*
 E1503	builtin.txt	/*E1503*
 E1504	builtin.txt	/*E1504*
 E1505	builtin.txt	/*E1505*
+E1506	editing.txt	/*E1506*
+E1507	editing.txt	/*E1507*
+E1508	editing.txt	/*E1508*
+E1509	editing.txt	/*E1509*
 E151	helphelp.txt	/*E151*
 E152	helphelp.txt	/*E152*
 E153	helphelp.txt	/*E153*
@@ -11224,6 +11229,7 @@ x-resources	version5.txt	/*x-resources*
 x11-clientserver	remote.txt	/*x11-clientserver*
 x11-cut-buffer	gui_x11.txt	/*x11-cut-buffer*
 x11-selection	gui_x11.txt	/*x11-selection*
+xattr	editing.txt	/*xattr*
 xf86conf.vim	syntax.txt	/*xf86conf.vim*
 xfontset	mbyte.txt	/*xfontset*
 xfree-xterm	syntax.txt	/*xfree-xterm*

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -1,4 +1,4 @@
-*various.txt*   For Vim version 9.0.  Last change: 2022 Dec 13
+*various.txt*   For Vim version 9.0.  Last change: 2023 Sep 27
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -503,6 +503,7 @@ T  *+windows*		more than one window; Always enabled since 8.0.1118.
 m  *+writebackup*	|'writebackup'| is default on
 m  *+xim*		X input method |xim|
    *+xfontset*		X fontset support |xfontset|
+N  *+xattr*		compiled with extended attribute support (Linux only)
    *+xpm*		pixmap support
 m  *+xpm_w32*		Win32 GUI only: pixmap support |w32-xpm-support|
    *+xsmp*		XSMP (X session management) support

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -825,6 +825,7 @@ with_global_runtime
 with_modified_by
 enable_smack
 enable_selinux
+enable_xattr
 with_features
 with_compiledby
 enable_xsmp
@@ -1514,6 +1515,7 @@ Optional Features:
   --disable-darwin        Disable Darwin (Mac OS X) support.
   --disable-smack	  Do not check for Smack support.
   --disable-selinux	  Do not check for SELinux support.
+  --disable-xattr	  Do not check for XATTR support.
   --disable-xsmp          Disable XSMP session management
   --disable-xsmp-interact Disable XSMP interaction
   --enable-luainterp=OPTS      Include Lua interpreter.  default=no OPTS=no/yes/dynamic
@@ -5418,6 +5420,32 @@ fi
 printf "%s\n" "yes" >&6; }
   fi
 fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --enable-xattr argument" >&5
+printf %s "checking --enable-xattr argument... " >&6; }
+# Check whether --enable-xattr was given.
+if test ${enable_xattr+y}
+then :
+  enableval=$enable_xattr;
+else $as_nop
+  enable_xattr="yes"
+fi
+
+if test "$enable_xattr" = "yes"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+  ac_fn_c_check_header_compile "$LINENO" "attr/xattr.h" "ac_cv_header_attr_xattr_h" "$ac_includes_default"
+if test "x$ac_cv_header_attr_xattr_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_XATTR 1" >>confdefs.h
+
+fi
+
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
 
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --with-features argument" >&5

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1471,6 +1471,9 @@ buf_write(
 # if defined(HAVE_SELINUX) || defined(HAVE_SMACK)
 			mch_copy_sec(fname, backup);
 # endif
+# ifdef FEAT_XATTR
+			mch_copy_xattr(fname, backup);
+# endif
 #endif
 
 			// copy the file.
@@ -1505,6 +1508,9 @@ buf_write(
 #endif
 #if defined(HAVE_SELINUX) || defined(HAVE_SMACK)
 			mch_copy_sec(fname, backup);
+#endif
+#ifdef FEAT_XATTR
+			mch_copy_xattr(fname, backup);
 #endif
 #ifdef MSWIN
 			(void)mch_copy_file_attribute(fname, backup);
@@ -2196,10 +2202,17 @@ restore_backup:
 	}
 #endif
 
-#if defined(HAVE_SELINUX) || defined(HAVE_SMACK)
+#if defined(HAVE_SELINUX) || defined(HAVE_SMACK) || defined(FEAT_XATTR)
 	// Probably need to set the security context.
 	if (!backup_copy)
+	{
+#if defined(HAVE_SELINUX) || defined(HAVE_SMACK)
 	    mch_copy_sec(backup, wfname);
+#endif
+#ifdef FEAT_XATTR
+	    mch_copy_xattr(backup, wfname);
+#endif
+	}
 #endif
 
 #ifdef UNIX

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -226,6 +226,7 @@
 #undef HAVE_MBLEN
 #undef HAVE_TIMER_CREATE
 #undef HAVE_CLOCK_GETTIME
+#undef HAVE_XATTR
 
 /* Define, if needed, for accessing large files. */
 #undef _LARGE_FILES

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -513,6 +513,18 @@ if test "x$found_smack" = "x"; then
   fi
 fi
 
+dnl enable xattr support
+AC_MSG_CHECKING(--enable-xattr argument)
+AC_ARG_ENABLE(xattr,
+	[  --disable-xattr	  Do not check for XATTR support.],
+	, enable_xattr="yes")
+if test "$enable_xattr" = "yes"; then
+  AC_MSG_RESULT(yes)
+  AC_CHECK_HEADER([attr/xattr.h], [AC_DEFINE(HAVE_XATTR)])
+else
+  AC_MSG_RESULT(no)
+fi
+
 dnl Check user requested features.
 
 AC_MSG_CHECKING(--with-features argument)

--- a/src/errors.h
+++ b/src/errors.h
@@ -3552,6 +3552,14 @@ EXTERN char e_positional_arg_num_type_inconsistent_str_str[]
 	INIT(= N_("E1504: Positional argument %d type used inconsistently: %s/%s"));
 EXTERN char e_invalid_format_specifier_str[]
 	INIT(= N_("E1505: Invalid format specifier: %s"));
-// E1506 - E1519 unused
+EXTERN char e_xattr_erange[]
+	INIT(= N_("E1506: Buffer too small to copy xattr value or key"));
+EXTERN char e_xattr_enotsup[]
+	INIT(= N_("E1507: Extended attributes are not supported by the filesystem"));
+EXTERN char e_xattr_e2big[]
+	INIT(= N_("E1508: size of the extended attribute value is larger than the maximum size allowed"));
+EXTERN char e_xattr_other[]
+	INIT(= N_("E1509: error occured when reading or writing extended attribute"));
+// E1509 - E1519 unused
 EXTERN char e_aptypes_is_null_nr_str[]
 	INIT(= "E1520: Internal error: ap_types or ap_types[idx] is NULL: %d: %s");

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6464,6 +6464,13 @@ f_has(typval_T *argvars, typval_T *rettv)
 		0
 #endif
 		},
+	{"xattr",
+#ifdef FEAT_XATTR
+		1
+#else
+		0
+#endif
+		},
 	{"xim",
 #ifdef FEAT_XIM
 		1

--- a/src/feature.h
+++ b/src/feature.h
@@ -22,7 +22,7 @@
  * - Add a #define below.
  * - Add a message in the table above ex_version().
  * - Add a string to f_has().
- * - Add a feature to ":help feature-list" in doc/eval.txt.
+ * - Add a feature to ":help feature-list" in doc/builtin.txt.
  * - Add feature to ":help +feature-list" in doc/various.txt.
  * - Add comment for the documentation of commands that use the feature.
  */
@@ -1174,4 +1174,12 @@
 	|| defined(DYNAMIC_LUA) \
 	|| defined(FEAT_TERMINAL)
 # define USING_LOAD_LIBRARY
+#endif
+
+/*
+ * XATTR support
+ */
+
+#if defined(FEAT_NORMAL) && defined(HAVE_XATTR)
+# define FEAT_XATTR
 #endif

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -37,6 +37,7 @@ long mch_getperm(char_u *name);
 int mch_setperm(char_u *name, long perm);
 int mch_fsetperm(int fd, long perm);
 void mch_copy_sec(char_u *from_file, char_u *to_file);
+void mch_copy_xattr(char_u *from_file, char_u *to_file);
 vim_acl_T mch_get_acl(char_u *fname);
 void mch_set_acl(char_u *fname, vim_acl_T aclent);
 void mch_free_acl(vim_acl_T aclent);

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -977,4 +977,27 @@ func Test_wq_quitpre_autocommand()
   call delete('Xsomefile')
 endfunc
 
+func Test_write_with_xattr_support()
+  CheckLinux
+  CheckExecutable setfattr
+
+  let contents = ["file with xattrs", "line two"]
+  call writefile(contents, 'Xwattr.txt', 'D')
+  " write a couple of xattr
+  call system('setfattr -n user.cookie -v chocolate Xwattr.txt')
+  call system('setfattr -n user.frieda -v bar Xwattr.txt')
+  call system('setfattr -n user.empty Xwattr.txt')
+
+  set backupcopy=no writebackup& backup&
+  sp Xwattr.txt
+  w
+  $r! getfattr -d %
+  let expected = ['file with xattrs', 'line two', '# file: Xwattr.txt', 'user.cookie="chocolate"', 'user.empty=""', 'user.frieda="bar"', '']
+  call assert_equal(expected, getline(1,'$'))
+
+  set backupcopy&
+  bw!
+
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/version.c
+++ b/src/version.c
@@ -654,6 +654,11 @@ static char *(features[]) =
 	"-X11",
 # endif
 #endif
+# ifdef FEAT_XATTR
+	"+xattr",
+# else
+	"-xattr",
+# endif
 #ifdef FEAT_XFONTSET
 	"+xfontset",
 #else


### PR DESCRIPTION
It's been a long standing issue, that if you write a file with extended attributes and backupcopy=no, the file will loose the extended attributes.

So this patch adds support for retrieving the extended attributes and copying it to the new file. It currently only works on linux, mainly I don't know the different APIs for other systems (BSD, MacOSX and Solaris).  On linux, this should be supported since Kernel 2.4 or something, so this should be pretty safe to use now.

I think it makes sense to have this enabled in normal builds so it is not so surprising if one loses those attributes, but not sure.

I also added it explicitly to the :version output as well as make it able to check using `:echo has("xattr")`, to have users easily check that this is available.

In contrast to the similar support for SELINUX and SMACK support (which also internally uses extended attributes), I have made this a FEAT_XATTR define, instead of the similar HAVE_XATTR, but that should just be a implementation detail (but happy to change if wanted).

todo:
[ ] try to write tests.

closes: #306