### PR TITLE
[vim9class] document `_` as protected instead of private

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -117,7 +117,7 @@ variable.
 
 
 Object variable write access ~
-
+						    *read-only-variable*
 Now try to change an object variable directly: >
 
 	pos.lnum = 9
@@ -133,7 +133,7 @@ way.  Most often there is no problem using a value, while setting a value may
 have side effects that need to be taken care of.  In this case, the SetLnum()
 method could check if the line number is valid and either give an error or use
 the closest valid value.
-							*:public* *E1331*
+					*:public* *public-variable* *E1331*
 If you don't care about side effects and want to allow the object variable to
 be changed at any time, you can make it public: >
 
@@ -150,16 +150,16 @@ If you try to set an object variable that doesn't exist you get an error: >
 							*E1376*
 A object variable cannot be accessed using the class name.
 
-Private variables ~
-					*private-variable* *E1332* *E1333*
-On the other hand, if you do not want the object variables to be read directly,
-you can make them private.  This is done by prefixing an underscore to the
-name: >
+Protected variables ~
+					*protected-variable* *E1332* *E1333*
+On the other hand, if you do not want the object variables to be read directly
+from outside the class or its sub-classes, you can make them protected.  This
+is done by prefixing an underscore to the name: >
 
 	this._lnum: number
 	this._col number
 
-Now you need to provide methods to get the value of the private variables.
+Now you need to provide methods to get the value of the protected variables.
 These are commonly called getters.  We recommend using a name that starts with
 "Get": >
 
@@ -182,11 +182,11 @@ number to the total number of lines: >
 	   return this._lnum
 	enddef
 <
-Private methods ~
-						*private-method* *E1366*
+Protected methods ~
+						*protected-method* *E1366*
 If you want object methods to be accessible only from other methods of the
 same class and not used from outside the class, then you can make them
-private.  This is done by prefixing the method name with an underscore: >
+protected.  This is done by prefixing the method name with an underscore: >
 
     class SomeClass
 	def _Foo(): number
@@ -197,7 +197,7 @@ private.  This is done by prefixing the method name with an underscore: >
 	enddef
     endclass
 <
