### PR TITLE
Fix vim9 disassemble test failure

### DIFF
--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -1030,7 +1030,7 @@ def Test_disassemble_closure_in_loop()
 
         'endif\_s*' ..
         'g:Ref = () => ii\_s*' ..
-        '\d\+ FUNCREF <lambda>4 vars  $3-$3\_s*' ..
+        '\d\+ FUNCREF <lambda>\d\+ vars  $3-$3\_s*' ..
         '\d\+ STOREG g:Ref\_s*' ..
 
         'continue\_s*' ..


### PR DESCRIPTION
I tried to bisect this failing test:
```
From test_vim9_disassemble.vim:
Found errors in Test_disassemble_closure_in_loop():
command line..script /home/ju/Documents/projects/vim/src/testdir/runtest.vim[607]..function RunTheTest[57]..Test_disassemble_closure_in_loop line 58: Pattern '<SNR>\\d\\+_ClosureInLoop\\_s*for i in range(5)\\_s*\\d\\+ STORE -1 in $0\\_s*\\d\\+ PUSHNR 5\\_s*\\d\\+ BCALL range(argc 1)\\_s*\\d\\+ FOR $0 -> \\d\\+\\_s*\\d\\+ STORE $2\\_s*var ii = i\\_s*\\d\\+ LOAD $2\\_s*\\d\\+ STORE $3\\_s*continue\\_s*\\d\\+ JUMP -> \\d\\+\\_s*break\\_s*\\d\\+ JUMP -> \\d\\+\\_s*if g:val\\_s*\\d\\+ LOADG g:val\\_s*\\d\\+ COND2BOOL\\_s*\\d\\+ JUMP_IF_FALSE -> \\d\\+\\_s*  return\\_s*\\d\\+ PUSHNR 0\\_s*\\d\\+ RETURN\\_s*endif\\_s*g:Ref = () => ii\\_s*\\d\\+ FUNCREF <lambda>4 vars  $3-$3\\_s*\\d\\+ STOREG g:Ref\\_s*continue\\_s*\\d\\+ ENDLOOP ref $1 save $3-$3 depth 0\\_s*\\d\\+ JUMP -> \\d\\+\\_s*break\\_s*\\d\\+ ENDLOOP ref $1 save $3-$3 depth 0\\_s*\\d\\+ JUMP -> \\d\\+\\_s*if g:val\\_s*\\d\\+ LOADG g:val\\_s*\\d\\+ COND2BOOL\\_s*\\d\\+ JUMP_IF_FALSE -> \\d\\+\\_s*  return\\_s*\\d\\+ PUSHNR 0\\_s*\\d\\+ ENDLOOP ref $1 save $3-$3 depth 0\\_s*\\d\\+ RETURN\\_s*endif\\_s*endfor\\_s*\\d\\+ ENDLOOP ref $1 save $3-$3 depth 0\\_s*\\d\\+ JUMP -> \\d\\+\\_s*\\d\\+ DROP\\_s*\\d\\+ RETURN void' does not match '\n<SNR>6_ClosureInLoop\n  for i in range(5)\n   0 STORE -1 in $0\n   1 PUSHNR 5\n   2 BCALL range(argc 1)\n   3 FOR $0 -> 28\n   4 STORE $2\n\n\n    var ii = i\n   5 LOAD $2\n   6 STORE $3\n\n\n    continue\n   7 JUMP -> 3\n\n\n    break\n   8 JUMP -> 28\n\n\n    if g:val\n   9 LOADG g:val\n  10 COND2BOOL\n  11 JUMP_IF_FALSE -> 14\n\n\n      return\n  12 PUSHNR 0\n  13 RETURN\n\n\n    endif\n    g:Ref = () => ii\n  14 FUNCREF <lambda>2 vars  $3-$3\n  15 STOREG g:Ref\n\n\n    continue\n  16 ENDLOOP ref $1 save $3-$3 depth 0\n  17 JUMP -> 3\n\n\n    break\n  18 ENDLOOP ref $1 save $3-$3 depth 0\n  19 JUMP -> 28\n\n\n    if g:val\n  20 LOADG g:val\n  21 COND2BOOL\n  22 JUMP_IF_FALSE -> 26\n\n\n      return\n  23 PUSHNR 0\n  24 ENDLOOP ref $1 save $3-$3 depth 0\n  25 RETURN\n\n\n    endif\n  endfor\n  26 ENDLOOP ref $1 save $3-$3 depth 0\n  27 JUMP -> 3\n  28 DROP\n  29 RETURN void'
```
But i noticed that it was failing all the way back to v9.0.0484, where it was added.
It tries to match `FUNCREF <lambda>4` but on my system the result is `FUNCREF <lambda>2`

So i simply changed this to `<lambda>\d\+`, which is already used by all of the tests in this file.
