### PR TITLE
cmdline may disappear when changing 'cmdheight'

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3742,4 +3742,17 @@ func Test_custom_completion_with_glob()
   delfunc TestGlobComplete
 endfunc
 
+func Test_window_size_stays_same_after_changing_cmdheight()
+  set laststatus=2
+  let expected = winheight(0)
+  function! Function_name() abort
+    call feedkeys(":"..repeat('x', &columns), 'x')
+    let &cmdheight=2
+    let &cmdheight=1
+    redraw
+  endfunction
+  call Function_name()
+  call assert_equal(expected, winheight(0))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -7131,17 +7131,17 @@ command_height(void)
 
     // If the space for the command line is already more than 'cmdheight' there
     // is nothing to do (window size must have decreased).
+    // Note: this makes curtab->tp_ch_used unreliable
     if (p_ch > old_p_ch && cmdline_row <= Rows - p_ch)
 	return;
 
     // Update cmdline_row to what it should be: just below the last window.
     cmdline_row = topframe->fr_height + tabline_height();
 
-    // If cmdline_row is smaller than what it is supposed to be for 'cmdheight'
-    // then set old_p_ch to what it would be, so that the windows get resized
+    // old_p_ch may be unreliable, because of the early return above, so
+    // set old_p_ch to what it would be, so that the windows get resized
     // properly for the new value.
-    if (cmdline_row < Rows - p_ch)
-	old_p_ch = Rows - cmdline_row;
+    old_p_ch = Rows - cmdline_row;
 
     // Find bottom frame with width of screen.
     frp = lastwin->w_frame;


### PR DESCRIPTION
Problem:  cmdline may disappear when changing 'cmdheight'
          (after Patch 9.0.0190, @markonm)
Solution: always re-calculate the old_p_ch value, not only
          when cmdline_row was higher than expected

closes: #13822