### PR TITLE
src: revision Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2070,7 +2070,7 @@ xxd/xxd$(EXEEXT): xxd/xxd.c
 languages:
 	@if test -n "$(MAKEMO)" -a -f $(PODIR)/Makefile; then \
 		cd $(PODIR); \
-		  CC="$(CC)" $(MAKE) prefix=$(DESTDIR)$(prefix); \
+		  CC="$(CC)" $(MAKE) prefix=$(DESTDIR)$(prefix) originals; \
 	fi
 	-@if test -n "$(MAKEMO)" -a -f $(PODIR)/Makefile; then \
 		cd $(PODIR); \


### PR DESCRIPTION
Added the rule name "originals" to the $(MAKE) call of the "languages" rule to
match the description in the comment.
The corresponding rule is added to "po/Makefile".
