### PR TITLE
configure.ac: Free the allocated memory

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -10136,8 +10136,11 @@ system ("touch conf.gtktest");
 tmp_version = g_strdup("$min_gtk_version");
 if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
    printf("%s, bad version string\n", "$min_gtk_version");
+   g_free(tmp_version);
    exit(1);
  }
+
+g_free(tmp_version);
 
 if ((gtk_major_version > major) ||
     ((gtk_major_version == major) && (gtk_minor_version > minor)) ||

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2700,8 +2700,11 @@ system ("touch conf.gtktest");
 tmp_version = g_strdup("$min_gtk_version");
 if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
    printf("%s, bad version string\n", "$min_gtk_version");
+   g_free(tmp_version);
    exit(1);
  }
+
+g_free(tmp_version);
 
 if ((gtk_major_version > major) ||
     ((gtk_major_version == major) && (gtk_minor_version > minor)) ||


### PR DESCRIPTION
If the memory is not freed, GTK GUI VIM cannot be build with address sanitizer for debugging purposes - configure script will report missing GTK, because the testing file compilation fails due reported memory leak.