### PR TITLE
Problem: C: is not considered an absolute path

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -393,7 +393,7 @@ mch_isFullName(char_u *fname)
     if (*fname == NUL)
 	return FALSE;
     return ((ASCII_ISALPHA(fname[0]) && fname[1] == ':'
-				      && (fname[2] == '/' || fname[2] == '\\'))
+		    && (fname[2] == NUL || fname[2] == '/' || fname[2] == '\\'))
 	    || (fname[0] == fname[1] && (fname[0] == '/' || fname[0] == '\\')));
 }
 

--- a/src/testdir/test_fnamemodify.vim
+++ b/src/testdir/test_fnamemodify.vim
@@ -1,5 +1,7 @@
 " Test filename modifiers.
 
+source check.vim
+
 func Test_fnamemodify()
   let save_home = $HOME
   let save_shell = &shell
@@ -101,6 +103,20 @@ endfunc
 func Test_fnamemodify_fail()
   call assert_fails('call fnamemodify({}, ":p")', 'E731:')
   call assert_fails('call fnamemodify("x", {})', 'E731:')
+endfunc
+
+func Test_fnamemodify_windows()
+  CheckMSWindows
+  let save_shellslash = &shellslash
+
+  call assert_equal('C:', fnamemodify('C:', ':p'))
+  call assert_equal('C:/', fnamemodify('C:/', ':p'))
+  call assert_equal('C:\', fnamemodify('C:\', ':p'))
+  call assert_equal(getcwd() .. '\foobar', fnamemodify('C:foobar', ':p'))
+  set shellslash
+  call assert_equal(getcwd() .. '/foobar', fnamemodify('C:foobar', ':p'))
+
+  let &shellslash = save_shellslash
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  C: is not considered an absolute path
Solution: Consider C: (without path separator) also an
          absolute path, make it behave same as c:\

fixes: #14279