### PR TITLE
CI: re-enable Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,20 +1,20 @@
-#env:
-#  CIRRUS_CLONE_DEPTH: 3
-#  FEATURES: huge
-#
-#freebsd_task:
-#  name: FreeBSD
-#  matrix:
-#    - name: FreeBSD 14.0
-#      freebsd_instance:
-#        image_family: freebsd-14-0
-#  timeout_in: 20m
-#  install_script:
-#    - pkg install -y gettext
-#  build_script:
-#    - NPROC=$(getconf _NPROCESSORS_ONLN)
-#    - ./configure --with-features=${FEATURES}
-#    - make -j${NPROC}
+env:
+  CIRRUS_CLONE_DEPTH: 3
+  FEATURES: huge
+
+freebsd_task:
+  name: FreeBSD
+  matrix:
+    - name: FreeBSD 14.0
+      freebsd_instance:
+        image_family: freebsd-14-0
+  timeout_in: 20m
+  install_script:
+    - pkg install -y gettext
+  build_script:
+    - NPROC=$(getconf _NPROCESSORS_ONLN)
+    - ./configure --with-features=${FEATURES}
+    - make -j${NPROC}
 #  test_script:
 #    - src/vim --version
 #      # run tests as user "cirrus" instead of root


### PR DESCRIPTION
Ref patch 9.0.1912:

> Perhaps at the beginning of the next month we can revisit and enable
> just a build without testing it.  Hopefully this is won't take too
> many credits and we can at least verify that building works.

Actually enabling testing should be fine. In the last month there were
three Cirrus CI jobs and credits ran out on Sep 15, but now there is
only one Cirrus CI job, so credits shouldn't run out.