### PR TITLE
runtime(vim): Add typespec filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2373,6 +2373,9 @@ au BufNewFile,BufRead *.mts,*.cts		setf typescript
 " TypeScript with React
 au BufNewFile,BufRead *.tsx			setf typescriptreact
 
+" TypeSpec files
+au BufNewFile,BufRead *.tsp			setf typespec
+
 " Motif UIT/UIL files
 au BufNewFile,BufRead *.uit,*.uil		setf uil
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -756,6 +756,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     typescript: ['file.mts', 'file.cts'],
     'typescript.glimmer': ['file.gts'],
     typescriptreact: ['file.tsx'],
+    typespec: ['file.tsp'],
     ungrammar: ['file.ungram'],
     uc: ['file.uc'],
     udevconf: ['/etc/udev/udev.conf', 'any/etc/udev/udev.conf'],


### PR DESCRIPTION
This adds a filetype for the [typespec language](https://typespec.io/), based on the `.tsp` extension.