### PR TITLE
Simple fix for #14040: set noreadonly when switching to edit mode out of less mode

### DIFF
--- a/runtime/macros/less.vim
+++ b/runtime/macros/less.vim
@@ -227,7 +227,7 @@ noremap q :q<CR>
 " Switch to editing (switch off less mode)
 map v :silent call <SID>End()<CR>
 fun! s:End()
-  set ma
+  set modifiable noreadonly
   if exists('s:lz')
     let &lz = s:lz
   endif


### PR DESCRIPTION
Fixes #14040 where the 'v' hotkey when used in vim's less mode (via the less.vim macro) does not properly set the opened file to a modifiable state (or rather sets "modifiable" but doesn't set "noreadonly", which is also necessary).