### PR TITLE
Initialize rettv in invoke_popup_callback()

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2382,6 +2382,8 @@ invoke_popup_callback(win_T *wp, typval_T *result)
     typval_T	rettv;
     typval_T	argv[3];
 
+    rettv.v_type = VAR_UNKNOWN;
+
     argv[0].v_type = VAR_NUMBER;
     argv[0].vval.v_number = (varnumber_T)wp->w_id;
 


### PR DESCRIPTION
Since v9.0.2030, call_callback may exit early when the callback recurses
too much.  This meant that call_func, which would set rettv->v_type =
VAR_UNKNOWN, was not being called.

Without rettv->v_type being explicitly set, it still contained whatever
garbage was used to initialize the stack value in invoke_popup_callback.
This would lead to possible crashes when calling clear_tv(&rettv).

Rather than rely on action at a distance, explicitly initialize rettv's
type to VAR_UNKNOWN so clear_tv can tell nothing needs to be done.

Closes #13495
Signed-off-by: James McCoy <jamessan@jamessan.com>