### PR TITLE
Test_term_gettitle() is flaky on MacOS and Github runners, so disable it

### DIFF
--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -535,6 +535,7 @@ func Test_term_getcursor()
 endfunc
 
 " Test for term_gettitle()
+" Known to be flaky on Mac-OS X on the GH runners
 func Test_term_gettitle()
   " term_gettitle() returns an empty string for a non-terminal buffer
   " and for a non-existing buffer.
@@ -543,6 +544,13 @@ func Test_term_gettitle()
 
   if !has('title') || empty(&t_ts)
     throw "Skipped: can't get/set title"
+  endif
+  if has('osx') && !empty($CI) && system('uname -m') =~# 'arm64'
+    " This test often fails with the following error message on Github runners
+    " MacOS-14
+    " '^\\[No Name\\] - VIM\\d*$' does not match 'e] - VIM'
+    " Why? Is the terminal that runs Vim too small?
+    throw 'Skipped: FIXME: Running this test on M1 Mac fails on GitHub Actions'
   endif
 
   let term = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', '-c', 'set title'])


### PR DESCRIPTION
Problem:  Test_term_gettitle() is flaky on MAcOS and Github runners
Solution: Skip the test on Github CI

It fails with this: '^\\[No Name\\] - VIM\\d*$' does not match 'e] - VIM' It is not clear why term_gettitle() only get's the last part of the expected title (perhaps there is a Carriage return in there or the terminal window is too small?)

So let's just disable this test for now.