### PR TITLE
Text height function does not respect it's argument

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -502,7 +502,7 @@ plines_m_win(win_T *wp, linenr_T first, linenr_T last, int limit_winheight)
 {
     int		count = 0;
 
-    while (first <= last)
+    while (first <= last && (!limit_winheight || count < wp->w_height))
     {
 #ifdef FEAT_FOLDING
 	int	x;
@@ -519,17 +519,20 @@ plines_m_win(win_T *wp, linenr_T first, linenr_T last, int limit_winheight)
 #endif
 	{
 #ifdef FEAT_DIFF
-	    if (first == wp->w_buffer->b_ml.ml_line_count)
-		count += diff_check_fill(wp, first + 1);
 	    if (first == wp->w_topline)
-		count += plines_win_nofill(wp, first, limit_winheight)
-							       + wp->w_topfill;
+		count += plines_win_nofill(wp, first, FALSE) + wp->w_topfill;
 	    else
 #endif
-		count += plines_win(wp, first, limit_winheight);
+		count += plines_win(wp, first, FALSE);
 	    ++first;
 	}
     }
+#ifdef FEAT_DIFF
+    if (first == wp->w_buffer->b_ml.ml_line_count + 1)
+	count += diff_check_fill(wp, first);
+#endif
+    if (limit_winheight && count > wp->w_height)
+	return wp->w_height;
     return (count);
 }
 

--- a/src/move.c
+++ b/src/move.c
@@ -3210,7 +3210,7 @@ pagescroll(int dir, long count, int half)
 	{
 	    int n = plines_correct_topline(curwin, curwin->w_topline, FALSE);
 	    if (n - count < curwin->w_height && curwin->w_topline < buflen)
-		n += plines_m_win(curwin, curwin->w_topline + 1, buflen, TRUE);
+		n += plines_m_win(curwin, curwin->w_topline + 1, buflen, FALSE);
 	    if (n - count < curwin->w_height)
 		count = n - curwin->w_height;
 	}

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -654,7 +654,7 @@ popup_show_curline(win_T *wp)
 	    wp->w_topline = wp->w_buffer->b_ml.ml_line_count;
 	while (wp->w_topline < wp->w_cursor.lnum
 		&& wp->w_topline < wp->w_buffer->b_ml.ml_line_count
-		&& plines_m_win(wp, wp->w_topline, wp->w_cursor.lnum, TRUE)
+		&& plines_m_win(wp, wp->w_topline, wp->w_cursor.lnum, FALSE)
 								> wp->w_height)
 	    ++wp->w_topline;
     }

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -2025,17 +2025,19 @@ endfunc
 
 " Ctrl-D reveals filler lines below the last line in the buffer.
 func Test_diff_eob_halfpage()
-  5new
+  new
   call setline(1, ['']->repeat(10) + ['a'])
   diffthis
-  call assert_true(5, winheight(5))
-  5new
+  new
   call setline(1, ['']->repeat(3) + ['a', 'b'])
   diffthis
+  resize 5
   wincmd j
-  resize 7
-  exe "norm! G\<C-D>"
-  call assert_equal(6, line('w0'))
+  resize 5
+  norm G
+  call assert_equal(7, line('w0'))
+  exe "norm! \<C-D>"
+  call assert_equal(8, line('w0'))
 
   %bwipe!
 endfunc


### PR DESCRIPTION
Problem:  plines_m_win() does not take into account it's "limit_winheight"
          argument for filler lines below the last line of the buffer.
Solution: Check window height when "limit_winheight" is TRUE.