### PR TITLE
Remove hardcoded private.ppk logic from netrw

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -281,14 +281,8 @@ call s:NetrwInit("g:netrw_rcp_cmd"  , "rcp")
 call s:NetrwInit("g:netrw_rsync_cmd", "rsync")
 call s:NetrwInit("g:netrw_rsync_sep", "/")
 if !exists("g:netrw_scp_cmd")
- if executable("scp")
-  call s:NetrwInit("g:netrw_scp_cmd" , "scp -q")
- elseif executable("pscp")
-  if has("win32") && filereadable('c:\private.ppk')
-   call s:NetrwInit("g:netrw_scp_cmd", 'pscp -i c:\private.ppk')
-  else
-   call s:NetrwInit("g:netrw_scp_cmd", 'pscp -q')
-  endif
+ if executable("pscp")
+  call s:NetrwInit("g:netrw_scp_cmd", 'pscp -q')
  else
   call s:NetrwInit("g:netrw_scp_cmd" , "scp -q")
  endif
@@ -369,10 +363,6 @@ endif
 call s:NetrwInit("g:netrw_keepdir",1)
 if !exists("g:netrw_list_cmd")
  if g:netrw_scp_cmd =~ '^pscp' && executable("pscp")
-  if has("win32") && filereadable("c:\\private.ppk")
-   " provide a pscp-based listing command
-   let g:netrw_scp_cmd ="pscp -i C:\\private.ppk"
-  endif
   if exists("g:netrw_list_cmd_options")
    let g:netrw_list_cmd= g:netrw_scp_cmd." -ls USEPORT HOSTNAME: ".g:netrw_list_cmd_options
   else


### PR DESCRIPTION
Problem: File browsing plugin "netrw" has weird logic assuming "C:\private.ppk" exists on the computer, and if so, sets that as the connection key

Solution: Remove this logic from the plugin, no reason to assume this file exists on the drive and handle this case

Sanity tested :nwrite scp://... command after this change with pscp and seems to work fine