### PR TITLE
filetype: ripgrep rc files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1824,6 +1824,9 @@ au BufNewFile,BufRead *.rego			setf rego
 " Rexx
 au BufNewFile,BufRead *.rex,*.orx,*.rxo,*.rxj,*.jrexx,*.rexxj,*.rexx,*.testGroup,*.testUnit	setf rexx
 
+" Ripgrep rc
+au BufNewFile,BufRead {.,}ripgreprc			setf conf
+
 " R Help file
 if has("fname_case")
   au BufNewFile,BufRead *.rd,*.Rd		setf rhelp

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -160,7 +160,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     cobol: ['file.cbl', 'file.cob', 'file.lib'],
     coco: ['file.atg'],
     conaryrecipe: ['file.recipe'],
-    conf: ['auto.master', 'file.conf'],
+    conf: ['auto.master', 'file.conf', '.ripgreprc', 'ripgreprc'],
     config: ['configure.in', 'configure.ac', '/etc/hostname.file', 'any/etc/hostname.file'],
     confini: ['/etc/pacman.conf', 'any/etc/pacman.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'file.nmconnection'],
     context: ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],


### PR DESCRIPTION
Problem: Ripgrep rc files are not recognized.
Solution: Add a pattern for ripgrep rc files
Refer: https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file
