### PR TITLE
refactor(argedit): filter duplicate item and insert in correct index

### DIFF
--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -371,32 +371,32 @@ func Test_argedit()
   call assert_equal(['a', 'b'], argv())
   call assert_equal('b', expand('%:t'))
   argedit a
-  call assert_equal(['a', 'b', 'a'], argv())
+  call assert_equal(['a', 'b'], argv())
   call assert_equal('a', expand('%:t'))
   " When file name case is ignored, an existing buffer with only case
   " difference is re-used.
   argedit C D
   call assert_equal('C', expand('%:t'))
-  call assert_equal(['a', 'b', 'a', 'C', 'D'], argv())
+  call assert_equal(['a', 'C', 'D', 'b'], argv())
   argedit c
   if has('fname_case')
-    call assert_equal(['a', 'b', 'a', 'C', 'c', 'D'], argv())
+    call assert_equal(['a', 'C', 'c', 'D', 'b'], argv())
   else
-    call assert_equal(['a', 'b', 'a', 'C', 'C', 'D'], argv())
+    call assert_equal(['a', 'C', 'D', 'b'], argv())
   endif
   0argedit x
   if has('fname_case')
-    call assert_equal(['x', 'a', 'b', 'a', 'C', 'c', 'D'], argv())
+    call assert_equal(['x', 'a', 'C', 'c', 'D', 'b'], argv())
   else
-    call assert_equal(['x', 'a', 'b', 'a', 'C', 'C', 'D'], argv())
+    call assert_equal(['x', 'a', 'C', 'D', 'b'], argv())
   endif
   enew! | set modified
   call assert_fails('argedit y', 'E37:')
   argedit! y
   if has('fname_case')
-    call assert_equal(['x', 'y', 'y', 'a', 'b', 'a', 'C', 'c', 'D'], argv())
+    call assert_equal(['x', 'y', 'a', 'C', 'c', 'D', 'b'], argv())
   else
-    call assert_equal(['x', 'y', 'y', 'a', 'b', 'a', 'C', 'C', 'D'], argv())
+    call assert_equal(['x', 'y', 'a', 'C', 'D', 'b'], argv())
   endif
   %argd
   bwipe! C


### PR DESCRIPTION
Problem: Currently, the argedit command does not work correctly. According to the help documentation, when a filename already exists in the argument list, that entry should be edited. However, argedit does not check for duplicates and instead inserts a new one. Additionally, it does not function like argadd. For instance, in the test case Test_argedit, after executing `argedit b` and `argedit a`, where the current file is a, then executing `argedit C D` should insert C and D after a. However, the expected result is a b C D, similar to the behavior observed with `argadd` where the current file is b: executing `:argadd x` results in the argument list `a b x c`.

Solution: Refactor argedit to avoid inserting duplicate items and to insert new items at the correct position.

(And fname_case is removed can remove test case for it ? )