### PR TITLE
runtime(typescriptreact): fix highlighting nested and escaped quotes in string props

### DIFF
--- a/runtime/syntax/typescriptreact.vim
+++ b/runtime/syntax/typescriptreact.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     TypeScript with React (JSX)
 " Maintainer:   The Vim Project <https://github.com/vim/vim>
-" Last Change:  2024 May 24
+" Last Change:  2024 May 26
 " Based On:     Herrington Darkholme's yats.vim
 " Changes:      See https://github.com/HerringtonDarkholme/yats.vim
 " Credits:      See yats.vim on github
@@ -118,7 +118,8 @@ syntax match tsxEqual +=+ display contained
 
 " <tag id="sample">
 "         s~~~~~~e
-syntax region tsxString contained start=+["']+ end=+["']+ contains=tsxEntity,@Spell display
+syntax region tsxString contained start=+"+ skip=+\\"+ end=+"+ contains=tsxEntity,@Spell display
+syntax region tsxString contained start=+'+ skip=+\\'+ end=+'+ contains=tsxEntity,@Spell display
 
 " <tag key={this.props.key}>
 "          s~~~~~~~~~~~~~~e


### PR DESCRIPTION
This PR is upstreamed from the patch https://github.com/HerringtonDarkholme/yats.vim/pull/280.

Fixes: https://github.com/HerringtonDarkholme/yats.vim/issues/279