### PR TITLE
trim(): Use default 'mask' when it is empty

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -10119,9 +10119,9 @@ trim({text} [, {mask} [, {dir}]])				*trim()*
 		Return {text} as a String where any character in {mask} is
 		removed from the beginning and/or end of {text}.
 
-		If {mask} is not given, {mask} is all characters up to 0x20,
-		which includes Tab, space, NL and CR, plus the non-breaking
-		space character 0xa0.
+		If {mask} is not given, or is an empty string, {mask} is all
+		characters up to 0x20, which includes Tab, space, NL and CR,
+		plus the non-breaking space character 0xa0.
 
 		The optional {dir} argument specifies where to remove the
 		characters:

--- a/src/strings.c
+++ b/src/strings.c
@@ -1977,6 +1977,8 @@ f_trim(typval_T *argvars, typval_T *rettv)
     if (argvars[1].v_type == VAR_STRING)
     {
 	mask = tv_get_string_buf_chk(&argvars[1], buf2);
+	if (*mask == NUL)
+	    mask = NULL;
 
 	if (argvars[2].v_type != VAR_UNKNOWN)
 	{

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2236,6 +2236,10 @@ func Test_trim()
   let chars = join(map(range(1, 0x20) + [0xa0], {n -> n->nr2char()}), '')
   call assert_equal("x", trim(chars . "x" . chars))
 
+  call assert_equal("x", trim(chars . "x" . chars, '', 0))
+  call assert_equal("x" . chars, trim(chars . "x" . chars, '', 1))
+  call assert_equal(chars . "x", trim(chars . "x" . chars, '', 2))
+
   call assert_fails('let c=trim([])', 'E730:')
 endfunc
 


### PR DESCRIPTION
The default 'mask' value is pretty complex, as it includes many characters.  Yet, if one needs to specify the trimming direction, the third argument, 'trim()' currently requires the 'mask' value to be provided explicitly.

Currently, an empty 'mask' will make 'trim()' call return 'text' value that is passed in unmodified.  It is unlikely that someone is using it, so the chances of scripts being broken by this change are low.

---

An alternative approach is to use `v:none` instead of an empty string: https://github.com/vim/vim/pull/13363.