### PR TITLE
if_x: Avoid using #ifndef - #else - #endif

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -102,18 +102,18 @@ static void luaV_call_lua_func_free(void *state);
 
 #ifdef DYNAMIC_LUA
 
-#ifndef MSWIN
+#ifdef MSWIN
+# define load_dll vimLoadLib
+# define symbol_from_dll GetProcAddress
+# define close_dll FreeLibrary
+# define load_dll_error GetWin32Error
+#else
 # include <dlfcn.h>
 # define HANDLE void*
 # define load_dll(n) dlopen((n), RTLD_LAZY|RTLD_GLOBAL)
 # define symbol_from_dll dlsym
 # define close_dll dlclose
 # define load_dll_error dlerror
-#else
-# define load_dll vimLoadLib
-# define symbol_from_dll GetProcAddress
-# define close_dll FreeLibrary
-# define load_dll_error GetWin32Error
 #endif
 
 // lauxlib

--- a/src/if_mzsch.c
+++ b/src/if_mzsch.c
@@ -1366,10 +1366,10 @@ mzscheme_buffer_free(buf_T *buf)
 
     bp = BUFFER_REF(buf);
     bp->buf = INVALID_BUFFER_VALUE;
-#ifndef MZ_PRECISE_GC
-    scheme_gc_ptr_ok(bp);
-#else
+#ifdef MZ_PRECISE_GC
     scheme_free_immobile_box(buf->b_mzscheme_ref);
+#else
+    scheme_gc_ptr_ok(bp);
 #endif
     buf->b_mzscheme_ref = NULL;
     MZ_GC_CHECK();
@@ -1391,10 +1391,10 @@ mzscheme_window_free(win_T *win)
     MZ_GC_REG();
     wp = WINDOW_REF(win);
     wp->win = INVALID_WINDOW_VALUE;
-#ifndef MZ_PRECISE_GC
-    scheme_gc_ptr_ok(wp);
-#else
+#ifdef MZ_PRECISE_GC
     scheme_free_immobile_box(win->w_mzscheme_ref);
+#else
+    scheme_gc_ptr_ok(wp);
 #endif
     win->w_mzscheme_ref = NULL;
     MZ_GC_CHECK();
@@ -1921,10 +1921,10 @@ window_new(win_T *win)
     MZ_GC_REG();
     self = scheme_malloc_fail_ok(scheme_malloc_tagged, sizeof(vim_mz_window));
     CLEAR_POINTER(self);
-#ifndef MZ_PRECISE_GC
-    scheme_dont_gc_ptr(self);	// because win isn't visible to GC
-#else
+#ifdef MZ_PRECISE_GC
     win->w_mzscheme_ref = scheme_malloc_immobile_box(NULL);
+#else
+    scheme_dont_gc_ptr(self);	// because win isn't visible to GC
 #endif
     MZ_GC_CHECK();
     WINDOW_REF(win) = self;
@@ -2305,10 +2305,10 @@ buffer_new(buf_T *buf)
     MZ_GC_REG();
     self = scheme_malloc_fail_ok(scheme_malloc_tagged, sizeof(vim_mz_buffer));
     CLEAR_POINTER(self);
-#ifndef MZ_PRECISE_GC
-    scheme_dont_gc_ptr(self);	// because buf isn't visible to GC
-#else
+#ifdef MZ_PRECISE_GC
     buf->b_mzscheme_ref = scheme_malloc_immobile_box(NULL);
+#else
+    scheme_dont_gc_ptr(self);	// because buf isn't visible to GC
 #endif
     MZ_GC_CHECK();
     BUFFER_REF(buf) = self;

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -166,7 +166,13 @@ typedef int XSUBADDR_t;
 typedef int perl_key;
 # endif
 
-# ifndef MSWIN
+# ifdef MSWIN
+#  define PERL_PROC FARPROC
+#  define load_dll vimLoadLib
+#  define symbol_from_dll GetProcAddress
+#  define close_dll FreeLibrary
+#  define load_dll_error GetWin32Error
+# else
 #  include <dlfcn.h>
 #  define HANDLE void*
 #  define PERL_PROC void*
@@ -174,12 +180,6 @@ typedef int perl_key;
 #  define symbol_from_dll dlsym
 #  define close_dll dlclose
 #  define load_dll_error dlerror
