### PR TITLE
src/po: revision makefiles and document files

### DIFF
--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -26,7 +26,14 @@ MSGMERGE = OLD_PO_FILE_INPUT=yes OLD_PO_FILE_OUTPUT=yes msgmerge
 
 .SUFFIXES:
 .SUFFIXES: .po .mo .pot .ck
-.PHONY: all install uninstall prefixcheck converted check clean checkclean distclean update-po $(LANGUAGES)
+.PHONY: all install uninstall prefixcheck originals converted check clean \
+	checkclean distclean update-po $(LANGUAGES)
+
+all: $(MOFILES) $(MOCONVERTED) $(MSGFMT_DESKTOP)
+
+originals: $(MOFILES)
+
+converted: $(MOCONVERTED)
 
 .po.mo:
 	$(MSGFMTCMD) -o $@ $<
@@ -35,8 +42,6 @@ MSGMERGE = OLD_PO_FILE_INPUT=yes OLD_PO_FILE_OUTPUT=yes msgmerge
 	$(VIM) -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" -S check.vim \
 		-c "if error == 0 | q | else | num 2 | cq | endif" $<
 	touch $@
-
-all: $(MOFILES) $(MOCONVERTED) $(MSGFMT_DESKTOP)
 
 check: $(CHECKFILES)
 
@@ -84,12 +89,10 @@ tryoutinstall: $(MOFILES) $(MOCONVERTED)
 	  fi; \
 	done
 
-converted: $(MOCONVERTED)
-
 # nl.po was added later, if it does not exist use a file with just a # in it
 # (an empty file doesn't work with old msgfmt).
 nl.po:
