### PR TITLE
runtime: Add indent support for json5

### DIFF
--- a/runtime/indent/json5.vim
+++ b/runtime/indent/json5.vim
@@ -1,0 +1,11 @@
+" Vim indent file
+" Language:     JSON5
+" Maintainer:   The Vim Project <https://github.com/vim/vim>
+" Last Change:  2024-03-26
+
+if exists("b:did_indent")
+  finish
+endif
+
+" Same as jsonc indenting for now
+runtime! indent/jsonc.vim


### PR DESCRIPTION
Add indent support for json5, it is just the same as jsonc for now.