### PR TITLE
fix uppercase of German sharp s (ß)

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -1436,11 +1436,11 @@ swapchar(int op_type, pos_T *pos)
     {
 	pos_T   sp = curwin->w_cursor;
 
-	// Special handling of German sharp s: change to "SS".
+	// Special handling for lowercase German sharp s (ß): convert to uppercase (ẞ).
 	curwin->w_cursor = *pos;
 	del_char(FALSE);
-	ins_char('S');
-	ins_char('S');
+	ins_char(0x1E9E);
+	pos->col -= 1;
 	curwin->w_cursor = sp;
 	inc(pos);
     }

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -2347,19 +2347,19 @@ func Test_normal30_changecase()
   norm! 1ggVu
   call assert_equal('this is a simple test: äüöß', getline('.'))
   norm! VU
-  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖSS', getline('.'))
+  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖẞ', getline('.'))
   norm! guu
-  call assert_equal('this is a simple test: äüöss', getline('.'))
+  call assert_equal('this is a simple test: äüöß', getline('.'))
   norm! gUgU
-  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖSS', getline('.'))
+  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖẞ', getline('.'))
   norm! gugu
-  call assert_equal('this is a simple test: äüöss', getline('.'))
+  call assert_equal('this is a simple test: äüöß', getline('.'))
   norm! gUU
-  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖSS', getline('.'))
+  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖẞ', getline('.'))
   norm! 010~
-  call assert_equal('this is a SIMPLE TEST: ÄÜÖSS', getline('.'))
+  call assert_equal('this is a SIMPLE TEST: ÄÜÖẞ', getline('.'))
   norm! V~
-  call assert_equal('THIS IS A simple test: äüöss', getline('.'))
+  call assert_equal('THIS IS A simple test: äüöß', getline('.'))
   call assert_beeps('norm! c~')
   %d
   call assert_beeps('norm! ~')

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1020,9 +1020,9 @@ func Test_visual_change_case()
   exe "normal Oblah di\rdoh dut\<Esc>VkUj\r"
   " Uppercase part of two lines
   exe "normal ddppi333\<Esc>k0i222\<Esc>fyllvjfuUk"
-  call assert_equal(['the YOUTUSSEUU end', '- yOUSSTUSSEXu -',
-        \ 'THE YOUTUSSEUU END', '111THE YOUTUSSEUU END', 'BLAH DI', 'DOH DUT',
-        \ '222the yoUTUSSEUU END', '333THE YOUTUßeuu end'], getline(2, '$'))
+  call assert_equal(['the YOUTUẞEUU end', '- yOUẞTUẞEXu -',
+        \ 'THE YOUTUẞEUU END', '111THE YOUTUẞEUU END', 'BLAH DI', 'DOH DUT',
+        \ '222the yoUTUẞEUU END', '333THE YOUTUßeuu end'], getline(2, '$'))
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:
now vim use two SS as upper case for German sharp s (ß). but there already have an upper case relate
https://wikipedia.org/wiki/ẞ

Solution:
use correct upper case 0x1e9e .

Fix #5573 