### PR TITLE
filetype: no support for keymap files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -663,7 +663,7 @@ au BufNewFile,BufRead *.dsl
 au BufNewFile,BufRead *.dtd			setf dtd
 
 " DTS/DSTI/DTSO (device tree files)
-au BufNewFile,BufRead *.dts,*.dtsi,*.dtso,*.its	setf dts
+au BufNewFile,BufRead *.dts,*.dtsi,*.dtso,*.its,*.keymap	setf dts
 
 " Earthfile
 au BufNewFile,BufRead Earthfile			setf earthfile

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -215,7 +215,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     dracula: ['file.drac', 'file.drc', 'filelvs', 'filelpe', 'drac.file', 'lpe', 'lvs', 'some-lpe', 'some-lvs'],
     dtd: ['file.dtd'],
     dtrace: ['/usr/lib/dtrace/io.d'],
-    dts: ['file.dts', 'file.dtsi', 'file.dtso', 'file.its'],
+    dts: ['file.dts', 'file.dtsi', 'file.dtso', 'file.its', 'file.keymap'],
     dune: ['jbuild', 'dune', 'dune-project', 'dune-workspace'],
     dylan: ['file.dylan'],
     dylanintr: ['file.intr'],


### PR DESCRIPTION
zmk uses devicetree files for configuration with a `.keymap` extension 

https://zmk.dev/docs/features/keymaps

btw should the autocmd line be split up since it's a bit long?