### PR TITLE
Mark tests as skipped when ch_open encounters E901

### DIFF
--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -113,6 +113,8 @@ func RunServer(cmd, testfunc, args)
     endif
 
     call call(function(a:testfunc), [port])
+  catch /E901.*Address family for hostname not supported/
+    throw 'Skipped: Invalid network setup ("' .. v:exception .. '" in ' .. v:throwpoint .. ')'
   catch
     call assert_report('Caught exception: "' . v:exception . '" in ' . v:throwpoint)
   finally


### PR DESCRIPTION
On some of the Debian build systems, the IPv6 channel tests fail because `ch_open('[::1]:<port>', ...)` raises the error "E901: getaddrinfo() in channel_open(): Address family for hostname not supported".

This appears to happen because `getaddrinfo()` can't perform the reverse lookup for the ::1, which is a config issue on that system.  Therefore, instead of reporting a test failure, mark the test as skipped due to the bad network config.