### PR TITLE
Termdebug: add Tbreak command

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -2159,6 +2159,7 @@ $quote	eval.txt	/*$quote*
 :Stop	terminal.txt	/*:Stop*
 :TOhtml	syntax.txt	/*:TOhtml*
 :TarDiff	pi_tar.txt	/*:TarDiff*
+:Tbreak	terminal.txt	/*:Tbreak*
 :Termdebug	terminal.txt	/*:Termdebug*
 :TermdebugCommand	terminal.txt	/*:TermdebugCommand*
 :Texplore	pi_netrw.txt	/*:Texplore*
@@ -7217,6 +7218,7 @@ ft-ia64-syntax	syntax.txt	/*ft-ia64-syntax*
 ft-inform-syntax	syntax.txt	/*ft-inform-syntax*
 ft-java-syntax	syntax.txt	/*ft-java-syntax*
 ft-javascript-omni	insert.txt	/*ft-javascript-omni*
+ft-json-plugin	filetype.txt	/*ft-json-plugin*
 ft-json-syntax	syntax.txt	/*ft-json-syntax*
 ft-ksh-syntax	syntax.txt	/*ft-ksh-syntax*
 ft-lace-syntax	syntax.txt	/*ft-lace-syntax*

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1331,6 +1331,9 @@ gdb:
  *:Break*	set a breakpoint at the cursor position
  :Break {position}
 		set a breakpoint at the specified position
+ *:Tbreak*	set a temporary breakpoint at the cursor position
+ :Tbreak {position}
+		set a temporary breakpoint at the specified position
  *:Clear*	delete the breakpoint at the cursor position
 
  *:Step*	execute the gdb "step" command

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -953,7 +953,7 @@ func s:InstallCommands()
   set cpo&vim
 
   command -nargs=? Break call s:SetBreakpoint(<q-args>)
-  command -nargs=? Tbreak call s:SetBreakpoint(<q-args>, 1)
+  command -nargs=? Tbreak call s:SetBreakpoint(<q-args>, v:true)
   command Clear call s:ClearBreakpoint()
   command Step call s:SendResumingCommand('-exec-step')
   command Over call s:SendResumingCommand('-exec-next')
@@ -1169,7 +1169,7 @@ func s:Until(at)
 endfunc
 
 " :Break - Set a breakpoint at the cursor position.
-func s:SetBreakpoint(at, t=0)
+func s:SetBreakpoint(at, tbreak=v:false)
   " Setting a breakpoint may not work while the program is running.
   " Interrupt to make it work.
   let do_continue = 0
@@ -1182,7 +1182,7 @@ func s:SetBreakpoint(at, t=0)
   " Use the fname:lnum format, older gdb can't handle --source.
   let at = empty(a:at) ?
 	\ fnameescape(expand('%:p')) . ':' . line('.') : a:at
-  if a:t
+  if a:tbreak
     let cmd = '-break-insert -t ' . at
   else
     let cmd = '-break-insert ' . at

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -953,6 +953,7 @@ func s:InstallCommands()
   set cpo&vim
 
   command -nargs=? Break call s:SetBreakpoint(<q-args>)
+  command -nargs=? Tbreak call s:SetBreakpoint(<q-args>, 1)
   command Clear call s:ClearBreakpoint()
   command Step call s:SendResumingCommand('-exec-step')
   command Over call s:SendResumingCommand('-exec-next')
@@ -1067,6 +1068,7 @@ endfunc
 " Delete installed debugger commands in the current window.
 func s:DeleteCommands()
   delcommand Break
+  delcommand Tbreak
   delcommand Clear
   delcommand Step
   delcommand Over
@@ -1167,7 +1169,7 @@ func s:Until(at)
 endfunc
 
 " :Break - Set a breakpoint at the cursor position.
-func s:SetBreakpoint(at)
+func s:SetBreakpoint(at, t=0)
   " Setting a breakpoint may not work while the program is running.
   " Interrupt to make it work.
   let do_continue = 0
@@ -1180,7 +1182,12 @@ func s:SetBreakpoint(at)
   " Use the fname:lnum format, older gdb can't handle --source.
   let at = empty(a:at) ?
 	\ fnameescape(expand('%:p')) . ':' . line('.') : a:at
-  call s:SendCommand('-break-insert ' . at)
+  if a:t
+    let cmd = '-break-insert -t ' . at
+  else
+    let cmd = '-break-insert ' . at
+  endif
+  call s:SendCommand(cmd)
   if do_continue
     Continue
   endif

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -18,8 +18,8 @@ if g:GCC->empty()
   throw 'Skipped: gcc is not found in $PATH'
 endif
 
-function s:generate_files(bin_name) 
-  let src_name = a:bin_name . '.c'
+function s:generate_files(bin_name)
+  let src_name = a:bin_name .. '.c'
   let lines =<< trim END
     #include <stdio.h>
     #include <stdlib.h>
@@ -47,18 +47,18 @@ function s:generate_files(bin_name)
   END
   call writefile(lines, src_name)
   call system($'{g:GCC} -g -o {a:bin_name} {src_name}')
-endfunction 
+endfunction
 
 function s:cleanup_files(bin_name)
   call delete(a:bin_name)
-  call delete(a:bin_name . '.c')
+  call delete(a:bin_name .. '.c')
 endfunction
 
 packadd termdebug
 
 func Test_termdebug_basic()
   let bin_name = 'XTD_basic'
-  let src_name = bin_name . '.c'
+  let src_name = bin_name .. '.c'
   call s:generate_files(bin_name)
 
   edit XTD_basic.c
@@ -165,67 +165,65 @@ func Test_termdebug_basic()
 endfunc
 
 func Test_termdebug_tbreak()
-  " the same as the first half part of Test_termdebug_basic(),
-  " but only 'debugPC' sign should be present after the breakpoint
-  " was hit once
-  let lines =<< trim END
-    #include <stdio.h>
-    #include <stdlib.h>
+  let bin_name = 'XTD_tbreak'
+  let src_name = bin_name .. '.c'
 
-    int isprime(int n)
-    {
-      if (n <= 1)
-        return 0;
+  eval s:generate_files(bin_name)
 
-      for (int i = 2; i <= n / 2; i++)
-        if (n % i == 0)
-          return 0;
+  execute 'edit ' .. src_name
+  execute 'Termdebug ./' .. bin_name
 
-      return 1;
-    }
-
-    int main(int argc, char *argv[])
-    {
-      int n = 7;
-
-      printf("%d is %s prime\n", n, isprime(n) ? "a" : "not a");
-
-      return 0;
-    }
-  END
-  call writefile(lines, 'XTD_basic.c', 'D')
-  call system($'{g:GCC} -g -o XTD_basic XTD_basic.c')
-
-  edit XTD_basic.c
-  Termdebug ./XTD_basic
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
   let gdb_buf = winbufnr(1)
   wincmd b
-  Tbreak 9
+
+  let bp_line = 22        " 'return' statement in main
+  let temp_bp_line = 10   " 'if' statement in 'for' loop body
+  execute "Tbreak " .. temp_bp_line
+  execute "Break " .. bp_line
+
   call term_wait(gdb_buf)
   redraw!
+  " both temporary and normal breakpoint signs were displayed...
   call assert_equal([
-        \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \ {'lnum': temp_bp_line, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'},
+        \ {'lnum': bp_line, 'id': 2014, 'name': 'debugBreakpoint2.0',
         \  'priority': 110, 'group': 'TermDebug'}],
         \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+
   Run
   call term_wait(gdb_buf, 400)
   redraw!
+  " debugPC sign is on the line where the temp. bp was set;
+  " temp. bp sign was removed after hit;
+  " normal bp sign is still present
   call WaitForAssert({-> assert_equal([
-        \ {'lnum': 9, 'id': 12, 'name': 'debugPC', 'priority': 110,
-        \  'group': 'TermDebug'}],
-        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
-  Finish
-  call term_wait(gdb_buf)
-  redraw!
-  call WaitForAssert({-> assert_equal([
-        \ {'lnum': 20, 'id': 12, 'name': 'debugPC',
+        \ {'lnum': temp_bp_line, 'id': 12, 'name': 'debugPC', 'priority': 110,
+        \  'group': 'TermDebug'},
+        \ {'lnum': bp_line, 'id': 2014, 'name': 'debugBreakpoint2.0',
         \  'priority': 110, 'group': 'TermDebug'}],
         \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
+
   Continue
   call term_wait(gdb_buf)
+  redraw!
+  " debugPC is on the normal breakpoint,
+  " temp. bp on line 10 was only hit once
+  call WaitForAssert({-> assert_equal([
+        \ {'lnum': bp_line, 'id': 12, 'name': 'debugPC', 'priority': 110,
+        \  'group': 'TermDebug'},
+        \ {'lnum': bp_line, 'id': 2014, 'name': 'debugBreakpoint2.0',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
+
+  wincmd t
+  quit!
+  redraw!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
   call assert_equal([], sign_getplaced('', #{group: 'TermDebug'})[0].signs)
 
-  call delete('XTD_basic')
+  eval s:cleanup_files(bin_name)
   %bw!
 endfunc
 

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -152,6 +152,71 @@ func Test_termdebug_basic()
   %bw!
 endfunc
 
+func Test_termdebug_tbreak()
+  " the same as the first half part of Test_termdebug_basic(),
+  " but only 'debugPC' sign should be present after the breakpoint
+  " was hit once
+  let lines =<< trim END
+    #include <stdio.h>
+    #include <stdlib.h>
+
+    int isprime(int n)
+    {
+      if (n <= 1)
+        return 0;
+
+      for (int i = 2; i <= n / 2; i++)
+        if (n % i == 0)
+          return 0;
+
+      return 1;
+    }
+
+    int main(int argc, char *argv[])
+    {
+      int n = 7;
+
+      printf("%d is %s prime\n", n, isprime(n) ? "a" : "not a");
+
+      return 0;
+    }
+  END
+  call writefile(lines, 'XTD_basic.c', 'D')
+  call system($'{g:GCC} -g -o XTD_basic XTD_basic.c')
+
+  edit XTD_basic.c
+  Termdebug ./XTD_basic
+  let gdb_buf = winbufnr(1)
+  wincmd b
+  Tbreak 9
+  call term_wait(gdb_buf)
+  redraw!
+  call assert_equal([
+        \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+  Run
+  call term_wait(gdb_buf, 400)
+  redraw!
+  call WaitForAssert({-> assert_equal([
+        \ {'lnum': 9, 'id': 12, 'name': 'debugPC', 'priority': 110,
+        \  'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
+  Finish
+  call term_wait(gdb_buf)
+  redraw!
+  call WaitForAssert({-> assert_equal([
+        \ {'lnum': 20, 'id': 12, 'name': 'debugPC',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
+  Continue
+  call term_wait(gdb_buf)
+  call assert_equal([], sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+
+  call delete('XTD_basic')
+  %bw!
+endfunc
+
 func Test_termdebug_mapping()
   %bw!
   call assert_equal(maparg('K', 'n', 0, 1)->empty(), 1)

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -18,9 +18,8 @@ if g:GCC->empty()
   throw 'Skipped: gcc is not found in $PATH'
 endif
 
-packadd termdebug
-
-func Test_termdebug_basic()
+function s:generate_files(bin_name) 
+  let src_name = a:bin_name . '.c'
   let lines =<< trim END
     #include <stdio.h>
     #include <stdlib.h>
@@ -46,8 +45,21 @@ func Test_termdebug_basic()
       return 0;
     }
   END
-  call writefile(lines, 'XTD_basic.c', 'D')
-  call system($'{g:GCC} -g -o XTD_basic XTD_basic.c')
+  call writefile(lines, src_name)
+  call system($'{g:GCC} -g -o {a:bin_name} {src_name}')
+endfunction 
+
+function s:cleanup_files(bin_name)
+  call delete(a:bin_name)
+  call delete(a:bin_name . '.c')
+endfunction
+
+packadd termdebug
+
+func Test_termdebug_basic()
+  let bin_name = 'XTD_basic'
+  let src_name = bin_name . '.c'
+  call s:generate_files(bin_name)
 
   edit XTD_basic.c
   Termdebug ./XTD_basic
@@ -148,7 +160,7 @@ func Test_termdebug_basic()
   call WaitForAssert({-> assert_equal(1, winnr('$'))})
   call assert_equal([], sign_getplaced('', #{group: 'TermDebug'})[0].signs)
 
-  call delete('XTD_basic')
+  call s:cleanup_files(bin_name)
   %bw!
 endfunc
 


### PR DESCRIPTION
Add `:Tbreak` command to insert a temporary breakpoint at the cursor location. 

Currently it can be achieved by using `tbreak` in the gdb-window, but typing the address in there looks much less convenient compared to vim navigation.