### PR TITLE
Make references to [range] consistent

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1121,7 +1121,7 @@ ShellCmdPost			After executing a shell command with |:!cmd|,
 				check for any changed files.
 							*ShellFilterPost*
 ShellFilterPost			After executing a shell command with
-				":{range}!cmd", ":w !cmd" or ":r !cmd".
+				":[range]!cmd", ":w !cmd" or ":r !cmd".
 				Can be used to check for any changed files.
 							*SourcePre*
 SourcePre			Before sourcing a Vim script. |:source|

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -254,9 +254,9 @@ If you prefer "cw" to include the space after a word, use this mapping: >
 Or use "caw" (see |aw|).
 
 							*:c* *:ch* *:change*
-:{range}c[hange][!]	Replace lines of text with some different text.
+:[range]c[hange][!]	Replace lines of text with some different text.
 			Type a line containing only "." to stop replacing.
-			Without {range}, this command changes only the current
+			Without [range], this command changes only the current
 			line.
 			Adding [!] toggles 'autoindent' for the time this
 			command is executed.
@@ -584,8 +584,8 @@ comment (starting with '"') after the `:!` command.
 {Visual}!{filter}	Filter the highlighted lines through the external
 			program {filter} (for {Visual} see |Visual-mode|).
 
-:{range}![!]{filter} [!][arg]				*:range!*
-			Filter {range} lines through the external program
+:[range]![!]{filter} [!][arg]				*:range!*
+			Filter [range] lines through the external program
 			{filter}.  Vim replaces the optional bangs with the
 			latest given command and appends the optional [arg].
 			Vim saves the output of the filter command in a

--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -48,7 +48,7 @@ There are four main types of jobs:
 
 For when using sockets See |job-start|, |job-start-nochannel| and
 |channel-open|.  For 2 and 3, one or more jobs using pipes, see |job-start|.
-For 4 use the ":{range}!cmd" command, see |filter|.
+For 4 use the ":[range]!cmd" command, see |filter|.
 
 Over the socket and pipes these protocols are available:
 RAW	nothing known, Vim cannot tell where a message ends

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -297,8 +297,8 @@ zf{motion}  or
 							*zF*
 zF		Create a fold for [count] lines.  Works like "zf".
 
-:{range}fo[ld]						*:fold* *:fo*
-		Create a fold for the lines in {range}.  Works like "zf".
+:[range]fo[ld]						*:fold* *:fo*
+		Create a fold for the lines in [range].  Works like "zf".
 
 							*zd* *E351*
 zd		Delete one fold at the cursor.  When the cursor is on a folded
@@ -399,15 +399,15 @@ zr		Reduce folding: Add |v:count1| to 'foldlevel'.
 zR		Open all folds.  This sets 'foldlevel' to highest fold level.
 
 							*:foldo* *:foldopen*
-:{range}foldo[pen][!]
-		Open folds in {range}.  When [!] is added all folds are
-		opened.  Useful to see all the text in {range}.  Without [!]
+:[range]foldo[pen][!]
+		Open folds in [range].  When [!] is added all folds are
+		opened.  Useful to see all the text in [range].  Without [!]
 		one level of folds is opened.
 
 							*:foldc* *:foldclose*
-:{range}foldc[lose][!]
-		Close folds in {range}.  When [!] is added all folds are
-		closed.  Useful to hide all the text in {range}.  Without [!]
+:[range]foldc[lose][!]
+		Close folds in [range].  When [!] is added all folds are
+		closed.  Useful to hide all the text in [range].  Without [!]
 		one level of folds is closed.
 
 							*zn*

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1161,7 +1161,7 @@ The commands are sorted on the non-optional part of their name.
 tag		command		action ~
 ------------------------------------------------------------------------------
 |:|		:		nothing
-|:range|	:{range}	go to last line in {range} (normally denoted |[range]|)
+|:[range]|	:{range}	go to last line in {range} (normally denoted |[range]|)
 |:!|		:!		filter lines or execute an external command
 |:!!|		:!!		repeat last ":!" command
 |:#|		:#		same as ":number"

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1161,7 +1161,7 @@ The commands are sorted on the non-optional part of their name.
 tag		command		action ~
 ------------------------------------------------------------------------------
 |:|		:		nothing
-|:range|	:{range}	go to last line in {range}
+|:range|	:{range}	go to last line in {range} (normally denoted |[range]|)
 |:!|		:!		filter lines or execute an external command
 |:!!|		:!!		repeat last ":!" command
 |:#|		:#		same as ":number"

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1972,8 +1972,8 @@ too long when appending characters a line break is automatically inserted.
 9. Ex insert commands					*inserting-ex*
 
 							*:a* *:append*
-:{range}a[ppend][!]	Insert several lines of text below the specified
-			line.  If the {range} is missing, the text will be
+:[range]a[ppend][!]	Insert several lines of text below the specified
+			line.  If the [range] is missing, the text will be
 			inserted after the current line.
 			Adding [!] toggles 'autoindent' for the time this
 			command is executed.
@@ -1982,8 +1982,8 @@ too long when appending characters a line break is automatically inserted.
 			name.
 
 							*:i* *:in* *:insert*
-:{range}i[nsert][!]	Insert several lines of text above the specified
-			line.  If the {range} is missing, the text will be
+:[range]i[nsert][!]	Insert several lines of text above the specified
+			line.  If the [range] is missing, the text will be
 			inserted before the current line.
 			Adding [!] toggles 'autoindent' for the time this
 			command is executed.
