### PR TITLE
Not able to use object method as a callback function for popups and timers

### DIFF
--- a/src/proto/vim9instr.pro
+++ b/src/proto/vim9instr.pro
@@ -62,7 +62,7 @@ int generate_CALL(cctx_T *cctx, ufunc_T *ufunc, class_T *cl, int mi, int pushed_
 int generate_UCALL(cctx_T *cctx, char_u *name, int argcount);
 int check_func_args_from_type(cctx_T *cctx, type_T *type, int argcount, int at_top, char_u *name);
 int generate_PCALL(cctx_T *cctx, int argcount, char_u *name, type_T *type, int at_top);
-int generate_DEFER(cctx_T *cctx, int var_idx, int obj_method, int argcount);
+int generate_DEFER(cctx_T *cctx, int var_idx, int argcount);
 int generate_STRINGMEMBER(cctx_T *cctx, char_u *name, size_t len);
 int generate_ECHO(cctx_T *cctx, int with_white, int count);
 int generate_MULT_EXPR(cctx_T *cctx, isntype_T isn_type, int count);

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -8043,12 +8043,14 @@ def Test_objmethod_popup_callback()
     endclass
 
     var a = A.new()
+    feedkeys('', 'xt')
     var winid = popup_create('Y/N?',
                               {filter: a.PopupFilter, callback: a.PopupCb})
     feedkeys('y', 'xt')
     popup_close(winid)
     assert_equal(100, a.selection)
     assert_equal(['y'], a.filterkeys)
+    feedkeys('', 'xt')
     winid = popup_create('Y/N?',
                               {filter: a.PopupFilter, callback: a.PopupCb})
     feedkeys('n', 'xt')
@@ -8078,12 +8080,14 @@ def Test_objmethod_popup_callback()
 
     def Foo()
       var a = A.new()
+      feedkeys('', 'xt')
       var winid = popup_create('Y/N?',
                                 {filter: a.PopupFilter, callback: a.PopupCb})
       feedkeys('y', 'xt')
       popup_close(winid)
       assert_equal(100, a.selection)
       assert_equal(['y'], a.filterkeys)
+      feedkeys('', 'xt')
       winid = popup_create('Y/N?',
                                 {filter: a.PopupFilter, callback: a.PopupCb})
       feedkeys('n', 'xt')
@@ -8116,12 +8120,14 @@ def Test_classmethod_popup_callback()
       enddef
     endclass
 
+    feedkeys('', 'xt')
     var winid = popup_create('Y/N?',
                               {filter: A.PopupFilter, callback: A.PopupCb})
     feedkeys('y', 'xt')
     popup_close(winid)
     assert_equal(100, A.selection)
     assert_equal(['y'], A.filterkeys)
+    feedkeys('', 'xt')
     winid = popup_create('Y/N?',
                               {filter: A.PopupFilter, callback: A.PopupCb})
     feedkeys('n', 'xt')
@@ -8150,12 +8156,14 @@ def Test_classmethod_popup_callback()
     endclass
 
     def Foo()
+      feedkeys('', 'xt')
       var winid = popup_create('Y/N?',
                                 {filter: A.PopupFilter, callback: A.PopupCb})
       feedkeys('y', 'xt')
       popup_close(winid)
       assert_equal(100, A.selection)
       assert_equal(['y'], A.filterkeys)
+      feedkeys('', 'xt')
       winid = popup_create('Y/N?',
                                 {filter: A.PopupFilter, callback: A.PopupCb})
       feedkeys('n', 'xt')

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -3276,7 +3276,7 @@ def Test_funcref_with_class()
     'defer a.Foo()\_s*' ..
     '0 LOAD arg\[-1\]\_s*' ..
     '1 FUNCREF A.Foo\_s*' ..
-    '2 DEFEROBJ 0 args\_s*' ..
+    '2 DEFER 0 args\_s*' ..
     '3 RETURN void', g:instr)
   unlet g:instr
 enddef

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -125,7 +125,6 @@ typedef enum {
     ISN_NEWFUNC,    // create a global function from a lambda function
     ISN_DEF,	    // list functions
     ISN_DEFER,	    // :defer  argument count is isn_arg.number
-    ISN_DEFEROBJ,   // idem, function is an object method
 
     // expression operations
     ISN_JUMP,	    // jump if condition is matched isn_arg.jump

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -2000,7 +2000,6 @@ compile_defer(char_u *arg_start, cctx_T *cctx)
     int		defer_var_idx;
     type_T	*type;
     int		func_idx;
-    int		obj_method = 0;
 
     // Get a funcref for the function name.
     // TODO: better way to find the "(".
@@ -2016,15 +2015,8 @@ compile_defer(char_u *arg_start, cctx_T *cctx)
 	// TODO: better type
 	generate_PUSHFUNC(cctx, (char_u *)internal_func_name(func_idx),
 							   &t_func_any, FALSE);
-    else
-    {
-	int typecount = cctx->ctx_type_stack.ga_len;
-	if (compile_expr0(&arg, cctx) == FAIL)
-	    return NULL;
-	if (cctx->ctx_type_stack.ga_len >= typecount + 2)
-	    // must have seen "obj.Func", pushed an object and a function
-	    obj_method = 1;
-    }
+    else if (compile_expr0(&arg, cctx) == FAIL)
+	return NULL;
     *paren = '(';
 
     // check for function type
@@ -2056,7 +2048,7 @@ compile_defer(char_u *arg_start, cctx_T *cctx)
     defer_var_idx = get_defer_var_idx(cctx);
     if (defer_var_idx == 0)
 	return NULL;
-    if (generate_DEFER(cctx, defer_var_idx - 1, obj_method, argcount) == FAIL)
+    if (generate_DEFER(cctx, defer_var_idx - 1, argcount) == FAIL)
 	return NULL;
 
     return skipwhite(arg);

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -450,9 +450,9 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 		return FAIL;
 	    }
 	    *arg = name_end;
