### PR TITLE
tools/rename.bat uses 'mv' and "move"

### DIFF
--- a/tools/rename.bat
+++ b/tools/rename.bat
@@ -1,6 +1,36 @@
-mv vim.exe vimw32.exe
-mv tee/tee.exe teew32.exe
-mv xxd/xxd.exe xxdw32.exe
-mv vim.pdb vimw32.pdb
-mv install.exe installw32.exe
-mv uninstall.exe uninstallw32.exe
+@ 2>/dev/null # 2>nul & goto:win32
+if test -e ../src/vim.exe ; then mv ../src/vim.exe ../src/vimw32.exe ; fi
+if test -e ../src/vim.pdb ; then mv ../src/vim.pdb ../src/vimw32.pdb ; fi
+if test -e ../src/gvim.exe ; then mv ../src/gvim.exe ../src/gvim_ole.exe ; fi
+if test -e ../src/gvim.pdb ; then mv ../src/gvim.pdb ../src/gvim_ole.pdb ; fi
+if test -e ../src/install.exe ;
+ then
+ mv ../src/install.exe ../src/installw32.exe ;
+fi
+if test -e ../src/uninstall.exe ;
+ then
+ mv ../src/uninstall.exe ../src/uninstallw32.exe ;
+fi
+if test -e ../src/tee/tee.exe ;
+ then
+ mv ../src/tee/tee.exe ../src/teew32.exe ; 
+fi
+if test -e ../src/xxd/xxd.exe ;
+ then
+ mv ../src/xxd/xxd.exe ../src/xxdw32.exe ; 
+fi
+return
+exit
+
+:win32
+if exist mv.exe (set "mv=mv.exe -f") else (set "mv=move /y")
+if exist ..\src\vim.exe %mv% ..\src\vim.exe ..\src\vimw32.exe
+if exist ..\src\vim.pdb %mv% ..\src\vim.pdb ..\src\vimw32.pdb
+if exist ..\src\gvim.exe %mv% ..\src\gvim.exe ..\src\gvim_ole.exe
+if exist ..\src\gvim.pdb %mv% ..\src\gvim.pdb ..\src\gvim_ole.pdb
+if exist ..\src\install.exe %mv% ..\src\install.exe ..\src\installw32.exe
+if exist ..\src\uninstall.exe %mv% ..\src\uninstall.exe ..\src\uninstallw32.exe
+if exist ..\src\tee\tee.exe %mv% ..\src\tee\tee.exe ..\src\teew32.exe
+if exist ..\src\xxd\xxd.exe %mv% ..\src\xxd\xxd.exe ..\src\xxdw32.exe
+set "mv="
+goto:EOF

--- a/tools/rename.bat
+++ b/tools/rename.bat
@@ -1,4 +1,5 @@
 @ 2>/dev/null # 2>nul & goto:win32
+#!\bin\sh
 if test -e ../src/vim.exe ; then mv ../src/vim.exe ../src/vimw32.exe ; fi
 if test -e ../src/vim.pdb ; then mv ../src/vim.pdb ../src/vimw32.pdb ; fi
 if test -e ../src/gvim.exe ; then mv ../src/gvim.exe ../src/gvim_ole.exe ; fi
@@ -19,7 +20,8 @@ if test -e ../src/xxd/xxd.exe ;
  then
  mv ../src/xxd/xxd.exe ../src/xxdw32.exe ; 
 fi
-return
+# Uncomment return if the file is run through the command "source"
+#return
 exit
 
 :win32

--- a/tools/rename.bat
+++ b/tools/rename.bat
@@ -1,5 +1,5 @@
 @ 2>/dev/null # 2>nul & goto:win32
-#!\bin\sh
+#!/bin/sh
 if test -e ../src/vim.exe ; then mv ../src/vim.exe ../src/vimw32.exe ; fi
 if test -e ../src/vim.pdb ; then mv ../src/vim.pdb ../src/vimw32.pdb ; fi
 if test -e ../src/gvim.exe ; then mv ../src/gvim.exe ../src/gvim_ole.exe ; fi


### PR DESCRIPTION
The file "tools/rename.bat" uses both "mv" (if available) and the native Windows "move" command.
To use this file on UNIX-like systems, you need to make it executable.