### PR TITLE
Fix tiny and normal builds for Motif.

### DIFF
--- a/runtime/vim16x16.xpm
+++ b/runtime/vim16x16.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * vim16x16[] = {
+static char * vim16x16[] = {
 "16 16 8 1",
 " 	c None",
 ".	c #000000",

--- a/runtime/vim32x32.xpm
+++ b/runtime/vim32x32.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * vim32x32[] = {
+static char * vim32x32[] = {
 "32 32 8 1",
 " 	c None",
 ".	c #000000",

--- a/runtime/vim48x48.xpm
+++ b/runtime/vim48x48.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * vim48x48[] = {
+static char * vim48x48[] = {
 "48 48 8 1",
 " 	c None",
 ".	c #000000",

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -2727,9 +2727,9 @@ mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 	 */
 	GList *icons = NULL;
 
-	icons = g_list_prepend(icons, gdk_pixbuf_new_from_xpm_data(vim16x16));
-	icons = g_list_prepend(icons, gdk_pixbuf_new_from_xpm_data(vim32x32));
-	icons = g_list_prepend(icons, gdk_pixbuf_new_from_xpm_data(vim48x48));
+	icons = g_list_prepend(icons, gdk_pixbuf_new_from_xpm_data((const char **)vim16x16));
+	icons = g_list_prepend(icons, gdk_pixbuf_new_from_xpm_data((const char **)vim32x32));
+	icons = g_list_prepend(icons, gdk_pixbuf_new_from_xpm_data((const char **)vim48x48));
 
 	gtk_window_set_icon_list(GTK_WINDOW(gui.mainwin), icons);
 


### PR DESCRIPTION
Problem: Motif requires non-const char pointer for XPM data shared with GTK.
Solution: Cast non-const to const char pointer for GTK.