### PR TITLE
ml_get: invalid lnum on :s command with visual selection

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -1318,6 +1318,10 @@ reg_match_visual(void)
 	    top = curbuf->b_visual.vi_end;
 	    bot = curbuf->b_visual.vi_start;
 	}
+	// a substitue command may have
+	// removed some lines
+	if (bot.lnum > curbuf->b_ml.ml_line_count)
+	    bot.lnum = curbuf->b_ml.ml_line_count;
 	mode = curbuf->b_visual.vi_mode;
 	curswant = curbuf->b_visual.vi_curswant;
     }

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1622,4 +1622,12 @@ func Test_visual_drag_out_of_window()
   bwipe!
 endfunc
 
+func Test_visual_substitute_visual()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  call feedkeys("Gk\<C-V>j$:s/\\%V\\_.*\\%V/foobar\<CR>", 'tx')
+  call assert_equal(['one', 'foobar'], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  ml_get: invalid lnum on :s command with visual selection
          (@ropery)
Solution: substitute may decrement the number of lines in a buffer,
          so validate, that the bottom lines stays within the max
          available buffer line

fixes: #13890