### PR TITLE
Getregion opts

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -263,7 +263,7 @@ getqflist({what})		Dict	get specific quickfix list properties
 getreg([{regname} [, 1 [, {list}]]])
 				String or List   contents of a register
 getreginfo([{regname}])		Dict	information about a register
-getregion({pos1}, {pos2}, {type} [, {opts}])
+getregion({pos1}, {pos2}[, {opts}])
 				List	get the text from {pos1} to {pos2}
 getregtype([{regname}])		String	type of a register
 getscriptinfo([{opts}])		List	list of sourced scripts
@@ -4271,9 +4271,8 @@ getreginfo([{regname}])					*getreginfo()*
 		Can also be used as a |method|: >
 			GetRegname()->getreginfo()
 
-getregion({pos1}, {pos2}, {type} [, {opts}])			*getregion()*
-		Returns the list of strings from {pos1} to {pos2} as if it's
-		selected in visual mode of {type}.
+getregion({pos1}, {pos2}[, {opts}])			*getregion()*
+		Returns the list of strings from {pos1} to {pos2}.
 
 		For possible values of {pos1} and {pos2} are |List| or |string|.
 		When {pos1} or {pos2} is |string|, see |line()|.
@@ -4282,17 +4281,21 @@ getregion({pos1}, {pos2}, {type} [, {opts}])			*getregion()*
 			[{lnum}, {col}, {off}]
 
 		{type} is the selection type:
-			"v" for |characterwise| mode
-			"V" for |linewise| mode
-			"<CTRL-V>" for |blockwise-visual| mode
 
 		The optional argument {opts} is a Dict and supports the
 		following items:
 
-		exclusive	Specify whether the ending column is exclusive
-				instead of 'selection' value.
+			type		Specify the selection type instead of
+					|visualmode()| value.
 
-		You can get the last selection type by |visualmode()|.
+					"v" for |characterwise| mode
+					"V" for |linewise| mode
+					"<CTRL-V>" for |blockwise-visual| mode
+
+			exclusive	Specify whether the ending column is
+					exclusive instead of 'selection'
+					value.
+
 		If Visual mode is active, use |mode()| to get the Visual mode
 		(e.g., in a |:vmap|).
 		This function uses the line and column number from the
@@ -4318,10 +4321,10 @@ getregion({pos1}, {pos2}, {type} [, {opts}])			*getregion()*
 
 		Examples: >
 			:xnoremap <CR>
-			\ <Cmd>echow getregion('v', '.', mode())<CR>
+			\ <Cmd>echow getregion('v', '.')<CR>
 <
 		Can also be used as a |method|: >
-			'.'->getregion("'a", 'v')
+			'.'->getregion("'a")
 <
 getregtype([{regname}])					*getregtype()*
 		The result is a String, which is type of register {regname}.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4275,12 +4275,16 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		Returns the list of strings from {pos1} to {pos2} in current
 		buffer.
 
-		For possible values of {pos1} and {pos2} are |List| or
-		|string|.
-		When {pos1} or {pos2} is |string|, see |line()|.
-		When {pos1} or {pos2} is |List|, with two or three items:
-			[{lnum}, {col}]
-			[{lnum}, {col}, {off}]
+		{pos1} and {pos2} must be a |List| with four numbers:
+			[bufnum, lnum, col, off]
+		"bufnum" is zero, unless a mark like '0 or 'A is used, then it
+		is the buffer number of the mark.
+		"lnum" and "col" are the position in the buffer.  The first
+		column is 1.
+		The "off" number is zero, unless 'virtualedit' is used.  Then
+		it is the offset in screen columns from the start of the
+		character.  E.g., a position within a <Tab> or after the last
+		character.
 
 		{type} is the selection type:
 
@@ -4315,19 +4319,17 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		- If the selection starts or ends in the middle of a multibyte
 		  character, it is not included but its selected part is
 		  substituted with spaces.
-		- If {pos1} or {pos2} equals "v" (see |line()|) and it is not in
-		  |visual-mode|, an empty list is returned.
-		- If {pos1}, {pos2} or {type} is an invalid string, an empty
-		  list is returned.
-		- If {pos1} or {pos2} is a mark in different buffer, an empty
-		  list is returned.
+		- If {type} is an invalid string, an empty list is returned.
+		- If {pos1} or {pos2} is not current buffer, an empty list is
+		  returned.
 
 		Examples: >
 			:xnoremap <CR>
