### PR TITLE
problem: memleak with ex_drop, NULL dereference

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5503,8 +5503,8 @@ ex_drop(exarg_T *eap)
 		buf_check_timestamp(curbuf, FALSE);
 		curbuf->b_p_ar = save_ar;
 	    }
-	    if (buf->b_ml.ml_flags & ML_EMPTY)
-		open_buffer(FALSE, eap, 0);
+	    if (curbuf->b_ml.ml_flags & ML_EMPTY)
+		ex_rewind(eap);
 	    return;
 	}
     }


### PR DESCRIPTION
Problem:  memleak with ex_drop(), NULL dereference
Solution: revert back to ex_rewind(), check buf != NULL

fixes: #14246