### PR TITLE
feat(runtime)!: add padding to commentstrings

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -176,6 +176,7 @@ runtime/ftplugin/kotlin.vim		@udalov
 runtime/ftplugin/less.vim		@genoma
 runtime/ftplugin/liquid.vim		@tpope
 runtime/ftplugin/lua.vim		@dkearns
+runtime/ftplugin/lc.vim			@ribru17
 runtime/ftplugin/lynx.vim		@dkearns
 runtime/ftplugin/m3build.vim		@dkearns
 runtime/ftplugin/m3quake.vim		@dkearns

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1914,8 +1914,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			{not available when compiled without the |+folding|
 			feature}
 	A template for a comment.  The "%s" in the value is replaced with the
-	comment text.  Currently only used to add markers for folding, see
-	|fold-marker|.  Also used by comment plugins |comment-install|.
+	comment text, and should be padded with a space when possible.
+	Currently only used to add markers for folding, see |fold-marker|.
+	Also used by comment plugins |comment-install|.
 
 			*'compatible'* *'cp'* *'nocompatible'* *'nocp'*
 'compatible' 'cp'	boolean	(default on, off when a |vimrc| or |gvimrc|

--- a/runtime/ftplugin/abaqus.vim
+++ b/runtime/ftplugin/abaqus.vim
@@ -3,6 +3,7 @@
 " Maintainer:   Carl Osterwisch <costerwi@gmail.com>
 " Last Change:  2022 Oct 08
 "               2024 Jan 14 by Vim Project (browsefilter)
+"               2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -27,7 +28,7 @@ setlocal isfname-=,
 
 " Define format of comment lines (see 'formatoptions' for uses)
 setlocal comments=:**
-setlocal commentstring=**%s
+setlocal commentstring=**\ %s
 
 " Definitions start with a * and assign a NAME, NSET, or ELSET
 " Used in [d ^wd and other commands

--- a/runtime/ftplugin/arduino.vim
+++ b/runtime/ftplugin/arduino.vim
@@ -3,6 +3,7 @@
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
 "		Ken Takata <https://github.com/k-takata>
 " Last Change:	2024 Apr 12
+"		2024 Jun 02 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 "
 " Most of the part was copied from c.vim.
 
@@ -32,7 +33,7 @@ setlocal fo-=t fo+=croql
 
 " These options have the right value as default, but the user may have
 " overruled that.
-setlocal commentstring& define& include&
+setlocal commentstring=/*\ %s\ */ define& include&
 
 " Set completion with CTRL-X CTRL-O to autoloaded function.
 if exists('&ofu')

--- a/runtime/ftplugin/asm.vim
+++ b/runtime/ftplugin/asm.vim
@@ -4,13 +4,14 @@
 " Last Change:	2020 May 23
 " 		2023 Aug 28 by Vim Project (undo_ftplugin)
 " 		2024 Apr 09 by Vim Project (add Matchit support)
+" 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
 
 setl include=^\\s*%\\s*include
 setl comments=:;,s1:/*,mb:*,ex:*/,://
-setl commentstring=;%s
+setl commentstring=;\ %s
 
 let b:undo_ftplugin = "setl commentstring< comments< include<"
 

--- a/runtime/ftplugin/astro.vim
+++ b/runtime/ftplugin/astro.vim
@@ -2,6 +2,7 @@
 " Language:     Astro
 " Maintainer:   Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change:  2024 Apr 21
+"               2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
     finish
@@ -25,17 +26,17 @@ function! s:AstroComments() abort
                 \ || s:IdentifyScope('^\s*<script', '^\s*<\/script>')
         " ECMAScript comments
         setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
-        setlocal commentstring=//%s
+        setlocal commentstring=//\ %s
 
     elseif s:IdentifyScope('^\s*<style', '^\s*<\/style>')
         " CSS comments
         setlocal comments=s1:/*,mb:*,ex:*/
-        setlocal commentstring=/*%s*/
+        setlocal commentstring=/*\ %s\ */
 
     else
         " HTML comments
         setlocal comments=s:<!--,m:\ \ \ \ ,e:-->
-        setlocal commentstring=<!--%s-->
+        setlocal commentstring=<!--\ %s\ -->
     endif
 endfunction
 

--- a/runtime/ftplugin/bitbake.vim
+++ b/runtime/ftplugin/bitbake.vim
@@ -3,13 +3,14 @@
 " Maintainer: Gregory Anders <greg@gpanders.com>
 " Repository: https://github.com/openembedded/bitbake
 " Latest Revision: 2022-07-23
+"                  2024-05-23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
 endif
 let b:did_ftplugin = 1
 
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal comments=:#
 setlocal suffixesadd=.bb,.bbclass
 

--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -2,6 +2,7 @@
 " Language:	C
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
 " Last Change:	2023 Aug 22
+"		2024 Jun 02 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -24,7 +25,7 @@ setlocal fo-=t fo+=croql
 
 " These options have the right value as default, but the user may have
 " overruled that.
-setlocal commentstring& define& include&
+setlocal commentstring=/*\ %s\ */ define& include&
 
 " Set completion with CTRL-X CTRL-O to autoloaded function.
 if exists('&ofu')

--- a/runtime/ftplugin/calendar.vim
+++ b/runtime/ftplugin/calendar.vim
@@ -2,6 +2,7 @@
 " Language:             calendar(1) input file
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2008-07-09
+"                       2024-06-02 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -13,7 +14,7 @@ set cpo&vim
 
 let b:undo_ftplugin = "setl com< cms< inc< fo<"
 
-setlocal comments=s1:/*,mb:*,ex:*/ commentstring& include&
+setlocal comments=s1:/*,mb:*,ex:*/ commentstring=/*\ %s\ */ include&
 setlocal formatoptions-=t formatoptions+=croql
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/cgdbrc.vim
+++ b/runtime/ftplugin/cgdbrc.vim
@@ -3,6 +3,7 @@
 " Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
 " Documentation:        https://cgdb.github.io/docs/Configuring-CGDB.html
 " Latest Revision:      2024-04-09
+"                       2024-05-23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists('b:did_ftplugin')
   finish
@@ -14,7 +15,7 @@ set cpoptions&vim
 
 let b:undo_ftplugin = 'setl com< cms<'
 
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal comments=:#
 
 let &cpoptions = s:save_cpoptions

--- a/runtime/ftplugin/csh.vim
+++ b/runtime/ftplugin/csh.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:	Dan Sharp
 " Contributor:		Johannes Zellner <johannes@zellner.org>
 " Last Change:		2024 Jan 14
+" 			2024 May 23 by Riley Bruins ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -14,7 +15,7 @@ let s:save_cpo = &cpo
 set cpo-=C
 
 setlocal comments=:#
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal formatoptions-=t
 setlocal formatoptions+=crql
 

--- a/runtime/ftplugin/css.vim
+++ b/runtime/ftplugin/css.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
 " Last Change:		2020 Dec 21
+"			2024 Jun 02 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -14,7 +15,7 @@ set cpo&vim
 
 let b:undo_ftplugin = "setl com< cms< inc< fo< ofu< isk<"
 
-setlocal comments=s1:/*,mb:*,ex:*/ commentstring&
+setlocal comments=s1:/*,mb:*,ex:*/ commentstring=/*\ %s\ */
 setlocal formatoptions-=t formatoptions+=croql
 setlocal omnifunc=csscomplete#CompleteCSS
 setlocal iskeyword+=-

--- a/runtime/ftplugin/desktop.vim
+++ b/runtime/ftplugin/desktop.vim
@@ -2,6 +2,7 @@
 " Language: XDG desktop entry
 " Maintainer: Eisuke Kawashima ( e.kawaschima+vim AT gmail.com )
 " Last Change: 2022-07-26
+"              2024-05-24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists('b:did_ftplugin')
   finish
@@ -9,5 +10,5 @@ endif
 let b:did_ftplugin = v:true
 
 setl comments=:#
-setl commentstring=#%s
+setl commentstring=#\ %s
 let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/ftplugin/dtd.vim
+++ b/runtime/ftplugin/dtd.vim
@@ -6,6 +6,7 @@
 " Former maintainer:	Dan Sharp
 " Last Change:		2009 Jan 20
 "			2024 Jan 14 by Vim Project (browsefilter)
+"			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -15,7 +16,7 @@ let b:did_ftplugin = 1
 let s:save_cpo = &cpo
 set cpo-=C
 
-setlocal commentstring=<!--%s-->
+setlocal commentstring=<!--\ %s\ -->
 setlocal comments=s:<!--,m:\ \ \ \ \ ,e:-->
 
 setlocal formatoptions-=t

--- a/runtime/ftplugin/dtrace.vim
+++ b/runtime/ftplugin/dtrace.vim
@@ -1,6 +1,7 @@
 " Language: D script as described in "Solaris Dynamic Tracing Guide",
 "           http://docs.sun.com/app/docs/doc/817-6223
 " Last Change: 2008/03/20
+"              2024/05/23 by Riley Bruins <ribru17@gmail.com ('commentstring')
 " Version: 1.2
 " Maintainer: Nicolas Weber <nicolasweber@gmx.de>
 
@@ -26,8 +27,8 @@ setlocal fo-=t fo+=croql
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/
 
 " dtrace uses /* */ comments. Set this explicitly, just in case the user
-" changed this (/*%s*/ is the default)
-setlocal commentstring=/*%s*/
+" changed this (/*\ %s\ */ is the default)
+setlocal commentstring=/*\ %s\ */
 
 setlocal iskeyword+=@,$
 

--- a/runtime/ftplugin/dts.vim
+++ b/runtime/ftplugin/dts.vim
@@ -2,6 +2,7 @@
 " Language:             dts/dtsi (device tree files)
 " Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
 " Latest Revision:      2024 Apr 12
+"                       2024 Jun 02 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists('b:did_ftplugin')
   finish
@@ -12,5 +13,5 @@ let b:undo_ftplugin = 'setl inc< cms< com<'
 
 setlocal include=^\\%(#include\\\|/include/\\)
 " same as C
-setlocal commentstring&
+setlocal commentstring=/*\ %s\ */
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://

--- a/runtime/ftplugin/erlang.vim
+++ b/runtime/ftplugin/erlang.vim
@@ -6,7 +6,8 @@
 "               Eduardo Lopez (http://github.com/tapichu)
 "               Arvid Bjurklint (http://github.com/slarwise)
 "               Paweł Zacharek (http://github.com/subc2)
-" Last Update:  2023-Dec-20
+"               Riley Bruins (http://github.com/ribru17) ('commentstring')
+" Last Update:  2024-May-23
 " License:      Vim license
 " URL:          https://github.com/vim-erlang/vim-erlang-runtime
 
@@ -27,7 +28,7 @@ if get(g:, 'erlang_folding', 0)
 endif
 
 setlocal comments=:%%%,:%%,:%
-setlocal commentstring=%%s
+setlocal commentstring=%\ %s
 
 setlocal formatoptions+=ro
 

--- a/runtime/ftplugin/eruby.vim
+++ b/runtime/ftplugin/eruby.vim
@@ -5,6 +5,7 @@
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2022 May 15
 "			2024 Jan 14 by Vim Project (browsefilter)
+"			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -125,7 +126,7 @@ if exists("loaded_matchit")
 endif
 
 " TODO: comments=
-setlocal commentstring=<%#%s%>
+setlocal commentstring=<%#\ %s\ %>
 
 let b:undo_ftplugin = "setl cms< " .
       \ " | unlet! b:browsefilter b:match_words | " . b:undo_ftplugin

--- a/runtime/ftplugin/fennel.vim
+++ b/runtime/ftplugin/fennel.vim
@@ -2,13 +2,14 @@
 " Language:     Fennel
 " Maintainer:   Gregory Anders <greg[NOSPAM]@gpanders.com>
 " Last Update:  2023 Jun 9
+"               2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists('b:did_ftplugin')
   finish
 endif
 let b:did_ftplugin = 1
 
-setlocal commentstring=;%s
+setlocal commentstring=;\ %s
 setlocal comments=:;;,:;
 setlocal formatoptions-=t
 setlocal suffixesadd=.fnl

--- a/runtime/ftplugin/fish.vim
+++ b/runtime/ftplugin/fish.vim
@@ -4,6 +4,7 @@
 " Repository:   https://github.com/nickeb96/fish.vim
 " Last Change:  February 1, 2023
 "               2023 Aug 28 by Vim Project (undo_ftplugin)
+"               2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
     finish
@@ -12,7 +13,7 @@ let b:did_ftplugin = 1
 
 setlocal iskeyword=@,48-57,_,192-255,-,.
 setlocal comments=:#
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal formatoptions+=crjq
 
 let b:undo_ftplugin = "setl cms< com< fo< isk<"

--- a/runtime/ftplugin/fortran.vim
+++ b/runtime/ftplugin/fortran.vim
@@ -11,6 +11,7 @@
 "  Doug Kearns, and Fritz Reese.
 " Last Change:	2023 Dec 22
 "		2024 Jan 14 by Vim Project (browsefilter)
+"		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do these settings when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -89,7 +90,7 @@ else
 endif
 
 " Set commentstring for foldmethod=marker
-setlocal cms=!%s
+setlocal cms=!\ %s
 
 " Tabs are not a good idea in Fortran so the default is to expand tabs
 if !exists("fortran_have_tabs")

--- a/runtime/ftplugin/fstab.vim
+++ b/runtime/ftplugin/fstab.vim
@@ -3,6 +3,7 @@
 " Maintainer: Radu Dineiu <radu.dineiu@gmail.com>
 " URL: https://raw.github.com/rid9/vim-fstab/master/ftplugin/fstab.vim
 " Last Change: 2021 Jan 02
+"              2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 " Version: 1.0
 "
 " Credits:
@@ -13,7 +14,7 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 let b:undo_ftplugin = "setlocal commentstring<"
 
 " vim: ts=8 ft=vim

--- a/runtime/ftplugin/gdb.vim
+++ b/runtime/ftplugin/gdb.vim
@@ -3,11 +3,12 @@
 " Maintainer:	Michaël Peeters <NOSPAMm.vim@noekeon.org>
 " Last Changed: 2017-10-26
 "               2024-04-10:	- add Matchit support (by Vim Project)
+"               2024-04-23:	- add space to commentstring (by Riley Bruins) ('commentstring')
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
 
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal include=^\\s*source
 
 " Undo the stuff we changed.

--- a/runtime/ftplugin/groovy.vim
+++ b/runtime/ftplugin/groovy.vim
@@ -2,6 +2,7 @@
 " Language:	groovy
 " Maintainer:	Justin M. Keyes <justinkz@gmail.com>
 " Last Change:	2016 May 22
+" 		2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists('b:did_ftplugin')
   finish
@@ -13,7 +14,7 @@ set cpo-=C
 
 let b:undo_ftplugin = 'setlocal commentstring<'
 
-setlocal commentstring=//%s
+setlocal commentstring=//\ %s
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/hamster.vim
+++ b/runtime/ftplugin/hamster.vim
@@ -3,6 +3,7 @@
 " Version:     2.0.6.0
 " Maintainer:  David Fishburn <dfishburn dot vim at gmail dot com>
 " Last Change: 2021 Jan 19
+"              2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -31,7 +32,7 @@ if &tw == 0
 endif
 
 " Comments start with a double quote
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 
 " Move around functions.
 noremap <silent><buffer> [[ :call search('^\s*sub\>', "bW")<CR>

--- a/runtime/ftplugin/html.vim
+++ b/runtime/ftplugin/html.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
 " Last Change:		2024 Jan 14
+" 			2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -13,7 +14,7 @@ let s:save_cpo = &cpo
 set cpo-=C
 
 setlocal matchpairs+=<:>
-setlocal commentstring=<!--%s-->
+setlocal commentstring=<!--\ %s\ -->
 setlocal comments=s:<!--,m:\ \ \ \ ,e:-->
 
 let b:undo_ftplugin = "setlocal comments< commentstring< matchpairs<"

--- a/runtime/ftplugin/indent.vim
+++ b/runtime/ftplugin/indent.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
 " Latest Revision:	2008-07-09
+"			2024-06-02 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -14,7 +15,7 @@ set cpo&vim
 
 let b:undo_ftplugin = "setl com< cms< fo<"
 
-setlocal comments=s1:/*,mb:*,ex:*/ commentstring&
+setlocal comments=s1:/*,mb:*,ex:*/ commentstring=/*\ %s\ */
 setlocal formatoptions-=t formatoptions+=croql
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/initex.vim
+++ b/runtime/ftplugin/initex.vim
@@ -3,6 +3,7 @@
 " Maintainer:   Benji Fisher, Ph.D. <benji@member.AMS.org>
 " Version:	1.0
 " Last Change:	Wed 19 Apr 2006
+" Last Change:	Thu 23 May 2024 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer.
 if exists("b:did_ftplugin")
@@ -23,7 +24,7 @@ setlocal com=sO:%\ -,mO:%\ \ ,eO:%%,:%
 
 " Set 'commentstring' to recognize the % comment character:
 " (Thanks to Ajit Thakkar.)
-setlocal cms=%%s
+setlocal cms=%\ %s
 
 " Allow "[d" to be used to find a macro definition:
 let &l:define='\\\([egx]\|char\|mathchar\|count\|dimen\|muskip\|skip\|toks\)\='

--- a/runtime/ftplugin/java.vim
+++ b/runtime/ftplugin/java.vim
@@ -5,6 +5,7 @@
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
 " Last Change:		2024 Apr 18
 "			2024 Jan 14 by Vim Project (browsefilter)
+"			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -61,7 +62,7 @@ setlocal formatoptions-=t formatoptions+=croql
 " Set 'comments' to format dashed lists in comments. Behaves just like C.
 setlocal comments& comments^=sO:*\ -,mO:*\ \ ,exO:*/
 
-setlocal commentstring=//%s
+setlocal commentstring=//\ %s
 
 " Change the :browse e filter to primarily show Java-related files.
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")

--- a/runtime/ftplugin/javascript.vim
+++ b/runtime/ftplugin/javascript.vim
@@ -3,6 +3,7 @@
 " Maintainer:   Doug Kearns <dougkearns@gmail.com>
 " Contributor:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change:	2024 Jan 14
+" 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
     finish
@@ -24,7 +25,7 @@ endif
 " Set 'comments' to format dashed lists in comments.
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 
-setlocal commentstring=//%s
+setlocal commentstring=//\ %s
 
 " Change the :browse e filter to primarily show JavaScript-related files.
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")

--- a/runtime/ftplugin/jq.vim
+++ b/runtime/ftplugin/jq.vim
@@ -2,6 +2,7 @@
 " Language:	jq
 " Maintainer:	Vito <vito.blog@gmail.com>
 " Last Change:	2024 Apr 29
+" 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 " Upstream: https://github.com/vito-c/jq.vim
 
 if exists('b:did_ftplugin')
@@ -10,7 +11,7 @@ endif
 let b:did_ftplugin = 1
 
 setlocal include=^\\s*\\%(import\\\|include\\)
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 compiler jq
 
 let b:undo_ftplugin = 'setl commentstring< include<'

--- a/runtime/ftplugin/jsonc.vim
+++ b/runtime/ftplugin/jsonc.vim
@@ -5,6 +5,7 @@
 "                   https://github.com/kevinoid/vim-jsonc
 " License:          MIT
 " Last Change:      2021 Nov 22
+"                   2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 runtime! ftplugin/json.vim
 
@@ -15,7 +16,7 @@ else
 endif
 
 " Set comment (formatting) related options. {{{1
-setlocal commentstring=//%s comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 
 " Let Vim know how to disable the plug-in.
 let b:undo_ftplugin = 'setlocal commentstring< comments<'

--- a/runtime/ftplugin/lc.vim
+++ b/runtime/ftplugin/lc.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	Elsa
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 May 25
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:-- commentstring=--\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/ftplugin/ld.vim
+++ b/runtime/ftplugin/ld.vim
@@ -2,6 +2,7 @@
 " Language:             ld(1) script
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2008-07-09
+"                       2024-05-23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -13,7 +14,7 @@ set cpo&vim
 
 let b:undo_ftplugin = "setl com< cms< inc< fo<"
 
-setlocal comments=s1:/*,mb:*,ex:*/ commentstring=/*%s*/ include=^\\s*INCLUDE
+setlocal comments=s1:/*,mb:*,ex:*/ commentstring=/*\ %s\ */ include=^\\s*INCLUDE
 setlocal formatoptions-=t formatoptions+=croql
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/liquid.vim
+++ b/runtime/ftplugin/liquid.vim
@@ -2,6 +2,7 @@
 " Language:     Liquid
 " Maintainer:   Tim Pope <vimNOSPAM@tpope.org>
 " Last Change:	2022 Mar 15
+"             	2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists('b:did_ftplugin')
   finish
@@ -56,6 +57,6 @@ if exists('loaded_matchit')
   let b:match_words .= '\<\%(if\w*\|unless\|case\)\>:\<\%(elsif\|else\|when\)\>:\<end\%(if\w*\|unless\|case\)\>,\<\%(for\|tablerow\)\>:\%({%\s*\)\@<=empty\>:\<end\%(for\|tablerow\)\>,\<\(capture\|comment\|highlight\)\>:\<end\1\>'
 endif
 
-setlocal commentstring={%\ comment\ %}%s{%\ endcomment\ %}
+setlocal commentstring={%\ comment\ %}\ %s\ {%\ endcomment\ %}
 
 let b:undo_ftplugin .= 'setl cms< | unlet! b:browsefilter b:match_words'

--- a/runtime/ftplugin/lisp.vim
+++ b/runtime/ftplugin/lisp.vim
@@ -5,6 +5,7 @@
 " Original author:    Dorai Sitaram <ds26@gte.com>
 " Original URL:		 http://www.ccs.neu.edu/~dorai/vimplugins/vimplugins.html
 " Last Change:   Mar 10, 2021
+"                May 23, 2024 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -19,6 +20,6 @@ setl define=^\\s*(def\\k*
 setl formatoptions-=t
 setl iskeyword+=+,-,*,/,%,<,=,>,:,$,?,!,@-@,94
 setl lisp
-setl commentstring=;%s
+setl commentstring=;\ %s
 
 let b:undo_ftplugin = "setlocal comments< define< formatoptions< iskeyword< lisp< commentstring<"

--- a/runtime/ftplugin/markdown.vim
+++ b/runtime/ftplugin/markdown.vim
@@ -2,6 +2,7 @@
 " Language:     Markdown
 " Maintainer:   Tim Pope <https://github.com/tpope/vim-markdown>
 " Last Change:  2023 Dec 28
+"               2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -12,7 +13,7 @@ runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim
 let s:keepcpo= &cpo
 set cpo&vim
 
-setlocal comments=fb:*,fb:-,fb:+,n:> commentstring=<!--%s-->
+setlocal comments=fb:*,fb:-,fb:+,n:> commentstring=<!--\ %s\ -->
 setlocal formatoptions+=tcqln formatoptions-=r formatoptions-=o
 setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^\\s*[-*+]\\s\\+\\\|^\\[^\\ze[^\\]]\\+\\]:\\&^.\\{4\\}
 

--- a/runtime/ftplugin/mma.vim
+++ b/runtime/ftplugin/mma.vim
@@ -2,6 +2,7 @@
 " Language:	Mathematica
 " Maintainer:	Ian Ford <ianf@wolfram.com>
 " Last Change:	22 January 2019
+" 		23 May 2024 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -13,4 +14,4 @@ let b:did_ftplugin = 1
 
 let b:undo_ftplugin = "setlocal commentstring<"
 
-setlocal commentstring=\(*%s*\)
+setlocal commentstring=\(*\ %s\ *\)

--- a/runtime/ftplugin/modula2.vim
+++ b/runtime/ftplugin/modula2.vim
@@ -2,6 +2,7 @@
 " Language:	Modula-2
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -17,7 +18,7 @@ if s:dialect ==# "r10"
   setlocal comments=s:(*,m:\ ,e:*),:!
   setlocal commentstring=!\ %s
 else
-  setlocal commentstring=(*%s*)
+  setlocal commentstring=(*\ %s\ *)
   setlocal comments=s:(*,m:\ ,e:*)
 endif
 setlocal formatoptions-=t formatoptions+=croql

--- a/runtime/ftplugin/modula3.vim
+++ b/runtime/ftplugin/modula3.vim
@@ -2,6 +2,7 @@
 " Language:	Modula-3
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 		2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -12,7 +13,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal comments=s0:(*,mb:\ ,ex:*)
-setlocal commentstring=(*%s*)
+setlocal commentstring=(*\ %s\ *)
 setlocal formatoptions-=t formatoptions+=croql
 setlocal suffixesadd+=.m3
 setlocal formatprg=m3pp

--- a/runtime/ftplugin/nroff.vim
+++ b/runtime/ftplugin/nroff.vim
@@ -3,14 +3,14 @@
 " Maintainer:	Aman Verma
 " Homepage:	https://github.com/a-vrma/vim-nroff-ftplugin
 " Previous Maintainer:	Chris Spiegel <cspiegel@gmail.com>
-" Last Change:	2020 Nov 21
+" 			2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
 endif
 let b:did_ftplugin = 1
 
-setlocal commentstring=.\\\"%s
+setlocal commentstring=.\\\"\ %s
 setlocal comments=:.\\\"
 setlocal sections+=Sh
 

--- a/runtime/ftplugin/obse.vim
+++ b/runtime/ftplugin/obse.vim
@@ -4,6 +4,7 @@
 " Maintainer:  Kat <katisntgood@gmail.com>
 " Created:     August 08, 2021
 " Last Change: 13 November 2022
+"              23 May 2024 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -20,7 +21,7 @@ noremap <script> <buffer> <silent> ]] <nop>
 noremap <script> <buffer> <silent> [] <nop>
 noremap <script> <buffer> <silent> ][ <nop>
 
-setlocal commentstring=;%s
+setlocal commentstring=;\ %s
 setlocal comments=:;
 
 function s:NextSection(type, backwards, visual)

--- a/runtime/ftplugin/ocaml.vim
+++ b/runtime/ftplugin/ocaml.vim
@@ -5,12 +5,14 @@
 "              Pierre Vittet       <pierre-vittet@pvittet.com>
 "              Stefano Zacchiroli  <zack@bononia.it>
 "              Vincent Aravantinos <firstname.name@imag.fr>
+"              Riley Bruins <ribru17@gmail.com> ('commentstring')
 " URL:         https://github.com/ocaml/vim-ocaml
 " Last Change:
 "              2013 Oct 27 - Added commentstring (MM)
 "              2013 Jul 26 - load default compiler settings (MM)
 "              2013 Jul 24 - removed superfluous efm-setting (MM)
 "              2013 Jul 22 - applied fixes supplied by Hirotaka Hamada (MM)
+"              2024 May 23 - added space in commentstring (RB)
 
 if exists("b:did_ftplugin")
   finish
@@ -40,7 +42,7 @@ set cpo&vim
 " Comment string
 setlocal comments=sr:(*\ ,mb:\ ,ex:*)
 setlocal comments^=sr:(**,mb:\ \ ,ex:*)
-setlocal commentstring=(*%s*)
+setlocal commentstring=(*\ %s\ *)
 
 " Add mappings, unless the user didn't want this.
 if !exists("no_plugin_maps") && !exists("no_ocaml_maps")

--- a/runtime/ftplugin/odin.vim
+++ b/runtime/ftplugin/odin.vim
@@ -5,6 +5,7 @@ vim9script
 # Maintainer: Maxim Kim <habamax@gmail.com>
 # Website: https://github.com/habamax/vim-odin
 # Last Change: 2024-01-15
+#              2024-05-23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
     finish
@@ -16,5 +17,5 @@ b:undo_ftplugin = 'setlocal commentstring<'
       \ .. '| setlocal suffixesadd<'
 
 setlocal suffixesadd=.odin
-setlocal commentstring=//%s
+setlocal commentstring=//\ %s
 setlocal comments=s1:/*,mb:*,ex:*/,://

--- a/runtime/ftplugin/openvpn.vim
+++ b/runtime/ftplugin/openvpn.vim
@@ -2,6 +2,7 @@
 " Language:	OpenVPN
 " Maintainer:	ObserverOfTime <chronobserver@disroot.org>
 " Last Change:	2022 Oct 16
+" 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists('b:did_ftplugin')
   finish
@@ -9,6 +10,6 @@ endif
 let b:did_ftplugin = 1
 
 setlocal iskeyword+=-,.,/
-setlocal comments=:#,:; commentstring=#%s
+setlocal comments=:#,:; commentstring=#\ %s
 
 let b:undo_ftplugin = 'setl isk< com< cms<'

--- a/runtime/ftplugin/pascal.vim
+++ b/runtime/ftplugin/pascal.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
 " Last Change:		2024 Jan 14
+" 			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -11,7 +12,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 set comments=s:(*,m:\ ,e:*),s:{,m:\ ,e:}
-set commentstring={%s}
+set commentstring={\ %s\ }
 
 if exists("pascal_delphi")
   set comments+=:///

--- a/runtime/ftplugin/pdf.vim
+++ b/runtime/ftplugin/pdf.vim
@@ -2,13 +2,14 @@
 " Language:	PDF
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.info>
 " Last Change:	2007 Dec 16
+" 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
     finish
 endif
 let b:did_ftplugin = 1
 
-setlocal commentstring=%%s
+setlocal commentstring=%\ %s
 setlocal comments=:%
 let b:undo_ftplugin = "setlocal cms< com< | unlet! b:match_words"
 

--- a/runtime/ftplugin/perl.vim
+++ b/runtime/ftplugin/perl.vim
@@ -8,6 +8,7 @@
 "                2023 Sep 07 by Vim Project (safety check: don't execute perl
 "                    from current directory)
 "                2024 Jan 14 by Vim Project (browsefilter)
+"                2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -22,7 +23,7 @@ setlocal formatoptions+=crqol
 setlocal keywordprg=perldoc\ -f
 
 setlocal comments=:#
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 
 " Provided by Ned Konz <ned at bike-nomad dot com>
 "---------------------------------------------

--- a/runtime/ftplugin/php.vim
+++ b/runtime/ftplugin/php.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
 " Last Change:		2024 Jan 14
+" Last Change:		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -44,7 +45,7 @@ if exists("b:match_skip")
 endif
 
 setlocal comments=s1:/*,mb:*,ex:*/,://,:#
-setlocal commentstring=/*%s*/
+setlocal commentstring=/*\ %s\ */
 setlocal formatoptions+=l formatoptions-=t
 
 if get(g:, "php_autocomment", 1)

--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -3,6 +3,7 @@
 " URL:         https://github.com/PProvost/vim-ps1
 " Last Change: 2021 Apr 02
 "              2024 Jan 14 by Vim Project (browsefilter)
+"              2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -14,7 +15,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal tw=0
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal formatoptions=tcqro
 " Enable autocompletion of hyphenated PowerShell commands,
 " e.g. Get-Content or Get-ADUser

--- a/runtime/ftplugin/ps1xml.vim
+++ b/runtime/ftplugin/ps1xml.vim
@@ -3,6 +3,7 @@
 " URL:         https://github.com/PProvost/vim-ps1
 " Last Change: 2021 Apr 02
 "              2024 Jan 14 by Vim Project (browsefilter)
+"              2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -14,7 +15,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal tw=0
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal formatoptions=tcqro
 
 " Change the browse dialog on Win32 and GTK to show mainly PowerShell-related files

--- a/runtime/ftplugin/qml.vim
+++ b/runtime/ftplugin/qml.vim
@@ -3,6 +3,7 @@
 " Maintainer: Chase Knowlden <haroldknowlden@gmail.com>
 " Last Change: 2023 Aug 16
 " 	       2023 Aug 23 by Vim Project (browsefilter)
+" 	       2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists( 'b:did_ftplugin' )
    finish
@@ -28,7 +29,7 @@ endif
 
 " Set 'comments' to format dashed lists in comments.
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
-setlocal commentstring=//%s
+setlocal commentstring=//\ %s
 
 setlocal formatoptions-=t
 setlocal formatoptions+=croql

--- a/runtime/ftplugin/racket.vim
+++ b/runtime/ftplugin/racket.vim
@@ -3,8 +3,7 @@
 " Maintainer:           D. Ben Knoble <ben.knoble+github@gmail.com>
 " Previous Maintainer:  Will Langstroth <will@langstroth.com>
 " URL:                  https://github.com/benknoble/vim-racket
-" Last Change:          2022 Aug 29
-"                       2024 Jan 14 by Vim Project (browsefilter)
+" Last Change:          2024 May 28
 
 if exists("b:did_ftplugin")
   finish
@@ -21,7 +20,7 @@ setlocal iskeyword=@,!,#-',*-:,<-Z,a-z,~,_,94
 setlocal comments=:;;;;,:;;;,:;;,:;
 setlocal formatoptions+=r
 
-"setlocal commentstring=;;%s
+"setlocal commentstring=;;\ %s
 setlocal commentstring=#\|\ %s\ \|#
 
 setlocal formatprg=raco\ fmt

--- a/runtime/ftplugin/raku.vim
+++ b/runtime/ftplugin/raku.vim
@@ -4,6 +4,7 @@
 " Homepage:      https://github.com/Raku/vim-raku
 " Bugs/requests: https://github.com/Raku/vim-raku/issues
 " Last Change:   2021-04-16
+"                2024-05-23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 " Contributors:  Hinrik Örn Sigurðsson <hinrik.sig@gmail.com>
 "
 " Based on ftplugin/perl.vim by Dan Sharp <dwsharp at hotmail dot com>
@@ -21,7 +22,7 @@ setlocal formatoptions+=crqol
 setlocal keywordprg=p6doc
 
 setlocal comments=:#\|,:#=,:#
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 
 " Provided by Ned Konz <ned at bike-nomad dot com>
 "---------------------------------------------

--- a/runtime/ftplugin/rust.vim
+++ b/runtime/ftplugin/rust.vim
@@ -2,6 +2,7 @@
 " Description:  Vim ftplugin for Rust
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
 " Last Change:  2024-03-17
+"               2024-05-23 by Riley Bruins <ribru17@gmail.com ('commentstring')
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("b:did_ftplugin")
@@ -36,7 +37,7 @@ if get(g:, 'rust_bang_comment_leader', 0)
 else
     setlocal comments=s0:/*!,ex:*/,s1:/*,mb:*,ex:*/,:///,://!,://
 endif
-setlocal commentstring=//%s
+setlocal commentstring=//\ %s
 setlocal formatoptions-=t formatoptions+=croqnl
 " j was only added in 7.3.541, so stop complaints about its nonexistence
 silent! setlocal formatoptions+=j

--- a/runtime/ftplugin/scdoc.vim
+++ b/runtime/ftplugin/scdoc.vim
@@ -1,6 +1,7 @@
 " scdoc filetype plugin
 " Maintainer: Gregory Anders <contact@gpanders.com>
 " Last Updated: 2022-05-09
+"               2024-05-23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 " Upstream: https://github.com/gpanders/vim-scdoc
 
 " Only do this when not done yet for this buffer
@@ -12,7 +13,7 @@ endif
 let b:did_ftplugin = 1
 
 setlocal comments=b:;
-setlocal commentstring=;%s
+setlocal commentstring=;\ %s
 setlocal formatoptions+=t
 setlocal noexpandtab
 setlocal shiftwidth=0

--- a/runtime/ftplugin/scheme.vim
+++ b/runtime/ftplugin/scheme.vim
@@ -1,6 +1,7 @@
 " Vim filetype plugin file
 " Language: Scheme (R7RS)
 " Last Change: 2019-11-19
+"              2024-05-23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 " Author: Evan Hanson <evhan@foldling.org>
 " Maintainer: Evan Hanson <evhan@foldling.org>
 " Previous Maintainer: Sergey Khorev <sergey.khorev@gmail.com>
@@ -16,7 +17,7 @@ set cpo&vim
 
 setl lisp
 setl comments=:;;;;,:;;;,:;;,:;,sr:#\|,mb:\|,ex:\|#
-setl commentstring=;%s
+setl commentstring=;\ %s
 setl define=^\\s*(def\\k*
 setl iskeyword=33,35-39,42-43,45-58,60-90,94,95,97-122,126
 

--- a/runtime/ftplugin/tcl.vim
+++ b/runtime/ftplugin/tcl.vim
@@ -3,6 +3,7 @@
 " Maintainer:       Robert L Hicks <sigzero@gmail.com>
 " Latest Revision:  2009-05-01
 "                   2024 Jan 14 by Vim Project (browsefilter)
+"                   2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -15,7 +16,7 @@ let s:cpo_save = &cpo
 set cpo-=C
 
 setlocal comments=:#
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal formatoptions+=croql
 
 " Change the browse dialog on Windows to show mainly Tcl-related files

--- a/runtime/ftplugin/typescript.vim
+++ b/runtime/ftplugin/typescript.vim
@@ -2,6 +2,7 @@
 " Language:	TypeScript
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -18,7 +19,7 @@ setlocal formatoptions-=t formatoptions+=croql
 " Set 'comments' to format dashed lists in comments.
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 
-setlocal commentstring=//%s
+setlocal commentstring=//\ %s
 
 setlocal suffixesadd+=.ts,.d.ts,.tsx,.js,.jsx,.cjs,.mjs
 

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -2,6 +2,7 @@
 " Language:		Vim
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2024 Apr 13
+" 			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -51,7 +52,7 @@ setlocal keywordprg=:help
 
 " Comments starts with # in Vim9 script.  We have to guess which one to use.
 if "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
-  setlocal commentstring=#%s
+  setlocal commentstring=#\ %s
 else
   setlocal commentstring=\"%s
 endif

--- a/runtime/ftplugin/wat.vim
+++ b/runtime/ftplugin/wat.vim
@@ -2,6 +2,7 @@
 " Language:     WebAssembly
 " Maintainer:   rhysd <lin90162@yahoo.co.jp>
 " Last Change:  Nov 14, 2023
+"               May 24, 2024 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 " For bugs, patches and license go to https://github.com/rhysd/vim-wasm
 
 if exists("b:did_ftplugin")
@@ -10,7 +11,7 @@ endif
 let b:did_ftplugin = 1
 
 setlocal comments=s:(;,e:;),:;;
-setlocal commentstring=(;%s;)
+setlocal commentstring=(;\ %s\ ;)
 setlocal formatoptions-=t
 setlocal iskeyword+=$,.,/
 

--- a/runtime/ftplugin/xdefaults.vim
+++ b/runtime/ftplugin/xdefaults.vim
@@ -2,6 +2,7 @@
 " Language:             X resources files like ~/.Xdefaults (xrdb)
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2008-07-09
+"                       2024-06-03 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -13,7 +14,7 @@ set cpo&vim
 
 let b:undo_ftplugin = "setl com< cms< inc< fo<"
 
-setlocal comments=s1:/*,mb:*,ex:*/,:! commentstring& inc&
+setlocal comments=s1:/*,mb:*,ex:*/,:! commentstring=!\ %s inc&
 setlocal formatoptions-=t formatoptions+=croql
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/xml.vim
+++ b/runtime/ftplugin/xml.vim
@@ -3,6 +3,7 @@
 "   Maintainer:	Christian Brabandt <cb@256bit.org>
 " Last Changed: Dec 07th, 2018
 "		2024 Jan 14 by Vim Project (browsefilter)
+"		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 "   Repository: https://github.com/chrisbra/vim-xml-ftplugin
 " Previous Maintainer:	Dan Sharp
 "          URL:		      http://dwsharp.users.sourceforge.net/vim/ftplugin
@@ -15,7 +16,7 @@ let b:did_ftplugin = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-setlocal commentstring=<!--%s-->
+setlocal commentstring=<!--\ %s\ -->
 " Remove the middlepart from the comments section, as this causes problems:
 " https://groups.google.com/d/msg/vim_dev/x4GT-nqa0Kg/jvtRnEbtAnMJ
 setlocal comments=s:<!--,e:-->

--- a/runtime/syntax/lc.vim
+++ b/runtime/syntax/lc.vim
@@ -2,6 +2,7 @@
 " Language:     Elsa
 " Maintainer:   Miles Glapa-Grossklag <miles@glapa-grossklag.com>
 " Last Change:  2023-01-29
+"               2024 May 25 by Riley Bruins <ribru17@gmail.com> (move 'commentstring' to ftplugin)
 
 if exists('b:current_syntax')
   finish
@@ -13,7 +14,6 @@ syntax match elsaKeyword "\v:"
 highlight link elsaKeyword Keyword
 
 " Comments
-setlocal commentstring=--%s
 syntax match elsaComment "\v--.*$"
 highlight link elsaComment Comment
 

--- a/runtime/syntax/mma.vim
+++ b/runtime/syntax/mma.vim
@@ -2,6 +2,7 @@
 " Language:     Mathematica
 " Maintainer:   steve layland <layland@wolfram.com>
 " Last Change:  2012 Feb 03 by Thilo Six
+"               2024 May 24 by Riley Bruins <ribru17@gmail.com> (remove 'commentstring')
 " Source:       http://members.wri.com/layland/vim/syntax/mma.vim
 "               http://vim.sourceforge.net/scripts/script.php?script_id=1273
 " Id:           $Id: mma.vim,v 1.4 2006/04/14 20:40:38 vimboss Exp $
@@ -248,7 +249,6 @@ syntax match mmaBoring "[(){}]" contained
 "syntax region mmaRegion start="(\*\+[^<]*<!--[^>]*\*\+)" end="--> \*)" containedin=ALLBUT,@mmaStrings transparent fold keepend
 
 " show fold text
-set commentstring='(*%s*)'
 "set foldtext=MmaFoldText()
 
 "function MmaFoldText()


### PR DESCRIPTION
Changes the default 'commentstring' value from '/*%s*/' to '/* %s */', and changes many ftplugin files to add space padding in their comment strings, if possible.

---

I understand if this PR is too invasive, and if needed I can amend it to only include ftplugin changes, without changing the default value of `commentstring`. Using [this query](https://github.com/search?q=repo%3Avim%2Fvim+%2F%28commentstring%7Ccms%29.*%5B%5E+%5D%25s%2F+path%3Aruntime&type=code), we can see that about a fifth of the specified `commentstring`s in various `ftplugin`s are *not* given space padding, while the rest are. This PR is an attempt to standardize the space padding more (when possible in the language). The only one I didn't touch was COBOL, because it is already kind of wonky and column-specific. Of the ones I did change, I gave a quick spec-read and github code search to make sure that the space-padded comments are still valid syntax in that language. Sorry for the large review!