### PR TITLE
runtime:compilers: ensure compiler! sets global options

### DIFF
--- a/runtime/compiler/bdf.vim
+++ b/runtime/compiler/bdf.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:             BDF to PCF Conversion
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2006-04-19
+" Latest Revision:      2024 Mar 29
 
 if exists("current_compiler")
   finish
@@ -11,9 +11,12 @@ let current_compiler = "bdf"
 let s:cpo_save = &cpo
 set cpo-=C
 
-setlocal makeprg=bdftopcf\ $*
+if exists(":CompilerSet") != 2 # Older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
 
-setlocal errorformat=%ABDF\ %trror\ on\ line\ %l:\ %m,
+CompilerSet makeprg=bdftopcf\ $*
+CompilerSet errorformat=%ABDF\ %trror\ on\ line\ %l:\ %m,
       \%-Z%p^,
       \%Cbdftopcf:\ bdf\ input\\,\ %f\\,\ corrupt,
       \%-G%.%#

--- a/runtime/compiler/bdf.vim
+++ b/runtime/compiler/bdf.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler:             BDF to PCF Conversion
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Last Change:      2024 Mar 29 by Enno Nagel
+" Contributors:         Enno Nagel
+" Last Change:          2024 Mar 29
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/bdf.vim
+++ b/runtime/compiler/bdf.vim
@@ -12,7 +12,7 @@ let current_compiler = "bdf"
 let s:cpo_save = &cpo
 set cpo-=C
 
-if exists(":CompilerSet") != 2 # Older Vim always used :setlocal
+if exists(":CompilerSet") != 2 " Older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 

--- a/runtime/compiler/bdf.vim
+++ b/runtime/compiler/bdf.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:             BDF to PCF Conversion
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2024 Mar 29
+" Last Change:      2024 Mar 29 by Enno Nagel
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/context.vim
+++ b/runtime/compiler/context.vim
@@ -3,7 +3,8 @@ vim9script
 # Language:           ConTeXt typesetting engine
 # Maintainer:         Nicola Vitacolonna <nvitacolonna@gmail.com>
 # Former Maintainers: Nikolai Weibull <now@bitwi.se>
-# Last Change:        2024 Mar 29 by Enno Nagel
+" Contributors:       Enno Nagel
+# Last Change:        2024 Mar 29
 
 if exists("g:current_compiler")
   finish

--- a/runtime/compiler/context.vim
+++ b/runtime/compiler/context.vim
@@ -3,7 +3,7 @@ vim9script
 # Language:           ConTeXt typesetting engine
 # Maintainer:         Nicola Vitacolonna <nvitacolonna@gmail.com>
 # Former Maintainers: Nikolai Weibull <now@bitwi.se>
-# Latest Revision:    2023 Dec 26
+# Latest Revision:    2024 Mar 29
 
 if exists("g:current_compiler")
   finish
@@ -20,6 +20,7 @@ g:current_compiler = 'context'
 if get(b:, 'context_ignore_makefile', get(g:, 'context_ignore_makefile', 0)) ||
   (!filereadable('Makefile') && !filereadable('makefile'))
   &l:makeprg =  join(context.ConTeXtCmd(shellescape(expand('%:p:t'))), ' ')
+  execute 'CompilerSet makeprg='. escape(&l:makeprg, ' ')
 else
   g:current_compiler = 'make'
 endif

--- a/runtime/compiler/context.vim
+++ b/runtime/compiler/context.vim
@@ -3,7 +3,7 @@ vim9script
 # Language:           ConTeXt typesetting engine
 # Maintainer:         Nicola Vitacolonna <nvitacolonna@gmail.com>
 # Former Maintainers: Nikolai Weibull <now@bitwi.se>
-# Latest Revision:    2024 Mar 29
+# Last Change:        2024 Mar 29 by Enno Nagel
 
 if exists("g:current_compiler")
   finish
@@ -19,8 +19,8 @@ g:current_compiler = 'context'
 
 if get(b:, 'context_ignore_makefile', get(g:, 'context_ignore_makefile', 0)) ||
   (!filereadable('Makefile') && !filereadable('makefile'))
-  &l:makeprg =  join(context.ConTeXtCmd(shellescape(expand('%:p:t'))), ' ')
-  execute 'CompilerSet makeprg='. escape(&l:makeprg, ' ')
+  var makeprg =  join(context.ConTeXtCmd(shellescape(expand('%:p:t'))), ' ')
+  execute 'CompilerSet makeprg=' .. escape(makeprg, ' ')
 else
   g:current_compiler = 'make'
 endif

--- a/runtime/compiler/context.vim
+++ b/runtime/compiler/context.vim
@@ -3,7 +3,7 @@ vim9script
 # Language:           ConTeXt typesetting engine
 # Maintainer:         Nicola Vitacolonna <nvitacolonna@gmail.com>
 # Former Maintainers: Nikolai Weibull <now@bitwi.se>
