### PR TITLE
Fail the Vim9 script compilation when a class is defined inside a function

### DIFF
--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1521,7 +1521,6 @@ Custom types can be defined with `:type`: >
 	:type MyList list<string>
 Custom types must start with a capital letter, to avoid name clashes with
 builtin types added later, similarly to user functions.
-{not implemented yet}
 
 And classes and interfaces can be used as types: >
 	:class MyClass

--- a/src/errors.h
+++ b/src/errors.h
@@ -3412,9 +3412,9 @@ EXTERN char e_invalid_class_variable_declaration_str[]
 EXTERN char e_invalid_type_for_object_variable_str[]
 	INIT(= N_("E1330: Invalid type for object variable: %s"));
 EXTERN char e_public_must_be_followed_by_var_static_final_or_const[]
-	INIT(= N_("E1331: Public must be followed by \"var\" or \"static\" or \"final\" or \"const\""));
+	INIT(= N_("E1331: public must be followed by \"var\" or \"static\" or \"final\" or \"const\""));
 EXTERN char e_public_variable_name_cannot_start_with_underscore_str[]
-	INIT(= N_("E1332: Public variable name cannot start with underscore: %s"));
+	INIT(= N_("E1332: public variable name cannot start with underscore: %s"));
 EXTERN char e_cannot_access_protected_variable_str[]
 	INIT(= N_("E1333: Cannot access protected variable \"%s\" in class \"%s\""));
 // E1334 unused
@@ -3532,9 +3532,9 @@ EXTERN char e_class_method_str_accessible_only_using_class_str[]
 EXTERN char e_object_method_str_accessible_only_using_object_str[]
 	INIT(= N_("E1386: Object method \"%s\" accessible only using class \"%s\" object"));
 EXTERN char e_public_variable_not_supported_in_interface[]
-	INIT(= N_("E1387: Public variable not supported in an interface"));
+	INIT(= N_("E1387: public variable not supported in an interface"));
 EXTERN char e_public_keyword_not_supported_for_method[]
-	INIT(= N_("E1388: Public keyword not supported for a method"));
+	INIT(= N_("E1388: public keyword not supported for a method"));
 EXTERN char e_missing_name_after_implements[]
 	INIT(= N_("E1389: Missing name after implements"));
 EXTERN char e_cannot_use_an_object_variable_except_with_the_new_method_str[]
@@ -3615,6 +3615,8 @@ EXTERN char e_enum_str_name_cannot_be_modified[]
 	INIT(= N_("E1427: Enum \"%s\" name cannot be modified"));
 EXTERN char e_duplicate_enum_str[]
 	INIT(= N_("E1428: Duplicate enum value: %s"));
+EXTERN char e_class_can_only_be_used_in_script[]
+	INIT(= N_("E1429: Class can only be used in a script"));
 #endif
 // E1429 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -400,7 +400,7 @@ def Test_class_def_method()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "var" or "static"', 3)
+  v9.CheckSourceFailure(lines, 'E1388: public keyword not supported for a method', 3)
 
   # Using the "public" keyword when defining a class method
   lines =<< trim END
@@ -410,7 +410,7 @@ def Test_class_def_method()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1388: Public keyword not supported for a method', 3)
+  v9.CheckSourceFailure(lines, 'E1388: public keyword not supported for a method', 3)
 
   # Using the "public" keyword when defining an object protected method
   lines =<< trim END
@@ -420,7 +420,7 @@ def Test_class_def_method()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "var" or "static"', 3)
+  v9.CheckSourceFailure(lines, 'E1388: public keyword not supported for a method', 3)
 
   # Using the "public" keyword when defining a class protected method
   lines =<< trim END
@@ -430,7 +430,7 @@ def Test_class_def_method()
       enddef
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1388: Public keyword not supported for a method', 3)
+  v9.CheckSourceFailure(lines, 'E1388: public keyword not supported for a method', 3)
 
   # Using a "def" keyword without an object method name
   lines =<< trim END
@@ -1191,7 +1191,7 @@ def Test_instance_variable_access()
       public var _val = 10
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1332: Public variable name cannot start with underscore: public var _val = 10', 3)
+  v9.CheckSourceFailure(lines, 'E1332: public variable name cannot start with underscore: public var _val = 10', 3)
 
   lines =<< trim END
     vim9script
@@ -1287,7 +1287,7 @@ def Test_instance_variable_access()
       public val = 1
     endclass
   END
-  v9.CheckSourceFailure(lines, 'E1331: Public must be followed by "var" or "static"', 3)
+  v9.CheckSourceFailure(lines, 'E1331: public must be followed by "var" or "static"', 3)
 
   # Modify a instance variable using the class name in the script context
   lines =<< trim END
@@ -6537,7 +6537,7 @@ def Test_interface_with_unsupported_members()
       public static var num: number
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1387: Public variable not supported in an interface', 3)
+  v9.CheckSourceFailure(lines, 'E1387: public variable not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -6545,7 +6545,7 @@ def Test_interface_with_unsupported_members()
       public static var num: number
     endinterface
   END
-  v9.CheckSourceFailure(lines, 'E1387: Public variable not supported in an interface', 3)
+  v9.CheckSourceFailure(lines, 'E1387: public variable not supported in an interface', 3)
 
   lines =<< trim END
     vim9script
@@ -10623,6 +10623,19 @@ def Test_abstract_method_defcompile()
     defcompile
   END
   v9.CheckScriptFailure(lines, 'E476: Invalid command: pass', 1)
+enddef
+
+" Test for defining a class in a function
+def Test_class_definition_in_a_function()
+  var lines =<< trim END
+    vim9script
+    def Foo()
+      class A
+      endclass
+    enddef
+    defcompile
+  END
+  v9.CheckScriptFailure(lines, 'E1429: Class can only be used in a script', 1)
 enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -2080,6 +2080,12 @@ early_ret:
 	    has_public = TRUE;
 	    p = skipwhite(line + 6);
 
+	    if (STRNCMP(p, "def", 3) == 0)
+	    {
+		emsg(_(e_public_keyword_not_supported_for_method));
+		break;
+	    }
+
 	    if (STRNCMP(p, "var", 3) != 0 && STRNCMP(p, "static", 6) != 0
 		&& STRNCMP(p, "final", 5) != 0 && STRNCMP(p, "const", 5) != 0)
 	    {

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -4028,10 +4028,13 @@ compile_def_function(
 		    line = (char_u *)"";
 		    break;
 
+	    case CMD_class:
+		    emsg(_(e_class_can_only_be_used_in_script));
+		    goto erret;
+
 	    case CMD_type:
 		    emsg(_(e_type_can_only_be_used_in_script));
 		    goto erret;
-		    break;
 
 	    case CMD_global:
 		    if (check_global_and_subst(ea.cmd, p) == FAIL)


### PR DESCRIPTION
Class definition inside a function is not supported.  Fail the compilation and give a proper error message.  Fixes #13326.
Display a consistent error message when the public keyword is used with class and object methods.  Fixes #13184.
