### PR TITLE
Implement support for using builtin functions with vim9 objects

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2265,8 +2265,8 @@ empty({expr})						*empty()*
 		- A |Job| is empty when it failed to start.
 		- A |Channel| is empty when it is closed.
 		- A |Blob| is empty when its length is zero.
-		- An |Object| is empty, when the |__empty()| dunder method in
-		  the object class (if present) returns true.
+		- An |Object| is empty, when the |empty()| builtin method in
+		  the object (if present) returns true.
 
 		For a long |List| this is much faster than comparing the
 		length with zero.
@@ -5478,9 +5478,9 @@ len({expr})	The result is a Number, which is the length of the argument.
 		When {expr} is a |Blob| the number of bytes is returned.
 		When {expr} is a |Dictionary| the number of entries in the
 		|Dictionary| is returned.
-		When {expr} is an |Object|, invokes the |__len()| dunder
-		method in the object class (if present) to get the length.
-		Otherwise an error is given and returns zero.
+		When {expr} is an |Object|, invokes the |len()| method in the
+		object (if present) to get the length.  Otherwise an error is
+		given and returns zero.
 
 		Can also be used as a |method|: >
 			mylist->len()
@@ -9591,9 +9591,9 @@ string({expr})	Return {expr} converted to a String.  If {expr} is a Number,
 		replaced by "[...]" or "{...}".  Using eval() on the result
 		will then fail.
 
-		For an object, invokes the |__string()| dunder method to get a
-		textual representation of the object.  If the method is not
-		present, then the default representation is used.
+		For an object, invokes the |string()| method to get a textual
+		representation of the object.  If the method is not present,
+		then the default representation is used.
 
 		Can also be used as a |method|: >
 			mylist->string()

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5479,8 +5479,8 @@ len({expr})	The result is a Number, which is the length of the argument.
 		When {expr} is a |Dictionary| the number of entries in the
 		|Dictionary| is returned.
 		When {expr} is an |Object|, invokes the |len()| method in the
-		object (if present) to get the length.  Otherwise an error is
-		given and returns zero.
+		object (if present) to get the length.  Otherwise returns
+		zero.
 
 		Can also be used as a |method|: >
 			mylist->len()

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2265,6 +2265,8 @@ empty({expr})						*empty()*
 		- A |Job| is empty when it failed to start.
 		- A |Channel| is empty when it is closed.
 		- A |Blob| is empty when its length is zero.
+		- An |Object| is empty, when the |__empty()| dunder method in
+		  the object class (if present) returns true.
 
 		For a long |List| this is much faster than comparing the
 		length with zero.
@@ -5476,6 +5478,8 @@ len({expr})	The result is a Number, which is the length of the argument.
 		When {expr} is a |Blob| the number of bytes is returned.
 		When {expr} is a |Dictionary| the number of entries in the
 		|Dictionary| is returned.
+		When {expr} is an |Object|, invokes the |__len()| dunder
+		method in the object class (if present) to get the length.
 		Otherwise an error is given and returns zero.
 
 		Can also be used as a |method|: >
@@ -9586,6 +9590,10 @@ string({expr})	Return {expr} converted to a String.  If {expr} is a Number,
 		When a |List| or |Dictionary| has a recursive reference it is
 		replaced by "[...]" or "{...}".  Using eval() on the result
 		will then fail.
