### PR TITLE
zos: fix xxd and set UTF-8 as the default encoding

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -450,9 +450,10 @@ set_init_default_encoding(void)
     char_u	*p;
     int		opt_idx;
 
-# ifdef MSWIN
+# if defined(MSWIN) || defined(__MVS__)
     // MS-Windows has builtin support for conversion to and from Unicode, using
     // "utf-8" for 'encoding' should work best for most users.
+    // z/OS built should default to UTF-8 mode as setlocale does not respect utf-8 environment variable locales
     p = vim_strsave((char_u *)ENC_DFLT);
 # else
     // enc_locale() will try to find the encoding of the current locale.

--- a/src/option.h
+++ b/src/option.h
@@ -130,7 +130,7 @@ typedef enum {
 #define ENC_UCSBOM	"ucs-bom"	// check for BOM at start of file
 
 // default value for 'encoding'
-#ifdef MSWIN
+#if defined(MSWIN) || defined(__MVS__)
 # define ENC_DFLT	"utf-8"
 #else
 # define ENC_DFLT	"latin1"

--- a/src/xxd/Makefile
+++ b/src/xxd/Makefile
@@ -1,7 +1,7 @@
 # The most simplistic Makefile
 
 xxd: xxd.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -DUNIX -o xxd xxd.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -DUNIX -o xxd xxd.c $(LIBS)
 
 clean:
 	rm -f xxd xxd.o

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -587,7 +587,7 @@ begin_coloring_char (char *l, int *c, int e, int ebcdic)
     }
   else  /* ASCII */
     {
-      #ifdef __MVS__
+      #if defined(__MVS__) && __CHARSET_LIB == 0
       if (e >= 64)
         l[(*c)++] = COLOR_GREEN;
       #else
@@ -905,6 +905,10 @@ main(int argc, char *argv[])
 	}
       rewind(fpo);
     }
+#ifdef __MVS__
+  // Disable auto-conversion on input file descriptors
+  __disableautocvt(fileno(fp));
+#endif
 
   if (revert)
     switch (hextype)
@@ -1066,7 +1070,7 @@ main(int argc, char *argv[])
 
           COLOR_PROLOGUE
           begin_coloring_char(l,&c,e,ebcdic);
-#ifdef __MVS__
+#if defined(__MVS__) && __CHARSET_LIB == 0
           if (e >= 64)
             l[c++] = e;
           else
@@ -1094,7 +1098,7 @@ main(int argc, char *argv[])
 
           c += addrlen + 3 + p;
           l[c++] =
-#ifdef __MVS__
+#if defined(__MVS__) && __CHARSET_LIB == 0
               (e >= 64)
 #else
               (e > 31 && e < 127)


### PR DESCRIPTION
* This removes the z/OS EBCDIC 1047 assumptions in xxd. We now build all new applications in ASCII/UTF8 mode for z/OS 
* z/OS support auto-conversion of tagged files, but for xxd we just want to compare the binary, therefore I've also added code to disable auto-conversion.
* I've also changed the Makefile to allow passing in of extra libraries (`$LIBS`). On z/OS, we typically link in another open source library, known as zoslib which provides compat with Linux.

For Vim:
* This also sets the default encoding to UTF-8 for z/OS (similar to win32)
