### PR TITLE
runtime(arduino): Add Arduino ftplugin and indent files

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -106,6 +106,7 @@ runtime/compiler/zsh.vim		@dkearns
 runtime/doc/ps1.txt			@heaths
 runtime/ftplugin/abaqus.vim		@costerwi
 runtime/ftplugin/apache.vim		@dubgeiser 
+runtime/ftplugin/arduino.vim		@k-takata
 runtime/ftplugin/astro.vim		@romainl
 runtime/ftplugin/awk.vim		@dkearns
 runtime/ftplugin/basic.vim		@dkearns
@@ -240,6 +241,7 @@ runtime/ftplugin/xml.vim		@chrisbra
 runtime/ftplugin/xs.vim			@petdance
 runtime/ftplugin/zsh.vim		@chrisbra
 runtime/import/dist/vimhighlight.vim	@lacygoill
+runtime/indent/arduino.vim		@k-takata
 runtime/indent/astro.vim		@wuelnerdotexe
 runtime/indent/basic.vim		@dkearns
 runtime/indent/bst.vim			@tpope

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -452,6 +452,18 @@ To disable folding everything under the title use this: >
 	let asciidoc_fold_under_title = 0
 
 
+ARDUINO							*ft-arduino-plugin*
+
+By default the following options are set, in accordance with the default
+settings of Arduino IDE: >
+
+	setlocal expandtab tabstop=2 softtabstop=2 shiftwidth=2
+
+To disable this behavior, set the following variable in your vimrc: >
+
+	let g:arduino_recommended_style = 0
+
+
 AWK							*ft-awk-plugin*
 
 Support for features specific to GNU Awk, like @include, can be enabled by

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7228,6 +7228,7 @@ ft-ada-syntax	ft_ada.txt	/*ft-ada-syntax*
 ft-ada-variables	ft_ada.txt	/*ft-ada-variables*
 ft-ant-syntax	syntax.txt	/*ft-ant-syntax*
 ft-apache-syntax	syntax.txt	/*ft-apache-syntax*
+ft-arduino-plugin	filetype.txt	/*ft-arduino-plugin*
 ft-asciidoc-plugin	filetype.txt	/*ft-asciidoc-plugin*
 ft-asm-syntax	syntax.txt	/*ft-asm-syntax*
 ft-asm68k-syntax	syntax.txt	/*ft-asm68k-syntax*

--- a/runtime/ftplugin/arduino.vim
+++ b/runtime/ftplugin/arduino.vim
@@ -1,0 +1,66 @@
+" Vim filetype plugin file
+" Language:	Arduino
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+"		Ken Takata <https://github.com/k-takata>
+" Last Change:	2024 Apr 12
+"
+" Most of the part was copied from c.vim.
+
+" Only do this when not done yet for this buffer
+if exists("b:did_ftplugin")
+  finish
+endif
+
+" Don't load another plugin for this buffer
+let b:did_ftplugin = 1
+
+" Using line continuation here.
+let s:cpo_save = &cpo
+set cpo-=C
+
+let b:undo_ftplugin = "setl fo< com< ofu< cms< def< inc<"
+
+if !exists("g:arduino_recommended_style") || g:arduino_recommended_style != 0
+  " Use the default setting of Arduino IDE.
+  setlocal expandtab tabstop=2 softtabstop=2 shiftwidth=2
+  let b:undo_ftplugin ..= " et< ts< sts< sw<"
+endif
+
+" Set 'formatoptions' to break comment lines but not other lines,
+" and insert the comment leader when hitting <CR> or using "o".
+setlocal fo-=t fo+=croql
+
+" These options have the right value as default, but the user may have
+" overruled that.
+setlocal commentstring& define& include&
+
+" Set completion with CTRL-X CTRL-O to autoloaded function.
+if exists('&ofu')
+  setlocal ofu=ccomplete#Complete
+endif
+
+" Set 'comments' to format dashed lists in comments.
+" Also include ///, used for Doxygen.
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://
+
+" When the matchit plugin is loaded, this makes the % command skip parens and
+" braces in comments properly.
+if !exists("b:match_words")
+  let b:match_words = '^\s*#\s*if\(\|def\|ndef\)\>:^\s*#\s*elif\>:^\s*#\s*else\>:^\s*#\s*endif\>'
+  let b:match_skip = 's:comment\|string\|character\|special'
+  let b:undo_ftplugin ..= " | unlet! b:match_skip b:match_words"
+endif
+
+" Win32 and GTK can filter files in the browse dialog
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Arduino Source Files (*.ino, *.pde)\t*.ino;*.pde\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/indent/arduino.vim
+++ b/runtime/indent/arduino.vim
@@ -1,0 +1,16 @@
+" Vim indent file
+" Language:	Arduino
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+"		Ken Takata <https://github.com/k-takata>
+" Last Change:	2024 Apr 03
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+" Use C indenting.
+setlocal cindent
+
+let b:undo_indent = "setl cin<"


### PR DESCRIPTION
We already have Arduino syntax file, but we didn't have ftplugin and indent files.

This commit adds a basic ftplugin file and a basic indent file.
Both of them are derived from {ftplugin,indent}/c.vim.