### PR TITLE
Importing an autoload imported script fails.  Return the script ID of the imported script.

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1690,6 +1690,8 @@ do_source_ext(
 	    // reset version, "vim9script" may have been added or removed.
 	    si->sn_version = 1;
 	}
+	if (ret_sid != NULL)
+	    *ret_sid = sid;
     }
     else
     {


### PR DESCRIPTION
Fixes #14171.