### PR TITLE
In `:def` handle storing to vim9 autoload export.

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -4235,6 +4235,7 @@ failed:
  * - Whether the variable is read-only
  * - Whether the variable value is locked
  * - Whether the variable is locked
+ * NOTE: "name" is only used for error messages.
  */
     int
 var_check_permission(dictitem_T *di, char_u *name)

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -381,6 +381,34 @@ def Test_disassemble_import_autoload()
   v9.CheckScriptSuccess(lines)
 enddef
 
+def Test_disassemble_import_autoload_autoload()
+  mkdir('Xauto_auto/autoload', 'pR')
+  var lines =<< trim END
+    vim9script
+    export const val = 11
+  END
+  writefile(lines, 'Xauto_auto/autoload/Xauto_vars_f1.vim')
+
+  lines =<< trim END
+    vim9script
+
+    import autoload './Xauto_auto/autoload/Xauto_vars_f1.vim' as f1
+    def F()
+        f1.val = 13
+    enddef
+    var res = execute('disass F')
+
+    assert_match('<SNR>\d*_F.*' ..
+      'f1.val = 13\_s*' ..
+      '\d PUSHNR 13\_s*' ..
+      '\d SOURCE .*/Xauto_auto/autoload/Xauto_vars_f1.vim\_s*' ..
+      '\d STOREEXPORT val in .*/Xauto_auto/autoload/Xauto_vars_f1.vim\_s*' ..
+      '\d RETURN void',
+      res)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 def s:ScriptFuncStore()
   var localnr = 1
   localnr = 2

--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -166,6 +166,37 @@ def Test_wrong_function_name()
   delfunc g:Define
 enddef
 
+" Check that in a legacy script a :def accesses the correct script variables.
+" Github issue: #14615.
+def Test_access_var_from_legacy_def()
+  # Access a script variable by name WITH "s:" prefix.
+  var lines =<< trim END
+    let s:foo = 'init'
+    let s:xxfoo = 'init'
+    def! AccessVarFromLegacyDef()
+        s:xxfoo = 'CHANGED'
+    enddef
+    call AccessVarFromLegacyDef()
+    call assert_equal('init', s:foo)
+    call assert_equal('CHANGED', s:xxfoo)
+  END
+  v9.CheckScriptSuccess(lines)
+
+  # Access a script variable by name WITHOUT "s:" prefix;
+  # previously this accessed "foo" and not "xxfoo"
+  lines =<< trim END
+    let s:foo = 'init'
+    let s:xxfoo = 'init'
+    def! AccessVarFromLegacyDef()
+        xxfoo = 'CHANGED'
+    enddef
+    call AccessVarFromLegacyDef()
+    call assert_equal('init', s:foo)
+    call assert_equal('CHANGED', s:xxfoo)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 def Test_listing_function_error()
   var lines =<< trim END
       var filler = 123

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -780,6 +780,7 @@ typedef enum {
     dest_vimvar,
     dest_class_member,
     dest_script,
+    dest_script_v9,
     dest_reg,
     dest_expr,
 } assign_dest_T;

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1367,6 +1367,7 @@ generate_loadvar(cctx_T *cctx, lhs_T *lhs)
 	    generate_LOAD(cctx, ISN_LOADT, 0, name + 2, type);
 	    break;
 	case dest_script:
+	case dest_script_v9:
 	    res = compile_load_scriptvar(cctx,
 				  name + (name[1] == ':' ? 2 : 0), NULL, NULL);
 	    break;
@@ -1838,7 +1839,8 @@ compile_lhs(
 			return FAIL;
 		    }
 
-		    lhs->lhs_dest = dest_script;
+		    lhs->lhs_dest = current_script_is_vim9()
+			      ? dest_script_v9 : dest_script;
 
 		    // existing script-local variables should have a type
 		    lhs->lhs_scriptvar_sid = current_sctx.sc_sid;
@@ -3026,8 +3028,9 @@ compile_assignment(
 	else
 	{
 	    if (is_decl && cmdidx == CMD_const && (lhs.lhs_dest == dest_script
-						|| lhs.lhs_dest == dest_global
-						|| lhs.lhs_dest == dest_local))
+					    || lhs.lhs_dest == dest_script_v9
+					    || lhs.lhs_dest == dest_global
+					    || lhs.lhs_dest == dest_local))
 		// ":const var": lock the value, but not referenced variables
 		generate_LOCKCONST(cctx);
 

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -2394,6 +2394,7 @@ generate_store_var(
 	case dest_vimvar:
 	    return generate_STORE(cctx, ISN_STOREV, vimvaridx, NULL);
 	case dest_script:
+	case dest_script_v9:
 	    {
 		int	    scriptvar_idx = lhs->lhs_scriptvar_idx;
 		int	    scriptvar_sid = lhs->lhs_scriptvar_sid;
@@ -2401,10 +2402,14 @@ generate_store_var(
 		{
 		    isntype_T   isn_type = ISN_STORES;
 
+		    // If "sn_import_autoload", generate ISN_STOREEXPORT (not
+		    // ISN_STORES) if destination is in a vim9script or if
+		    // there is no "sn_autoload_prefix".
 		    if (SCRIPT_ID_VALID(scriptvar_sid)
 			     && SCRIPT_ITEM(scriptvar_sid)->sn_import_autoload
-			     && SCRIPT_ITEM(scriptvar_sid)->sn_autoload_prefix
-								       == NULL)
+			     && ((SCRIPT_ITEM(scriptvar_sid)
+						  ->sn_autoload_prefix == NULL)
+				|| lhs->lhs_dest == dest_script_v9))
 		    {
 			// "import autoload './dir/script.vim'" - load script
 			// first


### PR DESCRIPTION
Fix #14606.

Also fix issue with :def in legacy script accessing the wrong variables.

Problem occurs when `import autoload ./.../autoload/...`. The `autoload` in the specified path causes the use of an autoload_prefix which combines with the `import autoload` to create trouble.

In `generate_store_var()` `case dest_script` use `ISN_STOREEXPORT`, when needed, instead of `ISN_STORES`. When executing `ISN_STOREEXPORT`, check for autoload_prefix.

**Reviewers** - there may be better ways to handle this problem.