### PR TITLE
filetype: add bp filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2961,6 +2961,9 @@ au BufNewFile,BufRead *.txt
 " Blueprint markup files
 au BufNewFile,BufRead *.blp			setf blueprint
 
+" Blueprint build system file
+au BufNewFile,BufRead *.bp			setf bp
+
 " Use the filetype detect plugins.  They may overrule any of the previously
 " detected filetypes.
 runtime! ftdetect/*.vim

--- a/runtime/ftplugin/bp.vim
+++ b/runtime/ftplugin/bp.vim
@@ -1,0 +1,14 @@
+" Blueprint build system filetype plugin file
+" Language: Blueprint
+" Maintainer: Bruno BELANYI <bruno.vim@belanyi.fr>
+" Latest Revision: 2024-04-10
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=b:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -126,6 +126,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     blade: ['file.blade.php'],
     blank: ['file.bl'],
     blueprint: ['file.blp'],
+    bp: ['Android.bp'],
     bsdl: ['file.bsd', 'file.bsdl'],
     bst: ['file.bst'],
     bzl: ['file.bazel', 'file.bzl', 'WORKSPACE', 'WORKSPACE.bzlmod'],


### PR DESCRIPTION
Problem: The Blueprint build system (e.g: `Android.bp` files [1]) is not recognized.

Solution: add `bp` filetype for those files.

[1]: https://source.android.com/docs/setup/build