### PR TITLE
Improve command-line completion docs

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -90,7 +90,7 @@ CTRL-SHIFT-Q	Works just like CTRL-V, unless |modifyOtherKeys| is active,
 		In the GUI the |key-notation| is inserted without simplifying.
 
 							*c_<Left>* *c_Left*
-<Left>		cursor left. See 'wildmenu' for behavior during wildmenu
+<Left>		cursor left.  See 'wildmenu' for behavior during wildmenu
 		completion mode.
 							*c_<Right>* *c_Right*
 <Right>		cursor right.  See 'wildmenu' for behavior during wildmenu

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -90,9 +90,11 @@ CTRL-SHIFT-Q	Works just like CTRL-V, unless |modifyOtherKeys| is active,
 		In the GUI the |key-notation| is inserted without simplifying.
 
 							*c_<Left>* *c_Left*
-<Left>		cursor left
+<Left>		cursor left. See 'wildmenu' for behavior during wildmenu
+		completion mode.
 							*c_<Right>* *c_Right*
-<Right>		cursor right
+<Right>		cursor right.  See 'wildmenu' for behavior during wildmenu
+		completion mode.
 							*c_<S-Left>*
 <S-Left> or <C-Left>					*c_<C-Left>*
 		cursor one WORD left
@@ -102,7 +104,8 @@ CTRL-SHIFT-Q	Works just like CTRL-V, unless |modifyOtherKeys| is active,
 CTRL-B or <Home>				*c_CTRL-B* *c_<Home>* *c_Home*
 		cursor to beginning of command-line
 CTRL-E or <End>					*c_CTRL-E* *c_<End>* *c_End*
-		cursor to end of command-line
+		cursor to end of command-line.  See 'wildmenu' for behavior
+		during wildmenu completion mode.
 
 							*c_<LeftMouse>*
 <LeftMouse>	Move the cursor to the position of the mouse click.
@@ -237,6 +240,7 @@ CTRL-\ e {expr}						*c_CTRL-\_e*
 CTRL-Y		When there is a modeless selection, copy the selection into
 		the clipboard. |modeless-selection|
 		If there is no selection CTRL-Y is inserted as a character.
+		See 'wildmenu' for behavior during wildmenu completion mode.
 
 CTRL-M or CTRL-J		*c_CTRL-M* *c_CTRL-J* *c_<NL>* *c_<CR>* *c_CR*
 <CR> or <NL>	start entered command
@@ -252,12 +256,14 @@ CTRL-C		quit command-line without executing
 
 							*c_<Up>* *c_Up*
 <Up>		recall older command-line from history, whose beginning
-		matches the current command-line (see below).
+		matches the current command-line (see below).  See 'wildmenu'
+		for behavior during wildmenu completion mode.
 		{not available when compiled without the |+cmdline_hist|
 		feature}
 							*c_<Down>* *c_Down*
 <Down>		recall more recent command-line from history, whose beginning
-		matches the current command-line (see below).
+		matches the current command-line (see below).  See 'wildmenu'
+		for behavior during wildmenu completion mode.
 		{not available when compiled without the |+cmdline_hist|
 		feature}
 
@@ -463,10 +469,15 @@ When repeating 'wildchar' or CTRL-N you cycle through the matches, eventually
 ending up back to what was typed.  If the first match is not what you wanted,
 you can use <S-Tab> or CTRL-P to go straight back to what you typed.
 
-The 'wildignorecase' option can be set to ignore case in filenames.
-
 The 'wildmenu' option can be set to show the matches just above the command
 line.
+
+The 'wildoptions' option provides additional configuration to use a popup menu
+for 'wildmenu', and to use fuzzy matching.
+
+The 'wildignorecase' option can be set to ignore case in filenames.  For
+completing other texts (e.g. command names), the 'ignorecase' option is used
+instead (fuzzy matching always ignores case, however).
 
 If you like tcsh's autolist completion, you can use this mapping:
 	:cnoremap X <C-L><C-D>

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1112,6 +1112,22 @@ tag		command		action in Command-line editing mode	~
 |c_<Insert>|	<Insert>	toggle insert/overstrike mode
 |c_<LeftMouse>|	<LeftMouse>	cursor at mouse click
 
