### PR TITLE
Crash when typing many keys with D- modifier

### DIFF
--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -248,21 +248,25 @@ func Test_map_meta_multibyte()
 endfunc
 
 func Test_map_super_quotes()
-  if has('gui_gtk') || has('gui_gtk3') || has("macos")
-    imap <D-"> foo
-    call feedkeys("Go-\<*D-\">-\<Esc>", "xt")
-    call assert_equal("-foo-", getline('$'))
-    set nomodified
-    iunmap <D-">
+  if "\<D-j>"[-1:] == '>'
+    throw 'Skipped: <D- modifier not supported'
   endif
+
+  imap <D-"> foo
+  call feedkeys("Go-\<*D-\">-\<Esc>", "xt")
+  call assert_equal("-foo-", getline('$'))
+  set nomodified
+  iunmap <D-">
 endfunc
 
 func Test_map_super_multibyte()
-  if has('gui_gtk') || has('gui_gtk3') || has("macos")
-    imap <D-á> foo
-    call assert_match('i  <D-á>\s*foo', execute('imap'))
-    iunmap <D-á>
+  if "\<D-j>"[-1:] == '>'
+    throw 'Skipped: <D- modifier not supported'
   endif
+
+  imap <D-á> foo
+  call assert_match('i  <D-á>\s*foo', execute('imap'))
+  iunmap <D-á>
 endfunc
 
 func Test_abbr_after_line_join()

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -261,6 +261,19 @@ func Test_zz_recording_with_select_mode_utf8_gui()
   call Run_test_recording_with_select_mode_utf8()
 endfunc
 
+func Test_recording_with_super_mod()
+  if "\<D-j>"[-1:] == '>'
+    throw 'Skipped: <D- modifier not supported'
+  endif
+
+  nnoremap <D-j> <Ignore>
+  let s = repeat("\<D-j>", 1000)
+  " This used to crash Vim
+  call feedkeys($'qr{s}q', 'tx')
+  call assert_equal(s, @r)
+  nunmap <D-j>
+endfunc
+
 " Test for executing the last used register (@)
 func Test_last_used_exec_reg()
   " Test for the @: command


### PR DESCRIPTION
Problem:  Crash when typing many keys with D- modifier (after 9.1.0227).
Solution: Don't treat a 0x80 byte inside a special sequence as the start
          of a special sequence.
