### PR TITLE
Page scrolling should place cursor at window boundaries

### DIFF
--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -3813,8 +3813,8 @@ func Test_normal_vert_scroll_longline()
   call assert_equal(11, line('.'))
   call assert_equal(1, winline())
   exe "normal \<C-B>"
-  call assert_equal(10, line('.'))
-  call assert_equal(4, winline())
+  call assert_equal(11, line('.'))
+  call assert_equal(5, winline())
   exe "normal \<C-B>\<C-B>"
   call assert_equal(5, line('.'))
   call assert_equal(5, winline())
@@ -4244,6 +4244,19 @@ func Test_halfpage_cursor_startend()
   call assert_equal(1, line('.'))
   exe "norm! G\<C-Y>k\<C-D>"
   call assert_equal(100, line('.'))
+  bwipe!
+endfunc
+
+" Test for Ctrl-F/B moving the cursor to the window boundaries.
+func Test_page_cursor_topbot()
+  10new
+  call setline(1, range(1, 100))
+  exe "norm! gg2\<C-F>"
+  call assert_equal(17, line('.'))
+  exe "norm! \<C-B>"
+  call assert_equal(18, line('.'))
+  exe "norm! \<C-B>\<C-F>"
+  call assert_equal(9, line('.'))
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  Page scrolling does not always place the cursor at the top or
          bottom of the window.
Solution: Place the cursor at the top or bottom of the window.

Fix #14585