### PR TITLE
Shift up error message, fixing numbering.

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6884,6 +6884,14 @@ printf({fmt}, {expr1} ...)				*printf()*
 <			E1505: Invalid format specifier:
 			%1$d at width %2$d is: %01$*2$.3$d
 
+							*E1507*
+		This internal error indicates that the logic to
+		parse a positional format error ran into a problem
+		that couldn't be otherwise reported. Please file a
+		bug against vim if you run into this, copying the
+		exact format string and parameters that were used.
+
+
 prompt_getprompt({buf})					*prompt_getprompt()*
 		Returns the effective prompt text for buffer {buf}.  {buf} can
 		be a buffer name or number.  See |prompt-buffer|.

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4510,6 +4510,7 @@ E1503	builtin.txt	/*E1503*
 E1504	builtin.txt	/*E1504*
 E1505	builtin.txt	/*E1505*
 E1506	editing.txt	/*E1506*
+E1507	builtin.txt	/*E1507*
 E1508	editing.txt	/*E1508*
 E1509	editing.txt	/*E1509*
 E151	helphelp.txt	/*E151*

--- a/src/errors.h
+++ b/src/errors.h
@@ -3554,10 +3554,9 @@ EXTERN char e_invalid_format_specifier_str[]
 	INIT(= N_("E1505: Invalid format specifier: %s"));
 EXTERN char e_xattr_erange[]
 	INIT(= N_("E1506: Buffer too small to copy xattr value or key"));
+EXTERN char e_aptypes_is_null_nr_str[]
+	INIT(= "E1507: Internal error: ap_types or ap_types[idx] is NULL: %d: %s");
 EXTERN char e_xattr_e2big[]
 	INIT(= N_("E1508: Size of the extended attribute value is larger than the maximum size allowed"));
 EXTERN char e_xattr_other[]
 	INIT(= N_("E1509: Error occured when reading or writing extended attribute"));
-// E1507, E1509 - E1519 unused
-EXTERN char e_aptypes_is_null_nr_str[]
-	INIT(= "E1520: Internal error: ap_types or ap_types[idx] is NULL: %d: %s");


### PR DESCRIPTION
Because the internal error message for the positional arguments was added after a few class related error messages, and it was shifted up by 100, there was a 'hole' at the end of the errors.h file. This shifts the error message inside the 'hole'.