### PR TITLE
Fix Windows warning for size_t to int conversion

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -860,7 +860,7 @@ highlight_reset_all(void)
 highlight_set_termgui_attr(int idx, char_u *key, char_u *arg, int init)
 {
     int		attr;
-    int		off;
+    size_t	off;
     keyvalue_T	target;
     keyvalue_T	*entry;
 


### PR DESCRIPTION
Another Windows size_t to int conversion warning was resolved by changing a declaration.