### PR TITLE
Fix funcref assignment type checking involving `varargs` and `unknown`.

### DIFF
--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -1863,6 +1863,62 @@ def Test_assign_lambda()
   v9.CheckDefAndScriptFailure(lines, 'E1051:')
 enddef
 
+def Test_assign_funcref_args()
+  # unspecified arguments match everything, including varargs
+  var lines =<< trim END
+    vim9script
+
+    var FuncUnknown: func: number
+
+    FuncUnknown = (v): number => v
+    assert_equal(5, FuncUnknown(5))
+
+    FuncUnknown = (v1, v2): number => v1 + v2
+    assert_equal(7, FuncUnknown(3, 4))
+
+    FuncUnknown = (...v1): number => v1[0] + v1[1] + len(v1) * 1000
+    assert_equal(4007, FuncUnknown(3, 4, 5, 6))
+
+    FuncUnknown = (v: list<any>): number => v[0] + v[1] + len(v) * 1000
+    assert_equal(5009, FuncUnknown([4, 5, 6, 7, 8]))
+  END
+  v9.CheckScriptSuccess(lines)
+
+  # varargs must match
+  lines =<< trim END
+    vim9script
+    var FuncAnyVA: func(...any): number
+    FuncAnyVA = (v): number => v
+  END
+  v9.CheckScriptFailure(lines, 'E1012: Type mismatch; expected func(...any): number but got func(any): number')
+
+  # varargs must match
+  lines =<< trim END
+    vim9script
+    var FuncAnyVA: func(...any): number
+    FuncAnyVA = (v1, v2): number => v1 + v2
+  END
+  v9.CheckScriptFailure(lines, 'E1012: Type mismatch; expected func(...any): number but got func(any, any): number')
+
+  # varargs must match
+  lines =<< trim END
+    vim9script
+    var FuncAnyVA: func(...any): number
+    FuncAnyVA = (v1: list<any>): number => 3
+  END
+  v9.CheckScriptFailure(lines, 'E1012: Type mismatch; expected func(...any): number but got func(list<any>): number')
+enddef
+
+def Test_assign_funcref_arg_any()
+  var lines =<< trim END
+    vim9script
+    var FuncAnyVA: func(any): number
+    FuncAnyVA = (v): number => v
+  END
+  # TODO: Verify this should succeed.
+  v9.CheckScriptSuccess(lines)
+enddef
+
 def Test_heredoc()
   # simple heredoc
   var lines =<< trim END

--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -1995,7 +1995,7 @@ def Test_varargs_mismatch()
       var res = Map((v) => str2nr(v))
       assert_equal(12, res)
   END
-  v9.CheckScriptSuccess(lines)
+  v9.CheckScriptFailure(lines, 'E1013: Argument 1: type mismatch, expected func(...any): number but got func(any): number')
 enddef
 
 def Test_using_var_as_arg()

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -884,6 +884,11 @@ check_type_maybe(
 		else
 		    ret = MAYBE;
 	    }
+	    if (ret != FAIL
+		    && ((expected->tt_flags & TTFLAG_VARARGS)
+			!= (actual->tt_flags & TTFLAG_VARARGS))
+		    && expected->tt_argcount != -1)
+		ret = FAIL;
 	    if (ret != FAIL && expected->tt_argcount != -1
 		    && actual->tt_min_argcount != -1
 		    && (actual->tt_argcount == -1


### PR DESCRIPTION
Note that this PR changes a test that passed into one that fails; it is `def Test_varargs_mismatch()`.
See https://github.com/vim/vim/issues/13343#issuecomment-1763486853, and surrounding comments, for discussion of this change in behavior. @yegappan , @dkearns comments?

There's an additional question; it has to do with funcref assignment and function argument type checking.

The following test passes, and I wonder if it should?
Since it involves `any`, I guess that's why it should pass

```
def Test_assign_funcref_arg_any()
  var lines =<< trim END
    vim9script
    var FuncAnyVA: func(any): number
    FuncAnyVA = (v): number => v
  END
  # TODO: Verify this should succeed.
  v9.CheckScriptSuccess(lines)
enddef
```
