### PR TITLE
Problem:  block_editing errors out when using del

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -1608,7 +1608,7 @@ op_insert(oparg_T *oap, long count1)
 
     if (oap->block_mode)
     {
-	size_t			ins_len;
+	int			ins_len;
 	char_u			*firstline, *ins_text;
 	struct block_def	bd2;
 	int			did_indent = FALSE;

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -2031,4 +2031,12 @@ func Test_getregion_maxcol()
   bwipe!
 endfunc
 
+func Test_visual_block_cursor_delete()
+  new
+  call setline(1, 'ab')
+  exe ":norm! $\<c-v>hI\<Del>\<ESC>"
+  call assert_equal(['b'], getline(1, 1))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  block_editing errors out when using del
Solution: Change ins_len from size_t to int and
          properly check that it doesn't become negative

fixes: #14734