### PR TITLE
filetype: x11vnc config files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2566,6 +2566,9 @@ au BufNewFile,BufRead *.ws[fc]			setf wsh
 " XHTML
 au BufNewFile,BufRead *.xhtml,*.xht		setf xhtml
 
+" X11vnc
+au BufNewFile,BufRead .x11vncrc			setf conf
+
 " X Pixmap (dynamically sets colors, this used to trigger on BufEnter to make
 " it work better, but that breaks setting 'filetype' manually)
 au BufNewFile,BufRead *.xpm

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -160,7 +160,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     cobol: ['file.cbl', 'file.cob', 'file.lib'],
     coco: ['file.atg'],
     conaryrecipe: ['file.recipe'],
-    conf: ['auto.master', 'file.conf'],
+    conf: ['auto.master', 'file.conf', '.x11vncrc'],
     config: ['configure.in', 'configure.ac', '/etc/hostname.file', 'any/etc/hostname.file'],
     confini: ['/etc/pacman.conf', 'any/etc/pacman.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'file.nmconnection'],
     context: ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],


### PR DESCRIPTION
Problem: x11vnc config files are not recognized.
Solution: Add a pattern for x11vnc config files.
Refer: https://linux.die.net/man/1/x11vnc
