### PR TITLE
(feat) Ctrl+[ always sends ESC, even on russian keyboard (#14272)

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -2271,6 +2271,11 @@ static void process_message_usual_key_classic(UINT vk, const MSG *pmsg)
 	    string[0] = Ctrl_AT;
 	    add_to_input_buf(string, 1);
 	}
+	else if (vk == 219 || MapVirtualKey(vk, 2) == (UINT)'[')
+	{
+	    string[0] = 27; // ESC
+	    add_to_input_buf(string, 1);
+	}
 	else
 	    TranslateMessage(pmsg);
     }


### PR DESCRIPTION
issue #14272 is marked as bug and is closed;
This PR is made from the assumption that it is useful feature request and tries to fix it.

According to my debugging, reason why with RU keyboard layout we do not get ``Ctrl+[`` seems to be that TranslateMessage() simply silently ignores this key combo, so need to intercept it earlier and inject "ESC" directly into vim input_buf.

This happens on the place where we do not have any idea about if we are on RU layout or on some else keyboard layout, therefore it does change handling logic for this key combo for _all_ keyboard layouts. We can think about restricting it effect to only RU layout by checking MapVirtualKey(vk, 2) == '?', which seems to be the result of that call for RU (EN: '[', DE: 'ü', ... probably another layouts will exist which do return '?' as well), right now such restriction is not made. Any thoughts?

Not 100% sure as well that we need ``MapVirtualKey(vk, 2) == '['`` comparison...

Anyway patch seems to work fine in my tests with following keyboard layouts: EN, RU, DE, FR

Would be nice as well if someone will test this PR on console windows vim, I made my tests only with gvim.