### PR TITLE
Add MsgArea highlight support

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5496,6 +5496,8 @@ MessageWindow	Messages popup window used by `:echowindow`.  If not defined
 		|hl-WarningMsg| is used.
 							*hl-ModeMsg*
 ModeMsg		'showmode' message (e.g., "-- INSERT --").
+							*hl-MsgArea*
+MsgArea		Area for messages and cmdline.
 							*hl-MoreMsg*
 MoreMsg		|more-prompt|
 							*hl-NonText*

--- a/src/message.c
+++ b/src/message.c
@@ -1637,6 +1637,9 @@ msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
     // Only quit when got_int was set in here.
     got_int = FALSE;
 
+    if (attr == 0)
+	attr = HL_ATTR(HLF_MSG);
+
     // if MSG_HIST flag set, add message to history
     if (attr & MSG_HIST)
     {
@@ -2230,6 +2233,9 @@ msg_puts_attr_len(char *str, int maxlen, int attr)
     if (msg_silent != 0)
 	return;
 
+    if (attr == 0)
+	attr = HL_ATTR(HLF_MSG);
+
     // if MSG_HIST flag set, add message to history
     if ((attr & MSG_HIST) && maxlen < 0)
     {
@@ -2678,13 +2684,15 @@ msg_scroll_up(void)
 	// Scrolling up doesn't result in the right background.  Set the
 	// background here.  It's not efficient, but avoids that we have to do
 	// it all over the code.
-	screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns, ' ', ' ', 0);
+	screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns,
+		' ', ' ', HL_ATTR(HLF_MSG));
 
 	// Also clear the last char of the last but one line if it was not
 	// cleared before to avoid a scroll-up.
 	if (ScreenAttrs[LineOffset[Rows - 2] + Columns - 1] == (sattr_T)-1)
 	    screen_fill((int)Rows - 2, (int)Rows - 1,
-				 (int)Columns - 1, (int)Columns, ' ', ' ', 0);
+				 (int)Columns - 1, (int)Columns,
+				 ' ', ' ', HL_ATTR(HLF_MSG));
     }
 }
 
@@ -2963,7 +2971,8 @@ disp_sb_line(int row, msgchunk_T *smp, int clear_to_eol)
 	// If clearing the screen did not work (e.g. because of a background
 	// color and t_ut isn't set) clear until the last column here.
 	if (clear_to_eol)
-	    screen_fill(row, row + 1, msg_col, (int)Columns, ' ', ' ', 0);
+	    screen_fill(row, row + 1, msg_col, (int)Columns,
+		    ' ', ' ', HL_ATTR(HLF_MSG));
 
 	if (mp->sb_eol || mp->sb_next == NULL)
 	    break;
@@ -3340,8 +3349,8 @@ do_more_prompt(int typed_char)
 		    // scroll up, display line at bottom
 		    msg_scroll_up();
 		    inc_msg_scrolled();
-		    screen_fill((int)Rows - 2, (int)Rows - 1, 0,
-						   (int)Columns, ' ', ' ', 0);
+		    screen_fill((int)Rows - 2, (int)Rows - 1, 0, (int)Columns,
+			    ' ', ' ', HL_ATTR(HLF_MSG));
 		    mp_last = disp_sb_line((int)Rows - 2, mp_last, FALSE);
 		    --toscroll;
 		}
@@ -3350,8 +3359,8 @@ do_more_prompt(int typed_char)
 	    if (toscroll <= 0)
 	    {
 		// displayed the requested text, more prompt again
-		screen_fill((int)Rows - 1, (int)Rows, 0,
-						   (int)Columns, ' ', ' ', 0);
+		screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns,
+			' ', ' ', HL_ATTR(HLF_MSG));
 		msg_moremsg(FALSE);
 		continue;
 	    }
@@ -3364,7 +3373,8 @@ do_more_prompt(int typed_char)
     }
 
     // clear the --more-- message
-    screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns, ' ', ' ', 0);
+    screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns,
+	    ' ', ' ', HL_ATTR(HLF_MSG));
     State = oldState;
     setmouse();
     if (quit_more)
@@ -3713,15 +3723,18 @@ msg_clr_eos_force(void)
 #ifdef FEAT_RIGHTLEFT
 	if (cmdmsg_rl)
 	{
-	    screen_fill(msg_row, msg_row + 1, 0, msg_col + 1, ' ', ' ', 0);
-	    screen_fill(msg_row + 1, (int)Rows, 0, (int)Columns, ' ', ' ', 0);
+	    screen_fill(msg_row, msg_row + 1, 0, msg_col + 1,
+		    ' ', ' ', HL_ATTR(HLF_MSG));
+	    screen_fill(msg_row + 1, (int)Rows, 0, (int)Columns,
+		    ' ', ' ', HL_ATTR(HLF_MSG));
 	}
 	else
 #endif
 	{
 	    screen_fill(msg_row, msg_row + 1, msg_col, (int)Columns,
-								 ' ', ' ', 0);
-	    screen_fill(msg_row + 1, (int)Rows, 0, (int)Columns, ' ', ' ', 0);
+		    ' ', ' ', HL_ATTR(HLF_MSG));
+	    screen_fill(msg_row + 1, (int)Rows, 0, (int)Columns,
+		    ' ', ' ', HL_ATTR(HLF_MSG));
 	}
     }
 }

--- a/src/message.c
+++ b/src/message.c
@@ -3140,6 +3140,9 @@ do_more_prompt(int typed_char)
     msgchunk_T	*mp_last = NULL;
     msgchunk_T	*mp;
     int		i;
