### PR TITLE
Dafny files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -534,6 +534,9 @@ au BufNewFile,BufRead *.csp,*.fdr		setf csp
 au BufNewFile,BufRead *.pld			setf cupl
 au BufNewFile,BufRead *.si			setf cuplsim
 
+" Dafny
+au BufNewFile,BufRead *.dfy			setf dafny
+
 " Dart
 au BufRead,BufNewfile *.dart,*.drt		setf dart
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -189,6 +189,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     cynpp: ['file.cyn'],
     cypher: ['file.cypher'],
     d: ['file.d'],
+    dafny: ['file.dfy'],
     dart: ['file.dart', 'file.drt'],
     datascript: ['file.ds'],
     dcd: ['file.dcd'],


### PR DESCRIPTION
Problem:  Dafny files are not recognized.
Solution: Recognize *.dfy files as filetype "dafny".

Ref: https://dafny.org/
Ref: https://github.com/mlr-msft/vim-loves-dafny
