### PR TITLE
Use :var for object and class variable declarations

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -78,8 +78,8 @@ Let's start with a simple example: a class that stores a text position (see
 below for how to do this more efficiently): >
 
 	class TextPosition
-	   this.lnum: number
-	   this.col: number
+	   var lnum: number
+	   var col: number
 
 	   def new(lnum: number, col: number)
 	      this.lnum = lnum
@@ -156,8 +156,8 @@ On the other hand, if you do not want the object variables to be read directly
 from outside the class or its sub-classes, you can make them protected.  This
 is done by prefixing an underscore to the name: >
 
-	this._lnum: number
-	this._col number
+	var _lnum: number
+	var _col number
 
 Now you need to provide methods to get the value of the protected variables.
 These are commonly called getters.  We recommend using a name that starts with
@@ -209,8 +209,8 @@ Many constructors take values for the object variables.  Thus you very often
 see this pattern: >
 
 	 class SomeClass
-	   this.lnum: number
-	   this.col: number
+	   var lnum: number
+	   var col: number
 
 	   def new(lnum: number, col: number)
 	      this.lnum = lnum
@@ -235,8 +235,8 @@ Putting together this way of using new() and making the variables public
 results in a much shorter class definition than what we started with: >
 
 	class TextPosition
-	   public this.lnum: number
-	   public this.col: number
+	   public var lnum: number
+	   public var col: number
 
 	   def new(this.lnum, this.col)
 	   enddef
@@ -277,8 +277,8 @@ Class members are declared with "static".  They are used by the name without a
 prefix in the class where they are defined: >
 
 	class OtherThing
-	   this.size: number
-	   static totalSize: number
+	   var size: number
+	   static var totalSize: number
 
 	   def new(this.size)
 	      totalSize += this.size
@@ -297,9 +297,9 @@ underscore as the first character in the name, and it can be made public by
 prefixing "public": >
 
     class OtherThing
-	static total: number	      # anybody can read, only class can write
-	static _sum: number	      # only class can read and write
-	public static result: number  # anybody can read and write
+	static var total: number	  # anybody can read, only class can write
+	static var _sum: number	          # only class can read and write
+	public static var result: number  # anybody can read and write
     endclass
 <
 							*class-method*
@@ -308,8 +308,8 @@ variables but they have no access to the object variables, they cannot use the
 "this" keyword:
 >
 	class OtherThing
-	   this.size: number
-	   static totalSize: number
+	   var size: number
+	   static var totalSize: number
 
 	   # Clear the total size and return the value it had before.
 	   static def ClearTotalSize(): number
@@ -345,14 +345,14 @@ outside of the defining class: >
 
     vim9script
     class Vehicle
-	static nextID: number = 1000
+	static var nextID: number = 1000
 	static def GetID(): number
 	    nextID += 1
 	    return nextID
 	enddef
     endclass
     class Car extends Vehicle
-	this.myID: number
+	var myID: number
 	def new()
 	    this.myID = Vehicle.GetID()
 	enddef
@@ -380,20 +380,20 @@ it is.  The Shape class functions as the base for a Square and a Triangle
 class, for which objects can be created.  Example: >
 
 	abstract class Shape
-	   this.color = Color.Black
-	   this.thickness = 10
+	   var color = Color.Black
+	   var thickness = 10
 	endclass
 
 	class Square extends Shape
-	   this.size: number
+	   var size: number
 
 	   def new(this.size)
 	   enddef
 	endclass
 
 	class Triangle extends Shape
-	   this.base: number
-	   this.height: number
+	   var base: number
+	   var height: number
 
 	   def new(this.base, this.height)
 	   enddef
@@ -430,8 +430,8 @@ interface called HasSurface, which specifies one method Surface() that returns
 a number.  This example extends the one above: >
 
 	abstract class Shape
-	   this.color = Color.Black
-	   this.thickness = 10
+	   var color = Color.Black
+	   var thickness = 10
 	endclass
 
 	interface HasSurface
@@ -439,7 +439,7 @@ a number.  This example extends the one above: >
 	endinterface
 
 	class Square extends Shape implements HasSurface
-	   this.size: number
+	   var size: number
 
 	   def new(this.size)
 	   enddef
@@ -450,8 +450,8 @@ a number.  This example extends the one above: >
 	endclass
 
 	class Triangle extends Shape implements HasSurface
-	   this.base: number
-	   this.height: number
+	   var base: number
+	   var height: number
 
 	   def new(this.base, this.height)
 	   enddef
@@ -598,13 +598,13 @@ Items in a class ~
 						*E1318* *E1325* *E1388*
 Inside a class, in between `:class` and `:endclass`, these items can appear:
 - An object variable declaration: >
-	this._protectedVariableName: memberType
-	this.readonlyVariableName: memberType
-	public this.readwriteVariableName: memberType
+	var _protectedVariableName: memberType
+	var readonlyVariableName: memberType
+	public var readwriteVariableName: memberType
 - A class variable declaration: >
-	static _protectedClassVariableName: memberType
-	static readonlyClassVariableName: memberType
-	static public readwriteClassVariableName: memberType
+	static var _protectedClassVariableName: memberType
+	static var readonlyClassVariableName: memberType
+	static var public readwriteClassVariableName: memberType
 - A constructor method: >
 	def new(arguments)
 	def newName(arguments)
@@ -620,9 +620,9 @@ this explicitly with ": {type}".  For simple types you can also use an
 initializer, such as "= 123", and Vim will see that the type is a number.
 Avoid doing this for more complex types and when the type will be incomplete.
 For example: >
-	this.nameList = []
+	var nameList = []
 This specifies a list, but the item type is unknown.  Better use: >
-	this.nameList: list<string>
+	var nameList: list<string>
 The initialization isn't needed, the list is empty by default.
 							*E1330*
 Some types cannot be used, such as "void", "null" and "v:none".
@@ -646,7 +646,7 @@ An interface can declare methods with `:def`, including the arguments and
 return type, but without the body and without `:enddef`.  Example: >
 
 	interface HasSurface
-	   this.size: number
+	   var size: number
 	   def Surface(): number
 	endinterface
 
@@ -674,9 +674,9 @@ defined.  This default constructor will have arguments for all the object
 variables, in the order they were specified.  Thus if your class looks like: >
 
 	class AutoNew
-	   this.name: string
-	   this.age: number
-	   this.gender: Gender
+	   var name: string
+	   var age: number
+	   var gender: Gender
 	endclass
 
 Then the default constructor will be: >
@@ -690,8 +690,8 @@ value for the object variables will be used.  This is a more useful example,
 with default values: >
 
 	class TextPosition
-	   this.lnum: number = 1
-	   this.col: number = 1
+	   var lnum: number = 1
+	   var col: number = 1
 	endclass
 
 If you want the constructor to have mandatory arguments, you need to write it
@@ -925,26 +925,26 @@ Following that Vim object variables could be declared like this: >
 Some users pointed out that this looks more like an assignment than a
 declaration.  Adding "var" changes that: >
 	class Point
-	  var this.x: number
-	  var this.y = 0
+	  var x: number
+	  var y = 0
 	endclass
 
 We also need to be able to declare class variables using the "static" keyword.
 There we can also choose to leave out "var": >
 	class Point
-	  var this.x: number
+	  var x: number
 	  static count = 0
 	endclass
 
 Or do use it, before "static": >
 	class Point
-	  var this.x: number
+	  var x: number
 	  var static count = 0
 	endclass
 
 Or after "static": >
 	class Point
-	  var this.x: number
+	  var x: number
 	  static var count = 0
 	endclass
 
@@ -952,8 +952,15 @@ This is more in line with "static def Func()".
 
 There is no clear preference whether to use "var" or not.  The two main
 reasons to leave it out are:
-1. TypeScript, Java and other popular languages do not use it.
+1. TypeScript and other popular languages do not use it.
 2. Less clutter.
+
+However, it is more common for languages to reuse their general variable and
+function declaration syntax for class/object variables and methods.  Vim9 also
+reuses the general function declaration syntax for methods.  So, for the sake
+of consistency, we require "var" in these declarations.
+
+This also allows for a natural use of "final" and "const" in the future.
 
 
 Using "ClassName.new()" to construct an object ~

--- a/src/errors.h
+++ b/src/errors.h
@@ -3402,11 +3402,12 @@ EXTERN char e_object_required_found_str[]
 	INIT(= N_("E1327: Object required, found %s"));
 EXTERN char e_constructor_default_value_must_be_vnone_str[]
 	INIT(= N_("E1328: Constructor default value must be v:none: %s"));
-// E1329 unused
+EXTERN char e_invalid_class_variable_declaration_str[]
+	INIT(= N_("E1329: Invalid class variable declaration: %s"));
 EXTERN char e_invalid_type_for_object_variable_str[]
 	INIT(= N_("E1330: Invalid type for object variable: %s"));
-EXTERN char e_public_must_be_followed_by_this_or_static[]
-	INIT(= N_("E1331: Public must be followed by \"this\" or \"static\""));
+EXTERN char e_public_must_be_followed_by_var_or_static[]
+	INIT(= N_("E1331: Public must be followed by \"var\" or \"static\""));
 EXTERN char e_public_variable_name_cannot_start_with_underscore_str[]
 	INIT(= N_("E1332: Public variable name cannot start with underscore: %s"));
 EXTERN char e_cannot_access_protected_variable_str[]
@@ -3487,8 +3488,8 @@ EXTERN char e_cannot_access_protected_method_str[]
 	INIT(= N_("E1366: Cannot access protected method: %s"));
 EXTERN char e_variable_str_of_interface_str_has_different_access[]
 	INIT(= N_("E1367: Access level of variable \"%s\" of interface \"%s\" is different"));
-EXTERN char e_static_cannot_be_followed_by_this[]
-	INIT(= N_("E1368: Static cannot be followed by \"this\" in a variable name"));
+EXTERN char e_static_must_be_followed_by_var_or_def[]
+	INIT(= N_("E1368: Static must be followed by \"var\" or \"def\""));
 EXTERN char e_duplicate_variable_str[]
 	INIT(= N_("E1369: Duplicate variable: %s"));
 EXTERN char e_cannot_define_new_method_as_static[]

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -4845,7 +4845,7 @@ def Test_values()
       vim9script
 
       class Foo
-        this.val: number
+        var val: number
         def Add()
           echo this.val
         enddef

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -67,6 +67,33 @@ def Test_class_basic()
   END
   v9.CheckSourceFailure(lines, "E488: Trailing characters: | echo 'done'", 3)
 
+  # Use old "this." prefixed member variable declaration syntax (without intialization)
+  lines =<< trim END
+    vim9script
+    class Something
+      this.count: number
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: this.count: number', 3)
+
+  # Use old "this." prefixed member variable declaration syntax (with intialization)
+  lines =<< trim END
+    vim9script
+    class Something
+      this.count: number = 42
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: this.count: number = 42', 3)
+
+  # Use old "this." prefixed member variable declaration syntax (type inferred)
+  lines =<< trim END
+    vim9script
+    class Something
+      this.count = 42
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: this.count = 42', 3)
+
   # Use "this" without any member variable name
   lines =<< trim END
     vim9script
@@ -74,7 +101,7 @@ def Test_class_basic()
       this
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: this', 3)
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: this', 3)
 
   # Use "this." without any member variable name
   lines =<< trim END
@@ -83,7 +110,7 @@ def Test_class_basic()
       this.
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: this.', 3)
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: this.', 3)
 
   # Space between "this" and ".<variable>"
   lines =<< trim END
@@ -92,7 +119,7 @@ def Test_class_basic()
       this .count
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: this .count', 3)
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: this .count', 3)
 
   # Space between "this." and the member variable name
   lines =<< trim END
@@ -101,26 +128,44 @@ def Test_class_basic()
       this. count
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: this. count', 3)
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: this. count', 3)
 
   # Use "that" instead of "this"
   lines =<< trim END
     vim9script
     class Something
-      this.count: number
+      var count: number
       that.count
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: that.count', 4)
 
-  # Member variable without a type or initialization
+  # Use "variable" instead of "var" for member variable declaration (without initialization)
   lines =<< trim END
     vim9script
     class Something
-      this.count
+      variable count: number
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1022: Type or initialization required', 3)
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: variable count: number', 3)
+
+  # Use "variable" instead of "var" for member variable declaration (with initialization)
+  lines =<< trim END
+    vim9script
+    class Something
+      variable count: number = 42
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: variable count: number = 42', 3)
+
+  # Use "variable" instead of "var" for member variable declaration (type inferred)
+  lines =<< trim END
+    vim9script
+    class Something
+      variable count = 42
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1318: Not a valid command in a class: variable count = 42', 3)
 
   # Use a non-existing member variable in new()
   lines =<< trim END
@@ -138,7 +183,7 @@ def Test_class_basic()
   lines =<< trim END
     vim9script
     class Something
-      this.count : number
+      var count : number
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1059: No white space allowed before colon: count : number', 3)
@@ -147,10 +192,37 @@ def Test_class_basic()
   lines =<< trim END
     vim9script
     class Something
-      this.count:number
+      var count:number
     endclass
   END
   v9.CheckSourceFailure(lines, "E1069: White space required after ':'", 3)
