### PR TITLE
Improve doc for empty(), len(), and string()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2265,8 +2265,8 @@ empty({expr})						*empty()*
 		- A |Job| is empty when it failed to start.
 		- A |Channel| is empty when it is closed.
 		- A |Blob| is empty when its length is zero.
-		- An |Object| is empty, when the |empty()| builtin method in
-		  the object (if present) returns true.
+		- An |Object| is empty, when the empty() method in the object
+		  (if present) returns true. |object-empty()|
 
 		For a long |List| this is much faster than comparing the
 		length with zero.
@@ -5485,9 +5485,9 @@ len({expr})	The result is a Number, which is the length of the argument.
 		When {expr} is a |Blob| the number of bytes is returned.
 		When {expr} is a |Dictionary| the number of entries in the
 		|Dictionary| is returned.
-		When {expr} is an |Object|, invokes the |len()| method in the
-		object (if present) to get the length.  Otherwise returns
-		zero.
+		When {expr} is an |Object|, invokes the len() method in the
+		object (if present) to get the length (|object-len()|).
+		Otherwise returns zero.
 
 		Can also be used as a |method|: >
 			mylist->len()
@@ -9605,9 +9605,9 @@ string({expr})	Return {expr} converted to a String.  If {expr} is a Number,
 		replaced by "[...]" or "{...}".  Using eval() on the result
 		will then fail.
 
-		For an object, invokes the |string()| method to get a textual
+		For an object, invokes the string() method to get a textual
 		representation of the object.  If the method is not present,
-		then the default representation is used.
+		then the default representation is used. |object-string()|
 
 		Can also be used as a |method|: >
 			mylist->string()


### PR DESCRIPTION
In the documentation for the use of empty(), len(), and string() for objects, there're links to |string()|, |len()|, and |string()| but these are misleading.  I think they should be |object-string()|, |object-len()| and |object-string()|.

This PR suggests a concrate changes of this.