### PR TITLE
CI: Upload failed screendump tests

### DIFF
--- a/.github/actions/screendump/action.yml
+++ b/.github/actions/screendump/action.yml
@@ -1,0 +1,26 @@
+name: 'screendump'
+description: "Upload failed syntax tests"
+runs:
+  using: "composite"
+  steps:
+    - name: Upload failed syntax tests
+      uses: actions/upload-artifact@v4
+      with:
+        # Name of the artifact to upload.
+        name: ${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-failed-syntax-tests
+
+        # A file, directory or wildcard pattern that describes what
+        # to upload.
+        path: |
+         ${{ github.workspace }}/runtime/syntax/testdir/failed/*
+         ${{ github.workspace }}/src/testdir/failed/*
+        # The desired behavior if no files are found using the
+        # provided path.
+        if-no-files-found: ignore
+
+        # Duration after which artifact will expire in days. 0 means
+        # using repository settings.
+        retention-days: 0
+
+        # If true, an artifact with a matching name will be deleted
+        overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,9 @@ jobs:
           do_test() { sg audio "sg $(id -gn) '$*'"; }
           do_test make ${SHADOWOPT} ${TEST}
 
+      - if: ${{ !cancelled() }}
+        uses: ./.github/actions/screendump
+
       - name: Vim tags
         if: contains(matrix.extra, 'vimtags')
         run: |
@@ -395,6 +398,9 @@ jobs:
         timeout-minutes: 20
         run: |
           make ${TEST}
+
+      - if: ${{ !cancelled() }}
+        uses: ./.github/actions/screendump
 
   windows:
     runs-on: windows-2022
@@ -690,6 +696,9 @@ jobs:
             @rem Run only tiny tests.
             nmake -nologo -f Make_mvc.mak tiny VIMPROG=..\vim  || exit 1
           )
+
+      - if: ${{ !cancelled() }}
+        uses: ./.github/actions/screendump
 
       - name: Generate gcov files
         if: matrix.coverage

--- a/Filelist
+++ b/Filelist
@@ -10,6 +10,7 @@ SRC_ALL =	\
 		.github/ISSUE_TEMPLATE/feature_request.md \
 		.github/workflows/ci.yml \
 		.github/workflows/codeql-analysis.yml \
+		.github/actions/screendump/action.yml \
 		.github/workflows/coverity.yml \
 		.github/dependabot.yml \
 		.gitignore \


### PR DESCRIPTION
It's a bit of a pain to debug failing screendump tests without knowing exactly what went wrong. Therefore include actions/upload-artifact for the Github CI runners and have them uploaded those failing screen dump tests.

Let's add this step to each of the Linux/MacOS/Windows workflows..

Example:
https://github.com/chrisbra/vim/actions/runs/9085493619