### PR TITLE
reg_executing() returns wrong result in :normal with range

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1377,7 +1377,7 @@ EXTERN int ex_no_reprint INIT(= FALSE); // no need to print after z or p
 EXTERN int reg_recording INIT(= 0);	// register for recording  or zero
 EXTERN int reg_executing INIT(= 0);	// register being executed or zero
 // Flag set when peeking a character and found the end of executed register
-EXTERN int pending_end_reg_executing INIT(= 0);
+EXTERN int pending_end_reg_executing INIT(= FALSE);
 
 // Set when a modifyOtherKeys sequence was seen, then simplified mappings will
 // no longer be used.  To be combined with modify_otherkeys_state.

--- a/src/register.c
+++ b/src/register.c
@@ -703,6 +703,7 @@ do_execreg(
 		return FAIL;
 	}
 	reg_executing = regname == 0 ? '"' : regname; // disable "q" command
+	pending_end_reg_executing = FALSE;
     }
     return retval;
 }

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -840,6 +840,23 @@ func Test_end_reg_executing()
   bwipe!
 endfunc
 
+func Test_reg_executing_in_range_normal()
+  new
+  set showcmd
+  call setline(1, range(10))
+  let g:log = []
+  nnoremap s <Cmd>let g:log += [reg_executing()]<CR>
+  let @r = 's'
+
+  %normal @r
+  call assert_equal(repeat(['r'], 10), g:log)
+
+  nunmap s
+  unlet g:log
+  set showcmd&
+  bwipe!
+endfunc
+
 " An operator-pending mode mapping shouldn't be applied to keys typed in
 " Insert mode immediately after a character search when replaying.
 func Test_replay_charsearch_omap()


### PR DESCRIPTION
Problem:  reg_executing() returns wrong result in :normal with range
          when 'showcmd' is set (after 8.2.4705).
Solution: Reset "pending_end_reg_executing" when executing a register.
