### PR TITLE
Add support for type aliases (:type)

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -743,12 +743,13 @@ constructor methods.
 
 7.  Type definition					*Vim9-type* *:type*
 
-{not implemented yet}
+A type definition is giving a name to a type specification.  This also known
+type alias.  For Example: >
 
-A type definition is giving a name to a type specification.  For Example: >
+	:type ListOfStrings = list<string>
 
-	:type ListOfStrings list<string>
-
+The type alias can be used wherever a built-in type can be used.  The type
+alias name must start with an upper case character.
 
 ==============================================================================
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -3384,17 +3384,17 @@ EXTERN char e_invalid_object_variable_declaration_str[]
 EXTERN char e_not_valid_command_in_class_str[]
 	INIT(= N_("E1318: Not a valid command in a class: %s"));
 EXTERN char e_using_class_as_number[]
-	INIT(= N_("E1319: Using a class as a Number"));
+	INIT(= N_("E1319: Using a Class as a Number"));
 EXTERN char e_using_object_as_number[]
-	INIT(= N_("E1320: Using an object as a Number"));
+	INIT(= N_("E1320: Using an Object as a Number"));
 EXTERN char e_using_class_as_float[]
-	INIT(= N_("E1321: Using a class as a Float"));
+	INIT(= N_("E1321: Using a Class as a Float"));
 EXTERN char e_using_object_as_float[]
-	INIT(= N_("E1322: Using an object as a Float"));
+	INIT(= N_("E1322: Using an Object as a Float"));
 EXTERN char e_using_class_as_string[]
-	INIT(= N_("E1323: Using a class as a String"));
+	INIT(= N_("E1323: Using a Class as a String"));
 EXTERN char e_using_object_as_string[]
-	INIT(= N_("E1324: Using an object as a String"));
+	INIT(= N_("E1324: Using an Object as a String"));
 EXTERN char e_method_not_found_on_class_str_str[]
 	INIT(= N_("E1325: Method \"%s\" not found in class \"%s\""));
 EXTERN char e_variable_not_found_on_object_str_str[]
@@ -3538,8 +3538,22 @@ EXTERN char e_cannot_lock_object_variable_str[]
 	INIT(= N_("E1391: Cannot (un)lock variable \"%s\" in class \"%s\""));
 EXTERN char e_cannot_lock_class_variable_str[]
 	INIT(= N_("E1392: Cannot (un)lock class variable \"%s\" in class \"%s\""));
+EXTERN char e_type_can_only_be_defined_in_vim9_script[]
+	INIT(= N_("E1393: Type can only be defined in Vim9 script"));
+EXTERN char e_type_name_must_start_with_uppercase_letter_str[]
+	INIT(= N_("E1394: Type name must start with an uppercase letter: %s"));
+EXTERN char e_using_typealias_as_variable[]
+	INIT(= N_("E1395: Type alias \"%s\" cannot be used as a variable"));
+EXTERN char e_typealias_already_exists_for_str[]
+	INIT(= N_("E1396: Type alias \"%s\" already exists"));
+EXTERN char e_missing_typealias_name[]
+	INIT(= N_("E1397: Missing type alias name"));
+EXTERN char e_missing_typealias_type[]
+	INIT(= N_("E1398: Missing type alias type"));
+EXTERN char e_type_can_only_be_used_in_script[]
+	INIT(= N_("E1399: Type can only be used in a script"));
 #endif
-// E1393 - E1499 unused (reserved for Vim9 class support)
+// E1400 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3890,6 +3890,12 @@ f_empty(typval_T *argvars, typval_T *rettv)
 			       || !channel_is_open(argvars[0].vval.v_channel);
 	    break;
 #endif
+	case VAR_TYPEALIAS:
+	    n = argvars[0].vval.v_typealias == NULL
+		|| argvars[0].vval.v_typealias->ta_name == NULL
+		|| *argvars[0].vval.v_typealias->ta_name == NUL;
+	    break;
+
 	case VAR_UNKNOWN:
 	case VAR_ANY:
 	case VAR_VOID:
@@ -7539,6 +7545,7 @@ f_len(typval_T *argvars, typval_T *rettv)
 	case VAR_INSTR:
 	case VAR_CLASS:
 	case VAR_OBJECT:
