### PR TITLE
Fix builtin `islocked()` SEGV when arg is class/object variable.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1375,6 +1375,7 @@ get_lval(
 		      && v_type != VAR_OBJECT
 		      && v_type != VAR_CLASS)
 	{
+	    // TODO: have a message with obj/class, not just dict,
 	    if (!quiet)
 		semsg(_(e_dot_can_only_be_used_on_dictionary_str), name);
 	    return NULL;
@@ -1385,6 +1386,7 @@ get_lval(
 		&& v_type != VAR_OBJECT
 		&& v_type != VAR_CLASS)
 	{
+	    // TODO: have a message with obj/class, not just dict/list/blob,
 	    if (!quiet)
 		emsg(_(e_can_only_index_list_dictionary_or_blob));
 	    return NULL;
@@ -1739,10 +1741,6 @@ get_lval(
 		    }
 		}
 
-		// TODO: dont' check access if inside class
-		// TODO: is GLV_READ_ONLY the right thing to use
-		//	     for class/object member access?
-		//	     Probably in some cases. Need inside class check
 		if (lp->ll_valtype == NULL)
 		{
 		    int		m_idx;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7347,6 +7347,22 @@ f_islocked(typval_T *argvars, typval_T *rettv)
 						   || tv_islocked(&di->di_tv));
 		}
 	    }
+	    else if (lv.ll_object != NULL)
+	    {
+		typval_T *tv = ((typval_T *)(lv.ll_object + 1)) + lv.ll_oi;
+		rettv->vval.v_number = tv_islocked(tv);
+#ifdef LOG_LOCKVAR
+		ch_log(NULL, "LKVAR: f_islocked(): name %s (obj)", lv.ll_name);
+#endif
+	    }
+	    else if (lv.ll_class != NULL)
+	    {
+		typval_T *tv = &lv.ll_class->class_members_tv[lv.ll_oi];
+		rettv->vval.v_number = tv_islocked(tv);
+#ifdef LOG_LOCKVAR
+		ch_log(NULL, "LKVAR: f_islocked(): name %s (cl)", lv.ll_name);
+#endif
+	    }
 	    else if (lv.ll_range)
 		emsg(_(e_range_not_allowed));
 	    else if (lv.ll_newkey != NULL)

--- a/src/structs.h
+++ b/src/structs.h
@@ -4547,11 +4547,18 @@ typedef struct
  *	"tv"	    points to the (first) list item value
  *	"li"	    points to the (first) list item
  *	"range", "n1", "n2" and "empty2" indicate what items are used.
- * For a member in a class/object: TODO: verify fields
+ * For a plain class or object:
+ *	"name"	    points to the variable name.
+ *	"exp_name"  is NULL.
+ *	"tv"	    points to the variable
+ *	"is_root"   TRUE
+ * For a variable in a class/object: (class is not NULL)
  *	"name"	    points to the (expanded) variable name.
  *	"exp_name"  NULL or non-NULL, to be freed later.
- *	"tv"	    points to the (first) list item value
- *	"oi"	    index into member array, see _type to determine which array
+ *	"tv"	    May point to class/object variable.
+ *	"object"    object containing variable, NULL if class variable
+ *	"class"	    class of object or class containing variable
+ *	"oi"	    index into class/object of tv
  * For an existing Dict item:
  *	"name"	    points to the (expanded) variable name.
  *	"exp_name"  NULL or non-NULL, to be freed later.
@@ -4591,8 +4598,8 @@ typedef struct lval_S
     object_T	*ll_object;	// The object or NULL, class is not NULL
     class_T	*ll_class;	// The class or NULL, object may be NULL
     int		ll_oi;		// The object/class member index
-    int		ll_is_root;	// Special case. ll_tv is lval_root,
-				// ignore the rest.
+    int		ll_is_root;	// TRUE if ll_tv is the lval_root, like a
+				// plain object/class. ll_tv is variable.
 } lval_T;
 
 /**


### PR DESCRIPTION
Now f_islocked() handles lval_T for object/class variable.

SEGV example
```
vim9script

class C1
  this.o0: list<list<number>> = [ [0],  [1],  [2]]
endclass
var obj = C1.new()
islocked("obj.o0")
```

Probably follow on PR for `islocked()`, but wanted to get the SEGV out of the way.