### PR TITLE
Netrw plugin fix for windows

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -7862,7 +7862,7 @@ fun! s:NetrwMarkFileMove(islocal)
      let movecmd     = netrw#WinPath(movecmd).movecmdargs
 "     call Decho("windows exception: movecmd<".movecmd."> (#1: had a space)",'~'.expand("<slnum>"))
     else
-     let movecmd = netrw#WinPath(movecmd)
+     let movecmd = netrw#WinPath(g:netrw_localmovecmd)
 "     call Decho("windows exception: movecmd<".movecmd."> (#2: no space)",'~'.expand("<slnum>"))
     endif
    else
@@ -7876,10 +7876,6 @@ fun! s:NetrwMarkFileMove(islocal)
     endif
     if !g:netrw_cygwin && (has("win32") || has("win95") || has("win64") || has("win16"))
      let fname= substitute(fname,'/','\\','g')
-     if g:netrw_keepdir
-      " Jul 19, 2022: fixing file move when g:netrw_keepdir is 1
-      let fname= b:netrw_curdir."\\".fname
-     endif
     endif
 "    call Decho("system(".movecmd." ".s:ShellEscape(fname)." ".tgt.")",'~'.expand("<slnum>"))
     let ret= system(movecmd.g:netrw_localmovecmdopt." ".s:ShellEscape(fname)." ".tgt)


### PR DESCRIPTION
The move command doesn't work on windows due:
+ The use of an uninitialized variable.
+ A filepath is prefixed twice with its dir.

~~This draft is for accountability purposes the corresponding patch has been mailed to Mr. Campbell.~~

Mr. Campbell has kindly answered me he is no longer supporting netrw actively. Let's fix this via PR then.