### PR TITLE
Add -Wstrict-prototypes -Wmissing-prototypes warnings check to CI

### DIFF
--- a/ci/config.mk.sed
+++ b/ci/config.mk.sed
@@ -1,3 +1,3 @@
-/^CFLAGS[[:blank:]]*=/s/$/ -Wall -Wextra -Wshadow -Werror -Wno-deprecated-declarations/
+/^CFLAGS[[:blank:]]*=/s/$/ -Wall -Wextra -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Werror -Wno-deprecated-declarations/
 /^PERL_CFLAGS_EXTRA[[:blank:]]*=/s/$/ -Wno-error=unused-function -Wno-shadow/
-/^RUBY_CFLAGS_EXTRA[[:blank:]]*=/s/$/ -Wno-error=unused-parameter/
+/^RUBY_CFLAGS_EXTRA[[:blank:]]*=/s/$/ -Wno-error=unused-parameter -Wno-strict-prototypes/

--- a/src/gui.h
+++ b/src/gui.h
@@ -22,7 +22,10 @@
 #  include "gui_gtk_vms.h"
 # endif // VMS
 # include <X11/Intrinsic.h>
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wstrict-prototypes"
 # include <gtk/gtk.h>
+# pragma GCC diagnostic pop
 #endif
 
 #ifdef FEAT_GUI_HAIKU

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -338,7 +338,7 @@ typedef int perl_key;
  */
 static HANDLE hPerlLib = NULL;
 
-static PerlInterpreter* (*perl_alloc)();
+static PerlInterpreter* (*perl_alloc)(void);
 static void (*perl_construct)(PerlInterpreter*);
 static void (*perl_destruct)(PerlInterpreter*);
 static void (*perl_free)(PerlInterpreter*);

