### PR TITLE
fix(completion): reset shown to first when leader delete to empty

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1254,6 +1254,14 @@ ins_compl_build_pum(void)
     if (match_at_original_text(compl_shown_match))
 	shown_match_ok = TRUE;
 
+    if (compl_leader != NULL
+	    && STRCMP(compl_leader, compl_orig_text) == 0
+	    && shown_match_ok == FALSE)
+    {
+	compl_shown_match = compl_no_select ? compl_first_match
+					    : compl_first_match->cp_next;
+    }
+
     i = 0;
     compl = compl_first_match;
     do

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -630,14 +630,14 @@ func Test_pum_with_preview_win()
   CheckScreendump
 
   let lines =<< trim END
-      funct Omni_test(findstart, base)
-	if a:findstart
-	  return col(".") - 1
-	endif
-	return [#{word: "one", info: "1info"}, #{word: "two", info: "2info"}, #{word: "three", info: "3info"}]
-      endfunc
-      set omnifunc=Omni_test
-      set completeopt+=longest
+    funct Omni_test(findstart, base)
+      if a:findstart
+        return col(".") - 1
+      endif
+      return [#{word: "one", info: "1info"}, #{word: "two", info: "2info"}, #{word: "three", info: "3info"}]
+    endfunc
+    set omnifunc=Omni_test
+    set completeopt+=longest
   END
 
   call writefile(lines, 'Xpreviewscript', 'D')

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -1175,6 +1175,8 @@ func Test_CompleteChanged()
   set completeopt=menu,menuone
   call feedkeys("i\<C-X>\<C-O>\<BS>\<BS>\<BS>f", 'tx')
   call assert_equal('five', g:word)
+  call feedkeys("i\<C-X>\<C-O>\<BS>\<BS>\<BS>f\<BS>", 'tx')
+  call assert_equal('one', g:word)
 
   autocmd! AAAAA_Group
   set complete& completeopt&


### PR DESCRIPTION
Problem:  when leader back to original leader the compl_shown_match need update.
Solution: restore to  first_match if not compl_no_select set to the first_match.cp_next