-	    if (type->tt_type == VAR_OBJECT)
-		return generate_FUNCREF(cctx, fp, cl, TRUE, m_idx, NULL);
-	    return generate_FUNCREF(cctx, fp, NULL, FALSE, 0, NULL);
+	    // Remove the object type from the stack
+	    --cctx->ctx_type_stack.ga_len;
+	    return generate_FUNCREF(cctx, fp, cl, TRUE, m_idx, NULL);
 	}
 
 	member_not_found_msg(cl, VAR_OBJECT, name, len);
@@ -490,9 +490,9 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 		return FAIL;
 	    }
 	    *arg = name_end;
-	    if (type->tt_type == VAR_CLASS)
-		return generate_FUNCREF(cctx, fp, cl, FALSE, m_idx, NULL);
-	    return generate_FUNCREF(cctx, fp, NULL, FALSE, 0, NULL);
+	    // Remove the class type from the stack
+	    --cctx->ctx_type_stack.ga_len;
+	    return generate_FUNCREF(cctx, fp, cl, FALSE, m_idx, NULL);
 	}
 
 	member_not_found_msg(cl, VAR_CLASS, name, len);

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -2039,17 +2039,14 @@ generate_PCALL(
 
 /*
  * Generate an ISN_DEFER instruction.
- * "obj_method" is one for "obj.Method()", zero otherwise.
  */
     int
-generate_DEFER(cctx_T *cctx, int var_idx, int obj_method, int argcount)
+generate_DEFER(cctx_T *cctx, int var_idx, int argcount)
 {
     isn_T *isn;
 
     RETURN_OK_IF_SKIP(cctx);
-    if ((isn = generate_instr_drop(cctx,
-		    obj_method == 0 ? ISN_DEFER : ISN_DEFEROBJ,
-		    argcount + 1)) == NULL)
+    if ((isn = generate_instr_drop(cctx, ISN_DEFER, argcount + 1)) == NULL)
 	return FAIL;
     isn->isn_arg.defer.defer_var_idx = var_idx;
     isn->isn_arg.defer.defer_argcount = argcount;
@@ -2711,7 +2708,6 @@ delete_instr(isn_T *isn)
 	case ISN_COND2BOOL:
 	case ISN_DEBUG:
 	case ISN_DEFER:
-	case ISN_DEFEROBJ:
 	case ISN_DROP:
 	case ISN_ECHO:
 	case ISN_ECHOCONSOLE:


### PR DESCRIPTION

After using an object method funcref, the object type is not removed from the type stack.
Remove the object type from the stack after getting the funcref.

While addressing this issue, I realized that the ISN_DEFEROBJ instruction introduced by
patch 9.0.1250 is no longer needed as the partial now has a pointer to the object.
The ISN_DEFER instruction can also handle deferring object methods.
So removed ISN_DEFEROBJ instruction.