### PR TITLE
Looping over modifier_keys_table[] unnecessarily

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1130,11 +1130,7 @@ simplify_key(int key, int *modifiers)
     int	    key0;
     int	    key1;
 
-    if (!(*modifiers & (MOD_MASK_SHIFT | MOD_MASK_CTRL | MOD_MASK_ALT
-#ifdef FEAT_GUI_GTK
-	    | MOD_MASK_CMD
-#endif
-    )))
+    if (!(*modifiers & (MOD_MASK_SHIFT | MOD_MASK_CTRL)))
 	return key;
 
     // TAB is a special case


### PR DESCRIPTION
Problem:  Looping over modifier_keys_table[] unnecessarily with only
          MOD_MASK_ALT or MOD_MASK_CMD, as modifier_keys_table[] only
          contains MOD_MASK_SHIFT and MOD_MASK_CTRL, and the loop won't
          do anything.
Solution: Remove MOD_MASK_ALT and MOD_MASK_CMD from the condition.