-Accessing a private method outside the class will result in an error (using
+Accessing a protected method outside the class will result in an error (using
 the above class): >
 
     var a = SomeClass.new()
@@ -292,9 +292,9 @@ or local variable name is not allowed.
 To access a class member outside of the class where it is defined, the class
 name prefix must be used.  A class member cannot be accessed using an object.
 
-Just like object members the access can be made private by using an underscore
-as the first character in the name, and it can be made public by prefixing
-"public": >
+Just like object members the access can be made protected by using an
+underscore as the first character in the name, and it can be made public by
+prefixing "public": >
 
     class OtherThing
 	static total: number	      # anybody can read, only class can write
@@ -323,8 +323,8 @@ Inside the class the class method can be called by name directly, outside the
 class the class name must be prefixed: `OtherThing.ClearTotalSize()`.  To use
 a super class method in a child class, the class name must be prefixed.
 
-Just like object methods the access can be made private by using an underscore
-as the first character in the method name: >
+Just like object methods the access can be made protected by using an
+underscore as the first character in the method name: >
 
     class OtherThing
 	static def _Foo()
@@ -477,8 +477,8 @@ The interface name can be used as a type: >
 <
 					*E1378* *E1379* *E1380* *E1387*
 An interface can contain only object methods and read-only object variables.
-An interface cannot contain read-write and private object variables, private
-object methods, class variables and class methods.
+An interface cannot contain read-write or protected object variables,
+protected object methods, class variables and class methods.
 
 An interface can extend another interface using "extends".  The sub-interface
 inherits all the instance variables and methods from the super interface.
@@ -526,11 +526,12 @@ once.  They can appear in any order, although this order is recommended: >
 <							*E1355* *E1369*
 Each variable and method name can be used only once.  It is not possible to
 define a method with the same name and different type of arguments.  It is not
-possible to use a public and private member variable with the same name.  A
+possible to use a public and protected member variable with the same name.  A
 object variable name used in a super class cannot be reused in a child class.
 
 
 Object Variable Initialization ~
+
 If the type of a variable is not explicitly specified in a class, then it is
 set to "any" during class definition.  When an object is instantiated from the
 class, then the type of the variable is set.
@@ -559,7 +560,7 @@ in the extended method.  The method of the base class can be called by
 prefixing "super.".
 
 						*E1377*
-The access level of a method (public or private) in a child class should be
+The access level of a method (public or protected) in a child class should be
 the same as the super class.
 
 Other object methods of the base class are taken over by the child class.
@@ -597,11 +598,11 @@ Items in a class ~
 						*E1318* *E1325* *E1388*
 Inside a class, in between `:class` and `:endclass`, these items can appear:
 - An object variable declaration: >
-	this._privateVariableName: memberType
+	this._protectedVariableName: memberType
 	this.readonlyVariableName: memberType
 	public this.readwriteVariableName: memberType
 - A class variable declaration: >
-	static _privateClassVariableName: memberType
+	static _protectedClassVariableName: memberType
 	static readonlyClassVariableName: memberType
 	static public readwriteClassVariableName: memberType
 - A constructor method: >
@@ -609,10 +610,10 @@ Inside a class, in between `:class` and `:endclass`, these items can appear:
 	def newName(arguments)
 - A class method: >
 	static def SomeMethod(arguments)
-	static def _PrivateMethod(arguments)
+	static def _ProtectedMethod(arguments)
 - An object method: >
 	def SomeMethod(arguments)
-	def _PrivateMethod(arguments)
+	def _ProtectedMethod(arguments)
 
 For the object variable the type must be specified.  The best way is to do
 this explicitly with ": {type}".  For simple types you can also use an
@@ -704,8 +705,8 @@ Note that you cannot use another default value than "v:none" here.  If you
 want to initialize the object variables, do it where they are declared.  This
 way you only need to look in one place for the default values.
 
-All object variables will be used in the default constructor, also private
-access ones.
+All object variables will be used in the default constructor, including
+protected access ones.
 
 If the class extends another one, the object variables of that class will come
 first.
@@ -962,6 +963,18 @@ while there is no ClassName() method, it's a method by another name in the
 class called ClassName.  Quite confusing.
 
 
+Vim9class access modes ~
+						    *vim9-access-modes*
+The variable access modes, and their meaning, supported by Vim9class are
+	|public-variable|	read and write from anywhere
+	|read-only-variable|	read from anywhere, write from inside the
+				class and sub-classes
+	|protected-variable|	read and write from inside the class and
+				sub-classes
+
+The method access modes are similar, but without the read-only mode.
+
+
 Default read access to object variables ~
 
 Some users will remark that the access rules for object variables are
@@ -978,10 +991,10 @@ directly writing you get an error, which makes you wonder if you actually want
 to allow that.  This helps writing code with fewer mistakes.
 
 
-Making object variables private with an underscore ~
+Making object variables protected with an underscore ~
 
-When an object variable is private, it can only be read and changed inside the
-class (and in sub-classes), then it cannot be used outside of the class.
+When an object variable is protected, it can only be read and changed inside
+the class (and in sub-classes), then it cannot be used outside of the class.
 Prepending an underscore is a simple way to make that visible.  Various
 programming languages have this as a recommendation.
 
@@ -991,21 +1004,21 @@ Since the name only appears in the class (and sub-classes) they will be easy
 to find and change.
 
 The other way around is much harder: you can easily prepend an underscore to
-the object variable inside the class to make it private, but any usage
+the object variable inside the class to make it protected, but any usage
 elsewhere you will have to track down and change.  You may have to make it a
 "set" method call.  This reflects the real world problem that taking away
 access requires work to be done for all places where that access exists.
 
-An alternative would have been using the "private" keyword, just like "public"
-changes the access in the other direction.  Well, that's just to reduce the
-number of keywords.
+An alternative would have been using the "protected" keyword, just like
+"public" changes the access in the other direction.  Well, that's just to
+reduce the number of keywords.
 
 
-No protected object variables ~
+No private object variables ~
 
 Some languages provide several ways to control access to object variables.
 The most known is "protected", and the meaning varies from language to
-language.  Others are "shared", "private" and even "friend".
+language.  Others are "shared", "private", "package" and even "friend".
 
 These rules make life more difficult.  That can be justified in projects where
 many people work on the same, complex code where it is easy to make mistakes.

--- a/src/errors.h
+++ b/src/errors.h
@@ -3410,8 +3410,8 @@ EXTERN char e_public_must_be_followed_by_this_or_static[]
 	INIT(= N_("E1331: Public must be followed by \"this\" or \"static\""));
 EXTERN char e_public_variable_name_cannot_start_with_underscore_str[]
 	INIT(= N_("E1332: Public variable name cannot start with underscore: %s"));
-EXTERN char e_cannot_access_private_variable_str[]
-	INIT(= N_("E1333: Cannot access private variable \"%s\" in class \"%s\""));
+EXTERN char e_cannot_access_protected_variable_str[]
+	INIT(= N_("E1333: Cannot access protected variable \"%s\" in class \"%s\""));
 // E1334 unused
 EXTERN char e_variable_is_not_writable_str[]
 	INIT(= N_("E1335: Variable \"%s\" in class \"%s\" is not writable"));
@@ -3484,8 +3484,8 @@ EXTERN char e_warning_pointer_block_corrupted[]
 #ifdef FEAT_EVAL
 EXTERN char e_cannot_use_a_return_type_with_new_method[]
 	INIT(= N_("E1365: Cannot use a return type with the \"new\" method"));
-EXTERN char e_cannot_access_private_method_str[]
-	INIT(= N_("E1366: Cannot access private method: %s"));
+EXTERN char e_cannot_access_protected_method_str[]
+	INIT(= N_("E1366: Cannot access protected method: %s"));
 EXTERN char e_variable_str_of_interface_str_has_different_access[]
 	INIT(= N_("E1367: Access level of variable \"%s\" of interface \"%s\" is different"));
 EXTERN char e_static_cannot_be_followed_by_this[]
@@ -3510,10 +3510,10 @@ EXTERN char e_method_str_of_class_str_has_different_access[]
 	INIT(= N_("E1377: Access level of method \"%s\" is different in class \"%s\""));
 EXTERN char e_static_member_not_supported_in_interface[]
 	INIT(= N_("E1378: Static member not supported in an interface"));
-EXTERN char e_private_variable_not_supported_in_interface[]
-	INIT(= N_("E1379: Private variable not supported in an interface"));
-EXTERN char e_private_method_not_supported_in_interface[]
-	INIT(= N_("E1380: Private method not supported in an interface"));
+EXTERN char e_protected_variable_not_supported_in_interface[]
+	INIT(= N_("E1379: Protected variable not supported in an interface"));
+EXTERN char e_protected_method_not_supported_in_interface[]
+	INIT(= N_("E1380: Protected method not supported in an interface"));
 EXTERN char e_interface_cannot_use_implements[]
 	INIT(= N_("E1381: Interface cannot use \"implements\""));
 EXTERN char e_variable_str_type_mismatch_expected_str_but_got_str[]

--- a/src/eval.c
+++ b/src/eval.c
@@ -1112,7 +1112,7 @@ get_lval_check_access(
 	switch (om->ocm_access)
 	{
 	    case VIM_ACCESS_PRIVATE:
-		msg = e_cannot_access_private_variable_str;
+		msg = e_cannot_access_protected_variable_str;
 		break;
 	    case VIM_ACCESS_READ:
 		// If [idx] or .key following, read only OK.

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -324,7 +324,7 @@ def Test_class_def_method()
   END
   v9.CheckSourceFailure(lines, 'E1388: Public keyword not supported for a method', 3)
 
-  # Using the "public" keyword when defining an object private method
+  # Using the "public" keyword when defining an object protected method
   lines =<< trim END
     vim9script
     class A
@@ -334,7 +334,7 @@ def Test_class_def_method()
   END
   v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "this" or "static"', 3)
 
-  # Using the "public" keyword when defining a class private method
+  # Using the "public" keyword when defining a class protected method
   lines =<< trim END
     vim9script
     class A
@@ -606,7 +606,7 @@ def Test_member_any_used_as_object()
   END
   v9.CheckSourceSuccess(lines)
 
-  # Try modifying a private variable using an "any" object
+  # Try modifying a protected variable using an "any" object
   lines =<< trim END
     vim9script
 
@@ -626,7 +626,7 @@ def Test_member_any_used_as_object()
     var outer_obj = Outer.new(inner_obj)
     F(outer_obj)
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_value" in class "Inner"', 1)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_value" in class "Inner"', 1)
 
   # Try modifying a non-existing variable using an "any" object
   lines =<< trim END
@@ -1085,9 +1085,9 @@ def Test_instance_variable_access()
     assert_equal(1, trip.GetOne())
     assert_equal(2, trip.two)
     assert_equal(3, trip.three)
-    assert_fails('echo trip._one', 'E1333: Cannot access private variable "_one" in class "Triple"')
+    assert_fails('echo trip._one', 'E1333: Cannot access protected variable "_one" in class "Triple"')
 
-    assert_fails('trip._one = 11', 'E1333: Cannot access private variable "_one" in class "Triple"')
+    assert_fails('trip._one = 11', 'E1333: Cannot access protected variable "_one" in class "Triple"')
     assert_fails('trip.two = 22', 'E1335: Variable "two" in class "Triple" is not writable')
     trip.three = 33
     assert_equal(33, trip.three)
@@ -1321,7 +1321,7 @@ def Test_class_variable_access()
   END
   v9.CheckSourceFailure(lines, 'E1335: Variable "ro_class_var" in class "A" is not writable', 1)
 
-  # A private class variable cannot be accessed from a child class
+  # A protected class variable cannot be accessed from a child class
   lines =<< trim END
     vim9script
     class A
@@ -1337,9 +1337,9 @@ def Test_class_variable_access()
     var b = B.new()
     b.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_priv_class_var" in class "A"', 1)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_priv_class_var" in class "A"', 1)
 
-  # A private class variable cannot be modified from a child class
+  # A protected class variable cannot be modified from a child class
   lines =<< trim END
     vim9script
     class A
@@ -1355,7 +1355,7 @@ def Test_class_variable_access()
     var b = B.new()
     b.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_priv_class_var" in class "A"', 1)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_priv_class_var" in class "A"', 1)
 
   # Access from child class extending a class and from script context
   lines =<< trim END
@@ -1536,8 +1536,8 @@ def Test_class_member()
     assert_fails('TextPos.counter = 5', 'E1335: Variable "counter" in class "TextPos" is not writable')
     assert_fails('TextPos.counter += 5', 'E1335: Variable "counter" in class "TextPos" is not writable')
 
-    assert_fails('echo TextPos._secret', 'E1333: Cannot access private variable "_secret" in class "TextPos"')
-    assert_fails('TextPos._secret = 8', 'E1333: Cannot access private variable "_secret" in class "TextPos"')
+    assert_fails('echo TextPos._secret', 'E1333: Cannot access protected variable "_secret" in class "TextPos"')
+    assert_fails('TextPos._secret = 8', 'E1333: Cannot access protected variable "_secret" in class "TextPos"')
 
     assert_equal(42, TextPos.anybody)
     TextPos.anybody = 12
@@ -1583,7 +1583,7 @@ def Test_class_member()
   END
   v9.CheckSourceSuccess(lines)
 
-  # access private member in lambda
+  # access protected member in lambda
   lines =<< trim END
     vim9script
 
@@ -1601,7 +1601,7 @@ def Test_class_member()
   END
   v9.CheckSourceSuccess(lines)
 
-  # access private member in lambda body
+  # access protected member in lambda body
   lines =<< trim END
     vim9script
 
@@ -1762,7 +1762,7 @@ def Test_defining_class_message()
     var o = Child.new()
     var x = o._v1
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_v1" in class "Base"', 11)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_v1" in class "Base"', 11)
   lines =<< trim END
     vim9script
 
@@ -1779,7 +1779,7 @@ def Test_defining_class_message()
     enddef
     F()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_v1" in class "Base"', 2)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_v1" in class "Base"', 2)
   lines =<< trim END
     vim9script
 
@@ -1811,7 +1811,7 @@ def Test_defining_class_message()
     F()
   END
 
-  # Attempt to read a private variable that is in the middle
+  # Attempt to read a protected variable that is in the middle
   # of the class hierarchy.
   v9.CheckSourceFailure(lines, 'E1335: Variable "v1" in class "Base" is not writable', 2)
   lines =<< trim END
@@ -1833,9 +1833,9 @@ def Test_defining_class_message()
     enddef
     F()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_v1" in class "Base"', 2)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_v1" in class "Base"', 2)
 
-  # Attempt to read a private variable that is at the start
+  # Attempt to read a protected variable that is at the start
   # of the class hierarchy.
   lines =<< trim END
     vim9script
@@ -1856,7 +1856,7 @@ def Test_defining_class_message()
     enddef
     F()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_v1" in class "Child"', 2)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_v1" in class "Child"', 2)
 enddef
 
 func Test_class_garbagecollect()
@@ -4132,7 +4132,7 @@ def Test_lockvar_general()
   END
   v9.CheckSourceFailure(lines, 'E741: Value is locked: l[0] = 11', 11)
 
-  # lock a list element referenced by a private object variable
+  # lock a list element referenced by a protected object variable
   # in an object fetched via a script level list
   lines =<< trim END
     vim9script
@@ -4155,8 +4155,8 @@ def Test_lockvar_general()
   v9.CheckSourceFailure(lines, 'E741: Value is locked: l[1] = [33]', 16)
 
   # similar to the previous test, except the locking code is executing
-  # in a class that does not own the private variable.
-  # Note that the locking code is in a class has a private variable of
+  # in a class that does not own the protected variable.
+  # Note that the locking code is in a class has a protected variable of
   # the same name.
   lines =<< trim END
     vim9script
@@ -4179,7 +4179,7 @@ def Test_lockvar_general()
     var o2 = C2.new()
     o2.Lock(o)
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_v1" in class "C"')
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_v1" in class "C"')
 enddef
 
 " Test builtin islocked()
@@ -4503,9 +4503,9 @@ def Test_lockvar_islocked_notfound()
   v9.CheckSourceSuccess(lines)
 enddef
 
-" Test for a private object method
+" Test for a protected object method
 def Test_private_object_method()
-  # Try calling a private method using an object (at the script level)
+  # Try calling a protected method using an object (at the script level)
   var lines =<< trim END
     vim9script
 
@@ -4517,9 +4517,9 @@ def Test_private_object_method()
     var a = A.new()
     a._Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 9)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 9)
 
-  # Try calling a private method using an object (from a def function)
+  # Try calling a protected method using an object (from a def function)
   lines =<< trim END
     vim9script
 
@@ -4534,9 +4534,9 @@ def Test_private_object_method()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 2)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo()', 2)
 
