### PR TITLE
[vim9script] Better handle script-level references to variables exported from autoload files

### DIFF
--- a/src/proto/evalvars.pro
+++ b/src/proto/evalvars.pro
@@ -63,6 +63,7 @@ int eval_variable(char_u *name, int len, scid_T sid, typval_T *rettv, dictitem_T
 int eval_variable_import(char_u *name, typval_T *rettv);
 void check_vars(char_u *name, int len);
 dictitem_T *find_var(char_u *name, hashtab_T **htp, int no_autoload);
+dictitem_T *find_var_autoload_prefix(char_u *name, int sid, hashtab_T **htp, char_u **namep);
 dictitem_T *find_var_also_in_script(char_u *name, hashtab_T **htp, int no_autoload);
 dictitem_T *find_var_in_ht(hashtab_T *ht, int htname, char_u *varname, int no_autoload);
 hashtab_T *get_script_local_ht(void);


### PR DESCRIPTION
Fix #14591.
This is about script-level access to `autoload` variables.
There are a variety of issues; see #14591 for the basic setup.
Most of the problems are when the variable is on the left hand side.

The mentioned issue shows that the imported file can not modify its own variable that it exports. In the file that does the import, there are similar issues.

The basic issue is that when a file is imported from a directory that has an `autoload` component, the exported items are put into the global namespace with names like "f2#val". This isn't handled well at script-level.

There are 4 changes
- Create `find_var_autoload_prefix()` to check if a variable is an autoload export.
  It is extracted from `find_var()`. It is used in the following three items
- In `lookup_scriptitem()`, which is used when checking if a script command is an assignment, use it for identifying the assignment lhs.
- In `set_var_const()`, to check if asign target is an autoload imported name.
- In `set_var_const()`, to check if asign target is an autoload exported name.
- 
