### PR TITLE
runtime: make command name for &iskeywordprg more unique

### DIFF
--- a/runtime/ftplugin/gpg.vim
+++ b/runtime/ftplugin/gpg.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             gpg(1) configuration file
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2008-07-09
+" Latest Revision:      2023-10-07
 
 if exists("b:did_ftplugin")
   finish
@@ -17,17 +17,17 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
   if !has('gui_running')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 GpgKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+--' . <q-args> . '\b'' --hilite-search" man ' . 'gpg' |
           \ redraw!
   elseif has('terminal')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 GpgKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
   endif
-  if exists(':Sman') == 2
+  if exists(':GpgKeywordPrg') == 2
     setlocal iskeyword+=-
-    setlocal keywordprg=:Sman
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer Sman'
+    setlocal keywordprg=:GpgKeywordPrg
+    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer GpgKeywordPrg'
   endif
 endif
 

--- a/runtime/ftplugin/modconf.vim
+++ b/runtime/ftplugin/modconf.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             modules.conf(5) configuration file
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2008-07-09
+" Latest Revision:      2023-10-07
 
 if exists("b:did_ftplugin")
   finish
@@ -18,17 +18,17 @@ setlocal formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
   if !has('gui_running')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 ModconfKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'modprobe.d' |
           \ redraw!
   elseif has('terminal')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 ModconfKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
   endif
-  if exists(':Sman') == 2
+  if exists(':ModconfKeywordPrg') == 2
     setlocal iskeyword+=-
-    setlocal keywordprg=:Sman
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer Sman'
+    setlocal keywordprg=:ModconfKeywordPrg
+    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer ModconfKeywordPrg'
   endif
 endif
 

--- a/runtime/ftplugin/muttrc.vim
+++ b/runtime/ftplugin/muttrc.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             mutt RC File
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2006-04-19
+" Latest Revision:      2023-10-07
 
 if exists("b:did_ftplugin")
   finish
@@ -20,17 +20,17 @@ let &l:include = '^\s*source\>'
 
 if has('unix') && executable('less')
   if !has('gui_running')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 MuttrcKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . 'muttrc' |
           \ redraw!
   elseif has('terminal')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 MuttrcKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
   endif
-  if exists(':Sman') == 2
+  if exists(':MuttrcKeywordPrg') == 2
     setlocal iskeyword+=-
-    setlocal keywordprg=:Sman
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer Sman'
+    setlocal keywordprg=:MuttrcKeywordPrg
+    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer MuttrcKeywordPrg'
   endif
 endif
 

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -32,17 +32,17 @@ endif
 
 if has('unix') && executable('less')
   if !has('gui_running')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 ReadlineKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . '3 readline' |
           \ redraw!
   elseif has('terminal')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 ReadlineKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
   endif
-  if exists(':Sman') == 2
+  if exists(':ReadlineKeywordPrg') == 2
     setlocal iskeyword+=-
-    setlocal keywordprg=:Sman
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer Sman'
+    setlocal keywordprg=:ReadlineKeywordPrg
+    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer ReadlineKeywordPrg'
   endif
 endif
 

--- a/runtime/ftplugin/sshconfig.vim
+++ b/runtime/ftplugin/sshconfig.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:         OpenSSH client configuration file
 " Previous Maintainer:       Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2008-07-09
+" Latest Revision:  2023-10-07
 
 if exists("b:did_ftplugin")
   finish
@@ -16,17 +16,17 @@ let b:undo_ftplugin = 'setlocal com< cms< fo<'
 
 if has('unix') && executable('less')
   if !has('gui_running')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 SshconfigKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '$'' --hilite-search" man ' . 'ssh_config' |
           \ redraw!
   elseif has('terminal')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 SshconfigKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
   endif
-  if exists(':Sman') == 2
+  if exists(':SshconfigKeywordPrg') == 2
     setlocal iskeyword+=-
-    setlocal keywordprg=:Sman
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer Sman'
+    setlocal keywordprg=:SshconfigKeywordPrg
+    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SshconfigKeywordPrg'
   endif
 endif
 

--- a/runtime/ftplugin/sudoers.vim
+++ b/runtime/ftplugin/sudoers.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             sudoers(5) configuration files
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2008-07-09
+" Latest Revision:      2023-10-07
 
 if exists("b:did_ftplugin")
   finish
@@ -17,17 +17,17 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
   if !has('gui_running')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 SudoersKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''\b' . <q-args> . '\b'' --hilite-search" man ' . 'sudoers' |
           \ redraw!
   elseif has('terminal')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 SudoersKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
   endif
-  if exists(':Sman') == 2
+  if exists(':SudoersKeywordPrg') == 2
     setlocal iskeyword+=-
