### PR TITLE
Window scrolls unexpectedly when 'scrollbind' is set

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -4924,6 +4924,10 @@ f_setbufvar(typval_T *argvars, typval_T *rettv UNUSED)
     if (*varname == '&')
     {
 	aco_save_T	aco;
+	// safe the current window position, it could
+	// change because of 'scrollbind' window-local
+	// options
+	linenr_T	old_topline = curwin->w_topline;
 
 	// Set curbuf to be our buf, temporarily.
 	aucmd_prepbuf(&aco, buf);
@@ -4935,6 +4939,7 @@ f_setbufvar(typval_T *argvars, typval_T *rettv UNUSED)
 	    // reset notion of buffer
 	    aucmd_restbuf(&aco);
 	}
+	curwin->w_topline = old_topline;
     }
     else
     {

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4215,4 +4215,22 @@ func Test_popup_close_callback_recursive()
   set maxfuncdepth&
 endfunc
 
+func Test_popupwin_setbufvar_changing_window_view()
+  " Test for Github Issue https://github.com/vim/vim/issues/13863
+  " using setbufvar(buf, '&option') should not scroll
+  " the current window
+  20new
+  call append(0, range(1, 25))
+  setlocal scrollbind
+  norm! G
+  let topline = winsaveview()['topline']
+  call setbufvar(winbufnr(popup_atcursor(['foobar'], {})), '&syntax', 'python')
+  " close popup
+  call popup_clear()
+  call assert_equal(topline, winsaveview()['topline'])
+
+  " clean up
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2


### PR DESCRIPTION
Problem:  Window may unexpectedly scroll when 'scrollbind' is set
          and setting a buffer-local option using setbufvar()
          (Boris Staletic)
Solution: Save and restore the windows topline before opening the
          popup window.

fixes: #13863