### PR TITLE
runtime: Remove fallback :CompilerSet definition from compiler plugins

### DIFF
--- a/runtime/compiler/ant.vim
+++ b/runtime/compiler/ant.vim
@@ -2,15 +2,12 @@
 " Compiler:	ant
 " Maintainer:	Johannes Zellner <johannes@zellner.org>
 " Last Change:	Mi, 13 Apr 2005 22:50:07 CEST
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
     finish
 endif
 let current_compiler = "ant"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/bcc.vim
+++ b/runtime/compiler/bcc.vim
@@ -2,15 +2,12 @@
 " Compiler:		bcc - Borland C
 " Maintainer:	Emile van Raaij (eraaij@xs4all.nl)
 " Last Change:	2004 Mar 27
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "bcc"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 " A workable errorformat for Borland C
 CompilerSet errorformat=%*[^0-9]%n\ %f\ %l:\ %m

--- a/runtime/compiler/bdf.vim
+++ b/runtime/compiler/bdf.vim
@@ -3,6 +3,7 @@
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Contributors:         Enno Nagel
 " Last Change:          2024 Mar 29
+"                       2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -11,10 +12,6 @@ let current_compiler = "bdf"
 
 let s:cpo_save = &cpo
 set cpo-=C
-
-if exists(":CompilerSet") != 2 " Older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=bdftopcf\ $*
 CompilerSet errorformat=%ABDF\ %trror\ on\ line\ %l:\ %m,

--- a/runtime/compiler/cargo.vim
+++ b/runtime/compiler/cargo.vim
@@ -2,6 +2,7 @@
 " Compiler:         Cargo Compiler
 " Maintainer:       Damien Radtke <damienradtke@gmail.com>
 " Latest Revision:  2023-09-11
+"                   2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists('current_compiler')

--- a/runtime/compiler/checkstyle.vim
+++ b/runtime/compiler/checkstyle.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Checkstyle
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Aug 2
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "checkstyle"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/cm3.vim
+++ b/runtime/compiler/cm3.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Critical Mass Modula-3 Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2021 Apr 08
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "cm3"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/context.vim
+++ b/runtime/compiler/context.vim
@@ -5,16 +5,13 @@ vim9script
 # Former Maintainers: Nikolai Weibull <now@bitwi.se>
 # Contributors:       Enno Nagel
 # Last Change:        2024 Mar 29
+#                     2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("g:current_compiler")
   finish
 endif
 
 import autoload '../autoload/context.vim'
-
-if exists(":CompilerSet") != 2 # Older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 g:current_compiler = 'context'
 

--- a/runtime/compiler/cs.vim
+++ b/runtime/compiler/cs.vim
@@ -3,6 +3,7 @@
 " Maintainer:             Yichao Zhou (broken.zhou@gmail.com)
 " Previous Maintainer:    Joseph H. Yao (hyao@sina.com)
 " Last Change:            Jul 22, 2019
+"                         2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -10,10 +11,6 @@ endif
 let current_compiler = "cs"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat&
 CompilerSet errorformat+=%f(%l\\,%v):\ %t%*[^:]:\ %m,

--- a/runtime/compiler/csslint.vim
+++ b/runtime/compiler/csslint.vim
@@ -1,16 +1,13 @@
 " Vim compiler file
 " Compiler:	csslint for CSS
-" Maintainer: Daniel Moch <daniel@danielmoch.com>
-" Last Change: 2016 May 21
+" Maintainer:	Daniel Moch <daniel@danielmoch.com>
+" Last Change:	2016 May 21
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "csslint"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=csslint\ --format=compact
 CompilerSet errorformat=%-G,%-G%f:\ lint\ free!,%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %m

--- a/runtime/compiler/cucumber.vim
+++ b/runtime/compiler/cucumber.vim
@@ -2,15 +2,12 @@
 " Compiler:	Cucumber
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Last Change:	2016 Aug 29
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "cucumber"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/dart.vim
+++ b/runtime/compiler/dart.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Dart VM
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 May 08
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "dart"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/dart2js.vim
+++ b/runtime/compiler/dart2js.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Dart to JavaScript Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 May 08
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "dart2js"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/dart2native.vim
+++ b/runtime/compiler/dart2native.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Dart to Native Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 May 08
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "dart2native"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/dartanalyser.vim
+++ b/runtime/compiler/dartanalyser.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Dart Analyzer
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 May 08
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "dartanalyzer"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/dartdevc.vim
+++ b/runtime/compiler/dartdevc.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Dart Development Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 May 08
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "dartdevc"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/dartdoc.vim
+++ b/runtime/compiler/dartdoc.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Dart Documentation Generator
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 May 08
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "dartdoc"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/dartfmt.vim
+++ b/runtime/compiler/dartfmt.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Dart Formatter
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 May 08
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "dartfmt"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/decada.vim
+++ b/runtime/compiler/decada.vim
@@ -14,6 +14,7 @@
 "               08.09.2006 MK Correct double load protection.
 "    Help Page: compiler-decada
 "------------------------------------------------------------------------------
