### PR TITLE
Allow modifying a final variable with a List value in-place using the += compound operator

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2093,7 +2093,7 @@ diff({fromlist}, {tolist} [, {options}])		*diff()*
 		Returns an empty List or String if {fromlist} and {tolist} are
 		identical.
 
-		Examples:
+		Examples: >
 		    :echo diff(['abc'], ['xxx'])
 		     @@ -1 +1 @@
 		     -abc
@@ -2103,7 +2103,7 @@ diff({fromlist}, {tolist} [, {options}])		*diff()*
 		     [{'from_idx': 0, 'from_count': 1, 'to_idx': 0, 'to_count': 1}]
 		    :echo diff(readfile('oldfile'), readfile('newfile'))
 		    :echo diff(getbufline(5, 1, '$'), getbufline(6, 1, '$'))
-
+<
 		For more examples, refer to |diff-func-examples|
 
 		Can also be used as a |method|: >

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -425,6 +425,18 @@ To change part of a list you can specify the first and last item to be
 modified.  The value must at least have the number of items in the range: >
 	:let list[3:5] = [3, 4, 5]
 
+To add items to a List in-place, you can use the |+=| operator: >
+	:let listA = [1, 2]
+	:let listA += [3, 4]
+<
+When two variables refer to the same List, changing one List in-place will
+cause the referenced List to be changed in-place: >
+	:let listA = [1, 2]
+	:let listB = listA
+	:let listB += [3, 4]
+	:echo listA
+	[1, 2, 3, 4]
+<
 Adding and removing items from a list is done with functions.  Here are a few
 examples: >
 	:call insert(list, 'a')		" prepend item 'a'

--- a/src/eval.c
+++ b/src/eval.c
@@ -1901,7 +1901,7 @@ set_var_lval(
 			   && !tv_check_lock(&di->di_tv, lp->ll_name, FALSE)))
 			&& tv_op(&tv, rettv, op) == OK)
 		    set_var_const(lp->ll_name, lp->ll_sid, NULL, &tv, FALSE,
-							    ASSIGN_NO_DECL, 0);
+				ASSIGN_NO_DECL | ASSIGN_COMPOUND_OP, 0);
 		clear_tv(&tv);
 	    }
 	}

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -3977,8 +3977,14 @@ set_var_const(
 	    if (check_typval_is_value(&di->di_tv) == FAIL)
 		goto failed;
 
+	    // List and Blob types can be modified in-place using the "+="
+	    // compound operator.  For other types, this is not allowed.
+	    int type_inplace_modifiable =
+		(di->di_tv.v_type == VAR_LIST || di->di_tv.v_type == VAR_BLOB);
+
 	    if (var_in_vim9script && (flags & ASSIGN_FOR_LOOP) == 0
-		    && (flags & ASSIGN_COMPOUND_OP) == 0)
+		    && ((flags & ASSIGN_COMPOUND_OP) == 0
+			|| !type_inplace_modifiable))
 	    {
 		where_T where = WHERE_INIT;
 		svar_T  *sv = find_typval_in_script(&di->di_tv, sid, TRUE);
@@ -3999,8 +4005,11 @@ set_var_const(
 		}
 	    }
 
