### PR TITLE
Fix syntax test fails depending on LANG settings

### DIFF
--- a/runtime/syntax/Makefile
+++ b/runtime/syntax/Makefile
@@ -25,7 +25,7 @@ test:
 	@# the "vimcmd" file is used by the screendump utils
 	@echo "../$(VIMPROG)" > testdir/vimcmd
 	@echo "$(RUN_VIMTEST)" >> testdir/vimcmd
-	VIMRUNTIME=$(VIMRUNTIME) $(VIMPROG) --clean --not-a-term $(DEBUGLOG) -u testdir/runtest.vim
+	LC_ALL=C LANG=C LANGUAGE=C VIMRUNTIME=$(VIMRUNTIME) $(VIMPROG) --clean --not-a-term $(DEBUGLOG) -u testdir/runtest.vim
 	@# FIXME: Temporarily show the whole file to find out what goes wrong
 	@#if [ -f testdir/messages ]; then tail -n 6 testdir/messages; fi
 	@if [ -f testdir/messages ]; then cat testdir/messages; fi


### PR DESCRIPTION
When `LANG=ja_JP.UTF-8`, the syntax test result will be NG unexpectedly.
So, I changed the following.

Fixed the following environment variables to "C" when executing syntax test.

```
LC_ALL
LANG
LANGUAGE
```

--
Best regards,
Hirohito Higashi (h_east)