### PR TITLE
Update `TextChangedI` to only trigger when on text change in Insert mode

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -174,6 +174,9 @@ edit(
 	return FALSE;
     }
     ins_compl_clear();	    // clear stuff for CTRL-X mode
+    // Reset Changedtick_i, so that TextChangedI will only be triggered for stuff
+    // from insert mode
+    curbuf->b_last_changedtick_i = CHANGEDTICK(curbuf);
 
     /*
      * Trigger InsertEnter autocommands.  Do not do this for "r<CR>" or "grx".
@@ -840,6 +843,7 @@ doESCkey:
 		if (cmdchar != 'r' && cmdchar != 'v' && c != Ctrl_C)
 		    ins_apply_autocmds(EVENT_INSERTLEAVE);
 		did_cursorhold = FALSE;
+		curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
 		return (c == Ctrl_O);
 	    }
 	    continue;

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2566,27 +2566,28 @@ func Test_ChangedP()
   call cursor(3, 1)
   let g:autocmd = ''
   call feedkeys("o\<esc>", 'tnix')
-  call assert_equal('I', g:autocmd)
+  " `TextChangedI` triggers only if text is actually changed in Insert mode
+  call assert_equal('', g:autocmd)
 
   let g:autocmd = ''
   call feedkeys("Sf", 'tnix')
-  call assert_equal('II', g:autocmd)
+  call assert_equal('I', g:autocmd)
 
   let g:autocmd = ''
   call feedkeys("Sf\<C-N>", 'tnix')
-  call assert_equal('IIP', g:autocmd)
+  call assert_equal('IP', g:autocmd)
 
   let g:autocmd = ''
   call feedkeys("Sf\<C-N>\<C-N>", 'tnix')
-  call assert_equal('IIPP', g:autocmd)
+  call assert_equal('IPP', g:autocmd)
 
   let g:autocmd = ''
   call feedkeys("Sf\<C-N>\<C-N>\<C-N>", 'tnix')
-  call assert_equal('IIPPP', g:autocmd)
+  call assert_equal('IPPP', g:autocmd)
 
   let g:autocmd = ''
   call feedkeys("Sf\<C-N>\<C-N>\<C-N>\<C-N>", 'tnix')
-  call assert_equal('IIPPPP', g:autocmd)
+  call assert_equal('IPPPP', g:autocmd)
 
   call assert_equal(['foo', 'bar', 'foobar', 'foo'], getline(1, '$'))
   " TODO: how should it handle completeopt=noinsert,noselect?
@@ -3609,6 +3610,16 @@ func Test_Changed_ChangedI()
   " TODO: Test test does not seem to trigger TextChanged autocommand.
   " call assert_equal('N4', g:autocmd_n)
   call assert_equal('I3', g:autocmd_i)
+
+  " TextChangedI should only trigger if change was done in Insert mode
+  let g:autocmd_i = ''
+  call feedkeys("yypi\<esc>", 'tnix')
+  call assert_equal('', g:autocmd_i)
+
+  " TextChanged should only trigger if change was done in Normal mode
+  let g:autocmd_n = ''
+  call feedkeys("ibar\<esc>", 'tnix')
+  call assert_equal('', g:autocmd_n)
 
   " CleanUp
   call test_override("char_avail", 0)


### PR DESCRIPTION
Problem:  `TextChangedI` can trigger on entering Insert mode if there was previously a change not in Insert mode.
Solution: Make it trigger only when text is actually changed in Insert mode.

Resolves #13265. This is basically a @chrisbra patch with updated tests.