### PR TITLE
fix(dialog): save unamed buffer correctly

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -164,6 +164,8 @@ dialog_changed(
     int		ret;
     buf_T	*buf2;
     exarg_T     ea;
+    int		empty_buf;
+    char_u	cwd[MAXPATHL];
 
     dialog_msg(buff, _("Save changes to \"%s\"?"), buf->b_fname);
     if (checkall)
@@ -181,10 +183,30 @@ dialog_changed(
 	// May get file name, when there is none
 	browse_save_fname(buf);
 #endif
-	if (buf->b_fname != NULL && check_overwrite(&ea, buf,
-				    buf->b_fname, buf->b_ffname, FALSE) == OK)
+	empty_buf = buf->b_fname == NULL ? TRUE : FALSE;
+	if (empty_buf == TRUE)
+	{
+	    buf->b_fname = vim_strsave((char_u *)"Untitled");
+	    if (mch_dirname(cwd, MAXPATHL) == OK)
+	    {
+		buf->b_ffname = concat_fnames(vim_strsave(cwd), buf->b_fname, TRUE);
+	    }
+	}
+	if (check_overwrite(&ea, buf, buf->b_fname, buf->b_ffname, FALSE) == OK)
+	{
 	    // didn't hit Cancel
-	    (void)buf_write_all(buf, FALSE);
+	    if (buf_write_all(buf, FALSE) == OK)
+		return;
+	}
+
+	// restore to empty when write failed
+	if (empty_buf == TRUE)
+	{
+	    vim_free(buf->b_fname);
+	    buf->b_fname = NULL;
+	    vim_free(buf->b_ffname);
+	    buf->b_ffname = NULL;
+	}
     }
     else if (ret == VIM_NO)
     {

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -165,7 +165,6 @@ dialog_changed(
     buf_T	*buf2;
     exarg_T     ea;
     int		empty_buf;
-    char_u	cwd[MAXPATHL];
 
     dialog_msg(buff, _("Save changes to \"%s\"?"), buf->b_fname);
     if (checkall)
@@ -186,11 +185,7 @@ dialog_changed(
 	empty_buf = buf->b_fname == NULL ? TRUE : FALSE;
 	if (empty_buf == TRUE)
 	{
-	    buf->b_fname = vim_strsave((char_u *)"Untitled");
-	    if (mch_dirname(cwd, MAXPATHL) == OK)
-	    {
-		buf->b_ffname = concat_fnames(vim_strsave(cwd), buf->b_fname, TRUE);
-	    }
+	    buf_set_name(buf->b_fnum, (char_u *)"Untitled");
 	}
 	if (check_overwrite(&ea, buf, buf->b_fname, buf->b_ffname, FALSE) == OK)
 	{
@@ -206,6 +201,9 @@ dialog_changed(
 	    buf->b_fname = NULL;
 	    vim_free(buf->b_ffname);
 	    buf->b_ffname = NULL;
+	    vim_free(buf->b_sfname);
+	    buf->b_sfname = NULL;
+	    unchanged(buf, TRUE, FALSE);
 	}
     }
     else if (ret == VIM_NO)

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -261,26 +261,10 @@ func Test_goto_buf_with_confirm()
   call assert_equal(1, &modified)
   call assert_equal('', @%)
   call feedkeys('y', 'L')
-  call assert_fails('confirm b XgotoConf', ['', 'E37:'])
-  call assert_equal(1, &modified)
-  call assert_equal('', @%)
-  call feedkeys('n', 'L')
   confirm b XgotoConf
   call assert_equal('XgotoConf', @%)
-  close!
-endfunc
-
-func Test_confirm_write_unamed()
-  CheckUnix
-  CheckNotGui
-  call writefile(['foo'], 'Xfoo', 'D')
-  enew
-  call setline(1, 'test')
-  call feedkeys('y', 'L')
-  confirm edit Xfoo
-  call assert_equal('Xfoo', @%)
-  bprevious
-  call assert_equal('Untitled', @%)
+  call assert_equal(['test'], readfile('Untitled'))
+  call delete('Untitled')
   close!
 endfunc
 

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -270,6 +270,20 @@ func Test_goto_buf_with_confirm()
   close!
 endfunc
 
+func Test_confirm_write_unamed()
+  CheckUnix
+  CheckNotGui
+  call writefile(['foo'], 'Xfoo', 'D')
+  enew
+  call setline(1, 'test')
+  call feedkeys('y', 'L')
+  confirm edit Xfoo
+  call assert_equal('Xfoo', @%)
+  bprevious
+  call assert_equal('Untitled', @%)
+  close!
+endfunc
+
 " Test for splitting buffer with 'switchbuf'
 func Test_buffer_switchbuf()
   new Xswitchbuf


### PR DESCRIPTION
Problem: when bufname is empty it can not save correctly

Solution: set bufname before save.



see https://github.com/neovim/neovim/issues/21682