### PR TITLE
Add support for alternate font highlighting

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5269,6 +5269,13 @@ ctermul={color-nr}				*highlight-ctermul*
 	command is given.  If the Normal group colors are changed later, the
 	"fg" and "bg" colors will not be adjusted.
 
+ctermfont={font-nr}				*highlight-ctermfont*
+	This gives the alternative font number to use in the terminal. The
+	available fonts depend on the terminal, and if the terminal is not set
+	up for alternative fonts this simply won't do anything. The range of
+	{font-nr} is 0-9 where 0 resets the font to the default font and 1-9
+	selects one of the 8 alternate fonts. For more information see your
+	terminals handling of SGR parameters 10-19.
 
 3. highlight arguments for the GUI
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5273,9 +5273,10 @@ ctermfont={font-nr}				*highlight-ctermfont*
 	This gives the alternative font number to use in the terminal. The
 	available fonts depend on the terminal, and if the terminal is not set
 	up for alternative fonts this simply won't do anything. The range of
-	{font-nr} is 0-9 where 0 resets the font to the default font and 1-9
-	selects one of the 8 alternate fonts. For more information see your
-	terminal's handling of SGR parameters 10-19.
+	{font-nr} is 0-10 where 0 resets the font to the default font, 1-9
+	selects one of the 9 alternate fonts, and 10 selects the Fraktur font.
+	For more information see your terminal's handling of SGR parameters
+	10-20.
 
 3. highlight arguments for the GUI
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5275,7 +5275,7 @@ ctermfont={font-nr}				*highlight-ctermfont*
 	up for alternative fonts this simply won't do anything. The range of
 	{font-nr} is 0-9 where 0 resets the font to the default font and 1-9
 	selects one of the 8 alternate fonts. For more information see your
