### PR TITLE
Leading zeros for the Patchlevel.

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -187,7 +187,7 @@ MINOR=		1
 !ENDIF
 
 !IF ![$(PS) $(PSFLAGS) try{Out-File -FilePath '.\patchlvl.tmp' -InputObject \
-	\"PATCHLEVEL=$$(((Get-Content -Path '.\version.c' \
+	\"PATCHLEVEL=$$([decimal^]((Get-Content -Path '.\version.c' \
 	-TotalCount ((Select-String -Pattern 'static int included_patches' \
 	-Path '.\version.c').LineNumber+3))[-1^]).Trim().TrimEnd(','))\"} \
 	catch{exit 1}]

--- a/src/version.h
+++ b/src/version.h
@@ -31,7 +31,19 @@
 #ifndef VIM_VERSION_PATCHLEVEL
 # define VIM_VERSION_PATCHLEVEL		0
 #endif
-#define VIM_VERSION_PATCHLEVEL_STR	VIM_TOSTR(VIM_VERSION_PATCHLEVEL)
+
+// Patchlevel with leading zeros
+#if VIM_VERSION_PATCHLEVEL < 10
+#define LEADZERO(x) 000 ## x
+#elif VIM_VERSION_PATCHLEVEL < 100
+#define LEADZERO(x) 00 ## x
+#elif VIM_VERSION_PATCHLEVEL < 1000
+#define LEADZERO(x) 0 ## x
+#else
+#define LEADZERO(x) x
+#endif
+
+#define VIM_VERSION_PATCHLEVEL_STR	VIM_TOSTR(LEADZERO(VIM_VERSION_PATCHLEVEL))
 // Used by MacOS port; should be one of: development, alpha, beta, final
 #define VIM_VERSION_RELEASE		final
 

--- a/src/version.h
+++ b/src/version.h
@@ -33,6 +33,9 @@
 #endif
 
 // Patchlevel with leading zeros
+// For compatibility with the installer from "vim-win32-installer" and WinGet.
+// For details see https://github.com/vim/vim-win32-installer/pull/277
+// and https://github.com/vim/vim-win32-installer/pull/285
 #if VIM_VERSION_PATCHLEVEL < 10
 #define LEADZERO(x) 000 ## x
 #elif VIM_VERSION_PATCHLEVEL < 100


### PR DESCRIPTION
If I understand what @chrisbra  [said](https://github.com/vim/vim-win32-installer/commit/db248ddf9665fbd8569e3f5e6e77af43befb52c5) correctly, the installer and WinGet require the patch level to be in four digit format.

I have slightly modified the "version.h" file to allow the leading zeros for the patchlevel to be displayed. The solution was honestly looked up on StackOverflow. Checked it out, it works.

> (Get-Item -Path 'F:\test-build-vim\vim\src\gvim.exe').VersionInfo
> ProductVersion   FileVersion      FileName                                                                                                                                                                          
> \--------------   -----------      --------                                                                                                                                                                          
> 9.1.0296         9.1.0296         F:\test-build-vim\vim\src\gvim.exe                                                                                                                                                
> 
> (Get-Item -Path 'F:\test-build-vim\vim\src\vim32.dll').VersionInfo
> ProductVersion   FileVersion      FileName                                                                                                                                                                          
> \--------------   -----------      --------                                                                                                                                                                          
> 9.1.0296         9.1.0296         F:\test-build-vim\vim\src\vim32.dll                                                                                                                                               
> 
> (Get-Item -Path 'F:\test-build-vim\vim\src\vim.exe').VersionInfo
> ProductVersion   FileVersion      FileName                                                                                                                                                                          
> \--------------   -----------      --------                                                                                                                                                                          
> 9.1.0296         9.1.0296         F:\test-build-vim\vim\src\vim.exe 

![vim_ver](https://github.com/vim/vim/assets/69863286/49531c2c-235d-4374-93b6-3f37ae6e24e1)
