### PR TITLE
compile fails on MacOS X because of different xattr headers

### DIFF
--- a/src/feature.h
+++ b/src/feature.h
@@ -1177,9 +1177,9 @@
 #endif
 
 /*
- * XATTR support
+ * currently Unix only: XATTR support
  */
 
-#if defined(FEAT_NORMAL) && defined(HAVE_XATTR)
+#if defined(FEAT_NORMAL) && defined(HAVE_XATTR) && !defined(MACOS_X)
 # define FEAT_XATTR
 #endif


### PR DESCRIPTION
undef FEAT_XATTR for MacOS X