+
+  # Missing ":var" in a "var" member variable declaration (without initialization)
+  lines =<< trim END
+    vim9script
+    class Something
+      var: number
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: var: number', 3)
+
+  # Missing ":var" in a "var" member variable declaration (with initialization)
+  lines =<< trim END
+    vim9script
+    class Something
+      var: number = 42
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: var: number = 42', 3)
+
+  # Missing ":var" in a "var" member variable declaration (type inferred)
+  lines =<< trim END
+    vim9script
+    class Something
+      var = 42
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1317: Invalid object variable declaration: var = 42', 3)
 
   # Test for unsupported comment specifier
   lines =<< trim END
@@ -227,8 +299,8 @@ def Test_class_basic()
     vim9script
 
     class TextPosition
-      this.lnum: number
-      this.col: number
+      var lnum: number
+      var col: number
 
       # make a nicely formatted string
       def ToString(): string
@@ -293,7 +365,7 @@ def Test_class_basic()
   lines =<< trim END
     vim9script
     class A
-      this.y = {
+      var y = {
         X: 1
       }
     endclass
@@ -312,7 +384,7 @@ def Test_class_def_method()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "this" or "static"', 3)
+  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "var" or "static"', 3)
 
   # Using the "public" keyword when defining a class method
   lines =<< trim END
@@ -332,7 +404,7 @@ def Test_class_def_method()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "this" or "static"', 3)
+  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "var" or "static"', 3)
 
   # Using the "public" keyword when defining a class protected method
   lines =<< trim END
@@ -415,7 +487,7 @@ def Test_class_interface_wrong_end()
   var lines =<< trim END
     vim9script
     abstract class SomeName
-      this.member = 'text'
+      var member = 'text'
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E476: Invalid command: endinterface, expected endclass', 4)
@@ -423,7 +495,7 @@ def Test_class_interface_wrong_end()
   lines =<< trim END
     vim9script
     export interface AnotherName
-      this.member: string
+      var member: string
     endclass
   END
   v9.CheckSourceFailure(lines, 'E476: Invalid command: endclass, expected endinterface', 4)
@@ -435,7 +507,7 @@ def Test_object_not_set()
     vim9script
 
     class State
-      this.value = 'xyz'
+      var value = 'xyz'
     endclass
 
     var state: State
@@ -449,7 +521,7 @@ def Test_object_not_set()
     vim9script
 
     class Class
-      this.id: string
+      var id: string
       def Method1()
         echo 'Method1' .. this.id
       enddef
@@ -469,11 +541,11 @@ def Test_object_not_set()
     vim9script
 
     class Background
-      this.background = 'dark'
+      var background = 'dark'
     endclass
 
     class Colorscheme
-      this._bg: Background
+      var _bg: Background
 
       def GetBackground(): string
         return this._bg.background
@@ -490,7 +562,7 @@ def Test_object_not_set()
     vim9script
 
     class Class
-      this.id: string
+      var id: string
       def Method1()
         echo 'Method1' .. this.id
       enddef
@@ -552,8 +624,8 @@ def Test_class_member_initializer()
     vim9script
 
     class TextPosition
-      this.lnum: number = 1
-      this.col: number = 1
+      var lnum: number = 1
+      var col: number = 1
 
       # constructor with only the line number
       def new(lnum: number)
@@ -588,11 +660,11 @@ def Test_member_any_used_as_object()
     vim9script
 
     class Inner
-      this.value: number = 0
+      var value: number = 0
     endclass
 
     class Outer
-      this.inner: any
+      var inner: any
     endclass
 
     def F(outer: Outer)
@@ -611,11 +683,11 @@ def Test_member_any_used_as_object()
     vim9script
 
     class Inner
-      this._value: string = ''
+      var _value: string = ''
     endclass
 
     class Outer
-      this.inner: any
+      var inner: any
     endclass
 
     def F(outer: Outer)
@@ -633,11 +705,11 @@ def Test_member_any_used_as_object()
     vim9script
 
     class Inner
-      this.value: string = ''
+      var value: string = ''
     endclass
 
     class Outer
-      this.inner: any
+      var inner: any
     endclass
 
     def F(outer: Outer)
@@ -657,11 +729,11 @@ def Test_assignment_nested_type()
     vim9script
 
     class Inner
-      public this.value: number = 0
+      public var value: number = 0
     endclass
 
     class Outer
-      this.inner: Inner
+      var inner: Inner
     endclass
 
     def F(outer: Outer)
@@ -689,11 +761,11 @@ def Test_assignment_nested_type()
     vim9script
 
     class Inner
-      this.value: number = 0
+      var value: number = 0
     endclass
 
     class Outer
-      this.inner: Inner
+      var inner: Inner
     endclass
 
     def F(outer: Outer)
@@ -716,11 +788,11 @@ def Test_assignment_nested_type()
     vim9script
 
     class Inner
-      this.value: number = 0
+      var value: number = 0
     endclass
 
     class Outer
-      this.inner: Inner
+      var inner: Inner
     endclass
 
     def F(outer: Outer)
@@ -741,7 +813,7 @@ def Test_assignment_with_operator()
     vim9script
 
     class Foo
-      public this.x: number
+      public var x: number
 
       def Add(n: number)
         this.x += n
@@ -788,7 +860,7 @@ def Test_expr_after_using_object()
     vim9script
 
     class Something
-      this.label: string = ''
+      var label: string = ''
     endclass
 
     def Foo(): Something
@@ -807,8 +879,8 @@ def Test_class_default_new()
     vim9script
 
     class TextPosition
-      this.lnum: number = 1
-      this.col: number = 1
+      var lnum: number = 1
+      var col: number = 1
     endclass
 
     var pos = TextPosition.new()
@@ -832,9 +904,9 @@ def Test_class_default_new()
   lines =<< trim END
     vim9script
     class Person
-      this.name: string
-      this.age: number = 42
-      this.education: string = "unknown"
+      var name: string
+      var age: number = 42
+      var education: string = "unknown"
 
       def new(this.name, this.age = v:none, this.education = v:none)
       enddef
@@ -855,9 +927,9 @@ def Test_class_default_new()
   lines =<< trim END
     vim9script
     class Person
-      this.name: string
-      this.age: number = 42
-      this.education: string = "unknown"
+      var name: string
+      var age: number = 42
+      var education: string = "unknown"
 
       def new(this.name, this.age = v:none, this.education = v:none)
       enddef
@@ -872,7 +944,7 @@ def Test_class_default_new()
   lines =<< trim END
     vim9script
     class A
-      this.val: string
+      var val: string
       def new(this.val = 'a')
       enddef
     endclass
@@ -885,8 +957,8 @@ def Test_class_new_with_object_member()
     vim9script
 
     class C
-      this.str: string
-      this.num: number
+      var str: string
+      var num: number
       def new(this.str, this.num)
       enddef
       def newVals(this.str, this.num)
@@ -915,8 +987,8 @@ def Test_class_new_with_object_member()
     vim9script
 
     class C
-      this.str: string
-      this.num: number
+      var str: string
+      var num: number
       def new(this.str, this.num)
       enddef
     endclass
@@ -937,8 +1009,8 @@ def Test_class_new_with_object_member()
     vim9script
 
     class C
-      this.str: string
-      this.num: number
+      var str: string
+      var num: number
       def newVals(this.str, this.num)
       enddef
     endclass
@@ -959,7 +1031,7 @@ def Test_class_new_with_object_member()
     vim9script
 
     class C
-      this.str: string
+      var str: string
       def new(str: any)
       enddef
     endclass
@@ -980,7 +1052,7 @@ def Test_class_new_with_object_member()
   lines =<< trim END
     vim9script
     class A
-      this.val = 10
+      var val = 10
       static def Foo(this.val: number)
       enddef
     endclass
@@ -991,7 +1063,7 @@ def Test_class_new_with_object_member()
   lines =<< trim END
     vim9script
     class A
-      this.val = 10
+      var val = 10
       def Foo(this.val: number)
       enddef
     endclass
@@ -1003,9 +1075,9 @@ def Test_class_object_member_inits()
   var lines =<< trim END
     vim9script
     class TextPosition
-      this.lnum: number
-      this.col = 1
-      this.addcol: number = 2
+      var lnum: number
+      var col = 1
+      var addcol: number = 2
     endclass
 
     var pos = TextPosition.new()
@@ -1018,8 +1090,8 @@ def Test_class_object_member_inits()
   lines =<< trim END
     vim9script
     class TextPosition
-      this.lnum
-      this.col = 1
+      var lnum
+      var col = 1
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1022: Type or initialization required', 3)
@@ -1036,9 +1108,9 @@ def Test_class_object_member_inits()
     enddef
 
     class A
-      this.str1 = Init()
-      this.str2: string = Init()
-      this.col = 1
+      var str1 = Init()
+      var str2: string = Init()
+      var col = 1
     endclass
 
     assert_equal(init_count, 0)
@@ -1051,7 +1123,7 @@ def Test_class_object_member_inits()
   lines =<< trim END
     vim9script
     class A
-       this.value = init_val
+       var value = init_val
     endclass
     var a = A.new()
   END
@@ -1061,7 +1133,7 @@ def Test_class_object_member_inits()
   lines =<< trim END
     vim9script
     class A
-       this.value: void
+       var value: void
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1330: Invalid type for object variable: void', 3)
@@ -1072,9 +1144,9 @@ def Test_instance_variable_access()
   var lines =<< trim END
     vim9script
     class Triple
-       this._one = 1
-       this.two = 2
-       public this.three = 3
+       var _one = 1
+       var two = 2
+       public var three = 3
 
        def GetOne(): number
          return this._one
@@ -1100,17 +1172,17 @@ def Test_instance_variable_access()
   lines =<< trim END
     vim9script
     class A
-      public this._val = 10
+      public var _val = 10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1332: Public variable name cannot start with underscore: public this._val = 10', 3)
+  v9.CheckSourceFailure(lines, 'E1332: Public variable name cannot start with underscore: public var _val = 10', 3)
 
   lines =<< trim END
     vim9script
 
     class MyCar
-      this.make: string
-      this.age = 5
+      var make: string
+      var age = 5
 
       def new(make_arg: string)
         this.make = make_arg
@@ -1145,7 +1217,7 @@ def Test_instance_variable_access()
     vim9script
 
     class MyCar
-      this.make: string
+      var make: string
 
       def new(make_arg: string)
         this.make = make_arg
@@ -1161,7 +1233,7 @@ def Test_instance_variable_access()
     vim9script
 
     class Foo
-      this.x: list<number> = []
+      var x: list<number> = []
 
       def Add(n: number): any
         this.x->add(n)
@@ -1187,25 +1259,25 @@ def Test_instance_variable_access()
   lines =<< trim END
     vim9script
     class Something
-      pub this.val = 1
+      pub var val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1065: Command cannot be shortened: pub this.val = 1', 3)
+  v9.CheckSourceFailure(lines, 'E1065: Command cannot be shortened: pub var val = 1', 3)
 
-  # Test for "public" keyword must be followed by "this" or "static".
+  # Test for "public" keyword must be followed by "var" or "static".
   lines =<< trim END
     vim9script
     class Something
       public val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "this" or "static"', 3)
+  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "var" or "static"', 3)
 
   # Modify a instance variable using the class name in the script context
   lines =<< trim END
     vim9script
     class A
-      public this.val = 1
+      public var val = 1
     endclass
     A.val = 1
   END
@@ -1215,7 +1287,7 @@ def Test_instance_variable_access()
   lines =<< trim END
     vim9script
     class A
-      public this.val = 1
+      public var val = 1
     endclass
     var i = A.val
   END
@@ -1225,7 +1297,7 @@ def Test_instance_variable_access()
   lines =<< trim END
     vim9script
     class A
-      public this.val = 1
+      public var val = 1
     endclass
     def T()
       A.val = 1
@@ -1238,7 +1310,7 @@ def Test_instance_variable_access()
   lines =<< trim END
     vim9script
     class A
-      public this.val = 1
+      public var val = 1
     endclass
     def T()
       var i = A.val
@@ -1251,9 +1323,9 @@ def Test_instance_variable_access()
   lines =<< trim END
     vim9script
     class A
-      this.ro_obj_var = 10
-      public this.rw_obj_var = 20
-      this._priv_obj_var = 30
+      var ro_obj_var = 10
+      public var rw_obj_var = 20
+      var _priv_obj_var = 30
     endclass
 
     class B extends A
@@ -1280,34 +1352,25 @@ def Test_class_variable_access()
   var lines =<< trim END
     vim9script
     class Something
-      stat this.val = 1
+      stat var val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1065: Command cannot be shortened: stat this.val = 1', 3)
-
-  # Test for "static" cannot be followed by "this".
-  lines =<< trim END
-    vim9script
-    class Something
-      static this.val = 1
-    endclass
-  END
-  v9.CheckSourceFailure(lines, 'E1368: Static cannot be followed by "this" in a variable name', 3)
+  v9.CheckSourceFailure(lines, 'E1065: Command cannot be shortened: stat var val = 1', 3)
 
   # Test for "static" cannot be followed by "public".
   lines =<< trim END
     vim9script
     class Something
-      static public val = 1
+      static public var val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1022: Type or initialization required', 3)
+  v9.CheckSourceFailure(lines, 'E1368: Static must be followed by "var" or "def"', 3)
 
   # A readonly class variable cannot be modified from a child class
   lines =<< trim END
     vim9script
     class A
-      static ro_class_var = 40
+      static var ro_class_var = 40
     endclass
 
     class B extends A
@@ -1325,7 +1388,7 @@ def Test_class_variable_access()
   lines =<< trim END
     vim9script
     class A
-      static _priv_class_var = 60
+      static var _priv_class_var = 60
     endclass
 
     class B extends A
@@ -1343,7 +1406,7 @@ def Test_class_variable_access()
   lines =<< trim END
     vim9script
     class A
-      static _priv_class_var = 60
+      static var _priv_class_var = 60
     endclass
 
     class B extends A
@@ -1361,9 +1424,9 @@ def Test_class_variable_access()
   lines =<< trim END
     vim9script
     class A
-      static ro_class_var = 10
-      public static rw_class_var = 20
-      static _priv_class_var = 30
+      static var ro_class_var = 10
+      public static var rw_class_var = 20
+      static var _priv_class_var = 30
     endclass
 
     class B extends A
@@ -1392,8 +1455,8 @@ def Test_class_object_compare()
   var class_lines =<< trim END
     vim9script
     class Item
-      this.nr = 0
-      this.name = 'xx'
+      var nr = 0
+      var name = 'xx'
     endclass
   END
 
@@ -1435,13 +1498,13 @@ def Test_object_type()
     vim9script
 
     class One
-      this.one = 1
+      var one = 1
     endclass
     class Two
-      this.two = 2
+      var two = 2
     endclass
     class TwoMore extends Two
-      this.more = 9
+      var more = 9
     endclass
 
     var o: One = One.new()
@@ -1457,10 +1520,10 @@ def Test_object_type()
     vim9script
 
     class One
-      this.one = 1
+      var one = 1
     endclass
     class Two
-      this.two = 2
+      var two = 2
     endclass
 
     var o: One = Two.new()
@@ -1474,7 +1537,7 @@ def Test_object_type()
       def GetMember(): number
     endinterface
     class Two implements One
-      this.one = 1
+      var one = 1
       def GetMember(): number
         return this.one
       enddef
@@ -1489,7 +1552,7 @@ def Test_object_type()
     vim9script
 
     class Num
-      this.n: number = 0
+      var n: number = 0
     endclass
 
     def Ref(name: string): func(Num): Num
@@ -1511,11 +1574,11 @@ def Test_class_member()
   var lines =<< trim END
     vim9script
     class TextPos
-       this.lnum = 1
-       this.col = 1
-       static counter = 0
-       static _secret = 7
-       public static  anybody = 42
+       var lnum = 1
+       var col = 1
+       static var counter = 0
+       static var _secret = 7
+       public static var anybody = 42
 
        static def AddToCounter(nr: number)
          counter += nr
@@ -1551,8 +1614,8 @@ def Test_class_member()
   lines =<< trim END
     vim9script
     class OtherThing
-      this.size: number
-      static totalSize: number
+      var size: number
+      static var totalSize: number
 
       def new(this.size)
         totalSize += this.size
@@ -1571,7 +1634,7 @@ def Test_class_member()
     vim9script
 
     class HTML
-      static author: string = 'John Doe'
+      static var author: string = 'John Doe'
 
       static def MacroSubstitute(s: string): string
         return substitute(s, '{{author}}', author, 'gi')
@@ -1588,7 +1651,7 @@ def Test_class_member()
     vim9script
 
     class Foo
-      this._x: number = 0
+      var _x: number = 0
 
       def Add(n: number): number
         const F = (): number => this._x + n
@@ -1606,7 +1669,7 @@ def Test_class_member()
     vim9script
 
     class Foo
-      this._x: number = 6
+      var _x: number = 6
 
       def Add(n: number): number
         var Lam = () => {
@@ -1627,7 +1690,7 @@ def Test_class_member()
     vim9script
 
     class Some
-      static count = 0
+      static var count = 0
       def Method(count: number)
         echo count
       enddef
@@ -1643,7 +1706,7 @@ def Test_class_member()
     vim9script
 
     class Some
-      static count = 0
+      static var count = 0
       def Method(arg: number)
         var count = 3
         echo arg count
@@ -1659,7 +1722,7 @@ def Test_class_member()
   lines =<< trim END
     vim9script
     class A
-      this.val: xxx
+      var val: xxx
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1010: Type not recognized: xxx', 3)
@@ -1668,7 +1731,7 @@ def Test_class_member()
   lines =<< trim END
     vim9script
     class A
-      public this.val: string
+      public var val: string
     endclass
 
     def F()
@@ -1683,7 +1746,7 @@ def Test_class_member()
   lines =<< trim END
     vim9script
     class A
-      this.val: string
+      var val: string
     endclass
 
     def F()
@@ -1698,7 +1761,7 @@ def Test_class_member()
   lines =<< trim END
     vim9script
     class A
-      public this.val: string
+      public var val: string
     endclass
 
     var obj: A
@@ -1710,7 +1773,7 @@ def Test_class_member()
   lines =<< trim END
     vim9script
     class A
-      this.val: string
+      var val: string
     endclass
 
     var obj: A
@@ -1723,14 +1786,14 @@ def Test_class_member()
   lines =<< trim END
     vim9script
     class A
-      this.val: number= 10
+      var val: number= 10
     endclass
   END
   v9.CheckSourceFailure(lines, "E1004: White space required before and after '='", 3)
   lines =<< trim END
     vim9script
     class A
-      this.val: number =10
+      var val: number =10
     endclass
   END
   v9.CheckSourceFailure(lines, "E1004: White space required before and after '='", 3)
@@ -1753,7 +1816,7 @@ def Test_defining_class_message()
     vim9script
 
     class Base
-      this._v1: list<list<number>>
+      var _v1: list<list<number>>
     endclass
 
     class Child extends Base
@@ -1767,7 +1830,7 @@ def Test_defining_class_message()
     vim9script
 
     class Base
-      this._v1: list<list<number>>
+      var _v1: list<list<number>>
     endclass
 
     class Child extends Base
@@ -1784,7 +1847,7 @@ def Test_defining_class_message()
     vim9script
 
     class Base
-      this.v1: list<list<number>>
+      var v1: list<list<number>>
     endclass
 
     class Child extends Base
@@ -1798,7 +1861,7 @@ def Test_defining_class_message()
     vim9script
 
     class Base
-      this.v1: list<list<number>>
+      var v1: list<list<number>>
     endclass
 
     class Child extends Base
@@ -1821,7 +1884,7 @@ def Test_defining_class_message()
     endclass
 
     class Base extends Base0
-      this._v1: list<list<number>>
+      var _v1: list<list<number>>
     endclass
 
     class Child extends Base
@@ -1847,7 +1910,7 @@ def Test_defining_class_message()
     endclass
 
     class Child extends Base
-      this._v1: list<list<number>>
+      var _v1: list<list<number>>
     endclass
 
     def F()
@@ -1864,9 +1927,9 @@ func Test_class_garbagecollect()
     vim9script
 
     class Point
-      this.p = [2, 3]
-      static pl = ['a', 'b']
-      static pd = {a: 'a', b: 'b'}
+      var p = [2, 3]
+      static var pl = ['a', 'b']
+      static var pd = {a: 'a', b: 'b'}
     endclass
 
     echo Point.pl Point.pd
@@ -1882,15 +1945,15 @@ func Test_class_garbagecollect()
     endinterface
 
     class Widget
-      this.view: View
+      var view: View
     endclass
 
     class MyView implements View
-      this.widget: Widget
+      var widget: Widget
 
       def new()
         # this will result in a circular reference to this object
-        this.widget = Widget.new(this)
+        var widget = Widget.new(this)
       enddef
     endclass
 
@@ -1909,17 +1972,17 @@ func Test_interface_garbagecollect()
     vim9script
 
     interface I
-      this.ro_obj_var: number
+      var ro_obj_var: number
 
       def ObjFoo(): number
     endinterface
 
     class A implements I
-      static ro_class_var: number = 10
-      public static rw_class_var: number = 20
-      static _priv_class_var: number = 30
-      this.ro_obj_var: number = 40
-      this._priv_obj_var: number = 60
+      static var ro_class_var: number = 10
+      public static var rw_class_var: number = 20
+      static var _priv_class_var: number = 30
+      var ro_obj_var: number = 40
+      var _priv_obj_var: number = 60
 
       static def _ClassBar(): number
         return _priv_class_var
@@ -1952,8 +2015,8 @@ def Test_class_method()
   var lines =<< trim END
     vim9script
     class Value
-      this.value = 0
-      static objects = 0
+      var value = 0
+      static var objects = 0
 
       def new(v: number)
         this.value = v
@@ -1990,7 +2053,7 @@ def Test_class_method()
   lines =<< trim END
     vim9script
     class A
-      static myList: list<number> = [1]
+      static var myList: list<number> = [1]
       static def Foo(n: number)
         myList->add(n)
       enddef
@@ -2087,8 +2150,8 @@ def Test_class_object_to_string()
   var lines =<< trim END
     vim9script
     class TextPosition
-      this.lnum = 1
-      this.col = 22
+      var lnum = 1
+      var col = 22
     endclass
 
     assert_equal("class TextPosition", string(TextPosition))
@@ -2103,7 +2166,7 @@ def Test_interface_basics()
   var lines =<< trim END
     vim9script
     interface Something
-      this.ro_var: list<number>
+      var ro_var: list<number>
       def GetCount(): number
     endinterface
   END
@@ -2111,7 +2174,7 @@ def Test_interface_basics()
 
   lines =<< trim END
     interface SomethingWrong
-      static count = 7
+      static var count = 7
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E1342: Interface can only be defined in Vim9 script', 1)
@@ -2120,7 +2183,7 @@ def Test_interface_basics()
     vim9script
 
     interface Some
-      this.value: number
+      var value: number
       def Method(value: number)
     endinterface
   END
@@ -2131,7 +2194,7 @@ def Test_interface_basics()
   lines =<< trim END
     vim9script
     interface somethingWrong
-      static count = 7
+      static var count = 7
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E1343: Interface name must start with an uppercase letter: somethingWrong', 2)
@@ -2139,8 +2202,8 @@ def Test_interface_basics()
   lines =<< trim END
     vim9script
     interface SomethingWrong
-      this.value: string
-      this.count = 7
+      var value: string
+      var count = 7
       def GetCount(): number
     endinterface
   END
@@ -2149,8 +2212,8 @@ def Test_interface_basics()
   lines =<< trim END
     vim9script
     interface SomethingWrong
-      this.value: string
-      this.count: number
+      var value: string
+      var count: number
       def GetCount(): number
         return 5
       enddef
@@ -2201,24 +2264,24 @@ def Test_class_implements_interface()
     vim9script
 
     interface Some
-      this.count: number
+      var count: number
       def Method(nr: number)
     endinterface
 
     class SomeImpl implements Some
-      this.count: number
+      var count: number
       def Method(nr: number)
         echo nr
       enddef
     endclass
 
     interface Another
-      this.member: string
+      var member: string
     endinterface
 
     class AnotherImpl implements Some, Another
-      this.member = 'abc'
-      this.count = 20
+      var member = 'abc'
+      var count = 20
       def Method(nr: number)
         echo nr
       enddef
@@ -2230,11 +2293,11 @@ def Test_class_implements_interface()
     vim9script
 
     interface Some
-      this.count: number
+      var count: number
     endinterface
 
     class SomeImpl implements Some implements Some
-      this.count: number
+      var count: number
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1350: Duplicate "implements"', 7)
@@ -2243,11 +2306,11 @@ def Test_class_implements_interface()
     vim9script
 
     interface Some
-      this.count: number
+      var count: number
     endinterface
 
     class SomeImpl implements Some, Some
-      this.count: number
+      var count: number
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1351: Duplicate interface after "implements": Some', 7)
@@ -2256,12 +2319,12 @@ def Test_class_implements_interface()
     vim9script
 
     interface Some
-      this.counter: number
+      var counter: number
       def Method(nr: number)
     endinterface
 
     class SomeImpl implements Some
-      this.count: number
+      var count: number
       def Method(nr: number)
         echo nr
       enddef
@@ -2273,12 +2336,12 @@ def Test_class_implements_interface()
     vim9script
 
     interface Some
-      this.count: number
+      var count: number
       def Methods(nr: number)
     endinterface
 
     class SomeImpl implements Some
-      this.count: number
+      var count: number
       def Method(nr: number)
         echo nr
       enddef
@@ -2291,15 +2354,15 @@ def Test_class_implements_interface()
     vim9script
 
       interface Result
-        this.label: string
-        this.errpos: number
+        var label: string
+        var errpos: number
       endinterface
 
       # order of members is opposite of interface
       class Failure implements Result
-        public this.lnum: number = 5
-        this.errpos: number = 42
-        this.label: string = 'label'
+        public var lnum: number = 5
+        var errpos: number = 42
+        var label: string = 'label'
       endclass
 
     def Test()
@@ -2412,16 +2475,16 @@ def Test_class_implements_interface()
     vim9script
 
     interface I1
-      this.mvar1: number
-      this.mvar2: number
+      var mvar1: number
+      var mvar2: number
     endinterface
 
     # NOTE: the order is swapped
     class A implements I1
-      this.mvar2: number
-      this.mvar1: number
-      public static svar2: number
-      public static svar1: number
+      var mvar2: number
+      var mvar1: number
+      public static var svar2: number
+      public static var svar1: number
       def new()
         svar1 = 11
         svar2 = 12
@@ -2464,20 +2527,20 @@ def Test_class_implements_interface()
     vim9script
 
     interface I1
-      this.mvar1: number
-      this.mvar2: number
+      var mvar1: number
+      var mvar2: number
     endinterface
 
     interface I2
-      this.mvar3: number
-      this.mvar4: number
+      var mvar3: number
+      var mvar4: number
     endinterface
 
     class A implements I1
-      public static svar1: number
-      public static svar2: number
-      this.mvar1: number
-      this.mvar2: number
+      public static var svar1: number
+      public static var svar2: number
+      var mvar1: number
+      var mvar2: number
       def new()
         svar1 = 11
         svar2 = 12
@@ -2487,10 +2550,10 @@ def Test_class_implements_interface()
     endclass
 
     class B extends A implements I2
-      static svar3: number
-      static svar4: number
-      this.mvar3: number
-      this.mvar4: number
+      static var svar3: number
+      static var svar4: number
+      var mvar3: number
+      var mvar4: number
       def new()
         svar3 = 23
         svar4 = 24
@@ -2502,7 +2565,7 @@ def Test_class_implements_interface()
     endclass
 
     class C extends B
-      public static svar5: number
+      public static var svar5: number
       def new()
         svar5 = 1001
         this.mvar1 = 131
@@ -2686,8 +2749,8 @@ def Test_class_used_as_type()
     vim9script
 
     class Point
-      this.x = 0
-      this.y = 0
+      var x = 0
+      var y = 0
     endclass
 
     var p: Point
@@ -2701,12 +2764,12 @@ def Test_class_used_as_type()
     vim9script
 
     interface HasX
-      this.x: number
+      var x: number
     endinterface
 
     class Point implements HasX
-      this.x = 0
-      this.y = 0
+      var x = 0
+      var y = 0
     endclass
 
     var p: Point
@@ -2720,8 +2783,8 @@ def Test_class_used_as_type()
     vim9script
 
     class Point
-      this.x = 0
-      this.y = 0
+      var x = 0
+      var y = 0
     endclass
 
     var p: Point
@@ -2734,13 +2797,13 @@ def Test_class_extends()
   var lines =<< trim END
     vim9script
     class Base
-      this.one = 1
+      var one = 1
       def GetOne(): number
         return this.one
       enddef
     endclass
     class Child extends Base
-      this.two = 2
+      var two = 2
       def GetTotal(): number
         return this.one + this.two
       enddef
@@ -2756,10 +2819,10 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Base
-      this.one = 1
+      var one = 1
     endclass
     class Child extends Base
-      this.two = 2
+      var two = 2
     endclass
     var o = Child.new(3, 44)
     assert_equal(3, o.one)
@@ -2770,10 +2833,10 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Base
-      this.one = 1
+      var one = 1
     endclass
     class Child extends Base extends Base
-      this.two = 2
+      var two = 2
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1352: Duplicate "extends"', 5)
@@ -2781,7 +2844,7 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Child extends BaseClass
-      this.two = 2
+      var two = 2
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1353: Class name not found: BaseClass', 4)
@@ -2790,7 +2853,7 @@ def Test_class_extends()
     vim9script
     var SomeVar = 99
     class Child extends SomeVar
-      this.two = 2
+      var two = 2
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1354: Cannot extend SomeVar', 5)
@@ -2798,14 +2861,14 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Base
-      this.name: string
+      var name: string
       def ToString(): string
         return this.name
       enddef
     endclass
 
     class Child extends Base
-      this.age: number
+      var age: number
       def ToString(): string
         return super.ToString() .. ': ' .. this.age
       enddef
@@ -2819,7 +2882,7 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Child
-      this.age: number
+      var age: number
       def ToString(): number
         return this.age
       enddef
@@ -2833,7 +2896,7 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Child
-      this.age: number
+      var age: number
       def ToString(): string
         return super .ToString() .. ': ' .. this.age
       enddef
@@ -2846,7 +2909,7 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Base
-      this.name: string
+      var name: string
       def ToString(): string
         return this.name
       enddef
@@ -2863,7 +2926,7 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Child
-      this.age: number
+      var age: number
       def ToString(): string
         return super.ToString() .. ': ' .. this.age
       enddef
@@ -2876,14 +2939,14 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Base
-      this.name: string
+      var name: string
       static def ToString(): string
         return 'Base class'
       enddef
     endclass
 
     class Child extends Base
-      this.age: number
+      var age: number
       def ToString(): string
         return Base.ToString() .. ': ' .. this.age
       enddef
@@ -2897,7 +2960,7 @@ def Test_class_extends()
   lines =<< trim END
     vim9script
     class Base
-      this.value = 1
+      var value = 1
       def new(init: number)
         this.value = number + 1
       enddef
@@ -2916,8 +2979,8 @@ def Test_class_extends()
     vim9script
 
     class Result
-      this.success: bool
-      this.value: any = null
+      var success: bool
+      var value: any = null
     endclass
 
     class Success extends Result
@@ -2986,7 +3049,7 @@ def Test_using_base_class()
     vim9script
 
     class Base
-      this.success: bool = false
+      var success: bool = false
       def Method(arg = 0)
         this.success = true
       enddef
@@ -3008,8 +3071,8 @@ def Test_class_import()
   var lines =<< trim END
     vim9script
     export class Animal
-      this.kind: string
-      this.name: string
+      var kind: string
+      var name: string
     endclass
   END
   writefile(lines, 'Xanimal.vim', 'D')
@@ -3034,10 +3097,10 @@ def Test_abstract_class()
   var lines =<< trim END
     vim9script
     abstract class Base
-      this.name: string
+      var name: string
     endclass
     class Person extends Base
-      this.age: number
+      var age: number
     endclass
     var p: Base = Person.new('Peter', 42)
     assert_equal('Peter', p.name)
@@ -3048,10 +3111,10 @@ def Test_abstract_class()
   lines =<< trim END
     vim9script
     abstract class Base
-      this.name: string
+      var name: string
     endclass
     class Person extends Base
-      this.age: number
+      var age: number
     endclass
     var p = Base.new('Peter')
   END
@@ -3059,7 +3122,7 @@ def Test_abstract_class()
 
   lines =<< trim END
     abstract class Base
-      this.name: string
+      var name: string
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1316: Class can only be defined in Vim9 script', 1)
@@ -3080,7 +3143,7 @@ def Test_closure_in_class()
     vim9script
 
     class Foo
-      this.y: list<string> = ['B']
+      var y: list<string> = ['B']
 
       def new()
         g:result = filter(['A', 'B'], (_, v) => index(this.y, v) == -1)
@@ -3145,8 +3208,8 @@ def Test_construct_object_from_legacy()
     var createdObject: any
 
     class A
-      this.val1: number
-      this.val2: number
+      var val1: number
+      var val2: number
       static def CreateA(...args: list<any>): any
         createdObject = call(A.new, args)
         return createdObject
@@ -3244,7 +3307,7 @@ def Test_extends_method_crashes_vim()
     endclass
 
     class Property
-      this.value: any
+      var value: any
 
       def Set(v: any)
         if v != this.value
@@ -3257,7 +3320,7 @@ def Test_extends_method_crashes_vim()
     endclass
 
     class Bool extends Property
-      this.value2: bool
+      var value2: bool
     endclass
 
     def Observe(obj: Property, who: Observer)
@@ -3435,7 +3498,7 @@ def Test_call_method_in_parent_class()
     vim9script
 
     class Widget
-      this._lnum: number = 1
+      var _lnum: number = 1
 
       def SetY(lnum: number)
         this._lnum = lnum
@@ -3545,15 +3608,15 @@ def Test_multi_level_member_access()
     vim9script
 
     class A
-      public this.val1: number = 0
+      public var val1: number = 0
     endclass
 
     class B extends A
-      public this.val2: number = 0
+      public var val2: number = 0
     endclass
 
     class C extends B
-      public this.val3: number = 0
+      public var val3: number = 0
     endclass
 
     def A_members(a: A)
@@ -3613,7 +3676,7 @@ def Test_new_return_type()
     vim9script
 
     class C
-      this._bufnr: number
+      var _bufnr: number
 
       def new(this._bufnr)
         if !bufexists(this._bufnr)
@@ -3643,7 +3706,7 @@ def Test_new_return_type()
     vim9script
 
     class C
-      this._bufnr: number
+      var _bufnr: number
 
       def new(this._bufnr)
         if !bufexists(this._bufnr)
@@ -3674,7 +3737,7 @@ def Test_new_return_type()
     vim9script
 
     class C
-      this._bufnr: number
+      var _bufnr: number
 
       def new(this._bufnr): any
         if !bufexists(this._bufnr)
@@ -3691,7 +3754,7 @@ def Test_new_return_type()
     vim9script
 
     class C
-      this._state: dict<any>
+      var _state: dict<any>
 
       def new(): dict<any>
         this._state = {}
@@ -3722,7 +3785,7 @@ def Test_runtime_type_check_for_member_init()
     enddef
 
     class C
-      this._foo: bool = F()
+      var _foo: bool = F()
     endclass
 
     var c1 = C.new()
@@ -3738,7 +3801,7 @@ def Test_lockvar_object()
     vim9script
 
     class C
-      this.val: number
+      var val: number
       def new(this.val)
       enddef
     endclass
@@ -3784,7 +3847,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      this.val1: number
+      var val1: number
       def Lock()
         lockvar this.val1
       enddef
@@ -3799,7 +3862,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      this.val2: number
+      var val2: number
     endclass
     var o = C.new(3)
     lockvar o.val2
@@ -3811,7 +3874,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      this.val3: number
+      var val3: number
     endclass
     var o = C.new(3)
     def Lock()
@@ -3826,7 +3889,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      this.val4: number
+      var val4: number
     endclass
     def Lock(o: C)
       lockvar o.val4
@@ -3843,7 +3906,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      this.val5: number
+      var val5: number
       def Lock(o_any: any)
         lockvar o_any.val5
       enddef
@@ -3858,7 +3921,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      this.val6: number
+      var val6: number
       static def Lock(o_any: any)
         lockvar o_any.val6
       enddef
@@ -3877,7 +3940,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      public this.val1: number
+      public var val1: number
       def Lock()
         lockvar this.val1
       enddef
@@ -3892,7 +3955,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      public this.val2: number
+      public var val2: number
     endclass
     var o = C.new(3)
     lockvar o.val2
@@ -3904,7 +3967,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      public this.val3: number
+      public var val3: number
     endclass
     var o = C.new(3)
     def Lock()
@@ -3919,7 +3982,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      public this.val4: number
+      public var val4: number
     endclass
     def Lock(o: C)
       lockvar o.val4
@@ -3933,7 +3996,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      public this.val5: number
+      public var val5: number
       def Lock(o_any: any)
         lockvar o_any.val5
       enddef
@@ -3948,7 +4011,7 @@ def Test_lockvar_object_variable()
     vim9script
 
     class C
-      public this.val6: number
+      public var val6: number
       static def Lock(o_any: any)
         lockvar o_any.val6
       enddef
@@ -3967,7 +4030,7 @@ def Test_lockvar_class_variable()
     vim9script
 
     class C
-      public static sval1: number
+      public static var sval1: number
       def Lock()
         lockvar sval1
       enddef
@@ -3982,7 +4045,7 @@ def Test_lockvar_class_variable()
     vim9script
 
     class C
-      public static sval2: number
+      public static var sval2: number
       def Lock()
         lockvar C.sval2
       enddef
@@ -3997,7 +4060,7 @@ def Test_lockvar_class_variable()
     vim9script
 
     class C
-      public static sval3: number
+      public static var sval3: number
       static def Lock()
         lockvar sval3
       enddef
@@ -4011,7 +4074,7 @@ def Test_lockvar_class_variable()
     vim9script
 
     class C
-      public static sval4: number
+      public static var sval4: number
       static def Lock()
         lockvar C.sval4
       enddef
@@ -4025,7 +4088,7 @@ def Test_lockvar_class_variable()
     vim9script
 
     class C
-      public static sval5: number
+      public static var sval5: number
     endclass
     lockvar C.sval5
   END
@@ -4036,7 +4099,7 @@ def Test_lockvar_class_variable()
     vim9script
 
     class C
-      public static sval6: number
+      public static var sval6: number
     endclass
     var o = C.new()
     lockvar o.sval6
@@ -4067,7 +4130,7 @@ def Test_lockvar_argument()
     vim9script
 
     class C
-      public static sval: list<number>
+      public static var sval: list<number>
     endclass
 
     def Lock2(sval: any)
@@ -4084,7 +4147,7 @@ def Test_lockvar_argument()
     vim9script
 
     class C
-      public static sval: list<number>
+      public static var sval: list<number>
     endclass
 
     def Lock2(sval: any)
@@ -4100,7 +4163,7 @@ def Test_lockvar_argument()
     vim9script
 
     class C
-      public static sval: list<number>
+      public static var sval: list<number>
     endclass
 
     def Lock2(sval: any)
@@ -4116,7 +4179,7 @@ def Test_lockvar_argument()
     vim9script
 
     class C
-      public static sval: list<number>
+      public static var sval: list<number>
       def Lock2()
         lockvar sval
       enddef
@@ -4191,7 +4254,7 @@ def Test_lockvar_general()
     vim9script
 
     class C
-      public this.val: list<list<number>> = [ [1], [2], [3] ]
+      public var val: list<list<number>> = [ [1], [2], [3] ]
     endclass
     def Lock2(obj: any)
       lockvar obj.val[1]
@@ -4217,7 +4280,7 @@ def Test_lockvar_general()
     vim9script
 
     class C
-      public this.val: list<list<number>> = [ [1], [2], [3] ]
+      public var val: list<list<number>> = [ [1], [2], [3] ]
     endclass
 
     var o = C.new()
@@ -4257,7 +4320,7 @@ def Test_lockvar_general()
     vim9script
 
     class C
-      this._v1: list<list<number>>
+      var _v1: list<list<number>>
       def Lock()
         lockvar lc[0]._v1[1]
       enddef
@@ -4281,14 +4344,14 @@ def Test_lockvar_general()
     vim9script
 
     class C2
-      this._v1: list<list<number>>
+      var _v1: list<list<number>>
       def Lock(obj: any)
         lockvar lc[0]._v1[1]
       enddef
     endclass
 
     class C
-      this._v1: list<list<number>>
+      var _v1: list<list<number>>
     endclass
 
     var l = [[1], [2], [3]]
@@ -4311,10 +4374,10 @@ def Test_lockvar_islocked()
     vim9script
 
     class C
-      this.o0: list<list<number>> = [ [0],  [1],  [2]]
-      this.o1: list<list<number>> = [[10], [11], [12]]
-      static c0: list<list<number>> = [[20], [21], [22]]
-      static c1: list<list<number>> = [[30], [31], [32]]
+      var o0: list<list<number>> = [ [0],  [1],  [2]]
+      var o1: list<list<number>> = [[10], [11], [12]]
+      static var c0: list<list<number>> = [[20], [21], [22]]
+      static var c1: list<list<number>> = [[30], [31], [32]]
     endclass
 
     def LockIt(arg: any)
@@ -4389,10 +4452,10 @@ def Test_lockvar_islocked()
     var l0c1 = [[130], [131], [132]]
 
     class C0
-      this.o0: list<list<number>> =   l0o0
-      this.o1: list<list<number>> =   l0o1
-      static c0: list<list<number>> = l0c0
-      static c1: list<list<number>> = l0c1
+      var o0: list<list<number>> =   l0o0
+      var o1: list<list<number>> =   l0o1
+      static var c0: list<list<number>> = l0c0
+      static var c1: list<list<number>> = l0c1
       def Islocked(arg: string): number
           return islocked(arg)
       enddef
@@ -4407,10 +4470,10 @@ def Test_lockvar_islocked()
     var l2c1 = [[20130], [20131], [20132]]
 
     class C2
-      this.o0: list<list<number>> =   l2o0
-      this.o1: list<list<number>> =   l2o1
-      static c0: list<list<number>> = l2c0
-      static c1: list<list<number>> = l2c1
+      var o0: list<list<number>> =   l2o0
+      var o1: list<list<number>> =   l2o1
+      static var c0: list<list<number>> = l2c0
+      static var c1: list<list<number>> = l2c1
       def Islocked(arg: string): number
           return islocked(arg)
       enddef
@@ -4576,7 +4639,7 @@ def Test_lockvar_islocked_notfound()
     vim9script
 
     class C
-      this.val = { key: "value" }
+      var val = { key: "value" }
       def Islocked(arg: string): number
           return islocked(arg)
       enddef
@@ -5113,8 +5176,8 @@ def Test_static_inheritence()
     vim9script
 
     class A
-      static _svar: number
-      this._mvar: number
+      static var _svar: number
+      var _mvar: number
       def new()
         _svar = 1
         this._mvar = 101
@@ -5167,8 +5230,8 @@ def Test_dup_member_variable()
   var lines =<< trim END
     vim9script
     class C
-      this.val = 10
-      this.val = 20
+      var val = 10
+      var val = 20
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 4)
@@ -5177,8 +5240,8 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class C
-      this._val = 10
-      this._val = 20
+      var _val = 10
+      var _val = 20
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 4)
@@ -5187,8 +5250,8 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class C
-      public this.val = 10
-      public this.val = 20
+      public var val = 10
+      public var val = 20
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 4)
@@ -5197,8 +5260,8 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class C
-      this.val = 10
-      this._val = 20
+      var val = 10
+      var _val = 20
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 4)
@@ -5207,8 +5270,8 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class C
-      this._val = 20
-      public this.val = 10
+      var _val = 20
+      public var val = 10
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 4)
@@ -5217,8 +5280,8 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class C
-      static s: string = "abc"
-      static _s: string = "def"
+      static var s: string = "abc"
+      static var _s: string = "def"
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _s', 4)
@@ -5227,8 +5290,8 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class C
-      public static s: string = "abc"
-      static _s: string = "def"
+      public static var s: string = "abc"
+      static var _s: string = "def"
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _s', 4)
@@ -5237,8 +5300,8 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class C
-      static val = 10
-      this.val = 20
+      static var val = 10
+      var val = 20
       def new()
       enddef
     endclass
