### PR TITLE
Fix infinite loop & signed overflow with 'smoothscroll' set

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1537,7 +1537,7 @@ win_update(win_T *wp)
 
     // Make sure skipcol is valid, it depends on various options and the window
     // width.
-    if (wp->w_skipcol > 0)
+    if (wp->w_skipcol > 0 && wp->w_width > win_col_off(wp))
     {
 	int w = 0;
 	int width1 = wp->w_width - win_col_off(wp);

--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -28,7 +28,7 @@ void may_make_initial_scroll_size_snapshot(void);
 void may_trigger_win_scrolled_resized(void);
 void win_close_othertab(win_T *win, int free_buf, tabpage_T *tp);
 void win_free_all(void);
-win_T *winframe_remove(win_T *win, int *dirp, tabpage_T *tp, frame_T **to_flatten);
+win_T *winframe_remove(win_T *win, int *dirp, tabpage_T *tp, frame_T **unflat_altfr);
 void close_others(int message, int forceit);
 void unuse_tabpage(tabpage_T *tp);
 void use_tabpage(tabpage_T *tp);

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -960,4 +960,42 @@ func Test_smoothscroll_insert_bottom()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_smoothscroll_in_zero_width_window()
+  set cpo+=n number smoothscroll
+  set winwidth=99999 winminwidth=0
+
+  vsplit
+  call assert_equal(0, winwidth(winnr('#')))
+  call win_execute(win_getid(winnr('#')), "norm! \<C-Y>")
+
+  only!
+  set winwidth& winminwidth&
+  set cpo-=n nonumber nosmoothscroll
+endfunc
+
+func Test_smoothscroll_textoff_small_winwidth()
+  set smoothscroll number
+  call setline(1, 'llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch')
+  vsplit
+
+  let textoff = getwininfo(win_getid())[0].textoff
+  execute 'vertical resize' textoff + 1
+  redraw
+  call assert_equal(0, winsaveview().skipcol)
+  execute "normal! 0\<C-E>"
+  redraw
+  call assert_equal(1, winsaveview().skipcol)
+  execute 'vertical resize' textoff - 1
+  " This caused a signed integer overflow.
+  redraw
+  call assert_equal(1, winsaveview().skipcol)
+  execute 'vertical resize' textoff
+  " This caused an infinite loop.
+  redraw
+  call assert_equal(1, winsaveview().skipcol)
+
+  %bw!
+  set smoothscroll& number&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -54,7 +54,7 @@ static void win_goto_hor(int left, long count);
 static void frame_add_height(frame_T *frp, int n);
 static void last_status_rec(frame_T *fr, int statusline);
 static void frame_flatten(frame_T *frp);
-static void winframe_restore(win_T *wp, int dir, frame_T *to_flatten);
+static void winframe_restore(win_T *wp, int dir, frame_T *unflat_altfr);
 
 static int make_snapshot_rec(frame_T *fr, frame_T **frp);
 static void clear_snapshot(tabpage_T *tp, int idx);


### PR DESCRIPTION
A fix for a random thing I noticed yesterday.

Also sneak in some missing changes I forgot to add to my previous PR (sorry!), and relocate Test_smoothscroll_in_zero_width_window to test_scroll_opt.vim, which feels more appropriate.

(Maybe it's possible for Vim to still draw some buffer text within the gaps of the textoff area when `cpo+=n` if the window isn't 0-width, but it seems Vim currently doesn't do that)