### PR TITLE
Internal error when passing mark in another buffer to getregion()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4300,6 +4300,8 @@ getregion({pos1}, {pos2}, {type})			*getregion()*
 		  |visual-mode|, an empty list is returned.
 		- If {pos1}, {pos2} or {type} is an invalid string, an empty
 		  list is returned.
+		- If {pos1} or {pos2} is a mark in non-current buffer, an
+		  empty list is returned.
 
 		Examples: >
 			:xnoremap <CR>

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5508,12 +5508,12 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 
     // NOTE: var2fpos() returns static pointer.
     fp = var2fpos(&argvars[0], TRUE, &fnum, FALSE);
-    if (fp == NULL)
+    if (fp == NULL || (fnum >= 0 && fnum != curbuf->b_fnum))
 	return;
     p1 = *fp;
 
     fp = var2fpos(&argvars[1], TRUE, &fnum, FALSE);
-    if (fp == NULL)
+    if (fp == NULL || (fnum >= 0 && fnum != curbuf->b_fnum))
 	return;
     p2 = *fp;
 

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1712,7 +1712,16 @@ func Test_visual_getregion()
   call assert_fails(':echo "."->getregion([],"V")', 'E1174:')
   call assert_fails(':echo "."->getregion("$", {})', 'E1174:')
   call assert_fails(':echo [0, 1, 1, 0]->getregion("$", "v")', 'E1174:')
-
+  " using a mark in another buffer
+  new
+  let newbuf = bufnr()
+  call setline(1, range(10))
+  normal! GmA
+  wincmd p
+  call assert_equal([newbuf, 10, 1, 0], getpos("'A"))
+  call assert_equal([], getregion(".", "'A", 'v'))
+  call assert_equal([], getregion("'A", ".", 'v'))
+  exe newbuf .. 'bwipe!'
 
   bwipe!
   " Selection in starts or ends in the middle of a multibyte character


### PR DESCRIPTION
Problem:  Internal error when passing mark in another buffer to
          getregion().
Solution: Don't allow marks in another buffer.