+	case VAR_TYPEALIAS:
 	    emsg(_(e_invalid_type_for_len));
 	    break;
     }
@@ -10885,6 +10892,7 @@ f_type(typval_T *argvars, typval_T *rettv)
 	case VAR_INSTR:   n = VAR_TYPE_INSTR; break;
 	case VAR_CLASS:   n = VAR_TYPE_CLASS; break;
 	case VAR_OBJECT:  n = VAR_TYPE_OBJECT; break;
+	case VAR_TYPEALIAS: n = VAR_TYPE_TYPEALIAS; break;
 	case VAR_UNKNOWN:
 	case VAR_ANY:
 	case VAR_VOID:

--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -6772,6 +6772,7 @@ ConvertToPyObject(typval_T *tv)
 	case VAR_INSTR:
 	case VAR_CLASS:
 	case VAR_OBJECT:
+	case VAR_TYPEALIAS:
 	    Py_INCREF(Py_None);
 	    return Py_None;
 	case VAR_BOOL:

--- a/src/json.c
+++ b/src/json.c
@@ -310,6 +310,7 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_INSTR:
 	case VAR_CLASS:
 	case VAR_OBJECT:
+	case VAR_TYPEALIAS:
 	    semsg(_(e_cannot_json_encode_str), vartype_name(val->v_type));
 	    return FAIL;
 

--- a/src/proto/vim9class.pro
+++ b/src/proto/vim9class.pro
@@ -4,6 +4,8 @@ void ex_class(exarg_T *eap);
 type_T *oc_member_type(class_T *cl, int is_object, char_u *name, char_u *name_end, int *member_idx);
 type_T *oc_member_type_by_idx(class_T *cl, int is_object, int member_idx);
 void ex_enum(exarg_T *eap);
+void typealias_free(typealias_T *ta);
+void typealias_unref(typealias_T *ta);
 void ex_type(exarg_T *eap);
 int class_object_index(char_u **arg, typval_T *rettv, evalarg_T *evalarg, int verbose);
 ufunc_T *find_class_func(char_u **arg);

--- a/src/structs.h
+++ b/src/structs.h
@@ -1468,6 +1468,7 @@ typedef struct ectx_S ectx_T;
 typedef struct instr_S instr_T;
 typedef struct class_S class_T;
 typedef struct object_S object_T;
+typedef struct typealias_S typealias_T;
 
 typedef enum
 {
@@ -1489,6 +1490,7 @@ typedef enum
     VAR_INSTR,		// "v_instr" is used
     VAR_CLASS,		// "v_class" is used (also used for interface)
     VAR_OBJECT,		// "v_object" is used
+    VAR_TYPEALIAS	// "v_typealias" is used
 } vartype_T;
 
 // A type specification.
@@ -1602,6 +1604,13 @@ struct object_S
     int		obj_copyID;	    // used by garbage collection
 };
 
+struct typealias_S
+{
+    int	    ta_refcount;
+    type_T  *ta_type;
+    char_u  *ta_name;
+};
+
 /*
  * Structure to hold an internal variable without a name.
  */
@@ -1625,6 +1634,7 @@ struct typval_S
 	instr_T		*v_instr;	// instructions to execute
 	class_T		*v_class;	// class value (can be NULL)
 	object_T	*v_object;	// object value (can be NULL)
+	typealias_T	*v_typealias;	// user-defined type name
     }		vval;
 };
 

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -170,7 +170,7 @@ def Test_class_basic()
     if A
     endif
   END
-  v9.CheckSourceFailure(lines, 'E1319: Using a class as a Number', 4)
+  v9.CheckSourceFailure(lines, 'E1319: Using a Class as a Number', 4)
 
   # Test for using object as a bool
   lines =<< trim END
@@ -181,7 +181,7 @@ def Test_class_basic()
     if a
     endif
   END
-  v9.CheckSourceFailure(lines, 'E1320: Using an object as a Number', 5)
+  v9.CheckSourceFailure(lines, 'E1320: Using an Object as a Number', 5)
 
   # Test for using class as a float
   lines =<< trim END
@@ -190,7 +190,7 @@ def Test_class_basic()
     endclass
     sort([1.1, A], 'f')
   END
