### PR TITLE
Unnecessary call to redraw_for_cursorline() in nv_mousescroll()

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -2224,10 +2224,6 @@ nv_mousescroll(cmdarg_T *cap)
     // Call the common mouse scroll function shared with other modes.
     do_mousescroll(cap);
 
-#ifdef FEAT_SYN_HL
-    if (curwin != old_curwin && curwin->w_p_cul)
-	redraw_for_cursorline(curwin);
-#endif
     curwin->w_redr_status = TRUE;
     curwin = old_curwin;
     curbuf = curwin->w_buffer;

--- a/src/move.c
+++ b/src/move.c
@@ -19,6 +19,7 @@
 
 #include "vim.h"
 
+static void redraw_for_cursorline(win_T *wp);
 static int scrolljump_value(void);
 static int check_top_offset(void);
 static void curs_rows(win_T *wp);
@@ -155,7 +156,7 @@ comp_botline(win_T *wp)
  * Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is
  * set.
  */
-    void
+    static void
 redraw_for_cursorline(win_T *wp)
 {
     if ((wp->w_p_rnu

--- a/src/proto/move.pro
+++ b/src/proto/move.pro
@@ -1,6 +1,5 @@
 /* move.c */
 int adjust_plines_for_skipcol(win_T *wp);
-void redraw_for_cursorline(win_T *wp);
 int sms_marker_overlap(win_T *wp, int extra2);
 void update_topline_redraw(void);
 void update_topline(void);


### PR DESCRIPTION
Problem:  The call to redraw_for_cursorline() in nv_mousescroll() is
          unnecessary because redraw_for_cursorline() only sets redraw
          type to UPD_VALID, and all code paths in do_mousescroll()
          already set redraw type to at least UPD_VALID.
Solution: Remove call to redraw_for_cursorline() in nv_mousescroll().
