### PR TITLE
Recursive callback limit causes problems on some architectures

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -1,4 +1,4 @@
-*message.txt*   For Vim version 9.0.  Last change: 2023 May 24
+*message.txt*   For Vim version 9.0.  Last change: 2023 Nov 08
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -135,6 +135,8 @@ This happens when an Ex command executes an Ex command that executes an Ex
 command, etc.  The limit is 200 or the value of 'maxfuncdepth', whatever is
 larger.  When it's more there probably is an endless loop.  Probably a
 |:execute| or |:source| command is involved.
+Can also happen with a recursive callback function (|job-callback|).
+A limit of 20 is used here.
 
 							*E254*
   Cannot allocate color {name} ~

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.0.  Last change: 2023 Oct 23
+*options.txt*	For Vim version 9.0.  Last change: 2023 Nov 08
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -5489,7 +5489,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Increasing this limit above 200 also changes the maximum for Ex
 	command recursion, see |E169|.
 	See also |:function|.
-	Also used for maximum depth of callback functions.
 
 						*'maxmapdepth'* *'mmd'* *E223*
 'maxmapdepth' 'mmd'	number	(default 1000)

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -14,6 +14,9 @@
 #include "vim.h"
 
 #if defined(FEAT_EVAL) || defined(PROTO)
+
+#define MAX_CALLBACK_DEPTH 20
+
 /*
  * All user-defined functions are found in this hashtable.
  */
@@ -3584,7 +3587,7 @@ call_callback(
     if (callback->cb_name == NULL || *callback->cb_name == NUL)
 	return FAIL;
 
-    if (callback_depth > p_mfd)
+    if (callback_depth > MAX_CALLBACK_DEPTH)
     {
 	emsg(_(e_command_too_recursive));
 	return FAIL;


### PR DESCRIPTION
Since commit 47510f3d6598a1218958c03ed11337a43b73f48d we have a test that causes a recursive popup callback function to be executed. However it seems the current limit of 'maxfuncdepth' option value is still too recursive for some 32bit architectures.

So instead of allowing a default limit of 100 (default value for 'maxfuncdepth'), let's reduce this limit to 20. I don't think there is a use case where one would need such a high recursive callback limit and a limit of 20 seems reasonable (although it is currently hard-coded).

closes: #13495