### PR TITLE
win32,py3: Fix uninitialized warning

### DIFF
--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -848,8 +848,9 @@ py3_get_system_libname(const char *libname)
 		break;
 
 	    major = wcstol(keyname, &wp, 10);
-	    if (*wp == L'.')
-		minor = wcstol(wp + 1, &wp, 10);
+	    if (*wp != L'.')
+		continue;
+	    minor = wcstol(wp + 1, &wp, 10);
 #  ifdef _WIN64
 	    if (*wp != L'\0')
 		continue;


### PR DESCRIPTION
Fix the following warning:
```
if_python3.c: In function 'py3_get_system_libname':
if_python3.c:879:16: warning: 'minor' may be used uninitialized [-Wmaybe-uninitialized]
  879 |             if (minor == PY_MINOR_VERSION)
      |                ^
if_python3.c:839:24: note: 'minor' was declared here
  839 |         long    major, minor;
      |                        ^~~~~
```