### PR TITLE
restricted mode: disable allow setting of environment variables

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1,4 +1,4 @@
-*starting.txt*  For Vim version 9.0.  Last change: 2023 Oct 17
+*starting.txt*  For Vim version 9.0.  Last change: 2023 Oct 20
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -249,10 +249,10 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 					*-Z* *restricted-mode* *E145* *E981*
 -Z		Restricted mode.  All commands that make use of an external
 		shell are disabled.  This includes suspending with CTRL-Z,
-		":sh", filtering, the system() function, backtick expansion
+		":sh", filtering, the |system()| function, backtick expansion
 		and libcall().
-		Also disallowed are delete(), rename(), mkdir(), job_start(),
-		etc.
+		Also disallowed are |delete()|, |rename()|, |mkdir()|,
+		|job_start()|, |setenv()| etc.
 		Interfaces, such as Python, Ruby and Lua, are also disabled,
 		since they could be used to execute shell commands.  Perl uses
 		the Safe module.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -9723,6 +9723,13 @@ f_setenv(typval_T *argvars, typval_T *rettv UNUSED)
     if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
 	return;
 
+    // seting an environment variable may be dangerous, e.g. you could
+    // setenv GCONV_PATH=/tmp and then have iconv() unexpectedly call
+    // a shell command using some shared library:
+    // see https://huntr.com/bounties/b0a2eda1-459c-4e36-98e6-0cc7d7faccfe/
+    if (check_restricted() || check_secure())
+	return;
+
     name = tv_get_string_buf(&argvars[0], namebuf);
     if (argvars[1].v_type == VAR_SPECIAL
 				      && argvars[1].vval.v_number == VVAL_NULL)

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5092,6 +5092,13 @@ f_iconv(typval_T *argvars UNUSED, typval_T *rettv)
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = NULL;
 
+    // should the iconv() function be disabled in
+    // restricted mode?
+#if 0
+    if (check_restricted() || check_secure())
+	return;
+#endif
+
     if (in_vim9script()
 	    && (check_for_string_arg(argvars, 0) == FAIL
 		|| check_for_string_arg(argvars, 1) == FAIL


### PR DESCRIPTION
This may be used to escape the restricted mode and execute some payload using GCONV_PATH when calling the iconv() function (by using the `iconv_open()` function.

Disable setting the GCONV_PATH environment variable, even so this is no complete protection, since if that environment variable is already in the environment, it may still execute shell commands.

We could disable the iconv() function completely in restricted mode, not sure if this is worth it?

I'd like to get some opinions here please