### PR TITLE
expand() removes slash after env variable that ends with colon

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1404,9 +1404,6 @@ expand_env_esc(
     int		mustfree;	// var was allocated, need to free it later
     int		at_start = TRUE; // at start of a name
     int		startstr_len = 0;
-#if defined(BACKSLASH_IN_FILENAME) || defined(AMIGA)
-    char_u	*save_dst = dst;
-#endif
 
     if (startstr != NULL)
 	startstr_len = (int)STRLEN(startstr);
@@ -1631,7 +1628,7 @@ expand_env_esc(
 		// with it, skip a character
 		if (after_pathsep(dst, dst + c)
 #if defined(BACKSLASH_IN_FILENAME) || defined(AMIGA)
-			&& (dst == save_dst || dst[-1] != ':')
+			&& dst[c - 1] != ':'
 #endif
 			&& vim_ispathsep(*tail))
 		    ++tail;

--- a/src/testdir/test_expand.vim
+++ b/src/testdir/test_expand.vim
@@ -51,6 +51,19 @@ func Test_expand_tilde_filename()
   bwipe!
 endfunc
 
+func Test_expand_env_pathsep()
+  let $FOO = './foo'
+  call assert_equal('./foo/bar', expand('$FOO/bar'))
+  let $FOO = './foo/'
+  call assert_equal('./foo/bar', expand('$FOO/bar'))
+  let $FOO = 'C:'
+  call assert_equal('C:/bar', expand('$FOO/bar'))
+  let $FOO = 'C:/'
+  call assert_equal('C:/bar', expand('$FOO/bar'))
+
+  unlet $FOO
+endfunc
+
 func Test_expandcmd()
   let $FOO = 'Test'
   call assert_equal('e x/Test/y', expandcmd('e x/$FOO/y'))


### PR DESCRIPTION
Problem:  expand() removes a slash after an environment variable that
          ends with a colon on Windows.
Solution: Check the correct char for a colon.