@@ -5252,12 +5315,12 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class A
-      this.val = 10
+      var val = 10
     endclass
     class B extends A
     endclass
     class C extends B
-      this.val = 20
+      var val = 20
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 9)
@@ -5266,12 +5329,12 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class A
-      this._val = 10
+      var _val = 10
     endclass
     class B extends A
     endclass
     class C extends B
-      this._val = 20
+      var _val = 20
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 9)
@@ -5280,12 +5343,12 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class A
-      this.val = 10
+      var val = 10
     endclass
     class B extends A
     endclass
     class C extends B
-      this._val = 20
+      var _val = 20
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: _val', 9)
@@ -5294,12 +5357,12 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class A
-      this._val = 10
+      var _val = 10
     endclass
     class B extends A
     endclass
     class C extends B
-      this.val = 20
+      var val = 20
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1369: Duplicate variable: val', 9)
@@ -5308,8 +5371,8 @@ def Test_dup_member_variable()
   lines =<< trim END
     vim9script
     class A
-      public static svar2: number
-      public static svar: number
+      public static var svar2: number
+      public static var svar: number
     endclass
   END
   v9.CheckSourceSuccess(lines)
@@ -5321,7 +5384,7 @@ def Test_private_member_access_outside_class()
   var lines =<< trim END
     vim9script
     class A
