### PR TITLE
Del in cmdline mode doesn't delete composing chars

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4188,32 +4188,12 @@ mb_copy_char(char_u **fp, char_u **tp)
     int
 mb_off_next(char_u *base, char_u *p)
 {
-    int		i;
-    int		j;
+    int		head_off = (*mb_head_off)(base, p);
 
-    if (enc_utf8)
-    {
-	if (*p < 0x80)		// be quick for ASCII
-	    return 0;
+    if (head_off == 0)
+	return 0;
 
-	// Find the next character that isn't 10xx.xxxx
-	for (i = 0; (p[i] & 0xc0) == 0x80; ++i)
-	    ;
-	if (i > 0)
-	{
-	    // Check for illegal sequence.
-	    for (j = 0; p - j > base; ++j)
-		if ((p[-j] & 0xc0) != 0x80)
-		    break;
-	    if (utf8len_tab[p[-j]] != i + j)
-		return 0;
-	}
-	return i;
-    }
-
-    // Only need to check if we're on a trail byte, it doesn't matter if we
-    // want the offset to the next or current character.
-    return (*mb_head_off)(base, p);
+    return (*mb_ptr2len)(p - head_off) - head_off;
 }
 
 /*

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -917,6 +917,26 @@ func Test_cmdline_remove_char()
   let &encoding = encoding_save
 endfunc
 
+func Test_cmdline_del_utf8()
+  let @s = '⒌'
+  call feedkeys(":\"\<C-R>s,,\<C-B>\<Right>\<Del>\<CR>", 'tx')
+  call assert_equal('",,', @:)
+
+  let @s = 'a̳'
+  call feedkeys(":\"\<C-R>s,,\<C-B>\<Right>\<Del>\<CR>", 'tx')
+  call assert_equal('",,', @:)
+
+  let @s = 'β̳'
+  call feedkeys(":\"\<C-R>s,,\<C-B>\<Right>\<Del>\<CR>", 'tx')
+  call assert_equal('",,', @:)
+
+  if has('arabic')
+    let @s = 'لا'
+    call feedkeys(":\"\<C-R>s,,\<C-B>\<Right>\<Del>\<CR>", 'tx')
+    call assert_equal('",,', @:)
+  endif
+endfunc
+
 func Test_cmdline_keymap_ctrl_hat()
   CheckFeature keymap
 


### PR DESCRIPTION
Problem:  Del in cmdline mode doesn't delete composing chars.
Solution: Use mb_head_off() and mb_ptr2len().
