### PR TITLE
CI: Add Codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           flags: linux,${{ matrix.features }}-${{ matrix.compiler }}-${{ matrix.extra }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: ASan logs
         if: contains(matrix.extra, 'asan') && !cancelled()
@@ -681,3 +682,4 @@ jobs:
         with:
           directory: src
           flags: windows,${{ matrix.toolchain }}-${{ matrix.arch }}-${{ matrix.features }}
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
codecov-action@4 requires a token.
Add it to the repository secrets.

See: https://github.com/vim/vim/pull/13978#issuecomment-1935336624