### PR TITLE
Clean up cmdline option tab-completion code

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -7989,7 +7989,7 @@ ExpandSettingSubtract(
 	    return FAIL;
 	}
 
-	int num_flags = STRLEN(option_val);
+	size_t num_flags = STRLEN(option_val);
 	if (num_flags == 0)
 	    return FAIL;
 

--- a/src/option.c
+++ b/src/option.c
@@ -1837,7 +1837,7 @@ stropt_get_newval(
 					     &(options[opt_idx]), OPT_GLOBAL));
     else
     {
-	++arg;	// joption_value2stringump to after the '=' or ':'
+	++arg;	// jump to after the '=' or ':'
 
 	// Set 'keywordprg' to ":help" if an empty
 	// value was passed to :set by the user.

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -737,7 +737,7 @@ did_set_option_listflag(char_u *val, char_u *flags, char *errbuf)
 expand_set_opt_string(
 	optexpand_T *args,
 	char **values,
-	int numValues,
+	size_t numValues,
 	int *numMatches,
 	char_u ***matches)
 {
@@ -863,7 +863,7 @@ expand_set_opt_listflag(
     int	    append = args->oe_append;
     int	    include_orig_val = args->oe_include_orig_val && (*option_val != NUL);
 
-    int num_flags = STRLEN(flags);
+    size_t num_flags = STRLEN(flags);
 
     // Assume we only have small number of flags, so just allocate max size.
     *matches = ALLOC_MULT(char_u *, num_flags + 1);
@@ -1765,7 +1765,7 @@ expand_set_diffopt(optexpand_T *args, int *numMatches, char_u ***matches)
     if (xp->xp_pattern > args->oe_set_arg && *(xp->xp_pattern-1) == ':')
     {
 	// Within "algorithm:", we have a subgroup of possible options.
-	int algo_len = STRLEN("algorithm:");
+	int algo_len = (int)STRLEN("algorithm:");
 	if (xp->xp_pattern - args->oe_set_arg >= algo_len &&
 		STRNCMP(xp->xp_pattern - algo_len, "algorithm:", algo_len) == 0)
 	{
@@ -2377,7 +2377,7 @@ expand_set_highlight(optexpand_T *args, int *numMatches, char_u ***matches)
     char_u	    *p;
     expand_T	    *xp = args->oe_xp;
     static char_u   hl_flags[HLF_COUNT] = HL_FLAGS;
-    int		    i;
+    size_t	    i;
     int		    count = 0;
 
     if (xp->xp_pattern > args->oe_set_arg && *(xp->xp_pattern-1) == ':')
@@ -2442,15 +2442,15 @@ expand_set_highlight(optexpand_T *args, int *numMatches, char_u ***matches)
     // the returned match.
 
     // Note: Keep this in sync with highlight_changed()
-    static char p_hl_mode_values[] =
+    static char_u p_hl_mode_values[] =
 	{':', 'b', 'i', '-', 'n', 'r', 's', 'u', 'c', '2', 'd', '=', 't'};
-    int num_hl_modes = ARRAY_LENGTH(p_hl_mode_values);
+    size_t num_hl_modes = ARRAY_LENGTH(p_hl_mode_values);
 
     *matches = ALLOC_MULT(char_u *, num_hl_modes);
     if (*matches == NULL)
 	return FAIL;
 
-    int pattern_len = STRLEN(xp->xp_pattern);
+    size_t pattern_len = STRLEN(xp->xp_pattern);
 
     for (i = 0; i < num_hl_modes; i++)
     {
@@ -2936,7 +2936,7 @@ expand_set_popupoption(optexpand_T *args, int *numMatches, char_u ***matches)
     if (xp->xp_pattern > args->oe_set_arg && *(xp->xp_pattern-1) == ':')
     {
 	// Within "highlight:"/"border:"/"align:", we have a subgroup of possible options.
-	int border_len = STRLEN("border:");
+	int border_len = (int)STRLEN("border:");
 	if (xp->xp_pattern - args->oe_set_arg >= border_len &&
 		STRNCMP(xp->xp_pattern - border_len, "border:", border_len) == 0)
 	{
@@ -2947,7 +2947,7 @@ expand_set_popupoption(optexpand_T *args, int *numMatches, char_u ***matches)
 		    numMatches,
 		    matches);
 	}
-	int align_len = STRLEN("align:");
+	int align_len = (int)STRLEN("align:");
 	if (xp->xp_pattern - args->oe_set_arg >= align_len &&
 		STRNCMP(xp->xp_pattern - align_len, "align:", align_len) == 0)
 	{
@@ -2958,7 +2958,7 @@ expand_set_popupoption(optexpand_T *args, int *numMatches, char_u ***matches)
 		    numMatches,
 		    matches);
 	}
-	int highlight_len = STRLEN("highlight:");
+	int highlight_len = (int)STRLEN("highlight:");
 	if (xp->xp_pattern - args->oe_set_arg >= highlight_len &&
 		STRNCMP(xp->xp_pattern - highlight_len, "highlight:", highlight_len) == 0)
 	{

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -940,7 +940,7 @@ expand_set_ambiwidth(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_ambw_values,
-	    sizeof(p_ambw_values) / sizeof(p_ambw_values[0]) - 1,
+	    ARRAY_LENGTH(p_ambw_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -987,7 +987,7 @@ expand_set_background(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_bg_values,
-	    sizeof(p_bg_values) / sizeof(p_bg_values[0]) - 1,
+	    ARRAY_LENGTH(p_bg_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1015,7 +1015,7 @@ expand_set_backspace(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_bs_values,
-	    sizeof(p_bs_values) / sizeof(p_bs_values[0]) - 1,
+	    ARRAY_LENGTH(p_bs_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1063,7 +1063,7 @@ expand_set_backupcopy(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_bkc_values,
-	    sizeof(p_bkc_values) / sizeof(p_bkc_values[0]) - 1,
+	    ARRAY_LENGTH(p_bkc_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1096,7 +1096,7 @@ expand_set_belloff(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_bo_values,
-	    sizeof(p_bo_values) / sizeof(p_bo_values[0]) - 1,
+	    ARRAY_LENGTH(p_bo_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1125,7 +1125,7 @@ expand_set_breakindentopt(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_briopt_values,
-	    sizeof(p_briopt_values) / sizeof(p_briopt_values[0]) - 1,
+	    ARRAY_LENGTH(p_briopt_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1151,7 +1151,7 @@ expand_set_browsedir(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_bsdir_values,
-	    sizeof(p_bsdir_values) / sizeof(p_bsdir_values[0]) - 1,
+	    ARRAY_LENGTH(p_bsdir_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1172,7 +1172,7 @@ expand_set_bufhidden(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_bufhidden_values,
-	    sizeof(p_bufhidden_values) / sizeof(p_bufhidden_values[0]) - 1,
+	    ARRAY_LENGTH(p_bufhidden_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1203,7 +1203,7 @@ expand_set_buftype(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_buftype_values,
-	    sizeof(p_buftype_values) / sizeof(p_buftype_values[0]) - 1,
+	    ARRAY_LENGTH(p_buftype_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1223,7 +1223,7 @@ expand_set_casemap(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_cmp_values,
-	    sizeof(p_cmp_values) / sizeof(p_cmp_values[0]) - 1,
+	    ARRAY_LENGTH(p_cmp_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1235,7 +1235,7 @@ expand_set_clipboard(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_cb_values,
-	    sizeof(p_cb_values) / sizeof(p_cb_values[0]) - 1,
+	    ARRAY_LENGTH(p_cb_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1461,7 +1461,7 @@ expand_set_complete(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_cpt_values,
-	    sizeof(p_cpt_values) / sizeof(p_cpt_values[0]) - 1,
+	    ARRAY_LENGTH(p_cpt_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1485,7 +1485,7 @@ expand_set_completeopt(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_cot_values,
-	    sizeof(p_cot_values) / sizeof(p_cot_values[0]) - 1,
+	    ARRAY_LENGTH(p_cot_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1525,7 +1525,7 @@ expand_set_completeslash(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_csl_values,
-	    sizeof(p_csl_values) / sizeof(p_csl_values[0]) - 1,
+	    ARRAY_LENGTH(p_csl_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1660,7 +1660,7 @@ expand_set_cryptmethod(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_cm_values,
-	    sizeof(p_cm_values) / sizeof(p_cm_values[0]) - 1,
+	    ARRAY_LENGTH(p_cm_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1718,7 +1718,7 @@ expand_set_cursorlineopt(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_culopt_values,
-	    sizeof(p_culopt_values) / sizeof(p_culopt_values[0]) - 1,
+	    ARRAY_LENGTH(p_culopt_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1739,7 +1739,7 @@ expand_set_debug(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_debug_values,
-	    sizeof(p_debug_values) / sizeof(p_debug_values[0]) - 1,
+	    ARRAY_LENGTH(p_debug_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1772,7 +1772,7 @@ expand_set_diffopt(optexpand_T *args, int *numMatches, char_u ***matches)
 	    return expand_set_opt_string(
 		    args,
 		    p_dip_algorithm_values,
-		    sizeof(p_dip_algorithm_values) / sizeof(p_dip_algorithm_values[0]) - 1,
+		    ARRAY_LENGTH(p_dip_algorithm_values) - 1,
 		    numMatches,
 		    matches);
 	}
@@ -1782,7 +1782,7 @@ expand_set_diffopt(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_dip_values,
-	    sizeof(p_dip_values) / sizeof(p_dip_values[0]) - 1,
+	    ARRAY_LENGTH(p_dip_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1807,7 +1807,7 @@ expand_set_display(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_dy_values,
-	    sizeof(p_dy_values) / sizeof(p_dy_values[0]) - 1,
+	    ARRAY_LENGTH(p_dy_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -1827,7 +1827,7 @@ expand_set_eadirection(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_ead_values,
-	    sizeof(p_ead_values) / sizeof(p_ead_values[0]) - 1,
+	    ARRAY_LENGTH(p_ead_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2001,7 +2001,7 @@ expand_set_fileformat(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_ff_values,
-	    sizeof(p_ff_values) / sizeof(p_ff_values[0]) - 1,
+	    ARRAY_LENGTH(p_ff_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2060,7 +2060,7 @@ expand_set_foldclose(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_fcl_values,
-	    sizeof(p_fcl_values) / sizeof(p_fcl_values[0]) - 1,
+	    ARRAY_LENGTH(p_fcl_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2136,7 +2136,7 @@ expand_set_foldmethod(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_fdm_values,
-	    sizeof(p_fdm_values) / sizeof(p_fdm_values[0]) - 1,
+	    ARRAY_LENGTH(p_fdm_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2156,7 +2156,7 @@ expand_set_foldopen(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_fdo_values,
-	    sizeof(p_fdo_values) / sizeof(p_fdo_values[0]) - 1,
+	    ARRAY_LENGTH(p_fdo_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2444,7 +2444,7 @@ expand_set_highlight(optexpand_T *args, int *numMatches, char_u ***matches)
     // Note: Keep this in sync with highlight_changed()
     static char p_hl_mode_values[] =
 	{':', 'b', 'i', '-', 'n', 'r', 's', 'u', 'c', '2', 'd', '=', 't'};
-    int num_hl_modes = sizeof(p_hl_mode_values) / sizeof(p_hl_mode_values[0]);
+    int num_hl_modes = ARRAY_LENGTH(p_hl_mode_values);
 
     *matches = ALLOC_MULT(char_u *, num_hl_modes);
     if (*matches == NULL)
@@ -2572,7 +2572,7 @@ expand_set_jumpoptions(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_jop_values,
-	    sizeof(p_jop_values) / sizeof(p_jop_values[0]) - 1,
+	    ARRAY_LENGTH(p_jop_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2656,7 +2656,7 @@ expand_set_keymodel(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_km_values,
-	    sizeof(p_km_values) / sizeof(p_km_values[0]) - 1,
+	    ARRAY_LENGTH(p_km_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2688,7 +2688,7 @@ expand_set_keyprotocol(optexpand_T *args, int *numMatches, char_u ***matches)
 	return expand_set_opt_string(
 		args,
 		p_kpc_protocol_values,
-		sizeof(p_kpc_protocol_values) / sizeof(p_kpc_protocol_values[0]) - 1,
+		ARRAY_LENGTH(p_kpc_protocol_values) - 1,
 		numMatches,
 		matches);
     }
@@ -2721,7 +2721,7 @@ expand_set_lispoptions(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_lop_values,
-	    sizeof(p_lop_values) / sizeof(p_lop_values[0]) - 1,
+	    ARRAY_LENGTH(p_lop_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2827,7 +2827,7 @@ expand_set_mousemodel(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_mousem_values,
-	    sizeof(p_mousem_values) / sizeof(p_mousem_values[0]) - 1,
+	    ARRAY_LENGTH(p_mousem_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2862,7 +2862,7 @@ expand_set_nrformats(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_nf_values,
-	    sizeof(p_nf_values) / sizeof(p_nf_values[0]) - 1,
+	    ARRAY_LENGTH(p_nf_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -2943,7 +2943,7 @@ expand_set_popupoption(optexpand_T *args, int *numMatches, char_u ***matches)
 	    return expand_set_opt_string(
 		    args,
 		    p_popup_option_border_values,
-		    sizeof(p_popup_option_border_values) / sizeof(p_popup_option_border_values[0]) - 1,
+		    ARRAY_LENGTH(p_popup_option_border_values) - 1,
 		    numMatches,
 		    matches);
 	}
@@ -2954,7 +2954,7 @@ expand_set_popupoption(optexpand_T *args, int *numMatches, char_u ***matches)
 	    return expand_set_opt_string(
 		    args,
 		    p_popup_option_align_values,
-		    sizeof(p_popup_option_align_values) / sizeof(p_popup_option_align_values[0]) - 1,
+		    ARRAY_LENGTH(p_popup_option_align_values) - 1,
 		    numMatches,
 		    matches);
 	}
@@ -2975,7 +2975,7 @@ expand_set_popupoption(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_popup_option_values,
-	    sizeof(p_popup_option_values) / sizeof(p_popup_option_values[0]) - 1,
+	    ARRAY_LENGTH(p_popup_option_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3018,7 +3018,7 @@ did_set_printencoding(optset_T *args UNUSED)
     static char_u *
 get_printoptions_names(expand_T *xp UNUSED, int idx)
 {
-    if (idx >= (int)(sizeof(printer_opts) / sizeof(printer_opts[0])))
+    if (idx >= (int)ARRAY_LENGTH(printer_opts))
 	return NULL;
     return (char_u*)printer_opts[idx].name;
 }
@@ -3111,7 +3111,7 @@ expand_set_rightleftcmd(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_rlc_values,
-	    sizeof(p_rlc_values) / sizeof(p_rlc_values[0]) - 1,
+	    ARRAY_LENGTH(p_rlc_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3143,7 +3143,7 @@ expand_set_scrollopt(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_scbopt_values,
-	    sizeof(p_scbopt_values) / sizeof(p_scbopt_values[0]) - 1,
+	    ARRAY_LENGTH(p_scbopt_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3166,7 +3166,7 @@ expand_set_selection(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_sel_values,
-	    sizeof(p_sel_values) / sizeof(p_sel_values[0]) - 1,
+	    ARRAY_LENGTH(p_sel_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3186,7 +3186,7 @@ expand_set_selectmode(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_slm_values,
-	    sizeof(p_slm_values) / sizeof(p_slm_values[0]) - 1,
+	    ARRAY_LENGTH(p_slm_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3217,7 +3217,7 @@ expand_set_sessionoptions(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_ssop_values,
-	    sizeof(p_ssop_values) / sizeof(p_ssop_values[0]) - 1,
+	    ARRAY_LENGTH(p_ssop_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3276,7 +3276,7 @@ expand_set_showcmdloc(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_sloc_values,
-	    sizeof(p_sloc_values) / sizeof(p_sloc_values[0]) - 1,
+	    ARRAY_LENGTH(p_sloc_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3308,7 +3308,7 @@ expand_set_signcolumn(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_scl_values,
-	    sizeof(p_scl_values) / sizeof(p_scl_values[0]) - 1,
+	    ARRAY_LENGTH(p_scl_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3378,7 +3378,7 @@ expand_set_spelloptions(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_spo_values,
-	    sizeof(p_spo_values) / sizeof(p_spo_values[0]) - 1,
+	    ARRAY_LENGTH(p_spo_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3401,7 +3401,7 @@ expand_set_spellsuggest(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_sps_values,
-	    sizeof(p_sps_values) / sizeof(p_sps_values[0]) - 1,
+	    ARRAY_LENGTH(p_sps_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3422,7 +3422,7 @@ expand_set_splitkeep(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_spk_values,
-	    sizeof(p_spk_values) / sizeof(p_spk_values[0]) - 1,
+	    ARRAY_LENGTH(p_spk_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3453,7 +3453,7 @@ expand_set_swapsync(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_sws_values,
-	    sizeof(p_sws_values) / sizeof(p_sws_values[0]) - 1,
+	    ARRAY_LENGTH(p_sws_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3473,7 +3473,7 @@ expand_set_switchbuf(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_swb_values,
-	    sizeof(p_swb_values) / sizeof(p_swb_values[0]) - 1,
+	    ARRAY_LENGTH(p_swb_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3525,7 +3525,7 @@ expand_set_tagcase(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_tc_values,
-	    sizeof(p_tc_values) / sizeof(p_tc_values[0]) - 1,
+	    ARRAY_LENGTH(p_tc_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3670,7 +3670,7 @@ expand_set_termwintype(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_twt_values,
-	    sizeof(p_twt_values) / sizeof(p_twt_values[0]) - 1,
+	    ARRAY_LENGTH(p_twt_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3714,7 +3714,7 @@ expand_set_toolbar(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_toolbar_values,
-	    sizeof(p_toolbar_values) / sizeof(p_toolbar_values[0]) - 1,
+	    ARRAY_LENGTH(p_toolbar_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3742,7 +3742,7 @@ expand_set_toolbariconsize(optexpand_T *args, int *numMatches, char_u ***matches
     return expand_set_opt_string(
 	    args,
 	    p_tbis_values,
-	    sizeof(p_tbis_values) / sizeof(p_tbis_values[0]) - 1,
+	    ARRAY_LENGTH(p_tbis_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3776,7 +3776,7 @@ expand_set_ttymouse(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_ttym_values,
-	    sizeof(p_ttym_values) / sizeof(p_ttym_values[0]) - 1,
+	    ARRAY_LENGTH(p_ttym_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -3992,7 +3992,7 @@ expand_set_virtualedit(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_ve_values,
-	    sizeof(p_ve_values) / sizeof(p_ve_values[0]) - 1,
+	    ARRAY_LENGTH(p_ve_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -4033,7 +4033,7 @@ expand_set_wildmode(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_wim_values,
-	    sizeof(p_wim_values) / sizeof(p_wim_values[0]) - 1,
+	    ARRAY_LENGTH(p_wim_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -4053,7 +4053,7 @@ expand_set_wildoptions(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_wop_values,
-	    sizeof(p_wop_values) / sizeof(p_wop_values[0]) - 1,
+	    ARRAY_LENGTH(p_wop_values) - 1,
 	    numMatches,
 	    matches);
 }
@@ -4087,7 +4087,7 @@ expand_set_winaltkeys(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_string(
 	    args,
 	    p_wak_values,
-	    sizeof(p_wak_values) / sizeof(p_wak_values[0]) - 1,
+	    ARRAY_LENGTH(p_wak_values) - 1,
 	    numMatches,
 	    matches);
 }

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -392,130 +392,130 @@ func Test_set_completion_string_values()
   " Test basic enum string options that have well-defined enum names
   "
 
-  call assert_equal(getcompletion('set display=', 'cmdline'), ['lastline', 'truncate', 'uhex'])
-  call assert_equal(getcompletion('set display=t', 'cmdline'), ['truncate'])
-  call assert_equal(getcompletion('set display=*ex*', 'cmdline'), ['uhex'])
+  call assert_equal(['lastline', 'truncate', 'uhex'], getcompletion('set display=', 'cmdline'))
+  call assert_equal(['truncate'], getcompletion('set display=t', 'cmdline'))
+  call assert_equal(['uhex'], getcompletion('set display=*ex*', 'cmdline'))
 
   " Test that if a value is set, it will populate the results, but only if
   " typed value is empty.
   set display=uhex,lastline
-  call assert_equal(getcompletion('set display=', 'cmdline'), ['uhex,lastline', 'lastline', 'truncate', 'uhex'])
-  call assert_equal(getcompletion('set display=u', 'cmdline'), ['uhex'])
+  call assert_equal(['uhex,lastline', 'lastline', 'truncate', 'uhex'], getcompletion('set display=', 'cmdline'))
+  call assert_equal(['uhex'], getcompletion('set display=u', 'cmdline'))
   " If the set value is part of the enum list, it will show as the first
   " result with no duplicate.
   set display=uhex
-  call assert_equal(getcompletion('set display=', 'cmdline'), ['uhex', 'lastline', 'truncate'])
+  call assert_equal(['uhex', 'lastline', 'truncate'], getcompletion('set display=', 'cmdline'))
   " If empty value, will just show the normal list without an empty item
   set display=
-  call assert_equal(getcompletion('set display=', 'cmdline'), ['lastline', 'truncate', 'uhex'])
+  call assert_equal(['lastline', 'truncate', 'uhex'], getcompletion('set display=', 'cmdline'))
   " Test escaping of the values
-  call assert_equal(getcompletion('set fillchars=', 'cmdline')[0], 'vert:\|,fold:-,eob:~,lastline:@')
+  call assert_equal('vert:\|,fold:-,eob:~,lastline:@', getcompletion('set fillchars=', 'cmdline')[0])
 
   " Test comma-separated lists will expand after a comma.
-  call assert_equal(getcompletion('set display=truncate,*ex*', 'cmdline'), ['uhex'])
+  call assert_equal(['uhex'], getcompletion('set display=truncate,*ex*', 'cmdline'))
   " Also test the positioning of the expansion is correct
   call feedkeys(":set display=truncate,l\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set display=truncate,lastline', @:)
   set display&
 
   " Test single-value options will not expand after a comma
-  call assert_equal(getcompletion('set ambw=single,', 'cmdline'), [])
+  call assert_equal([], getcompletion('set ambw=single,', 'cmdline'))
 
   " Test the other simple options to make sure they have basic auto-complete,
   " but don't exhaustively validate their results.
-  call assert_equal(getcompletion('set ambw=', 'cmdline')[0], 'single')
+  call assert_equal('single', getcompletion('set ambw=', 'cmdline')[0])
   call assert_match('light\|dark', getcompletion('set bg=', 'cmdline')[1])
-  call assert_equal(getcompletion('set backspace=', 'cmdline')[0], 'indent')
-  call assert_equal(getcompletion('set backupcopy=', 'cmdline')[1], 'yes')
-  call assert_equal(getcompletion('set belloff=', 'cmdline')[1], 'backspace')
-  call assert_equal(getcompletion('set briopt=', 'cmdline')[1], 'min:')
+  call assert_equal('indent', getcompletion('set backspace=', 'cmdline')[0])
+  call assert_equal('yes', getcompletion('set backupcopy=', 'cmdline')[1])
+  call assert_equal('backspace', getcompletion('set belloff=', 'cmdline')[1])
+  call assert_equal('min:', getcompletion('set briopt=', 'cmdline')[1])
   if exists('+browsedir')
-    call assert_equal(getcompletion('set browsedir=', 'cmdline')[1], 'current')
+    call assert_equal('current', getcompletion('set browsedir=', 'cmdline')[1])
   endif
-  call assert_equal(getcompletion('set bufhidden=', 'cmdline')[1], 'unload')
-  call assert_equal(getcompletion('set buftype=', 'cmdline')[1], 'nowrite')
-  call assert_equal(getcompletion('set casemap=', 'cmdline')[1], 'internal')
+  call assert_equal('unload', getcompletion('set bufhidden=', 'cmdline')[1])
+  call assert_equal('nowrite', getcompletion('set buftype=', 'cmdline')[1])
+  call assert_equal('internal', getcompletion('set casemap=', 'cmdline')[1])
   if exists('+clipboard')
     call assert_match('unnamed', getcompletion('set clipboard=', 'cmdline')[1])
   endif
-  call assert_equal(getcompletion('set complete=', 'cmdline')[1], '.')
-  call assert_equal(getcompletion('set completeopt=', 'cmdline')[1], 'menu')
+  call assert_equal('.', getcompletion('set complete=', 'cmdline')[1])
+  call assert_equal('menu', getcompletion('set completeopt=', 'cmdline')[1])
   if exists('+completeslash')
-    call assert_equal(getcompletion('set completeslash=', 'cmdline')[1], 'backslash')
+    call assert_equal('backslash', getcompletion('set completeslash=', 'cmdline')[1])
   endif
   if exists('+cryptmethod')
-    call assert_equal(getcompletion('set cryptmethod=', 'cmdline')[1], 'zip')
+    call assert_equal('zip', getcompletion('set cryptmethod=', 'cmdline')[1])
   endif
   if exists('+cursorlineopt')
-    call assert_equal(getcompletion('set cursorlineopt=', 'cmdline')[1], 'line')
+    call assert_equal('line', getcompletion('set cursorlineopt=', 'cmdline')[1])
   endif
-  call assert_equal(getcompletion('set debug=', 'cmdline')[1], 'throw')
-  call assert_equal(getcompletion('set eadirection=', 'cmdline')[1], 'ver')
-  call assert_equal(getcompletion('set fileformat=', 'cmdline')[2], 'mac')
+  call assert_equal('throw', getcompletion('set debug=', 'cmdline')[1])
+  call assert_equal('ver', getcompletion('set eadirection=', 'cmdline')[1])
+  call assert_equal('mac', getcompletion('set fileformat=', 'cmdline')[2])
   if exists('+foldclose')
-    call assert_equal(getcompletion('set foldclose=', 'cmdline')[0], 'all')
+    call assert_equal('all', getcompletion('set foldclose=', 'cmdline')[0])
   endif
   if exists('+foldmethod')
-    call assert_equal(getcompletion('set foldmethod=', 'cmdline')[1], 'expr')
+    call assert_equal('expr', getcompletion('set foldmethod=', 'cmdline')[1])
   endif
   if exists('+foldopen')
-    call assert_equal(getcompletion('set foldopen=', 'cmdline')[1], 'all')
+    call assert_equal('all', getcompletion('set foldopen=', 'cmdline')[1])
   endif
-  call assert_equal(getcompletion('set jumpoptions=', 'cmdline')[0], 'stack')
-  call assert_equal(getcompletion('set keymodel=', 'cmdline')[1], 'stopsel')
-  call assert_equal(getcompletion('set lispoptions=', 'cmdline')[1], 'expr:1')
+  call assert_equal('stack', getcompletion('set jumpoptions=', 'cmdline')[0])
+  call assert_equal('stopsel', getcompletion('set keymodel=', 'cmdline')[1])
+  call assert_equal('expr:1', getcompletion('set lispoptions=', 'cmdline')[1])
   call assert_match('popup', getcompletion('set mousemodel=', 'cmdline')[2])
-  call assert_equal(getcompletion('set nrformats=', 'cmdline')[1], 'bin')
+  call assert_equal('bin', getcompletion('set nrformats=', 'cmdline')[1])
   if exists('+rightleftcmd')
-    call assert_equal(getcompletion('set rightleftcmd=', 'cmdline')[0], 'search')
+    call assert_equal('search', getcompletion('set rightleftcmd=', 'cmdline')[0])
   endif
-  call assert_equal(getcompletion('set scrollopt=', 'cmdline')[1], 'ver')
-  call assert_equal(getcompletion('set selection=', 'cmdline')[1], 'exclusive')
-  call assert_equal(getcompletion('set selectmode=', 'cmdline')[1], 'key')
+  call assert_equal('ver', getcompletion('set scrollopt=', 'cmdline')[1])
+  call assert_equal('exclusive', getcompletion('set selection=', 'cmdline')[1])
+  call assert_equal('key', getcompletion('set selectmode=', 'cmdline')[1])
   if exists('+ssop')
-    call assert_equal(getcompletion('set ssop=', 'cmdline')[1], 'buffers')
+    call assert_equal('buffers', getcompletion('set ssop=', 'cmdline')[1])
   endif
-  call assert_equal(getcompletion('set showcmdloc=', 'cmdline')[1], 'statusline')
+  call assert_equal('statusline', getcompletion('set showcmdloc=', 'cmdline')[1])
   if exists('+signcolumn')
-    call assert_equal(getcompletion('set signcolumn=', 'cmdline')[1], 'yes')
+    call assert_equal('yes', getcompletion('set signcolumn=', 'cmdline')[1])
   endif
   if exists('+spelloptions')
-    call assert_equal(getcompletion('set spelloptions=', 'cmdline')[0], 'camel')
+    call assert_equal('camel', getcompletion('set spelloptions=', 'cmdline')[0])
   endif
   if exists('+spellsuggest')
-    call assert_equal(getcompletion('set spellsuggest+=', 'cmdline')[0], 'best')
+    call assert_equal('best', getcompletion('set spellsuggest+=', 'cmdline')[0])
   endif
-  call assert_equal(getcompletion('set splitkeep=', 'cmdline')[1], 'screen')
-  call assert_equal(getcompletion('set swapsync=', 'cmdline')[1], 'sync')
-  call assert_equal(getcompletion('set switchbuf=', 'cmdline')[1], 'usetab')
-  call assert_equal(getcompletion('set tagcase=', 'cmdline')[1], 'ignore')
+  call assert_equal('screen', getcompletion('set splitkeep=', 'cmdline')[1])
+  call assert_equal('sync', getcompletion('set swapsync=', 'cmdline')[1])
+  call assert_equal('usetab', getcompletion('set switchbuf=', 'cmdline')[1])
+  call assert_equal('ignore', getcompletion('set tagcase=', 'cmdline')[1])
   if exists('+termwintype')
-    call assert_equal(getcompletion('set termwintype=', 'cmdline')[1], 'conpty')
+    call assert_equal('conpty', getcompletion('set termwintype=', 'cmdline')[1])
   endif
   if exists('+toolbar')
-    call assert_equal(getcompletion('set toolbar=', 'cmdline')[1], 'text')
+    call assert_equal('text', getcompletion('set toolbar=', 'cmdline')[1])
   endif
   if exists('+tbis')
-    call assert_equal(getcompletion('set tbis=', 'cmdline')[2], 'medium')
+    call assert_equal('medium', getcompletion('set tbis=', 'cmdline')[2])
   endif
   if exists('+ttymouse')
     set ttymouse=
-    call assert_equal(getcompletion('set ttymouse=', 'cmdline')[1], 'xterm2')
+    call assert_equal('xterm2', getcompletion('set ttymouse=', 'cmdline')[1])
     set ttymouse&
   endif
-  call assert_equal(getcompletion('set virtualedit=', 'cmdline')[1], 'insert')
-  call assert_equal(getcompletion('set wildmode=', 'cmdline')[1], 'longest')
-  call assert_equal(getcompletion('set wildmode=list,longest:', 'cmdline')[0], 'full')
-  call assert_equal(getcompletion('set wildoptions=', 'cmdline')[1], 'tagfile')
+  call assert_equal('insert', getcompletion('set virtualedit=', 'cmdline')[1])
+  call assert_equal('longest', getcompletion('set wildmode=', 'cmdline')[1])
+  call assert_equal('full', getcompletion('set wildmode=list,longest:', 'cmdline')[0])
+  call assert_equal('tagfile', getcompletion('set wildoptions=', 'cmdline')[1])
   if exists('+winaltkeys')
-    call assert_equal(getcompletion('set winaltkeys=', 'cmdline')[1], 'yes')
+    call assert_equal('yes', getcompletion('set winaltkeys=', 'cmdline')[1])
   endif
 
   " Other string options that queries the system rather than fixed enum names
-  call assert_equal(getcompletion('set eventignore=', 'cmdline')[0:1], ['all', 'BufAdd'])
-  call assert_equal(getcompletion('set fileencodings=', 'cmdline')[1], 'latin1')
-  call assert_equal(getcompletion('set printoptions=', 'cmdline')[0], 'top')
-  call assert_equal(getcompletion('set wincolor=', 'cmdline')[0], 'SpecialKey')
+  call assert_equal(['all', 'BufAdd'], getcompletion('set eventignore=', 'cmdline')[0:1])
+  call assert_equal('latin1', getcompletion('set fileencodings=', 'cmdline')[1])
+  call assert_equal('top', getcompletion('set printoptions=', 'cmdline')[0])
+  call assert_equal('SpecialKey', getcompletion('set wincolor=', 'cmdline')[0])
 
   call assert_equal('eol', getcompletion('set listchars+=', 'cmdline')[0])
   call assert_equal(['multispace', 'leadmultispace'], getcompletion('set listchars+=', 'cmdline')[-2:])
@@ -529,33 +529,33 @@ func Test_set_completion_string_values()
   "
 
   " keyprotocol: only auto-complete when after ':' with known protocol types
-  call assert_equal(getcompletion('set keyprotocol=', 'cmdline'), [&keyprotocol])
+  call assert_equal([&keyprotocol], getcompletion('set keyprotocol=', 'cmdline'))
   call feedkeys(":set keyprotocol+=someterm:m\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set keyprotocol+=someterm:mok2', @:)
   set keyprotocol&
 
   " previewpopup / completepopup
-  call assert_equal(getcompletion('set previewpopup=', 'cmdline')[0], 'height:')
-  call assert_equal(getcompletion('set previewpopup=highlight:End*Buffer', 'cmdline')[0], 'EndOfBuffer')
+  call assert_equal('height:', getcompletion('set previewpopup=', 'cmdline')[0])
+  call assert_equal('EndOfBuffer', getcompletion('set previewpopup=highlight:End*Buffer', 'cmdline')[0])
   call feedkeys(":set previewpopup+=border:\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set previewpopup+=border:on', @:)
   call feedkeys(":set completepopup=height:10,align:\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set completepopup=height:10,align:item', @:)
-  call assert_equal(getcompletion('set completepopup=bogusname:', 'cmdline'), [])
+  call assert_equal([], getcompletion('set completepopup=bogusname:', 'cmdline'))
   set previewpopup& completepopup&
 
   " diffopt: special handling of algorithm:<alg_list>
-  call assert_equal(getcompletion('set diffopt+=', 'cmdline')[0], 'filler')
-  call assert_equal(getcompletion('set diffopt+=iblank,foldcolumn:', 'cmdline'), [])
-  call assert_equal(getcompletion('set diffopt+=iblank,algorithm:pat*', 'cmdline')[0], 'patience')
+  call assert_equal('filler', getcompletion('set diffopt+=', 'cmdline')[0])
+  call assert_equal([], getcompletion('set diffopt+=iblank,foldcolumn:', 'cmdline'))
+  call assert_equal('patience', getcompletion('set diffopt+=iblank,algorithm:pat*', 'cmdline')[0])
 
   " highlight: special parsing, including auto-completing highlight groups
   " after ':'
-  call assert_equal(getcompletion('set hl=', 'cmdline')[0:1], [&hl, '8'])
-  call assert_equal(getcompletion('set hl+=', 'cmdline')[0], '8')
-  call assert_equal(getcompletion('set hl+=8', 'cmdline')[0:2], ['8:', '8b', '8i'])
-  call assert_equal(getcompletion('set hl+=8b', 'cmdline')[0], '8bi')
-  call assert_equal(getcompletion('set hl+=8:No*ext', 'cmdline')[0], 'NonText')
+  call assert_equal([&hl, '8'], getcompletion('set hl=', 'cmdline')[0:1])
+  call assert_equal('8', getcompletion('set hl+=', 'cmdline')[0])
+  call assert_equal(['8:', '8b', '8i'], getcompletion('set hl+=8', 'cmdline')[0:2])
+  call assert_equal('8bi', getcompletion('set hl+=8b', 'cmdline')[0])
+  call assert_equal('NonText', getcompletion('set hl+=8:No*ext', 'cmdline')[0])
   " If all the display modes are used up we should be suggesting nothing. Make
   " a hl typed option with all the modes which will look like '8bi-nrsuc2d=t',
   " and make sure nothing is suggested from that.
@@ -564,7 +564,7 @@ func Test_set_completion_string_values()
         \            {idx, val -> val[1]}),
         \        {idx, val -> val != ':'}),
         \ '')
-  call assert_equal(getcompletion('set hl+=8'..hl_display_modes, 'cmdline'), [])
+  call assert_equal([], getcompletion('set hl+=8'..hl_display_modes, 'cmdline'))
 
   "
   " Test flag lists
@@ -573,16 +573,16 @@ func Test_set_completion_string_values()
   " Test set=. Show the original value if nothing is typed after '='.
   " Otherwise, the list should avoid showing what's already typed.
   set mouse=v
-  call assert_equal(getcompletion('set mouse=', 'cmdline'), ['v','a','n','i','c','h','r'])
+  call assert_equal(['v','a','n','i','c','h','r'], getcompletion('set mouse=', 'cmdline'))
   set mouse=nvi
-  call assert_equal(getcompletion('set mouse=', 'cmdline'), ['nvi','a','n','v','i','c','h','r'])
-  call assert_equal(getcompletion('set mouse=hn', 'cmdline'), ['a','v','i','c','r'])
+  call assert_equal(['nvi','a','n','v','i','c','h','r'], getcompletion('set mouse=', 'cmdline'))
+  call assert_equal(['a','v','i','c','r'], getcompletion('set mouse=hn', 'cmdline'))
 
   " Test set+=. Never show original value, and it also tries to avoid listing
   " flags that's already in the option value.
-  call assert_equal(getcompletion('set mouse+=', 'cmdline'), ['a','c','h','r'])
-  call assert_equal(getcompletion('set mouse+=hn', 'cmdline'), ['a','c','r'])
-  call assert_equal(getcompletion('set mouse+=acrhn', 'cmdline'), [])
+  call assert_equal(['a','c','h','r'], getcompletion('set mouse+=', 'cmdline'))
+  call assert_equal(['a','c','r'], getcompletion('set mouse+=hn', 'cmdline'))
+  call assert_equal([], getcompletion('set mouse+=acrhn', 'cmdline'))
 
   " Test that the position of the expansion is correct (even if there are
   " additional values after the current cursor)
@@ -593,15 +593,15 @@ func Test_set_completion_string_values()
   " Test that other flag list options have auto-complete, but don't
   " exhaustively validate their results.
   if exists('+concealcursor')
-    call assert_equal(getcompletion('set cocu=', 'cmdline')[0], 'n')
+    call assert_equal('n', getcompletion('set cocu=', 'cmdline')[0])
   endif
-  call assert_equal(getcompletion('set cpo=', 'cmdline')[1], 'a')
-  call assert_equal(getcompletion('set fo=', 'cmdline')[1], 't')
+  call assert_equal('a', getcompletion('set cpo=', 'cmdline')[1])
+  call assert_equal('t', getcompletion('set fo=', 'cmdline')[1])
   if exists('+guioptions')
-    call assert_equal(getcompletion('set go=', 'cmdline')[1], '!')
+    call assert_equal('!', getcompletion('set go=', 'cmdline')[1])
   endif
-  call assert_equal(getcompletion('set shortmess=', 'cmdline')[1], 'r')
-  call assert_equal(getcompletion('set whichwrap=', 'cmdline')[1], 'b')
+  call assert_equal('r', getcompletion('set shortmess=', 'cmdline')[1])
+  call assert_equal('b', getcompletion('set whichwrap=', 'cmdline')[1])
 
   "
   "Test set-=
@@ -609,54 +609,54 @@ func Test_set_completion_string_values()
 
   " Normal single-value option just shows the existing value
   set ambiwidth=double
-  call assert_equal(getcompletion('set ambw-=', 'cmdline'), ['double'])
+  call assert_equal(['double'], getcompletion('set ambw-=', 'cmdline'))
   set ambiwidth&
 
   " Works on numbers and term options as well
-  call assert_equal(getcompletion('set laststatus-=', 'cmdline'), [string(&laststatus)])
+  call assert_equal([string(&laststatus)], getcompletion('set laststatus-=', 'cmdline'))
   set t_Ce=testCe
-  call assert_equal(getcompletion('set t_Ce-=', 'cmdline'), ['testCe'])
+  call assert_equal(['testCe'], getcompletion('set t_Ce-=', 'cmdline'))
   set t_Ce&
 
   " Comma-separated lists should present each option
   set diffopt=context:123,,,,,iblank,iwhiteall
-  call assert_equal(getcompletion('set diffopt-=', 'cmdline'), ['context:123', 'iblank', 'iwhiteall'])
-  call assert_equal(getcompletion('set diffopt-=*n*', 'cmdline'), ['context:123', 'iblank'])
-  call assert_equal(getcompletion('set diffopt-=i', 'cmdline'), ['iblank', 'iwhiteall'])
+  call assert_equal(['context:123', 'iblank', 'iwhiteall'], getcompletion('set diffopt-=', 'cmdline'))
+  call assert_equal(['context:123', 'iblank'], getcompletion('set diffopt-=*n*', 'cmdline'))
+  call assert_equal(['iblank', 'iwhiteall'], getcompletion('set diffopt-=i', 'cmdline'))
   " Don't present more than one option as it doesn't make sense in set-=
-  call assert_equal(getcompletion('set diffopt-=iblank,', 'cmdline'), [])
+  call assert_equal([], getcompletion('set diffopt-=iblank,', 'cmdline'))
   " Test empty option
   set diffopt=
-  call assert_equal(getcompletion('set diffopt-=', 'cmdline'), [])
+  call assert_equal([], getcompletion('set diffopt-=', 'cmdline'))
   set diffopt&
 
   " Test escaping output
-  call assert_equal(getcompletion('set fillchars-=', 'cmdline')[0], 'vert:\|')
+  call assert_equal('vert:\|', getcompletion('set fillchars-=', 'cmdline')[0])
 
   " Test files with commas in name are being parsed and escaped properly
   set path=has\\\ space,file\\,with\\,comma,normal_file
   if exists('+completeslash')
-    call assert_equal(getcompletion('set path-=', 'cmdline'), ['has\\\ space', 'file\,with\,comma', 'normal_file'])
+    call assert_equal(['has\\\ space', 'file\,with\,comma', 'normal_file'], getcompletion('set path-=', 'cmdline'))
   else
-    call assert_equal(getcompletion('set path-=', 'cmdline'), ['has\\\ space', 'file\\,with\\,comma', 'normal_file'])
+    call assert_equal(['has\\\ space', 'file\\,with\\,comma', 'normal_file'], getcompletion('set path-=', 'cmdline'))
   endif
   set path&
 
   " Flag list should present orig value, then individual flags
   set mouse=v
-  call assert_equal(getcompletion('set mouse-=', 'cmdline'), ['v'])
+  call assert_equal(['v'], getcompletion('set mouse-=', 'cmdline'))
   set mouse=avn
-  call assert_equal(getcompletion('set mouse-=', 'cmdline'), ['avn','a','v','n'])
+  call assert_equal(['avn','a','v','n'], getcompletion('set mouse-=', 'cmdline'))
   " Don't auto-complete when we have at least one flags already
-  call assert_equal(getcompletion('set mouse-=n', 'cmdline'), [])
+  call assert_equal([], getcompletion('set mouse-=n', 'cmdline'))
   " Test empty option
   set mouse=
-  call assert_equal(getcompletion('set mouse-=', 'cmdline'), [])
+  call assert_equal([], getcompletion('set mouse-=', 'cmdline'))
   set mouse&
 
   " 'whichwrap' is an odd case where it's both flag list and comma-separated
   set ww=b,h
-  call assert_equal(getcompletion('set ww-=', 'cmdline'), ['b','h'])
+  call assert_equal(['b','h'], getcompletion('set ww-=', 'cmdline'))
   set ww&
 endfunc
 


### PR DESCRIPTION
- Fix manual array size calculations to just use `ARRAY_LENGTH()`.
- Fix unintentional typo in comments due to copy-paste error.
- Fix assert_equal() usages to pass the expected value to first parameter instead of 2nd one to avoid confusion.
- Fix misc signed vs unsigned warnings.