### PR TITLE
runtime(go): fix highlighting import string followed by some comment

### DIFF
--- a/runtime/syntax/go.vim
+++ b/runtime/syntax/go.vim
@@ -5,7 +5,7 @@
 " go.vim: Vim syntax file for Go.
 " Language:             Go
 " Maintainer:           Billie Cleek <bhcleek@gmail.com>
-" Latest Revision:      2024-03-17
+" Latest Revision:      2024-04-13
 "  2024-03-17:          - fix goPackageComment highlight (by Vim Project)
 " License:              BSD-style. See LICENSE file in source repository.
 " Repository:           https://github.com/fatih/vim-go
@@ -191,7 +191,7 @@ else
   syn region      goRawString         start=+`+ end=+`+
 endif
 
-syn match       goImportString      /^\%(\s\+\|import \)\(\h\w* \)\?\zs"[^"]\+"$/ contained containedin=goImport
+syn match       goImportString      /^\%(\s\+\|import \)\(\h\w* \)\?\zs"[^"]\+"/ contained containedin=goImport
 
 if s:HighlightFormatStrings()
   " [n] notation is valid for specifying explicit argument indexes


### PR DESCRIPTION
This patch is upstreamed from vim-go project.

- https://github.com/fatih/vim-go/pull/3657
- https://github.com/fatih/vim-go/commit/9049ae085ed2f822c377e8caaa96b0d02859470d

I confirmed the maintainer has no concern on upstreaming this patch by [this comment](https://github.com/fatih/vim-go/pull/3657#issuecomment-2052209898).

This PR fixes the issue described in https://github.com/fatih/vim-go/issues/3656. When some characters follow an import string, the import string loses its syntax highlight.