### PR TITLE
OpenVMS python3 and +xterm_save features

### DIFF
--- a/READMEdir/README_vms.txt
+++ b/READMEdir/README_vms.txt
@@ -19,14 +19,16 @@ src/INSTALLvms.txt.
 
 To use the binary version, you need one of these archives:
 
-  vim-XX-exe-ia64-gui.zip       IA64 GUI/Motif executables
-  vim-XX-exe-ia64-gtk.zip       IA64 GUI/GTK executables
-  vim-XX-exe-ia64-term.zip      IA64 console executables
+  vim-XX-exe-x86-gui.zip	X86_64 GUI/Motif executables
+  vim-XX-exe-x86-term.zip	X86_64 console executables
+  vim-XX-exe-ia64-gui.zip	IA64 GUI/Motif executables
+  vim-XX-exe-ia64-gtk.zip	IA64 GUI/GTK executables
+  vim-XX-exe-ia64-term.zip	IA64 console executables
   vim-XX-exe-axp-gui.zip	Alpha GUI/Motif executables
   vim-XX-exe-axp-gtk.zip	Alpha GUI/GTK executables
-  vim-XX-exe-axp-term.zip       Alpha console executables
+  vim-XX-exe-axp-term.zip	Alpha console executables
   vim-XX-exe-vax-gui.zip	VAX GUI executables
-  vim-XX-exe-vax-term.zip       VAX console executables
+  vim-XX-exe-vax-term.zip	VAX console executables
 
 and of course
   vim-XX-runtime.zip		runtime files
@@ -34,6 +36,8 @@ and of course
 The binary archives contain: vim.exe, ctags.exe, xxd.exe files,
 but there are also prepared "deploy ready" archives:
 
+vim-XX-x86.zip			GUI and console executables with runtime and
+				help files for X86_64 systems
 vim-XX-ia64.zip			GUI and console executables with runtime and
 				help files for IA64 systems
 vim-XX-axp.zip			GUI and console executables with runtime and

--- a/src/Make_vms.mms
+++ b/src/Make_vms.mms
@@ -582,7 +582,7 @@ OBJ = \
 	$(GUI_OBJ) \
 	$(XDIFF_OBJ) \
 	$(LUA_OBJ) \                                                                                                                                         
-    $(MZSCHEME_OBJ) \ 
+	$(MZSCHEME_OBJ) \ 
 	$(PERL_OBJ) \
 	$(PYTHON_OBJ) \
 	$(PYTHON3_OBJ) \

--- a/src/Make_vms.mms
+++ b/src/Make_vms.mms
@@ -1,8 +1,8 @@
 #
 # Makefile for Vim on OpenVMS
 #
-# Maintainer:   Zoltan Arpadffy <arpadffy@polarhome.com>
-# Last change:  2023 Nov 27
+# Maintainer:   Zoltan Arpadffy <zoltan.arpadffy@gmail.com>
+# Last change:  2024 Jan 03
 #
 # This script has been tested on VMS 6.2 to 9.2 on VAX, ALPHA, IA64 and X86_64
 # with MMS and MMK
@@ -65,6 +65,7 @@ CCVER = YES
 # VIM_TCL    = YES
 # VIM_PERL   = YES
 # VIM_PYTHON = YES
+# VIM_PYTHON3= YES
 # VIM_RUBY   = YES
 # VIM_LUA    = YES
 
@@ -224,6 +225,16 @@ PYTHON_LIB = ,OS_VMS_PYTHON.OPT/OPT
 PYTHON_INC = ,PYTHON_INCLUDE
 .ENDIF
 
+.IFDEF VIM_PYTHON3
+# Python related setup.
+PYTHON3_DEF = ,"FEAT_PYTHON3"
+PYTHON3_SRC = if_python3.c
+PYTHON3_OBJ = if_python3.obj
+PYTHON3_LIB = ,OS_VMS_PYTHON3.OPT/OPT
+PYTHON3_INC = ,PYTHON3_INCLUDE
+.ENDIF
+
+
 .IFDEF VIM_TCL
 # TCL related setup.
 TCL_DEF = ,"FEAT_TCL"
@@ -260,9 +271,9 @@ XIM_DEF = ,"FEAT_XIM"
 
 .IFDEF VIM_MZSCHEME
 # MZSCHEME related setup
-MZSCH_DEF = ,"FEAT_MZSCHEME"
-MZSCH_SRC = if_mzsch.c
-MZSCH_OBJ = if_mzsch.obj
+MZSCHEME_DEF = ,"FEAT_MZSCHEME"
+MZSCHEME_SRC = if_mzsch.c
+MZSCHEME_OBJ = if_mzsch.obj
 .ENDIF
 
 .IFDEF VIM_ICONV
@@ -294,26 +305,26 @@ VIMHOST = "''F$TRNLNM("SYS$NODE")'''F$TRNLNM("UCX$INET_HOST")'.''F$TRNLNM("UCX$I
 
 .SUFFIXES : .obj .c
 
