### PR TITLE
Backspace with 'smarttab' doesn't respect 'revins'

### DIFF
--- a/src/indent.c
+++ b/src/indent.c
@@ -163,7 +163,7 @@ tabstop_start(colnr_T col, int ts, int *vts)
     int		excess;
 
     if (vts == NULL || vts[0] == 0)
-	return (col / ts) * ts;
+	return col - col % ts;
 
     tabcount = vts[0];
     for (t = 1; t <= tabcount; ++t)
@@ -174,7 +174,7 @@ tabstop_start(colnr_T col, int ts, int *vts)
     }
 
     excess = tabcol % vts[tabcount];
-    return excess + ((col - excess) / vts[tabcount]) * vts[tabcount];
+    return col - (col - excess) % vts[tabcount];
 }
 
 /*


### PR DESCRIPTION
Problem:  Backspace with 'smarttab' doesn't respect 'revins'.
Solution: Delete from the end of whitespace with 'smarttab'.  Check
          inindent() after calling inc_cursor().  Also remove several
          unnecessary multiplications, as "col / ts * ts" is the same
          as "col - col % ts".

It's not entirely clear what the expected behavior of 'smarttab' should
be when 'revins' is set, but this at least fixes the obviously incorrect
behavior at the start of a line:
- Before 9.1.0204, it inserted spaces if the line above is long enough.
- After 9.1.0204, it didn't do anything.
