### PR TITLE
Check for xattr may fail

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -5279,7 +5279,7 @@ else
 printf "%s\n" "yes" >&6; }
 fi
 if test "$enable_smack" = "yes"; then
-  ac_fn_c_check_header_compile "$LINENO" "attr/xattr.h" "ac_cv_header_attr_xattr_h" "$ac_includes_default"
+  ac_fn_c_check_header_compile "$LINENO" "sys/xattr.h" "ac_cv_header_attr_xattr_h" "$ac_includes_default"
 if test "x$ac_cv_header_attr_xattr_h" = xyes
 then :
   true
@@ -5434,7 +5434,7 @@ fi
 if test "$enable_xattr" = "yes"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-  ac_fn_c_check_header_compile "$LINENO" "attr/xattr.h" "ac_cv_header_attr_xattr_h" "$ac_includes_default"
+  ac_fn_c_check_header_compile "$LINENO" "sys/xattr.h" "ac_cv_header_attr_xattr_h" "$ac_includes_default"
 if test "x$ac_cv_header_attr_xattr_h" = xyes
 then :
   printf "%s\n" "#define HAVE_XATTR 1" >>confdefs.h

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -480,7 +480,7 @@ else
   AC_MSG_RESULT(yes)
 fi
 if test "$enable_smack" = "yes"; then
-  AC_CHECK_HEADER([attr/xattr.h], true, enable_smack="no")
+  AC_CHECK_HEADER([sys/xattr.h], true, enable_smack="no")
 fi
 if test "$enable_smack" = "yes"; then
   AC_MSG_CHECKING(for XATTR_NAME_SMACKEXEC in linux/xattr.h)
@@ -520,7 +520,7 @@ AC_ARG_ENABLE(xattr,
 	, enable_xattr="yes")
 if test "$enable_xattr" = "yes"; then
   AC_MSG_RESULT(yes)
-  AC_CHECK_HEADER([attr/xattr.h], [AC_DEFINE(HAVE_XATTR)])
+  AC_CHECK_HEADER([sys/xattr.h], [AC_DEFINE(HAVE_XATTR)])
 else
   AC_MSG_RESULT(no)
 fi

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -36,12 +36,12 @@ static int selinux_enabled = -1;
 #endif
 
 #ifdef FEAT_XATTR
-# include <attr/xattr.h>
+# include <sys/xattr.h>
 # define XATTR_VAL_LEN 1024
 #endif
 
 #ifdef HAVE_SMACK
-# include <attr/xattr.h>
+# include <sys/xattr.h>
 # include <linux/xattr.h>
 # ifndef SMACK_LABEL_LEN
 #  define SMACK_LABEL_LEN 1024

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -979,6 +979,7 @@ endfunc
 
 func Test_write_with_xattr_support()
   CheckLinux
+  CheckFeature xattr
   CheckExecutable setfattr
 
   let contents = ["file with xattrs", "line two"]


### PR DESCRIPTION
Problem:  Check for xattr may fail.
Solution: Check for "sys/xattr.h" instead of "attr/xattr.h".

Fix #13227
