### PR TITLE
Fix: ftplugin/sbt.vim should not set b:did_ftplugin

### DIFF
--- a/runtime/ftplugin/sbt.vim
+++ b/runtime/ftplugin/sbt.vim
@@ -9,7 +9,6 @@ if exists('b:did_ftplugin') || &cp
   finish
 endif
 
-let b:did_ftplugin = 1
-
 runtime! ftplugin/scala.vim
 
+let b:did_ftplugin = 1


### PR DESCRIPTION
The `b:did_ftplugin` guard was set and prevented us from actually sourcing `ftplugin/scala.vim`. Since the latter script also sets the guard properly, we can simply remove the guard here.

PS! I can explain this in more detail if necessary, but I believe this is a very simple and clear fix.