### PR TITLE
Remove mode 1004 (focus reporting) from XM termcap

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -330,13 +330,11 @@ using the "xterm" workaround.  These are the relevant entries (so far):
 	PS	"\033[200~"	pasted text start |t_PS|
 	PE	"\033[201~"	pasted text end |t_PE|
 
-	XM	"\033[?1006;1004;1000%?%p1%{1}%=%th%el%;"
+	XM	"\033[?1006;1000%?%p1%{1}%=%th%el%;"
 				mouse enable / disable |t_XM|
 
 The "XM" entry includes "1006" to enable SGR style mouse reporting.  This
-supports columns above 223.  It also includes "1004" which enables focus
-reporting.  The t_fe and t_fd entries can be left empty (they don't have
-entries in terminfo/termcap anyway).
+supports columns above 223.
 
 						*xterm-kitty* *kitty-terminal*
 The Kitty terminal is a special case.  Mainly because it works differently


### PR DESCRIPTION
I am not sure why Bram added this snippet to the docs. The [commit][1] where this was added has only the commit message "Update runtime files", and I couldn't find any GitHub PRs or anything in the vim_dev mailing list about this either.

Mode 1004 (focus reporting) is not actually used in the [default `XM` termcap][2] defined in Vim. Ncurses mentions only modes 1000 and 1006 in their documentation ([here][3] and [here][4]).

Focus reporting does not have its own terminfo entry but does have its own Vim option (`t_fe` and `t_fd`) and correct default values. So adding mode 1004 to `XM` is not even necessary to enable focus events.

This is a documentation only change, so it does not fix any actual bugs (in Vim, anyway. It does cause bugs in other programs). But Vim is often used as a reference for how to support various terminal features, so this will hopefully prevent people from copying Vim's documentation and adding mode 1004 to the XM capability.

[1]: https://github.com/vim/vim/commit/be4e01637e71c8d5095c33b9861fd70b41476732
[2]: https://github.com/vim/vim/blob/87ca5e86fa0ef305f3d39cc4261b622f21417f7f/src/term.c#L477
[3]: https://www.man7.org/linux/man-pages/man5/user_caps.5.html
[4]: https://github.com/mirror/ncurses/blob/87c2c84cbd2332d6d94b12a1dcaf12ad1a51a938/doc/html/man/curs_mouse.3x.html#L339
