### PR TITLE
Disallow abstract static methods

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -411,6 +411,8 @@ prefix when defining the method: >
 	   abstract static def SetColor()
 	endclass
 <
+A static method in an abstract class cannot be an abstract method.
+
 						*E1373*
 A class extending the abstract class must implement all the abstract methods.
 The signature (arguments, argument types and return type) must be exactly the

--- a/src/errors.h
+++ b/src/errors.h
@@ -3494,8 +3494,8 @@ EXTERN char e_duplicate_variable_str[]
 	INIT(= N_("E1369: Duplicate variable: %s"));
 EXTERN char e_cannot_define_new_method_as_static[]
 	INIT(= N_("E1370: Cannot define a \"new\" method as static"));
-EXTERN char e_abstract_must_be_followed_by_def_or_static[]
-	INIT(= N_("E1371: Abstract must be followed by \"def\" or \"static\""));
+EXTERN char e_abstract_must_be_followed_by_def[]
+	INIT(= N_("E1371: Abstract must be followed by \"def\""));
 EXTERN char e_abstract_method_in_concrete_class[]
 	INIT(= N_("E1372: Abstract method \"%s\" cannot be defined in a concrete class"));
 EXTERN char e_abstract_method_str_not_found[]

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -35,7 +35,7 @@ def Test_class_basic()
   END
   v9.CheckSourceFailure(lines, 'E475: Invalid argument: noclass Something', 2)
 
-  # Only the completed word "class" should be recognized
+  # Only the complete word "class" should be recognized
   lines =<< trim END
     vim9script
     abstract classy Something
@@ -4186,8 +4186,8 @@ enddef
 def Test_lockvar_islocked()
   # Can't lock class/object variable
   # Lock class/object variable's value
-  # Lock item of variabl's value (a list item)
-  # varible is at index 1 within class/object
+  # Lock item of variable's value (a list item)
+  # variable is at index 1 within class/object
   var lines =<< trim END
     vim9script
 
@@ -5585,7 +5585,7 @@ def Test_abstract_method()
       abstract this.val = 10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1371: Abstract must be followed by "def" or "static"', 3)
+  v9.CheckSourceFailure(lines, 'E1371: Abstract must be followed by "def"', 3)
 
   # Use a static abstract method
   lines =<< trim END
@@ -5593,14 +5593,8 @@ def Test_abstract_method()
     abstract class A
       abstract static def Foo(): number
     endclass
-    class B extends A
-      static def Foo(): number
-        return 4
-      enddef
-    endclass
-    assert_equal(4, B.Foo())
   END
-  v9.CheckSourceSuccess(lines)
+  v9.CheckSourceFailure(lines, 'E1371: Abstract must be followed by "def"', 3)
 
   # Type mismatch between abstract method and concrete method
   lines =<< trim END
@@ -5615,17 +5609,6 @@ def Test_abstract_method()
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1383: Method "Foo": type mismatch, expected func(string, number): list<number> but got func(number, string): list<string>', 9)
-
-  # Use an abstract class to invoke an abstract method
-  # FIXME: This should fail
-  lines =<< trim END
-    vim9script
-    abstract class A
-      abstract static def Foo()
-    endclass
-    A.Foo()
-  END
-  v9.CheckSourceSuccess(lines)
 
   # Invoke an abstract method from a def function
   lines =<< trim END
@@ -5643,6 +5626,18 @@ def Test_abstract_method()
     enddef
     var b = B.new()
     Bar(b)
+  END
+  v9.CheckSourceSuccess(lines)
+
+  # Use a static method in an abstract class
+  lines =<< trim END
+    vim9script
+    abstract class A
+      static def Foo(): string
+        return 'foo'
+      enddef
+    endclass
+    assert_equal('foo', A.Foo())
   END
   v9.CheckSourceSuccess(lines)
 enddef

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1571,9 +1571,9 @@ early_ret:
 
 		abstract_method = TRUE;
 		p = skipwhite(pa + 8);
-		if (STRNCMP(p, "def", 3) != 0 && STRNCMP(p, "static", 6) != 0)
+		if (STRNCMP(p, "def", 3) != 0)
 		{
-		    emsg(_(e_abstract_must_be_followed_by_def_or_static));
+		    emsg(_(e_abstract_must_be_followed_by_def));
 		    break;
 		}
 	    }


### PR DESCRIPTION
Abstract static methods are not allowed in other OOP languages:

https://docs.oracle.com/javase/specs/jls/se9/html/jls-8.html#jls-8.4.3
https://www.reddit.com/r/java/comments/76d874/can_abstract_methods_be_declared_static/
https://stackoverflow.com/questions/20741737/can-one-declare-a-static-method-within-an-abstract-class-in-dart
https://github.com/microsoft/TypeScript/issues/14600

Disallow abstract static methods in Vim9 classes also. Fixes #13462.