### PR TITLE
runtime(doc): fix invalid link to Open Publication License

### DIFF
--- a/runtime/doc/usr_01.txt
+++ b/runtime/doc/usr_01.txt
@@ -1,4 +1,4 @@
-*usr_01.txt*	For Vim version 9.1.  Last change: 2023 May 12
+*usr_01.txt*	For Vim version 9.1.  Last change: 2024 May 11
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -165,7 +165,7 @@ The Vim user manual and reference manual are Copyright (c) 1988 by Bram
 Moolenaar.  This material may be distributed only subject to the terms and
 conditions set forth in the Open Publication License, v1.0 or later.  The
 latest version is presently available at:
-	     http://www.opencontent.org/openpub/
+	     https://opencontent.org/openpub/
 
 People who contribute to the manuals must agree with the above copyright
 notice.


### PR DESCRIPTION
The link in https://opencontent.org/openpub is actually invalid too:
```
Copyright (c) <year> by <author’s name or designee>.
This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, vX.Y or later (the latest version is presently available at https://www.opencontent.org/openpub/).
```

But since the text here doesn't exactly match that anyway (doesn't have the parentheses), it's probably fine to fix it.