+	    // Modifying a final variable with a List value using the "+="
+	    // operator is allowed.  For other types, it is not allowed.
 	    if (((flags & ASSIGN_FOR_LOOP) == 0
-			&& (flags & ASSIGN_COMPOUND_OP) == 0)
+			&& ((flags & ASSIGN_COMPOUND_OP) == 0
+			    || !type_inplace_modifiable))
 				 ? var_check_permission(di, name) == FAIL
 				 : var_check_ro(di->di_flags, name, FALSE))
 		goto failed;

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -3977,7 +3977,8 @@ set_var_const(
 	    if (check_typval_is_value(&di->di_tv) == FAIL)
 		goto failed;
 
-	    if (var_in_vim9script && (flags & ASSIGN_FOR_LOOP) == 0)
+	    if (var_in_vim9script && (flags & ASSIGN_FOR_LOOP) == 0
+		    && (flags & ASSIGN_COMPOUND_OP) == 0)
 	    {
 		where_T where = WHERE_INIT;
 		svar_T  *sv = find_typval_in_script(&di->di_tv, sid, TRUE);
@@ -3998,7 +3999,8 @@ set_var_const(
 		}
 	    }
 
-	    if ((flags & ASSIGN_FOR_LOOP) == 0
+	    if (((flags & ASSIGN_FOR_LOOP) == 0
+			&& (flags & ASSIGN_COMPOUND_OP) == 0)
 				 ? var_check_permission(di, name) == FAIL
 				 : var_check_ro(di->di_flags, name, FALSE))
 		goto failed;

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -3484,33 +3484,60 @@ def Test_assign_type_to_list_dict()
   v9.CheckScriptFailure(lines, 'E1407: Cannot use a Typealias as a variable or value')
 enddef
 
+" Test for modifying a final variable using a compound operator
+def Test_final_var_modification_with_compound_op()
+  var lines =<< trim END
+    vim9script
+
+    final i: number = 1000
+    assert_fails('i += 2', 'E46: Cannot change read-only variable "i"')
+    assert_fails('i -= 2', 'E46: Cannot change read-only variable "i"')
+    assert_fails('i *= 2', 'E46: Cannot change read-only variable "i"')
+    assert_fails('i /= 2', 'E46: Cannot change read-only variable "i"')
+    assert_fails('i %= 2', 'E46: Cannot change read-only variable "i"')
+    assert_equal(1000, i)
+
+    final f: float = 1000.0
+    assert_fails('f += 2', 'E46: Cannot change read-only variable "f"')
+    assert_fails('f -= 2', 'E46: Cannot change read-only variable "f"')
+    assert_fails('f *= 2', 'E46: Cannot change read-only variable "f"')
+    assert_fails('f /= 2', 'E46: Cannot change read-only variable "f"')
+    assert_equal(1000.0, f)
+
+    final s: string = 'abc'
+    assert_fails('s ..= "y"', 'E46: Cannot change read-only variable "s"')
+    assert_equal('abc', s)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " Test for modifying a final variable with a List value
 def Test_final_var_with_list_value()
   var lines =<< trim END
     vim9script
 
-    final l: list<string> = []
-    var l1 = l
+    final listA: list<string> = []
+    var listB = listA
 
-    l1->add('a')
-    assert_true(l is l1)
-    assert_equal(['a'], l)
-    assert_equal(['a'], l1)
+    listB->add('a')
+    assert_true(listA is listB)
+    assert_equal(['a'], listA)
+    assert_equal(['a'], listB)
 
-    l1 += ['b']
-    assert_true(l is l1)
-    assert_equal(['a', 'b'], l)
-    assert_equal(['a', 'b'], l1)
+    listB += ['b']
+    assert_true(listA is listB)
+    assert_equal(['a', 'b'], listA)
+    assert_equal(['a', 'b'], listB)
 
-    l->add('c')
-    assert_true(l is l1)
-    assert_equal(['a', 'b', 'c'], l)
-    assert_equal(['a', 'b', 'c'], l1)
+    listA->add('c')
+    assert_true(listA is listB)
+    assert_equal(['a', 'b', 'c'], listA)
+    assert_equal(['a', 'b', 'c'], listB)
 
-    l += ['d']
-    assert_true(l is l1)
-    assert_equal(['a', 'b', 'c', 'd'], l)
-    assert_equal(['a', 'b', 'c', 'd'], l1)
+    listA += ['d']
+    assert_true(listA is listB)
+    assert_equal(['a', 'b', 'c', 'd'], listA)
+    assert_equal(['a', 'b', 'c', 'd'], listB)
   END
   v9.CheckScriptSuccess(lines)
 enddef
@@ -3522,5 +3549,36 @@ func Test_final_var_with_list_value_legacy()
   vim9cmd g:TestVar += ['b']
   call assert_equal(['a', 'b'], g:TestVar)
 endfunc
+
+" Test for modifying a final variable with a Blob value
+def Test_final_var_with_blob_value()
+  var lines =<< trim END
+    vim9script
+
+    final blobA: blob = 0z10
+    var blobB = blobA
+
+    blobB->add(32)
+    assert_true(blobA is blobB)
+    assert_equal(0z1020, blobA)
+    assert_equal(0z1020, blobB)
+
+    blobB += 0z30
+    assert_true(blobA is blobB)
+    assert_equal(0z102030, blobA)
+    assert_equal(0z102030, blobB)
+
+    blobA->add(64)
+    assert_true(blobA is blobB)
+    assert_equal(0z10203040, blobA)
+    assert_equal(0z10203040, blobB)
+
+    blobA += 0z50
+    assert_true(blobA is blobB)
+    assert_equal(0z1020304050, blobA)
+    assert_equal(0z1020304050, blobB)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -3484,4 +3484,43 @@ def Test_assign_type_to_list_dict()
   v9.CheckScriptFailure(lines, 'E1407: Cannot use a Typealias as a variable or value')
 enddef
 
+" Test for modifying a final variable with a List value
+def Test_final_var_with_list_value()
+  var lines =<< trim END
+    vim9script
+
+    final l: list<string> = []
+    var l1 = l
+
+    l1->add('a')
+    assert_true(l is l1)
+    assert_equal(['a'], l)
+    assert_equal(['a'], l1)
+
+    l1 += ['b']
+    assert_true(l is l1)
+    assert_equal(['a', 'b'], l)
+    assert_equal(['a', 'b'], l1)
+
+    l->add('c')
+    assert_true(l is l1)
+    assert_equal(['a', 'b', 'c'], l)
+    assert_equal(['a', 'b', 'c'], l1)
+
+    l += ['d']
+    assert_true(l is l1)
+    assert_equal(['a', 'b', 'c', 'd'], l)
+    assert_equal(['a', 'b', 'c', 'd'], l1)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
+" Test for modifying a final variable with a List value using "+=" from a legacy
+" function.
+func Test_final_var_with_list_value_legacy()
+  vim9cmd final g:TestVar = ['a']
+  vim9cmd g:TestVar += ['b']
+  call assert_equal(['a', 'b'], g:TestVar)
+endfunc
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim.h
+++ b/src/vim.h
@@ -2379,6 +2379,7 @@ typedef int (*opt_expand_cb_T)(optexpand_T *args, int *numMatches, char_u ***mat
 #define ASSIGN_FOR_LOOP 0x40 // assigning to loop variable
 #define ASSIGN_INIT	0x80 // not assigning a value, just a declaration
 #define ASSIGN_UPDATE_BLOCK_ID 0x100  // update sav_block_id
+#define ASSIGN_COMPOUND_OP 0x200  // compound operator e.g. "+="
 
 #include "ex_cmds.h"	    // Ex command defines
 #include "spell.h"	    // spell checking stuff


### PR DESCRIPTION
Fixes #13745 and #13959.

As discussed in #13745, the "+=" operator modifies a List variable in-place.  So allow the List value of a final variable to be modified using "+=".

