### PR TITLE
Problem: 'viewdir' not respecting $XDG_CONFIG_HOME

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.1.  Last change: 2024 Mar 29
+*options.txt*	For Vim version 9.1.  Last change: 2024 May 02
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -6683,7 +6683,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 				*'runtimepath'* *'rtp'* *vimfiles*
 'runtimepath' 'rtp'	string	(default:
-					Unix:  "$HOME/.vim,
+					Unix:  "$HOME/.vim or
+						$XDG_CONFIG_HOME/vim,
 						$VIM/vimfiles,
 						$VIMRUNTIME,
 						$VIM/vimfiles/after,
@@ -6734,6 +6735,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  tutor/	files for vimtutor |tutor|
 
 	And any other file searched for with the |:runtime| command.
+
+	For $XDG_CONFIG_HOME see |xdg-base-dir|.
 
 	The defaults for most systems are setup to search five locations:
 	1. In your home directory, for your personal preferences.
@@ -8986,13 +8989,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'viewdir'* *'vdir'*
 'viewdir' 'vdir'	string	(default for Amiga: "home:vimfiles/view",
 					 for Win32: "$HOME/vimfiles/view",
-					 for Unix: "$HOME/.vim/view",
+					 for Unix: "$HOME/.vim/view" or
+					           "$XDG_CONFIG_HOME/vim/view"
 					 for macOS: "$VIM/vimfiles/view",
 					 for VMS: "sys$login:vimfiles/view")
 			global
 			{not available when compiled without the |+mksession|
 			feature}
 	Name of the directory where to store files for |:mkview|.
+	For $XDG_CONFIG_HOME see |xdg-base-dir|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1,4 +1,4 @@
-*starting.txt*  For Vim version 9.1.  Last change: 2024 Apr 21
+*starting.txt*  For Vim version 9.1.  Last change: 2024 May 02
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1119,8 +1119,8 @@ feature backward compatible). However, if you want to migrate to use
 and `~/.vim/vimrc` file.
 
 							*xdg-runtime*
-When the |xdg-vimrc| is used the |'runtimepath'| will be modified accordingly
-to respect the |xdg-base-dir|: >
+When the |xdg-vimrc| is used the 'runtimepath' and 'packpath' options will be
+modified accordingly to respect the |xdg-base-dir|: >
 
     "$XDG_CONFIG_HOME/vim,$VIMRUNTIME,/after,$XDG_CONFIG_HOME/vim/after"
 <

--- a/src/option.c
+++ b/src/option.c
@@ -417,6 +417,14 @@ set_init_xdg_rtp(void)
     options[opt_idx].def_val[VI_DEFAULT] = xdg_rtp;
     p_pp = xdg_rtp;
 
+#if defined(XDG_VDIR) && defined(FEAT_SESSION)
+    if ((opt_idx = findoption((char_u *)"viewdir")) < 0)
+	goto theend;
+
+    options[opt_idx].def_val[VI_DEFAULT] = (char_u *)XDG_VDIR;
+    p_vdir = (char_u *)XDG_VDIR;
+#endif
+
 theend:
     vim_free(vimrc1);
     vim_free(vimrc2);

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -347,6 +347,8 @@ typedef struct dsc$descriptor   DESC;
 #  define DFLT_VDIR    "sys$login:vimfiles/view"
 # else
 #  define DFLT_VDIR    "$HOME/.vim/view"       // default for 'viewdir'
+#  define XDG_VDIR     (mch_getenv("XDG_CONFIG_HOME") ? \
+	"$XDG_CONFIG_HOME/vim/view" : "~/.config/vim/view")
 # endif
 #endif
 

--- a/src/testdir/test_xdg.vim
+++ b/src/testdir/test_xdg.vim
@@ -80,6 +80,7 @@ func Test_xdg_runtime_files()
     call assert_match('XfakeHOME/\.vimrc', $MYVIMRC)
     call filter(g:, {idx, _ -> idx =~ '^rc'})
     call assert_equal(#{rc_one: 'one', rc: '.vimrc'}, g:)
+    call assert_match('XfakeHOME/\.vim/view', &viewdir)
     call writefile(v:errors, 'Xresult')
     quit
   END
@@ -94,6 +95,7 @@ func Test_xdg_runtime_files()
     call assert_match('XfakeHOME/\.vim/vimrc', $MYVIMRC)
     call filter(g:, {idx, _ -> idx =~ '^rc'})
     call assert_equal(#{rc_two: 'two', rc: '.vim/vimrc'}, g:)
+    call assert_match('XfakeHOME/\.vim/view', &viewdir)
     call writefile(v:errors, 'Xresult')
     quit
   END
@@ -112,6 +114,7 @@ func Test_xdg_runtime_files()
     call assert_match('XfakeHOME/\.config/vim/vimrc', $MYVIMRC, msg)
     call filter(g:, {idx, _ -> idx =~ '^rc'})
     call assert_equal(#{rc_three: 'three', rc: '.config/vim/vimrc'}, g:)
+    call assert_match('XfakeHOME/\.config/vim/view', &viewdir)
     call writefile(v:errors, 'Xresult')
     quit
   END
@@ -128,6 +131,7 @@ func Test_xdg_runtime_files()
     call assert_match('XfakeHOME/xdg/vim/vimrc', $MYVIMRC, msg)
     call filter(g:, {idx, _ -> idx =~ '^rc'})
     call assert_equal(#{rc_four: 'four', rc: 'xdg/vim/vimrc'}, g:)
+    call assert_match('XfakeHOME/xdg/vim/view, &viewdir)
     call writefile(v:errors, 'Xresult')
     quit
   END


### PR DESCRIPTION
Problem:  'viewdir' not respecting $XDG_CONFIG_HOME
          (Danilo Rezende, after v9.1.327)
Solution: adjust 'viewdir' option when enabling XDG config mode

fixes: #14680