### PR TITLE
Relative import in a script sourced from a buffer doesn't work

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1430,8 +1430,13 @@ do_source_buffer_init(source_cookie_T *sp, exarg_T *eap)
 	return NULL;
 
     // Use ":source buffer=<num>" as the script name
-    vim_snprintf((char *)IObuff, IOSIZE, ":source buffer=%d", curbuf->b_fnum);
-    fname = vim_strsave(IObuff);
+    if (curbuf->b_ffname != NULL)
+	fname = vim_strsave(curbuf->b_ffname);
+    else
+    {
+	vim_snprintf((char *)IObuff, IOSIZE, ":source buffer=%d", curbuf->b_fnum);
+	fname = vim_strsave(IObuff);
+    }
     if (fname == NULL)
 	return NULL;
 

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -456,15 +456,24 @@ handle_import(
 	scriptitem_T	*si = SCRIPT_ITEM(current_sctx.sc_sid);
 	char_u		*tail = gettail(si->sn_name);
 	char_u		*from_name;
+	int		sourced_from_nofile_buf = FALSE;
 
-	// Relative to current script: "./name.vim", "../../name.vim".
-	len = STRLEN(si->sn_name) - STRLEN(tail) + STRLEN(tv.vval.v_string) + 2;
-	from_name = alloc((int)len);
-	if (from_name == NULL)
-	    goto erret;
-	vim_strncpy(from_name, si->sn_name, tail - si->sn_name);
-	add_pathsep(from_name);
-	STRCAT(from_name, tv.vval.v_string);
+	if (STRNCMP(si->sn_name, ":source buffer=", 15) == 0)
+	    sourced_from_nofile_buf = TRUE;
+
+	if (!sourced_from_nofile_buf)
+	{
+	    // Relative to current script: "./name.vim", "../../name.vim".
+	    len = STRLEN(si->sn_name) - STRLEN(tail) + STRLEN(tv.vval.v_string) + 2;
+	    from_name = alloc((int)len);
+	    if (from_name == NULL)
+		goto erret;
+	    vim_strncpy(from_name, si->sn_name, tail - si->sn_name);
+	    add_pathsep(from_name);
+	    STRCAT(from_name, tv.vval.v_string);
+	}
+	else
+	    from_name = vim_strsave(tv.vval.v_string);
 	simplify_filename(from_name);
 
 	res = handle_import_fname(from_name, is_autoload, &sid);


### PR DESCRIPTION

When a script is sourced from a buffer, the file name is set to ":source buffer=<number>". 
In MS-Windows, the ":" is a path separator character (used after a drive letter).  This results
in the code trying to use the ":" prefix to import the script on MS-Windows.  To fix this,
when importing a script from a script sourced from a buffer with nofile, don't try to use
a script relative path name.  Fixes #14588.