### PR TITLE
runtime(uci): add support

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1298,9 +1298,9 @@ export def FTvba()
   endif
 enddef
 
-export def Detect_UCI_statements()
-  " Match a config or package statement at the start of the line.
-  let pattern = '^\s*\(\(c\|config\)\|\(p\|package\)\)\s\+\S'
+export def Detect_UCI_statements(): bool
+  # Match a config or package statement at the start of the line.
+  const pattern = '^\s*\(\(c\|config\)\|\(p\|package\)\)\s\+\S'
   return getline(1) =~# pattern || getline(2) =~# pattern || getline(3) =~# pattern
 enddef
 

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1298,5 +1298,11 @@ export def FTvba()
   endif
 enddef
 
+export def Detect_UCI_statements()
+  " Match a config or package statement at the start of the line.
+  let pattern = '^\s*\(\(c\|config\)\|\(p\|package\)\)\s\+\S'
+  return getline(1) =~# pattern || getline(2) =~# pattern || getline(3) =~# pattern
+enddef
+
 # Uncomment this line to check for compilation errors early
 # defcompile

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1300,8 +1300,18 @@ enddef
 
 export def Detect_UCI_statements(): bool
   # Match a config or package statement at the start of the line.
-  const pattern = '^\s*\(\(c\|config\)\|\(p\|package\)\)\s\+\S'
-  return getline(1) =~# pattern || getline(2) =~# pattern || getline(3) =~# pattern
+  const config_or_package_statement = '^\s*\(\(c\|config\)\|\(p\|package\)\)\s\+\S'
+  # Match a line that is either all blank or blank followed by a comment
+  const comment_or_blank = '^\s*\(#.*\)\?$'
+
+  # Return true iff the file has a config or package statement near the
+  # top of the file and all preceding lines were comments or blank.
+  return getline(1) =~# config_or_package_statement
+  \   || getline(1) =~# comment_or_blank
+  \      && (   getline(2) =~# config_or_package_statement
+  \          || getline(2) =~# comment_or_blank
+  \             && getline(3) =~# config_or_package_statement
+  \         )
 enddef
 
 # Uncomment this line to check for compilation errors early

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2980,6 +2980,9 @@ au BufNewFile,BufRead {.,}tmux*.conf*		setf tmux
 " Universal Scene Description
 au BufNewFile,BufRead *.usda,*.usd		setf usd
 
