### PR TITLE
filetype: add 'Config.in' filetype detection

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1141,7 +1141,7 @@ au BufNewFile,BufRead *.kt,*.ktm,*.kts		setf kotlin
 au BufNewFile,BufRead *.ks			setf kscript
 
 " Kconfig
-au BufNewFile,BufRead Kconfig,Kconfig.debug	setf kconfig
+au BufNewFile,BufRead Kconfig,Kconfig.debug,Config.in	setf kconfig
 
 " Lace (ISE)
 au BufNewFile,BufRead *.ace,*.ACE		setf lace
@@ -2780,7 +2780,7 @@ au! BufNewFile,BufRead *jarg*
 au BufNewFile,BufRead *.properties_??_??_*	call s:StarSetf('jproperties')
 
 " Kconfig
-au BufNewFile,BufRead Kconfig.*			call s:StarSetf('kconfig')
+au BufNewFile,BufRead Kconfig.*,Config.in.*	call s:StarSetf('kconfig')
 
 " Lilo: Linux loader
 au BufNewFile,BufRead lilo.conf*		call s:StarSetf('lilo')

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -357,7 +357,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     jsp: ['file.jsp'],
     julia: ['file.jl'],
     just: ['justfile', 'Justfile', '.justfile', 'config.just'],
-    kconfig: ['Kconfig', 'Kconfig.debug', 'Kconfig.file'],
+    kconfig: ['Kconfig', 'Kconfig.debug', 'Kconfig.file', 'Config.in', 'Config.in.host'],
     kdl: ['file.kdl'],
     kivy: ['file.kv'],
     kix: ['file.kix'],


### PR DESCRIPTION
The 'Config.in' file type is for Buildroot configuration files. Buildroot Config.in files use the same Kconfig backend as the Linux kernel's Kconfig files.

Buildroot also has other filename variants that follow "Config.in.*", they are used to distinguish multiple Config.in files in the same directory.

See https://buildroot.org/downloads/manual/manual.html#_literal_config_in_literal_file