### PR TITLE
CI: Fix i386 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
               libattr1-dev
             )
           fi
-          sudo apt-get update && sudo apt-get install -y "${PKGS[@]}"
+          sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y "${PKGS[@]}"
 
       - name: Install gcc-${{ env.GCC_VER }}
         if:  matrix.compiler == 'gcc'


### PR DESCRIPTION
Fix the following error:
```
The following packages have unmet dependencies:
 binutils : Conflicts: binutils:i386 but 2.38-4ubuntu2.4 is to be installed
 binutils:i386 : Conflicts: binutils but 2.38-4ubuntu2.3 is to be installed
 binutils-common : Breaks: binutils-common:i386 (!= 2.38-4ubuntu2.3) but 2.38-4ubuntu2.4 is to be installed
 binutils-common:i386 : Breaks: binutils-common (!= 2.38-4ubuntu2.4) but 2.38-4ubuntu2.3 is to be installed
 libbinutils : Breaks: libbinutils:i386 (!= 2.38-4ubuntu2.3) but 2.38-4ubuntu2.4 is to be installed
 libbinutils:i386 : Breaks: libbinutils (!= 2.38-4ubuntu2.4) but 2.38-4ubuntu2.3 is to be installed
 libctf0 : Breaks: libctf0:i386 (!= 2.38-4ubuntu2.3) but 2.38-4ubuntu2.4 is to be installed
 libctf0:i386 : Breaks: libctf0 (!= 2.38-4ubuntu2.4) but 2.38-4ubuntu2.3 is to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
```

Run `apt-get upgrade` before installing additional packages.