### PR TITLE
Remove diff* links added in #13776 and doc added in commit b1392be

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2024 Jan 03
+*syntax.txt*	For Vim version 9.1.  Last change: 2024 Jan 06
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1261,7 +1261,7 @@ To highlight KDE-reserved features, set >
 g:desktop_enable_kde follows g:desktop_enable_nonstd if not supplied
 
 
-DIFF						*diff.vim* *ft-diff-syntax*
+DIFF							*diff.vim*
 
 The diff highlighting normally finds translated headers.  This can be slow if
 there are very long lines in the file.  To disable translations: >
@@ -1270,15 +1270,6 @@ there are very long lines in the file.  To disable translations: >
 
 Also see |diff-slow|.
 
-Since the Vim 9.1 release |version-9.1| the diff filetype links the diffAdded,
-diffRemoved and diffChanged highlighting groups to |hl-DiffAdd|,
-|hl-DiffDelete| and |hl-DiffChange| by default.  If you do not want this, you
-can change it to the previous groups like this in your |.vimrc| >
-
-	hi link diffRemoved Special
-	hi link diffChanged PreProc
-	hi link diffAdded Identifier
-<
 DIRCOLORS			       *dircolors.vim* *ft-dircolors-syntax*
 
 The dircolors utility highlighting definition has one option.  It exists to

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -271,6 +271,10 @@ you can see the actual color, except for "Ignore"):
 	*Todo		anything that needs extra attention; mostly the
 			keywords TODO FIXME and XXX
 
