### PR TITLE
Fix the regression caused by 9.0.2072

### DIFF
--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -2992,13 +2992,67 @@ def Test_list_item_assign()
     vim9script
 
     def Foo()
-        var l: list<list<string>> = [['x', 'x', 'x'], ['y', 'y', 'y']]
-        var z: number = 1
+      var l: list<list<string>> = [['x', 'x', 'x'], ['y', 'y', 'y']]
+      var z: number = 1
 
-        [l[1][2], z] = ['a', 20]
-        assert_equal([['x', 'x', 'x'], ['y', 'y', 'a']], l)
+      [l[1][2], z] = ['a', 20]
+      assert_equal([['x', 'x', 'x'], ['y', 'y', 'a']], l)
     enddef
     Foo()
+  END
+  v9.CheckSourceSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+
+    var l: list<list<string>> = [['x', 'x', 'x'], ['y', 'y', 'y']]
+    var z: number = 1
+
+    [l[1][2], z] = ['a', 20]
+    assert_equal([['x', 'x', 'x'], ['y', 'y', 'a']], l)
+  END
+  v9.CheckSourceSuccess(lines)
+enddef
+
+" Test for assigning to a multi-dimensional dict item.
+def Test_dict_item_assign()
+  # This used to fail with the error "E1105: Cannot convert list to string"
+  # (Github issue #13485)
+  var lines =<< trim END
+    vim9script
+    def F()
+      var d: dict<dict<number>> = {a: {b: 0}}
+
+      for group in keys(d)
+        d['a']['b'] += 1
+      endfor
+      assert_equal({a: {b: 1}}, d)
+    enddef
+    F()
+  END
+  v9.CheckSourceSuccess(lines)
+
+  # This used to crash Vim
+  lines =<< trim END
+    vim9script
+    def F()
+      var d: dict<dict<number>> = {a: {b: 0}}
+      d['a']['b'] += 1
+      assert_equal({a: {b: 1}}, d)
+    enddef
+    F()
+  END
+  v9.CheckSourceSuccess(lines)
+
+  # Assignment at script level
+  lines =<< trim END
+    vim9script
+    var d: dict<dict<number>> = {a: {b: 0}}
+
+    for group in keys(d)
+      d['a']['b'] += 1
+    endfor
+    assert_equal({a: {b: 1}}, d)
   END
   v9.CheckSourceSuccess(lines)
 enddef

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -560,7 +560,6 @@ def Test_disassemble_store_index()
         '\d LOAD $0\_s*' ..
         '\d MEMBER dd\_s*' ..
         '\d\+ USEDICT\_s*' ..
-        '\d\+ 2STRING stack\[-2\]\_s*' ..
         '\d\+ STOREINDEX any\_s*' ..
         '\d\+ RETURN void',
         res)

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2221,15 +2221,6 @@ compile_load_lhs(
 		return FAIL;
 	}
 
-	if (lhs->lhs_type->tt_type == VAR_DICT && var_start[varlen] == '[')
-	{
-	    // If the lhs is a Dict variable and an item is accessed by "[",
-	    // then need to convert the key into a string.  The top item in the
-	    // type stack is the Dict and the second last item is the key.
-	    if (may_generate_2STRING(-2, FALSE, cctx) == FAIL)
-		return FAIL;
-	}
-
 	// Now we can properly check the type.  The variable is indexed, thus
 	// we need the member type.  For a class or object we don't know the
 	// type yet, it depends on what member is used.


### PR DESCRIPTION
The instruction to convert the dict index to a string is generated later in the compile_member() function.  So no need to generate that in compile_load_lhs().

Fixes #13485.