### PR TITLE
Syntax file for SWIG (Simplified Wrapper Interface Generator) description files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,6 +224,7 @@ runtime/ftplugin/spec.vim		@ignatenkobrain
 runtime/ftplugin/ssa.vim		@ObserverOfTime
 runtime/ftplugin/swayconfig.vim		@jamespeapen
 runtime/ftplugin/systemverilog.vim	@Kocha
+runtime/ftplugin/swig.vim		@jmarrec
 runtime/ftplugin/tap.vim		@petdance
 runtime/ftplugin/tcsh.vim		@dkearns
 runtime/ftplugin/tidy.vim		@dkearns
@@ -502,6 +503,7 @@ runtime/syntax/sshdconfig.vim		@Jakuje
 runtime/syntax/sudoers.vim		@e-kwsm
 runtime/syntax/svn.vim			@hdima
 runtime/syntax/swayconfig.vim		@jamespeapen
+runtime/syntax/swig.vim			@jmarrec
 runtime/syntax/systemverilog.vim	@Kocha
 runtime/syntax/tags.vim			@cecamp
 runtime/syntax/tap.vim			@petdance

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -590,18 +590,27 @@ export def FTprogress_cweb()
   endif
 enddef
 
+# These include the leading '%' sign
+var ft_swig_keywords = '^\s*%\%(addmethods\|apply\|beginfile\|clear\|constant\|define\|echo\|enddef\|endoffile\|extend\|feature\|fragment\|ignore\|import\|importfile\|include\|includefile\|inline\|insert\|keyword\|module\|name\|namewarn\|native\|newobject\|parms\|pragma\|rename\|template\|typedef\|typemap\|types\|varargs\|warn\)'
+# This is the start/end of a block that is copied literally to the processor file (C/C++)
+var ft_swig_verbatim_block_start = '^\s*%{'
+var ft_swig_verbatim_block_end = '^\s*}%'
+
 export def FTprogress_asm()
   if exists("g:filetype_i")
     exe "setf " .. g:filetype_i
     return
   endif
-  # This function checks for an assembly comment the first ten lines.
+  # This function checks for an assembly comment or a SWIG keyword or verbatim block in the first 50 lines.
   # If not found, assume Progress.
   var lnum = 1
-  while lnum <= 10 && lnum < line('$')
+  while lnum <= 50 && lnum < line('$')
     var line = getline(lnum)
     if line =~ '^\s*;' || line =~ '^\*'
       FTasm()
+      return
+    elseif line =~ ft_swig_keywords || line =~ ft_swig_verbatim_block_start || line =~ ft_swig_verbatim_block_end
+      setf swig
       return
     elseif line !~ '^\s*$' || line =~ '^/\*'
       # Not an empty line: Doesn't look like valid assembly code.

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -594,9 +594,8 @@ enddef
 var ft_swig_keywords = '^\s*%\%(addmethods\|apply\|beginfile\|clear\|constant\|define\|echo\|enddef\|endoffile\|extend\|feature\|fragment\|ignore\|import\|importfile\|include\|includefile\|inline\|insert\|keyword\|module\|name\|namewarn\|native\|newobject\|parms\|pragma\|rename\|template\|typedef\|typemap\|types\|varargs\|warn\)'
 # This is the start/end of a block that is copied literally to the processor file (C/C++)
 var ft_swig_verbatim_block_start = '^\s*%{'
-var ft_swig_verbatim_block_end = '^\s*}%'
 
-export def FTprogress_asm()
+export def FTi()
   if exists("g:filetype_i")
     exe "setf " .. g:filetype_i
     return
@@ -609,7 +608,7 @@ export def FTprogress_asm()
     if line =~ '^\s*;' || line =~ '^\*'
       FTasm()
       return
-    elseif line =~ ft_swig_keywords || line =~ ft_swig_verbatim_block_start || line =~ ft_swig_verbatim_block_end
+    elseif line =~ ft_swig_keywords || line =~ ft_swig_verbatim_block_start
       setf swig
       return
     endif

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -612,10 +612,6 @@ export def FTprogress_asm()
     elseif line =~ ft_swig_keywords || line =~ ft_swig_verbatim_block_start || line =~ ft_swig_verbatim_block_end
       setf swig
       return
