### PR TITLE
Correct filetype detection for just.

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1094,7 +1094,7 @@ au BufNewFile,BufRead *.jsonnet,*.libsonnet	setf jsonnet
 au BufNewFile,BufRead *.jl			setf julia
 
 " Just
-autocmd BufNewFile,BufRead *[jJ]ustfile,.justfile,*.just setfiletype just
+au BufNewFile,BufRead [jJ]ustfile,.justfile,*.just setf just
 
 " KDL
 au BufNewFile,BufRead *.kdl			setf kdl


### PR DESCRIPTION
See https://github.com/vim/vim/pull/13271#discussion_r1347279686 and
https://github.com/NoahTheDuke/vim-just/blob/main/ftdetect/just.vim.