+	*diffAdded	added line in a diff
+	*diffChanged	changed line in a diff
+	*diffRemoved	removed line in a diff
+
 The names marked with * are the preferred groups; the others are minor groups.
 For the preferred groups, the "syntax.vim" file contains default highlighting.
 The minor groups are linked to the preferred groups, so they get the same

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7207,7 +7207,6 @@ ft-cynlib-syntax	syntax.txt	/*ft-cynlib-syntax*
 ft-dart-syntax	syntax.txt	/*ft-dart-syntax*
 ft-dash-syntax	syntax.txt	/*ft-dash-syntax*
 ft-desktop-syntax	syntax.txt	/*ft-desktop-syntax*
-ft-diff-syntax	syntax.txt	/*ft-diff-syntax*
 ft-dircolors-syntax	syntax.txt	/*ft-dircolors-syntax*
 ft-docbk-syntax	syntax.txt	/*ft-docbk-syntax*
 ft-docbksgml-syntax	syntax.txt	/*ft-docbksgml-syntax*

--- a/runtime/syntax/diff.vim
+++ b/runtime/syntax/diff.vim
@@ -378,9 +378,6 @@ hi def link diffBDiffer		Constant
 hi def link diffIsA		Constant
 hi def link diffNoEOL		Constant
 hi def link diffCommon		Constant
-hi def link diffRemoved		DiffDelete
-hi def link diffChanged		DiffChange
-hi def link diffAdded		DiffAdd
 hi def link diffLine		Statement
 hi def link diffSubname		PreProc
 hi def link diffComment		Comment

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -141,6 +141,10 @@ syn match helpTodo		"\t[* ]Todo\t\+[a-z].*"
 
 syn match helpURL `\v<(((https?|ftp|gopher)://|(mailto|file|news):)[^' 	<>"]+|(www|web|w3)[a-z0-9_-]*\.[a-z0-9._-]+\.[^' 	<>"]+)[a-zA-Z0-9/]`
 
+syn match helpDiffAdded		"\t[* ]diffAdded\t\+[a-z].*"
+syn match helpDiffChanged	"\t[* ]diffChanged\t\+[a-z].*"
+syn match helpDiffRemoved	"\t[* ]diffRemoved\t\+[a-z].*"
+
 " Additionally load a language-specific syntax file "help_ab.vim".
 let s:i = match(expand("%"), '\.\a\ax$')
 if s:i > 0
@@ -216,6 +220,9 @@ hi def link helpUnderlined	Underlined
 hi def link helpError		Error
 hi def link helpTodo		Todo
 hi def link helpURL		String
+hi def link helpDiffAdded	diffAdded
+hi def link helpDiffChanged	diffChanged
+hi def link helpDiffRemoved	diffRemoved
 
 if has('textprop') && expand('%:p') =~ '[/\\]doc[/\\]syntax.txt'
   " highlight groups with their respective color

--- a/runtime/syntax/syncolor.vim
+++ b/runtime/syntax/syncolor.vim
@@ -41,6 +41,9 @@ if &background == "dark"
   SynColor Type		term=underline cterm=NONE ctermfg=LightGreen ctermbg=NONE gui=bold guifg=#60ff60 guibg=NONE
   SynColor Underlined	term=underline cterm=underline ctermfg=LightBlue gui=underline guifg=#80a0ff
   SynColor Ignore	term=NONE cterm=NONE ctermfg=black ctermbg=NONE gui=NONE guifg=bg guibg=NONE
+  SynColor diffAdded	term=NONE cterm=NONE ctermfg=green ctermbg=NONE gui=NONE guifg=green guibg=NONE
+  SynColor diffChanged	term=NONE cterm=NONE ctermfg=blue ctermbg=NONE gui=NONE guifg=blue guibg=NONE
+  SynColor diffRemoved	term=NONE cterm=NONE ctermfg=red ctermbg=NONE gui=NONE guifg=red guibg=NONE
 else
   SynColor Comment	term=bold cterm=NONE ctermfg=DarkBlue ctermbg=NONE gui=NONE guifg=Blue guibg=NONE
   SynColor Constant	term=underline cterm=NONE ctermfg=DarkRed ctermbg=NONE gui=NONE guifg=Magenta guibg=NONE
@@ -53,6 +56,9 @@ else
   SynColor Type		term=underline cterm=NONE ctermfg=DarkGreen ctermbg=NONE gui=bold guifg=SeaGreen guibg=NONE
   SynColor Underlined	term=underline cterm=underline ctermfg=DarkMagenta gui=underline guifg=SlateBlue
   SynColor Ignore	term=NONE cterm=NONE ctermfg=white ctermbg=NONE gui=NONE guifg=bg guibg=NONE
+  SynColor diffAdded	term=NONE cterm=NONE ctermfg=green ctermbg=NONE gui=NONE guifg=green guibg=NONE
+  SynColor diffChanged	term=NONE cterm=NONE ctermfg=blue ctermbg=NONE gui=NONE guifg=blue guibg=NONE
+  SynColor diffRemoved	term=NONE cterm=NONE ctermfg=red ctermbg=NONE gui=NONE guifg=red guibg=NONE
 endif
 SynColor Error		term=reverse cterm=NONE ctermfg=White ctermbg=Red gui=NONE guifg=White guibg=Red
 SynColor Todo		term=standout cterm=NONE ctermfg=Black ctermbg=Yellow gui=NONE guifg=Blue guibg=Yellow

--- a/runtime/syntax/syncolor.vim
+++ b/runtime/syntax/syncolor.vim
@@ -42,7 +42,7 @@ if &background == "dark"
   SynColor Underlined	term=underline cterm=underline ctermfg=LightBlue gui=underline guifg=#80a0ff
   SynColor Ignore	term=NONE cterm=NONE ctermfg=black ctermbg=NONE gui=NONE guifg=bg guibg=NONE
   SynColor diffAdded	term=NONE cterm=NONE ctermfg=green ctermbg=NONE gui=NONE guifg=green guibg=NONE
-  SynColor diffChanged	term=NONE cterm=NONE ctermfg=blue ctermbg=NONE gui=NONE guifg=blue guibg=NONE
+  SynColor diffChanged	term=NONE cterm=NONE ctermfg=blue ctermbg=NONE gui=NONE guifg=dodgerblue guibg=NONE
   SynColor diffRemoved	term=NONE cterm=NONE ctermfg=red ctermbg=NONE gui=NONE guifg=red guibg=NONE
 else
   SynColor Comment	term=bold cterm=NONE ctermfg=DarkBlue ctermbg=NONE gui=NONE guifg=Blue guibg=NONE
@@ -57,7 +57,7 @@ else
   SynColor Underlined	term=underline cterm=underline ctermfg=DarkMagenta gui=underline guifg=SlateBlue
   SynColor Ignore	term=NONE cterm=NONE ctermfg=white ctermbg=NONE gui=NONE guifg=bg guibg=NONE
   SynColor diffAdded	term=NONE cterm=NONE ctermfg=darkgreen ctermbg=NONE gui=NONE guifg=darkgreen guibg=NONE
-  SynColor diffChanged	term=NONE cterm=NONE ctermfg=blue ctermbg=NONE gui=NONE guifg=blue guibg=NONE
+  SynColor diffChanged	term=NONE cterm=NONE ctermfg=blue ctermbg=NONE gui=NONE guifg=dodgerblue guibg=NONE
   SynColor diffRemoved	term=NONE cterm=NONE ctermfg=red ctermbg=NONE gui=NONE guifg=red guibg=NONE
 endif
 SynColor Error		term=reverse cterm=NONE ctermfg=White ctermbg=Red gui=NONE guifg=White guibg=Red

--- a/runtime/syntax/syncolor.vim
+++ b/runtime/syntax/syncolor.vim
@@ -41,7 +41,7 @@ if &background == "dark"
   SynColor Type		term=underline cterm=NONE ctermfg=LightGreen ctermbg=NONE gui=bold guifg=#60ff60 guibg=NONE
   SynColor Underlined	term=underline cterm=underline ctermfg=LightBlue gui=underline guifg=#80a0ff
   SynColor Ignore	term=NONE cterm=NONE ctermfg=black ctermbg=NONE gui=NONE guifg=bg guibg=NONE
-  SynColor diffAdded	term=NONE cterm=NONE ctermfg=green ctermbg=NONE gui=NONE guifg=green guibg=NONE
+  SynColor diffAdded	term=NONE cterm=NONE ctermfg=green ctermbg=NONE gui=NONE guifg=limegreen guibg=NONE
   SynColor diffChanged	term=NONE cterm=NONE ctermfg=blue ctermbg=NONE gui=NONE guifg=dodgerblue guibg=NONE
   SynColor diffRemoved	term=NONE cterm=NONE ctermfg=red ctermbg=NONE gui=NONE guifg=red guibg=NONE
 else
@@ -56,7 +56,7 @@ else
   SynColor Type		term=underline cterm=NONE ctermfg=DarkGreen ctermbg=NONE gui=bold guifg=SeaGreen guibg=NONE
   SynColor Underlined	term=underline cterm=underline ctermfg=DarkMagenta gui=underline guifg=SlateBlue
   SynColor Ignore	term=NONE cterm=NONE ctermfg=white ctermbg=NONE gui=NONE guifg=bg guibg=NONE
-  SynColor diffAdded	term=NONE cterm=NONE ctermfg=darkgreen ctermbg=NONE gui=NONE guifg=darkgreen guibg=NONE
+  SynColor diffAdded	term=NONE cterm=NONE ctermfg=darkgreen ctermbg=NONE gui=NONE guifg=limegreen guibg=NONE
   SynColor diffChanged	term=NONE cterm=NONE ctermfg=blue ctermbg=NONE gui=NONE guifg=dodgerblue guibg=NONE
   SynColor diffRemoved	term=NONE cterm=NONE ctermfg=red ctermbg=NONE gui=NONE guifg=red guibg=NONE
 endif

--- a/runtime/syntax/syncolor.vim
+++ b/runtime/syntax/syncolor.vim
@@ -56,7 +56,7 @@ else
   SynColor Type		term=underline cterm=NONE ctermfg=DarkGreen ctermbg=NONE gui=bold guifg=SeaGreen guibg=NONE
   SynColor Underlined	term=underline cterm=underline ctermfg=DarkMagenta gui=underline guifg=SlateBlue
   SynColor Ignore	term=NONE cterm=NONE ctermfg=white ctermbg=NONE gui=NONE guifg=bg guibg=NONE
-  SynColor diffAdded	term=NONE cterm=NONE ctermfg=green ctermbg=NONE gui=NONE guifg=green guibg=NONE
+  SynColor diffAdded	term=NONE cterm=NONE ctermfg=darkgreen ctermbg=NONE gui=NONE guifg=darkgreen guibg=NONE
   SynColor diffChanged	term=NONE cterm=NONE ctermfg=blue ctermbg=NONE gui=NONE guifg=blue guibg=NONE
   SynColor diffRemoved	term=NONE cterm=NONE ctermfg=red ctermbg=NONE gui=NONE guifg=red guibg=NONE
 endif


### PR DESCRIPTION
The links added in #13776 are way too noisy for the contexts in which the `diff` syntax is applied (git commits, patches, etc.).

This commit…

- removes those links
- adds hopefully semantically correct styling for `diffAdded`, `diffChanged`, and `diffRemoved`, valid when using the `default` colorscheme and other colorschemes that don't explicitly override those highlight groups

For reference:

- `diff` before the change introduced in #13776

  <img width="278" alt="Capture d’écran 2024-01-04 à 19 22 53" src="https://github.com/vim/vim/assets/344335/416a5039-a93a-417a-822c-4f4f22118772">
  
  <img width="697" alt="Capture d’écran 2024-01-06 à 13 57 24" src="https://github.com/vim/vim/assets/344335/d11d59d8-51b7-42ba-a64f-f06b38510e59">

- `diff` *after* the change introduced in #13776 

  <img width="271" alt="Capture d’écran 2024-01-04 à 19 25 14" src="https://github.com/vim/vim/assets/344335/b2c5d300-30e9-4a37-a908-05b7faa364de">

  <img width="697" alt="Capture d’écran 2024-01-06 à 14 00 19" src="https://github.com/vim/vim/assets/344335/da7634ef-3401-4837-b9b1-ff75fb532a2e">

- `diff` *after* this commit

   <img width="697" alt="Capture d’écran 2024-01-06 à 14 02 31" src="https://github.com/vim/vim/assets/344335/63d3f0e8-6d67-4ff7-bd62-1db84d71598d">

  <img width="697" alt="Capture d’écran 2024-01-06 à 14 02 13" src="https://github.com/vim/vim/assets/344335/4d1bbff7-a3da-47f0-bb5e-280c98764fbc">