+
+		For an object, invokes the |__string()| dunder method to get a
+		textual representation of the object.  If the method is not
+		present, then the default representation is used.
 
 		Can also be used as a |method|: >
 			mylist->string()

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5889,6 +5889,9 @@ ZZ	editing.txt	/*ZZ*
 ]}	motion.txt	/*]}*
 ^	motion.txt	/*^*
 _	motion.txt	/*_*
+__empty()	vim9class.txt	/*__empty()*
+__len()	vim9class.txt	/*__len()*
+__string()	vim9class.txt	/*__string()*
 _exrc	starting.txt	/*_exrc*
 _gvimrc	gui.txt	/*_gvimrc*
 _vimrc	starting.txt	/*_vimrc*
@@ -6837,6 +6840,7 @@ drag-status-line	term.txt	/*drag-status-line*
 drop_file	gui.txt	/*drop_file*
 dtd.vim	syntax.txt	/*dtd.vim*
 dtd2vim	insert.txt	/*dtd2vim*
+dunder-methods	vim9class.txt	/*dunder-methods*
 dying-variable	eval.txt	/*dying-variable*
 e	motion.txt	/*e*
 easy	starting.txt	/*easy*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4517,6 +4517,8 @@ E1409	vim9class.txt	/*E1409*
 E141	message.txt	/*E141*
 E1410	vim9class.txt	/*E1410*
 E1411	vim9class.txt	/*E1411*
+E1412	vim9class.txt	/*E1412*
+E1413	vim9class.txt	/*E1413*
 E142	message.txt	/*E142*
 E143	autocmd.txt	/*E143*
 E144	various.txt	/*E144*
@@ -5889,9 +5891,6 @@ ZZ	editing.txt	/*ZZ*
 ]}	motion.txt	/*]}*
 ^	motion.txt	/*^*
 _	motion.txt	/*_*
-__empty()	vim9class.txt	/*__empty()*
-__len()	vim9class.txt	/*__len()*
-__string()	vim9class.txt	/*__string()*
 _exrc	starting.txt	/*_exrc*
 _gvimrc	gui.txt	/*_gvimrc*
 _vimrc	starting.txt	/*_vimrc*
@@ -6184,6 +6183,7 @@ bugs	intro.txt	/*bugs*
 builtin-function-details	builtin.txt	/*builtin-function-details*
 builtin-function-list	builtin.txt	/*builtin-function-list*
 builtin-functions	builtin.txt	/*builtin-functions*
+builtin-object-methods	vim9class.txt	/*builtin-object-methods*
 builtin-terms	term.txt	/*builtin-terms*
 builtin-tools	gui.txt	/*builtin-tools*
 builtin.txt	builtin.txt	/*builtin.txt*
@@ -6840,7 +6840,6 @@ drag-status-line	term.txt	/*drag-status-line*
 drop_file	gui.txt	/*drop_file*
 dtd.vim	syntax.txt	/*dtd.vim*
 dtd2vim	insert.txt	/*dtd2vim*
-dunder-methods	vim9class.txt	/*dunder-methods*
 dying-variable	eval.txt	/*dying-variable*
 e	motion.txt	/*e*
 easy	starting.txt	/*easy*
@@ -9155,9 +9154,12 @@ o_object-select	motion.txt	/*o_object-select*
 o_v	motion.txt	/*o_v*
 object	vim9class.txt	/*object*
 object-const-variable	vim9class.txt	/*object-const-variable*
+object-empty()	vim9class.txt	/*object-empty()*
 object-final-variable	vim9class.txt	/*object-final-variable*
+object-len()	vim9class.txt	/*object-len()*
 object-motions	motion.txt	/*object-motions*
 object-select	motion.txt	/*object-select*
+object-string()	vim9class.txt	/*object-string()*
 objects	index.txt	/*objects*
 obtaining-exted	netbeans.txt	/*obtaining-exted*
 ocaml.vim	syntax.txt	/*ocaml.vim*

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -132,7 +132,6 @@ Further Vim9 improvements:
     Possibly issue #11981 can be fixed at the same time (has two examples).
   - Forward declaration of a class?  E.g. for Clone() function.
 	Email lifepillar 2023 Mar 26
-  - object empty(), len() - can class define a method to be used for them?
   - When "Meta" is a class, is "const MetaAlias = Meta" allowed?  It should
     either work or given an error. Possibly give an error now and implement it
     later (using a typedef).  #12006

--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -277,36 +277,6 @@ When invoking an object method, the method name should be preceded by the
 object variable name.  An object method cannot be invoked using the class
 name.
 
-Dunder methods ~
-							*dunder-methods*
-The double underscore (dunder) methods are special methods which are invoked
-by internal Vim functions and are not directly used.  The name of these
-methods start with the prefix "__".
-
-							*E1393* *E1394*
-The following dunder methods are supported:
-
-							*__empty()*
-    __empty()	Invoked by the |empty()| function to check whether an object
-		is empty.  If this method is missing, then true is returned.
-		This method should not accept any arguments and must return
-		a boolean.
-							*__len()*
-    __len()	Invoked by the |len()| function to return the length of an
-		object.  If this method is missing in the class, then an error
-		is given and zero is returned.  This method should not accept
-		any arguments and must return a number.
-							*__string()*
-    __string()	Invoked by the |string()| function to get a textual
-		representation of an object.  Also used by the |:echo| command
-		for an object.  If this method is missing in the class, then a
-		built-in default textual representation is used.  This method
-		should not accept any arguments and must return a string.
-
-						*E1395* *E1396* *E1397* *E1398*
-Dunder methods cannot be directly invoked.  Dunder class methods are not
-supported.  Dunder methods cannot be defined in an interface.
-
 ==============================================================================
 
 3.  Class Variables and Methods			*Vim9-class-member*
@@ -740,6 +710,32 @@ The initialization isn't needed, the list is empty by default.
 							*E1330*
 Some types cannot be used, such as "void", "null" and "v:none".
 
+Builtin Object Methods ~
+                                                       *builtin-object-methods*
+Some of the builtin functions like |empty()|, |len()| and |string()| can be
+used with an object.  An object can implement a method with the same name as
+these builtin functions to return an object-specific value.
+
+                                                       *E1412*
+The following builtin methods are supported:
+                                                       *object-empty()*
+    empty()  Invoked by the |empty()| function to check whether an object is
+	     empty.  If this method is missing, then true is returned.  This
+	     method should not accept any arguments and must return a boolean.
+                                                       *object-len()*
+    len()    Invoked by the |len()| function to return the length of an
+	     object.  If this method is missing in the class, then an error is
+	     given and zero is returned.  This method should not accept any
+	     arguments and must return a number.
+                                                       *object-string()*
+    string() Invoked by the |string()| function to get a textual
+	     representation of an object.  Also used by the |:echo| command
+	     for an object.  If this method is missing in the class, then a
+	     built-in default textual representation is used.  This method
+	     should not accept any arguments and must return a string.
+
+                                                       *E1413*
+A class method cannot be used as a builtin method.
 
 Defining an interface ~
 					*Interface* *:interface* *:endinterface*

--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -277,6 +277,36 @@ When invoking an object method, the method name should be preceded by the
 object variable name.  An object method cannot be invoked using the class
 name.
 
+Dunder methods ~
+							*dunder-methods*
+The double underscore (dunder) methods are special methods which are invoked
+by internal Vim functions and are not directly used.  The name of these
+methods start with the prefix "__".
+
+							*E1393* *E1394*
+The following dunder methods are supported:
+
+							*__empty()*
+    __empty()	Invoked by the |empty()| function to check whether an object
+		is empty.  If this method is missing, then true is returned.
+		This method should not accept any arguments and must return
+		a boolean.
+							*__len()*
+    __len()	Invoked by the |len()| function to return the length of an
+		object.  If this method is missing in the class, then an error
+		is given and zero is returned.  This method should not accept
+		any arguments and must return a number.
+							*__string()*
+    __string()	Invoked by the |string()| function to get a textual
+		representation of an object.  Also used by the |:echo| command
+		for an object.  If this method is missing in the class, then a
+		built-in default textual representation is used.  This method
+		should not accept any arguments and must return a string.
+
+						*E1395* *E1396* *E1397* *E1398*
+Dunder methods cannot be directly invoked.  Dunder class methods are not
+supported.  Dunder methods cannot be defined in an interface.
+
 ==============================================================================
 
 3.  Class Variables and Methods			*Vim9-class-member*

--- a/src/errors.h
+++ b/src/errors.h
@@ -3579,8 +3579,20 @@ EXTERN char e_const_variable_not_supported_in_interface[]
 	INIT(= N_("E1410: Const variable not supported in an interface"));
 EXTERN char e_missing_dot_after_object_str[]
 	INIT(= N_("E1411: Missing dot after object \"%s\""));
+EXTERN char e_dunder_method_str_not_supported[]
+	INIT(= N_("E1412: Dunder method \"%s\" not supported"));
+EXTERN char e_dunder_method_str_incorrect_signature[]
+	INIT(= N_("E1413: Dunder method \"%s\" signature not correct"));
+EXTERN char e_dunder_method_cannot_be_used_directly[]
+	INIT(= N_("E1414: Dunder method \"%s\" cannot be directly used"));
+EXTERN char e_cannot_access_dunder_method_str[]
+	INIT(= N_("E1415: Cannot access dunder method: %s"));
+EXTERN char e_dunder_method_not_supported_in_interface[]
+	INIT(= N_("E1416: Dunder method not supported in interface"));
+EXTERN char e_dunder_class_method_not_supported[]
+	INIT(= N_("E1417: Dunder class method not supported"));
 #endif
-// E1412 - E1499 unused (reserved for Vim9 class support)
+// E1418 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/errors.h
+++ b/src/errors.h
@@ -3579,20 +3579,12 @@ EXTERN char e_const_variable_not_supported_in_interface[]
 	INIT(= N_("E1410: Const variable not supported in an interface"));
 EXTERN char e_missing_dot_after_object_str[]
 	INIT(= N_("E1411: Missing dot after object \"%s\""));
-EXTERN char e_dunder_method_str_not_supported[]
-	INIT(= N_("E1412: Dunder method \"%s\" not supported"));
-EXTERN char e_dunder_method_str_incorrect_signature[]
-	INIT(= N_("E1413: Dunder method \"%s\" signature not correct"));
-EXTERN char e_dunder_method_cannot_be_used_directly[]
-	INIT(= N_("E1414: Dunder method \"%s\" cannot be directly used"));
-EXTERN char e_cannot_access_dunder_method_str[]
-	INIT(= N_("E1415: Cannot access dunder method: %s"));
-EXTERN char e_dunder_method_not_supported_in_interface[]
-	INIT(= N_("E1416: Dunder method not supported in interface"));
-EXTERN char e_dunder_class_method_not_supported[]
-	INIT(= N_("E1417: Dunder class method not supported"));
+EXTERN char e_builtin_object_method_str_not_supported[]
+	INIT(= N_("E1412: Builtin object method \"%s\" not supported"));
+EXTERN char e_builtin_class_method_not_supported[]
+	INIT(= N_("E1413: Builtin class method not supported"));
 #endif
-// E1418 - E1499 unused (reserved for Vim9 class support)
+// E1415 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/eval.c
+++ b/src/eval.c
@@ -6318,36 +6318,9 @@ echo_string_core(
 	    break;
 
 	case VAR_OBJECT:
-	    {
-		garray_T ga;
-		ga_init2(&ga, 1, 50);
-		ga_concat(&ga, (char_u *)"object of ");
-		object_T *obj = tv->vval.v_object;
-		class_T *cl = obj == NULL ? NULL : obj->obj_class;
-		ga_concat(&ga, cl == NULL ? (char_u *)"[unknown]"
-							     : cl->class_name);
-		if (cl != NULL)
-		{
-		    ga_concat(&ga, (char_u *)" {");
-		    for (int i = 0; i < cl->class_obj_member_count; ++i)
-		    {
-			if (i > 0)
-			    ga_concat(&ga, (char_u *)", ");
-			ocmember_T *m = &cl->class_obj_members[i];
-			ga_concat(&ga, m->ocm_name);
-			ga_concat(&ga, (char_u *)": ");
-			char_u *tf = NULL;
-			ga_concat(&ga, echo_string_core(
-					       (typval_T *)(obj + 1) + i,
-					       &tf, numbuf, copyID, echo_style,
-					       restore_copyID, composite_val));
-			vim_free(tf);
-		    }
-		    ga_concat(&ga, (char_u *)"}");
-		}
-
-		*tofree = r = ga.ga_data;
-	    }
+	    *tofree = r = object_string(tv->vval.v_object, numbuf, copyID,
+					echo_style, restore_copyID,
+					composite_val);
 	    break;
 
 	case VAR_FLOAT:

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -986,6 +986,7 @@ arg_len1(type_T *type, type_T *decl_type UNUSED, argcontext_T *context)
 	    || type->tt_type == VAR_BLOB
 	    || type->tt_type == VAR_LIST
 	    || type->tt_type == VAR_DICT
+	    || type->tt_type == VAR_OBJECT
 	    || type_any_or_unknown(type))
 	return OK;
 
@@ -3981,7 +3982,7 @@ f_empty(typval_T *argvars, typval_T *rettv)
 	    n = argvars[0].vval.v_class != NULL;
 	    break;
 	case VAR_OBJECT:
-	    n = argvars[0].vval.v_object != NULL;
+	    n = object_empty(argvars[0].vval.v_object);
 	    break;
 
 	case VAR_BLOB:
@@ -7831,6 +7832,9 @@ f_len(typval_T *argvars, typval_T *rettv)
 	case VAR_DICT:
 	    rettv->vval.v_number = dict_len(argvars[0].vval.v_dict);
 	    break;
+	case VAR_OBJECT:
+	    rettv->vval.v_number = object_len(argvars[0].vval.v_object);
+	    break;
 	case VAR_UNKNOWN:
 	case VAR_ANY:
 	case VAR_VOID:
@@ -7843,7 +7847,6 @@ f_len(typval_T *argvars, typval_T *rettv)
 	case VAR_CHANNEL:
 	case VAR_INSTR:
 	case VAR_CLASS:
-	case VAR_OBJECT:
 	case VAR_TYPEALIAS:
 	    emsg(_(e_invalid_type_for_len));
 	    break;

--- a/src/proto/vim9class.pro
+++ b/src/proto/vim9class.pro
@@ -34,6 +34,10 @@ void member_not_found_msg(class_T *cl, vartype_T v_type, char_u *name, size_t le
 void defcompile_class(class_T *cl);
 void defcompile_classes_in_script(void);
 int is_class_name(char_u *name, typval_T *rettv);
+void protected_method_access_errmsg(char_u *method_name);
+int object_empty(object_T *obj);
+int object_len(object_T *obj);
+char_u *object_string(object_T *obj, char_u *numbuf, int copyID, int echo_style, int restore_copyID, int composite_val);
 int class_instance_of(class_T *cl, class_T *other_cl);
 void f_instanceof(typval_T *argvars, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/proto/vim9class.pro
+++ b/src/proto/vim9class.pro
@@ -1,5 +1,6 @@
 /* vim9class.c */
 int object_index_from_itf_index(class_T *itf, int is_method, int idx, class_T *cl);
