### PR TITLE
Added the objdump file/text format

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1462,6 +1462,9 @@ au BufNewFile,BufRead {env,config}.nu		setf nu
 " Oblivion Language and Oblivion Script Extender
 au BufNewFile,BufRead *.obl,*.obse,*.oblivion,*.obscript  setf obse
 
+" Objdump
+au BufNewFile,BufRead *.objdump,*.cppobjdump  setf objdump
+
 " OCaml
 au BufNewFile,BufRead *.ml,*.mli,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.mlip,*.mli.cppo,*.ml.cppo setf ocaml
 

--- a/runtime/ftplugin/objdump.vim
+++ b/runtime/ftplugin/objdump.vim
@@ -1,0 +1,18 @@
+" Vim filetype plugin file
+" Language:     Objdump
+" Maintainer:   Colin Kennedy <colinvfx@gmail.com>
+" Last Change:  2023 October 25
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let b:did_ftplugin = 1
+
+setlocal commentstring=#\ %s
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/ftplugin/objdump.vim
+++ b/runtime/ftplugin/objdump.vim
@@ -7,12 +7,8 @@ if exists("b:did_ftplugin")
   finish
 endif
 
-let s:cpo_save = &cpo
-set cpo&vim
-
 let b:did_ftplugin = 1
 
-setlocal commentstring=#\ %s
+let b:undo_ftplugin = "setlocal cms<"
 
-let &cpo = s:cpo_save
-unlet s:cpo_save
+setlocal commentstring=#\ %s

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -495,6 +495,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     nsis: ['file.nsi', 'file.nsh'],
     nu: ['env.nu', 'config.nu'],
     obj: ['file.obj'],
+    objdump: ['file.objdump'],
     obse: ['file.obl', 'file.obse', 'file.oblivion', 'file.obscript'],
     ocaml: ['file.ml', 'file.mli', 'file.mll', 'file.mly', '.ocamlinit', 'file.mlt', 'file.mlp', 'file.mlip', 'file.mli.cppo', 'file.ml.cppo'],
     occam: ['file.occ'],


### PR DESCRIPTION
This PR adds filetype recognition for [Objdump](https://man7.org/linux/man-pages/man1/objdump.1.html) output files.

About objdump's file extensions, `.objdump` [seems to be the most common](https://github.com/search?q=path%3A**%2F*.objdump&type=code) among GitHub users. GitHub linguist claims that there's [several other recognized extensions](https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L1278-L1285) such as `.c++-objdump`, `.cpp-objdump`, `.cppobjdump`, and the like but they seemed to be pretty rare. I can include those as well if you'd like.

### About runtime/ftplugin/objdump.vim

Though a bit uncommon, objdump files do have auto-generated comments so I've added that to `runtime/ftplugin/objdump.vim`. You can see a couple examples here: https://github.com/ColinKennedy/tree-sitter-objdump/blob/master/test/corpus/comment.txt

Please let me know if you'd like me to include anything for this PR