### PR TITLE
perf(internal_format): optimize gq for long lines

### DIFF
--- a/src/textformat.c
+++ b/src/textformat.c
@@ -91,10 +91,16 @@ internal_format(
 	int	wcc;			// counter for whitespace chars
 	int	did_do_comment = FALSE;
 
-	virtcol = get_nolist_virtcol()
-				   + char2cells(c != NUL ? c : gchar_cursor());
-	if (virtcol <= (colnr_T)textwidth)
-	    break;
+	// Cursor is currently at the end of line. No need to format
+	// if line length is less than textwidth (8 * textwidth for
+	// utf safety)
+	if (curwin->w_cursor.col < 8 * textwidth)
+	{
+	    virtcol = get_nolist_virtcol()
+		+ char2cells(c != NUL ? c : gchar_cursor());
+	    if (virtcol <= (colnr_T)textwidth)
+		break;
+	}
 
 	if (no_leader)
 	    do_comments = FALSE;
@@ -144,10 +150,16 @@ internal_format(
 	coladvance((colnr_T)textwidth);
 	wantcol = curwin->w_cursor.col;
 
-	curwin->w_cursor.col = startcol;
+	// If startcol is large (a long line), formatting takes too much
+	// time. The algorithm is O(n^2), it walks from the end of the
+	// line to textwidth border every time for each line break.
+	//
+	// Ceil to 8 * textwidth to optimize.
+	curwin->w_cursor.col = startcol < 8 * textwidth ? startcol : 8 * textwidth;
 	foundcol = 0;
 	skip_pos = 0;
 
+	int first_pass = TRUE;
 	// Find position to break at.
 	// Stop at first entered white when 'formatoptions' has 'v'
 	while ((!fo_ins_blank && !has_format_option(FO_INS_VI))
@@ -155,10 +167,16 @@ internal_format(
 		    || curwin->w_cursor.lnum != Insstart.lnum
 		    || curwin->w_cursor.col >= Insstart.col)
 	{
-	    if (curwin->w_cursor.col == startcol && c != NUL)
+	    if (first_pass && c != NUL)
+	    {
 		cc = c;
+		first_pass = FALSE;
+	    }
 	    else
+	    {
 		cc = gchar_cursor();
+	    }
+
 	    if (WHITECHAR(cc))
 	    {
 		// remember position of blank just before text


### PR DESCRIPTION
I was editing a relatively big text file with a single line (4 Mb). I tried to format the line with `gq` and neovim stuck. Profiling with callgrind, I found out that the culprits were the `n^2` nature of the algorithm (going backwards from the end of the line each time) and the expensive utf check for whether the line is longer than textwidth.

I implemented kind of hacky workarounds for both problems, involving a magic `8 * textwidth` constant, and the time is now relatively ok (the new bottleneck is `open_line`, but I won't go there).

### Benchmark 1: long lines
`python -c "print((('a' * 79 + ' ') * 750)[:-1])" > line60000.txt`
`time vim -u NONE -c 'normal gqgq' -c 'q!' line60000.txt`

Original:
```
real	0m0.420s
user	0m0.398s
sys	0m0.020s
```

Optimized:
```
real	0m0.031s
user	0m0.013s
sys	0m0.017s
```

The difference only grows with the line getting longer.

### Benchmark 2: lots of small lines:
`yes $(python -c "print('a' * 79 + ' a')") | head -n 10000 > lines10000.txt`
`time vim -u NONE -c 'normal ggVGgq' -c 'q!' lines10000.txt`

Original:
```
real	0m0.095s
user	0m0.084s
sys	0m0.010s
```
Optimized:
```
real	0m0.094s
user	0m0.083s
sys	0m0.010s
```

---

I manually tested to see whether `8 * textwidth` limit made the difference on the actual formatting done and found none.

This was originally a [PR](https://github.com/neovim/neovim/pull/27179) to neovim, but I got recommended to contribute here first.

Interestingly, in Neovim my changes slow down the many lines case, but in Vim there is no difference.