### PR TITLE
ci: disable codecov PR comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,8 @@ coverage:
       default:
         threshold: 0.05%
 
+comment: false
+
 # Files not run by tests
 ignore:
   - "src/dosinst.c"


### PR DESCRIPTION
The codecov report is incredibly intrusive, and getting a notification
for every PR to vim that codecov codecoved is annoying. If anyone is
interested in the report the information is readily available by
clicking on the job.