@@ -2043,7 +2043,7 @@ NOTE: These commands cannot be used with |:global| or |:vglobal|.
 			the cursor.
 			See |++opt| for the possible values of [++opt].
 
-:{range}r[ead] [++opt] [name]
+:[range]r[ead] [++opt] [name]
 			Insert the file [name] (default: current file) below
 			the specified line.
 			See |++opt| for the possible values of [++opt].

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1455,7 +1455,7 @@ Context-sensitive completion on the command-line:
 		set foldmethod=marker	folding by 'foldmarker'
 
 |zf|		zf{motion}		operator: Define a fold manually
-|:fold|		:{range}fold		define a fold for {range} lines
+|:fold|		:[range]fold		define a fold for [range] lines
 |zd|		zd			delete one fold under the cursor
 |zD|		zD			delete all folds under the cursor
 

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1279,7 +1279,7 @@ Implement named arguments for functions with optional arguments:
     call Foo(12, all = 0)
 
 Add a command to take a range of lines, filter them and put the output
-somewhere else.  :{range}copy {dest} !cmd
+somewhere else.  :[range]copy {dest} !cmd
 
 The TermResponse event is not triggered when a plugin has set 'eventignore' to
 "all".  Netrw does this. (Gary Johnson, 2017 Jan 24)

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -116,7 +116,7 @@ See |:verbose-cmd| for more information.
 			When the [range] argument is added, the function is
 			expected to take care of a range itself.  The range is
 			passed as "a:firstline" and "a:lastline".  If [range]
-			is excluded, ":{range}call" will call the function for
+			is excluded, ":[range]call" will call the function for
 			each line in the range, with the cursor on the start
 			of each line.  See |function-range-example|.
 			The cursor is still moved to the first line of the

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -134,9 +134,9 @@ if your text can't be properly formatted with Vim's builtin command.  See the
 
 To center a range of lines, use the following command: >
 
-	:{range}center [width]
+	:[range]center [width]
 
-{range} is the usual command-line range.  [width] is an optional line width to
+[range] is the usual command-line range.  [width] is an optional line width to
 use for centering.  If [width] is not specified, it defaults to the value of
 'textwidth'.  (If 'textwidth' is 0, the default is 80.)
    For example: >
@@ -170,7 +170,7 @@ LEFT ALIGNMENT
 
 Finally there is this command: >
 
-	:{range}left [margin]
+	:[range]left [margin]
 
 Unlike ":center" and ":right", however, the argument to ":left" is not the
 length of the line.  Instead it is the left margin.  If it is omitted, the

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -185,7 +185,7 @@ g8			Print the hex values of the bytes used in the
 := [flags]		Print the last line number.
 			See |ex-flags| for [flags].
 
-:{range}= [flags]	Prints the last line number in {range}.  For example,
+:[range]= [flags]	Prints the last line number in [range].  For example,
 			this prints the current line number: >
 				:.=
 <			See |ex-flags| for [flags].
@@ -230,9 +230,9 @@ g8			Print the hex values of the bytes used in the
 			Example: >
 				:exe "normal \<c-w>\<c-w>"
 
-:{range}norm[al][!] {commands}				*:normal-range*
+:[range]norm[al][!] {commands}				*:normal-range*
 			Execute Normal mode commands {commands} for each line
-			in the {range}.  Before executing the {commands}, the
+			in the [range].  Before executing the {commands}, the
 			cursor is positioned in the first column of the range,
 			for each line.  Otherwise it's the same as the
 			":normal" command without a range.

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -76,7 +76,7 @@ static int cause_abort = FALSE;
 
 /*
  * Return TRUE when immediately aborting on error, or when an interrupt
- * occurred or an exception was thrown but not caught.  Use for ":{range}call"
+ * occurred or an exception was thrown but not caught.  Use for ":[range]call"
  * to check whether an aborted function that does not handle a range itself
  * should be called again for the next line in the range.  Also used for
  * cancelling expression evaluation after a function call caused an immediate

--- a/src/match.c
+++ b/src/match.c
@@ -437,7 +437,7 @@ next_search_hl(
     int		called_emsg_before = called_emsg;
     int		timed_out = FALSE;
 
-    // for :{range}s/pat only highlight inside the range
+    // for :[range]s/pat only highlight inside the range
     if ((lnum < search_first_line || lnum > search_last_line) && cur == NULL)
     {
 	shl->lnum = 0;


### PR DESCRIPTION
Some parts of the vimdocs refer to ranges with `{range}` instead of `[range]`.  Since there are more instances of `[range]` and only information on the `[range]` variant exists (`:h [range]` and `:h :[range]` exist, `:h {range}` does not), I made **all** of the references consistent.

---

The EX commands index is the only instance where it is left as `{range}` but consequently clarified as normally being denoted with `[range]`, since that section of the helpdocs uses `[...]` to mean optional.  (`[range]` is not optional for `:[range]`, since it would otherwise be `:`, which is specified as a separate command.)

I also noticed that this line used the wrong tag for the command (it linked to information about ranges, `[range]`, instead of information about the command `:[range]`).

Below is context for what I am referring to (with my proposed changes included):
```
6. EX commands					*ex-cmd-index* *:index*

This is a brief but complete listing of all the ":" commands, without
mentioning any arguments.  The optional part of the command name is inside [].
The commands are sorted on the non-optional part of their name.

tag		command		action ~
------------------------------------------------------------------------------
```
```diff
|:|		:		nothing
-|:range|	:{range}	go to last line in {range}
+|:[range]|	:{range}	go to last line in {range} (normally denoted |[range]|)

```