### PR TITLE
centralize safe executable check

### DIFF
--- a/runtime/autoload/dist/vim.vim
+++ b/runtime/autoload/dist/vim.vim
@@ -1,0 +1,17 @@
+vim9script
+
+# Vim runtime support library
+#
+# Maintainer:	The Vim Project <https://github.com/vim/vim>
+# Last Change:	2023 Oct 25
+
+export def IsSafeExecutable(filetype: string, executable: string): bool
+  var cwd = getcwd()
+  return get(g:, filetype .. '_exec', get(g:, 'plugin_exec', 0))
+    && (fnamemodify(exepath(executable), ':p:h') !=# cwd
+        || (split($PATH, has('win32') ? ';' : ':')->index(cwd) != -1
+            && cwd != '.'))
+enddef
+
+# Uncomment this line to check for compilation errors early
+# defcompile

--- a/runtime/autoload/gzip.vim
+++ b/runtime/autoload/gzip.vim
@@ -11,10 +11,7 @@ fun s:check(cmd)
   let name = substitute(a:cmd, '\(\S*\).*', '\1', '')
   if !exists("s:have_" . name)
     " safety check, don't execute anything from the current directory
-    let s:tmp_cwd = getcwd()
-    let f = (fnamemodify(exepath(name), ":p:h") !=# s:tmp_cwd
-          \ || (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) != -1 && s:tmp_cwd != '.'))
-    unlet s:tmp_cwd
+    let f = dist#vim#IsSafeExecutable('gzip', name)
     if !f
       echoerr "Warning: NOT executing " .. name .. " from current directory!"
     endif

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -57,14 +57,10 @@ if !exists("g:zip_extractcmd")
  let g:zip_extractcmd= g:zip_unzipcmd
 endif
 
-let s:tmp_cwd = getcwd()
-if (fnamemodify(exepath(g:zip_unzipcmd), ":p:h") ==# getcwd()
-          \ && (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) == -1 || s:tmp_cwd == '.'))
- unlet s:tmp_cwd
+if !dist#vim#IsSafeExecutable('zip', g:zip_unzipcmd)
  echoerr "Warning: NOT executing " .. g:zip_unzipcmd .. " from current directory!"
  finish
 endif
-unlet s:tmp_cwd
 
 " ----------------
 "  Functions: {{{1

--- a/runtime/ftplugin/awk.vim
+++ b/runtime/ftplugin/awk.vim
@@ -37,8 +37,8 @@ if exists("g:awk_is_gawk")
     let b:undo_ftplugin .= " | setl fp<"
   endif
 
-  " Disabled by default for security reasons.  
-  if get(g:, 'awk_exec', get(g:, 'plugin_exec', 0))
+  " Disabled by default for security reasons.
+  if dist#vim#IsSafeExecutable('awk', 'gawk')
     let path = system("gawk 'BEGIN { printf ENVIRON[\"AWKPATH\"] }'")
     let path = substitute(path, '^\.\=:\|:\.\=$\|:\.\=:', ',,', 'g') " POSIX cwd
     let path = substitute(path, ':', ',', 'g')

--- a/runtime/ftplugin/changelog.vim
+++ b/runtime/ftplugin/changelog.vim
@@ -57,8 +57,8 @@ if &filetype == 'changelog'
     endif
     let s:default_login = 'unknown'
 
-    " Disabled by default for security reasons.  
-    if get(g:, 'changelog_exec', get(g:, 'plugin_exec', 0))
+    " Disabled by default for security reasons.
+    if dist#vim#IsSafeExecutable('changelog', 'whoami')
       let login = s:login()
     else
       let login = s:default_login

--- a/runtime/ftplugin/perl.vim
+++ b/runtime/ftplugin/perl.vim
@@ -56,12 +56,8 @@ endif
 
 " Set this once, globally.
 if !exists("perlpath")
-    let s:tmp_cwd = getcwd()
     " safety check: don't execute perl binary by default
-    if executable("perl") && get(g:, 'perl_exec', get(g:, 'plugin_exec', 0))
-        \ && (fnamemodify(exepath("perl"), ":p:h") != s:tmp_cwd
-        \ || (index(split($PATH, has("win32") ? ';' : ':'), s:tmp_cwd) != -1
-        \ && s:tmp_cwd != '.'))
+    if dist#vim#IsSafeExecutable('perl', 'perl')
       try
 	if &shellxquote != '"'
 	    let perlpath = system('perl -e "print join(q/,/,@INC)"')
@@ -77,7 +73,6 @@ if !exists("perlpath")
 	" current directory and the directory of the current file.
 	let perlpath = ".,,"
     endif
-    unlet! s:tmp_cwd
 endif
 
 " Append perlpath to the existing path value, if it is set.  Since we don't

--- a/runtime/ftplugin/zig.vim
+++ b/runtime/ftplugin/zig.vim
@@ -41,16 +41,13 @@ let &l:define='\v(<fn>|<const>|<var>|^\s*\#\s*define)'
 
 " Safety check: don't execute zig from current directory
 if !exists('g:zig_std_dir') && exists('*json_decode') &&
-    \  executable('zig') && get(g:, 'zig_exec', get(g:, 'plugin_exec', 0))
-    \ && (fnamemodify(exepath("zig"), ":p:h") != s:tmp_cwd
-    \ || (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) != -1 && s:tmp_cwd != '.'))
+    \  executable('zig') && dist#vim#IsSafeExecutable('zig', 'zig')
     silent let s:env = system('zig env')
     if v:shell_error == 0
         let g:zig_std_dir = json_decode(s:env)['std_dir']
     endif
     unlet! s:env
 endif
-unlet! s:tmp_cwd
 
 if exists('g:zig_std_dir')
     let &l:path = g:zig_std_dir . ',' . &l:path


### PR DESCRIPTION
Follow up to 816fbcc26 (patch 9.0.1833: [security] runtime file fixes, 2023-08-31) and f7ac0ef50 (runtime: don't execute external commands when loading ftplugins, 2023-09-06).

This puts the logic for safe executable checks in a single place so all filetypes benefit from consistency.

Notable changes:
- The gzip and zip plugins need to be opted into by enabling execution of those programs (or the global plugin_exec). This needs documentation or discussion.
- The ruby check is performed twice because of how the code is organized. Perhaps this could be refactored? But the working directory is changed as part of the function, so for now I think it should stay as-is.
- This fixes a bug in the zig plugin: code setting s:tmp_cwd was removed in f7ac0ef50 (runtime: don't execute external commands when loading ftplugins, 2023-09-06), but the variable was still referenced. Since the new function takes care of that automatically, the variable is no longer needed.

---

I haven't updated the last changed headers yet; I'll let maintainers weigh in on that.

CC maintainers: @cecamp, @dkearns, Martin Florian (?), Perl maintainers @petdance, @tpope, Zig upstream (@andrewrk ?).