### PR TITLE
Add missing error messages.

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3574,8 +3574,10 @@ EXTERN char e_cannot_change_readonly_variable_str_in_class_str[]
 	INIT(= N_("E1409: Cannot change read-only variable \"%s\" in class \"%s\""));
 EXTERN char e_const_variable_not_supported_in_interface[]
 	INIT(= N_("E1410: Const variable not supported in an interface"));
+EXTERN char e_missing_dot_after_object_str[]
+	INIT(= N_("E1411: Missing dot after object \"%s\""));
 #endif
-// E1411 - E1499 unused (reserved for Vim9 class support)
+// E1412 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -3174,6 +3174,31 @@ def Test_type_check()
     END
     v9.CheckSourceSuccess(lines)
   endif
+
+  lines =<< trim END
+    vim9script
+    class A
+    endclass
+
+    def F()
+      A += 3
+    enddef
+    F()
+  END
+  v9.CheckScriptFailure(lines, 'E1405: Class "A" cannot be used as a value')
+
+  lines =<< trim END
+    vim9script
+    class A
+    endclass
+
+    var o = A.new()
+    def F()
+      o += 4
+    enddef
+    F()
+  END
+  v9.CheckScriptFailure(lines, 'E1411: Missing dot after object "o"')
 enddef
 
 " Test for checking the argument type of a def function

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2265,7 +2265,10 @@ compile_load_lhs_with_index(lhs_T *lhs, char_u *var_start, cctx_T *cctx)
 	// Also for "obj.value".
        char_u *dot = vim_strchr(var_start, '.');
        if (dot == NULL)
+       {
+	   semsg(_(e_missing_dot_after_object_str), lhs->lhs_name);
 	   return FAIL;
+       }
 
 	class_T	*cl = lhs->lhs_type->tt_class;
 	type_T	*type = oc_member_type(cl, TRUE, dot + 1,
@@ -2294,7 +2297,10 @@ compile_load_lhs_with_index(lhs_T *lhs, char_u *var_start, cctx_T *cctx)
 	// "<classname>.value": load class variable "classname.value"
        char_u *dot = vim_strchr(var_start, '.');
        if (dot == NULL)
+       {
+	   check_type_is_value(lhs->lhs_type);
 	   return FAIL;
+       }
 
 	class_T	*cl = lhs->lhs_type->tt_class;
 	ocmember_T *m = class_member_lookup(cl, dot + 1,


### PR DESCRIPTION
The two lines in error don't output an error message
```
vim9script
class A
endclass

var o = A.new()
def F()
    A += 3  # produces generic message
    o += 4  # produces generic message
enddef
F()
```
Give this generic message
```
E1028: Compiling :def function failed
```

With this PR, get the messages
```
E1405: Class "A" cannot be used as a value
E1411: Missing dot after object "o"
```

