### PR TITLE
v:echospace wrong after setting invalid value to 'showcmdloc'

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -3440,8 +3440,12 @@ did_set_showbreak(optset_T *args)
     char *
 did_set_showcmdloc(optset_T *args UNUSED)
 {
-    comp_col();
-    return did_set_opt_strings(p_sloc, p_sloc_values, FALSE);
+    char	*errmsg = did_set_opt_strings(p_sloc, p_sloc_values, FALSE);
+
+    if (errmsg == NULL)
+	comp_col();
+
+    return errmsg;
 }
 
     int

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -166,6 +166,12 @@ func Test_echospace()
   call assert_equal(&columns - 19, v:echospace)
   set showcmdloc=tabline
   call assert_equal(&columns - 19, v:echospace)
+  call assert_fails('set showcmdloc=leap', 'E474:')
+  call assert_equal(&columns - 19, v:echospace)
+  set showcmdloc=last
+  call assert_equal(&columns - 29, v:echospace)
+  call assert_fails('set showcmdloc=jump', 'E474:')
+  call assert_equal(&columns - 29, v:echospace)
 
   set ruler& showcmd& showcmdloc&
 endfunc


### PR DESCRIPTION
Problem:  v:echospace wrong after setting invalid value to 'showcmdloc'.
Solution: Only call comp_col() if value is valid.