### PR TITLE
Filetype test fails

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -523,6 +523,10 @@ au BufNewFile,BufRead *.lrc			setf lyrics
 au BufNewFile,BufRead *.quake,cm3.cfg		setf m3quake
 au BufNewFile,BufRead m3makefile,m3overrides	setf m3build
 
+" Many Python tools use dosini as their config, like setuptools, pudb, coverage
+" (must be before *.cfg)
+au BufNewFile,BufRead setup.cfg,pudb.cfg,.coveragerc	setf dosini
+
 " Quake
 au BufNewFile,BufRead *baseq[2-3]/*.cfg,*id1/*.cfg	setf quake
 au BufNewFile,BufRead *quake[1-3]/*.cfg			setf quake
@@ -1045,9 +1049,6 @@ au BufNewFile,BufRead *.4gl,*.4gh,*.m4gl	setf fgl
 " .INI file for MSDOS
 au BufNewFile,BufRead *.ini,*.INI		setf dosini
 
-" Many python tools use dosini as their config, such as setuptools, pudb, coverage
-au BufNewFile,BufRead setup.cfg,pudb.cfg,.coveragerc	setf dosini
-
 " SysV Inittab
 au BufNewFile,BufRead inittab			setf inittab
 
@@ -1182,6 +1183,9 @@ au BufNewFile,BufRead *.sig			call dist#ft#FTsig()
 " LDAP LDIF
 au BufNewFile,BufRead *.ldif			setf ldif
 
+" Luadoc, Ldoc (must be before *.ld)
+au BufNewFile,BufRead config.ld			setf lua
+
 " Ld loader
 au BufNewFile,BufRead *.ld,*/ldscripts/*	setf ld
 
@@ -1270,9 +1274,6 @@ au BufNewFile,BufRead .luacheckrc		setf lua
 
 " Luarocks
 au BufNewFile,BufRead *.rockspec,rock_manifest	setf lua
-
-" Luadoc, Ldoc
-au BufNewFile,BufRead config.ld			setf lua
 
 " Linden Scripting Language (Second Life)
 au BufNewFile,BufRead *.lsl			call dist#ft#FTlsl()

--- a/src/edit.c
+++ b/src/edit.c
@@ -847,7 +847,7 @@ doESCkey:
 		// ins_redraw() triggers TextChangedI only when no characters
 		// are in the typeahead buffer, so reset curbuf->b_last_changedtick only
 		// if the TextChangedI was not blocked by char_avail() (e.g. using :norm!)
-		// and the TextChangeDI autocommand has been trigered
+		// and the TextChangedI autocommand has been triggered.
 		if (!char_avail() && curbuf->b_last_changedtick_i == CHANGEDTICK(curbuf))
 		    curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
 		return (c == Ctrl_O);

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -3734,11 +3734,6 @@ func Test_Changed_ChangedI()
   call feedkeys("yypi\<esc>", 'tnix')
   call assert_equal('', g:autocmd_i)
 
-  " TextChanged should only trigger if change was done in Normal mode
-  let g:autocmd_n = ''
-  call feedkeys("ibar\<esc>", 'tnix')
-  call assert_equal('', g:autocmd_n)
-
   " If change is a mix of Normal and Insert modes, TextChangedI should trigger
   func s:validate_mixed_textchangedi(keys)
     call feedkeys("ifoo\<esc>", 'tnix')
@@ -4532,20 +4527,30 @@ endfunc
 
 " Test TextChangedI and TextChanged
 func Test_Changed_ChangedI_2()
+  " Run this test in a terminal because it requires running the main loop.
   CheckRunVimInTerminal
   call writefile(['one', 'two', 'three'], 'XTextChangedI2', 'D')
   let before =<< trim END
-      autocmd TextChanged,TextChangedI * call writefile([b:changedtick], 'XTextChangedI3')
+      let [g:autocmd_n, g:autocmd_i] = ['','']
+
+      func TextChangedAutocmd(char)
+        let g:autocmd_{tolower(a:char)} = a:char .. b:changedtick
+        call writefile([g:autocmd_n, g:autocmd_i], 'XTextChangedI3')
+      endfunc
+
+      au TextChanged  <buffer> :call TextChangedAutocmd('N')
+      au TextChangedI <buffer> :call TextChangedAutocmd('I')
+
       nnoremap <CR> o<Esc>
       call writefile([], 'XTextChangedI3')
   END
 
   call writefile(before, 'Xinit', 'D')
   let buf = RunVimInTerminal('-S Xinit XtextChangedI2', {})
+  call WaitForAssert({-> assert_true(filereadable('XTextChangedI3'))})
   call term_sendkeys(buf, "\<cr>")
-  call term_wait(buf)
+  call WaitForAssert({-> assert_equal(['N4', ''], readfile('XTextChangedI3'))})
   call StopVimInTerminal(buf)
-  call assert_equal(['4'], readfile('XTextChangedI3'))
 
   call delete('XTextChangedI3')
 endfunc


### PR DESCRIPTION
Problem:  Filetype test fails.
Solution: Move detection by name before detection by extension.
          Improve TextChanged test and remove wrong test.
