### PR TITLE
Makefile for running indent tests on OS Windows.

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -1,8 +1,8 @@
 # List of distributed Vim files.
 # Used by Makefile.
 
-# Files of Git and GitHub.
-FILE_GIT =	\
+# Source files for all source archives.
+SRC_ALL =	\
 		.cirrus.yml \
 		.gitattributes \
 		.github/CODEOWNERS \
@@ -21,11 +21,6 @@ FILE_GIT =	\
 		ci/if_ver*.vim \
 		ci/setup-xvfb.sh \
 		ci/remove_snap.sh \
-		src/libvterm/.bzrignore \
-		src/libvterm/.gitignore \
-
-# The source code itself is for all source archives.
-BARE_SRC_ALL = \
 		src/Make_all.mak \
 		src/README.md \
 		src/alloc.c \
@@ -343,7 +338,10 @@ BARE_SRC_ALL = \
 		src/proto/viminfo.pro \
 		src/proto/winclip.pro \
 		src/proto/window.pro \
+		src/libvterm/.bzrignore \
+		src/libvterm/.gitignore \
 		src/libvterm/LICENSE \
+		src/libvterm/Makefile \
 		src/libvterm/README \
 		src/libvterm/CONTRIBUTING \
 		src/libvterm/tbl2inc_c.pl \
@@ -431,11 +429,6 @@ BARE_SRC_ALL = \
 		src/xdiff/xutils.c \
 		src/xdiff/xutils.h \
 
-# Source files for all source archives.
-SRC_ALL =	\
-		$(FILE_GIT) \
-		$(BARE_SRC_ALL) \
-
 
 # Source files for Unix-like only.
 SRC_UNIX =	\
@@ -483,7 +476,6 @@ SRC_UNIX =	\
 		src/osdef1.h.in \
 		src/osdef2.h.in \
 		src/pathdef.sh \
-		src/libvterm/Makefile \
 		src/proto/gui_gtk.pro \
 		src/proto/gui_gtk_x11.pro \
 		src/proto/gui_gtk_gresources.pro \
@@ -703,12 +695,19 @@ RT_ALL =	\
 		LICENSE \
 		CONTRIBUTING.md \
 		runtime/bugreport.vim \
