### PR TITLE
Cannot use modifiers before :-Ntabmove

### DIFF
--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -1,4 +1,4 @@
-*tabpage.txt*   For Vim version 9.1.  Last change: 2022 Feb 02
+*tabpage.txt*   For Vim version 9.1.  Last change: 2024 Mar 25
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -196,7 +196,7 @@ gt					*i_CTRL-<PageDown>* *i_<C-PageDown>*
 		    :1tabnext	" go to the first tab page
 		    :$tabnext	" go to the last tab page
 		    :tabnext $	" as above
-		    :tabnext #  " go to the last accessed tab page
+		    :tabnext #	" go to the last accessed tab page
 		    :tabnext -	" go to the previous tab page
 		    :tabnext -1	" as above
 		    :tabnext +	" go to the next tab page
@@ -248,13 +248,12 @@ REORDERING TAB PAGES:
 		Move the current tab page to after tab page N.  Use zero to
 		make the current tab page the first one.  N is counted before
 		the move, thus if the second tab is the current one,
-		`:tabmove 1` and `:tabmove 2`  have no effect.
+		`:tabmove 1` and `:tabmove 2` have no effect.
 		Without N the tab page is made the last one. >
 		    :.tabmove	" do nothing
 		    :-tabmove	" move the tab page to the left
 		    :+tabmove	" move the tab page to the right
-		    :0tabmove	" move the tab page to the beginning of the tab
-				" list
+		    :0tabmove	" move the tab page to the first
 		    :tabmove 0	" as above
 		    :tabmove	" move the tab page to the last
 		    :$tabmove	" as above

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6317,11 +6317,19 @@ get_tabpage_arg(exarg_T *eap)
 	else
 	{
 	    tab_number = eap->line2;
-	    if (!unaccept_arg0 && *skipwhite(*eap->cmdlinep) == '-')
+	    if (!unaccept_arg0)
 	    {
-		--tab_number;
-		if (tab_number < unaccept_arg0)
-		    eap->errmsg = _(e_invalid_range);
+		char_u *cmdp = eap->cmd;
+
+		while (--cmdp > *eap->cmdlinep
+			&& (VIM_ISWHITE(*cmdp) || VIM_ISDIGIT(*cmdp)))
+		    ;
+		if (*cmdp == '-')
+		{
+		    --tab_number;
+		    if (tab_number < unaccept_arg0)
+			eap->errmsg = _(e_invalid_range);
+		}
 	    }
 	}
     }

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -117,10 +117,16 @@ function Test_tabpage()
   call assert_equal(3, tabpagenr())
   +3tabmove
   call assert_equal(6, tabpagenr())
+  silent -tabmove
+  call assert_equal(5, tabpagenr())
+  silent -2 tabmove
+  call assert_equal(3, tabpagenr())
+  silent	-2	tabmove
+  call assert_equal(1, tabpagenr())
 
-  " The following are a no-op
   norm! 2gt
   call assert_equal(2, tabpagenr())
+  " The following are a no-op
   tabmove 2
   call assert_equal(2, tabpagenr())
   2tabmove


### PR DESCRIPTION
Problem:  Cannot use modifiers before :-Ntabmove.
Solution: Check backwards from the command instead of checking from the
          start of the command line. Slighyly adjust docs to make them
          more consistent.
