### PR TITLE
Reset w_skipcol when unsetting 'wrap'

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -4081,11 +4081,9 @@ did_set_showtabline(optset_T *args UNUSED)
     char *
 did_set_smoothscroll(optset_T *args UNUSED)
 {
-    if (curwin->w_p_sms)
-	return NULL;
+    if (!curwin->w_p_sms)
+	curwin->w_skipcol = 0;
 
-    curwin->w_skipcol = 0;
-    changed_line_abv_curs();
     return NULL;
 }
 
@@ -4535,9 +4533,12 @@ did_set_winwidth(optset_T *args UNUSED)
     char *
 did_set_wrap(optset_T *args UNUSED)
 {
-    // If 'wrap' is set, set w_leftcol to zero.
+    // Set w_leftcol or w_skipcol to zero.
     if (curwin->w_p_wrap)
 	curwin->w_leftcol = 0;
+    else
+	curwin->w_skipcol = 0;
+
     return NULL;
 }
 

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -2207,4 +2207,20 @@ func Test_set_keyprotocol()
   let &term = term
 endfunc
 
+func Test_set_wrap()
+  " Unsetting 'wrap' when 'smoothscroll' is set does not result in incorrect
+  " cursor position.
+  set wrap smoothscroll scrolloff=5
+
+  call setline(1, ['', 'aaaa'->repeat(500)])
+  20 split
+  20 vsplit
+  norm 2G$
+  redraw
+  set nowrap
+  call assert_equal(2, winline())
+
+  set wrap& smoothscroll& scrolloff&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  With 'smoothscroll' set, "w_skipcol" is not reset when unsetting 'wrap'.
          Resulting in incorrect calculation of the cursor position.
Solution: Reset "w_skipcol" when unsetting 'wrap'.

fixes: #12970