### PR TITLE
Collect and tweak 'smoothscroll' cursor logic

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -519,6 +519,8 @@ plines_m_win(win_T *wp, linenr_T first, linenr_T last, int limit_winheight)
 #endif
 	{
 #ifdef FEAT_DIFF
+	    if (first == wp->w_buffer->b_ml.ml_line_count)
+		count += diff_check_fill(wp, first + 1);
 	    if (first == wp->w_topline)
 		count += plines_win_nofill(wp, first, limit_winheight)
 							       + wp->w_topfill;

--- a/src/normal.c
+++ b/src/normal.c
@@ -2474,65 +2474,6 @@ nv_scroll_line(cmdarg_T *cap)
 }
 
 /*
- * Scroll "count" lines up or down, and redraw.
- */
-    void
-scroll_redraw(int up, long count)
-{
-    linenr_T	prev_topline = curwin->w_topline;
-    int		prev_skipcol = curwin->w_skipcol;
-#ifdef FEAT_DIFF
-    int		prev_topfill = curwin->w_topfill;
-#endif
-    linenr_T	prev_lnum = curwin->w_cursor.lnum;
-
-    if (up)
-	scrollup(count, TRUE);
-    else
-	scrolldown(count, TRUE);
-    if (get_scrolloff_value() > 0)
-    {
-	// Adjust the cursor position for 'scrolloff'.  Mark w_topline as
-	// valid, otherwise the screen jumps back at the end of the file.
-	cursor_correct();
-	check_cursor_moved(curwin);
-	curwin->w_valid |= VALID_TOPLINE;
-
-	// If moved back to where we were, at least move the cursor, otherwise
-	// we get stuck at one position.  Don't move the cursor up if the
-	// first line of the buffer is already on the screen
-	while (curwin->w_topline == prev_topline
-		&& curwin->w_skipcol == prev_skipcol
-#ifdef FEAT_DIFF
-		&& curwin->w_topfill == prev_topfill
-#endif
-		)
-	{
-	    if (up)
-	    {
-		if (curwin->w_cursor.lnum > prev_lnum
-			|| cursor_down(1L, FALSE) == FAIL)
-		    break;
-	    }
-	    else
-	    {
-		if (curwin->w_cursor.lnum < prev_lnum
-			|| prev_topline == 1L
-			|| cursor_up(1L, FALSE) == FAIL)
-		    break;
-	    }
-	    // Mark w_topline as valid, otherwise the screen jumps back at the
-	    // end of the file.
-	    check_cursor_moved(curwin);
-	    curwin->w_valid |= VALID_TOPLINE;
-	}
-    }
-    if (curwin->w_cursor.lnum != prev_lnum)
-	coladvance(curwin->w_curswant);
-    redraw_later(UPD_VALID);
-}
-
-/*
  * Get the count specified after a 'z' command. Only the 'z<CR>', 'zl', 'zh',
  * 'z<Left>', and 'z<Right>' commands accept a count after 'z'.
  * Returns TRUE to process the 'z' command and FALSE to skip it.

--- a/src/proto/move.pro
+++ b/src/proto/move.pro
@@ -37,6 +37,7 @@ void f_screenpos(typval_T *argvars, typval_T *rettv);
 void f_virtcol2col(typval_T *argvars, typval_T *rettv);
 void scrolldown(long line_count, int byfold);
 void scrollup(long line_count, int byfold);
+void scroll_redraw(int up, long count);
 void adjust_skipcol(void);
 void check_topfill(win_T *wp, int down);
 void scrolldown_clamp(void);

--- a/src/proto/normal.pro
+++ b/src/proto/normal.pro
@@ -25,7 +25,6 @@ int find_decl(char_u *ptr, int len, int locally, int thisblock, int flags_arg);
 void nv_g_home_m_cmd(cmdarg_T *cap);
 int nv_screengo(oparg_T *oap, int dir, long dist);
 void nv_scroll_line(cmdarg_T *cap);
-void scroll_redraw(int up, long count);
 void handle_tabmenu(void);
 void do_nv_ident(int c1, int c2);
 int get_visual_text(cmdarg_T *cap, char_u **pp, int *lenp);

--- a/src/testdir/dumps/Test_smooth_long_6.dump
+++ b/src/testdir/dumps/Test_smooth_long_6.dump
@@ -3,4 +3,4 @@
 |t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o
 |f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e
 |x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w
-| @21|3|,|9|0| @9|6@1|%| 
+|:|s|e|t| |s|c|r|o|l@1|o| @9|3|,|9|0| @9|6@1|%| 

--- a/src/testdir/dumps/Test_smooth_long_7.dump
+++ b/src/testdir/dumps/Test_smooth_long_7.dump
@@ -3,4 +3,4 @@
 |t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o
 |f| |t|e|x|t| |w|i>t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e
 |x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w|i|t|h| |l|o|t|s| |o|f| |t|e|x|t| |w
-| @21|3|,|1|7|0| @8|6@1|%| 
+|:|s|e|t| |s|c|r|o|l@1|o| @9|3|,|1|7|0| @8|6@1|%| 

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -2023,4 +2023,19 @@ func Test_diff_toggle_wrap_skipcol_leftcol()
   bwipe!
 endfunc
 
+" Ctrl-D reveals filler lines below the last line in the buffer.
+func Test_diff_eob_halfpage()
+  5new
+  call setline(1, ['']->repeat(10) + ['a'])
+  diffthis
+  5new
+  call setline(1, ['']->repeat(3) + ['a', 'b'])
+  diffthis
+  wincmd j
+  exe "norm! G\<C-D>"
+  call assert_equal(6, line('w0'))
+
+  %bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1020,30 +1020,36 @@ func Test_smoothscroll_page()
   " Half-page scrolling does not go beyond end of buffer and moves the cursor.
   " Even with 'nostartofline', the correct amount of lines is scrolled.
   setl nostartofline
-  exe "norm! 0\<C-D>"
+  exe "norm! 15|\<C-D>"
   call assert_equal(200, winsaveview().skipcol)
-  call assert_equal(204, col('.'))
+  call assert_equal(215, col('.'))
   exe "norm! \<C-D>"
   call assert_equal(400, winsaveview().skipcol)
-  call assert_equal(404, col('.'))
+  call assert_equal(415, col('.'))
   exe "norm! \<C-D>"
   call assert_equal(520, winsaveview().skipcol)
-  call assert_equal(601, col('.'))
+  call assert_equal(535, col('.'))
   exe "norm! \<C-D>"
   call assert_equal(520, winsaveview().skipcol)
-  call assert_equal(801, col('.'))
-  exe "norm! \<C-U>"
+  call assert_equal(735, col('.'))
+  exe "norm! \<C-D>"
   call assert_equal(520, winsaveview().skipcol)
-  call assert_equal(601, col('.'))
+  call assert_equal(895, col('.'))
   exe "norm! \<C-U>"
-  call assert_equal(400, winsaveview().skipcol)
-  call assert_equal(404, col('.'))
+  call assert_equal(320, winsaveview().skipcol)
+  call assert_equal(695, col('.'))
   exe "norm! \<C-U>"
-  call assert_equal(200, winsaveview().skipcol)
-  call assert_equal(204, col('.'))
+  call assert_equal(120, winsaveview().skipcol)
+  call assert_equal(495, col('.'))
   exe "norm! \<C-U>"
   call assert_equal(0, winsaveview().skipcol)
-  call assert_equal(40, col('.'))
+  call assert_equal(375, col('.'))
+  exe "norm! \<C-U>"
+  call assert_equal(0, winsaveview().skipcol)
+  call assert_equal(175, col('.'))
+  exe "norm! \<C-U>"
+  call assert_equal(0, winsaveview().skipcol)
+  call assert_equal(15, col('.'))
 
   bwipe!
 endfunc
@@ -1071,6 +1077,14 @@ func Test_smoothscroll_next_topline()
   redraw
   call assert_equal(2, line('w0'))
 
+  " Cursor does not end up above topline, adjusting topline later.
+  setlocal nu cpo+=n
+  exe "norm! G$g013\<C-Y>"
+  redraw
+  call assert_equal(2, line('.'))
+  call assert_equal(0, winsaveview().skipcol)
+
+  set cpo-=n
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  Logic to make sure cursor is in visible part of the screen after
          scrolling the text with 'smoothscroll' is scattered, asymmetric
          and contains bugs.
Solution: Adjust and create helper function for 'smoothscroll' cursor logic.