### PR TITLE
Crash when using heredoc with comment in command block

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -2089,17 +2089,6 @@ skiptowhite(char_u *p)
 }
 
 /*
- * skiptowhite: skip over text until ' ' or '\t' or newline or NUL.
- */
-    char_u *
-skiptowhite_or_nl(char_u *p)
-{
-    while (*p != ' ' && *p != '\t' && *p != NL && *p != NUL)
-	++p;
-    return p;
-}
-
-/*
  * skiptowhite_esc: Like skiptowhite(), but also skip escaped chars
  */
     char_u *

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -781,8 +781,15 @@ heredoc_get(exarg_T *eap, char_u *cmd, int script_get, int vim9compile)
     int		count = 0;
     int		heredoc_in_string = FALSE;
     char_u	*line_arg = NULL;
+    char_u	*nl_ptr = vim_strchr(cmd, '\n');
 
-    if (eap->ea_getline == NULL && vim_strchr(cmd, '\n') == NULL)
+    if (nl_ptr != NULL)
+    {
+	heredoc_in_string = TRUE;
+	line_arg = nl_ptr + 1;
+	*nl_ptr = NUL;
+    }
+    else if (eap->ea_getline == NULL)
     {
 	emsg(_(e_cannot_use_heredoc_here));
 	return NULL;
@@ -826,14 +833,8 @@ heredoc_get(exarg_T *eap, char_u *cmd, int script_get, int vim9compile)
     if (*cmd != NUL && *cmd != comment_char)
     {
 	marker = skipwhite(cmd);
-	p = skiptowhite_or_nl(marker);
-	if (*p == NL)
-	{
-	    // heredoc in a string
-	    line_arg = p + 1;
-	    heredoc_in_string = TRUE;
-	}
-	else if (*skipwhite(p) != NUL && *skipwhite(p) != comment_char)
+	p = skiptowhite(marker);
+	if (*skipwhite(p) != NUL && *skipwhite(p) != comment_char)
 	{
 	    semsg(_(e_trailing_characters_str), p);
 	    return NULL;

--- a/src/proto/charset.pro
+++ b/src/proto/charset.pro
@@ -61,7 +61,6 @@ int vim_isalpha(int c);
 int vim_toupper(int c);
 int vim_tolower(int c);
 char_u *skiptowhite(char_u *p);
-char_u *skiptowhite_or_nl(char_u *p);
 char_u *skiptowhite_esc(char_u *p);
 long getdigits(char_u **pp);
 long getdigits_quoted(char_u **pp);

--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -536,6 +536,13 @@ END
   XX
   call assert_equal(['Line1'], var1)
 
+  let var1 =<< trim XX " comment
+    Line1
+      Line2
+    Line3
+  XX
+  call assert_equal(['Line1', '  Line2', 'Line3'], var1)
+
   " ignore "endfunc"
   let var1 =<< END
 something
@@ -716,15 +723,27 @@ END
   call v9.CheckScriptFailure(lines, 'E15:')
 
   " Test for using heredoc in a single string using execute()
-  call assert_equal(["['one', 'two']"],
-    \ execute("let x =<< trim END\n  one\n  two\nEND\necho x")->split("\n"))
-  call assert_equal(["['  one', '  two']"],
-    \ execute("let x =<< END\n  one\n  two\nEND\necho x")->split("\n"))
+  call assert_equal("\n['one', 'two']",
+    \ execute("let x =<< trim END\n  one\n  two\nEND\necho x"))
+  call assert_equal("\n['one', '  two']",
+    \ execute("let x =<< trim END\n  one\n    two\nEND\necho x"))
+  call assert_equal("\n['one', 'two']",
+    \ execute("  let x =<< trim END\n    one\n    two\n  END\necho x"))
+  call assert_equal("\n['one', '  two']",
+    \ execute("  let x =<< trim END\n    one\n      two\n  END\necho x"))
+  call assert_equal("\n['  one', '  two']",
+    \ execute("let x =<< END\n  one\n  two\nEND\necho x"))
+  call assert_equal("\n['one', 'two']",
+    \ execute("let x =<< END\none\ntwo\nEND\necho x"))
+  call assert_equal("\n['one', 'two']",
+    \ execute("let x =<< END \" comment\none\ntwo\nEND\necho x"))
   let cmd = 'execute("let x =<< END\n  one\n  two\necho x")'
   call assert_fails(cmd, "E990: Missing end marker 'END'")
   let cmd = 'execute("let x =<<\n  one\n  two\necho x")'
-  call assert_fails(cmd, "E990: Missing end marker ''")
+  call assert_fails(cmd, "E172: Missing marker")
   let cmd = 'execute("let x =<< trim\n  one\n  two\necho x")'
+  call assert_fails(cmd, "E172: Missing marker")
+  let cmd = 'execute("let x =<< end\n  one\n  two\nend\necho x")'
   call assert_fails(cmd, "E221: Marker cannot start with lower case letter")
   let cmd = 'execute("let x =<< eval END\n  one\n  two{y}\nEND\necho x")'
   call assert_fails(cmd, 'E121: Undefined variable: y')

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -508,6 +508,22 @@ def Test_command_block_heredoc()
   CODE
   v9.CheckSourceSuccess(lines)
 
+  # Heredoc with comment
+  lines =<< trim CODE
+    vim9script
+    com SomeCommand {
+        g:someVar =<< trim END # comment
+          aaa
+          bbb
+        END
+      }
+    execute('SomeCommand')
+    assert_equal(['aaa', 'bbb'], g:someVar)
+    delcommand SomeCommand
+    unlet g:someVar
+  CODE
+  v9.CheckSourceSuccess(lines)
+
   # heredoc evaluation
   lines =<< trim CODE
     vim9script


### PR DESCRIPTION
Problem:  Crash when using heredoc with comment in command block.
Solution: Handle a newline more like the end of the line.
