### PR TITLE
Problem:  CI sound test aborts with undefined variable

### DIFF
--- a/src/testdir/test_sound.vim
+++ b/src/testdir/test_sound.vim
@@ -15,6 +15,7 @@ func Test_play_event()
   if has('win32')
     throw 'Skipped: Playing event with callback is not supported on Windows'
   endif
+  let g:result = 0
   let g:playcallback_count = 0
   let g:id = 0
   let event_name = 'bell'
@@ -37,6 +38,7 @@ endfunc
 func Test_play_silent()
   let fname = fnamemodify('silent.wav', '%p')
   let g:playcallback_count = 0
+  let g:result = -1
 
   " play without callback
   let id1 = sound_playfile(fname)


### PR DESCRIPTION
Problem:  CI sound test aborts with undefined variable
Solution: initialize g:result in test_sound.vim