-  # Use a private method from another object method (in script context)
+  # Use a protected method from another object method (in script context)
   lines =<< trim END
     vim9script
 
@@ -4553,7 +4553,7 @@ def Test_private_object_method()
   END
   v9.CheckSourceSuccess(lines)
 
-  # Use a private method from another object method (def function context)
+  # Use a protected method from another object method (def function context)
   lines =<< trim END
     vim9script
 
@@ -4573,7 +4573,7 @@ def Test_private_object_method()
   END
   v9.CheckSourceSuccess(lines)
 
-  # Try calling a private method without the "this" prefix
+  # Try calling a protected method without the "this" prefix
   lines =<< trim END
     vim9script
 
@@ -4590,7 +4590,7 @@ def Test_private_object_method()
   END
   v9.CheckSourceFailure(lines, 'E117: Unknown function: _Foo', 1)
 
-  # Try calling a private method using the class name
+  # Try calling a protected method using the class name
   lines =<< trim END
     vim9script
 
@@ -4601,9 +4601,9 @@ def Test_private_object_method()
     endclass
     A._Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 8)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 8)
 
-  # Define two private methods with the same name
+  # Define two protected methods with the same name
   lines =<< trim END
     vim9script
 
@@ -4617,7 +4617,7 @@ def Test_private_object_method()
   END
   v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo', 7)
 
