### PR TITLE
fix: tmp file not deleted when running make test_undo

### DIFF
--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -860,6 +860,7 @@ func Test_undo_after_write()
 
   call StopVimInTerminal(buf)
   call delete('Xtestfile.txt')
+  call delete('.Xtestfile.txt.un~')
 endfunc
 
 func Test_undo_range_normal()


### PR DESCRIPTION
Temporary file `.Xtestfile.txt.un~` was left running `make test_undo` and vim was configured with:
```
./configure --with-features=normal --enable-gui=no --enable-terminal
```