### PR TITLE
Unsupported option causes rest of modeline test to be skipped

### DIFF
--- a/src/testdir/test_modeline.vim
+++ b/src/testdir/test_modeline.vim
@@ -164,7 +164,9 @@ func Test_modeline_colon()
 endfunc
 
 func s:modeline_fails(what, text, error)
-  call CheckOption(a:what)
+  if !exists('+' .. a:what)
+    return
+  endif
   let fname = "Xmodeline_fails_" . a:what
   call writefile(['vim: set ' . a:text . ' :', 'nothing'], fname, 'D')
   let modeline = &modeline


### PR DESCRIPTION
Problem:  Unsupported option causes rest of modeline test to be skipped.
Solution: Revert the change from patch 8.2.1432.

Close #13499
