### PR TITLE
Count just enough lines for half page scrolling

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1781,7 +1781,7 @@ win_update(win_T *wp)
 	    if (j < wp->w_height - 2)		// not too far off
 	    {
 		i = plines_m_win(wp, wp->w_topline, wp->w_lines[0].wl_lnum - 1,
-									 TRUE);
+								wp->w_height);
 #ifdef FEAT_DIFF
 		// insert extra lines for previously invisible filler lines
 		if (wp->w_lines[0].wl_lnum != wp->w_topline)

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -497,12 +497,17 @@ plines_win_col(win_T *wp, linenr_T lnum, long column)
     return lines;
 }
 
+/*
+ * Return number of window lines the physical line range from "first" until
+ * "last" will occupy in window "wp". Takes into account folding, 'wrap',
+ * topfill and filler lines beyond the end of the buffer. Limit to "max" lines.
+ */
     int
-plines_m_win(win_T *wp, linenr_T first, linenr_T last, int limit_winheight)
+plines_m_win(win_T *wp, linenr_T first, linenr_T last, int max)
 {
     int		count = 0;
 
-    while (first <= last && (!limit_winheight || count < wp->w_height))
+    while (first <= last && count < max)
     {
 #ifdef FEAT_FOLDING
 	int	x;
@@ -531,9 +536,7 @@ plines_m_win(win_T *wp, linenr_T first, linenr_T last, int limit_winheight)
     if (first == wp->w_buffer->b_ml.ml_line_count + 1)
 	count += diff_check_fill(wp, first);
 #endif
-    if (limit_winheight && count > wp->w_height)
-	return wp->w_height;
-    return (count);
+    return MIN(max, count);
 }
 
     int

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -654,8 +654,8 @@ popup_show_curline(win_T *wp)
 	    wp->w_topline = wp->w_buffer->b_ml.ml_line_count;
 	while (wp->w_topline < wp->w_cursor.lnum
 		&& wp->w_topline < wp->w_buffer->b_ml.ml_line_count
-		&& plines_m_win(wp, wp->w_topline, wp->w_cursor.lnum, FALSE)
-								> wp->w_height)
+		&& plines_m_win(wp, wp->w_topline, wp->w_cursor.lnum,
+					    wp->w_height + 1) > wp->w_height)
 	    ++wp->w_topline;
     }
 

--- a/src/proto/misc1.pro
+++ b/src/proto/misc1.pro
@@ -7,7 +7,7 @@ int plines_nofill(linenr_T lnum);
 int plines_win_nofill(win_T *wp, linenr_T lnum, int limit_winheight);
 int plines_win_nofold(win_T *wp, linenr_T lnum);
 int plines_win_col(win_T *wp, linenr_T lnum, long column);
-int plines_m_win(win_T *wp, linenr_T first, linenr_T last, int limit_winheight);
+int plines_m_win(win_T *wp, linenr_T first, linenr_T last, int max);
 int gchar_pos(pos_T *pos);
 int gchar_cursor(void);
 void pchar_cursor(int c);


### PR DESCRIPTION
Problem:  Calculating line height for unnecessary amount of lines with
          half-page scrolling.
Solution: Replace "limit_winheight" argument with higher resolution
          "max" argument to which to limit the calculated line height
          in plines_m_win() to.

Fix #14650