### PR TITLE
Fix Go `goPackageComment` highlighting too broad

### DIFF
--- a/runtime/syntax/go.vim
+++ b/runtime/syntax/go.vim
@@ -531,12 +531,12 @@ if s:HighlightBuildConstraints() || s:FoldEnable('package_comment')
   " matched as comments to avoid looking like working build constraints.
   " The he, me, and re options let the "package" itself be highlighted by
   " the usual rules.
-  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package/'
-        \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
+  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package\s/'
+        \ . ' end=/\v\n\s*package\s/he=e-8,me=e-8,re=e-8'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (s:FoldEnable('package_comment') ? ' fold' : '')
-  exe 'syn region  goPackageComment    start=/\v^\s*\/\*.*\n(.*\n)*\s*\*\/\npackage/'
-        \ . ' end=/\v\*\/\n\s*package/he=e-7,me=e-7,re=e-7'
+  exe 'syn region  goPackageComment    start=/\v^\s*\/\*.*\n(.*\n)*\s*\*\/\npackage\s/'
+        \ . ' end=/\v\*\/\n\s*package\s/he=e-8,me=e-8,re=e-8'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (s:FoldEnable('package_comment') ? ' fold' : '')
   hi def link goPackageComment    Comment


### PR DESCRIPTION
Previously this would highlight any comment before a line starting `package`, for example

    var (
      // This comment would be highlighted as a goPackageComment
      packages []string
    )

The package clause is only valid when followed by a space[1], so include this restriction

This is upstreaming a change from `go-vim`[2]

[1] https://go.dev/ref/spec#Package_clause
[2] https://github.com/fatih/vim-go/commit/d1c36cc4173093d0be78fd826978a024febe6233