-			\ <Cmd>echow getregion('v', '.', #{ type: mode() })<CR>
+			\ <Cmd>echow getregion(
+			\ getpos('v'), getpos('.'), #{ type: mode() })<CR>
 <
 		Can also be used as a |method|: >
-			'.'->getregion("'a")
+			'.'->getregion(getpos("'a"))
 <
 getregtype([{regname}])					*getregtype()*
 		The result is a String, which is type of register {regname}.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -263,7 +263,7 @@ getqflist({what})		Dict	get specific quickfix list properties
 getreg([{regname} [, 1 [, {list}]]])
 				String or List   contents of a register
 getreginfo([{regname}])		Dict	information about a register
-getregion({pos1}, {pos2}[, {opts}])
+getregion({pos1}, {pos2} [, {opts}])
 				List	get the text from {pos1} to {pos2}
 getregtype([{regname}])		String	type of a register
 getscriptinfo([{opts}])		List	list of sourced scripts
@@ -4271,10 +4271,12 @@ getreginfo([{regname}])					*getreginfo()*
 		Can also be used as a |method|: >
 			GetRegname()->getreginfo()
 
-getregion({pos1}, {pos2}[, {opts}])			*getregion()*
-		Returns the list of strings from {pos1} to {pos2}.
+getregion({pos1}, {pos2} [, {opts}])			*getregion()*
+		Returns the list of strings from {pos1} to {pos2} in current
+		buffer.
 
-		For possible values of {pos1} and {pos2} are |List| or |string|.
+		For possible values of {pos1} and {pos2} are |List| or
+		|string|.
 		When {pos1} or {pos2} is |string|, see |line()|.
 		When {pos1} or {pos2} is |List|, with two or three items:
 			[{lnum}, {col}]
@@ -4286,7 +4288,7 @@ getregion({pos1}, {pos2}[, {opts}])			*getregion()*
 		following items:
 
 			type		Specify the selection type instead of
-					|visualmode()| value.
+					"v" value.
 
 					"v" for |characterwise| mode
 					"V" for |linewise| mode
@@ -4296,6 +4298,7 @@ getregion({pos1}, {pos2}[, {opts}])			*getregion()*
 					exclusive instead of 'selection'
 					value.
 
+		You can get the last selection type by |visualmode()|.
 		If Visual mode is active, use |mode()| to get the Visual mode
 		(e.g., in a |:vmap|).
 		This function uses the line and column number from the
@@ -4321,7 +4324,7 @@ getregion({pos1}, {pos2}[, {opts}])			*getregion()*
 
 		Examples: >
 			:xnoremap <CR>
-			\ <Cmd>echow getregion('v', '.')<CR>
+			\ <Cmd>echow getregion('v', '.', #{ type: mode() })<CR>
 <
 		Can also be used as a |method|: >
 			'.'->getregion("'a")

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4281,10 +4281,7 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		is the buffer number of the mark.
 		"lnum" and "col" are the position in the buffer.  The first
 		column is 1.
-		The "off" number is zero, unless 'virtualedit' is used.  Then
-		it is the offset in screen columns from the start of the
-		character.  E.g., a position within a <Tab> or after the last
-		character.
+		The "off" number is ignored.
 
 		{type} is the selection type:
 
@@ -4319,7 +4316,6 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		- If the selection starts or ends in the middle of a multibyte
 		  character, it is not included but its selected part is
 		  substituted with spaces.
-		- If {type} is an invalid string, an empty list is returned.
 		- If {pos1} or {pos2} is not current buffer, an empty list is
 		  returned.
 
@@ -4329,7 +4325,7 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 			\ getpos('v'), getpos('.'), #{ type: mode() })<CR>
 <
 		Can also be used as a |method|: >
-			'.'->getregion(getpos("'a"))
+			getpos('.')->getregion(getpos("'a"))
 <
 getregtype([{regname}])					*getregtype()*
 		The result is a String, which is type of register {regname}.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4275,15 +4275,10 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		Returns the list of strings from {pos1} to {pos2} in current
 		buffer.
 
-		{pos1} and {pos2} must be a |List| with four numbers:
+		{pos1} and {pos2} must be a |List| with four numbers in the
+		same format as the result of |getpos()|:
 			[bufnum, lnum, col, off]
-		"bufnum" must be zero or current buffer number.
-		"lnum" and "col" are the position in the buffer.  The first
-		column is 1.
-		The "off" number is zero, unless 'virtualedit' is used.  Then
-		it is the offset in screen columns from the start of the
-		character.  E.g., a position within a <Tab> or after the last
-		character.
+		And "bufnum" must be zero or current buffer number.
 
 		{type} is the selection type:
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -263,7 +263,7 @@ getqflist({what})		Dict	get specific quickfix list properties
 getreg([{regname} [, 1 [, {list}]]])
 				String or List   contents of a register
 getreginfo([{regname}])		Dict	information about a register
-getregion({pos1}, {pos2}, {type})
+getregion({pos1}, {pos2}, {type} [, {opts}])
 				List	get the text from {pos1} to {pos2}
 getregtype([{regname}])		String	type of a register
 getscriptinfo([{opts}])		List	list of sourced scripts
@@ -4271,7 +4271,7 @@ getreginfo([{regname}])					*getreginfo()*
 		Can also be used as a |method|: >
 			GetRegname()->getreginfo()
 
-getregion({pos1}, {pos2}, {type})			*getregion()*
+getregion({pos1}, {pos2}, {type} [, {opts}])			*getregion()*
 		Returns the list of strings from {pos1} to {pos2} as if it's
 		selected in visual mode of {type}.
 		For possible values of {pos1} and {pos2} see |line()|.
@@ -4279,6 +4279,14 @@ getregion({pos1}, {pos2}, {type})			*getregion()*
 			"v" for |characterwise| mode
 			"V" for |linewise| mode
 			"<CTRL-V>" for |blockwise-visual| mode
+
+		The optional argument {opts} is a Dict and supports the
+		following items:
+		    winid	Specify the window instead of current window.
+
+		    exclusive	Specify whether the ending column is exclusive
+		    		instead of 'selection' value.
+
 		You can get the last selection type by |visualmode()|.
 		If Visual mode is active, use |mode()| to get the Visual mode
 		(e.g., in a |:vmap|).

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4274,7 +4274,14 @@ getreginfo([{regname}])					*getreginfo()*
 getregion({pos1}, {pos2}, {type} [, {opts}])			*getregion()*
 		Returns the list of strings from {pos1} to {pos2} as if it's
 		selected in visual mode of {type}.
-		For possible values of {pos1} and {pos2} see |line()|.
+
+		For possible values of {pos1} and {pos2} are |List| or |string|.
+		When {pos1} or {pos2} is |string|, see |line()|.
+		When {pos1} or {pos2} is |List|, with two, three or four item:
+			[{lnum}, {col}]
+			[{lnum}, {col}, {off}]
+			[{lnum}, {col}, {off}, {curswant}]
+
 		{type} is the selection type:
 			"v" for |characterwise| mode
 			"V" for |linewise| mode

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4277,7 +4277,7 @@ getregion({pos1}, {pos2}, {type} [, {opts}])			*getregion()*
 
 		For possible values of {pos1} and {pos2} are |List| or |string|.
 		When {pos1} or {pos2} is |string|, see |line()|.
-		When {pos1} or {pos2} is |List|, with two, three or four item:
+		When {pos1} or {pos2} is |List|, with two or three items:
 			[{lnum}, {col}]
 			[{lnum}, {col}, {off}]
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4280,7 +4280,6 @@ getregion({pos1}, {pos2}, {type} [, {opts}])			*getregion()*
 		When {pos1} or {pos2} is |List|, with two, three or four item:
 			[{lnum}, {col}]
 			[{lnum}, {col}, {off}]
-			[{lnum}, {col}, {off}, {curswant}]
 
 		{type} is the selection type:
 			"v" for |characterwise| mode

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4277,11 +4277,13 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 
 		{pos1} and {pos2} must be a |List| with four numbers:
 			[bufnum, lnum, col, off]
-		"bufnum" is zero, unless a mark like '0 or 'A is used, then it
-		is the buffer number of the mark.
+		"bufnum" must be zero or current buffer number.
 		"lnum" and "col" are the position in the buffer.  The first
 		column is 1.
-		The "off" number is ignored.
+		The "off" number is zero, unless 'virtualedit' is used.  Then
+		it is the offset in screen columns from the start of the
+		character.  E.g., a position within a <Tab> or after the last
+		character.
 
 		{type} is the selection type:
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4290,8 +4290,8 @@ getregion({pos1}, {pos2}, {type} [, {opts}])			*getregion()*
 		The optional argument {opts} is a Dict and supports the
 		following items:
 
-		    exclusive	Specify whether the ending column is exclusive
-		    		instead of 'selection' value.
+		exclusive	Specify whether the ending column is exclusive
+				instead of 'selection' value.
 
 		You can get the last selection type by |visualmode()|.
 		If Visual mode is active, use |mode()| to get the Visual mode

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4282,7 +4282,6 @@ getregion({pos1}, {pos2}, {type} [, {opts}])			*getregion()*
 
 		The optional argument {opts} is a Dict and supports the
 		following items:
-		    winid	Specify the window instead of current window.
 
 		    exclusive	Specify whether the ending column is exclusive
 		    		instead of 'selection' value.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5493,7 +5493,9 @@ f_getregion(typval_T *argvars, typval_T *rettv)
     int			curswant = -1;
     pos_T		p1, p2;
     pos_T		*fp = NULL;
-    char_u		*pos1 = "", *pos2 = "", *type;
+    char_u		*pos1 = (char_u *)"";
+    char_u		*pos2 = (char_u *)"";
+    char_u		*type;
     int			save_virtual = -1;
     int			l;
     int			region_type = -1;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2132,7 +2132,7 @@ static funcentry_T global_functions[] =
 			ret_getreg,	    f_getreg},
     {"getreginfo",	0, 1, FEARG_1,	    arg1_string,
 			ret_dict_any,	    f_getreginfo},
-    {"getregion",	3, 3, FEARG_1,	    arg3_string,
+    {"getregion",	3, 4, FEARG_1,	    arg3_string,
 			ret_list_string,    f_getregion},
     {"getregtype",	0, 1, FEARG_1,	    arg1_string,
 			ret_string,	    f_getregtype},

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5533,7 +5533,7 @@ f_getregion(typval_T *argvars, typval_T *rettv)
     if (is_visual && !VIsual_active)
 	return;
 
-    default_type[0] = curbuf->b_visual_mode_eval;
+    default_type[0] = VIsual_mode;
     default_type[1] = NUL;
 
     if (argvars[2].v_type == VAR_DICT)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5507,7 +5507,7 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 	    || check_for_opt_dict_arg(argvars, 2) == FAIL)
 	return;
 
-    if (list2fpos(&argvars[0], &p1, &fnum, &curswant, FALSE) != OK
+    if (list2fpos(&argvars[0], &p1, &fnum, NULL, FALSE) != OK
 	    || (fnum >= 0 && fnum != curbuf->b_fnum))
 	return;
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5548,7 +5548,7 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 	pos2 = tv_get_string(&argvars[1]);
     type = tv_get_string(&argvars[2]);
 
-    if (argvars[2].v_type == VAR_DICT)
+    if (argvars[3].v_type == VAR_DICT)
 	is_select_exclusive = dict_get_bool(
 		argvars[3].vval.v_dict, "exclusive", *p_sel == 'e');
     else

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5496,7 +5496,7 @@ f_getregion(typval_T *argvars, typval_T *rettv)
     char_u		*pos1 = (char_u *)"";
     char_u		*pos2 = (char_u *)"";
     char_u		*type;
-    char_u		default_type[2];
+    char_u		default_type[] = "v";
     int			save_virtual = -1;
     int			l;
     int			region_type = -1;
@@ -5532,9 +5532,6 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 
     if (is_visual && !VIsual_active)
 	return;
-
-    default_type[0] = VIsual_mode;
-    default_type[1] = NUL;
 
     if (argvars[2].v_type == VAR_DICT)
     {

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5512,35 +5512,15 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 	return;
 
     // NOTE: var2fpos() returns static pointer.
-    if (argvars[0].v_type == VAR_LIST)
-    {
-	if (!list2fpos(&argvars[0], &p1, &fnum, &curswant, FALSE))
-	    return;
-    }
-    else
-    {
-	fp = var2fpos(&argvars[0], TRUE, &fnum, FALSE);
-	if (fp == NULL)
-	    return;
-	p1 = *fp;
-    }
-    if (fnum >= 0 && fnum != curbuf->b_fnum)
+    fp = var2fpos(&argvars[0], TRUE, &fnum, FALSE);
+    if (fp == NULL || fnum >= 0 && fnum != curbuf->b_fnum)
 	return;
+    p1 = *fp;
 
-    if (argvars[1].v_type == VAR_LIST)
-    {
-	if (!list2fpos(&argvars[1], &p2, &fnum, &curswant, FALSE))
-	    return;
-    }
-    else
-    {
-	fp = var2fpos(&argvars[1], TRUE, &fnum, FALSE);
-	if (fp == NULL)
-	    return;
-	p2 = *fp;
-    }
-    if (fnum >= 0 && fnum != curbuf->b_fnum)
+    fp = var2fpos(&argvars[1], TRUE, &fnum, FALSE);
+    if (fp == NULL || fnum >= 0 && fnum != curbuf->b_fnum)
 	return;
+    p2 = *fp;
 
     if (argvars[0].v_type == VAR_STRING)
 	pos1 = tv_get_string(&argvars[0]);

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5490,37 +5490,60 @@ f_getregion(typval_T *argvars, typval_T *rettv)
     char_u		*akt = NULL;
     int			inclusive = TRUE;
     int			fnum = -1;
+    int			curswant = -1;
     pos_T		p1, p2;
     pos_T		*fp = NULL;
-    char_u		*pos1, *pos2, *type;
+    char_u		*pos1 = "", *pos2 = "", *type;
     int			save_virtual = -1;
     int			l;
     int			region_type = -1;
-    int			is_visual;
+    int			is_visual = FALSE;
     int			is_select_exclusive;
 
     if (rettv_list_alloc(rettv) == FAIL)
 	return;
 
-    if (check_for_string_arg(argvars, 0) == FAIL
-	    || check_for_string_arg(argvars, 1) == FAIL
+    if (check_for_string_or_list_arg(argvars, 0) == FAIL
+	    || check_for_string_or_list_arg(argvars, 1) == FAIL
 	    || check_for_string_arg(argvars, 2) == FAIL
 	    || check_for_opt_dict_arg(argvars, 3) == FAIL)
 	return;
 
     // NOTE: var2fpos() returns static pointer.
-    fp = var2fpos(&argvars[0], TRUE, &fnum, FALSE);
-    if (fp == NULL || (fnum >= 0 && fnum != curbuf->b_fnum))
+    if (argvars[0].v_type == VAR_LIST)
+    {
+	if (!list2fpos(&argvars[0], &p1, &fnum, &curswant, FALSE))
+	    return;
+    }
+    else
+    {
+	fp = var2fpos(&argvars[0], TRUE, &fnum, FALSE);
+	if (fp == NULL)
+	    return;
+	p1 = *fp;
+    }
+    if (fnum >= 0 && fnum != curbuf->b_fnum)
 	return;
-    p1 = *fp;
 
-    fp = var2fpos(&argvars[1], TRUE, &fnum, FALSE);
-    if (fp == NULL || (fnum >= 0 && fnum != curbuf->b_fnum))
+    if (argvars[1].v_type == VAR_LIST)
+    {
+	if (!list2fpos(&argvars[1], &p2, &fnum, &curswant, FALSE))
+	    return;
+    }
+    else
+    {
+	fp = var2fpos(&argvars[1], TRUE, &fnum, FALSE);
+	if (fp == NULL)
+	    return;
+	p2 = *fp;
+    }
+    if (fnum >= 0 && fnum != curbuf->b_fnum)
 	return;
-    p2 = *fp;
 
-    pos1 = tv_get_string(&argvars[0]);
-    pos2 = tv_get_string(&argvars[1]);
+    if (argvars[0].v_type == VAR_STRING)
+	pos1 = tv_get_string(&argvars[0]);
+    if (argvars[1].v_type == VAR_STRING)
+	pos2 = tv_get_string(&argvars[1]);
     type = tv_get_string(&argvars[2]);
 
     if (argvars[2].v_type == VAR_DICT)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5490,7 +5490,6 @@ f_getregion(typval_T *argvars, typval_T *rettv)
     char_u		*akt = NULL;
     int			inclusive = TRUE;
     int			fnum = -1;
-    int			curswant = -1;
     pos_T		p1, p2;
     pos_T		*fp = NULL;
     char_u		*pos1 = (char_u *)"";

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5513,12 +5513,12 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 
     // NOTE: var2fpos() returns static pointer.
     fp = var2fpos(&argvars[0], TRUE, &fnum, FALSE);
-    if (fp == NULL || fnum >= 0 && fnum != curbuf->b_fnum)
+    if (fp == NULL || (fnum >= 0 && fnum != curbuf->b_fnum))
 	return;
     p1 = *fp;
 
     fp = var2fpos(&argvars[1], TRUE, &fnum, FALSE);
-    if (fp == NULL || fnum >= 0 && fnum != curbuf->b_fnum)
+    if (fp == NULL || (fnum >= 0 && fnum != curbuf->b_fnum))
 	return;
     p2 = *fp;
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5511,7 +5511,7 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 	    || (fnum >= 0 && fnum != curbuf->b_fnum))
 	return;
 
-    if (list2fpos(&argvars[1], &p2, &fnum, &curswant, FALSE) != OK
+    if (list2fpos(&argvars[1], &p2, &fnum, NULL, FALSE) != OK
 	    || (fnum >= 0 && fnum != curbuf->b_fnum))
 	return;
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5498,7 +5498,6 @@ f_getregion(typval_T *argvars, typval_T *rettv)
     int			l;
     int			region_type = -1;
     int			is_select_exclusive;
-    colnr_T		curswant = -1;
 
     if (rettv_list_alloc(rettv) == FAIL)
 	return;

--- a/src/testdir/test.ok
+++ b/src/testdir/test.ok
@@ -1,2 +1,0 @@
-fooSLASHbar
-fooPIPEbar

--- a/src/testdir/test.ok
+++ b/src/testdir/test.ok
@@ -1,0 +1,2 @@
+fooSLASHbar
+fooPIPEbar

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -5198,12 +5198,12 @@ def Test_passing_type_to_builtin()
 enddef
 
 def Test_getregion()
-  assert_equal(['x'], getregion('.', '.', 'v')->map((_, _) => 'x'))
+  assert_equal(['x'], getregion('.', '.')->map((_, _) => 'x'))
 
-  v9.CheckDefAndScriptFailure(['getregion(10, ".", "v")'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1222: String or List required for argument 1'])
-  assert_equal([''], getregion('.', '.', 'v'))
-  v9.CheckDefExecFailure(['getregion("a", ".", "v")'], 'E1209:')
-  v9.CheckDefExecAndScriptFailure(['getregion("", ".", "v")'], 'E1209: Invalid value for a line number')
+  v9.CheckDefAndScriptFailure(['getregion(10, ".")'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1222: String or List required for argument 1'])
+  assert_equal([''], getregion('.', '.'))
+  v9.CheckDefExecFailure(['getregion("a", ".")'], 'E1209:')
+  v9.CheckDefExecAndScriptFailure(['getregion("", ".")'], 'E1209: Invalid value for a line number')
 enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -5198,12 +5198,11 @@ def Test_passing_type_to_builtin()
 enddef
 
 def Test_getregion()
-  assert_equal(['x'], getregion('.', '.')->map((_, _) => 'x'))
+  assert_equal(['x'], getregion(getpos('.'), getpos('.'))->map((_, _) => 'x'))
 
-  v9.CheckDefAndScriptFailure(['getregion(10, ".")'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1222: String or List required for argument 1'])
-  assert_equal([''], getregion('.', '.'))
-  v9.CheckDefExecFailure(['getregion("a", ".")'], 'E1209:')
-  v9.CheckDefExecAndScriptFailure(['getregion("", ".")'], 'E1209: Invalid value for a line number')
+  v9.CheckDefAndScriptFailure(['getregion(10, getpos("."))'], ['E1013: Argument 1: type mismatch, expected list<any> but got number', 'E1211: List required for argument 1'])
+  assert_equal([''], getregion(getpos('.'), getpos('.')))
+  v9.CheckDefExecFailure(['getregion(getpos("a"), getpos("."))'], 'E1209:')
 enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -5200,7 +5200,7 @@ enddef
 def Test_getregion()
   assert_equal(['x'], getregion('.', '.', 'v')->map((_, _) => 'x'))
 
-  v9.CheckDefAndScriptFailure(['getregion(10, ".", "v")'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1174: String required for argument 1'])
+  v9.CheckDefAndScriptFailure(['getregion(10, ".", "v")'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1222: String or List required for argument 1'])
   assert_equal([''], getregion('.', '.', 'v'))
   v9.CheckDefExecFailure(['getregion("a", ".", "v")'], 'E1209:')
   v9.CheckDefExecAndScriptFailure(['getregion("", ".", "v")'], 'E1209: Invalid value for a line number')

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1677,10 +1677,10 @@ func Test_visual_getregion()
   " Using List
   call cursor(1, 1)
   call assert_equal(['one', 'two'], [2, 3]->getregion('.', #{ type: 'v' }))
-  call assert_equal(['one', 'two'], '.'->getregion([2, 3], #{ type: 'v' }))
+  call assert_equal(['one', 'two'], '.'->getregion([2, 3, 0], #{ type: 'v' }))
   call assert_equal(['one', 'two'], '.'->getregion([2, 3], #{ type: 'V' }))
   call assert_equal(['two'], [2, 3]->getregion([2, 3], #{ type: 'V' }))
-  call assert_equal(['one', 'two'], '.'->getregion([2, 3], #{ type: "\<c-v>" }))
+  call assert_equal(['one', 'two'], '.'->getregion([2, 3, 0], #{ type: "\<c-v>" }))
 
   " Multiline with line visual mode
   call cursor(1, 1)

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1717,7 +1717,7 @@ func Test_visual_getregion()
   " using an unset mark
   call assert_equal([], "'z"->getregion(".", #{ type: 'V' }))
   " using the wrong type
-  call assert_fails(':echo "."->getregion("$", {})', 'E1174:')
+  call assert_fails(':echo "."->getregion("$", [])', 'E1206:')
   " using a mark in another buffer
   new
   let newbuf = bufnr()

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1638,30 +1638,30 @@ func Test_visual_getregion()
   " Visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>vjl", 'tx')
-  call assert_equal(['one', 'tw'], 'v'->getregion('.'))
-  call assert_equal(['one', 'tw'], '.'->getregion('v'))
-  call assert_equal(['o'], 'v'->getregion('v'))
-  call assert_equal(['w'], '.'->getregion('.'))
+  call assert_equal(['one', 'tw'], 'v'->getregion('.', #{ type: 'v' }))
+  call assert_equal(['one', 'tw'], '.'->getregion('v', #{ type: 'v' }))
+  call assert_equal(['o'], 'v'->getregion('v', #{ type: 'v' }))
+  call assert_equal(['w'], '.'->getregion('.', #{ type: 'v' }))
   call assert_equal(['one', 'two'], '.'->getregion('v', #{ type: 'V' }))
   call assert_equal(['on', 'tw'], '.'->getregion('v', #{ type: "\<C-v>" }))
 
   " Line visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>Vl", 'tx')
-  call assert_equal(['one'], getregion('v', '.'))
-  call assert_equal(['one'], getregion('.', 'v'))
-  call assert_equal(['one'], getregion('v', 'v'))
-  call assert_equal(['one'], getregion('.', '.'))
+  call assert_equal(['one'], getregion('v', '.', #{ type: 'V' }))
+  call assert_equal(['one'], getregion('.', 'v', #{ type: 'V' }))
+  call assert_equal(['one'], getregion('v', 'v', #{ type: 'V' }))
+  call assert_equal(['one'], getregion('.', '.', #{ type: 'V' }))
   call assert_equal(['on'], '.'->getregion('v', #{ type: 'v' }))
   call assert_equal(['on'], '.'->getregion('v', #{ type: "\<C-v>" }))
 
   " Block visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>ll", 'tx')
-  call assert_equal(['one'], getregion('v', '.'))
-  call assert_equal(['one'], getregion('.', 'v'))
-  call assert_equal(['o'], getregion('v', 'v'))
-  call assert_equal(['e'], getregion('.', '.'))
+  call assert_equal(['one'], getregion('v', '.', #{ type: "\<C-v>" }))
+  call assert_equal(['one'], getregion('.', 'v', #{ type: "\<C-v>" }))
+  call assert_equal(['o'], getregion('v', 'v', #{ type: "\<C-v>" }))
+  call assert_equal(['e'], getregion('.', '.', #{ type: "\<C-v>" }))
   call assert_equal(['one'], '.'->getregion('v', #{ type: 'V' }))
   call assert_equal(['one'], '.'->getregion('v', #{ type: 'v' }))
 
@@ -1685,23 +1685,23 @@ func Test_visual_getregion()
   " Multiline with line visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>Vjj", 'tx')
-  call assert_equal(['one', 'two', 'three'], getregion('v', '.'))
+  call assert_equal(['one', 'two', 'three'], getregion('v', '.', #{ type: 'V' }))
 
   " Multiline with block visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>jj", 'tx')
-  call assert_equal(['o', 't', 't'], getregion('v', '.'))
+  call assert_equal(['o', 't', 't'], getregion('v', '.', #{ type: "\<C-v>" }))
 
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>jj$", 'tx')
-  call assert_equal(['one', 'two', 'three'], getregion('v', '.'))
+  call assert_equal(['one', 'two', 'three'], getregion('v', '.', #{ type: "\<C-v>" }))
 
   " 'virtualedit'
   set virtualedit=all
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>10ljj$", 'tx')
   call assert_equal(['one   ', 'two   ', 'three '],
-        \ getregion('v', '.'))
+        \ getregion('v', '.', #{ type: "\<C-v>" }))
   set virtualedit&
 
   " Invalid position
@@ -1740,17 +1740,18 @@ func Test_visual_getregion()
   call cursor(1, 3)
   call feedkeys("\<Esc>\<C-v>ljj", 'xt')
   call assert_equal(['cd', "\u00ab ", '34'],
-        \ getregion('v', '.'))
+        \ getregion('v', '.', #{ type: "\<C-v>" }))
   call cursor(1, 4)
   call feedkeys("\<Esc>\<C-v>ljj", 'xt')
   call assert_equal(['de', "\U0001f1e7", '45'],
-        \ getregion('v', '.'))
+        \ getregion('v', '.', #{ type: "\<C-v>" }))
   call cursor(1, 5)
   call feedkeys("\<Esc>\<C-v>jj", 'xt')
-  call assert_equal(['e', ' ', '5'], getregion('v', '.'))
+  call assert_equal(['e', ' ', '5'], getregion('v', '.', #{ type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>vj", 'xt')
-  call assert_equal(['abcdefghijk«', "\U0001f1e6"], getregion('v', '.'))
+  call assert_equal(['abcdefghijk«', "\U0001f1e6"],
+        \ getregion('v', '.', #{ type: 'v' }))
   " marks on multibyte chars
   set selection=exclusive
   call setpos("'a", [0, 1, 11, 0])
@@ -1769,22 +1770,22 @@ func Test_visual_getregion()
   call setline(1, ["a\tc", "x\tz", '', ''])
   call cursor(1, 1)
   call feedkeys("\<Esc>v2l", 'xt')
-  call assert_equal(["a\t"], getregion('v', '.'))
+  call assert_equal(["a\t"], getregion('v', '.', #{ type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$G", 'xt')
-  call assert_equal(["a\tc", "x\tz", ''], getregion('v', '.'))
+  call assert_equal(["a\tc", "x\tz", ''], getregion('v', '.', #{ type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.'))
+  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', #{ type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.'))
+  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', #{ type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$G", 'xt')
-  call assert_equal(["a", "x", '', ''], getregion('v', '.'))
+  call assert_equal(["a", "x", '', ''], getregion('v', '.', #{ type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>wv2j", 'xt')
-  call assert_equal(["c", "x\tz"], getregion('v', '.'))
+  call assert_equal(["c", "x\tz"], getregion('v', '.', #{ type: 'v' }))
   set selection&
 
   " Exclusive selection 2
@@ -1792,32 +1793,38 @@ func Test_visual_getregion()
   call setline(1, ["a\tc", "x\tz", '', ''])
   call cursor(1, 1)
   call feedkeys("\<Esc>v2l", 'xt')
-  call assert_equal(["a\t"], getregion('v', '.', #{ exclusive: v:true }))
+  call assert_equal(["a\t"],
+        \ getregion('v', '.', #{ exclusive: v:true, type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$G", 'xt')
-  call assert_equal(["a\tc", "x\tz", ''], getregion('v', '.', #{ exclusive: v:true }))
+  call assert_equal(["a\tc", "x\tz", ''],
+        \ getregion('v', '.', #{ exclusive: v:true, type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', #{ exclusive: v:true }))
+  call assert_equal(["a\tc", "x\tz"],
+        \ getregion('v', '.', #{ exclusive: v:true, type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', #{ exclusive: v:true }))
+  call assert_equal(["a\tc", "x\tz"],
+        \ getregion('v', '.', #{ exclusive: v:true, type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$G", 'xt')
-  call assert_equal(["a", "x", '', ''], getregion('v', '.', #{ exclusive: v:true }))
+  call assert_equal(["a", "x", '', ''],
+        \ getregion('v', '.', #{ exclusive: v:true, type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>wv2j", 'xt')
-  call assert_equal(["c", "x\tz"], getregion('v', '.', #{ exclusive: v:true }))
+  call assert_equal(["c", "x\tz"],
+        \ getregion('v', '.', #{ exclusive: v:true, type: 'v' }))
 
   " virtualedit
   set selection=exclusive
   set virtualedit=all
   call cursor(1, 1)
   call feedkeys("\<Esc>2lv2lj", 'xt')
-  call assert_equal(['      c', 'x   '], getregion('v', '.'))
+  call assert_equal(['      c', 'x   '], getregion('v', '.', #{ type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>2l\<C-v>2l2j", 'xt')
-  call assert_equal(['  ', '  ', '  '], getregion('v', '.'))
+  call assert_equal(['  ', '  ', '  '], getregion('v', '.', #{ type: "\<C-v>" }))
   set virtualedit&
   set selection&
 

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1699,8 +1699,8 @@ func Test_visual_getregion()
   " Invalid position
   call cursor(1, 1)
   call feedkeys("\<ESC>vjj$", 'tx')
-  call assert_fails("call getregion(1, 2, 'v')", 'E1174:')
-  call assert_fails("call getregion('.', {}, 'v')", 'E1174:')
+  call assert_fails("call getregion(1, 2, 'v')", 'E1222:')
+  call assert_fails("call getregion('.', {}, 'v')", 'E1222:')
   call assert_equal([], getregion('', '.', 'v'))
   call assert_equal([], getregion('.', '.', ''))
   call feedkeys("\<ESC>", 'tx')
@@ -1709,9 +1709,7 @@ func Test_visual_getregion()
   " using an unset mark
   call assert_equal([], "'z"->getregion(".", 'V'))
   " using the wrong type
-  call assert_fails(':echo "."->getregion([],"V")', 'E1174:')
   call assert_fails(':echo "."->getregion("$", {})', 'E1174:')
-  call assert_fails(':echo [0, 1, 1, 0]->getregion("$", "v")', 'E1174:')
   " using a mark in another buffer
   new
   let newbuf = bufnr()

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1638,84 +1638,84 @@ func Test_visual_getregion()
   " Visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>vjl", 'tx')
-  call assert_equal(['one', 'tw'], 'v'->getregion('.', 'v'))
-  call assert_equal(['one', 'tw'], '.'->getregion('v', 'v'))
-  call assert_equal(['o'], 'v'->getregion('v', 'v'))
-  call assert_equal(['w'], '.'->getregion('.', 'v'))
-  call assert_equal(['one', 'two'], '.'->getregion('v', 'V'))
-  call assert_equal(['on', 'tw'], '.'->getregion('v', "\<C-v>"))
+  call assert_equal(['one', 'tw'], 'v'->getregion('.'))
+  call assert_equal(['one', 'tw'], '.'->getregion('v'))
+  call assert_equal(['o'], 'v'->getregion('v'))
+  call assert_equal(['w'], '.'->getregion('.'))
+  call assert_equal(['one', 'two'], '.'->getregion('v', #{ type: 'V' }))
+  call assert_equal(['on', 'tw'], '.'->getregion('v', #{ type: "\<C-v>" }))
 
   " Line visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>Vl", 'tx')
-  call assert_equal(['one'], getregion('v', '.', 'V'))
-  call assert_equal(['one'], getregion('.', 'v', 'V'))
-  call assert_equal(['one'], getregion('v', 'v', 'V'))
-  call assert_equal(['one'], getregion('.', '.', 'V'))
-  call assert_equal(['on'], '.'->getregion('v', 'v'))
-  call assert_equal(['on'], '.'->getregion('v', "\<C-v>"))
+  call assert_equal(['one'], getregion('v', '.'))
+  call assert_equal(['one'], getregion('.', 'v'))
+  call assert_equal(['one'], getregion('v', 'v'))
+  call assert_equal(['one'], getregion('.', '.'))
+  call assert_equal(['on'], '.'->getregion('v', #{ type: 'v' }))
+  call assert_equal(['on'], '.'->getregion('v', #{ type: "\<C-v>" }))
 
   " Block visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>ll", 'tx')
-  call assert_equal(['one'], getregion('v', '.', "\<C-v>"))
-  call assert_equal(['one'], getregion('.', 'v', "\<C-v>"))
-  call assert_equal(['o'], getregion('v', 'v', "\<C-v>"))
-  call assert_equal(['e'], getregion('.', '.', "\<C-v>"))
-  call assert_equal(['one'], '.'->getregion('v', 'V'))
-  call assert_equal(['one'], '.'->getregion('v', 'v'))
+  call assert_equal(['one'], getregion('v', '.'))
+  call assert_equal(['one'], getregion('.', 'v'))
+  call assert_equal(['o'], getregion('v', 'v'))
+  call assert_equal(['e'], getregion('.', '.'))
+  call assert_equal(['one'], '.'->getregion('v', #{ type: 'V' }))
+  call assert_equal(['one'], '.'->getregion('v', #{ type: 'v' }))
 
   " Using Marks
   call setpos("'a", [0, 2, 3, 0])
   call cursor(1, 1)
-  call assert_equal(['one', 'two'], "'a"->getregion('.', 'v'))
-  call assert_equal(['one', 'two'], "."->getregion("'a", 'v'))
-  call assert_equal(['one', 'two'], "."->getregion("'a", 'V'))
-  call assert_equal(['two'], "'a"->getregion("'a", 'V'))
-  call assert_equal(['one', 'two'], "."->getregion("'a", "\<c-v>"))
+  call assert_equal(['one', 'two'], "'a"->getregion('.', #{ type: 'v' }))
+  call assert_equal(['one', 'two'], "."->getregion("'a", #{ type: 'v' }))
+  call assert_equal(['one', 'two'], "."->getregion("'a", #{ type: 'V' }))
+  call assert_equal(['two'], "'a"->getregion("'a", #{ type: 'V' }))
+  call assert_equal(['one', 'two'], "."->getregion("'a", #{ type: "\<c-v>" }))
 
   " Using List
   call cursor(1, 1)
-  call assert_equal(['one', 'two'], [2, 3]->getregion('.', 'v'))
-  call assert_equal(['one', 'two'], '.'->getregion([2, 3], 'v'))
-  call assert_equal(['one', 'two'], '.'->getregion([2, 3], 'V'))
-  call assert_equal(['two'], [2, 3]->getregion([2, 3], 'V'))
-  call assert_equal(['one', 'two'], '.'->getregion([2, 3], "\<c-v>"))
+  call assert_equal(['one', 'two'], [2, 3]->getregion('.', #{ type: 'v' }))
+  call assert_equal(['one', 'two'], '.'->getregion([2, 3], #{ type: 'v' }))
+  call assert_equal(['one', 'two'], '.'->getregion([2, 3], #{ type: 'V' }))
+  call assert_equal(['two'], [2, 3]->getregion([2, 3], #{ type: 'V' }))
+  call assert_equal(['one', 'two'], '.'->getregion([2, 3], #{ type: "\<c-v>" }))
 
   " Multiline with line visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>Vjj", 'tx')
-  call assert_equal(['one', 'two', 'three'], getregion('v', '.', 'V'))
+  call assert_equal(['one', 'two', 'three'], getregion('v', '.'))
 
   " Multiline with block visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>jj", 'tx')
-  call assert_equal(['o', 't', 't'], getregion('v', '.', "\<C-v>"))
+  call assert_equal(['o', 't', 't'], getregion('v', '.'))
 
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>jj$", 'tx')
-  call assert_equal(['one', 'two', 'three'], getregion('v', '.', "\<C-v>"))
+  call assert_equal(['one', 'two', 'three'], getregion('v', '.'))
 
   " 'virtualedit'
   set virtualedit=all
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>10ljj$", 'tx')
   call assert_equal(['one   ', 'two   ', 'three '],
-        \ getregion('v', '.', "\<C-v>"))
+        \ getregion('v', '.'))
   set virtualedit&
 
   " Invalid position
   call cursor(1, 1)
   call feedkeys("\<ESC>vjj$", 'tx')
-  call assert_fails("call getregion(1, 2, 'v')", 'E1222:')
-  call assert_fails("call getregion('.', {}, 'v')", 'E1222:')
-  call assert_equal([], getregion('', '.', 'v'))
-  call assert_equal([], getregion('.', '.', ''))
+  call assert_fails("call getregion(1, 2)", 'E1222:')
+  call assert_fails("call getregion('.', {})", 'E1222:')
+  call assert_equal([], getregion('', '.'))
+  call assert_equal([], getregion('.', '.', #{ type: '' }))
   call feedkeys("\<ESC>", 'tx')
-  call assert_equal([], getregion('v', '.', 'v'))
+  call assert_equal([], getregion('v', '.'))
 
   " using an unset mark
-  call assert_equal([], "'z"->getregion(".", 'V'))
+  call assert_equal([], "'z"->getregion(".", #{ type: 'V' }))
   " using the wrong type
   call assert_fails(':echo "."->getregion("$", {})', 'E1174:')
   " using a mark in another buffer
@@ -1725,8 +1725,8 @@ func Test_visual_getregion()
   normal! GmA
   wincmd p
   call assert_equal([newbuf, 10, 1, 0], getpos("'A"))
-  call assert_equal([], getregion(".", "'A", 'v'))
-  call assert_equal([], getregion("'A", ".", 'v'))
+  call assert_equal([], getregion(".", "'A", #{ type: 'v' }))
+  call assert_equal([], getregion("'A", ".", #{ type: 'v' }))
   exe newbuf .. 'bwipe!'
 
   bwipe!
@@ -1740,26 +1740,26 @@ func Test_visual_getregion()
   call cursor(1, 3)
   call feedkeys("\<Esc>\<C-v>ljj", 'xt')
   call assert_equal(['cd', "\u00ab ", '34'],
-        \ getregion('v', '.', "\<C-v>"))
+        \ getregion('v', '.'))
   call cursor(1, 4)
   call feedkeys("\<Esc>\<C-v>ljj", 'xt')
   call assert_equal(['de', "\U0001f1e7", '45'],
-        \ getregion('v', '.', "\<C-v>"))
+        \ getregion('v', '.'))
   call cursor(1, 5)
   call feedkeys("\<Esc>\<C-v>jj", 'xt')
-  call assert_equal(['e', ' ', '5'], getregion('v', '.', "\<C-v>"))
+  call assert_equal(['e', ' ', '5'], getregion('v', '.'))
   call cursor(1, 1)
   call feedkeys("\<Esc>vj", 'xt')
-  call assert_equal(['abcdefghijk«', "\U0001f1e6"], getregion('v', '.', "v"))
+  call assert_equal(['abcdefghijk«', "\U0001f1e6"], getregion('v', '.'))
   " marks on multibyte chars
   set selection=exclusive
   call setpos("'a", [0, 1, 11, 0])
   call setpos("'b", [0, 2, 16, 0])
   call setpos("'c", [0, 2, 0, 0])
   call cursor(1, 1)
-  call assert_equal(['ghijk', '🇨«🇩'], getregion("'a", "'b", "\<c-v>"))
-  call assert_equal(['k«', '🇦«🇧«🇨'], getregion("'a", "'b", "v"))
-  call assert_equal(['k«'], getregion("'a", "'c", "v"))
+  call assert_equal(['ghijk', '🇨«🇩'], getregion("'a", "'b", #{ type: "\<c-v>" }))
+  call assert_equal(['k«', '🇦«🇧«🇨'], getregion("'a", "'b", #{ type: "v" }))
+  call assert_equal(['k«'], getregion("'a", "'c", #{ type: "v" }))
 
   bwipe!
 
@@ -1769,22 +1769,22 @@ func Test_visual_getregion()
   call setline(1, ["a\tc", "x\tz", '', ''])
   call cursor(1, 1)
   call feedkeys("\<Esc>v2l", 'xt')
-  call assert_equal(["a\t"], getregion('v', '.', 'v'))
+  call assert_equal(["a\t"], getregion('v', '.'))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$G", 'xt')
-  call assert_equal(["a\tc", "x\tz", ''], getregion('v', '.', 'v'))
+  call assert_equal(["a\tc", "x\tz", ''], getregion('v', '.'))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', 'v'))
+  call assert_equal(["a\tc", "x\tz"], getregion('v', '.'))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', "\<C-v>"))
+  call assert_equal(["a\tc", "x\tz"], getregion('v', '.'))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$G", 'xt')
-  call assert_equal(["a", "x", '', ''], getregion('v', '.', "\<C-v>"))
+  call assert_equal(["a", "x", '', ''], getregion('v', '.'))
   call cursor(1, 1)
   call feedkeys("\<Esc>wv2j", 'xt')
-  call assert_equal(["c", "x\tz"], getregion('v', '.', 'v'))
+  call assert_equal(["c", "x\tz"], getregion('v', '.'))
   set selection&
 
   " Exclusive selection 2
@@ -1792,32 +1792,32 @@ func Test_visual_getregion()
   call setline(1, ["a\tc", "x\tz", '', ''])
   call cursor(1, 1)
   call feedkeys("\<Esc>v2l", 'xt')
-  call assert_equal(["a\t"], getregion('v', '.', 'v', #{ exclusive: v:true }))
+  call assert_equal(["a\t"], getregion('v', '.', #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$G", 'xt')
-  call assert_equal(["a\tc", "x\tz", ''], getregion('v', '.', 'v', #{ exclusive: v:true }))
+  call assert_equal(["a\tc", "x\tz", ''], getregion('v', '.', #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', 'v', #{ exclusive: v:true }))
+  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', "\<C-v>", #{ exclusive: v:true }))
+  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$G", 'xt')
-  call assert_equal(["a", "x", '', ''], getregion('v', '.', "\<C-v>", #{ exclusive: v:true }))
+  call assert_equal(["a", "x", '', ''], getregion('v', '.', #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>wv2j", 'xt')
-  call assert_equal(["c", "x\tz"], getregion('v', '.', 'v', #{ exclusive: v:true }))
+  call assert_equal(["c", "x\tz"], getregion('v', '.', #{ exclusive: v:true }))
 
   " virtualedit
   set selection=exclusive
   set virtualedit=all
   call cursor(1, 1)
   call feedkeys("\<Esc>2lv2lj", 'xt')
-  call assert_equal(['      c', 'x   '], getregion('v', '.', 'v'))
+  call assert_equal(['      c', 'x   '], getregion('v', '.'))
   call cursor(1, 1)
   call feedkeys("\<Esc>2l\<C-v>2l2j", 'xt')
-  call assert_equal(['  ', '  ', '  '], getregion('v', '.', "\<C-v>"))
+  call assert_equal(['  ', '  ', '  '], getregion('v', '.'))
   set virtualedit&
   set selection&
 

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1638,86 +1638,113 @@ func Test_visual_getregion()
   " Visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>vjl", 'tx')
-  call assert_equal(['one', 'tw'], 'v'->getregion('.', #{ type: 'v' }))
-  call assert_equal(['one', 'tw'], '.'->getregion('v', #{ type: 'v' }))
-  call assert_equal(['o'], 'v'->getregion('v', #{ type: 'v' }))
-  call assert_equal(['w'], '.'->getregion('.', #{ type: 'v' }))
-  call assert_equal(['one', 'two'], '.'->getregion('v', #{ type: 'V' }))
-  call assert_equal(['on', 'tw'], '.'->getregion('v', #{ type: "\<C-v>" }))
+  call assert_equal(['one', 'tw'],
+        \ 'v'->getpos()->getregion(getpos('.'), #{ type: 'v' }))
+  call assert_equal(['one', 'tw'],
+        \ '.'->getpos()->getregion(getpos('v'), #{ type: 'v' }))
+  call assert_equal(['o'],
+        \ 'v'->getpos()->getregion(getpos('v'), #{ type: 'v' }))
+  call assert_equal(['w'],
+        \ '.'->getpos()->getregion(getpos('.'), #{ type: 'v' }))
+  call assert_equal(['one', 'two'],
+        \ getpos('.')->getregion(getpos('v'), #{ type: 'V' }))
+  call assert_equal(['on', 'tw'],
+        \ getpos('.')->getregion(getpos('v'), #{ type: "\<C-v>" }))
 
   " Line visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>Vl", 'tx')
-  call assert_equal(['one'], getregion('v', '.', #{ type: 'V' }))
-  call assert_equal(['one'], getregion('.', 'v', #{ type: 'V' }))
-  call assert_equal(['one'], getregion('v', 'v', #{ type: 'V' }))
-  call assert_equal(['one'], getregion('.', '.', #{ type: 'V' }))
-  call assert_equal(['on'], '.'->getregion('v', #{ type: 'v' }))
-  call assert_equal(['on'], '.'->getregion('v', #{ type: "\<C-v>" }))
+  call assert_equal(['one'],
+        \ getregion(getpos('v'), getpos('.'), #{ type: 'V' }))
+  call assert_equal(['one'],
+        \ getregion(getpos('.'), getpos('v'), #{ type: 'V' }))
+  call assert_equal(['one'],
+        \ getregion(getpos('v'), getpos('v'), #{ type: 'V' }))
+  call assert_equal(['one'],
+        \ getregion(getpos('.'), getpos('.'), #{ type: 'V' }))
+  call assert_equal(['on'],
+        \ getpos('.')->getregion(getpos('v'), #{ type: 'v' }))
+  call assert_equal(['on'],
+        \ getpos('.')->getregion(getpos('v'), #{ type: "\<C-v>" }))
 
   " Block visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>ll", 'tx')
-  call assert_equal(['one'], getregion('v', '.', #{ type: "\<C-v>" }))
-  call assert_equal(['one'], getregion('.', 'v', #{ type: "\<C-v>" }))
-  call assert_equal(['o'], getregion('v', 'v', #{ type: "\<C-v>" }))
-  call assert_equal(['e'], getregion('.', '.', #{ type: "\<C-v>" }))
-  call assert_equal(['one'], '.'->getregion('v', #{ type: 'V' }))
-  call assert_equal(['one'], '.'->getregion('v', #{ type: 'v' }))
+  call assert_equal(['one'],
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
+  call assert_equal(['one'],
+        \ getregion(getpos('.'), getpos('v'), #{ type: "\<C-v>" }))
+  call assert_equal(['o'],
+        \ getregion(getpos('v'), getpos('v'), #{ type: "\<C-v>" }))
+  call assert_equal(['e'],
+        \ getregion(getpos('.'), getpos('.'), #{ type: "\<C-v>" }))
+  call assert_equal(['one'],
+        \ '.'->getpos()->getregion(getpos('v'), #{ type: 'V' }))
+  call assert_equal(['one'],
+        \ '.'->getpos()->getregion(getpos('v'), #{ type: 'v' }))
 
   " Using Marks
   call setpos("'a", [0, 2, 3, 0])
   call cursor(1, 1)
-  call assert_equal(['one', 'two'], "'a"->getregion('.', #{ type: 'v' }))
-  call assert_equal(['one', 'two'], "."->getregion("'a", #{ type: 'v' }))
-  call assert_equal(['one', 'two'], "."->getregion("'a", #{ type: 'V' }))
-  call assert_equal(['two'], "'a"->getregion("'a", #{ type: 'V' }))
-  call assert_equal(['one', 'two'], "."->getregion("'a", #{ type: "\<c-v>" }))
+  call assert_equal(['one', 'two'],
+        \ "'a"->getpos()->getregion(getpos('.'), #{ type: 'v' }))
+  call assert_equal(['one', 'two'],
+        \ "."->getpos()->getregion(getpos("'a"), #{ type: 'v' }))
+  call assert_equal(['one', 'two'],
+        \ "."->getpos()->getregion(getpos("'a"), #{ type: 'V' }))
+  call assert_equal(['two'],
+        \ "'a"->getpos()->getregion(getpos("'a"), #{ type: 'V' }))
+  call assert_equal(['one', 'two'],
+        \ "."->getpos()->getregion(getpos("'a"), #{ type: "\<c-v>" }))
 
   " Using List
   call cursor(1, 1)
-  call assert_equal(['one', 'two'], [2, 3]->getregion('.', #{ type: 'v' }))
-  call assert_equal(['one', 'two'], '.'->getregion([2, 3, 0], #{ type: 'v' }))
-  call assert_equal(['one', 'two'], '.'->getregion([2, 3], #{ type: 'V' }))
-  call assert_equal(['two'], [2, 3]->getregion([2, 3], #{ type: 'V' }))
-  call assert_equal(['one', 'two'], '.'->getregion([2, 3, 0], #{ type: "\<c-v>" }))
+  call assert_equal(['one', 'two'],
+        \ [0, 2, 3, 0]->getregion(getpos('.'), #{ type: 'v' }))
+  call assert_equal(['one', 'two'],
+        \ '.'->getpos()->getregion([0, 2, 3, 0], #{ type: 'v' }))
+  call assert_equal(['one', 'two'],
+        \ '.'->getpos()->getregion([0, 2, 3, 0], #{ type: 'V' }))
+  call assert_equal(['two'],
+        \ [0, 2, 3, 0]->getregion([0, 2, 3, 0], #{ type: 'V' }))
+  call assert_equal(['one', 'two'],
+        \ '.'->getpos()->getregion([0, 2, 3, 0], #{ type: "\<c-v>" }))
 
   " Multiline with line visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>Vjj", 'tx')
-  call assert_equal(['one', 'two', 'three'], getregion('v', '.', #{ type: 'V' }))
+  call assert_equal(['one', 'two', 'three'],
+        \ getregion(getpos('v'), getpos('.'), #{ type: 'V' }))
 
   " Multiline with block visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>jj", 'tx')
-  call assert_equal(['o', 't', 't'], getregion('v', '.', #{ type: "\<C-v>" }))
+  call assert_equal(['o', 't', 't'],
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
 
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>jj$", 'tx')
-  call assert_equal(['one', 'two', 'three'], getregion('v', '.', #{ type: "\<C-v>" }))
+  call assert_equal(['one', 'two', 'three'],
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
 
   " 'virtualedit'
   set virtualedit=all
   call cursor(1, 1)
   call feedkeys("\<ESC>\<C-v>10ljj$", 'tx')
   call assert_equal(['one   ', 'two   ', 'three '],
-        \ getregion('v', '.', #{ type: "\<C-v>" }))
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
   set virtualedit&
 
   " Invalid position
   call cursor(1, 1)
   call feedkeys("\<ESC>vjj$", 'tx')
-  call assert_fails("call getregion(1, 2)", 'E1222:')
-  call assert_fails("call getregion('.', {})", 'E1222:')
-  call assert_equal([], getregion('', '.'))
-  call assert_equal([], getregion('.', '.', #{ type: '' }))
-  call feedkeys("\<ESC>", 'tx')
-  call assert_equal([], getregion('v', '.'))
+  call assert_fails("call getregion(1, 2)", 'E1211:')
+  call assert_fails("call getregion(getpos('.'), {})", 'E1211:')
+  call assert_equal([], getregion(getpos('.'), getpos('.'), #{ type: '' }))
 
-  " using an unset mark
-  call assert_equal([], "'z"->getregion(".", #{ type: 'V' }))
   " using the wrong type
-  call assert_fails(':echo "."->getregion("$", [])', 'E1206:')
+  call assert_fails(':echo "."->getpos()->getregion("$", [])', 'E1211:')
+
   " using a mark in another buffer
   new
   let newbuf = bufnr()
@@ -1725,8 +1752,8 @@ func Test_visual_getregion()
   normal! GmA
   wincmd p
   call assert_equal([newbuf, 10, 1, 0], getpos("'A"))
-  call assert_equal([], getregion(".", "'A", #{ type: 'v' }))
-  call assert_equal([], getregion("'A", ".", #{ type: 'v' }))
+  call assert_equal([], getregion(getpos('.'), getpos("'A"), #{ type: 'v' }))
+  call assert_equal([], getregion(getpos("'A"), getpos('.'), #{ type: 'v' }))
   exe newbuf .. 'bwipe!'
 
   bwipe!
@@ -1740,27 +1767,31 @@ func Test_visual_getregion()
   call cursor(1, 3)
   call feedkeys("\<Esc>\<C-v>ljj", 'xt')
   call assert_equal(['cd', "\u00ab ", '34'],
-        \ getregion('v', '.', #{ type: "\<C-v>" }))
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
   call cursor(1, 4)
   call feedkeys("\<Esc>\<C-v>ljj", 'xt')
   call assert_equal(['de', "\U0001f1e7", '45'],
-        \ getregion('v', '.', #{ type: "\<C-v>" }))
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
   call cursor(1, 5)
   call feedkeys("\<Esc>\<C-v>jj", 'xt')
-  call assert_equal(['e', ' ', '5'], getregion('v', '.', #{ type: "\<C-v>" }))
+  call assert_equal(['e', ' ', '5'],
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>vj", 'xt')
   call assert_equal(['abcdefghijk«', "\U0001f1e6"],
-        \ getregion('v', '.', #{ type: 'v' }))
+        \ getregion(getpos('v'), getpos('.'), #{ type: 'v' }))
   " marks on multibyte chars
   set selection=exclusive
   call setpos("'a", [0, 1, 11, 0])
   call setpos("'b", [0, 2, 16, 0])
   call setpos("'c", [0, 2, 0, 0])
   call cursor(1, 1)
-  call assert_equal(['ghijk', '🇨«🇩'], getregion("'a", "'b", #{ type: "\<c-v>" }))
-  call assert_equal(['k«', '🇦«🇧«🇨'], getregion("'a", "'b", #{ type: "v" }))
-  call assert_equal(['k«'], getregion("'a", "'c", #{ type: "v" }))
+  call assert_equal(['ghijk', '🇨«🇩'],
+        \ getregion(getpos("'a"), getpos("'b"), #{ type: "\<c-v>" }))
+  call assert_equal(['k«', '🇦«🇧«🇨'],
+        \ getregion(getpos("'a"), getpos("'b"), #{ type: 'v' }))
+  call assert_equal(['k«'],
+        \ getregion(getpos("'a"), getpos("'c"), #{ type: 'v' }))
 
   bwipe!
 
@@ -1770,22 +1801,28 @@ func Test_visual_getregion()
   call setline(1, ["a\tc", "x\tz", '', ''])
   call cursor(1, 1)
   call feedkeys("\<Esc>v2l", 'xt')
-  call assert_equal(["a\t"], getregion('v', '.', #{ type: 'v' }))
+  call assert_equal(["a\t"],
+        \ getregion(getpos('v'), getpos('.'), #{ type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$G", 'xt')
-  call assert_equal(["a\tc", "x\tz", ''], getregion('v', '.', #{ type: 'v' }))
+  call assert_equal(["a\tc", "x\tz", ''],
+        \ getregion(getpos('v'), getpos('.'), #{ type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', #{ type: 'v' }))
+  call assert_equal(["a\tc", "x\tz"],
+        \ getregion(getpos('v'), getpos('.'), #{ type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$j", 'xt')
-  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', #{ type: "\<C-v>" }))
+  call assert_equal(["a\tc", "x\tz"],
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$G", 'xt')
-  call assert_equal(["a", "x", '', ''], getregion('v', '.', #{ type: "\<C-v>" }))
+  call assert_equal(["a", "x", '', ''],
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>wv2j", 'xt')
-  call assert_equal(["c", "x\tz"], getregion('v', '.', #{ type: 'v' }))
+  call assert_equal(["c", "x\tz"],
+        \ getregion(getpos('v'), getpos('.'), #{ type: 'v' }))
   set selection&
 
   " Exclusive selection 2
@@ -1794,37 +1831,41 @@ func Test_visual_getregion()
   call cursor(1, 1)
   call feedkeys("\<Esc>v2l", 'xt')
   call assert_equal(["a\t"],
-        \ getregion('v', '.', #{ exclusive: v:true }))
+        \ getregion(getpos('v'), getpos('.'), #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$G", 'xt')
   call assert_equal(["a\tc", "x\tz", ''],
-        \ getregion('v', '.', #{ exclusive: v:true }))
+        \ getregion(getpos('v'), getpos('.'), #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$j", 'xt')
   call assert_equal(["a\tc", "x\tz"],
-        \ getregion('v', '.', #{ exclusive: v:true }))
+        \ getregion(getpos('v'), getpos('.'), #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$j", 'xt')
   call assert_equal(["a\tc", "x\tz"],
-        \ getregion('v', '.', #{ exclusive: v:true, type: "\<C-v>" }))
+        \ getregion(getpos('v'), getpos('.'),
+        \           #{ exclusive: v:true, type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$G", 'xt')
   call assert_equal(["a", "x", '', ''],
-        \ getregion('v', '.', #{ exclusive: v:true, type: "\<C-v>" }))
+        \ getregion(getpos('v'), getpos('.'),
+        \           #{ exclusive: v:true, type: "\<C-v>" }))
   call cursor(1, 1)
   call feedkeys("\<Esc>wv2j", 'xt')
   call assert_equal(["c", "x\tz"],
-        \ getregion('v', '.', #{ exclusive: v:true }))
+        \ getregion(getpos('v'), getpos('.'), #{ exclusive: v:true }))
 
   " virtualedit
   set selection=exclusive
   set virtualedit=all
   call cursor(1, 1)
   call feedkeys("\<Esc>2lv2lj", 'xt')
-  call assert_equal(['      c', 'x   '], getregion('v', '.', #{ type: 'v' }))
+  call assert_equal(['      c', 'x   '],
+        \ getregion(getpos('v'), getpos('.'), #{ type: 'v' }))
   call cursor(1, 1)
   call feedkeys("\<Esc>2l\<C-v>2l2j", 'xt')
-  call assert_equal(['  ', '  ', '  '], getregion('v', '.', #{ type: "\<C-v>" }))
+  call assert_equal(['  ', '  ', '  '],
+        \ getregion(getpos('v'), getpos('.'), #{ type: "\<C-v>" }))
   set virtualedit&
   set selection&
 

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1794,15 +1794,15 @@ func Test_visual_getregion()
   call cursor(1, 1)
   call feedkeys("\<Esc>v2l", 'xt')
   call assert_equal(["a\t"],
-        \ getregion('v', '.', #{ exclusive: v:true, type: 'v' }))
+        \ getregion('v', '.', #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$G", 'xt')
   call assert_equal(["a\tc", "x\tz", ''],
-        \ getregion('v', '.', #{ exclusive: v:true, type: 'v' }))
+        \ getregion('v', '.', #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>v$j", 'xt')
   call assert_equal(["a\tc", "x\tz"],
-        \ getregion('v', '.', #{ exclusive: v:true, type: 'v' }))
+        \ getregion('v', '.', #{ exclusive: v:true }))
   call cursor(1, 1)
   call feedkeys("\<Esc>\<C-v>$j", 'xt')
   call assert_equal(["a\tc", "x\tz"],
@@ -1814,7 +1814,7 @@ func Test_visual_getregion()
   call cursor(1, 1)
   call feedkeys("\<Esc>wv2j", 'xt')
   call assert_equal(["c", "x\tz"],
-        \ getregion('v', '.', #{ exclusive: v:true, type: 'v' }))
+        \ getregion('v', '.', #{ exclusive: v:true }))
 
   " virtualedit
   set selection=exclusive

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1674,6 +1674,14 @@ func Test_visual_getregion()
   call assert_equal(['two'], "'a"->getregion("'a", 'V'))
   call assert_equal(['one', 'two'], "."->getregion("'a", "\<c-v>"))
 
+  " Using List
+  call cursor(1, 1)
+  call assert_equal(['one', 'two'], [0, 2, 3, 0]->getregion('.', 'v'))
+  call assert_equal(['one', 'two'], '.'->getregion([0, 2, 3, 0], 'v'))
+  call assert_equal(['one', 'two'], '.'->getregion([0, 2, 3, 0], 'V'))
+  call assert_equal(['two'], [0, 2, 3, 0]->getregion([0, 2, 3, 0], 'V'))
+  call assert_equal(['one', 'two'], '.'->getregion([0, 2, 3, 0], "\<c-v>"))
+
   " Multiline with line visual mode
   call cursor(1, 1)
   call feedkeys("\<ESC>Vjj", 'tx')

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1785,8 +1785,32 @@ func Test_visual_getregion()
   call cursor(1, 1)
   call feedkeys("\<Esc>wv2j", 'xt')
   call assert_equal(["c", "x\tz"], getregion('v', '.', 'v'))
+  set selection&
+
+  " Exclusive selection 2
+  new
+  call setline(1, ["a\tc", "x\tz", '', ''])
+  call cursor(1, 1)
+  call feedkeys("\<Esc>v2l", 'xt')
+  call assert_equal(["a\t"], getregion('v', '.', 'v', #{ exclusive: v:true }))
+  call cursor(1, 1)
+  call feedkeys("\<Esc>v$G", 'xt')
+  call assert_equal(["a\tc", "x\tz", ''], getregion('v', '.', 'v', #{ exclusive: v:true }))
+  call cursor(1, 1)
+  call feedkeys("\<Esc>v$j", 'xt')
+  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', 'v', #{ exclusive: v:true }))
+  call cursor(1, 1)
+  call feedkeys("\<Esc>\<C-v>$j", 'xt')
+  call assert_equal(["a\tc", "x\tz"], getregion('v', '.', "\<C-v>", #{ exclusive: v:true }))
+  call cursor(1, 1)
+  call feedkeys("\<Esc>\<C-v>$G", 'xt')
+  call assert_equal(["a", "x", '', ''], getregion('v', '.', "\<C-v>", #{ exclusive: v:true }))
+  call cursor(1, 1)
+  call feedkeys("\<Esc>wv2j", 'xt')
+  call assert_equal(["c", "x\tz"], getregion('v', '.', 'v', #{ exclusive: v:true }))
 
   " virtualedit
+  set selection=exclusive
   set virtualedit=all
   call cursor(1, 1)
   call feedkeys("\<Esc>2lv2lj", 'xt')

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1639,11 +1639,11 @@ func Test_visual_getregion()
   call cursor(1, 1)
   call feedkeys("\<ESC>vjl", 'tx')
   call assert_equal(['one', 'tw'],
-        \ 'v'->getpos()->getregion(getpos('.'), #{ type: 'v' }))
+        \ 'v'->getpos()->getregion(getpos('.')))
   call assert_equal(['one', 'tw'],
-        \ '.'->getpos()->getregion(getpos('v'), #{ type: 'v' }))
+        \ '.'->getpos()->getregion(getpos('v')))
   call assert_equal(['o'],
-        \ 'v'->getpos()->getregion(getpos('v'), #{ type: 'v' }))
+        \ 'v'->getpos()->getregion(getpos('v')))
   call assert_equal(['w'],
         \ '.'->getpos()->getregion(getpos('.'), #{ type: 'v' }))
   call assert_equal(['one', 'two'],

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1676,11 +1676,11 @@ func Test_visual_getregion()
 
   " Using List
   call cursor(1, 1)
-  call assert_equal(['one', 'two'], [0, 2, 3, 0]->getregion('.', 'v'))
-  call assert_equal(['one', 'two'], '.'->getregion([0, 2, 3, 0], 'v'))
-  call assert_equal(['one', 'two'], '.'->getregion([0, 2, 3, 0], 'V'))
-  call assert_equal(['two'], [0, 2, 3, 0]->getregion([0, 2, 3, 0], 'V'))
-  call assert_equal(['one', 'two'], '.'->getregion([0, 2, 3, 0], "\<c-v>"))
+  call assert_equal(['one', 'two'], [2, 3]->getregion('.', 'v'))
+  call assert_equal(['one', 'two'], '.'->getregion([2, 3], 'v'))
+  call assert_equal(['one', 'two'], '.'->getregion([2, 3], 'V'))
+  call assert_equal(['two'], [2, 3]->getregion([2, 3], 'V'))
+  call assert_equal(['one', 'two'], '.'->getregion([2, 3], "\<c-v>"))
 
   " Multiline with line visual mode
   call cursor(1, 1)


### PR DESCRIPTION
Continues of https://github.com/vim/vim/pull/13998

* Add opts arguments

* `{pos1}` and `{pos2}` can be list

~~I don't understand what is the correct argument check.~~

Note: I want to add `winid` support, but I gave up.  current routine depends on current buffer...