+" Last Change:	2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if (exists("current_compiler") && current_compiler == "decada") || version < 700
    finish
@@ -32,13 +33,6 @@ if !exists("g:decada")
      \'call decada.Make ()')
 
    call g:decada.Set_Session ()
-endif
-
-if exists(":CompilerSet") != 2
-   "
-   " plugin loaded by other means then the "compiler" command
-   "
-   command -nargs=* CompilerSet setlocal <args>
 endif
 
 execute "CompilerSet makeprg="     . escape (g:decada.Make_Command, ' ')

--- a/runtime/compiler/dot.vim
+++ b/runtime/compiler/dot.vim
@@ -2,15 +2,12 @@
 " Compiler:     ATT dot
 " Maintainer:	Marcos Macedo <bar4ka@bol.com.br>
 " Last Change:	2024 March 21
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "dot"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=dot\ -T$*\ \"%:p\"\ -o\ \"%:p:r.$*\"
 " matches error messages as below skipping final part after line number

--- a/runtime/compiler/dotnet.vim
+++ b/runtime/compiler/dotnet.vim
@@ -2,6 +2,7 @@
 " Compiler:            dotnet build (.NET CLI)
 " Maintainer:          Nick Jensen <nickspoon@gmail.com>
 " Last Change:         2022-12-06
+"                      2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " License:             Vim (see :h license)
 " Repository:          https://github.com/nickspoons/vim-cs
 
@@ -9,10 +10,6 @@ if exists("current_compiler")
   finish
 endif
 let current_compiler = "dotnet"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/erlang.vim
+++ b/runtime/compiler/erlang.vim
@@ -2,6 +2,7 @@
 " Compiler:     Erlang
 " Maintainer:	Dmitry Vasiliev <dima at hlabs dot org>
 " Last Change:	2019 Jul 23
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/eruby.vim
+++ b/runtime/compiler/eruby.vim
@@ -3,16 +3,12 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2018 Jan 25
+" Last Change:		2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "eruby"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -2,15 +2,12 @@
 " Compiler:    ESLint for JavaScript
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2020 August 20
+"	       2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "eslint"
-
-if exists(":CompilerSet") != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=npx\ eslint\ --format\ compact
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m,%-G%.%#

--- a/runtime/compiler/fbc.vim
+++ b/runtime/compiler/fbc.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	FreeBASIC Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2015 Jan 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "fbc"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/fortran_F.vim
+++ b/runtime/compiler/fortran_F.vim
@@ -3,16 +3,13 @@
 " URL:		http://www.unb.ca/chem/ajit/compiler/fortran_F.vim
 " Maintainer:	Ajit J. Thakkar (ajit AT unb.ca); <http://www.unb.ca/chem/ajit/>
 " Version:	0.2
-" Last Change: 2004 Mar 27
+" Last Change:	2004 Mar 27
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "fortran_F"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cposet=&cpoptions
 set cpoptions-=C

--- a/runtime/compiler/fortran_cv.vim
+++ b/runtime/compiler/fortran_cv.vim
@@ -2,15 +2,12 @@
 " Compiler:	Compaq Visual Fortran
 " Maintainer:	Joh.-G. Simon (johann-guenter.simon@linde-le.com)
 " Last Change:	11/05/2002
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "fortran_cv"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cposet = &cpoptions
 set cpoptions-=C

--- a/runtime/compiler/fortran_elf90.vim
+++ b/runtime/compiler/fortran_elf90.vim
@@ -4,16 +4,13 @@
 " URL:		http://www.unb.ca/chem/ajit/compiler/fortran_elf90.vim
 " Maintainer:	Ajit J. Thakkar (ajit AT unb.ca); <http://www.unb.ca/chem/ajit/>
 " Version:	0.2
-" Last Change: 2004 Mar 27
+" Last Change:	2004 Mar 27
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "fortran_elf90"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cposet=&cpoptions
 set cpoptions-=C

