### PR TITLE
Add Dart shebang filetype detection

### DIFF
--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -221,6 +221,10 @@ export def Exe2filetype(name: string, line1: string): string
   elseif name =~ '^janet\>'
     return 'janet'
 
+    # Dart
+  elseif name =~ '^dart\>'
+    return 'dart'
+
   endif
 
   return ''

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -955,7 +955,8 @@ def s:GetScriptChecks(): dict<list<list<string>>>
     crystal: [['#!/path/crystal']],
     rexx:   [['#!/path/rexx'],
             ['#!/path/regina']],
-    janet: [['#!/path/janet']],
+    janet:  [['#!/path/janet']],
+    dart:   [['#!/path/dart']],
   }
 enddef
 


### PR DESCRIPTION
Problem:  Not all Dart files detected
Solution: Add shebang filetype detection for Dart
