### PR TITLE
Error when joining lines with text properties without a proper type

### DIFF
--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -4373,4 +4373,19 @@ func Test_virtual_text_get()
   bwipe!
 endfunc
 
+" This used to throw: E967
+func Test_textprop_notype_join()
+  new Xtextprop_no_type_join
+  call setline(1, range(1, 3))
+  call cursor(1, 1)
+  let name = 'a'
+  call prop_type_add(name, {})
+  call prop_add(line('.'), col('.'), { 'type': name })
+  call prop_type_delete(name, {})
+  join
+  call assert_equal(["1 2", "3"], getline(1, '$'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -630,7 +630,7 @@ get_text_props(buf_T *buf, linenr_T lnum, char_u **props, int will_change)
     size_t textlen;
     size_t proplen;
 
-    // Be quick when no text property types have been defined or the buffer,
+    // Be quick when no text property types have been defined for the buffer,
     // unless we are adding one.
     if ((!buf->b_has_textprop && !will_change) || buf->b_ml.ml_mfp == NULL)
 	return 0;
@@ -714,8 +714,7 @@ count_props(linenr_T lnum, int only_starting, int last_line)
 	// previous line, or when not in the last line and it is virtual text
 	// after the line.
 	if ((only_starting && (prop.tp_flags & TP_FLAG_CONT_PREV))
-		|| (!last_line && prop.tp_col == MAXCOL)
-		|| !text_prop_type_valid(curbuf, &prop))
+		|| (!last_line && prop.tp_col == MAXCOL))
 	    --result;
     }
     return result;


### PR DESCRIPTION
When joining lines, we need to consider all text properties that are attached to a line, even when those text properties are invalid and do not have a type attached to them.

However, since patch v9.0.0993
(commit: 89469d157aea01513bde826b4519dd6b5fbceae4) those text properties won't be counted when joining lines and therefore this will cause the adjustment for text properties on joining to go wrong (and may later cause SIGABRT with an invalid free pointer)

I am not sure, why the condition to not count text properties with a valid type was added in patch v9.0.993, because no test fails if those condition is removed. So let's just remove this condition and add a test that verifies, that we are able to join lines, even when the text properties attached to it do not have a valid type.

fixes: #13609