### PR TITLE
Garbled output on serial terminals with XON/XOFF flow control

### DIFF
--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -3014,6 +3014,7 @@ static struct vimoption options[] =
     p_term("t_8f", T_8F)
     p_term("t_8b", T_8B)
     p_term("t_8u", T_8U)
+    p_term("t_xon", T_XON)
 
 // terminal key codes are not in here
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -3766,7 +3766,8 @@ mch_settmode(tmode_T tmode)
     {
 	// ~ICRNL enables typing ^V^M
 	// ~IXON disables CTRL-S stopping output, so that it can be mapped.
-	tnew.c_iflag &= ~(ICRNL | IXON);
+	tnew.c_iflag &= ~(ICRNL |
+		(T_XON == NULL || *T_XON == NUL ? IXON : 0));
 	tnew.c_lflag &= ~(ICANON | ECHO | ISIG | ECHOE
 # if defined(IEXTEN)
 		    | IEXTEN	    // IEXTEN enables typing ^V on SOLARIS

--- a/src/term.c
+++ b/src/term.c
@@ -1798,6 +1798,8 @@ get_term_entries(int *height, int *width)
 	T_DA = (char_u *)"y";
     if ((T_UT == NULL || T_UT == empty_option) && tgetflag("ut") > 0)
 	T_UT = (char_u *)"y";
+    if ((T_XON == NULL || T_XON == empty_option) && tgetflag("xo") > 0)
+	T_XON = (char_u *)"y";
 
     /*
      * get key codes

--- a/src/termdefs.h
+++ b/src/termdefs.h
@@ -115,10 +115,11 @@ enum SpecialKey
     KS_SRI,	// restore icon text
     KS_FD,	// disable focus event tracking
     KS_FE,	// enable focus event tracking
-    KS_CF	// set terminal alternate font
+    KS_CF,	// set terminal alternate font
+    KS_XON	// terminal uses xon/xoff handshaking
 };
 
-#define KS_LAST	    KS_CF
+#define KS_LAST	    KS_XON
 
 /*
  * the terminal capabilities are stored in this array
@@ -224,6 +225,7 @@ extern char_u *(term_strings[]);    // current terminal strings
 #define T_SRI	(TERM_STR(KS_SRI))	// restore icon text
 #define T_FD	(TERM_STR(KS_FD))	// disable focus event tracking
 #define T_FE	(TERM_STR(KS_FE))	// enable focus event tracking
+#define T_XON	(TERM_STR(KS_XON))	// terminal uses xon/xoff handshaking
 
 typedef enum {
     TMODE_COOK,	    // terminal mode for external cmds and Ex mode


### PR DESCRIPTION
Problem:  When used terminal with XON/XOFF flow control, vim tries to
          still make CTRL-S mapping available, which results in severe
          screen corruption, especially on large redraws, and even
          spurious inputs
Solution: Disallow CTRL-S mapping if such terminal is recognized.
          Don't remove IXON from the bitmask inversion.

closes: #12674 (well, at least CTRL-S mapping is disabled, cannot test vt420 corruption because I do not have such hardware)

**When started with TERM=vt420**:

    TERM=vt420 vim

subsequent

    :set termcap

shows ``t_xon=y``

mapping

    map <C-S> :echo "abc"<CR>

does nothing (after ``<C-S>`` output freezes and subsequent ``<C-Q>``
unfreezes it)

**When started with TERM=xterm**:

    TERM=xterm vim

subsequent

    :set termcap

shows ``t_xon=``

mapping

    map <C-S> :echo "abc"<CR>

works (after ``<C-S>`` one see ``abc`` string echo-ed)