### PR TITLE
cursor() and getregion() don't handle v:maxcol well

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3840,8 +3840,9 @@ set_cursorpos(typval_T *argvars, typval_T *rettv, int charcol)
 	return;		// type error; errmsg already given
     if (lnum > 0)
 	curwin->w_cursor.lnum = lnum;
-    if (col > 0)
-	curwin->w_cursor.col = col - 1;
+    if (col != MAXCOL && --col < 0)
+	col = 0;
+    curwin->w_cursor.col = col;
     curwin->w_cursor.coladd = coladd;
 
     // Make sure the cursor is in a valid position.
@@ -5554,17 +5555,22 @@ f_getregion(typval_T *argvars, typval_T *rettv)
 	semsg(_(e_invalid_line_number_nr), p1.lnum);
 	return;
     }
-    if (p1.col < 1 || p1.col > ml_get_buf_len(findbuf, p1.lnum) + 1)
+    if (p1.col == MAXCOL)
+	p1.col = ml_get_buf_len(findbuf, p1.lnum) + 1;
+    else if (p1.col < 1 || p1.col > ml_get_buf_len(findbuf, p1.lnum) + 1)
     {
 	semsg(_(e_invalid_column_number_nr), p1.col);
 	return;
     }
+
     if (p2.lnum < 1 || p2.lnum > findbuf->b_ml.ml_line_count)
     {
 	semsg(_(e_invalid_line_number_nr), p2.lnum);
 	return;
     }
-    if (p2.col < 1 || p2.col > ml_get_buf_len(findbuf, p2.lnum) + 1)
+    if (p2.col == MAXCOL)
+	p2.col = ml_get_buf_len(findbuf, p2.lnum) + 1;
+    else if (p2.col < 1 || p2.col > ml_get_buf_len(findbuf, p2.lnum) + 1)
     {
 	semsg(_(e_invalid_column_number_nr), p2.col);
 	return;

--- a/src/testdir/test_virtualedit.vim
+++ b/src/testdir/test_virtualedit.vim
@@ -709,5 +709,27 @@ func Test_virtualedit_replace_after_tab()
   bwipe!
 endfunc
 
+" Test that setpos('.') and cursor() behave the same for v:maxcol
+func Test_virtualedit_set_cursor_pos_maxcol()
+  new
+  set virtualedit=all
+
+  call setline(1, 'foobar')
+  exe "normal! V\<Esc>"
+  call assert_equal([0, 1, 1, 0], getpos("'<"))
+  call assert_equal([0, 1, v:maxcol, 0], getpos("'>"))
+  let pos = getpos("'>")
+
+  call cursor(1, 1)
+  call setpos('.', pos)
+  call assert_equal([0, 1, 7, 0], getpos('.'))
+
+  call cursor(1, 1)
+  call cursor(pos[1:])
+  call assert_equal([0, 1, 7, 0], getpos('.'))
+
+  set virtualedit&
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1698,6 +1698,9 @@ func Test_visual_getregion()
           \ "'a"->getpos()->getregion(getpos("'a"), {'type': 'V' }))
     call assert_equal(['one', 'two'],
           \ "."->getpos()->getregion(getpos("'a"), {'type': "\<c-v>" }))
+    call feedkeys("\<ESC>jVj\<ESC>", 'tx')
+    call assert_equal(['two', 'three'], getregion(getpos("'<"), getpos("'>")))
+    call assert_equal(['two', 'three'], getregion(getpos("'>"), getpos("'<")))
 
     #" Using List
     call cursor(1, 1)


### PR DESCRIPTION
Problem:  cursor() and getregion() don't handle v:maxcol well.
Solution: Add special handling for v:maxcol like setpos() does.
