### PR TITLE
Unnecessary loop in getvcol()

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -1482,7 +1482,6 @@ getvcol(
 {
     colnr_T	vcol;
     char_u	*ptr;		// points to current char
-    char_u	*posptr;	// points to char at pos->col
     char_u	*line;		// start of the line
     int		incr;
     int		head;
@@ -1498,24 +1497,6 @@ getvcol(
 
     vcol = 0;
     line = ptr = ml_get_buf(wp->w_buffer, pos->lnum, FALSE);
-    if (pos->col == MAXCOL)
-	posptr = NULL;  // continue until the NUL
-    else
-    {
-	colnr_T i;
-
-	// In a few cases the position can be beyond the end of the line.
-	for (i = 0; i < pos->col; ++i)
-	    if (ptr[i] == NUL)
-	    {
-		pos->col = i;
-		break;
-	    }
-	posptr = ptr + pos->col;
-	if (has_mbyte)
-	    // always start on the first byte
-	    posptr -= (*mb_head_off)(line, posptr);
-    }
 
     init_chartabsize_arg(&cts, wp, pos->lnum, 0, line, line);
     cts.cts_max_head_vcol = -1;
@@ -1577,11 +1558,12 @@ getvcol(
 		    incr = g_chartab[c] & CT_CELL_MASK;
 	    }
 
-	    if (posptr != NULL && ptr >= posptr) // character at pos->col
+	    char_u *next_ptr = ptr + (*mb_ptr2len)(ptr);
+	    if (next_ptr - line > pos->col) // character at pos->col
 		break;
 
 	    vcol += incr;
-	    MB_PTR_ADV(ptr);
+	    ptr = next_ptr;
 	}
     }
     else
@@ -1609,12 +1591,12 @@ getvcol(
 		wp->w_virtcol_first_char = cts.cts_first_char;
 #endif
 
-	    if (posptr != NULL && cts.cts_ptr >= posptr)
-		// character at pos->col
+	    char_u *next_ptr = cts.cts_ptr + (*mb_ptr2len)(cts.cts_ptr);
+	    if (next_ptr - line > pos->col) // character at pos->col
 		break;
 
 	    cts.cts_vcol += incr;
-	    MB_PTR_ADV(cts.cts_ptr);
+	    cts.cts_ptr = next_ptr;
 	}
 	vcol = cts.cts_vcol;
 	ptr = cts.cts_ptr;


### PR DESCRIPTION
Problem:  Unnecessary loop in getvcol().
Solution: Compare next char position with pos->col directly.

The loop below already handles end of line before checking for posptr,
and the next char is after pos->col whether pos->col is at the start or
in the middle of the char in question, so neither the NUL check nor the
mb_head_off() are needed when comparing the position of the next char
with pos->col directly.
