### PR TITLE
i_CTRL-R- doesn't work for multibyte chars in Replace mode

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -832,8 +832,9 @@ insert_reg(
 		    if ((State & REPLACE_FLAG) != 0)
 		    {
 			pos_T curpos;
-			u_save_cursor();
-			del_bytes((long)STRLEN(y_current->y_array[0]), TRUE, FALSE);
+			if (u_save_cursor() == FAIL)
+			    return FAIL;
+			del_chars((long)mb_charlen(y_current->y_array[0]), TRUE);
 			curpos = curwin->w_cursor;
 			if (oneright() == FAIL)
 			    // hit end of line, need to put forward (after the current position)

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -949,7 +949,7 @@ endfunc
 func Test_insert_small_delete_replace_mode()
   new
   call setline(1, ['foo', 'bar', 'foobar',  'bar'])
-  let @-='foo'
+  let @- = 'foo'
   call cursor(2, 1)
   exe ":norm! R\<C-R>-\<C-R>-"
   call assert_equal('foofoo', getline(2))
@@ -960,9 +960,21 @@ func Test_insert_small_delete_replace_mode()
   exe ":norm! R\<C-R>-ZZZZ"
   call assert_equal(['foo', 'foofoo', '',  'bfoobarZZZZ'], getline(1, 4))
   call cursor(1, 1)
-  let @-=''
+  let @- = ''
   exe ":norm! R\<C-R>-ZZZ"
   call assert_equal(['ZZZ', 'foofoo', '',  'bfoobarZZZZ'], getline(1, 4))
+  let @- = 'βbβ'
+  call cursor(4, 1)
+  exe ":norm! R\<C-R>-"
+  call assert_equal(['ZZZ', 'foofoo', '',  'βbβobarZZZZ'], getline(1, 4))
+  let @- = 'bβb'
+  call cursor(4, 1)
+  exe ":norm! R\<C-R>-"
+  call assert_equal(['ZZZ', 'foofoo', '',  'bβbobarZZZZ'], getline(1, 4))
+  let @- = 'βbβ'
+  call cursor(4, 1)
+  exe ":norm! R\<C-R>-"
+  call assert_equal(['ZZZ', 'foofoo', '',  'βbβobarZZZZ'], getline(1, 4))
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  i_CTRL-R- doesn't work for multibyte chars in Replace mode.
Solution: Use mb_charlen() and del_chars() instead.
