### PR TITLE
Fix indent after line with literal dict

### DIFF
--- a/runtime/autoload/dist/vimindent.vim
+++ b/runtime/autoload/dist/vimindent.vim
@@ -381,7 +381,7 @@ const LINE_CONTINUATION_AT_EOL: string = '\%('
     # It can be the start of a dictionary or a block.
     # We only want to match the former.
     .. '\|' .. $'^\%({STARTS_CURLY_BLOCK}\)\@!.*\zs{{'
-    .. '\)\s*\%(\s#.*\)\=$'
+    .. '\)\s*\%(\s#[^{].*\)\=$'
 # }}}2
 # SOL {{{2
 # BACKSLASH_AT_SOL {{{3

--- a/runtime/indent/testdir/vim.in
+++ b/runtime/indent/testdir/vim.in
@@ -946,3 +946,8 @@ Blue
 Black
 endenum
 " END_INDENT
+
+" START_INDENT
+call prop_type_add('indent_after_literal_dict', #{ foo: 'bar' })
+call prop_type_delete('indent_after_literal_dict')
+" END_INDENT

--- a/runtime/indent/testdir/vim.ok
+++ b/runtime/indent/testdir/vim.ok
@@ -946,3 +946,8 @@ enum Color
     Black
 endenum
 " END_INDENT
+
+" START_INDENT
+call prop_type_add('indent_after_literal_dict', #{ foo: 'bar' })
+call prop_type_delete('indent_after_literal_dict')
+" END_INDENT


### PR DESCRIPTION
There seems to be an issue with indentation when the previous line contains a literal dict with `#{ }` delimiters:

```vim
call prop_type_add('indent_after_literal_dict', #{ foo: 'bar' })
    call prop_type_delete('indent_after_literal_dict')
```

The attached patch fixes the issue. The "line continuation" regex ignores a tailing `#.*`, but if the next character after the `#` is a `{`, that shouldn't be considered a comment. This actually means that `#` alone won't be matched there, but oddly enough, indentation seems to work fine in that case for me.