--- a/runtime/compiler/fortran_g77.vim
+++ b/runtime/compiler/fortran_g77.vim
@@ -2,16 +2,13 @@
 " Compiler:     g77 (GNU Fortran)
 " Maintainer:   Ralf Wildenhues <Ralf.Wildenhues@gmx.de>
 " Last Change:  $Date: 2004/06/13 18:17:36 $
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " $Revision: 1.1 $
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "fortran_g77"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/fortran_lf95.vim
+++ b/runtime/compiler/fortran_lf95.vim
@@ -3,16 +3,13 @@
 " URL:		http://www.unb.ca/chem/ajit/compiler/fortran_lf95.vim
 " Maintainer:	Ajit J. Thakkar (ajit AT unb.ca); <http://www.unb.ca/chem/ajit/>
 " Version:	0.2
-" Last Change: 2004 Mar 27
+" Last Change:	2004 Mar 27
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "fortran_lf95"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cposet=&cpoptions
 set cpoptions-=C

--- a/runtime/compiler/fpc.vim
+++ b/runtime/compiler/fpc.vim
@@ -2,15 +2,12 @@
 " Compiler:     FPC 2.1
 " Maintainer:   Jaroslaw Blasiok <jaro3000@o2.pl>
 " Last Change:  2005 October 07
+"               2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "fpc"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 " NOTE: compiler must be run with -vb to write whole source path, not only file
 " name.

--- a/runtime/compiler/g95.vim
+++ b/runtime/compiler/g95.vim
@@ -2,6 +2,7 @@
 " Maintainer: H Xu <xuhdev@gmail.com>
 " Version: 0.1.3
 " Last Change: 2012 Apr 30
+"              2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " Homepage: http://www.vim.org/scripts/script.php?script_id=3492
 "           https://bitbucket.org/xuhdev/compiler-g95.vim
 " License: Same as Vim
@@ -12,10 +13,6 @@ endif
 let current_compiler = 'g95'
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=
             \%AIn\ file\ %f:%l,

--- a/runtime/compiler/gawk.vim
+++ b/runtime/compiler/gawk.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	GNU Awk
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Feb 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "gawk"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/gcc.vim
+++ b/runtime/compiler/gcc.vim
@@ -1,10 +1,11 @@
 " Vim compiler file
-" Compiler:             GNU C Compiler
-" Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2010-10-14
-" 			changed pattern for entering/leaving directories
-" 			by Daniel Hahler, 2019 Jul 12
-" 			added line suggested by Anton Lindqvist 2016 Mar 31
+" Compiler:		GNU C Compiler
+" Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
+" Last Change:		2010 Oct 14
+"			changed pattern for entering/leaving directories
+"			by Daniel Hahler, 2019 Jul 12
+"			added line suggested by Anton Lindqvist 2016 Mar 31
+"			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/gfortran.vim
+++ b/runtime/compiler/gfortran.vim
@@ -2,6 +2,7 @@
 " Maintainer: H Xu <xuhdev@gmail.com>
 " Version: 0.1.3
 " Last Change: 2012 Apr 30
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " Homepage: http://www.vim.org/scripts/script.php?script_id=3496
 "           https://bitbucket.org/xuhdev/compiler-gfortran.vim
 " License: Same as Vim
@@ -12,10 +13,6 @@ endif
 let current_compiler = 'gfortran'
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=
             \%A%f:%l.%c:,

--- a/runtime/compiler/gjs.vim
+++ b/runtime/compiler/gjs.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	GJS (Gnome JavaScript Bindings)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 Jul 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "gjs"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/gm2.vim
+++ b/runtime/compiler/gm2.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	GNU Modula-2 Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Jan 04
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "gm2"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/gnat.vim
+++ b/runtime/compiler/gnat.vim
@@ -52,13 +52,6 @@ if !exists("g:gnat")
    call g:gnat.Set_Session ()
 endif
 
-if exists(":CompilerSet") != 2
-   "
-   " plugin loaded by other means then the "compiler" command
-   "
-   command -nargs=* CompilerSet setlocal <args>
-endif
-
 execute "CompilerSet makeprg="     . escape (g:gnat.Get_Command('Make'), ' ')
 execute "CompilerSet errorformat=" . escape (g:gnat.Error_Format, ' ')
 

--- a/runtime/compiler/go.vim
+++ b/runtime/compiler/go.vim
@@ -2,6 +2,7 @@
 " Compiler:	Go
 " Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
 " Last Change:	2014 Aug 16
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists('current_compiler')
   finish

--- a/runtime/compiler/haml.vim
+++ b/runtime/compiler/haml.vim
@@ -2,15 +2,12 @@
 " Compiler:	Haml
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Last Change:	2016 Aug 29
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "haml"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/hare.vim
+++ b/runtime/compiler/hare.vim
@@ -2,6 +2,7 @@
 " Compiler: Hare Compiler
 " Maintainer: Amelia Clarke <me@rsaihe.dev>
 " Last Change: 2022-09-21
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("g:current_compiler")
   finish