-	terminals handling of SGR parameters 10-19.
+	terminal's handling of SGR parameters 10-19.
 
 3. highlight arguments for the GUI
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7919,6 +7919,7 @@ highlight-clear	syntax.txt	/*highlight-clear*
 highlight-cterm	syntax.txt	/*highlight-cterm*
 highlight-ctermbg	syntax.txt	/*highlight-ctermbg*
 highlight-ctermfg	syntax.txt	/*highlight-ctermfg*
+highlight-ctermfont	syntax.txt	/*highlight-ctermfont*
 highlight-ctermul	syntax.txt	/*highlight-ctermul*
 highlight-default	syntax.txt	/*highlight-default*
 highlight-font	syntax.txt	/*highlight-font*

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -626,7 +626,7 @@ syn match	vimHiGuiFontname	contained	"'[a-zA-Z\-* ]\+'"
 syn match	vimHiGuiRgb	contained	"#\x\{6}"
 
 " Highlighting: hi group key=arg ... {{{2
-syn cluster	vimHiCluster contains=vimGroup,vimHiGroup,vimHiTerm,vimHiCTerm,vimHiStartStop,vimHiCtermFgBg,vimHiCtermul,vimHiGui,vimHiGuiFont,vimHiGuiFgBg,vimHiKeyError,vimNotation
+syn cluster	vimHiCluster contains=vimGroup,vimHiGroup,vimHiTerm,vimHiCTerm,vimHiStartStop,vimHiCtermFgBg,vimHiCtermul,vimHiCtermfont,vimHiGui,vimHiGuiFont,vimHiGuiFgBg,vimHiKeyError,vimNotation
 syn region	vimHiKeyList	contained oneline start="\i\+" skip="\\\\\|\\|" end="$\||"	contains=@vimHiCluster
 if !exists("g:vimsyn_noerror") && !exists("g:vimsyn_vimhikeyerror")
  syn match	vimHiKeyError	contained	"\i\+="he=e-1
@@ -636,6 +636,7 @@ syn match	vimHiStartStop	contained	"\c\(start\|stop\)="he=e-1	nextgroup=vimHiTer
 syn match	vimHiCTerm	contained	"\ccterm="he=e-1		nextgroup=vimHiAttribList
 syn match	vimHiCtermFgBg	contained	"\ccterm[fb]g="he=e-1	nextgroup=vimHiNmbr,vimHiCtermColor,vimFgBgAttrib,vimHiCtermError
 syn match	vimHiCtermul	contained	"\cctermul="he=e-1	nextgroup=vimHiNmbr,vimHiCtermColor,vimFgBgAttrib,vimHiCtermError
+syn match	vimHiCtermfont	contained	"\cctermfont="he=e-1	nextgroup=vimHiNmbr,vimHiCtermColor,vimFgBgAttrib,vimHiCtermError
 syn match	vimHiGui	contained	"\cgui="he=e-1		nextgroup=vimHiAttribList
 syn match	vimHiGuiFont	contained	"\cfont="he=e-1		nextgroup=vimHiFontname
 syn match	vimHiGuiFgBg	contained	"\cgui\%([fb]g\|sp\)="he=e-1	nextgroup=vimHiGroup,vimHiGuiFontname,vimHiGuiRgb,vimFgBgAttrib
@@ -911,6 +912,7 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimFgBgAttrib	vimHiAttrib
  hi def link vimFuncEcho	vimCommand
  hi def link vimHiCtermul	vimHiTerm
+ hi def link vimHiCtermfont	vimHiTerm
  hi def link vimFold	Folded
  hi def link vimFTCmd	vimCommand
  hi def link vimFTOption	vimSynType

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -2684,6 +2684,7 @@ get_cterm_attr_idx(int attr, int fg, int bg)
     at_en.ae_u.cterm.fg_color = fg;
     at_en.ae_u.cterm.bg_color = bg;
     at_en.ae_u.cterm.ul_color = 0;
+    at_en.ae_u.cterm.font = 0;
     return get_attr_entry(&cterm_attr_table, &at_en);
 }
 #endif
@@ -3345,11 +3346,10 @@ set_hl_attr(
 	sgp->sg_term_attr = get_attr_entry(&term_attr_table, &at_en);
     }
 
-    if (sgp->sg_cterm_font != 0)
-	at_en.ae_u.cterm.font = sgp->sg_cterm_font;
     // For the color term mode: If there are other than "normal"
     // highlighting attributes, need to allocate an attr number.
-    if (sgp->sg_cterm_fg == 0 && sgp->sg_cterm_bg == 0 && sgp->sg_cterm_ul == 0
+    if (sgp->sg_cterm_fg == 0 && sgp->sg_cterm_bg == 0 &&
+	sgp->sg_cterm_ul == 0 && sgp->sg_cterm_font == 0
 # ifdef FEAT_TERMGUICOLORS
 	    && sgp->sg_gui_fg == INVALCOLOR
 	    && sgp->sg_gui_bg == INVALCOLOR
@@ -3363,6 +3363,7 @@ set_hl_attr(
 	at_en.ae_u.cterm.fg_color = sgp->sg_cterm_fg;
 	at_en.ae_u.cterm.bg_color = sgp->sg_cterm_bg;
 	at_en.ae_u.cterm.ul_color = sgp->sg_cterm_ul;
+	at_en.ae_u.cterm.font = sgp->sg_cterm_font;
 # ifdef FEAT_TERMGUICOLORS
 	at_en.ae_u.cterm.fg_rgb = GUI_MCH_GET_RGB2(sgp->sg_gui_fg);
 	at_en.ae_u.cterm.bg_rgb = GUI_MCH_GET_RGB2(sgp->sg_gui_bg);
@@ -4467,6 +4468,7 @@ hlg_add_or_update(dict_T *dict)
     char_u	*ctermfg;
     char_u	*ctermbg;
     char_u	*ctermul;
+    char_u	*ctermfont;
     char_u	*guifg;
     char_u	*guibg;
     char_u	*guisp;
@@ -4551,6 +4553,10 @@ hlg_add_or_update(dict_T *dict)
     if (error)
 	return FALSE;
 
+    ctermfont = hldict_get_string(dict, (char_u *)"ctermfont", &error);
+    if (error)
+	return FALSE;
+
     if (!hldict_attr_to_str(dict, (char_u *)"gui", gui_attr, sizeof(gui_attr)))
 	return FALSE;
 
@@ -4575,7 +4581,7 @@ hlg_add_or_update(dict_T *dict)
     // If none of the attributes are specified, then do nothing.
     if (term_attr[0] == NUL && start == NULL && stop == NULL
 	    && cterm_attr[0] == NUL && ctermfg == NULL && ctermbg == NULL
-	    && ctermul == NULL && gui_attr[0] == NUL
+	    && ctermul == NULL && ctermfont == NULL && gui_attr[0] == NUL
 # ifdef FEAT_GUI
 	    && font == NULL
 # endif
@@ -4595,6 +4601,7 @@ hlg_add_or_update(dict_T *dict)
     p = add_attr_and_value(p, (char_u *)" ctermfg=", 9, ctermfg);
     p = add_attr_and_value(p, (char_u *)" ctermbg=", 9, ctermbg);
     p = add_attr_and_value(p, (char_u *)" ctermul=", 9, ctermul);
+    p = add_attr_and_value(p, (char_u *)" ctermfont=", 9, ctermfont);
     p = add_attr_and_value(p, (char_u *)" gui=", 5, gui_attr);
 # ifdef FEAT_GUI
     p = add_attr_and_value(p, (char_u *)" font=", 6, font);

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -1062,7 +1062,7 @@ highlight_set_cterm_font(
     else
 	return FALSE;
 
-    HL_TABLE()[idx].sg_cterm_font = font;
+    HL_TABLE()[idx].sg_cterm_font = font + 1;
     return TRUE;
 }
 
@@ -2995,9 +2995,8 @@ highlight_list_one(int id)
 				    sgp->sg_cterm_bg, NULL, "ctermbg");
     didh = highlight_list_arg(id, didh, LIST_INT,
 				    sgp->sg_cterm_ul, NULL, "ctermul");
-    if (sgp->sg_cterm_font != 0)
-	didh = highlight_list_arg(id, didh, LIST_INT,
-				    sgp->sg_cterm_font + 1, NULL, "ctermfont");
+    didh = highlight_list_arg(id, didh, LIST_INT,
+				    sgp->sg_cterm_font, NULL, "ctermfont");
 
 #if defined(FEAT_GUI) || defined(FEAT_EVAL)
     didh = highlight_list_arg(id, didh, LIST_ATTR,
@@ -3197,7 +3196,7 @@ highlight_color(
 	else if (ul)
 	    n = HL_TABLE()[id - 1].sg_cterm_ul - 1;
 	else if (font)
-	    n = HL_TABLE()[id - 1].sg_cterm_font;
+	    n = HL_TABLE()[id - 1].sg_cterm_font - 1;
 	else
 	    n = HL_TABLE()[id - 1].sg_cterm_bg - 1;
 	if (n < 0)

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -1048,7 +1048,6 @@ highlight_set_ctermul(int idx, int color, int is_normal_group)
 highlight_set_cterm_font(
 	int	idx,
 	char_u	*arg,
-	int	is_normal_group,
 	int	init)
 {
     int		font;
@@ -1714,7 +1713,7 @@ do_highlight(
 	    }
 	    else if (STRCMP(key, "CTERMFONT") == 0)
 	    {
-		if (!highlight_set_cterm_font(idx, arg, is_normal_group, init))
+		if (!highlight_set_cterm_font(idx, arg, init))
 		{
 		    error = TRUE;
 		    break;

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -1059,6 +1059,8 @@ highlight_set_cterm_font(
 
     if (VIM_ISDIGIT(*arg))
 	font = atoi((char *)arg);
+    else if (STRICMP(arg, "NONE") == 0)
+	font = -1;
     else
 	return FALSE;
 

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -2995,8 +2995,9 @@ highlight_list_one(int id)
 				    sgp->sg_cterm_bg, NULL, "ctermbg");
     didh = highlight_list_arg(id, didh, LIST_INT,
 				    sgp->sg_cterm_ul, NULL, "ctermul");
-    didh = highlight_list_arg(id, didh, LIST_INT,
-				    sgp->sg_cterm_font, NULL, "ctermfont");
+    if (sgp->sg_cterm_font != 0)
+	didh = highlight_list_arg(id, didh, LIST_INT,
+				    sgp->sg_cterm_font + 1, NULL, "ctermfont");
 
 #if defined(FEAT_GUI) || defined(FEAT_EVAL)
     didh = highlight_list_arg(id, didh, LIST_ATTR,
@@ -3187,7 +3188,7 @@ highlight_color(
 	    return (HL_TABLE()[id - 1].sg_gui_sp_name);
 	return (HL_TABLE()[id - 1].sg_gui_bg_name);
     }
-    if (font || sp)
+    if (sp)
 	return NULL;
     if (modec == 'c')
     {
@@ -3195,6 +3196,8 @@ highlight_color(
 	    n = HL_TABLE()[id - 1].sg_cterm_fg - 1;
 	else if (ul)
 	    n = HL_TABLE()[id - 1].sg_cterm_ul - 1;
+	else if (font)
+	    n = HL_TABLE()[id - 1].sg_cterm_font;
 	else
 	    n = HL_TABLE()[id - 1].sg_cterm_bg - 1;
 	if (n < 0)
@@ -4234,7 +4237,8 @@ highlight_get_info(int hl_idx, int resolve_link)
 			highlight_color(hlgid, (char_u *)"ul", 'c')) == FAIL)
 	    goto error;
     if (sgp->sg_cterm_font != 0)
-	if (dict_add_number(dict, "font", sgp->sg_cterm_font) == FAIL)
+	if (dict_add_string(dict, "ctermfont",
+			highlight_color(hlgid, (char_u *)"font", 'c')) == FAIL)
 	    goto error;
     if (sgp->sg_gui != 0)
     {

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -1038,7 +1038,6 @@ highlight_set_ctermul(int idx, int color, int is_normal_group)
 /*
  * Set the cterm font for the highlight group at 'idx'.
  * 'arg' is the color name or the numeric value as a string.
- * 'is_normal_group' is set if the highlight group is 'NORMAL'
  * 'init' is set to TRUE when initializing highlighting.
  * Called for the ":highlight" command and the "hlset()" function.
  *
@@ -1177,6 +1176,7 @@ highlight_set_cterm_color(
 
     return TRUE;
 }
+
 #if defined(FEAT_GUI) || defined(FEAT_EVAL)
 /*
  * Set the GUI foreground color for the highlight group at 'idx'.

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -33,6 +33,7 @@ void term_set_winsize(int height, int width);
 void term_fg_color(int n);
 void term_bg_color(int n);
 void term_ul_color(int n);
+void term_font(int n);
 char_u *term_bg_default(void);
 void term_fg_rgb_color(guicolor_T rgb);
 void term_bg_rgb_color(guicolor_T rgb);

--- a/src/screen.c
+++ b/src/screen.c
@@ -1667,7 +1667,7 @@ screen_start_highlight(int attr)
      */
     if (aep != NULL)
     {
-	if (aep->ae_u.cterm.font >= 0 && aep->ae_u.cterm.font < 10)
+	if (aep->ae_u.cterm.font < 10)
 		term_font(aep->ae_u.cterm.font);
 #ifdef FEAT_TERMGUICOLORS
 	// When 'termguicolors' is set but fg or bg is unset,

--- a/src/screen.c
+++ b/src/screen.c
@@ -1667,7 +1667,7 @@ screen_start_highlight(int attr)
      */
     if (aep != NULL)
     {
-	if (aep->ae_u.cterm.font > 0 && aep->ae_u.cterm.font < 11)
+	if (aep->ae_u.cterm.font > 0 && aep->ae_u.cterm.font < 12)
 		term_font(aep->ae_u.cterm.font);
 #ifdef FEAT_TERMGUICOLORS
 	// When 'termguicolors' is set but fg or bg is unset,

--- a/src/screen.c
+++ b/src/screen.c
@@ -1667,7 +1667,7 @@ screen_start_highlight(int attr)
      */
     if (aep != NULL)
     {
-	if (aep->ae_u.cterm.font < 10)
+	if (aep->ae_u.cterm.font > 0 && aep->ae_u.cterm.font < 11)
 		term_font(aep->ae_u.cterm.font);
 #ifdef FEAT_TERMGUICOLORS
 	// When 'termguicolors' is set but fg or bg is unset,

--- a/src/screen.c
+++ b/src/screen.c
@@ -1667,6 +1667,8 @@ screen_start_highlight(int attr)
      */
     if (aep != NULL)
     {
+	if (aep->ae_u.cterm.font >= 0 && aep->ae_u.cterm.font < 10)
+		term_font(aep->ae_u.cterm.font);
 #ifdef FEAT_TERMGUICOLORS
 	// When 'termguicolors' is set but fg or bg is unset,
 	// fall back to the cterm colors.   This helps for SpellBad,

--- a/src/structs.h
+++ b/src/structs.h
@@ -1186,6 +1186,7 @@ typedef struct attr_entry
 	    short_u	    fg_color;	// foreground color number
 	    short_u	    bg_color;	// background color number
 	    short_u	    ul_color;	// underline color number
+	    short_u	    font;	// font number
 # ifdef FEAT_TERMGUICOLORS
 	    guicolor_T	    fg_rgb;	// foreground color RGB
 	    guicolor_T	    bg_rgb;	// background color RGB

--- a/src/term.c
+++ b/src/term.c
@@ -3121,7 +3121,7 @@ term_font(int n)
 {
     char buf[20];
     char *format = "\033[%dm";
-    sprintf(buf, format, 10 + n);
+    sprintf(buf, format, 9 + n);
     OUT_STR(buf);
 }
 

--- a/src/term.c
+++ b/src/term.c
@@ -3116,6 +3116,15 @@ term_set_winsize(int height, int width)
 }
 #endif
 
+    void
+term_font(int n)
+{
+    char buf[20];
+    char *format = "\033[%dm";
+    sprintf(buf, format, 10 + n);
+    OUT_STR(buf);
+}
+
     static void
 term_color(char_u *s, int n)
 {

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -888,6 +888,16 @@ func Test_highlight_ctermul()
   highlight Normal ctermul=NONE
 endfunc
 
+" Test for 'ctermfont' in a highlight group
+func Test_highlight_ctermfont()
+  CheckNotGui
+  call assert_notmatch('ctermfont=', HighlightArgs('Normal'))
+  highlight Normal ctermfont=3
+  call assert_match('ctermfont=3', HighlightArgs('Normal'))
+  call assert_equal('3', synIDattr(synIDtrans(hlID('Normal')), 'font'))
+  highlight Normal ctermfont=NONE
+endfunc
+
 " Test for specifying 'start' and 'stop' in a highlight group
 func Test_highlight_start_stop()
   hi HlGrp1 start=<Esc>[27h;<Esc>[<Space>r;
@@ -1314,6 +1324,7 @@ func Test_hlset()
   call hlset([{'name': 'hlg11', 'ctermfg': ''}])
   call hlset([{'name': 'hlg11', 'ctermbg': ''}])
   call hlset([{'name': 'hlg11', 'ctermul': ''}])
+  call hlset([{'name': 'hlg11', 'ctermfont': ''}])
   call hlset([{'name': 'hlg11', 'font': ''}])
   call hlset([{'name': 'hlg11', 'gui': {}}])
   call hlset([{'name': 'hlg11', 'guifg': ''}])


### PR DESCRIPTION
This adds support for alternate font highlighting using CSI SGR 10-19. Few terminals currently support this, but with added tool support this should improve over time. The change here is more or less taken from how colors are configured and applied, but there might be some parts I missed while implementing it. Changing fonts is done through the new `ctermfont` attribute which takes a number, 0 is the normal font, and the numbers 1-9 select an "alternative" font. Which fonts are in use is up to the terminal.

An example of what the result looks like can be found in my [patched version of pangoterm]( /PMunch/pangoterm-altfonts) which I used to implement this feature:

![Example](https://github.com/PMunch/pangoterm-altfonts/raw/master/example.png)