### PR TITLE
none: ternary opt doc typo

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -939,7 +939,7 @@ to avoid running out of stack and crashing. *E1169*
 expr1				*expr1* *ternary* *falsy-operator* *??* *E109*
 -----
 
-The ternary operator: expr2 ? expr1 : expr1
+The ternary operator: expr2 ? expr2 : expr1
 The falsy operator:   expr2 ?? expr1
 
 Ternary operator ~


### PR DESCRIPTION
// 'expr1 or expr1' seems odd
// 'expr2 or expr1' should be