--- a/runtime/compiler/hp_acc.vim
+++ b/runtime/compiler/hp_acc.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Matthias Ulrich <matthias-ulrich@web.de>
 " URL:          http://www.subhome.de/vim/hp_acc.vim
 " Last Change:	2012 Apr 30
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 "
 "  aCC --version says: "HP ANSI C++ B3910B A.03.13"
 "  This compiler has been tested on:
@@ -21,10 +22,6 @@ endif
 let current_compiler = "hp_acc"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=%A%trror\ %n\:\ \"%f\"\\,\ line\ %l\ \#\ %m,
          \%A%tarning\ (suggestion)\ %n\:\ \"%f\"\\,\ line\ %l\ \#\ %m\ %#,

--- a/runtime/compiler/icc.vim
+++ b/runtime/compiler/icc.vim
@@ -2,15 +2,12 @@
 " Compiler:		icc - Intel C++
 " Maintainer: Peter Puck <PtrPck@netscape.net>
 " Last Change: 2004 Mar 27
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "icc"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 " I think that Intel is calling the compiler icl under Windows
 

--- a/runtime/compiler/icon.vim
+++ b/runtime/compiler/icon.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Icon Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 Jun 16
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "icont"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/ifort.vim
+++ b/runtime/compiler/ifort.vim
@@ -2,6 +2,7 @@
 " Maintainer: H Xu <xuhdev@gmail.com>
 " Version: 0.1.1
 " Last Change: 2012 Apr 30
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " Homepage: http://www.vim.org/scripts/script.php?script_id=3497
 "           https://bitbucket.org/xuhdev/compiler-ifort.vim
 " License: Same as Vim
@@ -12,10 +13,6 @@ endif
 let current_compiler = 'ifort'
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=
             \%A%f(%l):\ %trror\ \#%n:\ %m,

--- a/runtime/compiler/intel.vim
+++ b/runtime/compiler/intel.vim
@@ -2,6 +2,7 @@
 " Compiler:     Intel C++ 7.1
 " Maintainer:   David Harrison <david_jr@users.sourceforge.net>
 " Last Change:  2012 Apr 30
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -9,10 +10,6 @@ endif
 let current_compiler = "intel"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=%E%f(%l):\ error:\ %m,
 		    \%W%f(%l):\ warning:\ %m,

--- a/runtime/compiler/irix5_c.vim
+++ b/runtime/compiler/irix5_c.vim
@@ -2,6 +2,7 @@
 " Compiler:	SGI IRIX 5.3 cc
 " Maintainer:	David Harrison <david_jr@users.sourceforge.net>
 " Last Change:	2012 Apr 30
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -9,10 +10,6 @@ endif
 let current_compiler = "irix5_c"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=\%Ecfe:\ Error:\ %f\\,\ line\ %l:\ %m,
 		     \%Wcfe:\ Warning:\ %n:\ %f\\,\ line\ %l:\ %m,

--- a/runtime/compiler/irix5_cpp.vim
+++ b/runtime/compiler/irix5_cpp.vim
@@ -2,6 +2,7 @@
 " Compiler:	SGI IRIX 5.3 CC or NCC
 " Maintainer:	David Harrison <david_jr@users.sourceforge.net>
 " Last Change:	2012 Apr 30
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -9,10 +10,6 @@ endif
 let current_compiler = "irix5_cpp"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=%E\"%f\"\\,\ line\ %l:\ error(%n):\ ,
 		    \%E\"%f\"\\,\ line\ %l:\ error(%n):\ %m,

--- a/runtime/compiler/javac.vim
+++ b/runtime/compiler/javac.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Java Development Kit Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 Oct 21
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "javac"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/jest.vim
+++ b/runtime/compiler/jest.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Jest
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2021 Nov 20
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "jest"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/jikes.vim
+++ b/runtime/compiler/jikes.vim
@@ -2,16 +2,13 @@
 " Compiler:	Jikes
 " Maintainer:	Dan Sharp <dwsharp at hotmail dot com>
 " Last Change:	2019 Jul 23
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " URL:		http://dwsharp.users.sourceforge.net/vim/compiler
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "jikes"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 " Jikes defaults to printing output on stderr
 CompilerSet makeprg=jikes\ -Xstdout\ +E\ \"%:S\"

