### PR TITLE
Insert mode not stopped if closing prompt buffer modifies hidden buffer

### DIFF
--- a/src/testdir/test_prompt_buffer.vim
+++ b/src/testdir/test_prompt_buffer.vim
@@ -297,4 +297,36 @@ func Test_prompt_appending_while_hidden()
   call StopVimInTerminal(buf)
 endfunc
 
+" Modifying a hidden buffer while closing a prompt buffer should not prevent
+" stopping of Insert mode.
+func Test_prompt_close_modify_hidden()
+  call CanTestPromptBuffer()
+
+  let script =<< trim END
+      file hidden
+      set bufhidden=hide
+      enew
+      new prompt
+      set buftype=prompt
+
+      inoremap <buffer> q <Cmd>bwipe!<CR>
+      autocmd BufWinLeave prompt call setbufline('hidden', 1, 'Test')
+  END
+  call writefile(script, 'XpromptCloseModifyHidden', 'D')
+
+  let buf = RunVimInTerminal('-S XpromptCloseModifyHidden', {'rows': 10})
+  call TermWait(buf)
+
+  call term_sendkeys(buf, "a")
+  call WaitForAssert({-> assert_match('-- INSERT --', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, "q")
+  call WaitForAssert({-> assert_notmatch('-- INSERT --', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, ":bwipe!\<CR>")
+  call WaitForAssert({-> assert_equal('Test', term_getline(buf, 1))})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -2362,7 +2362,7 @@ leaving_window(win_T *win)
     // When leaving the window (or closing the window) was done from a
     // callback we need to break out of the Insert mode loop and restart Insert
     // mode when entering the window again.
-    if (State & MODE_INSERT)
+    if ((State & MODE_INSERT) && !stop_insert_mode)
     {
 	stop_insert_mode = TRUE;
 	if (win->w_buffer->b_prompt_insert == NUL)


### PR DESCRIPTION
Problem:  Insert mode not stopped if an autocommand modifies a hidden
          buffer while closing a prompt buffer.
Solution: Don't set b_prompt_insert if stop_insert_mode is already set.
