### PR TITLE
macos: use explicit version tags for runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
       fail-fast: false
       matrix:
         features: [tiny, normal, huge]
-        runner: [macos-latest, macos-14]
+        runner: [macos-12, macos-14]
 
     steps:
       - name: Checkout repository from github


### PR DESCRIPTION
as we do on others like ubuntu
`macos-14` can become `macos-latest` soon if we want that anyway.