### PR TITLE
NSIS: Redesigning the appearance of the vimrc settings page

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -138,6 +138,8 @@ RequestExecutionLevel highest
 
 # Show all languages, despite user's codepage:
 !define MUI_LANGDLL_ALLLANGUAGES
+# Always show dialog choice language
+#!define MUI_LANGDLL_ALWAYSSHOW
 !define MUI_LANGDLL_REGISTRY_ROOT       "HKCU"
 !define MUI_LANGDLL_REGISTRY_KEY        "Software\Vim"
 !define MUI_LANGDLL_REGISTRY_VALUENAME  "Installer Language"
@@ -858,12 +860,12 @@ Function SetCustom
 
 
 	# 1st group - Compatibility
-	${NSD_CreateGroupBox} 0 0 100% 32% $(str_msg_compat_title)
+	${NSD_CreateGroupBox} 0u 0u 296u 44u $(str_msg_compat_title)
 	Pop $3
 
-	${NSD_CreateLabel} 5% 10% 35% 8% $(str_msg_compat_desc)
+	${NSD_CreateLabel} 16u 14u 269u 10u $(str_msg_compat_desc)
 	Pop $3
-	${NSD_CreateDropList} 18% 19% 75% 8% ""
+	${NSD_CreateDropList} 42u 26u 237u 13u ""
 	Pop $vim_nsd_compat
 	${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_vi)
 	${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_vim)
@@ -883,12 +885,12 @@ Function SetCustom
 
 
 	# 2nd group - Key remapping
-	${NSD_CreateGroupBox} 0 35% 100% 31% $(str_msg_keymap_title)
+	${NSD_CreateGroupBox} 0u 48u 296u 44u $(str_msg_keymap_title)
 	Pop $3
 
-	${NSD_CreateLabel} 5% 45% 90% 8% $(str_msg_keymap_desc)
+	${NSD_CreateLabel} 16u 62u 269u 10u $(str_msg_keymap_desc)
 	Pop $3
-	${NSD_CreateDropList} 38% 54% 55% 8% ""
+	${NSD_CreateDropList} 42u 74u 236u 13u ""
 	Pop $vim_nsd_keymap
 	${NSD_CB_AddString} $vim_nsd_keymap $(str_msg_keymap_default)
 	${NSD_CB_AddString} $vim_nsd_keymap $(str_msg_keymap_windows)
@@ -902,12 +904,12 @@ Function SetCustom
 
 
 	# 3rd group - Mouse behavior
-	${NSD_CreateGroupBox} 0 69% 100% 31% $(str_msg_mouse_title)
+	${NSD_CreateGroupBox} 0u 95u 296u 44u $(str_msg_mouse_title)
 	Pop $3
 
-	${NSD_CreateLabel} 5% 79% 90% 8% $(str_msg_mouse_desc)
+	${NSD_CreateLabel} 16u 108u 269u 10u $(str_msg_mouse_desc)
 	Pop $3
-	${NSD_CreateDropList} 23% 87% 70% 8% ""
+	${NSD_CreateDropList} 42u 121u 237u 13u ""
 	Pop $vim_nsd_mouse
 	${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_default)
 	${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_windows)


### PR DESCRIPTION
The width of the drop-down list fields is adjusted to a single size. This makes
the interface consistent and allows you to display translated strings completely
without cutting them off.

According to the [documentation](https://nsis.sourceforge.io/Docs/nsDialogs/Readme.html), the units of measurement have been changed from
percentages to dialog unit. This allows the interface to be more adaptive to
various settings of scale and font size.

Danish:
![danish](https://github.com/vim/vim/assets/69863286/25962549-3dcc-456d-a3eb-f77916478e5c)
English:
![english](https://github.com/vim/vim/assets/69863286/d568c66a-31ff-401b-bf2a-c79a1ca44599)
German:
![german](https://github.com/vim/vim/assets/69863286/bd2fb249-10dd-473b-a292-607c6062d488)
Greek:
![greek](https://github.com/vim/vim/assets/69863286/2aaf47b8-9b45-4cd3-97ff-24d97f9cee43)
Italian:
![italian](https://github.com/vim/vim/assets/69863286/f0aca60d-2fd9-48be-a5ca-9597816ca3da)
Japanese:
![japanese](https://github.com/vim/vim/assets/69863286/0b9238f1-83ce-4b50-b9b4-513bae457aba)
Russian:
![russian](https://github.com/vim/vim/assets/69863286/200ad28c-47f2-4524-a028-d6072b01da0a)
Serbian:
![serbian](https://github.com/vim/vim/assets/69863286/aba7ea35-aea6-4d1b-8eb7-076ac292b7b8)
Simple Chinese:
![simpchinese](https://github.com/vim/vim/assets/69863286/b85372d2-5c6c-42c4-a8c6-24be323a10fb)
Turkish:
![turkish](https://github.com/vim/vim/assets/69863286/8183b9f9-1963-41e1-9835-b7e7dab99b6f)
