### PR TITLE
Problem: Error with matchaddpos() and empty list

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -87,7 +87,7 @@ match_add(
     m = ALLOC_CLEAR_ONE(matchitem_T);
     if (m == NULL)
 	return -1;
-    if (pos_list != NULL)
+    if (pos_list != NULL && pos_list->lv_len > 0)
     {
 	m->mit_pos_array = ALLOC_CLEAR_MULT(llpos_T, pos_list->lv_len);
 	if (m->mit_pos_array == NULL)
@@ -1294,7 +1294,7 @@ f_matchaddpos(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 	return;
     }
     l = argvars[1].vval.v_list;
-    if (l == NULL)
+    if (l == NULL || l->lv_len == 0)
 	return;
 
     if (argvars[2].v_type != VAR_UNKNOWN)

--- a/src/testdir/test_match.vim
+++ b/src/testdir/test_match.vim
@@ -312,6 +312,8 @@ func Test_matchaddpos_error()
   call assert_fails("call matchaddpos('Search', [[{}]])", 'E728:')
   call assert_fails("call matchaddpos('Search', [[2, {}]])", 'E728:')
   call assert_fails("call matchaddpos('Search', [[3, 4, {}]])", 'E728:')
+  call assert_equal(-1, matchaddpos('Error', test_null_list()))
+  call assert_equal(-1, matchaddpos('Error', []))
 endfunc
 
 func OtherWindowCommon()
@@ -432,6 +434,5 @@ func Test_match_tab_with_linebreak()
 
   call StopVimInTerminal(buf)
 endfunc
-
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Error with matchaddpos() and empty list
          (@rickhow)
Solution: Return early for an empty list

fixes: #14525