### PR TITLE
Check listxattr's return value for failure

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -3048,7 +3048,7 @@ mch_copy_sec(char_u *from_file, char_u *to_file)
 
     size = listxattr((char *)from_file, NULL, 0);
     // not supported or no attributes to copy
-    if (errno == ENOTSUP || size == 0)
+    if (size <= 0)
 	return;
 
     for (index = 0 ; index < (int)(sizeof(smack_copied_attributes)
@@ -3112,8 +3112,8 @@ mch_copy_sec(char_u *from_file, char_u *to_file)
 mch_copy_xattr(char_u *from_file, char_u *to_file)
 {
     char	*xattr_buf;
-    size_t	size;
-    size_t	tsize;
+    ssize_t	size;
+    ssize_t	tsize;
     ssize_t	keylen, vallen, max_vallen = 0;
     char	*key;
     char	*val = NULL;
@@ -3125,7 +3125,7 @@ mch_copy_xattr(char_u *from_file, char_u *to_file)
     // get the length of the extended attributes
     size = listxattr((char *)from_file, NULL, 0);
     // not supported or no attributes to copy
-    if (errno == ENOTSUP || size == 0)
+    if (size <= 0)
 	return;
     xattr_buf = (char*)alloc(size);
     if (xattr_buf == NULL)


### PR DESCRIPTION
The existing logic will return when the listxattr call returns with the errno set to ENOTSUP (or a size of 0 bytes), without checking to see if listxattr actually failed. listxattr can fail with at least E2BIG, ENOTSUP, ERANGE, or anything that `stat(2)` can fail with (in my case; ENOENT from stat).

The returned size is stored to a size_t, but the return type is a ssize_t. On failure, listxattr returns -1, which will get translated to size_t's MAX. If the listxattr call failed with anything other than ENOTSUP, this triggers a request for size_t MAX bytes.

This means that, if the listxattr call fails with anything other than ENOTSUP on save, vim will error with

`E342: Out of memory!  (allocating 18446744073709551615 bytes)`

(keen observers will note 18446744073709551615 is 0xffffffffffffffff)

In reality, this is likely masking a different (usually filesystem?) error -- but at least it's an error being pushed to the user now, and we don't try to allocate size_t MAX bytes.

I've opted to change the type that we store listxattr to from size_t to ssize_t, to match listxattr(2)'s signature, and to check for the -1 return value. Additionally, I've removed the errno check -- if we get a listxattr failure for any reason, we may as well bail without trying; it's not like we can even recover.