### PR TITLE
Too much redraw when deleting lines with 'cursorline'

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -656,22 +656,20 @@ changed_common(
 		set_topline(wp, wp->w_topline);
 #endif
 	    // If lines have been added or removed, relative numbering always
-	    // requires a redraw.
+	    // requires an update even if cursor didn't move.
 	    if (wp->w_p_rnu && xtra != 0)
-	    {
 		wp->w_last_cursor_lnum_rnu = 0;
-		redraw_win_later(wp, UPD_VALID);
-	    }
+
 #ifdef FEAT_SYN_HL
-	    // Cursor line highlighting probably need to be updated with
-	    // "UPD_VALID" if it's below the change.
-	    // If the cursor line is inside the change we need to redraw more.
-	    if (wp->w_p_cul)
+	    if (wp->w_p_cul && wp->w_last_cursorline >= lnum)
 	    {
-		if (xtra == 0)
-		    redraw_win_later(wp, UPD_VALID);
-		else if (lnum <= wp->w_last_cursorline)
-		    redraw_win_later(wp, UPD_SOME_VALID);
+		if (wp->w_last_cursorline < lnume)
+		    // If 'cursorline' was inside the change, it has already
+		    // been invalidated in w_lines[] by the loop above.
+		    wp->w_last_cursorline = 0;
+		else
+		    // If 'cursorline' was below the change, adjust its lnum.
+		    wp->w_last_cursorline += xtra;
 	    }
 #endif
 	}

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -557,22 +557,23 @@ func Test_cursorline_after_yank()
   call StopVimInTerminal(buf)
 endfunc
 
-" test for issue #4862
+" Test for issue #4862: pasting above 'cursorline' redraws properly.
 func Test_put_before_cursorline()
   new
   only!
-  call setline(1, 'A')
+  call setline(1, ['A', 'B', 'C'])
+  call cursor(2, 1)
   redraw
-  let std_attr = screenattr(1, 1)
+  let std_attr = screenattr(2, 1)
   set cursorline
   redraw
-  let cul_attr = screenattr(1, 1)
+  let cul_attr = screenattr(2, 1)
   normal yyP
   redraw
-  " Line 1 has cursor so it should be highlighted with CursorLine.
-  call assert_equal(cul_attr, screenattr(1, 1))
-  " And CursorLine highlighting from the second line should be gone.
-  call assert_equal(std_attr, screenattr(2, 1))
+  " Line 2 has cursor so it should be highlighted with CursorLine.
+  call assert_equal(cul_attr, screenattr(2, 1))
+  " And CursorLine highlighting from line 3 should be gone.
+  call assert_equal(std_attr, screenattr(3, 1))
   set nocursorline
   bwipe!
 endfunc


### PR DESCRIPTION
Problem:  Too much redraw when deleting lines with 'cursorline'.
Solution: Use smarter invalidation and adjustment.  Remove unnecessary
          UPD_VALID as it is already set at the top of the loop.  Make
          the test for #4862 fail without the fix.
