### PR TITLE
test_winfixbuf.vim is very slow

### DIFF
--- a/src/testdir/test_winfixbuf.vim
+++ b/src/testdir/test_winfixbuf.vim
@@ -200,10 +200,7 @@ func s:reset_all_buffers()
   set nowinfixbuf
 
   call setqflist([])
-
-  for l:window_info in getwininfo()
-    call setloclist(l:window_info["winid"], [])
-  endfor
+  call setloclist(0, [], 'f')
 
   delmarks A-Z0-9
 endfunc
@@ -642,7 +639,7 @@ func Test_caddexpr()
   call s:reset_all_buffers()
 
   let l:file_path = tempname()
-  call writefile(["Error - bad-thing-found"], l:file_path)
+  call writefile(["Error - bad-thing-found"], l:file_path, 'D')
   execute "edit " . l:file_path
   let l:file_buffer = bufnr()
   let l:current = bufnr()
@@ -658,8 +655,6 @@ func Test_caddexpr()
 
   execute 'caddexpr expand("%") .. ":" .. line(".") .. ":" .. getline(".")'
   call assert_equal(l:current, bufnr())
-
-  call delete(l:file_path)
 endfunc
 
 " Fail :cbuffer but :cbuffer! is allowed
@@ -668,7 +663,7 @@ func Test_cbuffer()
   call s:reset_all_buffers()
 
   let l:file_path = tempname()
-  call writefile(["first.unittest:1:Error - bad-thing-found"], l:file_path)
+  call writefile(["first.unittest:1:Error - bad-thing-found"], l:file_path, 'D')
   execute "edit " . l:file_path
   let l:file_buffer = bufnr()
   let l:current = bufnr()
@@ -687,8 +682,6 @@ func Test_cbuffer()
 
   execute "cbuffer! " . l:file_buffer
   call assert_equal("first.unittest", expand("%:t"))
-
-  call delete(l:file_path)
 endfunc
 
 " Allow :cc but the 'nowinfixbuf' window is selected, instead
@@ -1305,7 +1298,7 @@ func Test_find()
 
   let l:current = bufnr()
   let l:file = tempname()
-  call writefile([], l:file)
+  call writefile([], l:file, 'D')
   let l:file = fnamemodify(l:file, ':p')  " In case it's Windows 8.3-style.
   let l:directory = fnamemodify(l:file, ":p:h")
   let l:name = fnamemodify(l:file, ":p:t")
@@ -1322,7 +1315,6 @@ func Test_find()
   call assert_equal(l:file, expand("%:p"))
 
   execute "set path=" . l:original_path
-  call delete(l:file)
 endfunc
 
 " Fail :first but :first! is allowed
@@ -1383,8 +1375,8 @@ func Test_ijump()
   call writefile([
         \ '#include "' . l:include_file . '"'
         \ ],
-        \ "main.c")
-  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file)
+        \ "main.c", 'D')
+  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file, 'D')
   edit main.c
 
   set winfixbuf
@@ -1406,8 +1398,6 @@ func Test_ijump()
   set define&
   set include&
   set path&
-  call delete("main.c")
-  call delete(l:include_file)
 endfunc
 
 " Fail :lNext but :lNext! is allowed
@@ -1472,7 +1462,7 @@ func Test_laddexpr()
   call s:reset_all_buffers()
 
   let l:file_path = tempname()
-  call writefile(["Error - bad-thing-found"], l:file_path)
+  call writefile(["Error - bad-thing-found"], l:file_path, 'D')
   execute "edit " . l:file_path
   let l:file_buffer = bufnr()
   let l:current = bufnr()
@@ -1488,8 +1478,6 @@ func Test_laddexpr()
 
   execute 'laddexpr expand("%") .. ":" .. line(".") .. ":" .. getline(".")'
   call assert_equal(l:current, bufnr())
-
-  call delete(l:file_path)
 endfunc
 
 " Fail :last but :last! is allowed
