### PR TITLE
Support string interpolation for Dict

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1345,8 +1345,8 @@ expression (like with the "/" command).
 The expression must evaluate to a String.  A Number is always automatically
 converted to a String.  For the "p" and ":put" command, if the result is a
 Float it's converted into a String.  If the result is a List each element is
-turned into a String and used as a line.  A Dictionary or FuncRef results in
-an error message (use string() to convert).
+turned into a String and used as a line.  A Dictionary is converted into a
+String.  A FuncRef results in an error message (use string() to convert).
 
 If the "= register is used for the "p" command, the String is split up at <NL>
 characters.  If the String ends in a <NL>, it is regarded as a linewise

--- a/src/eval.c
+++ b/src/eval.c
@@ -575,7 +575,8 @@ skip_expr_concatenate(
 
 /*
  * Convert "tv" to a string.
- * When "convert" is TRUE convert a List into a sequence of lines.
+ * When "convert" is TRUE convert a List into a sequence of lines and a Dict
+ * into a textual representation of the Dict.
  * Returns an allocated string (NULL when out of memory).
  */
     char_u *
@@ -596,6 +597,8 @@ typval2string(typval_T *tv, int convert)
 	ga_append(&ga, NUL);
 	retval = (char_u *)ga.ga_data;
     }
+    else if (convert && tv->v_type == VAR_DICT)
+	retval = dict2string(tv, get_copyID(), FALSE);
     else
 	retval = vim_strsave(tv_get_string(tv));
     return retval;

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -1962,8 +1962,8 @@ func Test_edit_ctrl_r_failed()
 
   let buf = RunVimInTerminal('', #{rows: 6, cols: 60})
 
-  " trying to insert a dictionary produces an error
-  call term_sendkeys(buf, "i\<C-R>={}\<CR>")
+  " trying to insert a blob produces an error
+  call term_sendkeys(buf, "i\<C-R>=0z\<CR>")
 
   " ending Insert mode should put the cursor back on the ':'
   call term_sendkeys(buf, ":\<Esc>")

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -950,6 +950,10 @@ func Test_string_interp()
     endif
     call assert_equal(0, tmp)
 
+    #" Dict interpolation
+    VAR d = {'a': 10, 'b': [1, 2]}
+    call assert_equal("{'a': 10, 'b': [1, 2]}", $'{d}')
+
     #" Stray closing brace.
     call assert_fails('echo $"moo}"', 'E1278:')
     #" Undefined variable in expansion.

--- a/src/testdir/test_let.vim
+++ b/src/testdir/test_let.vim
@@ -689,6 +689,13 @@ END
   END
   call assert_equal(['let a = {abc}', 'let b = X', 'let c = {'], code)
 
+  " Evaluate a dictionary
+  let d1 = #{a: 10, b: 'ss', c: {}}
+  let code =<< eval trim END
+    let d2 = {d1}
+  END
+  call assert_equal(["let d2 = {'a': 10, 'b': 'ss', 'c': {}}"], code)
+
   let code = 'xxx'
   let code =<< eval trim END
     let n = {5 +

--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -319,4 +319,13 @@ func Test_put_visual_replace_fold_marker()
   bwipe!
 endfunc
 
+func Test_put_dict()
+  new
+  let d = #{a: #{b: 'abc'}, c: [1, 2], d: 0z10}
+  put! =d
+  call assert_equal(["{'a': {'b': 'abc'}, 'c': [1, 2], 'd': 0z10}", ''],
+        \ getline(1, '$'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -2984,6 +2984,16 @@ def Test_heredoc_expr()
   CODE
   v9.CheckDefAndScriptSuccess(lines)
 
+  # Evaluate a dictionary
+  lines =<< trim CODE
+    var d1 = {'a': 10, 'b': [1, 2]}
+    var code =<< trim eval END
+      var d2 = {d1}
+    END
+    assert_equal(["var d2 = {'a': 10, 'b': [1, 2]}"], code)
+  CODE
+  v9.CheckDefAndScriptSuccess(lines)
+
   lines =<< trim CODE
     var code =<< eval trim END
       var s = "{$SOME_ENV_VAR}"

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -1653,6 +1653,7 @@ do_2string(typval_T *tv, int is_2string_any, int tolerant)
 	    case VAR_BOOL:
 	    case VAR_NUMBER:
 	    case VAR_FLOAT:
+	    case VAR_DICT:
 	    case VAR_BLOB:	break;
 
 	    case VAR_LIST:

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -222,6 +222,7 @@ may_generate_2STRING(int offset, int tolerant, cctx_T *cctx)
 
 	// conversion possible when tolerant
 	case VAR_LIST:
+	case VAR_DICT:
 			 if (tolerant)
 			 {
 			     isntype = ISN_2STRING_ANY;
@@ -234,7 +235,6 @@ may_generate_2STRING(int offset, int tolerant, cctx_T *cctx)
 	case VAR_BLOB:
 	case VAR_FUNC:
 	case VAR_PARTIAL:
-	case VAR_DICT:
 	case VAR_JOB:
 	case VAR_CHANNEL:
 	case VAR_INSTR:


### PR DESCRIPTION
When a Dict is used in an interpolated string or heredoc, convert the Dict to a string.
Addresses the issue described in #14529.

This also enables the support for using a Dict with the `:put =` command.

