### PR TITLE
Remove P_EXPAND flag from the 'filetype' option

### DIFF
--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -943,7 +943,7 @@ static struct vimoption options[] =
 				    (char_u *)FALSE,
 #endif
 					(char_u *)0L} SCTX_INIT},
-    {"filetype",    "ft",   P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_NOGLOB|P_NFNAME,
+    {"filetype",    "ft",   P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB|P_NFNAME,
 			    (char_u *)&p_ft, PV_FT,
 			    did_set_filetype_or_syntax, NULL,
 			    {(char_u *)"", (char_u *)0L}


### PR DESCRIPTION
Problem:  P_EXPAND flag is erroneously set for 'filetype' option
Solution: Remove the P_EXPAND flag

This flag is used by string options that accept file path values.  See
:help set_env.

This appears to have been included in d5e8c92 and resulted from an
incorrect implementation of 'filetype' completion.

See #12900 for a small discussion.
