### PR TITLE
[use-after-free] in ex_substitute

### DIFF
--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -1472,4 +1472,29 @@ func Test_substitute_expr_recursive()
   exe bufnr .. "bw!"
 endfunc
 
+" recursive call of :s and sub-replace special
+" (used to access freed memory)
+"
+" This test needs to be run as first one, because it
+" depends on that the last substitution pattern has
+" not yet been set
+func Test_aaaa_substitute_expr_recursive_special()
+  func R()
+    " FIXME: leaving out the 'n' flag leaks memory, why?
+    %s/./\='.'/gn
+  endfunc
+  new Xfoobar_UAF
+  put ='abcdef'
+  let bufnr = bufnr('%')
+  try
+    silent! :s/./~\=R()/0
+    "call assert_fails(':s/./~\=R()/0', 'E939:')
+    let @/='.'
+    ~g
+  catch /^Vim\%((\a\+)\)\=:E565:/
+  endtry
+  delfunc R
+  exe bufnr .. "bw!"
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -147,7 +147,6 @@ func Test_substitute_repeat()
   call feedkeys("Qsc\<CR>y", 'tx')
   bwipe!
 endfunc
-
 " Test %s/\n// which is implemented as a special case to use a
 " more efficient join rather than doing a regular substitution.
 func Test_substitute_join()
@@ -1447,10 +1446,29 @@ func Test_substitute_expr_switch_win()
   endfunc
   new Xfoobar
   let bufnr = bufnr('%')
-  put ="abcdef"
+  put ='abcdef'
   silent! s/\%')/\=R()
   call assert_fails(':%s/./\=R()/g', 'E565:')
   delfunc R
+  exe bufnr .. "bw!"
+endfunc
+
+" recursive call of :s using test-replace special
+func Test_substitute_expr_recursive()
+  func Q()
+    %s/./\='foobar'/gn
+    return "foobar"
+  endfunc
+  func R()
+    %s/./\=Q()/g
+  endfunc
+  new Xfoobar_UAF
+  let bufnr = bufnr('%')
+  put ='abcdef'
+  silent! s/./\=R()/g
+  call assert_fails(':%s/./\=R()/g', 'E565:')
+  delfunc R
+  delfunc Q
   exe bufnr .. "bw!"
 endfunc
 


### PR DESCRIPTION
There was a report that Vim was using heap-use-after free in a deeply recursive :substitute call chain.

The following commit will fix this. I haven't been able to create a reproducible test case yet unfortunately.

Until now, we used the sub variable mostly as a pointer to the stack, however, sometimes it was actually allocated, so in addition the variable sub_copy was used to remember if there was anything to free.

However, when calling :s recursively, it may happen that sub points to the allocated variable old_sub, which might be freed later in a recursive call, which means that sub would then point to freed memory.

So let's just always allocate memory for sub but of course now we need to make sure to properly free the memory whenever we leave the function.

Since sub is now always allocated, we don't need the sub_copy variable anymore, which makes it slightly more easier to read.

TODO: add a proper test case that causes the initial issue.