### PR TITLE
fix(ci): Run `Test_diff_screen` on macos-14 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,11 @@ jobs:
           "${SRCDIR}"/vim -u NONE -i NONE --not-a-term -esNX -V1 -S ci/if_ver-1.vim -c quit
           "${SRCDIR}"/vim -u NONE -i NONE --not-a-term -esNX -V1 -S ci/if_ver-2.vim -c quit
 
+      - name: Install packages for testing
+        run: |
+          # Apple diff is broken. Use GNU diff instead. See #14032.
+          brew install diffutils
+
       - name: Test
         timeout-minutes: 20
         run: |


### PR DESCRIPTION
## Problem

`Test_diff_screen` is skipped on macOS CI due to Apple diff issue (https://github.com/vim/vim/pull/14032 explained the details). On `macos-latest` runner, `diff` command is GNU diff since `diffutils` package is installed by default. However it is not installed on `macos-14`.

## Solution

Explicitly install `diffutils` package via Homebrew. By this package, `diff` command is replaced with GNU diff. I confirmed `Test_diff_screen` was run and passed successfully on my fork.

https://github.com/rhysd/vim/actions/runs/7958420090/job/21724006036

```
Executed Test_diff_screen()                        in   5.604062 seconds
```