### PR TITLE
No test that completing a partial mapping clears 'showcmd'

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1281,6 +1281,9 @@ del_typebuf(int len, int offset)
 	typebuf.tb_change_cnt = 1;
 }
 
+/*
+ * State for adding bytes to a recording or 'showcmd'.
+ */
 typedef struct
 {
     int		prev_c;

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -1811,7 +1811,7 @@ endfunc
 func Test_showcmd_part_map()
   CheckRunVimInTerminal
 
-  let lines =<< trim eval END
+  let lines =<< trim END
     set notimeout showcmd
     nnoremap ,a <Ignore>
     nnoremap ;a <Ignore>
@@ -1831,20 +1831,21 @@ func Test_showcmd_part_map()
   for c in [',', ';', 'À', 'Ë', 'β', 'ω', '…']
     call term_sendkeys(buf, c)
     call WaitForAssert({-> assert_equal(c, trim(term_getline(buf, 6)))})
-    call term_sendkeys(buf, "\<C-C>:echo\<CR>")
-    call WaitForAssert({-> assert_equal('', term_getline(buf, 6))})
+    call term_sendkeys(buf, 'a')
+    call WaitForAssert({-> assert_equal('', trim(term_getline(buf, 6)))})
   endfor
 
   call term_sendkeys(buf, "\<C-W>")
   call WaitForAssert({-> assert_equal('^W', trim(term_getline(buf, 6)))})
-  call term_sendkeys(buf, "\<C-C>:echo\<CR>")
-  call WaitForAssert({-> assert_equal('', term_getline(buf, 6))})
+  call term_sendkeys(buf, 'a')
+  call WaitForAssert({-> assert_equal('', trim(term_getline(buf, 6)))})
 
-  " Use feedkeys() as terminal buffer cannot forward this
+  " Use feedkeys() as terminal buffer cannot forward unsimplified Ctrl-W.
+  " This is like typing Ctrl-W with modifyOtherKeys enabled.
   call term_sendkeys(buf, ':call feedkeys("\<*C-W>", "m")' .. " | echo\<CR>")
   call WaitForAssert({-> assert_equal('^W', trim(term_getline(buf, 6)))})
-  call term_sendkeys(buf, "\<C-C>:echo\<CR>")
-  call WaitForAssert({-> assert_equal('', term_getline(buf, 6))})
+  call term_sendkeys(buf, 'a')
+  call WaitForAssert({-> assert_equal('', trim(term_getline(buf, 6)))})
 
   call StopVimInTerminal(buf)
 endfunc

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -300,7 +300,7 @@ func Test_setcellwidths_dump()
   call StopVimInTerminal(buf)
 endfunc
 
-" When `setcellwidth` is used on characters that are not targets of `ambiwidth`.
+" Test setcellwidths() on characters that are not targets of 'ambiwidth'.
 func Test_setcellwidths_with_non_ambiwidth_character_dump()
   CheckRunVimInTerminal
 
@@ -320,7 +320,6 @@ func Test_setcellwidths_with_non_ambiwidth_character_dump()
 
   call StopVimInTerminal(buf)
 endfunc
-
 
 " For some reason this test causes Test_customlist_completion() to fail on CI,
 " so run it as the last test.


### PR DESCRIPTION
Problem:  No test that completing a partial mapping clears 'showcmd'.
Solution: Complete partial mappings in Test_showcmd_part_map() instead
          of using :echo.  Adjust some comments.
