### PR TITLE
Fix duplicate help tag E741

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3001,7 +3001,7 @@ foldtextresult({lnum})					*foldtextresult()*
 foreach({expr1}, {expr2})					*foreach()*
 		{expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
 		For each item in {expr1} execute {expr2}. {expr1} is not
-		modified; its values may be, as with |:lockvar| 1. *E741*
+		modified; its values may be, as with |:lockvar| 1. |E741|
 		See |map()| and |filter()| to modify {expr1}.
 
 		{expr2} must be a |string| or |Funcref|.

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5167,7 +5167,6 @@ E738	eval.txt	/*E738*
 E739	builtin.txt	/*E739*
 E74	message.txt	/*E74*
 E740	userfunc.txt	/*E740*
-E741	builtin.txt	/*E741*
 E741	eval.txt	/*E741*
 E742	userfunc.txt	/*E742*
 E743	eval.txt	/*E743*


### PR DESCRIPTION
Fix #13860
BTW, can test for this error with something like the following
```
$ awk '{print $3}' < tags | sort > xx1
$ uniq xx1 > xx2
$ diff xx1 xx2
```