### PR TITLE
Only reload colorscheme when bg is changed

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -997,11 +997,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	what the background color looks like.  For changing the background
 	color, see |:hi-normal|.
 
-	When 'background' is set Vim will adjust the default color groups for
-	the new value.  But the colors used for syntax highlighting will not
-	change.					*g:colors_name*
+	When 'background' is changed Vim will adjust the default color groups
+	for the new value.  But the colors used for syntax highlighting will
+	not change.					*g:colors_name*
 	When a color scheme is loaded (the "g:colors_name" variable is set)
-	setting 'background' will cause the color scheme to be reloaded.  If
+	changing 'background' will cause the color scheme to be reloaded.  If
 	the color scheme adjusts to the value of 'background' this will work.
 	However, if the color scheme sets 'background' itself the effect may
 	be undone.  First delete the "g:colors_name" variable when needed.

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1050,10 +1050,14 @@ expand_set_ambiwidth(optexpand_T *args, int *numMatches, char_u ***matches)
  * The 'background' option is changed.
  */
     char *
-did_set_background(optset_T *args UNUSED)
+did_set_background(optset_T *args)
 {
     if (check_opt_strings(p_bg, p_bg_values, FALSE) == FAIL)
 	return e_invalid_argument;
+
+    if (args->os_oldval.string != NULL && args->os_oldval.string[0] == *p_bg)
+	// Value was not changed
+	return NULL;
 
 #ifdef FEAT_EVAL
     int dark = (*p_bg == 'd');


### PR DESCRIPTION
Currently the highlight groups are re-initialized and the colorscheme
(if any) is reloaded anytime 'background' is set, even if it is not
changed. This is unnecessary, because if the value was not changed then
there is no need to change highlight groups or do anything with the
colorscheme. Instead, only reload the colorscheme if the value of
'background' was actually changed.
