### PR TITLE
Disallow the use of abstract in an interface

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3560,8 +3560,10 @@ EXTERN char e_using_typealias_as_string[]
 	INIT(= N_("E1402: Using type alias \"%s\" as a String"));
 EXTERN char e_using_typealias_as_value[]
 	INIT(= N_("E1403: Type alias \"%s\" cannot be used as a value"));
+EXTERN char e_abstract_cannot_be_used_in_interface[]
+	INIT(= N_("E1404: Abstract cannot be used in an interface"));
 #endif
-// E1404 - E1499 unused (reserved for Vim9 class support)
+// E1405 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -5567,7 +5567,26 @@ def Test_abstract_method()
       enddef
     endclass
   END
-  v9.CheckSourceSuccess(lines)
+  v9.CheckSourceFailure(lines, 'E1404: Abstract cannot be used in an interface', 3)
+
+  # Use abstract static method in an interface
+  lines =<< trim END
+    vim9script
+    interface A
+      abstract static def Foo()
+      enddef
+    endinterface
+  END
+  v9.CheckSourceFailure(lines, 'E1404: Abstract cannot be used in an interface', 3)
+
+  # Use abstract static variable in an interface
+  lines =<< trim END
+    vim9script
+    interface A
+      abstract static foo: number = 10
+    endinterface
+  END
+  v9.CheckSourceFailure(lines, 'E1404: Abstract cannot be used in an interface', 3)
 
   # Abbreviate the "abstract" keyword
   lines =<< trim END

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1557,26 +1557,27 @@ early_ret:
 		break;
 	    }
 
-	    if (!is_class)
-		// ignore "abstract" in an interface (as all the methods in an
-		// interface are abstract.
-		p = skipwhite(pa + 8);
-	    else
+	    p = skipwhite(pa + 8);
+	    if (STRNCMP(p, "def", 3) != 0 && STRNCMP(p, "static", 6) != 0)
 	    {
-		if (!is_abstract)
-		{
-		    semsg(_(e_abstract_method_in_concrete_class), pa);
-		    break;
-		}
-
-		abstract_method = TRUE;
-		p = skipwhite(pa + 8);
-		if (STRNCMP(p, "def", 3) != 0 && STRNCMP(p, "static", 6) != 0)
-		{
-		    emsg(_(e_abstract_must_be_followed_by_def_or_static));
-		    break;
-		}
+		emsg(_(e_abstract_must_be_followed_by_def_or_static));
+		break;
 	    }
+
+	    if (!is_class)
+	    {
+		// "abstract" not supported in an interface
+		emsg(_(e_abstract_cannot_be_used_in_interface));
+		break;
+	    }
+
+	    if (!is_abstract)
+	    {
+		semsg(_(e_abstract_method_in_concrete_class), pa);
+		break;
+	    }
+
+	    abstract_method = TRUE;
 	}
 
 	int has_static = FALSE;


### PR DESCRIPTION
Instead of silently ignoring the `abstract` keyword in an interface, give an error message.

Fixes #13456.