### PR TITLE
Wrong display or screenpos() result when toggling diff mode

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -1520,6 +1520,7 @@ diff_win_options(
 	if (!wp->w_p_diff)
 	    wp->w_p_wrap_save = wp->w_p_wrap;
 	wp->w_p_wrap = FALSE;
+	wp->w_skipcol = 0;
     }
 # ifdef FEAT_FOLDING
     if (!wp->w_p_diff)
@@ -1583,8 +1584,11 @@ ex_diffoff(exarg_T *eap)
 		    wp->w_p_crb = wp->w_p_crb_save;
 		if (!(diff_flags & DIFF_FOLLOWWRAP))
 		{
-		    if (!wp->w_p_wrap)
-			wp->w_p_wrap = wp->w_p_wrap_save;
+		    if (!wp->w_p_wrap && wp->w_p_wrap_save)
+		    {
+			wp->w_p_wrap = TRUE;
+			wp->w_leftcol = 0;
+		    }
 		}
 #ifdef FEAT_FOLDING
 		free_string_option(wp->w_p_fdm);

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -3,6 +3,7 @@
 source shared.vim
 source screendump.vim
 source check.vim
+source view_util.vim
 
 func Test_diff_fold_sync()
   enew!
@@ -1951,6 +1952,72 @@ func Test_diffexpr_with_diff_func()
   let buf = RunVimInTerminal('-S XsetupDiffFunc.vim', {'rows': 12})
   call VerifyScreenDump(buf, 'Test_difffunc_diffexpr_1', {})
   call StopVimInTerminal(buf)
+endfunc
+
+func Test_diff_toggle_wrap_skipcol_leftcol()
+  61vnew
+  call setline(1, 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.')
+  30vnew
+  call setline(1, 'ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.')
+  let win1 = win_getid()
+  setlocal smoothscroll
+  exe "normal! $\<C-E>"
+  wincmd l
+  let win2 = win_getid()
+  setlocal smoothscroll
+  exe "normal! $\<C-E>"
+  call assert_equal([
+        \ '<<<sadipscing elitr, sed diam |<<<tetur sadipscing elitr, sed|',
+        \ 'nonumy eirmod tempor invidunt | diam nonumy eirmod tempor inv|',
+        \ 'ut labore et dolore magna aliq|idunt ut labore et dolore magn|',
+        \ 'uyam erat, sed diam voluptua. |a aliquyam erat, sed diam volu|',
+        \ '~                             |ptua.                         |',
+        \ ], ScreenLines([1, 5], 62))
+  call assert_equal({'col': 29, 'row': 4, 'endcol': 29, 'curscol': 29},
+        \ screenpos(win1, line('.', win1), col('.', win1)))
+  call assert_equal({'col': 36, 'row': 5, 'endcol': 36, 'curscol': 36},
+        \ screenpos(win2, line('.', win2), col('.', win2)))
+
+  wincmd h
+  diffthis
+  wincmd l
+  diffthis
+  normal! 0
+  call assert_equal([
+        \ '  ipsum dolor sit amet, conset|  Lorem ipsum dolor sit amet, |',
+        \ '~                             |~                             |',
+        \ ], ScreenLines([1, 2], 62))
+  call assert_equal({'col': 3, 'row': 1, 'endcol': 3, 'curscol': 3},
+        \ screenpos(win1, line('.', win1), col('.', win1)))
+  call assert_equal({'col': 34, 'row': 1, 'endcol': 34, 'curscol': 34},
+        \ screenpos(win2, line('.', win2), col('.', win2)))
+
+  normal! $
+  call assert_equal([
+        \ '  voluptua.                   |   diam voluptua.             |',
+        \ '~                             |~                             |',
+        \ ], ScreenLines([1, 2], 62))
+  call assert_equal({'col': 11, 'row': 1, 'endcol': 11, 'curscol': 11},
+        \ screenpos(win1, line('.', win1), col('.', win1)))
+  call assert_equal({'col': 48, 'row': 1, 'endcol': 48, 'curscol': 48},
+        \ screenpos(win2, line('.', win2), col('.', win2)))
+
+  diffoff!
+  call assert_equal([
+        \ 'ipsum dolor sit amet, consetet|Lorem ipsum dolor sit amet, co|',
+        \ 'ur sadipscing elitr, sed diam |nsetetur sadipscing elitr, sed|',
+        \ 'nonumy eirmod tempor invidunt | diam nonumy eirmod tempor inv|',
+        \ 'ut labore et dolore magna aliq|idunt ut labore et dolore magn|',
+        \ 'uyam erat, sed diam voluptua. |a aliquyam erat, sed diam volu|',
+        \ '~                             |ptua.                         |',
+        \ ], ScreenLines([1, 6], 62))
+  call assert_equal({'col': 29, 'row': 5, 'endcol': 29, 'curscol': 29},
+        \ screenpos(win1, line('.', win1), col('.', win1)))
+  call assert_equal({'col': 36, 'row': 6, 'endcol': 36, 'curscol': 36},
+        \ screenpos(win2, line('.', win2), col('.', win2)))
+
+  bwipe!
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Wrong display or screenpos() result when toggling diff mode.
Solution: Reset w_skipcol when disabling 'wrap'.  Reset w_leftcol when
          enabling 'wrap'.

Fix #14210