--- a/runtime/compiler/jjs.vim
+++ b/runtime/compiler/jjs.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Nashorn Shell
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2018 Jan 9
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "jjs"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/jshint.vim
+++ b/runtime/compiler/jshint.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	JSHint
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 Jul 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "jshint"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/jsonlint.vim
+++ b/runtime/compiler/jsonlint.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	JSON Lint
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 Jul 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "jsonlint"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/mcs.vim
+++ b/runtime/compiler/mcs.vim
@@ -3,6 +3,7 @@
 " Maintainer:   Jarek Sobiecki <harijari@go2.pl>
 " Contributors: Peter Collingbourne and Enno Nagel
 " Last Change:  2024 Mar 29
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/mips_c.vim
+++ b/runtime/compiler/mips_c.vim
@@ -2,6 +2,7 @@
 " Compiler:	SGI IRIX 6.5 MIPS C (cc)
 " Maintainer:	David Harrison <david_jr@users.sourceforge.net>
 " Last Change:	2012 Apr 30
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -9,10 +10,6 @@ endif
 let current_compiler = "mips_c"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=%Ecc\-%n\ %.%#:\ ERROR\ File\ =\ %f\%\\,\ Line\ =\ %l,
 		    \%Wcc\-%n\ %.%#:\ WARNING\ File\ =\ %f\%\\,\ Line\ =\ %l,

--- a/runtime/compiler/mipspro_c89.vim
+++ b/runtime/compiler/mipspro_c89.vim
@@ -2,6 +2,7 @@
 " Compiler:	SGI IRIX 6.5 MIPSPro C (c89)
 " Maintainer:	David Harrison <david_jr@users.sourceforge.net>
 " Last Change:	2012 Apr 30
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -9,10 +10,6 @@ endif
 let current_compiler = "mipspro_c89"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=%Ecc\-%n\ %.%#:\ ERROR\ File\ =\ %f\%\\,\ Line\ =\ %l,
 		    \%Wcc\-%n\ %.%#:\ WARNING\ File\ =\ %f\%\\,\ Line\ =\ %l,

--- a/runtime/compiler/mipspro_cpp.vim
+++ b/runtime/compiler/mipspro_cpp.vim
@@ -2,6 +2,7 @@
 " Compiler:	SGI IRIX 6.5 MIPSPro C++ (CC)
 " Maintainer:	David Harrison <david_jr@users.sourceforge.net>
 " Last Change:	2012 Apr 30
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -9,10 +10,6 @@ endif
 let current_compiler = "mipspro_cpp"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=%Ecc\-%n\ %.%#:\ ERROR\ File\ =\ %f\%\\,\ Line\ =\ %l,
 		    \%Wcc\-%n\ %.%#:\ WARNING\ File\ =\ %f\%\\,\ Line\ =\ %l,

--- a/runtime/compiler/modelsim_vcom.vim
+++ b/runtime/compiler/modelsim_vcom.vim
@@ -3,16 +3,13 @@
 " Maintainer:	Paul Baleme <pbaleme@mail.com>
 " Contributors: Enno Nagel
 " Last Change:	2024 Mar 29
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " Thanks to:    allanherriman@hotmail.com
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "modelsim_vcom"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=vcom
 

--- a/runtime/compiler/msbuild.vim
+++ b/runtime/compiler/msbuild.vim
@@ -2,6 +2,7 @@
 " Compiler:	Microsoft Visual Studio C#
 " Maintainer:	Chiel ten Brinke (ctje92@gmail.com)
 " Last Change:	2013 May 13
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -9,10 +10,6 @@ endif
 let current_compiler = "msbuild"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=\ %#%f(%l\\\,%c):\ %m
 CompilerSet makeprg=msbuild\ /nologo\ /v:q\ /property:GenerateFullPaths=true

--- a/runtime/compiler/msvc.vim
+++ b/runtime/compiler/msvc.vim
@@ -2,6 +2,7 @@
 " Compiler:	Microsoft Visual C
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
 " Last Change:	2023 Aug 10
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 if exists("current_compiler")

--- a/runtime/compiler/neato.vim
+++ b/runtime/compiler/neato.vim
@@ -2,15 +2,12 @@
 " Compiler:     ATT neato
 " Maintainer:	Marcos Macedo <bar4ka@bol.com.br>
 " Last Change:	2024 March 21
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "neato"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=neato\ -T$*\ \"%:p\"\ -o\ \"%:p:r.$*\"
 " matches error messages as below skipping final part after line number

--- a/runtime/compiler/ocaml.vim
+++ b/runtime/compiler/ocaml.vim
@@ -3,6 +3,7 @@
 " Maintainer:  Markus Mottl <markus.mottl@gmail.com>
 " URL:         https://github.com/ocaml/vim-ocaml
 " Last Change:
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 "              2020 Mar 28 - Improved error format (Thomas Leonard)
 "              2017 Nov 26 - Improved error format (Markus Mottl)
 "              2013 Aug 27 - Added a new OCaml error format (Markus Mottl)

