### PR TITLE
fix(echospace): don't subtract SHOWCMD_COLS if `showcmdloc` is statusline or tabline

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -3440,6 +3440,7 @@ did_set_showbreak(optset_T *args)
     char *
 did_set_showcmdloc(optset_T *args UNUSED)
 {
+    comp_col();
     return did_set_opt_strings(p_sloc, p_sloc_values, FALSE);
 }
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -4536,7 +4536,7 @@ comp_col(void)
 	if (!last_has_status)
 	    sc_col = ru_col;
     }
-    if (p_sc && STRCMP(p_sloc, "last") == 0)
+    if (p_sc && *p_sloc == 'l')
     {
 	sc_col += SHOWCMD_COLS;
 	if (!p_ru || last_has_status)	    // no need for separating space

--- a/src/screen.c
+++ b/src/screen.c
@@ -4536,7 +4536,7 @@ comp_col(void)
 	if (!last_has_status)
 	    sc_col = ru_col;
     }
-    if (p_sc)
+    if (p_sc && STRCMP(p_sloc,"last"))
     {
 	sc_col += SHOWCMD_COLS;
 	if (!p_ru || last_has_status)	    // no need for separating space

--- a/src/screen.c
+++ b/src/screen.c
@@ -4536,7 +4536,7 @@ comp_col(void)
 	if (!last_has_status)
 	    sc_col = ru_col;
     }
-    if (p_sc && STRCMP(p_sloc,"last"))
+    if (p_sc && STRCMP(p_sloc, "last"))
     {
 	sc_col += SHOWCMD_COLS;
 	if (!p_ru || last_has_status)	    // no need for separating space

--- a/src/screen.c
+++ b/src/screen.c
@@ -4536,7 +4536,7 @@ comp_col(void)
 	if (!last_has_status)
 	    sc_col = ru_col;
     }
-    if (p_sc && STRCMP(p_sloc, "last"))
+    if (p_sc && STRCMP(p_sloc, "last") == 0)
     {
 	sc_col += SHOWCMD_COLS;
 	if (!p_ru || last_has_status)	    // no need for separating space

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -162,8 +162,12 @@ func Test_echospace()
   call assert_equal(&columns - 12, v:echospace)
   set showcmd ruler
   call assert_equal(&columns - 29, v:echospace)
+  set showcmdloc=statusline
+  call assert_equal(&columns - 19, v:echospace)
+  set showcmdloc=tabline
+  call assert_equal(&columns - 19, v:echospace)
 
-  set ruler& showcmd&
+  set ruler& showcmd& showcmdloc&
 endfunc
 
 func Test_warning_scroll()


### PR DESCRIPTION
The command is not visible in the message area when `showcmdloc` is statusline making echospace smaller than what it can be.