### PR TITLE
filetype: translate shell config files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1002,6 +1002,9 @@ au BufRead,BufNewFile *.hoon			setf hoon
 " Tilde (must be before HTML)
 au BufNewFile,BufRead *.t.html			setf tilde
 
+" Translate shell
+au BufNewFile,BufRead init.trans,*/etc/translate-shell,.trans	setf clojure
+
 " HTML (.shtml and .stm for server side)
 au BufNewFile,BufRead *.html,*.htm,*.shtml,*.stm  call dist#ft#FThtml()
 au BufNewFile,BufRead *.cshtml			setf html

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -155,7 +155,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     chuck: ['file.ck'],
     cl: ['file.eni'],
     clean: ['file.dcl', 'file.icl'],
-    clojure: ['file.clj', 'file.cljs', 'file.cljx', 'file.cljc'],
+    clojure: ['file.clj', 'file.cljs', 'file.cljx', 'file.cljc', 'init.trans', 'any/etc/translate-shell', '.trans'],
     cmake: ['CMakeLists.txt', 'file.cmake', 'file.cmake.in'],
     cmod: ['file.cmod'],
     cmusrc: ['any/.cmus/autosave', 'any/.cmus/rc', 'any/.cmus/command-history', 'any/.cmus/file.theme', 'any/cmus/rc', 'any/cmus/file.theme', '/.cmus/autosave', '/.cmus/command-history', '/.cmus/file.theme', '/.cmus/rc', '/cmus/file.theme', '/cmus/rc'],


### PR DESCRIPTION
Problem: Translate shell config files are not recognized.
Solution: Add a pattern for translate shell config files.
Refer: https://github.com/soimort/translate-shell/wiki/Configuration

See its syntax highlight
