### PR TITLE
Enforce invariant type check for arguments and return value when assigning a funcref

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -7154,4 +7154,41 @@ def Test_recursive_class_method_call()
   v9.CheckSourceSuccess(lines)
 enddef
 
+" Test for checking the argument types and the return type when assigning a
+" funcref to make sure the invariant class type is used.
+def Test_funcref_argtype_returntype_check()
+  var lines =<< trim END
+    vim9script
+    class A
+    endclass
+    class B extends A
+    endclass
+
+    def Foo(p: B): B
+      return B.new()
+    enddef
+
+    var Bar: func(A): A = Foo
+  END
+  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected func(object<A>): object<A> but got func(object<B>): object<B>', 11)
+
+  lines =<< trim END
+    vim9script
+    class A
+    endclass
+    class B extends A
+    endclass
+
+    def Foo(p: B): B
+      return B.new()
+    enddef
+
+    def Baz()
+      var Bar: func(A): A = Foo
+    enddef
+    Baz()
+  END
+  v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected func(object<A>): object<A> but got func(object<B>): object<B>', 1)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -874,8 +874,7 @@ check_type_maybe(
 		{
 		    where_T  func_where = where;
 
-		    if (where.wt_kind == WT_METHOD)
-			func_where.wt_kind = WT_METHOD_RETURN;
+		    func_where.wt_kind = WT_METHOD_RETURN;
 		    ret = check_type_maybe(expected->tt_member,
 					    actual->tt_member, FALSE,
 					    func_where);
@@ -898,8 +897,7 @@ check_type_maybe(
 					       && i < actual->tt_argcount; ++i)
 		{
 		    where_T  func_where = where;
-		    if (where.wt_kind == WT_METHOD)
-			func_where.wt_kind = WT_METHOD_ARG;
+		    func_where.wt_kind = WT_METHOD_ARG;
 
 		    // Allow for using "any" argument type, lambda's have them.
 		    if (actual->tt_args[i] != &t_any && check_type(


### PR DESCRIPTION
Fixes #13299.