### PR TITLE
Check the imported variable type properly

### DIFF
--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -97,6 +97,18 @@ func Test_blob_assign()
 
   let lines =<< trim END
       VAR b = 0zDEADBEEF
+      LET b[0 : 1] = 0x1122
+  END
+  call v9.CheckLegacyAndVim9Failure(lines, ['E709:', 'E1012:', 'E709:'])
+
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      LET b[0] = 0z11
+  END
+  call v9.CheckLegacyAndVim9Failure(lines, ['E974:', 'E974:', 'E1012:'])
+
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
       LET b ..= 0z33
   END
   call v9.CheckLegacyAndVim9Failure(lines, ['E734:', 'E1019:', 'E734:'])

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -650,7 +650,7 @@ def Test_assign_index()
       var bl = 0z11
       bl[1] = g:val
   END
-  v9.CheckDefExecAndScriptFailure(lines, 'E1030: Using a String as a Number: "22"')
+  v9.CheckDefExecAndScriptFailure(lines, ['E1030: Using a String as a Number: "22"', 'E1012: Type mismatch; expected number but got string'])
 
   # should not read the next line when generating "a.b"
   var a = {}


### PR DESCRIPTION
When an imported dict or a class variable is set, check the dict item or the class variable type.