### PR TITLE
Correctly ignore unwanted smooth scroll events on X11

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -2152,6 +2152,10 @@ scroll_event(GtkWidget *widget,
 		    FALSE, vim_modifiers);
 	}
     }
+    else if (event->direction == GDK_SCROLL_SMOOTH && display_type == DT_X11)
+    {
+	// for x11 we deal with unsmooth events, and so ignore the smooth ones
+    }
     else
 #undef DT_X11
 #undef DT_WAYLAND


### PR DESCRIPTION
fixes #14578.