### PR TITLE
win32: Stop using wsock32

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -923,7 +923,7 @@ endif
 
 ifeq ($(CHANNEL),yes)
 OBJ += $(OUTDIR)/job.o $(OUTDIR)/channel.o
-LIB += -lwsock32 -lws2_32
+LIB += -lws2_32
 endif
 
 ifeq ($(DIRECTX),yes)

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -420,7 +420,6 @@ NBDEBUG_DEFS	= -DNBDEBUG
 NBDEBUG_INCL	= nbdebug.h
 NBDEBUG_SRC	= nbdebug.c
 !  endif
-NETBEANS_LIB	= WSock32.lib
 ! endif
 
 # DirectWrite (DirectX)
@@ -473,7 +472,7 @@ CHANNEL_PRO	= proto/job.pro proto/channel.pro
 CHANNEL_OBJ	= $(OBJDIR)/job.obj $(OBJDIR)/channel.obj
 CHANNEL_DEFS	= -DFEAT_JOB_CHANNEL -DFEAT_IPV6 -DHAVE_INET_NTOP
 
-NETBEANS_LIB	= WSock32.lib Ws2_32.lib
+NETBEANS_LIB	= Ws2_32.lib
 !endif
 
 # need advapi32.lib for GetUserName()

--- a/src/channel.c
+++ b/src/channel.c
@@ -10,13 +10,6 @@
  * Implements communication through a socket or any file handle.
  */
 
-#ifdef WIN32
-// Must include winsock2.h before windows.h since it conflicts with winsock.h
-// (included in windows.h).
-# include <winsock2.h>
-# include <ws2tcpip.h>
-#endif
-
 #include "vim.h"
 
 #if defined(FEAT_JOB_CHANNEL) || defined(PROTO)

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -24,17 +24,6 @@
 # define _USE_32BIT_TIME_T
 #endif
 
-/*
- * Prevent including winsock.h.  perl.h tries to detect whether winsock.h is
- * already included before including winsock2.h, because winsock2.h isn't
- * compatible with winsock.h.  However the detection doesn't work with some
- * versions of MinGW.  If WIN32_LEAN_AND_MEAN is defined, windows.h will not
- * include winsock.h.
- */
-#ifdef WIN32
-# define WIN32_LEAN_AND_MEAN
-#endif
-
 #include "vim.h"
 
 #ifdef _MSC_VER

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -85,6 +85,10 @@
 # define COBJMACROS	// For OLE: Enable "friendlier" access to objects
 #endif
 #ifndef PROTO
+// Must include winsock2.h before windows.h since it conflicts with winsock.h
+// (included in windows.h).
+# include <winsock2.h>
+# include <ws2tcpip.h>
 # include <windows.h>
 
 // Weird: rpcndr.h defines "small" to "char", which causes trouble


### PR DESCRIPTION
We have already used ws2_32 (winsock2) and already dropped support for Windows 95 and NT4.
So, we don't need to care about wsock32.

Use ws2_32 consistently.