### PR TITLE
Check for more error conditions and add additional tests

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -749,7 +749,9 @@ type alias.  For Example: >
 	:type ListOfStrings = list<string>
 
 The type alias can be used wherever a built-in type can be used.  The type
-alias name must start with an upper case character.
+alias name must start with an upper case character.  A type alias can be
+created only at the script level and not inside a function.  A type alias can
+be exported and used across scripts.
 
 ==============================================================================
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -3542,8 +3542,8 @@ EXTERN char e_type_can_only_be_defined_in_vim9_script[]
 	INIT(= N_("E1393: Type can only be defined in Vim9 script"));
 EXTERN char e_type_name_must_start_with_uppercase_letter_str[]
 	INIT(= N_("E1394: Type name must start with an uppercase letter: %s"));
-EXTERN char e_using_typealias_as_variable[]
-	INIT(= N_("E1395: Type alias \"%s\" cannot be used as a variable"));
+EXTERN char e_cannot_modify_typealias[]
+	INIT(= N_("E1395: Type alias \"%s\" cannot be modified"));
 EXTERN char e_typealias_already_exists_for_str[]
 	INIT(= N_("E1396: Type alias \"%s\" already exists"));
 EXTERN char e_missing_typealias_name[]
@@ -3552,8 +3552,16 @@ EXTERN char e_missing_typealias_type[]
 	INIT(= N_("E1398: Missing type alias type"));
 EXTERN char e_type_can_only_be_used_in_script[]
 	INIT(= N_("E1399: Type can only be used in a script"));
+EXTERN char e_using_typealias_as_number[]
+	INIT(= N_("E1400: Using type alias \"%s\" as a Number"));
+EXTERN char e_using_typealias_as_float[]
+	INIT(= N_("E1401: Using type alias \"%s\" as a Float"));
+EXTERN char e_using_typealias_as_string[]
+	INIT(= N_("E1402: Using type alias \"%s\" as a String"));
+EXTERN char e_using_typealias_as_value[]
+	INIT(= N_("E1403: Type alias \"%s\" cannot be used as a value"));
 #endif
