### PR TITLE
NSIS: corrected gvim.nsi

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -410,9 +410,6 @@ Section "$(str_section_exe)" id_section_exe
 !if /FileExists "${VIMSRC}\vim${BIT}.dll"
 	File ${VIMSRC}\vim${BIT}.dll
 !endif
-!if /FileExists "${VIMRT}\libsodium.dll"
-	File ${VIMRT}\libsodium.dll
-!endif
 	File /oname=install.exe ${VIMSRC}\installw32.exe
 	File /oname=uninstall.exe ${VIMSRC}\uninstallw32.exe
 	File ${VIMSRC}\vimrun.exe
@@ -431,6 +428,9 @@ Section "$(str_section_exe)" id_section_exe
 !endif
 !if /FileExists "${VIMTOOLS}\winpty-agent.exe"
 	File ${VIMTOOLS}\winpty-agent.exe
+!endif
+!if /FileExists "${VIMTOOLS}\libsodium.dll"
+	File ${VIMTOOLS}\libsodium.dll
 !endif
 
 	SetOutPath $0\colors
@@ -728,12 +728,12 @@ Section "$(str_section_nls)" id_section_nls
 	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
 	    "${GETTEXT}\gettext${BIT}\libiconv-2.dll" \
 	    "$0\libiconv-2.dll" "$0"
-  !if /FileExists "${GETTEXT}\gettext${BIT}\libgcc_s_sjlj-1.dll"
-	# Install libgcc_s_sjlj-1.dll only if it is needed.
-	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	    "${GETTEXT}\gettext${BIT}\libgcc_s_sjlj-1.dll" \
-	    "$0\libgcc_s_sjlj-1.dll" "$0"
-  !endif
+# Install libgcc_s_sjlj-1.dll only if it is needed.
+#  !if /FileExists "${GETTEXT}\gettext${BIT}\libgcc_s_sjlj-1.dll"
+#	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+#	    "${GETTEXT}\gettext${BIT}\libgcc_s_sjlj-1.dll" \
+#	    "$0\libgcc_s_sjlj-1.dll" "$0"
+#  !endif
 
 	${If} ${SectionIsSelected} ${id_section_editwith}
 	  ${If} ${RunningX64}
@@ -759,12 +759,12 @@ Section "$(str_section_nls)" id_section_nls
 	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
 	      "${GETTEXT}\gettext32\libiconv-2.dll" \
 	      "$0\GvimExt32\libiconv-2.dll" "$0\GvimExt32"
-  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
-	  # Install libgcc_s_sjlj-1.dll only if it is needed.
-	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll" \
-	      "$0\GvimExt32\libgcc_s_sjlj-1.dll" "$0\GvimExt32"
-  !endif
+# Install libgcc_s_sjlj-1.dll only if it is needed.
+#  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
+#	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+#	      "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll" \
+#	      "$0\GvimExt32\libgcc_s_sjlj-1.dll" "$0\GvimExt32"
+#  !endif
 	${EndIf}
 SectionEnd
 !endif

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -157,9 +157,54 @@
 # you can set DEFINES on the command line, e.g.,
 #	nmake -f Make_mvc.mvc "DEFINES=-DEMACS_TAGS"
 
+RM=		del /f /q
+PS=		powershell.exe
+
+PSFLAGS=	-NoLogo -NoProfile -Command
+
+!IF ![$(PS) $(PSFLAGS) try{Out-File -FilePath '.\major.tmp' -InputObject \
+	\"MAJOR=$$(((Select-String -Pattern 'VIM_VERSION_MAJOR\s+\d{1,2}' \
+	-Path '.\version.h').Line[-2..-1^]-join '').Trim())\"} \
+	catch{exit 1}]
+! INCLUDE .\major.tmp
+! IF [$(RM) .\major.tmp]
+! ENDIF
+!ELSE
+# Change this value for the new version
+MAJOR=		9
+!ENDIF
+
+!IF ![$(PS) $(PSFLAGS) try{Out-File -FilePath '.\minor.tmp' -InputObject \
+	\"MINOR=$$(((Select-String -Pattern 'VIM_VERSION_MINOR\s+\d{1,2}' \
+	-Path '.\version.h').Line[-2..-1^]-join '').Trim())\"} \
+	catch{exit 1}]
+! INCLUDE .\minor.tmp
+! IF [$(RM) .\minor.tmp]
+! ENDIF
+!ELSE
+# Change this value for the new version
+MINOR=		1
+!ENDIF
+
+!IF ![$(PS) $(PSFLAGS) try{Out-File -FilePath '.\patchlvl.tmp' -InputObject \
+	\"PATCHLEVEL=$$(((Get-Content -Path '.\version.c' \
+	-TotalCount ((Select-String -Pattern 'static int included_patches' \
+	-Path '.\version.c').LineNumber+3))[-1^]).Trim().TrimEnd(','))\"} \
+	catch{exit 1}]
+! INCLUDE .\patchlvl.tmp
+! IF [$(RM) .\patchlvl.tmp]
+! ENDIF
+!ENDIF
+
+
 # Build on Windows NT/XP
 
 TARGETOS = WINNT
+
+!IFDEF PATCHLEVEL
+RCFLAGS=	-DVIM_VERSION_PATCHLEVEL=$(PATCHLEVEL)
+!ENDIF
+
 
 !if "$(VIMDLL)" == "yes"
 GUI = yes
@@ -591,7 +636,7 @@ OPTFLAG = $(OPTFLAG) /GL
 ! endif
 
 CFLAGS = $(CFLAGS) $(OPTFLAG) -DNDEBUG $(CPUARG)
-RCFLAGS = -DNDEBUG
+RCFLAGS = $(RCFLAGS) -DNDEBUG
 ! ifdef USE_MSVCRT
 CFLAGS = $(CFLAGS) /MD
 LIBC = msvcrt.lib
@@ -607,7 +652,7 @@ VIM = vimd
 DEBUGINFO = /ZI
 ! endif
 CFLAGS = $(CFLAGS) -D_DEBUG -DDEBUG /Od
-RCFLAGS = -D_DEBUG -DDEBUG
+RCFLAGS = $(RCFLAGS) -D_DEBUG -DDEBUG
 # The /fixed:no is needed for Quantify.
 LIBC = /fixed:no
 ! ifdef USE_MSVCRT
@@ -621,7 +666,7 @@ LIBC = $(LIBC) libcmtd.lib
 !endif # DEBUG
 
 # Visual Studio 2005 has 'deprecated' many of the standard CRT functions
-CFLAGS_DEPR = /D_CRT_SECURE_NO_DEPRECATE /D_CRT_NONSTDC_NO_DEPRECATE
+CFLAGS_DEPR = -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
 CFLAGS = $(CFLAGS) $(CFLAGS_DEPR)
 
 !include Make_all.mak


### PR DESCRIPTION
Reverted behavior as it was in [patch 9.1.191](https://github.com/vim/vim/commit/2680a074d4790abb372ecda658b0c455a6fe06cf).

A workaround was applied to correct the error specified in the [issue](https://github.com/vim/vim-win32-installer/issues/337) from "vim-win32-installer" repository. This is now fixed in [this pull request](https://github.com/vim/vim-win32-installer/pull/338) to the "vim-win32-installer" repository.

Also in Make_mvc.mak added automatic insertion of the current patch number when Vim is compiled.
