### PR TITLE
Fix truncation of text_wrap 'wrap' virtual text after EOL list char

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -4116,7 +4116,7 @@ win_line(
 		    || text_prop_next <= last_textprop_text_idx
 #endif
 		    || (wp->w_p_list && wp->w_lcs_chars.eol != NUL
-						&& wlv.p_extra != at_end_str)
+						&& lcs_eol_one != -1)
 		    || (wlv.n_extra != 0 && (wlv.c_extra != NUL
 						      || *wlv.p_extra != NUL)))
 		)
@@ -4135,16 +4135,13 @@ win_line(
 
 	    // When not wrapping and finished diff lines, or when displayed
 	    // '$' and highlighting until last column, break here.
-	    if (((!wp->w_p_wrap
+	    if (!wp->w_p_wrap
 #ifdef FEAT_DIFF
 			&& wlv.filler_todo <= 0
 #endif
 #ifdef FEAT_PROP_POPUP
 			&& !text_prop_above
-#endif
-		 ) || lcs_eol_one == -1)
-#ifdef FEAT_PROP_POPUP
-		    && !text_prop_follows
+			&& !text_prop_follows
 #endif
 		       )
 		break;

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1121,8 +1121,6 @@ win_line(
 #if defined(FEAT_LINEBREAK) && defined(FEAT_PROP_POPUP)
     int		in_linebreak = FALSE;	// n_extra set for showing linebreak
 #endif
-    static char_u *at_end_str = (char_u *)""; // used for p_extra when
-					// displaying eol at end-of-line
     int		lcs_eol_one = wp->w_lcs_chars.eol; // eol until it's been used
     int		lcs_prec_todo = wp->w_lcs_chars.prec;
 					// prec until it's been used
@@ -3304,7 +3302,7 @@ win_line(
 			if (!(area_highlighting && virtual_active()
 				       && wlv.tocol != MAXCOL
 				       && wlv.vcol < wlv.tocol))
-			    wlv.p_extra = at_end_str;
+			    wlv.p_extra = (char_u *)"";
 			wlv.n_extra = 0;
 		    }
 		    if (wp->w_p_list && wp->w_lcs_chars.eol > 0)

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -4133,8 +4133,7 @@ win_line(
 	    ++wlv.row;
 	    ++wlv.screen_row;
 
-	    // When not wrapping and finished diff lines, or when displayed
-	    // '$' and highlighting until last column, break here.
+	    // When not wrapping and finished diff lines, break here.
 	    if (!wp->w_p_wrap
 #ifdef FEAT_DIFF
 			&& wlv.filler_todo <= 0


### PR DESCRIPTION
Fixes: #12725

As mentioned in https://github.com/vim/vim/issues/12725#issuecomment-1957206271, the problem was with that `|| lcs_eol_one == -1` `break` condition.

It looks like that condition was compensating for an incorrect outer `wlv.p_extra != at_end_str` that intended to check if the EOL character hadn't been added to the screen line, but that would evaluate to true because when `wlv.p_extra` is updated to the end of the string without being set to `at_end_str`, such as when the virtual text has been truncated by `text_prop_position` and the truncated text as finished being added to the screen line.  The inner `lcs_eol_one == -1` was compensating for this for the truncation case, but then caused problems for the cause where truncation of the virtual text shouldn't happen.  So I moved that problematic inner condition and used it to replace the incorrect outer condition.