### PR TITLE
Adding register viminfo partial write warning

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -2296,8 +2296,6 @@ EXTERN char e_not_possible_to_change_sign_str[]
 #ifdef FEAT_VIMINFO
 EXTERN char e_cant_rename_viminfo_file_to_str[]
 	INIT(= N_("E886: Can't rename viminfo file to %s!"));
-EXTERN char e_warning_registers_partially_written_to_viminfo[]
-	INIT(= N_("E2000: Warning: registers only partially written to viminfo, increase viminfo size"));
 #endif
 #if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 EXTERN char e_sorry_this_command_is_disabled_python_side_module_could_not_be_loaded[]

--- a/src/errors.h
+++ b/src/errors.h
@@ -2296,6 +2296,8 @@ EXTERN char e_not_possible_to_change_sign_str[]
 #ifdef FEAT_VIMINFO
 EXTERN char e_cant_rename_viminfo_file_to_str[]
 	INIT(= N_("E886: Can't rename viminfo file to %s!"));
+EXTERN char e_warning_registers_partially_written_to_viminfo[]
+	INIT(= N_("E2000: Warning: registers only partially written to viminfo, increase viminfo size"));
 #endif
 #if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 EXTERN char e_sorry_this_command_is_disabled_python_side_module_could_not_be_loaded[]

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -2764,7 +2764,7 @@ static struct vimoption options[] =
 #ifdef FEAT_VIMINFO
 			    (char_u *)&p_viminfo, PV_NONE, did_set_viminfo, NULL,
 #if defined(MSWIN)
-			    {(char_u *)"", (char_u *)"'100,<50,s10,h,rA:,rB:"}
+			    {(char_u *)"", (char_u *)"'100,<500,s100,h,rA:,rB:"}
 #elif defined(AMIGA)
 			    {(char_u *)"",
 				 (char_u *)"'100,<50,s10,h,rdf0:,rdf1:,rdf2:"}

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -2769,7 +2769,7 @@ static struct vimoption options[] =
 			    {(char_u *)"",
 				 (char_u *)"'100,<50,s10,h,rdf0:,rdf1:,rdf2:"}
 #else
-			    {(char_u *)"", (char_u *)"'100,<50,s10,h"}
+			    {(char_u *)"", (char_u *)"'100,<500,s100,h"}
 #endif
 #else
 			    (char_u *)NULL, PV_NONE, NULL, NULL,

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -315,6 +315,13 @@ func Test_cmdline_history_order()
   call delete('Xviminfo')
 endfunc
 
+func Force_write_viminfo()
+  redir => res
+  silent! wviminfo Xviminfo
+  redir END
+  call assert_match('W23:', res)
+endfunc
+
 func Test_viminfo_registers()
   call test_settime(8)
   call setreg('a', "eight", 'c')
@@ -366,26 +373,28 @@ func Test_viminfo_registers()
   endwhile
 
   " If the maximum number of lines saved for a register ('<' in 'viminfo') is
-  " zero, then register values should not be saved.
+  " zero, then register values should not be saved and a warning should be returned.
   let @a = 'abc'
   set viminfo='100,<0,s10,h,!,nviminfo
-  wviminfo Xviminfo
+  call Force_write_viminfo()
   let @a = 'xyz'
   rviminfo! Xviminfo
   call assert_equal('xyz', @a)
   " repeat the test with '"' instead of '<'
   let @b = 'def'
   set viminfo='100,\"0,s10,h,!,nviminfo
-  wviminfo Xviminfo
+  call Force_write_viminfo()
+
   let @b = 'rst'
   rviminfo! Xviminfo
   call assert_equal('rst', @b)
 
   " If the maximum size of an item ('s' in 'viminfo') is zero, then register
-  " values should not be saved.
+  " values should not be saved and a warning should be returned.
+
   let @c = '123'
   set viminfo='100,<20,s0,h,!,nviminfo
-  wviminfo Xviminfo
+  call Force_write_viminfo()
   let @c = '456'
   rviminfo! Xviminfo
   call assert_equal('456', @c)

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -316,9 +316,7 @@ func Test_cmdline_history_order()
 endfunc
 
 func Force_write_viminfo()
-  redir => res
-  silent! wviminfo Xviminfo
-  redir END
+  let res = execute('silent! wviminfo Xviminfo')
   call assert_match('W23:', res)
 endfunc
 

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1828,7 +1828,7 @@ write_viminfo_registers(FILE *fp)
     yankreg_T	*y_ptr;
     yankreg_T	*y_regs_p = get_y_regs();;
     // Signifies partial write
