### PR TITLE
runtime(doc): revision makefiles

### DIFF
--- a/runtime/doc/Make_mvc.mak
+++ b/runtime/doc/Make_mvc.mak
@@ -39,6 +39,9 @@ ICONV = "$(ICONV_PATH)\iconv.exe"
 !ENDIF
 
 RM = del /q
+PS = PowerShell.exe
+
+PSFLAGS = -NoLogo -NoProfile -Command
 
 .SUFFIXES :
 .SUFFIXES : .c .o .txt .html
@@ -49,9 +52,9 @@ all : tags perlhtml $(CONVERTED)
 # Use "doctags" to generate the tags file.  Only works for English!
 tags : doctags $(DOCS)
 	doctags.exe $(DOCS) | sort /L C /O tags
-	powershell -nologo -noprofile -Command \
-		"(Get-Content -Raw tags | Get-Unique | % {$$_ -replace \"`r\", \"\"}) \
-		| New-Item -Force -Path . -ItemType file -Name tags"
+	$(PS) $(PSFLAGS) \
+		(Get-Content -Raw tags ^| Get-Unique ^| %%{$$_ -replace \"`r\", \"\"})\
+		^| New-Item -Force -Path . -ItemType file -Name tags
 
 doctags : doctags.c
 	$(CC) doctags.c
@@ -64,12 +67,10 @@ vimtags : $(DOCS)
 
 
 uganda.nsis.txt : uganda.???
-	!@powershell -nologo -noprofile -Command \
-		$$ext=(Get-Item $?).Extension; (Get-Content $? ^| \
-		% {$$_ -replace '\s*\*[-a-zA-Z0-9.]*\*', '' -replace 'vim:tw=78:.*', ''}) \
+	!@$(PS) $(PSFLAGS) $$ext=(Get-Item $?).Extension; (Get-Content $? ^| \
+		%%{$$_ -replace '\s*\*[-a-zA-Z0-9.]*\*', '' -replace 'vim:tw=78:.*', ''})\
 		^| Set-Content $*$$ext
-	!@powershell -nologo -noprofile -Command \
-		$$ext=(Get-Item $?).Extension; \
+	!@$(PS) $(PSFLAGS) $$ext=(Get-Item $?).Extension; \
 		(Get-Content -Raw $(@B)$$ext).Trim() -replace '(\r\n){3,}', '$$1$$1' \
 		^| Set-Content $(@B)$$ext
 
@@ -105,7 +106,7 @@ perlhtml : tags $(DOCS)
 
 # Check URLs in the help with "curl" or "powershell".
 test_urls :
-	"$(VIMEXE)" -S test_urls.vim
+	"$(VIMEXE)" --clean -S test_urls.vim
 
 clean :
 	$(RM) doctags.exe doctags.obj
@@ -203,7 +204,7 @@ os_win32.txt :
 <<
 
 convert-all : $(CONVERTED)
-!IF [powershell -nologo -noprofile "exit $$psversiontable.psversion.major"] == 2
+!IF [$(PS) $(PSFLAGS) "exit $$psversiontable.psversion.major"] == 2
 !ERROR The program "PowerShell" version 3.0 or higher is required to work
 !ENDIF
 
@@ -212,7 +213,7 @@ vim-da.UTF-8.1 : vim-da.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -222,7 +223,7 @@ vimdiff-da.UTF-8.1 : vimdiff-da.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -232,7 +233,7 @@ vimtutor-da.UTF-8.1 : vimtutor-da.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -242,7 +243,7 @@ vim-de.UTF-8.1 : vim-de.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -252,7 +253,7 @@ evim-fr.UTF-8.1 : evim-fr.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -262,7 +263,7 @@ vim-fr.UTF-8.1 : vim-fr.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -272,7 +273,7 @@ vimdiff-fr.UTF-8.1 : vimdiff-fr.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -282,7 +283,7 @@ vimtutor-fr.UTF-8.1 : vimtutor-fr.1
 	$(ICONV) -f ISO-8859-1 -t utf-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -292,7 +293,7 @@ xxd-fr.UTF-8.1 : xxd-fr.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -302,7 +303,7 @@ evim-it.UTF-8.1 : evim-it.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -312,7 +313,7 @@ vim-it.UTF-8.1 : vim-it.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -322,7 +323,7 @@ vimdiff-it.UTF-8.1 : vimdiff-it.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -332,7 +333,7 @@ vimtutor-it.UTF-8.1 : vimtutor-it.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -342,7 +343,7 @@ xxd-it.UTF-8.1 : xxd-it.1
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -352,7 +353,7 @@ evim-pl.UTF-8.1 : evim-pl.1
 	$(ICONV) -f ISO-8859-2 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -362,7 +363,7 @@ vim-pl.UTF-8.1 : vim-pl.1
 	$(ICONV) -f ISO-8859-2 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -372,7 +373,7 @@ vimdiff-pl.UTF-8.1 : vimdiff-pl.1
 	$(ICONV) -f ISO-8859-2 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -382,7 +383,7 @@ vimtutor-pl.UTF-8.1 : vimtutor-pl.1
 	$(ICONV) -f ISO-8859-2 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -392,7 +393,7 @@ xxd-pl.UTF-8.1 : xxd-pl.1
 	$(ICONV) -f ISO-8859-2 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -402,7 +403,7 @@ evim-ru.UTF-8.1 : evim-ru.1
 	$(ICONV) -f KOI8-R -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -412,7 +413,7 @@ vim-ru.UTF-8.1 : vim-ru.1
 	$(ICONV) -f KOI8-R -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -422,7 +423,7 @@ vimdiff-ru.UTF-8.1 : vimdiff-ru.1
 	$(ICONV) -f KOI8-R -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -432,7 +433,7 @@ vimtutor-ru.UTF-8.1 : vimtutor-ru.1
 	$(ICONV) -f KOI8-R -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -442,7 +443,7 @@ xxd-ru.UTF-8.1 : xxd-ru.1
 	$(ICONV) -f KOI8-R -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -452,7 +453,7 @@ evim-tr.UTF-8.1 : evim-tr.1
 	$(ICONV) -f ISO-8859-9 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28599)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -462,7 +463,7 @@ vim-tr.UTF-8.1 : vim-tr.1
 	$(ICONV) -f ISO-8859-9 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28599)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -472,7 +473,7 @@ vimdiff-tr.UTF-8.1 : vimdiff-tr.1
 	$(ICONV) -f ISO-8859-9 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28599)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF
