### PR TITLE
Include the line number in assert_xxx() calls

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4479,6 +4479,9 @@ E1380	vim9class.txt	/*E1380*
 E1381	vim9class.txt	/*E1381*
 E1382	vim9class.txt	/*E1382*
 E1383	vim9class.txt	/*E1383*
+E1384	vim9class.txt	/*E1384*
+E1385	vim9class.txt	/*E1385*
+E1386	vim9class.txt	/*E1386*
 E1387	vim9class.txt	/*E1387*
 E1388	vim9class.txt	/*E1388*
 E1389	vim9class.txt	/*E1389*

--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -257,9 +257,14 @@ If the class extends a parent class, the same thing happens.  In the second
 step the object variables of the parent class are initialized first.  There is
 no need to call "super()" or "new()" on the parent.
 
-						*E1365*
+							*E1365*
 When defining the new() method the return type should not be specified.  It
 always returns an object of the class.
+
+							*E1386*
+When invoking an object method, the method name should be preceded by the
+object variable name.  A object method cannot be invoked using the class
+name.
 
 ==============================================================================
 
@@ -281,7 +286,7 @@ prefix in the class where they are defined: >
 Since the name is used as-is, shadowing the name by a method argument name
 or local variable name is not allowed.
 
-							*E1374* *E1375*
+					    *E1374* *E1375* *E1384* *E1385*
 To access a class member outside of the class where it is defined, the class
 name prefix must be used.  A class member cannot be accessed using an object.
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -2396,6 +2396,7 @@ EXTERN char e_io_file_requires_name_to_be_set[]
 #ifdef FEAT_EVAL
 EXTERN char e_invalid_callback_argument[]
 	INIT(= N_("E921: Invalid callback argument"));
+// E922 unused
 EXTERN char e_second_argument_of_function_must_be_list_or_dict[]
 	INIT(= N_("E923: Second argument of function() must be a list or a dict"));
 #endif
@@ -2790,7 +2791,7 @@ EXTERN char e_no_white_space_allowed_after_dot[]
 	INIT(= N_("E1074: No white space allowed after dot"));
 EXTERN char e_namespace_not_supported_str[]
 	INIT(= N_("E1075: Namespace not supported: %s"));
-// E1076 was deleted
+// E1076 unused (was deleted)
 EXTERN char e_missing_argument_type_for_str[]
 	INIT(= N_("E1077: Missing argument type for %s"));
 #endif
@@ -2858,6 +2859,7 @@ PLURAL_MSG(e_one_argument_too_many, "E1106: One argument too many",
 
 EXTERN char e_string_list_dict_or_blob_required[]
 	INIT(= N_("E1107: String, List, Dict or Blob required"));
+// E1108 unused
 EXTERN char e_list_item_nr_is_not_list[]
 	INIT(= N_("E1109: List item %d is not a List"));
 EXTERN char e_list_item_nr_does_not_contain_3_numbers[]
@@ -3210,6 +3212,7 @@ EXTERN char e_list_dict_blob_or_string_required_for_argument_nr[]
 	INIT(= N_("E1251: List, Dictionary, Blob or String required for argument %d"));
 EXTERN char e_string_list_or_blob_required_for_argument_nr[]
 	INIT(= N_("E1252: String, List or Blob required for argument %d"));
+// E1253 unused
 EXTERN char e_cannot_use_script_variable_in_for_loop[]
 	INIT(= N_("E1254: Cannot use script variable in for loop"));
 #endif
@@ -3523,7 +3526,7 @@ EXTERN char e_class_method_str_accessible_only_using_class_str[]
 	INIT(= N_("E1385: Class method \"%s\" accessible only using class \"%s\""));
 EXTERN char e_object_method_str_accessible_only_using_object_str[]
 	INIT(= N_("E1386: Object method \"%s\" accessible only using class \"%s\" object"));
-EXTERN char e_public_member_not_supported_in_interface[]
+EXTERN char e_public_variable_not_supported_in_interface[]
 	INIT(= N_("E1387: Public variable not supported in an interface"));
 EXTERN char e_public_keyword_not_supported_for_method[]
 	INIT(= N_("E1388: Public keyword not supported for a method"));

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -6,151 +6,151 @@ import './vim9.vim' as v9
 def Test_class_basic()
   # Class supported only in "vim9script"
   var lines =<< trim END
-      class NotWorking
-      endclass
+    class NotWorking
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1316:')
+  v9.CheckSourceFailure(lines, 'E1316: Class can only be defined in Vim9 script', 1)
 
   # First character in a class name should be capitalized.
   lines =<< trim END
-      vim9script
-      class notWorking
-      endclass
+    vim9script
+    class notWorking
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1314:')
+  v9.CheckSourceFailure(lines, 'E1314: Class name must start with an uppercase letter: notWorking', 2)
 
   # Only alphanumeric characters are supported in a class name
   lines =<< trim END
-      vim9script
-      class Not@working
-      endclass
+    vim9script
+    class Not@working
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1315:')
+  v9.CheckSourceFailure(lines, 'E1315: White space required after name: Not@working', 2)
 
   # Unsupported keyword (instead of class)
   lines =<< trim END
-      vim9script
-      abstract noclass Something
-      endclass
+    vim9script
+    abstract noclass Something
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E475:')
+  v9.CheckSourceFailure(lines, 'E475: Invalid argument: noclass Something', 2)
 
   # Only the completed word "class" should be recognized
   lines =<< trim END
-      vim9script
-      abstract classy Something
-      endclass
+    vim9script
+    abstract classy Something
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E475:')
+  v9.CheckSourceFailure(lines, 'E475: Invalid argument: classy Something', 2)
 
   # The complete "endclass" should be specified.
   lines =<< trim END
-      vim9script
-      class Something
-      endcl
+    vim9script
+    class Something
+    endcl
   END
-  v9.CheckSourceFailure(lines, 'E1065:')
+  v9.CheckSourceFailure(lines, 'E1065: Command cannot be shortened: endcl', 3)
 
   # Additional words after "endclass"
   lines =<< trim END
-      vim9script
-      class Something
-      endclass school's out
+    vim9script
+    class Something
+    endclass school's out
   END
-  v9.CheckSourceFailure(lines, 'E488:')
+  v9.CheckSourceFailure(lines, "E488: Trailing characters: school's out", 3)
 
   # Additional commands after "endclass"
   lines =<< trim END
-      vim9script
-      class Something
-      endclass | echo 'done'
+    vim9script
+    class Something
+    endclass | echo 'done'
   END
-  v9.CheckSourceFailure(lines, 'E488:')
+  v9.CheckSourceFailure(lines, "E488: Trailing characters: | echo 'done'", 3)
 
   # Use "this" without any member variable name
   lines =<< trim END
-      vim9script
-      class Something
-        this
-      endclass
+    vim9script
+    class Something
+      this
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1317:')
+  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: this', 3)
 
   # Use "this." without any member variable name
   lines =<< trim END
-      vim9script
-      class Something
-        this.
-      endclass
+    vim9script
+    class Something
+      this.
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1317:')
+  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: this.', 3)
 
   # Space between "this" and ".<variable>"
   lines =<< trim END
-      vim9script
-      class Something
-        this .count
-      endclass
+    vim9script
+    class Something
+      this .count
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1317:')
+  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: this .count', 3)
 
   # Space between "this." and the member variable name
   lines =<< trim END
-      vim9script
-      class Something
-        this. count
-      endclass
+    vim9script
+    class Something
+      this. count
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1317:')
+  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: this. count', 3)
 
   # Use "that" instead of "this"
   lines =<< trim END
-      vim9script
-      class Something
-        this.count: number
-        that.count
-      endclass
+    vim9script
+    class Something
+      this.count: number
+      that.count
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: that.count')
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: that.count', 4)
 
   # Member variable without a type or initialization
   lines =<< trim END
-      vim9script
-      class Something
-        this.count
-      endclass
+    vim9script
+    class Something
+      this.count
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1022:')
+  v9.CheckSourceFailure(lines, 'E1022: Type or initialization required', 3)
 
   # Use a non-existing member variable in new()
   lines =<< trim END
-      vim9script
-      class Something
-        def new()
-          this.state = 0
-        enddef
-      endclass
-      var obj = Something.new()
+    vim9script
+    class Something
+      def new()
+        this.state = 0
+      enddef
+    endclass
+    var obj = Something.new()
   END
-  v9.CheckSourceFailure(lines, 'E1326: Variable not found on object "Something": state')
+  v9.CheckSourceFailure(lines, 'E1326: Variable not found on object "Something": state', 1)
 
   # Space before ":" in a member variable declaration
   lines =<< trim END
-      vim9script
-      class Something
-        this.count : number
-      endclass
+    vim9script
+    class Something
+      this.count : number
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1059:')
+  v9.CheckSourceFailure(lines, 'E1059: No white space allowed before colon: count : number', 3)
 
   # No space after ":" in a member variable declaration
   lines =<< trim END
-      vim9script
-      class Something
-        this.count:number
-      endclass
+    vim9script
+    class Something
+      this.count:number
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1069:')
+  v9.CheckSourceFailure(lines, "E1069: White space required after ':'", 3)
 
   # Test for unsupported comment specifier
   lines =<< trim END
@@ -160,7 +160,7 @@ def Test_class_basic()
       #{
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1170:')
+  v9.CheckSourceFailure(lines, 'E1170: Cannot use #{ to start a comment', 3)
 
   # Test for using class as a bool
   lines =<< trim END
@@ -170,7 +170,7 @@ def Test_class_basic()
     if A
     endif
   END
-  v9.CheckSourceFailure(lines, 'E1319: Using a class as a Number')
+  v9.CheckSourceFailure(lines, 'E1319: Using a class as a Number', 4)
 
   # Test for using object as a bool
   lines =<< trim END
@@ -181,7 +181,7 @@ def Test_class_basic()
     if a
     endif
   END
-  v9.CheckSourceFailure(lines, 'E1320: Using an object as a Number')
+  v9.CheckSourceFailure(lines, 'E1320: Using an object as a Number', 5)
 
   # Test for using class as a float
   lines =<< trim END
@@ -190,7 +190,7 @@ def Test_class_basic()
     endclass
     sort([1.1, A], 'f')
   END
-  v9.CheckSourceFailure(lines, 'E1321: Using a class as a Float')
+  v9.CheckSourceFailure(lines, 'E1321: Using a class as a Float', 4)
 
   # Test for using object as a float
   lines =<< trim END
@@ -200,7 +200,7 @@ def Test_class_basic()
     var a = A.new()
     sort([1.1, a], 'f')
   END
-  v9.CheckSourceFailure(lines, 'E1322: Using an object as a Float')
+  v9.CheckSourceFailure(lines, 'E1322: Using an object as a Float', 5)
 
   # Test for using class as a string
   lines =<< trim END
@@ -209,7 +209,7 @@ def Test_class_basic()
     endclass
     :exe 'call ' .. A
   END
-  v9.CheckSourceFailure(lines, 'E1323: Using a class as a String')
+  v9.CheckSourceFailure(lines, 'E1323: Using a class as a String', 4)
 
   # Test for using object as a string
   lines =<< trim END
@@ -219,35 +219,35 @@ def Test_class_basic()
     var a = A.new()
     :exe 'call ' .. a
   END
-  v9.CheckSourceFailure(lines, 'E1324: Using an object as a String')
+  v9.CheckSourceFailure(lines, 'E1324: Using an object as a String', 5)
 
   # Test creating a class with member variables and methods, calling a object
   # method.  Check for using type() and typename() with a class and an object.
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class TextPosition
-        this.lnum: number
-        this.col: number
+    class TextPosition
+      this.lnum: number
+      this.col: number
 
-        # make a nicely formatted string
-        def ToString(): string
-          return $'({this.lnum}, {this.col})'
-        enddef
-      endclass
+      # make a nicely formatted string
+      def ToString(): string
+        return $'({this.lnum}, {this.col})'
+      enddef
+    endclass
 
-      # use the automatically generated new() method
-      var pos = TextPosition.new(2, 12)
-      assert_equal(2, pos.lnum)
-      assert_equal(12, pos.col)
+    # use the automatically generated new() method
+    var pos = TextPosition.new(2, 12)
+    assert_equal(2, pos.lnum)
+    assert_equal(12, pos.col)
 
-      # call an object method
-      assert_equal('(2, 12)', pos.ToString())
+    # call an object method
+    assert_equal('(2, 12)', pos.ToString())
 
-      assert_equal(v:t_class, type(TextPosition))
-      assert_equal(v:t_object, type(pos))
-      assert_equal('class<TextPosition>', typename(TextPosition))
-      assert_equal('object<TextPosition>', typename(pos))
+    assert_equal(v:t_class, type(TextPosition))
+    assert_equal(v:t_object, type(pos))
+    assert_equal('class<TextPosition>', typename(TextPosition))
+    assert_equal('object<TextPosition>', typename(pos))
   END
   v9.CheckSourceSuccess(lines)
 
@@ -262,7 +262,7 @@ def Test_class_basic()
     var a = A.new()
     var v = a. Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1202:')
+  v9.CheckSourceFailure(lines, "E1202: No white space allowed after '.'", 8)
 
   # Using an object without specifying a method or a member variable
   lines =<< trim END
@@ -275,7 +275,7 @@ def Test_class_basic()
     var a = A.new()
     var v = a.
   END
-  v9.CheckSourceFailure(lines, 'E15:')
+  v9.CheckSourceFailure(lines, 'E15: Invalid expression: "a."', 8)
 
   # Error when parsing the arguments of an object method.
   lines =<< trim END
@@ -287,7 +287,7 @@ def Test_class_basic()
     var a = A.new()
     var v = a.Foo(,)
   END
-  v9.CheckSourceFailure(lines, 'E15:')
+  v9.CheckSourceFailure(lines, 'E15: Invalid expression: "a.Foo(,)"', 7)
 
   # Use a multi-line initialization for a member variable
   lines =<< trim END
@@ -368,19 +368,19 @@ enddef
 def Test_class_defined_twice()
   # class defined twice should fail
   var lines =<< trim END
-      vim9script
-      class There
-      endclass
-      class There
-      endclass
+    vim9script
+    class There
+    endclass
+    class There
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1041: Redefining script item: "There"')
+  v9.CheckSourceFailure(lines, 'E1041: Redefining script item: "There"', 4)
 
   # one class, reload same script twice is OK
   lines =<< trim END
-      vim9script
-      class There
-      endclass
+    vim9script
+    class There
+    endclass
   END
   writefile(lines, 'XclassTwice.vim', 'D')
   source XclassTwice.vim
@@ -390,119 +390,119 @@ enddef
 def Test_returning_null_object()
   # this was causing an internal error
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class BufferList
-          def Current(): any
-              return null_object
-          enddef
-      endclass
+    class BufferList
+      def Current(): any
+        return null_object
+      enddef
+    endclass
 
-      var buffers = BufferList.new()
-      echo buffers.Current()
+    var buffers = BufferList.new()
+    echo buffers.Current()
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_using_null_class()
   var lines =<< trim END
-      @_ = null_class.member
+    @_ = null_class.member
   END
-  v9.CheckDefExecAndScriptFailure(lines, ['E715:', 'E1363:'])
+  v9.CheckDefExecAndScriptFailure(lines, ['E715: Dictionary required', 'E1363: Incomplete type'])
 enddef
 
 def Test_class_interface_wrong_end()
   var lines =<< trim END
-      vim9script
-      abstract class SomeName
-        this.member = 'text'
-      endinterface
+    vim9script
+    abstract class SomeName
+      this.member = 'text'
+    endinterface
   END
-  v9.CheckSourceFailure(lines, 'E476: Invalid command: endinterface, expected endclass')
+  v9.CheckSourceFailure(lines, 'E476: Invalid command: endinterface, expected endclass', 4)
 
   lines =<< trim END
-      vim9script
-      export interface AnotherName
-        this.member: string
-      endclass
+    vim9script
+    export interface AnotherName
+      this.member: string
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E476: Invalid command: endclass, expected endinterface')
+  v9.CheckSourceFailure(lines, 'E476: Invalid command: endclass, expected endinterface', 4)
 enddef
 
 def Test_object_not_set()
   # Use an uninitialized object in script context
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class State
-        this.value = 'xyz'
-      endclass
+    class State
+      this.value = 'xyz'
+    endclass
 
-      var state: State
-      var db = {'xyz': 789}
-      echo db[state.value]
+    var state: State
+    var db = {'xyz': 789}
+    echo db[state.value]
   END
-  v9.CheckSourceFailure(lines, 'E1360:')
+  v9.CheckSourceFailure(lines, 'E1360: Using a null object', 9)
 
   # Use an uninitialized object from a def function
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Class
-          this.id: string
-          def Method1()
-              echo 'Method1' .. this.id
-          enddef
-      endclass
-
-      var obj: Class
-      def Func()
-          obj.Method1()
+    class Class
+      this.id: string
+      def Method1()
+        echo 'Method1' .. this.id
       enddef
-      Func()
+    endclass
+
+    var obj: Class
+    def Func()
+      obj.Method1()
+    enddef
+    Func()
   END
-  v9.CheckSourceFailure(lines, 'E1360:')
+  v9.CheckSourceFailure(lines, 'E1360: Using a null object', 1)
 
   # Pass an uninitialized object variable to a "new" function and try to call an
   # object method.
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Background
-        this.background = 'dark'
-      endclass
+    class Background
+      this.background = 'dark'
+    endclass
 
-      class Colorscheme
-        this._bg: Background
+    class Colorscheme
+      this._bg: Background
 
-        def GetBackground(): string
-          return this._bg.background
-        enddef
-      endclass
+      def GetBackground(): string
+        return this._bg.background
+      enddef
+    endclass
 
-      var bg: Background           # UNINITIALIZED
-      echo Colorscheme.new(bg).GetBackground()
+    var bg: Background           # UNINITIALIZED
+    echo Colorscheme.new(bg).GetBackground()
   END
-  v9.CheckSourceFailure(lines, 'E1360:')
+  v9.CheckSourceFailure(lines, 'E1360: Using a null object', 1)
 
   # TODO: this should not give an error but be handled at runtime
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Class
-          this.id: string
-          def Method1()
-              echo 'Method1' .. this.id
-          enddef
-      endclass
-
-      var obj = null_object
-      def Func()
-          obj.Method1()
+    class Class
+      this.id: string
+      def Method1()
+        echo 'Method1' .. this.id
       enddef
-      Func()
+    endclass
+
+    var obj = null_object
+    def Func()
+      obj.Method1()
+    enddef
+    Func()
   END
-  v9.CheckSourceFailure(lines, 'E1363:')
+  v9.CheckSourceFailure(lines, 'E1363: Incomplete type', 1)
 enddef
 
 " Null object assignment and comparison
@@ -549,60 +549,60 @@ enddef
 " Test for object member initialization and disassembly
 def Test_class_member_initializer()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class TextPosition
-        this.lnum: number = 1
-        this.col: number = 1
+    class TextPosition
+      this.lnum: number = 1
+      this.col: number = 1
 
-        # constructor with only the line number
-        def new(lnum: number)
-          this.lnum = lnum
-        enddef
-      endclass
+      # constructor with only the line number
+      def new(lnum: number)
+        this.lnum = lnum
+      enddef
+    endclass
 
-      var pos = TextPosition.new(3)
-      assert_equal(3, pos.lnum)
-      assert_equal(1, pos.col)
+    var pos = TextPosition.new(3)
+    assert_equal(3, pos.lnum)
+    assert_equal(1, pos.col)
 
-      var instr = execute('disassemble TextPosition.new')
-      assert_match('new\_s*' ..
-            '0 NEW TextPosition size \d\+\_s*' ..
-            '\d PUSHNR 1\_s*' ..
-            '\d STORE_THIS 0\_s*' ..
-            '\d PUSHNR 1\_s*' ..
-            '\d STORE_THIS 1\_s*' ..
-            'this.lnum = lnum\_s*' ..
-            '\d LOAD arg\[-1]\_s*' ..
-            '\d PUSHNR 0\_s*' ..
-            '\d LOAD $0\_s*' ..
-            '\d\+ STOREINDEX object\_s*' ..
-            '\d\+ RETURN object.*',
-            instr)
+    var instr = execute('disassemble TextPosition.new')
+    assert_match('new\_s*' ..
+          '0 NEW TextPosition size \d\+\_s*' ..
+          '\d PUSHNR 1\_s*' ..
+          '\d STORE_THIS 0\_s*' ..
+          '\d PUSHNR 1\_s*' ..
+          '\d STORE_THIS 1\_s*' ..
+          'this.lnum = lnum\_s*' ..
+          '\d LOAD arg\[-1]\_s*' ..
+          '\d PUSHNR 0\_s*' ..
+          '\d LOAD $0\_s*' ..
+          '\d\+ STOREINDEX object\_s*' ..
+          '\d\+ RETURN object.*',
+          instr)
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_member_any_used_as_object()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class Inner
-        this.value: number = 0
-      endclass
+    class Inner
+      this.value: number = 0
+    endclass
 
-      class Outer
-        this.inner: any
-      endclass
+    class Outer
+      this.inner: any
+    endclass
 
-      def F(outer: Outer)
-        outer.inner.value = 1
-      enddef
+    def F(outer: Outer)
+      outer.inner.value = 1
+    enddef
 
-      var inner_obj = Inner.new(0)
-      var outer_obj = Outer.new(inner_obj)
-      F(outer_obj)
-      assert_equal(1, inner_obj.value)
+    var inner_obj = Inner.new(0)
+    var outer_obj = Outer.new(inner_obj)
+    F(outer_obj)
+    assert_equal(1, inner_obj.value)
   END
   v9.CheckSourceSuccess(lines)
 
@@ -626,7 +626,7 @@ def Test_member_any_used_as_object()
     var outer_obj = Outer.new(inner_obj)
     F(outer_obj)
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _value')
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _value', 1)
 
   # Try modifying a non-existing variable using an "any" object
   lines =<< trim END
@@ -648,7 +648,7 @@ def Test_member_any_used_as_object()
     var outer_obj = Outer.new(inner_obj)
     F(outer_obj)
   END
-  v9.CheckSourceFailure(lines, 'E1326: Variable not found on object "Inner": someval')
+  v9.CheckSourceFailure(lines, 'E1326: Variable not found on object "Inner": someval', 1)
 enddef
 
 " Nested assignment to a object variable which is of another class type
@@ -709,7 +709,7 @@ def Test_assignment_nested_type()
 
     Test_assign_to_nested_typed_member()
   END
-  v9.CheckSourceFailure(lines, 'E1335: Variable "value" in class "Inner" is not writable')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "value" in class "Inner" is not writable', 1)
 
   # Assignment where target item is read only script level
   lines =<< trim END
@@ -732,296 +732,296 @@ def Test_assignment_nested_type()
     script_outer.inner.value = 1
     assert_equal(1, script_inner.value)
   END
-  v9.CheckSourceFailure(lines, 'E1335: Variable "value" in class "Inner" is not writable')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "value" in class "Inner" is not writable', 17)
 enddef
 
 def Test_assignment_with_operator()
   # Use "+=" to assign to a object variable
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class Foo
-        public this.x: number
+    class Foo
+      public this.x: number
 
-        def Add(n: number)
-          this.x += n
-        enddef
-      endclass
-
-      var f =  Foo.new(3)
-      f.Add(17)
-      assert_equal(20, f.x)
-
-      def AddToFoo(obj: Foo)
-        obj.x += 3
+      def Add(n: number)
+        this.x += n
       enddef
+    endclass
 
-      AddToFoo(f)
-      assert_equal(23, f.x)
+    var f =  Foo.new(3)
+    f.Add(17)
+    assert_equal(20, f.x)
+
+    def AddToFoo(obj: Foo)
+      obj.x += 3
+    enddef
+
+    AddToFoo(f)
+    assert_equal(23, f.x)
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_list_of_objects()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class Foo
-        def Add()
-        enddef
-      endclass
-
-      def ProcessList(fooList: list<Foo>)
-        for foo in fooList
-          foo.Add()
-        endfor
+    class Foo
+      def Add()
       enddef
+    endclass
 
-      var l: list<Foo> = [Foo.new()]
-      ProcessList(l)
+    def ProcessList(fooList: list<Foo>)
+      for foo in fooList
+        foo.Add()
+      endfor
+    enddef
+
+    var l: list<Foo> = [Foo.new()]
+    ProcessList(l)
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_expr_after_using_object()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class Something
-        this.label: string = ''
-      endclass
+    class Something
+      this.label: string = ''
+    endclass
 
-      def Foo(): Something
-        var v = Something.new()
-        echo 'in Foo(): ' .. typename(v)
-        return v
-      enddef
+    def Foo(): Something
+      var v = Something.new()
+      echo 'in Foo(): ' .. typename(v)
+      return v
+    enddef
 
-      Foo()
+    Foo()
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_class_default_new()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class TextPosition
-        this.lnum: number = 1
-        this.col: number = 1
-      endclass
+    class TextPosition
+      this.lnum: number = 1
+      this.col: number = 1
+    endclass
 
-      var pos = TextPosition.new()
-      assert_equal(1, pos.lnum)
-      assert_equal(1, pos.col)
+    var pos = TextPosition.new()
+    assert_equal(1, pos.lnum)
+    assert_equal(1, pos.col)
 
-      pos = TextPosition.new(v:none, v:none)
-      assert_equal(1, pos.lnum)
-      assert_equal(1, pos.col)
+    pos = TextPosition.new(v:none, v:none)
+    assert_equal(1, pos.lnum)
+    assert_equal(1, pos.col)
 
-      pos = TextPosition.new(3, 22)
-      assert_equal(3, pos.lnum)
-      assert_equal(22, pos.col)
+    pos = TextPosition.new(3, 22)
+    assert_equal(3, pos.lnum)
+    assert_equal(22, pos.col)
 
-      pos = TextPosition.new(v:none, 33)
-      assert_equal(1, pos.lnum)
-      assert_equal(33, pos.col)
+    pos = TextPosition.new(v:none, 33)
+    assert_equal(1, pos.lnum)
+    assert_equal(33, pos.col)
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
-      class Person
-        this.name: string
-        this.age: number = 42
-        this.education: string = "unknown"
+    vim9script
+    class Person
+      this.name: string
+      this.age: number = 42
+      this.education: string = "unknown"
 
-        def new(this.name, this.age = v:none, this.education = v:none)
-        enddef
-      endclass
+      def new(this.name, this.age = v:none, this.education = v:none)
+      enddef
+    endclass
 
-      var piet = Person.new("Piet")
-      assert_equal("Piet", piet.name)
-      assert_equal(42, piet.age)
-      assert_equal("unknown", piet.education)
+    var piet = Person.new("Piet")
+    assert_equal("Piet", piet.name)
+    assert_equal(42, piet.age)
+    assert_equal("unknown", piet.education)
 
-      var chris = Person.new("Chris", 4, "none")
-      assert_equal("Chris", chris.name)
-      assert_equal(4, chris.age)
-      assert_equal("none", chris.education)
+    var chris = Person.new("Chris", 4, "none")
+    assert_equal("Chris", chris.name)
+    assert_equal(4, chris.age)
+    assert_equal("none", chris.education)
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
-      class Person
-        this.name: string
-        this.age: number = 42
-        this.education: string = "unknown"
+    vim9script
+    class Person
+      this.name: string
+      this.age: number = 42
+      this.education: string = "unknown"
 
-        def new(this.name, this.age = v:none, this.education = v:none)
-        enddef
-      endclass
+      def new(this.name, this.age = v:none, this.education = v:none)
+      enddef
+    endclass
 
-      var missing = Person.new()
+    var missing = Person.new()
   END
-  v9.CheckSourceFailure(lines, 'E119:')
+  v9.CheckSourceFailure(lines, 'E119: Not enough arguments for function: new', 11)
 
   # Using a specific value to initialize an instance variable in the new()
   # method.
   lines =<< trim END
-      vim9script
-      class A
-        this.val: string
-        def new(this.val = 'a')
-        enddef
-      endclass
+    vim9script
+    class A
+      this.val: string
+      def new(this.val = 'a')
+      enddef
+    endclass
   END
-  v9.CheckSourceFailure(lines, "E1328: Constructor default value must be v:none:  = 'a'")
+  v9.CheckSourceFailure(lines, "E1328: Constructor default value must be v:none:  = 'a'", 4)
 enddef
 
 def Test_class_new_with_object_member()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class C
-        this.str: string
-        this.num: number
-        def new(this.str, this.num)
-        enddef
-        def newVals(this.str, this.num)
-        enddef
-      endclass
-
-      def Check()
-        try
-          var c = C.new('cats', 2)
-          assert_equal('cats', c.str)
-          assert_equal(2, c.num)
-
-          c = C.newVals('dogs', 4)
-          assert_equal('dogs', c.str)
-          assert_equal(4, c.num)
-        catch
-          assert_report($'Unexpected exception was caught: {v:exception}')
-        endtry
+    class C
+      this.str: string
+      this.num: number
+      def new(this.str, this.num)
       enddef
+      def newVals(this.str, this.num)
+      enddef
+    endclass
 
-      Check()
+    def Check()
+      try
+        var c = C.new('cats', 2)
+        assert_equal('cats', c.str)
+        assert_equal(2, c.num)
+
+        c = C.newVals('dogs', 4)
+        assert_equal('dogs', c.str)
+        assert_equal(4, c.num)
+      catch
+        assert_report($'Unexpected exception was caught: {v:exception}')
+      endtry
+    enddef
+
+    Check()
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class C
-        this.str: string
-        this.num: number
-        def new(this.str, this.num)
-        enddef
-      endclass
-
-      def Check()
-        try
-          var c = C.new(1, 2)
-        catch
-          assert_report($'Unexpected exception was caught: {v:exception}')
-        endtry
+    class C
+      this.str: string
+      this.num: number
+      def new(this.str, this.num)
       enddef
+    endclass
 
-      Check()
+    def Check()
+      try
+        var c = C.new(1, 2)
+      catch
+        assert_report($'Unexpected exception was caught: {v:exception}')
+      endtry
+    enddef
+
+    Check()
   END
-  v9.CheckSourceFailure(lines, 'E1013:')
+  v9.CheckSourceFailure(lines, 'E1013: Argument 1: type mismatch, expected string but got number', 2)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class C
-        this.str: string
-        this.num: number
-        def newVals(this.str, this.num)
-        enddef
-      endclass
-
-      def Check()
-        try
-          var c = C.newVals('dogs', 'apes')
-        catch
-          assert_report($'Unexpected exception was caught: {v:exception}')
-        endtry
+    class C
+      this.str: string
+      this.num: number
+      def newVals(this.str, this.num)
       enddef
+    endclass
 
-      Check()
+    def Check()
+      try
+        var c = C.newVals('dogs', 'apes')
+      catch
+        assert_report($'Unexpected exception was caught: {v:exception}')
+      endtry
+    enddef
+
+    Check()
   END
-  v9.CheckSourceFailure(lines, 'E1013:')
+  v9.CheckSourceFailure(lines, 'E1013: Argument 2: type mismatch, expected number but got string', 2)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class C
-        this.str: string
-        def new(str: any)
-        enddef
-      endclass
-
-      def Check()
-        try
-          var c = C.new(1)
-        catch
-          assert_report($'Unexpected exception was caught: {v:exception}')
-        endtry
+    class C
+      this.str: string
+      def new(str: any)
       enddef
+    endclass
 
-      Check()
+    def Check()
+      try
+        var c = C.new(1)
+      catch
+        assert_report($'Unexpected exception was caught: {v:exception}')
+      endtry
+    enddef
+
+    Check()
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_class_object_member_inits()
   var lines =<< trim END
-      vim9script
-      class TextPosition
-        this.lnum: number
-        this.col = 1
-        this.addcol: number = 2
-      endclass
+    vim9script
+    class TextPosition
+      this.lnum: number
+      this.col = 1
+      this.addcol: number = 2
+    endclass
 
-      var pos = TextPosition.new()
-      assert_equal(0, pos.lnum)
-      assert_equal(1, pos.col)
-      assert_equal(2, pos.addcol)
+    var pos = TextPosition.new()
+    assert_equal(0, pos.lnum)
+    assert_equal(1, pos.col)
+    assert_equal(2, pos.addcol)
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
-      class TextPosition
-        this.lnum
-        this.col = 1
-      endclass
+    vim9script
+    class TextPosition
+      this.lnum
+      this.col = 1
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1022:')
+  v9.CheckSourceFailure(lines, 'E1022: Type or initialization required', 3)
 
   # If the type is not specified for a member, then it should be set during
   # object creation and not when defining the class.
   lines =<< trim END
-      vim9script
+    vim9script
 
-      var init_count = 0
-      def Init(): string
-        init_count += 1
-        return 'foo'
-      enddef
+    var init_count = 0
+    def Init(): string
+      init_count += 1
+      return 'foo'
+    enddef
 
-      class A
-        this.str1 = Init()
-        this.str2: string = Init()
-        this.col = 1
-      endclass
+    class A
+      this.str1 = Init()
+      this.str2: string = Init()
+      this.col = 1
+    endclass
 
-      assert_equal(init_count, 0)
-      var a = A.new()
-      assert_equal(init_count, 2)
+    assert_equal(init_count, 0)
+    var a = A.new()
+    assert_equal(init_count, 2)
   END
   v9.CheckSourceSuccess(lines)
 
@@ -1033,7 +1033,7 @@ def Test_class_object_member_inits()
     endclass
     var a = A.new()
   END
-  v9.CheckSourceFailure(lines, 'E1001:')
+  v9.CheckSourceFailure(lines, 'E1001: Variable not found: init_val', 1)
 
   # Test for initializing an object member with an special type
   lines =<< trim END
@@ -1042,35 +1042,35 @@ def Test_class_object_member_inits()
        this.value: void
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1330: Invalid type for object variable: void')
+  v9.CheckSourceFailure(lines, 'E1330: Invalid type for object variable: void', 3)
 enddef
 
 " Test for instance variable access
 def Test_instance_variable_access()
   var lines =<< trim END
-      vim9script
-      class Triple
-         this._one = 1
-         this.two = 2
-         public this.three = 3
+    vim9script
+    class Triple
+       this._one = 1
+       this.two = 2
+       public this.three = 3
 
-         def GetOne(): number
-           return this._one
-         enddef
-      endclass
+       def GetOne(): number
+         return this._one
+       enddef
+    endclass
 
-      var trip = Triple.new()
-      assert_equal(1, trip.GetOne())
-      assert_equal(2, trip.two)
-      assert_equal(3, trip.three)
-      assert_fails('echo trip._one', 'E1333')
+    var trip = Triple.new()
+    assert_equal(1, trip.GetOne())
+    assert_equal(2, trip.two)
+    assert_equal(3, trip.three)
+    assert_fails('echo trip._one', 'E1333: Cannot access private variable: _one')
 
-      assert_fails('trip._one = 11', 'E1333')
-      assert_fails('trip.two = 22', 'E1335')
-      trip.three = 33
-      assert_equal(33, trip.three)
+    assert_fails('trip._one = 11', 'E1333: Cannot access private variable: _one')
+    assert_fails('trip.two = 22', 'E1335: Variable "two" in class "Triple" is not writable')
+    trip.three = 33
+    assert_equal(33, trip.three)
 
-      assert_fails('trip.four = 4', 'E1326')
+    assert_fails('trip.four = 4', 'E1326: Variable not found on object "Triple": four')
   END
   v9.CheckSourceSuccess(lines)
 
@@ -1081,83 +1081,83 @@ def Test_instance_variable_access()
       public this._val = 10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1332:')
+  v9.CheckSourceFailure(lines, 'E1332: Public variable name cannot start with underscore: public this._val = 10', 3)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class MyCar
-        this.make: string
-        this.age = 5
+    class MyCar
+      this.make: string
+      this.age = 5
 
-        def new(make_arg: string)
-          this.make = make_arg
-        enddef
-
-        def GetMake(): string
-          return $"make = {this.make}"
-        enddef
-        def GetAge(): number
-          return this.age
-        enddef
-      endclass
-
-      var c = MyCar.new("abc")
-      assert_equal('make = abc', c.GetMake())
-
-      c = MyCar.new("def")
-      assert_equal('make = def', c.GetMake())
-
-      var c2 = MyCar.new("123")
-      assert_equal('make = 123', c2.GetMake())
-
-      def CheckCar()
-        assert_equal("make = def", c.GetMake())
-        assert_equal(5, c.GetAge())
+      def new(make_arg: string)
+        this.make = make_arg
       enddef
-      CheckCar()
+
+      def GetMake(): string
+        return $"make = {this.make}"
+      enddef
+      def GetAge(): number
+        return this.age
+      enddef
+    endclass
+
+    var c = MyCar.new("abc")
+    assert_equal('make = abc', c.GetMake())
+
+    c = MyCar.new("def")
+    assert_equal('make = def', c.GetMake())
+
+    var c2 = MyCar.new("123")
+    assert_equal('make = 123', c2.GetMake())
+
+    def CheckCar()
+      assert_equal("make = def", c.GetMake())
+      assert_equal(5, c.GetAge())
+    enddef
+    CheckCar()
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class MyCar
-        this.make: string
+    class MyCar
+      this.make: string
 
-        def new(make_arg: string)
-            this.make = make_arg
-        enddef
-      endclass
+      def new(make_arg: string)
+        this.make = make_arg
+      enddef
+    endclass
 
-      var c = MyCar.new("abc")
-      var c = MyCar.new("def")
+    var c = MyCar.new("abc")
+    var c = MyCar.new("def")
   END
-  v9.CheckSourceFailure(lines, 'E1041:')
+  v9.CheckSourceFailure(lines, 'E1041: Redefining script item: "c"', 12)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Foo
-        this.x: list<number> = []
+    class Foo
+      this.x: list<number> = []
 
-        def Add(n: number): any
-          this.x->add(n)
-          return this
-        enddef
-      endclass
+      def Add(n: number): any
+        this.x->add(n)
+        return this
+      enddef
+    endclass
 
-      echo Foo.new().Add(1).Add(2).x
-      echo Foo.new().Add(1).Add(2)
-            .x
-      echo Foo.new().Add(1)
-            .Add(2).x
-      echo Foo.new()
-            .Add(1).Add(2).x
-      echo Foo.new()
-            .Add(1) 
-            .Add(2)
-            .x
+    echo Foo.new().Add(1).Add(2).x
+    echo Foo.new().Add(1).Add(2)
+          .x
+    echo Foo.new().Add(1)
+          .Add(2).x
+    echo Foo.new()
+          .Add(1).Add(2).x
+    echo Foo.new()
+          .Add(1) 
+          .Add(2)
+          .x
   END
   v9.CheckSourceSuccess(lines)
 
@@ -1168,7 +1168,7 @@ def Test_instance_variable_access()
       pub this.val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1065:')
+  v9.CheckSourceFailure(lines, 'E1065: Command cannot be shortened: pub this.val = 1', 3)
 
   # Test for "public" keyword must be followed by "this" or "static".
   lines =<< trim END
@@ -1177,7 +1177,7 @@ def Test_instance_variable_access()
       public val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1331:')
+  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "this" or "static"', 3)
 
   # Modify a instance variable using the class name in the script context
   lines =<< trim END
@@ -1187,7 +1187,7 @@ def Test_instance_variable_access()
     endclass
     A.val = 1
   END
-  v9.CheckSourceFailure(lines, 'E1376: Object variable "val" accessible only using class "A" object')
+  v9.CheckSourceFailure(lines, 'E1376: Object variable "val" accessible only using class "A" object', 5)
 
   # Read a instance variable using the class name in the script context
   lines =<< trim END
@@ -1197,7 +1197,7 @@ def Test_instance_variable_access()
     endclass
     var i = A.val
   END
-  v9.CheckSourceFailure(lines, 'E1376: Object variable "val" accessible only using class "A" object')
+  v9.CheckSourceFailure(lines, 'E1376: Object variable "val" accessible only using class "A" object', 5)
 
   # Modify a instance variable using the class name in a def function
   lines =<< trim END
@@ -1210,7 +1210,7 @@ def Test_instance_variable_access()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1376: Object variable "val" accessible only using class "A" object')
+  v9.CheckSourceFailure(lines, 'E1376: Object variable "val" accessible only using class "A" object', 1)
 
   # Read a instance variable using the class name in a def function
   lines =<< trim END
@@ -1223,31 +1223,31 @@ def Test_instance_variable_access()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1376: Object variable "val" accessible only using class "A" object')
+  v9.CheckSourceFailure(lines, 'E1376: Object variable "val" accessible only using class "A" object', 1)
 
   # Access from child class extending a class:
   lines =<< trim END
-      vim9script
-      class A
-        this.ro_obj_var = 10
-        public this.rw_obj_var = 20
-        this._priv_obj_var = 30
-      endclass
+    vim9script
+    class A
+      this.ro_obj_var = 10
+      public this.rw_obj_var = 20
+      this._priv_obj_var = 30
+    endclass
 
-      class B extends A
-        def Foo()
-          var x: number
-          x = this.ro_obj_var
-          this.ro_obj_var = 0
-          x = this.rw_obj_var
-          this.rw_obj_var = 0
-          x = this._priv_obj_var
-          this._priv_obj_var = 0
-        enddef
-      endclass
+    class B extends A
+      def Foo()
+        var x: number
+        x = this.ro_obj_var
+        this.ro_obj_var = 0
+        x = this.rw_obj_var
+        this.rw_obj_var = 0
+        x = this._priv_obj_var
+        this._priv_obj_var = 0
+      enddef
+    endclass
 
-      var b = B.new()
-      b.Foo()
+    var b = B.new()
+    b.Foo()
   END
   v9.CheckSourceSuccess(lines)
 enddef
@@ -1261,7 +1261,7 @@ def Test_class_variable_access()
       stat this.val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1065:')
+  v9.CheckSourceFailure(lines, 'E1065: Command cannot be shortened: stat this.val = 1', 3)
 
   # Test for "static" cannot be followed by "this".
   lines =<< trim END
@@ -1270,7 +1270,7 @@ def Test_class_variable_access()
       static this.val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1368: Static cannot be followed by "this" in a variable name')
+  v9.CheckSourceFailure(lines, 'E1368: Static cannot be followed by "this" in a variable name', 3)
 
   # Test for "static" cannot be followed by "public".
   lines =<< trim END
@@ -1279,122 +1279,122 @@ def Test_class_variable_access()
       static public val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1022: Type or initialization required')
+  v9.CheckSourceFailure(lines, 'E1022: Type or initialization required', 3)
 
   # A readonly class variable cannot be modified from a child class
   lines =<< trim END
-      vim9script
-      class A
-        static ro_class_var = 40
-      endclass
+    vim9script
+    class A
+      static ro_class_var = 40
+    endclass
 
-      class B extends A
-        def Foo()
-          A.ro_class_var = 50
-        enddef
-      endclass
+    class B extends A
+      def Foo()
+        A.ro_class_var = 50
+      enddef
+    endclass
 
-      var b = B.new()
-      b.Foo()
+    var b = B.new()
+    b.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1335: Variable "ro_class_var" in class "A" is not writable')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "ro_class_var" in class "A" is not writable', 1)
 
   # A private class variable cannot be accessed from a child class
   lines =<< trim END
-      vim9script
-      class A
-        static _priv_class_var = 60
-      endclass
+    vim9script
+    class A
+      static _priv_class_var = 60
+    endclass
 
-      class B extends A
-        def Foo()
-          var i = A._priv_class_var
-        enddef
-      endclass
+    class B extends A
+      def Foo()
+        var i = A._priv_class_var
+      enddef
+    endclass
 
-      var b = B.new()
-      b.Foo()
+    var b = B.new()
+    b.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _priv_class_var')
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _priv_class_var', 1)
 
   # A private class variable cannot be modified from a child class
   lines =<< trim END
-      vim9script
-      class A
-        static _priv_class_var = 60
-      endclass
+    vim9script
+    class A
+      static _priv_class_var = 60
+    endclass
 
-      class B extends A
-        def Foo()
-          A._priv_class_var = 0
-        enddef
-      endclass
+    class B extends A
+      def Foo()
+        A._priv_class_var = 0
+      enddef
+    endclass
 
-      var b = B.new()
-      b.Foo()
+    var b = B.new()
+    b.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _priv_class_var')
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _priv_class_var', 1)
 
   # Access from child class extending a class and from script context
   lines =<< trim END
-      vim9script
-      class A
-        static ro_class_var = 10
-        public static rw_class_var = 20
-        static _priv_class_var = 30
-      endclass
+    vim9script
+    class A
+      static ro_class_var = 10
+      public static rw_class_var = 20
+      static _priv_class_var = 30
+    endclass
 
-      class B extends A
-        def Foo()
-          var x: number
-          x = A.ro_class_var
-          assert_equal(10, x)
-          x = A.rw_class_var
-          assert_equal(25, x)
-          A.rw_class_var = 20
-          assert_equal(20, A.rw_class_var)
-        enddef
-      endclass
+    class B extends A
+      def Foo()
+        var x: number
+        x = A.ro_class_var
+        assert_equal(10, x)
+        x = A.rw_class_var
+        assert_equal(25, x)
+        A.rw_class_var = 20
+        assert_equal(20, A.rw_class_var)
+      enddef
+    endclass
 
-      assert_equal(10, A.ro_class_var)
-      assert_equal(20, A.rw_class_var)
-      A.rw_class_var = 25
-      assert_equal(25, A.rw_class_var)
-      var b = B.new()
-      b.Foo()
+    assert_equal(10, A.ro_class_var)
+    assert_equal(20, A.rw_class_var)
+    A.rw_class_var = 25
+    assert_equal(25, A.rw_class_var)
+    var b = B.new()
+    b.Foo()
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_class_object_compare()
   var class_lines =<< trim END
-      vim9script
-      class Item
-        this.nr = 0
-        this.name = 'xx'
-      endclass
+    vim9script
+    class Item
+      this.nr = 0
+      this.name = 'xx'
+    endclass
   END
 
   # used at the script level and in a compiled function
   var test_lines =<< trim END
-      var i1 = Item.new()
-      assert_equal(i1, i1)
-      assert_true(i1 is i1)
-      var i2 = Item.new()
-      assert_equal(i1, i2)
-      assert_false(i1 is i2)
-      var i3 = Item.new(0, 'xx')
-      assert_equal(i1, i3)
+    var i1 = Item.new()
+    assert_equal(i1, i1)
+    assert_true(i1 is i1)
+    var i2 = Item.new()
+    assert_equal(i1, i2)
+    assert_false(i1 is i2)
+    var i3 = Item.new(0, 'xx')
+    assert_equal(i1, i3)
 
-      var io1 = Item.new(1, 'xx')
-      assert_notequal(i1, io1)
-      var io2 = Item.new(0, 'yy')
-      assert_notequal(i1, io2)
+    var io1 = Item.new(1, 'xx')
+    assert_notequal(i1, io1)
+    var io2 = Item.new(0, 'yy')
+    assert_notequal(i1, io2)
   END
 
   v9.CheckSourceSuccess(class_lines + test_lines)
   v9.CheckSourceSuccess(
-      class_lines + ['def Test()'] + test_lines + ['enddef', 'Test()'])
+    class_lines + ['def Test()'] + test_lines + ['enddef', 'Test()'])
 
   for op in ['>', '>=', '<', '<=', '=~', '!~']
     var op_lines = [
@@ -1402,7 +1402,7 @@ def Test_class_object_compare()
           'var i2 = Item.new()',
           'echo i1 ' .. op .. ' i2',
           ]
-    v9.CheckSourceFailure(class_lines + op_lines, 'E1153: Invalid operation for object')
+    v9.CheckSourceFailure(class_lines + op_lines, 'E1153: Invalid operation for object', 8)
     v9.CheckSourceFailure(class_lines
           + ['def Test()'] + op_lines + ['enddef', 'Test()'], 'E1153: Invalid operation for object')
   endfor
@@ -1410,76 +1410,76 @@ enddef
 
 def Test_object_type()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class One
-        this.one = 1
-      endclass
-      class Two
-        this.two = 2
-      endclass
-      class TwoMore extends Two
-        this.more = 9
-      endclass
+    class One
+      this.one = 1
+    endclass
+    class Two
+      this.two = 2
+    endclass
+    class TwoMore extends Two
+      this.more = 9
+    endclass
 
-      var o: One = One.new()
-      var t: Two = Two.new()
-      var m: TwoMore = TwoMore.new()
-      var tm: Two = TwoMore.new()
+    var o: One = One.new()
+    var t: Two = Two.new()
+    var m: TwoMore = TwoMore.new()
+    var tm: Two = TwoMore.new()
 
-      t = m
+    t = m
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class One
-        this.one = 1
-      endclass
-      class Two
-        this.two = 2
-      endclass
+    class One
+      this.one = 1
+    endclass
+    class Two
+      this.two = 2
+    endclass
 
-      var o: One = Two.new()
+    var o: One = Two.new()
   END
-  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected object<One> but got object<Two>')
+  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected object<One> but got object<Two>', 10)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface One
-        def GetMember(): number
-      endinterface
-      class Two implements One
-        this.one = 1
-        def GetMember(): number
-          return this.one
-        enddef
-      endclass
-
-      var o: One = Two.new(5)
-      assert_equal(5, o.GetMember())
-  END
-  v9.CheckSourceSuccess(lines)
-
-  lines =<< trim END
-      vim9script
-
-      class Num
-        this.n: number = 0
-      endclass
-
-      def Ref(name: string): func(Num): Num
-        return (arg: Num): Num => {
-          return eval(name)(arg)
-        }
+    interface One
+      def GetMember(): number
+    endinterface
+    class Two implements One
+      this.one = 1
+      def GetMember(): number
+        return this.one
       enddef
+    endclass
 
-      const Fn = Ref('Double')
-      var Double = (m: Num): Num => Num.new(m.n * 2)
+    var o: One = Two.new(5)
+    assert_equal(5, o.GetMember())
+  END
+  v9.CheckSourceSuccess(lines)
 
-      echo Fn(Num.new(4))
+  lines =<< trim END
+    vim9script
+
+    class Num
+      this.n: number = 0
+    endclass
+
+    def Ref(name: string): func(Num): Num
+      return (arg: Num): Num => {
+        return eval(name)(arg)
+      }
+    enddef
+
+    const Fn = Ref('Double')
+    var Double = (m: Num): Num => Num.new(m.n * 2)
+
+    echo Fn(Num.new(4))
   END
   v9.CheckSourceSuccess(lines)
 enddef
@@ -1487,151 +1487,151 @@ enddef
 def Test_class_member()
   # check access rules
   var lines =<< trim END
-      vim9script
-      class TextPos
-         this.lnum = 1
-         this.col = 1
-         static counter = 0
-         static _secret = 7
-         public static  anybody = 42
+    vim9script
+    class TextPos
+       this.lnum = 1
+       this.col = 1
+       static counter = 0
+       static _secret = 7
+       public static  anybody = 42
 
-         static def AddToCounter(nr: number)
-           counter += nr
-         enddef
-      endclass
+       static def AddToCounter(nr: number)
+         counter += nr
+       enddef
+    endclass
 
-      assert_equal(0, TextPos.counter)
-      TextPos.AddToCounter(3)
-      assert_equal(3, TextPos.counter)
-      assert_fails('echo TextPos.noSuchMember', 'E1337:')
+    assert_equal(0, TextPos.counter)
+    TextPos.AddToCounter(3)
+    assert_equal(3, TextPos.counter)
+    assert_fails('echo TextPos.noSuchMember', 'E1337: Class variable "noSuchMember" not found in class "TextPos"')
 
-      def GetCounter(): number
-        return TextPos.counter
-      enddef
-      assert_equal(3, GetCounter())
+    def GetCounter(): number
+      return TextPos.counter
+    enddef
+    assert_equal(3, GetCounter())
 
-      assert_fails('TextPos.noSuchMember = 2', 'E1337:')
-      assert_fails('TextPos.counter = 5', 'E1335:')
-      assert_fails('TextPos.counter += 5', 'E1335:')
+    assert_fails('TextPos.noSuchMember = 2', 'E1337: Class variable "noSuchMember" not found in class "TextPos"')
+    assert_fails('TextPos.counter = 5', 'E1335: Variable "counter" in class "TextPos" is not writable')
+    assert_fails('TextPos.counter += 5', 'E1335: Variable "counter" in class "TextPos" is not writable')
 
-      assert_fails('echo TextPos._secret', 'E1333:')
-      assert_fails('TextPos._secret = 8', 'E1333:')
+    assert_fails('echo TextPos._secret', 'E1333: Cannot access private variable: _secret')
+    assert_fails('TextPos._secret = 8', 'E1333: Cannot access private variable: _secret')
 
-      assert_equal(42, TextPos.anybody)
-      TextPos.anybody = 12
-      assert_equal(12, TextPos.anybody)
-      TextPos.anybody += 5
-      assert_equal(17, TextPos.anybody)
+    assert_equal(42, TextPos.anybody)
+    TextPos.anybody = 12
+    assert_equal(12, TextPos.anybody)
+    TextPos.anybody += 5
+    assert_equal(17, TextPos.anybody)
   END
   v9.CheckSourceSuccess(lines)
 
   # example in the help
   lines =<< trim END
-        vim9script
-	class OtherThing
-	   this.size: number
-	   static totalSize: number
+    vim9script
+    class OtherThing
+      this.size: number
+      static totalSize: number
 
-	   def new(this.size)
-	      totalSize += this.size
-	   enddef
-	endclass
-        assert_equal(0, OtherThing.totalSize)
-        var to3 = OtherThing.new(3)
-        assert_equal(3, OtherThing.totalSize)
-        var to7 = OtherThing.new(7)
-        assert_equal(10, OtherThing.totalSize)
+      def new(this.size)
+        totalSize += this.size
+      enddef
+    endclass
+    assert_equal(0, OtherThing.totalSize)
+    var to3 = OtherThing.new(3)
+    assert_equal(3, OtherThing.totalSize)
+    var to7 = OtherThing.new(7)
+    assert_equal(10, OtherThing.totalSize)
   END
   v9.CheckSourceSuccess(lines)
 
   # using static class member twice
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class HTML
-        static author: string = 'John Doe'
+    class HTML
+      static author: string = 'John Doe'
 
-        static def MacroSubstitute(s: string): string
-          return substitute(s, '{{author}}', author, 'gi')
-        enddef
-      endclass
+      static def MacroSubstitute(s: string): string
+        return substitute(s, '{{author}}', author, 'gi')
+      enddef
+    endclass
 
-      assert_equal('some text', HTML.MacroSubstitute('some text'))
-      assert_equal('some text', HTML.MacroSubstitute('some text'))
+    assert_equal('some text', HTML.MacroSubstitute('some text'))
+    assert_equal('some text', HTML.MacroSubstitute('some text'))
   END
   v9.CheckSourceSuccess(lines)
 
   # access private member in lambda
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Foo
-        this._x: number = 0
+    class Foo
+      this._x: number = 0
 
-        def Add(n: number): number
-          const F = (): number => this._x + n
-          return F()
-        enddef
-      endclass
+      def Add(n: number): number
+        const F = (): number => this._x + n
+        return F()
+      enddef
+    endclass
 
-      var foo = Foo.new()
-      assert_equal(5, foo.Add(5))
+    var foo = Foo.new()
+    assert_equal(5, foo.Add(5))
   END
   v9.CheckSourceSuccess(lines)
 
   # access private member in lambda body
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Foo
-        this._x: number = 6
+    class Foo
+      this._x: number = 6
 
-        def Add(n: number): number
-          var Lam = () => {
-            this._x = this._x + n
-          }
-          Lam()
-          return this._x
-        enddef
-      endclass
+      def Add(n: number): number
+        var Lam = () => {
+          this._x = this._x + n
+        }
+        Lam()
+        return this._x
+      enddef
+    endclass
 
-      var foo = Foo.new()
-      assert_equal(13, foo.Add(7))
+    var foo = Foo.new()
+    assert_equal(13, foo.Add(7))
   END
   v9.CheckSourceSuccess(lines)
 
   # check shadowing
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Some
-        static count = 0
-        def Method(count: number)
-          echo count
-        enddef
-      endclass
+    class Some
+      static count = 0
+      def Method(count: number)
+        echo count
+      enddef
+    endclass
 
-      var s = Some.new()
-      s.Method(7)
+    var s = Some.new()
+    s.Method(7)
   END
-  v9.CheckSourceFailure(lines, 'E1340: Argument already declared in the class: count')
+  v9.CheckSourceFailure(lines, 'E1340: Argument already declared in the class: count', 5)
 
   # Use a local variable in a method with the same name as a class variable
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Some
-        static count = 0
-        def Method(arg: number)
-          var count = 3
-          echo arg count
-        enddef
-      endclass
+    class Some
+      static count = 0
+      def Method(arg: number)
+        var count = 3
+        echo arg count
+      enddef
+    endclass
 
-      var s = Some.new()
-      s.Method(7)
+    var s = Some.new()
+    s.Method(7)
   END
-  v9.CheckSourceFailure(lines, 'E1341: Variable already declared in the class: count')
+  v9.CheckSourceFailure(lines, 'E1341: Variable already declared in the class: count', 1)
 
   # Test for using an invalid type for a member variable
   lines =<< trim END
@@ -1640,62 +1640,62 @@ def Test_class_member()
       this.val: xxx
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1010:')
+  v9.CheckSourceFailure(lines, 'E1010: Type not recognized: xxx', 3)
 
   # Test for setting a member on a null object
   lines =<< trim END
     vim9script
     class A
-        public this.val: string
+      public this.val: string
     endclass
 
     def F()
-        var obj: A
-        obj.val = ""
+      var obj: A
+      obj.val = ""
     enddef
     F()
   END
-  v9.CheckSourceFailure(lines, 'E1360: Using a null object')
+  v9.CheckSourceFailure(lines, 'E1360: Using a null object', 2)
 
   # Test for accessing a member on a null object
   lines =<< trim END
     vim9script
     class A
-        this.val: string
+      this.val: string
     endclass
 
     def F()
-        var obj: A
-        echo obj.val
+      var obj: A
+      echo obj.val
     enddef
     F()
   END
-  v9.CheckSourceFailure(lines, 'E1360: Using a null object')
+  v9.CheckSourceFailure(lines, 'E1360: Using a null object', 2)
 
   # Test for setting a member on a null object, at script level
   lines =<< trim END
     vim9script
     class A
-        public this.val: string
+      public this.val: string
     endclass
 
     var obj: A
     obj.val = ""
   END
   # FIXME(in source): this should give E1360 as well!
-  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected object<A> but got string')
+  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected object<A> but got string', 7)
 
   # Test for accessing a member on a null object, at script level
   lines =<< trim END
     vim9script
     class A
-        this.val: string
+      this.val: string
     endclass
 
     var obj: A
     echo obj.val
   END
-  v9.CheckSourceFailure(lines, 'E1360: Using a null object')
+  v9.CheckSourceFailure(lines, 'E1360: Using a null object', 7)
 
   # Test for no space before or after the '=' when initializing a member
   # variable
@@ -1705,14 +1705,14 @@ def Test_class_member()
       this.val: number= 10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1004:')
+  v9.CheckSourceFailure(lines, "E1004: White space required before and after '='", 3)
   lines =<< trim END
     vim9script
     class A
       this.val: number =10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1004:')
+  v9.CheckSourceFailure(lines, "E1004: White space required before and after '='", 3)
 
   # Access a non-existing member
   lines =<< trim END
@@ -1722,49 +1722,49 @@ def Test_class_member()
     var a = A.new()
     var v = a.bar
   END
-  v9.CheckSourceFailure(lines, 'E1326: Variable not found on object "A": bar')
+  v9.CheckSourceFailure(lines, 'E1326: Variable not found on object "A": bar', 5)
 enddef
 
 func Test_class_garbagecollect()
   let lines =<< trim END
-      vim9script
+    vim9script
 
-      class Point
-        this.p = [2, 3]
-        static pl = ['a', 'b']
-        static pd = {a: 'a', b: 'b'}
-      endclass
+    class Point
+      this.p = [2, 3]
+      static pl = ['a', 'b']
+      static pd = {a: 'a', b: 'b'}
+    endclass
 
-      echo Point.pl Point.pd
-      call test_garbagecollect_now()
-      echo Point.pl Point.pd
+    echo Point.pl Point.pd
+    call test_garbagecollect_now()
+    echo Point.pl Point.pd
   END
   call v9.CheckSourceSuccess(lines)
 
   let lines =<< trim END
-      vim9script
+    vim9script
 
-      interface View
-      endinterface
+    interface View
+    endinterface
 
-      class Widget
-        this.view: View
-      endclass
+    class Widget
+      this.view: View
+    endclass
 
-      class MyView implements View
-        this.widget: Widget
+    class MyView implements View
+      this.widget: Widget
 
-        def new()
-          # this will result in a circular reference to this object
-          this.widget = Widget.new(this)
-        enddef
-      endclass
+      def new()
+        # this will result in a circular reference to this object
+        this.widget = Widget.new(this)
+      enddef
+    endclass
 
-      var view = MyView.new()
+    var view = MyView.new()
 
-      # overwrite "view", will be garbage-collected next
-      view = MyView.new()
-      test_garbagecollect_now()
+    # overwrite "view", will be garbage-collected next
+    view = MyView.new()
+    test_garbagecollect_now()
   END
   call v9.CheckSourceSuccess(lines)
 endfunc
@@ -1816,26 +1816,26 @@ endfunc
 
 def Test_class_method()
   var lines =<< trim END
-      vim9script
-      class Value
-        this.value = 0
-        static objects = 0
+    vim9script
+    class Value
+      this.value = 0
+      static objects = 0
 
-        def new(v: number)
-          this.value = v
-          ++objects
-        enddef
+      def new(v: number)
+        this.value = v
+        ++objects
+      enddef
 
-        static def GetCount(): number
-          return objects
-        enddef
-      endclass
+      static def GetCount(): number
+        return objects
+      enddef
+    endclass
 
-      assert_equal(0, Value.GetCount())
-      var v1 = Value.new(2)
-      assert_equal(1, Value.GetCount())
-      var v2 = Value.new(7)
-      assert_equal(2, Value.GetCount())
+    assert_equal(0, Value.GetCount())
+    var v1 = Value.new(2)
+    assert_equal(1, Value.GetCount())
+    var v2 = Value.new(7)
+    assert_equal(2, Value.GetCount())
   END
   v9.CheckSourceSuccess(lines)
 
@@ -1849,7 +1849,7 @@ def Test_class_method()
       aaa
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1318:')
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: aaa', 5)
 
   # Test for calling a class method from another class method without the class
   # name prefix.
@@ -1877,49 +1877,49 @@ enddef
 
 def Test_class_defcompile()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class C
-          def Fo(i: number): string
-              return i
-          enddef
-      endclass
+    class C
+      def Fo(i: number): string
+        return i
+      enddef
+    endclass
 
-      defcompile C.Fo
+    defcompile C.Fo
   END
-  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected string but got number')
+  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected string but got number', 1)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class C
-          static def Fc(): number
-            return 'x'
-          enddef
-      endclass
+    class C
+      static def Fc(): number
+        return 'x'
+      enddef
+    endclass
 
-      defcompile C.Fc
+    defcompile C.Fc
   END
-  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected number but got string')
+  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected number but got string', 1)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class C
-          static def new()
-          enddef
-      endclass
+    class C
+      static def new()
+      enddef
+    endclass
 
-      defcompile C.new
+    defcompile C.new
   END
-  v9.CheckSourceFailure(lines, 'E1370: Cannot define a "new" method as static')
+  v9.CheckSourceFailure(lines, 'E1370: Cannot define a "new" method as static', 5)
 
   # Trying to compile a function using a non-existing class variable
   lines =<< trim END
     vim9script
     defcompile x.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E475:')
+  v9.CheckSourceFailure(lines, 'E475: Invalid argument: x.Foo()', 2)
 
   # Trying to compile a function using a variable which is not a class
   lines =<< trim END
@@ -1927,7 +1927,7 @@ def Test_class_defcompile()
     var x: number
     defcompile x.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E475:')
+  v9.CheckSourceFailure(lines, 'E475: Invalid argument: x.Foo()', 3)
 
   # Trying to compile a function without specifying the name
   lines =<< trim END
@@ -1936,7 +1936,7 @@ def Test_class_defcompile()
     endclass
     defcompile A.
   END
-  v9.CheckSourceFailure(lines, 'E475:')
+  v9.CheckSourceFailure(lines, 'E475: Invalid argument: A.', 4)
 
   # Trying to compile a non-existing class object member function
   lines =<< trim END
@@ -1946,115 +1946,115 @@ def Test_class_defcompile()
     var a = A.new()
     defcompile a.Foo()
   END
-  v9.CheckSourceFailureList(lines, ['E1326:', 'E475:'])
+  v9.CheckSourceFailureList(lines, ['E1326: Variable not found on object "A": Foo', 'E475: Invalid argument: a.Foo()'])
 enddef
 
 def Test_class_object_to_string()
   var lines =<< trim END
-      vim9script
-      class TextPosition
-        this.lnum = 1
-        this.col = 22
-      endclass
+    vim9script
+    class TextPosition
+      this.lnum = 1
+      this.col = 22
+    endclass
 
-      assert_equal("class TextPosition", string(TextPosition))
+    assert_equal("class TextPosition", string(TextPosition))
 
-      var pos = TextPosition.new()
-      assert_equal("object of TextPosition {lnum: 1, col: 22}", string(pos))
+    var pos = TextPosition.new()
+    assert_equal("object of TextPosition {lnum: 1, col: 22}", string(pos))
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_interface_basics()
   var lines =<< trim END
-      vim9script
-      interface Something
-        this.ro_var: list<number>
-        def GetCount(): number
-      endinterface
+    vim9script
+    interface Something
+      this.ro_var: list<number>
+      def GetCount(): number
+    endinterface
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      interface SomethingWrong
-        static count = 7
-      endinterface
+    interface SomethingWrong
+      static count = 7
+    endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1342:')
+  v9.CheckSourceFailure(lines, 'E1342: Interface can only be defined in Vim9 script', 1)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface Some
-        this.value: number
-        def Method(value: number)
-      endinterface
+    interface Some
+      this.value: number
+      def Method(value: number)
+    endinterface
   END
   # The argument name and the object member name are the same, but this is not a
   # problem because object members are always accessed with the "this." prefix.
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
-      interface somethingWrong
-        static count = 7
-      endinterface
+    vim9script
+    interface somethingWrong
+      static count = 7
+    endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1343: Interface name must start with an uppercase letter: somethingWrong')
+  v9.CheckSourceFailure(lines, 'E1343: Interface name must start with an uppercase letter: somethingWrong', 2)
 
   lines =<< trim END
-      vim9script
-      interface SomethingWrong
-        this.value: string
-        this.count = 7
-        def GetCount(): number
-      endinterface
+    vim9script
+    interface SomethingWrong
+      this.value: string
+      this.count = 7
+      def GetCount(): number
+    endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1344:')
+  v9.CheckSourceFailure(lines, 'E1344: Cannot initialize a variable in an interface', 4)
 
   lines =<< trim END
-      vim9script
-      interface SomethingWrong
-        this.value: string
-        this.count: number
-        def GetCount(): number
-          return 5
-        enddef
-      endinterface
+    vim9script
+    interface SomethingWrong
+      this.value: string
+      this.count: number
+      def GetCount(): number
+        return 5
+      enddef
+    endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1345: Not a valid command in an interface: return 5')
+  v9.CheckSourceFailure(lines, 'E1345: Not a valid command in an interface: return 5', 6)
 
   lines =<< trim END
-      vim9script
-      export interface EnterExit
-          def Enter(): void
-          def Exit(): void
-      endinterface
+    vim9script
+    export interface EnterExit
+      def Enter(): void
+      def Exit(): void
+    endinterface
   END
   writefile(lines, 'XdefIntf.vim', 'D')
 
   lines =<< trim END
-      vim9script
-      import './XdefIntf.vim' as defIntf
-      export def With(ee: defIntf.EnterExit, F: func)
-          ee.Enter()
-          try
-              F()
-          finally
-              ee.Exit()
-          endtry
-      enddef
+    vim9script
+    import './XdefIntf.vim' as defIntf
+    export def With(ee: defIntf.EnterExit, F: func)
+      ee.Enter()
+      try
+        F()
+      finally
+        ee.Exit()
+      endtry
+    enddef
   END
   v9.CheckScriptSuccess(lines)
 
   var imported =<< trim END
-      vim9script
-      export abstract class EnterExit
-          def Enter(): void
-          enddef
-          def Exit(): void
-          enddef
-      endclass
+    vim9script
+    export abstract class EnterExit
+      def Enter(): void
+      enddef
+      def Exit(): void
+      enddef
+    endclass
   END
   writefile(imported, 'XdefIntf2.vim', 'D')
 
@@ -2064,97 +2064,97 @@ enddef
 
 def Test_class_implements_interface()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      interface Some
-        this.count: number
-        def Method(nr: number)
-      endinterface
+    interface Some
+      this.count: number
+      def Method(nr: number)
+    endinterface
 
-      class SomeImpl implements Some
-        this.count: number
-        def Method(nr: number)
-          echo nr
-        enddef
-      endclass
+    class SomeImpl implements Some
+      this.count: number
+      def Method(nr: number)
+        echo nr
+      enddef
+    endclass
 
-      interface Another
-        this.member: string
-      endinterface
+    interface Another
+      this.member: string
+    endinterface
 
-      class AnotherImpl implements Some, Another
-        this.member = 'abc'
-        this.count = 20
-        def Method(nr: number)
-          echo nr
-        enddef
-      endclass
+    class AnotherImpl implements Some, Another
+      this.member = 'abc'
+      this.count = 20
+      def Method(nr: number)
+        echo nr
+      enddef
+    endclass
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface Some
-        this.count: number
-      endinterface
+    interface Some
+      this.count: number
+    endinterface
 
-      class SomeImpl implements Some implements Some
-        this.count: number
-      endclass
+    class SomeImpl implements Some implements Some
+      this.count: number
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1350:')
+  v9.CheckSourceFailure(lines, 'E1350: Duplicate "implements"', 7)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface Some
-        this.count: number
-      endinterface
+    interface Some
+      this.count: number
+    endinterface
 
-      class SomeImpl implements Some, Some
-        this.count: number
-      endclass
+    class SomeImpl implements Some, Some
+      this.count: number
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1351: Duplicate interface after "implements": Some')
+  v9.CheckSourceFailure(lines, 'E1351: Duplicate interface after "implements": Some', 7)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface Some
-        this.counter: number
-        def Method(nr: number)
-      endinterface
+    interface Some
+      this.counter: number
+      def Method(nr: number)
+    endinterface
 
-      class SomeImpl implements Some
-        this.count: number
-        def Method(nr: number)
-          echo nr
-        enddef
-      endclass
+    class SomeImpl implements Some
+      this.count: number
+      def Method(nr: number)
+        echo nr
+      enddef
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1348: Variable "counter" of interface "Some" is not implemented')
+  v9.CheckSourceFailure(lines, 'E1348: Variable "counter" of interface "Some" is not implemented', 13)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface Some
-        this.count: number
-        def Methods(nr: number)
-      endinterface
+    interface Some
+      this.count: number
+      def Methods(nr: number)
+    endinterface
 
-      class SomeImpl implements Some
-        this.count: number
-        def Method(nr: number)
-          echo nr
-        enddef
-      endclass
+    class SomeImpl implements Some
+      this.count: number
+      def Method(nr: number)
+        echo nr
+      enddef
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1349: Method "Methods" of interface "Some" is not implemented')
+  v9.CheckSourceFailure(lines, 'E1349: Method "Methods" of interface "Some" is not implemented', 13)
 
   # Check different order of members in class and interface works.
   lines =<< trim END
-      vim9script
+    vim9script
 
       interface Result
         this.label: string
@@ -2168,14 +2168,14 @@ def Test_class_implements_interface()
         this.label: string = 'label'
       endclass
 
-      def Test()
-        var result: Result = Failure.new()
+    def Test()
+      var result: Result = Failure.new()
 
         assert_equal('label', result.label)
         assert_equal(42, result.errpos)
       enddef
 
-      Test()
+    Test()
   END
   v9.CheckSourceSuccess(lines)
 
@@ -2187,7 +2187,7 @@ def Test_class_implements_interface()
     class B extends A"
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1315:')
+  v9.CheckSourceFailure(lines, 'E1315: White space required after name: A"', 4)
 
   # Trailing characters after a class name
   lines =<< trim END
@@ -2195,7 +2195,7 @@ def Test_class_implements_interface()
     class A bbb
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E488:')
+  v9.CheckSourceFailure(lines, 'E488: Trailing characters: bbb', 2)
 
   # using "implements" with a non-existing class
   lines =<< trim END
@@ -2203,7 +2203,7 @@ def Test_class_implements_interface()
     class A implements B
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1346:')
+  v9.CheckSourceFailure(lines, 'E1346: Interface name not found: B', 3)
 
   # using "implements" with a regular class
   lines =<< trim END
@@ -2213,7 +2213,7 @@ def Test_class_implements_interface()
     class B implements A
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1347:')
+  v9.CheckSourceFailure(lines, 'E1347: Not a valid interface: A', 5)
 
   # using "implements" with a variable
   lines =<< trim END
@@ -2222,7 +2222,7 @@ def Test_class_implements_interface()
     class A implements T
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1347:')
+  v9.CheckSourceFailure(lines, 'E1347: Not a valid interface: T', 4)
 
   # implements should be followed by a white space
   lines =<< trim END
@@ -2232,86 +2232,86 @@ def Test_class_implements_interface()
     class B implements A;
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1315:')
+  v9.CheckSourceFailure(lines, 'E1315: White space required after name: A;', 4)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface One
-        def IsEven(nr: number): bool
-      endinterface
-      class Two implements One
-        def IsEven(nr: number): string
-        enddef
-      endclass
+    interface One
+      def IsEven(nr: number): bool
+    endinterface
+    class Two implements One
+      def IsEven(nr: number): string
+      enddef
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1383: Method "IsEven": type mismatch, expected func(number): bool but got func(number): string')
+  v9.CheckSourceFailure(lines, 'E1383: Method "IsEven": type mismatch, expected func(number): bool but got func(number): string', 9)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface One
-        def IsEven(nr: number): bool
-      endinterface
-      class Two implements One
-        def IsEven(nr: bool): bool
-        enddef
-      endclass
+    interface One
+      def IsEven(nr: number): bool
+    endinterface
+    class Two implements One
+      def IsEven(nr: bool): bool
+      enddef
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1383: Method "IsEven": type mismatch, expected func(number): bool but got func(bool): bool')
+  v9.CheckSourceFailure(lines, 'E1383: Method "IsEven": type mismatch, expected func(number): bool but got func(bool): bool', 9)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface One
-        def IsEven(nr: number): bool
-      endinterface
-      class Two implements One
-        def IsEven(nr: number, ...extra: list<number>): bool
-        enddef
-      endclass
+    interface One
+      def IsEven(nr: number): bool
+    endinterface
+    class Two implements One
+      def IsEven(nr: number, ...extra: list<number>): bool
+      enddef
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1383: Method "IsEven": type mismatch, expected func(number): bool but got func(number, ...list<number>): bool')
+  v9.CheckSourceFailure(lines, 'E1383: Method "IsEven": type mismatch, expected func(number): bool but got func(number, ...list<number>): bool', 9)
 
   # access superclass interface members from subclass, mix variable order
   lines =<< trim END
     vim9script
 
     interface I1
-        this.mvar1: number
-        this.mvar2: number
+      this.mvar1: number
+      this.mvar2: number
     endinterface
 
     # NOTE: the order is swapped
     class A implements I1
-        this.mvar2: number
-        this.mvar1: number
-        public static svar2: number
-        public static svar1: number
-        def new()
-            svar1 = 11
-            svar2 = 12
-            this.mvar1 = 111
-            this.mvar2 = 112
-        enddef
+      this.mvar2: number
+      this.mvar1: number
+      public static svar2: number
+      public static svar1: number
+      def new()
+        svar1 = 11
+        svar2 = 12
+        this.mvar1 = 111
+        this.mvar2 = 112
+      enddef
     endclass
 
     class B extends A
-        def new()
-            this.mvar1 = 121
-            this.mvar2 = 122
-        enddef
+      def new()
+        this.mvar1 = 121
+        this.mvar2 = 122
+      enddef
     endclass
 
     class C extends B
-        def new()
-            this.mvar1 = 131
-            this.mvar2 = 132
-        enddef
+      def new()
+        this.mvar1 = 131
+        this.mvar2 = 132
+      enddef
     endclass
 
     def F2(i: I1): list<number>
-        return [ i.mvar1, i.mvar2 ]
+      return [ i.mvar1, i.mvar2 ]
     enddef
 
     var oa = A.new()
@@ -2330,60 +2330,60 @@ def Test_class_implements_interface()
     vim9script
 
     interface I1
-        this.mvar1: number
-        this.mvar2: number
+      this.mvar1: number
+      this.mvar2: number
     endinterface
 
     interface I2
-        this.mvar3: number
-        this.mvar4: number
+      this.mvar3: number
+      this.mvar4: number
     endinterface
 
     class A implements I1
-        public static svar1: number
-        public static svar2: number
-        this.mvar1: number
-        this.mvar2: number
-        def new()
-            svar1 = 11
-            svar2 = 12
-            this.mvar1 = 111
-            this.mvar2 = 112
-        enddef
+      public static svar1: number
+      public static svar2: number
+      this.mvar1: number
+      this.mvar2: number
+      def new()
+        svar1 = 11
+        svar2 = 12
+        this.mvar1 = 111
+        this.mvar2 = 112
+      enddef
     endclass
 
     class B extends A implements I2
-        static svar3: number
-        static svar4: number
-        this.mvar3: number
-        this.mvar4: number
-        def new()
-            svar3 = 23
-            svar4 = 24
-            this.mvar1 = 121
-            this.mvar2 = 122
-            this.mvar3 = 123
-            this.mvar4 = 124
-        enddef
+      static svar3: number
+      static svar4: number
+      this.mvar3: number
+      this.mvar4: number
+      def new()
+        svar3 = 23
+        svar4 = 24
+        this.mvar1 = 121
+        this.mvar2 = 122
+        this.mvar3 = 123
+        this.mvar4 = 124
+      enddef
     endclass
 
     class C extends B
-        public static svar5: number
-        def new()
-            svar5 = 1001
-            this.mvar1 = 131
-            this.mvar2 = 132
-            this.mvar3 = 133
-            this.mvar4 = 134
-        enddef
+      public static svar5: number
+      def new()
+        svar5 = 1001
+        this.mvar1 = 131
+        this.mvar2 = 132
+        this.mvar3 = 133
+        this.mvar4 = 134
+      enddef
     endclass
 
     def F2(i: I1): list<number>
-        return [ i.mvar1, i.mvar2 ]
+      return [ i.mvar1, i.mvar2 ]
     enddef
 
     def F4(i: I2): list<number>
-        return [ i.mvar3, i.mvar4 ]
+      return [ i.mvar3, i.mvar4 ]
     enddef
 
     var oa = A.new()
@@ -2531,269 +2531,269 @@ def Test_call_interface_method()
 
   # No class that implements the interface.
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface IWithEE
-          def Enter(): any
-          def Exit(): void
-      endinterface
+    interface IWithEE
+      def Enter(): any
+      def Exit(): void
+    endinterface
 
-      def With1(ee: IWithEE, F: func)
-          var r = ee.Enter()
-      enddef
+    def With1(ee: IWithEE, F: func)
+      var r = ee.Enter()
+    enddef
 
-      defcompile
+    defcompile
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_class_used_as_type()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class Point
-        this.x = 0
-        this.y = 0
-      endclass
+    class Point
+      this.x = 0
+      this.y = 0
+    endclass
 
-      var p: Point
-      p = Point.new(2, 33)
-      assert_equal(2, p.x)
-      assert_equal(33, p.y)
+    var p: Point
+    p = Point.new(2, 33)
+    assert_equal(2, p.x)
+    assert_equal(33, p.y)
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      interface HasX
-        this.x: number
-      endinterface
+    interface HasX
+      this.x: number
+    endinterface
 
-      class Point implements HasX
-        this.x = 0
-        this.y = 0
-      endclass
+    class Point implements HasX
+      this.x = 0
+      this.y = 0
+    endclass
 
-      var p: Point
-      p = Point.new(2, 33)
-      var hx = p
-      assert_equal(2, hx.x)
+    var p: Point
+    p = Point.new(2, 33)
+    var hx = p
+    assert_equal(2, hx.x)
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Point
-        this.x = 0
-        this.y = 0
-      endclass
+    class Point
+      this.x = 0
+      this.y = 0
+    endclass
 
-      var p: Point
-      p = 'text'
+    var p: Point
+    p = 'text'
   END
-  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected object<Point> but got string')
+  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected object<Point> but got string', 9)
 enddef
 
 def Test_class_extends()
   var lines =<< trim END
-      vim9script
-      class Base
-        this.one = 1
-        def GetOne(): number
-          return this.one
-        enddef
-      endclass
-      class Child extends Base
-        this.two = 2
-        def GetTotal(): number
-          return this.one + this.two
-        enddef
-      endclass
-      var o = Child.new()
-      assert_equal(1, o.one)
-      assert_equal(2, o.two)
-      assert_equal(1, o.GetOne())
-      assert_equal(3, o.GetTotal())
-  END
-  v9.CheckSourceSuccess(lines)
-
-  lines =<< trim END
-      vim9script
-      class Base
-        this.one = 1
-      endclass
-      class Child extends Base
-        this.two = 2
-      endclass
-      var o = Child.new(3, 44)
-      assert_equal(3, o.one)
-      assert_equal(44, o.two)
-  END
-  v9.CheckSourceSuccess(lines)
-
-  lines =<< trim END
-      vim9script
-      class Base
-        this.one = 1
-      endclass
-      class Child extends Base extends Base
-        this.two = 2
-      endclass
-  END
-  v9.CheckSourceFailure(lines, 'E1352: Duplicate "extends"')
-
-  lines =<< trim END
-      vim9script
-      class Child extends BaseClass
-        this.two = 2
-      endclass
-  END
-  v9.CheckSourceFailure(lines, 'E1353: Class name not found: BaseClass')
-
-  lines =<< trim END
-      vim9script
-      var SomeVar = 99
-      class Child extends SomeVar
-        this.two = 2
-      endclass
-  END
-  v9.CheckSourceFailure(lines, 'E1354: Cannot extend SomeVar')
-
-  lines =<< trim END
-      vim9script
-      class Base
-        this.name: string
-        def ToString(): string
-          return this.name
-        enddef
-      endclass
-
-      class Child extends Base
-        this.age: number
-        def ToString(): string
-          return super.ToString() .. ': ' .. this.age
-        enddef
-      endclass
-
-      var o = Child.new('John', 42)
-      assert_equal('John: 42', o.ToString())
-  END
-  v9.CheckSourceSuccess(lines)
-
-  lines =<< trim END
-      vim9script
-      class Child
-        this.age: number
-        def ToString(): number
-          return this.age
-        enddef
-        def ToString(): string
-          return this.age
-        enddef
-      endclass
-  END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: ToString')
-
-  lines =<< trim END
-      vim9script
-      class Child
-        this.age: number
-        def ToString(): string
-          return super .ToString() .. ': ' .. this.age
-        enddef
-      endclass
-      var o = Child.new(42)
-      echo o.ToString()
-  END
-  v9.CheckSourceFailure(lines, 'E1356:')
-
-  lines =<< trim END
-      vim9script
-      class Base
-        this.name: string
-        def ToString(): string
-          return this.name
-        enddef
-      endclass
-
-      var age = 42
-      def ToString(): string
-        return super.ToString() .. ': ' .. age
+    vim9script
+    class Base
+      this.one = 1
+      def GetOne(): number
+        return this.one
       enddef
-      echo ToString()
-  END
-  v9.CheckSourceFailure(lines, 'E1357:')
-
-  lines =<< trim END
-      vim9script
-      class Child
-        this.age: number
-        def ToString(): string
-          return super.ToString() .. ': ' .. this.age
-        enddef
-      endclass
-      var o = Child.new(42)
-      echo o.ToString()
-  END
-  v9.CheckSourceFailure(lines, 'E1358:')
-
-  lines =<< trim END
-      vim9script
-      class Base
-        this.name: string
-        static def ToString(): string
-          return 'Base class'
-        enddef
-      endclass
-
-      class Child extends Base
-        this.age: number
-        def ToString(): string
-          return Base.ToString() .. ': ' .. this.age
-        enddef
-      endclass
-
-      var o = Child.new('John', 42)
-      assert_equal('Base class: 42', o.ToString())
+    endclass
+    class Child extends Base
+      this.two = 2
+      def GetTotal(): number
+        return this.one + this.two
+      enddef
+    endclass
+    var o = Child.new()
+    assert_equal(1, o.one)
+    assert_equal(2, o.two)
+    assert_equal(1, o.GetOne())
+    assert_equal(3, o.GetTotal())
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
-      class Base
-        this.value = 1
-        def new(init: number)
-          this.value = number + 1
-        enddef
-      endclass
-      class Child extends Base
-        def new()
-          this.new(3)
-        enddef
-      endclass
-      var c = Child.new()
+    vim9script
+    class Base
+      this.one = 1
+    endclass
+    class Child extends Base
+      this.two = 2
+    endclass
+    var o = Child.new(3, 44)
+    assert_equal(3, o.one)
+    assert_equal(44, o.two)
   END
-  v9.CheckSourceFailure(lines, 'E1385: Class method "new" accessible only using class "Child"')
+  v9.CheckSourceSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+    class Base
+      this.one = 1
+    endclass
+    class Child extends Base extends Base
+      this.two = 2
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1352: Duplicate "extends"', 5)
+
+  lines =<< trim END
+    vim9script
+    class Child extends BaseClass
+      this.two = 2
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1353: Class name not found: BaseClass', 4)
+
+  lines =<< trim END
+    vim9script
+    var SomeVar = 99
+    class Child extends SomeVar
+      this.two = 2
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1354: Cannot extend SomeVar', 5)
+
+  lines =<< trim END
+    vim9script
+    class Base
+      this.name: string
+      def ToString(): string
+        return this.name
+      enddef
+    endclass
+
+    class Child extends Base
+      this.age: number
+      def ToString(): string
+        return super.ToString() .. ': ' .. this.age
+      enddef
+    endclass
+
+    var o = Child.new('John', 42)
+    assert_equal('John: 42', o.ToString())
+  END
+  v9.CheckSourceSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+    class Child
+      this.age: number
+      def ToString(): number
+        return this.age
+      enddef
+      def ToString(): string
+        return this.age
+      enddef
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: ToString', 9)
+
+  lines =<< trim END
+    vim9script
+    class Child
+      this.age: number
+      def ToString(): string
+        return super .ToString() .. ': ' .. this.age
+      enddef
+    endclass
+    var o = Child.new(42)
+    echo o.ToString()
+  END
+  v9.CheckSourceFailure(lines, 'E1356: "super" must be followed by a dot', 1)
+
+  lines =<< trim END
+    vim9script
+    class Base
+      this.name: string
+      def ToString(): string
+        return this.name
+      enddef
+    endclass
+
+    var age = 42
+    def ToString(): string
+      return super.ToString() .. ': ' .. age
+    enddef
+    echo ToString()
+  END
+  v9.CheckSourceFailure(lines, 'E1357: Using "super" not in a class method', 1)
+
+  lines =<< trim END
+    vim9script
+    class Child
+      this.age: number
+      def ToString(): string
+        return super.ToString() .. ': ' .. this.age
+      enddef
+    endclass
+    var o = Child.new(42)
+    echo o.ToString()
+  END
+  v9.CheckSourceFailure(lines, 'E1358: Using "super" not in a child class', 1)
+
+  lines =<< trim END
+    vim9script
+    class Base
+      this.name: string
+      static def ToString(): string
+        return 'Base class'
+      enddef
+    endclass
+
+    class Child extends Base
+      this.age: number
+      def ToString(): string
+        return Base.ToString() .. ': ' .. this.age
+      enddef
+    endclass
+
+    var o = Child.new('John', 42)
+    assert_equal('Base class: 42', o.ToString())
+  END
+  v9.CheckSourceSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+    class Base
+      this.value = 1
+      def new(init: number)
+        this.value = number + 1
+      enddef
+    endclass
+    class Child extends Base
+      def new()
+        this.new(3)
+      enddef
+    endclass
+    var c = Child.new()
+  END
+  v9.CheckSourceFailure(lines, 'E1385: Class method "new" accessible only using class "Child"', 1)
 
   # base class with more than one object member
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class Result
-        this.success: bool
-        this.value: any = null
-      endclass
+    class Result
+      this.success: bool
+      this.value: any = null
+    endclass
 
-      class Success extends Result
-        def new(this.value = v:none)
-          this.success = true
-        enddef
-      endclass
+    class Success extends Result
+      def new(this.value = v:none)
+        this.success = true
+      enddef
+    endclass
 
-      var v = Success.new('asdf')
-      assert_equal("object of Success {success: true, value: 'asdf'}", string(v))
+    var v = Success.new('asdf')
+    assert_equal("object of Success {success: true, value: 'asdf'}", string(v))
   END
   v9.CheckSourceSuccess(lines)
 
@@ -2805,7 +2805,7 @@ def Test_class_extends()
     class B extends A"
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1315:')
+  v9.CheckSourceFailure(lines, 'E1315: White space required after name: A"', 4)
 enddef
 
 def Test_using_base_class()
@@ -2813,31 +2813,31 @@ def Test_using_base_class()
     vim9script
 
     class BaseEE
-        def Enter(): any
-            return null
-        enddef
-        def Exit(resource: any): void
-        enddef
+      def Enter(): any
+        return null
+      enddef
+      def Exit(resource: any): void
+      enddef
     endclass
 
     class ChildEE extends BaseEE
-        def Enter(): any
-            return 42
-        enddef
+      def Enter(): any
+        return 42
+      enddef
 
-        def Exit(resource: number): void
-            g:result ..= '/exit'
-        enddef
+      def Exit(resource: number): void
+        g:result ..= '/exit'
+      enddef
     endclass
 
     def With(ee: BaseEE)
-        var r = ee.Enter()
-        try
-            g:result ..= r
-        finally
-            g:result ..= '/finally'
-            ee.Exit(r)
-        endtry
+      var r = ee.Enter()
+      try
+        g:result ..= r
+      finally
+        g:result ..= '/finally'
+        ee.Exit(r)
+      endtry
     enddef
 
     g:result = ''
@@ -2852,16 +2852,16 @@ def Test_using_base_class()
     vim9script
 
     class Base
-        this.success: bool = false
-        def Method(arg = 0)
-            this.success = true
-        enddef
+      this.success: bool = false
+      def Method(arg = 0)
+        this.success = true
+      enddef
     endclass
 
     class Child extends Base
-        def new()
-            super.Method()
-        enddef
+      def new()
+        super.Method()
+      enddef
     endclass
 
     var obj = Child.new()
@@ -2872,63 +2872,63 @@ enddef
 
 def Test_class_import()
   var lines =<< trim END
-      vim9script
-      export class Animal
-        this.kind: string
-        this.name: string
-      endclass
+    vim9script
+    export class Animal
+      this.kind: string
+      this.name: string
+    endclass
   END
   writefile(lines, 'Xanimal.vim', 'D')
 
   lines =<< trim END
-      vim9script
-      import './Xanimal.vim' as animal
+    vim9script
+    import './Xanimal.vim' as animal
 
-      var a: animal.Animal
-      a = animal.Animal.new('fish', 'Eric')
-      assert_equal('fish', a.kind)
-      assert_equal('Eric', a.name)
+    var a: animal.Animal
+    a = animal.Animal.new('fish', 'Eric')
+    assert_equal('fish', a.kind)
+    assert_equal('Eric', a.name)
 
-      var b: animal.Animal = animal.Animal.new('cat', 'Garfield')
-      assert_equal('cat', b.kind)
-      assert_equal('Garfield', b.name)
+    var b: animal.Animal = animal.Animal.new('cat', 'Garfield')
+    assert_equal('cat', b.kind)
+    assert_equal('Garfield', b.name)
   END
   v9.CheckScriptSuccess(lines)
 enddef
 
 def Test_abstract_class()
   var lines =<< trim END
-      vim9script
-      abstract class Base
-        this.name: string
-      endclass
-      class Person extends Base
-        this.age: number
-      endclass
-      var p: Base = Person.new('Peter', 42)
-      assert_equal('Peter', p.name)
-      assert_equal(42, p.age)
+    vim9script
+    abstract class Base
+      this.name: string
+    endclass
+    class Person extends Base
+      this.age: number
+    endclass
+    var p: Base = Person.new('Peter', 42)
+    assert_equal('Peter', p.name)
+    assert_equal(42, p.age)
   END
   v9.CheckSourceSuccess(lines)
 
   lines =<< trim END
-      vim9script
-      abstract class Base
-        this.name: string
-      endclass
-      class Person extends Base
-        this.age: number
-      endclass
-      var p = Base.new('Peter')
+    vim9script
+    abstract class Base
+      this.name: string
+    endclass
+    class Person extends Base
+      this.age: number
+    endclass
+    var p = Base.new('Peter')
   END
-  v9.CheckSourceFailure(lines, 'E1325: Method not found on class "Base": new')
+  v9.CheckSourceFailure(lines, 'E1325: Method not found on class "Base": new', 8)
 
   lines =<< trim END
-      abstract class Base
-        this.name: string
-      endclass
+    abstract class Base
+      this.name: string
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1316:')
+  v9.CheckSourceFailure(lines, 'E1316: Class can only be defined in Vim9 script', 1)
 
   # Abstract class cannot have a "new" function
   lines =<< trim END
@@ -2938,112 +2938,112 @@ def Test_abstract_class()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1359:')
+  v9.CheckSourceFailure(lines, 'E1359: Cannot define a "new" method in an abstract class', 4)
 enddef
 
 def Test_closure_in_class()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class Foo
-        this.y: list<string> = ['B']
+    class Foo
+      this.y: list<string> = ['B']
 
-        def new()
-          g:result = filter(['A', 'B'], (_, v) => index(this.y, v) == -1)
-        enddef
-      endclass
+      def new()
+        g:result = filter(['A', 'B'], (_, v) => index(this.y, v) == -1)
+      enddef
+    endclass
 
-      Foo.new()
-      assert_equal(['A'], g:result)
+    Foo.new()
+    assert_equal(['A'], g:result)
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_call_constructor_from_legacy()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      var newCalled = 'false'
+    var newCalled = 'false'
 
-      class A
-        def new()
-          newCalled = 'true'
-        enddef
-      endclass
-
-      export def F(options = {}): any
-        return A
+    class A
+      def new()
+        newCalled = 'true'
       enddef
+    endclass
 
-      g:p = F()
-      legacy call p.new()
-      assert_equal('true', newCalled)
+    export def F(options = {}): any
+      return A
+    enddef
+
+    g:p = F()
+    legacy call p.new()
+    assert_equal('true', newCalled)
   END
   v9.CheckSourceSuccess(lines)
 enddef
 
 def Test_defer_with_object()
   var lines =<< trim END
-      vim9script
+    vim9script
 
-      class CWithEE
-        def Enter()
-          g:result ..= "entered/"
-        enddef
-        def Exit()
-          g:result ..= "exited"
-        enddef
-      endclass
-
-      def With(ee: CWithEE, F: func)
-        ee.Enter()
-        defer ee.Exit()
-        F()
+    class CWithEE
+      def Enter()
+        g:result ..= "entered/"
       enddef
+      def Exit()
+        g:result ..= "exited"
+      enddef
+    endclass
 
-      g:result = ''
-      var obj = CWithEE.new()
-      obj->With(() => {
-        g:result ..= "called/"
-      })
-      assert_equal('entered/called/exited', g:result)
+    def With(ee: CWithEE, F: func)
+      ee.Enter()
+      defer ee.Exit()
+      F()
+    enddef
+
+    g:result = ''
+    var obj = CWithEE.new()
+    obj->With(() => {
+      g:result ..= "called/"
+    })
+    assert_equal('entered/called/exited', g:result)
   END
   v9.CheckSourceSuccess(lines)
   unlet g:result
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class BaseWithEE
-        def Enter()
-          g:result ..= "entered-base/"
-        enddef
-        def Exit()
-          g:result ..= "exited-base"
-        enddef
-      endclass
-
-      class CWithEE extends BaseWithEE
-        def Enter()
-          g:result ..= "entered-child/"
-        enddef
-        def Exit()
-          g:result ..= "exited-child"
-        enddef
-      endclass
-
-      def With(ee: BaseWithEE, F: func)
-        ee.Enter()
-        defer ee.Exit()
-        F()
+    class BaseWithEE
+      def Enter()
+        g:result ..= "entered-base/"
       enddef
+      def Exit()
+        g:result ..= "exited-base"
+      enddef
+    endclass
 
-      g:result = ''
-      var obj = CWithEE.new()
-      obj->With(() => {
-        g:result ..= "called/"
-      })
-      assert_equal('entered-child/called/exited-child', g:result)
+    class CWithEE extends BaseWithEE
+      def Enter()
+        g:result ..= "entered-child/"
+      enddef
+      def Exit()
+        g:result ..= "exited-child"
+      enddef
+    endclass
+
+    def With(ee: BaseWithEE, F: func)
+      ee.Enter()
+      defer ee.Exit()
+      F()
+    enddef
+
+    g:result = ''
+    var obj = CWithEE.new()
+    obj->With(() => {
+      g:result ..= "called/"
+    })
+    assert_equal('entered-child/called/exited-child', g:result)
   END
   v9.CheckSourceSuccess(lines)
   unlet g:result
@@ -3335,9 +3335,9 @@ def Test_stack_expansion_with_methods()
     vim9script
 
     class C
-        def M1()
-            F0()
-        enddef
+      def M1()
+        F0()
+      enddef
     endclass
 
     def F0()
@@ -3345,7 +3345,7 @@ def Test_stack_expansion_with_methods()
     enddef
 
     def F()
-        C.new().M1()
+      C.new().M1()
     enddef
 
     F()
@@ -3431,7 +3431,7 @@ def Test_new_return_type()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1365:')
+  v9.CheckSourceFailure(lines, 'E1365: Cannot use a return type with the "new" method', 11)
 
   # new() uses 'Dict' return type and returns a Dict
   lines =<< trim END
@@ -3449,7 +3449,7 @@ def Test_new_return_type()
     var c = C.new()
     assert_equal('object<C>', typename(c))
   END
-  v9.CheckSourceFailure(lines, 'E1365:')
+  v9.CheckSourceFailure(lines, 'E1365: Cannot use a return type with the "new" method', 9)
 enddef
 
 " Test for checking a member initialization type at run time.
@@ -3460,22 +3460,22 @@ def Test_runtime_type_check_for_member_init()
     var retnum: bool = false
 
     def F(): any
-        retnum = !retnum
-        if retnum
-            return 1
-        else
-            return "hello"
-        endif
+      retnum = !retnum
+      if retnum
+        return 1
+      else
+        return "hello"
+      endif
     enddef
 
     class C
-        this._foo: bool = F()
+      this._foo: bool = F()
     endclass
 
     var c1 = C.new()
     var c2 = C.new()
   END
-  v9.CheckSourceFailure(lines, 'E1012:')
+  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected bool but got string', 0)
 enddef
 
 " Test for locking a variable referring to an object and reassigning to another
@@ -3529,7 +3529,7 @@ def Test_private_object_method()
     var a = A.new()
     a._Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 9)
 
   # Try calling a private method using an object (from a def function)
   lines =<< trim END
@@ -3546,7 +3546,7 @@ def Test_private_object_method()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 2)
 
   # Use a private method from another object method (in script context)
   lines =<< trim END
@@ -3600,7 +3600,7 @@ def Test_private_object_method()
     var a = A.new()
     a.Bar()
   END
-  v9.CheckSourceFailure(lines, 'E117: Unknown function: _Foo')
+  v9.CheckSourceFailure(lines, 'E117: Unknown function: _Foo', 1)
 
   # Try calling a private method using the class name
   lines =<< trim END
@@ -3613,7 +3613,7 @@ def Test_private_object_method()
     endclass
     A._Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 8)
 
   # Define two private methods with the same name
   lines =<< trim END
@@ -3627,7 +3627,7 @@ def Test_private_object_method()
     endclass
     var a = A.new()
   END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo')
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo', 7)
 
   # Define a private method and a object method with the same name
   lines =<< trim END
@@ -3641,7 +3641,7 @@ def Test_private_object_method()
     endclass
     var a = A.new()
   END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo')
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo', 7)
 
   # Define an object method and a private method with the same name
   lines =<< trim END
@@ -3655,7 +3655,7 @@ def Test_private_object_method()
     endclass
     var a = A.new()
   END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo')
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo', 7)
 
   # Call a public method and a private method from a private method
   lines =<< trim END
@@ -3699,7 +3699,7 @@ def Test_private_object_method()
     var b = B.new()
     b.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 2)
 
   # Call a private object method from a child class object method
   lines =<< trim END
@@ -3742,7 +3742,7 @@ def Test_private_object_method()
     var c = C.new()
     assert_equal(1234, c._Foo())
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 16)
 
   # Using "_" prefix in a method name should fail outside of a class
   lines =<< trim END
@@ -3752,7 +3752,7 @@ def Test_private_object_method()
     enddef
     var a = _Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1267: Function name must start with a capital: _Foo(): number')
+  v9.CheckSourceFailure(lines, 'E1267: Function name must start with a capital: _Foo(): number', 2)
 enddef
 
 " Test for an private class method
@@ -3768,7 +3768,7 @@ def Test_private_class_method()
     endclass
     A._Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 8)
 
   # Try calling a class private method (from a def function)
   lines =<< trim END
@@ -3784,7 +3784,7 @@ def Test_private_class_method()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 1)
 
   # Try calling a class private method using an object (at the script level)
   lines =<< trim END
@@ -3798,7 +3798,7 @@ def Test_private_class_method()
     var a = A.new()
     a._Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 9)
 
   # Try calling a class private method using an object (from a def function)
   lines =<< trim END
@@ -3815,7 +3815,7 @@ def Test_private_class_method()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 2)
 
   # Use a class private method from an object method
   lines =<< trim END
@@ -3867,7 +3867,7 @@ def Test_private_class_method()
     endclass
     var a = A.new()
   END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo')
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo', 7)
 
   # Try calling a class private method from another class
   lines =<< trim END
@@ -3886,7 +3886,7 @@ def Test_private_class_method()
     var b = B.new()
     assert_equal(1234, b.Foo())
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 1)
 
   # Call a private class method from a child class object method
   lines =<< trim END
@@ -3908,7 +3908,7 @@ def Test_private_class_method()
     var c = C.new()
     assert_equal(1234, c.Baz())
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 1)
 
   # Call a private class method from a child class private class method
   lines =<< trim END
@@ -3929,7 +3929,7 @@ def Test_private_class_method()
     endclass
     assert_equal(1234, C.Baz())
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()')
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 1)
 
   # Call a private class method from a child class object
   lines =<< trim END
@@ -3950,7 +3950,7 @@ def Test_private_class_method()
     var c = C.new()
     assert_equal(1234, C._Foo())
   END
-  v9.CheckSourceFailure(lines, 'E1325: Method not found on class "C": _Foo')
+  v9.CheckSourceFailure(lines, 'E1325: Method not found on class "C": _Foo', 16)
 enddef
 
 " Test for using the return value of a class/object method as a function
@@ -4006,35 +4006,35 @@ def Test_static_inheritence()
     vim9script
 
     class A
-        static _svar: number
-        this._mvar: number
-        def new()
-            _svar = 1
-            this._mvar = 101
-        enddef
-        def AccessObject(): number
-            return this._mvar
-        enddef
-        def AccessStaticThroughObject(): number
-            return _svar
-        enddef
+      static _svar: number
+      this._mvar: number
+      def new()
+        _svar = 1
+        this._mvar = 101
+      enddef
+      def AccessObject(): number
+        return this._mvar
+      enddef
+      def AccessStaticThroughObject(): number
+        return _svar
+      enddef
     endclass
 
     class B extends A
-        def new()
-            this._mvar = 102
-        enddef
+      def new()
+        this._mvar = 102
+      enddef
     endclass
 
     class C extends B
-        def new()
-            this._mvar = 103
-        enddef
+      def new()
+        this._mvar = 103
+      enddef
 
-        def AccessPrivateStaticThroughClassName(): number
-            assert_equal(1, A._svar)
-            return 444
-        enddef
+      def AccessPrivateStaticThroughClassName(): number
+        assert_equal(1, A._svar)
+        return 444
+      enddef
     endclass
 
     var oa = A.new()
@@ -4064,7 +4064,7 @@ def Test_dup_member_variable()
       this.val = 20
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 4)
 
   # Duplicate private member variable
   lines =<< trim END
@@ -4074,7 +4074,7 @@ def Test_dup_member_variable()
       this._val = 20
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 4)
 
   # Duplicate public member variable
   lines =<< trim END
@@ -4084,7 +4084,7 @@ def Test_dup_member_variable()
       public this.val = 20
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 4)
 
   # Duplicate private member variable
   lines =<< trim END
@@ -4094,7 +4094,7 @@ def Test_dup_member_variable()
       this._val = 20
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 4)
 
   # Duplicate public and private member variable
   lines =<< trim END
@@ -4104,7 +4104,7 @@ def Test_dup_member_variable()
       public this.val = 10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 4)
 
   # Duplicate class member variable
   lines =<< trim END
@@ -4114,7 +4114,7 @@ def Test_dup_member_variable()
       static _s: string = "def"
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _s')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _s', 4)
 
   # Duplicate public and private class member variable
   lines =<< trim END
@@ -4124,7 +4124,7 @@ def Test_dup_member_variable()
       static _s: string = "def"
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _s')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _s', 4)
 
   # Duplicate class and object member variable
   lines =<< trim END
@@ -4153,7 +4153,7 @@ def Test_dup_member_variable()
       this.val = 20
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 9)
 
   # Duplicate object private member variable in a derived class
   lines =<< trim END
@@ -4167,7 +4167,7 @@ def Test_dup_member_variable()
       this._val = 20
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 9)
 
   # Duplicate object private member variable in a derived class
   lines =<< trim END
@@ -4181,7 +4181,7 @@ def Test_dup_member_variable()
       this._val = 20
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 9)
 
   # Duplicate object member variable in a derived class
   lines =<< trim END
@@ -4195,7 +4195,7 @@ def Test_dup_member_variable()
       this.val = 20
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val')
+  v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 9)
 
   # Two member variables with a common prefix
   lines =<< trim END
@@ -4225,7 +4225,7 @@ def Test_private_member_access_outside_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _val')
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _val', 2)
 
   # access a non-existing private object member variable
   lines =<< trim END
@@ -4239,7 +4239,7 @@ def Test_private_member_access_outside_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1326: Variable not found on object "A": _a')
+  v9.CheckSourceFailure(lines, 'E1326: Variable not found on object "A": _a', 2)
 
   # private static member variable
   lines =<< trim END
@@ -4253,7 +4253,7 @@ def Test_private_member_access_outside_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "_val" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "_val" accessible only using class "A"', 2)
 
   # private static member variable
   lines =<< trim END
@@ -4267,7 +4267,7 @@ def Test_private_member_access_outside_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "_val" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "_val" accessible only using class "A"', 2)
 
   # private static class variable
   lines =<< trim END
@@ -4280,7 +4280,7 @@ def Test_private_member_access_outside_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _val')
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _val', 1)
 
   # private static class variable
   lines =<< trim END
@@ -4293,7 +4293,7 @@ def Test_private_member_access_outside_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _val')
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable: _val', 1)
 enddef
 
 " Test for changing the member access of an interface in a implementation class
@@ -4307,7 +4307,7 @@ def Test_change_interface_member_access()
       public this.val = 10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1367: Access level of variable "val" of interface "A" is different')
+  v9.CheckSourceFailure(lines, 'E1367: Access level of variable "val" of interface "A" is different', 7)
 
   lines =<< trim END
     vim9script
@@ -4318,7 +4318,7 @@ def Test_change_interface_member_access()
       public this.val = 10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1367: Access level of variable "val" of interface "A" is different')
+  v9.CheckSourceFailure(lines, 'E1367: Access level of variable "val" of interface "A" is different', 7)
 enddef
 
 " Test for trying to change a readonly member from a def function
@@ -4334,7 +4334,7 @@ def Test_readonly_member_change_in_def_func()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1335: Variable "val" in class "A" is not writable')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "val" in class "A" is not writable', 2)
 enddef
 
 " Test for reading and writing a class member from a def function
@@ -4396,7 +4396,7 @@ def Test_class_variable_access_using_object()
     var a = A.new()
     echo a.svar2
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "svar2" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "svar2" accessible only using class "A"', 8)
 
   # Cannot write to a class variable using an object in script context
   lines =<< trim END
@@ -4409,7 +4409,7 @@ def Test_class_variable_access_using_object()
     var a = A.new()
     a.svar2 = [2]
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "svar2" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "svar2" accessible only using class "A"', 8)
 
   # Cannot read from a class variable using an object in def method context
   lines =<< trim END
@@ -4425,7 +4425,7 @@ def Test_class_variable_access_using_object()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "svar2" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "svar2" accessible only using class "A"', 2)
 
   # Cannot write to a class variable using an object in def method context
   lines =<< trim END
@@ -4441,7 +4441,7 @@ def Test_class_variable_access_using_object()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "svar2" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "svar2" accessible only using class "A"', 2)
 enddef
 
 " Test for using a interface method using a child object
@@ -4555,7 +4555,7 @@ def Test_abstract_method()
     class B extends A
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1373: Abstract method "Foo" is not implemented')
+  v9.CheckSourceFailure(lines, 'E1373: Abstract method "Foo" is not implemented', 6)
 
   # Use abstract method in a concrete class
   lines =<< trim END
@@ -4566,7 +4566,7 @@ def Test_abstract_method()
     class B extends A
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1372: Abstract method "abstract def Foo()" cannot be defined in a concrete class')
+  v9.CheckSourceFailure(lines, 'E1372: Abstract method "abstract def Foo()" cannot be defined in a concrete class', 3)
 
   # Use abstract method in an interface
   lines =<< trim END
@@ -4588,7 +4588,7 @@ def Test_abstract_method()
       abs def Foo()
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1065: Command cannot be shortened: abs def Foo()')
+  v9.CheckSourceFailure(lines, 'E1065: Command cannot be shortened: abs def Foo()', 3)
 
   # Use "abstract" with a member variable
   lines =<< trim END
@@ -4597,7 +4597,7 @@ def Test_abstract_method()
       abstract this.val = 10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1371: Abstract must be followed by "def" or "static"')
+  v9.CheckSourceFailure(lines, 'E1371: Abstract must be followed by "def" or "static"', 3)
 
   # Use a static abstract method
   lines =<< trim END
@@ -4626,7 +4626,7 @@ def Test_abstract_method()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1383: Method "Foo": type mismatch, expected func(string, number): list<number> but got func(number, string): list<string>')
+  v9.CheckSourceFailure(lines, 'E1383: Method "Foo": type mismatch, expected func(string, number): list<number> but got func(number, string): list<string>', 9)
 
   # Use an abstract class to invoke an abstract method
   # FIXME: This should fail
@@ -4680,7 +4680,7 @@ def Test_class_method_call_from_subclass()
     var b = B.new()
     b.Bar()
   END
-  v9.CheckSourceFailure(lines, 'E1384: Class method "Foo" accessible only inside class "A"')
+  v9.CheckSourceFailure(lines, 'E1384: Class method "Foo" accessible only inside class "A"', 1)
 enddef
 
 " Test for calling a class method using an object in a def function context and
@@ -4724,7 +4724,7 @@ def Test_class_method_call_using_object()
     var a = A.new()
     assert_equal('foo', a.Foo())
   END
-  v9.CheckSourceFailure(lines, 'E1385: Class method "Foo" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1385: Class method "Foo" accessible only using class "A"', 9)
 
   # def function context
   lines =<< trim END
@@ -4741,7 +4741,7 @@ def Test_class_method_call_using_object()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1385: Class method "Foo" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1385: Class method "Foo" accessible only using class "A"', 2)
 enddef
 
 def Test_class_variable()
@@ -4794,7 +4794,7 @@ def Test_class_variable()
     endclass
     B.ClassFunc()
   END
-  v9.CheckSourceFailure(lines, 'E1374: Class variable "val" accessible only inside class "A"')
+  v9.CheckSourceFailure(lines, 'E1374: Class variable "val" accessible only inside class "A"', 1)
 
   # Reading a parent class variable from a child class method
   lines =<< trim END
@@ -4811,7 +4811,7 @@ def Test_class_variable()
     endclass
     B.ClassFunc()
   END
-  v9.CheckSourceFailure(lines, 'E1374: Class variable "val" accessible only inside class "A"')
+  v9.CheckSourceFailure(lines, 'E1374: Class variable "val" accessible only inside class "A"', 1)
 
   # Modifying a parent class variable from a child object method
   lines =<< trim END
@@ -4829,7 +4829,7 @@ def Test_class_variable()
     var b = B.new()
     b.ObjFunc()
   END
-  v9.CheckSourceFailure(lines, 'E1374: Class variable "val" accessible only inside class "A"')
+  v9.CheckSourceFailure(lines, 'E1374: Class variable "val" accessible only inside class "A"', 1)
 
   # Reading a parent class variable from a child object method
   lines =<< trim END
@@ -4847,7 +4847,7 @@ def Test_class_variable()
     var b = B.new()
     b.ObjFunc()
   END
-  v9.CheckSourceFailure(lines, 'E1374: Class variable "val" accessible only inside class "A"')
+  v9.CheckSourceFailure(lines, 'E1374: Class variable "val" accessible only inside class "A"', 1)
 
   # Modifying a class variable using an object at script level
   lines =<< trim END
@@ -4859,7 +4859,7 @@ def Test_class_variable()
     var a = A.new()
     a.val = 20
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "val" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "val" accessible only using class "A"', 7)
 
   # Reading a class variable using an object at script level
   lines =<< trim END
@@ -4871,7 +4871,7 @@ def Test_class_variable()
     var a = A.new()
     var i = a.val
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "val" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "val" accessible only using class "A"', 7)
 
   # Modifying a class variable using an object at function level
   lines =<< trim END
@@ -4887,7 +4887,7 @@ def Test_class_variable()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "val" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "val" accessible only using class "A"', 2)
 
   # Reading a class variable using an object at function level
   lines =<< trim END
@@ -4902,7 +4902,7 @@ def Test_class_variable()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1375: Class variable "val" accessible only using class "A"')
+  v9.CheckSourceFailure(lines, 'E1375: Class variable "val" accessible only using class "A"', 2)
 enddef
 
 " Test for using a duplicate class method and class variable in a child class
@@ -5001,7 +5001,7 @@ def Test_instance_method_call_using_class()
     endclass
     A.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1386: Object method "Foo" accessible only using class "A" object')
+  v9.CheckSourceFailure(lines, 'E1386: Object method "Foo" accessible only using class "A" object', 7)
 
   # Invoke an object method using a class in def function context
   lines =<< trim END
@@ -5016,7 +5016,7 @@ def Test_instance_method_call_using_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1386: Object method "Foo" accessible only using class "A" object')
+  v9.CheckSourceFailure(lines, 'E1386: Object method "Foo" accessible only using class "A" object', 1)
 enddef
 
 " Test for duplicate class method and instance method
@@ -5031,7 +5031,7 @@ def Test_dup_classmethod_objmethod()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo')
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo', 6)
 
   # Duplicate private instance method
   lines =<< trim END
@@ -5043,7 +5043,7 @@ def Test_dup_classmethod_objmethod()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo')
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo', 6)
 
   # Duplicate class method
   lines =<< trim END
@@ -5055,7 +5055,7 @@ def Test_dup_classmethod_objmethod()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo')
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo', 6)
 
   # Duplicate private class method
   lines =<< trim END
@@ -5067,7 +5067,7 @@ def Test_dup_classmethod_objmethod()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo')
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo', 6)
 
   # Duplicate private class and object method
   lines =<< trim END
@@ -5079,7 +5079,7 @@ def Test_dup_classmethod_objmethod()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo')
+  v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo', 6)
 enddef
 
 " Test for an instance method access level comparison with parent instance
@@ -5099,7 +5099,7 @@ def Test_instance_method_access_level()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1377: Access level of method "_Foo" is different in class "A"')
+  v9.CheckSourceFailure(lines, 'E1377: Access level of method "_Foo" is different in class "A"', 11)
 
   # Public method in subclass
   lines =<< trim END
@@ -5115,7 +5115,7 @@ def Test_instance_method_access_level()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1377: Access level of method "Foo" is different in class "A"')
+  v9.CheckSourceFailure(lines, 'E1377: Access level of method "Foo" is different in class "A"', 11)
 enddef
 
 def Test_extend_empty_class()
@@ -5153,7 +5153,7 @@ def Test_interface_with_unsupported_members()
       static num: number
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface')
+  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -5161,7 +5161,7 @@ def Test_interface_with_unsupported_members()
       static _num: number
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface')
+  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -5169,7 +5169,7 @@ def Test_interface_with_unsupported_members()
       public static num: number
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1387: Public variable not supported in an interface')
+  v9.CheckSourceFailure(lines, 'E1387: Public variable not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -5177,7 +5177,7 @@ def Test_interface_with_unsupported_members()
       public static num: number
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1387: Public variable not supported in an interface')
+  v9.CheckSourceFailure(lines, 'E1387: Public variable not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -5185,7 +5185,7 @@ def Test_interface_with_unsupported_members()
       static _num: number
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface')
+  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -5193,7 +5193,7 @@ def Test_interface_with_unsupported_members()
       static def Foo(d: dict<any>): list<string>
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface')
+  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -5201,7 +5201,7 @@ def Test_interface_with_unsupported_members()
       static def _Foo(d: dict<any>): list<string>
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface')
+  v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -5209,7 +5209,7 @@ def Test_interface_with_unsupported_members()
       this._Foo: list<string>
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1379: Private variable not supported in an interface')
+  v9.CheckSourceFailure(lines, 'E1379: Private variable not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -5217,7 +5217,7 @@ def Test_interface_with_unsupported_members()
       def _Foo(d: dict<any>): list<string>
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1380: Private method not supported in an interface')
+  v9.CheckSourceFailure(lines, 'E1380: Private method not supported in an interface', 3)
 enddef
 
 " Test for extending an interface
@@ -5255,7 +5255,7 @@ def Test_extend_interface()
       this.var2 = {a: '1'}
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1349: Method "Foo" of interface "A" is not implemented')
+  v9.CheckSourceFailure(lines, 'E1349: Method "Foo" of interface "A" is not implemented', 10)
 
   lines =<< trim END
     vim9script
@@ -5270,7 +5270,7 @@ def Test_extend_interface()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1348: Variable "var2" of interface "B" is not implemented')
+  v9.CheckSourceFailure(lines, 'E1348: Variable "var2" of interface "B" is not implemented', 11)
 
   # interface cannot extend a class
   lines =<< trim END
@@ -5280,7 +5280,7 @@ def Test_extend_interface()
     interface B extends A
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1354: Cannot extend A')
+  v9.CheckSourceFailure(lines, 'E1354: Cannot extend A', 5)
 
   # class cannot extend an interface
   lines =<< trim END
@@ -5290,7 +5290,7 @@ def Test_extend_interface()
     class B extends A
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1354: Cannot extend A')
+  v9.CheckSourceFailure(lines, 'E1354: Cannot extend A', 5)
 
   # interface cannot implement another interface
   lines =<< trim END
@@ -5300,7 +5300,7 @@ def Test_extend_interface()
     interface B implements A
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1381: Interface cannot use "implements"')
+  v9.CheckSourceFailure(lines, 'E1381: Interface cannot use "implements"', 4)
 
   # interface cannot extend multiple interfaces
   lines =<< trim END
@@ -5312,7 +5312,7 @@ def Test_extend_interface()
     interface C extends A, B
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1315: White space required after name: A, B')
+  v9.CheckSourceFailure(lines, 'E1315: White space required after name: A, B', 6)
 
   # Variable type in an extended interface is of different type
   lines =<< trim END
@@ -5328,7 +5328,7 @@ def Test_extend_interface()
       this.val2: number
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1382: Variable "val1": type mismatch, expected number but got string')
+  v9.CheckSourceFailure(lines, 'E1382: Variable "val1": type mismatch, expected number but got string', 11)
 enddef
 
 " Test for a child class implementing an interface when some of the methods are
@@ -5425,7 +5425,7 @@ def Test_child_class_implements_interface()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1349: Method "F3" of interface "Intf" is not implemented')
+  v9.CheckSourceFailure(lines, 'E1349: Method "F3" of interface "Intf" is not implemented', 26)
 
   # One of the interface methods is of different type
   lines =<< trim END
@@ -5459,7 +5459,7 @@ def Test_child_class_implements_interface()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1383: Method "F3": type mismatch, expected func() but got func(): number')
+  v9.CheckSourceFailure(lines, 'E1383: Method "F3": type mismatch, expected func() but got func(): number', 29)
 
   # One of the interface variables is not present
   lines =<< trim END
@@ -5485,7 +5485,7 @@ def Test_child_class_implements_interface()
       this.var1 = [{a: 10}]
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1348: Variable "var3" of interface "Intf" is not implemented')
+  v9.CheckSourceFailure(lines, 'E1348: Variable "var3" of interface "Intf" is not implemented', 21)
 
   # One of the interface variables is of different type
   lines =<< trim END
@@ -5512,7 +5512,7 @@ def Test_child_class_implements_interface()
       this.var1 = [{a: 10}]
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1382: Variable "var3": type mismatch, expected list<dict<number>> but got list<dict<string>>')
+  v9.CheckSourceFailure(lines, 'E1382: Variable "var3": type mismatch, expected list<dict<number>> but got list<dict<string>>', 22)
 enddef
 
 " Test for extending an interface with duplicate variables and methods
@@ -5583,7 +5583,7 @@ def Test_implements_using_var_type_any()
     endclass
     var b = B.new()
   END
-  v9.CheckSourceFailure(lines, 'E1382: Variable "val": type mismatch, expected list<dict<string>> but got dict<number>')
+  v9.CheckSourceFailure(lines, 'E1382: Variable "val": type mismatch, expected list<dict<string>> but got dict<number>', 1)
 enddef
 
 " Test for assigning to a member variable in a nested class
@@ -5592,29 +5592,29 @@ def Test_nested_object_assignment()
     vim9script
 
     class A
-        this.value: number
+      this.value: number
     endclass
 
     class B
-        this.a: A = A.new()
+      this.a: A = A.new()
     endclass
 
     class C
-        this.b: B = B.new()
+      this.b: B = B.new()
     endclass
 
     class D
-        this.c: C = C.new()
+      this.c: C = C.new()
     endclass
 
     def T(da: D)
-        da.c.b.a.value = 10
+      da.c.b.a.value = 10
     enddef
 
     var d = D.new()
     T(d)
   END
-  v9.CheckSourceFailure(lines, 'E1335: Variable "value" in class "A" is not writable')
+  v9.CheckSourceFailure(lines, 'E1335: Variable "value" in class "A" is not writable', 1)
 enddef
 
 " Test for calling methods using a null object

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1549,7 +1549,7 @@ early_ret:
 	    }
 	    if (!is_class)
 	    {
-		emsg(_(e_public_member_not_supported_in_interface));
+		emsg(_(e_public_variable_not_supported_in_interface));
 		break;
 	    }
 	    has_public = TRUE;


### PR DESCRIPTION
 Include the entire error message in the tests.  Fix the indentation in the test file.  Add tags for new error codes and update help.