### PR TITLE
Fix: Object variable names can be used as formal arguments of methods other than constructors

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4483,6 +4483,7 @@ E1387	vim9class.txt	/*E1387*
 E1388	vim9class.txt	/*E1388*
 E1389	vim9class.txt	/*E1389*
 E139	message.txt	/*E139*
+E1390	vim9class.txt	/*E1390*
 E140	message.txt	/*E140*
 E1400	builtin.txt	/*E1400*
 E1401	builtin.txt	/*E1401*

--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -216,7 +216,8 @@ see this pattern: >
 	      this.col = col
 	   enddef
 	 endclass
-
+<
+							*E1390*
 Not only is this text you need to write, it also has the type of each
 variables twice.  Since this is so common a shorter way to write new() is
 provided: >

--- a/src/errors.h
+++ b/src/errors.h
@@ -3529,6 +3529,8 @@ EXTERN char e_public_keyword_not_supported_for_method[]
 	INIT(= N_("E1388: Public keyword not supported for a method"));
 EXTERN char e_missing_name_after_implements[]
 	INIT(= N_("E1389: Missing name after implements"));
+EXTERN char e_cannot_use_a_object_variable_except_with_the_new_method_str[]
+	INIT(= N_("E1390: Cannot use a object variable \"this.%s\" except with the \"new\" method"));
 #endif
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1400: Cannot mix positional and non-positional arguments: %s"));
@@ -3544,4 +3546,4 @@ EXTERN char e_invalid_format_specifier_str[]
 	INIT(= N_("E1405: Invalid format specifier: %s"));
 EXTERN char e_aptypes_is_null_nr_str[]
 	INIT(= "E1408: Internal error: ap_types or ap_types[idx] is NULL: %d: %s");
-// E1390 - E1399 unused
+// E1391 - E1399 unused

--- a/src/errors.h
+++ b/src/errors.h
@@ -3529,8 +3529,8 @@ EXTERN char e_public_keyword_not_supported_for_method[]
 	INIT(= N_("E1388: Public keyword not supported for a method"));
 EXTERN char e_missing_name_after_implements[]
 	INIT(= N_("E1389: Missing name after implements"));
-EXTERN char e_cannot_use_a_object_variable_except_with_the_new_method_str[]
-	INIT(= N_("E1390: Cannot use a object variable \"this.%s\" except with the \"new\" method"));
+EXTERN char e_cannot_use_an_object_variable_except_with_the_new_method_str[]
+	INIT(= N_("E1390: Cannot use an object variable \"this.%s\" except with the \"new\" method"));
 #endif
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1400: Cannot mix positional and non-positional arguments: %s"));

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -956,26 +956,15 @@ def Test_class_new_with_object_member()
   v9.CheckSourceFailure(lines, 'E1013:')
 
   lines =<< trim END
-      vim9script
+    vim9script
 
-      class C
-        this.str: string
-        def MethodA(this.str)
-        enddef
-      endclass
-
-      def Check()
-        try
-          var c = C.new()
-          c.MethodA('abc')
-        catch
-          assert_report($'Unexpected exception was caught: {v:exception}')
-        endtry
+    class C
+      this.str: string
+      def MethodA(this.str)
       enddef
-
-      Check()
+    endclass
   END
-  v9.CheckSourceFailure(lines, 'E1390:')
+  v9.CheckSourceFailure(lines, 'E1390: Cannot use an object variable "this.str" except with the "new" method')
 
   lines =<< trim END
       vim9script

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -960,6 +960,28 @@ def Test_class_new_with_object_member()
 
       class C
         this.str: string
+        def MethodA(this.str)
+        enddef
+      endclass
+
+      def Check()
+        try
+          var c = C.new()
+          c.MethodA('abc')
+        catch
+          assert_report($'Unexpected exception was caught: {v:exception}')
+        endtry
+      enddef
+
+      Check()
+  END
+  v9.CheckSourceFailure(lines, 'E1390:')
+
+  lines =<< trim END
+      vim9script
+
+      class C
+        this.str: string
         def new(str: any)
         enddef
       endclass

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -320,6 +320,16 @@ get_function_args(
 		++p;
 	    char_u *argend = p;
 
+	    // object variable can use constructor
+	    if (STRNCMP(eap->arg, "new", 3) != 0)
+	    {
+		c = *argend;
+		*argend = NUL;
+		semsg(_(e_cannot_use_a_object_variable_except_with_the_new_method_str), arg);
+		*argend = c;
+		break;
+	    }
+
 	    if (*skipwhite(p) == '=')
 	    {
 		char_u *defval = skipwhite(skipwhite(p) + 1);

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -320,12 +320,12 @@ get_function_args(
 		++p;
 	    char_u *argend = p;
 
-	    // object variable can use constructor
+	    // object variable this. can be used only in a constructor
 	    if (STRNCMP(eap->arg, "new", 3) != 0)
 	    {
 		c = *argend;
 		*argend = NUL;
-		semsg(_(e_cannot_use_a_object_variable_except_with_the_new_method_str), arg);
+		semsg(_(e_cannot_use_an_object_variable_except_with_the_new_method_str), arg);
 		*argend = c;
 		break;
 	    }


### PR DESCRIPTION
Close: #13152 