### PR TITLE
Tweaking of some documents. Mainly whitespace related.

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.0.  Last change: 2023 Sep 27
+*builtin.txt*	For Vim version 9.0.  Last change: 2023 Nov 20
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4008,8 +4008,8 @@ getqflist([{what}])					*getqflist()*
 			text	description of the error
 			type	type of the error, 'E', '1', etc.
 			valid	|TRUE|: recognized error message
-		        user_data
-			        custom data associated with the item, can be
+			user_data
+				custom data associated with the item, can be
 				any type.
 
 		When there is no error list or it's empty, an empty list is
@@ -6793,96 +6793,96 @@ printf({fmt}, {expr1} ...)				*printf()*
 		having a different word order, positional arguments may be
 		used to indicate this. For instance: >
 
-			#, c-format
-			msgid "%s returning %s"
-			msgstr "waarde %2$s komt terug van %1$s"
+		    #, c-format
+		    msgid "%s returning %s"
+		    msgstr "waarde %2$s komt terug van %1$s"
 <
-		In this example, the sentence has its 2 string arguments reversed
-		in the output. >
+		In this example, the sentence has its 2 string arguments
+		reversed in the output. >
 
-			echo printf(
-				"In The Netherlands, vim's creator's name is: %1$s %2$s",
-				"Bram", "Moolenaar")
-<			In The Netherlands, vim's creator's name is: Bram Moolenaar >
+		    echo printf(
+			"In The Netherlands, vim's creator's name is: %1$s %2$s",
+			"Bram", "Moolenaar")
+<		    In The Netherlands, vim's creator's name is: Bram Moolenaar >
 
-			echo printf(
-				"In Belgium, vim's creator's name is: %2$s %1$s",
-				"Bram", "Moolenaar")
-<			In Belgium, vim's creator's name is: Moolenaar Bram
+		    echo printf(
+			"In Belgium, vim's creator's name is: %2$s %1$s",
+			"Bram", "Moolenaar")
+<		    In Belgium, vim's creator's name is: Moolenaar Bram
 
 		Width (and precision) can be specified using the '*' specifier.
 		In this case, you must specify the field width position in the
 		argument list. >
 
-			echo printf("%1$*2$.*3$d", 1, 2, 3)
-<			001 >
-			echo printf("%2$*3$.*1$d", 1, 2, 3)
-<			  2 >
-			echo printf("%3$*1$.*2$d", 1, 2, 3)
-<			03 >
-			echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
-<			1.414
+		    echo printf("%1$*2$.*3$d", 1, 2, 3)
+<		    001 >
+		    echo printf("%2$*3$.*1$d", 1, 2, 3)
+<		      2 >
+		    echo printf("%3$*1$.*2$d", 1, 2, 3)
+<		    03 >
+		    echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
+<		    1.414
 
 		You can mix specifying the width and/or precision directly
 		and via positional arguments: >
 
-			echo printf("%1$4.*2$f", 1.4142135, 6)
-<			1.414214 >
-			echo printf("%1$*2$.4f", 1.4142135, 6)
-<			1.4142 >
-			echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
-<			  1.41
+		    echo printf("%1$4.*2$f", 1.4142135, 6)
+<		    1.414214 >
+		    echo printf("%1$*2$.4f", 1.4142135, 6)
+<		    1.4142 >
+		    echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
+<		      1.41
 
 							*E1500*
 		You cannot mix positional and non-positional arguments: >
-			echo printf("%s%1$s", "One", "Two")
-<			E1500: Cannot mix positional and non-positional
-			arguments: %s%1$s
+		    echo printf("%s%1$s", "One", "Two")
+<		    E1500: Cannot mix positional and non-positional arguments:
+		    %s%1$s
 
 							*E1501*
 		You cannot skip a positional argument in a format string: >
-			echo printf("%3$s%1$s", "One", "Two", "Three")
-<			E1501: format argument 2 unused in $-style
-			format: %3$s%1$s
+		    echo printf("%3$s%1$s", "One", "Two", "Three")
+<		    E1501: format argument 2 unused in $-style format:
+		    %3$s%1$s
 
 							*E1502*
 		You can re-use a [field-width] (or [precision]) argument: >
-			echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
-<			1 at width 2 is: 01
+		    echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
+<		    1 at width 2 is: 01
 
 		However, you can't use it as a different type: >
-			echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
-<			E1502: Positional argument 2 used as field
-			width reused as different type: long int/int
+		    echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
+<		    E1502: Positional argument 2 used as field width reused as
+		    different type: long int/int
 
 							*E1503*
 		When a positional argument is used, but not the correct number
 		or arguments is given, an error is raised: >
-			echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
-<			E1503: Positional argument 3 out of bounds:
-			%1$d at width %2$d is: %01$*2$.*3$d
+		    echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
+<		    E1503: Positional argument 3 out of bounds: %1$d at width
+		    %2$d is: %01$*2$.*3$d
 
 		Only the first error is reported: >
