### PR TITLE
Do not prompt when :filter /pat/ browse oldfiles returns a single entry

### DIFF
--- a/runtime/doc/usr_21.txt
+++ b/runtime/doc/usr_21.txt
@@ -1,4 +1,4 @@
-*usr_21.txt*	For Vim version 9.1.  Last change: 2019 Apr 25
+*usr_21.txt*	For Vim version 9.1.  Last change: 2024 May 17
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -206,6 +206,23 @@ You get the same list of files as with |:oldfiles|.  If you want to edit
 	Type number and <Enter> (empty cancels): ~
 
 Type "2" and press <Enter> to edit the second file.
+
+If you know that the filename contains a pattern, you can also |:filter| the
+list of files: >
+
+	:filter /resume/ :browse oldfiles
+<
+Since there is only one single matching filename, Vim will directly edit that
+file without prompting.  If the filter matches several files, you'll get
+prompted for the list of matching files instead: >
+
+	:filter! /resume/ browse oldfiles
+<	1: ~/.viminfo ~
+	3: /tmp/draft ~
+	Type number and <Enter> (q or empty cancels): ~
+
+Note: this time we filtered out all files NOT matching resume.
+
 
 More info at |:oldfiles|, |v:oldfiles| and |c_#<|.
 

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5622,6 +5622,9 @@ ex_oldfiles(exarg_T *eap UNUSED)
     listitem_T	*li;
     int		nr = 0;
     char_u	*fname;
+    // for a single filtered match, remember the number
+    // so we can jump directly to it without prompting
+    int		matches = -1;
 
     if (l == NULL)
     {
@@ -5637,6 +5640,10 @@ ex_oldfiles(exarg_T *eap UNUSED)
 	fname = tv_get_string(&li->li_tv);
 	if (!message_filtered(fname))
 	{
+	    if (matches < 0)
+		matches = nr;
+	    else
+		matches = 0;
 	    msg_outnum((long)nr);
 	    msg_puts(": ");
 	    msg_outtrans(fname);
@@ -5654,7 +5661,15 @@ ex_oldfiles(exarg_T *eap UNUSED)
     if (cmdmod.cmod_flags & CMOD_BROWSE)
     {
 	quit_more = FALSE;
-	nr = prompt_for_number(FALSE);
+	// we only need to prompt if there is more than 1 match
+	if (matches > 0)
+	{
+	    nr = matches;
+	    // msg_putchar above sets needs_wait_return
+	    need_wait_return = FALSE;
+	}
+	else
+	    nr = prompt_for_number(FALSE);
 	msg_starthere();
 	if (nr > 0)
 	{

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -1299,4 +1299,34 @@ func Test_viminfo_merge_old_jumplist()
   bw!
 endfunc
 
+func Test_viminfo_oldfiles_filter()
+  let v:oldfiles = []
+  let _viminfofile = &viminfofile
+  let &viminfofile=''
+  let lines = [
+	\ '# comment line',
+	\ '*encoding=utf-8',
+	\ "> /tmp/vimrc_one.vim",
+	\ "\t\"\t11\t0",
+	\ "",
+	\ "> /tmp/foobar.txt",
+	\ "\t\"\t11\t0",
+	\ "",
+	\ ]
+  call writefile(lines, 'Xviminfo1', 'D')
+  rviminfo! Xviminfo1
+  new
+  " filter returns a single item
+  let a = execute('filter /vim/ oldfiles')->split('\n')
+  call assert_equal(1, len(a))
+  " filter returns more than a single match
+  let a = execute('filter #tmp# oldfiles')->split('\n')
+  call assert_equal(2, len(a))
+  " don't get prompted for the file, but directly open it
+  filter /vim/ browse oldfiles
+  call assert_equal("/tmp/vimrc_one.vim", expand("%"))
+  bw
+  let &viminfofile = _viminfofile
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
I noticed a little annoyance, that filter will still prompt even when there is only one single return value. So how about we fix it...