### PR TITLE
parse error type and column number in MSVC errorformat

### DIFF
--- a/src/option.h
+++ b/src/option.h
@@ -87,7 +87,7 @@ typedef enum {
 # define DFLT_EFM	"%f>%l:%c:%t:%n:%m,%f:%l: %t%*\\D%n: %m,%f %l %t%*\\D%n: %m,%*[^\"]\"%f\"%*\\D%l: %m,%f:%l:%m,%f|%l| %m"
 #else
 # if defined(MSWIN)
-#  define DFLT_EFM	"%f(%l) \\=: %t%*\\D%n: %m,%*[^\"]\"%f\"%*\\D%l: %m,%f(%l) \\=: %m,%*[^ ] %f %l: %m,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,%f|%l| %m"
+#  define DFLT_EFM	"%f(%l): %t%*\\D%n: %m,%f(%l\\,%c): %t%*\\D%n: %m,%f(%l) \\=: %t%*\\D%n: %m,%*[^\"]\"%f\"%*\\D%l: %m,%f(%l) \\=: %m,%*[^ ] %f %l: %m,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,%f|%l| %m"
 # else
 #  if defined(__QNX__)
 #   define DFLT_EFM	"%f(%l):%*[^WE]%t%*\\D%n:%m,%f|%l| %m"


### PR DESCRIPTION
Using the latest MSVC, error messages are of the form:
`file_path(line number): error type: error message`
Moreover, it is common (and useful) to enable column numbers with the flag `-diagnostics:column`. This makes error messages of the form:
`file_path(line number,column number): error type: error message`

I don't recognize the format used in most of the provided formats in [src/option.h](https://github.com/vim/vim/blob/cf40409e7d17ddadaa697188788753c761479ef8/src/option.h#L90C11-L90C11) (possibly old MSVC versions?). It seems like with the modern syntax, it falls back to matching with `%f(%l):%m`. This works, but it doesn't match with error type, and it doesn't support column numbers. In fact, none of the provided errorformats for MSVC match column numbers so if you enable them with the aforementioned flag, it completely breaks the quickfix list because no match is found.