### PR TITLE
getregionpos() inconsistent for partly-selected multibyte char

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5788,6 +5788,7 @@ f_getregionpos(typval_T *argvars, typval_T *rettv)
     for (lnum = p1.lnum; lnum <= p2.lnum; lnum++)
     {
 	pos_T		ret_p1, ret_p2;
+	char_u		*line = ml_get(lnum);
 	colnr_T		line_len = ml_get_len(lnum);
 
 	if (region_type == MLINE)
@@ -5810,7 +5811,7 @@ f_getregionpos(typval_T *argvars, typval_T *rettv)
 	    {
 		if (region_type == MBLOCK)
 		{
-		    ret_p1.col = bd.textcol;
+		    ret_p1.col = mb_prevptr(line, bd.textstart) - line + 1;
 		    ret_p1.coladd = bd.start_char_vcols
 					     - (bd.start_vcol - oa.start_vcol);
 		}
@@ -5829,7 +5830,7 @@ f_getregionpos(typval_T *argvars, typval_T *rettv)
 	    }
 	    else if (bd.startspaces > 0)
 	    {
-		ret_p1.col = bd.textcol;
+		ret_p1.col = mb_prevptr(line, bd.textstart) - line + 1;
 		ret_p1.coladd = bd.start_char_vcols - bd.startspaces;
 	    }
 	    else

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -2073,16 +2073,40 @@ func Test_visual_getregion()
           \ getregion(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
     call assert_equal([
           \   [[bufnr('%'), 1, 5, 0], [bufnr('%'), 1, 5, 0]],
-          \   [[bufnr('%'), 2, 10, 1], [bufnr('%'), 2, 10, 2]],
+          \   [[bufnr('%'), 2, 7, 1], [bufnr('%'), 2, 7, 2]],
           \   [[bufnr('%'), 3, 5, 0], [bufnr('%'), 3, 5, 0]],
           \ ],
           \ getregionpos(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
+    call assert_equal(['efghijk«', '🇦«🇧«🇨«🇩', '12345'],
+          \ getregion(getpos('v'), getpos('.'), {'type': 'v' }))
     call assert_equal([
           \   [[bufnr('%'), 1, 5, 0], [bufnr('%'), 1, 13, 0]],
           \   [[bufnr('%'), 2, 1, 0], [bufnr('%'), 2, 22, 0]],
           \   [[bufnr('%'), 3, 1, 0], [bufnr('%'), 3, 5, 0]],
           \ ],
           \ getregionpos(getpos('v'), getpos('.'), {'type': 'v' }))
+
+    call cursor(1, 5)
+    call feedkeys("\<Esc>\<C-v>5l2j", 'xt')
+    call assert_equal(['efghij', ' «🇨« ', '567890'],
+          \ getregion(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
+    call assert_equal([
+          \   [[bufnr('%'), 1, 5, 0], [bufnr('%'), 1, 10, 0]],
+          \   [[bufnr('%'), 2, 7, 1], [bufnr('%'), 2, 19, 1]],
+          \   [[bufnr('%'), 3, 5, 0], [bufnr('%'), 3, 10, 0]],
+          \ ],
+          \ getregionpos(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
+
+    call cursor(1, 4)
+    call feedkeys("\<Esc>\<C-v>02j", 'xt')
+    call assert_equal(['abcd', '🇦« ', '1234'],
+          \ getregion(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
+    call assert_equal([
+          \   [[bufnr('%'), 1, 1, 0], [bufnr('%'), 1, 4, 0]],
+          \   [[bufnr('%'), 2, 1, 0], [bufnr('%'), 2, 7, 1]],
+          \   [[bufnr('%'), 3, 1, 0], [bufnr('%'), 3, 4, 0]],
+          \ ],
+          \ getregionpos(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
 
     #" characterwise selection with multibyte chars
     call cursor(1, 1)


### PR DESCRIPTION
Problem:  getregionpos() behaves inconsistently for a partly-selected
          multibyte char.
Solution: Always use column of the first byte for a partly-selected
          multibyte char.