-    elseif line !~ '^\s*$' || line =~ '^/\*'
-      # Not an empty line: Doesn't look like valid assembly code.
-      # Or it looks like a Progress /* comment
-      break
     endif
     lnum += 1
   endwhile

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2184,7 +2184,7 @@ au BufNewFile,BufRead *.swift.gyb		setf swiftgyb
 au BufNewFile,BufRead *.sil			call dist#ft#FTsil()
 
 " Swig
-au BufNewFile,BufRead *.swg,*.swig set filetype=swig
+au BufNewFile,BufRead *.swg,*.swig setf swig
 
 " Sysctl
 au BufNewFile,BufRead */etc/sysctl.conf,*/etc/sysctl.d/*.conf	setf sysctl

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1689,7 +1689,7 @@ au BufNewFile,BufRead .procmail,.procmailrc	setf procmail
 au BufNewFile,BufRead *.w			call dist#ft#FTprogress_cweb()
 
 " Progress or assembly or Swig
-au BufNewFile,BufRead *.i			call dist#ft#FTprogress_asm()
+au BufNewFile,BufRead *.i			call dist#ft#FTi()
 
 " Progress or Pascal
 au BufNewFile,BufRead *.p			call dist#ft#FTprogress_pascal()

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2183,6 +2183,9 @@ au BufNewFile,BufRead *.swift.gyb		setf swiftgyb
 " Swift Intermediate Language or SILE
 au BufNewFile,BufRead *.sil			call dist#ft#FTsil()
 
+" Swig
+autocmd BufNewFile,BufRead *.i,*.swg,*.swig set filetype=swig
+
 " Sysctl
 au BufNewFile,BufRead */etc/sysctl.conf,*/etc/sysctl.d/*.conf	setf sysctl
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1688,7 +1688,7 @@ au BufNewFile,BufRead .procmail,.procmailrc	setf procmail
 " Progress or CWEB
 au BufNewFile,BufRead *.w			call dist#ft#FTprogress_cweb()
 
-" Progress or assembly
+" Progress or assembly or Swig
 au BufNewFile,BufRead *.i			call dist#ft#FTprogress_asm()
 
 " Progress or Pascal
@@ -2184,7 +2184,7 @@ au BufNewFile,BufRead *.swift.gyb		setf swiftgyb
 au BufNewFile,BufRead *.sil			call dist#ft#FTsil()
 
 " Swig
-autocmd BufNewFile,BufRead *.i,*.swg,*.swig set filetype=swig
+au BufNewFile,BufRead *.swg,*.swig set filetype=swig
 
 " Sysctl
 au BufNewFile,BufRead */etc/sysctl.conf,*/etc/sysctl.d/*.conf	setf sysctl

--- a/runtime/ftplugin/swig.vim
+++ b/runtime/ftplugin/swig.vim
@@ -1,0 +1,11 @@
+" Vim filetype plugin file
+" Language:	SWIG
+" Maintainer:	Julien Marrec <julien.marrec 'at' gmail com>
+" Last Change:	2023 November 23
+
+" Only do this when not done yet for this buffer
+if exists("b:did_ftplugin")
+  finish
+endif
+
+setlocal iskeyword+=%

--- a/runtime/ftplugin/swig.vim
+++ b/runtime/ftplugin/swig.vim
@@ -7,5 +7,7 @@
 if exists("b:did_ftplugin")
   finish
 endif
+let b:did_ftplugin = 1
 
+let b:undo_ftplugin = "setlocal iskeyword<"
 setlocal iskeyword+=%

--- a/runtime/syntax/swig.vim
+++ b/runtime/syntax/swig.vim
@@ -1,0 +1,29 @@
+" Vim syntax file
+" Language:	SWIG
+" Maintainer:	Roman Stanchak (rstanchak@yahoo.com)
+" Last Change:	2023 April 27
+
+if exists("b:current_syntax")
+	finish
+endif
+
+" Read the C++ syntax to start with
+runtime! syntax/cpp.vim
+unlet b:current_syntax
+
+" SWIG extentions
+syn keyword swigDirective %typemap %define %apply %fragment %include %enddef %extend %newobject %name
+syn keyword swigDirective %rename %ignore %keyword %typemap %define %apply %fragment %include
+syn keyword swigDirective %enddef %extend %newobject %name %rename %ignore %template %module %constant
+syn match swigDirective "%\({\|}\)"
+syn match swigUserDef "%[-_a-zA-Z0-9]\+"
+
+" Default highlighting
+command -nargs=+ HiLink hi def link <args>
+HiLink swigDirective	Exception
+HiLink swigUserDef 		PreProc
+delcommand HiLink
+
+let b:current_syntax = "swig"
+
+" vim: ts=8

--- a/runtime/syntax/swig.vim
+++ b/runtime/syntax/swig.vim
@@ -62,6 +62,7 @@ syn keyword swigDirective %std_nodefconst_type %typecheck %typemaps_string %uniq
 syn match swigVerbatimStartEnd "%[{}]"
 
 syn match swigUserDef "%[-_a-zA-Z0-9]\+"
+syn match swigVerbatimMacro "^\s*%#[-_a-zA-Z0-9]\+\%( .*\)\?$"
 
 " Default highlighting
 hi def link swigInclude Include
@@ -87,6 +88,7 @@ hi def link swigOtherLanguageSpecific Special
 hi def link swigInsertSection PreProc
 
 hi def link swigVerbatimStartEnd Statement
+hi def link swigVerbatimMacro Macro
 
 let b:current_syntax = "swig"
 " vim: ts=8

--- a/runtime/syntax/swig.vim
+++ b/runtime/syntax/swig.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language:	SWIG
 " Maintainer:	Roman Stanchak (rstanchak@yahoo.com)
-" Last Change:	2023 April 27
+" Last Change:	2023 November 23
 
 if exists("b:current_syntax")
-	finish
+  finish
 endif
 
 " Read the C++ syntax to start with
@@ -12,17 +12,34 @@ runtime! syntax/cpp.vim
 unlet b:current_syntax
 
 " SWIG extentions
-syn keyword swigDirective %typemap %define %apply %fragment %include %enddef %extend %newobject %name
-syn keyword swigDirective %rename %ignore %keyword %typemap %define %apply %fragment %include
-syn keyword swigDirective %enddef %extend %newobject %name %rename %ignore %template %module %constant
-syn match swigDirective "%\({\|}\)"
+syn keyword swigMostCommonDirective %addmethods %apply %beginfile %clear %constant %define %echo %enddef %endoffile
+syn keyword swigMostCommonDirective %extend %feature %fragment %ignore %import %importfile %include %includefile %inline
+syn keyword swigMostCommonDirective %insert %keyword %module %name %namewarn %native %newobject %parms %pragma
+syn keyword swigMostCommonDirective %rename %template %typedef %typemap %types %varargs %warn
+syn keyword swigDirective %aggregate_check %alias %allocators %allowexception %array_class %array_functions %attribute %attribute2 %attribute2ref
+syn keyword swigDirective %attribute_ref %attributeref %attributestring %attributeval %auto_ptr %bang %bar %begin %callback
+syn keyword swigDirective %catches %cdata %cleardirector %clearimmutable %contract %copyctor %csattributes %csconst %csconstvalue
+syn keyword swigDirective %csmethodmodifiers %csnothrowexception %cstring_bounded_mutable %cstring_bounded_output %cstring_chunk_output %cstring_input_binary %cstring_mutable %cstring_output_allocate %cstring_output_allocate_size
+syn keyword swigDirective %cstring_output_maxsize %cstring_output_withsize %cwstring_bounded_mutable %cwstring_bounded_output %cwstring_chunk_output %cwstring_input_binary %cwstring_mutable %cwstring_output_allocate %cwstring_output_allocate_size
+syn keyword swigDirective %cwstring_output_maxsize %cwstring_output_withsize %dconstvalue %delete_array %delobject %director %dmanifestconst %dmethodmodifiers %exception
+syn keyword swigDirective %exceptionclass %extend_smart_pointer %factory %fastdispatch %free %freefunc %go_import %header %immutable
+syn keyword swigDirective %implicit %implicitconv %init %interface %interface_custom %interface_impl %intrusive_ptr %intrusive_ptr_no_wrap %javaconst
+syn keyword swigDirective %javaconstvalue %javaexception %javamethodmodifiers %luacode %malloc %markfunc %minit %mshutdown %multiple_values
+syn keyword swigDirective %mutable %naturalvar %nocallback %nocopyctor %nodefaultctor %nodefaultdtor %nojavaexception %nonaturalvar %nonspace
+syn keyword swigDirective %nspace %pointer_cast %pointer_class %pointer_functions %predicate %proxycode %pybinoperator %pybuffer_binary %pybuffer_mutable_binary
+syn keyword swigDirective %pybuffer_mutable_string %pybuffer_string %pythonappend %pythonbegin %pythoncode %pythondynamic %pythonnondynamic %pythonprepend %raise
+syn keyword swigDirective %refobject %remane %rinit %rshutdown %runtime %scilabconst %set_output %shared_ptr %std_comp_methods
+syn keyword swigDirective %std_nodefconst_type %trackobjects %typecheck %typemaps_string %unique_ptr %unrefobject %values_as_list %values_as_vector %valuewrapper
+syn keyword swigDirective %warnfilter %wrapper
+
+syn match swigVerbatim "%\({\|}\)"
 syn match swigUserDef "%[-_a-zA-Z0-9]\+"
 
 " Default highlighting
-command -nargs=+ HiLink hi def link <args>
-HiLink swigDirective	Exception
-HiLink swigUserDef 		PreProc
-delcommand HiLink
+hi def link swigMostCommonDirective Exception
+hi def link swigDirective Exception
+hi def link swigVerbatim Exception
+hi def link swigUserDef PreProc
 
 let b:current_syntax = "swig"
 

--- a/runtime/syntax/swig.vim
+++ b/runtime/syntax/swig.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:	SWIG
-" Maintainer:	Roman Stanchak (rstanchak@yahoo.com)
+" Maintainer:	Julien Marrec <julien.marrec 'at' gmail com>
 " Last Change:	2023 November 23
 
 if exists("b:current_syntax")
@@ -12,35 +12,83 @@ runtime! syntax/cpp.vim
 unlet b:current_syntax
 
 " SWIG extentions
-syn keyword swigMostCommonDirective %addmethods %apply %beginfile %clear %constant %define %echo %enddef %endoffile
-syn keyword swigMostCommonDirective %extend %feature %fragment %ignore %import %importfile %include %includefile %inline
-syn keyword swigMostCommonDirective %insert %keyword %module %name %namewarn %native %newobject %parms %pragma
-syn keyword swigMostCommonDirective %rename %template %typedef %typemap %types %varargs %warn
-syn keyword swigDirective %aggregate_check %alias %allocators %allowexception %array_class %array_functions %attribute %attribute2 %attribute2ref
-syn keyword swigDirective %attribute_ref %attributeref %attributestring %attributeval %auto_ptr %bang %bar %begin %callback
-syn keyword swigDirective %catches %cdata %cleardirector %clearimmutable %contract %copyctor %csattributes %csconst %csconstvalue
-syn keyword swigDirective %csmethodmodifiers %csnothrowexception %cstring_bounded_mutable %cstring_bounded_output %cstring_chunk_output %cstring_input_binary %cstring_mutable %cstring_output_allocate %cstring_output_allocate_size
-syn keyword swigDirective %cstring_output_maxsize %cstring_output_withsize %cwstring_bounded_mutable %cwstring_bounded_output %cwstring_chunk_output %cwstring_input_binary %cwstring_mutable %cwstring_output_allocate %cwstring_output_allocate_size
-syn keyword swigDirective %cwstring_output_maxsize %cwstring_output_withsize %dconstvalue %delete_array %delobject %director %dmanifestconst %dmethodmodifiers %exception
-syn keyword swigDirective %exceptionclass %extend_smart_pointer %factory %fastdispatch %free %freefunc %go_import %header %immutable
-syn keyword swigDirective %implicit %implicitconv %init %interface %interface_custom %interface_impl %intrusive_ptr %intrusive_ptr_no_wrap %javaconst
-syn keyword swigDirective %javaconstvalue %javaexception %javamethodmodifiers %luacode %malloc %markfunc %minit %mshutdown %multiple_values
-syn keyword swigDirective %mutable %naturalvar %nocallback %nocopyctor %nodefaultctor %nodefaultdtor %nojavaexception %nonaturalvar %nonspace
-syn keyword swigDirective %nspace %pointer_cast %pointer_class %pointer_functions %predicate %proxycode %pybinoperator %pybuffer_binary %pybuffer_mutable_binary
-syn keyword swigDirective %pybuffer_mutable_string %pybuffer_string %pythonappend %pythonbegin %pythoncode %pythondynamic %pythonnondynamic %pythonprepend %raise
-syn keyword swigDirective %refobject %remane %rinit %rshutdown %runtime %scilabconst %set_output %shared_ptr %std_comp_methods
-syn keyword swigDirective %std_nodefconst_type %trackobjects %typecheck %typemaps_string %unique_ptr %unrefobject %values_as_list %values_as_vector %valuewrapper
-syn keyword swigDirective %warnfilter %wrapper
+syn keyword swigInclude %include %import %importfile %includefile %module
 
-syn match swigVerbatim "%\({\|}\)"
+syn keyword swigMostCommonDirective %alias %apply %beginfile %clear %constant %define %echo %enddef %endoffile
+syn keyword swigMostCommonDirective %extend %feature %director %fragment %ignore  %inline
+syn keyword swigMostCommonDirective %keyword %name %namewarn %native %newobject %parms %pragma
+syn keyword swigMostCommonDirective %rename %template %typedef %typemap %types %varargs
+
+" SWIG: Language specific macros
+syn keyword swigOtherLanguageSpecific %luacode %go_import
+
+syn keyword swigCSharp %csattributes %csconst %csconstvalue %csmethodmodifiers %csnothrowexception
+syn keyword swigCSharp %dconstvalue %dmanifestconst %dmethodmodifiers
+
+syn keyword swigJava %javaconstvalue %javaexception %javamethodmodifiers %javaconst %nojavaexception
+
+syn keyword swigGuile %multiple_values %values_as_list %values_as_vector
+
+syn keyword swigPHP %rinit %rshutdown %minit %mshutdown
+
+syn keyword swigPython %pybinoperator %pybuffer_binary %pybuffer_mutable_binary %pybuffer_mutable_string %pybuffer_string
+syn keyword swigPython %pythonappend %pythonbegin %pythoncode %pythondynamic %pythonnondynamic %pythonprepend
+
+syn keyword swigRuby %markfunc %trackobjects %bang
+syn keyword swigScilab %scilabconst
+
+" SWIG: Insertion
+syn keyword swigInsertSection %insert %begin %runtime %header %wrapper %init
+
+" SWIG: Other directives
+syn keyword swigCstring %cstring_bounded_mutable %cstring_bounded_output %cstring_chunk_output %cstring_input_binary %cstring_mutable
+syn keyword swigCstring %cstring_output_allocate %cstring_output_allocate_size %cstring_output_maxsize %cstring_output_withsize
+syn keyword swigCWstring %cwstring_bounded_mutable %cwstring_bounded_output %cwstring_chunk_output %cwstring_input_binary %cwstring_mutable
+syn keyword swigCWstring %cwstring_output_allocate %cwstring_output_allocate_size %cwstring_output_maxsize %cwstring_output_withsize
+syn keyword swigCMalloc %malloc %calloc %realloc %free %sizeof %allocators
+
+syn keyword swigExceptionHandling %catches %raise %allowexception %exceptionclass %warn %warnfilter %exception
+syn keyword swigContract %contract %aggregate_check
+
+syn keyword swigDirective %addmethods %array_class %array_functions %attribute %attribute2 %attribute2ref
+syn keyword swigDirective %attribute_ref %attributeref %attributestring %attributeval %auto_ptr %callback
+syn keyword swigDirective %delete_array %delobject %extend_smart_pointer %factory %fastdispatch %freefunc %immutable
+syn keyword swigDirective %implicit %implicitconv %interface %interface_custom %interface_impl %intrusive_ptr %intrusive_ptr_no_wrap
+syn keyword swigDirective %mutable %naturalvar %nocallback %nocopyctor %nodefaultctor %nodefaultdtor %nonaturalvar %nonspace
+syn keyword swigDirective %nspace %pointer_cast %pointer_class %pointer_functions %predicate %proxycode
+syn keyword swigDirective %refobject %set_output %shared_ptr %std_comp_methods
+syn keyword swigDirective %std_nodefconst_type %typecheck %typemaps_string %unique_ptr %unrefobject %valuewrapper
+
+syn match swigVerbatimStartEnd "%\({\|}\)"
+syn region swigVerbatim  contained start="%{" end="%}"
+
 syn match swigUserDef "%[-_a-zA-Z0-9]\+"
 
 " Default highlighting
-hi def link swigMostCommonDirective Exception
-hi def link swigDirective Exception
-hi def link swigVerbatim Exception
-hi def link swigUserDef PreProc
+hi def link swigInclude Include
+hi def link swigMostCommonDirective Structure
+hi def link swigDirective Macro
+hi def link swigContract swigExceptionHandling
+hi def link swigExceptionHandling Exception
+hi def link swigUserDef Function
+
+hi def link swigCMalloc Statement
+hi def link swigCstring Type
+hi def link swigCWstring Type
+
+hi def link swigCSharp swigOtherLanguageSpecific
+hi def link swigJava swigOtherLanguageSpecific
+hi def link swigGuile swigOtherLanguageSpecific
+hi def link swigPHP swigOtherLanguageSpecific
+hi def link swigPython swigOtherLanguageSpecific
+hi def link swigRuby swigOtherLanguageSpecific
+hi def link swigScilab swigOtherLanguageSpecific
+hi def link swigOtherLanguageSpecific Special
+
+hi def link swigInsertSection PreProc
+
+hi def link swigVerbatim Statement
+hi def link swigVerbatimStartEnd Statement
 
 let b:current_syntax = "swig"
-
 " vim: ts=8

--- a/runtime/syntax/swig.vim
+++ b/runtime/syntax/swig.vim
@@ -61,8 +61,11 @@ syn keyword swigDirective %std_nodefconst_type %typecheck %typemaps_string %uniq
 
 syn match swigVerbatimStartEnd "%[{}]"
 
-syn match swigUserDef "%[-_a-zA-Z0-9]\+"
-syn match swigVerbatimMacro "^\s*%#[-_a-zA-Z0-9]\+\%( .*\)\?$"
+syn match swigUserDef "%\w\+"
+syn match swigVerbatimMacro "^\s*%#\w\+\%( .*\)\?$"
+
+" SWIG: typemap var and typemap macros (eg: $1, $*1_type, $&n_ltype, $self)
+syn match swigTypeMapVars "\$[*&_a-zA-Z0-9]\+"
 
 " Default highlighting
 hi def link swigInclude Include
@@ -89,6 +92,8 @@ hi def link swigInsertSection PreProc
 
 hi def link swigVerbatimStartEnd Statement
 hi def link swigVerbatimMacro Macro
+
+hi def link swigTypeMapVars SpecialChar
 
 let b:current_syntax = "swig"
 " vim: ts=8

--- a/runtime/syntax/swig.vim
+++ b/runtime/syntax/swig.vim
@@ -59,8 +59,7 @@ syn keyword swigDirective %nspace %pointer_cast %pointer_class %pointer_function
 syn keyword swigDirective %refobject %set_output %shared_ptr %std_comp_methods
 syn keyword swigDirective %std_nodefconst_type %typecheck %typemaps_string %unique_ptr %unrefobject %valuewrapper
 
-syn match swigVerbatimStartEnd "%\({\|}\)"
-syn region swigVerbatim  contained start="%{" end="%}"
+syn match swigVerbatimStartEnd "%[{}]"
 
 syn match swigUserDef "%[-_a-zA-Z0-9]\+"
 
@@ -87,7 +86,6 @@ hi def link swigOtherLanguageSpecific Special
 
 hi def link swigInsertSection PreProc
 
-hi def link swigVerbatim Statement
 hi def link swigVerbatimStartEnd Statement
 
 let b:current_syntax = "swig"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -673,6 +673,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     swayconfig: ['/home/user/.sway/config', '/home/user/.config/sway/config', '/etc/sway/config', '/etc/xdg/sway/config'],
     swift: ['file.swift'],
     swiftgyb: ['file.swift.gyb'],
+    swig: ['file.swg', 'file.swig'],
     sysctl: ['/etc/sysctl.conf', '/etc/sysctl.d/file.conf', 'any/etc/sysctl.conf', 'any/etc/sysctl.d/file.conf'],
     systemd: ['any/systemd/file.automount', 'any/systemd/file.dnssd',
               'any/systemd/file.link', 'any/systemd/file.mount',
@@ -2335,6 +2336,32 @@ func Test_vba_file()
   call writefile(['" Vimball Archiver by Charles E. Campbell, Ph.D.', 'UseVimball', 'finish'], 'Xfile.vba', 'D')
   split Xfile.vba
   call assert_equal('vim', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_swig_file()
+  filetype on
+
+  " Swig
+
+  call writefile(['%module mymodule'], 'Xfile.i', 'D')
+  split Xfile.i
+  call assert_equal('swig', &filetype)
+  bwipe!
+
+  " Swig
+
+  call writefile(['%{', '#include <header.hpp>", '%}'], 'Xfile.i', 'D')
+  split Xfile.i
+  call assert_equal('swig', &filetype)
+  bwipe!
+
+  " ASM
+  call writefile(['; comment'], 'Xfile.i', 'D')
+  split Xfile.i
+  call assert_equal('asm', &filetype)
   bwipe!
 
   filetype off

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2346,20 +2346,20 @@ func Test_swig_file()
 
   " Swig
 
-  call writefile(['%module mymodule'], 'Xfile.i', 'D')
+  call writefile(['%module mymodule', '/* a comment */'], 'Xfile.i', 'D')
   split Xfile.i
   call assert_equal('swig', &filetype)
   bwipe!
 
   " Swig
 
