### PR TITLE
Add runtime files and filetype detection for jj

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -161,6 +161,7 @@ runtime/ftplugin/j.vim			@glts
 runtime/ftplugin/java.vim		@zzzyxwvut
 runtime/ftplugin/javascript.vim		@dkearns
 runtime/ftplugin/javascriptreact.vim	@dkearns
+runtime/ftplugin/jj.vim			@gpanders
 runtime/ftplugin/json.vim		@dbarnett
 runtime/ftplugin/json5.vim		@dkearns
 runtime/ftplugin/jsonc.vim		@izhakjakov
@@ -406,6 +407,7 @@ runtime/syntax/j.vim			@glts
 runtime/syntax/jargon.vim		@h3xx
 runtime/syntax/java.vim			@zzzyxwvut
 runtime/syntax/javascript.vim		@fleiner
+runtime/syntax/jj.vim			@gpanders
 runtime/syntax/json.vim		        @vito-c
 runtime/syntax/jsonc.vim		@izhakjakov
 runtime/syntax/julia.vim		@carlobaldassi

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1148,6 +1148,9 @@ au BufNewFile,BufRead *.clp			setf jess
 " Jgraph
 au BufNewFile,BufRead *.jgr			setf jgraph
 
+" Jujutsu
+au BufNewFile,BufRead *.jjdescription		setf jj
+
 " Jovial
 au BufNewFile,BufRead *.jov,*.j73,*.jovial	setf jovial
 

--- a/runtime/ftplugin/jj.vim
+++ b/runtime/ftplugin/jj.vim
@@ -1,6 +1,6 @@
 " Vim filetype plugin
 " Language:	jj description
-" Maintainer:	Gregory Anders
+" Maintainer:	Gregory Anders <greg@gpanders.com>
 " Last Change:	2024 May 8
 
 if exists('b:did_ftplugin')

--- a/runtime/ftplugin/jj.vim
+++ b/runtime/ftplugin/jj.vim
@@ -1,0 +1,19 @@
+" Vim filetype plugin
+" Language:	jj description
+" Maintainer:	Gregory Anders
+" Last Change:	2024 May 8
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+" Use the same formatoptions and textwidth as the gitcommit ftplugin
+setlocal nomodeline formatoptions+=tl textwidth=72
+setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions-=q formatoptions+=n
+setlocal formatlistpat=^\\s*\\d\\+[\\]:.)}]\\s\\+\\\|^\\s*[-*+]\\s\\+
+
+setlocal comments=b:JJ:
+setlocal commentstring=JJ:\ %s
+
+let b:undo_ftplugin = 'setl modeline< formatoptions< textwidth< formatlistpat< comments< commentstring<'

--- a/runtime/syntax/jj.vim
+++ b/runtime/syntax/jj.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:	jj description
-" Maintainer:	Gregory Anders
+" Maintainer:	Gregory Anders <greg@gpanders.com>
 " Last Change:	2024 May 8
 
 if exists('b:current_syntax')

--- a/runtime/syntax/jj.vim
+++ b/runtime/syntax/jj.vim
@@ -1,0 +1,20 @@
+" Vim syntax file
+" Language:	jj description
+" Maintainer:	Gregory Anders
+" Last Change:	2024 May 8
+
+if exists('b:current_syntax')
+  finish
+endif
+let b:current_syntax = 'jj'
+
+syn match jjAdded "A .*" contained
+syn match jjRemoved "D .*" contained
+syn match jjChanged "M .*" contained
+
+syn region jjComment start="^JJ: " end="$" contains=jjAdded,jjRemoved,jjChanged
+
+hi def link jjComment Comment
+hi def link jjAdded Added
+hi def link jjRemoved Removed
+hi def link jjChanged Changed

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -359,6 +359,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     javascriptreact: ['file.jsx'],
     jess: ['file.clp'],
     jgraph: ['file.jgr'],
+    jj: ['file.jjdescription'],
     jq: ['file.jq'],
     jovial: ['file.jov', 'file.j73', 'file.jovial'],
     jproperties: ['file.properties', 'file.properties_xx', 'file.properties_xx_xx', 'some.properties_xx_xx_file', 'org.eclipse.xyz.prefs'],


### PR DESCRIPTION
[jj](https://github.com/martinvonz/jj) (Jujutsu) is a Git-compatible version control system.

Like git, `jj` allows the user to write a description of each change in a buffer. These are opened in the editor with a temporary file with a `.jjdescription` extension. Example:

```
Add runtime files and filetype detection for jj

JJ: This commit contains the following changes:
JJ:     M runtime/filetype.vim
JJ:     A runtime/ftplugin/jj.vim
JJ:     A runtime/syntax/jj.vim

JJ: Lines starting with "JJ: " (like this one) will be removed.
```

The format of the file is similar to a Git commit file. There is some plain text at the top of the file describing the change and some comments showing which files changed. The comment character is `JJ: ` (indicated by the text in the buffer).

The included syntax plugin highlights comments with the `Comment` highlight group, and highlights each of the individual changed files using the builtin `Added`, `Changed`, and `Removed` highlight groups.

The include filetype plugin is copied almost verbatim from the `gitcommit` filetype plugin, though I dropped the Git commands and adapted for the updated comment strings.