### PR TITLE
perf(syn-i3/swayconfig): clusters, nextgroup and command variant separation

### DIFF
--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -2,8 +2,8 @@
 " Language: i3 config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: Quentin Hibon (github user hiqua)
-" Version: 1.0.2
-" Last Change: 2023-12-28
+" Version: 1.2.1
+" Last Change: 2024-04-14
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -27,225 +27,246 @@ syn keyword i3ConfigTodo TODO FIXME XXX contained
 syn match i3ConfigSeparator /[,;\\]/ contained
 syn match i3ConfigParen /[{}]/ contained
 syn keyword i3ConfigBoolean yes no enabled disabled on off true false contained
-syn region i3ConfigString start=/\W\@<="/ skip=/\\\("\|$\)/ end=/"\|$/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigVariable,i3ConfigExecAction keepend extend
-syn region i3ConfigString start=/\W\@<='/ skip=/\\$/ end=/'\|$/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigVariable,i3ConfigExecAction keepend extend
+" String in simpler (matchable end) and more robust (includes `extend` keyword) forms
+syn cluster i3ConfigStrIn contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,@i3ConfigNumVar,i3ConfigExecAction
+syn match i3ConfigString /\(["']\)[^\\"')\]}]*\1/ contained contains=@i3ConfigStrIn
+syn region i3ConfigString start=/"[^\\"')\]}]*[\\')\]}]/ skip=/\\\@<=\("\|$\)/ end=/"\|$/ contained contains=@i3ConfigStrIn keepend extend
+syn region i3ConfigString start=/'[^\\"')\]}]*[\\")\]}]/ skip=/\\\@<=$/ end=/'\|$/ contained contains=@i3ConfigStrIn keepend extend
 syn match i3ConfigColor /#[0-9A-Fa-f]\{3,8}/ contained
 syn match i3ConfigNumber /[0-9A-Za-z_$-]\@<!-\?\d\+\w\@!/ contained
+" Grouping of common usages
+syn cluster i3ConfigStrVar contains=i3ConfigString,i3ConfigVariable
+syn cluster i3ConfigNumVar contains=i3ConfigNumber,i3ConfigVariable
+syn cluster i3ConfigColVar contains=i3ConfigColor,i3ConfigVariable
+syn cluster i3ConfigIdent contains=i3ConfigString,i3ConfigNumber,i3ConfigVariable
+syn cluster i3ConfigValue contains=@i3ConfigIdent,i3ConfigBoolean
 
 " 4.1 Include directive
-syn keyword i3ConfigIncludeKeyword include contained
-syn match i3ConfigIncludeCommand /`[^`]*`/ contained contains=i3ConfigShDelim,i3ConfigShParam,i3ConfigShOper,i3ConfigShCommand,i3ConfigString
-syn match i3ConfigParamLine /^include .*$/ contains=i3ConfigIncludeKeyword,i3ConfigString,i3ConfigVariable,i3ConfigIncludeCommand,i3ConfigShOper
+syn match i3ConfigIncludeCommand /`[^`]*`/ contained contains=@i3ConfigSh
+syn region i3ConfigParamLine matchgroup=i3ConfigKeyword start=/include / end=/$/ contained contains=@i3ConfigStrVar,i3ConfigIncludeCommand,i3ConfigShOper keepend
 
 " 4.2 Comments
-syn match i3ConfigComment /^\s*#.*$/ contains=i3ConfigTodo
+syn match i3ConfigComment /^\s*#.*$/ contained contains=i3ConfigTodo
 
 " 4.3 Fonts
-syn keyword i3ConfigFontKeyword font contained
+syn match i3ConfigFontSize / \d\+\(px\)\?$/ contained
 syn match i3ConfigColonOperator /:/ contained
-syn match i3ConfigFontNamespace /\w\+:/ contained contains=i3ConfigColonOperator
-syn match i3ConfigFontSize / \d\+\(px\)\?\s\?$/ contained
-syn region i3ConfigFont start=/^\s*font / skip=/\\$/ end=/$/ contains=i3ConfigFontKeyword,i3ConfigFontNamespace,i3ConfigFontSize,i3ConfigSeparator keepend
+syn match i3ConfigFontNamespace /pango:/ contained contains=i3ConfigColonOperator
+syn region i3ConfigParamLine matchgroup=i3ConfigKeyword start=/font / skip=/\\$/ end=/$/ contained contains=i3ConfigFontNamespace,i3ConfigFontSize,i3ConfigSeparator keepend containedin=i3ConfigBarBlock
 
 " 4.4-4.5 Keyboard/Mouse bindings
-syn keyword i3ConfigBindKeyword bindsym bindcode contained
-syn match i3ConfigBindArgument /--\(release\|border\|whole-window\|exclude-titlebar\)/ contained
+syn match i3ConfigBindArgument /--\(release\|border\|whole-window\|exclude-titlebar\) / contained nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
 syn match i3ConfigBindModifier /+/ contained
 syn keyword i3ConfigBindModkey Ctrl Shift Mod1 Mod2 Mod3 Mod4 Mod5 contained
-syn match i3ConfigBindCombo /[$0-9A-Za-z_+]\+ / contained contains=i3ConfigBindModifier,i3ConfigVariable,i3ConfigBindModkey
-syn match i3ConfigBindComboLine /bind\(sym\|code\)\( --[a-z-]\+\)* [$0-9A-Za-z_+]\+ / contained contains=i3ConfigBindKeyword,i3ConfigBindArgument,i3ConfigBindCombo
-syn region i3ConfigBind start=/^\s*bind\(sym\|code\) / skip=/\\$/ end=/$/ contains=i3ConfigBindComboLine,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean keepend
+syn match i3ConfigBindCombo /[$0-9A-Za-z_+]\+/ contained contains=i3ConfigBindModifier,i3ConfigVariable,i3ConfigBindModkey nextgroup=i3ConfigBind
+syn cluster i3ConfigBinder contains=i3ConfigCriteria,@i3ConfigCommand,i3ConfigSeparator
+syn region i3ConfigBind start=/\zs/ skip=/\\$/ end=/$/ contained contains=@i3ConfigBinder keepend
+syn keyword i3ConfigBindKeyword bindsym bindcode contained skipwhite nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
 
 " 4.6 Binding modes
-syn region i3ConfigKeyword start=/^mode\( --pango_markup\)\? \([^'" {]\+\|'[^']\+'\|".\+"\)\s\+{$/ end=/^\s*}$/ contains=i3ConfigShParam,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigNumber,i3ConfigParen,i3ConfigVariable fold keepend extend
+syn region i3ConfigModeBlock matchgroup=i3ConfigKeyword start=/^mode\ze\( --pango_markup\)\? \([^'" {]\+\|'[^']\+'\|".\+"\)\s\+{$/ end=/^}\zs$/ contained contains=i3ConfigShParam,@i3ConfigStrVar,i3ConfigBindKeyword,i3ConfigComment,i3ConfigParen fold keepend extend
 
 " 4.7 Floating modifier
-syn match i3ConfigKeyword /^floating_modifier [$0-9A-Za-z]*$/ contains=i3ConfigVariable,i3ConfigBindModkey
+syn keyword i3ConfigKeyword floating_modifier contained skipwhite nextgroup=i3ConfigVariable,i3ConfigBindModkey
 
 " 4.8 Floating window size
 syn keyword i3ConfigSizeSpecial x contained
-syn match i3ConfigSize / -\?\d\+ x -\?\d\+/ contained contains=i3ConfigSizeSpecial,i3ConfigNumber
-syn match i3ConfigKeyword /^floating_\(maximum\|minimum\)_size .*$/ contains=i3ConfigSize
+syn match i3ConfigSize /-\?\d\+ x -\?\d\+/ contained contains=i3ConfigSizeSpecial,i3ConfigNumber
+syn keyword i3ConfigKeyword floating_maximum_size floating_minimum_size contained skipwhite nextgroup=i3ConfigSize
 
 " 4.9 Orientation
 syn keyword i3ConfigOrientationOpts vertical horizontal auto contained
-syn match i3ConfigKeyword /^default_orientation \w*$/ contains=i3ConfigOrientationOpts
+syn keyword i3ConfigKeyword default_orientation contained skipwhite nextgroup=i3ConfigOrientationOpts
 
 " 4.10 Layout mode
 syn keyword i3ConfigWorkspaceLayoutOpts default stacking tabbed contained
-syn match i3ConfigKeyword /^workspace_layout \w*$/ contains=i3ConfigWorkspaceLayoutOpts
+syn keyword i3ConfigKeyword workspace_layout contained skipwhite nextgroup=i3ConfigWorkspaceLayoutOpts
 
 " 4.11 Title alignment
 syn keyword i3ConfigTitleAlignOpts left center right contained
-syn match i3ConfigKeyword /^title_align .*$/ contains=i3ConfigTitleAlignOpts
+syn keyword i3ConfigKeyword title_align contained skipwhite nextgroup=i3ConfigTitleAlignOpts
 
-" 4.12 Border style
-syn keyword i3ConfigBorderOpts none normal pixel contained
-syn match i3ConfigKeyword /^default\(_floating\)\?_border .*$/ contains=i3ConfigBorderOpts,i3ConfigNumber,i3ConfigVariable
+" 4.12 Border size
+syn keyword i3ConfigBorderOpts none normal pixel contained skipwhite nextgroup=@i3ConfigNumVar
+syn keyword i3ConfigKeyword default_floating_border default_border contained skipwhite nextgroup=i3ConfigBorderOpts
 
 " 4.13 Hide edge borders
 syn keyword i3ConfigEdgeOpts none vertical horizontal both smart smart_no_gaps contained
-syn match i3ConfigKeyword /^hide_edge_borders \w*$/ contains=i3ConfigEdgeOpts
+syn keyword i3ConfigKeyword hide_edge_borders contained skipwhite nextgroup=i3ConfigEdgeOpts
 
 " 4.14 Smart Borders
 syn keyword i3ConfigSmartBorderOpts no_gaps contained
-syn match i3ConfigKeyword /^smart_borders \(on\|off\|no_gaps\)$/ contains=i3ConfigSmartBorderOpts,i3ConfigBoolean
+syn keyword i3ConfigKeyword smart_borders contained skipwhite nextgroup=i3ConfigSmartBorderOpts,i3ConfigBoolean
 
 " 4.15 Arbitrary commands
-syn region i3ConfigKeyword start=/^for_window / end=/$/ contains=i3ConfigForWindowKeyword,i3ConfigCriteria keepend
+syn keyword i3ConfigKeyword for_window contained skipwhite nextgroup=i3ConfigCriteria
 
 " 4.16 No opening focus
-syn match i3ConfigKeyword /^no_focus .*$/ contains=i3ConfigCondition
+syn keyword i3ConfigKeyword no_focus contained skipwhite nextgroup=i3ConfigCondition
 
 " 4.17 Variables
 syn match i3ConfigVariable /\$[0-9A-Za-z_:|[\]-]\+/
-syn keyword i3ConfigSetKeyword set contained
-syn region i3ConfigSet start=/^set\s\+\$/ skip=/\\$/ end=/$/ contains=i3ConfigSetKeyword,i3ConfigVariable,i3ConfigColor,i3ConfigString,i3ConfigNumber,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShParam,i3ConfigShOper,i3ConfigBindModkey keepend
+syn region i3ConfigSet start=/\$/ skip=/\\$/ end=/$/ contained contains=@i3ConfigSh,@i3ConfigValue,i3ConfigColor,i3ConfigBindModkey keepend
+syn keyword i3ConfigKeyword set contained skipwhite nextgroup=i3ConfigSet
 
 " 4.18 X resources
-syn keyword i3ConfigResourceKeyword set_from_resource contained
-syn match i3ConfigParamLine /^set_from_resource\s\+.*$/ contains=i3ConfigResourceKeyword,i3ConfigCondition,i3ConfigColor,i3ConfigVariable,i3ConfigString,i3ConfigNumber
+syn region i3ConfigParamLine matchgroup=i3ConfigKeyword start=/set_from_resource\ze \$/ end=/$/ contained contains=@i3ConfigColVar,i3ConfigDotOperator
 
 " 4.19 Assign clients to workspaces
-syn keyword i3ConfigAssignKeyword assign contained
 syn match i3ConfigAssignSpecial /→\|number/ contained
-syn match i3ConfigAssign /^assign .*$/ contains=i3ConfigAssignKeyword,i3ConfigAssignSpecial,i3ConfigCondition,i3ConfigVariable,i3ConfigString,i3ConfigNumber
+syn region i3ConfigKeyword start=/assign / end=/$/ contained contains=i3ConfigAssignSpecial,i3ConfigCondition,@i3ConfigIdent keepend
 
 " 4.20 Executing shell commands
-syn keyword i3ConfigExecKeyword exec contained
-syn keyword i3ConfigExecAlwaysKeyword exec_always contained
-syn match i3ConfigShCmdDelim /\$(/ contained
-syn region i3ConfigShCommand start=/\$(/ end=/)/ contained contains=i3ConfigShCmdDelim,i3ConfigExecAction,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigString,i3ConfigNumber,i3ConfigVariable keepend extend
+syn region i3ConfigShCommand matchgroup=i3ConfigShDelim start=/\$(/ end=/)/ contained contains=i3ConfigExecAction,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigString,i3ConfigNumber,i3ConfigVariable extend
 syn match  i3ConfigShDelim /[[\]{}();`]\+/ contained
 syn match  i3ConfigShOper /[<>&|+=~^*!.?]\+/ contained
-syn match i3ConfigShParam /\<-[0-9A-Za-z_-]\+\>/ contained containedin=i3ConfigVar
-syn region i3ConfigExec start=/^\s*exec\(_always\)\?\( --no-startup-id\)\? [^{]/ skip=/\\$/ end=/$/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigExecAction keepend
+syn match i3ConfigShParam /\<-[A-Za-z-][0-9A-Za-z_-]*\>/ contained
+syn cluster i3ConfigSh contains=@i3ConfigIdent,i3ConfigShOper,i3ConfigShDelim,i3ConfigShParam,i3ConfigShCommand
+syn region i3ConfigExec start=/ [^{]/ skip=/\\$/ end=/$/ contained contains=i3ConfigExecAction,@i3ConfigSh keepend
+syn match i3ConfigKeyword /^\(exec_always\|exec\)/ contained nextgroup=i3ConfigExec
 
 " 4.21 Workspaces per output
-syn keyword i3ConfigWorkspaceKeyword workspace contained
-syn keyword i3ConfigWorkspaceOutput output contained
-syn keyword i3ConfigWorkspaceDir prev next back_and_forth number contained
-syn region i3ConfigWorkspaceLine start=/^workspace / skip=/\\$/ end=/$/ contains=i3ConfigWorkspaceKeyword,i3ConfigNumber,i3ConfigString,i3ConfigGaps,i3ConfigWorkspaceOutput,i3ConfigVariable,i3ConfigBoolean,i3ConfigSeparator keepend
+syn match i3ConfigOutputIdent /[^'",; ]\+/ contained contains=@i3ConfigIdent,i3ConfigColonOperator skipwhite nextgroup=i3ConfigOutputIdent
+syn region i3ConfigOutputIdent start=/['"]/ end=/\ze/ contained contains=@i3ConfigIdent skipwhite nextgroup=i3ConfigOutputIdent
+syn keyword i3ConfigOutput output contained skipwhite nextgroup=i3ConfigOutputIdent
+syn match i3ConfigWorkspaceIdent /[^'",; ]\+/ contained contains=@i3ConfigIdent skipwhite nextgroup=i3ConfigGaps,i3ConfigOutput
+syn region i3ConfigWorkspaceIdent start=/['"]/ end=/\ze/ contained contains=@i3ConfigIdent skipwhite nextgroup=i3ConfigGaps,i3ConfigOutput
+syn keyword i3ConfigKeyword workspace contained skipwhite nextgroup=i3ConfigWorkspaceIdent
 
 " 4.22 Changing colors
-syn match i3ConfigDotOperator /\./ contained
-syn keyword i3ConfigClientOpts focused focused_inactive unfocused urgent placeholder background contained
-syn match i3ConfigKeyword /^client\..*$/ contains=i3ConfigDotOperator,i3ConfigClientOpts,i3ConfigColor,i3ConfigVariable
+syn keyword i3ConfigClientOpts focused focused_inactive focused_tab_title unfocused urgent placeholder background contained skipwhite nextgroup=i3ConfigColorSeq
+syn match i3ConfigDotOperator /\./ contained nextgroup=i3ConfigClientOpts
+syn keyword i3ConfigKeyword client contained nextgroup=i3ConfigDotOperator
 
 " 4.23 Interprocess communication
-syn match i3ConfigIpcKeyword /ipc-socket/ contained
-syn match i3ConfigParamLine /^ipc-socket .*$/ contains=i3ConfigIpcKeyword
+syn region i3ConfigParamLine matchgroup=i3ConfigKeyword start=/ipc-socket / end=/$/ contained contains=i3ConfigNumber,i3ConfigShOper
 
 " 4.24 Focus follows mouse
-syn match i3ConfigKeyword /^focus_follows_mouse \(yes\|no\)$/ contains=i3ConfigBoolean
+syn keyword i3ConfigFocusFollowsMouseOpts always contained
+syn keyword i3ConfigKeyword focus_follows_mouse contained skipwhite nextgroup=i3ConfigBoolean,i3ConfigFocusFollowsMouseOpts
 
 " 4.25 Mouse warping
 syn keyword i3ConfigMouseWarpingOpts output container none contained
-syn match i3ConfigKeyword /^mouse_warping \w*$/ contains=i3ConfigMouseWarpingOpts
+syn keyword i3ConfigKeyword mouse_warping contained skipwhite nextgroup=i3ConfigMouseWarpingOpts
 
 " 4.26 Popups while fullscreen
 syn keyword i3ConfigPopupFullscreenOpts smart ignore leave_fullscreen contained
-syn match i3ConfigKeyword /^popup_during_fullscreen \w*$/ contains=i3ConfigPopupFullscreenOpts
+syn keyword i3ConfigKeyword popup_during_fullscreen contained skipwhite nextgroup=i3ConfigPopupFullscreenOpts
 
 " 4.27 Focus wrapping
 syn keyword i3ConfigFocusWrappingOpts force workspace contained
-syn match i3ConfigKeyword /^focus_wrapping \(yes\|no\|force\|workspace\)$/ contains=i3ConfigBoolean,i3ConfigFocusWrappingOpts
+syn keyword i3ConfigKeyword focus_wrapping contained skipwhite nextgroup=i3ConfigBoolean,i3ConfigFocusWrappingOpts
 
 " 4.28 Forcing Xinerama
-syn match i3ConfigKeyword /^force_xinerama \(yes\|no\)$/ contains=i3ConfigBoolean
-
 " 4.29 Automatic workspace back-and-forth
-syn match i3ConfigKeyword /^workspace_auto_back_and_forth \(yes\|no\)$/ contains=i3ConfigBoolean
+" 4.32 Show marks in title
+syn keyword i3ConfigKeyword force_xinerama workspace_auto_back_and_forth show_marks contained skipwhite nextgroup=i3ConfigBoolean
 
 " 4.30 Delay urgency hint
-syn keyword i3ConfigTimeUnit ms contained
-syn match i3ConfigKeyword /^force_display_urgency_hint \d\+\( ms\)\?$/ contains=i3ConfigNumber,i3ConfigTimeUnit
+syn match i3ConfigTimeUnit / \d\+\( ms\)\?$/ contained contains=i3ConfigNumber
+syn keyword i3ConfigKeyword force_display_urgency_hint contained nextgroup=i3ConfigTimeUnit
 
 " 4.31 Focus on window activation
 syn keyword i3ConfigFocusOnActivationOpts smart urgent focus none contained
-syn match i3ConfigKeyword /^focus_on_window_activation \w*$/  contains=i3ConfigFocusOnActivationOpts
-
-" 4.32 Show marks in title
-syn match i3ConfigShowMarks /^show_marks \(yes\|no\)$/ contains=i3ConfigBoolean
+syn keyword i3ConfigKeyword focus_on_window_activation contained skipwhite nextgroup=i3ConfigFocusOnActivationOpts
 
 " 4.34 Tiling drag
-syn keyword i3ConfigTilingDragOpts modifier titlebar contained
-syn match i3ConfigKeyword /^tiling_drag\( off\|\( modifier\| titlebar\)\{1,2\}\)$/ contains=i3ConfigTilingDragOpts,i3ConfigBoolean
+syn keyword i3ConfigTilingDragOpts modifier titlebar contained skipwhite nextgroup=i3ConfigTilingDragOpts
+syn keyword i3ConfigKeyword tiling_drag contained skipwhite nextgroup=i3ConfigTilingDragOpts,i3ConfigBoolean
 
-" 4.35 Gaps
-syn keyword i3ConfigGapsOpts inner outer horizontal vertical left right top bottom current all set plus minus toggle contained
-syn region i3ConfigGaps start=/gaps/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigGapsOpts,i3ConfigNumber,i3ConfigVariable,i3ConfigSeparator keepend
-syn match i3ConfigGapsLine /^gaps .*$/ contains=i3ConfigGaps
-syn keyword i3ConfigSmartGapOpts inverse_outer contained
-syn match i3ConfigKeyword /^smart_gaps \(on\|off\|inverse_outer\)$/ contains=i3ConfigSmartGapOpts,i3ConfigBoolean
+" 4.35 Gaps (+6.24)
+syn keyword i3ConfigGapsWhich inner outer horizontal vertical left right top bottom contained skipwhite nextgroup=i3ConfigGapsWhere,@i3ConfigNumVar
+syn keyword i3ConfigGapsWhere current all contained skipwhite nextgroup=i3ConfigGapsOper
+syn keyword i3ConfigGapsOper set plus minus toggle contained skipwhite nextgroup=@i3ConfigNumVar
+syn match i3ConfigGaps /gaps/ contained contains=i3ConfigCommand skipwhite nextgroup=i3ConfigGapsWhich
+syn keyword i3ConfigCommand gaps contained skipwhite nextgroup=i3ConfigGapsWhich
+
+syn keyword i3ConfigSmartGapOpts inverse_outer toggle contained
+syn keyword i3ConfigKeyword smart_gaps contained skipwhite nextgroup=i3ConfigSmartGapOpts,i3ConfigBoolean
 
 " 5 Configuring bar
-syn match i3ConfigBarModifier /^\s\+modifier \S\+$/ contained contains=i3ConfigBindModifier,i3ConfigVariable,i3ConfigBindModkey,i3ConfigBarOptVals
-syn keyword i3ConfigBarOpts bar i3bar_command status_command workspace_command mode hidden_state id position output tray_output tray_padding separator_symbol workspace_buttons workspace_min_width strip_workspace_numbers strip_workspace_name binding_mode_indicator padding contained
+syn keyword i3ConfigBarOpts modifier contained skipwhite nextgroup=i3ConfigBindCombo,i3ConfigBarOptVals
+syn keyword i3ConfigBarOpts i3bar_command status_command workspace_command contained skipwhite nextgroup=@i3ConfigSh
+syn keyword i3ConfigBarOpts mode hidden_state id position output tray_output tray_padding separator_symbol workspace_buttons workspace_min_width strip_workspace_numbers strip_workspace_name binding_mode_indicator padding contained skipwhite nextgroup=i3ConfigBarOptVals,@i3ConfigValue,i3ConfigShOper
 syn keyword i3ConfigBarOptVals dock hide invisible show none top bottom primary nonprimary contained
-syn region i3ConfigBarBlock start=/^bar {$/ end=/^}$/ contains=i3ConfigBarOpts,i3ConfigBarOptVals,i3ConfigBarModifier,i3ConfigBind,i3ConfigString,i3ConfigComment,i3ConfigFont,i3ConfigBoolean,i3ConfigNumber,i3ConfigParen,i3ConfigColor,i3ConfigVariable,i3ConfigColorsBlock,i3ConfigShOper,i3ConfigShCommand fold keepend extend
+syn region i3ConfigBarBlock matchgroup=i3ConfigKeyword start=/^bar\ze {$/ end=/^}\zs$/ contained contains=i3ConfigBarOpts,i3ConfigComment,i3ConfigParen,i3ConfigBindKeyword,i3ConfigColorsBlock fold keepend extend
 
 " 5.16 Color block
-syn keyword i3ConfigColorsKeyword colors contained
-syn match i3ConfigColorsOpts /\(focused_\)\?\(background\|statusline\|separator\)\|\(focused\|active\|inactive\|urgent\)_workspace\|binding_mode/ contained
-syn region i3ConfigColorsBlock start=/^\s\+colors {$/ end=/^\s\+}$/ contained contains=i3ConfigColorsKeyword,i3ConfigColorsOpts,i3ConfigColor,i3ConfigVariable,i3ConfigComment,i3ConfigParen fold keepend extend
+syn match i3ConfigColorSeq /#[0-9A-Fa-f]\{3,8}\|\$[0-9A-Za-z_:|[\]-]\+/ contained contains=@i3ConfigColVar skipwhite nextgroup=i3ConfigColorSeq
+syn keyword i3ConfigColorsOpts background statusline separator contained skipwhite nextgroup=@i3ConfigColVar
+syn match i3ConfigColorsOpts /focused_\(background\|statusline\|separator\)\|\(focused\|active\|inactive\|urgent\)_workspace\|binding_mode/ contained skipwhite nextgroup=i3ConfigColorSeq
+syn region i3ConfigColorsBlock matchgroup=i3ConfigKeyword start=/^\s\+colors \ze{$/ end=/^\s\+}\zs$/ contained contains=i3ConfigColorsOpts,i3ConfigComment,i3ConfigParen fold keepend extend
 
 " 6.0 Command criteria
 syn keyword i3ConfigConditionProp class instance window_role window_type machine id title urgent workspace con_mark con_id floating_from tiling_from contained
 syn keyword i3ConfigConditionSpecial __focused__ all floating tiling contained
-syn region i3ConfigCondition start=/\[/ end=/\]/ contained contains=i3ConfigShDelim,i3ConfigConditionProp,i3ConfigShOper,i3ConfigConditionSpecial,i3ConfigNumber,i3ConfigString keepend extend
-syn region i3ConfigCriteria start=/\[/ skip=/\\$/ end=/\(;\|$\)/ contained contains=i3ConfigCondition,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigBoolean,i3ConfigNumber,i3ConfigVariable,i3ConfigSeparator keepend transparent
+syn region i3ConfigCondition matchgroup=i3ConfigShDelim start=/\[/ end=/\]/ contained contains=i3ConfigConditionProp,i3ConfigShOper,i3ConfigConditionSpecial,@i3ConfigIdent keepend extend
+syn region i3ConfigCriteria start=/\[/ skip=/\\$/ end=/\(;\|$\)/ contained contains=i3ConfigCondition,@i3ConfigCommand,i3ConfigSeparator keepend transparent
 
 " 6.1 Actions through shell
 syn match i3ConfigExecActionKeyword /i3-msg/ contained
-syn region i3ConfigExecAction start=/[a-z3-]\+msg "/ skip=/ "\|\\$/ end=/"\|$/ contained contains=i3ConfigExecActionKeyword,i3ConfigShCommand,i3ConfigNumber,i3ConfigShOper,i3ConfigCriteria,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigVariable keepend extend
-syn region i3ConfigExecAction start=/[a-z3-]\+msg '/ skip=/ '\|\\$/ end=/'\|$/ contained contains=i3ConfigExecActionKeyword,i3ConfigShCommand,i3ConfigNumber,i3ConfigShOper,i3ConfigCriteria,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigVariable keepend extend
-syn region i3ConfigExecAction start=/[a-z3-]\+msg ['"-]\@!/ skip=/\\$/ end=/[&|;})'"]\@=\|$/ contained contains=i3ConfigExecActionKeyword,i3ConfigShCommand,i3ConfigNumber,i3ConfigShOper,i3ConfigCriteria,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigVariable keepend extend
+syn cluster i3ConfigExecActionVal contains=i3ConfigExecActionKeyword,i3ConfigCriteria,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,@i3ConfigNumVar
+syn region i3ConfigExecAction start=/[a-z3-]\+msg "/ skip=/ "\|\\$/ end=/"\|$/ contained contains=i3ConfigExecActionKeyword,@i3ConfigExecActionVal keepend extend
+syn region i3ConfigExecAction start=/[a-z3-]\+msg '/ skip=/ '\|\\$/ end=/'\|$/ contained contains=i3ConfigExecActionKeyword,@i3ConfigExecActionVal keepend extend
+syn region i3ConfigExecAction start=/[a-z3-]\+msg ['"-]\@!/ skip=/\\$/ end=/[&|;})'"]\@=\|$/ contained contains=i3ConfigExecActionKeyword,@i3ConfigExecActionVal keepend extend
 " 6.1 Executing applications (4.20)
-syn region i3ConfigAction start=/exec/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigExecKeyword,i3ConfigExecAction,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigSeparator keepend
+syn region i3ConfigAction matchgroup=i3ConfigCommand start=/exec / skip=/\\$/ end=/\ze[,;]\|$/ contained contains=i3ConfigExecAction,@i3ConfigSh keepend
 
 " 6.3 Manipulating layout
-syn keyword i3ConfigLayoutKeyword layout contained
 syn keyword i3ConfigLayoutOpts default tabbed stacking splitv splith toggle split all contained
-syn region i3ConfigAction start=/layout/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigLayoutKeyword,i3ConfigLayoutOpts,i3ConfigSeparator keepend transparent
+syn region i3ConfigAction matchgroup=i3ConfigCommand start=/layout / skip=/\\$/ end=/\ze[,;]\|$/ contained contains=i3ConfigLayoutOpts keepend transparent
 
 " 6.4 Focusing containers
-syn keyword i3ConfigFocusKeyword focus contained
-syn keyword i3ConfigFocusOpts left right up down workspace parent child next prev sibling floating tiling mode_toggle contained
-syn keyword i3ConfigFocusOutputOpts left right down up current primary nonprimary next prev contained
-syn region i3ConfigFocusOutput start=/ output / skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigWorkspaceOutput,i3ConfigFocusOutputOpts,i3ConfigString,i3ConfigNumber,i3ConfigSeparator keepend
-syn match i3ConfigFocusOutputLine /^focus output .*$/ contains=i3ConfigFocusKeyword,i3ConfigFocusOutput
-syn region i3ConfigAction start=/focus/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigFocusKeyword,i3ConfigFocusOpts,i3ConfigFocusOutput,i3ConfigString,i3ConfigSeparator keepend transparent
+syn keyword i3ConfigFocusOpts left right up down parent child next prev sibling floating tiling mode_toggle contained
+syn keyword i3ConfigOutputDir left right down up current primary nonprimary next prev contained skipwhite
+syn keyword i3ConfigFocusOutput output contained skipwhite nextgroup=i3ConfigOutputIdent,i3ConfigOutputDir
+syn keyword i3ConfigActionKeyword focus contained skipwhite nextgroup=i3ConfigFocusOpts,i3ConfigFocusOutput
+syn match i3ConfigKeyword /^focus / contained nextgroup=i3ConfigFocusOutput
 
 " 6.8 Focusing workspaces (4.21)
-syn region i3ConfigAction start=/workspace / skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigWorkspaceKeyword,i3ConfigWorkspaceDir,i3ConfigNumber,i3ConfigString,i3ConfigGaps,i3ConfigWorkspaceOutput,i3ConfigVariable,i3ConfigBoolean,i3ConfigSeparator keepend transparent
+syn keyword i3ConfigWorkspaceDir prev next back_and_forth contained
+syn keyword i3ConfigWorkspaceDir number contained skipwhite nextgroup=i3ConfigWorkspaceIdent
+syn keyword i3ConfigActionKeyword workspace contained skipwhite nextgroup=i3ConfigWorkspaceDir,i3ConfigWorkspaceIdent
 
 " 6.8.2 Renaming workspaces
-syn keyword i3ConfigRenameKeyword rename contained
-syn region i3ConfigAction start=/rename workspace/ end=/[,;]\|$/ contained contains=i3ConfigRenameKeyword,i3ConfigMoveDir,i3ConfigMoveType,i3ConfigNumber,i3ConfigVariable,i3ConfigString keepend transparent
+syn region i3ConfigWorkspaceFromTo start=/workspace\( .*\)\? to/ end=/\ze[,;]\|$/ contained contains=i3ConfigMoveType,@i3ConfigWorkspaceIdent keepend transparent
+syn keyword i3ConfigActionKeyword rename contained skipwhite nextgroup=i3ConfigWorkspaceFromTo
 
 " 6.5,6.9-6.11 Moving containers
-syn keyword i3ConfigMoveKeyword move contained
-syn keyword i3ConfigMoveDir left right down up position absolute center to current contained
-syn keyword i3ConfigMoveType window container workspace output mark mouse scratchpad contained
-syn match i3ConfigUnit / px\| ppt/ contained
-syn region i3ConfigAction start=/move/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigMoveKeyword,i3ConfigMoveDir,i3ConfigMoveType,i3ConfigWorkspaceDir,i3ConfigUnit,i3ConfigNumber,i3ConfigVariable,i3ConfigString,i3ConfigSeparator,i3ConfigShParam keepend transparent
+syn match i3ConfigUnit /-\?\d\+\( px\| ppt\)\?/ contained contains=i3ConfigNumber skipwhite nextgroup=i3ConfigUnit,i3ConfigResizeExtra
+syn keyword i3ConfigMoveDir left right down up position contained skipwhite nextgroup=i3ConfigUnit
+syn match i3ConfigMoveDir /position \(mouse\|center\)/ contained
+syn keyword i3ConfigMoveDir absolute contained skipwhite nextgroup=i3ConfigMoveDir
+syn keyword i3ConfigMoveDir absolute contained
+
+syn keyword i3ConfigMoveType mark contained skipwhite nextgroup=i3ConfigOutputIdent
+syn keyword i3ConfigMoveType scratchpad contained
+syn keyword i3ConfigMoveType output contained skipwhite nextgroup=i3ConfigOutputIdent,i3ConfigOutputDir
+syn keyword i3ConfigMoveType workspace contained skipwhite nextgroup=i3ConfigMoveType,i3ConfigWorkspaceIdent,i3ConfigWorkspaceDir
+syn keyword i3ConfigMoveType window container contained skipwhite nextgroup=i3ConfigMoveType
+syn keyword i3ConfigMoveTo to contained
+syn match i3ConfigMoveType /to/ contained contains=i3ConfigMoveTo skipwhite nextgroup=i3ConfigMoveType
+syn match i3ConfigActionKeyword /move\( --no-auto-back-and-forth\)\?/ contained contains=i3ConfigShParam skipwhite nextgroup=i3ConfigMoveType,i3ConfigMoveDir
 
 " 6.12 Resizing containers/windows
-syn keyword i3ConfigResizeKeyword resize contained
-syn keyword i3ConfigResizeOpts grow shrink up down left right set width height or contained
-syn region i3ConfigAction start=/resize/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigResizeKeyword,i3ConfigResizeOpts,i3ConfigNumber,i3ConfigUnit,i3ConfigSeparator keepend transparent
+syn keyword i3ConfigResizeExtra or height contained skipwhite nextgroup=i3ConfigUnit
+syn keyword i3ConfigResizeDir up down left right width height contained skipwhite nextgroup=i3ConfigUnit
+syn keyword i3ConfigResizeType grow shrink contained skipwhite nextgroup=i3ConfigResizeDir
+syn keyword i3ConfigResizeType set contained skipwhite nextgroup=i3ConfigResizeDir,i3ConfigUnit
+syn keyword i3ConfigActionKeyword resize contained skipwhite nextgroup=i3ConfigResizeType
 
 " 6.14 VIM-like marks
-syn match i3ConfigMark /mark\( --\(add\|replace\)\( --toggle\)\?\)\?/ contained contains=i3ConfigShParam
-syn region i3ConfigAction start=/\<mark/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigMark,i3ConfigNumber,i3ConfigString,i3ConfigSeparator keepend transparent
+syn match i3ConfigMarkOpt /--\(add\|replace\)\( --toggle\)\?/ contained contains=i3ConfigShParam skipwhite nextgroup=i3ConfigOutputIdent
+syn keyword i3ConfigActionKeyword mark contained skipwhite nextgroup=i3ConfigMarkOpt,i3ConfigOutputIdent
 
-" 6.24 Changing gaps (4.35)
-syn region i3ConfigAction start=/gaps/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigGaps keepend transparent
+" Commands usable for direct config calls - for enforcing start of line for Commands
+syn match i3ConfigTopLevelDirective /^/ skipwhite nextgroup=i3ConfigComment,i3ConfigKeyword,i3ConfigCommand,i3ConfigBindKeyword,i3ConfigParamLine,i3ConfigModeBlock,i3ConfigBarBlock,i3ConfigError
 
 " Commands useable in keybinds
-syn keyword i3ConfigActionKeyword mode append_layout kill open fullscreen sticky split floating swap unmark show_marks title_window_icon title_format border restart reload exit scratchpad nop bar contained
-syn keyword i3ConfigOption default enable disable toggle key restore current horizontal vertical auto none normal pixel show container with id con_id padding hidden_state hide dock invisible contained
+syn keyword i3ConfigActionKeyword mode append_layout kill open fullscreen sticky split floating swap unmark title_window_icon title_format border restart reload exit scratchpad nop bar contained skipwhite nextgroup=i3ConfigOption,@i3ConfigValue
+syn keyword i3ConfigOption default enable disable toggle key restore current horizontal vertical auto none normal pixel show container with id con_id padding hidden_state hide dock invisible contained skipwhite nextgroup=i3ConfigOption,@i3ConfigValue
+" Commands usable at runtime (outside loading config)
+syn cluster i3ConfigCommand contains=i3ConfigCommand,i3ConfigAction,i3ConfigActionKeyword,@i3ConfigValue,i3ConfigColor
 
 " Define the highlighting.
 hi def link i3ConfigError                           Error
@@ -260,18 +281,15 @@ hi def link i3ConfigBoolean                         Boolean
 hi def link i3ConfigString                          String
 hi def link i3ConfigColor                           Constant
 hi def link i3ConfigNumber                          Number
-hi def link i3ConfigIncludeKeyword                  i3ConfigKeyword
 hi def link i3ConfigComment                         Comment
-hi def link i3ConfigFontKeyword                     i3ConfigKeyword
 hi def link i3ConfigColonOperator                   i3ConfigOperator
 hi def link i3ConfigFontNamespace                   i3ConfigOption
 hi def link i3ConfigFontSize                        i3ConfigNumber
-hi def link i3ConfigFont                            i3ConfigString
-hi def link i3ConfigBindKeyword                     i3ConfigKeyword
 hi def link i3ConfigBindArgument                    i3ConfigShParam
 hi def link i3ConfigBindModifier                    i3ConfigOperator
 hi def link i3ConfigBindModkey                      Special
 hi def link i3ConfigBindCombo                       SpecialChar
+hi def link i3ConfigBindKeyword                     i3ConfigKeyword
 hi def link i3ConfigSizeSpecial                     i3ConfigOperator
 hi def link i3ConfigOrientationOpts                 i3ConfigOption
 hi def link i3ConfigWorkspaceLayoutOpts             i3ConfigOption
@@ -280,54 +298,47 @@ hi def link i3ConfigBorderOpts                      i3ConfigOption
 hi def link i3ConfigEdgeOpts                        i3ConfigOption
 hi def link i3ConfigSmartBorderOpts                 i3ConfigOption
 hi def link i3ConfigVariable                        Variable
-hi def link i3ConfigSetKeyword                      i3ConfigKeyword
-hi def link i3ConfigResourceKeyword                 i3ConfigKeyword
-hi def link i3ConfigAssignKeyword                   i3ConfigKeyword
 hi def link i3ConfigAssignSpecial                   i3ConfigOption
-hi def link i3ConfigExecKeyword                     i3ConfigCommand
-hi def link i3ConfigExecAlwaysKeyword               i3ConfigKeyword
 hi def link i3ConfigShParam                         PreProc
 hi def link i3ConfigShDelim                         Delimiter
 hi def link i3ConfigShOper                          Operator
-hi def link i3ConfigShCmdDelim                      i3ConfigShDelim
 hi def link i3ConfigShCommand                       Normal
-hi def link i3ConfigWorkspaceKeyword                i3ConfigCommand
-hi def link i3ConfigWorkspaceOutput                 i3ConfigMoveType
-hi def link i3ConfigWorkspaceDir                    i3ConfigOption
+hi def link i3ConfigOutputIdent                     i3ConfigParamLine
+hi def link i3ConfigOutput                          i3ConfigMoveType
+hi def link i3ConfigWorkspaceIdent                  i3ConfigParamLine
 hi def link i3ConfigDotOperator                     i3ConfigOperator
 hi def link i3ConfigClientOpts                      i3ConfigOption
-hi def link i3ConfigIpcKeyword                      i3ConfigKeyword
+hi def link i3ConfigFocusFollowsMouseOpts           i3ConfigOption
 hi def link i3ConfigMouseWarpingOpts                i3ConfigOption
 hi def link i3ConfigPopupFullscreenOpts             i3ConfigOption
 hi def link i3ConfigFocusWrappingOpts               i3ConfigOption
 hi def link i3ConfigTimeUnit                        i3ConfigNumber
 hi def link i3ConfigFocusOnActivationOpts           i3ConfigOption
-hi def link i3ConfigShowMarks                       i3ConfigCommand
 hi def link i3ConfigTilingDragOpts                  i3ConfigOption
-hi def link i3ConfigGapsOpts                        i3ConfigOption
-hi def link i3ConfigGaps                            i3ConfigCommand
+hi def link i3ConfigGapsWhich                       i3ConfigOption
+hi def link i3ConfigGapsWhere                       i3ConfigOption
+hi def link i3ConfigGapsOper                        i3ConfigOption
 hi def link i3ConfigSmartGapOpts                    i3ConfigOption
 hi def link i3ConfigBarModifier                     i3ConfigKeyword
 hi def link i3ConfigBarOpts                         i3ConfigKeyword
 hi def link i3ConfigBarOptVals                      i3ConfigOption
-hi def link i3ConfigColorsKeyword                   i3ConfigKeyword
 hi def link i3ConfigColorsOpts                      i3ConfigOption
 hi def link i3ConfigConditionProp                   i3ConfigShParam
 hi def link i3ConfigConditionSpecial                Constant
 hi def link i3ConfigExecActionKeyword               i3ConfigShCommand
 hi def link i3ConfigExecAction                      i3ConfigString
-hi def link i3ConfigLayoutKeyword                   i3ConfigCommand
 hi def link i3ConfigLayoutOpts                      i3ConfigOption
-hi def link i3ConfigFocusKeyword                    i3ConfigCommand
 hi def link i3ConfigFocusOpts                       i3ConfigOption
-hi def link i3ConfigFocusOutputOpts                 i3ConfigOption
-hi def link i3ConfigRenameKeyword                   i3ConfigCommand
-hi def link i3ConfigMoveKeyword                     i3ConfigCommand
+hi def link i3ConfigOutputDir                       i3ConfigOption
+hi def link i3ConfigFocusOutput                     i3ConfigOutput
+hi def link i3ConfigWorkspaceDir                    i3ConfigOption
 hi def link i3ConfigMoveDir                         i3ConfigOption
 hi def link i3ConfigMoveType                        Constant
+hi def link i3ConfigMoveTo                          i3ConfigOption
 hi def link i3ConfigUnit                            i3ConfigNumber
-hi def link i3ConfigResizeKeyword                   i3ConfigCommand
-hi def link i3ConfigResizeOpts                      i3ConfigOption
+hi def link i3ConfigResizeExtra                     i3ConfigOption
+hi def link i3ConfigResizeDir                       i3ConfigOption
+hi def link i3ConfigResizeType                      i3ConfigOption
 hi def link i3ConfigMark                            i3ConfigCommand
 hi def link i3ConfigActionKeyword                   i3ConfigCommand
 hi def link i3ConfigOption                          Type

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -2,8 +2,8 @@
 " Language: sway config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 1.0.2
-" Last Change: 2023-12-28
+" Version: 1.2.1
+" Last Change: 2024-04-14
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -18,40 +18,33 @@ endif
 
 runtime! syntax/i3config.vim
 
-" i3 extensions
-syn keyword i3ConfigActionKeyword opacity urgent shortcuts_inhibitor splitv splith splitt contained
-syn keyword i3ConfigOption set plus minus allow deny csd v h t contained
+" Sway extensions to i3
+syn cluster i3ConfigCommand contains=i3ConfigCommand,i3ConfigAction,i3ConfigActionKeyword,@i3ConfigValue,i3ConfigColor,i3ConfigKeyword
+syn keyword i3ConfigActionKeyword opacity urgent shortcuts_inhibitor splitv splith splitt contained contained skipwhite nextgroup=i3ConfigOption
+syn keyword i3ConfigOption set plus minus allow deny csd v h t contained contained skipwhite nextgroup=i3ConfigOption,@i3ConfigValue
 
 syn keyword i3ConfigConditionProp app_id pid shell contained
 
 syn keyword i3ConfigWorkspaceDir prev_on_output next_on_output contained
 
-syn keyword swayConfigBindKeyword bindswitch bindgesture contained
-syn match i3ConfigBindArgument /--\(locked\|to-code\|no-repeat\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
-syn region i3ConfigBind start=/^\s*bind\(switch\|gesture\) / skip=/\\$/ end=/$/ contains=swayConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,swayConfigBindgesture,swayConfigBindgestureArgument,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean keepend
+syn match i3ConfigBindArgument /--\(locked\|to-code\|no-repeat\|input-device=[^ '"]*\|no-warn\) / contained contains=i3ConfigShOper,@i3ConfigStrVar nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
+syn region i3ConfigBindArgument start=/--input-device=['"]/ end=/\s/ contained contains=@i3ConfigIdent,i3ConfigShOper,i3ConfigString nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
 
-syn match swayConfigBindBlockHeader /^\s*bind\(sym\|code\) .*{$/ contained contains=i3ConfigBindKeyword,i3ConfigBindArgument,i3ConfigParen
-syn match swayConfigBindBlockCombo /^\s\+\(--[a-z-]\+ \)*[$a-zA-Z0-9_+]\+ [a-z[]\@=/ contained contains=i3ConfigBindArgument,i3ConfigBindCombo
-syn region i3ConfigBind start=/^\s*bind\(sym\|code\) .*{$/ end=/^\s*}$/ contains=swayConfigBindBlockHeader,swayConfigBindBlockCombo,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean,i3ConfigComment,i3ConfigParen fold keepend extend
-" fix for extra long bindsym blocks that would be parsed incorrectly when scrolling up
-syn region i3ConfigBlockOrphan start=/^\s\+\S/ skip=/^\s\|^$/ end=/^}\?/ contains=swayConfigBindBlockCombo,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean,i3ConfigComment,i3ConfigParen keepend extend
+syn region i3ConfigBindCombo matchgroup=i3ConfigParen start=/{$/ end=/^\s*}$/ contained contains=i3ConfigBindArgument,i3ConfigBindCombo,i3ConfigComment fold keepend extend
+" hack for blocks with start outside parsing range
+syn region swayConfigBlockOrphan start=/^\s\+\(--[a-z-]\+ \)*[$a-zA-Z0-9_+]\+ [a-z[]/ skip=/\\$\|$\n^\s*}$/ end=/$/ contains=i3ConfigBindArgument,i3ConfigBindCombo,i3ConfigParen keepend extend
 
-syn keyword i3ConfigClientOpts focused_tab_title contained
-
-syn region swayConfigExecBlock start=/exec\(_always\)\? {/ end=/^}$/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigComment fold keepend extend
+syn region i3ConfigExec start=/ {$/ end=/^}$/ contained contains=i3ConfigExecAction,@i3ConfigSh,i3ConfigComment fold keepend extend
 
 syn keyword swayConfigFloatingModifierOpts normal inverse contained
 syn match i3ConfigKeyword /^floating_modifier [$a-zA-Z0-9+]\+ \(normal\|inverse\)$/ contains=i3ConfigVariable,i3ConfigBindModkey,swayConfigFloatingModifierOpts
 
-syn keyword swayConfigSmartGapsOpts toggle contained
-syn match i3ConfigKeyword /^smart_gaps toggle$/ contains=i3ConfigSmartGapOpts,i3ConfigBoolean,swayConfigSmartGapsOpts
+syn match swayConfigI3Param /--i3/ contains=i3ConfigShParam skipwhite nextgroup=i3ConfigEdgeOpts
+syn keyword i3ConfigKeyword hide_edge_borders contained skipwhite nextgroup=swayConfigI3Param,i3ConfigEdgeOpts
 
-syn keyword swayConfigFocusFollowsMouseOpts always contained
-syn match i3ConfigKeyword /^focus_follows_mouse always$/ contains=i3ConfigBoolean,swayConfigFocusFollowsMouseOpts
-
-syn match i3ConfigKeyword /^hide_edge_borders --i3 \w*$/ contains=i3ConfigEdgeKeyword,i3ConfigShParam
-
-syn keyword i3ConfigBarOpts swaybar_command gaps height pango_markup status_edge_padding status_padding wrap_scroll tray_bindcode tray_bindsym icon_theme contained
+syn keyword i3ConfigBarOpts swaybar_command contained skipwhite nextgroup=@i3ConfigSh
+syn region i3ConfigBarOpts matchgroup=i3ConfigBarOpts start=/gaps/ end=/$/ contained contains=@i3ConfigNumVar
+syn keyword i3ConfigBarOpts height pango_markup status_edge_padding status_padding wrap_scroll tray_bindcode tray_bindsym icon_theme contained skipwhite nextgroup=i3ConfigBarOptVals,@i3ConfigValue,i3ConfigShOper
 syn keyword i3ConfigBarOptVals overlay contained
 
 syn keyword i3ConfigExecActionKeyword swaymsg contained
@@ -59,77 +52,88 @@ syn keyword i3ConfigExecActionKeyword swaymsg contained
 " Sway-only options
 " Xwayland
 syn keyword swayConfigXOpt enable disable force contained
-syn match i3ConfigKeyword /^xwayland \w*$/ contains=swayConfigXOpt
+syn keyword i3ConfigKeyword xwayland contained skipwhite nextgroup=swayConfigXOpt
 
 " Inhibit idle
-syn keyword swayConfigInhibitKeyword inhibit_idle contained
 syn keyword swayConfigInhibitOpts focus fullscreen open none visible contained
-syn match i3ConfigAction /inhibit_idle \w*/ contained contains=swayConfigInhibitKeyword,swayConfigInhibitOpts
+syn keyword i3ConfigActionKeyword inhibit_idle contained skipwhite nextgroup=swayConfigInhibitOpts
 
 " Bindswitch
-syn match swayConfigBindswitchArgument /--\(locked\|no-warn\|reload\)/ contained
-syn keyword swayConfigBindswitchType lid tablet contained
+syn match swayConfigBindswitchArgument /--\(locked\|no-warn\|reload\) / contained nextgroup=swayConfigBindswitchArgument,swayConfigBindswitchType
+syn keyword swayConfigBindswitchType lid tablet contained nextgroup=swayConfigBindswitchCombo
 syn keyword swayConfigBindswitchState toggle contained
-syn match swayConfigBindswitch /\(lid\|tablet\):\(on\|off\|toggle\) / contained contains=swayConfigBindswitchType,i3ConfigColonOperator,swayConfigBindswitchState,i3ConfigBoolean
-syn region i3ConfigBind start=/^\s*bindswitch\s\+.*{$/ end=/^\s*}$/ contains=swayConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigSeparator,i3ConfigString,i3ConfigCriteria,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigComment,i3ConfigParen fold keepend extend
+syn match swayConfigBindswitchCombo /:\(on\|off\|toggle\) / contained contains=i3ConfigColonOperator,swayConfigBindswitchState,i3ConfigBoolean nextgroup=i3ConfigBind
+syn region swayConfigBindswitchType matchgroup=i3ConfigParen start=/{$/ end=/^\s*}$/ contained contains=swayConfigBindswitchArgument,swayConfigBindswitchType,i3ConfigComment fold keepend extend
+syn keyword i3ConfigBindKeyword bindswitch contained skipwhite nextgroup=swayConfigBindswitchArgument,swayConfigBindswitchType
+" hack for blocks with start outside parsing range
+syn region swayConfigBlockOrphan start=/^\s\+\(lid\|tablet\):/ skip=/\\$\|$\n^\s*}$/ end=/$/ contains=swayConfigBindswitchArgument,swayConfigBindswitchType,i3ConfigParen keepend extend
 
 " Bindgesture
-syn match swayConfigBindgestureArgument /--\(exact\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
+syn match swayConfigBindgestureArgument /--\(exact\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\) / contained nextgroup=swayConfigBindgestureArgument,swayConfigBindgestureCombo
 syn keyword swayConfigBindgestureType hold swipe pinch contained
 syn keyword swayConfigBindgestureDir up down left right inward outward clockwise counterclockwise contained
-syn match swayConfigBindgesture /\(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigNumber,swayConfigBindgestureType,i3ConfigColonOperator,swayConfigBindgestureDir,i3ConfigBindModifier
-syn region i3ConfigBind start=/^\s*bindgesture\s\+.*{$/ end=/^\s*}$/ contains=swayConfigBindKeyword,swayConfigBindgesture,swayConfigBindgestureArgument,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean,i3ConfigParen fold keepend extend
+syn match swayConfigBindgestureCombo /\(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigNumber,swayConfigBindgestureType,i3ConfigColonOperator,swayConfigBindgestureDir,i3ConfigBindModifier nextgroup=swayConfigBindgestureCombo,i3ConfigBind
+syn region swayConfigBindgestureCombo matchgroup=i3ConfigParen start=/{$/ end=/^\s*}$/ contained contains=swayConfigBindgestureArgument,swayConfigBindgestureCombo,i3ConfigComment fold keepend extend
+syn keyword i3ConfigBindKeyword bindgesture contained skipwhite nextgroup=swayConfigBindgestureArgument,swayConfigBindgestureCombo
+" hack for blocks with start outside parsing range
+syn region swayConfigBlockOrphan start=/^\s\+\(--[a-z-]\+ \)*\(hold\|swipe\|pinch\):/ skip=/\\$\|$\n^\s*}$/ end=/$/ contains=swayConfigBindgestureArgument,swayConfigBindgestureCombo,i3ConfigParen keepend extend
 
 " Tiling drag threshold
-syn match i3ConfigKeyword /^tiling_drag_threshold \d\+$/ contains=i3ConfigNumber
-
 " Titlebar commands
-syn match i3ConfigKeyword /^titlebar_border_thickness \(\d\+\|\$\S\+\)$/ contains=i3ConfigNumber,i3ConfigVariable
-syn match i3ConfigKeyword /^titlebar_padding \(\d\+\|\$\S\+\)\( \d\+\)\?$/ contains=i3ConfigNumber,i3ConfigVariable
+syn keyword i3ConfigKeyword tiling_drag_threshold titlebar_border_thickness contained skipwhite nextgroup=@i3ConfigNumVar
+syn match i3ConfigKeyword /^titlebar_padding \(\d\+\|\$\S\+\)\( \d\+\)\?$/ contains=@i3ConfigNumVar
 
-syn match swayConfigDeviceOps /[*,:;]/ contained
+syn match swayConfigDeviceOper /[*:;!]/ contained
 
 " Input devices
-syn keyword swayConfigInputKeyword input contained
-syn keyword swayConfigInputType touchpad pointer keyboard touch tablet_tool tablet_pad switch contained
-syn match swayConfigInputTypePair /\<type:\w\+\>/ contained contains=i3ConfigColonOperator,swayConfigInputType
-syn region swayConfigInputStart start=/^input / end=/\s/ contained contains=swayConfigInputKeyword,swayConfigInputTypePair,i3ConfigString keepend extend
-syn keyword swayConfigInputOpts xkb_layout xkb_variant xkb_rules xkb_switch_layout xkb_numlock xkb_file xkb_capslock xkb_model repeat_delay repeat_rate map_to_output map_to_region map_from_region tool_mode accel_profile dwt dwtp drag_lock drag click_method middle_emulation tap events calibration_matrix natural_scroll left_handed pointer_accel scroll_button scroll_factor scroll_method tap_button_map contained
-syn keyword swayConfigInputOptVals absolute relative adaptive flat none button_areas clickfinger toggle two_finger edge on_button_down lrm lmr next prev pen eraser brush pencil airbrush disabled_on_external_mouse disable contained
-syn match swayConfigXkbOptsPairVal /:[0-9a-z_-]\+/ contained contains=i3ConfigColonOperator
-syn match swayConfigXkbOptsPair /[a-z]\+:[0-9a-z_-]\+/ contained contains=swayConfigXkbOptsPairVal
-syn match swayConfigInputXkbOpts /xkb_options \([a-z]\+:[0-9a-z_-]\+,\?\)\+/ contained contains=swayConfigXkbOptsPair,swayConfigDeviceOps
-syn region i3ConfigAction start=/input/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigInputStart,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigBoolean,swayConfigDeviceOps keepend transparent
-syn region i3ConfigInput start=/^input/ skip=/\\$/ end=/$/ contains=swayConfigInputStart,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigBoolean,swayConfigDeviceOps keepend
-syn region i3ConfigInput start=/^input .* {/ end=/}$/ contains=swayConfigInputStart,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigBoolean,swayConfigDeviceOps,i3ConfigParen keepend extend
+syn keyword swayConfigInputOpts xkb_variant xkb_rules xkb_switch_layout xkb_numlock xkb_file xkb_capslock xkb_model repeat_delay repeat_rate map_to_output map_to_region map_from_region tool_mode accel_profile dwt dwtp drag_lock drag click_method middle_emulation tap events calibration_matrix natural_scroll left_handed pointer_accel scroll_button scroll_factor scroll_method tap_button_map contained skipwhite nextgroup=swayConfigInputOptVals,@i3ConfigValue
+syn keyword swayConfigInputOptVals absolute relative adaptive flat none button_areas clickfinger toggle two_finger edge on_button_down lrm lmr next prev pen eraser brush pencil airbrush disabled_on_external_mouse disable enable contained skipwhite nextgroup=swayConfigInputOpts,@i3ConfigValue,swayConfigDeviceOper
+syn match swayConfigDeviceOper /,/ contained nextgroup=swayConfigXkbOptsPair,swayConfigXkbLayout
+syn match swayConfigXkbLayout /[a-z]\+/ contained nextgroup=swayConfigDeviceOper
+syn keyword swayConfigInputOpts xkb_layout contained skipwhite nextgroup=swayConfigXkbLayout
+syn match swayConfigXkbOptsPairVal /[0-9a-z_-]\+/ contained contains=i3ConfigNumber skipwhite nextgroup=swayConfigDeviceOper,swayConfigInputOpts
+syn match swayConfigXkbOptsPair /[a-z]\+:/ contained contains=i3ConfigColonOperator nextgroup=swayConfigXkbOptsPairVal
+syn keyword swayConfigInputOpts xkb_options contained skipwhite nextgroup=swayConfigXkbOptsPair
+
+syn region swayConfigInput start=/\s/ skip=/\\$/ end=/\ze[,;]\|$/ contained contains=swayConfigInputOpts,@i3ConfigValue keepend
+syn region swayConfigInput matchgroup=i3ConfigParen start=/ {$/ end=/^}$/ contained contains=swayConfigInputOpts,@i3ConfigValue,i3ConfigComment keepend extend
+syn keyword swayConfigInputType touchpad pointer keyboard touch tablet_tool tablet_pad switch contained nextgroup=swayConfigInput
+syn match swayConfigInputIdent /type:!\?/ contained contains=swayConfigDeviceOper nextgroup=swayConfigInputType
+syn match swayConfigInputIdent /[^t '"]\S*/ contained contains=i3ConfigOutputIdent nextgroup=swayConfigInput
+syn region swayConfigInputIdent start=/['"]/ end=/\ze/ contained contains=i3ConfigOutputIdent nextgroup=swayConfigInput
+syn keyword i3ConfigKeyword input contained skipwhite nextgroup=swayConfigInputIdent
 
 " Seat
-syn keyword swayConfigSeatKeyword seat contained
-syn keyword swayConfigSeatOpts attach cursor fallback hide_cursor idle_inhibit idle_wake keyboard_grouping shortcuts_inhibitor pointer_constraint xcursor_theme contained
-syn match swayConfigSeatOptVals /when-typing/ contained
-syn keyword swayConfigSeatOptVals move set press release none smart activate deactivate toggle escape enable disable contained
-syn region i3ConfigAction start=/seat/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigSeatKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigDeviceOps,swayConfigInputType keepend transparent
-syn region swayConfigSeat start=/seat/ skip=/\\$/ end=/$/ contains=swayConfigSeatKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigDeviceOps,swayConfigInputType keepend
-syn region swayConfigSeat start=/seat .* {$/ end=/}$/ contains=swayConfigSeatKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigDeviceOps,i3ConfigParen,swayConfigInputType keepend extend
+syn keyword swayConfigSeatOpts cursor fallback hide_cursor keyboard_grouping shortcuts_inhibitor pointer_constraint xcursor_theme contained skipwhite nextgroup=swayConfigSeatOptVals,@i3ConfigValue
+syn match swayConfigInputTypeSeq / \w\+/ contained contains=swayConfigInputType nextgroup=swayConfigInputTypeSeq,swayConfigSeatOpts
+syn keyword swayConfigSeatOpts idle_inhibit idle_wake contained nextgroup=swayConfigInputTypeSeq
+syn keyword swayConfigSeatOpts attach contained skipwhite nextgroup=swayConfigSeatIdent
+syn match swayConfigSeatOptVals /when-typing/ contained skipwhite nextgroup=swayConfigSeatOptVals
+syn keyword swayConfigSeatOptVals move set press release none smart activate deactivate toggle escape enable disable contained skipwhite nextgroup=swayConfigSeatOpts
+syn region swayConfigSeat start=/\s/ skip=/\\$/ end=/\ze[,;]\|$/ contained contains=swayConfigSeatOpts,@i3ConfigValue keepend
+syn region swayConfigSeat matchgroup=i3ConfigParen start=/ {$/ end=/^}$/ contained contains=swayConfigSeatOpts,@i3ConfigValue,i3ConfigComment keepend extend
+syn match swayConfigSeatIdent /[^ ]\+/ contained contains=i3ConfigOutputIdent skipwhite nextgroup=swayConfigSeat
+syn keyword i3ConfigKeyword seat contained skipwhite nextgroup=swayConfigSeatIdent
 
 " Output monitors
-syn keyword swayConfigOutputKeyword output contained
-syn keyword swayConfigOutputOpts mode resolution res modeline position pos scale scale_filter subpixel background bg transform disable enable power dpms max_render_time adaptive_sync render_bit_depth contained
-syn keyword swayConfigOutputOptVals linear nearest smart rgb bgr vrgb vbgr none normal flipped fill stretch fit center tile solid_color clockwise anticlockwise toggle contained
-syn match swayConfigOutputOptVals /--custom\|flipped-\(90\|180\|270\)/ contained
-syn match swayConfigOutputFPS /@[0-9.]\+Hz/ contained
-syn match swayConfigOutputMode / [0-9]\+x[0-9]\+\(@[0-9.]\+Hz\)\?/ contained contains=swayConfigOutputFPS
-syn region i3ConfigAction start=/output/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps keepend transparent
-syn region swayConfigOutput start=/^output/ skip=/\\$/ end=/$/  contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps keepend
-syn region swayConfigOutput start=/^output .* {$/ end=/}$/  contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps,i3ConfigParen keepend extend
+syn keyword swayConfigOutputOpts mode resolution res modeline position pos scale scale_filter subpixel transform disable enable power dpms max_render_time adaptive_sync render_bit_depth contained skipwhite nextgroup=swayConfigOutputOptVals,@i3ConfigValue,swayConfigOutputMode
+syn keyword swayConfigOutputOptVals linear nearest smart rgb bgr vrgb vbgr none clockwise anticlockwise toggle contained skipwhite nextgroup=swayConfigOutputOptVals,@i3ConfigValue
+syn keyword swayConfigOutputBgVals solid_color fill stretch fit center tile contained skipwhite nextgroup=@i3ConfigColVar
+syn match swayConfigOutputBg /[#$]\S\+ solid_color/ contained contains=@i3ConfigColVar,swayConfigOutputBgVals
+syn match swayConfigOutputBg /[^b# '"]\S*/ contained contains=i3ConfigShOper skipwhite nextgroup=swayConfigOutputBgVals
+syn region swayConfigOutputBg start=/['"]/ end=/\ze/ contained contains=@i3ConfigIdent skipwhite nextgroup=swayConfigOutputBgVals
+syn keyword swayConfigOutputOpts bg background contained skipwhite nextgroup=swayConfigOutputBg
+syn match swayConfigOutputFPS /@[0-9.]\+Hz/ contained skipwhite nextgroup=swayConfigOutputOpts
+syn match swayConfigOutputMode /\(--custom \)\?[0-9]\+x[0-9]\+/ contained contains=i3ConfigShParam skipwhite nextgroup=swayConfigOutputFPS,swayConfigOutputOpts
+syn match swayConfigOutputOptVals /\(flipped-\)\?\(90\|180\|270\)\|flipped\|normal/ contained contains=i3ConfigNumber skipwhite nextgroup=swayConfigOutputOptsVals
+syn region swayConfigOutput start=/\s/ skip=/\\$/ end=/\ze[,;]\|$/ contained contains=swayConfigOutputOpts,@i3ConfigValue keepend
+syn region swayConfigOutput matchgroup=i3ConfigParen start=/ {$/ end=/^}$/ contained contains=swayConfigOutputOpts,@i3ConfigValue,i3ConfigComment keepend extend
+syn match swayConfigOutputIdent /[^ ]\+/ contained contains=i3ConfigOutputIdent skipwhite nextgroup=swayConfigOutput
+syn keyword i3ConfigKeyword output contained skipwhite nextgroup=swayConfigOutputIdent
 
 " Define the highlighting.
-hi def link swayConfigSmartGapsOpts          i3ConfigOption
 hi def link swayConfigFloatingModifierOpts   i3ConfigOption
-hi def link swayConfigFocusFollowsMouseOpts  i3ConfigOption
-hi def link swayConfigBindKeyword            i3ConfigBindKeyword
 hi def link swayConfigXOpt                   i3ConfigOption
-hi def link swayConfigInhibitKeyword         i3ConfigCommand
 hi def link swayConfigInhibitOpts            i3ConfigOption
 hi def link swayConfigBindswitchArgument     i3ConfigBindArgument
 hi def link swayConfigBindswitchType         i3ConfigMoveType
@@ -137,20 +141,18 @@ hi def link swayConfigBindswitchState        i3ConfigMoveDir
 hi def link swayConfigBindgestureArgument    i3ConfigBindArgument
 hi def link swayConfigBindgestureType        i3ConfigMoveType
 hi def link swayConfigBindgestureDir         i3ConfigMoveDir
-hi def link swayConfigDeviceOps              i3ConfigOperator
-hi def link swayConfigInputKeyword           i3ConfigCommand
+hi def link swayConfigDeviceOper             i3ConfigOperator
 hi def link swayConfigInputType              i3ConfigMoveType
-hi def link swayConfigInputTypePair          i3ConfigMoveDir
+hi def link swayConfigInputIdent             i3ConfigMoveDir
 hi def link swayConfigInputOptVals           i3ConfigShParam
 hi def link swayConfigInputOpts              i3ConfigOption
-hi def link swayConfigXkbOptsPairVal         i3ConfigString
+hi def link swayConfigXkbOptsPairVal         i3ConfigParamLine
 hi def link swayConfigXkbOptsPair            i3ConfigShParam
-hi def link swayConfigInputXkbOpts           i3ConfigOption
-hi def link swayConfigSeatKeyword            i3ConfigCommand
+hi def link swayConfigXkbLayout              i3ConfigParamLine
 hi def link swayConfigSeatOptVals            swayConfigInputOptVals
 hi def link swayConfigSeatOpts               swayConfigInputOpts
-hi def link swayConfigOutputKeyword          i3ConfigCommand
 hi def link swayConfigOutputOptVals          swayConfigInputOptVals
+hi def link swayConfigOutputBgVals           swayConfigInputOptVals
 hi def link swayConfigOutputOpts             swayConfigInputOpts
 hi def link swayConfigOutputFPS              Constant
 hi def link swayConfigOutputMode             i3ConfigNumber


### PR DESCRIPTION
Since the last update, I made another two refactorings and in order to use clusters, to reduce repetition, and nextgroup, to improve user experience when writing code.

Other changes include:
- support multiline `set` as discovered in #14531
- improve command-within-string handling
- fallback for lines from blocks that are out of parsing range (_"orphan"_ blocks)
- trying to remove as many extra explicit keyword groups as possible → using regions with appropriate matchgroup

I apologize for the awful diffs, but refactor of the entire structure to use a slightly different approach will probably always result in such a mess.

cc @hiqua @jamespeapen 