### PR TITLE
trigger CompleteChanged even no match item when completion active

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1350,7 +1350,13 @@ ins_compl_show_pum(void)
     }
 
     if (compl_match_array == NULL)
+    {
+#ifdef FEAT_EVAL
+	if (compl_started && has_completechanged())
+	    trigger_complete_changed_event(cur);
+#endif
 	return;
+    }
 
     // In Replace mode when a $ is displayed at the end of the line only
     // part of the screen would be updated.  We do need to redraw here.

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -1139,6 +1139,10 @@ func Test_CompleteChanged()
     let g:event = copy(v:event)
     let g:item = get(v:event, 'completed_item', {})
     let g:word = get(g:item, 'word', v:null)
+    let l:line = getline('.')
+    if g:word == v:null && l:line == "bc"
+      let g:word = l:line
+    endif
   endfunction
   augroup AAAAA_Group
     au!
@@ -1158,6 +1162,8 @@ func Test_CompleteChanged()
   call assert_equal(v:null, g:word)
   call feedkeys("a\<C-N>\<C-N>\<C-N>\<C-N>\<C-P>", 'tx')
   call assert_equal('foobar', g:word)
+  call feedkeys("S\<C-N>bc", 'tx')
+  call assert_equal("bc", g:word)
 
   func Omni_test(findstart, base)
     if a:findstart


### PR DESCRIPTION
Problem:
after add new leader and when is no matched items (`compl_match_array` is NULL) , vim doesn't fire any events.

Solution:
when completion is actived and no item matched.  still trigger CompletChanged event
