### PR TITLE
Prevent assigning class name to variable.

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1015,6 +1015,15 @@ eval_dict(char_u **arg, typval_T *rettv, evalarg_T *evalarg, int literal)
 		clear_tv(&tvkey);
 	    goto failret;
 	}
+	if (check_is_value(tv.v_type) == FAIL)
+	{
+	    if (evaluate)
+	    {
+		clear_tv(&tvkey);
+		clear_tv(&tv);
+	    }
+	    goto failret;
+	}
 	if (evaluate)
 	{
 	    item = dict_find(d, key, -1);

--- a/src/errors.h
+++ b/src/errors.h
@@ -3552,8 +3552,10 @@ EXTERN char e_missing_typealias_type[]
 	INIT(= N_("E1398: Missing type alias type"));
 EXTERN char e_type_can_only_be_used_in_script[]
 	INIT(= N_("E1399: Type can only be used in a script"));
+EXTERN char e_cannot_assign_class_to_variable[]
+	INIT(= N_("E1400: Cannot use a class as a variable or value"));
 #endif
-// E1400 - E1499 unused (reserved for Vim9 class support)
+// E1401 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/errors.h
+++ b/src/errors.h
@@ -1779,8 +1779,8 @@ EXTERN char e_can_only_compare_list_with_list[]
 	INIT(= N_("E691: Can only compare List with List"));
 EXTERN char e_invalid_operation_for_list[]
 	INIT(= N_("E692: Invalid operation for List"));
-EXTERN char e_list_or_class_required_for_argument_nr[]
-	INIT(= N_("E693: List or Class required for argument %d"));
+EXTERN char e_class_or_typealias_required_for_argument_nr[]
+	INIT(= N_("E693: Class or Typealias required for argument %d"));
 EXTERN char e_invalid_operation_for_funcrefs[]
 	INIT(= N_("E694: Invalid operation for Funcrefs"));
 EXTERN char e_cannot_index_a_funcref[]

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -758,15 +758,16 @@ arg_string_or_func(type_T *type, type_T *decl_type UNUSED, argcontext_T *context
 }
 
 /*
- * Check "type" is a list of 'any' or a class.
+ * Check "type" is a class.
  */
     static int
-arg_class_or_list(type_T *type, type_T *decl_type UNUSED, argcontext_T *context)
+arg_class(type_T *type, type_T *decl_type UNUSED, argcontext_T *context)
 {
     if (type->tt_type == VAR_CLASS
-	    || type->tt_type == VAR_LIST
-	    || type_any_or_unknown(type))
+	//|| type->tt_type == VAR_TYPEALIAS
+	)
 	return OK;
+    // TODO: consider TYPEALIAS in following
     arg_type_mismatch(&t_class, type, context->arg_idx + 1);
     return FAIL;
 }
@@ -1152,7 +1153,8 @@ static argcheck_T arg1_len[] = {arg_len1};
 static argcheck_T arg3_libcall[] = {arg_string, arg_string, arg_string_or_nr};
 static argcheck_T arg14_maparg[] = {arg_string, arg_string, arg_bool, arg_bool};
 static argcheck_T arg2_filter[] = {arg_list_or_dict_or_blob_or_string_mod, arg_filter_func};
-static argcheck_T arg2_instanceof[] = {arg_object, arg_class_or_list};
+// TODO: instead of arg_class, could have args_class followed by 17 NULLs
+static argcheck_T arg219_instanceof[] = {arg_object, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class, arg_class};
 static argcheck_T arg2_map[] = {arg_list_or_dict_or_blob_or_string_mod, arg_map_func};
 static argcheck_T arg2_mapnew[] = {arg_list_or_dict_or_blob_or_string, NULL};
 static argcheck_T arg25_matchadd[] = {arg_string, arg_string, arg_number, arg_number, arg_dict_any};
@@ -2154,7 +2156,7 @@ static funcentry_T global_functions[] =
 			ret_string,	    f_inputsecret},
     {"insert",		2, 3, FEARG_1,	    arg23_insert,
 			ret_first_arg,	    f_insert},
