### PR TITLE
runtime(doc): improve 'winfixbuf' docs

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.1.  Last change: 2024 Mar 06
+*options.txt*	For Vim version 9.1.  Last change: 2024 Mar 11
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -333,6 +333,7 @@ created, thus they behave slightly differently:
 	Option		Reason	~
 	'previewwindow'	there can only be a single one
 	'scroll'	specific to existing window
+	'winfixbuf'	specific to existing window
 	'winfixheight'	specific to existing window
 	'winfixwidth'	specific to existing window
 
@@ -9476,11 +9477,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'winfixbuf'*
 'winfixbuf' 'wfb'	boolean	(default off)
 			local to window
-	If enabled, the buffer and any window that displays it are paired.
+	If enabled, the window and the buffer it is displaying are paired.
 	For example, attempting to change the buffer with |:edit| will fail.
 	Other commands which change a window's buffer such as |:cnext| will
-	also skip any window with 'winfixbuf' enabled. However if a command
-	has an "!" option, a window can be forced to switch buffers.
+	also skip any window with 'winfixbuf' enabled.  However if an Ex
+	command has a "!" modifier, it can force switching buffers.
 
 			*'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*
 'winfixheight' 'wfh'	boolean	(default off)


### PR DESCRIPTION
- Make it not sound like a buffer option.
- "!" is called a modifier, not an option.
