### PR TITLE
Modifying hidden buffer still interferes with prompt buffer mode changes

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -1565,9 +1565,12 @@ aucmd_prepbuf(
     }
 
     aco->save_curwin_id = curwin->w_id;
-    aco->save_curbuf = curbuf;
     aco->save_prevwin_id = prevwin == NULL ? 0 : prevwin->w_id;
     aco->save_State = State;
+#ifdef FEAT_JOB_CHANNEL
+    if (bt_prompt(curbuf))
+	aco->save_prompt_insert = curbuf->b_prompt_insert;
+#endif
 
     if (win != NULL)
     {
@@ -1692,6 +1695,8 @@ win_found:
 #ifdef FEAT_JOB_CHANNEL
 	// May need to restore insert mode for a prompt buffer.
 	entering_window(curwin);
+	if (bt_prompt(curbuf))
+	    curbuf->b_prompt_insert = aco->save_prompt_insert;
 #endif
 	prevwin = win_find_by_id(aco->save_prevwin_id);
 #ifdef FEAT_EVAL

--- a/src/structs.h
+++ b/src/structs.h
@@ -4358,7 +4358,6 @@ typedef int vimmenu_T;
  */
 typedef struct
 {
-    buf_T	*save_curbuf;	    // saved curbuf
     int		use_aucmd_win_idx;  // index in aucmd_win[] if >= 0
     int		save_curwin_id;	    // ID of saved curwin
     int		new_curwin_id;	    // ID of new curwin
@@ -4367,6 +4366,9 @@ typedef struct
     char_u	*globaldir;	    // saved value of globaldir
     int		save_VIsual_active; // saved VIsual_active
     int		save_State;	    // saved State
+#ifdef FEAT_JOB_CHANNEL
+    int		save_prompt_insert; // saved b_prompt_insert
+#endif
 } aco_save_T;
 
 /*

--- a/src/testdir/test_prompt_buffer.vim
+++ b/src/testdir/test_prompt_buffer.vim
@@ -297,9 +297,10 @@ func Test_prompt_appending_while_hidden()
   call StopVimInTerminal(buf)
 endfunc
 
-" Modifying a hidden buffer while closing a prompt buffer should not prevent
-" stopping of Insert mode.
-func Test_prompt_close_modify_hidden()
+" Modifying a hidden buffer while leaving a prompt buffer should not prevent
+" stopping of Insert mode, and returning to the prompt buffer later should
+" restore Insert mode.
+func Test_prompt_leave_modify_hidden()
   call CanTestPromptBuffer()
 
   let script =<< trim END
@@ -309,22 +310,34 @@ func Test_prompt_close_modify_hidden()
       new prompt
       set buftype=prompt
 
+      inoremap <buffer> w <Cmd>wincmd w<CR>
       inoremap <buffer> q <Cmd>bwipe!<CR>
-      autocmd BufWinLeave prompt call setbufline('hidden', 1, 'Test')
+      autocmd BufLeave prompt call appendbufline('hidden', '$', 'Leave')
+      autocmd BufEnter prompt call appendbufline('hidden', '$', 'Enter')
+      autocmd BufWinLeave prompt call appendbufline('hidden', '$', 'Close')
   END
-  call writefile(script, 'XpromptCloseModifyHidden', 'D')
+  call writefile(script, 'XpromptLeaveModifyHidden', 'D')
 
-  let buf = RunVimInTerminal('-S XpromptCloseModifyHidden', {'rows': 10})
+  let buf = RunVimInTerminal('-S XpromptLeaveModifyHidden', {'rows': 10})
   call TermWait(buf)
 
   call term_sendkeys(buf, "a")
+  call WaitForAssert({-> assert_match('-- INSERT --', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, "w")
+  call WaitForAssert({-> assert_notmatch('-- INSERT --', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, "\<C-W>w")
   call WaitForAssert({-> assert_match('-- INSERT --', term_getline(buf, 10))})
 
   call term_sendkeys(buf, "q")
   call WaitForAssert({-> assert_notmatch('-- INSERT --', term_getline(buf, 10))})
 
   call term_sendkeys(buf, ":bwipe!\<CR>")
-  call WaitForAssert({-> assert_equal('Test', term_getline(buf, 1))})
+  call WaitForAssert({-> assert_equal('Leave', term_getline(buf, 2))})
+  call WaitForAssert({-> assert_equal('Enter', term_getline(buf, 3))})
+  call WaitForAssert({-> assert_equal('Leave', term_getline(buf, 4))})
+  call WaitForAssert({-> assert_equal('Close', term_getline(buf, 5))})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
Problem:  Modifying a hidden buffer still interferes with prompt buffer
          mode changes.
Solution: Save and restore b_prompt_insert.