@@ -482,7 +483,7 @@ vimtutor-tr.UTF-8.1 : vimtutor-tr.1
 	$(ICONV) -f ISO-8859-9 -t UTF-8 $? >$@
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
-	powershell -nologo -noprofile -Command \
+	$(PS) $(PSFLAGS) \
 		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28599)) ^| \
 		1>nul New-Item -Force -Path . -ItemType file -Name $@
 !ENDIF

--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -18,6 +18,7 @@ include Make_all.mak
 
 .SUFFIXES:
 .SUFFIXES: .c .o .txt .html
+.PHONY: all vimtags noerrors perlhtml clean test_urls
 
 all: tags vim.man evim.man vimdiff.man vimtutor.man xxd.man $(CONVERTED)
 
@@ -28,26 +29,26 @@ vimtags: $(DOCS)
 
 # Use "doctags" to generate the tags file.  Only works for English!
 tags: doctags $(DOCS)
-	./doctags $(DOCS) | LANG=C LC_ALL=C sort >tags
+	./doctags $(DOCS) | LANG=C LC_ALL=C sort >$@
 	uniq -d -2 tags
 
 doctags: doctags.c
 	$(CC) doctags.c -o doctags
 
 vim.man: vim.1
-	nroff -man vim.1 | sed -e s/.//g > vim.man
+	nroff -man $< | sed -e s/.//g > $@
 
 evim.man: evim.1
