### PR TITLE
filetype: Kbuild files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1356,6 +1356,7 @@ au BufNewFile,BufRead .mailcap,mailcap		setf mailcap
 
 " Makefile
 au BufNewFile,BufRead *[mM]akefile,*.mk,*.mak,*.dsp setf make
+au BufNewFile,BufRead Kbuild setf make
 
 " MakeIndex
 au BufNewFile,BufRead *.ist,*.mst		setf ist

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -417,7 +417,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     mail: ['snd.123', '.letter', '.letter.123', '.followup', '.article', '.article.123', 'pico.123', 'mutt-xx-xxx', 'muttng-xx-xxx', 'ae123.txt', 'file.eml', 'reportbug-file'],
     mailaliases: ['/etc/mail/aliases', '/etc/aliases', 'any/etc/aliases', 'any/etc/mail/aliases'],
     mailcap: ['.mailcap', 'mailcap'],
-    make: ['file.mk', 'file.mak', 'file.dsp', 'makefile', 'Makefile', 'makefile-file', 'Makefile-file', 'some-makefile', 'some-Makefile'],
+    make: ['file.mk', 'file.mak', 'file.dsp', 'makefile', 'Makefile', 'makefile-file', 'Makefile-file', 'some-makefile', 'some-Makefile', 'Kbuild'],
     mallard: ['file.page'],
     man: ['file.man'],
     manconf: ['/etc/man.conf', 'man.config', 'any/etc/man.conf'],


### PR DESCRIPTION
Problem:  Kbuild files are not recognized.

Solution: Detect Kbuild files as make files.