### PR TITLE
Add support for using a class type of itself in an object method

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -3830,7 +3830,7 @@ set_var(
  * If the variable already exists and "is_const" is FALSE the value is updated.
  * Otherwise the variable is created.
  */
-    void
+    int
 set_var_const(
     char_u	*name,
     scid_T	sid,
@@ -3854,6 +3854,7 @@ set_var_const(
     int		var_in_autoload = FALSE;
     int		flags = flags_arg;
     int		free_tv_arg = !copy;  // free tv_arg if not used
+    int		rc = FAIL;
 
     if (sid != 0)
     {
@@ -4127,10 +4128,14 @@ set_var_const(
 	// values.
 	item_lock(dest_tv, DICT_MAXNEST, TRUE, TRUE);
 
+    rc = OK;
+
 failed:
     vim_free(name_tofree);
     if (free_tv_arg)
 	clear_tv(tv_arg);
+
+    return rc;
 }
 
 /*

--- a/src/proto/evalvars.pro
+++ b/src/proto/evalvars.pro
@@ -77,7 +77,7 @@ void vars_clear_ext(hashtab_T *ht, int free_val);
 void delete_var(hashtab_T *ht, hashitem_T *hi);
 int before_set_vvar(char_u *varname, dictitem_T *di, typval_T *tv, int copy, int *type_error);
 void set_var(char_u *name, typval_T *tv, int copy);
-void set_var_const(char_u *name, scid_T sid, type_T *type_arg, typval_T *tv_arg, int copy, int flags_arg, int var_idx);
+int set_var_const(char_u *name, scid_T sid, type_T *type_arg, typval_T *tv_arg, int copy, int flags_arg, int var_idx);
 int var_check_permission(dictitem_T *di, char_u *name);
 int var_check_ro(int flags, char_u *name, int use_gettext);
 int var_check_lock(int flags, char_u *name, int use_gettext);

--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -301,7 +301,7 @@ func GetVimCommand(...)
   let cmd .= ' --not-a-term'
   let cmd .= ' --gui-dialog-file guidialogfile'
   " remove any environment variables
-  let cmd = substitute(cmd, '[A-Z_]*=\S\+ *', '', 'g')
+  let cmd = substitute(cmd, '[A-Z_]\+=\S\+ *', '', 'g')
 
   " If using valgrind, make sure every run uses a different log file.
   if cmd =~ 'valgrind.*--log-file='


### PR DESCRIPTION
Create the script-local variable for the class before parsing the contents of the class.  Fixes #12369.

Also, fix a regression issue introduced by 627c950e5b30503a084bd0092f9cb2a5fe73fe87 (9.1.0091)
in using valgrind for running the tests.