### PR TITLE
ml_get_buf_len() does not consider text properties

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -1364,6 +1364,7 @@ del_bytes(
 	    mch_memmove(newp + newlen + 1, oldp + oldlen + 1,
 			       (size_t)curbuf->b_ml.ml_line_len - oldlen - 1);
 	curbuf->b_ml.ml_line_len -= count;
+	curbuf->b_ml.ml_line_textlen = (int)STRLEN(newp) + 1;
     }
 #endif
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -5070,6 +5070,7 @@ ins_tab(void)
 			vim_free(curbuf->b_ml.ml_line_ptr);
 		    curbuf->b_ml.ml_line_ptr = newp;
 		    curbuf->b_ml.ml_line_len -= i;
+		    curbuf->b_ml.ml_line_textlen = (int)STRLEN(newp) + 1;
 		    curbuf->b_ml.ml_flags =
 			   (curbuf->b_ml.ml_flags | ML_LINE_DIRTY) & ~ML_EMPTY;
 		}

--- a/src/memline.c
+++ b/src/memline.c
@@ -2703,7 +2703,7 @@ ml_get_buf_len(buf_T *buf, linenr_T lnum)
     if (*ml_get_buf(buf, lnum, FALSE) == NUL)
         return 0;
 
-    return buf->b_ml.ml_line_len - 1;
+    return buf->b_ml.ml_line_textlen - 1;
 }
 
 /*
@@ -2737,6 +2737,7 @@ ml_get_buf(
 errorret:
 	STRCPY(questions, "???");
 	buf->b_ml.ml_line_len = 4;
+	buf->b_ml.ml_line_textlen = buf->b_ml.ml_line_len;
 	buf->b_ml.ml_line_lnum = lnum;
 	return questions;
     }
@@ -2746,6 +2747,7 @@ errorret:
     if (buf->b_ml.ml_mfp == NULL)	// there are no lines
     {
 	buf->b_ml.ml_line_len = 1;
+	buf->b_ml.ml_line_textlen = buf->b_ml.ml_line_len;
 	return (char_u *)"";
     }
 
@@ -2796,6 +2798,12 @@ errorret:
 
 	buf->b_ml.ml_line_ptr = (char_u *)dp + start;
 	buf->b_ml.ml_line_len = end - start;
+#if defined(FEAT_BYTEOFF) && defined(FEAT_PROP_POPUP)
+	if (buf->b_has_textprop)
+	    buf->b_ml.ml_line_textlen = (int)STRLEN(buf->b_ml.ml_line_ptr) + 1;
+	else
+#endif
+	    buf->b_ml.ml_line_textlen = buf->b_ml.ml_line_len;
 	buf->b_ml.ml_line_lnum = lnum;
 	buf->b_ml.ml_flags &= ~(ML_LINE_DIRTY | ML_ALLOCATED);
     }
@@ -3646,6 +3654,7 @@ ml_replace_len(
 
     curbuf->b_ml.ml_line_ptr = line;
     curbuf->b_ml.ml_line_len = len;
+    curbuf->b_ml.ml_line_textlen = len_arg + 1;
     curbuf->b_ml.ml_line_lnum = lnum;
     curbuf->b_ml.ml_flags = (curbuf->b_ml.ml_flags | ML_LINE_DIRTY) & ~ML_EMPTY;
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -800,7 +800,8 @@ typedef struct memline
 #define ML_ALLOCATED	0x10	// ml_line_ptr is an allocated copy
     int		ml_flags;
 
-    colnr_T	ml_line_len;	// length of the cached line, including NUL
+    colnr_T	ml_line_len;	// length of the cached line + textproperties, including NUL
+    colnr_T	ml_line_textlen;// length of the cached line, including NUL
     linenr_T	ml_line_lnum;	// line number of cached line, 0 if not valid
     char_u	*ml_line_ptr;	// pointer to cached line
 


### PR DESCRIPTION
Problem:  ml_get_buf_len() does not consider text properties
Solution: Store text length excluding text properties length
          in addition in the memline

related #14123