### PR TITLE
bail out if callback function is called recursively

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.0.  Last change: 2023 Aug 15
+*options.txt*	For Vim version 9.0.  Last change: 2023 Oct 14
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -5485,6 +5485,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Increasing this limit above 200 also changes the maximum for Ex
 	command recursion, see |E169|.
 	See also |:function|.
+	Also used for maximum depth of callback functions.
 
 						*'maxmapdepth'* *'mmd'* *E223*
 'maxmapdepth' 'mmd'	number	(default 1000)

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4205,5 +4205,11 @@ func Test_popupwin_with_error()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popup_close_callback_recursive()
+  " this invokes the callback recursively
+  let winid = popup_create('something', #{callback: 'popup_close'})
+  redraw
+  call assert_fails('call popup_close(winid)', 'E169')
+endfunc
 
 " vim: shiftwidth=2 sts=2

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -3577,6 +3577,13 @@ call_callback(
 
     if (callback->cb_name == NULL || *callback->cb_name == NUL)
 	return FAIL;
+
+    if (callback_depth > p_mfd)
+    {
+	emsg(_(e_command_too_recursive));
+	return FAIL;
+    }
+
     CLEAR_FIELD(funcexe);
     funcexe.fe_evaluate = TRUE;
     funcexe.fe_partial = callback->cb_partial;


### PR DESCRIPTION
This checks the 'maxfuncdepth' setting and throws E169 when a callback function recursively calls itself.

closes #13337