### PR TITLE
make :0cq return zero in exmode

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5954,6 +5954,9 @@ ex_quit(exarg_T *eap)
     static void
 ex_cquit(exarg_T *eap UNUSED)
 {
+    if (eap->addr_count > 0 && (int)eap->line2 == 0 && exmode_active)
+	ex_exitval = 0;
+
     // this does not always pass on the exit code to the Manx compiler. why?
     getout(eap->addr_count > 0 ? (int)eap->line2 : EXIT_FAILURE);
 }

--- a/src/testdir/test_crash.vim
+++ b/src/testdir/test_crash.vim
@@ -17,7 +17,7 @@ func Test_crash1()
   let buf = RunVimInTerminal('sh', opts)
 
   let file = 'crash/poc_huaf1'
-  let cmn_args = "%s -u NONE -i NONE -n -e -s -S %s -c ':qa!'"
+  let cmn_args = "%s -u NONE -i NONE -n -e -s -S %s -c ':0cq'"
   let args = printf(cmn_args, vim, file)
   call term_sendkeys(buf, args ..
     \ '  && echo "crash 1: [OK]" > X_crash1_result.txt' .. "\<cr>")
@@ -46,9 +46,8 @@ func Test_crash1()
 
   let file = 'crash/poc_tagfunc.vim'
   let args = printf(cmn_args, vim, file)
-  " using || because this poc causes vim to exit with exitstatus != 0
   call term_sendkeys(buf, args ..
-    \ '  || echo "crash 5: [OK]" >> X_crash1_result.txt' .. "\<cr>")
+    \ '  && echo "crash 5: [OK]" >> X_crash1_result.txt' .. "\<cr>")
 
   call TermWait(buf, 100)
 
@@ -69,7 +68,7 @@ func Test_crash1()
   let file = 'crash/vim_msg_trunc_poc'
   let args = printf(cmn_args, vim, file)
   call term_sendkeys(buf, args ..
-    \ '  || echo "crash 8: [OK]" >> X_crash1_result.txt' .. "\<cr>")
+    \ '  && echo "crash 8: [OK]" >> X_crash1_result.txt' .. "\<cr>")
   call TermWait(buf, 3000)
 
   let file = 'crash/crash_scrollbar'
@@ -81,7 +80,7 @@ func Test_crash1()
   let file = 'crash/editing_arg_idx_POC_1'
   let args = printf(cmn_args, vim, file)
   call term_sendkeys(buf, args ..
-    \ '  || echo "crash 10: [OK]" >> X_crash1_result.txt' .. "\<cr>")
+    \ '  && echo "crash 10: [OK]" >> X_crash1_result.txt' .. "\<cr>")
   call TermWait(buf, 1000)
   call delete('Xerr')
   call delete('@')

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -1351,5 +1351,28 @@ func Test_rename_buffer_on_startup()
   call delete('Xresult')
 endfunc
 
+" Test that -cq works as expected
+func Test_cq_zero_exmode()
+  let logfile = 'Xcq_log.txt'
+  let out = system(GetVimCommand() .. ' --clean --log ' .. logfile .. ' -es -X -c "argdelete foobar" -c"7cq"')
+  "call assert_equal("  E480: no match\n", out)
+  call assert_equal(8, v:shell_error)
+  let log = filter(readfile(logfile), {idx, val -> val =~ "E480"})
+  call assert_match('E480: No match: foobar', log[0])
+  call delete(logfile)
+
+  let out = system(GetVimCommand() .. ' --clean --log ' .. logfile .. ' -es -X -c "argdelete foobar" -c"0cq"')
+  call assert_equal(0, v:shell_error)
+  let log = filter(readfile(logfile), {idx, val -> val =~ "E480"})
+  call assert_match('E480: No match: foobar', log[0])
+  call delete(logfile)
+
+  " wrap-around
+  let out = system(GetVimCommand() .. ' --clean --log ' .. logfile .. ' -es -X -c "argdelete foobar" -c"255cq"')
+  call assert_equal(0, v:shell_error)
+  let log = filter(readfile(logfile), {idx, val -> val =~ "E480"})
+  call assert_match('E480: No match: foobar', log[0])
+  call delete('Xcq_log.txt')
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Currently, when an error occurs in ex-mode (e.g. -e or -E) and an error occurs, '-0cq' will still abort with an error.

Let's make it possible to return zero even in that case, so that Vim explicitly exits with zero exit code, even if an error occurred.

Add a few tests to verify this.

This also allows to use '&&' in the test_crash test suite.