-    {"instanceof",	2, 2, FEARG_1,	    arg2_instanceof,
+    {"instanceof",	2, 19, FEARG_1,	    arg219_instanceof,
 			ret_bool,	    f_instanceof},
     {"interrupt",	0, 0, 0,	    NULL,
 			ret_void,	    f_interrupt},

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -630,6 +630,29 @@ is_scoped_variable(char_u *name)
 }
 
 /*
+ * Check if the typval_T is a value; report an error if it is not.
+ * Only a value can be assigned to a variable; if it's not a value
+ * it's probably a type.
+ *
+ * Return OK if it's a value, else FAIL
+ */
+    int
+check_is_value(vartype_T typ)
+{
+    if (typ == VAR_CLASS)
+    {
+	emsg(_(e_cannot_assign_class_to_variable));
+	return FAIL;
+    }
+    //else if (typ == VAR_TYPEALIAS)
+    //{
+    //    emsg(_(e_cannot_assign_typealias_to_variable));
+    //    return FAIL;
+    //}
+    return OK;
+}
+
+/*
  * Evaluate one Vim expression {expr} in string "p" and append the
  * resulting string to "gap".  "p" points to the opening "{".
  * When "evaluate" is FALSE only skip over the expression.
@@ -1876,6 +1899,8 @@ ex_let_one(
 	p = get_lval(arg, tv, &lv, FALSE, FALSE, lval_flags, FNE_CHECK_START);
 	if (p != NULL && lv.ll_name != NULL)
 	{
+	    if (check_is_value(tv->v_type) == FAIL)
+		return NULL;
 	    if (endchars != NULL && vim_strchr(endchars,
 					   *skipwhite(lv.ll_name_end)) == NULL)
 	    {

--- a/src/list.c
+++ b/src/list.c
@@ -1572,6 +1572,13 @@ eval_list(char_u **arg, typval_T *rettv, evalarg_T *evalarg, int do_error)
     {
 	if (eval1(arg, &tv, evalarg) == FAIL)	// recursive!
 	    goto failret;
+	// TODO: For now skip checking for list item
+	//if (check_is_value(tv.v_type) == FAIL)
+	//{
+	//    if (evaluate)
+	//	clear_tv(&tv);
+	//    goto failret;
+	//}
 	if (evaluate)
 	{
 	    item = listitem_alloc();

--- a/src/list.c
+++ b/src/list.c
@@ -1572,13 +1572,12 @@ eval_list(char_u **arg, typval_T *rettv, evalarg_T *evalarg, int do_error)
     {
 	if (eval1(arg, &tv, evalarg) == FAIL)	// recursive!
 	    goto failret;
-	// TODO: For now skip checking for list item
-	//if (check_is_value(tv.v_type) == FAIL)
-	//{
-	//    if (evaluate)
-	//	clear_tv(&tv);
-	//    goto failret;
-	//}
+	if (check_is_value(tv.v_type) == FAIL)
+	{
+	    if (evaluate)
+		clear_tv(&tv);
+	    goto failret;
+	}
 	if (evaluate)
 	{
 	    item = listitem_alloc();

--- a/src/proto/evalvars.pro
+++ b/src/proto/evalvars.pro
@@ -14,6 +14,7 @@ int get_spellword(list_T *list, char_u **pp);
 void prepare_vimvar(int idx, typval_T *save_tv);
 void restore_vimvar(int idx, typval_T *save_tv);
 int is_scoped_variable(char_u *name);
+int check_is_value(vartype_T typ);
 char_u *eval_one_expr_in_str(char_u *p, garray_T *gap, int evaluate);
 list_T *heredoc_get(exarg_T *eap, char_u *cmd, int script_get, int vim9compile);
 void ex_var(exarg_T *eap);

--- a/src/proto/typval.pro
+++ b/src/proto/typval.pro
@@ -52,7 +52,7 @@ int check_for_list_or_dict_or_blob_arg(typval_T *args, int idx);
 int check_for_list_or_dict_or_blob_or_string_arg(typval_T *args, int idx);
 int check_for_opt_buffer_or_dict_arg(typval_T *args, int idx);
 int check_for_object_arg(typval_T *args, int idx);
-int check_for_class_or_list_arg(typval_T *args, int idx);
+int check_for_class_or_typealias_args(typval_T *args, int idx);
 char_u *tv_get_string(typval_T *varp);
 char_u *tv_get_string_strict(typval_T *varp);
 char_u *tv_get_string_buf(typval_T *varp, char_u *buf);

--- a/src/proto/userfunc.pro
+++ b/src/proto/userfunc.pro
@@ -7,7 +7,7 @@ char_u *register_cfunc(cfunc_T cb, cfunc_free_T cb_free, void *state);
 int get_lambda_tv(char_u **arg, typval_T *rettv, int types_optional, evalarg_T *evalarg);
 char_u *deref_func_name(char_u *name, int *lenp, partial_T **partialp, type_T **type, int no_autoload, int new_function, int *found_var);
 void emsg_funcname(char *ermsg, char_u *name);
-int get_func_arguments(char_u **arg, evalarg_T *evalarg, int partial_argc, typval_T *argvars, int *argcount);
+int get_func_arguments(char_u **arg, evalarg_T *evalarg, int partial_argc, typval_T *argvars, int *argcount, int is_builtin);
 int get_func_tv(char_u *name, int len, typval_T *rettv, char_u **arg, evalarg_T *evalarg, funcexe_T *funcexe);
 char_u *fname_trans_sid(char_u *name, char_u *fname_buf, char_u **tofree, funcerror_T *error);
 void func_name_with_sid(char_u *name, int sid, char_u *buffer);

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -2316,7 +2316,7 @@ def Test_instanceof()
     endclass
     instanceof(Foo.new(), 123)
   END
-  v9.CheckScriptFailure(lines, 'E693: List or Class required for argument 2')
+  v9.CheckScriptFailure(lines, 'E693: Class or Typealias required for argument 2')
 
   lines =<< trim END
     vim9script
@@ -2344,20 +2344,20 @@ def Test_instanceof()
     vim9script
     class Foo
     endclass
-    instanceof(Foo.new(), [{}])
+    instanceof(Foo.new(), {})
   END
-  v9.CheckSourceFailure(lines, 'E614: Class required')
+  v9.CheckSourceFailure(lines, 'E693: Class or Typealias required for argument 2')
 
   lines =<< trim END
     vim9script
     class Foo
     endclass
     def Bar()
-      instanceof(Foo.new(), [{}])
+      instanceof(Foo.new(), {})
     enddef
     Bar()
   END
-  v9.CheckSourceFailure(lines, 'E614: Class required')
+  v9.CheckSourceFailure(lines, 'E1013: Argument 2: type mismatch, expected class<Unknown> but got dict<unknown>')
 enddef
 
 def Test_invert()

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -190,7 +190,7 @@ def Test_class_basic()
     endclass
     sort([1.1, A], 'f')
   END
-  v9.CheckSourceFailure(lines, 'E1393: Cannot use a class as a variable or value', 4)
+  v9.CheckSourceFailure(lines, 'E1400: Cannot use a class as a variable or value', 4)
 
   # Test for using object as a float
   lines =<< trim END
@@ -3104,7 +3104,7 @@ def Test_assign_class_to_variable()
 
     var X = C
   END
-  v9.CheckSourceFailure(lines, 'E1393: Cannot use a class as a variable or value', 6)
+  v9.CheckSourceFailure(lines, 'E1400: Cannot use a class as a variable or value', 6)
 
   # :def
   lines =<< trim END
@@ -3118,7 +3118,7 @@ def Test_assign_class_to_variable()
     enddef
     F()
   END
-  v9.CheckSourceFailure(lines, 'E1393: Cannot use a class as a variable or value', 1)
+  v9.CheckSourceFailure(lines, 'E1400: Cannot use a class as a variable or value', 1)
 enddef
 
 def Test_construct_object_from_legacy()

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -190,7 +190,7 @@ def Test_class_basic()
     endclass
     sort([1.1, A], 'f')
   END
-  v9.CheckSourceFailure(lines, 'E1321: Using a Class as a Float', 4)
+  v9.CheckSourceFailure(lines, 'E1393: Cannot use a class as a variable or value', 4)
 
   # Test for using object as a float
   lines =<< trim END
@@ -3367,8 +3367,7 @@ def Test_instanceof()
     assert_true(instanceof(b2, Base1))
     assert_false(instanceof(b1, Base2))
     assert_true(instanceof(b3, Mix1))
-    assert_false(instanceof(b3, []))
-    assert_true(instanceof(b3, [Base1, Base2, Intf1]))
+    assert_true(instanceof(b3, Base1, Base2, Intf1))
 
     def Foo()
       var a1 = Base1.new()
@@ -3379,8 +3378,7 @@ def Test_instanceof()
       assert_true(instanceof(a2, Base1))
       assert_false(instanceof(a1, Base2))
       assert_true(instanceof(a3, Mix1))
-      assert_false(instanceof(a3, []))
-      assert_true(instanceof(a3, [Base1, Base2, Intf1]))
+      assert_true(instanceof(a3, Base1, Base2, Intf1))
     enddef
     Foo()
 
@@ -3389,6 +3387,58 @@ def Test_instanceof()
 
   END
   v9.CheckSourceSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+
+    class Base1
+    endclass
+    instanceof(Base1.new())
+  END
+  v9.CheckSourceFailure(lines, 'E119: Not enough arguments for function: instanceof')
+
+  lines =<< trim END
+    vim9script
+
+    class Base1
+    endclass
+    def F()
+      instanceof(Base1.new())
+    enddef
+    F()
+  END
+  v9.CheckSourceFailure(lines, 'E119: Not enough arguments for function: instanceof')
+
+  lines =<< trim END
+    vim9script
+
+    class Base1
+    endclass
+
+    class Base2
+    endclass
+
+    var o = Base2.new()
+    instanceof(o, Base1, Base2, 3)
+  END
+  v9.CheckSourceFailure(lines, 'E693: Class or Typealias required for argument 4', 10)
+
+  lines =<< trim END
+    vim9script
+
+    class Base1
+    endclass
+
+    class Base2
+    endclass
+
+    def F()
+      var o = Base2.new()
+      instanceof(o, Base1, Base2, 3)
+    enddef
+    F()
+  END
+  v9.CheckSourceFailure(lines, 'E1013: Argument 4: type mismatch, expected class<Unknown> but got number')
 enddef
 
 " Test for calling a method in the parent class that is extended partially.

--- a/src/typval.c
+++ b/src/typval.c
@@ -1004,15 +1004,21 @@ check_for_object_arg(typval_T *args, int idx)
 }
 
 /*
- * Give an error and return FAIL unless "args[idx]" is a class or a list.
+ * Give an error and return FAIL unless all of "args[idx]"
+ * to "args[xxx] == UNKNOWN" is a class.
  */
     int
