### PR TITLE
Update Debian runtime files

### DIFF
--- a/runtime/ftplugin/deb822sources.vim
+++ b/runtime/ftplugin/deb822sources.vim
@@ -1,6 +1,6 @@
 " Language:     Debian sources.list
 " Maintainer:   Debian Vim Maintainers <team+vim@tracker.debian.org>
-" Last Change:  2024 Mar 20
+" Last Change:  2024 May 25
 " License:      Vim License
 " URL:          https://salsa.debian.org/vim-team/vim-debian/blob/main/ftplugin/deb822sources.vim
 
@@ -10,7 +10,7 @@ endif
 let b:did_ftplugin=1
 
 setlocal comments=:#
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal formatoptions-=t
 
 let b:undo_ftplugin = 'setlocal comments< commentstring< formatoptions<'

--- a/runtime/ftplugin/debcontrol.vim
+++ b/runtime/ftplugin/debcontrol.vim
@@ -2,7 +2,7 @@
 " Language:     Debian control files
 " Maintainer:   Debian Vim Maintainers
 " Former Maintainer:    Pierre Habouzit <madcoder@debian.org>
-" Last Change:  2023 Jan 16
+" Last Change:  2024 May 25
 " URL:          https://salsa.debian.org/vim-team/vim-debian/blob/main/ftplugin/debcontrol.vim
 
 " Do these settings once per buffer
@@ -19,8 +19,11 @@ if exists('g:debcontrol_fold_enable')
 endif
 setlocal textwidth=0
 
+setlocal comments=:#
+setlocal commentstring=#\ %s
+
 " Clean unloading
-let b:undo_ftplugin = 'setlocal tw< foldmethod< foldexpr< foldtext<'
+let b:undo_ftplugin = 'setlocal tw< foldmethod< foldexpr< foldtext< comments< commentstring<'
 
 " }}}1
 

--- a/runtime/ftplugin/debsources.vim
+++ b/runtime/ftplugin/debsources.vim
@@ -1,6 +1,6 @@
 " Language:     Debian sources.list
 " Maintainer:   Debian Vim Maintainers <team+vim@tracker.debian.org>
-" Last Change:  2023 Aug 30
+" Last Change:  2024 May 25
 " License:      Vim License
 " URL:          https://salsa.debian.org/vim-team/vim-debian/blob/main/ftplugin/debsources.vim
 
@@ -10,7 +10,7 @@ endif
 let b:did_ftplugin=1
 
 setlocal comments=:#
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s
 setlocal formatoptions-=t
 
 let b:undo_ftplugin = 'setlocal comments< commentstring< formatoptions<'

--- a/runtime/syntax/shared/debversions.vim
+++ b/runtime/syntax/shared/debversions.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Debian version information
 " Maintainer:   Debian Vim Maintainers
-" Last Change:  2024 Apr 27
+" Last Change:  2024 May 25
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debversions.vim
 
 let s:cpo = &cpo
@@ -11,7 +11,7 @@ let g:debSharedSupportedVersions = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
       \ 'bullseye', 'bookworm', 'trixie', 'forky',
       \
-      \ 'trusty', 'xenial', 'bionic', 'focal', 'jammy', 'mantic', 'noble', 'oracular',
+      \ 'focal', 'jammy', 'mantic', 'noble', 'oracular',
       \ 'devel'
       \ ]
 let g:debSharedUnsupportedVersions = [
@@ -22,8 +22,9 @@ let g:debSharedUnsupportedVersions = [
       \ 'warty', 'hoary', 'breezy', 'dapper', 'edgy', 'feisty',
       \ 'gutsy', 'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid',
       \ 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy',
-      \ 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful', 'cosmic',
-      \ 'disco', 'eoan', 'hirsute', 'impish', 'kinetic', 'lunar', 'groovy'
+      \ 'trusty', 'utopic', 'vivid', 'wily', 'xenial', 'yakkety', 'zesty',
+      \ 'artful', 'bionic', 'cosmic', 'disco', 'eoan', 'hirsute',
+      \ 'impish', 'kinetic', 'lunar', 'groovy'
       \ ]
 
 let &cpo=s:cpo


### PR DESCRIPTION
- Add space in template for 'commentstring'
- Add 'comments' and 'commentstring' support to debcontrol
- debversions: Move Ubuntu releases outside of standard support to unsupported
