### PR TITLE
Problems with "zb" and scrolling to new topline with 'smoothscroll'

### DIFF
--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4210,4 +4210,19 @@ func Test_single_line_scroll()
   call prop_type_delete(vt)
 endfunc
 
+" Test for zb in buffer with a single line and filler lines
+func Test_single_line_filler_zb()
+  call setline(1, ['', 'foobar one two three'])
+  diffthis
+  new
+  call setline(1, ['foobar one two three'])
+  diffthis
+
+  " zb scrolls to reveal filler lines at the start of the buffer.
+  exe "normal \<C-E>zb"
+  call assert_equal(1, winsaveview().topfill)
+
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1018,6 +1018,8 @@ func Test_smoothscroll_page()
   call assert_equal(0, winsaveview().skipcol)
 
   " Half-page scrolling does not go beyond end of buffer and moves the cursor.
+  " Even with 'nostartofline', the correct amount of lines is scrolled.
+  setl nostartofline
   exe "norm! 0\<C-D>"
   call assert_equal(200, winsaveview().skipcol)
   call assert_equal(204, col('.'))
@@ -1041,7 +1043,7 @@ func Test_smoothscroll_page()
   call assert_equal(204, col('.'))
   exe "norm! \<C-U>"
   call assert_equal(0, winsaveview().skipcol)
-  call assert_equal(1, col('.'))
+  call assert_equal(40, col('.'))
 
   bwipe!
 endfunc
@@ -1058,6 +1060,11 @@ func Test_smoothscroll_next_topline()
   exe "norm! \<C-E>"
   redraw
   call assert_equal(0, winsaveview().skipcol)
+
+  " Also when scrolling back.
+  exe "norm! G\<C-Y>"
+  redraw
+  call assert_equal(880, winsaveview().skipcol)
 
   " Cursor in correct place when not in the first screenline of a buffer line.
   exe "norm! gg4gj20\<C-D>\<C-D>"


### PR DESCRIPTION
Problem: "zb" does not reveal filler lines at the start of a buffer.
          Scrolled cursor position with 'smoothscroll' is unpredictable,
          and may reset skipcol later if it is not visible.
Solution: Replace confusing for loop that reaches final control value too
          early with while loop. Set "w_curswant" accordingly so cursor
          will be placed in visible part of topline.