### PR TITLE
CI: check that all files are listed in Filelist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,12 @@ jobs:
       - name: Checkout repository from github
         uses: actions/checkout@v4
 
+      - name: Check Filelist (for packaging)
+        run: |
+          # If any files in the repository are not listed in Filelist this will
+          # exit with an error code and list the missing entries.
+          make -f ci/unlisted.make
+
       - run: sudo dpkg --add-architecture i386
         if: matrix.architecture == 'i386'
 

--- a/Filelist
+++ b/Filelist
@@ -213,6 +213,7 @@ SRC_ALL =	\
 		src/testdir/dumps/*.dump \
 		src/testdir/dumps/*.vim \
 		src/testdir/samples/*.txt \
+		src/testdir/samples/*.vim \
 		src/testdir/samples/test000 \
 		src/testdir/color_ramp.vim \
 		src/testdir/silent.wav \
@@ -1073,5 +1074,18 @@ LANG_SRC = \
 LANG_DOS = \
 		src/po/*.mo \
 		runtime/lang/Make_mvc.mak \
+
+# Files in the repository that are deliberately not listed above, and will thus
+# be excluded from distribution tarballs and the like.
+# This excludes them from the CI check for unlisted files.
+IGNORE = \
+		.appveyor.yml \
+		.github/FUNDING.yml \
+		.github/labeler.yml \
+		.github/workflows/label.yml \
+		SECURITY.md \
+		ci/unlisted.make \
+		src/libvterm/CODE-MAP \
+		runtime/syntax/testdir/input/html_html \
 
 # vim: set ft=make:

--- a/ci/unlisted.make
+++ b/ci/unlisted.make
@@ -1,0 +1,49 @@
+# vim: ft=make
+SHELL = /bin/bash
+
+# List all files that are tracked in git but not listed in Filelist.
+# Exit code is 2 ("Make encountered an error") if any such files exist.
+
+# Filelist is a Makefile that defines many variables, so we use Make itself to
+# query which variables it defines, then expand them all by wrapping each name
+# in $(...), importing Filelist and using $(eval).
+
+include Filelist
+$(eval all_patterns := $(shell \
+	make -f Filelist --question --print-data-base --no-builtin-rules \
+		--no-builtin-variables 2>/dev/null \
+	| sed -nre \
+		'/^# makefile .from \x27Filelist\x27,/ { \
+			n; \
+			s/ = .*//; \
+			T; \
+			s/.*/$$(\0)/; \
+			p; \
+		}'))
+
+# In Makefile's `prepeare` target, all the IN_README_DIR files are moved from
+# READMEdir to the root, so add those files in their Git-tracked location:
+all_patterns := $(all_patterns) \
+	$(foreach readme, $(IN_README_DIR), READMEdir/$(readme))
+
+# The result 'all_patterns' is a list of patterns (globs), which we expand with
+# wildcard to get actual filenames.  Note this means Filelist can list a file
+# that does not exist, and it will be omitted at this step.
+listed_files := $(wildcard $(all_patterns))
+
+# Default target to actually run the comparison:
+.PHONY: check
+check:
+	@# There are too many files to list on the command line, so we write
+	@# that to a temporary file, one per line.
+	$(file > Filelist-listed-files)
+	$(foreach filename, $(listed_files),\
+		$(file >> Filelist-listed-files,$(filename)))
+	@# Compare the sorted lists.  Delete that temporary file on both
+	@# success and failure, but exit with diff's exit code.
+	diff -u0 --label files-in-git <(git ls-files | sort) \
+		--label Filelist <(sort --unique Filelist-listed-files); \
+	RV=$$?; \
+	rm Filelist-listed-files; \
+	(($$RV != 0)) && echo "Add files to the right variable in Filelist."; \
+	exit $$RV


### PR DESCRIPTION
Following up on my comment in PR #13551, this adds a CI job to check whether any files in the repository are not listed in `Filelist`.

When files are not in `Filelist`, they will not be included in the tar archive used by distributions (at least Fedora) to build their packages.  (PR #13551 is one case where important files were excluded by accident.)  Filelist is included into the Makefile, and it lists source files in variables for the various build types, so we cannot generate it or add to it automatically (we would not know under which variable new files should go).  Thus we should alert the developer that they forgot a step when adding a file.

The few files in the repository that do not belong in any build or archive are added to a new `IGNORE` variable, which is not used elsewhere in the Makefile but passes this test's requirement that the files be added to a variable.

Note, I've tested the Make script, but I don't know what I'm doing with ci.yml, and I don't know how to test whether it works with GitHub.

This is part of a two-patch series; the first part adds other runtime files that should be listed in Filelist: PR #13600

## Aside about the code history:

The main tricky part is that Filelist is a list of globs, not always literal filenames.

This is the third version of this script I have written.  The first, included in my [comment on PR 13551](https://github.com/vim/vim/pull/13551#issuecomment-1821574495), is in Bash and is quadratic.  It takes about 11 seconds to run on my laptop.

I rewrote it in Python using fnmatch and just building up a big regex, also just parsing Filelist the quick and dirty way as in the shell version.  It's about 100 times faster.  Here is the code:

<details><summary>unlisted.py</summary>

```python
#!/usr/bin/env python3

# List all files that are tracked in git but not listed in Filelist.
# Exit code is 5 when any such files exist.

import fnmatch
import re
import subprocess
import sys

# Key incompatibilites with Make:
# This allows wildcards to match "/" anywhere and initial "." (and "."
# following "/"), which Make does not.  Also Make expands ~ and ~name which
# this does not.  Currently none of these incompatibilities are used in Vim's
# makefile.

def main():
    files = (subprocess.run(['git', 'ls-files', '-z'],
                           check=True, capture_output=True, text=True)
        .stdout
        .split('\0')
        [:-1])
    # The last element is dropped because it is always blank.  (Git uses \0 as
    # a terminator, not a separator.)

    patterns = []
    with open('Filelist') as f:
        for line in f:
            if m := re.match(r'\t*(.*) \\', line):
                patterns.append(m.group(1))

    unmatched = filter_out(files, patterns)
    for u in unmatched:
        print(u)
    if len(unmatched) > 0:
        sys.exit(5)

def filter_out(names: list[str], glob_patterns: list[str]):
    '''Return a list of the names that do not match any glob_pattern'''
    re_pat = "|".join(fnmatch.translate(g_pat) for g_pat in glob_patterns)
    re_pat = re.compile(re_pat)

    return [name for name in names if not re_pat.fullmatch(name)]

if __name__ == '__main__':
    main()
```

</details> 

I didn't want to introduce a new dependency, though, and parsing Filelist "manually" seems fragile.

So that brings us to the current Make-based version.  By using Make, we can parse Filelist correctly and robustly and it's easy to add special handling for the `IN_README_DIR` variable.  This version runs slightly faster than the Python version.
