### PR TITLE
Recursively delete directory by default on netrw

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -11456,7 +11456,7 @@ fun! s:NetrwLocalRmFile(path,fname,all)
    if !all
     echohl Statement
     call inputsave()
-    let ok= input("Confirm deletion of directory<".rmfile."> ","[{y(es)},n(o),a(ll),q(uit)] ")
+    let ok= input("Confirm *recursive* deletion of directory<".rmfile."> ","[{y(es)},n(o),a(ll),q(uit)] ")
     call inputrestore()
     let ok= substitute(ok,'\[{y(es)},n(o),a(ll),q(uit)]\s*','','e')
     if ok == ""

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -11469,7 +11469,7 @@ fun! s:NetrwLocalRmFile(path,fname,all)
    let rmfile= substitute(rmfile,'[\/]$','','e')
 
    if all || ok =~# 'y\%[es]' || ok == ""
-    if delete(rmfile,"d")
+    if delete(rmfile,"rf")
      call netrw#ErrorMsg(s:ERROR,"unable to delete directory <".rmfile.">!",103)
     endif
    endif


### PR DESCRIPTION
Problem: Currently the netrw delete command (triggered by pressing D on the folder) cannot delete directories which are not empty.

Solution: Delete directories recursively by default, there is a confirmation anyway, so the chance for mistake is slim

Sanity tested deletion on Windows 10 and Debian WSL and works