### PR TITLE
Heap buffer overflow when calling complete_add() in 'completefunc'

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2741,6 +2741,7 @@ expand_by_function(int type, char_u *base)
     --textlock;
 
     curwin->w_cursor = pos;	// restore the cursor position
+    check_cursor();  // make sure cursor position is valid, just in case
     validate_cursor();
     if (!EQUAL_POS(curwin->w_cursor, pos))
     {
@@ -4606,6 +4607,7 @@ get_userdefined_compl_info(colnr_T curs_col UNUSED)
 
     State = save_State;
     curwin->w_cursor = pos;	// restore the cursor position
+    check_cursor();  // make sure cursor position is valid, just in case
     validate_cursor();
     if (!EQUAL_POS(curwin->w_cursor, pos))
     {

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2429,4 +2429,26 @@ func Test_complete_changed_complete_info()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_completefunc_first_call_complete_add()
+  new
+
+  func Complete(findstart, base) abort
+    if a:findstart
+      let col = col('.')
+      call complete_add('#')
+      return col - 1
+    else
+      return []
+    endif
+  endfunc
+
+  set completeopt=longest completefunc=Complete
+  " This used to cause heap-buffer-overflow
+  call assert_fails('call feedkeys("ifoo#\<C-X>\<C-U>", "xt")', 'E840:')
+
+  delfunc Complete
+  set completeopt& completefunc&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Heap buffer overflow when calling complete_add() in the first
          call to 'completefunc'.
Solution: Call check_cursor() after calling 'completefunc'.
