### PR TITLE
Avoid unused assignments when checking the value of 'listchars'

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4726,7 +4726,7 @@ set_chars_option(win_T *wp, char_u *value, int is_listchars, int apply)
     }
 
     // first round: check for valid value, second round: assign values
-    for (round = 0; round <= 1; ++round)
+    for (round = 0; round <= (apply ? 1 : 0); ++round)
     {
 	if (round > 0)
 	{
@@ -4912,11 +4912,6 @@ set_chars_option(win_T *wp, char_u *value, int is_listchars, int apply)
 	{
 	    wp->w_fill_chars = fill_chars;
 	}
-    }
-    else if (is_listchars)
-    {
-	vim_free(lcs_chars.multispace);
-	vim_free(lcs_chars.leadmultispace);
     }
 
     return NULL;	// no error

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -265,6 +265,11 @@ func Test_listchars()
   call Check_listchars(expected, 5, 12)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
+  " Changing the value of 'ambiwidth' twice shouldn't cause double-free when
+  " "leadmultispace" is specified.
+  set ambiwidth=double
+  set ambiwidth&
+
   " Test leadmultispace and lead and space
   normal ggdG
   set listchars&


### PR DESCRIPTION
Problem:  Unused assignments when checking the value of 'listchars'.
Solution: Loop only once when just checking the value.  Add a test to
          check that this change doesn't cause double-free.
