### PR TITLE
filetype: matplotlibrc files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -425,8 +425,8 @@ au BufNewFile,BufRead .clang-format		setf yaml
 " Clang-tidy
 au BufNewFile,BufRead .clang-tidy		setf yaml
 
-" Matplotlib style
-au BufNewFile,BufRead *.mplstyle		setf yaml
+" Matplotlib
+au BufNewFile,BufRead *.mplstyle,matplotlibrc	setf yaml
 
 " Clean
 au BufNewFile,BufRead *.dcl,*.icl		setf clean

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -826,7 +826,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     xsd: ['file.xsd'],
     xslt: ['file.xsl', 'file.xslt'],
     yacc: ['file.yy', 'file.yxx', 'file.y++'],
-    yaml: ['file.yaml', 'file.yml', 'file.eyaml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'yarn.lock'],
+    yaml: ['file.yaml', 'file.yml', 'file.eyaml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'matplotlibrc', 'yarn.lock'],
     yang: ['file.yang'],
     yuck: ['file.yuck'],
     z8a: ['file.z8a'],


### PR DESCRIPTION
Problem: Matplotlibrc files are not recognized.
Solution: Add a pattern for matplotlibrc files.
Refer: https://matplotlib.org/stable/users/explain/customizing.html#the-matplotlibrc-file