-  v9.CheckSourceFailure(lines, 'E1321: Using a class as a Float', 4)
+  v9.CheckSourceFailure(lines, 'E1321: Using a Class as a Float', 4)
 
   # Test for using object as a float
   lines =<< trim END
@@ -200,7 +200,7 @@ def Test_class_basic()
     var a = A.new()
     sort([1.1, a], 'f')
   END
-  v9.CheckSourceFailure(lines, 'E1322: Using an object as a Float', 5)
+  v9.CheckSourceFailure(lines, 'E1322: Using an Object as a Float', 5)
 
   # Test for using class as a string
   lines =<< trim END
@@ -209,7 +209,7 @@ def Test_class_basic()
     endclass
     :exe 'call ' .. A
   END
-  v9.CheckSourceFailure(lines, 'E1323: Using a class as a String', 4)
+  v9.CheckSourceFailure(lines, 'E1323: Using a Class as a String', 4)
 
   # Test for using object as a string
   lines =<< trim END
@@ -219,7 +219,7 @@ def Test_class_basic()
     var a = A.new()
     :exe 'call ' .. a
   END
-  v9.CheckSourceFailure(lines, 'E1324: Using an object as a String', 5)
+  v9.CheckSourceFailure(lines, 'E1324: Using an Object as a String', 5)
 
   # Test creating a class with member variables and methods, calling a object
   # method.  Check for using type() and typename() with a class and an object.

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -4722,7 +4722,7 @@ def Test_defer_after_exception()
 
     assert_equal([2, 3, 1, 4, 5, 6, 7], callTrace)
   END
-  v9.CheckScriptSuccess(lines)
+  v9.CheckSourceSuccess(lines)
 enddef
 
 " Test for multiple deferred function which throw exceptions.
@@ -4779,6 +4779,384 @@ def Test_multidefer_with_exception()
 
     assert_equal('E605: Exception not caught: InnerException', v:errmsg)
     assert_equal([11, 9, 10, 7, 8, 5, 1, 3, 4, 12, 15, 16], callTrace)
