### PR TITLE
Text properties corrupted with fo+=aw and backspace

### DIFF
--- a/src/testdir/test_comments.vim
+++ b/src/testdir/test_comments.vim
@@ -237,6 +237,12 @@ func Test_comment_autoformat()
   call feedkeys("aone\ntwo\n", 'xt')
   call assert_equal(['one', 'two', ''], getline(1, '$'))
 
+  set backspace=indent,eol,start
+  %d
+  call feedkeys("aone \n\<BS>", 'xt')
+  call assert_equal(['one'], getline(1, '$'))
+  set backspace&
+
   close!
 endfunc
 

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -4466,4 +4466,23 @@ func Test_textprop_notype_join()
   bwipe!
 endfunc
 
+" This was causing text property corruption.
+func Test_textprop_backspace_fo_aw()
+  new
+  call setline(1, 'foobar')
+  call prop_type_add('test', {'highlight': 'ErrorMsg'})
+  call prop_add(1, 1, {'type': 'test', 'length': 3})
+  set backspace=indent,eol,start
+  setlocal formatoptions+=aw
+  call feedkeys("A \<CR>\<BS>\<Esc>", 'tx')
+  call assert_equal('foobar', getline(1))
+  call assert_equal([
+        \ #{id: 0, col: 1, start: 1, end: 1, type_bufnr: 0,
+        \   type: 'test', length: 3}], prop_list(1))
+
+  bwipe!
+  set backspace&
+  call prop_type_delete('test')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Text properties corrupted with fo+=aw and backspace.
Solution: Allocate line and move text properties.
