### PR TITLE
Vim9: comment may be treated as heredoc start

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -6894,7 +6894,7 @@ find_name_end(
     int		br_nest = 0;
     char_u	*p;
     int		len;
-    int		allow_curly = (flags & FNE_ALLOW_CURLY) || !in_vim9script();
+    int		allow_curly = !in_vim9script();
 
     if (expr_start != NULL)
     {

--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -396,6 +396,42 @@ func Test_let_heredoc_fails()
     call assert_report('Caught exception: ' .. v:exception)
   endtry
 
+  try
+    let @- =<< trim TEXT
+      change
+      insert
+      append
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E730:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
+    let [a b c] =<< trim TEXT
+      change
+      insert
+      append
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E475:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
+    let [a; b; c] =<< trim TEXT
+      change
+      insert
+      append
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E452:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
   let text =<< trim END
   func WrongSyntax()
     let v =<< that there
@@ -570,6 +606,22 @@ insert
 append
 END
   call assert_equal(['change', 'insert', 'append'], [a, b, c])
+
+  " unpack assignment with semicolon
+  let [a; b] =<< END
+change
+insert
+append
+END
+  call assert_equal(['change', ['insert', 'append']], [a, b])
+
+  " unpack assignment with registers
+  let [@/, @", @-] =<< END
+change
+insert
+append
+END
+  call assert_equal(['change', 'insert', 'append'], [@/, @", @-])
 
   " curly braces name and list slice assignment
   let foo_3_bar = ['', '', '']

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -1997,6 +1997,17 @@ def Test_heredoc()
   END
   v9.CheckScriptSuccess(lines)
 
+  # commented out heredoc assignment without space after '#'
+  lines =<< trim END
+      vim9script
+      def Func()
+        #x =<< trim [CODE]
+        #[CODE]
+      enddef
+      Func()
+  END
+  v9.CheckScriptSuccess(lines)
+
   v9.CheckDefFailure(['var lines =<< trim END X', 'END'], 'E488:')
   v9.CheckDefFailure(['var lines =<< trim END " comment', 'END'], 'E488:')
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -1227,12 +1227,20 @@ get_function_body(
 			|| checkforcmd(&arg, "const", 5)
 			|| vim9_function)
 		{
-		    while (vim_strchr((char_u *)"$@&", *arg) != NULL)
-			++arg;
-		    arg = skipwhite(find_name_end(arg, NULL, NULL,
-					       FNE_INCL_BR | FNE_ALLOW_CURLY));
-		    if (vim9_function && *arg == ':')
-			arg = skipwhite(skip_type(skipwhite(arg + 1), FALSE));
+		    int		save_sc_version = current_sctx.sc_version;
+		    int		var_count = 0;
+		    int		semicolon = 0;
+		    char_u	*argend;
+
+		    current_sctx.sc_version
+				     = vim9_function ? SCRIPT_VERSION_VIM9 : 1;
+		    argend = skip_var_list(arg, TRUE, &var_count, &semicolon,
+									 TRUE);
+		    if (argend == NULL)
+			// Invalid list assignment: skip to closing bracket.
+			argend = find_name_end(arg, NULL, NULL, FNE_INCL_BR);
+		    arg = skipwhite(argend);
+		    current_sctx.sc_version = save_sc_version;
 		    if (arg[0] == '=' && arg[1] == '<' && arg[2] =='<')
 		    {
 			p = skipwhite(arg + 3);

--- a/src/vim.h
+++ b/src/vim.h
@@ -2818,7 +2818,6 @@ typedef int (*opt_expand_cb_T)(optexpand_T *args, int *numMatches, char_u ***mat
 // flags for find_name_end()
 #define FNE_INCL_BR	1	// include [] in name
 #define FNE_CHECK_START	2	// check name starts with valid character
-#define FNE_ALLOW_CURLY	4	// always allow curly braces name
 
 // BSD is supposed to cover FreeBSD and similar systems.
 #if (defined(SUN_SYSTEM) || defined(BSD) || defined(__FreeBSD_kernel__)) \


### PR DESCRIPTION
Problem:  Vim9: comment may be treated as heredoc start.
Solution: Use skip_var_list() instead of find_name_end().

closes: #14444