+		runtime/doc/*.awk \
 		runtime/doc/*.pl \
 		runtime/doc/*.txt \
+		runtime/doc/Makefile \
 		runtime/doc/Make_all.mak \
 		runtime/doc/doctags.c \
 		runtime/doc/doctags.vim \
 		runtime/doc/test_urls.vim \
+		runtime/doc/vim.1 \
+		runtime/doc/evim.1 \
+		runtime/doc/vimdiff.1 \
+		runtime/doc/vimtutor.1 \
+		runtime/doc/xxd.1 \
 		runtime/ftoff.vim \
 		runtime/gvimrc_example.vim \
 		runtime/import/dist/vimhelp.vim \
@@ -726,7 +725,7 @@ RT_ALL =	\
 		runtime/macros/life/life.vim \
 		runtime/macros/matchit.vim \
 		runtime/macros/maze/README.txt \
-		runtime/macros/maze/Makefile \
+		runtime/macros/maze/[mM]akefile \
 		runtime/macros/maze/maze.c \
 		runtime/macros/maze/maze_5.78 \
 		runtime/macros/maze/maze_mac \
@@ -762,15 +761,18 @@ RT_ALL =	\
 		runtime/pack/dist/opt/editorconfig/.editorconfig \
 		runtime/pack/dist/opt/editorconfig/CONTRIBUTORS \
 		runtime/pack/dist/opt/editorconfig/LICENSE* \
+		runtime/pack/dist/opt/editorconfig/mkzip.sh \
 		runtime/pack/dist/opt/editorconfig/README.md \
 		runtime/pack/dist/opt/editorconfig/autoload/*.vim \
 		runtime/pack/dist/opt/editorconfig/autoload/editorconfig_core/*.vim \
+		runtime/pack/dist/opt/editorconfig/doc/tags \
 		runtime/pack/dist/opt/editorconfig/doc/editorconfig.txt \
 		runtime/pack/dist/opt/editorconfig/ftdetect/editorconfig.vim \
 		runtime/pack/dist/opt/editorconfig/plugin/editorconfig.vim \
 		runtime/pack/dist/opt/justify/plugin/justify.vim \
 		runtime/pack/dist/opt/matchit/plugin/matchit.vim \
 		runtime/pack/dist/opt/matchit/doc/matchit.txt \
+		runtime/pack/dist/opt/matchit/doc/tags \
 		runtime/pack/dist/opt/matchit/autoload/*.vim \
 		runtime/pack/dist/opt/shellmenu/plugin/shellmenu.vim \
 		runtime/pack/dist/opt/swapmouse/plugin/swapmouse.vim \
@@ -779,8 +781,6 @@ RT_ALL =	\
 # Runtime files for all distributions without CR/LF translation.
 RT_ALL_BIN =	\
 		runtime/doc/tags \
-		runtime/pack/dist/opt/editorconfig/doc/tags \
-		runtime/pack/dist/opt/matchit/doc/tags \
 		runtime/print/*.ps \
 
 # Runtime script files.
@@ -807,6 +807,7 @@ RT_SCRIPTS =	\
 		runtime/compiler/README.txt \
 		runtime/indent/*.vim \
 		runtime/indent/README.txt \
+		runtime/indent/Makefile \
 		runtime/indent/testdir/README.txt \
 		runtime/indent/testdir/*.vim \
 		runtime/indent/testdir/*.in \
@@ -836,15 +837,6 @@ RT_SCRIPTS =	\
 # Unix-like runtime.
 RT_UNIX =	\
 		README_unix.txt \
-		runtime/doc/*.awk \
-		runtime/doc/Makefile \
-		runtime/doc/vim.1 \
-		runtime/doc/evim.1 \
-		runtime/doc/vimdiff.1 \
-		runtime/doc/vimtutor.1 \
-		runtime/doc/xxd.1 \
-		runtime/indent/Makefile \
-		runtime/pack/dist/opt/editorconfig/mkzip.sh \
 		runtime/hi16-action-make.png \
 		runtime/hi22-action-make.png \
 		runtime/gvim.desktop \
@@ -890,7 +882,7 @@ RT_DOS_BIN =	\
 		runtime/vimlogo.pdf \
 		runtime/vimlogo.svg \
 
-# Amiga runtime (also in the extra archive).
+# Amiga runtime (also in the extra archive)
 RT_AMI =	\
 		README.txt.info \
 		README_ami.txt \

--- a/Filelist
+++ b/Filelist
@@ -1,8 +1,8 @@
 # List of distributed Vim files.
 # Used by Makefile.
 
-# source files for all source archives
-SRC_ALL =	\
+# Files of Git and GitHub.
+FILE_GIT =	\
 		.cirrus.yml \
 		.gitattributes \
 		.github/CODEOWNERS \
@@ -21,6 +21,11 @@ SRC_ALL =	\
 		ci/if_ver*.vim \
 		ci/setup-xvfb.sh \
 		ci/remove_snap.sh \
+		src/libvterm/.bzrignore \
+		src/libvterm/.gitignore \
+
+# The source code itself is for all source archives.
+BARE_SRC_ALL = \
 		src/Make_all.mak \
 		src/README.md \
 		src/alloc.c \
@@ -338,10 +343,7 @@ SRC_ALL =	\
 		src/proto/viminfo.pro \
 		src/proto/winclip.pro \
 		src/proto/window.pro \
-		src/libvterm/.bzrignore \
-		src/libvterm/.gitignore \
 		src/libvterm/LICENSE \
-		src/libvterm/Makefile \
 		src/libvterm/README \
 		src/libvterm/CONTRIBUTING \
 		src/libvterm/tbl2inc_c.pl \
@@ -429,8 +431,13 @@ SRC_ALL =	\
 		src/xdiff/xutils.c \
 		src/xdiff/xutils.h \
 
+# Source files for all source archives.
+SRC_ALL =	\
+		$(FILE_GIT) \
+		$(BARE_SRC_ALL) \
 
-# source files for Unix only
+
+# Source files for Unix-like only.
 SRC_UNIX =	\
 		Makefile \
 		Filelist \
@@ -476,6 +483,7 @@ SRC_UNIX =	\
 		src/osdef1.h.in \
 		src/osdef2.h.in \
 		src/pathdef.sh \
+		src/libvterm/Makefile \
 		src/proto/gui_gtk.pro \
 		src/proto/gui_gtk_x11.pro \
 		src/proto/gui_gtk_gresources.pro \
@@ -496,7 +504,7 @@ SRC_UNIX =	\
 		src/which.sh \
 		src/xxd/Makefile \
 
-# source files for both DOS and Unix
+# Source files for both MS Windows and Unix-like.
 SRC_DOS_UNIX =	\
 		src/gui_xim.c \
 		src/if_cscope.c \
@@ -522,7 +530,7 @@ SRC_DOS_UNIX =	\
 		src/proto/if_tcl.pro \
 		src/typemap \
 
-# source files for MS-Windows (also in the extra archive)
+# Source files for MS Windows (also in the extra archive).
 SRC_DOS =	\
 		src/GvimExt/*.mak \
 		src/GvimExt/GvimExt.reg \
@@ -598,7 +606,7 @@ SRC_DOS =	\
 		nsis/lang/*.nsi \
 		uninstall.txt \
 
-# source files for DOS without CR/LF translation (also in the extra archive)
+# Source files for MS Windows without CR/LF translation (also in the extra archive).
 SRC_DOS_BIN =	\
 		src/tearoff.bmp \
 		src/tools.bmp \
@@ -615,10 +623,10 @@ SRC_DOS_BIN =	\
 		runtime/bitmaps/vim.ico \
 		nsis/icons.zip \
 
-# source files for Amiga, DOS, etc. (also in the extra archive)
+# Source files for Amiga, DOS, etc. (also in the extra archive).
 SRC_AMI_DOS =	\
 
-# source files for Amiga (also in the extra archive)
+# Source files for Amiga (also in the extra archive).
 SRC_AMI =	\
 		README_amisrc.txt \
 		README_amisrc.txt.info \
@@ -632,7 +640,7 @@ SRC_AMI =	\
 		src/testdir/amiga.vim \
 		src/xxd/Make_amiga.mak \
 
-# source files for Haiku (also in the extra archive)
+# Source files for Haiku (also in the extra archive).
 SRC_HAIKU =	\
 		README_haiku.txt \
 		src/os_haiku.h \
@@ -641,7 +649,7 @@ SRC_HAIKU =	\
 		src/gui_haiku.h \
 		src/proto/gui_haiku.pro \
 
-# source files for the Mac (also in the extra archive)
+# Source files for the Mac (also in the extra archive).
 SRC_MAC =	\
 		src/INSTALLmac.txt \
 		src/os_mac.h \
@@ -650,7 +658,7 @@ SRC_MAC =	\
 		src/proto/os_mac_conv.pro \
 		src/proto/os_macosx.pro \
 
-# source files for VMS (in the extra archive)
+# Source files for VMS (in the extra archive).
 SRC_VMS =	\
 		src/INSTALLvms.txt \
 		src/Make_vms.mms \
@@ -664,7 +672,7 @@ SRC_VMS =	\
 		src/xxd/Make_vms.mms \
 		vimtutor.com \
 
-# source files for QNX (in the extra archive)
+# Source files for QNX (in the extra archive).
 SRC_QNX =	\
 		src/os_qnx.c \
 		src/os_qnx.h \
@@ -672,7 +680,7 @@ SRC_QNX =	\
 		src/proto/gui_photon.pro \
 		src/proto/os_qnx.pro \
 
-# source files for the extra archive (all sources that are not for Unix)
+# Source files for the extra archive (all sources that are not for Unix).
 SRC_EXTRA =	\
 		$(SRC_AMI) \
 		$(SRC_AMI_DOS) \
@@ -687,7 +695,7 @@ SRC_EXTRA =	\
 		src/os_vms_fix.com \
 		src/toolbar.phi \
 
-# runtime files for all distributions
+# Runtime files for all distributions.
 RT_ALL =	\
 		README.txt \
 		README.md \
@@ -695,19 +703,12 @@ RT_ALL =	\
 		LICENSE \
 		CONTRIBUTING.md \
 		runtime/bugreport.vim \
-		runtime/doc/*.awk \
 		runtime/doc/*.pl \
 		runtime/doc/*.txt \
-		runtime/doc/Makefile \
 		runtime/doc/Make_all.mak \
 		runtime/doc/doctags.c \
 		runtime/doc/doctags.vim \
 		runtime/doc/test_urls.vim \
-		runtime/doc/vim.1 \
-		runtime/doc/evim.1 \
-		runtime/doc/vimdiff.1 \
-		runtime/doc/vimtutor.1 \
-		runtime/doc/xxd.1 \
 		runtime/ftoff.vim \
 		runtime/gvimrc_example.vim \
 		runtime/import/dist/vimhelp.vim \
@@ -725,7 +726,7 @@ RT_ALL =	\
 		runtime/macros/life/life.vim \
 		runtime/macros/matchit.vim \
 		runtime/macros/maze/README.txt \
-		runtime/macros/maze/[mM]akefile \
+		runtime/macros/maze/Makefile \
 		runtime/macros/maze/maze.c \
 		runtime/macros/maze/maze_5.78 \
 		runtime/macros/maze/maze_mac \
@@ -761,29 +762,28 @@ RT_ALL =	\
 		runtime/pack/dist/opt/editorconfig/.editorconfig \
 		runtime/pack/dist/opt/editorconfig/CONTRIBUTORS \
 		runtime/pack/dist/opt/editorconfig/LICENSE* \
-		runtime/pack/dist/opt/editorconfig/mkzip.sh \
 		runtime/pack/dist/opt/editorconfig/README.md \
 		runtime/pack/dist/opt/editorconfig/autoload/*.vim \
 		runtime/pack/dist/opt/editorconfig/autoload/editorconfig_core/*.vim \
-		runtime/pack/dist/opt/editorconfig/doc/tags \
 		runtime/pack/dist/opt/editorconfig/doc/editorconfig.txt \
 		runtime/pack/dist/opt/editorconfig/ftdetect/editorconfig.vim \
 		runtime/pack/dist/opt/editorconfig/plugin/editorconfig.vim \
 		runtime/pack/dist/opt/justify/plugin/justify.vim \
 		runtime/pack/dist/opt/matchit/plugin/matchit.vim \
 		runtime/pack/dist/opt/matchit/doc/matchit.txt \
-		runtime/pack/dist/opt/matchit/doc/tags \
 		runtime/pack/dist/opt/matchit/autoload/*.vim \
 		runtime/pack/dist/opt/shellmenu/plugin/shellmenu.vim \
 		runtime/pack/dist/opt/swapmouse/plugin/swapmouse.vim \
 		runtime/pack/dist/opt/termdebug/plugin/termdebug.vim \
 
-# runtime files for all distributions without CR-NL translation
+# Runtime files for all distributions without CR/LF translation.
 RT_ALL_BIN =	\
 		runtime/doc/tags \
+		runtime/pack/dist/opt/editorconfig/doc/tags \
+		runtime/pack/dist/opt/matchit/doc/tags \
 		runtime/print/*.ps \
 
-# runtime script files
+# Runtime script files.
 RT_SCRIPTS =	\
 		runtime/filetype.vim \
 		runtime/scripts.vim \
@@ -807,7 +807,6 @@ RT_SCRIPTS =	\
 		runtime/compiler/README.txt \
 		runtime/indent/*.vim \
 		runtime/indent/README.txt \
-		runtime/indent/Makefile \
 		runtime/indent/testdir/README.txt \
 		runtime/indent/testdir/*.vim \
 		runtime/indent/testdir/*.in \
@@ -834,15 +833,24 @@ RT_SCRIPTS =	\
 		runtime/syntax/generator/update_date.vim \
 		runtime/syntax/generator/vim.vim.base \
 
-# Unix runtime
+# Unix-like runtime.
 RT_UNIX =	\
 		README_unix.txt \
+		runtime/doc/*.awk \
+		runtime/doc/Makefile \
+		runtime/doc/vim.1 \
+		runtime/doc/evim.1 \
+		runtime/doc/vimdiff.1 \
+		runtime/doc/vimtutor.1 \
+		runtime/doc/xxd.1 \
+		runtime/indent/Makefile \
+		runtime/pack/dist/opt/editorconfig/mkzip.sh \
 		runtime/hi16-action-make.png \
 		runtime/hi22-action-make.png \
 		runtime/gvim.desktop \
 		runtime/vim.desktop \
 
-# Unix and DOS runtime without CR-LF translation
+# Unix-like and MS Windows runtime without CR/LF translation.
 RT_UNIX_DOS_BIN =	\
 		runtime/vim16x16.gif \
 		runtime/vim16x16.png \
@@ -854,10 +862,10 @@ RT_UNIX_DOS_BIN =	\
 		runtime/vim48x48.png \
 		runtime/vim48x48.xpm \
 
-# runtime not for unix or extra
+# Runtime not for Unix-like or extra.
 RT_NO_UNIX =	\
 
-# runtime for Amiga (also in the extra archive)
+# Runtime for Amiga (also in the extra archive).
 RT_AMI_DOS =	\
 		runtime/doc/evim.man \
 		runtime/doc/vim.man \
@@ -865,15 +873,16 @@ RT_AMI_DOS =	\
 		runtime/doc/vimtutor.man \
 		runtime/doc/xxd.man \
 
-# DOS runtime (also in the extra archive)
+# MS Windows runtime (also in the extra archive).
 RT_DOS =	\
 		README_dos.txt \
 		runtime/doc/Make_mvc.mak \
+		runtime/indent/Make_mvc.mak \
 		runtime/tutor/Make_mvc.mak \
 		runtime/lang/Make_mvc.mak \
 		vimtutor.bat \
 
-# DOS runtime without CR-LF translation (also in the extra archive)
+# MS Windows runtime without CR/LF translation (also in the extra archive).
 RT_DOS_BIN =	\
 		runtime/vimlogo.cdr \
 		runtime/vimlogo.eps \
@@ -881,7 +890,7 @@ RT_DOS_BIN =	\
 		runtime/vimlogo.pdf \
 		runtime/vimlogo.svg \
 
-# Amiga runtime (also in the extra archive)
+# Amiga runtime (also in the extra archive).
 RT_AMI =	\
 		README.txt.info \
 		README_ami.txt \
@@ -901,7 +910,7 @@ RT_AMI =	\
 		runtime/tutor.info \
 		runtime/tutor/*.info \
 
-# runtime files in extra archive
+# Runtime files in extra archive.
 RT_EXTRA =	\
 		$(RT_AMI) \
 		$(RT_AMI_DOS) \
@@ -909,46 +918,46 @@ RT_EXTRA =	\
 		$(RT_DOS_BIN) \
 		README_mac.txt \
 
-# included in all Amiga archives
+# Included in all Amiga archives.
 ROOT_AMI =	\
 		Contents \
 		Contents.info \
 		runtime.info \
 		vimdir.info \
 
-# root files for the extra archive
+# Root files for the extra archive.
 ROOT_EXTRA =	\
 		$(ROOT_AMI) \
 
-# files for Amiga small binary (also in extra archive)
+# Files for Amiga small binary (also in extra archive).
 BIN_AMI =	\
 		README_amibin.txt \
 		README_amibin.txt.info \
 		Vim.info \
 		Xxd.info \
 
-# files for DOS binary (also in extra archive)
+# Files for MS Windows binary (also in extra archive).
 BIN_DOS =	\
 		README_bindos.txt \
 		uninstall.txt \
 
-# files for Win32 OLE binary (also in extra archive)
+# Files for Win32 OLE binary (also in extra archive).
 BIN_OLE =	\
 		README_ole.txt \
 
-# files for Win32s binary (also in extra archive)
+# Files for Win32s binary (also in extra archive).
 BIN_W32S =	\
 		README_w32s.txt \
 
-# files for VMS binary (also in extra archive)
+# Files for VMS binary (also in extra archive).
 BIN_VMS =	\
 		README_vms.txt \
 
-# files for OS/2 binary (also in extra archive)
+# Files for OS/2 binary (also in extra archive).
 BIN_OS2 =	\
 		README_os2.txt \
 
-# binary files for extra archive
+# Binary files for extra archive.
 BIN_EXTRA =	\
 		$(BIN_AMI) \
 		$(BIN_DOS) \
@@ -957,7 +966,7 @@ BIN_EXTRA =	\
 		$(BIN_VMS) \
 		$(BIN_OS2) \
 
-# all files for extra archive
+# All files for extra archive.
 EXTRA =		\
 		$(BIN_EXTRA) \
 		$(ROOT_EXTRA) \
@@ -966,7 +975,7 @@ EXTRA =		\
 		README_extra.txt \
 		runtime/vimlogo.xpm \
 
-# files in READMEdir that are included from the top dir
+# Files in READMEdir that are included from the top dir.
 IN_README_DIR = \
 		README.txt.info \
 		README_ami.txt \
@@ -997,7 +1006,7 @@ IN_README_DIR = \
 		src.info \
 		vimdir.info \
 
-# generic language files
+# Generic language files.
 LANG_GEN = \
 		runtime/doc/*-da.1 \
 		runtime/doc/*-da.UTF-8.1 \
@@ -1050,7 +1059,7 @@ LANG_GEN = \
 		runtime/spell/main.aap \
 		runtime/spell/*.vim \
 
-# generic language files, binary
+# Generic language files, binary.
 LANG_GEN_BIN = \
 		runtime/spell/README_en.txt \
 		runtime/spell/en.ascii.spl \
@@ -1060,7 +1069,7 @@ LANG_GEN_BIN = \
 		runtime/spell/en.latin1.sug \
 		runtime/spell/en.utf-8.sug \
 
-# all files for lang archive
+# All files for lang archive.
 LANG_SRC = \
 		src/po/README.txt \
 		src/po/README_mingw.txt \
@@ -1080,7 +1089,7 @@ LANG_SRC = \
 		src/po/big5corr.c \
 		src/po/*.po \
 
-# the language files for the Win32 lang archive
+# The language files for the Win32 lang archive.
 LANG_DOS = \
 		src/po/*.mo \
 

--- a/runtime/indent/Make_mvc.mak
+++ b/runtime/indent/Make_mvc.mak
@@ -1,0 +1,21 @@
+# Makefile for running indent tests on OS Windows.
+# Made on the base of a indent/Makefile.
+# Restorer, 13.03.2024
+
+.SUFFIXES:
+
+VIM = vim.exe
+VIMRUNTIME = ..
+
+# Run the tests that didn't run yet or failed previously.
+# If a test succeeds a testdir\*.out file will be written.
+# If a test fails a testdir\*.fail file will be written.
+test :
+	@ set "VIMRUNTIME=$(VIMRUNTIME)"
+	$(VIM) --clean --not-a-term -u testdir\runtest.vim
+
+
+clean testclean :
+	@ if exist testdir\*.fail del /q testdir\*.fail
+	@ if exist testdir\*.out del /q testdir\*.out
+

--- a/runtime/indent/Makefile
+++ b/runtime/indent/Makefile
@@ -1,5 +1,8 @@
 # Portable Makefile for running indent tests.
 
+.SUFFIXES:
+.PHONY: test clean testclean
+
 VIM = vim
 VIMRUNTIME = ..
 

--- a/runtime/indent/testdir/runtest.vim
+++ b/runtime/indent/testdir/runtest.vim
@@ -2,7 +2,7 @@
 "
 " Current directory must be runtime/indent.
 
-" Only do this with the +eval feature
+" Only do this with the +eval feature.
 if 1
 
 set nocp
@@ -18,7 +18,7 @@ au! SwapExists * call HandleSwapExists()
 func HandleSwapExists()
   " Ignore finding a swap file for the test input and output, the user might be
   " editing them and that's OK.
-  if expand('<afile>') =~ '.*\.\(in\|out\|fail\|ok\)'
+  if expand('<afile>') =~ '.*\.\%(in\|out\|fail\|ok\)'
     let v:swapchoice = 'e'
   endif
 endfunc
@@ -30,19 +30,19 @@ for fname in glob('testdir/*.in', 1, 1)
   " Execute the test if the .out file does not exist of when the .in file is
   " newer.
   let in_time = getftime(fname)
-  let out_time = getftime(root . '.out')
+  let out_time = getftime(root .. '.out')
   if out_time < 0 || in_time > out_time
-    call delete(root . '.fail')
-    call delete(root . '.out')
+    call delete(root .. '.fail')
+    call delete(root .. '.out')
 
     set sw& ts& filetype=
-    exe 'split ' . fname
+    exe 'split ' .. fname
 
     let did_some = 0
     let failed = 0
     let end = 1
     while 1
-      " Indent all the lines between "START_INDENT" and "END_INDENT"
+      " Indent all the lines between "START_INDENT" and "END_INDENT".
       exe end
       let start = search('\<START_INDENT\>')
       let end = search('\<END_INDENT\>')
@@ -63,7 +63,7 @@ for fname in glob('testdir/*.in', 1, 1)
 	  exe lnum + 1
 	  let lnum_exe = search('\<INDENT_EXE\>')
 	  exe lnum + 1
-	  let indent_at = search('\<INDENT_\(AT\|NEXT\|PREV\)\>')
+	  let indent_at = search('\<INDENT_\%(AT\|NEXT\|PREV\)\>')
 	  if lnum_exe > 0 && lnum_exe < end && (indent_at <= 0 || lnum_exe < indent_at)
 	    exe substitute(getline(lnum_exe), '.*INDENT_EXE', '', '')
 	    let lnum = lnum_exe
@@ -87,15 +87,15 @@ for fname in glob('testdir/*.in', 1, 1)
 	exe start + 1
 	if pattern == ''
 	  try
-	    exe 'normal =' . (end - 1) . 'G'
+	    exe 'normal =' .. (end - 1) .. 'G'
 	  catch
-	    call append(indent_at, 'ERROR: ' . v:exception)
+	    call append(indent_at, 'ERROR: ' .. v:exception)
 	    let failed = 1
 	  endtry
 	else
 	  let lnum = search(pattern)
 	  if lnum <= 0
-	    call append(indent_at, 'ERROR: pattern not found: ' . pattern)
+	    call append(indent_at, 'ERROR: pattern not found: ' .. pattern)
 	    let failed = 1
 	    break
 	  endif
@@ -109,7 +109,7 @@ for fname in glob('testdir/*.in', 1, 1)
 	  try
 	    normal ==
 	  catch
-	    call append(indent_at, 'ERROR: ' . v:exception)
+	    call append(indent_at, 'ERROR: ' .. v:exception)
 	    let failed = 1
 	  endtry
 	endif
@@ -118,21 +118,21 @@ for fname in glob('testdir/*.in', 1, 1)
 
     if !failed
       " Check the resulting text equals the .ok file.
-      if getline(1, '$') != readfile(root . '.ok')
+      if getline(1, '$') != readfile(root .. '.ok')
 	let failed = 1
       endif
     endif
 
     if failed
       let failed_count += 1
-      exe 'write ' . root . '.fail'
-      echoerr 'Test ' . fname . ' FAILED!'
+      exe 'write ' .. root .. '.fail'
+      echoerr 'Test ' .. fname .. ' FAILED!'
     else
-      exe 'write ' . root . '.out'
-      echo "Test " . fname . " OK\n"
+      exe 'write ' .. root .. '.out'
+      echo "Test " .. fname .. " OK\n"
     endif
 
-    quit!  " close the indented file
+    quit!  " Close the indented file.
   endif
 endfor
 
@@ -140,7 +140,7 @@ endfor
 endif
 
 if failed_count > 0
-  " have make report an error
+  " Have make report an error.
   cquit
 endif
 qall!


### PR DESCRIPTION
Problem: On OS Windows there is no makefile for testing indents.
Solution: Add Make_mvc.mak to the "runtime/indent" directory.
Also:
"indent/testdir/runtest.vim" — bit optimized.
"indent/Makefile" — added rules .PHONY and .SUFFIXES
"Filelist" — added the file "runtime/indent/Make_mvc.mak". Some files have been moved to more logically appropriate variables (macros).