### PR TITLE
work around neovim bug for lispoptions<

### DIFF
--- a/runtime/indent/racket.vim
+++ b/runtime/indent/racket.vim
@@ -3,7 +3,7 @@
 " Maintainer:           D. Ben Knoble <ben.knoble+github@gmail.com>
 " Previous Maintainer:  Will Langstroth <will@langstroth.com>
 " URL:                  https://github.com/benknoble/vim-racket
-" Last Change:          2023 Jul 17
+" Last Change:          2024 Jan 30
 
 if exists("b:did_indent")
    finish
@@ -66,4 +66,4 @@ setlocal lispwords+=if-view,case-view,cond-view,list-view,dyn-view
 setlocal lispwords+=case/dep
 setlocal lispwords+=define/obs
 
-let b:undo_indent = "setlocal indentexpr< lisp< lispoptions< ai< si< lw<"
+let b:undo_indent = "setlocal lisp< ai< si< lw<" .. (has('vim9script') ? 'indentexpr< lispoptions<' : '')


### PR DESCRIPTION
This copies commit 64edf95 (indent: only reset some options when has vim9, 2024-01-30) from https://github.com/benknoble/vim-racket.