### PR TITLE
Update Debian runtime files

### DIFF
--- a/runtime/syntax/deb822sources.vim
+++ b/runtime/syntax/deb822sources.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Debian deb822-format source list file
 " Maintainer:   Debian Vim Maintainers
-" Last Change: 2023 May 25
+" Last Change: 2024 Jan 30
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/deb822sources.vim
 
 " Standard syntax initialization
@@ -12,19 +12,19 @@ endif
 " case insensitive
 syn case ignore
 
+" A bunch of useful keywords
+syn match deb822sourcesType               /\<\(deb-src\|deb\)\ */ contained
+syn match deb822sourcesFreeComponent      /\<\(main\|universe\)\> */ contained
+syn match deb822sourcesNonFreeComponent   /\<\(contrib\|non-free-firmware\|non-free\|restricted\|multiverse\)\> */ contained
+
 " Comments are matched from the first character of a line to the end-of-line
 syn region deb822sourcesComment start="^#" end="$"
-
-" A bunch of useful keywords
-syn match deb822sourcesType               /\(deb-src\|deb\)/
-syn match deb822sourcesFreeComponent      /\(main\|universe\)/
-syn match deb822sourcesNonFreeComponent   /\(contrib\|non-free-firmware\|non-free\|restricted\|multiverse\)/
 
 " Include Debian versioning information
 runtime! syntax/shared/debversions.vim
 
-exe 'syn match deb822sourcesSupportedSuites contained + *\([[:alnum:]_./]*\)\<\('. join(g:debSharedSupportedVersions, '\|'). '\)\>\([-[:alnum:]_./]*\)+'
-exe 'syn match deb822sourcesUnsupportedSuites contained + *\([[:alnum:]_./]*\)\<\('. join(g:debSharedUnsupportedVersions, '\|'). '\)\>\([-[:alnum:]_./]*\)+'
+exe 'syn match deb822sourcesSupportedSuites contained + *\([[:alnum:]_./]*\)\<\('. join(g:debSharedSupportedVersions, '\|'). '\)\>\([-[:alnum:]_./]*\) *+'
+exe 'syn match deb822sourcesUnsupportedSuites contained + *\([[:alnum:]_./]*\)\<\('. join(g:debSharedUnsupportedVersions, '\|'). '\)\>\([-[:alnum:]_./]*\) *+'
 
 unlet g:debSharedSupportedVersions
 unlet g:debSharedUnsupportedVersions
@@ -37,13 +37,13 @@ syn keyword deb822sourcesYesNo contained yes no
 " Match uri's
 syn match deb822sourcesUri            '\(https\?://\|ftp://\|[rs]sh://\|debtorrent://\|\(cdrom\|copy\|file\):\)[^' 	<>"]\+'
 
-syn match deb822sourcesEntryField            "^\%(Types\|URIs\|Suites\|Components\): *"
-syn match deb822sourcesOptionField           "^\%(Signed-By\|Check-Valid-Until\|Valid-Until-Min\|Valid-Until-Max\|Date-Max-Future\|InRelease-Path\): *"
-syn match deb822sourcesMultiValueOptionField "^\%(Architectures\|Languages\|Targets\)\%(-Add\|-Remove\)\?: *"
-
+syn region deb822sourcesStrictField matchgroup=deb822sourcesEntryField start="^\%(Types\|URIs\|Suites\|Components\): *" end="$" contains=deb822sourcesType,deb822sourcesUri,deb822sourcesSupportedSuites,deb822sourcesUnsupportedSuites,deb822sourcesFreeComponent,deb822sourcesNonFreeComponent oneline
+syn region deb822sourcesField matchgroup=deb822sourcesOptionField start="^\%(Signed-By\|Check-Valid-Until\|Valid-Until-Min\|Valid-Until-Max\|Date-Max-Future\|InRelease-Path\): *" end="$" oneline
+syn region deb822sourcesField matchgroup=deb822sourcesMultiValueOptionField start="^\%(Architectures\|Languages\|Targets\)\%(-Add\|-Remove\)\?: *" end="$" oneline
 syn region deb822sourcesStrictField matchgroup=deb822sourcesBooleanOptionField start="^\%(PDiffs\|Allow-Insecure\|Allow-Weak\|Allow-Downgrade-To-Insecure\|Trusted\|Check-Date\): *" end="$" contains=deb822sourcesYesNo oneline
 syn region deb822sourcesStrictField matchgroup=deb822sourcesForceBooleanOptionField start="^\%(By-Hash\): *" end="$" contains=deb822sourcesForce,deb822sourcesYesNo oneline
 