-	@( echo \# > nl.po )
+	@( echo \# >> nl.po )
 
 # Norwegian/Bokmal: "nb" is an alias for "no".
 # Copying the file is not efficient, but I don't know of another way to make
@@ -102,75 +105,75 @@ nb.po: no.po
 # ja.sjis.po is outdated.
 ja.sjis.po: ja.po
 	@$(MAKE) sjiscorr
-	rm -f ja.sjis.po
-	iconv -f UTF-8 -t CP932 ja.po | ./sjiscorr > ja.sjis.po
+	rm -f $@
+	iconv -f UTF-8 -t CP932 $< | ./sjiscorr > $@
 
 sjiscorr: sjiscorr.c
 	$(CC) -o sjiscorr sjiscorr.c
 
 ja.euc-jp.po: ja.po
-	iconv -f UTF-8 -t EUC-JP ja.po | \
+	iconv -f UTF-8 -t EUC-JP $< | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=EUC-JP/' \
-			-e 's/# Original translations/# Generated from ja.po, DO NOT EDIT/' \
-			> ja.euc-jp.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 # Convert cs.po to create cs.cp1250.po.
 cs.cp1250.po: cs.po
-	rm -f cs.cp1250.po
-	iconv -f ISO-8859-2 -t CP1250 cs.po | \
+	rm -f $@
+	iconv -f ISO-8859-2 -t CP1250 $< | \
 		$(SED) -e 's/charset=[iI][sS][oO]-8859-2/charset=CP1250/' \
-			-e 's/# Original translations/# Generated from cs.po, DO NOT EDIT/' \
-			> cs.cp1250.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 # Convert pl.po to create pl.cp1250.po.
 pl.cp1250.po: pl.po
-	rm -f pl.cp1250.po
-	iconv -f ISO-8859-2 -t CP1250 pl.po | \
+	rm -f $@
+	iconv -f ISO-8859-2 -t CP1250 $< | \
 		$(SED) -e 's/charset=[iI][sS][oO]-8859-2/charset=CP1250/' \
-			-e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' \
-			> pl.cp1250.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 # Convert pl.po to create pl.UTF-8.po.
 pl.UTF-8.po: pl.po
-	rm -f pl.UTF-8.po
-	iconv -f ISO-8859-2 -t UTF-8 pl.po | \
+	rm -f $@
+	iconv -f ISO-8859-2 -t UTF-8 $< | \
 		$(SED) -e 's/charset=[iI][sS][oO]-8859-2/charset=UTF-8/' \
-			-e 's/# Original translations/# Generated from pl.po, DO NOT EDIT/' \
-			> pl.UTF-8.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 # Convert sk.po to create sk.cp1250.po.
 sk.cp1250.po: sk.po
-	rm -f sk.cp1250.po
-	iconv -f ISO-8859-2 -t CP1250 sk.po | \
+	rm -f $@
+	iconv -f ISO-8859-2 -t CP1250 $< | \
 		$(SED) -e 's/charset=[iI][sS][oO]-8859-2/charset=CP1250/' \
-			-e 's/# Original translations/# Generated from sk.po, DO NOT EDIT/' \
-			> sk.cp1250.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 # Convert zh_CN.UTF-8.po to create zh_CN.po.
 zh_CN.po: zh_CN.UTF-8.po
-	rm -f zh_CN.po
-	iconv -f UTF-8 -t GB2312 zh_CN.UTF-8.po | \
+	rm -f $@
+	iconv -f UTF-8 -t GB2312 $< | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=GB2312/' \
-			-e 's/# Original translations/# Generated from zh_CN.UTF-8.po, DO NOT EDIT/' \
-			> zh_CN.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 # Convert zh_CN.UTF-8.po to create zh_CN.cp936.po.
 # Set 'charset' to gbk to avoid that msfmt generates a warning.
 # This used to convert from zh_CN.po, but that results in a conversion error.
 zh_CN.cp936.po: zh_CN.UTF-8.po
-	rm -f zh_CN.cp936.po
-	iconv -f UTF-8 -t CP936 zh_CN.UTF-8.po | \
+	rm -f $@
+	iconv -f UTF-8 -t CP936 $< | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=GBK/' \
-			-e 's/# Original translations/# Generated from zh_CN.UTF-8.po, DO NOT EDIT/' \
-			> zh_CN.cp936.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 # Convert zh_TW.UTF-8.po to create zh_TW.po
 zh_TW.po: zh_TW.UTF-8.po
-	rm -f zh_TW.po
-	iconv -f UTF-8 -t BIG5 zh_TW.UTF-8.po | \
+	rm -f $@
+	iconv -f UTF-8 -t BIG5 $< | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=BIG5/' \
-			-e 's/# Original translations/# Generated from zh_TW.UTF-8.po, DO NOT EDIT/' \
-			> zh_TW.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 
 # Convert zh_TW.UTF-8.po to create zh_TW.po with backslash characters
@@ -192,8 +195,8 @@ zh_TW.po: zh_TW.UTF-8.po
 
 #zh_TW.po: zh_TW.UTF-8.po
 #	@$(MAKE) big5corr
-#	rm -f zh_TW.po
-#	iconv -f UTF-8 -t BIG5 zh_TW.UTF-8.po | ./big5corr > zh_TW.po
+#	rm -f $@
+#	iconv -f UTF-8 -t BIG5 $< | ./big5corr > $@
 
 
 # 06.11.23, added by Restorer
@@ -204,32 +207,32 @@ zh_TW.po: zh_TW.UTF-8.po
 
 # Convert ko.UTF-8.po to create ko.po.
 ko.po: ko.UTF-8.po
-	rm -f ko.po
-	iconv -f UTF-8 -t EUC-KR ko.UTF-8.po | \
+	rm -f $@
+	iconv -f UTF-8 -t EUC-KR $< | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=EUC-KR/' \
-			-e 's/# Original translations/# Generated from ko.UTF-8.po, DO NOT EDIT/' \
-			> ko.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 # Convert ru.po to create ru.cp1251.po.
 ru.cp1251.po: ru.po
-	rm -f ru.cp1251.po
-	iconv -f UTF-8 -t CP1251 ru.po | \
+	rm -f $@
+	iconv -f UTF-8 -t CP1251 $< | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=CP1251/' \
-			-e 's/# Original translations/# Generated from ru.po, DO NOT EDIT/' \
-			> ru.cp1251.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 # Convert uk.po to create uk.cp1251.po.
 uk.cp1251.po: uk.po
-	rm -f uk.cp1251.po
-	iconv -f UTF-8 -t CP1251 uk.po | \
+	rm -f $@
+	iconv -f UTF-8 -t CP1251 $< | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=CP1251/' \
-			-e 's/# Original translations/# Generated from uk.po, DO NOT EDIT/' \
-			> uk.cp1251.po
+			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			> $@
 
 prefixcheck:
 	@if test "x" = "x$(prefix)"; then \
 	  echo "******************************************"; \
-	  echo "  please use make from the src directory  "; \
+	  echo "  Please use make from the src directory  "; \
 	  echo "******************************************"; \
 	  exit 1; \
 	fi
@@ -283,7 +286,7 @@ gvim.desktop: gvim.desktop.in $(POFILES) vim.desktop
 	if command -v desktop-file-validate; then desktop-file-validate tmp_gvim.desktop; fi
 	mv tmp_gvim.desktop gvim.desktop
 
-# When updating ja.sjis.po there are a bunch of errors and a crash.
+# Only original translations with default encoding should be updated.
 # The files that are converted to a different encoding clearly state "DO NOT EDIT".
 update-po: $(MOFILES:.mo=)
 

--- a/src/po/README.txt
+++ b/src/po/README.txt
@@ -30,7 +30,7 @@ The distributed files are generated on Unix, but this should also be possible
 on MS-Windows.  Download the gettext packages, for example from:
 
 	http://sourceforge.net/projects/gettext
-	or
+or
 	https://mlocati.github.io/articles/gettext-iconv-windows.html
 
 You might have to do the commands manually.  Example:
@@ -53,7 +53,10 @@ CREATING A NEW PO FILE
 We will use "xx.po" as an example here, replace "xx" with the name of your
 language.
 
-- Edit Make_all.mak to add xx to LANGUAGES and xx.mo to MOFILES.
+- Edit Make_all.mak to add xx to LANGUAGES and xx.mo to MOFILES, xx.po to
+  POFILES and xx.ck to CHECKFILES.
+- If the encoding of the translation text differs from the default UTF-8, add a
+  corresponding entry in MOCONVERTED, specifying the required encoding.
 - If you haven't done so already, run ./configure in the top vim directory
   (i.e. go up two directories) and then come back here afterwards.
 - Execute these commands:
@@ -147,13 +150,13 @@ convert ja.po to EUC-JP (supposed as your system encoding):
 (1) Convert the file encoding:
 
 	mv ja.po ja.po.orig
-	iconv -f utf-8 -t euc-jp ja.po.orig > ja.po
+	iconv -f UTF-8 -t EUC-JP ja.po.orig > ja.po
 
 (2) Rewrite charset declaration in the file:
 
     Open ja.po find this line:
-	"Content-Type: text/plain; charset=utf-8\n"
+	"Content-Type: text/plain; charset=UTF-8\n"
     You should change "charset" like this:
-	"Content-Type: text/plain; charset=euc-jp\n"
+	"Content-Type: text/plain; charset=EUC-JP\n"
 
 There are examples in the Makefile for the conversions already supported.

--- a/src/po/README_mingw.txt
+++ b/src/po/README_mingw.txt
@@ -20,8 +20,10 @@ The make utility must be run from the po directory.
 First of all you must set the environment variable LANGUAGE to xx, where xx is
 the name of your language. You can do it from the command line or adding a
 line to your autoexec.bat file: set LANGUAGE=xx. You must also add your
-language to the Make_all.mak file in the lines LANGUAGES, MOFILES, AND
-POFILES.
+language to the Make_all.mak file in the lines LANGUAGES, MOFILES, POFILES,
+and CHECKFILES. If the encoding of the translation text differs from the
+default UTF-8, add a corresponding entry in MOCONVERTED, specifying the
+required encoding.
 
 If you don't have a xx.po file, you must create it with the command:
 

--- a/src/po/README_mvc.txt
+++ b/src/po/README_mvc.txt
@@ -2,18 +2,19 @@ TRANSLATING VIM MESSAGES
 
 This file explains how to create and maintain po files using a number of
 GnuWin packages.  You will need gettext, libiconv and libexpat.  As of
-August 2010 the versions known to work are gettext 0.14.4, libiconv 1.9.2-1
-and expat 2.0.1.  gettext and libiconv can be found at:
+January 2024 the versions known to work are gettext 0.14.4, libiconv 1.9.2-1
+and expat 2.5.0.  Gettext and libiconv can be found at:
 
 	http://gnuwin32.sourceforge.net/
 
 expat can be found at:
 
 	http://sourceforge.net/projects/expat/
+or
+	https://github.com/libexpat/libexpat
 
 expat will install into its own directory.  You should copy libexpat.dll into
 the bin directory created from the gettext/libiconv packages.
-
 Or Michele Locati kindly provides precompiled binaries gettext 0.21 and
 iconv 1.16 for Windows on his site: 
 
@@ -29,11 +30,13 @@ Set the environment variable LANGUAGE to the language code for the language
 you are translating Vim messages to.  Language codes are typically two
 characters and you can find a list of them at:
 
-	http://www.geocities.com/click2speak/languages.html
+	https://www.loc.gov/standards/iso639-2/php/code_list.php
+	https://www.science.co.il/language/Codes.php
+	https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
 
-Another possibility is to use the GnuWin32 port of gettext. This is
-recommended especially if you use already gnuwin32 tools to gunzip, bunzip,
-patch etc. these files. You find the GnuWin32 version of gettext here:
+Another possibility is to use the GnuWin32 port of gettext.  This is
+recommended especially if you use already GnuWin32 tools to gunzip, bunzip,
+patch etc. these files.  You find the GnuWin32 version of gettext here:
 
         http://gnuwin32.sourceforge.net/packages/gettext.htm
 
@@ -41,13 +44,16 @@ Yet another very strait forward way is to get the sources of gettext from
 
         http://www.gnu.org/software/gettext/gettext.html
 
-and build your own version of these tools. The documentation states that this
+and build your own version of these tools.  The documentation states that this
 should be possible with MSVC4.0, MSVC5.0, MSVC6.0 or MSVC7.0, but you can
 build it even successfully with MSVC8.0.
 
 The LANGUAGE environment variable can be set from the command line, by adding
 a line to your autoexec.bat file, or by defining a user variable from the
-Advanced tab in the System control panel.
+Advanced tab in the System control panel.  If the LANGUAGE environment
+variable has not been set in any of the above ways, the value of this variable
+will be set automatically according to the language used in the OS.  This
+value will be valid until the "nmake.exe" program terminates.
 
 Next, edit Make_mvc.mak so that GETTEXT_PATH points the binary directory of
 the installation.
@@ -56,10 +62,13 @@ the installation.
 CREATING A NEW TRANSLATION
 
 When creating a new translation you must add your language code to the
-Make_all.mak file in the lines defining LANGUAGES and MOFILES.  To create the
-initial .po file for your language you must use the command:
+Make_all.mak file in the lines defining LANGUAGES and MOFILES, POFILES and
+CHECKFILES.  If the encoding of the translation text differs from the default
+UTF-8, add a corresponding entry in MOCONVERTED, specifying the required
+encoding.
+To create the initial .po file for your language you must use the command:
 
-	make -f make_mvc.mak first_time
+	nmake.exe -f Make_mvc.mak first_time
 
 Note: You need to be in the po directory when using this makefile.
 
@@ -82,7 +91,7 @@ If there are new or changed messages in Vim that need translating, then the
 first thing to do is merge them into the existing translations.  This is done
 with the following command:
 
-	nmake -f Make_mvc.mak xx.po
+	nmake.exe -f Make_mvc.mak xx
 
 where xx is the language code for the language needing translations.  The
 original .po file is copied to xx.po.orig.
@@ -102,23 +111,30 @@ CHECKING THE TRANSLATION
 
 Check the translation with the following command:
 
-	nmake -f make_mvc.mak xx.mo
+	nmake.exe -f Make_mvc.mak xx.ck
 
-Correct any syntax errors reported.  When there are no more errors, the
-translation is ready to be installed.
+Correct any errors reported.  When there are no more errors, the translation
+is ready to be installed.
 
 
 INSTALLING THE TRANSLATION
 
 Install your translation with the following command:
 
-	nmake -f make_mvc.mak install
+	nmake.exe -f Make_mvc.mak install
 
 This will create the xx\LC_MESSAGES directory in runtime\lang if it does not
 already exist.
 You can also use the following command to install all languages:
 
-	nmake -f make_mvc.mak install-all
+	nmake.exe -f Make_mvc.mak install-all
 
+
+AFTER ALL OF THESE STEPS
+
+Clean the "po" directory of all temporary and unnecessary files.  Execute the
+command:
+
+	nmake.exe -f Make_mvc.mak clean
 
 vim:tw=78:


### PR DESCRIPTION
`Make_mvc.mak`
Added check of setting of LANGUAGE environment variable and, if necessary,
automatic assignment of the value based on the one used in the OS. With
corresponding message output to the user. This allows all available rules to
work with the intended user preferences.
Removed the phony rule "checklanguage" and related dependencies, which should
make future maintenance easier.
`Make_mvc.mak` and `Makefile`
Added "originals" rule to match "languages" rule from src/Makefile.
Continued #13589 :
Use predefined variables (`$@`, `$<` for `Makefile` (UNIX) and `$@`, `$?` for `Make_mvc.mak` (MSFT)) instead of the actual file names.
(Adding new rules should become easier.)
Other corrections.
`README.txt`, `README_mvc.txt` and `README_mingv.txt`
Updated documentation.