-  # Define a private method and a object method with the same name
+  # Define a protected method and a object method with the same name
   lines =<< trim END
     vim9script
 
@@ -4631,7 +4631,7 @@ def Test_private_object_method()
   END
   v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo', 7)
 
-  # Define an object method and a private method with the same name
+  # Define an object method and a protected method with the same name
   lines =<< trim END
     vim9script
 
@@ -4645,7 +4645,7 @@ def Test_private_object_method()
   END
   v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo', 7)
 
-  # Call a public method and a private method from a private method
+  # Call a public method and a protected method from a protected method
   lines =<< trim END
     vim9script
 
@@ -4669,7 +4669,7 @@ def Test_private_object_method()
   END
   v9.CheckSourceSuccess(lines)
 
-  # Try calling a private method from another class
+  # Try calling a protected method from another class
   lines =<< trim END
     vim9script
 
@@ -4687,9 +4687,9 @@ def Test_private_object_method()
     var b = B.new()
     b.Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 2)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo()', 2)
 
-  # Call a private object method from a child class object method
+  # Call a protected object method from a child class object method
   lines =<< trim END
     vim9script
     class A
@@ -4711,7 +4711,7 @@ def Test_private_object_method()
   END
   v9.CheckSourceSuccess(lines)
 
-  # Call a private object method from a child class object
+  # Call a protected object method from a child class object
   lines =<< trim END
     vim9script
     class A
