### PR TITLE
win_splitmove UAF if win_split_ins autocommands delete "wp"

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1191,6 +1191,15 @@ func Test_win_splitmove()
   call assert_equal(v:true, s:triggered)
   unlet! s:triggered
 
+  split
+  let close_win = winnr('#')
+  augroup WinSplitMove
+    au!
+    au WinEnter * ++once quit!
+  augroup END
+  call win_splitmove(close_win, winnr())
+  call assert_equal(0, win_id2win(close_win))
+
   au! WinSplitMove
   augroup! WinSplitMove
   %bw!

--- a/src/window.c
+++ b/src/window.c
@@ -1954,7 +1954,8 @@ win_splitmove(win_T *wp, int size, int flags)
     }
 
     // If splitting horizontally, try to preserve height.
-    if (size == 0 && !(flags & WSP_VERT))
+    // Note that win_split_ins autocommands may have immediately closed "wp"!
+    if (size == 0 && !(flags & WSP_VERT) && win_valid(wp))
     {
 	win_setheight_win(height, wp);
 	if (p_ea)


### PR DESCRIPTION
Problem: heap-use-after-free in win_splitmove if Enter/Leave autocommands from
win_split_ins immediately closes "wp".

Solution: check that "wp" is valid after win_split_ins.

(This one's not a regression; just missed this possibility previously)