### PR TITLE
Fix blockwise paste with multibyte characters

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -1903,10 +1903,10 @@ do_put(
 		spaces = y_width + 1;
 		init_chartabsize_arg(&cts, curwin, 0, 0,
 						      y_array[i], y_array[i]);
-		for (j = 0; j < yanklen; j++)
+
+		while (*cts.cts_ptr != NUL)
 		{
-		    spaces -= lbr_chartabsize(&cts);
-		    ++cts.cts_ptr;
+		    spaces -= lbr_chartabsize_adv(&cts);
 		    cts.cts_vcol = 0;
 		}
 		clear_chartabsize_arg(&cts);

--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -12,6 +12,16 @@ func Test_put_block()
   bwipe!
 endfunc
 
+func Test_put_block_unicode()
+  new
+  call setreg('a', "À\nÀÀ\naaaaaaaaaaaa", "\<C-V>")
+  call setline(1, [' 1', ' 2', ' 3'])
+  exe "norm! \<C-V>jj\"ap"
+  let expected = ['À           1', 'ÀÀ          2', 'aaaaaaaaaaaa3']
+  call assert_equal(expected, getline(1, 3))
+  bw!
+endfunc
+
 func Test_put_char_block()
   new
   call setline(1, ['Line 1', 'Line 2'])


### PR DESCRIPTION
Problem: incorrect number of trailing spaces is inserted for multibyte characters when pasting a blockwise register in blockwise visual mode.

When pasting in blockwise visual mode, and the register type is \<CTRL-V\>, vim will align the text after the replaced area by inserting spaces after pasted lines that are shorter than the longest line.
When a shorter line contains multibyte characters, each trailing UTF-8 byte's width is counted in addition to the width of the character itself. Each trailing byte counts as being 4 cells wide (since it would be displayed as `<xx>`).
![image](https://github.com/vim/vim/assets/65824523/a66e9c72-0fbe-4bb7-a1b5-922d4e37b90b) ![image](https://github.com/vim/vim/assets/65824523/cf52d4db-6832-421c-b468-7b10bf2dd7ca)

Solution:  skip over trailing UTF-8 bytes when computing the number of trailing spaces.