### PR TITLE
win32: Improve default font

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -392,16 +392,6 @@ static int (WINAPI *pGetSystemMetricsForDpi)(int, UINT) = NULL;
 static DPI_AWARENESS_CONTEXT (WINAPI *pSetThreadDpiAwarenessContext)(DPI_AWARENESS_CONTEXT dpiContext) = NULL;
 static DPI_AWARENESS (WINAPI *pGetAwarenessFromDpiAwarenessContext)(DPI_AWARENESS_CONTEXT) = NULL;
 
-    static UINT WINAPI
-stubGetDpiForSystem(void)
-{
-    HWND hwnd = GetDesktopWindow();
-    HDC hdc = GetWindowDC(hwnd);
-    UINT dpi = GetDeviceCaps(hdc, LOGPIXELSY);
-    ReleaseDC(hwnd, hdc);
-    return dpi;
-}
-
     static int WINAPI
 stubGetSystemMetricsForDpi(int nIndex, UINT dpi UNUSED)
 {
@@ -5286,7 +5276,7 @@ load_dpi_func(void)
 
 fail:
     // Disable PerMonitorV2 APIs.
-    pGetDpiForSystem = stubGetDpiForSystem;
+    pGetDpiForSystem = vimGetDpiForSystem;
     pGetDpiForWindow = NULL;
     pGetSystemMetricsForDpi = stubGetSystemMetricsForDpi;
     pSetThreadDpiAwarenessContext = NULL;

--- a/src/proto/os_mswin.pro
+++ b/src/proto/os_mswin.pro
@@ -51,6 +51,7 @@ void serverProcessPendingMessages(void);
 char *charset_id2name(int id);
 char *quality_id2name(DWORD id);
 void gui_mch_expand_font(optexpand_T *args, void *param, int (*add_match)(char_u *val));
+UINT WINAPI vimGetDpiForSystem(void);
 int get_logfont(LOGFONTW *lf, char_u *name, HDC printer_dc, int verbose);
 void channel_init_winsock(void);
 /* vim: set ft=c : */

--- a/src/testdir/test_mswin_event.vim
+++ b/src/testdir/test_mswin_event.vim
@@ -727,14 +727,14 @@ func Test_mswin_event_mouse()
   if has('gui_running')
     let args = { }
     let args.row = 9
-    let args.col = 7
+    let args.col = 5
     let args.move = 1
     let args.cell = 1
     call test_mswin_event("mouse", args)
     call feedkeys("\<Esc>", 'Lx!')
     let pos = getmousepos()
     call assert_equal(9, pos.screenrow)
-    call assert_equal(7, pos.screencol)
+    call assert_equal(5, pos.screencol)
 
     let args.cell = 0
     call test_mswin_event("mouse", args)


### PR DESCRIPTION
Currently, Fixedsys is the default font on Windows.
It is not suitable for recent High DPI environments.

* Change the default font to Consolas.
* Allow to change the default font by the translation message. E.g.:
  ```
  msgid "DefaultFontNameForWindows"
  msgstr "Courier New"
  ```

Close #12919