### PR TITLE
--remote-* does not ignore `wilidignore`

### DIFF
--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -566,6 +566,10 @@ build_drop_cmd(
     char_u	*p;
     char_u	*cdp;
     char_u	*cwd;
+    // reset wildignore temporarily
+    const char *wig[] =
+    { "<CR><C-\\><C-N>:let g:_wig=&wig|set wig=",
+      "<C-\\><C-N>:let &wig=g:_wig|unlet g:_wig<CR>"};
 
     if (filec > 0 && filev[0][0] == '+')
     {
@@ -599,6 +603,8 @@ build_drop_cmd(
     ga_init2(&ga, 1, 100);
     ga_concat(&ga, (char_u *)"<C-\\><C-N>:cd ");
     ga_concat(&ga, cdp);
+    // reset wildignorecase temporarily
+    ga_concat(&ga, (char_u *)wig[0]);
 
     // Call inputsave() so that a prompt for an encryption key works.
     ga_concat(&ga, (char_u *)
@@ -650,6 +656,8 @@ build_drop_cmd(
     ga_concat(&ga, cdp);
     ga_concat(&ga, (char_u *)"'|cd -|endif|endif<CR>");
     vim_free(cdp);
+    // reset wildignorecase
+    ga_concat(&ga, (char_u *)wig[1]);
 
     if (sendReply)
 	ga_concat(&ga, (char_u *)":call SetupRemoteReplies()<CR>");

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -248,6 +248,7 @@ NEW_TESTS = \
 	test_regexp_utf8 \
 	test_registers \
 	test_reltime \
+	test_remote \
 	test_rename \
 	test_restricted \
 	test_retab \
@@ -492,6 +493,7 @@ NEW_TESTS_RES = \
 	test_recover.res \
 	test_regex_char_classes.res \
 	test_registers.res \
+	test_remote.res \
 	test_rename.res \
 	test_restricted.res \
 	test_retab.res \

--- a/src/testdir/check.vim
+++ b/src/testdir/check.vim
@@ -184,6 +184,14 @@ func CheckNotRoot()
   endif
 endfunc
 
+" Command to check that we can make use of --servername and similar
+command CheckRemoteCapability call CheckRemoteCapability()
+func CheckRemoteCapability()
+  if empty(v:servername)
+    throw 'Skipped: Servername not defined'
+  endif
+endfunc
+
 " Command to check that the current language is English
 command CheckEnglish call CheckEnglish()
 func CheckEnglish()

--- a/src/testdir/check.vim
+++ b/src/testdir/check.vim
@@ -184,14 +184,6 @@ func CheckNotRoot()
   endif
 endfunc
 
-" Command to check that we can make use of --servername and similar
-command CheckRemoteCapability call CheckRemoteCapability()
-func CheckRemoteCapability()
-  if empty(v:servername)
-    throw 'Skipped: Servername not defined'
-  endif
-endfunc
-
 " Command to check that the current language is English
 command CheckEnglish call CheckEnglish()
 func CheckEnglish()

--- a/src/testdir/test_remote.vim
+++ b/src/testdir/test_remote.vim
@@ -1,0 +1,70 @@
+" Test for the --remote functionality
+
+source check.vim
+CheckFeature clientserver
+CheckFeature terminal
+"CheckRemoteCapability
+
+source shared.vim
+source screendump.vim
+source mouse.vim
+source term_util.vim
+
+let s:remote_works = 0
+let s:skip = 'Skipped: --remote feature is not possible'
+
+" nees to be run as first test to verify, that vim --servername works
+func Verify_remote_feature_works()
+  CheckRunVimInTerminal
+  enew
+  let buf = RunVimInTerminal('--servername XVIMTEST', {'rows': 8})
+  call TermWait(buf)
+  let cmd = GetVimCommandCleanTerm() .. '--serverlist'
+  call term_sendkeys(buf, ":r! " .. cmd .. "\<CR>")
+  call TermWait(buf)
+  call term_sendkeys(buf, ":w! XVimRemoteTest.txt\<CR>")
+  call TermWait(buf)
+  call term_sendkeys(buf, ":q\<CR>")
+  call StopVimInTerminal(buf)
+  bw!
+  let result = readfile('XVimRemoteTest.txt')
+  call delete('XVimRemoteTest.txt')
+  if empty(result)
+    throw s:skip
+  endif
+  let s:remote = 1
+endfunc
+
+call Verify_remote_feature_works()
+
+if !s:remote
+  finish
+endif
+
+let g:remote = s:remote
+
+func Test_remote_servername()
+  CheckRunVimInTerminal
+
+  call writefile(range(1, 20), 'XTEST.txt', 'D')
+
+  " Run Vim in a terminal and open a terminal window to run Vim in.
+  let lines =<< trim END
+    set wildignore=*.txt
+  END
+  call writefile(lines, 'XRemoteEditing.vim', 'D')
+  let buf = RunVimInTerminal('--servername XVIMTEST -S XRemoteEditing.vim', {'rows': 8})
+  call TermWait(buf)
+  botright new
+  let buf2 = RunVimInTerminal('--servername XVIMTEST --remote-silent XTEST.txt', {'rows': 5, 'wait_for_ruler': 0})
+  exe buf2 .. 'bw!'
+  call term_sendkeys(buf, ":3,$d\<CR>")
+  call term_sendkeys(buf, ":wq!\<CR>")
+  call StopVimInTerminal(buf)
+  let buf_contents = readfile('XTEST.txt')
+  call assert_equal(2, len(buf_contents))
+  bw!
+  close
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_remote.vim
+++ b/src/testdir/test_remote.vim
@@ -57,7 +57,7 @@ func Test_remote_servername()
   botright new
   let buf2 = RunVimInTerminal('--servername XVIMTEST --remote-silent XTEST.txt', {'rows': 5, 'wait_for_ruler': 0})
   exe buf2 .. 'bw!'
-  call term_sendkeys(buf, ":3,$d\<CR>")
+  call term_sendkeys(buf, ":5,$d\<CR>")
   call term_sendkeys(buf, ":wq!\<CR>")
   call StopVimInTerminal(buf)
   let buf_contents = readfile('XTEST.txt')

--- a/src/testdir/test_remote.vim
+++ b/src/testdir/test_remote.vim
@@ -3,7 +3,6 @@
 source check.vim
 CheckFeature clientserver
 CheckFeature terminal
-"CheckRemoteCapability
 
 source shared.vim
 source screendump.vim


### PR DESCRIPTION
Problem:  --remote-silent applies the wildignore option
          to each argument, which may result in "E479: No match"
Solution: temporarily reset 'wildignore' setting when building
          the :drop command

TODO: Need a way to find out how to test this properly