### PR TITLE
Redrawing can be improved with undo and 'spell'

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -559,6 +559,12 @@ changed_common(
 	    if (!redraw_not_allowed && wp->w_redr_type < UPD_VALID)
 		wp->w_redr_type = UPD_VALID;
 
+	    // When inserting/deleting lines and the window has specific lines
+	    // to be redrawn, w_redraw_top and w_redraw_bot may now be invalid,
+	    // so just redraw everything.
+	    if (xtra != 0 && wp->w_redraw_top != 0)
+		redraw_win_later(wp, UPD_NOT_VALID);
+
 	    // Reset "w_skipcol" if the topline length has become smaller to
 	    // such a degree that nothing will be visible anymore, accounting
 	    // for 'smoothscroll' <<< or 'listchars' "precedes" marker.

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1408,7 +1408,7 @@ fold_line(
  *		   - if wp->w_buffer->b_mod_set set, update lines between
  *		     b_mod_top and b_mod_bot.
  *		   - if wp->w_redraw_top non-zero, redraw lines between
- *		     wp->w_redraw_top and wp->w_redr_bot.
+ *		     wp->w_redraw_top and wp->w_redraw_bot.
  *		   - continue redrawing when syntax status is invalid.
  *		4. if scrolled up, update lines at the bottom.
  * This results in three areas that may need updating:
@@ -1567,14 +1567,6 @@ win_update(win_T *wp)
     else
 #endif
 
-    if (buf->b_mod_set && buf->b_mod_xlines != 0 && wp->w_redraw_top != 0)
-    {
-	// When there are both inserted/deleted lines and specific lines to be
-	// redrawn, w_redraw_top and w_redraw_bot may be invalid, just redraw
-	// everything (only happens when redrawing is off for while).
-	type = UPD_NOT_VALID;
-    }
-    else
     {
 	// Set mod_top to the first line that needs displaying because of
 	// changes.  Set mod_bot to the first line after the changes.

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3899,8 +3899,8 @@ may_update_popup_mask(int type)
 
 			// The screen position "line" / "col" needs to be
 			// redrawn.  Figure out what window that is and update
-			// w_redraw_top and w_redr_bot.  Only needs to be done
-			// once for each window line.
+			// w_redraw_top and w_redraw_bot.  Only needs to be
+			// done once for each window line.
 			wp = mouse_find_win(&line_cp, &col_cp, IGNORE_POPUP);
 			if (wp != NULL)
 			{


### PR DESCRIPTION
Problem:  When undoing with 'spell', redrawWinline() is called after
          changed_lines(), while later win_update() sets redraw type to
          UPD_NOT_VALID, even though w_redraw_top and w_redraw_bot are
          still valid.
Solution: Only set redraw type to UPD_NOT_VALID when inserting/deleting
          lines after parts of window has pending redraw, i.e., when
          changed_lines() is called after redrawWinline().
