### PR TITLE
Change variable types to resolve compiler warnings

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -81,7 +81,7 @@ static int	KeyNoremap = 0;	    // remapping flags
 static char_u	typebuf_init[TYPELEN_INIT];	// initial typebuf.tb_buf
 static char_u	noremapbuf_init[TYPELEN_INIT];	// initial typebuf.tb_noremap
 
-static int	last_recorded_len = 0;	// number of last recorded chars
+static size_t	last_recorded_len = 0;	// number of last recorded chars
 
 #ifdef FEAT_EVAL
 mapblock_T	*last_used_map = NULL;
@@ -163,7 +163,7 @@ get_recorded(void)
      * (possibly mapped) characters that stopped the recording.
      */
     len = STRLEN(p);
-    if ((int)len >= last_recorded_len)
+    if (len >= last_recorded_len)
     {
 	len -= last_recorded_len;
 	p[len] = NUL;
@@ -1789,7 +1789,7 @@ vgetc(void)
     else
     {
 	// number of characters recorded from the last vgetc() call
-	static int	last_vgetc_recorded_len = 0;
+	static size_t	last_vgetc_recorded_len = 0;
 
 	mod_mask = 0;
 	vgetc_mod_mask = 0;

--- a/src/ops.c
+++ b/src/ops.c
@@ -1593,12 +1593,12 @@ op_insert(oparg_T *oap, long count1)
 
     if (oap->block_mode)
     {
-	long			ins_len;
+	size_t			ins_len;
 	char_u			*firstline, *ins_text;
 	struct block_def	bd2;
 	int			did_indent = FALSE;
 	size_t			len;
-	int			add;
+	size_t			add;
 	// offset when cursor was moved in insert mode
 	int			offset = 0;
 
@@ -1703,7 +1703,7 @@ op_insert(oparg_T *oap, long count1)
 		    return;
 	    }
 	}
-	if ((size_t)add > len)
+	if (add > len)
 	    add = len;  // short line, point to the NUL
 	firstline += add;
 	len -= add;


### PR DESCRIPTION
Windows compiles were reporting a few size_t to signed integer conversion warnings that can be resolved by changing the variable declarations to be size_t to start with.