-// E1400 - E1499 unused (reserved for Vim9 class support)
+// E1404 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/eval.c
+++ b/src/eval.c
@@ -1885,7 +1885,7 @@ set_var_lval(
 	    {
 		if (di != NULL && di->di_tv.v_type == VAR_TYPEALIAS)
 		{
-		    semsg(_(e_using_typealias_as_variable),
+		    semsg(_(e_cannot_modify_typealias),
 					di->di_tv.vval.v_typealias->ta_name);
 		    clear_tv(&tv);
 		    return;
@@ -4045,7 +4045,8 @@ eval8(
 
 	    if (!equal_type(want_type, actual, 0))
 	    {
-		if (want_type == &t_bool && actual != &t_bool
+		if (want_type->tt_type == VAR_BOOL
+					&& actual->tt_type != VAR_BOOL
 					&& (actual->tt_flags & TTFLAG_BOOL_OK))
 		{
 		    int n = tv2bool(rettv);

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -1838,7 +1838,7 @@ ex_let_one(
 
     if (tv->v_type == VAR_TYPEALIAS)
     {
-	semsg(_(e_using_typealias_as_variable), tv->vval.v_typealias->ta_name);
+	semsg(_(e_using_typealias_as_value), tv->vval.v_typealias->ta_name);
 	return NULL;
     }
 
@@ -3979,7 +3979,7 @@ set_var_const(
 
 	    if (di->di_tv.v_type == VAR_TYPEALIAS)
 	    {
-		semsg(_(e_using_typealias_as_variable),
+		semsg(_(e_cannot_modify_typealias),
 					    di->di_tv.vval.v_typealias->ta_name);
 		clear_tv(&di->di_tv);
 		goto failed;

--- a/src/proto/typval.pro
+++ b/src/proto/typval.pro
@@ -52,6 +52,7 @@ int check_for_list_or_dict_or_blob_arg(typval_T *args, int idx);
 int check_for_list_or_dict_or_blob_or_string_arg(typval_T *args, int idx);
 int check_for_opt_buffer_or_dict_arg(typval_T *args, int idx);
 int check_for_object_arg(typval_T *args, int idx);
+int tv_class_alias(typval_T *tv);
 int check_for_class_or_list_arg(typval_T *args, int idx);
 char_u *tv_get_string(typval_T *varp);
 char_u *tv_get_string_strict(typval_T *varp);

--- a/src/typval.c
+++ b/src/typval.c
@@ -271,7 +271,7 @@ tv_get_bool_or_number_chk(
 	    emsg(_(e_cannot_use_void_value));
 	    break;
 	case VAR_TYPEALIAS:
-	    semsg(_(e_using_typealias_as_variable),
+	    semsg(_(e_using_typealias_as_number),
 					varp->vval.v_typealias->ta_name);
 	    break;
 	case VAR_UNKNOWN:
@@ -392,7 +392,7 @@ tv_get_float_chk(typval_T *varp, int *error)
 	    emsg(_(e_cannot_use_void_value));
 	    break;
 	case VAR_TYPEALIAS:
-	    semsg(_(e_using_typealias_as_variable),
+	    semsg(_(e_using_typealias_as_float),
 					varp->vval.v_typealias->ta_name);
 	    break;
 	case VAR_UNKNOWN:
@@ -1004,12 +1004,23 @@ check_for_object_arg(typval_T *args, int idx)
 }
 
 /*
+ * Returns TRUE if "tv" is a type alias for a class
+ */
+    int
+tv_class_alias(typval_T *tv)
+{
+    return tv->v_type == VAR_TYPEALIAS &&
+			tv->vval.v_typealias->ta_type->tt_type == VAR_OBJECT;
+}
+
+/*
  * Give an error and return FAIL unless "args[idx]" is a class or a list.
  */
     int
 check_for_class_or_list_arg(typval_T *args, int idx)
 {
-    if (args[idx].v_type != VAR_CLASS && args[idx].v_type != VAR_LIST)
+    if (args[idx].v_type != VAR_CLASS && args[idx].v_type != VAR_LIST
+					&& !tv_class_alias(&args[idx]))
     {
 	semsg(_(e_list_or_class_required_for_argument_nr), idx + 1);
 	return FAIL;
@@ -1146,6 +1157,9 @@ tv_get_string_buf_chk_strict(typval_T *varp, char_u *buf, int strict)
 	    emsg(_(e_cannot_use_void_value));
 	    break;
 	case VAR_TYPEALIAS:
+	    semsg(_(e_using_typealias_as_string),
+					varp->vval.v_typealias->ta_name);
+	    break;
 	case VAR_UNKNOWN:
 	case VAR_ANY:
 	case VAR_INSTR:

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -2196,13 +2196,26 @@ ex_type(exarg_T *eap UNUSED)
 	goto done;
     }
 
-    // Add the user-defined type to the script-local variables.
-    tv.v_type = VAR_TYPEALIAS;
-    tv.v_lock = 0;
-    tv.vval.v_typealias = ALLOC_CLEAR_ONE(typealias_T);
-    ++tv.vval.v_typealias->ta_refcount;
-    tv.vval.v_typealias->ta_name = vim_strsave(name_start);
-    tv.vval.v_typealias->ta_type = type;
+    // Create a script-local variable for the type alias.
+    if (type->tt_type != VAR_OBJECT)
+    {
+	tv.v_type = VAR_TYPEALIAS;
+	tv.v_lock = 0;
+	tv.vval.v_typealias = ALLOC_CLEAR_ONE(typealias_T);
+	++tv.vval.v_typealias->ta_refcount;
+	tv.vval.v_typealias->ta_name = vim_strsave(name_start);
+	tv.vval.v_typealias->ta_type = type;
+    }
+    else
+    {
+	// When creating a type alias for a class, use the class type itself to
+	// create the type alias variable.  This is needed to use the type
+	// alias to invoke class methods (e.g. new()) and use class variables.
+	tv.v_type = VAR_CLASS;
+	tv.v_lock = 0;
+	tv.vval.v_class = type->tt_class;
+	++tv.vval.v_class->class_refcount;
+    }
     set_var_const(name_start, current_sctx.sc_sid, NULL, &tv, FALSE,
 						ASSIGN_CONST | ASSIGN_FINAL, 0);
 
@@ -3155,6 +3168,7 @@ f_instanceof(typval_T *argvars, typval_T *rettv)
     typval_T	*object_tv = &argvars[0];
     typval_T	*classinfo_tv = &argvars[1];
     listitem_T	*li;
+    class_T	*c;
 
     rettv->vval.v_number = VVAL_FALSE;
 
@@ -3169,25 +3183,35 @@ f_instanceof(typval_T *argvars, typval_T *rettv)
     {
 	FOR_ALL_LIST_ITEMS(classinfo_tv->vval.v_list, li)
 	{
-	    if (li->li_tv.v_type != VAR_CLASS)
+	    if (li->li_tv.v_type != VAR_CLASS && !tv_class_alias(&li->li_tv))
 	    {
 		emsg(_(e_class_required));
 		return;
 	    }
 
-	    if (class_instance_of(object_tv->vval.v_object->obj_class,
-			li->li_tv.vval.v_class) == TRUE)
+	    if (li->li_tv.v_type == VAR_TYPEALIAS)
+		c = li->li_tv.vval.v_typealias->ta_type->tt_class;
+	    else
+		c = li->li_tv.vval.v_class;
+
+	    if (class_instance_of(object_tv->vval.v_object->obj_class, c)
+								== TRUE)
 	    {
 		rettv->vval.v_number = VVAL_TRUE;
 		return;
 	    }
 	}
+
+	return;
     }
-    else if (classinfo_tv->v_type == VAR_CLASS)
-    {
-	rettv->vval.v_number = class_instance_of(object_tv->vval.v_object->obj_class,
-		classinfo_tv->vval.v_class);
-    }
+
+    if (classinfo_tv->v_type == VAR_TYPEALIAS)
+	c = classinfo_tv->vval.v_typealias->ta_type->tt_class;
+    else
+	c = classinfo_tv->vval.v_class;
+
+    rettv->vval.v_number =
+		class_instance_of(object_tv->vval.v_object->obj_class, c);
 }
 
 #endif // FEAT_EVAL

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -3809,7 +3809,7 @@ exec_instructions(ectx_T *ectx)
 		tv = STACK_TV_VAR(iptr->isn_arg.number);
 		if (STACK_TV_BOT(0)->v_type == VAR_TYPEALIAS)
 		{
-		    semsg(_(e_using_typealias_as_variable),
+		    semsg(_(e_using_typealias_as_value),
 				STACK_TV_BOT(0)->vval.v_typealias->ta_name);
 		    clear_tv(STACK_TV_BOT(0));
 		    goto on_error;

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -530,13 +530,6 @@ compile_load_scriptvar(
     {
 	svar_T		*sv = ((svar_T *)si->sn_var_vals.ga_data) + idx;
 
-	if (sv->sv_tv->v_type == VAR_TYPEALIAS)
-	{
-	    semsg(_(e_using_typealias_as_variable),
-				sv->sv_tv->vval.v_typealias->ta_name);
-	    return FAIL;
-	}
-
 	generate_VIM9SCRIPT(cctx, ISN_LOADSCRIPT,
 					current_sctx.sc_sid, idx, sv->sv_type);
 	return OK;

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -1811,7 +1811,13 @@ f_typename(typval_T *argvars, typval_T *rettv)
     rettv->v_type = VAR_STRING;
     ga_init2(&type_list, sizeof(type_T *), 10);
     if (argvars[0].v_type == VAR_TYPEALIAS)
-	type = argvars[0].vval.v_typealias->ta_type;
+    {
+	type = copy_type(argvars[0].vval.v_typealias->ta_type, &type_list);
+	// A type alias for a class has the type set to VAR_OBJECT.  Change it
+	// to VAR_CLASS, so that the name is "typealias<class<xxx>>"
+	if (type->tt_type == VAR_OBJECT)
+	    type->tt_type = VAR_CLASS;
+    }
     else
 	type = typval2type(argvars, get_copyID(), &type_list, TVTT_DO_MEMBER);
     name = type_name(type, &tofree);


### PR DESCRIPTION
Fixes #13434, #13437 and #13438 and supports using class type aliases to create new objects.
