### PR TITLE
Avoid `prevwin == curwin` when closing `curwin`

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -131,6 +131,64 @@ func Test_window_quit()
   bw Xa Xb
 endfunc
 
+func Test_window_curwin_not_prevwin()
+  botright split
+  call assert_equal(2, winnr())
+  call assert_equal(1, winnr('#'))
+  quit
+  call assert_equal(1, winnr())
+  call assert_equal(0, winnr('#'))
+
+  botright split
+  botright split
+  call assert_equal(3, winnr())
+  call assert_equal(2, winnr('#'))
+  1quit
+  call assert_equal(2, winnr())
+  call assert_equal(1, winnr('#'))
+
+  botright split
+  call assert_equal(1, tabpagenr())
+  call assert_equal(3, winnr())
+  call assert_equal(2, winnr('#'))
+  wincmd T
+  call assert_equal(2, tabpagenr())
+  call assert_equal(1, winnr())
+  call assert_equal(0, winnr('#'))
+  tabfirst
+  call assert_equal(1, tabpagenr())
+  call assert_equal(2, winnr())
+  call assert_equal(0, winnr('#'))
+
+  tabonly
+  botright split
+  wincmd t
+  wincmd p
+  call assert_equal(3, winnr())
+  call assert_equal(1, winnr('#'))
+  quit
+  call assert_equal(2, winnr())
+  call assert_equal(1, winnr('#'))
+
+  botright split
+  wincmd t
+  wincmd p
+  call assert_equal(1, tabpagenr())
+  call assert_equal(3, winnr())
+  call assert_equal(1, winnr('#'))
+  wincmd T
+  call assert_equal(2, tabpagenr())
+  call assert_equal(1, winnr())
+  call assert_equal(0, winnr('#'))
+  tabfirst
+  call assert_equal(1, tabpagenr())
+  call assert_equal(2, winnr())
+  call assert_equal(1, winnr('#'))
+
+  tabonly
+  only
+endfunc
+
 func Test_window_horizontal_split()
   call assert_equal(1, winnr('$'))
   3wincmd s

--- a/src/window.c
+++ b/src/window.c
@@ -5381,11 +5381,15 @@ win_enter_ext(win_T *wp, int flags)
     // may have to copy the buffer options when 'cpo' contains 'S'
     if (wp->w_buffer != curbuf)
 	buf_copy_options(wp->w_buffer, BCO_ENTER | BCO_NOHELP);
+
     if (curwin_invalid == 0)
     {
 	prevwin = curwin;	// remember for CTRL-W p
 	curwin->w_redr_status = TRUE;
     }
+    else if (wp == prevwin)
+	prevwin = NULL;		// don't want it to be the new curwin
+
     curwin = wp;
     curbuf = wp->w_buffer;
     check_cursor();


### PR DESCRIPTION
Problem: When closing the current window (or when moving it to a tabpage), the
previous window may refer to the new current window (`winnr() == winnr('#')`) if
that window is selected as the new current window (due to the layout).

Solution: Set `prevwin = NULL` when switching away from an invalid `curwin` and
the target window was the `prevwin`.

_Or maybe the behaviour should just be documented instead?_

---

#4537 briefly touched on the issue, but the answer didn't address the `prevwin == curwin` oddity.

Note that it may be more consistent to *always* clear `prevwin` when closing `curwin`, as closing
`curwin` must have meant we switched away from it to have a valid new `curwin`, making it the real
previous window.

However, that may be too aggressive; for example, one may want to jump to a different window, do stuff,
close it, then use `<C-W>p` to return to the original window (as the new curwin Vim chose after closing may
not be the original, depending on which window fills the space).