### PR TITLE
Vim9: heredoc start may be recognized in string

### DIFF
--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -409,10 +409,16 @@ func Test_let_heredoc_fails()
   endtry
 
   try
+    let [] =<< trim TEXT
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E475:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
     let [a b c] =<< trim TEXT
-      change
-      insert
-      append
     TEXT
     call assert_report('No exception thrown')
   catch /E475:/
@@ -422,9 +428,6 @@ func Test_let_heredoc_fails()
 
   try
     let [a; b; c] =<< trim TEXT
-      change
-      insert
-      append
     TEXT
     call assert_report('No exception thrown')
   catch /E452:/

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -2008,6 +2008,20 @@ def Test_heredoc()
   END
   v9.CheckScriptSuccess(lines)
 
+  # heredoc start should not be recognized in string
+  lines =<< trim END
+      vim9script
+      def Func()
+        new
+        @" = 'bar'
+        ['foo', @"]->setline("]=<<"->count('='))
+        assert_equal(['foo', 'bar'], getline(1, '$'))
+        bwipe!
+      enddef
+      Func()
+  END
+  v9.CheckScriptSuccess(lines)
+
   v9.CheckDefFailure(['var lines =<< trim END X', 'END'], 'E488:')
   v9.CheckDefFailure(['var lines =<< trim END " comment', 'END'], 'E488:')
 

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -1230,18 +1230,15 @@ get_function_body(
 		    int		save_sc_version = current_sctx.sc_version;
 		    int		var_count = 0;
 		    int		semicolon = 0;
-		    char_u	*argend;
 
 		    current_sctx.sc_version
 				     = vim9_function ? SCRIPT_VERSION_VIM9 : 1;
-		    argend = skip_var_list(arg, TRUE, &var_count, &semicolon,
+		    arg = skip_var_list(arg, TRUE, &var_count, &semicolon,
 									 TRUE);
-		    if (argend == NULL)
-			// Invalid list assignment: skip to closing bracket.
-			argend = find_name_end(arg, NULL, NULL, FNE_INCL_BR);
-		    arg = skipwhite(argend);
+		    if (arg != NULL)
+			arg = skipwhite(arg);
 		    current_sctx.sc_version = save_sc_version;
-		    if (arg[0] == '=' && arg[1] == '<' && arg[2] =='<')
+		    if (arg != NULL && STRNCMP(arg, "=<<", 3) == 0)
 		    {
 			p = skipwhite(arg + 3);
 			while (TRUE)


### PR DESCRIPTION
Problem:  Vim9: heredoc start may be recognized in string.
Solution: Don't skip to closing bracket for invalid list assignment.
