### PR TITLE
Formatting text wrong when 'breakindent' is set

### DIFF
--- a/src/testdir/test_textformat.vim
+++ b/src/testdir/test_textformat.vim
@@ -1312,4 +1312,28 @@ func Test_textwdith_overflow()
   bw!
 endfunc
 
+func Test_breakindent_reformat()
+  " Make sure textformatting uses the full width
+  " of the textwidth and does not consider the indent
+  " from breakindent into account when calculating the
+  " line length. Should break at tw 78 and not at 70
+  CheckOption breakindent
+  new
+  80vnew
+  39vnew
+  setl ai breakindent tw=78
+  let lorem = [
+  \  '	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam luctus',
+  \  '	lectus sodales, dictum augue vel, molestie augue. Duis sit amet',
+  \  '	rhoncus justo. Nullam posuere risus semper magna commodo scelerisque.',
+  \  '	Duis et venenatis sem. In rhoncus augue sed tempor mattis. Mauris id',
+  \  '	aliquet odio.']
+  call setline(1, lorem)
+  norm! gqap
+  call assert_equal(lorem, getline(1, '$'))
+  bw!
+  bw!
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -59,9 +59,11 @@ internal_format(
     int		safe_tw = trim_to_int(8 * (vimlong_T)textwidth);
 #ifdef FEAT_LINEBREAK
     int		has_lbr = curwin->w_p_lbr;
+    int		has_bri = curwin->w_p_bri;
 
     // make sure win_lbr_chartabsize() counts correctly
     curwin->w_p_lbr = FALSE;
+    curwin->w_p_bri = FALSE;
 #endif
 
     // When 'ai' is off we don't want a space under the cursor to be
@@ -475,6 +477,7 @@ internal_format(
 
 #ifdef FEAT_LINEBREAK
     curwin->w_p_lbr = has_lbr;
+    curwin->w_p_bri = has_bri;
 #endif
     if (!format_only && haveto_redraw)
     {


### PR DESCRIPTION
Problem:  formatting text wrong when 'breakindent' is set
          (Gary Johnson)
Solution: temporarily disable breakindent option when formatting text,
          so that the breakindent is not wrongly taken into account for
          the line length

fixes: #14630