-  call writefile(['%{', '#include <header.hpp>", '%}'], 'Xfile.i', 'D')
+  call writefile(['%{', '#include <header.hpp>', '%}'], 'Xfile.i', 'D')
   split Xfile.i
   call assert_equal('swig', &filetype)
   bwipe!
 
   " ASM
-  call writefile(['; comment'], 'Xfile.i', 'D')
+  call writefile(['; comment', ';'], 'Xfile.i', 'D')
   split Xfile.i
   call assert_equal('asm', &filetype)
   bwipe!

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2341,18 +2341,16 @@ func Test_vba_file()
   filetype off
 endfunc
 
-func Test_swig_file()
+func Test_i_file()
   filetype on
 
-  " Swig
-
+  " Swig: keyword
   call writefile(['%module mymodule', '/* a comment */'], 'Xfile.i', 'D')
   split Xfile.i
   call assert_equal('swig', &filetype)
   bwipe!
 
-  " Swig
-
+  " Swig: verbatim block
   call writefile(['%{', '#include <header.hpp>', '%}'], 'Xfile.i', 'D')
   split Xfile.i
   call assert_equal('swig', &filetype)
@@ -2362,6 +2360,12 @@ func Test_swig_file()
   call writefile(['; comment', ';'], 'Xfile.i', 'D')
   split Xfile.i
   call assert_equal('asm', &filetype)
+  bwipe!
+
+  " *.i defaults to progress
+  call writefile(['looks like progress'], 'Xfile.i', 'D')
+  split Xfile.i
+  call assert_equal('progress', &filetype)
   bwipe!
 
   filetype off


### PR DESCRIPTION
* Supersedes https://github.com/vim/vim/pull/13540 by @mcepl
* Redid the syntax file from scratch, wrote some tests, added a minimalistic ftplugin file to set the `iskeyword+=%`