### PR TITLE
Check SHM_FILEINFO when autoread

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7253,7 +7253,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  q	use "recording" instead of "recording @a"		*shm-q*
 	  F	don't give the file info when editing a file, like	*shm-F*
 		`:silent` was used for the command; note that this also
-		affects messages from autocommands
+		affects messages from autocommands and 'autoread' reloading.
 	  S	do not show search count message when searching, e.g.	*shm-S*
 		"[1/5]"
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4344,7 +4344,7 @@ buf_check_timestamp(
 	    }
 	    else
 	    {
-		if (!autocmd_busy)
+		if (!autocmd_busy && !shortmess(SHM_FILEINFO))
 		{
 		    msg_start();
 		    msg_puts_attr(tbuf, HL_ATTR(HLF_E) + MSG_HIST);

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4294,7 +4294,7 @@ buf_check_timestamp(
 #endif
     }
 
-    if (mesg != NULL)
+    if (mesg != NULL && !shortmess(SHM_FILEINFO))
     {
 	path = home_replace_save(buf, buf->b_fname);
 	if (path != NULL)
@@ -4344,7 +4344,7 @@ buf_check_timestamp(
 	    }
 	    else
 	    {
-		if (!autocmd_busy && !shortmess(SHM_FILEINFO))
+		if (!autocmd_busy)
 		{
 		    msg_start();
 		    msg_puts_attr(tbuf, HL_ATTR(HLF_E) + MSG_HIST);

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1293,6 +1293,24 @@ func Test_shortmess_F2()
   call assert_fails('call test_getvalue("abc")', 'E475:')
 endfunc
 
+func Test_shortmess_F3()
+  defer delete('X_dummy')
+  set hidden
+  e X_dummy
+  e file
+  set shortmess+=FO
+  call writefile(["foo"], 'X_dummy')
+  call assert_true(empty(execute('bn', '')))
+  call assert_true(empty(execute('bn', '')))
+  set shortmess&
+  set hidden&
+  call writefile(["bar"], 'X_dummy')
+  call assert_match('X_dummy', execute('bn', ''))
+  call assert_match('file', execute('bn', ''))
+  bwipe
+  bwipe
+endfunc
+
 func Test_local_scrolloff()
   set so=5
   set siso=7

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1295,18 +1295,20 @@ endfunc
 
 func Test_shortmess_F3()
   defer delete('X_dummy')
+
   set hidden
+  set autoread
   e X_dummy
   e file
-  set shortmess+=FO
+
+  set shortmess+=F
   call writefile(["foo"], 'X_dummy')
   call assert_true(empty(execute('bn', '')))
   call assert_true(empty(execute('bn', '')))
+
   set shortmess&
+  set autoread&
   set hidden&
-  call writefile(["bar"], 'X_dummy')
-  call assert_match('X_dummy', execute('bn', ''))
-  call assert_match('file', execute('bn', ''))
   bwipe
   bwipe
 endfunc

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1757,9 +1757,6 @@ func Test_visual_getregion()
     call assert_equal([], getregion(getpos('.'), getpos("'A"), {'type': 'v' }))
     call assert_equal([], getregion(getpos("'A"), getpos('.'), {'type': 'v' }))
     exe $':{newbuf}bwipe!'
-
-    #" using invalid buffer
-    call assert_equal([], getregion([10000, 10, 1, 0], [10000, 10, 1, 0]))
   END
   call v9.CheckLegacyAndVim9Success(lines)
 

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1757,6 +1757,9 @@ func Test_visual_getregion()
     call assert_equal([], getregion(getpos('.'), getpos("'A"), {'type': 'v' }))
     call assert_equal([], getregion(getpos("'A"), getpos('.'), {'type': 'v' }))
     exe $':{newbuf}bwipe!'
+
+    #" using invalid buffer
+    call assert_equal([], getregion([10000, 10, 1, 0], [10000, 10, 1, 0]))
   END
   call v9.CheckLegacyAndVim9Success(lines)
 


### PR DESCRIPTION
When autoread, the file info message is displayed.
But it is not disabled when `set shortmess+=F`.

I have fixed it.