### PR TITLE
buffer-completion code too complicated and doesn't find all matches

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -691,7 +691,7 @@ func Test_getcompletion()
     bw Xtest\
   endif
 
-  call assert_fails("call getcompletion('\\\\@!\\\\@=', 'buffer')", 'E871:')
+  call assert_fails("call getcompletion('\\\\@!\\\\@=', 'buffer')", 'E866:')
   call assert_fails('call getcompletion("", "burp")', 'E475:')
   call assert_fails('call getcompletion("abc", [])', 'E1174:')
 endfunc
@@ -3753,6 +3753,23 @@ func Test_window_size_stays_same_after_changing_cmdheight()
   endfunction
   call Function_name()
   call assert_equal(expected, winheight(0))
+endfunc
+
+" verify that buffer-completion finds all buffer names matching a pattern
+func Test_buffer_completion()
+  " should return empty list
+  call assert_equal([], getcompletion('', 'buffer'))
+
+  call mkdir('Xbuf_complete', 'R')
+  e Xbuf_complete/Foobar.c
+  e Xbuf_complete/MyFoobar.c
+  e AFoobar.h
+  let expected = ["Xbuf_complete/Foobar.c", "Xbuf_complete/MyFoobar.c", "AFoobar.h"]
+
+  call assert_equal(3, len(getcompletion('Foo', 'buffer')))
+  call assert_equal(expected, getcompletion('Foo', 'buffer'))
+  call feedkeys(":b Foo\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"b Xbuf_complete/Foobar.c Xbuf_complete/MyFoobar.c AFoobar.h", @:)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  buffer-completion code too complicated and does not find
          all matches
Solution: do not try to anchor pattern to beginning of line or
          directory-separator, always return all matches

Note: we are considering the non-fuzzy buffer-matching here.

Currently, the buffer-completion code makes 2 attempts to match a pattern against the list of available patterns. First try is to match the pattern and anchor it to either the beginning of the file name or at a directory-separator (// or \\).

When a match is found, Vim returns the matching buffers and does not try to find a match anywhere within a buffer name. So if you have opened two buffers like /tmp/Foobar.c and /tmp/MyFoobar.c using `:b Foo` will only complete to the first filename, but not the second (the same happens with `getcompletion('Foo', 'buffer')`).

It may make sense, that completion priorities buffer names at directory boundaries, but it may cause confusion why a certain buffer name is not completed and when typing `:b Foo<C-D>` which returns only a single file name and then pressing Enter (to switch to that buffer), Vim will error with 'E93: More than one match for Foo').

So let's simplify the code and always try to match the pattern anywhere in the buffer name, do not try to favor matches at directory boundaries. This is also simplifies the code a bit, we do not need to run over the list of buffers several times, but only twice.

Note: Diff looks a lot better, if ignoring white-space changes

fixes #13894