### PR TITLE
filetype: some pbtxt files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1759,7 +1759,7 @@ au BufNewFile,BufRead *.psl			setf psl
 
 " Google protocol buffers
 au BufNewFile,BufRead *.proto			setf proto
-au BufNewFile,BufRead *.pbtxt			setf pbtxt
+au BufNewFile,BufRead *.txtpb,*.textproto,*.textpb,*.pbtxt setf pbtxt
 
 " Poke
 au BufNewFile,BufRead *.pk			setf poke

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -521,7 +521,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     papp: ['file.papp', 'file.pxml', 'file.pxsl'],
     pascal: ['file.pas', 'file.dpr', 'file.lpr'],
     passwd: ['any/etc/passwd', 'any/etc/passwd-', 'any/etc/passwd.edit', 'any/etc/shadow', 'any/etc/shadow-', 'any/etc/shadow.edit', 'any/var/backups/passwd.bak', 'any/var/backups/shadow.bak', '/etc/passwd', '/etc/passwd-', '/etc/passwd.edit', '/etc/shadow', '/etc/shadow-', '/etc/shadow.edit', '/var/backups/passwd.bak', '/var/backups/shadow.bak'],
-    pbtxt: ['file.pbtxt'],
+    pbtxt: ['file.txtpb', 'file.textproto', 'file.textpb', 'file.pbtxt'],
     pccts: ['file.g'],
     pcmk: ['file.pcmk'],
     pdf: ['file.pdf'],


### PR DESCRIPTION
Problem: some textual protocol buffers file extensions are not recognized. Especially, the now officially recommended extension `txtpb` (see [1]).

Solution: add patterns for all extensions that are not strongly discouraged by the documentation.

[1]: https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files