### PR TITLE
regexp: verymagic cannot match before/after a mark

### DIFF
--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -1641,7 +1641,7 @@ regatom(int *flagp)
 				  n = n * 10 + (c - '0');
 				  c = getchr();
 			      }
-			      if (c == '\'' && n == 0)
+			      if (no_Magic(c) == '\'' && n == 0)
 			      {
 				  // "\%'m", "\%<'m" and "\%>'m": Mark
 				  c = getchr();

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1733,7 +1733,7 @@ nfa_regatom(void)
 			    EMIT((int)n);
 			    break;
 			}
-			else if (c == '\'' && n == 0)
+			else if (no_Magic(c) == '\'' && n == 0)
 			{
 			    // \%'m  \%<'m  \%>'m
 			    EMIT(cmp == '<' ? NFA_MARK_LT :

--- a/src/testdir/test_regexp_latin.vim
+++ b/src/testdir/test_regexp_latin.vim
@@ -890,6 +890,7 @@ func Test_matching_marks()
   new
   set regexpengine=1
   call Regex_Mark()
+  call Regex_Mark_Verymagic()
   set regexpengine=2
   call Regex_Mark()
   call Regex_Mark_Verymagic()

--- a/src/testdir/test_regexp_latin.vim
+++ b/src/testdir/test_regexp_latin.vim
@@ -874,12 +874,25 @@ func Regex_Mark()
   %d
 endfunc
 
+" Same test as abobe, but use verymagic
+func Regex_Mark_Verymagic()
+  call append(0, ['', '', '', 'Marks:', 'asdfSasdfsadfEasdf', 'asdfSas',
+        \ 'dfsadfEasdf', '', '', '', '', ''])
+  call cursor(4, 1)
+  exe "normal jfSmsfEme:.-4,.+6s/\\v.%>'s.*%<'e../here/\<CR>"
+  exe "normal jfSmsj0fEme:.-4,.+6s/\\v.%>'s\\_.*%<'e../again/\<CR>"
+  call assert_equal(['', '', '', 'Marks:', 'asdfhereasdf', 'asdfagainasdf',
+        \ '', '', '', '', '', ''], getline(1, '$'))
+  %d
+endfunc
+
 func Test_matching_marks()
   new
   set regexpengine=1
   call Regex_Mark()
   set regexpengine=2
   call Regex_Mark()
+  call Regex_Mark_Verymagic()
   bwipe!
 endfunc
 


### PR DESCRIPTION
Fix regexp parser for `\v%>'m` and `\v%<'m`
Currently `\v%'m` works fine, but it is unable to match before or after the position of mark `m`. The reason is that in line 1653, when the condition is true, `c` gets a negative value returned by `getchr()`