### PR TITLE
Wrong Ex command executed when :g uses '?' as delimiter

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -620,7 +620,7 @@ skip_regexp_ex(
 {
     magic_T	mymagic;
     char_u	*p = startp;
-    size_t	startplen = STRLEN(startp);
+    size_t	startplen = 0;
 
     if (magic)
 	mymagic = MAGIC_ON;
@@ -644,16 +644,21 @@ skip_regexp_ex(
 	    if (dirc == '?' && newp != NULL && p[1] == '?')
 	    {
 		// change "\?" to "?", make a copy first.
+		if (startplen == 0)
+		    startplen = STRLEN(startp);
 		if (*newp == NULL)
 		{
 		    *newp = vim_strnsave(startp, startplen);
 		    if (*newp != NULL)
+		    {
 			p = *newp + (p - startp);
+			startp = *newp;
+		    }
 		}
 		if (dropped != NULL)
 		    ++*dropped;
 		if (*newp != NULL)
-		    mch_memmove(p, p + 1, (startplen - ((p + 1) - *newp)) + 1);
+		    mch_memmove(p, p + 1, startplen - ((p + 1) - startp) + 1);
 		else
 		    ++p;
 	    }

--- a/src/testdir/test_global.vim
+++ b/src/testdir/test_global.vim
@@ -116,7 +116,16 @@ func Test_global_newline()
   close!
 endfunc
 
-func Test_wrong_delimiter()
+" Test :g with ? as delimiter.
+func Test_global_question_delimiter()
+  new
+  call setline(1, ['aaaaa', 'b?bbb', 'ccccc', 'ddd?d', 'eeeee'])
+  g?\??delete
+  call assert_equal(['aaaaa', 'ccccc', 'eeeee'], getline(1, '$'))
+  bwipe!
+endfunc
+
+func Test_global_wrong_delimiter()
   call assert_fails('g x^bxd', 'E146:')
 endfunc
 

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -174,8 +174,8 @@ func Test_substitute_repeat()
   bwipe!
 endfunc
 
-" Test :s with ? as separator.
-func Test_substitute_question_separator()
+" Test :s with ? as delimiter.
+func Test_substitute_question_delimiter()
   new
   call setline(1, '??:??')
   %s?\?\??!!?g


### PR DESCRIPTION
Problem:  Wrong Ex command executed when :g uses '?' as delimiter and
          pattern contains escaped '?'.
Solution: Don't use "*newp" when it's not allocated.
