### PR TITLE
Fix 'winfixbuf' heap UAF/null pointer member access

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3146,7 +3146,7 @@ qf_goto_win_with_qfl_file(int qf_fnum)
 	    // Didn't find it, go to the window before the quickfix
 	    // window, unless 'switchbuf' contains 'uselast': in this case we
 	    // try to jump to the previously used window first.
-	    if ((swb_flags & SWB_USELAST) && !prevwin->w_p_wfb && win_valid(prevwin))
+	    if ((swb_flags & SWB_USELAST) && win_valid(prevwin) && !prevwin->w_p_wfb)
 		win = prevwin;
 	    else if (altwin != NULL)
 		win = altwin;

--- a/src/testdir/test_winfixbuf.vim
+++ b/src/testdir/test_winfixbuf.vim
@@ -1576,6 +1576,7 @@ endfunc
 
 " Fail vim.command if we try to change buffers while 'winfixbuf' is set
 func Test_lua_command()
+  CheckFeature lua
   call s:reset_all_buffers()
 
   enew
@@ -3129,3 +3130,21 @@ func Test_wprevious()
   call delete("middle")
   call delete("last")
 endfunc
+
+func Test_quickfix_switchbuf_invalid_prevwin()
+  call s:reset_all_buffers()
+
+  let [l:first, _] = s:make_simple_quickfix()
+  call assert_notequal(l:first, bufnr())
+  call assert_equal(1, winnr('$'))
+
+  set switchbuf=uselast
+  split
+  copen
+  execute winnr('#') 'quit'
+
+  call assert_fails('cfirst', 'E1513:')
+  set switchbuf&
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: qf_goto_win_with_qfl_file may check if prevwin has 'winfixbuf' set without checking if it's valid first.

Solution: fix the condition. Add a test, a modeline, and a missing CheckFeature.