@@ -4730,7 +4730,7 @@ def Test_private_object_method()
     var c = C.new()
     assert_equal(1234, c._Foo())
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 16)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 16)
 
   # Using "_" prefix in a method name should fail outside of a class
   lines =<< trim END
@@ -4743,9 +4743,9 @@ def Test_private_object_method()
   v9.CheckSourceFailure(lines, 'E1267: Function name must start with a capital: _Foo(): number', 2)
 enddef
 
-" Test for an private class method
+" Test for an protected class method
 def Test_private_class_method()
-  # Try calling a class private method (at the script level)
+  # Try calling a class protected method (at the script level)
   var lines =<< trim END
     vim9script
 
@@ -4756,9 +4756,9 @@ def Test_private_class_method()
     endclass
     A._Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 8)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 8)
 
-  # Try calling a class private method (from a def function)
+  # Try calling a class protected method (from a def function)
   lines =<< trim END
     vim9script
 
@@ -4772,9 +4772,9 @@ def Test_private_class_method()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 1)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo()', 1)
 
-  # Try calling a class private method using an object (at the script level)
+  # Try calling a class protected method using an object (at the script level)
   lines =<< trim END
     vim9script
 
@@ -4786,9 +4786,9 @@ def Test_private_class_method()
     var a = A.new()
     a._Foo()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 9)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 9)
 
-  # Try calling a class private method using an object (from a def function)
+  # Try calling a class protected method using an object (from a def function)
   lines =<< trim END
     vim9script
 
@@ -4803,9 +4803,9 @@ def Test_private_class_method()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 2)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 2)
 
-  # Use a class private method from an object method
+  # Use a class protected method from an object method
   lines =<< trim END
     vim9script
 
@@ -4822,7 +4822,7 @@ def Test_private_class_method()
   END
   v9.CheckSourceSuccess(lines)
 
-  # Use a class private method from another class private method without the
+  # Use a class protected method from another class protected method without the
   # class name prefix.
   lines =<< trim END
     vim9script
@@ -4843,7 +4843,7 @@ def Test_private_class_method()
   END
   v9.CheckSourceSuccess(lines)
 
-  # Declare a class method and a class private method with the same name
+  # Declare a class method and a class protected method with the same name
   lines =<< trim END
     vim9script
 
@@ -4857,7 +4857,7 @@ def Test_private_class_method()
   END
   v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo', 7)
 
-  # Try calling a class private method from another class
+  # Try calling a class protected method from another class
   lines =<< trim END
     vim9script
 
@@ -4874,9 +4874,9 @@ def Test_private_class_method()
     var b = B.new()
     assert_equal(1234, b.Foo())
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 1)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo()', 1)
 
-  # Call a private class method from a child class object method
+  # Call a protected class method from a child class object method
   lines =<< trim END
     vim9script
     class A
@@ -4896,9 +4896,9 @@ def Test_private_class_method()
     var c = C.new()
     assert_equal(1234, c.Baz())
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 1)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo()', 1)
 
