### PR TITLE
fix: wrong botline in BufEnter

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -4679,4 +4679,16 @@ func Test_SwapExists_set_other_buf_modified()
   bwipe!
 endfunc
 
+func Test_BufEnter_botline()
+  set hidden
+  call writefile(range(10), 'Xxx1', 'D')
+  call writefile(range(20), 'Xxx2', 'D')
+  edit Xxx1
+  edit Xxx2
+  au BufEnter Xxx1 call assert_true(line('w$') > 1)
+  edit Xxx1
+  au! BufEnter Xxx1
+  set hidden&vim
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim.h
+++ b/src/vim.h
@@ -656,8 +656,8 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define VALID_VIRTCOL	0x04	// w_virtcol (file col) is valid
 #define VALID_CHEIGHT	0x08	// w_cline_height and w_cline_folded valid
 #define VALID_CROW	0x10	// w_cline_row is valid
-#define VALID_BOTLINE	0x20	// w_botine and w_empty_rows are valid
-#define VALID_BOTLINE_AP 0x40	// w_botine is approximated
+#define VALID_BOTLINE	0x20	// w_botline and w_empty_rows are valid
+#define VALID_BOTLINE_AP 0x40	// w_botline is approximated
 #define VALID_TOPLINE	0x80	// w_topline is valid (for cursor position)
 
 // Values for w_popup_flags.

--- a/src/window.c
+++ b/src/window.c
@@ -2475,6 +2475,7 @@ win_init_empty(win_T *wp)
     wp->w_topfill = 0;
 #endif
     wp->w_botline = 2;
+    wp->w_valid = 0;
 #if defined(FEAT_SYN_HL) || defined(FEAT_SPELL)
     wp->w_s = &wp->w_buffer->b_s;
 #endif


### PR DESCRIPTION
Problem:
When `:edit`ing an existing buffer, `line('w$')` returns a wrong result.

`do_ecmd` reinitializes the current the current window (`curwin_init()`) whose `w_valid` may have `VALID_BOTLINE`. Resetting `w_botline` without marking it as invalid makes subsequent `validate_botline()` no-op, resulting in wrong `line('w$')` value.

Solution:
Reset `w_valid`.