### PR TITLE
Stuck with long line half-page scrolling and 'nosmoothscroll'

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3156,9 +3156,10 @@ static int get_scroll_overlap(int dir)
 
 /*
  * Scroll "count" lines with 'smoothscroll' in direction "dir". Return TRUE
- * when scrolling happened.
+ * when scrolling happened. Adjust "curscount" for scrolling different amount of
+ * lines when 'smoothscroll' is disabled.
  */
-static int scroll_with_sms(int dir, long count)
+static int scroll_with_sms(int dir, long count, long *curscount)
 {
     int		prev_sms = curwin->w_p_sms;
     colnr_T	prev_skipcol = curwin->w_skipcol;
@@ -3181,7 +3182,10 @@ static int scroll_with_sms(int dir, long count)
 	    fixdir = dir * -1;
 	while (curwin->w_skipcol > 0
 	    && curwin->w_topline < curbuf->b_ml.ml_line_count)
+	{
 	    scroll_redraw(fixdir == FORWARD, 1);
+	    *curscount += (fixdir == dir ? 1 : -1);
+	}
     }
     curwin->w_p_sms = prev_sms;
 
@@ -3218,7 +3222,7 @@ pagescroll(int dir, long count, int half)
 	    curwin->w_p_scr = MIN(curwin->w_height, count);
 	count = MIN(curwin->w_height, curwin->w_p_scr);
 
-	int curscount = count;
+	long curscount = count;
 	// Adjust count so as to not reveal end of buffer lines.
 	if (dir == FORWARD
 		    && (curwin->w_topline + curwin->w_height + count > buflen
@@ -3238,7 +3242,7 @@ pagescroll(int dir, long count, int half)
 	// (Try to) scroll the window unless already at the end of the buffer.
 	if (count > 0)
 	{
-	    nochange = scroll_with_sms(dir, count);
+	    nochange = scroll_with_sms(dir, count, &curscount);
 	    curwin->w_cursor.lnum = prev_lnum;
 	    curwin->w_cursor.col = prev_col;
 	    curwin->w_curswant = prev_curswant;
@@ -3257,7 +3261,7 @@ pagescroll(int dir, long count, int half)
 	// Scroll [count] times 'window' or current window height lines.
 	count *= ((ONE_WINDOW && p_window > 0 && p_window < Rows - 1) ?
 				MAX(1, p_window - 2) : get_scroll_overlap(dir));
-	nochange = scroll_with_sms(dir, count);
+	nochange = scroll_with_sms(dir, count, &count);
 
 	// Place cursor at top or bottom of window.
 	validate_botline();

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4260,4 +4260,12 @@ func Test_page_cursor_topbot()
   bwipe!
 endfunc
 
+" Test for Ctrl-D with long line
+func Test_halfpage_longline()
+  10new
+  call setline(1, ['long'->repeat(1000), 'short'])
+  exe "norm! \<C-D>"
+  call assert_equal(2, line('.'))
+  bwipe!
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  No scrolling happens with half-page scrolling with line
          filling entire window when 'smoothscroll' is disabled.
Solution: Adjust amount to move cursor by so that it is moved the same
          number of lines as was scrolled, even when scrolling different
          number of lines than requested with 'nosmoothscroll'.

Fix #14743