### PR TITLE
Use defining class in variable access error messages.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1105,26 +1105,28 @@ get_lval_check_access(
 #endif
     if (cl_exec == NULL || cl_exec != cl)
     {
+	char *msg = NULL;
 	switch (om->ocm_access)
 	{
 	    case VIM_ACCESS_PRIVATE:
-		semsg(_(e_cannot_access_private_variable_str),
-						om->ocm_name, cl->class_name);
-		return FAIL;
+		msg = e_cannot_access_private_variable_str;
+		break;
 	    case VIM_ACCESS_READ:
 		// If [idx] or .key following, read only OK.
 		if (*p == '[' || *p == '.')
 		    break;
 		if ((flags & GLV_READ_ONLY) == 0)
-		{
-		    semsg(_(e_variable_is_not_writable_str),
-						om->ocm_name, cl->class_name);
-		    return FAIL;
-		}
+		    msg = e_variable_is_not_writable_str;
 		break;
 	    case VIM_ACCESS_ALL:
 		break;
 	}
+	if (msg != NULL)
+	{
+	    emsg_var_cl_define(msg, om->ocm_name, 0, cl);
+	    return FAIL;
+	}
+
     }
     return OK;
 }

--- a/src/proto/vim9class.pro
+++ b/src/proto/vim9class.pro
@@ -16,6 +16,7 @@ ocmember_T *object_member_lookup(class_T *cl, char_u *name, size_t namelen, int 
 int object_method_idx(class_T *cl, char_u *name, size_t namelen);
 ufunc_T *object_method_lookup(class_T *cl, char_u *name, size_t namelen, int *idx);
 ocmember_T *member_lookup(class_T *cl, vartype_T v_type, char_u *name, size_t namelen, int *idx);
+void emsg_var_cl_define(char *msg, char_u *name, size_t len, class_T *cl);
 ufunc_T *method_lookup(class_T *cl, vartype_T v_type, char_u *name, size_t namelen, int *idx);
 int inside_class(cctx_T *cctx_arg, class_T *cl);
 void copy_object(typval_T *from, typval_T *to);

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1616,7 +1616,7 @@ lhs_class_member_modifiable(lhs_T *lhs, char_u	*var_start, cctx_T *cctx)
 	char *msg = (m->ocm_access == VIM_ACCESS_PRIVATE)
 				? e_cannot_access_private_variable_str
 				: e_variable_is_not_writable_str;
-	semsg(_(msg), m->ocm_name, cl->class_name);
+	emsg_var_cl_define(msg, m->ocm_name, 0, cl);
 	return FALSE;
     }
 

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2180,8 +2180,8 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 	    {
 		if (*member == '_')
 		{
-		    semsg(_(e_cannot_access_private_variable_str),
-						m->ocm_name, cl->class_name);
+		    emsg_var_cl_define(e_cannot_access_private_variable_str,
+							m->ocm_name, 0, cl);
 		    status = FAIL;
 		}
 

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -407,8 +407,8 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	{
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
-		semsg(_(e_cannot_access_private_variable_str), m->ocm_name,
-							    cl->class_name);
+		emsg_var_cl_define(e_cannot_access_private_variable_str,
+							m->ocm_name, 0, cl);
 		return FAIL;
 	    }
 
@@ -443,8 +443,8 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    // it is defined.
 	    if (*name == '_' && cctx->ctx_ufunc->uf_class != cl)
 	    {
-		semsg(_(e_cannot_access_private_variable_str), m->ocm_name,
-							    cl->class_name);
+		emsg_var_cl_define(e_cannot_access_private_variable_str,
+							m->ocm_name, 0, cl);
 		return FAIL;
 	    }
 


### PR DESCRIPTION
In vim9class.c:
```
void emsg_var_cl_define(char *msg, char_u *name, size_t len, class_T *cl) 
static class_T * class_defining_member(class_T *cl, char_u *name, size_t len, 
                                       vartype_T *p_typ, ocmember_T **p_m)
```
used as in
```
emsg_var_cl_define(e_cannot_access_private_variable_str, m->ocm_name, 0, cl);
```
Related uses, for example to get the class_T* of the defining class, things can be made public