+  END
+  v9.CheckSourceSuccess(lines)
+enddef
+
+" Test for :type command to create type aliases
+def Test_typealias()
+  var lines =<< trim END
+    vim9script
+    type ListOfStrings = list<string>
+    var a: ListOfStrings = ['a', 'b']
+    assert_equal(['a', 'b'], a)
+    def Foo(b: ListOfStrings): ListOfStrings
+      var c: ListOfStrings = ['c', 'd']
+      assert_equal(['c', 'd'], c)
+      return b
+    enddef
+    assert_equal(['e', 'f'], Foo(['e', 'f']))
+    assert_equal('typealias<list<string>>', typename(ListOfStrings))
+    assert_equal(v:t_typealias, type(ListOfStrings))
+    assert_equal('ListOfStrings', string(ListOfStrings))
+    assert_equal(false, null == ListOfStrings)
+  END
+  v9.CheckSourceSuccess(lines)
+
+  # Use :type outside a Vim9 script
+  lines =<< trim END
+    type Index = number
+  END
+  v9.CheckSourceFailure(lines, 'E1393: Type can only be defined in Vim9 script', 1)
+
+  # Use :type without any arguments
+  lines =<< trim END
+    vim9script
+    type
+  END
+  v9.CheckSourceFailure(lines, 'E1397: Missing type alias name', 2)
+
+  # Use :type with a name but no type
+  lines =<< trim END
+    vim9script
+    type MyType
+  END
+  v9.CheckSourceFailure(lines, "E398: Missing '=': ", 2)
+
+  # Use :type with a name but no type following "="
+  lines =<< trim END
+    vim9script
+    type MyType =
+  END
+  v9.CheckSourceFailure(lines, 'E1398: Missing type alias type', 2)
+
+  # No space before or after "="
+  lines =<< trim END
+    vim9script
+    type MyType=number
+  END
+  v9.CheckSourceFailure(lines, 'E1315: White space required after name: MyType=number', 2)
+
+  # No space after "="
+  lines =<< trim END
+    vim9script
+    type MyType =number
+  END
+  v9.CheckSourceFailure(lines, "E1069: White space required after '=': =number", 2)
+
+  # type alias without "="
+  lines =<< trim END
+    vim9script
+    type Index number
+  END
+  v9.CheckSourceFailure(lines, "E398: Missing '=': number", 2)
+
+  # type alias for a non-existing type
+  lines =<< trim END
+    vim9script
+    type Index = integer
+  END
+  v9.CheckSourceFailure(lines, 'E1010: Type not recognized: integer', 2)
+
+  # type alias starting with lower-case letter
+  lines =<< trim END
+    vim9script
+    type index number
+  END
+  v9.CheckSourceFailure(lines, 'E1394: Type name must start with an uppercase letter: index number', 2)
+
+  # No white space following the alias name
+  lines =<< trim END
+    vim9script
+    type Index:number
+  END
+  v9.CheckSourceFailure(lines, 'E1315: White space required after name: Index:number', 2)
+
+  # something following the type alias
+  lines =<< trim END
+    vim9script
+    type ListOfNums = list<number> string
+  END
+  v9.CheckSourceFailure(lines, 'E488: Trailing characters:  string', 2)
+
+  # type alias name collides with a variable name
+  lines =<< trim END
+    vim9script
+    var ListOfNums: number = 10
+    type ListOfNums = list<number>
+  END
+  v9.CheckSourceFailure(lines, 'E1041: Redefining script item: "ListOfNums"', 3)
+
+  # duplicate type alias name
+  lines =<< trim END
+    vim9script
+    type MyList = list<number>
+    type MyList = list<string>
+  END
+  v9.CheckSourceFailure(lines, 'E1396: Type alias "MyList" already exists', 3)
+
+  # Sourcing a script twice (which will free script local variables)
+  lines =<< trim END
+    vim9script
+    class C
+    endclass
+    type AC = C
+    assert_equal('typealias<object<C>>', typename(AC))
+  END
+  new
+  setline(1, lines)
+  :source
+  :source
+  bw!
+
+  # Assigning to a type alias (script level)
+  lines =<< trim END
+    vim9script
+    type MyType = list<number>
+    MyType = [1, 2, 3]
+  END
+  v9.CheckSourceFailure(lines, 'E1395: Type alias "MyType" cannot be used as a variable', 3)
+
+  # Assigning a type alias (def function level)
+  lines =<< trim END
+    vim9script
+    type A = list<string>
+    def Foo()
+      var x = A
+    enddef
+    Foo()
+  END
+  v9.CheckSourceFailure(lines, 'E1395: Type alias "A" cannot be used as a variable', 1)
+
+  # Using type alias in an expression (script level)
+  lines =<< trim END
+    vim9script
+    type MyType = list<number>
+    assert_fails('var m = MyType', 'E1395: Type alias "MyType" cannot be used as a variable')
+    assert_fails('var i = MyType + 1', 'E1395: Type alias "MyType" cannot be used as a variable')
+    assert_fails('var f = 1.0 + MyType', 'E1395: Type alias "MyType" cannot be used as a variable')
+    assert_fails('MyType += 10', 'E1395: Type alias "MyType" cannot be used as a variable')
+  END
+  v9.CheckSourceSuccess(lines)
+
+  # Using type alias in an expression (def function level)
+  lines =<< trim END
+    vim9script
+    type MyType = list<number>
+    def Foo()
+      var x = MyType + 1
+    enddef
+    Foo()
+  END
+  v9.CheckSourceFailure(lines, 'E1395: Type alias "MyType" cannot be used as a variable', 1)
+
+  # Using type alias in an expression (def function level)
+  lines =<< trim END
+    vim9script
+    type MyType = list<number>
+    def Foo()
+      MyType = list<string>
+    enddef
+    Foo()
+  END
+  v9.CheckSourceFailure(lines, 'E46: Cannot change read-only variable "MyType"', 1)
+
+  # Using type alias in an expression (def function level)
+  lines =<< trim END
+    vim9script
+    type MyType = list<number>
+    def Foo()
+      MyType += 10
+    enddef
+    Foo()
+  END
+  v9.CheckSourceFailure(lines, 'E46: Cannot change read-only variable "MyType"', 1)
+
+  # Creating a typealias in a def function
+  lines =<< trim END
+    vim9script
+    def Foo()
+      var n: number = 10
+      type A = list<string>
+    enddef
+    defcompile
+  END
+  v9.CheckSourceFailure(lines, 'E1399: Type can only be used in a script', 2)
+
+  # json_encode should fail with a type alias
+  lines =<< trim END
+    vim9script
+    type A = list<string>
+    var x = json_encode(A)
+  END
+  v9.CheckSourceFailure(lines, 'E1161: Cannot json encode a typealias', 3)
+
+  # Comparing type alias with a number (script level)
+  lines =<< trim END
+    vim9script
+    type A = list<string>
+    var n: number
+    var x = A == n
+  END
+  v9.CheckSourceFailure(lines, 'E1072: Cannot compare typealias with number', 4)
+
+  # Comparing type alias with a number (def function level)
+  lines =<< trim END
+    vim9script
+    type A = list<string>
+    def Foo()
+      var n: number
+      var x = A == n
+    enddef
+    Foo()
+  END
+  v9.CheckSourceFailure(lines, 'E1395: Type alias "A" cannot be used as a variable', 2)
+enddef
+
+" Test for exporting and importing type aliases
+def Test_import_typealias()
+  var lines =<< trim END
+    vim9script
+    export type MyType = list<number>
+  END
+  writefile(lines, 'Xtypeexport.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+    import './Xtypeexport.vim' as A
+
+    var myList: A.MyType = [1, 2, 3]
+    def Foo(l: A.MyType)
+      assert_equal([1, 2, 3], l)
+    enddef
+    Foo(myList)
+  END
+  v9.CheckScriptSuccess(lines)
+
+  # Use a non existing type alias
+  lines =<< trim END
+    vim9script
+    import './Xtypeexport.vim' as A
+
+    var myNum: A.SomeType = 10
+  END
+  v9.CheckScriptFailure(lines, 'E1010: Type not recognized: A.SomeType = 10', 4)
+
+  # Use a type alias that is not exported
+  lines =<< trim END
+    vim9script
+    type NewType = dict<string>
+  END
+  writefile(lines, 'Xtypeexport2.vim', 'D')
+  lines =<< trim END
+    vim9script
+    import './Xtypeexport2.vim' as A
+
+    var myDict: A.NewType = {}
+  END
+  v9.CheckScriptFailure(lines, 'E1049: Item not exported in script: NewType', 4)
+
+  # Using the same name as an imported type alias
+  lines =<< trim END
+    vim9script
+    export type MyType2 = list<number>
+  END
+  writefile(lines, 'Xtypeexport3.vim', 'D')
+  lines =<< trim END
+    vim9script
+    import './Xtypeexport3.vim' as A
+
+    type MyType2 = A.MyType2
+    var myList1: A.MyType2 = [1, 2, 3]
+    var myList2: MyType2 = [4, 5, 6]
+    assert_equal([1, 2, 3], myList1)
+    assert_equal([4, 5, 6], myList2)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
+" Test for using typealias as a def function argument and return type
+def Test_typealias_func_argument()
+  var lines =<< trim END
+    vim9script
+    type A = list<number>
+    def Foo(l: A): A
+      assert_equal([1, 2], l)
+      return l
+    enddef
+    var x: A = [1, 2]
+    assert_equal([1, 2], Foo(x))
+  END
+  v9.CheckScriptSuccess(lines)
+
+  # passing a type alias variable to a function expecting a specific type
+  lines =<< trim END
+    vim9script
+    type A = list<number>
+    def Foo(l: list<number>)
+      assert_equal([1, 2], l)
+    enddef
+    var x: A = [1, 2]
+    Foo(x)
+  END
+  v9.CheckScriptSuccess(lines)
+
+  # passing a type alias variable to a function expecting any
+  lines =<< trim END
+    vim9script
+    type A = list<number>
+    def Foo(l: any)
+      assert_equal([1, 2], l)
+    enddef
+    var x: A = [1, 2]
+    Foo(x)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
+" Using a type alias with a builtin function
+def Test_typealias_with_builtin_functions()
+  var lines =<< trim END
+    vim9script
+    type A = list<func>
+    assert_equal(0, empty(A))
+  END
+  v9.CheckScriptSuccess(lines)
+
+  # Using a type alias with len()
+  lines =<< trim END
+    vim9script
+    type A = list<func>
+    var x = len(A)
+  END
+  v9.CheckScriptFailure(lines, 'E701: Invalid type for len()', 3)
+
+  # Using a type alias with eval()
+  lines =<< trim END
+    vim9script
+    type A = number
+    def Foo()
+      var x = eval("A")
+    enddef
+    Foo()
+  END
+  v9.CheckScriptFailure(lines, 'E1395: Type alias "A" cannot be used as a variable', 1)
+enddef
+
+" Test for type alias refcount
+def Test_typealias_refcount()
+  var lines =<< trim END
+    vim9script
+    type A = list<func>
+    assert_equal(1, test_refcount(A))
+  END
+  v9.CheckScriptSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+    type B = list<number>
+    var x: B = []
+    assert_equal(1, test_refcount(B))
   END
   v9.CheckScriptSuccess(lines)
 enddef

--- a/src/testing.c
+++ b/src/testing.c
@@ -1132,6 +1132,10 @@ f_test_refcount(typval_T *argvars, typval_T *rettv)
 	    if (argvars[0].vval.v_dict != NULL)
 		retval = argvars[0].vval.v_dict->dv_refcount - 1;
 	    break;
+	case VAR_TYPEALIAS:
+	    if (argvars[0].vval.v_typealias != NULL)
+		retval = argvars[0].vval.v_typealias->ta_refcount - 1;
+	    break;
     }
 
     rettv->v_type = VAR_NUMBER;

