### PR TITLE
Fix wrong scrolling in Insert mode with 'smoothscroll'

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -501,9 +501,12 @@ edit(
 	 * something.
 	 * Don't do this when the topline changed already, it has
 	 * already been adjusted (by insertchar() calling open_line())).
+	 * Also don't do this when 'smoothscroll' is set, as the window should
+	 * then be scrolled by screen lines.
 	 */
 	if (curbuf->b_mod_set
 		&& curwin->w_p_wrap
+		&& !curwin->w_p_sms
 		&& !did_backspace
 		&& curwin->w_topline == old_topline
 #ifdef FEAT_DIFF

--- a/src/testdir/dumps/Test_smoothscroll_insert_bottom.dump
+++ b/src/testdir/dumps/Test_smoothscroll_insert_bottom.dump
@@ -1,0 +1,9 @@
+|<+0#4040ff13#ffffff0@2|e+0#0000000&|r|y| |l|o|n|g| |l|i|n|e| |.@2|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2
+|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2
+|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2
+|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2
+|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2
+|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2|A| |v|e|r|y| |l|o|n|g| |l|i|n|e| |.@2
+|1|2|3|4|5|6|7|8|9| @30
+> @39
+@40

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -920,7 +920,7 @@ func Test_smoothscroll_cursor_top()
       exe "norm G3\<C-E>k"
   END
   call writefile(lines, 'XSmoothScrollCursorTop', 'D')
-  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCursorTop', #{rows: 12, cols:40})
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCursorTop', #{rows: 12, cols: 40})
   call VerifyScreenDump(buf, 'Test_smoothscroll_cursor_top', {})
 
   call StopVimInTerminal(buf)
@@ -939,8 +939,23 @@ func Test_smoothscroll_crash()
       exe "norm! 0\<c-e>"
   END
   call writefile(lines, 'XSmoothScrollCrash', 'D')
-  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCrash', #{rows: 12, cols:40})
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCrash', #{rows: 12, cols: 40})
   call term_sendkeys(buf, "2\<C-E>\<C-L>")
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_smoothscroll_insert_bottom()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, repeat([repeat('A very long line ...', 10)], 5))
+    set wrap smoothscroll scrolloff=0
+  END
+  call writefile(lines, 'XSmoothScrollInsertBottom', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollInsertBottom', #{rows: 9, cols: 40})
+  call term_sendkeys(buf, "Go123456789\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_insert_bottom', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
Problem:  Wrong scrolling in Insert mode with 'smoothscroll' at the
          bottom of the window.
Solution: Don't use set_topline() when 'smoothscroll' is set.

Fix #13612
