### PR TITLE
CI: Check help tags for errors (duplicates, missing, etc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,12 @@ jobs:
         if: contains(matrix.extra, 'vimtags')
         run: |
           # This will exit with an error code if the generated vim tags differs from source.
-          git diff --exit-code -- runtime/doc/tags
+          (
+            cd runtime/doc
+            git diff --exit-code -- tags
+            make html; rm *.html tags.ref;
+            test -f errors.log && exit 3;
+          )
 
       - name: Generate gcov files
         if: matrix.coverage

--- a/runtime/doc/maketags.awk
+++ b/runtime/doc/maketags.awk
@@ -21,6 +21,13 @@ NR == 1 { nf=split(FILENAME,f,".")
 	gsub(/%/,"\\&#37;");
 
 	nf=split($0,tag,"	");
+	if (counttag[tag[1]] > 0)
+	{
+		print "==============" > "errors.log"
+		print "Duplicate Tag " tag[1] > "errors.log"
+		print "==============" > "errors.log"
+	}
+	counttag[tag[1]]++
 	tagkey[t]=tag[1];tagref[t]=tag[2];tagnum[t]=NR;
 	print $1 "	" $2 "	line " NR >"tags.ref"
 	n=split($2,w,".");


### PR DESCRIPTION
- Run the doc make html awk script, which also checks, that all referenced help tags exists.
- Run the doc make tags awk script, which checks for duplicates
- in case of any error in the previous two steps, exit the CI with an error and show the errors.log file, that is generated by the previous 2 steps