### PR TITLE
macos: --disable-xattr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,7 @@ jobs:
 
       - name: Configure
         run: |
-          ./configure --with-features=${{ matrix.features }} ${CONFOPT} --enable-fail-if-missing
+          ./configure --with-features=${{ matrix.features }} ${CONFOPT} --enable-fail-if-missing --disable-xattr
           # Append various warning flags to CFLAGS.
           # BSD sed needs backup extension specified.
           sed -i.bak -f ci/config.mk.sed ${SRCDIR}/auto/config.mk


### PR DESCRIPTION
As in (Linux only)  [patch 9.0.1962](https://github.com/vim/vim/commit/e085dfda5d8dde064b0332464040959479696d1c) we can disable the check on macOS
Follow-up: https://github.com/vim/vim/pull/13229