### PR TITLE
"C" doesn't include composing chars with 'virtualedit'

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -990,13 +990,20 @@ setmarks:
     static void
 mb_adjust_opend(oparg_T *oap)
 {
-    char_u	*p;
+    char_u	*line;
+    char_u	*ptr;
 
     if (!oap->inclusive)
 	return;
 
-    p = ml_get(oap->end.lnum);
-    oap->end.col += mb_tail_off(p, p + oap->end.col);
+    line = ml_get(oap->end.lnum);
+    ptr = line + oap->end.col;
+    if (*ptr != NUL)
+    {
+	ptr -= (*mb_head_off)(line, ptr);
+	ptr += (*mb_ptr2len)(ptr) - 1;
+	oap->end.col = ptr - line;
+    }
 }
 
 /*

--- a/src/testdir/test_virtualedit.vim
+++ b/src/testdir/test_virtualedit.vim
@@ -77,13 +77,30 @@ endfunc
 func Test_edit_change()
   new
   set virtualedit=all
+
   call setline(1, "\t⒌")
   normal Cx
   call assert_equal('x', getline(1))
+
+  call setline(1, "\ta̳")
+  normal Cx
+  call assert_equal('x', getline(1))
+
+  call setline(1, "\tβ̳")
+  normal Cx
+  call assert_equal('x', getline(1))
+
+  if has('arabic')
+    call setline(1, "\tلا")
+    normal Cx
+    call assert_equal('x', getline(1))
+  endif
+
   " Do a visual block change
   call setline(1, ['a', 'b', 'c'])
   exe "normal gg3l\<C-V>2jcx"
   call assert_equal(['a  x', 'b  x', 'c  x'], getline(1, '$'))
+
   bwipe!
   set virtualedit=
 endfunc


### PR DESCRIPTION
Problem:  "C" doesn't include composing chars with 'virtualedit'.
Solution: Use mb_head_off() and mb_ptr2len() instead of mb_tail_off().
