### PR TITLE
CI: Workaround for test_sound on macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,8 +330,16 @@ jobs:
           brew install lua libtool
           echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
+      - name: Install blackhole-2ch for macos-12
+        if: matrix.features == 'huge' && matrix.runner == 'macos-12'
+        run: |
+          # Install audio device for playing sound since some of macos-12 machines have no audio device installed.
+          if system_profiler -json SPAudioDataType | jq -er '.SPAudioDataType[]._items == []'; then
+            brew install blackhole-2ch
+          fi
+
       - name: Grant microphone access for macos-14
-        if: matrix.runner == 'macos-14'
+        if: matrix.features == 'huge' && matrix.runner == 'macos-14'
         run: |
           # Temporary fix to fix microphone permission issues for macos-14 when playing sound.
           sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"


### PR DESCRIPTION
## Problem

CI: test_sound often fails on macos-12.

## Cause

Some of macos-12 runners (machines) have no audio device installed.

On my investigation; macos-12 runner runs on any one of at least 3 machines and 2 of them have no audio device installed.
Therefore, when tests run on such machine, test_sound fails.

## Solution

Install an audio device before testing.
 
This PR adds to the step of installing blackhole-2ch, which is macOS audio driver.