### PR TITLE
Filler lines not checked properly in get_scroll_overlap()

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3102,7 +3102,7 @@ static int get_scroll_overlap(int dir)
 
     loff.lnum = dir == FORWARD ? curwin->w_botline : curwin->w_topline - 1;
 #ifdef FEAT_DIFF
-    loff.fill = diff_check_fill(curwin, loff.lnum + dir == BACKWARD)
+    loff.fill = diff_check_fill(curwin, loff.lnum + (dir == BACKWARD))
 		- (dir == FORWARD ? curwin->w_filler_rows : curwin->w_topfill);
     loff.height = loff.fill > 0 ? 1 : plines_nofill(loff.lnum);
 #else


### PR DESCRIPTION
Problem:  Filler lines not checked properly in get_scroll_overlap().
Solution: Add missing parentheses.

The missing parentheses causes the second argument to diff_check_fill()
to always be 0 as it is the result of a comparison between a positive
integer and -1 (the value of BACKWARD), in which case diff_check_fill()
always returns 0 instead of the number of filler lines above a line.

It's very hard to add a test for this, because this mistake at most
leads to 2 screen lines of difference in scrolling behavior, and in
cases where it may indeed lead to a difference in behavior, neither
behavior achieves complete symmetry between CTRL-F and CTRL-B.
