### PR TITLE
'shortmess' "F" flag doesn't work properly with 'autoread'

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4294,7 +4294,7 @@ buf_check_timestamp(
 #endif
     }
 
-    if (mesg != NULL && !shortmess(SHM_FILEINFO))
+    if (mesg != NULL)
     {
 	path = home_replace_save(buf, buf->b_fname);
 	if (path != NULL)
@@ -4489,8 +4489,14 @@ buf_reload(buf_T *buf, int orig_mode, int reload_options)
 
 	if (saved == OK)
 	{
+	    int old_msg_silent = msg_silent;
+
 	    curbuf->b_flags |= BF_CHECK_RO;	// check for RO again
 	    keep_filetype = TRUE;		// don't detect 'filetype'
+
+	    if (shortmess(SHM_FILEINFO))
+		msg_silent = 1;
+
 	    if (readfile(buf->b_ffname, buf->b_fname, (linenr_T)0,
 			(linenr_T)0,
 			(linenr_T)MAXLNUM, &ea, flags) != OK)
@@ -4521,6 +4527,8 @@ buf_reload(buf_T *buf, int orig_mode, int reload_options)
 		    u_unchanged(curbuf);
 		}
 	    }
+
+	    msg_silent = old_msg_silent;
 	}
 	vim_free(ea.cmd);
 

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1294,23 +1294,41 @@ func Test_shortmess_F2()
 endfunc
 
 func Test_shortmess_F3()
-  defer delete('X_dummy')
+  call writefile(['foo'], 'X_dummy', 'D')
 
   set hidden
   set autoread
   e X_dummy
-  e file
-
+  e Xotherfile
+  call assert_equal(['foo'], getbufline('X_dummy', 1, '$'))
   set shortmess+=F
-  call writefile(["foo"], 'X_dummy')
-  call assert_true(empty(execute('bn', '')))
-  call assert_true(empty(execute('bn', '')))
+  echo ''
+
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
+  call writefile(['bar'], 'X_dummy')
+  bprev
+  call assert_equal('', Screenline(&lines))
+  call assert_equal(['bar'], getbufline('X_dummy', 1, '$'))
+
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
+  call writefile(['baz'], 'X_dummy')
+  checktime
+  call assert_equal('', Screenline(&lines))
+  call assert_equal(['baz'], getbufline('X_dummy', 1, '$'))
 
   set shortmess&
   set autoread&
   set hidden&
-  bwipe
-  bwipe
+  bwipe X_dummy
+  bwipe Xotherfile
 endfunc
 
 func Test_local_scrolloff()


### PR DESCRIPTION
Problem:  'shortmess' "F" flag doesn't work properly with 'autoread'.
Solution: Hide the file info message instead of the warning dialog.
