### PR TITLE
Getregion buffer support

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4307,8 +4307,8 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		- If the region is blockwise and it starts or ends in the
 		  middle of a multi-cell character, it is not included but
 		  its selected part is substituted with spaces.
-		- If and {pos1} and {pos2} are not in the same buffer, an
-		  empty list is returned.
+		- If {pos1} and {pos2} are not in the same buffer, an empty
+		  list is returned.
 		- {pos1} and {pos2} must be exists in tabs.
 
 		Examples: >

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4309,7 +4309,8 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		  its selected part is substituted with spaces.
 		- If {pos1} and {pos2} are not in the same buffer, an empty
 		  list is returned.
-		- {pos1} and {pos2} must be exists in tabs.
+		- {pos1} and {pos2} must belong to a buffer that is loaded in a
+		  window in any tab.
 
 		Examples: >
 			:xnoremap <CR>

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4274,8 +4274,7 @@ getreginfo([{regname}])					*getreginfo()*
 			GetRegname()->getreginfo()
 
 getregion({pos1}, {pos2} [, {opts}])			*getregion()*
-		Returns the list of strings from {pos1} to {pos2} in current
-		buffer.
+		Returns the list of strings from {pos1} to {pos2} in buffer.
 
 		{pos1} and {pos2} must both be |List|s with four numbers.
 		See |getpos()| for the format of the list.
@@ -4308,8 +4307,9 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		- If the region is blockwise and it starts or ends in the
 		  middle of a multi-cell character, it is not included but
 		  its selected part is substituted with spaces.
-		- If {pos1} or {pos2} is not current in the buffer, an empty
-		  list is returned.
+		- If {pos1} or {pos2} is not same buffer, an empty list is
+		  returned.
+		- {pos1} and {pos2} must be exists in tabs.
 
 		Examples: >
 			:xnoremap <CR>

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4307,8 +4307,8 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		- If the region is blockwise and it starts or ends in the
 		  middle of a multi-cell character, it is not included but
 		  its selected part is substituted with spaces.
-		- If {pos1} or {pos2} is not same buffer, an empty list is
-		  returned.
+		- If and {pos1} and {pos2} are not in the same buffer, an
+		  empty list is returned.
 		- {pos1} and {pos2} must be exists in tabs.
 
 		Examples: >

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4311,6 +4311,7 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		  list is returned.
 		- {pos1} and {pos2} must belong to a buffer that is loaded in a
 		  window in any tab.
+		- It is evaluated in current window context.
 
 		Examples: >
 			:xnoremap <CR>

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5511,13 +5511,9 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 	    || check_for_opt_dict_arg(argvars, 2) == FAIL)
 	return;
 
-    if (list2fpos(&argvars[0], &p1, &fnum1, NULL, FALSE) != OK)
-	return;
-
-    if (list2fpos(&argvars[1], &p2, &fnum2, NULL, FALSE) != OK)
-	return;
-
-    if (fnum1 != fnum2)
+    if (list2fpos(&argvars[0], &p1, &fnum1, NULL, FALSE) != OK
+	    || list2fpos(&argvars[1], &p2, &fnum2, NULL, FALSE) != OK
+	    || fnum1 != fnum2)
 	return;
 
     buf = buflist_findnr(fnum1);

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5495,7 +5495,6 @@ f_getregion(typval_T *argvars, typval_T *rettv)
     pos_T		p1, p2;
     char_u		*type;
     buf_T		*buf;
-    tabpage_T		*tp;
     win_T		*wp = NULL;
     char_u		default_type[] = "v";
     int			save_virtual = -1;
@@ -5516,17 +5515,27 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 	    || fnum1 != fnum2)
 	return;
 
-    buf = buflist_findnr(fnum1);
-    FOR_ALL_TABPAGES(tp)
+    if (fnum1 == 0)
     {
-        FOR_ALL_WINDOWS(wp)
-        {
-            if (wp->w_buffer == buf)
-                break;
-        }
+	buf = curbuf;
+	wp = curwin;
     }
-    if (wp == NULL)
-	return;
+    else
+    {
+	tabpage_T      *tp;
+
+	buf = buflist_findnr(fnum1);
+	FOR_ALL_TABPAGES(tp)
+	{
+	    FOR_ALL_WINDOWS(wp)
+	    {
+		if (wp->w_buffer == buf)
+		    break;
+	    }
+	}
+	if (wp == NULL)
+	    return;
+    }
 
     if (argvars[2].v_type == VAR_DICT)
     {

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1747,7 +1747,7 @@ func Test_visual_getregion()
     #" using the wrong type
     call assert_fails(':echo "."->getpos()->getregion("$", [])', 'E1211:')
 
-    #" using a mark in another buffer
+    #" using a mark from another buffer to current buffer
     new
     VAR newbuf = bufnr()
     call setline(1, range(10))
@@ -1757,6 +1757,17 @@ func Test_visual_getregion()
     call assert_equal([], getregion(getpos('.'), getpos("'A"), {'type': 'v' }))
     call assert_equal([], getregion(getpos("'A"), getpos('.'), {'type': 'v' }))
     exe $':{newbuf}bwipe!'
+
+    #" using a mark from another buffer to another buffer
+    new
+    VAR anotherbuf = bufnr()
+    call setline(1, range(10))
+    normal! GmA
+    normal! GmB
+    wincmd p
+    call assert_equal([anotherbuf, 10, 1, 0], getpos("'A"))
+    call assert_equal(['9'], getregion(getpos("'B"), getpos("'A"), {'type': 'v' }))
+    exe $':{anotherbuf}bwipe!'
   END
   call v9.CheckLegacyAndVim9Success(lines)
 

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1768,6 +1768,9 @@ func Test_visual_getregion()
     call assert_equal([anotherbuf, 10, 1, 0], getpos("'A"))
     call assert_equal(['9'], getregion(getpos("'B"), getpos("'A"), {'type': 'v' }))
     exe $':{anotherbuf}bwipe!'
+
+    #" using invalid buffer
+    call assert_equal([], getregion([10000, 10, 1, 0], [10000, 10, 1, 0]))
   END
   call v9.CheckLegacyAndVim9Success(lines)
 


### PR DESCRIPTION
Continues of https://github.com/vim/vim/pull/14090.

NOTE:  The buffer yank is executed on current window context.
NOTE: `{pos1}` and `{pos2}` must be same buffer.