--- a/runtime/compiler/onsgmls.vim
+++ b/runtime/compiler/onsgmls.vim
@@ -2,15 +2,12 @@
 " Compiler:	onsgmls
 " Maintainer:	Robert Rowsome <rowsome@wam.umd.edu>
 " Last Change:	2019 Jul 23
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "onsgmls"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/pbx.vim
+++ b/runtime/compiler/pbx.vim
@@ -2,15 +2,12 @@
 " Compiler:	Apple Project Builder
 " Maintainer:	Alexander von Below (public@vonBelow.Com)
 " Last Change:	2004 Mar 27
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
    finish
 endif
 let current_compiler = "pbx"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 " The compiler actually is gcc, so the errorformat is unchanged
 CompilerSet errorformat&

--- a/runtime/compiler/perl.vim
+++ b/runtime/compiler/perl.vim
@@ -6,15 +6,12 @@
 " Bugs/requests: https://github.com/vim-perl/vim-perl/issues
 " License:       Vim License (see :help license)
 " Last Change:   2021 Nov 2
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "perl"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:savecpo = &cpo
 set cpo&vim

--- a/runtime/compiler/perlcritic.vim
+++ b/runtime/compiler/perlcritic.vim
@@ -6,15 +6,12 @@
 " Bugs/requests: https://github.com/vim-perl/vim-perl/issues
 " License:       Vim License (see :help license)
 " Last Change:   2021 Oct 20
+"                2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "perlcritic"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/php.vim
+++ b/runtime/compiler/php.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	PHP CLI
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2013 Jun 25
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "php"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/podchecker.vim
+++ b/runtime/compiler/podchecker.vim
@@ -6,15 +6,12 @@
 " Bugs/requests: https://github.com/vim-perl/vim-perl/issues
 " License:       Vim License (see :help license)
 " Last Change:   2021 Oct 20
+"                2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "podchecker"
-
-if exists(":CompilerSet") != 2          " older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/powershell.vim
+++ b/runtime/compiler/powershell.vim
@@ -3,15 +3,12 @@
 " URL: https://github.com/PProvost/vim-ps1
 " Contributors: Enno Nagel
 " Last Change: 2024 Mar 29
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "powershell"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/pylint.vim
+++ b/runtime/compiler/pylint.vim
@@ -2,15 +2,12 @@
 " Compiler:	Pylint for Python
 " Maintainer: Daniel Moch <daniel@danielmoch.com>
 " Last Change: 2016 May 20
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "pylint"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=pylint\ --output-format=text\ --msg-template=\"{path}:{line}:{column}:{C}:\ [{symbol}]\ {msg}\"\ --reports=no
 CompilerSet errorformat=%A%f:%l:%c:%t:\ %m,%A%f:%l:\ %m,%A%f:(%l):\ %m,%-Z%p^%.%#,%-G%.%#

--- a/runtime/compiler/pyunit.vim
+++ b/runtime/compiler/pyunit.vim
@@ -2,15 +2,12 @@
 " Compiler:	Unit testing tool for Python
 " Maintainer:	Max Ischenko <mfi@ukr.net>
 " Last Change: 2004 Mar 27
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "pyunit"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet efm=%C\ %.%#,%A\ \ File\ \"%f\"\\,\ line\ %l%.%#,%Z%[%^\ ]%\\@=%m
 

--- a/runtime/compiler/raco.vim
+++ b/runtime/compiler/raco.vim
@@ -3,12 +3,9 @@
 " Maintainer:   D. Ben Knoble <ben.knoble+github@gmail.com>
 " URL:          https://github.com/benknoble/vim-racket
 " Last Change: 2022 Aug 12
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 let current_compiler = 'raco'
-
-if exists(":CompilerSet") != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=raco
 CompilerSet errorformat=%f:%l:%c:%m

--- a/runtime/compiler/racomake.vim
+++ b/runtime/compiler/racomake.vim
@@ -3,12 +3,9 @@
 " Maintainer:   D. Ben Knoble <ben.knoble+github@gmail.com>
 " URL:          https://github.com/benknoble/vim-racket
 " Last Change: 2022 Aug 12
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 let current_compiler = 'racomake'
-
-if exists(":CompilerSet") != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=raco\ make\ --\ %
 CompilerSet errorformat=%f:%l:%c:%m

