### PR TITLE
Handle islocked() builtin from a method.

### DIFF
--- a/src/proto/vim9execute.pro
+++ b/src/proto/vim9execute.pro
@@ -4,6 +4,7 @@ void update_has_breakpoint(ufunc_T *ufunc);
 int funcstack_check_refcount(funcstack_T *funcstack);
 int set_ref_in_funcstacks(int copyID);
 int in_def_function(void);
+int fill_exec_lval_root(lval_root_T *lr);
 ectx_T *clear_current_ectx(void);
 void restore_current_ectx(ectx_T *ectx);
 int add_defer_function(char_u *name, int argcount, typval_T *argvars);

--- a/src/structs.h
+++ b/src/structs.h
@@ -4604,13 +4604,16 @@ typedef struct lval_S
 } lval_T;
 
 /**
- * This may be used to specify the base type that get_lval() uses when
+ * This may be used to specify the base typval that get_lval() uses when
  * following a chain, for example a[idx1][idx2].
+ * The lr_sync_root flags signals get_lval that the first time through
+ * the indexing loop, skip handling  '.' and '[idx]'.
  */
 typedef struct lval_root_S {
     typval_T	*lr_tv;
     class_T	*lr_cl_exec;	// executing class for access checking
     int		lr_is_arg;
+    int		lr_sync_root;
 } lval_root_T;
 
 // Structure used to save the current state.  Used when executing Normal mode


### PR DESCRIPTION
- Setup `lval_root` from `f_islocked()`.
- Add function `fill_exec_lval_root()` to get info about executing method. 
- `sync_root` added in `get_lval()` to handle method member access.