### PR TITLE
Termdebug: allow multibyte characters as breakpoint signs

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1661,7 +1661,7 @@ func s:CreateBreakpoint(id, subid, enabled)
       endif
     endif
     call sign_define('debugBreakpoint' .. nr,
-				\ #{text: strpart(label, 0, 2), 
+				\ #{text: (strchars(label) > 2 ? strpart(label, 0, 2) : label),
 				\ texthl: hiName})
   endif
 endfunc

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1661,7 +1661,7 @@ func s:CreateBreakpoint(id, subid, enabled)
       endif
     endif
     call sign_define('debugBreakpoint' .. nr,
-				\ #{text: (strchars(label) > 2 ? strpart(label, 0, 2) : label),
+				\ #{text: slice(label, 0, 2),
 				\ texthl: hiName})
   endif
 endfunc


### PR DESCRIPTION
There is a small issue in Termdebug where it doesn't allow unicode characters as breakpoint signs.
This prevents customization, for example using NerdFont characters as signs.

Steps to reproduce:
    
    vim --clean
    
    :packadd termdebug
    :let g:termdebug_config = {'sign': '󰯯'}

The sign is a custom font character:
![image](https://github.com/vim/vim/assets/981184/86cc8534-eb9e-4130-a4f5-084e66f000da)

    :Termdebug test
    (gdb) break main
    
The following error is shown in `:messages`

    Error detected while processing function <SNR>9_CommOutput[15]..<SNR>9_HandleNewBreakpoint[24]..<SNR>9_CreateBreakpoint:
    line   19:
    E239: Invalid sign text: <f3><b0>

The fix prevents truncation if the number of characters is less than 2 (as opposed to number of bytes).

Final result after the fix:
![image](https://github.com/vim/vim/assets/981184/6e9a1fd1-eec1-44cc-af75-008e67255ddc)

