### PR TITLE
libgpm may delete some signal handlers

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -7494,7 +7494,19 @@ gpm_open(void)
 	return 1; // succeed
     }
     if (gpm_fd == -2)
+    {
 	Gpm_Close(); // We don't want to talk to xterm via gpm
+
+        // Gpm_Close fails to properly restore the WINCH and TSTP handlers,
+        // leading to Vim ignoring resize signals. We have to re-initialize
+        // these handlers again here.
+# ifdef SIGWINCH
+	mch_signal(SIGWINCH, sig_winch);
+# endif
+# ifdef SIGTSTP
+	mch_signal(SIGTSTP, restricted ? SIG_IGN : sig_tstp);
+# endif
+    }
     return 0;
 }
 


### PR DESCRIPTION
Problem:  libgpm may delete some signal handlers
Solution: restore these signal handlers after calling gpm

When 'mouse' is set, vim is trying to detect mouse support on startup. Eventually, vim resorts to using libgpm as the final method of mouse detection. This library may delete some signals handlers that were initially set up by vim.

This is how:
- mch_setmouse() calls gpm_open()
- Gpm_Open is executed, which returns early on line 210 [1]
- Keep in mind that lines 353-373 [2] are skipped, so gpm_saved_suspend_hook and gpm_saved_winch_hook are empty
- Finally, Gpm_Close is called, which will reset [3] SIGWINCH and SIGTSTP to an empty sigaction.

[1] https://github.com/telmich/gpm/blob/e82d1a653ca94aa4ed12441424da6ce780b1e530/src/lib/liblow.c#L210
[2] https://github.com/telmich/gpm/blob/e82d1a653ca94aa4ed12441424da6ce780b1e530/src/lib/liblow.c#L353-L373
[3] https://github.com/telmich/gpm/blob/e82d1a653ca94aa4ed12441424da6ce780b1e530/src/lib/liblow.c#L419-L424

Fixes: #12154