### PR TITLE
runtime(r,rhelp,rmd,rnoweb,rrst): Update ftplugin, browsefilter labels

### DIFF
--- a/runtime/ftplugin/r.vim
+++ b/runtime/ftplugin/r.vim
@@ -1,11 +1,9 @@
 " Vim filetype plugin file
-" Language: R
-" Maintainer: This runtime file is looking for a new maintainer.
-" Former Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
-" Former Repository: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	2022 Apr 24  09:14AM
-"		2024 Jan 14 by Vim Project (browsefilter)
-"		2024 Feb 19 by Vim Project (announce adoption)
+" Language:		R
+" Maintainer:		This runtime file is looking for a new maintainer.
+" Former Maintainer:	Jakson Alves de Aquino <jalvesaq@gmail.com>
+" Former Repository:	https://github.com/jalvesaq/R-Vim-runtime
+" Last Change:		2024 Feb 28 by Vim Project
 
 " Only do this when not yet done for this buffer
 if exists("b:did_ftplugin")
@@ -25,7 +23,7 @@ setlocal comments=:#',:###,:##,:#
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "R Source Files (*.R)\t*.R\n" .
-        \ "Files that include R (*.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+        \ "Files that include R (*.Rnw, *.Rd, *.Rmd, *.Rrst, *.qmd)\t*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
   if has("win32")
     let b:browsefilter .= "All Files (*.*)\t*\n"
   else

--- a/runtime/ftplugin/rhelp.vim
+++ b/runtime/ftplugin/rhelp.vim
@@ -1,9 +1,9 @@
 " Vim filetype plugin file
-" Language: R help file
-" Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
-" Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	2022 Apr 24  09:12AM
-"		2024 Jan 14 by Vim Project (browsefilter)
+" Language:		R help file
+" Maintainer:		This runtime file is looking for a new maintainer.
+" Former Maintainer:	Jakson Alves de Aquino <jalvesaq@gmail.com>
+" Former Repository:	https://github.com/jalvesaq/R-Vim-runtime
+" Last Change:		2024 Feb 28 by Vim Project
 
 " Only do this when not yet done for this buffer
 if exists("b:did_ftplugin")
@@ -19,7 +19,7 @@ set cpo&vim
 setlocal iskeyword=@,48-57,_,.
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+  let b:browsefilter = "R Source Files (*.R, *.Rnw, *.Rd, *.Rmd, *.Rrst, *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
   if has("win32")
     let b:browsefilter .= "All Files (*.*)\t*\n"
   else

--- a/runtime/ftplugin/rmd.vim
+++ b/runtime/ftplugin/rmd.vim
@@ -1,9 +1,9 @@
 " Vim filetype plugin file
-" Language: R Markdown file
-" Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
-" Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	2023 May 29  06:31AM
-"		2024 Jan 14 by Vim Project (browsefilter)
+" Language:		R Markdown file
+" Maintainer:		This runtime file is looking for a new maintainer.
+" Former Maintainer:	Jakson Alves de Aquino <jalvesaq@gmail.com>
+" Former Repository:	https://github.com/jalvesaq/R-Vim-runtime
+" Last Change:		2024 Feb 28 by Vim Project
 " Original work by Alex Zvoleff (adjusted from R help for rmd by Michel Kuhlmann)
 
 " Only do this when not yet done for this buffer
@@ -65,7 +65,7 @@ runtime ftplugin/pandoc.vim
 let b:did_ftplugin = 1
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+  let b:browsefilter = "R Source Files (*.R, *.Rnw, *.Rd, *.Rmd, *.Rrst, *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
   if has("win32")
     let b:browsefilter .= "All Files (*.*)\t*\n"
   else

--- a/runtime/ftplugin/rnoweb.vim
+++ b/runtime/ftplugin/rnoweb.vim
@@ -1,11 +1,9 @@
 " Vim filetype plugin file
-" Language: Rnoweb
-" Maintainer: This runtime file is looking for a new maintainer.
-" Former Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
-" Former Repository: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	2023 Feb 27  07:16PM
-"		2024 Jan 14 by Vim Project (browsefilter)
-"		2024 Feb 19 by Vim Project (announce adoption)
+" Language:		Rnoweb
+" Maintainer:		This runtime file is looking for a new maintainer.
+" Former Maintainer:	Jakson Alves de Aquino <jalvesaq@gmail.com>
+" Former Repository:	https://github.com/jalvesaq/R-Vim-runtime
+" Last Change:		2024 Feb 28 by Vim Project
 
 " Only do this when not yet done for this buffer
 if exists("b:did_ftplugin")
@@ -28,7 +26,7 @@ setlocal suffixesadd=.bib,.tex
 setlocal comments=b:%,b:#,b:##,b:###,b:#'
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+  let b:browsefilter = "R Source Files (*.R, *.Rnw, *.Rd, *.Rmd, *.Rrst, *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
   if has("win32")
     let b:browsefilter .= "All Files (*.*)\t*\n"
   else

--- a/runtime/ftplugin/rrst.vim
+++ b/runtime/ftplugin/rrst.vim
@@ -1,11 +1,9 @@
 " Vim filetype plugin file
-" Language: reStructuredText documentation format with R code
-" Maintainer: This runtime file is looking for a new maintainer.
-" Former Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
-" Former Repository: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	2023 Feb 27  07:16PM
-"		2024 Jan 14 by Vim Project (browsefilter)
-"		2024 Feb 19 by Vim Project (announce adoption)
+" Language:		reStructuredText documentation format with R code
+" Maintainer:		This runtime file is looking for a new maintainer.
+" Former Maintainer:	Jakson Alves de Aquino <jalvesaq@gmail.com>
+" Former Repository:	https://github.com/jalvesaq/R-Vim-runtime
+" Last Change:		2024 Feb 28 by Vim Project
 " Original work by Alex Zvoleff
 
 " Only do this when not yet done for this buffer
@@ -41,7 +39,7 @@ if !exists("g:rrst_dynamic_comments") || (exists("g:rrst_dynamic_comments") && g
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+  let b:browsefilter = "R Source Files (*.R, *.Rnw, *.Rd, *.Rmd, *.Rrst, *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
   if has("win32")
     let b:browsefilter .= "All Files (*.*)\t*\n"
   else


### PR DESCRIPTION
Update browsefilter labels to use the standard format:
  `File Description (*.ext1, *.ext2, *.ext3)`

@chrisbra, I removed the list of changes attributed to "Vim Project".  They were primarily intended to notify temporarily absent maintainers and probably don't make much sense for unmaintained files.  I'll re-add them if you prefer.
