### PR TITLE
Remove unused display_text_first boolean variable

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -2072,8 +2072,6 @@ win_line(
 		    // not on the next char yet, don't start another prop
 		    --bcol;
 # endif
-		int display_text_first = FALSE;
-
 		// Add any text property that starts in this column.
 		// With 'nowrap' and not in the first screen line only "below"
 		// text prop can show.
@@ -2109,8 +2107,7 @@ win_line(
 		    text_prop_id = 0;
 		    reset_extra_attr = FALSE;
 		}
-		if (text_props_active > 0 && wlv.n_extra == 0
-							&& !display_text_first)
+		if (text_props_active > 0 && wlv.n_extra == 0)
 		{
 		    int used_tpi = -1;
 		    int used_attr = 0;
@@ -2157,8 +2154,6 @@ win_line(
 				// skip this prop, first display the '$' after
 				// the line or display an empty line
 				text_prop_follows = TRUE;
-				if (used_tpi < 0)
-				    display_text_first = TRUE;
 				continue;
 			    }
 
@@ -2172,7 +2167,6 @@ win_line(
 			    text_prop_flags = pt->pt_flags;
 			    text_prop_id = tp->tp_id;
 			    used_tpi = tpi;
-			    display_text_first = FALSE;
 			}
 		    }
 		    if (text_prop_id < 0 && used_tpi >= 0


### PR DESCRIPTION
## Problem

The variable display_text_first in the win_line function doesn't actually have any effect, but its presence makes it harder to understand the code.

The only place it is used, uses its initial constant value, then the following conditionally values set to the variable are unused.

For context, the variable was initially introduced in commit 9d9a20ee8799bafe9caac616fef11b7a26db6a8d, where it had an effect, but then commit 234c3fab28c14846b962c90097496b27ee1b4df8 changed the code to the current state where it doesn't anything.  Those changes are both covered by regression tests.

## Solution

Unless someone sees why the variable is still needed, I think we should just remove it.  If we end up needing to add a variable like that back, it is better to do once we have a regression test showing the need for it.