### PR TITLE
Add file type detection for Inko

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1103,6 +1103,9 @@ au BufNewFile,BufRead *.ini,*.INI		setf dosini
 " SysV Inittab
 au BufNewFile,BufRead inittab			setf inittab
 
+" Inko
+au BufNewFile,BufRead *.inko			setf inko
+
 " Inno Setup
 au BufNewFile,BufRead *.iss			setf iss
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -344,6 +344,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     inform: ['file.inf', 'file.INF'],
     initng: ['/etc/initng/any/file.i', 'file.ii', 'any/etc/initng/any/file.i'],
     inittab: ['inittab'],
+    inko: ['file.inko'],
     ipfilter: ['ipf.conf', 'ipf6.conf', 'ipf.rules'],
     iss: ['file.iss'],
     ist: ['file.ist', 'file.mst'],


### PR DESCRIPTION
This adds file type detection for [Inko](https://inko-lang.org/).

While there's also a Vim plugin that does this (https://github.com/inko-lang/inko.vim), it includes more logic (e.g. indent and syntax rules). Some of that (most notably the syntax) might change such that upstreaming and maintaining it in Vim itself is a bit painful, hence this PR only includes the file type detection logic. 