### PR TITLE
runtime(tutor): Use more general terms

### DIFF
--- a/runtime/tutor/tutor
+++ b/runtime/tutor/tutor
@@ -700,13 +700,14 @@ NOTE:  You can also read the output of an external command.  For example,
 	  :!dir		   :!ls		   -  shows a directory listing.
 	  :!del FILENAME   :!rm FILENAME   -  removes file FILENAME.
 
-  2.  :w FILENAME  writes the current Vim file to disk with name FILENAME.
+  2.  :w FILENAME  writes the current Vim file to a storage device with name
+      FILENAME.
 
   3.  v  motion  :w FILENAME  saves the Visually selected lines in file
       FILENAME.
 
-  4.  :r FILENAME  retrieves disk file FILENAME and puts it below the
-      cursor position.
+  4.  :r FILENAME  retrieves file FILENAME and puts it below the cursor
+      position.
 
   5.  :r !dir  reads the output of the dir command and puts it below the
       cursor position.


### PR DESCRIPTION
Since files may not be stored on disks, we should use more general terms to describe the devices used to store files.