### PR TITLE
May leak memory in completion when ga_grow() fails

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -653,7 +653,10 @@ ins_compl_infercase_gettext(
 	    // getting to six bytes from the edge of IObuff switch to using a
 	    // growarray.  Add the character in the next round.
 	    if (ga_grow(&gap, IOSIZE) == FAIL)
+	    {
+		vim_free(wca);
 		return (char_u *)"[failed]";
+	    }
 	    *p = NUL;
 	    STRCPY(gap.ga_data, IObuff);
 	    gap.ga_len = (int)STRLEN(IObuff);


### PR DESCRIPTION
Problem:  May leak memory in completion when ga_grow() fails.
Solution: Free "wca" when ga_grow() fails.

Fix #14248
