### PR TITLE
fix: a bit nicer termdebug breakpoint sign label

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1588,9 +1588,9 @@ If there is no g:termdebug_config you can use: >
 
 Change default signs ~
 							*termdebug_signs*
-Termdebug uses the last two characters of the breakpoint ID in the
-signcolumn to represent breakpoints. For example, breakpoint ID 133
-will be displayed as `33`.
+Termdebug uses the hex number of the breakpoint ID in the signcolumn to
+represent breakpoints. if it is greater than "0xFF", then it will be displayed
+as "F+", due to we really only have two screen cells for the sign.
 
 If you want to customize the breakpoint signs: >
 	let g:termdebug_config['sign'] = '>>'

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1648,9 +1648,9 @@ func s:CreateBreakpoint(id, subid, enabled)
       let label = get(g:termdebug_config, 'sign', '')
     endif
     if label == ''
-      let label = substitute(nr, '\..*', '', '')
-      if strlen(label) > 2
-	let label = strpart(label, strlen(label) - 2)
+      let label = printf('%02X', a:id)
+      if a:id > 255
+        let label = 'F+'
       endif
     endif
     call sign_define('debugBreakpoint' .. nr,

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -80,6 +80,32 @@ func Test_termdebug_basic()
         \  'priority': 110, 'group': 'TermDebug'}],
         \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
   Continue
+  call term_wait(gdb_buf)
+
+  let i = 2
+  while i <= 258
+    Break
+    call term_wait(gdb_buf)
+    if i == 2
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint2.0')[0].text, '02')})
+    endif
+    if i == 10
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint10.0')[0].text, '0A')})
+    endif
+    if i == 168
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint168.0')[0].text, 'A8')})
+    endif
+    if i == 255
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint255.0')[0].text, 'FF')})
+    endif
+    if i == 256
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint256.0')[0].text, 'F+')})
+    endif
+    if i == 258
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint258.0')[0].text, 'F+')})
+    endif
+    let i += 1
+  endwhile
 
   let cn = 0
   " 60 is approx spaceBuffer * 3


### PR DESCRIPTION
1. this make the breakpoint sign label can hold 255 bp id (>100).
2. this will not re-use existed bp id if over 255 (less confusion).

// related #12589
// that should be the last chat (I) with Bram, r.i.p