### PR TITLE
Wrong cursor pos when clicking after eol with 'rl', 've' and conceal

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -975,15 +975,14 @@ draw_screen_line(win_T *wp, winlinevars_T *wlv)
 		++wlv->off;
 		++wlv->col;
 	    }
+	    ++wlv->vcol;
 
-	    if (VCOL_HLC >= rightmost_vcol
+	    if (VCOL_HLC > rightmost_vcol
 # ifdef LINE_ATTR
 		    && wlv->line_attr == 0
 # endif
 		    && wlv->win_attr == 0)
 		break;
-
-	    ++wlv->vcol;
 	}
     }
 #endif

--- a/src/screen.c
+++ b/src/screen.c
@@ -18,8 +18,7 @@
  *		     displayed (excluding text written by external commands).
  * ScreenAttrs[off]  Contains the associated attributes.
  * ScreenCols[off]   Contains the virtual columns in the line. -1 means not
- *		     available or before buffer text, MAXCOL means after the
- *		     end of the line.
+ *		     available or before buffer text.
  *
  * LineOffset[row]   Contains the offset into ScreenLines*[], ScreenAttrs[]
  *		     and ScreenCols[] for each line.
@@ -509,6 +508,8 @@ screen_line(
 	// Clear rest first, because it's left of the text.
 	if (clear_width > 0)
 	{
+	    int clear_start = col;
+
 	    while (col <= endcol && ScreenLines[off_to] == ' '
 		    && ScreenAttrs[off_to] == 0
 				  && (!enc_utf8 || ScreenLinesUC[off_to] == 0))
@@ -519,6 +520,10 @@ screen_line(
 	    if (col <= endcol)
 		screen_fill(row, row + 1, col + coloff,
 					    endcol + coloff + 1, ' ', ' ', 0);
+
+	    for (int i = endcol; i >= clear_start; i--)
+		ScreenCols[off_to + (i - col)] =
+		    (flags & SLF_INC_VCOL) ? ++last_vcol : last_vcol;
 	}
 	col = endcol + 1;
 	off_to = LineOffset[row] + col + coloff;

--- a/src/testdir/test_conceal.vim
+++ b/src/testdir/test_conceal.vim
@@ -464,6 +464,53 @@ func Test_conceal_mouse_click()
     call test_setmouse(1, 32)
     call feedkeys("\<LeftMouse>", "tx")
     call assert_equal([0, 1, 24, 12, 36], getcurpos())
+    " Behavior should also be the same with 'colorcolumn'.
+    setlocal colorcolumn=30
+    redraw
+    call test_setmouse(1, 31)
+    call feedkeys("\<LeftMouse>", "tx")
+    call assert_equal([0, 1, 24, 11, 35], getcurpos())
+    call test_setmouse(1, 32)
+    call feedkeys("\<LeftMouse>", "tx")
+    call assert_equal([0, 1, 24, 12, 36], getcurpos())
+    setlocal colorcolumn&
+
+    if has('rightleft')
+      setlocal rightleft
+      call assert_equal([
+            \ '                     ereh kcilc  laecnoc',
+            \ ], ScreenLines(1, 40))
+      " Click on the space between "this" and "click" puts cursor there.
+      call test_setmouse(1, 41 - 9)
+      call feedkeys("\<LeftMouse>", "tx")
+      call assert_equal([0, 1, 13, 0, 13], getcurpos())
+      " Click on 'h' of "here" puts cursor there.
+      call test_setmouse(1, 41 - 16)
+      call feedkeys("\<LeftMouse>", "tx")
+      call assert_equal([0, 1, 20, 0, 20], getcurpos())
+      " Click on 'e' of "here" puts cursor there.
+      call test_setmouse(1, 41 - 19)
+      call feedkeys("\<LeftMouse>", "tx")
+      call assert_equal([0, 1, 23, 0, 23], getcurpos())
+      " Click after end of line puts cursor there with 'virtualedit'.
+      call test_setmouse(1, 41 - 20)
+      call feedkeys("\<LeftMouse>", "tx")
+      call assert_equal([0, 1, 24, 0, 24], getcurpos())
+      call test_setmouse(1, 41 - 21)
+      call feedkeys("\<LeftMouse>", "tx")
+      call assert_equal([0, 1, 24, 1, 25], getcurpos())
+      call test_setmouse(1, 41 - 22)
+      call feedkeys("\<LeftMouse>", "tx")
+      call assert_equal([0, 1, 24, 2, 26], getcurpos())
+      call test_setmouse(1, 41 - 31)
+      call feedkeys("\<LeftMouse>", "tx")
+      call assert_equal([0, 1, 24, 11, 35], getcurpos())
+      call test_setmouse(1, 41 - 32)
+      call feedkeys("\<LeftMouse>", "tx")
+      call assert_equal([0, 1, 24, 12, 36], getcurpos())
+      setlocal rightleft&
+    endif
+
     set virtualedit&
 
     " Test with a wrapped line.


### PR DESCRIPTION
Problem:  Wrong cursor position when clicking after end of line with
          'rightleft', 'virtualedit' and conceal.
Solution: Set values in ScreenCols[] also with SLF_RIGHTLEFT.  Also fix
          off-by-one cursor position with 'colorcolumn'.