@@ -1512,7 +1500,7 @@ func Test_lbuffer()
   call s:reset_all_buffers()
 
   let l:file_path = tempname()
-  call writefile(["first.unittest:1:Error - bad-thing-found"], l:file_path)
+  call writefile(["first.unittest:1:Error - bad-thing-found"], l:file_path, 'D')
   execute "edit " . l:file_path
   let l:file_buffer = bufnr()
   let l:current = bufnr()
@@ -1531,8 +1519,6 @@ func Test_lbuffer()
 
   execute "lbuffer! " . l:file_buffer
   call assert_equal("first.unittest", expand("%:t"))
-
-  call delete(l:file_path)
 endfunc
 
 " Fail :ldo but :ldo! is allowed
@@ -1596,7 +1582,7 @@ func Test_lfile()
   write
 
   let l:file = tempname()
-  call writefile(["first.unittest:1:Error - bad-thing-found was detected"], l:file)
+  call writefile(["first.unittest:1:Error - bad-thing-found was detected"], l:file, 'D')
 
   let l:current = bufnr()
 
@@ -1608,7 +1594,6 @@ func Test_lfile()
   execute ":lfile! " . l:file
   call assert_equal(l:first, bufnr())
 
-  call delete(l:file)
   call delete("first.unittest")
   call delete("second.unittest")
 endfunc
@@ -1748,9 +1733,9 @@ func Test_ltag()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
   execute "normal \<C-]>"
 
@@ -1763,9 +1748,6 @@ func Test_ltag()
   ltag! one
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail vim.command if we try to change buffers while 'winfixbuf' is set
@@ -1971,9 +1953,9 @@ func Test_normal_g_ctrl_square_bracket_right()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -1984,9 +1966,6 @@ func Test_normal_g_ctrl_square_bracket_right()
   call assert_equal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail to jump to a tag with g<RightMouse> if 'winfixbuf' is enabled
@@ -1999,9 +1978,9 @@ func Test_normal_g_rightmouse()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
   execute "normal \<C-]>"
 
@@ -2014,9 +1993,6 @@ func Test_normal_g_rightmouse()
 
   set tags&
   set mouse&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail to jump to a tag with g] if 'winfixbuf' is enabled
@@ -2028,9 +2004,9 @@ func Test_normal_g_square_bracket_right()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -2041,9 +2017,6 @@ func Test_normal_g_square_bracket_right()
   call assert_equal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail to jump to a tag with <C-RightMouse> if 'winfixbuf' is enabled
@@ -2056,9 +2029,9 @@ func Test_normal_ctrl_rightmouse()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
   execute "normal \<C-]>"
 
@@ -2071,9 +2044,6 @@ func Test_normal_ctrl_rightmouse()
 
   set tags&
   set mouse&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail to jump to a tag with <C-t> if 'winfixbuf' is enabled
@@ -2085,9 +2055,9 @@ func Test_normal_ctrl_t()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
   execute "normal \<C-]>"
 
@@ -2099,9 +2069,6 @@ func Test_normal_ctrl_t()
   call assert_equal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Disallow <C-^> in 'winfixbuf' windows
@@ -2203,9 +2170,9 @@ func Test_normal_ctrl_square_bracket_right()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -2216,9 +2183,6 @@ func Test_normal_ctrl_square_bracket_right()
   call assert_equal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Allow <C-w><C-]> with 'winfixbuf' enabled because it runs in a new, split window
@@ -2230,9 +2194,9 @@ func Test_normal_ctrl_w_ctrl_square_bracket_right()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -2242,9 +2206,6 @@ func Test_normal_ctrl_w_ctrl_square_bracket_right()
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Allow <C-w>g<C-]> with 'winfixbuf' enabled because it runs in a new, split window
@@ -2256,9 +2217,9 @@ func Test_normal_ctrl_w_g_ctrl_square_bracket_right()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -2268,9 +2229,6 @@ func Test_normal_ctrl_w_g_ctrl_square_bracket_right()
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail to jump to a tag with <C-]> if 'winfixbuf' is enabled
@@ -2282,9 +2240,9 @@ func Test_normal_gt()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one", "two", "three"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one", "two", "three"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -2295,9 +2253,6 @@ func Test_normal_gt()
   call assert_equal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Prevent gF from switching a 'winfixbuf' window's buffer
