### PR TITLE
Reserve the double underscore prefix for class/object method names for future use

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -364,6 +364,9 @@ super class.  Depending on the class where the member is used the
 corresponding class member will be used.  The type of the class member in a
 child class can be different from that in the super class.
 
+The double underscore (__) prefix for a class or object method name is
+reserved for future use.
+
 					*object-final-variable* *E1409*
 The |:final| keyword can be used to make a class or object variable a
 constant.  Examples: >

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -9659,4 +9659,31 @@ def Test_const_class_object_variable()
   v9.CheckSourceFailure(lines, 'E1022: Type or initialization required', 3)
 enddef
 
+" Test for using double underscore prefix in a class/object method name.
+def Test_method_double_underscore_prefix()
+  # class method
+  var lines =<< trim END
+    vim9script
+    class A
+      static def __foo()
+        echo "foo"
+      enddef
+    endclass
+    defcompile
+  END
+  v9.CheckSourceFailure(lines, 'E1034: Cannot use reserved name __foo()', 3)
+
+  # object method
+  lines =<< trim END
+    vim9script
+    class A
+      def __foo()
+        echo "foo"
+      enddef
+    endclass
+    defcompile
+  END
+  v9.CheckSourceFailure(lines, 'E1034: Cannot use reserved name __foo()', 3)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1774,6 +1774,15 @@ early_ret:
 		break;
 	    }
 
+	    if (*p == '_' && *(p + 1) == '_')
+	    {
+		// double underscore prefix for a method name is currently
+		// reserved.  This could be used in the future to support
+		// object methods called by Vim builtin functions.
+		semsg(_(e_cannot_use_reserved_name_str), p);
+		break;
+	    }
+
 	    CLEAR_FIELD(ea);
 	    ea.cmd = line;
 	    ea.arg = p;

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2263,12 +2263,12 @@ compile_load_lhs_with_index(lhs_T *lhs, char_u *var_start, cctx_T *cctx)
 	// "this.value": load "this" object and get the value at index for an
 	// object or class member get the type of the member.
 	// Also for "obj.value".
-       char_u *dot = vim_strchr(var_start, '.');
-       if (dot == NULL)
-       {
-	   semsg(_(e_missing_dot_after_object_str), lhs->lhs_name);
-	   return FAIL;
-       }
+	char_u *dot = vim_strchr(var_start, '.');
+	if (dot == NULL)
+	{
+	    semsg(_(e_missing_dot_after_object_str), lhs->lhs_name);
+	    return FAIL;
+	}
 
 	class_T	*cl = lhs->lhs_type->tt_class;
 	type_T	*type = oc_member_type(cl, TRUE, dot + 1,
@@ -2295,12 +2295,12 @@ compile_load_lhs_with_index(lhs_T *lhs, char_u *var_start, cctx_T *cctx)
     else if (lhs->lhs_type->tt_type == VAR_CLASS)
     {
 	// "<classname>.value": load class variable "classname.value"
-       char_u *dot = vim_strchr(var_start, '.');
-       if (dot == NULL)
-       {
-	   check_type_is_value(lhs->lhs_type);
-	   return FAIL;
-       }
+	char_u *dot = vim_strchr(var_start, '.');
+	if (dot == NULL)
+	{
+	    check_type_is_value(lhs->lhs_type);
+	    return FAIL;
+	}
 
 	class_T	*cl = lhs->lhs_type->tt_class;
 	ocmember_T *m = class_member_lookup(cl, dot + 1,


### PR DESCRIPTION

The PR https://github.com/vim/vim/pull/13238 for supporting builtin functions like len() for Vim9 objects is still under discussion.
For now, reserve the double underscore prefix for class/object method names for future use.  After the Vim9.1 release, we can
either decide to use the double underscore prefix or unreserve it.

While at this, also fix a code indentation issue.