+" Uci
+au BufNewFile,BufRead */etc/config/*		call s:StarSetf('uci')
+
 " VHDL
 au BufNewFile,BufRead *.vhdl_[0-9]*		call s:StarSetf('vhdl')
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2980,8 +2980,11 @@ au BufNewFile,BufRead {.,}tmux*.conf*		setf tmux
 " Universal Scene Description
 au BufNewFile,BufRead *.usda,*.usd		setf usd
 
-" Uci
-au BufNewFile,BufRead */etc/config/*		call s:StarSetf('uci')
+" UCI
+" UCI files are normally in /etc/config, but that might be mounted over sshfs or similar, so we match more loosely.
+" There was some concern[1] that this pattern would match too much, so now we check the file content as well.
+" [1]: https://github.com/vim/vim/pull/14385#discussion_r1558878741
+au BufNewFile,BufRead */etc/config/*		if dist#ft#Detect_UCI_statements() | call s:StarSetf('uci') | endif
 
 " VHDL
 au BufNewFile,BufRead *.vhdl_[0-9]*		call s:StarSetf('vhdl')

--- a/runtime/ftplugin/uci.vim
+++ b/runtime/ftplugin/uci.vim
@@ -18,4 +18,4 @@ setl softtabstop=0
 
 setl commentstring=#\ %s
 
-let b:undo_ftplugin = "setlocal et< cms<"
+let b:undo_ftplugin = "setlocal et< cms< sts< sw<"

--- a/runtime/ftplugin/uci.vim
+++ b/runtime/ftplugin/uci.vim
@@ -2,7 +2,7 @@
 " Language:	OpenWrt Unified Configuration Interface
 " Maintainer:	Colin Caine <complaints@cmcaine.co.uk>
 " Upstream:	https://github.com/cmcaine/vim-uci
-" Last Change:	2024 Apr 4
+" Last Change:	2024 Apr 17
 "
 " For more information on uci, see https://openwrt.org/docs/guide-user/base-system/uci
 
@@ -12,7 +12,10 @@ endif
 let b:did_ftplugin = 1
 
 " UCI files are indented with tabs.
-setl noet
+setl noexpandtab
+setl shiftwidth=0
+setl softtabstop=0
+
 setl commentstring=#\ %s
 
 let b:undo_ftplugin = "setlocal et< cms<"

--- a/runtime/ftplugin/uci.vim
+++ b/runtime/ftplugin/uci.vim
@@ -1,0 +1,18 @@
+" Vim ftplugin file
+" Language:	OpenWrt Unified Configuration Interface
+" Maintainer:	Colin Caine <complaints@cmcaine.co.uk>
+" Upstream:	https://github.com/cmcaine/vim-uci
+" Last Change:	2024 Apr 4
+"
+" For more information on uci, see https://openwrt.org/docs/guide-user/base-system/uci
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+" UCI files are indented with tabs.
+setl noet
+setl commentstring=#\ %s
+
+let b:undo_ftplugin = "setlocal et< cms<"

--- a/runtime/syntax/uci.vim
+++ b/runtime/syntax/uci.vim
@@ -1,0 +1,33 @@
+" Vim syntax file
+" Language:	OpenWrt Unified Configuration Interface
+" Maintainer:	Colin Caine <complaints@cmcaine.co.uk>
+" Upstream:	https://github.com/cmcaine/vim-uci
+" Last Change:	2021 Sep 19
+"
+" For more information on uci, see https://openwrt.org/docs/guide-user/base-system/uci
+
+if exists("b:current_syntax")
+    finish
+endif
+
+" Fancy zero-width non-capturing look-behind to see what the last word was.
+" Would be really nice if there was some less obscure or more efficient way to
+" do this.
+syntax match uciOptionName '\%(\%(option\|list\)\s\+\)\@<=\S*'
+syntax match uciConfigName '\%(\%(package\|config\)\s\+\)\@<=\S*'
+syntax keyword uciConfigDec package config nextgroup=uciConfigName skipwhite
+syntax keyword uciOptionType option list nextgroup=uciOptionName skipwhite
+
+" Standard matches.
+syntax match uciComment "#.*$"
+syntax region uciString start=+"+ end=+"+ skip=+\\"+
+syntax region uciString start=+'+ end=+'+ skip=+\\'+
+
+highlight default link uciConfigName Identifier
+highlight default link uciOptionName Constant
+highlight default link uciConfigDec Statement
+highlight default link uciOptionType Type
+highlight default link uciComment Comment
+highlight default link uciString Normal
+
+let b:current_syntax = "uci"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -764,7 +764,6 @@ def s:GetFilenameChecks(): dict<list<string>>
     typespec: ['file.tsp'],
     ungrammar: ['file.ungram'],
     uc: ['file.uc'],
-    uci: ['any/etc/config/file'],
     udevconf: ['/etc/udev/udev.conf', 'any/etc/udev/udev.conf'],
     udevperm: ['/etc/udev/permissions.d/file.permissions', 'any/etc/udev/permissions.d/file.permissions'],
     udevrules: ['/etc/udev/rules.d/file.rules', '/usr/lib/udev/rules.d/file.rules', '/lib/udev/rules.d/file.rules'],
@@ -2425,6 +2424,28 @@ func Test_def_file()
   split Xfile.def
   call assert_equal('modula2', &filetype)
   call assert_equal('pim', b:modula2.dialect)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_uci_file()
+  filetype on
+
+  call mkdir('any/etc/config', 'pR')
+  call writefile(['config firewall'], 'any/etc/config/firewall', 'D')
+  split any/etc/config/firewall
+  call assert_equal('uci', &filetype)
+  bwipe!
+
+  call writefile(['# config for nginx here'], 'any/etc/config/firewall', 'D')
+  split any/etc/config/firewall
+  call assert_notequal('uci', &filetype)
+  bwipe!
+
+  call writefile(['# Copyright Cool Cats 1997', 'config firewall'], 'any/etc/config/firewall', 'D')
+  split any/etc/config/firewall
+  call assert_equal('uci', &filetype)
   bwipe!
 
   filetype off

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -764,6 +764,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     typespec: ['file.tsp'],
     ungrammar: ['file.ungram'],
     uc: ['file.uc'],
+    uci: ['any/etc/config/file'],
     udevconf: ['/etc/udev/udev.conf', 'any/etc/udev/udev.conf'],
     udevperm: ['/etc/udev/permissions.d/file.permissions', 'any/etc/udev/permissions.d/file.permissions'],
     udevrules: ['/etc/udev/rules.d/file.rules', '/usr/lib/udev/rules.d/file.rules', '/lib/udev/rules.d/file.rules'],


### PR DESCRIPTION
Updated version of #14385

This version adds content detection for files that have a line starting with "c \S", "config \S" or "p \S" or "package \S" in the first 3 lines.

The detection only checks the second line if the first line looked like it was blank or a comment. Similarly for line 3.