### PR TITLE
runtime(syntax-tests): Filter out non-Latin-1 characters for syntax tests

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -834,6 +834,7 @@ RT_SCRIPTS =	\
 		runtime/syntax/testdir/input/*.* \
 		runtime/syntax/testdir/input/setup/*.* \
 		runtime/syntax/testdir/dumps/*.dump \
+		runtime/syntax/testdir/dumps/*.vim \
 		runtime/syntax/generator/Makefile \
 		runtime/syntax/generator/README.md \
 		runtime/syntax/generator/gen_syntax_vim.vim \

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_00.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_01.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_02.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_03.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_04.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_99.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_99.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_00.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_01.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_02.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_03.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_04.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_99.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_99.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_00.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_01.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_02.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_03.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_04.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_99.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_99.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_00.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_01.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_02.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_03.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_04.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_99.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_99.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/vim9_keymap_01.vim
+++ b/runtime/syntax/testdir/dumps/vim9_keymap_01.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[“�]+?+ge

--- a/runtime/syntax/testdir/dumps/vim9_keymap_99.vim
+++ b/runtime/syntax/testdir/dumps/vim9_keymap_99.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[“�]+?+ge

--- a/runtime/syntax/testdir/dumps/vim_keymap_99.vim
+++ b/runtime/syntax/testdir/dumps/vim_keymap_99.vim
@@ -1,0 +1,2 @@
+" Replace known non-Latin-1 characters.
+%s+[“�]+?+ge


### PR DESCRIPTION
Syntax tests are run with the `LC_ALL=C` environment variable  
passed to "make".  Occasionally, there are CI failures for  
such test files containing non-Latin-1 characters with error  
messages pointing to multi-byte characters:

https://github.com/vim/vim/actions/runs/8824925004/job/24228298023#step:10:16370 ,  
https://github.com/vim/vim/actions/runs/8840856619/job/24276935260#step:10:16347 ,  
https://github.com/vim/vim/actions/runs/8854043458/job/24316210645#step:10:16362 ,  
https://github.com/vim/vim/actions/runs/8856501136/job/24322848765#step:10:16354 ,  
https://github.com/vim/vim/actions/runs/9038417238/job/24839482152#step:11:16980 .

But since the very same unchanged tests pass at other times:

https://github.com/vim/vim/actions/runs/8827593571/job/24235935458#step:10:16353 ,  
https://github.com/vim/vim/actions/runs/9065214647/job/24905321661#step:11:17002 ;

these failures are unrelated to the nature of syntax tests  
and should be considered false positives.

As a temporary workaround, all bytes of known non-Latin-1  
characters can be replaced in memory with an arbitrary ASCII  
byte (?) by applying [a filter](https://github.com/vim/vim/blob/v9.1.0411/src/testdir/screendump.vim#L42-L45)

> " To ignore part of the dump, provide a "dumps/{filename}.vim" file with
> " Vim commands to be applied to both the reference and the current dump, so
> " that parts that are irrelevant are not used for the comparison.  The result
> " is NOT written, thus "term_dumpdiff()" shows the difference anyway.

before lines are compared between files.