-      this._val = 10
+      var _val = 10
       def GetVal(): number
         return this._val
       enddef
@@ -5338,7 +5401,7 @@ def Test_private_member_access_outside_class()
   lines =<< trim END
     vim9script
     class A
-      this._val = 10
+      var _val = 10
     endclass
     def T()
       var a = A.new()
@@ -5352,7 +5415,7 @@ def Test_private_member_access_outside_class()
   lines =<< trim END
     vim9script
     class A
-      static _val = 10
+      static var _val = 10
     endclass
     def T()
       var a = A.new()
@@ -5366,7 +5429,7 @@ def Test_private_member_access_outside_class()
   lines =<< trim END
     vim9script
     class A
-      static _val = 10
+      static var _val = 10
     endclass
     def T()
       var a = A.new()
@@ -5380,7 +5443,7 @@ def Test_private_member_access_outside_class()
   lines =<< trim END
     vim9script
     class A
-      static _val = 10
+      static var _val = 10
     endclass
     def T()
       var x = A._val
@@ -5393,7 +5456,7 @@ def Test_private_member_access_outside_class()
   lines =<< trim END
     vim9script
     class A
-      static _val = 10
+      static var _val = 10
     endclass
     def T()
       A._val = 3
@@ -5408,10 +5471,10 @@ def Test_change_interface_member_access()
   var lines =<< trim END
     vim9script
     interface A
