### PR TITLE
Problem: "i" in 'complete' option may slow down Vim

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.1.  Last change: 2024 May 19
+*options.txt*	For Vim version 9.1.  Last change: 2024 May 27
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2042,7 +2042,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	'writebackup'	+ on or off	depends on the |+writebackup| feature
 
 						*'complete'* *'cpt'* *E535*
-'complete' 'cpt'	string	(default: ".,w,b,u,t,i")
+'complete' 'cpt'	string	(default: ".,w,b,u,t")
 			local to buffer
 	This option specifies how keyword completion |ins-completion| works
 	when CTRL-P or CTRL-N are used.  It is also used for whole-line

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -1,4 +1,4 @@
-*version9.txt*  For Vim version 9.1.  Last change: 2024 May 17
+*version9.txt*  For Vim version 9.1.  Last change: 2024 May 27
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -41561,6 +41561,8 @@ Changed						*changed-9.2*
 
 - use 'smoothscroll' logic for CTRL-F and CTRL-B for pagewise scrolling
 - use 'smoothscroll' logic for CTRL-D and CTRL-U for half-pagewise scrolling
+- the default value for 'complete' no longer contains "i" to scan for included
+  files (because this can be slow)
 
 Added						*added-9.2*
 -----

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -642,7 +642,7 @@ static struct vimoption options[] =
 			    {(char_u *)TRUE, (char_u *)FALSE} SCTX_INIT},
     {"complete",    "cpt",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_cpt, PV_CPT, did_set_complete, expand_set_complete,
-			    {(char_u *)".,w,b,u,t,i", (char_u *)0L}
+			    {(char_u *)".,w,b,u,t", (char_u *)0L}
 			    SCTX_INIT},
     {"completefunc", "cfu", P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE|P_FUNC,
 #ifdef FEAT_COMPL_FUNC


### PR DESCRIPTION
Problem:  "i" in 'complete' option may slow down Vim
Solution: Change default and remove the "i"

As mentioned in #14853 the "i" in the 'complete' option may cause slow down using <C-N>/<C-P>, because Vim has to scan all include files.

Let's remove it from the default option value and see if anybody complains.