--- a/src/typval.c
+++ b/src/typval.c
@@ -92,6 +92,10 @@ free_tv(typval_T *varp)
 	    object_unref(varp->vval.v_object);
 	    break;
 
+	case VAR_TYPEALIAS:
+	    typealias_unref(varp->vval.v_typealias);
+	    break;
+
 	case VAR_NUMBER:
 	case VAR_FLOAT:
 	case VAR_ANY:
@@ -168,6 +172,10 @@ clear_tv(typval_T *varp)
 	case VAR_OBJECT:
 	    object_unref(varp->vval.v_object);
 	    varp->vval.v_object = NULL;
+	    break;
+	case VAR_TYPEALIAS:
+	    typealias_unref(varp->vval.v_typealias);
+	    varp->vval.v_typealias = NULL;
 	    break;
 	case VAR_UNKNOWN:
 	case VAR_ANY:
@@ -261,6 +269,10 @@ tv_get_bool_or_number_chk(
 	    break;
 	case VAR_VOID:
 	    emsg(_(e_cannot_use_void_value));
+	    break;
+	case VAR_TYPEALIAS:
+	    semsg(_(e_using_typealias_as_variable),
+					varp->vval.v_typealias->ta_name);
 	    break;
 	case VAR_UNKNOWN:
 	case VAR_ANY:
@@ -378,6 +390,10 @@ tv_get_float_chk(typval_T *varp, int *error)
 	    break;
 	case VAR_VOID:
 	    emsg(_(e_cannot_use_void_value));
+	    break;
+	case VAR_TYPEALIAS:
+	    semsg(_(e_using_typealias_as_variable),
+					varp->vval.v_typealias->ta_name);
 	    break;
 	case VAR_UNKNOWN:
 	case VAR_ANY:
@@ -1129,6 +1145,7 @@ tv_get_string_buf_chk_strict(typval_T *varp, char_u *buf, int strict)
 	case VAR_VOID:
 	    emsg(_(e_cannot_use_void_value));
 	    break;
+	case VAR_TYPEALIAS:
 	case VAR_UNKNOWN:
 	case VAR_ANY:
 	case VAR_INSTR:
@@ -1288,6 +1305,15 @@ copy_tv(typval_T *from, typval_T *to)
 	    {
 		to->vval.v_dict = from->vval.v_dict;
 		++to->vval.v_dict->dv_refcount;
+	    }
+	    break;
+	case VAR_TYPEALIAS:
+	    if (from->vval.v_typealias == NULL)
+		to->vval.v_typealias = NULL;
+	    else
+	    {
+		to->vval.v_typealias = from->vval.v_typealias;
+		++to->vval.v_typealias->ta_refcount;
 	    }
 	    break;
 	case VAR_VOID:
@@ -1596,6 +1622,7 @@ typval_compare_null(typval_T *tv1, typval_T *tv2)
 	    case VAR_FLOAT: if (!in_vim9script())
 				 return tv->vval.v_float == 0.0;
 			     break;
+	    case VAR_TYPEALIAS: return tv->vval.v_typealias == NULL;
 	    default: break;
 	}
     }
