### PR TITLE
filetype: rock_manifest and config.ld files cannot be recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1254,7 +1254,10 @@ au BufNewFile,BufRead .luaurc		setf jsonc
 au BufNewFile,BufRead .luacheckrc		setf lua
 
 " Luarocks
-au BufNewFile,BufRead *.rockspec		setf lua
+au BufNewFile,BufRead *.rockspec,rock_manifest	setf lua
+
+" Luadoc, Ldoc
+au BufNewFile,BufRead config.ld			setf lua
 
 " Linden Scripting Language (Second Life)
 au BufNewFile,BufRead *.lsl			call dist#ft#FTlsl()

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -396,7 +396,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     lpc: ['file.lpc', 'file.ulpc'],
     lsl: ['file.lsl'],
     lss: ['file.lss'],
-    lua: ['file.lua', 'file.rockspec', 'file.nse', '.luacheckrc', '.busted'],
+    lua: ['file.lua', 'file.rockspec', 'file.nse', '.luacheckrc', '.busted', 'rock_manifest', 'config.ld'],
     luau: ['file.luau'],
     lynx: ['lynx.cfg'],
     lyrics: ['file.lrc'],


### PR DESCRIPTION
Problem: Rock_manifest and config.ld files cannot be recognized.
Solution: Add a pattern for rock_manifest and config.ld files
