### PR TITLE
ci.yml: downgrade codecov-action@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,7 +683,7 @@ jobs:
       - name: Codecov
         timeout-minutes: 20
         if: matrix.coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           directory: src
           flags: windows,${{ matrix.toolchain }}-${{ matrix.arch }}-${{ matrix.features }}


### PR DESCRIPTION
added missing packages for codecov ci
```
warning - 2024-03-02 15:18:43,549 -- coverage.py is not installed or can't be found.
info - 2024-03-02 15:18:43,652 -- Found 0 coverage files to upload
Error: No coverage reports found. Please make sure you're generating reports successfully.
Warning: Codecov:
                      Failed to properly upload report: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```