### PR TITLE
Prefix the class name with the script name in the stack trace.

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -215,6 +215,9 @@ estack_sfile(estack_arg_T which UNUSED)
 	    if (*class_name != NUL)
 	    {
 		// For class methods prepend "<class name>." to the function name.
+		ga_concat(&ga, (char_u *)"<SNR>");
+		ga.ga_len += vim_snprintf((char *)ga.ga_data + ga.ga_len, 23,
+		       "%d_", entry->es_info.ufunc->uf_script_ctx.sc_sid);
 		ga_concat(&ga, class_name);
 		ga_append(&ga, '.');
 	    }

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -3741,7 +3741,7 @@ def Test_stack_expansion_with_methods()
     endclass
 
     def F0()
-      assert_match('<SNR>\d\+_F\[1\]\.\.C\.M1\[1\]\.\.<SNR>\d\+_F0\[1\]$', expand('<stack>'))
+      assert_match('<SNR>\d\+_F\[1\]\.\.<SNR>\d\+_C\.M1\[1\]\.\.<SNR>\d\+_F0\[1\]$', expand('<stack>'))
     enddef
 
     def F()


### PR DESCRIPTION
Fix #14376