### PR TITLE
Fixed so `guiligatures` map isn't incorrectly cleared after being set from a .vimrc

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -456,7 +456,11 @@ gui_init_check(void)
     gui.prev_wrap = -1;
 
 #if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
-    CLEAR_FIELD(gui.ligatures_map);
+    // Note: gui_set_ligatures() might already have been called e.g. from .vimrc,
+    // and in that case we don't want to overwrite ligatures map that has already
+    // been correctly populated (as that would lead to a cleared ligatures maps).
+    if (*p_guiligatures == NUL)
+        CLEAR_FIELD(gui.ligatures_map);
 #endif
 
 #if defined(ALWAYS_USE_GUI) || defined(VIMDLL)

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -4530,7 +4530,7 @@ did_set_string_option(
 		|| varp == &p_guifontset	// 'guifontset'
 # endif
 		|| varp == &p_guifontwide	// 'guifontwide'
-# ifdef FEAT_GUI_GTK
+# if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
 		|| varp == &p_guiligatures	// 'guiligatures'
 # endif
 	    )


### PR DESCRIPTION
Related: #14084

Problem: I downloaded the latest Vim build and added `guiligatures` to my .vimrc and noticed that ligatures were still broken on Win32-version of `gvim`. If I manually set `guiligatures` after gVim has started the ligatures work fine. i.e. previous PR did indeed fix the ligatures in Win32 but it looks like ligatures map isn't being populated correctly when it's being set directly from the .vimrc.

Steps to reproduce/test:

1. Add `set guiligatures=!*+-/:<=>\|~` to your .vimrc
2. Start gVim
3. Notice broken looking ligatures
4. `:set guiligatures=!*+-/:<=>\|~` in the running Vim
5. See that ligatures look ok again

Solution: Looking at it in a debugger, the problem is that `gui.ligatures_map` is cleared in `gui_init_check()` after having already been correctly set in .vimrc sourcing through `did_set_guiligatures()` -> `gui_set_ligatures()`. It works in a running instance of Vim because `gui_set_ligatures()` overwrites the cleared values with the correct ones again. The fix is to not clear the map if we have already done `gui_set_ligatures()` which will be true if `p_guiligatures` isn't `NUL`. I'm not sure why it isn't an issue in GTK-version of gVim (or maybe it is?) but maybe the initialization order is different? This PR also fixes a missing redraw similar to that which happens to `set guifont`.