### PR TITLE
Duplicate Error Message for Netbeans Interface

### DIFF
--- a/runtime/doc/netbeans.txt
+++ b/runtime/doc/netbeans.txt
@@ -1,4 +1,4 @@
-*netbeans.txt*  For Vim version 9.0.  Last change: 2022 Apr 03
+*netbeans.txt*  For Vim version 9.0.  Last change: 2023 Nov 26
 
 
 		  VIM REFERENCE MANUAL    by Gordon Prieur et al.
@@ -846,7 +846,7 @@ REJECT		Not used.
 These errors occur when a message violates the protocol:
 *E627* *E628* *E629* *E632* *E633* *E634* *E635* *E636*
 *E637* *E638* *E639* *E640* *E641* *E642* *E643* *E644* *E645* *E646*
-*E647* *E648* *E649* *E650* *E651* *E652*
+*E647* *E648* *E650* *E651* *E652*
 
 
 ==============================================================================

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5047,7 +5047,6 @@ E645	netbeans.txt	/*E645*
 E646	netbeans.txt	/*E646*
 E647	netbeans.txt	/*E647*
 E648	netbeans.txt	/*E648*
-E649	netbeans.txt	/*E649*
 E65	pattern.txt	/*E65*
 E650	netbeans.txt	/*E650*
 E651	netbeans.txt	/*E651*

--- a/src/errors.h
+++ b/src/errors.h
@@ -1658,8 +1658,7 @@ EXTERN char e_invalid_buffer_identifier_in_setdot[]
 	INIT(= N_("E647: Invalid buffer identifier in setDot"));
 EXTERN char e_invalid_buffer_identifier_in_close[]
 	INIT(= N_("E648: Invalid buffer identifier in close"));
-EXTERN char e_invalid_buffer_identifier_in_close_2[]
-	INIT(= N_("E649: Invalid buffer identifier in close"));
+// E649 unused
 EXTERN char e_invalid_buffer_identifier_in_defineannotype[]
 	INIT(= N_("E650: Invalid buffer identifier in defineAnnoType"));
 EXTERN char e_invalid_buffer_identifier_in_addanno[]

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -1875,7 +1875,7 @@ nb_do_cmd(
 		// This message was commented out, probably because it can
 		// happen when shutting down.
 		if (p_verbose > 0)
-		    emsg(_(e_invalid_buffer_identifier_in_close_2));
+		    emsg(_(e_invalid_buffer_identifier_in_close));
 	    }
 	    nbdebug(("    CLOSE %d: %s\n", bufno, name));
 #ifdef FEAT_GUI


### PR DESCRIPTION
We have 2 error Messages used for the Netbeans interface:

- EXTERN char e_invalid_buffer_identifier_in_close[] INIT(= N_("E648: Invalid buffer identifier in close"));
- EXTERN char e_invalid_buffer_identifier_in_close_2[] INIT(= N_("E649: Invalid buffer identifier in close"));

Since the error message is exactly the same, get rid of the  second message.