### PR TITLE
Correct version number in Windows Registry

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -225,7 +225,7 @@ Page custom SetCustom ValidateCustom
 # Version resources
 
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "Vim"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "Vim Developers"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "The Vim Project"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" "Vim"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright (C) 1996"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "Vi Improved - A Text Editor"

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1321,6 +1321,10 @@ $(OUTDIR):
 
 CFLAGS_INST = /nologo /O2 -DNDEBUG -DWIN32 -DWINVER=$(WINVER) -D_WIN32_WINNT=$(WINVER) $(CFLAGS_DEPR)
 
+!IFDEF PATCHLEVEL
+CFLAGS_INST=	$(CFLAGS_INST) -DVIM_VERSION_PATCHLEVEL=$(PATCHLEVEL)
+!ENDIF
+
 install.exe: dosinst.c dosinst.h version.h
 	$(CC) $(CFLAGS_INST) dosinst.c kernel32.lib shell32.lib \
 		user32.lib ole32.lib advapi32.lib uuid.lib \

--- a/src/dosinst.c
+++ b/src/dosinst.c
@@ -1663,7 +1663,7 @@ install_registry(void)
 	uninstall_string,
 	icon_string,
 	version_string,
-	"Bram Moolenaar et al.");
+	"The Vim Project");
     if (ERROR_SUCCESS != lRet)
 	return FAIL;
 


### PR DESCRIPTION
Fixed display of version number with patch level in Windows register.
issue #14629  

Other:
changed contents of “Publisher” and “CompanyName” fields to “The Vim Project”
for uniformity.