### PR TITLE
runtime(diff): Update default links

### DIFF
--- a/runtime/syntax/diff.vim
+++ b/runtime/syntax/diff.vim
@@ -378,9 +378,9 @@ hi def link diffBDiffer		Constant
 hi def link diffIsA		Constant
 hi def link diffNoEOL		Constant
 hi def link diffCommon		Constant
-hi def link diffRemoved		Special
-hi def link diffChanged		PreProc
-hi def link diffAdded		Identifier
+hi def link diffRemoved		DiffDelete
+hi def link diffChanged		DiffChange
+hi def link diffAdded		DiffAdd
 hi def link diffLine		Statement
 hi def link diffSubname		PreProc
 hi def link diffComment		Comment


### PR DESCRIPTION
Problem: Current default links for `diffAdded`, `diffChanged`, and
  `diffRemoved` do not address the diff nature of the filetype.

Solution: Use `DiffAdd`, `DiffChange`, and `DiffDelete`.

------

Resolves #13759. I also updated default link for `diffChanged`, as there is also a good `DiffChange` alternative.