### PR TITLE
Added missing keywords to mojo.vim file.

### DIFF
--- a/runtime/syntax/mojo.vim
+++ b/runtime/syntax/mojo.vim
@@ -85,13 +85,14 @@ syn keyword mojoStatement	False None True
 syn keyword mojoStatement	as assert break continue del global
 syn keyword mojoStatement	lambda nonlocal pass return with yield
 syn keyword mojoStatement	class def nextgroup=mojoFunction skipwhite
-syn keyword mojoStatement	struct fn nextgroup=mojoFunction skipwhite
+syn keyword mojoStatement	struct fn trait nextgroup=mojoFunction skipwhite
 syn keyword mojoStatement	alias var let
+syn keyword mojoStatement	inout owned borrowed 
 syn keyword mojoConditional	elif else if
 syn keyword mojoRepeat		for while
 syn keyword mojoOperator	and in is not or
 syn keyword mojoException	except finally raise try
-syn keyword mojoInclude		from import
+syn keyword mojoInclude		from import self
 syn keyword mojoAsync		async await
 
 " Soft keywords


### PR DESCRIPTION
missing keywords added: trait, inout, owned and borrowed