-" Contributors:       Enno Nagel
+# Contributors:       Enno Nagel
 # Last Change:        2024 Mar 29
 
 if exists("g:current_compiler")

--- a/runtime/compiler/mcs.vim
+++ b/runtime/compiler/mcs.vim
@@ -1,8 +1,7 @@
 " Vim compiler file
 " Compiler:    Mono C# Compiler
 " Maintainer:  Jarek Sobiecki <harijari@go2.pl>
-" Last Updated By: Peter Collingbourne
-" Latest Revision: 2024 Mar 29
+" Last Change: 2024 Mar 29 by Enno Nagel
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/mcs.vim
+++ b/runtime/compiler/mcs.vim
@@ -2,7 +2,7 @@
 " Compiler:    Mono C# Compiler
 " Maintainer:  Jarek Sobiecki <harijari@go2.pl>
 " Last Updated By: Peter Collingbourne
-" Latest Revision: 2012 Jul 19
+" Latest Revision: 2024 Mar 29
 
 if exists("current_compiler")
   finish
@@ -12,7 +12,12 @@ let current_compiler = "mcs"
 let s:cpo_save = &cpo
 set cpo-=C
 
-setlocal errorformat=
+if exists(":CompilerSet") != 2 # Older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet makeprg=mcs
+CompilerSet errorformat=
          \%D%.%#Project\ \"%f/%[%^/\"]%#\"%.%#,
          \%X%.%#Done\ building\ project\ \"%f/%[%^/\"]%#\"%.%#,
          \%-G%\\s%.%#,

--- a/runtime/compiler/mcs.vim
+++ b/runtime/compiler/mcs.vim
@@ -12,7 +12,7 @@ let current_compiler = "mcs"
 let s:cpo_save = &cpo
 set cpo-=C
 
-if exists(":CompilerSet") != 2 # Older Vim always used :setlocal
+if exists(":CompilerSet") != 2 " Older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 

--- a/runtime/compiler/mcs.vim
+++ b/runtime/compiler/mcs.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
-" Compiler:    Mono C# Compiler
-" Maintainer:  Jarek Sobiecki <harijari@go2.pl>
-" Last Change: 2024 Mar 29 by Enno Nagel
+" Compiler:     Mono C# Compiler
+" Maintainer:   Jarek Sobiecki <harijari@go2.pl>
+" Contributors: Peter Collingbourne and Enno Nagel
+" Last Change:  2024 Mar 29
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/modelsim_vcom.vim
+++ b/runtime/compiler/modelsim_vcom.vim
@@ -1,7 +1,7 @@
 " Vim Compiler File
 " Compiler:	Modelsim Vcom
 " Maintainer:	Paul Baleme <pbaleme@mail.com>
-" Last Change:	September 8, 2003
+" Last Change:	2024 Mar 29
 " Thanks to:    allanherriman@hotmail.com
 
 if exists("current_compiler")
@@ -13,8 +13,9 @@ if exists(":CompilerSet") != 2		" older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 
-"setlocal errorformat=\*\*\ %tRROR:\ %f(%l):\ %m,%tRROR:\ %f(%l):\ %m,%tARNING\[%*[0-9]\]:\ %f(%l):\ %m,\*\*\ %tRROR:\ %m,%tRROR:\ %m,%tARNING\[%*[0-9]\]:\ %m
+CompilerSet makeprg=vcom
 
+"setlocal errorformat=\*\*\ %tRROR:\ %f(%l):\ %m,%tRROR:\ %f(%l):\ %m,%tARNING\[%*[0-9]\]:\ %f(%l):\ %m,\*\*\ %tRROR:\ %m,%tRROR:\ %m,%tARNING\[%*[0-9]\]:\ %m
 "setlocal errorformat=%tRROR:\ %f(%l):\ %m,%tARNING\[%*[0-9]\]:\ %m
 CompilerSet errorformat=\*\*\ %tRROR:\ %f(%l):\ %m,\*\*\ %tRROR:\ %m,\*\*\ %tARNING:\ %m,\*\*\ %tOTE:\ %m,%tRROR:\ %f(%l):\ %m,%tARNING\[%*[0-9]\]:\ %f(%l):\ %m,%tRROR:\ %m,%tARNING\[%*[0-9]\]:\ %m
 

--- a/runtime/compiler/modelsim_vcom.vim
+++ b/runtime/compiler/modelsim_vcom.vim
@@ -1,7 +1,7 @@
 " Vim Compiler File
 " Compiler:	Modelsim Vcom
 " Maintainer:	Paul Baleme <pbaleme@mail.com>
-" Last Change:	2024 Mar 29
+" Last Change:	2024 Mar 29 by Enno Nagel
 " Thanks to:    allanherriman@hotmail.com
 
 if exists("current_compiler")

--- a/runtime/compiler/modelsim_vcom.vim
+++ b/runtime/compiler/modelsim_vcom.vim
@@ -1,7 +1,8 @@
 " Vim Compiler File
 " Compiler:	Modelsim Vcom
 " Maintainer:	Paul Baleme <pbaleme@mail.com>
