### PR TITLE
Harden crypto 'key' option: turn off cmdline completion, disable set-=

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4928,6 +4928,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"echo &key".  This is to avoid showing it to someone who shouldn't
 	know.  It also means you cannot see it yourself once you have set it,
 	be careful not to make a typing error!
+	You also cannot use |:set-=|, |:set+=|, |:set^=| on this option to
+	prevent an attacker from guessing substrings in your key.
 	You can use "&key" in an expression to detect whether encryption is
 	enabled.  When 'key' is set it returns "*****" (five stars).
 

--- a/src/option.c
+++ b/src/option.c
@@ -1315,13 +1315,6 @@ ex_set(exarg_T *eap)
  * :set operator types
  */
 typedef enum {
-    OP_NONE = 0,
-    OP_ADDING,		// "opt+=arg"
-    OP_PREPENDING,	// "opt^=arg"
-    OP_REMOVING,	// "opt-=arg"
-} set_op_T;
-
-typedef enum {
     PREFIX_NO = 0,	// "no" prefix
     PREFIX_NONE,	// no prefix
     PREFIX_INV,		// "inv" prefix
@@ -1935,7 +1928,7 @@ do_set_option_string(
 	char_u	    **argp,
 	int	    nextchar,
 	set_op_T    op_arg,
-	int	    flags,
+	long_u	    flags,
 	int	    cp_val,
 	char_u	    *varp_arg,
 	char	    *errbuf,
@@ -2037,7 +2030,7 @@ do_set_option_string(
 	// be triggered that can cause havoc.
 	*errmsg = did_set_string_option(
 			opt_idx, (char_u **)varp, oldval, newval, errbuf,
-			opt_flags, value_checked);
+			opt_flags, op, value_checked);
 
 	secure = secure_saved;
     }
@@ -7802,6 +7795,10 @@ ExpandOldSetting(int *numMatches, char_u ***matches)
     char_u  *var = NULL;	// init for GCC
     char_u  *buf;
 
+    if (expand_option_idx >= 0 &&
+	    (options[expand_option_idx].flags & P_NO_CMD_EXPAND))
+	return FAIL;
+
     *numMatches = 0;
     *matches = ALLOC_MULT(char_u *, 1);
     if (*matches == NULL)
@@ -7897,6 +7894,10 @@ ExpandSettingSubtract(
     if (expand_option_idx < 0)
 	// term option
 	return ExpandOldSetting(numMatches, matches);
+
+    if (expand_option_idx >= 0 &&
+	    (options[expand_option_idx].flags & P_NO_CMD_EXPAND))
+	return FAIL;
 
     char_u *option_val = *(char_u**)get_option_varp_scope(
 	expand_option_idx, expand_option_flags);

--- a/src/option.c
+++ b/src/option.c
@@ -7369,6 +7369,15 @@ set_context_in_set_cmd(
     else
 	expand_option_idx = opt_idx;
 
+    if (!is_term_option)
+    {
+	if (options[opt_idx].flags & P_NO_CMD_EXPAND)
+	{
+	    xp->xp_context=EXPAND_UNSUCCESSFUL;
+	    return;
+	}
+    }
+
     xp->xp_pattern = p + 1;
     expand_option_start_col = (int)(p + 1 - xp->xp_line);
 
@@ -7795,10 +7804,6 @@ ExpandOldSetting(int *numMatches, char_u ***matches)
     char_u  *var = NULL;	// init for GCC
     char_u  *buf;
 
-    if (expand_option_idx >= 0 &&
-	    (options[expand_option_idx].flags & P_NO_CMD_EXPAND))
-	return FAIL;
-
     *numMatches = 0;
     *matches = ALLOC_MULT(char_u *, 1);
     if (*matches == NULL)
@@ -7894,10 +7899,6 @@ ExpandSettingSubtract(
     if (expand_option_idx < 0)
 	// term option
 	return ExpandOldSetting(numMatches, matches);
-
-    if (expand_option_idx >= 0 &&
-	    (options[expand_option_idx].flags & P_NO_CMD_EXPAND))
-	return FAIL;
 
     char_u *option_val = *(char_u**)get_option_varp_scope(
 	expand_option_idx, expand_option_flags);

--- a/src/option.h
+++ b/src/option.h
@@ -25,6 +25,7 @@
 				// the same.
 #define P_EXPAND	0x10	// environment expansion.  NOTE: P_EXPAND can
 				// never be used for local or hidden options!
+#define P_NO_CMD_EXPAND	0x20	// don't perform cmdline completions
 #define P_NODEFAULT	0x40	// don't set to default value
 #define P_DEF_ALLOCED	0x80	// default value is in allocated memory, must
 				//  use vim_free() when assigning new value
@@ -61,7 +62,10 @@
 #define P_MLE	     0x20000000L // under control of 'modelineexpr'
 #define P_FUNC	     0x40000000L // accept a function reference or a lambda
 #define P_COLON	     0x80000000L // values use colons to create sublists
-#define P_NO_CMD_EXPAND	0x100000000L // don't perform cmdline completions
+// Warning: Currently we have used all 32 bits for option flags. On some 32-bit
+//          systems, the flags are stored as a 32-bit integer, and adding more
+//          flags will overflow it. Adding another flag will need to change how
+//          it's stored first.
 
 // Returned by get_option_value().
 typedef enum {

--- a/src/option.h
+++ b/src/option.h
@@ -61,6 +61,7 @@
 #define P_MLE	     0x20000000L // under control of 'modelineexpr'
 #define P_FUNC	     0x40000000L // accept a function reference or a lambda
 #define P_COLON	     0x80000000L // values use colons to create sublists
+#define P_NO_CMD_EXPAND	0x100000000L // don't perform cmdline completions
 
 // Returned by get_option_value().
 typedef enum {

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1467,7 +1467,7 @@ static struct vimoption options[] =
     {"jumpoptions", "jop",  P_STRING|P_VI_DEF|P_VIM|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_jop, PV_NONE, did_set_jumpoptions, expand_set_jumpoptions,
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
-    {"key",	    NULL,   P_STRING|P_ALLOCED|P_VI_DEF|P_NO_MKRC,
+    {"key",	    NULL,   P_STRING|P_ALLOCED|P_VI_DEF|P_NO_MKRC|P_NO_CMD_EXPAND,
 #ifdef FEAT_CRYPT
 			    (char_u *)&p_key, PV_KEY, did_set_cryptkey, NULL,
 			    {(char_u *)"", (char_u *)0L}

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -121,7 +121,7 @@ char *did_set_wildmode(optset_T *args);
 char *did_set_wildoptions(optset_T *args);
 char *did_set_winaltkeys(optset_T *args);
 char *did_set_wincolor(optset_T *args);
-char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char_u *value, char *errbuf, int opt_flags, int *value_checked);
+char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char_u *value, char *errbuf, int opt_flags, set_op_T op, int *value_checked);
 int expand_set_ambiwidth(optexpand_T *args, int *numMatches, char_u ***matches);
 int expand_set_background(optexpand_T *args, int *numMatches, char_u ***matches);
 int expand_set_backspace(optexpand_T *args, int *numMatches, char_u ***matches);

--- a/src/structs.h
+++ b/src/structs.h
@@ -588,6 +588,13 @@ typedef enum {
     XP_PREFIX_INV,	// "inv" prefix for bool option
 } xp_prefix_T;
 
+typedef enum {
+    OP_NONE = 0,
+    OP_ADDING,		// "opt+=arg"
+    OP_PREPENDING,	// "opt^=arg"
+    OP_REMOVING,	// "opt-=arg"
+} set_op_T;
+
 /*
  * used for completion on the command line
  */
@@ -4876,6 +4883,7 @@ typedef struct
     char_u	*os_varp;
     int		os_idx;
     int		os_flags;
+    set_op_T	os_op;
 
     // old value of the option (can be a string, number or a boolean)
     union

--- a/src/testdir/test_crypt.vim
+++ b/src/testdir/test_crypt.vim
@@ -438,4 +438,27 @@ func Test_crypt_set_key_segfault()
   bwipe!
 endfunc
 
+func Test_crypt_set_key_disallow_append_subtract()
+  new Xtest4
+
+  set key=foobar
+  call assert_true(&modified)
+  setl nomodified
+
+  call assert_fails('set key-=foo', 'E474:')
+  call assert_fails('set key-=bar', 'E474:')
+  call assert_fails('set key-=foobar', 'E474:')
+  call assert_fails('set key-=test1', 'E474:')
+
+  call assert_false(&modified)
+  call assert_equal('*****', &key)
+
+  call assert_fails('set key+=test2', 'E474:')
+  call assert_fails('set key^=test3', 'E474:')
+
+  call assert_false(&modified)
+  set key=
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_history.vim
+++ b/src/testdir/test_history.vim
@@ -244,8 +244,13 @@ endfunc
 " Test for making sure the key value is not stored in history
 func Test_history_crypt_key()
   CheckFeature cryptv
+
   call feedkeys(":set bs=2 key=abc ts=8\<CR>", 'xt')
   call assert_equal('set bs=2 key= ts=8', histget(':'))
+
+  call assert_fails("call feedkeys(':set bs=2 key-=abc ts=8\<CR>', 'xt')")
+  call assert_equal('set bs=2 key-= ts=8', histget(':'))
+
   set key& bs& ts&
 endfunc
 

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -365,13 +365,15 @@ func Test_set_completion()
   call feedkeys(":set spellsuggest=best,file:test_options.v\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"set spellsuggest=best,file:test_options.vim", @:)
 
-  " Expand value for 'key'
-  set key=abcd
-  call feedkeys(":set key=\<Tab>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"set key=*****', @:)
-  call feedkeys(":set key-=\<Tab>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"set key-=*****', @:)
-  set key=
+  " Expanding value for 'key' is disallowed
+  if exists('+key')
+    set key=abcd
+    call feedkeys(":set key=\<Tab>\<C-B>\"\<CR>", 'xt')
+    call assert_equal('"set key=', @:)
+    call feedkeys(":set key-=\<Tab>\<C-B>\"\<CR>", 'xt')
+    call assert_equal('"set key-=', @:)
+    set key=
+  endif
 
   " Expand values for 'filetype'
   call feedkeys(":set filetype=sshdconfi\<Tab>\<C-B>\"\<CR>", 'xt')


### PR DESCRIPTION
"set-=" can be used maliciously with a crypto key, as it allows an attacker (who either has access to the computer or a plugin author) to guess a substring by observing the modified state. Simply turn off set+=/-=/^= for this option as there is no good reason for them to be used.

Update docs to make that clear as well.

Also, don't allow cmdline completion for 'key' as it just shows ***** which is not useful and confusing to the user what it means (if the user accidentally hits enter they will have replaced their key with "*****" instead).