### PR TITLE
Make doc list-concatenation more clear as for += and extend(). #1

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -303,7 +303,9 @@ List concatenation ~
 							*list-concatenation*
 Two lists can be concatenated with the "+" operator: >
 	:let longlist = mylist + [5, 6]
+A list can be concatenated with another one in place using the "+=" operator or |extend()|: >
 	:let mylist += [7, 8]
+	:call extend(mylist, [7, 8])
 
 To prepend or append an item, turn the item into a list by putting [] around
 it.  To change a list in-place, refer to |list-modification| below.


### PR DESCRIPTION
This is a follow up of [pull/13962](https://github.com/vim/vim/pull/13962#issuecomment-1929845084).

Before  commit 1af3563 was accepted. I tried clear the doc for `list-concatenation` in eval.txt

Then after commit 1af3563 being accepted @chrisbra suggest me create PR here instead of on my fork.

Since the situation changes. (My change didn't cope well with newly added lines to eval.txt)


> Should I
> 1. Just forget it and accept commit 1af3563 as final.
> 2. Create a PR and discuss there (which will revert change to eval.txt in commit 1af3563).
> 3. Discuss further here.
> Which one should I choose? @chrisbra 
> 
> P.S., as for reference.
> My appoach, [2 line addition to eval.txt](https://github.com/qeatzy/vim/pull/1/commits/f911dc007011e37eab02859b811f4f9e129c0616)
> commit 1af3563, [More than 10 lines to eval.txt, but IMO still not clear.](https://github.com/vim/vim/commit/1af35631f85d2fcdc83c5d457af8273697f5146a#diff-b3aeef96275167ddcc1e5fee6d51b8f2018f9359f921d86ad6e7035ca80f20e9)

In commit 1af3563, below lines added in eval.txt

> To add items to a List in-place, you can use the |+=| operator: >
> 	:let listA = [1, 2]
> 	:let listA += [3, 4]
> <
> When two variables refer to the same List, changing one List in-place will
> cause the referenced List to be changed in-place: >
> 	:let listA = [1, 2]
> 	:let listB = listA
> 	:let listB += [3, 4]
> 	:echo listA
> 	[1, 2, 3, 4]
> <

Is it too much for new users?
Besides, it didn't mention `extend()` which is *the workhorse* of list concatenation.
Also add to list usually mean adding single item, eg `add()` in vimscript, `append()` in python etc.
Mixing add() with extend()/concat create more confusions.
As I said in [issues/13745](https://github.com/vim/vim/issues/13745#issuecomment-1925685444)

> 4. `add(lst, 'a')` is equivalent to `extend(lst, ['a'])`, but `add()` *is* technically unrelated to list concatenation.

Using *add* here might not be a good idea.

As for attempting to clear identity of listA and listB, the intention is good. But for programmer with other language experience, it's so obvious and just noise. For nor programmer/new user, it probably intimidates rather than enlightens.

So I suggest, revert these lines. Just add two lines.

from old doc
> Two lists can be concatenated with the "+" operator: >
> 	:let longlist = mylist + [5, 6]
> 	:let mylist += [7, 8]

To

> Two lists can be concatenated with the "+" operator: >
> 	:let longlist = mylist + [5, 6]
>  A list can be concatenated with another one in place using the "+=" operator or |extend()|: >
> 	:let mylist += [7, 8]
> 	:call extend(mylist, [7, 8])

So what's your ideas? @chrisbra @yegappan @errael 