+hi def link deb822sourcesField                   Default
 hi def link deb822sourcesComment                 Comment
 hi def link deb822sourcesEntryField              Keyword
 hi def link deb822sourcesOptionField             Special

--- a/runtime/syntax/debsources.vim
+++ b/runtime/syntax/debsources.vim
@@ -2,7 +2,7 @@
 " Language:     Debian sources.list
 " Maintainer:   Debian Vim Maintainers
 " Former Maintainer: Matthijs Mohlmann <matthijs@cacholong.nl>
-" Last Change: 2023 Oct 11
+" Last Change: 2024 Jan 30
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/debsources.vim
 
 " Standard syntax initialization
@@ -14,9 +14,9 @@ endif
 syn case match
 
 " A bunch of useful keywords
-syn match debsourcesType               /\(deb-src\|deb\)/
-syn match debsourcesFreeComponent      /\(main\|universe\)/
-syn match debsourcesNonFreeComponent   /\(contrib\|non-free-firmware\|non-free\|restricted\|multiverse\)/
+syn match debsourcesType               /\<\(deb-src\|deb\)\>/ contained
+syn match debsourcesFreeComponent      /\<\(main\|universe\)\>/ contained
+syn match debsourcesNonFreeComponent   /\<\(contrib\|non-free-firmware\|non-free\|restricted\|multiverse\)\>/ contained
 
 " Match comments
 syn match debsourcesComment        /#.*/  contains=@Spell
@@ -33,7 +33,6 @@ unlet g:debSharedUnsupportedVersions
 " Match uri's
 syn match debsourcesUri            '\(https\?://\|ftp://\|[rs]sh://\|debtorrent://\|\(cdrom\|copy\|file\):\)[^' 	<>"]\+'
 syn region debsourcesLine start="^" end="$" contains=debsourcesType,debsourcesFreeComponent,debsourcesNonFreeComponent,debsourcesComment,debsourcesUri,debsourcesDistrKeyword,debsourcesUnsupportedDistrKeyword oneline
-
 
 " Associate our matches and regions with pretty colours
 hi def link debsourcesType                    Statement

--- a/runtime/syntax/shared/debversions.vim
+++ b/runtime/syntax/shared/debversions.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Debian version information
 " Maintainer:   Debian Vim Maintainers
-" Last Change: 2023 Nov 01
+" Last Change: 2024 Jan 25
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debversions.vim
 
 let s:cpo = &cpo
@@ -11,7 +11,7 @@ let g:debSharedSupportedVersions = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
       \ 'bullseye', 'bookworm', 'trixie', 'forky',
       \
-      \ 'trusty', 'xenial', 'bionic', 'focal', 'jammy', 'lunar', 'mantic', 'noble',
+      \ 'trusty', 'xenial', 'bionic', 'focal', 'jammy', 'mantic', 'noble',
       \ 'devel'
       \ ]
 let g:debSharedUnsupportedVersions = [
@@ -23,7 +23,7 @@ let g:debSharedUnsupportedVersions = [
       \ 'gutsy', 'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid',
       \ 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy',
       \ 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful', 'cosmic',
-      \ 'disco', 'eoan', 'hirsute', 'impish', 'kinetic', 'groovy'
+      \ 'disco', 'eoan', 'hirsute', 'impish', 'kinetic', 'lunar', 'groovy'
       \ ]
 
 let &cpo=s:cpo


### PR DESCRIPTION
- debsources: Add word boundaries around keyword match patterns
- debversions.vim: Move lunar to unsupported release

Co-authored-by: James Addison <jay@jp-hosting.net>