-      this.val: number
+      var val: number
     endinterface
     class B implements A
-      public this.val = 10
+      public var val = 10
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1367: Access level of variable "val" of interface "A" is different', 7)
@@ -5419,10 +5482,10 @@ def Test_change_interface_member_access()
   lines =<< trim END
     vim9script
     interface A
-      this.val: number
+      var val: number
     endinterface
     class B implements A
-      public this.val = 10
+      public var val = 10
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1367: Access level of variable "val" of interface "A" is different', 7)
@@ -5433,7 +5496,7 @@ def Test_readonly_member_change_in_def_func()
   var lines =<< trim END
     vim9script
     class A
-      this.val: number
+      var val: number
     endclass
     def T()
       var a = A.new()
@@ -5449,10 +5512,10 @@ def Test_modify_class_member_from_def_function()
   var lines =<< trim END
     vim9script
     class A
-      this.var1: number = 10
-      public static var2: list<number> = [1, 2]
-      public static var3: dict<number> = {a: 1, b: 2}
-      static _priv_var4: number = 40
+      var var1: number = 10
+      public static var var2: list<number> = [1, 2]
+      public static var var3: dict<number> = {a: 1, b: 2}
+      static var _priv_var4: number = 40
     endclass
     def T()
       assert_equal([1, 2], A.var2)
@@ -5473,8 +5536,8 @@ def Test_class_variable_access_using_object()
   var lines =<< trim END
     vim9script
     class A
-      public static svar1: list<number> = [1]
-      public static svar2: list<number> = [2]
+      public static var svar1: list<number> = [1]
+      public static var svar2: list<number> = [2]
     endclass
 
     A.svar1->add(3)
@@ -5496,8 +5559,8 @@ def Test_class_variable_access_using_object()
   lines =<< trim END
     vim9script
     class A
-      public this.var1: number
-      public static svar2: list<number> = [1]
+      public var var1: number
+      public static var svar2: list<number> = [1]
     endclass
 
     var a = A.new()
@@ -5509,8 +5572,8 @@ def Test_class_variable_access_using_object()
   lines =<< trim END
     vim9script
     class A
-      public this.var1: number
-      public static svar2: list<number> = [1]
+      public var var1: number
+      public static var svar2: list<number> = [1]
     endclass
 
     var a = A.new()
@@ -5522,8 +5585,8 @@ def Test_class_variable_access_using_object()
   lines =<< trim END
     vim9script
     class A
-      public this.var1: number
-      public static svar2: list<number> = [1]
+      public var var1: number
+      public static var svar2: list<number> = [1]
     endclass
 
     def T()
@@ -5538,8 +5601,8 @@ def Test_class_variable_access_using_object()
   lines =<< trim END
     vim9script
     class A
-      public this.var1: number
-      public static svar2: list<number> = [1]
+      public var var1: number
+      public static var svar2: list<number> = [1]
     endclass
 
     def T()
@@ -5870,7 +5933,7 @@ def Test_class_variable()
     vim9script
 
     class A
-      public static val: number = 10
+      public static var val: number = 10
       static def ClassFunc()
         assert_equal(10, val)
       enddef
@@ -5905,7 +5968,7 @@ def Test_class_variable()
     vim9script
 
     class A
-      static val: number = 10
+      static var val: number = 10
     endclass
 
     class B extends A
@@ -5922,7 +5985,7 @@ def Test_class_variable()
     vim9script
 
     class A
-      static val: number = 10
+      static var val: number = 10
     endclass
 
     class B extends A
@@ -5939,7 +6002,7 @@ def Test_class_variable()
     vim9script
 
     class A
-      static val: number = 10
+      static var val: number = 10
     endclass
 
     class B extends A
@@ -5957,7 +6020,7 @@ def Test_class_variable()
     vim9script
 
     class A
-      static val: number = 10
+      static var val: number = 10
     endclass
 
     class B extends A
@@ -5975,7 +6038,7 @@ def Test_class_variable()
     vim9script
 
     class A
-      static val: number = 10
+      static var val: number = 10
     endclass
     var a = A.new()
     a.val = 20
@@ -5987,7 +6050,7 @@ def Test_class_variable()
     vim9script
 
     class A
-      static val: number = 10
+      static var val: number = 10
     endclass
     var a = A.new()
     var i = a.val
@@ -5999,7 +6062,7 @@ def Test_class_variable()
     vim9script
 
     class A
-      static val: number = 10
+      static var val: number = 10
     endclass
 
     def T()
@@ -6015,7 +6078,7 @@ def Test_class_variable()
     vim9script
 
     class A
-      static val: number = 10
+      static var val: number = 10
     endclass
     def T()
       var a = A.new()
@@ -6024,6 +6087,67 @@ def Test_class_variable()
     T()
   END
   v9.CheckSourceFailure(lines, 'E1375: Class variable "val" accessible only using class "A"', 2)
