### PR TITLE
Maximum callback depth is not configurable

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -1,4 +1,4 @@
-*message.txt*   For Vim version 9.0.  Last change: 2023 Nov 08
+*message.txt*   For Vim version 9.0.  Last change: 2023 Dec 20
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -135,8 +135,6 @@ This happens when an Ex command executes an Ex command that executes an Ex
 command, etc.  The limit is 200 or the value of 'maxfuncdepth', whatever is
 larger.  When it's more there probably is an endless loop.  Probably a
 |:execute| or |:source| command is involved.
-Can also happen with a recursive callback function (|job-callback|).
-A limit of 20 is used here.
 
 							*E254*
   Cannot allocate color {name} ~

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.0.  Last change: 2023 Dec 16
+*options.txt*	For Vim version 9.0.  Last change: 2023 Dec 20
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -5477,6 +5477,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Increasing this limit above 200 also changes the maximum for Ex
 	command recursion, see |E169|.
 	See also |:function|.
+	Also used for maximum depth of callback functions.
 
 						*'maxmapdepth'* *'mmd'* *E223*
 'maxmapdepth' 'mmd'	number	(default 1000)

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4206,10 +4206,13 @@ func Test_popupwin_with_error()
 endfunc
 
 func Test_popup_close_callback_recursive()
+  set maxfuncdepth=20
   " this invokes the callback recursively
   let winid = popup_create('something', #{callback: 'popup_close'})
   redraw
-  call assert_fails('call popup_close(winid)', 'E169')
+  call assert_fails('call popup_close(winid)', 'E169:')
+
+  set maxfuncdepth&
 endfunc
 
 " vim: shiftwidth=2 sts=2

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -14,9 +14,6 @@
 #include "vim.h"
 
 #if defined(FEAT_EVAL) || defined(PROTO)
-
-#define MAX_CALLBACK_DEPTH 20
-
 /*
  * All user-defined functions are found in this hashtable.
  */
@@ -3603,7 +3600,7 @@ call_callback(
     if (callback->cb_name == NULL || *callback->cb_name == NUL)
 	return FAIL;
 
-    if (callback_depth > MAX_CALLBACK_DEPTH)
+    if (callback_depth > p_mfd)
     {
 	emsg(_(e_command_too_recursive));
 	return FAIL;


### PR DESCRIPTION
Problem:  Maximum callback depth is not configurable.
Solution: Revert patch 9.0.2103.  Set 'maxfuncdepth' in test.

Fix #13732
