### PR TITLE
Make nu filetype use a general glob pattern

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1460,7 +1460,7 @@ au BufNewFile,BufRead *.nse			setf lua
 au BufNewFile,BufRead *.nsi,*.nsh		setf nsis
 
 " Nu
-au BufNewFile,BufRead {env,config}.nu		setf nu
+au BufNewFile,BufRead *.nu		setf nu
 
 " Oblivion Language and Oblivion Script Extender
 au BufNewFile,BufRead *.obl,*.obse,*.oblivion,*.obscript  setf obse

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -494,7 +494,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     nqc: ['file.nqc'],
     nroff: ['file.tr', 'file.nr', 'file.roff', 'file.tmac', 'file.mom', 'tmac.file'],
     nsis: ['file.nsi', 'file.nsh'],
-    nu: ['env.nu', 'config.nu'],
+    nu: ['file.nu'],
     obj: ['file.obj'],
     objdump: ['file.objdump', 'file.cppobjdump'],
     obse: ['file.obl', 'file.obse', 'file.oblivion', 'file.obscript'],


### PR DESCRIPTION
Nushell scripting is more than {env,config}.nu

See for instance here: https://github.com/neovim/nvim-lspconfig/pull/2900