### PR TITLE
Cannot scroll up in diff mode with many filler lines and scrolloff=0

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3262,6 +3262,7 @@ onepage(int dir, long count)
 #ifdef FEAT_DIFF
 			curwin->w_topfill = 0;
 #endif
+			curwin->w_valid &= ~(VALID_WROW|VALID_CROW);
 		    }
 		    comp_botline(curwin);
 		    curwin->w_cursor.lnum = curwin->w_botline - 1;

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -1614,6 +1614,42 @@ func Test_diff_scroll_wrap_on()
   call assert_equal(1, winsaveview().topline)
   normal! j
   call assert_equal(2, winsaveview().topline)
+
+  bwipe!
+  bwipe!
+endfunc
+
+func Test_diff_scroll_many_filler()
+  20new
+  vnew
+  call setline(1, ['^^^', '^^^', '$$$', '$$$'])
+  diffthis
+  setlocal scrolloff=0
+  wincmd p
+  call setline(1, ['^^^', '^^^'] + repeat(['###'], 41) + ['$$$', '$$$'])
+  diffthis
+  setlocal scrolloff=0
+  wincmd p
+  redraw
+
+  " Note: need a redraw after each scroll, otherwise the test always passes.
+  normal! G
+  redraw
+  call assert_equal(3, winsaveview().topline)
+  call assert_equal(18, winsaveview().topfill)
+  exe "normal! \<C-B>"
+  redraw
+  call assert_equal(3, winsaveview().topline)
+  call assert_equal(19, winsaveview().topfill)
+  exe "normal! \<C-B>"
+  redraw
+  call assert_equal(2, winsaveview().topline)
+  call assert_equal(0, winsaveview().topfill)
+  exe "normal! \<C-B>"
+  redraw
+  call assert_equal(1, winsaveview().topline)
+  call assert_equal(0, winsaveview().topfill)
+
   bwipe!
   bwipe!
 endfunc


### PR DESCRIPTION
Problem:  Cannot scroll up in diff mode with many filler lines and zero
          'scrolloff'.
Solution: Invalidate w_cline_row before calling comp_botline().
