### PR TITLE
Recorded register cannot be translated using keytrans()

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1339,12 +1339,12 @@ gotchars(char_u *chars, int len)
 }
 
 /*
- * Record a <Nop> key.
+ * Record an <Ignore> key.
  */
     void
-gotchars_nop(void)
+gotchars_ignore(void)
 {
-    char_u nop_buf[3] = { K_SPECIAL, KS_EXTRA, KE_NOP };
+    char_u nop_buf[3] = { K_SPECIAL, KS_EXTRA, KE_IGNORE };
     gotchars(nop_buf, 3);
 }
 
@@ -3666,9 +3666,9 @@ vgetorpeek(int advance)
 #endif
     if (timedout && c == ESC)
     {
-	// When recording there will be no timeout.  Add a <Nop> after the ESC
-	// to avoid that it forms a key code with following characters.
-	gotchars_nop();
+	// When recording there will be no timeout.  Add an <Ignore> after the
+	// ESC to avoid that it forms a key code with following characters.
+	gotchars_ignore();
     }
 
     --vgetc_busy;

--- a/src/normal.c
+++ b/src/normal.c
@@ -568,10 +568,10 @@ normal_cmd_get_more_chars(
 	    ++no_mapping;
 	    // Vim may be in a different mode when the user types the next key,
 	    // but when replaying a recording the next key is already in the
-	    // typeahead buffer, so record a <Nop> before that to prevent the
-	    // vpeekc() above from applying wrong mappings when replaying.
+	    // typeahead buffer, so record an <Ignore> before that to prevent
+	    // the vpeekc() above from applying wrong mappings when replaying.
 	    ++no_u_sync;
-	    gotchars_nop();
+	    gotchars_ignore();
 	    --no_u_sync;
 	}
     }

--- a/src/proto/getchar.pro
+++ b/src/proto/getchar.pro
@@ -30,7 +30,7 @@ int typebuf_changed(int tb_change_cnt);
 int typebuf_typed(void);
 int typebuf_maplen(void);
 void del_typebuf(int len, int offset);
-void gotchars_nop(void);
+void gotchars_ignore(void);
 void ungetchars(int len);
 int save_typebuf(void);
 void save_typeahead(tasave_T *tp);

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -868,6 +868,8 @@ func Test_replay_charsearch_omap()
   call timer_start(10, {-> feedkeys(",bar\<Esc>q", 't')})
   call feedkeys('qrct[', 'xt!')
   call assert_equal(',bar[blah]', getline(1))
+  call assert_equal("ct[\<Ignore>,bar\<Esc>", @r)
+  call assert_equal('ct[<Ignore>,bar<Esc>', keytrans(@r))
   undo
   call assert_equal('foo[blah]', getline(1))
   call feedkeys('@r', 'xt!')


### PR DESCRIPTION
Problem:  Recorded register cannot be translated using keytrans() when
          it involves character search.
Solution: Record a K_IGNORE instead of a K_NOP.

related: #13916
