### PR TITLE
Can define function with invalid name inside 'formatexpr'

### DIFF
--- a/src/testdir/test_user_func.vim
+++ b/src/testdir/test_user_func.vim
@@ -968,4 +968,23 @@ func Test_multidefer_with_exception()
   delfunc Foo
 endfunc
 
+func Test_func_curly_brace_invalid_name()
+  func Fail()
+    func Foo{'()'}bar()
+    endfunc
+  endfunc
+
+  call assert_fails('call Fail()', 'E475: Invalid argument: Foo()bar')
+
+  silent! call Fail()
+  call assert_equal([], getcompletion('Foo', 'function'))
+
+  set formatexpr=Fail()
+  normal! gqq
+  call assert_equal([], getcompletion('Foo', 'function'))
+
+  set formatexpr&
+  delfunc Fail
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -4977,7 +4977,10 @@ define_function(
 					: eval_isnamec(name_base[i])); ++i)
 		;
 	    if (name_base[i] != NUL)
+	    {
 		emsg_funcname(e_invalid_argument_str, arg);
+		goto ret_free;
+	    }
 
 	    // In Vim9 script a function cannot have the same name as a
 	    // variable.


### PR DESCRIPTION
Problem:  Can define function with invalid name inside 'formatexpr'.
Solution: Use goto instead of checking for did_emsg later.
