### PR TITLE
settabvar() and settabwinvar() change last accessed tabpage

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -4841,11 +4841,6 @@ f_getbufvar(typval_T *argvars, typval_T *rettv)
     void
 f_settabvar(typval_T *argvars, typval_T *rettv UNUSED)
 {
-    tabpage_T	*save_curtab;
-    tabpage_T	*tp;
-    char_u	*varname, *tabvarname;
-    typval_T	*varp;
-
     if (check_secure())
 	return;
 
@@ -4854,17 +4849,18 @@ f_settabvar(typval_T *argvars, typval_T *rettv UNUSED)
 		|| check_for_string_arg(argvars, 1) == FAIL))
 	return;
 
-    tp = find_tabpage((int)tv_get_number_chk(&argvars[0], NULL));
-    varname = tv_get_string_chk(&argvars[1]);
-    varp = &argvars[2];
+    tabpage_T	*tp = find_tabpage((int)tv_get_number_chk(&argvars[0], NULL));
+    char_u	*varname = tv_get_string_chk(&argvars[1]);
+    typval_T	*varp = &argvars[2];
 
     if (varname == NULL || tp == NULL)
 	return;
 
-    save_curtab = curtab;
+    tabpage_T	*save_curtab = curtab;
+    tabpage_T	*save_lu_tp = lastused_tabpage;
     goto_tabpage_tp(tp, FALSE, FALSE);
 
-    tabvarname = alloc(STRLEN(varname) + 3);
+    char_u	*tabvarname = alloc(STRLEN(varname) + 3);
     if (tabvarname != NULL)
     {
 	STRCPY(tabvarname, "t:");
@@ -4875,7 +4871,11 @@ f_settabvar(typval_T *argvars, typval_T *rettv UNUSED)
 
     // Restore current tabpage
     if (valid_tabpage(save_curtab))
+    {
 	goto_tabpage_tp(save_curtab, FALSE, FALSE);
+	if (valid_tabpage(save_lu_tp))
+	    lastused_tabpage = save_lu_tp;
+    }
 }
 
 /*

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -1382,7 +1382,10 @@ switch_win_noblock(
 	    topframe = curtab->tp_topframe;
 	}
 	else
+	{
+	    switchwin->sw_lu_tp = lastused_tabpage;
 	    goto_tabpage_tp(tp, FALSE, FALSE);
+	}
     }
     if (!win_valid(win))
 	return FAIL;
@@ -1426,7 +1429,11 @@ restore_win_noblock(
 	    topframe = curtab->tp_topframe;
 	}
 	else
+	{
 	    goto_tabpage_tp(switchwin->sw_curtab, FALSE, FALSE);
+	    if (valid_tabpage(switchwin->sw_lu_tp))
+		lastused_tabpage = switchwin->sw_lu_tp;
+	}
     }
 
     if (!switchwin->sw_same_win)

--- a/src/structs.h
+++ b/src/structs.h
@@ -4894,6 +4894,7 @@ typedef enum {
 typedef struct {
     win_T	*sw_curwin;
     tabpage_T	*sw_curtab;
+    tabpage_T	*sw_lu_tp;	    // saved lastused_tabpage value
     int		sw_same_win;	    // VIsual_active was not reset
     int		sw_visual_active;
 } switchwin_T;

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -993,4 +993,29 @@ func Test_tabpage_drop_tabmove()
   bwipe!
 endfunc
 
+" settabvar() and settabwinvar() shouldn't change the last accessed tabpage
+func Test_settabvar_lastused_tabpage()
+  tabonly!
+  tabnew
+  tabnew
+  tabnew
+  call assert_equal(3, tabpagenr('#'))
+
+  call settabvar(2, 'myvar', 'tabval')
+  call assert_equal('tabval', gettabvar(2, 'myvar'))
+  call assert_equal(3, tabpagenr('#'))
+
+  call settabwinvar(2, 1, 'myvar', 'winval')
+  call assert_equal('winval', gettabwinvar(2, 1, 'myvar'))
+  call assert_equal(3, tabpagenr('#'))
+
+  call settabwinvar(2, 1, '&number', 1)
+  call assert_equal(1, gettabwinvar(2, 1, '&number'))
+  call assert_equal(3, tabpagenr('#'))
+
+  bwipe!
+  bwipe!
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  settabvar() and settabwinvar() change last accessed tabpage.
Solution: Save and restore lastused_tabpage.
