### PR TITLE
xxd: crash with higer number of column

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -200,7 +200,33 @@ char osver[] = "";
 
 #define TRY_SEEK	/* attempt to use lseek, or skip forward by reading */
 #define COLS 256	/* change here, if you ever need more columns */
-#define LLEN ((2*(int)sizeof(unsigned long)) + 4 + (9*COLS-1) + COLS + 2)
+
+/*
+ * LLEN is the maximum length of a line; other than the visible characters
+ * we need to consider also the escape color sequence prologue/epilogue ,
+ * (11 bytes for each character). The most larger format is the default one:
+ * addr + 1 word for each col/2 + 1 char for each col
+ *
+ *   addr        1st group       2nd group
+ * +-------+ +-----------------+ +------+
+ * 01234567: 1234 5678 9abc def0 12345678
+ *
+ * - addr: typically 012345678:    -> from 10 up to 18 bytes (including trailing
+ *                                    space)
+ * - 1st group: 1234 5678 9abc ... -> each byte may be colored, so add 11
+ *                                    for each byte
+ * - space                         -> 1 byte
+ * - 2nd group: 12345678           -> each char may be colore so add 11
+ *                                    for each byte
+ * - new line                      -> 1 byte
+ * - zero (end line)               -> 1 byte
+ */
+#define LLEN (2*(int)sizeof(unsigned long) + 2 +     /* addr + ": " */ \
+             (11 * 2 + 4 + 1) * (COLS / 2) +         /* 1st group */   \
+	     1 +                                     /* space */       \
+	     (1 + 11) * COLS +                       /* 2nd group */   \
+	     1 +                                     /* new line */    \
+	     1)                                      /* zero */
 
 char hexxa[] = "0123456789abcdef0123456789ABCDEF", *hexx = hexxa;
 


### PR DESCRIPTION
xxd writes the data into a buffer before printing. Unfortunately the buffer doesn't consider the space consumed by the escape sequences used to change the color of the character.

BEFORE:
$ xxd -Ralways -c 256 /etc/passwd
Segmentation fault (core dumped)

AFTER:
$ ./xxd -Ralways -c 256 /etc/passwd
00000000: 726f 6f74 3a78 3a30 3a30 3a72 6f6f 743a 2f72 [...]

To solve this issue I had to increase the size of the buffer considering for each byte of data 11 further characters for the color escape sequence.