### PR TITLE
'winfixbuf' is now more flexible - You can :edit the current buffer

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -462,7 +462,6 @@ restore_dbg_stuff(struct dbg_stuff *dsp)
 
 /*
  * Check if ffname differs from fnum.
- *
  * fnum is a buffer number. 0 == current buffer, 1-or-more must be a valid buffer ID.
  * ffname is a full path to where a buffer lives on-disk or would live on-disk.
  *

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -460,6 +460,37 @@ restore_dbg_stuff(struct dbg_stuff *dsp)
 }
 #endif
 
+// @param fnum A buffer number. 0 == current buffer, 1-or-more must be a valid buffer ID.
+// @param ffname The full path to where a buffer lives on-disk or would live on-disk.
+// @return if `ffname` is the same as `fnum` buffer, return true.
+//
+static int is_other_file(int fnum, char_u *ffname)
+{
+  if (fnum != 0)
+  {
+    if (fnum == curbuf->b_fnum)
+      return FALSE;
+
+    return TRUE;
+  }
+
+  if (ffname == NULL)
+    return TRUE;
+
+  if (*ffname == NUL)
+    return FALSE;
+
+  // TODO: Need a reliable way to know whether a buffer is meant to live on-disk
+  // !curbuf->b_dev_valid is not always available (example: missing on Windows)
+  if (curbuf->b_sfname != NULL
+      && *curbuf->b_sfname != NUL)
+    // This occurs with unsaved buffers. In which case `ffname`
+    // actually corresponds to curbuf->b_sfname
+    return fnamecmp(ffname, curbuf->b_sfname) != 0;
+
+  return otherfile(ffname);
+}
+
 /*
  * do_exmode(): Repeatedly get commands for the "Ex" mode, until the ":vi"
  * command is given.
@@ -7248,12 +7279,15 @@ ex_open(exarg_T *eap)
     static void
 ex_edit(exarg_T *eap)
 {
+    char_u *ffname = eap->cmdidx == CMD_enew ? NULL : eap->arg;
+
     // Exclude commands which keep the window's current buffer
     if (
 	    eap->cmdidx != CMD_badd
 	    && eap->cmdidx != CMD_balt
 	    // All other commands must obey 'winfixbuf' / ! rules
-	    && !check_can_set_curbuf_forceit(eap->forceit))
+	    && (is_other_file(0, ffname) && !check_can_set_curbuf_forceit(eap->forceit))
+    )
         return;
 
     do_exedit(eap, NULL);

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -460,11 +460,15 @@ restore_dbg_stuff(struct dbg_stuff *dsp)
 }
 #endif
 
-// @param fnum A buffer number. 0 == current buffer, 1-or-more must be a valid buffer ID.
-// @param ffname The full path to where a buffer lives on-disk or would live on-disk.
-// @return if `ffname` is the same as `fnum` buffer, return true.
-//
-static int is_other_file(int fnum, char_u *ffname)
+/*
+ * Check if ffname differs from fnum.
+ *
+ * fnum is a buffer number. 0 == current buffer, 1-or-more must be a valid buffer ID.
+ * ffname is a full path to where a buffer lives on-disk or would live on-disk.
+ *
+ */
+    static int
+is_other_file(int fnum, char_u *ffname)
 {
   if (fnum != 0)
   {


### PR DESCRIPTION
A follow-up to https://github.com/vim/vim/pull/14244

Problem: cannot use :e with 'winfixbuf' enabled
Solution: allow :e without args

closes: https://github.com/vim/vim/issues/14237

## What Is In This PR
With `'winfixbuf'` enabled on a window, the following are now allowed:

- `:edit` (no arguments) 
- `:edit foo` (if foo is in-memory)
- `:edit /tmp/foo` (if /tmp/foo is a currently-saved file)
- Various permutations of "if looking at an in-memory buffer and attempting to switch to an on-disk buffer of the same name (relative or absolute paths / with or without `cd`-ing in advance) will detect the "other" buffer and fail


## What Is Not In This PR
- `:edit foo` (if `:cd`'ed to `/tmp` and `/tmp/foo` is on-disk)

I couldn't figure out a way to determine if a buffer name refers to a buffer that lives on-disk or not. @chrisbra do you have any ideas? I got this equivalent working in Neovim. To get a visual on exactly the problem, please have a look at https://github.com/neovim/neovim/compare/master...ColinKennedy:neovim:issues/14237-neovim_edit_without_args. In particular the `Test_edit_same_buffer_on_disk_relative_path` test. In Neovim the test works because I'm allowed to check `!curbuf->file_id_valid` which covers all cases that I could see. But the Vim equivalent, `buf_T.b_dev_valid`, is only available on UNIX builds and so will fail Windows unittests. So I excluded `Test_edit_same_buffer_on_disk_relative_path` from this PR, because it fails to pass and is still a known issue

Edit: It looks like `Test_edit_same_buffer_on_disk_absolute_path` is also failing on Windows, which I didn't expect. Possibly / probably because of `\` vs `\` and `fnamecmp` behavior.