### PR TITLE
matchparen: do not use hard-coded match id

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1,4 +1,4 @@
-*pattern.txt*   For Vim version 9.0.  Last change: 2023 Feb 04
+*pattern.txt*   For Vim version 9.0.  Last change: 2023 Oct 20
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1461,10 +1461,11 @@ Finally, these constructs are unique to Perl:
 		Just like |:match| above, but set a separate match.  Thus
 		there can be three matches active at the same time.  The match
 		with the lowest number has priority if several match at the
-		same position.
-		The ":3match" command is used by the |matchparen| plugin.  You
-		are suggested to use ":match" for manual matching and
-		":2match" for another plugin.
+		same position.  It uses the match id 3.
+		The ":3match" command is used by (older Vims) |matchparen|
+		plugin. You are suggested to use ":match" for manual matching
+		and ":2match" for another plugin or even better make use of
+		the more flexible |matchadd()| (and similar) functions instead.
 
 ==============================================================================
 11. Fuzzy matching					*fuzzy-matching*

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -204,8 +204,7 @@ endfunction
 func s:Remove_Matches()
   if exists('w:paren_hl_on') && w:paren_hl_on
     while !empty(w:matchparen_ids)
-      let id = remove(w:matchparen_ids, 0)
-      silent! call matchdelete(id)
+      silent! call remove(w:matchparen_ids, 0)->matchdelete()
     endwhile
     let w:paren_hl_on = 0
   endif

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -1,6 +1,6 @@
 " Vim plugin for showing matching parens
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Last Change:	2023 Oct 20
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Exit quickly when:
@@ -17,6 +17,8 @@ endif
 if !exists("g:matchparen_insert_timeout")
   let g:matchparen_insert_timeout = 60
 endif
+
+let s:has_matchaddpos = exists('*matchaddpos')
 
 augroup matchparen
   " Replace all matchparen autocommands
@@ -38,6 +40,9 @@ set cpo-=C
 " The function that is invoked (very often) to define a ":match" highlighting
 " for any matching paren.
 func s:Highlight_Matching_Pair()
+  if !exists("w:matchparen_ids")
+    let w:matchparen_ids = []
+  endif
   " Remove any previous match.
   call s:Remove_Matches()
 
@@ -185,11 +190,12 @@ func s:Highlight_Matching_Pair()
 
   " If a match is found setup match highlighting.
   if m_lnum > 0 && m_lnum >= stoplinetop && m_lnum <= stoplinebottom 
-    if exists('*matchaddpos')
-      call matchaddpos('MatchParen', [[c_lnum, c_col - before], [m_lnum, m_col]], 10, 3)
+    if s:has_matchaddpos
+      call add(w:matchparen_ids, matchaddpos('MatchParen', [[c_lnum, c_col - before], [m_lnum, m_col]], 10))
     else
       exe '3match MatchParen /\(\%' . c_lnum . 'l\%' . (c_col - before) .
 	    \ 'c\)\|\(\%' . m_lnum . 'l\%' . m_col . 'c\)/'
+      call add(w:matchparen_ids, 3)
     endif
     let w:paren_hl_on = 1
   endif
@@ -197,11 +203,13 @@ endfunction
 
 func s:Remove_Matches()
   if exists('w:paren_hl_on') && w:paren_hl_on
-    silent! call matchdelete(3)
+    while !empty(w:matchparen_ids)
+      let id = remove(w:matchparen_ids, 0)
+      silent! call matchdelete(id)
+    endwhile
     let w:paren_hl_on = 0
   endif
 endfunc
-
 
 " Define commands that will disable and enable the plugin.
 command DoMatchParen call s:DoMatchParen()


### PR DESCRIPTION
Instead of using the hard-coded match id 3, which may also be used by other plugins, let the matchparen plugin use whatever ids are automatically returned when calling matchaddpos().

For backwards-compatibility, keep the `:3match` call, which will still use the hard-coded id 3 (as mentioned in :h :3match).

related: #13381