@@ -2306,7 +2261,7 @@ func Test_normal_gF()
 
   let l:file = tempname()
   call append(0, [l:file])
-  call writefile([], l:file)
+  call writefile([], l:file, 'D')
   " Place the cursor onto the line that has `l:file`
   normal gg
   " Prevent Vim from erroring with "No write since last change @ command
@@ -2325,7 +2280,7 @@ func Test_normal_gF()
   normal gF
   call assert_notequal(l:buffer, bufnr())
 
-  call delete(l:file)
+  set nohidden
 endfunc
 
 " Prevent gf from switching a 'winfixbuf' window's buffer
@@ -2334,7 +2289,7 @@ func Test_normal_gf()
 
   let l:file = tempname()
   call append(0, [l:file])
-  call writefile([], l:file)
+  call writefile([], l:file, 'D')
   " Place the cursor onto the line that has `l:file`
   normal gg
   " Prevent Vim from erroring with "No write since last change @ command
@@ -2353,7 +2308,7 @@ func Test_normal_gf()
   normal gf
   call assert_notequal(l:buffer, bufnr())
 
-  call delete(l:file)
+  set nohidden
 endfunc
 
 " Fail "goto file under the cursor" (using [f, which is the same as `:normal gf`)
@@ -2362,7 +2317,7 @@ func Test_normal_square_bracket_left_f()
 
   let l:file = tempname()
   call append(0, [l:file])
-  call writefile([], l:file)
+  call writefile([], l:file, 'D')
   " Place the cursor onto the line that has `l:file`
   normal gg
   " Prevent Vim from erroring with "No write since last change @ command
@@ -2381,7 +2336,7 @@ func Test_normal_square_bracket_left_f()
   normal [f
   call assert_notequal(l:buffer, bufnr())
 
-  call delete(l:file)
+  set nohidden
 endfunc
 
 " Fail to go to a C macro with [<C-d> if 'winfixbuf' is enabled
@@ -2392,8 +2347,8 @@ func Test_normal_square_bracket_left_ctrl_d()
   call writefile(["min(1, 12);",
         \ '#include "' . l:include_file . '"'
         \ ],
-        \ "main.c")
-  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file)
+        \ "main.c", 'D')
+  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file, 'D')
   edit main.c
   normal ]\<C-d>
 
@@ -2408,9 +2363,6 @@ func Test_normal_square_bracket_left_ctrl_d()
 
   execute "normal [\<C-d>"
   call assert_notequal(l:current, bufnr())
-
-  call delete("main.c")
-  call delete(l:include_file)
 endfunc
 
 " Fail to go to a C macro with ]<C-d> if 'winfixbuf' is enabled
@@ -2421,8 +2373,8 @@ func Test_normal_square_bracket_right_ctrl_d()
   call writefile(["min(1, 12);",
         \ '#include "' . l:include_file . '"'
         \ ],
-        \ "main.c")
-  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file)
+        \ "main.c", 'D')
+  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file, 'D')
   edit main.c
 
   set winfixbuf
@@ -2436,9 +2388,6 @@ func Test_normal_square_bracket_right_ctrl_d()
 
   execute "normal ]\<C-d>"
   call assert_notequal(l:current, bufnr())
-
-  call delete("main.c")
-  call delete(l:include_file)
 endfunc
 
 " Fail to go to a C macro with [<C-i> if 'winfixbuf' is enabled
