### PR TITLE
xxd: Fix that color was disabled on Cygwin

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -88,6 +88,8 @@
 #endif
 #if defined(WIN32) || defined(CYGWIN)
 # include <io.h>	/* for setmode() */
+#endif
+#ifdef WIN32
 # include <windows.h>
 #endif
 #ifdef UNIX


### PR DESCRIPTION
"windows.h" was unintentionally included on Cygwin since 9.0.1834. This accidentally disabled coloring on Cygwin.
Stop including "windows.h" on Cygwin.