### PR TITLE
Recalculate scrollbar in `popup_getpos()`

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3057,6 +3057,7 @@ f_popup_getpos(typval_T *argvars, typval_T *rettv)
     wp = find_popup_win(id);
     if (wp == NULL)
 	return;  // invalid {id}
+    popup_adjust_position(wp);
     top_extra = popup_top_extra(wp);
     left_extra = wp->w_popup_border[3] + wp->w_popup_padding[3];
 

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3046,7 +3046,6 @@ f_popup_getpos(typval_T *argvars, typval_T *rettv)
     win_T	*wp;
     int		top_extra;
     int		left_extra;
-    int		lnum;
 
     if (rettv_dict_alloc(rettv) == FAIL)
 	return;

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3061,8 +3061,6 @@ f_popup_getpos(typval_T *argvars, typval_T *rettv)
     top_extra = popup_top_extra(wp);
     left_extra = wp->w_popup_border[3] + wp->w_popup_padding[3];
 
-    popup_adjust_position(wp);
-
     // we know how much space we need, avoid resizing halfway
     dict = rettv->vval.v_dict;
     hash_lock_size(&dict->dv_hashtab, 11);
@@ -3079,11 +3077,13 @@ f_popup_getpos(typval_T *argvars, typval_T *rettv)
     dict_add_number(dict, "core_width", wp->w_width);
     dict_add_number(dict, "core_height", wp->w_height);
 
-    dict_add_number(dict, "scrollbar", wp->w_has_scrollbar);
     dict_add_number(dict, "firstline", wp->w_topline);
     dict_add_number(dict, "lastline", wp->w_botline - 1);
     dict_add_number(dict, "visible",
 	    win_valid(wp) && (wp->w_popup_flags & POPF_HIDDEN) == 0);
+
+    popup_adjust_position(wp);
+    dict_add_number(dict, "scrollbar", wp->w_has_scrollbar);
 
     hash_unlock(&dict->dv_hashtab);
 }

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3046,6 +3046,7 @@ f_popup_getpos(typval_T *argvars, typval_T *rettv)
     win_T	*wp;
     int		top_extra;
     int		left_extra;
+    int		lnum;
 
     if (rettv_dict_alloc(rettv) == FAIL)
 	return;
@@ -3057,7 +3058,15 @@ f_popup_getpos(typval_T *argvars, typval_T *rettv)
     wp = find_popup_win(id);
     if (wp == NULL)
 	return;  // invalid {id}
-    popup_adjust_position(wp);
+
+    // recalculate scrollbar
+    if (wp->w_firstline < 0)
+	lnum = wp->w_buffer->b_ml.ml_line_count;
+    else
+	lnum = wp->w_topline;
+    wp->w_has_scrollbar = wp->w_want_scrollbar
+	   && (wp->w_topline > 1 || lnum <= wp->w_buffer->b_ml.ml_line_count);
+
     top_extra = popup_top_extra(wp);
     left_extra = wp->w_popup_border[3] + wp->w_popup_padding[3];
 

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3059,16 +3059,10 @@ f_popup_getpos(typval_T *argvars, typval_T *rettv)
     if (wp == NULL)
 	return;  // invalid {id}
 
-    // recalculate scrollbar
-    if (wp->w_firstline < 0)
-	lnum = wp->w_buffer->b_ml.ml_line_count;
-    else
-	lnum = wp->w_topline;
-    wp->w_has_scrollbar = wp->w_want_scrollbar
-	   && (wp->w_topline > 1 || lnum <= wp->w_buffer->b_ml.ml_line_count);
-
     top_extra = popup_top_extra(wp);
     left_extra = wp->w_popup_border[3] + wp->w_popup_padding[3];
+
+    popup_adjust_position(wp);
 
     // we know how much space we need, avoid resizing halfway
     dict = rettv->vval.v_dict;

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -1320,6 +1320,17 @@ func Test_popup_getpos()
   call assert_equal(1, res.visible)
 
   call popup_close(winid)
+
+  " Test for Github Issue https://github.com/vim/vim/issues/14290
+  " using popup_getpos(winid) should return correct 'scrollbar' information
+
+  let winid = popup_create([], {'maxheight': 3, 'minheight': 3, 'minwidth': 19, 'maxwidth': 19, 'scrollbar': v:true, 'wrap': 1})
+  call popup_settext(winid, ["hello world", "hello world (10)", "hello world"])
+  call win_execute(winid, "setl nu")
+  let pos = popup_getpos(winid)
+  call assert_equal(pos.scrollbar, 1)
+
+  call popup_clear(winid)
 endfunc
 
 func Test_popup_width_longest()

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4237,8 +4237,8 @@ func Test_popupwin_popup_getpos()
   " Test for Github Issue https://github.com/vim/vim/issues/14290
   " using popup_getpos(winid) should return correct 'scrollbar' information
 
-  let winid = popup_create([], { 'maxheight': 3, 'minheight': 3, 'minwidth': 19, 'maxwidth': 19, 'scrollbar': v:true, 'wrap': 1})
-  call popup_settext(winid, [ "hello world", "hello world (10)", "hello world", ])
+  let winid = popup_create([], {'maxheight': 3, 'minheight': 3, 'minwidth': 19, 'maxwidth': 19, 'scrollbar': v:true, 'wrap': 1})
+  call popup_settext(winid, ["hello world", "hello world (10)", "hello world"])
   call win_execute(winid, "setl nu")
   let pos = popup_getpos(winid)
   call assert_equal(pos.scrollbar, 1)

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4233,4 +4233,17 @@ func Test_popupwin_setbufvar_changing_window_view()
   bw!
 endfunc
 
+func Test_popupwin_popup_getpos()
+  " Test for Github Issue https://github.com/vim/vim/issues/14290
+  " using popup_getpos(winid) should return correct 'scrollbar' information
+
+  let winid = popup_create([], { 'maxheight': 3, 'minheight': 3, 'minwidth': 19, 'maxwidth': 19, 'scrollbar': v:true, 'wrap': 1})
+  call popup_settext(winid, [ "hello world", "hello world (10)", "hello world", ])
+  call win_execute(winid, "setl nu")
+  let pos = popup_getpos(winid)
+  call assert_equal(pos.scrollbar, 1)
+
+  call popup_clear()
+endfunc
+
 " vim: shiftwidth=2 sts=2

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4244,17 +4244,4 @@ func Test_popupwin_setbufvar_changing_window_view()
   bw!
 endfunc
 
-func Test_popupwin_popup_getpos()
-  " Test for Github Issue https://github.com/vim/vim/issues/14290
-  " using popup_getpos(winid) should return correct 'scrollbar' information
-
-  let winid = popup_create([], {'maxheight': 3, 'minheight': 3, 'minwidth': 19, 'maxwidth': 19, 'scrollbar': v:true, 'wrap': 1})
-  call popup_settext(winid, ["hello world", "hello world (10)", "hello world"])
-  call win_execute(winid, "setl nu")
-  let pos = popup_getpos(winid)
-  call assert_equal(pos.scrollbar, 1)
-
-  call popup_clear()
-endfunc
-
 " vim: shiftwidth=2 sts=2


### PR DESCRIPTION
Use `popup_adjust_position()` in `popup_getpos()` to update scrollbar information before returning it.

Fixes #14290