### PR TITLE
win32,macOS: Disable Test_glob_extended_bash

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -3629,6 +3629,8 @@ endfunc
 func Test_glob_extended_bash()
   CheckExecutable bash
   CheckNotMSWindows
+  CheckNotMac   " The default version of bash is old on macOS.
+
   let _shell = &shell
   set shell=bash
 

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -3628,6 +3628,7 @@ endfunc
 " Test for glob() with shell special patterns
 func Test_glob_extended_bash()
   CheckExecutable bash
+  CheckNotMSWindows
   let _shell = &shell
   set shell=bash
 


### PR DESCRIPTION
This test doesn't work on Windows even if bash can be executed.