### PR TITLE
Fix build on hurd when using -Werror=implicit-function-declaration

### DIFF
--- a/src/vim.h
+++ b/src/vim.h
@@ -36,7 +36,7 @@
 #  error configure did not run properly.  Check auto/config.log.
 # endif
 
-# if (defined(__linux__) && !defined(__ANDROID__)) || defined(__CYGWIN__)
+# if (defined(__linux__) && !defined(__ANDROID__)) || defined(__CYGWIN__) || defined(__GNU__)
 // Needed for strptime().  Needs to be done early, since header files can
 // include other header files and end up including time.h, where these symbols
 // matter for Vim.


### PR DESCRIPTION
strptime() requires _XOPEN_SOURCE to be defined for its declaration to be visible.  This is already done for non-Android Linux and Cygwin, but also needs to be exposed for GNU/Hurd.