+
+  # Use old implicit var declaration syntax (without initialization)
+  lines =<< trim END
+    vim9script
+
+    class A
+      static val: number
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1368: Static must be followed by "var" or "def"', 4)
+
+  # Use old implicit var declaration syntax (with initialization)
+  lines =<< trim END
+    vim9script
+
+    class A
+      static val: number = 10
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1368: Static must be followed by "var" or "def"', 4)
+
+  # Use old implicit var declaration syntax (type inferred)
+  lines =<< trim END
+    vim9script
+
+    class A
+      static val = 10
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1368: Static must be followed by "var" or "def"', 4)
+
+  # Missing ":var" in "var" class variable declaration (without initialization)
+  lines =<< trim END
+    vim9script
+
+    class A
+      static var: number
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1329: Invalid class variable declaration: static var: number', 4)
+
+  # Missing ":var" in "var" class variable declaration (with initialization)
+  lines =<< trim END
+    vim9script
+
+    class A
+      static var: number = 10
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1329: Invalid class variable declaration: static var: number = 10', 4)
+
+  # Missing ":var" in "var" class variable declaration (type inferred)
+  lines =<< trim END
+    vim9script
+
+    class A
+      static var = 10
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1329: Invalid class variable declaration: static var = 10', 4)
+
 enddef
 
 " Test for using a duplicate class method and class variable in a child class
@@ -6032,7 +6156,7 @@ def Test_dup_class_member()
   var lines =<< trim END
     vim9script
     class A
-      static sval = 100
+      static var sval = 100
       static def Check()
         assert_equal(100, sval)
       enddef
@@ -6042,7 +6166,7 @@ def Test_dup_class_member()
     endclass
 
     class B extends A
-      static sval = 200
+      static var sval = 200
       static def Check()
         assert_equal(200, sval)
       enddef
@@ -6074,7 +6198,7 @@ def Test_dup_class_member()
   lines =<< trim END
     vim9script
     class A
-      static sval = 100
+      static var sval = 100
       static def Check()
         assert_equal(100, sval)
       enddef
@@ -6084,7 +6208,7 @@ def Test_dup_class_member()
     endclass
 
     class B extends A
-      static sval = 200
+      static var sval = 200
       static def Check()
         assert_equal(200, sval)
       enddef
@@ -6247,8 +6371,8 @@ def Test_extend_empty_class()
     class B extends A
     endclass
     class C extends B
-      public static rw_class_var = 1
-      public this.rw_obj_var = 2
+      public static var rw_class_var = 1
+      public var rw_obj_var = 2
       static def ClassMethod(): number
         return 3
       enddef
@@ -6271,7 +6395,7 @@ def Test_interface_with_unsupported_members()
   var lines =<< trim END
     vim9script
     interface A
-      static num: number
+      static var num: number
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface', 3)
@@ -6279,7 +6403,7 @@ def Test_interface_with_unsupported_members()
   lines =<< trim END
     vim9script
     interface A
-      static _num: number
+      static var _num: number
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface', 3)
@@ -6287,7 +6411,7 @@ def Test_interface_with_unsupported_members()
   lines =<< trim END
     vim9script
     interface A
-      public static num: number
+      public static var num: number
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E1387: Public variable not supported in an interface', 3)
@@ -6295,7 +6419,7 @@ def Test_interface_with_unsupported_members()
   lines =<< trim END
     vim9script
     interface A
-      public static num: number
+      public static var num: number
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E1387: Public variable not supported in an interface', 3)
@@ -6303,7 +6427,7 @@ def Test_interface_with_unsupported_members()
   lines =<< trim END
     vim9script
     interface A
-      static _num: number
+      static var _num: number
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E1378: Static member not supported in an interface', 3)
@@ -6327,7 +6451,7 @@ def Test_interface_with_unsupported_members()
   lines =<< trim END
     vim9script
     interface A
-      this._Foo: list<string>
+      var _Foo: list<string>
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E1379: Protected variable not supported in an interface', 3)
@@ -6346,18 +6470,18 @@ def Test_extend_interface()
   var lines =<< trim END
     vim9script
     interface A
-      this.var1: list<string>
+      var var1: list<string>
       def Foo()
     endinterface
     interface B extends A
-      this.var2: dict<string>
+      var var2: dict<string>
       def Bar()
     endinterface
     class C implements A, B
-      this.var1 = [1, 2]
+      var var1 = [1, 2]
       def Foo()
       enddef
-      this.var2 = {a: '1'}
+      var var2 = {a: '1'}
       def Bar()
       enddef
     endclass
@@ -6382,10 +6506,10 @@ def Test_extend_interface()
       def Foo()
     endinterface
     interface B extends A
-      this.var2: dict<string>
+      var var2: dict<string>
     endinterface
     class C implements A, B
-      this.var2 = {a: '1'}
+      var var2 = {a: '1'}
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1349: Method "Foo" of interface "A" is not implemented', 10)
@@ -6396,7 +6520,7 @@ def Test_extend_interface()
       def Foo()
     endinterface
     interface B extends A
-      this.var2: dict<string>
+      var var2: dict<string>
     endinterface
     class C implements A, B
       def Foo()
@@ -6451,14 +6575,14 @@ def Test_extend_interface()
   lines =<< trim END
     vim9script
     interface A
-      this.val1: number
+      var val1: number
     endinterface
     interface B extends A
-      this.val2: string
+      var val2: string
     endinterface
     interface C extends B
-      this.val1: string
-      this.val2: number
+      var val1: string
+      var val2: number
     endinterface
   END
   v9.CheckSourceFailure(lines, 'E1382: Variable "val1": type mismatch, expected number but got string', 11)
@@ -6474,9 +6598,9 @@ def Test_child_class_implements_interface()
       def F1(): list<list<number>>
       def F2(): list<list<number>>
       def F3(): list<list<number>>
-      this.var1: list<dict<number>>
-      this.var2: list<dict<number>>
-      this.var3: list<dict<number>>
+      var var1: list<dict<number>>
+      var var2: list<dict<number>>
+      var var3: list<dict<number>>
     endinterface
 
     class A
@@ -6485,8 +6609,8 @@ def Test_child_class_implements_interface()
       def F3(): list<list<number>>
         return [[3]]
       enddef
-      this.v1: list<list<number>> = [[0]]
-      this.var3 = [{c: 30}]
+      var v1: list<list<number>> = [[0]]
+      var var3 = [{c: 30}]
     endclass
 
     class B extends A
@@ -6495,8 +6619,8 @@ def Test_child_class_implements_interface()
       def F2(): list<list<number>>
         return [[2]]
       enddef
-      this.v2: list<list<number>> = [[0]]
-      this.var2 = [{b: 20}]
+      var v2: list<list<number>> = [[0]]
+      var var2 = [{b: 20}]
     endclass
 
     class C extends B implements Intf
@@ -6505,8 +6629,8 @@ def Test_child_class_implements_interface()
       def F1(): list<list<number>>
         return [[1]]
       enddef
-      this.v3: list<list<number>> = [[0]]
-      this.var1 = [{a: 10}]
+      var v3: list<list<number>> = [[0]]
+      var var1 = [{a: 10}]
     endclass
 
     def T(if: Intf)
@@ -6599,23 +6723,23 @@ def Test_child_class_implements_interface()
     vim9script
 
     interface Intf
-      this.var1: list<dict<number>>
-      this.var2: list<dict<number>>
-      this.var3: list<dict<number>>
+      var var1: list<dict<number>>
+      var var2: list<dict<number>>
+      var var3: list<dict<number>>
     endinterface
 
     class A
-      this.v1: list<list<number>> = [[0]]
+      var v1: list<list<number>> = [[0]]
     endclass
 
     class B extends A
-      this.v2: list<list<number>> = [[0]]
-      this.var2 = [{b: 20}]
+      var v2: list<list<number>> = [[0]]
+      var var2 = [{b: 20}]
     endclass
 
     class C extends B implements Intf
-      this.v3: list<list<number>> = [[0]]
-      this.var1 = [{a: 10}]
+      var v3: list<list<number>> = [[0]]
+      var var1 = [{a: 10}]
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1348: Variable "var3" of interface "Intf" is not implemented', 21)
@@ -6625,24 +6749,24 @@ def Test_child_class_implements_interface()
     vim9script
 
     interface Intf
-      this.var1: list<dict<number>>
-      this.var2: list<dict<number>>
-      this.var3: list<dict<number>>
+      var var1: list<dict<number>>
+      var var2: list<dict<number>>
+      var var3: list<dict<number>>
     endinterface
 
     class A
-      this.v1: list<list<number>> = [[0]]
-      this.var3: list<dict<string>>
+      var v1: list<list<number>> = [[0]]
+      var var3: list<dict<string>>
     endclass
 
     class B extends A
-      this.v2: list<list<number>> = [[0]]
-      this.var2 = [{b: 20}]
+      var v2: list<list<number>> = [[0]]
+      var var2 = [{b: 20}]
     endclass
 
     class C extends B implements Intf
-      this.v3: list<list<number>> = [[0]]
-      this.var1 = [{a: 10}]
+      var v3: list<list<number>> = [[0]]
+      var var1 = [{a: 10}]
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1382: Variable "var3": type mismatch, expected list<dict<number>> but got list<dict<string>>', 22)
@@ -6653,18 +6777,18 @@ def Test_interface_extends_with_dup_members()
   var lines =<< trim END
     vim9script
     interface A
-      this.n1: number
+      var n1: number
       def Foo1(): number
     endinterface
     interface B extends A
-      this.n2: number
-      this.n1: number
+      var n2: number
+      var n1: number
       def Foo2(): number
       def Foo1(): number
     endinterface
     class C implements B
-      this.n1 = 10
-      this.n2 = 20
+      var n1 = 10
+      var n2 = 20
       def Foo1(): number
         return 30
       enddef
@@ -6695,10 +6819,10 @@ def Test_implements_using_var_type_any()
   var lines =<< trim END
     vim9script
     interface A
-      this.val: list<dict<string>>
+      var val: list<dict<string>>
     endinterface
     class B implements A
-      this.val = [{a: '1'}, {b: '2'}]
+      var val = [{a: '1'}, {b: '2'}]
     endclass
     var b = B.new()
     assert_equal([{a: '1'}, {b: '2'}], b.val)
@@ -6709,10 +6833,10 @@ def Test_implements_using_var_type_any()
   lines =<< trim END
     vim9script
     interface A
-      this.val: list<dict<string>>
+      var val: list<dict<string>>
     endinterface
     class B implements A
-      this.val = {a: 1, b: 2}
+      var val = {a: 1, b: 2}
     endclass
     var b = B.new()
   END
@@ -6725,19 +6849,19 @@ def Test_nested_object_assignment()
     vim9script
 
     class A
-      this.value: number
+      var value: number
     endclass
 
     class B
-      this.a: A = A.new()
+      var a: A = A.new()
     endclass
 
     class C
-      this.b: B = B.new()
+      var b: B = B.new()
     endclass
 
     class D
-      this.c: C = C.new()
+      var c: C = C.new()
     endclass
 
     def T(da: D)
@@ -6837,7 +6961,7 @@ def Test_dict_object_member()
     vim9script
 
     class Context
-      public this.state: dict<number> = {}
+      public var state: dict<number> = {}
       def GetState(): dict<number>
         return this.state
       enddef
@@ -6896,8 +7020,8 @@ def Test_duplicate_variable()
   var lines =<< trim END
     vim9script
     class A
-      public static sval: number
-      public this.sval: number
+      public static var sval: number
+      public var sval: number
     endclass
     var a = A.new()
   END
@@ -6907,8 +7031,8 @@ def Test_duplicate_variable()
   lines =<< trim END
     vim9script
     class A
-      public static sval: number
-      public this.sval: number
+      public static var sval: number
+      public var sval: number
       def F1()
         echo this.sval
       enddef
@@ -6924,8 +7048,8 @@ def Test_duplicate_variable()
   lines =<< trim END
     vim9script
     class A
-      public static sval: number
-      public this.sval: number
+      public static var sval: number
+      public var sval: number
       def new()
       enddef
     endclass
@@ -6943,7 +7067,7 @@ def Test_reserved_varname()
     var lines =<< trim eval END
       vim9script
       class C
-        public this.{kword}: list<number> = [1, 2, 3]
+        public var {kword}: list<number> = [1, 2, 3]
       endclass
       var o = C.new()
     END
@@ -6952,7 +7076,7 @@ def Test_reserved_varname()
     lines =<< trim eval END
       vim9script
       class C
-        public this.{kword}: list<number> = [1, 2, 3]
+        public var {kword}: list<number> = [1, 2, 3]
         def new()
         enddef
       endclass
@@ -6963,7 +7087,7 @@ def Test_reserved_varname()
     lines =<< trim eval END
       vim9script
       class C
-        public this.{kword}: list<number> = [1, 2, 3]
+        public var {kword}: list<number> = [1, 2, 3]
         def new()
         enddef
         def F()
@@ -6980,7 +7104,7 @@ def Test_reserved_varname()
       lines =<< trim eval END
         vim9script
         class C
-          public static {kword}: list<number> = [1, 2, 3]
+          public static var {kword}: list<number> = [1, 2, 3]
         endclass
       END
       v9.CheckSourceFailure(lines, $'E1034: Cannot use reserved name {kword}', 3)
