### PR TITLE
Still a qsort() comparison function that returns result of subtraction

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -4561,7 +4561,10 @@ fuzzy_match_item_compare(const void *s1, const void *s2)
     int		idx1 = ((fuzzyItem_T *)s1)->idx;
     int		idx2 = ((fuzzyItem_T *)s2)->idx;
 
-    return v1 == v2 ? (idx1 - idx2) : v1 > v2 ? -1 : 1;
+    if (v1 == v2)
+	return idx1 == idx2 ? 0 : idx1 > idx2 ? 1 : -1;
+    else
+	return v1 > v2 ? -1 : 1;
 }
 
 /*


### PR DESCRIPTION
Problem:  Still a qsort() comparison function fuzzy_match_item_compare()
          that returns result of subtraction (after 9.1.0089).
Solution: Use an explicit comparison instead of subtraction.
