### PR TITLE
Unnecessary multiplications in backspace code

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -4210,12 +4210,11 @@ ins_bs(
 				&& (!*inserted_space_p
 				    || arrow_used))))))
 	{
-	    int		ts;
 	    colnr_T	vcol = 0;
 	    colnr_T	want_vcol;
 	    char_u	*line;
 	    char_u	*ptr;
-	    char_u	*end_ptr;
+	    char_u	*cursor_ptr;
 	    char_u	*space_ptr;
 	    colnr_T	space_vcol = 0;
 	    int		prev_space = FALSE;
@@ -4224,11 +4223,13 @@ ins_bs(
 	    *inserted_space_p = FALSE;
 
 	    space_ptr = ptr = line = ml_get_curline();
-	    end_ptr = line + curwin->w_cursor.col;
+	    cursor_ptr = line + curwin->w_cursor.col;
 
-	    // Find the last whitespace that is preceded by non-whitespace.
+	    // Compute virtual column of cursor position, and find the last
+	    // whitespace before cursor that is preceded by non-whitespace.
 	    // Use chartabsize() so that virtual text and wrapping are ignored.
-	    do {
+	    while (ptr < cursor_ptr)
+	    {
 		int	cur_space = VIM_ISWHITE(*ptr);
 
 		if (!prev_space && cur_space)
@@ -4239,25 +4240,18 @@ ins_bs(
 		vcol += chartabsize(ptr, vcol);
 		MB_PTR_ADV(ptr);
 		prev_space = cur_space;
-	    } while (ptr < end_ptr);
+	    }
 
 	    // Compute the virtual column where we want to be.
-	    want_vcol = vcol - 1;
-#ifdef FEAT_VARTABS
+	    want_vcol = vcol > 0 ? vcol - 1 : 0;
 	    if (p_sta && in_indent)
-	    {
-		ts = (int)get_sw_value(curbuf);
-		want_vcol = (want_vcol / ts) * ts;
-	    }
+		want_vcol -= want_vcol % (int)get_sw_value(curbuf);
 	    else
+#ifdef FEAT_VARTABS
 		want_vcol = tabstop_start(want_vcol, get_sts_value(),
 						       curbuf->b_p_vsts_array);
 #else
-	    if (p_sta && in_indent)
-		ts = (int)get_sw_value(curbuf);
-	    else
-		ts = (int)get_sts_value();
-	    want_vcol = (want_vcol / ts) * ts;
+		want_vcol -= want_vcol % (int)get_sts_value();
 #endif
 
 	    // Find the position to stop backspacing.

--- a/src/indent.c
+++ b/src/indent.c
@@ -163,7 +163,7 @@ tabstop_start(colnr_T col, int ts, int *vts)
     int		excess;
 
     if (vts == NULL || vts[0] == 0)
-	return (col / ts) * ts;
+	return col - col % ts;
 
     tabcount = vts[0];
     for (t = 1; t <= tabcount; ++t)
@@ -174,7 +174,7 @@ tabstop_start(colnr_T col, int ts, int *vts)
     }
 
     excess = tabcol % vts[tabcount];
-    return excess + ((col - excess) / vts[tabcount]) * vts[tabcount];
+    return col - (col - excess) % vts[tabcount];
 }
 
 /*

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -2044,7 +2044,10 @@ func Test_edit_revins()
   call setline(1, 'one two three')
   exe "normal! wi\nfour"
   call assert_equal(['one two three', 'ruof'], getline(1, '$'))
-  set revins&
+  set backspace=indent,eol,start
+  exe "normal! ggA\<BS>:"
+  call assert_equal(['one two three:ruof'], getline(1, '$'))
+  set revins& backspace&
   bw!
 endfunc
 
@@ -2161,7 +2164,7 @@ func s:check_backspace(expected)
   inoremap <buffer> <F2> <Cmd>let g:actual += [getline('.')]<CR>
   set backspace=indent,eol,start
 
-  exe "normal $i" .. repeat("\<BS>\<F2>", len(a:expected))
+  exe "normal i" .. repeat("\<BS>\<F2>", len(a:expected))
   call assert_equal(a:expected, g:actual)
 
   set backspace&
@@ -2171,9 +2174,12 @@ endfunc
 
 " Test that backspace works with 'smarttab' and mixed Tabs and spaces.
 func Test_edit_backspace_smarttab_mixed()
+  set smarttab
   call NewWindow(1, 30)
-  setlocal smarttab tabstop=4 shiftwidth=4
+  setlocal tabstop=4 shiftwidth=4
+
   call setline(1, "\t    \t         \t a")
+  normal! $
   call s:check_backspace([
         \ "\t    \t         \ta",
         \ "\t    \t        a",
@@ -2185,15 +2191,19 @@ func Test_edit_backspace_smarttab_mixed()
         \ ])
 
   call CloseWindow()
+  set smarttab&
 endfunc
 
 " Test that backspace works with 'smarttab' and 'varsofttabstop'.
 func Test_edit_backspace_smarttab_varsofttabstop()
   CheckFeature vartabs
 
+  set smarttab
   call NewWindow(1, 30)
-  setlocal smarttab tabstop=8 varsofttabstop=6,2,5,3
+  setlocal tabstop=8 varsofttabstop=6,2,5,3
+
   call setline(1, "a\t    \t a")
+  normal! $
   call s:check_backspace([
         \ "a\t    \ta",
         \ "a\t     a",
@@ -2204,13 +2214,17 @@ func Test_edit_backspace_smarttab_varsofttabstop()
         \ ])
 
   call CloseWindow()
+  set smarttab&
 endfunc
 
 " Test that backspace works with 'smarttab' when a Tab is shown as "^I".
 func Test_edit_backspace_smarttab_list()
+  set smarttab
   call NewWindow(1, 30)
-  setlocal smarttab tabstop=4 shiftwidth=4 list listchars=
+  setlocal tabstop=4 shiftwidth=4 list listchars=
+
   call setline(1, "\t    \t         \t a")
+  normal! $
   call s:check_backspace([
         \ "\t    \t        a",
         \ "\t    \t    a",
@@ -2220,15 +2234,19 @@ func Test_edit_backspace_smarttab_list()
         \ ])
 
   call CloseWindow()
+  set smarttab&
 endfunc
 
 " Test that backspace works with 'smarttab' and 'breakindent'.
 func Test_edit_backspace_smarttab_breakindent()
   CheckFeature linebreak
 
+  set smarttab
   call NewWindow(3, 17)
-  setlocal smarttab tabstop=4 shiftwidth=4 breakindent breakindentopt=min:5
+  setlocal tabstop=4 shiftwidth=4 breakindent breakindentopt=min:5
+
   call setline(1, "\t    \t         \t a")
+  normal! $
   call s:check_backspace([
         \ "\t    \t         \ta",
         \ "\t    \t        a",
@@ -2240,17 +2258,21 @@ func Test_edit_backspace_smarttab_breakindent()
         \ ])
 
   call CloseWindow()
+  set smarttab&
 endfunc
 
 " Test that backspace works with 'smarttab' and virtual text.
 func Test_edit_backspace_smarttab_virtual_text()
   CheckFeature textprop
 
+  set smarttab
   call NewWindow(1, 50)
-  setlocal smarttab tabstop=4 shiftwidth=4
+  setlocal tabstop=4 shiftwidth=4
+
   call setline(1, "\t    \t         \t a")
   call prop_type_add('theprop', {})
   call prop_add(1, 3, {'type': 'theprop', 'text': 'text'})
+  normal! $
   call s:check_backspace([
         \ "\t    \t         \ta",
         \ "\t    \t        a",
@@ -2263,6 +2285,7 @@ func Test_edit_backspace_smarttab_virtual_text()
 
   call CloseWindow()
   call prop_type_delete('theprop')
+  set smarttab&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Unnecessary multiplications in backspace code, as
          "col / ts * ts" is the same as "col - col % ts".
Solution: Change "col / ts * ts" to "col - col % ts".  Adjust the loop
          and the comments ins_bs() to be easier to understand.  Update
          tests to reset 'smarttab' properly.