-  # Call a private class method from a child class private class method
+  # Call a protected class method from a child class protected class method
   lines =<< trim END
     vim9script
     class A
@@ -4917,9 +4917,9 @@ def Test_private_class_method()
     endclass
     assert_equal(1234, C.Baz())
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo()', 1)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo()', 1)
 
-  # Call a private class method from a child class object
+  # Call a protected class method from a child class object
   lines =<< trim END
     vim9script
     class A
@@ -5032,7 +5032,7 @@ def Test_static_inheritence()
     assert_equal(102, ob.AccessObject())
     assert_equal(103, oc.AccessObject())
 
-    assert_fails('echo oc.AccessPrivateStaticThroughClassName()', 'E1333: Cannot access private variable "_svar" in class "A"')
+    assert_fails('echo oc.AccessPrivateStaticThroughClassName()', 'E1333: Cannot access protected variable "_svar" in class "A"')
 
     # verify object properly resolves to correct static
     assert_equal(1, oa.AccessStaticThroughObject())
@@ -5054,7 +5054,7 @@ def Test_dup_member_variable()
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 4)
 
-  # Duplicate private member variable
+  # Duplicate protected member variable
   lines =<< trim END
     vim9script
     class C
@@ -5074,7 +5074,7 @@ def Test_dup_member_variable()
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 4)
 
-  # Duplicate private member variable
+  # Duplicate protected member variable
   lines =<< trim END
     vim9script
     class C
@@ -5084,7 +5084,7 @@ def Test_dup_member_variable()
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 4)
 
-  # Duplicate public and private member variable
+  # Duplicate public and protected member variable
   lines =<< trim END
     vim9script
     class C
@@ -5104,7 +5104,7 @@ def Test_dup_member_variable()
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _s', 4)
 
-  # Duplicate public and private class member variable
+  # Duplicate public and protected class member variable
   lines =<< trim END
     vim9script
     class C
@@ -5143,7 +5143,7 @@ def Test_dup_member_variable()
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 9)
 
-  # Duplicate object private member variable in a derived class
+  # Duplicate object protected member variable in a derived class
   lines =<< trim END
     vim9script
     class A
@@ -5157,7 +5157,7 @@ def Test_dup_member_variable()
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 9)
 
-  # Duplicate object private member variable in a derived class
+  # Duplicate object protected member variable in a derived class
   lines =<< trim END
     vim9script
     class A
@@ -5196,9 +5196,9 @@ def Test_dup_member_variable()
   v9.CheckSourceSuccess(lines)
 enddef
 
-" Test for accessing a private member outside a class in a def function
+" Test for accessing a protected member outside a class in a def function
 def Test_private_member_access_outside_class()
-  # private object member variable
+  # protected object member variable
   var lines =<< trim END
     vim9script
     class A
@@ -5213,9 +5213,9 @@ def Test_private_member_access_outside_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_val" in class "A"', 2)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_val" in class "A"', 2)
 
-  # access a non-existing private object member variable
+  # access a non-existing protected object member variable
   lines =<< trim END
     vim9script
     class A
@@ -5229,7 +5229,7 @@ def Test_private_member_access_outside_class()
   END
   v9.CheckSourceFailure(lines, 'E1326: Variable "_a" not found in object "A"', 2)
 
-  # private static member variable
+  # protected static member variable
   lines =<< trim END
     vim9script
     class A
@@ -5243,7 +5243,7 @@ def Test_private_member_access_outside_class()
   END
   v9.CheckSourceFailure(lines, 'E1375: Class variable "_val" accessible only using class "A"', 2)
 
-  # private static member variable
+  # protected static member variable
   lines =<< trim END
     vim9script
     class A
@@ -5257,7 +5257,7 @@ def Test_private_member_access_outside_class()
   END
   v9.CheckSourceFailure(lines, 'E1375: Class variable "_val" accessible only using class "A"', 2)
 
-  # private static class variable
+  # protected static class variable
   lines =<< trim END
     vim9script
     class A
@@ -5268,9 +5268,9 @@ def Test_private_member_access_outside_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_val" in class "A"', 1)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_val" in class "A"', 1)
 
-  # private static class variable
+  # protected static class variable
   lines =<< trim END
     vim9script
     class A
@@ -5281,7 +5281,7 @@ def Test_private_member_access_outside_class()
     enddef
     T()
   END
-  v9.CheckSourceFailure(lines, 'E1333: Cannot access private variable "_val" in class "A"', 1)
+  v9.CheckSourceFailure(lines, 'E1333: Cannot access protected variable "_val" in class "A"', 1)
 enddef
 
 " Test for changing the member access of an interface in a implementation class
@@ -5342,7 +5342,7 @@ def Test_modify_class_member_from_def_function()
       A.var3 = {c: 3, d: 4}
       assert_equal([3, 4], A.var2)
       assert_equal({c: 3, d: 4}, A.var3)
