### PR TITLE
tests: avoid error when there are no swap files

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -215,7 +215,7 @@ endfunc
 for name in s:GetSwapFileList()
   call delete(name)
 endfor
-unlet name
+unlet! name
 
 
 " Invoked when a test takes too much time.


### PR DESCRIPTION
When there are no swap files, g:name is never created.