### PR TITLE
Moving tabpages during drop command may cause an endless loop

### DIFF
--- a/src/arglist.c
+++ b/src/arglist.c
@@ -983,6 +983,9 @@ arg_all_close_unused_windows(arg_all_state_T *aall)
 
     if (aall->had_tab > 0)
 	goto_tabpage_tp(first_tabpage, TRUE, TRUE);
+
+    // moving tabpages around in an autocommand may cause an endless loop
+    tabpage_move_disallowed++;
     for (;;)
     {
 	tpnext = curtab->tp_next;
@@ -1093,6 +1096,7 @@ arg_all_close_unused_windows(arg_all_state_T *aall)
 
 	goto_tabpage_tp(tpnext, TRUE, TRUE);
     }
+    tabpage_move_disallowed--;
 }
 
 /*

--- a/src/globals.h
+++ b/src/globals.h
@@ -792,8 +792,9 @@ EXTERN int	is_mac_terminal INIT(= FALSE);  // recognized Terminal.app
 #endif
 
 EXTERN int	autocmd_busy INIT(= FALSE);	// Is apply_autocmds() busy?
-EXTERN int	autocmd_no_enter INIT(= FALSE); // *Enter autocmds disabled
-EXTERN int	autocmd_no_leave INIT(= FALSE); // *Leave autocmds disabled
+EXTERN int	autocmd_no_enter INIT(= FALSE); // Buf/WinEnter autocmds disabled
+EXTERN int	autocmd_no_leave INIT(= FALSE); // Buf/WinLeave autocmds disabled
+EXTERN int	tabpage_move_disallowed INIT(= FALSE);  // moving tabpages around disallowed
 
 EXTERN int	modified_was_set;		// did ":set modified"
 EXTERN int	did_filetype INIT(= FALSE);	// FileType event found

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -903,4 +903,23 @@ func Test_tabpage_last_line()
   bwipe!
 endfunc
 
+" this was causing an endless loop
+func Test_tabpage_drop_tabmove()
+  augroup TestTabpageTabmove
+    au!
+    autocmd! TabEnter * :if tabpagenr() > 1 | tabmove - | endif
+  augroup end
+  $tab drop XTab_99.log
+  $tab drop XTab_98.log
+  $tab drop XTab_97.log
+
+  autocmd! TestTabpageTabmove
+  augroup! TestTabpageTabmove
+
+  " clean up
+  bwipe!
+  bwipe!
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -4970,6 +4970,9 @@ tabpage_move(int nr)
     if (first_tabpage->tp_next == NULL)
 	return;
 
+    if (tabpage_move_disallowed)
+	return;
+
     for (tp = first_tabpage; tp->tp_next != NULL && n < nr; tp = tp->tp_next)
 	++n;
 


### PR DESCRIPTION
When executing a :tab drop command, Vim will close all windows not in the argument list. This triggers various autocommands. If a user has now created a 'au Tabenter * :tabmove -' autocommand, this can cause Vim to end up in an endless loop, when trying to iterate over all tabs (which would trigger the tabmove autocommand, which will change the tpnext pointer, etc).

So instead of blocking all autocommands specifically before we actually try to edit the given file, let simply disallow to move tabpages around. Otherwise, we may change the expected number of events triggered during a :drop command, which users may rely on (there is actually a test, that expects various TabLeave/TabEnter autocommands) and would therefore be a backwards incompatible change.

Don't cause an error, as this could trigger several times during the drop command, but silently ignore the :tabmove command in this case (and it should in fact finally trigger successfully when loading the given file in a new tab). So let's just be quiet here.

fixes: #13676