### PR TITLE
Fix syntax vim bug (Close #14858)

### DIFF
--- a/runtime/syntax/generator/gen_syntax_vim.vim
+++ b/runtime/syntax/generator/gen_syntax_vim.vim
@@ -464,6 +464,10 @@ function! s:parse_vim_hlgroup(li)
 		let item.type = 'both'
 		call add(a:li, copy(item))
 
+		" "Conceal" is an option and cannot be used as keyword, so remove it.
+		" (Separately specified as 'syn match' in vim.vim.base).
+		call filter(a:li, {idx, val -> val.name !=# 'Conceal'})
+
 		quit!
 
 		if empty(a:li)

--- a/runtime/syntax/generator/vim.vim.base
+++ b/runtime/syntax/generator/vim.vim.base
@@ -70,6 +70,7 @@ syn keyword vimGroup contained	Comment Constant String Character Number Boolean 
 
 " Default highlighting groups {{{2
 " GEN_SYN_VIM: vimHLGroup, START_STR='syn keyword vimHLGroup contained', END_STR=''
+syn match vimHLGroup contained "\<Conceal\>"
 syn case match
 
 " Function Names {{{2


### PR DESCRIPTION
@chrisbra 
It appears that `runtime/syntax/vim.vim` has not been updated in over a month.
