### PR TITLE
Wrong cursor position when dragging out of window

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -2050,7 +2050,9 @@ retnomove:
 	}
     }
 
-    if (prev_row >= 0 && prev_row < Rows && prev_col >= 0 && prev_col <= Columns
+    if (prev_row >= W_WINROW(curwin)
+	&& prev_row < W_WINROW(curwin) + curwin->w_height
+	&& prev_col >= curwin->w_wincol && prev_col < W_ENDCOL(curwin)
 						       && ScreenLines != NULL)
     {
 	int off = LineOffset[prev_row] + prev_col;

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1585,6 +1585,41 @@ func Test_Visual_r_CTRL_C()
   call feedkeys("\<c-v>$gr\<c-c>", 'tx')
   call assert_equal([''], getline(1, 1))
   bw!
-endfu
+endfunc
+
+func Test_visual_drag_out_of_window()
+  rightbelow vnew
+  call setline(1, '123456789')
+  set mouse=a
+  func ClickExpr(off)
+    call test_setmouse(1, getwininfo(win_getid())[0].wincol + a:off)
+    return "\<LeftMouse>"
+  endfunc
+  func DragExpr(off)
+    call test_setmouse(1, getwininfo(win_getid())[0].wincol + a:off)
+    return "\<LeftDrag>"
+  endfunc
+
+  nnoremap <expr> <F2> ClickExpr(5)
+  nnoremap <expr> <F3> DragExpr(-1)
+  redraw
+  call feedkeys("\<F2>\<F3>\<LeftRelease>", 'tx')
+  call assert_equal([1, 6], [col('.'), col('v')])
+  call feedkeys("\<Esc>", 'tx')
+
+  nnoremap <expr> <F2> ClickExpr(6)
+  nnoremap <expr> <F3> DragExpr(-2)
+  redraw
+  call feedkeys("\<F2>\<F3>\<LeftRelease>", 'tx')
+  call assert_equal([1, 7], [col('.'), col('v')])
+  call feedkeys("\<Esc>", 'tx')
+
+  nunmap <F2>
+  nunmap <F3>
+  delfunc ClickExpr
+  delfunc DragExpr
+  set mouse&
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Wrong cursor position when dragging out of window.
Solution: Don't use ScreenCols[] when mouse is not in current window.

Fix #13705
