### PR TITLE
win32: Suppress MS_WIN64 redefined warning

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -513,9 +513,6 @@ endif # RUBY
 DEF_GUI=-DFEAT_GUI_MSWIN -DFEAT_CLIPBOARD
 DEFINES=-DWIN32 -DWINVER=$(WINVER) -D_WIN32_WINNT=$(WINVER) \
 	-DHAVE_PATHDEF -DFEAT_$(FEATURES) -DHAVE_STDINT_H
-ifeq ($(ARCH),x86-64)
-DEFINES+=-DMS_WIN64
-endif
 
 #>>>>> end of choices
 ###########################################################################


### PR DESCRIPTION
Suppress the following warning:
```
In file included from C:/Python312-64/include/Python.h:12,
                 from if_python3.c:79:
C:/Python312-64/include/pyconfig.h:240: warning: "MS_WIN64" redefined
  240 | #define MS_WIN64
      |
<command-line>: note: this is the location of the previous definition
```

`MS_WIN64` is not defined in `Make_mvc.mak` either. This should be able to be safely removed.