### PR TITLE
xxd: buffer-overflow with specific flags

### DIFF
--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -416,9 +416,10 @@ endfunc
 func Test_xxd_buffer_overflow()
   new
   let input = repeat('A', 256)
-  let expected = ' -9223372036854775808: ' . repeat("\e[1;32m41\e[0m ", 256) . ' ' . repeat("\e[1;32mA\e[0m", 256)
-  exe 'r! printf ' . input . '| ' . s:xxd_cmd . ' -Ralways -g1 -c256 -d -o 9223372036854775808'
-  call assert_equal(expected, join(getline(1, '$')))
+  call writefile(['-9223372036854775808: ' . repeat("\e[1;32m41\e[0m ", 256) . ' ' . repeat("\e[1;32mA\e[0m", 256)], 'Xxdexpected', 'D')
+  exe 'r! printf ' . input . '| ' . s:xxd_cmd . ' -Ralways -g1 -c256 -d -o 9223372036854775808 > Xxdout'
+  call assert_equalfile('Xxdexpected', 'Xxdout')
+  call delete('Xxdout')
   bwipe!
 endfunc
 

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -411,6 +411,17 @@ func Test_xxd_max_cols()
   endfor
 endfunc
 
+
+" Try to trigger a buffer overflow (#14738)
+func Test_xxd_buffer_overflow()
+  new
+  let input = repeat('A', 256)
+  let expected = ' -9223372036854775808: ' . repeat("\e[1;32m41\e[0m ", 256) . ' ' . repeat("\e[1;32mA\e[0m", 256)
+  exe 'r! printf ' . input . '| ' . s:xxd_cmd . ' -Ralways -g1 -c256 -d -o 9223372036854775808'
+  call assert_equal(expected, join(getline(1, '$')))
+  bwipe!
+endfunc
+
 " -c0 selects the format specific default column value, as if no -c was given
 " except for -ps, where it disables extra newlines
 func Test_xxd_c0_is_def_cols()

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -205,29 +205,16 @@ char osver[] = "";
 /*
  * LLEN is the maximum length of a line; other than the visible characters
  * we need to consider also the escape color sequence prologue/epilogue ,
- * (11 bytes for each character). The most larger format is the default one:
- * addr + 1 word for each col/2 + 1 char for each col
- *
- *   addr        1st group       2nd group
- * +-------+ +-----------------+ +------+
- * 01234567: 1234 5678 9abc def0 12345678
- *
- * - addr: typically 012345678:    -> from 10 up to 18 bytes (including trailing
- *                                    space)
- * - 1st group: 1234 5678 9abc ... -> each byte may be colored, so add 11
- *                                    for each byte
- * - space                         -> 1 byte
- * - 2nd group: 12345678           -> each char may be colore so add 11
- *                                    for each byte
- * - new line                      -> 1 byte
- * - zero (end line)               -> 1 byte
+ * (11 bytes for each character).
  */
-#define LLEN (2*(int)sizeof(unsigned long) + 2 +     /* addr + ": " */ \
-             (11 * 2 + 4 + 1) * (COLS / 2) +         /* 1st group */   \
-	     1 +                                     /* space */       \
-	     (1 + 11) * COLS +                       /* 2nd group */   \
-	     1 +                                     /* new line */    \
-	     1)                                      /* zero */
+#define LLEN \
+    39             /* addr: ⌈log10(ULONG_MAX)⌉ if "-d" flag given. We assume ULONG_MAX = 2**128 */ \
+    + 2            /* ": " */ \
+    + 13 * COLS    /* hex dump with colors */ \
+    + (COLS - 1)   /* whitespace between groups if "-g1" option given and "-c" maxed out */ \
+    + 2            /* whitespace */ \
+    + 12 * COLS    /* ASCII dump with colors */ \
+    + 2            /* "\n\0" */
 
 char hexxa[] = "0123456789abcdef0123456789ABCDEF", *hexx = hexxa;
 

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -208,13 +208,13 @@ char osver[] = "";
  * (11 bytes for each character).
  */
 #define LLEN \
-    39             /* addr: ⌈log10(ULONG_MAX)⌉ if "-d" flag given. We assume ULONG_MAX = 2**128 */ \
+    (39            /* addr: ⌈log10(ULONG_MAX)⌉ if "-d" flag given. We assume ULONG_MAX = 2**128 */ \
     + 2            /* ": " */ \
     + 13 * COLS    /* hex dump with colors */ \
     + (COLS - 1)   /* whitespace between groups if "-g1" option given and "-c" maxed out */ \
     + 2            /* whitespace */ \
     + 12 * COLS    /* ASCII dump with colors */ \
-    + 2            /* "\n\0" */
+    + 2)           /* "\n\0" */
 
 char hexxa[] = "0123456789abcdef0123456789ABCDEF", *hexx = hexxa;
 


### PR DESCRIPTION
This is a continuation of #14003.

xxd writes each output line into a global buffer before printing. The maximum size of that buffer was not calculated correctly.

This command was crashing in AddressSanitizer:

    xxd -Ralways -g1 -c256 -d -o 9223372036854775808 /etc/passwd

This prints a line of 6680 bytes but the buffer only had room for 6549 bytes. If the output from "-b" was colored, the line could be even longer.