### PR TITLE
Make 'wfb' failing to split still report E1513, fix CI failures

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -475,13 +475,12 @@ ex_listdo(exarg_T *eap)
 	{
 	    // Split the window, which will be 'nowinfixbuf', and set curwin to
 	    // that
-	    if (win_split(0, 0) == FAIL)
-		return; // error message already given
+	    (void)win_split(0, 0);
 
 	    if (curwin->w_p_wfb)
 	    {
 		// Autocommands set 'winfixbuf' or sent us to another window
-		// with it set.  Give up.
+		// with it set, or we failed to split the window.  Give up.
 		emsg(_(e_winfixbuf_cannot_go_to_buffer));
 		return;
 	    }

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3293,8 +3293,9 @@ qf_jump_edit_buffer(
 		if (curwin->w_p_wfb)
 		{
 		    // Autocommands set 'winfixbuf' or sent us to another window
-		    // with it set.  Give up, but don't return immediately, as
-		    // they may have messed with the list.
+		    // with it set, or we failed to split the window.  Give up,
+		    // but don't return immediately, as they may have messed
+		    // with the list.
 		    emsg(_(e_winfixbuf_cannot_go_to_buffer));
 		    retval = FAIL;
 		}

--- a/src/testdir/test_winfixbuf.vim
+++ b/src/testdir/test_winfixbuf.vim
@@ -479,6 +479,9 @@ endfunc
 
 " Fail :browse edit but :browse edit! is allowed
 func Test_browse_edit_fail()
+  " A GUI dialog may stall the test.
+  CheckNotGui
+
   call s:reset_all_buffers()
 
   let l:other = s:make_buffer_pairs()
@@ -487,18 +490,31 @@ func Test_browse_edit_fail()
   call assert_fails("browse edit other", "E1513:")
   call assert_equal(l:current, bufnr())
 
-  browse edit! other
-  call assert_equal(l:other, bufnr())
+  try
+    browse edit! other
+    call assert_equal(l:other, bufnr())
+  catch /E338:/
+    " Ignore E338, which occurs if console Vim is built with +browse.
+    " Console Vim without +browse will treat this as a regular :edit.
+  endtry
 endfunc
 
 " Allow :browse w because it doesn't change the buffer in the current file
 func Test_browse_edit_pass()
+  " A GUI dialog may stall the test.
+  CheckNotGui
+
   call s:reset_all_buffers()
 
   let l:other = s:make_buffer_pairs()
   let l:current = bufnr()
 
-  browse write other
+  try
+    browse write other
+  catch /E338:/
+    " Ignore E338, which occurs if console Vim is built with +browse.
+    " Console Vim without +browse will treat this as a regular :write.
+  endtry
 
   call delete("other")
 endfunc
@@ -1145,6 +1161,7 @@ func Test_find()
   let l:current = bufnr()
   let l:file = tempname()
   call writefile([], l:file)
+  let l:file = fnamemodify(l:file, ':p')  " In case it's Windows 8.3-style.
   let l:directory = fnamemodify(l:file, ":p:h")
   let l:name = fnamemodify(l:file, ":p:t")
 
@@ -1514,6 +1531,7 @@ func Test_lnfile()
   call assert_equal(l:current, bufnr())
 
   call assert_fails("lnfile", "E1513:")
+  " Ensure the entry didn't change.
   call assert_equal(2, getloclist(0, #{idx: 0}).idx)
   call assert_equal(l:current, bufnr())
 
@@ -2490,8 +2508,8 @@ func Test_previous()
   call assert_equal(l:first, bufnr())
 endfunc
 
-" Fail pydo if it changes a window with 'winfixbuf' is set
-func Test_python_pydo()
+" Fail pyxdo if it changes a window with 'winfixbuf' is set
+func Test_pythonx_pyxdo()
   CheckFeature pythonx
   call s:reset_all_buffers()
 
@@ -2504,17 +2522,17 @@ func Test_python_pydo()
 
   set winfixbuf
 
-  python << EOF
+  pythonx << EOF
 import vim
 
-def test_winfixbuf_Test_python_pydo_set_buffer():
+def test_winfixbuf_Test_pythonx_pyxdo_set_buffer():
     buffer = vim.vars['_previous_buffer']
     vim.current.buffer = vim.buffers[buffer]
 EOF
 
   try
-    pydo test_winfixbuf_Test_python_pydo_set_buffer()
-  catch /Vim(pydo):vim.error: Vim:E1513: Cannot edit buffer. 'winfixbuf' is enabled/
+    pyxdo test_winfixbuf_Test_pythonx_pyxdo_set_buffer()
+  catch /Vim(pyxdo):vim.error: Vim:E1513: Cannot edit buffer. 'winfixbuf' is enabled/
     let l:caught = 1
   endtry
 
@@ -2523,8 +2541,8 @@ EOF
   unlet g:_previous_buffer
 endfunc
 
-" Fail pyfile if it changes a window with 'winfixbuf' is set
-func Test_python_pyfile()
+" Fail pyxfile if it changes a window with 'winfixbuf' is set
+func Test_pythonx_pyxfile()
   CheckFeature pythonx
   call s:reset_all_buffers()
 
@@ -2544,8 +2562,8 @@ func Test_python_pyfile()
         \ "file.py")
 
   try
-    pyfile file.py
-  catch /Vim(pyfile):vim.error: Vim:E1513: Cannot edit buffer. 'winfixbuf' is enabled/
+    pyxfile file.py
+  catch /Vim(pyxfile):vim.error: Vim:E1513: Cannot edit buffer. 'winfixbuf' is enabled/
     let l:caught = 1
   endtry
 
@@ -2556,7 +2574,7 @@ func Test_python_pyfile()
 endfunc
 
 " Fail vim.current.buffer if 'winfixbuf' is set
-func Test_python_vim_current_buffer()
+func Test_pythonx_vim_current_buffer()
   CheckFeature pythonx
   call s:reset_all_buffers()
 
@@ -2572,13 +2590,13 @@ func Test_python_vim_current_buffer()
   set winfixbuf
 
   try
-    python << EOF
+    pythonx << EOF
 import vim
 
 buffer = vim.vars["_previous_buffer"]
 vim.current.buffer = vim.buffers[buffer]
 EOF
-  catch /Vim(python):vim\.error: Vim:E1513: Cannot edit buffer. 'winfixbuf' is enabled/
+  catch /Vim(pythonx):vim\.error: Vim:E1513: Cannot edit buffer. 'winfixbuf' is enabled/
     let l:caught = 1
   endtry
 
@@ -3248,14 +3266,20 @@ func Test_quickfix_changed_split_failed()
   augroup! QfChanged
 endfunc
 
-func Test_bufdo_splitwin_fails()
+func Test_bufdo_cnext_splitwin_fails()
   call s:reset_all_buffers()
-  let other = s:make_buffer_pairs()
+  call s:make_simple_quickfix()
+  call assert_equal(1, getqflist(#{idx: 0}).idx)
   " Make sure there is not enough room to
   " split the winfixedbuf window
   let &winheight=&lines
   let &winminheight=&lines-2
-  call assert_fails(':bufdo echo 1', 'E36:')
+  " Still want E1513, or it may not be clear why a split was attempted and why
+  " it failing caused the commands to abort.
+  call assert_fails(':bufdo echo 1', ['E36:', 'E1513:'])
+  call assert_fails(':cnext', ['E36:', 'E1513:'])
+  " Ensure the entry didn't change.
+  call assert_equal(1, getqflist(#{idx: 0}).idx)
   set winminheight&vim winheight&vim
 endfunc
 


### PR DESCRIPTION
Problem: may not be clear why failing to split causes an `:Xdo` command to abort if 'wfb' is set.

Solution: do not return immediately if win_split fails, so E1513 is still given. Expect both errors in the test.

A follow up to my comment [here](https://github.com/vim/vim/commit/af7ae8160041e2d17c56945381e9370e7178e596#r139468883); hopefully this is OK. :+1:

Also fix the failures from testing test_winfixbuf on the CI. (Don't mind the one flaky test_normal.vim failure :innocent:)