### PR TITLE
Problem: leaking memory in exe_newdict() on error

### DIFF
--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -260,7 +260,10 @@ exe_newdict(int count, ectx_T *ectx)
     if (count > 0)
 	ectx->ec_stack.ga_len -= 2 * count - 1;
     else if (GA_GROW_FAILS(&ectx->ec_stack, 1))
+    {
+	dict_unref(dict);
 	return FAIL;
+    }
     else
 	++ectx->ec_stack.ga_len;
     tv = STACK_TV_BOT(-1);


### PR DESCRIPTION
Problem:  leaking memory in exe_newdict() on error
Solution: free allocated dict if GA_GROW_FALIS()

fixes: #14255