### PR TITLE
Fix: current empty buffer won't be reused by `:drop` command

### DIFF
--- a/src/arglist.c
+++ b/src/arglist.c
@@ -502,7 +502,7 @@ do_arglist(
     void
 set_arglist(char_u *str)
 {
-    do_arglist(str, AL_SET, 0, FALSE);
+    do_arglist(str, AL_SET, 0, TRUE);
 }
 
 /*

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5425,8 +5425,7 @@ ex_smile(exarg_T *eap UNUSED)
 
 /*
  * ":drop"
- * Opens the first argument in a window.  When there are two or more arguments
- * the argument list is redefined.
+ * Opens the first argument in a window, and the argument list is redefined.
  */
     void
 ex_drop(exarg_T *eap)
@@ -5463,6 +5462,8 @@ ex_drop(exarg_T *eap)
 	// edited in a window yet.  It's like ":tab all" but without closing
 	// windows or tabs.
 	ex_all(eap);
+	cmdmod.cmod_tab = 0;
+	ex_rewind(eap);
 	return;
     }
 
@@ -5486,7 +5487,6 @@ ex_drop(exarg_T *eap)
 		buf_check_timestamp(curbuf, FALSE);
 		curbuf->b_p_ar = save_ar;
 	    }
-	    return;
 	}
     }
 

--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -84,18 +84,27 @@ endfunc
 " Test for the :drop command
 func Test_drop_cmd()
   call writefile(['L1', 'L2'], 'Xdropfile', 'D')
+  " Test for reusing the current buffer
   enew | only
+  let expected_nr = bufnr()
   drop Xdropfile
+  call assert_equal(expected_nr, bufnr())
   call assert_equal('L2', getline(2))
   " Test for switching to an existing window
   below new
   drop Xdropfile
   call assert_equal(1, winnr())
-  " Test for splitting the current window
+  " Test for splitting the current window (set nohidden)
   enew | only
   set modified
   drop Xdropfile
   call assert_equal(2, winnr('$'))
+  " Not splitting the current window even if modified (set hidden)
+  set hidden
+  enew | only
+  set modified
+  drop Xdropfile
+  call assert_equal(1, winnr('$'))
   " Check for setting the argument list
   call assert_equal(['Xdropfile'], argv())
   enew | only!

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -164,6 +164,74 @@ func Test_tabpage_drop()
   bwipe!
   bwipe!
   call assert_equal(1, tabpagenr('$'))
+
+  call assert_equal(1, winnr('$'))
+  call assert_equal('', bufname(''))
+  call writefile(['L1', 'L2'], 'Xdropfile', 'D')
+
+  " Test for ':tab drop single-file': reuse current buffer
+  let expected_nr = bufnr()
+  tab drop Xdropfile
+  call assert_equal(1, tabpagenr('$'))
+  call assert_equal(expected_nr, bufnr())
+  call assert_equal('L2', getline(2))
+  bwipe!
+
+  " Test for ':tab drop single-file': not reuse modified buffer
+  set modified
+  let expected_nr = bufnr() + 1
+  tab drop Xdropfile
+  call assert_equal(2, tabpagenr())
+  call assert_equal(2, tabpagenr('$'))
+  call assert_equal(expected_nr, bufnr())
+  call assert_equal('L2', getline(2))
+  bwipe!
+
+  " Test for ':tab drop single-file': multiple tabs already exist
+  tab split f2
+  tab split f3
+  let expected_nr = bufnr() + 1
+  tab drop Xdropfile
+  call assert_equal(4, tabpagenr())
+  call assert_equal(4, tabpagenr('$'))
+  call assert_equal(expected_nr, bufnr())
+  call assert_equal('L2', getline(2))
+  %bwipe!
+
+  " Test for ':tab drop multi-files': reuse current buffer
+  let expected_nr = bufnr()
+  tab drop Xdropfile f1 f2 f3
+  call assert_equal(1, tabpagenr())
+  call assert_equal(4, tabpagenr('$'))
+  call assert_equal(expected_nr, bufnr())
+  call assert_equal('L2', getline(2))
+  %bwipe!
+
+  " Test for ':tab drop multi-files': not reuse modified buffer
+  set modified
+  let expected_nr = bufnr() + 1
+  tab drop Xdropfile f1 f2 f3
+  call assert_equal(2, tabpagenr())
+  call assert_equal(5, tabpagenr('$'))
+  call assert_equal(expected_nr, bufnr())
+  call assert_equal('L2', getline(2))
+  %bwipe!
+
+  " Test for ':tab drop multi-files': multiple tabs already exist
+  tab split f2
+  tab split f3
+  let expected_nr = bufnr() + 1
+  tab drop a b c
+  call assert_equal(4, tabpagenr())
+  call assert_equal(6, tabpagenr('$'))
+  call assert_equal(expected_nr, bufnr())
+  let expected_nr = bufnr() + 3
+  tab drop Xdropfile f1 f2 f3
+  call assert_equal(5, tabpagenr())
+  call assert_equal(8, tabpagenr('$'))
+  call assert_equal(expected_nr, bufnr())
+  call assert_equal('L2', getline(2))
+  %bwipe!
 endfunc
 
 " Test autocommands
@@ -260,14 +328,14 @@ function Test_tabpage_with_autocmd_tab_drop()
 
   let s:li = []
   tab drop test1
-  call assert_equal(['BufLeave', 'BufEnter'], s:li)
+  call assert_equal(['BufEnter'], s:li)
 
   let s:li = []
   tab drop test2 test3
   call assert_equal([
         \ 'TabLeave', 'TabEnter', 'TabLeave', 'TabEnter',
         \ 'TabLeave', 'WinEnter', 'TabEnter', 'BufEnter',
-        \ 'TabLeave', 'WinEnter', 'TabEnter', 'BufEnter'], s:li)
+        \ 'TabLeave', 'WinEnter', 'TabEnter', 'BufEnter', 'BufEnter'], s:li)
 
   autocmd! TestTabpageGroup
   augroup! TestTabpageGroup


### PR DESCRIPTION
Fix #13851

If the current buffer is an empty `[No Name]` buffer and has not been modified yet, the `:drop` command does not reuse it like the `:next` command does. This is caused by the default parameters of the `do_arglist` function when calling the `set_arglist` function in `ex_drop` as follows:

https://github.com/vim/vim/blob/211211052d0426394cbd5f42f3f3f78a64822e2a/src/ex_cmds.c#L5450

I can't modify it directly here, for example `do_arglist(eap->arg, AL_SET, 0, TRUE);`, because that need to use macro `AL_SET` defined in the *arglist.c* file. By globally searching for calls to the function `set_arglist`, only called here in `ex_drop`, so I modified the initialization parameters of the `do_arglist` function directly.

```c
/*
 * Redefine the argument list.
 */
    void
set_arglist(char_u *str)
{
    do_arglist(str, AL_SET, 0, TRUE);
}
```

Also, I made a slight change to the comment for the `:drop` command because the original comment was ambiguous. Like the `:next` command, the `:drop` command will reset the argument list, even if there is only one parameter, as described in the documentation [`:h :drop`](https://github.com/vim/vim/blob/211211052d0426394cbd5f42f3f3f78a64822e2a/runtime/doc/windows.txt#L801).