@@ -2068,6 +2095,9 @@ tv_equal(
 
 	case VAR_FUNC:
 	    return tv1->vval.v_string == tv2->vval.v_string;
+
+	case VAR_TYPEALIAS:
+	    return tv1->vval.v_typealias == tv2->vval.v_typealias;
 
 	case VAR_UNKNOWN:
 	case VAR_ANY:

--- a/src/vim.h
+++ b/src/vim.h
@@ -2142,7 +2142,8 @@ typedef int sock_T;
 #define VV_SIZEOFPOINTER 104
 #define VV_MAXCOL	105
 #define VV_PYTHON3_VERSION 106
-#define VV_LEN		107	// number of v: vars
+#define VV_TYPE_TYPEALIAS 107
+#define VV_LEN		108	// number of v: vars
 
 // used for v_number in VAR_BOOL and VAR_SPECIAL
 #define VVAL_FALSE	0L	// VAR_BOOL
@@ -2165,6 +2166,7 @@ typedef int sock_T;
 #define VAR_TYPE_INSTR	    11
 #define VAR_TYPE_CLASS	    12
 #define VAR_TYPE_OBJECT	    13
+#define VAR_TYPE_TYPEALIAS  15
 
 #define DICT_MAXNEST 100	// maximum nesting of lists and dicts
 

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -3807,6 +3807,13 @@ exec_instructions(ectx_T *ectx)
 	    case ISN_STORE:
 		--ectx->ec_stack.ga_len;
 		tv = STACK_TV_VAR(iptr->isn_arg.number);
+		if (STACK_TV_BOT(0)->v_type == VAR_TYPEALIAS)
+		{
+		    semsg(_(e_using_typealias_as_variable),
+				STACK_TV_BOT(0)->vval.v_typealias->ta_name);
+		    clear_tv(STACK_TV_BOT(0));
+		    goto on_error;
+		}
 		clear_tv(tv);
 		*tv = *STACK_TV_BOT(0);
 		break;
@@ -7517,6 +7524,7 @@ tv2bool(typval_T *tv)
 	case VAR_INSTR:
 	case VAR_CLASS:
 	case VAR_OBJECT:
+	case VAR_TYPEALIAS:
 	    break;
     }
     return FALSE;

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -238,6 +238,7 @@ compile_member(int is_slice, int *keeping_dict, cctx_T *cctx)
 	    case VAR_INSTR:
 	    case VAR_CLASS:
 	    case VAR_OBJECT:
+	    case VAR_TYPEALIAS:
 	    case VAR_UNKNOWN:
 	    case VAR_ANY:
 	    case VAR_VOID:
@@ -528,6 +529,13 @@ compile_load_scriptvar(
     if (idx >= 0)
     {
 	svar_T		*sv = ((svar_T *)si->sn_var_vals.ga_data) + idx;
+
+	if (sv->sv_tv->v_type == VAR_TYPEALIAS)
+	{
+	    semsg(_(e_using_typealias_as_variable),
+				sv->sv_tv->vval.v_typealias->ta_name);
+	    return FAIL;
+	}
 
 	generate_VIM9SCRIPT(cctx, ISN_LOADSCRIPT,
 					current_sctx.sc_sid, idx, sv->sv_type);

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -240,6 +240,7 @@ may_generate_2STRING(int offset, int tolerant, cctx_T *cctx)
 	case VAR_INSTR:
 	case VAR_CLASS:
 	case VAR_OBJECT:
+	case VAR_TYPEALIAS:
 			 to_string_error(type->tt_type);
 			 return FAIL;
     }

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1374,7 +1374,8 @@ write_viminfo_varlist(FILE *fp)
 		    case VAR_INSTR:
 		    case VAR_CLASS:
 		    case VAR_OBJECT:
-				     continue;
+		    case VAR_TYPEALIAS:
+				      continue;
 		}
 		fprintf(fp, "!%s\t%s\t", this_var->di_key, s);
 		if (this_var->di_tv.v_type == VAR_BOOL


### PR DESCRIPTION
Implement the :type command (in the todo list) to create type aliases.