-      assert_fails('echo A._priv_var4', 'E1333: Cannot access private variable "_priv_var4" in class "A"')
+      assert_fails('echo A._priv_var4', 'E1333: Cannot access protected variable "_priv_var4" in class "A"')
     enddef
     T()
   END
@@ -6035,7 +6035,7 @@ def Test_dup_classmethod_objmethod()
   END
   v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo', 6)
 
-  # Duplicate private instance method
+  # Duplicate protected instance method
   lines =<< trim END
     vim9script
     class A
@@ -6059,7 +6059,7 @@ def Test_dup_classmethod_objmethod()
   END
   v9.CheckSourceFailure(lines, 'E1355: Duplicate function: Foo', 6)
 
-  # Duplicate private class method
+  # Duplicate protected class method
   lines =<< trim END
     vim9script
     class A
@@ -6071,7 +6071,7 @@ def Test_dup_classmethod_objmethod()
   END
   v9.CheckSourceFailure(lines, 'E1355: Duplicate function: _Foo', 6)
 
-  # Duplicate private class and object method
+  # Duplicate protected class and object method
   lines =<< trim END
     vim9script
     class A
@@ -6087,7 +6087,7 @@ enddef
 " Test for an instance method access level comparison with parent instance
 " methods.
 def Test_instance_method_access_level()
-  # Private method in subclass
+  # protected method in subclass
   var lines =<< trim END
     vim9script
     class A
@@ -6147,7 +6147,7 @@ def Test_extend_empty_class()
 enddef
 
 " A interface cannot have a static variable or a static method or a private
-" variable or a private method or a public variable
+" variable or a protected method or a public variable
 def Test_interface_with_unsupported_members()
   var lines =<< trim END
     vim9script
@@ -6211,7 +6211,7 @@ def Test_interface_with_unsupported_members()
       this._Foo: list<string>
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1379: Private variable not supported in an interface', 3)
+  v9.CheckSourceFailure(lines, 'E1379: Protected variable not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -6219,7 +6219,7 @@ def Test_interface_with_unsupported_members()
       def _Foo(d: dict<any>): list<string>
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1380: Private method not supported in an interface', 3)
+  v9.CheckSourceFailure(lines, 'E1380: Protected method not supported in an interface', 3)
 enddef
 
 " Test for extending an interface
@@ -7653,7 +7653,7 @@ def Test_object_funcref()
   END
   v9.CheckSourceSuccess(lines)
 
-  # Try using a private object method funcref from a def function
+  # Try using a protected object method funcref from a def function
   lines =<< trim END
     vim9script
     class A
@@ -7666,9 +7666,9 @@ def Test_object_funcref()
     enddef
     Bar()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 2)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 2)
 
-  # Try using a private object method funcref at the script level
+  # Try using a protected object method funcref at the script level
   lines =<< trim END
     vim9script
     class A
@@ -7678,9 +7678,9 @@ def Test_object_funcref()
     var a = A.new()
     var Fn = a._Foo
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 7)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 7)
 
-  # Using a private object method funcref from another object method
+  # Using a protected object method funcref from another object method
   lines =<< trim END
     vim9script
     class A
@@ -7812,7 +7812,7 @@ def Test_class_funcref()
   END
   v9.CheckSourceSuccess(lines)
 
-  # Try using a private class method funcref in a def function
+  # Try using a protected class method funcref in a def function
   lines =<< trim END
     vim9script
     class A
@@ -7824,9 +7824,9 @@ def Test_class_funcref()
     enddef
     Bar()
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 1)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 1)
 
-  # Try using a private class method funcref at script level
+  # Try using a protected class method funcref at script level
   lines =<< trim END
     vim9script
     class A
@@ -7835,9 +7835,9 @@ def Test_class_funcref()
     endclass
     var Fn = A._Foo
   END
-  v9.CheckSourceFailure(lines, 'E1366: Cannot access private method: _Foo', 6)
+  v9.CheckSourceFailure(lines, 'E1366: Cannot access protected method: _Foo', 6)
 
