### PR TITLE
Include several missing files in Filelist for packaging/distribution

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -757,6 +757,17 @@ RT_ALL =	\
 		runtime/pack/dist/opt/dvorak/dvorak/enable.vim \
 		runtime/pack/dist/opt/dvorak/dvorak/disable.vim \
 		runtime/pack/dist/opt/editexisting/plugin/editexisting.vim \
+		runtime/pack/dist/opt/editorconfig/.editorconfig \
+		runtime/pack/dist/opt/editorconfig/CONTRIBUTORS \
+		runtime/pack/dist/opt/editorconfig/LICENSE* \
+		runtime/pack/dist/opt/editorconfig/mkzip.sh \
+		runtime/pack/dist/opt/editorconfig/README.md \
+		runtime/pack/dist/opt/editorconfig/autoload/*.vim \
+		runtime/pack/dist/opt/editorconfig/autoload/editorconfig_core/*.vim \
+		runtime/pack/dist/opt/editorconfig/doc/tags \
+		runtime/pack/dist/opt/editorconfig/doc/editorconfig.txt \
+		runtime/pack/dist/opt/editorconfig/ftdetect/editorconfig.vim \
+		runtime/pack/dist/opt/editorconfig/plugin/editorconfig.vim \
 		runtime/pack/dist/opt/justify/plugin/justify.vim \
 		runtime/pack/dist/opt/matchit/plugin/matchit.vim \
 		runtime/pack/dist/opt/matchit/doc/matchit.txt \
@@ -782,7 +793,9 @@ RT_SCRIPTS =	\
 		runtime/makemenu.vim \
 		runtime/autoload/*.vim \
 		runtime/autoload/README.txt \
+		runtime/autoload/cargo/*.vim \
 		runtime/autoload/dist/*.vim \
+		runtime/autoload/rust/*.vim \
 		runtime/autoload/xml/*.vim \
 		runtime/autoload/zig/*.vim \
 		runtime/colors/*.vim \
@@ -955,6 +968,7 @@ IN_README_DIR = \
 		README_bindos.txt \
 		README_dos.txt \
 		README_extra.txt \
+		README_haiku.txt \
 		README_mac.txt \
 		README_ole.txt \
 		README_os2.txt \


### PR DESCRIPTION
Files need to be listed in `Filelist` (which is included into the Makefile) in order to be included in the tar archive.  Fedora (at least) uses the archive from `make unixall` so anything not listed there will be excluded from their package.  See PR #13551 for a recent case; this is part of the follow-up.

This is part of a two-patch series: see PR #13601 which adds a CI job to check for such overlooked files.

These files were discovered to be missing from Filelist, and thus distribution tarballs:
- editorconfig plugin
- extra files for Rust support
- readme for Haiku OS builds

It seems like all of them ought to be included, but I don't know whether they might have been excluded deliberately.  Ping @gpanders for editorconfig, @lilyball for Rust/Cargo, and @bitigchi for Haiku.

Incidentally, the SRC_HAIKU variable actually appears to be unused in makefiles... Is it actually used for building on Haiku?