### PR TITLE
When assigning a List or a Dict value to a variable of type 'any', keep the type

### DIFF
--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -3323,4 +3323,30 @@ def Test_func_rettype_check()
   v9.CheckSourceFailure(lines, 'E1012: Type mismatch; expected object<A> but got number', 1)
 enddef
 
+" Test for assigning different types of value to a variable of type "any"
+def Test_assign_to_any()
+  for [typestr, val] in [
+                          ["'bool'", 'true'],
+                          ["'number'", '100'],
+                          ["'float'", '1.1'],
+                          ["'string'", '"abc"'],
+                          ["'blob'", '0z10'],
+                          ["'list<number>'", '[1, 2, 3]'],
+                          ["'dict<number>'", '{a: 1}'],
+                        ]
+    var lines =<< trim eval END
+      vim9script
+      var x: any = {val}
+      assert_equal({typestr}, typename(x))
+      x = [{{a: 1}}, {{b: 2}}]
+      assert_equal('list<dict<number>>', typename(x))
+      def Foo(xarg: any, s: string)
+        assert_equal(s, typename(xarg))
+      enddef
+      Foo({val}, {typestr})
+    END
+    v9.CheckSourceSuccess(lines)
+  endfor
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -201,6 +201,10 @@ set_tv_type_recurse(type_T *type)
     void
 set_tv_type(typval_T *tv, type_T *type)
 {
+    if (type->tt_type == VAR_ANY)
+	// If the variable type is "any", then keep the value type.
+	// e.g.  var x: any = [1, 2] or var y: any = {v: 1}
+	return;
     if (tv->v_type == VAR_DICT && tv->vval.v_dict != NULL)
     {
 	dict_T *d = tv->vval.v_dict;


### PR DESCRIPTION
When a number, float, boolean, string or blob value is assigned to a variable of type "any", the variable type is set to the type of the value.  But when a List or Dict value is assigned to the variable, the type of the variable is set to "any".  Make it consistent and retain the type of the value.

Fixes one of the issues mentioned in #13639.