### PR TITLE
fix compl_curr_match not correct when new leader add

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1363,6 +1363,10 @@ ins_compl_show_pum(void)
     pum_display(compl_match_array, compl_match_arraysize, cur);
     curwin->w_cursor.col = col;
 
+    // After adding leader, set the current match to shown match.
+    if (compl_started && compl_curr_match != compl_shown_match)
+	compl_curr_match = compl_shown_match;
+
 #ifdef FEAT_EVAL
     if (has_completechanged())
 	trigger_complete_changed_event(cur);

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -1159,9 +1159,21 @@ func Test_CompleteChanged()
   call feedkeys("a\<C-N>\<C-N>\<C-N>\<C-N>\<C-P>", 'tx')
   call assert_equal('foobar', g:word)
 
+  func Omni_test(findstart, base)
+    if a:findstart
+      return col(".")
+    endif
+    return [#{word: "one"}, #{word: "two"}, #{word: "five"}]
+  endfunc
+  set omnifunc=Omni_test
+  set completeopt=menu,menuone
+  call feedkeys("i\<C-X>\<C-O>\<BS>\<BS>\<BS>f", 'tx')
+  call assert_equal('five', g:word)
+
   autocmd! AAAAA_Group
   set complete& completeopt&
   delfunc! OnPumChange
+  delfunc! Omni_test
   bw!
 endfunc
 


### PR DESCRIPTION
Problem: when delete leader then add new leader the `compl_curr_match` value not sync to shown match value . it will cause the `completed_item` in `CompelteChanged` event not correct.

Solution: update the `compl_curr_match` to `compl_shown_match` when new leader add after delete leader when pum display.