### PR TITLE
Fix a win_execute issue, re-allow curwin == prevwin

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -10947,7 +10947,8 @@ winnr([{arg}])	The result is a Number, which is the number of the current
 			#	the number of the last accessed window (where
 				|CTRL-W_p| goes to).  If there is no previous
 				window or it is in another tab page 0 is
-				returned.
+				returned.  May refer to the current window in
+				some cases.
 			{N}j	the number of the Nth window below the
 				current window (where |CTRL-W_j| goes to).
 			{N}k	the number of the Nth window above the current

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -1351,13 +1351,8 @@ switch_win_noblock(
 	switchwin->sw_curtab = curtab;
 	if (no_display)
 	{
-	    curtab->tp_firstwin = firstwin;
-	    curtab->tp_lastwin = lastwin;
-	    curtab->tp_topframe = topframe;
-	    curtab = tp;
-	    firstwin = curtab->tp_firstwin;
-	    lastwin = curtab->tp_lastwin;
-	    topframe = curtab->tp_topframe;
+	    unuse_tabpage(curtab);
+	    use_tabpage(tp);
 	}
 	else
 	    goto_tabpage_tp(tp, FALSE, FALSE);
@@ -1395,13 +1390,12 @@ restore_win_noblock(
     {
 	if (no_display)
 	{
-	    curtab->tp_firstwin = firstwin;
-	    curtab->tp_lastwin = lastwin;
-	    curtab->tp_topframe = topframe;
-	    curtab = switchwin->sw_curtab;
-	    firstwin = curtab->tp_firstwin;
-	    lastwin = curtab->tp_lastwin;
-	    topframe = curtab->tp_topframe;
+	    win_T	*old_tp_curwin = curtab->tp_curwin;
+
+	    unuse_tabpage(curtab);
+	    // Don't change the curwin of the tabpage we temporarily visited.
+	    curtab->tp_curwin = old_tp_curwin;
+	    use_tabpage(switchwin->sw_curtab);
 	}
 	else
 	    goto_tabpage_tp(switchwin->sw_curtab, FALSE, FALSE);

--- a/src/globals.h
+++ b/src/globals.h
@@ -976,7 +976,7 @@ EXTERN int	clip_unnamed_saved INIT(= 0);
  */
 EXTERN win_T	*firstwin;		// first window
 EXTERN win_T	*lastwin;		// last window
-EXTERN win_T	*prevwin INIT(= NULL);	// previous window
+EXTERN win_T	*prevwin INIT(= NULL);	// previous window (may equal curwin)
 #define ONE_WINDOW (firstwin == lastwin)
 #define W_NEXT(wp) ((wp)->w_next)
 

--- a/src/testdir/test_execute_func.vim
+++ b/src/testdir/test_execute_func.vim
@@ -204,4 +204,28 @@ func Test_execute_func_with_null()
   endif
 endfunc
 
+func Test_win_execute_tabpagewinnr()
+  belowright split
+  tab split
+  belowright split
+  call assert_equal(2, tabpagewinnr(1))
+
+  tabprevious
+  wincmd p
+  call assert_equal(1, tabpagenr())
+  call assert_equal(1, tabpagewinnr(1))
+  call assert_equal(2, tabpagewinnr(2))
+
+  call win_execute(win_getid(1, 2),
+        \      'call assert_equal(2, tabpagenr())'
+        \ .. '| call assert_equal(1, tabpagewinnr(1))'
+        \ .. '| call assert_equal(1, tabpagewinnr(2))')
+
+  call assert_equal(1, tabpagenr())
+  call assert_equal(1, tabpagewinnr(1))
+  call assert_equal(2, tabpagewinnr(2))
+
+  %bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -131,64 +131,6 @@ func Test_window_quit()
   bw Xa Xb
 endfunc
 
-func Test_window_curwin_not_prevwin()
-  botright split
-  call assert_equal(2, winnr())
-  call assert_equal(1, winnr('#'))
-  quit
-  call assert_equal(1, winnr())
-  call assert_equal(0, winnr('#'))
-
-  botright split
-  botright split
-  call assert_equal(3, winnr())
-  call assert_equal(2, winnr('#'))
-  1quit
-  call assert_equal(2, winnr())
-  call assert_equal(1, winnr('#'))
-
-  botright split
-  call assert_equal(1, tabpagenr())
-  call assert_equal(3, winnr())
-  call assert_equal(2, winnr('#'))
-  wincmd T
-  call assert_equal(2, tabpagenr())
-  call assert_equal(1, winnr())
-  call assert_equal(0, winnr('#'))
-  tabfirst
-  call assert_equal(1, tabpagenr())
-  call assert_equal(2, winnr())
-  call assert_equal(0, winnr('#'))
-
-  tabonly
-  botright split
-  wincmd t
-  wincmd p
-  call assert_equal(3, winnr())
-  call assert_equal(1, winnr('#'))
-  quit
-  call assert_equal(2, winnr())
-  call assert_equal(1, winnr('#'))
-
-  botright split
-  wincmd t
-  wincmd p
-  call assert_equal(1, tabpagenr())
-  call assert_equal(3, winnr())
-  call assert_equal(1, winnr('#'))
-  wincmd T
-  call assert_equal(2, tabpagenr())
-  call assert_equal(1, winnr())
-  call assert_equal(0, winnr('#'))
-  tabfirst
-  call assert_equal(1, tabpagenr())
-  call assert_equal(2, winnr())
-  call assert_equal(1, winnr('#'))
-
-  tabonly
-  only
-endfunc
-
 func Test_window_horizontal_split()
   call assert_equal(1, winnr('$'))
   3wincmd s

--- a/src/window.c
+++ b/src/window.c
@@ -5526,15 +5526,11 @@ win_enter_ext(win_T *wp, int flags)
     // may have to copy the buffer options when 'cpo' contains 'S'
     if (wp->w_buffer != curbuf)
 	buf_copy_options(wp->w_buffer, BCO_ENTER | BCO_NOHELP);
-
     if (curwin_invalid == 0)
     {
 	prevwin = curwin;	// remember for CTRL-W p
 	curwin->w_redr_status = TRUE;
     }
-    else if (wp == prevwin)
-	prevwin = NULL;		// don't want it to be the new curwin
-
     curwin = wp;
     curbuf = wp->w_buffer;
     check_cursor();


### PR DESCRIPTION
Details are in the commit messages. Hopefully it's OK. :+1:

If the 2nd commit is merged, #14047 should be closed.

_**Note**: alternatively, I have a patch [here](https://github.com/seandewar/vim/commit/d243d6595f601f407f073ecbb0da9531af578723) that addresses the cases mentioned in the last bullet in the 2nd commit's message, if preferred._