### PR TITLE
fix(swayconfig): floating_modifier

### DIFF
--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -2,8 +2,8 @@
 " Language: i3 config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: Quentin Hibon (github user hiqua)
-" Version: 1.2.2
-" Last Change: 2024-04-14
+" Version: 1.2.3
+" Last Change: 2024-05-23
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -67,7 +67,7 @@ syn keyword i3ConfigBindKeyword bindsym bindcode contained skipwhite nextgroup=i
 syn region i3ConfigModeBlock matchgroup=i3ConfigKeyword start=/mode\ze\( --pango_markup\)\? \([^'" {]\+\|'[^']\+'\|".\+"\)\s\+{$/ end=/^}\zs$/ contained contains=i3ConfigShParam,@i3ConfigStrVar,i3ConfigBindKeyword,i3ConfigComment,i3ConfigParen fold keepend extend
 
 " 4.7 Floating modifier
-syn keyword i3ConfigKeyword floating_modifier contained skipwhite nextgroup=i3ConfigVariable,i3ConfigBindModkey
+syn match i3ConfigKeyword /^floating_modifier [$0-9A-Za-z]*$/ contains=i3ConfigVariable,i3ConfigBindModkey
 
 " 4.8 Floating window size
 syn keyword i3ConfigSizeSpecial x contained

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -2,8 +2,8 @@
 " Language: sway config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 1.2.2
-" Last Change: 2024-05-12
+" Version: 1.2.3
+" Last Change: 2024-05-23
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -38,8 +38,8 @@ syn region swayConfigBlockOrphan start=/^\s\+\(--[a-z-]\+ \)*\([A-Z$][$a-zA-Z0-9
 
 syn region i3ConfigExec start=/ {$/ end=/^\s*}$/ contained contains=i3ConfigExecAction,@i3ConfigSh,i3ConfigComment fold keepend extend
 
-syn keyword swayConfigFloatingModifierOpts normal inverse contained
-syn match i3ConfigKeyword /floating_modifier [$a-zA-Z0-9+]\+ \(normal\|inverse\)$/ contained contains=i3ConfigVariable,i3ConfigBindModkey,swayConfigFloatingModifierOpts
+syn keyword swayConfigFloatingModifierOpts normal inverse none contained
+syn match i3ConfigKeyword /floating_modifier \(none\|[$a-zA-Z0-9+]\+ \(normal\|inverse\)\)$/ contained contains=i3ConfigVariable,i3ConfigBindModkey,swayConfigFloatingModifierOpts
 
 syn match swayConfigI3Param /--i3/ contains=i3ConfigShParam skipwhite nextgroup=i3ConfigEdgeOpts
 syn keyword i3ConfigKeyword hide_edge_borders contained skipwhite nextgroup=swayConfigI3Param,i3ConfigEdgeOpts


### PR DESCRIPTION
Restores correct highlighting of swayconfig's `floating_modifier` with the `normal` and `inverse` options. Both i3 and sway have this keyword, but i3 does not have the `normal|inverse`. When this match was set as `contained` in 679f5ab, it prevented the sway options from being recognized.

Added the `none` option which was not supported but is a [valid option](https://github.com/swaywm/sway/blob/970415241497ceccfb013b6f8cb2395abee74e5c/sway/sway.5.scd?plain=1#L680) in sway config.

Ideally `floating_modifier` would  be a keyword as it is in `i3config.vim`, but I'm still working that out.

Fixes #14826 

