### PR TITLE
runtime(doc): Add missing null_<type> help tags

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -9062,10 +9062,12 @@ null	vim9.txt	/*null*
 null-variable	eval.txt	/*null-variable*
 null_blob	vim9.txt	/*null_blob*
 null_channel	vim9.txt	/*null_channel*
+null_class	vim9.txt	/*null_class*
 null_dict	vim9.txt	/*null_dict*
 null_function	vim9.txt	/*null_function*
 null_job	vim9.txt	/*null_job*
 null_list	vim9.txt	/*null_list*
+null_object	vim9.txt	/*null_object*
 null_partial	vim9.txt	/*null_partial*
 null_string	vim9.txt	/*null_string*
 number_relativenumber	options.txt	/*number_relativenumber*

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1025,8 +1025,9 @@ always converted to string: >
 Simple types are Number, Float, Special and Bool.  For other types |string()|
 should be used.
 			*false* *true* *null* *null_blob* *null_channel*
-			*null_dict* *null_function* *null_job* *null_list*
-			*null_partial* *null_string* *E1034*
+			*null_class* *null_dict* *null_function* *null_job*
+			*null_list* *null_object* *null_partial* *null_string*
+			*E1034*
 In Vim9 script one can use the following predefined values: >
 	true
 	false


### PR DESCRIPTION
Problem:  Not all null_<type> values have a help tag
Solution: Add missing help tags