-    int		part_write = OK;
+    int		retval = OK;
 
     fputs(_("\n# Registers:\n"), fp);
 

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1911,7 +1911,7 @@ write_viminfo_registers(FILE *fp)
 	fprintf(fp, "\t%s\t%d\n", type, (int)y_ptr->y_width);
 
 	// If max_num_lines < 0, then we save ALL the lines in the register
-	if (max_num_lines > 0 && num_lines > max_num_lines) 
+	if (max_num_lines > 0 && num_lines > max_num_lines)
 	{
 	    num_lines = max_num_lines;
 	    part_write = FAIL;

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1881,7 +1881,7 @@ write_viminfo_registers(FILE *fp)
 		len += (long)STRLEN(y_ptr->y_array[j]) + 1L;
 	    if (len > (long)max_kbyte * 1024L)
 	    {
-		part_write = FAIL;
+		retval = FAIL;
 		continue;
 	    }
 	}
@@ -1914,7 +1914,7 @@ write_viminfo_registers(FILE *fp)
 	if (max_num_lines > 0 && num_lines > max_num_lines)
 	{
 	    num_lines = max_num_lines;
-	    part_write = FAIL;
+	    retval = FAIL;
 	}
 	for (j = 0; j < num_lines; j++)
 	{
@@ -1951,7 +1951,7 @@ write_viminfo_registers(FILE *fp)
 	}
     }
 
-   return part_write;
+   return retval;
 }
 
 /*

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1879,7 +1879,8 @@ write_viminfo_registers(FILE *fp)
 	    len = 0;
 	    for (j = 0; j < num_lines; j++)
 		len += (long)STRLEN(y_ptr->y_array[j]) + 1L;
-	    if (len > (long)max_kbyte * 1024L) {
+	    if (len > (long)max_kbyte * 1024L)
+	    {
 		part_write = FAIL;
 		continue;
 	    }

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -2960,7 +2960,8 @@ do_viminfo(FILE *fp_in, FILE *fp_out, int flags)
 	write_viminfo_sub_string(fp_out);
 	write_viminfo_history(fp_out, merge);
 
-	if(write_viminfo_registers(fp_out) == FAIL) {
+	if (write_viminfo_registers(fp_out) == FAIL)
+	{
 		emsg(_(e_warning_registers_partially_written_to_viminfo));
 		retval = FAIL;
 	}

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1911,7 +1911,8 @@ write_viminfo_registers(FILE *fp)
 	fprintf(fp, "\t%s\t%d\n", type, (int)y_ptr->y_width);
 
 	// If max_num_lines < 0, then we save ALL the lines in the register
-	if (max_num_lines > 0 && num_lines > max_num_lines) {
+	if (max_num_lines > 0 && num_lines > max_num_lines) 
+	{
 	    num_lines = max_num_lines;
 	    part_write = FAIL;
 	}
@@ -2962,7 +2963,7 @@ do_viminfo(FILE *fp_in, FILE *fp_out, int flags)
 
 	if (write_viminfo_registers(fp_out) == FAIL)
 	{
-		emsg(_(e_warning_registers_partially_written_to_viminfo));
+		emsg(_("W23: Warning: Registers only partially written to viminfo, increase viminfo size"));
 		retval = FAIL;
 	}
 


### PR DESCRIPTION
The following often happens to me:
I cut ("c" command) 100+ lines from file1, close file1, paste into file2, realize I had lost 50+ lines of text, which can't be recovered from file1 because it was cut out and the file closed.
I realize that this problem has many solutions (use one vim session, `:set viminfo`, use system clipboard &c) yet this still happens to me, especially on machines where I forgot to `:set viminfo` in vimrc and where there is no system clipboard.
For the sake of noobs I decided to atleast give a warning when such a thing is about to happen.

This feature request tries to address this in the following ways:
1. Add a warning when exiting with register size bigger than viminfo
2. Increasing viminfo register max line count from default 50 lines to 500 lines

Note 1: Regarding the warning, it doesn't prevent the user from exiting, it just displays the messages and after pressing Enter, exits. This is because even though I changed it so that do_viminfo now returns a FAIL or OK status, write_viminfo doesn't return such an error because I have no idea of how about implementing the more intrusive feature of an getout failing, ie. ex_exit failing.

Note 2: What error number should be applied to the new warning (I set it to 2000)? 
