### PR TITLE
runtime: add pacman.log syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -450,6 +450,7 @@ runtime/syntax/nix.vim			@equill
 runtime/syntax/nroff.vim		@jmarshall
 runtime/syntax/nsis.vim			@k-takata
 runtime/syntax/openvpn.vim		@ObserverOfTime
+runtime/syntax/pacmanlog.vim		@rpigott
 runtime/syntax/pascal.vim		@dkearns
 runtime/syntax/pbtxt.vim		@lakshayg
 runtime/syntax/pdf.vim			@tpope

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1521,6 +1521,9 @@ au BufNewFile,BufRead *.hook
 	\   setf confini |
 	\ endif
 
+" Pacman log
+au BufNewFile,BufRead pacman.log			setf pacmanlog
+
 " Pam conf
 au BufNewFile,BufRead */etc/pam.conf			setf pamconf
 

--- a/runtime/syntax/pacmanlog.vim
+++ b/runtime/syntax/pacmanlog.vim
@@ -1,0 +1,41 @@
+" Vim syntax file
+" Language: pacman.log
+" Maintainer: Ronan Pigott <ronan@rjp.ie>
+" Last Change: 2023 Dec 04
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn sync maxlines=1
+syn region pacmanlogMsg start='\S' end='$' keepend contains=pacmanlogTransaction,pacmanlogALPMMsg
+syn region pacmanlogTag start='\['hs=s+1 end='\]'he=e-1 keepend nextgroup=pacmanlogMsg
+syn region pacmanlogTime start='^\['hs=s+1 end='\]'he=e-1 keepend nextgroup=pacmanlogTag
+
+syn match pacmanlogPackageName '\v[a-z0-9@_+.-]+' contained skipwhite nextgroup=pacmanlogPackageVersion
+syn match pacmanlogPackageVersion '(.*)' contained
+
+syn match pacmanlogTransaction 'transaction \v(started|completed)$' contained
+syn match pacmanlogInstalled   '\v(re)?installed' contained nextgroup=pacmanlogPackageName
+syn match pacmanlogUpgraded    'upgraded'         contained nextgroup=pacmanlogPackageName
+syn match pacmanlogDowngraded  'downgraded'       contained nextgroup=pacmanlogPackageName
+syn match pacmanlogRemoved     'removed'          contained nextgroup=pacmanlogPackageName
+syn match pacmanlogWarning     'warning:.*$'      contained
+
+syn region pacmanlogALPMMsg start='\v(\[ALPM\] )@<=(transaction|(re)?installed|upgraded|downgraded|removed|warning)>' end='$' contained
+	\ contains=pacmanlogTransaction,pacmanlogInstalled,pacmanlogUpgraded,pacmanlogDowngraded,pacmanlogRemoved,pacmanlogWarning,pacmanlogPackageName,pacmanlogPackgeVersion
+
+hi def link pacmanlogTime String
+hi def link pacmanlogTag  Type
+
+hi def link pacmanlogTransaction Special
+hi def link pacmanlogInstalled   Identifier
+hi def link pacmanlogRemoved     Repeat
+hi def link pacmanlogUpgraded    pacmanlogInstalled
+hi def link pacmanlogDowngraded  pacmanlogRemoved
+hi def link pacmanlogWarning     WarningMsg
+
+hi def link pacmanlogPackageName    Normal
+hi def link pacmanlogPackageVersion Comment
+
+let b:current_syntax = "pacmanlog"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -511,6 +511,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     opl: ['file.OPL', 'file.OPl', 'file.OpL', 'file.Opl', 'file.oPL', 'file.oPl', 'file.opL', 'file.opl'],
     ora: ['file.ora'],
     org: ['file.org', 'file.org_archive'],
+    pacmanlog: ['pacman.log'],
     pamconf: ['/etc/pam.conf', '/etc/pam.d/file', 'any/etc/pam.conf', 'any/etc/pam.d/file'],
     pamenv: ['/etc/security/pam_env.conf', '/home/user/.pam_environment', '.pam_environment', 'pam_env.conf'],
     papp: ['file.papp', 'file.pxml', 'file.pxsl'],


### PR DESCRIPTION
pacman.log is a filetype common to Arch Linux and related distributions.

pacman.log records every pacman operation performed on a machine. It's a single line format that is simply 

> `[<TIMESTAMP>] [<CALLER>] <MSG>`

My goal with this syntax is to highlight the log messages that installed or removed packages differently, and to delineate each pacman transaction more clearly in the log, to improve legibility. I tried to choose sensible defaults for the highlight groups, otherwise whatever looked good to me.

I haven't created any vim syntax definitions before this one, so there may be oddities or errors. PTAL.