-check_for_class_or_list_arg(typval_T *args, int idx)
+check_for_class_or_typealias_args(typval_T *args, int idx)
 {
-    if (args[idx].v_type != VAR_CLASS && args[idx].v_type != VAR_LIST)
+    for (int i = idx; args[i].v_type != VAR_UNKNOWN; ++i)
     {
-	semsg(_(e_list_or_class_required_for_argument_nr), idx + 1);
-	return FAIL;
+	if (args[i].v_type != VAR_CLASS
+	    // && args[i].v_type != VAR_TYPEALIAS
+	    )
+	{
+	    semsg(_(e_class_or_typealias_required_for_argument_nr), i + 1);
+	    return FAIL;
+	}
     }
     return OK;
 }

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -3154,39 +3154,30 @@ f_instanceof(typval_T *argvars, typval_T *rettv)
 {
     typval_T	*object_tv = &argvars[0];
     typval_T	*classinfo_tv = &argvars[1];
-    listitem_T	*li;
 
     rettv->vval.v_number = VVAL_FALSE;
 
     if (check_for_object_arg(argvars, 0) == FAIL
-	    || check_for_class_or_list_arg(argvars, 1) == FAIL)
+	    || check_for_class_or_typealias_args(argvars, 1) == FAIL)
 	return;
 
     if (object_tv->vval.v_object == NULL)
 	return;
 