-	nroff -man evim.1 | sed -e s/.//g > evim.man
+	nroff -man $< | sed -e s/.//g > $@
 
 vimdiff.man: vimdiff.1
-	nroff -man vimdiff.1 | sed -e s/.//g > vimdiff.man
+	nroff -man $< | sed -e s/.//g > $@
 
 vimtutor.man: vimtutor.1
-	nroff -man vimtutor.1 | sed -e s/.//g > vimtutor.man
+	nroff -man $< | sed -e s/.//g > $@
 
 xxd.man: xxd.1
-	nroff -man xxd.1 | sed -e s/.//g > xxd.man
+	nroff -man $< | sed -e s/.//g > $@
 
 uganda.nsis.txt: uganda.txt
 	sed -e 's/[ 	]*\*[-a-zA-Z0-9.]*\*//g' -e 's/vim:tw=78:.*//' \
@@ -68,10 +69,10 @@ $(HTMLS): tags.ref
 # index.html is the starting point for HTML, but for the help files it is
 # help.txt.  Therefore use vimindex.html for index.txt.
 index.html: help.txt
-	$(AWK) -f makehtml.awk help.txt >index.html
+	$(AWK) -f makehtml.awk $< >$@
 
 vimindex.html: index.txt
-	$(AWK) -f makehtml.awk index.txt >vimindex.html
+	$(AWK) -f makehtml.awk $< >$@
 
 tags.ref tags.html: tags
 	$(AWK) -f maketags.awk tags >tags.html
@@ -84,7 +85,7 @@ perlhtml: tags $(DOCS)
 
 # Check URLs in the help with "curl".
 test_urls:
-	vim -S test_urls.vim
+	$(VIMEXE) --clean -S test_urls.vim
 
 clean:
 	-rm -f doctags *.html tags.ref
@@ -92,58 +93,58 @@ clean:
 # These files are in the extra archive, skip if not present
 
 arabic.txt:
-	touch arabic.txt
+	touch $@
 
 farsi.txt:
-	touch farsi.txt
+	touch $@
 
 hebrew.txt:
-	touch hebrew.txt
+	touch $@
 
 russian.txt:
-	touch russian.txt
+	touch $@
 
 gui_w32.txt:
-	touch gui_w32.txt
+	touch $@
 
 if_ole.txt:
-	touch if_ole.txt
+	touch $@
 
 os_390.txt:
-	touch os_390.txt
+	touch $@
 
 os_amiga.txt:
-	touch os_amiga.txt
+	touch $@
 
 os_beos.txt:
-	touch os_beos.txt
+	touch $@
 
 os_dos.txt:
-	touch os_dos.txt
+	touch $@
 
 os_haiku.txt:
-	touch os_haiku.txt
+	touch $@
 
 os_mac.txt:
-	touch os_mac.txt
+	touch $@
 
 os_mint.txt:
-	touch os_mint.txt
+	touch $@
 
 os_msdos.txt:
-	touch os_msdos.txt
+	touch $@
 
 os_os2.txt:
-	touch os_os2.txt
+	touch $@
 
 os_qnx.txt:
-	touch os_qnx.txt
+	touch $@
 
 os_risc.txt:
-	touch os_risc.txt
+	touch $@
 
 os_win32.txt:
-	touch os_win32.txt
+	touch $@
 
 # Note that $< works with GNU make while $> works for BSD make.
 # Is there a solution that works for both??


### PR DESCRIPTION
`Make_mvc.mak` and `Makefile`.                                                                                                                                                                                                              
Added --clean key to Vim call from "test_urls" rule.                                                                                                                                                                        
Continued #13589 :
Use predefined variables (`$@`, `$<`) instead of the actual file names.
(Adding new rules should become easier.)
