### PR TITLE
completion: move in right direction when  filling completion_info()

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3051,19 +3051,19 @@ info_add_completion_info(list_T *li)
 
     match = compl_first_match;
     // There are four cases to consider here:
-    // 1) when just going forward through the menu, 
+    // 1) when just going forward through the menu,
     //    compl_first_match should point to the initial entry with
     //    number zero and CP_ORIGINAL_TEXT flag set
     // 2) when just going backwards,
     //    compl-first_match should point to the last entry before
     //    the entry with the CP_ORIGINAL_TEXT flag set
     // 3) when first going forwards and then backwards, e.g.
-    //    pressing C-N, C-P, compl_first_match points to the 
+    //    pressing C-N, C-P, compl_first_match points to the
     //    last entry before the entry with the CP_ORIGINAL_TEXT
     //    flag set and next-entry moves opposite through the list
     //    compared to case 2, so pretend the direction is forward again
     // 4) when first going backwards and then forwards, e.g.
-    //    pressing C-P, C-N, compl_first_match points to the 
+    //    pressing C-P, C-N, compl_first_match points to the
     //    first entry with the CP_ORIGINAL_TEXT
     //    flag set and next-entry moves in opposite direction through the list
     //    compared to case 1, so pretend the direction is backwards again

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3044,14 +3044,39 @@ ins_compl_update_sequence_numbers(void)
 info_add_completion_info(list_T *li)
 {
     compl_T	*match;
+    int		forward = compl_dir_forward();
 
     if (compl_first_match == NULL)
 	return OK;
 
+    match = compl_first_match;
+    // There are four cases to consider here:
+    // 1) when just going forward through the menu, 
+    //    compl_first_match should point to the initial entry with
+    //    number zero and CP_ORIGINAL_TEXT flag set
+    // 2) when just going backwards,
+    //    compl-first_match should point to the last entry before
+    //    the entry with the CP_ORIGINAL_TEXT flag set
+    // 3) when first going forwards and then backwards, e.g.
+    //    pressing C-N, C-P, compl_first_match points to the 
+    //    last entry before the entry with the CP_ORIGINAL_TEXT
+    //    flag set and next-entry moves opposite through the list
+    //    compared to case 2, so pretend the direction is forward again
+    // 4) when first going backwards and then forwards, e.g.
+    //    pressing C-P, C-N, compl_first_match points to the 
+    //    first entry with the CP_ORIGINAL_TEXT
+    //    flag set and next-entry moves in opposite direction through the list
+    //    compared to case 1, so pretend the direction is backwards again
+
+    if (forward && !match_at_original_text(match))
+	forward = FALSE;
+    else if (!forward && match_at_original_text(match))
+	forward = TRUE;
+
     // Skip the element with the CP_ORIGINAL_TEXT flag at the beginning, in case of
     // forward completion, or at the end, in case of backward completion.
-    match = compl_dir_forward()
-	    ? compl_first_match->cp_next : compl_first_match->cp_prev->cp_prev;
+    match = forward ? match->cp_next : match->cp_prev->cp_prev;
+
     while (match != NULL && !match_at_original_text(match))
     {
 	dict_T *di = dict_alloc();
@@ -3071,7 +3096,7 @@ info_add_completion_info(list_T *li)
 	else
 	    dict_add_tv(di, "user_data", &match->cp_user_data);
 
-	match = compl_dir_forward() ? match->cp_next : match->cp_prev;
+	match = forward ? match->cp_next : match->cp_prev;
     }
 
     return OK;

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3067,15 +3067,20 @@ info_add_completion_info(list_T *li)
     //    first entry with the CP_ORIGINAL_TEXT
     //    flag set and next-entry moves in opposite direction through the list
     //    compared to case 1, so pretend the direction is backwards again
+    //
+    // But only do this when the 'noselect' option is not active!
 
-    if (forward && !match_at_original_text(match))
-	forward = FALSE;
-    else if (!forward && match_at_original_text(match))
-	forward = TRUE;
+    if (!compl_no_select)
+    {
+	if (forward && !match_at_original_text(match))
+	    forward = FALSE;
+	else if (!forward && match_at_original_text(match))
+	    forward = TRUE;
+    }
 
     // Skip the element with the CP_ORIGINAL_TEXT flag at the beginning, in case of
     // forward completion, or at the end, in case of backward completion.
-    match = forward ? match->cp_next : match->cp_prev->cp_prev;
+    match = forward ? match->cp_next : (compl_no_select ? match->cp_prev : match->cp_prev->cp_prev);
 
     while (match != NULL && !match_at_original_text(match))
     {

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2267,24 +2267,72 @@ func Test_complete_info_index()
   " Ensure 'index' in complete_info() is coherent with the 'items' array.
 
   set completeopt=menu,preview
-  " Search forward.
+  " Search forward
   call feedkeys("Go\<C-X>\<C-N>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
   call feedkeys("Go\<C-X>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("bbb", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("ccc", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("ddd", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("eee", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  " Search forward: unselected item
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal(6 , len(g:compl_info['items']))
+  call assert_equal(-1 , g:compl_info['selected'])
 
-  " Search backward.
+  " Search backward
   call feedkeys("Go\<C-X>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
   call feedkeys("Go\<C-X>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("eee", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("ddd", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("ccc", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("bbb", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  " search backwards: unselected item
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal(6 , len(g:compl_info['items']))
+  call assert_equal(-1 , g:compl_info['selected'])
 
-  " switch direction
+  " switch direction: forwards, then backwards
   call feedkeys("Go\<C-X>\<C-N>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  " switch direction: forwards, then backwards, then forwards again
+  call feedkeys("Go\<C-X>\<C-N>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-P>\<C-P>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
 
+  " switch direction: backwards, then forwards
   call feedkeys("Go\<C-X>\<C-P>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  " switch direction: backwards, then forwards, then backwards again
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-N>\<C-N>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
 
   " Add 'noselect', check that 'selected' is -1 when nothing is selected.
   set completeopt+=noselect

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2279,6 +2279,13 @@ func Test_complete_info_index()
   call feedkeys("Go\<C-X>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("eee", g:compl_info['items'][g:compl_info['selected']]['word'])
 
+  " switch direction
+  call feedkeys("Go\<C-X>\<C-N>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+
+  call feedkeys("Go\<C-X>\<C-P>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+
   " Add 'noselect', check that 'selected' is -1 when nothing is selected.
   set completeopt+=noselect
   " Search forward.

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2344,6 +2344,16 @@ func Test_complete_info_index()
   call feedkeys("Go\<C-X>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal(-1, g:compl_info['selected'])
 
+  " Check if index out of range
+  " https://github.com/vim/vim/pull/12971
+  call feedkeys("Go\<C-X>\<C-N>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal(0, g:compl_info['selected'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word']) 
+  call assert_equal(6 , len(g:compl_info['items']))
+
   set completeopt&
   bwipe!
 endfunc


### PR DESCRIPTION
When moving through the insert completion menu and switching directions, we need to make sure we start at the correct position in the list and move correctly forward/backwards through it, so that we do not skip entries and the selected item points to the correct entry in the list of completion entries generated by the completion_info() function.

The general case is this:

1) CTRL-X CTRL-N, we will traverse the list starting from
   compl_first_match and then go forwards (using the cp->next pointer)
   through the list (skipping the very first entry, which has the
   CP_ORIGINAL_TEXT flag set (since that is the empty/non-selected entry

2) CTRL-X CTRL-P, we will traverse the list starting from
   compl_first_match (which now points to the last entry). The previous
   entry will have the CP_ORIGINAL_TEXT flag set, so we need to start
   traversing the list from the second prev pointer.

There are in fact 2 special cases after starting the completion menu with CTRL-X:

3)  CTRL-N and then going backwards by pressing CTRL-P again.
    compl_first_match will point to the same entry as in step 1 above,
    but since compl_dir_foward() has been switched by pressing CTRL-P
    to backwards we need to pretend to be in still in case 1 and still
    traverse the list in forward direction using the cp_next pointer

4)  CTRL-P and then going forwards by pressing CTRL-N again.
    compl_first_match will point to the same entry as in step 2 above,
    but since compl_dir_foward() has been switched by pressing CTRL-N
    to forwards we need to pretend to be in still in case 2 and still
    traverse the list in backward direction using the cp_prev pointer

related: #13402
related: #12971