-# else
-#  define PERL_PROC FARPROC
-#  define load_dll vimLoadLib
-#  define symbol_from_dll GetProcAddress
-#  define close_dll FreeLibrary
-#  define load_dll_error GetWin32Error
 # endif
 /*
  * Wrapper defines

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -130,7 +130,12 @@ struct PyMethodDef { Py_ssize_t a; };
 #  define HINSTANCE long_u		// for generating prototypes
 # endif
 
-# ifndef MSWIN
+# ifdef MSWIN
+#  define load_dll vimLoadLib
+#  define close_dll FreeLibrary
+#  define symbol_from_dll GetProcAddress
+#  define load_dll_error GetWin32Error
+# else
 #  include <dlfcn.h>
 #  define FARPROC void*
 #  define HINSTANCE void*
@@ -142,11 +147,6 @@ struct PyMethodDef { Py_ssize_t a; };
 #  define close_dll dlclose
 #  define symbol_from_dll dlsym
 #  define load_dll_error dlerror
-# else
-#  define load_dll vimLoadLib
-#  define close_dll FreeLibrary
-#  define symbol_from_dll GetProcAddress
-#  define load_dll_error GetWin32Error
 # endif
 
 // This makes if_python.c compile without warnings against Python 2.5
@@ -496,14 +496,14 @@ static struct
     PYTHON_PROC *ptr;
 } python_funcname_table[] =
 {
-# ifndef PY_SSIZE_T_CLEAN
-    {"PyArg_Parse", (PYTHON_PROC*)&dll_PyArg_Parse},
-    {"PyArg_ParseTuple", (PYTHON_PROC*)&dll_PyArg_ParseTuple},
-    {"Py_BuildValue", (PYTHON_PROC*)&dll_Py_BuildValue},
-# else
+# ifdef PY_SSIZE_T_CLEAN
     {"_PyArg_Parse_SizeT", (PYTHON_PROC*)&dll_PyArg_Parse},
     {"_PyArg_ParseTuple_SizeT", (PYTHON_PROC*)&dll_PyArg_ParseTuple},
     {"_Py_BuildValue_SizeT", (PYTHON_PROC*)&dll_Py_BuildValue},
+# else
+    {"PyArg_Parse", (PYTHON_PROC*)&dll_PyArg_Parse},
+    {"PyArg_ParseTuple", (PYTHON_PROC*)&dll_PyArg_ParseTuple},
+    {"Py_BuildValue", (PYTHON_PROC*)&dll_Py_BuildValue},
 # endif
     {"PyMem_Free", (PYTHON_PROC*)&dll_PyMem_Free},
     {"PyMem_Malloc", (PYTHON_PROC*)&dll_PyMem_Malloc},

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -174,7 +174,13 @@
 #include "version.h"
 
 #ifdef DYNAMIC_RUBY
-# if !defined(MSWIN)  // must come after including vim.h, where it is defined
+# ifdef MSWIN	// must come after including vim.h, where it is defined
+#  define RUBY_PROC FARPROC
+#  define load_dll vimLoadLib
+#  define symbol_from_dll GetProcAddress
+#  define close_dll FreeLibrary
+#  define load_dll_error GetWin32Error
+# else
 #  include <dlfcn.h>
 #  define HINSTANCE void*
 #  define RUBY_PROC void*
@@ -182,12 +188,6 @@
 #  define symbol_from_dll dlsym
 #  define close_dll dlclose
 #  define load_dll_error dlerror
-# else
-#  define RUBY_PROC FARPROC
-#  define load_dll vimLoadLib
-#  define symbol_from_dll GetProcAddress
-#  define close_dll FreeLibrary
-#  define load_dll_error GetWin32Error
 # endif
 #endif
 

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -160,7 +160,13 @@ static struct ref refsdeleted;	// dummy object for deleted ref list
 typedef int HANDLE;
 # endif
 
-# ifndef MSWIN
+# ifdef MSWIN
+#  define TCL_PROC FARPROC
+#  define load_dll vimLoadLib
+#  define symbol_from_dll GetProcAddress
+#  define close_dll FreeLibrary
+#  define load_dll_error GetWin32Error
+# else
 #  include <dlfcn.h>
 #  define HANDLE void*
 #  define TCL_PROC void*
@@ -168,12 +174,6 @@ typedef int HANDLE;
 #  define symbol_from_dll dlsym
 #  define close_dll dlclose
 #  define load_dll_error dlerror
-# else
-#  define TCL_PROC FARPROC
-#  define load_dll vimLoadLib
-#  define symbol_from_dll GetProcAddress
-#  define close_dll FreeLibrary
-#  define load_dll_error GetWin32Error
 # endif
 
 /*
@@ -242,10 +242,10 @@ static char *find_executable_arg = NULL;
     void
 vim_tcl_init(char *arg)
 {
-#ifndef DYNAMIC_TCL
-    Tcl_FindExecutable(arg);
-#else
+#ifdef DYNAMIC_TCL
     find_executable_arg = arg;
+#else
+    Tcl_FindExecutable(arg);
 #endif
 }
 


### PR DESCRIPTION
Using #ifndef - #else - #endif is sometimes confusing. Use #ifdef - #else - #endif instead.