-    setlocal keywordprg=:Sman
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer Sman'
+    setlocal keywordprg=:SudoersKeywordPrg
+    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SudoersKeywordPrg'
   endif
 endif
 

--- a/runtime/ftplugin/systemd.vim
+++ b/runtime/ftplugin/systemd.vim
@@ -1,6 +1,7 @@
 " Vim filetype plugin file
 " Language:			systemd.unit(5)
 " Keyword Lookup Support:	Enno Nagel <enno.nagel+vim@gmail.com>
+" Latest Revision:      2023-10-07
 
 if !exists('b:did_ftplugin')
   " Looks a lot like dosini files.
@@ -9,11 +10,11 @@ endif
 
 if has('unix') && executable('less')
   if !has('gui_running')
-    command -buffer -nargs=1 Sman silent exe '!' . KeywordLookup_systemd(<q-args>) | redraw!
+    command -buffer -nargs=1 SystemdKeywordPrg silent exe '!' . KeywordLookup_systemd(<q-args>) | redraw!
   elseif has('terminal')
-    command -buffer -nargs=1 Sman silent exe 'term ' . KeywordLookup_systemd(<q-args>)
+    command -buffer -nargs=1 SystemdKeywordPrg silent exe 'term ' . KeywordLookup_systemd(<q-args>)
   endif
-  if exists(':Sman') == 2
+  if exists(':SystemdKeywordPrg') == 2
     if !exists('*KeywordLookup_systemd')
       function KeywordLookup_systemd(keyword) abort
         let matches = matchlist(getline(search('\v^\s*\[\s*.+\s*\]\s*$', 'nbWz')), '\v^\s*\[\s*(\k+).*\]\s*$')
@@ -26,11 +27,11 @@ if has('unix') && executable('less')
       endfunction
     endif
     setlocal iskeyword+=-
-    setlocal keywordprg=:Sman
+    setlocal keywordprg=:SystemdKeywordPrg
     if !exists('b:undo_ftplugin') || empty(b:undo_ftplugin)
       let b:undo_ftplugin = 'setlocal keywordprg< iskeyword<'
     else
-      let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer Sman'
+      let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SystemdKeywordPrg'
     endif
   endif
 endif

--- a/runtime/ftplugin/udevrules.vim
+++ b/runtime/ftplugin/udevrules.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             udev(8) rules file
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2008-07-09
+" Latest Revision:      2023-10-07
 
 if exists("b:did_ftplugin")
   finish
@@ -17,17 +17,17 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
   if !has('gui_running')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 UdevrulesKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'udev' |
           \ redraw!
   elseif has('terminal')
-    command -buffer -nargs=1 Sman
+    command -buffer -nargs=1 UdevrulesKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
   endif
-  if exists(':Sman') == 2
+  if exists(':UdevrulesKeywordPrg') == 2
     setlocal iskeyword+=-
-    setlocal keywordprg=:Sman
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer Sman'
+    setlocal keywordprg=:UdevrulesKeywordPrg
+    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer UdevrulesKeywordPrg'
   endif
 endif
 

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -2,7 +2,7 @@
 " Language:             Zsh shell script
 " Maintainer:           Christian Brabandt <cb@256bit.org>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2021-04-03
+" Latest Revision:      2023-10-07
 " License:              Vim (see :h license)
 " Repository:           https://github.com/chrisbra/vim-zsh
 
@@ -20,17 +20,17 @@ let b:undo_ftplugin = "setl com< cms< fo< "
 
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
   if !has('gui_running') && executable('less')
-    command! -buffer -nargs=1 RunHelp silent exe '!MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
+    command! -buffer -nargs=1 ZshKeywordPrg silent exe '!MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
   elseif has('terminal')
-    command! -buffer -nargs=1 RunHelp silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
+    command! -buffer -nargs=1 ZshKeywordPrg silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
   else
-    command! -buffer -nargs=1 RunHelp echo system('zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
+    command! -buffer -nargs=1 ZshKeywordPrg echo system('zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
   endif
   if !exists('current_compiler')
     compiler zsh
   endif
-  setlocal keywordprg=:RunHelp
-  let b:undo_ftplugin .= 'keywordprg< | sil! delc -buffer RunHelp'
+  setlocal keywordprg=:ZshKeywordPrg
+  let b:undo_ftplugin .= 'keywordprg< | sil! delc -buffer ZshKeywordPrg'
 endif
 
 let b:match_words = '\<if\>:\<elif\>:\<else\>:\<fi\>'


### PR DESCRIPTION
See https://github.com/vim/vim/pull/13213/commits by @dkearns: Rename 'keywordprg' user command to ShKeywordPrg as this is just a leaking implementation detail.