### PR TITLE
runtime(doc): link cmdline completion to to |wildcards|

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1,4 +1,4 @@
-*cmdline.txt*   For Vim version 9.0.  Last change: 2023 Nov 15
+*cmdline.txt*   For Vim version 9.0.  Last change: 2023 Dec 09
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -463,9 +463,8 @@ CTRL-T		When 'incsearch' is set, entering a search pattern for "/" or
 		keyboard T is above G.
 
 The 'wildchar' option defaults to <Tab> (CTRL-E when in Vi compatible mode; in
-a previous version <Esc> was used).  In the pattern standard wildcards '*' and
-'?' are accepted when matching file names.  '*' matches any string, '?'
-matches exactly one character.
+a previous version <Esc> was used).  In the pattern standard |wildcards| are
+accepted when matching file names.
 
 When repeating 'wildchar' or CTRL-N you cycle through the matches, eventually
 ending up back to what was typed.  If the first match is not what you wanted,

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 9.0.  Last change: 2023 Dec 7
+*eval.txt*	For Vim version 9.0.  Last change: 2023 Dec 09
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -4828,7 +4828,7 @@ have Vim execute random executables or may have forbidden to do so for
 specific filetypes by setting the "<filetype>_exec" variable (|plugin_exec|).
 
 It returns |true| or |false| to indicate whether the plugin should run the given
-exectuable.  It takes the following arguments:
+executable.  It takes the following arguments:
 
 	argument	type ~
 

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -1,4 +1,4 @@
-*indent.txt*    For Vim version 9.0.  Last change: 2023 Dec 05
+*indent.txt*    For Vim version 9.0.  Last change: 2023 Dec 09
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -718,7 +718,7 @@ subroutines, functions, modules, and program blocks is optional.  Comments,
 labeled statements, and continuation lines are indented if the Fortran is in
 free source form, whereas they are not indented if the Fortran is in fixed
 source form because of the left margin requirements.  Hence manual indent
-corrections will be necessary for labelled statements and continuation lines
+corrections will be necessary for labeled statements and continuation lines
 when fixed source form is being used.  For further discussion of the method
 used for the detection of source format see |ft-fortran-syntax|.
 

--- a/runtime/doc/os_vms.txt
+++ b/runtime/doc/os_vms.txt
@@ -1,4 +1,4 @@
-*os_vms.txt*    For Vim version 9.0.  Last change: 2022 Nov 25
+*os_vms.txt*    For Vim version 9.0.  Last change: 2023 Dec 09
 
 
 		  VIM REFERENCE MANUAL
@@ -767,7 +767,7 @@ GNU_TOOLS.ZIP package downloadable from http://www.polarhome.com/vim/
 
 Version 9.0 (2023 Nov 27)
 - Vim is ported to the X86_64 architecture
-	- IMPORTANT: because of the getline function name used in stucts like in ex_cmds.h
+	- IMPORTANT: because of the getline function name used in structs like in ex_cmds.h
 	on X86_64 the CRTL_VER is kept under 80500000 level. The proper solution would be
 	to rename the getline function to something else in the struct (and in all places
 	it is used) - and avoiding to use POSIX functions in structs, but this change would

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.0.  Last change: 2023 Dec 05
+*syntax.txt*	For Vim version 9.0.  Last change: 2023 Dec 09
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1643,7 +1643,7 @@ script allows a maximum line length of 80 characters as do all compilers
 created in the last three decades.  An even longer line length of 132
 characters is allowed if you set the variable fortran_extended_line_length
 with a command such as >
-    :let fortran_line_length=1
+    :let fortran_extended_line_length=1
 placed prior to the :syntax on command.
 
 If you want additional highlighting of the CUDA Fortran extensions, you should

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -1,4 +1,4 @@
-*term.txt*      For Vim version 9.0.  Last change: 2023 Nov 20
+*term.txt*      For Vim version 9.0.  Last change: 2023 Dec 09
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -313,7 +313,7 @@ convert all key sequences to their 8-bit variants.
 
 						*xterm-terminfo-entries*
 For some time the terminfo entries were insufficient to describe all the
-features tht Vim can use.  The builtin xterm termcap entries did have these,
+features that Vim can use.  The builtin xterm termcap entries did have these,
 with the result that several terminals that were similar enough to xterm took
 advantage of these by prefixing "xterm-" to the terminal name in $TERM.
 

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1,4 +1,4 @@
-*vim9.txt*	For Vim version 9.0.  Last change: 2023 Oct 23
+*vim9.txt*	For Vim version 9.0.  Last change: 2023 Dec 09
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1684,7 +1684,7 @@ the type must match: >
 	FuncVA = (v1: string, v: string2): number => 333     # Error!
 	FuncVA = (v: list<string>): number => 3	    # Error!
 
-If the destinataion funcref has no specified arguments, then there is no
+If the destination funcref has no specified arguments, then there is no
 argument type checking: >
 	var FuncUnknownArgs: func: number
 	FuncUnknownArgs = (v): number => v			# OK


### PR DESCRIPTION
The docs for cmdline completion doesn't mention that [abc] is considered
a wildcard, and |wildcards| contains more detailed information, so just
link to it.

Also fix some typos in other help files.
