### PR TITLE
:checktime works when shortmess includes "F".

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1954,7 +1954,7 @@ enter_buffer(buf_T *buf)
 	    need_fileinfo = TRUE;	// display file info after redraw
 
 	// check if file changed
-	(void)buf_check_timestamp(curbuf, FALSE);
+	(void)buf_check_timestamp(curbuf, FALSE, FALSE);
 
 	curwin->w_topline = 1;
 #ifdef FEAT_DIFF

--- a/src/diff.c
+++ b/src/diff.c
@@ -890,7 +890,7 @@ diff_try_update(
 	{
 	    buf = curtab->tp_diffbuf[idx_new];
 	    if (buf_valid(buf))
-		buf_check_timestamp(buf, FALSE);
+		buf_check_timestamp(buf, FALSE, FALSE);
 	}
 
     // Write the first buffer to a tempfile or mmfile_t.

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2755,7 +2755,7 @@ do_ecmd(
 	{
 	    oldbuf = TRUE;
 	    set_bufref(&bufref, buf);
-	    (void)buf_check_timestamp(buf, FALSE);
+	    (void)buf_check_timestamp(buf, FALSE, FALSE);
 	    // Check if autocommands made the buffer invalid or changed the
 	    // current buffer.
 	    if (!bufref_valid(&bufref) || curbuf != old_curbuf.br_buf)
@@ -5497,7 +5497,7 @@ ex_drop(exarg_T *eap)
 
 		// reload the file if it is newer
 		curbuf->b_p_ar = TRUE;
-		buf_check_timestamp(curbuf, FALSE);
+		buf_check_timestamp(curbuf, FALSE, FALSE);
 		curbuf->b_p_ar = save_ar;
 	    }
 	    ex_rewind(eap);

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1023,7 +1023,7 @@ ex_checktime(exarg_T *eap)
     {
 	buf = buflist_findnr((int)eap->line2);
 	if (buf != NULL)	// cannot happen?
-	    (void)buf_check_timestamp(buf, FALSE);
+	    (void)buf_check_timestamp(buf, TRUE, FALSE);
     }
     no_check_timestamps = save_no_check_timestamps;
 }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4023,7 +4023,7 @@ check_timestamps(
 		bufref_T bufref;
 
 		set_bufref(&bufref, buf);
-		n = buf_check_timestamp(buf, focus);
+		n = buf_check_timestamp(buf, TRUE, focus);
 		if (didit < n)
 		    didit = n;
 		if (n > 0 && !bufref_valid(&bufref))
@@ -4102,6 +4102,7 @@ move_lines(buf_T *frombuf, buf_T *tobuf)
     int
 buf_check_timestamp(
     buf_T	*buf,
+    int		force,
     int		focus UNUSED)	// called for GUI focus event
 {
     stat_T	st;
@@ -4294,7 +4295,7 @@ buf_check_timestamp(
 #endif
     }
 
-    if (mesg != NULL && !shortmess(SHM_FILEINFO))
+    if (mesg != NULL && (!shortmess(SHM_FILEINFO) || force))
     {
 	path = home_replace_save(buf, buf->b_fname);
 	if (path != NULL)

--- a/src/proto/fileio.pro
+++ b/src/proto/fileio.pro
@@ -27,7 +27,7 @@ char_u *buf_modname(int shortname, char_u *fname, char_u *ext, int prepend_dot);
 int vim_fgets(char_u *buf, int size, FILE *fp);
 int vim_rename(char_u *from, char_u *to);
 int check_timestamps(int focus);
-int buf_check_timestamp(buf_T *buf, int focus);
+int buf_check_timestamp(buf_T *buf, int force, int focus);
 void buf_reload(buf_T *buf, int orig_mode, int reload_options);
 void buf_store_time(buf_T *buf, stat_T *st, char_u *fname);
 void write_lnum_adjust(linenr_T offset);

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1306,6 +1306,12 @@ func Test_shortmess_F3()
   call assert_true(empty(execute('bn', '')))
   call assert_true(empty(execute('bn', '')))
 
+  " :checktime works when shortmess includes "F".
+  e X_dummy
+  w!
+  call writefile(["bar"], 'X_dummy')
+  call assert_false(empty(execute('checktime', '')))
+
   set shortmess&
   set autoread&
   set hidden&


### PR DESCRIPTION
Fix https://github.com/vim/vim/pull/14144 regression