--- a/runtime/compiler/racosetup.vim
+++ b/runtime/compiler/racosetup.vim
@@ -3,12 +3,9 @@
 " Maintainer:   D. Ben Knoble <ben.knoble+github@gmail.com>
 " URL:          https://github.com/benknoble/vim-racket
 " Last Change: 2022 Aug 12
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 let current_compiler = 'racosetup'
-
-if exists(":CompilerSet") != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=raco\ setup
 CompilerSet errorformat=%f:%l:%c:%m

--- a/runtime/compiler/racotest.vim
+++ b/runtime/compiler/racotest.vim
@@ -3,12 +3,9 @@
 " Maintainer:   D. Ben Knoble <ben.knoble+github@gmail.com>
 " URL:          https://github.com/benknoble/vim-racket
 " Last Change: 2022 Aug 12
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 let current_compiler = 'racotest'
-
-if exists(":CompilerSet") != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=raco\ test\ %
 CompilerSet errorformat=location:%f:%l:%c

--- a/runtime/compiler/rake.vim
+++ b/runtime/compiler/rake.vim
@@ -4,15 +4,12 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2018 Mar 02
+"			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "rake"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/rhino.vim
+++ b/runtime/compiler/rhino.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Rhino Shell (JavaScript in Java)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 Jul 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "rhino"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/rspec.vim
+++ b/runtime/compiler/rspec.vim
@@ -4,15 +4,12 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2018 Aug 07
+"			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "rspec"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/rst.vim
+++ b/runtime/compiler/rst.vim
@@ -2,7 +2,8 @@
 " Compiler:             sphinx >= 1.0.8, http://www.sphinx-doc.org
 " Description:          reStructuredText Documentation Format
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2017-03-31
+" Last Change:          2017 Mar 31
+"                       2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -11,10 +12,6 @@ let current_compiler = "rst"
 
 let s:cpo_save = &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=
       \%f\\:%l:\ %tEBUG:\ %m,

--- a/runtime/compiler/rubocop.vim
+++ b/runtime/compiler/rubocop.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	RuboCop
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 Jul 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "rubocop"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/ruby.vim
+++ b/runtime/compiler/ruby.vim
@@ -5,15 +5,12 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2019 Jan 06
+"			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "ruby"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/rubyunit.vim
+++ b/runtime/compiler/rubyunit.vim
@@ -4,15 +4,12 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2014 Mar 23
+"			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "rubyunit"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/rustc.vim
+++ b/runtime/compiler/rustc.vim
@@ -14,10 +14,6 @@ let s:save_cpo = &cpo
 set cpo&vim
 " vint: +ProhibitAbbreviationOption
 
-if exists(":CompilerSet") != 2
-    command -nargs=* CompilerSet setlocal <args>
-endif
-
 if get(g:, 'rustc_makeprg_no_percent', 0)
     CompilerSet makeprg=rustc
 else

--- a/runtime/compiler/sass.vim
+++ b/runtime/compiler/sass.vim
@@ -2,15 +2,12 @@
 " Compiler:	Sass
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Last Change:	2016 Aug 29
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "sass"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/se.vim
+++ b/runtime/compiler/se.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	se (Liberty Eiffel Compiler)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2013 Jun 29
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "se"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/shellcheck.vim
+++ b/runtime/compiler/shellcheck.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	ShellCheck
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Sep 4
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "shellcheck"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/sml.vim
+++ b/runtime/compiler/sml.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	SML/NJ Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 Feb 09
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "sml"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/spectral.vim
+++ b/runtime/compiler/spectral.vim
@@ -2,15 +2,12 @@
 " Compiler:    Spectral for YAML
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2021 July 21
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
     finish
 endif
 let current_compiler = "spectral"
-
-if exists(":CompilerSet") != 2
-    command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=spectral\ lint\ %\ -f\ text
 CompilerSet errorformat=%f:%l:%c\ %t%.%\\{-}\ %m

--- a/runtime/compiler/splint.vim
+++ b/runtime/compiler/splint.vim
@@ -3,16 +3,13 @@
 " Maintainer:   Ralf Wildenhues <Ralf.Wildenhues@gmx.de>
 " Splint Home:	http://www.splint.org/
 " Last Change:  2019 Jul 23
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 " $Revision: 1.3 $
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "splint"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo-=C

--- a/runtime/compiler/standard.vim
+++ b/runtime/compiler/standard.vim
@@ -2,15 +2,12 @@
 " Compiler:    Standard for JavaScript
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2020 August 20
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "standard"
-
-if exists(":CompilerSet") != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=npx\ standard
 CompilerSet errorformat=%f:%l:%c:\ %m,%-G%.%#

