### PR TITLE
Refactor to remove STRLEN() part 5

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -2078,12 +2078,12 @@ vim_regsub_both(
 	{
 	    if (eval_result[nested] != NULL)
 	    {
-		int len = (int)STRLEN(eval_result[nested]);
+		int eval_len = (int)STRLEN(eval_result[nested]);
 
-		if (len < destlen)
+		if (eval_len < destlen)
 		{
 		    STRCPY(dest, eval_result[nested]);
-		    dst += len;
+		    dst += eval_len;
 		    VIM_CLEAR(eval_result[nested]);
 		}
 	    }

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -2615,7 +2615,7 @@ reg_submatch(int no)
 		    s = reg_getline_submatch(lnum);
 		    if (round == 2)
 			STRCPY(retval + len, s);
-		    len = (int)reg_getline_submatchlen(lnum);
+		    len += (int)reg_getline_submatchlen(lnum);
 		    if (round == 2)
 			retval[len] = '\n';
 		    ++len;

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -3414,7 +3414,7 @@ regmatch(
 		{
 		    colnr_T pos_col = pos->lnum == rex.lnum + rex.reg_firstlnum
 							  && pos->col == MAXCOL
-				      ? reg_getline_submatch_len(pos->lnum - rex.reg_firstlnum)
+				      ? reg_getline_len(pos->lnum - rex.reg_firstlnum)
 				      : pos->col;
 
 		    if ((pos->lnum == rex.lnum + rex.reg_firstlnum
@@ -4702,7 +4702,7 @@ regmatch(
 				// right.
 				if (rex.line == NULL)
 				    break;
-				rex.input = rex.line + reg_getline_submatch_len(rex.lnum);
+				rex.input = rex.line + reg_getline_len(rex.lnum);
 				fast_breakcheck();
 			    }
 			    else

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -3414,7 +3414,7 @@ regmatch(
 		{
 		    colnr_T pos_col = pos->lnum == rex.lnum + rex.reg_firstlnum
 							  && pos->col == MAXCOL
-				      ? reg_getlinelen(pos->lnum - rex.reg_firstlnum)
+				      ? reg_getline_submatch_len(pos->lnum - rex.reg_firstlnum)
 				      : pos->col;
 
 		    if ((pos->lnum == rex.lnum + rex.reg_firstlnum
@@ -4702,7 +4702,7 @@ regmatch(
 				// right.
 				if (rex.line == NULL)
 				    break;
-				rex.input = rex.line + reg_getlinelen(rex.lnum);
+				rex.input = rex.line + reg_getline_submatch_len(rex.lnum);
 				fast_breakcheck();
 			    }
 			    else

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -2570,11 +2570,14 @@ bt_regcomp(char_u *expr, int re_flags)
 	    len = 0;
 	    for (; scan != NULL; scan = regnext(scan))
 	    {
-		scanlen = STRLEN(OPERAND(scan));
-		if (OP(scan) == EXACTLY && scanlen >= (size_t)len)
+		if (OP(scan) == EXACTLY)
 		{
-		    longest = OPERAND(scan);
-		    len = (int)scanlen;
+		    scanlen = STRLEN(OPERAND(scan));
+		    if (scanlen >= (size_t)len)
+		    {
+			longest = OPERAND(scan);
+			len = (int)scanlen;
+		    }
 		}
 	    }
 	    r->regmust = longest;

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -2564,14 +2564,19 @@ bt_regcomp(char_u *expr, int re_flags)
 	if ((flags & SPSTART || OP(scan) == BOW || OP(scan) == EOW)
 							  && !(flags & HASNL))
 	{
+	    size_t  scanlen;
+
 	    longest = NULL;
 	    len = 0;
 	    for (; scan != NULL; scan = regnext(scan))
-		if (OP(scan) == EXACTLY && STRLEN(OPERAND(scan)) >= (size_t)len)
+	    {
+		scanlen = STRLEN(OPERAND(scan));
+		if (OP(scan) == EXACTLY && scanlen >= (size_t)len)
 		{
 		    longest = OPERAND(scan);
-		    len = (int)STRLEN(OPERAND(scan));
+		    len = (int)scanlen;
 		}
+	    }
 	    r->regmust = longest;
 	    r->regmlen = len;
 	}
@@ -3406,8 +3411,7 @@ regmatch(
 		{
 		    colnr_T pos_col = pos->lnum == rex.lnum + rex.reg_firstlnum
 							  && pos->col == MAXCOL
-				      ? (colnr_T)STRLEN(reg_getline(
-						pos->lnum - rex.reg_firstlnum))
+				      ? reg_getlinelen(pos->lnum - rex.reg_firstlnum)
 				      : pos->col;
 
 		    if ((pos->lnum == rex.lnum + rex.reg_firstlnum
@@ -4695,7 +4699,7 @@ regmatch(
 				// right.
 				if (rex.line == NULL)
 				    break;
-				rex.input = rex.line + STRLEN(rex.line);
+				rex.input = rex.line + reg_getlinelen(rex.lnum);
 				fast_breakcheck();
 			    }
 			    else
@@ -5249,8 +5253,10 @@ regprop(char_u *op)
 {
     char	    *p;
     static char	    buf[50];
+    static size_t   buflen = 0;
 
     STRCPY(buf, ":");
+    buflen = 1;
 
     switch ((int) OP(op))
     {
@@ -5491,7 +5497,7 @@ regprop(char_u *op)
       case MOPEN + 7:
       case MOPEN + 8:
       case MOPEN + 9:
-	sprintf(buf + STRLEN(buf), "MOPEN%d", OP(op) - MOPEN);
+	buflen += sprintf(buf + buflen, "MOPEN%d", OP(op) - MOPEN);
 	p = NULL;
 	break;
       case MCLOSE + 0:
@@ -5506,7 +5512,7 @@ regprop(char_u *op)
       case MCLOSE + 7:
       case MCLOSE + 8:
       case MCLOSE + 9:
-	sprintf(buf + STRLEN(buf), "MCLOSE%d", OP(op) - MCLOSE);
+	buflen += sprintf(buf + buflen, "MCLOSE%d", OP(op) - MCLOSE);
 	p = NULL;
 	break;
       case BACKREF + 1:
@@ -5518,7 +5524,7 @@ regprop(char_u *op)
       case BACKREF + 7:
       case BACKREF + 8:
       case BACKREF + 9:
-	sprintf(buf + STRLEN(buf), "BACKREF%d", OP(op) - BACKREF);
+	buflen += sprintf(buf + buflen, "BACKREF%d", OP(op) - BACKREF);
 	p = NULL;
 	break;
       case NOPEN:
@@ -5537,7 +5543,7 @@ regprop(char_u *op)
       case ZOPEN + 7:
       case ZOPEN + 8:
       case ZOPEN + 9:
-	sprintf(buf + STRLEN(buf), "ZOPEN%d", OP(op) - ZOPEN);
+	buflen += sprintf(buf + buflen, "ZOPEN%d", OP(op) - ZOPEN);
 	p = NULL;
 	break;
       case ZCLOSE + 1:
@@ -5549,7 +5555,7 @@ regprop(char_u *op)
       case ZCLOSE + 7:
       case ZCLOSE + 8:
       case ZCLOSE + 9:
-	sprintf(buf + STRLEN(buf), "ZCLOSE%d", OP(op) - ZCLOSE);
+	buflen += sprintf(buf + buflen, "ZCLOSE%d", OP(op) - ZCLOSE);
 	p = NULL;
 	break;
       case ZREF + 1:
@@ -5561,7 +5567,7 @@ regprop(char_u *op)
       case ZREF + 7:
       case ZREF + 8:
       case ZREF + 9:
-	sprintf(buf + STRLEN(buf), "ZREF%d", OP(op) - ZREF);
+	bulen += sprintf(buf + buflen, "ZREF%d", OP(op) - ZREF);
 	p = NULL;
 	break;
 #endif
@@ -5602,7 +5608,7 @@ regprop(char_u *op)
       case BRACE_COMPLEX + 7:
       case BRACE_COMPLEX + 8:
       case BRACE_COMPLEX + 9:
-	sprintf(buf + STRLEN(buf), "BRACE_COMPLEX%d", OP(op) - BRACE_COMPLEX);
+	buflen += sprintf(buf + buflen, "BRACE_COMPLEX%d", OP(op) - BRACE_COMPLEX);
 	p = NULL;
 	break;
       case MULTIBYTECODE:
@@ -5612,12 +5618,12 @@ regprop(char_u *op)
 	p = "NEWL";
 	break;
       default:
-	sprintf(buf + STRLEN(buf), "corrupt %d", OP(op));
+	buflen += sprintf(buf + buflen, "corrupt %d", OP(op));
 	p = NULL;
 	break;
     }
     if (p != NULL)
-	STRCAT(buf, p);
+	STRCPY(buf + buflen, p);
     return (char_u *)buf;
 }
 #endif	    // DEBUG

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -5387,7 +5387,7 @@ recursive_regmatch(
 		    rex.input = rex.line;
 		}
 		else
-		    rex.input = rex.line + reg_getline_submatch_len(rex.lnum);
+		    rex.input = rex.line + reg_getline_len(rex.lnum);
 	    }
 	    if ((int)(rex.input - rex.line) >= state->val)
 	    {
@@ -6937,7 +6937,7 @@ nfa_regmatch(
 		{
 		    colnr_T pos_col = pos->lnum == rex.lnum + rex.reg_firstlnum
 							  && pos->col == MAXCOL
-				      ? reg_getline_submatch_len(pos->lnum - rex.reg_firstlnum)
+				      ? reg_getline_len(pos->lnum - rex.reg_firstlnum)
 				      : pos->col;
 
 		    result = (pos->lnum == rex.lnum + rex.reg_firstlnum

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -5387,7 +5387,7 @@ recursive_regmatch(
 		    rex.input = rex.line;
 		}
 		else
-		    rex.input = rex.line + reg_getlinelen(rex.lnum);
+		    rex.input = rex.line + reg_getline_submatch_len(rex.lnum);
 	    }
 	    if ((int)(rex.input - rex.line) >= state->val)
 	    {
@@ -6937,7 +6937,7 @@ nfa_regmatch(
 		{
 		    colnr_T pos_col = pos->lnum == rex.lnum + rex.reg_firstlnum
 							  && pos->col == MAXCOL
-				      ? reg_getlinelen(pos->lnum - rex.reg_firstlnum)
+				      ? reg_getline_submatch_len(pos->lnum - rex.reg_firstlnum)
 				      : pos->col;
 
 		    result = (pos->lnum == rex.lnum + rex.reg_firstlnum

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -5387,7 +5387,7 @@ recursive_regmatch(
 		    rex.input = rex.line;
 		}
 		else
-		    rex.input = rex.line + STRLEN(rex.line);
+		    rex.input = rex.line + reg_getlinelen(rex.lnum);
 	    }
 	    if ((int)(rex.input - rex.line) >= state->val)
 	    {
@@ -6937,8 +6937,7 @@ nfa_regmatch(
 		{
 		    colnr_T pos_col = pos->lnum == rex.lnum + rex.reg_firstlnum
 							  && pos->col == MAXCOL
-				      ? (colnr_T)STRLEN(reg_getline(
-						pos->lnum - rex.reg_firstlnum))
+				      ? reg_getlinelen(pos->lnum - rex.reg_firstlnum)
 				      : pos->col;
 
 		    result = (pos->lnum == rex.lnum + rex.reg_firstlnum


### PR DESCRIPTION
Refactor regexp.c, regexp_bt.c and regexp_nfa.c to remove STRLEN() calls.

At the same time improve the efficiency of character class lookups in function get_char_class().

My measurements on an empty buffer show no difference in the number of comparisons (~100). This is because my start up files use '[[:alnum:]]' almost exclusively. However, each comparison originally included a call to STRLEN() and STRNCMP(). After the change each comparison only uses STRNCMP().

Cheers
John