### PR TITLE
Completion_info not filled

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3080,7 +3080,7 @@ info_add_completion_info(list_T *li)
 
     // Skip the element with the CP_ORIGINAL_TEXT flag at the beginning, in case of
     // forward completion, or at the end, in case of backward completion.
-    match = forward ? match->cp_next : (compl_no_select ? match->cp_prev : match->cp_prev->cp_prev);
+    match = forward ? match->cp_next : (compl_no_select && match_at_original_text(match) ? match->cp_prev : match->cp_prev->cp_prev);
 
     while (match != NULL && !match_at_original_text(match))
     {

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2344,14 +2344,15 @@ func Test_complete_info_index()
   call feedkeys("Go\<C-X>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal(-1, g:compl_info['selected'])
 
-  " Check if index out of range
-  " https://github.com/vim/vim/pull/12971
   call feedkeys("Go\<C-X>\<C-N>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal(0, g:compl_info['selected'])
   call assert_equal(6 , len(g:compl_info['items']))
   call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
   call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal(-1, g:compl_info['selected'])
   call assert_equal(6 , len(g:compl_info['items']))
 
   set completeopt&


### PR DESCRIPTION
Unfortunately, Commit daef8c74375141974d61b85199b383017644978c introduced a regression, that when ':set completeopt+=noselect' is set and no completion item has been selected yet, it did not fill the complete_info['items'] list.

This happened, because the current match item did not have the CP_ORIGINAL_TEXT flag set and then the cp->prev pointer did point to the original flag item, which caused the following while loop to not being run but being skipped instead.

So when the 'noselect' is set, only start with to the previous selection item, if the initial completion item has the CP_ORIGINAL_TEXT flag set, else use the 2nd previous item instead.

fixes: #vim/vim#13451