### PR TITLE
Not all files are deleted on uninstallation

### DIFF
--- a/nsis/README.txt
+++ b/nsis/README.txt
@@ -37,7 +37,7 @@ To build the installable .exe:
 5.  Also put "winpty32.dll" and "winpty-agent.exe" in "../.." (above the "vim91"
     directory).  This is required for the terminal window.
 
-6.  To use encryption, add a library Sodium.  You can get it here:
+6.  To use stronger encryption, add the Sodium library.  You can get it here:
 	https://github.com/jedisct1/libsodium/releases/download/1.0.19-RELEASE/libsodium-1.0.19-msvc.zip
     Unpack the archive.  Put the "libsodium.dll" from
     path/to/libsodium/Win32/Release/v143/dynamic for the 32‐bit version or

--- a/nsis/README.txt
+++ b/nsis/README.txt
@@ -29,18 +29,26 @@ To build the installable .exe:
 
 4.  Get a "diff.exe" program.  If you skip this the built-in diff will always
     be used (which is fine for most users).  If you do have your own
-    "diff.exe" put it in the "../.." directory (above the "vim90" directory,
+    "diff.exe" put it in the "../.." directory (above the "vim91" directory,
     it's the same for all Vim versions).
     You can find one in previous Vim versions or in this archive:
-		http://www.mossbayeng.com/~ron/vim/diffutils.tar.gz
+	http://www.mossbayeng.com/~ron/vim/diffutils.tar.gz
 
-5   Also put winpty32.dll and winpty-agent.exe in "../.." (above the "vim90"
+5.  Also put "winpty32.dll" and "winpty-agent.exe" in "../.." (above the "vim91"
     directory).  This is required for the terminal window.
 
-6.  Do "make uganda.nsis.txt" in runtime/doc.  This requires sed, you may have
+6.  To use encryption, add a library Sodium.  You can get it here:
+	https://github.com/jedisct1/libsodium/releases/download/1.0.19-RELEASE/libsodium-1.0.19-msvc.zip
+    Unpack the archive.  Put the "libsodium.dll" from
+    path/to/libsodium/Win32/Release/v142/dynamic for the 32‐bit version or
+    path/to/libsodium/X64/Release/v142/dynamic for the 64‐bit version in the
+    "../.." directory (above the "vim91" directory, where "diff.exe" and
+    "winpty32.dll").
+
+7.  Do "make uganda.nsis.txt" in runtime/doc.  This requires sed, you may have
     to do this on Unix.  Make sure the file is in DOS file format!
 
-7.  Get gettext and iconv DLLs from the following site:
+8.  Get gettext and iconv DLLs from the following site:
 	https://github.com/mlocati/gettext-iconv-windows/releases
     Both 64- and 32-bit versions are needed.
     Download the files gettextX.X.X.X-iconvX.XX-shared-{32,64}.zip, extract

--- a/nsis/README.txt
+++ b/nsis/README.txt
@@ -40,8 +40,8 @@ To build the installable .exe:
 6.  To use encryption, add a library Sodium.  You can get it here:
 	https://github.com/jedisct1/libsodium/releases/download/1.0.19-RELEASE/libsodium-1.0.19-msvc.zip
     Unpack the archive.  Put the "libsodium.dll" from
-    path/to/libsodium/Win32/Release/v142/dynamic for the 32‐bit version or
-    path/to/libsodium/X64/Release/v142/dynamic for the 64‐bit version in the
+    path/to/libsodium/Win32/Release/v143/dynamic for the 32‐bit version or
+    path/to/libsodium/X64/Release/v143/dynamic for the 64‐bit version in the
     "../.." directory (above the "vim91" directory, where "diff.exe" and
     "winpty32.dll").
 

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -1097,8 +1097,8 @@ SectionEnd
 
 # Remove "vimfiles" directory under the specified directory.
 !macro RemoveVimfiles dir
-	${If} ${FileExists} $0\_viminfo
-	  Delete $0\_viminfo
+	${If} ${FileExists} ${dir}\_viminfo
+	  Delete ${dir}\_viminfo
 	${EndIf}
 	${If} ${DirExists} ${dir}\vimfiles
 	  RMDir ${dir}\vimfiles\colors
@@ -1110,8 +1110,8 @@ SectionEnd
 	  RMDir ${dir}\vimfiles\keymap
 	  RMDir ${dir}\vimfiles\plugin
 	  RMDir ${dir}\vimfiles\syntax
-	  ${If} ${FileExists} $0\vimfiles\.netrwhist*
-	    Delete $0\vimfiles\.netrwhist*
+	  ${If} ${FileExists} ${dir}\vimfiles\.netrwhist*
+	    Delete ${dir}\vimfiles\.netrwhist*
 	  ${EndIf}
 	  RMDir ${dir}\vimfiles
 	${EndIf}

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -1,6 +1,6 @@
 # NSIS file to create a self-installing exe for Vim.
 # It requires NSIS version 3.0 or later.
-# Last Change:	2024 Mart 17
+# Last Change:	2024 Mar 17
 
 Unicode true
 

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -1,6 +1,6 @@
 # NSIS file to create a self-installing exe for Vim.
 # It requires NSIS version 3.0 or later.
-# Last Change:	2014 Nov 5
+# Last Change:	2024 Mart 01
 
 Unicode true
 
@@ -390,20 +390,22 @@ Section "$(str_section_exe)" id_section_exe
 	File ${VIMRT}\compiler\*.*
 
 	SetOutPath $0\doc
-	File ${VIMRT}\doc\*.txt
+	File /x uganda.nsis.txt ${VIMRT}\doc\*.txt
 	File ${VIMRT}\doc\tags
 
 	SetOutPath $0\ftplugin
 	File ${VIMRT}\ftplugin\*.*
 
 	SetOutPath $0\indent
-	File ${VIMRT}\indent\*.*
+	File ${VIMRT}\indent\README.txt
+	File ${VIMRT}\indent\*.vim
 
 	SetOutPath $0\keymap
-	File ${VIMRT}\keymap\*.*
+	File ${VIMRT}\keymap\README.txt
+	File ${VIMRT}\keymap\*.vim
 
 	SetOutPath $0\macros
-	File /r ${VIMRT}\macros\*.*
+	File /r /x *.info ${VIMRT}\macros\*.*
 
 	SetOutPath $0\pack
 	File /r ${VIMRT}\pack\*.*
@@ -421,7 +423,7 @@ Section "$(str_section_exe)" id_section_exe
 	File ${VIMSRC}\vim.ico
 
 	SetOutPath $0\syntax
-	File /r /x testdir /x generator ${VIMRT}\syntax\*.*
+	File /r /x testdir /x generator /x Makefile ${VIMRT}\syntax\*.*
 
 	SetOutPath $0\spell
 	File ${VIMRT}\spell\*.txt
@@ -433,7 +435,7 @@ Section "$(str_section_exe)" id_section_exe
 	File ${VIMRT}\tools\*.*
 
 	SetOutPath $0\tutor
-	File ${VIMRT}\tutor\*.*
+	File /x Makefile /x *.info ${VIMRT}\tutor\*.*
 SectionEnd
 
 ##########################################################
@@ -564,10 +566,7 @@ Section "$(str_section_nls)" id_section_nls
 	SectionIn 1 3
 
 	SetOutPath $0\lang
-	File /r ${VIMRT}\lang\*.*
-	SetOutPath $0\keymap
-	File ${VIMRT}\keymap\README.txt
-	File ${VIMRT}\keymap\*.vim
+	File /r /x Makefile ${VIMRT}\lang\*.*
 	SetOutPath $0
 	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
 	    "${GETTEXT}\gettext${BIT}\libintl-8.dll" \
@@ -947,7 +946,7 @@ Section "un.$(str_unsection_register)" id_unsection_register
 	SectionIn RO
 
 	# Apparently $INSTDIR is set to the directory where the uninstaller is
-	# created.  Thus the "vim61" directory is included in it.
+	# created.  Thus the "vim91" directory is included in it.
 	StrCpy $0 "$INSTDIR"
 
 	# delete the context menu entry and batch files
@@ -1044,6 +1043,7 @@ Section "un.$(str_unsection_exe)" id_unsection_exe
 	RMDir /r $0\tutor
 	RMDir /r $0\lang
 	RMDir /r $0\keymap
+	RMDir /r $0\bitmaps
 	Delete $0\*.exe
 	Delete $0\*.bat
 	Delete $0\*.vim
@@ -1053,7 +1053,7 @@ Section "un.$(str_unsection_exe)" id_unsection_exe
 	  MessageBox MB_OK|MB_ICONEXCLAMATION $(str_msg_rm_exe_fail) /SD IDOK
 	${EndIf}
 
-	# No error message if the "vim62" directory can't be removed, the
+	# No error message if the "vim91" directory can't be removed, the
 	# gvimext.dll may still be there.
 	RMDir $0
 SectionEnd
@@ -1081,6 +1081,12 @@ SectionGroup "un.$(str_ungroup_plugin)" id_ungroup_plugin
 		Pop $0
 
 		${If} $0 != ""
+		  ${If} ${FileExists} $0\_viminfo
+		    Delete $0\_viminfo
+		  ${EndIf}
+		  ${If} ${FileExists} $0\vimfiles\.netrwhist*
+		    Delete $0\vimfiles\.netrwhist*
+		  ${EndIf}
 		  !insertmacro RemoveVimfiles $0
 		${EndIf}
 	SectionEnd

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -79,7 +79,7 @@ Unicode true
 !define FileExists `"" FileExists2`
 !macro _DirExists _a _b _t _f
 	!insertmacro _LOGICLIB_TEMP
-	StrCpy $_LOGICLIB_TEMP "0"	
+	StrCpy $_LOGICLIB_TEMP "0"
 ;if path is not blank, continue to next check
 	StrCmp `${_b}` `` +3 0
 ;if directory exists, continue to confirm exists

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -374,9 +374,9 @@ DYNAMIC_SODIUM = yes
 
 !if "$(SODIUM)" != "no"
 ! if "$(CPU)" == "AMD64"
-SOD_LIB		= $(SODIUM)\x64\Release\v140\dynamic
+SOD_LIB		= $(SODIUM)\x64\Release\v142\dynamic
 ! elseif "$(CPU)" == "i386"
-SOD_LIB		= $(SODIUM)\Win32\Release\v140\dynamic
+SOD_LIB		= $(SODIUM)\Win32\Release\v142\dynamic
 ! else
 SODIUM = no
 ! endif

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -374,9 +374,9 @@ DYNAMIC_SODIUM = yes
 
 !if "$(SODIUM)" != "no"
 ! if "$(CPU)" == "AMD64"
-SOD_LIB		= $(SODIUM)\x64\Release\v142\dynamic
+SOD_LIB		= $(SODIUM)\x64\Release\v143\dynamic
 ! elseif "$(CPU)" == "i386"
-SOD_LIB		= $(SODIUM)\Win32\Release\v142\dynamic
+SOD_LIB		= $(SODIUM)\Win32\Release\v143\dynamic
 ! else
 SODIUM = no
 ! endif


### PR DESCRIPTION
Some files are not required for installation. Not all files are deleted on uninstallation.

Section "Vim GUI and runtime files" $(str_section_exe):
\doc directory - excluded "uganda.nsis.txt", duplicate files ("uganda.txt" and "uganda.nsis.txt");
\indent directory - excluded makefiles, not applicable without "testdir" directory;
\macros directory - excluded *.info files, not applicable in OS Windows;
\syntax directory - excluded makefiles, not applicable without "testdir" directory;
\tutor directory - excludes Makefile and *.info files, not applicable in OS Windows.

Native Language Support" section $(str_section_nls):
\keymap directory excluded - after patch 9.1.0032 it is always copied, code duplication;
\lang directory - excluded Makefile, not applicable in OS Windows.

Section "Remove Vim Executables/Runtime Files" un.$(str_unsection_exe):
add \bitmaps directory - it is created during installation (patch 8.2.4545), but was not included for removal.

Section "Remove the plugin directories from HOME directory" un.$(str_unsection_plugin_home):
add "_viminfo" file and Netrw plug-in history files for removal.

‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐‐

Added a description of how to place the library in the ${VIMTOOLS} directory,
with corresponding changes in "gvim.nsi".

To prevent the installer build from crashing, a file existence check has been
added "diff.exe ". According to the [documentation](https://github.com/vim/vim/blob/f6272551bdae3f265b6948a4155b079c37fe110f/nsis/README.txt#L30), it may not be there.

Added a check for the existence of files "winpty{32/64}.dll" and
"winpty-agent.exe ". Vim can be built without terminal support and, accordingly,
these files may be absent.

The deletion of the "_viminfo" and "netrwhist" files has been moved to the
"RemoveVimfiles" macro.

According to the description from the [documentation](https://nsis.sourceforge.io/LogicLib), checking the existence of
files and directories for the "{FileExists}" macro has changed a little.
