### PR TITLE
Add new deb822sources filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -544,6 +544,7 @@ au BufNewFile,BufRead copyright
 " Debian Sources.list
 au BufNewFile,BufRead */etc/apt/sources.list		setf debsources
 au BufNewFile,BufRead */etc/apt/sources.list.d/*.list	setf debsources
+au BufNewFile,BufRead */etc/apt/sources.list.d/*.sources	setf deb822sources
 
 " Deny hosts
 au BufNewFile,BufRead denyhosts.conf		setf denyhosts

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -194,6 +194,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     debcontrol: ['/debian/control', 'any/debian/control'],
     debcopyright: ['/debian/copyright', 'any/debian/copyright'],
     debsources: ['/etc/apt/sources.list', '/etc/apt/sources.list.d/file.list', 'any/etc/apt/sources.list', 'any/etc/apt/sources.list.d/file.list'],
+    deb822sources: ['/etc/apt/sources.list.d/file.sources', 'any/etc/apt/sources.list.d/file.sources'],
     def: ['file.def'],
     denyhosts: ['denyhosts.conf'],
     desc: ['file.desc'],


### PR DESCRIPTION
I'll follow up with a Debian runtime update, including the new syntax
file for deb822sources (to address #11934), after this.