### PR TITLE
runtime(filetype): Modula-2 files with priority not detected

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim functions for file type detection
 #
 # Maintainer:		The Vim Project <https://github.com/vim/vim>
-# Last Change:		2024 Jan 05
+# Last Change:		2024 Feb 18
 # Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 # These functions are moved here from runtime/filetype.vim to make startup
@@ -531,7 +531,7 @@ def IsLProlog(): bool
 enddef
 
 def IsModula2(): bool
-  return getline(nextnonblank(1)) =~ '\<MODULE\s\+\w\+\s*;\|^\s*(\*'
+  return getline(nextnonblank(1)) =~ '\<MODULE\s\+\w\+\s*\%(\[.*]\s*\)\=;\|^\s*(\*'
 enddef
 
 def SetFiletypeModula2()
@@ -1293,4 +1293,4 @@ export def FTvba()
 enddef
 
 # Uncomment this line to check for compilation errors early
-defcompile
+# defcompile

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1603,82 +1603,89 @@ func Test_mod_file()
   filetype on
 
   " *.mod defaults to Modsim III
-  call writefile(['locks like Modsim III'], 'modfile.mod')
-  split modfile.mod
+  call writefile(['locks like Modsim III'], 'Xfile.mod', 'D')
+  split Xfile.mod
   call assert_equal('modsim3', &filetype)
   bwipe!
 
   " Users preference set by g:filetype_mod
   let g:filetype_mod = 'lprolog'
-  split modfile.mod
+  split Xfile.mod
   call assert_equal('lprolog', &filetype)
   unlet g:filetype_mod
   bwipe!
 
+  " LambdaProlog module
+  call writefile(['module lpromod.'], 'Xfile.mod')
+  split Xfile.mod
+  call assert_equal('lprolog', &filetype)
+  bwipe!
+
+  " LambdaProlog with comment and empty lines prior module
+  call writefile(['', '% with',  '% comment', '', 'module lpromod.'], 'Xfile.mod')
+  split Xfile.mod
+  call assert_equal('lprolog', &filetype)
+  bwipe!
+
   " RAPID header start with a line containing only "%%%",
   " but is not always present.
-  call writefile(['%%%'], 'modfile.mod')
-  split modfile.mod
+  call writefile(['%%%'], 'Xfile.mod')
+  split Xfile.mod
   call assert_equal('rapid', &filetype)
   bwipe!
-  call delete('modfile.mod')
 
   " RAPID supports umlauts in module names, leading spaces,
   " the .mod extension is not case sensitive.
-  call writefile(['  module ÜmlautModule'], 'modfile.Mod')
-  split modfile.Mod
+  call writefile(['  module ÜmlautModule'], 'Xfile.Mod', 'D')
+  split Xfile.Mod
   call assert_equal('rapid', &filetype)
   bwipe!
-  call delete('modfile.Mod')
 
   " RAPID is not case sensitive, embedded spaces, sysmodule,
   " file starts with empty line(s).
-  call writefile(['', 'MODULE  rapidmödüle  (SYSMODULE,NOSTEPIN)'], 'modfile.MOD')
-  split modfile.MOD
+  call writefile(['', 'MODULE  rapidmödüle  (SYSMODULE,NOSTEPIN)'], 'Xfile.MOD', 'D')
+  split Xfile.MOD
   call assert_equal('rapid', &filetype)
   bwipe!
 
   " Modula-2 MODULE not start of line
-  call writefile(['IMPLEMENTATION MODULE Module2Mod;'], 'modfile.MOD')
-  split modfile.MOD
+  call writefile(['IMPLEMENTATION MODULE Module2Mod;'], 'Xfile.mod')
+  split Xfile.mod
   call assert_equal('modula2', &filetype)
   call assert_equal('pim', b:modula2.dialect)
   bwipe!
 
   " Modula-2 with comment and empty lines prior MODULE
-  call writefile(['', '(* with',  ' comment *)', '', 'MODULE Module2Mod;'], 'modfile.MOD')
-  split modfile.MOD
+  call writefile(['', '(* with',  ' comment *)', '', 'MODULE Module2Mod;'], 'Xfile.mod')
+  split Xfile.mod
   call assert_equal('modula2', &filetype)
   call assert_equal('pim', b:modula2.dialect)
   bwipe!
 
-  call delete('modfile.MOD')
-
-  " LambdaProlog module
-  call writefile(['module lpromod.'], 'modfile.mod')
-  split modfile.mod
-  call assert_equal('lprolog', &filetype)
+  " Modula-2 program MODULE with priorty (and uppercase extension)
+  call writefile(['MODULE Module2Mod [42];'], 'Xfile.MOD')
+  split Xfile.MOD
+  call assert_equal('modula2', &filetype)
+  call assert_equal('pim', b:modula2.dialect)
   bwipe!
 
-  " LambdaProlog with comment and empty lines prior module
-  call writefile(['', '% with',  '% comment', '', 'module lpromod.'], 'modfile.mod')
-  split modfile.mod
-  call assert_equal('lprolog', &filetype)
+  " Modula-2 implementation MODULE with priorty (and uppercase extension)
+  call writefile(['IMPLEMENTATION MODULE Module2Mod [42];'], 'Xfile.MOD')
+  split Xfile.MOD
+  call assert_equal('modula2', &filetype)
+  call assert_equal('pim', b:modula2.dialect)
   bwipe!
-  call delete('modfile.mod')
 
   " go.mod
-  call writefile(['module example.com/M'], 'go.mod')
+  call writefile(['module example.com/M'], 'go.mod', 'D')
   split go.mod
   call assert_equal('gomod', &filetype)
   bwipe!
-  call delete('go.mod')
 
   call writefile(['module M'], 'go.mod')
   split go.mod
   call assert_equal('gomod', &filetype)
   bwipe!
-  call delete('go.mod')
 
   filetype off
 endfunc


### PR DESCRIPTION
Problem:  Modula-2 files with a specified priority are not detected.
Solution: Match the priority syntax in module header lines when
          performing heuristic content detection.
