### PR TITLE
Add Vim function 'searchstr()'

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -518,6 +518,8 @@ searchpairpos({start}, {middle}, {end} [, {flags} [, {skip} [...]]])
 				List	search for other end of start/end pair
 searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 				List	search for {pattern}
+searchstr({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
+				String	get string matching {pattern}
 server2client({clientid}, {string})
 				Number	send reply string
 serverlist()			String	get a list of available servers
@@ -8343,6 +8345,11 @@ searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 
 		Can also be used as a |method|: >
 			GetPattern()->searchpos()
+searchstr({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
+		Same as |search()|, but returns a matching string when found.
+		Example: >
+	:let year_suffix = searchstr('\<\d\{4\}[a-z]\?', 'n')
+
 
 server2client({clientid}, {string})			*server2client()*
 		Send a reply string to {clientid}.  The most recent {clientid}

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -195,6 +195,7 @@ New and extended functions: ~
 |readdirex()|		get a List of file information in a directory
 |reduce()|		reduce a List to a value
 |searchcount()|		get number of matches before/after the cursor
+|searchstr()|		get string that matches the pattern
 |setcellwidths()|	set character cell width overrides
 |setcharpos()|		set character position of cursor, mark, etc.
 |setcursorcharpos()|	set character position of the cursor

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -148,10 +148,10 @@ static void f_screencol(typval_T *argvars, typval_T *rettv);
 static void f_screenrow(typval_T *argvars, typval_T *rettv);
 static void f_screenstring(typval_T *argvars, typval_T *rettv);
 static void f_search(typval_T *argvars, typval_T *rettv);
-static void f_searchstr(typval_T *argvars, typval_T *rettv);
 static void f_searchdecl(typval_T *argvars, typval_T *rettv);
 static void f_searchpair(typval_T *argvars, typval_T *rettv);
 static void f_searchpairpos(typval_T *argvars, typval_T *rettv);
+static void f_searchstr(typval_T *argvars, typval_T *rettv);
 static void f_searchpos(typval_T *argvars, typval_T *rettv);
 static void f_setcharpos(typval_T *argvars, typval_T *rettv);
 static void f_setcharsearch(typval_T *argvars, typval_T *rettv);
@@ -9853,7 +9853,7 @@ f_searchstr(typval_T *argvars, typval_T *rettv)
     rettv->v_type = VAR_STRING;
 
     rettv->vval.v_number = search_cmn(argvars, &match_pos, &end_pos, &flags);
-    
+
     if (rettv->vval.v_number > 0)
     {
     match_pos.col -= 1; // search_cmn increments match start col by 1, adjust it for ml_get_pos.

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -2194,5 +2194,13 @@ func Test_search_with_invalid_range()
   bwipe!
 endfunc
 
+func Test_searchstr()
+  new
+  call setline(1, ['  1', '  2 these', '  3 the', '  4 their', '  5 there', '  6 their', '  7 the', '  8 them', '  9 these', ' 10 foobar'])
+  call assert_equal("2 these\n  3", searchstr('\<2\s\+\_.*3\>'))
+  
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -2198,7 +2198,7 @@ func Test_searchstr()
   new
   call setline(1, ['  1', '  2 these', '  3 the', '  4 their', '  5 there', '  6 their', '  7 the', '  8 them', '  9 these', ' 10 foobar'])
   call assert_equal("2 these\n  3", searchstr('\<2\s\+\_.*3\>'))
-  
+
   bwipe!
 endfunc
 


### PR DESCRIPTION
Add a Vim function `searchstr()` which returns matched string. Same as `search()` function in all other aspects.

There are no easy options to get a matched string in Vimscript otherwise, see [1] for some adhoc solutions.

[1] https://vi.stackexchange.com/questions/4305/is-it-possible-to-get-the-matched-string-after-calling-search

NB: This is my first contribution to Vim and I'm sure I've overlooked many things; and there are better ways to accomplish the functionality. Reviews are very welcome. Once the approach is finalized, I intend to add a `searchlist()` function too, which returns a list of all matches.