### PR TITLE
Scrolling inactive window is inconsistent when 'cursorbind' is set

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3570,6 +3570,14 @@ halfpage(int flag, linenr_T Prenum)
     void
 do_check_cursorbind(void)
 {
+    static win_T	*prev_curwin = NULL;
+    static pos_T	prev_cursor = {0, 0, 0};
+
+    if (curwin == prev_curwin && EQUAL_POS(curwin->w_cursor, prev_cursor))
+	return;
+    prev_curwin = curwin;
+    prev_cursor = curwin->w_cursor;
+
     linenr_T	line = curwin->w_cursor.lnum;
     colnr_T	col = curwin->w_cursor.col;
     colnr_T	coladd = curwin->w_cursor.coladd;

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1,4 +1,4 @@
-" Test for reset 'scroll' and 'smoothscroll'
+" Test for 'scroll', 'scrolloff', 'smoothscroll', etc.
 
 source check.vim
 source screendump.vim
@@ -39,20 +39,74 @@ func Test_reset_scroll()
 endfunc
 
 func Test_scolloff_even_line_count()
-   new
-   resize 6
-   setlocal scrolloff=3
-   call setline(1, range(20))
-   normal 2j
-   call assert_equal(1, getwininfo(win_getid())[0].topline)
-   normal j
-   call assert_equal(1, getwininfo(win_getid())[0].topline)
-   normal j
-   call assert_equal(2, getwininfo(win_getid())[0].topline)
-   normal j
-   call assert_equal(3, getwininfo(win_getid())[0].topline)
+  new
+  resize 6
+  setlocal scrolloff=3
+  call setline(1, range(20))
+  normal 2j
+  call assert_equal(1, getwininfo(win_getid())[0].topline)
+  normal j
+  call assert_equal(1, getwininfo(win_getid())[0].topline)
+  normal j
+  call assert_equal(2, getwininfo(win_getid())[0].topline)
+  normal j
+  call assert_equal(3, getwininfo(win_getid())[0].topline)
 
-   bwipe!
+  bwipe!
+endfunc
+
+func Test_mouse_scroll_inactive_with_cursorbind()
+  for scb in [0, 1]
+    for so in [0, 1, 2]
+      let msg = $'scb={scb} so={so}'
+
+      new | only
+      let w1 = win_getid()
+      setlocal cursorbind
+      let &l:scb = scb
+      let &l:so = so
+      call setline(1, range(101, 109))
+      rightbelow vnew
+      let w2 = win_getid()
+      setlocal cursorbind
+      let &l:scb = scb
+      let &l:so = so
+      call setline(1, range(101, 109))
+
+      normal! $
+      call assert_equal(3, col('.', w1), msg)
+      call assert_equal(3, col('.', w2), msg)
+      call test_setmouse(1, 1)
+      call feedkeys("\<ScrollWheelDown>", 'xt')
+      call assert_equal(4, line('w0', w1), msg)
+      call assert_equal(4 + so, line('.', w1), msg)
+      call assert_equal(1, line('w0', w2), msg)
+      call assert_equal(1, line('.', w2), msg)
+      call feedkeys("\<ScrollWheelDown>", 'xt')
+      call assert_equal(7, line('w0', w1), msg)
+      call assert_equal(7 + so, line('.', w1), msg)
+      call assert_equal(1, line('w0', w2), msg)
+      call assert_equal(1, line('.', w2), msg)
+      call feedkeys("\<ScrollWheelUp>", 'xt')
+      call assert_equal(4, line('w0', w1), msg)
+      call assert_equal(7 + so, line('.', w1), msg)
+      call assert_equal(1, line('w0', w2), msg)
+      call assert_equal(1, line('.', w2), msg)
+      call feedkeys("\<ScrollWheelUp>", 'xt')
+      call assert_equal(1, line('w0', w1), msg)
+      call assert_equal(7 + so, line('.', w1), msg)
+      call assert_equal(1, line('w0', w2), msg)
+      call assert_equal(1, line('.', w2), msg)
+      normal! 0
+      call assert_equal(1, line('.', w1), msg)
+      call assert_equal(1, col('.', w1), msg)
+      call assert_equal(1, line('.', w2), msg)
+      call assert_equal(1, col('.', w2), msg)
+
+      bwipe!
+      bwipe!
+    endfor
+  endfor
 endfunc
 
 func Test_CtrlE_CtrlY_stop_at_end()


### PR DESCRIPTION
Problem:  Scrolling non-current window using mouse is inconsistent
          depending on 'scrollbind'/'scrolloff' and different from GUI
          vertical scrollbar when 'cursorbind' is set.
Solution: Don't move cursor in non-current windows for 'cursorbind' if
          cursor in the current window didn't move.

Fix #13210.
I'm not sure if this behavior make most sense, but I think this is the
least hacky solution.