### PR TITLE
Two unrelated things are tested by a single test

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7502,8 +7502,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	highlighted with |hl-NonText|.
 	You may also want to add "lastline" to the 'display' option to show as
 	much of the last line as possible.
-	NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y,
-	CTRL-D, CTRL-U, CTRL-F, CTRL-B and scrolling with the mouse.
+	NOTE: partly implemented, doesn't yet work for |gj| and |gk|, etc.
 
 					*'softtabstop'* *'sts'*
 'softtabstop' 'sts'	number	(default 0)

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4174,7 +4174,20 @@ func Test_normal34_zet_large()
   norm! z9765405999999999999
 endfunc
 
-" Test for { and } paragraph movements and Ctrl-B in buffer with a single line
+" Test for { and } paragraph movements in a single line
+func Test_brace_single_line()
+  new
+  call setline(1, ['foobar one two three'])
+  1
+  norm! 0}
+
+  call assert_equal([0, 1, 20, 0], getpos('.'))
+  norm! {
+  call assert_equal([0, 1, 1, 0], getpos('.'))
+  bw!
+endfunc
+
+" Test for Ctrl-B/Ctrl-U in buffer with a single line
 func Test_single_line_scroll()
   CheckFeature textprop
 
@@ -4183,12 +4196,7 @@ func Test_single_line_scroll()
   let vt = 'virt_above'
   call prop_type_add(vt, {'highlight': 'IncSearch'})
   call prop_add(1, 0, {'type': vt, 'text': '---', 'text_align': 'above'})
-  1
-  norm! 0}
-
-  call assert_equal([0, 1, 20, 0], getpos('.'))
-  norm! {
-  call assert_equal([0, 1, 1, 0], getpos('.'))
+  call cursor(1, 1)
 
   " Ctrl-B/Ctrl-U scroll up with hidden "above" virtual text.
   set smoothscroll
@@ -4203,6 +4211,7 @@ func Test_single_line_scroll()
 
   set smoothscroll&
   bw!
+  call prop_type_delete(vt)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -738,6 +738,7 @@ func Test_smoothscroll_mouse_pos()
   let &mouse = save_mouse
   let &term = save_term
   let &ttymouse = save_ttymouse
+  bwipe!
 endfunc
 
 " this was dividing by zero
@@ -999,9 +1000,8 @@ func Test_smoothscroll_textoff_small_winwidth()
 endfunc
 
 func Test_smoothscroll_page()
-  set smoothscroll
-
-  10split | 40vsplit
+  call NewWindow(10, 40)
+  setlocal smoothscroll
   call setline(1, 'abcde '->repeat(150))
 
   exe "norm! \<C-F>"
@@ -1038,7 +1038,7 @@ func Test_smoothscroll_page()
   exe "norm! \<C-U>"
   call assert_equal(0, winsaveview().skipcol)
 
-  set smoothscroll&
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Two unrelated things are tested by a single test.
Solution: Split it into two, restoring the old Test_brace_single_line().
          Add missing cleanup to some tests.