@@ -7113,7 +7237,7 @@ func Test_class_variable_complex_type_check()
       return {}
     enddef
     class A
-      public static Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
+      public static var Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
     endclass
     test_garbagecollect_now()
     A.Fn = "abc"
@@ -7128,7 +7252,7 @@ func Test_class_variable_complex_type_check()
       return {}
     enddef
     class A
-      public static Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
+      public static var Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
       def Bar()
         Fn = "abc"
       enddef
@@ -7147,7 +7271,7 @@ func Test_class_variable_complex_type_check()
       return {}
     enddef
     class A
-      public static Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
+      public static var Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
     endclass
     def Bar()
       A.Fn = "abc"
@@ -7165,7 +7289,7 @@ func Test_class_variable_complex_type_check()
       return {}
     enddef
     class A
-      public static Fn = Foo
+      public static var Fn = Foo
     endclass
     test_garbagecollect_now()
     A.Fn = "abc"
@@ -7180,7 +7304,7 @@ func Test_class_variable_complex_type_check()
       return {}
     enddef
     class A
-      public static Fn = Foo
+      public static var Fn = Foo
       def Bar()
         Fn = "abc"
       enddef
@@ -7199,7 +7323,7 @@ func Test_class_variable_complex_type_check()
       return {}
     enddef
     class A
-      public static Fn = Foo
+      public static var Fn = Foo
     endclass
     def Bar()
       A.Fn = "abc"
@@ -7216,8 +7340,8 @@ func Test_class_variable_complex_type_check()
       return {}
     enddef
     class A
-      public static Fn: any = Foo
-      public static Fn2: any
+      public static var Fn: any = Foo
+      public static var Fn2: any
     endclass
     test_garbagecollect_now()
     assert_equal('func(list<dict<blob>>): dict<list<blob>>', typename(A.Fn))
@@ -7240,8 +7364,8 @@ func Test_class_variable_complex_type_check()
       return {}
     enddef
     class A
-      public static Fn: any = Foo
-      public static Fn2: any
+      public static var Fn: any = Foo
+      public static var Fn2: any
 
       def Bar()
         assert_equal('func(list<dict<blob>>): dict<list<blob>>', typename(Fn))
@@ -7269,8 +7393,8 @@ func Test_class_variable_complex_type_check()
       return {}
     enddef
     class A
-      public static Fn: any = Foo
-      public static Fn2: any
+      public static var Fn: any = Foo
+      public static var Fn2: any
     endclass
 
     def Bar()
@@ -7292,7 +7416,7 @@ func Test_class_variable_complex_type_check()
   let lines =<< trim END
     vim9script
     class A
-      public static foo = [0z10, 0z20]
+      public static var foo = [0z10, 0z20]
     endclass
     assert_equal([0z10, 0z20], A.foo)
     A.foo = [0z30]
@@ -7313,7 +7437,7 @@ func Test_object_variable_complex_type_check()
       return {}
     enddef
     class A
-      public this.Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
+      public var Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
     endclass
     var a = A.new()
     test_garbagecollect_now()
@@ -7329,7 +7453,7 @@ func Test_object_variable_complex_type_check()
       return {}
     enddef
     class A
-      public this.Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
+      public var Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
       def Bar()
         this.Fn = "abc"
         this.Fn = Foo
@@ -7349,7 +7473,7 @@ func Test_object_variable_complex_type_check()
       return {}
     enddef
     class A
-      public this.Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
+      public var Fn: func(list<dict<blob>>): dict<list<blob>> = Foo
     endclass
     def Bar()
       var a = A.new()
@@ -7369,7 +7493,7 @@ func Test_object_variable_complex_type_check()
       return {}
     enddef
     class A
-      public this.Fn = Foo
+      public var Fn = Foo
     endclass
     var a = A.new()
     test_garbagecollect_now()
@@ -7385,7 +7509,7 @@ func Test_object_variable_complex_type_check()
       return {}
     enddef
     class A
-      public this.Fn = Foo
+      public var Fn = Foo
       def Bar()
         this.Fn = "abc"
         this.Fn = Foo
@@ -7405,7 +7529,7 @@ func Test_object_variable_complex_type_check()
       return {}
     enddef
     class A
-      public this.Fn = Foo
+      public var Fn = Foo
     endclass
     def Bar()
       var a = A.new()
@@ -7424,8 +7548,8 @@ func Test_object_variable_complex_type_check()
       return {}
     enddef
     class A
-      public this.Fn: any = Foo
-      public this.Fn2: any
+      public var Fn: any = Foo
+      public var Fn2: any
     endclass
 
     var a = A.new()
@@ -7450,8 +7574,8 @@ func Test_object_variable_complex_type_check()
       return {}
     enddef
     class A
-      public this.Fn: any = Foo
-      public this.Fn2: any
+      public var Fn: any = Foo
+      public var Fn2: any
 
       def Bar()
         assert_equal('func(list<dict<blob>>): dict<list<blob>>', typename(this.Fn))
@@ -7480,8 +7604,8 @@ func Test_object_variable_complex_type_check()
       return {}
     enddef
     class A
-      public this.Fn: any = Foo
-      public this.Fn2: any
+      public var Fn: any = Foo
+      public var Fn2: any
     endclass
 
     def Bar()
@@ -7508,7 +7632,7 @@ def Test_recursive_object_method_call()
   var lines =<< trim END
     vim9script
     class A
-      this.val: number = 0
+      var val: number = 0
       def Foo(): number
         if this.val >= 90
           return this.val
@@ -7528,7 +7652,7 @@ def Test_recursive_class_method_call()
   var lines =<< trim END
     vim9script
     class A
-      static val: number = 0
+      static var val: number = 0
       static def Foo(): number
         if val >= 90
           return val
@@ -7633,7 +7757,7 @@ def Test_op_and_assignment()
   var lines =<< trim END
     vim9script
     class A
-      public static val: list<number> = []
+      public static var val: list<number> = []
       static def Foo(): list<number>
         val += [1]
         return val
@@ -7654,7 +7778,7 @@ def Test_op_and_assignment()
   lines =<< trim END
     vim9script
     class A
-      public this.val: list<number> = []
+      public var val: list<number> = []
       def Foo(): list<number>
         this.val += [1]
         return this.val
@@ -7710,7 +7834,7 @@ def Test_object_funcref()
   lines =<< trim END
     vim9script
     class A
-      this.val: number
+      var val: number
       def Foo(): number
         return this.val
       enddef
@@ -7820,7 +7944,7 @@ def Test_object_funcref()
   lines =<< trim END
     vim9script
     class A
-      this.val: number
+      var val: number
       def Foo(): number
         return this.val
       enddef
@@ -7872,7 +7996,7 @@ def Test_class_funcref()
   lines =<< trim END
     vim9script
     class A
-      public static val: number
+      public static var val: number
       static def Foo(): number
         return val
       enddef
@@ -7976,7 +8100,7 @@ def Test_class_funcref()
   lines =<< trim END
     vim9script
     class A
-      public static val: number
+      public static var val: number
       static def Foo(): number
         return val
       enddef
@@ -8002,7 +8126,7 @@ def Test_object_member_funcref()
     enddef
 
     class A
-      this.Cb: func(number): number = Foo
+      var Cb: func(number): number = Foo
       def Bar()
         assert_equal(200, this.Cb(20))
       enddef
@@ -8021,7 +8145,7 @@ def Test_object_member_funcref()
     enddef
 
     class A
-      this.Cb: func(number): number = Foo
+      var Cb: func(number): number = Foo
     endclass
 
     def Bar()
@@ -8040,7 +8164,7 @@ def Test_object_member_funcref()
     enddef
 
     class A
-      this.Cb: func(number): number = Foo
+      var Cb: func(number): number = Foo
     endclass
 
     var a = A.new()
@@ -8053,7 +8177,7 @@ def Test_object_member_funcref()
   lines =<< trim END
     vim9script
     class A
-      this.Cb: func(number): number = this.Foo
+      var Cb: func(number): number = this.Foo
       def Foo(n: number): number
         return n * 10
       enddef
@@ -8072,7 +8196,7 @@ def Test_object_member_funcref()
   lines =<< trim END
     vim9script
     class A
-      this.Cb: func(number): number = this.Foo
+      var Cb: func(number): number = this.Foo
       def Foo(n: number): number
         return n * 10
       enddef
@@ -8091,7 +8215,7 @@ def Test_object_member_funcref()
   lines =<< trim END
     vim9script
     class A
-      this.Cb = this.Foo
+      var Cb = this.Foo
       def Foo(n: number): number
         return n * 10
       enddef
@@ -8113,7 +8237,7 @@ def Test_class_member_funcref()
     enddef
 
     class A
-      static Cb = Foo
+      static var Cb = Foo
       static def Bar()
         assert_equal(200, Cb(20))
       enddef
@@ -8131,7 +8255,7 @@ def Test_class_member_funcref()
     enddef
 
     class A
-      public static Cb = Foo
+      public static var Cb = Foo
     endclass
 
     def Bar()
@@ -8149,7 +8273,7 @@ def Test_class_member_funcref()
     enddef
 
     class A
-      public static Cb = Foo
+      public static var Cb = Foo
     endclass
 
     assert_equal(200, A.Cb(20))
@@ -8161,7 +8285,7 @@ def Test_class_member_funcref()
   lines =<< trim END
     vim9script
     class A
-      static Cb: func(number): number
+      static var Cb: func(number): number
       static def Foo(n: number): number
         return n * 10
       enddef
@@ -8182,7 +8306,7 @@ def Test_class_member_funcref()
   lines =<< trim END
     vim9script
     class A
-      static Cb: func(number): number
+      static var Cb: func(number): number
       static def Foo(n: number): number
         return n * 10
       enddef
@@ -8203,7 +8327,7 @@ def Test_class_member_funcref()
   lines =<< trim END
     vim9script
     class A
-      static Cb: func(number): number
+      static var Cb: func(number): number
       static def Foo(n: number): number
         return n * 10
       enddef
@@ -8225,8 +8349,8 @@ def Test_objmethod_popup_callback()
     vim9script
 
     class A
-      this.selection: number = -1
-      this.filterkeys: list<string> = []
+      var selection: number = -1
+      var filterkeys: list<string> = []
 
       def PopupFilter(id: number, key: string): bool
         add(this.filterkeys, key)
@@ -8261,8 +8385,8 @@ def Test_objmethod_popup_callback()
     vim9script
 
     class A
-      this.selection: number = -1
-      this.filterkeys: list<string> = []
+      var selection: number = -1
+      var filterkeys: list<string> = []
 
       def PopupFilter(id: number, key: string): bool
         add(this.filterkeys, key)
@@ -8303,8 +8427,8 @@ def Test_classmethod_popup_callback()
     vim9script
 
     class A
-      static selection: number = -1
-      static filterkeys: list<string> = []
+      static var selection: number = -1
+      static var filterkeys: list<string> = []
 
       static def PopupFilter(id: number, key: string): bool
         add(filterkeys, key)
@@ -8338,8 +8462,8 @@ def Test_classmethod_popup_callback()
     vim9script
 
     class A
-      static selection: number = -1
-      static filterkeys: list<string> = []
+      static var selection: number = -1
+      static var filterkeys: list<string> = []
 
       static def PopupFilter(id: number, key: string): bool
         add(filterkeys, key)
@@ -8379,7 +8503,7 @@ def Test_objmethod_timer_callback()
     vim9script
 
     class A
-      this.timerTick: number = -1
+      var timerTick: number = -1
       def TimerCb(timerID: number)
         this.timerTick = 6
       enddef
@@ -8401,7 +8525,7 @@ def Test_objmethod_timer_callback()
     vim9script
 
     class A
-      this.timerTick: number = -1
+      var timerTick: number = -1
       def TimerCb(timerID: number)
         this.timerTick = 6
       enddef
@@ -8429,7 +8553,7 @@ def Test_classmethod_timer_callback()
     vim9script
 
     class A
-      static timerTick: number = -1
+      static var timerTick: number = -1
       static def TimerCb(timerID: number)
         timerTick = 6
       enddef
@@ -8450,7 +8574,7 @@ def Test_classmethod_timer_callback()
     vim9script
 
     class A
-      static timerTick: number = -1
+      static var timerTick: number = -1
       static def TimerCb(timerID: number)
         timerTick = 6
       enddef
@@ -8476,11 +8600,11 @@ def Test_class_variable_as_operands()
   var lines =<< trim END
     vim9script
     class Tests
-      static truthy: bool = true
-      public static TruthyFn: func
-      static list: list<any> = []
-      static four: number = 4
-      static str: string = 'hello'
+      static var truthy: bool = true
+      public static var TruthyFn: func
+      static var list: list<any> = []
+      static var four: number = 4
+      static var str: string = 'hello'
 
       static def Str(): string
         return str
@@ -8581,7 +8705,7 @@ def Test_dict_member_key_type_check()
     vim9script
 
     abstract class State
-      this.numbers: dict<string> = {0: 'nil', 1: 'unity'}
+      var numbers: dict<string> = {0: 'nil', 1: 'unity'}
     endclass
 
     class Test extends State
@@ -8666,7 +8790,7 @@ def Test_dict_member_key_type_check()
     vim9script
 
     class A
