### PR TITLE
CI: Fix macos-14 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,17 +319,17 @@ jobs:
       - name: Checkout repository from github
         uses: actions/checkout@v4
 
-      - name: Install packages on Intel Mac
-        if: matrix.features == 'huge' && matrix.runner == 'macos-latest'
-        run: |
-          brew install lua
-          echo "LUA_PREFIX=/usr/local" >> $GITHUB_ENV
-
-      - name: Install packages on M1 Mac
-        if: matrix.features == 'huge' && matrix.runner == 'macos-14'
+      - name: Install packages
+        if: matrix.features == 'huge'
         run: |
           brew install lua libtool
-          echo "LUA_PREFIX=/opt/homebrew" >> $GITHUB_ENV
+          echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
+
+      - name: Grant microphone access for macos-14
+        if: matrix.runner == 'macos-14'
+        run: |
+          # Temporary fix to fix microphone permission issues for macos-14 when playing sound.
+          sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
 
       - name: Set up environment
         run: |

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -871,8 +871,8 @@ func VerifyInternal(buf, dumpfile, extra)
 endfunc
 
 func Test_diff_screen()
-  if has('osx') && !empty($CI) && system('uname -m') =~# 'arm64'
-    throw 'Skipped: FIXME: This test fails on M1 Mac on GitHub Actions'
+  if has('osxdarwin') && system('diff --version') =~ '^Apple diff'
+    throw 'Skipped: unified diff does not work properly on this macOS version'
   endif
 
   let g:test_is_flaky = 1

--- a/src/testdir/test_sound.vim
+++ b/src/testdir/test_sound.vim
@@ -15,9 +15,6 @@ func Test_play_event()
   if has('win32')
     throw 'Skipped: Playing event with callback is not supported on Windows'
   endif
-  if has('osx') && !empty($CI) && system('uname -m') =~# 'arm64'
-    throw 'Skipped: FIXME: Running this test on M1 Mac hangs on GitHub Actions'
-  endif
   let g:playcallback_count = 0
   let g:id = 0
   let event_name = 'bell'
@@ -38,10 +35,6 @@ func Test_play_event()
 endfunc
 
 func Test_play_silent()
-  if has('osx') && !empty($CI) && system('uname -m') =~# 'arm64'
-    throw 'Skipped: FIXME: Running this test on M1 Mac hangs on GitHub Actions'
-  endif
-
   let fname = fnamemodify('silent.wav', '%p')
   let g:playcallback_count = 0
 

--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -536,10 +536,6 @@ endfunc
 
 " Test for term_gettitle()
 func Test_term_gettitle()
-  if has('osx') && !empty($CI) && system('uname -m') =~# 'arm64'
-    throw 'Skipped: FIXME: Title got on M1 Mac is broken on GitHub Actions'
-  endif
-
   " term_gettitle() returns an empty string for a non-terminal buffer
   " and for a non-existing buffer.
   call assert_equal('', bufnr('%')->term_gettitle())


### PR DESCRIPTION
macos-14 runner was turned on in #13943, but it had to turn off a few tests in order for CI to run. Re-enable them and fix the underlying issues.

* `Test_diff_screen`: The test failure is due to a bug in Apple's diff utility. Apple introduced a new diff tool based on FreeBSD in macOS 13 and it has buggy behaviors when using unified diff (`-U0`) and the diff is on the first line of the file. Simply disable this test for now if we detect Apple diff (instead of the old GNU diff). Can re-enable this in the future if Apple fixes the issue.
* `Test_play_event` / `Test_play_silent`: GitHub Actions currently has an issue with playing sound in CI in macos-14 runners. It for some reason triggers a microphone permission dialog popup which blocks the CI action (see https://github.com/actions/runner-images/issues/9330). To fix this, add a temporary step in macos-14 to manually allow microphone permissions in the runner.
* `Test_term_gettitle`: I could not reproduce the failure, so I just turned it on and it seems to run just fine. Maybe it's a timing issue and whatnot but either way that should be fixed when we can reproduce the issue.