### PR TITLE
Skip checks in win_gotoid when id == curwin

### DIFF
--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -824,6 +824,13 @@ f_win_gotoid(typval_T *argvars, typval_T *rettv)
 	return;
 
     id = tv_get_number(&argvars[0]);
+    if (curwin->w_id == id)
+    {
+	// Nothing to do.
+	rettv->vval.v_number = 1;
+	return;
+    }
+
     if (text_or_buf_locked())
 	return;
 #if defined(FEAT_PROP_POPUP) && defined(FEAT_TERMINAL)

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -2225,6 +2225,10 @@ func Test_win_gotoid_splitmove_textlock_cmdwin()
   set debug+=throw indentexpr=win_gotoid(win_getid(winnr('#')))
   call assert_fails('normal! ==', 'E565:')
   call assert_equal(curwin, win_getid())
+  " No error if attempting to switch to curwin; nothing happens.
+  set indentexpr=assert_equal(1,win_gotoid(win_getid()))
+  normal! ==
+  call assert_equal(curwin, win_getid())
 
   set indentexpr=win_splitmove(winnr('#'),winnr())
   call assert_fails('normal! ==', 'E565:')
@@ -2240,6 +2244,8 @@ func Test_win_gotoid_splitmove_textlock_cmdwin()
 
   call feedkeys('q:'
            \ .. ":call assert_fails('call win_gotoid(win_getid(winnr(''#'')))', 'E11:')\<CR>"
+           "\ No error if attempting to switch to curwin; nothing happens.
+           \ .. ":call assert_equal(1, win_gotoid(win_getid()))\<CR>"
            \ .. ":call assert_equal('command', win_gettype())\<CR>"
            \ .. ":call assert_equal('', win_gettype(winnr('#')))\<CR>", 'ntx')
 endfunc


### PR DESCRIPTION
Problem: win_gotoid checks for textlock and other things when switching to a window that is already current.

Solution: return early with success when attempting to switch to curwin.

Closes #14073; other potential causes of E565 from win_gotoid after v9.1.0119 should be correct. Plugins can consider using win_execute instead if they wish to temporarily switch windows during textlock (though maybe that's also a bit dubious, especially if win_execute ends up closing the old curwin... maybe closing it is not possible though, as there's some checks for textlock when doing that).