-    if (classinfo_tv->v_type == VAR_LIST)
+    for (; classinfo_tv->v_type != VAR_UNKNOWN; ++classinfo_tv)
     {
-	FOR_ALL_LIST_ITEMS(classinfo_tv->vval.v_list, li)
+	if (classinfo_tv->v_type == VAR_CLASS)
 	{
-	    if (li->li_tv.v_type != VAR_CLASS)
-	    {
-		emsg(_(e_class_required));
-		return;
-	    }
-
 	    if (class_instance_of(object_tv->vval.v_object->obj_class,
-			li->li_tv.vval.v_class) == TRUE)
+					classinfo_tv->vval.v_class) == TRUE)
 	    {
 		rettv->vval.v_number = VVAL_TRUE;
 		return;
 	    }
 	}
-    }
-    else if (classinfo_tv->v_type == VAR_CLASS)
-    {
-	rettv->vval.v_number = class_instance_of(object_tv->vval.v_object->obj_class,
-		classinfo_tv->vval.v_class);
+	// else	// must be VAR_TYPEALIAS
+	// {
+	// }
     }
 }
 

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -2310,7 +2310,7 @@ call_oc_method(
     }
 
     char_u *argp = name_end;
-    int ret = get_func_arguments(&argp, evalarg, 0, argvars, &argcount);
+    int ret = get_func_arguments(&argp, evalarg, 0, argvars, &argcount, FALSE);
     if (ret == FAIL)
 	return FAIL;
 

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2806,6 +2806,8 @@ compile_assignment(
 
 		rhs_type = cctx->ctx_type_stack.ga_len == 0 ? &t_void
 						  : get_type_on_stack(cctx, 0);
+		if (check_is_value(rhs_type->tt_type) == FAIL)
+		    goto theend;
 		if (lhs.lhs_lvar != NULL && (is_decl || !lhs.lhs_has_type))
 		{
 		    if ((rhs_type->tt_type == VAR_FUNC

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -398,6 +398,9 @@ check_ufunc_arg_types(ufunc_T *ufunc, int argcount, int off, ectx_T *ectx)
 	if (argv[i].v_type == VAR_SPECIAL
 		&& argv[i].vval.v_number == VVAL_NONE)
 	    continue;
+	// only pass values to user functions, never types
+	if (check_is_value(argv[i].v_type) == FAIL)
+	    return FAIL;
 
 	if (i < ufunc->uf_args.ga_len && ufunc->uf_arg_types != NULL)
 	    type = ufunc->uf_arg_types[i];
@@ -4444,6 +4447,11 @@ exec_instructions(ectx_T *ectx)
 		    garray_T	*trystack = &ectx->ec_trystack;
 		    trycmd_T    *trycmd = NULL;
 
+		    ///////////////////////////////////////////////////
+		    // TODO: If FAIL, line number in output not correct
+		    ///////////////////////////////////////////////////
+		    if (check_is_value(STACK_TV_BOT(-1)->v_type) == FAIL)
+			goto theend;
 		    if (trystack->ga_len > 0)
 			trycmd = ((trycmd_T *)trystack->ga_data)
 							+ trystack->ga_len - 1;

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -1333,7 +1333,8 @@ generate_NEWLIST(cctx_T *cctx, int count, int use_null)
 
     // Get the member type and the declared member type from all the items on
     // the stack.
-    member_type = get_member_type_from_stack(count, 1, cctx);
+    if ((member_type = get_member_type_from_stack(count, 1, cctx)) == NULL)
+	return FAIL;
     type = get_list_type(member_type, cctx->ctx_type_list);
     decl_type = get_list_type(&t_any, cctx->ctx_type_list);
 
@@ -1361,7 +1362,8 @@ generate_NEWDICT(cctx_T *cctx, int count, int use_null)
 	return FAIL;
     isn->isn_arg.number = use_null ? -1 : count;
 
-    member_type = get_member_type_from_stack(count, 2, cctx);
+    if ((member_type = get_member_type_from_stack(count, 2, cctx)) == NULL)
+	return FAIL;
     type = get_dict_type(member_type, cctx->ctx_type_list);
     decl_type = get_dict_type(&t_any, cctx->ctx_type_list);
 
@@ -1958,6 +1960,8 @@ check_func_args_from_type(
 		type_T	*actual = get_type_on_stack(cctx, -1 - offset);
 		type_T	*expected;
 
+		if (check_is_value(actual->tt_type) == FAIL)
+		    return FAIL;
 		if (varargs && i >= type->tt_argcount - 1)
 		{
 		    expected = type->tt_args[type->tt_argcount - 1];

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -1644,16 +1644,19 @@ get_member_type_from_stack(
     if (count == 0)
 	return &t_unknown;
 
-    // Use the first value type for the list member type, then find the common
-    // type from following items.
+    // find the common type from items.
     typep = ((type2_T *)stack->ga_data) + stack->ga_len;
-    result = (typep -(count * skip) + skip - 1)->type_curr;
-    for (i = 1; i < count; ++i)
+    result = &t_unknown;
+    for (i = 0; i < count; ++i)
     {
-	if (result == &t_any)
-	    break;  // won't get more common
 	type = (typep -((count - i) * skip) + skip - 1)->type_curr;
-	common_type(type, result, &result, type_gap);
+	//if (check_is_value(type->tt_type) == FAIL)
+	// TODO: For now skip checking for list item
+	// Using "skip != 1", which happens to imply list, is an ugly HACK
+	if (skip != 1 && check_is_value(type->tt_type) == FAIL)
+	    return NULL;
+	if (result != &t_any)
+	    common_type(type, result, &result, type_gap);
     }
 
     return result;

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -1650,10 +1650,7 @@ get_member_type_from_stack(
     for (i = 0; i < count; ++i)
     {
 	type = (typep -((count - i) * skip) + skip - 1)->type_curr;
-	//if (check_is_value(type->tt_type) == FAIL)
-	// TODO: For now skip checking for list item
-	// Using "skip != 1", which happens to imply list, is an ugly HACK
-	if (skip != 1 && check_is_value(type->tt_type) == FAIL)
+	if (check_is_value(type->tt_type) == FAIL)
 	    return NULL;
 	if (result != &t_any)
 	    common_type(type, result, &result, type_gap);


### PR DESCRIPTION
@lifepillar @yegappan @dkearns please review.
Code reviewers, please consider where the errors are generated. Is there a better place to check? Are all the cases caught?


Error is `E1393: Cannot use a class as a variable or value`

**notes on changes**

Prevent assignment
- from non-value items, e.g. `class` or `typealias`.
- of non-value items as function argument or return.
- to `dict`/`list`: `var l = [1, C]`, `var d = {x: C}`.

NOTE: currently non-value items can be added to a list (while #13421 is being sorted out)
NOTE: a builtin must not return a non-value:, bare, in `list`, in `dict`

Here's an overview of the code changes made (so far).
```
simple assignments
    scriptlevel assignment  ex_let_one in evalvars.c
    :def assignment         compile_assignment in vim9compile.c

Function related checks
    scriptlevel argument    get_func_arguments in userfunc.c
    argument, call in def   check_ufunc_arg_types in vim9execute.c
    return value            ISN_RETURN (but gives wrong line number)
    defer/funcref           check_func_args_from_type in vim9instr.c

dict/list checks
    script list         eval_list in list.c
    script dict         eval_dict in dict.c
    compile list/dict   get_member_type_from_stack in vim9instr.c
```
There is a separate commit for `instanceof()` experimentation.
There is a separate commit for uniform builtin argument checking.

**TODO**
- More tests.
  Fixed tests as needed, but have around a dozen or so tests to write based on debug scripts. Plan to add tests after initial review (particularly of the error message).

**What now?**

This PR is very conservative. Some of the checks could be backed out.
The advantage of aggressive checks is uniformity, which should be less
confusing.
- No extra builtin checks, builtins have their own checks.
- Allow non-values in list/dict.
  This would ease some problems with builtins like `instanceof()`
  This still wouldn't allow the use of the non-value.
  Need to prevent non-value from being the result of an expression;
  protects against usage like aList[0].new().


---

**Notes on why the change**

With this PR, `Test_call_constructor_from_legacy()` failed, the test has been
replaced with `Test_construct_object_from_legacy()` which shows an alternate
way to do the same thing.

There's the following TODO item:
```
When "Meta" is a class, is "const MetaAlias = Meta" allowed?  It should
either work or given an error. Possibly give an error now and implement it
later (using a typedef).  #12006
```

This PR "give[s] an error now".
The important question: does preventing this take away an important capability?

When I first saw this TODO, I wondered why not just let it be, and take care
of it later. I played with it, #12961, and noted that it was very limited with
common stuff not working. I think I didn't read the original issue, #12006,
carefully; just reading it now, Bram's argument is
- it should be handled by typedef whenever something like that becomes available
- there is no class type.

If it's left in, **it leaves a lot of technical debt** to get it fully working.

Some uses for this, can be achieved with something like
```
class C
    static def CreateC(): any ... enddef
endclass
var CreateC: func = C.Create
```
