### PR TITLE
NSIS: Possibility to include translated license and README.txt files

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -596,6 +596,7 @@ SRC_DOS =	\
 		nsis/gvim_version.nsh \
 		nsis/README.txt \
 		nsis/lang/*.nsi \
+		nsis/lang/README.txt \
 		uninstall.txt \
 
 # Source files for MS Windows without CR/LF translation (also in the extra archive).

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ dist:
 # Clean up some files to avoid they are included.
 # Copy README files to the top directory.
 prepare:
-	if test -f runtime/doc/uganda.nsis.txt then \
+	if test -f runtime/doc/uganda.nsis.txt; then \
 		rm runtime/doc/uganda.nsis.???; fi
 	for name in $(IN_README_DIR); do \
 	  cp READMEdir/"$$name" .; \

--- a/Makefile
+++ b/Makefile
@@ -266,8 +266,8 @@ dist:
 # Clean up some files to avoid they are included.
 # Copy README files to the top directory.
 prepare:
-	if test -f runtime/doc/uganda.nsis.txt; then \
-		rm runtime/doc/uganda.nsis.txt; fi
+	if test -f runtime/doc/uganda.nsis.txt then \
+		rm runtime/doc/uganda.nsis.???; fi
 	for name in $(IN_README_DIR); do \
 	  cp READMEdir/"$$name" .; \
 	  done
@@ -407,12 +407,8 @@ amisrc: dist prepare
 	gzip -9 dist/vim$(VERSION)src.tar
 	mv dist/vim$(VERSION)src.tar.gz dist/vim$(VERSION)src.tgz
 
-no_title.vim: Makefile
-	echo "set notitle noicon nocp nomodeline viminfo=" >no_title.vim
-
 # MS-DOS sources
-dossrc: dist no_title.vim dist/$(COMMENT_SRC) \
-	runtime/doc/uganda.nsis.txt \
+dossrc: dist dist/$(COMMENT_SRC) runtime/doc/uganda.nsis.txt \
 	nsis/gvim_version.nsh
 	-rm -rf dist/vim$(VERSION)src.zip
 	-rm -rf dist/vim
@@ -424,16 +420,14 @@ dossrc: dist no_title.vim dist/$(COMMENT_SRC) \
 		$(SRC_DOS_BIN) \
 		$(SRC_AMI_DOS) \
 		$(SRC_DOS_UNIX) \
-		runtime/doc/uganda.nsis.txt \
+		runtime/doc/uganda.nsis.??? \
 		nsis/gvim_version.nsh \
 		| (cd dist/vim/$(VIMRTDIR); tar xf -)
 	mv dist/vim/$(VIMRTDIR)/runtime/* dist/vim/$(VIMRTDIR)
 	rmdir dist/vim/$(VIMRTDIR)/runtime
-	# This file needs to be in dos fileformat for NSIS.
-	$(VIM) -e -X -u no_title.vim -c ":set tx|wq" dist/vim/$(VIMRTDIR)/doc/uganda.nsis.txt
 	cd dist && zip -9 -rD -z vim$(VERSION)src.zip vim <$(COMMENT_SRC)
 
-runtime/doc/uganda.nsis.txt: runtime/doc/uganda.txt
+runtime/doc/uganda.nsis.txt: runtime/doc/uganda.???
 	cd runtime/doc && $(MAKE) uganda.nsis.txt
 
 nsis/gvim_version.nsh: Makefile
@@ -450,7 +444,7 @@ dosrt: dist dist/$(COMMENT_RT) dosrt_files
 
 # Split in two parts to avoid an "argument list too long" error.
 # We no longer convert the files from unix to dos fileformat.
-dosrt_files: dist prepare no_title.vim
+dosrt_files: dist prepare
 	-rm -rf dist/vim
 	mkdir dist/vim
 	mkdir dist/vim/$(VIMRTDIR)
@@ -506,7 +500,7 @@ dosbin: prepare dosbin_gvim dosbin_w32 dosbin_ole $(DOSBIN_S)
 	-rm $(IN_README_DIR)
 
 # make Win32 gvim
-dosbin_gvim: dist no_title.vim dist/$(COMMENT_GVIM)
+dosbin_gvim: dist dist/$(COMMENT_GVIM)
 	-rm -rf dist/gvim$(VERSION).zip
 	-rm -rf dist/vim
 	mkdir dist/vim
@@ -528,7 +522,7 @@ dosbin_gvim: dist no_title.vim dist/$(COMMENT_GVIM)
 	cp gvim.pdb dist/gvim$(VERSION).pdb
 
 # make Win32 console
-dosbin_w32: dist no_title.vim dist/$(COMMENT_W32)
+dosbin_w32: dist dist/$(COMMENT_W32)
 	-rm -rf dist/vim$(VERSION)w32.zip
 	-rm -rf dist/vim
 	mkdir dist/vim
@@ -545,7 +539,7 @@ dosbin_w32: dist no_title.vim dist/$(COMMENT_W32)
 	cp vimw32.pdb dist/vim$(VERSION)w32.pdb
 
 # make Win32 gvim with OLE
-dosbin_ole: dist no_title.vim dist/$(COMMENT_OLE)
+dosbin_ole: dist dist/$(COMMENT_OLE)
 	-rm -rf dist/gvim$(VERSION)ole.zip
 	-rm -rf dist/vim
 	mkdir dist/vim

--- a/nsis/README.txt
+++ b/nsis/README.txt
@@ -54,8 +54,8 @@ To build the installable .exe file:
 
 7.  On MS Windows do "nmake.exe -f Make_mvc.mak uganda.nsis.txt" in runtime/doc.
     On Unix-like system do "make runtime/doc/uganda.nsis.txt" in top directory
-    or "make uganda.nsis.txt" in runtime/doc, and be sure to convert the file
-    "uganda.nsis.txt" to DOS file format.
+    or "make uganda.nsis.txt" in runtime/doc.  The created files
+    "uganda.nsis.???" will be automatically converted to DOS file format.
 
 8.  Get gettext and iconv DLLs from the following site:
 	https://github.com/mlocati/gettext-iconv-windows/releases

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -1,6 +1,6 @@
 # NSIS file to create a self-installing exe for Vim.
 # It requires NSIS version 3.0 or later.
-# Last Change:	2024 Mar 18
+# Last Change:	2024 Mar 20
 
 Unicode true
 
@@ -139,7 +139,7 @@ RequestExecutionLevel highest
 # Show all languages, despite user's codepage:
 !define MUI_LANGDLL_ALLLANGUAGES
 # Always show dialog choice language
-#!define MUI_LANGDLL_ALWAYSSHOW
+!define MUI_LANGDLL_ALWAYSSHOW
 !define MUI_LANGDLL_REGISTRY_ROOT       "HKCU"
 !define MUI_LANGDLL_REGISTRY_KEY        "Software\Vim"
 !define MUI_LANGDLL_REGISTRY_VALUENAME  "Installer Language"
@@ -157,9 +157,9 @@ RequestExecutionLevel highest
 
 !define MUI_COMPONENTSPAGE_SMALLDESC
 !define MUI_LICENSEPAGE_CHECKBOX
-!define MUI_FINISHPAGE_RUN
-!define MUI_FINISHPAGE_RUN_FUNCTION        LaunchApplication
-!define MUI_FINISHPAGE_RUN_TEXT            $(str_show_readme)
+!define MUI_FINISHPAGE_SHOWREADME
+!define MUI_FINISHPAGE_SHOWREADME_TEXT	    $(str_show_readme)
+!define MUI_FINISHPAGE_SHOWREADME_FUNCTION  LaunchApplication
 
 # This adds '\Vim' to the user choice automagically.  The actual value is
 # obtained below with CheckOldVim.
@@ -183,7 +183,7 @@ SilentInstall normal
 
 # Installer pages
 !insertmacro MUI_PAGE_WELCOME
-!insertmacro MUI_PAGE_LICENSE "${VIMRT}\doc\uganda.nsis.txt"
+!insertmacro MUI_PAGE_LICENSE $(page_lic_file)
 !insertmacro MUI_PAGE_COMPONENTS
 Page custom SetCustom ValidateCustom
 #!define MUI_PAGE_CUSTOMFUNCTION_LEAVE VimFinalCheck
@@ -365,7 +365,7 @@ FunctionEnd
 
 Function LaunchApplication
    SetOutPath $0
-   ShellExecAsUser::ShellExecAsUser "" "$0\gvim.exe" '-R "$0\README.txt"'
+   ShellExecAsUser::ShellExecAsUser "" "$0\gvim.exe" '-R "$0\$(vim_readme_file)"'
 FunctionEnd
 
 ##########################################################
@@ -615,6 +615,110 @@ SectionGroupEnd
 Section "$(str_section_nls)" id_section_nls
 	SectionIn 1 3
 
+#; FIXME: When adding new translations, do not forget to make changes here.
+	SetOutPath $0
+!if /FileExists ..\README.dax.txt
+    ${If} $Language = ${LANG_DANISH}
+	File ..\README.dax.txt
+    ${EndIf}
+!endif
+!if /FileExists ..\README.nlx.txt
+    ${If} $Language = ${LANG_DUTCH}
+	File ..\README.nlx.txt
+    ${EndIf}
+!endif
+!if /FileExists ..\README.dex.txt
+    ${If} $Language = ${LANG_GERMAN}
+	File ..\README.dex.txt
+    ${EndIf}
+!endif
+!if /FileExists ..\README.itx.txt
+    ${If} $Language = ${LANG_ITALIAN}
+	File ..\README.itx.txt
+    ${EndIf}
+!endif
+!if /FileExists ..\README.jax.txt
+    ${If} $Language = ${LANG_JAPANESE}
+	File ..\README.jax.txt
+    ${EndIf}
+!endif
+!if /FileExists ..\README.rux.txt
+    ${If} $Language = ${LANG_RUSSIAN}
+	File ..\README.rux.txt
+    ${EndIf}
+!endif
+!if /FileExists ..\README.srx.txt
+    ${If} $Language = ${LANG_SERBIAN}
+	File ..\README.srx.txt
+    ${EndIf}
+!endif
+!if /FileExists ..\README.cnx.txt
+    ${If} $Language = ${LANG_SIMPCHINESE}
+	File ..\README.cnx.txt
+    ${EndIf}
+!endif
+!if /FileExists ..\README.twx.txt
+    ${If} $Language = ${LANG_TRADCHINESE}
+	File ..\README.twx.txt
+    ${EndIf}
+!endif
+!if /FileExists ..\README.trx.txt
+    ${OrIf} $Language = ${LANG_TURKISH}
+	File ..\README.trx.txt
+    ${EndIf}
+!endif
+#; FIXME: When adding new translations, do not forget to make changes here.
+	SetOutPath $0\doc
+!if /FileExists "${VIMRT}\doc\uganda.dax"
+    ${If} $Language = ${LANG_DANISH}
+	File ${VIMRT}\doc\uganda.dax
+    ${EndIf}
+!endif
+!if /FileExists "${VIMRT}\doc\uganda.nlx"
+    ${If} $Language = ${LANG_DUTCH}
+	File ${VIMRT}\doc\uganda.nlx
+    ${EndIf}
+!endif
+!if /FileExists "${VIMRT}\doc\uganda.dex"
+    ${If} $Language = ${LANG_GERMAN}
+	File ${VIMRT}\doc\uganda.dex
+    ${EndIf}
+!endif
+!if /FileExists "${VIMRT}\doc\uganda.itx"
+    ${If} $Language = ${LANG_ITALIAN}
+	File ${VIMRT}\doc\uganda.itx
+    ${EndIf}
+!endif
+!if /FileExists "${VIMRT}\doc\uganda.jax"
+    ${If} $Language = ${LANG_JAPANESE}
+	File ${VIMRT}\doc\uganda.jax
+    ${EndIf}
+!endif
+!if /FileExists "${VIMRT}\doc\uganda.rux"
+    ${If} $Language = ${LANG_RUSSIAN}
+	File ${VIMRT}\doc\uganda.rux
+    ${EndIf}
+!endif
+!if /FileExists "${VIMRT}\doc\uganda.srx"
+    ${If} $Language = ${LANG_SERBIAN}
+	File ${VIMRT}\doc\uganda.srx
+    ${EndIf}
+!endif
+!if /FileExists "${VIMRT}\doc\uganda.cnx"
+    ${If} $Language = ${LANG_SIMPCHINESE}
+	File ${VIMRT}\doc\uganda.cnx
+    ${EndIf}
+!endif
+!if /FileExists "${VIMRT}\doc\uganda.twx"
+    ${If} $Language = ${LANG_TRADCHINESE}
+	File ${VIMRT}\doc\uganda.twx
+    ${EndIf}
+!endif
+!if /FileExists "${VIMRT}\doc\uganda.trx"
+    ${If} $Language = ${LANG_TURKISH}
+	File ${VIMRT}\doc\uganda.trx
+    ${EndIf}
+!endif
 	SetOutPath $0\lang
 	File /r /x Makefile ${VIMRT}\lang\*.*
 	SetOutPath $0

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -139,7 +139,7 @@ RequestExecutionLevel highest
 # Show all languages, despite user's codepage:
 !define MUI_LANGDLL_ALLLANGUAGES
 # Always show dialog choice language
-!define MUI_LANGDLL_ALWAYSSHOW
+#!define MUI_LANGDLL_ALWAYSSHOW
 !define MUI_LANGDLL_REGISTRY_ROOT       "HKCU"
 !define MUI_LANGDLL_REGISTRY_KEY        "Software\Vim"
 !define MUI_LANGDLL_REGISTRY_VALUENAME  "Installer Language"

--- a/nsis/lang/README.txt
+++ b/nsis/lang/README.txt
@@ -1,0 +1,34 @@
+This directory contains a file with text strings for gVim installer.
+It also contains files with translations of the text strings for gVim installer
+into different languages.
+
+For translators.
+
+If you want to prepare a translation for the gVim installer, use the file
+"english.nsi" as a master file.  See the other translation files in this
+directory.
+Note that in the definition of the MUI_LANGUAGE macro, the name of the language
+to be translated must be the English name of the language.
+The name of the file with the translation must match the name of the target
+language.
+Also, when translating strings, pay attention to some restrictions on the
+allowable length of strings.  For example:
+ component description field - 117 characters;
+ description above the drop-down lists on the .vimrc page - 53 characters;
+ drop-down lists on the .vimrc page - 55 characters.
+Characters in this case mean characters of the English alphabet.
+
+If you do not yet have a translated "uganda.txt" file and a main "README.txt"
+file, set the following values:
+
+for the license file
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+
+for the readme.txt file
+LangString vim_readme_file 0 "README.txt"
+
+Once you have the translations of these files, then set the values for these
+variables similarly to what is done in the other translation files.
+Also add the appropriate entries to the "gvim.nsi" file as done for other
+languages.
+

--- a/nsis/lang/danish.nsi
+++ b/nsis/lang/danish.nsi
@@ -3,6 +3,7 @@
 # danish.nsi: Danish language strings for gvim NSIS installer.
 #
 # Locale ID    : 1030
+# Locale Name  : da
 # fileencoding : UTF-8
 # Author       : scootergrisen
 
@@ -13,6 +14,20 @@
 # These strings should be always English.  Otherwise dosinst.c fails.
 LangString ^SetupCaption     ${LANG_DANISH}         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_DANISH}         "$(^Name) Uninstall"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_DANISH} "${VIMRT}\doc\uganda.nsis.dax"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_DANISH} "README.dax.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/dutch.nsi
+++ b/nsis/lang/dutch.nsi
@@ -18,6 +18,20 @@ LangString ^UninstallCaption ${LANG_DUTCH} \
         "$(^Name) Uninstall"
 
 ##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_DUTCH} "${VIMRT}\doc\uganda.nsis.nlx"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_DUTCH} "README.nlx.txt"
+
+##############################################################################
 # MUI Configuration Strings                                               {{{1
 ##############################################################################
 

--- a/nsis/lang/english.nsi
+++ b/nsis/lang/english.nsi
@@ -3,6 +3,7 @@
 # english.nsi: English language strings for gvim NSIS installer.
 #
 # Locale ID    : 1033
+# Locale Name  : en
 # fileencoding : UTF-8
 # Author       : Guopeng Wen, Ken Takata
 
@@ -15,6 +16,18 @@ LangString ^SetupCaption     ${LANG_ENGLISH} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_ENGLISH} \
         "$(^Name) Uninstall"
+
+##############################################################################
+# License file for the license page                                       {{{1
+##############################################################################
+
+LicenseLangString page_lic_file ${LANG_ENGLISH} "${VIMRT}\doc\uganda.nsis.txt"
+
+##############################################################################
+# README.txt file, which is opened after installation                     {{{1
+##############################################################################
+
+LangString vim_readme_file ${LANG_ENGLISH} "README.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/german.nsi
+++ b/nsis/lang/german.nsi
@@ -3,6 +3,7 @@
 # german.nsi : German language strings for gvim NSIS installer.
 #
 # Locale ID    : 1031
+# Locale Name  : de
 # fileencoding : UTF-8
 # Author       : Christian Brabandt, tux
 
@@ -15,6 +16,20 @@ LangString ^SetupCaption     ${LANG_GERMAN} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_GERMAN} \
         "$(^Name) Uninstall"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_GERMAN} "${VIMRT}\doc\uganda.nsis.dex"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_GERMAN} "README.dex.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/greek.nsi
+++ b/nsis/lang/greek.nsi
@@ -3,6 +3,7 @@
 # greek.nsi: Greek language strings for gvim NSIS installer.
 #
 # Locale ID    : 1032
+# Locale Name  : el
 # fileencoding : UTF-8
 # Author       : Christos Longros
 
@@ -15,6 +16,20 @@ LangString ^SetupCaption     ${LANG_GREEK} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_GREEK} \
         "$(^Name) Uninstall"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_GREEK} "${VIMRT}\doc\uganda.nsis.elx"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_GREEK} "README.elx.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/italian.nsi
+++ b/nsis/lang/italian.nsi
@@ -3,6 +3,7 @@
 # italian.nsi : Italian language strings for gvim NSIS installer.
 #
 # Locale ID    : 1040
+# Locale Name  : it
 # fileencoding : UTF-8
 # Author       : Antonio Colombo, bovirus - revision: 12.05.2023
 
@@ -15,6 +16,20 @@ LangString ^SetupCaption     ${LANG_ITALIAN} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_ITALIAN} \
         "$(^Name) Uninstall"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_ITALIAN} "${VIMRT}\doc\uganda.nsis.itx"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_ITALIAN} "README.itx.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/japanese.nsi
+++ b/nsis/lang/japanese.nsi
@@ -3,6 +3,7 @@
 # japanese.nsi: Japanese language strings for gvim NSIS installer.
 #
 # Locale ID    : 1041
+# Locale Name  : ja
 # fileencoding : UTF-8
 # Author       : Ken Takata
 
@@ -25,6 +26,20 @@ LangString ^SpaceRequired    ${LANG_JAPANESE} \
 # Fix another NSIS Japanese translation. The access key was missing.
 LangString ^InstallBtn       ${LANG_JAPANESE} \
         "インストール(&I)"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_JAPANESE} "${VIMRT}\doc\uganda.nsis.jax"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_JAPANESE} "README.jax.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/russian.nsi
+++ b/nsis/lang/russian.nsi
@@ -3,7 +3,7 @@
 # russian.nsi: Russian language strings for gvim NSIS installer.
 #
 # Locale ID    : 1049
-# Locale name  : ru-RU
+# Locale name  : ru
 # fileencoding : UTF-8
 # Author       : Restorer
 
@@ -16,6 +16,18 @@ LangString ^SetupCaption     ${LANG_RUSSIAN} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_RUSSIAN} \
         "$(^Name) Uninstall"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file ${LANG_RUSSIAN} "${VIMRT}\doc\uganda.nsis.rux"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file ${LANG_RUSSIAN} "README.rux.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/serbian.nsi
+++ b/nsis/lang/serbian.nsi
@@ -3,6 +3,7 @@
 # serbian.nsi: Serbian language strings for gvim NSIS installer.
 #
 # Locale ID    : 3098
+# Locale Name  : sr
 # fileencoding : UTF-8
 # Author       : Ivan Pešić
 
@@ -15,6 +16,20 @@ LangString ^SetupCaption     ${LANG_SERBIAN} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_SERBIAN} \
         "$(^Name) Uninstall"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_SERBIAN} "${VIMRT}\doc\uganda.nsis.srx"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_SERBIAN} "README.srx.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/simpchinese.nsi
+++ b/nsis/lang/simpchinese.nsi
@@ -4,6 +4,7 @@
 # installer.
 #
 # Locale ID    : 2052
+# Locale Name  : cn
 # fileencoding : UTF-8
 # Author       : Guopeng Wen, David Liu
 
@@ -16,6 +17,21 @@ LangString ^SetupCaption     ${LANG_SIMPCHINESE} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_SIMPCHINESE} \
         "$(^Name) Uninstall"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_SIMPCHINESE} \
+#        "${VIMRT}\doc\uganda.nsis.cnx"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_SIMPCHINESE} "README.cnx.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/tradchinese.nsi
+++ b/nsis/lang/tradchinese.nsi
@@ -4,6 +4,7 @@
 # installer.
 #
 # Locale ID    : 1028
+# Locale Name  : tw
 # fileencoding : UTF-8
 # Author       : Guopeng Wen
 
@@ -16,6 +17,21 @@ LangString ^SetupCaption     ${LANG_TRADCHINESE} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_TRADCHINESE} \
         "$(^Name) Uninstall"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_TRADCHINESE} \
+#        "${VIMRT}\doc\uganda.nsis.twx"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_TRADCHINESE} "README.twx.txt"
 
 ##############################################################################
 # MUI Configuration Strings                                               {{{1

--- a/nsis/lang/turkish.nsi
+++ b/nsis/lang/turkish.nsi
@@ -1,4 +1,9 @@
+# vi:set ts=8 sts=4 sw=4 et fdm=marker:
+#
 # turkish.nsi: Turkish language strings for gvim NSIS installer.
+#
+# Locale ID    : 1055
+# Locale Name  : tr
 # fileencoding : UTF-8
 # Author       : Emir SARI
 
@@ -10,6 +15,22 @@ LangString ^SetupCaption     ${LANG_TURKISH} \
         "$(^Name) Setup"
 LangString ^UninstallCaption ${LANG_TURKISH} \
         "$(^Name) Uninstall"
+
+##############################################################################
+# Translated license file for the license page                            {{{1
+##############################################################################
+
+LicenseLangString page_lic_file 0 "${VIMRT}\doc\uganda.nsis.txt"
+#LicenseLangString page_lic_file ${LANG_TURKISH} "${VIMRT}\doc\uganda.nsis.trx"
+
+##############################################################################
+# Translated README.txt file, which is opened after installation          {{{1
+##############################################################################
+
+LangString vim_readme_file 0 "README.txt"
+#LangString vim_readme_file ${LANG_TURKISH} "README.trx.txt"
+
+##############################################################################
 
 LangString str_show_readme          ${LANG_TURKISH} \
     "Kurulum bittikten sonra README dosyasını aç"

--- a/runtime/doc/Make_mvc.mak
+++ b/runtime/doc/Make_mvc.mak
@@ -1,7 +1,7 @@
 #
 # Makefile for the Vim documentation on Windows
 #
-# 17.11.23, Restorer, <restorer@mail2k.ru>
+# 20.03.24, Restorer, <restorer@mail2k.ru>
 
 # Common components
 !INCLUDE Make_all.mak
@@ -23,7 +23,7 @@ ICONV_PATH = D:\Programs\GetText\bin
 # If the "touch" program is installed on the system, but it is not registered
 # in the %PATH% environment variable, then specify the full path to this file.
 !IF EXIST ("touch.exe")
-TOUCH = "touch.exe" %1
+TOUCH = touch.exe %1
 !ELSE
 TOUCH = if exist %1 ( copy /b %1+,, ) else ( type nul >%1 )
 !ENDIF
@@ -33,7 +33,7 @@ TOUCH = if exist %1 ( copy /b %1+,, ) else ( type nul >%1 )
 # If the "iconv" program is installed on the system, but it is not registered
 # in the %PATH% environment variable, then specify the full path to this file.
 !IF EXIST ("iconv.exe")
-ICONV = "iconv.exe"
+ICONV = iconv.exe
 !ELSEIF EXIST ("$(ICONV_PATH)\iconv.exe")
 ICONV = "$(ICONV_PATH)\iconv.exe"
 !ENDIF
@@ -53,8 +53,8 @@ all : tags perlhtml $(CONVERTED)
 tags : doctags $(DOCS)
 	doctags.exe $(DOCS) | sort /L C /O tags
 	$(PS) $(PSFLAGS) \
-		(Get-Content -Raw tags ^| Get-Unique ^| %%{$$_ -replace \"`r\", \"\"})\
-		^| New-Item -Force -Path . -ItemType file -Name tags
+		(Get-Content -Raw tags ^| Get-Unique ^| %%{$$_ -replace \"`r\", \"\"}) \
+		^| New-Item -Path . -Force -ItemType file -Name tags
 
 doctags : doctags.c
 	$(CC) doctags.c
@@ -67,13 +67,12 @@ vimtags : $(DOCS)
 
 
 uganda.nsis.txt : uganda.???
-	!@$(PS) $(PSFLAGS) $$ext=(Get-Item $?).Extension; (Get-Content $? ^| \
-		%%{$$_ -replace '\s*\*[-a-zA-Z0-9.]*\*', '' -replace 'vim:tw=78:.*', ''})\
-		^| Set-Content $*$$ext
-	!@$(PS) $(PSFLAGS) $$ext=(Get-Item $?).Extension; \
-		(Get-Content -Raw $(@B)$$ext).Trim() -replace '(\r\n){3,}', '$$1$$1' \
-		^| Set-Content $(@B)$$ext
-
+	! $(PS) $(PSFLAGS) (Get-Content $? -Encoding UTF8 \
+		^| %%{$$_ -replace '[\t\s]*\*.*\*', '' -replace 'vim:tw=\d\d:.*', ''}) \
+		^| Set-Content \"$(@B)$$((Get-Item $?).Extension)\" -Encoding Unicode
+	! $(PS) $(PSFLAGS)\
+		(Get-Content $(@B)$$((Get-Item $?).Extension) -Raw).Trim() -replace '(\r\n){3,}', '$$1$$1' \
+		^| Set-Content \"$(@B)$$((Get-Item $?).Extension)\" -Encoding Unicode
 
 # TODO:
 #html: noerrors tags $(HTMLS)

--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -50,9 +50,15 @@ vimtutor.man: vimtutor.1
 xxd.man: xxd.1
 	nroff -man $< | sed -e s/.//g > $@
 
-uganda.nsis.txt: uganda.txt
-	sed -e 's/[ 	]*\*[-a-zA-Z0-9.]*\*//g' -e 's/vim:tw=78:.*//' \
-		uganda.txt | uniq >uganda.nsis.txt
+uganda.nsis.txt : uganda.???
+	for dpn in $?; do \
+	  trg=$@; \
+          sed -e 's/[ 	]*\*.*\*//g' -e 's/vim:tw=[[:digit:]][[:digit:]]:.*//' \
+            $${dpn} | uniq > $${trg%txt}$${dpn##*.}; \
+	done
+# This files needs to be in dos fileformat for NSIS.
+	$(VIMEXE) -e -X -u NONE --cmd "set notitle noicon nocp noml viminfo=" \
+	  -c "argdo write ++ff=dos" -c "qa" uganda.nsis.???
 
 # Awk version of .txt to .html conversion.
 html: noerrors tags $(HTMLS)


### PR DESCRIPTION
Possibility to include translated license and README.txt files to the Vim installer.

nsis/gvim.nsi:
Changes have been made to add translated license and the main "README.txt" files
to the installer.
The files "uganda.??x" and "README.??x.txt" will be copied to the destination
directory depending on the selected language.

nsis/lang:
Added variables to the \<language\>.nsi files to specify the translated license
file and README.txt file. These lines are commented out.
To activate this feature you need to uncomment these lines and add translated
files "uganda.??x" and/or "README.??x.txt".
Added "README.txt" file with description of directory contents and
recommendations for translators.

runtime/doc:
The "Make_mvc.mak" and "Makefile" files have been modified to allow the creation
of "uganda.nsis.??x" files from translated "uganda.??x" files.

Makefile:
The rules for modifying the "uganda.nsis.txt" file in the Makefile have been
removed, since all work has been moved to the "runtime/doc/Makefile" file.
