### PR TITLE
runtime: i3config and swayconfig updates

### DIFF
--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -2,8 +2,8 @@
 " Language: i3 config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: Quentin Hibon (github user hiqua)
-" Version: 1.0.0
-" Last Change: 2023-11-11
+" Version: 1.0.2
+" Last Change: 2023-12-28
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -137,8 +137,7 @@ syn match i3ConfigIpcKeyword /ipc-socket/ contained
 syn match i3ConfigParamLine /^ipc-socket .*$/ contains=i3ConfigIpcKeyword
 
 " 4.24 Focus follows mouse
-syn keyword i3ConfigFocusFollowsMouseOpts always contained
-syn match i3ConfigKeyword /^focus_follows_mouse \(yes\|no\|always\)$/ contains=i3ConfigBoolean,i3ConfigFocusFollowsMouseOpts
+syn match i3ConfigKeyword /^focus_follows_mouse \(yes\|no\)$/ contains=i3ConfigBoolean
 
 " 4.25 Mouse warping
 syn keyword i3ConfigMouseWarpingOpts output container none contained
@@ -298,7 +297,6 @@ hi def link i3ConfigWorkspaceDir                    i3ConfigOption
 hi def link i3ConfigDotOperator                     i3ConfigOperator
 hi def link i3ConfigClientOpts                      i3ConfigOption
 hi def link i3ConfigIpcKeyword                      i3ConfigKeyword
-hi def link i3ConfigFocusFollowsMouseOpts           i3ConfigOption
 hi def link i3ConfigMouseWarpingOpts                i3ConfigOption
 hi def link i3ConfigPopupFullscreenOpts             i3ConfigOption
 hi def link i3ConfigFocusWrappingOpts               i3ConfigOption

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -2,7 +2,7 @@
 " Language: sway config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 1.0.1
+" Version: 1.0.2
 " Last Change: 2023-12-28
 
 " References:
@@ -42,6 +42,9 @@ syn region swayConfigExecBlock start=/exec\(_always\)\? {/ end=/^}$/ contains=i3
 
 syn keyword swayConfigFloatingModifierOpts normal inverse contained
 syn match i3ConfigKeyword /^floating_modifier [$a-zA-Z0-9+]\+ \(normal\|inverse\)$/ contains=i3ConfigVariable,i3ConfigBindModkey,swayConfigFloatingModifierOpts
+
+syn keyword swayConfigSmartGapsOpts toggle contained
+syn match i3ConfigKeyword /^smart_gaps toggle$/ contains=i3ConfigSmartGapOpts,i3ConfigBoolean,swayConfigSmartGapsOpts
 
 syn keyword swayConfigFocusFollowsMouseOpts always contained
 syn match i3ConfigKeyword /^focus_follows_mouse always$/ contains=i3ConfigBoolean,swayConfigFocusFollowsMouseOpts
@@ -121,6 +124,7 @@ syn region swayConfigOutput start=/^output/ skip=/\\$/ end=/$/  contains=swayCon
 syn region swayConfigOutput start=/^output .* {$/ end=/}$/  contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps,i3ConfigParen keepend extend
 
 " Define the highlighting.
+hi def link swayConfigSmartGapsOpts          i3ConfigOption
 hi def link swayConfigFloatingModifierOpts   i3ConfigOption
 hi def link swayConfigFocusFollowsMouseOpts  i3ConfigOption
 hi def link swayConfigBindKeyword            i3ConfigBindKeyword

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -2,8 +2,8 @@
 " Language: sway config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 1.0.0
-" Last Change: 2023-09-14
+" Version: 1.0.1
+" Last Change: 2023-12-28
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -42,6 +42,9 @@ syn region swayConfigExecBlock start=/exec\(_always\)\? {/ end=/^}$/ contains=i3
 
 syn keyword swayConfigFloatingModifierOpts normal inverse contained
 syn match i3ConfigKeyword /^floating_modifier [$a-zA-Z0-9+]\+ \(normal\|inverse\)$/ contains=i3ConfigVariable,i3ConfigBindModkey,swayConfigFloatingModifierOpts
+
+syn keyword swayConfigFocusFollowsMouseOpts always contained
+syn match i3ConfigKeyword /^focus_follows_mouse always$/ contains=i3ConfigBoolean,swayConfigFocusFollowsMouseOpts
 
 syn match i3ConfigKeyword /^hide_edge_borders --i3 \w*$/ contains=i3ConfigEdgeKeyword,i3ConfigShParam
 
@@ -119,6 +122,7 @@ syn region swayConfigOutput start=/^output .* {$/ end=/}$/  contains=swayConfigO
 
 " Define the highlighting.
 hi def link swayConfigFloatingModifierOpts   i3ConfigOption
+hi def link swayConfigFocusFollowsMouseOpts  i3ConfigOption
 hi def link swayConfigBindKeyword            i3ConfigBindKeyword
 hi def link swayConfigXOpt                   i3ConfigOption
 hi def link swayConfigInhibitKeyword         i3ConfigCommand


### PR DESCRIPTION
- Move `always` option from i3config's `focus_follows_mouse` to swayconfig
- Add `toggle` as option to swayconfig `smart_gaps`

@hiqua: could you please review the i3Config updates?