### PR TITLE
TextChanged not triggered for :norm! command

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -843,7 +843,12 @@ doESCkey:
 		if (cmdchar != 'r' && cmdchar != 'v' && c != Ctrl_C)
 		    ins_apply_autocmds(EVENT_INSERTLEAVE);
 		did_cursorhold = FALSE;
-		curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
+
+		// ins_redraw() triggers TextChangedI only when no characters
+		// are in the typeahead buffer, so only reset curbuf->b_last_changedtick
+		// if the TextChangedI was not blocked by char_avail() (e.g. using :norm!)
+		if (!char_avail())
+		    curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
 		return (c == Ctrl_O);
 	    }
 	    continue;

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2706,6 +2706,24 @@ func Test_TextChangedI_with_setline()
   bwipe!
 endfunc
 
+func Test_TextChanged_with_norm()
+  " For unknown reason this fails on MS-Windows
+  CheckNotMSWindows
+  CheckFeature terminal
+  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': 3})
+  call assert_equal('running', term_getstatus(buf))
+  call term_sendkeys(buf, ":let g:a=0\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":au! TextChanged * :let g:a+=1\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":norm! ia\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":echo g:a\<cr>")
+  call term_wait(buf, 50)
+  call WaitForAssert({-> assert_match('^1.*$', term_getline(buf, 3))})
+  bwipe!
+endfunc
+
 func Test_Changed_FirstTime()
   CheckFeature terminal
   CheckNotGui


### PR DESCRIPTION
Problem:  TextChanged not triggered for :norm! command
          (machakann)
Solution: do not reset curbuf->b_last_changedtick if TextChangedI
          was not triggered in insert mode

fixes: #13967