### PR TITLE
filetype: gnuplot history files are not recognised

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -862,7 +862,7 @@ au BufNewFile,BufRead *.gts			setf typescript.glimmer
 au BufNewFile,BufRead *.gjs			setf javascript.glimmer
 
 " Gnuplot scripts
-au BufNewFile,BufRead *.gpi,*.gnuplot		setf gnuplot
+au BufNewFile,BufRead *.gpi,*.gnuplot,.gnuplot_history	setf gnuplot
 
 " Go (Google)
 au BufNewFile,BufRead *.go			setf go

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -283,7 +283,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     glsl: ['file.glsl'],
     gn: ['file.gn', 'file.gni'],
     gnash: ['gnashrc', '.gnashrc', 'gnashpluginrc', '.gnashpluginrc'],
-    gnuplot: ['file.gpi', '.gnuplot', 'file.gnuplot'],
+    gnuplot: ['file.gpi', '.gnuplot', 'file.gnuplot', '.gnuplot_history'],
     go: ['file.go'],
     gomod: ['go.mod'],
     gosum: ['go.sum', 'go.work.sum'],


### PR DESCRIPTION
Problem: Gnuplot history files are not recognised.
Solution: Add a pattern for gnuplot history files.
