### PR TITLE
Introduce and use INT_TRIM/trim_to_int.

### DIFF
--- a/src/cindent.c
+++ b/src/cindent.c
@@ -1734,7 +1734,7 @@ parse_cino(buf_T *buf)
     int		divider;
     int		fraction = 0;
     int		sw;
-    long long	t = get_sw_value(buf);
+    long	t = get_sw_value(buf);
 
     // needed for cino-(, it will be multiplied by 2 again
     if (t > INT_MAX / 2)
@@ -1902,17 +1902,14 @@ parse_cino(buf_T *buf)
 	    {
 		n *= sw;
 		if (divider)
-		    n += (sw * fraction + divider / 2) / divider;
+		    n += ((long long)sw * fraction + divider / 2) / divider;
 	    }
 	    ++p;
 	}
 	if (l[1] == '-')
 	    n = -n;
 
-	if (n > INT_MAX)
-	    n = INT_MAX;
-	else if (n < INT_MIN)
-	    n = INT_MIN;
+	n = trim_to_int(n);
 
 	// When adding an entry here, also update the default 'cinoptions' in
 	// doc/indent.txt, and add explanation for it!

--- a/src/ops.c
+++ b/src/ops.c
@@ -135,6 +135,13 @@ get_extra_op_char(int optype)
     return opchars[optype][1];
 }
 
+// Return something that fits into an int.
+    int
+trim_to_int(long long x)
+{
+    return x > INT_MAX ? INT_MAX : x < INT_MIN ? INT_MIN : x;
+}
+
 /*
  * op_shift - handle a shift operation
  */
@@ -230,8 +237,8 @@ shift_line(
     int call_changed_bytes)	// call changed_bytes()
 {
     long long	count;
-    long	i, j;
-    long	sw_val = get_sw_value_indent(curbuf);
+    int		i, j;
+    int		sw_val = trim_to_int(get_sw_value_indent(curbuf));
 
     count = (long long)get_indent();	// get current indent
 

--- a/src/proto/ops.pro
+++ b/src/proto/ops.pro
@@ -3,6 +3,7 @@ int get_op_type(int char1, int char2);
 int op_is_change(int op);
 int get_op_char(int optype);
 int get_extra_op_char(int optype);
+int trim_to_int(long long x);
 void op_shift(oparg_T *oap, int curs_top, int amount);
 void shift_line(int left, int round, int amount, int call_changed_bytes);
 int op_delete(oparg_T *oap);


### PR DESCRIPTION
The macro typically used to constrain a long to fit into an int.

Initially used to trim int options sizes, and defensively in `shift_line()`.

@chrisbra If `sw` remains constrained to an int, then the use of INT_TRIM at the entry in `shift_line()` is not required. LMK if you want that change.