### PR TITLE
runtime: add PicoLisp filetype

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1191,6 +1191,28 @@ export def FTdat()
   endif
 enddef
 
+# Determne if a *.l file is Lex or PicoLisp
+export def FTl()
+  " Default to Lex
+  set ft=lex
+  for i in range(1, line("$"))
+    let l:line = trim(getline(i))
+    " PicoLisp uses # comments
+    if l:line =~ "^#\.*$"
+      set ft=picolisp
+      return
+    " Lex uses // comments
+    elseif (l:line =~ "//" && l:line !~ "([^)]*//") || l:line =~ "/\\*" || l:line =~ "\\*/"
+      set ft=lex
+      return
+    " PicoLisp uses Lisp syntax
+    elseif l:line =~ "^("
+      set ft=picolisp
+      return
+    endif
+  endfor
+enddef
+
 export def FTlsl()
   if exists("g:filetype_lsl")
     exe "setf " .. g:filetype_lsl

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1191,27 +1191,31 @@ export def FTdat()
   endif
 enddef
 
-# Determine if a *.l file is Lex or PicoLisp
+# Determine if a *.l file is Lex or PicoLisp (default to Lex)
 export def FTl()
-  " Default to Lex
-  setf lex
+  if exists("g:filetype_l")
+    exe "setf " .. g:filetype_l
+    return
+  endif
   for i in range(1, line("$"))
-    let l:line = trim(getline(i))
-    " PicoLisp uses # comments
-    if l:line =~ "^#\.*$"
-      set ft=picolisp
+    var line = trim(getline(i))
+    if line =~ "^%{.*$"
+      setf lex
       return
-    " Lex uses // comments
-    elseif (l:line =~ "//" && l:line !~ "([^)]*//") || l:line =~ "/\\*" || l:line =~ "\\*/"
-      set ft=lex
+    elseif line =~ "^%%.*$"
+      setf lex
       return
-    " PicoLisp uses Lisp syntax
-    elseif l:line =~ "^("
-      set ft=picolisp
+    elseif line =~ "^#.*$"
+      setf picolisp
+      return
+    elseif line =~ "^\(.*$"
+      setf picolisp
       return
     endif
   endfor
-enddef
+  setf lex
+  return
+enddef 
 
 export def FTlsl()
   if exists("g:filetype_lsl")

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1191,7 +1191,7 @@ export def FTdat()
   endif
 enddef
 
-# Determne if a *.l file is Lex or PicoLisp
+# Determine if a *.l file is Lex or PicoLisp
 export def FTl()
   " Default to Lex
   set ft=lex

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1194,7 +1194,7 @@ enddef
 # Determine if a *.l file is Lex or PicoLisp
 export def FTl()
   " Default to Lex
-  set ft=lex
+  setf lex
   for i in range(1, line("$"))
     let l:line = trim(getline(i))
     " PicoLisp uses # comments

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -155,6 +155,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.h		g:c_syntax_for_h	|ft-c-syntax|
 	*.i		g:filetype_i		|ft-progress-syntax|
 	*.inc		g:filetype_inc
+	*.l		g:filetype_l
 	*.lsl		g:filetype_lsl
 	*.m		g:filetype_m		|ft-mathematica-syntax|
 	*.mod		g:filetype_mod

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1199,7 +1199,10 @@ au BufRead,BufNewFile *.ldg,*.ledger,*.journal			setf ledger
 au BufNewFile,BufRead *.less			setf less
 
 " Lex
-au BufNewFile,BufRead *.lex,*.l,*.lxx,*.l++	setf lex
+au BufNewFile,BufRead *.lex,*.lxx,*.l++		setf lex
+
+" Lex and PicoLisp
+au BufNewFile,BufRead *.l			call dist#ft#FTl()
 
 " Libao
 au BufNewFile,BufRead */etc/libao.conf,*/.libao	setf libao

--- a/runtime/ftplugin/picolisp.vim
+++ b/runtime/ftplugin/picolisp.vim
@@ -1,0 +1,14 @@
+" PicoLisp filetype plugin file
+" Language: PicoLisp
+" Maintainer: nat-418 <93013864+nat-418@users.noreply.github.com>
+" Latest Revision: 2024-04-10
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=s1:#{,ex:}#,:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setl com< cms<"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -528,6 +528,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     pf: ['pf.conf'],
     pfmain: ['main.cf', 'main.cf.proto'],
     php: ['file.php', 'file.php9', 'file.phtml', 'file.ctp', 'file.phpt', 'file.theme'],
+    picolisp: ['file.l'],
     pike: ['file.pike', 'file.pmod'],
     pilrc: ['file.rcp'],
     pine: ['.pinerc', 'pinerc', '.pinercex', 'pinercex'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -528,7 +528,6 @@ def s:GetFilenameChecks(): dict<list<string>>
     pf: ['pf.conf'],
     pfmain: ['main.cf', 'main.cf.proto'],
     php: ['file.php', 'file.php9', 'file.phtml', 'file.ctp', 'file.phpt', 'file.theme'],
-    picolisp: ['file.l'],
     pike: ['file.pike', 'file.pmod'],
     pilrc: ['file.rcp'],
     pine: ['.pinerc', 'pinerc', '.pinercex', 'pinercex'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2276,6 +2276,46 @@ func Test_inc_file()
   filetype off
 endfunc
 
+func Test_l_file()
+  filetype on
+
+  call writefile(['%{'], 'Xfile.l')
+  split Xfile.l
+  call assert_equal('lex', &filetype)
+  bwipe!
+
+  call writefile(['%%'], 'Xfile.l')
+  split Xfile.l
+  call assert_equal('lex', &filetype)
+  bwipe!
+
+  call writefile(['(de example "Looks like PicoLisp")'], 'Xfile.l', 'D')
+  split Xfile.l
+  call assert_equal('picolisp', &filetype)
+  bwipe!
+
+  call writefile(['# PicoLisp comment'], 'Xfile.l')
+  split Xfile.l
+  call assert_equal('picolisp', &filetype)
+  bwipe!
+
+  let g:filetype_l = 'lex'
+  call writefile([''], 'Xfile.l', 'D')
+  split Xfile.l
+  call assert_equal('lex', &filetype)
+  unlet g:filetype_l
+  bwipe!
+
+  let g:filetype_l = 'picolisp'
+  call writefile([''], 'Xfile.l', 'D')
+  split Xfile.l
+  call assert_equal('picolisp', &filetype)
+  bwipe!
+
+  unlet g:filetype_l
+  filetype off
+endfunc
+
 func Test_lsl_file()
   filetype on
 


### PR DESCRIPTION
This PR adds support for the [PicoLisp](https://picolisp.com/wiki/?home) programming language. ~~PicoLisp exclusively uses the `*.l` filename extension, which is currently also used by Lex among several other extensions, so I have removed `*.l` from the Lex filename extensions and transferred it to PicoLisp.~~