### PR TITLE
Filelist: Add new sub-Makefiles

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -698,6 +698,7 @@ RT_ALL =	\
 		runtime/doc/*.pl \
 		runtime/doc/*.txt \
 		runtime/doc/Makefile \
+		runtime/doc/Make_all.mak \
 		runtime/doc/doctags.c \
 		runtime/doc/doctags.vim \
 		runtime/doc/test_urls.vim \
@@ -846,6 +847,7 @@ RT_AMI_DOS =	\
 # DOS runtime (also in the extra archive)
 RT_DOS =	\
 		README_dos.txt \
+		runtime/doc/Make_mvc.mak \
 		vimtutor.bat \
 
 # DOS runtime without CR-LF translation (also in the extra archive)


### PR DESCRIPTION
Tags for help files disappeared with the latest Vim update in Fedora, which is caused by silent error (it didn't stop the build) about missing file. I use 'make unixall' in Fedora to get the latest patchlevels and the new files were missing from Filelist file which is used for generating the tarball.

The error from the build:
```
cd ../runtime/doc; if test -z "" -a -f tags; then \
	mv -f tags tags.dist; fi
generating help tags
# We can assume Vim was build, but it may not have been installed,
# thus use the executable in the current directory.
make[1]: Entering directory '/builddir/build/BUILD/vim90/runtime/doc'
Makefile:17: Make_all.mak: No such file or directory
make[1]: *** No rule to make target 'Make_all.mak'.  Stop.
make[1]: Leaving directory '/builddir/build/BUILD/vim90/runtime/doc'
make: [Makefile:2350: installrtbase] Error 2 (ignored)
cd ../runtime/doc; \
	files=`ls *.txt tags`; \
	files="$files `ls *.??x tags-?? 2>/dev/null || true`"; \
	cp $files  /builddir/build/BUILDROOT/vim-9.0.2105-1.fc38.ppc64le/usr/share/vim/vim90/doc; \
	cd /builddir/build/BUILDROOT/vim-9.0.2105-1.fc38.ppc64le/usr/share/vim/vim90/doc; \
	chmod 644 $files
ls: cannot access 'tags': No such file or directory
```

[Fedora bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2250722)