### PR TITLE
runtime(syntax): unlet b:filetype_in_cpp_family

### DIFF
--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -125,5 +125,6 @@ hi def link cppFloat		Number
 hi def link cppModule		Include
 
 let b:current_syntax = "cpp"
+unlet b:filetype_in_cpp_family
 
 " vim: ts=8

--- a/runtime/syntax/squirrel.vim
+++ b/runtime/syntax/squirrel.vim
@@ -46,5 +46,6 @@ hi def link squirrelRepeat		cRepeat
 hi def link squirrelShComment		Comment
 
 let b:current_syntax = "squirrel"
+unlet b:filetype_in_cpp_family
 
 " vim: ts=8


### PR DESCRIPTION
Update runtime/syntax/cpp.vim to unlet b:filetype_in_cpp_family as it remains set even after updating the ft of a file manually or through a modeline, not allowing c specific keywords to be highlighted.