### PR TITLE
Empty line after a lambda causes use-after-free access

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -2699,6 +2699,9 @@ eval_next_non_blank(char_u *arg, evalarg_T *evalarg, int *getnext)
 /*
  * To be called after eval_next_non_blank() sets "getnext" to TRUE.
  * Only called for Vim9 script.
+ *
+ * If "arg" is not NULL, then the caller should assign the return value to
+ * "arg".
  */
     char_u *
 eval_next_line(char_u *arg, evalarg_T *evalarg)
@@ -2747,8 +2750,12 @@ eval_next_line(char_u *arg, evalarg_T *evalarg)
     }
 
     // Advanced to the next line, "arg" no longer points into the previous
-    // line.
-    evalarg->eval_using_cmdline = FALSE;
+    // line.  The caller assigns the return value to "arg".
+    // If "arg" is NULL, then the return value is discarded.  In that case,
+    // "arg" still points to the previous line.  So don't reset
+    // "eval_using_cmdline".
+    if (arg != NULL)
+	evalarg->eval_using_cmdline = FALSE;
     return skipwhite(line);
 }
 

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -4906,6 +4906,31 @@ def Test_for_stmt_space_before_type()
   v9.CheckSourceFailure(lines, 'E1059: No white space allowed before colon: :number in range(10)', 2)
 enddef
 
+" This test used to cause an use-after-free memory access
+def Test_for_empty_line_after_lambda()
+  var lines =<< trim END
+    vim9script
+    echomsg range(0, 2)->map((_, v) => {
+      return 1
+    })
+
+    assert_equal('[1, 1, 1]', v:statusmsg)
+  END
+  v9.CheckSourceSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+    echomsg range(0, 1)->map((_, v) => {
+      return 1
+    }) range(0, 1)->map((_, v) => {
+      return 2
+    }) # comment
+
+    assert_equal('[1, 1] [2, 2]', v:statusmsg)
+  END
+  v9.CheckSourceSuccess(lines)
+enddef
+
 " Keep this last, it messes up highlighting.
 def Test_substitute_cmd()
   new


### PR DESCRIPTION

Fixes #13833.