### PR TITLE
Fixed font ligatures not rendering correctly on cursor movement in Win32

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4000,7 +4000,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'guiligatures'* *'gli'* *E1243*
 'guiligatures' 'gli'	string	(default "")
 			global
-			{only for GTK GUI}
+			{only for GTK and Win32 GUI}
 	List of ASCII characters that, when combined together, can create more
 	complex shapes. Each character must be a printable ASCII character
 	with a value in the 32-127 range.

--- a/src/errors.h
+++ b/src/errors.h
@@ -3185,7 +3185,7 @@ EXTERN char e_separator_not_supported_str[]
 EXTERN char e_no_white_space_allowed_before_separator_str[]
 	INIT(= N_("E1242: No white space allowed before separator: %s"));
 #endif
-#ifdef FEAT_GUI_GTK
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
 EXTERN char e_ascii_code_not_in_range[]
 	INIT(= N_("E1243: ASCII code not in 32-127 range"));
 #endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -455,7 +455,7 @@ gui_init_check(void)
     gui.scrollbar_width = gui.scrollbar_height = SB_DEFAULT_WIDTH;
     gui.prev_wrap = -1;
 
-#ifdef FEAT_GUI_GTK
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
     CLEAR_FIELD(gui.ligatures_map);
 #endif
 
@@ -1064,7 +1064,7 @@ gui_get_wide_font(void)
     return OK;
 }
 
-#if defined(FEAT_GUI_GTK) || defined(PROTO)
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN) || defined(PROTO)
 /*
  * Set list of ascii characters that combined can create ligature.
  * Store them in char map for quick access from gui_gtk2_draw_string.
@@ -2691,7 +2691,7 @@ gui_undraw_cursor(void)
     int startcol = gui.cursor_col > 0 ? gui.cursor_col - 1 : gui.cursor_col;
     int endcol = gui.cursor_col;
 
-#ifdef FEAT_GUI_GTK
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
     gui_adjust_undraw_cursor_for_ligatures(&startcol, &endcol);
 #endif
     gui_redraw_block(gui.cursor_row, startcol,

--- a/src/gui.h
+++ b/src/gui.h
@@ -389,10 +389,12 @@ typedef struct Gui
     char_u	*browse_fname;	    // file name from filedlg
 
     guint32	event_time;
+#endif	// FEAT_GUI_GTK
 
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
     char_u ligatures_map[256];	    // ascii map for characters 0-255, value is
 				    // 1 if in 'guiligatures'
-#endif	// FEAT_GUI_GTK
+#endif
 
 #if defined(FEAT_GUI_TABLINE) \
 	&& (defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_MOTIF) \

--- a/src/option.h
+++ b/src/option.h
@@ -637,7 +637,7 @@ EXTERN char_u	*p_guifontset;	// 'guifontset'
 EXTERN char_u	*p_guifontwide;	// 'guifontwide'
 EXTERN int	p_guipty;	// 'guipty'
 #endif
-#ifdef FEAT_GUI_GTK
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
 EXTERN char_u	*p_guiligatures;  // 'guiligatures'
 # endif
 #if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_X11)

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1212,7 +1212,7 @@ static struct vimoption options[] =
 			    {(char_u *)50L, (char_u *)0L} SCTX_INIT},
 
     {"guiligatures", "gli", P_STRING|P_VI_DEF|P_RCLR|P_ONECOMMA|P_NODUP,
-#if defined(FEAT_GUI_GTK)
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
 			    (char_u *)&p_guiligatures, PV_NONE,
 			    did_set_guiligatures, NULL,
 			    {(char_u *)"", (char_u *)0L}

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -2438,7 +2438,7 @@ did_set_guifontwide(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_GUI_GTK) || defined(PROTO)
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN) || defined(PROTO)
 /*
  * The 'guiligatures' option is changed.
  */

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -635,7 +635,7 @@ endfunc
 func Test_set_guiligatures()
   CheckX11BasedGui
 
-  if has('gui_gtk') || has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3')
+  if has('gui_gtk') || has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3') || has('win32')
     " Try correct value
     set guiligatures=<>=ab
     call assert_equal("<>=ab", &guiligatures)


### PR DESCRIPTION
Related open issues: #12901 
Related closed issues: #9181

Problem: font ligatures don't render correctly in the Win32 GUI-version of `gvim` even when `set rop=type:directx` is used. Setting `guiligatures` also doesn't make any difference. This leads to broken font ligatures when the cursor passes through them. It does not recover from this, and they remain broken until you re-render the whole buffer (e.g. by using Ctrl+L). See GIF below before fix.

![ligatures bug (broken)](https://github.com/vim/vim/assets/5418661/d3f1e85a-1e3c-43cd-ae53-148722c639d0)

Steps to reproduce/test:

1. Open any Win32 GUI-release of `gvim`
2. `set guifont=Iosevka`
3. `set rop=type:directx`
4. Notice font ligatures rendering correctly, until you pass the cursor through them.

Solution: the problem is that we only re-draw the current and previous character in `gui_undraw_cursor` and only have the special case for GTK when it comes to rendering ligatures. This PR enables `gui_adjust_undraw_cursor_for_ligatures` to also happen for Win32 GUI if `guiligatures` is setup correctly (all this does is expand the range of `gui_undraw_cursor` with ligature characters).

Here's a GIF of how it behaves after the fix:

![ligatures bug (working)](https://github.com/vim/vim/assets/5418661/a075eea3-68eb-4fe1-9e87-afc7878a1f03)