+int is_valid_builtin_obj_methodname(char_u *funcname);
 void ex_class(exarg_T *eap);
 type_T *oc_member_type(class_T *cl, int is_object, char_u *name, char_u *name_end, int *member_idx);
 type_T *oc_member_type_by_idx(class_T *cl, int is_object, int member_idx);

--- a/src/proto/vim9class.pro
+++ b/src/proto/vim9class.pro
@@ -1,6 +1,7 @@
 /* vim9class.c */
 int object_index_from_itf_index(class_T *itf, int is_method, int idx, class_T *cl);
 int is_valid_builtin_obj_methodname(char_u *funcname);
+ufunc_T *class_get_builtin_method(class_T *cl, class_builtin_T builtin_method, int *method_idx);
 void ex_class(exarg_T *eap);
 type_T *oc_member_type(class_T *cl, int is_object, char_u *name, char_u *name_end, int *member_idx);
 type_T *oc_member_type_by_idx(class_T *cl, int is_object, int member_idx);

--- a/src/structs.h
+++ b/src/structs.h
@@ -1529,6 +1529,17 @@ typedef enum {
 #define OCMFLAG_CONST		0x04	// "const" object/class member
 
 /*
+ * Object methods called by builtin functions (e.g. string(), empty(), etc.)
+ */
+typedef enum {
+    CLASS_BUILTIN_INVALID,
+    CLASS_BUILTIN_STRING,
+    CLASS_BUILTIN_EMPTY,
+    CLASS_BUILTIN_LEN,
+    CLASS_BUILTIN_MAX
+} class_builtin_T;
+
+/*
  * Entry for an object or class member variable.
  */
 typedef struct {
@@ -1590,6 +1601,9 @@ struct class_S
     int		class_obj_method_count;		    // total count
     int		class_obj_method_count_child;	    // count without "extends"
     ufunc_T	**class_obj_methods;	// allocated
+
+					// index of builtin methods
+    int		class_builtin_methods[CLASS_BUILTIN_MAX];
 
     garray_T	class_type_list;	// used for type pointers
     type_T	class_type;		// type used for the class

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -9778,8 +9778,8 @@ func Test_object_empty()
 
     def Foo()
       var afoo = A.new()
-      assert_equal(1, empty(afoo))
-      assert_equal(1, afoo->empty())
+      assert_equal(true, empty(afoo))
+      assert_equal(true, afoo->empty())
     enddef
 
     var a = A.new()
@@ -9902,9 +9902,9 @@ func Test_object_empty()
       enddef
     endclass
     def Foo(afoo: A)
-      assert_equal(1, empty(afoo))
+      assert_equal(true, empty(afoo))
       var bfoo = B.new()
-      assert_equal(1, empty(bfoo))
+      assert_equal(true, empty(bfoo))
     enddef
     var b = B.new()
     assert_equal(1, empty(b))
@@ -9924,7 +9924,7 @@ func Test_object_empty()
       enddef
     endclass
     def Foo(a: A)
-      assert_equal(0, empty(a))
+      assert_equal(false, empty(a))
     enddef
     var b = B.new()
     Foo(b)

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -9979,7 +9979,7 @@ func Test_object_length()
     assert_equal(0, len(a))
     Foo()
   END
-  call v9.CheckSourceFailure(lines, 'E701: Invalid type for len()', 11)
+  call v9.CheckSourceSuccess(lines)
 
   " Unsupported signature for the len() method
   let lines =<< trim END
@@ -10109,23 +10109,24 @@ func Test_object_string()
   let lines =<< trim END
     vim9script
     class A
+      var name: string
       def string(): string
-        return 'Class-A'
+        return this.name
       enddef
     endclass
 
     def Foo()
-      var afoo = A.new()
-      assert_equal('Class-A', string(afoo))
-      assert_equal('Class-A', afoo->string())
+      var afoo = A.new("foo-A")
+      assert_equal('foo-A', string(afoo))
+      assert_equal('foo-A', afoo->string())
     enddef
 
-    var a = A.new()
-    assert_equal('Class-A', string(a))
-    assert_equal('Class-A', a->string())
-    assert_equal(['Class-A'], execute('echo a')->split("\n"))
+    var a = A.new("script-A")
+    assert_equal('script-A', string(a))
+    assert_equal('script-A', a->string())
+    assert_equal(['script-A'], execute('echo a')->split("\n"))
     test_garbagecollect_now()
-    assert_equal('Class-A', string(a))
+    assert_equal('script-A', string(a))
     Foo()
     test_garbagecollect_now()
     Foo()

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -7483,206 +7483,6 @@ func Test_class_variable_complex_type_check()
   call v9.CheckSourceSuccess(lines)
 endfunc
 
-" Test for cases common to all the dunder methods
-def Test_object_dunder_method()
-  var lines =<< trim END
-    vim9script
-    class A
-      def __abc()
-      enddef
-    endclass
-  END
-  v9.CheckSourceFailure(lines, 'E1412: Dunder method "__abc" not supported', 4)
-
-  lines =<< trim END
-    vim9script
-    class A
-      static def __len(): number
-      enddef
-    endclass
-  END
-  v9.CheckSourceFailure(lines, 'E1417: Dunder class method not supported', 3)
-
-  # define __len method in an interface
-  lines =<< trim END
-    vim9script
-    interface A
-      def __len(): number
-    endinterface
-  END
-  v9.CheckSourceFailure(lines, 'E1416: Dunder method not supported in interface', 3)
-enddef
-
-" Test for using __len() with object
-" This is legacy function to use the test_garbagecollect_now() function.
-func Test_object_length()
-  let lines =<< trim END
-    vim9script
-    class A
-      var mylen: number = 0
-      def new(n: number)
-        this.mylen = n
-      enddef
-      def __len(): number
-        return this.mylen
-      enddef
-    endclass
-
-    def Foo()
-      var afoo = A.new(12)
-      assert_equal(12, len(afoo))
-      assert_equal(12, afoo->len())
-    enddef
-
-    var a = A.new(22)
-    assert_equal(22, len(a))
-    assert_equal(22, a->len())
-    test_garbagecollect_now()
-    assert_equal(22, len(a))
-    Foo()
-    test_garbagecollect_now()
-    Foo()
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " len() should return 0 without the dunder method
-  let lines =<< trim END
-    vim9script
-    class A
-    endclass
-
-    def Foo()
-      var afoo = A.new()
-      assert_equal(0, len(afoo))
-    enddef
-
-    var a = A.new()
-    assert_equal(0, len(a))
-    Foo()
-  END
-  call v9.CheckSourceFailure(lines, 'E701: Invalid type for len()', 11)
-
-  " Unsupported signature for the __len() method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __len()
-      enddef
-    endclass
-  END
-  call v9.CheckSourceFailure(lines, 'E1383: Method "__len": type mismatch, expected func(): number but got func()', 4)
-
-  " Error when calling the __len() method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __len(): number
-        throw "Failed to compute length"
-      enddef
-    endclass
-
-    def Foo()
-      var afoo = A.new()
-      var i = len(afoo)
-    enddef
-
-    var a = A.new()
-    assert_fails('len(a)', 'Failed to compute length')
-    assert_fails('Foo()', 'Failed to compute length')
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " call __len() using an object from a script
-  let lines =<< trim END
-    vim9script
-    class A
-      def __len(): number
-        return 1
-      enddef
-    endclass
-    var afoo = A.new()
-    var i = afoo.__len()
-  END
-  call v9.CheckSourceFailure(lines, 'E1415: Cannot access dunder method: __len', 8)
-
-  " call __len() using an object from a method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __len(): number
-        return 1
-      enddef
-    endclass
-    def Foo()
-      var afoo = A.new()
-      var i = afoo.__len()
-    enddef
-    Foo()
-  END
-  call v9.CheckSourceFailure(lines, 'E1414: Dunder method "__len" cannot be directly used', 2)
-
-  " call __len() using "this" from an object method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __len(): number
-        return 1
-      enddef
-      def Foo(): number
-        return this.__len()
-      enddef
-    endclass
-    def Bar()
-      var abar = A.new()
-      var i = abar.Foo()
-    enddef
-    Bar()
-  END
-  call v9.CheckSourceFailure(lines, 'E1414: Dunder method "__len" cannot be directly used', 1)
-
-  " Call __len() from a derived object
-  let lines =<< trim END
-    vim9script
-    class A
-      def __len(): number
-        return 10
-      enddef
-    endclass
-    class B extends A
-      def __len(): number
-        return 20
-      enddef
-    endclass
-    def Foo(afoo: A)
-      assert_equal(20, len(afoo))
-      var bfoo = B.new()
-      assert_equal(20, len(bfoo))
-    enddef
-    var b = B.new()
-    assert_equal(20, len(b))
-    Foo(b)
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " Invoking __len method using an interface
-  let lines =<< trim END
-    vim9script
-    interface A
-    endinterface
-    class B implements A
-      def __len(): number
-        return 123
-      enddef
-    endclass
-    def Foo(a: A)
-      assert_equal(123, len(a))
-    enddef
-    var b = B.new()
-    Foo(b)
-  END
-  call v9.CheckSourceSuccess(lines)
-endfunc
-
 " Test type checking for object variable in assignments
 func Test_object_variable_complex_type_check()
   " object variable with a specific type.  Try assigning a different type at
@@ -9859,339 +9659,6 @@ def Test_const_class_object_variable()
   v9.CheckSourceFailure(lines, 'E1022: Type or initialization required', 3)
 enddef
 
-" Test for using __empty() with object
-" This is legacy function to use the test_garbagecollect_now() function.
-func Test_object_empty()
-  let lines =<< trim END
-    vim9script
-    class A
-      def __empty(): bool
-        return true
-      enddef
-    endclass
-
-    def Foo()
-      var afoo = A.new()
-      assert_equal(1, empty(afoo))
-      assert_equal(1, afoo->empty())
-    enddef
-
-    var a = A.new()
-    assert_equal(1, empty(a))
-    assert_equal(1, a->empty())
-    test_garbagecollect_now()
-    assert_equal(1, empty(a))
-    Foo()
-    test_garbagecollect_now()
-    Foo()
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " empty() should return 1 without the dunder method
-  let lines =<< trim END
-    vim9script
-    class A
-    endclass
-
-    def Foo()
-      var afoo = A.new()
-      assert_equal(1, empty(afoo))
-    enddef
-
-    var a = A.new()
-    assert_equal(1, empty(a))
-    Foo()
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " Unsupported signature for the __empty() method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __empty()
-      enddef
-    endclass
-  END
-  call v9.CheckSourceFailure(lines, 'E1383: Method "__empty": type mismatch, expected func(): bool but got func()', 4)
-
-  " Error when calling the __empty() method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __empty(): bool
-        throw "Failed to check emptiness"
-      enddef
-    endclass
-
-    def Foo()
-      var afoo = A.new()
-      var i = empty(afoo)
-    enddef
-
-    var a = A.new()
-    assert_fails('empty(a)', 'Failed to check emptiness')
-    assert_fails('Foo()', 'Failed to check emptiness')
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " call __empty() using an object from a script
-  let lines =<< trim END
-    vim9script
-    class A
-      def __empty(): bool
-        return true
-      enddef
-    endclass
-    var afoo = A.new()
-    var i = afoo.__empty()
-  END
-  call v9.CheckSourceFailure(lines, 'E1415: Cannot access dunder method: __empty', 8)
-
-  " call __empty() using an object from a method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __empty(): bool
-        return true
-      enddef
-    endclass
-    def Foo()
-      var afoo = A.new()
-      var i = afoo.__empty()
-    enddef
-    Foo()
-  END
-  call v9.CheckSourceFailure(lines, 'E1414: Dunder method "__empty" cannot be directly used', 2)
-
-  " call __empty() using "this" from an object method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __empty(): bool
-        return true
-      enddef
-      def Foo(): bool
-        return this.__empty()
-      enddef
-    endclass
-    def Bar()
-      var abar = A.new()
-      var i = abar.__empty()
-    enddef
-    Bar()
-  END
-  call v9.CheckSourceFailure(lines, 'E1414: Dunder method "__empty" cannot be directly used', 2)
-
-  " Call __empty() from a derived object
-  let lines =<< trim END
-    vim9script
-    class A
-      def __empty(): bool
-        return false
-      enddef
-    endclass
-    class B extends A
-      def __empty(): bool
-        return true
-      enddef
-    endclass
-    def Foo(afoo: A)
-      assert_equal(1, empty(afoo))
-      var bfoo = B.new()
-      assert_equal(1, empty(bfoo))
-    enddef
-    var b = B.new()
-    assert_equal(1, empty(b))
-    Foo(b)
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " Invoking __empty method using an interface
-  let lines =<< trim END
-    vim9script
-    interface A
-    endinterface
-    class B implements A
-      def __empty(): bool
-        return false
-      enddef
-    endclass
-    def Foo(a: A)
-      assert_equal(0, empty(a))
-    enddef
-    var b = B.new()
-    Foo(b)
-  END
-  call v9.CheckSourceSuccess(lines)
-endfunc
-
-" Test for using __string() with object
-" This is legacy function to use the test_garbagecollect_now() function.
-func Test_object_string()
-  let lines =<< trim END
-    vim9script
-    class A
-      def __string(): string
-        return 'Class-A'
-      enddef
-    endclass
-
-    def Foo()
-      var afoo = A.new()
-      assert_equal('Class-A', string(afoo))
-      assert_equal('Class-A', afoo->string())
-    enddef
-
-    var a = A.new()
-    assert_equal('Class-A', string(a))
-    assert_equal('Class-A', a->string())
-    assert_equal(['Class-A'], execute('echo a')->split("\n"))
-    test_garbagecollect_now()
-    assert_equal('Class-A', string(a))
-    Foo()
-    test_garbagecollect_now()
-    Foo()
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " string() should return "object of A {}" without the dunder method
-  let lines =<< trim END
-    vim9script
-    class A
-    endclass
-
-    def Foo()
-      var afoo = A.new()
-      assert_equal('object of A {}', string(afoo))
-    enddef
-
-    var a = A.new()
-    assert_equal('object of A {}', string(a))
-    Foo()
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " Unsupported signature for the __string() method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __string()
-      enddef
-    endclass
-  END
-  call v9.CheckSourceFailure(lines, 'E1383: Method "__string": type mismatch, expected func(): string but got func()', 4)
-
-  " Error when calling the __string() method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __string(): string
-        throw "Failed to get text"
-      enddef
-    endclass
-
-    def Foo()
-      var afoo = A.new()
-      var i = string(afoo)
-    enddef
-
-    var a = A.new()
-    assert_fails('string(a)', 'Failed to get text')
-    assert_fails('Foo()', 'Failed to get text')
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " call __string() using an object from a script
-  let lines =<< trim END
-    vim9script
-    class A
-      def __string(): string
-        return 'A'
-      enddef
-    endclass
-    var afoo = A.new()
-    var s = afoo.__string()
-  END
-  call v9.CheckSourceFailure(lines, 'E1415: Cannot access dunder method: __string', 8)
-
-  " call __string() using an object from a method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __string(): string
-        return 'A'
-      enddef
-    endclass
-    def Foo()
-      var afoo = A.new()
-      var s = afoo.__string()
-    enddef
-    Foo()
-  END
-  call v9.CheckSourceFailure(lines, 'E1414: Dunder method "__string" cannot be directly used', 2)
-
-  " call __string() using "this" from an object method
-  let lines =<< trim END
-    vim9script
-    class A
-      def __string(): string
-        return 'A'
-      enddef
-      def Foo(): string
-        return this.__string()
-      enddef
-    endclass
-    def Bar()
-      var abar = A.new()
-      var s = abar.__string()
-    enddef
-    Bar()
-  END
-  call v9.CheckSourceFailure(lines, 'E1414: Dunder method "__string" cannot be directly used', 2)
-
-  " Call __string() from a derived object
-  let lines =<< trim END
-    vim9script
-    class A
-      def __string(): string
-        return 'A'
-      enddef
-    endclass
-    class B extends A
-      def __string(): string
-        return 'B'
-      enddef
-    endclass
-    def Foo(afoo: A)
-      assert_equal('B', string(afoo))
-      var bfoo = B.new()
-      assert_equal('B', string(bfoo))
-    enddef
-    var b = B.new()
-    assert_equal('B', string(b))
-    Foo(b)
-  END
-  call v9.CheckSourceSuccess(lines)
-
-  " Invoking __string method using an interface
-  let lines =<< trim END
-    vim9script
-    interface A
-    endinterface
-    class B implements A
-      def __string(): string
-        return 'B'
-      enddef
-    endclass
-    def Foo(a: A)
-      assert_equal('B', string(a))
-    enddef
-    var b = B.new()
-    Foo(b)
-  END
-  call v9.CheckSourceSuccess(lines)
-endfunc
-
 " Test for compiling class/object methods using :defcompile
 def Test_defcompile_class()
   # defcompile all the classes in the current script
@@ -10274,5 +9741,534 @@ def Test_defcompile_class()
   END
   v9.CheckScriptSuccess(lines)
 enddef
+
+" Test for cases common to all the object builtin methods
+def Test_object_builtin_method()
+  var lines =<< trim END
+    vim9script
+    class A
+      def abc()
+      enddef
+    endclass
+  END
+  v9.CheckSourceFailure(lines, 'E1267: Function name must start with a capital: abc()', 3)
+
+  for funcname in ["len", "string", "empty"]
+    lines =<< trim eval END
+      vim9script
+      class A
+        static def {funcname}(): number
+        enddef
+      endclass
+    END
+    v9.CheckSourceFailure(lines, 'E1413: Builtin class method not supported', 3)
+  endfor
+enddef
+
+" Test for using the empty() builtin method with an object
+" This is a legacy function to use the test_garbagecollect_now() function.
+func Test_object_empty()
+  let lines =<< trim END
+    vim9script
+    class A
+      def empty(): bool
+        return true
+      enddef
+    endclass
+
+    def Foo()
+      var afoo = A.new()
+      assert_equal(1, empty(afoo))
+      assert_equal(1, afoo->empty())
+    enddef
+
+    var a = A.new()
+    assert_equal(1, empty(a))
+    assert_equal(1, a->empty())
+    test_garbagecollect_now()
+    assert_equal(1, empty(a))
+    Foo()
+    test_garbagecollect_now()
+    Foo()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " empty() should return 1 without a builtin method
+  let lines =<< trim END
+    vim9script
+    class A
+    endclass
+
+    def Foo()
+      var afoo = A.new()
+      assert_equal(1, empty(afoo))
+    enddef
+
+    var a = A.new()
+    assert_equal(1, empty(a))
+    Foo()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " Unsupported signature for the empty() method
+  let lines =<< trim END
+    vim9script
+    class A
+      def empty()
+      enddef
+    endclass
+  END
+  call v9.CheckSourceFailure(lines, 'E1383: Method "empty": type mismatch, expected func(): bool but got func()', 4)
+
+  " Error when calling the empty() method
+  let lines =<< trim END
+    vim9script
+    class A
+      def empty(): bool
+        throw "Failed to check emptiness"
+      enddef
+    endclass
+
+    def Foo()
+      var afoo = A.new()
+      var i = empty(afoo)
+    enddef
+
+    var a = A.new()
+    assert_fails('empty(a)', 'Failed to check emptiness')
+    assert_fails('Foo()', 'Failed to check emptiness')
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " call empty() using an object from a script
+  let lines =<< trim END
+    vim9script
+    class A
+      def empty(): bool
+        return true
+      enddef
+    endclass
+    var afoo = A.new()
+    assert_equal(true, afoo.empty())
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " call empty() using an object from a method
+  let lines =<< trim END
+    vim9script
+    class A
+      def empty(): bool
+        return true
+      enddef
+    endclass
+    def Foo()
+      var afoo = A.new()
+      assert_equal(true, afoo.empty())
+    enddef
+    Foo()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " call empty() using "this" from an object method
+  let lines =<< trim END
+    vim9script
+    class A
+      def empty(): bool
+        return true
+      enddef
+      def Foo(): bool
+        return this.empty()
+      enddef
+    endclass
+    def Bar()
+      var abar = A.new()
+      assert_equal(true, abar.Foo())
+    enddef
+    Bar()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " Call empty() from a derived object
+  let lines =<< trim END
+    vim9script
+    class A
+      def empty(): bool
+        return false
+      enddef
+    endclass
+    class B extends A
+      def empty(): bool
+        return true
+      enddef
+    endclass
+    def Foo(afoo: A)
+      assert_equal(1, empty(afoo))
+      var bfoo = B.new()
+      assert_equal(1, empty(bfoo))
+    enddef
+    var b = B.new()
+    assert_equal(1, empty(b))
+    Foo(b)
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " Invoking empty method using an interface
+  let lines =<< trim END
+    vim9script
+    interface A
+      def empty(): bool
+    endinterface
+    class B implements A
+      def empty(): bool
+        return false
+      enddef
+    endclass
+    def Foo(a: A)
+      assert_equal(0, empty(a))
+    enddef
+    var b = B.new()
+    Foo(b)
+  END
+  call v9.CheckSourceSuccess(lines)
+endfunc
+
+" Test for using the len() builtin method with an object
+" This is a legacy function to use the test_garbagecollect_now() function.
+func Test_object_length()
+  let lines =<< trim END
+    vim9script
+    class A
+      var mylen: number = 0
+      def new(n: number)
+        this.mylen = n
+      enddef
+      def len(): number
+        return this.mylen
+      enddef
+    endclass
+
+    def Foo()
+      var afoo = A.new(12)
+      assert_equal(12, len(afoo))
+      assert_equal(12, afoo->len())
+    enddef
+
+    var a = A.new(22)
+    assert_equal(22, len(a))
+    assert_equal(22, a->len())
+    test_garbagecollect_now()
+    assert_equal(22, len(a))
+    Foo()
+    test_garbagecollect_now()
+    Foo()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " len() should return 0 without a builtin method
+  let lines =<< trim END
+    vim9script
+    class A
+    endclass
+
+    def Foo()
+      var afoo = A.new()
+      assert_equal(0, len(afoo))
+    enddef
+
+    var a = A.new()
+    assert_equal(0, len(a))
+    Foo()
+  END
+  call v9.CheckSourceFailure(lines, 'E701: Invalid type for len()', 11)
+
+  " Unsupported signature for the len() method
+  let lines =<< trim END
+    vim9script
+    class A
+      def len()
+      enddef
+    endclass
+  END
+  call v9.CheckSourceFailure(lines, 'E1383: Method "len": type mismatch, expected func(): number but got func()', 4)
+
+  " Error when calling the len() method
+  let lines =<< trim END
+    vim9script
+    class A
+      def len(): number
+        throw "Failed to compute length"
+      enddef
+    endclass
+
+    def Foo()
+      var afoo = A.new()
+      var i = len(afoo)
+    enddef
+
+    var a = A.new()
+    assert_fails('len(a)', 'Failed to compute length')
+    assert_fails('Foo()', 'Failed to compute length')
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " call len() using an object from a script
+  let lines =<< trim END
+    vim9script
+    class A
+      def len(): number
+        return 5
+      enddef
+    endclass
+    var afoo = A.new()
+    assert_equal(5, afoo.len())
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " call len() using an object from a method
+  let lines =<< trim END
+    vim9script
+    class A
+      def len(): number
+        return 5
+      enddef
+    endclass
+    def Foo()
+      var afoo = A.new()
+      assert_equal(5, afoo.len())
+    enddef
+    Foo()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " call len() using "this" from an object method
+  let lines =<< trim END
+    vim9script
+    class A
+      def len(): number
+        return 8
+      enddef
+      def Foo(): number
+        return this.len()
+      enddef
+    endclass
+    def Bar()
+      var abar = A.new()
+      assert_equal(8, abar.Foo())
+    enddef
+    Bar()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " Call len() from a derived object
+  let lines =<< trim END
+    vim9script
+    class A
+      def len(): number
+        return 10
+      enddef
+    endclass
+    class B extends A
+      def len(): number
+        return 20
+      enddef
+    endclass
+    def Foo(afoo: A)
+      assert_equal(20, len(afoo))
+      var bfoo = B.new()
+      assert_equal(20, len(bfoo))
+    enddef
+    var b = B.new()
+    assert_equal(20, len(b))
+    Foo(b)
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " Invoking len method using an interface
+  let lines =<< trim END
+    vim9script
+    interface A
+      def len(): number
+    endinterface
+    class B implements A
+      def len(): number
+        return 123
+      enddef
+    endclass
+    def Foo(a: A)
+      assert_equal(123, len(a))
+    enddef
+    var b = B.new()
+    Foo(b)
+  END
+  call v9.CheckSourceSuccess(lines)
+endfunc
+
+" Test for using the string() builtin method with an object
+" This is a legacy function to use the test_garbagecollect_now() function.
+func Test_object_string()
+  let lines =<< trim END
+    vim9script
+    class A
+      def string(): string
+        return 'Class-A'
+      enddef
+    endclass
+
+    def Foo()
+      var afoo = A.new()
+      assert_equal('Class-A', string(afoo))
+      assert_equal('Class-A', afoo->string())
+    enddef
+
+    var a = A.new()
+    assert_equal('Class-A', string(a))
+    assert_equal('Class-A', a->string())
+    assert_equal(['Class-A'], execute('echo a')->split("\n"))
+    test_garbagecollect_now()
+    assert_equal('Class-A', string(a))
+    Foo()
+    test_garbagecollect_now()
+    Foo()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " string() should return "object of A {}" without a builtin method
+  let lines =<< trim END
+    vim9script
+    class A
+    endclass
+
+    def Foo()
+      var afoo = A.new()
+      assert_equal('object of A {}', string(afoo))
+    enddef
+
+    var a = A.new()
+    assert_equal('object of A {}', string(a))
+    Foo()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " Unsupported signature for the string() method
+  let lines =<< trim END
+    vim9script
+    class A
+      def string()
+      enddef
+    endclass
+  END
+  call v9.CheckSourceFailure(lines, 'E1383: Method "string": type mismatch, expected func(): string but got func()', 4)
+
+  " Error when calling the string() method
+  let lines =<< trim END
+    vim9script
+    class A
+      def string(): string
+        throw "Failed to get text"
+      enddef
+    endclass
+
+    def Foo()
+      var afoo = A.new()
+      var i = string(afoo)
+    enddef
+
+    var a = A.new()
+    assert_fails('string(a)', 'Failed to get text')
+    assert_fails('Foo()', 'Failed to get text')
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " call string() using an object from a script
+  let lines =<< trim END
+    vim9script
+    class A
+      def string(): string
+        return 'A'
+      enddef
+    endclass
+    var afoo = A.new()
+    assert_equal('A', afoo.string())
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " call string() using an object from a method
+  let lines =<< trim END
+    vim9script
+    class A
+      def string(): string
+        return 'A'
+      enddef
+    endclass
+    def Foo()
+      var afoo = A.new()
+      assert_equal('A', afoo.string())
+    enddef
+    Foo()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " call string() using "this" from an object method
+  let lines =<< trim END
+    vim9script
+    class A
+      def string(): string
+        return 'A'
+      enddef
+      def Foo(): string
+        return this.string()
+      enddef
+    endclass
+    def Bar()
+      var abar = A.new()
+      assert_equal('A', abar.string())
+    enddef
+    Bar()
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " Call string() from a derived object
+  let lines =<< trim END
+    vim9script
+    class A
+      def string(): string
+        return 'A'
+      enddef
+    endclass
+    class B extends A
+      def string(): string
+        return 'B'
+      enddef
+    endclass
+    def Foo(afoo: A)
+      assert_equal('B', string(afoo))
+      var bfoo = B.new()
+      assert_equal('B', string(bfoo))
+    enddef
+    var b = B.new()
+    assert_equal('B', string(b))
+    Foo(b)
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " Invoking string method using an interface
+  let lines =<< trim END
+    vim9script
+    interface A
+      def string(): string
+    endinterface
+    class B implements A
+      def string(): string
+        return 'B'
+      enddef
+    endclass
+    def Foo(a: A)
+      assert_equal('B', string(a))
+    enddef
+    var b = B.new()
+    Foo(b)
+  END
+  call v9.CheckSourceSuccess(lines)
+endfunc
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -3273,4 +3273,167 @@ def Test_funcref_with_class()
   unlet g:instr
 enddef
 
+" Disassemble instructions for calls to a string() function in an object
+def Test_disassemble_object_string()
+  var lines =<< trim END
+    vim9script
+    class A
+      def string(): string
+        return 'A'
+      enddef
+    endclass
+    def Bar()
+      var a = A.new()
+      var s = string(a)
+      s = string(A)
+    enddef
+    g:instr = execute('disassemble Bar')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('<SNR>\d*_Bar\_s*' ..
+    'var a = A.new()\_s*' ..
+    '0 DCALL new(argc 0)\_s*' ..
+    '1 STORE $0\_s*' ..
+    'var s = string(a)\_s*' ..
+    '2 LOAD $0\_s*' ..
+    '3 METHODCALL A.string(argc 0)\_s*' ..
+    '4 STORE $1\_s*' ..
+    's = string(A)\_s*' ..
+    '5 LOADSCRIPT A-0 from .*\_s*' ..
+    '6 BCALL string(argc 1)\_s*' ..
+    '7 STORE $1\_s*' ..
+    '8 RETURN void', g:instr)
+  unlet g:instr
+
+  # Use the default string() function for a class
+  lines =<< trim END
+    vim9script
+    class A
+    endclass
+    def Bar()
+      var a = A.new()
+      var s = string(a)
+      s = string(A)
+    enddef
+    g:instr = execute('disassemble Bar')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('<SNR>\d*_Bar\_s*' ..
+    'var a = A.new()\_s*' ..
+    '0 DCALL new(argc 0)\_s*' ..
+    '1 STORE $0\_s*' ..
+    'var s = string(a)\_s*' ..
+    '2 LOAD $0\_s*' ..
+    '3 BCALL string(argc 1)\_s*' ..
+    '4 STORE $1\_s*' ..
+    's = string(A)\_s*' ..
+    '5 LOADSCRIPT A-0 from .*\_s*' ..
+    '6 BCALL string(argc 1)\_s*' ..
+    '7 STORE $1\_s*' ..
+    '8 RETURN void', g:instr)
+  unlet g:instr
+enddef
+
+" Disassemble instructions for calls to a empty() function in an object
+def Test_disassemble_object_empty()
+  var lines =<< trim END
+    vim9script
+    class A
+      def empty(): bool
+        return true
+      enddef
+    endclass
+    def Bar()
+      var a = A.new()
+      var s = empty(a)
+    enddef
+    g:instr = execute('disassemble Bar')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('<SNR>\d*_Bar\_s*' ..
+    'var a = A.new()\_s*' ..
+    '0 DCALL new(argc 0)\_s*' ..
+    '1 STORE $0\_s*' ..
+    'var s = empty(a)\_s*' ..
+    '2 LOAD $0\_s*' ..
+    '3 METHODCALL A.empty(argc 0)\_s*' ..
+    '4 STORE $1\_s*' ..
+    '5 RETURN void', g:instr)
+  unlet g:instr
+
+  # Use the default empty() function for a class
+  lines =<< trim END
+    vim9script
+    class A
+    endclass
+    def Bar()
+      var a = A.new()
+      var s = empty(a)
+    enddef
+    g:instr = execute('disassemble Bar')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('<SNR>\d*_Bar\_s*' ..
+    'var a = A.new()\_s*' ..
+    '0 DCALL new(argc 0)\_s*' ..
+    '1 STORE $0\_s*' ..
+    'var s = empty(a)\_s*' ..
+    '2 LOAD $0\_s*' ..
+    '3 BCALL empty(argc 1)\_s*' ..
+    '4 STORE $1\_s*' ..
+    '5 RETURN void', g:instr)
+  unlet g:instr
+enddef
+
+" Disassemble instructions for calls to a len() function in an object
+def Test_disassemble_object_len()
+  var lines =<< trim END
+    vim9script
+    class A
+      def len(): number
+        return 10
+      enddef
+    endclass
+    def Bar()
+      var a = A.new()
+      var s = len(a)
+    enddef
+    g:instr = execute('disassemble Bar')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('<SNR>\d*_Bar\_s*' ..
+    'var a = A.new()\_s*' ..
+    '0 DCALL new(argc 0)\_s*' ..
+    '1 STORE $0\_s*' ..
+    'var s = len(a)\_s*' ..
+    '2 LOAD $0\_s*' ..
+    '3 METHODCALL A.len(argc 0)\_s*' ..
+    '4 STORE $1\_s*' ..
+    '5 RETURN void', g:instr)
+  unlet g:instr
+
+  # Use the default len() function for a class
+  lines =<< trim END
+    vim9script
+    class A
+    endclass
+    def Bar()
+      var a = A.new()
+      var s = len(a)
+    enddef
+    g:instr = execute('disassemble Bar')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('<SNR>\d*_Bar\_s*' ..
+    'var a = A.new()\_s*' ..
+    '0 DCALL new(argc 0)\_s*' ..
+    '1 STORE $0\_s*' ..
+    'var s = len(a)\_s*' ..
+    '2 LOAD $0\_s*' ..
+    '3 BCALL len(argc 1)\_s*' ..
+    '4 STORE $1\_s*' ..
+    '5 RETURN void', g:instr)
+  unlet g:instr
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -4459,12 +4459,13 @@ trans_function_name_ext(
 	}
     }
     // The function name must start with an upper case letter (unless it is a
-    // Vim9 class new() function or a Vim9 class private method)
+    // Vim9 class new() function or a Vim9 class private method or one of the
+    // supported Vim9 object builtin functions)
     else if (!(flags & TFN_INT)
 	    && (builtin_function(lv.ll_name, len)
 				   || (vim9script && *lv.ll_name == '_'))
 	    && !((flags & TFN_IN_CLASS)
-		&& (STRNCMP(lv.ll_name, "new", 3) == 0
+		&& (is_valid_builtin_obj_methodname(lv.ll_name)
 		    || (*lv.ll_name == '_'))))
     {
 	semsg(_(vim9script ? e_function_name_must_start_with_capital_str

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -3464,10 +3464,7 @@ object_len(object_T *obj)
 
     if (object_call_builtin_method(obj, CLASS_BUILTIN_LEN, 0, NULL, &rettv)
 								== FAIL)
-    {
-	emsg(_(e_invalid_type_for_len));
 	return 0;
-    }
 
     return tv_to_number(&rettv);
 }

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -393,6 +393,13 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    }
 	}
 
+	// A dunder method cannot be directly invoked
+	if (ufunc != NULL && *ufunc->uf_name == '_' && *(ufunc->uf_name + 1) == '_')
+	{
+	    semsg(_(e_dunder_method_cannot_be_used_directly), ufunc->uf_name);
+	    return FAIL;
+	}
+
 	// A private object method can be used only inside the class where it
 	// is defined or in one of the child classes.
 	// A private class method can be used only in the class where it is
@@ -403,7 +410,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 		 || (type->tt_type == VAR_CLASS
 		     && cctx->ctx_ufunc->uf_class != cl)))
 	{
-	    semsg(_(e_cannot_access_protected_method_str), name);
+	    protected_method_access_errmsg(name);
 	    return FAIL;
 	}
 
