### PR TITLE
fix: using 'vimdoc' as vim ft compiler was a bit aggressive

### DIFF
--- a/runtime/compiler/vimdoc.vim
+++ b/runtime/compiler/vimdoc.vim
@@ -1,9 +1,10 @@
 " Vim Compiler File
 " Language:             vimdoc
 " Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
-" Latest Revision:      2024-04-09
+" Latest Revision:      2024-04-13
 "
-" you can get it by `pip install vimdoc` or the package manager of your distribution.
+" If you can not find 'vimdoc' in the package manager of your distribution e.g
+" 'pip', then you may need to build it from its source.
 
 if exists('b:current_compiler')
   finish

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:		Vim
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2024 Apr 08
+" Last Change:		2024 Apr 13
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -14,8 +14,6 @@ let b:did_ftplugin = 1
 
 let s:cpo_save = &cpo
 set cpo&vim
-
-compiler vimdoc
 
 if !exists('*VimFtpluginUndo')
   func VimFtpluginUndo()


### PR DESCRIPTION
// trying to mdf if really to keep it as a 'compiler' 
// or maybe just back out #14459