### PR TITLE
Suppress GCC warning

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -2159,7 +2159,7 @@ f_resolve(typval_T *argvars, typval_T *rettv)
 		if (q > p && *q == NUL)
 		{
 		    // Ignore trailing path separator.
-		    q[-1] = NUL;
+		    p[q - p - 1] = NUL;
 		    q = gettail(p);
 		}
 		if (q > p && !mch_isFullName(buf))


### PR DESCRIPTION
Suppress the following warning:
```
filepath.c: In function ‘f_resolve’:
filepath.c:2162:27: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 2162 |                     q[-1] = NUL;
```

Close #13352