### PR TITLE
Update vi_diff.txt: added default value for flash

### DIFF
--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -49,7 +49,7 @@ printed.
 
 autoprint (ap)		boolean	(default on)		*'autoprint'* *'ap'*
 beautify (bf)		boolean	(default off)		*'beautify'* *'bf'*
-flash (fl)		boolean	(default ??)		*'flash'* *'fl'*
+flash (fl)		boolean	(default on)		*'flash'* *'fl'*
 graphic (gr)		boolean	(default off)		*'graphic'* *'gr'*
 hardtabs (ht)		number	(default 8)		*'hardtabs'* *'ht'*
 	number of spaces that a <Tab> moves on the display


### PR DESCRIPTION
The "flash" option was added relatively late and seems to be exclusive to System V. (It's not in 4.4BSD and it's not in V8 UNIX, checked [on TUHS](https://www.tuhs.org/cgi-bin/utree.pl).) The oldest occurrence of `flash` in "a vi" I could find is in SysV R2 for the VAX, where it [defaults to 1](https://github.com/ryanwoodsmall/oldsysv/blob/master/sysvr2-vax/src/cmd/vi/vax/ex_data.c) = on. So, added.