### PR TITLE
Invalid memory access when 'foldexpr' returns empty string

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -968,7 +968,7 @@ eval_foldexpr(win_T *wp, int *cp)
 	    // If the result is a string, check if there is a non-digit before
 	    // the number.
 	    s = tv.vval.v_string;
-	    if (!VIM_ISDIGIT(*s) && *s != '-')
+	    if (*s != NUL && !VIM_ISDIGIT(*s) && *s != '-')
 		*cp = *s++;
 	    retval = atol((char *)s);
 	}

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1769,4 +1769,13 @@ func Test_foldcolumn_linebreak_control_char()
   bwipe!
 endfunc
 
+" This used to cause invalid memory access
+func Test_foldexpr_return_empty_string()
+  new
+  setlocal foldexpr='' foldmethod=expr
+  redraw
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Invalid memory access when 'foldexpr' returns empty string.
Solution: Check for NUL.
