### PR TITLE
runtime(requirements): add support

### DIFF
--- a/runtime/compiler/pip_compile.vim
+++ b/runtime/compiler/pip_compile.vim
@@ -1,0 +1,46 @@
+" the Requirements File Format syntax support for Vim
+" Version: 1.8.0
+" Author:  raimon <raimon49@hotmail.com>
+" Upstream: https://github.com/raimon49/requirements.txt.vim
+" License: MIT LICENSE
+" The MIT License (MIT)
+"
+" Copyright (c) 2015 raimon
+"
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the "Software"), to deal
+" in the Software without restriction, including without limitation the rights
+" to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+" copies of the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+"
+" The above copyright notice and this permission notice shall be included in all
+" copies or substantial portions of the Software.
+"
+" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+" OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+" SOFTWARE.
+
+if exists('b:current_compiler')
+    finish
+endif
+let b:current_compiler = 'pip_compile'
+
+let s:save_cpoptions = &cpoptions
+set cpoptions&vim
+
+if exists(':CompilerSet') != 2
+    command -nargs=* CompilerSet setlocal <args>
+endif
+CompilerSet makeprg=pip-compile\ %:S
+CompilerSet errorformat=%ECould\ not\ find\ a\ version\ that\ matches\ %o\ (from\ -r\ %f\ (line\ %l)),
+            \%C%m,
+            \%Z,
+            \%-G%.%#
+let &cpoptions = s:save_cpoptions
+unlet s:save_cpoptions
+" vim: et sw=4 ts=4 sts=4:

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1693,6 +1693,11 @@ au BufNewFile,BufRead .pinerc,pinerc,.pinercex,pinercex		setf pine
 " Pip requirements
 au BufNewFile,BufRead *.pip			setf requirements
 au BufNewFile,BufRead requirements.txt		setf requirements
