### PR TITLE
Fixing Windows gVim feature of interactive pipelining into commands

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -5194,7 +5194,7 @@ mch_system_piped(char *cmd, int options)
 		     */
 		    if ((len == 1 || len == 4 ) && cmd != NULL)
 		    {
-			if (ta_buf[0] == Ctrl_C
+			if (ta_buf[0] == Ctrl_D
 			    || (ta_buf[0] == CSI
 				&& ta_buf[1] == KS_MODIFIER
 				&& ta_buf[3] == Ctrl_D))

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -5176,7 +5176,7 @@ mch_system_piped(char *cmd, int options)
 		{
 		    /*
 		     * For pipes: Check for CTRL-C: send interrupt signal to
-		     * child.  Check for CTRL-D: EOF, close pipe to child.
+		     * child.
 		     */
 		    if (len == 1 && cmd != NULL)
 		    {
@@ -5186,10 +5186,21 @@ mch_system_piped(char *cmd, int options)
 			// now put 9 as SIGKILL
 			    TerminateProcess(pi.hProcess, 9);
 			}
-			if (ta_buf[ta_len] == Ctrl_D)
+		    }
+
+		    /*
+		     * Check for CTRL-D: EOF, close pipe to child.
+		     * Ctrl_D receives no special treatment in _OnChar() as Ctrl_C does
+		     */
+		    if (len == 4 && cmd != NULL)
+		    {
+			if (ta_buf[0] == CSI &&
+			    ta_buf[1] == KS_MODIFIER &&
+			    ta_buf[3] == Ctrl_D)
 			{
 			    CloseHandle(g_hChildStd_IN_Wr);
 			    g_hChildStd_IN_Wr = NULL;
+			    len = 0;
 			}
 		    }
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -5190,13 +5190,14 @@ mch_system_piped(char *cmd, int options)
 
 		    /*
 		     * Check for CTRL-D: EOF, close pipe to child.
-		     * Ctrl_D receives no special treatment in _OnChar() as Ctrl_C does
+		     * Ctrl_D may be decorated by _OnChar()
 		     */
-		    if (len == 4 && cmd != NULL)
+		    if ((len == 1 || len == 4 ) && cmd != NULL)
 		    {
-			if (ta_buf[0] == CSI &&
-			    ta_buf[1] == KS_MODIFIER &&
-			    ta_buf[3] == Ctrl_D)
+			if (ta_buf[0] == Ctrl_C
+			    || (ta_buf[0] == CSI
+				&& ta_buf[1] == KS_MODIFIER
+				&& ta_buf[3] == Ctrl_D))
 			{
 			    CloseHandle(g_hChildStd_IN_Wr);
 			    g_hChildStd_IN_Wr = NULL;


### PR DESCRIPTION
On Windows gvim uses pipelines instead of files for redirection. Originally (4b9669f1dc circa 2011) vim allows interaction with commands through the input pipeline.
For example, calling `xxd` without arguments would trigger `xxd` to read from stdin and the user could type the input. If the user typed "abcd(CTRL-D)" it would get:

```vim
:read !xxd
00000000: 6162 6364 650d 0a                        abcde..
```
Unfortunately since commit 77fc0b02e5 (2022) it no longer works because CTRL-D (which in windows is map to EOF) is not captured anymore. The only way of leaving interaction is CTRL-C which kills `xxd` and provides no output.

The actual issue is that `_OnChar` function has modified the encoding of CTRL-D in the input buffer. Thus, `mch_system_piped` can no longer identified CTRL-D. The pull request fixes the CTRL-D detection and restores the former behavior.