### PR TITLE
'breakindentopt' "min" works incorrectly with 'signcolumn'

### DIFF
--- a/src/indent.c
+++ b/src/indent.c
@@ -935,9 +935,7 @@ get_breakindent_win(
     int		    bri = 0;
     // window width minus window margin space, i.e. what rests for text
     const int	    eff_wwidth = wp->w_width
-			    - ((wp->w_p_nu || wp->w_p_rnu)
-				&& (vim_strchr(p_cpo, CPO_NUMCOL) == NULL)
-						? number_width(wp) + 1 : 0);
+					  - win_col_off(wp) + win_col_off2(wp);
 
     // In list mode, if 'listchars' "tab" isn't set, a TAB is displayed as ^I.
     int no_ts = wp->w_p_list && wp->w_lcs_chars.tab1 == NUL;

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -733,7 +733,7 @@ func Test_breakindent20_list()
 	\ "shall make no law   ",
 	\ ]
   call s:compare_lines(expect, lines)
-  " set minimum indent
+  " set minimum text width
   setl briopt=min:5
   redraw!
   let lines = s:screen_lines2(1, 6, 20)
@@ -1131,6 +1131,38 @@ func Test_breakindent_list_split()
   call s:compare_lines(expect, lines)
 
   bwipe!
+endfunc
+
+func Test_breakindent_min_with_signcol()
+  call s:test_windows('setl briopt=min:15 signcolumn=yes')
+  redraw!
+  let expect = [
+        \ "      abcdefghijklmn",
+        \ "     opqrstuvwxyzABC",
+        \ "     DEFGHIJKLMNOP  "
+        \ ]
+  let lines = s:screen_lines(line('.'), 20)
+  call s:compare_lines(expect, lines)
+  setl briopt=min:17
+  redraw!
+  let expect = [
+        \ "      abcdefghijklmn",
+        \ "   opqrstuvwxyzABCDE",
+        \ "   FGHIJKLMNOP      "
+        \ ]
+  let lines = s:screen_lines(line('.'), 20)
+  call s:compare_lines(expect, lines)
+  setl briopt=min:19
+  redraw!
+  let expect = [
+        \ "      abcdefghijklmn",
+        \ "  opqrstuvwxyzABCDEF",
+        \ "  GHIJKLMNOP        "
+        \ ]
+  let lines = s:screen_lines(line('.'), 20)
+  call s:compare_lines(expect, lines)
+
+  call s:close_windows()
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -1133,7 +1133,7 @@ func Test_diff_breakindent_after_filler()
   CheckScreendump
 
   let lines =<< trim END
-    set laststatus=0 diffopt+=followwrap breakindent
+    set laststatus=0 diffopt+=followwrap breakindent breakindentopt=min:0
     call setline(1, ['a', '  ' .. repeat('c', 50)])
     vnew
     call setline(1, ['a', 'b', '  ' .. repeat('c', 50)])


### PR DESCRIPTION
Problem:  'breakindentopt' "min" works incorrectly with 'signcolumn'.
Solution: Use win_col_off() and win_col_off2().
