### PR TITLE
tests: remove incorrect :unlet

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -215,8 +215,6 @@ endfunc
 for name in s:GetSwapFileList()
   call delete(name)
 endfor
-unlet name
-
 
 " Invoked when a test takes too much time.
 func TestTimeout(id)


### PR DESCRIPTION
This :unlet actually causes an error, and slows testing by 1 second.
