### PR TITLE
Crash when using '?' as separator for :s

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -620,6 +620,7 @@ skip_regexp_ex(
 {
     magic_T	mymagic;
     char_u	*p = startp;
+    size_t	startplen = STRLEN(startp);
 
     if (magic)
 	mymagic = MAGIC_ON;
@@ -642,12 +643,9 @@ skip_regexp_ex(
 	{
 	    if (dirc == '?' && newp != NULL && p[1] == '?')
 	    {
-		size_t	startplen = 0;
-
 		// change "\?" to "?", make a copy first.
 		if (*newp == NULL)
 		{
-		    startplen = STRLEN(startp);
 		    *newp = vim_strnsave(startp, startplen);
 		    if (*newp != NULL)
 			p = *newp + (p - startp);

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -173,6 +173,16 @@ func Test_substitute_repeat()
   call feedkeys("Qsc\<CR>y", 'tx')
   bwipe!
 endfunc
+
+" Test :s with ? as separator.
+func Test_substitute_question_separator()
+  new
+  call setline(1, '??:??')
+  %s?\?\??!!?g
+  call assert_equal('!!:!!', getline(1))
+  bwipe!
+endfunc
+
 " Test %s/\n// which is implemented as a special case to use a
 " more efficient join rather than doing a regular substitution.
 func Test_substitute_join()


### PR DESCRIPTION
Problem:  Crash when using '?' as separator for :s and pattern contains
          escaped '?'s (after 9.1.0409).
Solution: Always compute startplen.

Fix neovim/neovim#28935
