### PR TITLE
source gvimrc if XDG_CONFIG_HOME is used

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -579,6 +579,10 @@ gui_init(void)
 		 && do_source((char_u *)USR_GVIMRC_FILE3, TRUE,
 						     DOSO_GVIMRC, NULL) == FAIL
 #endif
+#ifdef XDG_GVIMRC_FILE
+		 && do_source((char_u *)XDG_GVIMRC_FILE, TRUE,
+						     DOSO_GVIMRC, NULL) == FAIL
+#endif
 				)
 	    {
 #ifdef USR_GVIMRC_FILE4

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -281,6 +281,12 @@ typedef struct dsc$descriptor   DESC;
 # endif
 #endif
 
+#ifndef XDG_GVIMRC_FILE
+# define XDG_GVIMRC_FILE mch_getenv("XDG_CONFIG_HOME") \
+	? (char_u *)"$XDG_CONFIG_HOME/vim/gvimrc" \
+	: (char_u *)"~/.config/vim/gvimrc"
+#endif
+
 #ifndef VIM_DEFAULTS_FILE
 # define VIM_DEFAULTS_FILE "$VIMRUNTIME/defaults.vim"
 #endif


### PR DESCRIPTION
Fixes #14567

Probably needs test case added?