--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -105,7 +105,7 @@ struct typeobject_wrapper {
 # define Py_TYPE_GET_TP_METHODS(type) ((PyMethodDef *)PyType_GetSlot(type, Py_tp_methods))
 
 // PyObject_NEW is not part of stable ABI, but PyObject_Malloc/Init are.
-PyObject* Vim_PyObject_New(PyTypeObject *type, size_t objsize)
+static PyObject* Vim_PyObject_New(PyTypeObject *type, size_t objsize)
 {
     PyObject *obj = (PyObject *)PyObject_Malloc(objsize);
     if (obj == NULL)
@@ -168,7 +168,7 @@ PyObject* Vim_PyObject_New(PyTypeObject *type, size_t objsize)
 #  define PyIter_Check(obj) (FALSE)
 # endif
 
-PyTypeObject* AddHeapType(struct typeobject_wrapper* type_object)
+static PyTypeObject* AddHeapType(struct typeobject_wrapper* type_object)
 {
     PyType_Spec type_spec;
     type_spec.name = type_object->tp_name;
@@ -254,7 +254,7 @@ PyTypeObject* AddHeapType(struct typeobject_wrapper* type_object)
 
 // Limited API does not provide PyRun_* functions. Need to implement manually
 // using PyCompile and PyEval.
-PyObject* Vim_PyRun_String(const char *str, int start, PyObject *globals, PyObject *locals)
+static PyObject* Vim_PyRun_String(const char *str, int start, PyObject *globals, PyObject *locals)
 {
     // Just pass "" for filename for now.
     PyObject* compiled = Py_CompileString(str, "", start);
@@ -265,7 +265,7 @@ PyObject* Vim_PyRun_String(const char *str, int start, PyObject *globals, PyObje
     Py_DECREF(compiled);
     return eval_result;
 }
-int Vim_PyRun_SimpleString(const char *str)
+static int Vim_PyRun_SimpleString(const char *str)
 {
     // This function emulates CPython's implementation.
     PyObject* m = PyImport_AddModule("__main__");

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -395,8 +395,8 @@ static int (*py3_PyObject_SetAttrString)(PyObject *, const char *, PyObject *);
 static PyObject* (*py3_PyObject_CallFunctionObjArgs)(PyObject *, ...);
 static PyObject* (*py3__PyObject_CallFunction_SizeT)(PyObject *, char *, ...);
 static PyObject* (*py3_PyObject_Call)(PyObject *, PyObject *, PyObject *);
-static PyObject* (*py3_PyEval_GetGlobals)();
-static PyObject* (*py3_PyEval_GetLocals)();
+static PyObject* (*py3_PyEval_GetGlobals)(void);
+static PyObject* (*py3_PyEval_GetLocals)(void);
 static PyObject* (*py3_PyList_GetItem)(PyObject *, Py_ssize_t);
 static PyObject* (*py3_PyImport_ImportModule)(const char *);
 static PyObject* (*py3_PyImport_AddModule)(const char *);
@@ -1061,7 +1061,7 @@ static struct PyModuleDef vimmodule;
 // An alternative would be to convert all attribute string comparisons to use
 // PyUnicode_CompareWithASCIIString to skip having to extract the chars.
 static char py3_unicode_utf8_chars[20];
-char* PY_UNICODE_GET_UTF8_CHARS(PyObject* str)
+static char* PY_UNICODE_GET_UTF8_CHARS(PyObject* str)
 {
     py3_unicode_utf8_chars[0] = '\0';
     PyObject* bytes = PyUnicode_AsUTF8String(str);

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -180,7 +180,7 @@ typedef int HANDLE;
  * Declare HANDLE for tcl.dll and function pointers.
  */
 static HANDLE hTclLib = NULL;
-Tcl_Interp* (*dll_Tcl_CreateInterp)();
+Tcl_Interp* (*dll_Tcl_CreateInterp)(void);
 void (*dll_Tcl_FindExecutable)(const void *);
 
 /*

--- a/src/option.c
+++ b/src/option.c
@@ -7518,7 +7518,7 @@ set_context_in_set_cmd(
  * If 'test_only' is FALSE and 'fuzzy' is TRUE and if 'str' fuzzy matches
  * 'fuzzystr', then stores the match details in fuzmatch[idx] and returns TRUE.
  */
-    int
+    static int
 match_str(
 	char_u		*str,
 	regmatch_T	*regmatch,
@@ -8014,7 +8014,7 @@ ExpandSettingSubtract(
 	    // character as individual choice.
 	    for (char_u *flag = option_val; *flag != NUL; flag++)
 	    {
-		char_u *p = vim_strnsave(flag, 1);
+		p = vim_strnsave(flag, 1);
 		if (p == NULL)
 		    break;
 		(*matches)[count++] = p;

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -733,7 +733,7 @@ did_set_option_listflag(char_u *val, char_u *flags, char *errbuf)
 /*
  * Expand an option that accepts a list of string values.
  */
-    int
+    static int
 expand_set_opt_string(
 	optexpand_T *args,
 	char **values,
@@ -819,7 +819,7 @@ expand_set_opt_callback(expand_T *xp, int idx)
 /*
  * Expand an option with a callback that iterates through a list of possible names.
  */
-    int
+    static int
 expand_set_opt_generic(
 	optexpand_T *args,
 	char_u *((*func)(expand_T *, int)),
@@ -850,7 +850,7 @@ expand_set_opt_generic(
 /*
  * Expand an option which is a list of flags.
  */
-    int
+    static int
 expand_set_opt_listflag(
 	optexpand_T *args,
 	char_u *flags,


### PR DESCRIPTION
Add two new warnings to CI:

- `strict-prototypes` helps prevent declaring a function with an empty argument list, e.g. `int func()`. In C++, that's equivalent to `int func(void)`, but in C, that means a function that can take any number of arguments which is rarely what we want.

- `missing-prototypes` makes sure we use `static` for file-only internal functions. Non-static functions should have been declared on a prototype file.

Also, fix up misc code warnings that this found.

GTK header needs to have #pragma warning suppressiong because GTK2 headers will warn on `-Wstrict-prototypes`, and it's included by gui.h and so we can't just turn off the warning in a couple files.