### PR TITLE
Apply termcap entries when 'keyprotocol' changes

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1945,8 +1945,12 @@ did_set_keymodel(optset_T *args UNUSED)
     char *
 did_set_keyprotocol(optset_T *args UNUSED)
 {
-    if (match_keyprotocol(NULL) == KEYPROTOCOL_FAIL)
+    char_u *term = T_NAME;
+    keyprot_T kpc = match_keyprotocol(term);
+    if (kpc == KEYPROTOCOL_FAIL)
 	return e_invalid_argument;
+
+    apply_keyprotocol(term, kpc);
 
     return NULL;
 }

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -5,6 +5,7 @@ void init_term_props(int all);
 void f_terminalprops(typval_T *argvars, typval_T *rettv);
 void set_color_count(int nr);
 keyprot_T match_keyprotocol(char_u *term);
+void apply_keyprotocol(char_u *term, keyprot_T prot);
 int set_termname(char_u *term);
 void free_cur_term(void);
 void getlinecol(long *cp, long *rp);

--- a/src/term.c
+++ b/src/term.c
@@ -1608,6 +1608,23 @@ apply_builtin_tcap(char_u *term, tcap_entry_T *entries, int overwrite)
 }
 
 /*
+ * Apply builtin termcap entries for a given keyprotocol.
+ */
+    void
+apply_keyprotocol(char_u *term, keyprot_T prot)
+{
+    if (prot == KEYPROTOCOL_KITTY)
+	apply_builtin_tcap(term, builtin_kitty, TRUE);
+    if (prot == KEYPROTOCOL_MOK2)
+	apply_builtin_tcap(term, builtin_mok2, TRUE);
+
+    if (prot != KEYPROTOCOL_NONE)
+	// Some function keys may accept modifiers even though the
+	// terminfo/termcap entry does not indicate this.
+	accept_modifiers_for_function_keys();
+}
+
+/*
  * Parsing of the builtin termcap entries.
  * Caller should check if "term" is a valid builtin terminal name.
  * The terminal's name is not set, as this is already done in termcapinit().
@@ -2083,10 +2100,7 @@ set_termname(char_u *term)
 	// Use the 'keyprotocol' option to adjust the t_TE and t_TI
 	// termcap entries if there is an entry matching "term".
 	keyprot_T kpc = match_keyprotocol(term);
-	if (kpc == KEYPROTOCOL_KITTY)
-	    apply_builtin_tcap(term, builtin_kitty, TRUE);
-	else if (kpc == KEYPROTOCOL_MOK2)
-	    apply_builtin_tcap(term, builtin_mok2, TRUE);
+	apply_keyprotocol(term, kpc);
 
 #ifdef FEAT_TERMGUICOLORS
 	// There is no good way to detect that the terminal supports RGB
@@ -2098,11 +2112,6 @@ set_termname(char_u *term)
 		&& term_strings_not_set(KS_8U))
 	    apply_builtin_tcap(term, builtin_rgb, TRUE);
 #endif
-
-	if (kpc != KEYPROTOCOL_NONE)
-	    // Some function keys may accept modifiers even though the
-	    // terminfo/termcap entry does not indicate this.
-	    accept_modifiers_for_function_keys();
     }
 
 /*

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1861,4 +1861,16 @@ func Test_binary_depending_options()
   call delete('Xoutput_bin')
 endfunc
 
+func Test_set_keyprotocol()
+  let term = &term
+  set term=ansi
+  call assert_equal('', &t_TI)
+
+  " Setting 'keyprotocol' should affect terminal codes without needing to
+  " reset 'term'
+  set keyprotocol+=ansi:kitty
+  call assert_equal("\<Esc>[=1;1u", &t_TI)
+  let &term = term
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When the 'keyprotocol' option was set after startup (including in a
user's .vimrc) the termcap entries associated with the matching protocol
were not applied. Thus, setting the option has no effect.

When 'keyprotocol' is changed it should also update the termcap entries.
