### PR TITLE
Misplaced comments about set_op_T and set_prefix_T

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3587,7 +3587,7 @@ do_check_cursorbind(void)
     FOR_ALL_WINDOWS(curwin)
     {
 	curbuf = curwin->w_buffer;
-	// skip original window  and windows with 'noscrollbind'
+	// skip original window and windows with 'nocursorbind'
 	if (curwin != old_curwin && curwin->w_p_crb)
 	{
 # ifdef FEAT_DIFF

--- a/src/option.c
+++ b/src/option.c
@@ -1312,7 +1312,7 @@ ex_set(exarg_T *eap)
 }
 
 /*
- * :set operator types
+ * :set boolean option prefix
  */
 typedef enum {
     PREFIX_NO = 0,	// "no" prefix

--- a/src/structs.h
+++ b/src/structs.h
@@ -588,6 +588,9 @@ typedef enum {
     XP_PREFIX_INV,	// "inv" prefix for bool option
 } xp_prefix_T;
 
+/*
+ * :set operator types
+ */
 typedef enum {
     OP_NONE = 0,
     OP_ADDING,		// "opt+=arg"


### PR DESCRIPTION
Problem:  Misplacd comments about set_op_T and set_prefix_T.
Solution: Correct the comments. Fix a typo in another comment.