### PR TITLE
'listchars' completion doesn't include "multispace" and "leadmultispace"

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4693,6 +4693,8 @@ static struct charstab lcstab[] =
 #else
     {NULL,			"conceal"},
 #endif
+    {NULL,			"multispace"},
+    {NULL,			"leadmultispace"},
 };
 
 /*
@@ -4706,7 +4708,7 @@ static struct charstab lcstab[] =
     static char *
 set_chars_option(win_T *wp, char_u *value, int is_listchars, int apply)
 {
-    int	    round, i, len, len2, entries;
+    int	    round, i, len, entries;
     char_u  *p, *s;
     int	    c1 = 0, c2 = 0, c3 = 0;
     char_u  *last_multispace = NULL;  // Last occurrence of "multispace:"
@@ -4784,58 +4786,12 @@ set_chars_option(win_T *wp, char_u *value, int is_listchars, int apply)
 	    for (i = 0; i < entries; ++i)
 	    {
 		len = (int)STRLEN(tab[i].name);
-		if (STRNCMP(p, tab[i].name, len) == 0
+		if (!(STRNCMP(p, tab[i].name, len) == 0
 			&& p[len] == ':'
-			&& p[len + 1] != NUL)
-		{
-		    c2 = c3 = 0;
-		    s = p + len + 1;
-		    c1 = get_encoded_char_adv(&s);
-		    if (char2cells(c1) > 1)
-			return e_invalid_argument;
-		    if (tab[i].cp == &lcs_chars.tab2)
-		    {
-			if (*s == NUL)
-			    return e_invalid_argument;
-			c2 = get_encoded_char_adv(&s);
-			if (char2cells(c2) > 1)
-			    return e_invalid_argument;
-			if (!(*s == ',' || *s == NUL))
-			{
-			    c3 = get_encoded_char_adv(&s);
-			    if (char2cells(c3) > 1)
-				return e_invalid_argument;
-			}
-		    }
+			&& p[len + 1] != NUL))
+		    continue;
 
-		    if (*s == ',' || *s == NUL)
-		    {
-			if (round > 0)
-			{
-			    if (tab[i].cp == &lcs_chars.tab2)
-			    {
-				lcs_chars.tab1 = c1;
-				lcs_chars.tab2 = c2;
-				lcs_chars.tab3 = c3;
-			    }
-			    else if (tab[i].cp != NULL)
-				*(tab[i].cp) = c1;
-
-			}
-			p = s;
-			break;
-		    }
-		}
-	    }
-
-	    if (i == entries)
-	    {
-		len = (int)STRLEN("multispace");
-		len2 = (int)STRLEN("leadmultispace");
-		if (is_listchars
-			&& STRNCMP(p, "multispace", len) == 0
-			&& p[len] == ':'
-			&& p[len + 1] != NUL)
+		if (is_listchars && strcmp(tab[i].name, "multispace") == 0)
 		{
 		    s = p + len + 1;
 		    if (round == 0)
@@ -4867,14 +4823,12 @@ set_chars_option(win_T *wp, char_u *value, int is_listchars, int apply)
 			}
 			p = s;
 		    }
+		    break;
 		}
 
-		else if (is_listchars
-			&& STRNCMP(p, "leadmultispace", len2) == 0
-			&& p[len2] == ':'
-			&& p[len2 + 1] != NUL)
+		if (is_listchars && strcmp(tab[i].name, "leadmultispace") == 0)
 		{
-		    s = p + len2 + 1;
+		    s = p + len + 1;
 		    if (round == 0)
 		    {
 			// get length of lcs-leadmultispace string in first
@@ -4905,10 +4859,50 @@ set_chars_option(win_T *wp, char_u *value, int is_listchars, int apply)
 			}
 			p = s;
 		    }
+		    break;
 		}
-		else
+
+		c2 = c3 = 0;
+		s = p + len + 1;
+		c1 = get_encoded_char_adv(&s);
+		if (char2cells(c1) > 1)
 		    return e_invalid_argument;
+		if (tab[i].cp == &lcs_chars.tab2)
+		{
+		    if (*s == NUL)
+			return e_invalid_argument;
+		    c2 = get_encoded_char_adv(&s);
+		    if (char2cells(c2) > 1)
+			return e_invalid_argument;
+		    if (!(*s == ',' || *s == NUL))
+		    {
+			c3 = get_encoded_char_adv(&s);
+			if (char2cells(c3) > 1)
+			    return e_invalid_argument;
+		    }
+		}
+
+		if (*s == ',' || *s == NUL)
+		{
+		    if (round > 0)
+		    {
+			if (tab[i].cp == &lcs_chars.tab2)
+			{
+			    lcs_chars.tab1 = c1;
+			    lcs_chars.tab2 = c2;
+			    lcs_chars.tab3 = c3;
+			}
+			else if (tab[i].cp != NULL)
+			    *(tab[i].cp) = c1;
+
+		    }
+		    p = s;
+		    break;
+		}
 	    }
+
+	    if (i == entries)
+		return e_invalid_argument;
 
 	    if (*p == ',')
 		++p;

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -517,10 +517,12 @@ func Test_set_completion_string_values()
   call assert_equal(getcompletion('set printoptions=', 'cmdline')[0], 'top')
   call assert_equal(getcompletion('set wincolor=', 'cmdline')[0], 'SpecialKey')
 
-  call assert_equal(getcompletion('set listchars+=', 'cmdline')[0], 'eol')
-  call assert_equal(getcompletion('setl listchars+=', 'cmdline')[0], 'eol')
-  call assert_equal(getcompletion('set fillchars+=', 'cmdline')[0], 'stl')
-  call assert_equal(getcompletion('setl fillchars+=', 'cmdline')[0], 'stl')
+  call assert_equal('eol', getcompletion('set listchars+=', 'cmdline')[0])
+  call assert_equal(['multispace', 'leadmultispace'], getcompletion('set listchars+=', 'cmdline')[-2:])
+  call assert_equal('eol', getcompletion('setl listchars+=', 'cmdline')[0])
+  call assert_equal(['multispace', 'leadmultispace'], getcompletion('setl listchars+=', 'cmdline')[-2:])
+  call assert_equal('stl', getcompletion('set fillchars+=', 'cmdline')[0])
+  call assert_equal('stl', getcompletion('setl fillchars+=', 'cmdline')[0])
 
   "
   " Unique string options below


### PR DESCRIPTION
Problem:  Cmdline completion for 'listchars' fields doesn't include
          "multispace" and "leadmultispace".
Solution: Include "multispace" and "leadmultispace" in lcstab.