+commands in wildmenu mode (see 'wildmenu')
+
+		<Up>		move up to parent / select the previous match
+		<Down>		move down to submenu / select the next match
+		<Left>		select the previous match / move up to parent
+		<Down>		select the next match / move down to submenu
+		<CR>		move into submenu when doing menu completion
+		other		stop completion and insert the typed character
+
+commands in wildmenu mode with 'wildoptions' set to "pum"
+
+		CTRL-E		stop completion and go back to original text
+		CTRL-Y		accept selected match and stop completion
+		<PageUp>	select a match several entries back
+		<PageDown>	select a match several entries forward
+
 ==============================================================================
 5. Terminal-Job mode				*terminal-job-index*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -9336,9 +9336,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			  parent directory or parent menu.
 	<Right>		- in filename/menu name completion: move into a
 			  subdirectory or submenu.
-	<Up>		- select previous match (like CTRL-P)
-	<PageUp>	  Select a match several entries back, but don't insert it.
-	<PageDown>	  Select a match several entries further, but don't insert it.
+	<PageUp>	- Select a match several entries back, but don't insert it.
+	<PageDown>	- Select a match several entries further, but don't insert it.
 	CTRL-E		- end completion, go back to what was there before
 			  selecting a match.
 	CTRL-Y		- accept the currently selected match and stop

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4440,8 +4440,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'ignorecase'* *'ic'* *'noignorecase'* *'noic'*
 'ignorecase' 'ic'	boolean	(default off)
 			global
-	Ignore case in search patterns.  Also used when searching in the tags
-	file.
+	Ignore case in search patterns, |cmdline-completion|, when
+	searching in the tags file, and non-|Vim9| |expr-==|.
 	Also see 'smartcase' and 'tagcase'.
 	Can be overruled by using "\c" or "\C" in the pattern, see
 	|/ignorecase|.
@@ -9314,29 +9314,33 @@ A jump table for the options with a short description can be found at |Q_op|.
 	as needed.
 	The "wildmenu" mode is abandoned when a key is hit that is not used
 	for selecting a completion.
-	While the "wildmenu" is active, not using the popup menu, the
-	following keys have special meanings:
-
-	<Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
-	<Down>		- in filename/menu name completion: move into a
-			  subdirectory or submenu.
+	While the "wildmenu" is active, the following keys have special
+	meanings:
+	CTRL-P		- go to the previous entry
+	CTRL-N		- go to the next entry
 	<CR>		- in menu completion, when the cursor is just after a
 			  dot: move into a submenu.
+
+	When not using the popup menu for command line completion, the
+	following keys have special meanings:
+	<Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
 	<Up>		- in filename/menu name completion: move up into
 			  parent directory or parent menu.
+	<Down>		- in filename/menu name completion: move into a
+			  subdirectory or submenu.
 
 	When using the popup menu for command line completion, the following
 	keys have special meanings:
-	<Down>		- select next match (like CTRL-N)
+	<Up> <Down>	- select previous/next match (like CTRL-P/CTRL-N)
 	<Left>		- in filename/menu name completion: move up into
 			  parent directory or parent menu.
 	<Right>		- in filename/menu name completion: move into a
 			  subdirectory or submenu.
 	<Up>		- select previous match (like CTRL-P)
+	<PageUp>	  Select a match several entries back, but don't insert it.
+	<PageDown>	  Select a match several entries further, but don't insert it.
 	CTRL-E		- end completion, go back to what was there before
 			  selecting a match.
-	CTRL-N		- go to the next entry
-	CTRL-P		- go to the previous entry
 	CTRL-Y		- accept the currently selected match and stop
 			  completion.
 


### PR DESCRIPTION
Add more details about 'ignorecase' and its effect on cmdline completion.

Make sure keys used in wildmenu are properly documented and linked in the keys' documentation entries, and in `:h index` for proper cross-referencing, as wildmenu popup is slightly different from insert-mode popup menu.