### PR TITLE
filetype: intel hex files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -938,7 +938,7 @@ au BufNewFile,BufRead *.vc,*.ev,*.sum,*.errsum	setf hercules
 au BufRead,BufNewFile *.heex			setf heex
 
 " HEX (Intel)
-au BufNewFile,BufRead *.hex,*.h32		setf hex
+au BufNewFile,BufRead *.hex,*.ihex,*.int,*.ihe,*.ihx,*.mcs,*.h32,*.h80,*.h86,*.a43,*.a90	setf hex
 
 " Hjson
 au BufNewFile,BufRead *.hjson			setf hjson

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -312,7 +312,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     hcl: ['file.hcl'],
     heex: ['file.heex'],
     hercules: ['file.vc', 'file.ev', 'file.sum', 'file.errsum'],
-    hex: ['file.hex', 'file.h32'],
+    hex: ['file.hex', 'file.ihex', 'file.ihe', 'file.ihx', 'file.int', 'file.mcs', 'file.h32', 'file.h80', 'file.h86', 'file.a43', 'file.a90'],
     hgcommit: ['hg-editor-file.txt'],
     hjson: ['file.hjson'],
     hlsplaylist: ['file.m3u', 'file.m3u8'],


### PR DESCRIPTION
Problem: sometimes intel hex files are not recognized
Solution: Add a pattern for them
Refer: https://en.wikipedia.org/wiki/Intel_HEX
