### PR TITLE
CI: change dependabot prefix to "CI"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "CI"


### PR DESCRIPTION
The default prefix of dependabot is "build(deps)".  Change it to "CI".

Ref https://github.com/vim/vim/commit/c1c3b83816c8e22c9a710fb0c0cebc180ee6ce1e which used "CI" prefix.