### PR TITLE
Test `import './file.vim'` works with `:source`.

### DIFF
--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -1140,6 +1140,31 @@ def Test_autoload_import_relative()
   v9.CheckScriptFailure(lines, 'E484:')
 enddef
 
+def Test_autoload_import_relative_compiled()
+  # autoload relative, access from compiled function. #14565
+  var lines =<< trim END
+    vim9script
+
+    export def F1(): string
+        return 'InFile.vim'
+    enddef
+  END
+  writefile(lines, 'xfile.vim', 'D')
+  lines =<< trim END
+    vim9script
+
+    import autoload './xfile.vim'
+
+    def F(): string
+      return xfile.F1()
+    enddef
+    assert_equal('InFile.vim', F())
+  END
+  new
+  setline(1, lines)
+  :source
+enddef
+
 def Test_autoload_import_relative_autoload_dir()
   mkdir('autoload', 'pR')
   var lines =<< trim END


### PR DESCRIPTION
A recent change, https://github.com/vim/vim/commit/9a90179a11b433fcbcf587182032222e229c6d75, unexpectedly fixed this problem. Adding a test to avoid regression.

To produce the error, execute the following **xxx.vim** file like either
- vim -u NONE -U NONE xxx.vim
  :source
- vim -u NONE -U NONE xxx.vim -c 'source'

```
FAIL
Vim(echo):E117: Unknown function: <SNR>2_F1
```

**xxx.vim**
```
vim9script

var lines =<< trim END
    vim9script

    export def F1(): string
        return 'InFile.vim'
    enddef
END
writefile(lines, 'xfile.vim')

import autoload './xfile.vim'

def F(): string
    return xfile.F1()
enddef

try
    echo F()
    echo "PASS"
catch
    echo "FAIL"
    echo v:exception
endtry

delete('xfile.vim')
```