### PR TITLE
Relax split restrictions when split-moving windows

### DIFF
--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -1001,8 +1001,8 @@ f_win_splitmove(typval_T *argvars, typval_T *rettv)
 	size = (int)dict_get_number(d, "size");
     }
 
-    // Check if we can split the target before we bother switching windows.
-    if (text_or_buf_locked() || check_split_disallowed(targetwin) == FAIL)
+    // Check if we can switch or move windows before we bother switching.
+    if (text_or_buf_locked() || check_split_disallowed(NULL) == FAIL)
 	return;
 
     if (curwin != targetwin)

--- a/src/window.c
+++ b/src/window.c
@@ -865,8 +865,8 @@ cmd_with_count(
 }
 
 /*
- * If "split_disallowed" is set for "wp", give an error and return FAIL.
- * Otherwise return OK.
+ * If "split_disallowed" is set, or if "wp" is not NULL and its buffer is
+ * closing, give an error and return FAIL. Otherwise return OK.
  */
     int
 check_split_disallowed(win_T *wp)
@@ -876,7 +876,7 @@ check_split_disallowed(win_T *wp)
 	emsg(_(e_cant_split_window_while_closing_another));
 	return FAIL;
     }
-    if (wp->w_buffer->b_locked_split)
+    if (wp != NULL && wp->w_buffer->b_locked_split)
     {
 	emsg(_(e_cannot_split_window_when_closing_buffer));
 	return FAIL;
@@ -1932,7 +1932,7 @@ win_splitmove(win_T *wp, int size, int flags)
 
     if (ONE_WINDOW)
 	return OK;	// nothing to do
-    if (check_split_disallowed(wp) == FAIL)
+    if (check_split_disallowed(NULL) == FAIL)
 	return FAIL;
 
     // Remove the window and frame from the tree of frames.  Don't flatten any


### PR DESCRIPTION
Following up on [my comment here](https://github.com/vim/vim/pull/14042#discussion_r1493919216), it seems unnecessary to check `b_locked_split` when "split-moving" windows. It looks like the flag exists to stop new views into a buffer being created while it's closing (which can result in windows into a freed buffer remaining), but split-moving doesn't result in any new views into a buffer, unlike regular splitting.

The doc comment for `b_locked_split` also seems to support this:
https://github.com/vim/vim/blob/0c98a71236e6eca983fed5d903d07bd53190d16b/src/structs.h#L3002-L3003

So, continue to check `split_disallowed` when split-moving (it looks possibly relevant), but add a test to check that split-moving is OK when `b_locked_split` is set (I've made sure it crashes Vim if the `b_locked_split` check is reverted for regular splitting).

---

**Edit:** hmm, actually the crash I based the test on has the same backtrace as #13839, which wasn't what I was going for :laughing:.

I was hoping to base it on `Test_autocmd_normal_mess`, which is the test introduced with `b_locked_split`, but even that test doesn't seem to crash anymore when reverting the `b_locked_split` check for regular splitting...

**Edit 2:** actually, it seems to be a different issue (unrelated to 9.1.0143 or the issue it fixes); it seems `close_buffer` and its callers don't consider that autocmds can make another window view a buffer that's being wiped, without causing `b->b_nwindows > 1`.

The following crashes Vim with a heap UAF:

```vim
let w = win_getid()
sp
new
let b = bufnr()
au BufWipeout * ++once cal win_gotoid(w) | exe b 'b' | winc p
bw!
```

I'll try to address this at some point, unless someone beats me to it. :innocent: 