### PR TITLE
make strace ft check less strict

### DIFF
--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -369,7 +369,7 @@ def DetectFromText(line1: string)
 
     # Strace
     # inaccurate fast match first, then use accurate slow match
-  elseif (line1 =~ 'execve(' && line1 =~ '^[0-9:.]* *execve(')
+  elseif (line1 =~ 'execve(' && line1 =~ '^[0-9:. ]*execve(')
 	   || line1 =~ '^__libc_start_main'
     setl ft=strace
 


### PR DESCRIPTION
Strace output, depending on parameters (`-ttf` this time), can dump both times and pid:
```
  1038  07:14:20.959262 execve("./e.py", ["./e.py"], 0x7ffca1422840 /* 51 vars */) = 0 <0.000150>
```
So loose the regexp matching this, so that the above is matched too.

Fixes #13481.