### PR TITLE
Fix mouseshape to be set correctly when using 'r' or 'gr' #12157

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -418,6 +418,9 @@ normal_cmd_get_more_chars(
 #ifdef CURSOR_SHAPE
 	    ui_cursor_shape();	// show different cursor shape
 #endif
+#ifdef FEAT_MOUSESHAPE
+	    update_mouseshape(-1);
+#endif
 	}
 	if (lang && curbuf->b_p_iminsert == B_IMODE_LMAP)
 	{

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -3980,8 +3980,7 @@ func Test_mouse_shape_after_cancelling_gr()
   END
   call writefile(lines, 'Xmouseshape.vim', 'D')
   call RunVim([], [], "-g -S Xmouseshape.vim")
-  sleep 300m
-  call assert_equal(['beam', 'arrow'], readfile('Xmouseshapes'))
+  call WaitForAssert({-> assert_equal(['beam', 'arrow'], readfile('Xmouseshapes'))})
 
   call delete('Xmouseshapes')
 endfunc


### PR DESCRIPTION
https://github.com/vim/vim/pull/12157
https://github.com/vim/vim/issues/14660