### PR TITLE
Don't free non-heap b:changedtick value

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -943,7 +943,7 @@ free_buffer(buf_T *buf)
     free_buffer_stuff(buf, TRUE);
 #ifdef FEAT_EVAL
     // b:changedtick uses an item in buf_T, remove it now
-    dictitem_remove(buf->b_vars, (dictitem_T *)&buf->b_ct_di, "free buffer");
+    dictitem_remove_nofree(buf->b_vars, (dictitem_T *)&buf->b_ct_di, "free buffer");
     unref_var_dict(buf->b_vars);
     remove_listeners(buf);
 #endif

--- a/src/dict.c
+++ b/src/dict.c
@@ -275,6 +275,23 @@ dictitem_remove(dict_T *dict, dictitem_T *item, char *command)
 }
 
 /*
+ * Remove item "item" from Dictionary "dict" but do *not* free it. Only call
+ * this is "item" is managed by the caller to avoid leaks.
+ * "command" is used for the error message when the hashtab if frozen.
+ */
+    void
+dictitem_remove_nofree(dict_T *dict, dictitem_T *item, char *command)
+{
+    hashitem_T	*hi;
+
+    hi = hash_find(&dict->dv_hashtab, item->di_key);
+    if (HASHITEM_EMPTY(hi))
+	internal_error("dictitem_remove()");
+    else
+	hash_remove(&dict->dv_hashtab, hi, command);
+}
+
+/*
  * Free a dict item.  Also clears the value.
  */
     void

--- a/src/proto/dict.pro
+++ b/src/proto/dict.pro
@@ -11,6 +11,7 @@ int dict_free_nonref(int copyID);
 void dict_free_items(int copyID);
 dictitem_T *dictitem_alloc(char_u *key);
 void dictitem_remove(dict_T *dict, dictitem_T *item, char *command);
+void dictitem_remove_nofree(dict_T *dict, dictitem_T *item, char *command);
 void dictitem_free(dictitem_T *item);
 dict_T *dict_copy(dict_T *orig, int deep, int top, int copyID);
 int dict_wrong_func_name(dict_T *d, typval_T *tv, char_u *name);


### PR DESCRIPTION
The b:changedtick value is managed as part of the `file_buffer` buffer structure and not allocated with alloc(). As such, calling vim_free on it is invalid.