-      this.numbers: dict<string> = {a: '1', b: '2'}
+      var numbers: dict<string> = {a: '1', b: '2'}
 
       def new()
       enddef
@@ -8686,7 +8810,7 @@ def Test_dict_member_key_type_check()
     vim9script
 
     class A
-      this.numbers: dict<number> = {a: 1, b: 2}
+      var numbers: dict<number> = {a: 1, b: 2}
 
       def new()
       enddef

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -3062,15 +3062,15 @@ def Test_disassemble_interface_static_member()
   var lines =<< trim END
     vim9script
     interface I
-      this.o_var: number
-      this.o_var2: number
+      var o_var: number
+      var o_var2: number
     endinterface
 
     class C implements I
-      public static s_var: number
-      this.o_var: number
-      public static s_var2: number
-      this.o_var2: number
+      public static var s_var: number
+      var o_var: number
+      public static var s_var2: number
+      var o_var2: number
     endclass
 
     def F1(i: I)
@@ -3124,7 +3124,7 @@ def Test_disassemble_class_variable()
     vim9script
 
     class A
-      public static val = 10
+      public static var val = 10
       def Foo(): number
         val = 20
         return val
@@ -3173,7 +3173,7 @@ def Test_disassemble_ifargnotset()
   var lines =<< trim END
     vim9script
     class A
-      this.val: number = 10
+      var val: number = 10
     endclass
     g:instr = execute('disassemble A.new')
   END

--- a/src/testdir/test_vim9_typealias.vim
+++ b/src/testdir/test_vim9_typealias.vim
@@ -393,7 +393,7 @@ def Test_typealias_import()
   lines =<< trim END
     vim9script
     export class MyClass
-      this.val = 10
+      var val = 10
     endclass
   END
   writefile(lines, 'Xtypeexport4.vim', 'D')
@@ -537,7 +537,7 @@ def Test_typealias_class()
   var lines =<< trim END
     vim9script
     class C
-      this.color = 'green'
+      var color = 'green'
     endclass
     type MyClass = C
     var o: MyClass = MyClass.new()

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1540,9 +1540,9 @@ early_ret:
 	    has_public = TRUE;
 	    p = skipwhite(line + 6);
 
-	    if (STRNCMP(p, "this", 4) != 0 && STRNCMP(p, "static", 6) != 0)
+	    if (STRNCMP(p, "var", 3) != 0 && STRNCMP(p, "static", 6) != 0)
 	    {
-		emsg(_(e_public_must_be_followed_by_this_or_static));
+		emsg(_(e_public_must_be_followed_by_var_or_static));
 		break;
 	    }
 	}
@@ -1597,29 +1597,38 @@ early_ret:
 	    }
 	    has_static = TRUE;
 	    p = skipwhite(ps + 6);
+
+	    if (STRNCMP(p, "var", 3) != 0 && STRNCMP(p, "def", 3) != 0)
+	    {
+		emsg(_(e_static_must_be_followed_by_var_or_def));
+		break;
+	    }
 	}
 
 	// object members (public, read access, private):
-	//	"this._varname"
-	//	"this.varname"
-	//	"public this.varname"
-	if (STRNCMP(p, "this", 4) == 0)
+	//	"var _varname"
+	//	"var varname"
+	//	"public var varname"
+	// class members (public, read access, private):
+	//	"static var _varname"
+	//	"static var varname"
+	//	"public static var varname"
+	if (checkforcmd(&p, "var", 3))
 	{
-	    if (p[4] != '.' || !eval_isnamec1(p[5]))
-	    {
-		semsg(_(e_invalid_object_variable_declaration_str), p);
-		break;
-	    }
-	    if (has_static)
-	    {
-		emsg(_(e_static_cannot_be_followed_by_this));
-		break;
-	    }
-	    char_u *varname = p + 5;
+	    char_u *varname = p;
 	    char_u *varname_end = NULL;
 	    type_T *type = NULL;
 	    char_u *init_expr = NULL;
 	    int	    has_type = FALSE;
+
+	    if (!eval_isnamec1(*p))
+	    {
+		if (has_static)
+		    semsg(_(e_invalid_class_variable_declaration_str), line);
+		else
+		    semsg(_(e_invalid_object_variable_declaration_str), line);
+		break;
+	    }
 
 	    if (!is_class && *varname == '_')
 	    {
@@ -1644,7 +1653,7 @@ early_ret:
 		vim_free(init_expr);
 		break;
 	    }
-	    if (add_member(&objmembers, varname, varname_end,
+	    if (add_member(has_static ? &classmembers : &objmembers, varname, varname_end,
 				has_public, has_type, type, init_expr) == FAIL)
 	    {
 		vim_free(init_expr);
@@ -1743,42 +1752,6 @@ early_ret:
 		    ((ufunc_T **)fgap->ga_data)[fgap->ga_len] = uf;
 		    ++fgap->ga_len;
 		}
-	    }
-	}
-
-	// class members
-	else if (has_static)
-	{
-	    // class members (public, read access, private):
-	    //	"static _varname"
-	    //	"static varname"
-	    //	"public static varname"
-	    char_u  *varname = p;
-	    char_u  *varname_end = NULL;
-	    int	    has_type = FALSE;
-	    type_T  *type = NULL;
-	    char_u  *init_expr = NULL;
-
-	    if (parse_member(eap, line, varname, has_public,
-		      &varname_end, &has_type, &type_list, &type,
-		      &init_expr) == FAIL)
-		break;
-	    if (is_reserved_varname(varname, varname_end))
-	    {
-		vim_free(init_expr);
-		break;
-	    }
-	    if (is_duplicate_variable(&classmembers, &objmembers, varname,
-								varname_end))
-	    {
-		vim_free(init_expr);
-		break;
-	    }
-	    if (add_member(&classmembers, varname, varname_end,
-			      has_public, has_type, type, init_expr) == FAIL)
-	    {
-		vim_free(init_expr);
-		break;
 	    }
 	}
 


### PR DESCRIPTION
This PR modifies the object and class variable declarations to require use of the :var keyword.

The current object/class variable declaration syntax is inconsistent with that used in other language contexts where `:var`, `:const`, or `:final` introduce variables.  It is also inconsistent with object/class method declarations which reuse the syntax employed for all other function declarations, i.e., `:def`.

Classes and interfaces are not special enough, as syntactic structures, to warrant these deviations.  Similar programming languages usually reuse their general variable declaration syntax for field declarations, and the small number that don't use a dedicated and internally consistent class syntax.

Aside, from being a needless deviation from the general syntax with no obvious benefit, it also introduces various syntactic oddities, as highlighted by the [proposed syntax for final object/class variables](13655).

I initially raised this topic in and around the first call for comments on Vim9 classes, as did others.  The last I heard was that it was still "under consideration" but, with the recent unfortunate developments, some of these decisions appear to have been implicitly crystallised without further discussion.  As I dislike the syntax as much now, having actually used it anger, as I did when I first saw it twelve months ago it seems worth raising again while there is still an opportunity to change it.

For reference this topic is covered in vim9class.txt under "Rationale" -> "Declaring object and class variables" and quoted at the end here for convenience.

### Current syntax

Object variables are currently declared with a specific syntax unused elsewhere in the language and are not introduced with the `var` keyword.

```vim
this.x: number
this.y: number = 42
this.z = 87
```

On the other hand methods are defined with exactly the same syntax used for functions in other contexts using `:def` and an unqualified name. The `this.` prefix is neither required nor allowed.

```vim
def Foo(): number
  return 42
enddef
```

This special object variable syntax is distinct even from that used for class variables.  These use a specific modifier keyword `static` and the declaration has the same shape as other declarations using `var`, `final` and `const`.

```vim
static x: number
static y: number = 42
static z = 87
```

This could, of course, be viewed as a modifier keyword for an implied `var` declaration. 

```vim
static {var} x: number
static def Y()
enddef
```

One might have expected class variable declarations to have used something more consistent with their object variable counterparts like the class name or another class-wide shared object as a prefix, but this was not chosen on the grounds that it was too cumbersome.

```vim
class Foo
  Foo.x : number = 42
endclass
```

### Other languages

Similar languages, most commonly, reuse their general variable syntax when declaring class fields. 

E.g., Swift (Kotlin, Scala and others): 

```swift
import Foundation

var foo: Int = 42

func bar() -> String {
    var baz: String = "Forty Two"
    return baz
}

class Qux {
    var quux: Int = 42
    func corge() -> Int {
        var grault: Int = 2
        return quux * grault
    }
}

let o = Qux()
print(o.corge())
```

E.g., Dart (Java, C# and others using a C-style syntax):

```dart
int foo = 42;

String bar() {
  String baz = "Forty Two";
  return baz;
}

class Qux {
  int quux = 42;
  int corge() {
    int grault = 2;
    return quux * grault;
  }
}

void main() {
  var o = Qux();
  print(o.corge());
}

```

A notable exception to this is TypeScript which Bram referenced when introducing this Vim9-script class syntax.

```typescript
var foo: number = 42

function bar(): string {
  var baz: string = "Forty Two"
  return baz
}

class Qux {
  quux: number = 42
  corge(): number {
    var grault: number = 2
    return this.quux * grault
  }
}

var o = new Qux()
console.log(o.corge())
```

However, here a different and consistent method declaration is used which would look like the following for Vim9 script, if based on the existing object variable syntax.

```vim
this.foo: number = 42
this.Bar(arg: number): number {
  return this.foo + arg
}
```

### Proposed change

Following common language trends and, arguably, user expectations Vim9 script should simply reuse the exiting variable declaration syntax.

```vim
class Demo
  static var quux: string = "Forty Two"
  static def Grault(): string
    return quux;
  enddef
  var foo: number = 42
  def Bar(arg: number): number
    return this.x + arg
  enddef
endclass
```

### Future issues

There is a TODO item (currently available as a draft PR) to allow for final object/class variables.  The proposed syntax, again, does not mirror the use of the `var` and `final` sibling keywords as used in other declaration contexts.

```vim
static final a: number
static b: number
final this.x: number
# final x: number
this.y: number
```

Even if the final object member declarations are not `this` qualified either choice will be inconsistent with one of the current method or variable declaration styles.  `final` also tends to read as a modifier keyword here in this context rather than a variable declaration keyword, as these were previously not needed for object/class variable declarations. E.g.,

```vim
final {var} this.x: number
```

Using `var` to declare object variables allows `final` to be included without any extra syntactic quirks.

```vim
class Demo
  static final a: number
  static var b: number
  final x: number
  var y: string
endclass
```

### Previous discussions

https://groups.google.com/g/vim_dev/c/MKbzhgqvSj8/m/CTpMTe5YDQAJ
https://groups.google.com/g/vim_dev/c/yYpFNUHdRho/m/xjgrKqMoBQAJ?pli=1

Bram proposed the current syntax, aware that some would see it as unnatural, and with what I consider an unconvincing argument.

> Notice that there is no "var" keyword. It's not needed to recognize the declaration. I can't think of a good reason to add "var" here, other than that a declaration would be expected to always have "var". Well, I don't have that expectation.

`var` is not needed to recognise a declaration in other contexts either and yet it _is_ required everywhere else.  I find it hard to see that a different syntax for object members has any utility at all.  It seems needlessly quirky.

He later softened his opinion when adding the following to the help below:

> There is no clear preference whether to use "var" or not.

This seems like reason enough not to introduce different syntax.  Unform syntax is a nice language feature and one of the strong aspects of the initial Vim9-script release.

> The two main reasons to leave it out are:
> 1. TypeScript, Java and other popular languages do not use it.

Actually Java _does_ use a the same syntax for fields and local variables.  It just uses a C-style syntax, without a keyword.
As already mentioned, TypeScript uses a dedicated and consistent class syntax for _both_ variable and method declarations.

> 2. Less clutter.

The redundant `this.` is at least as cluttering and doesn't clearly announce a declaration.  A type inferred object variable declaration is indistinguishable from a plain assignment.

The proposed change is also one character shorter.

Others have previously made these points and suggested this same change in the referenced discussions.

***

### Rationale (from doc/vim9class.txt)

> Declaring object and class variables
>
> The main choice is whether to use "var" as with variable declarations.
> TypeScript does not use it:
>         class Point {
>           x: number;
>           y = 0;
>         }
>
> Following that Vim object variables could be declared like this:
>         class Point
>           this.x: number
>           this.y = 0
>         endclass
>
> Some users pointed out that this looks more like an assignment than a
> declaration.  Adding "var" changes that:
>         class Point
>           var this.x: number
>           var this.y = 0
>         endclass
>
> We also need to be able to declare class variables using the "static" keyword.
> There we can also choose to leave out "var":
>         class Point
>           var this.x: number
>           static count = 0
>         endclass
>
> Or do use it, before "static":
>         class Point
>           var this.x: number
>           var static count = 0
>         endclass
>
> Or after "static":
>         class Point
>           var this.x: number
>           static var count = 0
>         endclass
>
> This is more in line with "static def Func()".
>
> There is no clear preference whether to use "var" or not.  The two main
> reasons to leave it out are:
> 1. TypeScript, Java and other popular languages do not use it.
> 2. Less clutter.

