### PR TITLE
Calling STRLEN() to compute ml_line_textlen when not needed

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -1364,7 +1364,7 @@ del_bytes(
 	    mch_memmove(newp + newlen + 1, oldp + oldlen + 1,
 			       (size_t)curbuf->b_ml.ml_line_len - oldlen - 1);
 	curbuf->b_ml.ml_line_len -= count;
-	curbuf->b_ml.ml_line_textlen = (int)STRLEN(newp) + 1;
+	curbuf->b_ml.ml_line_textlen = 0;
     }
 #endif
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -5088,7 +5088,7 @@ ins_tab(void)
 			vim_free(curbuf->b_ml.ml_line_ptr);
 		    curbuf->b_ml.ml_line_ptr = newp;
 		    curbuf->b_ml.ml_line_len -= i;
-		    curbuf->b_ml.ml_line_textlen = (int)STRLEN(newp) + 1;
+		    curbuf->b_ml.ml_line_textlen = 0;
 		    curbuf->b_ml.ml_flags =
 			   (curbuf->b_ml.ml_flags | ML_LINE_DIRTY) & ~ML_EMPTY;
 		}

--- a/src/structs.h
+++ b/src/structs.h
@@ -802,8 +802,8 @@ typedef struct memline
 #define ML_ALLOCATED	0x10	// ml_line_ptr is an allocated copy
     int		ml_flags;
 
-    colnr_T	ml_line_len;	// length of the cached line + textproperties, including NUL
-    colnr_T	ml_line_textlen;// length of the cached line, including NUL
+    colnr_T	ml_line_len;	// length of the cached line + NUL + text properties
+    colnr_T	ml_line_textlen;// length of the cached line + NUL, 0 if not known yet
     linenr_T	ml_line_lnum;	// line number of cached line, 0 if not valid
     char_u	*ml_line_ptr;	// pointer to cached line
 


### PR DESCRIPTION
Problem:  Calling STRLEN() to compute ml_line_textlen when not needed.
Solution: Use 0 when STRLEN() will be required and call STRLEN() later.
