### PR TITLE
Fixing remote file removal via ssh

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -10668,7 +10668,7 @@ fun! s:NetrwRemoteRmFile(path,rmfile,all)
       NetrwKeepj call netrw#ErrorMsg(s:ERROR,"for some reason b:netrw_curdir doesn't exist!",53)
       let ok="q"
      else
-      let remotedir= substitute(b:netrw_curdir,'^.*//[^/]\+/\(.*\)$','\1','')
+      let remotedir= substitute(b:netrw_curdir,'^.\{-}//[^/]\+/\(.*\)$','\1','')
 "      call Decho("netrw_rm_cmd<".netrw_rm_cmd.">",'~'.expand("<slnum>"))
 "      call Decho("remotedir<".remotedir.">",'~'.expand("<slnum>"))
 "      call Decho("rmfile<".a:rmfile.">",'~'.expand("<slnum>"))


### PR DESCRIPTION
When trying to delete a file with a path like `scp://user@host//opt/program/file.ext` it fails.
After some tampering I found the actual ssh command was trying to delete `program/file.ext` instead of `/opt/program/file.ext`.
The issue is the regular expression used to extract the path. The original one (`^.*//[^/]\+/\(.*\)$`) is greedy and the '.*' expression matches `scp://user@host`.
In order to get it right we must use a non-greedy one (`.\{-}`) which will only match `scp:`.
