### PR TITLE
runtime(jq): fix undefined variable s:save_cpoptions in ftplugin

### DIFF
--- a/runtime/ftplugin/jq.vim
+++ b/runtime/ftplugin/jq.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Language:	jq
 " Maintainer:	Vito <vito.blog@gmail.com>
-" Last Change:	2024 Apr 17
+" Last Change:	2024 Apr 29
 " Upstream: https://github.com/vito-c/jq.vim
 
 if exists('b:did_ftplugin')
@@ -13,6 +13,3 @@ let b:undo_ftplugin = 'setl commentstring<'
 
 setlocal commentstring=#%s
 compiler jq
-
-let &cpoptions = s:save_cpoptions
-unlet s:save_cpoptions


### PR DESCRIPTION
This PR fixes an issue about undefined variable in the jq ftplugin file. It is recommended not to setting 'cpo' if unnecessary (https://github.com/vim/vim/pull/14619#discussion_r1575249285), I removed the resetting lines instead of adding `let s:save_cpooptions = &cpooptions` and `set cpo&vim`.
