### PR TITLE
Problem: Motif: leaking memory when mui_mch_dialog() fails

### DIFF
--- a/src/gui_motif.c
+++ b/src/gui_motif.c
@@ -2732,7 +2732,10 @@ gui_mch_dialog(
     // Motif.
     label = XmStringCreateLtoR((char *)message, STRING_TAG);
     if (label == NULL)
+    {
+	vim_free(buttons);
 	return -1;
+    }
     w = XtVaCreateManagedWidget("dialogMessage",
 				xmLabelGadgetClass, form,
 				XmNlabelString, label,


### PR DESCRIPTION
Problem:  Motif: leaking memory when mui_mch_dialog() fails
Solution: When allocating the label using the XmStringCreateLtoR()
          function fails, before returning also free the allocated
          buttons pointer.

fixes: #14247