### PR TITLE
document pandoc compiler and enable configuring arguments

### DIFF
--- a/runtime/compiler/pandoc.vim
+++ b/runtime/compiler/pandoc.vim
@@ -46,6 +46,7 @@ execute 'CompilerSet makeprg=pandoc\ --standalone' .
       \ '\ --metadata\ title=%:t:r:S' .
       \ '\ --metadata\ lang=' . matchstr(&spelllang, '^\a\a') .
       \ '\ --from=' . s:PandocFiletype(&filetype) .
+      \ '\ ' . escape(get(b:, 'pandoc_compiler_args', get(g:, 'pandoc_compiler_args', '')), ' ') .
       \ '\ --output\ %:r:S.$*\ %:S'
 
 CompilerSet errorformat="%f",\ line\ %l:\ %m

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1321,6 +1321,13 @@ If Vim was started from the compiler, the :sh and some :!  commands will not
 work, because Vim is then running in the same process as the compiler and
 stdin (standard input) will not be interactive.
 
+PANDOC					*quickfix-pandoc* *compiler-pandoc*
+
+The Pandoc compiler plugin expects that an output file extension is passed to make, say :make html or :make pdf.
+Additional arguments can be passed to pandoc 
+
+- either by appending them to make, say :make html --self-contained.
+- or setting them in b:pandoc_compiler_args or g:pandoc_compiler_args
 
 PERL					*quickfix-perl* *compiler-perl*
 


### PR DESCRIPTION
This enables globally, or buffer, in particular filetype, locally, configuring the options passed to pandoc