-ALL_CFLAGS = /def=($(MODEL_DEF)$(DEFS)$(DEBUG_DEF)$(PERL_DEF)$(PYTHON_DEF) -
- $(TCL_DEF)$(RUBY_DEF)$(LUA_DEF)$(XIM_DEF)$(TAG_DEF)$(MZSCH_DEF) -
+ALL_CFLAGS = /def=($(MODEL_DEF)$(DEFS)$(DEBUG_DEF)$(PERL_DEF)$(PYTHON_DEF)$(PYTHON3_DEF) -
+ $(TCL_DEF)$(RUBY_DEF)$(LUA_DEF)$(XIM_DEF)$(TAG_DEF)$(MZSCHEME_DEF) -
  $(ICONV_DEF)$(ARCH_DEF)) -
  $(CFLAGS)$(GUI_FLAG) -
- /include=($(C_INC)$(GUI_INC_DIR)$(GUI_INC)$(PERL_INC)$(PYTHON_INC) -
+ /include=($(C_INC)$(GUI_INC_DIR)$(GUI_INC)$(PERL_INC)$(PYTHON_INC)$(PYTHON3_INC) -
  $(TCL_INC)$(XDIFF_INC)$(XPM_INC))
 
 # CFLAGS displayed in :ver information
 # It is specially formatted for correct display of unix like includes
 # as $(GUI_INC) - replaced with $(GUI_INC_VER)
 # Otherwise should not be any other difference.
-ALL_CFLAGS_VER = /def=($(MODEL_DEF)$(DEFS)$(DEBUG_DEF)$(PERL_DEF)$(PYTHON_DEF) -
- $(TCL_DEF)$(RUBY_DEF)$(LUA_DEF)$(XIM_DEF)$(TAG_DEF)$(MZSCH_DEF) -
+ALL_CFLAGS_VER = /def=($(MODEL_DEF)$(DEFS)$(DEBUG_DEF)$(PERL_DEF)$(PYTHON_DEF)$(PYTHON3_DEF) -
+ $(TCL_DEF)$(RUBY_DEF)$(LUA_DEF)$(XIM_DEF)$(TAG_DEF)$(MZSCHEME_DEF) -
  $(ICONV_DEF)$(ARCH_DEF)) -
  $(CFLAGS)$(GUI_FLAG) -
- /include=($(C_INC)$(GUI_INC_DIR)$(GUI_INC_VER)$(PERL_INC)$(PYTHON_INC) -
+ /include=($(C_INC)$(GUI_INC_DIR)$(GUI_INC_VER)$(PERL_INC)$(PYTHON_INC)$(PYTHON3_INC) -
  $(TCL_INC)$(XDIFF_INC)$(XPM_INC))
 
 ALL_LIBS = $(LIBS) $(GUI_LIB_DIR) $(GUI_LIB) $(XPM_LIB)\
-	   $(PERL_LIB) $(PYTHON_LIB) $(TCL_LIB) $(RUBY_LIB) $(LUA_LIB)
+	   $(PERL_LIB) $(PYTHON_LIB) $(PYTHON3_LIB) $(TCL_LIB) $(RUBY_LIB) $(LUA_LIB)
 
 SRC = \
 	alloc.c \
@@ -437,13 +448,14 @@ SRC = \
 	viminfo.c \
 	window.c \
 	$(GUI_SRC) \
+	$(XDIFF_SRC) \
+	$(LUA_SRC) \
+	$(MZSCHEME_SRC) \
 	$(PERL_SRC) \
 	$(PYTHON_SRC) \
+	$(PYTHON3_SRC) \
 	$(TCL_SRC) \
-	$(RUBY_SRC) \
-	$(LUA_SRC) \
-	$(MZSCH_SRC) \
-	$(XDIFF_SRC)
+	$(RUBY_SRC) 
 
 OBJ = \
 	alloc.obj \
@@ -568,13 +580,14 @@ OBJ = \
 	viminfo.obj \
 	window.obj \
 	$(GUI_OBJ) \
+	$(XDIFF_OBJ) \
+	$(LUA_OBJ) \                                                                                                                                         
+    $(MZSCHEME_OBJ) \ 
 	$(PERL_OBJ) \
 	$(PYTHON_OBJ) \
+	$(PYTHON3_OBJ) \
 	$(TCL_OBJ) \
-	$(RUBY_OBJ) \
-	$(LUA_OBJ) \
-	$(MZSCH_OBJ) \
-	$(XDIFF_OBJ)
+	$(RUBY_OBJ) 
 
 # Default target is making the executable
 all : [.auto]config.h mmk_compat motif_env gtk_env perl_env python_env tcl_env ruby_env lua_env $(TARGET)
@@ -732,6 +745,20 @@ python_env :
 	-@ close opt_file
 .ELSE
 python_env :
+	-@ !
+.ENDIF
+
+.IFDEF VIM_PYTHON3
+python3_env :
+	-@ write sys$output "using PYTHON3 environment:"
+	-@ show logical PYTHON3_INCLUDE
+	-@ show logical PYTHON3_OLB
+	-@ write sys$output "creating OS_VMS_PYTHON3.OPT file."
+	-@ open/write opt_file OS_VMS_PYTHON3.OPT
+	-@ write opt_file "PYTHON3_OLB:PYTHON3.OLB /share"
+	-@ close opt_file
+.ELSE
+python3_env :
 	-@ !
 .ENDIF
 

--- a/src/os_vms_conf.h
+++ b/src/os_vms_conf.h
@@ -144,6 +144,7 @@
 
 // Default features
 #define FEAT_IPV6
+#define FEAT_XTERM_SAVE
 
 // Hardware specific
 #if defined(__VAX) || defined(VAX)


### PR DESCRIPTION
Thank you all for the 9.1 release.

I have tested on VAX, Alpha, Itanium and x86_64 OpenVMS platforms - and 9.1 builds and works well.

Meanwhile, I have realized, that the Unix and OpenVMS make files are not fully aligned, therefore, I corrected that cosmetics issue. I have also added the python3 support, as well as the xterm_save feature.

Please review.
Thank you... and happy New year :)
