### PR TITLE
configure: sys/xattr.hs: Regenerate with autoconf 2.71

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -5279,8 +5279,8 @@ else
 printf "%s\n" "yes" >&6; }
 fi
 if test "$enable_smack" = "yes"; then
-  ac_fn_c_check_header_compile "$LINENO" "sys/xattr.h" "ac_cv_header_attr_xattr_h" "$ac_includes_default"
-if test "x$ac_cv_header_attr_xattr_h" = xyes
+  ac_fn_c_check_header_compile "$LINENO" "sys/xattr.h" "ac_cv_header_sys_xattr_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_xattr_h" = xyes
 then :
   true
 else $as_nop
@@ -5434,8 +5434,8 @@ fi
 if test "$enable_xattr" = "yes"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-  ac_fn_c_check_header_compile "$LINENO" "sys/xattr.h" "ac_cv_header_attr_xattr_h" "$ac_includes_default"
-if test "x$ac_cv_header_attr_xattr_h" = xyes
+  ac_fn_c_check_header_compile "$LINENO" "sys/xattr.h" "ac_cv_header_sys_xattr_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_xattr_h" = xyes
 then :
   printf "%s\n" "#define HAVE_XATTR 1" >>confdefs.h
 
@@ -5445,7 +5445,6 @@ else
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
 fi
-
 
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --with-features argument" >&5


### PR DESCRIPTION
It seems that `auto/configure` update in

  commit 6de4e58cf27a3bb6e81653ca63b77e29d1bb46f2 (tag: v9.0.1963)
  Author: zeertzjq <zeertzjq@outlook.com>
  Date:   Sat Sep 30 14:19:14 2023 +0200

      patch 9.0.1963: Configure script may not detect xattr

      Problem:  Configure script may not detect xattr correctly
      Solution: include sys/xattr instead of attr/xattr,
                make Test_write_with_xattr_support() test
                xattr feature correctly

      This also applies to the Smack security feature, so change the include
      and configure script for it as well.

      closes: #13229

      Signed-off-by: Christian Brabandt <cb@256bit.org>
      Co-authored-by: zeertzjq <zeertzjq@outlook.com>

was done manually, and missed an update to the generated variable name.