### PR TITLE
Add keymap completion

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3566,6 +3566,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		help		help subjects
 		highlight	highlight groups
 		history		|:history| suboptions
+		keymap		keyboard mappings
 		locale		locale names (as output of locale -a)
 		mapclear	buffer argument
 		mapping		mapping name

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1629,6 +1629,7 @@ completion can be enabled:
 	-complete=help		help subjects
 	-complete=highlight	highlight groups
 	-complete=history	:history suboptions
+	-complete=keymap	keyboard mappings
 	-complete=locale	locale names (as output of locale -a)
 	-complete=mapclear	buffer argument
 	-complete=mapping	mapping name

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -50,6 +50,7 @@ cmdline_fuzzy_completion_supported(expand_T *xp)
 	    && xp->xp_context != EXPAND_FILES_IN_PATH
 	    && xp->xp_context != EXPAND_FILETYPE
 	    && xp->xp_context != EXPAND_HELP
+	    && xp->xp_context != EXPAND_KEYMAP
 	    && xp->xp_context != EXPAND_OLD_SETTING
 	    && xp->xp_context != EXPAND_STRING_SETTING
 	    && xp->xp_context != EXPAND_SETTING_SUBTRACT
@@ -1394,6 +1395,7 @@ addstar(
 		|| context == EXPAND_COMPILER
 		|| context == EXPAND_OWNSYNTAX
 		|| context == EXPAND_FILETYPE
+		|| context == EXPAND_KEYMAP
 		|| context == EXPAND_PACKADD
 		|| context == EXPAND_RUNTIME
 		|| ((context == EXPAND_TAGS_LISTFILES
@@ -3131,6 +3133,13 @@ ExpandFromContext(
 	char *directories[] = {"syntax", "indent", "ftplugin", NULL};
 	return ExpandRTDir(pat, 0, numMatches, matches, directories);
     }
+#ifdef FEAT_KEYMAP
+    if (xp->xp_context == EXPAND_KEYMAP)
+    {
+	char *directories[] = {"keymap", NULL};
+	return ExpandRTDir(pat, 0, numMatches, matches, directories);
+    }
+#endif
 #if defined(FEAT_EVAL)
     if (xp->xp_context == EXPAND_USER_LIST)
 	return ExpandUserList(xp, matches, numMatches);

--- a/src/option.c
+++ b/src/option.c
@@ -7412,6 +7412,13 @@ set_context_in_set_cmd(
 	xp->xp_context = EXPAND_FILETYPE;
 	return;
     }
+#ifdef FEAT_KEYMAP
+    if (options[opt_idx].var == (char_u *)&p_keymap)
+    {
+	xp->xp_context = EXPAND_KEYMAP;
+	return;
+    }
+#endif
 
     // Now pick. If the option has a custom expander, use that. Otherwise, just
     // fill with the existing option value.

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -545,6 +545,13 @@ func Test_getcompletion()
   let l = getcompletion('horse', 'filetype')
   call assert_equal([], l)
 
+  if has('keymap')
+    let l = getcompletion('acc', 'keymap')
+    call assert_true(index(l, 'accents') >= 0)
+    let l = getcompletion('nullkeymap', 'keymap')
+    call assert_equal([], l)
+  endif
+
   let l = getcompletion('z', 'syntax')
   call assert_true(index(l, 'zimbu') >= 0)
   let l = getcompletion('emacs', 'syntax')

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -435,6 +435,14 @@ func Test_set_completion()
   call assert_equal('"set syntax=sshdconfig', @:)
   call feedkeys(":set syntax=a\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set syntax=' .. getcompletion('a*', 'syntax')->join(), @:)
+
+  if has('keymap')
+    " Expand values for 'keymap'
+    call feedkeys(":set keymap=acc\<Tab>\<C-B>\"\<CR>", 'xt')
+    call assert_equal('"set keymap=accents', @:)
+    call feedkeys(":set keymap=a\<C-A>\<C-B>\"\<CR>", 'xt')
+    call assert_equal('"set keymap=' .. getcompletion('a*', 'keymap')->join(), @:)
+  endif
 endfunc
 
 " Test handling of expanding individual string option values

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -73,6 +73,9 @@ static struct
     {EXPAND_HELP, "help"},
     {EXPAND_HIGHLIGHT, "highlight"},
     {EXPAND_HISTORY, "history"},
+#if defined(FEAT_KEYMAP)
+    {EXPAND_KEYMAP, "keymap"},
+#endif
 #if defined(HAVE_LOCALE_H) || defined(X_LOCALE)
     {EXPAND_LOCALES, "locale"},
 #endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -841,6 +841,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define EXPAND_SETTING_SUBTRACT	55
 #define EXPAND_ARGOPT		56
 #define EXPAND_TERMINALOPT	57
+#define EXPAND_KEYMAP		58
 
 // Values for exmode_active (0 is no exmode)
 #define EXMODE_NORMAL		1


### PR DESCRIPTION
Problem:  Keymap completion is not available.
Solution: Add keymap completion.

Add keymap completion to the 'keymap' option, user commands and builtin
completion functions.
