### PR TITLE
CI: ubuntu-toolchain-r/test repository will be removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
       - name: Install gcc-${{ env.GCC_VER }}
         if:  matrix.compiler == 'gcc'
         run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -y
           sudo apt-get install -y gcc-${{ env.GCC_VER }}:${{ matrix.architecture }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VER }} 100
           sudo update-alternatives --set gcc /usr/bin/gcc-${{ env.GCC_VER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
       - name: Install gcc-${{ env.GCC_VER }}
         if:  matrix.compiler == 'gcc'
         run: |
+          # ubuntu-toolchain-r/test PPA for gcc-13 compiler
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update -y
           sudo apt-get install -y gcc-${{ env.GCC_VER }}:${{ matrix.architecture }}


### PR DESCRIPTION
The `ubuntu-toolchain-r/test` PPA will be removed from Ubuntu images. The images rollout process will start on May 6 and take 3-4 days.

**Mitigation ways**

The repository can still be added manually in runtime by calling to following commands:
```
sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
sudo apt-get update -y
```
ref: https://github.com/actions/runner-images/issues/9679