### PR TITLE
did_set_breakat() should be in optionstr.c

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -3269,27 +3269,6 @@ did_set_binary(optset_T *args)
     return NULL;
 }
 
-#if defined(FEAT_LINEBREAK) || defined(PROTO)
-/*
- * Called when the 'breakat' option changes value.
- */
-    char *
-did_set_breakat(optset_T *args UNUSED)
-{
-    char_u	*p;
-    int		i;
-
-    for (i = 0; i < 256; i++)
-	breakat_flags[i] = FALSE;
-
-    if (p_breakat != NULL)
-	for (p = p_breakat; *p; p++)
-	    breakat_flags[*p] = TRUE;
-
-    return NULL;
-}
-#endif
-
 /*
  * Process the updated 'buflisted' option value.
  */

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1208,6 +1208,25 @@ expand_set_belloff(optexpand_T *args, int *numMatches, char_u ***matches)
 
 #if defined(FEAT_LINEBREAK) || defined(PROTO)
 /*
+ * The 'breakat' option is changed.
+ */
+    char *
+did_set_breakat(optset_T *args UNUSED)
+{
+    char_u	*p;
+    int		i;
+
+    for (i = 0; i < 256; i++)
+	breakat_flags[i] = FALSE;
+
+    if (p_breakat != NULL)
+	for (p = p_breakat; *p; p++)
+	    breakat_flags[*p] = TRUE;
+
+    return NULL;
+}
+
+/*
  * The 'breakindentopt' option is changed.
  */
     char *

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -29,7 +29,6 @@ char *did_set_autochdir(optset_T *args);
 char *did_set_ballooneval(optset_T *args);
 char *did_set_balloonevalterm(optset_T *args);
 char *did_set_binary(optset_T *args);
-char *did_set_breakat(optset_T *args);
 char *did_set_buflisted(optset_T *args);
 char *did_set_cmdheight(optset_T *args);
 char *did_set_compatible(optset_T *args);

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -20,6 +20,7 @@ int expand_set_backupcopy(optexpand_T *args, int *numMatches, char_u ***matches)
 char *did_set_backupext_or_patchmode(optset_T *args);
 char *did_set_belloff(optset_T *args);
 int expand_set_belloff(optexpand_T *args, int *numMatches, char_u ***matches);
+char *did_set_breakat(optset_T *args);
 char *did_set_breakindentopt(optset_T *args);
 int expand_set_breakindentopt(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_browsedir(optset_T *args);


### PR DESCRIPTION
Problem:  did_set_breakat() should be in optionstr.c as 'breakat' is a
          string option.
Solution: Move did_set_breakat() to optionstr.c.
