### PR TITLE
runtime(termdebug): Fix #12718

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -418,8 +418,12 @@ func s:StartDebug_prompt(dict)
 
   if empty(glob('gdb'))
     file gdb
+  elseif empty(glob(' Termdebug-gdb-console'))
+     file Termdebug-gdb-console
   else
-    file Termdebug-gdb-console
+    Echoerr("You have a file/folder named 'gdb'
+          \ or 'Termdebug-gdb-console'.
+          \ Termdebug cannot start. Please rename them. ")
   endif
 
   call prompt_setcallback(s:promptbuf, function('s:PromptCallback'))
@@ -1469,9 +1473,12 @@ func s:GotoAsmwinOrCreateIt()
 
     if s:asmbuf > 0 && bufexists(s:asmbuf)
       exe 'buffer' . s:asmbuf
-    else
+    elseif empty(glob('Termdebug-asm-listing'))
       silent file Termdebug-asm-listing
       let s:asmbuf = bufnr('Termdebug-asm-listing')
+    else
+      Echoerr("You have a file/folder named Termdebug-asm-listing'.
+          \ Termdebug cannot start. Please rename such a file/folder. ")
     endif
 
     if mdf != 'vert' && s:GetDisasmWindowHeight() > 0
@@ -1538,9 +1545,12 @@ func s:GotoVariableswinOrCreateIt()
 
     if s:varbuf > 0 && bufexists(s:varbuf)
       exe 'buffer' . s:varbuf
-    else
+    elseif empty(glob('Termdebug-variables-listing'))
       silent file Termdebug-variables-listing
       let s:varbuf = bufnr('Termdebug-variables-listing')
+    else
+      Echoerr("You have a file/folder named Termdebug-variables-listing'.
+          \ Termdebug cannot start. Please rename such a file/folder. ")
     endif
 
     if mdf != 'vert' && s:GetVariablesWindowHeight() > 0

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -418,12 +418,12 @@ func s:StartDebug_prompt(dict)
 
   if empty(glob('gdb'))
     file gdb
-  elseif empty(glob(' Termdebug-gdb-console'))
-     file Termdebug-gdb-console
+  elseif empty(glob('Termdebug-gdb-console'))
+    file Termdebug-gdb-console
   else
-    Echoerr("You have a file/folder named 'gdb'
+    call s:Echoerr("You have a file/folder named 'gdb'
           \ or 'Termdebug-gdb-console'.
-          \ Termdebug cannot start. Please rename them. ")
+          \ Termdebug cannot start. Please rename them.")
   endif
 
   call prompt_setcallback(s:promptbuf, function('s:PromptCallback'))
@@ -1477,8 +1477,8 @@ func s:GotoAsmwinOrCreateIt()
       silent file Termdebug-asm-listing
       let s:asmbuf = bufnr('Termdebug-asm-listing')
     else
-      Echoerr("You have a file/folder named Termdebug-asm-listing'.
-          \ Termdebug cannot start. Please rename such a file/folder. ")
+      call s:Echoerr("You have a file/folder named Termdebug-asm-listing'.
+          \ Termdebug cannot start. Please rename such a file/folder.")
     endif
 
     if mdf != 'vert' && s:GetDisasmWindowHeight() > 0
@@ -1549,8 +1549,8 @@ func s:GotoVariableswinOrCreateIt()
       silent file Termdebug-variables-listing
       let s:varbuf = bufnr('Termdebug-variables-listing')
     else
-      Echoerr("You have a file/folder named Termdebug-variables-listing'.
-          \ Termdebug cannot start. Please rename such a file/folder. ")
+      call s:Echoerr("You have a file/folder named Termdebug-variables-listing'.
+          \ Termdebug cannot start. Please rename such a file/folder.")
     endif
 
     if mdf != 'vert' && s:GetVariablesWindowHeight() > 0

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -423,7 +423,7 @@ func s:StartDebug_prompt(dict)
   else
     call s:Echoerr("You have a file/folder named 'gdb'
           \ or 'Termdebug-gdb-console'.
-          \ Termdebug cannot start. Please rename them.")
+          \ Please exit and rename them because Termdebug may not work as expected.")
   endif
 
   call prompt_setcallback(s:promptbuf, function('s:PromptCallback'))
@@ -1477,8 +1477,8 @@ func s:GotoAsmwinOrCreateIt()
       silent file Termdebug-asm-listing
       let s:asmbuf = bufnr('Termdebug-asm-listing')
     else
-      call s:Echoerr("You have a file/folder named Termdebug-asm-listing'.
-          \ Termdebug cannot start. Please rename such a file/folder.")
+      call s:Echoerr("You have a file/folder named 'Termdebug-asm-listing'.
+          \ Please exit and rename it because Termdebug may not work as expected.")
     endif
 
     if mdf != 'vert' && s:GetDisasmWindowHeight() > 0
@@ -1549,8 +1549,8 @@ func s:GotoVariableswinOrCreateIt()
       silent file Termdebug-variables-listing
       let s:varbuf = bufnr('Termdebug-variables-listing')
     else
-      call s:Echoerr("You have a file/folder named Termdebug-variables-listing'.
-          \ Termdebug cannot start. Please rename such a file/folder.")
+      call s:Echoerr("You have a file/folder named 'Termdebug-variables-listing'.
+          \ Please exit and rename it because Termdebug may not work as expected.")
     endif
 
     if mdf != 'vert' && s:GetVariablesWindowHeight() > 0

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -415,7 +415,13 @@ func s:StartDebug_prompt(dict)
   let s:promptbuf = bufnr('')
   call prompt_setprompt(s:promptbuf, 'gdb> ')
   set buftype=prompt
-  file gdb
+
+  if empty(glob('gdb'))
+    file gdb
+  else
+    file Termdebug-gdb-console
+  endif
+
   call prompt_setcallback(s:promptbuf, function('s:PromptCallback'))
   call prompt_setinterrupt(s:promptbuf, function('s:PromptInterrupt'))
 

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -311,7 +311,8 @@ func Test_termdebug_bufnames()
   call writefile(['This', 'is', 'a', 'test'], filename, 'D')
   " Throw away the file once the test has done.
   Termdebug
-  call WaitForAssert({-> assert_equal(3, winnr('$'))}
+  " Once termdebug has completed the startup you should have 3 windows on screen
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
   " A file named filename already exists in the working directory,
   " hence you must call the newly created buffer differently
   call WaitForAssert({-> assert_false(bufexists(filename))})
@@ -326,7 +327,8 @@ func Test_termdebug_bufnames()
   " Check only the head of the error message
   let error_message = "You have a file/folder named '" .. filename .. "'"
   Termdebug
-  sleep 2
+  " Once termdebug has completed the startup you should have 4 windows on screen
+  call WaitForAssert({-> assert_equal(4, winnr('$'))})
   call WaitForAssert({-> assert_notequal(-1, stridx(execute('messages'), error_message))})
   quit!
   wincmd b

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -315,7 +315,7 @@ func Test_termdebug_bufnames()
   " A file named filename already exists in the working directory,
   " hence you must call the newly created buffer differently
   call WaitForAssert({-> assert_false(bufexists(filename))})
-  call WaitForAssert({-> assert_true(bufexists(bureplacement_filename))})
+  call WaitForAssert({-> assert_true(bufexists(replacement_filename))})
   %bw!
 
   " Check if error message is in :message

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -328,15 +328,12 @@ func Test_termdebug_bufnames()
   let error_message = "You have a file/folder named '" .. filename .. "'"
   execute 'Termdebug'
   sleep 2
-  call WaitForAssert({->assert_true(stridx(execute('messages'), error_message) != -1 )})
+  call WaitForAssert({->assert_notequal(-1, stridx(execute('messages'), error_message))})
   quit!
-  wincmd t 
+  wincmd t
   wincmd q
 
   unlet g:termdebug_config
-  unlet filename
-  unlet replacement_filename
-  unlet error_message
 endfunc
 
 

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -300,4 +300,22 @@ func Test_termdebug_mapping()
   %bw!
 endfunc
 
+func Test_termdebug_bufnames()
+  " Test if user has filename/folders named gdb, Termdebug-gdb-console,
+  " etc. in the current directory
+  let filename = 'gdb'
+  let replacement_filename =  'Termdebug-gdb-console'
+
+  call writefile(['This', 'is', 'a', 'test'], filename)
+  " Throw away the file once the test has done.
+  execute 'defer ' .. filename
+  execute 'Termdebug'
+  " A file named filename already exists in the working directory,
+  " hence you must call the newly created buffer differently
+  call WaitForAssert({-> assert_false(bufexists(bufnr(filename)))})
+  call WaitForAssert({-> assert_true(bufexists(bufnr(replacement_filename)))})
+  quit!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -304,7 +304,7 @@ func Test_termdebug_bufnames()
   " Test if user has filename/folders named gdb, Termdebug-gdb-console,
   " etc. in the current directory
   let filename = 'gdb'
-  let replacement_filename =  'Termdebug-gdb-console'
+  let replacement_filename = 'Termdebug-gdb-console'
 
   call writefile(['This', 'is', 'a', 'test'], filename)
   " Throw away the file once the test has done.

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -328,7 +328,7 @@ func Test_termdebug_bufnames()
   let error_message = "You have a file/folder named '" .. filename .. "'"
   Termdebug
   " Once termdebug has completed the startup you should have 4 windows on screen
-  call WaitForAssert({-> assert_equal(4, winnr('$'))})
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
   call WaitForAssert({-> assert_notequal(-1, stridx(execute('messages'), error_message))})
   quit!
   wincmd b

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -317,7 +317,7 @@ func Test_termdebug_bufnames()
   call WaitForAssert({-> assert_false(bufexists(filename))})
   call WaitForAssert({-> assert_true(bufexists(replacement_filename))})
   quit!
-  call WaitForAssert({-> assert_equal(1, winnr('$'))}
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
 
   " Check if error message is in :message
   let g:termdebug_config['disasm_window'] = 1

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -306,9 +306,8 @@ func Test_termdebug_bufnames()
   let filename = 'gdb'
   let replacement_filename = 'Termdebug-gdb-console'
 
-  call writefile(['This', 'is', 'a', 'test'], filename)
+  call writefile(['This', 'is', 'a', 'test'], filename, 'D')
   " Throw away the file once the test has done.
-  execute 'defer delete(filename)'
   execute 'Termdebug'
   " A file named filename already exists in the working directory,
   " hence you must call the newly created buffer differently

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -317,10 +317,9 @@ func Test_termdebug_bufnames()
   call WaitForAssert({-> assert_false(bufexists(filename))})
   call WaitForAssert({-> assert_true(bufexists(replacement_filename))})
   quit!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))}
 
   " Check if error message is in :message
-  " Delay for securing that Termdebug is shutoff
-  sleep 1
   let g:termdebug_config['disasm_window'] = 1
   let filename = 'Termdebug-asm-listing'
   call writefile(['This', 'is', 'a', 'test'], filename, 'D')
@@ -328,10 +327,11 @@ func Test_termdebug_bufnames()
   let error_message = "You have a file/folder named '" .. filename .. "'"
   Termdebug
   sleep 2
-  call WaitForAssert({->assert_notequal(-1, stridx(execute('messages'), error_message))})
+  call WaitForAssert({-> assert_notequal(-1, stridx(execute('messages'), error_message))})
   quit!
-  wincmd t
+  wincmd b
   wincmd q
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
 
   unlet g:termdebug_config
 endfunc

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -328,7 +328,7 @@ func Test_termdebug_bufnames()
   let error_message = "You have a file/folder named '" .. filename .. "'"
   Termdebug
   " Once termdebug has completed the startup you should have 4 windows on screen
-  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+  call WaitForAssert({-> assert_equal(4, winnr('$'))})
   call WaitForAssert({-> assert_notequal(-1, stridx(execute('messages'), error_message))})
   quit!
   wincmd b

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -311,7 +311,7 @@ func Test_termdebug_bufnames()
   call writefile(['This', 'is', 'a', 'test'], filename, 'D')
   " Throw away the file once the test has done.
   Termdebug
-  sleep 2
+  call WaitForAssert({-> assert_equal(3, winnr('$'))}
   " A file named filename already exists in the working directory,
   " hence you must call the newly created buffer differently
   call WaitForAssert({-> assert_false(bufexists(filename))})

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -308,12 +308,12 @@ func Test_termdebug_bufnames()
 
   call writefile(['This', 'is', 'a', 'test'], filename)
   " Throw away the file once the test has done.
-  execute 'defer ' .. filename
+  execute 'defer delete(filename)'
   execute 'Termdebug'
   " A file named filename already exists in the working directory,
   " hence you must call the newly created buffer differently
-  call WaitForAssert({-> assert_false(bufexists(bufnr(filename)))})
-  call WaitForAssert({-> assert_true(bufexists(bufnr(replacement_filename)))})
+  call WaitForAssert({-> assert_false(bufexists(filename))})
+  call WaitForAssert({-> assert_true(bufexists(bureplacement_filename))})
   quit!
 endfunc
 

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -303,17 +303,38 @@ endfunc
 func Test_termdebug_bufnames()
   " Test if user has filename/folders named gdb, Termdebug-gdb-console,
   " etc. in the current directory
+  let g:termdebug_config = {}
+  let g:termdebug_config['use_prompt'] = 1
   let filename = 'gdb'
   let replacement_filename = 'Termdebug-gdb-console'
 
   call writefile(['This', 'is', 'a', 'test'], filename, 'D')
   " Throw away the file once the test has done.
   execute 'Termdebug'
+  sleep 2
   " A file named filename already exists in the working directory,
   " hence you must call the newly created buffer differently
   call WaitForAssert({-> assert_false(bufexists(filename))})
   call WaitForAssert({-> assert_true(bufexists(bureplacement_filename))})
-  quit!
+  %bw!
+
+  " Check if error message is in :message
+  " Delay for securing that Termdebug is shutoff
+  sleep 1
+  let g:termdebug_config['disasm_window'] = 1
+  let filename = 'Termdebug-asm-listing'
+  call writefile(['This', 'is', 'a', 'test'], filename, 'D')
+  " Check only the head of the error message
+  let error_message = "You have a file/folder named '" .. filename .. "'"
+  execute 'Termdebug'
+  sleep 2
+  call WaitForAssert({->assert_true(stridx(execute('messages'), error_message) != -1 )})
+  %bw!
+
+  unlet g:termdebug_config
+  unlet filename
+  unlet replacement_filename
+  unlet error_message
 endfunc
 
 

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -310,7 +310,7 @@ func Test_termdebug_bufnames()
 
   call writefile(['This', 'is', 'a', 'test'], filename, 'D')
   " Throw away the file once the test has done.
-  execute 'Termdebug'
+  Termdebug
   sleep 2
   " A file named filename already exists in the working directory,
   " hence you must call the newly created buffer differently
@@ -326,7 +326,7 @@ func Test_termdebug_bufnames()
   call writefile(['This', 'is', 'a', 'test'], filename, 'D')
   " Check only the head of the error message
   let error_message = "You have a file/folder named '" .. filename .. "'"
-  execute 'Termdebug'
+  Termdebug
   sleep 2
   call WaitForAssert({->assert_notequal(-1, stridx(execute('messages'), error_message))})
   quit!

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -316,7 +316,7 @@ func Test_termdebug_bufnames()
   " hence you must call the newly created buffer differently
   call WaitForAssert({-> assert_false(bufexists(filename))})
   call WaitForAssert({-> assert_true(bufexists(replacement_filename))})
-  %bw!
+  quit!
 
   " Check if error message is in :message
   " Delay for securing that Termdebug is shutoff
@@ -329,7 +329,9 @@ func Test_termdebug_bufnames()
   execute 'Termdebug'
   sleep 2
   call WaitForAssert({->assert_true(stridx(execute('messages'), error_message) != -1 )})
-  %bw!
+  quit!
+  wincmd t 
+  wincmd q
 
   unlet g:termdebug_config
   unlet filename


### PR DESCRIPTION
Hi!

This is my proposal for fixing https://github.com/vim/vim/issues/12718 
I could have done something even more robust, like 

```
if empty(glob('gdb'))
     file gdb
  elseif empty(glob(' Termdebug-gdb-console'))
     file Termdebug-gdb-console
  else
    Echoerr("You have a file/folder named 'gdb' or 'Termdebug-gdb-console'. Termdebug cannot start. Please rename them. ")
endif
```

Shall the same `if-then-else` condition be placed in other lines of the form `file <hard-coded name>` ? 

OBS! I am not in the vim-dev mailing list! 