### PR TITLE
runtime: fix :compiler leaving behind a g:makeprg variable

### DIFF
--- a/runtime/compiler/powershell.vim
+++ b/runtime/compiler/powershell.vim
@@ -4,6 +4,7 @@
 " Contributors: Enno Nagel
 " Last Change: 2024 Mar 29
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"		2024 Apr 05 by The Vim Project (avoid leaving behind g:makeprg)
 
 if exists("current_compiler")
   finish
@@ -35,7 +36,7 @@ let g:ps1_efm_show_error_categories = get(g:, 'ps1_efm_show_error_categories', 0
 
 " Use absolute path because powershell requires explicit relative paths
 " (./file.ps1 is okay, but # expands to file.ps1)
-let makeprg = g:ps1_makeprg_cmd .. ' %:p:S'
+let s:makeprg = g:ps1_makeprg_cmd .. ' %:p:S'
 
 " Parse file, line, char from callstacks:
 "     Write-Ouput : The term 'Write-Ouput' is not recognized as the name of a
@@ -48,7 +49,7 @@ let makeprg = g:ps1_makeprg_cmd .. ' %:p:S'
 "         + CategoryInfo          : ObjectNotFound: (Write-Ouput:String) [], CommandNotFoundException
 "         + FullyQualifiedErrorId : CommandNotFoundException
 
-execute 'CompilerSet makeprg=' .. escape(makeprg, ' ')
+execute 'CompilerSet makeprg=' .. escape(s:makeprg, ' ')
 
 " Showing error in context with underlining.
 CompilerSet errorformat=%+G+%m

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -4,6 +4,7 @@
 " Contributors: Enno Nagel
 " Last Change:  2024 Mar 29
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"		2024 Apr 05 by The Vim Project (avoid leaving behind g:makeprg)
 
 if exists("current_compiler")
 	finish
@@ -25,8 +26,8 @@ if exists('b:tex_ignore_makefile') || exists('g:tex_ignore_makefile') ||
 	else
 		let current_compiler = "latex"
 	endif
-	let makeprg=current_compiler .. ' -interaction=nonstopmode'
-	execute 'CompilerSet makeprg=' .. escape(makeprg, ' ')
+	let s:makeprg=current_compiler .. ' -interaction=nonstopmode'
+	execute 'CompilerSet makeprg=' .. escape(s:makeprg, ' ')
 else
 	let current_compiler = 'make'
 endif


### PR DESCRIPTION
Problem:  :compiler may leave behind a g:makeprg variable after #14336.
Solution: Use a script local variable.
