### PR TITLE
problem: cannot use :e with 'winfixbuf' enabled

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7252,6 +7252,7 @@ ex_edit(exarg_T *eap)
     if (
 	    eap->cmdidx != CMD_badd
 	    && eap->cmdidx != CMD_balt
+	    && !(eap->cmdidx == CMD_edit && *eap->arg == NUL)
 	    // All other commands must obey 'winfixbuf' / ! rules
 	    && !check_can_set_curbuf_forceit(eap->forceit))
         return;

--- a/src/testdir/test_winfixbuf.vim
+++ b/src/testdir/test_winfixbuf.vim
@@ -3283,4 +3283,25 @@ func Test_bufdo_cnext_splitwin_fails()
   set winminheight&vim winheight&vim
 endfunc
 
+" Fdit without filename is allowed
+func Test_edit_noarg()
+  " A GUI dialog may stall the test.
+  CheckNotGui
+
+  call s:reset_all_buffers()
+
+  let l:other = s:make_buffer_pairs()
+  let l:current = bufnr()
+
+  call assert_fails("browse edit other", "E1513:")
+  call assert_equal(l:current, bufnr())
+
+  try
+    edit
+  catch /^Vim\%((\a\+)\)\=:E1513:/
+    " should not happen
+    call assert_equal(1, 2)
+  endtry
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  cannot use :e with 'winfixbuf' enabled
Solution: allow :e without args

closes: #14237