### PR TITLE
filetype: add URLs for some zsh modules files, recognize mdd as sh

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -3094,12 +3094,14 @@ au BufNewFile,BufRead .zsh*,.zlog*,.zcompdump*  call s:StarSetf('zsh')
 au BufNewFile,BufRead zsh*,zlog*		call s:StarSetf('zsh')
 
 " Zsh module
+" mdd: https://github.com/zsh-users/zsh/blob/57248b88830ce56adc243a40c7773fb3825cab34/Etc/zsh-development-guide#L285-L288
+" mdh, pro: https://github.com/zsh-users/zsh/blob/57248b88830ce56adc243a40c7773fb3825cab34/Etc/zsh-development-guide#L268-L271
 " *.mdd will generate *.mdh, *.pro and *.epro.
 " module's *.c will #include *.mdh containing module dependency information and
 " *.pro containing all static declarations of *.c
 " *.epro contains all external declarations of *.c
 au BufNewFile,BufRead *.mdh,*.epro		setf c
-au BufNewFile,BufRead *.mdd			setf zsh
+au BufNewFile,BufRead *.mdd			setf sh
 
 " Help files match *.txt but should have a last line that is a modeline.
 au BufNewFile,BufRead *.txt

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -642,7 +642,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     sh: ['.bashrc', '.bash_profile', '.bash-profile', '.bash_logout', '.bash-logout', '.bash_aliases', '.bash-aliases', '.bash_history', '.bash-history',
          '/tmp/bash-fc-3Ozjlw', '/tmp/bash-fc.3Ozjlw', 'PKGBUILD', 'APKBUILD', 'file.bash', '/usr/share/doc/bash-completion/filter.sh',
          '/etc/udev/cdsymlinks.conf', 'any/etc/udev/cdsymlinks.conf', 'file.bats', '.ash_history', 'any/etc/neofetch/config.conf', '.xprofile',
-         'user-dirs.defaults', 'user-dirs.dirs', 'makepkg.conf', '.makepkg.conf'],
+         'user-dirs.defaults', 'user-dirs.dirs', 'makepkg.conf', '.makepkg.conf', 'file.mdd'],
     sieve: ['file.siv', 'file.sieve'],
     sil: ['file.sil'],
     simula: ['file.sim'],
@@ -855,7 +855,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     zsh: ['.zprofile', '/etc/zprofile', '.zfbfmarks', 'file.zsh', 'file.zsh-theme', 'file.zunit',
           '.zcompdump', '.zlogin', '.zlogout', '.zshenv', '.zshrc', '.zsh_history',
           '.zcompdump-file', '.zlog', '.zlog-file', '.zsh', '.zsh-file',
-          'any/etc/zprofile', 'zlog', 'zlog-file', 'zsh', 'zsh-file', 'file.mdd'],
+          'any/etc/zprofile', 'zlog', 'zlog-file', 'zsh', 'zsh-file'],
 
     help: [$VIMRUNTIME .. '/doc/help.txt'],
     }


### PR DESCRIPTION
Problem:  mdd files is a sh script not a zsh script
Solution: add URLs for some zsh modules files, recognize mdd as sh
