### PR TITLE
runtime(c): Highlight user defined functions

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1022,6 +1022,8 @@ Variable		Highlight ~
 *c_no_c99*		don't highlight C99 standard items
 *c_no_c11*		don't highlight C11 standard items
 *c_no_bsd*		don't highlight BSD specific types
+*c_functions*		highlight function calls and definitions
+*c_function_pointers*	highlight function pointers definitions
 
 When 'foldmethod' is set to "syntax" then /* */ comments and { } blocks will
 become a fold.  If you don't want comments to become a fold use: >

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -444,6 +444,14 @@ syn match	cUserLabel	display "\I\i*" contained
 syn match	cBitField	display "^\s*\zs\I\i*\s*:\s*[1-9]"me=e-1 contains=cType
 syn match	cBitField	display ";\s*\zs\I\i*\s*:\s*[1-9]"me=e-1 contains=cType
 
+if exists("c_functions")
+  syn match cFunction "\<\h\w*\ze\_s*("
+ endif
+
+if exists("c_function_pointers")
+  syn match cFunctionPointer "\%((\s*\*\s*\)\@<=\h\w*\ze\s*)\_s*(.*)"
+endif
+
 if exists("c_minlines")
   let b:c_minlines = c_minlines
 else
@@ -513,6 +521,8 @@ hi def link cCppOutSkip		cCppOutIf2
 hi def link cCppInElse2		cCppOutIf2
 hi def link cCppOutIf2		cCppOut
 hi def link cCppOut		Comment
+hi def link cFunction		Function
+hi def link cFunctionPointer	Function
 
 let b:current_syntax = "c"
 


### PR DESCRIPTION
Hi,
This PR makes the syntax matches, by default, all function calls and definitions, and make them link to `Function`. This behavior can be disabled by setting the variable `c_no_user_functions`.