### PR TITLE
smoothscroll may cause infinite loop

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -873,11 +873,12 @@ win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
     if (len == MAXCOL && cts->cts_has_prop_with_text && *cts->cts_ptr == NUL)
     {
 	(void)win_lbr_chartabsize(cts, NULL);
-	cts->cts_vcol += cts->cts_cur_text_width;
+	vcol += cts->cts_cur_text_width;
 	// when properties are above or below the empty line must also be
 	// counted
 	if (cts->cts_ptr == cts->cts_line && cts->cts_prop_lines > 0)
-	    ++cts->cts_vcol;
+	    ++vcol;
+	cts->cts_vcol = vcol > MAXCOL ? MAXCOL : (int)vcol;
     }
 #endif
 }

--- a/src/move.c
+++ b/src/move.c
@@ -1630,6 +1630,7 @@ static void cursor_correct_sms(void)
     int	    width2 = width1 + curwin_col_off2();
     int	    so_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
     int	    space_cols = (curwin->w_height - 1) * width2;
+    int	    overlap, top, bot;
     int	    size = so == 0 ? 0 : win_linetabsize(curwin, curwin->w_topline,
 				    ml_get(curwin->w_topline), (colnr_T)MAXCOL);
 
@@ -1639,16 +1640,16 @@ static void cursor_correct_sms(void)
 	so_cols = space_cols / 2;  // Not enough room: put cursor in the middle.
 
     // Not enough screen lines in topline: ignore 'scrolloff'.
-    while (so_cols > size && so_cols - width2 >= width1)
+    while (so_cols > size && so_cols - width2 >= width1 && width1 > 0)
 	so_cols -= width2;
     if (so_cols >= width1 && so_cols > size)
 	so_cols -= width1;
 
     // If there is no marker or we have non-zero scrolloff, just ignore it.
-    int overlap = (curwin->w_skipcol == 0 || so_cols != 0) ? 0
+    overlap = (curwin->w_skipcol == 0 || so_cols != 0) ? 0
 					    : sms_marker_overlap(curwin, -1);
-    int top = curwin->w_skipcol + overlap + so_cols;
-    int bot = curwin->w_skipcol + width1 + (curwin->w_height - 1) * width2
+    top = curwin->w_skipcol + overlap + so_cols;
+    bot = curwin->w_skipcol + width1 + (curwin->w_height - 1) * width2
 								    - so_cols;
     validate_virtcol();
     colnr_T col = curwin->w_virtcol;

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4268,4 +4268,14 @@ func Test_halfpage_longline()
   call assert_equal(2, line('.'))
   bwipe!
 endfunc
+
+" Test for Ctrl-E with long line and very narrow window,
+" used to cause an inifite loop
+func Test_scroll_longline_no_loop()
+  4vnew
+  setl smoothscroll number showbreak=> scrolloff=2
+  call setline(1, repeat(['Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'], 3))
+  exe "normal! \<C-E>"
+  bwipe!
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  smoothscroll may cause infinite loop, with
          very narrow windows
          (Jaehwang Jung, after v9.1.0280)
Solution: Check for width1 being negative, also verify
          that win_linetabsize does not overflow

fixes: #14750