### PR TITLE
ftplugin(cmake): Add include and suffixesadd

### DIFF
--- a/runtime/ftplugin/cmake.vim
+++ b/runtime/ftplugin/cmake.vim
@@ -15,7 +15,7 @@ set cpo&vim
 " Don't load another plugin for this buffer
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "setl commentstring<"
+let b:undo_ftplugin = "setl inc< sua< commentstring<"
 
 if exists('loaded_matchit')
   let b:match_words = '\<if\>:\<elseif\>\|\<else\>:\<endif\>'
@@ -27,6 +27,8 @@ if exists('loaded_matchit')
   let b:undo_ftplugin .= "| unlet b:match_words"
 endif
 
+setlocal include=\s*include
+setlocal suffixesadd=.cmake,-config.cmake
 setlocal commentstring=#\ %s
 
 " restore 'cpo' and clean up buffer variable


### PR DESCRIPTION
Not sure should we add `setlocal path=.,/usr/lib/cmake/*,/usr/share/cmake/*`?
Looks only GNU/Linux use this paths.
