### PR TITLE
Conceal test fails when rightleft feature is disabled

### DIFF
--- a/src/testdir/test_conceal.vim
+++ b/src/testdir/test_conceal.vim
@@ -199,6 +199,7 @@ endfunc
 
 " Same as Test_conceal_wrapped_cursorline_wincolor(), but with 'rightleft'.
 func Test_conceal_wrapped_cursorline_wincolor_rightleft()
+  CheckFeature rightleft
   CheckScreendump
 
   let code =<< trim [CODE]


### PR DESCRIPTION
Problem:  Conceal test fails when rightleft feature is disabled.
Solution: Skip test if rightleft feature is missing.