### PR TITLE
Make `autoload/dist/vim.vim` work properly when lacking vim9script support

### DIFF
--- a/runtime/autoload/dist/vim.vim
+++ b/runtime/autoload/dist/vim.vim
@@ -15,16 +15,18 @@ if !exists('g:gzip_exec')
   let g:gzip_exec = 1
 endif
 
-if !exists(":def")
-    function dist#vim#IsSafeExecutable(filetype, executable)
+if !has('vim9script')
+  function dist#vim#IsSafeExecutable(filetype, executable)
     let cwd = getcwd()
     return get(g:, a:filetype .. '_exec', get(g:, 'plugin_exec', 0)) &&
           \ (fnamemodify(exepath(a:executable), ':p:h') !=# cwd
           \ || (split($PATH, has('win32') ? ';' : ':')->index(cwd) != -1 &&
           \  cwd != '.'))
-    endfunction
-else
-    def dist#vim#IsSafeExecutable(filetype: string, executable: string): bool
-      return dist#vim9#IsSafeExecutable(filetype, executable)
-    enddef
+  endfunction
+
+  finish
 endif
+
+def dist#vim#IsSafeExecutable(filetype: string, executable: string): bool
+  return dist#vim9#IsSafeExecutable(filetype, executable)
+enddef


### PR DESCRIPTION
`:return` cannot be used outside of `:function` in older Vims lacking Vim9script support or in Neovim, even when evaluation is being skipped in the dead `:else` branch.

Instead, use the pattern described in `:h vim9-mix`, which uses `:finish` to end script processing before it reaches the Vim9script stuff.