### PR TITLE
Fix macOS FEAT_SOUND guards to be less restrictive

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -173,8 +173,8 @@
 #  define FEAT_CLIPBOARD
 # endif
 # if defined(FEAT_HUGE) && !defined(FEAT_SOUND) && \
-   defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
-    MAC_OS_X_VERSION_MIN_REQUIRED >= 101100
+	defined(__clang_major__) && __clang_major__ >= 7 && \
+	defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
 #  define FEAT_SOUND
 # endif
 # if defined(FEAT_SOUND)


### PR DESCRIPTION
This allows +sound to work on older macOS platforms again. The +sound implementation uses APIs available in 10.6, but the code itself uses generics with type parameters which was only added in Xcode 7 / clang 7, which was released for macOS 10.11. This means as long as Vim is compiled under 10.11+, and using a deployment target >= 10.6, the feature will work.