### PR TITLE
Problem: find_module has been removed in Python 3.13

### DIFF
--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -1,4 +1,4 @@
-*if_pyth.txt*   For Vim version 9.1.  Last change: 2023 Oct 25
+*if_pyth.txt*   For Vim version 9.1.  Last change: 2024 May 16
 
 
 		  VIM REFERENCE MANUAL    by Paul Moore
@@ -343,7 +343,8 @@ In python vim.VIM_SPECIAL_PATH special directory is used as a replacement for
 the list of paths found in 'runtimepath': with this directory in sys.path and
 vim.path_hooks in sys.path_hooks python will try to load module from
 {rtp}/python2 (or python3) and {rtp}/pythonx (for both python versions) for
-each {rtp} found in 'runtimepath'.
+each {rtp} found in 'runtimepath' (Note: find_module() has been removed from
+imp module around Python 3.12.0a7).
 
 Implementation is similar to the following, but written in C: >
 
@@ -404,10 +405,12 @@ vim.VIM_SPECIAL_PATH					*python-VIM_SPECIAL_PATH*
 
 vim.find_module(...)					*python-find_module*
 vim.path_hook(path)					*python-path_hook*
+vim.find_spec(...)					*python-find_spec*
 	Methods or objects used to implement path loading as described above.
 	You should not be using any of these directly except for vim.path_hook
-	in case you need to do something with sys.meta_path. It is not
-	guaranteed that any of the objects will exist in the future vim
+	in case you need to do something with sys.meta_path, vim.find_spec()
+	is available starting with Python 3.7.
+	It is not guaranteed that any of the objects will exist in future vim
 	versions.
 
 vim._get_paths						*python-_get_paths*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -9518,6 +9518,7 @@ python-eval	if_pyth.txt	/*python-eval*
 python-examples	if_pyth.txt	/*python-examples*
 python-fchdir	if_pyth.txt	/*python-fchdir*
 python-find_module	if_pyth.txt	/*python-find_module*
+python-find_spec	if_pyth.txt	/*python-find_spec*
 python-foreach_rtp	if_pyth.txt	/*python-foreach_rtp*
 python-input	if_pyth.txt	/*python-input*
 python-options	if_pyth.txt	/*python-options*

--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -7325,12 +7325,11 @@ populate_module(PyObject *m)
 	return -1;
     }
 
+# if PY_VERSION_HEX < 0x30c00a7
+    // find_module has been removed as of Python 3.12.0a7
     if ((py_find_module = PyObject_GetAttrString(cls, "find_module")))
-    {
-	// find_module() is deprecated, this may stop working in some later
-	// version.
 	ADD_OBJECT(m, "_find_module", py_find_module);
-    }
+# endif
 
     Py_DECREF(imp);
 


### PR DESCRIPTION
Problem:  find_module has been removed in Python 3.13
Solution: Do not include find_module for Python >= 3.13

fixes: #14776