### PR TITLE
Remove redefinition of static keyword

### DIFF
--- a/runtime/vim16x16.xpm
+++ b/runtime/vim16x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static char * vim16x16[] = {
+static const char * vim16x16[] = {
 "16 16 8 1",
 " 	c None",
 ".	c #000000",

--- a/runtime/vim32x32.xpm
+++ b/runtime/vim32x32.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static char * vim32x32[] = {
+static const char * vim32x32[] = {
 "32 32 8 1",
 " 	c None",
 ".	c #000000",

--- a/runtime/vim48x48.xpm
+++ b/runtime/vim48x48.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static char * vim48x48[] = {
+static const char * vim48x48[] = {
 "48 48 8 1",
 " 	c None",
 ".	c #000000",

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -2704,23 +2704,9 @@ global_event_filter(GdkXEvent *xev,
     static void
 mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 {
-// If you get an error message here, you still need to unpack the runtime
-// archive!
-#ifdef magick
-# undef magick
-#endif
-  // A bit hackish, but avoids casting later and allows optimization
-# define static static const
-#define magick vim32x32
 #include "../runtime/vim32x32.xpm"
-#undef magick
-#define magick vim16x16
 #include "../runtime/vim16x16.xpm"
-#undef magick
-#define magick vim48x48
 #include "../runtime/vim48x48.xpm"
-#undef magick
-# undef static
 
     GdkWindow * const mainwin_win = gtk_widget_get_window(gui.mainwin);
 

--- a/src/gui_x11.c
+++ b/src/gui_x11.c
@@ -1363,20 +1363,9 @@ gui_mch_init(void)
 #else
 // Use Pixmaps, looking much nicer.
 
-// If you get an error message here, you still need to unpack the runtime
-// archive!
-# ifdef magick
-#  undef magick
-# endif
-# define magick vim32x32
 # include "../runtime/vim32x32.xpm"
-# undef magick
-# define magick vim16x16
 # include "../runtime/vim16x16.xpm"
-# undef magick
-# define magick vim48x48
 # include "../runtime/vim48x48.xpm"
-# undef magick
 
     static Pixmap	icon = 0;
     static Pixmap	icon_mask = 0;


### PR DESCRIPTION
Problem: Ancient preprocessor hack could lead to very confusing build errors.
Solution: Use simpler XPM that reflects current source control approach.

My primary concern here is removing the redefinition of `static`. This was [seemingly originally used as a workaround](https://github.com/vim/vim/blob/071d4279d6ab81b7187b48f3a0fc61e587b6db6c/src/gui_gtk_x11.c) to  GTKv1 vs GTKv2 API difference. When GTKv1 support was dropped, this redefinition should have also been abandoned in favor of declaring the XPM data `static const`. Those XPM files have been in version control, unchanged since 2004. Beyond being unnecessary, if one misplaces an `#if` or an `#end` this can result in _very_ confusing _"invalid storage class for function"_ errors because some functions will effectively be declared `static const`.

I've also removed this `magick` define/undef sequence because AFAICT it serves no purpose. If anyone knows a good reason this should remain, I'm open to keeping it but if we keep it then it's purpose should be documented. My best guess is that either at some point prior to the XPM files being put under version control they included code that interacted with that `magick` symbol. I consulted the v6.4 source code on the FTP archive and that version does not include any of this code so there seems to be a gap between v6.4 and the v7 sources in the git repo.
