### PR TITLE
filetype: add '*.its' filetype detection

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -647,7 +647,7 @@ au BufNewFile,BufRead *.dsl
 au BufNewFile,BufRead *.dtd			setf dtd
 
 " DTS/DSTI/DTSO (device tree files)
-au BufNewFile,BufRead *.dts,*.dtsi,*.dtso	setf dts
+au BufNewFile,BufRead *.dts,*.dtsi,*.dtso,*.its	setf dts
 
 " EDIF (*.edf,*.edif,*.edn,*.edo) or edn
 au BufNewFile,BufRead *.ed\(f\|if\|o\)		setf edif

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -214,7 +214,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     dracula: ['file.drac', 'file.drc', 'filelvs', 'filelpe', 'drac.file', 'lpe', 'lvs', 'some-lpe', 'some-lvs'],
     dtd: ['file.dtd'],
     dtrace: ['/usr/lib/dtrace/io.d'],
-    dts: ['file.dts', 'file.dtsi', 'file.dtso'],
+    dts: ['file.dts', 'file.dtsi', 'file.dtso', 'file.its'],
     dune: ['jbuild', 'dune', 'dune-project', 'dune-workspace'],
     dylan: ['file.dylan'],
     dylanintr: ['file.intr'],


### PR DESCRIPTION
The '*.its' file type is for U-Boot Flattened Image Trees (FIT) which use the flattened devicetree format.

See https://github.com/u-boot/u-boot/blob/master/doc/usage/fit/source_file_format.rst#terminology