### PR TITLE
1-second delay after Test_BufEnter_botline()

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -4687,6 +4687,9 @@ func Test_BufEnter_botline()
   edit Xxx2
   au BufEnter Xxx1 call assert_true(line('w$') > 1)
   edit Xxx1
+
+  bwipe! Xxx1
+  bwipe! Xxx2
   au! BufEnter Xxx1
   set hidden&vim
 endfunc


### PR DESCRIPTION
Problem:  1-second delay after Test_BufEnter_botline().
Solution: Wipe the created buffers.