@@ -449,7 +456,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    // Private methods are not accessible outside the class
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
-		semsg(_(e_cannot_access_protected_method_str), fp->uf_name);
+		protected_method_access_errmsg(fp->uf_name);
 		return FAIL;
 	    }
 	    *arg = name_end;
@@ -491,7 +498,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    // Private methods are not accessible outside the class
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
-		semsg(_(e_cannot_access_protected_method_str), fp->uf_name);
+		protected_method_access_errmsg(fp->uf_name);
 		return FAIL;
 	    }
 	    *arg = name_end;

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -393,13 +393,6 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    }
 	}
 
-	// A dunder method cannot be directly invoked
-	if (ufunc != NULL && *ufunc->uf_name == '_' && *(ufunc->uf_name + 1) == '_')
-	{
-	    semsg(_(e_dunder_method_cannot_be_used_directly), ufunc->uf_name);
-	    return FAIL;
-	}
-
 	// A private object method can be used only inside the class where it
 	// is defined or in one of the child classes.
 	// A private class method can be used only in the class where it is
@@ -410,7 +403,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 		 || (type->tt_type == VAR_CLASS
 		     && cctx->ctx_ufunc->uf_class != cl)))
 	{
-	    protected_method_access_errmsg(name);
+	    semsg(_(e_cannot_access_protected_method_str), name);
 	    return FAIL;
 	}
 
@@ -456,7 +449,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    // Private methods are not accessible outside the class
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
-		protected_method_access_errmsg(fp->uf_name);
+		semsg(_(e_cannot_access_protected_method_str), fp->uf_name);
 		return FAIL;
 	    }
 	    *arg = name_end;
@@ -498,7 +491,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    // Private methods are not accessible outside the class
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
-		protected_method_access_errmsg(fp->uf_name);
+		semsg(_(e_cannot_access_protected_method_str), fp->uf_name);
 		return FAIL;
 	    }
 	    *arg = name_end;


### PR DESCRIPTION

Add support for using builtin functions like string(), len() and empty() with Vim9 objects.
Allow object methods with the same name as the builtin functions. Compile the builtin method calls.
