### PR TITLE
Update translation makefiles after 9.0.2127

### DIFF
--- a/src/po/Make_mvc.mak
+++ b/src/po/Make_mvc.mak
@@ -526,7 +526,7 @@ update-po: $(MOFILES:.mo=)
 
 # Don't add a dependency here, we only want to update the .po files manually
 $(LANGUAGES):
-	@$(MAKE) -nologo -f Make_mvc.mak $(PACKAGE).pot GETTEXT_PATH=$(GETTEXT_PATH)
+	@$(MAKE) -nologo -f Make_mvc.mak $(PACKAGE).pot GETTEXT_PATH="$(GETTEXT_PATH)"
 	$(CP) $@.po $@.po.orig
 	$(MV) $@.po $@.po.old
 	$(MSGMERGE) $@.po.old $(PACKAGE).pot -o $@.po

--- a/src/po/Make_mvc.mak
+++ b/src/po/Make_mvc.mak
@@ -43,9 +43,9 @@ ICONV="$(GETTEXT_PATH)\iconv.exe"
 # If the "touch" program is installed on the system, but it is not registered
 # in the %PATH% environment variable, then specify the full path to this file.
 !IF EXIST ("touch.exe")
-TOUCH = touch.exe $@
+TOUCH_TARGET = touch.exe $@
 !ELSE
-TOUCH = @if exist $@ ( copy /b $@+,, ) else ( type nul >$@ )
+TOUCH_TARGET = @if exist $@ ( copy /b $@+,, ) else ( type nul >$@ )
 !ENDIF
 
 MV = move /y
@@ -66,7 +66,7 @@ all: $(MOFILES) $(MOCONVERTED)
 .po.ck:
 	$(VIM) -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" -S check.vim \
 		-c "if error == 0 | q | else | num 2 | cq | endif" $<
-	$(TOUCH)
+	$(TOUCH_TARGET)
 
 check: $(CHECKFILES)
 

--- a/src/po/Make_mvc.mak
+++ b/src/po/Make_mvc.mak
@@ -18,10 +18,11 @@ VIMRUNTIME = ..\..\runtime
 !ENDIF
 
 PACKAGE = vim
-# Correct the following line for the where executeable file vim is installed
+# Correct the following line for the where executeable file vim is installed.
 VIM = ..\vim
 
-# Correct the following line for the directory where gettext et al is installed
+# Correct the following line for the directory where gettext et al is
+# installed.  Please do not put the path in quotes.
 GETTEXT_PATH = D:\Programs\GetText\bin
 
 MSGFMT = "$(GETTEXT_PATH)\msgfmt" -v
@@ -543,7 +544,7 @@ install-all: all
 		$(VIMRUNTIME)\lang\%%l\LC_MESSAGES\$(PACKAGE).mo
 
 cleanup-po: checklanguage $(LANGUAGE).po
-	$(VIM) -u NONE -e -X -S cleanup.vim -c wq $**
+	$(VIM) -u NONE -e -X -S cleanup.vim -c wq $(LANGUAGE).po
 
 cleanup-po-all: $(POFILES)
 	!$(VIM) -u NONE -e -X -S cleanup.vim -c wq $**

--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -32,7 +32,8 @@ MSGMERGE = OLD_PO_FILE_INPUT=yes OLD_PO_FILE_OUTPUT=yes msgmerge
 	$(MSGFMTCMD) -o $@ $<
 
 .po.ck:
-	$(VIM) -u NONE -e -X -S check.vim -c "if error == 0 | q | endif" -c cq $<
+	$(VIM) -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" -S check.vim \
+		-c "if error == 0 | q | else | num 2 | cq | endif" $<
 	touch $@
 
 all: $(MOFILES) $(MOCONVERTED) $(MSGFMT_DESKTOP)


### PR DESCRIPTION
* Change how to check `%LANGUAGE%`.
  Check it only when needed.
* Add double quotes to where `GETTEXT_PATH` is used.
  Before 9.0.2127, this worked: `nmake -f Make_mvc.mak GETTEXT_PATH="\"C:\Program Files\Git\usr\bin\""` (which was a bit tricky.)
  9.0.2127 broke this and a syntax error occurred.
  This doesn't work either in 9.0.2127: `nmake -f Make_mvc.mak GETTEXT_PATH="C:\Program Files\Git\usr\bin"`
  With this PR, this works: `nmake -f Make_mvc.mak GETTEXT_PATH="C:\Program Files\Git\usr\bin"`
* Better error report for the `check` target.
  Show the line number of the error. (Imported from vim-jp/lang-ja.)