### PR TITLE
filetype: identify Pacman hooks as confini

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1503,7 +1503,7 @@ au BufNewFile,BufRead *.nmconnection			setf confini
 " Pacman hooks
 au BufNewFile,BufRead *.hook
 	\ if getline(1) == '[Trigger]' |
-	\   setf conf |
+	\   setf confini |
 	\ endif
 
 " Pam conf

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1476,12 +1476,12 @@ func Test_hook_file()
 
   call writefile(['[Trigger]', 'this is pacman config'], 'Xfile.hook', 'D')
   split Xfile.hook
-  call assert_equal('conf', &filetype)
+  call assert_equal('confini', &filetype)
   bwipe!
 
   call writefile(['not pacman'], 'Xfile.hook')
   split Xfile.hook
-  call assert_notequal('conf', &filetype)
+  call assert_notequal('confini', &filetype)
   bwipe!
 
   filetype off


### PR DESCRIPTION
Because confini has much better syntax highlighting than conf.

For reference, I identified pacman.conf and pacman hooks as dosini in https://github.com/vim/vim/pull/6335, then
https://github.com/vim/vim/pull/10213 changed them to conf, then https://github.com/vim/vim/pull/10518 changed pacman.conf to confini but forgot to change hooks.