### PR TITLE
Add vimlong_T; used to detect int overflow.

### DIFF
--- a/src/cindent.c
+++ b/src/cindent.c
@@ -1730,7 +1730,7 @@ parse_cino(buf_T *buf)
     char_u	*p;
     char_u	*l;
     char_u	*digits;
-    long long	n;
+    vimlong_T	n;
     int		divider;
     int		fraction = 0;
     int		sw;
@@ -1902,7 +1902,7 @@ parse_cino(buf_T *buf)
 	    {
 		n *= sw;
 		if (divider)
-		    n += ((long long)sw * fraction + divider / 2) / divider;
+		    n += ((vimlong_T)sw * fraction + divider / 2) / divider;
 	    }
 	    ++p;
 	}

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2843,7 +2843,7 @@ vim_append_digit_long(long *value, int digit)
 
 // Return something that fits into an int.
     int
-trim_to_int(long long x)
+trim_to_int(vimlong_T x)
 {
     return x > INT_MAX ? INT_MAX : x < INT_MIN ? INT_MIN : x;
 }

--- a/src/ops.c
+++ b/src/ops.c
@@ -229,11 +229,11 @@ shift_line(
     int	amount,
     int call_changed_bytes)	// call changed_bytes()
 {
-    long long	count;
+    vimlong_T	count;
     int		i, j;
     int		sw_val = trim_to_int(get_sw_value_indent(curbuf));
 
-    count = (long long)get_indent();	// get current indent
+    count = get_indent();	// get current indent
 
     if (round)			// round off indent
     {
@@ -249,18 +249,18 @@ shift_line(
 	}
 	else
 	    i += amount;
-	count = (long long)i * (long long)sw_val;
+	count = (vimlong_T)i * (vimlong_T)sw_val;
     }
     else		// original vi indent
     {
 	if (left)
 	{
-	    count -= (long long)sw_val * (long long)amount;
+	    count -= (vimlong_T)sw_val * (vimlong_T)amount;
 	    if (count < 0)
 		count = 0;
 	}
 	else
-	    count += (long long)sw_val * (long long)amount;
+	    count += (vimlong_T)sw_val * (vimlong_T)amount;
     }
 
     // Set new indent

--- a/src/proto/misc1.pro
+++ b/src/proto/misc1.pro
@@ -55,5 +55,5 @@ void restore_v_event(dict_T *v_event, save_v_event_T *sve);
 void may_trigger_modechanged(void);
 int vim_append_digit_int(int *value, int digit);
 int vim_append_digit_long(long *value, int digit);
-int trim_to_int(long long x);
+int trim_to_int(vimlong_T x);
 /* vim: set ft=c : */

--- a/src/vim.h
+++ b/src/vim.h
@@ -435,6 +435,12 @@ typedef unsigned short sattr_T;
  */
 typedef unsigned int u8char_T;	// int is 32 bits or more
 
+/*
+ * The vimlong_T has sizeof(vimlong_T) >= 2 * sizeof(int).
+ * One use is simple handling of overflow in int calculations.
+ */
+typedef long long vimlong_T;
+
 #ifndef UNIX		    // For Unix this is included in os_unix.h
 # include <stdio.h>
 # include <ctype.h>


### PR DESCRIPTION
Assumption is `sizeof(overflow_T) >= 2 * sizeof(int)`. This makes `overflow_T` suitable for detecting `int` overflow with simple comparisons and makes it easy to find locations with this kind of overflow checking.

@k-takata @chrisbra  I'm not sure of the best name or where in the code to put it; please advise. (or if it is even wanted).

A side effect is that it is easier for unsupported and/or older build systems to create `vim` binaries without changing `.c` files.