### PR TITLE
Missing test for patch 9.1.0285

### DIFF
--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4237,4 +4237,14 @@ func Test_halfpage_scrolloff_eob()
   bwipe!
 endfunc
 
+" Test for Ctrl-U/D moving the cursor at the buffer boundaries.
+func Test_halfpage_cursor_startend()
+  call setline(1, range(1, 100))
+  exe "norm! jztj\<C-U>"
+  call assert_equal(1, line('.'))
+  exe "norm! G\<C-Y>k\<C-D>"
+  call assert_equal(100, line('.'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Not all of what was fixed by patch 9.1.0285 is tested.
Solution: Add a test for cursor movement at buffer boundaries.