### PR TITLE
Duplicate assignment in f_getregion()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4280,7 +4280,7 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		{pos1} and {pos2} must both be |List|s with four numbers.
 		See |getpos()| for the format of the list.  It's possible
 		to specify positions from a different buffer, but please
-		note the limitations at |getregion-notes|
+		note the limitations at |getregion-notes|.
 
 		The optional argument {opts} is a Dict and supports the
 		following items:
@@ -4314,9 +4314,9 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 		- If {pos1} and {pos2} are not in the same buffer, an empty
 		  list is returned.
 		- {pos1} and {pos2} must belong to a |bufloaded()| buffer.
-		- It is evaluated in current window context, this makes a
-		  different if a buffer is displayed in a different window and
-		  'virtualedit' or 'list' is set
+		- It is evaluated in current window context, which makes a
+		  difference if the buffer is displayed in a window with
+		  different 'virtualedit' or 'list' values.
 
 		Examples: >
 			:xnoremap <CR>

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5546,7 +5546,6 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 	// buffer not loaded
 	if (findbuf == NULL || findbuf->b_ml.ml_mfp == NULL)
 	    return;
-	save_curbuf = curbuf;
 	curbuf = findbuf;
     }
 

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -583,7 +583,7 @@ funct Test_undofile()
   endif
   call assert_equal('', undofile(''))
 
-  " Test undofile() with 'undodir' set to to an existing directory.
+  " Test undofile() with 'undodir' set to an existing directory.
   call mkdir('Xundodir')
   set undodir=Xundodir
   let cwd = getcwd()


### PR DESCRIPTION
Problem:  Duplicate assignment in f_getregion().
Solution: Remove the duplicate assignment.  Also improve getregion()
          docs wording and fix an unrelated typo.