-			echo printf("%01$*2$.*3$d %4$d", 1, 2)
-<			E1503: Positional argument 3 out of bounds:
-			%01$*2$.*3$d %4$d
+		    echo printf("%01$*2$.*3$d %4$d", 1, 2)
+<		    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
+		    %4$d
 
 							*E1504*
 		A positional argument can be used more than once: >
-			echo printf("%1$s %2$s %1$s", "One", "Two")
-<			One Two One
+		    echo printf("%1$s %2$s %1$s", "One", "Two")
+<		    One Two One
 
 		However, you can't use a different type the second time: >
-			echo printf("%1$s %2$s %1$d", "One", "Two")
-<			E1504: Positional argument 1 type used
-			inconsistently: int/string
+		    echo printf("%1$s %2$s %1$d", "One", "Two")
+<		    E1504: Positional argument 1 type used inconsistently:
+		    int/string
 
 							*E1505*
 		Various other errors that lead to a format string being
 		wrongly formatted lead to: >
-			echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
-<			E1505: Invalid format specifier:
-			%1$d at width %2$d is: %01$*2$.3$d
+		    echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
+<		    E1505: Invalid format specifier: %1$d at width %2$d is:
+		    %01$*2$.3$d
 
 							*E1507*
 		This internal error indicates that the logic to parse a
@@ -10177,8 +10177,8 @@ type({expr})	The result is a Number representing the type of {expr}.
 			Job:	    8  |v:t_job|
 			Channel:    9  |v:t_channel|
 			Blob:	   10  |v:t_blob|
-			Class	   12  |v:t_class|
-			Object	   13  |v:t_object|
+			Class:	   12  |v:t_class|
+			Object:	   13  |v:t_object|
 		For backward compatibility, this method can be used: >
 			:if type(myvar) == type(0)
 			:if type(myvar) == type("")

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4809,12 +4809,12 @@ Vim comes bundled with a Vim script library, that can be used by runtime,
 script authors.  Currently, it only includes very few functions, but it may
 grow over time.
 
-The functions are available as |Vim9-script| as well as using legacy vim
+The functions are available as |Vim9-script| as well as using legacy Vim
 script (to be used for non Vim 9.0 versions and Neovim).
 
 							*dist#vim* *dist#vim9*
-The functions make use of the autoloaded prefix "dist#vim" (for legacy Vim script and
-Neovim) and "dist#vim9" for Vim9 script.
+The functions make use of the autoloaded prefix "dist#vim" (for legacy Vim
+script and Neovim) and "dist#vim9" for Vim9 script.
 
 The following functions are available:
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 9.0.  Last change: 2023 Nov 05
+*eval.txt*	For Vim version 9.0.  Last change: 2023 Nov 20
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.0.  Last change: 2023 Nov 19
+*options.txt*	For Vim version 9.0.  Last change: 2023 Nov 20
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -9299,7 +9299,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	uses another default.
 
 
-			*'wildignorecase'* *'wic'* *'nowildignorecase'* *'nowic'*
+		    *'wildignorecase'* *'wic'* *'nowildignorecase'* *'nowic'*
 'wildignorecase' 'wic'	boolean	(default off)
 			global
 	When set case is ignored when completing file names and directories.

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -757,8 +757,9 @@ For Windows Terminal you can use something like this: >
 	let &t_SI = "\e[5 q"    " blink bar
 	let &t_SR = "\e[3 q"    " blink underline
 	let &t_EI = "\e[1 q"    " blink block
-	let &t_ti ..= "\e[1 q"   " blink block
-	let &t_te ..= "\e[0 q"   " default (depends on terminal, normally blink block)
+	let &t_ti ..= "\e[1 q"  " blink block
+	let &t_te ..= "\e[0 q"  " default (depends on terminal, normally blink
+				" block)
     endif
 
 {not available when compiled without the |+cursorshape| feature}

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -1,4 +1,4 @@
-*term.txt*      For Vim version 9.0.  Last change: 2023 Nov 04
+*term.txt*      For Vim version 9.0.  Last change: 2023 Nov 20
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -1,4 +1,4 @@
-*vim9class.txt*	For Vim version 9.0.  Last change: 2023 Sep 18
+*vim9class.txt*	For Vim version 9.0.  Last change: 2023 Nov 20
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -402,7 +402,7 @@ class, for which objects can be created.  Example: >
 An abstract class is defined the same way as a normal class, except that it
 does not have any new() method. *E1359*
 
-						*abstract-method* *E1371* *E1372*
+					    *abstract-method* *E1371* *E1372*
 An abstract method can be defined in an abstract class by using the "abstract"
 prefix when defining the method: >
 


### PR DESCRIPTION
Details.

- builtin.txt:
getqflist():  Fixed spaces to tabs.
printf-$:  Adjust nesting amount.  (This is a suggestion)
type():  Fixed missing colon.
- options.txt:  Fixed over 80 columns.
- term.txt:  Aligned comment start position with others.
- vim9class.txt:  Fixed over 80 columns.
- eval.txt: Fixed over 80 columns, capitalize `Vim`.
