### PR TITLE
filetype: yarn lock files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2944,6 +2944,9 @@ au filetypedetect BufNewFile,BufRead,StdinReadPost *
 	\   setf FALLBACK conf |
 	\ endif
 
+" Yarn lock
+au BufNewFile,BufRead yarn.lock			setf yaml
+
 
 " If the GUI is already running, may still need to install the Syntax menu.
 " Don't do it when the 'M' flag is included in 'guioptions'.

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -820,7 +820,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     xsd: ['file.xsd'],
     xslt: ['file.xsl', 'file.xslt'],
     yacc: ['file.yy', 'file.yxx', 'file.y++'],
-    yaml: ['file.yaml', 'file.yml', 'file.eyaml', '.clangd', '.clang-format', '.clang-tidy'],
+    yaml: ['file.yaml', 'file.yml', 'file.eyaml', '.clangd', '.clang-format', '.clang-tidy', 'yarn.lock'],
     yang: ['file.yang'],
     yuck: ['file.yuck'],
     z8a: ['file.z8a'],


### PR DESCRIPTION
Problem: Yarn lock files are not recognized.
Solution: Add a pattern for yarn lock files