-  # Using a private class method funcref from another class method
+  # Using a protected class method funcref from another class method
   lines =<< trim END
     vim9script
     class A

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1624,7 +1624,7 @@ early_ret:
 	    if (!is_class && *varname == '_')
 	    {
 		// private variables are not supported in an interface
-		semsg(_(e_private_variable_not_supported_in_interface),
+		semsg(_(e_protected_variable_not_supported_in_interface),
 			varname);
 		break;
 	    }
@@ -1710,7 +1710,7 @@ early_ret:
 		if (!is_class && *name == '_')
 		{
 		    // private variables are not supported in an interface
-		    semsg(_(e_private_method_not_supported_in_interface),
+		    semsg(_(e_protected_method_not_supported_in_interface),
 			    name);
 		    func_clear_free(uf, FALSE);
 		    break;
@@ -2248,7 +2248,7 @@ get_member_tv(
 
     if (*name == '_')
     {
-	emsg_var_cl_define(e_cannot_access_private_variable_str,
+	emsg_var_cl_define(e_cannot_access_protected_variable_str,
 							m->ocm_name, 0, cl);
 	return FAIL;
     }
@@ -2319,7 +2319,7 @@ call_oc_method(
     if (ocm == NULL && *fp->uf_name == '_')
     {
 	// Cannot access a private method outside of a class
-	semsg(_(e_cannot_access_private_method_str), fp->uf_name);
+	semsg(_(e_cannot_access_protected_method_str), fp->uf_name);
 	return FAIL;
     }
 
@@ -2437,7 +2437,7 @@ class_object_index(
 	    // Private methods are not accessible outside the class
 	    if (*name == '_')
 	    {
-		semsg(_(e_cannot_access_private_method_str), fp->uf_name);
+		semsg(_(e_cannot_access_protected_method_str), fp->uf_name);
 		return FAIL;
 	    }
 
@@ -3078,7 +3078,7 @@ method_not_found_msg(class_T *cl, vartype_T v_type, char_u *name, size_t len)
     {
 	// If this is a class method, then give a different error
 	if (*name == '_')
-	    semsg(_(e_cannot_access_private_method_str), method_name);
+	    semsg(_(e_cannot_access_protected_method_str), method_name);
 	else
 	    semsg(_(e_class_method_str_accessible_only_using_class_str),
 		    method_name, cl->class_name);
@@ -3088,7 +3088,7 @@ method_not_found_msg(class_T *cl, vartype_T v_type, char_u *name, size_t len)
     {
 	// If this is an object method, then give a different error
 	if (*name == '_')
-	    semsg(_(e_cannot_access_private_method_str), method_name);
+	    semsg(_(e_cannot_access_protected_method_str), method_name);
 	else
 	    semsg(_(e_object_method_str_accessible_only_using_object_str),
 		    method_name, cl->class_name);

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1617,7 +1617,7 @@ lhs_class_member_modifiable(lhs_T *lhs, char_u	*var_start, cctx_T *cctx)
 	     || (!is_object && cctx->ctx_ufunc->uf_class != cl)))
     {
 	char *msg = (m->ocm_access == VIM_ACCESS_PRIVATE)
-				? e_cannot_access_private_variable_str
+				? e_cannot_access_protected_variable_str
 				: e_variable_is_not_writable_str;
 	emsg_var_cl_define(msg, m->ocm_name, 0, cl);
 	return FALSE;
@@ -2034,8 +2034,8 @@ compile_lhs(
 		     || (!is_object && cctx->ctx_ufunc->uf_class != cl)))
 	    {
 		char *msg = (m->ocm_access == VIM_ACCESS_PRIVATE)
-					? e_cannot_access_private_variable_str
-					: e_variable_is_not_writable_str;
+				    ? e_cannot_access_protected_variable_str
+				    : e_variable_is_not_writable_str;
 		emsg_var_cl_define(msg, m->ocm_name, 0, cl);
 		return FAIL;
 	    }

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2248,7 +2248,7 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 	    {
 		if (*member == '_')
 		{
-		    emsg_var_cl_define(e_cannot_access_private_variable_str,
+		    emsg_var_cl_define(e_cannot_access_protected_variable_str,
 							m->ocm_name, 0, cl);
 		    status = FAIL;
 		}

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -403,7 +403,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 		 || (type->tt_type == VAR_CLASS
 		     && cctx->ctx_ufunc->uf_class != cl)))
 	{
-	    semsg(_(e_cannot_access_private_method_str), name);
+	    semsg(_(e_cannot_access_protected_method_str), name);
 	    return FAIL;
 	}
 
@@ -430,7 +430,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	{
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
-		emsg_var_cl_define(e_cannot_access_private_variable_str,
+		emsg_var_cl_define(e_cannot_access_protected_variable_str,
 							m->ocm_name, 0, cl);
 		return FAIL;
 	    }
@@ -449,7 +449,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    // Private methods are not accessible outside the class
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
-		semsg(_(e_cannot_access_private_method_str), fp->uf_name);
+		semsg(_(e_cannot_access_protected_method_str), fp->uf_name);
 		return FAIL;
 	    }
 	    *arg = name_end;
@@ -472,7 +472,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    // it is defined.
 	    if (*name == '_' && cctx->ctx_ufunc->uf_class != cl)
 	    {
-		emsg_var_cl_define(e_cannot_access_private_variable_str,
+		emsg_var_cl_define(e_cannot_access_protected_variable_str,
 							m->ocm_name, 0, cl);
 		return FAIL;
 	    }
@@ -491,7 +491,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    // Private methods are not accessible outside the class
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
-		semsg(_(e_cannot_access_private_method_str), fp->uf_name);
+		semsg(_(e_cannot_access_protected_method_str), fp->uf_name);
 		return FAIL;
 	    }
 	    *arg = name_end;


### PR DESCRIPTION
Fixes #13504.

The implementation of this PR takes a minimalist approach. Mostly just change "private" to "protected". Keep an eye out for things that don't read naturally, even if not directly part of this change. There is some additional text and some |links| have been added. Any issues with them?

Some error messages are changed along with the tests that reference them.
