### PR TITLE
fix: Regression setcellwidths with GUI

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -1981,22 +1981,20 @@ screen_char(unsigned off, int row, int col)
     {
 	char_u	    buf[MB_MAXBYTES + 1];
 
-	if (get_cellwidth(ScreenLinesUC[off]) > 1)
+	if (1
+#ifdef FEAT_GUI
+	    && !gui.in_use
+#endif
+	    && get_cellwidth(ScreenLinesUC[off]) > 1
+	    )
 	{
 	    // If the width is set to 2 with `setcellwidths`
 
-#ifdef FEAT_GUI
-	    if (!gui.in_use)
-	    {
-#endif
-		// Clear the two screen cells. If the character is actually
-		// single width it won't change the second cell.
-		out_str((char_u *)"  ");
-		term_windgoto(row, col);
-		screen_cur_col = 9999;
-#ifdef FEAT_GUI
-	    }
-#endif
+	    // Clear the two screen cells. If the character is actually
+	    // single width it won't change the second cell.
+	    out_str((char_u *)"  ");
+	    term_windgoto(row, col);
+	    screen_cur_col = 9999;
 	}
 	else if (utf_ambiguous_width(ScreenLinesUC[off]))
 	{


### PR DESCRIPTION
A regression has occurred since version [9.1.0344](https://github.com/vim/vim/commit/e20fa59903525e15cecd680a2f32ece8a5d1bc0c).
(ID-Call as patch authors: @mikoto2000 @zeertzjq)

Related: #14539 #14540

### Step to repro.

1. Start GUI Vim with few parameters.
```bash
$ vim -g -Nu NONE +'call setcellwidths([[0x2502, 0x2502, 2]])' +'call setline(1, ["abc\u2502def"])'
```

2. Behavior of GUI Vim 9.1.0344
There is an extra space before `d`.
![gui_ng_1](https://github.com/vim/vim/assets/518808/273cefbb-35b9-4877-8534-fa440ff14dae)

    After type `fd`, The cursor will move to the extra space and `d` will appear.
![gui_ng](https://github.com/vim/vim/assets/518808/af78f063-a779-4f3c-b113-82bb5584ff33)

### Expected behavior
3. Behavior of GUI Vim before version 9.1.0343 or with this PR patch applied.
There is no extra space before d.
![gui_ok_1](https://github.com/vim/vim/assets/518808/2c8fb70c-f71a-4120-ae03-7ac00df17f52)

    After type `fd`.
![gui_ok](https://github.com/vim/vim/assets/518808/04ddd70e-a223-46e7-9e62-e01f8a7d038e)
