### PR TITLE
Disable autoformat on save by default for Zig ftplugin

### DIFF
--- a/runtime/ftplugin/zig.vim
+++ b/runtime/ftplugin/zig.vim
@@ -58,7 +58,7 @@ let b:undo_ftplugin =
 
 augroup vim-zig
     autocmd! * <buffer>
-    autocmd BufWritePre <buffer> if get(g:, 'zig_fmt_autosave', 1) | call zig#fmt#Format() | endif
+    autocmd BufWritePre <buffer> if get(g:, 'zig_fmt_autosave', 0) | call zig#fmt#Format() | endif
 augroup END
 
 let b:undo_ftplugin .= '|au! vim-zig * <buffer>'


### PR DESCRIPTION
Bundled ftplugins do not typically enable autoformatting on save by default (nor should they, as that is a feature that should rightfully be left for the user to opt-in to). Users can re-enable this feature by setting `g:zig_fmt_autosave` to `1`.