### PR TITLE
Wrong cursor position after using setcellwidths()

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5733,6 +5733,7 @@ f_setcellwidths(typval_T *argvars, typval_T *rettv UNUSED)
     }
 
     vim_free(cw_table_save);
+    changed_window_setting_all();
     redraw_all_later(UPD_CLEAR);
 }
 

--- a/src/move.c
+++ b/src/move.c
@@ -678,6 +678,19 @@ changed_window_setting_buf(buf_T *buf)
 #endif
 
 /*
+ * Call changed_window_setting_win() for every window.
+ */
+    void
+changed_window_setting_all(void)
+{
+    tabpage_T	*tp;
+    win_T	*wp;
+
+    FOR_ALL_TAB_WINDOWS(tp, wp)
+	changed_window_setting_win(wp);
+}
+
+/*
  * Set wp->w_topline to a certain number.
  */
     void

--- a/src/proto/move.pro
+++ b/src/proto/move.pro
@@ -9,6 +9,7 @@ void check_cursor_moved(win_T *wp);
 void changed_window_setting(void);
 void changed_window_setting_win(win_T *wp);
 void changed_window_setting_buf(buf_T *buf);
+void changed_window_setting_all(void);
 void set_topline(win_T *wp, linenr_T lnum);
 void changed_cline_bef_curs(void);
 void changed_cline_bef_curs_win(win_T *wp);

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -170,6 +170,7 @@ func Test_screenchar_utf8()
 endfunc
 
 func Test_setcellwidths()
+  new
   call setcellwidths([
         \ [0x1330, 0x1330, 2],
         \ [9999, 10000, 1],
@@ -212,6 +213,18 @@ func Test_setcellwidths()
     " Ambiguous width chars
     call assert_equal(2, strwidth("\u00A1"))
     call assert_equal(2, strwidth("\u2010"))
+
+    call setcellwidths([])
+    call setline(1, repeat("\u2103", 10))
+    normal! $
+    redraw
+    call assert_equal((aw == 'single') ? 10 : 19, wincol())
+    call setcellwidths([[0x2103, 0x2103, 1]])
+    redraw
+    call assert_equal(10, wincol())
+    call setcellwidths([[0x2103, 0x2103, 2]])
+    redraw
+    call assert_equal(19, wincol())
   endfor
   set ambiwidth& isprint&
 
@@ -245,6 +258,7 @@ func Test_setcellwidths()
   set listchars&
   set fillchars&
   call setcellwidths([])
+  bwipe!
 endfunc
 
 func Test_getcellwidths()


### PR DESCRIPTION
Problem:  Wrong cursor position after using setcellwidths().
Solution: Invalidate cursor position in addition to redrawing.
