### PR TITLE
Fix bug of silent mode clearing terminal screen on Windows

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -8578,6 +8578,9 @@ vtp_printf(
     DWORD   result;
     int	    len;
 
+    if (silent_mode)
+	return 0;
+
     va_start(list, format);
     len = vim_vsnprintf((char *)buf, 100, (char *)format, list);
     va_end(list);


### PR DESCRIPTION
Problem: Terminal control codes (https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences) are sent even when silent mode is on, causing the terminal to clear up

Solution: Block any terminal codes when silent mode is on

closes #12822 