### PR TITLE
Docs: non-existent parameter in command

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -516,7 +516,7 @@ SHIFTING LINES LEFT OR RIGHT				*shift-left-right*
 			lines to [indent] (default 0).
 
 							*:>*
-:[range]> [flags]	Shift {count} [range] lines one 'shiftwidth' right.
+:[range]> [flags]	Shift [range] lines one 'shiftwidth' right.
 			Repeat '>' for shifting multiple 'shiftwidth's.
 			See |ex-flags| for [flags].
 


### PR DESCRIPTION
The variant with the `{count}` parameter is explained in the next item.