### PR TITLE
Remove unnecessary field os_doskip

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -3680,7 +3680,6 @@ did_set_modifiable(optset_T *args UNUSED)
 		    && curbuf->b_term != NULL && !term_is_finished(curbuf))))
     {
 	curbuf->b_p_ma = FALSE;
-	args->os_doskip = TRUE;
 	return e_cannot_make_terminal_with_running_job_modifiable;
     }
 # endif
@@ -3942,7 +3941,6 @@ did_set_previewwindow(optset_T *args)
 	if (win->w_p_pvw && win != curwin)
 	{
 	    curwin->w_p_pvw = FALSE;
-	    args->os_doskip = TRUE;
 	    return e_preview_window_already_exists;
 	}
 
@@ -4130,7 +4128,6 @@ did_set_termguicolors(optset_T *args UNUSED)
 	    !has_vtp_working())
     {
 	p_tgc = 0;
-	args->os_doskip = TRUE;
 	return e_24_bit_colors_are_not_supported_on_this_environment;
     }
     if (is_term_win32())
@@ -4602,7 +4599,7 @@ set_bool_option(
 	args.os_newval.boolean = value;
 	args.os_errbuf = NULL;
 	errmsg = options[opt_idx].opt_did_set_cb(&args);
-	if (args.os_doskip)
+	if (errmsg != NULL)
 	    return errmsg;
     }
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -4948,10 +4948,6 @@ typedef struct
 	char_u	*string;
     } os_newval;
 
-    // When set by the called function: Stop processing the option further.
-    // Currently only used for boolean options.
-    int		os_doskip;
-
     // Option value was checked to be safe, no need to set P_INSECURE
     // Used for the 'keymap', 'filetype' and 'syntax' options.
     int		os_value_checked;


### PR DESCRIPTION
Callback functions for boolean options set os_doskip immediately before
returning an error message, so os_doskip isn't actually needed.
