### PR TITLE
runtime(elixir): fix indentation

### DIFF
--- a/runtime/ftplugin/elixir.vim
+++ b/runtime/ftplugin/elixir.vim
@@ -1,7 +1,7 @@
 " Elixir filetype plugin
 " Language: Elixir
 " Maintainer:	Mitchell Hanberg <vimNOSPAM@mitchellhanberg.com>
-" Last Change: 2022 Sep 20
+" Last Change: 2023 Dec 26
 
 if exists("b:did_ftplugin")
   finish
@@ -26,6 +26,12 @@ endif
 setlocal shiftwidth=2 softtabstop=2 expandtab iskeyword+=!,?
 setlocal comments=:#
 setlocal commentstring=#\ %s
+
+setlocal indentkeys=0#,!^F,o,O
+" Enable keys for blocks
+setlocal indentkeys+=0=after,0=catch,0=do,0=else,0=end,0=rescue
+" Enable keys that are usually the first keys in a line
+setlocal indentkeys+=0->,0\|>,0},0],0),>
 
 let b:undo_ftplugin = 'setlocal sw< sts< et< isk< com< cms<'
 


### PR DESCRIPTION
Hi!

As of right now, Elixir is being indented (in insert mode) from:

```elixir
defmodule Foo do
  def bar do
    {# Cursor here
  end
end
```

to:

```elixir
defmodule Foo do
  def bar do
{# Cursor here
  end
end
```

That's because we need to remove `0{`and others from `indentkeys`. I also added some other useful indentation keys.

@mhanberg, what do you think? Should we move these into a new `runtime/indent/elixir.vim` file?