+au BufNewFile,BufRead *-requirements.txt	setf requirements
+au BufNewFile,BufRead constraints.txt		setf requirements
+au BufNewFile,BufRead requirements.in		setf requirements
+au BufNewFile,BufRead requirements/*.txt	setf requirements
+au BufNewFile,BufRead requires/*.txt		setf requirements
 
 " Pipenv Pipfiles
 au BufNewFile,BufRead Pipfile			setf toml

--- a/runtime/ftplugin/requirements.vim
+++ b/runtime/ftplugin/requirements.vim
@@ -1,0 +1,43 @@
+" the Requirements File Format syntax support for Vim
+" Version: 1.8.0
+" Author:  raimon <raimon49@hotmail.com>
+" Upstream: https://github.com/raimon49/requirements.txt.vim
+" License: MIT LICENSE
+" The MIT License (MIT)
+"
+" Copyright (c) 2015 raimon
+"
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the "Software"), to deal
+" in the Software without restriction, including without limitation the rights
+" to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+" copies of the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+"
+" The above copyright notice and this permission notice shall be included in all
+" copies or substantial portions of the Software.
+"
+" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+" OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+" SOFTWARE.
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:save_cpoptions = &cpoptions
+set cpoptions&vim
+
+let b:undo_ftplugin = "setl iskeyword< commentstring<"
+" pip options contain "-"
+setlocal iskeyword+=-
+setlocal commentstring=#\ %s
+compiler pip_compile
+
+let &cpoptions = s:save_cpoptions
+unlet s:save_cpoptions
+" vim: et sw=4 ts=4 sts=4:

--- a/runtime/syntax/requirements.vim
+++ b/runtime/syntax/requirements.vim
@@ -1,0 +1,67 @@
+" the Requirements File Format syntax support for Vim
+" Version: 1.8.0
+" Author:  raimon <raimon49@hotmail.com>
+" Upstream: https://github.com/raimon49/requirements.txt.vim
+" License: MIT LICENSE
+" The MIT License (MIT)
+"
+" Copyright (c) 2015 raimon
+"
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the "Software"), to deal
+" in the Software without restriction, including without limitation the rights
+" to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+" copies of the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+"
+" The above copyright notice and this permission notice shall be included in all
+" copies or substantial portions of the Software.
+"
+" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+" OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+" SOFTWARE.
+
+if exists("b:current_syntax") && b:current_syntax == "requirements"
+    finish
+endif
+
+syn case match
+
+" https://pip.pypa.io/en/stable/reference/requirements-file-format/
+" https://pip.pypa.io/en/stable/reference/inspect-report/#example
+syn keyword requirementsKeyword implementation_name implementation_version os_name platform_machine platform_release platform_system platform_version python_full_version platform_python_implementation python_version sys_platform contained
+syn region requirementsSubst matchgroup=requirementsSubstDelim start="\V${" end="\V}"
+syn region requirementsString matchgroup=requirementsStringDelim start=`'` skip=`\\'` end=`'`
+syn region requirementsString matchgroup=requirementsStringDelim start=`"` skip=`\\"` end=`"`
+syn match requirementsVersion "\v\d+[a-zA-Z0-9\.\-\*]*"
+syn region requirementsComment start="[ \t]*#" end="$"
+syn match requirementsCommandOption "\v^\[?--?[a-zA-Z\-]*\]?"
+syn match requirementsVersionSpecifiers "\v(\=\=\=?|\<\=?|\>\=?|\~\=|\!\=)"
+syn match requirementsPackageName "\v^([a-zA-Z0-9][a-zA-Z0-9\-_\.]*[a-zA-Z0-9])"
+syn match requirementsExtras "\v\[\S+\]"
+syn match requirementsVersionControls "\v(git\+?|hg\+|svn\+|bzr\+).*://.\S+"
+syn match requirementsURLs "\v(\@\s)?(https?|ftp|gopher)://?[^\s/$.?#].\S*"
+syn match requirementsEnvironmentMarkers "\v;\s[^#]+" contains=requirementsKeyword,requirementsVersionSpecifiers,requirementsString
+
+hi def link requirementsKeyword Keyword
+hi def link requirementsSubstDelim Delimiter
+hi def link requirementsSubst PreProc
+hi def link requirementsStringDelim Delimiter
+hi def link requirementsString String
+hi def link requirementsVersion Number
+hi def link requirementsComment Comment
+hi def link requirementsCommandOption Special
+hi def link requirementsVersionSpecifiers Boolean
+hi def link requirementsPackageName Identifier
+hi def link requirementsExtras Type
+hi def link requirementsVersionControls Underlined
+hi def link requirementsURLs Underlined
+hi def link requirementsEnvironmentMarkers Macro
+
+let b:current_syntax = "requirements"
+
+" vim: et sw=4 ts=4 sts=4:

--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -71,10 +71,10 @@ func Test_compiler_completion()
   call assert_match('^"compiler ' .. clist .. '$', @:)
 
   call feedkeys(":compiler p\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match('"compiler pandoc pbx perl\( p[a-z]\+\)\+ pylint pyunit', @:)
+  call assert_match('"compiler pandoc pbx perl\( p[a-z_]\+\)\+ pylint pyunit', @:)
 
   call feedkeys(":compiler! p\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match('"compiler! pandoc pbx perl\( p[a-z]\+\)\+ pylint pyunit', @:)
+  call assert_match('"compiler! pandoc pbx perl\( p[a-z_]\+\)\+ pylint pyunit', @:)
 endfunc
 
 func Test_compiler_error()

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -585,7 +585,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     readline: ['.inputrc', 'inputrc'],
     rego: ['file.rego'],
     remind: ['.reminders', 'file.remind', 'file.rem', '.reminders-file'],
-    requirements: ['file.pip', 'requirements.txt'],
+    requirements: ['file.pip', 'requirements.txt', 'dev-requirements.txt', 'constraints.txt', 'requirements.in', 'requirements/dev.txt', 'requires/dev.txt'],
     rescript: ['file.res', 'file.resi'],
     resolv: ['resolv.conf'],
     reva: ['file.frt'],


### PR DESCRIPTION
runtime/filetype.vim have requirements, however its syntax is missing.