--- a/runtime/compiler/stylelint.vim
+++ b/runtime/compiler/stylelint.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Stylelint
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Jun 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "stylelint"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/tcl.vim
+++ b/runtime/compiler/tcl.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	tcl
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2004 Nov 27
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "tcl"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=tcl
 

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -3,16 +3,13 @@
 " Maintainer:   Artem Chuprina <ran@ran.pp.ru>
 " Contributors: Enno Nagel
 " Last Change:  2024 Mar 29
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
 	finish
 endif
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 " If makefile exists and we are not asked to ignore it, we use standard make
 " (do not redefine makeprg)

--- a/runtime/compiler/tidy.vim
+++ b/runtime/compiler/tidy.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	HTML Tidy
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Sep 4
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "tidy"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/ts-node.vim
+++ b/runtime/compiler/ts-node.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	TypeScript Runner
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Feb 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "node"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/tsc.vim
+++ b/runtime/compiler/tsc.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	TypeScript Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Feb 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "tsc"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/typedoc.vim
+++ b/runtime/compiler/typedoc.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	TypeDoc
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Feb 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "typedoc"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/xbuild.vim
+++ b/runtime/compiler/xbuild.vim
@@ -2,6 +2,7 @@
 " Compiler:	Mono C#
 " Maintainer:	Chiel ten Brinke (ctje92@gmail.com)
 " Last Change:	2013 May 13
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -10,10 +11,6 @@ endif
 let current_compiler = "xbuild"
 let s:keepcpo= &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet errorformat=\ %#%f(%l\\\,%c):\ %m
 CompilerSet makeprg=xbuild\ /nologo\ /v:q\ /property:GenerateFullPaths=true

--- a/runtime/compiler/xmllint.vim
+++ b/runtime/compiler/xmllint.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Libxml2 Command-Line Tool
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Jul 30
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "xmllint"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/xmlwf.vim
+++ b/runtime/compiler/xmlwf.vim
@@ -2,6 +2,7 @@
 " Compiler:	xmlwf
 " Maintainer:	Robert Rowsome <rowsome@wam.umd.edu>
 " Last Change:	2019 Jul 23
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -10,10 +11,6 @@ let current_compiler = "xmlwf"
 
 let s:cpo_save = &cpo
 set cpo&vim
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=xmlwf\ %:S
 

--- a/runtime/compiler/xo.vim
+++ b/runtime/compiler/xo.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	XO
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 Jul 10
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "xo"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/compiler/yamllint.vim
+++ b/runtime/compiler/yamllint.vim
@@ -2,15 +2,12 @@
 " Compiler:    Yamllint for YAML
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2021 July 21
+"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
     finish
 endif
 let current_compiler = "yamllint"
-
-if exists(":CompilerSet") != 2
-    command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=yamllint\ -f\ parsable
 

--- a/runtime/compiler/zig.vim
+++ b/runtime/compiler/zig.vim
@@ -10,10 +10,6 @@ let current_compiler = "zig"
 let s:save_cpo = &cpo
 set cpo&vim
 
-if exists(":CompilerSet") != 2
-    command -nargs=* CompilerSet setlocal <args>
-endif
-
 " a subcommand must be provided for the this compiler (test, build-exe, etc)
 if has('patch-7.4.191')
     CompilerSet makeprg=zig\ \$*\ \%:S

--- a/runtime/compiler/zsh.vim
+++ b/runtime/compiler/zsh.vim
@@ -1,16 +1,12 @@
 " Vim compiler file
 " Compiler:	Zsh
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Sep 6
+" Last Change:	2024 Apr 03
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "zsh"
-
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/runtime/doc/usr_51.txt
+++ b/runtime/doc/usr_51.txt
@@ -649,13 +649,9 @@ When you write a compiler file and put it in your personal runtime directory
 make the default file skip the settings.
 							*:CompilerSet*
 The second mechanism is to use ":set" for ":compiler!" and ":setlocal" for
-":compiler".  Vim defines the ":CompilerSet" user command for this.  However,
-older Vim versions don't, thus your plugin should define it then.  This is an
-example: >
+":compiler".  Vim defines the ":CompilerSet" user command for this.  This is
+an example: >
 
-  if exists(":CompilerSet") != 2
-    command -nargs=* CompilerSet setlocal <args>
-  endif
   CompilerSet errorformat&		" use the default 'errorformat'
   CompilerSet makeprg=nmake
 


### PR DESCRIPTION
The `:CompilerSet` command was added in version Vim 6.4 which was released twenty years ago.  Other runtime files do not support versions of that vintage so it is reasonable to remove this fallback command definition now.
