### PR TITLE
win32: Add "**" test

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -386,8 +386,8 @@ is to use "path\[[]abc]", this matches the file "path\[abc]".
 
 					*starstar-wildcard*
 Expanding "**" is possible on Unix, Win32, macOS and a few other systems (but
-it may depend on your 'shell' setting. It's known to work correctly for zsh; for
-bash this requires at least bash version >= 4.X).
+it may depend on your 'shell' setting on Unix and macOS. It's known to work
+correctly for zsh; for bash this requires at least bash version >= 4.X).
 This allows searching a directory tree.  This goes up to 100 directories deep.
 Note there are some commands where this works slightly differently, see
 |file-searching|.

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -3647,4 +3647,22 @@ func Test_glob_extended_bash()
   let &shell=_shell
 endfunc
 
+" Test for glob() with extended patterns (MS-Windows)
+" Vim doesn't use 'shell' to expand wildcards on MS-Windows.
+" Unlike bash, it doesn't support {,} expansion.
+func Test_glob_extended_mswin()
+  CheckMSWindows
+
+  call mkdir('Xtestglob/foo/bar/src', 'p')
+  call writefile([], 'Xtestglob/foo/bar/src/foo.sh')
+  call writefile([], 'Xtestglob/foo/bar/src/foo.h')
+  call writefile([], 'Xtestglob/foo/bar/src/foo.cpp')
+
+  " Sort output of glob() otherwise we end up with different
+  " ordering depending on whether file system is case-sensitive.
+  let expected = ['Xtestglob/foo/bar/src/foo.cpp', 'Xtestglob/foo/bar/src/foo.h', 'Xtestglob/foo/bar/src/foo.sh']
+  call assert_equal(expected, sort(glob('Xtestglob/**/foo.*', 0, 1)))
+  call delete('Xtestglob', 'rf')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Vim supports "**" on MS-Windows. However, it is not tested by `Test_glob_extended_bash`.

Unlike Unix, it doesn't use 'shell' and doesn't support {,} expansion. So, I added as a separate test.

Related: #13205