@@ -2449,8 +2398,8 @@ func Test_normal_square_bracket_left_ctrl_i()
   call writefile(['#include "' . l:include_file . '"',
         \ "min(1, 12);",
         \ ],
-        \ "main.c")
-  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file)
+        \ "main.c", 'D')
+  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file, 'D')
   edit main.c
   " Move to the line with `min(1, 12);` on it"
   normal j
@@ -2473,8 +2422,6 @@ func Test_normal_square_bracket_left_ctrl_i()
   set define&
   set include&
   set path&
-  call delete("main.c")
-  call delete(l:include_file)
 endfunc
 
 " Fail to go to a C macro with ]<C-i> if 'winfixbuf' is enabled
@@ -2485,8 +2432,8 @@ func Test_normal_square_bracket_right_ctrl_i()
   call writefile(["min(1, 12);",
         \ '#include "' . l:include_file . '"'
         \ ],
-        \ "main.c")
-  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file)
+        \ "main.c", 'D')
+  call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file, 'D')
   edit main.c
 
   set winfixbuf
@@ -2508,8 +2455,6 @@ func Test_normal_square_bracket_right_ctrl_i()
   set define&
   set include&
   set path&
-  call delete("main.c")
-  call delete(l:include_file)
 endfunc
 
 " Fail "goto file under the cursor" (using ]f, which is the same as `:normal gf`)
@@ -2518,7 +2463,7 @@ func Test_normal_square_bracket_right_f()
 
   let l:file = tempname()
   call append(0, [l:file])
-  call writefile([], l:file)
+  call writefile([], l:file, 'D')
   " Place the cursor onto the line that has `l:file`
   normal gg
   " Prevent Vim from erroring with "No write since last change @ command
@@ -2537,7 +2482,7 @@ func Test_normal_square_bracket_right_f()
   normal ]f
   call assert_notequal(l:buffer, bufnr())
 
-  call delete(l:file)
+  set nohidden
 endfunc
 
 " Fail to jump to a tag with v<C-]> if 'winfixbuf' is enabled
@@ -2549,9 +2494,9 @@ func Test_normal_v_ctrl_square_bracket_right()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -2562,9 +2507,6 @@ func Test_normal_v_ctrl_square_bracket_right()
   call assert_equal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail to jump to a tag with vg<C-]> if 'winfixbuf' is enabled
@@ -2576,9 +2518,9 @@ func Test_normal_v_g_ctrl_square_bracket_right()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -2589,9 +2531,6 @@ func Test_normal_v_g_ctrl_square_bracket_right()
   call assert_equal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Allow :pedit because, unlike :edit, it uses a separate window
@@ -2616,9 +2555,9 @@ func Test_pop()
         \ "thesame\tXfile\t2;\"\td\tfile:",
         \ "thesame\tXfile\t3;\"\td\tfile:",
         \ ],
-        \ "Xtags")
-  call writefile(["thesame one", "thesame two", "thesame three"], "Xfile")
-  call writefile(["thesame one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["thesame one", "thesame two", "thesame three"], "Xfile", 'D')
+  call writefile(["thesame one"], "Xother", 'D')
   edit Xother
 
   tag thesame
@@ -2634,9 +2573,6 @@ func Test_pop()
   call assert_notequal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail :previous but :previous! is allowed
@@ -2704,7 +2640,7 @@ func Test_pythonx_pyxfile()
         \ "buffer = vim.vars['_previous_buffer']",
         \ "vim.current.buffer = vim.buffers[buffer]",
         \ ],
-        \ "file.py")
+        \ "file.py", 'D')
 
   try
     pyxfile file.py
@@ -2714,7 +2650,6 @@ func Test_pythonx_pyxfile()
 
   call assert_equal(1, l:caught)
 
-  call delete("file.py")
   unlet g:_previous_buffer
 endfunc
 
@@ -2892,9 +2827,9 @@ func Test_tNext()
         \ "thesame\tXfile\t2;\"\td\tfile:",
         \ "thesame\tXfile\t3;\"\td\tfile:",
         \ ],
