### PR TITLE
Fix for Sodium version 1.0.19 and MinGW

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,11 +408,11 @@ jobs:
       # winpty
       WINPTY_URL: https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip
       # libsodium
-      SODIUM_VER: '1.0.18'
+      SODIUM_VER: '1.0.19'
       SODIUM_MSVC_URL: https://download.libsodium.org/libsodium/releases/libsodium-%SODIUM_VER%-stable-msvc.zip
       SODIUM_MSVC_VER: v143
       SODIUM_MINGW_URL: https://download.libsodium.org/libsodium/releases/libsodium-%SODIUM_VER%-stable-mingw.tar.gz
-      SODIUM_MINGW_VER: 23
+      SODIUM_MINGW_VER: 26
       # Escape sequences
       COL_RED: "\x1b[31m"
       COL_GREEN: "\x1b[32m"


### PR DESCRIPTION
It should, in theory, solve the problem with MinGW and libsodium ver. 1.0.19