### PR TITLE
ftplugin: sh: don't assume MANPAGER makes sense

### DIFF
--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -46,11 +46,11 @@ endif
 
 if get(b:, "is_bash", 0)
   if !has("gui_running") && executable("less")
-    command! -buffer -nargs=1 ShKeywordPrg silent exe '!bash -c "{ help "<args>" 2>/dev/null || man "<args>"; } | LESS= less"' | redraw!
+    command! -buffer -nargs=1 ShKeywordPrg silent exe '!bash -c "{ help "<args>" 2>/dev/null || MANPAGER= man "<args>"; } | LESS= less"' | redraw!
   elseif has("terminal")
     command! -buffer -nargs=1 ShKeywordPrg silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
   else
-    command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || man "<args>"')
+    command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || MANPAGER= man "<args>"')
   endif
   setlocal keywordprg=:ShKeywordPrg
   let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer ShKeywordPrg"

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -24,7 +24,7 @@ if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
   elseif has('terminal')
     command! -buffer -nargs=1 ZshKeywordPrg silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
   else
-    command! -buffer -nargs=1 ZshKeywordPrg echo system('zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
+    command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
   endif
   if !exists('current_compiler')
     compiler zsh


### PR DESCRIPTION
Say you use Vim and set MANPAGER='vim -M +MANPAGER --not-a-term -'; then :ShKeywordPrg (or K) will crap out and spew terminal garbage into less when bash's "help" fails. This was introduced by 2f25e40b1 (runtime: configure keywordpg for some file types (#5566), 2023-08-23) and may be present in other files touched by that commit.

Make the "man" invocation sensible by unsetting MANPAGER in the environment.