-        \ "Xtags")
-  call writefile(["thesame one", "thesame two", "thesame three"], "Xfile")
-  call writefile(["thesame one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["thesame one", "thesame two", "thesame three"], "Xfile", 'D')
+  call writefile(["thesame one"], "Xother", 'D')
   edit Xother
 
   tag thesame
@@ -2911,9 +2846,6 @@ func Test_tNext()
   tNext!
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Call :tabdo and choose the next available 'nowinfixbuf' window.
@@ -2971,9 +2903,9 @@ func Test_tag()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -2987,9 +2919,6 @@ func Test_tag()
   call assert_notequal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 
@@ -3002,9 +2931,9 @@ func Test_tfirst()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -3018,9 +2947,6 @@ func Test_tfirst()
   call assert_notequal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail :tjump but :tjump! is allowed
@@ -3032,9 +2958,9 @@ func Test_tjump()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
-  call writefile(["one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
+  call writefile(["one"], "Xother", 'D')
   edit Xother
 
   set winfixbuf
@@ -3048,9 +2974,6 @@ func Test_tjump()
   call assert_notequal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail :tlast but :tlast! is allowed
@@ -3062,8 +2985,8 @@ func Test_tlast()
         \ "one\tXfile\t1",
         \ "three\tXfile\t3",
         \ "two\tXfile\t2"],
-        \ "Xtags")
-  call writefile(["one", "two", "three"], "Xfile")
+        \ "Xtags", 'D')
+  call writefile(["one", "two", "three"], "Xfile", 'D')
   edit Xfile
   tjump one
   edit Xfile
@@ -3079,8 +3002,6 @@ func Test_tlast()
   call assert_equal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
 endfunc
 
 " Fail :tnext but :tnext! is allowed
@@ -3093,9 +3014,9 @@ func Test_tnext()
         \ "thesame\tXfile\t2;\"\td\tfile:",
         \ "thesame\tXfile\t3;\"\td\tfile:",
         \ ],
-        \ "Xtags")
-  call writefile(["thesame one", "thesame two", "thesame three"], "Xfile")
-  call writefile(["thesame one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["thesame one", "thesame two", "thesame three"], "Xfile", 'D')
+  call writefile(["thesame one"], "Xother", 'D')
   edit Xother
 
   tag thesame
@@ -3112,9 +3033,6 @@ func Test_tnext()
   call assert_notequal(l:current, bufnr())
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail :tprevious but :tprevious! is allowed
@@ -3127,9 +3045,9 @@ func Test_tprevious()
         \ "thesame\tXfile\t2;\"\td\tfile:",
         \ "thesame\tXfile\t3;\"\td\tfile:",
         \ ],
-        \ "Xtags")
-  call writefile(["thesame one", "thesame two", "thesame three"], "Xfile")
-  call writefile(["thesame one"], "Xother")
+        \ "Xtags", 'D')
+  call writefile(["thesame one", "thesame two", "thesame three"], "Xfile", 'D')
+  call writefile(["thesame one"], "Xother", 'D')
   edit Xother
 
   tag thesame
@@ -3146,9 +3064,6 @@ func Test_tprevious()
   tprevious!
 
   set tags&
-  call delete("Xtags")
-  call delete("Xfile")
-  call delete("Xother")
 endfunc
 
 " Fail :view but :view! is allowed
@@ -3436,7 +3351,7 @@ func Test_exitfree_no_error()
   END
   call writefile(lines, 'Xwfb_exitfree', 'D')
   call assert_notmatch('E1513:',
-        \ system(GetVimCommandClean() .. ' -X -S Xwfb_exitfree'))
+        \ system(GetVimCommandClean() .. ' --not-a-term -X -S Xwfb_exitfree'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
The test_winfixbuf.vim test takes 15 seconds to run.  After these changes it takes around 1.3 seconds.
The "hidden" option is not cleared at the end of some tests and "--not-a-term" option is not used when
using system() to run a Vim instance.