### PR TITLE
Put in Visual mode wrong if it replaces fold marker

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -7323,6 +7323,9 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     int		dir;
     int		flags = 0;
     int		keep_registers = FALSE;
+#ifdef FEAT_FOLDING
+    int		save_fen = curwin->w_p_fen;
+#endif
 
     if (cap->oap->op_type != OP_NOP)
     {
@@ -7388,6 +7391,12 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
 	    reg1 = get_register(regname, TRUE);
 	}
 
+#ifdef FEAT_FOLDING
+	// Temporarily disable folding, as deleting a fold marker may cause
+	// the cursor to be included in a fold.
+	curwin->w_p_fen = FALSE;
+#endif
+
 	// Now delete the selected text. Avoid messages here.
 	cap->cmdchar = 'd';
 	cap->nchar = NUL;
@@ -7435,10 +7444,14 @@ nv_put_opt(cmdarg_T *cap, int fix_indent)
     if (reg2 != NULL)
 	put_register(regname, reg2);
 
-    // What to reselect with "gv"?  Selecting the just put text seems to
-    // be the most useful, since the original text was removed.
     if (was_visual)
     {
+#ifdef FEAT_FOLDING
+	if (save_fen)
+	    curwin->w_p_fen = TRUE;
+#endif
+	// What to reselect with "gv"?  Selecting the just put text seems to
+	// be the most useful, since the original text was removed.
 	curbuf->b_visual.vi_start = curbuf->b_op_start;
 	curbuf->b_visual.vi_end = curbuf->b_op_end;
 	// need to adjust cursor position

--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -290,5 +290,33 @@ func Test_put_in_last_displayed_line()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_put_visual_replace_whole_fold()
+  new
+  let lines = repeat(['{{{1', 'foo', 'bar', ''], 2)
+  call setline(1, lines)
+  setlocal foldmethod=marker
+  call setreg('"', 'baz')
+  call setreg('1', '')
+  normal! Vp
+  call assert_equal("{{{1\nfoo\nbar\n\n", getreg('1'))
+  call assert_equal(['baz', '{{{1', 'foo', 'bar', ''], getline(1, '$'))
+
+  bwipe!
+endfunc
+
+func Test_put_visual_replace_fold_marker()
+  new
+  let lines = repeat(['{{{1', 'foo', 'bar', ''], 4)
+  call setline(1, lines)
+  setlocal foldmethod=marker
+  normal! Gkzo
+  call setreg('"', '{{{1')
+  call setreg('1', '')
+  normal! Vp
+  call assert_equal("{{{1\n", getreg('1'))
+  call assert_equal(lines, getline(1, '$'))
+
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Put in Visual mode wrong if it replaces fold marker.
Solution: Temporarily disable folding during put in Visual mode.

Fix #14097