-" Last Change:	2024 Mar 29 by Enno Nagel
+" Contributors: Enno Nagel
+" Last Change:	2024 Mar 29
 " Thanks to:    allanherriman@hotmail.com
 
 if exists("current_compiler")

--- a/runtime/compiler/powershell.vim
+++ b/runtime/compiler/powershell.vim
@@ -38,7 +38,7 @@ let g:ps1_efm_show_error_categories = get(g:, 'ps1_efm_show_error_categories', 0
 
 " Use absolute path because powershell requires explicit relative paths
 " (./file.ps1 is okay, but # expands to file.ps1)
-let &l:makeprg = g:ps1_makeprg_cmd .' %:p:S'
+let makeprg = g:ps1_makeprg_cmd .. ' %:p:S'
 
 " Parse file, line, char from callstacks:
 "     Write-Ouput : The term 'Write-Ouput' is not recognized as the name of a
@@ -51,7 +51,7 @@ let &l:makeprg = g:ps1_makeprg_cmd .' %:p:S'
 "         + CategoryInfo          : ObjectNotFound: (Write-Ouput:String) [], CommandNotFoundException
 "         + FullyQualifiedErrorId : CommandNotFoundException
 
-execute 'CompilerSet makeprg='. escape(&l:makeprg, ' ')
+execute 'CompilerSet makeprg=' .. escape(makeprg, ' ')
 
 " Showing error in context with underlining.
 CompilerSet errorformat=%+G+%m

--- a/runtime/compiler/powershell.vim
+++ b/runtime/compiler/powershell.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler:	powershell
 " URL: https://github.com/PProvost/vim-ps1
-" Last Change: 2024 Mar 29 by Enno Nagel
+" Contributors: Enno Nagel
+" Last Change: 2024 Mar 29
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/powershell.vim
+++ b/runtime/compiler/powershell.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:	powershell
 " URL: https://github.com/PProvost/vim-ps1
-" Last Change: 2020 Mar 30
+" Last Change: 2024 Mar 29
 
 if exists("current_compiler")
   finish
@@ -49,6 +49,8 @@ let &l:makeprg = g:ps1_makeprg_cmd .' %:p:S'
 "     +     ~~~~~~~~~~~
 "         + CategoryInfo          : ObjectNotFound: (Write-Ouput:String) [], CommandNotFoundException
 "         + FullyQualifiedErrorId : CommandNotFoundException
+
+execute 'CompilerSet makeprg='. escape(&l:makeprg, ' ')
 
 " Showing error in context with underlining.
 CompilerSet errorformat=%+G+%m

--- a/runtime/compiler/powershell.vim
+++ b/runtime/compiler/powershell.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:	powershell
 " URL: https://github.com/PProvost/vim-ps1
-" Last Change: 2024 Mar 29
+" Last Change: 2024 Mar 29 by Enno Nagel
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     TeX
 " Maintainer:   Artem Chuprina <ran@ran.pp.ru>
-" Last Change:  2024 Mar 29
+" Last Change:  2024 Mar 29 by Enno Nagel
 
 if exists("current_compiler")
 	finish

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -28,8 +28,8 @@ if exists('b:tex_ignore_makefile') || exists('g:tex_ignore_makefile') ||
 	else
 		let current_compiler = "latex"
 	endif
-	let &l:makeprg=current_compiler.' -interaction=nonstopmode'
-	execute 'CompilerSet makeprg='. escape(&l:makeprg, ' ')
+	let makeprg=current_compiler .. ' -interaction=nonstopmode'
+	execute 'CompilerSet makeprg=' .. escape(makeprg, ' ')
 else
 	let current_compiler = 'make'
 endif

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     TeX
 " Maintainer:   Artem Chuprina <ran@ran.pp.ru>
-" Last Change:  2012 Apr 30
+" Last Change:  2024 Mar 29
 
 if exists("current_compiler")
 	finish
@@ -28,6 +28,7 @@ if exists('b:tex_ignore_makefile') || exists('g:tex_ignore_makefile') ||
 		let current_compiler = "latex"
 	endif
 	let &l:makeprg=current_compiler.' -interaction=nonstopmode'
+	execute 'CompilerSet makeprg='. escape(&l:makeprg, ' ')
 else
 	let current_compiler = 'make'
 endif

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler:     TeX
 " Maintainer:   Artem Chuprina <ran@ran.pp.ru>
-" Last Change:  2024 Mar 29 by Enno Nagel
+" Contributors: Enno Nagel
+" Last Change:  2024 Mar 29
 
 if exists("current_compiler")
 	finish


### PR DESCRIPTION
Previously some options were only set locally by
&l:makeprg/errorformat

This suffices for :compiler (without a trailing bang) but falls short for :compiler! that sets &g:makeprg/errorformat as well