+    int		msg_attr;
+
+    msg_attr = HL_ATTR(HLF_MSG);
 
     // We get called recursively when a timer callback outputs a message. In
     // that case don't show another prompt. Also when at the hit-Enter prompt
@@ -3350,7 +3353,7 @@ do_more_prompt(int typed_char)
 		    msg_scroll_up();
 		    inc_msg_scrolled();
 		    screen_fill((int)Rows - 2, (int)Rows - 1, 0, (int)Columns,
-			    ' ', ' ', HL_ATTR(HLF_MSG));
+			    ' ', ' ', msg_attr);
 		    mp_last = disp_sb_line((int)Rows - 2, mp_last, FALSE);
 		    --toscroll;
 		}
@@ -3360,7 +3363,7 @@ do_more_prompt(int typed_char)
 	    {
 		// displayed the requested text, more prompt again
 		screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns,
-			' ', ' ', HL_ATTR(HLF_MSG));
+			' ', ' ', msg_attr);
 		msg_moremsg(FALSE);
 		continue;
 	    }
@@ -3373,8 +3376,7 @@ do_more_prompt(int typed_char)
     }
 
     // clear the --more-- message
-    screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns,
-	    ' ', ' ', HL_ATTR(HLF_MSG));
+    screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns, ' ', ' ', msg_attr);
     State = oldState;
     setmouse();
     if (quit_more)
@@ -3720,21 +3722,25 @@ msg_clr_eos_force(void)
     }
     else
     {
+	int msg_attr;
+
+	msg_attr = HL_ATTR(HLF_MSG);
+
 #ifdef FEAT_RIGHTLEFT
 	if (cmdmsg_rl)
 	{
 	    screen_fill(msg_row, msg_row + 1, 0, msg_col + 1,
-		    ' ', ' ', HL_ATTR(HLF_MSG));
+		    ' ', ' ', msg_attr);
 	    screen_fill(msg_row + 1, (int)Rows, 0, (int)Columns,
-		    ' ', ' ', HL_ATTR(HLF_MSG));
+		    ' ', ' ', msg_attr);
 	}
 	else
 #endif
 	{
 	    screen_fill(msg_row, msg_row + 1, msg_col, (int)Columns,
-		    ' ', ' ', HL_ATTR(HLF_MSG));
+		    ' ', ' ', msg_attr);
 	    screen_fill(msg_row + 1, (int)Rows, 0, (int)Columns,
-		    ' ', ' ', HL_ATTR(HLF_MSG));
+		    ' ', ' ', msg_attr);
 	}
     }
 }

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -300,7 +300,7 @@ struct vimoption
 # define ISP_LATIN1 (char_u *)"@,161-255"
 #endif
 
-# define HIGHLIGHT_INIT "8:SpecialKey,~:EndOfBuffer,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,y:CurSearch,m:MoreMsg,M:ModeMsg,n:LineNr,a:LineNrAbove,b:LineNrBelow,N:CursorLineNr,G:CursorLineSign,O:CursorLineFold,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,[:PmenuKind,]:PmenuKindSel,{:PmenuExtra,}:PmenuExtraSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine,z:StatusLineTerm,Z:StatusLineTermNC"
+# define HIGHLIGHT_INIT "8:SpecialKey,~:EndOfBuffer,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,y:CurSearch,m:MoreMsg,M:ModeMsg,n:LineNr,a:LineNrAbove,b:LineNrBelow,N:CursorLineNr,G:CursorLineSign,O:CursorLineFold,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,[:PmenuKind,]:PmenuKindSel,{:PmenuExtra,}:PmenuExtraSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine,z:StatusLineTerm,Z:StatusLineTermNC,g:MsgArea"
 
 // Default python version for pyx* commands
 #if defined(FEAT_PYTHON) && defined(FEAT_PYTHON3)

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -856,6 +856,15 @@ func Test_highlight_User()
   hi clear
 endfunc
 
+" Test for MsgArea highlighting
+func Test_highlight_MsgArea()
+  CheckNotGui
+  hi MsgArea ctermfg=20
+  redraw!
+  call assert_equal('20', synIDattr(synIDtrans(hlID('MsgArea')), 'fg'))
+  hi clear
+endfunc
+
 " Test for using RGB color values in a highlight group
 func Test_xxlast_highlight_RGB_color()
   CheckCanRunGui

--- a/src/vim.h
+++ b/src/vim.h
@@ -1515,6 +1515,7 @@ typedef enum
     , HLF_QFL	    // quickfix window line currently selected
     , HLF_ST	    // status lines of terminal windows
     , HLF_STNC	    // status lines of not-current terminal windows
+    , HLF_MSG	    // message area
     , HLF_COUNT	    // MUST be the last one
 } hlf_T;
 
@@ -1526,7 +1527,7 @@ typedef enum
 		  'B', 'P', 'R', 'L', \
 		  '+', '=', '[', ']', '{', '}', 'x', 'X', \
 		  '*', '#', '_', '!', '.', 'o', 'q', \
-		  'z', 'Z'}
+		  'z', 'Z', 'g'}
 
 /*
  * Boolean constants


### PR DESCRIPTION
neovim implements `MsgArea` highlight support.

So I have implemented it in Vim.

It is useful to implement input command line plugin.

![2024-03-29_10-15](https://github.com/vim/vim/assets/41495/d9bed315-7269-4df1-89c8-f57f12312044)
