### PR TITLE
[vim9class] Rework `islocked()` to remove `sync_root` from `get_lval()`

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -4604,16 +4604,12 @@ typedef struct lval_S
 } lval_T;
 
 /**
- * This may be used to specify the base typval that get_lval() uses when
- * following a chain, for example a[idx1][idx2].
- * The lr_sync_root flags signals get_lval that the first time through
- * the indexing loop, skip handling  '.' and '[idx]'.
+ * This specifies optional parameters for get_lval(). Arguments may be NULL.
  */
 typedef struct lval_root_S {
-    typval_T	*lr_tv;
-    class_T	*lr_cl_exec;	// executing class for access checking
-    int		lr_is_arg;
-    int		lr_sync_root;
+    typval_T	*lr_tv;		// Base typval.
+    class_T	*lr_cl_exec;	// Executing class for access checking.
+    int		lr_is_arg;	// name is an arg (not a member).
 } lval_root_T;
 
 // Structure used to save the current state.  Used when executing Normal mode


### PR DESCRIPTION
Reviewing my notes, to summarize the `islocked()` change in https://github.com/vim/vim/pull/13309#issuecomment-1758667554, triggered a deeper insight into the workings of `get_lval()` and typval_T. (Thanks @chrisbra for the nudge) 

This PR simplifies that change; it removes `sync_root` and instead preps the lval_root with the `lr_tv` as needed for a class member. Essentially, `get_lval()` is reverted to before the change.