### PR TITLE
Use SAFE_() macros for is*() and to*() functions

### DIFF
--- a/runtime/tools/ccfilter.c
+++ b/runtime/tools/ccfilter.c
@@ -249,7 +249,7 @@ int main( int argc, char *argv[] )
 
 	    stay = (echogets(Line2, echo) != NULL);
 	    while ( stay && (Line2[0] == '|') )
-	      { for (p=&Line2[2]; (*p) && (SAFE_isspace(*p)); p++);
+	      { for (p=&Line2[2]; (*p) && (isspace((unsigned char)*p)); p++);
 		strcat( Reason, ": " );
 		strcat( Reason, p );
 		Line2[0] = 0;
@@ -265,7 +265,7 @@ int main( int argc, char *argv[] )
 	    ok	      = 0;
 	    if ( !strncmp(Line, "cfe: ", 5) )
 	      { p = &Line[5];
-		Severity = SAFE_tolower(*p);
+		Severity = tolower((unsigned char)*p);
 		p = strchr( &Line[5], ':' );
 		if (p == NULL)
 		  { ok = 0;
@@ -313,7 +313,7 @@ int main( int argc, char *argv[] )
 	}
        else
 	{
-	  for (p=Reason; (*p) && (SAFE_isspace(*p)); p++);
+	  for (p=Reason; (*p) && (isspace((unsigned char)*p)); p++);
 	  if ( BasePath[CWDlen] == 0 )
 	      printf( "%s:%lu:%lu:%c:%s\n", FileName, Row, Col, Severity, p );
 	  else

--- a/runtime/tools/ccfilter.c
+++ b/runtime/tools/ccfilter.c
@@ -249,7 +249,7 @@ int main( int argc, char *argv[] )
 
 	    stay = (echogets(Line2, echo) != NULL);
 	    while ( stay && (Line2[0] == '|') )
-	      { for (p=&Line2[2]; (*p) && (isspace(*p)); p++);
+	      { for (p=&Line2[2]; (*p) && (SAFE_isspace(*p)); p++);
 		strcat( Reason, ": " );
 		strcat( Reason, p );
 		Line2[0] = 0;
@@ -265,7 +265,7 @@ int main( int argc, char *argv[] )
 	    ok	      = 0;
 	    if ( !strncmp(Line, "cfe: ", 5) )
 	      { p = &Line[5];
-		Severity = tolower(*p);
+		Severity = SAFE_tolower(*p);
 		p = strchr( &Line[5], ':' );
 		if (p == NULL)
 		  { ok = 0;
@@ -313,7 +313,7 @@ int main( int argc, char *argv[] )
 	}
        else
 	{
-	  for (p=Reason; (*p) && (isspace(*p)); p++);
+	  for (p=Reason; (*p) && (SAFE_isspace(*p)); p++);
 	  if ( BasePath[CWDlen] == 0 )
 	      printf( "%s:%lu:%lu:%c:%s\n", FileName, Row, Col, Severity, p );
 	  else

--- a/runtime/tools/xcmdsrv_client.c
+++ b/runtime/tools/xcmdsrv_client.c
@@ -336,7 +336,7 @@ LookupName(
     for (p = regProp; (p - regProp) < numItems; )
     {
 	entry = p;
-	while ((*p != 0) && (!SAFE_isspace(*p)))
+	while ((*p != 0) && (!isspace((unsigned char)*p)))
 	    p++;
 	if ((*p != 0) && (strcasecmp(name, p + 1) == 0))
 	{
@@ -353,7 +353,7 @@ LookupName(
 	for (p = regProp; (p - regProp) < numItems; )
 	{
 	    entry = p;
-	    while ((*p != 0) && (!SAFE_isspace(*p)))
+	    while ((*p != 0) && (!isspace((unsigned char)*p)))
 		p++;
 	    if ((*p != 0) && IsSerialName(p + 1)
 		    && (strncmp(name, p + 1, strlen(name)) == 0))
@@ -574,5 +574,5 @@ IsSerialName(char *str)
 {
     int len = strlen(str);
 
-    return (len > 1 && SAFE_isdigit(str[len - 1]));
+    return (len > 1 && isdigit((unsigned char)str[len - 1]));
 }

--- a/runtime/tools/xcmdsrv_client.c
+++ b/runtime/tools/xcmdsrv_client.c
@@ -336,7 +336,7 @@ LookupName(
     for (p = regProp; (p - regProp) < numItems; )
     {
 	entry = p;
-	while ((*p != 0) && (!isspace(*p)))
+	while ((*p != 0) && (!SAFE_isspace(*p)))
 	    p++;
 	if ((*p != 0) && (strcasecmp(name, p + 1) == 0))
 	{
@@ -353,7 +353,7 @@ LookupName(
 	for (p = regProp; (p - regProp) < numItems; )
 	{
 	    entry = p;
-	    while ((*p != 0) && (!isspace(*p)))
+	    while ((*p != 0) && (!SAFE_isspace(*p)))
 		p++;
 	    if ((*p != 0) && IsSerialName(p + 1)
 		    && (strncmp(name, p + 1, strlen(name)) == 0))
@@ -574,5 +574,5 @@ IsSerialName(char *str)
 {
     int len = strlen(str);
 
-    return (len > 1 && isdigit(str[len - 1]));
+    return (len > 1 && SAFE_isdigit(str[len - 1]));
 }

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4022,7 +4022,7 @@ maketitle(void)
 					buf + off, SPACE_FOR_DIR - off, TRUE);
 #ifdef BACKSLASH_IN_FILENAME
 		// avoid "c:/name" to be reduced to "c"
-		if (isalpha(buf[off]) && buf[off + 1] == ':')
+		if (SAFE_isalpha(buf[off]) && buf[off + 1] == ':')
 		    off += 2;
 #endif
 		// remove the file name
@@ -5671,7 +5671,7 @@ chk_modeline(
 			&& (s[0] != 'V'
 				  || STRNCMP(skipwhite(e + 1), "set", 3) == 0)
 			&& (s[3] == ':'
-			    || (VIM_VERSION_100 >= vers && isdigit(s[3]))
+			    || (VIM_VERSION_100 >= vers && SAFE_isdigit(s[3]))
 			    || (VIM_VERSION_100 < vers && s[3] == '<')
 			    || (VIM_VERSION_100 > vers && s[3] == '>')
 			    || (VIM_VERSION_100 == vers && s[3] == '=')))

--- a/src/charset.c
+++ b/src/charset.c
@@ -1958,7 +1958,7 @@ vim_islower(int c)
 	if (enc_latin1like)
 	    return (latin1flags[c] & LATIN1LOWER) == LATIN1LOWER;
     }
-    return islower(c);
+    return SAFE_islower(c);
 }
 
     int
@@ -1982,7 +1982,7 @@ vim_isupper(int c)
 	if (enc_latin1like)
 	    return (latin1flags[c] & LATIN1UPPER) == LATIN1UPPER;
     }
-    return isupper(c);
+    return SAFE_isupper(c);
 }
 
     int

--- a/src/cmdhist.c
+++ b/src/cmdhist.c
@@ -674,7 +674,7 @@ remove_key_from_history(void)
 	return;
 
     for ( ; *p; ++p)
-	if (STRNCMP(p, "key", 3) == 0 && !isalpha(p[3]))
+	if (STRNCMP(p, "key", 3) == 0 && !SAFE_isalpha(p[3]))
 	{
 	    p = vim_strchr(p + 3, '=');
 	    if (p == NULL)

--- a/src/diff.c
+++ b/src/diff.c
@@ -1712,7 +1712,7 @@ diff_read(
 		// --- file1       2018-03-20 13:23:35.783153140 +0100
 		// +++ file2       2018-03-20 13:23:41.183156066 +0100
 		// @@ -1,3 +1,5 @@
-		if (isdigit(*line))
+		if (SAFE_isdigit(*line))
 		    diffstyle = DIFF_ED;
 		else if ((STRNCMP(line, "@@ ", 3) == 0))
 		    diffstyle = DIFF_UNIFIED;
@@ -1730,7 +1730,7 @@ diff_read(
 
 	    if (diffstyle == DIFF_ED)
 	    {
-		if (!isdigit(*line))
+		if (!SAFE_isdigit(*line))
 		    continue;	// not the start of a diff block
 		if (parse_diff_ed(line, hunk) == FAIL)
 		    continue;

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -2760,7 +2760,7 @@ main(int argc, char **argv)
 	    rewind(stdin);
 	    if (scanf("%99s", buf) == 1)
 	    {
-		if (SAFE_isdigit(buf[0]))
+		if (isdigit((unsigned char)buf[0]))
 		{
 		    // Change a choice.
 		    i = atoi(buf);

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -2760,7 +2760,7 @@ main(int argc, char **argv)
 	    rewind(stdin);
 	    if (scanf("%99s", buf) == 1)
 	    {
-		if (isdigit(buf[0]))
+		if (SAFE_isdigit(buf[0]))
 		{
 		    // Change a choice.
 		    i = atoi(buf);

--- a/src/edit.c
+++ b/src/edit.c
@@ -5318,7 +5318,7 @@ ins_ctrl_ey(int tc)
 	    // was typed after a CTRL-V, and pretend 'textwidth'
 	    // wasn't set.  Digits, 'o' and 'x' are special after a
 	    // CTRL-V, don't use it for these.
-	    if (c < 256 && !isalnum(c))
+	    if (c < 256 && !SAFE_isalnum(c))
 		AppendToRedobuff((char_u *)CTRL_V_STR);	// CTRL-V
 	    tw_save = curbuf->b_p_tw;
 	    curbuf->b_p_tw = -1;

--- a/src/eval.c
+++ b/src/eval.c
@@ -4257,7 +4257,7 @@ eval9(
 	return FAIL;
     end_leader = *arg;
 
-    if (**arg == '.' && (!isdigit(*(*arg + 1)) || in_old_script(2)))
+    if (**arg == '.' && (!SAFE_isdigit(*(*arg + 1)) || in_old_script(2)))
     {
 	semsg(_(e_invalid_expression_str), *arg);
 	++*arg;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6665,7 +6665,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 				     && has_patch(atoi(end + 3))))));
 		}
 	    }
-	    else if (isdigit(name[5]))
+	    else if (SAFE_isdigit(name[5]))
 		n = has_patch(atoi((char *)name + 5));
 	}
 	else if (STRICMP(name, "vim_starting") == 0)

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -3306,7 +3306,7 @@ find_var(char_u *name, hashtab_T **htp, int no_autoload)
     dictitem_T *
 find_var_also_in_script(char_u *name, hashtab_T **htp, int no_autoload)
 {
-    if (STRNCMP(name, "<SNR>", 5) == 0 && isdigit(name[5]))
+    if (STRNCMP(name, "<SNR>", 5) == 0 && SAFE_isdigit(name[5]))
     {
 	char_u	    *p = name + 5;
 	int	    sid = getdigits(&p);
@@ -4946,7 +4946,7 @@ get_callback(typval_T *arg)
     else
     {
 	if (arg->v_type == VAR_STRING && arg->vval.v_string != NULL
-					       && isdigit(*arg->vval.v_string))
+					       && SAFE_isdigit(*arg->vval.v_string))
 	    r = FAIL;
 	else if (arg->v_type == VAR_FUNC || arg->v_type == VAR_STRING)
 	{

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3707,7 +3707,7 @@ skip_substitute(char_u *start, int delimiter)
     static int
 check_regexp_delim(int c)
 {
-    if (isalpha(c))
+    if (SAFE_isalpha(c))
     {
 	emsg(_(e_regular_expressions_cant_be_delimited_by_letters));
 	return FAIL;

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7995,7 +7995,7 @@ ex_winsize(exarg_T *eap)
     char_u	*arg = eap->arg;
     char_u	*p;
 
-    if (!isdigit(*arg))
+    if (!SAFE_isdigit(*arg))
     {
 	semsg(_(e_invalid_argument_str), arg);
 	return;
@@ -8386,7 +8386,7 @@ ex_later(exarg_T *eap)
 
     if (*p == NUL)
 	count = 1;
-    else if (isdigit(*p))
+    else if (SAFE_isdigit(*p))
     {
 	count = getdigits(&p);
 	switch (*p)
@@ -8489,7 +8489,7 @@ ex_redir(exarg_T *eap)
 			arg++;
 		    // Make register empty when not using @A-@Z and the
 		    // command is valid.
-		    if (*arg == NUL && !isupper(redir_reg))
+		    if (*arg == NUL && !SAFE_isupper(redir_reg))
 			write_reg_contents(redir_reg, (char_u *)"", -1, FALSE);
 		}
 	    }

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -2953,7 +2953,7 @@ get_past_head(char_u *path)
 
 #if defined(MSWIN)
     // may skip "c:"
-    if (isalpha(path[0]) && path[1] == ':')
+    if (SAFE_isalpha(path[0]) && path[1] == ':')
 	retval = path + 2;
     else
 	retval = path;

--- a/src/findfile.c
+++ b/src/findfile.c
@@ -1847,7 +1847,7 @@ grab_file_name(long count, linenr_T *file_lnum)
 	if (get_visual_text(NULL, &ptr, &len) == FAIL)
 	    return NULL;
 	// Only recognize ":123" here
-	if (file_lnum != NULL && ptr[len] == ':' && isdigit(ptr[len + 1]))
+	if (file_lnum != NULL && ptr[len] == ':' && SAFE_isdigit(ptr[len + 1]))
 	{
 	    char_u *p = ptr + len + 1;
 
@@ -1981,10 +1981,10 @@ file_name_in_line(
 	    p = skipwhite(p);
 	if (*p != NUL)
 	{
-	    if (!isdigit(*p))
+	    if (!SAFE_isdigit(*p))
 		++p;		    // skip the separator
 	    p = skipwhite(p);
-	    if (isdigit(*p))
+	    if (SAFE_isdigit(*p))
 		*file_lnum = (int)getdigits(&p);
 	}
     }

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -870,7 +870,7 @@ start_redo(long count, int old_redo)
 	{
 	    c = read_redo(FALSE, old_redo);
 	    add_char_buff(&readbuf2, c);
-	    if (!isdigit(c))
+	    if (!SAFE_isdigit(c))
 		break;
 	}
 	c = read_redo(FALSE, old_redo);
@@ -1873,7 +1873,7 @@ vgetc(void)
 
 		    // Handle <SID>{sid};  Do up to 20 digits for safety.
 		    last_used_sid = 0;
-		    for (j = 0; j < 20 && isdigit(c = vgetorpeek(TRUE)); ++j)
+		    for (j = 0; j < 20 && SAFE_isdigit(c = vgetorpeek(TRUE)); ++j)
 			last_used_sid = last_used_sid * 10 + (c - '0');
 		    last_used_map = NULL;
 		    continue;

--- a/src/gui.c
+++ b/src/gui.c
@@ -5030,7 +5030,7 @@ display_errors(void)
 
     // avoid putting up a message box with blanks only
     for (p = (char_u *)error_ga.ga_data; *p != NUL; ++p)
-	if (!isspace(*p))
+	if (!SAFE_isspace(*p))
 	{
 	    // Truncate a very long message, it will go off-screen.
 	    if (STRLEN(p) > 2000)

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -4031,17 +4031,6 @@ gui_mch_mousehide(int hide)
     //	TODO
 }
 
-    static int
-hex_digit(int c)
-{
-    if (isdigit(c))
-	return c - '0';
-    c = TOLOWER_ASC(c);
-    if (c >= 'a' && c <= 'f')
-	return c - 'a' + 10;
-    return -1000;
-}
-
 /*
  * This function has been lifted from gui_w32.c and extended a bit.
  *

--- a/src/gui_photon.c
+++ b/src/gui_photon.c
@@ -977,7 +977,7 @@ gui_ph_is_buffer_item(vimmenu_T *menu, vimmenu_T *parent)
 	if (mark != NULL)
 	{
 	    mark++;
-	    while (isdigit(*mark))
+	    while (SAFE_isdigit(*mark))
 		mark++;
 
 	    if (*mark == ')')
@@ -2545,7 +2545,7 @@ gui_mch_add_menu(vimmenu_T *menu, int index)
 
 	    if (menu->mnemonic != 0)
 	    {
-		PtAddHotkeyHandler(gui.vimWindow, tolower(menu->mnemonic),
+		PtAddHotkeyHandler(gui.vimWindow, SAFE_tolower(menu->mnemonic),
 			Pk_KM_Alt, 0, menu, gui_ph_handle_pulldown_menu);
 	    }
 	}
@@ -2829,7 +2829,7 @@ gui_ph_parse_font_name(
 	{
 	    while (*mark != NUL && *mark++ == ':')
 	    {
-		switch (tolower(*mark++))
+		switch (SAFE_tolower(*mark++))
 		{
 		    case 'a': *font_flags |= PF_STYLE_ANTIALIAS; break;
 		    case 'b': *font_flags |= PF_STYLE_BOLD; break;

--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -1471,7 +1471,7 @@ xim_real_init(Window x11_window, Display *x11_display)
 		break;
 	    if ((ns = end = strchr(s, ',')) == NULL)
 		end = s + strlen(s);
-	    while (isspace(((char_u *)end)[-1]))
+	    while (SAFE_isspace(((char_u *)end)[-1]))
 		end--;
 	    *end = NUL;
 
@@ -1533,7 +1533,7 @@ xim_real_init(Window x11_window, Display *x11_display)
     strcpy(tmp, gui.rsrc_preedit_type_name);
     for (s = tmp; s && !found; )
     {
-	while (*s && isspace((unsigned char)*s))
+	while (*s && SAFE_isspace((unsigned char)*s))
 	    s++;
 	if (!*s)
 	    break;
@@ -1541,7 +1541,7 @@ xim_real_init(Window x11_window, Display *x11_display)
 	    ns++;
 	else
 	    end = s + strlen(s);
-	while (isspace((unsigned char)*end))
+	while (SAFE_isspace((unsigned char)*end))
 	    end--;
 	*end = '\0';
 

--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -1471,7 +1471,7 @@ xim_real_init(Window x11_window, Display *x11_display)
 		break;
 	    if ((ns = end = strchr(s, ',')) == NULL)
 		end = s + strlen(s);
-	    while (SAFE_isspace(((char_u *)end)[-1]))
+	    while (SAFE_isspace(end[-1]))
 		end--;
 	    *end = NUL;
 
@@ -1533,7 +1533,7 @@ xim_real_init(Window x11_window, Display *x11_display)
     strcpy(tmp, gui.rsrc_preedit_type_name);
     for (s = tmp; s && !found; )
     {
-	while (*s && SAFE_isspace((unsigned char)*s))
+	while (*s && SAFE_isspace(*s))
 	    s++;
 	if (!*s)
 	    break;
@@ -1541,7 +1541,7 @@ xim_real_init(Window x11_window, Display *x11_display)
 	    ns++;
 	else
 	    end = s + strlen(s);
-	while (SAFE_isspace((unsigned char)*end))
+	while (SAFE_isspace(*end))
 	    end--;
 	*end = '\0';
 

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -1745,7 +1745,7 @@ prt_resfile_skip_nonws(int offset)
     idx = prt_resfile.line_start + offset;
     while (idx < prt_resfile.line_end)
     {
-	if (isspace(prt_resfile.buffer[idx]))
+	if (SAFE_isspace(prt_resfile.buffer[idx]))
 	    return idx - prt_resfile.line_start;
 	idx++;
     }
@@ -1760,7 +1760,7 @@ prt_resfile_skip_ws(int offset)
     idx = prt_resfile.line_start + offset;
     while (idx < prt_resfile.line_end)
     {
-	if (!isspace(prt_resfile.buffer[idx]))
+	if (!SAFE_isspace(prt_resfile.buffer[idx]))
 	    return idx - prt_resfile.line_start;
 	idx++;
     }

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -2307,7 +2307,7 @@ gui_adjust_rgb(guicolor_T c)
     static int
 hex_digit(int c)
 {
-    if (isdigit(c))
+    if (SAFE_isdigit(c))
 	return c - '0';
     c = TOLOWER_ASC(c);
     if (c >= 'a' && c <= 'f')

--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -3240,7 +3240,7 @@ FunctionNew(PyTypeObject *subtype, char_u *name, int argc, typval_T *argv,
     if (self == NULL)
 	return NULL;
 
-    if (SAFE_isdigit(*name))
+    if (isdigit((unsigned char)*name))
     {
 	if (!translated_function_exists(name, FALSE))
 	{

--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -3240,7 +3240,7 @@ FunctionNew(PyTypeObject *subtype, char_u *name, int argc, typval_T *argv,
     if (self == NULL)
 	return NULL;
 
-    if (isdigit(*name))
+    if (SAFE_isdigit(*name))
     {
 	if (!translated_function_exists(name, FALSE))
 	{

--- a/src/if_xcmdsrv.c
+++ b/src/if_xcmdsrv.c
@@ -657,7 +657,7 @@ serverGetVimNames(Display *dpy)
     for (p = regProp; (long_u)(p - regProp) < numItems; p++)
     {
 	entry = p;
-	while (*p != 0 && !isspace(*p))
+	while (*p != 0 && !SAFE_isspace(*p))
 	    p++;
 	if (*p != 0)
 	{
@@ -928,7 +928,7 @@ LookupName(
     for (p = regProp; (long_u)(p - regProp) < numItems; )
     {
 	entry = p;
-	while (*p != 0 && !isspace(*p))
+	while (*p != 0 && !SAFE_isspace(*p))
 	    p++;
 	if (*p != 0 && STRICMP(name, p + 1) == 0)
 	{
@@ -945,7 +945,7 @@ LookupName(
 	for (p = regProp; (long_u)(p - regProp) < numItems; )
 	{
 	    entry = p;
-	    while (*p != 0 && !isspace(*p))
+	    while (*p != 0 && !SAFE_isspace(*p))
 		p++;
 	    if (*p != 0 && IsSerialName(p + 1)
 		    && STRNICMP(name, p + 1, STRLEN(name)) == 0)

--- a/src/iscygpty.c
+++ b/src/iscygpty.c
@@ -147,7 +147,7 @@ int is_cygpty(int fd)
 			p = NULL;
 		}
 		if (p != NULL) {
-			while (*p && SAFE_isxdigit(*p))	// Skip 16-digit hexadecimal.
+			while (*p && isxdigit((unsigned char)*p))	// Skip 16-digit hexadecimal.
 				++p;
 			if (is_wprefix(p, L"-pty")) {
 				p += 4;
@@ -156,7 +156,7 @@ int is_cygpty(int fd)
 			}
 		}
 		if (p != NULL) {
-			while (*p && SAFE_isdigit(*p))	// Skip pty number.
+			while (*p && isdigit((unsigned char)*p))	// Skip pty number.
 				++p;
 			if (is_wprefix(p, L"-from-master")) {
 				//p += 12;

--- a/src/iscygpty.c
+++ b/src/iscygpty.c
@@ -147,7 +147,7 @@ int is_cygpty(int fd)
 			p = NULL;
 		}
 		if (p != NULL) {
-			while (*p && isxdigit(*p))	// Skip 16-digit hexadecimal.
+			while (*p && SAFE_isxdigit(*p))	// Skip 16-digit hexadecimal.
 				++p;
 			if (is_wprefix(p, L"-pty")) {
 				p += 4;
@@ -156,7 +156,7 @@ int is_cygpty(int fd)
 			}
 		}
 		if (p != NULL) {
-			while (*p && isdigit(*p))	// Skip pty number.
+			while (*p && SAFE_isdigit(*p))	// Skip pty number.
 				++p;
 			if (is_wprefix(p, L"-from-master")) {
 				//p += 12;

--- a/src/macros.h
+++ b/src/macros.h
@@ -50,6 +50,28 @@
  */
 #define BUFEMPTY() (curbuf->b_ml.ml_line_count == 1 && *ml_get((linenr_T)1) == NUL)
 
+// The is*() and to*() functions declared in <ctype.h> have
+// undefined behavior for values other than EOF outside the range of
+// unsigned char.  If plain char is signed, a call with a negative
+// value has undefined behavior.  These macros cast the argument to
+// unsigned char.  (Most implementations behave more or less sanely
+// with negative values, and most character values in practice are
+// positive, but we want to avoid undefined behavior anyway.)
+#define SAFE_isalnum(c)  (isalnum ((unsigned char)(c)))
+#define SAFE_isalpha(c)  (isalpha ((unsigned char)(c)))
+#define SAFE_isblank(c)  (isblank ((unsigned char)(c)))
+#define SAFE_iscntrl(c)  (iscntrl ((unsigned char)(c)))
+#define SAFE_isdigit(c)  (isdigit ((unsigned char)(c)))
+#define SAFE_isgraph(c)  (isgraph ((unsigned char)(c)))
+#define SAFE_islower(c)  (islower ((unsigned char)(c)))
+#define SAFE_isprint(c)  (isprint ((unsigned char)(c)))
+#define SAFE_ispunct(c)  (ispunct ((unsigned char)(c)))
+#define SAFE_isspace(c)  (isspace ((unsigned char)(c)))
+#define SAFE_isupper(c)  (isupper ((unsigned char)(c)))
+#define SAFE_isxdigit(c) (isxdigit((unsigned char)(c)))
+#define SAFE_tolower(c)  (tolower ((unsigned char)(c)))
+#define SAFE_toupper(c)  (toupper ((unsigned char)(c)))
+
 /*
  * toupper() and tolower() that use the current locale.
  * On some systems toupper()/tolower() only work on lower/uppercase
@@ -90,28 +112,6 @@
 // non-zero for superscript 1.  Also avoids that isdigit() crashes for numbers
 // below 0 and above 255.
 #define VIM_ISDIGIT(c) ((unsigned)(c) - '0' < 10)
-
-// The is*() and to*() functions declared in <ctype.h> have
-// undefined behavior for values other than EOF outside the range of
-// unsigned char.  If plain char is signed, a call with a negative
-// value has undefined behavior.  These macros cast the argument to
-// unsigned char.  (Most implementations behave more or less sanely
-// with negative values, and most character values in practice are
-// positive, but we want to avoid undefined behavior anyway.)
-#define SAFE_isalnum(c)  (isalnum ((unsigned char)(c)))
-#define SAFE_isalpha(c)  (isalpha ((unsigned char)(c)))
-#define SAFE_isblank(c)  (isblank ((unsigned char)(c)))
-#define SAFE_iscntrl(c)  (iscntrl ((unsigned char)(c)))
-#define SAFE_isdigit(c)  (isdigit ((unsigned char)(c)))
-#define SAFE_isgraph(c)  (isgraph ((unsigned char)(c)))
-#define SAFE_islower(c)  (islower ((unsigned char)(c)))
-#define SAFE_isprint(c)  (isprint ((unsigned char)(c)))
-#define SAFE_ispunct(c)  (ispunct ((unsigned char)(c)))
-#define SAFE_isspace(c)  (isspace ((unsigned char)(c)))
-#define SAFE_isupper(c)  (isupper ((unsigned char)(c)))
-#define SAFE_isxdigit(c) (isxdigit((unsigned char)(c)))
-#define SAFE_tolower(c)  (tolower ((unsigned char)(c)))
-#define SAFE_toupper(c)  (toupper ((unsigned char)(c)))
 
 // Like isalpha() but reject non-ASCII characters.  Can't be used with a
 // special key (negative value).

--- a/src/macros.h
+++ b/src/macros.h
@@ -64,11 +64,11 @@
 #  define TOLOWER_LOC(c)	tolower_tab[(c) & 255]
 #else
 # ifdef BROKEN_TOUPPER
-#  define TOUPPER_LOC(c)	(islower(c) ? toupper(c) : (c))
-#  define TOLOWER_LOC(c)	(isupper(c) ? tolower(c) : (c))
+#  define TOUPPER_LOC(c)	(SAFE_islower(c) ? SAFE_toupper(c) : (c))
+#  define TOLOWER_LOC(c)	(SAFE_isupper(c) ? SAFE_tolower(c) : (c))
 # else
-#  define TOUPPER_LOC		toupper
-#  define TOLOWER_LOC		tolower
+#  define TOUPPER_LOC		SAFE_toupper
+#  define TOLOWER_LOC		SAFE_tolower
 # endif
 #endif
 
@@ -90,6 +90,28 @@
 // non-zero for superscript 1.  Also avoids that isdigit() crashes for numbers
 // below 0 and above 255.
 #define VIM_ISDIGIT(c) ((unsigned)(c) - '0' < 10)
+
+// The is*() and to*() functions declared in <ctype.h> have
+// undefined behavior for values other than EOF outside the range of
+// unsigned char.  If plain char is signed, a call with a negative
+// value has undefined behavior.  These macros cast the argument to
+// unsigned char.  (Most implementations behave more or less sanely
+// with negative values, and most character values in practice are
+// positive, but we want to avoid undefined behavior anyway.)
+#define SAFE_isalnum(c)  (isalnum ((unsigned char)(c)))
+#define SAFE_isalpha(c)  (isalpha ((unsigned char)(c)))
+#define SAFE_isblank(c)  (isblank ((unsigned char)(c)))
+#define SAFE_iscntrl(c)  (iscntrl ((unsigned char)(c)))
+#define SAFE_isdigit(c)  (isdigit ((unsigned char)(c)))
+#define SAFE_isgraph(c)  (isgraph ((unsigned char)(c)))
+#define SAFE_islower(c)  (islower ((unsigned char)(c)))
+#define SAFE_isprint(c)  (isprint ((unsigned char)(c)))
+#define SAFE_ispunct(c)  (ispunct ((unsigned char)(c)))
+#define SAFE_isspace(c)  (isspace ((unsigned char)(c)))
+#define SAFE_isupper(c)  (isupper ((unsigned char)(c)))
+#define SAFE_isxdigit(c) (isxdigit((unsigned char)(c)))
+#define SAFE_tolower(c)  (tolower ((unsigned char)(c)))
+#define SAFE_toupper(c)  (toupper ((unsigned char)(c)))
 
 // Like isalpha() but reject non-ASCII characters.  Can't be used with a
 // special key (negative value).

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4628,7 +4628,7 @@ enc_canonize(char_u *enc)
     }
 
     // "iso-8859n" -> "iso-8859-n"
-    if (STRNCMP(p, "iso-8859", 8) == 0 && isdigit(p[8]))
+    if (STRNCMP(p, "iso-8859", 8) == 0 && SAFE_isdigit(p[8]))
     {
 	STRMOVE(p + 9, p + 8);
 	p[8] = '-';
@@ -4705,7 +4705,7 @@ enc_locale_env(char *locale)
     if ((p = (char *)vim_strchr((char_u *)s, '.')) != NULL)
     {
 	if (p > s + 2 && STRNICMP(p + 1, "EUC", 3) == 0
-			&& !isalnum((int)p[4]) && p[4] != '-' && p[-3] == '_')
+			&& !SAFE_isalnum((int)p[4]) && p[4] != '-' && p[-3] == '_')
 	{
 	    // copy "XY.EUC" to "euc-XY" to buf[10]
 	    STRCPY(buf + 10, "euc-");
@@ -4721,7 +4721,7 @@ enc_locale_env(char *locale)
     {
 	if (s[i] == '_' || s[i] == '-')
 	    buf[i] = '-';
-	else if (isalnum((int)s[i]))
+	else if (SAFE_isalnum(s[i]))
 	    buf[i] = TOLOWER_ASC(s[i]);
 	else
 	    break;

--- a/src/normal.c
+++ b/src/normal.c
@@ -4464,11 +4464,11 @@ nv_brackets(cmdarg_T *cap)
 		return;
 
 	    find_pattern_in_path(ptr, 0, len, TRUE,
-		cap->count0 == 0 ? !isupper(cap->nchar) : FALSE,
+		cap->count0 == 0 ? !SAFE_isupper(cap->nchar) : FALSE,
 		((cap->nchar & 0xf) == ('d' & 0xf)) ?  FIND_DEFINE : FIND_ANY,
 		cap->count1,
-		isupper(cap->nchar) ? ACTION_SHOW_ALL :
-			    islower(cap->nchar) ? ACTION_SHOW : ACTION_GOTO,
+		SAFE_isupper(cap->nchar) ? ACTION_SHOW_ALL :
+			    SAFE_islower(cap->nchar) ? ACTION_SHOW : ACTION_GOTO,
 		cap->cmdchar == ']' ? curwin->w_cursor.lnum + 1 : (linenr_T)1,
 		(linenr_T)MAXLNUM);
 	    vim_free(ptr);
@@ -5211,7 +5211,7 @@ v_visop(cmdarg_T *cap)
 
     // Uppercase means linewise, except in block mode, then "D" deletes till
     // the end of the line, and "C" replaces till EOL
-    if (isupper(cap->cmdchar))
+    if (SAFE_isupper(cap->cmdchar))
     {
 	if (VIsual_mode != Ctrl_V)
 	{

--- a/src/ops.c
+++ b/src/ops.c
@@ -2734,7 +2734,7 @@ do_addsub(
 	{
 	    if (CharOrd(firstdigit) < Prenum1)
 	    {
-		if (isupper(firstdigit))
+		if (SAFE_isupper(firstdigit))
 		    firstdigit = 'A';
 		else
 		    firstdigit = 'a';
@@ -2746,7 +2746,7 @@ do_addsub(
 	{
 	    if (26 - CharOrd(firstdigit) - 1 < Prenum1)
 	    {
-		if (isupper(firstdigit))
+		if (SAFE_isupper(firstdigit))
 		    firstdigit = 'Z';
 		else
 		    firstdigit = 'z';
@@ -2875,9 +2875,9 @@ do_addsub(
 	save_pos = curwin->w_cursor;
 	for (i = 0; i < todel; ++i)
 	{
-	    if (c < 0x100 && isalpha(c))
+	    if (c < 0x100 && SAFE_isalpha(c))
 	    {
-		if (isupper(c))
+		if (SAFE_isupper(c))
 		    hexupper = TRUE;
 		else
 		    hexupper = FALSE;

--- a/src/option.c
+++ b/src/option.c
@@ -7680,7 +7680,7 @@ ExpandSettings(
 	{
 	    for (opt_idx = 0; (str = get_termcode(opt_idx)) != NULL; opt_idx++)
 	    {
-		if (!isprint(str[0]) || !isprint(str[1]))
+		if (!SAFE_isprint(str[0]) || !SAFE_isprint(str[1]))
 		    continue;
 
 		name_buf[0] = 't';

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -675,7 +675,7 @@ display_errors(void)
 	{
 	    // avoid putting up a message box with blanks only
 	    for (p = (char_u *)error_ga.ga_data; *p; ++p)
-		if (!isspace(*p))
+		if (!SAFE_isspace(*p))
 		{
 		    // Only use a dialog when not using --gui-dialog-file:
 		    // write text to a file.
@@ -759,7 +759,7 @@ mch_chdir(char *path)
 	smsg("chdir(%s)", path);
 	verbose_leave();
     }
-    if (isalpha(path[0]) && path[1] == ':')	// has a drive name
+    if (SAFE_isalpha(path[0]) && path[1] == ':')	// has a drive name
     {
 	// If we can change to the drive, skip that part of the path.  If we
 	// can't then the current directory may be invalid, try using chdir()
@@ -1751,7 +1751,7 @@ is_reparse_point_included(LPCWSTR fname)
     WCHAR	buf[MAX_PATH];
     DWORD	attr;
 
-    if (isalpha(p[0]) && p[1] == L':' && is_path_sep(p[2]))
+    if (SAFE_isalpha(p[0]) && p[1] == L':' && is_path_sep(p[2]))
 	p += 3;
     else if (is_path_sep(p[0]) && is_path_sep(p[1]))
 	p += 2;

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -6166,7 +6166,7 @@ mch_signal_job(job_T *job, char_u *how)
     else if (STRCMP(how, "winch") == 0)
 	sig = SIGWINCH;
 #endif
-    else if (isdigit(*how))
+    else if (SAFE_isdigit(*how))
 	sig = atoi((char *)how);
     else
 	return FAIL;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7440,7 +7440,7 @@ notsgr:
 	{
 	    int l = 2;
 
-	    if (isdigit(s[l]))
+	    if (SAFE_isdigit(s[l]))
 		l++;
 	    if (s[l] == ' ' && s[l + 1] == 'q')
 	    {

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -1874,12 +1874,12 @@ collection:
 				break;
 			    case CLASS_ALNUM:
 				for (cu = 1; cu < 128; cu++)
-				    if (SAFE_isalnum(cu))
+				    if (isalnum(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_ALPHA:
 				for (cu = 1; cu < 128; cu++)
-				    if (SAFE_isalpha(cu))
+				    if (isalpha(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_BLANK:
@@ -1888,7 +1888,7 @@ collection:
 				break;
 			    case CLASS_CNTRL:
 				for (cu = 1; cu <= 127; cu++)
-				    if (SAFE_iscntrl(cu))
+				    if (iscntrl(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_DIGIT:
@@ -1898,7 +1898,7 @@ collection:
 				break;
 			    case CLASS_GRAPH:
 				for (cu = 1; cu <= 127; cu++)
-				    if (SAFE_isgraph(cu))
+				    if (isgraph(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_LOWER:
@@ -1914,7 +1914,7 @@ collection:
 				break;
 			    case CLASS_PUNCT:
 				for (cu = 1; cu < 128; cu++)
-				    if (SAFE_ispunct(cu))
+				    if (ispunct(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_SPACE:

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -1874,12 +1874,12 @@ collection:
 				break;
 			    case CLASS_ALNUM:
 				for (cu = 1; cu < 128; cu++)
-				    if (isalnum(cu))
+				    if (SAFE_isalnum(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_ALPHA:
 				for (cu = 1; cu < 128; cu++)
-				    if (isalpha(cu))
+				    if (SAFE_isalpha(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_BLANK:
@@ -1888,7 +1888,7 @@ collection:
 				break;
 			    case CLASS_CNTRL:
 				for (cu = 1; cu <= 127; cu++)
-				    if (iscntrl(cu))
+				    if (SAFE_iscntrl(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_DIGIT:
@@ -1898,7 +1898,7 @@ collection:
 				break;
 			    case CLASS_GRAPH:
 				for (cu = 1; cu <= 127; cu++)
-				    if (isgraph(cu))
+				    if (SAFE_isgraph(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_LOWER:
@@ -1914,7 +1914,7 @@ collection:
 				break;
 			    case CLASS_PUNCT:
 				for (cu = 1; cu < 128; cu++)
-				    if (ispunct(cu))
+				    if (SAFE_ispunct(cu))
 					regmbc(cu);
 				break;
 			    case CLASS_SPACE:

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -5041,11 +5041,11 @@ check_char_class(int class, int c)
     switch (class)
     {
 	case NFA_CLASS_ALNUM:
-	    if (SAFE_isalnum(c))
+	    if (c >= 1 && c < 128 && isalnum(c))
 		return OK;
 	    break;
 	case NFA_CLASS_ALPHA:
-	    if (SAFE_isalpha(c))
+	    if (c >= 1 && c < 128 && isalpha(c))
 		return OK;
 	    break;
 	case NFA_CLASS_BLANK:
@@ -5053,7 +5053,7 @@ check_char_class(int class, int c)
 		return OK;
 	    break;
 	case NFA_CLASS_CNTRL:
-	    if (SAFE_iscntrl(c))
+	    if (c >= 1 && c <= 127 && iscntrl(c))
 		return OK;
 	    break;
 	case NFA_CLASS_DIGIT:
@@ -5061,7 +5061,7 @@ check_char_class(int class, int c)
 		return OK;
 	    break;
 	case NFA_CLASS_GRAPH:
-	    if (SAFE_isgraph(c))
+	    if (c >= 1 && c <= 127 && isgraph(c))
 		return OK;
 	    break;
 	case NFA_CLASS_LOWER:
@@ -5073,7 +5073,7 @@ check_char_class(int class, int c)
 		return OK;
 	    break;
 	case NFA_CLASS_PUNCT:
-	    if (SAFE_ispunct(c))
+	    if (c >= 1 && c < 128 && ispunct(c))
 		return OK;
 	    break;
 	case NFA_CLASS_SPACE:

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -5041,11 +5041,11 @@ check_char_class(int class, int c)
     switch (class)
     {
 	case NFA_CLASS_ALNUM:
-	    if (c >= 1 && c < 128 && isalnum(c))
+	    if (SAFE_isalnum(c))
 		return OK;
 	    break;
 	case NFA_CLASS_ALPHA:
-	    if (c >= 1 && c < 128 && isalpha(c))
+	    if (SAFE_isalpha(c))
 		return OK;
 	    break;
 	case NFA_CLASS_BLANK:
@@ -5053,7 +5053,7 @@ check_char_class(int class, int c)
 		return OK;
 	    break;
 	case NFA_CLASS_CNTRL:
-	    if (c >= 1 && c <= 127 && iscntrl(c))
+	    if (SAFE_iscntrl(c))
 		return OK;
 	    break;
 	case NFA_CLASS_DIGIT:
@@ -5061,7 +5061,7 @@ check_char_class(int class, int c)
 		return OK;
 	    break;
 	case NFA_CLASS_GRAPH:
-	    if (c >= 1 && c <= 127 && isgraph(c))
+	    if (SAFE_isgraph(c))
 		return OK;
 	    break;
 	case NFA_CLASS_LOWER:
@@ -5073,7 +5073,7 @@ check_char_class(int class, int c)
 		return OK;
 	    break;
 	case NFA_CLASS_PUNCT:
-	    if (c >= 1 && c < 128 && ispunct(c))
+	    if (SAFE_ispunct(c))
 		return OK;
 	    break;
 	case NFA_CLASS_SPACE:

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -2890,7 +2890,7 @@ spell_read_aff(spellinfo_T *spin, char_u *fname)
 		     || is_aff_rule(items, itemcnt, "REPSAL", 2))
 	    {
 		// Ignore REP/REPSAL count
-		if (!isdigit(*items[1]))
+		if (!SAFE_isdigit(*items[1]))
 		    smsg(_("Expected REP(SAL) count in %s line %d"),
 								 fname, lnum);
 	    }
@@ -2925,7 +2925,7 @@ spell_read_aff(spellinfo_T *spin, char_u *fname)
 		{
 		    // First line contains the count.
 		    found_map = TRUE;
-		    if (!isdigit(*items[1]))
+		    if (!SAFE_isdigit(*items[1]))
 			smsg(_("Expected MAP count in %s line %d"),
 								 fname, lnum);
 		}

--- a/src/tag.c
+++ b/src/tag.c
@@ -1194,7 +1194,7 @@ add_llist_tags(
 	// Get the line number or the search pattern used to locate
 	// the tag.
 	lnum = 0;
-	if (isdigit(*tagp.command))
+	if (SAFE_isdigit(*tagp.command))
 	    // Line number is used to locate the tag
 	    lnum = atol((char *)tagp.command);
 	else

--- a/src/term.c
+++ b/src/term.c
@@ -3434,7 +3434,7 @@ ttest(int pairs)
 #endif
     {
 	env_colors = mch_getenv((char_u *)"COLORS");
-	if (env_colors != NULL && isdigit(*env_colors))
+	if (env_colors != NULL && SAFE_isdigit(*env_colors))
 	{
 	    int colors = atoi((char *)env_colors);
 
@@ -5849,7 +5849,7 @@ handle_dcs(char_u *tp, char_u *argp, int len, char_u *key_name, int *slen)
 	// characters.
 	for (i = j + 3; i < len; ++i)
 	{
-	    if (i - j == 3 && !isdigit(tp[i]))
+	    if (i - j == 3 && !SAFE_isdigit(tp[i]))
 		break;
 	    if (i - j == 4 && tp[i] != ' ')
 		break;
@@ -6083,7 +6083,7 @@ check_termcode(
 			// The mouse termcode "ESC [" is also the prefix of
 			// "ESC [ I" (focus gained) and other keys.  Check some
 			// more bytes to find out.
-			if (!isdigit(tp[2]))
+			if (!SAFE_isdigit(tp[2]))
 			{
 			    // ESC [ without number following: Only use it when
 			    // there is no other match.
@@ -6166,7 +6166,7 @@ check_termcode(
 			    // Skip over the digits, the final char must
 			    // follow. URXVT can use a negative value, thus
 			    // also accept '-'.
-			    for (j = slen - 2; j < len && (isdigit(tp[j])
+			    for (j = slen - 2; j < len && (SAFE_isdigit(tp[j])
 				       || tp[j] == '-' || tp[j] == ';'); ++j)
 				;
 			    ++j;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -853,13 +853,13 @@ ex_terminal(exarg_T *eap)
 	    else
 		opt.jo_term_api = NULL;
 	}
-	else if (OPTARG_HAS("rows") && ep != NULL && isdigit(ep[1]))
+	else if (OPTARG_HAS("rows") && ep != NULL && SAFE_isdigit(ep[1]))
 	{
 	    opt.jo_set2 |= JO2_TERM_ROWS;
 	    opt.jo_term_rows = atoi((char *)ep + 1);
 	    p = skiptowhite(cmd);
 	}
-	else if (OPTARG_HAS("cols") && ep != NULL && isdigit(ep[1]))
+	else if (OPTARG_HAS("cols") && ep != NULL && SAFE_isdigit(ep[1]))
 	{
 	    opt.jo_set2 |= JO2_TERM_COLS;
 	    opt.jo_term_cols = atoi((char *)ep + 1);
@@ -5463,11 +5463,11 @@ read_dump_file(FILE *fd, VTermPos *cursor_pos)
 		    // use same attr as previous cell
 		    c = fgetc(fd);
 		}
-		else if (isdigit(c))
+		else if (SAFE_isdigit(c))
 		{
 		    // get the decimal attribute
 		    attr = 0;
-		    while (isdigit(c))
+		    while (SAFE_isdigit(c))
 		    {
 			attr = attr * 10 + (c - '0');
 			c = fgetc(fd);
@@ -5499,9 +5499,9 @@ read_dump_file(FILE *fd, VTermPos *cursor_pos)
 			    c = fgetc(fd);
 			    blue = (blue << 4) + hex2nr(c);
 			    c = fgetc(fd);
-			    if (!isdigit(c))
+			    if (!SAFE_isdigit(c))
 				dump_is_corrupt(&ga_text);
-			    while (isdigit(c))
+			    while (SAFE_isdigit(c))
 			    {
 				index = index * 10 + (c - '0');
 				c = fgetc(fd);
@@ -5565,7 +5565,7 @@ read_dump_file(FILE *fd, VTermPos *cursor_pos)
 		for (;;)
 		{
 		    c = fgetc(fd);
-		    if (!isdigit(c))
+		    if (!SAFE_isdigit(c))
 			break;
 		    count = count * 10 + (c - '0');
 		}

--- a/src/typval.c
+++ b/src/typval.c
@@ -2390,7 +2390,7 @@ eval_string(char_u **arg, typval_T *rettv, int evaluate, int interpolate)
 			  if (vim_isxdigit(p[1]))
 			  {
 			      int	n, nr;
-			      int	c = toupper(*p);
+			      int	c = SAFE_toupper(*p);
 
 			      if (c == 'X')
 				  n = 2;

--- a/src/uninstall.c
+++ b/src/uninstall.c
@@ -29,7 +29,7 @@ confirm(void)
     char	answer[10];
 
     fflush(stdout);
-    return (scanf(" %c", answer) == 1 && SAFE_toupper(answer[0]) == 'Y');
+    return (scanf(" %c", answer) == 1 && toupper((unsigned char)answer[0]) == 'Y');
 }
 
     static int

--- a/src/uninstall.c
+++ b/src/uninstall.c
@@ -29,7 +29,7 @@ confirm(void)
     char	answer[10];
 
     fflush(stdout);
-    return (scanf(" %c", answer) == 1 && toupper(answer[0]) == 'Y');
+    return (scanf(" %c", answer) == 1 && SAFE_toupper(answer[0]) == 'Y');
 }
 
     static int

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -77,7 +77,7 @@ one_function_arg(
 
     while (ASCII_ISALNUM(*p) || *p == '_')
 	++p;
-    if (arg == p || isdigit(*arg)
+    if (arg == p || SAFE_isdigit(*arg)
 	    || (argtypes == NULL
 		&& ((p - arg == 9 && STRNCMP(arg, "firstline", 9) == 0)
 		    || (p - arg == 8 && STRNCMP(arg, "lastline", 8) == 0))))
@@ -2256,7 +2256,7 @@ func_requires_g_prefix(ufunc_T *ufunc)
     return ufunc->uf_name[0] != K_SPECIAL
 	    && (ufunc->uf_flags & FC_LAMBDA) == 0
 	    && vim_strchr(ufunc->uf_name, AUTOLOAD_CHAR) == NULL
-	    && !isdigit(ufunc->uf_name[0]);
+	    && !SAFE_isdigit(ufunc->uf_name[0]);
 }
 
 /*
@@ -2432,8 +2432,8 @@ cleanup_function_call(funccall_T *fc)
     static int
 numbered_function(char_u *name)
 {
-    return isdigit(*name)
-	    || (name[0] == 'g' && name[1] == ':' && isdigit(name[2]));
+    return SAFE_isdigit(*name)
+	    || (name[0] == 'g' && name[1] == ':' && SAFE_isdigit(name[2]));
 }
 
 /*
@@ -4637,7 +4637,7 @@ list_functions(regmatch_T *regmatch)
 		    && (regmatch == NULL
 			? !message_filtered(fp->uf_name)
 			    && !func_name_refcount(fp->uf_name)
-			: !isdigit(*fp->uf_name)
+			: !SAFE_isdigit(*fp->uf_name)
 			    && vim_regexec(regmatch, fp->uf_name, 0)))
 	    {
 		if (list_func_head(fp, FALSE) == FAIL)

--- a/src/version.c
+++ b/src/version.c
@@ -5382,9 +5382,9 @@ do_intro_line(
 	if (highest_patch())
 	{
 	    // Check for 9.9x or 9.9xx, alpha/beta version
-	    if (isalpha((int)vers[3]))
+	    if (SAFE_isalpha((int)vers[3]))
 	    {
-		int len = (isalpha((int)vers[4])) ? 5 : 4;
+		int len = (SAFE_isalpha((int)vers[4])) ? 5 : 4;
 		sprintf((char *)vers + len, ".%d%s", highest_patch(),
 							 mediumVersion + len);
 	    }

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -3129,7 +3129,7 @@ get_cmd_count(char_u *line, exarg_T *eap)
     // skip over colons and white space
     for (p = line; *p == ':' || VIM_ISWHITE(*p); ++p)
 	;
-    if (!isdigit(*p))
+    if (!SAFE_isdigit(*p))
     {
 	// The command or modifiers must be following.  Assume a lower case
 	// character means there is a modifier.

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -1943,7 +1943,7 @@ get_compare_type(char_u *p, int *len, int *type_is)
 			if (p[2] == 'n' && p[3] == 'o' && p[4] == 't')
 			    *len = 5;
 			i = p[*len];
-			if (!isalnum(i) && i != '_')
+			if (!SAFE_isalnum(i) && i != '_')
 			{
 			    type = *len == 2 ? EXPR_IS : EXPR_ISNOT;
 			    *type_is = TRUE;

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1068,7 +1068,7 @@ barline_parse(vir_T *virp, char_u *text, garray_T *values)
 	    }
 	}
 
-	if (isdigit(*p))
+	if (SAFE_isdigit(*p))
 	{
 	    value->bv_type = BVAL_NR;
 	    value->bv_nr = getdigits(&p);
@@ -2484,7 +2484,7 @@ read_viminfo_filemark(vir_T *virp, int force)
     str = virp->vir_line + 1;
     if (*str <= 127
 	    && ((*virp->vir_line == '\''
-				       && (VIM_ISDIGIT(*str) || isupper(*str)))
+				       && (VIM_ISDIGIT(*str) || SAFE_isupper(*str)))
 	     || (*virp->vir_line == '-' && *str == '\'')))
     {
 	if (*str == '\'')

--- a/src/xdiff/xemit.c
+++ b/src/xdiff/xemit.c
@@ -99,12 +99,12 @@ xdchange_t *xdl_get_hunk(xdchange_t **xscr, xdemitconf_t const *xecfg)
 static long def_ff(const char *rec, long len, char *buf, long sz)
 {
 	if (len > 0 &&
-			(SAFE_isalpha((unsigned char)*rec) || /* identifier? */
+			(isalpha((unsigned char)*rec) || /* identifier? */
 			 *rec == '_' || /* also identifier? */
 			 *rec == '$')) { /* identifiers from VMS and other esoterico */
 		if (len > sz)
 			len = sz;
-		while (0 < len && SAFE_isspace((unsigned char)rec[len - 1]))
+		while (0 < len && isspace((unsigned char)rec[len - 1]))
 			len--;
 		memcpy(buf, rec, len);
 		return len;

--- a/src/xdiff/xemit.c
+++ b/src/xdiff/xemit.c
@@ -99,12 +99,12 @@ xdchange_t *xdl_get_hunk(xdchange_t **xscr, xdemitconf_t const *xecfg)
 static long def_ff(const char *rec, long len, char *buf, long sz)
 {
 	if (len > 0 &&
-			(isalpha((unsigned char)*rec) || /* identifier? */
+			(SAFE_isalpha((unsigned char)*rec) || /* identifier? */
 			 *rec == '_' || /* also identifier? */
 			 *rec == '$')) { /* identifiers from VMS and other esoterico */
 		if (len > sz)
 			len = sz;
-		while (0 < len && isspace((unsigned char)rec[len - 1]))
+		while (0 < len && SAFE_isspace((unsigned char)rec[len - 1]))
 			len--;
 		memcpy(buf, rec, len);
 		return len;

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -206,7 +206,7 @@ char hexxa[] = "0123456789abcdef0123456789ABCDEF", *hexx = hexxa;
 #define HEX_BITS 3		/* not hex a dump, but bits: 01111001 */
 #define HEX_LITTLEENDIAN 4
 
-#define CONDITIONAL_CAPITALIZE(c) (capitalize ? SAFE_toupper(c) : c)
+#define CONDITIONAL_CAPITALIZE(c) (capitalize ? toupper((unsigned char)(c)) : (c))
 
 #define COLOR_PROLOGUE \
 l[c++] = '\033'; \
@@ -225,30 +225,6 @@ l[c++] = 'm';
 #define COLOR_YELLOW '3'
 #define COLOR_BLUE '4'
 #define COLOR_WHITE '7'
-
-// The is*() and to*() functions declared in <ctype.h> have
-// undefined behavior for values other than EOF outside the range of
-// unsigned char.  If plain char is signed, a call with a negative
-// value has undefined behavior.  These macros cast the argument to
-// unsigned char.  (Most implementations behave more or less sanely
-// with negative values, and most character values in practice are
-// positive, but we want to avoid undefined behavior anyway.)
-// These macro definitions are copied from src/macros.h.
-// Not all of them are used here.
-#define SAFE_isalnum(c)  (isalnum ((unsigned char)(c)))
-#define SAFE_isalpha(c)  (isalpha ((unsigned char)(c)))
-#define SAFE_isblank(c)  (isblank ((unsigned char)(c)))
-#define SAFE_iscntrl(c)  (iscntrl ((unsigned char)(c)))
-#define SAFE_isdigit(c)  (isdigit ((unsigned char)(c)))
-#define SAFE_isgraph(c)  (isgraph ((unsigned char)(c)))
-#define SAFE_islower(c)  (islower ((unsigned char)(c)))
-#define SAFE_isprint(c)  (isprint ((unsigned char)(c)))
-#define SAFE_ispunct(c)  (ispunct ((unsigned char)(c)))
-#define SAFE_isspace(c)  (isspace ((unsigned char)(c)))
-#define SAFE_isupper(c)  (isupper ((unsigned char)(c)))
-#define SAFE_isxdigit(c) (isxdigit((unsigned char)(c)))
-#define SAFE_tolower(c)  (tolower ((unsigned char)(c)))
-#define SAFE_toupper(c)  (toupper ((unsigned char)(c)))
 
 static char *pname;
 
@@ -980,9 +956,9 @@ main(int argc, char *argv[])
 
       if (varname != NULL)
 	{
-	  FPRINTF_OR_DIE((fpo, "unsigned char %s", SAFE_isdigit(varname[0]) ? "__" : ""));
+	  FPRINTF_OR_DIE((fpo, "unsigned char %s", isdigit((unsigned char)varname[0]) ? "__" : ""));
 	  for (e = 0; (c = varname[e]) != 0; e++)
-	    putc_or_die(SAFE_isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
+	    putc_or_die(isalnum((unsigned char)c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
 	  fputs_or_die("[] = {\n", fpo);
 	}
 
@@ -1000,9 +976,9 @@ main(int argc, char *argv[])
       if (varname != NULL)
 	{
 	  fputs_or_die("};\n", fpo);
-	  FPRINTF_OR_DIE((fpo, "unsigned int %s", SAFE_isdigit(varname[0]) ? "__" : ""));
+	  FPRINTF_OR_DIE((fpo, "unsigned int %s", isdigit((unsigned char)varname[0]) ? "__" : ""));
 	  for (e = 0; (c = varname[e]) != 0; e++)
-	    putc_or_die(SAFE_isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
+	    putc_or_die(isalnum((unsigned char)c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
 	  FPRINTF_OR_DIE((fpo, "_%s = %d;\n", capitalize ? "LEN" : "len", p));
 	}
 

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -94,8 +94,8 @@
 # include <unistd.h>
 #endif
 #include <stdlib.h>
-#include <string.h>	/* for strncmp() */
-#include <ctype.h>	/* for isalnum() */
+#include <string.h>
+#include <ctype.h>
 #include <limits.h>
 #if __MWERKS__ && !defined(BEBOX)
 # include <unix.h>	/* for fdopen() on MAC */
@@ -206,7 +206,7 @@ char hexxa[] = "0123456789abcdef0123456789ABCDEF", *hexx = hexxa;
 #define HEX_BITS 3		/* not hex a dump, but bits: 01111001 */
 #define HEX_LITTLEENDIAN 4
 
-#define CONDITIONAL_CAPITALIZE(c) (capitalize ? toupper((int)c) : c)
+#define CONDITIONAL_CAPITALIZE(c) (capitalize ? SAFE_toupper(c) : c)
 
 #define COLOR_PROLOGUE \
 l[c++] = '\033'; \
@@ -225,6 +225,30 @@ l[c++] = 'm';
 #define COLOR_YELLOW '3'
 #define COLOR_BLUE '4'
 #define COLOR_WHITE '7'
+
+// The is*() and to*() functions declared in <ctype.h> have
+// undefined behavior for values other than EOF outside the range of
+// unsigned char.  If plain char is signed, a call with a negative
+// value has undefined behavior.  These macros cast the argument to
+// unsigned char.  (Most implementations behave more or less sanely
+// with negative values, and most character values in practice are
+// positive, but we want to avoid undefined behavior anyway.)
+// These macro definitions are copied from src/macros.h.
+// Not all of them are used here.
+#define SAFE_isalnum(c)  (isalnum ((unsigned char)(c)))
+#define SAFE_isalpha(c)  (isalpha ((unsigned char)(c)))
+#define SAFE_isblank(c)  (isblank ((unsigned char)(c)))
+#define SAFE_iscntrl(c)  (iscntrl ((unsigned char)(c)))
+#define SAFE_isdigit(c)  (isdigit ((unsigned char)(c)))
+#define SAFE_isgraph(c)  (isgraph ((unsigned char)(c)))
+#define SAFE_islower(c)  (islower ((unsigned char)(c)))
+#define SAFE_isprint(c)  (isprint ((unsigned char)(c)))
+#define SAFE_ispunct(c)  (ispunct ((unsigned char)(c)))
+#define SAFE_isspace(c)  (isspace ((unsigned char)(c)))
+#define SAFE_isupper(c)  (isupper ((unsigned char)(c)))
+#define SAFE_isxdigit(c) (isxdigit((unsigned char)(c)))
+#define SAFE_tolower(c)  (tolower ((unsigned char)(c)))
+#define SAFE_toupper(c)  (toupper ((unsigned char)(c)))
 
 static char *pname;
 
@@ -956,9 +980,9 @@ main(int argc, char *argv[])
 
       if (varname != NULL)
 	{
-	  FPRINTF_OR_DIE((fpo, "unsigned char %s", isdigit((int)varname[0]) ? "__" : ""));
+	  FPRINTF_OR_DIE((fpo, "unsigned char %s", SAFE_isdigit(varname[0]) ? "__" : ""));
 	  for (e = 0; (c = varname[e]) != 0; e++)
-	    putc_or_die(isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
+	    putc_or_die(SAFE_isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
 	  fputs_or_die("[] = {\n", fpo);
 	}
 
@@ -976,9 +1000,9 @@ main(int argc, char *argv[])
       if (varname != NULL)
 	{
 	  fputs_or_die("};\n", fpo);
-	  FPRINTF_OR_DIE((fpo, "unsigned int %s", isdigit((int)varname[0]) ? "__" : ""));
+	  FPRINTF_OR_DIE((fpo, "unsigned int %s", SAFE_isdigit(varname[0]) ? "__" : ""));
 	  for (e = 0; (c = varname[e]) != 0; e++)
-	    putc_or_die(isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
+	    putc_or_die(SAFE_isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
 	  FPRINTF_OR_DIE((fpo, "_%s = %d;\n", capitalize ? "LEN" : "len", p));
 	}
 


### PR DESCRIPTION
The standard is*() and to*() functions declared in <ctype.h> have undefined behavior for negative arguments other than EOF.  If plain char is signed, passing an unchecked value from argv for from user input to one of these functions has undefined behavior.

Solution: Add SAFE_*() macros that cast the argument to unsigned char.

Most implementations behave sanely for negative arguments, and most character values in practice are non-negative, but it's still best to avoid undefined behavior.

This addresses https://github.com/vim/vim/issues/13332.